### PR TITLE
[CODEOWNERS][NFC] Update clang offload tools code owners list

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,7 +45,7 @@ xptifw/ @intel/llvm-reviewers-runtime
 llvm/ @intel/dpcpp-tools-reviewers
 
 # Clang offload tools
-clang/tools/clang-offload-*/ @intel/dpcpp-tools-reviewers
+clang/tools/clang-offload-*/ @sndmitriev @intel/dpcpp-tools-reviewers
 
 # Explicit SIMD
 ESIMD/ @intel/dpcpp-esimd-reviewers


### PR DESCRIPTION
Add Dmitriev Sergey as a code owner for clang offload tools directories,
because he will be excluded from DPCPP tools group.

Signed-off-by: Mikhail Lychkov [mikhail.lychkov@intel.com]