### PR TITLE
[SYCL][NFC] Silence unknown attribute warnings on Host compilation

### DIFF
--- a/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
+++ b/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
@@ -1,9 +1,5 @@
 // RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify %s
 // RUN: not %clang_cc1 -fsycl-is-device -ast-dump %s | FileCheck %s
-// RUN: %clang_cc1 -verify -DNO_SYCL %s
-// RUN: %clang_cc1 -fsycl-is-host -fsyntax-only -verify -DSYCL_HOST %s
-
-#if !defined(NO_SYCL) || defined(SYCL_HOST)
 
 [[intel::device_indirectly_callable]] // expected-warning {{'device_indirectly_callable' attribute only applies to functions}}
 int N;
@@ -40,14 +36,6 @@ void helper() {}
 void foo() {
   helper();
 }
-
-#else
-
-[[intel::device_indirectly_callable]] // expected-warning {{'device_indirectly_callable' attribute ignored}}
-void
-baz() {}
-
-#endif // NO_SYCL
 
 // CHECK: FunctionDecl {{.*}} helper
 //

--- a/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
+++ b/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
@@ -1,5 +1,9 @@
 // RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify %s
 // RUN: not %clang_cc1 -fsycl-is-device -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -verify -DNO_SYCL %s
+// RUN: %clang_cc1 -fsycl-is-host -fsyntax-only -verify -DSYCL_HOST %s
+
+#if !defined(NO_SYCL) || defined(SYCL_HOST)
 
 [[intel::device_indirectly_callable]] // expected-warning {{'device_indirectly_callable' attribute only applies to functions}}
 int N;
@@ -36,6 +40,14 @@ void helper() {}
 void foo() {
   helper();
 }
+
+#else
+
+[[intel::device_indirectly_callable]] // expected-warning {{'device_indirectly_callable' attribute ignored}}
+void
+baz() {}
+
+#endif // NO_SYCL
 
 // CHECK: FunctionDecl {{.*}} helper
 //

--- a/clang/test/SemaSYCL/spurious-host-warning.cpp
+++ b/clang/test/SemaSYCL/spurious-host-warning.cpp
@@ -1,5 +1,5 @@
 // RUN: %clang_cc1 -fsycl-is-host -triple x86_64-pc-linux-gnu -fsyntax-only -verify %s
-// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fsyntax-only -verify=host %s
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fsyntax-only -verify=device %s
 
 // Test checks the attribute is silently ignored during host compilation
 // where -fsycl-is-host is passed on cc1.
@@ -8,39 +8,39 @@
 
 void foo()
 {
-  [[intel::doublepump]] unsigned int v_one[64]; // host-warning {{'doublepump' attribute ignored}}
+  [[intel::doublepump]] unsigned int v_one[64]; // device-warning {{'doublepump' attribute ignored}}
 
-  [[intel::fpga_memory]] unsigned int v_two[64]; // host-warning {{'fpga_memory' attribute ignored}}
+  [[intel::fpga_memory]] unsigned int v_two[64]; // device-warning {{'fpga_memory' attribute ignored}}
 
-  [[intel::fpga_register]] unsigned int v_three[64]; // host-warning {{'fpga_register' attribute ignored}}
+  [[intel::fpga_register]] unsigned int v_three[64]; // device-warning {{'fpga_register' attribute ignored}}
 
-  [[intel::singlepump]] unsigned int v_four[64]; // host-warning {{'singlepump' attribute ignored}}
+  [[intel::singlepump]] unsigned int v_four[64]; // device-warning {{'singlepump' attribute ignored}}
 
-  [[intel::bankwidth(4)]] unsigned int v_five[32]; // host-warning {{'bankwidth' attribute ignored}}
+  [[intel::bankwidth(4)]] unsigned int v_five[32]; // device-warning {{'bankwidth' attribute ignored}}
 
-  [[intel::numbanks(8)]] unsigned int v_six[32]; // host-warning {{'numbanks' attribute ignored}}
+  [[intel::numbanks(8)]] unsigned int v_six[32]; // device-warning {{'numbanks' attribute ignored}}
 
-  [[intel::private_copies(8)]] unsigned int v_seven[64]; // host-warning {{'private_copies' attribute ignored}}
+  [[intel::private_copies(8)]] unsigned int v_seven[64]; // device-warning {{'private_copies' attribute ignored}}
 
-  [[intel::merge("mrg1", "depth")]] unsigned int v_eight[64]; // host-warning {{'merge' attribute ignored}}
+  [[intel::merge("mrg1", "depth")]] unsigned int v_eight[64]; // device-warning {{'merge' attribute ignored}}
 
-  [[intel::max_replicates(2)]] unsigned int v_nine[64]; // host-warning {{'max_replicates' attribute ignored}}
+  [[intel::max_replicates(2)]] unsigned int v_nine[64]; // device-warning {{'max_replicates' attribute ignored}}
 
-  [[intel::simple_dual_port]] unsigned int v_ten[64]; // host-warning {{'simple_dual_port' attribute ignored}}
+  [[intel::simple_dual_port]] unsigned int v_ten[64]; // device-warning {{'simple_dual_port' attribute ignored}}
 
-  [[intel::bank_bits(2, 3, 4, 5)]] unsigned int v_eleven[64]; // host-warning {{'bank_bits' attribute ignored}}
+  [[intel::bank_bits(2, 3, 4, 5)]] unsigned int v_eleven[64]; // device-warning {{'bank_bits' attribute ignored}}
 
-  [[intel::use_stall_enable_clusters]] void func(); // host-warning {{'use_stall_enable_clusters' attribute ignored}}
+  [[intel::use_stall_enable_clusters]] void func(); // device-warning {{'use_stall_enable_clusters' attribute ignored}}
 
-  [[intel::max_global_work_dim(1)]] void func1(); // host-warning {{'max_global_work_dim' attribute ignored}}
+  [[intel::max_global_work_dim(1)]] void func1(); // device-warning {{'max_global_work_dim' attribute ignored}}
 
-  [[intel::scheduler_target_fmax_mhz(3)]] void func2(); // host-warning {{'scheduler_target_fmax_mhz' attribute ignored}}
+  [[intel::scheduler_target_fmax_mhz(3)]] void func2(); // device-warning {{'scheduler_target_fmax_mhz' attribute ignored}}
 
-  [[intel::kernel_args_restrict]] void func3(); // host-warning {{'kernel_args_restrict' attribute ignored}}
+  [[intel::kernel_args_restrict]] void func3(); // device-warning {{'kernel_args_restrict' attribute ignored}}
 
-  [[intel::num_simd_work_items(12)]] void func4(); // host-warning {{'num_simd_work_items' attribute ignored}}
+  [[intel::num_simd_work_items(12)]] void func4(); // device-warning {{'num_simd_work_items' attribute ignored}}
 
-  [[intel::max_work_group_size(32, 32, 32)]] void func5(); // host-warning {{'max_work_group_size' attribute ignored}}
+  [[intel::max_work_group_size(32, 32, 32)]] void func5(); // device-warning {{'max_work_group_size' attribute ignored}}
 
-  [[intel::device_indirectly_callable]] void func6(); // host-warning {{'device_indirectly_callable' attribute ignored}}
+  [[intel::device_indirectly_callable]] void func6(); // device-warning {{'device_indirectly_callable' attribute ignored}}
 }

--- a/clang/test/SemaSYCL/spurious-host-warning.cpp
+++ b/clang/test/SemaSYCL/spurious-host-warning.cpp
@@ -1,97 +1,46 @@
-// RUN: %clang_cc1 -fsycl-is-host -triple x86_64-pc-linux-gnu -fsyntax-only -verify %s -DSYCLHOST
-// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsycl-is-host -triple x86_64-pc-linux-gnu -fsyntax-only -verify %s
+// RUN: %clang_cc1 -triple x86_64-pc-linux-gnu -fsyntax-only -verify=host %s
 
 // Test checks the attribute is silently ignored during host compilation
 // where -fsycl-is-host is passed on cc1.
 
-#ifdef SYCLHOST
 // expected-no-diagnostics
-#endif
 
 void foo()
 {
-#ifndef SYCLHOST
-// expected-warning@+2 {{'doublepump' attribute ignored}}
-#endif
-  [[intel::doublepump]] unsigned int v_one[64];
+  [[intel::doublepump]] unsigned int v_one[64]; // host-warning {{'doublepump' attribute ignored}}
 
-#ifndef SYCLHOST
-// expected-warning@+2 {{'fpga_memory' attribute ignored}}
-#endif
-  [[intel::fpga_memory]] unsigned int v_two[64];
+  [[intel::fpga_memory]] unsigned int v_two[64]; // host-warning {{'fpga_memory' attribute ignored}}
 
-#ifndef SYCLHOST
-// expected-warning@+2 {{'fpga_register' attribute ignored}}
-#endif
-  [[intel::fpga_register]] unsigned int v_three[64];
+  [[intel::fpga_register]] unsigned int v_three[64]; // host-warning {{'fpga_register' attribute ignored}}
 
-#ifndef SYCLHOST
-// expected-warning@+2 {{'singlepump' attribute ignored}}
-#endif
-  [[intel::singlepump]] unsigned int v_four[64];
+  [[intel::singlepump]] unsigned int v_four[64]; // host-warning {{'singlepump' attribute ignored}}
 
-#ifndef SYCLHOST
-// expected-warning@+2 {{'bankwidth' attribute ignored}}
-#endif
-  [[intel::bankwidth(4)]] unsigned int v_five[32];
+  [[intel::bankwidth(4)]] unsigned int v_five[32]; // host-warning {{'bankwidth' attribute ignored}}
 
-#ifndef SYCLHOST
-// expected-warning@+2 {{'numbanks' attribute ignored}}
-#endif
-  [[intel::numbanks(8)]] unsigned int v_six[32];
+  [[intel::numbanks(8)]] unsigned int v_six[32]; // host-warning {{'numbanks' attribute ignored}}
 
-#ifndef SYCLHOST
-// expected-warning@+2 {{'private_copies' attribute ignored}}
-#endif
-  [[intel::private_copies(8)]] unsigned int v_seven[64];
+  [[intel::private_copies(8)]] unsigned int v_seven[64]; // host-warning {{'private_copies' attribute ignored}}
 
-#ifndef SYCLHOST
-// expected-warning@+2 {{'merge' attribute ignored}}
-#endif
-  [[intel::merge("mrg1", "depth")]] unsigned int v_eight[64];
+  [[intel::merge("mrg1", "depth")]] unsigned int v_eight[64]; // host-warning {{'merge' attribute ignored}}
 
-#ifndef SYCLHOST
-// expected-warning@+2 {{'max_replicates' attribute ignored}}
-#endif
-  [[intel::max_replicates(2)]] unsigned int v_nine[64];
+  [[intel::max_replicates(2)]] unsigned int v_nine[64]; // host-warning {{'max_replicates' attribute ignored}}
 
-#ifndef SYCLHOST
-// expected-warning@+2 {{'simple_dual_port' attribute ignored}}
-#endif
-  [[intel::simple_dual_port]] unsigned int v_ten[64];
+  [[intel::simple_dual_port]] unsigned int v_ten[64]; // host-warning {{'simple_dual_port' attribute ignored}}
 
-#ifndef SYCLHOST
-// expected-warning@+2 {{'bank_bits' attribute ignored}}
-#endif
-  [[intel::bank_bits(2, 3, 4, 5)]] unsigned int v_eleven[64];
+  [[intel::bank_bits(2, 3, 4, 5)]] unsigned int v_eleven[64]; // host-warning {{'bank_bits' attribute ignored}}
 
-#ifndef SYCLHOST
-// expected-warning@+2 {{'use_stall_enable_clusters' attribute ignored}}
-#endif
-  [[intel::use_stall_enable_clusters]] void func();
+  [[intel::use_stall_enable_clusters]] void func(); // host-warning {{'use_stall_enable_clusters' attribute ignored}}
 
-#ifndef SYCLHOST
-// expected-warning@+2 {{'max_global_work_dim' attribute ignored}}
-#endif
-  [[intel::max_global_work_dim(1)]] void func1();
+  [[intel::max_global_work_dim(1)]] void func1(); // host-warning {{'max_global_work_dim' attribute ignored}}
 
-#ifndef SYCLHOST
-// expected-warning@+2 {{'scheduler_target_fmax_mhz' attribute ignored}}
-#endif
-  [[intel::scheduler_target_fmax_mhz(3)]] void func2();
+  [[intel::scheduler_target_fmax_mhz(3)]] void func2(); // host-warning {{'scheduler_target_fmax_mhz' attribute ignored}}
 
-#ifndef SYCLHOST
-// expected-warning@+2 {{'kernel_args_restrict' attribute ignored}}
-#endif
-  [[intel::kernel_args_restrict]] void func3();
+  [[intel::kernel_args_restrict]] void func3(); // host-warning {{'kernel_args_restrict' attribute ignored}}
 
-#ifndef SYCLHOST
-// expected-warning@+2 {{'num_simd_work_items' attribute ignored}}
-#endif
-  [[intel::num_simd_work_items(12)]] void func4();
+  [[intel::num_simd_work_items(12)]] void func4(); // host-warning {{'num_simd_work_items' attribute ignored}}
 
-#ifndef SYCLHOST
-// expected-warning@+2 {{'max_work_group_size' attribute ignored}}
-#endif
-  [[intel::max_work_group_size(32, 32, 32)]] void func5();
+  [[intel::max_work_group_size(32, 32, 32)]] void func5(); // host-warning {{'max_work_group_size' attribute ignored}}
+
+  [[intel::device_indirectly_callable]] void func6(); // host-warning {{'device_indirectly_callable' attribute ignored}}
 }


### PR DESCRIPTION
This patch updates test to use a custom verify. e.g, -verify=device on
the RUN line and then // device-warning {{'bank_bits' attribute ignored}}
instead of using the preprocessor conditional.

Fixes https://github.com/intel/llvm/issues/5667

Signed-off-by: Soumi Manna <soumi.manna@intel.com>