### PR TITLE
[SYCL] Keep CG ownership for run_on_host_intel command nodes

### DIFF
--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -557,13 +557,6 @@ public:
   // the cleanup process.
   EmptyCommand *MEmptyCmd = nullptr;
 
-  // This function is only usable for native kernel to prevent access to free'd
-  // memory in DispatchNativeKernel.
-  // TODO remove when native kernel support is terminated.
-  void releaseCG() {
-    MCommandGroup.release();
-  }
-
   bool producesPiEvent() const final;
 
   bool supportsPostEnqueueCleanup() const final;

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -121,9 +121,6 @@ EventImplPtr Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup,
 
     auto CleanUp = [&]() {
       if (NewCmd && (NewCmd->MDeps.size() == 0 && NewCmd->MUsers.size() == 0)) {
-        if (Type == CG::RunOnHostIntel)
-          static_cast<ExecCGCommand *>(NewCmd)->releaseCG();
-
         NewEvent->setCommand(nullptr);
         delete NewCmd;
       }

--- a/sycl/unittests/scheduler/CMakeLists.txt
+++ b/sycl/unittests/scheduler/CMakeLists.txt
@@ -21,4 +21,5 @@ add_sycl_unittest(SchedulerTests OBJECT
     utils.cpp
     LeafLimitDiffContexts.cpp
     InOrderQueueSyncCheck.cpp
+    RunOnHostIntelCG.cpp
 )

--- a/sycl/unittests/scheduler/RunOnHostIntelCG.cpp
+++ b/sycl/unittests/scheduler/RunOnHostIntelCG.cpp
@@ -1,0 +1,45 @@
+//==----------- RunOnHostIntelCG.cpp --- Scheduler unit tests --------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+
+#include "SchedulerTest.hpp"
+#include "SchedulerTestUtils.hpp"
+
+#include <detail/event_impl.hpp>
+
+using namespace sycl;
+
+bool CGDeleted = false;
+class MockCGExecKernel : public detail::CGExecKernel {
+public:
+  MockCGExecKernel(detail::NDRDescT NDRDesc,
+                   std::unique_ptr<detail::HostKernelBase> HostKernel)
+      : CGExecKernel(NDRDesc, std::move(HostKernel), /*SyclKernel*/ nullptr,
+                     /*ArgsStorage*/ {}, /*AccStorage*/ {},
+                     /*SharedPtrStorage*/ {}, /*Requirements*/ {},
+                     /*Events*/ {}, /*Args*/ {}, /*KernelName*/ "",
+                     detail::OSUtil::ExeModuleHandle, /*Streams*/ {},
+                     /*AuxilaryResources*/ {}, detail::CG::RunOnHostIntel) {}
+  ~MockCGExecKernel() override { CGDeleted = true; }
+};
+
+// Check that the command group associated with run_on_host_intel is properly
+// released on command destruction.
+TEST_F(SchedulerTest, RunOnHostIntelCG) {
+  MockScheduler MS;
+  detail::QueueImplPtr QueueImpl = detail::getSyclObjImpl(MQueue);
+
+  detail::NDRDescT NDRDesc;
+  NDRDesc.set(range<1>{1}, id<1>{0});
+  std::unique_ptr<detail::HostKernelBase> HostKernel{
+      new detail::HostKernel<std::function<void()>, void, 1>([]() {})};
+  std::unique_ptr<detail::CG> CommandGroup{
+      new MockCGExecKernel(std::move(NDRDesc), std::move(HostKernel))};
+  MS.addCG(std::move(CommandGroup), QueueImpl);
+  EXPECT_TRUE(CGDeleted);
+}


### PR DESCRIPTION
As of commit 5373ccbcde9323f55245491971e91bb01b054bbf
DispatchNativeKernel uses copies of the required data instead of using
the associated command group object directly. This change removes the
release of CG ownership from the command node since the CG is no longer
accessed or deleted by DispatchNativeKernel.