### PR TITLE
[SYCL][NFC] Fix C++20 compilation in lambda capturing this

### DIFF
--- a/sycl/plugins/level_zero/usm_allocator.cpp
+++ b/sycl/plugins/level_zero/usm_allocator.cpp
@@ -191,7 +191,7 @@ public:
       return More;
     };
 
-    auto MemParser = [=](std::string &Params, SystemMemory::MemType M) {
+    auto MemParser = [=, this](std::string &Params, SystemMemory::MemType M) {
       bool ParamWasSet;
       SystemMemory::MemType LM = M;
       if (M == SystemMemory::All)


### PR DESCRIPTION
This shows up because we are compiling the SYCL runtime in C++20 mode with `set(CMAKE_CXX_STANDARD 20)` in `sycl/CMakeLists.txt`.