### PR TITLE
[sycl-post-link][NFC] Put passes and their dependencies in namespace llvm

### DIFF
--- a/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.cpp
+++ b/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.cpp
@@ -23,6 +23,9 @@ static constexpr char DEVICELIB_FUNC_PREFIX[] = "__devicelib_";
 using namespace llvm;
 
 namespace {
+
+using SYCLDeviceLibFuncMap = std::unordered_map<std::string, DeviceLibExt>;
+
 // Please update SDLMap if any item is added to or removed from
 // fallback device libraries in libdevice.
 SYCLDeviceLibFuncMap SDLMap = {

--- a/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.cpp
+++ b/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.cpp
@@ -20,6 +20,8 @@
 
 static constexpr char DEVICELIB_FUNC_PREFIX[] = "__devicelib_";
 
+using namespace llvm;
+
 namespace {
 // Please update SDLMap if any item is added to or removed from
 // fallback device libraries in libdevice.

--- a/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.cpp
+++ b/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.cpp
@@ -18,6 +18,9 @@
 #include "llvm/ADT/Triple.h"
 #include "llvm/IR/Module.h"
 
+#include <string>
+#include <unordered_map>
+
 static constexpr char DEVICELIB_FUNC_PREFIX[] = "__devicelib_";
 
 using namespace llvm;

--- a/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.h
+++ b/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.h
@@ -19,8 +19,6 @@
 #include "llvm/Pass.h"
 
 #include <cstdint>
-#include <string>
-#include <unordered_map>
 
 namespace llvm {
 

--- a/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.h
+++ b/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.h
@@ -17,8 +17,12 @@
 #pragma once
 
 #include "llvm/Pass.h"
+
+#include <cstdint>
+#include <string>
 #include <unordered_map>
-using namespace llvm;
+
+namespace llvm {
 
 // DeviceLibExt is shared between sycl-post-link tool and sycl runtime.
 // If any change is made here, need to sync with DeviceLibExt definition
@@ -33,6 +37,7 @@ enum class DeviceLibExt : std::uint32_t {
 };
 
 using SYCLDeviceLibFuncMap = std::unordered_map<std::string, DeviceLibExt>;
+
 class SYCLDeviceLibReqMaskPass : public ModulePass {
 public:
   static char ID;
@@ -43,3 +48,5 @@ public:
 private:
   uint32_t MReqMask;
 };
+
+} // namespace llvm

--- a/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.h
+++ b/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.h
@@ -36,8 +36,6 @@ enum class DeviceLibExt : std::uint32_t {
   cl_intel_devicelib_cstring,
 };
 
-using SYCLDeviceLibFuncMap = std::unordered_map<std::string, DeviceLibExt>;
-
 class SYCLDeviceLibReqMaskPass : public ModulePass {
 public:
   static char ID;

--- a/llvm/tools/sycl-post-link/SpecConstants.cpp
+++ b/llvm/tools/sycl-post-link/SpecConstants.cpp
@@ -783,7 +783,7 @@ PreservedAnalyses SpecConstantsPass::run(Module &M,
   return IRModified ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }
 
-bool SpecConstantsPass::collectSpecConstantMetadata(Module &M,
+bool SpecConstantsPass::collectSpecConstantMetadata(const Module &M,
                                                     SpecIDMapTy &IDMap) {
   NamedMDNode *MD = M.getNamedMetadata(SPEC_CONST_MD_STRING);
   if (!MD)
@@ -814,7 +814,7 @@ bool SpecConstantsPass::collectSpecConstantMetadata(Module &M,
 }
 
 bool SpecConstantsPass::collectSpecConstantDefaultValuesMetadata(
-    Module &M, std::vector<char> &DefaultValues) {
+    const Module &M, std::vector<char> &DefaultValues) {
   NamedMDNode *N = M.getNamedMetadata(SPEC_CONST_DEFAULT_VAL_MD_STRING);
   if (!N)
     return false;

--- a/llvm/tools/sycl-post-link/SpecConstants.h
+++ b/llvm/tools/sycl-post-link/SpecConstants.h
@@ -54,7 +54,7 @@ public:
   // - if true, it is lowered to SPIRV intrinsic which retrieves constant value
   // - if false, it is replaced with C++ default (used for AOT compilers)
   SpecConstantsPass(bool SetValAtRT = true) : SetValAtRT(SetValAtRT) {}
-  PreservedAnalyses run(Module &M, llvm::ModuleAnalysisManager &MAM);
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
 
   // Searches given module for occurrences of specialization constant-specific
   // metadata and builds "spec constant name" -> vector<"spec constant int ID">

--- a/llvm/tools/sycl-post-link/SpecConstants.h
+++ b/llvm/tools/sycl-post-link/SpecConstants.h
@@ -46,25 +46,24 @@ struct SpecConstantDescriptor {
   unsigned Size;
 };
 using SpecIDMapTy =
-    llvm::MapVector<llvm::StringRef, std::vector<SpecConstantDescriptor>>;
+    MapVector<StringRef, std::vector<SpecConstantDescriptor>>;
 
-class SpecConstantsPass : public llvm::PassInfoMixin<SpecConstantsPass> {
+class SpecConstantsPass : public PassInfoMixin<SpecConstantsPass> {
 public:
   // SetValAtRT parameter controls spec constant lowering mode:
   // - if true, it is lowered to SPIRV intrinsic which retrieves constant value
   // - if false, it is replaced with C++ default (used for AOT compilers)
   SpecConstantsPass(bool SetValAtRT = true) : SetValAtRT(SetValAtRT) {}
-  llvm::PreservedAnalyses run(llvm::Module &M,
-                              llvm::ModuleAnalysisManager &MAM);
+  PreservedAnalyses run(Module &M, llvm::ModuleAnalysisManager &MAM);
 
   // Searches given module for occurrences of specialization constant-specific
   // metadata and builds "spec constant name" -> vector<"spec constant int ID">
   // map
-  static bool collectSpecConstantMetadata(llvm::Module &M, SpecIDMapTy &IDMap);
+  static bool collectSpecConstantMetadata(const Module &M, SpecIDMapTy &IDMap);
   // Searches given module for occurrences of specialization constant-specific
   // metadata and builds vector of default values for every spec constant.
   static bool
-  collectSpecConstantDefaultValuesMetadata(llvm::Module &M,
+  collectSpecConstantDefaultValuesMetadata(const Module &M,
                                            std::vector<char> &DefaultValues);
 
 private:

--- a/llvm/tools/sycl-post-link/SpecConstants.h
+++ b/llvm/tools/sycl-post-link/SpecConstants.h
@@ -19,7 +19,6 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/PassManager.h"
 
-#include <map>
 #include <vector>
 
 namespace llvm {

--- a/llvm/tools/sycl-post-link/SpecConstants.h
+++ b/llvm/tools/sycl-post-link/SpecConstants.h
@@ -22,8 +22,8 @@
 #include <vector>
 
 namespace llvm {
+
 class StringRef;
-}
 
 // Represents either an element of a composite specialization constant or a
 // single scalar specialization constant - at SYCL RT level composite
@@ -70,3 +70,5 @@ public:
 private:
   bool SetValAtRT;
 };
+
+} // namespace llvm

--- a/llvm/tools/sycl-post-link/SpecConstants.h
+++ b/llvm/tools/sycl-post-link/SpecConstants.h
@@ -45,8 +45,8 @@ struct SpecConstantDescriptor {
   // Encodes size of scalar specialization constant.
   unsigned Size;
 };
-using SpecIDMapTy =
-    MapVector<StringRef, std::vector<SpecConstantDescriptor>>;
+
+using SpecIDMapTy = MapVector<StringRef, std::vector<SpecConstantDescriptor>>;
 
 class SpecConstantsPass : public PassInfoMixin<SpecConstantsPass> {
 public:


### PR DESCRIPTION
Currently the SYCLDeviceLibReqMask and SpecConstantsPass classes are declared
inside the global namespace. To make them aligned with all the other declarations
used in the sycl-post-link tool, the passes and their dependencies have been moved
into the llvm namespace.