### PR TITLE
[Matrix][SYCL] Change the template parameter of joint_matrix_fill to …

### DIFF
--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-jit.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-jit.hpp
@@ -203,16 +203,16 @@ joint_matrix_mad(Group sg, joint_matrix<T1, M, K, LayoutA, Group> &mA,
 }
 
 template <typename Group, typename T, size_t NumRows, size_t NumCols,
-          matrix_layout Layout>
+          matrix_layout Layout, typename T2>
 inline __SYCL_ALWAYS_INLINE void
 joint_matrix_fill(Group sg,
                   joint_matrix<T, NumRows, NumCols, Layout, Group> &res,
-                  const T v) {
+                  const T2 v) {
   // We kept the unused "sg" in joint_matrix_fill to match the other DPC++
   // functions
   (void)sg;
 #ifdef __SYCL_DEVICE_ONLY__
-  res.spvm = __spirv_CompositeConstruct<T, NumRows, NumCols>(v);
+  res.spvm = __spirv_CompositeConstruct<T, NumRows, NumCols>(static_cast<T>(v));
 #else
   (void)res;
   (void)v;


### PR DESCRIPTION
…fix the issue of deduced conflicting types

This is because Type deduction does not consider implicit conversions
(other than type adjustments listed above): that's the job for overload
resolution, which happens later.
https://godbolt.org/z/W4z3KcbbY is a small reproducer for fill's bug and https://godbolt.org/z/d7nPKhnGh is a fix.