### PR TITLE
[SYCL] Add overload of select for bool

### DIFF
--- a/sycl/include/CL/sycl/builtins.hpp
+++ b/sycl/include/CL/sycl/builtins.hpp
@@ -1306,6 +1306,13 @@ detail::enable_if_t<detail::is_gentype<T>::value, T> bitselect(T a, T b,
   return __sycl_std::__invoke_bitselect<T>(a, b, c);
 }
 
+// sgentype select (sgentype a, sgentype b, bool c)
+template <typename T>
+detail::enable_if_t<detail::is_sgentype<T>::value, T> select(T a, T b,
+                                                             bool c) __NOEXC {
+  return __sycl_std::__invoke_select<T>(a, b, (int) c);
+}
+
 // geninteger select (geninteger a, geninteger b, igeninteger c)
 template <typename T, typename T2>
 detail::enable_if_t<

--- a/sycl/include/CL/sycl/builtins.hpp
+++ b/sycl/include/CL/sycl/builtins.hpp
@@ -1310,7 +1310,7 @@ detail::enable_if_t<detail::is_gentype<T>::value, T> bitselect(T a, T b,
 template <typename T>
 detail::enable_if_t<detail::is_sgentype<T>::value, T> select(T a, T b,
                                                              bool c) __NOEXC {
-  return __sycl_std::__invoke_select<T>(a, b, (int) c);
+  return __sycl_std::__invoke_select<T>(a, b, static_cast<int>(c));
 }
 
 // geninteger select (geninteger a, geninteger b, igeninteger c)


### PR DESCRIPTION
Addresses the common case of sycl::select(a, b, c) where c is a bool.

Signed-off-by: John Pennycook <john.pennycook@intel.com>

Closes #5948.

Tested by: https://github.com/intel/llvm-test-suite/pull/986