### PR TITLE
[SYCL][CMake] Extend Clang workarounds to new 'IntelLLVM' compiler ID

### DIFF
--- a/sycl/plugins/CMakeLists.txt
+++ b/sycl/plugins/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
-if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" )
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang|IntelLLVM" )
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-covered-switch-default")
 endif()
 


### PR DESCRIPTION
Newer versions of CMake will detect icx as "IntelLLVM" rather than
"Clang."

To preserve this workaround, extend the compiler ID check to match
either compiler ID. This should allow builds using icx and newer
versions of CMake to continue to work as expected.
