### PR TITLE
[SYCL] Initial implementation of `invoke_simd` and `uniform` extensions.

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/simd.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/simd.hpp
@@ -19,6 +19,8 @@
 #include <sycl/ext/intel/esimd/detail/types.hpp>
 #include <sycl/ext/intel/esimd/simd_view.hpp>
 
+#include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
+
 #ifndef __SYCL_DEVICE_ONLY__
 #include <iostream>
 #endif // __SYCL_DEVICE_ONLY__
@@ -77,6 +79,15 @@ public:
     __esimd_dbg_print(simd(const SimdT &RHS));
   }
 
+  // Implicit conversion constructor from sycl::ext::oneapi::experimental::simd
+  template <
+      int N1 = N, class Ty1 = Ty,
+      class SFINAE = std::enable_if_t<
+          (N1 == N) && (N1 <= std::experimental::simd_abi::max_fixed_size<
+                                  Ty>)&&!detail::is_wrapper_elem_type_v<Ty1>>>
+  simd(const sycl::ext::oneapi::experimental::simd<Ty, N1> &v)
+      : simd(static_cast<raw_vector_type>(v)) {}
+
   /// Broadcast constructor with conversion. Converts given value to
   /// #element_type and replicates it in all elements.
   /// Available when \c T1 is a valid simd element type.
@@ -99,6 +110,19 @@ public:
   operator To() const {
     __esimd_dbg_print(operator To());
     return detail::convert_scalar<To, element_type>(base_type::data()[0]);
+  }
+
+  /// Implicitly converts this object to a sycl::ext::oneapi::experimental::simd
+  /// object. Available when the number of elements does not exceed maximum
+  /// fixed size of the oneapi's simd_abi and (TODO, temporary limitation) the
+  /// element type is a primitive type (e.g. can't be sycl::half).
+  template <
+      int N1, class Ty1 = Ty,
+      class SFINAE = std::enable_if_t<
+          (N1 == N) && (N1 <= std::experimental::simd_abi::max_fixed_size<
+                                  Ty>)&&!detail::is_wrapper_elem_type_v<Ty1>>>
+  operator sycl::ext::oneapi::experimental::simd<Ty, N1>() {
+    return sycl::ext::oneapi::experimental::simd<Ty, N1>(base_type::data());
   }
 
   /// Prefix increment, increments elements of this object.

--- a/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
@@ -248,7 +248,7 @@ simd_call_helper(const void *obj_ptr,
 ///   the specification.
 // TODO works only for functions now, enable for other callables.
 template <class Callable, class... T>
-__attribute__((always_inline)) auto invoke_simd(sycl::ext::oneapi::sub_group sg,
+__attribute__((always_inline)) auto invoke_simd(sycl::sub_group sg,
                                                 Callable &&f, T... args) {
   // If the invoke_simd call site is fully uniform, then it does not matter
   // what the subgroup size is and arguments don't need widening and return

--- a/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
@@ -1,0 +1,122 @@
+//==------ invoke_simd.hpp - SYCL invoke_simd extension --*- C++ -*---------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===--------------------------------------------------------------------=== //
+// Implemenation of the sycl_ext_oneapi_invoke_simd extension.
+// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_invoke_simd.asciidoc
+// ===--------------------------------------------------------------------=== //
+
+#pragma once
+
+// 1 - Initial extension version. Base features are supported.
+#define SYCL_EXT_ONEAPI_INVOKE_SIMD 1
+
+#include <sycl/ext/oneapi/experimental/uniform.hpp>
+
+#include <std/experimental/simd.hpp>
+
+// TODO FIXME dummy implementation to kick-off testing
+constexpr int __builtin_get_reqd_subgroup_size() { return /*FE builtin*/ 16; }
+
+/// Middle End - to - Back End interface to invoke explicit SIMD functions from
+/// SPMD SYCL context.
+template <class Ret, class F, class... Args>
+Ret __builtin_invoke_simd(F, Args...) SYCL_EXTERNAL
+#ifdef __SYCL_DEVICE_ONLY__
+    ;
+#else
+{
+  throw sycl::exception(sycl::errc::feature_not_supported);
+}
+#endif // __SYCL_DEVICE_ONLY__
+
+namespace sycl {
+namespace ext {
+namespace oneapi {
+namespace experimental {
+
+namespace simd_abi {
+template <class T, int N>
+using native_fixed_size = typename std::experimental::__simd_abi<
+    std::experimental::_StorageKind::_VecExt, N>;
+} // namespace simd_abi
+
+template <class T, int N>
+using simd = std::experimental::simd<T, simd_abi::native_fixed_size<T, N>>;
+
+template <class T, int N>
+using simd_mask =
+    std::experimental::simd_mask<T, simd_abi::native_fixed_size<T, N>>;
+
+namespace detail {
+template <class T, int N = __builtin_get_reqd_subgroup_size(), class = void>
+struct spmd2simd;
+template <class T, int N> struct spmd2simd<uniform<T>, N> {
+  using type = T;
+};
+template <class... T, int N> struct spmd2simd<std::tuple<T...>, N> {
+  using type = std::tuple<typename spmd2simd<T, N>::type...>;
+};
+template <class T, int N>
+struct spmd2simd<T, N, std::enable_if_t<std::is_arithmetic_v<T>>> {
+  using type = simd<T, N>;
+};
+// TODO implement bool translation
+
+template <class, class = void> struct simd2spmd;
+template <class T, int N> struct simd2spmd<simd<T, N>> {
+  using type = T;
+};
+template <class... T> struct simd2spmd<std::tuple<T...>> {
+  using type = std::tuple<typename simd2spmd<T>::type...>;
+};
+template <class T>
+struct simd2spmd<T, std::enable_if_t<std::is_arithmetic_v<T>>> {
+  using type = uniform<T>;
+};
+
+// Unwrap the uniform object so that it is passed as underlying type
+template <typename T> struct unwrap {
+  static auto impl(T val) { return val; }
+};
+
+template <typename T> struct unwrap<uniform<T>> {
+  static T impl(uniform<T> val) { return val; }
+};
+
+template <class Callable, class... T>
+using SPMDInvokeResult = typename simd2spmd<
+    std::invoke_result_t<Callable, typename spmd2simd<T>::type...>>::type;
+} // namespace detail
+
+/// The invoke_simd free function invokes a SIMD function using all work-items
+/// in a sub_group. The invoke_simd interface marshals data between the SPMD
+/// context of the calling kernel and the SIMD context of the callee, converting
+/// arguments and return values between scalar and SIMD types as appropriate.
+///
+/// @param sg the subgroup simd function is invoked from
+/// @param f represents the invoked simd function.
+///   Must be a C++ callable that can be invoked with the same number of
+///   arguments specified in the args parameter pack. Callable may be a function
+///   object, a lambda, or a function pointer (if the device supports
+///   SPV_INTEL_function_pointers). Callable must be an immutable callable with
+///   the same type and state for all work-items in the sub-group, otherwise
+///   behavior is undefined.
+/// @param args SPMD parameters to the invoked function, which undergo
+///   transformation before actual passing to the simd function, as described in
+///   the specification.
+// TODO works only for functions now, enable for other callables.
+template <class Callable, class... T>
+__attribute__((always_inline)) detail::SPMDInvokeResult<Callable, T...>
+invoke_simd(sycl::sub_group sg, Callable &&f, T... args) {
+  using RetSpmd = detail::SPMDInvokeResult<Callable, T...>;
+  return __builtin_invoke_simd<RetSpmd>(f, detail::unwrap<T>::impl(args)...);
+}
+
+} // namespace experimental
+} // namespace oneapi
+} // namespace ext
+} // namespace sycl

--- a/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
@@ -240,19 +240,23 @@ simd_call_helper(const void *obj_ptr,
 //     return std::is_function_v<std::remove_reference_t<F>>;
 //   }
 // where F is a function type with __regcall.
-template <class F> struct is_regcall_function_ptr_or_ref_v : std::false_type {};
+template <class F> struct is_regcall_function_ptr_or_ref : std::false_type {};
 
 template <class Ret, class... Args>
-struct is_regcall_function_ptr_or_ref_v<Ret(__regcall &)(Args...)>
+struct is_regcall_function_ptr_or_ref<Ret(__regcall &)(Args...)>
     : std::true_type {};
 
 template <class Ret, class... Args>
-struct is_regcall_function_ptr_or_ref_v<Ret(__regcall *)(Args...)>
+struct is_regcall_function_ptr_or_ref<Ret(__regcall *)(Args...)>
+    : std::true_type {};
+
+template <class Ret, class... Args>
+struct is_regcall_function_ptr_or_ref<Ret(__regcall *&)(Args...)>
     : std::true_type {};
 
 template <class F>
 static constexpr bool is_regcall_function_ptr_or_ref_v =
-    is_regcall_function_ptr_or_ref_v<F>::value;
+    is_regcall_function_ptr_or_ref<F>::value;
 #endif // __INVOKE_SIMD_USE_STD_IS_FUNCTION_WA
 
 template <class Callable>

--- a/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
@@ -226,8 +226,9 @@ simd_call_helper(const void *obj_ptr,
   return f(simd_args...);
 };
 
-// TODO
-// This is a workaround for Linux clang behavior which returns false for
+// TODO This is a workaround for libstdc++ version 9 buggy behavior which
+// returns false in the code below. Version 10 works fine. Once required
+// minimum libstdc++ version is bumped to 10, this w/a should be removed.
 //   template <class F> bool foo(F &&f) {
 //     return std::is_function_v<std::remove_reference_t<F>>;
 //   }

--- a/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
@@ -11,25 +11,54 @@
 
 #pragma once
 
+// SYCL extension macro definition as required by the SYCL specification.
 // 1 - Initial extension version. Base features are supported.
 #define SYCL_EXT_ONEAPI_INVOKE_SIMD 1
 
 #include <sycl/ext/oneapi/experimental/uniform.hpp>
 
 #include <std/experimental/simd.hpp>
+#include <sycl/detail/boost/mp11.hpp>
 
-// TODO FIXME dummy implementation to kick-off testing
-constexpr int __builtin_get_reqd_subgroup_size() { return /*FE builtin*/ 16; }
+#include <functional>
+
+// TODOs:
+// * (a) TODO bool translation in spmd2simd.
+// * (b) TODO enforce constness of a functor/lambda's () operator
+// * (c) TODO support lambdas and functors in BE
 
 /// Middle End - to - Back End interface to invoke explicit SIMD functions from
-/// SPMD SYCL context.
-template <class Ret, class F, class... Args>
-Ret __builtin_invoke_simd(F, Args...) SYCL_EXTERNAL
+/// SPMD SYCL context. Must not be used by user code. BEs are expected to
+/// recognize this intrinsic and transform the intrinsic call with a direct call
+/// to the SIMD target, as well as process SPMD arguments in the way described
+/// in the specification for `invoke_simd`.
+/// @tparam SpmdRet the return type. Can be `uniform<T>`.
+/// @tparam SimdCallee the type of the SIMD callee function (the "target"). Must
+///  be a function type (not lambda or functor).
+/// @tparam SpmdArgs The original SPMD arguments passed to the invoke_simd.
+template <bool IsFunc, class SpmdRet, class SimdCallee, class... SpmdArgs,
+          class = std::enable_if_t<!IsFunc>>
+SYCL_EXTERNAL __regcall SpmdRet
+__builtin_invoke_simd(SimdCallee target, const void *obj, SpmdArgs... args)
 #ifdef __SYCL_DEVICE_ONLY__
     ;
 #else
 {
-  throw sycl::exception(sycl::errc::feature_not_supported);
+  // __builtin_invoke_simd is not supported on the host device yet
+  throw feature_not_supported();
+}
+#endif // __SYCL_DEVICE_ONLY__
+
+template <bool IsFunc, class SpmdRet, class SimdCallee, class... SpmdArgs,
+          class = std::enable_if_t<IsFunc>>
+SYCL_EXTERNAL __regcall SpmdRet __builtin_invoke_simd(SimdCallee target,
+                                                      SpmdArgs... args)
+#ifdef __SYCL_DEVICE_ONLY__
+    ;
+#else
+{
+  // __builtin_invoke_simd is not supported on the host device yet
+  throw feature_not_supported();
 }
 #endif // __SYCL_DEVICE_ONLY__
 
@@ -38,59 +67,155 @@ namespace ext {
 namespace oneapi {
 namespace experimental {
 
+// --- Basic definitions prescribed by the spec.
 namespace simd_abi {
+// "Fixed-size simd width of N" ABI based on clang vectors - used as the ABI for
+// SIMD objects this implementation of invoke_simd spec is based on.
 template <class T, int N>
 using native_fixed_size = typename std::experimental::__simd_abi<
     std::experimental::_StorageKind::_VecExt, N>;
 } // namespace simd_abi
 
+// The SIMD object type, which is the generic std::experimental::simd type with
+// the native fixed size ABI.
 template <class T, int N>
 using simd = std::experimental::simd<T, simd_abi::native_fixed_size<T, N>>;
 
+// The SIMD mask object type.
 template <class T, int N>
 using simd_mask =
     std::experimental::simd_mask<T, simd_abi::native_fixed_size<T, N>>;
 
+// --- Helpers
 namespace detail {
-template <class T, int N = __builtin_get_reqd_subgroup_size(), class = void>
-struct spmd2simd;
+
+namespace __MP11_NS = sycl::detail::boost::mp11;
+
+// This structure performs the SPMD-to-SIMD parameter type conversion as defined
+// by the spec.
+template <class T, int N, class = void> struct spmd2simd;
+// * `uniform<T>` converts to `T`
 template <class T, int N> struct spmd2simd<uniform<T>, N> {
   using type = T;
 };
+// * tuple of types converts to tuple of converted tuple element types.
 template <class... T, int N> struct spmd2simd<std::tuple<T...>, N> {
   using type = std::tuple<typename spmd2simd<T, N>::type...>;
 };
+// * arithmetic type converts to a simd vector with this element type and the
+//   width equal to caller's subgroup size and passed as the `N` template
+//   argument.
 template <class T, int N>
 struct spmd2simd<T, N, std::enable_if_t<std::is_arithmetic_v<T>>> {
   using type = simd<T, N>;
 };
-// TODO implement bool translation
 
+// This structure performs the SIMD-to-SPMD return type conversion as defined
+// by the spec.
 template <class, class = void> struct simd2spmd;
+// * `uniform<T>` stays the same
+template <class T> struct simd2spmd<uniform<T>> {
+  using type = uniform<T>;
+};
+// * `simd<T, N>` converts to T
 template <class T, int N> struct simd2spmd<simd<T, N>> {
   using type = T;
 };
+// * tuple of types converts to tuple of converted tuple element types.
 template <class... T> struct simd2spmd<std::tuple<T...>> {
   using type = std::tuple<typename simd2spmd<T>::type...>;
 };
+// * arithmetic type T converts to `uniform<T>`
 template <class T>
 struct simd2spmd<T, std::enable_if_t<std::is_arithmetic_v<T>>> {
   using type = uniform<T>;
 };
 
-// Unwrap the uniform object so that it is passed as underlying type
-template <typename T> struct unwrap {
+// Check if given type is uniform.
+template <class T> struct is_uniform_type : std::false_type {};
+template <class T> struct is_uniform_type<uniform<T>> : std::true_type {
+  using type = T;
+};
+
+// Check if given type is simd or simd_mask.
+template <class T> struct is_simd_or_mask_type : std::false_type {};
+template <class T, int N>
+struct is_simd_or_mask_type<simd<T, N>> : std::true_type {};
+template <class T, int N>
+struct is_simd_or_mask_type<simd_mask<T, N>> : std::true_type {};
+
+// Checks if the return value type and the types of arguments of given
+// SimdCallable are all uniform.
+template <class SimdCallable, class... SpmdArgs> struct has_uniform_signature {
+  constexpr operator bool() {
+    using ArgTypeList = __MP11_NS::mp_list<SpmdArgs...>;
+
+    if constexpr (__MP11_NS::mp_all_of<ArgTypeList, is_uniform_type>::value) {
+      using SimdRet = std::invoke_result_t<SimdCallable, SpmdArgs...>;
+      return is_uniform_type<SimdRet>::value ||
+             !is_simd_or_mask_type<SimdRet>::value;
+    } else {
+      return false;
+    }
+  }
+};
+
+// "Unwraps" a value of the `uniform` type (used before passing to SPMD
+//  arguments to the __builtin_invoke_simd):
+// - the case when there is nothing to unwrap
+template <typename T> struct unwrap_uniform {
   static auto impl(T val) { return val; }
 };
 
-template <typename T> struct unwrap<uniform<T>> {
+// - the real unwrapping case
+template <typename T> struct unwrap_uniform<uniform<T>> {
   static T impl(uniform<T> val) { return val; }
 };
 
-template <class Callable, class... T>
-using SPMDInvokeResult = typename simd2spmd<
-    std::invoke_result_t<Callable, typename spmd2simd<T>::type...>>::type;
+// Deduces subgroup size of the caller based on given SIMD callable and
+// corresponding SPMD arguments it is being invoke with via invoke_simd.
+// Basically, for each supported subgroup size, this meta-function finds out if
+// the callable can be invoked by C++ rules given the SPMD arguments transformed
+// as prescribed by the spec assuming this subgroup size. One and only one
+// subgroup size should conform.
+template <class SimdCallable, class... SpmdArgs> struct sg_size {
+  template <class N>
+  using IsInvocableSgSize = __MP11_NS::mp_bool<std::is_invocable_v<
+      SimdCallable, typename spmd2simd<SpmdArgs, N::value>::type...>>;
+
+  constexpr operator int() {
+    using SupportedSgSizes = __MP11_NS::mp_list_c<int, 1, 2, 4, 8, 16, 32>;
+    using InvocableSgSizes =
+        __MP11_NS::mp_copy_if<SupportedSgSizes, IsInvocableSgSize>;
+    static_assert((__MP11_NS::mp_size<InvocableSgSizes>::value == 1) &&
+                  "no or multiple invoke_simd targets found");
+    return __MP11_NS::mp_front<InvocableSgSizes>::value;
+  }
+};
+
+// Determine the return type of a SIMD callable.
+template <int N, class SimdCallable, class... SpmdArgs>
+using SimdRetType =
+    std::invoke_result_t<SimdCallable,
+                         typename spmd2simd<SpmdArgs, N>::type...>;
+// Determine the return type of an invoke_simd based on the return type of a
+// SIMD callable.
+template <int N, class SimdCallable, class... SpmdArgs>
+using SpmdRetType =
+    typename simd2spmd<SimdRetType<N, SimdCallable, SpmdArgs...>>::type;
+
+template <class SimdCallable, class... SpmdArgs>
+static constexpr int get_sg_size() {
+  if constexpr (has_uniform_signature<SimdCallable, SpmdArgs...>()) {
+    return 0; // subgroup size does not matter then
+  } else {
+    return sg_size<SimdCallable, SpmdArgs...>();
+  }
+}
+
 } // namespace detail
+
+// --- The main API
 
 /// The invoke_simd free function invokes a SIMD function using all work-items
 /// in a sub_group. The invoke_simd interface marshals data between the SPMD
@@ -110,10 +235,44 @@ using SPMDInvokeResult = typename simd2spmd<
 ///   the specification.
 // TODO works only for functions now, enable for other callables.
 template <class Callable, class... T>
-__attribute__((always_inline)) detail::SPMDInvokeResult<Callable, T...>
-invoke_simd(sycl::sub_group sg, Callable &&f, T... args) {
-  using RetSpmd = detail::SPMDInvokeResult<Callable, T...>;
-  return __builtin_invoke_simd<RetSpmd>(f, detail::unwrap<T>::impl(args)...);
+__attribute__((always_inline)) auto invoke_simd(sycl::sub_group sg,
+                                                Callable &&f, T... args) {
+  // If the invoke_simd call site is fully uniform, then it does not matter
+  // what the subgroup size is and arguments don't need widening and return
+  // value does not need shrinking by this library or SPMD compiler, so 0
+  // is fine in this case.
+  constexpr int N = detail::get_sg_size<Callable, T...>();
+  using RetSpmd = detail::SpmdRetType<N, Callable, T...>;
+
+  using CallableNoRef = std::remove_reference_t<Callable>;
+  using CallableNoRefNoPtr = std::remove_pointer_t<CallableNoRef>;
+  constexpr bool is_function = std::is_function_v<CallableNoRefNoPtr>;
+
+  if constexpr (is_function) {
+    return __builtin_invoke_simd<is_function, RetSpmd>(
+        f, detail::unwrap_uniform<T>::impl(args)...);
+  } else {
+    // TODO support functors and lambdas which are handled in this branch.
+    // The limiting factor for now is that the LLVMIR data flow analysis
+    // implemented in LowerInvokeSimd.cpp which, finds actual invoke_simd
+    // target function, can't handle this case yet.
+    return __builtin_invoke_simd<is_function, RetSpmd>(
+        // this magic 'plus' before the lambda (1) requires that the lambda has
+        // no captures and (2) converts it to a function pointer
+        +[](const void *f1,
+            typename detail::spmd2simd<T, N>::type... simd_args) {
+          auto f2 =
+              *reinterpret_cast<const std::remove_reference_t<Callable> *>(f1);
+          return f2(simd_args...);
+        },
+        &f, detail::unwrap_uniform<T>::impl(args)...);
+  }
+// TODO Temporary macro and assert to enable API compilation testing.
+// LowerInvokeSimd.cpp does not support this case yet.
+#ifndef __INVOKE_SIMD_ENABLE_ALL_CALLABLES
+  static_assert(is_function &&
+                "invoke_simd does not support functors or lambdas yet");
+#endif // __INVOKE_SIMD_ENABLE_ALL_CALLABLES
 }
 
 } // namespace experimental

--- a/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
@@ -46,7 +46,7 @@ __builtin_invoke_simd(SimdCallee target, const void *obj, SpmdArgs... args)
 #else
 {
   // __builtin_invoke_simd is not supported on the host device yet
-  throw feature_not_supported();
+  throw sycl::feature_not_supported();
 }
 #endif // __SYCL_DEVICE_ONLY__
 
@@ -59,7 +59,7 @@ SYCL_EXTERNAL __regcall SpmdRet __builtin_invoke_simd(SimdCallee target,
 #else
 {
   // __builtin_invoke_simd is not supported on the host device yet
-  throw feature_not_supported();
+  throw sycl::feature_not_supported();
 }
 #endif // __SYCL_DEVICE_ONLY__
 

--- a/sycl/include/sycl/ext/oneapi/experimental/uniform.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/uniform.hpp
@@ -11,6 +11,7 @@
 
 #pragma once
 
+// SYCL extension macro definition as required by the SYCL specification.
 // 1 - Initial extension version. Base features are supported.
 #define SYCL_EXT_ONEAPI_UNIFORM 1
 
@@ -69,6 +70,12 @@ template <class T> class uniform {
 
 public:
   explicit uniform(T x) noexcept : Val(x) {}
+
+  // TODO provide a ways to reflect this conversion from uniform to T in the IR
+  // so that the compiler can take advantage of uniformness. Could be marked
+  // with some intrinsic call like `__builtin_uniform_unwrap(Val);`
+
+  /// Implicit conversion to the underlying type.
   operator const T() const { return Val; }
 
   uniform &operator=(const uniform &) = delete;

--- a/sycl/include/sycl/ext/oneapi/experimental/uniform.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/uniform.hpp
@@ -26,14 +26,8 @@ template <int> class nd_item;
 template <int> class h_item;
 template <int> class group;
 template <int> class nd_range;
-
-namespace ext {
-namespace oneapi {
-
 struct sub_group;
 
-} // namespace oneapi
-} // namespace ext
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)
 
@@ -73,7 +67,7 @@ template <class T> class uniform {
            !detail::is_instance_of_tmpl_int_v<U, sycl::h_item> &&
            !detail::is_instance_of_tmpl_int_v<U, sycl::group> &&
            !detail::is_instance_of_tmpl_int_v<U, sycl::nd_range> &&
-           !std::is_same_v<U, sycl::ext::oneapi::sub_group>;
+           !std::is_same_v<U, sycl::sub_group>;
   }
   static_assert(can_be_uniform<T>() && "type not allowed to be `uniform`");
 

--- a/sycl/include/sycl/ext/oneapi/experimental/uniform.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/uniform.hpp
@@ -17,16 +17,23 @@
 
 #include <type_traits>
 
+// Forward declarations of types not allowed to be wrapped in uniform:
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
-// Forward declarations of types not allowed to be wrapped in uniform:
+namespace ext {
+namespace oneapi {
+
+struct sub_group;
+
+} // namespace oneapi
+} // namespace ext
 
 template <int, bool> class item;
 template <int> class nd_item;
 template <int> class h_item;
 template <int> class group;
 template <int> class nd_range;
-struct sub_group;
+using ext::oneapi::sub_group;
 
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/sycl/ext/oneapi/experimental/uniform.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/uniform.hpp
@@ -17,6 +17,7 @@
 
 #include <type_traits>
 
+__SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 // Forward declarations of types not allowed to be wrapped in uniform:
 
@@ -31,9 +32,17 @@ namespace oneapi {
 
 struct sub_group;
 
-namespace experimental {
+} // namespace oneapi
+} // namespace ext
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)
 
+namespace sycl {
+namespace ext {
+namespace oneapi {
+namespace experimental {
 namespace detail {
+
 template <class T, template <int> class Tmpl>
 struct is_instance_of_tmpl_int : std::false_type {};
 template <int N, template <int> class T, template <int> class Tmpl>

--- a/sycl/include/sycl/ext/oneapi/experimental/uniform.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/uniform.hpp
@@ -1,0 +1,100 @@
+//==------ uniform.hpp - SYCL uniform extension --------*- C++ -*-----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===--------------------------------------------------------------------=== //
+// Implemenation of the sycl_ext_oneapi_uniform extension.
+// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_uniform.asciidoc
+// ===--------------------------------------------------------------------=== //
+
+#pragma once
+
+// 1 - Initial extension version. Base features are supported.
+#define SYCL_EXT_ONEAPI_UNIFORM 1
+
+#include <type_traits>
+
+namespace sycl {
+// Forward declarations of types not allowed to be wrapped in uniform:
+
+template <int, bool> class item;
+template <int> class nd_item;
+template <int> class h_item;
+template <int> class group;
+template <int> class nd_range;
+
+namespace ext {
+namespace oneapi {
+
+struct sub_group;
+
+namespace experimental {
+
+namespace detail {
+template <class T, template <int> class Tmpl>
+struct is_instance_of_tmpl_int : std::false_type {};
+template <int N, template <int> class T, template <int> class Tmpl>
+struct is_instance_of_tmpl_int<T<N>, Tmpl>
+    : std::conditional<std::is_same_v<T<N>, Tmpl<N>>, std::true_type,
+                       std::false_type> {};
+template <class T, template <int> class Tmpl>
+static inline constexpr bool is_instance_of_tmpl_int_v =
+    is_instance_of_tmpl_int<T, Tmpl>::value;
+
+template <class T, template <int, bool> class Tmpl>
+struct is_instance_of_tmpl_int_bool : std::false_type {};
+template <int N, bool X, template <int, bool> class T,
+          template <int, bool> class Tmpl>
+struct is_instance_of_tmpl_int_bool<T<N, X>, Tmpl>
+    : std::conditional<std::is_same_v<T<N, X>, Tmpl<N, X>>, std::true_type,
+                       std::false_type> {};
+template <class T, template <int, bool> class Tmpl>
+static inline constexpr bool is_instance_of_tmpl_int_bool_v =
+    is_instance_of_tmpl_int_bool<T, Tmpl>::value;
+} // namespace detail
+
+template <class T> class uniform {
+  template <class U> static constexpr bool can_be_uniform() {
+    return !detail::is_instance_of_tmpl_int_v<U, sycl::id> &&
+           !detail::is_instance_of_tmpl_int_bool_v<U, sycl::item> &&
+           !detail::is_instance_of_tmpl_int_v<U, sycl::nd_item> &&
+           !detail::is_instance_of_tmpl_int_v<U, sycl::h_item> &&
+           !detail::is_instance_of_tmpl_int_v<U, sycl::group> &&
+           !detail::is_instance_of_tmpl_int_v<U, sycl::nd_range> &&
+           !std::is_same_v<U, sycl::ext::oneapi::sub_group>;
+  }
+  static_assert(can_be_uniform<T>() && "type not allowed to be `uniform`");
+
+public:
+  explicit uniform(T x) noexcept : Val(x) {}
+  operator const T() const { return Val; }
+
+  uniform &operator=(const uniform &) = delete;
+
+  /* Other explicitly deleted operators improve error messages
+     if a user incorrectly attempts to modify a uniform */
+  uniform &operator+=(const T &) = delete;
+  uniform &operator-=(const T &) = delete;
+  uniform &operator*=(const T &) = delete;
+  uniform &operator/=(const T &) = delete;
+  uniform &operator%=(const T &) = delete;
+  uniform &operator&=(const T &) = delete;
+  uniform &operator|=(const T &) = delete;
+  uniform &operator^=(const T &) = delete;
+  uniform &operator<<=(const T &) = delete;
+  uniform &operator>>=(const T &) = delete;
+  uniform &operator++() = delete;
+  uniform &operator++(int) = delete;
+  uniform &operator--() = delete;
+  uniform &operator--(int) = delete;
+
+private:
+  T Val;
+};
+
+} // namespace experimental
+} // namespace oneapi
+} // namespace ext
+} // namespace sycl

--- a/sycl/test/esimd/simd_view.cpp
+++ b/sycl/test/esimd/simd_view.cpp
@@ -113,7 +113,7 @@ SYCL_ESIMD_FUNCTION void test_simd_view_from_vector() {
   simd_view sv16b(v16);
   // expected-error@+5 {{no matching constructor for initialization of 'simd_view}}
   // expected-note@sycl/ext/intel/esimd/simd_view.hpp:* 3 {{candidate }}
-  // expected-note@sycl/ext/intel/esimd/simd.hpp:* {{candidate }}
+  // expected-note@sycl/ext/intel/esimd/simd.hpp:* 2 {{candidate }}
   // expected-note@sycl/ext/intel/esimd/detail/simd_obj_impl.hpp:* {{candidate }}
   // expected-note@sycl/ext/intel/esimd/simd_view.hpp:* 2 {{candidate }}
   simd_view<simd<int, 16>, region_base<false, int, 1, 1, 16, 1>> sv16c(

--- a/sycl/test/invoke_simd/invoke_simd.cpp
+++ b/sycl/test/invoke_simd/invoke_simd.cpp
@@ -276,9 +276,9 @@ void ordinary_func();
 
 // clang-format off
 void check_f(
-  int(*func_ptr)(float*), int(__regcall* func_ptr_regcall)(float*),
-  int(&func_ref)(float*), int(__regcall& func_ref_regcall)(float*),
-  int(func)(float*), int(__regcall func_regcall)(float*)) {
+  int(*func_ptr)(float*), int(__regcall* func_ptr_regcall)(float*, int),
+  int(&func_ref)(), int(__regcall& func_ref_regcall)(int*),
+  int(func)(float), int(__regcall func_regcall)(int)) {
 
   assert_is_func(SIMD_CALLEE);
   assert_is_func(ordinary_func);

--- a/sycl/test/invoke_simd/invoke_simd.cpp
+++ b/sycl/test/invoke_simd/invoke_simd.cpp
@@ -1,0 +1,151 @@
+// RUN: %clangxx -c -fsycl %s
+
+// The tests checks that invoke_simd API is compileable.
+
+#include <CL/sycl.hpp>
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
+#include <sycl/ext/oneapi/experimental/uniform.hpp>
+
+#include <functional>
+#include <iostream>
+#include <type_traits>
+
+using namespace sycl::ext::oneapi::experimental;
+namespace esimd = sycl::ext::intel::esimd;
+constexpr int VL = 16;
+
+__attribute__((always_inline)) esimd::simd<float, VL>
+ESIMD_CALLEE(float *A, esimd::simd<float, VL> b, int i) SYCL_ESIMD_FUNCTION {
+  esimd::simd<float, VL> a;
+  a.copy_from(A + i);
+  return a + b;
+}
+
+SYCL_EXTERNAL
+simd<float, VL> __regcall SIMD_CALLEE(float *A, simd<float, VL> b,
+                                      int i) SYCL_ESIMD_FUNCTION;
+
+float SPMD_CALLEE(float *A, float b, int i) { return A[i] + b; }
+
+using namespace cl::sycl;
+
+class ESIMDSelector : public device_selector {
+  // Require GPU device unless HOST is requested in SYCL_DEVICE_FILTER env
+  virtual int operator()(const device &device) const {
+    if (const char *dev_filter = getenv("SYCL_DEVICE_FILTER")) {
+      std::string filter_string(dev_filter);
+      if (filter_string.find("gpu") != std::string::npos)
+        return device.is_gpu() ? 1000 : -1;
+      if (filter_string.find("host") != std::string::npos)
+        return device.is_host() ? 1000 : -1;
+      std::cerr
+          << "Supported 'SYCL_DEVICE_FILTER' env var values are 'gpu' and "
+             "'host', '"
+          << filter_string << "' does not contain such substrings.\n";
+      return -1;
+    }
+    // If "SYCL_DEVICE_FILTER" not defined, only allow gpu device
+    return device.is_gpu() ? 1000 : -1;
+  }
+};
+
+inline auto createExceptionHandler() {
+  return [](exception_list l) {
+    for (auto ep : l) {
+      try {
+        std::rethrow_exception(ep);
+      } catch (cl::sycl::exception &e0) {
+        std::cout << "sycl::exception: " << e0.what() << std::endl;
+      } catch (std::exception &e) {
+        std::cout << "std::exception: " << e.what() << std::endl;
+      } catch (...) {
+        std::cout << "generic exception\n";
+      }
+    }
+  };
+}
+
+#ifndef INVOKE_SIMD
+#define INVOKE_SIMD 1
+#endif
+
+int main(void) {
+  constexpr unsigned Size = 1024;
+  constexpr unsigned GroupSize = 4 * VL;
+
+  queue q(ESIMDSelector{}, createExceptionHandler());
+
+  auto dev = q.get_device();
+  std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+  auto ctxt = q.get_context();
+  // TODO: release memory in the end of the test
+  float *A =
+      static_cast<float *>(malloc_shared(Size * sizeof(float), dev, ctxt));
+  float *B =
+      static_cast<float *>(malloc_shared(Size * sizeof(float), dev, ctxt));
+  float *C =
+      static_cast<float *>(malloc_shared(Size * sizeof(float), dev, ctxt));
+
+  for (unsigned i = 0; i < Size; ++i) {
+    A[i] = B[i] = i;
+    C[i] = -1;
+  }
+
+  cl::sycl::range<1> GlobalRange{Size};
+  // Number of workitems in each workgroup.
+  cl::sycl::range<1> LocalRange{GroupSize};
+
+  cl::sycl::nd_range<1> Range(GlobalRange, LocalRange);
+
+  try {
+    auto e = q.submit([&](handler &cgh) {
+      cgh.parallel_for<class Test>(
+          Range, [=](nd_item<1> ndi) [[intel::reqd_sub_group_size(VL)]] {
+            sub_group sg = ndi.get_sub_group();
+            group<1> g = ndi.get_group();
+            uint32_t i =
+                sg.get_group_linear_id() * VL + g.get_linear_id() * GroupSize;
+            uint32_t wi_id = i + sg.get_local_id();
+
+#if INVOKE_SIMD != 0
+            float res =
+                invoke_simd(sg, SIMD_CALLEE, uniform{A}, B[wi_id], uniform{i});
+#else
+        float res = SPMD_CALLEE(A, B[wi_id], wi_id);
+#endif
+            C[wi_id] = res;
+          });
+    });
+    e.wait();
+  } catch (cl::sycl::exception const &e) {
+    std::cout << "SYCL exception caught: " << e.what() << '\n';
+    return e.get_cl_code();
+  }
+
+  int err_cnt = 0;
+
+  for (unsigned i = 0; i < Size; ++i) {
+    if (A[i] + B[i] != C[i]) {
+      if (++err_cnt < 10) {
+        std::cout << "failed at index " << i << ", " << C[i] << " != " << A[i]
+                  << " + " << B[i] << "\n";
+      }
+    }
+  }
+  if (err_cnt > 0) {
+    std::cout << "  pass rate: "
+              << ((float)(Size - err_cnt) / (float)Size) * 100.0f << "% ("
+              << (Size - err_cnt) << "/" << Size << ")\n";
+  }
+
+  std::cout << (err_cnt > 0 ? "FAILED\n" : "Passed\n");
+  return err_cnt > 0 ? 1 : 0;
+}
+
+SYCL_EXTERNAL
+simd<float, VL> __regcall SIMD_CALLEE(float *A, simd<float, VL> b,
+                                      int i) SYCL_ESIMD_FUNCTION {
+  esimd::simd<float, VL> res = ESIMD_CALLEE(A, b, i);
+  return res;
+}


### PR DESCRIPTION
- invoke_simd:
https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_invoke_simd.asciidoc
  Current limitations:
  * bool parameter type not supported
 
  Based on POC by @rolandschulz.

- uniform:
https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_uniform.asciidoc

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>