### PR TITLE
[SPIR-V] Translate complex nested vector expressions instead of lowering them

### DIFF
--- a/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
@@ -975,7 +975,8 @@ SPIRVValue *LLVMToSPIRVBase::transValue(Value *V, SPIRVBasicBlock *BB,
 
   SPIRVDBG(dbgs() << "[transValue] " << *V << '\n');
   assert((!isa<Instruction>(V) || isa<GetElementPtrInst>(V) ||
-          isa<CastInst>(V) || BB) &&
+          isa<CastInst>(V) || isa<ExtractElementInst>(V) ||
+          isa<BinaryOperator>(V) || BB) &&
          "Invalid SPIRV BB");
 
   auto BV = transValueWithoutDecoration(V, BB, CreateForward, FuncTrans);
@@ -995,7 +996,9 @@ SPIRVInstruction *LLVMToSPIRVBase::transBinaryInst(BinaryOperator *B,
       transBoolOpCode(Op0, OpCodeMap::map(LLVMOC)), transType(B->getType()),
       Op0, transValue(B->getOperand(1), BB), BB);
 
-  if (isUnfusedMulAdd(B)) {
+  // BinaryOperator can have no parent if it is handled as an expression inside
+  // another instruction.
+  if (B->getParent() && isUnfusedMulAdd(B)) {
     Function *F = B->getFunction();
     SPIRVDBG(dbgs() << "[fp-contract] disabled for " << F->getName()
                     << ": possible fma candidate " << *B << '\n');

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVInstruction.cpp
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVInstruction.cpp
@@ -230,7 +230,18 @@ SPIRVSpecConstantOp *createSpecConstantOpInst(SPIRVInstruction *Inst) {
   auto OC = Inst->getOpCode();
   assert(isSpecConstantOpAllowedOp(OC) &&
          "Op code not allowed for OpSpecConstantOp");
-  auto Ops = Inst->getIds(Inst->getOperands());
+  std::vector<SPIRVWord> Ops;
+
+  // CompositeExtract/Insert operations use zero-based numbering for their
+  // indexes (containted in instruction operands). All their operands are
+  // Literals, so we can pass them as is for further handling.
+  if (OC == OpCompositeExtract || OC == OpCompositeInsert) {
+    auto *SPIRVInst = static_cast<SPIRVInstTemplateBase *>(Inst);
+    Ops = SPIRVInst->getOpWords();
+  } else {
+    Ops = Inst->getIds(Inst->getOperands());
+  }
+
   Ops.insert(Ops.begin(), OC);
   return static_cast<SPIRVSpecConstantOp *>(SPIRVSpecConstantOp::create(
       OpSpecConstantOp, Inst->getType(), Inst->getId(), Ops, nullptr,

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVInstruction.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVInstruction.h
@@ -2757,10 +2757,28 @@ _SPIRV_OP(ImageQuerySamples, true, 4)
 #define _SPIRV_OP(x, ...)                                                      \
   typedef SPIRVInstTemplate<SPIRVInstTemplateBase, Op##x, __VA_ARGS__> SPIRV##x;
 // Other instructions
-_SPIRV_OP(SpecConstantOp, true, 4, true, 0)
 _SPIRV_OP(GenericPtrMemSemantics, true, 4, false)
 _SPIRV_OP(GenericCastToPtrExplicit, true, 5, false, 1)
 #undef _SPIRV_OP
+
+class SPIRVSpecConstantOpBase : public SPIRVInstTemplateBase {
+public:
+  bool isOperandLiteral(unsigned I) const override {
+    // If SpecConstant results from CompositeExtract/Insert operation, then all
+    // operands are expected to be literals.
+    switch (Ops[0]) { // Opcode of underlying SpecConstant operation
+    case OpCompositeExtract:
+    case OpCompositeInsert:
+      return true;
+    default:
+      return SPIRVInstTemplateBase::isOperandLiteral(I);
+    }
+  }
+};
+
+typedef SPIRVInstTemplate<SPIRVSpecConstantOpBase, OpSpecConstantOp, true, 4,
+                          true, 0>
+    SPIRVSpecConstantOp;
 
 class SPIRVAssumeTrueKHR : public SPIRVInstruction {
 public:

--- a/llvm-spirv/test/complex-constexpr-vector.ll
+++ b/llvm-spirv/test/complex-constexpr-vector.ll
@@ -1,0 +1,94 @@
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64"
+
+define linkonce_odr hidden spir_func void @foo() {
+entry:
+; CHECK-SPIRV-DAG: Constant [[#]] [[#CONSTANT1:]] 65793
+; CHECK-SPIRV-DAG: Constant [[#]] [[#CONSTANT2:]] 131586
+
+; CHECK-SPIRV: ConstantComposite [[#]] [[#COMPOS0:]] [[#CONSTANT1]]
+; 124 is OpBitcast opcode
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#BITCAST_RES0:]] 124 [[#COMPOS0]]
+
+; 81 is OpCompositeExtract opcode
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#EXTRACT_RES0:]] 81 [[#BITCAST_RES0]] 0
+; CHECK-SPIRV: ConstantComposite [[#]] [[#COMPOS1:]] [[#CONSTANT2]]
+
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#BITCAST_RES1:]] 124 [[#COMPOS1]]
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#EXTRACT_RES1:]] 81 [[#BITCAST_RES1]] 0
+; 129 is OpFAdd opcode
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#MEMBER_1:]] 129 [[#EXTRACT_RES0:]] [[#EXTRACT_RES1]]
+
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#EXTRACT_RES2:]] 81 [[#BITCAST_RES0]] 1
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#EXTRACT_RES3:]] 81 [[#BITCAST_RES1]] 1
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#MEMBER_2:]] 129 [[#EXTRACT_RES2]] [[#EXTRACT_RES3]]
+
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#BITCAST_RES2:]] 81 [[#BITCAST_RES0]] 2
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#BITCAST_RES2:]] 81 [[#BITCAST_RES1]] 2
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#MEMBER_3:]] 129 [[#]] [[#BITCAST_RES2]]
+
+; CHECK-SPIRV: Undef [[#]] [[#MEMBER_4:]]
+; CHECK-SPIRV: ConstantComposite [[#]] [[#FINAL_COMPOS:]] [[#MEMBER_1]] [[#MEMBER_2]] [[#MEMBER_3]] [[#MEMBER_4]]
+; CHECK-SPIRV: DebugValue [[#]] [[#FINAL_COMPOS]]
+
+; CHECK-LLVM: call void @llvm.dbg.value(
+; CHECK-LLVM-SAME:   metadata <4 x half> <
+; CHECK-LLVM-SAME:   half fadd (
+; CHECK-LLVM-SAME:     half extractelement (<4 x half> bitcast (<2 x i32> <i32 65793, i32 65793> to <4 x half>), i32 0),
+; CHECK-LLVM-SAME:     half extractelement (<4 x half> bitcast (<2 x i32> <i32 131586, i32 131586> to <4 x half>), i32 0)),
+; CHECK-LLVM-SAME:   half fadd (
+; CHECK-LLVM-SAME:     half extractelement (<4 x half> bitcast (<2 x i32> <i32 65793, i32 65793> to <4 x half>), i32 1),
+; CHECK-LLVM-SAME:     half extractelement (<4 x half> bitcast (<2 x i32> <i32 131586, i32 131586> to <4 x half>), i32 1)),
+; CHECK-LLVM-SAME:   half fadd (
+; CHECK-LLVM-SAME:     half extractelement (<4 x half> bitcast (<2 x i32> <i32 65793, i32 65793> to <4 x half>), i32 2),
+; CHECK-LLVM-SAME:     half extractelement (<4 x half> bitcast (<2 x i32> <i32 131586, i32 131586> to <4 x half>), i32 2)),
+; CHECK-LLVM-SAME:   half undef>,
+; CHECK-LLVM-SAME:   metadata ![[#]], metadata !DIExpression()), !dbg ![[#]]
+  call void @llvm.dbg.value(
+    metadata <4 x half> <
+    half fadd (
+      half extractelement (<4 x half> bitcast (<2 x i32> <i32 65793, i32 65793> to <4 x half>), i32 0),
+      half extractelement (<4 x half> bitcast (<2 x i32> <i32 131586, i32 131586> to <4 x half>), i32 0)),
+    half fadd (
+      half extractelement (<4 x half> bitcast (<2 x i32> <i32 65793, i32 65793> to <4 x half>), i32 1),
+      half extractelement (<4 x half> bitcast (<2 x i32> <i32 131586, i32 131586> to <4 x half>), i32 1)),
+    half fadd (
+      half extractelement (<4 x half> bitcast (<2 x i32> <i32 65793, i32 65793> to <4 x half>), i32 2),
+      half extractelement (<4 x half> bitcast (<2 x i32> <i32 131586, i32 131586> to <4 x half>), i32 2)),
+    half undef>,
+      metadata !12, metadata !DIExpression()), !dbg !7
+  ret void
+}
+
+; Function Attrs: nofree nosync nounwind readnone speculatable willreturn
+declare void @llvm.dbg.value(metadata, metadata, metadata)
+
+!llvm.dbg.cu = !{!0}
+!llvm.module.flags = !{!3, !4}
+!opencl.used.extensions = !{!2}
+!opencl.used.optional.core.features = !{!2}
+!opencl.compiler.options = !{!2}
+!llvm.ident = !{!5}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang version 13.0.0 (https://github.com/intel/llvm.git)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: None)
+!1 = !DIFile(filename: "main.cpp", directory: "/export/users")
+!2 = !{}
+!3 = !{i32 2, !"Debug Info Version", i32 3}
+!4 = !{i32 1, !"wchar_size", i32 4}
+!5 = !{!"clang version 13.0.0"}
+!6 = distinct !DISubprogram(name: "main", scope: !1, file: !1, line: 1, type: !8, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!7 = !DILocation(line: 1, scope: !6, inlinedAt: !11)
+!8 = !DISubroutineType(types: !9)
+!9 = !{!10}
+!10 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!11 = !DILocation(line: 1, column: 0, scope: !6)
+!12 = !DILocalVariable(name: "resVec", scope: !6, file: !1, line: 1, type: !13)
+!13 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "vec<cl::sycl::detail::half_impl::half, 3>", scope: !6, file: !1, line: 1, size: 64, flags: DIFlagTypePassByValue, elements: !2)

--- a/llvm-spirv/test/constexpr_phi.ll
+++ b/llvm-spirv/test/constexpr_phi.ll
@@ -7,19 +7,22 @@
 ; RUN: FileCheck < %t.r.ll %s --check-prefix=CHECK-LLVM
 
 ; CHECK-SPIRV: Name [[#F:]] "_Z3runiiPi"
+
+; 117 is OpConvertPtrToU opcode
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#SpecConst0:]] 117 [[#F1Ptr:]]
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#SpecConst1:]] 117 [[#F2Ptr:]]
+; CHECK-SPIRV: ConstantComposite [[#]] [[#Compos0:]] [[#SpecConst0]] [[#SpecConst0]]
+; CHECK-SPIRV: ConstantComposite [[#]] [[#Compos1:]] [[#SpecConst0]] [[#SpecConst1]]
+
 ; CHECK-SPIRV: Function [[#]] [[#F]] [[#]] [[#]]
 ; CHECK-SPIRV: Label [[#L1:]]
-; CHECK-SPIRV: CompositeInsert [[#]] [[#Ins1:]] [[#]] [[#]] 0
-; CHECK-SPIRV: CompositeInsert [[#]] [[#Ins2:]] [[#]] [[#Ins1]] 1 
 ; CHECK-SPIRV: BranchConditional [[#]] [[#L2:]] [[#L3:]]
 ; CHECK-SPIRV: Label [[#L2]]
-; CHECK-SPIRV: CompositeInsert [[#]] [[#Ins3:]] [[#]] [[#]] 0
-; CHECK-SPIRV: CompositeInsert [[#]] [[#Ins4:]] [[#]] [[#Ins3]] 1
 ; CHECK-SPIRV: Branch [[#L3]]
 ; CHECK-SPIRV: Label [[#L3]]
 ; CHECK-NEXT-SPIRV: Phi [[#]] [[#]]
-  ; CHECK-SAME-SPIRV: [[#Ins2]] [[#L1]]
-  ; CHECK-SAME-SPIRV: [[#Ins4]] [[#L2]]
+  ; CHECK-SAME-SPIRV: [[#Compos0]] [[#L1]]
+  ; CHECK-SAME-SPIRV: [[#Compos1]] [[#L2]]
 
 ; CHECK-LLVM: br label %[[#L:]]
 ; CHECK-LLVM: [[#L]]:

--- a/llvm-spirv/test/constexpr_vector.ll
+++ b/llvm-spirv/test/constexpr_vector.ll
@@ -1,114 +1,61 @@
-; RUN: llvm-as < %s | llvm-spirv -s | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
 
-; CHECK-LLVM: define dllexport void @vadd() {
-; CHECK-LLVM:   %Funcs = alloca <16 x i8>, align 16
-; CHECK-LLVM:   %0 = ptrtoint i32 (i32)* @_Z2f1u2CMvb32_j to i64
-; CHECK-LLVM:   %1 = bitcast i64 %0 to <8 x i8>
-; CHECK-LLVM:   %2 = extractelement <8 x i8> %1, i32 0
-; CHECK-LLVM:   %3 = extractelement <8 x i8> %1, i32 1
-; CHECK-LLVM:   %4 = extractelement <8 x i8> %1, i32 2
-; CHECK-LLVM:   %5 = extractelement <8 x i8> %1, i32 3
-; CHECK-LLVM:   %6 = extractelement <8 x i8> %1, i32 4
-; CHECK-LLVM:   %7 = extractelement <8 x i8> %1, i32 5
-; CHECK-LLVM:   %8 = extractelement <8 x i8> %1, i32 6
-; CHECK-LLVM:   %9 = extractelement <8 x i8> %1, i32 7
-; CHECK-LLVM:   %10 = ptrtoint i32 (i32)* @_Z2f2u2CMvb32_j to i64
-; CHECK-LLVM:   %11 = bitcast i64 %10 to <8 x i8>
-; CHECK-LLVM:   %12 = extractelement <8 x i8> %11, i32 0
-; CHECK-LLVM:   %13 = extractelement <8 x i8> %11, i32 1
-; CHECK-LLVM:   %14 = extractelement <8 x i8> %11, i32 2
-; CHECK-LLVM:   %15 = extractelement <8 x i8> %11, i32 3
-; CHECK-LLVM:   %16 = extractelement <8 x i8> %11, i32 4
-; CHECK-LLVM:   %17 = extractelement <8 x i8> %11, i32 5
-; CHECK-LLVM:   %18 = extractelement <8 x i8> %11, i32 6
-; CHECK-LLVM:   %19 = extractelement <8 x i8> %11, i32 7
-; CHECK-LLVM:   %20 = insertelement <16 x i8> undef, i8 %2, i32 0
-; CHECK-LLVM:   %21 = insertelement <16 x i8> %20, i8 %3, i32 1
-; CHECK-LLVM:   %22 = insertelement <16 x i8> %21, i8 %4, i32 2
-; CHECK-LLVM:   %23 = insertelement <16 x i8> %22, i8 %5, i32 3
-; CHECK-LLVM:   %24 = insertelement <16 x i8> %23, i8 %6, i32 4
-; CHECK-LLVM:   %25 = insertelement <16 x i8> %24, i8 %7, i32 5
-; CHECK-LLVM:   %26 = insertelement <16 x i8> %25, i8 %8, i32 6
-; CHECK-LLVM:   %27 = insertelement <16 x i8> %26, i8 %9, i32 7
-; CHECK-LLVM:   %28 = insertelement <16 x i8> %27, i8 %12, i32 8
-; CHECK-LLVM:   %29 = insertelement <16 x i8> %28, i8 %13, i32 9
-; CHECK-LLVM:   %30 = insertelement <16 x i8> %29, i8 %14, i32 10
-; CHECK-LLVM:   %31 = insertelement <16 x i8> %30, i8 %15, i32 11
-; CHECK-LLVM:   %32 = insertelement <16 x i8> %31, i8 %16, i32 12
-; CHECK-LLVM:   %33 = insertelement <16 x i8> %32, i8 %17, i32 13
-; CHECK-LLVM:   %34 = insertelement <16 x i8> %33, i8 %18, i32 14
-; CHECK-LLVM:   %35 = insertelement <16 x i8> %34, i8 %19, i32 15
-; CHECK-LLVM:   store <16 x i8> %35, <16 x i8>* %Funcs, align 16
-; CHECK-LLVM:        %Funcs1 = alloca <2 x i64>, align 16
-; CHECK-LLVM:   %36 = ptrtoint i32 (i32)* @_Z2f1u2CMvb32_j to i64
-; CHECK-LLVM:   %37 = ptrtoint i32 (i32)* @_Z2f2u2CMvb32_j to i64
-; CHECK-LLVM:   %38 = insertelement <2 x i64> undef, i64 %36, i32 0
-; CHECK-LLVM:   %39 = insertelement <2 x i64> %38, i64 %37, i32 1
-; CHECK-LLVM:   store <2 x i64> %39, <2 x i64>* %Funcs1, align 16
+; RUN: llvm-as %s -o %t.bc
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_function_pointers
+; RUN: llvm-spirv %t.spv -to-text -o %t.spt
+; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis %t.rev.bc
+; RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
 
-; RUN: llvm-as < %s | llvm-spirv -spirv-text --spirv-ext=+SPV_INTEL_function_pointers | FileCheck %s --check-prefix=CHECK-SPIRV
 
-; CHECK-SPIRV-DAG: 4 Name [[Funcs:[0-9]+]] "Funcs"
-; CHECK-SPIRV-DAG: 4 Name [[Funcs1:[0-9]+]] "Funcs1"
-; CHECK-SPIRV-DAG: 6 Name [[F1:[0-9+]]] "_Z2f1u2CMvb32_j"
-; CHECK-SPIRV-DAG: 6 Name [[F2:[0-9+]]] "_Z2f2u2CMvb32_j"
+; CHECK-SPIRV-DAG: 4 Name [[#Funcs:]] "Funcs"
+; CHECK-SPIRV-DAG: 4 Name [[#Funcs1:]] "Funcs1"
+; CHECK-SPIRV-DAG: 6 Name [[#F1:]] "_Z2f1u2CMvb32_j"
+; CHECK-SPIRV-DAG: 6 Name [[#F2:]] "_Z2f2u2CMvb32_j"
 
 ; CHECK-SPIRV-DAG: 4 TypeInt [[TypeInt8:[0-9]+]] 8 0
 ; CHECK-SPIRV-DAG: 4 TypeInt [[TypeInt32:[0-9]+]] 32 0
 ; CHECK-SPIRV-DAG: 4 TypeInt [[TypeInt64:[0-9]+]] 64 0
-; CHECK-SPIRV-DAG: 4 TypeVector [[TypeVec16:[0-9]+]] [[TypeInt8]] 16
-; CHECK-SPIRV-DAG: 4 TypeVector [[TypeVec8:[0-9]+]] [[TypeInt8]] 8
-; CHECK-SPIRV-DAG: 4 TypeVector [[TypeVec64:[0-9]+]] [[TypeInt64]] 2
-; CHECK-SPIRV-DAG: 4 TypePointer [[StorePtr:[0-9]+]] 7 [[TypeVec16]]
-; CHECK-SPIRV-DAG: 3 Undef [[TypeVec16]] [[TypeUndefV16:[0-9]+]]
-; CHECK-SPIRV-DAG: 3 Undef [[TypeVec64]] [[TypeUndefV64:[0-9]+]]
-; CHECK-SPIRV-DAG: 4 ConstantFunctionPointerINTEL [[FuncPtrTy:[0-9]+]] [[F1Ptr:[0-9]+]] [[F1]]
-; CHECK-SPIRV-DAG: 4 ConstantFunctionPointerINTEL [[FuncPtrTy]] [[F2Ptr:[0-9]+]] [[F2]]
-; CHECK-SPIRV-DAG: 4 ConstantFunctionPointerINTEL [[FuncPtrTy]] [[F11Ptr:[0-9]+]] [[F1]]
-; CHECK-SPIRV-DAG: 4 ConstantFunctionPointerINTEL [[FuncPtrTy]] [[F21Ptr:[0-9]+]] [[F2]]
 
-; CHECK-SPIRV: 4 ConvertPtrToU [[TypeInt64]] [[Ptr1:[0-9]+]] [[F1Ptr]]
-; CHECK-SPIRV: 4 Bitcast [[TypeVec8]] [[Vec1:[0-9]+]] [[Ptr1]]
-; CHECK-SPIRV: 5 CompositeExtract [[TypeInt8]] [[v00:[0-9]+]] [[Vec1]] 0
-; CHECK-SPIRV: 5 CompositeExtract [[TypeInt8]] [[v01:[0-9]+]] [[Vec1]] 1
-; CHECK-SPIRV: 5 CompositeExtract [[TypeInt8]] [[v02:[0-9]+]] [[Vec1]] 2
-; CHECK-SPIRV: 5 CompositeExtract [[TypeInt8]] [[v03:[0-9]+]] [[Vec1]] 3
-; CHECK-SPIRV: 5 CompositeExtract [[TypeInt8]] [[v04:[0-9]+]] [[Vec1]] 4
-; CHECK-SPIRV: 5 CompositeExtract [[TypeInt8]] [[v05:[0-9]+]] [[Vec1]] 5
-; CHECK-SPIRV: 5 CompositeExtract [[TypeInt8]] [[v06:[0-9]+]] [[Vec1]] 6
-; CHECK-SPIRV: 5 CompositeExtract [[TypeInt8]] [[v07:[0-9]+]] [[Vec1]] 7
-; CHECK-SPIRV: 4 ConvertPtrToU [[TypeInt64]] [[Ptr2:[0-9]+]] [[F2Ptr]]
-; CHECK-SPIRV: 4 Bitcast [[TypeVec8]] [[Vec2:[0-9]+]] [[Ptr2]]
-; CHECK-SPIRV: 5 CompositeExtract [[TypeInt8]] [[v10:[0-9]+]] [[Vec2]] 0
-; CHECK-SPIRV: 5 CompositeExtract [[TypeInt8]] [[v11:[0-9]+]] [[Vec2]] 1
-; CHECK-SPIRV: 5 CompositeExtract [[TypeInt8]] [[v12:[0-9]+]] [[Vec2]] 2
-; CHECK-SPIRV: 5 CompositeExtract [[TypeInt8]] [[v13:[0-9]+]] [[Vec2]] 3
-; CHECK-SPIRV: 5 CompositeExtract [[TypeInt8]] [[v14:[0-9]+]] [[Vec2]] 4
-; CHECK-SPIRV: 5 CompositeExtract [[TypeInt8]] [[v15:[0-9]+]] [[Vec2]] 5
-; CHECK-SPIRV: 5 CompositeExtract [[TypeInt8]] [[v16:[0-9]+]] [[Vec2]] 6
-; CHECK-SPIRV: 5 CompositeExtract [[TypeInt8]] [[v17:[0-9]+]] [[Vec2]] 7
-; CHECK-SPIRV: 6 CompositeInsert [[TypeVec16]] [[NewVec0:[0-9]+]] [[v00]] [[TypeUndefV16]] 0
-; CHECK-SPIRV: 6 CompositeInsert [[TypeVec16]] [[NewVec1:[0-9]+]] [[v01]] [[NewVec0]] 1
-; CHECK-SPIRV: 6 CompositeInsert [[TypeVec16]] [[NewVec2:[0-9]+]] [[v02]] [[NewVec1]] 2
-; CHECK-SPIRV: 6 CompositeInsert [[TypeVec16]] [[NewVec3:[0-9]+]] [[v03]] [[NewVec2]] 3
-; CHECK-SPIRV: 6 CompositeInsert [[TypeVec16]] [[NewVec4:[0-9]+]] [[v04]] [[NewVec3]] 4
-; CHECK-SPIRV: 6 CompositeInsert [[TypeVec16]] [[NewVec5:[0-9]+]] [[v05]] [[NewVec4]] 5
-; CHECK-SPIRV: 6 CompositeInsert [[TypeVec16]] [[NewVec6:[0-9]+]] [[v06]] [[NewVec5]] 6
-; CHECK-SPIRV: 6 CompositeInsert [[TypeVec16]] [[NewVec7:[0-9]+]] [[v07]] [[NewVec6]] 7
-; CHECK-SPIRV: 6 CompositeInsert [[TypeVec16]] [[NewVec8:[0-9]+]] [[v10]] [[NewVec7]] 8
-; CHECK-SPIRV: 6 CompositeInsert [[TypeVec16]] [[NewVec9:[0-9]+]] [[v11]] [[NewVec8]] 9
-; CHECK-SPIRV: 6 CompositeInsert [[TypeVec16]] [[NewVec10:[0-9]+]] [[v12]] [[NewVec9]] 10
-; CHECK-SPIRV: 6 CompositeInsert [[TypeVec16]] [[NewVec11:[0-9]+]] [[v13]] [[NewVec10]] 11
-; CHECK-SPIRV: 6 CompositeInsert [[TypeVec16]] [[NewVec12:[0-9]+]] [[v14]] [[NewVec11]] 12
-; CHECK-SPIRV: 6 CompositeInsert [[TypeVec16]] [[NewVec13:[0-9]+]] [[v15]] [[NewVec12]] 13
-; CHECK-SPIRV: 6 CompositeInsert [[TypeVec16]] [[NewVec14:[0-9]+]] [[v16]] [[NewVec13]] 14
-; CHECK-SPIRV: 6 CompositeInsert [[TypeVec16]] [[NewVec15:[0-9]+]] [[v17]] [[NewVec14]] 15
-; CHECK-SPIRV: 5 Store [[Funcs]] [[NewVec15]] [[TypeInt32]] [[StorePtr]]
-; CHECK-SPIRV: 4 ConvertPtrToU [[TypeInt64]] [[Ptr3:[0-9]+]] [[F11Ptr]]
-; CHECK-SPIRV: 4 ConvertPtrToU [[TypeInt64]] [[Ptr4:[0-9]+]] [[F21Ptr]]
-; CHECK-SPIRV: 6 CompositeInsert [[TypeVec64]] [[NewVec20:[0-9]+]] [[Ptr3]] [[TypeUndefV64]] 0
-; CHECK-SPIRV: 6 CompositeInsert [[TypeVec64]] [[NewVec21:[0-9]+]] [[Ptr4]] [[NewVec20]] 1
-; CHECK-SPIRV: 5 Store [[Funcs1]] [[NewVec21]] [[TypeInt32]] [[StorePtr]]
+; 117 is OpConvertPtrToU opcode
+; 81 is OpCompositeExtract opcode
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#FIRST_ARG:]] 117 [[#F1Ptr:]]
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#VEC_0:]] 81 [[#FIRST_COMPOSITE:]] 0
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#VEC_1:]] 81 [[#FIRST_COMPOSITE]] 1
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#VEC_2:]] 81 [[#FIRST_COMPOSITE]] 2
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#VEC_3:]] 81 [[#FIRST_COMPOSITE]] 3
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#VEC_4:]] 81 [[#FIRST_COMPOSITE]] 4
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#VEC_5:]] 81 [[#FIRST_COMPOSITE]] 5
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#VEC_6:]] 81 [[#FIRST_COMPOSITE]] 6
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#VEC_7:]] 81 [[#FIRST_COMPOSITE]] 7
+
+; 117 is OpConvertPtrToU opcode
+; 81 is OpCompositeExtract opcode
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#SECOND_ARG:]] 117 [[#F2Ptr:]]
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#VEC_8:]] 81 [[#SECOND_COMPOSITE:]] 0
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#VEC_9:]] 81 [[#SECOND_COMPOSITE]] 1
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#VEC_10:]] 81 [[#SECOND_COMPOSITE]] 2
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#VEC_11:]] 81 [[#SECOND_COMPOSITE]] 3
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#VEC_12:]] 81 [[#SECOND_COMPOSITE]] 4
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#VEC_13:]] 81 [[#SECOND_COMPOSITE]] 5
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#VEC_14:]] 81 [[#SECOND_COMPOSITE]] 6
+; CHECK-SPIRV: SpecConstantOp [[#]] [[#VEC_15:]] 81 [[#SECOND_COMPOSITE]] 7
+
+; CHECK-SPIRV-DAG: 4 TypeVector [[#TypeVec16:]] [[TypeInt8]] 16
+; CHECK-SPIRV-DAG: 4 TypeVector [[#TypeVec8:]] [[TypeInt8]] 8
+; CHECK-SPIRV-DAG: 4 TypeVector [[#TypeVec64:]] [[TypeInt64]] 2
+; CHECK-SPIRV-DAG: 4 TypePointer [[#StorePtr:]] 7 [[#TypeVec16]]
+
+; 124 is OpBitcast opcode
+; CHECK-SPIRV-DAG: 4 ConstantFunctionPointerINTEL [[#FuncPtrTy:]] [[#F1Ptr]] [[#F1]]
+; CHECK-SPIRV: SpecConstantOp [[#TypeVec8]] [[#FIRST_COMPOSITE]] 124 [[#FIRST_ARG]]
+; CHECK-SPIRV-DAG: 4 ConstantFunctionPointerINTEL [[#FuncPtrTy]] [[#F2Ptr]] [[#F2]]
+; CHECK-SPIRV: SpecConstantOp [[#TypeVec8]] [[#SECOND_COMPOSITE]] 124 [[#SECOND_ARG]]
+; CHECK-SPIRV: ConstantComposite [[#TypeVec16]] [[#FUNCS_COMPOSITE:]] [[#VEC_0]] [[#VEC_1]] [[#VEC_2]] [[#VEC_3]] [[#VEC_4]] [[#VEC_5]] [[#VEC_6]] [[#VEC_7]] [[#VEC_8]] [[#VEC_9]] [[#VEC_10]] [[#VEC_11]] [[#VEC_12]] [[#VEC_13]] [[#VEC_14]] [[#VEC_15]]
+; CHECK-SPIRV: ConstantComposite [[#TypeVec64]] [[#FUNCS1_COMPOSITE:]] [[#FIRST_ARG]] [[#SECOND_ARG]]
+
+; CHECK-SPIRV: 5 Store [[#Funcs]] [[#FUNCS_COMPOSITE]] [[TypeInt32]] [[#StorePtr]]
+; CHECK-SPIRV: 5 Store [[#Funcs1]] [[#FUNCS1_COMPOSITE]] [[TypeInt32]] [[#StorePtr]]
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir-unknown-unknown"
@@ -123,12 +70,38 @@ define internal i32 @_Z2f2u2CMvb32_j(i32 %x) {
 entry:
   ret i32 %x
 }
+
+; CHECK-LLVM: define spir_func void @vadd()
+; CHECK-LLVM: %Funcs = alloca <16 x i8>, align 16
+; CHECK-LLVM: store <16 x i8> <i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 0), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 1), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 2), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 3), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 4), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 5), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 6), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 7), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 0), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 1), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 2), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 3), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 4), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 5), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 6), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 7)>, <16 x i8>* %Funcs, align 16
+; CHECK-LLVM: %Funcs1 = alloca <2 x i64>, align 16
+; CHECK-LLVM: store <2 x i64> <i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64), i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64)>, <2 x i64>* %Funcs1, align 16
 ; Function Attrs: noinline nounwind
 define dllexport void @vadd() {
 entry:
   %Funcs = alloca <16 x i8>, align 16
-  store <16 x i8> <i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 0), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 1), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 2), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 3), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 4), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 5), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 6), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 7), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 0), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 1), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 2), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 3), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 4), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 5), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 6), i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 7)>, <16 x i8>* %Funcs, align 16
+  store <16 x i8> <
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 0),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 1),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 2),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 3),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 4),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 5),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 6),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64) to <8 x i8>), i32 7),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 0),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 1),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 2),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 3),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 4),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 5),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 6),
+    i8 extractelement (<8 x i8> bitcast (i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64) to <8 x i8>), i32 7)
+    >, <16 x i8>* %Funcs, align 16
   %Funcs1 = alloca <2 x i64>, align 16
-  store <2 x i64> <i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64), i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64)>, <2 x i64>* %Funcs1, align 16
+  store <2 x i64> <
+    i64 ptrtoint (i32 (i32)* @_Z2f1u2CMvb32_j to i64),
+    i64 ptrtoint (i32 (i32)* @_Z2f2u2CMvb32_j to i64)
+    >, <2 x i64>* %Funcs1, align 16
   ret void
 }

--- a/llvm-spirv/test/vector-metadata-constexpr.ll
+++ b/llvm-spirv/test/vector-metadata-constexpr.ll
@@ -8,27 +8,57 @@ target triple = "spir64-unknown-unknown"
 ; Function Attrs: nounwind ssp uwtable
 define void @foo() #0 !dbg !4 {
 entry:
-  call void @llvm.dbg.value(metadata <3 x i8> <i8 add (i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 65793, i32 65793> to <8 x i8>), i32 0), i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 131586, i32 131586> to <8 x i8>), i32 0)), i8 add (i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 65793, i32 65793> to <8 x i8>), i32 1), i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 131586, i32 131586> to <8 x i8>), i32 1)), i8 add (i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 65793, i32 65793> to <8 x i8>), i32 2), i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 131586, i32 131586> to <8 x i8>), i32 2))>, metadata !12, metadata !DIExpression()), !dbg !18
-  ret void, !dbg !20
-; CHECK: %0 = bitcast <2 x i32> <i32 65793, i32 65793> to <8 x i8>
-; CHECK: %1 = extractelement <8 x i8> %0, i32 0
-; CHECK: %2 = bitcast <2 x i32> <i32 131586, i32 131586> to <8 x i8>
-; CHECK: %3 = extractelement <8 x i8> %2, i32 0
-; CHECK: %4 = add i8 %1, %3
-; CHECK: %5 = bitcast <2 x i32> <i32 65793, i32 65793> to <8 x i8>
-; CHECK: %6 = extractelement <8 x i8> %5, i32 1
-; CHECK: %7 = bitcast <2 x i32> <i32 131586, i32 131586> to <8 x i8>
-; CHECK: %8 = extractelement <8 x i8> %7, i32 1
-; CHECK: %9 = add i8 %6, %8
-; CHECK: %10 = bitcast <2 x i32> <i32 65793, i32 65793> to <8 x i8>
-; CHECK: %11 = extractelement <8 x i8> %10, i32 2
-; CHECK: %12 = bitcast <2 x i32> <i32 131586, i32 131586> to <8 x i8>
-; CHECK: %13 = extractelement <8 x i8> %12, i32 2
-; CHECK: %14 = add i8 %11, %13
-; CHECK: %15 = insertelement <3 x i8> undef, i8 %4, i32 0
-; CHECK: %16 = insertelement <3 x i8> %15, i8 %9, i32 1
-; CHECK: %17 = insertelement <3 x i8> %16, i8 %14, i32 2
-; CHECK: call void @llvm.dbg.value(metadata <3 x i8> %17, metadata !{{[0-9]+}}, metadata !DIExpression()), !dbg !{{[0-9]+}}
+  call void @llvm.dbg.value(
+    metadata <3 x i8> <
+      i8 add (
+        i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 65793, i32 65793> to <8 x i8>), i32 0),
+        i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 131586, i32 131586> to <8 x i8>), i32 0)),
+      i8 add (
+        i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 65793, i32 65793> to <8 x i8>), i32 1),
+        i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 131586, i32 131586> to <8 x i8>), i32 1)),
+      i8 add (
+        i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 65793, i32 65793> to <8 x i8>), i32 2),
+        i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 131586, i32 131586> to <8 x i8>), i32 2))>,
+      metadata !12, metadata !DIExpression()), !dbg !18
+; CHECK: call void @llvm.dbg.value(
+; CHECK-SAME:   metadata <3 x i8> <
+; CHECK-SAME:     i8 add (
+; CHECK-SAME:       i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 65793, i32 65793> to <8 x i8>), i32 0),
+; CHECK-SAME:       i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 131586, i32 131586> to <8 x i8>), i32 0)),
+; CHECK-SAME:     i8 add (
+; CHECK-SAME:       i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 65793, i32 65793> to <8 x i8>), i32 1),
+; CHECK-SAME:       i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 131586, i32 131586> to <8 x i8>), i32 1)),
+; CHECK-SAME:     i8 add (
+; CHECK-SAME:       i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 65793, i32 65793> to <8 x i8>), i32 2),
+; CHECK-SAME:       i8 extractelement (<8 x i8> bitcast (<2 x i32> <i32 131586, i32 131586> to <8 x i8>), i32 2))>,
+; CHECK-SAME:     metadata ![[#]], metadata !DIExpression()), !dbg ![[#]]
+  call void @llvm.dbg.value(
+    metadata <4 x half> <
+    half fadd (
+      half extractelement (<4 x half> bitcast (<2 x i32> <i32 65793, i32 65793> to <4 x half>), i32 0),
+      half extractelement (<4 x half> bitcast (<2 x i32> <i32 131586, i32 131586> to <4 x half>), i32 0)),
+    half fadd (
+      half extractelement (<4 x half> bitcast (<2 x i32> <i32 65793, i32 65793> to <4 x half>), i32 1),
+      half extractelement (<4 x half> bitcast (<2 x i32> <i32 131586, i32 131586> to <4 x half>), i32 1)),
+    half fadd (
+      half extractelement (<4 x half> bitcast (<2 x i32> <i32 65793, i32 65793> to <4 x half>), i32 2),
+      half extractelement (<4 x half> bitcast (<2 x i32> <i32 131586, i32 131586> to <4 x half>), i32 2)),
+    half undef>,
+    metadata !23, metadata !DIExpression()), !dbg !20
+; CHECK: call void @llvm.dbg.value(
+; CHECK-SAME:   metadata <4 x half> <
+; CHECK-SAME:   half fadd (
+; CHECK-SAME:     half extractelement (<4 x half> bitcast (<2 x i32> <i32 65793, i32 65793> to <4 x half>), i32 0),
+; CHECK-SAME:     half extractelement (<4 x half> bitcast (<2 x i32> <i32 131586, i32 131586> to <4 x half>), i32 0)),
+; CHECK-SAME:   half fadd (
+; CHECK-SAME:     half extractelement (<4 x half> bitcast (<2 x i32> <i32 65793, i32 65793> to <4 x half>), i32 1),
+; CHECK-SAME:     half extractelement (<4 x half> bitcast (<2 x i32> <i32 131586, i32 131586> to <4 x half>), i32 1)),
+; CHECK-SAME:   half fadd (
+; CHECK-SAME:     half extractelement (<4 x half> bitcast (<2 x i32> <i32 65793, i32 65793> to <4 x half>), i32 2),
+; CHECK-SAME:     half extractelement (<4 x half> bitcast (<2 x i32> <i32 131586, i32 131586> to <4 x half>), i32 2)),
+; CHECK-SAME:   half undef>,
+; CHECK-SAME:   metadata ![[#]], metadata !DIExpression()), !dbg ![[#]]
+  ret void, !dbg !22
 }
 
 ; Function Attrs: nounwind readnone
@@ -38,7 +68,7 @@ attributes #0 = { nounwind ssp uwtable  }
 attributes #2 = { nounwind readnone }
 attributes #3 = { nounwind }
 
-!llvm.dbg.cu = !{!0}
+!llvm.dbg.cu = !{!0, !26}
 !llvm.module.flags = !{!13, !14, !15}
 !llvm.ident = !{!16}
 
@@ -61,4 +91,10 @@ attributes #3 = { nounwind }
 !17 = !DIExpression()
 !18 = !DILocation(line: 2, column: 52, scope: !7, inlinedAt: !19)
 !19 = distinct !DILocation(line: 4, column: 3, scope: !4)
-!20 = !DILocation(line: 6, column: 1, scope: !4)
+!20 = !DILocation(line: 5, scope: !4, inlinedAt: !21)
+!21 = !DILocation(line: 1, column: 0, scope: !4)
+!22 = !DILocation(line: 6, column: 1, scope: !4)
+!23 = !DILocalVariable(name: "resVec", scope: !4, file: !24, line: 1, type: !25)
+!24 = !DIFile(filename: "main.cpp", directory: "/export/users")
+!25 = distinct !DICompositeType(tag: DW_TAG_class_type, name: "vec<cl::sycl::detail::half_impl::half, 3>", scope: !4, file: !24, line: 1, size: 64, flags: DIFlagTypePassByValue, elements: !2)
+!26 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !24, producer: "clang version 13.0.0 (https://github.com/intel/llvm.git)", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, nameTableKind: None)


### PR DESCRIPTION
Allow translator to go deeper into complex nested instructions.
Enabled a possibility to translate expressions in `extractelement` and binary
operator instructions (e.g., `fadd`, `fmul`).

Also this change removes lowering for constant expression vector as the
alternative approach was introduced - to translate any complicated nested
instruction instead of lowering.

Original commit:
KhronosGroup/SPIRV-LLVM-Translator@c3c3c68