### PR TITLE
[SYCL][FPGA] Ignore [[intel::kernel_args_restrict]] attribute on type position

### DIFF
--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -8282,8 +8282,10 @@ static void processTypeAttrs(TypeProcessingState &state, QualType &type,
       if (attr.isStandardAttributeSyntax() && TAL == TAL_DeclChunk &&
           (!state.isProcessingLambdaExpr() ||
            !attr.supportsNonconformingLambdaSyntax())) {
-        state.getSema().Diag(attr.getLoc(), diag::warn_unknown_attribute_ignored)
-            << attr << attr.getRange();;
+	state.getSema().Diag(attr.getLoc(),
+                             diag::warn_unknown_attribute_ignored)
+            << attr << attr.getRange();
+	;
       }
       break;
     case ParsedAttr::AT_OpenCLPrivateAddressSpace:

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -8275,6 +8275,17 @@ static void processTypeAttrs(TypeProcessingState &state, QualType &type,
       // it it breaks large amounts of Linux software.
       attr.setUsedAsTypeAttr();
       break;
+    case ParsedAttr::AT_SYCLIntelKernelArgsRestrict:
+      // The [[intel::kernel_args_restrict]] attribute has an effect when
+      // applied to a function, and no effect otherwise. Ignore the
+      // attribute with a warning for all other cases.
+      if (attr.isStandardAttributeSyntax() && TAL == TAL_DeclChunk &&
+          (!state.isProcessingLambdaExpr() ||
+           !attr.supportsNonconformingLambdaSyntax())) {
+        state.getSema().Diag(attr.getLoc(), diag::warn_unknown_attribute_ignored)
+            << attr << attr.getRange();;
+      }
+      break;
     case ParsedAttr::AT_OpenCLPrivateAddressSpace:
     case ParsedAttr::AT_OpenCLGlobalAddressSpace:
     case ParsedAttr::AT_OpenCLGlobalDeviceAddressSpace:

--- a/clang/lib/Sema/SemaType.cpp
+++ b/clang/lib/Sema/SemaType.cpp
@@ -8282,10 +8282,10 @@ static void processTypeAttrs(TypeProcessingState &state, QualType &type,
       if (attr.isStandardAttributeSyntax() && TAL == TAL_DeclChunk &&
           (!state.isProcessingLambdaExpr() ||
            !attr.supportsNonconformingLambdaSyntax())) {
-	state.getSema().Diag(attr.getLoc(),
+        state.getSema().Diag(attr.getLoc(),
                              diag::warn_unknown_attribute_ignored)
             << attr << attr.getRange();
-	;
+        ;
       }
       break;
     case ParsedAttr::AT_OpenCLPrivateAddressSpace:

--- a/clang/test/SemaSYCL/intel-restrict.cpp
+++ b/clang/test/SemaSYCL/intel-restrict.cpp
@@ -1,10 +1,16 @@
 // RUN: %clang_cc1 %s -fsyntax-only -fsycl-is-device -sycl-std=2017 -Wno-sycl-2017-compat -triple spir64 -DCHECKDIAG -verify
 // RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl-is-device -sycl-std=2017 -Wno-sycl-2017-compat -triple spir64 | FileCheck %s
 
-[[intel::kernel_args_restrict]] void func_do_not_ignore() {}
+[[intel::kernel_args_restrict]] void func_do_not_ignore() {} // OK
+
+void func_ignore() [[intel::kernel_args_restrict]] {} // expected-warning{{unknown attribute 'kernel_args_restrict' ignored}}
 
 struct FuncObj {
-  [[intel::kernel_args_restrict]] void operator()() const {}
+  [[intel::kernel_args_restrict]] void operator()() const {} // OK
+};
+
+struct Func {
+  void operator()() const [[intel::kernel_args_restrict]] {} // expected-warning{{unknown attribute 'kernel_args_restrict' ignored}}
 };
 
 template <typename name, typename Func>
@@ -30,4 +36,14 @@ int main() {
   // CHECK:       SYCLIntelKernelArgsRestrictAttr
   kernel<class test_kernel3>(
       []() { func_do_not_ignore(); });
+
+  // CHECK-LABEL: FunctionDecl {{.*}}test_kernel4
+  // CHECK-NOT:   SYCLIntelKernelArgsRestrictAttr
+  kernel<class test_kernel4>(
+      []() { Func(); });
+
+  // CHECK-LABEL: FunctionDecl {{.*}}test_kernel5
+  // CHECK-NOT:   SYCLIntelKernelArgsRestrictAttr
+  kernel<class test_kernel5>(
+      []() { func_ignore(); });
 }

--- a/clang/test/SemaSYCL/intel-restrict.cpp
+++ b/clang/test/SemaSYCL/intel-restrict.cpp
@@ -1,6 +1,8 @@
 // RUN: %clang_cc1 %s -fsyntax-only -fsycl-is-device -sycl-std=2017 -Wno-sycl-2017-compat -triple spir64 -DCHECKDIAG -verify
 // RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl-is-device -sycl-std=2017 -Wno-sycl-2017-compat -triple spir64 | FileCheck %s
 
+// Test checks support and functionality of [[intel::kernel_args_restrict]] attribute.
+
 [[intel::kernel_args_restrict]] void func_do_not_ignore() {} // OK
 
 void func_ignore() [[intel::kernel_args_restrict]] {} // expected-warning{{unknown attribute 'kernel_args_restrict' ignored}}


### PR DESCRIPTION
The [[intel::kernel_args_restrict]] attribute was implemented as a function declaration attribute: https://github.com/intel/llvm/commit/36319015d158941be07abdd85d06de40a74eab8e couple of years ago.

The attribute currently shows an error below when it is applied to type of the operator() instead of 'functor' or operator() itself.
error: 'kernel_args_restrict' attribute cannot be applied to types

class functor_foo {
    void operator()() [[intel::kernel_args_restrict]] { }
}; 

According to the spec: https://github.com/triSYCL/sycl/blob/sycl/unified/master/sycl/doc/extensions/KernelRestrictAll/SYCL_INTEL_kernel_restrict_all.asciidoc, the intel::kernel_args_restrict attribute has an effect when applied to a function, and no effect otherwise.

This patch ignores the attribute with a warning instead of error when it is applied to the type position in a function declaration.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>