### PR TITLE
[SYCL][L0] Correctly use global timestamps, instead of context

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -5331,15 +5331,15 @@ pi_result piEventGetProfilingInfo(pi_event Event, pi_profiling_info ParamName,
   case PI_PROFILING_INFO_COMMAND_START: {
     ZE_CALL(zeEventQueryKernelTimestamp, (Event->ZeEvent, &tsResult));
     uint64_t ContextStartTime =
-        (tsResult.context.kernelStart & TimestampMaxValue) * ZeTimerResolution;
+        (tsResult.global.kernelStart & TimestampMaxValue) * ZeTimerResolution;
     return ReturnValue(ContextStartTime);
   }
   case PI_PROFILING_INFO_COMMAND_END: {
     ZE_CALL(zeEventQueryKernelTimestamp, (Event->ZeEvent, &tsResult));
 
     uint64_t ContextStartTime =
-        (tsResult.context.kernelStart & TimestampMaxValue);
-    uint64_t ContextEndTime = (tsResult.context.kernelEnd & TimestampMaxValue);
+        (tsResult.global.kernelStart & TimestampMaxValue);
+    uint64_t ContextEndTime = (tsResult.global.kernelEnd & TimestampMaxValue);
 
     //
     // Handle a possible wrap-around (the underlying HW counter is < 64-bit).


### PR DESCRIPTION
Signed-off-by: Jaime Arteaga <jaime.a.arteaga.molina@intel.com>