### PR TITLE
[Driver][SYCL] Fix -fsycl-targets validation when using -Xsycl-target…

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1286,7 +1286,7 @@ llvm::opt::DerivedArgList *ToolChain::TranslateOffloadTargetArgs(
       // improved upon
       auto SingleTargetTripleCount = [&Args](OptSpecifier Opt) {
         const Arg *TargetArg = Args.getLastArg(Opt);
-        if (TargetArg && TargetArg->getValues().size() == 1)
+        if (!TargetArg || TargetArg->getValues().size() == 1)
           return true;
         return false;
       };

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -671,6 +671,11 @@
 // RUN:   | FileCheck -check-prefix=CHK-FSYCL-TARGET-2X-ERROR %s
 // CHK-FSYCL-TARGET-2X-ERROR-NOT: clang{{.*}} error: cannot deduce implicit triple value for '-Xsycl-target{{.*}}', specify triple using '-Xsycl-target{{.*}}=<triple>'
 
+/// Check -Xsycl-target-frontend does not trigger an error when no -fsycl-targets is specified
+// RUN:   %clang -### -fsycl -Xsycl-target-frontend -DFOO %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-NO-FSYCL-TARGET-ERROR %s
+// CHK-NO-FSYCL-TARGET-ERROR-NOT: clang{{.*}} error: cannot deduce implicit triple value for '-Xsycl-target-frontend', specify triple using '-Xsycl-target-frontend=<triple>'
+
 /// ###########################################################################
 
 /// Ahead of Time compilation for fpga, gen, cpu


### PR DESCRIPTION
…-frontend

We were improperly requiring at least one -fsycl-targets when using
-Xsycl-target-*. We should allow no -fsycl-targets is specified when
using -Xsycl-target-frontend.

Signed-off-by: Qichao Gu <qichao.gu@intel.com>