### PR TITLE
[SYCL] Resolve namespace ambiguity in this_id, this_item, and this_group

### DIFF
--- a/sycl/include/CL/sycl/group.hpp
+++ b/sycl/include/CL/sycl/group.hpp
@@ -439,7 +439,8 @@ namespace oneapi {
 namespace experimental {
 template <int Dims> group<Dims> this_group() {
 #ifdef __SYCL_DEVICE_ONLY__
-  return sycl::detail::Builder::getElement(detail::declptr<group<Dims>>());
+  return sycl::detail::Builder::getElement(
+      sycl::detail::declptr<group<Dims>>());
 #else
   throw sycl::exception(
       sycl::make_error_code(sycl::errc::feature_not_supported),

--- a/sycl/include/CL/sycl/id.hpp
+++ b/sycl/include/CL/sycl/id.hpp
@@ -360,7 +360,7 @@ namespace oneapi {
 namespace experimental {
 template <int Dims> id<Dims> this_id() {
 #ifdef __SYCL_DEVICE_ONLY__
-  return sycl::detail::Builder::getElement(detail::declptr<id<Dims>>());
+  return sycl::detail::Builder::getElement(sycl::detail::declptr<id<Dims>>());
 #else
   throw sycl::exception(
       sycl::make_error_code(sycl::errc::feature_not_supported),

--- a/sycl/include/CL/sycl/item.hpp
+++ b/sycl/include/CL/sycl/item.hpp
@@ -150,7 +150,7 @@ namespace oneapi {
 namespace experimental {
 template <int Dims> item<Dims> this_item() {
 #ifdef __SYCL_DEVICE_ONLY__
-  return sycl::detail::Builder::getElement(detail::declptr<item<Dims>>());
+  return sycl::detail::Builder::getElement(sycl::detail::declptr<item<Dims>>());
 #else
   throw sycl::exception(
       sycl::make_error_code(sycl::errc::feature_not_supported),


### PR DESCRIPTION
Since the `detail` namespace appears in both the `sycl` namespace and in the `sycl::ext::oneapi::experimental` namespace, the implementation of `sycl::ext::oneapi::experimental::this_id`, `sycl::ext::oneapi::experimental::this_item`, and `sycl::ext::oneapi::experimental::this_group`  may fail due to `detail::declptr` not existing in the latter. These changes remove the ambiguity.