### PR TITLE
[SYCL] Enable OpenCL and Level Zero plugins if SYCL_ENABLE_PLUGINS is undefined

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -14,6 +14,12 @@ if (NOT SYCL_COVERAGE_PATH)
   set(SYCL_COVERAGE_PATH "${CMAKE_CURRENT_BINARY_DIR}/profiles")
 endif()
 
+# If SYCL_ENABLE_PLUGINS is undefined, we default to enabling OpenCL and Level
+# Zero plugins.
+if (NOT DEFINED SYCL_ENABLE_PLUGINS)
+  set(SYCL_ENABLE_PLUGINS "opencl;level_zero")
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 include(AddSYCLExecutable)
 include(AddSYCL)


### PR DESCRIPTION
These changes make SYCL_ENABLE_PLUGINS enable both the OpenCL and the Level Zero PI plugins if it is unset.

This is closer to the behavior exhibited prior to https://github.com/intel/llvm/pull/5799.