### PR TITLE
[SYCL] Redirect warning from using SYCL_DEVICE_FILTER with sycl-ls

### DIFF
--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -107,9 +107,9 @@ int main(int argc, char **argv) {
 
   const char *filter = std::getenv("SYCL_DEVICE_FILTER");
   if (filter) {
-    std::cout << "Warning: SYCL_DEVICE_FILTER environment variable is set to "
+    std::cerr << "Warning: SYCL_DEVICE_FILTER environment variable is set to "
               << filter << "." << std::endl;
-    std::cout
+    std::cerr
         << "To see the correct device id, please unset SYCL_DEVICE_FILTER."
         << std::endl
         << std::endl;


### PR DESCRIPTION
Redirect warning from using SYCL_DEVICE_FILTER with sycl-ls to std::cerr (MKL request)