### PR TITLE
[SYCL][NFC] Fix static code analysis concerns

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -5131,14 +5131,14 @@ bool Util::isSyclKernelHandlerType(QualType Ty) {
 
 bool Util::isSyclAccessorNoAliasPropertyType(QualType Ty) {
   std::array<DeclContextDesc, 7> Scopes = {
-      Util::DeclContextDesc{Decl::Kind::Namespace, "cl"},
-      Util::DeclContextDesc{Decl::Kind::Namespace, "sycl"},
-      Util::DeclContextDesc{Decl::Kind::Namespace, "ext"},
-      Util::DeclContextDesc{Decl::Kind::Namespace, "oneapi"},
-      Util::DeclContextDesc{Decl::Kind::Namespace, "property"},
-      Util::DeclContextDesc{Decl::Kind::CXXRecord, "no_alias"},
-      Util::DeclContextDesc{Decl::Kind::ClassTemplateSpecialization,
-                            "instance"}};
+      Util::MakeDeclContextDesc(Decl::Kind::Namespace, "cl"),
+      Util::MakeDeclContextDesc(Decl::Kind::Namespace, "sycl"),
+      Util::MakeDeclContextDesc(Decl::Kind::Namespace, "ext"),
+      Util::MakeDeclContextDesc(Decl::Kind::Namespace, "oneapi"),
+      Util::MakeDeclContextDesc(Decl::Kind::Namespace, "property"),
+      Util::MakeDeclContextDesc(Decl::Kind::CXXRecord, "no_alias"),
+      Util::MakeDeclContextDesc(Decl::Kind::ClassTemplateSpecialization,
+                                "instance")};
   return matchQualifiedTypeName(Ty, Scopes);
 }
 


### PR DESCRIPTION
Found via a static-analysis tool: Non-void function does not return value

Inside isSyclAccessorNoAliasPropertyType() in SemaSYCL.cpp file:
```
bool Util::isSyclAccessorNoAliasPropertyType(QualType Ty) {
  std::array<DeclContextDesc, 7> Scopes = {
      Util::DeclContextDesc{Decl::Kind::Namespace, "cl"},
      Util::DeclContextDesc{Decl::Kind::Namespace, "sycl"},
      Util::DeclContextDesc{Decl::Kind::Namespace, "ext"},
      Util::DeclContextDesc{Decl::Kind::Namespace, "oneapi"},
      Util::DeclContextDesc{Decl::Kind::Namespace, "property"},
      Util::DeclContextDesc{Decl::Kind::CXXRecord, "no_alias"},
      Util::DeclContextDesc{Decl::Kind::ClassTemplateSpecialization,
                            "instance"}};
  return matchQualifiedTypeName(Ty, Scopes);
}
```

This patch adds Util::MakeDeclContextDesc() instead of Util::DeclContextDesc() to avoid a spurious diagnostic from the static analyzer.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>