### PR TITLE
[SYCL] Fix unittest crashes after PR #6128

### DIFF
--- a/sycl/unittests/SYCL2020/KernelBundle.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundle.cpp
@@ -104,10 +104,8 @@ TEST(KernelBundle, GetKernelBundleFromKernel) {
   setupDefaultMockAPIs(Mock);
 
   const sycl::device Dev = Plt.get_devices()[0];
-
-  sycl::queue Queue{Dev};
-
-  const sycl::context Ctx = Queue.get_context();
+  sycl::context Ctx{Dev};
+  sycl::queue Queue{Ctx, Dev};
 
   sycl::kernel_bundle<sycl::bundle_state::executable> KernelBundle =
       sycl::get_kernel_bundle<sycl::bundle_state::executable>(Ctx, {Dev});

--- a/sycl/unittests/SYCL2020/KernelID.cpp
+++ b/sycl/unittests/SYCL2020/KernelID.cpp
@@ -157,10 +157,8 @@ TEST(KernelID, FreeKernelIDEqualsKernelBundleId) {
   setupDefaultMockAPIs(Mock);
 
   const sycl::device Dev = Plt.get_devices()[0];
-
-  sycl::queue Queue{Dev};
-
-  const sycl::context Ctx = Queue.get_context();
+  sycl::context Ctx{Dev};
+  sycl::queue Queue{Ctx, Dev};
 
   sycl::kernel_bundle<sycl::bundle_state::executable> KernelBundle =
       sycl::get_kernel_bundle<sycl::bundle_state::executable>(Ctx, {Dev});
@@ -200,10 +198,8 @@ TEST(KernelID, KernelBundleKernelIDsIntersectAll) {
   setupDefaultMockAPIs(Mock);
 
   const sycl::device Dev = Plt.get_devices()[0];
-
-  sycl::queue Queue{Dev};
-
-  const sycl::context Ctx = Queue.get_context();
+  sycl::context Ctx{Dev};
+  sycl::queue Queue{Ctx, Dev};
 
   sycl::kernel_bundle<sycl::bundle_state::executable> KernelBundle =
       sycl::get_kernel_bundle<sycl::bundle_state::executable>(Ctx, {Dev});
@@ -239,10 +235,8 @@ TEST(KernelID, KernelIDHasKernel) {
   setupDefaultMockAPIs(Mock);
 
   const sycl::device Dev = Plt.get_devices()[0];
-
-  sycl::queue Queue{Dev};
-
-  const sycl::context Ctx = Queue.get_context();
+  sycl::context Ctx{Dev};
+  sycl::queue Queue{Ctx, Dev};
 
   sycl::kernel_bundle<sycl::bundle_state::executable> KernelBundle =
       sycl::get_kernel_bundle<sycl::bundle_state::executable>(Ctx, {Dev});

--- a/sycl/unittests/SYCL2020/SpecializationConstant.cpp
+++ b/sycl/unittests/SYCL2020/SpecializationConstant.cpp
@@ -191,10 +191,8 @@ TEST(SpecializationConstant, SetSpecConstAfterUseKernelBundle) {
   setupDefaultMockAPIs(Mock);
 
   const sycl::device Dev = Plt.get_devices()[0];
-
-  sycl::queue Queue{Dev};
-
-  const sycl::context Ctx = Queue.get_context();
+  sycl::context Ctx{Dev};
+  sycl::queue Queue{Ctx, Dev};
 
   sycl::kernel_bundle KernelBundle =
       sycl::get_kernel_bundle<sycl::bundle_state::executable>(Ctx, {Dev});
@@ -252,8 +250,8 @@ TEST(SpecializationConstant, GetSpecConstAfterUseKernelBundle) {
   setupDefaultMockAPIs(Mock);
 
   const sycl::device Dev = Plt.get_devices()[0];
-  sycl::queue Queue{Dev};
-  const sycl::context Ctx = Queue.get_context();
+  sycl::context Ctx{Dev};
+  sycl::queue Queue{Ctx, Dev};
 
   sycl::kernel_bundle KernelBundle =
       sycl::get_kernel_bundle<sycl::bundle_state::executable>(Ctx, {Dev});
@@ -312,8 +310,8 @@ TEST(SpecializationConstant, UseKernelBundleAfterSetSpecConst) {
   setupDefaultMockAPIs(Mock);
 
   const sycl::device Dev = Plt.get_devices()[0];
-  sycl::queue Queue{Dev};
-  const sycl::context Ctx = Queue.get_context();
+  sycl::context Ctx{Dev};
+  sycl::queue Queue{Ctx, Dev};
 
   sycl::kernel_bundle KernelBundle =
       sycl::get_kernel_bundle<sycl::bundle_state::executable>(Ctx, {Dev});

--- a/sycl/unittests/assert/assert.cpp
+++ b/sycl/unittests/assert/assert.cpp
@@ -623,9 +623,8 @@ TEST(Assert, TestInteropKernelFromProgramNegative) {
   sycl::unittest::PiMock Mock{Plt};
 
   const sycl::device Dev = Plt.get_devices()[0];
-  sycl::queue Queue{Dev};
-
-  const sycl::context Ctx = Queue.get_context();
+  sycl::context Ctx{Dev};
+  sycl::queue Queue{Ctx, Dev};
 
   setupMockForInterop(Mock, Ctx, Dev);
 

--- a/sycl/unittests/program_manager/BuildLog.cpp
+++ b/sycl/unittests/program_manager/BuildLog.cpp
@@ -99,10 +99,9 @@ TEST(BuildLog, OutputNothingOnLevel1) {
   setupCommonTestAPIs(Mock);
 
   const sycl::device Dev = Plt.get_devices()[0];
+  sycl::context Ctx{Dev};
+  sycl::queue Queue{Ctx, Dev};
 
-  sycl::queue Queue{Dev};
-
-  sycl::context Ctx = Queue.get_context();
   auto ContextImpl = getSyclObjImpl(Ctx);
   // Make sure no kernels are cached
   ContextImpl->getKernelProgramCache().reset();
@@ -133,10 +132,9 @@ TEST(BuildLog, OutputLogOnLevel2) {
   setupCommonTestAPIs(Mock);
 
   const sycl::device Dev = Plt.get_devices()[0];
+  sycl::context Ctx{Dev};
+  sycl::queue Queue{Ctx, Dev};
 
-  sycl::queue Queue{Dev};
-
-  const sycl::context Ctx = Queue.get_context();
   auto ContextImpl = getSyclObjImpl(Ctx);
   // Make sure no kernels are cached
   ContextImpl->getKernelProgramCache().reset();

--- a/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
+++ b/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
@@ -267,8 +267,8 @@ TEST(Link_Compile_Options, check_sycl_build) {
                                                   expected_link_options);
   static sycl::unittest::PiImageArray<1> DevImageArray{&DevImage};
   auto KernelID = sycl::get_kernel_id<EAMTestKernel1>();
-  sycl::queue Queue{Dev};
-  const sycl::context Ctx = Queue.get_context();
+  sycl::context Ctx{Dev};
+  sycl::queue Queue{Ctx, Dev};
   sycl::kernel_bundle KernelBundle =
       sycl::get_kernel_bundle<sycl::bundle_state::input>(Ctx, {Dev},
                                                          {KernelID});

--- a/sycl/unittests/stream/stream.cpp
+++ b/sycl/unittests/stream/stream.cpp
@@ -53,8 +53,8 @@ TEST(Stream, TestStreamConstructorExceptionNoAllocation) {
       redefinedMemBufferCreate);
 
   const sycl::device Dev = Plt.get_devices()[0];
-  sycl::queue Queue{Dev};
-  const sycl::context Ctx = Queue.get_context();
+  sycl::context Ctx{Dev};
+  sycl::queue Queue{Ctx, Dev};
 
   sycl::kernel_bundle KernelBundle =
       sycl::get_kernel_bundle<sycl::bundle_state::input>(Ctx, {Dev});


### PR DESCRIPTION
We need to destroy resources when the Ctx object is destructed. Otherwise the
destruction of internal RT objects would be delayed until global context
destruction that happens *after* ~PiMock.