### PR TITLE
[SYCL][CUDA][Windows] fixed async barrier definition clash with predefined macro

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/cuda/barrier.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/cuda/barrier.hpp
@@ -133,7 +133,13 @@ public:
 #endif
   }
 
+// On Windows certain headers define macros min/max
+#pragma push_macro("max")
+#ifdef max
+#undef max
+#endif
   static constexpr uint64_t max() { return (1 << 20) - 1; }
+#pragma pop_macro("max")
 };
 
 } // namespace sycl::ext::oneapi::experimental::cuda


### PR DESCRIPTION
Fixed async barrier definition clash with `max` macro defined in some headers on windows by temporarily undefining the macro.

The issue was reported here: https://github.com/intel/llvm/pull/5303#issuecomment-1131008516