### PR TITLE
[SYCL] Allow calls to _wassert in kernel code

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -617,7 +617,10 @@ public:
         // info is in ParsedAttr. We don't have to map from Attr to ParsedAttr
         // currently. Erich is currently working on that in LLVM, once that is
         // committed we need to change this".
-        if (FD->hasAttr<DLLImportAttr>()) {
+        // `_wassert` is provided by libdevice's CRT wrapper, don't error on
+        // it.
+        if (FD->hasAttr<DLLImportAttr>() &&
+            FD->getNameAsString() != "_wassert") {
           SemaRef.Diag(e->getExprLoc(), diag::err_sycl_restrict)
               << Sema::KernelCallDllimportFunction;
           SemaRef.Diag(FD->getLocation(), diag::note_callee_decl) << FD;


### PR DESCRIPTION
On Windows `_wassert` is provided by libdevice's CRT wrapper, make sure that the compiler does not issue dll import error when it gets called.

This is somewhat awkward to test, as llvm test suite either explicitly excludes assert tests for windows and/or hip/cuda, or those that are available are not suitable for windows (use of `true` command as a placeholder).

Fixes: https://github.com/intel/llvm/issues/5922