### PR TITLE
[SYCL] Allow [[sycl::device_has]] attribute on kernel

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1246,6 +1246,7 @@ def SYCLDeviceHas : InheritableAttr {
   let Args = [VariadicExprArgument<"Aspects">];
   let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let Documentation = [SYCLDeviceHasDocs];
+  let SupportsNonconformingLambdaSyntax = 1;
 }
 
 def SYCLUsesAspects : InheritableAttr {

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -575,7 +575,7 @@ static void collectSYCLAttributes(Sema &S, FunctionDecl *FD,
       return isa<SYCLIntelLoopFuseAttr, SYCLIntelFPGAMaxConcurrencyAttr,
                  SYCLIntelFPGADisableLoopPipeliningAttr,
                  SYCLIntelFPGAInitiationIntervalAttr,
-                 SYCLIntelUseStallEnableClustersAttr>(A);
+                 SYCLIntelUseStallEnableClustersAttr, SYCLDeviceHasAttr>(A);
     });
   }
 }
@@ -3967,6 +3967,7 @@ static void PropagateAndDiagnoseDeviceAttr(
   case attr::Kind::SYCLIntelFPGADisableLoopPipelining:
   case attr::Kind::SYCLIntelFPGAInitiationInterval:
   case attr::Kind::SYCLIntelUseStallEnableClusters:
+  case attr::Kind::SYCLDeviceHas:
     SYCLKernel->addAttr(A);
     break;
   case attr::Kind::IntelNamedSubGroupSize:

--- a/clang/test/CodeGenSYCL/device_has.cpp
+++ b/clang/test/CodeGenSYCL/device_has.cpp
@@ -46,7 +46,7 @@ void foo() {
     KernelFunctor f1;
     h.single_task<class kernel_name_1>(f1);
     // CHECK: define dso_local spir_kernel void @{{.*}}kernel_name_2{{.*}} !intel_declared_aspects ![[ASPECTS4:[0-9]+]]
-    h.single_task<class kernel_name_2>([]() [[sycl::device_has(cl::sycl::aspect::gpu)]]{});
+    h.single_task<class kernel_name_2>([]() [[sycl::device_has(cl::sycl::aspect::gpu)]] {});
   });
 }
 

--- a/clang/test/SemaSYCL/device_has_ast.cpp
+++ b/clang/test/SemaSYCL/device_has_ast.cpp
@@ -60,10 +60,7 @@ void func5() {}
 // CHECK: CXXRecordDecl {{.*}} KernelFunctor
 class KernelFunctor {
 public:
-  // CHECK: CXXMethodDecl {{.*}} used operator() 'void () const'
-  // CHECK: SYCLDeviceHasAtt
-  // CHECK-NEXT: DeclRefExpr {{.*}} 'sycl::aspect' EnumConstant {{.*}} 'cpu' 'sycl::aspect'
-  [[sycl::device_has(cl::sycl::aspect::cpu)]] void operator()() const {
+  void operator()() const {
     func1();
     func2();
     func3();
@@ -73,20 +70,34 @@ public:
   }
 };
 
+// CHECK: CXXRecordDecl {{.*}} KernelFunctorAttr
+class KernelFunctorAttr {
+public:
+  // CHECK: CXXMethodDecl {{.*}} used operator() 'void () const'
+  // CHECK: SYCLDeviceHasAtt
+  // CHECK-NEXT: DeclRefExpr {{.*}} 'sycl::aspect' EnumConstant {{.*}} 'cpu' 'sycl::aspect'
+  [[sycl::device_has(cl::sycl::aspect::cpu)]] void operator()() const {}
+};
+
 void foo() {
   q.submit([&](handler &h) {
-    // Attribute applied on operator of kernel functor should be applied on kernel function.
-    // CHECK: FunctionDecl {{.*}}kernel_name_1
-    // CHECK: SYCLDeviceHasAttr
-    // CHECK-NEXT: DeclRefExpr {{.*}} 'sycl::aspect' EnumConstant {{.*}} 'cpu' 'sycl::aspect'
     // Attributes applied to functions called from the kernel should not be propagated to kernel.
+    // CHECK: FunctionDecl {{.*}}kernel_name_1
     // CHECK-NOT: SYCLDeviceHasAttr
     KernelFunctor f1;
     h.single_task<class kernel_name_1>(f1);
 
+    // Attribute applied to operator() method of kernel functor is applied to kernel function
     // CHECK: FunctionDecl {{.*}}kernel_name_2
     // CHECK: SYCLDeviceHasAttr
+    // CHECK-NEXT: DeclRefExpr {{.*}} 'sycl::aspect' EnumConstant {{.*}} 'cpu' 'sycl::aspect'
+    KernelFunctorAttr f2;
+    h.single_task<class kernel_name_2>(f2);
+
+    // Attribute applied to kernel lambda
+    // CHECK: FunctionDecl {{.*}}kernel_name_3
+    // CHECK: SYCLDeviceHasAttr
     // CHECK-NEXT: DeclRefExpr {{.*}} 'sycl::aspect' EnumConstant {{.*}} 'gpu' 'sycl::aspect'
-    h.single_task<class kernel_name_2>([]() [[sycl::device_has(cl::sycl::aspect::gpu)]]{});
+    h.single_task<class kernel_name_3>([]() [[sycl::device_has(cl::sycl::aspect::gpu)]] {});
   });
 }


### PR DESCRIPTION
The original implementation of this attribute in
https://github.com/intel/llvm/pull/5166, did not support
applying the attribute on the kernel itself. This patch
fixes that. The attribute can be applied to the operator
method of kernel functor or on the kernel lambda.

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>