### PR TITLE
[Clang][NFC] Fix documentation for add_ir_annotations_member attribute

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -3629,6 +3629,7 @@ occur after the first argument of the attribute, the N+2'th argument of the
 attribute will occur after the second argument of the attribute, etc.
 The generated call to ``llvm.ptr.annotation`` will have the following arguments
 in this order:
+
   * First argument is a pointer to the field.
   * A pointer to a string literal in a constant global variable. This will
     always be "sycl-properties".
@@ -3639,6 +3640,7 @@ in this order:
     literals in constant global variables. These pointers to string literals
     occur in pairs. If the second value of a pair was a ``nullptr`` or an empty
     string then the pointer will be a null-pointer.
+
 A pair will not be in the call to ``llvm.ptr.annotation`` if the first value of
 the pair is an empty string.
 


### PR DESCRIPTION
Documentation generation currently fails due to incorrect format in [[__sycl_detail__::add_ir_annotations_member]] attribute documentation. This commit fixes the format.

Failure seen in https://github.com/intel/llvm/pull/5972.