### PR TITLE
[SYCL][CUDA] Don't link pi_cuda against libsycl

### DIFF
--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -98,8 +98,6 @@ function(add_sycl_rt_library LIB_NAME)
       OpenCL-ICD
       ${CMAKE_DL_LIBS}
       ${CMAKE_THREAD_LIBS_INIT}
-    PUBLIC
-      $<$<BOOL:${SYCL_BUILD_PI_CUDA}>:pi_cuda>
   )
 
   add_common_options(${LIB_NAME} ${LIB_OBJ_NAME})


### PR DESCRIPTION
The plugins are dynamically loaded and shouldn't be linked against
libsycl.

In this case it meant that a build of libsycl with the CUDA plugin
enabled was unusable on a system where CUDA isn't installed, even when
using other plugins or the host device.

When the plugins are dynamically loaded, if some dependencies are
missing the plugins will just be skipped instead of crashing the
application.