### PR TITLE
[SYCL] Change negative and static_cast logical for half

### DIFF
--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -202,6 +202,8 @@ public:
   constexpr half_v2(half_v2 &&) = default;
 
   __SYCL_CONSTEXPR_HALF half_v2(const float &rhs) : Buf(float2Half(rhs)) {}
+  __SYCL_CONSTEXPR_HALF explicit half_v2(const double &rhs)
+      : Buf(float2Half(rhs)) {}
 
   constexpr half_v2 &operator=(const half_v2 &rhs) = default;
 

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -278,6 +278,11 @@ public:
   }
 
   // Operator neg
+  constexpr half_v2 &operator-() {
+    Buf ^= 0x8000;
+    return *this;
+  }
+
   __SYCL_CONSTEXPR_HALF friend half_v2 operator-(half_v2 other) {
     other.Buf ^= 0x8000;
     return other;

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -218,19 +218,19 @@ public:
   }
   __SYCL_CONSTEXPR_HALF friend bool operator<(const half_v2 &lhs,
                                               const half_v2 &rhs) {
-    return lhs.Buf < rhs.Buf;
+    return half2Float(lhs.Buf) < half2Float(rhs.Buf);
   }
   __SYCL_CONSTEXPR_HALF friend bool operator>(const half_v2 &lhs,
                                               const half_v2 &rhs) {
-    return lhs.Buf > rhs.Buf;
+    return half2Float(lhs.Buf) > half2Float(rhs.Buf);
   }
   __SYCL_CONSTEXPR_HALF friend bool operator>=(const half_v2 &lhs,
                                                const half_v2 &rhs) {
-    return lhs.Buf >= rhs.Buf;
+    return half2Float(lhs.Buf) >= half2Float(rhs.Buf);
   }
   __SYCL_CONSTEXPR_HALF friend bool operator<=(const half_v2 &lhs,
                                                const half_v2 &rhs) {
-    return lhs.Buf <= rhs.Buf;
+    return half2Float(lhs.Buf) <= half2Float(rhs.Buf);
   }
 
   // Operator +=, -=, *=, /=
@@ -278,8 +278,9 @@ public:
   }
 
   // Operator neg
-  __SYCL_CONSTEXPR_HALF friend half_v2 operator-(const half_v2 other) {
-    return half_v2(uint16_t(-other.Buf ^ 0x800));
+  __SYCL_CONSTEXPR_HALF friend half_v2 operator-(half_v2 other) {
+    other.Buf |= 0x8000;
+    return other;
   }
 
   // Operator float

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -279,7 +279,7 @@ public:
 
   // Operator neg
   __SYCL_CONSTEXPR_HALF friend half_v2 operator-(half_v2 other) {
-    other.Buf |= 0x8000;
+    other.Buf ^= 0x8000;
     return other;
   }
 

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -205,6 +205,32 @@ public:
 
   constexpr half_v2 &operator=(const half_v2 &rhs) = default;
 
+  // Operator ==
+  __SYCL_CONSTEXPR_HALF friend bool operator==(const half_v2 &lhs,
+                                               const half_v2 &rhs) {
+    return lhs.Buf == rhs.Buf;
+  }
+  __SYCL_CONSTEXPR_HALF friend bool operator!=(const half_v2 &lhs,
+                                               const half_v2 &rhs) {
+    return lhs.Buf != rhs.Buf;
+  }
+  __SYCL_CONSTEXPR_HALF friend bool operator<(const half_v2 &lhs,
+                                              const half_v2 &rhs) {
+    return lhs.Buf < rhs.Buf;
+  }
+  __SYCL_CONSTEXPR_HALF friend bool operator>(const half_v2 &lhs,
+                                              const half_v2 &rhs) {
+    return lhs.Buf > rhs.Buf;
+  }
+  __SYCL_CONSTEXPR_HALF friend bool operator>=(const half_v2 &lhs,
+                                               const half_v2 &rhs) {
+    return lhs.Buf >= rhs.Buf;
+  }
+  __SYCL_CONSTEXPR_HALF friend bool operator<=(const half_v2 &lhs,
+                                               const half_v2 &rhs) {
+    return lhs.Buf <= rhs.Buf;
+  }
+
   // Operator +=, -=, *=, /=
   __SYCL_CONSTEXPR_HALF half_v2 &operator+=(const half_v2 &rhs) {
     *this = operator float() + static_cast<float>(rhs);
@@ -250,9 +276,8 @@ public:
   }
 
   // Operator neg
-  constexpr half_v2 &operator-() {
-    Buf ^= 0x8000;
-    return *this;
+  __SYCL_CONSTEXPR_HALF friend half_v2 operator-(const half_v2 other) {
+    return half_v2(uint16_t(-other.Buf ^ 0x800));
   }
 
   // Operator float
@@ -509,67 +534,67 @@ public:
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
                                                 const double &rhs) {           \
-    return lhs.Data op rhs;                                                    \
+    return lhs.Data op static_cast<StorageT>(rhs);                             \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(const double &lhs,             \
                                                 const half &rhs) {             \
-    return lhs op rhs.Data;                                                    \
+    return static_cast<StorageT>(lhs) op rhs.Data;                             \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
                                                 const float &rhs) {            \
-    return lhs.Data op rhs;                                                    \
+    return lhs.Data op static_cast<StorageT>(rhs);                             \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(const float &lhs,              \
                                                 const half &rhs) {             \
-    return lhs op rhs.Data;                                                    \
+    return static_cast<StorageT>(lhs) op rhs.Data;                             \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
                                                 const int &rhs) {              \
-    return lhs.Data op rhs;                                                    \
+    return static_cast<int>(lhs.Data) op rhs;                                  \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(const int &lhs,                \
                                                 const half &rhs) {             \
-    return lhs op rhs.Data;                                                    \
+    return lhs op static_cast<int>(rhs.Data);                                  \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
                                                 const long &rhs) {             \
-    return lhs.Data op rhs;                                                    \
+    return static_cast<long>(lhs.Data) op rhs;                                 \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(const long &lhs,               \
                                                 const half &rhs) {             \
-    return lhs op rhs.Data;                                                    \
+    return lhs op static_cast<long>(rhs.Data);                                 \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
                                                 const long long &rhs) {        \
-    return lhs.Data op rhs;                                                    \
+    return static_cast<long long>(lhs.Data) op rhs;                            \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(const long long &lhs,          \
                                                 const half &rhs) {             \
-    return lhs op rhs.Data;                                                    \
+    return lhs op static_cast<long long>(rhs.Data);                            \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
                                                 const unsigned int &rhs) {     \
-    return lhs.Data op rhs;                                                    \
+    return static_cast<unsigned int>(lhs.Data) op rhs;                         \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(const unsigned int &lhs,       \
                                                 const half &rhs) {             \
-    return lhs op rhs.Data;                                                    \
+    return lhs op static_cast<unsigned int>(rhs.Data);                         \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(const half &lhs,               \
                                                 const unsigned long &rhs) {    \
-    return lhs.Data op rhs;                                                    \
+    return static_cast<unsigned long>(lhs.Data) op rhs;                        \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(const unsigned long &lhs,      \
                                                 const half &rhs) {             \
-    return lhs op rhs.Data;                                                    \
+    return lhs op static_cast<unsigned long>(rhs.Data);                        \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(                               \
       const half &lhs, const unsigned long long &rhs) {                        \
-    return lhs.Data op rhs;                                                    \
+    return static_cast<unsigned long long>(lhs.Data) op rhs;                   \
   }                                                                            \
   __SYCL_CONSTEXPR_HALF friend bool operator op(const unsigned long long &lhs, \
                                                 const half &rhs) {             \
-    return lhs op rhs.Data;                                                    \
+    return lhs op static_cast<unsigned long long>(rhs.Data);                   \
   }
   OP(==)
   OP(!=)

--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -278,14 +278,15 @@ public:
   }
 
   // Operator neg
-  constexpr half_v2 &operator-() {
-    Buf ^= 0x8000;
-    return *this;
-  }
-
   __SYCL_CONSTEXPR_HALF friend half_v2 operator-(half_v2 other) {
     other.Buf ^= 0x8000;
     return other;
+  }
+
+  // TODO: legacy operator remove when ABI break allowed
+  constexpr half_v2 &operator-() {
+    Buf ^= 0x8000;
+    return *this;
   }
 
   // Operator float

--- a/sycl/test/abi/sycl_symbols_windows.dump
+++ b/sycl/test/abi/sycl_symbols_windows.dump
@@ -390,6 +390,7 @@
 ??0half_v2@host_half_impl@detail@sycl@cl@@QEAA@AEBM@Z
 ??0half_v2@host_half_impl@detail@sycl@cl@@QEAA@AEBV01234@@Z
 ??0half_v2@host_half_impl@detail@sycl@cl@@QEAA@G@Z
+??0half_v2@host_half_impl@detail@sycl@cl@@QEAA@AEBN@Z
 ??0handler@sycl@cl@@AEAA@V?$shared_ptr@Vqueue_impl@detail@sycl@cl@@@std@@00_N@Z
 ??0handler@sycl@cl@@AEAA@V?$shared_ptr@Vqueue_impl@detail@sycl@cl@@@std@@_N@Z
 ??0host_selector@sycl@cl@@QEAA@$$QEAV012@@Z


### PR DESCRIPTION
This PR resolves ambiguous operators on windows caused by https://github.com/intel/llvm/commit/ad47114ad8500c78046161d492ac13a8e3e610eb. 
The issue is caused by MSVC not having the same specialisation ranking as linux, and additional operators being considered of similar specialisation through implicit conversions. 
The fix adds logical operators for the host half type, and explicitly converts types for the general half to prevent implicit conversions.

This is a fix for: #6142