### PR TITLE
[ESIMD] Add --enable-new-pm=1 to one of the LowerESIMD tests.

### DIFF
--- a/llvm/test/SYCLLowerIR/ESIMD/lower_intrins.ll
+++ b/llvm/test/SYCLLowerIR/ESIMD/lower_intrins.ll
@@ -1,7 +1,8 @@
 ; This test checks C++ ESIMD intrinsics lowering to "@llvm.genx.*" form
 ; consumable by the CM back-end.
 ;
-; RUN: opt < %s -LowerESIMD -S | FileCheck %s
+; RUN: opt < %s -LowerESIMD -S --enable-new-pm=1 | FileCheck %s
+; RUN: opt < %s -LowerESIMD -S --enable-new-pm=0 | FileCheck %s
 ;
 ; TODO refactor all the test cases - make them C++ and move to
 ; sycl\test\esimd\intrins_trans.cpp for much easier maintenance w/o losing


### PR DESCRIPTION
Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>