### PR TITLE
[SYCL] Add DFS to event_impl destructor

### DIFF
--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -44,8 +44,58 @@ cl_event event_impl::get() const {
   getPlugin().call<PiApiKind::piEventRetain>(MEvent);
   return pi::cast<cl_event>(MEvent);
 }
+class DepIter {
+public:
+  DepIter(event_impl *event) : CurrentEvent(event), Idx(0) {
+    DepsSize = CurrentEvent->MPreparedDepsEvents.size() +
+               CurrentEvent->MPreparedHostDepsEvents.size();
+  }
+
+  void operator++() { ++Idx; }
+  std::shared_ptr<event_impl> &operator*() {
+    assert(Idx < DepsSize);
+    auto size = CurrentEvent->MPreparedDepsEvents.size();
+    if (Idx < size)
+      return CurrentEvent->MPreparedDepsEvents[Idx];
+    else
+      return CurrentEvent->MPreparedHostDepsEvents[Idx - size];
+  }
+
+  bool is_end() { return Idx >= DepsSize; }
+
+private:
+  event_impl *CurrentEvent;
+  size_t Idx, DepsSize;
+};
 
 event_impl::~event_impl() {
+  {
+    std::deque<DepIter> Q;
+
+    if (MPreparedDepsEvents.size() > 0 || MPreparedHostDepsEvents.size() > 0) {
+      Q.emplace_back(this);
+    }
+
+    while (Q.size() > 0) {
+      while (!Q.back().is_end()) {
+        if (*Q.back()) {
+          Q.emplace_back((*Q.back()).get());
+        } else {
+          ++Q.back();
+        }
+      }
+
+      Q.pop_back();
+      if (Q.size() > 0) {
+        (*Q.back()).get()->MPreparedDepsEvents.clear();
+        (*Q.back()).get()->MPreparedHostDepsEvents.clear();
+        (*Q.back()).reset();
+        ++Q.back();
+      }
+    }
+    MPreparedDepsEvents.clear();
+    MPreparedHostDepsEvents.clear();
+  }
   if (MEvent)
     getPlugin().call<PiApiKind::piEventRelease>(MEvent);
 }

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -243,6 +243,7 @@ private:
   bool MNeedsCleanupAfterWait = false;
 
   std::mutex MMutex;
+  friend class DepIter;
 };
 
 } // namespace detail


### PR DESCRIPTION
Destruction of event_impl dependencies in some cases leads to stack overflow. Add DFS to the event_impl destructor to eliminate this problem.
Signed-off-by: mdimakov <maxim.dimakov@intel.com>