### PR TITLE
[SYCL] Force inline spec constant retrieval function to help BEs at -O0.

### DIFF
--- a/sycl/include/CL/sycl/kernel_handler.hpp
+++ b/sycl/include/CL/sycl/kernel_handler.hpp
@@ -23,7 +23,7 @@ class kernel_handler {
 public:
 #if __cplusplus >= 201703L
   template <auto &S>
-  typename std::remove_reference_t<decltype(S)>::value_type
+  __SYCL_ALWAYS_INLINE typename std::remove_reference_t<decltype(S)>::value_type
   get_specialization_constant() {
 #ifdef __SYCL_DEVICE_ONLY__
     return getSpecializationConstantOnDevice<S>();
@@ -49,7 +49,7 @@ private:
       auto &S,
       typename T = typename std::remove_reference_t<decltype(S)>::value_type,
       std::enable_if_t<std::is_fundamental_v<T>> * = nullptr>
-  T getSpecializationConstantOnDevice() {
+  __SYCL_ALWAYS_INLINE T getSpecializationConstantOnDevice() {
     const char *SymbolicID = __builtin_sycl_unique_stable_id(S);
     return __sycl_getScalar2020SpecConstantValue<T>(
         SymbolicID, &S, MSpecializationConstantsBuffer);
@@ -58,7 +58,7 @@ private:
       auto &S,
       typename T = typename std::remove_reference_t<decltype(S)>::value_type,
       std::enable_if_t<std::is_compound_v<T>> * = nullptr>
-  T getSpecializationConstantOnDevice() {
+  __SYCL_ALWAYS_INLINE T getSpecializationConstantOnDevice() {
     const char *SymbolicID = __builtin_sycl_unique_stable_id(S);
     return __sycl_getComposite2020SpecConstantValue<T>(
         SymbolicID, &S, MSpecializationConstantsBuffer);

--- a/sycl/test/regression/spec_const_O0.cpp
+++ b/sycl/test/regression/spec_const_O0.cpp
@@ -1,0 +1,19 @@
+// RUN: %clangxx -O0 -fsycl -fsycl-device-only -Xclang -emit-llvm %s -o - | FileCheck %s
+// This test checks that even under -O0 the entire call chain starting from
+// kh.get_specialization_constant and ending with
+// __sycl_getScalar2020SpecConstantValue gets inlined.
+#include <CL/sycl.hpp>
+
+using namespace cl::sycl;
+
+constexpr specialization_id<unsigned int> SPEC_CONST(1024);
+
+SYCL_EXTERNAL unsigned int foo(kernel_handler &kh) {
+  return kh.get_specialization_constant<SPEC_CONST>();
+}
+
+// CHECK-LABEL: define dso_local spir_func noundef i32 @_Z3foo{{.*}} {
+// CHECK-NOT: {{.*}}spir_func
+// CHECK: %{{.*}} = {{.*}}call spir_func {{.*}}i32 @_Z37__sycl_getScalar2020SpecConstantValue
+// CHECK-NOT: {{.*}}spir_func
+// CHECK-LABEL: }


### PR DESCRIPTION
kernel_handler::get_specialization_constant translates to a sequence of
calls with __spirv_SpecConstant in the end under -O0, which hurts BE
ability to guess actual constant value at the call site, especially
since it is also invoked with -O0. Forcing inlining of all the
participating functions turns the callsite into single
__spirv_SpecConstant, which is then replaced by actual constant.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>