### PR TITLE
[sycl-post-link] Remove padding from DeviceGlobalProperty

### DIFF
--- a/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
@@ -106,16 +106,15 @@ attributes #6 = { "sycl-unique-id"="6da74a122db9f35d____ZL7no_dg_int1" "device_i
 ;  1. 8 bytes denoting the bit-size of the byte array, here 64 bits or 8 bytes.
 ;  2. 4 bytes with the value of the 32-bit uint32_t integer with the size of the
 ;     underlying type of the device global variable. Its value being 1.
-;  3. 1 byte with the value of the 8-bit uint8_t integer with the flag that
+;  3. 4 byte with the value of the 32-bit uint32_t integer with the flag that
 ;     the device global variable has the 'device_image_scope' property.
 ;     Its value being 1, property is present.
-;  4. Any 3 bytes used as padding to align the structure to 8 bytes.
 ;
 ; CHECK-PROP: [SYCL/device globals]
-; CHECK-PROP-NEXT: 6da74a122db9f35d____ZL7dg_int1=2|ABAAAAAAAAABAAAAA
-; CHECK-PROP-NEXT: 7da74a1187b9f35d____ZL7dg_int2=2|ABAAAAAAAAABAAAAA
-; CHECK-PROP-NEXT: 9d329ad59055e972____ZL8dg_bool3=2|ABAAAAAAAAQAAAAAB
-; CHECK-PROP-NEXT: dda2bad52c45c432____ZL8dg_bool4=2|ABAAAAAAAAQAAAAAB
+; CHECK-PROP-NEXT: 6da74a122db9f35d____ZL7dg_int1=2|ABAAAAAAAAABAAAAAAAAAA
+; CHECK-PROP-NEXT: 7da74a1187b9f35d____ZL7dg_int2=2|ABAAAAAAAAABAAAAAAAAAA
+; CHECK-PROP-NEXT: 9d329ad59055e972____ZL8dg_bool3=2|ABAAAAAAAAQAAAAABAAAAA
+; CHECK-PROP-NEXT: dda2bad52c45c432____ZL8dg_bool4=2|ABAAAAAAAAQAAAAABAAAAA
 ;
 ; The variable is not a device global one and must be ignored
 ; CHECK-PROP-NOT: 6da74a122db9f35d____ZL7no_dg_int1

--- a/llvm/tools/sycl-post-link/DeviceGlobals.h
+++ b/llvm/tools/sycl-post-link/DeviceGlobals.h
@@ -35,6 +35,8 @@ struct DeviceGlobalProperty {
 
   // Either 1 (true) or 0 (false), telling whether the device global variable
   // was declared with the device_image_scope property.
+  // We use uint32_t for a boolean value to eliminate padding after the field
+  // and supress false positive reports from MemorySanitizer.
   uint32_t DeviceImageScope;
 };
 

--- a/llvm/tools/sycl-post-link/DeviceGlobals.h
+++ b/llvm/tools/sycl-post-link/DeviceGlobals.h
@@ -36,7 +36,7 @@ struct DeviceGlobalProperty {
   // Either 1 (true) or 0 (false), telling whether the device global variable
   // was declared with the device_image_scope property.
   // We use uint32_t for a boolean value to eliminate padding after the field
-  // and supress false positive reports from MemorySanitizer.
+  // and suppress false positive reports from MemorySanitizer.
   uint32_t DeviceImageScope;
 };
 

--- a/llvm/tools/sycl-post-link/DeviceGlobals.h
+++ b/llvm/tools/sycl-post-link/DeviceGlobals.h
@@ -35,7 +35,7 @@ struct DeviceGlobalProperty {
 
   // Either 1 (true) or 0 (false), telling whether the device global variable
   // was declared with the device_image_scope property.
-  uint8_t DeviceImageScope;
+  uint32_t DeviceImageScope;
 };
 
 using DeviceGlobalPropertyMapTy =

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1222,7 +1222,8 @@ void ProgramManager::addImages(pi_device_binaries DeviceBinary) {
           assert(DeviceGlobalInfo.size() >= 13 && "Unexpected property size");
           const std::uint32_t TypeSize =
               *reinterpret_cast<const std::uint32_t *>(&DeviceGlobalInfo[8]);
-          const std::uint32_t DeviceImageScopeDecorated = DeviceGlobalInfo[12];
+          const std::uint32_t DeviceImageScopeDecorated =
+              *reinterpret_cast<const std::uint32_t *>(&DeviceGlobalInfo[12]);
           Entry->second.initialize(TypeSize, DeviceImageScopeDecorated);
         }
       }

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1217,9 +1217,8 @@ void ProgramManager::addImages(pi_device_binaries DeviceBinary) {
           // The supplied device_global info property is expected to contain:
           // * 8 bytes - Size of the property.
           // * 4 bytes - Size of the underlying type in the device_global.
-          // * 1 byte  - 0 if device_global has device_image_scope and any value
+          // * 4 bytes - 0 if device_global has device_image_scope and any value
           //             otherwise.
-          // Note: Property may be padded.
           assert(DeviceGlobalInfo.size() >= 13 && "Unexpected property size");
           const std::uint32_t TypeSize =
               *reinterpret_cast<const std::uint32_t *>(&DeviceGlobalInfo[8]);

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1219,7 +1219,7 @@ void ProgramManager::addImages(pi_device_binaries DeviceBinary) {
           // * 4 bytes - Size of the underlying type in the device_global.
           // * 4 bytes - 0 if device_global has device_image_scope and any value
           //             otherwise.
-          assert(DeviceGlobalInfo.size() >= 13 && "Unexpected property size");
+          assert(DeviceGlobalInfo.size() == 16 && "Unexpected property size");
           const std::uint32_t TypeSize =
               *reinterpret_cast<const std::uint32_t *>(&DeviceGlobalInfo[8]);
           const std::uint32_t DeviceImageScopeDecorated =


### PR DESCRIPTION
As it is described in [1], MemorySanitizer emits an unexpected report
about an uninitialized value when we are reading a structure with
padding as a byte array. The patch implements a workaround:
the type of the DeviceImageScope flag has been replaced with uint32_t
to not require a space for padding. The change should have no impact
on performance and ABI because the size is the same.

[1] https://github.com/llvm/llvm-project/issues/54476