### PR TITLE
[SYCL] Fix properties include dependency in fpga extensions

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/fpga_lsu.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_lsu.hpp
@@ -10,6 +10,7 @@
 #include "fpga_utils.hpp"
 #include <CL/sycl/detail/defines.hpp>
 #include <CL/sycl/pointers.hpp>
+#include <sycl/ext/oneapi/properties/properties.hpp>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {

--- a/sycl/include/sycl/ext/intel/experimental/pipes.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/pipes.hpp
@@ -12,6 +12,7 @@
 #include <CL/__spirv/spirv_ops.hpp>
 #include <CL/__spirv/spirv_types.hpp>
 #include <CL/sycl/stl.hpp>
+#include <sycl/ext/oneapi/properties/properties.hpp>
 #include <type_traits>
 
 __SYCL_INLINE_NAMESPACE(cl) {


### PR DESCRIPTION
fpga_lsu.hpp and pipes.hpp use the compile-time properties extension but do not include the corresponding header file. This issue only shows up when the fpga extension header (or fpga_lsu.hpp/pipes.hpp directly) is included before sycl.hpp. These changes resolves the include dependency.