### PR TITLE
[SYCL][NFC] Fix skipping KernelBundleWith2Kernels test

### DIFF
--- a/sycl/unittests/helpers/PiMock.hpp
+++ b/sycl/unittests/helpers/PiMock.hpp
@@ -66,7 +66,7 @@ namespace RT = detail::pi;
 /// redefinitions would also affect other platforms' behavior.
 /// Therefore, any plugin-related information is fully copied whenever
 /// a user-passed SYCL object instance is being mocked.
-/// The underlying SYCL platform must be a non-host plaftorm to facilitate
+/// The underlying SYCL platform must be a non-host platform to facilitate
 /// plugin usage.
 ///
 /// Simple usage examples would look like this:

--- a/sycl/unittests/program_manager/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/EliminatedArgMask.cpp
@@ -191,15 +191,11 @@ sycl::detail::ProgramManager::KernelArgMask getKernelArgMaskFromBundle(
 // kernel bundle after two kernels are compiled and linked.
 TEST(EliminatedArgMask, KernelBundleWith2Kernels) {
   sycl::platform Plt{sycl::default_selector()};
-  if (Plt.is_host()) {
-    std::cerr << "Test is not supported on host, skipping\n";
-    return; // test is not supported on host.
-  } else if (Plt.get_backend() == sycl::backend::ext_oneapi_cuda) {
-    std::cerr << "Test is not supported on CUDA platform, skipping\n";
-    return;
-  } else if (Plt.get_backend() == sycl::backend::ext_oneapi_hip) {
-    std::cout << "Test is not supported on HIP platform, skipping\n";
-    return;
+  if (Plt.is_host() || Plt.get_backend() == sycl::backend::ext_oneapi_cuda ||
+      Plt.get_backend() == sycl::backend::ext_oneapi_hip) {
+    std::cerr << "Test is not supported on "
+              << Plt.get_info<sycl::info::platform::name>() << ", skipping\n";
+    GTEST_SKIP(); // test is not supported on selected platform.
   }
 
   sycl::unittest::PiMock Mock{Plt};


### PR DESCRIPTION
Currently most of unit tests print something and just return if test
pre-requisites are not met. llvm-lit reports such tests as "passed"
instead of "skipped" because Google Test framework reports test status
incorrectly. GTEST_SKIP must be used to indicate the framework "skipped"
test status.

Fixed a typo in PiMock.hpp.

TODO: the same approach must be applied to all other unittests.