### PR TITLE
[SYCL][Doc] Add sub_group::load/store extension

### DIFF
--- a/sycl/doc/extensions/README.md
+++ b/sycl/doc/extensions/README.md
@@ -9,7 +9,6 @@ DPC++ extensions status:
 |-------------|:------------|:------------|
 | [SPV_INTEL_function_pointers](SPIRV/SPV_INTEL_function_pointers.asciidoc)                                                   | Supported(OpenCL: CPU, GPU; HOST)         | |
 | [SPV_INTEL_inline_assembly](SPIRV/SPV_INTEL_inline_assembly.asciidoc)                                                       | Supported(OpenCL: GPU)                    | |
-| [Sub-groups for NDRange Parallelism](SubGroupNDRange/SubGroupNDRange.md)                                                    | Deprecated(OpenCL: CPU, GPU)              | |
 
 Legend:
 

--- a/sycl/doc/extensions/SubGroupNDRange/SubGroupNDRange.md
+++ b/sycl/doc/extensions/SubGroupNDRange/SubGroupNDRange.md
@@ -1,7 +1,0 @@
-The sub-group extension has been split into two extensions, which can be found below:
-- [SubGroup](../SubGroup/)
-- [SubGroupAlgorithms](../SubGroupAlgorithms/)
-
-The previous extension is archived [here](https://github.com/intel/llvm/blob/fba2e0602550a86c74149d9875b788ad1117f8d3/sycl/doc/extensions/SubGroupNDRange/SubGroupNDRange.md).
-
-Some existing sub-group functionality has been deprecated as part of this change, and will be removed in a future version of the compiler.

--- a/sycl/doc/extensions/experimental/SYCL_EXT_ONEAPI_GROUP_LOAD_STORE.asciidoc
+++ b/sycl/doc/extensions/experimental/SYCL_EXT_ONEAPI_GROUP_LOAD_STORE.asciidoc
@@ -1,0 +1,173 @@
+= SYCL_EXT_ONEAPI_GROUP_LOAD_STORE
+:source-highlighter: coderay
+:coderay-linenums-mode: table
+
+// This section needs to be after the document title.
+:doctype: book
+:toc2:
+:toc: left
+:encoding: utf-8
+:lang: en
+
+:blank: pass:[ +]
+
+// Set the default source code type in this document to C++,
+// for syntax highlighting purposes.  This is needed because
+// docbook uses c++ and html5 uses cpp.
+:language: {basebackend@docbook:c++:cpp}
+
+== Introduction
+IMPORTANT: This specification is a draft.
+
+NOTE: Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are
+trademarks of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc.
+used by permission by Khronos.
+
+NOTE: This extension is experimental: interfaces are subject to change later.
+
+NOTE: This extension documents functionality that predates SYCL 2020's formal
+extension mechanism. Work is underway to align the extension with SYCL 2020;
+the documentation in its current state does not reflect the intended long-term
+direction of the extension.
+
+== Notice
+
+Copyright (c) 2019-2022 Intel Corporation.  All rights reserved.
+
+== Contact
+
+John Pennycook, Intel (john 'dot' pennycook 'at' intel 'dot' com)
+
+== Dependencies
+
+This extension is written against the SYCL 2020 specification, Revision 4.
+
+== Feature Test Macro
+
+A feature test macro will be defined in a future revision of this extension.
+
+== Overview
+
+This extension defines sub-group load and store functions which enable
+developers to assert that all work-items in a sub-group read/write from/to
+contiguous locations in memory.
+
+These functions are defined as member functions of the `sub_group` class.
+
+All functions act as group functions, and must be encountered by all work-items
+within the sub-group within converged control flow.
+
+NOTE: When this extension is updated to align with SYCL 2020, these member
+functions are expected to be replaced with free functions accepting a `Group`
+object as their first argument.
+
+== Loads
+
+[source,c++]
+----
+template <typename T>
+T load(const T* src)
+----
+_Constraints_: `T` must be a _NumericType_.
+
+_Preconditions_: The value of `src` must be the same for all work-items in the
+sub-group. `src` must be a pointer to the global or local address space.
+
+_Returns_: Returns one element per work-item, corresponding to the memory
+location at `src` + `get_local_id()`.
+
+[source,c++]
+----
+template <typename T, access::address_space Space>
+T load(const multi_ptr<T, Space>* src)
+----
+_Constraints_: `T` must be a _NumericType_. `Space` must be
+`access::address_space::global_space` or `access::address_space::local_space`.
+
+_Preconditions_: The value of `src` must be the same for all work-items in the
+sub-group.
+
+_Returns_: Returns one element per work-item, corresponding to the memory
+location at `src` + `get_local_id()`.
+
+[source,c++]
+----
+template <int N, typename T, access::address_space Space>
+vec<T, N> load(const multi_ptr<T, Space> src)
+----
+_Constraints_: `T` must be a _NumericType_. `Space` must be
+`access::address_space::global_space` or `access::address_space::local_space`.
+
+_Preconditions_: The value of `src` must be the same for all work-items in the
+sub-group.
+
+_Returns_: Returns `N` elements per work-item, corresponding to the `N` memory
+locations at `src` + `i` * `get_max_local_range()` + `get_local_id()` for `i`
+between 0 and `N`.
+
+== Stores
+
+[source,c++]
+----
+template <typename T>
+void store(T* dst, const T& x)
+----
+_Constraints_: `T` must be a _NumericType_.
+
+_Preconditions_: The value of `dst` must be the same for all work-items in the
+sub-group. `dst` must be a pointer to the global or local address space.
+
+_Effects_: Writes the value of `x` from each work-item to the memory location at
+`dst` + `get_local_id()`.
+
+[source,c++]
+----
+template <typename T, access::address_space Space>
+void store(multi_ptr<T, Space> dst, const T& x)
+----
+_Constraints_: `T` must be a _NumericType_. `Space` must be
+`access::address_space::global_space` or `access::address_space::local_space`.
+
+_Preconditions_: The value of `dst` must be the same for all work-items in the
+sub-group.
+
+_Effects_: Writes the value of `x` from each work-item to the memory location at
+`dst` + `get_local_id()`.
+
+[source,c++]
+----
+template <typename T, access::address_space Space>
+void store(multi_ptr<T, Space> dst, const vec<T, N>& x)
+----
+_Constraints_: `T` must be a _NumericType_. `Space` must be
+`access::address_space::global_space` or `access::address_space::local_space`.
+
+_Preconditions_: The value of `dst` must be the same for all work-items in the
+sub-group.
+
+_Effects_: Writes the `N` elements from each work-item's value of `x` to the
+memory locations at `dst` + `i` * `get_max_local_range()` + `get_local_id()`
+for `i` between 0 and `N`.
+
+== Issues
+
+. What should the return type of `load` be?
+--
+*RESOLVED*: The return type should be an unspecified type that is implicitly
+convertible to `vec<T, N>` (if `T` is compatible with the `vec` interface) and
+also to `marray<T, N>`. Similarly, `store` should accept both `vec` and
+`marray` arguments. This change will be reflected in a future version of the
+extension.
+--
+
+. How should the interface extend to cover cases with different data layouts?
+--
+*RESOLVED*: A future version of the extension will use the compile-time property
+interface to provide additional functionality.
+--
+
+//. asd
+//+
+//--
+//*RESOLUTION*: Not resolved.
+//--


### PR DESCRIPTION
The original extension document containing the specifications for the
sub_group::load and sub_group::store functions was previously removed,
leaving these extensions undocumented.

Although we plan to deprecate and replace these extensions in the near
term, providing no documentation is not user-friendly.

Note that the documentation introduced by this PR describes only the
functionality that is already implemented in the sub_group class.

Signed-off-by: John Pennycook <john.pennycook@intel.com>