### PR TITLE
[SYCL] Incorrect diagnostic for __spirv calls

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3719,6 +3719,12 @@ static void CheckSYCL2020SubGroupSizes(Sema &S, FunctionDecl *SYCLKernel,
       CalcEffectiveSubGroup(S.Context, S.getLangOpts(), FD))
     return;
 
+  // No need to validate __spirv routines here since they
+  // are mapped to the equivalent SPIRV operations.
+  const IdentifierInfo *II = FD->getIdentifier();
+  if (II && II->getName().startswith("__spirv_"))
+    return;
+
   // Else we need to figure out why they don't match.
   SourceLocation FDAttrLoc = GetSubGroupLoc(FD);
   SourceLocation KernelAttrLoc = GetSubGroupLoc(SYCLKernel);

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -66,7 +66,6 @@ enum class address_space : int {
   constant_space,
   local_space
 };
-
 } // namespace access
 
 // Dummy aspect enum with limited enumerators

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -5,8 +5,7 @@
 extern "C" int printf(const char* fmt, ...);
 
 #ifdef __SYCL_DEVICE_ONLY__
-__attribute__((convergent))
-extern SYCL_EXTERNAL void
+__attribute__((convergent)) extern SYCL_EXTERNAL void
 __spirv_ControlBarrier(int, int, int) noexcept;
 #endif
 

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -67,12 +67,6 @@ enum class address_space : int {
   local_space
 };
 
-enum class fence_space {
-  local_space = 0,
-  global_space = 1,
-  global_and_local = 2
-};
-
 } // namespace access
 
 // Dummy aspect enum with limited enumerators

--- a/clang/test/CodeGenSYCL/reqd-sub-group-size-spirv-intrin.cpp
+++ b/clang/test/CodeGenSYCL/reqd-sub-group-size-spirv-intrin.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64 -fsycl-is-device -std=c++17 -internal-isystem %S/Inputs -fdeclare-spirv-builtins %s -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64 -fsycl-is-device -internal-isystem %S/Inputs -fdeclare-spirv-builtins %s -emit-llvm -o - | FileCheck %s
 
 // Test that when __spirv intrinsics are invoked from kernel functions
 // that have a sub_group_size specified, that such invocations don't
@@ -11,11 +11,11 @@ int main() {
   sycl::queue q;
 
   q.submit([&](sycl::handler &cgh) {
-    auto kernel_ = [=](sycl::nd_item<1> item) [[intel::sub_group_size(8)]] {
-      item.barrier(sycl::access::fence_space::local_space);
+    auto kernel_ = [=](sycl::group<1> item) [[intel::sub_group_size(8)]] {
     };
 
-    cgh.parallel_for<class kernel_class>(cl::sycl::nd_range<1>(), kernel_);
+    cgh.parallel_for_work_group<class kernel_class>(
+        cl::sycl::range<1>(), cl::sycl::range<1>(), kernel_);
   });
   return 0;
 }

--- a/clang/test/CodeGenSYCL/reqd-sub-group-size-spirv-intrin.cpp
+++ b/clang/test/CodeGenSYCL/reqd-sub-group-size-spirv-intrin.cpp
@@ -1,23 +1,20 @@
 // RUN: %clang_cc1 -triple spir64 -fsycl-is-device -std=c++17 -internal-isystem %S/Inputs -fdeclare-spirv-builtins %s -emit-llvm -o - | FileCheck %s
 
 // Test that when __spirv intrinsics are invoked from kernel functions
-// that have a sub_group_size specified, that such invocations don't 
+// that have a sub_group_size specified, that such invocations don't
 // trigger the error diagnostic that the intrinsic routines must also
 // marked with the same attribute.
 
 #include "Inputs/sycl.hpp"
 
 int main() {
-  const int local_size = 8;
-  const int global_size = 1*local_size;
+  sycl::queue q;
 
-  cl::sycl::queue q;
-  
-  q.submit([&] (cl::sycl::handler &cgh) {
-    auto kernel_ = [=](cl::sycl::nd_item<1> item) [[intel::sub_group_size(8)]] {
+  q.submit([&](sycl::handler &cgh) {
+    auto kernel_ = [=](sycl::nd_item<1> item) [[intel::sub_group_size(8)]] {
       item.barrier(sycl::access::fence_space::local_space);
     };
-    
+
     cgh.parallel_for<class kernel_class>(cl::sycl::nd_range<1>(), kernel_);
   });
   return 0;

--- a/clang/test/CodeGenSYCL/reqd-sub-group-size-spirv-intrin.cpp
+++ b/clang/test/CodeGenSYCL/reqd-sub-group-size-spirv-intrin.cpp
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -triple spir64 -fsycl-is-device -std=c++17 -internal-isystem %S/Inputs -fdeclare-spirv-builtins %s -emit-llvm -o - | FileCheck %s
+
+// Test that when __spirv intrinsics are invoked from kernel functions
+// that have a sub_group_size specified, that such invocations don't 
+// trigger the error diagnostic that the intrinsic routines must also
+// marked with the same attribute.
+
+#include "Inputs/sycl.hpp"
+
+int main() {
+  const int local_size = 8;
+  const int global_size = 1*local_size;
+
+  cl::sycl::queue q;
+  
+  q.submit([&] (cl::sycl::handler &cgh) {
+    auto kernel_ = [=](cl::sycl::nd_item<1> item) [[intel::sub_group_size(8)]] {
+      item.barrier(sycl::access::fence_space::local_space);
+    };
+    
+    cgh.parallel_for<class kernel_class>(cl::sycl::nd_range<1>(), kernel_);
+  });
+  return 0;
+}
+
+// CHECK: define dso_local spir_kernel void @{{.*}}main{{.*}}kernel_class() {{.*}} !intel_reqd_sub_group_size ![[SUBGROUPSIZE:[0-9]+]]
+// CHECK: tail call spir_func void @{{.*}}__spirv_ControlBarrier{{.*}}({{.*}})
+
+// CHECK: declare spir_func void @{{.*}}__spirv_ControlBarrier{{.*}}({{.*}})
+
+// CHECK: ![[SUBGROUPSIZE]] = !{i32 8}


### PR DESCRIPTION
When the reqd_sub_group_size attribute is applied on a
sycl kernel, we check that SYCL_EXTERNAL functions called
from such kernels also have the same sub_group_size. This
need not be enforced on __spirv intrinsics since they are
mapped to the equivalent SPIR-V operations.