### PR TITLE
[SYCL][L0] Support buffer migration for contexts with multiple devices

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -6304,6 +6304,8 @@ pi_result piEnqueueMemBufferMap(pi_queue Queue, pi_mem Mem, pi_bool BlockingMap,
     *RetMap = Buffer->MapHostPtr + Offset;
   } else {
     // TODO: use USM host allocator here
+    // TODO: Do we even need every map to allocate new host memory?
+    //       In the case when the buffer is "OnHost" we use single allocation.
     if (auto Res = ZeHostMemAllocHelper(RetMap, Queue->Context, Size))
       return Res;
   }

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -3380,7 +3380,7 @@ static pi_result ZeHostMemAllocHelper(void **ResultPtr, pi_context Context,
     PI_CALL(piContextRetain(Context));
   }
 
-  ze_host_mem_alloc_desc_t ZeDesc = {};
+  ZeStruct<ze_host_mem_alloc_desc_t> ZeDesc;
   ZeDesc.flags = 0;
   ZE_CALL(zeMemAllocHost, (Context->ZeContext, &ZeDesc, Size, 1, ResultPtr));
 
@@ -7974,7 +7974,10 @@ pi_result _pi_buffer::free() {
     if (Context->SingleRootDevice && Context->SingleRootDevice != Device) {
       // These were re-using root-device allocations
     }
-    PI_CALL(piextUSMFree(Context, Alloc.second.ZeHandle));
+    // It is possible that the real allocation wasn't made if the buffer
+    // wasn't really used on this device.
+    if (Alloc.second.ZeHandle)
+      PI_CALL(piextUSMFree(Context, Alloc.second.ZeHandle));
   }
   return PI_SUCCESS;
 }

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -1057,11 +1057,13 @@ struct _pi_image final : _pi_mem {
 
   virtual pi_result getZeHandle(char *&ZeHandle, access_mode_t,
                                 pi_device Device = nullptr) override {
+    (void *)Device;
     ZeHandle = pi_cast<char *>(ZeImage);
     return PI_SUCCESS;
   }
   virtual pi_result getZeHandlePtr(char **&ZeHandlePtr, access_mode_t,
                                    pi_device Device = nullptr) override {
+    (void *)Device;
     ZeHandlePtr = pi_cast<char **>(&ZeImage);
     return PI_SUCCESS;
   }

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -1023,7 +1023,7 @@ struct _pi_buffer final : _pi_mem {
         Size(Size), SubBuffer{nullptr, 0} {
 
     // Re-use the given device allocation.
-    // If it is not a device allocatiin then still mark it as valid, and
+    // If it is not a device allocation then still mark it as valid, and
     // expect caller to initialize it right after buffer construction.
     auto D = Device ? Device : Context->Devices[0];
     LastDeviceWithValidAllocation = D;


### PR DESCRIPTION
The changes make SYCL buffer to work properly in contexts with multiple devices.
Instead of creating a single host allocation and using it from all devices (which is slow, at least) it is now maintaining device allocations in all used devices, and maintains migration of valid buffer data across these multiple device allocations.

E2E test is in https://github.com/intel/llvm-test-suite/pull/976
Signed-off-by: Sergey V Maslov <sergey.v.maslov@intel.com>