### PR TITLE
[ESIMD] Update saturation usage interface and cleanup APIs.

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/esimd/common.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/common.hpp
@@ -13,6 +13,7 @@
 #include <CL/sycl/detail/defines.hpp>
 
 #include <cstdint> // for uint* types
+#include <type_traits>
 
 /// @cond ESIMD_DETAIL
 

--- a/sycl/include/sycl/ext/intel/experimental/esimd/common.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/common.hpp
@@ -81,16 +81,18 @@ using uchar = unsigned char;
 using ushort = unsigned short;
 using uint = unsigned int;
 
-/// Gen hardware supports applying saturation to results of some operation.
-/// This enum allows to control this behavior.
-enum class saturation : uint8_t { off, on };
+/// Gen hardware supports applying saturation to results of certain operations.
+/// This type tag represents "saturation on" behavior.
+struct saturation_on_tag : std::true_type {};
 
-/// Integer type short-cut to saturation::off.
-static inline constexpr uint8_t saturation_off =
-    static_cast<uint8_t>(saturation::off);
-/// Integer type short-cut to saturation::on.
-static inline constexpr uint8_t saturation_on =
-    static_cast<uint8_t>(saturation::on);
+/// This type tag represents "saturation off" behavior.
+struct saturation_off_tag : std::false_type {};
+
+/// Type tag object representing "saturation off" behavior.
+static inline constexpr saturation_off_tag saturation_off{};
+
+/// Type tag object representing "saturation on" behavior.
+static inline constexpr saturation_on_tag saturation_on{};
 
 /// Represents a pixel's channel.
 enum class rgba_channel : uint8_t { R, G, B, A };

--- a/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
@@ -1562,11 +1562,7 @@ ESIMD_NODEBUG
 
   Result.merge(T(0.0), TooBig);
   Result.merge(T(ESIMD_HDR_CONST_PI) - Result, Neg);
-
-  if constexpr (std::is_same_v<Sat, saturation_off_tag>)
-    return Result;
-  else
-    return esimd::saturate<T>(Result);
+  return Result;
 }
 
 template <typename T>
@@ -1588,11 +1584,7 @@ ESIMD_NODEBUG
       T(ESIMD_HDR_CONST_PI / 2.0) - esimd::acos(esimd::abs(src0));
 
   Result.merge(-Result, Neg);
-
-  if constexpr (std::is_same_v<Sat, saturation_off_tag>)
-    return Result;
-  else
-    return esimd::saturate<T>(Result);
+  return Result;
 }
 
 template <typename T>

--- a/sycl/test/esimd/enums.cpp
+++ b/sycl/test/esimd/enums.cpp
@@ -14,5 +14,4 @@ void foo() SYCL_ESIMD_FUNCTION {
   x = static_cast<int>(split_barrier_action::wait);
   x = static_cast<int>(atomic_op::add);
   x = static_cast<int>(rgba_channel_mask::R);
-  x = static_cast<int>(saturation::off);
 }


### PR DESCRIPTION
THIS IS API BREAKING CHANGE. But we are still in experimental namespace, and
this change is aimed at a cleaner and more performance-prodictable API.

- Make saturation parameter always a compile-time constant via type tags.
- Remove saturation parameter from APIs which don't have hardware support for
  saturation. Many VC BE intrinsics mapped to by other APIs whith saturation
  don't provide saturation support even though hardware provides it. This is a
  TODO and needs to be changed in the VC BE.
- Fix bug in saturation handling by `shl`.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>