### PR TITLE
[SYCL][ESIMD] Change esimd-verifier logic for detecting valid SYCL calls

### DIFF
--- a/sycl/test/esimd/esimd_verify.cpp
+++ b/sycl/test/esimd/esimd_verify.cpp
@@ -3,6 +3,7 @@
 // RUN: not %clangxx -fsycl -fsycl-device-only -flegacy-pass-manager -O0 -S %s -o /dev/null 2>&1 | FileCheck %s
 // RUN: not %clangxx -fsycl -fsycl-device-only -fno-legacy-pass-manager -O0 -S %s -o /dev/null 2>&1 | FileCheck %s
 
+#include <CL/sycl.hpp>
 #include <sycl/ext/intel/esimd.hpp>
 
 using namespace cl::sycl;
@@ -10,6 +11,7 @@ using namespace sycl::ext::intel::esimd;
 
 // CHECK-DAG: error: function 'cl::sycl::multi_ptr<{{.+}}> cl::sycl::accessor<{{.+}}>::get_pointer<{{.+}}>() const' is not supported in ESIMD context
 // CHECK-DAG: error: function '{{.+}} cl::sycl::accessor<{{.+}}>::operator[]<{{.+}}>({{.+}}) const' is not supported in ESIMD context
+// CHECK-DAG: error: function 'cl::sycl::ext::oneapi::detail::reducer<int, std::plus<int>, void>::combine(int const&)' is not supported in ESIMD context
 
 SYCL_EXTERNAL auto
 test(accessor<int, 1, access::mode::read_write, access::target::device> &acc)
@@ -21,4 +23,11 @@ SYCL_EXTERNAL void
 test1(accessor<int, 1, access::mode::read_write, access::target::device> &acc)
     SYCL_ESIMD_FUNCTION {
   acc[0] = 0;
+}
+
+void test2(sycl::handler &cgh, int *buf) {
+  auto reduction = sycl::reduction(buf, sycl::plus<int>());
+  cgh.parallel_for<class Test2>(sycl::range<1>(1), reduction,
+                                [=](sycl::id<1>, auto &reducer)
+                                    SYCL_ESIMD_KERNEL { reducer.combine(15); });
 }


### PR DESCRIPTION
Instead of having a list of invalid cl::sycl::* functions esimd-verifier now
has a list of valid cl::sycl::* functions that are allowed for use in ESIMD
context. All other SYCL functions are considered invalid.

Signed-off-by: Sergey Dmitriev <serguei.n.dmitriev@intel.com>