### PR TITLE
[SYCL] Add reduction overloads accepting span

### DIFF
--- a/sycl/include/CL/sycl/handler.hpp
+++ b/sycl/include/CL/sycl/handler.hpp
@@ -240,9 +240,9 @@ private:
 namespace ext {
 namespace oneapi {
 namespace detail {
-template <typename T, class BinaryOperation, int Dims, bool IsUSM,
-          access::placeholder IsPlaceholder>
-class reduction_impl;
+template <typename T, class BinaryOperation, int Dims, size_t Extent,
+          class Algorithm>
+class reduction_impl_algo;
 
 using cl::sycl::detail::enable_if_t;
 using cl::sycl::detail::queue_impl;
@@ -2685,11 +2685,11 @@ private:
   // Make stream class friend to be able to keep the list of associated streams
   friend class stream;
   friend class detail::stream_impl;
-  // Make reduction_impl friend to store buffers and arrays created for it
-  // in handler from reduction_impl methods.
-  template <typename T, class BinaryOperation, int Dims, bool IsUSM,
-            access::placeholder IsPlaceholder>
-  friend class ext::oneapi::detail::reduction_impl;
+  // Make reduction friends to store buffers and arrays created for it
+  // in handler from reduction methods.
+  template <typename T, class BinaryOperation, int Dims, size_t Extent,
+            class Algorithm>
+  friend class ext::oneapi::detail::reduction_impl_algo;
 
   // This method needs to call the method finalize().
   template <typename Reduction, typename... RestT>

--- a/sycl/include/CL/sycl/reduction.hpp
+++ b/sycl/include/CL/sycl/reduction.hpp
@@ -100,6 +100,7 @@ reduction(T *Var, const T &Identity, BinaryOperation Combiner,
   return {Var, Identity, Combiner, InitializeToIdentity};
 }
 
+#if __cplusplus >= 201703L
 /// Constructs a reduction object using the reduction variable referenced by
 /// the given sycl::span \p Span, reduction operation \p Combiner, and
 /// optional reduction properties.
@@ -149,6 +150,7 @@ reduction(span<T, Extent> Span, const T &Identity, BinaryOperation Combiner,
       PropList.has_property<property::reduction::initialize_to_identity>();
   return {Span, Identity, Combiner, InitializeToIdentity};
 }
+#endif
 
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/reduction.hpp
+++ b/sycl/include/CL/sycl/reduction.hpp
@@ -20,7 +20,9 @@ namespace sycl {
 template <typename T, typename AllocatorT, typename BinaryOperation>
 std::enable_if_t<has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, false, access::placeholder::true_t>>
+                     T, BinaryOperation, 0, 1,
+                     ext::oneapi::detail::default_reduction_algorithm<
+                         false, access::placeholder::true_t, 1>>>
 reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, BinaryOperation,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -35,7 +37,9 @@ reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, BinaryOperation,
 template <typename T, typename AllocatorT, typename BinaryOperation>
 std::enable_if_t<!has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, false, access::placeholder::true_t>>
+                     T, BinaryOperation, 0, 1,
+                     ext::oneapi::detail::default_reduction_algorithm<
+                         false, access::placeholder::true_t, 1>>>
 reduction(buffer<T, 1, AllocatorT>, handler &, BinaryOperation,
           const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
@@ -49,9 +53,11 @@ reduction(buffer<T, 1, AllocatorT>, handler &, BinaryOperation,
 /// the given USM pointer \p Var, handler \p CGH, reduction operation
 /// \p Combiner, and optional reduction properties.
 template <typename T, typename BinaryOperation>
-std::enable_if_t<
-    has_known_identity<BinaryOperation, T>::value,
-    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, true>>
+std::enable_if_t<has_known_identity<BinaryOperation, T>::value,
+                 ext::oneapi::detail::reduction_impl<
+                     T, BinaryOperation, 0, 1,
+                     ext::oneapi::detail::default_reduction_algorithm<
+                         true, access::placeholder::false_t, 1>>>
 reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
@@ -64,9 +70,11 @@ reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
 /// The reduction algorithm may be less efficient for this variant as the
 /// reduction identity is not known statically and it is not provided by user.
 template <typename T, typename BinaryOperation>
-std::enable_if_t<
-    !has_known_identity<BinaryOperation, T>::value,
-    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, true>>
+std::enable_if_t<!has_known_identity<BinaryOperation, T>::value,
+                 ext::oneapi::detail::reduction_impl<
+                     T, BinaryOperation, 0, 1,
+                     ext::oneapi::detail::default_reduction_algorithm<
+                         true, access::placeholder::false_t, 1>>>
 reduction(T *, BinaryOperation, const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
   (void)PropList;
@@ -79,8 +87,10 @@ reduction(T *, BinaryOperation, const property_list &PropList = {}) {
 /// reduction identity value \p Identity, reduction operation \p Combiner,
 /// and optional reduction properties.
 template <typename T, typename AllocatorT, typename BinaryOperation>
-ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, false,
-                                    access::placeholder::true_t>
+ext::oneapi::detail::reduction_impl<
+    T, BinaryOperation, 0, 1,
+    ext::oneapi::detail::default_reduction_algorithm<
+        false, access::placeholder::true_t, 1>>
 reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
           BinaryOperation Combiner, const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -92,7 +102,10 @@ reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
 /// the given USM pointer \p Var, reduction identity value \p Identity,
 /// binary operation \p Combiner, and optional reduction properties.
 template <typename T, typename BinaryOperation>
-ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, true>
+ext::oneapi::detail::reduction_impl<
+    T, BinaryOperation, 0, 1,
+    ext::oneapi::detail::default_reduction_algorithm<
+        true, access::placeholder::false_t, 1>>
 reduction(T *Var, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -109,8 +122,10 @@ reduction(T *Var, const T &Identity, BinaryOperation Combiner,
 template <typename T, size_t Extent, typename BinaryOperation>
 std::enable_if_t<Extent != dynamic_extent &&
                      has_known_identity<BinaryOperation, T>::value,
-                 ext::oneapi::detail::reduction_impl<span<T, Extent>,
-                                                     BinaryOperation, 1, true>>
+                 ext::oneapi::detail::reduction_impl<
+                     T, BinaryOperation, 1, Extent,
+                     ext::oneapi::detail::default_reduction_algorithm<
+                         true, access::placeholder::false_t, 1>>>
 reduction(span<T, Extent> Span, BinaryOperation,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -126,8 +141,10 @@ reduction(span<T, Extent> Span, BinaryOperation,
 template <typename T, size_t Extent, typename BinaryOperation>
 std::enable_if_t<Extent != dynamic_extent &&
                      !has_known_identity<BinaryOperation, T>::value,
-                 ext::oneapi::detail::reduction_impl<span<T, Extent>,
-                                                     BinaryOperation, 1, true>>
+                 ext::oneapi::detail::reduction_impl<
+                     T, BinaryOperation, 1, Extent,
+                     ext::oneapi::detail::default_reduction_algorithm<
+                         true, access::placeholder::false_t, 1>>>
 reduction(span<T, Extent> Span, BinaryOperation,
           const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
@@ -142,8 +159,10 @@ reduction(span<T, Extent> Span, BinaryOperation,
 /// reduction operation \p Combiner, and optional reduction properties.
 template <typename T, size_t Extent, typename BinaryOperation>
 std::enable_if_t<Extent != dynamic_extent,
-                 ext::oneapi::detail::reduction_impl<span<T, Extent>,
-                                                     BinaryOperation, 1, true>>
+                 ext::oneapi::detail::reduction_impl<
+                     T, BinaryOperation, 1, Extent,
+                     ext::oneapi::detail::default_reduction_algorithm<
+                         true, access::placeholder::false_t, 1>>>
 reduction(span<T, Extent> Span, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =

--- a/sycl/include/CL/sycl/reduction.hpp
+++ b/sycl/include/CL/sycl/reduction.hpp
@@ -117,8 +117,6 @@ reduction(T *Var, const T &Identity, BinaryOperation Combiner,
 /// Constructs a reduction object using the reduction variable referenced by
 /// the given sycl::span \p Span, reduction operation \p Combiner, and
 /// optional reduction properties.
-/// The reduction algorithm may be less efficient for this variant as the
-/// reduction identity is not known statically and it is not provided by user.
 template <typename T, size_t Extent, typename BinaryOperation>
 std::enable_if_t<Extent != dynamic_extent &&
                      has_known_identity<BinaryOperation, T>::value,

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -112,9 +112,13 @@ __SYCL_EXPORT size_t reduComputeWGSize(size_t NWorkItems, size_t MaxWGSize,
 /// types and operations for which the identity value is not known.
 /// The Algorithm template can be used to specialize reducers for different
 /// reduction algorithms. The View template describes whether the reducer
-/// owns its data or not -- with the current default reduction algorithm,
-/// the top-level reducer that is passed to the user's lambda owns its data,
-/// while any reducer created by a subscript operator contains a reference.
+/// owns its data or not: if View is 'true', then the reducer does not own
+/// its data and instead provides a view of data allocated elsewhere (i.e.
+/// via a reference or pointer member); if View is 'false', then the reducer
+/// owns its data. With the current default reduction algorithm, the top-level
+/// reducers that are passed to the user's lambda contain a private copy of
+/// the reduction variable, whereas any reducer created by a subscript operator
+/// contains a reference to a reduction variable allocated elsewhere.
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
           class Algorithm, bool View = false, typename Subst = void>
 class reducer;

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -369,8 +369,8 @@ public:
     return known_identity_impl<_BinaryOperation, _T>::value;
   }
 
-  T &getElement(size_t E) { return MValue; }
-  const T &getElement(size_t E) const { return MValue; }
+  T &getElement(size_t) { return MValue; }
+  const T &getElement(size_t) const { return MValue; }
   T MValue;
 };
 

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -1998,7 +1998,7 @@ struct IsScalarReduction {
 struct IsArrayReduction {
   template <typename Reduction> struct Func {
     static constexpr bool value =
-        (Reduction::dims == 1 && Reduction::num_elements > 1);
+        (Reduction::dims == 1 && Reduction::num_elements >= 1);
   };
 };
 

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -224,7 +224,7 @@ public:
     auto reducer = static_cast<const Reducer *>(this);
     for (size_t E = 0; E < Extent; ++E) {
       atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
-          *multi_ptr<T, Space>(ReduVarPtr))
+          multi_ptr<T, Space>(ReduVarPtr)[E])
           .fetch_add(reducer->getElement(E));
     }
   }
@@ -241,7 +241,7 @@ public:
     auto reducer = static_cast<const Reducer *>(this);
     for (size_t E = 0; E < Extent; ++E) {
       atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
-          *multi_ptr<T, Space>(ReduVarPtr))
+          multi_ptr<T, Space>(ReduVarPtr)[E])
           .fetch_or(reducer->getElement(E));
     }
   }
@@ -258,7 +258,7 @@ public:
     auto reducer = static_cast<const Reducer *>(this);
     for (size_t E = 0; E < Extent; ++E) {
       atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
-          *multi_ptr<T, Space>(ReduVarPtr))
+          multi_ptr<T, Space>(ReduVarPtr)[E])
           .fetch_xor(reducer->getElement(E));
     }
   }
@@ -275,7 +275,7 @@ public:
     auto reducer = static_cast<const Reducer *>(this);
     for (size_t E = 0; E < Extent; ++E) {
       atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
-          *multi_ptr<T, Space>(ReduVarPtr))
+          multi_ptr<T, Space>(ReduVarPtr)[E])
           .fetch_and(reducer->getElement(E));
     }
   }
@@ -292,7 +292,7 @@ public:
     auto reducer = static_cast<const Reducer *>(this);
     for (size_t E = 0; E < Extent; ++E) {
       atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
-          *multi_ptr<T, Space>(ReduVarPtr))
+          multi_ptr<T, Space>(ReduVarPtr)[E])
           .fetch_min(reducer->getElement(E));
     }
   }
@@ -309,7 +309,7 @@ public:
     auto reducer = static_cast<const Reducer *>(this);
     for (size_t E = 0; E < Extent; ++E) {
       atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
-          *multi_ptr<T, Space>(ReduVarPtr))
+          multi_ptr<T, Space>(ReduVarPtr)[E])
           .fetch_max(reducer->getElement(E));
     }
   }
@@ -333,7 +333,7 @@ public:
   T getIdentity() const { return MIdentity; }
 
   T &getElement(size_t) { return MValue; }
-
+  const T &getElement(size_t E) const { return MValue; }
   T MValue;
 
 private:

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -112,60 +112,228 @@ __SYCL_EXPORT size_t reduComputeWGSize(size_t NWorkItems, size_t MaxWGSize,
 /// functions and representing users' reduction variable.
 /// The generic version of the class represents those reductions of those
 /// types and operations for which the identity value is not known.
-template <typename T, class BinaryOperation, typename Subst = void>
-class reducer {
+/// The Algorithm template can be used to specialize reducers for different
+/// reduction algorithms. The View template describes whether the reducer
+/// owns its data or not -- with the current default reduction algorithm,
+/// the top-level reducer that is passed to the user's lambda owns its data,
+/// while any reducer created by a subscript operator contains a reference.
+template <typename T, class BinaryOperation, int Dims, size_t Extent,
+          class Algorithm, bool View = false, typename Subst = void>
+class reducer;
+
+/// Helper class for accessing reducer-defined types in CRTP
+/// May prove to be useful for other things later
+template <typename Reducer> struct ReducerTraits;
+
+template <typename T, class BinaryOperation, int Dims, std::size_t Extent,
+          class Algorithm, bool View, typename Subst>
+struct ReducerTraits<
+    reducer<T, BinaryOperation, Dims, Extent, Algorithm, View, Subst>> {
+  using type = T;
+  using op = BinaryOperation;
+  static constexpr int dims = Dims;
+  static constexpr size_t extent = Extent;
+};
+
+/// Use CRTP to avoid redefining shorthand operators in terms of combine
+///
+/// Also, for many types with known identity the operation 'atomic_combine()'
+/// is implemented here, which allows to use more efficient version of kernels
+/// using those operations, which are based on functionality provided by
+/// sycl::atomic class.
+///
+/// For example, it is known that 0 is identity for sycl::plus operations
+/// accepting native scalar types to which scalar 0 is convertible.
+/// Also, for int32/64 types the atomic_combine() is lowered to
+/// sycl::atomic::fetch_add().
+template <class Reducer> class combiner {
+  using T = typename ReducerTraits<Reducer>::type;
+  using BinaryOperation = typename ReducerTraits<Reducer>::op;
+  static constexpr int Dims = ReducerTraits<Reducer>::dims;
+  static constexpr size_t Extent = ReducerTraits<Reducer>::extent;
+
+public:
+  template <typename _T = T, int _Dims = Dims>
+  enable_if_t<(_Dims == 0) &&
+              sycl::detail::IsPlus<_T, BinaryOperation>::value &&
+              sycl::detail::is_geninteger<_T>::value>
+  operator++() {
+    static_cast<Reducer *>(this)->combine(static_cast<T>(1));
+  }
+
+  template <typename _T = T, int _Dims = Dims>
+  enable_if_t<(_Dims == 0) &&
+              sycl::detail::IsPlus<_T, BinaryOperation>::value &&
+              sycl::detail::is_geninteger<_T>::value>
+  operator++(int) {
+    static_cast<Reducer *>(this)->combine(static_cast<T>(1));
+  }
+
+  template <typename _T = T, int _Dims = Dims>
+  enable_if_t<(_Dims == 0) && sycl::detail::IsPlus<_T, BinaryOperation>::value>
+  operator+=(const _T &Partial) {
+    static_cast<Reducer *>(this)->combine(Partial);
+  }
+
+  template <typename _T = T, int _Dims = Dims>
+  enable_if_t<(_Dims == 0) &&
+              sycl::detail::IsMultiplies<_T, BinaryOperation>::value>
+  operator*=(const _T &Partial) {
+    static_cast<Reducer *>(this)->combine(Partial);
+  }
+
+  template <typename _T = T, int _Dims = Dims>
+  enable_if_t<(_Dims == 0) && sycl::detail::IsBitOR<_T, BinaryOperation>::value>
+  operator|=(const _T &Partial) {
+    static_cast<Reducer *>(this)->combine(Partial);
+  }
+
+  template <typename _T = T, int _Dims = Dims>
+  enable_if_t<(_Dims == 0) &&
+              sycl::detail::IsBitXOR<_T, BinaryOperation>::value>
+  operator^=(const _T &Partial) {
+    static_cast<Reducer *>(this)->combine(Partial);
+  }
+
+  template <typename _T = T, int _Dims = Dims>
+  enable_if_t<(_Dims == 0) &&
+              sycl::detail::IsBitAND<_T, BinaryOperation>::value>
+  operator&=(const _T &Partial) {
+    static_cast<Reducer *>(this)->combine(Partial);
+  }
+
+private:
+  template <access::address_space Space>
+  static constexpr memory_scope getMemoryScope() {
+    return Space == access::address_space::local_space
+               ? memory_scope::work_group
+               : memory_scope::device;
+  }
+
+public:
+  /// Atomic ADD operation: *ReduVarPtr += MValue;
+  template <access::address_space Space = access::address_space::global_space,
+            typename _T = T, class _BinaryOperation = BinaryOperation>
+  enable_if_t<std::is_same<typename remove_AS<_T>::type, T>::value &&
+              (IsReduOptForFastAtomicFetch<T, _BinaryOperation>::value ||
+               IsReduOptForAtomic64Add<T, _BinaryOperation>::value) &&
+              sycl::detail::IsPlus<T, _BinaryOperation>::value &&
+              (Space == access::address_space::global_space ||
+               Space == access::address_space::local_space)>
+  atomic_combine(_T *ReduVarPtr) const {
+    auto reducer = static_cast<const Reducer *>(this);
+    for (size_t E = 0; E < Extent; ++E) {
+      atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
+          *multi_ptr<T, Space>(ReduVarPtr))
+          .fetch_add(reducer->getElement(E));
+    }
+  }
+
+  /// Atomic BITWISE OR operation: *ReduVarPtr |= MValue;
+  template <access::address_space Space = access::address_space::global_space,
+            typename _T = T, class _BinaryOperation = BinaryOperation>
+  enable_if_t<std::is_same<typename remove_AS<_T>::type, T>::value &&
+              IsReduOptForFastAtomicFetch<T, _BinaryOperation>::value &&
+              sycl::detail::IsBitOR<T, _BinaryOperation>::value &&
+              (Space == access::address_space::global_space ||
+               Space == access::address_space::local_space)>
+  atomic_combine(_T *ReduVarPtr) const {
+    auto reducer = static_cast<const Reducer *>(this);
+    for (size_t E = 0; E < Extent; ++E) {
+      atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
+          *multi_ptr<T, Space>(ReduVarPtr))
+          .fetch_or(reducer->getElement(E));
+    }
+  }
+
+  /// Atomic BITWISE XOR operation: *ReduVarPtr ^= MValue;
+  template <access::address_space Space = access::address_space::global_space,
+            typename _T = T, class _BinaryOperation = BinaryOperation>
+  enable_if_t<std::is_same<typename remove_AS<_T>::type, T>::value &&
+              IsReduOptForFastAtomicFetch<T, _BinaryOperation>::value &&
+              sycl::detail::IsBitXOR<T, _BinaryOperation>::value &&
+              (Space == access::address_space::global_space ||
+               Space == access::address_space::local_space)>
+  atomic_combine(_T *ReduVarPtr) const {
+    auto reducer = static_cast<const Reducer *>(this);
+    for (size_t E = 0; E < Extent; ++E) {
+      atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
+          *multi_ptr<T, Space>(ReduVarPtr))
+          .fetch_xor(reducer->getElement(E));
+    }
+  }
+
+  /// Atomic BITWISE AND operation: *ReduVarPtr &= MValue;
+  template <access::address_space Space = access::address_space::global_space,
+            typename _T = T, class _BinaryOperation = BinaryOperation>
+  enable_if_t<std::is_same<typename remove_AS<_T>::type, T>::value &&
+              IsReduOptForFastAtomicFetch<T, _BinaryOperation>::value &&
+              sycl::detail::IsBitAND<T, _BinaryOperation>::value &&
+              (Space == access::address_space::global_space ||
+               Space == access::address_space::local_space)>
+  atomic_combine(_T *ReduVarPtr) const {
+    auto reducer = static_cast<const Reducer *>(this);
+    for (size_t E = 0; E < Extent; ++E) {
+      atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
+          *multi_ptr<T, Space>(ReduVarPtr))
+          .fetch_and(reducer->getElement(E));
+    }
+  }
+
+  /// Atomic MIN operation: *ReduVarPtr = sycl::minimum(*ReduVarPtr, MValue);
+  template <access::address_space Space = access::address_space::global_space,
+            typename _T = T, class _BinaryOperation = BinaryOperation>
+  enable_if_t<std::is_same<typename remove_AS<_T>::type, T>::value &&
+              IsReduOptForFastAtomicFetch<T, _BinaryOperation>::value &&
+              sycl::detail::IsMinimum<T, _BinaryOperation>::value &&
+              (Space == access::address_space::global_space ||
+               Space == access::address_space::local_space)>
+  atomic_combine(_T *ReduVarPtr) const {
+    auto reducer = static_cast<const Reducer *>(this);
+    for (size_t E = 0; E < Extent; ++E) {
+      atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
+          *multi_ptr<T, Space>(ReduVarPtr))
+          .fetch_min(reducer->getElement(E));
+    }
+  }
+
+  /// Atomic MAX operation: *ReduVarPtr = sycl::maximum(*ReduVarPtr, MValue);
+  template <access::address_space Space = access::address_space::global_space,
+            typename _T = T, class _BinaryOperation = BinaryOperation>
+  enable_if_t<std::is_same<typename remove_AS<_T>::type, T>::value &&
+              IsReduOptForFastAtomicFetch<T, _BinaryOperation>::value &&
+              sycl::detail::IsMaximum<T, _BinaryOperation>::value &&
+              (Space == access::address_space::global_space ||
+               Space == access::address_space::local_space)>
+  atomic_combine(_T *ReduVarPtr) const {
+    auto reducer = static_cast<const Reducer *>(this);
+    for (size_t E = 0; E < Extent; ++E) {
+      atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
+          *multi_ptr<T, Space>(ReduVarPtr))
+          .fetch_max(reducer->getElement(E));
+    }
+  }
+};
+
+template <typename T, class BinaryOperation, int Dims, size_t Extent,
+          class Algorithm, bool View>
+class reducer<T, BinaryOperation, Dims, Extent, Algorithm, View,
+              enable_if_t<Dims == 0 && Extent == 1 && View == false &&
+                          !IsKnownIdentityOp<T, BinaryOperation>::value>>
+    : public combiner<
+          reducer<T, BinaryOperation, Dims, Extent, Algorithm, View,
+                  enable_if_t<Dims == 0 && Extent == 1 && View == false &&
+                              !IsKnownIdentityOp<T, BinaryOperation>::value>>> {
 public:
   reducer(const T &Identity, BinaryOperation BOp)
       : MValue(Identity), MIdentity(Identity), MBinaryOp(BOp) {}
+
   void combine(const T &Partial) { MValue = MBinaryOp(MValue, Partial); }
 
   T getIdentity() const { return MIdentity; }
 
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsPlus<_T, BinaryOperation>::value &&
-              sycl::detail::is_geninteger<_T>::value>
-  operator++() {
-    combine(static_cast<T>(1));
-  }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsPlus<_T, BinaryOperation>::value &&
-              sycl::detail::is_geninteger<_T>::value>
-  operator++(int) {
-    combine(static_cast<T>(1));
-  }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsPlus<_T, BinaryOperation>::value>
-  operator+=(const _T &Partial) {
-    combine(Partial);
-  }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsMultiplies<_T, BinaryOperation>::value>
-  operator*=(const _T &Partial) {
-    combine(Partial);
-  }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsBitOR<_T, BinaryOperation>::value>
-  operator|=(const _T &Partial) {
-    combine(Partial);
-  }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsBitXOR<_T, BinaryOperation>::value>
-  operator^=(const _T &Partial) {
-    combine(Partial);
-  }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsBitAND<_T, BinaryOperation>::value>
-  operator&=(const _T &Partial) {
-    combine(Partial);
-  }
-
   T &getElement(size_t) { return MValue; }
+
   T MValue;
 
 private:
@@ -178,24 +346,19 @@ private:
 ///
 /// It allows to reduce the size of the 'reducer' object by not holding
 /// the identity field inside it and allows to add a default constructor.
-///
-/// Also, for many types with known identity the operation 'atomic_combine()'
-/// is implemented here, which allows to use more efficient version of kernels
-/// using those operations, which are based on functionality provided by
-/// sycl::atomic class.
-///
-/// For example, it is known that 0 is identity for sycl::plus operations
-/// accepting native scalar types to which scalar 0 is convertible.
-/// Also, for int32/64 types the atomic_combine() is lowered to
-/// sycl::atomic::fetch_add().
-//
 // TODO: More types and ops can be added to here later.
-template <typename T, class BinaryOperation>
-class reducer<T, BinaryOperation,
-              enable_if_t<IsKnownIdentityOp<T, BinaryOperation>::value>> {
+template <typename T, class BinaryOperation, int Dims, size_t Extent,
+          class Algorithm, bool View>
+class reducer<T, BinaryOperation, Dims, Extent, Algorithm, View,
+              enable_if_t<Dims == 0 && Extent == 1 && View == false &&
+                          IsKnownIdentityOp<T, BinaryOperation>::value>>
+    : public combiner<
+          reducer<T, BinaryOperation, Dims, Extent, Algorithm, View,
+                  enable_if_t<Dims == 0 && Extent == 1 && View == false &&
+                              IsKnownIdentityOp<T, BinaryOperation>::value>>> {
 public:
   reducer() : MValue(getIdentity()) {}
-  reducer(const T &, BinaryOperation) : MValue(getIdentity()) {}
+  reducer(const T & /* Identity */, BinaryOperation) : MValue(getIdentity()) {}
 
   void combine(const T &Partial) {
     BinaryOperation BOp;
@@ -208,228 +371,54 @@ public:
     return known_identity_impl<_BinaryOperation, _T>::value;
   }
 
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsPlus<_T, BinaryOperation>::value &&
-              sycl::detail::is_geninteger<_T>::value>
-  operator++() {
-    combine(static_cast<T>(1));
-  }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsPlus<_T, BinaryOperation>::value &&
-              sycl::detail::is_geninteger<_T>::value>
-  operator++(int) {
-    combine(static_cast<T>(1));
-  }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsPlus<_T, BinaryOperation>::value>
-  operator+=(const _T &Partial) {
-    combine(Partial);
-  }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsMultiplies<_T, BinaryOperation>::value>
-  operator*=(const _T &Partial) {
-    combine(Partial);
-  }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsBitOR<_T, BinaryOperation>::value>
-  operator|=(const _T &Partial) {
-    combine(Partial);
-  }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsBitXOR<_T, BinaryOperation>::value>
-  operator^=(const _T &Partial) {
-    combine(Partial);
-  }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsBitAND<_T, BinaryOperation>::value>
-  operator&=(const _T &Partial) {
-    combine(Partial);
-  }
-
-private:
-  template <access::address_space Space>
-  static constexpr memory_scope getMemoryScope() {
-    return Space == access::address_space::local_space
-               ? memory_scope::work_group
-               : memory_scope::device;
-  }
-
-public:
-  /// Atomic ADD operation: *ReduVarPtr += MValue;
-  template <access::address_space Space = access::address_space::global_space,
-            typename _T = T, class _BinaryOperation = BinaryOperation>
-  enable_if_t<std::is_same<typename remove_AS<_T>::type, T>::value &&
-              (IsReduOptForFastAtomicFetch<T, _BinaryOperation>::value ||
-               IsReduOptForAtomic64Add<T, _BinaryOperation>::value) &&
-              sycl::detail::IsPlus<T, _BinaryOperation>::value &&
-              (Space == access::address_space::global_space ||
-               Space == access::address_space::local_space)>
-  atomic_combine(_T *ReduVarPtr) const {
-    atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
-        *multi_ptr<T, Space>(ReduVarPtr))
-        .fetch_add(MValue);
-  }
-
-  /// Atomic BITWISE OR operation: *ReduVarPtr |= MValue;
-  template <access::address_space Space = access::address_space::global_space,
-            typename _T = T, class _BinaryOperation = BinaryOperation>
-  enable_if_t<std::is_same<typename remove_AS<_T>::type, T>::value &&
-              IsReduOptForFastAtomicFetch<T, _BinaryOperation>::value &&
-              sycl::detail::IsBitOR<T, _BinaryOperation>::value &&
-              (Space == access::address_space::global_space ||
-               Space == access::address_space::local_space)>
-  atomic_combine(_T *ReduVarPtr) const {
-    atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
-        *multi_ptr<T, Space>(ReduVarPtr))
-        .fetch_or(MValue);
-  }
-
-  /// Atomic BITWISE XOR operation: *ReduVarPtr ^= MValue;
-  template <access::address_space Space = access::address_space::global_space,
-            typename _T = T, class _BinaryOperation = BinaryOperation>
-  enable_if_t<std::is_same<typename remove_AS<_T>::type, T>::value &&
-              IsReduOptForFastAtomicFetch<T, _BinaryOperation>::value &&
-              sycl::detail::IsBitXOR<T, _BinaryOperation>::value &&
-              (Space == access::address_space::global_space ||
-               Space == access::address_space::local_space)>
-  atomic_combine(_T *ReduVarPtr) const {
-    atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
-        *multi_ptr<T, Space>(ReduVarPtr))
-        .fetch_xor(MValue);
-  }
-
-  /// Atomic BITWISE AND operation: *ReduVarPtr &= MValue;
-  template <access::address_space Space = access::address_space::global_space,
-            typename _T = T, class _BinaryOperation = BinaryOperation>
-  enable_if_t<std::is_same<typename remove_AS<_T>::type, T>::value &&
-              IsReduOptForFastAtomicFetch<T, _BinaryOperation>::value &&
-              sycl::detail::IsBitAND<T, _BinaryOperation>::value &&
-              (Space == access::address_space::global_space ||
-               Space == access::address_space::local_space)>
-  atomic_combine(_T *ReduVarPtr) const {
-    atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
-        *multi_ptr<T, Space>(ReduVarPtr))
-        .fetch_and(MValue);
-  }
-
-  /// Atomic MIN operation: *ReduVarPtr = sycl::minimum(*ReduVarPtr, MValue);
-  template <access::address_space Space = access::address_space::global_space,
-            typename _T = T, class _BinaryOperation = BinaryOperation>
-  enable_if_t<std::is_same<typename remove_AS<_T>::type, T>::value &&
-              IsReduOptForFastAtomicFetch<T, _BinaryOperation>::value &&
-              sycl::detail::IsMinimum<T, _BinaryOperation>::value &&
-              (Space == access::address_space::global_space ||
-               Space == access::address_space::local_space)>
-  atomic_combine(_T *ReduVarPtr) const {
-    atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
-        *multi_ptr<T, Space>(ReduVarPtr))
-        .fetch_min(MValue);
-  }
-
-  /// Atomic MAX operation: *ReduVarPtr = sycl::maximum(*ReduVarPtr, MValue);
-  template <access::address_space Space = access::address_space::global_space,
-            typename _T = T, class _BinaryOperation = BinaryOperation>
-  enable_if_t<std::is_same<typename remove_AS<_T>::type, T>::value &&
-              IsReduOptForFastAtomicFetch<T, _BinaryOperation>::value &&
-              sycl::detail::IsMaximum<T, _BinaryOperation>::value &&
-              (Space == access::address_space::global_space ||
-               Space == access::address_space::local_space)>
-  atomic_combine(_T *ReduVarPtr) const {
-    atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
-        *multi_ptr<T, Space>(ReduVarPtr))
-        .fetch_max(MValue);
-  }
-
   T &getElement(size_t E) { return MValue; }
+  const T &getElement(size_t E) const { return MValue; }
   T MValue;
 };
 
 /// Component of 'reducer' class for array reductions, representing a single
 /// element of the span (as returned by the subscript operator).
-// TODO: Support alternative algorithms for different values of Extent
-template <typename T, class BinaryOperation> class reducer_element {
+template <typename T, class BinaryOperation, int Dims, size_t Extent,
+          class Algorithm, bool View>
+class reducer<T, BinaryOperation, Dims, Extent, Algorithm, View,
+              enable_if_t<Dims == 0 && View == true>>
+    : public combiner<reducer<T, BinaryOperation, Dims, Extent, Algorithm, View,
+                              enable_if_t<Dims == 0 && View == true>>> {
 public:
-  // FIXME: This shouldn't be public :)
-  reducer_element(T *Ptr, BinaryOperation BOp)
-      : MElement(Ptr), MBinaryOp(BOp) {}
+  reducer(T &Ref, BinaryOperation BOp) : MElement(Ref), MBinaryOp(BOp) {}
 
-  void combine(const T &Partial) { *MElement = MBinaryOp(*MElement, Partial); }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsPlus<_T, BinaryOperation>::value &&
-              sycl::detail::is_geninteger<_T>::value>
-  operator++() {
-    combine(static_cast<T>(1));
-  }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsPlus<_T, BinaryOperation>::value &&
-              sycl::detail::is_geninteger<_T>::value>
-  operator++(int) {
-    combine(static_cast<T>(1));
-  }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsPlus<_T, BinaryOperation>::value>
-  operator+=(const _T &Partial) {
-    combine(Partial);
-  }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsMultiplies<_T, BinaryOperation>::value>
-  operator*=(const _T &Partial) {
-    combine(Partial);
-  }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsBitOR<_T, BinaryOperation>::value>
-  operator|=(const _T &Partial) {
-    combine(Partial);
-  }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsBitXOR<_T, BinaryOperation>::value>
-  operator^=(const _T &Partial) {
-    combine(Partial);
-  }
-
-  template <typename _T = T>
-  enable_if_t<sycl::detail::IsBitAND<_T, BinaryOperation>::value>
-  operator&=(const _T &Partial) {
-    combine(Partial);
-  }
+  void combine(const T &Partial) { MElement = MBinaryOp(MElement, Partial); }
 
 private:
-  T *MElement;
+  T &MElement;
   BinaryOperation MBinaryOp;
 };
 
-/// Specialization of 'reducer' class for array reductions accepting a span
-/// in cases where the identity value is not known.
-// TODO: Support alternative algorithms for different values of Extent
-#if __cplusplus >= 201703L
-template <typename T, size_t Extent, class BinaryOperation>
-class reducer<span<T, Extent>, BinaryOperation,
-              enable_if_t<!IsKnownIdentityOp<T, BinaryOperation>::value>> {
+/// Specialization of 'reducer' class for array reductions exposing the
+/// subscript operator.
+template <typename T, class BinaryOperation, int Dims, size_t Extent,
+          class Algorithm, bool View>
+class reducer<T, BinaryOperation, Dims, Extent, Algorithm, View,
+              enable_if_t<Dims == 1 && View == false &&
+                          !IsKnownIdentityOp<T, BinaryOperation>::value>>
+    : public combiner<
+          reducer<T, BinaryOperation, Dims, Extent, Algorithm, View,
+                  enable_if_t<Dims == 1 && View == false &&
+                              !IsKnownIdentityOp<T, BinaryOperation>::value>>> {
 public:
   reducer(const T &Identity, BinaryOperation BOp)
       : MValue(Identity), MIdentity(Identity), MBinaryOp(BOp) {}
 
   // SYCL 2020 revision 4 says this should be const, but this is a bug
   // see https://github.com/KhronosGroup/SYCL-Docs/pull/252
-  reducer_element<T, BinaryOperation> operator[](size_t index) {
-    T *ElementPtr = &MValue[index];
-    return {ElementPtr, MBinaryOp};
+  reducer<T, BinaryOperation, Dims - 1, Extent, Algorithm, true>
+  operator[](size_t Index) {
+    return {MValue[Index], MBinaryOp};
   }
 
   T getIdentity() const { return MIdentity; }
   T &getElement(size_t E) { return MValue[E]; }
+  const T &getElement(size_t E) const { return MValue[E]; }
 
 private:
   marray<T, Extent> MValue;
@@ -439,19 +428,24 @@ private:
 
 /// Specialization of 'reducer' class for array reductions accepting a span
 /// in cases where the identity value is known.
-// TODO: Support alternative algorithms for different values of Extent
-template <typename T, size_t Extent, class BinaryOperation>
-class reducer<span<T, Extent>, BinaryOperation,
-              enable_if_t<IsKnownIdentityOp<T, BinaryOperation>::value>> {
+template <typename T, class BinaryOperation, int Dims, size_t Extent,
+          class Algorithm, bool View>
+class reducer<T, BinaryOperation, Dims, Extent, Algorithm, View,
+              enable_if_t<Dims == 1 && View == false &&
+                          IsKnownIdentityOp<T, BinaryOperation>::value>>
+    : public combiner<
+          reducer<T, BinaryOperation, Dims, Extent, Algorithm, View,
+                  enable_if_t<Dims == 1 && View == false &&
+                              IsKnownIdentityOp<T, BinaryOperation>::value>>> {
 public:
   reducer() : MValue(getIdentity()) {}
-  reducer(const T &, BinaryOperation) : MValue(getIdentity()) {}
+  reducer(const T & /* Identity */, BinaryOperation) : MValue(getIdentity()) {}
 
   // SYCL 2020 revision 4 says this should be const, but this is a bug
   // see https://github.com/KhronosGroup/SYCL-Docs/pull/252
-  reducer_element<T, BinaryOperation> operator[](size_t index) /*const*/ {
-    T *ElementPtr = &MValue[index];
-    return {ElementPtr, BinaryOperation()};
+  reducer<T, BinaryOperation, Dims - 1, Extent, Algorithm, true>
+  operator[](size_t Index) {
+    return {MValue[Index], BinaryOperation()};
   }
 
   template <typename _T = T, class _BinaryOperation = BinaryOperation>
@@ -460,155 +454,92 @@ public:
     return known_identity_impl<_BinaryOperation, _T>::value;
   }
 
-private:
-  template <access::address_space Space>
-  static constexpr memory_scope getMemoryScope() {
-    return Space == access::address_space::local_space
-               ? memory_scope::work_group
-               : memory_scope::device;
-  }
-
-  // TODO: Skip atomic operations with the identity
-public:
-  /// Atomic ADD operation: *ReduVarPtr += MValue;
-  template <access::address_space Space = access::address_space::global_space,
-            typename _T = T, class _BinaryOperation = BinaryOperation>
-  enable_if_t<std::is_same<typename remove_AS<_T>::type, T>::value &&
-              (IsReduOptForFastAtomicFetch<T, _BinaryOperation>::value ||
-               IsReduOptForAtomic64Add<T, _BinaryOperation>::value) &&
-              sycl::detail::IsPlus<T, _BinaryOperation>::value &&
-              (Space == access::address_space::global_space ||
-               Space == access::address_space::local_space)>
-  atomic_combine(_T *ReduVarPtr) const {
-    for (size_t i = 0; i < Extent; ++i) {
-      atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
-          *multi_ptr<T, Space>(ReduVarPtr + i))
-          .fetch_add(MValue[i]);
-    }
-  }
-
-  /// Atomic BITWISE OR operation: *ReduVarPtr |= MValue;
-  template <access::address_space Space = access::address_space::global_space,
-            typename _T = T, class _BinaryOperation = BinaryOperation>
-  enable_if_t<std::is_same<typename remove_AS<_T>::type, T>::value &&
-              IsReduOptForFastAtomicFetch<T, _BinaryOperation>::value &&
-              sycl::detail::IsBitOR<T, _BinaryOperation>::value &&
-              (Space == access::address_space::global_space ||
-               Space == access::address_space::local_space)>
-  atomic_combine(_T *ReduVarPtr) const {
-    for (size_t i = 0; i < Extent; ++i) {
-      atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
-          *multi_ptr<T, Space>(ReduVarPtr + i))
-          .fetch_or(MValue[i]);
-    }
-  }
-
-  /// Atomic BITWISE XOR operation: *ReduVarPtr ^= MValue;
-  template <access::address_space Space = access::address_space::global_space,
-            typename _T = T, class _BinaryOperation = BinaryOperation>
-  enable_if_t<std::is_same<typename remove_AS<_T>::type, T>::value &&
-              IsReduOptForFastAtomicFetch<T, _BinaryOperation>::value &&
-              sycl::detail::IsBitXOR<T, _BinaryOperation>::value &&
-              (Space == access::address_space::global_space ||
-               Space == access::address_space::local_space)>
-  atomic_combine(_T *ReduVarPtr) const {
-    for (size_t i = 0; i < Extent; ++i) {
-      atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
-          *multi_ptr<T, Space>(ReduVarPtr + i))
-          .fetch_xor(MValue[i]);
-    }
-  }
-
-  /// Atomic BITWISE AND operation: *ReduVarPtr &= MValue;
-  template <access::address_space Space = access::address_space::global_space,
-            typename _T = T, class _BinaryOperation = BinaryOperation>
-  enable_if_t<std::is_same<typename remove_AS<_T>::type, T>::value &&
-              IsReduOptForFastAtomicFetch<T, _BinaryOperation>::value &&
-              sycl::detail::IsBitAND<T, _BinaryOperation>::value &&
-              (Space == access::address_space::global_space ||
-               Space == access::address_space::local_space)>
-  atomic_combine(_T *ReduVarPtr) const {
-    for (size_t i = 0; i < Extent; ++i) {
-      atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
-          *multi_ptr<T, Space>(ReduVarPtr + i))
-          .fetch_and(MValue[i]);
-    }
-  }
-
-  /// Atomic MIN operation: *ReduVarPtr = sycl::minimum(*ReduVarPtr, MValue);
-  template <access::address_space Space = access::address_space::global_space,
-            typename _T = T, class _BinaryOperation = BinaryOperation>
-  enable_if_t<std::is_same<typename remove_AS<_T>::type, T>::value &&
-              IsReduOptForFastAtomicFetch<T, _BinaryOperation>::value &&
-              sycl::detail::IsMinimum<T, _BinaryOperation>::value &&
-              (Space == access::address_space::global_space ||
-               Space == access::address_space::local_space)>
-  atomic_combine(_T *ReduVarPtr) const {
-    for (size_t i = 0; i < Extent; ++i) {
-      atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
-          *multi_ptr<T, Space>(ReduVarPtr + i))
-          .fetch_min(MValue[i]);
-    }
-  }
-
-  /// Atomic MAX operation: *ReduVarPtr = sycl::maximum(*ReduVarPtr, MValue);
-  template <access::address_space Space = access::address_space::global_space,
-            typename _T = T, class _BinaryOperation = BinaryOperation>
-  enable_if_t<std::is_same<typename remove_AS<_T>::type, T>::value &&
-              IsReduOptForFastAtomicFetch<T, _BinaryOperation>::value &&
-              sycl::detail::IsMaximum<T, _BinaryOperation>::value &&
-              (Space == access::address_space::global_space ||
-               Space == access::address_space::local_space)>
-  atomic_combine(_T *ReduVarPtr) const {
-    for (size_t i = 0; i < Extent; ++i) {
-      atomic_ref<T, memory_order::relaxed, getMemoryScope<Space>(), Space>(
-          *multi_ptr<T, Space>(ReduVarPtr + i))
-          .fetch_max(MValue[i]);
-    }
-  }
-
   T &getElement(size_t E) { return MValue[E]; }
+  const T &getElement(size_t E) const { return MValue[E]; }
 
 private:
   marray<T, Extent> MValue;
 };
-#endif
 
 /// Base non-template class which is a base class for all reduction
 /// implementation classes. It is needed to detect the reduction classes.
 class reduction_impl_base {};
 
-/// Predicate returning true if all template type parameters except the last one
-/// are reductions.
-template <typename FirstT, typename... RestT> struct AreAllButLastReductions {
-  static constexpr bool value =
-      std::is_base_of<reduction_impl_base, FirstT>::value &&
-      AreAllButLastReductions<RestT...>::value;
-};
+/// Templated class for common functionality of all reduction implementation
+/// classes.
+template <typename T, class BinaryOperation> class reduction_impl_common {
+protected:
+  reduction_impl_common(const T &Identity, BinaryOperation BinaryOp,
+                        bool Init = false)
+      : MIdentity(Identity), MBinaryOp(BinaryOp), InitializeToIdentity(Init) {}
 
-/// Helper specialization of AreAllButLastReductions for one element only.
-/// Returns true if the template parameter is not a reduction.
-template <typename T> struct AreAllButLastReductions<T> {
-  static constexpr bool value = !std::is_base_of<reduction_impl_base, T>::value;
-};
-
-/// This class encapsulates the reduction variable/accessor,
-/// the reduction operator and an optional operator identity.
-template <typename T, class BinaryOperation, int Dims, bool IsUSM,
-          access::placeholder IsPlaceholder = access::placeholder::false_t>
-class reduction_impl : private reduction_impl_base {
 public:
-  using reducer_type = reducer<T, BinaryOperation>;
+  /// Returns the statically known identity value.
+  template <typename _T = T, class _BinaryOperation = BinaryOperation>
+  enable_if_t<IsKnownIdentityOp<_T, _BinaryOperation>::value,
+              _T> constexpr getIdentity() {
+    return known_identity_impl<_BinaryOperation, _T>::value;
+  }
+
+  /// Returns the identity value given by user.
+  template <typename _T = T, class _BinaryOperation = BinaryOperation>
+  enable_if_t<!IsKnownIdentityOp<_T, _BinaryOperation>::value, _T>
+  getIdentity() {
+    return MIdentity;
+  }
+
+  /// Returns the binary operation associated with the reduction.
+  BinaryOperation getBinaryOperation() const { return MBinaryOp; }
+  bool initializeToIdentity() const { return InitializeToIdentity; }
+
+protected:
+  /// Identity of the BinaryOperation.
+  /// The result of BinaryOperation(X, MIdentity) is equal to X for any X.
+  const T MIdentity;
+
+  BinaryOperation MBinaryOp;
+  bool InitializeToIdentity;
+};
+
+/// Types representing specific reduction algorithms
+/// Enables reduction_impl_algo to take additional algorithm-specific templates
+template <bool IsUSM, access::placeholder IsPlaceholder, int AccessorDims>
+class default_reduction_algorithm {};
+
+/// Templated class for implementations of specific reduction algorithms
+template <typename T, class BinaryOperation, int Dims, size_t Extent,
+          class Algorithm>
+class reduction_impl_algo;
+
+/// Original reduction algorithm is the default. It supports both USM and
+/// accessors via a single class
+template <typename T, class BinaryOperation, int Dims, size_t Extent,
+          bool IsUSM, access::placeholder IsPlaceholder, int AccessorDims>
+class reduction_impl_algo<
+    T, BinaryOperation, Dims, Extent,
+    default_reduction_algorithm<IsUSM, IsPlaceholder, AccessorDims>>
+    : public reduction_impl_common<T, BinaryOperation> {
+  using base = reduction_impl_common<T, BinaryOperation>;
+
+public:
+  using reducer_type =
+      reducer<T, BinaryOperation, Dims, Extent,
+              default_reduction_algorithm<IsUSM, IsPlaceholder, AccessorDims>>;
   using result_type = T;
   using binary_operation = BinaryOperation;
-  using rw_accessor_type =
-      accessor<T, Dims, access::mode::read_write, access::target::device,
-               IsPlaceholder, ext::oneapi::accessor_property_list<>>;
+
+  // Buffers and accessors always describe scalar reductions (i.e. Dims == 0)
+  // The input buffer/accessor is allowed to have different dimensionality
+  // AccessorDims also determines the dimensionality of some temp storage
+  static constexpr int accessor_dim = AccessorDims;
+  static constexpr int buffer_dim = (AccessorDims == 0) ? 1 : AccessorDims;
+  using rw_accessor_type = accessor<T, AccessorDims, access::mode::read_write,
+                                    access::target::device, IsPlaceholder,
+                                    ext::oneapi::accessor_property_list<>>;
   using dw_accessor_type =
-      accessor<T, Dims, access::mode::discard_write, access::target::device,
-               IsPlaceholder, ext::oneapi::accessor_property_list<>>;
-  static constexpr int accessor_dim = Dims;
-  static constexpr int buffer_dim = (Dims == 0) ? 1 : Dims;
+      accessor<T, AccessorDims, access::mode::discard_write,
+               access::target::device, IsPlaceholder,
+               ext::oneapi::accessor_property_list<>>;
 
   static constexpr bool has_atomic_add_float64 =
       IsReduOptForAtomic64Add<T, BinaryOperation>::value;
@@ -619,241 +550,17 @@ public:
   static constexpr bool is_usm = IsUSM;
   static constexpr bool is_placeholder =
       (IsPlaceholder == access::placeholder::true_t);
+  static constexpr size_t num_elements = Extent;
 
-  static constexpr size_t num_elements = 1;
-
-  // Only scalar (i.e. 0-dim and 1-dim with 1 element) reductions supported now.
-  // TODO: suport (Dims > 1) accessors/reductions.
-  // TODO: support true 1-Dimensional accessors/reductions (size() > 1).
-  // (size() == 1) is checked in the constructor of reduction_impl.
-  static_assert(Dims <= 1,
-                "Multi-dimensional reductions are not supported yet.");
-
-  /// Returns the statically known identity value.
-  template <typename _T = T, class _BinaryOperation = BinaryOperation>
-  enable_if_t<IsKnownIdentityOp<_T, _BinaryOperation>::value,
-              _T> constexpr getIdentity() {
-    return reducer_type::getIdentity();
-  }
-
-  /// Returns the identity value given by user.
-  template <typename _T = T, class _BinaryOperation = BinaryOperation>
-  enable_if_t<!IsKnownIdentityOp<_T, _BinaryOperation>::value, _T>
-  getIdentity() {
-    return MIdentity;
-  }
-
-  /// SYCL-2020.
-  /// Constructs reduction_impl when the identity value is statically known.
-  template <typename _T, typename AllocatorT,
-            std::enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * =
-                nullptr>
-  reduction_impl(buffer<_T, 1, AllocatorT> Buffer, handler &CGH,
-                 bool InitializeToIdentity)
-      : MRWAcc(std::make_shared<rw_accessor_type>(Buffer)),
-        MIdentity(getIdentity()), InitializeToIdentity(InitializeToIdentity) {
-    associateWithHandler(CGH);
-    if (Buffer.size() != 1)
-      throw sycl::runtime_error(errc::invalid,
-                                "Reduction variable must be a scalar.",
-                                PI_INVALID_VALUE);
-  }
-
-  /// Constructs reduction_impl when the identity value is statically known.
-  template <
-      typename _T = T,
-      enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
-  reduction_impl(rw_accessor_type &Acc)
-      : MRWAcc(new rw_accessor_type(Acc)), MIdentity(getIdentity()),
-        InitializeToIdentity(false) {
-    if (Acc.size() != 1)
-      throw sycl::runtime_error(errc::invalid,
-                                "Reduction variable must be a scalar.",
-                                PI_INVALID_VALUE);
-  }
-
-  /// Constructs reduction_impl when the identity value is statically known.
-  template <
-      typename _T = T,
-      enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
-  reduction_impl(dw_accessor_type &Acc)
-      : MDWAcc(new dw_accessor_type(Acc)), MIdentity(getIdentity()),
-        InitializeToIdentity(true) {
-    if (Acc.size() != 1)
-      throw sycl::runtime_error(errc::invalid,
-                                "Reduction variable must be a scalar.",
-                                PI_INVALID_VALUE);
-  }
-
-  /// SYCL-2020.
-  /// Constructs reduction_impl when the identity value is statically known,
-  /// and user still passed the identity value.
-  template <
-      typename _T, typename AllocatorT,
-      enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
-  reduction_impl(buffer<_T, 1, AllocatorT> Buffer, handler &CGH,
-                 const T & /*Identity*/, BinaryOperation,
-                 bool InitializeToIdentity)
-      : MRWAcc(std::make_shared<rw_accessor_type>(Buffer)),
-        MIdentity(getIdentity()), InitializeToIdentity(InitializeToIdentity) {
-    associateWithHandler(CGH);
-    if (Buffer.size() != 1)
-      throw sycl::runtime_error(errc::invalid,
-                                "Reduction variable must be a scalar.",
-                                PI_INVALID_VALUE);
-    // For now the implementation ignores the identity value given by user
-    // when the implementation knows the identity.
-    // The SPEC could prohibit passing identity parameter to operations with
-    // known identity, but that could have some bad consequences too.
-    // For example, at some moment the implementation may NOT know the identity
-    // for COMPLEX-PLUS reduction. User may create a program that would pass
-    // COMPLEX value (0,0) as identity for PLUS reduction. At some later moment
-    // when the implementation starts handling COMPLEX-PLUS as known operation
-    // the existing user's program remains compilable and working correctly.
-    // I.e. with this constructor here, adding more reduction operations to the
-    // list of known operations does not break the existing programs.
-  }
-
-  /// Constructs reduction_impl when the identity value is statically known,
-  /// and user still passed the identity value.
-  template <
-      typename _T = T,
-      enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
-  reduction_impl(rw_accessor_type &Acc, const T & /*Identity*/, BinaryOperation)
-      : MRWAcc(new rw_accessor_type(Acc)), MIdentity(getIdentity()),
-        InitializeToIdentity(false) {
-    if (Acc.size() != 1)
-      throw sycl::runtime_error(errc::invalid,
-                                "Reduction variable must be a scalar.",
-                                PI_INVALID_VALUE);
-    // For now the implementation ignores the identity value given by user
-    // when the implementation knows the identity.
-    // The SPEC could prohibit passing identity parameter to operations with
-    // known identity, but that could have some bad consequences too.
-    // For example, at some moment the implementation may NOT know the identity
-    // for COMPLEX-PLUS reduction. User may create a program that would pass
-    // COMPLEX value (0,0) as identity for PLUS reduction. At some later moment
-    // when the implementation starts handling COMPLEX-PLUS as known operation
-    // the existing user's program remains compilable and working correctly.
-    // I.e. with this constructor here, adding more reduction operations to the
-    // list of known operations does not break the existing programs.
-  }
-
-  /// Constructs reduction_impl when the identity value is statically known,
-  /// and user still passed the identity value.
-  template <
-      typename _T = T,
-      enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
-  reduction_impl(dw_accessor_type &Acc, const T & /*Identity*/, BinaryOperation)
-      : MDWAcc(new dw_accessor_type(Acc)), MIdentity(getIdentity()),
-        InitializeToIdentity(true) {
-    if (Acc.size() != 1)
-      throw sycl::runtime_error(errc::invalid,
-                                "Reduction variable must be a scalar.",
-                                PI_INVALID_VALUE);
-    // For now the implementation ignores the identity value given by user
-    // when the implementation knows the identity.
-    // The SPEC could prohibit passing identity parameter to operations with
-    // known identity, but that could have some bad consequences too.
-    // For example, at some moment the implementation may NOT know the identity
-    // for COMPLEX-PLUS reduction. User may create a program that would pass
-    // COMPLEX value (0,0) as identity for PLUS reduction. At some later moment
-    // when the implementation starts handling COMPLEX-PLUS as known operation
-    // the existing user's program remains compilable and working correctly.
-    // I.e. with this constructor here, adding more reduction operations to the
-    // list of known operations does not break the existing programs.
-  }
-
-  /// SYCL-2020.
-  /// Constructs reduction_impl when the identity value is NOT known statically.
-  template <
-      typename _T, typename AllocatorT,
-      enable_if_t<!IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
-  reduction_impl(buffer<_T, 1, AllocatorT> Buffer, handler &CGH,
-                 const T &Identity, BinaryOperation BOp,
-                 bool InitializeToIdentity)
-      : MRWAcc(std::make_shared<rw_accessor_type>(Buffer)), MIdentity(Identity),
-        MBinaryOp(BOp), InitializeToIdentity(InitializeToIdentity) {
-    associateWithHandler(CGH);
-    if (Buffer.size() != 1)
-      throw sycl::runtime_error(errc::invalid,
-                                "Reduction variable must be a scalar.",
-                                PI_INVALID_VALUE);
-  }
-
-  /// Constructs reduction_impl when the identity value is unknown.
-  template <
-      typename _T = T,
-      enable_if_t<!IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
-  reduction_impl(rw_accessor_type &Acc, const T &Identity, BinaryOperation BOp)
-      : MRWAcc(new rw_accessor_type(Acc)), MIdentity(Identity), MBinaryOp(BOp),
-        InitializeToIdentity(false) {
-    if (Acc.size() != 1)
-      throw sycl::runtime_error(errc::invalid,
-                                "Reduction variable must be a scalar.",
-                                PI_INVALID_VALUE);
-  }
-
-  /// Constructs reduction_impl when the identity value is unknown.
-  template <
-      typename _T = T,
-      enable_if_t<!IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
-  reduction_impl(dw_accessor_type &Acc, const T &Identity, BinaryOperation BOp)
-      : MDWAcc(new dw_accessor_type(Acc)), MIdentity(Identity), MBinaryOp(BOp),
-        InitializeToIdentity(true) {
-    if (Acc.size() != 1)
-      throw sycl::runtime_error(errc::invalid,
-                                "Reduction variable must be a scalar.",
-                                PI_INVALID_VALUE);
-  }
-
-  /// Constructs reduction_impl when the identity value is statically known.
-  /// The \param VarPtr is a USM pointer to memory, to where the computed
-  /// reduction value is added using BinaryOperation, i.e. it is expected that
-  /// the memory is pre-initialized with some meaningful value.
-  template <
-      typename _T = T,
-      enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
-  reduction_impl(T *VarPtr, bool InitializeToIdentity = false)
-      : MIdentity(getIdentity()), MUSMPointer(VarPtr),
-        InitializeToIdentity(InitializeToIdentity) {}
-
-  /// Constructs reduction_impl when the identity value is statically known,
-  /// and user still passed the identity value.
-  /// The \param VarPtr is a USM pointer to memory, to where the computed
-  /// reduction value is added using BinaryOperation, i.e. it is expected that
-  /// the memory is pre-initialized with some meaningful value.
-  template <
-      typename _T = T,
-      enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
-  reduction_impl(T *VarPtr, const T &Identity, BinaryOperation,
-                 bool InitializeToIdentity = false)
-      : MIdentity(Identity), MUSMPointer(VarPtr),
-        InitializeToIdentity(InitializeToIdentity) {
-    // For now the implementation ignores the identity value given by user
-    // when the implementation knows the identity.
-    // The SPEC could prohibit passing identity parameter to operations with
-    // known identity, but that could have some bad consequences too.
-    // For example, at some moment the implementation may NOT know the identity
-    // for COMPLEX-PLUS reduction. User may create a program that would pass
-    // COMPLEX value (0,0) as identity for PLUS reduction. At some later moment
-    // when the implementation starts handling COMPLEX-PLUS as known operation
-    // the existing user's program remains compilable and working correctly.
-    // I.e. with this constructor here, adding more reduction operations to the
-    // list of known operations does not break the existing programs.
-  }
-
-  /// Constructs reduction_impl when the identity value is unknown.
-  /// The \param VarPtr is a USM pointer to memory, to where the computed
-  /// reduction value is added using BinaryOperation, i.e. it is expected that
-  /// the memory is pre-initialized with some meaningful value.
-  template <
-      typename _T = T,
-      enable_if_t<!IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
-  reduction_impl(T *VarPtr, const T &Identity, BinaryOperation BOp,
-                 bool InitializeToIdentity = false)
-      : MIdentity(Identity), MUSMPointer(VarPtr), MBinaryOp(BOp),
-        InitializeToIdentity(InitializeToIdentity) {}
+  reduction_impl_algo(const T &Identity, BinaryOperation BinaryOp, bool Init,
+                      std::shared_ptr<rw_accessor_type> AccPointer)
+      : base(Identity, BinaryOp, Init), MRWAcc(AccPointer){};
+  reduction_impl_algo(const T &Identity, BinaryOperation BinaryOp, bool Init,
+                      std::shared_ptr<dw_accessor_type> AccPointer)
+      : base(Identity, BinaryOp, Init), MDWAcc(AccPointer){};
+  reduction_impl_algo(const T &Identity, BinaryOperation BinaryOp, bool Init,
+                      T *USMPointer)
+      : base(Identity, BinaryOp, Init), MUSMPointer(USMPointer){};
 
   /// Associates the reduction accessor to user's memory with \p CGH handler
   /// to keep the accessor alive until the command group finishes the work.
@@ -936,263 +643,17 @@ public:
   /// require initialization with identity value, then return user's read-write
   /// accessor. Otherwise, create 1-element global buffer initialized with
   /// identity value and return an accessor to that buffer.
-
   template <bool HasFastAtomics = (has_fast_atomics || has_atomic_add_float64)>
   std::enable_if_t<HasFastAtomics, rw_accessor_type>
   getReadWriteAccessorToInitializedMem(handler &CGH) {
-    if (!is_usm && !initializeToIdentity())
-      return *MRWAcc;
-
-    auto RWReduVal = std::make_shared<T>(MIdentity);
-    CGH.addReduction(RWReduVal);
-    MOutBufPtr = std::make_shared<buffer<T, 1>>(RWReduVal.get(), range<1>(1));
-    MOutBufPtr->set_final_data();
-    CGH.addReduction(MOutBufPtr);
-    return createHandlerWiredReadWriteAccessor(CGH, *MOutBufPtr);
-  }
-
-  accessor<int, 1, access::mode::read_write, access::target::device,
-           access::placeholder::false_t>
-  getReadWriteAccessorToInitializedGroupsCounter(handler &CGH) {
-    auto CounterMem = std::make_shared<int>(0);
-    CGH.addReduction(CounterMem);
-    auto CounterBuf = std::make_shared<buffer<int, 1>>(CounterMem.get(), 1);
-    CounterBuf->set_final_data();
-    CGH.addReduction(CounterBuf);
-    return {*CounterBuf, CGH};
-  }
-
-  bool hasUserDiscardWriteAccessor() { return MDWAcc != nullptr; }
-
-  template <bool _IsUSM = IsUSM>
-  std::enable_if_t<!_IsUSM, rw_accessor_type &> getUserReadWriteAccessor() {
-    return *MRWAcc;
-  }
-
-  template <bool _IsUSM = IsUSM>
-  std::enable_if_t<!_IsUSM, dw_accessor_type &> getUserDiscardWriteAccessor() {
-    return *MDWAcc;
-  }
-
-  result_type *getUSMPointer() {
-    assert(is_usm && "Unexpected call of getUSMPointer().");
-    return MUSMPointer;
-  }
-
-  static inline result_type *getOutPointer(const rw_accessor_type &OutAcc) {
-    return OutAcc.get_pointer().get();
-  }
-
-  static inline result_type *getOutPointer(result_type *OutPtr) {
-    return OutPtr;
-  }
-
-  /// Returns the binary operation associated with the reduction.
-  BinaryOperation getBinaryOperation() const { return MBinaryOp; }
-  bool initializeToIdentity() const { return InitializeToIdentity; }
-
-private:
-  template <typename BufferT, access::placeholder IsPH = IsPlaceholder>
-  std::enable_if_t<IsPH == access::placeholder::false_t, rw_accessor_type>
-  createHandlerWiredReadWriteAccessor(handler &CGH, BufferT Buffer) {
-    return {Buffer, CGH};
-  }
-
-  template <typename BufferT, access::placeholder IsPH = IsPlaceholder>
-  std::enable_if_t<IsPH == access::placeholder::true_t, rw_accessor_type>
-  createHandlerWiredReadWriteAccessor(handler &CGH, BufferT Buffer) {
-    rw_accessor_type Acc(Buffer);
-    CGH.require(Acc);
-    return Acc;
-  }
-
-  /// Identity of the BinaryOperation.
-  /// The result of BinaryOperation(X, MIdentity) is equal to X for any X.
-  const T MIdentity;
-
-  /// User's accessor to where the reduction must be written.
-  std::shared_ptr<rw_accessor_type> MRWAcc;
-  std::shared_ptr<dw_accessor_type> MDWAcc;
-
-  std::shared_ptr<buffer<T, buffer_dim>> MOutBufPtr;
-
-  /// USM pointer referencing the memory to where the result of the reduction
-  /// must be written. Applicable/used only for USM reductions.
-  T *MUSMPointer = nullptr;
-
-  BinaryOperation MBinaryOp;
-
-  bool InitializeToIdentity;
-};
-
-/// Specialization of reduction_impl for spans
-// TODO: Consider hoisting some functionality into reduction_impl_base
-// TODO: Refactor to remove IsUSM and IsPlaceholder arguments?
-#if __cplusplus >= 201703L
-template <typename T, size_t Extent, class BinaryOperation, int Dims,
-          bool IsUSM, access::placeholder IsPlaceholder>
-class reduction_impl<span<T, Extent>, BinaryOperation, Dims, IsUSM,
-                     IsPlaceholder> : private reduction_impl_base {
-public:
-  using reducer_type = reducer<span<T, Extent>, BinaryOperation>;
-  using result_type = T;
-  using binary_operation = BinaryOperation;
-
-  using rw_accessor_type =
-      accessor<T, Dims, access::mode::read_write, access::target::device,
-               IsPlaceholder, ext::oneapi::accessor_property_list<>>;
-  using dw_accessor_type =
-      accessor<T, Dims, access::mode::discard_write, access::target::device,
-               IsPlaceholder, ext::oneapi::accessor_property_list<>>;
-  static constexpr int accessor_dim = Dims;
-  static constexpr int buffer_dim = (Dims == 0) ? 1 : Dims;
-
-  static constexpr bool has_atomic_add_float64 =
-      IsReduOptForAtomic64Add<T, BinaryOperation>::value;
-  static constexpr bool has_fast_atomics =
-      IsReduOptForFastAtomicFetch<T, BinaryOperation>::value;
-  static constexpr bool has_fast_reduce =
-      IsReduOptForFastReduce<T, BinaryOperation>::value;
-  static constexpr bool is_usm = IsUSM;
-  static constexpr bool is_placeholder =
-      (IsPlaceholder == access::placeholder::true_t);
-
-  static constexpr size_t num_elements = Extent;
-
-  /// Constructs reduction_impl when the identity value is statically known
-  template <
-      typename _T = T,
-      enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
-  reduction_impl(span<_T, Extent> Span, bool InitializeToIdentity = false)
-      : MIdentity(getIdentity()), MUSMPointer(Span.data()),
-        InitializeToIdentity(InitializeToIdentity) {}
-
-  /// Constructs reduction_impl when the identity value is statically known
-  /// and user passed an identity value anyway
-  template <
-      typename _T = T,
-      enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
-  reduction_impl(span<_T, Extent> Span, const T & /* Identity */,
-                 BinaryOperation BOp, bool InitializeToIdentity = false)
-      : MIdentity(getIdentity()), MBinaryOp(BOp), MUSMPointer(Span.data()),
-        InitializeToIdentity(InitializeToIdentity) {}
-
-  /// Constructs reduction_impl when the identity value is not statically known
-  template <
-      typename _T = T,
-      enable_if_t<!IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
-  reduction_impl(span<T, Extent> Span, const T &Identity, BinaryOperation BOp,
-                 bool InitializeToIdentity = false)
-      : MIdentity(Identity), MBinaryOp(BOp), MUSMPointer(Span.data()),
-        InitializeToIdentity(InitializeToIdentity) {}
-
-  /// Returns the statically known identity value.
-  template <typename _T = T, class _BinaryOperation = BinaryOperation>
-  enable_if_t<IsKnownIdentityOp<_T, _BinaryOperation>::value,
-              _T> constexpr getIdentity() {
-    return reducer_type::getIdentity();
-  }
-
-  /// Returns the identity value given by user.
-  template <typename _T = T, class _BinaryOperation = BinaryOperation>
-  enable_if_t<!IsKnownIdentityOp<_T, _BinaryOperation>::value, _T>
-  getIdentity() {
-    return MIdentity;
-  }
-
-  /// Associates the reduction accessor to user's memory with \p CGH handler
-  /// to keep the accessor alive until the command group finishes the work.
-  /// This function does not do anything for USM reductions.
-  void associateWithHandler(handler &CGH) {
-#ifndef __SYCL_DEVICE_ONLY__
-    if (MRWAcc)
-      CGH.associateWithHandler(MRWAcc.get(), access::target::device);
-    else if (MDWAcc)
-      CGH.associateWithHandler(MDWAcc.get(), access::target::device);
-#else
-    (void)CGH;
-#endif
-  }
-
-  /// Creates and returns a local accessor with the \p Size elements.
-  /// By default the local accessor elements are of the same type as the
-  /// elements processed by the reduction, but may it be altered by specifying
-  /// \p _T explicitly if need an accessor with elements of different type.
-  template <typename _T = result_type>
-  static accessor<_T, buffer_dim, access::mode::read_write,
-                  access::target::local>
-  getReadWriteLocalAcc(size_t Size, handler &CGH) {
-    return {Size, CGH};
-  }
-
-  accessor<T, buffer_dim, access::mode::read>
-  getReadAccToPreviousPartialReds(handler &CGH) const {
-    CGH.addReduction(MOutBufPtr);
-    return {*MOutBufPtr, CGH};
-  }
-
-  /// Returns user's USM pointer passed to reduction for editing.
-  template <bool IsOneWG, bool _IsUSM = is_usm>
-  std::enable_if_t<IsOneWG && _IsUSM, result_type *>
-  getWriteMemForPartialReds(size_t, handler &) {
-    return getUSMPointer();
-  }
-
-  /// Returns user's accessor passed to reduction for editing if that is
-  /// the read-write accessor. Otherwise, create a new buffer and return
-  /// read-write accessor to it.
-  template <bool IsOneWG, bool _IsUSM = is_usm>
-  std::enable_if_t<IsOneWG && !_IsUSM, rw_accessor_type>
-  getWriteMemForPartialReds(size_t, handler &CGH) {
-    if (MRWAcc)
-      return *MRWAcc;
-    return getWriteMemForPartialReds<false>(1, CGH);
-  }
-
-  /// Constructs a new temporary buffer to hold partial sums and returns
-  /// the accessor for that buffer.
-  template <bool IsOneWG>
-  std::enable_if_t<!IsOneWG, rw_accessor_type>
-  getWriteMemForPartialReds(size_t Size, handler &CGH) {
-    MOutBufPtr = std::make_shared<buffer<T, buffer_dim>>(range<1>(Size));
-    CGH.addReduction(MOutBufPtr);
-    return createHandlerWiredReadWriteAccessor(CGH, *MOutBufPtr);
-  }
-
-  /// Returns an accessor accessing the memory that will hold the reduction
-  /// partial sums.
-  /// If \p Size is equal to one, then the reduction result is the final and
-  /// needs to be written to user's read-write accessor (if there is such).
-  /// Otherwise, a new buffer is created and accessor to that buffer is
-  /// returned.
-  rw_accessor_type getWriteAccForPartialReds(size_t Size, handler &CGH) {
-    if (Size == 1 && MRWAcc != nullptr) {
-      associateWithHandler(CGH);
-      return *MRWAcc;
-    }
-
-    // Create a new output buffer and return an accessor to it.
-    MOutBufPtr = std::make_shared<buffer<T, buffer_dim>>(range<1>(Size));
-    CGH.addReduction(MOutBufPtr);
-    return createHandlerWiredReadWriteAccessor(CGH, *MOutBufPtr);
-  }
-
-  /// If reduction is initialized with read-write accessor, which does not
-  /// require initialization with identity value, then return user's read-write
-  /// accessor. Otherwise, create global buffer initialized with identity value
-  /// for each result and return an accessor to that buffer.
-
-  template <bool HasFastAtomics = (has_fast_atomics || has_atomic_add_float64)>
-  std::enable_if_t<HasFastAtomics, rw_accessor_type>
-  getReadWriteAccessorToInitializedMem(handler &CGH) {
-    if (!is_usm && !initializeToIdentity())
+    if (!is_usm && !base::initializeToIdentity())
       return *MRWAcc;
 
     // TODO: Move to T[] in C++20 to simplify handling here
     // auto RWReduVal = std::make_shared<T[num_elements]>();
     auto RWReduVal = std::make_shared<std::array<T, num_elements>>();
     for (int i = 0; i < num_elements; ++i) {
-      (*RWReduVal)[i] = 0;
+      (*RWReduVal)[i] = base::getIdentity();
     }
     CGH.addReduction(RWReduVal);
     MOutBufPtr = std::make_shared<buffer<T, 1>>(RWReduVal.get()->data(),
@@ -1238,12 +699,7 @@ public:
     return OutPtr;
   }
 
-  /// Returns the binary operation associated with the reduction.
-  BinaryOperation getBinaryOperation() const { return MBinaryOp; }
-  bool initializeToIdentity() const { return InitializeToIdentity; }
-
 private:
-  // TODO: Determine if these are necessary for spans
   template <typename BufferT, access::placeholder IsPH = IsPlaceholder>
   std::enable_if_t<IsPH == access::placeholder::false_t, rw_accessor_type>
   createHandlerWiredReadWriteAccessor(handler &CGH, BufferT Buffer) {
@@ -1258,10 +714,6 @@ private:
     return Acc;
   }
 
-  /// Identity of the BinaryOperation.
-  /// The result of BinaryOperation(X, MIdentity) is equal to X for any X.
-  const T MIdentity;
-
   /// User's accessor to where the reduction must be written.
   std::shared_ptr<rw_accessor_type> MRWAcc;
   std::shared_ptr<dw_accessor_type> MDWAcc;
@@ -1271,12 +723,278 @@ private:
   /// USM pointer referencing the memory to where the result of the reduction
   /// must be written. Applicable/used only for USM reductions.
   T *MUSMPointer = nullptr;
-
-  BinaryOperation MBinaryOp;
-
-  bool InitializeToIdentity;
 };
+
+/// Predicate returning true if all template type parameters except the last one
+/// are reductions.
+template <typename FirstT, typename... RestT> struct AreAllButLastReductions {
+  static constexpr bool value =
+      std::is_base_of<reduction_impl_base, FirstT>::value &&
+      AreAllButLastReductions<RestT...>::value;
+};
+
+/// Helper specialization of AreAllButLastReductions for one element only.
+/// Returns true if the template parameter is not a reduction.
+template <typename T> struct AreAllButLastReductions<T> {
+  static constexpr bool value = !std::is_base_of<reduction_impl_base, T>::value;
+};
+
+/// This class encapsulates the reduction variable/accessor,
+/// the reduction operator and an optional operator identity.
+template <typename T, class BinaryOperation, int Dims, size_t Extent,
+          class Algorithm>
+class reduction_impl
+    : private reduction_impl_base,
+      public reduction_impl_algo<T, BinaryOperation, Dims, Extent, Algorithm> {
+private:
+  using algo = reduction_impl_algo<T, BinaryOperation, Dims, Extent, Algorithm>;
+
+public:
+  using reducer_type = typename algo::reducer_type;
+  // using result_type = T;
+  // using binary_operation = BinaryOperation;
+  using rw_accessor_type = typename algo::rw_accessor_type;
+  using dw_accessor_type = typename algo::dw_accessor_type;
+
+  // Only scalar and 1D array reductions are supported by SYCL 2020.
+  static_assert(Dims <= 1, "Multi-dimensional reductions are not supported.");
+
+  /// SYCL-2020.
+  /// Constructs reduction_impl when the identity value is statically known.
+  template <typename _T, typename AllocatorT,
+            std::enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * =
+                nullptr>
+  reduction_impl(buffer<_T, 1, AllocatorT> Buffer, handler &CGH,
+                 bool InitializeToIdentity)
+      : algo(reducer_type::getIdentity(), BinaryOperation(),
+             InitializeToIdentity, std::make_shared<rw_accessor_type>(Buffer)) {
+    algo::associateWithHandler(CGH);
+    if (Buffer.size() != 1)
+      throw sycl::runtime_error(errc::invalid,
+                                "Reduction variable must be a scalar.",
+                                PI_INVALID_VALUE);
+  }
+
+  /// Constructs reduction_impl when the identity value is statically known.
+  template <
+      typename _T = T,
+      enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
+  reduction_impl(rw_accessor_type &Acc)
+      : algo(reducer_type::getIdentity(), BinaryOperation(), false,
+             std::make_shared<rw_accessor_type>(Acc)) {
+    if (Acc.size() != 1)
+      throw sycl::runtime_error(errc::invalid,
+                                "Reduction variable must be a scalar.",
+                                PI_INVALID_VALUE);
+  }
+
+  /// Constructs reduction_impl when the identity value is statically known.
+  template <
+      typename _T = T,
+      enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
+  reduction_impl(dw_accessor_type &Acc)
+      : algo(reducer_type::getIdentity(), BinaryOperation(), true,
+             std::make_shared<dw_accessor_type>(Acc)) {
+    if (Acc.size() != 1)
+      throw sycl::runtime_error(errc::invalid,
+                                "Reduction variable must be a scalar.",
+                                PI_INVALID_VALUE);
+  }
+
+  /// SYCL-2020.
+  /// Constructs reduction_impl when the identity value is statically known,
+  /// and user still passed the identity value.
+  template <
+      typename _T, typename AllocatorT,
+      enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
+  reduction_impl(buffer<_T, 1, AllocatorT> Buffer, handler &CGH,
+                 const T & /*Identity*/, BinaryOperation,
+                 bool InitializeToIdentity)
+      : algo(reducer_type::getIdentity(), BinaryOperation(),
+             InitializeToIdentity, std::make_shared<rw_accessor_type>(Buffer)) {
+    algo::associateWithHandler(CGH);
+    if (Buffer.size() != 1)
+      throw sycl::runtime_error(errc::invalid,
+                                "Reduction variable must be a scalar.",
+                                PI_INVALID_VALUE);
+    // For now the implementation ignores the identity value given by user
+    // when the implementation knows the identity.
+    // The SPEC could prohibit passing identity parameter to operations with
+    // known identity, but that could have some bad consequences too.
+    // For example, at some moment the implementation may NOT know the identity
+    // for COMPLEX-PLUS reduction. User may create a program that would pass
+    // COMPLEX value (0,0) as identity for PLUS reduction. At some later moment
+    // when the implementation starts handling COMPLEX-PLUS as known operation
+    // the existing user's program remains compilable and working correctly.
+    // I.e. with this constructor here, adding more reduction operations to the
+    // list of known operations does not break the existing programs.
+  }
+
+  /// Constructs reduction_impl when the identity value is statically known,
+  /// and user still passed the identity value.
+  template <
+      typename _T = T,
+      enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
+  reduction_impl(rw_accessor_type &Acc, const T & /*Identity*/, BinaryOperation)
+      : algo(reducer_type::getIdentity(), BinaryOperation(), false,
+             std::make_shared<rw_accessor_type>(Acc)) {
+    if (Acc.size() != 1)
+      throw sycl::runtime_error(errc::invalid,
+                                "Reduction variable must be a scalar.",
+                                PI_INVALID_VALUE);
+    // For now the implementation ignores the identity value given by user
+    // when the implementation knows the identity.
+    // The SPEC could prohibit passing identity parameter to operations with
+    // known identity, but that could have some bad consequences too.
+    // For example, at some moment the implementation may NOT know the identity
+    // for COMPLEX-PLUS reduction. User may create a program that would pass
+    // COMPLEX value (0,0) as identity for PLUS reduction. At some later moment
+    // when the implementation starts handling COMPLEX-PLUS as known operation
+    // the existing user's program remains compilable and working correctly.
+    // I.e. with this constructor here, adding more reduction operations to the
+    // list of known operations does not break the existing programs.
+  }
+
+  /// Constructs reduction_impl when the identity value is statically known,
+  /// and user still passed the identity value.
+  template <
+      typename _T = T,
+      enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
+  reduction_impl(dw_accessor_type &Acc, const T & /*Identity*/, BinaryOperation)
+      : algo(reducer_type::getIdentity(), BinaryOperation(), true,
+             std::make_shared<dw_accessor_type>(Acc)) {
+    if (Acc.size() != 1)
+      throw sycl::runtime_error(errc::invalid,
+                                "Reduction variable must be a scalar.",
+                                PI_INVALID_VALUE);
+    // For now the implementation ignores the identity value given by user
+    // when the implementation knows the identity.
+    // The SPEC could prohibit passing identity parameter to operations with
+    // known identity, but that could have some bad consequences too.
+    // For example, at some moment the implementation may NOT know the identity
+    // for COMPLEX-PLUS reduction. User may create a program that would pass
+    // COMPLEX value (0,0) as identity for PLUS reduction. At some later moment
+    // when the implementation starts handling COMPLEX-PLUS as known operation
+    // the existing user's program remains compilable and working correctly.
+    // I.e. with this constructor here, adding more reduction operations to the
+    // list of known operations does not break the existing programs.
+  }
+
+  /// SYCL-2020.
+  /// Constructs reduction_impl when the identity value is NOT known statically.
+  template <
+      typename _T, typename AllocatorT,
+      enable_if_t<!IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
+  reduction_impl(buffer<_T, 1, AllocatorT> Buffer, handler &CGH,
+                 const T &Identity, BinaryOperation BOp,
+                 bool InitializeToIdentity)
+      : algo(Identity, BOp, InitializeToIdentity,
+             std::make_shared<rw_accessor_type>(Buffer)) {
+    algo::associateWithHandler(CGH);
+    if (Buffer.size() != 1)
+      throw sycl::runtime_error(errc::invalid,
+                                "Reduction variable must be a scalar.",
+                                PI_INVALID_VALUE);
+  }
+
+  /// Constructs reduction_impl when the identity value is unknown.
+  template <
+      typename _T = T,
+      enable_if_t<!IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
+  reduction_impl(rw_accessor_type &Acc, const T &Identity, BinaryOperation BOp)
+      : algo(Identity, BOp, false, std::make_shared<rw_accessor_type>(Acc)) {
+    if (Acc.size() != 1)
+      throw sycl::runtime_error(errc::invalid,
+                                "Reduction variable must be a scalar.",
+                                PI_INVALID_VALUE);
+  }
+
+  /// Constructs reduction_impl when the identity value is unknown.
+  template <
+      typename _T = T,
+      enable_if_t<!IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
+  reduction_impl(dw_accessor_type &Acc, const T &Identity, BinaryOperation BOp)
+      : algo(Identity, BOp, true, std::make_shared<dw_accessor_type>(Acc)) {
+    if (Acc.size() != 1)
+      throw sycl::runtime_error(errc::invalid,
+                                "Reduction variable must be a scalar.",
+                                PI_INVALID_VALUE);
+  }
+
+  /// Constructs reduction_impl when the identity value is statically known.
+  /// The \param VarPtr is a USM pointer to memory, to where the computed
+  /// reduction value is added using BinaryOperation, i.e. it is expected that
+  /// the memory is pre-initialized with some meaningful value.
+  template <
+      typename _T = T,
+      enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
+  reduction_impl(T *VarPtr, bool InitializeToIdentity = false)
+      : algo(reducer_type::getIdentity(), BinaryOperation(),
+             InitializeToIdentity, VarPtr) {}
+
+  /// Constructs reduction_impl when the identity value is statically known,
+  /// and user still passed the identity value.
+  /// The \param VarPtr is a USM pointer to memory, to where the computed
+  /// reduction value is added using BinaryOperation, i.e. it is expected that
+  /// the memory is pre-initialized with some meaningful value.
+  template <
+      typename _T = T,
+      enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
+  reduction_impl(T *VarPtr, const T &Identity, BinaryOperation,
+                 bool InitializeToIdentity = false)
+      : algo(Identity, BinaryOperation(), InitializeToIdentity, VarPtr) {
+    // For now the implementation ignores the identity value given by user
+    // when the implementation knows the identity.
+    // The SPEC could prohibit passing identity parameter to operations with
+    // known identity, but that could have some bad consequences too.
+    // For example, at some moment the implementation may NOT know the identity
+    // for COMPLEX-PLUS reduction. User may create a program that would pass
+    // COMPLEX value (0,0) as identity for PLUS reduction. At some later moment
+    // when the implementation starts handling COMPLEX-PLUS as known operation
+    // the existing user's program remains compilable and working correctly.
+    // I.e. with this constructor here, adding more reduction operations to the
+    // list of known operations does not break the existing programs.
+  }
+
+  /// Constructs reduction_impl when the identity value is unknown.
+  /// The \param VarPtr is a USM pointer to memory, to where the computed
+  /// reduction value is added using BinaryOperation, i.e. it is expected that
+  /// the memory is pre-initialized with some meaningful value.
+  template <
+      typename _T = T,
+      enable_if_t<!IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
+  reduction_impl(T *VarPtr, const T &Identity, BinaryOperation BOp,
+                 bool InitializeToIdentity = false)
+      : algo(Identity, BOp, InitializeToIdentity, VarPtr) {}
+
+#if __cplusplus >= 201703L
+  /// Constructs reduction_impl when the identity value is statically known
+  template <
+      typename _T = T,
+      enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
+  reduction_impl(span<_T, Extent> Span, bool InitializeToIdentity = false)
+      : algo(reducer_type::getIdentity(), BinaryOperation(),
+             InitializeToIdentity, Span.data()) {}
+
+  /// Constructs reduction_impl when the identity value is statically known
+  /// and user passed an identity value anyway
+  template <
+      typename _T = T,
+      enable_if_t<IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
+  reduction_impl(span<_T, Extent> Span, const T & /* Identity */,
+                 BinaryOperation BOp, bool InitializeToIdentity = false)
+      : algo(reducer_type::getIdentity(), BOp, InitializeToIdentity,
+             Span.data()) {}
+
+  /// Constructs reduction_impl when the identity value is not statically known
+  template <
+      typename _T = T,
+      enable_if_t<!IsKnownIdentityOp<_T, BinaryOperation>::value> * = nullptr>
+  reduction_impl(span<T, Extent> Span, const T &Identity, BinaryOperation BOp,
+                 bool InitializeToIdentity = false)
+      : algo(Identity, BOp, InitializeToIdentity, Span.data()) {}
 #endif
+};
 
 /// These are the forward declaration for the classes that help to create
 /// names for additional kernels. It is used only when there are
@@ -2605,7 +2323,8 @@ tuple_select_elements(TupleT Tuple, std::index_sequence<Is...>) {
 /// operation used in the reduction.
 template <typename T, class BinaryOperation, int Dims, access::mode AccMode,
           access::placeholder IsPH>
-detail::reduction_impl<T, BinaryOperation, Dims, false, IsPH>
+detail::reduction_impl<T, BinaryOperation, 0, 1,
+                       detail::default_reduction_algorithm<false, IsPH, Dims>>
 reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
           const T &Identity, BinaryOperation BOp) {
   return {Acc, Identity, BOp};
@@ -2618,7 +2337,9 @@ reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
 template <typename T, class BinaryOperation, int Dims, access::mode AccMode,
           access::placeholder IsPH>
 std::enable_if_t<detail::IsKnownIdentityOp<T, BinaryOperation>::value,
-                 detail::reduction_impl<T, BinaryOperation, Dims, false, IsPH>>
+                 detail::reduction_impl<
+                     T, BinaryOperation, 0, 1,
+                     detail::default_reduction_algorithm<false, IsPH, Dims>>>
 reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
           BinaryOperation) {
   return {Acc};
@@ -2629,7 +2350,9 @@ reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
 /// the computed reduction must be stored \param VarPtr, identity value
 /// \param Identity, and the binary operation used in the reduction.
 template <typename T, class BinaryOperation>
-detail::reduction_impl<T, BinaryOperation, 1, true>
+detail::reduction_impl<
+    T, BinaryOperation, 0, 1,
+    detail::default_reduction_algorithm<true, access::placeholder::false_t, 1>>
 reduction(T *VarPtr, const T &Identity, BinaryOperation BOp) {
   return {VarPtr, Identity, BOp};
 }
@@ -2640,8 +2363,11 @@ reduction(T *VarPtr, const T &Identity, BinaryOperation BOp) {
 /// operation used in the reduction.
 /// The identity value is not passed to this version as it is statically known.
 template <typename T, class BinaryOperation>
-std::enable_if_t<detail::IsKnownIdentityOp<T, BinaryOperation>::value,
-                 detail::reduction_impl<T, BinaryOperation, 1, true>>
+std::enable_if_t<
+    detail::IsKnownIdentityOp<T, BinaryOperation>::value,
+    detail::reduction_impl<T, BinaryOperation, 0, 1,
+                           detail::default_reduction_algorithm<
+                               true, access::placeholder::false_t, 1>>>
 reduction(T *VarPtr, BinaryOperation) {
   return {VarPtr};
 }

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -372,10 +372,8 @@ public:
     MValue = BOp(MValue, Partial);
   }
 
-  template <typename _T = T, class _BinaryOperation = BinaryOperation>
-  static enable_if_t<has_known_identity_impl<_BinaryOperation, _T>::value, _T>
-  getIdentity() {
-    return known_identity_impl<_BinaryOperation, _T>::value;
+  static T getIdentity() {
+    return known_identity_impl<BinaryOperation, T>::value;
   }
 
   T &getElement(size_t) { return MValue; }
@@ -455,10 +453,8 @@ public:
     return {MValue[Index], BinaryOperation()};
   }
 
-  template <typename _T = T, class _BinaryOperation = BinaryOperation>
-  static enable_if_t<has_known_identity_impl<_BinaryOperation, _T>::value, _T>
-  getIdentity() {
-    return known_identity_impl<_BinaryOperation, _T>::value;
+  static T getIdentity() {
+    return known_identity_impl<BinaryOperation, T>::value;
   }
 
   T &getElement(size_t E) { return MValue[E]; }

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -355,7 +355,6 @@ private:
 ///
 /// It allows to reduce the size of the 'reducer' object by not holding
 /// the identity field inside it and allows to add a default constructor.
-// TODO: More types and ops can be added to here later.
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
           class Algorithm, bool View>
 class reducer<T, BinaryOperation, Dims, Extent, Algorithm, View,

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -331,7 +331,7 @@ public:
   T getIdentity() const { return MIdentity; }
 
   T &getElement(size_t) { return MValue; }
-  const T &getElement(size_t E) const { return MValue; }
+  const T &getElement(size_t) const { return MValue; }
   T MValue;
 
 private:

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -94,11 +94,13 @@ using IsReduOptForFastReduce =
                    sycl::detail::IsMaximum<T, BinaryOperation>::value)>;
 #endif
 
-// Using std::tuple allows usage of functions like std::tuple_element_t
-// Switching tuple can be done by changing the definitions below
-template <typename... Ts> using ReduTupleT = std::tuple<Ts...>;
+// std::tuple seems to be a) too heavy and b) not copyable to device now
+// Thus sycl::detail::tuple is used instead.
+// Switching from sycl::device::tuple to std::tuple can be done by re-defining
+// the ReduTupleT type and makeReduTupleT() function below.
+template <typename... Ts> using ReduTupleT = sycl::detail::tuple<Ts...>;
 template <typename... Ts> ReduTupleT<Ts...> makeReduTupleT(Ts... Elements) {
-  return std::make_tuple(Elements...);
+  return sycl::detail::make_tuple(Elements...);
 }
 
 __SYCL_EXPORT size_t reduGetMaxWGSize(std::shared_ptr<queue_impl> Queue,
@@ -2010,7 +2012,7 @@ template <bool Pow2WG, bool IsOneWG, typename... Reductions, int Dims,
           typename... Ts, typename... BOPsT, size_t... Is>
 void reduCGFuncImplScalar(
     nd_item<Dims> NDIt, ReduTupleT<LocalAccT...> LocalAccsTuple,
-    ReduTupleT<OutAccT...> OutAccsTuple, ReduTupleT<ReducerT...> &ReducersTuple,
+    ReduTupleT<OutAccT...> OutAccsTuple, std::tuple<ReducerT...> &ReducersTuple,
     ReduTupleT<Ts...> IdentitiesTuple, ReduTupleT<BOPsT...> BOPsTuple,
     std::array<bool, sizeof...(Reductions)> InitToIdentityProps,
     std::index_sequence<Is...> ReduIndices) {
@@ -2112,7 +2114,7 @@ template <bool Pow2WG, bool IsOneWG, typename... Reductions, int Dims,
           typename... Ts, typename... BOPsT, size_t... Is>
 void reduCGFuncImplArray(
     nd_item<Dims> NDIt, ReduTupleT<LocalAccT...> LocalAccsTuple,
-    ReduTupleT<OutAccT...> OutAccsTuple, ReduTupleT<ReducerT...> &ReducersTuple,
+    ReduTupleT<OutAccT...> OutAccsTuple, std::tuple<ReducerT...> &ReducersTuple,
     ReduTupleT<Ts...> IdentitiesTuple, ReduTupleT<BOPsT...> BOPsTuple,
     std::array<bool, sizeof...(Reductions)> InitToIdentityProps,
     std::index_sequence<Is...> ReduIndices) {

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -645,7 +645,7 @@ public:
 
   /// If reduction is initialized with read-write accessor, which does not
   /// require initialization with identity value, then return user's read-write
-  /// accessor. Otherwise, create 1-element global buffer initialized with
+  /// accessor. Otherwise, create global buffer with 'num_elements' initialized with
   /// identity value and return an accessor to that buffer.
   template <bool HasFastAtomics = (has_fast_atomics || has_atomic_add_float64)>
   std::enable_if_t<HasFastAtomics, rw_accessor_type>

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -165,7 +165,7 @@ public:
     combine(Partial);
   }
 
-  T &getElement(size_t E) { return MValue; }
+  T &getElement(size_t) { return MValue; }
   T MValue;
 
 private:

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -646,8 +646,8 @@ public:
 
   /// If reduction is initialized with read-write accessor, which does not
   /// require initialization with identity value, then return user's read-write
-  /// accessor. Otherwise, create global buffer with 'num_elements' initialized with
-  /// identity value and return an accessor to that buffer.
+  /// accessor. Otherwise, create global buffer with 'num_elements' initialized
+  /// with identity value and return an accessor to that buffer.
   template <bool HasFastAtomics = (has_fast_atomics || has_atomic_add_float64)>
   std::enable_if_t<HasFastAtomics, rw_accessor_type>
   getReadWriteAccessorToInitializedMem(handler &CGH) {

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -757,8 +757,6 @@ private:
 
 public:
   using reducer_type = typename algo::reducer_type;
-  // using result_type = T;
-  // using binary_operation = BinaryOperation;
   using rw_accessor_type = typename algo::rw_accessor_type;
   using dw_accessor_type = typename algo::dw_accessor_type;
 

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -317,6 +317,11 @@ public:
   }
 };
 
+/// Specialization of the generic class 'reducer'. It is used for reductions
+/// of those types and operations for which the identity value is not known.
+///
+/// It stores a copy of the identity and binary operation associated with the
+/// reduction.
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
           class Algorithm, bool View>
 class reducer<T, BinaryOperation, Dims, Extent, Algorithm, View,

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -413,6 +413,7 @@ private:
 /// Specialization of 'reducer' class for array reductions accepting a span
 /// in cases where the identity value is not known.
 // TODO: Support alternative algorithms for different values of Extent
+#if __cplusplus >= 201703L
 template <typename T, size_t Extent, class BinaryOperation>
 class reducer<span<T, Extent>, BinaryOperation,
               enable_if_t<!IsKnownIdentityOp<T, BinaryOperation>::value>> {
@@ -571,6 +572,7 @@ public:
 private:
   marray<T, Extent> MValue;
 };
+#endif
 
 /// Base non-template class which is a base class for all reduction
 /// implementation classes. It is needed to detect the reduction classes.
@@ -1026,6 +1028,7 @@ private:
 /// Specialization of reduction_impl for spans
 // TODO: Consider hoisting some functionality into reduction_impl_base
 // TODO: Refactor to remove IsUSM and IsPlaceholder arguments?
+#if __cplusplus >= 201703L
 template <typename T, size_t Extent, class BinaryOperation, int Dims,
           bool IsUSM, access::placeholder IsPlaceholder>
 class reduction_impl<span<T, Extent>, BinaryOperation, Dims, IsUSM,
@@ -1273,6 +1276,7 @@ private:
 
   bool InitializeToIdentity;
 };
+#endif
 
 /// These are the forward declaration for the classes that help to create
 /// names for additional kernels. It is used only when there are

--- a/sycl/test/esimd/esimd_verify.cpp
+++ b/sycl/test/esimd/esimd_verify.cpp
@@ -11,7 +11,7 @@ using namespace sycl::ext::intel::esimd;
 
 // CHECK-DAG: error: function 'cl::sycl::multi_ptr<{{.+}}> cl::sycl::accessor<{{.+}}>::get_pointer<{{.+}}>() const' is not supported in ESIMD context
 // CHECK-DAG: error: function '{{.+}} cl::sycl::accessor<{{.+}}>::operator[]<{{.+}}>({{.+}}) const' is not supported in ESIMD context
-// CHECK-DAG: error: function 'cl::sycl::ext::oneapi::detail::reducer<int, std::plus<int>, void>::combine(int const&)' is not supported in ESIMD context
+// CHECK-DAG: error: function '{{.+}}combine(int const&)' is not supported in ESIMD context
 
 SYCL_EXTERNAL auto
 test(accessor<int, 1, access::mode::read_write, access::target::device> &acc)


### PR DESCRIPTION
A new static member function "num_elements" is added to all reduction
specializations to distinguish between scalar reductions and array reductions.
A scalar reduction (all existing implementations of reduction) always
has (num_elements == 1); an array reduction (this new specialization) has
(num_elements == Extent), where Extent is the extent of the span.

If (num_elements > 1), the implementation currently reduces each element
separately. This allows array reductions to use the same amount of work-group
local memory as a scalar reduction using the same T, but at the expense of
additional synchronization calls.

The notion of a reducer's "dimensionality" is now tied to the dimensionality of
the reduction being performed (i.e. 0 for scalars, 1 for spans) and not to the
dimensionality of the input accessor/buffer. This will simplify extending
reductions to true multi-dimensional array reductions (i.e. with md_span).

In future, the code handling the reduction packs could be generalized to
handle more reduction/reducer types while making fewer assumptions about
the reduction algorithm.

Signed-off-by: John Pennycook <john.pennycook@intel.com>