### PR TITLE
[SYCL][CUDA][libclc] Add software atomics implementations for lower sm versions

### DIFF
--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1249,8 +1249,9 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
 
     const llvm::Triple &DeviceTriple = TI.getTriple();
     const llvm::Triple::SubArchType DeviceSubArch = DeviceTriple.getSubArch();
-    if (DeviceTriple.isNVPTX() || (DeviceTriple.isSPIR() &&
-        DeviceSubArch != llvm::Triple::SPIRSubArch_fpga))
+    if (DeviceTriple.isNVPTX() ||
+        (DeviceTriple.isSPIR() &&
+         DeviceSubArch != llvm::Triple::SPIRSubArch_fpga))
       Builder.defineMacro("SYCL_USE_NATIVE_FP_ATOMICS");
     // Enable generation of USM address spaces for FPGA.
     if (DeviceSubArch == llvm::Triple::SPIRSubArch_fpga) {

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1249,8 +1249,8 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
 
     const llvm::Triple &DeviceTriple = TI.getTriple();
     const llvm::Triple::SubArchType DeviceSubArch = DeviceTriple.getSubArch();
-    if (DeviceTriple.isSPIR() &&
-        DeviceSubArch != llvm::Triple::SPIRSubArch_fpga)
+    if (DeviceTriple.isNVPTX() || (DeviceTriple.isSPIR() &&
+        DeviceSubArch != llvm::Triple::SPIRSubArch_fpga))
       Builder.defineMacro("SYCL_USE_NATIVE_FP_ATOMICS");
     // Enable generation of USM address spaces for FPGA.
     if (DeviceSubArch == llvm::Triple::SPIRSubArch_fpga) {

--- a/clang/test/Preprocessor/sycl-macro-target-specific.cpp
+++ b/clang/test/Preprocessor/sycl-macro-target-specific.cpp
@@ -20,7 +20,7 @@
 // RUN: %clang_cc1 %s -fsycl-is-device -triple spir64_fpga-unknown-unknown -E -dM \
 // RUN: | FileCheck --check-prefix=CHECK-SYCL-FP-ATOMICS-NEG %s
 // RUN: %clang_cc1 %s -fsycl-is-device -triple nvptx64-nvidia-nvcl -E -dM \
-// RUN: | FileCheck --check-prefix=CHECK-SYCL-FP-ATOMICS-NEG %s
+// RUN: | FileCheck --check-prefix=CHECK-SYCL-FP-ATOMICS %s
 // CHECK-SYCL-FP-ATOMICS: #define SYCL_USE_NATIVE_FP_ATOMICS
 // CHECK-SYCL-FP-ATOMICS-NEG-NOT: #define SYCL_USE_NATIVE_FP_ATOMICS
 

--- a/libclc/ptx-nvidiacl/libspirv/atomic/atomic_add.cl
+++ b/libclc/ptx-nvidiacl/libspirv/atomic/atomic_add.cl
@@ -17,7 +17,98 @@ __CLC_NVVM_ATOMIC(ulong, m, long, l, add, _Z18__spirv_AtomicIAdd)
 
 __CLC_NVVM_ATOMIC(float, f, float, f, add, _Z21__spirv_AtomicFAddEXT)
 #ifdef cl_khr_int64_base_atomics
-__CLC_NVVM_ATOMIC(double, d, double, d, add, _Z21__spirv_AtomicFAddEXT)
+
+#define __CLC_NVVM_ATOMIC_ADD_DOUBLE_IMPL(ADDR_SPACE, ADDR_SPACE_MANGLED,                                                                                     \
+                                          ADDR_SPACE_NV, SUBSTITUTION1,                                                                                       \
+                                          SUBSTITUTION2)                                                                                                      \
+  long                                                                                                                                                        \
+      _Z18__spirv_AtomicLoadP##ADDR_SPACE_MANGLED##KlN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagE(                                                      \
+          volatile ADDR_SPACE const long *, enum Scope,                                                                                                       \
+          enum MemorySemanticsMask);                                                                                                                          \
+  long                                                                                                                                                        \
+      _Z29__spirv_AtomicCompareExchange##P##ADDR_SPACE_MANGLED##lN5__spv5Scope4FlagENS##SUBSTITUTION1##_19MemorySemanticsMask4FlagES##SUBSTITUTION2##_ll(     \
+          volatile ADDR_SPACE long *, enum Scope, enum MemorySemanticsMask,                                                                                   \
+          enum MemorySemanticsMask, long, long);                                                                                                              \
+  __attribute__((always_inline)) _CLC_DECL double                                                                                                             \
+      _Z21__spirv_AtomicFAddEXT##P##ADDR_SPACE_MANGLED##d##N5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagE##d(                                             \
+          volatile ADDR_SPACE double *pointer, enum Scope scope,                                                                                              \
+          enum MemorySemanticsMask semantics, double value) {                                                                                                 \
+    /* Semantics mask may include memory order, storage class and other info                                                                                  \
+Memory order is stored in the lowest 5 bits */                                                                                                                \
+    unsigned int order = semantics & 0x1F;                                                                                                                    \
+    if (__clc_nvvm_reflect_arch() >= 600) {                                                                                                                   \
+      switch (order) {                                                                                                                                        \
+      case None:                                                                                                                                              \
+        __CLC_NVVM_ATOMIC_IMPL_ORDER(double, double, d, add, ADDR_SPACE,                                                                                      \
+                                     ADDR_SPACE_NV, )                                                                                                         \
+        break;                                                                                                                                                \
+      case Acquire:                                                                                                                                           \
+        if (__clc_nvvm_reflect_arch() >= 700) {                                                                                                               \
+          __CLC_NVVM_ATOMIC_IMPL_ORDER(double, double, d, add, ADDR_SPACE,                                                                                    \
+                                       ADDR_SPACE_NV, _acquire)                                                                                               \
+        } else {                                                                                                                                              \
+          __CLC_NVVM_ATOMIC_IMPL_ACQUIRE_FENCE(double, double, d, add,                                                                                        \
+                                               ADDR_SPACE, ADDR_SPACE_NV)                                                                                     \
+        }                                                                                                                                                     \
+        break;                                                                                                                                                \
+      case Release:                                                                                                                                           \
+        if (__clc_nvvm_reflect_arch() >= 700) {                                                                                                               \
+          __CLC_NVVM_ATOMIC_IMPL_ORDER(double, double, d, add, ADDR_SPACE,                                                                                    \
+                                       ADDR_SPACE_NV, _release)                                                                                               \
+        } else {                                                                                                                                              \
+          __spirv_MemoryBarrier(scope, Release);                                                                                                              \
+          __CLC_NVVM_ATOMIC_IMPL_ORDER(double, double, d, add, ADDR_SPACE,                                                                                    \
+                                       ADDR_SPACE_NV, )                                                                                                       \
+        }                                                                                                                                                     \
+        break;                                                                                                                                                \
+      case AcquireRelease:                                                                                                                                    \
+        if (__clc_nvvm_reflect_arch() >= 700) {                                                                                                               \
+          __CLC_NVVM_ATOMIC_IMPL_ORDER(double, double, d, add, ADDR_SPACE,                                                                                    \
+                                       ADDR_SPACE_NV, _acq_rel)                                                                                               \
+        } else {                                                                                                                                              \
+          __spirv_MemoryBarrier(scope, Release);                                                                                                              \
+          __CLC_NVVM_ATOMIC_IMPL_ACQUIRE_FENCE(double, double, d, add,                                                                                        \
+                                               ADDR_SPACE, ADDR_SPACE_NV)                                                                                     \
+        }                                                                                                                                                     \
+        break;                                                                                                                                                \
+      }                                                                                                                                                       \
+      __builtin_trap();                                                                                                                                       \
+      __builtin_unreachable();                                                                                                                                \
+    } else {                                                                                                                                                  \
+      enum MemorySemanticsMask load_order;                                                                                                                    \
+      switch (semantics) {                                                                                                                                    \
+      case SequentiallyConsistent:                                                                                                                            \
+        load_order = SequentiallyConsistent;                                                                                                                  \
+        break;                                                                                                                                                \
+      case Acquire:                                                                                                                                           \
+      case AcquireRelease:                                                                                                                                    \
+        load_order = Acquire;                                                                                                                                 \
+        break;                                                                                                                                                \
+      default:                                                                                                                                                \
+        load_order = None;                                                                                                                                    \
+      }                                                                                                                                                       \
+      volatile ADDR_SPACE long *pointer_int =                                                                                                                 \
+          (volatile ADDR_SPACE long *)pointer;                                                                                                                \
+      long old_int;                                                                                                                                           \
+      long new_val_int;                                                                                                                                       \
+      do {                                                                                                                                                    \
+        old_int =                                                                                                                                             \
+            _Z18__spirv_AtomicLoadP##ADDR_SPACE_MANGLED##KlN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagE(                                                \
+                pointer_int, scope, load_order);                                                                                                              \
+        double new_val = *(double *)&old_int + *(double *)&value;                                                                                             \
+        new_val_int = *(long *)&new_val;                                                                                                                      \
+      } while (                                                                                                                                               \
+          _Z29__spirv_AtomicCompareExchange##P##ADDR_SPACE_MANGLED##lN5__spv5Scope4FlagENS##SUBSTITUTION1##_19MemorySemanticsMask4FlagES##SUBSTITUTION2##_ll( \
+              pointer_int, scope, semantics, semantics, new_val_int,                                                                                          \
+              old_int) != old_int);                                                                                                                           \
+      return *(double *)&old_int;                                                                                                                             \
+    }                                                                                                                                                         \
+  }
+
+__CLC_NVVM_ATOMIC_ADD_DOUBLE_IMPL(, , _gen_, 0, 4)
+__CLC_NVVM_ATOMIC_ADD_DOUBLE_IMPL(__global, U3AS1, _global_, 1, 5)
+__CLC_NVVM_ATOMIC_ADD_DOUBLE_IMPL(__local, U3AS3, _shared_, 1, 5)
+
 #endif
 
 #undef __CLC_NVVM_ATOMIC_TYPES

--- a/libclc/ptx-nvidiacl/libspirv/atomic/atomic_cmpxchg.cl
+++ b/libclc/ptx-nvidiacl/libspirv/atomic/atomic_cmpxchg.cl
@@ -10,6 +10,7 @@
 #include <spirv/spirv_types.h>
 
 int __clc_nvvm_reflect_arch();
+_CLC_OVERLOAD _CLC_DECL void __spirv_MemoryBarrier(unsigned int, unsigned int);
 
 #define __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,   \
                                          ADDR_SPACE, ADDR_SPACE_NV, ORDER)     \
@@ -18,7 +19,7 @@ int __clc_nvvm_reflect_arch();
   case Workgroup: {                                                            \
     if (__clc_nvvm_reflect_arch() >= 600) {                                    \
       TYPE_NV res =                                                            \
-           __nvvm_atom##ORDER##_cta_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(      \
+          __nvvm_atom##ORDER##_cta_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(       \
               (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value, cmp);         \
       return *(TYPE *)&res;                                                    \
     }                                                                          \
@@ -32,8 +33,37 @@ int __clc_nvvm_reflect_arch();
   default: {                                                                   \
     if (__clc_nvvm_reflect_arch() >= 600) {                                    \
       TYPE_NV res =                                                            \
-           __nvvm_atom##ORDER##_sys_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(      \
+          __nvvm_atom##ORDER##_sys_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(       \
               (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value, cmp);         \
+      return *(TYPE *)&res;                                                    \
+    }                                                                          \
+  }                                                                            \
+  }
+
+#define __CLC_NVVM_ATOMIC_CAS_IMPL_ACQUIRE_FENCE(                              \
+    TYPE, TYPE_NV, TYPE_MANGLED_NV, OP, ADDR_SPACE, ADDR_SPACE_NV)             \
+  switch (scope) {                                                             \
+  case Subgroup:                                                               \
+  case Workgroup: {                                                            \
+    if (__clc_nvvm_reflect_arch() >= 600) {                                    \
+      TYPE_NV res = __nvvm_atom##_cta_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(    \
+          (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value, cmp);             \
+      __spirv_MemoryBarrier(Workgroup, Acquire);                               \
+      return *(TYPE *)&res;                                                    \
+    }                                                                          \
+  }                                                                            \
+  case Device: {                                                               \
+    TYPE_NV res = __nvvm_atom##_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(          \
+        (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value, cmp);               \
+    __spirv_MemoryBarrier(Device, Acquire);                                    \
+    return *(TYPE *)&res;                                                      \
+  }                                                                            \
+  case CrossDevice:                                                            \
+  default: {                                                                   \
+    if (__clc_nvvm_reflect_arch() >= 600) {                                    \
+      TYPE_NV res = __nvvm_atom##_sys_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(    \
+          (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value, cmp);             \
+      __spirv_MemoryBarrier(CrossDevice, Acquire);                             \
       return *(TYPE *)&res;                                                    \
     }                                                                          \
   }                                                                            \
@@ -58,17 +88,31 @@ Memory order is stored in the lowest 5 bits */                                  
       if (__clc_nvvm_reflect_arch() >= 700) {                                                                                                                   \
         __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                    \
                                          ADDR_SPACE, ADDR_SPACE_NV, _acquire)                                                                                   \
+      } else {                                                                                                                                                  \
+        __CLC_NVVM_ATOMIC_CAS_IMPL_ACQUIRE_FENCE(                                                                                                               \
+            TYPE, TYPE_NV, TYPE_MANGLED_NV, OP, ADDR_SPACE, ADDR_SPACE_NV)                                                                                      \
       }                                                                                                                                                         \
+      break;                                                                                                                                                    \
     case Release:                                                                                                                                               \
       if (__clc_nvvm_reflect_arch() >= 700) {                                                                                                                   \
         __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                    \
                                          ADDR_SPACE, ADDR_SPACE_NV, _release)                                                                                   \
+      } else {                                                                                                                                                  \
+        __spirv_MemoryBarrier(scope, Release);                                                                                                                  \
+        __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                    \
+                                         ADDR_SPACE, ADDR_SPACE_NV, )                                                                                           \
       }                                                                                                                                                         \
+      break;                                                                                                                                                    \
     case AcquireRelease:                                                                                                                                        \
       if (__clc_nvvm_reflect_arch() >= 700) {                                                                                                                   \
         __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                                                    \
                                          ADDR_SPACE, ADDR_SPACE_NV, _acq_rel)                                                                                   \
+      } else {                                                                                                                                                  \
+        __spirv_MemoryBarrier(scope, Release);                                                                                                                  \
+        __CLC_NVVM_ATOMIC_CAS_IMPL_ACQUIRE_FENCE(                                                                                                               \
+            TYPE, TYPE_NV, TYPE_MANGLED_NV, OP, ADDR_SPACE, ADDR_SPACE_NV)                                                                                      \
       }                                                                                                                                                         \
+      break;                                                                                                                                                    \
     }                                                                                                                                                           \
     __builtin_trap();                                                                                                                                           \
     __builtin_unreachable();                                                                                                                                    \

--- a/libclc/ptx-nvidiacl/libspirv/atomic/atomic_helpers.h
+++ b/libclc/ptx-nvidiacl/libspirv/atomic/atomic_helpers.h
@@ -113,7 +113,7 @@ Memory order is stored in the lowest 5 bits */                                  
       } else {                                                                                                               \
         __spirv_MemoryBarrier(scope, Release);                                                                               \
         __CLC_NVVM_ATOMIC_IMPL_ACQUIRE_FENCE(TYPE, TYPE_NV, TYPE_MANGLED_NV,                                                 \
-                                             OP, ADDR_SPACE, ADDR_SPACE_NV)                                                \
+                                             OP, ADDR_SPACE, ADDR_SPACE_NV)                                                  \
       }                                                                                                                      \
       break;                                                                                                                 \
     }                                                                                                                        \

--- a/libclc/ptx-nvidiacl/libspirv/atomic/atomic_helpers.h
+++ b/libclc/ptx-nvidiacl/libspirv/atomic/atomic_helpers.h
@@ -13,6 +13,7 @@
 #include <spirv/spirv_types.h>
 
 extern int __clc_nvvm_reflect_arch();
+_CLC_OVERLOAD _CLC_DECL void __spirv_MemoryBarrier(unsigned int, unsigned int);
 
 #define __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,       \
                                      ADDR_SPACE, ADDR_SPACE_NV, ORDER)         \
@@ -42,6 +43,35 @@ extern int __clc_nvvm_reflect_arch();
   }                                                                            \
   }
 
+#define __CLC_NVVM_ATOMIC_IMPL_ACQUIRE_FENCE(TYPE, TYPE_NV, TYPE_MANGLED_NV,   \
+                                             OP, ADDR_SPACE, ADDR_SPACE_NV)    \
+  switch (scope) {                                                             \
+  case Subgroup:                                                               \
+  case Workgroup: {                                                            \
+    if (__clc_nvvm_reflect_arch() >= 600) {                                    \
+      TYPE_NV res = __nvvm_atom##_cta_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(    \
+          (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value);                  \
+      __spirv_MemoryBarrier(Workgroup, Acquire);                               \
+      return *(TYPE *)&res;                                                    \
+    }                                                                          \
+  }                                                                            \
+  case Device: {                                                               \
+    TYPE_NV res = __nvvm_atom##_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(          \
+        (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value);                    \
+    __spirv_MemoryBarrier(Device, Acquire);                                    \
+    return *(TYPE *)&res;                                                      \
+  }                                                                            \
+  case CrossDevice:                                                            \
+  default: {                                                                   \
+    if (__clc_nvvm_reflect_arch() >= 600) {                                    \
+      TYPE_NV res = __nvvm_atom##_sys_##OP##ADDR_SPACE_NV##TYPE_MANGLED_NV(    \
+          (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value);                  \
+      __spirv_MemoryBarrier(CrossDevice, Acquire);                             \
+      return *(TYPE *)&res;                                                    \
+    }                                                                          \
+  }                                                                            \
+  }
+
 #define __CLC_NVVM_ATOMIC_IMPL(TYPE, TYPE_MANGLED, TYPE_NV, TYPE_MANGLED_NV,                                                 \
                                OP, NAME_MANGLED, ADDR_SPACE,                                                                 \
                                ADDR_SPACE_MANGLED, ADDR_SPACE_NV)                                                            \
@@ -56,21 +86,36 @@ Memory order is stored in the lowest 5 bits */                                  
     case None:                                                                                                               \
       __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                       \
                                    ADDR_SPACE, ADDR_SPACE_NV, )                                                              \
+      break;                                                                                                                 \
     case Acquire:                                                                                                            \
       if (__clc_nvvm_reflect_arch() >= 700) {                                                                                \
         __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                     \
                                      ADDR_SPACE, ADDR_SPACE_NV, _acquire)                                                    \
+      } else {                                                                                                               \
+        __CLC_NVVM_ATOMIC_IMPL_ACQUIRE_FENCE(TYPE, TYPE_NV, TYPE_MANGLED_NV,                                                 \
+                                             OP, ADDR_SPACE, ADDR_SPACE_NV)                                                  \
       }                                                                                                                      \
+      break;                                                                                                                 \
     case Release:                                                                                                            \
       if (__clc_nvvm_reflect_arch() >= 700) {                                                                                \
         __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                     \
                                      ADDR_SPACE, ADDR_SPACE_NV, _release)                                                    \
+      } else {                                                                                                               \
+        __spirv_MemoryBarrier(scope, Release);                                                                               \
+        __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                     \
+                                     ADDR_SPACE, ADDR_SPACE_NV, )                                                            \
       }                                                                                                                      \
+      break;                                                                                                                 \
     case AcquireRelease:                                                                                                     \
       if (__clc_nvvm_reflect_arch() >= 700) {                                                                                \
         __CLC_NVVM_ATOMIC_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,                                                     \
                                      ADDR_SPACE, ADDR_SPACE_NV, _acq_rel)                                                    \
+      } else {                                                                                                               \
+        __spirv_MemoryBarrier(scope, Release);                                                                               \
+        __CLC_NVVM_ATOMIC_IMPL_ACQUIRE_FENCE(TYPE, TYPE_NV, TYPE_MANGLED_NV,                                                 \
+                                             OP, ADDR_SPACE, ADDR_SPACE_NV)                                                \
       }                                                                                                                      \
+      break;                                                                                                                 \
     }                                                                                                                        \
     __builtin_trap();                                                                                                        \
     __builtin_unreachable();                                                                                                 \

--- a/libclc/ptx-nvidiacl/libspirv/atomic/atomic_load.cl
+++ b/libclc/ptx-nvidiacl/libspirv/atomic/atomic_load.cl
@@ -10,6 +10,7 @@
 #include <spirv/spirv_types.h>
 
 extern int __clc_nvvm_reflect_arch();
+_CLC_OVERLOAD _CLC_DECL void __spirv_MemoryBarrier(unsigned int, unsigned int);
 
 #define __CLC_NVVM_ATOMIC_LOAD_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV,      \
                                           ADDR_SPACE, ADDR_SPACE_NV, ORDER)    \
@@ -53,10 +54,15 @@ Memory order is stored in the lowest 5 bits */                                  
                                           ADDR_SPACE, ADDR_SPACE_NV, _acquire)                                            \
       }                                                                                                                   \
     } else {                                                                                                              \
-      if (order == None) {                                                                                                \
-        TYPE_NV res = __nvvm_volatile_ld##ADDR_SPACE_NV##TYPE_MANGLED_NV(                                                 \
-            (ADDR_SPACE TYPE_NV *)pointer);                                                                               \
+      TYPE_NV res = __nvvm_volatile_ld##ADDR_SPACE_NV##TYPE_MANGLED_NV(                                                   \
+          (ADDR_SPACE TYPE_NV *)pointer);                                                                                 \
+      switch (order) {                                                                                                    \
+      case None:                                                                                                          \
         return *(TYPE *)&res;                                                                                             \
+      case Acquire: {                                                                                                     \
+        __spirv_MemoryBarrier(scope, Acquire);                                                                            \
+        return *(TYPE *)&res;                                                                                             \
+      }                                                                                                                   \
       }                                                                                                                   \
     }                                                                                                                     \
     __builtin_trap();                                                                                                     \

--- a/libclc/ptx-nvidiacl/libspirv/atomic/atomic_store.cl
+++ b/libclc/ptx-nvidiacl/libspirv/atomic/atomic_store.cl
@@ -10,6 +10,7 @@
 #include <spirv/spirv_types.h>
 
 extern int __clc_nvvm_reflect_arch();
+_CLC_OVERLOAD _CLC_DECL void __spirv_MemoryBarrier(unsigned int, unsigned int);
 
 #define __CLC_NVVM_ATOMIC_STORE_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV,     \
                                            ADDR_SPACE, ADDR_SPACE_NV, ORDER)   \
@@ -54,10 +55,17 @@ Memory order is stored in the lowest 5 bits */                                  
                                            _release)                                                                                  \
       }                                                                                                                               \
     } else {                                                                                                                          \
-      if (order == None) {                                                                                                            \
+      switch (order) {                                                                                                                \
+      case Release:                                                                                                                   \
+        __spirv_MemoryBarrier(scope, Release);                                                                                        \
         __nvvm_volatile_st##ADDR_SPACE_NV##TYPE_MANGLED_NV(                                                                           \
             (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value);                                                                       \
         return;                                                                                                                       \
+      case None: {                                                                                                                    \
+        __nvvm_volatile_st##ADDR_SPACE_NV##TYPE_MANGLED_NV(                                                                           \
+            (ADDR_SPACE TYPE_NV *)pointer, *(TYPE_NV *)&value);                                                                       \
+        return;                                                                                                                       \
+      }                                                                                                                               \
       }                                                                                                                               \
     }                                                                                                                                 \
     __builtin_trap();                                                                                                                 \

--- a/libclc/ptx-nvidiacl/libspirv/synchronization/barrier.cl
+++ b/libclc/ptx-nvidiacl/libspirv/synchronization/barrier.cl
@@ -11,7 +11,11 @@
 
 _CLC_OVERLOAD _CLC_DEF void __spirv_MemoryBarrier(unsigned int memory,
                                                   unsigned int semantics) {
-  __nvvm_membar_cta();
+  if (memory == CrossDevice) {
+    __nvvm_membar_sys();
+  } else {
+    __nvvm_membar_cta();
+  }
 }
 
 _CLC_OVERLOAD _CLC_DEF _CLC_CONVERGENT void

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -852,15 +852,8 @@ pi_result cuda_piContextGetInfo(pi_context context, pi_context_info param_name,
     return getInfo(param_value_size, param_value, param_value_size_ret,
                    context->get_reference_count());
   case PI_CONTEXT_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES: {
-    int major = 0;
-    cl::sycl::detail::pi::assertion(
-        cuDeviceGetAttribute(&major,
-                             CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
-                             context->get_device()->get()) == CUDA_SUCCESS);
-    pi_memory_order_capabilities capabilities =
-        (major >= 6) ? PI_MEMORY_ORDER_RELAXED | PI_MEMORY_ORDER_ACQUIRE |
-                           PI_MEMORY_ORDER_RELEASE | PI_MEMORY_ORDER_ACQ_REL
-                     : PI_MEMORY_ORDER_RELAXED;
+    pi_memory_order_capabilities capabilities = PI_MEMORY_ORDER_RELAXED | PI_MEMORY_ORDER_ACQUIRE |
+                           PI_MEMORY_ORDER_RELEASE | PI_MEMORY_ORDER_ACQ_REL;
     return getInfo(param_value_size, param_value, param_value_size_ret,
                    capabilities);
   }
@@ -871,10 +864,11 @@ pi_result cuda_piContextGetInfo(pi_context context, pi_context_info param_name,
                              CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
                              context->get_device()->get()) == CUDA_SUCCESS);
     pi_memory_order_capabilities capabilities =
-        (major >= 5) ? PI_MEMORY_SCOPE_WORK_ITEM | PI_MEMORY_SCOPE_SUB_GROUP |
+        (major >= 7) ? PI_MEMORY_SCOPE_WORK_ITEM | PI_MEMORY_SCOPE_SUB_GROUP |
                            PI_MEMORY_SCOPE_WORK_GROUP | PI_MEMORY_SCOPE_DEVICE |
                            PI_MEMORY_SCOPE_SYSTEM
-                     : PI_MEMORY_SCOPE_DEVICE;
+                     : PI_MEMORY_SCOPE_WORK_ITEM | PI_MEMORY_SCOPE_SUB_GROUP |
+                           PI_MEMORY_SCOPE_WORK_GROUP | PI_MEMORY_SCOPE_DEVICE;
     return getInfo(param_value_size, param_value, param_value_size_ret,
                    capabilities);
   }
@@ -1139,15 +1133,8 @@ pi_result cuda_piDeviceGetInfo(pi_device device, pi_device_info param_name,
                    atomic64);
   }
   case PI_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES: {
-    int major = 0;
-    cl::sycl::detail::pi::assertion(
-        cuDeviceGetAttribute(&major,
-                             CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
-                             device->get()) == CUDA_SUCCESS);
-    pi_memory_order_capabilities capabilities =
-        (major >= 6) ? PI_MEMORY_ORDER_RELAXED | PI_MEMORY_ORDER_ACQUIRE |
-                           PI_MEMORY_ORDER_RELEASE | PI_MEMORY_ORDER_ACQ_REL
-                     : PI_MEMORY_ORDER_RELAXED;
+    pi_memory_order_capabilities capabilities = PI_MEMORY_ORDER_RELAXED | PI_MEMORY_ORDER_ACQUIRE |
+                           PI_MEMORY_ORDER_RELEASE | PI_MEMORY_ORDER_ACQ_REL;
     return getInfo(param_value_size, param_value, param_value_size_ret,
                    capabilities);
   }
@@ -1158,10 +1145,11 @@ pi_result cuda_piDeviceGetInfo(pi_device device, pi_device_info param_name,
                              CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR,
                              device->get()) == CUDA_SUCCESS);
     pi_memory_order_capabilities capabilities =
-        (major >= 5) ? PI_MEMORY_SCOPE_WORK_ITEM | PI_MEMORY_SCOPE_SUB_GROUP |
+        (major >= 7) ? PI_MEMORY_SCOPE_WORK_ITEM | PI_MEMORY_SCOPE_SUB_GROUP |
                            PI_MEMORY_SCOPE_WORK_GROUP | PI_MEMORY_SCOPE_DEVICE |
                            PI_MEMORY_SCOPE_SYSTEM
-                     : PI_MEMORY_SCOPE_DEVICE;
+                     : PI_MEMORY_SCOPE_WORK_ITEM | PI_MEMORY_SCOPE_SUB_GROUP |
+                           PI_MEMORY_SCOPE_WORK_GROUP | PI_MEMORY_SCOPE_DEVICE;
     return getInfo(param_value_size, param_value, param_value_size_ret,
                    capabilities);
   }

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -852,8 +852,9 @@ pi_result cuda_piContextGetInfo(pi_context context, pi_context_info param_name,
     return getInfo(param_value_size, param_value, param_value_size_ret,
                    context->get_reference_count());
   case PI_CONTEXT_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES: {
-    pi_memory_order_capabilities capabilities = PI_MEMORY_ORDER_RELAXED | PI_MEMORY_ORDER_ACQUIRE |
-                           PI_MEMORY_ORDER_RELEASE | PI_MEMORY_ORDER_ACQ_REL;
+    pi_memory_order_capabilities capabilities =
+        PI_MEMORY_ORDER_RELAXED | PI_MEMORY_ORDER_ACQUIRE |
+        PI_MEMORY_ORDER_RELEASE | PI_MEMORY_ORDER_ACQ_REL;
     return getInfo(param_value_size, param_value, param_value_size_ret,
                    capabilities);
   }
@@ -1133,8 +1134,9 @@ pi_result cuda_piDeviceGetInfo(pi_device device, pi_device_info param_name,
                    atomic64);
   }
   case PI_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES: {
-    pi_memory_order_capabilities capabilities = PI_MEMORY_ORDER_RELAXED | PI_MEMORY_ORDER_ACQUIRE |
-                           PI_MEMORY_ORDER_RELEASE | PI_MEMORY_ORDER_ACQ_REL;
+    pi_memory_order_capabilities capabilities =
+        PI_MEMORY_ORDER_RELAXED | PI_MEMORY_ORDER_ACQUIRE |
+        PI_MEMORY_ORDER_RELEASE | PI_MEMORY_ORDER_ACQ_REL;
     return getInfo(param_value_size, param_value, param_value_size_ret,
                    capabilities);
   }


### PR DESCRIPTION
Adds software implementations for various atomics for sm versions blow ones where they are supported natively. Now all atomics, except for the ones using system scope are supported regardless of the sm version.

Now `SYCL_USE_NATIVE_FP_ATOMICS` is also defined for CUDA by default.

Closes https://github.com/intel/llvm/issues/5936.

Tested by: https://github.com/intel/llvm-test-suite/pull/985