### PR TITLE
[SYCL] Align usm_allocator with the specification

### DIFF
--- a/sycl/include/CL/sycl/usm/usm_allocator.hpp
+++ b/sycl/include/CL/sycl/usm/usm_allocator.hpp
@@ -30,7 +30,7 @@ __SYCL_EXPORT void *aligned_alloc(size_t alignment, size_t size,
 __SYCL_EXPORT void free(void *ptr, const context &ctxt,
                         const detail::code_location CodeLoc);
 
-template <typename T, usm::alloc AllocKind, size_t Alignment = alignof(T)>
+template <typename T, usm::alloc AllocKind, size_t Alignment = 0>
 class usm_allocator {
 public:
   using value_type = T;
@@ -116,7 +116,9 @@ public:
   }
 
 private:
-  constexpr size_t getAlignment() const { return Alignment; }
+  constexpr size_t getAlignment() const {
+    return std::max(alignof(T), Alignment);
+  }
 
   template <class U, usm::alloc AllocKindU, size_t AlignmentU>
   friend class usm_allocator;


### PR DESCRIPTION
According to

https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#_c_allocator_interface

the default value for the "Alignment" template parameter must be 0. Otherwise
the rebound allocator wouldn't change the alignment properly.

Test added in https://github.com/intel/llvm-test-suite/pull/1038