### PR TITLE
[SYCL][CUDA] Add managed mem check to enqueue prefetch

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -4762,6 +4762,12 @@ pi_result cuda_piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr,
     return PI_PLUGIN_SPECIFIC_ERROR;
   }
 
+  unsigned int is_managed;
+  PI_CHECK_ERROR(cuPointerGetAttribute(
+      &is_managed, CU_POINTER_ATTRIBUTE_IS_MANAGED, (CUdeviceptr)ptr));
+  if (!is_managed)
+    return PI_SUCCESS;
+
   // flags is currently unused so fail if set
   if (flags != 0)
     return PI_INVALID_VALUE;

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -4765,8 +4765,11 @@ pi_result cuda_piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr,
   unsigned int is_managed;
   PI_CHECK_ERROR(cuPointerGetAttribute(
       &is_managed, CU_POINTER_ATTRIBUTE_IS_MANAGED, (CUdeviceptr)ptr));
-  if (!is_managed)
-    return PI_SUCCESS;
+  if (!is_managed) {
+    setErrorMessage("Prefetch hint ignored as prefetch only works with ",
+                    "USM" PI_SUCCESS);
+    return PI_PLUGIN_SPECIFIC_ERROR;
+  }
 
   // flags is currently unused so fail if set
   if (flags != 0)

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -4766,8 +4766,8 @@ pi_result cuda_piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr,
   PI_CHECK_ERROR(cuPointerGetAttribute(
       &is_managed, CU_POINTER_ATTRIBUTE_IS_MANAGED, (CUdeviceptr)ptr));
   if (!is_managed) {
-    setErrorMessage("Prefetch hint ignored as prefetch only works with ",
-                    "USM" PI_SUCCESS);
+    setErrorMessage("Prefetch hint ignored as prefetch only works with USM",
+                    PI_SUCCESS);
     return PI_PLUGIN_SPECIFIC_ERROR;
   }
 


### PR DESCRIPTION
This PR adds a managed memory check in `cuda_piextUSMEnqueuePrefetch`. 
`cuMemPrefetchAsync` only works on managed memory and returns an error if host or device memory is passed. 

This check ignores the prefetch hint if the memory provided is not managed.
A warning is emitted to the user if the prefetch is ignored.

This is a partial fix to: #5209