### PR TITLE
Revert "[CI] Cancel outdated pre-commit jobs"

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -5,10 +5,6 @@ on:
     branches:
     - sycl
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Jobs didn't handle well cancelling in the middle of the process. Temporarily revert this optimization, until the issue is sorted out.