### PR TITLE
[SYCL] Do not build device code for sub-devices

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2124,8 +2124,7 @@ pi_result piDeviceGetInfo(pi_device Device, pi_device_info ParamName,
     }
   }
   case PI_DEVICE_INFO_PARENT_DEVICE:
-    // TODO: all Level Zero devices are parent ?
-    return ReturnValue(pi_device{0});
+    return ReturnValue(Device->RootDevice);
   case PI_DEVICE_INFO_PLATFORM:
     return ReturnValue(Device->Platform);
   case PI_DEVICE_INFO_VENDOR_ID:

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -53,13 +53,11 @@ device_impl::device_impl(pi_native_handle InteropDeviceHandle,
   Plugin.call<PiApiKind::piDeviceGetInfo>(
       MDevice, PI_DEVICE_INFO_TYPE, sizeof(RT::PiDeviceType), &MType, nullptr);
 
-  RT::PiDevice parent = nullptr;
   // TODO catch an exception and put it to list of asynchronous exceptions
   Plugin.call<PiApiKind::piDeviceGetInfo>(MDevice, PI_DEVICE_INFO_PARENT_DEVICE,
-                                          sizeof(RT::PiDevice), &parent,
+                                          sizeof(RT::PiDevice), &MRootDevice,
                                           nullptr);
 
-  MIsRootDevice = (nullptr == parent);
   if (!InteroperabilityConstructor) {
     // TODO catch an exception and put it to list of asynchronous exceptions
     // Interoperability Constructor already calls DeviceRetain in

--- a/sycl/source/detail/device_impl.hpp
+++ b/sycl/source/detail/device_impl.hpp
@@ -225,12 +225,14 @@ public:
 
   bool isAssertFailSupported() const;
 
+  bool isRootDevice() const { return MRootDevice == nullptr; }
+
 private:
   explicit device_impl(pi_native_handle InteropDevice, RT::PiDevice Device,
                        PlatformImplPtr Platform, const plugin &Plugin);
   RT::PiDevice MDevice = 0;
   RT::PiDeviceType MType;
-  bool MIsRootDevice = false;
+  RT::PiDevice MRootDevice = nullptr;
   bool MIsHostDevice;
   PlatformImplPtr MPlatform;
   bool MIsAssertFailSupported = false;

--- a/sycl/source/detail/persistent_device_code_cache.cpp
+++ b/sycl/source/detail/persistent_device_code_cache.cpp
@@ -78,10 +78,13 @@ void PersistentDeviceCodeCache::putItemToDisc(
     const SerializedObj &SpecConsts, const std::string &BuildOptionsString,
     const RT::PiProgram &NativePrg) {
 
+  if (!isImageCached(Img))
+    return;
+
   std::string DirName =
       getCacheItemPath(Device, Img, SpecConsts, BuildOptionsString);
 
-  if (!isImageCached(Img) || DirName.empty())
+  if (DirName.empty())
     return;
 
   auto Plugin = detail::getSyclObjImpl(Device)->getPlugin();
@@ -137,10 +140,13 @@ std::vector<std::vector<char>> PersistentDeviceCodeCache::getItemFromDisc(
     const device &Device, const RTDeviceBinaryImage &Img,
     const SerializedObj &SpecConsts, const std::string &BuildOptionsString) {
 
+  if (!isImageCached(Img))
+    return {};
+
   std::string Path =
       getCacheItemPath(Device, Img, SpecConsts, BuildOptionsString);
 
-  if (!isImageCached(Img) || Path.empty() || !OSUtil::isPathPresent(Path))
+  if (Path.empty() || !OSUtil::isPathPresent(Path))
     return {};
 
   int i = 0;

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -107,8 +107,8 @@ public:
                        SerializedObj SpecConsts);
   /// Builds or retrieves from cache a program defining the kernel with given
   /// name.
-  /// \param M idenfies the OS module the kernel comes from (multiple OS modules
-  ///          may have kernels with the same name)
+  /// \param M identifies the OS module the kernel comes from (multiple OS
+  ///        modules may have kernels with the same name)
   /// \param Context the context to build the program with
   /// \param Device the device for which the program is built
   /// \param KernelName the kernel's name
@@ -152,7 +152,7 @@ public:
   /// \param NativePrg the native program, target for spec constant setting; if
   ///        not null then overrides the native program in Prg
   /// \param Img A source of the information about which constants need
-  ///        setting and symboling->integer spec constnant ID mapping. If not
+  ///        setting and symboling->integer spec constant ID mapping. If not
   ///        null, overrides native program->binary image binding maintained by
   ///        the program manager.
   void flushSpecConstants(const program_impl &Prg,

--- a/sycl/unittests/helpers/CommonRedefinitions.hpp
+++ b/sycl/unittests/helpers/CommonRedefinitions.hpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <CL/sycl.hpp>
 #include <helpers/PiImage.hpp>
 #include <helpers/PiMock.hpp>
 

--- a/sycl/unittests/helpers/PiImage.hpp
+++ b/sycl/unittests/helpers/PiImage.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/pi.hpp>
 #include <detail/platform_impl.hpp>

--- a/sycl/unittests/helpers/PiMock.hpp
+++ b/sycl/unittests/helpers/PiMock.hpp
@@ -27,9 +27,11 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
 #include <CL/sycl/detail/common.hpp>
 #include <CL/sycl/detail/pi.hpp>
+#include <CL/sycl/device_selector.hpp>
+#include <CL/sycl/platform.hpp>
+#include <CL/sycl/queue.hpp>
 #include <detail/platform_impl.hpp>
 
 #include <functional>

--- a/sycl/unittests/helpers/TestKernel.hpp
+++ b/sycl/unittests/helpers/TestKernel.hpp
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "PiImage.hpp"
+
+class TestKernel;
+
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace detail {
+template <> struct KernelInfo<TestKernel> {
+  static constexpr unsigned getNumParams() { return 0; }
+  static const kernel_param_desc_t &getParamDesc(int) {
+    static kernel_param_desc_t Dummy;
+    return Dummy;
+  }
+  static constexpr const char *getName() { return "TestKernel"; }
+  static constexpr bool isESIMD() { return false; }
+  static constexpr bool callsThisItem() { return false; }
+  static constexpr bool callsAnyThisFreeFunction() { return false; }
+};
+
+} // namespace detail
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)
+
+static sycl::unittest::PiImage generateDefaultImage() {
+  using namespace sycl::unittest;
+
+  PiPropertySet PropSet;
+
+  std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
+
+  PiArray<PiOffloadEntry> Entries = makeEmptyKernels({"TestKernel"});
+
+  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
+              "",                                     // Compile options
+              "",                                     // Link options
+              std::move(Bin),
+              std::move(Entries),
+              std::move(PropSet)};
+
+  return Img;
+}
+
+static sycl::unittest::PiImage Img = generateDefaultImage();
+static sycl::unittest::PiImageArray<1> ImgArray{&Img};

--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -117,6 +117,7 @@ static pi_result redefinedKernelCreate(pi_program program,
                                        pi_kernel *ret_kernel) {
   return PI_SUCCESS;
 }
+
 static pi_result redefinedKernelRelease(pi_kernel kernel) { return PI_SUCCESS; }
 
 class KernelAndProgramCacheTest : public ::testing::Test {

--- a/sycl/unittests/pi/PiMock.cpp
+++ b/sycl/unittests/pi/PiMock.cpp
@@ -6,9 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <gtest/gtest.h>
 #include <helpers/PiMock.hpp>
+
 #include <detail/queue_impl.hpp>
+
+#include <gtest/gtest.h>
 
 using namespace cl::sycl;
 

--- a/sycl/unittests/pi/TestGetPlatforms.hpp
+++ b/sycl/unittests/pi/TestGetPlatforms.hpp
@@ -4,7 +4,8 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
+#include <CL/sycl/platform.hpp>
+
 #include <algorithm>
 #include <functional>
 #include <vector>

--- a/sycl/unittests/program_manager/CMakeLists.txt
+++ b/sycl/unittests/program_manager/CMakeLists.txt
@@ -3,5 +3,6 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 add_sycl_unittest(ProgramManagerTests OBJECT
   EliminatedArgMask.cpp
   itt_annotations.cpp
+  SubDevices.cpp
 )
 

--- a/sycl/unittests/program_manager/SubDevices.cpp
+++ b/sycl/unittests/program_manager/SubDevices.cpp
@@ -1,0 +1,139 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl/program.hpp>
+#include <detail/kernel_bundle_impl.hpp>
+
+#include <helpers/CommonRedefinitions.hpp>
+#include <helpers/PiImage.hpp>
+#include <helpers/PiMock.hpp>
+
+#include <gtest/gtest.h>
+
+#include <helpers/TestKernel.hpp>
+
+static pi_device rootDevice;
+static pi_device piSubDev1 = (pi_device)0x1;
+static pi_device piSubDev2 = (pi_device)0x2;
+
+namespace {
+pi_result redefinedDeviceGetInfo(pi_device device, pi_device_info param_name,
+                                 size_t param_value_size, void *param_value,
+                                 size_t *param_value_size_ret) {
+  if (param_name == PI_DEVICE_INFO_PARTITION_PROPERTIES) {
+    if (!param_value) {
+      *param_value_size_ret = 2 * sizeof(pi_device_partition_property);
+    } else {
+      ((pi_device_partition_property *)param_value)[0] =
+          PI_DEVICE_PARTITION_BY_AFFINITY_DOMAIN;
+      ((pi_device_partition_property *)param_value)[1] =
+          PI_DEVICE_PARTITION_BY_AFFINITY_DOMAIN;
+    }
+  }
+  if (param_name == PI_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN) {
+    if (!param_value) {
+      *param_value_size_ret = sizeof(pi_device_affinity_domain);
+    } else {
+      ((pi_device_affinity_domain *)param_value)[0] =
+          PI_DEVICE_AFFINITY_DOMAIN_NUMA |
+          PI_DEVICE_AFFINITY_DOMAIN_NEXT_PARTITIONABLE;
+    }
+  }
+  if (param_name == PI_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES) {
+    ((pi_uint32 *)param_value)[0] = 2;
+  }
+  if (param_name == PI_DEVICE_INFO_PARENT_DEVICE) {
+    if (device == piSubDev1 || device == piSubDev2)
+      ((pi_device *)param_value)[0] = rootDevice;
+    else
+      ((pi_device *)param_value)[0] = nullptr;
+  }
+  return PI_SUCCESS;
+}
+
+pi_result redefinedDevicePartition(
+    pi_device Device, const pi_device_partition_property *Properties,
+    pi_uint32 NumDevices, pi_device *OutDevices, pi_uint32 *OutNumDevices) {
+  if (OutNumDevices)
+    *OutNumDevices = 2;
+  if (OutDevices) {
+    OutDevices[0] = {};
+    OutDevices[1] = {};
+  }
+  return PI_SUCCESS;
+}
+
+pi_result redefinedDeviceRetain(pi_device c) { return PI_SUCCESS; }
+
+pi_result redefinedDeviceRelease(pi_device c) { return PI_SUCCESS; }
+
+pi_result redefinedProgramBuild(
+    pi_program prog, pi_uint32, const pi_device *, const char *,
+    void (*pfn_notify)(pi_program program, void *user_data), void *user_data) {
+  static int m = 0;
+  m++;
+  // if called more than once return an error
+  if (m > 1)
+    return PI_ERROR_UNKNOWN;
+
+  return PI_SUCCESS;
+}
+} // anonymous namespace
+
+// Check that program is built once for all sub-devices
+TEST(SubDevices, BuildProgramForSubdevices) {
+  sycl::platform Plt{sycl::default_selector()};
+  // Host devices do not support sub-devices
+  if (Plt.is_host()) {
+    std::cerr << "Test is not supported on "
+              << Plt.get_info<sycl::info::platform::name>() << ", skipping\n";
+    GTEST_SKIP(); // test is not supported on selected platform.
+  }
+
+  // Setup Mock APIs
+  sycl::unittest::PiMock Mock{Plt};
+  setupDefaultMockAPIs(Mock);
+  Mock.redefine<sycl::detail::PiApiKind::piDeviceGetInfo>(
+      redefinedDeviceGetInfo);
+  Mock.redefine<sycl::detail::PiApiKind::piDevicePartition>(
+      redefinedDevicePartition);
+  Mock.redefine<sycl::detail::PiApiKind::piDeviceRetain>(redefinedDeviceRetain);
+  Mock.redefine<sycl::detail::PiApiKind::piDeviceRelease>(
+      redefinedDeviceRelease);
+  Mock.redefine<sycl::detail::PiApiKind::piProgramBuild>(redefinedProgramBuild);
+
+  // Create 2 sub-devices and use first device as a root device
+  sycl::context Ctx{Plt};
+  const sycl::device device = Plt.get_devices()[0];
+  // Initialize root device
+  rootDevice = sycl::detail::getSyclObjImpl(device)->getHandleRef();
+  // Initialize sub-devices
+  auto PltImpl = sycl::detail::getSyclObjImpl(Plt);
+  auto subDev1 = std::make_shared<sycl::detail::device_impl>(
+      piSubDev1, PltImpl->getPlugin());
+  auto subDev2 = std::make_shared<sycl::detail::device_impl>(
+      piSubDev2, PltImpl->getPlugin());
+
+  // Create device binary description structures for getBuiltPIProgram API.
+  auto devBin = Img.convertToNativeType();
+  pi_device_binaries_struct devBinStruct{PI_DEVICE_BINARIES_VERSION, 1,
+                                         &devBin};
+  sycl::detail::ProgramManager::getInstance().addImages(&devBinStruct);
+
+  // Build program via getBuiltPIProgram API
+  sycl::detail::ProgramManager::getInstance().getBuiltPIProgram(
+      sycl::detail::OSUtil::getOSModuleHandle(&devBin),
+      sycl::detail::getSyclObjImpl(Ctx), subDev1,
+      sycl::detail::KernelInfo<TestKernel>::getName());
+  // This call should re-use built binary from the cache. If piProgramBuild is
+  // called again, the test will fail as second call of redefinedProgramBuild
+  sycl::detail::ProgramManager::getInstance().getBuiltPIProgram(
+      sycl::detail::OSUtil::getOSModuleHandle(&devBin),
+      sycl::detail::getSyclObjImpl(Ctx), subDev2,
+      sycl::detail::KernelInfo<TestKernel>::getName());
+}

--- a/sycl/unittests/queue/USM.cpp
+++ b/sycl/unittests/queue/USM.cpp
@@ -6,9 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <CL/sycl/usm.hpp>
 #include <detail/event_impl.hpp>
-#include <gtest/gtest.h>
+
 #include <helpers/PiMock.hpp>
+
+#include <gtest/gtest.h>
 
 namespace {
 using namespace sycl;

--- a/sycl/unittests/scheduler/InOrderQueueHostTaskDeps.cpp
+++ b/sycl/unittests/scheduler/InOrderQueueHostTaskDeps.cpp
@@ -18,49 +18,7 @@
 
 #include <gtest/gtest.h>
 
-class TestKernel;
-
-__SYCL_INLINE_NAMESPACE(cl) {
-namespace sycl {
-namespace detail {
-template <> struct KernelInfo<TestKernel> {
-  static constexpr unsigned getNumParams() { return 0; }
-  static const kernel_param_desc_t &getParamDesc(int) {
-    static kernel_param_desc_t Dummy;
-    return Dummy;
-  }
-  static constexpr const char *getName() { return "TestKernel"; }
-  static constexpr bool isESIMD() { return false; }
-  static constexpr bool callsThisItem() { return false; }
-  static constexpr bool callsAnyThisFreeFunction() { return false; }
-};
-
-} // namespace detail
-} // namespace sycl
-} // __SYCL_INLINE_NAMESPACE(cl)
-
-static sycl::unittest::PiImage generateDefaultImage() {
-  using namespace sycl::unittest;
-
-  PiPropertySet PropSet;
-
-  std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
-
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels({"TestKernel"});
-
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
-
-  return Img;
-}
-
-static sycl::unittest::PiImage Img = generateDefaultImage();
-static sycl::unittest::PiImageArray<1> ImgArray{&Img};
+#include <helpers/TestKernel.hpp>
 
 using namespace sycl;
 

--- a/sycl/unittests/scheduler/RequiredWGSize.cpp
+++ b/sycl/unittests/scheduler/RequiredWGSize.cpp
@@ -18,30 +18,11 @@
 
 #include <stdlib.h>
 
-class TestKernel;
+#include <helpers/TestKernel.hpp>
 
 bool KernelGetGroupInfoCalled = false;
 std::array<size_t, 3> IncomingLocalSize = {0, 0, 0};
 std::array<size_t, 3> RequiredLocalSize = {0, 0, 0};
-
-__SYCL_INLINE_NAMESPACE(cl) {
-namespace sycl {
-namespace detail {
-template <> struct KernelInfo<TestKernel> {
-  static constexpr unsigned getNumParams() { return 0; }
-  static const kernel_param_desc_t &getParamDesc(int) {
-    static kernel_param_desc_t Dummy;
-    return Dummy;
-  }
-  static constexpr const char *getName() { return "TestKernel"; }
-  static constexpr bool isESIMD() { return false; }
-  static constexpr bool callsThisItem() { return false; }
-  static constexpr bool callsAnyThisFreeFunction() { return false; }
-};
-
-} // namespace detail
-} // namespace sycl
-} // __SYCL_INLINE_NAMESPACE(cl)
 
 static pi_result redefinedProgramCreate(pi_context, const void *, size_t,
                                         pi_program *) {
@@ -204,29 +185,6 @@ static void setupDefaultMockAPIs(sycl::unittest::PiMock &Mock) {
   Mock.redefine<PiApiKind::piEnqueueKernelLaunch>(redefinedEnqueueKernelLaunch);
   Mock.redefine<PiApiKind::piKernelGetGroupInfo>(redefinedKernelGetGroupInfo);
 }
-
-static sycl::unittest::PiImage generateDefaultImage() {
-  using namespace sycl::unittest;
-
-  PiPropertySet PropSet;
-
-  std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
-
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels({"TestKernel"});
-
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
-
-  return Img;
-}
-
-sycl::unittest::PiImage Img = generateDefaultImage();
-sycl::unittest::PiImageArray<1> ImgArray{&Img};
 
 static void performChecks() {
   sycl::platform Plt{sycl::default_selector()};

--- a/sycl/unittests/scheduler/SchedulerTest.hpp
+++ b/sycl/unittests/scheduler/SchedulerTest.hpp
@@ -8,7 +8,8 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
+#include <CL/sycl/queue.hpp>
+
 #include <gtest/gtest.h>
 
 class SchedulerTest : public ::testing::Test {

--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
-#include <CL/sycl.hpp>
 #include <CL/sycl/detail/cl.h>
 #include <detail/queue_impl.hpp>
 #include <detail/scheduler/commands.hpp>

--- a/sycl/unittests/stream/stream.cpp
+++ b/sycl/unittests/stream/stream.cpp
@@ -16,48 +16,7 @@
 
 #include <limits>
 
-class TestKernel;
-
-__SYCL_INLINE_NAMESPACE(cl) {
-namespace sycl {
-namespace detail {
-template <> struct KernelInfo<TestKernel> {
-  static constexpr unsigned getNumParams() { return 0; }
-  static const kernel_param_desc_t &getParamDesc(int) {
-    static kernel_param_desc_t Dummy;
-    return Dummy;
-  }
-  static constexpr const char *getName() { return "Stream_TestKernel"; }
-  static constexpr bool isESIMD() { return false; }
-  static constexpr bool callsThisItem() { return false; }
-  static constexpr bool callsAnyThisFreeFunction() { return false; }
-};
-} // namespace detail
-} // namespace sycl
-} // __SYCL_INLINE_NAMESPACE(cl)
-
-static sycl::unittest::PiImage generateDefaultImage() {
-  using namespace sycl::unittest;
-
-  PiPropertySet PropSet;
-
-  std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
-
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels({"Stream_TestKernel"});
-
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
-
-  return Img;
-}
-
-static sycl::unittest::PiImage Img = generateDefaultImage();
-static sycl::unittest::PiImageArray<1> ImgArray{&Img};
+#include <helpers/TestKernel.hpp>
 
 size_t GBufferCreateCounter = 0;
 


### PR DESCRIPTION
Technically sub-devices are the same as their root device, so we can
build program for root device only and re-use the binary for sub-devices
to avoid "duplicate" builds.