### PR TITLE
[ESIMD] Make esimd implementation of fmod compatible with std::fmod

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
@@ -1407,7 +1407,8 @@ template <> ESIMD_INLINE float fmod(float y, float x) {
   reminder = abs_y - abs_x * __ESIMD_NS::trunc<float>(abs_y / abs_x);
   reminder_sign_mask.merge(1.0f, 0.0f, reminder < 0);
 
-  fmod = __ESIMD_NS::abs(reminder + abs_x * reminder_sign_mask) * result_sign_mask;
+  fmod =
+      __ESIMD_NS::abs(reminder + abs_x * reminder_sign_mask) * result_sign_mask;
 
   return fmod[0];
 }

--- a/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
@@ -1371,21 +1371,35 @@ template <> ESIMD_INLINE float atan2(float y, float x) {
 template <int N>
 ESIMD_INLINE __ESIMD_NS::simd<float, N> fmod(__ESIMD_NS::simd<float, N> y,
                                              __ESIMD_NS::simd<float, N> x) {
-  __ESIMD_NS::simd<int, N> v_quot;
   __ESIMD_NS::simd<float, N> fmod;
+  __ESIMD_NS::simd<float, N> abs_x;
+  __ESIMD_NS::simd<float, N> reminder;
+  __ESIMD_NS::simd<float, N> reminder_sign_mask;
+  __ESIMD_NS::simd<float, N> y_sign_mask;
 
-  v_quot = convert<int>(y / x);
-  fmod = y - x * convert<float>(v_quot);
-  return fmod;
+  y_sign_mask.merge(-1.0f, 1.0f, y < 0);
+  abs_x = __ESIMD_NS::abs(x);
+  reminder = y - abs_x * __ESIMD_NS::trunc<float>(__ESIMD_NS::abs(y) / abs_x);
+  reminder_sign_mask.merge(1.0f, 0.0f, reminder < 0);
+
+  fmod = reminder + abs_x * reminder_sign_mask;
+  return __ESIMD_NS::abs(fmod) * y_sign_mask;
 }
 
 //     For Scalar Input
 template <> ESIMD_INLINE float fmod(float y, float x) {
-  int v_quot;
   __ESIMD_NS::simd<float, 1> fmod;
+  __ESIMD_NS::simd<float, 1> abs_x;
+  __ESIMD_NS::simd<float, 1> reminder;
+  __ESIMD_NS::simd<float, 1> reminder_sign_mask;
+  __ESIMD_NS::simd<float, 1> y_sign_mask;
 
-  v_quot = (int)(y / x);
-  fmod = y - x * v_quot;
+  y_sign_mask.merge(-1.0f, 1.0f, y < 0);
+  abs_x = __ESIMD_NS::abs(x);
+  reminder = y - abs_x * __ESIMD_NS::trunc<float>(__ESIMD_NS::abs(y) / abs_x);
+  reminder_sign_mask.merge(1.0f, 0.0f, reminder < 0);
+
+  fmod = __ESIMD_NS::abs(reminder + abs_x * reminder_sign_mask) * y_sign_mask;
   return fmod[0];
 }
 

--- a/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
@@ -1373,13 +1373,15 @@ ESIMD_INLINE __ESIMD_NS::simd<float, N> fmod(__ESIMD_NS::simd<float, N> y,
                                              __ESIMD_NS::simd<float, N> x) {
   __ESIMD_NS::simd<float, N> fmod;
   __ESIMD_NS::simd<float, N> abs_x;
+  __ESIMD_NS::simd<float, N> abs_y;
   __ESIMD_NS::simd<float, N> reminder;
   __ESIMD_NS::simd<float, N> reminder_sign_mask;
   __ESIMD_NS::simd<float, N> y_sign_mask;
 
   y_sign_mask.merge(-1.0f, 1.0f, y < 0);
   abs_x = __ESIMD_NS::abs(x);
-  reminder = y - abs_x * __ESIMD_NS::trunc<float>(__ESIMD_NS::abs(y) / abs_x);
+  abs_y = __ESIMD_NS::abs(y);
+  reminder = abs_y - abs_x * __ESIMD_NS::trunc<float>(abs_y / abs_x);
   reminder_sign_mask.merge(1.0f, 0.0f, reminder < 0);
 
   fmod = reminder + abs_x * reminder_sign_mask;
@@ -1390,13 +1392,15 @@ ESIMD_INLINE __ESIMD_NS::simd<float, N> fmod(__ESIMD_NS::simd<float, N> y,
 template <> ESIMD_INLINE float fmod(float y, float x) {
   __ESIMD_NS::simd<float, 1> fmod;
   __ESIMD_NS::simd<float, 1> abs_x;
+  __ESIMD_NS::simd<float, 1> abs_y;
   __ESIMD_NS::simd<float, 1> reminder;
   __ESIMD_NS::simd<float, 1> reminder_sign_mask;
   __ESIMD_NS::simd<float, 1> y_sign_mask;
 
   y_sign_mask.merge(-1.0f, 1.0f, y < 0);
   abs_x = __ESIMD_NS::abs(x);
-  reminder = y - abs_x * __ESIMD_NS::trunc<float>(__ESIMD_NS::abs(y) / abs_x);
+  abs_y = __ESIMD_NS::abs(y);
+  reminder = abs_y - abs_x * __ESIMD_NS::trunc<float>(abs_y / abs_x);
   reminder_sign_mask.merge(1.0f, 0.0f, reminder < 0);
 
   fmod = __ESIMD_NS::abs(reminder + abs_x * reminder_sign_mask) * y_sign_mask;

--- a/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
@@ -1376,16 +1376,18 @@ ESIMD_INLINE __ESIMD_NS::simd<float, N> fmod(__ESIMD_NS::simd<float, N> y,
   __ESIMD_NS::simd<float, N> abs_y;
   __ESIMD_NS::simd<float, N> reminder;
   __ESIMD_NS::simd<float, N> reminder_sign_mask;
-  __ESIMD_NS::simd<float, N> y_sign_mask;
+  __ESIMD_NS::simd<float, N> result_sign_mask;
 
-  y_sign_mask.merge(-1.0f, 1.0f, y < 0);
+  auto bits = y.template bit_cast_view<int32_t>();
+  result_sign_mask.merge(-1.0f, 1.0f, (bits & 0x80000000) != 0);
   abs_x = __ESIMD_NS::abs(x);
   abs_y = __ESIMD_NS::abs(y);
   reminder = abs_y - abs_x * __ESIMD_NS::trunc<float>(abs_y / abs_x);
   reminder_sign_mask.merge(1.0f, 0.0f, reminder < 0);
 
   fmod = reminder + abs_x * reminder_sign_mask;
-  return __ESIMD_NS::abs(fmod) * y_sign_mask;
+
+  return __ESIMD_NS::abs(fmod) * result_sign_mask;
 }
 
 //     For Scalar Input
@@ -1395,15 +1397,18 @@ template <> ESIMD_INLINE float fmod(float y, float x) {
   __ESIMD_NS::simd<float, 1> abs_y;
   __ESIMD_NS::simd<float, 1> reminder;
   __ESIMD_NS::simd<float, 1> reminder_sign_mask;
-  __ESIMD_NS::simd<float, 1> y_sign_mask;
+  __ESIMD_NS::simd<float, 1> result_sign_mask;
+  __ESIMD_NS::simd<float, 1> simd_y = y;
 
-  y_sign_mask.merge(-1.0f, 1.0f, y < 0);
+  auto bits = simd_y.template bit_cast_view<int32_t>();
+  result_sign_mask.merge(-1.0f, 1.0f, (bits & 0x80000000) != 0);
   abs_x = __ESIMD_NS::abs(x);
   abs_y = __ESIMD_NS::abs(y);
   reminder = abs_y - abs_x * __ESIMD_NS::trunc<float>(abs_y / abs_x);
   reminder_sign_mask.merge(1.0f, 0.0f, reminder < 0);
 
-  fmod = __ESIMD_NS::abs(reminder + abs_x * reminder_sign_mask) * y_sign_mask;
+  fmod = __ESIMD_NS::abs(reminder + abs_x * reminder_sign_mask) * result_sign_mask;
+
   return fmod[0];
 }
 

--- a/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
@@ -1382,13 +1382,14 @@ ESIMD_INLINE __ESIMD_NS::simd<float, N> fmod(__ESIMD_NS::simd<float, N> y,
   __ESIMD_NS::simd<float, N> fmod = reminder + abs_x;
   __ESIMD_NS::simd<float, N> fmod_abs = __ESIMD_NS::abs(fmod);
 
-  auto fmod_bits = (fmod_abs.template bit_cast_view<int32_t>()) | fmod_sign_mask;
+  auto fmod_bits =
+      (fmod_abs.template bit_cast_view<int32_t>()) | fmod_sign_mask;
   return fmod_bits.template bit_cast_view<float>();
 }
 
 // For Scalar Input
 template <> ESIMD_INLINE float fmod(float y, float x) {
-  return fmod (__ESIMD_NS::simd<float, 1>(y), __ESIMD_NS::simd<float, 1>(x))[0];
+  return fmod(__ESIMD_NS::simd<float, 1>(y), __ESIMD_NS::simd<float, 1>(x))[0];
 }
 
 // sin_emu - EU emulation for sin(x)


### PR DESCRIPTION
This fix, brings sycl::ext::intel::experimental::esimd::fmod implementation in line with std::fmod implementation.
The std::fmod implementation details are from https://en.cppreference.com/w/cpp/numeric/math/fmod
Complementary test PR [intel/llvm-test-suite#1045](https://github.com/intel/llvm-test-suite/pull/1045)