### PR TITLE
[SYCL] Add deprecation for group::get_global_range in SYCL 2020

### DIFF
--- a/sycl/include/CL/sycl/group.hpp
+++ b/sycl/include/CL/sycl/group.hpp
@@ -114,8 +114,12 @@ public:
 
   size_t get_group_id(int dimension) const { return index[dimension]; }
 
+  __SYCL2020_DEPRECATED(
+      "sycl::group::get_global_range() is removed in SYCL 2020")
   range<Dimensions> get_global_range() const { return globalRange; }
 
+  __SYCL2020_DEPRECATED(
+      "sycl::group::get_global_range() is removed in SYCL 2020")
   size_t get_global_range(int dimension) const {
     return globalRange[dimension];
   }

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -187,6 +187,10 @@ int main() {
   group.get_id(1);
   // expected-warning@+1{{'get_linear_id' is deprecated: use sycl::group::get_group_linear_id() instead}}
   group.get_linear_id();
+  // expected-warning@+1{{'get_global_range' is deprecated: sycl::group::get_global_range() is removed in SYCL 2020}}
+  group.get_global_range();
+  // expected-warning@+1{{'get_global_range' is deprecated: sycl::group::get_global_range() is removed in SYCL 2020}}
+  group.get_global_range(1);
 
   return 0;
 }


### PR DESCRIPTION
4.9.1.7 of SYCL 2020 does not have get_global_range function definition