### PR TITLE
[SYCL] Assume interop event is host-visible

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -5272,6 +5272,10 @@ pi_result piextEventCreateWithNativeHandle(pi_native_handle NativeHandle,
   *Event = new _pi_event(ZeEvent, nullptr /* ZeEventPool */, Context,
                          PI_COMMAND_TYPE_USER, OwnNativeHandle);
 
+  // Assume native event is host-visible, or otherwise we'd
+  // need to create a host-visible proxy for it.
+  (*Event)->HostVisibleEvent = *Event;
+
   return PI_SUCCESS;
 }
 


### PR DESCRIPTION
Fixes the hang in https://github.com/intel/llvm-test-suite/blob/intel/SYCL/Plugin/interop-level-zero-keep-ownership.cpp after https://github.com/intel/llvm/pull/5354
Signed-off-by: Sergey V Maslov <sergey.v.maslov@intel.com>