### PR TITLE
[SYCL] Suppress warnings for Google Test

### DIFF
--- a/sycl/unittests/CMakeLists.txt
+++ b/sycl/unittests/CMakeLists.txt
@@ -10,7 +10,6 @@ endforeach()
 # suppress warnings which came from Google Test sources
 if (CXX_SUPPORTS_SUGGEST_OVERRIDE_FLAG)
   add_compile_options("-Wno-suggest-override")
-  add_compile_options("-Wno-inconsistent-missing-override")
 endif()
 check_cxx_compiler_flag("-Winconsistent-missing-override" SYCL_CXX_SUPPORTS_INCONSISTENT_MISSING_OVERRIDE_FLAG)
 # make CMake variable unique for SYCL toolchain by adding SYCL_ prefix to make sure there 

--- a/sycl/unittests/CMakeLists.txt
+++ b/sycl/unittests/CMakeLists.txt
@@ -7,6 +7,18 @@ foreach(flag_var
 string(REGEX REPLACE "/MT" "/MD" ${flag_var} "${${flag_var}}")
 endforeach()
 
+# suppress warnings which came from Google Test sources
+if (CXX_SUPPORTS_SUGGEST_OVERRIDE_FLAG)
+  add_compile_options("-Wno-suggest-override")
+  add_compile_options("-Wno-inconsistent-missing-override")
+endif()
+check_cxx_compiler_flag("-Winconsistent-missing-override" SYCL_CXX_SUPPORTS_INCONSISTENT_MISSING_OVERRIDE_FLAG)
+# make CMake variable unique for SYCL toolchain by adding SYCL_ prefix to make sure there 
+# are no variable overrides in the future if LLVM introduces CXX_SUPPORTS_INCONSISTENT_MISSING_OVERRIDE_FLAG
+if (SYCL_CXX_SUPPORTS_INCONSISTENT_MISSING_OVERRIDE_FLAG)
+  add_compile_options("-Wno-inconsistent-missing-override")
+endif()
+
 string(TOLOWER "${CMAKE_BUILD_TYPE}" build_type_lower)
 
 include(AddSYCLUnitTest)


### PR DESCRIPTION
This patch suppresses warnings which came from Google Test sources when
compiling DPC++ RT unit tests. Now unit tests are buildable with
-Werror=on option