### PR TITLE
[SYCL][DOC] Update SYCL rev in extension template

### DIFF
--- a/sycl/doc/extensions/template.asciidoc
+++ b/sycl/doc/extensions/template.asciidoc
@@ -36,7 +36,7 @@ https://github.com/intel/llvm/issues
 
 == Dependencies
 
-This extension is written against the SYCL 2020 revision 4 specification.  All
+This extension is written against the SYCL 2020 revision 5 specification.  All
 references below to the "core SYCL specification" or to section numbers in the
 SYCL specification refer to that revision.
 


### PR DESCRIPTION
A new revision of the SYCL 2020 specification was recently published,
so update the revision in the template we use for extensions.