### PR TITLE
[ESIMD] Fix removal of "llvm.used" global in sycl-post-link

### DIFF
--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -859,10 +859,11 @@ static bool removeSYCLKernelsConstRefArray(GlobalVariable *GV) {
   for (auto It = IOperands.begin(); It != IOperands.end(); It++) {
     assert(llvm::isSafeToDestroyConstant(*It) &&
            "Cannot remove an element of initializer of llvm.used global");
-    auto F = cast<Function>((*It)->getOperand(0));
+    auto Op = (*It)->getOperand(0);
     (*It)->destroyConstant();
     // Remove unused kernel declarations to avoid LLVM IR check fails.
-    if (F->isDeclaration())
+    auto *F = dyn_cast<Function>(Op);
+    if (F && F->isDeclaration())
       F->eraseFromParent();
   }
   return true;


### PR DESCRIPTION
The code removing llvm.used global in sycl-post-link wrongly
assumed that all elements of the global array are either functions
or function declarations. In fact llvm.used also may contain specialization
constants as well.
The fix adds additional check of IR before removal.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>