### PR TITLE
[SYCL][CUDA][DOC] GettingStartedGuide.md to recommend cuda 11.6

### DIFF
--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -171,7 +171,7 @@ Windows DPC++ toolchain, but add the `--cuda` flag to `configure.py`. Note,
 the CUDA backend has Windows support; windows subsystem for
 linux (WSL) is not needed to build and run the CUDA backend.
 
-Enabling this flag requires an installation of
+Enabling this flag requires an installation of at least
 [CUDA 10.2](https://developer.nvidia.com/cuda-10.2-download-archive) on
 the system, refer to
 [NVIDIA CUDA Installation Guide for Linux](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html)


### PR DESCRIPTION
An issue with CUDA toolkit versions prior to 11.6 has been identified: https://github.com/intel/llvm/issues/5648 https://github.com/intel/llvm/issues/4436

We now recommend that users install CUDA toolkit 11.6 and later for use with DPC++.

Note that the following line

"Currently, the only combination tested is Ubuntu 18.04 with CUDA 10.2 using
a Titan RTX GPU (SM 71)."

could also potentially be updated here. I just want to check that the semantics of this sentence is not meant to mean that this is the only combination that is consistently tested via the CI?