### PR TITLE
[SYCL] Reset PiFunctionTable in PiMock::~PiMock

### DIFF
--- a/sycl/unittests/helpers/PiMock.hpp
+++ b/sycl/unittests/helpers/PiMock.hpp
@@ -141,7 +141,7 @@ public:
   PiMock(const cl::sycl::host_selector &HostSelector) = delete;
 
   PiMock(PiMock &&Other) {
-    MPlatform=std::move(Other.MPlatform);
+    MPlatform = std::move(Other.MPlatform);
     OrigFuncTable = std::move(Other.OrigFuncTable);
     Other.OrigFuncTable = {}; // Move above doesn't reset the optional.
     MPiPluginMockPtr = std::move(Other.MPiPluginMockPtr);

--- a/sycl/unittests/helpers/PiMock.hpp
+++ b/sycl/unittests/helpers/PiMock.hpp
@@ -35,6 +35,7 @@
 #include <detail/platform_impl.hpp>
 
 #include <functional>
+#include <optional>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
@@ -133,14 +134,26 @@ public:
     MPiPluginMockPtr = &NewPluginPtr->getPiPlugin();
     // Save a copy of the platform resource
     MPlatform = OriginalPlatform;
+    OrigFuncTable = OriginalPiPlugin.getPiPlugin().PiFunctionTable;
   }
 
   /// Explicit construction from a host_selector is forbidden.
   PiMock(const cl::sycl::host_selector &HostSelector) = delete;
 
+  PiMock(PiMock &&Other) {
+    MPlatform=std::move(Other.MPlatform);
+    OrigFuncTable = std::move(Other.OrigFuncTable);
+    Other.OrigFuncTable = {}; // Move above doesn't reset the optional.
+    MPiPluginMockPtr = std::move(Other.MPiPluginMockPtr);
+  }
   PiMock(const PiMock &) = delete;
   PiMock &operator=(const PiMock &) = delete;
-  ~PiMock() = default;
+  ~PiMock() {
+    if (!OrigFuncTable)
+      return;
+
+    MPiPluginMockPtr->PiFunctionTable = *OrigFuncTable;
+  }
 
   /// Returns a handle to the SYCL platform instance.
   ///
@@ -184,6 +197,7 @@ public:
 
 private:
   cl::sycl::platform MPlatform;
+  std::optional<pi_plugin::FunctionPointers> OrigFuncTable;
   // Extracted at initialization for convenience purposes. The resource
   // itself is owned by the platform instance.
   RT::PiPlugin *MPiPluginMockPtr;

--- a/sycl/unittests/queue/EventClear.cpp
+++ b/sycl/unittests/queue/EventClear.cpp
@@ -82,11 +82,11 @@ pi_result redefinedEventRelease(pi_event event) {
   return PI_SUCCESS;
 }
 
-bool preparePiMock(platform &Plt) {
+std::optional<unittest::PiMock> preparePiMock(platform &Plt) {
   if (Plt.is_host()) {
     std::cout << "Not run on host - no PI events created in that case"
               << std::endl;
-    return false;
+    return {};
   }
 
   unittest::PiMock Mock{Plt};
@@ -98,14 +98,15 @@ bool preparePiMock(platform &Plt) {
   Mock.redefine<detail::PiApiKind::piEventGetInfo>(redefinedEventGetInfo);
   Mock.redefine<detail::PiApiKind::piEventRetain>(redefinedEventRetain);
   Mock.redefine<detail::PiApiKind::piEventRelease>(redefinedEventRelease);
-  return true;
+  return std::move(Mock);
 }
 
 // Check that the USM events are cleared from the queue upon call to wait(),
 // so that they are not waited for multiple times.
 TEST(QueueEventClear, ClearOnQueueWait) {
   platform Plt{default_selector()};
-  if (!preparePiMock(Plt))
+  auto Mock = preparePiMock(Plt);
+  if (!Mock)
     return;
 
   context Ctx{Plt.get_devices()[0]};
@@ -126,7 +127,8 @@ TEST(QueueEventClear, ClearOnQueueWait) {
 // exceeds a threshold.
 TEST(QueueEventClear, CleanupOnThreshold) {
   platform Plt{default_selector()};
-  if (!preparePiMock(Plt))
+  auto Mock = preparePiMock(Plt);
+  if (!Mock)
     return;
 
   context Ctx{Plt.get_devices()[0]};

--- a/sycl/unittests/queue/Wait.cpp
+++ b/sycl/unittests/queue/Wait.cpp
@@ -86,11 +86,12 @@ pi_result redefinedEventRelease(pi_event event) {
   return PI_SUCCESS;
 }
 
-bool preparePiMock(platform &Plt) {
+TEST(QueueWait, QueueWaitTest) {
+  platform Plt{default_selector()};
   if (Plt.is_host()) {
     std::cout << "Not run on host - no PI events created in that case"
               << std::endl;
-    return false;
+    return;
   }
 
   unittest::PiMock Mock{Plt};
@@ -105,13 +106,6 @@ bool preparePiMock(platform &Plt) {
   Mock.redefine<detail::PiApiKind::piEventGetInfo>(redefinedEventGetInfo);
   Mock.redefine<detail::PiApiKind::piEventRetain>(redefinedEventRetain);
   Mock.redefine<detail::PiApiKind::piEventRelease>(redefinedEventRelease);
-  return true;
-}
-
-TEST(QueueWait, QueueWaitTest) {
-  platform Plt{default_selector()};
-  if (!preparePiMock(Plt))
-    return;
   context Ctx{Plt.get_devices()[0]};
   queue Q{Ctx, default_selector()};
 

--- a/sycl/unittests/scheduler/RequiredWGSize.cpp
+++ b/sycl/unittests/scheduler/RequiredWGSize.cpp
@@ -238,6 +238,5 @@ TEST(RequiredWGSize, NoRequiredSize) {
 TEST(RequiredWGSize, HasRequiredSize) {
   reset();
   RequiredLocalSize = {1, 2, 3};
-  return; // FIXME: Resolve post-commit failures.
   performChecks();
 }


### PR DESCRIPTION
So that tests wouldn't have unexpected cross-tests influence/dependency.

Re-enable RequiredWGSize.HasRequiredSize as it is fixed by that change.