### PR TITLE
[SYCL][L0] Fix build with clang compiler

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -3437,7 +3437,7 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
     }
   }
 
-  pi_result Result;
+  pi_result Result = PI_SUCCESS;
   if (DeviceIsIntegrated) {
     if (HostPtrImported) {
       // When HostPtr is imported we use it for the buffer.


### PR DESCRIPTION
Fixes uninitialized variable warning introduced by https://github.com/intel/llvm/commit/844d7b6c23822a80985d279888483231bf8ac4c9:
```
llvm/src/sycl/plugins/level_zero/pi_level_zero.cpp:3474:9: error: variable 'Result' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
        PI_CALL(piextUSMHostAlloc(&Ptr, Context, nullptr, Size, Alignment));
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
