### PR TITLE
[ESIMD] Fix wrong genx attributes generation in sycl-post-link

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -898,6 +898,9 @@ static inline llvm::Metadata *getMD(llvm::Value *V) {
 // 2) For now such intrinsics are also handled in functions directly called
 // from kernels and being translate into those caller-kernel meeven though such
 // behaviour is not fully specified/documented.
+// 3) This code (or the code in FE) must verify that slm_init or other such
+// intrinsic is not called from another module because kernels in that other
+// module would not get updated meta data attributes.
 static void updateGenXMDNodes(llvm::Function *F, genx::KernelMDOp MD,
                               uint64_t NewVal) {
   llvm::NamedMDNode *GenXKernelMD =

--- a/sycl/test/esimd/genx_func_attr.cpp
+++ b/sycl/test/esimd/genx_func_attr.cpp
@@ -1,0 +1,40 @@
+// RUN: %clangxx -O2 -fsycl -fsycl-device-only -Xclang -emit-llvm %s -o %t
+// RUN: sycl-post-link -split-esimd -lower-esimd -O2 -S %t -o %t.table
+// RUN: FileCheck %s -input-file=%t_esimd_0.ll
+
+// Checks ESIMD intrinsic translation.
+// NOTE: must be run in -O0, as optimizer optimizes away some of the code
+
+#include <CL/sycl.hpp>
+#include <CL/sycl/detail/image_ocl_types.hpp>
+#include <sycl/ext/intel/esimd.hpp>
+
+using namespace sycl::ext::intel::esimd;
+
+template <typename name, typename Func>
+__attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
+  kernelFunc();
+}
+
+SYCL_ESIMD_FUNCTION SYCL_EXTERNAL ESIMD_NOINLINE void callee(int x) {
+  slm_init(1234);
+  sycl::ext::intel::experimental::esimd::named_barrier_init<13>();
+}
+
+// inherits SLMSize and NBarrierCount from callee
+void caller_abc(int x) {
+  kernel<class kernel_abc>([=]() SYCL_ESIMD_KERNEL { callee(x); });
+  // CHECK: define dso_local spir_kernel void @_ZTSZ10caller_abciE10kernel_abc(i32 noundef "VCArgumentIOKind"="0" %_arg_x) local_unnamed_addr #2
+}
+
+// inherits only NBarrierCount from callee
+void caller_xyz(int x) {
+  kernel<class kernel_xyz>([=]() SYCL_ESIMD_KERNEL {
+    slm_init(1235);
+    callee(x);
+  });
+  // CHECK: define dso_local spir_kernel void @_ZTSZ10caller_xyziE10kernel_xyz(i32 noundef "VCArgumentIOKind"="0" %_arg_x) local_unnamed_addr #3
+}
+
+// CHECK: attributes #2 = { {{.*}} "VCNamedBarrierCount"="13" "VCSLMSize"="1234"
+// CHECK: attributes #3 = { {{.*}} "VCNamedBarrierCount"="13" "VCSLMSize"="1235"


### PR DESCRIPTION
The attributes NBarrierCount and SLMSize were set incorrectly in
those cases where there was a function shared for 2 different kernels.

The attribute generated in the shared function should be set for all callers.
Previously, only attributes of the 1st caller were updated.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>