### PR TITLE
[SYC][NFC] Unify C++ version check

### DIFF
--- a/sycl/include/CL/sycl/access/access.hpp
+++ b/sycl/include/CL/sycl/access/access.hpp
@@ -72,7 +72,7 @@ template <access_mode mode, target trgt> struct mode_target_tag_t {
   explicit mode_target_tag_t() = default;
 };
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
 inline constexpr mode_tag_t<access_mode::read> read_only{};
 inline constexpr mode_tag_t<access_mode::read_write> read_write{};

--- a/sycl/include/CL/sycl/accessor.hpp
+++ b/sycl/include/CL/sycl/accessor.hpp
@@ -876,7 +876,7 @@ protected:
     return AdjustedMode;
   }
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
   template <typename TagT> static constexpr bool IsValidTag() {
     return std::is_same<TagT, mode_tag_t<AccessMode>>::value ||
@@ -1187,7 +1187,7 @@ public:
   }
 #endif
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename TagT,
@@ -1277,7 +1277,7 @@ public:
   }
 #endif
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename TagT,
@@ -1333,7 +1333,7 @@ public:
       const detail::code_location CodeLoc = detail::code_location::current())
       : accessor(BufferRef, AccessRange, {}, PropertyList, CodeLoc) {}
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename TagT,
@@ -1389,7 +1389,7 @@ public:
       : accessor(BufferRef, CommandGroupHandler, AccessRange, {}, PropertyList,
                  CodeLoc) {}
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename TagT,
@@ -1486,7 +1486,7 @@ public:
   }
 #endif
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename TagT,
@@ -1579,7 +1579,7 @@ public:
   }
 #endif
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename TagT,
@@ -1770,7 +1770,7 @@ private:
   }
 };
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
 template <typename DataT, int Dimensions, typename AllocatorT>
 accessor(buffer<DataT, Dimensions, AllocatorT>)
@@ -2302,7 +2302,7 @@ protected:
     return std::is_same<T, DataT>::value && (Dims > 0) && (Dims == Dimensions);
   }
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
   template <typename TagT> static constexpr bool IsValidTag() {
     return std::is_same<TagT, mode_tag_t<AccessMode>>::value;
@@ -2361,7 +2361,7 @@ public:
       const detail::code_location CodeLoc = detail::code_location::current())
       : AccessorT(BufferRef, PropertyList, CodeLoc) {}
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>()>>
@@ -2381,7 +2381,7 @@ public:
       const detail::code_location CodeLoc = detail::code_location::current())
       : AccessorT(BufferRef, CommandGroupHandler, PropertyList, CodeLoc) {}
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>()>>
@@ -2402,7 +2402,7 @@ public:
       const detail::code_location CodeLoc = detail::code_location::current())
       : AccessorT(BufferRef, AccessRange, {}, PropertyList, CodeLoc) {}
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>()>>
@@ -2425,7 +2425,7 @@ public:
       : AccessorT(BufferRef, CommandGroupHandler, AccessRange, {}, PropertyList,
                   CodeLoc) {}
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>()>>
@@ -2449,7 +2449,7 @@ public:
       : AccessorT(BufferRef, AccessRange, AccessOffset, PropertyList, CodeLoc) {
   }
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>()>>
@@ -2473,7 +2473,7 @@ public:
       : AccessorT(BufferRef, CommandGroupHandler, AccessRange, AccessOffset,
                   PropertyList, CodeLoc) {}
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>()>>
@@ -2489,7 +2489,7 @@ public:
 #endif
 };
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
 template <typename DataT, int Dimensions, typename AllocatorT>
 host_accessor(buffer<DataT, Dimensions, AllocatorT>)

--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -373,7 +373,7 @@ public:
         *this, accessRange, accessOffset, {}, CodeLoc);
   }
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
   template <typename... Ts> auto get_access(Ts... args) {
     return accessor{*this, args...};

--- a/sycl/include/CL/sycl/detail/accessor_impl.hpp
+++ b/sycl/include/CL/sycl/detail/accessor_impl.hpp
@@ -209,7 +209,7 @@ using Requirement = AccessorImplHost;
 
 void __SYCL_EXPORT addHostAccessorAndWait(Requirement *Req);
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
 template <typename MayBeTag1, typename MayBeTag2>
 constexpr access::mode deduceAccessMode() {

--- a/sycl/include/CL/sycl/detail/defines_elementary.hpp
+++ b/sycl/include/CL/sycl/detail/defines_elementary.hpp
@@ -75,7 +75,7 @@
 #endif
 
 #ifndef __SYCL_FALLTHROUGH
-#if defined(__cplusplus) && __cplusplus >= 201703L &&                           \
+#if defined(__cplusplus) && __cplusplus >= 201703L &&                          \
     __SYCL_HAS_CPP_ATTRIBUTE(fallthrough)
 #define __SYCL_FALLTHROUGH [[fallthrough]]
 #elif __SYCL_HAS_CPP_ATTRIBUTE(gnu::fallthrough)

--- a/sycl/include/CL/sycl/detail/defines_elementary.hpp
+++ b/sycl/include/CL/sycl/detail/defines_elementary.hpp
@@ -75,7 +75,7 @@
 #endif
 
 #ifndef __SYCL_FALLTHROUGH
-#if defined(__cplusplus) && __cplusplus > 201402L &&                           \
+#if defined(__cplusplus) && __cplusplus >= 201703L &&                           \
     __SYCL_HAS_CPP_ATTRIBUTE(fallthrough)
 #define __SYCL_FALLTHROUGH [[fallthrough]]
 #elif __SYCL_HAS_CPP_ATTRIBUTE(gnu::fallthrough)

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -1298,7 +1298,7 @@ public:
   handler &operator=(const handler &) = delete;
   handler &operator=(handler &&) = delete;
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
   template <auto &SpecName>
   void set_specialization_constant(
       typename std::remove_reference_t<decltype(SpecName)>::value_type Value) {

--- a/sycl/include/CL/sycl/kernel_bundle.hpp
+++ b/sycl/include/CL/sycl/kernel_bundle.hpp
@@ -259,7 +259,7 @@ public:
   // This guard is needed because the libsycl.so can compiled with C++ <=14
   // while the code requires C++17. This code is not supposed to be used by the
   // libsycl.so so it should not be a problem.
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
   /// \returns true if any device image in the kernel_bundle uses specialization
   /// constant whose address is SpecName
   template <auto &SpecName> bool has_specialization_constant() const noexcept {

--- a/sycl/include/CL/sycl/kernel_handler.hpp
+++ b/sycl/include/CL/sycl/kernel_handler.hpp
@@ -21,7 +21,7 @@ namespace sycl {
 /// \ingroup sycl_api
 class kernel_handler {
 public:
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
   template <auto &S>
   typename std::remove_reference_t<decltype(S)>::value_type
   get_specialization_constant() {
@@ -35,7 +35,7 @@ public:
         PI_INVALID_OPERATION);
 #endif // __SYCL_DEVICE_ONLY__
   }
-#endif // __cplusplus > 201402L
+#endif // __cplusplus >= 201703L
 
 private:
   void __init_specialization_constants_buffer(

--- a/sycl/include/CL/sycl/properties/accessor_properties.hpp
+++ b/sycl/include/CL/sycl/properties/accessor_properties.hpp
@@ -25,7 +25,7 @@ class __SYCL2020_DEPRECATED("spelling is now: no_init") noinit
 
 } // namespace property
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
 __SYCL_INLINE_CONSTEXPR property::no_init no_init;
 
@@ -61,7 +61,7 @@ struct buffer_location {
   };
 };
 } // namespace property
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 template <int A>
 inline constexpr property::buffer_location::instance<A> buffer_location{};
 #endif
@@ -93,7 +93,7 @@ struct no_alias {
 };
 } // namespace property
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
 inline constexpr property::no_offset::instance no_offset;
 inline constexpr property::no_alias::instance no_alias;

--- a/sycl/include/sycl/ext/oneapi/atomic_accessor.hpp
+++ b/sycl/include/sycl/ext/oneapi/atomic_accessor.hpp
@@ -18,7 +18,7 @@ namespace sycl {
 namespace ext {
 namespace oneapi {
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
 template <memory_order> struct order_tag_t {
   explicit order_tag_t() = default;
@@ -69,7 +69,7 @@ public:
 
   using AccessorT::AccessorT;
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             memory_order Order, memory_scope Scope>
@@ -108,7 +108,7 @@ public:
   }
 };
 
-#if __cplusplus > 201402L
+#if __cplusplus >= 201703L
 
 template <typename DataT, int Dimensions, typename AllocatorT,
           memory_order Order, memory_scope Scope>


### PR DESCRIPTION
Currently DPC++ headers use two different ways to check whether C++
version is 17 or higher.
`#if __cplusplus > 201402L` and `#if __cplusplus >= 201703L`.
This patch make `#if __cplusplus >= 201703L` a canonical version of the
C++ version check.