### PR TITLE
[clang-offload-wrapper] Clean-up the code a bit

### DIFF
--- a/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
+++ b/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
@@ -1411,10 +1411,6 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &Out,
   return Out;
 }
 
-// enable_if_t is available only starting with C++14
-template <bool Cond, typename T = void>
-using my_enable_if_t = typename std::enable_if<Cond, T>::type;
-
 // Helper class to order elements of multiple cl::list option lists according to
 // the sequence they occurred on the command line. Each cl::list defines a
 // separate options "class" to identify which class current options belongs to.
@@ -1507,13 +1503,13 @@ private:
   }
 
   template <int MAX, int ID, typename XTy, typename... XTys>
-      my_enable_if_t < ID<MAX> addLists(XTy &Arg, XTys &... Args) {
+      std::enable_if_t < ID<MAX> addLists(XTy &Arg, XTys &...Args) {
     addListImpl<ID>(Arg);
     addLists<MAX, ID + 1>(Args...);
   }
 
   template <int MAX, int ID, typename XTy>
-  my_enable_if_t<ID == MAX> addLists(XTy &Arg) {
+  std::enable_if_t<ID == MAX> addLists(XTy &Arg) {
     addListImpl<ID>(Arg);
   }
 
@@ -1538,12 +1534,12 @@ private:
     }
   }
 
-  template <int N> my_enable_if_t<N != 0> inc() {
+  template <int N> std::enable_if_t<N != 0> inc() {
     incImpl<N>();
     inc<N - 1>();
   }
 
-  template <int N> my_enable_if_t<N == 0> inc() { incImpl<N>(); }
+  template <int N> std::enable_if_t<N == 0> inc() { incImpl<N>(); }
 };
 
 } // anonymous namespace

--- a/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
+++ b/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
@@ -260,13 +260,6 @@ static cl::opt<bool> AddOpenMPOffloadNotes(
 
 namespace {
 
-struct OffloadKindToUint {
-  using argument_type = OffloadKind;
-  unsigned operator()(argument_type Kind) const {
-    return static_cast<unsigned>(Kind);
-  }
-};
-
 /// Implements binary image information collecting and wrapping it in a host
 /// bitcode file.
 class BinaryWrapper {

--- a/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
+++ b/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
@@ -1515,7 +1515,7 @@ private:
 
   /// Does the actual sequencing of options found in given list.
   template <int ID, typename T> void addListImpl(T &L) {
-    // iterate via all occurences of an option of given list class
+    // iterate via all occurrences of an option of given list class
     for (auto It = L.begin(); It != L.end(); It++) {
       // calculate its sequential position in the command line
       unsigned Pos = L.getPosition(It - L.begin());

--- a/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
+++ b/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
@@ -1502,8 +1502,10 @@ private:
     return (*OptListIDs)[Cur];
   }
 
+  // clang-format off
   template <int MAX, int ID, typename XTy, typename... XTys>
-      std::enable_if_t < ID<MAX> addLists(XTy &Arg, XTys &...Args) {
+      std::enable_if_t<ID < MAX> addLists(XTy &Arg, XTys &...Args) {
+    // clang-format on
     addListImpl<ID>(Arg);
     addLists<MAX, ID + 1>(Args...);
   }

--- a/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
+++ b/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
@@ -751,7 +751,7 @@ private:
     return addStructArrayToModule(PropInits, getSyclPropTy());
   }
 
-  // Given in-memory representaion of a set of property sets, inserts it into
+  // Given in-memory representation of a set of property sets, inserts it into
   // the wrapper object file. In-object representation is given below.
   //
   // column is a contiguous area of the wrapper object file;

--- a/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
+++ b/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
@@ -157,21 +157,18 @@ static cl::list<BinaryImageFormat>
 /// Sets offload target.
 static cl::list<std::string> Targets("target", cl::ZeroOrMore,
                                      cl::desc("offload target triple"),
-                                     cl::cat(ClangOffloadWrapperCategory),
                                      cl::cat(ClangOffloadWrapperCategory));
 
 /// Sets compile options for device binary image.
 static cl::list<std::string>
     CompileOptions("compile-opts", cl::ZeroOrMore,
                    cl::desc("compile options passed to the offload runtime"),
-                   cl::cat(ClangOffloadWrapperCategory),
                    cl::cat(ClangOffloadWrapperCategory));
 
 /// Sets link options for device binary image.
 static cl::list<std::string>
     LinkOptions("link-opts", cl::ZeroOrMore,
                 cl::desc("link options passed to the offload runtime"),
-                cl::cat(ClangOffloadWrapperCategory),
                 cl::cat(ClangOffloadWrapperCategory));
 
 /// Sets the name of the file containing offload function entries


### PR DESCRIPTION
The following changes are incorporated to the patch:
 - Remove second call to cl::cat for properties
 - Remove unused struct OffloadKindToUint
 - Use std::enable_if_t wherever possible
 - Fix a typo in a comment