### PR TITLE
[SYCL] Store the kernel object size in the integration header

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -335,7 +335,8 @@ public:
   ///  Signals that subsequent parameter descriptor additions will go to
   ///  the kernel with given name. Starts new kernel invocation descriptor.
   void startKernel(const FunctionDecl *SyclKernel, QualType KernelNameType,
-                   SourceLocation Loc, bool IsESIMD, bool IsUnnamedKernel);
+                   SourceLocation Loc, bool IsESIMD, bool IsUnnamedKernel,
+                   unsigned long ObjSize);
 
   /// Adds a kernel parameter descriptor to current kernel invocation
   /// descriptor.
@@ -402,10 +403,15 @@ private:
     // hasn't provided an explicit name for.
     bool IsUnnamedKernel;
 
+    /// Size of the kernel object.
+    unsigned long ObjSize = 0;
+
     KernelDesc(const FunctionDecl *SyclKernel, QualType NameType,
-               SourceLocation KernelLoc, bool IsESIMD, bool IsUnnamedKernel)
+               SourceLocation KernelLoc, bool IsESIMD, bool IsUnnamedKernel,
+               unsigned long ObjSize)
         : SyclKernel(SyclKernel), NameType(NameType), KernelLocation(KernelLoc),
-          IsESIMDKernel(IsESIMD), IsUnnamedKernel(IsUnnamedKernel) {}
+          IsESIMDKernel(IsESIMD), IsUnnamedKernel(IsUnnamedKernel),
+          ObjSize(ObjSize) {}
 
     void updateKernelNames(StringRef Name, StringRef StableName) {
       this->Name = Name.str();

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -336,7 +336,7 @@ public:
   ///  the kernel with given name. Starts new kernel invocation descriptor.
   void startKernel(const FunctionDecl *SyclKernel, QualType KernelNameType,
                    SourceLocation Loc, bool IsESIMD, bool IsUnnamedKernel,
-                   unsigned long ObjSize);
+                   int64_t ObjSize);
 
   /// Adds a kernel parameter descriptor to current kernel invocation
   /// descriptor.
@@ -404,11 +404,11 @@ private:
     bool IsUnnamedKernel;
 
     /// Size of the kernel object.
-    unsigned long ObjSize = 0;
+    int64_t ObjSize = 0;
 
     KernelDesc(const FunctionDecl *SyclKernel, QualType NameType,
                SourceLocation KernelLoc, bool IsESIMD, bool IsUnnamedKernel,
-               unsigned long ObjSize)
+               int64_t ObjSize)
         : SyclKernel(SyclKernel), NameType(NameType), KernelLocation(KernelLoc),
           IsESIMDKernel(IsESIMD), IsUnnamedKernel(IsUnnamedKernel),
           ObjSize(ObjSize) {}

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3125,9 +3125,9 @@ public:
       : SyclKernelFieldHandler(S), Header(H) {
     bool IsSIMDKernel = isESIMDKernelType(KernelObj);
     // The header needs to access the kernel object size.
-    unsigned long ObjSize = SemaRef.getASTContext()
-                                .getTypeSizeInChars(KernelObj->getTypeForDecl())
-                                .getQuantity();
+    int64_t ObjSize = SemaRef.getASTContext()
+                          .getTypeSizeInChars(KernelObj->getTypeForDecl())
+                          .getQuantity();
     Header.startKernel(KernelFunc, NameType, KernelObj->getLocation(),
                        IsSIMDKernel, IsSYCLUnnamedKernel(S, KernelFunc),
                        ObjSize);
@@ -4784,7 +4784,7 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
     O << "  }\n";
     O << "  // Returns the size of the kernel object in bytes.\n";
     O << "  __SYCL_DLL_LOCAL\n";
-    O << "  static constexpr unsigned long getKernelObjectSize() { return "
+    O << "  static constexpr int64_t getKernelSizeof() { return "
       << K.ObjSize << "; }\n";
     O << "};\n";
     CurStart += N;
@@ -4817,7 +4817,7 @@ void SYCLIntegrationHeader::startKernel(const FunctionDecl *SyclKernel,
                                         SourceLocation KernelLocation,
                                         bool IsESIMDKernel,
                                         bool IsUnnamedKernel,
-                                        unsigned long ObjSize) {
+                                        int64_t ObjSize) {
   KernelDescs.emplace_back(SyclKernel, KernelNameType, KernelLocation,
                            IsESIMDKernel, IsUnnamedKernel, ObjSize);
 }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4783,8 +4783,9 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
     O << "#endif\n";
     O << "  }\n";
     StringRef ReturnType =
-        (S.Context.getTargetInfo().getInt64Type() == TargetInfo::SignedLong) ?
-            "long" : "long long";
+        (S.Context.getTargetInfo().getInt64Type() == TargetInfo::SignedLong)
+            ? "long"
+            : "long long";
     O << "  // Returns the size of the kernel object in bytes.\n";
     O << "  __SYCL_DLL_LOCAL\n";
     O << "  static constexpr " << ReturnType << " getKernelSize() { return "
@@ -4819,8 +4820,7 @@ void SYCLIntegrationHeader::startKernel(const FunctionDecl *SyclKernel,
                                         QualType KernelNameType,
                                         SourceLocation KernelLocation,
                                         bool IsESIMDKernel,
-                                        bool IsUnnamedKernel,
-                                        int64_t ObjSize) {
+                                        bool IsUnnamedKernel, int64_t ObjSize) {
   KernelDescs.emplace_back(SyclKernel, KernelNameType, KernelLocation,
                            IsESIMDKernel, IsUnnamedKernel, ObjSize);
 }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4782,9 +4782,12 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
     O << "    return 0;\n";
     O << "#endif\n";
     O << "  }\n";
+    StringRef ReturnType =
+        (S.Context.getTargetInfo().getInt64Type() == TargetInfo::SignedLong) ?
+            "long" : "long long";
     O << "  // Returns the size of the kernel object in bytes.\n";
     O << "  __SYCL_DLL_LOCAL\n";
-    O << "  static constexpr int64_t getKernelSizeof() { return "
+    O << "  static constexpr " << ReturnType << " getKernelSize() { return "
       << K.ObjSize << "; }\n";
     O << "};\n";
     CurStart += N;

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4782,9 +4782,10 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
     O << "    return 0;\n";
     O << "#endif\n";
     O << "  }\n";
+    O << "  // Returns the size of the kernel object in bytes.\n";
     O << "  __SYCL_DLL_LOCAL\n";
-    O << "  static constexpr unsigned long getSize() { return " << K.ObjSize
-      << "; }\n";
+    O << "  static constexpr unsigned long getKernelObjectSize() { return "
+      << K.ObjSize << "; }\n";
     O << "};\n";
     CurStart += N;
   }

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3125,9 +3125,9 @@ public:
       : SyclKernelFieldHandler(S), Header(H) {
     bool IsSIMDKernel = isESIMDKernelType(KernelObj);
     // The header needs to access the kernel object size.
-    unsigned long ObjSize = SemaRef.getASTContext().
-                                getTypeSizeInChars(KernelObj->getTypeForDecl()).
-                                getQuantity();
+    unsigned long ObjSize = SemaRef.getASTContext()
+                                .getTypeSizeInChars(KernelObj->getTypeForDecl())
+                                .getQuantity();
     Header.startKernel(KernelFunc, NameType, KernelObj->getLocation(),
                        IsSIMDKernel, IsSYCLUnnamedKernel(S, KernelFunc),
                        ObjSize);
@@ -4783,8 +4783,8 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
     O << "#endif\n";
     O << "  }\n";
     O << "  __SYCL_DLL_LOCAL\n";
-    O << "  static constexpr unsigned long getSize() { return "
-      << K.ObjSize << "; }\n";
+    O << "  static constexpr unsigned long getSize() { return " << K.ObjSize
+      << "; }\n";
     O << "};\n";
     CurStart += N;
   }

--- a/clang/test/CodeGenSYCL/int_header_kernelobjsize.cpp
+++ b/clang/test/CodeGenSYCL/int_header_kernelobjsize.cpp
@@ -1,9 +1,9 @@
 // RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -fsycl-int-header=%t.h %s
 // RUN: FileCheck -input-file=%t.h %s
 
-// This test checks that the getSize() member function is generated
-// into the integration header and that it returns the size of the
-// kernel object.
+// This test checks that the getKernelObjectSize() member function
+// is generated into the integration header and that it returns the
+// size of the kernel object in bytes.
 
 #include "sycl.hpp"
 
@@ -13,11 +13,14 @@ void testA() {
   queue q;
   constexpr int N = 256;
   int A[N] = {10};
-  kernel_single_task<class KernelName>([=]() {
-    for (int k = 0; k < N; ++k) {
-      (void)A[k];
-    }
+  q.submit([&](handler &h) {
+    h.single_task<class KernelName>([=]() {
+      for (int k = 0; k < N; ++k) {
+        (void)A[k];
+      }
+    });
   });
 }
 // CHECK: template <> struct KernelInfo<KernelName> {
-// CHECK:   static constexpr unsigned long getSize() { return 1024; }
+// CHECK: // Returns the size of the kernel object in bytes.
+// CHECK: static constexpr unsigned long getKernelObjectSize() { return 1024; }

--- a/clang/test/CodeGenSYCL/int_header_kernelobjsize.cpp
+++ b/clang/test/CodeGenSYCL/int_header_kernelobjsize.cpp
@@ -12,7 +12,7 @@ using namespace cl::sycl;
 void testA() {
   queue q;
   constexpr int N = 256;
-  int A[N] = { 10 };
+  int A[N] = {10};
   kernel_single_task<class KernelName>([=]() {
     for (int k = 0; k < N; ++k) {
       (void)A[k];

--- a/clang/test/CodeGenSYCL/int_header_kernelobjsize.cpp
+++ b/clang/test/CodeGenSYCL/int_header_kernelobjsize.cpp
@@ -1,8 +1,8 @@
 // RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -fsycl-int-header=%t.h %s
 // RUN: FileCheck -input-file=%t.h %s
 
-// This test checks that the getKernelObjectSize() member function
-// is generated into the integration header and that it returns the
+// This test checks that the getKernelSizeof() member function is
+// generated into the integration header and that it returns the
 // size of the kernel object in bytes.
 
 #include "sycl.hpp"
@@ -23,4 +23,4 @@ void testA() {
 }
 // CHECK: template <> struct KernelInfo<KernelName> {
 // CHECK: // Returns the size of the kernel object in bytes.
-// CHECK: static constexpr unsigned long getKernelObjectSize() { return 1024; }
+// CHECK: static constexpr int64_t getKernelSizeof() { return 1024; }

--- a/clang/test/CodeGenSYCL/int_header_kernelobjsize.cpp
+++ b/clang/test/CodeGenSYCL/int_header_kernelobjsize.cpp
@@ -1,0 +1,23 @@
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -fsycl-int-header=%t.h %s
+// RUN: FileCheck -input-file=%t.h %s
+
+// This test checks that the getSize() member function is generated
+// into the integration header and that it returns the size of the
+// kernel object.
+
+#include "sycl.hpp"
+
+using namespace cl::sycl;
+
+void testA() {
+  queue q;
+  constexpr int N = 256;
+  int A[N] = { 10 };
+  kernel_single_task<class KernelName>([=]() {
+    for (int k = 0; k < N; ++k) {
+      (void)A[k];
+    }
+  });
+}
+// CHECK: template <> struct KernelInfo<KernelName> {
+// CHECK:   static constexpr unsigned long getSize() { return 1024; }

--- a/clang/test/CodeGenSYCL/int_header_kernelobjsize.cpp
+++ b/clang/test/CodeGenSYCL/int_header_kernelobjsize.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -fsycl-int-header=%t.h %s
 // RUN: FileCheck -input-file=%t.h %s
 
-// This test checks that the getKernelSizeof() member function is
+// This test checks that the getKernelSize() member function is
 // generated into the integration header and that it returns the
 // size of the kernel object in bytes.
 
@@ -23,4 +23,4 @@ void testA() {
 }
 // CHECK: template <> struct KernelInfo<KernelName> {
 // CHECK: // Returns the size of the kernel object in bytes.
-// CHECK: static constexpr int64_t getKernelSizeof() { return 1024; }
+// CHECK: static constexpr long{{.*}} getKernelSize() { return 1024; }


### PR DESCRIPTION
Sometimes when the host compiler is different from the device compiler,
it is possible that the size of the kernel object on the host will differ from the
size of the kernel object on the device.   One such case is when constexpr
variables are used; compilers differ on whether they need to be captured and
this causes a discrepancy in the size of the kernel object and leads to failures
at runtime.

This change adds an interface to the integration header which returns the size
of the kernel object as computed on the device.   The expectation is that the
library will assert the size of a kernel when compiling the host to detect
potential mismatches.