### PR TITLE
[SYCL][ESIMD][EMU] Missing change in header file path

### DIFF
--- a/sycl/plugins/esimd_emulator/pi_esimd_emulator.hpp
+++ b/sycl/plugins/esimd_emulator/pi_esimd_emulator.hpp
@@ -171,4 +171,4 @@ struct _pi_kernel : _pi_object {
   _pi_kernel() {}
 };
 
-#include <sycl/ext/intel/experimental/esimd/emu/detail/esimd_emulator_device_interface.hpp>
+#include <sycl/ext/intel/esimd/emu/detail/esimd_emulator_device_interface.hpp>


### PR DESCRIPTION
- Header file path for esimd_emulator backend is updated for missing
change from PR5729