### PR TITLE
[sycl-post-link] Implement the CompileTimePropertiesPass module pass

### DIFF
--- a/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
@@ -70,7 +70,7 @@ attributes #6 = { "sycl-unique-id"="6da74a122db9f35d____ZL7no_dg_int1" "device_i
 
 ; Ensure that the generated metadata nodes are correct
 ; CHECK-IR-DAG: !0 = !{!1, !2, !3}
-; CHECK-IR-DAG: !1 = !{i32 6147, i32 1}
+; CHECK-IR-DAG: !1 = !{i32 6147, i32 1, !"6da74a122db9f35d____ZL7dg_int1"}
 ; CHECK-IR-DAG: !2 = !{i32 6149, i32 1}
 ; CHECK-IR-DAG: !3 = !{i32 6148, i32 0}
 
@@ -79,10 +79,10 @@ attributes #6 = { "sycl-unique-id"="6da74a122db9f35d____ZL7no_dg_int1" "device_i
 ; CHECK-IR-DAG: !6 = !{i32 6148, i32 1}
 
 ; CHECK-IR-DAG: !7 = !{!8, !2, !3}
-; CHECK-IR-DAG: !8 = !{i32 6147, i32 0}
+; CHECK-IR-DAG: !8 = !{i32 6147, i32 0, !"9d329ad59055e972____ZL8dg_bool3"}
 
 ; CHECK-IR-DAG: !9 = !{!10}
-; CHECK-IR-DAG: !10 = !{i32 6147, i32 2}
+; CHECK-IR-DAG: !10 = !{i32 6147, i32 2, !"dda2bad52c45c432____ZL8dg_bool4"}
 
 ; Ensure that the default values are correct.
 ; ABAAAAAAAAABAAAAAxxxxx is decoded to

--- a/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
@@ -17,13 +17,13 @@ target triple = "spir64-unknown-unknown"
 %class.anon.0 = type { i8 }
 
 @_ZL7dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #0
-; CHECK-IR: @_ZL7dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations !0 #0
+; CHECK-IR: @_ZL7dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations ![[#MN0:]] #0
 @_ZL7dg_int2 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #1
-; CHECK-IR: @_ZL7dg_int2 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations !4 #1
+; CHECK-IR: @_ZL7dg_int2 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations ![[#MN4:]] #1
 @_ZL8dg_bool3 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1 #2
-; CHECK-IR: @_ZL8dg_bool3 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1, !spirv.Decorations !7 #2
+; CHECK-IR: @_ZL8dg_bool3 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1, !spirv.Decorations ![[#MN7:]] #2
 @_ZL8dg_bool4 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1 #3
-; CHECK-IR: @_ZL8dg_bool4 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1, !spirv.Decorations !9 #3
+; CHECK-IR: @_ZL8dg_bool4 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1, !spirv.Decorations ![[#MN9:]] #3
 @_ZL7no_dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #6
 ; CHECK-IR-NOT: @_ZL7no_dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 !spirv.Decorations
 
@@ -69,20 +69,20 @@ attributes #6 = { "sycl-unique-id"="6da74a122db9f35d____ZL7no_dg_int1" "device_i
 !5 = !{!"clang version 14.0.0"}
 
 ; Ensure that the generated metadata nodes are correct
-; CHECK-IR-DAG: !0 = !{!1, !2, !3}
-; CHECK-IR-DAG: !1 = !{i32 6147, i32 1, !"6da74a122db9f35d____ZL7dg_int1"}
-; CHECK-IR-DAG: !2 = !{i32 6149, i32 1}
-; CHECK-IR-DAG: !3 = !{i32 6148, i32 0}
+; CHECK-IR-DAG: ![[#MN0]] = !{![[#MN1:]], ![[#MN2:]], ![[#MN3:]]}
+; CHECK-IR-DAG: ![[#MN1]] = !{i32 6147, i32 1, !"6da74a122db9f35d____ZL7dg_int1"}
+; CHECK-IR-DAG: ![[#MN2]] = !{i32 6149, i32 1}
+; CHECK-IR-DAG: ![[#MN3]] = !{i32 6148, i32 0}
 
-; CHECK-IR-DAG: !4 = !{!5, !6}
-; CHECK-IR-DAG: !5 = !{i32 6149, i32 0}
-; CHECK-IR-DAG: !6 = !{i32 6148, i32 1}
+; CHECK-IR-DAG: ![[#MN4]] = !{![[#MN5:]], ![[#MN6:]]}
+; CHECK-IR-DAG: ![[#MN5]] = !{i32 6149, i32 0}
+; CHECK-IR-DAG: ![[#MN6]] = !{i32 6148, i32 1}
 
-; CHECK-IR-DAG: !7 = !{!8, !2, !3}
-; CHECK-IR-DAG: !8 = !{i32 6147, i32 0, !"9d329ad59055e972____ZL8dg_bool3"}
+; CHECK-IR-DAG: ![[#MN7]] = !{![[#MN8:]], ![[#MN2]], ![[#MN3]]}
+; CHECK-IR-DAG: ![[#MN8]] = !{i32 6147, i32 0, !"9d329ad59055e972____ZL8dg_bool3"}
 
-; CHECK-IR-DAG: !9 = !{!10}
-; CHECK-IR-DAG: !10 = !{i32 6147, i32 2, !"dda2bad52c45c432____ZL8dg_bool4"}
+; CHECK-IR-DAG: ![[#MN9]] = !{![[#MN10:]]}
+; CHECK-IR-DAG: ![[#MN10]] = !{i32 6147, i32 2, !"dda2bad52c45c432____ZL8dg_bool4"}
 
 ; Ensure that the default values are correct.
 ; ABAAAAAAAAABAAAAAxxxxx is decoded to

--- a/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
@@ -69,20 +69,20 @@ attributes #6 = { "sycl-unique-id"="6da74a122db9f35d____ZL7no_dg_int1" "device_i
 !5 = !{!"clang version 14.0.0"}
 
 ; Ensure that the generated metadata nodes are correct
-; CHECK-IR:      !0 = !{!1, !2, !3}
-; CHECK-IR-NEXT: !1 = !{i32 6147, i32 1}
-; CHECK-IR-NEXT: !2 = !{i32 6149, i32 1}
-; CHECK-IR-NEXT: !3 = !{i32 6148, i32 0}
+; CHECK-IR-DAG: !0 = !{!1, !2, !3}
+; CHECK-IR-DAG: !1 = !{i32 6147, i32 1}
+; CHECK-IR-DAG: !2 = !{i32 6149, i32 1}
+; CHECK-IR-DAG: !3 = !{i32 6148, i32 0}
 
-; CHECK-IR:      !4 = !{!5, !6}
-; CHECK-IR-NEXT: !5 = !{i32 6149, i32 0}
-; CHECK-IR-NEXT: !6 = !{i32 6148, i32 1}
+; CHECK-IR-DAG: !4 = !{!5, !6}
+; CHECK-IR-DAG: !5 = !{i32 6149, i32 0}
+; CHECK-IR-DAG: !6 = !{i32 6148, i32 1}
 
-; CHECK-IR:      !7 = !{!8, !2, !3}
-; CHECK-IR-NEXT: !8 = !{i32 6147, i32 0}
+; CHECK-IR-DAG: !7 = !{!8, !2, !3}
+; CHECK-IR-DAG: !8 = !{i32 6147, i32 0}
 
-; CHECK-IR:      !9 = !{!10}
-; CHECK-IR-NEXT: !10 = !{i32 6147, i32 2}
+; CHECK-IR-DAG: !9 = !{!10}
+; CHECK-IR-DAG: !10 = !{i32 6147, i32 2}
 
 ; Ensure that the default values are correct.
 ; ABAAAAAAAAABAAAAAxxxxx is decoded to

--- a/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
@@ -17,7 +17,7 @@ target triple = "spir64-unknown-unknown"
 %class.anon.0 = type { i8 }
 
 @_ZL7dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #0
-; CHECK-IR: @_ZL7dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations ![[#MN0:]] #0
+; CHECK-IR: @_ZL7dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations ![[#MN0:]] #[[#ATR0:]]
 @_ZL7dg_int2 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #1
 ; CHECK-IR: @_ZL7dg_int2 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations ![[#MN4:]] #[[#ATR1:]]
 @_ZL8dg_bool3 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1 #2

--- a/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
@@ -52,7 +52,7 @@ attributes #2 = { "sycl-unique-id"="9d329ad59055e972____ZL8dg_bool3" "device_ima
 attributes #3 = { "sycl-unique-id"="dda2bad52c45c432____ZL8dg_bool4" "device_image_scope" "host_access"="2" "sycl-device-global-size"="1" }
 attributes #4 = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
 attributes #5 = { convergent nounwind }
-; no the sycl-device-global-size attribute, this is not a device global variable but it contains compile-time properties,
+; no sycl-device-global-size attribute, this is not a device global variable but it contains compile-time properties,
 ; a metadata node will be generated.
 attributes #6 = { "sycl-unique-id"="6da74a122db9f35d____ZL7no_dg_int1" "device_image_scope"="false" "host_access"="1" "implement_in_csr"="true" "init_mode"="0" }
 

--- a/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
@@ -19,13 +19,13 @@ target triple = "spir64-unknown-unknown"
 @_ZL7dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #0
 ; CHECK-IR: @_ZL7dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations ![[#MN0:]] #0
 @_ZL7dg_int2 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #1
-; CHECK-IR: @_ZL7dg_int2 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations ![[#MN4:]] #1
+; CHECK-IR: @_ZL7dg_int2 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations ![[#MN4:]] #[[#ATR1:]]
 @_ZL8dg_bool3 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1 #2
-; CHECK-IR: @_ZL8dg_bool3 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1, !spirv.Decorations ![[#MN7:]] #2
+; CHECK-IR: @_ZL8dg_bool3 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1, !spirv.Decorations ![[#MN7:]] #[[#ATR2:]]
 @_ZL8dg_bool4 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1 #3
-; CHECK-IR: @_ZL8dg_bool4 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1, !spirv.Decorations ![[#MN9:]] #3
+; CHECK-IR: @_ZL8dg_bool4 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1, !spirv.Decorations ![[#MN9:]] #[[#ATR3:]]
 @_ZL7no_dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #6
-; CHECK-IR-NOT: @_ZL7no_dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 !spirv.Decorations
+; CHECK-IR: @_ZL7no_dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations ![[#MN11:]] #[[#ATR4:]]
 
 define internal spir_func void @_ZZ4mainENKUlvE_clEv(%class.anon.0 addrspace(4)* align 1 dereferenceable_or_null(1) %this) #4 align 2 {
 entry:
@@ -52,7 +52,8 @@ attributes #2 = { "sycl-unique-id"="9d329ad59055e972____ZL8dg_bool3" "device_ima
 attributes #3 = { "sycl-unique-id"="dda2bad52c45c432____ZL8dg_bool4" "device_image_scope" "host_access"="2" "sycl-device-global-size"="1" }
 attributes #4 = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
 attributes #5 = { convergent nounwind }
-; no the sycl-device-global-size attribute, this is not a device global variable
+; no the sycl-device-global-size attribute, this is not a device global variable but it contains compile-time properties,
+; a metadata node will be generated.
 attributes #6 = { "sycl-unique-id"="6da74a122db9f35d____ZL7no_dg_int1" "device_image_scope"="false" "host_access"="1" "implement_in_csr"="true" "init_mode"="0" }
 
 !llvm.dependent-libraries = !{!0}
@@ -70,19 +71,22 @@ attributes #6 = { "sycl-unique-id"="6da74a122db9f35d____ZL7no_dg_int1" "device_i
 
 ; Ensure that the generated metadata nodes are correct
 ; CHECK-IR-DAG: ![[#MN0]] = !{![[#MN1:]], ![[#MN2:]], ![[#MN3:]]}
-; CHECK-IR-DAG: ![[#MN1]] = !{i32 6147, i32 1, !"6da74a122db9f35d____ZL7dg_int1"}
-; CHECK-IR-DAG: ![[#MN2]] = !{i32 6149, i32 1}
-; CHECK-IR-DAG: ![[#MN3]] = !{i32 6148, i32 0}
+; CHECK-IR-DAG: ![[#MN1]] = !{i32 6149, i32 1}
+; CHECK-IR-DAG: ![[#MN2]] = !{i32 6148, i32 0}
+; CHECK-IR-DAG: ![[#MN3]] = !{i32 6147, i32 1, !"6da74a122db9f35d____ZL7dg_int1"}
 
 ; CHECK-IR-DAG: ![[#MN4]] = !{![[#MN5:]], ![[#MN6:]]}
 ; CHECK-IR-DAG: ![[#MN5]] = !{i32 6149, i32 0}
 ; CHECK-IR-DAG: ![[#MN6]] = !{i32 6148, i32 1}
 
-; CHECK-IR-DAG: ![[#MN7]] = !{![[#MN8:]], ![[#MN2]], ![[#MN3]]}
+; CHECK-IR-DAG: ![[#MN7]] = !{![[#MN1]], ![[#MN2]], ![[#MN8:]]}
 ; CHECK-IR-DAG: ![[#MN8]] = !{i32 6147, i32 0, !"9d329ad59055e972____ZL8dg_bool3"}
 
 ; CHECK-IR-DAG: ![[#MN9]] = !{![[#MN10:]]}
 ; CHECK-IR-DAG: ![[#MN10]] = !{i32 6147, i32 2, !"dda2bad52c45c432____ZL8dg_bool4"}
+
+; CHECK-IR-DAG: ![[#MN11]] = !{![[#MN1]], ![[#MN2]], ![[#MN12:]]}
+; CHECK-IR-DAG: ![[#MN12]] = !{i32 6147, i32 1, !"6da74a122db9f35d____ZL7no_dg_int1"}
 
 ; Ensure that the default values are correct.
 ; ABAAAAAAAAABAAAAAxxxxx is decoded to

--- a/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
@@ -1,7 +1,10 @@
 ; RUN: sycl-post-link --device-globals -S %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefix CHECK-PROP
+; RUN: FileCheck %s -input-file=%t.files_0.ll --check-prefix CHECK-IR
+; RUN: sycl-post-link --ir-output-only --device-globals %s -S -o - | FileCheck %s --check-prefix CHECK-IR
 
 ; This test is intended to check that DeviceGlobalPass adds all the required
+; metadata nodes to every device global variable as well as the required
 ; properties in the 'SYCL/device globals' property set and handles the
 ; 'device_image_scope' attribute written in any allowed form.
 
@@ -14,10 +17,15 @@ target triple = "spir64-unknown-unknown"
 %class.anon.0 = type { i8 }
 
 @_ZL7dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #0
+; CHECK-IR: @_ZL7dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations !0 #0
 @_ZL7dg_int2 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #1
+; CHECK-IR: @_ZL7dg_int2 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations !4 #1
 @_ZL8dg_bool3 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1 #2
+; CHECK-IR: @_ZL8dg_bool3 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1, !spirv.Decorations !7 #2
 @_ZL8dg_bool4 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1 #3
+; CHECK-IR: @_ZL8dg_bool4 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1, !spirv.Decorations !9 #3
 @_ZL7no_dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #6
+; CHECK-IR-NOT: @_ZL7no_dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 !spirv.Decorations
 
 define internal spir_func void @_ZZ4mainENKUlvE_clEv(%class.anon.0 addrspace(4)* align 1 dereferenceable_or_null(1) %this) #4 align 2 {
 entry:
@@ -39,13 +47,14 @@ declare spir_func align 4 dereferenceable(4) i32 addrspace(4)* @_ZNK2cl4sycl3ext
 declare spir_func align 1 dereferenceable(1) i8 addrspace(4)* @_ZNK2cl4sycl3ext6oneapi13device_globalIbJNS2_8PropertyIXadsoKcL_ZL5Name1EEEXadsoS5_L_ZL6Value1EEEEENS4_IXadsoS5_L_ZL5Name2EEEXadsoS5_L_ZL6Value2EEEEENS4_IXadsoS5_L_ZL5Name3EEEXadsoS5_L_ZL6Value3EEEEENS4_IXadsoS5_L_ZL5Name4EEEXadsoS5_L_ZL6Value4EEEEEEE3getEv(%"class.cl::sycl::ext::oneapi::device_global.1" addrspace(4)* align 1 dereferenceable_or_null(1) %this) #4 align 2
 
 attributes #0 = { "sycl-unique-id"="6da74a122db9f35d____ZL7dg_int1" "device_image_scope"="false" "host_access"="1" "implement_in_csr"="true" "init_mode"="0" "sycl-device-global-size"="4" }
-attributes #1 = { "sycl-unique-id"="7da74a1187b9f35d____ZL7dg_int2" "host_access"="1" "implement_in_csr"="true" "init_mode"="0" "sycl-device-global-size"="4" }
-attributes #2 = { "sycl-unique-id"="9d329ad59055e972____ZL8dg_bool3" "device_image_scope"="true" "host_access"="1" "implement_in_csr"="true" "init_mode"="0" "sycl-device-global-size"="1" }
-attributes #3 = { "sycl-unique-id"="dda2bad52c45c432____ZL8dg_bool4" "device_image_scope" "host_access"="1" "implement_in_csr"="true" "init_mode"="0" "sycl-device-global-size"="1" }
+attributes #1 = { "sycl-unique-id"="7da74a1187b9f35d____ZL7dg_int2" "implement_in_csr"="false" "init_mode"="1" "sycl-device-global-size"="4" }
+attributes #2 = { "sycl-unique-id"="9d329ad59055e972____ZL8dg_bool3" "device_image_scope"="true" "host_access"="0" "implement_in_csr" "init_mode"="0" "sycl-device-global-size"="1" }
+attributes #3 = { "sycl-unique-id"="dda2bad52c45c432____ZL8dg_bool4" "device_image_scope" "host_access"="2" "sycl-device-global-size"="1" }
 attributes #4 = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
 attributes #5 = { convergent nounwind }
 ; no the sycl-device-global-size attribute, this is not a device global variable
 attributes #6 = { "sycl-unique-id"="6da74a122db9f35d____ZL7no_dg_int1" "device_image_scope"="false" "host_access"="1" "implement_in_csr"="true" "init_mode"="0" }
+
 !llvm.dependent-libraries = !{!0}
 !llvm.module.flags = !{!1, !2}
 !opencl.spir.version = !{!3}
@@ -58,6 +67,22 @@ attributes #6 = { "sycl-unique-id"="6da74a122db9f35d____ZL7no_dg_int1" "device_i
 !3 = !{i32 1, i32 2}
 !4 = !{i32 4, i32 100000}
 !5 = !{!"clang version 14.0.0"}
+
+; Ensure that the generated metadata nodes are correct
+; CHECK-IR:      !0 = !{!1, !2, !3}
+; CHECK-IR-NEXT: !1 = !{i32 6147, i32 1}
+; CHECK-IR-NEXT: !2 = !{i32 6149, i32 1}
+; CHECK-IR-NEXT: !3 = !{i32 6148, i32 0}
+
+; CHECK-IR:      !4 = !{!5, !6}
+; CHECK-IR-NEXT: !5 = !{i32 6149, i32 0}
+; CHECK-IR-NEXT: !6 = !{i32 6148, i32 1}
+
+; CHECK-IR:      !7 = !{!8, !2, !3}
+; CHECK-IR-NEXT: !8 = !{i32 6147, i32 0}
+
+; CHECK-IR:      !9 = !{!10}
+; CHECK-IR-NEXT: !10 = !{i32 6147, i32 2}
 
 ; Ensure that the default values are correct.
 ; ABAAAAAAAAABAAAAAxxxxx is decoded to

--- a/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
@@ -21,11 +21,11 @@ target triple = "spir64-unknown-unknown"
 @_ZL7dg_int2 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #1
 ; CHECK-IR: @_ZL7dg_int2 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations ![[#MN4:]] #[[#ATR1:]]
 @_ZL8dg_bool3 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1 #2
-; CHECK-IR: @_ZL8dg_bool3 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1, !spirv.Decorations ![[#MN7:]] #[[#ATR2:]]
+; CHECK-IR: @_ZL8dg_bool3 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1, !spirv.Decorations ![[#MN8:]] #[[#ATR2:]]
 @_ZL8dg_bool4 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1 #3
-; CHECK-IR: @_ZL8dg_bool4 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1, !spirv.Decorations ![[#MN9:]] #[[#ATR3:]]
+; CHECK-IR: @_ZL8dg_bool4 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1, !spirv.Decorations ![[#MN10:]] #[[#ATR3:]]
 @_ZL7no_dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #6
-; CHECK-IR: @_ZL7no_dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations ![[#MN11:]] #[[#ATR4:]]
+; CHECK-IR: @_ZL7no_dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations ![[#MN12:]] #[[#ATR4:]]
 
 define internal spir_func void @_ZZ4mainENKUlvE_clEv(%class.anon.0 addrspace(4)* align 1 dereferenceable_or_null(1) %this) #4 align 2 {
 entry:
@@ -75,18 +75,20 @@ attributes #6 = { "sycl-unique-id"="6da74a122db9f35d____ZL7no_dg_int1" "device_i
 ; CHECK-IR-DAG: ![[#MN2]] = !{i32 6148, i32 0}
 ; CHECK-IR-DAG: ![[#MN3]] = !{i32 6147, i32 1, !"6da74a122db9f35d____ZL7dg_int1"}
 
-; CHECK-IR-DAG: ![[#MN4]] = !{![[#MN5:]], ![[#MN6:]]}
+; CHECK-IR-DAG: ![[#MN4]] = !{![[#MN5:]], ![[#MN6:]], ![[#MN7:]]}
 ; CHECK-IR-DAG: ![[#MN5]] = !{i32 6149, i32 0}
 ; CHECK-IR-DAG: ![[#MN6]] = !{i32 6148, i32 1}
+; CHECK-IR-DAG: ![[#MN7]] = !{i32 6147, i32 2, !"7da74a1187b9f35d____ZL7dg_int2"}
 
-; CHECK-IR-DAG: ![[#MN7]] = !{![[#MN1]], ![[#MN2]], ![[#MN8:]]}
-; CHECK-IR-DAG: ![[#MN8]] = !{i32 6147, i32 0, !"9d329ad59055e972____ZL8dg_bool3"}
+; CHECK-IR-DAG: ![[#MN8]] = !{![[#MN1]], ![[#MN2]], ![[#MN9:]]}
+; CHECK-IR-DAG: ![[#MN9]] = !{i32 6147, i32 0, !"9d329ad59055e972____ZL8dg_bool3"}
 
-; CHECK-IR-DAG: ![[#MN9]] = !{![[#MN10:]]}
-; CHECK-IR-DAG: ![[#MN10]] = !{i32 6147, i32 2, !"dda2bad52c45c432____ZL8dg_bool4"}
+; CHECK-IR-DAG: ![[#MN10]] = !{![[#MN11:]]}
+; CHECK-IR-DAG: ![[#MN11]] = !{i32 6147, i32 2, !"dda2bad52c45c432____ZL8dg_bool4"}
 
-; CHECK-IR-DAG: ![[#MN11]] = !{![[#MN1]], ![[#MN2]], ![[#MN12:]]}
-; CHECK-IR-DAG: ![[#MN12]] = !{i32 6147, i32 1, !"6da74a122db9f35d____ZL7no_dg_int1"}
+; For not a device global variable, only actually present compile-time
+; properties are handled
+; CHECK-IR-DAG: ![[#MN12]] = !{![[#MN1]], ![[#MN2]]}
 
 ; Ensure that the default values are correct.
 ; ABAAAAAAAAABAAAAAxxxxx is decoded to

--- a/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
@@ -17,15 +17,15 @@ target triple = "spir64-unknown-unknown"
 %class.anon.0 = type { i8 }
 
 @_ZL7dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #0
-; CHECK-IR: @_ZL7dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations ![[#MN0:]] #[[#ATR0:]]
+; CHECK-IR: @_ZL7dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations ![[#MN0:]]
 @_ZL7dg_int2 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #1
-; CHECK-IR: @_ZL7dg_int2 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations ![[#MN4:]] #[[#ATR1:]]
+; CHECK-IR: @_ZL7dg_int2 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations ![[#MN4:]]
 @_ZL8dg_bool3 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1 #2
-; CHECK-IR: @_ZL8dg_bool3 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1, !spirv.Decorations ![[#MN8:]] #[[#ATR2:]]
+; CHECK-IR: @_ZL8dg_bool3 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1, !spirv.Decorations ![[#MN8:]]
 @_ZL8dg_bool4 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1 #3
-; CHECK-IR: @_ZL8dg_bool4 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1, !spirv.Decorations ![[#MN10:]] #[[#ATR3:]]
+; CHECK-IR: @_ZL8dg_bool4 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.1" zeroinitializer, align 1, !spirv.Decorations ![[#MN10:]]
 @_ZL7no_dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #6
-; CHECK-IR: @_ZL7no_dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations ![[#MN12:]] #[[#ATR4:]]
+; CHECK-IR: @_ZL7no_dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8, !spirv.Decorations ![[#MN12:]]
 
 define internal spir_func void @_ZZ4mainENKUlvE_clEv(%class.anon.0 addrspace(4)* align 1 dereferenceable_or_null(1) %this) #4 align 2 {
 entry:

--- a/llvm/test/tools/sycl-post-link/device-globals/test_no_metadata_generated.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_no_metadata_generated.ll
@@ -11,7 +11,7 @@ target triple = "spir64-unknown-unknown"
 %class.anon.0 = type { i8 }
 
 @_ZL7dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #0
-; CHECK-NOT: @_ZL7dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 !spirv.Decorations
+; CHECK-NOT: !spirv.Decorations
 
 define internal spir_func void @_ZZ4mainENKUlvE_clEv(%class.anon.0 addrspace(4)* align 1 dereferenceable_or_null(1) %this) #1 align 2 {
 entry:

--- a/llvm/test/tools/sycl-post-link/device-globals/test_no_metadata_generated.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_no_metadata_generated.ll
@@ -1,0 +1,49 @@
+; RUN: sycl-post-link --ir-output-only --device-globals %s -S -o - | FileCheck %s
+
+; This test is intended to check that sycl-post-link doesn't add metadata nodes
+; for device global variables without any compile-time properties.
+
+source_filename = "test_global_variable.cpp"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+%"class.cl::sycl::ext::oneapi::device_global.0" = type { i32 addrspace(4)* }
+%class.anon.0 = type { i8 }
+
+@_ZL7dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #0
+; CHECK-NOT: @_ZL7dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 !spirv.Decorations
+
+define internal spir_func void @_ZZ4mainENKUlvE_clEv(%class.anon.0 addrspace(4)* align 1 dereferenceable_or_null(1) %this) #1 align 2 {
+entry:
+  %this.addr = alloca %class.anon.0 addrspace(4)*, align 8
+  %this.addr.ascast = addrspacecast %class.anon.0 addrspace(4)** %this.addr to %class.anon.0 addrspace(4)* addrspace(4)*
+  store %class.anon.0 addrspace(4)* %this, %class.anon.0 addrspace(4)* addrspace(4)* %this.addr.ascast, align 8
+  %this1 = load %class.anon.0 addrspace(4)*, %class.anon.0 addrspace(4)* addrspace(4)* %this.addr.ascast, align 8
+  %call1 = call spir_func align 4 dereferenceable(4) i32 addrspace(4)* @_ZNK2cl4sycl3ext6oneapi13device_globalIiJNS2_8PropertyIXadsoKcL_ZL5Name1EEEXadsoS5_L_ZL6Value1EEEEENS4_IXadsoS5_L_ZL5Name2EEEXadsoS5_L_ZL6Value2EEEEENS4_IXadsoS5_L_ZL5Name3EEEXadsoS5_L_ZL6Value3EEEEENS4_IXadsoS5_L_ZL5Name4EEEXadsoS5_L_ZL6Value4EEEEEEE3getEv(%"class.cl::sycl::ext::oneapi::device_global.0" addrspace(4)* align 8 dereferenceable_or_null(8) addrspacecast (%"class.cl::sycl::ext::oneapi::device_global.0" addrspace(1)* @_ZL7dg_int1 to %"class.cl::sycl::ext::oneapi::device_global.0" addrspace(4)*)) #2
+  ret void
+}
+
+; Function Attrs: convergent mustprogress noinline norecurse nounwind optnone
+declare spir_func align 4 dereferenceable(4) i32 addrspace(4)* @_ZNK2cl4sycl3ext6oneapi13device_globalIiJNS2_8PropertyIXadsoKcL_ZL5Name1EEEXadsoS5_L_ZL6Value1EEEEENS4_IXadsoS5_L_ZL5Name2EEEXadsoS5_L_ZL6Value2EEEEENS4_IXadsoS5_L_ZL5Name3EEEXadsoS5_L_ZL6Value3EEEEENS4_IXadsoS5_L_ZL5Name4EEEXadsoS5_L_ZL6Value4EEEEEEE3getEv(%"class.cl::sycl::ext::oneapi::device_global.0" addrspace(4)* align 8 dereferenceable_or_null(8) %this) #1 align 2
+
+; this is a device global variable without any compile-time parameters
+attributes #0 = { "sycl-unique-id"="6da74a122db9f35d____ZL7dg_int1" "device_image_scope"="false" "sycl-device-global-size"="4" }
+attributes #1 = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
+attributes #2 = { convergent nounwind }
+
+!llvm.dependent-libraries = !{!0}
+!llvm.module.flags = !{!1, !2}
+!opencl.spir.version = !{!3}
+!spirv.Source = !{!4}
+!llvm.ident = !{!5}
+
+!0 = !{!"libcpmt"}
+!1 = !{i32 1, !"wchar_size", i32 2}
+!2 = !{i32 7, !"frame-pointer", i32 2}
+!3 = !{i32 1, i32 2}
+!4 = !{i32 4, i32 100000}
+!5 = !{!"clang version 14.0.0"}
+
+; CHECK-NOT: ![[#MN1:]] = !{i32 6147
+; CHECK-NOT: ![[#MN2:]] = !{i32 6148
+; CHECK-NOT: ![[#MN3:]] = !{i32 6149

--- a/llvm/test/tools/sycl-post-link/device-globals/test_no_metadata_generated.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_no_metadata_generated.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link --ir-output-only --device-globals %s -S -o - | FileCheck %s
+; RUN: sycl-post-link --ir-output-only --device-globals %s -S -o - | FileCheck %s --implicit-check-not "!spirv.Decorations"
 
 ; This test is intended to check that sycl-post-link doesn't add metadata nodes
 ; for a non device global variable.
@@ -11,7 +11,6 @@ target triple = "spir64-unknown-unknown"
 %class.anon.0 = type { i8 }
 
 @_ZL7dg_int1 = internal addrspace(1) constant %"class.cl::sycl::ext::oneapi::device_global.0" zeroinitializer, align 8 #0
-; CHECK-NOT: !spirv.Decorations
 
 define internal spir_func void @_ZZ4mainENKUlvE_clEv(%class.anon.0 addrspace(4)* align 1 dereferenceable_or_null(1) %this) #1 align 2 {
 entry:

--- a/llvm/test/tools/sycl-post-link/device-globals/test_no_metadata_generated.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_no_metadata_generated.ll
@@ -1,7 +1,7 @@
 ; RUN: sycl-post-link --ir-output-only --device-globals %s -S -o - | FileCheck %s
 
 ; This test is intended to check that sycl-post-link doesn't add metadata nodes
-; for device global variables without any compile-time properties.
+; for a non device global variable.
 
 source_filename = "test_global_variable.cpp"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
@@ -26,8 +26,8 @@ entry:
 ; Function Attrs: convergent mustprogress noinline norecurse nounwind optnone
 declare spir_func align 4 dereferenceable(4) i32 addrspace(4)* @_ZNK2cl4sycl3ext6oneapi13device_globalIiJNS2_8PropertyIXadsoKcL_ZL5Name1EEEXadsoS5_L_ZL6Value1EEEEENS4_IXadsoS5_L_ZL5Name2EEEXadsoS5_L_ZL6Value2EEEEENS4_IXadsoS5_L_ZL5Name3EEEXadsoS5_L_ZL6Value3EEEEENS4_IXadsoS5_L_ZL5Name4EEEXadsoS5_L_ZL6Value4EEEEEEE3getEv(%"class.cl::sycl::ext::oneapi::device_global.0" addrspace(4)* align 8 dereferenceable_or_null(8) %this) #1 align 2
 
-; this is a device global variable without any compile-time parameters
-attributes #0 = { "sycl-unique-id"="6da74a122db9f35d____ZL7dg_int1" "device_image_scope"="false" "sycl-device-global-size"="4" }
+; this is not a device global variable
+attributes #0 = { "sycl-unique-id"="6da74a122db9f35d____ZL7dg_int1" "device_image_scope"="false" }
 attributes #1 = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
 attributes #2 = { convergent nounwind }
 

--- a/llvm/tools/sycl-post-link/CMakeLists.txt
+++ b/llvm/tools/sycl-post-link/CMakeLists.txt
@@ -19,6 +19,7 @@ include_directories(
 
 add_llvm_tool(sycl-post-link
   sycl-post-link.cpp
+  CompileTimePropertiesPass.cpp
   DeviceGlobals.cpp
   SpecConstants.cpp
   SYCLDeviceLibReqMask.cpp

--- a/llvm/tools/sycl-post-link/CompileTimeProperties.def
+++ b/llvm/tools/sycl-post-link/CompileTimeProperties.def
@@ -10,5 +10,8 @@
 #error "SYCL_COMPILE_TIME_PROPERTY(PropertyName, Decoration, ValueType) is not defined."
 #endif
 
+// The corresponding SPIR-V OpCodes for the init_mode and implement_in_csr
+// properties is documented in the SPV_INTEL_global_variable_decorations design
+// document: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/DeviceGlobal/SPV_INTEL_global_variable_decorations.asciidoc#decoration
 SYCL_COMPILE_TIME_PROPERTY("init_mode", 6148, DecorValueTy::uint32)
 SYCL_COMPILE_TIME_PROPERTY("implement_in_csr", 6149, DecorValueTy::boolean)

--- a/llvm/tools/sycl-post-link/CompileTimeProperties.def
+++ b/llvm/tools/sycl-post-link/CompileTimeProperties.def
@@ -11,7 +11,7 @@
 #endif
 
 // The corresponding SPIR-V OpCodes for the init_mode and implement_in_csr
-// properties is documented in the SPV_INTEL_global_variable_decorations design
+// properties are documented in the SPV_INTEL_global_variable_decorations design
 // document: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/DeviceGlobal/SPV_INTEL_global_variable_decorations.asciidoc#decoration
 SYCL_COMPILE_TIME_PROPERTY("init_mode", 6148, DecorValueTy::uint32)
 SYCL_COMPILE_TIME_PROPERTY("implement_in_csr", 6149, DecorValueTy::boolean)

--- a/llvm/tools/sycl-post-link/CompileTimeProperties.def
+++ b/llvm/tools/sycl-post-link/CompileTimeProperties.def
@@ -1,0 +1,14 @@
+/*=- CompileTimeProperties.def - Compile-time properties registry-*- C++ -*-= *\
+|*
+|* Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+|* See https://llvm.org/LICENSE.txt for license information.
+|* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+|*
+\*===----------------------------------------------------------------------===*/
+
+#ifndef SYCL_COMPILE_TIME_PROPERTY
+#error "SYCL_COMPILE_TIME_PROPERTY(PropertyName, Decoration, ValueType) is not defined."
+#endif
+
+SYCL_COMPILE_TIME_PROPERTY("init_mode", 6148, DecorValueTy::uint32)
+SYCL_COMPILE_TIME_PROPERTY("implement_in_csr", 6149, DecorValueTy::boolean)

--- a/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
+++ b/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
@@ -23,6 +23,9 @@ namespace {
 constexpr StringRef SYCL_HOST_ACCESS_ATTR = "host_access";
 
 constexpr StringRef SPIRV_DECOR_MD_KIND = "spirv.Decorations";
+// The corresponding SPIR-V OpCode for the host_access property is documented
+// in the SPV_INTEL_global_variable_decorations design document:
+// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/DeviceGlobal/SPV_INTEL_global_variable_decorations.asciidoc#decoration
 constexpr uint32_t SPIRV_HOST_ACCESS_DECOR = 6147;
 constexpr uint32_t SPIRV_HOST_ACCESS_DEFAULT_VALUE = 2; // Read/Write
 

--- a/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
+++ b/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
@@ -146,5 +146,5 @@ PreservedAnalyses CompileTimePropertiesPass::run(Module &M,
   // any analysis, but we need return PreservedAnalyses::none() to inform
   // the caller that at least one compile-time property was met.
   return CompileTimePropertiesMet ? PreservedAnalyses::none()
-                                     : PreservedAnalyses::all();
+                                  : PreservedAnalyses::all();
 }

--- a/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
+++ b/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
@@ -37,9 +37,13 @@ struct Decor {
   DecorValueTy Type;
 };
 
+#define SYCL_COMPILE_TIME_PROPERTY(PropertyName, Decoration, ValueType) \
+{ PropertyName, { Decoration, ValueType }},
+
 const StringMap<Decor> SpirvDecorMap = {
-    {"init_mode", {6148, DecorValueTy::uint32}},
-    {"implement_in_csr", {6149, DecorValueTy::boolean}}};
+#include "CompileTimeProperties.def"
+};
+#undef SYCL_COMPILE_TIME_PROPERTY
 
 /// Builds a metadata node for a SPIR-V decoration (both decoration code
 /// and value are \c uint32_t integers).

--- a/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
+++ b/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
@@ -37,8 +37,8 @@ struct Decor {
   DecorValueTy Type;
 };
 
-#define SYCL_COMPILE_TIME_PROPERTY(PropertyName, Decoration, ValueType) \
-{ PropertyName, { Decoration, ValueType }},
+#define SYCL_COMPILE_TIME_PROPERTY(PropertyName, Decoration, ValueType)        \
+  {PropertyName, {Decoration, ValueType}},
 
 const StringMap<Decor> SpirvDecorMap = {
 #include "CompileTimeProperties.def"

--- a/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
+++ b/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
@@ -1,0 +1,142 @@
+//===---- CompileTimePropertiesPass.cpp - SYCL Compile Time Props Pass ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// See comments in the header.
+//===----------------------------------------------------------------------===//
+
+#include "CompileTimePropertiesPass.h"
+#include "DeviceGlobals.h"
+
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/IR/Module.h"
+
+using namespace llvm;
+
+namespace {
+
+constexpr StringRef SYCL_HOST_ACCESS_ATTR = "host_access";
+
+constexpr StringRef SPIRV_DECOR_MD_KIND = "spirv.Decorations";
+constexpr uint32_t SPIRV_HOST_ACCESS_DECOR = 6147;
+
+enum class DecorValueTy {
+  // the value is an unsigned number (uint32_t)
+  uint32,
+  // the value is a boolean value (bool)
+  boolean,
+};
+
+struct Decor {
+  uint32_t Code;
+  DecorValueTy Type;
+};
+
+const StringMap<Decor> SpirvDecorMap = {
+    {"init_mode", {6148, DecorValueTy::uint32}},
+    {"implement_in_csr", {6149, DecorValueTy::boolean}}};
+
+/// Builds a metadata node for a SPIR-V decoration (both decoration code
+/// and value are \c uint32_t integers).
+///
+/// @param Ctx   [in] the LLVM Context.
+/// @param Decor [in] the decoration code.
+/// @param Value [in] the decoration value.
+///
+/// @returns a pointer to the metadata node created for the required decoration
+/// and its value.
+MDNode *buildSpirvDecorMetadata(LLVMContext &Ctx, uint32_t Decor,
+                                uint32_t Value) {
+  auto *Ty = Type::getInt32Ty(Ctx);
+  SmallVector<Metadata *, 2> MD;
+  MD.push_back(
+      ConstantAsMetadata::get(Constant::getIntegerValue(Ty, APInt(32, Decor))));
+  MD.push_back(
+      ConstantAsMetadata::get(Constant::getIntegerValue(Ty, APInt(32, Value))));
+  return MDNode::get(Ctx, MD);
+}
+
+/// Builds a metadata node for a SPIR-V decoration (both decoration code
+/// and value are \c uint32_t integers, and the secondary extra operand is a
+/// string).
+///
+/// @param Ctx       [in] the LLVM Context.
+/// @param Decor     [in] the decoration code.
+/// @param Value     [in] the decoration value.
+/// @param Secondary [in] the secondary "extra operands" (\c StringRef).
+///
+/// @returns a pointer to the metadata node created for the required decoration
+/// and its value.
+MDNode *buildSpirvDecorMetadata(LLVMContext &Ctx, uint32_t Decor,
+                                uint32_t Value, StringRef Secondary) {
+  auto *Ty = Type::getInt32Ty(Ctx);
+  SmallVector<Metadata *, 3> MD;
+  MD.push_back(
+      ConstantAsMetadata::get(Constant::getIntegerValue(Ty, APInt(32, Decor))));
+  MD.push_back(
+      ConstantAsMetadata::get(Constant::getIntegerValue(Ty, APInt(32, Value))));
+  MD.push_back(MDString::get(Ctx, Secondary));
+  return MDNode::get(Ctx, MD);
+}
+
+} // anonymous namespace
+
+PreservedAnalyses CompileTimePropertiesPass::run(Module &M,
+                                                 ModuleAnalysisManager &MAM) {
+  LLVMContext &Ctx = M.getContext();
+  unsigned MDKindID = Ctx.getMDKindID(SPIRV_DECOR_MD_KIND);
+  bool AnyCompileTimePropertiesMet = false;
+
+  // Let's process all the globals
+  for (auto &GV : M.globals()) {
+    // we suppose the enumeration orders in every enumeration in the SYCL
+    // headers are the same as in the descriptions of the corresponding
+    // decorations in the SPV_INTEL_* extensions.
+    SmallVector<Metadata *, 8> MDOps;
+    for (auto &Attribute : GV.getAttributes()) {
+      // Currently, only string attributes are supported
+      if (!Attribute.isStringAttribute())
+        continue;
+      auto DecorIt = SpirvDecorMap.find(Attribute.getKindAsString());
+      if (DecorIt == SpirvDecorMap.end())
+        continue;
+      auto Decor = DecorIt->second;
+      auto DecorCode = Decor.Code;
+      auto DecorValue = Decor.Type == DecorValueTy::uint32
+                            ? getAttributeAsInteger<uint32_t>(Attribute)
+                            : hasProperty(Attribute);
+      MDOps.push_back(buildSpirvDecorMetadata(Ctx, DecorCode, DecorValue));
+    }
+
+    // Some properties should be handled specially.
+
+    // The host_access property is handled specially because the SPIR-V
+    // decoration requires two "extra operands". The second SPIR-V operand
+    // is the "name" (the value of the "sycl-unique-id" property) of the
+    // variable.
+    if (hasVariableUniqueId(GV) && GV.hasAttribute(SYCL_HOST_ACCESS_ATTR)) {
+      auto HostAccessDecorValue =
+          getAttributeAsInteger<uint32_t>(GV, SYCL_HOST_ACCESS_ATTR);
+      auto VarName = getVariableUniqueId(GV);
+      MDOps.push_back(buildSpirvDecorMetadata(Ctx, SPIRV_HOST_ACCESS_DECOR,
+                                              HostAccessDecorValue, VarName));
+    }
+
+    // Add the generated metadata to the variable
+    if (!MDOps.empty()) {
+      GV.addMetadata(MDKindID, *MDNode::get(Ctx, MDOps));
+      AnyCompileTimePropertiesMet = true;
+    }
+  }
+
+  // The pass just adds some metadata to the module, it should not ruin
+  // any analysis, but we need return PreservedAnalyses::none() to inform
+  // the caller that at least one compile-time property was met.
+  return AnyCompileTimePropertiesMet ? PreservedAnalyses::none()
+                                     : PreservedAnalyses::all();
+}

--- a/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
+++ b/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
@@ -30,9 +30,7 @@ constexpr uint32_t SPIRV_HOST_ACCESS_DECOR = 6147;
 constexpr uint32_t SPIRV_HOST_ACCESS_DEFAULT_VALUE = 2; // Read/Write
 
 enum class DecorValueTy {
-  // the value is an unsigned number (uint32_t)
   uint32,
-  // the value is a boolean value (bool)
   boolean,
 };
 

--- a/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
+++ b/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
@@ -55,7 +55,7 @@ const StringMap<Decor> SpirvDecorMap = {
 ///
 /// @returns a pointer to the metadata node created for the required decoration
 /// and its value.
-MDNode *buildSpirvDecorMetadata(LLVMContext &Ctx, uint32_t Decor,
+MDNode *buildSpirvDecorMetadata(LLVMContext &Ctx, uint32_t OpCode,
                                 uint32_t Value) {
   auto *Ty = Type::getInt32Ty(Ctx);
   SmallVector<Metadata *, 2> MD;

--- a/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
+++ b/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
@@ -49,9 +49,9 @@ const StringMap<Decor> SpirvDecorMap = {
 /// Builds a metadata node for a SPIR-V decoration (both decoration code
 /// and value are \c uint32_t integers).
 ///
-/// @param Ctx   [in] the LLVM Context.
-/// @param Decor [in] the decoration code.
-/// @param Value [in] the decoration value.
+/// @param Ctx    [in] the LLVM Context.
+/// @param OpCode [in] the SPIR-V OpCode code.
+/// @param Value  [in] the SPIR-V decoration value.
 ///
 /// @returns a pointer to the metadata node created for the required decoration
 /// and its value.
@@ -59,8 +59,8 @@ MDNode *buildSpirvDecorMetadata(LLVMContext &Ctx, uint32_t OpCode,
                                 uint32_t Value) {
   auto *Ty = Type::getInt32Ty(Ctx);
   SmallVector<Metadata *, 2> MD;
-  MD.push_back(
-      ConstantAsMetadata::get(Constant::getIntegerValue(Ty, APInt(32, Decor))));
+  MD.push_back(ConstantAsMetadata::get(
+      Constant::getIntegerValue(Ty, APInt(32, OpCode))));
   MD.push_back(
       ConstantAsMetadata::get(Constant::getIntegerValue(Ty, APInt(32, Value))));
   return MDNode::get(Ctx, MD);
@@ -70,10 +70,10 @@ MDNode *buildSpirvDecorMetadata(LLVMContext &Ctx, uint32_t OpCode,
 /// and value are \c uint32_t integers, and the secondary extra operand is a
 /// string).
 ///
-/// @param Ctx       [in] the LLVM Context.
-/// @param Decor     [in] the decoration code.
-/// @param Value     [in] the decoration value.
-/// @param Secondary [in] the secondary "extra operands" (\c StringRef).
+/// @param Ctx        [in] the LLVM Context.
+/// @param OpCode     [in] the SPIR-V OpCode code.
+/// @param Value      [in] the SPIR-V decoration value.
+/// @param Secondary  [in] the secondary "extra operands" (\c StringRef).
 ///
 /// @returns a pointer to the metadata node created for the required decoration
 /// and its value.
@@ -81,8 +81,8 @@ MDNode *buildSpirvDecorMetadata(LLVMContext &Ctx, uint32_t OpCode,
                                 uint32_t Value, StringRef Secondary) {
   auto *Ty = Type::getInt32Ty(Ctx);
   SmallVector<Metadata *, 3> MD;
-  MD.push_back(
-      ConstantAsMetadata::get(Constant::getIntegerValue(Ty, APInt(32, Decor))));
+  MD.push_back(ConstantAsMetadata::get(
+      Constant::getIntegerValue(Ty, APInt(32, OpCode))));
   MD.push_back(
       ConstantAsMetadata::get(Constant::getIntegerValue(Ty, APInt(32, Value))));
   MD.push_back(MDString::get(Ctx, Secondary));

--- a/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
+++ b/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
@@ -77,7 +77,7 @@ MDNode *buildSpirvDecorMetadata(LLVMContext &Ctx, uint32_t OpCode,
 ///
 /// @returns a pointer to the metadata node created for the required decoration
 /// and its value.
-MDNode *buildSpirvDecorMetadata(LLVMContext &Ctx, uint32_t Decor,
+MDNode *buildSpirvDecorMetadata(LLVMContext &Ctx, uint32_t OpCode,
                                 uint32_t Value, StringRef Secondary) {
   auto *Ty = Type::getInt32Ty(Ctx);
   SmallVector<Metadata *, 3> MD;

--- a/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
+++ b/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
@@ -96,7 +96,7 @@ PreservedAnalyses CompileTimePropertiesPass::run(Module &M,
                                                  ModuleAnalysisManager &MAM) {
   LLVMContext &Ctx = M.getContext();
   unsigned MDKindID = Ctx.getMDKindID(SPIRV_DECOR_MD_KIND);
-  bool AnyCompileTimePropertiesMet = false;
+  bool CompileTimePropertiesMet = false;
 
   // Let's process all the globals
   for (auto &GV : M.globals()) {
@@ -138,13 +138,13 @@ PreservedAnalyses CompileTimePropertiesPass::run(Module &M,
     // Add the generated metadata to the variable
     if (!MDOps.empty()) {
       GV.addMetadata(MDKindID, *MDNode::get(Ctx, MDOps));
-      AnyCompileTimePropertiesMet = true;
+      CompileTimePropertiesMet = true;
     }
   }
 
   // The pass just adds some metadata to the module, it should not ruin
   // any analysis, but we need return PreservedAnalyses::none() to inform
   // the caller that at least one compile-time property was met.
-  return AnyCompileTimePropertiesMet ? PreservedAnalyses::none()
+  return CompileTimePropertiesMet ? PreservedAnalyses::none()
                                      : PreservedAnalyses::all();
 }

--- a/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
+++ b/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
@@ -129,7 +129,7 @@ PreservedAnalyses CompileTimePropertiesPass::run(Module &M,
           GV.hasAttribute(SYCL_HOST_ACCESS_ATTR)
               ? getAttributeAsInteger<uint32_t>(GV, SYCL_HOST_ACCESS_ATTR)
               : SPIRV_HOST_ACCESS_DEFAULT_VALUE;
-      auto VarName = getVariableUniqueId(GV);
+      auto VarName = getGlobalVariableUniqueId(GV);
       MDOps.push_back(buildSpirvDecorMetadata(Ctx, SPIRV_HOST_ACCESS_DECOR,
                                               HostAccessDecorValue, VarName));
     }

--- a/llvm/tools/sycl-post-link/CompileTimePropertiesPass.h
+++ b/llvm/tools/sycl-post-link/CompileTimePropertiesPass.h
@@ -60,8 +60,7 @@ inline bool hasProperty(const Attribute &Attr) {
 /// @tparam Int [in] The deserved type of the result.
 ///
 /// @returns \c the attribute's value as an @Int.
-template <typename Int>
-Int getAttributeAsInteger(const Attribute &Attr) {
+template <typename Int> Int getAttributeAsInteger(const Attribute &Attr) {
   assert(Attr.isStringAttribute() &&
          "The attribute Attr must be a string attribute");
   Int Value;

--- a/llvm/tools/sycl-post-link/CompileTimePropertiesPass.h
+++ b/llvm/tools/sycl-post-link/CompileTimePropertiesPass.h
@@ -1,0 +1,109 @@
+//=== CompileTimePropertiesPass.h - SYCL Compile Time Props Pass-*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// A transformation pass which converts values of symbolic attributes
+// (compile-time properties) to integer id-based ones to later map to LLVM IR
+// metadata nodes. The header also contains a number of function templates to
+// extract corresponding attributes and their values.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "llvm/IR/PassManager.h"
+
+#include <cassert>
+
+namespace llvm {
+
+class CompileTimePropertiesPass
+    : public PassInfoMixin<CompileTimePropertiesPass> {
+public:
+  // Enriches the module with metadata that describes the found variables for
+  // the SPIRV-LLVM Translator.
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
+};
+
+namespace detail {
+
+/// Converts the string into a boolean value. If the string is equal to "false"
+/// we consider its value as /c false, /true otherwise.
+///
+/// @param Value [in] "boolean as string" value.
+///
+/// @returns \c false if the value of \c Value equals to "false", \c true
+/// otherwise.
+inline bool toBool(StringRef Value) { return !Value.equals("false"); }
+
+} // namespace detail
+
+/// Returns a boolean representation of an attribute's value.
+///
+/// Currently the function works for string attributes only
+///
+/// @param Attr [in] An attribute
+/// @return \c true if the attribute is a string attribute and its value is not
+/// equal to \c "false", \c false otherwise.
+inline bool hasProperty(const Attribute &Attr) {
+  return Attr.isStringAttribute() && detail::toBool(Attr.getValueAsString());
+}
+
+/// Returns the attribute @Attribute's value as an integer of type @Int.
+///
+/// Currently the function works for string attributes only
+///
+/// @param Attr [in] An attribute
+/// @tparam Int [in] The deserved type of the result.
+///
+/// @returns \c the attribute's value as an @Int.
+template <typename Int>
+Int getAttributeAsInteger(const Attribute &Attr) {
+  assert(Attr.isStringAttribute() &&
+         "The attribute Attr must be a string attribute");
+  Int Value;
+  bool Error = Attr.getValueAsString().getAsInteger(10, Value);
+  assert(!Error && "The attribute's value is not a number");
+  (void)Error;
+  return Value;
+}
+
+/// Checks whether the object @Object has the @AttributeName property.
+/// The object has the property if the @AttributeName attribute is a string
+/// attribute defined for the object and its value is not represented as
+/// \c false.
+///
+/// @param Object        [in] Object that can have attributes.
+/// @param AttributeName [in] Property name.
+/// @tparam T            [in] Object's type, the type must be able to work with
+///                           attributes.
+///
+/// @returns \c true if the object @Object has the @AttributeName property,
+/// \c false otherwise.
+template <typename T>
+bool hasProperty(const T &Object, StringRef AttributeName) {
+  return Object.hasAttribute(AttributeName) &&
+         hasProperty(Object.getAttribute(AttributeName));
+}
+
+/// Returns the value of the string @AttributeName attribute of the object
+/// @Object as an integer of type @Int.
+///
+/// @param Object        [in] Object that can have attributes.
+/// @param AttributeName [in] Property name.
+/// @tparam Int          [in] The deserved type of the result.
+/// @tparam T            [in] Object's type, the type must be able to work with
+///                           attributes.
+///
+/// @returns \c the attribute's value as an @Int.
+template <typename Int, typename T>
+Int getAttributeAsInteger(const T &Object, StringRef AttributeName) {
+  assert(Object.hasAttribute(AttributeName) &&
+         "The object Object must have the requested attribute");
+  return getAttributeAsInteger<Int>(Object.getAttribute(AttributeName));
+}
+
+} // namespace llvm

--- a/llvm/tools/sycl-post-link/DeviceGlobals.cpp
+++ b/llvm/tools/sycl-post-link/DeviceGlobals.cpp
@@ -10,6 +10,7 @@
 
 #include "DeviceGlobals.h"
 
+#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/Module.h"
@@ -23,6 +24,14 @@ namespace {
 constexpr StringRef SYCL_DEVICE_GLOBAL_SIZE_ATTR = "sycl-device-global-size";
 constexpr StringRef SYCL_UNIQUE_ID_ATTR = "sycl-unique-id";
 constexpr StringRef SYCL_DEVICE_IMAGE_SCOPE_ATTR = "device_image_scope";
+constexpr StringRef SYCL_HOST_ACCESS_ATTR = "host_access";
+constexpr StringRef SYCL_INIT_MODE_ATTR = "init_mode";
+constexpr StringRef SYCL_IMPLEMENT_IN_CSR_ATTR = "implement_in_csr";
+
+constexpr StringRef SPIRV_DECOR_MD_KIND = "spirv.Decorations";
+constexpr uint32_t SPIRV_HOST_ACCESS_DECOR = 6147;
+constexpr uint32_t SPIRV_INIT_MODE_DECOR = 6148;
+constexpr uint32_t SPIRV_IMPLEMENT_IN_CSR_DECOR = 6149;
 
 /// Converts the string into a boolean value. If the string is equal to "false"
 /// we consider its value as /c false, /true otherwise.
@@ -33,19 +42,39 @@ constexpr StringRef SYCL_DEVICE_IMAGE_SCOPE_ATTR = "device_image_scope";
 /// otherwise.
 bool toBool(StringRef Value) { return !Value.equals("false"); }
 
-/// Checks whether the device global variable has the \c device_image_scope
-/// property. The variable has the property if the \c sycl-device-image-scope
-/// attribute is defined for the variable and the attribute value is not
+/// Checks whether the device global variable has the \c AttributeName
+/// property. The variable has the property if the \c AttributeName
+/// attribute is defined for the variable and its value is not
 /// represented as \c false.
 ///
-/// @param GV [in] Device Global variable.
+/// @param GV            [in] Device Global variable.
+/// @param AttributeName [in] Property name.
 ///
-/// @returns \c true if variable \c GV has the \c device_image_scope property,
+/// @returns \c true if variable \c GV has the \c AttributeName property,
 /// \c false otherwise.
-bool hasDeviceImageScope(const GlobalVariable &GV) {
-  return GV.hasAttribute(SYCL_DEVICE_IMAGE_SCOPE_ATTR) &&
-         toBool(
-             GV.getAttribute(SYCL_DEVICE_IMAGE_SCOPE_ATTR).getValueAsString());
+bool hasProperty(const GlobalVariable &GV, StringRef AttributeName) {
+  return GV.hasAttribute(AttributeName) &&
+         toBool(GV.getAttribute(AttributeName).getValueAsString());
+}
+
+/// Returns the value of the \c AttributeName attribute of the \c GV global
+/// variable as an integer
+///
+/// @param GV            [in] Device Global variable.
+/// @param AttributeName [in] Property name.
+///
+/// @returns \c the attribute's value as an integer.
+uint32_t getAttributeAsInteger(const GlobalVariable &GV,
+                               StringRef AttributeName) {
+  assert(GV.hasAttribute(AttributeName) &&
+         "The global variable GV must have the requested attribute");
+  uint32_t value;
+  bool error = GV.getAttribute(AttributeName)
+                   .getValueAsString()
+                   .getAsInteger(10, value);
+  assert(!error && "The attribute's value is not a number");
+  (void)error;
+  return value;
 }
 
 /// Returns the size (in bytes) of the underlying type \c T of the device
@@ -61,17 +90,9 @@ bool hasDeviceImageScope(const GlobalVariable &GV) {
 uint32_t getUnderlyingTypeSize(const GlobalVariable &GV) {
   assert(GV.hasAttribute(SYCL_DEVICE_GLOBAL_SIZE_ATTR) &&
          "The device global variable must have the 'sycl-device-global-size' "
-         "attribute");
-  uint32_t value;
-  bool error = GV.getAttribute(SYCL_DEVICE_GLOBAL_SIZE_ATTR)
-                   .getValueAsString()
-                   .getAsInteger(10, value);
-  assert(!error &&
-         "The 'sycl-device-global-size' attribute must contain a number"
-         " representing the size of the underlying type T of the device"
-         " global variable");
-  (void)error;
-  return value;
+         "attribute that must contain a number representing the size of the "
+         "underlying type T of the device global variable");
+  return getAttributeAsInteger(GV, SYCL_DEVICE_GLOBAL_SIZE_ATTR);
 }
 
 /// Returns the unique id for the device global variable.
@@ -103,7 +124,72 @@ bool isDeviceGlobalVariable(const GlobalVariable &GV) {
   return GV.hasAttribute(SYCL_DEVICE_GLOBAL_SIZE_ATTR);
 }
 
+/// Builds a metadata node for a SPIR-V decoration.
+///
+/// @param Ctx   [in] the LLVM Context.
+/// @param Ty    [in] the type of the decoration code and value.
+/// @param Decor [in] the decoration code.
+/// @param Value [in] the decoration value.
+///
+/// @returns a pointer to the metadata node created for the required decoration
+/// and its value.
+MDNode *buildSpirvDecorMetadata(LLVMContext &Ctx, Type *Ty, uint32_t Decor,
+                                uint32_t Value) {
+  SmallVector<Metadata *, 2> MD;
+  MD.push_back(ConstantAsMetadata::get(
+        Constant::getIntegerValue(Ty, APInt(32, Decor))));
+  MD.push_back(ConstantAsMetadata::get(
+        Constant::getIntegerValue(Ty, APInt(32, Value))));
+  return MDNode::get(Ctx, MD);
+}
+
 } // namespace
+
+PreservedAnalyses
+DeviceGlobalsPass::run(Module &M, ModuleAnalysisManager &MAM) {
+  LLVMContext &Ctx = M.getContext();
+  unsigned MDKindID = Ctx.getMDKindID(SPIRV_DECOR_MD_KIND);
+  auto *Int32Ty = Type::getInt32Ty(Ctx);
+
+  for (auto &GV : M.globals()) {
+    if (!isDeviceGlobalVariable(GV))
+      continue;
+
+    // we suppose the enumeration orders in the host_access and init_mode
+    // enumerations in the SYCL headers are the same as in the descriptions of
+    // the HostAccessINTEL and InitModeINTEL decorations in the
+    // SPV_INTEL_global_variable_decorations extension.
+    SmallVector<Metadata *, 4> MDOps;                                             
+    if (GV.hasAttribute(SYCL_HOST_ACCESS_ATTR)) {
+      uint32_t HostAccessValue =
+          getAttributeAsInteger(GV, SYCL_HOST_ACCESS_ATTR);
+      MDOps.push_back(buildSpirvDecorMetadata(Ctx, Int32Ty,
+                                              SPIRV_HOST_ACCESS_DECOR,
+                                              HostAccessValue));
+    }
+
+    if (GV.hasAttribute(SYCL_INIT_MODE_ATTR)) {
+      uint32_t InitModeValue = getAttributeAsInteger(GV, SYCL_INIT_MODE_ATTR);
+      MDOps.push_back(buildSpirvDecorMetadata(Ctx, Int32Ty,
+                                              SPIRV_INIT_MODE_DECOR,
+                                              InitModeValue));
+    }
+
+    if (GV.hasAttribute(SYCL_IMPLEMENT_IN_CSR_ATTR)) {
+      uint32_t InCSRValue =
+          hasProperty(GV, SYCL_IMPLEMENT_IN_CSR_ATTR) ? 1 : 0;
+      MDOps.push_back(buildSpirvDecorMetadata(Ctx, Int32Ty,
+                                              SPIRV_IMPLEMENT_IN_CSR_DECOR,
+                                              InCSRValue));    
+    }
+
+    GV.addMetadata(MDKindID, *MDNode::get(Ctx, MDOps));
+  }
+
+  // The pass just adds some metadata to the module, it should not ruine
+  // any analysis.
+  return PreservedAnalyses::all();
+}
 
 DeviceGlobalPropertyMapTy
 DeviceGlobalsPass::collectDeviceGlobalProperties(const Module &M) {
@@ -119,7 +205,8 @@ DeviceGlobalsPass::collectDeviceGlobalProperties(const Module &M) {
       continue;
 
     DGM[getUniqueId(GV)] = {
-        {{getUnderlyingTypeSize(GV), hasDeviceImageScope(GV)}}};
+        {{getUnderlyingTypeSize(GV),
+          hasProperty(GV, SYCL_DEVICE_IMAGE_SCOPE_ATTR)}}};
   }
 
   return DGM;

--- a/llvm/tools/sycl-post-link/DeviceGlobals.cpp
+++ b/llvm/tools/sycl-post-link/DeviceGlobals.cpp
@@ -68,7 +68,7 @@ bool isDeviceGlobalVariable(const GlobalVariable &GV) {
 ///
 /// @returns the unique id of the device global variable represented
 /// in the LLVM IR by \c GV.
-StringRef getVariableUniqueId(const GlobalVariable &GV) {
+StringRef getGlobalVariableUniqueId(const GlobalVariable &GV) {
   assert(GV.hasAttribute(SYCL_UNIQUE_ID_ATTR) &&
          "a 'sycl-unique-id' string must be associated with every device "
          "global variable");
@@ -87,7 +87,7 @@ DeviceGlobalPropertyMapTy collectDeviceGlobalProperties(const Module &M) {
     if (!isDeviceGlobalVariable(GV))
       continue;
 
-    DGM[getVariableUniqueId(GV)] = {
+    DGM[getGlobalVariableUniqueId(GV)] = {
         {{getUnderlyingTypeSize(GV),
           hasProperty(GV, SYCL_DEVICE_IMAGE_SCOPE_ATTR)}}};
   }

--- a/llvm/tools/sycl-post-link/DeviceGlobals.cpp
+++ b/llvm/tools/sycl-post-link/DeviceGlobals.cpp
@@ -47,16 +47,16 @@ uint32_t getUnderlyingTypeSize(const GlobalVariable &GV) {
 
 namespace llvm {
 
-/// Returns \c true if the device global variable has the unique id
+/// Return \c true if the variable @GV is a device global variable.
 ///
 /// The function checks whether the variable has the LLVM IR attribute \c
-/// sycl-unique-id.
+/// sycl-device-global-size.
+/// @param GV [in] A variable to test.
 ///
-/// @param GV [in] Device Global variable.
-///
-/// @returns \c true if the variable has the unique id, \c false otherwise.
-bool hasVariableUniqueId(const GlobalVariable &GV) {
-  return GV.hasAttribute(SYCL_UNIQUE_ID_ATTR);
+/// @return \c true if the variable is a device global variable, \c false
+/// otherwise.
+bool isDeviceGlobalVariable(const GlobalVariable &GV) {
+  return GV.hasAttribute(SYCL_DEVICE_GLOBAL_SIZE_ATTR);
 }
 
 /// Returns the unique id for the device global variable.
@@ -76,18 +76,15 @@ StringRef getVariableUniqueId(const GlobalVariable &GV) {
 }
 
 DeviceGlobalPropertyMapTy collectDeviceGlobalProperties(const Module &M) {
-  auto IsDeviceGlobalVariable = [](auto &GV) {
-    return GV.hasAttribute(SYCL_DEVICE_GLOBAL_SIZE_ATTR);
-  };
   DeviceGlobalPropertyMapTy DGM;
-  auto DevGlobalNum = count_if(M.globals(), IsDeviceGlobalVariable);
+  auto DevGlobalNum = count_if(M.globals(), isDeviceGlobalVariable);
   if (DevGlobalNum == 0)
     return DGM;
 
   DGM.reserve(DevGlobalNum);
 
   for (auto &GV : M.globals()) {
-    if (!IsDeviceGlobalVariable(GV))
+    if (!isDeviceGlobalVariable(GV))
       continue;
 
     DGM[getVariableUniqueId(GV)] = {

--- a/llvm/tools/sycl-post-link/DeviceGlobals.cpp
+++ b/llvm/tools/sycl-post-link/DeviceGlobals.cpp
@@ -9,10 +9,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "DeviceGlobals.h"
+#include "CompileTimePropertiesPass.h"
 
-#include "llvm/ADT/APInt.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/IR/Module.h"
 
@@ -25,79 +24,6 @@ namespace {
 constexpr StringRef SYCL_DEVICE_GLOBAL_SIZE_ATTR = "sycl-device-global-size";
 constexpr StringRef SYCL_UNIQUE_ID_ATTR = "sycl-unique-id";
 constexpr StringRef SYCL_DEVICE_IMAGE_SCOPE_ATTR = "device_image_scope";
-constexpr StringRef SYCL_HOST_ACCESS_ATTR = "host_access";
-constexpr StringRef SYCL_INIT_MODE_ATTR = "init_mode";
-constexpr StringRef SYCL_IMPL_IN_CSR_ATTR = "implement_in_csr";
-
-constexpr StringRef SPIRV_DECOR_MD_KIND = "spirv.Decorations";
-constexpr uint32_t SPIRV_HOST_ACCESS_DECOR = 6147;
-constexpr uint32_t SPIRV_INIT_MODE_DECOR = 6148;
-constexpr uint32_t SPIRV_IMPL_IN_CSR_DECOR = 6149;
-
-enum class DecorValueTy {
-  // the value is an unsigned number (uint32_t)
-  uint,
-  // the value is a boolean value (bool)
-  boolean,
-};
-
-struct Decor {
-  uint32_t Code;
-  DecorValueTy Type;
-  // The variable name (from sycl-unique-id) is required as a secondary extra
-  // operand
-  bool NeedVarName;
-};
-
-const StringMap<Decor> SpirvDecorMap = {
-    {SYCL_HOST_ACCESS_ATTR,
-     {SPIRV_HOST_ACCESS_DECOR, DecorValueTy::uint, true}},
-    {SYCL_INIT_MODE_ATTR, {SPIRV_INIT_MODE_DECOR, DecorValueTy::uint, false}},
-    {SYCL_IMPL_IN_CSR_ATTR,
-     {SPIRV_IMPL_IN_CSR_DECOR, DecorValueTy::boolean, false}}};
-
-/// Converts the string into a boolean value. If the string is equal to "false"
-/// we consider its value as /c false, /true otherwise.
-///
-/// @param Value [in] "boolean as string" value.
-///
-/// @returns \c false if the value of \c Value equals to "false", \c true
-/// otherwise.
-bool toBool(StringRef Value) { return !Value.equals("false"); }
-
-/// Checks whether the device global variable has the \c AttributeName
-/// property. The variable has the property if the \c AttributeName
-/// attribute is defined for the variable and its value is not
-/// represented as \c false.
-///
-/// @param GV            [in] Device Global variable.
-/// @param AttributeName [in] Property name.
-///
-/// @returns \c true if variable \c GV has the \c AttributeName property,
-/// \c false otherwise.
-bool hasProperty(const GlobalVariable &GV, StringRef AttributeName) {
-  return GV.hasAttribute(AttributeName) &&
-         toBool(GV.getAttribute(AttributeName).getValueAsString());
-}
-
-/// Returns the value of the \c AttributeName attribute of the \c GV global
-/// variable as an integer
-///
-/// @param GV            [in] Device Global variable.
-/// @param AttributeName [in] Property name.
-///
-/// @returns \c the attribute's value as an integer.
-uint32_t getAttributeAsInteger(const GlobalVariable &GV,
-                               StringRef AttributeName) {
-  assert(GV.hasAttribute(AttributeName) &&
-         "The global variable GV must have the requested attribute");
-  uint32_t value;
-  bool error =
-      GV.getAttribute(AttributeName).getValueAsString().getAsInteger(10, value);
-  assert(!error && "The attribute's value is not a number");
-  (void)error;
-  return value;
-}
 
 /// Returns the size (in bytes) of the underlying type \c T of the device
 /// global variable.
@@ -108,150 +34,68 @@ uint32_t getAttributeAsInteger(const GlobalVariable &GV,
 /// @param GV [in] Device Global variable.
 ///
 /// @returns the size (int bytes) of the underlying type \c T of the
-/// device global variable represented in the LLVM IR by \c GV.
+/// device global variable represented in the LLVM IR by  @GV.
 uint32_t getUnderlyingTypeSize(const GlobalVariable &GV) {
   assert(GV.hasAttribute(SYCL_DEVICE_GLOBAL_SIZE_ATTR) &&
          "The device global variable must have the 'sycl-device-global-size' "
          "attribute that must contain a number representing the size of the "
          "underlying type T of the device global variable");
-  return getAttributeAsInteger(GV, SYCL_DEVICE_GLOBAL_SIZE_ATTR);
+  return getAttributeAsInteger<uint32_t>(GV, SYCL_DEVICE_GLOBAL_SIZE_ATTR);
+}
+
+} // anonymous namespace
+
+namespace llvm {
+
+/// Returns \c true if the device global variable has the unique id
+///
+/// The function checks whether the variable has the LLVM IR attribute \c
+/// sycl-unique-id.
+///
+/// @param GV [in] Device Global variable.
+///
+/// @returns \c true if the variable has the unique id, \c false otherwise.
+bool hasVariableUniqueId(const GlobalVariable &GV) {
+  return GV.hasAttribute(SYCL_UNIQUE_ID_ATTR);
 }
 
 /// Returns the unique id for the device global variable.
 ///
 /// The function gets this value from the LLVM IR attribute \c
-/// sycl-unique-id. If the attribute is not found for the variable
-/// an error should occur even in the release build.
+/// sycl-unique-id.
 ///
 /// @param GV [in] Device Global variable.
 ///
 /// @returns the unique id of the device global variable represented
 /// in the LLVM IR by \c GV.
-StringRef getUniqueId(const GlobalVariable &GV) {
+StringRef getVariableUniqueId(const GlobalVariable &GV) {
   assert(GV.hasAttribute(SYCL_UNIQUE_ID_ATTR) &&
          "a 'sycl-unique-id' string must be associated with every device "
          "global variable");
   return GV.getAttribute(SYCL_UNIQUE_ID_ATTR).getValueAsString();
 }
 
-/// Checks whether the variable is a device global one.
-///
-/// A variable is device global if and only if it contains the LLVM IR
-/// attribute \c sycl-device-global-size.
-///
-/// @param GV [in] a global variable.
-///
-/// @returns \c true if variable \c GV is device global, \c false otherwise.
-bool isDeviceGlobalVariable(const GlobalVariable &GV) {
-  return GV.hasAttribute(SYCL_DEVICE_GLOBAL_SIZE_ATTR);
-}
-
-/// Builds a metadata node for a SPIR-V decoration.
-///
-/// @param Ctx   [in] the LLVM Context.
-/// @param Ty    [in] the type of the decoration code and value.
-/// @param Decor [in] the decoration code.
-/// @param Value [in] the decoration value.
-///
-/// @returns a pointer to the metadata node created for the required decoration
-/// and its value.
-MDNode *buildSpirvDecorMetadata(LLVMContext &Ctx, Type *Ty, uint32_t Decor,
-                                uint32_t Value) {
-  SmallVector<Metadata *, 2> MD;
-  MD.push_back(
-      ConstantAsMetadata::get(Constant::getIntegerValue(Ty, APInt(32, Decor))));
-  MD.push_back(
-      ConstantAsMetadata::get(Constant::getIntegerValue(Ty, APInt(32, Value))));
-  return MDNode::get(Ctx, MD);
-}
-
-/// Builds a metadata node for a SPIR-V decoration.
-///
-/// @param Ctx     [in] the LLVM Context.
-/// @param Ty      [in] the type of the decoration code and value.
-/// @param Decor   [in] the decoration code.
-/// @param Value   [in] the decoration value.
-/// @param VarName [in] the variable's name, the secondary "extra operands".
-///
-/// @returns a pointer to the metadata node created for the required decoration
-/// and its value.
-MDNode *buildSpirvDecorMetadata(LLVMContext &Ctx, Type *Ty, uint32_t Decor,
-                                uint32_t Value, StringRef VarName) {
-  SmallVector<Metadata *, 3> MD;
-  MD.push_back(
-      ConstantAsMetadata::get(Constant::getIntegerValue(Ty, APInt(32, Decor))));
-  MD.push_back(
-      ConstantAsMetadata::get(Constant::getIntegerValue(Ty, APInt(32, Value))));
-  MD.push_back(MDString::get(Ctx, VarName));
-  return MDNode::get(Ctx, MD);
-}
-
-} // anonymous namespace
-
-PreservedAnalyses DeviceGlobalsPass::run(Module &M,
-                                         ModuleAnalysisManager &MAM) {
-  LLVMContext &Ctx = M.getContext();
-  unsigned MDKindID = Ctx.getMDKindID(SPIRV_DECOR_MD_KIND);
-  auto *Int32Ty = Type::getInt32Ty(Ctx);
-
-  for (auto &GV : M.globals()) {
-    if (!isDeviceGlobalVariable(GV))
-      continue;
-
-    // we suppose the enumeration orders in the host_access and init_mode
-    // enumerations in the SYCL headers are the same as in the descriptions of
-    // the HostAccessINTEL and InitModeINTEL decorations in the
-    // SPV_INTEL_global_variable_decorations extension.
-    SmallVector<Metadata *, 4> MDOps;
-    for (auto &Attribute : GV.getAttributes()) {
-      if (!Attribute.isStringAttribute())
-        continue;
-      auto AttributeKind = Attribute.getKindAsString();
-      auto DecorIt = SpirvDecorMap.find(AttributeKind);
-      if (DecorIt == SpirvDecorMap.end())
-        continue;
-      auto Decor = DecorIt->second;
-      auto DecorCode = Decor.Code;
-      auto DecorValue = Decor.Type == DecorValueTy::uint
-                            ? getAttributeAsInteger(GV, AttributeKind)
-                            : hasProperty(GV, AttributeKind);
-      MDNode *MDOp =
-          Decor.NeedVarName
-              ? buildSpirvDecorMetadata(Ctx, Int32Ty, DecorCode, DecorValue,
-                                        getUniqueId(GV))
-              : buildSpirvDecorMetadata(Ctx, Int32Ty, DecorCode, DecorValue);
-      MDOps.push_back(MDOp);
-    }
-
-    if (!MDOps.empty())
-      GV.addMetadata(MDKindID, *MDNode::get(Ctx, MDOps));
-  }
-
-  // The pass just adds some metadata to the module, it should not ruine
-  // any analysis.
-  return PreservedAnalyses::all();
-}
-
-DeviceGlobalPropertyMapTy
-DeviceGlobalsPass::collectDeviceGlobalProperties(const Module &M) {
+DeviceGlobalPropertyMapTy collectDeviceGlobalProperties(const Module &M) {
+  auto IsDeviceGlobalVariable = [](auto &GV) {
+    return GV.hasAttribute(SYCL_DEVICE_GLOBAL_SIZE_ATTR);
+  };
   DeviceGlobalPropertyMapTy DGM;
-  auto DevGlobalNum = countDeviceGlobals(M);
+  auto DevGlobalNum = count_if(M.globals(), IsDeviceGlobalVariable);
   if (DevGlobalNum == 0)
     return DGM;
 
   DGM.reserve(DevGlobalNum);
 
   for (auto &GV : M.globals()) {
-    if (!isDeviceGlobalVariable(GV))
+    if (!IsDeviceGlobalVariable(GV))
       continue;
 
-    DGM[getUniqueId(GV)] = {{{getUnderlyingTypeSize(GV),
-                              hasProperty(GV, SYCL_DEVICE_IMAGE_SCOPE_ATTR)}}};
+    DGM[getVariableUniqueId(GV)] = {
+        {{getUnderlyingTypeSize(GV),
+          hasProperty(GV, SYCL_DEVICE_IMAGE_SCOPE_ATTR)}}};
   }
 
   return DGM;
 }
 
-ptrdiff_t DeviceGlobalsPass::countDeviceGlobals(const Module &M) {
-  return count_if(M.globals(), isDeviceGlobalVariable);
-}
+} // namespace llvm

--- a/llvm/tools/sycl-post-link/DeviceGlobals.h
+++ b/llvm/tools/sycl-post-link/DeviceGlobals.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "llvm/ADT/MapVector.h"
+#include "llvm/IR/PassManager.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -43,8 +44,12 @@ struct DeviceGlobalProperty {
 using DeviceGlobalPropertyMapTy =
     MapVector<StringRef, std::vector<DeviceGlobalProperty>>;
 
-class DeviceGlobalsPass {
+class DeviceGlobalsPass : public PassInfoMixin<DeviceGlobalsPass> {
 public:
+  // Enriches the module with metadata that describes the found device global
+  // variables for the SPIRV-LLVM Translator.
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
+
   // Searches given module for occurrences of device global variable-specific
   // metadata and builds "device global variable name" ->
   // vector<"variable properties"> map.

--- a/llvm/tools/sycl-post-link/DeviceGlobals.h
+++ b/llvm/tools/sycl-post-link/DeviceGlobals.h
@@ -17,6 +17,7 @@
 
 #include "llvm/ADT/MapVector.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <vector>
 
@@ -49,6 +50,9 @@ public:
   // vector<"variable properties"> map.
   static DeviceGlobalPropertyMapTy
   collectDeviceGlobalProperties(const Module &M);
+
+  // Counts how many device global variables are found in the module.
+  static ptrdiff_t countDeviceGlobals(const Module &M);
 };
 
 } // end namespace llvm

--- a/llvm/tools/sycl-post-link/DeviceGlobals.h
+++ b/llvm/tools/sycl-post-link/DeviceGlobals.h
@@ -65,6 +65,6 @@ bool isDeviceGlobalVariable(const GlobalVariable &GV);
 ///
 /// @returns the unique id of the device global variable represented
 /// in the LLVM IR by \c GV.
-StringRef getVariableUniqueId(const GlobalVariable &GV);
+StringRef getGlobalVariableUniqueId(const GlobalVariable &GV);
 
 } // end namespace llvm

--- a/llvm/tools/sycl-post-link/DeviceGlobals.h
+++ b/llvm/tools/sycl-post-link/DeviceGlobals.h
@@ -51,12 +51,13 @@ using DeviceGlobalPropertyMapTy =
 /// map.
 DeviceGlobalPropertyMapTy collectDeviceGlobalProperties(const Module &M);
 
-/// Returns \c true if the device global variable has the unique id
+/// Return \c true if the variable @GV is a device global variable.
 ///
-/// @param GV [in] Device Global variable.
+/// @param GV [in] A variable to test.
 ///
-/// @returns \c true if the variable has the unique id, \c false otherwise.
-bool hasVariableUniqueId(const GlobalVariable &GV);
+/// @return \c true if the variable is a device global variable, \c false
+/// otherwise.
+bool isDeviceGlobalVariable(const GlobalVariable &GV);
 
 /// Returns the unique id for the device global variable.
 ///

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -202,7 +202,7 @@ struct GlobalBinImageProps {
   bool EmitProgramMetadata;
   bool EmitExportedSymbols;
   bool IsEsimdKernel;
-  bool EmitDeviceGlobalPropSet;
+  bool DeviceGlobalsMet;
 };
 
 void error(const Twine &Msg) {
@@ -630,7 +630,7 @@ void saveModuleProperties(Module &M, const EntryPointGroup &ModuleEntryPoints,
       PropSet[PropSetRegTy::SYCL_ASSERT_USED].insert({FName, true});
   }
 
-  if (ImgPSInfo.EmitDeviceGlobalPropSet) {
+  if (ImgPSInfo.DeviceGlobalsMet) {
     // Extract device global maps per module
     auto DevGlobalPropertyMap =
         DeviceGlobalsPass::collectDeviceGlobalProperties(M);

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -704,10 +704,9 @@ bool processCompileTimeProperties(Module &M) {
 
   ModulePassManager RunCompileTimeProperties;
   ModuleAnalysisManager MAM;
-  CompileTimePropertiesPass CTPP;
   // Register required analysis
   MAM.registerPass([&] { return PassInstrumentationAnalysis(); });
-  RunCompileTimeProperties.addPass(std::move(CTPP));
+  RunCompileTimeProperties.addPass(CompileTimePropertiesPass());
 
   // Enrich the module with compile-time properties metadata
   PreservedAnalyses Res = RunCompileTimeProperties.run(M, MAM);

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -699,6 +699,8 @@ bool processSpecConstants(Module &M) {
 }
 
 bool processCompileTimeProperties(Module &M) {
+  // TODO: the early exit can be removed as soon as we have compile-time
+  // properties not attached to device globals.
   if (DeviceGlobals.getNumOccurrences() == 0)
     return false;
 

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -981,11 +981,6 @@ int main(int argc, char **argv) {
            << " -" << IROutputOnly.ArgStr << "\n";
     return 1;
   }
-  if (IROutputOnly && DoDeviceGlobals) {
-    errs() << "error: -" << DeviceGlobals.ArgStr << " can't be used with"
-           << " -" << IROutputOnly.ArgStr << "\n";
-    return 1;
-  }
 
   if (OutputFilename.getNumOccurrences() == 0)
     OutputFilename = (Twine(sys::path::stem(InputFilename)) + ".files").str();

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -808,10 +808,9 @@ TableFiles processOneModule(std::unique_ptr<Module> M, bool IsEsimd,
       // no spec constants and no splitting.
       // We cannot reuse input module for ESIMD code since it was transformed.
       std::string ResModuleFile{};
-      bool CanReuseInputModule = !SyclAndEsimdCode && !IsEsimd &&
-                                 !IsLLVMUsedRemoved && !SpecConstsMet &&
-                                 !DeviceGlobalsMet &&
-                                 (MSplit.totalSplits() == 1);
+      bool CanReuseInputModule =
+          !SyclAndEsimdCode && !IsEsimd && !IsLLVMUsedRemoved &&
+          !SpecConstsMet && !DeviceGlobalsMet && (MSplit.totalSplits() == 1);
       if (CanReuseInputModule)
         ResModuleFile = InputFilename;
       else {


### PR DESCRIPTION
The pass enriches the LLVM IR with the !spirv.Decorations metadata
for the properties of every device global variable.

The implementation is in accordance to the "Changes to the sycl-post-link tool"
chapter of the design document [1] and the "Property on a global variable"
chapter of the design document [2].

We suppose the enumeration orders in the host_access and init_mode
enumerations in the SYCL headers are the same as in the descriptions of
the HostAccessINTEL and InitModeINTEL decorations in the
SPV_INTEL_global_variable_decorations extension.

[1] https://github.com/intel/llvm/blob/sycl/sycl/doc/DeviceGlobal.md#changes-to-the-sycl-post-link-tool
[2] https://github.com/intel/llvm/blob/sycl/sycl/doc/CompileTimeProperties.md#property-on-a-global-variable