### PR TITLE
[SYCL][XPTI] Fix compilation issue when building SYCL without XPTI

### DIFF
--- a/sycl/source/detail/xpti_registry.cpp
+++ b/sycl/source/detail/xpti_registry.cpp
@@ -16,6 +16,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
+#ifdef XPTI_ENABLE_INSTRUMENTATION
 xpti::trace_event_data_t *
 XPTIRegistry::createTraceEvent(void *Obj, const char *ObjName, uint64_t &IId,
                                const detail::code_location &CodeLoc,
@@ -39,6 +40,8 @@ XPTIRegistry::createTraceEvent(void *Obj, const char *ObjName, uint64_t &IId,
   return xptiMakeEvent(Name.c_str(), &Payload, TraceEventType, xpti_at::active,
                        &IId);
 }
+#endif // XPTI_ENABLE_INSTRUMENTATION
+
 void XPTIRegistry::bufferConstructorNotification(
     void *UserObj, const detail::code_location &CodeLoc) {
   (void)UserObj;

--- a/sycl/source/detail/xpti_registry.hpp
+++ b/sycl/source/detail/xpti_registry.hpp
@@ -98,6 +98,7 @@ public:
   static void bufferAccessorNotification(void *UserObj, void *AccessorObj,
                                          uint32_t Target, uint32_t Mode,
                                          const detail::code_location &CodeLoc);
+
 private:
   std::unordered_set<std::string> MActiveStreams;
   std::once_flag MInitialized;

--- a/sycl/source/detail/xpti_registry.hpp
+++ b/sycl/source/detail/xpti_registry.hpp
@@ -98,14 +98,16 @@ public:
   static void bufferAccessorNotification(void *UserObj, void *AccessorObj,
                                          uint32_t Target, uint32_t Mode,
                                          const detail::code_location &CodeLoc);
+private:
+  std::unordered_set<std::string> MActiveStreams;
+  std::once_flag MInitialized;
+
+#ifdef XPTI_ENABLE_INSTRUMENTATION
   static xpti::trace_event_data_t *
   createTraceEvent(void *Obj, const char *ObjName, uint64_t &IId,
                    const detail::code_location &CodeLoc,
                    uint16_t TraceEventType);
-
-private:
-  std::unordered_set<std::string> MActiveStreams;
-  std::once_flag MInitialized;
+#endif // XPTI_ENABLE_INSTRUMENTATION
 };
 } // namespace detail
 } // namespace sycl


### PR DESCRIPTION
Also the XPTIRegistry::createTraceEvent static method has been moved into
the private part of the class since it is used in the class only.

Closes #5274