### PR TITLE
[SYCL][Doc] Move properties to experimental namespace

### DIFF
--- a/sycl/doc/extensions/PropertyList/SYCL_EXT_ONEAPI_properties.asciidoc
+++ b/sycl/doc/extensions/PropertyList/SYCL_EXT_ONEAPI_properties.asciidoc
@@ -8,7 +8,7 @@ The `sycl::property_list` found in SYCL 2020 is used to store properties used in
 
 Compile-time-constant properties are an important building block for classes and functions that have a need to propagate compile-time information for semantic and optimization purposes, while runtime properties continue to serve an important role in dynamic parameter specification.
 
-This extension introduces `sycl::ext::oneapi::properties`, which is a replacement for `sycl::property_list` that supports the storage and manipulation of compile-time-constant properties in addition to runtime properties.
+This extension introduces `sycl::ext::oneapi::experimental::properties`, which is a replacement for `sycl::property_list` that supports the storage and manipulation of compile-time-constant properties in addition to runtime properties.
 
 == Contributors
 Joe Garvey, Intel +
@@ -135,12 +135,12 @@ value to determine which of the extension's APIs the implementation supports.
 
 Properties have a value and key type,
 and by convention, these classes are declared in the root of the
-`sycl::ext::oneapi` namespace. For a runtime property the key and value types are the same and the name of the property value
+`sycl::ext::oneapi::experimental` namespace. For a runtime property the key and value types are the same and the name of the property value
 class has no suffix. A runtime property value typically has a constructor
 which takes the value(s) of the properties and member function(s) which return those values. 
 
 ```c++
-namespace sycl::ext::oneapi {
+namespace sycl::ext::oneapi::experimental {
 
 // This is a runtime property value with one integer parameter.
 // The name of the property value class is the the name of the property without any suffix.
@@ -151,7 +151,7 @@ struct foo {
 // A runtime property key is an alias to the value type.
 using foo_key = foo;
 
-} // namespace oneapi::ext::sycl
+} // namespace experimental::oneapi::ext::sycl
 ```
 
 For compile-time constant parameters the value type is a template specialization of `property_value`. 
@@ -161,7 +161,7 @@ time-constant property can be either types or non-type values.
 The implementation provides a variable with the property value type. The variable has the name of the property without a suffix.
 
 ```c++
-namespace sycl::ext::oneapi {
+namespace sycl::ext::oneapi::experimental {
 
 template<typename...> struct property_value;
 
@@ -191,7 +191,7 @@ struct boo_key {
 template<typename... Ts>
 inline constexpr boo_key::value_t<Ts...> boo;
 
-} // namespace oneapi::ext::sycl
+} // namespace experimental::oneapi::ext::sycl
 
 === Property traits
 
@@ -203,7 +203,7 @@ that inherits from `std::true_type` for each SYCL runtime class that the
 property can be applied to. All have a base case which inherits from `std::false_type`.
 
 ```c++
-namespace sycl::ext::oneapi {
+namespace sycl::ext::oneapi::experimental {
 //Base case
 template<typename> struct is_property_key : std::false_type {};
 template<typename, typename> struct is_property_key_of : std::false_type {};
@@ -229,7 +229,7 @@ template<typename V> struct is_property_value<V, std::void_t<typename V::key_t>>
 template<typename V, typename O> struct is_property_value_of<V, O, std::void_t<typename V::key_t>> :
   is_property_key_of<typename V::key_t, O> {};
 
-} // namespace oneapi::ext::sycl
+} // namespace experimental::oneapi::ext::sycl
 ```
 
 === Property value class
@@ -242,7 +242,7 @@ and type of the parameter. When a property has more than one parameter, the
 the values and types of the parameters.
 
 ```c++
-namespace sycl::ext::oneapi {
+namespace sycl::ext::oneapi::experimental {
 
 template<typename Property, typename First, typename...Others>
 struct property_value {
@@ -259,7 +259,7 @@ struct property_value {
   using value_t = First;
 };
 
-} // namespace oneapi::ext::sycl
+} // namespace experimental::oneapi::ext::sycl
 ```
 
 The members of `property_value` are described in the table below.
@@ -295,7 +295,7 @@ The implementation provides equality and inequality operators for
 properties.
 
 ```c++
-namespace sycl::ext::oneapi {
+namespace sycl::ext::oneapi::experimental {
 
 // Available only if Prop is a compile-time constant property
 template <typename Prop, typename...A, typename...B>
@@ -313,7 +313,7 @@ bool operator==(Prop P1, Prop P2);
 template <typename Prop>
 bool operator!=(Prop P1, Prop P2);
 
-} // namespace oneapi::ext::sycl
+} // namespace experimental::oneapi::ext::sycl
 ```
 
 --
@@ -350,13 +350,13 @@ bool operator!=(Prop P1, Prop P2);
 
 === Property list `properties`
 
-This extension adds a new template class, `sycl::ext::oneapi::properties`, which is a property list that can contain compile-time constant properties as well as runtime properties.
+This extension adds a new template class, `sycl::ext::oneapi::experimental::properties`, which is a property list that can contain compile-time constant properties as well as runtime properties.
 
 `properties` is a class template, and the properties stored by it influence its type. Two `properties` objects have the same type if and only if they were constructed with the same set of compile-time constant property values and the same set of runtime properties.
 
 [NOTE]
 ====
-The runtime properties contained in the property list affect the type of `sycl::ext::oneapi::properties`, but their property values do not.
+The runtime properties contained in the property list affect the type of `sycl::ext::oneapi::experimental::properties`, but their property values do not.
 ====
 
 It is possible at compile-time to determine whether a `properties` object contains a particular (runtime or compile-time constant) property. See the `static constexpr` function `has_property` of the `properties` class.
@@ -376,7 +376,7 @@ That last sentence is not explicitly stated in the core SYCL spec, but it is ass
 The new `properties` class template is as follows:
 
 ```c++
-namespace sycl::ext::oneapi {
+namespace sycl::ext::oneapi::experimental {
 
 template<typename PropertyValuesT>
 class properties {
@@ -401,7 +401,7 @@ class properties {
   static constexpr auto get_property();
 };
 
-} // namespace oneapi::ext::sycl
+} // namespace experimental::oneapi::ext::sycl
 ```
 
 [NOTE]
@@ -456,7 +456,7 @@ Available only if `PropertyKeyT` is the property key class of a compile-time con
 The following trait is added to recognize a `properties`.
 
 ```c++
-namespace sycl::ext::oneapi {
+namespace sycl::ext::oneapi::experimental {
 
 // New trait to recognize a properties
 template<typename propertyListT>
@@ -465,7 +465,7 @@ struct is_property_list;
 template<typename propertyListT>
 inline constexpr bool is_property_list_v = is_property_list<properties>::value;
 
-} // namespace oneapi::ext::sycl
+} // namespace experimental::oneapi::ext::sycl
 ```
 
 The following table describes the new `is_property_list` trait:
@@ -642,7 +642,7 @@ Adding a new compile-time constant property requires implementers to introduce t
 This is an example showing the definition of a compile-time constant property `foo` that takes a single integer parameter. The property key class associated with the property is `foo_key`.
 
 ```c++
-namespace sycl::ext::oneapi {
+namespace sycl::ext::oneapi::experimental {
 
 // foo is the property key class
 struct foo_key {
@@ -663,10 +663,7 @@ struct is_property_key<foo_key> : std::true_type {};
 template<typename SyclObjectT>
 struct is_property_key_of<foo_key, SyclObjectT> : std::true_type {};
 
-} // namespace oneapi
-} // namespace ext
-
-} // namespace sycl
+} // namespace experimental::oneapi::ext::sycl
 ```
 
 


### PR DESCRIPTION
These changes move `properties` and property-related APIs into `sycl::ext::oneapi::experimental`.