### PR TITLE
[CI] Enable tools for coverage measurements

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -191,6 +191,9 @@ jobs:
         cmake --build $GITHUB_WORKSPACE/build --target install-clang-format
         cmake --build $GITHUB_WORKSPACE/build --target install-clang-tidy
         cmake --build $GITHUB_WORKSPACE/build --target install-llvm-size
+        cmake --build $GITHUB_WORKSPACE/build --target install-llvm-cov
+        cmake --build $GITHUB_WORKSPACE/build --target install-llvm-profdata
+        cmake --build $GITHUB_WORKSPACE/build --target install-compiler-rt
         # TODO this should be resolved in CMakeLists.txt
         cmake --build $GITHUB_WORKSPACE/build --target install-lld || echo "skipped"
 

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -103,8 +103,8 @@ def do_configure(args):
         print("# Default CI configuration will be applied. #")
         print("#############################################")
 
-        # For clang-format and clang-tidy
-        llvm_enable_projects += ";clang-tools-extra"
+        # For clang-format, clang-tidy and code coverage
+        llvm_enable_projects += ";clang-tools-extra;compiler-rt"
         # libclc is required for CI validation
         if 'libclc' not in llvm_enable_projects:
             llvm_enable_projects += ';libclc'


### PR DESCRIPTION
Enable and install `compiler-rt` and coverage tools to measure SYCL runtime code coverage in CI.