### PR TITLE
[SYCL] Fix returned alignment of allocation functions

### DIFF
--- a/sycl/include/CL/sycl/usm.hpp
+++ b/sycl/include/CL/sycl/usm.hpp
@@ -158,7 +158,8 @@ T *malloc_device(
     const property_list &PropList = {},
     const detail::code_location CodeLoc = detail::code_location::current()) {
   return static_cast<T *>(
-      malloc_device(Count * sizeof(T), Dev, Ctxt, PropList, CodeLoc));
+      aligned_alloc_device(std::max(alignof(T), alignof(std::max_align_t)),
+                           Count * sizeof(T), Dev, Ctxt, PropList, CodeLoc));
 }
 
 template <typename T>
@@ -174,8 +175,9 @@ T *aligned_alloc_device(
     size_t Alignment, size_t Count, const device &Dev, const context &Ctxt,
     const property_list &PropList = {},
     const detail::code_location CodeLoc = detail::code_location::current()) {
-  return static_cast<T *>(aligned_alloc_device(Alignment, Count * sizeof(T),
-                                               Dev, Ctxt, PropList, CodeLoc));
+  return static_cast<T *>(aligned_alloc_device(std::max(Alignment, alignof(T)),
+                                               Count * sizeof(T), Dev, Ctxt,
+                                               PropList, CodeLoc));
 }
 
 template <typename T>
@@ -192,7 +194,8 @@ T *malloc_host(
     size_t Count, const context &Ctxt, const property_list &PropList = {},
     const detail::code_location CodeLoc = detail::code_location::current()) {
   return static_cast<T *>(
-      malloc_host(Count * sizeof(T), Ctxt, PropList, CodeLoc));
+      aligned_alloc_host(std::max(alignof(T), alignof(std::max_align_t)),
+                         Count * sizeof(T), Ctxt, PropList, CodeLoc));
 }
 
 template <typename T>
@@ -208,7 +211,8 @@ T *malloc_shared(
     const property_list &PropList = {},
     const detail::code_location CodeLoc = detail::code_location::current()) {
   return static_cast<T *>(
-      malloc_shared(Count * sizeof(T), Dev, Ctxt, PropList, CodeLoc));
+      aligned_alloc_shared(std::max(alignof(T), alignof(std::max_align_t)),
+                           Count * sizeof(T), Dev, Ctxt, PropList, CodeLoc));
 }
 
 template <typename T>
@@ -224,8 +228,9 @@ T *aligned_alloc_host(
     size_t Alignment, size_t Count, const context &Ctxt,
     const property_list &PropList = {},
     const detail::code_location CodeLoc = detail::code_location::current()) {
-  return static_cast<T *>(aligned_alloc_host(Alignment, Count * sizeof(T), Ctxt,
-                                             PropList, CodeLoc));
+  return static_cast<T *>(aligned_alloc_host(std ::max(Alignment, alignof(T)),
+                                             Count * sizeof(T), Ctxt, PropList,
+                                             CodeLoc));
 }
 
 template <typename T>
@@ -242,8 +247,9 @@ T *aligned_alloc_shared(
     size_t Alignment, size_t Count, const device &Dev, const context &Ctxt,
     const property_list &PropList = {},
     const detail::code_location CodeLoc = detail::code_location::current()) {
-  return static_cast<T *>(aligned_alloc_shared(Alignment, Count * sizeof(T),
-                                               Dev, Ctxt, PropList, CodeLoc));
+  return static_cast<T *>(aligned_alloc_shared(std::max(Alignment, alignof(T)),
+                                               Count * sizeof(T), Dev, Ctxt,
+                                               PropList, CodeLoc));
 }
 
 template <typename T>
@@ -278,8 +284,9 @@ T *aligned_alloc(
     size_t Alignment, size_t Count, const device &Dev, const context &Ctxt,
     usm::alloc Kind, const property_list &PropList = {},
     const detail::code_location CodeLoc = detail::code_location::current()) {
-  return static_cast<T *>(aligned_alloc(Alignment, Count * sizeof(T), Dev, Ctxt,
-                                        Kind, PropList, CodeLoc));
+  return static_cast<T *>(aligned_alloc(std::max(Alignment, alignof(T)),
+                                        Count * sizeof(T), Dev, Ctxt, Kind,
+                                        PropList, CodeLoc));
 }
 
 template <typename T>

--- a/sycl/include/CL/sycl/usm.hpp
+++ b/sycl/include/CL/sycl/usm.hpp
@@ -267,7 +267,8 @@ T *malloc(
     const property_list &PropList = {},
     const detail::code_location CodeLoc = detail::code_location::current()) {
   return static_cast<T *>(
-      malloc(Count * sizeof(T), Dev, Ctxt, Kind, PropList, CodeLoc));
+      aligned_alloc(std::max(alignof(T), alignof(std::max_align_t)),
+                    Count * sizeof(T), Dev, Ctxt, Kind, PropList, CodeLoc));
 }
 
 template <typename T>


### PR DESCRIPTION
A test is being added in https://github.com/intel/llvm-test-suite/pull/1042.