### PR TITLE
[SYCL][CUDA][DOC] State min. CUDA ver. for sm_75

### DIFF
--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -177,6 +177,9 @@ the system, refer to
 [NVIDIA CUDA Installation Guide for Linux](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html)
 or
 [NVIDIA CUDA Installation Guide for Windows](https://docs.nvidia.com/cuda/cuda-installation-guide-microsoft-windows/index.html)
+An installation of at least
+[CUDA 11.0](https://developer.nvidia.com/cuda-11.0-download-archive)
+is required for fully utilize Turing (SM 75) devices.
 
 Currently, the only combination tested is Ubuntu 18.04 with CUDA 10.2 using
 a Titan RTX GPU (SM 71). The CUDA backend should work on Windows or Linux 


### PR DESCRIPTION
This patch adds a note on the Get Started Guide regarding the minimum CUDA toolkit version required for fully utilize Turing devices (sm_75).

CUDA toolkit version 11.0 introduces PTX7.0. This version supports for the first time the Ampere architecture (sm_80), however some instructions introduced by PTX7.0 (e.g. approximated tanh (https://github.com/intel/llvm/pull/5265) and ex2 for halfs) can be executed also by Turing devices (sm_75), if CUDA 11.0 (or above) is installed.

Compilation on Turing devices is possible also using CUDA 10.2 (the actual version reported as tested), however if one these PTX7.0 instruction is used, it will generate an error.