### PR TITLE
[ESIMD] Fix public simd and simd_view APIs.

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_mask_impl.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_mask_impl.hpp
@@ -49,7 +49,7 @@ public:
   /// Construct from an array. To allow e.g. simd_mask<N> m({1,0,0,1,...}).
   template <int N1, class = std::enable_if_t<N1 == N>>
   simd_mask_impl(const raw_element_type (&&Arr)[N1]) {
-    base_type::init_from_array(std::move(Arr));
+    base_type::template init_from_array<false>(std::move(Arr));
   }
 
   /// Implicit conversion from simd.

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_view_impl.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_view_impl.hpp
@@ -68,8 +68,6 @@ private:
 protected:
   simd_view_impl(BaseTy &Base, RegionTy Region)
       : M_base(Base), M_region(Region) {}
-  simd_view_impl(BaseTy &&Base, RegionTy Region)
-      : M_base(Base), M_region(Region) {}
 
   simd_view_impl(BaseTy &Base) : M_base(Base), M_region(RegionTy(0)) {}
 


### PR DESCRIPTION
- Remove simd::copy_to(RawTy (&&Arr)[N1]), as it does not make sense
- Remove simd_view_impl(BaseTy &&Base, RegionTy Region), as it does not make
  sense
- simd::copy_from(const RawTy (&&Arr)[N1]) -> ... Ty ..., as user APIs must not
  use raw types
- Replace "operator const simd::raw_vector_type &() const &" and
  "explicit operator raw_vector_type &() &" with
  "operator simd::raw_vector_type() const" - to avoid publishing references
  to internal state

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>