### PR TITLE
[ESIMD] Bump up vc-intrinsics repo commit hash.

### DIFF
--- a/llvm/lib/SYCLLowerIR/CMakeLists.txt
+++ b/llvm/lib/SYCLLowerIR/CMakeLists.txt
@@ -13,12 +13,10 @@ endif()
 if (NOT TARGET LLVMGenXIntrinsics)
   if (NOT DEFINED LLVMGenXIntrinsics_SOURCE_DIR)
     set(LLVMGenXIntrinsics_GIT_REPO https://github.com/intel/vc-intrinsics.git)
-    # commit 8b6e209fe1269a2c6470b36dfbaa0e051d2a100f (master)
-    # Author: Konstantin Vladimirov <konstantin.vladimirov@intel.com>
-    # Date:   Tue Feb 8 10:47:03 2022 +0000
-    # introducing named barrier support in adaptor pass
-    # named barrier required for DPC++ and other customers
-    set(LLVMGenXIntrinsics_GIT_TAG 8b6e209fe1269a2c6470b36dfbaa0e051d2a100f)
+    # Author: Victor Mustya <victor.mustya@intel.com>
+    # Date:   Tue, 3 May 2022 17:56:40 +0000
+    # Remove default switch labels for LSC-related functions
+    set(LLVMGenXIntrinsics_GIT_TAG 561f4ff575a198b36a72fcb790e1997d7d6d6c91)
 
     message(STATUS "vc-intrinsics repo is missing. Will try to download it from ${LLVMGenXIntrinsics_GIT_REPO}")
     include(FetchContent)


### PR DESCRIPTION
The new commit has necessary fixes to support slm_init with non-constant (Specialization constant) argument.
Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>