### PR TITLE
[SYCL] Avoid unconditional debug info generation for libsycl_profiler_collector.so

### DIFF
--- a/sycl/tools/sycl-prof/CMakeLists.txt
+++ b/sycl/tools/sycl-prof/CMakeLists.txt
@@ -23,8 +23,6 @@ target_include_directories(sycl_profiler_collector PRIVATE
     "${sycl_src_dir}"
 )
 
-target_compile_options(sycl_profiler_collector PRIVATE -g)
-
 add_dependencies(sycl-prof sycl_profiler_collector)
 add_dependencies(sycl-toolchain sycl-prof)
 


### PR DESCRIPTION
That was probably an accidental commit from the workspace as nothing in the
tests fails without it.