### PR TITLE
[SYCL] Revert workaround for issue #1594

### DIFF
--- a/clang/lib/Lex/PPDirectives.cpp
+++ b/clang/lib/Lex/PPDirectives.cpp
@@ -2202,9 +2202,7 @@ Preprocessor::ImportAction Preprocessor::HandleHeaderIncludeOrImport(
   // Issue a diagnostic if the name of the file on disk has a different case
   // than the one we're about to open.
   const bool CheckIncludePathPortability =
-//      !IsMapped && !File->getFileEntry().tryGetRealPathName().empty();
-// Disable file portability check to unblock pulldown
-      false;
+      !IsMapped && !File->getFileEntry().tryGetRealPathName().empty();
 
   if (CheckIncludePathPortability) {
     StringRef Name = LookupFilename;

--- a/clang/test/Lexer/case-insensitive-include-ms.c
+++ b/clang/test/Lexer/case-insensitive-include-ms.c
@@ -1,6 +1,4 @@
 // REQUIRES: case-insensitive-filesystem
-// Disable file portability check to unblock pulldown
-// XFAIL: system-windows
 
 // RUN: mkdir -p %t/Output/apath
 // RUN: cp %S/Inputs/case-insensitive-include.h %t/Output

--- a/clang/test/Lexer/case-insensitive-include-win.c
+++ b/clang/test/Lexer/case-insensitive-include-win.c
@@ -3,8 +3,6 @@
 // run.
 
 // REQUIRES: system-windows
-// Disable file portability check to unblock pulldown (intel/llvm/issues/1594)
-// XFAIL: system-windows
 // RUN: mkdir -p %t.dir
 // RUN: touch %t.dir/foo.h
 // RUN: not %clang_cl /FI\\?\%t.dir\FOO.h /WX -fsyntax-only %s 2>&1 | FileCheck %s

--- a/clang/test/Lexer/case-insensitive-include.c
+++ b/clang/test/Lexer/case-insensitive-include.c
@@ -1,6 +1,4 @@
 // REQUIRES: case-insensitive-filesystem
-// Disable file portability check to unblock pulldown
-// XFAIL: system-windows
 
 // RUN: mkdir -p %t/Output/apath
 // RUN: mkdir -p %t/Output/asystempath

--- a/clang/test/Lexer/case-insensitive-system-include.c
+++ b/clang/test/Lexer/case-insensitive-system-include.c
@@ -1,6 +1,4 @@
 // REQUIRES: case-insensitive-filesystem
-// Disable file portability check to unblock pulldown
-// XFAIL: system-windows
 
 // RUN: mkdir -p %t/asystempath
 // RUN: cp %S/Inputs/case-insensitive-include.h %t/asystempath/


### PR DESCRIPTION
Include file portability check was disabled to unblock pulldown: https://github.com/intel/llvm/pull/1564
This patch enables the check back and fixes corresponding LIT tests.