### PR TITLE
[CI] Automatically close stale issues

### DIFF
--- a/.github/workflows/sycl_stale_ussues.yml
+++ b/.github/workflows/sycl_stale_ussues.yml
@@ -1,0 +1,18 @@
+name: Stale Issues
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  runs-on: ubuntu-latest
+  steps:
+  - uses: actions/stale@v4
+    with:
+      stale-issue-message: 'This issue is stale because it has been open 180 days with no activity. Remove stale label or comment or this will be closed in 30 days.'
+      close-issue-message: 'This issue was closed because it has been stalled for 30 days with no activity.'
+      days-before-stale: 180
+      days-before-close: 30
+      exempt-issue-labels: 'confirmed,hip,cuda,enhancement'
+      stale-issue-label: 'stale'
+      exempt-all-issue-assignees: true


### PR DESCRIPTION
New job will close issues if:
- They have been stalled for 30 days or more
- They have no assignee
- They don't have `enhancement`, `confirmed`, `cuda`, or `hip` labels

Issues are considered to be stalled if there was no activity for 180 days.