### PR TITLE
[Community][Object] Skip section offset checking for /<XFGHASHMAP>/

### DIFF
--- a/llvm/lib/Object/Archive.cpp
+++ b/llvm/lib/Object/Archive.cpp
@@ -256,6 +256,10 @@ Expected<StringRef> ArchiveMemberHeader::getName(uint64_t Size) const {
       return Name;
     if (Name.size() == 2 && Name[1] == '/') // String table.
       return Name;
+    // System libraries from the Windows SDK for Windows 11 contain this symbol.
+    // It looks like a CFG guard: we just skip it for now.
+    if (Name.equals("/<XFGHASHMAP>/"))
+      return Name;
     // It's a long name.
     // Get the string table offset.
     std::size_t StringOffset;

--- a/llvm/test/tools/llvm-lib/xfghashmap-list.test
+++ b/llvm/test/tools/llvm-lib/xfghashmap-list.test
@@ -1,0 +1,33 @@
+# RUN: rm -rf %t && mkdir -p %t && cd %t
+# RUN: llvm-mc -triple=x86_64-pc-windows-msvc -filetype=obj -o a.obj %S/Inputs/a.s
+# RUN: llvm-mc -triple=x86_64-pc-windows-msvc -filetype=obj -o b.obj %S/Inputs/b.s
+# RUN: llvm-lib /out:xfghashmap.lib a.obj b.obj
+
+## Replace a section in the library file with /<XFGHASHMAP>/ emulating
+## a library from the Windows SDK for Windows 11.
+# RUN: %python %s xfghashmap.lib b.obj/
+
+## This should print the /<XFGHASHMAP>/ section as well as an .obj one.
+# RUN: llvm-lib /list %t/xfghashmap.lib | FileCheck %s
+
+# CHECK: a.obj
+# CHECK: /<XFGHASHMAP>/
+# CHECK-NOT: b.obj
+
+import sys
+
+if len(sys.argv) < 3:
+  print("Use: python3 xfghashmap-list.test <LIBRARY_FILE> <TEMPLATE>")
+  exit(1)
+
+template = bytes(sys.argv[2], 'utf-8')
+xfghashmap = b'/<XFGHASHMAP>/'
+
+data = None
+with open(sys.argv[1], "rb") as inp:
+  data = inp.read()
+with open(sys.argv[1], "wb") as outp:
+  pos = data.find(template)
+  outp.write(data[:pos])
+  outp.write(xfghashmap)
+  outp.write(data[pos + len(xfghashmap):])


### PR DESCRIPTION
Starting from Windows SDK for Windows 11 (10.0.22000.x), all the system
libraries (.lib files) contain a section with the '/<XFGHASHMAP>/' name.
This looks like the libraries are built with control flow guard enabled:
https://docs.microsoft.com/en-us/cpp/build/reference/guard-enable-control-flow-guard?view=msvc-170

To let the LLVM tools (llvm-ar, llvm-lib) work with these libraries,
this patch just skips the section offset check for sections with the
'/<XFGHASHMAP>/' name.

Closes: llvm/llvm-project#53814

Signed-off-by: Pavel Samolysov <pavel.samolysov@intel.com>