### PR TITLE
[SYCL] Add CUSTOM_WIN_VER cmake option

### DIFF
--- a/clang/tools/clang-linker-wrapper/CMakeLists.txt
+++ b/clang/tools/clang-linker-wrapper/CMakeLists.txt
@@ -21,6 +21,7 @@ endif()
 add_clang_executable(clang-linker-wrapper
   ClangLinkerWrapper.cpp
   OffloadWrapper.cpp
+  CUSTOM_WIN_VER
 
   DEPENDS
   ${tablegen_deps}

--- a/clang/tools/clang-nvlink-wrapper/CMakeLists.txt
+++ b/clang/tools/clang-nvlink-wrapper/CMakeLists.txt
@@ -6,6 +6,7 @@ endif()
 
 add_clang_executable(clang-nvlink-wrapper
   ClangNvlinkWrapper.cpp
+  CUSTOM_WIN_VER
 
   DEPENDS
   ${tablegen_deps}

--- a/clang/tools/clang-offload-bundler/CMakeLists.txt
+++ b/clang/tools/clang-offload-bundler/CMakeLists.txt
@@ -11,6 +11,7 @@ set(LLVM_LINK_COMPONENTS
 
 add_clang_tool(clang-offload-bundler
   ClangOffloadBundler.cpp
+  CUSTOM_WIN_VER
   
   DEPENDS
   intrinsics_gen

--- a/clang/tools/clang-offload-deps/CMakeLists.txt
+++ b/clang/tools/clang-offload-deps/CMakeLists.txt
@@ -2,6 +2,7 @@ set(LLVM_LINK_COMPONENTS BitWriter Core Object Support)
 
 add_clang_tool(clang-offload-deps
   ClangOffloadDeps.cpp
+  CUSTOM_WIN_VER
 
   DEPENDS
   intrinsics_gen

--- a/clang/tools/clang-offload-extract/CMakeLists.txt
+++ b/clang/tools/clang-offload-extract/CMakeLists.txt
@@ -2,6 +2,7 @@ set(LLVM_LINK_COMPONENTS Core Object Support)
 
 add_clang_tool(clang-offload-extract
   ClangOffloadExtract.cpp
+  CUSTOM_WIN_VER
 
   DEPENDS
   intrinsics_gen

--- a/clang/tools/clang-offload-wrapper/CMakeLists.txt
+++ b/clang/tools/clang-offload-wrapper/CMakeLists.txt
@@ -5,6 +5,7 @@ add_clang_tool(clang-offload-wrapper
 
   DEPENDS
   intrinsics_gen
+  CUSTOM_WIN_VER
   )
 
 set(CLANG_OFFLOAD_WRAPPER_LIB_DEPS

--- a/clang/tools/clang-offload-wrapper/CMakeLists.txt
+++ b/clang/tools/clang-offload-wrapper/CMakeLists.txt
@@ -2,10 +2,10 @@ set(LLVM_LINK_COMPONENTS BitWriter Core Object Support TransformUtils)
 
 add_clang_tool(clang-offload-wrapper
   ClangOffloadWrapper.cpp
+  CUSTOM_WIN_VER
 
   DEPENDS
   intrinsics_gen
-  CUSTOM_WIN_VER
   )
 
 set(CLANG_OFFLOAD_WRAPPER_LIB_DEPS

--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -435,10 +435,12 @@ endfunction(set_windows_version_resource_properties)
 #      This is used to specify that this is a component library of
 #      LLVM which means that the source resides in llvm/lib/ and it is a
 #      candidate for inclusion into libLLVM.so.
+#   CUSTOM_WIN_VER
+#      Default LLVM versioning on windows is skipped when set
 #   )
 function(llvm_add_library name)
   cmake_parse_arguments(ARG
-    "MODULE;SHARED;STATIC;OBJECT;DISABLE_LLVM_LINK_LLVM_DYLIB;SONAME;NO_INSTALL_RPATH;COMPONENT_LIB"
+    "MODULE;SHARED;STATIC;OBJECT;DISABLE_LLVM_LINK_LLVM_DYLIB;SONAME;NO_INSTALL_RPATH;COMPONENT_LIB;CUSTOM_WIN_VER"
     "OUTPUT_NAME;PLUGIN_TOOL;ENTITLEMENTS;BUNDLE_PATH"
     "ADDITIONAL_HEADERS;DEPENDS;LINK_COMPONENTS;LINK_LIBS;OBJLIBS"
     ${ARGN})
@@ -545,7 +547,7 @@ function(llvm_add_library name)
 
   if(ARG_MODULE)
     add_library(${name} MODULE ${ALL_FILES})
-  elseif(ARG_SHARED)
+  elseif(ARG_SHARED AND NOT ARG_CUSTOM_WIN_VER)
     add_windows_version_resource_file(ALL_FILES ${ALL_FILES})
     add_library(${name} SHARED ${ALL_FILES})
   else()
@@ -859,7 +861,7 @@ endmacro(add_llvm_library name)
 
 macro(add_llvm_executable name)
   cmake_parse_arguments(ARG
-    "DISABLE_LLVM_LINK_LLVM_DYLIB;IGNORE_EXTERNALIZE_DEBUGINFO;NO_INSTALL_RPATH;SUPPORT_PLUGINS"
+    "DISABLE_LLVM_LINK_LLVM_DYLIB;IGNORE_EXTERNALIZE_DEBUGINFO;NO_INSTALL_RPATH;SUPPORT_PLUGINS;CUSTOM_WIN_VER"
     "ENTITLEMENTS;BUNDLE_PATH"
     "DEPENDS"
     ${ARGN})
@@ -881,7 +883,9 @@ macro(add_llvm_executable name)
     set_target_properties(${obj_name} PROPERTIES FOLDER "Object Libraries")
   endif()
 
-  add_windows_version_resource_file(ALL_FILES ${ALL_FILES})
+  if(NOT ARG_CUSTOM_WIN_VER)
+    add_windows_version_resource_file(ALL_FILES ${ALL_FILES})
+  endif()
 
   if(XCODE)
     # Note: the dummy.cpp source file provides no definitions. However,

--- a/llvm/cmake/modules/AddLLVM.cmake
+++ b/llvm/cmake/modules/AddLLVM.cmake
@@ -436,7 +436,7 @@ endfunction(set_windows_version_resource_properties)
 #      LLVM which means that the source resides in llvm/lib/ and it is a
 #      candidate for inclusion into libLLVM.so.
 #   CUSTOM_WIN_VER
-#      Default LLVM versioning on windows is skipped when set
+#      Suppress default LLVM versioning on Windows.
 #   )
 function(llvm_add_library name)
   cmake_parse_arguments(ARG

--- a/llvm/tools/append-file/CMakeLists.txt
+++ b/llvm/tools/append-file/CMakeLists.txt
@@ -5,6 +5,7 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_tool(append-file
   append-file.cpp
+  CUSTOM_WIN_VER
 
   DEPENDS
   intrinsics_gen

--- a/llvm/tools/file-table-tform/CMakeLists.txt
+++ b/llvm/tools/file-table-tform/CMakeLists.txt
@@ -4,4 +4,5 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_tool(file-table-tform
   file-table-tform.cpp
+  CUSTOM_WIN_VER
   )

--- a/llvm/tools/llvm-ar/CMakeLists.txt
+++ b/llvm/tools/llvm-ar/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_tool(llvm-ar
   llvm-ar.cpp
+  CUSTOM_WIN_VER
 
   DEPENDS
   intrinsics_gen

--- a/llvm/tools/llvm-config/CMakeLists.txt
+++ b/llvm/tools/llvm-config/CMakeLists.txt
@@ -12,6 +12,7 @@ add_llvm_tool(llvm-config
   # want to build an entire native libLLVM.so in addition to the cross one just
   # for the native `llvm-config`!
   DISABLE_LLVM_LINK_LLVM_DYLIB
+  CUSTOM_WIN_VER
   )
 
 # Compute the substitution values for various items.

--- a/llvm/tools/llvm-cxxdump/CMakeLists.txt
+++ b/llvm/tools/llvm-cxxdump/CMakeLists.txt
@@ -8,4 +8,5 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_tool(llvm-cxxdump
   llvm-cxxdump.cpp
   Error.cpp
+  CUSTOM_WIN_VER
   )

--- a/llvm/tools/llvm-foreach/CMakeLists.txt
+++ b/llvm/tools/llvm-foreach/CMakeLists.txt
@@ -4,4 +4,5 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_tool(llvm-foreach
   llvm-foreach.cpp
+  CUSTOM_WIN_VER
 )

--- a/llvm/tools/llvm-link/CMakeLists.txt
+++ b/llvm/tools/llvm-link/CMakeLists.txt
@@ -13,6 +13,7 @@ set(LLVM_LINK_COMPONENTS
 
 add_llvm_tool(llvm-link
   llvm-link.cpp
+  CUSTOM_WIN_VER
 
   DEPENDS
   intrinsics_gen

--- a/llvm/tools/llvm-no-spir-kernel/CMakeLists.txt
+++ b/llvm/tools/llvm-no-spir-kernel/CMakeLists.txt
@@ -8,6 +8,7 @@ set(LLVM_LINK_COMPONENTS
 add_llvm_tool(llvm-no-spir-kernel
   llvm-no-spir-kernel.cpp
 
+  CUSTOM_WIN_VER
   DEPENDS
   intrinsics_gen
   )

--- a/llvm/tools/llvm-objcopy/CMakeLists.txt
+++ b/llvm/tools/llvm-objcopy/CMakeLists.txt
@@ -26,6 +26,7 @@ add_public_tablegen_target(StripOptsTableGen)
 add_llvm_tool(llvm-objcopy
   ObjcopyOptions.cpp
   llvm-objcopy.cpp
+  CUSTOM_WIN_VER
   DEPENDS
   ObjcopyOptsTableGen
   InstallNameToolOptsTableGen

--- a/llvm/tools/llvm-readobj/CMakeLists.txt
+++ b/llvm/tools/llvm-readobj/CMakeLists.txt
@@ -27,6 +27,7 @@ add_llvm_tool(llvm-readobj
   Win64EHDumper.cpp
   WindowsResourceDumper.cpp
   XCOFFDumper.cpp
+  CUSTOM_WIN_VER
   )
 
 add_llvm_tool_symlink(llvm-readelf llvm-readobj)

--- a/llvm/tools/sycl-post-link/CMakeLists.txt
+++ b/llvm/tools/sycl-post-link/CMakeLists.txt
@@ -31,6 +31,7 @@ add_llvm_tool(sycl-post-link
   DEPENDS
   intrinsics_gen
   LLVMGenXIntrinsics
+  CUSTOM_WIN_VER
   )
 
 target_link_libraries(sycl-post-link PRIVATE LLVMGenXIntrinsics)

--- a/sycl/cmake/modules/AddSYCLUnitTest.cmake
+++ b/sycl/cmake/modules/AddSYCLUnitTest.cmake
@@ -18,10 +18,10 @@ macro(add_sycl_unittest test_dirname link_variant)
 
   if ("${link_variant}" MATCHES "SHARED")
     set(SYCL_LINK_LIBS ${sycl_so_target})
-    add_unittest(SYCLUnitTests ${test_dirname} ${ARGN})
+    add_unittest(SYCLUnitTests ${test_dirname} CUSTOM_WIN_VER ${ARGN})
   else()
     add_unittest(SYCLUnitTests ${test_dirname}
-                $<TARGET_OBJECTS:${sycl_obj_target}> ${ARGN})
+                $<TARGET_OBJECTS:${sycl_obj_target}> CUSTOM_WIN_VER ${ARGN})
     target_compile_definitions(${test_dirname}
                                PRIVATE __SYCL_BUILD_SYCL_DLL)
 


### PR DESCRIPTION
Add CUSTOM_WIN_VER cmake option that suppresses default LLVM versioning on Windows. It is needed to skip adding LLVM default versioning for binaries.