### PR TITLE
[SYCL][NFC] Fix static code analysis concerns

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4148,7 +4148,7 @@ bool Sema::checkAllowedSYCLInitializer(VarDecl *VD) {
     return true;
 
   const Expr *Init = VD->getInit();
-  bool ValueDependent = Init->isValueDependent();
+  bool ValueDependent = Init && Init->isValueDependent();
   bool isConstantInit =
       Init && !ValueDependent && Init->isConstantInitializer(Context, false);
   if (!VD->isConstexpr() && Init && !ValueDependent && !isConstantInit)


### PR DESCRIPTION
Found via a static-analysis tool:
Suspicious dereference of pointer in function call before NULL check

Inside checkAllowedSYCLInitializer() in SemaSYCL.cpp file:

    const Expr *Init = VD->getInit();
    bool ValueDependent = Init->isValueDependent(); --> 'Init' is dereferenced by being passed as argument 0 to function "isValueDependent
    bool isConstantInit =
       Init && !ValueDependent && Init->isConstantInitializer(Context, false);  --> 'Init' is checked for NULL here

This patch adds NULL value checking for 'Init' expression.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>