### PR TITLE
[SYCL][NFC] Resolve variable name conflict with a macro

### DIFF
--- a/sycl/include/CL/sycl/usm.hpp
+++ b/sycl/include/CL/sycl/usm.hpp
@@ -20,133 +20,133 @@ namespace sycl {
 ///
 __SYCL_EXPORT void *malloc_device(
     size_t size, const device &dev, const context &ctxt,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *malloc_device(
     size_t size, const device &dev, const context &ctxt,
     const property_list &propList,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *malloc_device(
     size_t size, const queue &q,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *malloc_device(
     size_t size, const queue &q, const property_list &propList,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 
 __SYCL_EXPORT void *aligned_alloc_device(
     size_t alignment, size_t size, const device &dev, const context &ctxt,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_device(
     size_t alignment, size_t size, const device &dev, const context &ctxt,
     const property_list &propList,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_device(
     size_t alignment, size_t size, const queue &q,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_device(
     size_t alignment, size_t size, const queue &q,
     const property_list &propList,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 
 __SYCL_EXPORT void
 free(void *ptr, const context &ctxt,
-     const detail::code_location codeLoc = detail::code_location::current());
+     const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void
 free(void *ptr, const queue &q,
-     const detail::code_location codeLoc = detail::code_location::current());
+     const detail::code_location CodeLoc  = detail::code_location::current());
 
 ///
 // Restricted USM
 ///
 __SYCL_EXPORT void *malloc_host(
     size_t size, const context &ctxt,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *malloc_host(
     size_t size, const context &ctxt, const property_list &propList,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *malloc_host(
     size_t size, const queue &q,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *malloc_host(
     size_t size, const queue &q, const property_list &propList,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 
 __SYCL_EXPORT void *malloc_shared(
     size_t size, const device &dev, const context &ctxt,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *malloc_shared(
     size_t size, const device &dev, const context &ctxt,
     const property_list &propList,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *malloc_shared(
     size_t size, const queue &q,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *malloc_shared(
     size_t size, const queue &q, const property_list &propList,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 
 __SYCL_EXPORT void *aligned_alloc_host(
     size_t alignment, size_t size, const context &ctxt,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_host(
     size_t alignment, size_t size, const context &ctxt,
     const property_list &propList,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_host(
     size_t alignment, size_t size, const queue &q,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_host(
     size_t alignment, size_t size, const queue &q,
     const property_list &propList,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 
 __SYCL_EXPORT void *aligned_alloc_shared(
     size_t alignment, size_t size, const device &dev, const context &ctxt,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_shared(
     size_t alignment, size_t size, const device &dev, const context &ctxt,
     const property_list &propList,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_shared(
     size_t alignment, size_t size, const queue &q,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_shared(
     size_t alignment, size_t size, const queue &q,
     const property_list &propList,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 
 ///
 // single form
 ///
 __SYCL_EXPORT void *
 malloc(size_t size, const device &dev, const context &ctxt, usm::alloc kind,
-       const detail::code_location codeLoc = detail::code_location::current());
+       const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *
 malloc(size_t size, const device &dev, const context &ctxt, usm::alloc kind,
        const property_list &propList,
-       const detail::code_location codeLoc = detail::code_location::current());
+       const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *
 malloc(size_t size, const queue &q, usm::alloc kind,
-       const detail::code_location codeLoc = detail::code_location::current());
+       const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *
 malloc(size_t size, const queue &q, usm::alloc kind,
        const property_list &propList,
-       const detail::code_location codeLoc = detail::code_location::current());
+       const detail::code_location CodeLoc  = detail::code_location::current());
 
 __SYCL_EXPORT void *aligned_alloc(
     size_t alignment, size_t size, const device &dev, const context &ctxt,
     usm::alloc kind,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc(
     size_t alignment, size_t size, const device &dev, const context &ctxt,
     usm::alloc kind, const property_list &propList,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc(
     size_t alignment, size_t size, const queue &q, usm::alloc kind,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc(
     size_t alignment, size_t size, const queue &q, usm::alloc kind,
     const property_list &propList,
-    const detail::code_location codeLoc = detail::code_location::current());
+    const detail::code_location CodeLoc  = detail::code_location::current());
 
 ///
 // Template forms
@@ -155,139 +155,139 @@ template <typename T>
 T *malloc_device(
     size_t Count, const device &Dev, const context &Ctxt,
     const property_list &PropList = {},
-    const detail::code_location codeLoc = detail::code_location::current()) {
+    const detail::code_location CodeLoc  = detail::code_location::current()) {
   return static_cast<T *>(
-      malloc_device(Count * sizeof(T), Dev, Ctxt, PropList, codeLoc));
+      malloc_device(Count * sizeof(T), Dev, Ctxt, PropList, CodeLoc ));
 }
 
 template <typename T>
 T *malloc_device(
     size_t Count, const queue &Q, const property_list &PropList = {},
-    const detail::code_location codeLoc = detail::code_location::current()) {
+    const detail::code_location CodeLoc  = detail::code_location::current()) {
   return malloc_device<T>(Count, Q.get_device(), Q.get_context(), PropList,
-                          codeLoc);
+                          CodeLoc );
 }
 
 template <typename T>
 T *aligned_alloc_device(
     size_t Alignment, size_t Count, const device &Dev, const context &Ctxt,
     const property_list &PropList = {},
-    const detail::code_location codeLoc = detail::code_location::current()) {
+    const detail::code_location CodeLoc  = detail::code_location::current()) {
   return static_cast<T *>(aligned_alloc_device(Alignment, Count * sizeof(T),
-                                               Dev, Ctxt, PropList, codeLoc));
+                                               Dev, Ctxt, PropList, CodeLoc ));
 }
 
 template <typename T>
 T *aligned_alloc_device(
     size_t Alignment, size_t Count, const queue &Q,
     const property_list &PropList = {},
-    const detail::code_location codeLoc = detail::code_location::current()) {
+    const detail::code_location CodeLoc  = detail::code_location::current()) {
   return aligned_alloc_device<T>(Alignment, Count, Q.get_device(),
-                                 Q.get_context(), PropList, codeLoc);
+                                 Q.get_context(), PropList, CodeLoc );
 }
 
 template <typename T>
 T *malloc_host(
     size_t Count, const context &Ctxt, const property_list &PropList = {},
-    const detail::code_location codeLoc = detail::code_location::current()) {
+    const detail::code_location CodeLoc  = detail::code_location::current()) {
   return static_cast<T *>(
-      malloc_host(Count * sizeof(T), Ctxt, PropList, codeLoc));
+      malloc_host(Count * sizeof(T), Ctxt, PropList, CodeLoc ));
 }
 
 template <typename T>
 T *malloc_host(
     size_t Count, const queue &Q, const property_list &PropList = {},
-    const detail::code_location codeLoc = detail::code_location::current()) {
-  return malloc_host<T>(Count, Q.get_context(), PropList, codeLoc);
+    const detail::code_location CodeLoc  = detail::code_location::current()) {
+  return malloc_host<T>(Count, Q.get_context(), PropList, CodeLoc );
 }
 
 template <typename T>
 T *malloc_shared(
     size_t Count, const device &Dev, const context &Ctxt,
     const property_list &PropList = {},
-    const detail::code_location codeLoc = detail::code_location::current()) {
+    const detail::code_location CodeLoc  = detail::code_location::current()) {
   return static_cast<T *>(
-      malloc_shared(Count * sizeof(T), Dev, Ctxt, PropList, codeLoc));
+      malloc_shared(Count * sizeof(T), Dev, Ctxt, PropList, CodeLoc ));
 }
 
 template <typename T>
 T *malloc_shared(
     size_t Count, const queue &Q, const property_list &PropList = {},
-    const detail::code_location codeLoc = detail::code_location::current()) {
+    const detail::code_location CodeLoc  = detail::code_location::current()) {
   return malloc_shared<T>(Count, Q.get_device(), Q.get_context(), PropList,
-                          codeLoc);
+                          CodeLoc );
 }
 
 template <typename T>
 T *aligned_alloc_host(
     size_t Alignment, size_t Count, const context &Ctxt,
     const property_list &PropList = {},
-    const detail::code_location codeLoc = detail::code_location::current()) {
+    const detail::code_location CodeLoc  = detail::code_location::current()) {
   return static_cast<T *>(aligned_alloc_host(Alignment, Count * sizeof(T), Ctxt,
-                                             PropList, codeLoc));
+                                             PropList, CodeLoc ));
 }
 
 template <typename T>
 T *aligned_alloc_host(
     size_t Alignment, size_t Count, const queue &Q,
     const property_list &PropList = {},
-    const detail::code_location codeLoc = detail::code_location::current()) {
+    const detail::code_location CodeLoc  = detail::code_location::current()) {
   return aligned_alloc_host<T>(Alignment, Count, Q.get_context(), PropList,
-                               codeLoc);
+                               CodeLoc );
 }
 
 template <typename T>
 T *aligned_alloc_shared(
     size_t Alignment, size_t Count, const device &Dev, const context &Ctxt,
     const property_list &PropList = {},
-    const detail::code_location codeLoc = detail::code_location::current()) {
+    const detail::code_location CodeLoc  = detail::code_location::current()) {
   return static_cast<T *>(aligned_alloc_shared(Alignment, Count * sizeof(T),
-                                               Dev, Ctxt, PropList, codeLoc));
+                                               Dev, Ctxt, PropList, CodeLoc ));
 }
 
 template <typename T>
 T *aligned_alloc_shared(
     size_t Alignment, size_t Count, const queue &Q,
     const property_list &PropList = {},
-    const detail::code_location codeLoc = detail::code_location::current()) {
+    const detail::code_location CodeLoc  = detail::code_location::current()) {
   return aligned_alloc_shared<T>(Alignment, Count, Q.get_device(),
-                                 Q.get_context(), PropList, codeLoc);
+                                 Q.get_context(), PropList, CodeLoc );
 }
 
 template <typename T>
 T *malloc(
     size_t Count, const device &Dev, const context &Ctxt, usm::alloc Kind,
     const property_list &PropList = {},
-    const detail::code_location codeLoc = detail::code_location::current()) {
+    const detail::code_location CodeLoc  = detail::code_location::current()) {
   return static_cast<T *>(
-      malloc(Count * sizeof(T), Dev, Ctxt, Kind, PropList, codeLoc));
+      malloc(Count * sizeof(T), Dev, Ctxt, Kind, PropList, CodeLoc ));
 }
 
 template <typename T>
 T *malloc(
     size_t Count, const queue &Q, usm::alloc Kind,
     const property_list &PropList = {},
-    const detail::code_location codeLoc = detail::code_location::current()) {
+    const detail::code_location CodeLoc  = detail::code_location::current()) {
   return malloc<T>(Count, Q.get_device(), Q.get_context(), Kind, PropList,
-                   codeLoc);
+                   CodeLoc );
 }
 
 template <typename T>
 T *aligned_alloc(
     size_t Alignment, size_t Count, const device &Dev, const context &Ctxt,
     usm::alloc Kind, const property_list &PropList = {},
-    const detail::code_location codeLoc = detail::code_location::current()) {
+    const detail::code_location CodeLoc  = detail::code_location::current()) {
   return static_cast<T *>(aligned_alloc(Alignment, Count * sizeof(T), Dev, Ctxt,
-                                        Kind, PropList, codeLoc));
+                                        Kind, PropList, CodeLoc ));
 }
 
 template <typename T>
 T *aligned_alloc(
     size_t Alignment, size_t Count, const queue &Q, usm::alloc Kind,
     const property_list &PropList = {},
-    const detail::code_location codeLoc = detail::code_location::current()) {
+    const detail::code_location CodeLoc  = detail::code_location::current()) {
   return aligned_alloc<T>(Alignment, Count, Q.get_device(), Q.get_context(),
-                          Kind, PropList, codeLoc);
+                          Kind, PropList, CodeLoc );
 }
 
 // Pointer queries

--- a/sycl/include/CL/sycl/usm.hpp
+++ b/sycl/include/CL/sycl/usm.hpp
@@ -20,133 +20,133 @@ namespace sycl {
 ///
 __SYCL_EXPORT void *malloc_device(
     size_t size, const device &dev, const context &ctxt,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *malloc_device(
     size_t size, const device &dev, const context &ctxt,
     const property_list &propList,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *malloc_device(
     size_t size, const queue &q,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *malloc_device(
     size_t size, const queue &q, const property_list &propList,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 
 __SYCL_EXPORT void *aligned_alloc_device(
     size_t alignment, size_t size, const device &dev, const context &ctxt,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_device(
     size_t alignment, size_t size, const device &dev, const context &ctxt,
     const property_list &propList,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_device(
     size_t alignment, size_t size, const queue &q,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_device(
     size_t alignment, size_t size, const queue &q,
     const property_list &propList,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 
 __SYCL_EXPORT void
 free(void *ptr, const context &ctxt,
-     const detail::code_location CL = detail::code_location::current());
+     const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void
 free(void *ptr, const queue &q,
-     const detail::code_location CL = detail::code_location::current());
+     const detail::code_location codeLoc = detail::code_location::current());
 
 ///
 // Restricted USM
 ///
 __SYCL_EXPORT void *
 malloc_host(size_t size, const context &ctxt,
-            const detail::code_location CL = detail::code_location::current());
+            const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *
 malloc_host(size_t size, const context &ctxt, const property_list &propList,
-            const detail::code_location CL = detail::code_location::current());
+            const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *
 malloc_host(size_t size, const queue &q,
-            const detail::code_location CL = detail::code_location::current());
+            const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *
 malloc_host(size_t size, const queue &q, const property_list &propList,
-            const detail::code_location CL = detail::code_location::current());
+            const detail::code_location codeLoc = detail::code_location::current());
 
 __SYCL_EXPORT void *malloc_shared(
     size_t size, const device &dev, const context &ctxt,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *malloc_shared(
     size_t size, const device &dev, const context &ctxt,
     const property_list &propList,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *malloc_shared(
     size_t size, const queue &q,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *malloc_shared(
     size_t size, const queue &q, const property_list &propList,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 
 __SYCL_EXPORT void *aligned_alloc_host(
     size_t alignment, size_t size, const context &ctxt,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_host(
     size_t alignment, size_t size, const context &ctxt,
     const property_list &propList,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_host(
     size_t alignment, size_t size, const queue &q,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_host(
     size_t alignment, size_t size, const queue &q,
     const property_list &propList,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 
 __SYCL_EXPORT void *aligned_alloc_shared(
     size_t alignment, size_t size, const device &dev, const context &ctxt,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_shared(
     size_t alignment, size_t size, const device &dev, const context &ctxt,
     const property_list &propList,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_shared(
     size_t alignment, size_t size, const queue &q,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_shared(
     size_t alignment, size_t size, const queue &q,
     const property_list &propList,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 
 ///
 // single form
 ///
 __SYCL_EXPORT void *
 malloc(size_t size, const device &dev, const context &ctxt, usm::alloc kind,
-       const detail::code_location CL = detail::code_location::current());
+       const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *
 malloc(size_t size, const device &dev, const context &ctxt, usm::alloc kind,
        const property_list &propList,
-       const detail::code_location CL = detail::code_location::current());
+       const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *
 malloc(size_t size, const queue &q, usm::alloc kind,
-       const detail::code_location CL = detail::code_location::current());
+       const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *
 malloc(size_t size, const queue &q, usm::alloc kind,
        const property_list &propList,
-       const detail::code_location CL = detail::code_location::current());
+       const detail::code_location codeLoc = detail::code_location::current());
 
 __SYCL_EXPORT void *aligned_alloc(
     size_t alignment, size_t size, const device &dev, const context &ctxt,
     usm::alloc kind,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc(
     size_t alignment, size_t size, const device &dev, const context &ctxt,
     usm::alloc kind, const property_list &propList,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc(
     size_t alignment, size_t size, const queue &q, usm::alloc kind,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc(
     size_t alignment, size_t size, const queue &q, usm::alloc kind,
     const property_list &propList,
-    const detail::code_location CL = detail::code_location::current());
+    const detail::code_location codeLoc = detail::code_location::current());
 
 ///
 // Template forms
@@ -155,132 +155,132 @@ template <typename T>
 T *malloc_device(
     size_t Count, const device &Dev, const context &Ctxt,
     const property_list &PropList = {},
-    const detail::code_location CL = detail::code_location::current()) {
+    const detail::code_location codeLoc = detail::code_location::current()) {
   return static_cast<T *>(
-      malloc_device(Count * sizeof(T), Dev, Ctxt, PropList, CL));
+      malloc_device(Count * sizeof(T), Dev, Ctxt, PropList, codeLoc));
 }
 
 template <typename T>
 T *malloc_device(
     size_t Count, const queue &Q, const property_list &PropList = {},
-    const detail::code_location CL = detail::code_location::current()) {
-  return malloc_device<T>(Count, Q.get_device(), Q.get_context(), PropList, CL);
+    const detail::code_location codeLoc = detail::code_location::current()) {
+  return malloc_device<T>(Count, Q.get_device(), Q.get_context(), PropList, codeLoc);
 }
 
 template <typename T>
 T *aligned_alloc_device(
     size_t Alignment, size_t Count, const device &Dev, const context &Ctxt,
     const property_list &PropList = {},
-    const detail::code_location CL = detail::code_location::current()) {
+    const detail::code_location codeLoc = detail::code_location::current()) {
   return static_cast<T *>(aligned_alloc_device(Alignment, Count * sizeof(T),
-                                               Dev, Ctxt, PropList, CL));
+                                               Dev, Ctxt, PropList, codeLoc));
 }
 
 template <typename T>
 T *aligned_alloc_device(
     size_t Alignment, size_t Count, const queue &Q,
     const property_list &PropList = {},
-    const detail::code_location CL = detail::code_location::current()) {
+    const detail::code_location codeLoc = detail::code_location::current()) {
   return aligned_alloc_device<T>(Alignment, Count, Q.get_device(),
-                                 Q.get_context(), PropList, CL);
+                                 Q.get_context(), PropList, codeLoc);
 }
 
 template <typename T>
 T *malloc_host(
     size_t Count, const context &Ctxt, const property_list &PropList = {},
-    const detail::code_location CL = detail::code_location::current()) {
-  return static_cast<T *>(malloc_host(Count * sizeof(T), Ctxt, PropList, CL));
+    const detail::code_location codeLoc = detail::code_location::current()) {
+  return static_cast<T *>(malloc_host(Count * sizeof(T), Ctxt, PropList, codeLoc));
 }
 
 template <typename T>
 T *malloc_host(
     size_t Count, const queue &Q, const property_list &PropList = {},
-    const detail::code_location CL = detail::code_location::current()) {
-  return malloc_host<T>(Count, Q.get_context(), PropList, CL);
+    const detail::code_location codeLoc = detail::code_location::current()) {
+  return malloc_host<T>(Count, Q.get_context(), PropList, codeLoc);
 }
 
 template <typename T>
 T *malloc_shared(
     size_t Count, const device &Dev, const context &Ctxt,
     const property_list &PropList = {},
-    const detail::code_location CL = detail::code_location::current()) {
+    const detail::code_location codeLoc = detail::code_location::current()) {
   return static_cast<T *>(
-      malloc_shared(Count * sizeof(T), Dev, Ctxt, PropList, CL));
+      malloc_shared(Count * sizeof(T), Dev, Ctxt, PropList, codeLoc));
 }
 
 template <typename T>
 T *malloc_shared(
     size_t Count, const queue &Q, const property_list &PropList = {},
-    const detail::code_location CL = detail::code_location::current()) {
-  return malloc_shared<T>(Count, Q.get_device(), Q.get_context(), PropList, CL);
+    const detail::code_location codeLoc = detail::code_location::current()) {
+  return malloc_shared<T>(Count, Q.get_device(), Q.get_context(), PropList, codeLoc);
 }
 
 template <typename T>
 T *aligned_alloc_host(
     size_t Alignment, size_t Count, const context &Ctxt,
     const property_list &PropList = {},
-    const detail::code_location CL = detail::code_location::current()) {
+    const detail::code_location codeLoc = detail::code_location::current()) {
   return static_cast<T *>(
-      aligned_alloc_host(Alignment, Count * sizeof(T), Ctxt, PropList, CL));
+      aligned_alloc_host(Alignment, Count * sizeof(T), Ctxt, PropList, codeLoc));
 }
 
 template <typename T>
 T *aligned_alloc_host(
     size_t Alignment, size_t Count, const queue &Q,
     const property_list &PropList = {},
-    const detail::code_location CL = detail::code_location::current()) {
-  return aligned_alloc_host<T>(Alignment, Count, Q.get_context(), PropList, CL);
+    const detail::code_location codeLoc = detail::code_location::current()) {
+  return aligned_alloc_host<T>(Alignment, Count, Q.get_context(), PropList, codeLoc);
 }
 
 template <typename T>
 T *aligned_alloc_shared(
     size_t Alignment, size_t Count, const device &Dev, const context &Ctxt,
     const property_list &PropList = {},
-    const detail::code_location CL = detail::code_location::current()) {
+    const detail::code_location codeLoc = detail::code_location::current()) {
   return static_cast<T *>(aligned_alloc_shared(Alignment, Count * sizeof(T),
-                                               Dev, Ctxt, PropList, CL));
+                                               Dev, Ctxt, PropList, codeLoc));
 }
 
 template <typename T>
 T *aligned_alloc_shared(
     size_t Alignment, size_t Count, const queue &Q,
     const property_list &PropList = {},
-    const detail::code_location CL = detail::code_location::current()) {
+    const detail::code_location codeLoc = detail::code_location::current()) {
   return aligned_alloc_shared<T>(Alignment, Count, Q.get_device(),
-                                 Q.get_context(), PropList, CL);
+                                 Q.get_context(), PropList, codeLoc);
 }
 
 template <typename T>
 T *malloc(size_t Count, const device &Dev, const context &Ctxt, usm::alloc Kind,
           const property_list &PropList = {},
-          const detail::code_location CL = detail::code_location::current()) {
+          const detail::code_location codeLoc = detail::code_location::current()) {
   return static_cast<T *>(
-      malloc(Count * sizeof(T), Dev, Ctxt, Kind, PropList, CL));
+      malloc(Count * sizeof(T), Dev, Ctxt, Kind, PropList, codeLoc));
 }
 
 template <typename T>
 T *malloc(size_t Count, const queue &Q, usm::alloc Kind,
           const property_list &PropList = {},
-          const detail::code_location CL = detail::code_location::current()) {
-  return malloc<T>(Count, Q.get_device(), Q.get_context(), Kind, PropList, CL);
+          const detail::code_location codeLoc = detail::code_location::current()) {
+  return malloc<T>(Count, Q.get_device(), Q.get_context(), Kind, PropList, codeLoc);
 }
 
 template <typename T>
 T *aligned_alloc(
     size_t Alignment, size_t Count, const device &Dev, const context &Ctxt,
     usm::alloc Kind, const property_list &PropList = {},
-    const detail::code_location CL = detail::code_location::current()) {
+    const detail::code_location codeLoc = detail::code_location::current()) {
   return static_cast<T *>(aligned_alloc(Alignment, Count * sizeof(T), Dev, Ctxt,
-                                        Kind, PropList, CL));
+                                        Kind, PropList, codeLoc));
 }
 
 template <typename T>
 T *aligned_alloc(
     size_t Alignment, size_t Count, const queue &Q, usm::alloc Kind,
     const property_list &PropList = {},
-    const detail::code_location CL = detail::code_location::current()) {
+    const detail::code_location codeLoc = detail::code_location::current()) {
   return aligned_alloc<T>(Alignment, Count, Q.get_device(), Q.get_context(),
-                          Kind, PropList, CL);
+                          Kind, PropList, codeLoc);
 }
 
 // Pointer queries

--- a/sycl/include/CL/sycl/usm.hpp
+++ b/sycl/include/CL/sycl/usm.hpp
@@ -57,18 +57,18 @@ free(void *ptr, const queue &q,
 ///
 // Restricted USM
 ///
-__SYCL_EXPORT void *
-malloc_host(size_t size, const context &ctxt,
-            const detail::code_location codeLoc = detail::code_location::current());
-__SYCL_EXPORT void *
-malloc_host(size_t size, const context &ctxt, const property_list &propList,
-            const detail::code_location codeLoc = detail::code_location::current());
-__SYCL_EXPORT void *
-malloc_host(size_t size, const queue &q,
-            const detail::code_location codeLoc = detail::code_location::current());
-__SYCL_EXPORT void *
-malloc_host(size_t size, const queue &q, const property_list &propList,
-            const detail::code_location codeLoc = detail::code_location::current());
+__SYCL_EXPORT void *malloc_host(
+    size_t size, const context &ctxt,
+    const detail::code_location codeLoc = detail::code_location::current());
+__SYCL_EXPORT void *malloc_host(
+    size_t size, const context &ctxt, const property_list &propList,
+    const detail::code_location codeLoc = detail::code_location::current());
+__SYCL_EXPORT void *malloc_host(
+    size_t size, const queue &q,
+    const detail::code_location codeLoc = detail::code_location::current());
+__SYCL_EXPORT void *malloc_host(
+    size_t size, const queue &q, const property_list &propList,
+    const detail::code_location codeLoc = detail::code_location::current());
 
 __SYCL_EXPORT void *malloc_shared(
     size_t size, const device &dev, const context &ctxt,
@@ -164,7 +164,8 @@ template <typename T>
 T *malloc_device(
     size_t Count, const queue &Q, const property_list &PropList = {},
     const detail::code_location codeLoc = detail::code_location::current()) {
-  return malloc_device<T>(Count, Q.get_device(), Q.get_context(), PropList, codeLoc);
+  return malloc_device<T>(Count, Q.get_device(), Q.get_context(), PropList,
+                          codeLoc);
 }
 
 template <typename T>
@@ -189,7 +190,8 @@ template <typename T>
 T *malloc_host(
     size_t Count, const context &Ctxt, const property_list &PropList = {},
     const detail::code_location codeLoc = detail::code_location::current()) {
-  return static_cast<T *>(malloc_host(Count * sizeof(T), Ctxt, PropList, codeLoc));
+  return static_cast<T *>(
+      malloc_host(Count * sizeof(T), Ctxt, PropList, codeLoc));
 }
 
 template <typename T>
@@ -212,7 +214,8 @@ template <typename T>
 T *malloc_shared(
     size_t Count, const queue &Q, const property_list &PropList = {},
     const detail::code_location codeLoc = detail::code_location::current()) {
-  return malloc_shared<T>(Count, Q.get_device(), Q.get_context(), PropList, codeLoc);
+  return malloc_shared<T>(Count, Q.get_device(), Q.get_context(), PropList,
+                          codeLoc);
 }
 
 template <typename T>
@@ -220,8 +223,8 @@ T *aligned_alloc_host(
     size_t Alignment, size_t Count, const context &Ctxt,
     const property_list &PropList = {},
     const detail::code_location codeLoc = detail::code_location::current()) {
-  return static_cast<T *>(
-      aligned_alloc_host(Alignment, Count * sizeof(T), Ctxt, PropList, codeLoc));
+  return static_cast<T *>(aligned_alloc_host(Alignment, Count * sizeof(T), Ctxt,
+                                             PropList, codeLoc));
 }
 
 template <typename T>
@@ -229,7 +232,8 @@ T *aligned_alloc_host(
     size_t Alignment, size_t Count, const queue &Q,
     const property_list &PropList = {},
     const detail::code_location codeLoc = detail::code_location::current()) {
-  return aligned_alloc_host<T>(Alignment, Count, Q.get_context(), PropList, codeLoc);
+  return aligned_alloc_host<T>(Alignment, Count, Q.get_context(), PropList,
+                               codeLoc);
 }
 
 template <typename T>
@@ -251,18 +255,21 @@ T *aligned_alloc_shared(
 }
 
 template <typename T>
-T *malloc(size_t Count, const device &Dev, const context &Ctxt, usm::alloc Kind,
-          const property_list &PropList = {},
-          const detail::code_location codeLoc = detail::code_location::current()) {
+T *malloc(
+    size_t Count, const device &Dev, const context &Ctxt, usm::alloc Kind,
+    const property_list &PropList = {},
+    const detail::code_location codeLoc = detail::code_location::current()) {
   return static_cast<T *>(
       malloc(Count * sizeof(T), Dev, Ctxt, Kind, PropList, codeLoc));
 }
 
 template <typename T>
-T *malloc(size_t Count, const queue &Q, usm::alloc Kind,
-          const property_list &PropList = {},
-          const detail::code_location codeLoc = detail::code_location::current()) {
-  return malloc<T>(Count, Q.get_device(), Q.get_context(), Kind, PropList, codeLoc);
+T *malloc(
+    size_t Count, const queue &Q, usm::alloc Kind,
+    const property_list &PropList = {},
+    const detail::code_location codeLoc = detail::code_location::current()) {
+  return malloc<T>(Count, Q.get_device(), Q.get_context(), Kind, PropList,
+                   codeLoc);
 }
 
 template <typename T>

--- a/sycl/include/CL/sycl/usm.hpp
+++ b/sycl/include/CL/sycl/usm.hpp
@@ -20,133 +20,133 @@ namespace sycl {
 ///
 __SYCL_EXPORT void *malloc_device(
     size_t size, const device &dev, const context &ctxt,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *malloc_device(
     size_t size, const device &dev, const context &ctxt,
     const property_list &propList,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *malloc_device(
     size_t size, const queue &q,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *malloc_device(
     size_t size, const queue &q, const property_list &propList,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 
 __SYCL_EXPORT void *aligned_alloc_device(
     size_t alignment, size_t size, const device &dev, const context &ctxt,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_device(
     size_t alignment, size_t size, const device &dev, const context &ctxt,
     const property_list &propList,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_device(
     size_t alignment, size_t size, const queue &q,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_device(
     size_t alignment, size_t size, const queue &q,
     const property_list &propList,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 
 __SYCL_EXPORT void
 free(void *ptr, const context &ctxt,
-     const detail::code_location CodeLoc  = detail::code_location::current());
+     const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void
 free(void *ptr, const queue &q,
-     const detail::code_location CodeLoc  = detail::code_location::current());
+     const detail::code_location CodeLoc = detail::code_location::current());
 
 ///
 // Restricted USM
 ///
 __SYCL_EXPORT void *malloc_host(
     size_t size, const context &ctxt,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *malloc_host(
     size_t size, const context &ctxt, const property_list &propList,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *malloc_host(
     size_t size, const queue &q,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *malloc_host(
     size_t size, const queue &q, const property_list &propList,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 
 __SYCL_EXPORT void *malloc_shared(
     size_t size, const device &dev, const context &ctxt,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *malloc_shared(
     size_t size, const device &dev, const context &ctxt,
     const property_list &propList,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *malloc_shared(
     size_t size, const queue &q,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *malloc_shared(
     size_t size, const queue &q, const property_list &propList,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 
 __SYCL_EXPORT void *aligned_alloc_host(
     size_t alignment, size_t size, const context &ctxt,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_host(
     size_t alignment, size_t size, const context &ctxt,
     const property_list &propList,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_host(
     size_t alignment, size_t size, const queue &q,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_host(
     size_t alignment, size_t size, const queue &q,
     const property_list &propList,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 
 __SYCL_EXPORT void *aligned_alloc_shared(
     size_t alignment, size_t size, const device &dev, const context &ctxt,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_shared(
     size_t alignment, size_t size, const device &dev, const context &ctxt,
     const property_list &propList,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_shared(
     size_t alignment, size_t size, const queue &q,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc_shared(
     size_t alignment, size_t size, const queue &q,
     const property_list &propList,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 
 ///
 // single form
 ///
 __SYCL_EXPORT void *
 malloc(size_t size, const device &dev, const context &ctxt, usm::alloc kind,
-       const detail::code_location CodeLoc  = detail::code_location::current());
+       const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *
 malloc(size_t size, const device &dev, const context &ctxt, usm::alloc kind,
        const property_list &propList,
-       const detail::code_location CodeLoc  = detail::code_location::current());
+       const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *
 malloc(size_t size, const queue &q, usm::alloc kind,
-       const detail::code_location CodeLoc  = detail::code_location::current());
+       const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *
 malloc(size_t size, const queue &q, usm::alloc kind,
        const property_list &propList,
-       const detail::code_location CodeLoc  = detail::code_location::current());
+       const detail::code_location CodeLoc = detail::code_location::current());
 
 __SYCL_EXPORT void *aligned_alloc(
     size_t alignment, size_t size, const device &dev, const context &ctxt,
     usm::alloc kind,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc(
     size_t alignment, size_t size, const device &dev, const context &ctxt,
     usm::alloc kind, const property_list &propList,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc(
     size_t alignment, size_t size, const queue &q, usm::alloc kind,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 __SYCL_EXPORT void *aligned_alloc(
     size_t alignment, size_t size, const queue &q, usm::alloc kind,
     const property_list &propList,
-    const detail::code_location CodeLoc  = detail::code_location::current());
+    const detail::code_location CodeLoc = detail::code_location::current());
 
 ///
 // Template forms
@@ -155,139 +155,139 @@ template <typename T>
 T *malloc_device(
     size_t Count, const device &Dev, const context &Ctxt,
     const property_list &PropList = {},
-    const detail::code_location CodeLoc  = detail::code_location::current()) {
+    const detail::code_location CodeLoc = detail::code_location::current()) {
   return static_cast<T *>(
-      malloc_device(Count * sizeof(T), Dev, Ctxt, PropList, CodeLoc ));
+      malloc_device(Count * sizeof(T), Dev, Ctxt, PropList, CodeLoc));
 }
 
 template <typename T>
 T *malloc_device(
     size_t Count, const queue &Q, const property_list &PropList = {},
-    const detail::code_location CodeLoc  = detail::code_location::current()) {
+    const detail::code_location CodeLoc = detail::code_location::current()) {
   return malloc_device<T>(Count, Q.get_device(), Q.get_context(), PropList,
-                          CodeLoc );
+                          CodeLoc);
 }
 
 template <typename T>
 T *aligned_alloc_device(
     size_t Alignment, size_t Count, const device &Dev, const context &Ctxt,
     const property_list &PropList = {},
-    const detail::code_location CodeLoc  = detail::code_location::current()) {
+    const detail::code_location CodeLoc = detail::code_location::current()) {
   return static_cast<T *>(aligned_alloc_device(Alignment, Count * sizeof(T),
-                                               Dev, Ctxt, PropList, CodeLoc ));
+                                               Dev, Ctxt, PropList, CodeLoc));
 }
 
 template <typename T>
 T *aligned_alloc_device(
     size_t Alignment, size_t Count, const queue &Q,
     const property_list &PropList = {},
-    const detail::code_location CodeLoc  = detail::code_location::current()) {
+    const detail::code_location CodeLoc = detail::code_location::current()) {
   return aligned_alloc_device<T>(Alignment, Count, Q.get_device(),
-                                 Q.get_context(), PropList, CodeLoc );
+                                 Q.get_context(), PropList, CodeLoc);
 }
 
 template <typename T>
 T *malloc_host(
     size_t Count, const context &Ctxt, const property_list &PropList = {},
-    const detail::code_location CodeLoc  = detail::code_location::current()) {
+    const detail::code_location CodeLoc = detail::code_location::current()) {
   return static_cast<T *>(
-      malloc_host(Count * sizeof(T), Ctxt, PropList, CodeLoc ));
+      malloc_host(Count * sizeof(T), Ctxt, PropList, CodeLoc));
 }
 
 template <typename T>
 T *malloc_host(
     size_t Count, const queue &Q, const property_list &PropList = {},
-    const detail::code_location CodeLoc  = detail::code_location::current()) {
-  return malloc_host<T>(Count, Q.get_context(), PropList, CodeLoc );
+    const detail::code_location CodeLoc = detail::code_location::current()) {
+  return malloc_host<T>(Count, Q.get_context(), PropList, CodeLoc);
 }
 
 template <typename T>
 T *malloc_shared(
     size_t Count, const device &Dev, const context &Ctxt,
     const property_list &PropList = {},
-    const detail::code_location CodeLoc  = detail::code_location::current()) {
+    const detail::code_location CodeLoc = detail::code_location::current()) {
   return static_cast<T *>(
-      malloc_shared(Count * sizeof(T), Dev, Ctxt, PropList, CodeLoc ));
+      malloc_shared(Count * sizeof(T), Dev, Ctxt, PropList, CodeLoc));
 }
 
 template <typename T>
 T *malloc_shared(
     size_t Count, const queue &Q, const property_list &PropList = {},
-    const detail::code_location CodeLoc  = detail::code_location::current()) {
+    const detail::code_location CodeLoc = detail::code_location::current()) {
   return malloc_shared<T>(Count, Q.get_device(), Q.get_context(), PropList,
-                          CodeLoc );
+                          CodeLoc);
 }
 
 template <typename T>
 T *aligned_alloc_host(
     size_t Alignment, size_t Count, const context &Ctxt,
     const property_list &PropList = {},
-    const detail::code_location CodeLoc  = detail::code_location::current()) {
+    const detail::code_location CodeLoc = detail::code_location::current()) {
   return static_cast<T *>(aligned_alloc_host(Alignment, Count * sizeof(T), Ctxt,
-                                             PropList, CodeLoc ));
+                                             PropList, CodeLoc));
 }
 
 template <typename T>
 T *aligned_alloc_host(
     size_t Alignment, size_t Count, const queue &Q,
     const property_list &PropList = {},
-    const detail::code_location CodeLoc  = detail::code_location::current()) {
+    const detail::code_location CodeLoc = detail::code_location::current()) {
   return aligned_alloc_host<T>(Alignment, Count, Q.get_context(), PropList,
-                               CodeLoc );
+                               CodeLoc);
 }
 
 template <typename T>
 T *aligned_alloc_shared(
     size_t Alignment, size_t Count, const device &Dev, const context &Ctxt,
     const property_list &PropList = {},
-    const detail::code_location CodeLoc  = detail::code_location::current()) {
+    const detail::code_location CodeLoc = detail::code_location::current()) {
   return static_cast<T *>(aligned_alloc_shared(Alignment, Count * sizeof(T),
-                                               Dev, Ctxt, PropList, CodeLoc ));
+                                               Dev, Ctxt, PropList, CodeLoc));
 }
 
 template <typename T>
 T *aligned_alloc_shared(
     size_t Alignment, size_t Count, const queue &Q,
     const property_list &PropList = {},
-    const detail::code_location CodeLoc  = detail::code_location::current()) {
+    const detail::code_location CodeLoc = detail::code_location::current()) {
   return aligned_alloc_shared<T>(Alignment, Count, Q.get_device(),
-                                 Q.get_context(), PropList, CodeLoc );
+                                 Q.get_context(), PropList, CodeLoc);
 }
 
 template <typename T>
 T *malloc(
     size_t Count, const device &Dev, const context &Ctxt, usm::alloc Kind,
     const property_list &PropList = {},
-    const detail::code_location CodeLoc  = detail::code_location::current()) {
+    const detail::code_location CodeLoc = detail::code_location::current()) {
   return static_cast<T *>(
-      malloc(Count * sizeof(T), Dev, Ctxt, Kind, PropList, CodeLoc ));
+      malloc(Count * sizeof(T), Dev, Ctxt, Kind, PropList, CodeLoc));
 }
 
 template <typename T>
 T *malloc(
     size_t Count, const queue &Q, usm::alloc Kind,
     const property_list &PropList = {},
-    const detail::code_location CodeLoc  = detail::code_location::current()) {
+    const detail::code_location CodeLoc = detail::code_location::current()) {
   return malloc<T>(Count, Q.get_device(), Q.get_context(), Kind, PropList,
-                   CodeLoc );
+                   CodeLoc);
 }
 
 template <typename T>
 T *aligned_alloc(
     size_t Alignment, size_t Count, const device &Dev, const context &Ctxt,
     usm::alloc Kind, const property_list &PropList = {},
-    const detail::code_location CodeLoc  = detail::code_location::current()) {
+    const detail::code_location CodeLoc = detail::code_location::current()) {
   return static_cast<T *>(aligned_alloc(Alignment, Count * sizeof(T), Dev, Ctxt,
-                                        Kind, PropList, CodeLoc ));
+                                        Kind, PropList, CodeLoc));
 }
 
 template <typename T>
 T *aligned_alloc(
     size_t Alignment, size_t Count, const queue &Q, usm::alloc Kind,
     const property_list &PropList = {},
-    const detail::code_location CodeLoc  = detail::code_location::current()) {
+    const detail::code_location CodeLoc = detail::code_location::current()) {
   return aligned_alloc<T>(Alignment, Count, Q.get_device(), Q.get_context(),
-                          Kind, PropList, CodeLoc );
+                          Kind, PropList, CodeLoc);
 }
 
 // Pointer queries

--- a/sycl/include/CL/sycl/usm/usm_allocator.hpp
+++ b/sycl/include/CL/sycl/usm/usm_allocator.hpp
@@ -26,9 +26,9 @@ __SYCL_EXPORT void *aligned_alloc(size_t alignment, size_t size,
                                   const device &dev, const context &ctxt,
                                   usm::alloc kind,
                                   const property_list &propList,
-                                  const detail::code_location CodeLoc );
+                                  const detail::code_location CodeLoc);
 __SYCL_EXPORT void free(void *ptr, const context &ctxt,
-                        const detail::code_location CodeLoc );
+                        const detail::code_location CodeLoc);
 
 template <typename T, usm::alloc AllocKind, size_t Alignment = alignof(T)>
 class usm_allocator {
@@ -77,12 +77,12 @@ public:
   /// Allocates memory.
   ///
   /// \param NumberOfElements is a count of elements to allocate memory for.
-  T *allocate(size_t NumberOfElements, const detail::code_location CodeLoc  =
+  T *allocate(size_t NumberOfElements, const detail::code_location CodeLoc =
                                            detail::code_location::current()) {
 
     auto Result = reinterpret_cast<T *>(
         aligned_alloc(getAlignment(), NumberOfElements * sizeof(value_type),
-                      MDevice, MContext, AllocKind, MPropList, CodeLoc ));
+                      MDevice, MContext, AllocKind, MPropList, CodeLoc));
     if (!Result) {
       throw memory_allocation_error();
     }
@@ -95,9 +95,9 @@ public:
   /// \param Size is a number of elements previously passed to allocate.
   void deallocate(
       T *Ptr, size_t,
-      const detail::code_location CodeLoc  = detail::code_location::current()) {
+      const detail::code_location CodeLoc = detail::code_location::current()) {
     if (Ptr) {
-      free(Ptr, MContext, CodeLoc );
+      free(Ptr, MContext, CodeLoc);
     }
   }
 

--- a/sycl/include/CL/sycl/usm/usm_allocator.hpp
+++ b/sycl/include/CL/sycl/usm/usm_allocator.hpp
@@ -26,9 +26,9 @@ __SYCL_EXPORT void *aligned_alloc(size_t alignment, size_t size,
                                   const device &dev, const context &ctxt,
                                   usm::alloc kind,
                                   const property_list &propList,
-                                  const detail::code_location codeLoc);
+                                  const detail::code_location CodeLoc );
 __SYCL_EXPORT void free(void *ptr, const context &ctxt,
-                        const detail::code_location codeLoc);
+                        const detail::code_location CodeLoc );
 
 template <typename T, usm::alloc AllocKind, size_t Alignment = alignof(T)>
 class usm_allocator {
@@ -77,12 +77,12 @@ public:
   /// Allocates memory.
   ///
   /// \param NumberOfElements is a count of elements to allocate memory for.
-  T *allocate(size_t NumberOfElements, const detail::code_location codeLoc =
+  T *allocate(size_t NumberOfElements, const detail::code_location CodeLoc  =
                                            detail::code_location::current()) {
 
     auto Result = reinterpret_cast<T *>(
         aligned_alloc(getAlignment(), NumberOfElements * sizeof(value_type),
-                      MDevice, MContext, AllocKind, MPropList, codeLoc));
+                      MDevice, MContext, AllocKind, MPropList, CodeLoc ));
     if (!Result) {
       throw memory_allocation_error();
     }
@@ -95,9 +95,9 @@ public:
   /// \param Size is a number of elements previously passed to allocate.
   void deallocate(
       T *Ptr, size_t,
-      const detail::code_location codeLoc = detail::code_location::current()) {
+      const detail::code_location CodeLoc  = detail::code_location::current()) {
     if (Ptr) {
-      free(Ptr, MContext, codeLoc);
+      free(Ptr, MContext, CodeLoc );
     }
   }
 

--- a/sycl/include/CL/sycl/usm/usm_allocator.hpp
+++ b/sycl/include/CL/sycl/usm/usm_allocator.hpp
@@ -26,9 +26,9 @@ __SYCL_EXPORT void *aligned_alloc(size_t alignment, size_t size,
                                   const device &dev, const context &ctxt,
                                   usm::alloc kind,
                                   const property_list &propList,
-                                  const detail::code_location CL);
+                                  const detail::code_location codeLoc);
 __SYCL_EXPORT void free(void *ptr, const context &ctxt,
-                        const detail::code_location CL);
+                        const detail::code_location codeLoc);
 
 template <typename T, usm::alloc AllocKind, size_t Alignment = alignof(T)>
 class usm_allocator {
@@ -77,12 +77,12 @@ public:
   /// Allocates memory.
   ///
   /// \param NumberOfElements is a count of elements to allocate memory for.
-  T *allocate(size_t NumberOfElements, const detail::code_location CL =
+  T *allocate(size_t NumberOfElements, const detail::code_location codeLoc =
                                            detail::code_location::current()) {
 
     auto Result = reinterpret_cast<T *>(
         aligned_alloc(getAlignment(), NumberOfElements * sizeof(value_type),
-                      MDevice, MContext, AllocKind, MPropList, CL));
+                      MDevice, MContext, AllocKind, MPropList, codeLoc));
     if (!Result) {
       throw memory_allocation_error();
     }
@@ -95,9 +95,9 @@ public:
   /// \param Size is a number of elements previously passed to allocate.
   void deallocate(
       T *Ptr, size_t,
-      const detail::code_location CL = detail::code_location::current()) {
+      const detail::code_location codeLoc = detail::code_location::current()) {
     if (Ptr) {
-      free(Ptr, MContext, CL);
+      free(Ptr, MContext, codeLoc);
     }
   }
 


### PR DESCRIPTION
This patch renames conflicted `detail::code_location` name from `detail::code_location CL` to `detail::code_location codeLoc`.
It fixes https://github.com/intel/llvm/issues/5479