### PR TITLE
[SYCL][NFC] Optimize getKernelNamesUsingAssert

### DIFF
--- a/llvm/test/tools/sycl-post-link/assert-indirect-with-split-2.ll
+++ b/llvm/test/tools/sycl-post-link/assert-indirect-with-split-2.ll
@@ -9,7 +9,7 @@
 ; marked as using asserts.
 
 ; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
-; RUN: FileCheck %s -input-file=%t_0.prop
+; RUN: FileCheck %s -input-file=%t_0.prop --implicit-check-not main_TU0_kernel1
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-linux"
@@ -63,6 +63,12 @@ entry:
   ret void
 }
 
+define dso_local spir_kernel void @main_TU0_kernel1() #0 {
+entry:
+  call spir_func void @_Z4foo1v()
+  ret void
+}
+
 ; Function Attrs: nounwind
 define dso_local spir_func void @_Z4foo1v() {
 entry:
@@ -75,13 +81,6 @@ entry:
 define dso_local spir_kernel void @main_TU1_kernel0() #2 {
 entry:
   call spir_func void @_Z3foov() ; call assert
-  ret void
-}
-
-; CHECK-NOT: main_TU0_kernel1
-define dso_local spir_kernel void @main_TU0_kernel1() #0 {
-entry:
-  call spir_func void @_Z4foo1v()
   ret void
 }
 

--- a/llvm/test/tools/sycl-post-link/assert-indirect-with-split-2.ll
+++ b/llvm/test/tools/sycl-post-link/assert-indirect-with-split-2.ll
@@ -63,13 +63,6 @@ entry:
   ret void
 }
 
-; CHECK-NOT: main_TU0_kernel1
-define dso_local spir_kernel void @main_TU0_kernel1() #0 {
-entry:
-  call spir_func void @_Z4foo1v()
-  ret void
-}
-
 ; Function Attrs: nounwind
 define dso_local spir_func void @_Z4foo1v() {
 entry:
@@ -82,6 +75,13 @@ entry:
 define dso_local spir_kernel void @main_TU1_kernel0() #2 {
 entry:
   call spir_func void @_Z3foov() ; call assert
+  ret void
+}
+
+; CHECK-NOT: main_TU0_kernel1
+define dso_local spir_kernel void @main_TU0_kernel1() #0 {
+entry:
+  call spir_func void @_Z4foo1v()
   ret void
 }
 

--- a/llvm/test/tools/sycl-post-link/assert-indirect-with-split-2.ll
+++ b/llvm/test/tools/sycl-post-link/assert-indirect-with-split-2.ll
@@ -9,7 +9,7 @@
 ; marked as using asserts.
 
 ; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
-; RUN: FileCheck %s -input-file=%t_0.prop --implicit-check-not main_TU0_kernel1
+; RUN: FileCheck %s -input-file=%t_0.prop
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-linux"
@@ -24,17 +24,15 @@ target triple = "spir64-unknown-linux"
 
 ; CHECK: [SYCL/assert used]
 
-; CHECK-DAG: main_TU1_kernel1
-define dso_local spir_kernel void @main_TU1_kernel1() #2 {
-entry:
-  call spir_func void @foo()
-  call spir_func void @bar()
-  ret void
-}
-
 define dso_local spir_func void @foo() #2 {
 entry:
   call spir_func void @_Z4foo1v()
+  ret void
+}
+
+; CHECK-NOT: empty_kernel
+define dso_local spir_kernel void @empty_kernel() {
+  %1 = ptrtoint void ()* @bar to i64
   ret void
 }
 
@@ -45,12 +43,13 @@ entry:
   ret void
 }
 
-; CHECK-DAG: main_TU0_kernel0
+; CHECK: main_TU0_kernel0
 define dso_local spir_kernel void @main_TU0_kernel0() #0 {
 entry:
   call spir_func void @_Z3foov() ; call assert
   ret void
 }
+
 
 define dso_local spir_func void @_Z3foov() {
 entry:
@@ -63,6 +62,7 @@ entry:
   ret void
 }
 
+; CHECK-NOT: main_TU0_kernel1
 define dso_local spir_kernel void @main_TU0_kernel1() #0 {
 entry:
   call spir_func void @_Z4foo1v()
@@ -77,7 +77,7 @@ entry:
   ret void
 }
 
-; CHECK-DAG: main_TU1_kernel0
+; CHECK: main_TU1_kernel0
 define dso_local spir_kernel void @main_TU1_kernel0() #2 {
 entry:
   call spir_func void @_Z3foov() ; call assert
@@ -96,6 +96,13 @@ entry:
   ret void
 }
 
+; CHECK: main_TU1_kernel1
+define dso_local spir_kernel void @main_TU1_kernel1() #2 {
+entry:
+  call spir_func void @foo()
+  call spir_func void @bar()
+  ret void
+}
 
 ; Function Attrs: convergent norecurse mustprogress
 define weak dso_local spir_func void @__assert_fail(i8 addrspace(4)* %expr, i8 addrspace(4)* %file, i32 %line, i8 addrspace(4)* %func) local_unnamed_addr {

--- a/llvm/test/tools/sycl-post-link/assert-indirect-with-split.ll
+++ b/llvm/test/tools/sycl-post-link/assert-indirect-with-split.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-linux"
 
 ; CHECK: [SYCL/assert used]
 
-; CHECK: main_TU0_kernel0
+; CHECK-DAG: main_TU0_kernel0
 define dso_local spir_kernel void @main_TU0_kernel0() #0 {
 entry:
   call spir_func void @_Z3foov()
@@ -40,7 +40,7 @@ entry:
   ret void
 }
 
-; CHECK: main_TU0_kernel1
+; CHECK-DAG: main_TU0_kernel1
 define dso_local spir_kernel void @main_TU0_kernel1() #0 {
 entry:
   call spir_func void @_Z4foo1v()
@@ -55,14 +55,14 @@ entry:
   ret void
 }
 
-; CHECK: main_TU1_kernel0
+; CHECK-DAG: main_TU1_kernel0
 define dso_local spir_kernel void @main_TU1_kernel0() #2 {
 entry:
   call spir_func void @_Z3foov()
   ret void
 }
 
-; CHECK: main_TU1_kernel1
+; CHECK-DAG: main_TU1_kernel1
 define dso_local spir_kernel void @main_TU1_kernel1() #2 {
 entry:
   call spir_func void @_Z4foo2v()

--- a/llvm/test/tools/sycl-post-link/assert-indirect-with-split.ll
+++ b/llvm/test/tools/sycl-post-link/assert-indirect-with-split.ll
@@ -22,7 +22,7 @@ target triple = "spir64-unknown-linux"
 
 ; CHECK: [SYCL/assert used]
 
-; CHECK-DAG: main_TU0_kernel0
+; CHECK: main_TU0_kernel0
 define dso_local spir_kernel void @main_TU0_kernel0() #0 {
 entry:
   call spir_func void @_Z3foov()
@@ -40,7 +40,7 @@ entry:
   ret void
 }
 
-; CHECK-DAG: main_TU0_kernel1
+; CHECK: main_TU0_kernel1
 define dso_local spir_kernel void @main_TU0_kernel1() #0 {
 entry:
   call spir_func void @_Z4foo1v()
@@ -55,14 +55,14 @@ entry:
   ret void
 }
 
-; CHECK-DAG: main_TU1_kernel0
+; CHECK: main_TU1_kernel0
 define dso_local spir_kernel void @main_TU1_kernel0() #2 {
 entry:
   call spir_func void @_Z3foov()
   ret void
 }
 
-; CHECK-DAG: main_TU1_kernel1
+; CHECK: main_TU1_kernel1
 define dso_local spir_kernel void @main_TU1_kernel1() #2 {
 entry:
   call spir_func void @_Z4foo2v()

--- a/llvm/test/tools/sycl-post-link/assert-property-1.ll
+++ b/llvm/test/tools/sycl-post-link/assert-property-1.ll
@@ -57,6 +57,14 @@ entry:
   ret void
 }
 
+; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE10TheKernel3
+; Function Attrs: convergent norecurse
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE10TheKernel3"() #0 {
+entry:
+  call spir_func void @"_ZZZ4mainENK3$_0clERN2cl4sycl7handlerEENKUlNS1_4itemILi2ELb1EEEE1_clES5_"()
+  ret void
+}
+
 ; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE9TheKernel
 ; Function Attrs: convergent norecurse
 define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE9TheKernel"() #0 {
@@ -91,14 +99,6 @@ entry:
 define dso_local spir_func void @_Z3bazv() {
 entry:
   tail call spir_func void @__assert_fail(i8 addrspace(4)* getelementptr inbounds ([2 x i8], [2 x i8] addrspace(4)* addrspacecast ([2 x i8] addrspace(1)* @.str to [2 x i8] addrspace(4)*), i64 0, i64 0), i8 addrspace(4)* getelementptr inbounds ([11 x i8], [11 x i8] addrspace(4)* addrspacecast ([11 x i8] addrspace(1)* @.str.1 to [11 x i8] addrspace(4)*), i64 0, i64 0), i32 8, i8 addrspace(4)* getelementptr inbounds ([11 x i8], [11 x i8] addrspace(4)* addrspacecast ([11 x i8] addrspace(1)* @__PRETTY_FUNCTION__._Z3foov to [11 x i8] addrspace(4)*), i64 0, i64 0))
-  ret void
-}
-
-; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE10TheKernel3
-; Function Attrs: convergent norecurse
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE10TheKernel3"() #0 {
-entry:
-  call spir_func void @"_ZZZ4mainENK3$_0clERN2cl4sycl7handlerEENKUlNS1_4itemILi2ELb1EEEE1_clES5_"()
   ret void
 }
 

--- a/llvm/test/tools/sycl-post-link/assert-property-1.ll
+++ b/llvm/test/tools/sycl-post-link/assert-property-1.ll
@@ -3,7 +3,8 @@
 ; graph.
 
 ; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
-; RUN: FileCheck %s -input-file=%t_0.prop
+; RUN: FileCheck %s -input-file=%t_0.prop -check-prefix=PRESENCE-CHECK
+; RUN: FileCheck %s -input-file=%t_0.prop -check-prefix=ABSENCE-CHECK
 
 ; SYCL source:
 ; void foo() {
@@ -48,7 +49,7 @@ target triple = "spir64_x86_64-unknown-unknown"
 @__spirv_BuiltInLocalInvocationId = external dso_local addrspace(1) constant <3 x i64>, align 32
 @_ZL10assert_fmt = internal addrspace(2) constant [85 x i8] c"%s:%d: %s: global id: [%lu,%lu,%lu], local id: [%lu,%lu,%lu] Assertion `%s` failed.\0A\00", align 1
 
-; CHECK: [SYCL/assert used]
+; PRESENCE-CHECK: [SYCL/assert used]
 
 ; Function Attrs: convergent norecurse nounwind mustprogress
 define dso_local spir_func void @_Z3foov() {
@@ -57,15 +58,7 @@ entry:
   ret void
 }
 
-; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE10TheKernel3
-; Function Attrs: convergent norecurse
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE10TheKernel3"() #0 {
-entry:
-  call spir_func void @"_ZZZ4mainENK3$_0clERN2cl4sycl7handlerEENKUlNS1_4itemILi2ELb1EEEE1_clES5_"()
-  ret void
-}
-
-; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE9TheKernel
+; PRESENCE-CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE9TheKernel
 ; Function Attrs: convergent norecurse
 define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE9TheKernel"() #0 {
 entry:
@@ -79,7 +72,7 @@ entry:
   ret void
 }
 
-; CHECK-NOT: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE10TheKernel2
+; ABSENCE-CHECK-NOT: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE10TheKernel2
 ; Function Attrs: norecurse
 define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE10TheKernel2"() #1 {
 entry:
@@ -99,6 +92,14 @@ entry:
 define dso_local spir_func void @_Z3bazv() {
 entry:
   tail call spir_func void @__assert_fail(i8 addrspace(4)* getelementptr inbounds ([2 x i8], [2 x i8] addrspace(4)* addrspacecast ([2 x i8] addrspace(1)* @.str to [2 x i8] addrspace(4)*), i64 0, i64 0), i8 addrspace(4)* getelementptr inbounds ([11 x i8], [11 x i8] addrspace(4)* addrspacecast ([11 x i8] addrspace(1)* @.str.1 to [11 x i8] addrspace(4)*), i64 0, i64 0), i32 8, i8 addrspace(4)* getelementptr inbounds ([11 x i8], [11 x i8] addrspace(4)* addrspacecast ([11 x i8] addrspace(1)* @__PRETTY_FUNCTION__._Z3foov to [11 x i8] addrspace(4)*), i64 0, i64 0))
+  ret void
+}
+
+; PRESENCE-CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE10TheKernel3
+; Function Attrs: convergent norecurse
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE10TheKernel3"() #0 {
+entry:
+  call spir_func void @"_ZZZ4mainENK3$_0clERN2cl4sycl7handlerEENKUlNS1_4itemILi2ELb1EEEE1_clES5_"()
   ret void
 }
 

--- a/llvm/test/tools/sycl-post-link/assert-property-2.ll
+++ b/llvm/test/tools/sycl-post-link/assert-property-2.ll
@@ -122,7 +122,7 @@ entry:
   ret void
 }
 
-; CHECK: _ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E7Kernel9
+; CHECK-DAG: _ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E7Kernel9
 ; Function Attrs: convergent noinline norecurse mustprogress
 define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E7Kernel9() #0 {
 entry:
@@ -130,7 +130,7 @@ entry:
   ret void
 }
 
-; CHECK: _ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E8Kernel10
+; CHECK-DAG: _ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E8Kernel10
 ; Function Attrs: convergent noinline norecurse optnone mustprogress
 define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E8Kernel10() #0 {
 entry:
@@ -164,7 +164,7 @@ entry:
   ret void
 }
 
-; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE6Kernel
+; CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE6Kernel
 ; Function Attrs: convergent norecurse mustprogress
 define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE6Kernel"() local_unnamed_addr #0 {
 entry:
@@ -186,7 +186,7 @@ entry:
   ret void
 }
 
-; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel2
+; CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel2
 ; Function Attrs: convergent norecurse mustprogress
 define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel2"() local_unnamed_addr #0 {
 entry:
@@ -216,7 +216,7 @@ entry:
   ret void
 }
 
-; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel3
+; CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel3
 ; Function Attrs: convergent norecurse mustprogress
 define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel3"() local_unnamed_addr #0 {
 entry:
@@ -244,7 +244,7 @@ entry:
   ret void
 }
 
-; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel4
+; CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel4
 ; Function Attrs: convergent norecurse mustprogress
 define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel4"() local_unnamed_addr #0 {
 entry:
@@ -252,7 +252,7 @@ entry:
   ret void
 }
 
-; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel5
+; CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel5
 ; Function Attrs: convergent norecurse mustprogress
 define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel5"() local_unnamed_addr #0 {
 entry:
@@ -267,15 +267,6 @@ entry:
   ret void
 }
 
-; CHECK-NOT: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel
-; Function Attrs: convergent norecurse mustprogress
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel6"() local_unnamed_addr #0 {
-entry:
-  call spir_func void @_Z6E_exclv()
-  call spir_func void @_Z6E_exclv()
-  ret void
-}
-
 ; Function Attrs: convergent norecurse nounwind mustprogress
 define dso_local spir_func void @_Z6F_inclv() local_unnamed_addr {
 entry:
@@ -283,7 +274,7 @@ entry:
   ret void
 }
 
-; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel7
+; CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel7
 ; Function Attrs: convergent norecurse mustprogress
 define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel7"() local_unnamed_addr #0 {
 entry:
@@ -328,11 +319,20 @@ entry:
   ret void
 }
 
-; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel8
+; CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel8
 ; Function Attrs: convergent norecurse mustprogress
 define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel8"() local_unnamed_addr #0 {
   call spir_func void @_Z1Gv()
   call spir_func void @_Z1Hv()
+  ret void
+}
+
+; CHECK-NOT: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel6
+; Function Attrs: convergent norecurse mustprogress
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel6"() local_unnamed_addr #0 {
+entry:
+  call spir_func void @_Z6E_exclv()
+  call spir_func void @_Z6E_exclv()
   ret void
 }
 

--- a/llvm/test/tools/sycl-post-link/assert-property-2.ll
+++ b/llvm/test/tools/sycl-post-link/assert-property-2.ll
@@ -3,7 +3,7 @@
 ; graph.
 
 ; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
-; RUN: FileCheck %s -input-file=%t_0.prop
+; RUN: FileCheck %s -input-file=%t_0.prop --implicit-check-not _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel6
 
 ; SYCL source:
 ; void assert_func() {
@@ -267,6 +267,14 @@ entry:
   ret void
 }
 
+; Function Attrs: convergent norecurse mustprogress
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel6"() local_unnamed_addr #0 {
+entry:
+  call spir_func void @_Z6E_exclv()
+  call spir_func void @_Z6E_exclv()
+  ret void
+}
+
 ; Function Attrs: convergent norecurse nounwind mustprogress
 define dso_local spir_func void @_Z6F_inclv() local_unnamed_addr {
 entry:
@@ -324,15 +332,6 @@ entry:
 define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel8"() local_unnamed_addr #0 {
   call spir_func void @_Z1Gv()
   call spir_func void @_Z1Hv()
-  ret void
-}
-
-; CHECK-NOT: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel6
-; Function Attrs: convergent norecurse mustprogress
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel6"() local_unnamed_addr #0 {
-entry:
-  call spir_func void @_Z6E_exclv()
-  call spir_func void @_Z6E_exclv()
   ret void
 }
 

--- a/llvm/test/tools/sycl-post-link/assert-property-2.ll
+++ b/llvm/test/tools/sycl-post-link/assert-property-2.ll
@@ -3,7 +3,8 @@
 ; graph.
 
 ; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
-; RUN: FileCheck %s -input-file=%t_0.prop
+; RUN: FileCheck %s -input-file=%t_0.prop -check-prefix=PRESENCE-CHECK
+; RUN: FileCheck %s -input-file=%t_0.prop -check-prefix=ABSENCE-CHECK
 
 ; SYCL source:
 ; void assert_func() {
@@ -105,7 +106,7 @@ target triple = "spir64_x86_64-unknown-unknown"
 @__PRETTY_FUNCTION__._Z11assert_funcv = private unnamed_addr addrspace(1) constant [19 x i8] c"void assert_func()\00", align 1
 @_ZL10assert_fmt = internal addrspace(2) constant [85 x i8] c"%s:%d: %s: global id: [%lu,%lu,%lu], local id: [%lu,%lu,%lu] Assertion `%s` failed.\0A\00", align 1
 
-; CHECK: [SYCL/assert used]
+; PRESENCE-CHECK: [SYCL/assert used]
 
 ; Function Attrs: convergent noinline norecurse optnone mustprogress
 define dso_local spir_func void @_Z1Jv() #3 {
@@ -122,76 +123,7 @@ entry:
   ret void
 }
 
-; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE6Kernel
-; Function Attrs: convergent norecurse mustprogress
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE6Kernel"() local_unnamed_addr #0 {
-entry:
-  call spir_func void @_Z6A_exclv()
-  call spir_func void @_Z6B_inclv()
-  ret void
-}
-
-; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel2
-; Function Attrs: convergent norecurse mustprogress
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel2"() local_unnamed_addr #0 {
-entry:
-  call spir_func void @_Z6A_inclv()
-  call spir_func void @_Z6B_exclv()
-  ret void
-}
-
-; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel3
-; Function Attrs: convergent norecurse mustprogress
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel3"() local_unnamed_addr #0 {
-entry:
-  call spir_func void @_Z6commonv()
-  ret void
-}
-
-; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel4
-; Function Attrs: convergent norecurse mustprogress
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel4"() local_unnamed_addr #0 {
-entry:
-  call spir_func void @_Z7common2v()
-  ret void
-}
-
-; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel5
-; Function Attrs: convergent norecurse mustprogress
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel5"() local_unnamed_addr #0 {
-entry:
-  call spir_func void @_Z6B_inclv()
-  call spir_func void @_Z6A_exclv()
-  ret void
-}
-
-; CHECK-NOT: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel6
-; Function Attrs: convergent norecurse mustprogress
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel6"() local_unnamed_addr #0 {
-entry:
-  call spir_func void @_Z6E_exclv()
-  call spir_func void @_Z6E_exclv()
-  ret void
-}
-
-; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel7
-; Function Attrs: convergent norecurse mustprogress
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel7"() local_unnamed_addr #0 {
-entry:
-  call spir_func void @_Z6F_inclv()
-  call spir_func void @_Z6F_inclv()
-  ret void
-}
-
-; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel8
-; Function Attrs: convergent norecurse mustprogress
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel8"() local_unnamed_addr #0 {
-  call spir_func void @_Z1Gv()
-  call spir_func void @_Z1Hv()
-  ret void
-}
-
-; CHECK: _ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E7Kernel9
+; PRESENCE-CHECK-DAG: _ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E7Kernel9
 ; Function Attrs: convergent noinline norecurse mustprogress
 define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E7Kernel9() #0 {
 entry:
@@ -199,7 +131,7 @@ entry:
   ret void
 }
 
-; CHECK: _ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E8Kernel10
+; PRESENCE-CHECK-DAG: _ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E8Kernel10
 ; Function Attrs: convergent noinline norecurse optnone mustprogress
 define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E8Kernel10() #0 {
 entry:
@@ -233,6 +165,15 @@ entry:
   ret void
 }
 
+; PRESENCE-CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE6Kernel
+; Function Attrs: convergent norecurse mustprogress
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE6Kernel"() local_unnamed_addr #0 {
+entry:
+  call spir_func void @_Z6A_exclv()
+  call spir_func void @_Z6B_inclv()
+  ret void
+}
+
 ; Function Attrs: convergent norecurse nounwind mustprogress
 define dso_local spir_func void @_Z6A_inclv() local_unnamed_addr {
 entry:
@@ -243,6 +184,15 @@ entry:
 ; Function Attrs: nofree norecurse nosync nounwind readnone willreturn mustprogress
 define dso_local spir_func void @_Z6B_exclv() local_unnamed_addr {
 entry:
+  ret void
+}
+
+; PRESENCE-CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel2
+; Function Attrs: convergent norecurse mustprogress
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel2"() local_unnamed_addr #0 {
+entry:
+  call spir_func void @_Z6A_inclv()
+  call spir_func void @_Z6B_exclv()
   ret void
 }
 
@@ -267,6 +217,14 @@ entry:
   ret void
 }
 
+; PRESENCE-CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel3
+; Function Attrs: convergent norecurse mustprogress
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel3"() local_unnamed_addr #0 {
+entry:
+  call spir_func void @_Z6commonv()
+  ret void
+}
+
 ; Function Attrs: convergent norecurse nounwind mustprogress
 define dso_local spir_func void @_Z7common2v() local_unnamed_addr {
 entry:
@@ -287,6 +245,23 @@ entry:
   ret void
 }
 
+; PRESENCE-CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel4
+; Function Attrs: convergent norecurse mustprogress
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel4"() local_unnamed_addr #0 {
+entry:
+  call spir_func void @_Z7common2v()
+  ret void
+}
+
+; PRESENCE-CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel5
+; Function Attrs: convergent norecurse mustprogress
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel5"() local_unnamed_addr #0 {
+entry:
+  call spir_func void @_Z6B_inclv()
+  call spir_func void @_Z6A_exclv()
+  ret void
+}
+
 ; Function Attrs: nofree norecurse nosync nounwind readnone willreturn mustprogress
 define dso_local spir_func void @_Z6E_exclv() local_unnamed_addr {
 entry:
@@ -297,6 +272,15 @@ entry:
 define dso_local spir_func void @_Z6F_inclv() local_unnamed_addr {
 entry:
   call spir_func void @_Z11assert_funcv()
+  ret void
+}
+
+; PRESENCE-CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel7
+; Function Attrs: convergent norecurse mustprogress
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel7"() local_unnamed_addr #0 {
+entry:
+  call spir_func void @_Z6F_inclv()
+  call spir_func void @_Z6F_inclv()
   ret void
 }
 
@@ -333,6 +317,23 @@ entry:
 define dso_local spir_func void @_Z6I_inclv() local_unnamed_addr {
 entry:
   call spir_func void @_Z11assert_funcv()
+  ret void
+}
+
+; PRESENCE-CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel8
+; Function Attrs: convergent norecurse mustprogress
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel8"() local_unnamed_addr #0 {
+  call spir_func void @_Z1Gv()
+  call spir_func void @_Z1Hv()
+  ret void
+}
+
+; ABSENCE-CHECK-NOT: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel6
+; Function Attrs: convergent norecurse mustprogress
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel6"() local_unnamed_addr #0 {
+entry:
+  call spir_func void @_Z6E_exclv()
+  call spir_func void @_Z6E_exclv()
   ret void
 }
 

--- a/llvm/test/tools/sycl-post-link/assert-property-2.ll
+++ b/llvm/test/tools/sycl-post-link/assert-property-2.ll
@@ -3,7 +3,7 @@
 ; graph.
 
 ; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
-; RUN: FileCheck %s -input-file=%t_0.prop --implicit-check-not _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel6
+; RUN: FileCheck %s -input-file=%t_0.prop
 
 ; SYCL source:
 ; void assert_func() {
@@ -122,7 +122,76 @@ entry:
   ret void
 }
 
-; CHECK-DAG: _ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E7Kernel9
+; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE6Kernel
+; Function Attrs: convergent norecurse mustprogress
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE6Kernel"() local_unnamed_addr #0 {
+entry:
+  call spir_func void @_Z6A_exclv()
+  call spir_func void @_Z6B_inclv()
+  ret void
+}
+
+; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel2
+; Function Attrs: convergent norecurse mustprogress
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel2"() local_unnamed_addr #0 {
+entry:
+  call spir_func void @_Z6A_inclv()
+  call spir_func void @_Z6B_exclv()
+  ret void
+}
+
+; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel3
+; Function Attrs: convergent norecurse mustprogress
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel3"() local_unnamed_addr #0 {
+entry:
+  call spir_func void @_Z6commonv()
+  ret void
+}
+
+; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel4
+; Function Attrs: convergent norecurse mustprogress
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel4"() local_unnamed_addr #0 {
+entry:
+  call spir_func void @_Z7common2v()
+  ret void
+}
+
+; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel5
+; Function Attrs: convergent norecurse mustprogress
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel5"() local_unnamed_addr #0 {
+entry:
+  call spir_func void @_Z6B_inclv()
+  call spir_func void @_Z6A_exclv()
+  ret void
+}
+
+; CHECK-NOT: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel6
+; Function Attrs: convergent norecurse mustprogress
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel6"() local_unnamed_addr #0 {
+entry:
+  call spir_func void @_Z6E_exclv()
+  call spir_func void @_Z6E_exclv()
+  ret void
+}
+
+; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel7
+; Function Attrs: convergent norecurse mustprogress
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel7"() local_unnamed_addr #0 {
+entry:
+  call spir_func void @_Z6F_inclv()
+  call spir_func void @_Z6F_inclv()
+  ret void
+}
+
+; CHECK: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel8
+; Function Attrs: convergent norecurse mustprogress
+define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel8"() local_unnamed_addr #0 {
+  call spir_func void @_Z1Gv()
+  call spir_func void @_Z1Hv()
+  ret void
+}
+
+; CHECK: _ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E7Kernel9
 ; Function Attrs: convergent noinline norecurse mustprogress
 define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E7Kernel9() #0 {
 entry:
@@ -130,7 +199,7 @@ entry:
   ret void
 }
 
-; CHECK-DAG: _ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E8Kernel10
+; CHECK: _ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E8Kernel10
 ; Function Attrs: convergent noinline norecurse optnone mustprogress
 define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_E8Kernel10() #0 {
 entry:
@@ -164,15 +233,6 @@ entry:
   ret void
 }
 
-; CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE6Kernel
-; Function Attrs: convergent norecurse mustprogress
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE6Kernel"() local_unnamed_addr #0 {
-entry:
-  call spir_func void @_Z6A_exclv()
-  call spir_func void @_Z6B_inclv()
-  ret void
-}
-
 ; Function Attrs: convergent norecurse nounwind mustprogress
 define dso_local spir_func void @_Z6A_inclv() local_unnamed_addr {
 entry:
@@ -183,15 +243,6 @@ entry:
 ; Function Attrs: nofree norecurse nosync nounwind readnone willreturn mustprogress
 define dso_local spir_func void @_Z6B_exclv() local_unnamed_addr {
 entry:
-  ret void
-}
-
-; CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel2
-; Function Attrs: convergent norecurse mustprogress
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel2"() local_unnamed_addr #0 {
-entry:
-  call spir_func void @_Z6A_inclv()
-  call spir_func void @_Z6B_exclv()
   ret void
 }
 
@@ -216,14 +267,6 @@ entry:
   ret void
 }
 
-; CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel3
-; Function Attrs: convergent norecurse mustprogress
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel3"() local_unnamed_addr #0 {
-entry:
-  call spir_func void @_Z6commonv()
-  ret void
-}
-
 ; Function Attrs: convergent norecurse nounwind mustprogress
 define dso_local spir_func void @_Z7common2v() local_unnamed_addr {
 entry:
@@ -244,34 +287,9 @@ entry:
   ret void
 }
 
-; CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel4
-; Function Attrs: convergent norecurse mustprogress
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel4"() local_unnamed_addr #0 {
-entry:
-  call spir_func void @_Z7common2v()
-  ret void
-}
-
-; CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel5
-; Function Attrs: convergent norecurse mustprogress
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel5"() local_unnamed_addr #0 {
-entry:
-  call spir_func void @_Z6B_inclv()
-  call spir_func void @_Z6A_exclv()
-  ret void
-}
-
 ; Function Attrs: nofree norecurse nosync nounwind readnone willreturn mustprogress
 define dso_local spir_func void @_Z6E_exclv() local_unnamed_addr {
 entry:
-  ret void
-}
-
-; Function Attrs: convergent norecurse mustprogress
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel6"() local_unnamed_addr #0 {
-entry:
-  call spir_func void @_Z6E_exclv()
-  call spir_func void @_Z6E_exclv()
   ret void
 }
 
@@ -279,15 +297,6 @@ entry:
 define dso_local spir_func void @_Z6F_inclv() local_unnamed_addr {
 entry:
   call spir_func void @_Z11assert_funcv()
-  ret void
-}
-
-; CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel7
-; Function Attrs: convergent norecurse mustprogress
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel7"() local_unnamed_addr #0 {
-entry:
-  call spir_func void @_Z6F_inclv()
-  call spir_func void @_Z6F_inclv()
   ret void
 }
 
@@ -324,14 +333,6 @@ entry:
 define dso_local spir_func void @_Z6I_inclv() local_unnamed_addr {
 entry:
   call spir_func void @_Z11assert_funcv()
-  ret void
-}
-
-; CHECK-DAG: _ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel8
-; Function Attrs: convergent norecurse mustprogress
-define weak_odr dso_local spir_kernel void @"_ZTSZZ4mainENK3$_0clERN2cl4sycl7handlerEE7Kernel8"() local_unnamed_addr #0 {
-  call spir_func void @_Z1Gv()
-  call spir_func void @_Z1Hv()
   ret void
 }
 

--- a/llvm/test/tools/sycl-post-link/assert-property-with-split.ll
+++ b/llvm/test/tools/sycl-post-link/assert-property-with-split.ll
@@ -18,7 +18,7 @@ target triple = "spir64-unknown-linux"
 
 ; CHECK: [SYCL/assert used]
 
-; CHECK: _ZTSZ4mainE11TU0_kernel0
+; CHECK-DAG: _ZTSZ4mainE11TU0_kernel0
 define dso_local spir_kernel void @_ZTSZ4mainE11TU0_kernel0() #0 {
 entry:
   call spir_func void @_Z3foov()
@@ -36,6 +36,13 @@ entry:
   ret void
 }
 
+; CHECK-DAG: _ZTSZ4mainE10TU1_kernel
+define dso_local spir_kernel void @_ZTSZ4mainE10TU1_kernel() #1 {
+entry:
+  call spir_func void @_Z4foo2v()
+  ret void
+}
+
 ; CHECK-NOT: _ZTSZ4mainE11TU0_kernel1
 define dso_local spir_kernel void @_ZTSZ4mainE11TU0_kernel1() #0 {
 entry:
@@ -48,13 +55,6 @@ define dso_local spir_func void @_Z4foo1v() {
 entry:
   %a = alloca i32, align 4
   store i32 2, i32* %a, align 4
-  ret void
-}
-
-; CHECK: _ZTSZ4mainE10TU1_kernel
-define dso_local spir_kernel void @_ZTSZ4mainE10TU1_kernel() #1 {
-entry:
-  call spir_func void @_Z4foo2v()
   ret void
 }
 

--- a/llvm/test/tools/sycl-post-link/assert-property-with-split.ll
+++ b/llvm/test/tools/sycl-post-link/assert-property-with-split.ll
@@ -3,7 +3,7 @@
 ; in their call graph.
 
 ; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
-; RUN: FileCheck %s -input-file=%t_0.prop --implicit-check-not _ZTSZ4mainE11TU0_kernel1
+; RUN: FileCheck %s -input-file=%t_0.prop
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-linux"
@@ -18,7 +18,14 @@ target triple = "spir64-unknown-linux"
 
 ; CHECK: [SYCL/assert used]
 
-; CHECK-DAG: _ZTSZ4mainE11TU0_kernel0
+; CHECK: _ZTSZ4mainE10TU1_kernel
+define dso_local spir_kernel void @_ZTSZ4mainE10TU1_kernel() #1 {
+entry:
+  call spir_func void @_Z4foo2v()
+  ret void
+}
+
+; CHECK: _ZTSZ4mainE11TU0_kernel0
 define dso_local spir_kernel void @_ZTSZ4mainE11TU0_kernel0() #0 {
 entry:
   call spir_func void @_Z3foov()
@@ -36,6 +43,7 @@ entry:
   ret void
 }
 
+; CHECK-NOT: _ZTSZ4mainE11TU0_kernel1
 define dso_local spir_kernel void @_ZTSZ4mainE11TU0_kernel1() #0 {
 entry:
   call spir_func void @_Z4foo1v()
@@ -47,13 +55,6 @@ define dso_local spir_func void @_Z4foo1v() {
 entry:
   %a = alloca i32, align 4
   store i32 2, i32* %a, align 4
-  ret void
-}
-
-; CHECK-DAG: _ZTSZ4mainE10TU1_kernel
-define dso_local spir_kernel void @_ZTSZ4mainE10TU1_kernel() #1 {
-entry:
-  call spir_func void @_Z4foo2v()
   ret void
 }
 

--- a/llvm/test/tools/sycl-post-link/assert-property-with-split.ll
+++ b/llvm/test/tools/sycl-post-link/assert-property-with-split.ll
@@ -3,7 +3,8 @@
 ; in their call graph.
 
 ; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
-; RUN: FileCheck %s -input-file=%t_0.prop
+; RUN: FileCheck %s -input-file=%t_0.prop -check-prefix=PRESENCE-CHECK
+; RUN: FileCheck %s -input-file=%t_0.prop -check-prefix=ABSENCE-CHECK
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-linux"
@@ -16,16 +17,9 @@ target triple = "spir64-unknown-linux"
 @__spirv_BuiltInLocalInvocationId = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
 @_ZL10assert_fmt = internal addrspace(2) constant [85 x i8] c"%s:%d: %s: global id: [%lu,%lu,%lu], local id: [%lu,%lu,%lu] Assertion `%s` failed.\0A\00", align 1
 
-; CHECK: [SYCL/assert used]
+; PRESENCE-CHECK: [SYCL/assert used]
 
-; CHECK: _ZTSZ4mainE10TU1_kernel
-define dso_local spir_kernel void @_ZTSZ4mainE10TU1_kernel() #1 {
-entry:
-  call spir_func void @_Z4foo2v()
-  ret void
-}
-
-; CHECK: _ZTSZ4mainE11TU0_kernel0
+; PRESENCE-CHECK-DAG: _ZTSZ4mainE11TU0_kernel0
 define dso_local spir_kernel void @_ZTSZ4mainE11TU0_kernel0() #0 {
 entry:
   call spir_func void @_Z3foov()
@@ -43,7 +37,14 @@ entry:
   ret void
 }
 
-; CHECK-NOT: _ZTSZ4mainE11TU0_kernel1
+; PRESENCE-CHECK-DAG: _ZTSZ4mainE10TU1_kernel
+define dso_local spir_kernel void @_ZTSZ4mainE10TU1_kernel() #1 {
+entry:
+  call spir_func void @_Z4foo2v()
+  ret void
+}
+
+; ABSENCE-CHECK-NOT: _ZTSZ4mainE11TU0_kernel1
 define dso_local spir_kernel void @_ZTSZ4mainE11TU0_kernel1() #0 {
 entry:
   call spir_func void @_Z4foo1v()

--- a/llvm/test/tools/sycl-post-link/assert-property-with-split.ll
+++ b/llvm/test/tools/sycl-post-link/assert-property-with-split.ll
@@ -3,7 +3,7 @@
 ; in their call graph.
 
 ; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
-; RUN: FileCheck %s -input-file=%t_0.prop
+; RUN: FileCheck %s -input-file=%t_0.prop --implicit-check-not _ZTSZ4mainE11TU0_kernel1
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-linux"
@@ -36,14 +36,6 @@ entry:
   ret void
 }
 
-; CHECK-DAG: _ZTSZ4mainE10TU1_kernel
-define dso_local spir_kernel void @_ZTSZ4mainE10TU1_kernel() #1 {
-entry:
-  call spir_func void @_Z4foo2v()
-  ret void
-}
-
-; CHECK-NOT: _ZTSZ4mainE11TU0_kernel1
 define dso_local spir_kernel void @_ZTSZ4mainE11TU0_kernel1() #0 {
 entry:
   call spir_func void @_Z4foo1v()
@@ -55,6 +47,13 @@ define dso_local spir_func void @_Z4foo1v() {
 entry:
   %a = alloca i32, align 4
   store i32 2, i32* %a, align 4
+  ret void
+}
+
+; CHECK-DAG: _ZTSZ4mainE10TU1_kernel
+define dso_local spir_kernel void @_ZTSZ4mainE10TU1_kernel() #1 {
+entry:
+  call spir_func void @_Z4foo2v()
   ret void
 }
 

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -387,9 +387,8 @@ TraverseCGToFindSPIRKernels(const Function *StartingFunction) {
       if (VisitedFunctions.count(ParentF))
         continue;
 
-      if (ParentF->hasFnAttribute("referenced-indirectly")) {
+      if (ParentF->hasFnAttribute("referenced-indirectly"))
         return {};
-      }
 
       if (ParentF->getCallingConv() == CallingConv::SPIR_KERNEL)
         KernelNames.push_back(ParentF->getName());
@@ -409,9 +408,8 @@ std::vector<StringRef> getKernelNamesUsingAssert(const Module &M) {
   auto TraverseResult =
       TraverseCGToFindSPIRKernels(DevicelibAssertFailFunction);
 
-  if (TraverseResult.hasValue()) {
+  if (TraverseResult.hasValue())
     return std::move(*TraverseResult);
-  }
 
   // Here we reached "referenced-indirectly", so we need to find all kernels and
   // return them.

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -382,8 +382,12 @@ TraverseCGToFindSPIRKernels(const Function *StartingFunction) {
       continue;
 
     for (const auto *U : F->users()) {
-      const Instruction *I = cast<const Instruction>(U);
-      const Function *ParentF = I->getFunction();
+      const CallInst *CI = dyn_cast<const CallInst>(U);
+      if (!CI)
+        continue;
+
+      const Function *ParentF = CI->getFunction();
+
       if (VisitedFunctions.count(ParentF))
         continue;
 
@@ -612,6 +616,7 @@ void saveModuleProperties(Module &M, const EntryPointGroup &ModuleEntryPoints,
 
   {
     std::vector<StringRef> FuncNames = getKernelNamesUsingAssert(M);
+    std::sort(FuncNames.begin(), FuncNames.end());
     for (const StringRef &FName : FuncNames)
       PropSet[PropSetRegTy::SYCL_ASSERT_USED].insert({FName, true});
   }

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -46,7 +46,10 @@
 #include <algorithm>
 #include <map>
 #include <memory>
+#include <queue>
 #include <string>
+#include <unordered_set>
+#include <utility>
 #include <vector>
 
 using namespace llvm;
@@ -352,124 +355,81 @@ void groupEntryPoints(const Module &M, EntryPointGroupMap &EntryPointsGroups,
     EntryPointsGroups[GLOBAL_SCOPE_NAME] = {};
 }
 
-enum HasAssertStatus { No_Assert, Assert, Assert_Indirect };
+// This function traverses over reversed call graph by BFS algorithm.
+// It means that an edge links some function @func with functions
+// which contain call of function @func.It starts from
+// @StartingFunction and lifts up until it reach all reachable functions
+// or it reaches some function containing "referenced-indirectly" attribute.
+// If it reaches "referenced-indirectly" attribute than it returns true and
+// an empty list.
+// Otherwise, it returns false and a list of reached SPIR kernel function's
+// names.
+std::pair<bool, std::vector<StringRef>>
+TraverseCGToFindSPIRKernels(const Function *StartingFunction) {
+  std::queue<const Function *> FunctionsToVisit;
+  std::unordered_set<const Function *> VisitedFunctions;
+  FunctionsToVisit.push(StartingFunction);
+  std::vector<StringRef> KernelNames;
 
-// Go through function call graph searching for assert call.
-HasAssertStatus hasAssertInFunctionCallGraph(const Function *Func) {
-  // Map holds the info about assertions in already examined functions:
-  // true  - if there is an assertion in underlying functions,
-  // false - if there are definetely no assertions in underlying functions.
-  static std::map<const Function *, bool> hasAssertionInCallGraphMap;
-  std::vector<const Function *> FuncCallStack;
+  while (!FunctionsToVisit.empty()) {
+    const Function *F = FunctionsToVisit.front();
+    FunctionsToVisit.pop();
 
-  static std::vector<const Function *> isIndirectlyCalledInGraph;
+    // It is possible that we insert some particular function several
+    // times in functionsToVisit queue.
+    if (VisitedFunctions.find(F) != VisitedFunctions.end())
+      continue;
 
-  std::vector<const Function *> Workstack;
-  Workstack.push_back(Func);
+    VisitedFunctions.insert(F);
 
-  while (!Workstack.empty()) {
-    const Function *F = Workstack.back();
-    Workstack.pop_back();
-    if (F != Func)
-      FuncCallStack.push_back(F);
-
-    bool HasIndirectlyCalledAttr = false;
-    if (std::find(isIndirectlyCalledInGraph.begin(),
-                  isIndirectlyCalledInGraph.end(),
-                  F) != isIndirectlyCalledInGraph.end())
-      HasIndirectlyCalledAttr = true;
-    else if (F->hasFnAttribute("referenced-indirectly")) {
-      HasIndirectlyCalledAttr = true;
-      isIndirectlyCalledInGraph.push_back(F);
-    }
-
-    bool IsLeaf = true;
-    for (const auto &I : instructions(F)) {
-      if (!isa<CallBase>(&I))
+    for (const auto *U : F->users()) {
+      const Instruction *I = cast<const Instruction>(U);
+      const Function *ParentF = I->getFunction();
+      if (VisitedFunctions.find(ParentF) != VisitedFunctions.end())
         continue;
 
-      const Function *CF = cast<CallBase>(&I)->getCalledFunction();
-      if (!CF)
-        continue;
-
-      bool IsIndirectlyCalled =
-          HasIndirectlyCalledAttr ||
-          std::find(isIndirectlyCalledInGraph.begin(),
-                    isIndirectlyCalledInGraph.end(),
-                    CF) != isIndirectlyCalledInGraph.end();
-
-      // Return if we've already discovered if there are asserts in the
-      // function call graph.
-      auto HasAssert = hasAssertionInCallGraphMap.find(CF);
-      if (HasAssert != hasAssertionInCallGraphMap.end()) {
-        // If we know, that this function does not contain assert, we still
-        // should investigate another instructions in the function.
-        if (!HasAssert->second)
-          continue;
-
-        return IsIndirectlyCalled ? Assert_Indirect : Assert;
+      if (ParentF->hasFnAttribute("referenced-indirectly")) {
+        return {true, {}};
       }
 
-      if (CF->getName().startswith("__devicelib_assert_fail")) {
-        // Mark all the functions above in call graph as ones that can call
-        // assert.
-        for (const auto *It : FuncCallStack)
-          hasAssertionInCallGraphMap[It] = true;
+      if (ParentF->getCallingConv() == CallingConv::SPIR_KERNEL)
+        KernelNames.push_back(ParentF->getName());
 
-        hasAssertionInCallGraphMap[Func] = true;
-        hasAssertionInCallGraphMap[CF] = true;
-
-        return IsIndirectlyCalled ? Assert_Indirect : Assert;
-      }
-
-      if (!CF->isDeclaration()) {
-        Workstack.push_back(CF);
-        IsLeaf = false;
-        if (HasIndirectlyCalledAttr)
-          isIndirectlyCalledInGraph.push_back(CF);
-      }
-    }
-
-    if (IsLeaf && !FuncCallStack.empty()) {
-      // Mark the leaf function as one that definetely does not call assert.
-      hasAssertionInCallGraphMap[FuncCallStack.back()] = false;
-      FuncCallStack.clear();
+      FunctionsToVisit.push(ParentF);
     }
   }
-  return No_Assert;
+
+  return {false, std::move(KernelNames)};
 }
 
 std::vector<StringRef> getKernelNamesUsingAssert(const Module &M) {
-  std::vector<StringRef> Result;
+  Optional<const Function *> DevicelibAssertFailFunction;
+  std::vector<StringRef> SPIRKernelNames;
+  // This loop finds all SPIR kernel's names and __devicelib_assert_fail
+  // function if it is present.
+  for (const Function &F : M) {
+    if (F.getCallingConv() == CallingConv::SPIR_KERNEL)
+      SPIRKernelNames.push_back(F.getName());
 
-  bool HasIndirectlyCalledAssert = false;
-  EntryPointGroup Kernels;
-  for (const auto &F : M.functions()) {
-    // TODO: handle SYCL_EXTERNAL functions for dynamic linkage.
-    // TODO: handle function pointers.
-    if (F.getCallingConv() != CallingConv::SPIR_KERNEL)
-      continue;
-
-    Kernels.push_back(&F);
-    if (HasIndirectlyCalledAssert)
-      continue;
-
-    HasAssertStatus HasAssert = hasAssertInFunctionCallGraph(&F);
-    switch (HasAssert) {
-    case Assert:
-      Result.push_back(F.getName());
-      break;
-    case Assert_Indirect:
-      HasIndirectlyCalledAssert = true;
-      break;
-    case No_Assert:
-      break;
+    if (F.getName().startswith("__devicelib_assert_fail")) {
+      assert(!DevicelibAssertFailFunction.hasValue());
+      DevicelibAssertFailFunction = &F;
     }
   }
 
-  if (HasIndirectlyCalledAssert)
-    for (const auto *F : Kernels)
-      Result.push_back(F->getName());
+  if (!DevicelibAssertFailFunction)
+    return {};
+
+  auto TraverseResult =
+      TraverseCGToFindSPIRKernels(*DevicelibAssertFailFunction);
+  std::vector<StringRef> Result;
+  if (TraverseResult.first) {
+    // If assert is met in some indirectly callable function than
+    // we return all kernels in Module due to the current assert's design.
+    Result = std::move(SPIRKernelNames);
+  } else {
+    Result = std::move(TraverseResult.second);
+  }
 
   return Result;
 }

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -616,7 +616,6 @@ void saveModuleProperties(Module &M, const EntryPointGroup &ModuleEntryPoints,
 
   {
     std::vector<StringRef> FuncNames = getKernelNamesUsingAssert(M);
-    std::sort(FuncNames.begin(), FuncNames.end());
     for (const StringRef &FName : FuncNames)
       PropSet[PropSetRegTy::SYCL_ASSERT_USED].insert({FName, true});
   }


### PR DESCRIPTION
Now it traverses reversed call graph by BFS algorithm from
__devicelib_assert_fail function up to SPIR kernels.