### PR TITLE
[SYCL] Add support for SYCL 2020 in class group

### DIFF
--- a/sycl/include/CL/sycl/group.hpp
+++ b/sycl/include/CL/sycl/group.hpp
@@ -108,6 +108,12 @@ public:
 
   size_t get_id(int dimension) const { return index[dimension]; }
 
+  // get_group_id functions are successors in SYCL 2020 for get_id functions
+  // from SYCL 1.2
+  id<Dimensions> get_group_id() const { return index; }
+
+  size_t get_group_id(int dimension) const { return index[dimension]; }
+
   range<Dimensions> get_global_range() const { return globalRange; }
 
   size_t get_global_range(int dimension) const {

--- a/sycl/include/CL/sycl/group.hpp
+++ b/sycl/include/CL/sycl/group.hpp
@@ -18,6 +18,7 @@
 #include <CL/sycl/device_event.hpp>
 #include <CL/sycl/h_item.hpp>
 #include <CL/sycl/id.hpp>
+#include <CL/sycl/info/info_desc.hpp>
 #include <CL/sycl/memory_enums.hpp>
 #include <CL/sycl/pointers.hpp>
 #include <CL/sycl/range.hpp>
@@ -104,12 +105,12 @@ public:
 
   group() = delete;
 
+  __SYCL_DEPRECATED("use sycl::group::get_group_id() instead")
   id<Dimensions> get_id() const { return index; }
 
+  __SYCL_DEPRECATED("use sycl::group::get_group_id() instead")
   size_t get_id(int dimension) const { return index[dimension]; }
 
-  // get_group_id functions are successors in SYCL 2020 for get_id functions
-  // from SYCL 1.2
   id<Dimensions> get_group_id() const { return index; }
 
   size_t get_group_id(int dimension) const { return index[dimension]; }
@@ -120,9 +121,65 @@ public:
     return globalRange[dimension];
   }
 
+  id<Dimensions> get_local_id() const {
+#ifdef __SYCL_DEVICE_ONLY__
+    return __spirv::initLocalInvocationId<Dimensions, id<Dimensions>>();
+#else
+    throw runtime_error("get_local_id() is not implemented on host device",
+                        PI_INVALID_DEVICE);
+    // Implementing get_local_id() on host device requires ABI breaking change.
+    // It requires extending class group with local item which represents
+    // local_id. Currently this local id is only used in nd_item and group
+    // cannot access it.
+#endif
+  }
+
+  template <int dims = Dimensions>
+  typename detail::enable_if_t<(dims == 1), size_t>
+  get_local_linear_id() const {
+    id<Dimensions> localId = get_local_id();
+    return localId[0];
+  }
+
+  template <int dims = Dimensions>
+  typename detail::enable_if_t<(dims == 2), size_t>
+  get_local_linear_id() const {
+    id<Dimensions> localId = get_local_id();
+    return localId[0] * groupRange[1] + localId[1];
+  }
+
+  template <int dims = Dimensions>
+  typename detail::enable_if_t<(dims == 3), size_t>
+  get_local_linear_id() const {
+    id<Dimensions> localId = get_local_id();
+    return (localId[0] * groupRange[1] * groupRange[2]) +
+           (localId[1] * groupRange[2]) + localId[2];
+  }
+
   range<Dimensions> get_local_range() const { return localRange; }
 
   size_t get_local_range(int dimension) const { return localRange[dimension]; }
+
+  template <int dims = Dimensions>
+  typename detail::enable_if_t<(dims == 1), size_t>
+  get_local_linear_range() const {
+    auto localRange = get_local_range();
+    return localRange[0];
+  }
+
+  template <int dims = Dimensions>
+  typename detail::enable_if_t<(dims == 2), size_t>
+  get_local_linear_range() const {
+    auto localRange = get_local_range();
+    return localRange[0] * localRange[1];
+  }
+
+  template <int dims = Dimensions>
+  typename detail::enable_if_t<(dims == 3), size_t>
+  get_local_linear_range() const {
+    auto localRange = get_local_range();
+    return localRange[0] * localRange[1] * localRange[2];
+  }
 
   range<Dimensions> get_group_range() const { return groupRange; }
 
@@ -130,15 +187,68 @@ public:
     return get_group_range()[dimension];
   }
 
+  template <int dims = Dimensions>
+  typename detail::enable_if_t<(dims == 1), size_t>
+  get_group_linear_range() const {
+    auto groupRange = get_group_range();
+    return groupRange[0];
+  }
+
+  template <int dims = Dimensions>
+  typename detail::enable_if_t<(dims == 2), size_t>
+  get_group_linear_range() const {
+    auto groupRange = get_group_range();
+    return groupRange[0] * groupRange[1];
+  }
+
+  template <int dims = Dimensions>
+  typename detail::enable_if_t<(dims == 3), size_t>
+  get_group_linear_range() const {
+    auto groupRange = get_group_range();
+    return groupRange[0] * groupRange[1] * groupRange[2];
+  }
+
+  template <int dims = Dimensions>
+  typename detail::enable_if_t<(dims == 1), range<Dimensions>>
+  get_max_local_range() const {
+    return range<Dimensions>{
+        static_cast<size_t>(info::device::max_work_group_size)};
+  }
+
+  template <int dims = Dimensions>
+  typename detail::enable_if_t<(dims == 2), range<Dimensions>>
+  get_max_local_range() const {
+    return range<Dimensions>{
+        static_cast<size_t>(info::device::max_work_group_size),
+        static_cast<size_t>(info::device::max_work_group_size)};
+  }
+
+  template <int dims = Dimensions>
+  typename detail::enable_if_t<(dims == 3), range<Dimensions>>
+  get_max_local_range() const {
+    return range<Dimensions>{
+        static_cast<size_t>(info::device::max_work_group_size),
+        static_cast<size_t>(info::device::max_work_group_size),
+        static_cast<size_t>(info::device::max_work_group_size)};
+  }
+
   size_t operator[](int dimension) const { return index[dimension]; }
 
   template <int dims = Dimensions>
-  typename detail::enable_if_t<(dims == 1), size_t> get_linear_id() const {
+  __SYCL_DEPRECATED("use sycl::group::get_group_linear_id() instead")
+  size_t get_linear_id() const {
+    return get_group_linear_id<dims>();
+  }
+
+  template <int dims = Dimensions>
+  typename detail::enable_if_t<(dims == 1), size_t>
+  get_group_linear_id() const {
     return index[0];
   }
 
   template <int dims = Dimensions>
-  typename detail::enable_if_t<(dims == 2), size_t> get_linear_id() const {
+  typename detail::enable_if_t<(dims == 2), size_t>
+  get_group_linear_id() const {
     return index[0] * groupRange[1] + index[1];
   }
 
@@ -153,10 +263,13 @@ public:
   //    Get a linearized version of the work-group id. Calculating a linear
   //    work-group id from a multi-dimensional index follows the equation 4.3.
   template <int dims = Dimensions>
-  typename detail::enable_if_t<(dims == 3), size_t> get_linear_id() const {
+  typename detail::enable_if_t<(dims == 3), size_t>
+  get_group_linear_id() const {
     return (index[0] * groupRange[1] * groupRange[2]) +
            (index[1] * groupRange[2]) + index[2];
   }
+
+  bool leader() const { return false; }
 
   template <typename WorkItemFunctionT>
   void parallel_for_work_item(WorkItemFunctionT Func) const {

--- a/sycl/test/basic_tests/group.cpp
+++ b/sycl/test/basic_tests/group.cpp
@@ -29,6 +29,19 @@ int main() {
   assert(one_dim.get_group_range(0) == 2);
   assert(one_dim[0] == 1);
   assert(one_dim.get_linear_id() == 1);
+  assert(one_dim.get_group_linear_id() == 1);
+
+  try {
+    one_dim.get_local_id();
+    assert(0); // get_local_id() is not implemented on host device
+  } catch (cl::sycl::runtime_error) {
+  }
+
+  try {
+    one_dim.get_local_linear_id();
+    assert(0); // get_local_id() is not implemented on host device
+  } catch (cl::sycl::runtime_error) {
+  }
 
   // two dimension group
   cl::sycl::group<2> two_dim = Builder::createGroup<2>({8, 4}, {4, 2}, {1, 1});
@@ -47,6 +60,19 @@ int main() {
   assert(two_dim[0] == 1);
   assert(two_dim[1] == 1);
   assert(two_dim.get_linear_id() == 3);
+  assert(two_dim.get_group_linear_id() == 3);
+
+  try {
+    two_dim.get_local_id();
+    assert(0); // get_local_id() is not implemented on host device
+  } catch (cl::sycl::runtime_error) {
+  }
+
+  try {
+    two_dim.get_local_linear_id();
+    assert(0); // get_local_id() is not implemented on host device
+  } catch (cl::sycl::runtime_error) {
+  }
 
   // three dimension group
   cl::sycl::group<3> three_dim =
@@ -71,4 +97,17 @@ int main() {
   assert(three_dim[1] == 1);
   assert(three_dim[2] == 1);
   assert(three_dim.get_linear_id() == 7);
+  assert(three_dim.get_group_linear_id() == 7);
+
+  try {
+    three_dim.get_local_id();
+    assert(0); // get_local_id() is not implemented on host device
+  } catch (cl::sycl::runtime_error) {
+  }
+
+  try {
+    three_dim.get_local_linear_id();
+    assert(0); // get_local_id() is not implemented on host device
+  } catch (cl::sycl::runtime_error) {
+  }
 }

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -179,5 +179,14 @@ int main() {
   // expected-warning@+1 {{'atomic<int, sycl::access::address_space::global_space>' is deprecated: sycl::atomic is deprecated since SYCL 2020}}
   cl::sycl::atomic<int> b(a);
 
+  cl::sycl::group<1> group =
+      cl::sycl::detail::Builder::createGroup<1>({8}, {4}, {1});
+  // expected-warning@+1{{'get_id' is deprecated: use sycl::group::get_group_id() instead}}
+  group.get_id();
+  // expected-warning@+1{{'get_id' is deprecated: use sycl::group::get_group_id() instead}}
+  group.get_id(1);
+  // expected-warning@+1{{'get_linear_id' is deprecated: use sycl::group::get_group_linear_id() instead}}
+  group.get_linear_id();
+
   return 0;
 }


### PR DESCRIPTION
Implement missing methods for `class group` according to SYCL 2020 4.9.1.7.