### PR TITLE
Update SPV_INTEL_global_variable_decorations.asciidoc

### DIFF
--- a/sycl/doc/design/spirv-extensions/SPV_INTEL_global_variable_decorations.asciidoc
+++ b/sycl/doc/design/spirv-extensions/SPV_INTEL_global_variable_decorations.asciidoc
@@ -109,7 +109,8 @@ Modify Section 3.20, Decoration, adding these rows to the Decoration table:
 | 6147
 a|
 *HostAccessINTEL* +
-Only valid on global (module scope) *OpVariable*.
+Only valid on global (module scope) *OpVariable* or *OpConstantPipeStorage*
+or *OpConstantPipeStorageINTEL*.
 
 The client API's execution environment may provide a way to access a global
 variable's value from the host system.  If it does, this decoration provides


### PR DESCRIPTION
[SYCL] Update global variable decorations spec to allow HostAccessINTEL decorations on OpConstantPipeStorage and OpConstantPipeStorageINTEL.