### PR TITLE
[Clang] Recognize target address space in superset calculation

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -477,9 +477,9 @@ public:
   ///   every address space is a superset of itself.
   /// CL2.0 adds:
   ///   __generic is a superset of any address space except for __constant.
-  /// If ASMap is provided and address spaces are provided in both language and
-  /// target form the function will attempt to convert language to
-  /// target address space.
+  /// If ASMap is provided and address spaces are given in both language and
+  /// target form the function will attempt to convert language to target
+  /// address space.
   static bool isAddressSpaceSupersetOf(LangAS A, LangAS B,
                                        const LangASMap *ASMap = nullptr,
                                        bool IsSYCLOrOpenCL = false) {
@@ -505,15 +505,14 @@ public:
           A = static_cast<LangAS>(
               (*ASMap)[static_cast<unsigned>(A)] +
               static_cast<unsigned>(LangAS::FirstTargetAddressSpace));
-        // When dealing with target AS return true iff:
+        // When dealing with target AS return true if:
         // * A is equal to B, or
         // * in OpenCL or SYCL and A is generic and B is not constant (making
         // sure that constant and generic are in target address spaces).
         if (IsSYCLOrOpenCL)
           return A == B ||
                  (A == Generic && B != Constant && Generic != Constant);
-        else
-          return A == B;
+        return A == B;
       }
     }
 

--- a/clang/lib/Sema/SemaCast.cpp
+++ b/clang/lib/Sema/SemaCast.cpp
@@ -2623,8 +2623,10 @@ void CastOperation::checkAddressSpaceCast(QualType SrcType, QualType DestType) {
       LangAS DestAS = DestPPointee.getAddressSpace();
       LangAS SrcAS = SrcPPointee.getAddressSpace();
       const bool OverlappingAS =
-          Qualifiers::isAddressSpaceSupersetOf(DestAS, SrcAS, &ASMap, true) ||
-          Qualifiers::isAddressSpaceSupersetOf(SrcAS, DestAS, &ASMap, true);
+          Qualifiers::isAddressSpaceSupersetOf(
+              DestAS, SrcAS, &ASMap, clang::Qualifiers::ASOffload::OpenCL) ||
+          Qualifiers::isAddressSpaceSupersetOf(
+              SrcAS, DestAS, &ASMap, clang::Qualifiers::ASOffload::OpenCL);
       if (Nested ? DestAS != SrcAS : !OverlappingAS) {
         Self.Diag(OpRange.getBegin(), DiagID)
             << SrcType << DestType << Sema::AA_Casting

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -9234,9 +9234,14 @@ checkPointerTypesForAssignment(Sema &S, QualType LHSType, QualType RHSType) {
     rhq.removeObjCLifetime();
   }
 
-  if (!lhq.compatiblyIncludes(rhq)) {
+  const bool IsSYCLOrOpenCL =
+      S.getLangOpts().OpenCL || S.getLangOpts().SYCLIsDevice;
+  const LangASMap &ASMap = S.Context.getTargetInfo().getAddressSpaceMap();
+  if (!lhq.compatiblyIncludes(rhq, &ASMap)) {
     // Treat address-space mismatches as fatal.
-    if (!lhq.isAddressSpaceSupersetOf(rhq))
+    if (!Qualifiers::isAddressSpaceSupersetOf(lhq.getAddressSpace(),
+                                              rhq.getAddressSpace(), &ASMap,
+                                              IsSYCLOrOpenCL))
       return Sema::IncompatiblePointerDiscardsQualifiers;
 
     // It's okay to add or remove GC or lifetime qualifiers when converting to

--- a/clang/test/Sema/address_space_type_casts_amdgpu.cl
+++ b/clang/test/Sema/address_space_type_casts_amdgpu.cl
@@ -1,0 +1,32 @@
+// REQUIRES: amdgpu-registered-target
+// RUN: %clang_cc1 -cl-std=CL2.0 -triple amdgcn-amd-amdhsa -verify -pedantic -fsyntax-only %s
+
+void __builtins_AS_3(__attribute__((address_space(3))) int *);
+
+// Check calling a function using address space 3 (local for AMD) pointer works
+// with __local.
+__kernel void ker(__local int *IL) {
+  __builtins_AS_3(IL);
+}
+
+// Check casting __local to address space 3 (local for AMD) pointer works.
+__kernel void ker_2(__global int *Array, int N) {
+  __local int IL;
+  __attribute__((address_space(3))) int *I3;
+  I3 = (__attribute__((address_space(3))) int *)&IL;
+  Array[N] = *I3;
+}
+
+// Check casting __shared to address space 5 (private for AMD) pointer errors.
+__kernel void ker_3(__global int *Array, int N) {
+  __private int IP;
+  __attribute__((address_space(5))) int *I5;
+  I5 = (__attribute__((address_space(5))) int *)&IP;
+  Array[N] = *I5;
+}
+
+// Check casting of address_space(3) to __generic pointer works.
+__kernel void ker_4(__global int *Array, int N, __attribute__((address_space(3))) int *AS3_ptr) {
+  __generic int *IG;
+  IG = AS3_ptr; // expected-warning {{assigning to '__generic int *__private' from '__attribute__((address_space(3))) int *__private' discards qualifiers}}
+}

--- a/clang/test/Sema/address_space_type_casts_amdgpu.cl
+++ b/clang/test/Sema/address_space_type_casts_amdgpu.cl
@@ -17,16 +17,22 @@ __kernel void ker_2(__global int *Array, int N) {
   Array[N] = *I3;
 }
 
-// Check casting __shared to address space 5 (private for AMD) pointer errors.
+// Check casting __local to address space 5 (private for AMD) pointer errors.
 __kernel void ker_3(__global int *Array, int N) {
-  __private int IP;
+  __local int IP;
   __attribute__((address_space(5))) int *I5;
-  I5 = (__attribute__((address_space(5))) int *)&IP;
+  I5 = (__attribute__((address_space(5))) int *)&IP; // expected-error {{casting '__local int *' to type '__attribute__((address_space(5))) int *' changes address space of pointer}}
   Array[N] = *I5;
 }
 
 // Check casting of address_space(3) to __generic pointer works.
 __kernel void ker_4(__global int *Array, int N, __attribute__((address_space(3))) int *AS3_ptr) {
   __generic int *IG;
-  IG = AS3_ptr; // expected-warning {{assigning to '__generic int *__private' from '__attribute__((address_space(3))) int *__private' discards qualifiers}}
+  IG = AS3_ptr;
+}
+
+// Check casting of address_space(4) (__constant) to __generic pointer fails.
+__kernel void ker_5(__global int *Array, int N, __attribute__((address_space(4))) int *AS4_ptr) {
+  __generic int *IG;
+  IG = AS4_ptr; // expected-error {{assigning '__attribute__((address_space(4))) int *__private' to '__generic int *__private' changes address space of pointer}}
 }

--- a/clang/test/Sema/address_space_type_casts_default.cl
+++ b/clang/test/Sema/address_space_type_casts_default.cl
@@ -1,0 +1,34 @@
+// REQUIRES: x86-registered-target
+// RUN: %clang_cc1 -cl-std=CL2.0 -verify -pedantic -fsyntax-only %s
+
+// The same as address_space_type_cast_amdgpu.cl, but as x86 does not provide
+// ASMap all cases should error out.
+
+void __builtins_AS_3(__attribute__((address_space(3))) int *); // expected-note {{passing argument to parameter here}}
+
+// No relatioship between address_space(3) and __local on x86.
+__kernel void ker(__local int *IL) {
+  __builtins_AS_3(IL); // expected-error {{passing '__local int *__private' to parameter of type '__attribute__((address_space(3))) int *' changes address space of pointer}}
+}
+
+// No relatioship between address_space(3) and __local on x86.
+__kernel void ker_2(__global int *Array, int N) {
+  __local int IL;
+  __attribute__((address_space(3))) int *I3;
+  I3 = (__attribute__((address_space(3))) int *)&IL; // expected-error {{casting '__local int *' to type '__attribute__((address_space(3))) int *' changes address space of pointer}}
+  Array[N] = *I3;
+}
+
+// No relatioship between address_space(5) and __private on x86.
+__kernel void ker_3(__global int *Array, int N) {
+  __private int IP;
+  __attribute__((address_space(5))) int *I5;
+  I5 = (__attribute__((address_space(5))) int *)&IP; // expected-error {{casting '__private int *' to type '__attribute__((address_space(5))) int *' changes address space of pointer}}
+  Array[N] = *I5;
+}
+
+// Without ASMap compiler can't tell if address_space(3) is not equal to __constant, fail.
+__kernel void ker_4(__global int *Array, int N, __attribute__((address_space(3))) int *AS3_ptr) {
+  __generic int *IG;
+  IG = AS3_ptr; // expected-error {{assigning '__attribute__((address_space(3))) int *__private' to '__generic int *__private' changes address space of pointer}}
+}

--- a/clang/test/SemaOpenCL/atomic-ops.cl
+++ b/clang/test/SemaOpenCL/atomic-ops.cl
@@ -67,12 +67,12 @@ void f(atomic_int *i, const atomic_int *ci,
   bool cmpexch_1 = __opencl_atomic_compare_exchange_strong(i, I, 1, memory_order_seq_cst, memory_order_seq_cst, memory_scope_work_group);
   bool cmpexch_2 = __opencl_atomic_compare_exchange_strong(p, P, 1, memory_order_seq_cst, memory_order_seq_cst, memory_scope_work_group);
   bool cmpexch_3 = __opencl_atomic_compare_exchange_strong(f, I, 1, memory_order_seq_cst, memory_order_seq_cst, memory_scope_work_group); // expected-warning {{incompatible pointer types passing '__generic int *__private' to parameter of type '__generic float *'}}
-  (void)__opencl_atomic_compare_exchange_strong(i, CI, 1, memory_order_seq_cst, memory_order_seq_cst, memory_scope_work_group); // expected-warning {{passing 'const __generic int *__private' to parameter of type '__generic int *' discards qualifiers}}
+  (void)__opencl_atomic_compare_exchange_strong(i, CI, 1, memory_order_seq_cst, memory_order_seq_cst, memory_scope_work_group);
 
   bool cmpexchw_1 = __opencl_atomic_compare_exchange_weak(i, I, 1, memory_order_seq_cst, memory_order_seq_cst, memory_scope_work_group);
   bool cmpexchw_2 = __opencl_atomic_compare_exchange_weak(p, P, 1, memory_order_seq_cst, memory_order_seq_cst, memory_scope_work_group);
   bool cmpexchw_3 = __opencl_atomic_compare_exchange_weak(f, I, 1, memory_order_seq_cst, memory_order_seq_cst, memory_scope_work_group); // expected-warning {{incompatible pointer types passing '__generic int *__private' to parameter of type '__generic float *'}}
-  (void)__opencl_atomic_compare_exchange_weak(i, CI, 1, memory_order_seq_cst, memory_order_seq_cst, memory_scope_work_group); // expected-warning {{passing 'const __generic int *__private' to parameter of type '__generic int *' discards qualifiers}}
+  (void)__opencl_atomic_compare_exchange_weak(i, CI, 1, memory_order_seq_cst, memory_order_seq_cst, memory_scope_work_group);
 
   // Pointers to different address spaces are allowed.
   bool cmpexch_10 = __opencl_atomic_compare_exchange_strong((global atomic_int *)0x308, (constant int *)0x309, 1, memory_order_seq_cst, memory_order_seq_cst, memory_scope_work_group);

--- a/clang/test/SemaOpenCL/numbered-address-space.cl
+++ b/clang/test/SemaOpenCL/numbered-address-space.cl
@@ -2,11 +2,16 @@
 // RUN: %clang_cc1 -cl-std=CL2.0 -triple amdgcn-amd-amdhsa -verify -pedantic -fsyntax-only %s
 
 void test_numeric_as_to_generic_implicit_cast(__attribute__((address_space(3))) int *as3_ptr, float src) {
-  generic int *generic_ptr = as3_ptr; // expected-warning {{initializing '__generic int *__private' with an expression of type '__attribute__((address_space(3))) int *__private' discards qualifiers}}
+  generic int *generic_ptr = as3_ptr;
+}
+
+// AS 4 is constant on AMDGPU, casting it to generic is illegal.
+void test_numeric_as_const_to_generic_implicit_cast(__attribute__((address_space(4))) int *as4_ptr, float src) {
+  generic int *generic_ptr = as4_ptr; // expected-error{{initializing '__generic int *__private' with an expression of type '__attribute__((address_space(4))) int *__private' changes address space of pointer}}
 }
 
 void test_numeric_as_to_generic_explicit_cast(__attribute__((address_space(3))) int *as3_ptr, float src) {
-  generic int* generic_ptr = (generic int*) as3_ptr; // Should maybe be valid?
+  generic int *generic_ptr = (generic int *)as3_ptr;
 }
 
 void test_generic_to_numeric_as_implicit_cast(void) {
@@ -20,12 +25,12 @@ void test_generic_to_numeric_as_explicit_cast(void) {
 }
 
 void test_generic_as_to_builtin_parameter_explicit_cast_numeric(__attribute__((address_space(3))) int *as3_ptr, float src) {
-  generic int *generic_ptr = as3_ptr; // expected-warning {{initializing '__generic int *__private' with an expression of type '__attribute__((address_space(3))) int *__private' discards qualifiers}}
-  // This is legal, as address_space(3) correspongs to local on amdgpu.
+  generic int *generic_ptr = as3_ptr;
+  // This is legal, as address_space(3) corresponds to local on amdgpu.
   volatile float result = __builtin_amdgcn_ds_fmaxf((__attribute__((address_space(3))) float *)generic_ptr, src, 0, 0, false);
 }
 
 void test_generic_as_to_builtin_parameterimplicit_cast_numeric(__attribute__((address_space(3))) int *as3_ptr, float src) {
-  generic int *generic_ptr = as3_ptr;                                               // expected-warning {{initializing '__generic int *__private' with an expression of type '__attribute__((address_space(3))) int *__private' discards qualifiers}}
+  generic int *generic_ptr = as3_ptr;
   volatile float result = __builtin_amdgcn_ds_fmaxf(generic_ptr, src, 0, 0, false); // expected-error {{passing '__generic int *__private' to parameter of type '__local float *' changes address space of pointer}}
 }

--- a/clang/test/SemaOpenCL/numbered-address-space.cl
+++ b/clang/test/SemaOpenCL/numbered-address-space.cl
@@ -2,7 +2,7 @@
 // RUN: %clang_cc1 -cl-std=CL2.0 -triple amdgcn-amd-amdhsa -verify -pedantic -fsyntax-only %s
 
 void test_numeric_as_to_generic_implicit_cast(__attribute__((address_space(3))) int *as3_ptr, float src) {
-  generic int* generic_ptr = as3_ptr; // FIXME: This should error
+  generic int *generic_ptr = as3_ptr; // expected-warning {{initializing '__generic int *__private' with an expression of type '__attribute__((address_space(3))) int *__private' discards qualifiers}}
 }
 
 void test_numeric_as_to_generic_explicit_cast(__attribute__((address_space(3))) int *as3_ptr, float src) {
@@ -20,12 +20,12 @@ void test_generic_to_numeric_as_explicit_cast(void) {
 }
 
 void test_generic_as_to_builtin_parameter_explicit_cast_numeric(__attribute__((address_space(3))) int *as3_ptr, float src) {
-  generic int* generic_ptr = as3_ptr; // FIXME: This should error
-  volatile float result = __builtin_amdgcn_ds_fmaxf((__attribute__((address_space(3))) float*) generic_ptr, src, 0, 0, false); // expected-error {{passing '__attribute__((address_space(3))) float *' to parameter of type '__local float *' changes address space of pointer}}
+  generic int *generic_ptr = as3_ptr; // expected-warning {{initializing '__generic int *__private' with an expression of type '__attribute__((address_space(3))) int *__private' discards qualifiers}}
+  // This is legal, as address_space(3) correspongs to local on amdgpu.
+  volatile float result = __builtin_amdgcn_ds_fmaxf((__attribute__((address_space(3))) float *)generic_ptr, src, 0, 0, false);
 }
 
 void test_generic_as_to_builtin_parameterimplicit_cast_numeric(__attribute__((address_space(3))) int *as3_ptr, float src) {
-  generic int* generic_ptr = as3_ptr;
+  generic int *generic_ptr = as3_ptr;                                               // expected-warning {{initializing '__generic int *__private' with an expression of type '__attribute__((address_space(3))) int *__private' discards qualifiers}}
   volatile float result = __builtin_amdgcn_ds_fmaxf(generic_ptr, src, 0, 0, false); // expected-error {{passing '__generic int *__private' to parameter of type '__local float *' changes address space of pointer}}
 }
-

--- a/clang/test/SemaOpenCL/predefined-expr.cl
+++ b/clang/test/SemaOpenCL/predefined-expr.cl
@@ -2,7 +2,7 @@
 // RUN: %clang_cc1 %s -verify -cl-std=CL2.0
 
 void f() {
-  char *f1 = __func__;          //expected-error-re{{initializing '{{__generic|__private}} char *__private' with an expression of type 'const __constant char *' changes address space of pointer}}
-  constant char *f2 = __func__; //expected-warning{{initializing '__constant char *__private' with an expression of type 'const __constant char[2]' discards qualifiers}}
+  char *f1 = __func__; // expected-error-re{{initializing '{{__generic|__private}} char *__private' with an expression of type 'const __constant char *' changes address space of pointer}}
+  constant char *f2 = __func__;
   constant const char *f3 = __func__;
 }

--- a/clang/test/SemaOpenCL/vector-conv.cl
+++ b/clang/test/SemaOpenCL/vector-conv.cl
@@ -16,7 +16,8 @@ void vector_conv_invalid(const global int4 *const_global_ptr) {
   e = (constant int4)i;
   e = (private int4)i;
 
-  private int4 *private_ptr = (const private int4 *)const_global_ptr; // expected-error{{casting 'const __global int4 *' to type 'const __private int4 *' changes address space of pointer}}
-  global int4 *global_ptr = const_global_ptr;                 // expected-warning {{initializing '__global int4 *__private' with an expression of type 'const __global int4 *__private' discards qualifiers}}
+private
+  int4 *private_ptr = (const private int4 *)const_global_ptr; // expected-error{{casting 'const __global int4 *' to type 'const __private int4 *' changes address space of pointer}}
+  global int4 *global_ptr = const_global_ptr;
   global_ptr = (global int4 *)const_global_ptr;
 }


### PR DESCRIPTION
This patch extends `isAddressSpaceSupersetOf` function, making it possible to match language with target address spaces. It harnesses `LangASMap` provided by targets to align both address spaces to the target's values.
 
The need for AS translation was observed when reviewing:
https://reviews.llvm.org/D112718

especially, the fact that builtins could now be declared in target address space and accept language inputs.