### PR TITLE
[NFC] Update test for Windows to match clang-offload-bundler option

### DIFF
--- a/clang/test/Driver/sycl-intelfpga-static-lib-win.cpp
+++ b/clang/test/Driver/sycl-intelfpga-static-lib-win.cpp
@@ -33,7 +33,7 @@
 /// Check for unbundle and use of deps in static lib
 // RUN: %clang_cl --target=x86_64-pc-windows-msvc -fsycl -fno-sycl-device-lib=all -fintelfpga -Xshardware %t.lib -### 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHECK_UNBUNDLE %s
-// CHECK_UNBUNDLE: clang-offload-bundler" "-type=aoo" "-targets=sycl-fpga_dep" "-inputs={{.*}}" "-outputs=[[DEPFILES:.+\.txt]]" "-unbundle"
+// CHECK_UNBUNDLE: clang-offload-bundler" "-type=aoo" "-targets=sycl-fpga_dep" "-input={{.*}}" "-output=[[DEPFILES:.+\.txt]]" "-unbundle"
 // CHECK_UNBUNDLE: aoc{{.*}} "-dep-files=@[[DEPFILES]]"
 
 /// Check for no unbundle and use of deps in static lib when using triple


### PR DESCRIPTION
The options used for the clang-offload-bundler have been updated.  Update the
test to match these expectation.  This was previously masked in testing due to
the requires clang-driver check which was recently removed.