### PR TITLE
[CI] Install required keys to fix NV container build problem

### DIFF
--- a/devops/containers/ubuntu2004_build.Dockerfile
+++ b/devops/containers/ubuntu2004_build.Dockerfile
@@ -4,14 +4,14 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 USER root
 
+# Install SYCL prerequisites
+COPY scripts/install_build_tools.sh /install.sh
+RUN /install.sh
+
 # Install Nvidia keys
 # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772
 RUN wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
 RUN dpkg -i cuda-keyring_1.0-1_all.deb
-
-# Install SYCL prerequisites
-COPY scripts/install_build_tools.sh /install.sh
-RUN /install.sh
 
 # Install AMD ROCm
 RUN apt install -yqq libnuma-dev wget gnupg2 && \

--- a/devops/containers/ubuntu2004_build.Dockerfile
+++ b/devops/containers/ubuntu2004_build.Dockerfile
@@ -4,14 +4,15 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 USER root
 
+# Install Nvidia keys
+# https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772
+RUN apt install -yqq wget
+RUN wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
+RUN dpkg -i cuda-keyring_1.0-1_all.deb
+
 # Install SYCL prerequisites
 COPY scripts/install_build_tools.sh /install.sh
 RUN /install.sh
-
-# Install Nvidia keys
-# https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772
-RUN wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
-RUN dpkg -i cuda-keyring_1.0-1_all.deb
 
 # Install AMD ROCm
 RUN apt install -yqq libnuma-dev wget gnupg2 && \

--- a/devops/containers/ubuntu2004_build.Dockerfile
+++ b/devops/containers/ubuntu2004_build.Dockerfile
@@ -6,7 +6,7 @@ USER root
 
 # Install Nvidia keys
 # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772
-RUN apt install -yqq wget
+RUN apt update && apt install -yqq wget
 RUN wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
 RUN dpkg -i cuda-keyring_1.0-1_all.deb
 

--- a/devops/containers/ubuntu2004_build.Dockerfile
+++ b/devops/containers/ubuntu2004_build.Dockerfile
@@ -4,6 +4,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 USER root
 
+# Install Nvidia keys
+# https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772
+RUN wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
+RUN dpkg -i cuda-keyring_1.0-1_all.deb
+
 # Install SYCL prerequisites
 COPY scripts/install_build_tools.sh /install.sh
 RUN /install.sh

--- a/devops/containers/ubuntu2004_build.Dockerfile
+++ b/devops/containers/ubuntu2004_build.Dockerfile
@@ -6,7 +6,8 @@ USER root
 
 # Install Nvidia keys
 # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772
-RUN apt update && apt install -yqq wget
+RUN apt update
+RUN apt install -yqq wget
 RUN wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
 RUN dpkg -i cuda-keyring_1.0-1_all.deb
 

--- a/devops/containers/ubuntu2004_build.Dockerfile
+++ b/devops/containers/ubuntu2004_build.Dockerfile
@@ -6,10 +6,7 @@ USER root
 
 # Install Nvidia keys
 # https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212772
-RUN apt update
-RUN apt install -yqq wget
-RUN wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
-RUN dpkg -i cuda-keyring_1.0-1_all.deb
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
 
 # Install SYCL prerequisites
 COPY scripts/install_build_tools.sh /install.sh


### PR DESCRIPTION
Error:
The following signatures couldn't be verified because the public key is
not available: NO_PUBKEY A4B469963BF863CC

See https://forums.developer.nvidia.com/t/invalid-public-key-for-cuda-apt-repository/212901