### PR TITLE
[SYCL][NFC] Resolve cyclic dependency in headers

### DIFF
--- a/sycl/include/sycl/ext/intel/fpga_device_selector.hpp
+++ b/sycl/include/sycl/ext/intel/fpga_device_selector.hpp
@@ -8,10 +8,17 @@
 
 #pragma once
 
-#include <CL/sycl.hpp>
+#include <CL/sycl/device.hpp>
+#include <CL/sycl/device_selector.hpp>
+
+#include <string>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
+
+// Forward declaration
+class platform;
+
 namespace ext {
 namespace intel {
 


### PR DESCRIPTION
This change breaks sycl.hpp <- fpga_device_selector.hpp <- sycl.hpp
cycle of includes.