### PR TITLE
[SYCL] WA for RT hang when exit(1) unexpectedly called in backend & SYCL_PI_TRACE enabled

### DIFF
--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -145,7 +145,7 @@ void shutdown() {
     for (plugin &Plugin : GlobalHandler::instance().getPlugins()) {
       // shutdown() is called once and only when process is terminating.
       // Till the time it is called all threads using RT must be closed so it
-      // should be safe to work will plugin without multi thread protection.
+      // should be safe to work with plugin without multi thread protection.
       // Shutdown mode allows to skip some potentially unsafe code
       // (lock/unlock).
       Plugin.enableShutdownMode();

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -120,7 +120,7 @@ void GlobalHandler::registerDefaultContextReleaseHandler() {
   static DefaultContextReleaseHandler handler{};
 }
 
-void shutdown() {
+void shutdown(bool NormalExit) {
   // Ensure neither host task is working so that no default context is accessed
   // upon its release
   if (GlobalHandler::instance().MHostTaskThreadPool.Inst)
@@ -143,6 +143,10 @@ void shutdown() {
   // there's no need to load and unload plugins.
   if (GlobalHandler::instance().MPlugins.Inst) {
     for (plugin &Plugin : GlobalHandler::instance().getPlugins()) {
+      // shutdown() is called only when process is terminated by exitProcess()
+      // Emergency mode allows to skip some potentially unsafe code
+      if (!NormalExit)
+        Plugin.enableEmergencyMode();
       // PluginParameter is reserved for future use that can control
       // some parameters in the plugin tear-down process.
       // Currently, it is not used.
@@ -165,7 +169,7 @@ extern "C" __SYCL_EXPORT BOOL WINAPI DllMain(HINSTANCE hinstDLL,
   switch (fdwReason) {
   case DLL_PROCESS_DETACH:
     if (!lpReserved)
-      shutdown();
+      shutdown(true);
     break;
   case DLL_PROCESS_ATTACH:
   case DLL_THREAD_ATTACH:
@@ -175,11 +179,19 @@ extern "C" __SYCL_EXPORT BOOL WINAPI DllMain(HINSTANCE hinstDLL,
   return TRUE; // Successful DLL_PROCESS_ATTACH.
 }
 #else
+void TearDown(int ExitCode, void *) { shutdown(ExitCode == EXIT_SUCCESS); }
+
+__attribute__((constructor(110))) static void syclLoad() {
+  int Res = on_exit(TearDown, nullptr);
+  if (Res != 0) {
+    exit(EXIT_FAILURE);
+  };
+}
 // Setting low priority on destructor ensures it runs after all other global
 // destructors. Priorities 0-100 are reserved by the compiler. The priority
 // value 110 allows SYCL users to run their destructors after runtime library
 // deinitialization.
-__attribute__((destructor(110))) static void syclUnload() { shutdown(); }
+//__attribute__((destructor(110))) static void syclUnload() { shutdown(); }
 #endif
 } // namespace detail
 } // namespace sycl

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -74,7 +74,7 @@ public:
 
 private:
   friend void releaseDefaultContexts();
-  friend void shutdown(bool NormalExit);
+  friend void shutdown();
 
   // Constructor and destructor are declared out-of-line to allow incomplete
   // types as template arguments to unique_ptr.

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -74,7 +74,7 @@ public:
 
 private:
   friend void releaseDefaultContexts();
-  friend void shutdown();
+  friend void shutdown(bool NormalExit);
 
   // Constructor and destructor are declared out-of-line to allow incomplete
   // types as template arguments to unique_ptr.


### PR DESCRIPTION
WAs the case when underlying layer calls exit(1). The only intension of this commit is to eliminate RT hang in this case.