### PR TITLE
[SYCL] Don't select devices with no available images

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1450,6 +1450,26 @@ kernel_id ProgramManager::getSYCLKernelID(const std::string &KernelName) {
   return KernelID->second;
 }
 
+bool ProgramManager::hasCompatibleImage(const device &Dev) {
+  std::set<RTDeviceBinaryImage *> BinImages;
+  {
+    std::lock_guard<std::mutex> Guard(Sync::getGlobalLock());
+    for (auto &ImagesSets : m_DeviceImages) {
+      auto &ImagesUPtrs = *ImagesSets.second.get();
+      for (auto &ImageUPtr : ImagesUPtrs)
+        BinImages.insert(ImageUPtr.get());
+    }
+  }
+
+  for (auto Img : BinImages) {
+    if (compatibleWithDevice(Img, Dev)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 std::vector<kernel_id> ProgramManager::getAllSYCLKernelIDs() {
   std::lock_guard<std::mutex> KernelIDsGuard(m_KernelIDsMutex);
 

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -188,6 +188,9 @@ public:
   void addOrInitDeviceGlobalEntry(const void *DeviceGlobalPtr,
                                   const char *UniqueId);
 
+  // Returns true if any available image is compatible with the device Dev.
+  bool hasCompatibleImage(const device &Dev);
+
   // The function returns a vector of SYCL device images that are compiled with
   // the required state and at least one device from the passed list of devices.
   std::vector<device_image_plain> getSYCLDeviceImagesWithCompatibleState(

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -77,8 +77,12 @@ device device_selector::select_device() const {
 
     // SYCL spec says: "If more than one device receives the high score then
     // one of those tied devices will be returned, but which of the devices
-    // from the tied set is to be returned is not defined".
-    if (score < dev_score) {
+    // from the tied set is to be returned is not defined". So use the device
+    // preference score to resolve ties, this is necessary for custom_selectors
+    // that may not already include device preference in their scoring.
+    if ((score < dev_score) ||
+        ((score == dev_score) &&
+         (getDevicePreference(dev) > getDevicePreference(*res)))) {
       res = &dev;
       score = dev_score;
     }

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -27,14 +27,27 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
-// Utility function to check if device is of the preferred backend.
-// Currently preference is given to the level_zero backend.
-static bool isDeviceOfPreferredSyclBe(const device &Device) {
-  if (Device.is_host())
-    return false;
+// SYCL_DEVICE_FILTER doesn't need to be considered in the device preferences
+// as it filters the device list returned by device::get_devices itself, so
+// only matching devices will be scored.
+static int getDevicePreference(const device &Device) {
+  int Score = 0;
 
-  return detail::getSyclObjImpl(Device)->getPlugin().getBackend() ==
-         backend::ext_oneapi_level_zero;
+  // No preferences for host devices.
+  if (Device.is_host())
+    return Score;
+
+  // Strongly prefer devices with available images.
+  auto &program_manager = cl::sycl::detail::ProgramManager::getInstance();
+  if (program_manager.hasCompatibleImage(Device))
+    Score += 1000;
+
+  // Prefer level_zero backend devices.
+  if (detail::getSyclObjImpl(Device)->getPlugin().getBackend() ==
+      backend::ext_oneapi_level_zero)
+    Score += 50;
+
+  return Score;
 }
 
 device device_selector::select_device() const {
@@ -63,17 +76,10 @@ device device_selector::select_device() const {
     if (dev_score < 0)
       continue;
 
-    // Don't select devices with no compatible images
-    if (!dev.is_host() && !program_manager.hasCompatibleImage(dev))
-      continue;
-
     // SYCL spec says: "If more than one device receives the high score then
     // one of those tied devices will be returned, but which of the devices
-    // from the tied set is to be returned is not defined". Here we give a
-    // preference to the device of the preferred BE.
-    //
-    if ((score < dev_score) ||
-        (score == dev_score && isDeviceOfPreferredSyclBe(dev))) {
+    // from the tied set is to be returned is not defined".
+    if (score < dev_score) {
       res = &dev;
       score = dev_score;
     }
@@ -102,22 +108,9 @@ device device_selector::select_device() const {
 /// 1. GPU
 /// 2. CPU
 /// 3. Host
+/// 4. Accelerator
 int default_selector::operator()(const device &dev) const {
-
   int Score = REJECT_DEVICE_SCORE;
-
-  // Give preference to device of SYCL BE.
-  if (isDeviceOfPreferredSyclBe(dev))
-    Score = 50;
-
-  // If SYCL_DEVICE_FILTER is set, filter device gets a high point.
-  // All unmatched devices should never be selected.
-  detail::device_filter_list *FilterList =
-      detail::SYCLConfig<detail::SYCL_DEVICE_FILTER>::get();
-  // device::get_devices returns filtered list of devices.
-  // Keep 1000 for default score when filters were applied.
-  if (FilterList)
-    Score = 1000;
 
   if (dev.get_info<info::device::device_type>() == detail::get_forced_type())
     Score += 1000;
@@ -137,6 +130,10 @@ int default_selector::operator()(const device &dev) const {
   if (dev.is_accelerator())
     Score += 75;
 
+  // If the device wasn't rejected, add preference score.
+  if (Score > REJECT_DEVICE_SCORE)
+    Score += getDevicePreference(dev);
+
   return Score;
 }
 
@@ -144,11 +141,8 @@ int gpu_selector::operator()(const device &dev) const {
   int Score = REJECT_DEVICE_SCORE;
 
   if (dev.is_gpu()) {
-    // device::get_devices returns filtered list of devices.
     Score = 1000;
-    // Give preference to device of SYCL BE.
-    if (isDeviceOfPreferredSyclBe(dev))
-      Score += 50;
+    Score += getDevicePreference(dev);
   }
   return Score;
 }
@@ -157,12 +151,8 @@ int cpu_selector::operator()(const device &dev) const {
   int Score = REJECT_DEVICE_SCORE;
 
   if (dev.is_cpu()) {
-    // device::get_devices returns filtered list of devices.
     Score = 1000;
-
-    // Give preference to device of SYCL BE.
-    if (isDeviceOfPreferredSyclBe(dev))
-      Score += 50;
+    Score += getDevicePreference(dev);
   }
   return Score;
 }
@@ -171,12 +161,8 @@ int accelerator_selector::operator()(const device &dev) const {
   int Score = REJECT_DEVICE_SCORE;
 
   if (dev.is_accelerator()) {
-    // device::get_devices returns filtered list of devices.
     Score = 1000;
-
-    // Give preference to device of SYCL BE.
-    if (isDeviceOfPreferredSyclBe(dev))
-      Score += 50;
+    Score += getDevicePreference(dev);
   }
   return Score;
 }
@@ -186,9 +172,7 @@ int host_selector::operator()(const device &dev) const {
 
   if (dev.is_host()) {
     Score = 1000;
-    // Give preference to device of SYCL BE.
-    if (isDeviceOfPreferredSyclBe(dev))
-      Score += 50;
+    Score += getDevicePreference(dev);
   }
   return Score;
 }

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -52,7 +52,6 @@ static int getDevicePreference(const device &Device) {
 
 device device_selector::select_device() const {
   std::vector<device> devices = device::get_devices();
-  auto &program_manager = cl::sycl::detail::ProgramManager::getInstance();
   int score = REJECT_DEVICE_SCORE;
   const device *res = nullptr;
 

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -82,7 +82,7 @@ device device_selector::select_device() const {
     // that may not already include device preference in their scoring.
     if ((score < dev_score) ||
         ((score == dev_score) &&
-         (getDevicePreference(dev) > getDevicePreference(*res)))) {
+         (getDevicePreference(*res) < getDevicePreference(dev)))) {
       res = &dev;
       score = dev_score;
     }

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -39,6 +39,7 @@ static bool isDeviceOfPreferredSyclBe(const device &Device) {
 
 device device_selector::select_device() const {
   std::vector<device> devices = device::get_devices();
+  auto &program_manager = cl::sycl::detail::ProgramManager::getInstance();
   int score = REJECT_DEVICE_SCORE;
   const device *res = nullptr;
 
@@ -60,6 +61,10 @@ device device_selector::select_device() const {
 
     // A negative score means that a device must not be selected.
     if (dev_score < 0)
+      continue;
+
+    // Don't select devices with no compatible images
+    if (!dev.is_host() && !program_manager.hasCompatibleImage(dev))
       continue;
 
     // SYCL spec says: "If more than one device receives the high score then

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -113,7 +113,8 @@ device device_selector::select_device() const {
 /// 3. Host
 /// 4. Accelerator
 int default_selector::operator()(const device &dev) const {
-  int Score = REJECT_DEVICE_SCORE;
+  // The default selector doesn't reject any devices.
+  int Score = 0;
 
   if (dev.get_info<info::device::device_type>() == detail::get_forced_type())
     Score += 2000;
@@ -133,9 +134,8 @@ int default_selector::operator()(const device &dev) const {
   if (dev.is_accelerator())
     Score += 75;
 
-  // If the device wasn't rejected, add preference score.
-  if (Score > REJECT_DEVICE_SCORE)
-    Score += getDevicePreference(dev);
+  // Add preference score.
+  Score += getDevicePreference(dev);
 
   return Score;
 }

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -116,7 +116,7 @@ int default_selector::operator()(const device &dev) const {
   int Score = REJECT_DEVICE_SCORE;
 
   if (dev.get_info<info::device::device_type>() == detail::get_forced_type())
-    Score += 1000;
+    Score += 2000;
 
   if (dev.is_gpu())
     Score += 500;


### PR DESCRIPTION
This patch solves:
* https://github.com/intel/llvm/issues/2004

And is related to:
* https://github.com/intel/llvm/issues/1665

In some cases the current selector may select a device for which we don't have an AOT or SPIR-V binary for, this patch ensures that such devices get skipped.