### PR TITLE
[SYCL][NFC] Fix warnings after compile-time properties implementation

### DIFF
--- a/sycl/include/sycl/ext/oneapi/properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/properties.hpp
@@ -96,7 +96,7 @@ struct ExtractProperties<std::tuple<PropertiesTs...>> {
 
   template <typename... PropertyValueTs>
   static ExtractedPropertiesT<PropertyValueTs...>
-  Extract(std::tuple<PropertyValueTs...> PropertyValues) {
+  Extract(std::tuple<PropertyValueTs...>) {
     return {};
   }
 };

--- a/sycl/include/sycl/ext/oneapi/properties/property_value.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_value.hpp
@@ -51,16 +51,16 @@ struct property_value
 template <typename PropertyT, typename... A, typename... B>
 constexpr std::enable_if_t<detail::IsCompileTimeProperty<PropertyT>::value,
                            bool>
-operator==(const property_value<PropertyT, A...> &LHS,
-           const property_value<PropertyT, B...> &RHS) {
+operator==(const property_value<PropertyT, A...> &,
+           const property_value<PropertyT, B...> &) {
   return (std::is_same<A, B>::value && ...);
 }
 
 template <typename PropertyT, typename... A, typename... B>
 constexpr std::enable_if_t<detail::IsCompileTimeProperty<PropertyT>::value,
                            bool>
-operator!=(const property_value<PropertyT, A...> &LHS,
-           const property_value<PropertyT, B...> &RHS) {
+operator!=(const property_value<PropertyT, A...> &,
+           const property_value<PropertyT, B...> &) {
   return (!std::is_same<A, B>::value || ...);
 }
 


### PR DESCRIPTION
Fixes warnings caused by https://github.com/intel/llvm/commit/87f60f6e7c3f07fc816fd1e0f667c98e881f4933