### PR TITLE
[SYCL][CI] Add unit test coverage regression report for runtime

### DIFF
--- a/.github/workflows/sycl_pre_commit_rt.yml
+++ b/.github/workflows/sycl_pre_commit_rt.yml
@@ -5,12 +5,18 @@ on:
     branches:
     - sycl
     paths:
+    '.github/workflows/sycl_pre_commit_rt.yml'
+  pull_request_target:
+    branches:
+    - sycl
+    paths:
     - 'sycl/**'
     - '!sycl/doc/**'
 
 jobs:
   runtime_coverage:
     runs-on: ubuntu-latest
+    if: github.repository == 'intel/llvm'
     container:
       image: ghcr.io/intel/llvm/sycl_ubuntu2004_nightly:no-drivers
     steps:
@@ -59,6 +65,7 @@ jobs:
         name: sycl_rt_coverage
         path: exp/report/
     - name: Report difference
+      if: ${{ github.event_name == 'pull_request_target' }}
       uses: Nef10/lcov-reporter-action@badb09a7ebbd0906681002d671bcd16c819a911d
       with:
         lcov-file: exp.lcov

--- a/.github/workflows/sycl_pre_commit_rt.yml
+++ b/.github/workflows/sycl_pre_commit_rt.yml
@@ -48,7 +48,7 @@ jobs:
         ninja check-sycl-unittests
         cd ..
         python3 ./llvm/llvm/utils/prepare-code-coverage-artifact.py \
-          --unified-report llvm-profdata llvm-cov ./exp/tools/sycl/profiles \
+          --unified-report llvm-profdata llvm-cov ./ref/tools/sycl/profiles \
           ./ref/report ./ref/lib/libsycl.so
         llvm-cov export --format=lcov \
           --instr-profile=./ref/tools/sycl/profiles/Coverage.profdata \

--- a/.github/workflows/sycl_pre_commit_rt.yml
+++ b/.github/workflows/sycl_pre_commit_rt.yml
@@ -43,8 +43,8 @@ jobs:
         mkdir ref
         CC=clang CXX=clang++ python3 llvm/buildbot/configure.py \
           -t Debug -o ./ref --cmake-opt="-DSYCL_ENABLE_COVERAGE=ON" --no-werror
-        cd exp
         export LD_LIBRARY_PATH=$PWD/ref/lib:$LD_LIBRARY_PATH
+        cd ref
         ninja check-sycl-unittests
         cd ..
         python3 ./llvm/llvm/utils/prepare-code-coverage-artifact.py \

--- a/.github/workflows/sycl_pre_commit_rt.yml
+++ b/.github/workflows/sycl_pre_commit_rt.yml
@@ -5,7 +5,7 @@ on:
     branches:
     - sycl
     paths:
-    '.github/workflows/sycl_pre_commit_rt.yml'
+    - '.github/workflows/sycl_pre_commit_rt.yml'
   pull_request_target:
     branches:
     - sycl

--- a/.github/workflows/sycl_pre_commit_rt.yml
+++ b/.github/workflows/sycl_pre_commit_rt.yml
@@ -1,0 +1,64 @@
+name: SYCL RT
+
+on:
+  pull_request:
+    branches:
+    - sycl
+    paths:
+    - 'sycl/**'
+    - '!sycl/doc/**'
+
+jobs:
+  runtime_coverage:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/intel/llvm/sycl_ubuntu2004_nightly:no-drivers
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: llvm
+        fetch-depth: 2
+    - name: Experimental build
+      run: |
+        mkdir exp
+        CC=clang CXX=clang++ python3 llvm/buildbot/configure.py \
+          -t Debug -o ./exp --cmake-opt="-DSYCL_ENABLE_COVERAGE=ON" --no-werror
+        cd exp
+        ninja check-sycl-unittests
+        cd ..
+        python3 ./llvm/llvm/utils/prepare-code-coverage-artifact.py \
+          --unified-report llvm-profdata llvm-cov ./exp/tools/sycl/profiles \
+          ./exp/report ./exp/lib/libsycl.so
+        llvm-cov export --format=lcov \
+          --instr-profile=./exp/tools/sycl/profiles/Coverage.profdata \
+          ./exp/lib/libsycl.so > exp.lcov
+    - name: Get reference commit
+      run: |
+        cd llvm
+        git checkout ${GITHUB_SHA}^1
+        cd ..
+    - name: Reference build
+      run: |
+        mkdir ref
+        CC=clang CXX=clang++ python3 llvm/buildbot/configure.py \
+          -t Debug -o ./ref --cmake-opt="-DSYCL_ENABLE_COVERAGE=ON" --no-werror
+        cd exp
+        ninja check-sycl-unittests
+        cd ..
+        python3 ./llvm/llvm/utils/prepare-code-coverage-artifact.py \
+          --unified-report llvm-profdata llvm-cov ./exp/tools/sycl/profiles \
+          ./ref/report ./ref/lib/libsycl.so
+        llvm-cov export --format=lcov \
+          --instr-profile=./ref/tools/sycl/profiles/Coverage.profdata \
+          ./ref/lib/libsycl.so > ref.lcov
+    - name: Upload experimental report
+      uses: actions/upload-artifact@v2
+      with:
+        name: sycl_rt_coverage
+        path: exp/report/
+    - name: Report difference
+      uses: Nef10/lcov-reporter-action@badb09a7ebbd0906681002d671bcd16c819a911d
+      with:
+        lcov-file: exp.lcov
+        lcov-base: ref.lcov
+        pr-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/sycl_pre_commit_rt.yml
+++ b/.github/workflows/sycl_pre_commit_rt.yml
@@ -23,6 +23,7 @@ jobs:
         mkdir exp
         CC=clang CXX=clang++ python3 llvm/buildbot/configure.py \
           -t Debug -o ./exp --cmake-opt="-DSYCL_ENABLE_COVERAGE=ON" --no-werror
+        export LD_LIBRARY_PATH=$PWD/exp/lib:$LD_LIBRARY_PATH
         cd exp
         ninja check-sycl-unittests
         cd ..
@@ -43,6 +44,7 @@ jobs:
         CC=clang CXX=clang++ python3 llvm/buildbot/configure.py \
           -t Debug -o ./ref --cmake-opt="-DSYCL_ENABLE_COVERAGE=ON" --no-werror
         cd exp
+        export LD_LIBRARY_PATH=$PWD/ref/lib:$LD_LIBRARY_PATH
         ninja check-sycl-unittests
         cd ..
         python3 ./llvm/llvm/utils/prepare-code-coverage-artifact.py \

--- a/sycl/unittests/config/ConfigTests.cpp
+++ b/sycl/unittests/config/ConfigTests.cpp
@@ -10,7 +10,7 @@
 #include <gtest/gtest.h>
 #include <regex>
 
-TEST(ConfigTests, CheckConfigProcessing) {
+TEST(ConfigTests, DISABLED_CheckConfigProcessing) {
 #ifdef _WIN32
   _putenv_s("SYCL_CONFIG_FILE_NAME", "conf.txt");
 #else


### PR DESCRIPTION
Whenever there're changes to `sycl/` directory, a separate job will run regression testing on RT unit tests, and print code coverage difference as a comment to Pull Request. Developers are expected not to regress that metric.