### PR TITLE
[SYCL] Workaround bugs in Level Zero driver

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -3900,7 +3900,7 @@ pi_result piProgramLink(pi_context Context, pi_uint32 NumDevices,
     ZeModuleDesc.pNext = &ZeExtModuleDesc;
     ZeModuleDesc.format = ZE_MODULE_FORMAT_IL_SPIRV;
 
-    // This works around a bug in the Level Zero driver.  When "ZEBUG=-1", the
+    // This works around a bug in the Level Zero driver.  When "ZE_DEBUG=-1", the
     // driver does validation of the API calls, and it expects "pInputModule"
     // to be non-NULL and "inputSize" to be non-zero.  This validation is wrong
     // when using the "ze_module_program_exp_desc_t" extension because those

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -3900,12 +3900,12 @@ pi_result piProgramLink(pi_context Context, pi_uint32 NumDevices,
     ZeModuleDesc.pNext = &ZeExtModuleDesc;
     ZeModuleDesc.format = ZE_MODULE_FORMAT_IL_SPIRV;
 
-    // This works around a bug in the Level Zero driver.  When "ZE_DEBUG=-1", the
-    // driver does validation of the API calls, and it expects "pInputModule"
-    // to be non-NULL and "inputSize" to be non-zero.  This validation is wrong
-    // when using the "ze_module_program_exp_desc_t" extension because those
-    // fields are supposed to be ignored.  As a workaround, set both fields
-    // to 1.
+    // This works around a bug in the Level Zero driver.  When "ZE_DEBUG=-1",
+    // the driver does validation of the API calls, and it expects
+    // "pInputModule" to be non-NULL and "inputSize" to be non-zero.  This
+    // validation is wrong when using the "ze_module_program_exp_desc_t"
+    // extension because those fields are supposed to be ignored.  As a
+    // workaround, set both fields to 1.
     //
     // TODO: Remove this workaround when the driver is fixed.
     ZeModuleDesc.pInputModule = reinterpret_cast<const uint8_t *>(1);

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -3900,10 +3900,30 @@ pi_result piProgramLink(pi_context Context, pi_uint32 NumDevices,
     ZeModuleDesc.pNext = &ZeExtModuleDesc;
     ZeModuleDesc.format = ZE_MODULE_FORMAT_IL_SPIRV;
 
+    // This works around a bug in the Level Zero driver.  When "ZEBUG=-1", the
+    // driver does validation of the API calls, and it expects "pInputModule"
+    // to be non-NULL and "inputSize" to be non-zero.  This validation is wrong
+    // when using the "ze_module_program_exp_desc_t" extension because those
+    // fields are supposed to be ignored.  As a workaround, set both fields
+    // to 1.
+    //
+    // TODO: Remove this workaround when the driver is fixed.
+    ZeModuleDesc.pInputModule = reinterpret_cast<const uint8_t *>(1);
+    ZeModuleDesc.inputSize = 1;
+
     // We need a Level Zero extension to compile multiple programs together into
     // a single Level Zero module.  However, we don't need that extension if
     // there happens to be only one input program.
-    if (!PiDriverModuleProgramExtensionFound) {
+    //
+    // The "|| (NumInputPrograms == 1)" term is a workaround for a bug in the
+    // Level Zero driver.  The driver's "ze_module_program_exp_desc_t"
+    // extension should work even in the case when there is just one input
+    // module.  However, there is currently a bug in the driver that leads to a
+    // crash.  As a workaround, do not use the extension when there is one
+    // input module.
+    //
+    // TODO: Remove this workaround when the driver is fixed.
+    if (!PiDriverModuleProgramExtensionFound || (NumInputPrograms == 1)) {
       if (NumInputPrograms == 1) {
         ZeModuleDesc.pNext = nullptr;
         ZeModuleDesc.inputSize = ZeExtModuleDesc.inputSizes[0];


### PR DESCRIPTION
Work around two bugs in the Level Zero driver, related to the
"ze_module_program_exp_desc_t" extension (aka "static linking").