### PR TITLE
[WIP][NOT TESTED][SYCL] Enable post enqueue cleanup for empty command and enqueue dependent tasks after host task completion

### DIFF
--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -395,6 +395,18 @@ void event_impl::cleanupDependencyEvents() {
   MPreparedHostDepsEvents.clear();
 }
 
+void event_impl::attachEmptyCommand(void *Cmd) {
+  assert(MCommand && static_cast<Command *>(MCommand)->getType() ==
+                         Command::CommandType::HOST_TASK);
+  assert(Cmd && "NULL empty command is not acceptable");
+
+  Command *TypedCmd = static_cast<Command *>(Cmd);
+  assert(TypedCmd->getType() == Command::CommandType::EMPTY_TASK &&
+         "Command type is not acceptable");
+
+  MEmptyCmdEvent = TypedCmd->getEvent();
+}
+
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -822,13 +822,13 @@ const char *Command::getBlockReason() const {
   return "Unknown block reason";
 }
 
-void Command::addBlockedUser(const EventImplPtr &NewUser) {
+void EmptyCommand::addBlockedUser(const EventImplPtr &NewUser) {
   MBlockedUsers.insert(NewUser);
 }
-void Command::removeBlockedUser(const EventImplPtr &User) {
+void EmptyCommand::removeBlockedUser(const EventImplPtr &User) {
   MBlockedUsers.erase(User);
 }
-const std::unordered_set<EventImplPtr> &Command::getBlockedUsers() const {
+const std::unordered_set<EventImplPtr> &EmptyCommand::getBlockedUsers() const {
   return MBlockedUsers;
 }
 

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1730,7 +1730,11 @@ static std::string cgTypeToString(detail::CG::CGTYPE Type) {
 
 ExecCGCommand::ExecCGCommand(std::unique_ptr<detail::CG> CommandGroup,
                              QueueImplPtr Queue)
-    : Command(CommandType::RUN_CG, std::move(Queue)),
+    // TODO: add HOST_TASK to XPTI instrumentation.
+    : Command(MCommandGroup->getType() == detail::CG::CodeplayHostTask
+                  ? CommandType::HOST_TASK
+                  : CommandType::RUN_CG,
+              std::move(Queue)),
       MCommandGroup(std::move(CommandGroup)) {
   if (MCommandGroup->getType() == detail::CG::CodeplayHostTask) {
     MSubmittedQueue =

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1731,7 +1731,7 @@ static std::string cgTypeToString(detail::CG::CGTYPE Type) {
 ExecCGCommand::ExecCGCommand(std::unique_ptr<detail::CG> CommandGroup,
                              QueueImplPtr Queue)
     // TODO: add HOST_TASK to XPTI instrumentation.
-    : Command(MCommandGroup->getType() == detail::CG::CodeplayHostTask
+    : Command(CommandGroup->getType() == detail::CG::CodeplayHostTask
                   ? CommandType::HOST_TASK
                   : CommandType::RUN_CG,
               std::move(Queue)),

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -216,6 +216,7 @@ protected:
   /// See processDepEvent for details.
   std::vector<EventImplPtr> &MPreparedDepsEvents;
   std::vector<EventImplPtr> &MPreparedHostDepsEvents;
+  std::unordered_set<EventImplPtr> &MBlockingExplicitDeps;
 
   void waitForEvents(QueueImplPtr Queue, std::vector<EventImplPtr> &RawEvents,
                      RT::PiEvent &Event);
@@ -257,11 +258,6 @@ public:
   /// Contains list of commands that depend on the command.
   std::unordered_set<Command *> MUsers;
 
-  /// Contains list of commands that blocks this command from being enqueued
-  /// (not edges). Commands from set is moved to the top level command during
-  /// dependency building process and erased when blocking host task is
-  /// completed.
-  std::unordered_set<EventImplPtr> MBlockingExplicitDeps;
   /// Indicates whether the command can be blocked from enqueueing.
   bool MIsBlockable = false;
   /// Counts the number of memory objects this command is a leaf for.

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -256,7 +256,11 @@ public:
   std::vector<DepDesc> MDeps;
   /// Contains list of commands that depend on the command.
   std::unordered_set<Command *> MUsers;
-  /// Contains list of commands that blocks this command from being enqueued (not edges). Commands from set is moved to the top level command during dependency building process and erased when blocking host task is completed.
+
+  /// Contains list of commands that blocks this command from being enqueued
+  /// (not edges). Commands from set is moved to the top level command during
+  /// dependency building process and erased when blocking host task is
+  /// completed.
   std::unordered_set<EventImplPtr> MBlockingExplicitDeps;
   /// Indicates whether the command can be blocked from enqueueing.
   bool MIsBlockable = false;
@@ -335,9 +339,11 @@ public:
 
   bool producesPiEvent() const final;
   bool supportsPostEnqueueCleanup() const final;
-  void addBlockedUser(const EventImplPtr& NewUser) {MBlockedUsers.insert(NewUser);}
-  void removeBlockedUser(const EventImplPtr& User) {MBlockedUsers.erase(User);}
-  const std::unordered_set<EventImplPtr>& getBlockedUsers() const { return MBlockedUsers; }
+
+  void addBlockedUser(const EventImplPtr &NewUser);
+  void removeBlockedUser(const EventImplPtr &User);
+  const std::unordered_set<EventImplPtr> &getBlockedUsers() const;
+
 private:
   cl_int enqueueImp() final;
 

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -122,6 +122,7 @@ public:
                                 std::vector<Command *> &ToCleanUp);
 
   void addUser(Command *NewUser) { MUsers.insert(NewUser); }
+  void addExplicitUser(Command *NewUser) { MExplicitUsers.insert(NewUser); }
 
   /// \return type of the command, e.g. Allocate, MemoryCopy.
   CommandType getType() const { return MType; }
@@ -201,10 +202,10 @@ public:
   /// for memory copy commands.
   virtual const QueueImplPtr &getWorkerQueue() const;
 
-  /// Returns true iff the command produces a PI event on non-host devices.
+  /// Returns true if the command produces a PI event on non-host devices.
   virtual bool producesPiEvent() const;
 
-  /// Returns true iff this command can be freed by post enqueue cleanup.
+  /// Returns true if this command can be freed by post enqueue cleanup.
   virtual bool supportsPostEnqueueCleanup() const;
 
 protected:
@@ -256,6 +257,10 @@ public:
   std::vector<DepDesc> MDeps;
   /// Contains list of commands that depend on the command.
   std::unordered_set<Command *> MUsers;
+  /// Contains list of commands that depend on the host command explicitly (by
+  /// depends_on). Not involved into cleanup process since it is one-way link
+  /// and not holds resources.
+  std::unordered_set<Command *> MExplicitUsers;
   /// Indicates whether the command can be blocked from enqueueing.
   bool MIsBlockable = false;
   /// Counts the number of memory objects this command is a leaf for.
@@ -332,6 +337,7 @@ public:
   void emitInstrumentationData() override;
 
   bool producesPiEvent() const final;
+  bool supportsPostEnqueueCleanup() const final;
 
 private:
   cl_int enqueueImp() final;

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -1226,12 +1226,14 @@ void Scheduler::GraphBuilder::cleanupFinishedCommands(
     if (CmdT == Command::ALLOCA || CmdT == Command::ALLOCA_SUB_BUF)
       continue;
 
-    // We should enqueue empty cmd for cleanup only when related Cmd is planned
-    // to be deleted. Host task doesn't support post enqueue cleanup so here we
-    // definitely know that it will be marked as MToBeDeleted.
+    // We should enqueue empty cmd without deps for cleanup only when related
+    // Cmd is planned to be deleted. Host task doesn't support post enqueue
+    // cleanup so here we definitely know that it will be marked as
+    // MToBeDeleted.
     if (Cmd->getType() == Command::CommandType::RUN_CG) {
       auto ExecCmd = static_cast<ExecCGCommand *>(Cmd);
-      if (ExecCmd->getCG().getType() == CG::CGTYPE::CodeplayHostTask) {
+      if (ExecCmd->getCG().getType() == CG::CGTYPE::CodeplayHostTask &&
+          !ExecCmd->MEmptyCmd->MDeps.size()) {
         assert(ExecCmd->MEmptyCmd && "EmptyTask must be attached to HOST_TASK");
         assert(Cmd->MUsers.size() == 1 &&
                (*Cmd->MUsers.begin()) == ExecCmd->MEmptyCmd &&

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -1226,6 +1226,20 @@ void Scheduler::GraphBuilder::cleanupFinishedCommands(
     if (CmdT == Command::ALLOCA || CmdT == Command::ALLOCA_SUB_BUF)
       continue;
 
+    // We should enqueue empty cmd for cleanup only when related Cmd is planned
+    // to be deleted. Host task doesn't support post enqueue cleanup so here we
+    // definitely know that it will be marked as MToBeDeleted.
+    if (Cmd->getType() == Command::CommandType::RUN_CG) {
+      auto ExecCmd = static_cast<ExecCGCommand *>(Cmd);
+      if (ExecCmd->getCG().getType() == CG::CGTYPE::CodeplayHostTask) {
+        assert(ExecCmd->MEmptyCmd && "EmptyTask must be attached to HOST_TASK");
+        assert(Cmd->MUsers.size() == 1 &&
+               (*Cmd->MUsers.begin()) == ExecCmd->MEmptyCmd &&
+               "HostTask must have the only user which is EmptyTask");
+        MCmdsToVisit.push(ExecCmd->MEmptyCmd);
+      }
+    }
+
     for (Command *UserCmd : Cmd->MUsers) {
       for (DepDesc &Dep : UserCmd->MDeps) {
         // Link the users of the command to the alloca command(s) instead

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -1226,22 +1226,6 @@ void Scheduler::GraphBuilder::cleanupFinishedCommands(
     if (CmdT == Command::ALLOCA || CmdT == Command::ALLOCA_SUB_BUF)
       continue;
 
-    // We should enqueue empty cmd without deps for cleanup only when related
-    // Cmd is planned to be deleted. Host task doesn't support post enqueue
-    // cleanup so here we definitely know that it will be marked as
-    // MToBeDeleted.
-    if (Cmd->getType() == Command::CommandType::RUN_CG) {
-      auto ExecCmd = static_cast<ExecCGCommand *>(Cmd);
-      if (ExecCmd->getCG().getType() == CG::CGTYPE::CodeplayHostTask &&
-          !ExecCmd->MEmptyCmd->MDeps.size()) {
-        assert(ExecCmd->MEmptyCmd && "EmptyTask must be attached to HOST_TASK");
-        assert(Cmd->MUsers.size() == 1 &&
-               (*Cmd->MUsers.begin()) == ExecCmd->MEmptyCmd &&
-               "HostTask must have the only user which is EmptyTask");
-        MCmdsToVisit.push(ExecCmd->MEmptyCmd);
-      }
-    }
-
     for (Command *UserCmd : Cmd->MUsers) {
       for (DepDesc &Dep : UserCmd->MDeps) {
         // Link the users of the command to the alloca command(s) instead

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -1014,10 +1014,14 @@ Scheduler::GraphBuilder::addCG(std::unique_ptr<detail::CG> CommandGroup,
       ToEnqueue.push_back(ConnCmd);
   }
 
-  if (CGType == CG::CGTYPE::CodeplayHostTask)
+  if (CGType == CG::CGTYPE::CodeplayHostTask) {
     NewCmd->MEmptyCmd =
         addEmptyCmd(NewCmd.get(), NewCmd->getCG().MRequirements, Queue,
                     Command::BlockReason::HostTask, ToEnqueue);
+    // Keeping empty command in host task event is essential when host task may
+    // be deleted during post-enqueue cleanup
+    NewCmd->getEvent()->attachEmptyCommand(NewCmd->MEmptyCmd);
+  }
 
   if (MPrintOptionsArray[AfterAddCG])
     printGraphAsDot("after_addCG");

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -357,6 +357,17 @@ void Scheduler::enqueueLeavesOfReqUnlocked(const Requirement *const Req,
   EnqueueLeaves(Record->MWriteLeaves);
 }
 
+void Scheduler::enqueueUnlockedCommands(
+    const std::unordered_set<Command *> &CmdsToEnqueue,
+    std::vector<Command *> &ToCleanUp) {
+  for (auto &Cmd : CmdsToEnqueue) {
+    EnqueueResultT Res;
+    bool Enqueued = GraphProcessor::enqueueCommand(Cmd, Res, ToCleanUp);
+    if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
+      throw runtime_error("Enqueue process failed.", PI_INVALID_OPERATION);
+  }
+}
+
 void Scheduler::allocateStreamBuffers(stream_impl *Impl,
                                       size_t StreamBufferSize,
                                       size_t FlushBufferSize) {

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -120,10 +120,11 @@ EventImplPtr Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup,
 
     if (Type != CG::CodeplayHostTask)
       EventToReturn = NewEvent;
-    else
-    {
-      ExecCGCommand* ExecCmd = static_cast<ExecCGCommand*>(NewCmd);
-      assert(ExecCmd->MEmptyCmd && "Host command nust have Empty command attached");
+
+    else {
+      ExecCGCommand *ExecCmd = static_cast<ExecCGCommand *>(NewCmd);
+      assert(ExecCmd->MEmptyCmd &&
+             "Host command nust have Empty command attached");
       EventToReturn = ExecCmd->MEmptyCmd->getEvent();
     }
 
@@ -368,12 +369,15 @@ void Scheduler::enqueueLeavesOfReqUnlocked(const Requirement *const Req,
   EnqueueLeaves(Record->MWriteLeaves);
 }
 
-void Scheduler::enqueueUnlockedCommands(const EventImplPtr& UnblockedDep,
+void Scheduler::enqueueUnlockedCommands(
+    const EventImplPtr &UnblockedDep,
     const std::unordered_set<EventImplPtr> &ToEnqueue,
     std::vector<Command *> &ToCleanUp) {
   for (auto &CmdEvent : ToEnqueue) {
-    Command* Cmd = static_cast<Command*>(CmdEvent->getCommand());
-    assert(Cmd && "Event with blocked command must always has not NULL command");
+    Command *Cmd = static_cast<Command *>(CmdEvent->getCommand());
+    assert(Cmd &&
+           "Event with blocked command must always has not NULL command");
+
     EnqueueResultT Res;
     bool Enqueued = GraphProcessor::enqueueCommand(Cmd, Res, ToCleanUp);
     if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -369,7 +369,7 @@ void Scheduler::enqueueLeavesOfReqUnlocked(const Requirement *const Req,
   EnqueueLeaves(Record->MWriteLeaves);
 }
 
-void Scheduler::enqueueUnlockedCommands(
+void Scheduler::enqueueUnblockedCommands(
     const EventImplPtr &UnblockedDep,
     const std::unordered_set<EventImplPtr> &ToEnqueue,
     std::vector<Command *> &ToCleanUp) {

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -464,7 +464,7 @@ protected:
   static void enqueueLeavesOfReqUnlocked(const Requirement *const Req,
                                          std::vector<Command *> &ToCleanUp);
   static void
-  enqueueUnlockedCommands(const std::unordered_set<Command *> &CmdsToEnqueue,
+  enqueueUnlockedCommands(const EventImplPtr& UnblockedDep, const std::unordered_set<EventImplPtr> &CmdsToEnqueue,
                           std::vector<Command *> &ToCleanUp);
 
   /// Graph builder class.

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -464,7 +464,9 @@ protected:
   static void enqueueLeavesOfReqUnlocked(const Requirement *const Req,
                                          std::vector<Command *> &ToCleanUp);
   static void
-  enqueueUnlockedCommands(const EventImplPtr& UnblockedDep, const std::unordered_set<EventImplPtr> &CmdsToEnqueue,
+
+  enqueueUnlockedCommands(const EventImplPtr &UnblockedDep,
+                          const std::unordered_set<EventImplPtr> &CmdsToEnqueue,
                           std::vector<Command *> &ToCleanUp);
 
   /// Graph builder class.

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -463,6 +463,9 @@ protected:
 
   static void enqueueLeavesOfReqUnlocked(const Requirement *const Req,
                                          std::vector<Command *> &ToCleanUp);
+  static void
+  enqueueUnlockedCommands(const std::unordered_set<Command *> &CmdsToEnqueue,
+                          std::vector<Command *> &ToCleanUp);
 
   /// Graph builder class.
   ///

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -463,11 +463,10 @@ protected:
 
   static void enqueueLeavesOfReqUnlocked(const Requirement *const Req,
                                          std::vector<Command *> &ToCleanUp);
-  static void
-
-  enqueueUnlockedCommands(const EventImplPtr &UnblockedDep,
-                          const std::unordered_set<EventImplPtr> &CmdsToEnqueue,
-                          std::vector<Command *> &ToCleanUp);
+  static void enqueueUnblockedCommands(
+      const EventImplPtr &UnblockedDep,
+      const std::unordered_set<EventImplPtr> &CmdsToEnqueue,
+      std::vector<Command *> &ToCleanUp);
 
   /// Graph builder class.
   ///

--- a/sycl/unittests/scheduler/StreamInitDependencyOnHost.cpp
+++ b/sycl/unittests/scheduler/StreamInitDependencyOnHost.cpp
@@ -149,7 +149,7 @@ TEST_F(SchedulerTest, StreamInitDependencyOnHost) {
   // [MAIN_CG] -> [EMPTY_NODE {FlushBufMemObj}] -> [FILL_CG {FlushBufMemObj}] ->
   //     [[ALLOC_TASK {FlushBufMemObj}]
   std::vector<CmdTypeTy> DepCmdsTypes({CmdTypeTy::EMPTY_TASK,
-                                       CmdTypeTy::RUN_CG, // FILL_CG
+                                       CmdTypeTy::HOST_TASK, // FILL_CG
                                        CmdTypeTy::ALLOCA});
   ASSERT_TRUE(ValidateDepCommandsTree(NewCmd, DepCmdsTypes, FlushBufMemObjPtr))
       << "Dependency on stream flush buffer initialization not found";


### PR DESCRIPTION
Previously empty command was scheduled to cleanup as dependency for other tasks. Although if we have host_task without any task that is dependent on it - empty cmd deletion will not happen, corresponding resources are not released. This commit is fixing that case and schedule empty command deletion earlier.

Testing: E2E test for memory leaks with llvm-test-suite/SYCL/Basic/event.cpp
Signed-off-by: Tikhomirova, Kseniya <kseniya.tikhomirova@intel.com>