### PR TITLE
[sycl-post-link] Add SYCLStripDeadDebugInfo pass

### DIFF
--- a/llvm/test/tools/sycl-post-link/aggressive-strip-debug-info-cu.ll
+++ b/llvm/test/tools/sycl-post-link/aggressive-strip-debug-info-cu.ll
@@ -2,18 +2,18 @@
 ; from those units are absent in split module.
 
 ; RUN: sycl-post-link -split=kernel -S %s -o %t.table
-; RUN: FileCheck %s -input-file=%t_0.ll -check-prefix=AGGR
-; RUN: FileCheck %s -input-file=%t_1.ll -check-prefix=AGGR
+; RUN: FileCheck %s -input-file=%t_0.ll -check-prefix=CHECK-AGGR
+; RUN: FileCheck %s -input-file=%t_1.ll -check-prefix=CHECK-AGGR
 
 ; CHECK-AGGR: !llvm.dbg.cu = !{!{{[0-9]+}}}
 ; CHECK-AGGR-COUNT-1: !DICompileUnit
 
 ; RUN: sycl-post-link -split=kernel -safe-strip-dead-debug-info=true -S %s -o %t.table
-; RUN: FileCheck %s -input-file=%t_0.ll -check-prefix=SAFE
-; RUN: FileCheck %s -input-file=%t_1.ll -check-prefix=SAFE
+; RUN: FileCheck %s -input-file=%t_0.ll -check-prefix=CHECK-SAFE
+; RUN: FileCheck %s -input-file=%t_1.ll -check-prefix=CHECK-SAFE
 
 ; CHECK-SAFE: !llvm.dbg.cu = !{!{{[0-9]+}}, !{{[0-9]+}}}
-; CHECK-AGGR-COUNT-2: !DICompileUnit
+; CHECK-SAFE-COUNT-2: !DICompileUnit
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"

--- a/llvm/test/tools/sycl-post-link/aggressive-strip-debug-info-cu.ll
+++ b/llvm/test/tools/sycl-post-link/aggressive-strip-debug-info-cu.ll
@@ -1,12 +1,19 @@
 ; This test checks that sycl-post-link delete debug compile units if functions
 ; from those units are absent in split module.
 
-; RUN: sycl-post-link -split=kernel -aggressive-strip-debug-info -S %s -o %t.table
-; RUN: FileCheck %s -input-file=%t_0.ll
-; RUN: FileCheck %s -input-file=%t_1.ll
+; RUN: sycl-post-link -split=kernel -S %s -o %t.table
+; RUN: FileCheck %s -input-file=%t_0.ll -check-prefix=AGGR
+; RUN: FileCheck %s -input-file=%t_1.ll -check-prefix=AGGR
 
-; CHECK: !llvm.dbg.cu = !{!{{[0-9]+}}}
-; CHECK-COUNT-1: !DICompileUnit
+; CHECK-AGGR: !llvm.dbg.cu = !{!{{[0-9]+}}}
+; CHECK-AGGR-COUNT-1: !DICompileUnit
+
+; RUN: sycl-post-link -split=kernel -safe-strip-dead-debug-info=true -S %s -o %t.table
+; RUN: FileCheck %s -input-file=%t_0.ll -check-prefix=SAFE
+; RUN: FileCheck %s -input-file=%t_1.ll -check-prefix=SAFE
+
+; CHECK-SAFE: !llvm.dbg.cu = !{!{{[0-9]+}}, !{{[0-9]+}}}
+; CHECK-AGGR-COUNT-2: !DICompileUnit
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"

--- a/llvm/test/tools/sycl-post-link/aggressive-strip-debug-info-cu.ll
+++ b/llvm/test/tools/sycl-post-link/aggressive-strip-debug-info-cu.ll
@@ -1,0 +1,46 @@
+; This test checks that sycl-post-link delete debug compile units if functions
+; from those units are absent in split module.
+
+; RUN: sycl-post-link -split=kernel -aggressive-strip-debug-info -S %s -o %t.table
+; RUN: FileCheck %s -input-file=%t_0.ll
+; RUN: FileCheck %s -input-file=%t_1.ll
+
+; CHECK: !llvm.dbg.cu = !{!{{[0-9]+}}}
+; CHECK-COUNT-1: !DICompileUnit
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: convergent mustprogress noinline norecurse nounwind optnone
+define spir_func void @dev_func1() #0 !dbg !13 {
+  ret void, !dbg !14
+}
+
+; Function Attrs: convergent mustprogress noinline norecurse nounwind optnone
+define spir_func void @dev_func2() #1 !dbg !15 {
+  ret void, !dbg !16
+}
+
+attributes #0 = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="/home/user/test/dev_func1.cpp" }
+attributes #1 = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="/home/user/test/dev_func2.cpp" }
+
+!llvm.dbg.cu = !{!0, !3, !5}
+!llvm.module.flags = !{!12}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, imports: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "dev_func1.cpp", directory: "/home/user/test")
+!2 = !{}
+!3 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !4, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, imports: !2, splitDebugInlining: false, nameTableKind: None)
+!4 = !DIFile(filename: "dev_func2.cpp", directory: "/home/user/test")
+!5 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !6, producer: "clang", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, retainedTypes: !2, imports: !7, splitDebugInlining: false, nameTableKind: None)
+!6 = !DIFile(filename: "dev_func3.cpp", directory: "/home/user/test")
+!7 = !{!8}
+!8 = !DIImportedEntity(tag: DW_TAG_imported_declaration, scope: !6, entity: !9, file: !6, line: 129)
+!9 = distinct !DISubprogram(name: "dev_func3", linkageName: "dev_func3", scope: !6, file: !6, line: 96, type: !10, scopeLine: 96, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !5, retainedNodes: !2)
+!10 = !DISubroutineType(cc: DW_CC_LLVM_SpirFunction, types: !11)
+!11 = !{null}
+!12 = !{i32 2, !"Debug Info Version", i32 3}
+!13 = distinct !DISubprogram(name: "dev_func1", linkageName: "dev_func1", scope: !1, file: !1, line: 22, type: !10, scopeLine: 22, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!14 = !DILocation(line: 29, column: 5, scope: !13)
+!15 = distinct !DISubprogram(name: "dev_func2", linkageName: "dev_func2", scope: !4, file: !4, line: 22, type: !10, scopeLine: 22, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !3, retainedNodes: !2)
+!16 = !DILocation(line: 29, column: 5, scope: !15)

--- a/llvm/test/tools/sycl-post-link/aggressive-strip-debug-info-gve.ll
+++ b/llvm/test/tools/sycl-post-link/aggressive-strip-debug-info-gve.ll
@@ -1,12 +1,23 @@
 ; This test checks that sycl-post-link delete debug compile units if global
 ; constants from those units are absent in split module.
 
-; RUN: sycl-post-link -split=kernel -aggressive-strip-debug-info -S %s -o %t.table
-; RUN: FileCheck %s -input-file=%t_0.ll
-; RUN: FileCheck %s -input-file=%t_1.ll
+; RUN: sycl-post-link -split=kernel -S %s -o %t.table
+; RUN: FileCheck %s -input-file=%t_0.ll -check-prefix=AGGR
+; RUN: FileCheck %s -input-file=%t_1.ll -check-prefix=AGGR
+; RUN: FileCheck %s -input-file=%t_2.ll -check-prefix=AGGR
 
-; CHECK: !llvm.dbg.cu = !{!{{[0-9]+}}}
+; CHECK-AGGR: !llvm.dbg.cu = !{!{{[0-9]+}}}
 ; CHECK-COUNT-1: !DICompileUnit
+
+; Note: one of IR files should contain 3 compile units, but to simplify
+;       validation we check that at least 2 compile units present in each file.
+; RUN: sycl-post-link -split=kernel -safe-strip-dead-debug-info=true -S %s -o %t.table
+; RUN: FileCheck %s -input-file=%t_0.ll -check-prefix=SAFE
+; RUN: FileCheck %s -input-file=%t_1.ll -check-prefix=SAFE
+; RUN: FileCheck %s -input-file=%t_2.ll -check-prefix=SAFE
+
+; CHECK-SAFE: !llvm.dbg.cu = !{!{{[0-9]+}}, !{{[0-9]+}}
+; CHECK-SAFE-COUNT-2: !DICompileUnit
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"

--- a/llvm/test/tools/sycl-post-link/aggressive-strip-debug-info-gve.ll
+++ b/llvm/test/tools/sycl-post-link/aggressive-strip-debug-info-gve.ll
@@ -1,0 +1,63 @@
+; This test checks that sycl-post-link delete debug compile units if global
+; constants from those units are absent in split module.
+
+; RUN: sycl-post-link -split=kernel -aggressive-strip-debug-info -S %s -o %t.table
+; RUN: FileCheck %s -input-file=%t_0.ll
+; RUN: FileCheck %s -input-file=%t_1.ll
+
+; CHECK: !llvm.dbg.cu = !{!{{[0-9]+}}}
+; CHECK-COUNT-1: !DICompileUnit
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: convergent mustprogress noinline norecurse nounwind optnone
+define spir_func void @dev_func1() #0 !dbg !16 {
+  %1 = call spir_func i32 @dev_subfunc1(i32 0) #2, !dbg !19
+  ret void, !dbg !20
+}
+
+; Function Attrs: convergent mustprogress noinline norecurse nounwind optnone
+define spir_func i32 @dev_subfunc1(i32 %0) #0 !dbg !21 {
+  ret i32 %0, !dbg !24
+}
+
+; Function Attrs: convergent mustprogress noinline norecurse nounwind optnone
+define spir_func void @dev_func2() #1 !dbg !25 {
+  ret void, !dbg !26
+}
+
+attributes #0 = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="/home/usr/test/dev_func1.cpp" }
+attributes #1 = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "min-legal-vector-width"="0" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="/home/usr/test/dev_func2.cpp" }
+attributes #2 = { convergent }
+
+!llvm.dbg.cu = !{!0, !8, !10}
+!llvm.module.flags = !{!15}
+
+!0 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !1, isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !3, imports: !2, splitDebugInlining: false, nameTableKind: None)
+!1 = !DIFile(filename: "dev_func1.cpp", directory: "/home/usr/test")
+!2 = !{}
+!3 = !{!4}
+!4 = !DIGlobalVariableExpression(var: !5, expr: !DIExpression(DW_OP_constu, 0, DW_OP_stack_value))
+!5 = distinct !DIGlobalVariable(name: "ZERO", scope: !1, file: !1, line: 32, type: !6, isLocal: true, isDefinition: true)
+!6 = !DIDerivedType(tag: DW_TAG_const_type, baseType: !7)
+!7 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!8 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !9, isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, imports: !2, splitDebugInlining: false, nameTableKind: None)
+!9 = !DIFile(filename: "dev_func2.cpp", directory: "/home/usr/test")
+!10 = distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: !11, isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !2, globals: !12, imports: !2, splitDebugInlining: false, nameTableKind: None)
+!11 = !DIFile(filename: "file3.cpp", directory: "/home/usr/test")
+!12 = !{!13}
+!13 = !DIGlobalVariableExpression(var: !14, expr: !DIExpression(DW_OP_constu, 0, DW_OP_stack_value))
+!14 = distinct !DIGlobalVariable(name: "ZERO", scope: !11, file: !11, line: 145, type: !6, isLocal: true, isDefinition: true)
+!15 = !{i32 2, !"Debug Info Version", i32 3}
+!16 = distinct !DISubprogram(name: "dev_func1", linkageName: "dev_func1", scope: !1, file: !1, line: 22, type: !17, scopeLine: 22, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!17 = !DISubroutineType(cc: DW_CC_LLVM_SpirFunction, types: !18)
+!18 = !{null}
+!19 = !DILocation(line: 12, column: 1, scope: !16)
+!20 = !DILocation(line: 29, column: 5, scope: !16)
+!21 = distinct !DISubprogram(name: "dev_subfunc1", linkageName: "dev_subfunc1", scope: !1, file: !1, line: 42, type: !22, scopeLine: 42, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+!22 = !DISubroutineType(cc: DW_CC_LLVM_SpirFunction, types: !23)
+!23 = !{!7, !7}
+!24 = !DILocation(line: 5, column: 1, scope: !21)
+!25 = distinct !DISubprogram(name: "dev_func2", linkageName: "dev_func2", scope: !9, file: !9, line: 22, type: !17, scopeLine: 22, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !8, retainedNodes: !2)
+!26 = !DILocation(line: 29, column: 5, scope: !25)

--- a/llvm/test/tools/sycl-post-link/aggressive-strip-debug-info-gve.ll
+++ b/llvm/test/tools/sycl-post-link/aggressive-strip-debug-info-gve.ll
@@ -2,19 +2,19 @@
 ; constants from those units are absent in split module.
 
 ; RUN: sycl-post-link -split=kernel -S %s -o %t.table
-; RUN: FileCheck %s -input-file=%t_0.ll -check-prefix=AGGR
-; RUN: FileCheck %s -input-file=%t_1.ll -check-prefix=AGGR
-; RUN: FileCheck %s -input-file=%t_2.ll -check-prefix=AGGR
+; RUN: FileCheck %s -input-file=%t_0.ll -check-prefix=CHECK-AGGR
+; RUN: FileCheck %s -input-file=%t_1.ll -check-prefix=CHECK-AGGR
+; RUN: FileCheck %s -input-file=%t_2.ll -check-prefix=CHECK-AGGR
 
 ; CHECK-AGGR: !llvm.dbg.cu = !{!{{[0-9]+}}}
-; CHECK-COUNT-1: !DICompileUnit
+; CHECK-AGGR-COUNT-1: !DICompileUnit
 
 ; Note: one of IR files should contain 3 compile units, but to simplify
 ;       validation we check that at least 2 compile units present in each file.
 ; RUN: sycl-post-link -split=kernel -safe-strip-dead-debug-info=true -S %s -o %t.table
-; RUN: FileCheck %s -input-file=%t_0.ll -check-prefix=SAFE
-; RUN: FileCheck %s -input-file=%t_1.ll -check-prefix=SAFE
-; RUN: FileCheck %s -input-file=%t_2.ll -check-prefix=SAFE
+; RUN: FileCheck %s -input-file=%t_0.ll -check-prefix=CHECK-SAFE
+; RUN: FileCheck %s -input-file=%t_1.ll -check-prefix=CHECK-SAFE
+; RUN: FileCheck %s -input-file=%t_2.ll -check-prefix=CHECK-SAFE
 
 ; CHECK-SAFE: !llvm.dbg.cu = !{!{{[0-9]+}}, !{{[0-9]+}}
 ; CHECK-SAFE-COUNT-2: !DICompileUnit

--- a/llvm/tools/sycl-post-link/CMakeLists.txt
+++ b/llvm/tools/sycl-post-link/CMakeLists.txt
@@ -24,6 +24,7 @@ add_llvm_tool(sycl-post-link
   SpecConstants.cpp
   SYCLDeviceLibReqMask.cpp
   SYCLKernelParamOptInfo.cpp
+  SYCLStripDeadDebugInfo.cpp
   ADDITIONAL_HEADER_DIRS
   ${LLVMGenXIntrinsics_SOURCE_DIR}/GenXIntrinsics/include
   ${LLVMGenXIntrinsics_BINARY_DIR}/GenXIntrinsics/include

--- a/llvm/tools/sycl-post-link/SYCLStripDeadDebugInfo.cpp
+++ b/llvm/tools/sycl-post-link/SYCLStripDeadDebugInfo.cpp
@@ -27,7 +27,7 @@ namespace {
 // llvm::StripDeadDebugInfoPass, but some conditions for delete debug info more
 // aggressive taking into account that processed module is split from another
 // bigger module and contains only a subset of functions from it.
-bool stripDeadDebugInfoImpl(Module &M) {
+bool stripDeadDebugInfoImpl(Module &M, bool AggressiveMode) {
   bool Changed = false;
 
   LLVMContext &C = M.getContext();
@@ -128,7 +128,7 @@ namespace llvm {
 
 PreservedAnalyses SYCLStripDeadDebugInfo::run(Module &M,
                                               ModuleAnalysisManager &AM) {
-  stripDeadDebugInfoImpl(M);
+  stripDeadDebugInfoImpl(M, AggressiveMode);
   return PreservedAnalyses::all();
 }
 

--- a/llvm/tools/sycl-post-link/SYCLStripDeadDebugInfo.cpp
+++ b/llvm/tools/sycl-post-link/SYCLStripDeadDebugInfo.cpp
@@ -1,0 +1,123 @@
+//===-- SYCLStripDeadDebugInfo.cpp - Strip debug info from split module ---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "SYCLStripDeadDebugInfo.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/DebugInfoMetadata.h"
+#include "llvm/IR/GlobalVariable.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/IR/Module.h"
+
+#include <set>
+#include <unordered_set>
+
+using namespace llvm;
+
+namespace {
+
+// The implementation of this function is almost the same as of the one for
+// llvm::StripDeadDebugInfoPass, but some conditions for delete debug info more
+// aggressive taking into account that processed module is split from another
+// bigger module and contains only a subset of functions from it.
+bool stripDeadDebugInfoImpl(Module &M) {
+  bool Changed = false;
+
+  LLVMContext &C = M.getContext();
+
+  // Find all debug info in DIF. This is actually overkill in terms of what we
+  // want to do, but we want to try and be as resilient as possible in the face
+  // of potential debug info changes by using the formal interfaces given to us
+  // as much as possible.
+  DebugInfoFinder DIF;
+  DIF.processModule(M);
+
+  // For each compile unit, find the live set of global variables/functions and
+  // replace the current list of potentially dead global variables/functions
+  // with the live list.
+  SmallVector<Metadata *, 64> LiveGlobalVariables;
+  DenseSet<DIGlobalVariableExpression *> VisitedSet;
+
+  std::set<DIGlobalVariableExpression *> LiveGVs;
+  for (GlobalVariable &GV : M.globals()) {
+    SmallVector<DIGlobalVariableExpression *, 1> GVEs;
+    GV.getDebugInfo(GVEs);
+    for (auto *GVE : GVEs)
+      LiveGVs.insert(GVE);
+  }
+
+  std::unordered_set<const DISubprogram *> PresentFunctionsSPs;
+  for (auto &F : M.functions())
+    if (auto *FSP = cast_or_null<DISubprogram>(F.getSubprogram()))
+      PresentFunctionsSPs.insert(FSP);
+
+  std::set<DICompileUnit *> LiveCUs;
+  // Any CU referenced from a subprogram is live if this subprogram is linked to
+  // a function in a processed module.
+  for (const DISubprogram *SP : DIF.subprograms())
+    if (SP->getUnit() && PresentFunctionsSPs.count(SP))
+      LiveCUs.insert(SP->getUnit());
+
+  bool HasDeadCUs = false;
+  for (DICompileUnit *DIC : DIF.compile_units()) {
+    // Create our live global variable list.
+    bool GlobalVariableChange = false;
+    for (auto *DIG : DIC->getGlobalVariables()) {
+      // Make sure we only visit each global variable only once.
+      if (!VisitedSet.insert(DIG).second)
+        continue;
+
+      // If a global variable references DIG, the global variable is live.
+      if (LiveGVs.count(DIG))
+        LiveGlobalVariables.push_back(DIG);
+      else
+        GlobalVariableChange = true;
+    }
+
+    if (!LiveGlobalVariables.empty())
+      LiveCUs.insert(DIC);
+    else if (!LiveCUs.count(DIC))
+      HasDeadCUs = true;
+
+    // If we found dead global variables, replace the current global
+    // variable list with our new live global variable list.
+    if (GlobalVariableChange) {
+      DIC->replaceGlobalVariables(MDTuple::get(C, LiveGlobalVariables));
+      Changed = true;
+    }
+
+    // Reset lists for the next iteration.
+    LiveGlobalVariables.clear();
+  }
+
+  if (HasDeadCUs) {
+    // Delete the old node and replace it with a new one
+    NamedMDNode *NMD = M.getOrInsertNamedMetadata("llvm.dbg.cu");
+    NMD->clearOperands();
+    if (!LiveCUs.empty())
+      for (DICompileUnit *CU : LiveCUs)
+        NMD->addOperand(CU);
+    Changed = true;
+  }
+
+  return Changed;
+}
+
+} // anonymous namespace
+
+namespace llvm {
+
+PreservedAnalyses SYCLStripDeadDebugInfo::run(Module &M,
+                                              ModuleAnalysisManager &AM) {
+  stripDeadDebugInfoImpl(M);
+  return PreservedAnalyses::all();
+}
+
+} // namespace llvm

--- a/llvm/tools/sycl-post-link/SYCLStripDeadDebugInfo.h
+++ b/llvm/tools/sycl-post-link/SYCLStripDeadDebugInfo.h
@@ -19,7 +19,11 @@
 namespace llvm {
 
 class SYCLStripDeadDebugInfo : public PassInfoMixin<SYCLStripDeadDebugInfo> {
+  bool AggressiveMode = true;
+
 public:
+  SYCLStripDeadDebugInfo(bool AggrMode = true) : AggressiveMode(AggrMode) {}
+
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
 };
 

--- a/llvm/tools/sycl-post-link/SYCLStripDeadDebugInfo.h
+++ b/llvm/tools/sycl-post-link/SYCLStripDeadDebugInfo.h
@@ -1,0 +1,26 @@
+//===--- SYCLStripDeadDebugInfo.h - Strip debug info from split module ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass goes through split module's metadata nodes list to detect those
+// nodes that relate to dropped code and can be safely removed to reduce debug
+// information size.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "llvm/IR/PassManager.h"
+
+namespace llvm {
+
+class SYCLStripDeadDebugInfo : public PassInfoMixin<SYCLStripDeadDebugInfo> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
+};
+
+} // namespace llvm


### PR DESCRIPTION
StripDeadDebugInfo pass from IPO is not stripping debug info thoroughly.
Split modules may still contain a lot of useless debug info after this
pass. If input module has a lot of debug info then device code after
split may significantly grow due to many duplications.
If making strip rules more strict then device code after split may be
reduced by 2-10 times, but there is no 100% garantie that these changes
doesn't corrupt debug info in any case. So, changing StripDeadDebugInfo
pass directly may add regressions to non sycl-post-link components that
use this pass.
Add SYCLStripDeadDebugInfo pass based on StripDeadDebugInfo pass with
more strict rules. Using these rules is enabled by default. An option
'-safe-strip-debug-info' may be used to roll back to the stripping algorithm
realized in StripDeadDebugInfo pass.

Signed-off-by: Mikhail Lychkov <mikhail.lychkov@intel.com>