### PR TITLE
[NFC] Cleanup instrumentation test and hookup warning check

### DIFF
--- a/clang/test/Driver/sycl-instrumentation.c
+++ b/clang/test/Driver/sycl-instrumentation.c
@@ -21,10 +21,8 @@
 
 // RUN: %clangxx -fsycl -fno-sycl-instrument-device-code -fsycl-targets=spir64 -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-NONPASSED %s
-// RUN: %clangxx -fsycl -fsycl-targets=nvptx64-nvidia-cuda -nocudalib -### %s 2>&1 \
-// RUN: | FileCheck -check-prefixes=CHECK-NONPASSED %s
+// RUN: %clangxx -fsycl -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-instrument-device-code -nocudalib -### %s 2>&1 \
+// RUN: | FileCheck -check-prefixes=CHECK-NONPASSED,CHECK-WARNING %s
 // CHECK-NONPASSED-NOT: "-fsycl-instrument-device-code"
 // CHECK-NONPASSED-NOT: "-input={{.*}}libsycl-itt-{{.*}}.{{o|obj}}"
-// RUN: %clangxx -fsycl -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-instrument-device-code -nocudalib -### %s 2>&1 \
-// RUN: | FileCheck -check-prefixes=CHECK-NONPASSED %s
 // CHECK-WARNING: warning: argument unused during compilation: '-fno-sycl-instrument-device-code'


### PR DESCRIPTION
The sycl-instrumentation.c test had some inconsistencies, clean these up
and check that the expected warning is emitted.