### PR TITLE
[Driver][SYCL] Improve -mlong-double behaviors

### DIFF
--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1214,10 +1214,17 @@ llvm::opt::DerivedArgList *ToolChain::TranslateOffloadTargetArgs(
       // AMD GPU is a special case, as -mcpu is required for the device
       // compilation, except for SYCL which uses --offload-arch.
       if (SameTripleAsHost || (getTriple().getArch() == llvm::Triple::amdgcn &&
-                               DeviceOffloadKind != Action::OFK_SYCL))
+                               DeviceOffloadKind != Action::OFK_SYCL)) {
         DAL->append(A);
-      else
-        Modified = true;
+        continue;
+      }
+      // SPIR-V special case for -mlong-double
+      if (getTriple().isSPIR() &&
+          A->getOption().matches(options::OPT_LongDouble_Group)) {
+        DAL->append(A);
+        continue;
+      }
+      Modified = true;
       continue;
     }
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5664,7 +5664,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   if (Arg *A = Args.getLastArg(options::OPT_LongDouble_Group)) {
-    if (TC.getTriple().isX86() || TC.getTriple().isSPIR())
+    if (TC.getTriple().isX86())
+      A->render(Args, CmdArgs);
+    else if (TC.getTriple().isSPIR() &&
+             (A->getOption().getID() == options::OPT_mlong_double_64))
+      // Only allow for -mlong-double-64 for SPIR-V
       A->render(Args, CmdArgs);
     else if (TC.getTriple().isPPC() &&
              (A->getOption().getID() != options::OPT_mlong_double_80))

--- a/clang/test/Driver/mlong-double-128.c
+++ b/clang/test/Driver/mlong-double-128.c
@@ -2,7 +2,6 @@
 // RUN: %clang -target powerpc64-pc-freebsd12 -c -### %s -mlong-double-128 2>&1 | FileCheck %s
 // RUN: %clang -target powerpc64le-linux-musl -c -### %s -mlong-double-128 2>&1 | FileCheck %s
 // RUN: %clang -target i686-linux-gnu -c -### %s -mlong-double-128 2>&1 | FileCheck %s
-// RUN: %clang -target spir64-unknown-unknown -c -### %s -mlong-double-128 2>&1 | FileCheck %s
 
 // RUN: %clang -target x86_64-linux-musl -c -### %s -mlong-double-128 -mlong-double-80 2>&1 | FileCheck --implicit-check-not=-mlong-double-128 /dev/null
 // RUN: %clang -target x86_64-linux-musl -c -### %s -mlong-double-80 -mlong-double-128 2>&1 | FileCheck %s
@@ -11,6 +10,10 @@
 
 // RUN: %clang -target aarch64 -c -### %s -mlong-double-128 2>&1 | FileCheck --check-prefix=ERR %s
 // RUN: %clang -target powerpc -c -### %s -mlong-double-80 2>&1 | FileCheck --check-prefix=ERR2 %s
+// RUN: %clang -target spir64-unknown-unknown -c -### %s -mlong-double-128 2>&1 | FileCheck --check-prefix=ERR3 %s
+// RUN: %clang -target spir64-unknown-unknown -c -### %s -mlong-double-80 2>&1 | FileCheck --check-prefix=ERR4 %s
 
 // ERR: error: unsupported option '-mlong-double-128' for target 'aarch64'
 // ERR2: error: unsupported option '-mlong-double-80' for target 'powerpc'
+// ERR3: error: unsupported option '-mlong-double-128' for target 'spir64-unknown-unknown'
+// ERR4: error: unsupported option '-mlong-double-80' for target 'spir64-unknown-unknown'

--- a/clang/test/Driver/sycl-mlong-double.cpp
+++ b/clang/test/Driver/sycl-mlong-double.cpp
@@ -1,0 +1,15 @@
+/// -mlong-double-64 is valid for host and device for -fsycl
+// RUN: %clangxx -c -fsycl -mlong-double-64 -target x86_64-unknown-linux-gnu %s -### 2>&1 | FileCheck %s
+// CHECK: clang{{.*}} "-triple" "spir64-unknown-unknown"
+// CHECK-SAME:  "-mlong-double-64"
+// CHECK: clang{{.*}} "-triple" "x86_64-unknown-linux-gnu"
+// CHECK-SAME:  "-mlong-double-64"
+
+/// -mlong-double-128 and -mlong-double-80 are not supported for spir64.
+// RUN: %clangxx -c -fsycl -mlong-double-128 -target x86_64-unknown-linux-gnu %s -### 2>&1 | FileCheck --check-prefix=CHECK-128 %s
+// CHECK-128: error: unsupported option '-mlong-double-128' for target 'spir64-unknown-unknown'
+// CHECK-128-NOT: clang{{.*}} "-triple" "-spir64-unknown-unknown" {{.*}} "-mlong-double-128"
+
+// RUN: %clangxx -c -fsycl -mlong-double-80 -target x86_64-unknown-linux-gnu %s -### 2>&1 | FileCheck --check-prefix=CHECK-80 %s
+// CHECK-80: error: unsupported option '-mlong-double-80' for target 'spir64-unknown-unknown'
+// CHECK-80-NOT: clang{{.*}} "-triple" "-spir64-unknown-unknown" {{.*}} "-mlong-double-80"


### PR DESCRIPTION
The use of -mlong-double-64 should be allowed for host and target
compilation.  This was being filtered by a more general m_Group check.
Update the driver so -mlong-double is properly passed through to the
device compilation for SPIR-V offload targets, also restrict so only
-mlong-double-64 is valid for device.