### PR TITLE
[SYCL] Destroy event_impl dependencies in command class destructor

### DIFF
--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -188,9 +188,7 @@ public:
     return nullptr;
   }
 
-  virtual ~Command() {
-    MEvent->cleanupDependencyEvents();
-  }
+  virtual ~Command() { MEvent->cleanupDependencyEvents(); }
 
   const char *getBlockReason() const;
 

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -19,6 +19,7 @@
 #include <CL/sycl/access/access.hpp>
 #include <CL/sycl/detail/accessor_impl.hpp>
 #include <CL/sycl/detail/cg.hpp>
+#include <detail/event_impl.hpp>
 #include <detail/program_manager/program_manager.hpp>
 
 __SYCL_INLINE_NAMESPACE(cl) {
@@ -187,7 +188,9 @@ public:
     return nullptr;
   }
 
-  virtual ~Command() = default;
+  virtual ~Command() {
+    MEvent->cleanupDependencyEvents();
+  }
 
   const char *getBlockReason() const;
 

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -129,7 +129,6 @@ static void handleVisitedNodes(std::vector<Command *> &Visited) {
   for (Command *Cmd : Visited) {
     if (Cmd->MMarks.MToBeDeleted) {
       Cmd->getEvent()->setCommand(nullptr);
-      Cmd->getEvent()->cleanupDependencyEvents();
       delete Cmd;
     } else
       Cmd->MMarks.MVisited = false;
@@ -1187,7 +1186,6 @@ void Scheduler::GraphBuilder::cleanupCommand(Command *Cmd) {
   }
 
   Cmd->getEvent()->setCommand(nullptr);
-  Cmd->getEvent()->cleanupDependencyEvents();
   delete Cmd;
 }
 


### PR DESCRIPTION
Move destroying of dependencies to command destructor.
Signed-off-by: mdimakov <maxim.dimakov@intel.com>