### PR TITLE
[SYCL][DOC] Change device_global property definitions

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_global.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_global.asciidoc
@@ -172,7 +172,7 @@ A `device_global` on a given device maintains its state (address of the allocati
 [source,c++]
 ----
 namespace sycl::ext::oneapi {
-template <typename T, typename PropertyListT = property_list<>>
+template <typename T, typename PropertyListT = properties<>>
 class device_global {
   ...
 ----
@@ -203,7 +203,7 @@ The section below and the table following describe the constructors, member func
 ----
 namespace sycl::ext::oneapi {
 
-template <typename T, typename PropertyListT = property_list<>>
+template <typename T, typename PropertyListT = properties<>>
 class device_global {
   using subscript_return_t =
     std::remove_reference_t<decltype(std::declval<T>()[std::ptrdiff_t{}])>;
@@ -378,7 +378,7 @@ template<typename propertyT>
 static constexpr bool has_property();
 ----
 | Returns true if the `PropertyListT` contains the property specified by `propertyT`. Returns false if it does not.
-Available only if `sycl::is_property_of_v<propertyT, sycl::ext::oneapi::device_global>` is true.
+Available only if `sycl::is_property_key_of_v<propertyT, sycl::ext::oneapi::device_global>` is true.
 
 // --- ROW BREAK ---
 a|
@@ -389,7 +389,7 @@ static constexpr auto get_property();
 ----
 | Returns an object of the class used to represent the value of property `propertyT`.
 Must produce a compiler diagnostic if `PropertyListT` does not contain a `propertyT` property.
-Available only if `sycl::is_property_of_v<propertyT, sycl::ext::oneapi::device_global>` is true.
+Available only if `sycl::is_property_key_of_v<propertyT, sycl::ext::oneapi::device_global>` is true.
 
 |===
 
@@ -491,8 +491,8 @@ parameter as shown in this example:
 ----
 using namespace sycl::ext::oneapi;
 
-device_global<MyClass, property_list_t<device_image_scope::value_t>> dm1;
-device_global<int[4], property_list_t<host_access::value_t<host_access::access::read>> dm2;
+device_global<MyClass, decltype(properties(device_image_scope))> dm1;
+device_global<int[4], decltype(properties(host_access_read))> dm2;
 ----
 
 The following code synopsis shows the set of supported properties, and the
@@ -502,45 +502,83 @@ following table describes their effect.
 ----
 namespace sycl::ext::oneapi {
 
-struct device_image_scope {
-  using value_t = property_value<device_image_scope>;
+struct device_image_scope_key {
+  using value_t = property_value<device_image_scope_key>;
 };
 
-struct host_access {
-  enum class access: /*unspecified*/ {
-    read,
-    write,
-    read_write,
-    none
-  };
-  template<access A>
-  using value_t = property_value<host_access, std::integral_constant<access, A>>;
-
-struct init_mode {
-  enum class trigger: /*unspecified*/ {
-    reprogram,
-    reset
-  };
-  template<trigger T>
-  using value_t = property_value<init_mode, std::integral_constant<trigger, T>>;
+enum class host_access_enum : /* unspecified */ {
+  read,
+  write,
+  read_write,
+  none
 };
 
-struct implement_in_csr {
+struct host_access_key {
+  template <host_access_enum Access>
+  using value_t =
+      property_value<host_access_key,
+                     std::integral_constant<host_access_enum, Access>>;
+};
+
+enum class init_mode_enum : /* unspecified */ { 
+  reprogram,
+  reset
+};
+
+struct init_mode_key {
+  template <init_mode_enum Trigger>
+  using value_t =
+      property_value<init_mode_key,
+                     std::integral_constant<init_mode_enum, Trigger>>;
+};
+
+struct implement_in_csr_key {
   template <bool Enable>
-  using value_t = property_value<implement_in_csr, std::bool_constant<Enable>>;
+  using value_t =
+      property_value<implement_in_csr_key, std::bool_constant<Enable>>;
 };
 
+inline constexpr device_image_scope_key::value_t device_image_scope;
 
-inline constexpr device_image_scope::value_t device_image_scope_v;
+template <host_access_enum Access>
+inline constexpr host_access_key::value_t<Access> host_access;
+inline constexpr host_access_key::value_t<host_access_enum::read>
+    host_access_read;
+inline constexpr host_access_key::value_t<host_access_enum::write>
+    host_access_write;
+inline constexpr host_access_key::value_t<host_access_enum::read_write>
+    host_access_read_write;
+inline constexpr host_access_key::value_t<host_access_enum::none>
+    host_access_none;
 
-template<host_access::access A>
-inline constexpr host_access::value_t<A> host_access_v;
+template <init_mode_enum Trigger>
+inline constexpr init_mode_key::value_t<Trigger> init_mode;
+inline constexpr init_mode_key::value_t<init_mode_enum::reprogram>
+    init_mode_reprogram;
+inline constexpr init_mode_key::value_t<init_mode_enum::reset> init_mode_reset;
 
-template<init_mode::trigger T>
-inline constexpr init_mode::value_t<T> init_mode_v;
+template <bool Enable>
+inline constexpr implement_in_csr_key::value_t<Enable> implement_in_csr;
+inline constexpr implement_in_csr_key::value_t<true> implement_in_csr_on;
+inline constexpr implement_in_csr_key::value_t<false> implement_in_csr_off;
 
-template<bool Enable>
-inline constexpr implement_in_csr::value_t<Enable> implement_in_csr_v;
+template <> struct is_property_key<device_image_scope_key> : std::true_type {};
+template <> struct is_property_key<host_access_key> : std::true_type {};
+template <> struct is_property_key<init_mode_key> : std::true_type {};
+template <> struct is_property_key<implement_in_csr_key> : std::true_type {};
+
+template <typename T, typename PropertyListT>
+struct is_property_key_of<device_image_scope_key, device_global<T, PropertyListT>>
+  : std::true_type {};
+template <typename T, typename PropertyListT>
+struct is_property_key_of<host_access_key, device_global<T, PropertyListT>>
+  : std::true_type {};
+template <typename T, typename PropertyListT>
+struct is_property_key_of<init_mode_key, device_global<T, PropertyListT>>
+  : std::true_type {};
+template <typename T, typename PropertyListT>
+struct is_property_key_of<implement_in_csr_key, device_global<T, PropertyListT>>
+  : std::true_type {};
 
 } // namespace sycl::ext::oneapi
 ----
@@ -1078,7 +1116,7 @@ A sketch of the anticipated constructor interface is:
 ----
 namespace sycl::ext::oneapi {
 
-template <typename T, typename PropertyListT = property_list<>>
+template <typename T, typename PropertyListT = properties<>>
 class device_global {
 public:
   using element_type = std::remove_extent_t<T>; 


### PR DESCRIPTION
With the recent change to the compile-time property extension, properties must follow a different structure and naming to the one used by the `device_global` extension. This commit makes the `device_global` extension adhere to the new requirements and adds additional non-template variants of templated properties, e.g. `host_access_read` as a shorthand for `host_access<host_access_enum::read>`.