### PR TITLE
[CI] Add cache checkout script to docker containers

### DIFF
--- a/devops/actions/cached_checkout/action.yml
+++ b/devops/actions/cached_checkout/action.yml
@@ -1,0 +1,39 @@
+name: 'Cached checkout'
+description: 'Checkout a git repository using local cache if possible'
+inputs:
+  repository:
+    description: 'Repository name with owner'
+    default: ${{ github.repository }}
+  ref:
+    description: 'Commit-ish to checkout'
+  path:
+    description: 'Path to checkout repo to'
+  fetch-depth:
+    description: 'Number of commits to fetch'
+    default: 1
+  cache_path:
+    description: 'Path to cache location for all repos'
+
+runs:
+  using: 'composite'
+  steps:
+  - name: Fetch cache
+    shell: bash
+    run: |
+      mkdir -p ${{ inputs.cache_path }}/${{ inputs.repository }}
+      cd ${{ inputs.cache_path }}/${{ inputs.repository }}
+      if [ -d ./.git ]; then
+        git pull
+      else
+        git clone https://github.com/${{ inputs.repository }}.git .
+      fi
+      chown -R sycl:sycl ${{ inputs.cache_path }}/${{ inputs.repository }}
+  - name: Checkout
+    env:
+      GIT_ALTERNATE_OBJECT_DIRECTORIES: ${{ inputs.cache_path }}/${{ inputs.repository }}/.git/objects
+    uses: actions/checkout@v2
+    with:
+      repository: ${{ inputs.repository }}
+      ref: ${{ inputs.ref }}
+      path: ${{ inputs.path }}
+      fetch-depth: ${{ inputs.fetch-depth }}

--- a/devops/containers/ubuntu2004_base.Dockerfile
+++ b/devops/containers/ubuntu2004_base.Dockerfile
@@ -16,6 +16,8 @@ RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
 # Add sycl user to video group so that it can access GPU
 RUN usermod -aG video sycl
 
+COPY actions/cached_checkout /actions/cached_checkout
+COPY actions/cleanup /actions/cleanup
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 
 ENTRYPOINT ["/docker_entrypoint.sh"]

--- a/devops/containers/ubuntu2004_build.Dockerfile
+++ b/devops/containers/ubuntu2004_build.Dockerfile
@@ -25,6 +25,8 @@ RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
 # Add sycl user to video group so that it can access GPU
 RUN usermod -aG video sycl
 
+COPY actions/cached_checkout /actions/cached_checkout
+COPY actions/cleanup /actions/cleanup
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 
 ENTRYPOINT ["/docker_entrypoint.sh"]

--- a/devops/scripts/install_build_tools.sh
+++ b/devops/scripts/install_build_tools.sh
@@ -9,5 +9,10 @@ apt update && apt install -yqq \
       python3 \
       python3-distutils \
       python-is-python3 \
+      python3-pip \
+      zstd \
       ocl-icd-libopencl1 \
       vim
+
+pip3 install psutil
+


### PR DESCRIPTION
Add a new cache checkout script to docker containers. General idea is to keep a local copy of repository and re-use existing objects to avoid long clone times.

Also add zstd to experiment with LLVM compression times and psutil, which is required to kill tests by timeout.