### PR TITLE
[SYCL] Add complex support to group algorithms

### DIFF
--- a/sycl/include/CL/sycl/feature_test.hpp.in
+++ b/sycl/include/CL/sycl/feature_test.hpp.in
@@ -5,6 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 // ===--------------------------------------------------------------------=== //
+
+//
+// IMPORTANT:  feature_test.hpp is a generated file - DO NOT EDIT
+//             original definitions are in feature_test.hpp.in
+//
+
 #pragma once
 
 #include <CL/sycl/detail/defines_elementary.hpp>
@@ -35,6 +41,7 @@ namespace sycl {
 #define SYCL_EXT_ONEAPI_MATRIX 2
 #endif
 #define SYCL_EXT_ONEAPI_ASSERT 1
+#define SYCL_EXT_ONEAPI_COMPLEX_ALGORITHMS 1
 #define SYCL_EXT_ONEAPI_DISCARD_QUEUE_EVENTS 1
 #define SYCL_EXT_ONEAPI_ENQUEUE_BARRIER 1
 #define SYCL_EXT_ONEAPI_FREE_FUNCTION_QUERIES 1

--- a/sycl/include/CL/sycl/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/group_algorithm.hpp
@@ -152,11 +152,7 @@ reduce_over_group(Group, T x, BinaryOperation binary_op) {
 #endif
 }
 
-
-
-// CANONICAL CALL: std::complex<T> res = sycl::reduce_over_group(item.get_group(),val,std::plus<std::complex<T>>());
-
-// complex specializaion. T is std::complex<float> or similar.
+// complex specialization. T is std::complex<float> or similar.
 //   binary op is  sycl::plus<std::complex<float>>
 template <typename Group, typename T>
 detail::enable_if_t<(is_group_v<std::decay_t<Group>> &&
@@ -165,10 +161,7 @@ detail::enable_if_t<(is_group_v<std::decay_t<Group>> &&
                     T>
 reduce_over_group(Group g, T x, sycl::plus<T> binary_op) {
 #ifdef __SYCL_DEVICE_ONLY__
-  // return sycl::detail::calc<T, __spv::GroupOperation::Reduce,
-  //                           sycl::detail::spirv::group_scope<Group>::value>(
-  //     typename sycl::detail::GroupOpTag<T>::type(), x, binary_op);
-  T result; //
+  T result;
   result.real(reduce_over_group(g, x.real(), sycl::plus<>()));
   result.imag(reduce_over_group(g, x.imag(), sycl::plus<>()));
   return result;
@@ -254,7 +247,6 @@ reduce_over_group(Group g, V x, T init, BinaryOperation binary_op) {
 
 // ---- joint_reduce
 //    specialized for is_arithmetic (both scalar and vector) and complex
-//    (limited to sycl::plus)
 template <typename Group, typename Ptr, class BinaryOperation>
 detail::enable_if_t<
     (is_group_v<std::decay_t<Group>> && detail::is_pointer<Ptr>::value &&

--- a/sycl/include/CL/sycl/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/group_algorithm.hpp
@@ -870,7 +870,7 @@ inclusive_scan_over_group(Group g, T x, BinaryOperation binary_op) {
 #endif
 }
 
-// four argument version of exclusive_scan_over_group is specialized twice
+// four argument version of inclusive_scan_over_group is specialized twice
 // once for (scalar_arithmetic || complex) and once for vector_arithmetic
 template <typename Group, typename V, class BinaryOperation, typename T>
 detail::enable_if_t<

--- a/sycl/include/CL/sycl/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/group_algorithm.hpp
@@ -166,6 +166,9 @@ reduce_over_group(Group g, T x, sycl::plus<T> binary_op) {
   result.imag(reduce_over_group(g, x.imag(), sycl::plus<>()));
   return result;
 #else
+  (void)g;
+  (void)x;
+  (void)binary_op;
   throw runtime_error("Group algorithms are not supported on host device.",
                       PI_INVALID_DEVICE);
 #endif
@@ -259,6 +262,7 @@ joint_reduce(Group g, Ptr first, Ptr last, BinaryOperation binary_op) {
   return joint_reduce(g, first, last, init, binary_op);
 #else
   (void)g;
+  (void)first;
   (void)last;
   (void)binary_op;
   throw runtime_error("Group algorithms are not supported on host device.",
@@ -312,6 +316,7 @@ joint_reduce(Group g, Ptr first, Ptr last,
   return joint_reduce(g, first, last, init, binary_op);
 #else
   (void)g;
+  (void)first;
   (void)last;
   (void)binary_op;
   throw runtime_error("Group algorithms are not supported on host device.",
@@ -338,7 +343,10 @@ joint_reduce(Group g, Ptr first, Ptr last, T init, sycl::plus<T> binary_op) {
   return reduce_over_group(g, partial, init, binary_op);
 #else
   (void)g;
+  (void)first;
   (void)last;
+  (void)init;
+  (void)binary_op;
   throw runtime_error("Group algorithms are not supported on host device.",
                       PI_INVALID_DEVICE);
 #endif
@@ -627,6 +635,9 @@ exclusive_scan_over_group(Group g, T x, sycl::plus<T> binary_op) {
   result.imag(exclusive_scan_over_group(g, x.imag(), sycl::plus<>()));
   return result;
 #else
+  (void)g;
+  (void)x;
+  (void)binary_op;
   throw runtime_error("Group algorithms are not supported on host device.",
                       PI_INVALID_DEVICE);
 #endif
@@ -833,9 +844,11 @@ joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, T init,
   return result + N;
 #else
   (void)g;
+  (void)first;
   (void)last;
   (void)result;
   (void)init;
+  (void)binary_op;
   throw runtime_error("Group algorithms are not supported on host device.",
                       PI_INVALID_DEVICE);
 #endif
@@ -916,6 +929,9 @@ inclusive_scan_over_group(Group g, T x, BinaryOperation binary_op) {
   result.imag(inclusive_scan_over_group(g, x.imag(), sycl::plus<>()));
   return result;
 #else
+  (void)g;
+  (void)x;
+  (void)binary_op;
   throw runtime_error("Group algorithms are not supported on host device.",
                       PI_INVALID_DEVICE);
 #endif
@@ -1093,8 +1109,11 @@ joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
   return result + N;
 #else
   (void)g;
+  (void)first;
   (void)last;
   (void)result;
+  (void)binary_op;
+  (void)init;
   throw runtime_error("Group algorithms are not supported on host device.",
                       PI_INVALID_DEVICE);
 #endif

--- a/sycl/include/CL/sycl/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/group_algorithm.hpp
@@ -22,8 +22,6 @@
 #include <sycl/ext/oneapi/experimental/group_sort.hpp>
 #include <sycl/ext/oneapi/functional.hpp>
 
-#define SYCL_EXT_ONEAPI_COMPLEX_ALGORITHMS 1
-
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {

--- a/sycl/include/CL/sycl/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/group_algorithm.hpp
@@ -104,15 +104,16 @@ template <typename T, typename BinaryOperation> struct is_native_op {
 // ---- is_complex
 template <typename T>
 struct is_complex
-    : std::bool_constant<std::is_same_v<T, std::complex<float>> ||
-                         std::is_same_v<T, std::complex<double>> ||
-                         std::is_same_v<T, std::complex<long double>>> {};
+    : std::integral_constant<
+          bool, std::is_same<T, std::complex<float>>::value ||
+                    std::is_same<T, std::complex<double>>::value ||
+                    std::is_same<T, std::complex<long double>>::value> {};
 
 // ---- is_arithmetic_or_complex
 template <typename T>
 using is_arithmetic_or_complex =
-    std::bool_constant<sycl::detail::is_complex<T>::value ||
-                       sycl::detail::is_arithmetic<T>::value>;
+    std::integral_constant<bool, sycl::detail::is_complex<T>::value ||
+                                     sycl::detail::is_arithmetic<T>::value>;
 
 // ---- identity_for_ga_op
 //   the group algorithms support std::complex, limited to sycl::plus operation

--- a/sycl/include/CL/sycl/group_algorithm.hpp
+++ b/sycl/include/CL/sycl/group_algorithm.hpp
@@ -129,6 +129,8 @@ using is_plus_if_complex =
 // ---- identity_for_ga_op
 //   the group algorithms support std::complex, limited to sycl::plus operation
 //   get the correct identity for group algorithm operation.
+// TODO: identiy_for_ga_op should be replaced with known_identity once the other
+// callers of known_identity support complex numbers.
 template <typename T, class BinaryOperation>
 constexpr detail::enable_if_t<
     (is_complex<T>::value && is_plus<T, BinaryOperation>::value), T>


### PR DESCRIPTION
Many of the group algorithms already support std::complex data types, but not all. There is a new extension that defines their expanded use in the reduce and scan group algorithms.  ( [here](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/ComplexAlgorithms/ComplexAlgorithms.asciidoc) ).   This PR implements that new extension. 

Tests have been updated here: https://github.com/intel/llvm-test-suite/pull/767