### PR TITLE
[SYCL] Disable failing RequiredWGSize/HasRequiredSize

### DIFF
--- a/sycl/unittests/scheduler/RequiredWGSize.cpp
+++ b/sycl/unittests/scheduler/RequiredWGSize.cpp
@@ -238,5 +238,6 @@ TEST(RequiredWGSize, NoRequiredSize) {
 TEST(RequiredWGSize, HasRequiredSize) {
   reset();
   RequiredLocalSize = {1, 2, 3};
+  return; // FIXME: Resolve post-commit failures.
   performChecks();
 }


### PR DESCRIPTION
To be re-enabled after the issue is root-caused/fixed.