### PR TITLE
[CI] Update IGC to align with the compute runtime

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -48,9 +48,9 @@
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "igc": {
-      "github_tag": "igc-1.0.10200",
-      "version": "1.0.10200",
-      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/igc-1.0.10200",
+      "github_tag": "igc-1.0.10409",
+      "version": "1.0.10409",
+      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/igc-1.0.10409",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "cm": {


### PR DESCRIPTION
igc-1.0.10409 is recommended version for 22.09.22577 GPU driver.