### PR TITLE
[SYCL][AMDGCN] Fix up and down shuffles and reductions

### DIFF
--- a/libclc/amdgcn-amdhsa/libspirv/group/collectives.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/group/collectives.cl
@@ -42,8 +42,8 @@ __clc__get_group_scratch_double() __asm("__clc__get_group_scratch_double");
   _CLC_DECL TYPE _Z28__spirv_SubgroupShuffleINTELI##TYPE_MANGLED##ET_S0_j(     \
       TYPE, int);                                                              \
   _CLC_DECL TYPE                                                               \
-      _Z30__spirv_SubgroupShuffleUpINTELI##TYPE_MANGLED##ET_S0_S0_j(TYPE,      \
-                                                                    int);
+      _Z30__spirv_SubgroupShuffleUpINTELI##TYPE_MANGLED##ET_S0_S0_j(           \
+          TYPE, TYPE, unsigned int);
 
 __CLC_DECLARE_SHUFFLES(char, a);
 __CLC_DECLARE_SHUFFLES(unsigned char, h);
@@ -72,7 +72,8 @@ __CLC_DECLARE_SHUFFLES(double, d);
   /* Can't use XOR/butterfly shuffles; some lanes may be inactive */           \
   for (int o = 1; o < __spirv_SubgroupMaxSize(); o *= 2) {                     \
     TYPE contribution =                                                        \
-        _Z28__spirv_SubgroupShuffleINTELI##TYPE_MANGLED##ET_S0_j(x, o);        \
+        _Z30__spirv_SubgroupShuffleUpINTELI##TYPE_MANGLED##ET_S0_S0_j(x, x,    \
+                                                                      o);      \
     bool inactive = (sg_lid < o);                                              \
     contribution = (inactive) ? IDENTITY : contribution;                       \
     x = OP(x, contribution);                                                   \
@@ -90,8 +91,8 @@ __CLC_DECLARE_SHUFFLES(double, d);
   } /* For ExclusiveScan, shift and prepend identity */                        \
   else if (op == ExclusiveScan) {                                              \
     *carry = x;                                                                \
-    result =                                                                   \
-        _Z30__spirv_SubgroupShuffleUpINTELI##TYPE_MANGLED##ET_S0_S0_j(x, 1);   \
+    result = _Z30__spirv_SubgroupShuffleUpINTELI##TYPE_MANGLED##ET_S0_S0_j(    \
+        x, x, 1);                                                              \
     if (sg_lid == 0) {                                                         \
       result = IDENTITY;                                                       \
     }                                                                          \

--- a/libclc/amdgcn-amdhsa/libspirv/workitem/get_max_sub_group_size.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/workitem/get_max_sub_group_size.cl
@@ -17,7 +17,6 @@ extern constant unsigned char __oclc_wavefrontsize64;
 _CLC_DEF _CLC_OVERLOAD uint __spirv_SubgroupMaxSize() {
   if (__oclc_wavefrontsize64 == 1) {
     return 64;
-  } else {
-    return 32;
   }
+  return 32;
 }

--- a/libclc/amdgcn-amdhsa/libspirv/workitem/get_max_sub_group_size.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/workitem/get_max_sub_group_size.cl
@@ -8,21 +8,16 @@
 
 #include <spirv/spirv.h>
 
-// FIXME: Remove the following workaround once the clang change is released.
-// This is for backward compatibility with older clang which does not define
-// __AMDGCN_WAVEFRONT_SIZE. It does not consider -mwavefrontsize64.
-// See:
-// https://github.com/intel/llvm/blob/sycl/clang/lib/Basic/Targets/AMDGPU.h#L414
-// and:
-// https://github.com/intel/llvm/blob/sycl/clang/lib/Basic/Targets/AMDGPU.cpp#L421
-#ifndef __AMDGCN_WAVEFRONT_SIZE
-#if __gfx1010__ || __gfx1011__ || __gfx1012__ || __gfx1030__ || __gfx1031__
-#define __AMDGCN_WAVEFRONT_SIZE 32
-#else
-#define __AMDGCN_WAVEFRONT_SIZE 64
-#endif
-#endif
+// The clang driver will define this variable depending on the architecture and
+// compile flags by linking in ROCm bitcode defining it to true or false. If
+// it's 1 the wavefront size used is 64, if it's 0 the wavefront size used is
+// 32.
+extern constant unsigned char __oclc_wavefrontsize64;
 
 _CLC_DEF _CLC_OVERLOAD uint __spirv_SubgroupMaxSize() {
-  return __AMDGCN_WAVEFRONT_SIZE;
+  if (__oclc_wavefrontsize64 == 1) {
+    return 64;
+  } else {
+    return 32;
+  }
 }


### PR DESCRIPTION
This patch fixes the group collective implementation for AMDGCN, which
had two main issues, in one place it was calling a regular `shuffle`
instead of a `shuffleUp` which ended up breaking the reduction
algorithm. In addition it was also not using the correct interface for
the SPIR-V `shuffleUp` function.

Which leads to the second part of this patch which fixes the `shuffleUp`
and `shuffleDown` functions, mostly for the AMDGCN built-ins but also in
the SYCL header, as the SYCL built-ins were not implemented properly on
top of the SPIR-V built-ins.

At the SYCL level, the `shuffleUp` and `shuffleDown` built-ins take a
value to participate in the shuffle and a delta. The delta is used to
compute which thread to take the value from during the shuffle
operation. For `shuffleUp` it will be substracted from the thread id,
and for `shuffleDown` it will be added.  And so in SYCL this delta must
be defined such as `subgroup_local_id - delta` falls within `[0,
subgroup_local_size[` for `shuffleUp`, and `subgroup_local_id + delta`
falls within `[0, subgroup_local_size[` for `shuffleDown`.

However in SPIR-V, these built-ins are a bit more complicated and take
two values to participate in the shuffle and support twice the delta
range as the SYCL built-ins. For example for `shuffleUp` the valid range
for `subgroup_local_id - delta` is `[-subgroup_local_size,
subgroup_local_size[` and in this instance if it falls within
`[-subgroup_local_size, 0[` the first value will be used to participate
in the shuffle, and if it falls within `[0, subgroup_local_size[` the
second value will be used to participate in the shuffle. And it works in
a similar way for `shuffleDown`.

And so when implementing the SYCL built-ins using the SPIR-V built-ins,
only half of the range can be used in a properly defined way, which
means only one of the value parameters of the SPIR-V built-ins actually
matters. Therefore the SYCL built-ins are implemented passing in the
same value to both value parameters of the SPIR-V built-ins.

The complete definition of the SPIR-V built-ins can be found here:

* https://github.com/KhronosGroup/SPIRV-Registry/blob/main/extensions/INTEL/SPV_INTEL_subgroups.asciidoc#instructions