### PR TITLE
[CI] Remove new_pm testing task in nightly

### DIFF
--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -60,13 +60,3 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository }}/sycl_ubuntu2004_nightly:no-drivers-${{ github.sha }}
           ghcr.io/${{ github.repository }}/sycl_ubuntu2004_nightly:no-drivers
-  ubuntu2004_build_test_new_pm:
-    # Default Linux building and LIT testing using new Pass Manager by default
-    if: github.repository == 'intel/llvm'
-    uses: ./.github/workflows/sycl_linux_build_and_test.yml
-    with:
-      build_cache_root: "/__w/"
-      build_cache_suffix: new_pm
-      build_artifact_suffix: new_pm
-      build_configure_extra_args: '--hip --cuda --cmake-opt=-DLLVM_ENABLE_NEW_PASS_MANAGER=ON'
-      lts_config: "hip_amdgpu;ocl_x64"


### PR DESCRIPTION
We switched to new PM by default at this pulldown from upstream: https://github.com/intel/llvm/pull/6045