### PR TITLE
[SYCL] Make default device the one selected by default_selector

### DIFF
--- a/sycl/include/CL/sycl/device.hpp
+++ b/sycl/include/CL/sycl/device.hpp
@@ -28,6 +28,9 @@ class device_impl;
 auto getDeviceComparisonLambda();
 }
 
+// A tag to allow for creating a host device
+struct host_device {};
+
 /// The SYCL device class encapsulates a single SYCL device on which kernels
 /// may be executed.
 ///
@@ -35,6 +38,9 @@ auto getDeviceComparisonLambda();
 class __SYCL_EXPORT device {
 public:
   /// Constructs a SYCL device instance as a host device.
+  device(host_device);
+
+  /// Constructs a SYCL device instance as selected by default_selector
   device();
 
   /// Constructs a SYCL device instance from an OpenCL cl_device_id

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -240,7 +240,7 @@ platform_impl::get_devices(info::device_type DeviceType) const {
     // If SYCL_DEVICE_FILTER is set, check if filter contains host.
     device_filter_list *FilterList = SYCLConfig<SYCL_DEVICE_FILTER>::get();
     if (!FilterList || FilterList->containsHost()) {
-      Res.push_back(device());
+      Res.push_back(device(host_device{}));
     }
   }
 

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -372,7 +372,7 @@ void Scheduler::deallocateStreamBuffers(stream_impl *Impl) {
 }
 
 Scheduler::Scheduler() {
-  sycl::device HostDevice;
+  sycl::device HostDevice(sycl::host_device{});
   sycl::context HostContext{HostDevice};
   DefaultHostQueue = QueueImplPtr(
       new queue_impl(detail::getSyclObjImpl(HostDevice),

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -29,7 +29,11 @@ void force_type(info::device_type &t, const info::device_type &ft) {
 }
 } // namespace detail
 
-device::device() : impl(detail::device_impl::getHostDeviceImpl()) {}
+device::device() {
+  *this = default_selector{}.select_device();
+}
+
+device::device(host_device) : impl(detail::device_impl::getHostDeviceImpl()) {}
 
 device::device(cl_device_id DeviceId) {
   // The implementation constructor takes ownership of the native handle so we

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -29,9 +29,7 @@ void force_type(info::device_type &t, const info::device_type &ft) {
 }
 } // namespace detail
 
-device::device() {
-  *this = default_selector{}.select_device();
-}
+device::device() { *this = default_selector{}.select_device(); }
 
 device::device(host_device) : impl(detail::device_impl::getHostDeviceImpl()) {}
 


### PR DESCRIPTION
Host device still can be retrieved with help of special tag `host_device`:

    sycl::device D(sycl::host_device{});

