### PR TITLE
[SYCL] Add new metadata kernel_arg_exclusive_ptr

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1920,13 +1920,13 @@ void CodeGenModule::GenOpenCLArgMetadata(llvm::Function *Fn,
       // runtime allocated alignment.
       // 2. kernel_arg_exclusive_ptr - To indicate that it is illegal to
       // dereference the pointer from outside current invocation of the
-      // kernel
+      // kernel.
       // In both cases, the value of metadata element is 'true' for any
       // kernel arguments that corresponds to the base pointer of an accessor
       // and 'false' otherwise.
-      // Note: Although both metadata applies only to base pointer of accessor
-      // currently, it is possible that one or both may be extended to include
-      // other pointers. Therefore, both metadata is required.
+      // Note: Although both metadata apply only to the base pointer of an
+      // accessor currently, it is possible that one or both may be extended
+      // to include other pointers. Therefore, both metadata are required.
       if (parm->hasAttr<SYCLAccessorPtrAttr>()) {
         isKernelArgAnAccessor = true;
         argSYCLAccessorPtrs.push_back(

--- a/clang/test/CodeGenSYCL/kernel-arg-accessor-pointer.cpp
+++ b/clang/test/CodeGenSYCL/kernel-arg-accessor-pointer.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -triple spir64-unknown-unknown -disable-llvm-passes -opaque-pointers -emit-llvm %s -o - | FileCheck %s
 
 // This test checks if the metadata "kernel-arg-runtime-aligned" and "kernel_arg_exclusive_ptr"
-// is generated if the kernel captures an accessor.
+// are generated if the kernel captures an accessor.
 
 #include "sycl.hpp"
 

--- a/clang/test/CodeGenSYCL/kernel-arg-accessor-pointer.cpp
+++ b/clang/test/CodeGenSYCL/kernel-arg-accessor-pointer.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -triple spir64-unknown-unknown -disable-llvm-passes -opaque-pointers -emit-llvm %s -o - | FileCheck %s
 
-// This test checks if the metadata "kernel-arg-runtime-aligned"
+// This test checks if the metadata "kernel-arg-runtime-aligned" and "kernel_arg_exclusive_ptr"
 // is generated if the kernel captures an accessor.
 
 #include "sycl.hpp"
@@ -100,7 +100,8 @@ int main() {
 // CHECK-SAME: ptr noundef byval{{.*}}align 4 [[ACC_RANGE2:%[a-zA-Z0-9_]+6]],
 // CHECK-SAME: ptr noundef byval{{.*}}align 4 [[MEM_RANGE2:%[a-zA-Z0-9_]+7]],
 // CHECK-SAME: ptr noundef byval{{.*}}align 4 [[OFFSET2:%[a-zA-Z0-9_]+8]])
-// CHECK-SAME: !kernel_arg_runtime_aligned ![[#RTALIGNED1:]]
+// CHECK-SAME: !kernel_arg_runtime_aligned ![[#ACCESSORMD1:]]
+// CHECK-SAME: !kernel_arg_exclusive_ptr ![[#ACCESSORMD1]]
 
 // Check kernel_readOnlyAcc parameters
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_readOnlyAcc
@@ -108,29 +109,34 @@ int main() {
 // CHECK-SAME: ptr noundef byval{{.*}}align 4 [[ACC_RANGE1:%[a-zA-Z0-9_]+1]],
 // CHECK-SAME: ptr noundef byval{{.*}}align 4 [[MEM_RANGE1:%[a-zA-Z0-9_]+2]],
 // CHECK-SAME: ptr noundef byval{{.*}}align 4 [[OFFSET1:%[a-zA-Z0-9_]+3]]
-// CHECK-SAME: !kernel_arg_runtime_aligned ![[#RTALIGNED2:]]
+// CHECK-SAME: !kernel_arg_runtime_aligned ![[#ACCESSORMD2:]]
+// CHECK-SAME: !kernel_arg_exclusive_ptr ![[#ACCESSORMD2]]
 
 // Check kernel_B parameters
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_B
 // CHECK-NOT: kernel_arg_runtime_aligned
+// CHECK-NOT: kernel_arg_exclusive_ptr
 
 // Check kernel_C parameters
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_C
 // CHECK-SAME: i32 noundef [[MEM_ARG1:%[a-zA-Z0-9_]+]]
 // CHECK-NOT: kernel_arg_runtime_aligned
+// CHECK-NOT: kernel_arg_exclusive_ptr
 
 // Check usm_ptr parameters
 // CHECK: define {{.*}}spir_kernel void @{{.*}}usm_ptr
 // CHECK-SAME: ptr addrspace(1) noundef align 4 [[MEM_ARG1:%[a-zA-Z0-9_]+]],
 // CHECK-SAME: ptr addrspace(1) noundef align 4 [[MEM_ARG1:%[a-zA-Z0-9_]+]]
 // CHECK-NOT: kernel_arg_runtime_aligned
+// CHECK-NOT: kernel_arg_exclusive_ptr
 
 // CHECK: define {{.*}}spir_kernel void @{{.*}}localAccessor
 // CHECK-SAME: ptr addrspace(1) noundef align 4 [[MEM_ARG1:%[a-zA-Z0-9_]+]],
 // CHECK-SAME: ptr noundef byval{{.*}}align 4 [[ACC_RANGE1:%[a-zA-Z0-9_]+1]],
 // CHECK-SAME: ptr noundef byval{{.*}}align 4 [[MEM_RANGE1:%[a-zA-Z0-9_]+2]],
 // CHECK-SAME: ptr noundef byval{{.*}}align 4 [[OFFSET1:%[a-zA-Z0-9_]+3]]
-// CHECK-SAME: !kernel_arg_runtime_aligned ![[#RTALIGNED2]]
+// CHECK-SAME: !kernel_arg_runtime_aligned ![[#ACCESSORMD2]]
+// CHECK-SAME: !kernel_arg_exclusive_ptr ![[#ACCESSORMD2]]
 
 // Check kernel_acc_raw_ptr parameters
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_acc_raw_ptr
@@ -139,7 +145,8 @@ int main() {
 // CHECK-SAME: ptr noundef byval{{.*}}align 4 [[MEM_RANGE1:%[a-zA-Z0-9_]+2]],
 // CHECK-SAME: ptr noundef byval{{.*}}align 4 [[OFFSET1:%[a-zA-Z0-9_]+3]]
 // CHECK-SAME: ptr addrspace(1) noundef align 4 [[MEM_ARG1:%[a-zA-Z0-9_]+]]
-// CHECK-SAME: !kernel_arg_runtime_aligned ![[#RTALIGNED3:]]
+// CHECK-SAME: !kernel_arg_runtime_aligned ![[#ACCESSORMD3:]]
+// CHECK-SAME: !kernel_arg_exclusive_ptr ![[#ACCESSORMD3]]
 
 // Check esimd_kernel_with_acc parameters
 // CHECK: define {{.*}}spir_kernel void @{{.*}}esimd_kernel_with_acc
@@ -148,6 +155,6 @@ int main() {
 // Check kernel-arg-runtime-aligned metadata.
 // The value of any metadata element is 1 for any kernel arguments
 // that corresponds to the base pointer of an accessor and 0 otherwise.
-// CHECK: ![[#RTALIGNED1]] = !{i1 true, i1 false, i1 false, i1 false, i1 true, i1 false, i1 false, i1 false}
-// CHECK: ![[#RTALIGNED2]] = !{i1 true, i1 false, i1 false, i1 false}
-// CHECK: ![[#RTALIGNED3]] = !{i1 true, i1 false, i1 false, i1 false, i1 false}
+// CHECK: ![[#ACCESSORMD1]] = !{i1 true, i1 false, i1 false, i1 false, i1 true, i1 false, i1 false, i1 false}
+// CHECK: ![[#ACCESSORMD2]] = !{i1 true, i1 false, i1 false, i1 false}
+// CHECK: ![[#ACCESSORMD3]] = !{i1 true, i1 false, i1 false, i1 false, i1 false}


### PR DESCRIPTION
kernel_arg_exclusive_ptr metadata guarantees that the kernel
pointer argument, or pointers that derive from it, will not be
dereferenced outside current invocation of the kernel.

At the moment, this guarantee is met by the base pointer of an
accessor.

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>