### PR TITLE
Port Local Accessor and Global Offset passes to the new PM

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
+++ b/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This pass operates on SYCL kernels being compiled to CUDA. It looks for uses
-// of the `llvm.nvvm.implicit.offset` intrinsic and replaces it with a offset
-// parameter which will be threaded through from the kernel entry point.
+// This pass operates on SYCL kernels. It looks for uses of the
+// `llvm.{amdgcn|nvvm}.implicit.offset` intrinsic and replaces it with an
+// offset parameter which will be threaded through from the kernel entry point.
 //
 //===----------------------------------------------------------------------===//
 
@@ -36,22 +36,80 @@ public:
   static StringRef getPassName() { return "Add implicit SYCL global offset"; }
 
 private:
-  void processKernelEntryPoint(Module &M, Function *Func);
+  /// After the execution of this function, the module to which the kernel
+  /// `Func` belongs contains a clone of the original kernel with the signature
+  /// extended with the implicit offset parameter and `_with_offset` appended
+  /// to the name.
+  /// An alloca of 3 zeros (corresponding to offsets in x, y and z) is added to
+  /// the original kernel, in order to keep the interface of kernel's call
+  /// graph unified, regardless of the fact if the global offset has been used.
+  ///
+  /// \param Func Kernel to be processed.
+  void processKernelEntryPoint(Function *Func);
+
+  /// This function adds an implicit parameter to the function containing a
+  /// call instruction to the implicit offset intrinsic or another function
+  /// (which eventually calls the instrinsic). If the call instruction is to
+  /// the implicit offset intrinsic, then the intrinisic is replaced with the
+  /// parameter that was added.
+  ///
+  /// Once the function, say `F`, containing a call to `Callee` has the
+  /// implicit parameter added, callers of `F` are processed by recursively
+  /// calling this function, passing `F` to `CalleeWithImplicitParam`.
+  ///
+  /// Since the cloning of entry points may alter the users of a function, the
+  /// cloning must be done as early as possible, as to ensure that no users are
+  /// added to previous callees in the call-tree.
+  ///
+  /// \param Callee is the function (to which this transformation has already
+  /// been applied), or to the implicit offset intrinsic.
+  ///
+  /// \param CalleeWithImplicitParam indicates whether Callee is to the
+  /// implicit intrinsic (when `nullptr`) or to another function (not
+  /// `nullptr`) - this is used to know whether calls to it needs to have the
+  /// implicit parameter added to it or replaced with the implicit parameter.
   void addImplicitParameterToCallers(Module &M, Value *Callee,
                                      Function *CalleeWithImplicitParam);
+
+  /// For a given function `Func` extend signature to contain an implicit
+  /// offset argument.
+  ///
+  /// \param Func A function to add offset to.
+  ///
+  /// \param ImplicitArgumentType Architecture dependant type of the implicit
+  /// argument holding the global offset.
+  ///
+  /// \param KeepOriginal If set to true, rather than splicing the old `Func`,
+  /// keep it intact and create a clone of it with `_wit_offset` appended to
+  /// the name.
+  ///
+  /// \returns A pair of new function with the offset argument added and a
+  /// pointer to the implicit argument (either a func argument or a bitcast
+  /// turning it to the correct type).
   std::pair<Function *, Value *>
   addOffsetArgumentToFunction(Module &M, Function *Func,
                               Type *ImplicitArgumentType = nullptr,
                               bool KeepOriginal = false);
+
+  /// This function makes sure that a given kernel entry point has no llvm
+  /// uses.
+  ///
+  /// \param KernelPayloads A collection of kernel functions present in a
+  /// module `M`.
+  ///
+  /// \returns A map of kernel functions to corresponding metadata nodes.
   DenseMap<Function *, MDNode *>
   validateKernels(Module &M, SmallVectorImpl<KernelPayload> &KernelPayloads);
 
 private:
-  // Keep track of which functions have been processed to avoid processing twice
+  /// Keep track of which functions have been processed to avoid processing
+  /// twice.
   llvm::DenseMap<Function *, Value *> ProcessedFunctions;
-  // Keep a map of all entry point functions with metadata
+  /// Keep a map of all entry point functions with metadata.
   llvm::DenseMap<Function *, MDNode *> EntryPointMetadata;
+  /// A type of implicit argument added to the kernel signature.
   llvm::Type *KernelImplicitArgumentType = nullptr;
+  /// A type used for the alloca holding the values of global offsets.
   llvm::Type *ImplicitOffsetPtrType = nullptr;
 
   ArchType AT;

--- a/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
+++ b/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
@@ -18,10 +18,10 @@ namespace llvm {
 class ModulePass;
 class PassRegistry;
 
-/// This pass operates on SYCL kernels. It looks for uses of the
-/// `llvm.{amdgcn|nvvm}.implicit.offset` intrinsic and replaces it with an
-/// offset parameter which will be threaded through from the kernel entry
-/// point.
+/// This pass operates on SYCL kernels that target AMDGPU or NVVM. It looks for
+/// uses of the `llvm.{amdgcn|nvvm}.implicit.offset` intrinsic and replaces it
+/// with an offset parameter which will be threaded through from the kernel
+/// entry point.
 class GlobalOffsetPass : public PassInfoMixin<GlobalOffsetPass> {
 private:
   using KernelPayload = TargetHelpers::KernelPayload;
@@ -35,9 +35,9 @@ public:
 
 private:
   /// After the execution of this function, the module to which the kernel
-  /// `Func` belongs contains a clone of the original kernel with the signature
-  /// extended with the implicit offset parameter and `_with_offset` appended
-  /// to the name.
+  /// `Func` belongs, contains both the original function and its clone with the
+  /// signature extended with the implicit offset parameter and `_with_offset`
+  /// appended to the name.
   /// An alloca of 3 zeros (corresponding to offsets in x, y and z) is added to
   /// the original kernel, in order to keep the interface of kernel's call
   /// graph unified, regardless of the fact if the global offset has been used.
@@ -89,15 +89,17 @@ private:
                               Type *ImplicitArgumentType = nullptr,
                               bool KeepOriginal = false);
 
-  /// This function makes sure that a given kernel entry point has no llvm
-  /// uses.
+  /// Create a mapping of kernel entry points to their metadata nodes. While
+  /// iterating over kernels make sure that a given kernel entry point has no
+  /// llvm uses.
   ///
   /// \param KernelPayloads A collection of kernel functions present in a
   /// module `M`.
   ///
   /// \returns A map of kernel functions to corresponding metadata nodes.
   DenseMap<Function *, MDNode *>
-  validateKernels(Module &M, SmallVectorImpl<KernelPayload> &KernelPayloads);
+  generateKernelMDNodeMap(Module &M,
+                          SmallVectorImpl<KernelPayload> &KernelPayloads);
 
 private:
   /// Keep track of which functions have been processed to avoid processing

--- a/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
+++ b/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
@@ -5,12 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
-// This pass operates on SYCL kernels. It looks for uses of the
-// `llvm.{amdgcn|nvvm}.implicit.offset` intrinsic and replaces it with an
-// offset parameter which will be threaded through from the kernel entry point.
-//
-//===----------------------------------------------------------------------===//
 
 #ifndef LLVM_SYCL_GLOBALOFFSET_H
 #define LLVM_SYCL_GLOBALOFFSET_H
@@ -24,6 +18,10 @@ namespace llvm {
 class ModulePass;
 class PassRegistry;
 
+/// This pass operates on SYCL kernels. It looks for uses of the
+/// `llvm.{amdgcn|nvvm}.implicit.offset` intrinsic and replaces it with an
+/// offset parameter which will be threaded through from the kernel entry
+/// point.
 class GlobalOffsetPass : public PassInfoMixin<GlobalOffsetPass> {
 private:
   using KernelPayload = TargetHelpers::KernelPayload;

--- a/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
+++ b/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
@@ -15,11 +15,51 @@
 #ifndef LLVM_SYCL_GLOBALOFFSET_H
 #define LLVM_SYCL_GLOBALOFFSET_H
 
-#include "llvm/Pass.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+#include "llvm/SYCLLowerIR/TargetHelpers.h"
 
 namespace llvm {
 
-ModulePass *createGlobalOffsetPass();
+class ModulePass;
+class PassRegistry;
+
+class GlobalOffsetPass : public PassInfoMixin<GlobalOffsetPass> {
+private:
+  using KernelPayload = TargetHelpers::KernelPayload;
+  using ArchType = TargetHelpers::ArchType;
+
+public:
+  explicit GlobalOffsetPass() {}
+
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
+  static StringRef getPassName() { return "Add implicit SYCL global offset"; }
+
+private:
+  void processKernelEntryPoint(Module &M, Function *Func);
+  void addImplicitParameterToCallers(Module &M, Value *Callee,
+                                     Function *CalleeWithImplicitParam);
+  std::pair<Function *, Value *>
+  addOffsetArgumentToFunction(Module &M, Function *Func,
+                              Type *ImplicitArgumentType = nullptr,
+                              bool KeepOriginal = false);
+  DenseMap<Function *, MDNode *>
+  validateKernels(Module &M, SmallVectorImpl<KernelPayload> &KernelPayloads);
+
+private:
+  // Keep track of which functions have been processed to avoid processing twice
+  llvm::DenseMap<Function *, Value *> ProcessedFunctions;
+  // Keep a map of all entry point functions with metadata
+  llvm::DenseMap<Function *, MDNode *> EntryPointMetadata;
+  llvm::Type *KernelImplicitArgumentType;
+  llvm::Type *ImplicitOffsetPtrType;
+
+  ArchType AT;
+  unsigned TargetAS = 0;
+};
+
+ModulePass *createGlobalOffsetPassLegacy();
+void initializeGlobalOffsetLegacyPass(PassRegistry &);
 
 } // end namespace llvm
 

--- a/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
+++ b/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
@@ -51,8 +51,8 @@ private:
   llvm::DenseMap<Function *, Value *> ProcessedFunctions;
   // Keep a map of all entry point functions with metadata
   llvm::DenseMap<Function *, MDNode *> EntryPointMetadata;
-  llvm::Type *KernelImplicitArgumentType;
-  llvm::Type *ImplicitOffsetPtrType;
+  llvm::Type *KernelImplicitArgumentType = nullptr;
+  llvm::Type *ImplicitOffsetPtrType = nullptr;
 
   ArchType AT;
   unsigned TargetAS = 0;

--- a/llvm/include/llvm/SYCLLowerIR/LocalAccessorToSharedMemory.h
+++ b/llvm/include/llvm/SYCLLowerIR/LocalAccessorToSharedMemory.h
@@ -6,11 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This pass operates on SYCL kernels being compiled to CUDA. It modifies
-// kernel entry points which take pointers to shared memory and modifies them
-// to take offsets into shared memory (represented by a symbol in the shared
-// address space). The SYCL runtime is expected to provide offsets rather than
-// pointers to these functions.
+// This pass operates on SYCL kernels. It modifies kernel entry points which
+// take pointers to shared memory and alters them to take offsets into shared
+// memory (represented by a symbol in the shared address space). The SYCL
+// runtime is expected to provide offsets rather than pointers to these
+// functions.
 //
 //===----------------------------------------------------------------------===//
 
@@ -41,13 +41,26 @@ public:
   }
 
 private:
+  /// This function replaces pointers to shared memory with offsets to a global
+  /// symbol in shared memory.
+  /// It alters the signature of the kernel (pointer vs offset value) as well
+  /// as the access (dereferencing the argument pointer vs GEP to the global
+  /// symbol).
+  ///
+  /// \param F The kernel to be processed.
+  ///
+  /// \returns A new function with global symbol accesses.
   Function *processKernel(Module &M, Function *F);
+
+  /// Update kernel metadata to reflect the change in the signature.
+  ///
+  /// \param A map of original kernels to the modified ones.
   void postProcessKernels(
       SmallVectorImpl<std::pair<Function *, KernelPayload>> &NewToOldKernels);
 
 private:
-  // The value for NVVM's ADDRESS_SPACE_SHARED and AMD's LOCAL_ADDRESS happen to
-  // be 3.
+  /// The value for NVVM's ADDRESS_SPACE_SHARED and AMD's LOCAL_ADDRESS happen
+  /// to be 3.
   const unsigned SharedASValue = 3;
 };
 

--- a/llvm/include/llvm/SYCLLowerIR/LocalAccessorToSharedMemory.h
+++ b/llvm/include/llvm/SYCLLowerIR/LocalAccessorToSharedMemory.h
@@ -5,14 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
-// This pass operates on SYCL kernels. It modifies kernel entry points which
-// take pointers to shared memory and alters them to take offsets into shared
-// memory (represented by a symbol in the shared address space). The SYCL
-// runtime is expected to provide offsets rather than pointers to these
-// functions.
-//
-//===----------------------------------------------------------------------===//
 
 #ifndef LLVM_SYCL_LOCALACCESSORTOSHAREDMEMORY_H
 #define LLVM_SYCL_LOCALACCESSORTOSHAREDMEMORY_H
@@ -26,6 +18,11 @@ namespace llvm {
 class ModulePass;
 class PassRegistry;
 
+/// This pass operates on SYCL kernels. It modifies kernel entry points which
+/// take pointers to shared memory and alters them to take offsets into shared
+/// memory (represented by a symbol in the shared address space). The SYCL
+/// runtime is expected to provide offsets rather than pointers to these
+/// functions.
 class LocalAccessorToSharedMemoryPass
     : public PassInfoMixin<LocalAccessorToSharedMemoryPass> {
 private:

--- a/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
+++ b/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/SYCLLowerIR/GlobalOffset.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Instructions.h"
@@ -24,7 +25,6 @@
 #include "llvm/Transforms/Utils/Cloning.h"
 
 using namespace llvm;
-using namespace TargetHelpers;
 
 #define DEBUG_TYPE "globaloffset"
 
@@ -37,396 +37,385 @@ ModulePass *createGlobalOffsetPass();
 void initializeGlobalOffsetPass(PassRegistry &);
 } // end namespace llvm
 
+// Legacy PM wrapper.
 namespace {
-
-class GlobalOffset : public ModulePass {
+class GlobalOffsetLegacy : public ModulePass {
 public:
   static char ID;
-  GlobalOffset() : ModulePass(ID) {}
+  GlobalOffsetLegacy() : ModulePass(ID) {
+    initializeGlobalOffsetLegacyPass(*PassRegistry::getPassRegistry());
+  }
 
   bool runOnModule(Module &M) override {
-    if (skipModule(M))
-      return false;
-
-    if (!EnableGlobalOffset)
-      return false;
-
-    AT = getArchType(M);
-    llvm::Function *ImplicitOffsetIntrinsic = M.getFunction(Intrinsic::getName(
-        AT == ArchType::Cuda ? Intrinsic::nvvm_implicit_offset
-                             : Intrinsic::amdgcn_implicit_offset));
-
-    if (!ImplicitOffsetIntrinsic || ImplicitOffsetIntrinsic->use_empty()) {
-      return false;
-    }
-
-    // For AMD allocas and pointers have to be to CONSTANT_PRIVATE (5), NVVM is
-    // happy with ADDRESS_SPACE_GENERIC (0).
-    TargetAS = AT == ArchType::Cuda ? 0 : 5;
-    KernelImplicitArgumentType =
-        ArrayType::get(Type::getInt32Ty(M.getContext()), 3);
-    ImplicitOffsetPtrType =
-        Type::getInt32Ty(M.getContext())->getPointerTo(TargetAS);
-    assert(
-        (!ImplicitOffsetIntrinsic ||
-         ImplicitOffsetIntrinsic->getReturnType() == ImplicitOffsetPtrType) &&
-        "Implicit offset intrinsic does not return the expected type");
-
-    SmallVector<KernelPayload, 4> KernelPayloads;
-    populateKernels(M, KernelPayloads, AT);
-
-    // Validate kernels and populate entry map
-    EntryPointMetadata = validateKernels(M, KernelPayloads);
-
-    // Add implicit parameters to all direct and indirect users of the offset
-    addImplicitParameterToCallers(M, ImplicitOffsetIntrinsic, nullptr);
-
-    // Assert that all uses of `ImplicitOffsetIntrinsic` are removed and delete
-    // it.
-    assert(ImplicitOffsetIntrinsic->use_empty() &&
-           "Not all uses of intrinsic removed");
-    ImplicitOffsetIntrinsic->eraseFromParent();
-
-    return true;
-  }
-
-  void processKernelEntryPoint(Module &M, Function *Func) {
-    assert(EntryPointMetadata.count(Func) != 0 &&
-           "Function must be an entry point");
-
-    LLVMContext &Ctx = M.getContext();
-    MDNode *FuncMetadata = EntryPointMetadata[Func];
-
-    // Already processed.
-    if (ProcessedFunctions.count(Func) == 1)
-      return;
-
-    // Add the new argument to all other kernel entry points, despite not
-    // using the global offset.
-    auto *KernelMetadata = M.getNamedMetadata(getAnnotationString(AT).c_str());
-    assert(KernelMetadata && "IR compiled must have correct annotations");
-
-    auto *NewFunc = addOffsetArgumentToFunction(
-                        M, Func, KernelImplicitArgumentType->getPointerTo(),
-                        /*KeepOriginal=*/true)
-                        .first;
-    Argument *NewArgument = NewFunc->arg_begin() + (NewFunc->arg_size() - 1);
-    // Pass byval to the kernel for NVIDIA, AMD's calling convention disallows
-    // byval args, use byref.
-    auto Attr =
-        AT == ArchType::Cuda
-            ? Attribute::getWithByValType(Ctx, KernelImplicitArgumentType)
-            : Attribute::getWithByRefType(Ctx, KernelImplicitArgumentType);
-    NewArgument->addAttr(Attr);
-
-    // Add the metadata.
-    Metadata *NewMetadata[] = {ConstantAsMetadata::get(NewFunc),
-                               FuncMetadata->getOperand(1),
-                               FuncMetadata->getOperand(2)};
-    KernelMetadata->addOperand(MDNode::get(Ctx, NewMetadata));
-
-    // Create alloca of zeros for the implicit offset in original func
-    BasicBlock *EntryBlock = &Func->getEntryBlock();
-    IRBuilder<> Builder(EntryBlock, EntryBlock->getFirstInsertionPt());
-    Type *ImplicitOffsetType =
-        ArrayType::get(Type::getInt32Ty(M.getContext()), 3);
-    AllocaInst *ImplicitOffset =
-        Builder.CreateAlloca(ImplicitOffsetType, TargetAS);
-    uint64_t AllocByteSize =
-        ImplicitOffset->getAllocationSizeInBits(M.getDataLayout()).getValue() /
-        8;
-    CallInst *MemsetCall =
-        Builder.CreateMemSet(ImplicitOffset, Builder.getInt8(0), AllocByteSize,
-                             ImplicitOffset->getAlign());
-    MemsetCall->addParamAttr(0, Attribute::NonNull);
-    MemsetCall->addDereferenceableParamAttr(0, AllocByteSize);
-    ProcessedFunctions[Func] = Builder.CreateConstInBoundsGEP2_32(
-        ImplicitOffsetType, ImplicitOffset, 0, 0);
-  }
-
-  // This function adds an implicit parameter to the function containing a call
-  // instruction to the implicit offset intrinsic or another function (which
-  // eventually calls the instrinsic). If the call instruction is to the
-  // implicit offset intrinsic, then the intrinisic is replaced with the
-  // parameter that was added.
-  //
-  // `Callee` is the function (to which this transformation has already been
-  // applied), or to the implicit offset intrinsic. `CalleeWithImplicitParam`
-  // indicates whether Callee is to the implicit intrinsic (when `nullptr`) or
-  // to another function (not `nullptr`) - this is used to know whether calls to
-  // it needs to have the implicit parameter added to it or replaced with the
-  // implicit parameter.
-  //
-  // Once the function, say `F`, containing a call to `Callee` has the implicit
-  // parameter added, callers of `F` are processed by recursively calling this
-  // function, passing `F` to `CalleeWithImplicitParam`.
-  //
-  // Since the cloning of entry points may alter the users of a function, the
-  // cloning must be done as early as possible, as to ensure that no users are
-  // added to previous callees in the call-tree.
-  void addImplicitParameterToCallers(Module &M, Value *Callee,
-                                     Function *CalleeWithImplicitParam) {
-
-    // Make sure that all entry point callers are processed.
-    SmallVector<User *, 8> Users{Callee->users()};
-    for (User *U : Users) {
-      auto *Call = dyn_cast<CallInst>(U);
-      if (!Call)
-        continue;
-
-      Function *Caller = Call->getFunction();
-      if (EntryPointMetadata.count(Caller) != 0) {
-        processKernelEntryPoint(M, Caller);
-      }
-    }
-
-    // User collection may have changed, so we reinitialize it.
-    Users = SmallVector<User *, 8>{Callee->users()};
-    for (User *U : Users) {
-      auto *CallToOld = dyn_cast<CallInst>(U);
-      if (!CallToOld)
-        return;
-
-      auto *Caller = CallToOld->getFunction();
-
-      // Determine if `Caller` needs processed or if this is another callsite
-      // from an already-processed function.
-      Function *NewFunc;
-      Value *ImplicitOffset = ProcessedFunctions[Caller];
-      bool AlreadyProcessed = ImplicitOffset != nullptr;
-      if (AlreadyProcessed) {
-        NewFunc = Caller;
-      } else {
-        std::tie(NewFunc, ImplicitOffset) =
-            addOffsetArgumentToFunction(M, Caller);
-      }
-
-      if (!CalleeWithImplicitParam) {
-        // Replace intrinsic call with parameter.
-        CallToOld->replaceAllUsesWith(ImplicitOffset);
-      } else {
-        // Build up a list of arguments to call the modified function using.
-        llvm::SmallVector<Value *, 8> ImplicitOffsets;
-        for (Use &U : CallToOld->args()) {
-          ImplicitOffsets.push_back(U);
-        }
-        ImplicitOffsets.push_back(ImplicitOffset);
-
-        // Replace call to other function (which now has a new parameter),
-        // with a call including the new parameter to that same function.
-        auto *NewCaller = CallInst::Create(
-            /* Ty= */ CalleeWithImplicitParam->getFunctionType(),
-            /* Func= */ CalleeWithImplicitParam,
-            /* Args= */ ImplicitOffsets,
-            /* NameStr= */ Twine(),
-            /* InsertBefore= */ CallToOld);
-        NewCaller->setTailCallKind(CallToOld->getTailCallKind());
-        NewCaller->copyMetadata(*CallToOld);
-        CallToOld->replaceAllUsesWith(NewCaller);
-
-        if (CallToOld->hasName()) {
-          NewCaller->takeName(CallToOld);
-        }
-      }
-
-      // Remove the caller now that it has been replaced.
-      CallToOld->eraseFromParent();
-
-      if (!AlreadyProcessed) {
-        // Process callers of the old function.
-        addImplicitParameterToCallers(M, Caller, NewFunc);
-
-        // Now that the old function is dead, delete it.
-        Caller->dropAllReferences();
-        Caller->eraseFromParent();
-      }
-    }
-  }
-
-  std::pair<Function *, Value *>
-  addOffsetArgumentToFunction(Module &M, Function *Func,
-                              Type *ImplicitArgumentType = nullptr,
-                              bool KeepOriginal = false) {
-    FunctionType *FuncTy = Func->getFunctionType();
-    const AttributeList &FuncAttrs = Func->getAttributes();
-    ImplicitArgumentType =
-        ImplicitArgumentType ? ImplicitArgumentType : ImplicitOffsetPtrType;
-
-    // Construct an argument list containing all of the previous arguments.
-    SmallVector<Type *, 8> Arguments;
-    SmallVector<AttributeSet, 8> ArgumentAttributes;
-
-    unsigned i = 0;
-    for (Function::arg_iterator FuncArg = Func->arg_begin(),
-                                FuncEnd = Func->arg_end();
-         FuncArg != FuncEnd; ++FuncArg, ++i) {
-      Arguments.push_back(FuncArg->getType());
-      ArgumentAttributes.push_back(FuncAttrs.getParamAttrs(i));
-    }
-
-    // Add the offset argument. Must be the same type as returned by
-    // `llvm.{amdgcn|nvvm}.implicit.offset`.
-    Arguments.push_back(ImplicitArgumentType);
-    ArgumentAttributes.push_back(AttributeSet());
-
-    // Build the new function.
-    AttributeList NAttrs =
-        AttributeList::get(Func->getContext(), FuncAttrs.getFnAttrs(),
-                           FuncAttrs.getRetAttrs(), ArgumentAttributes);
-    assert(!FuncTy->isVarArg() && "Variadic arguments prohibited in SYCL");
-    FunctionType *NewFuncTy = FunctionType::get(FuncTy->getReturnType(),
-                                                Arguments, FuncTy->isVarArg());
-
-    Function *NewFunc = Function::Create(NewFuncTy, Func->getLinkage(),
-                                         Func->getAddressSpace());
-
-    // Keep original function ordering.
-    M.getFunctionList().insertAfter(Func->getIterator(), NewFunc);
-
-    Value *ImplicitOffset = nullptr;
-    bool ImplicitOffsetAllocaInserted = false;
-    if (KeepOriginal) {
-      // TODO: Are there better naming alternatives that allow for unmangling?
-      NewFunc->setName(Func->getName() + "_with_offset");
-
-      ValueToValueMapTy VMap;
-      for (Function::arg_iterator FuncArg = Func->arg_begin(),
-                                  FuncEnd = Func->arg_end(),
-                                  NewFuncArg = NewFunc->arg_begin();
-           FuncArg != FuncEnd; ++FuncArg, ++NewFuncArg) {
-        VMap[FuncArg] = NewFuncArg;
-      }
-
-      SmallVector<ReturnInst *, 8> Returns;
-      CloneFunctionInto(NewFunc, Func, VMap,
-                        CloneFunctionChangeType::GlobalChanges, Returns);
-      // In order to keep the signatures of functions called by the kernel
-      // unified, the pass has to copy global offset to an array allocated in
-      // addrspace(3). This is done as kernels can't allocate and fill the
-      // array in constant address space, which would be required for the case
-      // with no global offset.
-      if (AT == ArchType::AMDHSA) {
-        BasicBlock *EntryBlock = &NewFunc->getEntryBlock();
-        IRBuilder<> Builder(EntryBlock, EntryBlock->getFirstInsertionPt());
-        Type *ImplicitOffsetType =
-            ArrayType::get(Type::getInt32Ty(M.getContext()), 3);
-        Value *OrigImplicitOffset =
-            NewFunc->arg_begin() + (NewFunc->arg_size() - 1);
-        AllocaInst *ImplicitOffsetAlloca =
-            Builder.CreateAlloca(ImplicitOffsetType, TargetAS);
-        auto DL = M.getDataLayout();
-        uint64_t AllocByteSize =
-            ImplicitOffsetAlloca->getAllocationSizeInBits(DL).getValue() / 8;
-        // After AMD's kernel arg lowering pass runs the accesses to arguments
-        // are replaced with uses of kernarg.segment.ptr which is in
-        // addrspace(4), cast implicit offset arg to constant memory so the
-        // memcpy is issued into a correct address space.
-        auto OrigImplicitOffsetAS4 = Builder.CreateAddrSpaceCast(
-            OrigImplicitOffset,
-            Type::getInt8Ty(M.getContext())->getPointerTo(4));
-        Builder.CreateMemCpy(
-            ImplicitOffsetAlloca, ImplicitOffsetAlloca->getAlign(),
-            OrigImplicitOffsetAS4,
-            OrigImplicitOffsetAS4->getPointerAlignment(DL), AllocByteSize);
-        ImplicitOffset = ImplicitOffsetAlloca;
-        ImplicitArgumentType = ImplicitOffset->getType();
-        ImplicitOffsetAllocaInserted = true;
-      } else {
-        ImplicitOffset = NewFunc->arg_begin() + (NewFunc->arg_size() - 1);
-      }
-    } else {
-      NewFunc->copyAttributesFrom(Func);
-      NewFunc->setComdat(Func->getComdat());
-      NewFunc->setAttributes(NAttrs);
-      NewFunc->takeName(Func);
-
-      // Splice the body of the old function right into the new function.
-      NewFunc->getBasicBlockList().splice(NewFunc->begin(),
-                                          Func->getBasicBlockList());
-
-      for (Function::arg_iterator FuncArg = Func->arg_begin(),
-                                  FuncEnd = Func->arg_end(),
-                                  NewFuncArg = NewFunc->arg_begin();
-           FuncArg != FuncEnd; ++FuncArg, ++NewFuncArg) {
-        FuncArg->replaceAllUsesWith(NewFuncArg);
-      }
-
-      // Clone metadata of the old function, including debug info descriptor.
-      SmallVector<std::pair<unsigned, MDNode *>, 1> MDs;
-      Func->getAllMetadata(MDs);
-      for (auto MD : MDs)
-        NewFunc->addMetadata(MD.first, *MD.second);
-
-      ImplicitOffset = NewFunc->arg_begin() + (NewFunc->arg_size() - 1);
-    }
-    assert(ImplicitOffset && "Value of implicit offset must be set.");
-
-    // Add bitcast to match the return type of the intrinsic if needed.
-    if (ImplicitArgumentType != ImplicitOffsetPtrType) {
-      BasicBlock *EntryBlock = &NewFunc->getEntryBlock();
-      // Make sure bitcast is inserted after alloca, if present.
-      BasicBlock::iterator InsertionPt =
-          ImplicitOffsetAllocaInserted
-              ? std::next(((AllocaInst *)ImplicitOffset)->getIterator())
-              : EntryBlock->getFirstInsertionPt();
-      IRBuilder<> Builder(EntryBlock, InsertionPt);
-      ImplicitOffset = Builder.CreateBitCast(
-          ImplicitOffset,
-          Type::getInt32Ty(M.getContext())->getPointerTo(TargetAS));
-    }
-
-    ProcessedFunctions[NewFunc] = ImplicitOffset;
-
-    // Return the new function and the offset argument.
-    return {NewFunc, ImplicitOffset};
-  }
-
-  static DenseMap<Function *, MDNode *>
-  validateKernels(Module &M, SmallVectorImpl<KernelPayload> &KernelPayloads) {
-    SmallPtrSet<GlobalValue *, 8u> Used;
-    SmallVector<GlobalValue *, 4> Vec;
-    collectUsedGlobalVariables(M, Vec, /*CompilerUsed=*/false);
-    collectUsedGlobalVariables(M, Vec, /*CompilerUsed=*/true);
-    Used = {Vec.begin(), Vec.end()};
-
-    auto HasUseOtherThanLLVMUsed = [&Used](GlobalValue *GV) {
-      if (GV->use_empty())
-        return false;
-      return !GV->hasOneUse() || !Used.count(GV);
-    };
-
-    llvm::DenseMap<Function *, MDNode *> EntryPointMetadata;
-    for (auto &KP : KernelPayloads) {
-      if (HasUseOtherThanLLVMUsed(KP.Kernel))
-        llvm_unreachable("Kernel entry point can't have uses.");
-
-      EntryPointMetadata[KP.Kernel] = KP.MD;
-    }
-
-    return EntryPointMetadata;
-  }
-
-  virtual llvm::StringRef getPassName() const override {
-    return "Add implicit SYCL global offset";
+    ModuleAnalysisManager DummyMAM;
+    auto PA = Impl.run(M, DummyMAM);
+    return !PA.areAllPreserved();
   }
 
 private:
-  // Keep track of which functions have been processed to avoid processing twice
-  llvm::DenseMap<Function *, Value *> ProcessedFunctions;
-  // Keep a map of all entry point functions with metadata
-  llvm::DenseMap<Function *, MDNode *> EntryPointMetadata;
-  llvm::Type *KernelImplicitArgumentType;
-  llvm::Type *ImplicitOffsetPtrType;
-
-  TargetHelpers::ArchType AT;
-  unsigned TargetAS = 0;
+  GlobalOffsetPass Impl;
 };
+} // namespace
 
-} // end anonymous namespace
+char GlobalOffsetLegacy::ID = 0;
+INITIALIZE_PASS(GlobalOffsetLegacy, "globaloffset",
+                "SYCL Add Implicit Global Offset", false, false)
 
-char GlobalOffset::ID = 0;
+ModulePass *llvm::createGlobalOffsetPassLegacy() {
+  return new GlobalOffsetLegacy();
+}
 
-INITIALIZE_PASS(GlobalOffset, "globaloffset", "SYCL Global Offset", false,
-                false)
+// New PM implementation.
+PreservedAnalyses GlobalOffsetPass::run(Module &M, ModuleAnalysisManager &) {
+  if (!EnableGlobalOffset)
+    return PreservedAnalyses::all();
 
-ModulePass *llvm::createGlobalOffsetPass() { return new GlobalOffset(); }
+  AT = TargetHelpers::getArchType(M);
+  llvm::Function *ImplicitOffsetIntrinsic = M.getFunction(Intrinsic::getName(
+      AT == ArchType::Cuda
+          ? static_cast<unsigned>(Intrinsic::nvvm_implicit_offset)
+          : static_cast<unsigned>(Intrinsic::amdgcn_implicit_offset)));
+
+  if (!ImplicitOffsetIntrinsic || ImplicitOffsetIntrinsic->use_empty())
+    return PreservedAnalyses::all();
+
+  // For AMD allocas and pointers have to be to CONSTANT_PRIVATE (5), NVVM is
+  // happy with ADDRESS_SPACE_GENERIC (0).
+  TargetAS = AT == ArchType::Cuda ? 0 : 5;
+  KernelImplicitArgumentType =
+      ArrayType::get(Type::getInt32Ty(M.getContext()), 3);
+  ImplicitOffsetPtrType =
+      Type::getInt32Ty(M.getContext())->getPointerTo(TargetAS);
+  assert((!ImplicitOffsetIntrinsic ||
+          ImplicitOffsetIntrinsic->getReturnType() == ImplicitOffsetPtrType) &&
+         "Implicit offset intrinsic does not return the expected type");
+
+  SmallVector<KernelPayload, 4> KernelPayloads;
+  TargetHelpers::populateKernels(M, KernelPayloads, AT);
+
+  // Validate kernels and populate entry map
+  EntryPointMetadata = validateKernels(M, KernelPayloads);
+
+  // Add implicit parameters to all direct and indirect users of the offset
+  addImplicitParameterToCallers(M, ImplicitOffsetIntrinsic, nullptr);
+
+  // Assert that all uses of `ImplicitOffsetIntrinsic` are removed and delete
+  // it.
+  assert(ImplicitOffsetIntrinsic->use_empty() &&
+         "Not all uses of intrinsic removed");
+  ImplicitOffsetIntrinsic->eraseFromParent();
+
+  return PreservedAnalyses::none();
+}
+
+void GlobalOffsetPass::processKernelEntryPoint(Module &M, Function *Func) {
+  assert(EntryPointMetadata.count(Func) != 0 &&
+         "Function must be an entry point");
+
+  LLVMContext &Ctx = M.getContext();
+  MDNode *FuncMetadata = EntryPointMetadata[Func];
+
+  // Already processed.
+  if (ProcessedFunctions.count(Func) == 1)
+    return;
+
+  // Add the new argument to all other kernel entry points, despite not
+  // using the global offset.
+  auto *KernelMetadata = M.getNamedMetadata(getAnnotationString(AT).c_str());
+  assert(KernelMetadata && "IR compiled must have correct annotations");
+
+  auto *NewFunc = addOffsetArgumentToFunction(
+                      M, Func, KernelImplicitArgumentType->getPointerTo(),
+                      /*KeepOriginal=*/true)
+                      .first;
+  Argument *NewArgument = NewFunc->arg_begin() + (NewFunc->arg_size() - 1);
+  // Pass byval to the kernel for NVIDIA, AMD's calling convention disallows
+  // byval args, use byref.
+  auto Attr =
+      AT == ArchType::Cuda
+          ? Attribute::getWithByValType(Ctx, KernelImplicitArgumentType)
+          : Attribute::getWithByRefType(Ctx, KernelImplicitArgumentType);
+  NewArgument->addAttr(Attr);
+
+  // Add the metadata.
+  Metadata *NewMetadata[] = {ConstantAsMetadata::get(NewFunc),
+                             FuncMetadata->getOperand(1),
+                             FuncMetadata->getOperand(2)};
+  KernelMetadata->addOperand(MDNode::get(Ctx, NewMetadata));
+
+  // Create alloca of zeros for the implicit offset in original func
+  BasicBlock *EntryBlock = &Func->getEntryBlock();
+  IRBuilder<> Builder(EntryBlock, EntryBlock->getFirstInsertionPt());
+  Type *ImplicitOffsetType =
+      ArrayType::get(Type::getInt32Ty(M.getContext()), 3);
+  AllocaInst *ImplicitOffset =
+      Builder.CreateAlloca(ImplicitOffsetType, TargetAS);
+  uint64_t AllocByteSize =
+      ImplicitOffset->getAllocationSizeInBits(M.getDataLayout()).getValue() / 8;
+  CallInst *MemsetCall =
+      Builder.CreateMemSet(ImplicitOffset, Builder.getInt8(0), AllocByteSize,
+                           ImplicitOffset->getAlign());
+  MemsetCall->addParamAttr(0, Attribute::NonNull);
+  MemsetCall->addDereferenceableParamAttr(0, AllocByteSize);
+  ProcessedFunctions[Func] = Builder.CreateConstInBoundsGEP2_32(
+      ImplicitOffsetType, ImplicitOffset, 0, 0);
+}
+
+// This function adds an implicit parameter to the function containing a call
+// instruction to the implicit offset intrinsic or another function (which
+// eventually calls the instrinsic). If the call instruction is to the
+// implicit offset intrinsic, then the intrinisic is replaced with the
+// parameter that was added.
+//
+// `Callee` is the function (to which this transformation has already been
+// applied), or to the implicit offset intrinsic. `CalleeWithImplicitParam`
+// indicates whether Callee is to the implicit intrinsic (when `nullptr`) or
+// to another function (not `nullptr`) - this is used to know whether calls to
+// it needs to have the implicit parameter added to it or replaced with the
+// implicit parameter.
+//
+// Once the function, say `F`, containing a call to `Callee` has the implicit
+// parameter added, callers of `F` are processed by recursively calling this
+// function, passing `F` to `CalleeWithImplicitParam`.
+//
+// Since the cloning of entry points may alter the users of a function, the
+// cloning must be done as early as possible, as to ensure that no users are
+// added to previous callees in the call-tree.
+void GlobalOffsetPass::addImplicitParameterToCallers(
+    Module &M, Value *Callee, Function *CalleeWithImplicitParam) {
+
+  // Make sure that all entry point callers are processed.
+  SmallVector<User *, 8> Users{Callee->users()};
+  for (User *U : Users) {
+    auto *Call = dyn_cast<CallInst>(U);
+    if (!Call)
+      continue;
+
+    Function *Caller = Call->getFunction();
+    if (EntryPointMetadata.count(Caller) != 0) {
+      processKernelEntryPoint(M, Caller);
+    }
+  }
+
+  // User collection may have changed, so we reinitialize it.
+  Users = SmallVector<User *, 8>{Callee->users()};
+  for (User *U : Users) {
+    auto *CallToOld = dyn_cast<CallInst>(U);
+    if (!CallToOld)
+      return;
+
+    auto *Caller = CallToOld->getFunction();
+
+    // Determine if `Caller` needs processed or if this is another callsite
+    // from an already-processed function.
+    Function *NewFunc;
+    Value *ImplicitOffset = ProcessedFunctions[Caller];
+    bool AlreadyProcessed = ImplicitOffset != nullptr;
+    if (AlreadyProcessed) {
+      NewFunc = Caller;
+    } else {
+      std::tie(NewFunc, ImplicitOffset) =
+          addOffsetArgumentToFunction(M, Caller);
+    }
+
+    if (!CalleeWithImplicitParam) {
+      // Replace intrinsic call with parameter.
+      CallToOld->replaceAllUsesWith(ImplicitOffset);
+    } else {
+      // Build up a list of arguments to call the modified function using.
+      llvm::SmallVector<Value *, 8> ImplicitOffsets;
+      for (Use &U : CallToOld->args()) {
+        ImplicitOffsets.push_back(U);
+      }
+      ImplicitOffsets.push_back(ImplicitOffset);
+
+      // Replace call to other function (which now has a new parameter),
+      // with a call including the new parameter to that same function.
+      auto *NewCaller = CallInst::Create(
+          /* Ty= */ CalleeWithImplicitParam->getFunctionType(),
+          /* Func= */ CalleeWithImplicitParam,
+          /* Args= */ ImplicitOffsets,
+          /* NameStr= */ Twine(),
+          /* InsertBefore= */ CallToOld);
+      NewCaller->setTailCallKind(CallToOld->getTailCallKind());
+      NewCaller->copyMetadata(*CallToOld);
+      CallToOld->replaceAllUsesWith(NewCaller);
+
+      if (CallToOld->hasName()) {
+        NewCaller->takeName(CallToOld);
+      }
+    }
+
+    // Remove the caller now that it has been replaced.
+    CallToOld->eraseFromParent();
+
+    if (!AlreadyProcessed) {
+      // Process callers of the old function.
+      addImplicitParameterToCallers(M, Caller, NewFunc);
+
+      // Now that the old function is dead, delete it.
+      Caller->dropAllReferences();
+      Caller->eraseFromParent();
+    }
+  }
+}
+
+std::pair<Function *, Value *> GlobalOffsetPass::addOffsetArgumentToFunction(
+    Module &M, Function *Func, Type *ImplicitArgumentType, bool KeepOriginal) {
+  FunctionType *FuncTy = Func->getFunctionType();
+  const AttributeList &FuncAttrs = Func->getAttributes();
+  ImplicitArgumentType =
+      ImplicitArgumentType ? ImplicitArgumentType : ImplicitOffsetPtrType;
+
+  // Construct an argument list containing all of the previous arguments.
+  SmallVector<Type *, 8> Arguments;
+  SmallVector<AttributeSet, 8> ArgumentAttributes;
+
+  unsigned i = 0;
+  for (Function::arg_iterator FuncArg = Func->arg_begin(),
+                              FuncEnd = Func->arg_end();
+       FuncArg != FuncEnd; ++FuncArg, ++i) {
+    Arguments.push_back(FuncArg->getType());
+    ArgumentAttributes.push_back(FuncAttrs.getParamAttrs(i));
+  }
+
+  // Add the offset argument. Must be the same type as returned by
+  // `llvm.{amdgcn|nvvm}.implicit.offset`.
+  Arguments.push_back(ImplicitArgumentType);
+  ArgumentAttributes.push_back(AttributeSet());
+
+  // Build the new function.
+  AttributeList NAttrs =
+      AttributeList::get(Func->getContext(), FuncAttrs.getFnAttrs(),
+                         FuncAttrs.getRetAttrs(), ArgumentAttributes);
+  assert(!FuncTy->isVarArg() && "Variadic arguments prohibited in SYCL");
+  FunctionType *NewFuncTy =
+      FunctionType::get(FuncTy->getReturnType(), Arguments, FuncTy->isVarArg());
+
+  Function *NewFunc =
+      Function::Create(NewFuncTy, Func->getLinkage(), Func->getAddressSpace());
+
+  // Keep original function ordering.
+  M.getFunctionList().insertAfter(Func->getIterator(), NewFunc);
+
+  Value *ImplicitOffset = nullptr;
+  bool ImplicitOffsetAllocaInserted = false;
+  if (KeepOriginal) {
+    // TODO: Are there better naming alternatives that allow for unmangling?
+    NewFunc->setName(Func->getName() + "_with_offset");
+
+    ValueToValueMapTy VMap;
+    for (Function::arg_iterator FuncArg = Func->arg_begin(),
+                                FuncEnd = Func->arg_end(),
+                                NewFuncArg = NewFunc->arg_begin();
+         FuncArg != FuncEnd; ++FuncArg, ++NewFuncArg) {
+      VMap[FuncArg] = NewFuncArg;
+    }
+
+    SmallVector<ReturnInst *, 8> Returns;
+    CloneFunctionInto(NewFunc, Func, VMap,
+                      CloneFunctionChangeType::GlobalChanges, Returns);
+    // In order to keep the signatures of functions called by the kernel
+    // unified, the pass has to copy global offset to an array allocated in
+    // addrspace(3). This is done as kernels can't allocate and fill the
+    // array in constant address space, which would be required for the case
+    // with no global offset.
+    if (AT == ArchType::AMDHSA) {
+      BasicBlock *EntryBlock = &NewFunc->getEntryBlock();
+      IRBuilder<> Builder(EntryBlock, EntryBlock->getFirstInsertionPt());
+      Type *ImplicitOffsetType =
+          ArrayType::get(Type::getInt32Ty(M.getContext()), 3);
+      Value *OrigImplicitOffset =
+          NewFunc->arg_begin() + (NewFunc->arg_size() - 1);
+      AllocaInst *ImplicitOffsetAlloca =
+          Builder.CreateAlloca(ImplicitOffsetType, TargetAS);
+      auto DL = M.getDataLayout();
+      uint64_t AllocByteSize =
+          ImplicitOffsetAlloca->getAllocationSizeInBits(DL).getValue() / 8;
+      // After AMD's kernel arg lowering pass runs the accesses to arguments
+      // are replaced with uses of kernarg.segment.ptr which is in
+      // addrspace(4), cast implicit offset arg to constant memory so the
+      // memcpy is issued into a correct address space.
+      auto OrigImplicitOffsetAS4 = Builder.CreateAddrSpaceCast(
+          OrigImplicitOffset, Type::getInt8Ty(M.getContext())->getPointerTo(4));
+      Builder.CreateMemCpy(
+          ImplicitOffsetAlloca, ImplicitOffsetAlloca->getAlign(),
+          OrigImplicitOffsetAS4, OrigImplicitOffsetAS4->getPointerAlignment(DL),
+          AllocByteSize);
+      ImplicitOffset = ImplicitOffsetAlloca;
+      ImplicitArgumentType = ImplicitOffset->getType();
+      ImplicitOffsetAllocaInserted = true;
+    } else {
+      ImplicitOffset = NewFunc->arg_begin() + (NewFunc->arg_size() - 1);
+    }
+  } else {
+    NewFunc->copyAttributesFrom(Func);
+    NewFunc->setComdat(Func->getComdat());
+    NewFunc->setAttributes(NAttrs);
+    NewFunc->takeName(Func);
+
+    // Splice the body of the old function right into the new function.
+    NewFunc->getBasicBlockList().splice(NewFunc->begin(),
+                                        Func->getBasicBlockList());
+
+    for (Function::arg_iterator FuncArg = Func->arg_begin(),
+                                FuncEnd = Func->arg_end(),
+                                NewFuncArg = NewFunc->arg_begin();
+         FuncArg != FuncEnd; ++FuncArg, ++NewFuncArg) {
+      FuncArg->replaceAllUsesWith(NewFuncArg);
+    }
+
+    // Clone metadata of the old function, including debug info descriptor.
+    SmallVector<std::pair<unsigned, MDNode *>, 1> MDs;
+    Func->getAllMetadata(MDs);
+    for (auto MD : MDs)
+      NewFunc->addMetadata(MD.first, *MD.second);
+
+    ImplicitOffset = NewFunc->arg_begin() + (NewFunc->arg_size() - 1);
+  }
+  assert(ImplicitOffset && "Value of implicit offset must be set.");
+
+  // Add bitcast to match the return type of the intrinsic if needed.
+  if (ImplicitArgumentType != ImplicitOffsetPtrType) {
+    BasicBlock *EntryBlock = &NewFunc->getEntryBlock();
+    // Make sure bitcast is inserted after alloca, if present.
+    BasicBlock::iterator InsertionPt =
+        ImplicitOffsetAllocaInserted
+            ? std::next(((AllocaInst *)ImplicitOffset)->getIterator())
+            : EntryBlock->getFirstInsertionPt();
+    IRBuilder<> Builder(EntryBlock, InsertionPt);
+    ImplicitOffset = Builder.CreateBitCast(
+        ImplicitOffset,
+        Type::getInt32Ty(M.getContext())->getPointerTo(TargetAS));
+  }
+
+  ProcessedFunctions[NewFunc] = ImplicitOffset;
+
+  // Return the new function and the offset argument.
+  return {NewFunc, ImplicitOffset};
+}
+
+DenseMap<Function *, MDNode *> GlobalOffsetPass::validateKernels(
+    Module &M, SmallVectorImpl<KernelPayload> &KernelPayloads) {
+  SmallPtrSet<GlobalValue *, 8u> Used;
+  SmallVector<GlobalValue *, 4> Vec;
+  collectUsedGlobalVariables(M, Vec, /*CompilerUsed=*/false);
+  collectUsedGlobalVariables(M, Vec, /*CompilerUsed=*/true);
+  Used = {Vec.begin(), Vec.end()};
+
+  auto HasUseOtherThanLLVMUsed = [&Used](GlobalValue *GV) {
+    if (GV->use_empty())
+      return false;
+    return !GV->hasOneUse() || !Used.count(GV);
+  };
+
+  llvm::DenseMap<Function *, MDNode *> EntryPointMetadata;
+  for (auto &KP : KernelPayloads) {
+    if (HasUseOtherThanLLVMUsed(KP.Kernel))
+      llvm_unreachable("Kernel entry point can't have uses.");
+
+    EntryPointMetadata[KP.Kernel] = KP.MD;
+  }
+
+  return EntryPointMetadata;
+}

--- a/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
+++ b/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
@@ -143,7 +143,7 @@ void GlobalOffsetPass::processKernelEntryPoint(Module &M, Function *Func) {
                              FuncMetadata->getOperand(2)};
   KernelMetadata->addOperand(MDNode::get(Ctx, NewMetadata));
 
-  // Create alloca of zeros for the implicit offset in original func
+  // Create alloca of zeros for the implicit offset in the original func.
   BasicBlock *EntryBlock = &Func->getEntryBlock();
   IRBuilder<> Builder(EntryBlock, EntryBlock->getFirstInsertionPt());
   Type *ImplicitOffsetType =

--- a/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
+++ b/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
@@ -89,7 +89,7 @@ PreservedAnalyses GlobalOffsetPass::run(Module &M, ModuleAnalysisManager &) {
   TargetHelpers::populateKernels(M, KernelPayloads, AT);
 
   // Validate kernels and populate entry map
-  EntryPointMetadata = validateKernels(M, KernelPayloads);
+  EntryPointMetadata = generateKernelMDNodeMap(M, KernelPayloads);
 
   // Add implicit parameters to all direct and indirect users of the offset
   addImplicitParameterToCallers(M, ImplicitOffsetIntrinsic, nullptr);
@@ -367,7 +367,7 @@ std::pair<Function *, Value *> GlobalOffsetPass::addOffsetArgumentToFunction(
   return {NewFunc, ImplicitOffset};
 }
 
-DenseMap<Function *, MDNode *> GlobalOffsetPass::validateKernels(
+DenseMap<Function *, MDNode *> GlobalOffsetPass::generateKernelMDNodeMap(
     Module &M, SmallVectorImpl<KernelPayload> &KernelPayloads) {
   SmallPtrSet<GlobalValue *, 8u> Used;
   SmallVector<GlobalValue *, 4> Vec;

--- a/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
+++ b/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
@@ -5,12 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
-// This pass operates on SYCL kernels. It looks for uses of the
-// `llvm.{amdgcn|nvvm}.implicit.offset` intrinsic and replaces it with an
-// offset parameter which will be threaded through from the kernel entry point.
-//
-//===----------------------------------------------------------------------===//
 
 #include "llvm/SYCLLowerIR/GlobalOffset.h"
 #include "llvm/ADT/SmallSet.h"

--- a/llvm/lib/SYCLLowerIR/LocalAccessorToSharedMemory.cpp
+++ b/llvm/lib/SYCLLowerIR/LocalAccessorToSharedMemory.cpp
@@ -5,14 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//
-// This pass operates on SYCL kernels. It modifies kernel entry points which
-// take pointers to shared memory and alters them to take offsets into shared
-// memory (represented by a symbol in the shared address space). The SYCL
-// runtime is expected to provide offsets rather than pointers to these
-// functions.
-//
-//===----------------------------------------------------------------------===//
 
 #include "llvm/SYCLLowerIR/LocalAccessorToSharedMemory.h"
 #include "llvm/IR/Constants.h"

--- a/llvm/lib/SYCLLowerIR/LocalAccessorToSharedMemory.cpp
+++ b/llvm/lib/SYCLLowerIR/LocalAccessorToSharedMemory.cpp
@@ -19,7 +19,7 @@
 #include "llvm/IR/GlobalValue.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/PassManager.h"
-#include "llvm/SYCLLowerIR/TargetHelpers.h"
+#include "llvm/Pass.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Transforms/IPO.h"
 
@@ -27,204 +27,200 @@ using namespace llvm;
 
 #define DEBUG_TYPE "localaccessortosharedmemory"
 
-namespace llvm {
-void initializeLocalAccessorToSharedMemoryPass(PassRegistry &);
-} // namespace llvm
-
+// Legacy PM wrapper.
 namespace {
-
-class LocalAccessorToSharedMemory : public ModulePass {
-private:
-  using KernelPayload = TargetHelpers::KernelPayload;
-  using ArchType = TargetHelpers::ArchType;
-
-  // The value for NVVM's ADDRESS_SPACE_SHARED and AMD's LOCAL_ADDRESS happen to
-  // be 3.
-  const unsigned SharedASValue = 3;
-
+class LocalAccessorToSharedMemoryLegacy : public ModulePass {
 public:
   static char ID;
-  LocalAccessorToSharedMemory() : ModulePass(ID) {}
 
-  bool runOnModule(Module &M) override {
-    const auto AT = TargetHelpers::getArchType(M);
-
-    // Invariant: This pass is only intended to operate on SYCL kernels being
-    // compiled to either `nvptx{,64}-nvidia-cuda`, or `amdgcn-amd-amdhsa`
-    // triples.
-    if (ArchType::Unsupported == AT)
-      return false;
-
-    if (skipModule(M))
-      return false;
-
-    SmallVector<KernelPayload, 4> Kernels;
-    TargetHelpers::populateKernels(M, Kernels, AT);
-    SmallVector<std::pair<Function *, KernelPayload>, 4> NewToOldKernels;
-    if (Kernels.empty())
-      return false;
-
-    // Process the function and if changed, update the metadata.
-    for (auto K : Kernels) {
-      auto *NewKernel = processKernel(M, K.Kernel);
-      if (NewKernel)
-        NewToOldKernels.push_back(std::make_pair(NewKernel, K));
-    }
-
-    if (NewToOldKernels.empty())
-      return false;
-
-    postProcessKernels(NewToOldKernels);
-
-    return true;
+  LocalAccessorToSharedMemoryLegacy() : ModulePass(ID) {
+    initializeLocalAccessorToSharedMemoryLegacyPass(
+        *PassRegistry::getPassRegistry());
   }
 
-  virtual llvm::StringRef getPassName() const override {
-    return "SYCL Local Accessor to Shared Memory";
+  bool runOnModule(Module &M) override {
+    ModuleAnalysisManager DummyMAM;
+    auto PA = Impl.run(M, DummyMAM);
+    return !PA.areAllPreserved();
   }
 
 private:
-  Function *processKernel(Module &M, Function *F) {
-    // Check if this function is eligible by having an argument that uses shared
-    // memory.
-    auto UsesLocalMemory = false;
-    for (Function::arg_iterator FA = F->arg_begin(), FE = F->arg_end();
-         FA != FE; ++FA) {
-      if (FA->getType()->isPointerTy() &&
-          FA->getType()->getPointerAddressSpace() == SharedASValue) {
-        UsesLocalMemory = true;
-        break;
-      }
-    }
-
-    // Skip functions which are not eligible.
-    if (!UsesLocalMemory)
-      return nullptr;
-
-    // Create a global symbol to CUDA shared memory.
-    auto SharedMemGlobalName = F->getName().str();
-    SharedMemGlobalName.append("_shared_mem");
-    auto *SharedMemGlobalType =
-        ArrayType::get(Type::getInt8Ty(M.getContext()), 0);
-    auto *SharedMemGlobal = new GlobalVariable(
-        /* Module= */ M,
-        /* Type= */ &*SharedMemGlobalType,
-        /* IsConstant= */ false,
-        /* Linkage= */ GlobalValue::ExternalLinkage,
-        /* Initializer= */ nullptr,
-        /* Name= */ Twine{SharedMemGlobalName},
-        /* InsertBefore= */ nullptr,
-        /* ThreadLocalMode= */ GlobalValue::NotThreadLocal,
-        /* AddressSpace= */ SharedASValue,
-        /* IsExternallyInitialized= */ false);
-    SharedMemGlobal->setAlignment(Align(4));
-
-    FunctionType *FTy = F->getFunctionType();
-    const AttributeList &FAttrs = F->getAttributes();
-
-    // Store the arguments and attributes for the new function, as well as which
-    // arguments were replaced.
-    std::vector<Type *> Arguments;
-    SmallVector<AttributeSet, 8> ArgumentAttributes;
-    SmallVector<bool, 10> ArgumentReplaced(FTy->getNumParams(), false);
-
-    unsigned i = 0;
-    for (Function::arg_iterator FA = F->arg_begin(), FE = F->arg_end();
-         FA != FE; ++FA, ++i) {
-      if (FA->getType()->isPointerTy() &&
-          FA->getType()->getPointerAddressSpace() == SharedASValue) {
-        // Replace pointers to shared memory with i32 offsets.
-        Arguments.push_back(Type::getInt32Ty(M.getContext()));
-        ArgumentAttributes.push_back(
-            AttributeSet::get(M.getContext(), ArrayRef<Attribute>{}));
-        ArgumentReplaced[i] = true;
-      } else {
-        // Replace other arguments with the same type as before.
-        Arguments.push_back(FA->getType());
-        ArgumentAttributes.push_back(FAttrs.getParamAttrs(i));
-      }
-    }
-
-    // Create new function type.
-    AttributeList NAttrs =
-        AttributeList::get(F->getContext(), FAttrs.getFnAttrs(),
-                           FAttrs.getRetAttrs(), ArgumentAttributes);
-    FunctionType *NFTy =
-        FunctionType::get(FTy->getReturnType(), Arguments, FTy->isVarArg());
-
-    // Create the new function body and insert it into the module.
-    Function *NF = Function::Create(NFTy, F->getLinkage(), F->getAddressSpace(),
-                                    Twine{""}, &M);
-    NF->copyAttributesFrom(F);
-    NF->setComdat(F->getComdat());
-    NF->setAttributes(NAttrs);
-    NF->takeName(F);
-
-    // Splice the body of the old function right into the new function.
-    NF->getBasicBlockList().splice(NF->begin(), F->getBasicBlockList());
-
-    i = 0;
-    for (Function::arg_iterator FA = F->arg_begin(), FE = F->arg_end(),
-                                NFA = NF->arg_begin();
-         FA != FE; ++FA, ++NFA, ++i) {
-      Value *NewValueForUse = NFA;
-      if (ArgumentReplaced[i]) {
-        // If this argument was replaced, then create a `getelementptr`
-        // instruction that uses it to recreate the pointer that was replaced.
-        auto *InsertBefore = &NF->getEntryBlock().front();
-        auto *PtrInst = GetElementPtrInst::CreateInBounds(
-            /* PointeeType= */ SharedMemGlobalType,
-            /* Ptr= */ SharedMemGlobal,
-            /* IdxList= */
-            ArrayRef<Value *>{
-                ConstantInt::get(Type::getInt32Ty(M.getContext()), 0, false),
-                NFA,
-            },
-            /* NameStr= */ Twine{NFA->getName()}, InsertBefore);
-        // Then create a bitcast to make sure the new pointer is the same type
-        // as the old one. This will only ever be a `i8 addrspace(3)*` to `i32
-        // addrspace(3)*` type of cast.
-        auto *CastInst = new BitCastInst(PtrInst, FA->getType());
-        CastInst->insertAfter(PtrInst);
-        NewValueForUse = CastInst;
-      }
-
-      // Replace uses of the old function's argument with the new argument or
-      // the result of the `getelementptr`/`bitcast` instructions.
-      FA->replaceAllUsesWith(&*NewValueForUse);
-      NewValueForUse->takeName(&*FA);
-    }
-
-    // There should be no callers of kernel entry points.
-    assert(F->use_empty());
-
-    // Clone metadata of the old function, including debug info descriptor.
-    SmallVector<std::pair<unsigned, MDNode *>, 1> MDs;
-    F->getAllMetadata(MDs);
-    for (auto MD : MDs)
-      NF->addMetadata(MD.first, *MD.second);
-
-    // Now that the old function is dead, delete it.
-    F->eraseFromParent();
-
-    return NF;
-  }
-
-  void postProcessKernels(
-      SmallVectorImpl<std::pair<Function *, KernelPayload>> &NewToOldKernels) {
-    for (auto &Pair : NewToOldKernels) {
-      std::get<1>(Pair).MD->replaceOperandWith(
-          0, llvm::ConstantAsMetadata::get(std::get<0>(Pair)));
-    }
-  }
+  LocalAccessorToSharedMemoryPass Impl;
 };
-} // end anonymous namespace
+} // namespace
 
-char LocalAccessorToSharedMemory::ID = 0;
-
-INITIALIZE_PASS(LocalAccessorToSharedMemory, "localaccessortosharedmemory",
+char LocalAccessorToSharedMemoryLegacy::ID = 0;
+INITIALIZE_PASS(LocalAccessorToSharedMemoryLegacy,
+                "localaccessortosharedmemory",
                 "SYCL Local Accessor to Shared Memory", false, false)
 
-ModulePass *llvm::createLocalAccessorToSharedMemoryPass() {
-  return new LocalAccessorToSharedMemory();
+ModulePass *llvm::createLocalAccessorToSharedMemoryPassLegacy() {
+  return new LocalAccessorToSharedMemoryLegacy();
+}
+
+// New PM implementation.
+PreservedAnalyses
+LocalAccessorToSharedMemoryPass::run(Module &M, ModuleAnalysisManager &) {
+  const auto AT = TargetHelpers::getArchType(M);
+
+  // Invariant: This pass is only intended to operate on SYCL kernels being
+  // compiled to either `nvptx{,64}-nvidia-cuda`, or `amdgcn-amd-amdhsa`
+  // triples.
+  if (ArchType::Unsupported == AT)
+    return PreservedAnalyses::all();
+
+  SmallVector<KernelPayload, 4> Kernels;
+  TargetHelpers::populateKernels(M, Kernels, AT);
+  SmallVector<std::pair<Function *, KernelPayload>, 4> NewToOldKernels;
+  if (Kernels.empty())
+    return PreservedAnalyses::all();
+
+  // Process the function and if changed, update the metadata.
+  for (auto K : Kernels) {
+    auto *NewKernel = processKernel(M, K.Kernel);
+    if (NewKernel)
+      NewToOldKernels.push_back(std::make_pair(NewKernel, K));
+  }
+
+  if (NewToOldKernels.empty())
+    return PreservedAnalyses::all();
+
+  postProcessKernels(NewToOldKernels);
+
+  return PreservedAnalyses::none();
+}
+
+Function *LocalAccessorToSharedMemoryPass::processKernel(Module &M,
+                                                         Function *F) {
+  // Check if this function is eligible by having an argument that uses shared
+  // memory.
+  auto UsesLocalMemory = false;
+  for (Function::arg_iterator FA = F->arg_begin(), FE = F->arg_end(); FA != FE;
+       ++FA) {
+    if (FA->getType()->isPointerTy() &&
+        FA->getType()->getPointerAddressSpace() == SharedASValue) {
+      UsesLocalMemory = true;
+      break;
+    }
+  }
+
+  // Skip functions which are not eligible.
+  if (!UsesLocalMemory)
+    return nullptr;
+
+  // Create a global symbol to CUDA shared memory.
+  auto SharedMemGlobalName = F->getName().str();
+  SharedMemGlobalName.append("_shared_mem");
+  auto *SharedMemGlobalType =
+      ArrayType::get(Type::getInt8Ty(M.getContext()), 0);
+  auto *SharedMemGlobal = new GlobalVariable(
+      /* Module= */ M,
+      /* Type= */ &*SharedMemGlobalType,
+      /* IsConstant= */ false,
+      /* Linkage= */ GlobalValue::ExternalLinkage,
+      /* Initializer= */ nullptr,
+      /* Name= */ Twine{SharedMemGlobalName},
+      /* InsertBefore= */ nullptr,
+      /* ThreadLocalMode= */ GlobalValue::NotThreadLocal,
+      /* AddressSpace= */ SharedASValue,
+      /* IsExternallyInitialized= */ false);
+  SharedMemGlobal->setAlignment(Align(4));
+
+  FunctionType *FTy = F->getFunctionType();
+  const AttributeList &FAttrs = F->getAttributes();
+
+  // Store the arguments and attributes for the new function, as well as which
+  // arguments were replaced.
+  std::vector<Type *> Arguments;
+  SmallVector<AttributeSet, 8> ArgumentAttributes;
+  SmallVector<bool, 10> ArgumentReplaced(FTy->getNumParams(), false);
+
+  unsigned i = 0;
+  for (Function::arg_iterator FA = F->arg_begin(), FE = F->arg_end(); FA != FE;
+       ++FA, ++i) {
+    if (FA->getType()->isPointerTy() &&
+        FA->getType()->getPointerAddressSpace() == SharedASValue) {
+      // Replace pointers to shared memory with i32 offsets.
+      Arguments.push_back(Type::getInt32Ty(M.getContext()));
+      ArgumentAttributes.push_back(
+          AttributeSet::get(M.getContext(), ArrayRef<Attribute>{}));
+      ArgumentReplaced[i] = true;
+    } else {
+      // Replace other arguments with the same type as before.
+      Arguments.push_back(FA->getType());
+      ArgumentAttributes.push_back(FAttrs.getParamAttrs(i));
+    }
+  }
+
+  // Create new function type.
+  AttributeList NAttrs =
+      AttributeList::get(F->getContext(), FAttrs.getFnAttrs(),
+                         FAttrs.getRetAttrs(), ArgumentAttributes);
+  FunctionType *NFTy =
+      FunctionType::get(FTy->getReturnType(), Arguments, FTy->isVarArg());
+
+  // Create the new function body and insert it into the module.
+  Function *NF = Function::Create(NFTy, F->getLinkage(), F->getAddressSpace(),
+                                  Twine{""}, &M);
+  NF->copyAttributesFrom(F);
+  NF->setComdat(F->getComdat());
+  NF->setAttributes(NAttrs);
+  NF->takeName(F);
+
+  // Splice the body of the old function right into the new function.
+  NF->getBasicBlockList().splice(NF->begin(), F->getBasicBlockList());
+
+  i = 0;
+  for (Function::arg_iterator FA = F->arg_begin(), FE = F->arg_end(),
+                              NFA = NF->arg_begin();
+       FA != FE; ++FA, ++NFA, ++i) {
+    Value *NewValueForUse = NFA;
+    if (ArgumentReplaced[i]) {
+      // If this argument was replaced, then create a `getelementptr`
+      // instruction that uses it to recreate the pointer that was replaced.
+      auto *InsertBefore = &NF->getEntryBlock().front();
+      auto *PtrInst = GetElementPtrInst::CreateInBounds(
+          /* PointeeType= */ SharedMemGlobalType,
+          /* Ptr= */ SharedMemGlobal,
+          /* IdxList= */
+          ArrayRef<Value *>{
+              ConstantInt::get(Type::getInt32Ty(M.getContext()), 0, false),
+              NFA,
+          },
+          /* NameStr= */ Twine{NFA->getName()}, InsertBefore);
+      // Then create a bitcast to make sure the new pointer is the same type
+      // as the old one. This will only ever be a `i8 addrspace(3)*` to `i32
+      // addrspace(3)*` type of cast.
+      auto *CastInst = new BitCastInst(PtrInst, FA->getType());
+      CastInst->insertAfter(PtrInst);
+      NewValueForUse = CastInst;
+    }
+
+    // Replace uses of the old function's argument with the new argument or
+    // the result of the `getelementptr`/`bitcast` instructions.
+    FA->replaceAllUsesWith(&*NewValueForUse);
+    NewValueForUse->takeName(&*FA);
+  }
+
+  // There should be no callers of kernel entry points.
+  assert(F->use_empty());
+
+  // Clone metadata of the old function, including debug info descriptor.
+  SmallVector<std::pair<unsigned, MDNode *>, 1> MDs;
+  F->getAllMetadata(MDs);
+  for (auto MD : MDs)
+    NF->addMetadata(MD.first, *MD.second);
+
+  // Now that the old function is dead, delete it.
+  F->eraseFromParent();
+
+  return NF;
+}
+
+void LocalAccessorToSharedMemoryPass::postProcessKernels(
+    SmallVectorImpl<std::pair<Function *, KernelPayload>> &NewToOldKernels) {
+  for (auto &Pair : NewToOldKernels) {
+    std::get<1>(Pair).MD->replaceOperandWith(
+        0, llvm::ConstantAsMetadata::get(std::get<0>(Pair)));
+  }
 }

--- a/llvm/lib/SYCLLowerIR/LocalAccessorToSharedMemory.cpp
+++ b/llvm/lib/SYCLLowerIR/LocalAccessorToSharedMemory.cpp
@@ -31,8 +31,8 @@ public:
   }
 
   bool runOnModule(Module &M) override {
-    ModuleAnalysisManager DummyMAM;
-    auto PA = Impl.run(M, DummyMAM);
+    ModuleAnalysisManager MAM;
+    auto PA = Impl.run(M, MAM);
     return !PA.areAllPreserved();
   }
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -388,7 +388,7 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeAMDGPUTarget() {
 
   // SYCL-specific passes, needed here to be available to `opt`.
   initializeGlobalOffsetLegacyPass(*PR);
-  initializeLocalAccessorToSharedMemoryPass(*PR);
+  initializeLocalAccessorToSharedMemoryLegacyPass(*PR);
 }
 
 static std::unique_ptr<TargetLoweringObjectFile> createTLOF(const Triple &TT) {
@@ -640,6 +640,10 @@ void AMDGPUTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
         }
         if (PassName == "amdgpu-lower-module-lds") {
           PM.addPass(AMDGPULowerModuleLDSPass());
+          return true;
+        }
+        if (PassName == "localaccessortosharedmemory") {
+          PM.addPass(LocalAccessorToSharedMemoryPass());
           return true;
         }
         if (PassName == "globaloffset") {
@@ -1048,7 +1052,7 @@ void AMDGPUPassConfig::addIRPasses() {
 
   if (TM.getTargetTriple().getArch() == Triple::amdgcn &&
       TM.getTargetTriple().getOS() == Triple::OSType::AMDHSA) {
-    addPass(createLocalAccessorToSharedMemoryPass());
+    addPass(createLocalAccessorToSharedMemoryPassLegacy());
     addPass(createGlobalOffsetPassLegacy());
   }
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -387,7 +387,7 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeAMDGPUTarget() {
   initializeGCNPreRAOptimizationsPass(*PR);
 
   // SYCL-specific passes, needed here to be available to `opt`.
-  initializeGlobalOffsetPass(*PR);
+  initializeGlobalOffsetLegacyPass(*PR);
   initializeLocalAccessorToSharedMemoryPass(*PR);
 }
 
@@ -640,6 +640,10 @@ void AMDGPUTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
         }
         if (PassName == "amdgpu-lower-module-lds") {
           PM.addPass(AMDGPULowerModuleLDSPass());
+          return true;
+        }
+        if (PassName == "globaloffset") {
+          PM.addPass(LocalAccessorToSharedMemoryPass());
           return true;
         }
         return false;
@@ -1045,7 +1049,7 @@ void AMDGPUPassConfig::addIRPasses() {
   if (TM.getTargetTriple().getArch() == Triple::amdgcn &&
       TM.getTargetTriple().getOS() == Triple::OSType::AMDHSA) {
     addPass(createLocalAccessorToSharedMemoryPass());
-    addPass(createGlobalOffsetPass());
+    addPass(createGlobalOffsetPassLegacy());
   }
 }
 

--- a/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
@@ -83,7 +83,7 @@ void initializeNVPTXLowerArgsPass(PassRegistry &);
 void initializeNVPTXLowerAllocaPass(PassRegistry &);
 void initializeNVPTXProxyRegErasurePass(PassRegistry &);
 
-void initializeGlobalOffsetPass(PassRegistry &);
+void initializeGlobalOffsetLegacyPass(PassRegistry &);
 void initializeLocalAccessorToSharedMemoryPass(PassRegistry &);
 
 } // end namespace llvm
@@ -108,7 +108,7 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeNVPTXTarget() {
   initializeNVPTXProxyRegErasurePass(PR);
 
   // SYCL-specific passes, needed here to be available to `opt`.
-  initializeGlobalOffsetPass(PR);
+  initializeGlobalOffsetLegacyPass(PR);
   initializeLocalAccessorToSharedMemoryPass(PR);
 }
 
@@ -340,7 +340,7 @@ void NVPTXPassConfig::addIRPasses() {
   // FIXME: should the target triple check be done by the pass itself?
   // See createNVPTXLowerArgsPass as an example
   if (getTM<NVPTXTargetMachine>().getTargetTriple().getOS() == Triple::CUDA) {
-    addPass(createGlobalOffsetPass());
+    addPass(createGlobalOffsetPassLegacy());
     addPass(createLocalAccessorToSharedMemoryPass());
   }
 

--- a/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
+++ b/llvm/lib/Target/NVPTX/NVPTXTargetMachine.cpp
@@ -84,7 +84,7 @@ void initializeNVPTXLowerAllocaPass(PassRegistry &);
 void initializeNVPTXProxyRegErasurePass(PassRegistry &);
 
 void initializeGlobalOffsetLegacyPass(PassRegistry &);
-void initializeLocalAccessorToSharedMemoryPass(PassRegistry &);
+void initializeLocalAccessorToSharedMemoryLegacyPass(PassRegistry &);
 
 } // end namespace llvm
 
@@ -109,7 +109,7 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeNVPTXTarget() {
 
   // SYCL-specific passes, needed here to be available to `opt`.
   initializeGlobalOffsetLegacyPass(PR);
-  initializeLocalAccessorToSharedMemoryPass(PR);
+  initializeLocalAccessorToSharedMemoryLegacyPass(PR);
 }
 
 static std::string computeDataLayout(bool is64Bit, bool UseShortPointers) {
@@ -341,7 +341,7 @@ void NVPTXPassConfig::addIRPasses() {
   // See createNVPTXLowerArgsPass as an example
   if (getTM<NVPTXTargetMachine>().getTargetTriple().getOS() == Triple::CUDA) {
     addPass(createGlobalOffsetPassLegacy());
-    addPass(createLocalAccessorToSharedMemoryPass());
+    addPass(createLocalAccessorToSharedMemoryPassLegacy());
   }
 
   if (getOptLevel() != CodeGenOpt::None)

--- a/llvm/test/CodeGen/AMDGPU/llc-pipeline.ll
+++ b/llvm/test/CodeGen/AMDGPU/llc-pipeline.ll
@@ -48,7 +48,7 @@
 ; GCN-O0-NEXT:      Scalarize Masked Memory Intrinsics
 ; GCN-O0-NEXT:      Expand reduction intrinsics
 ; GCN-O0-NEXT:    SYCL Local Accessor to Shared Memory
-; GCN-O0-NEXT:    Add implicit SYCL global offset
+; GCN-O0-NEXT:    SYCL Add Implicit Global Offset
 ; GCN-O0-NEXT:    AMDGPU Attributor
 ; GCN-O0-NEXT:    CallGraph Construction
 ; GCN-O0-NEXT:    Call Graph SCC Pass Manager
@@ -217,7 +217,7 @@
 ; GCN-O1-NEXT:      Natural Loop Information
 ; GCN-O1-NEXT:      TLS Variable Hoist
 ; GCN-O1-NEXT:    SYCL Local Accessor to Shared Memory
-; GCN-O1-NEXT:    Add implicit SYCL global offset
+; GCN-O1-NEXT:    SYCL Add Implicit Global Offset
 ; GCN-O1-NEXT:    AMDGPU Attributor
 ; GCN-O1-NEXT:    CallGraph Construction
 ; GCN-O1-NEXT:    Call Graph SCC Pass Manager
@@ -491,7 +491,7 @@
 ; GCN-O1-OPTS-NEXT:      TLS Variable Hoist
 ; GCN-O1-OPTS-NEXT:      Early CSE
 ; GCN-O1-OPTS-NEXT:    SYCL Local Accessor to Shared Memory
-; GCN-O1-OPTS-NEXT:    Add implicit SYCL global offset
+; GCN-O1-OPTS-NEXT:    SYCL Add Implicit Global Offset
 ; GCN-O1-OPTS-NEXT:    AMDGPU Attributor
 ; GCN-O1-OPTS-NEXT:    CallGraph Construction
 ; GCN-O1-OPTS-NEXT:    Call Graph SCC Pass Manager
@@ -779,7 +779,7 @@
 ; GCN-O2-NEXT:      TLS Variable Hoist
 ; GCN-O2-NEXT:      Early CSE
 ; GCN-O2-NEXT:    SYCL Local Accessor to Shared Memory
-; GCN-O2-NEXT:    Add implicit SYCL global offset
+; GCN-O2-NEXT:    SYCL Add Implicit Global Offset
 ; GCN-O2-NEXT:    AMDGPU Attributor
 ; GCN-O2-NEXT:    CallGraph Construction
 ; GCN-O2-NEXT:    Call Graph SCC Pass Manager
@@ -1081,7 +1081,7 @@
 ; GCN-O3-NEXT:      Optimization Remark Emitter
 ; GCN-O3-NEXT:      Global Value Numbering
 ; GCN-O3-NEXT:    SYCL Local Accessor to Shared Memory
-; GCN-O3-NEXT:    Add implicit SYCL global offset
+; GCN-O3-NEXT:    SYCL Add Implicit Global Offset
 ; GCN-O3-NEXT:    AMDGPU Attributor
 ; GCN-O3-NEXT:    CallGraph Construction
 ; GCN-O3-NEXT:    Call Graph SCC Pass Manager


### PR DESCRIPTION
This patch ports Local Accessor and Global Offset passes to the new pass manager. As most of other passes in both AMDGPU and NVPTX backends are still running with the legacy PM, it provides a legacy struct that wraps around the new PM and lets the old interface be used.

Fixes: https://github.com/intel/llvm/issues/5310