### PR TITLE
[SYCL] Some fixes for SchedulerTests

### DIFF
--- a/sycl/unittests/helpers/CommonRedefinitions.hpp
+++ b/sycl/unittests/helpers/CommonRedefinitions.hpp
@@ -205,7 +205,7 @@ inline void setupDefaultMockAPIs(sycl::unittest::PiMock &Mock) {
       "libsycl-fallback-cassert.spv",      "libsycl-fallback-cmath.spv",
       "libsycl-fallback-cmath-fp64.spv",   "libsycl-fallback-complex.spv",
       "libsycl-fallback-complex-fp64.spv", "libsycl-fallback-cstring.spv"};
-  for (const char * Name: FileNames) {
+  for (const char *Name : FileNames) {
     std::ofstream F(LibSyclDir + OSUtil::DirSep + Name);
     F << "Mock\n";
   }

--- a/sycl/unittests/helpers/CommonRedefinitions.hpp
+++ b/sycl/unittests/helpers/CommonRedefinitions.hpp
@@ -195,4 +195,18 @@ inline void setupDefaultMockAPIs(sycl::unittest::PiMock &Mock) {
       redefinedEnqueueKernelLaunchCommon);
   Mock.redefine<PiApiKind::piextDeviceSelectBinary>(
       redefinedDeviceSelectBinary);
+
+  // Library code uses current DSO to locate fallback .spv files. Unittest don't
+  // link against libsycl.so but use object files directly so that currend DSO
+  // is the unittest's executable location. Ensure we have mock .spv files in
+  // place.
+  std::string LibSyclDir = OSUtil::getCurrentDSODir();
+  const char *FileNames[] = {
+      "libsycl-fallback-cassert.spv",      "libsycl-fallback-cmath.spv",
+      "libsycl-fallback-cmath-fp64.spv",   "libsycl-fallback-complex.spv",
+      "libsycl-fallback-complex-fp64.spv", "libsycl-fallback-cstring.spv"};
+  for (const char * Name : FileNames) {
+    std::ofstream F(LibSyclDir + OSUtil::DirSep + Name);
+    F << "Mock\n";
+  }
 }

--- a/sycl/unittests/helpers/CommonRedefinitions.hpp
+++ b/sycl/unittests/helpers/CommonRedefinitions.hpp
@@ -205,7 +205,7 @@ inline void setupDefaultMockAPIs(sycl::unittest::PiMock &Mock) {
       "libsycl-fallback-cassert.spv",      "libsycl-fallback-cmath.spv",
       "libsycl-fallback-cmath-fp64.spv",   "libsycl-fallback-complex.spv",
       "libsycl-fallback-complex-fp64.spv", "libsycl-fallback-cstring.spv"};
-  for (const char * Name : FileNames) {
+  for (const char * Name: FileNames) {
     std::ofstream F(LibSyclDir + OSUtil::DirSep + Name);
     F << "Mock\n";
   }


### PR DESCRIPTION
* Only bailout if no suitable device found, not if the first one is unsuitable
* Mock libsycl-fallback-*.spv files in the directory with the compiled unittest
* Make redefinedProgram[Create|Link] return non-NULL program pointer