### PR TITLE
[CI] Enable cached checkout in main pipeline

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -109,9 +109,10 @@ jobs:
       image: ${{ fromJSON(needs.configure.outputs.params).build_image }}
       options: -u 1001:1001
     steps:
-    - uses: actions/checkout@v2
+    - uses: alexbatashev/llvm/devops/actions/cached_checkout@repo_cache
       with:
         path: src
+        cache_path: "/__w/repo_cache/"
     - name: Register cleanup after job is finished
       uses: ./src/devops/actions/cleanup
     - name: Setup Cache
@@ -213,9 +214,10 @@ jobs:
       image: ${{ fromJSON(needs.configure.outputs.params).intel_drivers_image }}
       options: -u 1001 --device=/dev/dri
     steps:
-    - uses: actions/checkout@v2
+    - uses: alexbatashev/llvm/devops/actions/cached_checkout@repo_cache
       with:
         path: llvm
+        cache_path: "/__w/repo_cache/"
     - name: Register cleanup after job is finished
       uses: ./llvm/devops/actions/cleanup
     - uses: ./llvm/devops/actions/llvm_test_suite
@@ -240,9 +242,10 @@ jobs:
       image: ${{ fromJSON(needs.configure.outputs.params).intel_drivers_image }}
       options: -u 1001 --device=/dev/dri
     steps:
-    - uses: actions/checkout@v2
+    - uses: alexbatashev/llvm/devops/actions/cached_checkout@repo_cache
       with:
         path: llvm
+        cache_path: "/__w/repo_cache/"
     - name: Register cleanup after job is finished
       uses: ./llvm/devops/actions/cleanup
     - uses: ./llvm/devops/actions/llvm_test_suite
@@ -267,9 +270,10 @@ jobs:
       image: ${{ fromJSON(needs.configure.outputs.params).intel_drivers_image }}
       options: -u 1001
     steps:
-    - uses: actions/checkout@v2
+    - uses: alexbatashev/llvm/devops/actions/cached_checkout@repo_cache
       with:
         path: llvm
+        cache_path: "/__w/repo_cache/"
     - name: Register cleanup after job is finished
       uses: ./llvm/devops/actions/cleanup
     - uses: ./llvm/devops/actions/llvm_test_suite
@@ -293,9 +297,10 @@ jobs:
       image: ${{ fromJSON(needs.configure.outputs.params).amdgpu_image }}
       options: --device=/dev/dri --device=/dev/kfd
     steps:
-    - uses: actions/checkout@v2
+    - uses: alexbatashev/llvm/devops/actions/cached_checkout@repo_cache
       with:
         path: llvm
+        cache_path: "/__w/repo_cache/"
     - name: Register cleanup after job is finished
       uses: ./llvm/devops/actions/cleanup
     - uses: ./llvm/devops/actions/llvm_test_suite

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -221,10 +221,10 @@ jobs:
     - run: cp -r /actions .
     - name: Register cleanup after job is finished
       uses: ./actions/cleanup
-    - uses: ./actions/cached_checkout
+    # FIXME cached_checkout fails here, but works everywhere else
+    - uses: actions/checkout@v2
       with:
         path: llvm
-        cache_path: "/__w/repo_cache/"
     # TODO should this action be packed into container as well?
     - uses: ./llvm/devops/actions/llvm_test_suite
       name: Run LLVM Test Suite
@@ -251,10 +251,10 @@ jobs:
     - run: cp -r /actions .
     - name: Register cleanup after job is finished
       uses: ./actions/cleanup
-    - uses: ./actions/cached_checkout
+    # FIXME cached_checkout fails here, but works everywhere else
+    - uses: actions/checkout@v2
       with:
         path: llvm
-        cache_path: "/__w/repo_cache/"
     - uses: ./llvm/devops/actions/llvm_test_suite
       name: Run LLVM Test Suite
       with:
@@ -280,10 +280,10 @@ jobs:
     - run: cp -r /actions .
     - name: Register cleanup after job is finished
       uses: ./actions/cleanup
-    - uses: ./actions/cached_checkout
+    # FIXME cached_checkout fails here, but works everywhere else
+    - uses: actions/checkout@v2
       with:
         path: llvm
-        cache_path: "/__w/repo_cache/"
     - uses: ./llvm/devops/actions/llvm_test_suite
       name: Run LLVM Test Suite
       with:
@@ -306,21 +306,14 @@ jobs:
       options: --device=/dev/dri --device=/dev/kfd
     steps:
     - run: cp -r /actions .
-    - run: |
-        ls -la /__w/
-        ls -la /__w/_actions/
     - name: Register cleanup after job is finished
       uses: ./actions/cleanup
-    - run: |
-        ls -la /__w/
-        ls -la /__w/_actions/
     # TODO remove this step one LLVM Test Suite action is settled and packed
     # into container.
-    - name: Checkout llvm repo
-      uses: ./actions/cached_checkout
+    # FIXME cached_checkout fails here, but works everywhere else
+    - uses: actions/checkout@v2
       with:
         path: llvm
-        cache_path: "/__w/repo_cache/"
     - uses: ./llvm/devops/actions/llvm_test_suite
       name: Run LLVM Test Suite
       with:

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -81,17 +81,17 @@ jobs:
               \"cc\":\"gcc\",
               \"cxx\":\"g++\",
               \"build_runs_on\":\"build\",
-              \"build_image\":\"ghcr.io/testorg-abatashev/llvm/ubuntu2004_base:latest\",
+              \"build_image\":\"ghcr.io/intel/llvm/ubuntu2004_build:latest\",
               \"build_github_cache\":\"false\",
               \"build_cache_root\":\"/__w/\",
               \"build_cache_suffix\":\"default\",
               \"build_cache_size\":\"2G\",
-              \"build_configure_extra_args\":\"\",
+              \"build_configure_extra_args\":\"--hip --hip-amd-arch=gfx906 --cuda\",
               \"build_artifact_suffix\":\"default\",
               \"build_upload_artifact\":\"false\",
               \"intel_drivers_image\":\"ghcr.io/intel/llvm/ubuntu2004_intel_drivers:latest\",
               \"amdgpu_image\":\"ghcr.io/intel/llvm/ubuntu2004_build:latest\",
-              \"lts_config\":\"\",
+              \"lts_config\":\"ocl_x64;hip_amdgpu\",
               \"gen9_runs_on\":\"gen9\",
               \"amdgpu_runs_on\":\"amdgpu\"
             }"
@@ -109,13 +109,11 @@ jobs:
       image: ${{ fromJSON(needs.configure.outputs.params).build_image }}
       options: -u 1001:1001
     steps:
-    - run: cp -r /actions .
-    - name: Register cleanup after job is finished
-      uses: ./actions/cleanup
-    - uses: ./actions/cached_checkout
+    - uses: actions/checkout@v2
       with:
         path: src
-        cache_path: "/__w/repo_cache/"
+    - name: Register cleanup after job is finished
+      uses: ./src/devops/actions/cleanup
     - name: Setup Cache
       uses: actions/cache@v2
       if: ${{ steps.parameters.build_github_cache }}
@@ -215,10 +213,9 @@ jobs:
       image: ${{ fromJSON(needs.configure.outputs.params).intel_drivers_image }}
       options: -u 1001 --device=/dev/dri
     steps:
-    - uses: alexbatashev/llvm/devops/actions/cached_checkout@repo_cache
+    - uses: actions/checkout@v2
       with:
         path: llvm
-        cache_path: "/__w/repo_cache/"
     - name: Register cleanup after job is finished
       uses: ./llvm/devops/actions/cleanup
     - uses: ./llvm/devops/actions/llvm_test_suite
@@ -243,10 +240,9 @@ jobs:
       image: ${{ fromJSON(needs.configure.outputs.params).intel_drivers_image }}
       options: -u 1001 --device=/dev/dri
     steps:
-    - uses: alexbatashev/llvm/devops/actions/cached_checkout@repo_cache
+    - uses: actions/checkout@v2
       with:
         path: llvm
-        cache_path: "/__w/repo_cache/"
     - name: Register cleanup after job is finished
       uses: ./llvm/devops/actions/cleanup
     - uses: ./llvm/devops/actions/llvm_test_suite
@@ -271,10 +267,9 @@ jobs:
       image: ${{ fromJSON(needs.configure.outputs.params).intel_drivers_image }}
       options: -u 1001
     steps:
-    - uses: alexbatashev/llvm/devops/actions/cached_checkout@repo_cache
+    - uses: actions/checkout@v2
       with:
         path: llvm
-        cache_path: "/__w/repo_cache/"
     - name: Register cleanup after job is finished
       uses: ./llvm/devops/actions/cleanup
     - uses: ./llvm/devops/actions/llvm_test_suite
@@ -298,10 +293,9 @@ jobs:
       image: ${{ fromJSON(needs.configure.outputs.params).amdgpu_image }}
       options: --device=/dev/dri --device=/dev/kfd
     steps:
-    - uses: alexbatashev/llvm/devops/actions/cached_checkout@repo_cache
+    - uses: actions/checkout@v2
       with:
         path: llvm
-        cache_path: "/__w/repo_cache/"
     - name: Register cleanup after job is finished
       uses: ./llvm/devops/actions/cleanup
     - uses: ./llvm/devops/actions/llvm_test_suite

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -109,7 +109,7 @@ jobs:
       image: ${{ fromJSON(needs.configure.outputs.params).build_image }}
       options: -u 1001:1001
     steps:
-    - uses: /actions/cached_checkout@repo_cache
+    - uses: /actions/cached_checkout
       with:
         path: src
         cache_path: "/__w/repo_cache/"

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -81,17 +81,17 @@ jobs:
               \"cc\":\"gcc\",
               \"cxx\":\"g++\",
               \"build_runs_on\":\"build\",
-              \"build_image\":\"ghcr.io/intel/llvm/ubuntu2004_build:latest\",
+              \"build_image\":\"ghcr.io/testorg-abatashev/llvm/ubuntu2004_base:latest\",
               \"build_github_cache\":\"false\",
               \"build_cache_root\":\"/__w/\",
               \"build_cache_suffix\":\"default\",
               \"build_cache_size\":\"2G\",
-              \"build_configure_extra_args\":\"--hip --hip-amd-arch=gfx906 --cuda\",
+              \"build_configure_extra_args\":\"\",
               \"build_artifact_suffix\":\"default\",
               \"build_upload_artifact\":\"false\",
               \"intel_drivers_image\":\"ghcr.io/intel/llvm/ubuntu2004_intel_drivers:latest\",
               \"amdgpu_image\":\"ghcr.io/intel/llvm/ubuntu2004_build:latest\",
-              \"lts_config\":\"ocl_x64;ocl_gen9;hip_amdgpu\",
+              \"lts_config\":\"\",
               \"gen9_runs_on\":\"gen9\",
               \"amdgpu_runs_on\":\"amdgpu\"
             }"
@@ -109,7 +109,7 @@ jobs:
       image: ${{ fromJSON(needs.configure.outputs.params).build_image }}
       options: -u 1001:1001
     steps:
-    - uses: alexbatashev/llvm/devops/actions/cached_checkout@repo_cache
+    - uses: /actions/cached_checkout@repo_cache
       with:
         path: src
         cache_path: "/__w/repo_cache/"

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -91,7 +91,7 @@ jobs:
               \"build_upload_artifact\":\"false\",
               \"intel_drivers_image\":\"ghcr.io/intel/llvm/ubuntu2004_intel_drivers:latest\",
               \"amdgpu_image\":\"ghcr.io/intel/llvm/ubuntu2004_build:latest\",
-              \"lts_config\":\"ocl_x64;hip_amdgpu\",
+              \"lts_config\":\"ocl_x64;ocl_gen9;hip_amdgpu\",
               \"gen9_runs_on\":\"gen9\",
               \"amdgpu_runs_on\":\"amdgpu\"
             }"

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -109,11 +109,16 @@ jobs:
       image: ${{ fromJSON(needs.configure.outputs.params).build_image }}
       options: -u 1001:1001
     steps:
-    - uses: actions/checkout@v2
+    # GHA requires relative paths for actions. Copy actions from container root
+    # to CWD.
+    - run: cp -r /actions .
+    # Cleanup will be run after all actions are completed.
+    - name: Register cleanup after job is finished
+      uses: ./actions/cleanup
+    - uses: ./actions/cached_checkout
       with:
         path: src
-    - name: Register cleanup after job is finished
-      uses: ./src/devops/actions/cleanup
+        cache_path: "/__w/repo_cache/"
     - name: Setup Cache
       uses: actions/cache@v2
       if: ${{ steps.parameters.build_github_cache }}
@@ -213,11 +218,14 @@ jobs:
       image: ${{ fromJSON(needs.configure.outputs.params).intel_drivers_image }}
       options: -u 1001 --device=/dev/dri
     steps:
-    - uses: actions/checkout@v2
+    - run: cp -r /actions .
+    - name: Register cleanup after job is finished
+      uses: ./actions/cleanup
+    - uses: ./actions/cached_checkout
       with:
         path: llvm
-    - name: Register cleanup after job is finished
-      uses: ./llvm/devops/actions/cleanup
+        cache_path: "/__w/repo_cache/"
+    # TODO should this action be packed into container as well?
     - uses: ./llvm/devops/actions/llvm_test_suite
       name: Run LLVM Test Suite
       with:
@@ -240,11 +248,13 @@ jobs:
       image: ${{ fromJSON(needs.configure.outputs.params).intel_drivers_image }}
       options: -u 1001 --device=/dev/dri
     steps:
-    - uses: actions/checkout@v2
+    - run: cp -r /actions .
+    - name: Register cleanup after job is finished
+      uses: ./actions/cleanup
+    - uses: ./actions/cached_checkout
       with:
         path: llvm
-    - name: Register cleanup after job is finished
-      uses: ./llvm/devops/actions/cleanup
+        cache_path: "/__w/repo_cache/"
     - uses: ./llvm/devops/actions/llvm_test_suite
       name: Run LLVM Test Suite
       with:
@@ -267,11 +277,13 @@ jobs:
       image: ${{ fromJSON(needs.configure.outputs.params).intel_drivers_image }}
       options: -u 1001
     steps:
-    - uses: actions/checkout@v2
+    - run: cp -r /actions .
+    - name: Register cleanup after job is finished
+      uses: ./actions/cleanup
+    - uses: ./actions/cached_checkout
       with:
         path: llvm
-    - name: Register cleanup after job is finished
-      uses: ./llvm/devops/actions/cleanup
+        cache_path: "/__w/repo_cache/"
     - uses: ./llvm/devops/actions/llvm_test_suite
       name: Run LLVM Test Suite
       with:
@@ -293,11 +305,13 @@ jobs:
       image: ${{ fromJSON(needs.configure.outputs.params).amdgpu_image }}
       options: --device=/dev/dri --device=/dev/kfd
     steps:
-    - uses: actions/checkout@v2
+    - run: cp -r /actions .
+    - name: Register cleanup after job is finished
+      uses: ./actions/cleanup
+    - uses: ./actions/cached_checkout
       with:
         path: llvm
-    - name: Register cleanup after job is finished
-      uses: ./llvm/devops/actions/cleanup
+        cache_path: "/__w/repo_cache/"
     - uses: ./llvm/devops/actions/llvm_test_suite
       name: Run LLVM Test Suite
       with:

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -306,9 +306,18 @@ jobs:
       options: --device=/dev/dri --device=/dev/kfd
     steps:
     - run: cp -r /actions .
+    - run: |
+        ls -la /__w/
+        ls -la /__w/_actions/
     - name: Register cleanup after job is finished
       uses: ./actions/cleanup
-    - uses: ./actions/cached_checkout
+    - run: |
+        ls -la /__w/
+        ls -la /__w/_actions/
+    # TODO remove this step one LLVM Test Suite action is settled and packed
+    # into container.
+    - name: Checkout llvm repo
+      uses: ./actions/cached_checkout
       with:
         path: llvm
         cache_path: "/__w/repo_cache/"

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -109,12 +109,13 @@ jobs:
       image: ${{ fromJSON(needs.configure.outputs.params).build_image }}
       options: -u 1001:1001
     steps:
-    - uses: /actions/cached_checkout
+    - run: cp -r /actions .
+    - name: Register cleanup after job is finished
+      uses: ./actions/cleanup
+    - uses: ./actions/cached_checkout
       with:
         path: src
         cache_path: "/__w/repo_cache/"
-    - name: Register cleanup after job is finished
-      uses: ./src/devops/actions/cleanup
     - name: Setup Cache
       uses: actions/cache@v2
       if: ${{ steps.parameters.build_github_cache }}

--- a/devops/actions/llvm_test_suite/action.yml
+++ b/devops/actions/llvm_test_suite/action.yml
@@ -34,6 +34,7 @@ runs:
   using: "composite"
   steps:
   - run: cp -r /actions .
+    shell: bash
   - name: Checkout LLVM Test Suite
     uses: ./actions/cached_checkout
     with:

--- a/devops/actions/llvm_test_suite/action.yml
+++ b/devops/actions/llvm_test_suite/action.yml
@@ -33,6 +33,7 @@ post-if: false
 runs:
   using: "composite"
   steps:
+  - run: cp -r /actions .
   - name: Checkout LLVM Test Suite
     uses: ./actions/cached_checkout
     with:

--- a/devops/actions/llvm_test_suite/action.yml
+++ b/devops/actions/llvm_test_suite/action.yml
@@ -34,12 +34,11 @@ runs:
   using: "composite"
   steps:
   - name: Checkout LLVM Test Suite
-    uses: alexbatashev/llvm/devops/actions/cached_checkout@repo_cache
+    uses: actions/checkout@v2
     with:
       path: llvm_test_suite
       repository: 'intel/llvm-test-suite'
       ref: ${{ inputs.test_ref }}
-      cache_path: "/__w/repo_cache/"
   - name: Download compiler toolchain
     uses: actions/download-artifact@v2
     with:

--- a/devops/actions/llvm_test_suite/action.yml
+++ b/devops/actions/llvm_test_suite/action.yml
@@ -34,11 +34,12 @@ runs:
   using: "composite"
   steps:
   - name: Checkout LLVM Test Suite
-    uses: actions/checkout@v2
+    uses: alexbatashev/llvm/devops/actions/cached_checkout@repo_cache
     with:
       path: llvm_test_suite
       repository: 'intel/llvm-test-suite'
       ref: ${{ inputs.test_ref }}
+      cache_path: "/__w/repo_cache/"
   - name: Download compiler toolchain
     uses: actions/download-artifact@v2
     with:

--- a/devops/actions/llvm_test_suite/action.yml
+++ b/devops/actions/llvm_test_suite/action.yml
@@ -34,11 +34,13 @@ runs:
   using: "composite"
   steps:
   - name: Checkout LLVM Test Suite
-    uses: actions/checkout@v2
+    uses: ./actions/cached_checkout
     with:
+      path: llvm
       path: llvm_test_suite
       repository: 'intel/llvm-test-suite'
       ref: ${{ inputs.test_ref }}
+      cache_path: "/__w/repo_cache/"
   - name: Download compiler toolchain
     uses: actions/download-artifact@v2
     with:

--- a/devops/actions/llvm_test_suite/action.yml
+++ b/devops/actions/llvm_test_suite/action.yml
@@ -37,7 +37,6 @@ runs:
   - name: Checkout LLVM Test Suite
     uses: ./actions/cached_checkout
     with:
-      path: llvm
       path: llvm_test_suite
       repository: 'intel/llvm-test-suite'
       ref: ${{ inputs.test_ref }}


### PR DESCRIPTION
Enabling repo cache significantly improves performance for LLVM Test Suite jobs (approx. 10 minutes down to 5).

For yet unknown reason, enabling cache doesn't work for intel/llvm repo in LLVM Test Suite jobs, but since LLVM Test Suite action will be packaged with containers in future, this is not a big deal.