### PR TITLE
[SYCL][XPTI] Fix dependencies on XPTI

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -241,13 +241,6 @@ add_custom_target( sycl-toolchain
   COMMENT "Building SYCL compiler toolchain..."
 )
 
-if (SYCL_ENABLE_XPTI_TRACING)
-  add_dependencies( sycl-toolchain xpti)
-  if (MSVC)
-    add_dependencies( sycl-toolchain xptid)
-  endif()
-endif()
-
 option(SYCL_INCLUDE_TESTS
   "Generate build targets for the SYCL unit tests."
   ${LLVM_INCLUDE_TESTS})

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -218,6 +218,13 @@ if (libdevice IN_LIST LLVM_ENABLE_PROJECTS)
   add_dependencies(sycl libsycldevice)
 endif()
 
+if (SYCL_ENABLE_XPTI_TRACING)
+  add_dependencies( sycl xpti)
+  if (MSVC)
+    add_dependencies( sycl xptid)
+  endif()
+endif()
+
 install(TARGETS ${SYCL_RT_LIBS}
   ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT sycl
   LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT sycl

--- a/sycl/tools/pi-trace/CMakeLists.txt
+++ b/sycl/tools/pi-trace/CMakeLists.txt
@@ -11,4 +11,11 @@ target_include_directories(pi_trace PRIVATE
     "${sycl_src_dir}"
 )
 
+if (SYCL_ENABLE_XPTI_TRACING)
+  add_dependencies( pi_trace xpti xptifw)
+  if (MSVC)
+    add_dependencies( pi_trace xptid xptifwd)
+  endif()
+endif()
+
 add_dependencies(sycl-toolchain pi_trace)

--- a/sycl/tools/pi-trace/CMakeLists.txt
+++ b/sycl/tools/pi-trace/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories(pi_trace PRIVATE
 if (SYCL_ENABLE_XPTI_TRACING)
   add_dependencies( pi_trace xpti xptifw)
   if (MSVC)
-    add_dependencies( pi_trace xptid xptifwd)
+    add_dependencies( pi_trace xptid xptifw)
   endif()
 endif()
 


### PR DESCRIPTION
SYCL components sycl and pi_trace does not have direct dependency on
xpti component that they actually depends on. That causing build
failures when the component are build directly or
deploy-sycl-toolchain put building of xpti and sycl components in the
wrong order.