### PR TITLE
[NFC][SYCL] Follow up for 44dea0be6e

### DIFF
--- a/clang/test/CodeGenSYCL/kernel-arg-accessor-pointer.cpp
+++ b/clang/test/CodeGenSYCL/kernel-arg-accessor-pointer.cpp
@@ -108,7 +108,7 @@ int main() {
 // CHECK-SAME: %"struct.cl::sycl::range"* noundef byval{{.*}}align 4 [[ACC_RANGE1:%[a-zA-Z0-9_]+1]],
 // CHECK-SAME: %"struct.cl::sycl::range"* noundef byval{{.*}}align 4 [[MEM_RANGE1:%[a-zA-Z0-9_]+2]],
 // CHECK-SAME: %"struct.cl::sycl::id"* noundef byval{{.*}}align 4 [[OFFSET1:%[a-zA-Z0-9_]+3]]
-// CHECK-SAME: !kernel_arg_runtime_aligned !14
+// CHECK-SAME: !kernel_arg_runtime_aligned ![[#RTALIGNED2:]]
 
 // Check kernel_B parameters
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_B
@@ -130,7 +130,7 @@ int main() {
 // CHECK-SAME: %"struct.cl::sycl::range.5"* noundef byval{{.*}}align 4 [[ACC_RANGE1:%[a-zA-Z0-9_]+1]],
 // CHECK-SAME: %"struct.cl::sycl::range.5"* noundef byval{{.*}}align 4 [[MEM_RANGE1:%[a-zA-Z0-9_]+2]],
 // CHECK-SAME: %"struct.cl::sycl::id.6"* noundef byval{{.*}}align 4 [[OFFSET1:%[a-zA-Z0-9_]+3]]
-// CHECK-SAME: !kernel_arg_runtime_aligned ![[#RTALIGNED2:]]
+// CHECK-SAME: !kernel_arg_runtime_aligned ![[#RTALIGNED2]]
 
 // Check kernel_acc_raw_ptr parameters
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_acc_raw_ptr


### PR DESCRIPTION
Remove a check, that was missed in
[NFC][SYCL] Replace hard-coded checks in kernel-arg-accessor-pointer.cpp test

Signed-off-by: Dmitry Sidorov <dmitry.sidorov@intel.com>