### PR TITLE
[SYCL][Docs] Add new rule for naming C++ identifiers in SYCL project

### DIFF
--- a/sycl/doc/developer/ContributeToDPCPP.md
+++ b/sycl/doc/developer/ContributeToDPCPP.md
@@ -62,7 +62,7 @@ end-to-end or SYCL-CTS tests.
 - Add a helpful comment describing what the test does at the beginning and
   other comments throughout the test as necessary.
 
-- Use variables with name length more than 1 symbol in `llvm/sycl` headers and source files. 
+- All identifiers used in `llvm/sycl` headers and source files must contain at least one lowercase letter due to avoid conflicts with user-defined macros. 
 
 - Try to follow descriptive naming convention for variables, functions as
   much as possible. Please refer to

--- a/sycl/doc/developer/ContributeToDPCPP.md
+++ b/sycl/doc/developer/ContributeToDPCPP.md
@@ -62,6 +62,8 @@ end-to-end or SYCL-CTS tests.
 - Add a helpful comment describing what the test does at the beginning and
   other comments throughout the test as necessary.
 
+- Start all variables' name in llvm/sycl `.h` and `.cpp` (weather template or function variables) with underscore (`_`).
+
 - Try to follow descriptive naming convention for variables, functions as
   much as possible. Please refer to
   [LLVM naming convention](https://llvm.org/docs/CodingStandards.html#name-types-functions-variables-and-enumerators-properly)

--- a/sycl/doc/developer/ContributeToDPCPP.md
+++ b/sycl/doc/developer/ContributeToDPCPP.md
@@ -62,10 +62,8 @@ end-to-end or SYCL-CTS tests.
 - Add a helpful comment describing what the test does at the beginning and
   other comments throughout the test as necessary.
 
-- All identifiers used in `llvm/sycl` headers and source files must contain at least one lowercase letter due to avoid conflicts with user-defined macros. 
-
-- Line length must not exceed 80 symbols.
-
+- All identifiers used in `llvm/sycl` headers and source files must contain at
+  least one lowercase letter due to avoid conflicts with user-defined macros.
 - Try to follow descriptive naming convention for variables, functions as
   much as possible. Please refer to
   [LLVM naming convention](https://llvm.org/docs/CodingStandards.html#name-types-functions-variables-and-enumerators-properly)

--- a/sycl/doc/developer/ContributeToDPCPP.md
+++ b/sycl/doc/developer/ContributeToDPCPP.md
@@ -64,6 +64,8 @@ end-to-end or SYCL-CTS tests.
 
 - All identifiers used in `llvm/sycl` headers and source files must contain at least one lowercase letter due to avoid conflicts with user-defined macros. 
 
+- Line length must not exceed 80 symbols.
+
 - Try to follow descriptive naming convention for variables, functions as
   much as possible. Please refer to
   [LLVM naming convention](https://llvm.org/docs/CodingStandards.html#name-types-functions-variables-and-enumerators-properly)

--- a/sycl/doc/developer/ContributeToDPCPP.md
+++ b/sycl/doc/developer/ContributeToDPCPP.md
@@ -62,7 +62,7 @@ end-to-end or SYCL-CTS tests.
 - Add a helpful comment describing what the test does at the beginning and
   other comments throughout the test as necessary.
 
-- Start all variables' name in llvm/sycl `.h` and `.cpp` (weather template or function variables) with underscore (`_`).
+- Use variables with name length more than 1 symbol in `llvm/sycl` headers and source files. 
 
 - Try to follow descriptive naming convention for variables, functions as
   much as possible. Please refer to

--- a/sycl/doc/developer/ContributeToDPCPP.md
+++ b/sycl/doc/developer/ContributeToDPCPP.md
@@ -64,6 +64,7 @@ end-to-end or SYCL-CTS tests.
 
 - All identifiers used in `llvm/sycl` headers and source files must contain at
   least one lowercase letter due to avoid conflicts with user-defined macros.
+
 - Try to follow descriptive naming convention for variables, functions as
   much as possible. Please refer to
   [LLVM naming convention](https://llvm.org/docs/CodingStandards.html#name-types-functions-variables-and-enumerators-properly)

--- a/sycl/doc/developer/ContributeToDPCPP.md
+++ b/sycl/doc/developer/ContributeToDPCPP.md
@@ -62,7 +62,7 @@ end-to-end or SYCL-CTS tests.
 - Add a helpful comment describing what the test does at the beginning and
   other comments throughout the test as necessary.
 
-- All identifiers used in `llvm/sycl` headers and source files must contain at
+- All identifiers used in `llvm/sycl` headers files must contain at
   least one lowercase letter due to avoid conflicts with user-defined macros.
 
 - Try to follow descriptive naming convention for variables, functions as


### PR DESCRIPTION
This patch implements a new rule of naming local, template and function variables in SYCL headers and source files. Now all variables' name in such files have to have length more than 1 symbol. It's needed to exclude possibility to fail SYCL app compilation by defining macros before including `CL/sycl.hpp`.