### PR TITLE
[SYCL] Remove unnecessary mutex locks from release and retain functions

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -2364,7 +2364,7 @@ pi_result piDeviceRelease(pi_device Device) {
 
   // Root devices are destroyed during the piTearDown process.
   if (Device->isSubDevice()) {
-    if (Device->RefCount.decrement_and_test()) {
+    if (Device->RefCount.decrementAndTest()) {
       delete Device;
     }
   }
@@ -3151,7 +3151,7 @@ pi_result ContextReleaseHelper(pi_context Context) {
 
   PI_ASSERT(Context, PI_INVALID_CONTEXT);
 
-  if (!Context->RefCount.decrement_and_test())
+  if (!Context->RefCount.decrementAndTest())
     return PI_SUCCESS;
 
   if (IndirectAccessTrackingEnabled) {
@@ -3334,7 +3334,7 @@ pi_result piQueueRelease(pi_queue Queue) {
 static pi_result piQueueReleaseInternal(pi_queue Queue, pi_queue LockedQueue) {
   PI_ASSERT(Queue, PI_INVALID_QUEUE);
 
-  if (!Queue->RefCount.decrement_and_test())
+  if (!Queue->RefCount.decrementAndTest())
     return PI_SUCCESS;
 
   if (Queue->OwnZeCommandQueue) {
@@ -3674,7 +3674,7 @@ static pi_result ZeMemFreeHelper(pi_context Context, void *Ptr,
     if (It == std::end(Context->MemAllocs)) {
       die("All memory allocations must be tracked!");
     }
-    if (!It->second.RefCount.decrement_and_test()) {
+    if (!It->second.RefCount.decrementAndTest()) {
       // Memory can't be deallocated yet.
       return PI_SUCCESS;
     }
@@ -3699,7 +3699,7 @@ static pi_result USMFreeHelper(pi_context Context, void *Ptr,
 pi_result piMemRelease(pi_mem Mem) {
   PI_ASSERT(Mem, PI_INVALID_MEM_OBJECT);
 
-  if (!Mem->RefCount.decrement_and_test())
+  if (!Mem->RefCount.decrementAndTest())
     return PI_SUCCESS;
 
   if (Mem->isImage()) {
@@ -4529,7 +4529,7 @@ pi_result piProgramRetain(pi_program Program) {
 pi_result piProgramRelease(pi_program Program) {
   PI_ASSERT(Program, PI_INVALID_PROGRAM);
 
-  if (!Program->RefCount.decrement_and_test())
+  if (!Program->RefCount.decrementAndTest())
     return PI_SUCCESS;
 
   delete Program;
@@ -4915,7 +4915,7 @@ pi_result piKernelRelease(pi_kernel Kernel) {
     }
   }
 
-  if (!Kernel->RefCount.decrement_and_test())
+  if (!Kernel->RefCount.decrementAndTest())
     return PI_SUCCESS;
 
   auto KernelProgram = Kernel->Program;
@@ -5562,7 +5562,7 @@ pi_result piEventRelease(pi_event Event) {
 static pi_result EventRelease(pi_event Event, pi_queue LockedQueue) {
   PI_ASSERT(Event, PI_INVALID_EVENT);
 
-  if (!Event->RefCount.decrement_and_test())
+  if (!Event->RefCount.decrementAndTest())
     return PI_SUCCESS;
 
   if (!Event->CleanedUp)
@@ -5794,7 +5794,7 @@ pi_result piSamplerRetain(pi_sampler Sampler) {
 pi_result piSamplerRelease(pi_sampler Sampler) {
   PI_ASSERT(Sampler, PI_INVALID_SAMPLER);
 
-  if (!Sampler->RefCount.decrement_and_test())
+  if (!Sampler->RefCount.decrementAndTest())
     return PI_SUCCESS;
 
   ZE_CALL(zeSamplerDestroy, (Sampler->ZeSampler));
@@ -7515,7 +7515,7 @@ static pi_result USMFreeHelper(pi_context Context, void *Ptr,
     if (It == std::end(Context->MemAllocs)) {
       die("All memory allocations must be tracked!");
     }
-    if (!It->second.RefCount.decrement_and_test()) {
+    if (!It->second.RefCount.decrementAndTest()) {
       // Memory can't be deallocated yet.
       return PI_SUCCESS;
     }

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -662,7 +662,7 @@ inline static pi_result createEventAndAssociateQueue(
   // piEventRelease requires access to the associated pi_queue.
   // In piEventRelease, the reference counter of the Queue is decremented
   // to release it.
-  Queue->RefCount++;
+  Queue->RefCount.increment();
 
   // SYCL RT does not track completion of the events, so it could
   // release a PI event as soon as that's not being waited in the app.
@@ -1334,7 +1334,7 @@ void _pi_queue::CaptureIndirectAccesses() {
         // SubmissionsCount turns to 0. We don't want to know how many times
         // allocation was retained by each submission.
         if (Pair.second)
-          Elem.second.RefCount++;
+          Elem.second.RefCount.increment();
       }
     }
     Kernel->SubmissionsCount++;
@@ -2354,7 +2354,7 @@ pi_result piDeviceRetain(pi_device Device) {
 
   // The root-device ref-count remains unchanged (always 1).
   if (Device->isSubDevice()) {
-    ++(Device->RefCount);
+    Device->RefCount.increment();
   }
   return PI_SUCCESS;
 }
@@ -2362,13 +2362,9 @@ pi_result piDeviceRetain(pi_device Device) {
 pi_result piDeviceRelease(pi_device Device) {
   PI_ASSERT(Device, PI_INVALID_DEVICE);
 
-  // Check if the device is already released
-  if (Device->RefCount <= 0)
-    die("piDeviceRelease: the device has been already released");
-
   // Root devices are destroyed during the piTearDown process.
   if (Device->isSubDevice()) {
-    if (--(Device->RefCount) == 0) {
+    if (Device->RefCount.decrement_and_test()) {
       delete Device;
     }
   }
@@ -2546,7 +2542,7 @@ pi_result piDeviceGetInfo(pi_device Device, pi_device_info ParamName,
     return ReturnValue(pi_uint32{(unsigned int)(Device->SubDevices.size())});
   }
   case PI_DEVICE_INFO_REFERENCE_COUNT:
-    return ReturnValue(pi_uint32{Device->RefCount});
+    return ReturnValue(pi_uint32{Device->RefCount.load()});
   case PI_DEVICE_INFO_PARTITION_PROPERTIES: {
     // SYCL spec says: if this SYCL device cannot be partitioned into at least
     // two sub devices then the returned vector must be empty.
@@ -3085,7 +3081,7 @@ pi_result piContextGetInfo(pi_context Context, pi_context_info ParamName,
   case PI_CONTEXT_INFO_NUM_DEVICES:
     return ReturnValue(pi_uint32(Context->Devices.size()));
   case PI_CONTEXT_INFO_REFERENCE_COUNT:
-    return ReturnValue(pi_uint32{Context->RefCount});
+    return ReturnValue(pi_uint32{Context->RefCount.load()});
   case PI_CONTEXT_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES:
   default:
     // TODO: implement other parameters
@@ -3144,7 +3140,7 @@ pi_result piContextRetain(pi_context Context) {
 
   PI_ASSERT(Context, PI_INVALID_CONTEXT);
 
-  ++(Context->RefCount);
+  Context->RefCount.increment();
   return PI_SUCCESS;
 }
 
@@ -3155,35 +3151,35 @@ pi_result ContextReleaseHelper(pi_context Context) {
 
   PI_ASSERT(Context, PI_INVALID_CONTEXT);
 
-  if (--(Context->RefCount) == 0) {
-    if (IndirectAccessTrackingEnabled) {
-      pi_platform Plt = Context->getPlatform();
-      auto &Contexts = Plt->Contexts;
-      auto It = std::find(Contexts.begin(), Contexts.end(), Context);
-      if (It != Contexts.end())
-        Contexts.erase(It);
-    }
-    ze_context_handle_t DestoryZeContext =
-        Context->OwnZeContext ? Context->ZeContext : nullptr;
+  if (!Context->RefCount.decrement_and_test())
+    return PI_SUCCESS;
 
-    // Clean up any live memory associated with Context
-    pi_result Result = Context->finalize();
-
-    // We must delete Context first and then destroy zeContext because
-    // Context deallocation requires ZeContext in some member deallocation of
-    // pi_context.
-    delete Context;
-
-    // Destruction of some members of pi_context uses L0 context
-    // and therefore it must be valid at that point.
-    // Technically it should be placed to the destructor of pi_context
-    // but this makes API error handling more complex.
-    if (DestoryZeContext)
-      ZE_CALL(zeContextDestroy, (DestoryZeContext));
-
-    return Result;
+  if (IndirectAccessTrackingEnabled) {
+    pi_platform Plt = Context->getPlatform();
+    auto &Contexts = Plt->Contexts;
+    auto It = std::find(Contexts.begin(), Contexts.end(), Context);
+    if (It != Contexts.end())
+      Contexts.erase(It);
   }
-  return PI_SUCCESS;
+  ze_context_handle_t DestoryZeContext =
+      Context->OwnZeContext ? Context->ZeContext : nullptr;
+
+  // Clean up any live memory associated with Context
+  pi_result Result = Context->finalize();
+
+  // We must delete Context first and then destroy zeContext because
+  // Context deallocation requires ZeContext in some member deallocation of
+  // pi_context.
+  delete Context;
+
+  // Destruction of some members of pi_context uses L0 context
+  // and therefore it must be valid at that point.
+  // Technically it should be placed to the destructor of pi_context
+  // but this makes API error handling more complex.
+  if (DestoryZeContext)
+    ZE_CALL(zeContextDestroy, (DestoryZeContext));
+
+  return Result;
 }
 
 pi_result piContextRelease(pi_context Context) {
@@ -3260,7 +3256,7 @@ pi_result piQueueGetInfo(pi_queue Queue, pi_queue_info ParamName,
   case PI_QUEUE_INFO_DEVICE:
     return ReturnValue(Queue->Device);
   case PI_QUEUE_INFO_REFERENCE_COUNT:
-    return ReturnValue(pi_uint32{Queue->RefCount});
+    return ReturnValue(pi_uint32{Queue->RefCount.load()});
   case PI_QUEUE_INFO_PROPERTIES:
     die("PI_QUEUE_INFO_PROPERTIES in piQueueGetInfo not implemented\n");
     break;
@@ -3280,58 +3276,56 @@ pi_result piQueueGetInfo(pi_queue Queue, pi_queue_info ParamName,
 }
 
 pi_result piQueueRetain(pi_queue Queue) {
-  Queue->RefCountExternal++;
-  Queue->RefCount++;
+  {
+    std::scoped_lock Lock(Queue->Mutex);
+    Queue->RefCountExternal++;
+  }
+  Queue->RefCount.increment();
   return PI_SUCCESS;
 }
 
 pi_result piQueueRelease(pi_queue Queue) {
   PI_ASSERT(Queue, PI_INVALID_QUEUE);
 
-  if (--(Queue->RefCountExternal) != 0) {
-    PI_CALL(piQueueReleaseInternal(Queue, nullptr));
-    return PI_SUCCESS;
-  }
+  {
+    std::scoped_lock Lock(Queue->Mutex);
 
-  // Only a single thread can reach external ref count equal to 0. So, the
-  // following codec doesn't need to be guarded with a mutex. If external ref
-  // count reaches 0 then it means that queue is not accessible anymore from
-  // outside of the Level Zero plugin. Behavior is undefined if DPCPP runtime
-  // calls piQueueRelease on a queue with external ref count 0 or provides such
-  // queue as an argument to any of the pi functions.
+    if ((--Queue->RefCountExternal) != 0)
+      return PI_SUCCESS;
 
-  // When external reference count goes to zero it is still possible
-  // that internal references still exists, e.g. command-lists that
-  // are not yet completed. So do full queue synchronization here
-  // and perform proper cleanup.
-  //
-  // It is possible to get to here and still have an open command list
-  // if no wait or finish ever occurred for this queue.
-  if (auto Res = Queue->executeAllOpenCommandLists())
-    return Res;
+    // When external reference count goes to zero it is still possible
+    // that internal references still exists, e.g. command-lists that
+    // are not yet completed. So do full queue synchronization here
+    // and perform proper cleanup.
+    //
+    // It is possible to get to here and still have an open command list
+    // if no wait or finish ever occurred for this queue.
+    if (auto Res = Queue->executeAllOpenCommandLists())
+      return Res;
 
-  // Make sure all commands get executed.
-  Queue->synchronize();
+    // Make sure all commands get executed.
+    Queue->synchronize();
 
-  // Destroy all the fences created associated with this queue.
-  for (auto it = Queue->CommandListMap.begin();
-       it != Queue->CommandListMap.end(); ++it) {
-    // This fence wasn't yet signalled when we polled it for recycling
-    // the command-list, so need to release the command-list too.
-    // For immediate commandlists we don't need to do an L0 reset of the
-    // commandlist but do need to do event cleanup which is also in the
-    // resetCommandList function.
-    if (it->second.InUse) {
-      Queue->resetCommandList(it, true);
+    // Destroy all the fences created associated with this queue.
+    for (auto it = Queue->CommandListMap.begin();
+         it != Queue->CommandListMap.end(); ++it) {
+      // This fence wasn't yet signalled when we polled it for recycling
+      // the command-list, so need to release the command-list too.
+      // For immediate commandlists we don't need to do an L0 reset of the
+      // commandlist but do need to do event cleanup which is also in the
+      // resetCommandList function.
+      if (it->second.InUse) {
+        Queue->resetCommandList(it, true);
+      }
+      // TODO: remove "if" when the problem is fixed in the level zero
+      // runtime. Destroy only if a queue is healthy. Destroying a fence may
+      // cause a hang otherwise.
+      // If the fence is a nullptr we are using immediate commandlists.
+      if (Queue->Healthy && it->second.ZeFence != nullptr)
+        ZE_CALL(zeFenceDestroy, (it->second.ZeFence));
     }
-    // TODO: remove "if" when the problem is fixed in the level zero
-    // runtime. Destroy only if a queue is healthy. Destroying a fence may
-    // cause a hang otherwise.
-    // If the fence is a nullptr we are using immediate commandlists.
-    if (Queue->Healthy && it->second.ZeFence != nullptr)
-      ZE_CALL(zeFenceDestroy, (it->second.ZeFence));
+    Queue->CommandListMap.clear();
   }
-  Queue->CommandListMap.clear();
 
   PI_CALL(piQueueReleaseInternal(Queue, nullptr));
   return PI_SUCCESS;
@@ -3340,13 +3334,9 @@ pi_result piQueueRelease(pi_queue Queue) {
 static pi_result piQueueReleaseInternal(pi_queue Queue, pi_queue LockedQueue) {
   PI_ASSERT(Queue, PI_INVALID_QUEUE);
 
-  if (--(Queue->RefCount) != 0)
+  if (!Queue->RefCount.decrement_and_test())
     return PI_SUCCESS;
 
-  // Only a single thread can reach internal ref count equal to 0. This means
-  // that the following code is executed by a single thread. If internal ref
-  // count reaches 0 then it means that queue is deleted. Behavior is undefined
-  // if the Level Zero plugin uses a deleted queue (with internal ref count 0).
   if (Queue->OwnZeCommandQueue) {
     for (auto &ZeQueue : Queue->ComputeQueueGroup.ZeQueues) {
       if (ZeQueue)
@@ -3666,7 +3656,7 @@ pi_result piMemGetInfo(pi_mem Mem, pi_mem_info ParamName, size_t ParamValueSize,
 pi_result piMemRetain(pi_mem Mem) {
   PI_ASSERT(Mem, PI_INVALID_MEM_OBJECT);
 
-  ++(Mem->RefCount);
+  Mem->RefCount.increment();
   return PI_SUCCESS;
 }
 
@@ -3684,7 +3674,7 @@ static pi_result ZeMemFreeHelper(pi_context Context, void *Ptr,
     if (It == std::end(Context->MemAllocs)) {
       die("All memory allocations must be tracked!");
     }
-    if (--(It->second.RefCount) != 0) {
+    if (!It->second.RefCount.decrement_and_test()) {
       // Memory can't be deallocated yet.
       return PI_SUCCESS;
     }
@@ -3709,11 +3699,9 @@ static pi_result USMFreeHelper(pi_context Context, void *Ptr,
 pi_result piMemRelease(pi_mem Mem) {
   PI_ASSERT(Mem, PI_INVALID_MEM_OBJECT);
 
-  if (--(Mem->RefCount) != 0)
+  if (!Mem->RefCount.decrement_and_test())
     return PI_SUCCESS;
 
-  // Only a single thread can reach ref count equal to 0. This means that
-  // the following code is executed by a single thread.
   if (Mem->isImage()) {
     char *ZeHandleImage;
     PI_CALL(Mem->getZeHandle(ZeHandleImage, _pi_mem::write_only));
@@ -4086,7 +4074,7 @@ pi_result piProgramGetInfo(pi_program Program, pi_program_info ParamName,
   ReturnHelper ReturnValue(ParamValueSize, ParamValue, ParamValueSizeRet);
   switch (ParamName) {
   case PI_PROGRAM_INFO_REFERENCE_COUNT:
-    return ReturnValue(pi_uint32{Program->RefCount});
+    return ReturnValue(pi_uint32{Program->RefCount.load()});
   case PI_PROGRAM_INFO_NUM_DEVICES:
     // TODO: return true number of devices this program exists for.
     return ReturnValue(pi_uint32{1});
@@ -4534,18 +4522,16 @@ pi_result piProgramGetBuildInfo(pi_program Program, pi_device Device,
 
 pi_result piProgramRetain(pi_program Program) {
   PI_ASSERT(Program, PI_INVALID_PROGRAM);
-  ++(Program->RefCount);
+  Program->RefCount.increment();
   return PI_SUCCESS;
 }
 
 pi_result piProgramRelease(pi_program Program) {
   PI_ASSERT(Program, PI_INVALID_PROGRAM);
 
-  if (--(Program->RefCount) != 0)
+  if (!Program->RefCount.decrement_and_test())
     return PI_SUCCESS;
 
-  // Only a single thread can reach ref count equal to 0. This means that
-  // the following code is executed by a single thread.
   delete Program;
 
   return PI_SUCCESS;
@@ -4791,7 +4777,7 @@ pi_result piKernelGetInfo(pi_kernel Kernel, pi_kernel_info ParamName,
   case PI_KERNEL_INFO_NUM_ARGS:
     return ReturnValue(pi_uint32{Kernel->ZeKernelProperties->numKernelArgs});
   case PI_KERNEL_INFO_REFERENCE_COUNT:
-    return ReturnValue(pi_uint32{Kernel->RefCount});
+    return ReturnValue(pi_uint32{Kernel->RefCount.load()});
   case PI_KERNEL_INFO_ATTRIBUTES:
     try {
       uint32_t Size;
@@ -4901,7 +4887,7 @@ pi_result piKernelRetain(pi_kernel Kernel) {
 
   PI_ASSERT(Kernel, PI_INVALID_KERNEL);
 
-  Kernel->RefCount++;
+  Kernel->RefCount.increment();
   return PI_SUCCESS;
 }
 
@@ -4929,11 +4915,9 @@ pi_result piKernelRelease(pi_kernel Kernel) {
     }
   }
 
-  if (--(Kernel->RefCount) != 0)
+  if (!Kernel->RefCount.decrement_and_test())
     return PI_SUCCESS;
 
-  // Only a single thread can reach ref count equal to 0. This means that
-  // the following code is executed by a single thread.
   auto KernelProgram = Kernel->Program;
   if (Kernel->OwnZeKernel)
     ZE_CALL(zeKernelDestroy, (Kernel->ZeKernel));
@@ -5074,7 +5058,7 @@ piEnqueueKernelLaunch(pi_queue Queue, pi_kernel Kernel, pi_uint32 WorkDim,
   // in use. Once the event has been signalled, the code in Event.cleanup() will
   // do a piReleaseKernel to update the reference count on the kernel, using the
   // kernel saved in CommandData.
-  Kernel->retain();
+  PI_CALL(piKernelRetain(Kernel));
 
   // Add to list of kernels to be submitted
   if (IndirectAccessTrackingEnabled)
@@ -5305,7 +5289,7 @@ pi_result piEventGetInfo(pi_event Event, pi_event_info ParamName,
     return ReturnValue(pi_cast<pi_int32>(Result));
   }
   case PI_EVENT_INFO_REFERENCE_COUNT:
-    return ReturnValue(pi_uint32{Event->RefCount});
+    return ReturnValue(pi_uint32{Event->RefCount.load()});
   default:
     zePrint("Unsupported ParamName in piEventGetInfo: ParamName=%d(%x)\n",
             ParamName, ParamName);
@@ -5404,36 +5388,34 @@ pi_result _pi_event::cleanup(pi_queue LockedQueue) {
       // Event has been signalled: If the fence for the associated command list
       // is signalled, then reset the fence and command list and add them to the
       // available list for reuse in PI calls.
-      if (Queue->RefCount > 0) {
-        auto it = Queue->CommandListMap.find(ZeCommandList);
-        if (it == Queue->CommandListMap.end()) {
-          die("Missing command-list completition fence");
-        }
+      auto it = Queue->CommandListMap.find(ZeCommandList);
+      if (it == Queue->CommandListMap.end()) {
+        die("Missing command-list completition fence");
+      }
 
-        // It is possible that the fence was already noted as signalled and
-        // reset.  In that case the InUse flag will be false, and
-        // we shouldn't query it, synchronize on it, or try to reset it.
-        if (it->second.InUse) {
-          // Workaround for VM_BIND mode.
-          // Make sure that the command-list doing memcpy is reset before
-          // non-USM host memory potentially involved in the memcpy is freed.
-          //
-          // NOTE: it is valid to wait for the fence here as long as we aren't
-          // doing batching on the involved command-list. Today memcpy goes by
-          // itself in a command list.
-          //
-          // TODO: this will unnecessarily(?) wait for non-USM memory buffers
-          // too, so we might need to add a new command type to differentiate.
-          //
-          ze_result_t ZeResult =
-              (CommandType == PI_COMMAND_TYPE_MEM_BUFFER_COPY)
-                  ? ZE_CALL_NOCHECK(zeHostSynchronize, (it->second.ZeFence))
-                  : ZE_CALL_NOCHECK(zeFenceQueryStatus, (it->second.ZeFence));
+      // It is possible that the fence was already noted as signalled and
+      // reset.  In that case the InUse flag will be false, and
+      // we shouldn't query it, synchronize on it, or try to reset it.
+      if (it->second.InUse) {
+        // Workaround for VM_BIND mode.
+        // Make sure that the command-list doing memcpy is reset before
+        // non-USM host memory potentially involved in the memcpy is freed.
+        //
+        // NOTE: it is valid to wait for the fence here as long as we aren't
+        // doing batching on the involved command-list. Today memcpy goes by
+        // itself in a command list.
+        //
+        // TODO: this will unnecessarily(?) wait for non-USM memory buffers
+        // too, so we might need to add a new command type to differentiate.
+        //
+        ze_result_t ZeResult =
+            (CommandType == PI_COMMAND_TYPE_MEM_BUFFER_COPY)
+                ? ZE_CALL_NOCHECK(zeHostSynchronize, (it->second.ZeFence))
+                : ZE_CALL_NOCHECK(zeFenceQueryStatus, (it->second.ZeFence));
 
-          if (ZeResult == ZE_RESULT_SUCCESS) {
-            Queue->resetCommandList(it, true);
-            ZeCommandList = nullptr;
-          }
+        if (ZeResult == ZE_RESULT_SUCCESS) {
+          Queue->resetCommandList(it, true);
+          ZeCommandList = nullptr;
         }
       }
     }
@@ -5527,10 +5509,8 @@ pi_result piEventsWait(pi_uint32 NumEvents, const pi_event *EventList) {
       // Lock automatically releases when this goes out of scope.
       std::scoped_lock lock(Queue->Mutex);
 
-      if (Queue->RefCount > 0) {
-        if (auto Res = Queue->executeAllOpenCommandLists())
-          return Res;
-      }
+      if (auto Res = Queue->executeAllOpenCommandLists())
+        return Res;
     }
   }
   for (uint32_t I = 0; I < NumEvents; I++) {
@@ -5571,7 +5551,7 @@ pi_result piEventSetStatus(pi_event Event, pi_int32 ExecutionStatus) {
 }
 
 pi_result piEventRetain(pi_event Event) {
-  ++(Event->RefCount);
+  Event->RefCount.increment();
   return PI_SUCCESS;
 }
 
@@ -5581,45 +5561,44 @@ pi_result piEventRelease(pi_event Event) {
 
 static pi_result EventRelease(pi_event Event, pi_queue LockedQueue) {
   PI_ASSERT(Event, PI_INVALID_EVENT);
-  if (!Event->RefCount) {
-    die("piEventRelease: called on a destroyed event");
-  }
 
-  if (--(Event->RefCount) == 0) {
-    if (!Event->CleanedUp)
-      Event->cleanup(LockedQueue);
+  if (!Event->RefCount.decrement_and_test())
+    return PI_SUCCESS;
 
-    if (Event->CommandType == PI_COMMAND_TYPE_MEM_BUFFER_UNMAP &&
-        Event->CommandData) {
-      // Free the memory allocated in the piEnqueueMemBufferMap.
-      if (auto Res = ZeMemFreeHelper(Event->Context, Event->CommandData))
-        return Res;
-      Event->CommandData = nullptr;
-    }
-    if (Event->OwnZeEvent) {
-      ZE_CALL(zeEventDestroy, (Event->ZeEvent));
-    }
-    // It is possible that host-visible event was never created.
-    // In case it was check if that's different from this same event
-    // and release a reference to it.
-    if (Event->HostVisibleEvent && Event->HostVisibleEvent != Event) {
-      // Decrement ref-count of the host-visible proxy event.
-      PI_CALL(EventRelease(Event->HostVisibleEvent, LockedQueue));
-    }
+  if (!Event->CleanedUp)
+    Event->cleanup(LockedQueue);
 
-    auto Context = Event->Context;
-    if (auto Res = Context->decrementUnreleasedEventsInPool(Event))
+  if (Event->CommandType == PI_COMMAND_TYPE_MEM_BUFFER_UNMAP &&
+      Event->CommandData) {
+    // Free the memory allocated in the piEnqueueMemBufferMap.
+    if (auto Res = ZeMemFreeHelper(Event->Context, Event->CommandData))
       return Res;
-
-    // We intentionally incremented the reference counter when an event is
-    // created so that we can avoid pi_queue is released before the associated
-    // pi_event is released. Here we have to decrement it so pi_queue
-    // can be released successfully.
-    if (Event->Queue) {
-      PI_CALL(piQueueReleaseInternal(Event->Queue, LockedQueue));
-    }
-    delete Event;
+    Event->CommandData = nullptr;
   }
+  if (Event->OwnZeEvent) {
+    ZE_CALL(zeEventDestroy, (Event->ZeEvent));
+  }
+  // It is possible that host-visible event was never created.
+  // In case it was check if that's different from this same event
+  // and release a reference to it.
+  if (Event->HostVisibleEvent && Event->HostVisibleEvent != Event) {
+    // Decrement ref-count of the host-visible proxy event.
+    PI_CALL(EventRelease(Event->HostVisibleEvent, LockedQueue));
+  }
+
+  auto Context = Event->Context;
+  if (auto Res = Context->decrementUnreleasedEventsInPool(Event))
+    return Res;
+
+  // We intentionally incremented the reference counter when an event is
+  // created so that we can avoid pi_queue is released before the associated
+  // pi_event is released. Here we have to decrement it so pi_queue
+  // can be released successfully.
+  if (Event->Queue) {
+    PI_CALL(piQueueReleaseInternal(Event->Queue, LockedQueue));
+  }
+  delete Event;
+
   return PI_SUCCESS;
 }
 
@@ -5808,18 +5787,16 @@ pi_result piSamplerGetInfo(pi_sampler Sampler, pi_sampler_info ParamName,
 pi_result piSamplerRetain(pi_sampler Sampler) {
   PI_ASSERT(Sampler, PI_INVALID_SAMPLER);
 
-  ++(Sampler->RefCount);
+  Sampler->RefCount.increment();
   return PI_SUCCESS;
 }
 
 pi_result piSamplerRelease(pi_sampler Sampler) {
   PI_ASSERT(Sampler, PI_INVALID_SAMPLER);
 
-  if (--(Sampler->RefCount) != 0)
+  if (!Sampler->RefCount.decrement_and_test())
     return PI_SUCCESS;
 
-  // Only a single thread can reach ref count equal to 0. This means that
-  // the following code is executed by a single thread.
   ZE_CALL(zeSamplerDestroy, (Sampler->ZeSampler));
   delete Sampler;
 
@@ -7538,7 +7515,7 @@ static pi_result USMFreeHelper(pi_context Context, void *Ptr,
     if (It == std::end(Context->MemAllocs)) {
       die("All memory allocations must be tracked!");
     }
-    if (--(It->second.RefCount) != 0) {
+    if (!It->second.RefCount.decrement_and_test()) {
       // Memory can't be deallocated yet.
       return PI_SUCCESS;
     }

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -243,7 +243,7 @@ public:
 // counter and to make allowed operations more transparent in terms of
 // thread-safety in the plugin. increment() and load() operations do not need a
 // mutex guard around them since the underlying data is already atomic.
-// decrement_and_test() method is used to guard a code which needs to be
+// decrementAndTest() method is used to guard a code which needs to be
 // executed when object's ref count becomes zero after release. This method also
 // doesn't need a mutex guard because decrement operation is atomic and only one
 // thread can reach ref count equal to zero, i.e. only a single thread can pass
@@ -273,7 +273,7 @@ struct ReferenceCounter {
   // scope after this check. Of course if we access another objects in this code
   // (not the one which is being deleted) then access to these objects must be
   // guarded, for example with a mutex.
-  bool decrement_and_test() { return --RefCount == 0; }
+  bool decrementAndTest() { return --RefCount == 0; }
 
 private:
   std::atomic<pi_uint32> RefCount;

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -239,13 +239,46 @@ public:
   }
 };
 
+// This wrapper around std::atomic is created to limit operations with reference
+// counter and to make allowed operations more transparent in terms of
+// thread-safety in the plugin.
+struct reference_counter {
+  reference_counter(pi_uint32 InitVal) : RefCount{InitVal} {}
+
+  // Used when retaining an object.
+  void increment() { RefCount++; }
+
+  // Supposed to be used in piGet* methods where ref count value is requested.
+  pi_uint32 load() { return RefCount.load(); }
+
+  // This method allows to guard a code which needs to be executed when object's
+  // ref count becomes zero after release. It is important to notice that only a
+  // single thread can pass through this check. This is true because of several
+  // reasons:
+  //   1. Decrement operation is executed atomically.
+  //   2. It is not allowed to retain an object after its refcount reaches zero.
+  //   3. It is not allowed to release an object more times than the value of
+  //   the ref count.
+  // 2. and 3. basically means that we can't use an object at all as soon as its
+  // refcount reaches zero. Using this check guarantees that code for deleting
+  // an object and releasing its resources is executed once by a single thread
+  // and we don't need to use any mutexes to guard access to this object in the
+  // scope after this check. Of course if we access another objects in this code
+  // (not the one which is being deleted) then access to these objects must be
+  // guarded, for example with a mutex.
+  bool decrement_and_test() { return --RefCount == 0; }
+
+private:
+  std::atomic<pi_uint32> RefCount;
+};
+
 // Base class to store common data
 struct _pi_object {
   _pi_object() : RefCount{1} {}
 
   // Level Zero doesn't do the reference counting, so we have to do.
   // Must be atomic to prevent data race when incrementing/decrementing.
-  std::atomic<pi_uint32> RefCount;
+  reference_counter RefCount;
 
   // This mutex protects accesses to all the non-const member variables.
   // Exclusive access is required to modify any of these members.
@@ -261,8 +294,6 @@ struct _pi_object {
   //   std::shared_lock Obj3Lock(Obj3->Mutex, std::defer_lock);
   //   std::scoped_lock LockAll(Obj1->Mutex, Obj2->Mutex, Obj3Lock);
   pi_shared_mutex Mutex;
-
-  void retain() { ++RefCount; }
 };
 
 // Record for a memory allocation. This structure is used to keep information
@@ -947,7 +978,12 @@ struct _pi_queue : _pi_object {
   // references. This way we are able to tell when the queue is being finished
   // externally, and can wait for internal references to complete, and do proper
   // cleanup of the queue.
-  std::atomic<pi_uint32> RefCountExternal{1};
+  // This counter doesn't track the lifetime of a queue object, it only tracks
+  // the number of external references. I.e. even if it reaches zero a queue
+  // object may not be destroyed and can be used internally in the plugin.
+  // That's why we intentionally don't use atomic type for this counter to
+  // enforce guarding with a mutex all the work involving this counter.
+  pi_uint32 RefCountExternal{1};
 
   // Indicates that the queue is healthy and all operations on it are OK.
   bool Healthy{true};

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -1395,13 +1395,6 @@ struct _pi_kernel : _pi_object {
     return true;
   }
 
-  // The caller must lock access to the kernel and program.
-  void retain() {
-    ++RefCount;
-    // When retaining a kernel, you are also retaining the program it is part
-    // of.
-    Program->retain();
-  }
   // Level Zero function handle.
   ze_kernel_handle_t ZeKernel;
 


### PR DESCRIPTION
Commit removes mutex locks from PI release and retain functions. They
were added under impression that 2 threads working simultaneously on
releasing resources can both reach ref count 0 and cause double free.
But since our ref count is atomic and decrement is an atomic operation
only single thread will execute code under if (--(PiObj->RefCount) == 0).
There can't be 2 threads which can reach ref count 0.

Behavior is undefined if DPCPP runtime somehow uses deleted pi object
(with ref count 0) or provides it as an argument to any of the pi functions.