### PR TITLE
[SYCL][FPGA] Add support for [[intel::loop_count()]] attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2059,7 +2059,7 @@ def SYCLIntelFPGALoopCount : StmtAttr {
   let Spellings = [CXX11<"intel", "loop_count_min">,
                    CXX11<"intel", "loop_count_max">,
                    CXX11<"intel", "loop_count_avg">,
-                    CXX11<"intel", "loop_count">];
+                   CXX11<"intel", "loop_count">];
   let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt],
                              ErrorDiag, "'for', 'while', and 'do' statements">;
   let Accessors = [Accessor<"isMin", [CXX11<"intel", "loop_count_min">]>,

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2058,12 +2058,14 @@ def : MutualExclusions<[SYCLIntelFPGAMaxConcurrency,
 def SYCLIntelFPGALoopCount : StmtAttr {
   let Spellings = [CXX11<"intel", "loop_count_min">,
                    CXX11<"intel", "loop_count_max">,
-                   CXX11<"intel", "loop_count_avg">];
+                   CXX11<"intel", "loop_count_avg">,
+                    CXX11<"intel", "loop_count">];
   let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt],
                              ErrorDiag, "'for', 'while', and 'do' statements">;
   let Accessors = [Accessor<"isMin", [CXX11<"intel", "loop_count_min">]>,
                    Accessor<"isMax", [CXX11<"intel", "loop_count_max">]>,
-                   Accessor<"isAvg", [CXX11<"intel", "loop_count_avg">]>];
+                   Accessor<"isAvg", [CXX11<"intel", "loop_count_avg">]>,
+                   Accessor<"isCount", [CXX11<"intel", "loop_count">]>];
   let Args = [ExprArgument<"NTripCount">];
   let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let IsStmtDependent = 1;

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -3270,7 +3270,7 @@ or ``ivdep``.
 
 def SYCLIntelFPGALoopCountAttrDocs : Documentation {
   let Category = DocCatVariable;
-  let Heading = "intel::loop_count_min, intel::loop_count_max, intel::loop_count_avg";
+  let Heading = "intel::loop_count_min, intel::loop_count_max, intel::loop_count_avg, intel::loop_count";
   let Content = [{
 The loop count attributes specify the minimum, maximum, or average number of
 iterations for a ``for`` loop. These are hints that the user specify that can be
@@ -3288,10 +3288,15 @@ using PGO.
     [[intel::loop_count_max(10)]] for (int i = 0; i < n; ++i) array[i] = 0;
   }
 
+  void count(int *array, size_t n) {
+    [[intel::loop_count(20)]] for (int i = 0; i < n; ++i) array[i] = 0;
+  }
+
   void goo(int *array, size_t n) {
     [[intel::loop_count_min(3)]]
     [[intel::loop_count_max(10)]]
     [[intel::loop_count_avg(5)]]
+    [[intel::loop_count(20)]]
     for (int i = 0; i < n; ++i) array[i] = 0;
   }
 
@@ -3300,6 +3305,10 @@ using PGO.
     [[intel::loop_count_avg(N)]] for(;;) { }
   }
 
+  template<int A>
+  void func() {
+    [[intel::loop_count(A)]] for(;;) { }
+  }
   }];
 }
 

--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -1036,13 +1036,11 @@ void LoopInfoStack::push(BasicBlock *Header, clang::ASTContext &Ctx,
       const auto *CE =
           cast<ConstantExpr>(IntelFPGALoopCountAvg->getNTripCount());
       llvm::APSInt ArgVal = CE->getResultAsAPSInt();
-      const char *Var = IntelFPGALoopCountAvg->isMax()
-                            ? "llvm.loop.intel.loopcount_max"
-                            : IntelFPGALoopCountAvg->isMin()
-                                  ? "llvm.loop.intel.loopcount_min"
-                                  : IntelFPGALoopCountAvg->isAvg()
-                                  ? "llvm.loop.intel.loopcount_avg"
-                                  : "llvm.loop.intel.loopcount";
+      const char *Var =
+          IntelFPGALoopCountAvg->isMax()   ? "llvm.loop.intel.loopcount_max"
+          : IntelFPGALoopCountAvg->isMin() ? "llvm.loop.intel.loopcount_min"
+          : IntelFPGALoopCountAvg->isAvg() ? "llvm.loop.intel.loopcount_avg"
+                                           : "llvm.loop.intel.loopcount";
       setSYCLIntelFPGAVariantCount(Var, ArgVal.getSExtValue());
     }
 

--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -1040,7 +1040,9 @@ void LoopInfoStack::push(BasicBlock *Header, clang::ASTContext &Ctx,
                             ? "llvm.loop.intel.loopcount_max"
                             : IntelFPGALoopCountAvg->isMin()
                                   ? "llvm.loop.intel.loopcount_min"
-                                  : "llvm.loop.intel.loopcount_avg";
+                                  : IntelFPGALoopCountAvg->isAvg()
+                                  ? "llvm.loop.intel.loopcount_avg"
+                                  : "llvm.loop.intel.loopcount";
       setSYCLIntelFPGAVariantCount(Var, ArgVal.getSExtValue());
     }
 

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -402,7 +402,10 @@ CheckForDuplicateSYCLIntelLoopCountAttrs(Sema &S,
   unsigned int Count = 0;
   for (const auto *A : OnlyLoopCountAttrs) {
     const auto *At = dyn_cast<SYCLIntelFPGALoopCountAttr>(A);
-    At->isMin() ? MinCount++ : At->isMax() ? MaxCount++ : At->isAvg() ? AvgCount++ : Count++;
+    At->isMin()   ? MinCount++
+    : At->isMax() ? MaxCount++
+    : At->isAvg() ? AvgCount++
+                  : Count++;
     if (MinCount > 1 || MaxCount > 1 || AvgCount > 1 || Count > 1)
       S.Diag(A->getLocation(), diag::err_sycl_loop_attr_duplication) << 1 << A;
   }

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -399,10 +399,11 @@ CheckForDuplicateSYCLIntelLoopCountAttrs(Sema &S,
   unsigned int MinCount = 0;
   unsigned int MaxCount = 0;
   unsigned int AvgCount = 0;
+  unsigned int Count = 0;
   for (const auto *A : OnlyLoopCountAttrs) {
     const auto *At = dyn_cast<SYCLIntelFPGALoopCountAttr>(A);
-    At->isMin() ? MinCount++ : At->isMax() ? MaxCount++ : AvgCount++;
-    if (MinCount > 1 || MaxCount > 1 || AvgCount > 1)
+    At->isMin() ? MinCount++ : At->isMax() ? MaxCount++ : At->isAvg() ? AvgCount++ : Count++;
+    if (MinCount > 1 || MaxCount > 1 || AvgCount > 1 || Count > 1)
       S.Diag(A->getLocation(), diag::err_sycl_loop_attr_duplication) << 1 << A;
   }
 }

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -19,6 +19,7 @@
 // CHECK: br label %for.cond, !llvm.loop ![[MD_LCA:[0-9]+]]
 // CHECK: br label %for.cond2, !llvm.loop ![[MD_LCA_1:[0-9]+]]
 // CHECK: br label %for.cond13, !llvm.loop ![[MD_LCA_2:[0-9]+]]
+// CHECK: br label %for.cond24, !llvm.loop ![[MD_LCA_3:[0-9]+]]
 
 void disable_loop_pipelining() {
   int a[10];
@@ -136,12 +137,18 @@ void loop_count_control() {
   // CHECK-NEXT: ![[MD_loop_count_max]] = !{!"llvm.loop.intel.loopcount_max", i32 4}
   [[intel::loop_count_max(4)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // CHECK: ![[MD_LCA_2]] = distinct !{![[MD_LCA_2]], ![[MP:[0-9]+]], ![[MD_loop_count_min:[0-9]+]], ![[MD_loop_count_max_1:[0-9]+]], ![[MD_loop_count_avg_1:[0-9]+]]}
+  // CHECK: ![[MD_LCA_2]] = distinct !{![[MD_LCA_2]], ![[MP:[0-9]+]], ![[MD_loop_count_min:[0-9]+]], ![[MD_loop_count_max_1:[0-9]+]], ![[MD_loop_count_avg_1:[0-9]+]], ![[MD_loop_count_1:[0-9]+]]}
   // CHECK: ![[MD_loop_count_min]] = !{!"llvm.loop.intel.loopcount_min", i32 4}
   // CHECK: ![[MD_loop_count_max_1]] = !{!"llvm.loop.intel.loopcount_max", i32 40}
-  // CHECK-NEXT: ![[MD_loop_count_avg_1]] = !{!"llvm.loop.intel.loopcount_avg", i32 21}
-  [[intel::loop_count_min(4)]] [[intel::loop_count_max(40)]] [[intel::loop_count_avg(21)]] for (int i = 0; i != 10; ++i)
+  // CHECK: ![[MD_loop_count_avg_1]] = !{!"llvm.loop.intel.loopcount_avg", i32 21}
+  // CHECK: ![[MD_loop_count_1]] = !{!"llvm.loop.intel.loopcount", i32 30}
+  [[intel::loop_count_min(4)]] [[intel::loop_count_max(40)]] [[intel::loop_count_avg(21)]] [[intel::loop_count(30)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
+
+  // CHECK: ![[MD_LCA_3]] = distinct !{![[MD_LCA_3]], ![[MP:[0-9]+]], ![[MD_loop_count:[0-9]+]]}
+  // CHECK-NEXT: ![[MD_loop_count]] = !{!"llvm.loop.intel.loopcount", i32 12}
+  [[intel::loop_count(A)]] for (int i = 0; i != 10; ++i)
+       a[i] = 0;
 }
 
 template <typename name, typename Func>

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -137,18 +137,17 @@ void loop_count_control() {
   // CHECK-NEXT: ![[MD_loop_count_max]] = !{!"llvm.loop.intel.loopcount_max", i32 4}
   [[intel::loop_count_max(4)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // CHECK: ![[MD_LCA_2]] = distinct !{![[MD_LCA_2]], ![[MP:[0-9]+]], ![[MD_loop_count_min:[0-9]+]], ![[MD_loop_count_max_1:[0-9]+]], ![[MD_loop_count_avg_1:[0-9]+]], ![[MD_loop_count_1:[0-9]+]]}
+  // CHECK: ![[MD_LCA_2]] = distinct !{![[MD_LCA_2]], ![[MP:[0-9]+]], ![[MD_loop_count_min:[0-9]+]], ![[MD_loop_count_max_1:[0-9]+]], ![[MD_loop_count_avg_1:[0-9]+]], ![[MD_loop_count:[0-9]+]]}
   // CHECK: ![[MD_loop_count_min]] = !{!"llvm.loop.intel.loopcount_min", i32 4}
   // CHECK: ![[MD_loop_count_max_1]] = !{!"llvm.loop.intel.loopcount_max", i32 40}
   // CHECK: ![[MD_loop_count_avg_1]] = !{!"llvm.loop.intel.loopcount_avg", i32 21}
-  // CHECK: ![[MD_loop_count_1]] = !{!"llvm.loop.intel.loopcount", i32 30}
+  // CHECK-NEXT: ![[MD_loop_count]] = !{!"llvm.loop.intel.loopcount", i32 30}
   [[intel::loop_count_min(4)]] [[intel::loop_count_max(40)]] [[intel::loop_count_avg(21)]] [[intel::loop_count(30)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-
-  // CHECK: ![[MD_LCA_3]] = distinct !{![[MD_LCA_3]], ![[MP:[0-9]+]], ![[MD_loop_count:[0-9]+]]}
-  // CHECK-NEXT: ![[MD_loop_count]] = !{!"llvm.loop.intel.loopcount", i32 12}
+  // CHECK: ![[MD_LCA_3]] = distinct !{![[MD_LCA_3]], ![[MP:[0-9]+]], ![[MD_loop_count_1:[0-9]+]]}
+  // CHECK-NEXT: ![[MD_loop_count_1]] = !{!"llvm.loop.intel.loopcount", i32 12}
   [[intel::loop_count(A)]] for (int i = 0; i != 10; ++i)
-       a[i] = 0;
+      a[i] = 0;
 }
 
 template <typename name, typename Func>

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -23,7 +23,9 @@ void foo() {
   // expected-error@+1 {{'nofusion' attribute cannot be applied to a declaration}}
   [[intel::nofusion]] int k[10];
   // expected-error@+1{{'loop_count_avg' attribute cannot be applied to a declaration}}
-  [[intel::loop_count_avg(6)]] int p[10];
+  [[intel::loop_count_avg(6)]] int l[10];
+  // expected-error@+1{{'loop_count' attribute cannot be applied to a declaration}}
+  [[intel::loop_count(8)]] int m[10];
 }
 
 // Test for deprecated spelling of Intel FPGA loop attributes
@@ -117,6 +119,9 @@ void boo() {
   // expected-error@+1 {{'loop_count_avg' attribute takes one argument}}
   [[intel::loop_count_avg(3, 6)]]  for (int i = 0; i != 10; ++i)
       a[i] = 0;
+  // expected-error@+1 {{'loop_count' attribute takes one argument}}
+  [[intel::loop_count(6, 9)]]  for (int i = 0; i != 10; ++i)
+      a[i] = 0;
 }
 
 // Test for incorrect argument value for Intel FPGA loop attributes
@@ -202,6 +207,14 @@ void goo() {
       a[i] = 0;
   // expected-error@+1 {{integral constant expression must have integral or unscoped enumeration type, not 'const char[4]'}}
   [[intel::loop_count_avg("abc")]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+  // expected-error@+1 {{integral constant expression must have integral or unscoped enumeration type, not 'const char[4]'}}
+  [[intel::loop_count("abc")]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+  [[intel::loop_count(0)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+  // expected-error@+1 {{'loop_count' attribute requires a non-negative integral compile time constant expression}}
+  [[intel::loop_count(-1)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 }
 
@@ -316,6 +329,11 @@ void zoo() {
   // expected-error@+1{{duplicate Intel FPGA loop attribute 'loop_count_avg'}}
   [[intel::loop_count_avg(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
+
+  [[intel::loop_count(2)]]
+  // expected-error@+1{{duplicate Intel FPGA loop attribute 'loop_count'}}
+  [[intel::loop_count(2)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
 }
 
 // Test for Intel FPGA loop attributes compatibility
@@ -363,6 +381,9 @@ void loop_attrs_compatibility() {
   for (int i = 0; i != 10; ++i)
       a[i] = 0;
   [[intel::loop_count_max(8)]]
+  for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+  [[intel::loop_count(8)]]
   for (int i = 0; i != 10; ++i)
       a[i] = 0;
 }
@@ -499,6 +520,11 @@ void loop_count_control_dependent() {
   for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
+  //expected-error@+1{{'loop_count' attribute requires a non-negative integral compile time constant expression}}
+  [[intel::loop_count(C)]]
+  for (int i = 0; i != 10; ++i)
+       a[i] = 0;
+
   [[intel::loop_count_avg(A)]]
   //expected-error@+1{{duplicate Intel FPGA loop attribute 'loop_count_avg'}}
   [[intel::loop_count_avg(B)]] for (int i = 0; i != 10; ++i)
@@ -514,6 +540,10 @@ void loop_count_control_dependent() {
   [[intel::loop_count_max(B)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
+  [[intel::loop_count(A)]]
+  //expected-error@+1{{duplicate Intel FPGA loop attribute 'loop_count'}}
+  [[intel::loop_count(B)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
 }
 
 void check_max_concurrency_expression() {
@@ -647,6 +677,11 @@ void check_loop_attr_template_instantiation() {
   // expected-error@+2 {{integral constant expression must have integral or unscoped enumeration type, not 'S'}}
   // expected-error@+1 {{integral constant expression must have integral or unscoped enumeration type, not 'float'}}
   [[intel::loop_count_min(Ty{})]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+
+  // expected-error@+2 {{integral constant expression must have integral or unscoped enumeration type, not 'S'}}
+  // expected-error@+1 {{integral constant expression must have integral or unscoped enumeration type, not 'float'}}
+  [[intel::loop_count(Ty{})]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 }
 

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -521,7 +521,7 @@ void loop_count_control_dependent() {
 
   // expected-error@+1{{'loop_count' attribute requires a non-negative integral compile time constant expression}}
   [[intel::loop_count(C)]] for (int i = 0; i != 10; ++i)
-       a[i] = 0;
+      a[i] = 0;
 
   [[intel::loop_count_avg(A)]]
   //expected-error@+1{{duplicate Intel FPGA loop attribute 'loop_count_avg'}}

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -117,10 +117,10 @@ void boo() {
   [[intel::nofusion(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   // expected-error@+1 {{'loop_count_avg' attribute takes one argument}}
-  [[intel::loop_count_avg(3, 6)]]  for (int i = 0; i != 10; ++i)
+  [[intel::loop_count_avg(3, 6)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   // expected-error@+1 {{'loop_count' attribute takes one argument}}
-  [[intel::loop_count(6, 9)]]  for (int i = 0; i != 10; ++i)
+  [[intel::loop_count(6, 9)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 }
 
@@ -383,8 +383,7 @@ void loop_attrs_compatibility() {
   [[intel::loop_count_max(8)]]
   for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  [[intel::loop_count(8)]]
-  for (int i = 0; i != 10; ++i)
+  [[intel::loop_count(8)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 }
 
@@ -520,9 +519,8 @@ void loop_count_control_dependent() {
   for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
-  //expected-error@+1{{'loop_count' attribute requires a non-negative integral compile time constant expression}}
-  [[intel::loop_count(C)]]
-  for (int i = 0; i != 10; ++i)
+  // expected-error@+1{{'loop_count' attribute requires a non-negative integral compile time constant expression}}
+  [[intel::loop_count(C)]] for (int i = 0; i != 10; ++i)
        a[i] = 0;
 
   [[intel::loop_count_avg(A)]]
@@ -541,7 +539,7 @@ void loop_count_control_dependent() {
       a[i] = 0;
 
   [[intel::loop_count(A)]]
-  //expected-error@+1{{duplicate Intel FPGA loop attribute 'loop_count'}}
+  // expected-error@+1{{duplicate Intel FPGA loop attribute 'loop_count'}}
   [[intel::loop_count(B)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 }


### PR DESCRIPTION
The original implementation of this attribute in
https://github.com/intel/llvm/pull/3438, did not support
the [[intel::loop_count()]] attribute spelling. This patch
adds support for that spelling.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>