### PR TITLE
[SYCL][FPGA] Silence unknown attribut warnings on Host compilation

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1370,7 +1370,7 @@ def SYCLRequiresDecomposition : InheritableAttr {
 def SYCLIntelKernelArgsRestrict : InheritableAttr {
   let Spellings = [CXX11<"intel", "kernel_args_restrict">];
   let Subjects = SubjectList<[Function], ErrorDiag>;
-  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let Documentation = [SYCLIntelKernelArgsRestrictDocs];
   let SimpleHandler = 1;
   let SupportsNonconformingLambdaSyntax = 1;
@@ -1379,7 +1379,7 @@ def SYCLIntelKernelArgsRestrict : InheritableAttr {
 def SYCLIntelNumSimdWorkItems : InheritableAttr {
   let Spellings = [CXX11<"intel", "num_simd_work_items">];
   let Args = [ExprArgument<"Value">];
-  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [SYCLIntelNumSimdWorkItemsAttrDocs];
   let SupportsNonconformingLambdaSyntax = 1;
@@ -1387,7 +1387,7 @@ def SYCLIntelNumSimdWorkItems : InheritableAttr {
 
 def SYCLIntelUseStallEnableClusters : InheritableAttr {
   let Spellings = [CXX11<"intel","use_stall_enable_clusters">];
-  let LangOpts = [SYCLIsHost, SYCLIsDevice];
+  let LangOpts = [SilentlyIgnoreSYCLIsHost, SYCLIsDevice];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [SYCLIntelUseStallEnableClustersAttrDocs];
   let SupportsNonconformingLambdaSyntax = 1;
@@ -1396,7 +1396,7 @@ def SYCLIntelUseStallEnableClusters : InheritableAttr {
 def SYCLIntelSchedulerTargetFmaxMhz : InheritableAttr {
   let Spellings = [CXX11<"intel", "scheduler_target_fmax_mhz">];
   let Args = [ExprArgument<"Value">];
-  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [SYCLIntelSchedulerTargetFmaxMhzAttrDocs];
   let SupportsNonconformingLambdaSyntax = 1;
@@ -1407,7 +1407,7 @@ def SYCLIntelMaxWorkGroupSize : InheritableAttr {
   let Args = [ExprArgument<"XDim">,
               ExprArgument<"YDim">,
               ExprArgument<"ZDim">];
-  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let AdditionalMembers = [{
     Optional<llvm::APSInt> getXDimVal() const {
@@ -1433,7 +1433,7 @@ def SYCLIntelMaxWorkGroupSize : InheritableAttr {
 def SYCLIntelMaxGlobalWorkDim : InheritableAttr {
   let Spellings = [CXX11<"intel", "max_global_work_dim">];
   let Args = [ExprArgument<"Value">];
-  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let Documentation = [SYCLIntelMaxGlobalWorkDimAttrDocs];
   let SupportsNonconformingLambdaSyntax = 1;
@@ -2269,7 +2269,7 @@ def IntelFPGABankBits : Attr {
   let Args = [VariadicExprArgument<"Args">];
   let Subjects = SubjectList<[IntelFPGAConstVar, IntelFPGALocalStaticAgentMemVar,
                               Field], ErrorDiag>;
-  let LangOpts = [SYCLIsDevice, SYCLIsHost];
+  let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let Documentation = [IntelFPGABankBitsDocs];
 }
 def : MutualExclusions<[IntelFPGARegister, IntelFPGABankBits]>;

--- a/clang/test/SemaSYCL/spurious-host-warning.cpp
+++ b/clang/test/SemaSYCL/spurious-host-warning.cpp
@@ -1,6 +1,9 @@
 // RUN: %clang_cc1 -fsycl-is-host -triple x86_64-pc-linux-gnu -fsyntax-only -verify %s -DSYCLHOST
 // RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fsyntax-only -verify %s
 
+// Test checks the attribute is silently ignored during host compilation
+// where -fsycl-is-host is passed on cc1.
+
 #ifdef SYCLHOST
 // expected-no-diagnostics
 #endif
@@ -56,5 +59,39 @@ void foo()
 // expected-warning@+2 {{'simple_dual_port' attribute ignored}}
 #endif
   [[intel::simple_dual_port]] unsigned int v_ten[64];
-}
 
+#ifndef SYCLHOST
+// expected-warning@+2 {{'bank_bits' attribute ignored}}
+#endif
+  [[intel::bank_bits(2, 3, 4, 5)]] unsigned int v_eleven[64];
+
+#ifndef SYCLHOST
+// expected-warning@+2 {{'use_stall_enable_clusters' attribute ignored}}
+#endif
+  [[intel::use_stall_enable_clusters]] void func();
+
+#ifndef SYCLHOST
+// expected-warning@+2 {{'max_global_work_dim' attribute ignored}}
+#endif
+  [[intel::max_global_work_dim(1)]] void func1();
+
+#ifndef SYCLHOST
+// expected-warning@+2 {{'scheduler_target_fmax_mhz' attribute ignored}}
+#endif
+  [[intel::scheduler_target_fmax_mhz(3)]] void func3();
+
+#ifndef SYCLHOST
+// expected-warning@+2 {{'kernel_args_restrict' attribute ignored}}
+#endif
+  [[intel::kernel_args_restrict]] void func4();
+
+#ifndef SYCLHOST
+// expected-warning@+2 {{'num_simd_work_items' attribute ignored}}
+#endif
+  [[intel::num_simd_work_items(12)]] void func5();
+
+#ifndef SYCLHOST
+// expected-warning@+2 {{'max_work_group_size' attribute ignored}}
+#endif
+  [[intel::max_work_group_size(32, 32, 32)]] void func6();
+}

--- a/clang/test/SemaSYCL/spurious-host-warning.cpp
+++ b/clang/test/SemaSYCL/spurious-host-warning.cpp
@@ -78,20 +78,20 @@ void foo()
 #ifndef SYCLHOST
 // expected-warning@+2 {{'scheduler_target_fmax_mhz' attribute ignored}}
 #endif
-  [[intel::scheduler_target_fmax_mhz(3)]] void func3();
+  [[intel::scheduler_target_fmax_mhz(3)]] void func2();
 
 #ifndef SYCLHOST
 // expected-warning@+2 {{'kernel_args_restrict' attribute ignored}}
 #endif
-  [[intel::kernel_args_restrict]] void func4();
+  [[intel::kernel_args_restrict]] void func3();
 
 #ifndef SYCLHOST
 // expected-warning@+2 {{'num_simd_work_items' attribute ignored}}
 #endif
-  [[intel::num_simd_work_items(12)]] void func5();
+  [[intel::num_simd_work_items(12)]] void func4();
 
 #ifndef SYCLHOST
 // expected-warning@+2 {{'max_work_group_size' attribute ignored}}
 #endif
-  [[intel::max_work_group_size(32, 32, 32)]] void func6();
+  [[intel::max_work_group_size(32, 32, 32)]] void func5();
 }


### PR DESCRIPTION
The compiler emits "unknown attribute" warnings during host compilation
for attributes:
1. [[intel::num_simd_work_items()]]
2. [[intel::kernel_args_restrict()]]
3. [[intel::use_stall_enable_clusters]]
4. [[intel::scheduler_target_fmax_mhz()]]
5. [[intel::max_work_group_size()]]
6. [[intel::max_global_work_dim()]]
7. [[intel::bank_bits()]]

This patch marks the attributes in Attr.td with "SilentlyIgnoreSYCLIsHost",
so the diagnostic is not being issued on the host at all.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>