### PR TITLE
[SYCL] updating GPU driver dependencies. 

### DIFF
--- a/devops/actions/llvm_test_suite/action.yml
+++ b/devops/actions/llvm_test_suite/action.yml
@@ -84,11 +84,16 @@ runs:
       export LIT_OPTS="-v --no-progress-bar --show-unsupported --time-tests -o $PWD/build/results_${{ inputs.results_name_suffix }}.json"
       if [ -e /runtimes/oneapi-tbb/env/vars.sh ]; then
         source /runtimes/oneapi-tbb/env/vars.sh;
+      elif [ -e /opt/runtimes/oneapi-tbb/env/vars.sh ]; then
+        source /opt/runtimes/oneapi-tbb/env/vars.sh;
+      else
+        echo "no TBB vars in /opt/runtimes or /runtimes";
       fi
       # TODO remove workaround of FPGA emu bug
       mkdir -p icd
       echo /usr/lib/x86_64-linux-gnu/intel-opencl/libigdrcl.so > icd/gpu.icd
       echo /runtimes/oclcpu/x64/libintelocl.so > icd/cpu.icd
+      echo /opt/runtimes/oclcpu/x64/libintelocl.so > icd/cpu2.icd
       export OCL_ICD_VENDORS=$PWD/icd
       echo "::group::sycl-ls --verbose"
       sycl-ls --verbose

--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -1,21 +1,21 @@
 {
   "linux": {
     "compute_runtime": {
-      "github_tag": "22.10.22597",
-      "version": "22.10.22597",
-      "url": "https://github.com/intel/compute-runtime/releases/tag/22.10.22597",
+      "github_tag": "22.15.22905",
+      "version": "22.15.22905",
+      "url": "https://github.com/intel/compute-runtime/releases/tag/22.15.22905",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "igc": {
-      "github_tag": "igc-1.0.10409",
-      "version": "1.0.10409",
-      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/igc-1.0.10409",
+      "github_tag": "igc-1.0.10840",
+      "version": "1.0.10840",
+      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/igc-1.0.10840",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "cm": {
-      "github_tag": "cmclang-1.0.120",
-      "version": "1.0.120",
-      "url": "https://github.com/intel/cm-compiler/releases/tag/cmclang-1.0.120",
+      "github_tag": "cmclang-1.0.144",
+      "version": "1.0.144",
+      "url": "https://github.com/intel/cm-compiler/releases/tag/cmclang-1.0.144",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "tbb": {
@@ -42,21 +42,21 @@
   },
   "linux_staging": {
     "compute_runtime": {
-      "github_tag": "22.11.22682",
-      "version": "22.11.22682",
-      "url": "https://github.com/intel/compute-runtime/releases/tag/22.11.22682",
+      "github_tag": "22.15.22905",
+      "version": "22.15.22905",
+      "url": "https://github.com/intel/compute-runtime/releases/tag/22.15.22905",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "igc": {
-      "github_tag": "igc-1.0.10409",
-      "version": "1.0.10409",
-      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/igc-1.0.10409",
+      "github_tag": "igc-1.0.10840",
+      "version": "1.0.10840",
+      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/igc-1.0.10840",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "cm": {
-      "github_tag": "cmclang-1.0.126",
-      "version": "1.0.126",
-      "url": "https://github.com/intel/cm-compiler/releases/tag/cmclang-1.0.126",
+      "github_tag": "cmclang-1.0.144",
+      "version": "1.0.144",
+      "url": "https://github.com/intel/cm-compiler/releases/tag/cmclang-1.0.144",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "tbb": {


### PR DESCRIPTION
updating GPU driver dependencies. 
Note, there is some difference in which docker image is used by the CI that can result in the CPU runtime being at /opt/runtimes or /runtimes. So I'm also expanding the test suite environment to support both paths. That will allow this PR to pass tests, as well as others that may depend on newly made docker images, until we can better understand the reasons for the differences.

I previously had this work at https://github.com/intel/llvm/pull/6031 but I closed that PR because the commit history was too messy with experiments while trying to understand the CI failures we were seeing there.  

Signed-off-by: Chris Perkins <chris.perkins@intel.com>