### PR TITLE
[CI] Fix Update GPU Driver GitHub Action

### DIFF
--- a/.github/workflows/sycl_update_gpu_driver.yml
+++ b/.github/workflows/sycl_update_gpu_driver.yml
@@ -29,7 +29,7 @@ jobs:
         git add -u
         git commit -m "[GHA] Uplift GPU RT version for Linux CI" || exit 0   # exit if commit is empty
         git push https://$LLVMBOT_TOKEN@github.com/${{ github.repository }} ${BRANCH}
-        gh pr create --title "[GHA] Uplift GPU RT version for Linux CI" --body "Uplift GPU RT version for Linux to $NEW_DRIVER_VERSION" --assignee @intel/dpcpp-devops-reviewers
+        gh pr create --head $BRANCH --title "[GHA] Uplift GPU RT version for Linux CI" --body "Uplift GPU RT version for Linux to $NEW_DRIVER_VERSION" --assignee @intel/dpcpp-devops-reviewers
 
   update_driver_linux_staging:
     runs-on: ubuntu-latest
@@ -42,6 +42,7 @@ jobs:
         echo 'NEW_DRIVER_VERSION='$version >> $GITHUB_ENV
     - name: Update sycl Branch
       env:
+        BRANCH: ci/update_gpu_driver-linux_staging-${{ env.NEW_DRIVER_VERSION }}
         LLVMBOT_TOKEN: ${{ secrets.LLVM_MAIN_SYNC_BBSYCL_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -49,7 +50,9 @@ jobs:
         # Set fake identity to fulfil git requirements
         git config --global user.name "GitHub Actions"
         git config --global user.email "actions@github.com"
-        git checkout sycl
+        git checkout -B $BRANCH
         git add -u
-        git commit -m "[GHA] Uplift GPU RT version for Nightly runs" || exit 0
-        git push origin sycl
+        git commit -m "[GHA] Uplift GPU RT version for Linux CI" || exit 0   # exit if commit is empty
+        git push https://$LLVMBOT_TOKEN@github.com/${{ github.repository }} ${BRANCH}
+        gh pr create --head $BRANCH --title "[GHA] Uplift GPU RT version for Linux CI" --body "Uplift GPU RT version for Linux to $NEW_DRIVER_VERSION" --assignee @intel/dpcpp-devops-reviewers
+

--- a/.github/workflows/sycl_update_gpu_driver.yml
+++ b/.github/workflows/sycl_update_gpu_driver.yml
@@ -52,7 +52,7 @@ jobs:
         git config --global user.email "actions@github.com"
         git checkout -B $BRANCH
         git add -u
-        git commit -m "[GHA] Uplift GPU RT version for Linux CI" || exit 0   # exit if commit is empty
+        git commit -m "[GHA] Uplift GPU RT version for Nightly Builds" || exit 0   # exit if commit is empty
         git push https://$LLVMBOT_TOKEN@github.com/${{ github.repository }} ${BRANCH}
-        gh pr create --head $BRANCH --title "[GHA] Uplift GPU RT version for Linux CI" --body "Uplift GPU RT version for Linux to $NEW_DRIVER_VERSION" --assignee @intel/dpcpp-devops-reviewers
+        gh pr create --head $BRANCH --title "[GHA] Uplift GPU RT version for Nightly Builds" --body "Uplift GPU RT version for Linux to $NEW_DRIVER_VERSION" --assignee @intel/dpcpp-devops-reviewers
 


### PR DESCRIPTION
We seem to be tripping over https://github.com/cli/cli/issues/2979   in the sycl_update_gpu_driver.yml  action. Fortunately, adding the `--head` flag to the PR creation command is trivial and _should_ work around it.  Also, the `sycl` branch is protected  on intel/llvm, so am switching from a direct push to a PR for the nightly.

Note that this has been tested on my fork and works, but that was true for its previous incarnation. It is possible that this fix may yet be incomplete. Won't know until we exercise it. 