### PR TITLE
[SYCL] Fix unused parameter warnings in bf16 storage builtins

### DIFF
--- a/sycl/include/sycl/ext/oneapi/bf16_storage_builtins.hpp
+++ b/sycl/include/sycl/ext/oneapi/bf16_storage_builtins.hpp
@@ -41,7 +41,7 @@ std::enable_if_t<detail::is_bf16_storage_type<T>::value, T> fabs(T x) {
 #ifdef __SYCL_DEVICE_ONLY__
   return __clc_fabs(x);
 #else
-  (void) x;
+  (void)x;
   throw runtime_error("bf16 is not supported on host device.",
                       PI_INVALID_DEVICE);
 #endif
@@ -51,8 +51,8 @@ std::enable_if_t<detail::is_bf16_storage_type<T>::value, T> fmin(T x, T y) {
 #ifdef __SYCL_DEVICE_ONLY__
   return __clc_fmin(x, y);
 #else
-  (void) x;
-  (void) y;
+  (void)x;
+  (void)y;
   throw runtime_error("bf16 is not supported on host device.",
                       PI_INVALID_DEVICE);
 #endif
@@ -62,8 +62,8 @@ std::enable_if_t<detail::is_bf16_storage_type<T>::value, T> fmax(T x, T y) {
 #ifdef __SYCL_DEVICE_ONLY__
   return __clc_fmax(x, y);
 #else
-  (void) x;
-  (void) y;
+  (void)x;
+  (void)y;
   throw runtime_error("bf16 is not supported on host device.",
                       PI_INVALID_DEVICE);
 #endif
@@ -73,9 +73,9 @@ std::enable_if_t<detail::is_bf16_storage_type<T>::value, T> fma(T x, T y, T z) {
 #ifdef __SYCL_DEVICE_ONLY__
   return __clc_fma(x, y, z);
 #else
-  (void) x;
-  (void) y;
-  (void) z;
+  (void)x;
+  (void)y;
+  (void)z;
   throw runtime_error("bf16 is not supported on host device.",
                       PI_INVALID_DEVICE);
 #endif

--- a/sycl/include/sycl/ext/oneapi/bf16_storage_builtins.hpp
+++ b/sycl/include/sycl/ext/oneapi/bf16_storage_builtins.hpp
@@ -41,6 +41,7 @@ std::enable_if_t<detail::is_bf16_storage_type<T>::value, T> fabs(T x) {
 #ifdef __SYCL_DEVICE_ONLY__
   return __clc_fabs(x);
 #else
+  (void) x;
   throw runtime_error("bf16 is not supported on host device.",
                       PI_INVALID_DEVICE);
 #endif
@@ -50,6 +51,8 @@ std::enable_if_t<detail::is_bf16_storage_type<T>::value, T> fmin(T x, T y) {
 #ifdef __SYCL_DEVICE_ONLY__
   return __clc_fmin(x, y);
 #else
+  (void) x;
+  (void) y;
   throw runtime_error("bf16 is not supported on host device.",
                       PI_INVALID_DEVICE);
 #endif
@@ -59,6 +62,8 @@ std::enable_if_t<detail::is_bf16_storage_type<T>::value, T> fmax(T x, T y) {
 #ifdef __SYCL_DEVICE_ONLY__
   return __clc_fmax(x, y);
 #else
+  (void) x;
+  (void) y;
   throw runtime_error("bf16 is not supported on host device.",
                       PI_INVALID_DEVICE);
 #endif
@@ -68,6 +73,9 @@ std::enable_if_t<detail::is_bf16_storage_type<T>::value, T> fma(T x, T y, T z) {
 #ifdef __SYCL_DEVICE_ONLY__
   return __clc_fma(x, y, z);
 #else
+  (void) x;
+  (void) y;
+  (void) z;
   throw runtime_error("bf16 is not supported on host device.",
                       PI_INVALID_DEVICE);
 #endif


### PR DESCRIPTION
When compiling for host, the functions had unused parameters which resulted in warnings and errors with -Werr. This fixes the issue.