### PR TITLE
[SYCL] Resolve namespace ambiguity in this_nd_item

### DIFF
--- a/sycl/include/CL/sycl/nd_item.hpp
+++ b/sycl/include/CL/sycl/nd_item.hpp
@@ -207,7 +207,8 @@ namespace oneapi {
 namespace experimental {
 template <int Dims> nd_item<Dims> this_nd_item() {
 #ifdef __SYCL_DEVICE_ONLY__
-  return sycl::detail::Builder::getElement(detail::declptr<nd_item<Dims>>());
+  return sycl::detail::Builder::getElement(
+      sycl::detail::declptr<nd_item<Dims>>());
 #else
   throw sycl::exception(
       sycl::make_error_code(sycl::errc::feature_not_supported),

--- a/sycl/test/basic_tests/free_function_queries/free_function_queries_interface.cpp
+++ b/sycl/test/basic_tests/free_function_queries/free_function_queries_interface.cpp
@@ -53,7 +53,7 @@ template <template <int, bool = true> class Item, int Dims> void test() {
       "Wrong return type of free function query for Item");
 }
 
-int main() {
+void test_all() {
   test<sycl::id>(this_id_caller<1>{});
   test<sycl::id>(this_id_caller<2>{});
   test<sycl::id>(this_id_caller<3>{});
@@ -74,4 +74,13 @@ int main() {
       std::is_same<decltype(sycl::ext::oneapi::experimental::this_sub_group()),
                    sycl::ext::oneapi::sub_group>::value,
       "Wrong return type of free function query for Sub Group");
+}
+
+int main() {
+  // Test on host.
+  test_all();
+
+  // Test on device.
+  sycl::queue Q;
+  Q.single_task([]() { test_all(); });
 }

--- a/sycl/test/basic_tests/free_function_queries/free_function_queries_interface.cpp
+++ b/sycl/test/basic_tests/free_function_queries/free_function_queries_interface.cpp
@@ -53,7 +53,7 @@ template <template <int, bool = true> class Item, int Dims> void test() {
       "Wrong return type of free function query for Item");
 }
 
-void test_all() {
+SYCL_EXTERNAL void test_all() {
   test<sycl::id>(this_id_caller<1>{});
   test<sycl::id>(this_id_caller<2>{});
   test<sycl::id>(this_id_caller<3>{});
@@ -74,13 +74,4 @@ void test_all() {
       std::is_same<decltype(sycl::ext::oneapi::experimental::this_sub_group()),
                    sycl::ext::oneapi::sub_group>::value,
       "Wrong return type of free function query for Sub Group");
-}
-
-int main() {
-  // Test on host.
-  test_all();
-
-  // Test on device.
-  sycl::queue Q;
-  Q.single_task([]() { test_all(); });
 }


### PR DESCRIPTION
Since the `detail` namespace appears in both the `sycl` namespace and in the `sycl::ext::oneapi::experimental` namespace, the implementation of `sycl::ext::oneapi::experimental::this_nd_item` may fail due to `detail::declptr` not existing in the latter. These changes remove the ambiguity.