### PR TITLE
[Driver] Pass the flag -dI to cc1 invocation

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7158,6 +7158,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   Args.AddLastArg(CmdArgs, options::OPT_dM);
   Args.AddLastArg(CmdArgs, options::OPT_dD);
+  Args.AddLastArg(CmdArgs, options::OPT_dI);
 
   Args.AddLastArg(CmdArgs, options::OPT_fmax_tokens_EQ);
 

--- a/clang/test/Driver/preprocessor.c
+++ b/clang/test/Driver/preprocessor.c
@@ -4,3 +4,10 @@
 #define A B
 A A
 
+// The driver should pass preprocessor dump flags (-dD, -dM and -dI) to cc1 invocation
+// RUN: %clang -### -E -dD %s 2>&1 | FileCheck --check-prefix=CHECK-dD %s
+// RUN: %clang -### -E -dM %s 2>&1 | FileCheck --check-prefix=CHECK-dM %s
+// RUN: %clang -### -E -dI %s 2>&1 | FileCheck --check-prefix=CHECK-dI %s
+// CHECK-dD: clang{{.*}} "-cc1" {{.*}} "-dD"
+// CHECK-dM: clang{{.*}} "-cc1" {{.*}} "-dM"
+// CHECK-dI: clang{{.*}} "-cc1" {{.*}} "-dI"


### PR DESCRIPTION
The flag -dI is missed when the driver calls cc1.
Hook up the flag -dI in the driver to pass it to cc1 invocation.

Signed-off-by: Qichao Gu <qichao.gu@intel.com>