### PR TITLE
[ESIMD] Fix merge APIs.

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/esimd/alt_ui.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/alt_ui.hpp
@@ -21,29 +21,41 @@ namespace esimd {
 /// @addtogroup sycl_esimd_misc
 /// @{
 
-/// "Merges" elements of the input vectors according to the merge mask.
-/// @param a the first vector
-/// @param b the second vector
-/// @param m the merge mask
-/// @return a vector, where each element equals to corresponding element from
-///    \c a (if corresponding mask element is zero) or \c b (otherwise)
+/// "Merges" elements of the input simd object according to the merge mask.
+/// @param a The first simd object.
+/// @param b The second simd object.
+/// @param m The merge mask.
+/// @return A simd object, where each element equals to corresponding element
+///   from \c a if corresponding merge mask element is non-zero or element
+///   from \c b otherwise.
 template <class T, int N>
 __ESIMD_API simd<T, N> merge(simd<T, N> a, simd<T, N> b, simd_mask<N> m) {
-  a.merge(b, m);
-  return a;
+  b.merge(a, m);
+  return b;
 }
 
 /// "Merges" elements of the input masks according to the merge mask.
+/// @param a The first mask.
+/// @param b The second mask.
+/// @param m The merge mask.
+/// @return A mask, where each element equals to corresponding element from
+///    \c a if corresponding merge mask element is non-zero or \c element from
+///    \c b otherwise.
 template <int N>
 __ESIMD_API simd_mask<N> merge(simd_mask<N> a, simd_mask<N> b, simd_mask<N> m) {
-  a.merge(b, m);
+  b.merge(a, m);
   return a;
 }
 
 /// "Merges" elements of vectors referenced by the input views.
-/// Available only when all of the following holds:
-/// - the length and the element type of the sub-regions referenced by both
-///   input views are the same.
+/// Available only when all of the length and the element type of the subregions
+/// referenced by both input views are the same.
+/// @param a The first view.
+/// @param b The second view.
+/// @param m The merge mask.
+/// @return A vector (mask or simd object), where each element equals to
+///   corresponding element from \c a if corresponding merge mask element is
+///   non-zero or \c element from \c b otherwise.
 template <class BaseT1, class BaseT2, class RegionT1, class RegionT2,
           class = std::enable_if_t<
               (shape_type<RegionT1>::length == shape_type<RegionT2>::length) &&

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_obj_impl.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/simd_obj_impl.hpp
@@ -373,11 +373,11 @@ public:
 
   /// Merges given two objects with a mask and writes resulting data into this
   /// object.
-  /// @param Val1 The first object, provides elements for lanes with zero
+  /// @param Val1 The first object, provides elements for lanes with non-zero
   ///   corresponding predicates.
-  /// @param Val2 The second object, provides elements for lanes with non-zero
+  /// @param Val2 The second object, provides elements for lanes with zero
   ///   corresponding predicates.
-  /// @param Mask The mask.
+  /// @param Mask The merge mask.
   void merge(const Derived &Val1, Derived Val2, const simd_mask_type<N> &Mask) {
     Val2.merge(Val1, Mask);
     set(Val2.data());


### PR DESCRIPTION
- Inverse semantics of the merge mask in the new esimd::merge free function to
  match simd_obj_impl::merge(simd_obj_impl, simd_obj_impl, simd_mask), so that
  'a = esimd::merge(b, c, m);' has same semantics as 'a.merge(b, c, m);'
- Fix documentation for
  'simd_obj_impl::merge(simd_obj_impl, simd_obj_impl, simd_mask)'

E2E test: https://github.com/intel/llvm-test-suite/pull/739

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>