### PR TITLE
[SYCL] Fix get_native for sycl::event

### DIFF
--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -99,7 +99,7 @@ void event_impl::setContextImpl(const ContextImplPtr &Context) {
 }
 
 event_impl::event_impl(HostEventState State)
-    : MIsFlushed(true), MState(State) {}
+    : MIsInitialized(false), MIsFlushed(true), MState(State) {}
 
 event_impl::event_impl(RT::PiEvent Event, const context &SyclContext)
     : MEvent(Event), MContext(detail::getSyclObjImpl(SyclContext)),
@@ -342,7 +342,18 @@ void HostProfilingInfo::start() { StartTime = getTimestamp(); }
 void HostProfilingInfo::end() { EndTime = getTimestamp(); }
 
 pi_native_handle event_impl::getNative() const {
+  if (!MContext) {
+    static context SyclContext;
+    MContext = getSyclObjImpl(SyclContext);
+    MHostEvent = MContext->is_host();
+    MOpenCLInterop = !MHostEvent;
+  }
   auto Plugin = getPlugin();
+  if (!MIsInitialized) {
+    MIsInitialized = true;
+    auto TempContext = MContext.get()->getHandleRef();
+    Plugin.call<PiApiKind::piEventCreate>(TempContext, &MEvent);
+  }
   if (Plugin.getBackend() == backend::opencl)
     Plugin.call<PiApiKind::piEventRetain>(getHandleRef());
   pi_native_handle Handle;

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -215,10 +215,11 @@ private:
   void instrumentationEpilog(void *TelementryEvent, const std::string &Name,
                              int32_t StreamID, uint64_t IId) const;
   void checkProfilingPreconditions() const;
-  RT::PiEvent MEvent = nullptr;
-  ContextImplPtr MContext;
-  bool MOpenCLInterop = false;
-  bool MHostEvent = true;
+  mutable bool MIsInitialized = true;
+  mutable RT::PiEvent MEvent = nullptr;
+  mutable ContextImplPtr MContext;
+  mutable bool MOpenCLInterop = false;
+  mutable bool MHostEvent = true;
   std::unique_ptr<HostProfilingInfo> MHostProfilingInfo;
   void *MCommand = nullptr;
   std::weak_ptr<queue_impl> MQueue;


### PR DESCRIPTION
Reworked event_impl: added new member flag to observe the state of init of the event and edited getter alongside default event_impl constructor, also made necessary members mutable, so that it supports lazy init, which now occurs when a get_native (both member and free) tries to get implementation of event which is constructed with the default constructor. These changes are to make sycl::event class meet the ad hoc requirements of the specification.