### PR TITLE
[SYCL] Move ITT annotation option check to clang options parser (#5315)

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2254,12 +2254,12 @@ def SYCLIntelPipeIO : InheritableAttr {
 }
 
 // Variadic integral arguments.
-def IntelFPGABankBits : Attr {
+def IntelFPGABankBits : InheritableAttr {
   let Spellings = [CXX11<"intel", "bank_bits">];
   let Args = [VariadicExprArgument<"Args">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticAgentMemVar,
                               Field], ErrorDiag>;
-  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let Documentation = [IntelFPGABankBitsDocs];
 }
 def : MutualExclusions<[IntelFPGARegister, IntelFPGABankBits]>;

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10482,6 +10482,9 @@ public:
 
   void AddIntelFPGABankBitsAttr(Decl *D, const AttributeCommonInfo &CI,
                                 Expr **Exprs, unsigned Size);
+  IntelFPGABankBitsAttr *
+  MergeIntelFPGABankBitsAttr(Decl *D, const IntelFPGABankBitsAttr &A);
+
   template <typename AttrType>
   void addIntelTripleArgAttr(Decl *D, const AttributeCommonInfo &CI,
                              Expr *XDimExpr, Expr *YDimExpr, Expr *ZDimExpr);

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1044,9 +1044,8 @@ void EmitAssemblyHelper::EmitAssemblyWithLegacyPassManager(
   // -fsycl-instrument-device-code option was passed. This option can be
   // used only with spir triple.
   if (CodeGenOpts.SPIRITTAnnotations) {
-    if (!llvm::Triple(TheModule->getTargetTriple()).isSPIR())
-      llvm::report_fatal_error(
-          "ITT annotations can only by added to a module with spir target");
+    assert(llvm::Triple(TheModule->getTargetTriple()).isSPIR() &&
+           "ITT annotations can only by added to a module with spir target");
     PerModulePasses.add(createSPIRITTAnnotationsLegacyPass());
   }
 

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1900,6 +1900,13 @@ bool CompilerInvocation::ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args,
     Opts.EnableAIXExtendedAltivecABI = O.matches(OPT_mabi_EQ_vec_extabi);
   }
 
+  if (Arg *A = Args.getLastArg(OPT_fsycl_instrument_device_code)) {
+    if (!T.isSPIR())
+      Diags.Report(diag::err_drv_unsupported_opt_for_target)
+          << A->getSpelling() << T.str();
+    Opts.SPIRITTAnnotations = true;
+  }
+
   bool NeedLocTracking = false;
 
   if (!Opts.OptRecordFile.empty())

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -2732,6 +2732,8 @@ static bool mergeDeclAttribute(Sema &S, NamedDecl *D,
     NewAttr = S.MergeSYCLUsesAspectsAttr(D, *A);
   else if (const auto *A = dyn_cast<SYCLIntelPipeIOAttr>(Attr))
     NewAttr = S.MergeSYCLIntelPipeIOAttr(D, *A);
+  else if (const auto *A = dyn_cast<IntelFPGABankBitsAttr>(Attr))
+    NewAttr = S.MergeIntelFPGABankBitsAttr(D, *A);
   else if (Attr->shouldInheritEvenIfAlreadyPresent() || !DeclHasAttr(D, Attr))
     NewAttr = cast<InheritableAttr>(Attr->clone(S.Context));
 

--- a/clang/test/CodeGen/sycl-instrumentation-option.c
+++ b/clang/test/CodeGen/sycl-instrumentation-option.c
@@ -1,0 +1,17 @@
+/// Check if -fsycl-instrument-device-code is allowed only for spir target
+
+// RUN: %clang_cc1 -fsycl-instrument-device-code -triple spir-unknown-unknown %s -emit-llvm -o - 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fsycl-instrument-device-code -triple spir64-unknown-unknown %s -emit-llvm -o - 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fsycl-instrument-device-code -triple spir64_gen-unknown-unknown %s -emit-llvm -o - 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fsycl-instrument-device-code -triple spir64_fpga-unknown-unknown %s -emit-llvm -o - 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -fsycl-instrument-device-code -triple spir64_x86_64-unknown-unknown %s -emit-llvm -o - 2>&1 | FileCheck %s
+// CHECK-NOT: error
+
+// RUN: not %clang_cc1 -fsycl-instrument-device-code -triple spirv32 -emit-llvm %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-ERR
+// RUN: not %clang_cc1 -fsycl-instrument-device-code -triple spirv64 -emit-llvm %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-ERR
+// RUN: not %clang_cc1 -fsycl-instrument-device-code -triple x86_64-unknown-unknown -emit-llvm %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-ERR
+// RUN: not %clang_cc1 -fsycl-instrument-device-code -triple i386-unknown-unknown -emit-llvm %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-ERR
+// RUN: not %clang_cc1 -fsycl-instrument-device-code -triple xcore-unknown-unknown -emit-llvm %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-ERR
+// RUN: not %clang_cc1 -fsycl-instrument-device-code -triple powerpc64-unknown-unknown -emit-llvm %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-ERR
+// RUN: not %clang_cc1 -fsycl-instrument-device-code -triple armv7-unknown-unknown -emit-llvm %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=CHECK-ERR
+// CHECK-ERR: error: unsupported option '-fsycl-instrument-device-code' for target

--- a/clang/test/SemaSYCL/intel-fpga-global-const.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-global-const.cpp
@@ -115,3 +115,12 @@
 //expected-note@+1{{conflicting attribute is here}}
 [[intel::bankwidth(8)]] extern const int var_bankwidth_2;
 [[intel::fpga_register]] const int var_bankwidth_2 =0;
+
+
+// Test that checks global constant variable (which allows the redeclaration) since
+// IntelFPGAConstVar is one of the subjects listed for [[intel::bank_bits()]] attribute.
+// Merging of different arg values.
+// expected-warning@+3{{attribute 'bank_bits' is already applied}}
+//expected-note@+1{{previous attribute is here}}
+[[intel::bank_bits(2, 3, 4, 5)]] extern const int bankbits_1;
+[[intel::bank_bits(41, 42, 43, 44)]] const int bankbits_1 = 0;

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -612,6 +612,7 @@ void diagnostics()
   //expected-note@-2 1{{conflicting attribute is here}}
   unsigned int bb_reg[4];
 
+  // Checking of different argument values.
   //CHECK: VarDecl{{.*}}bb_bb
   //CHECK: IntelFPGABankBitsAttr
   //CHECK-NEXT: ConstantExpr
@@ -620,15 +621,9 @@ void diagnostics()
   //CHECK-NEXT: ConstantExpr
   //CHECK-NEXT: value:{{.*}}43
   //CHECK-NEXT: IntegerLiteral{{.*}}43{{$}}
-  //CHECK: IntelFPGABankBitsAttr
-  //CHECK-NEXT: ConstantExpr
-  //CHECK-NEXT: value:{{.*}}1
-  //CHECK-NEXT: IntegerLiteral{{.*}}1{{$}}
-  //CHECK-NEXT: ConstantExpr
-  //CHECK-NEXT: value:{{.*}}2
-  //CHECK-NEXT: IntegerLiteral{{.*}}2{{$}}
+  //CHECK-NOT: IntelFPGABankBitsAttr
   //expected-warning@+2{{attribute 'bank_bits' is already applied}}
-  [[intel::bank_bits(42, 43)]]
+  [[intel::bank_bits(42, 43)]] //expected-note{{previous attribute is here}}
   [[intel::bank_bits(1, 2)]] unsigned int bb_bb[4];
 
   //expected-error@+1{{the number of bank_bits must be equal to ceil(log2(numbanks))}}
@@ -873,6 +868,29 @@ void check_template_parameters() {
   //CHECK-NEXT: NonTypeTemplateParmDecl
   //CHECK-NEXT: IntegerLiteral{{.*}}8{{$}}
   [[intel::bank_bits(A, 3), intel::bankwidth(C)]] unsigned int bank_bits_width;
+
+  // Test that checks template instantiations for different arg values.
+  //CHECK: VarDecl{{.*}}bank_bits_args 'unsigned int'
+  //CHECK: IntelFPGAMemoryAttr{{.*}}Implicit Default
+  //CHECK: IntelFPGANumBanksAttr
+  //CHECK-NEXT: ConstantExpr
+  //CHECK-NEXT: value:{{.*}}4
+  //CHECK-NEXT: IntegerLiteral{{.*}}'int' 4
+  //CHECK: IntelFPGANumBanksAttr{{.*}}Implicit
+  //CHECK-NEXT: IntegerLiteral{{.*}} 'int' 4
+  //CHECK-NEXT: IntelFPGAMemoryAttr{{.*}}Implicit
+  //CHECK-NEXT: IntelFPGABankBitsAttr
+  //CHECK-NEXT: ConstantExpr
+  //CHECK-NEXT: value:{{.*}}2
+  //CHECK-NEXT: SubstNonTypeTemplateParmExpr
+  //CHECK-NEXT: NonTypeTemplateParmDecl
+  //CHECK-NEXT: IntegerLiteral{{.*}}2{{$}}
+  //CHECK-NEXT: ConstantExpr
+  //CHECK-NEXT: value:{{.*}}3
+  //CHECK-NEXT: IntegerLiteral{{.*}}3{{$}}
+  //expected-note@+2{{previous attribute is here}}
+  //expected-warning@+1{{attribute 'bank_bits' is already applied}}
+  [[intel::bank_bits(A, 3), intel::bank_bits(42, 43)]] unsigned int bank_bits_args;
 
   // Add implicit memory attribute.
   //CHECK: VarDecl{{.*}}max_replicates


### PR DESCRIPTION
Signed-off-by: Mikhail Lychkov <mikhail.lychkov@intel.com>