### PR TITLE
[SYCL] Remove attribute ignored diagnostic for sycl_device

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1226,7 +1226,7 @@ def : MutualExclusions<[CUDAConstant, CUDAShared, HIPManaged]>;
 def SYCLDevice : InheritableAttr {
   let Spellings = [GNU<"sycl_device">];
   let Subjects = SubjectList<[Function]>;
-  let LangOpts = [SYCLIsDevice];
+  let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let Documentation = [SYCLDeviceDocs];
 }
 

--- a/clang/test/SemaSYCL/sycl-device.cpp
+++ b/clang/test/SemaSYCL/sycl-device.cpp
@@ -1,8 +1,10 @@
-// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify -DSYCL %s
 // RUN: %clang_cc1 -fsycl-is-host -fsyntax-only -verify -DHOST %s
-// RUN: %clang_cc1 -verify -DNO_SYCL %s
+// RUN: %clang_cc1 -verify %s
 
-#ifndef NO_SYCL
+// Semantic tests for sycl_device attribute
+
+#ifdef SYCL
 
 __attribute__((sycl_device)) // expected-warning {{'sycl_device' attribute only applies to functions}}
 int N;
@@ -41,8 +43,8 @@ __attribute__((sycl_device)) void func2(int *) {}
 // expected-no-diagnostics
 __attribute__((sycl_device)) void func3() {}
 
-#else // NO_SYCL
+#else
 __attribute__((sycl_device)) // expected-warning {{'sycl_device' attribute ignored}}
 void baz() {}
 
-#endif // NO_SYCL
+#endif

--- a/clang/test/SemaSYCL/sycl-device.cpp
+++ b/clang/test/SemaSYCL/sycl-device.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsycl-is-host -fsyntax-only -verify -DHOST %s
 // RUN: %clang_cc1 -verify -DNO_SYCL %s
 
 #ifndef NO_SYCL
@@ -34,6 +35,11 @@ public:
 __attribute__((sycl_device)) int *func0() { return nullptr; }
 
 __attribute__((sycl_device)) void func2(int *) {}
+
+#elif defined(HOST)
+
+// expected-no-diagnostics
+__attribute__((sycl_device)) void func3() {}
 
 #else // NO_SYCL
 __attribute__((sycl_device)) // expected-warning {{'sycl_device' attribute ignored}}


### PR DESCRIPTION
Remove warning diagnostic on host compilation when using
__attribute__((sycl_device))

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>