### PR TITLE
[SYCL][NFC] Fix "unused parameter" warning

### DIFF
--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -668,7 +668,8 @@ private:
       KernelType MKernelFunc;
       NormalizedKernelType(const KernelType &KernelFunc)
           : MKernelFunc(KernelFunc) {}
-      void operator()([[maybe_unused]] const nd_item<Dims> &Arg) {
+      void operator()(const nd_item<Dims> &Arg) {
+        (void)Arg;
         detail::runKernelWithoutArg(MKernelFunc);
       }
     };

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -668,7 +668,7 @@ private:
       KernelType MKernelFunc;
       NormalizedKernelType(const KernelType &KernelFunc)
           : MKernelFunc(KernelFunc) {}
-      void operator()(const nd_item<Dims> &Arg) {
+      void operator()([[maybe_unused]] const nd_item<Dims> &Arg) {
         detail::runKernelWithoutArg(MKernelFunc);
       }
     };


### PR DESCRIPTION
This fixes compilation failure in case of compiling with -Werror,-Wunused-parameter.