### PR TITLE
[SYCL] Werror and header include fix

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -576,7 +576,7 @@ pi_result _pi_program::build_program(const char *build_options) {
 ///       query to PI and use cuModuleGetFunction to check for a kernel.
 /// Note: Another alternative is to add kernel names as metadata, like with
 ///       reqd_work_group_size.
-std::string getKernelNames(pi_program program) {
+std::string getKernelNames(pi_program) {
   cl::sycl::detail::pi::die("getKernelNames not implemented");
   return {};
 }

--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -24,13 +24,14 @@
 #include <cassert>
 #include <cstring>
 #include <cuda.h>
+#include <functional>
 #include <limits>
+#include <mutex>
 #include <numeric>
 #include <stdint.h>
 #include <string>
+#include <unordered_map>
 #include <vector>
-#include <functional>
-#include <mutex>
 
 extern "C" {
 


### PR DESCRIPTION
Fixes: https://github.com/intel/llvm/issues/5264

A `Werror` fix and an explicit include of `unordered_map`.