### PR TITLE
[SYCL] Support USM buffer location property in malloc_shared

### DIFF
--- a/sycl/test/extensions/usm/usm_alloc_utility.cpp
+++ b/sycl/test/extensions/usm/usm_alloc_utility.cpp
@@ -67,15 +67,20 @@ int main() {
     array = (int *)malloc_shared(N * sizeof(int), q);
     check_and_free(array, dev, ctxt);
 
-    array = (int *)malloc_shared(N * sizeof(int), q, property_list{});
+    array = (int *)malloc_shared(
+        N * sizeof(int), q,
+        property_list{
+            ext::intel::experimental::property::usm::buffer_location{2}});
     check_and_free(array, dev, ctxt);
 
     array = (int *)aligned_alloc_shared(alignof(long long), N * sizeof(int),
                                         dev, ctxt);
     check_and_free(array, dev, ctxt);
 
-    array = (int *)aligned_alloc_shared(alignof(long long), N * sizeof(int),
-                                        dev, ctxt, property_list{});
+    array = (int *)aligned_alloc_shared(
+        alignof(long long), N * sizeof(int), dev, ctxt,
+        property_list{
+            ext::intel::experimental::property::usm::buffer_location{2}});
     check_and_free(array, dev, ctxt);
   }
 


### PR DESCRIPTION
This ports commit 12c988a06ee2d490b567ac85c5d6cc7d3f416d35 from `malloc_device` to `malloc_shared` for use with the [FPGA Runtime for OpenCL](https://github.com/intel/fpga-runtime-for-opencl).

See `malloc_device` implementation in https://github.com/intel/llvm/pull/5634

See SYCL extension specification in https://github.com/intel/llvm/pull/6219

@tiwaria1 @bsyrowik @GarveyJoe @aditikum @ajaykumarkannan