### PR TITLE
Make sycl/test/tools/abi_check_positive work with lld linker

### DIFF
--- a/sycl/test/tools/abi_check_positive_dump.txt
+++ b/sycl/test/tools/abi_check_positive_dump.txt
@@ -1,6 +1,5 @@
 __libc_csu_fini
 __libc_csu_init
-_dl_relocate_static_pie
 _start
 _Z3foov
 main

--- a/sycl/tools/abi_check.py
+++ b/sycl/tools/abi_check.py
@@ -102,6 +102,10 @@ def check_symbols(ref_path, target_path):
     readobj_out = subprocess.check_output([get_llvm_bin_path()+"llvm-readobj",
                                            readobj_opts, target_path])
     symbols = parse_readobj_output(readobj_out)
+    # Presence of _dl_relocate_static_pie depends on whether ld.gold or ld.lld
+    # is used. Ignore it for the purpose of the library ABI check.
+    ignore_symbols = ["_dl_relocate_static_pie"]
+    symbols = [s for s in symbols if s not in ignore_symbols]
 
     missing_symbols, new_symbols = compare_results(ref_symbols, symbols)
 


### PR DESCRIPTION
$ clang --driver-mode=g++ -D_GLIBCXX_ASSERTIONS=1 abi_check_positive.cpp ; nm a.out | grep _dl_relocate_static_pie
0000000000401050 T _dl_relocate_static_pie

$ clang -fuse-ld=ld.lld  --driver-mode=g++ -D_GLIBCXX_ASSERTIONS=1 abi_check_positive.cpp ; nm a.out | grep _dl_relocate_static_pie
00000000002015e0 t _dl_relocate_static_pie

Note, that in order to reproduce it, one has to enable lld as the default linker
on the system and just LLVM_ENABLE_LLD=ON/LLVM_USE_LINKER=LLD isn't enough as
that doesn't change how the linker is invoked inside the test.

Also, relatively recent version of LLD is needed to pass the ABI checks in the
built libsycl.so, e.g. LLD-10 doesn't mark aliases produced via linker
script (abi_replacements_linux.txt) with Function type. LLD-12 doesn't have that
issue.