### PR TITLE
[LIBCLC][AMDGCN] Fix get_max_sub_group_size

### DIFF
--- a/libclc/amdgcn-amdhsa/libspirv/workitem/get_max_sub_group_size.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/workitem/get_max_sub_group_size.cl
@@ -17,7 +17,6 @@ extern constant unsigned char __oclc_wavefrontsize64;
 _CLC_DEF _CLC_OVERLOAD uint __spirv_SubgroupMaxSize() {
   if (__oclc_wavefrontsize64 == 1) {
     return 64;
-  } else {
-    return 32;
   }
+  return 32;
 }

--- a/libclc/amdgcn-amdhsa/libspirv/workitem/get_max_sub_group_size.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/workitem/get_max_sub_group_size.cl
@@ -8,21 +8,16 @@
 
 #include <spirv/spirv.h>
 
-// FIXME: Remove the following workaround once the clang change is released.
-// This is for backward compatibility with older clang which does not define
-// __AMDGCN_WAVEFRONT_SIZE. It does not consider -mwavefrontsize64.
-// See:
-// https://github.com/intel/llvm/blob/sycl/clang/lib/Basic/Targets/AMDGPU.h#L414
-// and:
-// https://github.com/intel/llvm/blob/sycl/clang/lib/Basic/Targets/AMDGPU.cpp#L421
-#ifndef __AMDGCN_WAVEFRONT_SIZE
-#if __gfx1010__ || __gfx1011__ || __gfx1012__ || __gfx1030__ || __gfx1031__
-#define __AMDGCN_WAVEFRONT_SIZE 32
-#else
-#define __AMDGCN_WAVEFRONT_SIZE 64
-#endif
-#endif
+// The clang driver will define this variable depending on the architecture and
+// compile flags by linking in ROCm bitcode defining it to true or false. If
+// it's 1 the wavefront size used is 64, if it's 0 the wavefront size used is
+// 32.
+extern constant unsigned char __oclc_wavefrontsize64;
 
 _CLC_DEF _CLC_OVERLOAD uint __spirv_SubgroupMaxSize() {
-  return __AMDGCN_WAVEFRONT_SIZE;
+  if (__oclc_wavefrontsize64 == 1) {
+    return 64;
+  } else {
+    return 32;
+  }
 }


### PR DESCRIPTION
Using defines to figure out the wavefront size there is incorrect
because libclc is not built for a specific amdgcn version, so it will
always default to `64`.

Instead use the `__oclc_wavefront64` global variable provided by ROCm,
which will be set to a different value depending on the architecture.

This may fix some of the discrepancies between tests being run on `gfx908` and the tests running on the CI, as the CI hardware uses a wavefront of 32 which mismatches with what was returned by this function, and that this function is used in the implementation of the group collectives.

And so it may fix:
* https://github.com/intel/llvm-test-suite/pull/740
and potentially the discrepancies I was seeing on:
* https://github.com/intel/llvm/pull/5359
