### PR TITLE
[SYCL] fix failing clang-format github action. 

### DIFF
--- a/devops/actions/clang-format/action.yml
+++ b/devops/actions/clang-format/action.yml
@@ -6,6 +6,7 @@ runs:
   - name: Run clang-format for the patch
     shell: bash {0}
     run: |
+      git config --global --add safe.directory /__w/llvm/llvm
       git clang-format ${GITHUB_SHA}^1
       git diff > ./clang-format.patch
   # Add patch with formatting fixes to CI job artifacts

--- a/devops/actions/llvm_test_suite/action.yml
+++ b/devops/actions/llvm_test_suite/action.yml
@@ -33,7 +33,9 @@ post-if: false
 runs:
   using: "composite"
   steps:
-  - run: cp -r /actions .
+  - run: |
+      cp -r /actions .
+      git config --global --add safe.directory /__w/repo_cache/intel/llvm-test-suite
     shell: bash
   - name: Checkout LLVM Test Suite
     uses: ./actions/cached_checkout


### PR DESCRIPTION
clang-format Github action is failing. ( see https://github.com/intel/llvm/pull/6015 and discussion: https://github.com/actions/checkout/issues/760 )  

Repo needs to be marked as safe for security reasons

Signed-off-by: Chris Perkins <chris.perkins@intel.com>