### PR TITLE
[SYCL] Guard __uses_aspects__(ext_intel_bf16_conversion) with device-only macro

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/bfloat16.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/bfloat16.hpp
@@ -19,9 +19,9 @@ namespace experimental {
 
 class
 #if defined(__SYCL_DEVICE_ONLY__)
-[[__sycl_detail__::__uses_aspects__(ext_intel_bf16_conversion)]]
+    [[__sycl_detail__::__uses_aspects__(ext_intel_bf16_conversion)]]
 #endif
-bfloat16 {
+    bfloat16 {
   using storage_t = uint16_t;
   storage_t value;
 

--- a/sycl/include/sycl/ext/intel/experimental/bfloat16.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/bfloat16.hpp
@@ -17,7 +17,11 @@ namespace ext {
 namespace intel {
 namespace experimental {
 
-class [[sycl_detail::uses_aspects(ext_intel_bf16_conversion)]] bfloat16 {
+class
+#if defined(__SYCL_DEVICE_ONLY__)
+[[__sycl_detail__::__uses_aspects__(ext_intel_bf16_conversion)]]
+#endif
+bfloat16 {
   using storage_t = uint16_t;
   storage_t value;
 


### PR DESCRIPTION
Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>