### PR TITLE
[SYCL] Retain event in old OpenCL interop constructor

### DIFF
--- a/sycl/source/event.cpp
+++ b/sycl/source/event.cpp
@@ -26,7 +26,12 @@ event::event() : impl(std::make_shared<detail::event_impl>()) {}
 
 event::event(cl_event ClEvent, const context &SyclContext)
     : impl(std::make_shared<detail::event_impl>(
-          detail::pi::cast<RT::PiEvent>(ClEvent), SyclContext)) {}
+          detail::pi::cast<RT::PiEvent>(ClEvent), SyclContext)) {
+  // This is a special interop constructor for OpenCL, so the event must be
+  // retained.
+  impl->getPlugin().call<detail::PiApiKind::piEventRetain>(
+      detail::pi::cast<RT::PiEvent>(ClEvent));
+}
 
 bool event::operator==(const event &rhs) const { return rhs.impl == impl; }
 


### PR DESCRIPTION
https://github.com/intel/llvm/pull/6180 moved the retain logic for events to the make_event interop API. However, this means that the old OpenCL interop constructor for event does not retain the native event. These changes add the retain logic directly to the old OpenCL interop constructor for OpenCL.