### PR TITLE
[SYCL] Fix addressspace cast for _alloca

### DIFF
--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -2058,10 +2058,17 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
     Value *Src = Visit(const_cast<Expr*>(E));
     llvm::Type *SrcTy = Src->getType();
     llvm::Type *DstTy = ConvertType(DestTy);
-    if (SrcTy->isPtrOrPtrVectorTy() && DstTy->isPtrOrPtrVectorTy() &&
+
+    if (SrcTy->isPointerTy() && DstTy->isPointerTy() &&
         SrcTy->getPointerAddressSpace() != DstTy->getPointerAddressSpace())
       Src = Builder.CreateAddrSpaceCast(
-          Src, llvm::PointerType::get(SrcTy, DstTy->getPointerAddressSpace()));
+          Src,
+          llvm::PointerType::getWithSamePointeeType(
+              cast<llvm::PointerType>(SrcTy), DstTy->getPointerAddressSpace()));
+    else if (SrcTy->isPtrOrPtrVectorTy() && DstTy->isPtrOrPtrVectorTy() &&
+             SrcTy->getPointerAddressSpace() != DstTy->getPointerAddressSpace())
+      llvm_unreachable("wrong cast for pointers in different address spaces"
+                       "(must be an address space cast)!");
 
     if (CGF.SanOpts.has(SanitizerKind::CFIUnrelatedCast)) {
       if (auto *PT = DestTy->getAs<PointerType>()) {

--- a/clang/test/CodeGenSYCL/address-space-builtin-alloca.cpp
+++ b/clang/test/CodeGenSYCL/address-space-builtin-alloca.cpp
@@ -1,13 +1,12 @@
-// RUN: %clang_cc1 -triple spir64-unknown-linux -fsycl-is-device -disable-llvm-passes -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -triple spir64-unknown-linux -fsycl-is-device -disable-llvm-passes -opaque-pointers -emit-llvm -x c++ %s -o - | FileCheck %s
 
 // Test to verify that address space cast is generated correctly for __builtin_alloca
 
 __attribute__((sycl_device)) void foo() {
-  // CHECK: %TestVar = alloca i32 addrspace(4)*, align 8
-  // CHECK: %TestVar.ascast = addrspacecast i32 addrspace(4)** %TestVar to i32 addrspace(4)* addrspace(4)*
+  // CHECK: %TestVar = alloca ptr addrspace(4), align 8
+  // CHECK: %TestVar.ascast = addrspacecast ptr %TestVar to ptr addrspace(4)
   // CHECK: %[[ALLOCA:[0-9]+]] = alloca i8, i64 1, align 8
-  // CHECK: %[[ADDRSPCAST:[0-9]+]] = addrspacecast i8* %[[ALLOCA]] to i8* addrspace(4)*
-  // CHECK: %[[BITCAST:[0-9]+]] = bitcast i8* addrspace(4)* %[[ADDRSPCAST]] to i32 addrspace(4)*
-  // CHECK: store i32 addrspace(4)* %[[BITCAST]], i32 addrspace(4)* addrspace(4)* %TestVar.ascast, align 8
+  // CHECK: %[[ADDRSPCAST:[0-9]+]] = addrspacecast ptr %[[ALLOCA]] to ptr addrspace(4)
+  // CHECK: store ptr addrspace(4) %[[ADDRSPCAST]], ptr addrspace(4) %TestVar.ascast, align 8
   int *TestVar = (int *)__builtin_alloca(1);
 }

--- a/clang/test/CodeGenSYCL/no_opaque_address-space-builtin-alloca.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_address-space-builtin-alloca.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -triple spir64-unknown-linux -fsycl-is-device -disable-llvm-passes -no-opaque-pointers -emit-llvm -x c++ %s -o - | FileCheck %s
+
+// Test to verify that address space cast is generated correctly for __builtin_alloca
+
+__attribute__((sycl_device)) void foo() {
+  // CHECK: %TestVar = alloca i32 addrspace(4)*, align 8
+  // CHECK: %TestVar.ascast = addrspacecast i32 addrspace(4)** %TestVar to i32 addrspace(4)* addrspace(4)*
+  // CHECK: %[[ALLOCA:[0-9]+]] = alloca i8, i64 1, align 8
+  // CHECK: %[[ADDRSPCAST:[0-9]+]] = addrspacecast i8* %[[ALLOCA]] to i8 addrspace(4)*
+  // CHECK: %[[BITCAST:[0-9]+]] = bitcast i8 addrspace(4)* %[[ADDRSPCAST]] to i32 addrspace(4)*
+  // CHECK: store i32 addrspace(4)* %[[BITCAST]], i32 addrspace(4)* addrspace(4)* %TestVar.ascast, align 8
+  int *TestVar = (int *)__builtin_alloca(1);
+}


### PR DESCRIPTION
This is a follow-up to PR#6050. The address space cast should use
element type and not change type. PR#6050 incorrectly changed
Type* to Type** (when adding the cast). This patch fixes the bug.

PR#6050 also added the cast for LLVM vector of pointer types. This
patch reverts the behavior for vector type to match old behavior (i.e. 
unreachable), since it is unclear what the required behavior is in this
case and what the code which triggers unreachable would even look
like. We can modify the behavior in future if we hit that case in some
scenario. 

This patch also adds an opaque pointer version of the test.

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>