### PR TITLE
[SYCL][Driver] Pass -emit-param-info (almost) unconditionally

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9541,11 +9541,7 @@ void SYCLPostLink::ConstructJob(Compilation &C, const JobAction &JA,
   // OPT_fsycl_device_code_split is not checked as it is an alias to
   // -fsycl-device-code-split=auto
 
-  // Turn on Dead Parameter Elimination Optimization with early optimizations
-  if (!(getToolChain().getTriple().isAMDGCN()) &&
-      TCArgs.hasFlag(options::OPT_fsycl_dead_args_optimization,
-                     options::OPT_fno_sycl_dead_args_optimization,
-                     isSYCLOptimizationO2orHigher(TCArgs)))
+  if (!(getToolChain().getTriple().isAMDGCN()))
     addArgs(CmdArgs, TCArgs, {"-emit-param-info"});
   // Enable PI program metadata
   if (getToolChain().getTriple().isNVPTX())

--- a/clang/test/Driver/sycl-device-optimizations.cpp
+++ b/clang/test/Driver/sycl-device-optimizations.cpp
@@ -43,7 +43,7 @@
 // RUN:   %clang_cl -### -fsycl -fno-sycl-dead-args-optimization %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-NO-DAE %s
 // CHECK-NO-DAE-NOT: clang{{.*}} "-fenable-sycl-dae"
-// CHECK-NO-DAE-NOT: sycl-post-link{{.*}} "-emit-param-info"
+// CHECK-NO-DAE: sycl-post-link{{.*}} "-emit-param-info"
 
 // Check "-fgpu-inline-threshold" is passed to the front-end:
 // RUN:   %clang -### -fsycl -fgpu-inline-threshold=100000 %s 2>&1 \


### PR DESCRIPTION
Motivation behind this change is that user can set different
optimization levels at compil and link stages when separate compilation
is performed:
```
clang++ -fsycl -c a.cpp -O2 -o a.o
clang++ -fsycl a.o -O0 -o a.out
```

In such situation, compile step launches dead argument eliminination
optimization, which could alter kernels signature. However, during the
link step `-emit-param-info` weren't passed until this commit and
without that information runtime is not capable to handle altered
kernel signature (with arguments being optimized out).