### PR TITLE
[SYCL] Fix basic_tests/sycl-kernel-save-user-names.cpp for the build …

### DIFF
--- a/sycl/test/basic_tests/sycl-kernel-save-user-names.cpp
+++ b/sycl/test/basic_tests/sycl-kernel-save-user-names.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-device-only -fno-sycl-early-optimizations -o %t.bc %s
+// RUN: %clangxx -fsycl -fsycl-device-only -fno-discard-value-names -fno-sycl-early-optimizations -o %t.bc %s
 // RUN: sycl-post-link %t.bc -spec-const=default -o %t.table
 // RUN: llvm-spirv -o %t.spv -spirv-max-version=1.3 -spirv-ext=+all %t.bc
 // RUN: llvm-spirv -o %t.rev.bc -r %t.spv


### PR DESCRIPTION
…without assertions

Value names are discarded if assertions are disabled:
https://clang.llvm.org/docs/UsersManual.html#controlling-value-names-in-llvm-ir

Fix the test which checks value names and fails in the post commit
testing.