### PR TITLE
[sycl-post-link][NFC] Address clang-tidy concerns in the sycl-post-link

### DIFF
--- a/llvm/tools/sycl-post-link/SpecConstants.cpp
+++ b/llvm/tools/sycl-post-link/SpecConstants.cpp
@@ -369,11 +369,11 @@ void collectCompositeElementsDefaultValuesRecursive(
 
   // Assume that we encountered some scalar element
   size_t NumBytes = M.getDataLayout().getTypeStoreSize(C->getType());
-  if (auto* IntConst = dyn_cast<ConstantInt>(C)) {
+  if (auto *IntConst = dyn_cast<ConstantInt>(C)) {
     auto Val = IntConst->getValue().getZExtValue();
     std::copy_n(reinterpret_cast<char *>(&Val), NumBytes,
                 std::back_inserter(DefaultValues));
-  } else if (auto* FPConst = dyn_cast<ConstantFP>(C)) {
+  } else if (auto *FPConst = dyn_cast<ConstantFP>(C)) {
     auto Val = FPConst->getValue();
 
     if (NumBytes == 2) {

--- a/llvm/tools/sycl-post-link/SpecConstants.cpp
+++ b/llvm/tools/sycl-post-link/SpecConstants.cpp
@@ -369,11 +369,11 @@ void collectCompositeElementsDefaultValuesRecursive(
 
   // Assume that we encountered some scalar element
   size_t NumBytes = M.getDataLayout().getTypeStoreSize(C->getType());
-  if (auto IntConst = dyn_cast<ConstantInt>(C)) {
+  if (auto* IntConst = dyn_cast<ConstantInt>(C)) {
     auto Val = IntConst->getValue().getZExtValue();
     std::copy_n(reinterpret_cast<char *>(&Val), NumBytes,
                 std::back_inserter(DefaultValues));
-  } else if (auto FPConst = dyn_cast<ConstantFP>(C)) {
+  } else if (auto* FPConst = dyn_cast<ConstantFP>(C)) {
     auto Val = FPConst->getValue();
 
     if (NumBytes == 2) {
@@ -383,12 +383,12 @@ void collectCompositeElementsDefaultValuesRecursive(
       std::copy_n(reinterpret_cast<char *>(&Storage), NumBytes,
                   std::back_inserter(DefaultValues));
     } else if (NumBytes == 4) {
-      float v = Val.convertToFloat();
-      std::copy_n(reinterpret_cast<char *>(&v), NumBytes,
+      float V = Val.convertToFloat();
+      std::copy_n(reinterpret_cast<char *>(&V), NumBytes,
                   std::back_inserter(DefaultValues));
     } else if (NumBytes == 8) {
-      double v = Val.convertToDouble();
-      std::copy_n(reinterpret_cast<char *>(&v), NumBytes,
+      double V = Val.convertToDouble();
+      std::copy_n(reinterpret_cast<char *>(&V), NumBytes,
                   std::back_inserter(DefaultValues));
     } else {
       llvm_unreachable("Unexpected constant floating point type");

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -423,7 +423,7 @@ std::vector<StringRef> getKernelNamesUsingAssert(const Module &M) {
       traverseCGToFindSPIRKernels(DevicelibAssertFailFunction);
 
   if (TraverseResult.hasValue())
-    return std::move(*TraverseResult); // TODO remove std::move after C++17
+    return std::move(*TraverseResult);
 
   // Here we reached "referenced-indirectly", so we need to find all kernels and
   // return them.

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -368,14 +368,14 @@ void groupEntryPoints(const Module &M, EntryPointGroupMap &EntryPointsGroups,
 // This function traverses over reversed call graph by BFS algorithm.
 // It means that an edge links some function @func with functions
 // which contain call of function @func. It starts from
-// @StartingFunction and lifts up until it reach all reachable functions
+// @StartingFunction and lifts up until it reach all reachable functions,
 // or it reaches some function containing "referenced-indirectly" attribute.
 // If it reaches "referenced-indirectly" attribute than it returns an empty
 // Optional.
 // Otherwise, it returns an Optional containing a list of reached
 // SPIR kernel function's names.
 Optional<std::vector<StringRef>>
-TraverseCGToFindSPIRKernels(const Function *StartingFunction) {
+traverseCGToFindSPIRKernels(const Function *StartingFunction) {
   std::queue<const Function *> FunctionsToVisit;
   std::unordered_set<const Function *> VisitedFunctions;
   FunctionsToVisit.push(StartingFunction);
@@ -411,19 +411,19 @@ TraverseCGToFindSPIRKernels(const Function *StartingFunction) {
     }
   }
 
-  return std::move(KernelNames);
+  return {std::move(KernelNames)};
 }
 
 std::vector<StringRef> getKernelNamesUsingAssert(const Module &M) {
-  auto DevicelibAssertFailFunction = M.getFunction("__devicelib_assert_fail");
+  auto *DevicelibAssertFailFunction = M.getFunction("__devicelib_assert_fail");
   if (!DevicelibAssertFailFunction)
     return {};
 
   auto TraverseResult =
-      TraverseCGToFindSPIRKernels(DevicelibAssertFailFunction);
+      traverseCGToFindSPIRKernels(DevicelibAssertFailFunction);
 
   if (TraverseResult.hasValue())
-    return std::move(*TraverseResult);
+    return std::move(*TraverseResult); // TODO remove std::move after C++17
 
   // Here we reached "referenced-indirectly", so we need to find all kernels and
   // return them.
@@ -438,7 +438,7 @@ std::vector<StringRef> getKernelNamesUsingAssert(const Module &M) {
 
 // Gets reqd_work_group_size information for function Func.
 std::vector<uint32_t> getKernelReqdWorkGroupSizeMetadata(const Function &Func) {
-  auto ReqdWorkGroupSizeMD = Func.getMetadata("reqd_work_group_size");
+  auto *ReqdWorkGroupSizeMD = Func.getMetadata("reqd_work_group_size");
   if (!ReqdWorkGroupSizeMD)
     return {};
   // TODO: Remove 3-operand assumption when it is relaxed.


### PR DESCRIPTION
The patch fixes some issues from clang-tidy related to the code-style
and missed auto-stars (auto*) when a local variable is a pointer.