### PR TITLE
[SYCL] Fix post-commit build in tools

### DIFF
--- a/sycl/tools/CMakeLists.txt
+++ b/sycl/tools/CMakeLists.txt
@@ -1,3 +1,10 @@
+function(link_llvm_libs target)
+  foreach(LIB ${ARGN})
+    target_include_directories(${target} SYSTEM PRIVATE ${LLVM_MAIN_INCLUDE_DIR})
+    target_link_libraries(${target} PRIVATE ${LIB})
+  endforeach()
+endfunction()
+
 add_subdirectory(sycl-ls)
 
 if (SYCL_ENABLE_XPTI_TRACING)

--- a/sycl/tools/sycl-prof/CMakeLists.txt
+++ b/sycl/tools/sycl-prof/CMakeLists.txt
@@ -6,7 +6,7 @@ target_include_directories(sycl-prof PRIVATE
   "${CMAKE_CURRENT_SOURCE_DIR}/../xpti_helpers/"
 )
 
-target_link_libraries(sycl-prof PRIVATE
+link_llvm_libs(sycl-prof
   LLVMSupport
 )
 

--- a/sycl/tools/sycl-sanitize/CMakeLists.txt
+++ b/sycl/tools/sycl-sanitize/CMakeLists.txt
@@ -4,7 +4,7 @@ target_include_directories(sycl-sanitize PRIVATE
   "${CMAKE_CURRENT_SOURCE_DIR}/../xpti_helpers/"
 )
 
-target_link_libraries(sycl-sanitize PRIVATE
+link_llvm_libs(sycl-sanitize
   LLVMSupport
 )
 

--- a/sycl/tools/sycl-trace/CMakeLists.txt
+++ b/sycl/tools/sycl-trace/CMakeLists.txt
@@ -6,7 +6,7 @@ target_include_directories(sycl-trace PRIVATE
 
 target_compile_options(sycl-trace PRIVATE -fno-exceptions -fno-rtti)
 
-target_link_libraries(sycl-trace PRIVATE
+link_llvm_libs(sycl-trace
   LLVMSupport
 )
 


### PR DESCRIPTION
Warnings come from community code. Mark community headers as system to suppress warnings.