### PR TITLE
[SYCL] Restrict collection of information for optimization record

### DIFF
--- a/clang/include/clang/Basic/LangOptions.h
+++ b/clang/include/clang/Basic/LangOptions.h
@@ -470,6 +470,10 @@ public:
   /// The seed used by the randomize structure layout feature.
   std::string RandstructSeed;
 
+  /// The name of the file to which the backend should save YAML optimization
+  /// records.
+  std::string OptRecordFile;
+
   LangOptions();
 
   /// Set language defaults for the given input language and

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5897,7 +5897,7 @@ def arcmt_action_EQ : Joined<["-"], "arcmt-action=">, Flags<[CC1Option, NoDriver
 
 def opt_record_file : Separate<["-"], "opt-record-file">,
   HelpText<"File name to use for YAML optimization record output">,
-  MarshallingInfoString<CodeGenOpts<"OptRecordFile">>;
+  MarshallingInfoString<LangOpts<"OptRecordFile">>;
 def opt_record_passes : Separate<["-"], "opt-record-passes">,
   HelpText<"Only record remark information for passes whose names match the given regular expression">;
 def opt_record_format : Separate<["-"], "opt-record-format">,

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -1946,6 +1946,8 @@ bool CompilerInvocation::ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args,
 
   bool NeedLocTracking = false;
 
+  Opts.OptRecordFile = LangOpts->OptRecordFile;
+
   if (!Opts.OptRecordFile.empty())
     NeedLocTracking = true;
 
@@ -3318,6 +3320,8 @@ void CompilerInvocation::GenerateLangArgs(const LangOptions &Opts,
       GenerateArg(Args, OPT_pic_is_pie, SA);
     for (StringRef Sanitizer : serializeSanitizerKinds(Opts.Sanitize))
       GenerateArg(Args, OPT_fsanitize_EQ, Sanitizer, SA);
+    if (!Opts.OptRecordFile.empty())
+      GenerateArg(Args, OPT_opt_record_file, Opts.OptRecordFile, SA);
 
     return;
   }
@@ -3616,6 +3620,12 @@ bool CompilerInvocation::ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.PIE = Args.hasArg(OPT_pic_is_pie);
     parseSanitizerKinds("-fsanitize=", Args.getAllArgValues(OPT_fsanitize_EQ),
                         Diags, Opts.Sanitize);
+
+    // OptRecordFile is used to generate the optimization record file should
+    // be set regardless of the input type.
+    if (Args.hasArg(OPT_opt_record_file))
+      Opts.OptRecordFile =
+          std::string(Args.getLastArgValue(OPT_opt_record_file));
 
     return Diags.getNumErrors() == NumErrorsBefore;
   }


### PR DESCRIPTION
Collect information for optimization record only if the optmization
record is saved by user (i.e. -fsave-optimization-record or
-opt-record-file is passed). This patch prevents unecessary calls
to opt-report handlers when not required.

I couldn't think of a way to add a test for this since there is no
change in output. Information is collected when the flag is passed
and emitted into optimization record. Information is no longer
collected when there is no optimization record.

This is a follow up to https://github.com/intel/llvm/pull/3492
and https://github.com/intel/llvm/pull/3730/

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>