### PR TITLE
[SYCL] Fix host device local accessor alignment

### DIFF
--- a/sycl/include/CL/sycl/detail/accessor_impl.hpp
+++ b/sycl/include/CL/sycl/detail/accessor_impl.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <CL/sycl/access/access.hpp>
+#include <CL/sycl/detail/aligned_allocator.hpp>
 #include <CL/sycl/detail/export.hpp>
 #include <CL/sycl/detail/sycl_mem_obj_i.hpp>
 #include <CL/sycl/id.hpp>
@@ -177,7 +178,7 @@ public:
   sycl::range<3> MSize;
   int MDims;
   int MElemSize;
-  std::vector<char> MMem;
+  std::vector<char, aligned_allocator<char>> MMem;
 };
 
 using LocalAccessorImplPtr = std::shared_ptr<LocalAccessorImplHost>;

--- a/sycl/include/CL/sycl/detail/accessor_impl.hpp
+++ b/sycl/include/CL/sycl/detail/accessor_impl.hpp
@@ -170,9 +170,11 @@ private:
 
 class __SYCL_EXPORT LocalAccessorImplHost {
 public:
+  // Allocate ElemSize more data to have sufficient padding to enforce
+  // alignment.
   LocalAccessorImplHost(sycl::range<3> Size, int Dims, int ElemSize)
       : MSize(Size), MDims(Dims), MElemSize(ElemSize),
-        MMem(Size[0] * Size[1] * Size[2] * ElemSize) {}
+        MMem(Size[0] * Size[1] * Size[2] * ElemSize + ElemSize) {}
 
   sycl::range<3> MSize;
   int MDims;
@@ -185,10 +187,8 @@ using LocalAccessorImplPtr = std::shared_ptr<LocalAccessorImplHost>;
 class LocalAccessorBaseHost {
 public:
   LocalAccessorBaseHost(sycl::range<3> Size, int Dims, int ElemSize) {
-    // Allocate ElemSize more data to have sufficient padding to enforce
-    // alignment.
     impl = std::shared_ptr<LocalAccessorImplHost>(
-        new LocalAccessorImplHost(Size + ElemSize, Dims, ElemSize));
+        new LocalAccessorImplHost(Size, Dims, ElemSize));
   }
   sycl::range<3> &getSize() { return impl->MSize; }
   const sycl::range<3> &getSize() const { return impl->MSize; }


### PR DESCRIPTION
Local kernel arguments must be aligned to the type size, simply using `std::vector<char>` doesn't always provide the correct alignment. So this patch adds extra padding to the vector and ensures that the pointer returned for the accessor is actually aligned to the type size.

This issue was exposed by: https://github.com/intel/llvm-test-suite/pull/608, which was a follow up to fixing local accessor alignment for the CUDA plugin.
