### PR TITLE
[SYCL] Silence "unknown attribute" warning for `device_indirectly_callable`

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1347,7 +1347,7 @@ def SYCLScope : Attr {
 def SYCLDeviceIndirectlyCallable : InheritableAttr {
   let Spellings = [ CXX11<"intel", "device_indirectly_callable"> ];
   let Subjects = SubjectList<[Function]>;
-  let LangOpts = [SYCLIsDevice];
+  let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let Documentation = [SYCLDeviceIndirectlyCallableDocs];
 }
 

--- a/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
+++ b/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
@@ -3,7 +3,7 @@
 // RUN: %clang_cc1 -verify -DNO_SYCL %s
 // RUN: %clang_cc1 -fsycl-is-host -fsyntax-only -verify -DSYCL_HOST %s
 
-#if !defined(NO_SYCL) || defined (SYCL_HOST)
+#if !defined(NO_SYCL) || defined(SYCL_HOST)
 
 [[intel::device_indirectly_callable]] // expected-warning {{'device_indirectly_callable' attribute only applies to functions}}
 int N;

--- a/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
+++ b/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
@@ -1,8 +1,9 @@
 // RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify %s
 // RUN: not %clang_cc1 -fsycl-is-device -ast-dump %s | FileCheck %s
 // RUN: %clang_cc1 -verify -DNO_SYCL %s
+// RUN: %clang_cc1 -fsycl-is-host -fsyntax-only -verify -DSYCL_HOST %s
 
-#ifndef NO_SYCL
+#if !defined(NO_SYCL) || defined (SYCL_HOST)
 
 [[intel::device_indirectly_callable]] // expected-warning {{'device_indirectly_callable' attribute only applies to functions}}
 int N;


### PR DESCRIPTION
The compiler used to emit "unknown attribute" warnings during host part
of full -fsycl compilation when it saw
`[[intel::device_indirectly_callable]]` attribute.