### PR TITLE
Draft: [SYCL] Make lazily initialized events use default context

### DIFF
--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -129,9 +129,11 @@ public:
   const RT::PiEvent &getHandleRef() const;
 
   /// Returns context that is associated with this event.
+  /// If the context has not been set, the event will be associated with the
+  /// default context for the backend of the default device.
   ///
   /// \return a shared pointer to a valid context_impl.
-  const ContextImplPtr &getContextImpl();
+  const ContextImplPtr &getContextImpl() const;
 
   /// \return the Plugin associated with the context of this event.
   /// Should be called when this is not a Host Event.


### PR DESCRIPTION
Recent changes to get_native made events adhere to default-constructed events using the default context. This was done through using a default-constructed context in static storage. However, the statically stored context could cause the context to live longer than expected.

These changes moves the lazy initialization of context on events with no context to the get-context method, which is in turn called by the get-plugin method. With this, events with lazily-initialized native events, such as default-constructed events, will be associated with the default context of the platform of the default device.

Co-authored-by: Kharchikov, Igor <igor.kharchikov@intel.com>