### PR TITLE
[SYCL] Make sure [AMDGPU|NVPTX]CodeGen links in lower SYCL IR passes

### DIFF
--- a/llvm/lib/Target/AMDGPU/CMakeLists.txt
+++ b/llvm/lib/Target/AMDGPU/CMakeLists.txt
@@ -176,6 +176,7 @@ add_llvm_target(AMDGPUCodeGen
   GlobalISel
   BinaryFormat
   MIRParser
+  SYCLLowerIR
 
   ADD_TO_COMPONENT
   AMDGPU

--- a/llvm/lib/Target/NVPTX/CMakeLists.txt
+++ b/llvm/lib/Target/NVPTX/CMakeLists.txt
@@ -58,6 +58,7 @@ add_llvm_target(NVPTXCodeGen
   TransformUtils
   Vectorize
   Passes
+  SYCLLowerIR
 
   ADD_TO_COMPONENT
   NVPTX


### PR DESCRIPTION
Fixes undefined references to `llvm::initializeLocalAccessorToSharedMemoryPass` when creating shared libraries for AMDGPU and NVPTX codegen.