### PR TITLE
[Driver][SYCL] Remove extra SPIR-V conversion when using -fsycl-devic…

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -47,41 +47,6 @@ void SYCLInstallationDetector::print(llvm::raw_ostream &OS) const {
   }
 }
 
-const char *SYCL::Linker::constructLLVMSpirvCommand(
-    Compilation &C, const JobAction &JA, const InputInfo &Output,
-    StringRef OutputFilePrefix, bool ToBc, const char *InputFileName) const {
-  // Construct llvm-spirv command.
-  // The output is a bc file or vice versa depending on the -r option usage
-  // llvm-spirv -r -o a_kernel.bc a_kernel.spv
-  // llvm-spirv -o a_kernel.spv a_kernel.bc
-  ArgStringList CmdArgs;
-  const char *OutputFileName = nullptr;
-  if (ToBc) {
-    std::string TmpName =
-        C.getDriver().GetTemporaryPath(OutputFilePrefix.str() + "-spirv", "bc");
-    OutputFileName = C.addTempFile(C.getArgs().MakeArgString(TmpName));
-    CmdArgs.push_back("-r");
-    CmdArgs.push_back("-o");
-    CmdArgs.push_back(OutputFileName);
-  } else {
-    CmdArgs.push_back("-spirv-max-version=1.4");
-    CmdArgs.push_back("-spirv-ext=+all");
-    CmdArgs.push_back("-spirv-debug-info-version=ocl-100");
-    CmdArgs.push_back("-spirv-allow-extra-diexpressions");
-    CmdArgs.push_back("-spirv-allow-unknown-intrinsics=llvm.genx.");
-    CmdArgs.push_back("-o");
-    CmdArgs.push_back(Output.getFilename());
-  }
-  CmdArgs.push_back(InputFileName);
-
-  SmallString<128> LLVMSpirvPath(C.getDriver().Dir);
-  llvm::sys::path::append(LLVMSpirvPath, "llvm-spirv");
-  const char *LLVMSpirv = C.getArgs().MakeArgString(LLVMSpirvPath);
-  C.addCommand(std::make_unique<Command>(
-      JA, *this, ResponseFileSupport::AtFileUTF8(), LLVMSpirv, CmdArgs, None));
-  return OutputFileName;
-}
-
 static void addFPGATimingDiagnostic(std::unique_ptr<Command> &Cmd,
                                     Compilation &C) {
   const char *Msg = C.getArgs().MakeArgString(
@@ -343,22 +308,11 @@ void SYCL::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     return;
   }
 
-  // We want to use llvm-spirv linker to link spirv binaries before putting
-  // them into the fat object.
-  // Each command outputs different files.
   InputInfoList SpirvInputs;
   for (const auto &II : Inputs) {
     if (!II.isFilename())
       continue;
-    if (!Args.getLastArgValue(options::OPT_fsycl_device_obj_EQ)
-             .equals_insensitive("spirv"))
-      SpirvInputs.push_back(II);
-    else {
-      const char *LLVMSpirvOutputFile = constructLLVMSpirvCommand(
-          C, JA, Output, Prefix, true, II.getFilename());
-      SpirvInputs.push_back(InputInfo(types::TY_LLVM_BC, LLVMSpirvOutputFile,
-                                      LLVMSpirvOutputFile));
-    }
+    SpirvInputs.push_back(II);
   }
 
   constructLLVMLinkCommand(C, JA, Output, Args, SubArchName, Prefix,

--- a/clang/lib/Driver/ToolChains/SYCL.h
+++ b/clang/lib/Driver/ToolChains/SYCL.h
@@ -54,11 +54,6 @@ public:
                     const char *LinkingOutput) const override;
 
 private:
-  /// \return llvm-spirv output file name.
-  const char *constructLLVMSpirvCommand(Compilation &C, const JobAction &JA,
-                                       const InputInfo &Output,
-                                       llvm::StringRef OutputFilePrefix,
-                                       bool isBc, const char *InputFile) const;
   /// \return llvm-link output file name.
   const char *constructLLVMLinkCommand(Compilation &C, const JobAction &JA,
                              const InputInfo &Output,

--- a/clang/test/Driver/sycl-spirv-obj.cpp
+++ b/clang/test/Driver/sycl-spirv-obj.cpp
@@ -34,3 +34,11 @@
 // SPIRV_DEVICE_OBJ_PHASES: 10: backend, {9}, assembler, (host-sycl)
 // SPIRV_DEVICE_OBJ_PHASES: 11: assembler, {10}, object, (host-sycl)
 // SPIRV_DEVICE_OBJ_PHASES: 12: clang-offload-bundler, {4, 11}, object, (host-sycl)
+
+/// Use of -fsycl-device-obj=spirv should not be effective during linking
+// RUN: touch %t.o
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fsycl-device-obj=spirv -### %t.o 2>&1 | \
+// RUN:  FileCheck %s -check-prefixes=OPT_WARNING,LLVM_SPIRV_R
+// OPT_WARNING: warning: argument unused during compilation: '-fsycl-device-obj=spirv'
+// LLVM_SPIRV_R: spirv-to-ir-wrapper{{.*}}
+// LLVM_SPIRV_R-NOT: llvm-spirv{{.*}} "-r"


### PR DESCRIPTION
…e-obj=spirv

The use of -fsycl-device-obj=spirv should only be relevant when creating
objects.  Clean up usage of llvm-spirv -r when processing objects, as this
is already taken care of by the spirv-to-ir-wrapper call.