### PR TITLE
[CI] Roll back to 22.07 driver

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -39,7 +39,7 @@ on:
       intel_drivers_image:
         type: string
         required: false
-        default: "ghcr.io/intel/llvm/ubuntu2004_intel_drivers:unstable"
+        default: "ghcr.io/intel/llvm/ubuntu2004_intel_drivers:unstable-b000db8dc64869339c3d5b3871b48aa73ed2954c"
       lts_config:
         type: string
         required: false

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -39,7 +39,7 @@ on:
       intel_drivers_image:
         type: string
         required: false
-        default: "ghcr.io/intel/llvm/ubuntu2004_intel_drivers:unstable-b000db8dc64869339c3d5b3871b48aa73ed2954c"
+        default: "ghcr.io/intel/llvm/ubuntu2004_intel_drivers:latest-9bec920dca088488aaca91f6294cb430dd198478"
       lts_config:
         type: string
         required: false


### PR DESCRIPTION
Check if 22.09 driver is the root cause for hangs in pre-commit.