### PR TITLE
[SYCL] Initialize enable_default_contexts with true on Windows

### DIFF
--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -318,12 +318,7 @@ template <> class SYCLConfig<SYCL_ENABLE_DEFAULT_CONTEXTS> {
 
 public:
   static bool get() {
-#ifdef WIN32
-    constexpr bool DefaultValue = false;
-#else
     constexpr bool DefaultValue = true;
-#endif
-
     const char *ValStr = getCachedValue();
 
     if (!ValStr)


### PR DESCRIPTION
previously, ENABLE_DEFAULT_CONTEXTS was initialized to false on Windows to workaround a handle release/memory leak. That issue has since been resolved, so default context should be enabled on both Linux and Win

Signed-off-by: Chris Perkins <chris.perkins@intel.com>