### PR TITLE
[ESIMD] Fix minor bug in ballot SFINAE filtering.

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/math.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/math.hpp
@@ -682,7 +682,7 @@ pack_mask(simd_mask<N> src0) {
 /// the source operand is non-zero and unset otherwise.
 template <typename T, int N>
 __ESIMD_API
-    std::enable_if_t<detail::is_type<T, ushort, uint> && (N > 0 && N <= 32),
+    std::enable_if_t<detail::is_type<T, ushort, uint>() && (N > 0 && N <= 32),
                      uint>
     ballot(simd<T, N> mask) {
   simd_mask<N> cmp = (mask != 0);


### PR DESCRIPTION
It lead to the following warning below and allowing unintended types:
...sycl/ext/intel/esimd/math.hpp:685:22: warning: address of function 'detail::is_type<unsigned short, cl::sycl::ext::intel::esimd::ushort, cl::sycl::ext::intel::esimd::uint>' will always
      evaluate to 'true' [-Wpointer-bool-conversion]
    std::enable_if_t<detail::is_type<T, ushort, uint> && (N > 0 && N <= 32),
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ~~

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>