### PR TITLE
[SYCL][libdevice] Solve inline attr conflict when building libdevice

### DIFF
--- a/libdevice/cmath_wrapper.cpp
+++ b/libdevice/cmath_wrapper.cpp
@@ -10,31 +10,31 @@
 
 #ifdef __SPIR__
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 int abs(int x) { return __devicelib_abs(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 long int labs(long int x) { return __devicelib_labs(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 long long int llabs(long long int x) { return __devicelib_llabs(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 div_t div(int x, int y) { return __devicelib_div(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 ldiv_t ldiv(long x, long y) { return __devicelib_ldiv(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 lldiv_t lldiv(long long x, long long y) { return __devicelib_lldiv(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float scalbnf(float x, int n) { return __devicelib_scalbnf(x, n); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float logf(float x) { return __devicelib_logf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float expf(float x) { return __devicelib_expf(x); }
 // On Windows, the math.h includes wrapper definition for functions:
 // frexpf, ldexpf, hypotf, so we can't provide these 3 functions in
@@ -44,121 +44,121 @@ float expf(float x) { return __devicelib_expf(x); }
 // frexp and ldexp. frexpf and ldexpf can only be used on platforms
 // with fp64 support currently.
 #ifndef _WIN32
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float frexpf(float x, int *exp) { return __devicelib_frexpf(x, exp); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float ldexpf(float x, int exp) { return __devicelib_ldexpf(x, exp); }
 #endif
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float log10f(float x) { return __devicelib_log10f(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float modff(float x, float *intpart) { return __devicelib_modff(x, intpart); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float exp2f(float x) { return __devicelib_exp2f(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float expm1f(float x) { return __devicelib_expm1f(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 int ilogbf(float x) { return __devicelib_ilogbf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float log1pf(float x) { return __devicelib_log1pf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float log2f(float x) { return __devicelib_log2f(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float logbf(float x) { return __devicelib_logbf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float sqrtf(float x) { return __devicelib_sqrtf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float cbrtf(float x) { return __devicelib_cbrtf(x); }
 
 #ifndef _WIN32
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float hypotf(float x, float y) { return __devicelib_hypotf(x, y); }
 #else
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float _hypotf(float x, float y) { return __devicelib_hypotf(x, y); }
 #endif
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float erff(float x) { return __devicelib_erff(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float erfcf(float x) { return __devicelib_erfcf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float tgammaf(float x) { return __devicelib_tgammaf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float lgammaf(float x) { return __devicelib_lgammaf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float fmodf(float x, float y) { return __devicelib_fmodf(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float remainderf(float x, float y) { return __devicelib_remainderf(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float remquof(float x, float y, int *q) { return __devicelib_remquof(x, y, q); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float nextafterf(float x, float y) { return __devicelib_nextafterf(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float fdimf(float x, float y) { return __devicelib_fdimf(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float fmaf(float x, float y, float z) { return __devicelib_fmaf(x, y, z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float sinf(float x) { return __devicelib_sinf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float cosf(float x) { return __devicelib_cosf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float tanf(float x) { return __devicelib_tanf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float powf(float x, float y) { return __devicelib_powf(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float acosf(float x) { return __devicelib_acosf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float asinf(float x) { return __devicelib_asinf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float atanf(float x) { return __devicelib_atanf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float atan2f(float x, float y) { return __devicelib_atan2f(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float coshf(float x) { return __devicelib_coshf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float sinhf(float x) { return __devicelib_sinhf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float tanhf(float x) { return __devicelib_tanhf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float acoshf(float x) { return __devicelib_acoshf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float asinhf(float x) { return __devicelib_asinhf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float atanhf(float x) { return __devicelib_atanhf(x); }
 
 #if defined(_WIN32)
@@ -186,7 +186,7 @@ union _Dconst {            // pun float types as integer array
   { 0, w0 }
 
 #define _FXbig (float)((NBITS + 1) * 347L / 1000)
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 short _FDtest(float *px) { // categorize *px
   _Fval *ps = (_Fval *)(char *)px;
   short ret = 0;
@@ -201,7 +201,7 @@ short _FDtest(float *px) { // categorize *px
 
 // Returns _FP_LT, _FP_GT or _FP_EQ based on the ordering
 // relationship between x and y. '0' means unordered.
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 int _fdpcomp(float x, float y) {
   int res = 0;
   if (_FDtest(&x) == _NANCODE || _FDtest(&y) == _NANCODE) {
@@ -220,11 +220,11 @@ int _fdpcomp(float x, float y) {
 }
 
 // Returns 0, if the sign bit is not set, and non-zero otherwise.
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 int _fdsign(float x) { return FSIGN(x); }
 
 // fpclassify() equivalent with a pointer argument.
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 short _fdtest(float *px) {
   switch (_FDtest(px)) {
   case _DENORM:
@@ -240,7 +240,7 @@ short _fdtest(float *px) {
   return FP_ZERO;
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 short _FDnorm(_Fval *ps) { // normalize float fraction
   short xchar;
   unsigned short sign = (unsigned short)(ps->_Sh[_F0] & _FSIGN);
@@ -267,7 +267,7 @@ short _FDnorm(_Fval *ps) { // normalize float fraction
   return xchar;
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 short _FDscale(float *px, long lexp) { // scale *px by 2^xexp with checking
   _Dconst _FInf = {INIT(_FMAX << _FOFF)};
   _Fval *ps = (_Fval *)(char *)px;
@@ -327,7 +327,7 @@ short _FDscale(float *px, long lexp) { // scale *px by 2^xexp with checking
   return ret;
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 short _FExp(float *px, float y,
             short eoff) { // compute y * e^(*px), (*px) finite, |y| not huge
   static const float hugexp = FHUGE_EXP;
@@ -364,7 +364,7 @@ short _FExp(float *px, float y,
   return ret;
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float _FCosh(float x, float y) { // compute y * cosh(x), |y| <= 1
   switch (_FDtest(&x)) {         // test for special codes
   case _NANCODE:
@@ -388,7 +388,7 @@ float _FCosh(float x, float y) { // compute y * cosh(x), |y| <= 1
   }
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float _FSinh(float x, float y) { // compute y * sinh(x), |y| <= 1
   _Dconst _FRteps = {INIT((_FBIAS - NBITS / 2) << _FOFF)};
   static const float p[] = {0.00020400F, 0.00832983F, 0.16666737F, 0.99999998F};

--- a/libdevice/cmath_wrapper_fp64.cpp
+++ b/libdevice/cmath_wrapper_fp64.cpp
@@ -14,126 +14,126 @@
 // reference. If users provide their own math or complex functions(with
 // the prototype), functions in device libraries will be ignored and
 // overrided by users' version.
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double log(double x) { return __devicelib_log(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double exp(double x) { return __devicelib_exp(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double frexp(double x, int *exp) { return __devicelib_frexp(x, exp); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double ldexp(double x, int exp) { return __devicelib_ldexp(x, exp); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double log10(double x) { return __devicelib_log10(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double modf(double x, double *intpart) { return __devicelib_modf(x, intpart); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double exp2(double x) { return __devicelib_exp2(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double expm1(double x) { return __devicelib_expm1(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 int ilogb(double x) { return __devicelib_ilogb(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double log1p(double x) { return __devicelib_log1p(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double log2(double x) { return __devicelib_log2(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double logb(double x) { return __devicelib_logb(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double sqrt(double x) { return __devicelib_sqrt(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double cbrt(double x) { return __devicelib_cbrt(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double hypot(double x, double y) { return __devicelib_hypot(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double erf(double x) { return __devicelib_erf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double erfc(double x) { return __devicelib_erfc(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double tgamma(double x) { return __devicelib_tgamma(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double lgamma(double x) { return __devicelib_lgamma(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double fmod(double x, double y) { return __devicelib_fmod(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double remainder(double x, double y) { return __devicelib_remainder(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double remquo(double x, double y, int *q) {
   return __devicelib_remquo(x, y, q);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double nextafter(double x, double y) { return __devicelib_nextafter(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double fdim(double x, double y) { return __devicelib_fdim(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double fma(double x, double y, double z) { return __devicelib_fma(x, y, z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double sin(double x) { return __devicelib_sin(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double cos(double x) { return __devicelib_cos(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double tan(double x) { return __devicelib_tan(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double pow(double x, double y) { return __devicelib_pow(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double acos(double x) { return __devicelib_acos(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double asin(double x) { return __devicelib_asin(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double atan(double x) { return __devicelib_atan(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double atan2(double x, double y) { return __devicelib_atan2(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double cosh(double x) { return __devicelib_cosh(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double sinh(double x) { return __devicelib_sinh(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double tanh(double x) { return __devicelib_tanh(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double acosh(double x) { return __devicelib_acosh(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double asinh(double x) { return __devicelib_asinh(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double atanh(double x) { return __devicelib_atanh(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double scalbn(double x, int exp) { return __devicelib_scalbn(x, exp); }
 
 #if defined(_WIN32)
@@ -166,7 +166,7 @@ union _Dconst {            // pun float types as integer array
 
 #define _Xbig (double)((NBITS + 1) * 347L / 1000)
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 short _Dtest(double *px) { // categorize *px
   _Dval *ps = (_Dval *)(char *)px;
 
@@ -185,7 +185,7 @@ short _Dtest(double *px) { // categorize *px
 
 // Returns _FP_LT, _FP_GT or _FP_EQ based on the ordering
 // relationship between x and y.
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 int _dpcomp(double x, double y) {
   int res = 0;
   if (_Dtest(&x) == _NANCODE || _Dtest(&y) == _NANCODE) {
@@ -204,11 +204,11 @@ int _dpcomp(double x, double y) {
 }
 
 // Returns 0, if the sign bit is not set, and non-zero otherwise.
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 int _dsign(double x) { return DSIGN(x); }
 
 // fpclassify() equivalent with a pointer argument.
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 short _dtest(double *px) {
   switch (_Dtest(px)) {
   case _DENORM:
@@ -224,7 +224,7 @@ short _dtest(double *px) {
   return FP_ZERO;
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 short _Dnorm(_Dval *ps) { // normalize double fraction
   short xchar;
   unsigned short sign = (unsigned short)(ps->_Sh[_D0] & _DSIGN);
@@ -256,7 +256,7 @@ short _Dnorm(_Dval *ps) { // normalize double fraction
   return xchar;
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 short _Dscale(double *px, long lexp) { // scale *px by 2^xexp with checking
   _Dval *ps = (_Dval *)(char *)px;
   _Dconst _Inf = {INIT(_DMAX << _DOFF)};
@@ -326,7 +326,7 @@ short _Dscale(double *px, long lexp) { // scale *px by 2^xexp with checking
   return ret;
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 short _Exp(double *px, double y,
            short eoff) { // compute y * e^(*px), (*px) finite, |y| not huge
   static const double invln2 = 1.4426950408889634073599246810018921;
@@ -365,7 +365,7 @@ short _Exp(double *px, double y,
   return ret;
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double _Cosh(double x, double y) { // compute y * cosh(x), |y| <= 1
   switch (_Dtest(&x)) {            // test for special codes
   case _NANCODE:
@@ -389,7 +389,7 @@ double _Cosh(double x, double y) { // compute y * cosh(x), |y| <= 1
   }
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double _Poly(double x, const double *tab, int n) { // compute polynomial
   double y;
 
@@ -399,7 +399,7 @@ double _Poly(double x, const double *tab, int n) { // compute polynomial
   return y;
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double _Sinh(double x, double y) { // compute y * sinh(x), |y| <= 1
 
   short neg;

--- a/libdevice/complex_wrapper.cpp
+++ b/libdevice/complex_wrapper.cpp
@@ -10,92 +10,92 @@
 
 #ifdef __SPIR__
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float cimagf(float __complex__ z) { return __devicelib_cimagf(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float crealf(float __complex__ z) { return __devicelib_crealf(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float cargf(float __complex__ z) { return __devicelib_cargf(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float cabsf(float __complex__ z) { return __devicelib_cabsf(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ cprojf(float __complex__ z) { return __devicelib_cprojf(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ cexpf(float __complex__ z) { return __devicelib_cexpf(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ clogf(float __complex__ z) { return __devicelib_clogf(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ cpowf(float __complex__ x, float __complex__ y) {
   return __devicelib_cpowf(x, y);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ cpolarf(float rho, float theta) {
   return __devicelib_cpolarf(rho, theta);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ csqrtf(float __complex__ z) { return __devicelib_csqrtf(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ csinhf(float __complex__ z) { return __devicelib_csinhf(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ ccoshf(float __complex__ z) { return __devicelib_ccoshf(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ ctanhf(float __complex__ z) { return __devicelib_ctanhf(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ csinf(float __complex__ z) { return __devicelib_csinf(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ ccosf(float __complex__ z) { return __devicelib_ccosf(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ ctanf(float __complex__ z) { return __devicelib_ctanf(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ cacosf(float __complex__ z) { return __devicelib_cacosf(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ casinhf(float __complex__ z) {
   return __devicelib_casinhf(z);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ casinf(float __complex__ z) { return __devicelib_casinf(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ cacoshf(float __complex__ z) {
   return __devicelib_cacoshf(z);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ catanhf(float __complex__ z) {
   return __devicelib_catanhf(z);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ catanf(float __complex__ z) { return __devicelib_catanf(z); }
 
 // __mulsc3
 // Returns: the product of a + ib and c + id
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __mulsc3(float __a, float __b, float __c, float __d) {
   return __devicelib___mulsc3(__a, __b, __c, __d);
 }
 
 // __divsc3
 // Returns: the quotient of (a + ib) / (c + id)
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __divsc3(float __a, float __b, float __c, float __d) {
   return __devicelib___divsc3(__a, __b, __c, __d);
 }

--- a/libdevice/complex_wrapper_fp64.cpp
+++ b/libdevice/complex_wrapper_fp64.cpp
@@ -10,92 +10,92 @@
 
 #ifdef __SPIR__
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double cimag(double __complex__ z) { return __devicelib_cimag(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double creal(double __complex__ z) { return __devicelib_creal(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double cabs(double __complex__ z) { return __devicelib_cabs(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double carg(double __complex__ z) { return __devicelib_carg(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ cproj(double __complex__ z) { return __devicelib_cproj(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ cexp(double __complex__ z) { return __devicelib_cexp(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ clog(double __complex__ z) { return __devicelib_clog(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ cpow(double __complex__ x, double __complex__ y) {
   return __devicelib_cpow(x, y);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ cpolar(double rho, double theta) {
   return __devicelib_cpolar(rho, theta);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ csqrt(double __complex__ z) { return __devicelib_csqrt(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ csinh(double __complex__ z) { return __devicelib_csinh(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ ccosh(double __complex__ z) { return __devicelib_ccosh(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ ctanh(double __complex__ z) { return __devicelib_ctanh(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ csin(double __complex__ z) { return __devicelib_csin(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ ccos(double __complex__ z) { return __devicelib_ccos(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ ctan(double __complex__ z) { return __devicelib_ctan(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ cacos(double __complex__ z) { return __devicelib_cacos(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ casinh(double __complex__ z) {
   return __devicelib_casinh(z);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ casin(double __complex__ z) { return __devicelib_casin(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ cacosh(double __complex__ z) {
   return __devicelib_cacosh(z);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ catanh(double __complex__ z) {
   return __devicelib_catanh(z);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ catan(double __complex__ z) { return __devicelib_catan(z); }
 
 // __muldc3
 // Returns: the product of a + ib and c + id
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __muldc3(double __a, double __b, double __c, double __d) {
   return __devicelib___muldc3(__a, __b, __c, __d);
 }
 
 // __divdc3
 // Returns: the quotient of (a + ib) / (c + id)
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __divdc3(double __a, double __b, double __c, double __d) {
   return __devicelib___divdc3(__a, __b, __c, __d);
 }

--- a/libdevice/crt_wrapper.cpp
+++ b/libdevice/crt_wrapper.cpp
@@ -9,17 +9,17 @@
 #include "wrapper.h"
 
 #ifdef __SPIR__
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 void *memcpy(void *dest, const void *src, size_t n) {
   return __devicelib_memcpy(dest, src, n);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 void *memset(void *dest, int c, size_t n) {
   return __devicelib_memset(dest, c, n);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 int memcmp(const void *s1, const void *s2, size_t n) {
   return __devicelib_memcmp(s1, s2, n);
 }

--- a/libdevice/device.h
+++ b/libdevice/device.h
@@ -17,13 +17,14 @@
 
 #ifdef __SPIR__
 #ifdef __SYCL_DEVICE_ONLY__
-#define DEVICE_EXTERNAL                                                        \
-  SYCL_EXTERNAL __attribute__((weak)) __attribute__((always_inline))
+#define DEVICE_EXTERNAL SYCL_EXTERNAL __attribute__((weak))
 #else // __SYCL_DEVICE_ONLY__
 #define DEVICE_EXTERNAL __attribute__((weak))
 #endif // __SYCL_DEVICE_ONLY__
 
 #define DEVICE_EXTERN_C DEVICE_EXTERNAL EXTERN_C
+#define DEVICE_EXTERN_C_INLINE                                                 \
+  DEVICE_EXTERNAL EXTERN_C __attribute__((always_inline))
 #endif // __SPIR__
 
 #endif // __LIBDEVICE_DEVICE_H__

--- a/libdevice/fallback-cmath-fp64.cpp
+++ b/libdevice/fallback-cmath-fp64.cpp
@@ -13,138 +13,138 @@
 // To support fallback device libraries on-demand loading, please update the
 // DeviceLibFuncMap in llvm/tools/sycl-post-link/sycl-post-link.cpp if you add
 // or remove any item in this file.
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_log(double x) { return __spirv_ocl_log(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_exp(double x) { return __spirv_ocl_exp(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_frexp(double x, int *exp) {
   return __spirv_ocl_frexp(x, exp);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_ldexp(double x, int exp) {
   return __spirv_ocl_ldexp(x, exp);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_log10(double x) { return __spirv_ocl_log10(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_modf(double x, double *intpart) {
   return __spirv_ocl_modf(x, intpart);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_exp2(double x) { return __spirv_ocl_exp2(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_expm1(double x) { return __spirv_ocl_expm1(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 int __devicelib_ilogb(double x) { return __spirv_ocl_ilogb(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_log1p(double x) { return __spirv_ocl_log1p(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_log2(double x) { return __spirv_ocl_log2(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_logb(double x) { return __spirv_ocl_logb(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_sqrt(double x) { return __spirv_ocl_sqrt(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_cbrt(double x) { return __spirv_ocl_cbrt(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_hypot(double x, double y) { return __spirv_ocl_hypot(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_erf(double x) { return __spirv_ocl_erf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_erfc(double x) { return __spirv_ocl_erfc(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_tgamma(double x) { return __spirv_ocl_tgamma(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_lgamma(double x) { return __spirv_ocl_lgamma(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_fmod(double x, double y) { return __spirv_ocl_fmod(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_remainder(double x, double y) {
   return __spirv_ocl_remainder(x, y);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_remquo(double x, double y, int *q) {
   return __spirv_ocl_remquo(x, y, q);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_nextafter(double x, double y) {
   return __spirv_ocl_nextafter(x, y);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_fdim(double x, double y) { return __spirv_ocl_fdim(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_fma(double x, double y, double z) {
   return __spirv_ocl_fma(x, y, z);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_sin(double x) { return __spirv_ocl_sin(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_cos(double x) { return __spirv_ocl_cos(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_tan(double x) { return __spirv_ocl_tan(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_pow(double x, double y) { return __spirv_ocl_pow(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_acos(double x) { return __spirv_ocl_acos(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_asin(double x) { return __spirv_ocl_asin(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_atan(double x) { return __spirv_ocl_atan(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_atan2(double x, double y) { return __spirv_ocl_atan2(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_cosh(double x) { return __spirv_ocl_cosh(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_sinh(double x) { return __spirv_ocl_sinh(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_tanh(double x) { return __spirv_ocl_tanh(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_acosh(double x) { return __spirv_ocl_acosh(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_asinh(double x) { return __spirv_ocl_asinh(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_atanh(double x) { return __spirv_ocl_atanh(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_scalbn(double x, int exp) {
   return __spirv_ocl_ldexp(x, exp);
 }

--- a/libdevice/fallback-cmath.cpp
+++ b/libdevice/fallback-cmath.cpp
@@ -16,154 +16,154 @@
 // TODO: generate the DeviceLibFuncMap in sycl-post-link.cpp automatically
 // during the build based on libdevice to avoid manually sync.
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 int __devicelib_abs(int x) { return x < 0 ? -x : x; }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 long int __devicelib_labs(long int x) { return x < 0 ? -x : x; }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 long long int __devicelib_llabs(long long int x) { return x < 0 ? -x : x; }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 div_t __devicelib_div(int x, int y) { return {x / y, x % y}; }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 ldiv_t __devicelib_ldiv(long x, long y) { return {x / y, x % y}; }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 lldiv_t __devicelib_lldiv(long long x, long long y) { return {x / y, x % y}; }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_scalbnf(float x, int n) { return __spirv_ocl_ldexp(x, n); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_logf(float x) { return __spirv_ocl_log(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_expf(float x) { return __spirv_ocl_exp(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_frexpf(float x, int *exp) {
   return __spirv_ocl_frexp(x, exp);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_ldexpf(float x, int exp) { return __spirv_ocl_ldexp(x, exp); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_log10f(float x) { return __spirv_ocl_log10(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_modff(float x, float *intpart) {
   return __spirv_ocl_modf(x, intpart);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_exp2f(float x) { return __spirv_ocl_exp2(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_expm1f(float x) { return __spirv_ocl_expm1(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 int __devicelib_ilogbf(float x) { return __spirv_ocl_ilogb(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_log1pf(float x) { return __spirv_ocl_log1p(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_log2f(float x) { return __spirv_ocl_log2(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_logbf(float x) { return __spirv_ocl_logb(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_sqrtf(float x) { return __spirv_ocl_sqrt(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_cbrtf(float x) { return __spirv_ocl_cbrt(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_hypotf(float x, float y) { return __spirv_ocl_hypot(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_erff(float x) { return __spirv_ocl_erf(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_erfcf(float x) { return __spirv_ocl_erfc(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_tgammaf(float x) { return __spirv_ocl_tgamma(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_lgammaf(float x) { return __spirv_ocl_lgamma(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_fmodf(float x, float y) { return __spirv_ocl_fmod(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_remainderf(float x, float y) {
   return __spirv_ocl_remainder(x, y);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_remquof(float x, float y, int *q) {
   return __spirv_ocl_remquo(x, y, q);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_nextafterf(float x, float y) {
   return __spirv_ocl_nextafter(x, y);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_fdimf(float x, float y) { return __spirv_ocl_fdim(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_fmaf(float x, float y, float z) {
   return __spirv_ocl_fma(x, y, z);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_sinf(float x) { return __spirv_ocl_sin(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_cosf(float x) { return __spirv_ocl_cos(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_tanf(float x) { return __spirv_ocl_tan(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_powf(float x, float y) { return __spirv_ocl_pow(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_acosf(float x) { return __spirv_ocl_acos(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_asinf(float x) { return __spirv_ocl_asin(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_atanf(float x) { return __spirv_ocl_atan(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_atan2f(float x, float y) { return __spirv_ocl_atan2(x, y); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_coshf(float x) { return __spirv_ocl_cosh(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_sinhf(float x) { return __spirv_ocl_sinh(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_tanhf(float x) { return __spirv_ocl_tanh(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_acoshf(float x) { return __spirv_ocl_acosh(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_asinhf(float x) { return __spirv_ocl_asinh(x); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_atanhf(float x) { return __spirv_ocl_atanh(x); }
 
 #endif // __SPIR__

--- a/libdevice/fallback-complex-fp64.cpp
+++ b/libdevice/fallback-complex-fp64.cpp
@@ -15,15 +15,15 @@
 // To support fallback device libraries on-demand loading, please update the
 // DeviceLibFuncMap in llvm/tools/sycl-post-link/sycl-post-link.cpp if you add
 // or remove any item in this file.
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_creal(double __complex__ z) { return __real__(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_cimag(double __complex__ z) { return __imag__(z); }
 
 // __muldc3
 // Returns: the product of a + ib and c + id
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib___muldc3(double __a, double __b, double __c,
                                         double __d) {
   double __ac = __a * __c;
@@ -75,7 +75,7 @@ double __complex__ __devicelib___muldc3(double __a, double __b, double __c,
 
 // __divdc3
 // Returns: the quotient of (a + ib) / (c + id)
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib___divdc3(double __a, double __b, double __c,
                                         double __d) {
   int __ilogbw = 0;
@@ -117,17 +117,17 @@ double __complex__ __devicelib___divdc3(double __a, double __b, double __c,
   return z;
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_cabs(double __complex__ z) {
   return __spirv_ocl_hypot(__devicelib_creal(z), __devicelib_cimag(z));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __devicelib_carg(double __complex__ z) {
   return __spirv_ocl_atan2(__devicelib_cimag(z), __devicelib_creal(z));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib_cproj(double __complex__ z) {
   double __complex__ r = z;
   if (__spirv_IsInf(__devicelib_creal(z)) ||
@@ -136,7 +136,7 @@ double __complex__ __devicelib_cproj(double __complex__ z) {
   return r;
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib_cexp(double __complex__ z) {
   double z_imag = __devicelib_cimag(z);
   double z_real = __devicelib_creal(z);
@@ -157,12 +157,12 @@ double __complex__ __devicelib_cexp(double __complex__ z) {
                (__e * __spirv_ocl_sin(z_imag)));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib_clog(double __complex__ z) {
   return CMPLX(__spirv_ocl_log(__devicelib_cabs(z)), __devicelib_carg(z));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib_cpow(double __complex__ x,
                                     double __complex__ y) {
   double __complex__ t = __devicelib_clog(x);
@@ -172,7 +172,7 @@ double __complex__ __devicelib_cpow(double __complex__ x,
   return __devicelib_cexp(w);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib_cpolar(double rho, double theta) {
   if (__spirv_IsNan(rho) || __spirv_SignBitSet(rho))
     return CMPLX(NAN, NAN);
@@ -195,7 +195,7 @@ double __complex__ __devicelib_cpolar(double rho, double theta) {
   return CMPLX(x, y);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib_csqrt(double __complex__ z) {
   double z_real = __devicelib_creal(z);
   double z_imag = __devicelib_cimag(z);
@@ -213,7 +213,7 @@ double __complex__ __devicelib_csqrt(double __complex__ z) {
                             __devicelib_carg(z) / 2.0);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib_csinh(double __complex__ z) {
   double z_real = __devicelib_creal(z);
   double z_imag = __devicelib_cimag(z);
@@ -227,7 +227,7 @@ double __complex__ __devicelib_csinh(double __complex__ z) {
                __spirv_ocl_cosh(z_real) * __spirv_ocl_sin(z_imag));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib_ccosh(double __complex__ z) {
   double z_real = __devicelib_creal(z);
   double z_imag = __devicelib_cimag(z);
@@ -243,7 +243,7 @@ double __complex__ __devicelib_ccosh(double __complex__ z) {
                __spirv_ocl_sinh(z_real) * __spirv_ocl_sin(z_imag));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib_ctanh(double __complex__ z) {
   double z_real = __devicelib_creal(z);
   double z_imag = __devicelib_cimag(z);
@@ -263,33 +263,33 @@ double __complex__ __devicelib_ctanh(double __complex__ z) {
   return CMPLX(__2rsh / __d, __spirv_ocl_sin(__2i) / __d);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib_csin(double __complex__ z) {
   double __complex__ w =
       __devicelib_csinh(CMPLX(-__devicelib_cimag(z), __devicelib_creal(z)));
   return CMPLX(__devicelib_cimag(w), -__devicelib_creal(w));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib_ccos(double __complex__ z) {
   return __devicelib_ccosh(CMPLX(-__devicelib_cimag(z), __devicelib_creal(z)));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib_ctan(double __complex__ z) {
   double __complex__ w =
       __devicelib_ctanh(CMPLX(-__devicelib_cimag(z), __devicelib_creal(z)));
   return CMPLX(__devicelib_cimag(w), -__devicelib_creal(w));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __sqr(double __complex__ z) {
   double z_real = __devicelib_creal(z);
   double z_imag = __devicelib_cimag(z);
   return CMPLX((z_real + z_imag) * (z_real - z_imag), 2.0 * z_real * z_imag);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib_cacos(double __complex__ z) {
   double z_real = __devicelib_creal(z);
   double z_imag = __devicelib_cimag(z);
@@ -324,7 +324,7 @@ double __complex__ __devicelib_cacos(double __complex__ z) {
                -__spirv_ocl_fabs(__devicelib_creal(w)));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib_casinh(double __complex__ z) {
   double z_real = __devicelib_creal(z);
   double z_imag = __devicelib_cimag(z);
@@ -352,14 +352,14 @@ double __complex__ __devicelib_casinh(double __complex__ z) {
                __spirv_ocl_copysign(__devicelib_cimag(w), z_imag));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib_casin(double __complex__ z) {
   double __complex__ w =
       __devicelib_casinh(CMPLX(-__devicelib_cimag(z), __devicelib_creal(z)));
   return CMPLX(__devicelib_cimag(w), -__devicelib_creal(w));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib_cacosh(double __complex__ z) {
   double z_real = __devicelib_creal(z);
   double z_imag = __devicelib_cimag(z);
@@ -391,7 +391,7 @@ double __complex__ __devicelib_cacosh(double __complex__ z) {
                __spirv_ocl_copysign(__devicelib_cimag(w), z_imag));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib_catanh(double __complex__ z) {
   double z_real = __devicelib_creal(z);
   double z_imag = __devicelib_cimag(z);
@@ -422,7 +422,7 @@ double __complex__ __devicelib_catanh(double __complex__ z) {
                __spirv_ocl_copysign(__devicelib_cimag(w), z_imag));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 double __complex__ __devicelib_catan(double __complex__ z) {
   double __complex__ w =
       __devicelib_catanh(CMPLX(-__devicelib_cimag(z), __devicelib_creal(z)));

--- a/libdevice/fallback-complex.cpp
+++ b/libdevice/fallback-complex.cpp
@@ -15,15 +15,15 @@
 // To support fallback device libraries on-demand loading, please update the
 // DeviceLibFuncMap in llvm/tools/sycl-post-link/sycl-post-link.cpp if you add
 // or remove any item in this file.
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_crealf(float __complex__ z) { return __real__(z); }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_cimagf(float __complex__ z) { return __imag__(z); }
 
 // __mulsc3
 // Returns: the product of a + ib and c + id
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib___mulsc3(float __a, float __b, float __c,
                                        float __d) {
   float __ac = __a * __c;
@@ -77,7 +77,7 @@ float __complex__ __devicelib___mulsc3(float __a, float __b, float __c,
 // Returns: the quotient of (a + ib) / (c + id)
 // FIXME: divsc3/divdc3 have overflow issue when dealing with large number.
 // And this overflow issue is from libc++/compiler-rt's implementation.
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib___divsc3(float __a, float __b, float __c,
                                        float __d) {
   int __ilogbw = 0;
@@ -119,17 +119,17 @@ float __complex__ __devicelib___divsc3(float __a, float __b, float __c,
   return z;
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_cargf(float __complex__ z) {
   return __spirv_ocl_atan2(__devicelib_cimagf(z), __devicelib_crealf(z));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __devicelib_cabsf(float __complex__ z) {
   return __spirv_ocl_hypot(__devicelib_crealf(z), __devicelib_cimagf(z));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib_cprojf(float __complex__ z) {
   float __complex__ r = z;
   if (__spirv_IsInf(__devicelib_crealf(z)) ||
@@ -138,7 +138,7 @@ float __complex__ __devicelib_cprojf(float __complex__ z) {
   return r;
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib_cexpf(float __complex__ z) {
   float z_imag = __devicelib_cimagf(z);
   float z_real = __devicelib_crealf(z);
@@ -159,12 +159,12 @@ float __complex__ __devicelib_cexpf(float __complex__ z) {
                 (__e * __spirv_ocl_sin(z_imag)));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib_clogf(float __complex__ z) {
   return CMPLXF(__spirv_ocl_log(__devicelib_cabsf(z)), __devicelib_cargf(z));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib_cpowf(float __complex__ x, float __complex__ y) {
   float __complex__ t = __devicelib_clogf(x);
   float __complex__ w =
@@ -173,7 +173,7 @@ float __complex__ __devicelib_cpowf(float __complex__ x, float __complex__ y) {
   return __devicelib_cexpf(w);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib_cpolarf(float rho, float theta) {
   if (__spirv_IsNan(rho) || __spirv_SignBitSet(rho))
     return CMPLXF(NAN, NAN);
@@ -196,7 +196,7 @@ float __complex__ __devicelib_cpolarf(float rho, float theta) {
   return CMPLXF(x, y);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib_csqrtf(float __complex__ z) {
   float z_real = __devicelib_crealf(z);
   float z_imag = __devicelib_cimagf(z);
@@ -214,7 +214,7 @@ float __complex__ __devicelib_csqrtf(float __complex__ z) {
                              __devicelib_cargf(z) / 2.0f);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib_csinhf(float __complex__ z) {
   float z_real = __devicelib_crealf(z);
   float z_imag = __devicelib_cimagf(z);
@@ -228,7 +228,7 @@ float __complex__ __devicelib_csinhf(float __complex__ z) {
                 __spirv_ocl_cosh(z_real) * __spirv_ocl_sin(z_imag));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib_ccoshf(float __complex__ z) {
   float z_real = __devicelib_crealf(z);
   float z_imag = __devicelib_cimagf(z);
@@ -244,7 +244,7 @@ float __complex__ __devicelib_ccoshf(float __complex__ z) {
                 __spirv_ocl_sinh(z_real) * __spirv_ocl_sin(z_imag));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib_ctanhf(float __complex__ z) {
   float z_real = __devicelib_crealf(z);
   float z_imag = __devicelib_cimagf(z);
@@ -266,34 +266,34 @@ float __complex__ __devicelib_ctanhf(float __complex__ z) {
   return CMPLXF(__2rsh / __d, __spirv_ocl_sin(__2i) / __d);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib_csinf(float __complex__ z) {
   float __complex__ w =
       __devicelib_csinhf(CMPLXF(-__devicelib_cimagf(z), __devicelib_crealf(z)));
   return CMPLXF(__devicelib_cimagf(w), -__devicelib_crealf(w));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib_ccosf(float __complex__ z) {
   return __devicelib_ccoshf(
       CMPLXF(-__devicelib_cimagf(z), __devicelib_crealf(z)));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib_ctanf(float __complex__ z) {
   float __complex__ w =
       __devicelib_ctanhf(CMPLXF(-__devicelib_cimagf(z), __devicelib_crealf(z)));
   return CMPLXF(__devicelib_cimagf(w), -__devicelib_crealf(w));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __sqrf(float __complex__ z) {
   float z_real = __devicelib_crealf(z);
   float z_imag = __devicelib_cimagf(z);
   return CMPLXF((z_real + z_imag) * (z_real - z_imag), 2.0f * z_real * z_imag);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib_cacosf(float __complex__ z) {
   float z_real = __devicelib_crealf(z);
   float z_imag = __devicelib_cimagf(z);
@@ -328,7 +328,7 @@ float __complex__ __devicelib_cacosf(float __complex__ z) {
                 -__spirv_ocl_fabs(__devicelib_crealf(w)));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib_casinhf(float __complex__ z) {
   float z_real = __devicelib_crealf(z);
   float z_imag = __devicelib_cimagf(z);
@@ -356,14 +356,14 @@ float __complex__ __devicelib_casinhf(float __complex__ z) {
                 __spirv_ocl_copysign(__devicelib_cimagf(w), z_imag));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib_casinf(float __complex__ z) {
   float __complex__ w = __devicelib_casinhf(
       CMPLXF(-__devicelib_cimagf(z), __devicelib_crealf(z)));
   return CMPLXF(__devicelib_cimagf(w), -__devicelib_crealf(w));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib_cacoshf(float __complex__ z) {
   float z_real = __devicelib_crealf(z);
   float z_imag = __devicelib_cimagf(z);
@@ -395,7 +395,7 @@ float __complex__ __devicelib_cacoshf(float __complex__ z) {
                 __spirv_ocl_copysign(__devicelib_cimagf(w), z_imag));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib_catanhf(float __complex__ z) {
   float z_real = __devicelib_crealf(z);
   float z_imag = __devicelib_cimagf(z);
@@ -426,7 +426,7 @@ float __complex__ __devicelib_catanhf(float __complex__ z) {
                 __spirv_ocl_copysign(__devicelib_cimagf(w), z_imag));
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 float __complex__ __devicelib_catanf(float __complex__ z) {
   float __complex__ w = __devicelib_catanhf(
       CMPLXF(-__devicelib_cimagf(z), __devicelib_crealf(z)));

--- a/libdevice/fallback-cstring.cpp
+++ b/libdevice/fallback-cstring.cpp
@@ -42,7 +42,7 @@ static void *__devicelib_memcpy_uint32_aligned(void *dest, const void *src,
   return dest;
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 void *__devicelib_memcpy(void *dest, const void *src, size_t n) {
   if (dest == NULL || src == NULL || n == 0)
     return dest;
@@ -104,7 +104,7 @@ static void *__devicelib_memset_uint32_aligned(void *dest, int c, size_t n) {
   return dest;
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 void *__devicelib_memset(void *dest, int c, size_t n) {
   if (dest == NULL || n == 0)
     return dest;
@@ -173,7 +173,7 @@ static int __devicelib_memcmp_uint32_aligned(const void *s1, const void *s2,
       &s1_uint32_ptr[cmp_num], &s2_uint32_ptr[cmp_num], tailing_bytes);
 }
 
-DEVICE_EXTERN_C
+DEVICE_EXTERN_C_INLINE
 int __devicelib_memcmp(const void *s1, const void *s2, size_t n) {
   if (s1 == s2 || n == 0)
     return 0;


### PR DESCRIPTION
Signed-off-by: jinge90 <ge.jin@intel.com>

Previous patch https://github.com/intel/llvm/pull/5979 to apply "always_inline" to all libdevice functions have some problem, so libdevice functions are required to be no-inline. Currently, we have following groups of libdevice functions:
1. assert support      //Not sure inline impact to those functions, so we don't apply always_inline to assert for safety.
2. string support      // No problem for string utils, apply always_inline
3. cmath/cmath-fp64 //No problem for cmah utils, apply always_inline
4. complex/complex-fp64 //No problem for complex math utils, apply always_inline
5. ITT // Some functions in ITT support are required to be no-inline, we shouldn't apply always_inline to them.