### PR TITLE
[SYCL] Updated namespace for ctz function

### DIFF
--- a/sycl/include/CL/sycl/builtins.hpp
+++ b/sycl/include/CL/sycl/builtins.hpp
@@ -724,13 +724,19 @@ detail::enable_if_t<detail::is_geninteger<T>::value, T> clz(T x) __NOEXC {
   return __sycl_std::__invoke_clz<T>(x);
 }
 
+// geninteger ctz (geninteger x)
+template <typename T>
+detail::enable_if_t<detail::is_geninteger<T>::value, T> ctz(T x) __NOEXC {
+  return __sycl_std::__invoke_ctz<T>(x);
+}
+
 namespace ext {
 namespace intel {
-// geninteger ctz (geninteger x)
+// geninteger ctz (geninteger x) for calls in depraceted variant
 template <typename T>
 sycl::detail::enable_if_t<sycl::detail::is_geninteger<T>::value, T>
 ctz(T x) __NOEXC {
-  return __sycl_std::__invoke_ctz<T>(x);
+  return sycl::ctz(x);
 }
 } // namespace intel
 } // namespace ext
@@ -738,6 +744,7 @@ ctz(T x) __NOEXC {
 namespace __SYCL2020_DEPRECATED("use 'ext::intel' instead") intel {
   using namespace ext::intel;
 }
+
 
 // geninteger mad_hi (geninteger a, geninteger b, geninteger c)
 template <typename T>

--- a/sycl/include/CL/sycl/builtins.hpp
+++ b/sycl/include/CL/sycl/builtins.hpp
@@ -745,7 +745,6 @@ namespace __SYCL2020_DEPRECATED("use 'ext::intel' instead") intel {
   using namespace ext::intel;
 }
 
-
 // geninteger mad_hi (geninteger a, geninteger b, geninteger c)
 template <typename T>
 detail::enable_if_t<detail::is_igeninteger<T>::value, T> mad_hi(T x, T y,

--- a/sycl/include/CL/sycl/builtins.hpp
+++ b/sycl/include/CL/sycl/builtins.hpp
@@ -730,9 +730,9 @@ detail::enable_if_t<detail::is_geninteger<T>::value, T> ctz(T x) __NOEXC {
   return __sycl_std::__invoke_ctz<T>(x);
 }
 
+// geninteger ctz (geninteger x) for calls with deprecated namespace
 namespace ext {
 namespace intel {
-// geninteger ctz (geninteger x) for calls in depraceted variant
 template <typename T>
 sycl::detail::enable_if_t<sycl::detail::is_geninteger<T>::value, T>
 ctz(T x) __NOEXC {


### PR DESCRIPTION
Fix moved ctz(x) template geninteger function from deprecated namespace 'ext::intel::' to 'sycl::' according to an ad hoc part of Sycl Specification. Function is still callable from 'ext::intel::' namespace for supporting legacy codes.

Signed-off-by: Igor Kharchikov igor.kharchikov@intel.com