### PR TITLE
[SYCL] Rename "f[no-]sycl-device-lib-online-link" to "f[no-]sycl-device-lib-jit-link"

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4913,12 +4913,12 @@ def fno_sycl_device_lib_EQ : CommaJoined<["-"], "fno-sycl-device-lib=">, Group<s
   Values<"libc, libm-fp32, libm-fp64, all">, HelpText<"Control exclusion of "
   "device libraries from device binary linkage. Valid arguments "
   "are libc, libm-fp32, libm-fp64, all">;
-def fsycl_device_lib_online_link : Flag<["-"], "fsycl-device-lib-online-link">,
+def fsycl_device_lib_jit_link : Flag<["-"], "fsycl-device-lib-jit-link">,
   Group<sycl_Group>, Flags<[NoArgumentUnused, CoreOption]>, HelpText<"Enables "
-  "sycl device library online link (experimental)">;
-def fno_sycl_device_lib_online_link : Flag<["-"], "fno-sycl-device-lib-online-link">,
+  "sycl device library jit link (experimental)">;
+def fno_sycl_device_lib_jit_link : Flag<["-"], "fno-sycl-device-lib-jit-link">,
   Group<sycl_Group>, Flags<[NoArgumentUnused, CoreOption]>, HelpText<"Disables "
-  "sycl device library online link (experimental)">;
+  "sycl device library jit link (experimental)">;
 def fsycl_fp32_prec_sqrt : Flag<["-"], "fsycl-fp32-prec-sqrt">, Group<sycl_Group>, Flags<[CC1Option]>,
   HelpText<"SYCL only. Specify that single precision floating-point sqrt is correctly rounded.">,
   MarshallingInfoFlag<CodeGenOpts<"SYCLFp32PrecSqrt">>;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5009,12 +5009,12 @@ class OffloadingActionBuilder final {
         // device libraries are only needed when current toolchain is using
         // AOT compilation.
         if (isSPIR) {
-          bool UseOnlineLink =
-              Args.hasFlag(options::OPT_fsycl_device_lib_online_link,
-                           options::OPT_fno_sycl_device_lib_online_link, false);
-          bool UseOfflineLink = isSpirvAOT || !UseOnlineLink;
+          bool UseJitLink =
+              Args.hasFlag(options::OPT_fsycl_device_lib_jit_link,
+                           options::OPT_fno_sycl_device_lib_jit_link, false);
+          bool UseAOTLink = isSpirvAOT || !UseJitLink;
           SYCLDeviceLibLinked = addSYCLDeviceLibs(
-              TC, FullLinkObjects, UseOfflineLink,
+              TC, FullLinkObjects, UseAOTLink,
               C.getDefaultToolChain().getTriple().isWindowsMSVCEnvironment());
         }
 

--- a/clang/test/Driver/sycl-device-lib-win.cpp
+++ b/clang/test/Driver/sycl-device-lib-win.cpp
@@ -6,14 +6,14 @@
 
 /// ###########################################################################
 
-/// test behavior of device library default link and fno-sycl-device-lib-online-link
+/// test behavior of device library default link and fno-sycl-device-lib-jit-link
 // RUN: %clangxx -fsycl %s --sysroot=%S/Inputs/SYCL-windows -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT
-// RUN: %clangxx -fsycl -fno-sycl-device-lib-online-link %s --sysroot=%S/Inputs/SYCL-windows -### 2>&1 \
+// RUN: %clangxx -fsycl -fno-sycl-device-lib-jit-link %s --sysroot=%S/Inputs/SYCL-windows -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT
 // RUN: %clangxx -fsycl %s -fsycl-device-lib=libc --sysroot=%S/Inputs/SYCL-windows -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT
-// RUN: %clangxx -fsycl -fno-sycl-device-lib-online-link %s -fsycl-device-lib=libc --sysroot=%S/Inputs/SYCL-windows -### 2>&1 \
+// RUN: %clangxx -fsycl -fno-sycl-device-lib-jit-link %s -fsycl-device-lib=libc --sysroot=%S/Inputs/SYCL-windows -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT
 // RUN: %clangxx -fsycl %s -fsycl-device-lib=libm-fp32 --sysroot=%S/Inputs/SYCL-windows -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT
@@ -32,8 +32,8 @@
 // SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cmath-fp64.obj" "-output={{.*}}libsycl-fallback-cmath-fp64-{{.*}}.o" "-unbundle"
 
 /// ###########################################################################
-/// test sycl fallback device libraries are not linked when using online link.
-// RUN: %clangxx -fsycl -fsycl-device-lib-online-link %s --sysroot=%S/Inputs/SYCL-windows -### 2>&1 \
+/// test sycl fallback device libraries are not linked when using jit link.
+// RUN: %clangxx -fsycl -fsycl-device-lib-jit-link %s --sysroot=%S/Inputs/SYCL-windows -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_NO_FALLBACK
 // SYCL_DEVICE_LIB_NO_FALLBACK: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-crt.obj" "-output={{.*}}libsycl-crt-{{.*}}.o" "-unbundle"
 // SYCL_DEVICE_LIB_NO_FALLBACK-NOT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-{{.*}}.obj"

--- a/clang/test/Driver/sycl-device-lib.cpp
+++ b/clang/test/Driver/sycl-device-lib.cpp
@@ -6,14 +6,14 @@
 
 /// ###########################################################################
 
-/// test behavior of device library default link and fno-sycl-device-lib-online-link
+/// test behavior of device library default link and fno-sycl-device-lib-jit-link
 // RUN: %clangxx -fsycl %s --sysroot=%S/Inputs/SYCL -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT
-// RUN: %clangxx -fsycl -fno-sycl-device-lib-online-link %s --sysroot=%S/Inputs/SYCL -### 2>&1 \
+// RUN: %clangxx -fsycl -fno-sycl-device-lib-jit-link %s --sysroot=%S/Inputs/SYCL -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT
 // RUN: %clangxx -fsycl %s -fsycl-device-lib=libc --sysroot=%S/Inputs/SYCL -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT
-// RUN: %clangxx -fsycl -fno-sycl-device-lib-online-link %s -fsycl-device-lib=libc --sysroot=%S/Inputs/SYCL -### 2>&1 \
+// RUN: %clangxx -fsycl -fno-sycl-device-lib-jit-link %s -fsycl-device-lib=libc --sysroot=%S/Inputs/SYCL -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT
 // RUN: %clangxx -fsycl %s -fsycl-device-lib=libm-fp32 --sysroot=%S/Inputs/SYCL -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT
@@ -33,7 +33,7 @@
 
 /// ###########################################################################
 /// test sycl fallback device libraries are not linked by default
-// RUN: %clangxx -fsycl -fsycl-device-lib-online-link %s --sysroot=%S/Inputs/SYCL -### 2>&1 \
+// RUN: %clangxx -fsycl -fsycl-device-lib-jit-link %s --sysroot=%S/Inputs/SYCL -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_NO_FALLBACK
 // SYCL_DEVICE_LIB_NO_FALLBACK: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-crt.o" "-output={{.*}}libsycl-crt-{{.*}}.o" "-unbundle"
 // SYCL_DEVICE_LIB_NO_FALLBACK-NOT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-{{.*}}.o"

--- a/sycl/doc/UsersManual.md
+++ b/sycl/doc/UsersManual.md
@@ -201,12 +201,12 @@ and not recommended to use in production environment.
     libm-fp32, libm-fp64, libc, all. Use of 'all' will enable/disable all of
     the device libraries.
 
-**`-f[no-]sycl-device-lib-online-link`** [EXPERIMENTAL]
+**`-f[no-]sycl-device-lib-jit-link`** [EXPERIMENTAL]
 
-    Enables/disables online link mechanism for SYCL device library in JIT
-    compilation. If online link is enabled, all required device libraries will
+    Enables/disables jit link mechanism for SYCL device library in JIT
+    compilation. If jit link is enabled, all required device libraries will
     be linked with user's device image by SYCL runtime during execution time,
-    otherwise the link will happen in build time, online link is disabled by
+    otherwise the link will happen in build time, jit link is disabled by
     default currently. This option is ignored in AOT compilation.
 
 **`-f[no-]sycl-instrument-device-code`** [EXPERIMENTAL]


### PR DESCRIPTION
For users, the terms "JIT" and "AOT" have been consistently used to refer to things
happening at run-time versus compile-time. Use "jit-link" can be easier to understand.

Signed-off-by: jinge90 <ge.jin@intel.com>