### PR TITLE
[SYCL] Change matrix type

### DIFF
--- a/sycl/include/CL/__spirv/spirv_types.hpp
+++ b/sycl/include/CL/__spirv/spirv_types.hpp
@@ -110,9 +110,25 @@ enum class GroupOperation : uint32_t {
 
 enum class MatrixLayout { RowMajor, ColumnMajor, PackedA, PackedB };
 
+// TODO: replace the following W/A with a better solution when we have it.
+// The following structure is used to represent the joint matrix type in the
+// LLVM IR. The structure has a pointer to a multidimensional array member which
+// makes the encoding of the matrix type information within the LLVM IR looks
+// like this:
+// %struct.__spirv_JointMatrixINTEL = type { [42 x [6 x [2 x [1 x float]]]]* }
+// Note that an array cannot be of zero size but MatrixLayout and Scope
+// parameters can; hence '+ 1' is added to the 3rd and 4th dimensions.
+// In general, representing a matrix type information like this is a bit odd
+// (especially for MatrixLayout and Scope parameters). But with the current
+// tools we have in Clang, this is the only way to preserve and communicate this
+// information to SPIRV translator.
+// The long term solution would be to introduce a matrix type in Clang and use
+// it instead of this member.
 template <typename T, std::size_t R, std::size_t C, MatrixLayout U,
           Scope::Flag S = Scope::Flag::Subgroup>
-struct __spirv_JointMatrixINTEL;
+struct __spirv_JointMatrixINTEL {
+  T (*Value)[R][C][static_cast<size_t>(U) + 1][static_cast<size_t>(S) + 1];
+};
 
 } // namespace __spv
 

--- a/sycl/include/CL/__spirv/spirv_types.hpp
+++ b/sycl/include/CL/__spirv/spirv_types.hpp
@@ -108,7 +108,12 @@ enum class GroupOperation : uint32_t {
   ExclusiveScan = 2
 };
 
-enum class MatrixLayout { RowMajor, ColumnMajor, PackedA, PackedB };
+enum class MatrixLayout : uint32_t {
+  RowMajor = 0,
+  ColumnMajor = 1,
+  PackedA = 2,
+  PackedB = 3
+};
 
 // TODO: replace the following W/A with a better solution when we have it.
 // The following structure is used to represent the joint matrix type in the

--- a/sycl/test/matrix/matrix-int8-test.cpp
+++ b/sycl/test/matrix/matrix-int8-test.cpp
@@ -1,9 +1,8 @@
 // RUN: %clangxx -fsycl -fsycl-device-only -O2 -S -emit-llvm -o - %s | FileCheck %s
-// RUNx: %clangxx -fsycl -O2 %s -o %t.out
 
-// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL.16" = type { [12 x [12 x [1 x [4 x i32]]]] addrspace(4)* }
 // CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL" = type { [12 x [48 x [1 x [4 x i8]]]] addrspace(4)* }
-// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL.14" = type { [48 x [12 x [4 x [4 x i8]]]] addrspace(4)* }
+// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL.[[#]]" = type { [12 x [12 x [1 x [4 x i32]]]] addrspace(4)* }
+// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL.[[#]]" = type { [48 x [12 x [4 x [4 x i8]]]] addrspace(4)* }
 
 #include <CL/sycl.hpp>
 #if (SYCL_EXT_ONEAPI_MATRIX == 2)

--- a/sycl/test/matrix/matrix-int8-test.cpp
+++ b/sycl/test/matrix/matrix-int8-test.cpp
@@ -1,8 +1,11 @@
 // RUN: %clangxx -fsycl -fsycl-device-only -O2 -S -emit-llvm -o - %s | FileCheck %s
 
-// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL" = type { [12 x [48 x [1 x [4 x i8]]]] addrspace(4)* }
-// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL.[[#]]" = type { [12 x [12 x [1 x [4 x i32]]]] addrspace(4)* }
-// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL.[[#]]" = type { [48 x [12 x [4 x [4 x i8]]]] addrspace(4)* }
+// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL" =
+// CHECK-DAG: type { [12 x [48 x [1 x [4 x i8]]]] addrspace(4)* }
+// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL.[[#]]" =
+// CHECK-DAG: type { [12 x [12 x [1 x [4 x i32]]]] addrspace(4)* }
+// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL.[[#]]" =
+// CHECK-DAG: type { [48 x [12 x [4 x [4 x i8]]]] addrspace(4)* }
 
 #include <CL/sycl.hpp>
 #if (SYCL_EXT_ONEAPI_MATRIX == 2)

--- a/sycl/test/matrix/matrix-int8-test.cpp
+++ b/sycl/test/matrix/matrix-int8-test.cpp
@@ -1,11 +1,8 @@
 // RUN: %clangxx -fsycl -fsycl-device-only -O2 -S -emit-llvm -o - %s | FileCheck %s
 
-// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL" =
-// CHECK-DAG: type { [12 x [48 x [1 x [4 x i8]]]] addrspace(4)* }
-// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL.[[#]]" =
-// CHECK-DAG: type { [12 x [12 x [1 x [4 x i32]]]] addrspace(4)* }
-// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL.[[#]]" =
-// CHECK-DAG: type { [48 x [12 x [4 x [4 x i8]]]] addrspace(4)* }
+// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL" = type { [12 x [48 x [1 x [4 x i8]]]] addrspace(4)* }
+// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL.[[#]]" = type { [12 x [12 x [1 x [4 x i32]]]] addrspace(4)* }
+// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL.[[#]]" = type { [48 x [12 x [4 x [4 x i8]]]] addrspace(4)* }
 
 #include <CL/sycl.hpp>
 #if (SYCL_EXT_ONEAPI_MATRIX == 2)

--- a/sycl/test/matrix/matrix-int8-test.cpp
+++ b/sycl/test/matrix/matrix-int8-test.cpp
@@ -1,5 +1,10 @@
-// RUN: %clangxx -fsycl -O2 %s -o %t.out
-// XFAIL: *
+// RUN: %clangxx -fsycl -fsycl-device-only -O2 -S -emit-llvm -o - %s | FileCheck %s
+// RUNx: %clangxx -fsycl -O2 %s -o %t.out
+
+// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL.16" = type { [12 x [12 x [1 x [4 x i32]]]] addrspace(4)* }
+// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL" = type { [12 x [48 x [1 x [4 x i8]]]] addrspace(4)* }
+// CHECK-DAG: %"struct.__spv::__spirv_JointMatrixINTEL.14" = type { [48 x [12 x [4 x [4 x i8]]]] addrspace(4)* }
+
 #include <CL/sycl.hpp>
 #if (SYCL_EXT_ONEAPI_MATRIX == 2)
 #include <iostream>


### PR DESCRIPTION
Previously we relied on the structure type (which represented matrix
type) mangling to obtain its layout. Now, when DPCPP mangling scheme is
aligned with C++, thus the structure lost their usual mangling. Yet we
want to preserve the desired information within the matrix type, coming
from DPCPP headers. To achive this the 'Matrix structure' was changed
form:
template <typename T, int R, int C, int L, int S>
struct __spirv_JointMatrixINTEL;
to
template <typename T, int R, int C, int L, int S>
struct __spirv_JointMatrixINTEL {
T (*Value)[R][C][L + 1][S + 1];
};

so it's no longer an opaque structure and now it look like this in LLVM
IR:
%struct.__spirv_JointMatrixINTEL = type { [42 x [6 x [2 x [1 x i32]]]]* }

Here we encode the number of Rows, Cols, Layout and Scope as sizes of an
array (which element type is the same as the base matrix's type), which
is a bit odd, but it's probably the best way we can preserve the
information now without having the matrix type itself in LLVM.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>