### PR TITLE
[SYCL] Fix dead pointer usage if leaf buffer overflows

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -589,8 +589,11 @@ Command *Command::addDep(DepDesc NewDep, std::vector<Command *> &ToCleanUp) {
   // ConnectionCmd insertion builds the following dependency structure:
   // this -> emptyCmd (for ConnectionCmd) -> ConnectionCmd -> NewDep
   // that means that this and NewDep are already dependent
-  if (!ConnectionCmd)
+  if (!ConnectionCmd) {
     MDeps.push_back(NewDep);
+    if (NewDep.MDepCommand)
+      NewDep.MDepCommand->addUser(this);
+  }
 
 #ifdef XPTI_ENABLE_INSTRUMENTATION
   emitEdgeEventForCommandDependence(

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -586,7 +586,12 @@ Command *Command::addDep(DepDesc NewDep, std::vector<Command *> &ToCleanUp) {
     ConnectionCmd =
         processDepEvent(NewDep.MDepCommand->getEvent(), NewDep, ToCleanUp);
   }
-  MDeps.push_back(NewDep);
+  // ConnectionCmd insertion builds the following dependency structure:
+  // this -> emptyCmd (for ConnectionCmd) -> ConnectionCmd -> NewDep
+  // that means that this and NewDep are already dependent
+  if (!ConnectionCmd)
+    MDeps.push_back(NewDep);
+
 #ifdef XPTI_ENABLE_INSTRUMENTATION
   emitEdgeEventForCommandDependence(
       NewDep.MDepCommand, (void *)NewDep.MDepRequirement->MSYCLMemObj,

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -1356,7 +1356,6 @@ Command *Scheduler::GraphBuilder::connectDepEvent(
     EmptyCmd->addUser(Cmd);
   }
 
-
   ConnectCmd->MEmptyCmd = EmptyCmd;
 
   return ConnectCmd;

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -606,7 +606,7 @@ protected:
         EmptyCommand *>
     addEmptyCmd(Command *Cmd, const std::vector<T *> &Req,
                 const QueueImplPtr &Queue, Command::BlockReason Reason,
-                std::vector<Command *> &ToEnqueue);
+                std::vector<Command *> &ToEnqueue, bool AddDepsToLeaves = true);
 
   protected:
     /// Finds a command dependency corresponding to the record.

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -606,7 +606,8 @@ protected:
         EmptyCommand *>
     addEmptyCmd(Command *Cmd, const std::vector<T *> &Req,
                 const QueueImplPtr &Queue, Command::BlockReason Reason,
-                std::vector<Command *> &ToEnqueue, bool AddDepsToLeaves = true);
+                std::vector<Command *> &ToEnqueue,
+                const bool AddDepsToLeaves = true);
 
   protected:
     /// Finds a command dependency corresponding to the record.

--- a/sycl/unittests/scheduler/CMakeLists.txt
+++ b/sycl/unittests/scheduler/CMakeLists.txt
@@ -18,4 +18,5 @@ add_sycl_unittest(SchedulerTests OBJECT
     QueueFlushing.cpp
     PostEnqueueCleanup.cpp
     utils.cpp
+    LeafLimitDiffContexts.cpp
 )

--- a/sycl/unittests/scheduler/LeafLimitDiffContexts.cpp
+++ b/sycl/unittests/scheduler/LeafLimitDiffContexts.cpp
@@ -1,0 +1,155 @@
+//==---------------- LeafLimit.cpp --- Scheduler unit tests ----------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "SchedulerTest.hpp"
+#include "SchedulerTestUtils.hpp"
+
+#include <detail/config.hpp>
+#include <helpers/CommonRedefinitions.hpp>
+#include <helpers/PiMock.hpp>
+#include <helpers/ScopedEnvVar.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+using namespace cl::sycl;
+
+inline constexpr auto DisablePostEnqueueCleanupName =
+    "SYCL_DISABLE_POST_ENQUEUE_CLEANUP";
+
+// Checks that scheduler's (or graph-builder's) addNodeToLeaves method works
+// correctly with dependency tracking when leaf-limit for generic commands is
+// overflowed.
+// Checks that in case of different contexts for deleted leaf and a new one
+// ConnectCmd will be created and scheduler will build the following dependency
+// structure: NewLeaf->EmptyCmd/ConnectCmd->OldLeaf
+TEST_F(SchedulerTest, LeafLimitDiffContexts) {
+  // All of the mock commands are owned on the test side, prevent post enqueue
+  // cleanup from deleting some of them.
+  unittest::ScopedEnvVar DisabledCleanup{
+      DisablePostEnqueueCleanupName, "1",
+      detail::SYCLConfig<detail::SYCL_DISABLE_POST_ENQUEUE_CLEANUP>::reset};
+
+  default_selector Selector;
+  device Device = Selector.select_device();
+  // ConnectCmd will not be created for host contextx
+  if (Device.is_host()) {
+    std::cout << "Not run due to host-only environment\n";
+    return;
+  }
+
+  struct QueueRelatedObjects {
+    cl::sycl::context Context;
+    cl::sycl::queue Queue;
+    std::unique_ptr<MockCommand> DepCmd;
+    detail::MemObjRecord *Rec;
+    detail::AllocaCommandBase *AllocaCmd;
+
+    QueueRelatedObjects(const device &Dev)
+        : Context(Dev), Queue(Context, Dev), DepCmd(), Rec(nullptr),
+          AllocaCmd(nullptr) {}
+
+    void InitializeUtils(detail::Requirement &MockReq, MockScheduler &MS) {
+      std::vector<detail::Command *> ToEnqueue;
+      Rec = MS.getOrInsertMemObjRecord(detail::getSyclObjImpl(Queue), &MockReq,
+                                       ToEnqueue);
+      // Creating Alloca on both - device and host contexts (will be created in
+      // real case in insertMemMove for example) It is done to avoid extra
+      // AllocCmd insertion during ConnectCmd insertion
+      AllocaCmd = MS.getOrCreateAllocaForReq(
+          Rec, &MockReq, detail::getSyclObjImpl(Queue), ToEnqueue);
+      std::ignore = MS.getOrCreateAllocaForReq(
+          Rec, &MockReq, MS.getDefaultHostQueue(), ToEnqueue);
+      DepCmd =
+          std::make_unique<MockCommand>(detail::getSyclObjImpl(Queue), MockReq);
+    }
+  };
+
+  // Creating 2 queues with different context objects
+  QueueRelatedObjects ExtQueue1(Device), ExtQueue2(Device);
+  MockScheduler MS;
+  std::vector<std::unique_ptr<MockCommand>> AddedLeaves;
+
+  buffer<int, 1> Buf(range<1>(1));
+  detail::Requirement MockReq = getMockRequirement(Buf);
+
+  ExtQueue1.InitializeUtils(MockReq, MS);
+  ExtQueue2.InitializeUtils(MockReq, MS);
+
+  size_t CommandsCapacity =
+      ExtQueue1.Rec->MWriteLeaves.genericCommandsCapacity();
+
+  // Adds leaf with 1 deps to buffer
+  auto AddLeafWithDeps = [&AddedLeaves, &MockReq,
+                          &MS](const QueueRelatedObjects &QueueStuff) {
+    auto NewLeaf = std::make_unique<MockCommand>(
+        detail::getSyclObjImpl(QueueStuff.Queue), MockReq);
+    // Create edges: all soon-to-be leaves are direct users of MockDep
+    std::vector<detail::Command *> ToCleanUp;
+    (void)NewLeaf->addDep(detail::DepDesc{QueueStuff.DepCmd.get(), &MockReq,
+                                          QueueStuff.AllocaCmd},
+                          ToCleanUp);
+    QueueStuff.DepCmd->addUser(NewLeaf.get());
+
+    std::vector<cl::sycl::detail::Command *> ToEnqueue;
+    MS.addNodeToLeaves(QueueStuff.Rec, NewLeaf.get(), access::mode::write,
+                       ToEnqueue);
+    AddedLeaves.push_back(std::move(NewLeaf));
+  };
+
+  // Create commands that will be added as leaves up to the limit
+  for (std::size_t i = 0; i < CommandsCapacity; ++i) {
+    AddLeafWithDeps(ExtQueue1);
+  }
+  // Adding extra command on different to exceed buffer limit
+  // The command #0 and command #8 must be on different queues to insert connect
+  // command
+  AddLeafWithDeps(ExtQueue2);
+
+  // Check that the oldest leaf #0 has been removed from the leaf list
+  const detail::CircularBuffer<detail::Command *> &Leaves =
+      ExtQueue1.Rec->MWriteLeaves.getGenericCommands();
+  ASSERT_TRUE(std::find(Leaves.begin(), Leaves.end(),
+                        AddedLeaves.front().get()) == Leaves.end());
+  // Check that another leaves #1...#7 that should not be removed are present in
+  // buffer
+  for (std::size_t i = 1; i < AddedLeaves.size(); ++i) {
+    assert(std::find(Leaves.begin(), Leaves.end(), AddedLeaves[i].get()) !=
+           Leaves.end());
+  }
+
+  // Check NewLeaf->EmptyCmd/ConnectCmd->OldLeaf structure
+  MockCommand *OldestLeaf = AddedLeaves.front().get();
+  MockCommand *NewestLeaf = AddedLeaves.back().get();
+  // The only user for oldLeaf must be ConnectCmd
+  ASSERT_EQ(OldestLeaf->MUsers.size(), 1U);
+  // No direct connection between OldLeaf and newLeaf, only via ConnectCmd
+  EXPECT_EQ(OldestLeaf->MUsers.count(NewestLeaf), 0U);
+  // 2 deps for NewLeaf: 1 dep command and connect cmd - no OldLeaf direct
+  // dependency
+  ASSERT_EQ(NewestLeaf->MDeps.size(), 2U);
+  EXPECT_FALSE(std::any_of(
+      NewestLeaf->MDeps.begin(), NewestLeaf->MDeps.end(),
+      [&](const detail::DepDesc &DD) { return DD.MDepCommand == OldestLeaf; }));
+  // Check NewLeaf dependencies in depth by MUsers
+  auto ConnectCmdIt = OldestLeaf->MUsers.begin();
+  ASSERT_EQ((*ConnectCmdIt)->MUsers.size(), 1U);
+  auto EmptyCmdIt = (*ConnectCmdIt)->MUsers.begin();
+  EXPECT_TRUE(std::any_of(NewestLeaf->MDeps.begin(), NewestLeaf->MDeps.end(),
+                          [&](const detail::DepDesc &DD) {
+                            return DD.MDepCommand == (*EmptyCmdIt);
+                          }));
+  // ConnectCmd is created internally in scheduler and not a mock object
+  // This fact leads to active scheduler shutdown process that deletes a
+  // part of commands for record we store in AddedLeaves vector.
+  // We abort this process by removing record to avoid double release or
+  // or memory leaks
+  MS.removeRecordForMemObj(MockReq.MSYCLMemObj);
+}

--- a/sycl/unittests/scheduler/LeafLimitDiffContexts.cpp
+++ b/sycl/unittests/scheduler/LeafLimitDiffContexts.cpp
@@ -10,8 +10,6 @@
 #include "SchedulerTestUtils.hpp"
 
 #include <detail/config.hpp>
-#include <helpers/CommonRedefinitions.hpp>
-#include <helpers/PiMock.hpp>
 #include <helpers/ScopedEnvVar.hpp>
 
 #include <algorithm>
@@ -46,8 +44,8 @@ TEST_F(SchedulerTest, LeafLimitDiffContexts) {
   }
 
   struct QueueRelatedObjects {
-    cl::sycl::context Context;
-    cl::sycl::queue Queue;
+    context Context;
+    queue Queue;
     std::unique_ptr<MockCommand> DepCmd;
     detail::MemObjRecord *Rec;
     detail::AllocaCommandBase *AllocaCmd;
@@ -98,7 +96,7 @@ TEST_F(SchedulerTest, LeafLimitDiffContexts) {
                           ToCleanUp);
     QueueStuff.DepCmd->addUser(NewLeaf.get());
 
-    std::vector<cl::sycl::detail::Command *> ToEnqueue;
+    std::vector<detail::Command *> ToEnqueue;
     MS.addNodeToLeaves(QueueStuff.Rec, NewLeaf.get(), access::mode::write,
                        ToEnqueue);
     AddedLeaves.push_back(std::move(NewLeaf));


### PR DESCRIPTION
When leaf buffer overflows we take oldLeaf and make a new one dependent on it.
In case of connect command insertion we again should take oldLeaf and do the same. So we do recursive work with the same buffer.
This change helps to eliminate it by not adding connect command to the leaf buffer since we already put to the buffer or will put command depending on connectCmd.
It also tries to remove duplicated dependencies between newLeaf and oldLeaf. If connection command inserted new leaf already depends on old leaf via connect cmd. So we do not put old leaf as standalone dependency.

Signed-off-by: Tikhomirova, Kseniya <kseniya.tikhomirova@intel.com>