### PR TITLE
[sycl-post-link] Initialize the integer Value variable

### DIFF
--- a/llvm/tools/sycl-post-link/CompileTimePropertiesPass.h
+++ b/llvm/tools/sycl-post-link/CompileTimePropertiesPass.h
@@ -63,7 +63,7 @@ inline bool hasProperty(const Attribute &Attr) {
 template <typename Int> Int getAttributeAsInteger(const Attribute &Attr) {
   assert(Attr.isStringAttribute() &&
          "The attribute Attr must be a string attribute");
-  Int Value;
+  Int Value = 0;
   bool Error = Attr.getValueAsString().getAsInteger(10, Value);
   assert(!Error && "The attribute's value is not a number");
   (void)Error;


### PR DESCRIPTION
A static analysis tool emits a warning about uninitialized integer
variable 'Value' in the CompileTimePropertiesPass.h header. Actually,
the variable is used just to pass a reference to it as an output
parameter into the 'getAsInteger()' function and will be initialized
there, but if an error occurs, the variable will remain uninitialized.
Although there is a check for the error, let the variable be initialized
is the best strategy.