### PR TITLE
[SYCL] Adds properties for device_global

### DIFF
--- a/sycl/include/sycl/ext/oneapi/device_global/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/device_global/properties.hpp
@@ -1,0 +1,101 @@
+//==----- properties.hpp - SYCL properties associated with device_global ---==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <sycl/ext/oneapi/properties/property.hpp>
+
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace ext {
+namespace oneapi {
+namespace experimental {
+
+struct device_image_scope_key {
+  using value_t = property_value<device_image_scope_key>;
+};
+
+
+enum class host_access_enum : std::uint16_t { read, write, read_write, none };
+
+struct host_access_key {
+  template <host_access_enum Access>
+  using value_t =
+      property_value<host_access_key,
+                     std::integral_constant<host_access_enum, Access>>;
+};
+
+enum class init_mode_enum : std::uint16_t { reprogram, reset };
+
+struct init_mode_key {
+  template <init_mode_enum Trigger>
+  using value_t =
+      property_value<init_mode_key,
+                     std::integral_constant<init_mode_enum, Trigger>>;
+};
+
+struct implement_in_csr_key {
+  template <bool Enable>
+  using value_t =
+      property_value<implement_in_csr_key, std::bool_constant<Enable>>;
+};
+
+inline constexpr device_image_scope_key::value_t device_image_scope;
+
+template <host_access_enum Access>
+inline constexpr host_access_key::value_t<Access> host_access;
+inline constexpr host_access_key::value_t<host_access_enum::read>
+    host_access_read;
+inline constexpr host_access_key::value_t<host_access_enum::write>
+    host_access_write;
+inline constexpr host_access_key::value_t<host_access_enum::read_write>
+    host_access_read_write;
+inline constexpr host_access_key::value_t<host_access_enum::none>
+    host_access_none;
+
+template <init_mode_enum Trigger>
+inline constexpr init_mode_key::value_t<Trigger> init_mode;
+inline constexpr init_mode_key::value_t<init_mode_enum::reprogram>
+    init_mode_reprogram;
+inline constexpr init_mode_key::value_t<init_mode_enum::reset> init_mode_reset;
+
+template <bool Enable>
+inline constexpr implement_in_csr_key::value_t<Enable> implement_in_csr;
+inline constexpr implement_in_csr_key::value_t<true> implement_in_csr_on;
+inline constexpr implement_in_csr_key::value_t<false> implement_in_csr_off;
+
+template <> struct is_property_key<device_image_scope_key> : std::true_type {};
+template <> struct is_property_key<host_access_key> : std::true_type {};
+template <> struct is_property_key<init_mode_key> : std::true_type {};
+template <> struct is_property_key<implement_in_csr_key> : std::true_type {};
+
+namespace detail {
+template <> struct PropertyToKind<device_image_scope_key> {
+  static constexpr PropKind Kind = PropKind::DeviceImageScope;
+};
+template <> struct PropertyToKind<host_access_key> {
+  static constexpr PropKind Kind = PropKind::HostAccess;
+};
+template <> struct PropertyToKind<init_mode_key> {
+  static constexpr PropKind Kind = PropKind::InitMode;
+};
+template <> struct PropertyToKind<implement_in_csr_key> {
+  static constexpr PropKind Kind = PropKind::ImplementInCSR;
+};
+
+template <>
+struct IsCompileTimeProperty<device_image_scope_key> : std::true_type {};
+template <> struct IsCompileTimeProperty<host_access_key> : std::true_type {};
+template <> struct IsCompileTimeProperty<init_mode_key> : std::true_type {};
+template <>
+struct IsCompileTimeProperty<implement_in_csr_key> : std::true_type {};
+
+} // namespace detail
+} // namespace experimental
+} // namespace oneapi
+} // namespace ext
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/sycl/ext/oneapi/device_global/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/device_global/properties.hpp
@@ -18,7 +18,6 @@ struct device_image_scope_key {
   using value_t = property_value<device_image_scope_key>;
 };
 
-
 enum class host_access_enum : std::uint16_t { read, write, read_write, none };
 
 struct host_access_key {

--- a/sycl/include/sycl/ext/oneapi/properties/property.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property.hpp
@@ -144,7 +144,11 @@ namespace detail {
 
 // List of all properties.
 enum PropKind : uint32_t {
-  PropKindSize = 0,
+  DeviceImageScope = 0,
+  HostAccess = 1,
+  InitMode = 2,
+  ImplementInCSR = 3,
+  PropKindSize = 4,
 };
 
 // This trait must be specialized for all properties and must have a unique

--- a/sycl/test/extensions/properties/properties_device_global.cpp
+++ b/sycl/test/extensions/properties/properties_device_global.cpp
@@ -1,0 +1,69 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning %s
+// expected-no-diagnostics
+
+#include <CL/sycl.hpp>
+
+#include <sycl/ext/oneapi/device_global/properties.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+
+constexpr host_access_enum TestAccess = host_access_enum::read_write;
+constexpr init_mode_enum TestTrigger = init_mode_enum::reset;
+
+int main() {
+  // Check that is_property_key is correctly specialized.
+  static_assert(is_property_key<device_image_scope_key>::value);
+  static_assert(is_property_key<host_access_key>::value);
+  static_assert(is_property_key<init_mode_key>::value);
+  static_assert(is_property_key<implement_in_csr_key>::value);
+
+  // Check that is_property_value is correctly specialized.
+  static_assert(is_property_value<decltype(device_image_scope)>::value);
+  static_assert(is_property_value<decltype(host_access<TestAccess>)>::value);
+  static_assert(is_property_value<decltype(host_access_read)>::value);
+  static_assert(is_property_value<decltype(host_access_write)>::value);
+  static_assert(is_property_value<decltype(host_access_read_write)>::value);
+  static_assert(is_property_value<decltype(host_access_none)>::value);
+  static_assert(is_property_value<decltype(init_mode<TestTrigger>)>::value);
+  static_assert(is_property_value<decltype(init_mode_reprogram)>::value);
+  static_assert(is_property_value<decltype(init_mode_reset)>::value);
+  static_assert(is_property_value<decltype(implement_in_csr<true>)>::value);
+  static_assert(is_property_value<decltype(implement_in_csr_on)>::value);
+  static_assert(is_property_value<decltype(implement_in_csr_off)>::value);
+
+  // Checks that fully specialized properties are the same as the templated
+  // variants.
+  static_assert(std::is_same_v<decltype(host_access_read),
+                               decltype(host_access<host_access_enum::read>)>);
+  static_assert(std::is_same_v<decltype(host_access_write),
+                               decltype(host_access<host_access_enum::write>)>);
+  static_assert(
+      std::is_same_v<decltype(host_access_read_write),
+                     decltype(host_access<host_access_enum::read_write>)>);
+  static_assert(std::is_same_v<decltype(host_access_none),
+                               decltype(host_access<host_access_enum::none>)>);
+  static_assert(std::is_same_v<decltype(init_mode_reprogram),
+                               decltype(init_mode<init_mode_enum::reprogram>)>);
+  static_assert(std::is_same_v<decltype(init_mode_reset),
+                               decltype(init_mode<init_mode_enum::reset>)>);
+  static_assert(std::is_same_v<decltype(implement_in_csr_on),
+                               decltype(implement_in_csr<true>)>);
+  static_assert(std::is_same_v<decltype(implement_in_csr_off),
+                               decltype(implement_in_csr<false>)>);
+
+  // Check that property lists will accept the new properties.
+  using P =
+      decltype(properties(device_image_scope, host_access<TestAccess>,
+                          init_mode<TestTrigger>, implement_in_csr<true>));
+  static_assert(is_property_list_v<P>);
+  static_assert(P::has_property<device_image_scope_key>());
+  static_assert(P::has_property<host_access_key>());
+  static_assert(P::has_property<init_mode_key>());
+  static_assert(P::has_property<implement_in_csr_key>());
+  static_assert(P::get_property<device_image_scope_key>() ==
+                device_image_scope);
+  static_assert(P::get_property<host_access_key>() == host_access<TestAccess>);
+  static_assert(P::get_property<init_mode_key>() == init_mode<TestTrigger>);
+  static_assert(P::get_property<implement_in_csr_key>() ==
+                implement_in_csr<true>);
+}


### PR DESCRIPTION
These changes add the properties associated with device_global extension, specifically `device_image_scope`, `host_access`, `init_mode`, and `implement_in_csr`.

Note: These properties are based on https://github.com/intel/llvm/pull/5691.