### PR TITLE
[SYCL][ESIMD][EMU] Merging buffer/image info to surface info

### DIFF
--- a/sycl/plugins/esimd_emulator/pi_esimd_emulator.cpp
+++ b/sycl/plugins/esimd_emulator/pi_esimd_emulator.cpp
@@ -1005,12 +1005,12 @@ pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
   int Status = cm_support::CM_FAILURE;
 
   if (Flags & PI_MEM_FLAGS_HOST_PTR_USE) {
-    CmBuf.tag = cm_surface_ptr_t::type_user_provided_buffer;
+    CmBuf.tag = cm_surface_ptr_t::TypeUserProvidedBuffer;
     Status = Context->Device->CmDevicePtr->CreateBufferUP(
         static_cast<unsigned int>(Size), HostPtr, CmBuf.UPBufPtr);
     CmBuf.UPBufPtr->GetIndex(CmIndex);
   } else {
-    CmBuf.tag = cm_surface_ptr_t::type_regular_buffer;
+    CmBuf.tag = cm_surface_ptr_t::TypeRegularBuffer;
     Status = Context->Device->CmDevicePtr->CreateBuffer(
         static_cast<unsigned int>(Size), CmBuf.RegularBufPtr);
     CmBuf.RegularBufPtr->GetIndex(CmIndex);
@@ -1068,20 +1068,19 @@ pi_result piMemRelease(pi_mem Mem) {
   if (--(Mem->RefCount) == 0) {
     int Status = cm_support::CM_FAILURE;
 
-    if (Mem->SurfacePtr.tag == cm_surface_ptr_t::type_user_provided_buffer) {
+    if (Mem->SurfacePtr.tag == cm_surface_ptr_t::TypeUserProvidedBuffer) {
       _pi_buffer *PiBuf = static_cast<_pi_buffer *>(Mem);
       Status = Mem->Context->Device->CmDevicePtr->DestroyBufferUP(
           PiBuf->SurfacePtr.UPBufPtr);
-    } else if (Mem->SurfacePtr.tag == cm_surface_ptr_t::type_regular_buffer) {
+    } else if (Mem->SurfacePtr.tag == cm_surface_ptr_t::TypeRegularBuffer) {
       _pi_buffer *PiBuf = static_cast<_pi_buffer *>(Mem);
       Status = Mem->Context->Device->CmDevicePtr->DestroySurface(
           PiBuf->SurfacePtr.RegularBufPtr);
-    } else if (Mem->SurfacePtr.tag ==
-               cm_surface_ptr_t::type_user_provided_image) {
+    } else if (Mem->SurfacePtr.tag == cm_surface_ptr_t::TypeUserProvidedImage) {
       _pi_image *PiImg = static_cast<_pi_image *>(Mem);
       Status = Mem->Context->Device->CmDevicePtr->DestroySurface2DUP(
           PiImg->SurfacePtr.UPImgPtr);
-    } else if (Mem->SurfacePtr.tag == cm_surface_ptr_t::type_regular_image) {
+    } else if (Mem->SurfacePtr.tag == cm_surface_ptr_t::TypeRegularImage) {
       _pi_image *PiImg = static_cast<_pi_image *>(Mem);
       Status = Mem->Context->Device->CmDevicePtr->DestroySurface(
           PiImg->SurfacePtr.RegularImgPtr);
@@ -1212,14 +1211,14 @@ pi_result piMemImageCreate(pi_context Context, pi_mem_flags Flags,
   int Status = cm_support::CM_SUCCESS;
 
   if (Flags & PI_MEM_FLAGS_HOST_PTR_USE) {
-    CmImg.tag = cm_surface_ptr_t::type_user_provided_image;
+    CmImg.tag = cm_surface_ptr_t::TypeUserProvidedImage;
     Status = Context->Device->CmDevicePtr->CreateSurface2DUP(
         static_cast<unsigned int>(ImageDesc->image_width),
         static_cast<unsigned int>(ImageDesc->image_height), CmSurfFormat,
         HostPtr, CmImg.UPImgPtr);
     CmImg.UPImgPtr->GetIndex(CmIndex);
   } else {
-    CmImg.tag = cm_surface_ptr_t::type_regular_image;
+    CmImg.tag = cm_surface_ptr_t::TypeRegularImage;
     Status = Context->Device->CmDevicePtr->CreateSurface2D(
         static_cast<unsigned int>(ImageDesc->image_width),
         static_cast<unsigned int>(ImageDesc->image_height), CmSurfFormat,
@@ -1495,12 +1494,12 @@ pi_result piEnqueueMemBufferRead(pi_queue Queue, pi_mem Src,
     RetEv->IsDummyEvent = true;
   }
 
-  if (buf->SurfacePtr.tag == cm_surface_ptr_t::type_user_provided_buffer) {
+  if (buf->SurfacePtr.tag == cm_surface_ptr_t::TypeUserProvidedBuffer) {
     // CM does not provide 'ReadSurface' call for 'User-Provided'
     // Surface. memcpy is used for BufferRead PI_API call.
     memcpy(Dst, buf->MapHostPtr, Size);
   } else {
-    assert(buf->SurfacePtr.tag == cm_surface_ptr_t::type_regular_buffer);
+    assert(buf->SurfacePtr.tag == cm_surface_ptr_t::TypeRegularBuffer);
     int Status = buf->SurfacePtr.RegularBufPtr->ReadSurface(
         reinterpret_cast<unsigned char *>(Dst),
         nullptr, // event
@@ -1669,12 +1668,12 @@ pi_result piEnqueueMemImageRead(pi_queue CommandQueue, pi_mem Image,
   }
 
   size_t Size = RowPitch * (Region->height);
-  if (PiImg->SurfacePtr.tag == cm_surface_ptr_t::type_user_provided_image) {
+  if (PiImg->SurfacePtr.tag == cm_surface_ptr_t::TypeUserProvidedImage) {
     // CM does not provide 'ReadSurface' call for 'User-Provided'
     // Surface. memcpy is used for ImageRead PI_API call.
     memcpy(Ptr, PiImg->MapHostPtr, Size);
   } else {
-    assert(PiImg->SurfacePtr.tag == cm_surface_ptr_t::type_regular_image);
+    assert(PiImg->SurfacePtr.tag == cm_surface_ptr_t::TypeRegularImage);
     int Status = PiImg->SurfacePtr.RegularImgPtr->ReadSurface(
         reinterpret_cast<unsigned char *>(Ptr),
         nullptr, // event
@@ -1939,20 +1938,19 @@ pi_result piTearDown(void *) {
     }
     int Status = cm_support::CM_FAILURE;
 
-    if (Mem->SurfacePtr.tag == cm_surface_ptr_t::type_user_provided_buffer) {
+    if (Mem->SurfacePtr.tag == cm_surface_ptr_t::TypeUserProvidedBuffer) {
       _pi_buffer *PiBuf = static_cast<_pi_buffer *>(Mem);
       Status = Mem->Context->Device->CmDevicePtr->DestroyBufferUP(
           PiBuf->SurfacePtr.UPBufPtr);
-    } else if (Mem->SurfacePtr.tag == cm_surface_ptr_t::type_regular_buffer) {
+    } else if (Mem->SurfacePtr.tag == cm_surface_ptr_t::TypeRegularBuffer) {
       _pi_buffer *PiBuf = static_cast<_pi_buffer *>(Mem);
       Status = Mem->Context->Device->CmDevicePtr->DestroySurface(
           PiBuf->SurfacePtr.RegularBufPtr);
-    } else if (Mem->SurfacePtr.tag ==
-               cm_surface_ptr_t::type_user_provided_image) {
+    } else if (Mem->SurfacePtr.tag == cm_surface_ptr_t::TypeUserProvidedImage) {
       _pi_image *PiImg = static_cast<_pi_image *>(Mem);
       Status = Mem->Context->Device->CmDevicePtr->DestroySurface2DUP(
           PiImg->SurfacePtr.UPImgPtr);
-    } else if (Mem->SurfacePtr.tag == cm_surface_ptr_t::type_regular_image) {
+    } else if (Mem->SurfacePtr.tag == cm_surface_ptr_t::TypeRegularImage) {
       _pi_image *PiImg = static_cast<_pi_image *>(Mem);
       Status = Mem->Context->Device->CmDevicePtr->DestroySurface(
           PiImg->SurfacePtr.RegularImgPtr);

--- a/sycl/plugins/esimd_emulator/pi_esimd_emulator.hpp
+++ b/sycl/plugins/esimd_emulator/pi_esimd_emulator.hpp
@@ -52,6 +52,8 @@ struct _pi_object {
   _pi_object() : RefCount{1} {}
 
   std::atomic<pi_uint32> RefCount;
+
+  virtual ~_pi_object() = default;
 };
 struct _pi_platform {
   _pi_platform() = default;
@@ -127,8 +129,6 @@ struct cm_surface_ptr_t {
 };
 
 struct _pi_mem : _pi_object {
-  _pi_mem() = default;
-
   pi_context Context;
 
   // To be used for piEnqueueMemBufferMap

--- a/sycl/plugins/esimd_emulator/pi_esimd_emulator.hpp
+++ b/sycl/plugins/esimd_emulator/pi_esimd_emulator.hpp
@@ -158,6 +158,9 @@ struct _pi_mem : _pi_object {
 
   cm_surface_ptr_t SurfacePtr;
 
+  // Destructor for invoking buffer/image destory calls in CM Runtime
+  ~_pi_mem();
+
 protected:
   _pi_mem(pi_context ctxt, char *HostPtr, cm_surface_ptr_t SurfacePtrArg,
           unsigned int SurfaceIdxArg)

--- a/sycl/plugins/esimd_emulator/pi_esimd_emulator.hpp
+++ b/sycl/plugins/esimd_emulator/pi_esimd_emulator.hpp
@@ -110,13 +110,13 @@ struct cm_surface_ptr_t {
   // Buffer/Image created with PI_MEM_FLAGS_HOST_PTR_USE option in
   // SYCL
   enum SurfaceType {
-    type_none,
-    type_regular_buffer,
-    type_user_provided_buffer,
-    type_regular_image,
-    type_user_provided_image
+    TypeNone,
+    TypeRegularBuffer,
+    TypeUserProvidedBuffer,
+    TypeRegularImage,
+    TypeUserProvidedImage
   };
-  SurfaceType tag = type_none;
+  SurfaceType tag = TypeNone;
 
   union {
     cm_support::CmBuffer *RegularBufPtr = nullptr;

--- a/sycl/plugins/esimd_emulator/pi_esimd_emulator.hpp
+++ b/sycl/plugins/esimd_emulator/pi_esimd_emulator.hpp
@@ -105,6 +105,27 @@ struct _pi_queue : _pi_object {
   cm_support::CmQueue *CmQueuePtr = nullptr;
 };
 
+struct cm_surface_ptr_t {
+  // 'UP' means 'User-Provided' in CM Lib - corresponding to
+  // Buffer/Image created with PI_MEM_FLAGS_HOST_PTR_USE option in
+  // SYCL
+  enum SurfaceType {
+    type_none,
+    type_regular_buffer,
+    type_user_provided_buffer,
+    type_regular_image,
+    type_user_provided_image
+  };
+  SurfaceType tag = type_none;
+
+  union {
+    cm_support::CmBuffer *RegularBufPtr = nullptr;
+    cm_support::CmBufferUP *UPBufPtr;
+    cm_support::CmSurface2D *RegularImgPtr;
+    cm_support::CmSurface2DUP *UPImgPtr;
+  };
+};
+
 struct _pi_mem : _pi_object {
   _pi_mem() = default;
 
@@ -135,67 +156,32 @@ struct _pi_mem : _pi_object {
   // Supporing multi-threaded mapping/unmapping calls
   std::mutex MappingsMutex;
 
-  _pi_mem_type getMemType() const { return MemType; };
+  cm_surface_ptr_t SurfacePtr;
 
 protected:
-  _pi_mem(pi_context ctxt, char *HostPtr, _pi_mem_type MemTypeArg,
+  _pi_mem(pi_context ctxt, char *HostPtr, cm_surface_ptr_t SurfacePtrArg,
           unsigned int SurfaceIdxArg)
-      : Context{ctxt}, MapHostPtr{HostPtr},
-        SurfaceIndex{SurfaceIdxArg}, MemType{MemTypeArg} {}
-
-private:
-  _pi_mem_type MemType;
-};
-
-// TODO: Merge cm_buffer_ptr_slot and cm_image_ptr_slot into one
-// struct
-struct cm_buffer_ptr_slot {
-  // 'UP' means 'User-Provided' in CM Lib - corresponding to
-  // Host-created buffer in SYCL
-
-  enum type { type_none, type_regular, type_user_provided };
-  type tag = type_none;
-
-  union {
-    cm_support::CmBuffer *RegularBufPtr = nullptr;
-    cm_support::CmBufferUP *UPBufPtr;
-  };
-};
-
-struct cm_image_ptr_slot {
-  // 'UP' means 'User-Provided' in CM Lib - corresponding to
-  // Host-created image in SYCL
-
-  enum type { type_none, type_regular, type_user_provided };
-  type tag = type_none;
-
-  union {
-    cm_support::CmSurface2D *RegularImgPtr = nullptr;
-    cm_support::CmSurface2DUP *UPImgPtr;
-  };
+      : Context{ctxt}, MapHostPtr{HostPtr}, SurfaceIndex{SurfaceIdxArg},
+        SurfacePtr{SurfacePtrArg} {}
 };
 
 struct _pi_buffer final : _pi_mem {
   // Buffer/Sub-buffer constructor
-  _pi_buffer(pi_context ctxt, char *HostPtr, cm_buffer_ptr_slot BufferPtrArg,
+  _pi_buffer(pi_context ctxt, char *HostPtr, cm_surface_ptr_t SurfacePtrArg,
              unsigned int SurfaceIdxArg, size_t SizeArg)
-      : _pi_mem(ctxt, HostPtr, PI_MEM_TYPE_BUFFER, SurfaceIdxArg),
-        BufferPtr{BufferPtrArg}, Size{SizeArg} {}
+      : _pi_mem(ctxt, HostPtr, SurfacePtrArg, SurfaceIdxArg), Size{SizeArg} {}
 
-  cm_buffer_ptr_slot BufferPtr;
   size_t Size;
 };
 
 struct _pi_image final : _pi_mem {
   // Image constructor
-  _pi_image(pi_context ctxt, char *HostPtr, cm_image_ptr_slot ImagePtrArg,
+  _pi_image(pi_context ctxt, char *HostPtr, cm_surface_ptr_t SurfacePtrArg,
             unsigned int SurfaceIdxArg, size_t WidthArg, size_t HeightArg,
             size_t BPPArg)
-      : _pi_mem(ctxt, HostPtr, PI_MEM_TYPE_IMAGE2D, SurfaceIdxArg),
-        ImagePtr(ImagePtrArg), Width{WidthArg}, Height{HeightArg},
-        BytesPerPixel{BPPArg} {}
+      : _pi_mem(ctxt, HostPtr, SurfacePtrArg, SurfaceIdxArg), Width{WidthArg},
+        Height{HeightArg}, BytesPerPixel{BPPArg} {}
 
-  cm_image_ptr_slot ImagePtr;
   size_t Width;
   size_t Height;
   size_t BytesPerPixel;


### PR DESCRIPTION
This PR is to merge cm buffer info and cm image info into one surface_info struct. Suggested in https://github.com/intel/llvm/pull/5606.

Comment : https://github.com/intel/llvm/pull/5606/files#r831642498, https://github.com/intel/llvm/pull/5606/files#r836308878