### PR TITLE
[SYCL] Add checks on file-system operations in persistent cache unit-test

### DIFF
--- a/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
+++ b/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
@@ -121,7 +121,8 @@ public:
     std::string ItemDir = detail::PersistentDeviceCodeCache::getCacheItemPath(
         Dev, Img, {'S', 'p', 'e', 'c', 'C', 'o', 'n', 's', 't', ProgramID},
         BuildOptions);
-    llvm::sys::fs::remove_directories(ItemDir);
+    EXPECT_EQ(llvm::sys::fs::remove_directories(ItemDir), std::error_code{})
+        << "Failed to remove item directory";
 
     Barrier b(ThreadCount);
     {
@@ -147,7 +148,8 @@ public:
 
       ThreadPool MPool(ThreadCount, testLambda);
     }
-    llvm::sys::fs::remove_directories(ItemDir);
+    EXPECT_EQ(llvm::sys::fs::remove_directories(ItemDir), std::error_code{})
+        << "Failed to remove item directory";
   }
 
 protected:
@@ -188,7 +190,8 @@ TEST_F(PersistenDeviceCodeCache, KeysWithNullTermSymbol) {
   std::vector<unsigned char> SpecConst(Key.begin(), Key.end());
   std::string ItemDir = detail::PersistentDeviceCodeCache::getCacheItemPath(
       Dev, Img, SpecConst, Key);
-  llvm::sys::fs::remove_directories(ItemDir);
+  EXPECT_EQ(llvm::sys::fs::remove_directories(ItemDir), std::error_code{})
+      << "Failed to remove item directory";
 
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, SpecConst, Key,
                                                    NativeProg);
@@ -204,7 +207,8 @@ TEST_F(PersistenDeviceCodeCache, KeysWithNullTermSymbol) {
     }
   }
 
-  llvm::sys::fs::remove_directories(ItemDir);
+  EXPECT_EQ(llvm::sys::fs::remove_directories(ItemDir), std::error_code{})
+      << "Failed to remove item directory";
 }
 
 /* Do read/write for the same cache item to/from 300 threads for small device
@@ -246,7 +250,8 @@ TEST_F(PersistenDeviceCodeCache, CorruptedCacheFiles) {
   std::string BuildOptions{"--corrupted-file"};
   std::string ItemDir = detail::PersistentDeviceCodeCache::getCacheItemPath(
       Dev, Img, {}, BuildOptions);
-  llvm::sys::fs::remove_directories(ItemDir);
+  EXPECT_EQ(llvm::sys::fs::remove_directories(ItemDir), std::error_code{})
+      << "Failed to remove item directory";
 
   // Only source file is present
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
@@ -257,7 +262,8 @@ TEST_F(PersistenDeviceCodeCache, CorruptedCacheFiles) {
                                                                 BuildOptions);
   EXPECT_EQ(Res.size(), static_cast<size_t>(0))
       << "Item with missed binary file was read";
-  llvm::sys::fs::remove_directories(ItemDir);
+  EXPECT_EQ(llvm::sys::fs::remove_directories(ItemDir), std::error_code{})
+      << "Failed to remove item directory";
 
   // Only binary file is present
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
@@ -268,7 +274,8 @@ TEST_F(PersistenDeviceCodeCache, CorruptedCacheFiles) {
                                                            BuildOptions);
   EXPECT_EQ(Res.size(), static_cast<size_t>(0))
       << "Item with missed source file was read";
-  llvm::sys::fs::remove_directories(ItemDir);
+  EXPECT_EQ(llvm::sys::fs::remove_directories(ItemDir), std::error_code{})
+      << "Failed to remove item directory";
 
   // Binary file is corrupted
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
@@ -286,7 +293,8 @@ TEST_F(PersistenDeviceCodeCache, CorruptedCacheFiles) {
   EXPECT_EQ(Res.size(), static_cast<size_t>(0))
       << "Item with corrupted binary file was read";
 
-  llvm::sys::fs::remove_directories(ItemDir);
+  EXPECT_EQ(llvm::sys::fs::remove_directories(ItemDir), std::error_code{})
+      << "Failed to remove item directory";
 
   // Source file is empty
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
@@ -299,7 +307,8 @@ TEST_F(PersistenDeviceCodeCache, CorruptedCacheFiles) {
                                                            BuildOptions);
   EXPECT_EQ(Res.size(), static_cast<size_t>(0))
       << "Item with corrupted binary file was read";
-  llvm::sys::fs::remove_directories(ItemDir);
+  EXPECT_EQ(llvm::sys::fs::remove_directories(ItemDir), std::error_code{})
+      << "Failed to remove item directory";
 }
 
 /* Checks that lock file affects cache operations as expected:
@@ -317,7 +326,8 @@ TEST_F(PersistenDeviceCodeCache, LockFile) {
   std::string BuildOptions{"--obsolete-lock"};
   std::string ItemDir = detail::PersistentDeviceCodeCache::getCacheItemPath(
       Dev, Img, {}, BuildOptions);
-  llvm::sys::fs::remove_directories(ItemDir);
+  EXPECT_EQ(llvm::sys::fs::remove_directories(ItemDir), std::error_code{})
+      << "Failed to remove item directory";
 
   // Create 1st cahe item
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
@@ -356,7 +366,8 @@ TEST_F(PersistenDeviceCodeCache, LockFile) {
           << "Corrupted image loaded from persistent cache";
     }
   }
-  llvm::sys::fs::remove_directories(ItemDir);
+  EXPECT_EQ(llvm::sys::fs::remove_directories(ItemDir), std::error_code{})
+      << "Failed to remove item directory";
 }
 
 #ifndef _WIN32
@@ -374,17 +385,24 @@ TEST_F(PersistenDeviceCodeCache, AccessDeniedForCacheDir) {
   std::string BuildOptions{"--build-options"};
   std::string ItemDir = detail::PersistentDeviceCodeCache::getCacheItemPath(
       Dev, Img, {}, BuildOptions);
-  llvm::sys::fs::remove_directories(ItemDir);
+  EXPECT_EQ(llvm::sys::fs::remove_directories(ItemDir), std::error_code{})
+      << "Failed to remove item directory";
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
                                                    NativeProg);
   EXPECT_TRUE(llvm::sys::fs::exists(ItemDir + "/0.bin")) << "No file created";
-  llvm::sys::fs::setPermissions(ItemDir + "/0.bin", llvm::sys::fs::no_perms);
+  EXPECT_EQ(llvm::sys::fs::setPermissions(ItemDir + "/0.bin",
+                                          llvm::sys::fs::no_perms),
+            std::error_code{})
+      << "Failed to set no_perms permission on 0.bin";
   // No access to binary file new cache item to be created
   detail::PersistentDeviceCodeCache::putItemToDisc(Dev, Img, {}, BuildOptions,
                                                    NativeProg);
   EXPECT_TRUE(llvm::sys::fs::exists(ItemDir + "/1.bin")) << "No file created";
 
-  llvm::sys::fs::setPermissions(ItemDir + "/1.bin", llvm::sys::fs::no_perms);
+  EXPECT_EQ(llvm::sys::fs::setPermissions(ItemDir + "/1.bin",
+                                          llvm::sys::fs::no_perms),
+            std::error_code{})
+      << "Failed to set no_perms permission on 1.bin";
   auto Res = detail::PersistentDeviceCodeCache::getItemFromDisc(Dev, Img, {},
                                                                 BuildOptions);
 
@@ -392,8 +410,14 @@ TEST_F(PersistenDeviceCodeCache, AccessDeniedForCacheDir) {
   EXPECT_EQ(Res.size(), static_cast<size_t>(0))
       << "Read from the file without permissions.";
 
-  llvm::sys::fs::setPermissions(ItemDir + "/0.bin", llvm::sys::fs::all_perms);
-  llvm::sys::fs::setPermissions(ItemDir + "/1.bin", llvm::sys::fs::all_perms);
+  EXPECT_EQ(llvm::sys::fs::setPermissions(ItemDir + "/0.bin",
+                                          llvm::sys::fs::all_perms),
+            std::error_code{})
+      << "Failed to set all_perms permission on 0.bin";
+  EXPECT_EQ(llvm::sys::fs::setPermissions(ItemDir + "/1.bin",
+                                          llvm::sys::fs::all_perms),
+            std::error_code{})
+      << "Failed to set all_perms permission on 1.bin";
 
   Res = detail::PersistentDeviceCodeCache::getItemFromDisc(Dev, Img, {},
                                                            BuildOptions);
@@ -404,7 +428,8 @@ TEST_F(PersistenDeviceCodeCache, AccessDeniedForCacheDir) {
           << "Corrupted image loaded from persistent cache";
     }
   }
-  llvm::sys::fs::remove_directories(ItemDir);
+  EXPECT_EQ(llvm::sys::fs::remove_directories(ItemDir), std::error_code{})
+      << "Failed to remove item directory";
 }
 #endif //_WIN32
 } // namespace


### PR DESCRIPTION
This commit adds checks to file-system operations in the persistent device code cache unit-test cases that did not have them.