### PR TITLE
[SYCL] Change cast for vector<cl_event> if SYCL2020_CONFORMANT_APIS macro is defined

### DIFF
--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -416,6 +416,9 @@ template <class To, class From> inline To cast(From value) {
 // Cast for std::vector<cl_event>, according to the spec, make_event
 // should create one(?) event from a vector of cl_event
 template <class To> inline To cast(std::vector<cl_event> value) {
+  RT::assertion(value.size() == 1,
+                "Temporary workaround requires that the "
+                "size of the input vector for make_event be equal to one.");
   return (To)(value[0]);
 }
 

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -413,13 +413,11 @@ template <class To, class From> inline To cast(From value) {
   return (To)(value);
 }
 
-#ifdef SYCL2020_CONFORMANT_APIS
 // Cast for std::vector<cl_event>, according to the spec, make_event
-// should create one cl_event from a vector of cl_event
+// should create one(?) event from a vector of cl_event
 template <class To> inline To cast(std::vector<cl_event> value) {
   return (To)(value[0]);
 }
-#endif
 
 // These conversions should use PI interop API.
 template <> inline pi::PiProgram cast(cl_program) {

--- a/sycl/include/CL/sycl/detail/pi.hpp
+++ b/sycl/include/CL/sycl/detail/pi.hpp
@@ -413,6 +413,14 @@ template <class To, class From> inline To cast(From value) {
   return (To)(value);
 }
 
+#ifdef SYCL2020_CONFORMANT_APIS
+// Cast for std::vector<cl_event>, according to the spec, make_event
+// should create one cl_event from a vector of cl_event
+template <class To> inline To cast(std::vector<cl_event> value) {
+  return (To)(value[0]);
+}
+#endif
+
 // These conversions should use PI interop API.
 template <> inline pi::PiProgram cast(cl_program) {
   RT::assertion(false, "pi::cast -> use piextCreateProgramWithNativeHandle");

--- a/sycl/test/regression/check_vector_of_opencl_event.cpp
+++ b/sycl/test/regression/check_vector_of_opencl_event.cpp
@@ -18,6 +18,8 @@ int main() {
     });
     std::vector<cl_event> interopEventVec =
         sycl::get_native<sycl::backend::opencl>(event);
+    auto outEvent = sycl::make_event<sycl::backend::opencl>(
+        interopEventVec, Queue.get_context());
   }
 #endif
 }

--- a/sycl/test/regression/check_vector_of_opencl_event.cpp
+++ b/sycl/test/regression/check_vector_of_opencl_event.cpp
@@ -1,25 +1,30 @@
-// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify -DSYCL2020_CONFORMANT_APIS %s
-// expected-no-diagnostics
+// RUN: %clangxx -fsycl -DSYCL2020_CONFORMANT_APIS %s -o %t.out
+// RUN: %RUN_ON_HOST %t.out
 //
 //===----------------------------------------------------------------------===//
-// This test checks that sycl::get_native<sycl::backend::opencl>(event) return
-// std::vector<cl_event> when backend = opencl, according to:
-// SYCL™ 2020 Specification (revision 3)
+// This test verifies that sycl::get_native<backend::opencl> and
+// sycl::make_event<backend::opencl> work according to the SYCL™ 2020
+// Specification (revision 4)
 //===----------------------------------------------------------------------===//
 
 #include <sycl/sycl.hpp>
 
 int main() {
-#ifdef SYCL_BACKEND_OPENCL
   sycl::queue Queue;
   if (Queue.get_backend() == sycl::backend::opencl) {
     sycl::event event = Queue.submit([&](sycl::handler &cgh) {
       cgh.single_task<class event_kernel>([]() {});
     });
-    std::vector<cl_event> interopEventVec =
-        sycl::get_native<sycl::backend::opencl>(event);
-    auto outEvent = sycl::make_event<sycl::backend::opencl>(
-        interopEventVec, Queue.get_context());
+    // Check that get_native function returns a vector
+    std::vector<cl_event> ClEventVec = get_native<sycl::backend::opencl>(event);
+    // Check that make_event is working properly with vector<cl_event> as a
+    // param
+    sycl::event SyclEvent = sycl::make_event<sycl::backend::opencl>(
+        ClEventVec, Queue.get_context());
+    std::vector<cl_event> ClEventVecFromMake =
+        sycl::get_native<sycl::backend::opencl>(SyclEvent);
+    if (ClEventVec[0] != ClEventVecFromMake[0])
+      throw std::runtime_error("Cl events are not the same");
   }
-#endif
+  return 0;
 }


### PR DESCRIPTION
Change cast for vector<cl_event> if SYCL2020_CONFORMANT_APIS macro is defined.
According to the spec, make_event\<sycl::backend::opencl\>() should create one cl_event from a vector of cl_event