### PR TITLE
[DOC][SPIR-V] Add Joint Matrix to composite types

### DIFF
--- a/sycl/doc/extensions/SPIRV/SPV_INTEL_joint_matrix.asciidoc
+++ b/sycl/doc/extensions/SPIRV/SPV_INTEL_joint_matrix.asciidoc
@@ -125,6 +125,14 @@ OpJointMatrixUUMADINTEL
 
 == Modifications to the SPIR-V Specification, Version 1.5
 
+=== 2.2 Terms
+Add new terms to section 2.2.2 Types:
+
+_Joint Matrix_: A two-dimensional ordered collection of scalars, whose storage
+is spread across multiple invocations.
+
+Add _Joint Matrix_ to the definition of _Composite_.
+
 === Matrix layout
 
 Add section 3.XX, Matrix layout.
@@ -462,6 +470,13 @@ result of a constant instruction with scalar 'integer type'. +
 | '<id>' +
 'Scope'
 |=====
+
+=== 3.42.12. Composite Instructions
+
+Modify OpCompositeConstruct to make an exception for joint matrix types:
+"If the 'Result Type' is <<OpTypeJointMatrixINTEL,*OpTypeJointMatrixINTEL*>> and
+there is only one 'Constituent', it will be used to initialize all elements of
+the matrix."
 
 === Issues
 

--- a/sycl/doc/extensions/SPIRV/SPV_INTEL_joint_matrix.asciidoc
+++ b/sycl/doc/extensions/SPIRV/SPV_INTEL_joint_matrix.asciidoc
@@ -53,7 +53,7 @@ please let us know!
 [width="40%",cols="25,25"]
 |========================================
 | Last Modified Date | {docdate}
-| Revision           | A
+| Revision           | B
 |========================================
 
 == Dependencies
@@ -492,4 +492,5 @@ Revision History
 |Rev|Date|Author|Changes
 |1|2021-02-16|Alexey Sotkin|Initial revision
 |1|2021-09-06|Dmitry Sidorov|Split OpJointMatrixMadINTEL instruction into 4
+|1|2021-12-28|Dmitry Sidorov|Add Joint Matrix to Composite definition
 |========================================

--- a/sycl/doc/extensions/SPIRV/SPV_INTEL_joint_matrix.asciidoc
+++ b/sycl/doc/extensions/SPIRV/SPV_INTEL_joint_matrix.asciidoc
@@ -52,8 +52,8 @@ please let us know!
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | {docdate}
-| Revision           | B
+| Last Modified Date | 2021-12-28
+| Revision           | 3
 |========================================
 
 == Dependencies
@@ -491,6 +491,6 @@ Revision History
 |========================================
 |Rev|Date|Author|Changes
 |1|2021-02-16|Alexey Sotkin|Initial revision
-|1|2021-09-06|Dmitry Sidorov|Split OpJointMatrixMadINTEL instruction into 4
-|1|2021-12-28|Dmitry Sidorov|Add Joint Matrix to Composite definition
+|2|2021-09-06|Dmitry Sidorov|Split OpJointMatrixMadINTEL instruction into 4
+|3|2021-12-28|Dmitry Sidorov|Add Joint Matrix to Composite definition
 |========================================


### PR DESCRIPTION
And reuse OpConstantComposite to create a matrix.

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>