### PR TITLE
[SYCL][NFC] Simplify SYCLDeviceLibReqMask

### DIFF
--- a/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.cpp
+++ b/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This pass goes through input module's function list to detect all SYCL
+// This function goes through input module's function list to detect all SYCL
 // devicelib functions invoked. Each devicelib function invoked is included in
 // one 'fallback' SPIR-V library loaded by SYCL runtime. After scanning all
 // functions in input module, a mask telling which SPIR-V libraries are needed

--- a/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.cpp
+++ b/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.cpp
@@ -214,8 +214,6 @@ uint32_t getModuleDeviceLibReqMask(const Module &M) {
 }
 } // namespace
 
-char SYCLDeviceLibReqMaskPass::ID = 0;
-bool SYCLDeviceLibReqMaskPass::runOnModule(Module &M) {
-  MReqMask = getModuleDeviceLibReqMask(M);
-  return false;
+uint32_t llvm::getSYCLDeviceLibReqMask(const Module &M) {
+  return getModuleDeviceLibReqMask(M);
 }

--- a/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.cpp
+++ b/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.cpp
@@ -190,11 +190,13 @@ uint32_t getDeviceLibBits(const std::string &FuncName) {
                             DeviceLibExt::cl_intel_devicelib_assert)));
 }
 
+} // namespace
+
 // For each device image module, we go through all functions which meets
 // 1. The function name has prefix "__devicelib_"
 // 2. The function is declaration which means it doesn't have function body
 // And we don't expect non-spirv functions with "__devicelib_" prefix.
-uint32_t getModuleDeviceLibReqMask(const Module &M) {
+uint32_t llvm::getSYCLDeviceLibReqMask(const Module &M) {
   // Device libraries will be enabled only for spir-v module.
   if (!llvm::Triple(M.getTargetTriple()).isSPIR())
     return 0;
@@ -211,9 +213,4 @@ uint32_t getModuleDeviceLibReqMask(const Module &M) {
     }
   }
   return ReqMask;
-}
-} // namespace
-
-uint32_t llvm::getSYCLDeviceLibReqMask(const Module &M) {
-  return getModuleDeviceLibReqMask(M);
 }

--- a/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.cpp
+++ b/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.cpp
@@ -198,7 +198,7 @@ uint32_t getDeviceLibBits(const std::string &FuncName) {
 // And we don't expect non-spirv functions with "__devicelib_" prefix.
 uint32_t llvm::getSYCLDeviceLibReqMask(const Module &M) {
   // Device libraries will be enabled only for spir-v module.
-  if (!llvm::Triple(M.getTargetTriple()).isSPIR())
+  if (!Triple(M.getTargetTriple()).isSPIR())
     return 0;
   // 0x1 means sycl runtime will link and load libsycl-fallback-assert.spv as
   // default. In fact, default link assert spv is not necessary but dramatic

--- a/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.h
+++ b/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.h
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This pass goes through input module's function list to detect all SYCL
+// This function goes through input module's function list to detect all SYCL
 // devicelib functions invoked. Each devicelib function invoked is included in
 // one 'fallback' SPIR-V library loaded by SYCL runtime. After scanning all
 // functions in input module, a mask telling which SPIR-V libraries are needed
@@ -16,11 +16,11 @@
 
 #pragma once
 
-#include "llvm/Pass.h"
-
 #include <cstdint>
 
 namespace llvm {
+
+class Module;
 
 // DeviceLibExt is shared between sycl-post-link tool and sycl runtime.
 // If any change is made here, need to sync with DeviceLibExt definition

--- a/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.h
+++ b/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.h
@@ -34,15 +34,6 @@ enum class DeviceLibExt : std::uint32_t {
   cl_intel_devicelib_cstring,
 };
 
-class SYCLDeviceLibReqMaskPass : public ModulePass {
-public:
-  static char ID;
-  SYCLDeviceLibReqMaskPass() : ModulePass(ID) { MReqMask = 0; }
-  bool runOnModule(Module &M) override;
-  uint32_t getSYCLDeviceLibReqMask() { return MReqMask; }
-
-private:
-  uint32_t MReqMask;
-};
+uint32_t getSYCLDeviceLibReqMask(const Module &M);
 
 } // namespace llvm

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -623,11 +623,7 @@ void saveModuleProperties(Module &M, const EntryPointGroup &ModuleEntryPoints,
   PropSetRegTy PropSet;
 
   {
-    legacy::PassManager GetSYCLDeviceLibReqMask;
-    auto *SDLReqMaskLegacyPass = new SYCLDeviceLibReqMaskPass();
-    GetSYCLDeviceLibReqMask.add(SDLReqMaskLegacyPass);
-    GetSYCLDeviceLibReqMask.run(M);
-    uint32_t MRMask = SDLReqMaskLegacyPass->getSYCLDeviceLibReqMask();
+    uint32_t MRMask = getSYCLDeviceLibReqMask(M);
     std::map<StringRef, uint32_t> RMEntry = {{"DeviceLibReqMask", MRMask}};
     PropSet.add(PropSetRegTy::SYCL_DEVICELIB_REQ_MASK, RMEntry);
   }


### PR DESCRIPTION
[SYCL] SYCLDeviceLibReqMask simplified: Pass manager infrastructure usage replaced with helper function getSYCLDeviceLibReqMask. 
Closes #5362.