### PR TITLE
[SYCL] Fix buffer creation from rvalue iterator

### DIFF
--- a/sycl/include/CL/sycl/buffer.hpp
+++ b/sycl/include/CL/sycl/buffer.hpp
@@ -236,7 +236,7 @@ public:
         make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>(
             allocator));
     size_t r[3] = {Range[0], 0, 0};
-    impl->constructorNotification(CodeLoc, (void *)impl.get(), &*first,
+    impl->constructorNotification(CodeLoc, (void *)impl.get(), &first,
                                   (const void *)typeid(T).name(), dimensions,
                                   sizeof(T), r);
   }
@@ -253,7 +253,7 @@ public:
         propList,
         make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT>>());
     size_t r[3] = {Range[0], 0, 0};
-    impl->constructorNotification(CodeLoc, (void *)impl.get(), &*first,
+    impl->constructorNotification(CodeLoc, (void *)impl.get(), &first,
                                   (const void *)typeid(T).name(), dimensions,
                                   sizeof(T), r);
   }

--- a/sycl/test/regression/buffer_from_rvalue.cpp
+++ b/sycl/test/regression/buffer_from_rvalue.cpp
@@ -1,0 +1,12 @@
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -sycl-std=2020 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
+// expected-no-diagnostics
+
+#include <CL/sycl.hpp>
+
+int main() {
+  std::vector<int> v(1);
+  std::move_iterator it1(v.begin());
+  std::move_iterator it2(v.end());
+  cl::sycl::buffer b1(it1, it2);
+  return 0;
+}


### PR DESCRIPTION
Use pointer to iterator instead of pointer to underlining data as host
pointer in XPTI notification.