### PR TITLE
[SYCL][PI] Restore find_package(Threads) to fix build issue in some env

### DIFF
--- a/sycl/plugins/level_zero/CMakeLists.txt
+++ b/sycl/plugins/level_zero/CMakeLists.txt
@@ -103,6 +103,8 @@ if (SYCL_ENABLE_XPTI_TRACING)
   set(XPTI_PROXY_SRC "${CMAKE_SOURCE_DIR}/../xpti/src/xpti_proxy.cpp")
 endif()
 
+find_package(Threads REQUIRED)
+
 add_sycl_plugin(level_zero
   SOURCES
     "${sycl_inc_dir}/CL/sycl/detail/pi.h"

--- a/sycl/plugins/level_zero/CMakeLists.txt
+++ b/sycl/plugins/level_zero/CMakeLists.txt
@@ -116,6 +116,7 @@ add_sycl_plugin(level_zero
     ${XPTI_PROXY_SRC}
   LIBRARIES
     "${LEVEL_ZERO_LOADER}"
+    Threads::Threads
 )
 
 find_package(Python3 REQUIRED)


### PR DESCRIPTION
Trying to fix regression after https://github.com/intel/llvm/pull/6023
https://github.com/intel/llvm/runs/6164928984?check_suite_focus=true

> CMake Error at D:/github/_work/llvm/llvm/src/sycl/cmake/modules/AddSYCL.cmake:8 (add_library):
  Target "pi_level_zero" links to target "Threads::Threads" but the target
  was not found.  Perhaps a find_package() call is missing for an IMPORTED
  target, or an ALIAS target is missing?
Call Stack (most recent call first):
  D:/github/_work/llvm/llvm/src/sycl/cmake/modules/AddSYCL.cmake:41 (add_sycl_library)
  D:/github/_work/llvm/llvm/src/sycl/plugins/level_zero/CMakeLists.txt:106 (add_sycl_plugin)