### PR TITLE
[Driver] Allow printing defines for sycl when input is stdin

### DIFF
--- a/clang/test/Driver/print-internal-defines-for-sycl.c
+++ b/clang/test/Driver/print-internal-defines-for-sycl.c
@@ -6,6 +6,7 @@
 // RUN: | FileCheck --check-prefix CHECK-PRINT-INTERNAL-DEFINES %s
 // CHECK-PRINT-INTERNAL-DEFINES: #define
 
-// Printing defines also work even when input is stdin
+// Printing defines also works even when input is stdin
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -dM -E - < /dev/null 2>&1 \
-// RUN: | FileCheck --check-prefix CHECK-PRINT-INTERNAL-DEFINES %s
+// RUN: | FileCheck --check-prefixes=CHECK-PRINT-INTERNAL-DEFINES,CHECK-NO-ERROR %s
+// CHECK-NO-ERROR-NOT: append-file: input file not found

--- a/clang/test/Driver/print-internal-defines-for-sycl.c
+++ b/clang/test/Driver/print-internal-defines-for-sycl.c
@@ -5,3 +5,7 @@
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -dM -E -x c++ %s 2>&1 \
 // RUN: | FileCheck --check-prefix CHECK-PRINT-INTERNAL-DEFINES %s
 // CHECK-PRINT-INTERNAL-DEFINES: #define
+
+// Printing defines also work even when input is stdin
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -dM -E - < /dev/null 2>&1 \
+// RUN: | FileCheck --check-prefix CHECK-PRINT-INTERNAL-DEFINES %s

--- a/llvm/tools/append-file/append-file.cpp
+++ b/llvm/tools/append-file/append-file.cpp
@@ -60,7 +60,7 @@ int main(int argc, const char **argv) {
       "input file.\n");
 
   // Input file has to exist.
-  if (!llvm::sys::fs::exists(Input))
+  if (Input != "-" && !llvm::sys::fs::exists(Input))
     error("input file not found");
 
   // Open the original source file stream.


### PR DESCRIPTION
With normal source file as input, clang is able to print defines for sycl.
With stdin as input, however, clang fails to do that due to errors from
the tool append-file, which is because append-file does not allow using
stdin as input.
We need to allow clang to print defines for sycl when input is stdin.

Signed-off-by: Qichao Gu <qichao.gu@intel.com>