### PR TITLE
[SYCL] Remove circular dependency between piEventRelease and cleanup()

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -5544,9 +5544,6 @@ static pi_result EventRelease(pi_event Event, pi_queue LockedQueue) {
   }
 
   if (--(Event->RefCount) == 0) {
-    if (!Event->CleanedUp)
-      Event->cleanup(LockedQueue);
-
     if (Event->CommandType == PI_COMMAND_TYPE_MEM_BUFFER_UNMAP &&
         Event->CommandData) {
       // Free the memory allocated in the piEnqueueMemBufferMap.


### PR DESCRIPTION
Event is retained explicitely when created in createEventAndAssociateQueue()
to ensure that the event is not destroyed before it is really signalled.
Ref count is decremented in Event->cleanup() after event is singalled. This
means that if reference count for an event is zero then cleanup was already
called for this event and should not be called anymore.

Interop events and user events don't have associated command list, queue,
kernel and waitlist, so we don't need to call cleanup() for interop and user
events.