### PR TITLE
Use immediate cmdlists by default, with on-demand device-only events.

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -77,7 +77,7 @@ static const bool UseCopyEngineForInOrderQueue = [] {
 // Setting a value >=1 specifies use of immediate commandlists.
 // Note: when immediate commandlists are used then device-only events
 // must be either AllHostVisible or OnDemandHostVisibleProxy.
-// See env var SYCL_PI_LEVEL_ZERO_DEVICE_SCOPE_EVENTS.
+// (See env var SYCL_PI_LEVEL_ZERO_DEVICE_SCOPE_EVENTS).
 static const bool UseImmediateCommandLists = [] {
   const char *ImmediateFlag =
       std::getenv("SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS");

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -868,7 +868,7 @@ struct _pi_queue : _pi_object {
   // batched into.
   // If IsBlocking is true, then batching will not be allowed regardless
   // of the value of OKToBatchCommand
-  // 
+  //
   // For immediate commandlists, no close and execute is necessary.
   pi_result executeCommandList(pi_command_list_ptr_t CommandList,
                                bool IsBlocking = false,


### PR DESCRIPTION
This PR tests use of immediate command lists by default.