### PR TITLE
[SYCL][CUDA] Remove unsued _pi_kernel constructor

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -672,17 +672,6 @@ struct _pi_kernel {
     assert(retError == PI_SUCCESS);
   }
 
-  _pi_kernel(CUfunction func, const char *name, pi_program program,
-             pi_context ctxt)
-      : _pi_kernel{func, nullptr, name, program, ctxt} {
-    /// Note: this code assumes that there is only one device per context
-    pi_result retError = cuda_piKernelGetGroupInfo(
-        this, ctxt->get_device(), PI_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE,
-        sizeof(reqdThreadsPerBlock_), reqdThreadsPerBlock_, nullptr);
-    (void)retError;
-    assert(retError == PI_SUCCESS);
-  }
-
   ~_pi_kernel()
   {
     cuda_piProgramRelease(program_);


### PR DESCRIPTION
This constructor is not used anywhere.

This resolves the discussion on intel/llvm#5152 about how
`cuda_piKernelGetGroupInfo` would be called twice when this constructor
is used, as it defers to the other constructor which also calls it. But
this constructor wasn't being used anyway so it can simply be removed.