### PR TITLE
[SYCL] Make local accessor argument allocation 1-byte minimum

### DIFF
--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -543,6 +543,9 @@ void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
       int SizeInBytes = LAcc->MElemSize;
       for (int I = 0; I < Dims; ++I)
         SizeInBytes *= Size[I];
+      // Some backends do not accept zero-sized local memory arguments, so we
+      // make it a minimum allocation of 1 byte.
+      SizeInBytes = std::max(SizeInBytes, 1);
       MArgs.emplace_back(kernel_param_kind_t::kind_std_layout, nullptr,
                          SizeInBytes, Index + IndexShift);
       if (!IsKernelCreatedFromSource) {


### PR DESCRIPTION
Some DPC++ backends, such as OpenCL, does not allow setting local memory kernel arguments with a size of zero bytes. As such, the runtime library can fail with a backend error if a local accessor has a zero-size. These changes make a special case for local accessors with a zero byte size making it allocate a single byte of memory.