### PR TITLE
[SYCL] Fix boost/mp11 installation directory: sycl -> sycl/detail

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -180,7 +180,7 @@ add_custom_command(
 install(DIRECTORY "${sycl_inc_dir}/sycl" DESTINATION ${SYCL_INCLUDE_DIR} COMPONENT sycl-headers)
 install(DIRECTORY "${sycl_inc_dir}/CL" DESTINATION ${SYCL_INCLUDE_DIR}/sycl COMPONENT sycl-headers)
 install(DIRECTORY "${sycl_inc_dir}/std" DESTINATION ${SYCL_INCLUDE_DIR} COMPONENT sycl-headers)
-install(DIRECTORY ${BOOST_MP11_DESTINATION_DIR} DESTINATION ${SYCL_INCLUDE_DIR}/sycl COMPONENT boost_mp11-headers)
+install(DIRECTORY ${BOOST_MP11_DESTINATION_DIR} DESTINATION ${SYCL_INCLUDE_DIR}/sycl/detail COMPONENT boost_mp11-headers)
 
 set(SYCL_RT_LIBS sycl)
 if (MSVC)


### PR DESCRIPTION
boost::mp11 is imported into sycl::detail namespace, so in must reside in sycl/detail install directory. Build directory is already correct.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>