### PR TITLE
[SYCL] Fix enabling of persistent device code cache in unit-tests

### DIFF
--- a/sycl/source/detail/persistent_device_code_cache.cpp
+++ b/sycl/source/detail/persistent_device_code_cache.cpp
@@ -6,11 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cstdio>
 #include <detail/device_impl.hpp>
 #include <detail/persistent_device_code_cache.hpp>
 #include <detail/plugin.hpp>
 #include <detail/program_manager/program_manager.hpp>
+
+#include <cstdio>
+#include <optional>
 
 #if defined(__SYCL_RT_OS_LINUX)
 #include <unistd.h>

--- a/sycl/source/detail/persistent_device_code_cache.cpp
+++ b/sycl/source/detail/persistent_device_code_cache.cpp
@@ -379,11 +379,28 @@ static bool parsePersistentCacheConfig() {
   return Ret;
 }
 
+/* Cached static variable signalling if the persistent cache is enabled.
+ * The variable can have three values:
+ *  - None  : The configuration has not been parsed.
+ *  - true  : The persistent cache is enabled.
+ *  - false : The persistent cache is disabled.
+ */
+static std::optional<bool> CacheIsEnabled;
+
+/* Forces a reparsing of the information used to determine if the persistent
+ * cache is enabled. This is primarily used for unit-testing where the
+ * corresponding configuration variable is set by the individual tests.
+ */
+void PersistentDeviceCodeCache::reparseConfig() {
+  CacheIsEnabled = parsePersistentCacheConfig();
+}
+
 /* Returns true if persistent cache is enabled.
  */
 bool PersistentDeviceCodeCache::isEnabled() {
-  static bool Val = parsePersistentCacheConfig();
-  return Val;
+  if (!CacheIsEnabled)
+    reparseConfig();
+  return *CacheIsEnabled;
 }
 
 /* Returns path for device code cache root directory

--- a/sycl/source/detail/persistent_device_code_cache.hpp
+++ b/sycl/source/detail/persistent_device_code_cache.hpp
@@ -184,6 +184,12 @@ public:
                             const std::string &BuildOptionsString,
                             const RT::PiProgram &NativePrg);
 
+  /* Forces a reparsing of the information used to determine if the persistent
+   * cache is enabled. This is primarily used for unit-testing where the
+   * corresponding configuration variable is set by the individual tests.
+   */
+  static void reparseConfig();
+
   /* Sends message to std:cerr stream when SYCL_CACHE_TRACE environemnt is set*/
   static void trace(const std::string &msg) {
     static const char *TraceEnabled = SYCLConfig<SYCL_CACHE_TRACE>::get();

--- a/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
+++ b/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
@@ -16,6 +16,7 @@
 #include <gtest/gtest.h>
 #include <helpers/PiMock.hpp>
 #include <llvm/Support/FileSystem.h>
+#include <optional>
 #include <vector>
 
 // TODO: Introduce common unit tests header and move it there


### PR DESCRIPTION
The persistent device code cache currently only parse the configurations indicating if it is enabled once, caching the result. This can cause unit-tests for the cache to fail as they may be run after other tests that may have populated the cached result. To fix this, the persistent code cache now exposes a new function forcing the configuration to be reparsed.

Additionally, the unit-tests will reset the SYCL_CACHE_PERSISTENT after each test case if it was set during.