### PR TITLE
[SYCL][Doc] Clarify availability of get_property()

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
@@ -444,15 +444,16 @@ a|
 template<typename PropertyT>
 PropertyT get_property() const;
 ``` | Returns a copy of the property value contained in the property list.
-Must produce a compile error if the property list does not contain a PropertyT property.
-Available only if `PropertyT` is a runtime property.
+Available only if `PropertyT` is a runtime property and the property list
+contains a `PropertyT` property.
 a|
 ```c++
 template<typename PropertyKeyT>
 static constexpr auto get_property();
 ``` | Returns a copy of the property value contained in the property list.
-Must produce a compile error if the property_list does not contain a property with the `PropertyKeyT` key.
-Available only if `PropertyKeyT` is the property key class of a compile-time constant property.
+Available only if `PropertyKeyT` is the property key class of a compile-time
+constant property and the property list contains a property with the
+`PropertyKeyT` key.
 |===
 --
 


### PR DESCRIPTION
The extension previously said that certain calls to get_property()
must produce a compiler error, which could be satisfied by calling
static_assert(). A static_assert()-based solution throws errors
any time the get_property<> template is instantiated, which can
lead to some surprising errors in user code.

Stating that get_property() must only be available when the property
type exists in the property list has two advantages:

1) Users can more easily reason about when errors will be thrown and
   how to avoid those errors.

2) Users can rely on all implementations to have the same error
   behavior.

Signed-off-by: John Pennycook <john.pennycook@intel.com>