### PR TITLE
[SYCL] Warn on explicit cast from default address space to named 

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11611,7 +11611,7 @@ def warn_sycl_implicit_decl
               "declaration for a kernel type name; your program may not "
               "be portable">,
       InGroup<SyclStrict>, ShowInSystemHeader, DefaultIgnore;
-def warn_sycl_nonsecure_as_cast : Warning<
+def warn_sycl_potentially_invalid_as_cast : Warning<
   "explicit cast from %0 to %1 potentially leads to an invalid address space"
   " cast in the resulting code">, InGroup<SyclStrict>,
   ShowInSystemHeader;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11611,6 +11611,10 @@ def warn_sycl_implicit_decl
               "declaration for a kernel type name; your program may not "
               "be portable">,
       InGroup<SyclStrict>, ShowInSystemHeader, DefaultIgnore;
+def warn_sycl_nonsecure_as_cast : Warning<
+  "explicit cast from %0 to %1 potentially leads to an invalid address space"
+  " cast in the resulting code">, InGroup<SyclStrict>,
+  ShowInSystemHeader;
 def err_ivdep_duplicate_arg : Error<
   "duplicate argument to 'ivdep'; attribute requires one or both of a safelen "
   "and array">;

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -2573,8 +2573,7 @@ static TryCastResult TryAddressSpaceCast(Sema &Self, ExprResult &SrcExpr,
   if (Self.getLangOpts().SYCLIsDevice) {
     Qualifiers SrcQ = SrcPointeeType.getQualifiers();
     Qualifiers DestQ = DestPointeeType.getQualifiers();
-    if (SrcQ.isAddressSpaceSupersetOf(DestQ) &&
-        !DestQ.isAddressSpaceSupersetOf(SrcQ) && OpRange.isValid()) {
+    if (!DestQ.isAddressSpaceSupersetOf(SrcQ) && OpRange.isValid()) {
       Self.SYCLDiagIfDeviceCode(OpRange.getBegin(),
                                 diag::warn_sycl_potentially_invalid_as_cast)
           << SrcType << DestType << OpRange;

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -2576,7 +2576,7 @@ static TryCastResult TryAddressSpaceCast(Sema &Self, ExprResult &SrcExpr,
     if (SrcQ.isAddressSpaceSupersetOf(DestQ) &&
         !DestQ.isAddressSpaceSupersetOf(SrcQ) && OpRange.isValid()) {
       Self.SYCLDiagIfDeviceCode(OpRange.getBegin(),
-                                diag::warn_sycl_nonsecure_as_cast)
+                                diag::warn_sycl_potentially_invalid_as_cast)
           << SrcType << DestType << OpRange;
     }
   }

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -2545,7 +2545,7 @@ static TryCastResult TryReinterpretCast(Sema &Self, ExprResult &SrcExpr,
 static TryCastResult TryAddressSpaceCast(Sema &Self, ExprResult &SrcExpr,
                                          QualType DestType, bool CStyle,
                                          unsigned &msg, CastKind &Kind) {
-  if (!Self.getLangOpts().OpenCL)
+  if (!Self.getLangOpts().OpenCL && !Self.getLangOpts().SYCLIsDevice)
     // FIXME: As compiler doesn't have any information about overlapping addr
     // spaces at the moment we have to be permissive here.
     return TC_NotApplicable;

--- a/clang/test/CodeGenSYCL/address-space-conversions.cpp
+++ b/clang/test/CodeGenSYCL/address-space-conversions.cpp
@@ -40,7 +40,7 @@ __attribute__((sycl_device)) void usages() {
   __attribute__((opencl_global_host)) int *GLOBHOST;
 
   // Explicit conversions
-  // From names address spaces to default address space
+  // From named address spaces to default address space
   // CHECK-DAG: [[GLOB_LOAD:%[a-zA-Z0-9]+]] = load i32 addrspace(1)*, i32 addrspace(1)* addrspace(4)* [[GLOB]].ascast
   // CHECK-DAG: [[GLOB_CAST:%[a-zA-Z0-9]+]] = addrspacecast i32 addrspace(1)* [[GLOB_LOAD]] to i32 addrspace(4)*
   // CHECK-DAG: store i32 addrspace(4)* [[GLOB_CAST]], i32 addrspace(4)* addrspace(4)* [[NoAS]].ascast

--- a/clang/test/SemaSYCL/Inputs/sycl.hpp
+++ b/clang/test/SemaSYCL/Inputs/sycl.hpp
@@ -33,7 +33,8 @@ enum class address_space : int {
   private_space = 0,
   global_space,
   constant_space,
-  local_space
+  local_space,
+  generic_space
 };
 } // namespace access
 
@@ -327,6 +328,33 @@ public:
 private:
   cl::sycl::accessor<char, 1, cl::sycl::access::mode::read_write> Acc;
   int FlushBufferSize;
+};
+
+template <typename ElementType, access::address_space addressSpace>
+struct DecoratedType;
+
+template <typename ElementType>
+struct DecoratedType<ElementType, access::address_space::private_space> {
+  using type = __attribute__((opencl_private)) ElementType;
+};
+
+template <typename ElementType>
+struct DecoratedType<ElementType, access::address_space::generic_space> {
+  using type = ElementType;
+};
+
+template <typename ElementType>
+struct DecoratedType<ElementType, access::address_space::global_space> {
+  using type = __attribute__((opencl_global)) ElementType;
+};
+
+template <typename T, access::address_space AS> class multi_ptr {
+  using pointer_t = typename DecoratedType<T, AS>::type *;
+  pointer_t m_Pointer;
+
+public:
+  multi_ptr(T *Ptr) : m_Pointer((pointer_t)(Ptr)) {}
+  pointer_t get() { return m_Pointer; }
 };
 
 namespace ext {

--- a/clang/test/SemaSYCL/address-space-conversions.cpp
+++ b/clang/test/SemaSYCL/address-space-conversions.cpp
@@ -59,6 +59,9 @@ void usages() {
   baz(NoAS);                                   // expected-error {{no matching function for call to 'baz'}}
   __attribute__((opencl_local)) int *l = NoAS; // expected-error {{cannot initialize a variable of type '__local int *' with an lvalue of type 'int *'}}
 
+  // Explicit casts between disjoint address spaces are disallowed
+  GLOB = (__attribute__((opencl_global)) int *)PRIV; // expected-error {{C-style cast from '__private int *' to '__global int *' converts between mismatching address spaces}}
+
   (void)static_cast<int *>(GLOB);
   (void)static_cast<void *>(GLOB);
   int *i = GLOB;

--- a/clang/test/SemaSYCL/explicit-cast-to-generic.cpp
+++ b/clang/test/SemaSYCL/explicit-cast-to-generic.cpp
@@ -1,0 +1,24 @@
+// RUN: %clang_cc1 -internal-isystem %S/Inputs -fsycl-is-device -verify -fsyntax-only %s
+
+// This test checks that a warning is emitted on attempt to cast from default
+// address space to named address spaces.
+
+#include "sycl.hpp"
+
+using namespace sycl;
+
+void foo(__attribute__((opencl_global)) int *A) {
+}
+
+void __attribute__((sycl_device)) onDeviceUsages(multi_ptr<int, access::address_space::global_space> F) {
+  int *NoAS;
+  // expected-warning@+1 {{explicit cast from 'int *' to '__local int *' potentially leads to an invalid address space cast in the resulting code}}
+  __attribute__((opencl_local)) int *LL = (__attribute((opencl_local)) int *)NoAS;
+
+  // expected-warning@Inputs/sycl.hpp:356 {{explicit cast from 'int *' to 'sycl::multi_ptr<int, sycl::access::address_space::private_space>::pointer_t' (aka '__private int *') potentially leads to an invalid address space cast in the resulting code}}
+  //expected-note@+1 {{called by 'onDeviceUsages'}}
+  auto P = multi_ptr<int, access::address_space::private_space>{F.get()};
+
+  // expected-warning@+1 {{explicit cast from 'int *' to '__global int *' potentially leads to an invalid address space cast in the resulting code}}
+  foo((__attribute((opencl_global)) int *)NoAS);
+}

--- a/clang/test/SemaSYCL/explicit-cast-to-generic.cpp
+++ b/clang/test/SemaSYCL/explicit-cast-to-generic.cpp
@@ -16,7 +16,7 @@ void __attribute__((sycl_device)) onDeviceUsages(multi_ptr<int, access::address_
   __attribute__((opencl_local)) int *LL = (__attribute((opencl_local)) int *)NoAS;
 
   // expected-warning@Inputs/sycl.hpp:356 {{explicit cast from 'int *' to 'sycl::multi_ptr<int, sycl::access::address_space::private_space>::pointer_t' (aka '__private int *') potentially leads to an invalid address space cast in the resulting code}}
-  //expected-note@+1 {{called by 'onDeviceUsages'}}
+  // expected-note@+1 {{called by 'onDeviceUsages'}}
   auto P = multi_ptr<int, access::address_space::private_space>{F.get()};
 
   // expected-warning@+1 {{explicit cast from 'int *' to '__global int *' potentially leads to an invalid address space cast in the resulting code}}


### PR DESCRIPTION
Such cast is allowed by the doc
https://github.com/intel/llvm/blob/sycl/clang/docs/SYCLSupport.rst#id2,
but patterns like
```
__global int *Global;
__private int *Private;
int *Default;

Default = Global;
Private = (__private int *)Default;
```
may create incorrect address space casts. It is not always that obvious where
the cast has happened and it may happen under the hood of SYCL classes like in
https://github.com/intel/llvm/issues/3172 .
The warning provides user-friendly info about concrete place in the code
that could cause address space problems.