### PR TITLE
[SYCL][HIP] Remove arch requirement for running lit tests

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -40,7 +40,7 @@ on:
       build_configure_extra_args:
         type: string
         required: false
-        default: "--hip --hip-amd-arch=gfx906 --cuda"
+        default: "--hip --cuda"
       build_artifact_suffix:
         type: string
         required: true
@@ -86,7 +86,7 @@ jobs:
               \"build_cache_root\":\"/__w/\",
               \"build_cache_suffix\":\"default\",
               \"build_cache_size\":\"2G\",
-              \"build_configure_extra_args\":\"--hip --hip-amd-arch=gfx906 --cuda\",
+              \"build_configure_extra_args\":\"--hip --cuda\",
               \"build_artifact_suffix\":\"default\",
               \"build_upload_artifact\":\"false\",
               \"intel_drivers_image\":\"ghcr.io/intel/llvm/ubuntu2004_intel_drivers:latest\",

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -66,8 +66,6 @@ def do_configure(args):
         if args.hip_platform == 'AMD':
             llvm_targets_to_build += ';AMDGPU'
             libclc_targets_to_build += libclc_amd_target_names
-            if args.hip_amd_arch:
-                sycl_clang_extra_flags += "-Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch="+args.hip_amd_arch
 
             # The HIP plugin for AMD uses lld for linking
             llvm_enable_projects += ';lld'
@@ -211,7 +209,6 @@ def main():
     parser.add_argument("--cuda", action='store_true', help="switch from OpenCL to CUDA")
     parser.add_argument("--hip", action='store_true', help="switch from OpenCL to HIP")
     parser.add_argument("--hip-platform", type=str, choices=['AMD', 'NVIDIA'], default='AMD', help="choose hardware platform for HIP backend")
-    parser.add_argument("--hip-amd-arch", type=str, help="Sets AMD gpu architecture for llvm lit tests, this is only needed for the HIP backend and AMD platform")
     parser.add_argument("--arm", action='store_true', help="build ARM support rather than x86")
     parser.add_argument("--enable-esimd-emulator", action='store_true', help="build with ESIMD emulation support")
     parser.add_argument("--no-assertions", action='store_true', help="build without assertions")

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -502,6 +502,11 @@ skipped.
 If CUDA support has been built, it is tested only if there are CUDA devices
 available.
 
+If testing with HIP for AMD, the lit tests will use `gfx906` as the default
+architecture. It is possible to change it by adding
+`-Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=<target>` to the CMake
+variable `SYCL_CLANG_EXTRA_FLAGS`.
+
 #### Run DPC++ E2E test suite
 
 Follow instructions from the link below to build and run tests:

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -502,11 +502,6 @@ skipped.
 If CUDA support has been built, it is tested only if there are CUDA devices
 available.
 
-If testing with HIP for AMD make sure to specify the GPU being used
-by adding `-hip-amd-arch=<target>`to buildbot/configure.py or add 
-`-Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=<target>` 
-to the CMake variable `SYCL_CLANG_EXTRA_FLAGS`.
-
 #### Run DPC++ E2E test suite
 
 Follow instructions from the link below to build and run tests:

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -116,7 +116,7 @@ if triple == 'nvptx64-nvidia-cuda':
 if triple == 'amdgcn-amd-amdhsa':
     config.available_features.add('hip_amd')
     # For AMD the specific GPU has to be specified with --offload-arch, only
-    # compiler tests are run so hardcode the offload arch to gfx908
+    # compiler tests are run so hardcode the offload arch to gfx906
     additional_flags += ['-Xsycl-target-backend=amdgcn-amd-amdhsa',
                          '--offload-arch=gfx906']
 

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -112,7 +112,6 @@ if config.esimd_emulator_be == "ON":
 if triple == 'nvptx64-nvidia-cuda':
     config.available_features.add('cuda')
 
-
 if triple == 'amdgcn-amd-amdhsa':
     config.available_features.add('hip_amd')
     # For AMD the specific GPU has to be specified with --offload-arch, only

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -114,10 +114,12 @@ if triple == 'nvptx64-nvidia-cuda':
 
 if triple == 'amdgcn-amd-amdhsa':
     config.available_features.add('hip_amd')
-    # For AMD the specific GPU has to be specified with --offload-arch, only
-    # compiler tests are run so hardcode the offload arch to gfx906
-    additional_flags += ['-Xsycl-target-backend=amdgcn-amd-amdhsa',
-                         '--offload-arch=gfx906']
+    # For AMD the specific GPU has to be specified with --offload-arch
+    if not any([f.startswith('--offload-arch') for f in additional_flags]):
+        # If the offload arch wasn't specified in SYCL_CLANG_EXTRA_FLAGS,
+        # hardcode it to gfx906, this is fine because only compiler tests
+        additional_flags += ['-Xsycl-target-backend=amdgcn-amd-amdhsa',
+                            '--offload-arch=gfx906']
 
 llvm_config.use_clang(additional_flags=additional_flags)
 


### PR DESCRIPTION
This flag was introduced before all the tests that run code were moved
to the `llvm-test-suite` repository. The tests left in this repository
are only compiler tests so the offload architecture can simply be
hardcoded as the tests don't depend on what hardware is available.

This simplifies building and running the tests for hip.