### PR TITLE
[SYCL][NFC] Remove unnecessary device_global entry lookup and assert

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1200,10 +1200,6 @@ void ProgramManager::addImages(pi_device_binaries DeviceBinary) {
 
         auto DeviceGlobals = Img->getDeviceGlobals();
         for (const pi_device_binary_property &DeviceGlobal : DeviceGlobals) {
-          auto Entry = m_DeviceGlobals.find(DeviceGlobal->Name);
-          assert(Entry != m_DeviceGlobals.end() &&
-                 "Device global has not been registered.");
-
           pi::ByteArray DeviceGlobalInfo =
               pi::DeviceBinaryProperty(DeviceGlobal).asByteArray();
 


### PR DESCRIPTION
This commit removes an unused lookup of an entry in the device_global initialization step. This was not intended to stay after making the map initialization order agnostic.