### PR TITLE
[SYCL] Cast to correct address space for _alloca

### DIFF
--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -2057,10 +2057,9 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
     llvm::Type *SrcTy = Src->getType();
     llvm::Type *DstTy = ConvertType(DestTy);
     if (SrcTy->isPtrOrPtrVectorTy() && DstTy->isPtrOrPtrVectorTy() &&
-        SrcTy->getPointerAddressSpace() != DstTy->getPointerAddressSpace()) {
-      llvm_unreachable("wrong cast for pointers in different address spaces"
-                       "(must be an address space cast)!");
-    }
+        SrcTy->getPointerAddressSpace() != DstTy->getPointerAddressSpace())
+      Src = Builder.CreateAddrSpaceCast(
+          Src, llvm::PointerType::get(SrcTy, DstTy->getPointerAddressSpace()));
 
     if (CGF.SanOpts.has(SanitizerKind::CFIUnrelatedCast)) {
       if (auto *PT = DestTy->getAs<PointerType>()) {

--- a/clang/test/CodeGenSYCL/address-space-builtin-alloca.cpp
+++ b/clang/test/CodeGenSYCL/address-space-builtin-alloca.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -triple spir64-unknown-linux -fsycl-is-device -disable-llvm-passes -emit-llvm -x c++ %s -o - | FileCheck %s
+
+// Test to verify that address space cast is generated correctly for __builtin_alloca
+
+__attribute__((sycl_device)) void foo() {
+  // CHECK: %TestVar = alloca i32 addrspace(4)*, align 8
+  // CHECK: %TestVar.ascast = addrspacecast i32 addrspace(4)** %TestVar to i32 addrspace(4)* addrspace(4)*
+  // CHECK: %[[ALLOCA:[0-9]+]] = alloca i8, i64 1, align 8
+  // CHECK: %[[ADDRSPCAST:[0-9]+]] = addrspacecast i8* %[[ALLOCA]] to i8* addrspace(4)*
+  // CHECK: %[[BITCAST:[0-9]+]] = bitcast i8* addrspace(4)* %[[ADDRSPCAST]] to i32 addrspace(4)*
+  // CHECK: store i32 addrspace(4)* %[[BITCAST]], i32 addrspace(4)* addrspace(4)* %TestVar.ascast, align 8
+  int *TestVar = (int *)__builtin_alloca(1);
+}


### PR DESCRIPTION
Alloca instruction for _alloca is generated in AllocaAddrSpace.
Addspace cast is required since pointers have address space 4
in SYCL.

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>