### PR TITLE
[CI] Disable meaningless build jobs

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -4,6 +4,13 @@ on:
   pull_request:
     branches:
     - sycl
+    # Do not run builds if changes are only in the following locations
+    paths-ignore:
+    - 'devops/containers/**'
+    - 'devops/scripts/install_drivers.sh'
+    - 'devops/scripts/install_build_tools.sh'
+    - 'sycl/doc/**'
+    - 'clang/docs/**'
 
 jobs:
   lint:


### PR DESCRIPTION
Do not run builds and tests for changes, that only affect documentation or Docker containers, since these are not functional changes, and do not affect product.