### PR TITLE
[SYCL] Change clang toolchain local accessor check

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5791,7 +5791,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   // Enable local accessor to shared memory pass for SYCL.
-  if (isa<BackendJobAction>(JA) && IsSYCL) {
+  if (isa<BackendJobAction>(JA) && IsSYCLOffloadDevice && (Triple.isNVPTX() ||
+      Triple.isAMDGCN())) {
     CmdArgs.push_back("-mllvm");
     CmdArgs.push_back("-sycl-enable-local-accessor");
   }

--- a/clang/test/Driver/sycl-local-accessor-opt.cpp
+++ b/clang/test/Driver/sycl-local-accessor-opt.cpp
@@ -9,3 +9,7 @@
 // RUN:   %clang -fsycl -fsycl-targets=nvptx64-nvidia-cuda -### %s 2>&1 \
 // RUN:   | FileCheck %s
 // CHECK: "-sycl-enable-local-accessor"
+
+// RUN:   %clang -fsycl -fsycl-targets=nvptx64-nvidia-cuda -S -### %s 2>&1 \
+// RUN:   | FileCheck %s
+// CHECK: "-sycl-enable-local-accessor"


### PR DESCRIPTION
This PR resolves an issue raised in #5149.
It changes the the check from `IsSYCL` to `IsSYCLOffloadDevice` and limits its usage to nvptx and amdgcn.
A new test is added, to prevent regression.