### PR TITLE
[SYCL][DOC] Change wording in sycl-post-link error message

### DIFF
--- a/sycl/doc/DeviceGlobal.md
+++ b/sycl/doc/DeviceGlobal.md
@@ -372,7 +372,7 @@ than one module, the `sycl-post-link` tool issues an error diagnostic:
 
 ```
 error: device_global variable <name> with property "device_image_scope"
-       is contained in more than one device image.
+       is used in more than one device image.
 ```
 
 Assuming that no error diagnostic is issued, the `sycl-post-link` tool includes


### PR DESCRIPTION
It would be clearer for a user to see "used" instead of "contained".
Also, even for us the fact that device_global is "contained" is
determined by whether device_global is used.

Co-authored-by: Alexey Sachkov <alexey.sachkov@intel.com>
Signed-off-by: Pavel Samolysov <pavel.samolysov@intel.com>