### PR TITLE
[SYCL] Fix crash during search for undefined functions

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -515,6 +515,10 @@ static bool isSYCLUndefinedAllowed(const FunctionDecl *Callee,
   if (!Callee)
     return false;
 
+  // The check below requires declaration name, make sure we have it.
+  if (!Callee->getIdentifier())
+    return false;
+
   // libstdc++-11 introduced an undefined function "void __failed_assertion()"
   // which may lead to SemaSYCL check failure. However, this undefined function
   // is used to trigger some compilation error when the check fails at compile
@@ -4153,6 +4157,7 @@ void Sema::finalizeSYCLDelayedAnalysis(const FunctionDecl *Caller,
   // Currently, there is an exception of "__failed_assertion" in libstdc++-11,
   // this undefined function is used to trigger a compiling error.
   if (!Callee->isDefined() && !Callee->getBuiltinID() &&
+      !Callee->isReplaceableGlobalAllocationFunction() &&
       !isSYCLUndefinedAllowed(Callee, getSourceManager())) {
     Diag(Loc, diag::err_sycl_restrict) << Sema::KernelCallUndefinedFunction;
     Diag(Callee->getLocation(), diag::note_previous_decl) << Callee;

--- a/clang/test/SemaSYCL/new-inside-recursive-function.cpp
+++ b/clang/test/SemaSYCL/new-inside-recursive-function.cpp
@@ -21,4 +21,3 @@ __attribute__((sycl_device)) bool foo() {
   foo();
   return true;
 }
-

--- a/clang/test/SemaSYCL/new-inside-recursive-function.cpp
+++ b/clang/test/SemaSYCL/new-inside-recursive-function.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -fsycl-is-device -sycl-std=2020 -verify -fsyntax-only %s
+
+// This test makes sure that SemaSYCL doesn't crash and emits correct error
+// messages if operator new was used inside recursive function.
+
+typedef __typeof__(sizeof(int)) size_t;
+
+struct S {
+  // expected-note@+1 {{'operator new' declared here}}
+  void *operator new(size_t);
+};
+
+// expected-note@+2 {{function implemented using recursion declared here}}
+// expected-note@+1 {{called by 'foo'}}
+__attribute__((sycl_device)) bool foo() {
+  // expected-error@+1 {{SYCL kernel cannot call an undefined function without SYCL_EXTERNAL attribute}}
+  S *P = new S();
+  // expected-error@+1 {{SYCL kernel cannot allocate storage}}
+  int *IP = new int;
+  // expected-error@+1 {{SYCL kernel cannot call a recursive function}}
+  foo();
+  return true;
+}
+


### PR DESCRIPTION
There was a crash if operator `new` was used inside recursive function
or if undefined overloaded operator `new` was used inside random device
code. The reason for crash is that `FunctionDecl` that represents
operator `new` doesn't have a valid name in AST and `isSYCLUndefinedAllowed`
checks it.