### PR TITLE
[CI] Enable LLVM Test Suite in nightly

### DIFF
--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -18,7 +18,7 @@ jobs:
       build_github_cache: true
       build_cache_root: "/__w/"
       build_artifact_suffix: default
-      lts_config: "ocl_gen9;hip_amdgpu"
+      lts_config: "ocl_gen9;ocl_x64;hip_amdgpu"
   ubuntu2004_docker_build_push:
     if: github.repository == 'intel/llvm'
     runs-on: ubuntu-latest

--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -18,7 +18,7 @@ jobs:
       build_github_cache: true
       build_cache_root: "/__w/"
       build_artifact_suffix: default
-      lts_config: "l0_gen9"
+      lts_config: "ocl_gen9;hip_amdgpu"
   ubuntu2004_docker_build_push:
     if: github.repository == 'intel/llvm'
     runs-on: ubuntu-latest

--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -18,6 +18,7 @@ jobs:
       build_github_cache: true
       build_cache_root: "/__w/"
       build_artifact_suffix: default
+      lts_config: "l0_gen9"
   ubuntu2004_docker_build_push:
     if: github.repository == 'intel/llvm'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Enable LLVM Test Suite on OCL CPU, OCL GEN9 and AMD GPU HIP.
Level Zero faces test failures, and requires more analysis before enabling.