### PR TITLE
[CI] Fix doxygen documentation generation

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -54,5 +54,5 @@ jobs:
         git config --global user.name "iclsrc"
         git config --global user.email "ia.compiler.tools.git@intel.com"
         git add .
-        git diff-index --quiet HEAD || git commit -m "Update docs" -s
-        git push
+        git diff-index --quiet HEAD || git commit --amend -m "Update docs" -s
+        git push -f


### PR DESCRIPTION
With the old setup https://github.com/intel/llvm-docs repo size exceeded
30Gb, that caused docs gen job fail in github actions due to size exceeded.

This patch reworks the setup by always ammending changes on updates, keeping
docs repo size under control. If we ever need doxygen docs history we can start
producing tags for interested dates.