### PR TITLE
[CI] Use concrete driver versions for unstable container

### DIFF
--- a/.github/workflows/sycl_containers.yaml
+++ b/.github/workflows/sycl_containers.yaml
@@ -107,6 +107,15 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
+      - name: Get dependencies configuration
+        id: deps
+        run: |
+          DEPS=`cat devops/dependencies.json`
+          DEPS="${DEPS//'%'/'%25'}"
+          DEPS="${DEPS//$'\n'/'%0A'}"
+          DEPS="${DEPS//$'\r'/'%0D'}"
+          echo $DEPS
+          echo "::set-output name=deps::$DEPS"
       - name: Build and Push Container
         uses: ./devops/actions/build_container
         with:
@@ -117,4 +126,10 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/ubuntu2004_intel_drivers:unstable-${{ github.sha }}
             ghcr.io/${{ github.repository }}/ubuntu2004_intel_drivers:unstable
+          build-args: |
+            compute_runtime_tag=${{fromJson(steps.deps.outputs.deps).linux_staging.compute_runtime.github_tag}}
+            igc_tag=${{fromJson(steps.deps.outputs.deps).linux_staging.igc.github_tag}}
+            tbb_tag=${{fromJson(steps.deps.outputs.deps).linux_staging.tbb.github_tag}}
+            fpgaemu_tag=${{fromJson(steps.deps.outputs.deps).linux_staging.fpgaemu.github_tag}}
+            cpu_tag=${{fromJson(steps.deps.outputs.deps).linux_staging.oclcpu.github_tag}}
 

--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -40,6 +40,47 @@
       "root": "{ARCHIVE_ROOT}/comp/oclfpga/linux"
     }
   },
+  "linux_staging": {
+    "compute_runtime": {
+      "github_tag": "22.05.22297",
+      "version": "22.05.22297",
+      "url": "https://github.com/intel/compute-runtime/releases/tag/22.05.22297",
+      "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
+    },
+    "igc": {
+      "github_tag": "igc-1.0.9933",
+      "version": "1.0.9933",
+      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/igc-1.0.9933",
+      "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
+    },
+    "cm": {
+      "github_tag": "cmclang-1.0.120",
+      "version": "1.0.120",
+      "url": "https://github.com/intel/cm-compiler/releases/tag/cmclang-1.0.120",
+      "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
+    },
+    "tbb": {
+      "github_tag": "v2021.5.0",
+      "version": "2021.5.0",
+      "url": "https://github.com/oneapi-src/oneTBB/releases/download/v2021.5.0/oneapi-tbb-2021.5.0-lin.tgz",
+      "root": "{DEPS_ROOT}/tbb/lin"
+    },
+    "oclcpu": {
+      "github_tag": "2021-WW50",
+      "version": "2021.13.11.0.23",
+      "url": "https://github.com/intel/llvm/releases/download/2021-WW50/oclcpuexp-2021.13.11.0.23_rel.tar.gz",
+      "root": "{DEPS_ROOT}/opencl/runtime/linux/oclcpu"
+    },
+    "fpgaemu": {
+      "github_tag": "2021-WW50",
+      "version": "2021.13.11.0.23",
+      "url": "https://github.com/intel/llvm/releases/download/2021-WW50/fpgaemu-2021.13.11.0.23_rel.tar.gz",
+      "root": "{DEPS_ROOT}/opencl/runtime/linux/oclfpgaemu"
+    },
+    "fpga": {
+      "root": "{ARCHIVE_ROOT}/comp/oclfpga/linux"
+    }
+  },
   "windows": {
     "compute_runtime": {
       "version": "101.1191",


### PR DESCRIPTION
There should be another PR to automate dependency uplift for Intel drivers.