### PR TITLE
[SYCL][libdevice] Allow iterator debug level mismatch

### DIFF
--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -29,6 +29,7 @@ set(compile_opts
 
 if (WIN32)
   list(APPEND compile_opts -D_ALLOW_RUNTIME_LIBRARY_MISMATCH)
+  list(APPEND compile_opts -D_ALLOW_ITERATOR_DEBUG_LEVEL_MISMATCH)
 endif()
 
 set(devicelib-obj-file ${obj_binary_dir}/libsycl-crt.${lib-suffix})


### PR DESCRIPTION
On Windows, users will encounter host link error saying
"ITERATOR DEBUG LEVEL MISMATCH" when building programs
with /MDd when libsycl-fallback-cassert.obj is involved.
In fact, the host obj extracted from libdevice is an
empty file and we can use "-D_ALLOW_ITERATOR_DEBUG_LEVEL"
to bypass this issue.

Signed-off-by: jinge90 <ge.jin@intel.com>