### PR TITLE
[SYCL] Prevent unnecessary command batching in L0 plug-in

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -3091,6 +3091,9 @@ pi_result piQueueFinish(pi_queue Queue) {
       ZE_CALL(zeHostSynchronize, (Queue->ZeCopyCommandQueues[i]));
   }
 
+  // Prevent unneeded already finished events to show up in the wait list.
+  Queue->LastCommandEvent = nullptr;
+
   return PI_SUCCESS;
 }
 


### PR DESCRIPTION
This patch nullifies Queue->LastCommandEvent in Level Zero's
piQueueFinish as it was in _pi_event::cleanup to prevent extra batching
and performance drop.