### PR TITLE
[SYCL] Add half non-assign math operators

### DIFF
--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -397,21 +397,24 @@ public:
 
 // Operator +, -, *, /
 #define OP(op, op1)                                                            \
-  friend half operator op(const half &lhs, const half &rhs) {                  \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
+                                                const half &rhs) {             \
     half rtn = lhs;                                                            \
     rtn op1 rhs;                                                               \
     return rtn;                                                                \
   }                                                                            \
   template <typename T,                                                        \
             typename = std::enable_if_t<std::is_arithmetic<T>::value>>         \
-  friend half operator op(const half &lhs, const T &rhs) {                     \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
+                                                const T &rhs) {                \
     half rtn = lhs;                                                            \
     rtn op1 rhs;                                                               \
     return rtn;                                                                \
   }                                                                            \
   template <typename T,                                                        \
             typename = std::enable_if_t<std::is_arithmetic<T>::value>>         \
-  friend half operator op(const T &lhs, const half &rhs) {                     \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const T &lhs,                  \
+                                                const half &rhs) {             \
     half rtn = rhs;                                                            \
     rtn op1 lhs;                                                               \
     return rtn;                                                                \

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -467,6 +467,62 @@ public:
   OP(-, -=)
   OP(*, *=)
   OP(/, /=)
+
+#undef OP
+
+// Operator ==, !=, <, >, <=, >=
+#define OP(op)                                                                 \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
+                                                const half &rhs) {             \
+    return lhs.Data op rhs.Data;                                               \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
+                                                const double &rhs) {           \
+    return lhs.Data op rhs;                                                    \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const double &lhs,             \
+                                                const half &rhs) {             \
+    return lhs op rhs.Data;                                                    \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
+                                                const float &rhs) {            \
+    return lhs.Data op rhs;                                                    \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const float &lhs,              \
+                                                const half &rhs) {             \
+    return lhs op rhs.Data;                                                    \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
+                                                const int &rhs) {              \
+    return lhs.Data op rhs;                                                    \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const int &lhs,                \
+                                                const half &rhs) {             \
+    return lhs op rhs.Data;                                                    \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
+                                                const long &rhs) {             \
+    return lhs.Data op rhs;                                                    \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const long &lhs,               \
+                                                const half &rhs) {             \
+    return lhs op rhs.Data;                                                    \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
+                                                const long long &rhs) {        \
+    return lhs.Data op rhs;                                                    \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const long long &lhs,          \
+                                                const half &rhs) {             \
+    return lhs op rhs.Data;                                                    \
+  }
+  OP(==)
+  OP(!=)
+  OP(<)
+  OP(>)
+  OP(<=)
+  OP(>=)
+
 #undef OP
 
   // Operator float

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -462,6 +462,42 @@ public:
     half rtn = rhs;                                                            \
     rtn op_eq lhs;                                                             \
     return rtn;                                                                \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
+                                                const unsigned int &rhs) {     \
+    half rtn = lhs;                                                            \
+    rtn op_eq rhs;                                                             \
+    return rtn;                                                                \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const unsigned int &lhs,       \
+                                                const half &rhs) {             \
+    half rtn = rhs;                                                            \
+    rtn op_eq lhs;                                                             \
+    return rtn;                                                                \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
+                                                const unsigned long &rhs) {    \
+    half rtn = lhs;                                                            \
+    rtn op_eq rhs;                                                             \
+    return rtn;                                                                \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const unsigned long &lhs,               \
+                                                const half &rhs) {             \
+    half rtn = rhs;                                                            \
+    rtn op_eq lhs;                                                             \
+    return rtn;                                                                \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
+                                                const unsigned long long &rhs) {        \
+    half rtn = lhs;                                                            \
+    rtn op_eq rhs;                                                             \
+    return rtn;                                                                \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const unsigned long long &lhs,          \
+                                                const half &rhs) {             \
+    half rtn = rhs;                                                            \
+    rtn op_eq lhs;                                                             \
+    return rtn;                                                                \
   }
   OP(+, +=)
   OP(-, -=)
@@ -513,6 +549,30 @@ public:
     return lhs.Data op rhs;                                                    \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(const long long &lhs,          \
+                                                const half &rhs) {             \
+    return lhs op rhs.Data;                                                    \
+  }                                                                             \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
+                                                const unsigned int &rhs) {              \
+    return lhs.Data op rhs;                                                    \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const unsigned int &lhs,                \
+                                                const half &rhs) {             \
+    return lhs op rhs.Data;                                                    \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
+                                                const unsigned long &rhs) {             \
+    return lhs.Data op rhs;                                                    \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const unsigned long &lhs,               \
+                                                const half &rhs) {             \
+    return lhs op rhs.Data;                                                    \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
+                                                const unsigned long long &rhs) {        \
+    return lhs.Data op rhs;                                                    \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const unsigned long long &lhs,          \
                                                 const half &rhs) {             \
     return lhs op rhs.Data;                                                    \
   }

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -396,71 +396,71 @@ public:
   }
 
 // Operator +, -, *, /
-#define OP(op, op1)                                                            \
+#define OP(op, op_eq)                                                          \
   __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
                                                 const half &rhs) {             \
     half rtn = lhs;                                                            \
-    rtn op1 rhs;                                                               \
+    rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend double operator op(const half &lhs,             \
                                                   const double &rhs) {         \
     double rtn = lhs;                                                          \
-    rtn op1 rhs;                                                               \
+    rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend double operator op(const double &lhs,           \
                                                   const half &rhs) {           \
     double rtn = rhs;                                                          \
-    rtn op1 lhs;                                                               \
+    rtn op_eq lhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend float operator op(const half &lhs,              \
                                                  const float &rhs) {           \
     float rtn = lhs;                                                           \
-    rtn op1 rhs;                                                               \
+    rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend float operator op(const float &lhs,             \
                                                  const half &rhs) {            \
     float rtn = rhs;                                                           \
-    rtn op1 lhs;                                                               \
+    rtn op_eq lhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
                                                 const int &rhs) {              \
     half rtn = lhs;                                                            \
-    rtn op1 rhs;                                                               \
+    rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend half operator op(const int &lhs,                \
                                                 const half &rhs) {             \
     half rtn = rhs;                                                            \
-    rtn op1 lhs;                                                               \
+    rtn op_eq lhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
                                                 const long &rhs) {             \
     half rtn = lhs;                                                            \
-    rtn op1 rhs;                                                               \
+    rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend half operator op(const long &lhs,               \
                                                 const half &rhs) {             \
     half rtn = rhs;                                                            \
-    rtn op1 lhs;                                                               \
+    rtn op_eq lhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
                                                 const long long &rhs) {        \
     half rtn = lhs;                                                            \
-    rtn op1 rhs;                                                               \
+    rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend half operator op(const long long &lhs,          \
                                                 const half &rhs) {             \
     half rtn = rhs;                                                            \
-    rtn op1 lhs;                                                               \
+    rtn op_eq lhs;                                                             \
     return rtn;                                                                \
   }
   OP(+, +=)

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -403,17 +403,61 @@ public:
     rtn op1 rhs;                                                               \
     return rtn;                                                                \
   }                                                                            \
-  template <typename T,                                                        \
-            typename = std::enable_if_t<std::is_arithmetic<T>::value>>         \
+  __SYCL_CONSTEXPR_HALF friend double operator op(const half &lhs,             \
+                                                  const double &rhs) {         \
+    double rtn = lhs;                                                          \
+    rtn op1 rhs;                                                               \
+    return rtn;                                                                \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend double operator op(const double &lhs,           \
+                                                  const half &rhs) {           \
+    double rtn = rhs;                                                          \
+    rtn op1 lhs;                                                               \
+    return rtn;                                                                \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend float operator op(const half &lhs,              \
+                                                 const float &rhs) {           \
+    float rtn = lhs;                                                           \
+    rtn op1 rhs;                                                               \
+    return rtn;                                                                \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend float operator op(const float &lhs,             \
+                                                 const half &rhs) {            \
+    float rtn = rhs;                                                           \
+    rtn op1 lhs;                                                               \
+    return rtn;                                                                \
+  }                                                                            \
   __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
-                                                const T &rhs) {                \
+                                                const int &rhs) {              \
     half rtn = lhs;                                                            \
     rtn op1 rhs;                                                               \
     return rtn;                                                                \
   }                                                                            \
-  template <typename T,                                                        \
-            typename = std::enable_if_t<std::is_arithmetic<T>::value>>         \
-  __SYCL_CONSTEXPR_HALF friend half operator op(const T &lhs,                  \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const int &lhs,                \
+                                                const half &rhs) {             \
+    half rtn = rhs;                                                            \
+    rtn op1 lhs;                                                               \
+    return rtn;                                                                \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
+                                                const long &rhs) {             \
+    half rtn = lhs;                                                            \
+    rtn op1 rhs;                                                               \
+    return rtn;                                                                \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const long &lhs,               \
+                                                const half &rhs) {             \
+    half rtn = rhs;                                                            \
+    rtn op1 lhs;                                                               \
+    return rtn;                                                                \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
+                                                const long long &rhs) {        \
+    half rtn = lhs;                                                            \
+    rtn op1 rhs;                                                               \
+    return rtn;                                                                \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const long long &lhs,          \
                                                 const half &rhs) {             \
     half rtn = rhs;                                                            \
     rtn op1 lhs;                                                               \

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -386,81 +386,76 @@ public:
     operator--();
     return ret;
   }
-  constexpr half &operator-() {
-    Data = -Data;
-    return *this;
-  }
-  constexpr half operator-() const {
-    half r = *this;
-    return -r;
+  __SYCL_CONSTEXPR_HALF friend half operator-(const half other) {
+    return half(-other.Data);
   }
 
 // Operator +, -, *, /
 #define OP(op, op_eq)                                                          \
-  __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
-                                                const half &rhs) {             \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const half lhs,                \
+                                                const half rhs) {              \
     half rtn = lhs;                                                            \
     rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
-  __SYCL_CONSTEXPR_HALF friend double operator op(const half &lhs,             \
-                                                  const double &rhs) {         \
+  __SYCL_CONSTEXPR_HALF friend double operator op(const half lhs,              \
+                                                  const double rhs) {          \
     double rtn = lhs;                                                          \
     rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
-  __SYCL_CONSTEXPR_HALF friend double operator op(const double &lhs,           \
-                                                  const half &rhs) {           \
-    double rtn = rhs;                                                          \
-    rtn op_eq lhs;                                                             \
+  __SYCL_CONSTEXPR_HALF friend double operator op(const double lhs,            \
+                                                  const half rhs) {            \
+    double rtn = lhs;                                                          \
+    rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
-  __SYCL_CONSTEXPR_HALF friend float operator op(const half &lhs,              \
-                                                 const float &rhs) {           \
+  __SYCL_CONSTEXPR_HALF friend float operator op(const half lhs,               \
+                                                 const float rhs) {            \
     float rtn = lhs;                                                           \
     rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
-  __SYCL_CONSTEXPR_HALF friend float operator op(const float &lhs,             \
-                                                 const half &rhs) {            \
-    float rtn = rhs;                                                           \
-    rtn op_eq lhs;                                                             \
+  __SYCL_CONSTEXPR_HALF friend float operator op(const float lhs,              \
+                                                 const half rhs) {             \
+    float rtn = lhs;                                                           \
+    rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
-  __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
-                                                const int &rhs) {              \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const half lhs,                \
+                                                const int rhs) {               \
     half rtn = lhs;                                                            \
     rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
-  __SYCL_CONSTEXPR_HALF friend half operator op(const int &lhs,                \
-                                                const half &rhs) {             \
-    half rtn = rhs;                                                            \
-    rtn op_eq lhs;                                                             \
-    return rtn;                                                                \
-  }                                                                            \
-  __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
-                                                const long &rhs) {             \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const int lhs,                 \
+                                                const half rhs) {              \
     half rtn = lhs;                                                            \
     rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
-  __SYCL_CONSTEXPR_HALF friend half operator op(const long &lhs,               \
-                                                const half &rhs) {             \
-    half rtn = rhs;                                                            \
-    rtn op_eq lhs;                                                             \
-    return rtn;                                                                \
-  }                                                                            \
-  __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
-                                                const long long &rhs) {        \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const half lhs,                \
+                                                const long rhs) {              \
     half rtn = lhs;                                                            \
     rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
-  __SYCL_CONSTEXPR_HALF friend half operator op(const long long &lhs,          \
-                                                const half &rhs) {             \
-    half rtn = rhs;                                                            \
-    rtn op_eq lhs;                                                             \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const long lhs,                \
+                                                const half rhs) {              \
+    half rtn = lhs;                                                            \
+    rtn op_eq rhs;                                                             \
+    return rtn;                                                                \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const half lhs,                \
+                                                const long long rhs) {         \
+    half rtn = lhs;                                                            \
+    rtn op_eq rhs;                                                             \
+    return rtn;                                                                \
+  }                                                                            \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const long long lhs,           \
+                                                const half rhs) {              \
+    half rtn = lhs;                                                            \
+    rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
@@ -471,8 +466,8 @@ public:
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend half operator op(const unsigned int &lhs,       \
                                                 const half &rhs) {             \
-    half rtn = rhs;                                                            \
-    rtn op_eq lhs;                                                             \
+    half rtn = lhs;                                                            \
+    rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
@@ -483,8 +478,8 @@ public:
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend half operator op(const unsigned long &lhs,      \
                                                 const half &rhs) {             \
-    half rtn = rhs;                                                            \
-    rtn op_eq lhs;                                                             \
+    half rtn = lhs;                                                            \
+    rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend half operator op(                               \
@@ -495,8 +490,8 @@ public:
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend half operator op(const unsigned long long &lhs, \
                                                 const half &rhs) {             \
-    half rtn = rhs;                                                            \
-    rtn op_eq lhs;                                                             \
+    half rtn = lhs;                                                            \
+    rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }
   OP(+, +=)

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -394,6 +394,34 @@ public:
     half r = *this;
     return -r;
   }
+
+// Operator +, -, *, /
+#define OP(op, op1)                                                            \
+  friend half operator op(const half &lhs, const half &rhs) {                  \
+    half rtn = lhs;                                                            \
+    rtn op1 rhs;                                                               \
+    return rtn;                                                                \
+  }                                                                            \
+  template <typename T,                                                        \
+            typename = std::enable_if_t<std::is_arithmetic<T>::value>>         \
+  friend half operator op(const half &lhs, const T &rhs) {                     \
+    half rtn = lhs;                                                            \
+    rtn op1 rhs;                                                               \
+    return rtn;                                                                \
+  }                                                                            \
+  template <typename T,                                                        \
+            typename = std::enable_if_t<std::is_arithmetic<T>::value>>         \
+  friend half operator op(const T &lhs, const half &rhs) {                     \
+    half rtn = rhs;                                                            \
+    rtn op1 lhs;                                                               \
+    return rtn;                                                                \
+  }
+  OP(+, +=)
+  OP(-, -=)
+  OP(*, *=)
+  OP(/, /=)
+#undef OP
+
   // Operator float
   __SYCL_CONSTEXPR_HALF operator float() const {
     return static_cast<float>(Data);

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -481,19 +481,19 @@ public:
     rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
-  __SYCL_CONSTEXPR_HALF friend half operator op(const unsigned long &lhs,               \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const unsigned long &lhs,      \
                                                 const half &rhs) {             \
     half rtn = rhs;                                                            \
     rtn op_eq lhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
-  __SYCL_CONSTEXPR_HALF friend half operator op(const half &lhs,               \
-                                                const unsigned long long &rhs) {        \
+  __SYCL_CONSTEXPR_HALF friend half operator op(                               \
+      const half &lhs, const unsigned long long &rhs) {                        \
     half rtn = lhs;                                                            \
     rtn op_eq rhs;                                                             \
     return rtn;                                                                \
   }                                                                            \
-  __SYCL_CONSTEXPR_HALF friend half operator op(const unsigned long long &lhs,          \
+  __SYCL_CONSTEXPR_HALF friend half operator op(const unsigned long long &lhs, \
                                                 const half &rhs) {             \
     half rtn = rhs;                                                            \
     rtn op_eq lhs;                                                             \
@@ -551,28 +551,28 @@ public:
   __SYCL_CONSTEXPR_HALF friend bool operator op(const long long &lhs,          \
                                                 const half &rhs) {             \
     return lhs op rhs.Data;                                                    \
-  }                                                                             \
+  }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
-                                                const unsigned int &rhs) {              \
+                                                const unsigned int &rhs) {     \
     return lhs.Data op rhs;                                                    \
   }                                                                            \
-  __SYCL_CONSTEXPR_HALF friend bool operator op(const unsigned int &lhs,                \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const unsigned int &lhs,       \
                                                 const half &rhs) {             \
     return lhs op rhs.Data;                                                    \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
-                                                const unsigned long &rhs) {             \
+                                                const unsigned long &rhs) {    \
     return lhs.Data op rhs;                                                    \
   }                                                                            \
-  __SYCL_CONSTEXPR_HALF friend bool operator op(const unsigned long &lhs,               \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const unsigned long &lhs,      \
                                                 const half &rhs) {             \
     return lhs op rhs.Data;                                                    \
   }                                                                            \
-  __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
-                                                const unsigned long long &rhs) {        \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(                               \
+      const half &lhs, const unsigned long long &rhs) {                        \
     return lhs.Data op rhs;                                                    \
   }                                                                            \
-  __SYCL_CONSTEXPR_HALF friend bool operator op(const unsigned long long &lhs,          \
+  __SYCL_CONSTEXPR_HALF friend bool operator op(const unsigned long long &lhs, \
                                                 const half &rhs) {             \
     return lhs op rhs.Data;                                                    \
   }

--- a/sycl/source/detail/builtins_math.cpp
+++ b/sycl/source/detail/builtins_math.cpp
@@ -42,7 +42,7 @@ template <typename T> inline T __cospi(T x) { return std::cos(M_PI * x); }
 template <typename T> T inline __fract(T x, T *iptr) {
   T f = std::floor(x);
   *(iptr) = f;
-  return std::fmin(x - f, nextafter(T(1.0), T(0.0)));
+  return std::fmin(x - f, std::nextafter(T(1.0), T(0.0)));
 }
 
 template <typename T> inline T __lgamma_r(T x, s::cl_int *signp) {

--- a/sycl/test/type_traits/half_operator_types.cpp
+++ b/sycl/test/type_traits/half_operator_types.cpp
@@ -9,25 +9,46 @@
 
 #include <CL/sycl.hpp>
 
-template <typename T1, typename T2, typename T_rtn>
-void check_half_operator_types() {
-  static_assert(std::is_same<decltype(T1(1) + T2(1)), T_rtn>::value);
-  static_assert(std::is_same<decltype(T1(1) - T2(1)), T_rtn>::value);
-  static_assert(std::is_same<decltype(T1(1) * T2(1)), T_rtn>::value);
-  static_assert(std::is_same<decltype(T1(1) / T2(1)), T_rtn>::value);
+template <typename T1, typename T_rtn> void check_half_math_operator_types() {
+  static_assert(std::is_same<decltype(T1(1) + sycl::half(1)), T_rtn>::value);
+  static_assert(std::is_same<decltype(T1(1) - sycl::half(1)), T_rtn>::value);
+  static_assert(std::is_same<decltype(T1(1) * sycl::half(1)), T_rtn>::value);
+  static_assert(std::is_same<decltype(T1(1) / sycl::half(1)), T_rtn>::value);
+
+  static_assert(std::is_same<decltype(sycl::half(1) + T1(1)), T_rtn>::value);
+  static_assert(std::is_same<decltype(sycl::half(1) - T1(1)), T_rtn>::value);
+  static_assert(std::is_same<decltype(sycl::half(1) * T1(1)), T_rtn>::value);
+  static_assert(std::is_same<decltype(sycl::half(1) / T1(1)), T_rtn>::value);
+}
+
+template <typename T1> void check_half_logical_operator_types() {
+  static_assert(std::is_same<decltype(T1(1) == sycl::half(1)), bool>::value);
+  static_assert(std::is_same<decltype(T1(1) != sycl::half(1)), bool>::value);
+  static_assert(std::is_same<decltype(T1(1) > sycl::half(1)), bool>::value);
+  static_assert(std::is_same<decltype(T1(1) < sycl::half(1)), bool>::value);
+  static_assert(std::is_same<decltype(T1(1) <= sycl::half(1)), bool>::value);
+  static_assert(std::is_same<decltype(T1(1) <= sycl::half(1)), bool>::value);
+
+  static_assert(std::is_same<decltype(sycl::half(1) == T1(1)), bool>::value);
+  static_assert(std::is_same<decltype(sycl::half(1) != T1(1)), bool>::value);
+  static_assert(std::is_same<decltype(sycl::half(1) > T1(1)), bool>::value);
+  static_assert(std::is_same<decltype(sycl::half(1) < T1(1)), bool>::value);
+  static_assert(std::is_same<decltype(sycl::half(1) <= T1(1)), bool>::value);
+  static_assert(std::is_same<decltype(sycl::half(1) <= T1(1)), bool>::value);
 }
 
 int main() {
-  check_half_operator_types<sycl::half, sycl::half, sycl::half>();
-  check_half_operator_types<double, sycl::half, double>();
-  check_half_operator_types<sycl::half, double, double>();
-  check_half_operator_types<float, sycl::half, float>();
-  check_half_operator_types<sycl::half, float, float>();
+  check_half_math_operator_types<sycl::half, sycl::half>();
+  check_half_math_operator_types<double, double>();
+  check_half_math_operator_types<float, float>();
+  check_half_math_operator_types<int, sycl::half>();
+  check_half_math_operator_types<long, sycl::half>();
+  check_half_math_operator_types<long long, sycl::half>();
 
-  check_half_operator_types<int, sycl::half, sycl::half>();
-  check_half_operator_types<sycl::half, int, sycl::half>();
-  check_half_operator_types<long, sycl::half, sycl::half>();
-  check_half_operator_types<sycl::half, long, sycl::half>();
-  check_half_operator_types<long long, sycl::half, sycl::half>();
-  check_half_operator_types<sycl::half, long long, sycl::half>();
+  check_half_logical_operator_types<sycl::half>();
+  check_half_logical_operator_types<double>();
+  check_half_logical_operator_types<float>();
+  check_half_logical_operator_types<int>();
+  check_half_logical_operator_types<long>();
+  check_half_logical_operator_types<long long>();
 }

--- a/sycl/test/type_traits/half_operator_types.cpp
+++ b/sycl/test/type_traits/half_operator_types.cpp
@@ -1,0 +1,33 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+//==-------------- type_traits.cpp - SYCL type_traits test -----------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+
+template <typename T1, typename T2, typename T_rtn>
+void check_half_operator_types() {
+  static_assert(std::is_same<decltype(T1(1) + T2(1)), T_rtn>::value);
+  static_assert(std::is_same<decltype(T1(1) - T2(1)), T_rtn>::value);
+  static_assert(std::is_same<decltype(T1(1) * T2(1)), T_rtn>::value);
+  static_assert(std::is_same<decltype(T1(1) / T2(1)), T_rtn>::value);
+}
+
+int main() {
+  check_half_operator_types<sycl::half, sycl::half, sycl::half>();
+  check_half_operator_types<double, sycl::half, double>();
+  check_half_operator_types<sycl::half, double, double>();
+  check_half_operator_types<float, sycl::half, float>();
+  check_half_operator_types<sycl::half, float, float>();
+
+  check_half_operator_types<int, sycl::half, sycl::half>();
+  check_half_operator_types<sycl::half, int, sycl::half>();
+  check_half_operator_types<long, sycl::half, sycl::half>();
+  check_half_operator_types<sycl::half, long, sycl::half>();
+  check_half_operator_types<long long, sycl::half, sycl::half>();
+  check_half_operator_types<sycl::half, long long, sycl::half>();
+}

--- a/sycl/test/type_traits/half_operator_types.cpp
+++ b/sycl/test/type_traits/half_operator_types.cpp
@@ -8,72 +8,77 @@
 //===----------------------------------------------------------------------===//
 
 #include <CL/sycl.hpp>
+using namespace std;
+
+template <typename T1, typename T_rtn> void math_operator_helper() {
+  static_assert(
+      is_same_v<decltype(declval<T1>() + declval<sycl::half>()), T_rtn>);
+  static_assert(
+      is_same_v<decltype(declval<T1>() - declval<sycl::half>()), T_rtn>);
+  static_assert(
+      is_same_v<decltype(declval<T1>() * declval<sycl::half>()), T_rtn>);
+  static_assert(
+      is_same_v<decltype(declval<T1>() / declval<sycl::half>()), T_rtn>);
+
+  static_assert(
+      is_same_v<decltype(declval<sycl::half>() + declval<T1>()), T_rtn>);
+  static_assert(
+      is_same_v<decltype(declval<sycl::half>() - declval<T1>()), T_rtn>);
+  static_assert(
+      is_same_v<decltype(declval<sycl::half>() * declval<T1>()), T_rtn>);
+  static_assert(
+      is_same_v<decltype(declval<sycl::half>() / declval<T1>()), T_rtn>);
+}
+
+template <typename T1> void logical_operator_helper() {
+  static_assert(
+      is_same_v<decltype(declval<T1>() == declval<sycl::half>()), bool>);
+  static_assert(
+      is_same_v<decltype(declval<T1>() != declval<sycl::half>()), bool>);
+  static_assert(
+      is_same_v<decltype(declval<T1>() > declval<sycl::half>()), bool>);
+  static_assert(
+      is_same_v<decltype(declval<T1>() < declval<sycl::half>()), bool>);
+  static_assert(
+      is_same_v<decltype(declval<T1>() <= declval<sycl::half>()), bool>);
+  static_assert(
+      is_same_v<decltype(declval<T1>() >= declval<sycl::half>()), bool>);
+
+  static_assert(
+      is_same_v<decltype(declval<sycl::half>() == declval<T1>()), bool>);
+  static_assert(
+      is_same_v<decltype(declval<sycl::half>() != declval<T1>()), bool>);
+  static_assert(
+      is_same_v<decltype(declval<sycl::half>() > declval<T1>()), bool>);
+  static_assert(
+      is_same_v<decltype(declval<sycl::half>() < declval<T1>()), bool>);
+  static_assert(
+      is_same_v<decltype(declval<sycl::half>() <= declval<T1>()), bool>);
+  static_assert(
+      is_same_v<decltype(declval<sycl::half>() >= declval<T1>()), bool>);
+}
 
 template <typename T1, typename T_rtn>
-void check_half_math_operator_types(sycl::queue Queue) {
+void check_half_math_operator_types(sycl::queue &Queue) {
 
   // Test on host
-  static_assert(std::is_same_v<decltype(T1(1) + sycl::half(1)), T_rtn>);
-  static_assert(std::is_same_v<decltype(T1(1) - sycl::half(1)), T_rtn>);
-  static_assert(std::is_same_v<decltype(T1(1) * sycl::half(1)), T_rtn>);
-  static_assert(std::is_same_v<decltype(T1(1) / sycl::half(1)), T_rtn>);
-
-  static_assert(std::is_same_v<decltype(sycl::half(1) + T1(1)), T_rtn>);
-  static_assert(std::is_same_v<decltype(sycl::half(1) - T1(1)), T_rtn>);
-  static_assert(std::is_same_v<decltype(sycl::half(1) * T1(1)), T_rtn>);
-  static_assert(std::is_same_v<decltype(sycl::half(1) / T1(1)), T_rtn>);
+  math_operator_helper<T1, T_rtn>();
 
   // Test on device
   Queue.submit([&](sycl::handler &cgh) {
-    cgh.single_task([=] {
-      static_assert(std::is_same_v<decltype(T1(1) + sycl::half(1)), T_rtn>);
-      static_assert(std::is_same_v<decltype(T1(1) - sycl::half(1)), T_rtn>);
-      static_assert(std::is_same_v<decltype(T1(1) * sycl::half(1)), T_rtn>);
-      static_assert(std::is_same_v<decltype(T1(1) / sycl::half(1)), T_rtn>);
-
-      static_assert(std::is_same_v<decltype(sycl::half(1) + T1(1)), T_rtn>);
-      static_assert(std::is_same_v<decltype(sycl::half(1) - T1(1)), T_rtn>);
-      static_assert(std::is_same_v<decltype(sycl::half(1) * T1(1)), T_rtn>);
-      static_assert(std::is_same_v<decltype(sycl::half(1) / T1(1)), T_rtn>);
-    });
+    cgh.single_task([=] { math_operator_helper<T1, T_rtn>(); });
   });
 }
 
 template <typename T1>
-void check_half_logical_operator_types(sycl::queue Queue) {
+void check_half_logical_operator_types(sycl::queue &Queue) {
 
   // Test on host
-  static_assert(std::is_same_v<decltype(T1(1) == sycl::half(1)), bool>);
-  static_assert(std::is_same_v<decltype(T1(1) != sycl::half(1)), bool>);
-  static_assert(std::is_same_v<decltype(T1(1) > sycl::half(1)), bool>);
-  static_assert(std::is_same_v<decltype(T1(1) < sycl::half(1)), bool>);
-  static_assert(std::is_same_v<decltype(T1(1) <= sycl::half(1)), bool>);
-  static_assert(std::is_same_v<decltype(T1(1) <= sycl::half(1)), bool>);
-
-  static_assert(std::is_same_v<decltype(sycl::half(1) == T1(1)), bool>);
-  static_assert(std::is_same_v<decltype(sycl::half(1) != T1(1)), bool>);
-  static_assert(std::is_same_v<decltype(sycl::half(1) > T1(1)), bool>);
-  static_assert(std::is_same_v<decltype(sycl::half(1) < T1(1)), bool>);
-  static_assert(std::is_same_v<decltype(sycl::half(1) <= T1(1)), bool>);
-  static_assert(std::is_same_v<decltype(sycl::half(1) <= T1(1)), bool>);
+  logical_operator_helper<T1>();
 
   // Test on device
   Queue.submit([&](sycl::handler &cgh) {
-    cgh.single_task([=] {
-      static_assert(std::is_same_v<decltype(T1(1) == sycl::half(1)), bool>);
-      static_assert(std::is_same_v<decltype(T1(1) != sycl::half(1)), bool>);
-      static_assert(std::is_same_v<decltype(T1(1) > sycl::half(1)), bool>);
-      static_assert(std::is_same_v<decltype(T1(1) < sycl::half(1)), bool>);
-      static_assert(std::is_same_v<decltype(T1(1) <= sycl::half(1)), bool>);
-      static_assert(std::is_same_v<decltype(T1(1) <= sycl::half(1)), bool>);
-
-      static_assert(std::is_same_v<decltype(sycl::half(1) == T1(1)), bool>);
-      static_assert(std::is_same_v<decltype(sycl::half(1) != T1(1)), bool>);
-      static_assert(std::is_same_v<decltype(sycl::half(1) > T1(1)), bool>);
-      static_assert(std::is_same_v<decltype(sycl::half(1) < T1(1)), bool>);
-      static_assert(std::is_same_v<decltype(sycl::half(1) <= T1(1)), bool>);
-      static_assert(std::is_same_v<decltype(sycl::half(1) <= T1(1)), bool>);
-    });
+    cgh.single_task([=] { logical_operator_helper<T1>(); });
   });
 }
 

--- a/sycl/test/type_traits/half_operator_types.cpp
+++ b/sycl/test/type_traits/half_operator_types.cpp
@@ -9,46 +9,89 @@
 
 #include <CL/sycl.hpp>
 
-template <typename T1, typename T_rtn> void check_half_math_operator_types() {
-  static_assert(std::is_same<decltype(T1(1) + sycl::half(1)), T_rtn>::value);
-  static_assert(std::is_same<decltype(T1(1) - sycl::half(1)), T_rtn>::value);
-  static_assert(std::is_same<decltype(T1(1) * sycl::half(1)), T_rtn>::value);
-  static_assert(std::is_same<decltype(T1(1) / sycl::half(1)), T_rtn>::value);
+template <typename T1, typename T_rtn>
+void check_half_math_operator_types(sycl::queue Queue) {
 
-  static_assert(std::is_same<decltype(sycl::half(1) + T1(1)), T_rtn>::value);
-  static_assert(std::is_same<decltype(sycl::half(1) - T1(1)), T_rtn>::value);
-  static_assert(std::is_same<decltype(sycl::half(1) * T1(1)), T_rtn>::value);
-  static_assert(std::is_same<decltype(sycl::half(1) / T1(1)), T_rtn>::value);
+  // Test on host
+  static_assert(std::is_same_v<decltype(T1(1) + sycl::half(1)), T_rtn>);
+  static_assert(std::is_same_v<decltype(T1(1) - sycl::half(1)), T_rtn>);
+  static_assert(std::is_same_v<decltype(T1(1) * sycl::half(1)), T_rtn>);
+  static_assert(std::is_same_v<decltype(T1(1) / sycl::half(1)), T_rtn>);
+
+  static_assert(std::is_same_v<decltype(sycl::half(1) + T1(1)), T_rtn>);
+  static_assert(std::is_same_v<decltype(sycl::half(1) - T1(1)), T_rtn>);
+  static_assert(std::is_same_v<decltype(sycl::half(1) * T1(1)), T_rtn>);
+  static_assert(std::is_same_v<decltype(sycl::half(1) / T1(1)), T_rtn>);
+
+  // Test on device
+  Queue.submit([&](sycl::handler &cgh) {
+    cgh.single_task([=] {
+      static_assert(std::is_same_v<decltype(T1(1) + sycl::half(1)), T_rtn>);
+      static_assert(std::is_same_v<decltype(T1(1) - sycl::half(1)), T_rtn>);
+      static_assert(std::is_same_v<decltype(T1(1) * sycl::half(1)), T_rtn>);
+      static_assert(std::is_same_v<decltype(T1(1) / sycl::half(1)), T_rtn>);
+
+      static_assert(std::is_same_v<decltype(sycl::half(1) + T1(1)), T_rtn>);
+      static_assert(std::is_same_v<decltype(sycl::half(1) - T1(1)), T_rtn>);
+      static_assert(std::is_same_v<decltype(sycl::half(1) * T1(1)), T_rtn>);
+      static_assert(std::is_same_v<decltype(sycl::half(1) / T1(1)), T_rtn>);
+    });
+  });
 }
 
-template <typename T1> void check_half_logical_operator_types() {
-  static_assert(std::is_same<decltype(T1(1) == sycl::half(1)), bool>::value);
-  static_assert(std::is_same<decltype(T1(1) != sycl::half(1)), bool>::value);
-  static_assert(std::is_same<decltype(T1(1) > sycl::half(1)), bool>::value);
-  static_assert(std::is_same<decltype(T1(1) < sycl::half(1)), bool>::value);
-  static_assert(std::is_same<decltype(T1(1) <= sycl::half(1)), bool>::value);
-  static_assert(std::is_same<decltype(T1(1) <= sycl::half(1)), bool>::value);
+template <typename T1>
+void check_half_logical_operator_types(sycl::queue Queue) {
 
-  static_assert(std::is_same<decltype(sycl::half(1) == T1(1)), bool>::value);
-  static_assert(std::is_same<decltype(sycl::half(1) != T1(1)), bool>::value);
-  static_assert(std::is_same<decltype(sycl::half(1) > T1(1)), bool>::value);
-  static_assert(std::is_same<decltype(sycl::half(1) < T1(1)), bool>::value);
-  static_assert(std::is_same<decltype(sycl::half(1) <= T1(1)), bool>::value);
-  static_assert(std::is_same<decltype(sycl::half(1) <= T1(1)), bool>::value);
+  // Test on host
+  static_assert(std::is_same_v<decltype(T1(1) == sycl::half(1)), bool>);
+  static_assert(std::is_same_v<decltype(T1(1) != sycl::half(1)), bool>);
+  static_assert(std::is_same_v<decltype(T1(1) > sycl::half(1)), bool>);
+  static_assert(std::is_same_v<decltype(T1(1) < sycl::half(1)), bool>);
+  static_assert(std::is_same_v<decltype(T1(1) <= sycl::half(1)), bool>);
+  static_assert(std::is_same_v<decltype(T1(1) <= sycl::half(1)), bool>);
+
+  static_assert(std::is_same_v<decltype(sycl::half(1) == T1(1)), bool>);
+  static_assert(std::is_same_v<decltype(sycl::half(1) != T1(1)), bool>);
+  static_assert(std::is_same_v<decltype(sycl::half(1) > T1(1)), bool>);
+  static_assert(std::is_same_v<decltype(sycl::half(1) < T1(1)), bool>);
+  static_assert(std::is_same_v<decltype(sycl::half(1) <= T1(1)), bool>);
+  static_assert(std::is_same_v<decltype(sycl::half(1) <= T1(1)), bool>);
+
+  // Test on device
+  Queue.submit([&](sycl::handler &cgh) {
+    cgh.single_task([=] {
+      static_assert(std::is_same_v<decltype(T1(1) == sycl::half(1)), bool>);
+      static_assert(std::is_same_v<decltype(T1(1) != sycl::half(1)), bool>);
+      static_assert(std::is_same_v<decltype(T1(1) > sycl::half(1)), bool>);
+      static_assert(std::is_same_v<decltype(T1(1) < sycl::half(1)), bool>);
+      static_assert(std::is_same_v<decltype(T1(1) <= sycl::half(1)), bool>);
+      static_assert(std::is_same_v<decltype(T1(1) <= sycl::half(1)), bool>);
+
+      static_assert(std::is_same_v<decltype(sycl::half(1) == T1(1)), bool>);
+      static_assert(std::is_same_v<decltype(sycl::half(1) != T1(1)), bool>);
+      static_assert(std::is_same_v<decltype(sycl::half(1) > T1(1)), bool>);
+      static_assert(std::is_same_v<decltype(sycl::half(1) < T1(1)), bool>);
+      static_assert(std::is_same_v<decltype(sycl::half(1) <= T1(1)), bool>);
+      static_assert(std::is_same_v<decltype(sycl::half(1) <= T1(1)), bool>);
+    });
+  });
 }
 
 int main() {
-  check_half_math_operator_types<sycl::half, sycl::half>();
-  check_half_math_operator_types<double, double>();
-  check_half_math_operator_types<float, float>();
-  check_half_math_operator_types<int, sycl::half>();
-  check_half_math_operator_types<long, sycl::half>();
-  check_half_math_operator_types<long long, sycl::half>();
 
-  check_half_logical_operator_types<sycl::half>();
-  check_half_logical_operator_types<double>();
-  check_half_logical_operator_types<float>();
-  check_half_logical_operator_types<int>();
-  check_half_logical_operator_types<long>();
-  check_half_logical_operator_types<long long>();
+  sycl::queue Queue;
+
+  check_half_math_operator_types<sycl::half, sycl::half>(Queue);
+  check_half_math_operator_types<double, double>(Queue);
+  check_half_math_operator_types<float, float>(Queue);
+  check_half_math_operator_types<int, sycl::half>(Queue);
+  check_half_math_operator_types<long, sycl::half>(Queue);
+  check_half_math_operator_types<long long, sycl::half>(Queue);
+
+  check_half_logical_operator_types<sycl::half>(Queue);
+  check_half_logical_operator_types<double>(Queue);
+  check_half_logical_operator_types<float>(Queue);
+  check_half_logical_operator_types<int>(Queue);
+  check_half_logical_operator_types<long>(Queue);
+  check_half_logical_operator_types<long long>(Queue);
 }


### PR DESCRIPTION
This PR adds missing half operations +-*/. 

There are existing operations for the legacy class host_half_impl, however these were not extended to the half class. These operations were being performed as floating point operations via the implicit floating conversion. This results in the output being a float not half type.

The template is limited to arithmetic types to prevent ambiguous templating.
A minor change to built-in `__fract` is needed to ensure fmin is not ambiguous.

llvm-test-suite PR: https://github.com/intel/llvm-test-suite/pull/1012
Fixes: #6028