### PR TITLE
[SYCL][NFC][DOC] Add esimd_emulator to SYCL_DEVICE_FILTER description

### DIFF
--- a/sycl/doc/EnvironmentVariables.md
+++ b/sycl/doc/EnvironmentVariables.md
@@ -43,6 +43,7 @@ The value of this environment variable is a comma separated list of filters, whe
 - `opencl`
 - `cuda`
 - `hip`
+- `esimd_emulator`
 - `*`
 
 Possible values of `device_type` are:


### PR DESCRIPTION
According to [4020](https://github.com/intel/llvm/pull/4020/files#diff-5a63a5dacf374e89656d23696f03fb898201df951d967644340a7bfba75b9ac5R179), esimd_emulator is a possible value for backend in SYCL_DEVICE_FILTER.