### PR TITLE
[SYCL][XPTI] Fix unused function warning with XPTI disabled

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -86,12 +86,14 @@ static std::string deviceToString(device Device) {
     return "UNKNOWN";
 }
 
+#ifdef XPTI_ENABLE_INSTRUMENTATION
 static size_t deviceToID(const device &Device) {
   if (Device.is_host())
     return 0;
   else
     return reinterpret_cast<size_t>(getSyclObjImpl(Device)->getHandleRef());
 }
+#endif
 
 static std::string accessModeToString(access::mode Mode) {
   switch (Mode) {


### PR DESCRIPTION
This function is only used in XPTI instrumentation code which causes a
warning with the latest `gcc`, that trips up the `-Werror` build:

```
/home/nicolas/oneapi/llvm/sycl/source/detail/scheduler/commands.cpp:89:15: error: ‘size_t cl::sycl::detail::deviceToID(const cl::sycl::device&)’ defined but not used [-Werror=unused-function]
   89 | static size_t deviceToID(const device &Device) {
      |               ^~~~~~~~~~
```