### PR TITLE
[NFC] Fix static analysis warning

### DIFF
--- a/sycl/source/detail/posix_pi.cpp
+++ b/sycl/source/detail/posix_pi.cpp
@@ -22,9 +22,11 @@ void *loadOsLibrary(const std::string &PluginPath) {
   // RTLD_DEEPBIND option when there are multiple plugins.
   void *so = dlopen(PluginPath.c_str(), RTLD_NOW);
   if (!so && trace(TraceLevel::PI_TRACE_ALL)) {
-    char *Error = dlerror();
+    const char *Error = dlerror();
+    if (!Error)
+      Error = "unknown error";
     std::cerr << "SYCL_PI_TRACE[-1]: dlopen(" << PluginPath << ") failed with <"
-              << (Error ? Error : "unknown error") << ">" << std::endl;
+              << Error << ">" << std::endl;
   }
   return so;
 }


### PR DESCRIPTION
I think it is a false positive, but just make the tool happy (hopefully).