### PR TITLE
[SYCL][CUDA][HIP] Fix PI_MEM_ALLOC_DEVICE USM pointer query

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -4825,12 +4825,19 @@ pi_result cuda_piextUSMGetMemAllocInfo(pi_context context, const void *ptr,
 #endif
     }
     case PI_MEM_ALLOC_DEVICE: {
-      unsigned int value;
+      // get device index associated with this pointer
+      unsigned int device_idx;
       result = PI_CHECK_ERROR(cuPointerGetAttribute(
-          &value, CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL, (CUdeviceptr)ptr));
-      pi_platform platform;
-      result = cuda_piPlatformsGet(1, &platform, nullptr);
-      pi_device device = platform->devices_[value].get();
+          &device_idx, CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL, (CUdeviceptr)ptr));
+
+      // currently each device is in its own platform, so find the platform at
+      // the same index
+      std::vector<pi_platform> platforms;
+      platforms.resize(device_idx + 1);
+      result = cuda_piPlatformsGet(device_idx + 1, platforms.data(), nullptr);
+
+      // get the device from the platform
+      pi_device device = platforms[device_idx]->devices_[0].get();
       return getInfo(param_value_size, param_value, param_value_size_ret,
                      device);
     }

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -4792,15 +4792,19 @@ pi_result hip_piextUSMGetMemAllocInfo(pi_context context, const void *ptr,
     }
 
     case PI_MEM_ALLOC_DEVICE: {
-      unsigned int value;
+      // get device index associated with this pointer
       result = PI_CHECK_ERROR(
           hipPointerGetAttributes(&hipPointerAttributeType, ptr));
-      auto devicePointer =
-          static_cast<int *>(hipPointerAttributeType.devicePointer);
-      value = *devicePointer;
-      pi_platform platform;
-      result = hip_piPlatformsGet(1, &platform, nullptr);
-      pi_device device = platform->devices_[value].get();
+      int device_idx = hipPointerAttributeType.device;
+
+      // currently each device is in its own platform, so find the platform at
+      // the same index
+      std::vector<pi_platform> platforms;
+      platforms.resize(device_idx + 1);
+      result = hip_piPlatformsGet(device_idx + 1, platforms.data(), nullptr);
+
+      // get the device from the platform
+      pi_device device = platforms[device_idx]->devices_[0].get();
       return getInfo(param_value_size, param_value, param_value_size_ret,
                      device);
     }


### PR DESCRIPTION
This fixes the `USM/pointer_quer.cpp` test from `llvm-test-suite` for
HIP.

For HIP the code was using the device pointer to index the device array
for some reason, which is obviously incorrect, now it should be using
the correct property to get the device index on the hardware.

In addition for both HIP and CUDA the query was using the device index
to index into the array of devices on the platform, this is incorrect
since #4571 which moved every device in its own platform. Therefore to
get the correct device we now need to use the index on the list of
platforms, and then `0` on the list of devices.