### PR TITLE
[SYCL] fix incorrect setting of Queue->LastCommandEvent

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -3271,12 +3271,6 @@ pi_result piQueueFinish(pi_queue Queue) {
     if (ZeQueue)
       ZE_CALL(zeHostSynchronize, (ZeQueue));
   }
-
-  // Lock automatically releases when this goes out of scope.
-  std::scoped_lock lock(Queue->Mutex);
-  // Prevent unneeded already finished events to show up in the wait list.
-  Queue->LastCommandEvent = nullptr;
-
   return PI_SUCCESS;
 }
 


### PR DESCRIPTION
Since we aren't locking SYCL queue while this thread is synchronizing, other threads might submit new commands to that in-order queue. So, when sync is completed, we can't just reset the last command since this can be pointing to something else that is still running, and we need to take that as a dependency for in-order execution. 

Signed-off-by: Sergey V Maslov <sergey.v.maslov@intel.com>