### PR TITLE
[SYCL][HIP] Fix reported device name

### DIFF
--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -1450,6 +1450,17 @@ pi_result hip_piDeviceGetInfo(pi_device device, pi_device_info param_name,
     cl::sycl::detail::pi::assertion(
         hipDeviceGetName(name, MAX_DEVICE_NAME_LENGTH, device->get()) ==
         hipSuccess);
+
+    // On AMD GPUs hipDeviceGetName returns an empty string, so return the arch
+    // name instead, this is also what AMD OpenCL devices return.
+    if (strlen(name) == 0) {
+      hipDeviceProp_t props;
+      cl::sycl::detail::pi::assertion(
+          hipGetDeviceProperties(&props, device->get()) == hipSuccess);
+
+      return getInfoArray(strlen(props.gcnArchName) + 1, param_value_size,
+                          param_value, param_value_size_ret, props.gcnArchName);
+    }
     return getInfoArray(strlen(name) + 1, param_value_size, param_value,
                         param_value_size_ret, name);
   }


### PR DESCRIPTION
On AMD GPUs it seems that `hipDeviceGetName` returns an empty string, so
when this is the case simply return the architecture instead, as this
what AMD OpenCL devices return for the name.

Before this patch:
```
Devices  : 1
    Device [#0]:
    Type       : gpu
    Version    : 0.0
    Name       :
    Vendor     : AMD Corporation
    Driver     : HIP 40421.43
```

After this patch:
```
Devices  : 1
    Device [#0]:
    Type       : gpu
    Version    : 0.0
    Name       : gfx908:sramecc+:xnack-
    Vendor     : AMD Corporation
    Driver     : HIP 40421.43
```