### PR TITLE
[ESIMD] Fix fail caused by filter/check in genx_func_attr.cpp test

### DIFF
--- a/sycl/test/esimd/genx_func_attr.cpp
+++ b/sycl/test/esimd/genx_func_attr.cpp
@@ -24,7 +24,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL ESIMD_NOINLINE void callee(int x) {
 // inherits SLMSize and NBarrierCount from callee
 void caller_abc(int x) {
   kernel<class kernel_abc>([=]() SYCL_ESIMD_KERNEL { callee(x); });
-  // CHECK: define dso_local spir_kernel void @_ZTSZ10caller_abciE10kernel_abc(i32 noundef "VCArgumentIOKind"="0" %_arg_x) local_unnamed_addr #2
+  // CHECK: define dso_local spir_kernel void @_ZTSZ10caller_abciE10kernel_abc(i32 noundef "VCArgumentIOKind"="0" %{{.*}}) local_unnamed_addr #2
 }
 
 // inherits only NBarrierCount from callee
@@ -33,7 +33,7 @@ void caller_xyz(int x) {
     slm_init(1235);
     callee(x);
   });
-  // CHECK: define dso_local spir_kernel void @_ZTSZ10caller_xyziE10kernel_xyz(i32 noundef "VCArgumentIOKind"="0" %_arg_x) local_unnamed_addr #3
+  // CHECK: define dso_local spir_kernel void @_ZTSZ10caller_xyziE10kernel_xyz(i32 noundef "VCArgumentIOKind"="0" %{{.*}}) local_unnamed_addr #3
 }
 
 // CHECK: attributes #2 = { {{.*}} "VCNamedBarrierCount"="13" "VCSLMSize"="1234"


### PR DESCRIPTION
The error showed up with no-aaserts build as it discarded func argument names.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>