### PR TITLE
[Matrix][SYCL] Add explicit conversion in wi_element when it is necessary

### DIFF
--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-jit.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-jit.hpp
@@ -287,7 +287,8 @@ public:
   wi_element &operator+=(const T &rhs) {
 #ifdef __SYCL_DEVICE_ONLY__
     M.spvm = __spirv_VectorInsertDynamic(
-        M.spvm, __spirv_VectorExtractDynamic(M.spvm, idx) + rhs, idx);
+        M.spvm, static_cast<T>(__spirv_VectorExtractDynamic(M.spvm, idx) + rhs),
+        idx);
     return *this;
 #else
     (void)rhs;
@@ -311,7 +312,8 @@ public:
   wi_element &operator-=(const T &rhs) {
 #ifdef __SYCL_DEVICE_ONLY__
     M.spvm = __spirv_VectorInsertDynamic(
-        M.spvm, __spirv_VectorExtractDynamic(M.spvm, idx) - rhs, idx);
+        M.spvm, static_cast<T>(__spirv_VectorExtractDynamic(M.spvm, idx) - rhs),
+        idx);
     return *this;
 #else
     (void)rhs;
@@ -335,7 +337,8 @@ public:
   wi_element &operator*=(const T &rhs) {
 #ifdef __SYCL_DEVICE_ONLY__
     M.spvm = __spirv_VectorInsertDynamic(
-        M.spvm, __spirv_VectorExtractDynamic(M.spvm, idx) * rhs, idx);
+        M.spvm, static_cast<T>(__spirv_VectorExtractDynamic(M.spvm, idx) * rhs),
+        idx);
     return *this;
 #else
     (void)rhs;
@@ -359,7 +362,8 @@ public:
   wi_element &operator/=(const T &rhs) {
 #ifdef __SYCL_DEVICE_ONLY__
     M.spvm = __spirv_VectorInsertDynamic(
-        M.spvm, __spirv_VectorExtractDynamic(M.spvm, idx) / rhs, idx);
+        M.spvm, static_cast<T>(__spirv_VectorExtractDynamic(M.spvm, idx) / rhs),
+        idx);
     return *this;
 #else
     (void)rhs;


### PR DESCRIPTION
Previously, there was a potential issue of deduced conflicting types because we didn't take integral promotion into consideration
Now, we add explicit conversion where integral promotion might happen to avoid such issues to appear.