### PR TITLE
[SYCL] Fix Windows build configure issue

### DIFF
--- a/sycl/plugins/level_zero/CMakeLists.txt
+++ b/sycl/plugins/level_zero/CMakeLists.txt
@@ -114,7 +114,6 @@ add_sycl_plugin(level_zero
     ${XPTI_PROXY_SRC}
   LIBRARIES
     "${LEVEL_ZERO_LOADER}"
-    Threads::Threads
 )
 
 find_package(Python3 REQUIRED)


### PR DESCRIPTION
Error: "Threads::Threads" but the target was not found.  Perhaps a
find_package() call is missing for an IMPORTED target, or an ALIAS
target is missing?