### PR TITLE
[SYCL] Fix SYCL Kernel Body Check

### DIFF
--- a/clang/test/SemaSYCL/non-kernel-functor.cpp
+++ b/clang/test/SemaSYCL/non-kernel-functor.cpp
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown  -verify %s
+
+// Test to verify that non-kernel functors are not processed as SYCL kernel
+// functors
+
+// expected-no-diagnostics
+class First {
+public:
+  void operator()() { return; }
+};
+
+class Second {
+public:
+  First operator()() { return First(); }
+};
+
+SYCL_EXTERNAL
+void foo() {
+  Second m_uold;
+  m_uold()();
+}


### PR DESCRIPTION
SYCLKernelAttr can be used to check if a given function is
a SYCL kernel body function or not. A SYCL kernel body function
is the operator() method of a SYCL Kernel Functor or Lamda Function.
The existing check which only tested if a FunctionDecl was an
operator or not, allowed for false positives. This patch adds an
additional check for th SYCLKernelAttr, which will be attached to
the kernel body function's parent/ parent's parent (for wrapped
kernels)

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>