### PR TITLE
Revert "[SYCL] Fix performance regression in parallel_for with using id class (#5385)"

### DIFF
--- a/sycl/include/CL/sycl/detail/stl_type_traits.hpp
+++ b/sycl/include/CL/sycl/detail/stl_type_traits.hpp
@@ -78,12 +78,6 @@ struct is_output_iterator<T, output_iterator_requirements<T>> {
   static constexpr bool value = true;
 };
 
-template <typename T, typename U>
-inline constexpr bool is_same_v = std::is_same<T, U>::value;
-
-template <typename T, typename U>
-inline constexpr bool is_convertible_v = std::is_convertible<T, U>::value;
-
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -927,14 +927,11 @@ private:
   }
 
   template <int Dims, typename LambdaArgType> struct TransformUserItemType {
-    using type = typename std::conditional_t<
-        detail::is_same_v<id<Dims>, LambdaArgType>, LambdaArgType,
-        typename std::conditional_t<
-            detail::is_convertible_v<nd_item<Dims>, LambdaArgType>,
-            nd_item<Dims>,
-            typename std::conditional_t<
-                detail::is_convertible_v<item<Dims>, LambdaArgType>, item<Dims>,
-                LambdaArgType>>>;
+    using type = typename std::conditional<
+        std::is_convertible<nd_item<Dims>, LambdaArgType>::value, nd_item<Dims>,
+        typename std::conditional<
+            std::is_convertible<item<Dims>, LambdaArgType>::value, item<Dims>,
+            LambdaArgType>::type>::type;
   };
 
   /// Defines and invokes a SYCL kernel function for the specified range.

--- a/sycl/test/basic_tests/parallel_for_type_check.cpp
+++ b/sycl/test/basic_tests/parallel_for_type_check.cpp
@@ -1,6 +1,7 @@
 // RUN: %clangxx -fsycl -fsycl-device-only -D__SYCL_INTERNAL_API -O0 -c -emit-llvm -S -o - %s | FileCheck %s
 
 // This test performs basic type check for sycl::id that is used in result type.
+// Check that sycl::id is converted from sycl::item.
 
 #include <CL/sycl.hpp>
 #include <iostream>
@@ -21,7 +22,7 @@ int main() {
     auto buf_acc = data_buf.get_access<sycl::access::mode::read_write>(h);
     h.parallel_for(
         sycl::range<1>{sz},
-        // CHECK: cl{{.*}}sycl{{.*}}detail{{.*}}RoundedRangeKernel{{.*}}id{{.*}}main{{.*}}handler
+        // CHECK: cl{{.*}}sycl{{.*}}detail{{.*}}RoundedRangeKernel{{.*}}item{{.*}}main{{.*}}handler
         [=](sycl::id<1> item) { buf_acc[item] += 1; });
   });
   q.wait();


### PR DESCRIPTION
This reverts commit a5760aa2813e5f689c74dad4bda785199edb7616.

Test is kept to check that id is converted from item within kernel.

https://github.com/intel/llvm/pull/5385 intends to fix a perf regression of a workload on cpu device. An alternative fix for the regression is to fix two pre- and post-vectorizer passes which have not handled llvm.assume properly, which I think is a better approach.

https://github.com/intel/llvm/pull/5385 causes regression on another vectorizer workload due to missing fsycl-id-queries-fit-in-int support for sycl::id that is used for querying global_id within a kernel. fsycl-id-queries-fit-in-int support is very important for vectorizer performance, so it is necessary to have the support for sycl::id.