### PR TITLE
[CI] Enable llvm-test-suite on CUDA Linux target

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -52,6 +52,10 @@ on:
         type: string
         required: false
         default: "ghcr.io/intel/llvm/ubuntu2004_build:latest"
+      cuda_image:
+        type: string
+        required: false
+        default: "ghcr.io/intel/llvm/ubuntu2004_build:latest"
       lts_ref:
         type: string
         required: false

--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -41,4 +41,4 @@ jobs:
       build_cache_size: "8G"
       build_artifact_suffix: "default"
       build_cache_suffix: "default"
-      lts_config: "hip_amdgpu;ocl_x64;ocl_gen9;l0_gen9;esimd_emu"
+      lts_config: "cuda"  ## TEMPORARY CHANGE - ROLLBACK BEFORE MERGE

--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -41,4 +41,4 @@ jobs:
       build_cache_size: "8G"
       build_artifact_suffix: "default"
       build_cache_suffix: "default"
-      lts_config: "cuda"  ## TEMPORARY CHANGE - ROLLBACK BEFORE MERGE
+      lts_config: "hip_amdgpu;ocl_x64;ocl_gen9;l0_gen9;esimd_emu;cuda"

--- a/.github/workflows/sycl_windows_build_and_test.yml
+++ b/.github/workflows/sycl_windows_build_and_test.yml
@@ -38,7 +38,7 @@ jobs:
         IF NOT EXIST D:\github\_work\cache MKDIR D:\github\_work\cache
         IF NOT EXIST D:\github\_work\cache\sycl_${{inputs.build_cache_suffix}} MKDIR D:\github\_work\cache\${{inputs.build_cache_suffix}}
         python.exe src/buildbot/configure.py -o build ^
-          --ci-default ^
+          --ci-defaults ^
           --cmake-opt="-DCMAKE_C_COMPILER=cl" ^
           --cmake-opt="-DCMAKE_CXX_COMPILER=cl" ^
           --cmake-opt="-DCMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\install" ^

--- a/devops/test_configs.json
+++ b/devops/test_configs.json
@@ -59,6 +59,18 @@
       "container_options": "--device=/dev/dri --device=/dev/kfd",
       "check_sycl_all": "hip:gpu,host",
       "cmake_args": "-DHIP_PLATFORM=\"AMD\" -DAMD_ARCH=\"gfx1031\""
+    },
+    {
+      "config": "cuda",
+      "name": "CUDA LLVM Test Suite",
+      "runs-on": [
+        "Linux",
+        "cuda"
+      ],
+      "image": "${{ inputs.cuda_image }}",
+      "container_options": "--gpus all",
+      "check_sycl_all": "cuda:gpu,host",
+      "cmake_args": ""
     }
   ]
 }


### PR DESCRIPTION
* Update reusable workflow with corresponding config
* Add cuda llvm-test-suite run to pre-commit on Linux
* Fix option typo [NFC]

Failing tests disabled at: https://github.com/intel/llvm-test-suite/pull/1052
Issue: https://github.com/intel/llvm/issues/6285