### PR TITLE
[SYCL][DOC] Update buffer_location property spec

### DIFF
--- a/sycl/doc/extensions/supported/sycl_ext_intel_buffer_location.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_intel_buffer_location.asciidoc
@@ -82,7 +82,8 @@ a|
 ```c++
 property::buffer_location
 ``` | The buffer_location property notifies the SYCL device compiler that the given accessor will only ever point to the memory identified by the int template parameter of its instance class.
-It also notifies the SYCL runtime to store the given accessor in that memory. | Yes
+It also notifies the SYCL runtime to store the given accessor in that memory. 
+This property is ignored for devices that don't support ```c++ cl_intel_mem_alloc_buffer_location ``` extension. | Yes
 |===
 --
 

--- a/sycl/doc/extensions/supported/sycl_ext_intel_buffer_location.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_intel_buffer_location.asciidoc
@@ -83,7 +83,7 @@ a|
 property::buffer_location
 ``` | The buffer_location property notifies the SYCL device compiler that the given accessor will only ever point to the memory identified by the int template parameter of its instance class.
 It also notifies the SYCL runtime to store the given accessor in that memory. 
-This property is ignored for devices that don't support ```c++ cl_intel_mem_alloc_buffer_location ``` extension. | Yes
+This property is meaningful only when the kernel is submitted to a device that has more than one type of global memory (e.g. an FPGA). When a kernel using this property is submitted to a different device, the property is ignored. | Yes
 |===
 --
 


### PR DESCRIPTION
Update spec accordingly to the changes from https://github.com/intel/llvm/pull/5604. buffer_location property will be ignored if the device it passed to doesn't support it.
Signed-off-by: mdimakov <maxim.dimakov@intel.com>