### PR TITLE
[SYCL] Fixes unused argument for L0 _pi_buffer

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -976,8 +976,8 @@ struct _pi_buffer final : _pi_mem {
   _pi_buffer(pi_context Ctx, char *Mem, char *HostPtr, bool OwnZeMemHandle,
              _pi_mem *Parent = nullptr, size_t Origin = 0, size_t Size = 0,
              bool MemOnHost = false, bool ImportedHostPtr = false)
-      : _pi_mem(Ctx, HostPtr, OwnZeMemHandle, MemOnHost), ZeMem{Mem},
-        SubBuffer{Parent, Origin, Size} {}
+      : _pi_mem(Ctx, HostPtr, OwnZeMemHandle, MemOnHost, ImportedHostPtr),
+        ZeMem{Mem}, SubBuffer{Parent, Origin, Size} {}
 
   void *getZeHandle() override { return ZeMem; }
 


### PR DESCRIPTION
intel/llvm#5229 removed the propagation of the ImportedHostPtr argument from _pi_buffer to the _pi_mem superclass. This seems like an unintended change and this commit re-adds the propagation.

This should fix the current post-commit `-Werror` failures.