### PR TITLE
[SYCL] Skip RequiredWGSize.HasRequiredSize without aspect::online_compiler

### DIFF
--- a/sycl/unittests/scheduler/RequiredWGSize.cpp
+++ b/sycl/unittests/scheduler/RequiredWGSize.cpp
@@ -207,6 +207,10 @@ static void performChecks() {
   setupDefaultMockAPIs(Mock);
 
   const sycl::device Dev = Plt.get_devices()[0];
+  if (!Dev.has(sycl::aspect::online_compiler)) {
+    std::cerr << "aspect::online_compiler is required for this test.";
+    return;
+  }
 
   sycl::queue Queue{Dev};
 


### PR DESCRIPTION
The aspect is required on the device to work with kernel bundles APIs.