### PR TITLE
[SYCL][CUDA] Disable by default the Image support

### DIFF
--- a/sycl/doc/EnvironmentVariables.md
+++ b/sycl/doc/EnvironmentVariables.md
@@ -147,4 +147,17 @@ variables in production code.</span>
 | `SYCL_PI_LEVEL_ZERO_USE_COPY_ENGINE_FOR_D2D_COPY` (experimental) | Integer | Allows the use of copy engine, if available in the device, in Level Zero plugin for device to device copy operations. The default is 0. This option is experimental and will be removed once heuristics are added to make a decision about use of copy engine for device to device copy operations. |
 | `SYCL_PI_LEVEL_ZERO_DEVICE_SCOPE_EVENTS` | Any(\*) | Enable support of device-scope events whose state is not visible to the host. If enabled the Level Zero plugin would create all events having device-scope only and create proxy host-visible events for them when their status is needed (wait/query) on the host. The default is 0, meaning all events are host-visible. |
 
+## Debugging variables for CUDA Plugin
+
+:warning: **Warning:** <span style="color:red">the environment variables
+described below are used for development and debugging of DPC++ compiler
+and runtime. Their semantics are subject to change. Do not rely on these
+variables in production code.</span>
+
+| Environment variable | Values | Description |
+| -------------------- | ------ | ----------- |
+| `SYCL_PI_CUDA_ENABLE_IMAGE_SUPPORT` (experimental) | Any(\*) | Enable support of images. This option is experimental since the image support is not fully implemented. |
+
+`(*) Note: Any means this environment variable is effective when set to any non-null value.`
+
 [xpti]: https://github.com/intel/llvm/blob/sycl/xptifw/doc/XPTI_Framework.md

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -1161,8 +1161,21 @@ pi_result cuda_piDeviceGetInfo(pi_device device, pi_device_info param_name,
                    pi_uint64{max_alloc});
   }
   case PI_DEVICE_INFO_IMAGE_SUPPORT: {
+    pi_bool enabled;
+
+    if (std::getenv("PI_CUDA_ENABLE_IMAGE_SUPPORT") != nullptr) {
+      enabled = PI_TRUE;
+    } else {
+      cl::sycl::detail::pi::cuPrint(
+          "Images are not fully supported by the CUDA BE, their support is "
+          "disabled by default. Their partial support can be activated by "
+          "setting PI_CUDA_ENABLE_IMAGE_SUPPORT environment variable at "
+          "runtime.");
+      enabled = PI_FALSE;
+    }
+
     return getInfo(param_value_size, param_value, param_value_size_ret,
-                   PI_TRUE);
+                   enabled);
   }
   case PI_DEVICE_INFO_MAX_READ_IMAGE_ARGS: {
     // This call doesn't match to CUDA as it doesn't have images, but instead

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -1161,7 +1161,7 @@ pi_result cuda_piDeviceGetInfo(pi_device device, pi_device_info param_name,
                    pi_uint64{max_alloc});
   }
   case PI_DEVICE_INFO_IMAGE_SUPPORT: {
-    pi_bool enabled;
+    pi_bool enabled = PI_FALSE;
 
     if (std::getenv("PI_CUDA_ENABLE_IMAGE_SUPPORT") != nullptr) {
       enabled = PI_TRUE;

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -1169,7 +1169,7 @@ pi_result cuda_piDeviceGetInfo(pi_device device, pi_device_info param_name,
       cl::sycl::detail::pi::cuPrint(
           "Images are not fully supported by the CUDA BE, their support is "
           "disabled by default. Their partial support can be activated by "
-          "setting PI_CUDA_ENABLE_IMAGE_SUPPORT environment variable at "
+          "setting SYCL_PI_CUDA_ENABLE_IMAGE_SUPPORT environment variable at "
           "runtime.");
     }
 

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -1163,7 +1163,7 @@ pi_result cuda_piDeviceGetInfo(pi_device device, pi_device_info param_name,
   case PI_DEVICE_INFO_IMAGE_SUPPORT: {
     pi_bool enabled = PI_FALSE;
 
-    if (std::getenv("PI_CUDA_ENABLE_IMAGE_SUPPORT") != nullptr) {
+    if (std::getenv("SYCL_PI_CUDA_ENABLE_IMAGE_SUPPORT") != nullptr) {
       enabled = PI_TRUE;
     } else {
       cl::sycl::detail::pi::cuPrint(

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -1171,7 +1171,6 @@ pi_result cuda_piDeviceGetInfo(pi_device device, pi_device_info param_name,
           "disabled by default. Their partial support can be activated by "
           "setting PI_CUDA_ENABLE_IMAGE_SUPPORT environment variable at "
           "runtime.");
-      enabled = PI_FALSE;
     }
 
     return getInfo(param_value_size, param_value, param_value_size_ret,


### PR DESCRIPTION
due to the fact that its actual CUDA implementation is partial.

It is possible to re-enable it by setting `PI_CUDA_ENABLE_IMAGE_SUPPORT` environment variable at runtime.