### PR TITLE
[SYCL][HIP][libclc] Revert revert "Fix wrong address spaces for HIP"

### DIFF
--- a/clang/lib/Basic/Targets/AMDGPU.h
+++ b/clang/lib/Basic/Targets/AMDGPU.h
@@ -328,6 +328,8 @@ public:
     case OCLTK_Queue:
     case OCLTK_ReserveID:
       return LangAS::opencl_global;
+    case OCLTK_Event:
+      return LangAS::opencl_private;
 
     default:
       return TargetInfo::getOpenCLTypeAddrSpace(TK);

--- a/libclc/amdgcn-amdhsa/libspirv/SOURCES
+++ b/libclc/amdgcn-amdhsa/libspirv/SOURCES
@@ -56,3 +56,4 @@ workitem/get_sub_group_id.cl
 workitem/get_sub_group_local_id.cl
 workitem/get_sub_group_size.cl
 misc/sub_group_shuffle.cl
+async/wait_group_events.cl

--- a/libclc/amdgcn-amdhsa/libspirv/async/wait_group_events.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/async/wait_group_events.cl
@@ -1,0 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <spirv/spirv.h>
+
+_CLC_DEF void _Z23__spirv_GroupWaitEventsjiP9ocl_event(unsigned int scope,
+                                                    int num_events,
+                                                    event_t __attribute__((address_space(0)))* event_list) {
+  __spirv_ControlBarrier(scope, Workgroup, SequentiallyConsistent);
+}
+
+

--- a/libclc/amdgcn-amdhsa/libspirv/async/wait_group_events.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/async/wait_group_events.cl
@@ -14,4 +14,9 @@ _CLC_DEF void _Z23__spirv_GroupWaitEventsjiP9ocl_event(unsigned int scope,
   __spirv_ControlBarrier(scope, Workgroup, SequentiallyConsistent);
 }
 
+_CLC_OVERLOAD _CLC_DEF void __spirv_GroupWaitEvents(unsigned int scope,
+                                                    int num_events,
+                                                    event_t *event_list) {
+  __spirv_ControlBarrier(scope, Workgroup, SequentiallyConsistent);
+}
 


### PR DESCRIPTION
Reverts #5284 , reintroducing the reverted #4966 and adds fixes the failing libclc test.