### PR TITLE
[Matrix][SYCL] Fix the bug of comparison between two bf16's wi_element

### DIFF
--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-jit.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-jit.hpp
@@ -477,8 +477,8 @@ public:
 
   explicit operator bool() {
 #ifdef __SYCL_DEVICE_ONLY__
-    return __spirv_VectorExtractDynamic(M.spvm, idx) !=
-           static_cast<uint16_t>(0);
+    return std::fabs(make_fp32(__spirv_VectorExtractDynamic(M.spvm, idx))) <
+           std::numeric_limits<float>::epsilon();
 #else
     throw runtime_error("joint matrix is not supported on host device.",
                         PI_INVALID_DEVICE);
@@ -706,8 +706,9 @@ public:
   operator==(const wi_element<uint16_t, NumRows, NumCols, Layout, Group> &lhs,
              const uint16_t &rhs) {
 #ifdef __SYCL_DEVICE_ONLY__
-    return make_fp32(__spirv_VectorExtractDynamic(lhs.M.spvm, lhs.idx)) ==
-           make_fp32(rhs);
+    return std::fabs(
+               make_fp32(__spirv_VectorExtractDynamic(lhs.M.spvm, lhs.idx)) -
+               make_fp32(rhs)) < std::numeric_limits<float>::epsilon();
 #else
     (void)lhs;
     (void)rhs;
@@ -720,8 +721,9 @@ public:
   operator!=(const wi_element<uint16_t, NumRows, NumCols, Layout, Group> &lhs,
              const uint16_t &rhs) {
 #ifdef __SYCL_DEVICE_ONLY__
-    return make_fp32(__spirv_VectorExtractDynamic(lhs.M.spvm, lhs.idx)) !=
-           make_fp32(rhs);
+    return std::fabs(
+               make_fp32(__spirv_VectorExtractDynamic(lhs.M.spvm, lhs.idx)) -
+               make_fp32(rhs)) >= std::numeric_limits<float>::epsilon();
 #else
     (void)lhs;
     (void)rhs;

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-jit.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-jit.hpp
@@ -477,7 +477,7 @@ public:
 
   explicit operator bool() {
 #ifdef __SYCL_DEVICE_ONLY__
-    return std::fabs(make_fp32(__spirv_VectorExtractDynamic(M.spvm, idx))) <
+    return std::fabs(make_fp32(__spirv_VectorExtractDynamic(M.spvm, idx))) >=
            std::numeric_limits<float>::epsilon();
 #else
     throw runtime_error("joint matrix is not supported on host device.",


### PR DESCRIPTION
Previously, as for bf16's comparison, we directly compare two unsigned short and it is wrong.
Now, we extend b16 to float and do the correct comparsion.