### PR TITLE
[SYCL] Call piProgramLink per device for L0 plugin 

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2052,8 +2052,9 @@ cl_int enqueueImpKernel(
   if (KernelBundleImplPtr && !KernelBundleImplPtr->isInterop()) {
     kernel_id KernelID =
         detail::ProgramManager::getInstance().getSYCLKernelID(KernelName);
-    kernel SyclKernel =
-        KernelBundleImplPtr->get_kernel(KernelID, KernelBundleImplPtr);
+    kernel SyclKernel = KernelBundleImplPtr->get_kernel(
+        KernelID, createSyclObjFromImpl<device>(DeviceImpl),
+        KernelBundleImplPtr);
 
     SyclKernelImpl = detail::getSyclObjImpl(SyclKernel);
 


### PR DESCRIPTION
L0 supports piprogramLink only with single device.
Since compilation & linking for kernel bundle is done for all devices in context -> this limitation will led to runtime error.
What is done:
1) do per device piProgramLink calls in case of context on L0 plugin
2) add get_kernel version to accept device to choose kernel based on kernelId and compatibility with device.
3) enqueueImpKernel will search for appropriate kernel version compatible with device

Note: right now, piextDeviceSelectBinary in L0 do not do analysis if binary was compiled for the device
Note2: piProgramCompile in L0 do not do actual job and all is done in piProgramLink.


Signed-off-by: Tikhomirova, Kseniya <kseniya.tikhomirova@intel.com>