### PR TITLE
[ESIMD] Don't force-inline VCStackCall functions.

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -1650,10 +1650,14 @@ size_t SYCLLowerESIMDPass::runOnFunction(Function &F,
   // There is a current limitation of GPU vector backend that requires kernel
   // functions to be inlined into the kernel itself. To overcome this
   // limitation, mark every function called from ESIMD kernel with
-  // 'alwaysinline' attribute, except few cases.
+  // 'alwaysinline' attribute, except few cases:
+  //     - kernels are not called from device code, so can't be inlined
   if ((F.getCallingConv() != CallingConv::SPIR_KERNEL) &&
+      // - 'noninline' should not be overridden
       !F.hasFnAttribute(Attribute::NoInline) &&
+      // - 'alwaysinline' should not be duplicated
       !F.hasFnAttribute(Attribute::AlwaysInline) &&
+      // - VC BE forbids 'alwaysinline' and "VCStackCall" on the same function
       !F.hasFnAttribute(llvm::genx::VCFunctionMD::VCStackCall))
     F.addFnAttr(Attribute::AlwaysInline);
 

--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -1650,10 +1650,11 @@ size_t SYCLLowerESIMDPass::runOnFunction(Function &F,
   // There is a current limitation of GPU vector backend that requires kernel
   // functions to be inlined into the kernel itself. To overcome this
   // limitation, mark every function called from ESIMD kernel with
-  // 'alwaysinline' attribute.
+  // 'alwaysinline' attribute, except few cases.
   if ((F.getCallingConv() != CallingConv::SPIR_KERNEL) &&
       !F.hasFnAttribute(Attribute::NoInline) &&
-      !F.hasFnAttribute(Attribute::AlwaysInline))
+      !F.hasFnAttribute(Attribute::AlwaysInline) &&
+      !F.hasFnAttribute(llvm::genx::VCFunctionMD::VCStackCall))
     F.addFnAttr(Attribute::AlwaysInline);
 
   SmallVector<CallInst *, 32> ESIMDIntrCalls;

--- a/llvm/test/SYCLLowerIR/ESIMD/force_inline.ll
+++ b/llvm/test/SYCLLowerIR/ESIMD/force_inline.ll
@@ -1,0 +1,49 @@
+; This test checks that LowerESIMD pass adds alwaysinline attribute to
+; functions, except those marked with
+; - spir_kernel
+; - noinline
+; - "VCStackCall"
+
+; RUN: opt -passes=LowerESIMD -S < %s | FileCheck %s
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+; Function w/o attributes, must be marked with "alwaysinline"
+define dso_local spir_func void @no_attrs_func(float addrspace(4)* %ptr) {
+; CHECK: define dso_local spir_func void @no_attrs_func(float addrspace(4)* %ptr) #[[ATTRS1:[0-9]+]] {
+  store float 2.0, float addrspace(4)* %ptr
+  ret void
+}
+
+; VCStackCall function, must not be marked with "alwaysinline"
+define dso_local spir_func void @vc_stack_call_func(float addrspace(4)* %ptr) #0 {
+; CHECK: define dso_local spir_func void @vc_stack_call_func(float addrspace(4)* %ptr) #[[ATTRS2:[0-9]+]] {
+  store float 1.0, float addrspace(4)* %ptr
+  ret void
+}
+
+; Function with "noinline" attribute", must not be marked with "alwaysinline"
+define dso_local spir_func void @noinline_func(float addrspace(4)* %ptr) #1 {
+; CHECK: define dso_local spir_func void @noinline_func(float addrspace(4)* %ptr) #[[ATTRS3:[0-9]+]] {
+  store float 2.0, float addrspace(4)* %ptr
+  ret void
+}
+
+; Kernel, must not be marked with "alwaysinline"
+define dso_local spir_kernel void @KERNEL(float addrspace(4)* %ptr) !sycl_explicit_simd !0 !intel_reqd_sub_group_size !1 {
+; CHECK: define dso_local spir_kernel void @KERNEL(float addrspace(4)* %ptr) #[[ATTRS4:[0-9]+]] !sycl_explicit_simd !{{.*}} !intel_reqd_sub_group_size !{{.*}} {
+  store float 2.0, float addrspace(4)* %ptr
+  ret void
+}
+
+
+attributes #0 = { "VCStackCall" }
+attributes #1 = { noinline }
+; CHECK-DAG: attributes #[[ATTRS1]] = { alwaysinline }
+; CHECK-DAG: attributes #[[ATTRS2]] = { "VCStackCall" }
+; CHECK-DAG: attributes #[[ATTRS3]] = { noinline }
+; CHECK-DAG: attributes #[[ATTRS4]] = { "CMGenxMain" "oclrt"="1" }
+
+!0 = !{}
+!1 = !{i32 1}


### PR DESCRIPTION
Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>