### PR TITLE
[CI] Roll back intel driver to the latest version

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -39,7 +39,7 @@ on:
       intel_drivers_image:
         type: string
         required: false
-        default: "ghcr.io/intel/llvm/ubuntu2004_intel_drivers:unstable"
+        default: "ghcr.io/intel/llvm/ubuntu2004_intel_drivers:latest"
       lts_config:
         type: string
         required: false


### PR DESCRIPTION
Revert accidentally committed change in https://github.com/intel/llvm/commit/a618ca76e01a4be51dc27fdd8e1b85b0f805f203.