### PR TITLE
[SYCL][HIP] Use valid cast for CUdeviceptr in HIP PI;

### DIFF
--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -2131,8 +2131,7 @@ pi_result hip_piMemGetInfo(pi_mem memObj, pi_mem_info queriedInfo,
 /// \return PI_SUCCESS
 pi_result hip_piextMemGetNativeHandle(pi_mem mem,
                                       pi_native_handle *nativeHandle) {
-  *nativeHandle =
-      reinterpret_cast<pi_native_handle>(mem->mem_.buffer_mem_.get());
+  *nativeHandle = static_cast<pi_native_handle>(mem->mem_.buffer_mem_.get());
   return PI_SUCCESS;
 }
 


### PR DESCRIPTION
This is a fix for #6189.

Replaces invalid `reinterpret_cast` with `static_cast` for `CUdeviceptr` in `hip_piextMemGetNativeHandle` to fix build error occuring when building HIP PI on CUDA machines;

Signed-off-by: Lukas Sommer <lukas.sommer@codeplay.com>