### PR TITLE
[SYCL][Build] Add --enable-all-llvm-targets switch to configure.py

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -75,6 +75,11 @@ def do_configure(args):
         sycl_build_pi_hip_platform = args.hip_platform
         sycl_enabled_plugins.append("hip")
 
+    # all backends don't require 3rd party dependencies, so can be built/tested
+    # even if specific runtimes are not available
+    if args.enable_all_backends:
+        llvm_targets_to_build += ';NVPTX;AMDGPU'
+
     if args.werror or args.ci_defaults:
         sycl_werror = 'ON'
         xpti_enable_werror = 'ON'
@@ -210,6 +215,7 @@ def main():
     parser.add_argument("--hip-platform", type=str, choices=['AMD', 'NVIDIA'], default='AMD', help="choose hardware platform for HIP backend")
     parser.add_argument("--arm", action='store_true', help="build ARM support rather than x86")
     parser.add_argument("--enable-esimd-emulator", action='store_true', help="build with ESIMD emulation support")
+    parser.add_argument("--enable-all-backends", action='store_true', help="build compiler with all supported backends")
     parser.add_argument("--no-assertions", action='store_true', help="build without assertions")
     parser.add_argument("--docs", action='store_true', help="build Doxygen documentation")
     parser.add_argument("--werror", action='store_true', help="Don't treat warnings as errors")

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -75,9 +75,9 @@ def do_configure(args):
         sycl_build_pi_hip_platform = args.hip_platform
         sycl_enabled_plugins.append("hip")
 
-    # all backends don't require 3rd party dependencies, so can be built/tested
-    # even if specific runtimes are not available
-    if args.enable_all_backends:
+    # all llvm compiler targets don't require 3rd party dependencies, so can be
+    # built/tested even if specific runtimes are not available
+    if args.enable_all_llvm_targets:
         llvm_targets_to_build += ';NVPTX;AMDGPU'
 
     if args.werror or args.ci_defaults:
@@ -215,7 +215,7 @@ def main():
     parser.add_argument("--hip-platform", type=str, choices=['AMD', 'NVIDIA'], default='AMD', help="choose hardware platform for HIP backend")
     parser.add_argument("--arm", action='store_true', help="build ARM support rather than x86")
     parser.add_argument("--enable-esimd-emulator", action='store_true', help="build with ESIMD emulation support")
-    parser.add_argument("--enable-all-backends", action='store_true', help="build compiler with all supported backends")
+    parser.add_argument("--enable-all-llvm-targets", action='store_true', help="build compiler with all supported targets, it doesn't change runtime build")
     parser.add_argument("--no-assertions", action='store_true', help="build without assertions")
     parser.add_argument("--docs", action='store_true', help="build Doxygen documentation")
     parser.add_argument("--werror", action='store_true', help="Don't treat warnings as errors")

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -121,8 +121,8 @@ flags can be found by launching the script with `--help`):
 * `--hip` -> use the HIP backend (see [HIP](#build-dpc-toolchain-with-support-for-hip-amd))
 * `--hip-platform` -> select the platform used by the hip backend, `AMD` or `NVIDIA` (see [HIP AMD](#build-dpc-toolchain-with-support-for-hip-amd) or see [HIP NVIDIA](#build-dpc-toolchain-with-support-for-hip-nvidia))
 * `--enable-esimd-emulator` -> enable ESIMD CPU emulation (see [ESIMD CPU emulation](#build-dpc-toolchain-with-support-for-esimd-cpu))
-* `--enable-all-backends` -> build compiler (but not a runtime) with all
-  supported backends
+* `--enable-all-llvm-targets` -> build compiler (but not a runtime) with all
+  supported targets
 * `--shared-libs` -> Build shared libraries
 * `-t` -> Build type (Debug or Release)
 * `-o` -> Path to build directory

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -116,14 +116,15 @@ python %DPCPP_HOME%\llvm\buildbot\compile.py
 You can use the following flags with `configure.py` (full list of available
 flags can be found by launching the script with `--help`):
 
-* `--system-ocl` -> Don't download OpenCL headers and library via CMake but use the system ones
 * `--werror` -> treat warnings as errors when compiling LLVM
 * `--cuda` -> use the cuda backend (see [Nvidia CUDA](#build-dpc-toolchain-with-support-for-nvidia-cuda))
 * `--hip` -> use the HIP backend (see [HIP](#build-dpc-toolchain-with-support-for-hip-amd))
 * `--hip-platform` -> select the platform used by the hip backend, `AMD` or `NVIDIA` (see [HIP AMD](#build-dpc-toolchain-with-support-for-hip-amd) or see [HIP NVIDIA](#build-dpc-toolchain-with-support-for-hip-nvidia))
 * `--enable-esimd-emulator` -> enable ESIMD CPU emulation (see [ESIMD CPU emulation](#build-dpc-toolchain-with-support-for-esimd-cpu))
+* `--enable-all-backends` -> build compiler (but not a runtime) with all
+  supported backends
 * `--shared-libs` -> Build shared libraries
-* `-t` -> Build type (debug or release)
+* `-t` -> Build type (Debug or Release)
 * `-o` -> Path to build directory
 * `--cmake-gen` -> Set build system type (e.g. `--cmake-gen "Unix Makefiles"`)
 


### PR DESCRIPTION
Can be used to enable all supported llvm compiler targets in the compiler build,
currently:
* NVPTX
* AMDGPU

Compiler backends do not require any 3rd party software to build and
test, this can be useful in some local testing, for example when
bringing changes from upstream

Also minor fixes to docs based on currently supported switches.

This is NFC for all existing processes.