### PR TITLE
[SYCL] Add fsycl-id-queries-fit-in-int support for id class

### DIFF
--- a/sycl/include/CL/sycl/id.hpp
+++ b/sycl/include/CL/sycl/id.hpp
@@ -103,6 +103,27 @@ public:
   }
 
 #ifndef __SYCL_DISABLE_ID_TO_INT_CONV__
+  size_t __SYCL_ALWAYS_INLINE get(int dimension) const {
+    base::check_dimension(dimension);
+    size_t Result = this->common_array[dimension];
+    __SYCL_ASSUME_INT(Result);
+    return Result;
+  }
+
+  size_t __SYCL_ALWAYS_INLINE &operator[](int dimension) {
+    base::check_dimension(dimension);
+    size_t &Result = this->common_array[dimension];
+    __SYCL_ASSUME_INT(Result);
+    return Result;
+  }
+
+  size_t __SYCL_ALWAYS_INLINE operator[](int dimension) const {
+    base::check_dimension(dimension);
+    size_t Result = this->common_array[dimension];
+    __SYCL_ASSUME_INT(Result);
+    return Result;
+  }
+
   /* Template operator is not allowed because it disables further type
    * conversion. For example, the next code will not work in case of template
    * conversion:

--- a/sycl/include/CL/sycl/item.hpp
+++ b/sycl/include/CL/sycl/item.hpp
@@ -50,15 +50,11 @@ public:
   id<dimensions> get_id() const { return MImpl.MIndex; }
 
   size_t __SYCL_ALWAYS_INLINE get_id(int dimension) const {
-    size_t Id = MImpl.MIndex[dimension];
-    __SYCL_ASSUME_INT(Id);
-    return Id;
+    return MImpl.MIndex[dimension];
   }
 
   size_t __SYCL_ALWAYS_INLINE operator[](int dimension) const {
-    size_t Id = MImpl.MIndex[dimension];
-    __SYCL_ASSUME_INT(Id);
-    return Id;
+    return MImpl.MIndex[dimension];
   }
 
   range<dimensions> get_range() const { return MImpl.MExtent; }

--- a/sycl/test/check_device_code/id_queries_fit_int.cpp
+++ b/sycl/test/check_device_code/id_queries_fit_int.cpp
@@ -43,3 +43,39 @@ SYCL_EXTERNAL void testNDItem(nd_item<1> TestNDItem) {
   // CHECK: call void @llvm.assume(i1 {{.*}})
   int OffsetConferted = TestNDItem.get_offset();
 }
+
+// CHECK-LABEL: _Z10TestIdDim1N2cl4sycl2idILi1EEE
+SYCL_EXTERNAL void TestIdDim1(id<1> TestId) {
+  // CHECK: call void @llvm.assume(i1 {{.*}})
+  int Id0Get = TestId.get(0);
+  // CHECK: call void @llvm.assume(i1 {{.*}})
+  int Id0 = TestId[0];
+}
+
+// CHECK-LABEL: _Z10TestIdDim2N2cl4sycl2idILi2EEE
+SYCL_EXTERNAL void TestIdDim2(id<2> TestId) {
+  // CHECK: call void @llvm.assume(i1 {{.*}})
+  int Id0Get = TestId.get(0);
+  // CHECK: call void @llvm.assume(i1 {{.*}})
+  int Id1Get = TestId.get(1);
+  // CHECK: call void @llvm.assume(i1 {{.*}})
+  int Id0 = TestId[0];
+  // CHECK: call void @llvm.assume(i1 {{.*}})
+  int Id1 = TestId[1];
+}
+
+// CHECK-LABEL: _Z10TestIdDim3N2cl4sycl2idILi3EEE
+SYCL_EXTERNAL void TestIdDim3(id<3> TestId) {
+  // CHECK: call void @llvm.assume(i1 {{.*}})
+  int Id0Get = TestId.get(0);
+  // CHECK: call void @llvm.assume(i1 {{.*}})
+  int Id1Get = TestId.get(1);
+  // CHECK: call void @llvm.assume(i1 {{.*}})
+  int Id2Get = TestId.get(2);
+  // CHECK: call void @llvm.assume(i1 {{.*}})
+  int Id0 = TestId[0];
+  // CHECK: call void @llvm.assume(i1 {{.*}})
+  int Id1 = TestId[1];
+  // CHECK: call void @llvm.assume(i1 {{.*}})
+  int Id2 = TestId[2];
+}


### PR DESCRIPTION
This patch also removes two __SYCL_ASSUME_INT from item class. They
becomes redundant since MIndex is implemented using id.

This patch intends to fix performance regression of vectorization on cpu device due to change in https://github.com/intel/llvm/pull/5385: when sycl::id type is used, it won't be converted to sycl::item.
sycl::item already has fsycl-id-queries-fit-in-int support support since #1685.

