### PR TITLE
[SYCL] Minor fixes to device_global properties

### DIFF
--- a/sycl/include/CL/sycl.hpp
+++ b/sycl/include/CL/sycl.hpp
@@ -60,6 +60,7 @@
 #if SYCL_EXT_ONEAPI_BACKEND_LEVEL_ZERO
 #include <sycl/ext/oneapi/backend/level_zero.hpp>
 #endif
+#include <sycl/ext/oneapi/device_global/properties.hpp>
 #include <sycl/ext/oneapi/experimental/builtins.hpp>
 #include <sycl/ext/oneapi/filter_selector.hpp>
 #include <sycl/ext/oneapi/group_algorithm.hpp>

--- a/sycl/include/sycl/ext/oneapi/device_global/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/device_global/properties.hpp
@@ -6,7 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#pragma once
+
 #include <sycl/ext/oneapi/properties/property.hpp>
+#include <sycl/ext/oneapi/properties/property_value.hpp>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
@@ -39,7 +42,7 @@ struct init_mode_key {
 struct implement_in_csr_key {
   template <bool Enable>
   using value_t =
-      property_value<implement_in_csr_key, std::bool_constant<Enable>>;
+      property_value<implement_in_csr_key, sycl::detail::bool_constant<Enable>>;
 };
 
 inline constexpr device_image_scope_key::value_t device_image_scope;


### PR DESCRIPTION
These changes includes device_global properties as part of sycl.hpp and fixes some minor oversights in the implementation.