### PR TITLE
[SYCL] Make the device default ctor SYCL 2020 conformant

### DIFF
--- a/sycl/include/CL/sycl/device.hpp
+++ b/sycl/include/CL/sycl/device.hpp
@@ -34,7 +34,8 @@ auto getDeviceComparisonLambda();
 /// \ingroup sycl_api
 class __SYCL_EXPORT device {
 public:
-  /// Constructs a SYCL device instance as a host device.
+  /// Constructs a SYCL device instance that is a copy of the device returned
+  /// from default_selector instance
   device();
 
   /// Constructs a SYCL device instance from an OpenCL cl_device_id

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -29,7 +29,7 @@ void force_type(info::device_type &t, const info::device_type &ft) {
 }
 } // namespace detail
 
-device::device() : impl(detail::device_impl::getHostDeviceImpl()) {}
+device::device() { *this = default_selector{}.select_device(); }
 
 device::device(cl_device_id DeviceId) {
   // The implementation constructor takes ownership of the native handle so we


### PR DESCRIPTION
This patch changes the behaviour of `sycl::device::device()` ctor.

SYCL 1.2.1: Constructs a SYCL `device` instance as a host device
SYCL 2020: Constructs a SYCL `device` instance that is a copy of the
device returned by `default_selector_v`.

Note: SYCL 2020 predefined device selectors are not implemented yet, so
use SYCL 1.2.1 device selectors such as `default_selector`