### PR TITLE
[ESIMD] Treat any non-zero (not just 1 in LSB) as 'true' in pack_mask.

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/operators.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/operators.hpp
@@ -121,6 +121,9 @@ namespace detail {
       const __SEIEED::simd_obj_impl<__raw_t<T1>, N, SimdT<T1, N>> &LHS,        \
       const __SEIEED::simd_obj_impl<__raw_t<T2>, N, SimdT<T2, N>> &RHS) {      \
     if constexpr (__SEIEED::is_simd_type_v<SimdT<T1, N>>) {                    \
+      /* TODO CM_COMPAT To match CM behavior, here vector element types are */ \
+      /* promoted similar to C++ scalar type promotion, which is different  */ \
+      /* from clang behavior when applying binary ops to vectors            */ \
       using PromotedT = __SEIEED::computation_type_t<T1, T2>;                  \
       /* vector_binary_op returns SimdT<PromotedT, N>::raw_vector_type */      \
       SimdT<PromotedT, N> Res = vector_binary_op<BINOP_ID, PromotedT, N>(      \


### PR DESCRIPTION
E2E test: https://github.com/intel/llvm-test-suite/pull/826

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>