### PR TITLE
[NFC][SYCL][L0] Fix a warning about unused parameter

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -6865,6 +6865,7 @@ static pi_result USMSharedAllocImpl(void **ResultPtr, pi_context Context,
                                     pi_device Device,
                                     pi_usm_mem_properties *Properties,
                                     size_t Size, pi_uint32 Alignment) {
+  (void)Properties;
   PI_ASSERT(Context, PI_INVALID_CONTEXT);
   PI_ASSERT(Device, PI_INVALID_DEVICE);
 


### PR DESCRIPTION
This PR fixed error `error: unused parameter 'Properties' [-Werror,-Wunused-parameter]` in `sycl/plugins/level_zero/pi_level_zero.cpp` caused by https://github.com/intel/llvm/commit/644c61445dd40d01a0d1016e2df66aca161fd464