### PR TITLE
[SYCL][CUDA] Added IPSCCP pass to O0 by default

### DIFF
--- a/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
@@ -37,6 +37,7 @@
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/Scalar/GVN.h"
 #include "llvm/Transforms/Vectorize.h"
+#include "llvm/Transforms/IPO.h"
 #include <cassert>
 #include <string>
 
@@ -62,6 +63,12 @@ static cl::opt<bool> UseShortPointersOpt(
     cl::desc(
         "Use 32-bit pointers for accessing const/local/shared address spaces."),
     cl::init(false), cl::Hidden);
+
+static cl::opt<bool>
+    UseIPSCCPO0("use-ipsccp-nvptx-O0",
+                cl::desc("Use IPSCCP pass at O0 as a temp solution for "
+                         "nvvm-reflect dead-code errors."),
+                cl::init(true), cl::Hidden);
 
 namespace llvm {
 
@@ -326,6 +333,10 @@ void NVPTXPassConfig::addIRPasses() {
   // call addEarlyAsPossiblePasses.
   const NVPTXSubtarget &ST = *getTM<NVPTXTargetMachine>().getSubtargetImpl();
   addPass(createNVVMReflectPass(ST.getSmVersion()));
+
+  if (getOptLevel() == CodeGenOpt::None && UseIPSCCPO0) {
+    addPass(createIPSCCPPass());
+  }
 
   // FIXME: should the target triple check be done by the pass itself?
   // See createNVPTXLowerArgsPass as an example

--- a/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
@@ -33,11 +33,11 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Target/TargetMachine.h"
 #include "llvm/Target/TargetOptions.h"
+#include "llvm/Transforms/IPO.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 #include "llvm/Transforms/Scalar.h"
 #include "llvm/Transforms/Scalar/GVN.h"
 #include "llvm/Transforms/Vectorize.h"
-#include "llvm/Transforms/IPO.h"
 #include <cassert>
 #include <string>
 

--- a/llvm/test/CodeGen/NVPTX/param-load-store.ll
+++ b/llvm/test/CodeGen/NVPTX/param-load-store.ll
@@ -1,5 +1,5 @@
 ; Verifies correctness of load/store of parameters and return values.
-; RUN: llc < %s -march=nvptx64 -mcpu=sm_35 -O0 -verify-machineinstrs | FileCheck -allow-deprecated-dag-overlap %s
+; RUN: llc < %s -march=nvptx64 -mcpu=sm_35 -O0 -verify-machineinstrs -use-ipsccp-nvptx-O0=false | FileCheck -allow-deprecated-dag-overlap %s
 
 %s_i1 = type { i1 }
 %s_i8 = type { i8 }

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -825,6 +825,18 @@ which contains all the symbols required.
   significantly slower but matches the default precision used by `nvcc`, and
   this `clang++` flag is equivalent to the `nvcc` `-prec-sqrt` flag, except that
   it defaults to `false`.
+* No Opt (O0) uses the IPSCCP compiler pass by default, although the IPSCCP pass
+  can be switched off at O0 using the `-mllvm -use-ipsccp-nvptx-O0=false` flag at
+  the user's discretion.
+  The reason that the IPSCCP pass is used by default even at O0 is that there is
+  currently an unresolved issue with the nvvm-reflect compiler pass: This pass is
+  used to pick the correct branches depending on the SM version which can be
+  optionally specified by the `--cuda-gpu-arch` flag.
+  If the arch flag is not specified by the user, the default value, SM 50, is used.
+  Without the execution of the IPSCCP pass at -O0 when using a low SM version,
+  dead instructions which require a higher SM version can remain. Since
+  corresponding issues occur in other backends future work will aim for a
+  universal solution to these issues.
 
 ### HIP back-end limitations
 


### PR DESCRIPTION
The IPSCCP pass can set branch conditions to ConstInt and swap conditional branches to unconditional branches.
This is necessary at O0 in the nvptx backend in cases where the `nvvm_reflect` function is used: after the nvvm-reflect pass is called, dead branches containing unused instructions aimed at a different architecture generation (SM version) to the one compiled for can remain.

A solution only targeting branches that are using the `nvvm_reflect` function was initially explored by adding a patch to the existing nvvm-reflect pass.  This solution would require considering several cases and was abandoned in favour of a simple comprehensive solution of simply adding the IPSCCP pass to OO: since after discussions it turned out that other backends face a corresponding issue, it was decided that a simple temporary DPC++ solution is favoured and that later on in the year a permanent general solution will be worked on.

New backend flag `use-ipsccp-nvptx-O0` can remove the IPSCCP pass from O0 when set false, at the users discretion.