### PR TITLE
[SYCL] kernel_not_supported errc from a failed kernel creation

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -594,11 +594,9 @@ ProgramManager::getOrCreateKernel(OSModuleHandle M,
   auto BuildF = [&Program, &KernelName, &ContextImpl] {
     PiKernelT *Result = nullptr;
 
-    // TODO need some user-friendly error/exception
-    // instead of currently obscure one
     const detail::plugin &Plugin = ContextImpl->getPlugin();
-    Plugin.call<PiApiKind::piKernelCreate>(Program, KernelName.c_str(),
-                                           &Result);
+    Plugin.call<errc::kernel_not_supported, PiApiKind::piKernelCreate>(
+        Program, KernelName.c_str(), &Result);
 
     // Some PI Plugins (like OpenCL) require this call to enable USM
     // For others, PI will turn this into a NOP.


### PR DESCRIPTION
kernel creation is supposed to throw errc::kernel_not_supported error code. This ensures that it does.

Signed-off-by: Chris Perkins <chris.perkins@intel.com>