### PR TITLE
[CI] Temporarily disable OCL FPGA Emulator

### DIFF
--- a/devops/actions/llvm_test_suite/action.yml
+++ b/devops/actions/llvm_test_suite/action.yml
@@ -83,7 +83,11 @@ runs:
       if [ -e /runtimes/oneapi-tbb/env/vars.sh ]; then
         source /runtimes/oneapi-tbb/env/vars.sh;
       fi
-      export OCL_ICD_FILENAMES="/usr/lib/x86_64-linux-gnu/intel-opencl/libigdrcl.so:/runtimes/oclcpu/x64/libintelocl.so"
+      # TODO remove workaround of FPGA emu bug
+      mkdir icd
+      echo /usr/lib/x86_64-linux-gnu/intel-opencl/libigdrcl.so > icd/gpu.icd
+      echo /runtimes/oclcpu/x64/libintelocl.so > icd/cpu.icd
+      export OCL_ICD_VENDORS=$PWD/icd
       echo "::group::sycl-ls --verbose"
       sycl-ls --verbose
       echo "::endgroup::"

--- a/devops/actions/llvm_test_suite/action.yml
+++ b/devops/actions/llvm_test_suite/action.yml
@@ -84,7 +84,7 @@ runs:
         source /runtimes/oneapi-tbb/env/vars.sh;
       fi
       # TODO remove workaround of FPGA emu bug
-      mkdir icd
+      mkdir -p icd
       echo /usr/lib/x86_64-linux-gnu/intel-opencl/libigdrcl.so > icd/gpu.icd
       echo /runtimes/oclcpu/x64/libintelocl.so > icd/cpu.icd
       export OCL_ICD_VENDORS=$PWD/icd

--- a/devops/actions/llvm_test_suite/action.yml
+++ b/devops/actions/llvm_test_suite/action.yml
@@ -83,6 +83,7 @@ runs:
       if [ -e /runtimes/oneapi-tbb/env/vars.sh ]; then
         source /runtimes/oneapi-tbb/env/vars.sh;
       fi
+      export OCL_ICD_FILENAMES="/usr/lib/x86_64-linux-gnu/intel-opencl/libigdrcl.so:/runtimes/oclcpu/x64/libintelocl.so"
       echo "::group::sycl-ls --verbose"
       sycl-ls --verbose
       echo "::endgroup::"


### PR DESCRIPTION
FPGA emulator causes crashes on SYCL runtime initialization.