### PR TITLE
[SYCL][FPGA] Add support for new attribute for loop pipelining

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2308,6 +2308,23 @@ def : MutualExclusions<[SYCLIntelFPGAIVDep,
 def : MutualExclusions<[SYCLIntelFPGAMaxConcurrency,
                         SYCLIntelFPGADisableLoopPipelining]>;
 
+def SYCLIntelFpgaPipeline : InheritableAttr {
+  let Spellings = [CXX11<"intel","fpga_pipeline">];
+  let Args = [ExprArgument<"Value", /*optional*/1>];
+  let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
+  let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt],
+                              ErrorDiag, "'for', 'while', and 'do' statements">;
+  let Documentation = [SYCLIntelFpgaPipelineAttrDocs];
+  let IsStmtDependent = 1;
+}
+
+def : MutualExclusions<[SYCLIntelFPGAInitiationInterval,
+                        SYCLIntelFpgaPipeline]>;
+def : MutualExclusions<[SYCLIntelFPGAIVDep,
+                        SYCLIntelFpgaPipeline]>;
+def : MutualExclusions<[SYCLIntelFPGAMaxConcurrency,
+                        SYCLIntelFpgaPipeline]>;
+
 def SYCLIntelFPGALoopCount : StmtAttr {
   let Spellings = [CXX11<"intel", "loop_count_min">,
                    CXX11<"intel", "loop_count_max">,
@@ -2340,6 +2357,9 @@ def SYCLIntelFPGAMaxInterleaving : StmtAttr {
 def : MutualExclusions<[SYCLIntelFPGADisableLoopPipelining,
                         SYCLIntelFPGAMaxInterleaving]>;
 
+def : MutualExclusions<[SYCLIntelFpgaPipeline,
+                        SYCLIntelFPGAMaxInterleaving]>;
+
 def SYCLIntelFPGASpeculatedIterations : StmtAttr {
   let Spellings = [CXX11<"intel", "speculated_iterations">];
   let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt],
@@ -2350,6 +2370,9 @@ def SYCLIntelFPGASpeculatedIterations : StmtAttr {
   let Documentation = [SYCLIntelFPGASpeculatedIterationsAttrDocs];
 }
 def : MutualExclusions<[SYCLIntelFPGADisableLoopPipelining,
+                        SYCLIntelFPGASpeculatedIterations]>;
+
+def : MutualExclusions<[SYCLIntelFpgaPipeline,
                         SYCLIntelFPGASpeculatedIterations]>;
 
 def SYCLIntelFPGANofusion : StmtAttr {

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2308,22 +2308,22 @@ def : MutualExclusions<[SYCLIntelFPGAIVDep,
 def : MutualExclusions<[SYCLIntelFPGAMaxConcurrency,
                         SYCLIntelFPGADisableLoopPipelining]>;
 
-def SYCLIntelFpgaPipeline : InheritableAttr {
+def SYCLIntelFPGAPipeline : InheritableAttr {
   let Spellings = [CXX11<"intel","fpga_pipeline">];
   let Args = [ExprArgument<"Value", /*optional*/1>];
   let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let Subjects = SubjectList<[ForStmt, CXXForRangeStmt, WhileStmt, DoStmt],
                               ErrorDiag, "'for', 'while', and 'do' statements">;
-  let Documentation = [SYCLIntelFpgaPipelineAttrDocs];
+  let Documentation = [SYCLIntelFPGAPipelineAttrDocs];
   let IsStmtDependent = 1;
 }
 
 def : MutualExclusions<[SYCLIntelFPGAInitiationInterval,
-                        SYCLIntelFpgaPipeline]>;
+                        SYCLIntelFPGAPipeline]>;
 def : MutualExclusions<[SYCLIntelFPGAIVDep,
-                        SYCLIntelFpgaPipeline]>;
+                        SYCLIntelFPGAPipeline]>;
 def : MutualExclusions<[SYCLIntelFPGAMaxConcurrency,
-                        SYCLIntelFpgaPipeline]>;
+                        SYCLIntelFPGAPipeline]>;
 
 def SYCLIntelFPGALoopCount : StmtAttr {
   let Spellings = [CXX11<"intel", "loop_count_min">,
@@ -2357,7 +2357,7 @@ def SYCLIntelFPGAMaxInterleaving : StmtAttr {
 def : MutualExclusions<[SYCLIntelFPGADisableLoopPipelining,
                         SYCLIntelFPGAMaxInterleaving]>;
 
-def : MutualExclusions<[SYCLIntelFpgaPipeline,
+def : MutualExclusions<[SYCLIntelFPGAPipeline,
                         SYCLIntelFPGAMaxInterleaving]>;
 
 def SYCLIntelFPGASpeculatedIterations : StmtAttr {
@@ -2372,7 +2372,7 @@ def SYCLIntelFPGASpeculatedIterations : StmtAttr {
 def : MutualExclusions<[SYCLIntelFPGADisableLoopPipelining,
                         SYCLIntelFPGASpeculatedIterations]>;
 
-def : MutualExclusions<[SYCLIntelFpgaPipeline,
+def : MutualExclusions<[SYCLIntelFPGAPipeline,
                         SYCLIntelFPGASpeculatedIterations]>;
 
 def SYCLIntelFPGANofusion : StmtAttr {

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -3306,7 +3306,7 @@ synonym for ``[[[intel::fpga_pipeline]]`` and will be removed in the future.
   }];
 }
 
-def SYCLIntelFpgaPipelineAttrDocs : Documentation {
+def SYCLIntelFPGAPipelineAttrDocs : Documentation {
   let Category = DocCatVariable;
   let Heading = "intel::fpga_pipeline";
   let Content = [{
@@ -3332,8 +3332,23 @@ loop in conjunction with the  ``max_interleaving``, ``speculated_iterations``,
     [[intel::fpga_pipeline(1)]] for (int i = 0; i < 10; ++i) var++;
   }
 
-  void count(int *array, size_t n) {
-    [[intel::fpga_pipeline(1)]] for (int i = 0; i < n; ++i) array[i] = 0;
+  void Array(int *array, size_t n) {
+    // identical to [[intel::fpga_pipeline(1)]]
+    [[intel::fpga_pipeline]] for (int i = 0; i < n; ++i) array[i] = 0;
+  }
+
+  void count () {
+  int a1[10], int i = 0;
+  [[intel::fpga_pipeline(1)]] while (i < 10) {
+    a1[i] += 3;
+  }
+
+  void check() {
+    int a = 10;
+    [[intel::fpga_pipeline(1)]]
+    do {
+        a = a + 1;
+    }while( a < 20 );
   }
 
   template<int A>

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -3345,10 +3345,9 @@ loop in conjunction with the  ``max_interleaving``, ``speculated_iterations``,
 
   void check() {
     int a = 10;
-    [[intel::fpga_pipeline(1)]]
-    do {
-        a = a + 1;
-    }while( a < 20 );
+    [[intel::fpga_pipeline(1)]] do {
+      a = a + 1;
+    } while (a < 20);
   }
 
   template<int A>

--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -3291,6 +3291,9 @@ function, or in conjunction with ``max_interleaving``,
 ``speculated_iterations``, ``max_concurrency``, ``initiation_interval``,
 or ``ivdep``.
 
+The ``[[intel::disable_loop_pipelining]]`` attribute spelling is a deprecated
+synonym for ``[[[intel::fpga_pipeline]]`` and will be removed in the future.
+
 .. code-block:: c++
 
   void foo() {
@@ -3299,6 +3302,44 @@ or ``ivdep``.
   }
 
   [[intel::disable_loop_pipelining]] void foo1() { }
+
+  }];
+}
+
+def SYCLIntelFpgaPipelineAttrDocs : Documentation {
+  let Category = DocCatVariable;
+  let Heading = "intel::fpga_pipeline";
+  let Content = [{
+The ``intel::fpga_pipeline(N)`` attribute applies to a loop and it allows users
+to disable or enable pipelining iterations of a loop. The attribute optionally
+accepts an integer constant expression that is converted to `bool`. A `true`
+value enables pipelining while a `false` value disables pipelining. The
+optional argument defaults to `true`. This attribute cannot be applied to a
+loop in conjunction with the  ``max_interleaving``, ``speculated_iterations``,
+``max_concurrency``, ``initiation_interval``, or ``ivdep`` attributes.
+
+.. code-block:: c++
+
+  // Disable loop pipelining
+  void bar() {
+    int a[10];
+    [[[intel::fpga_pipeline(0)]] for (int i = 0; i != 10; ++i) a[i] = 0;
+  }
+
+  // Enable loop pipelining
+  void foo() {
+    int var = 0;
+    [[intel::fpga_pipeline(1)]] for (int i = 0; i < 10; ++i) var++;
+  }
+
+  void count(int *array, size_t n) {
+    [[intel::fpga_pipeline(1)]] for (int i = 0; i < n; ++i) array[i] = 0;
+  }
+
+  template<int A>
+  void func() {
+    [[intel::fpga_pipeline(A)]] for(;;) { }
+  }
 
   }];
 }

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -2277,12 +2277,8 @@ public:
   SYCLIntelFPGALoopCoalesceAttr *
   BuildSYCLIntelFPGALoopCoalesceAttr(const AttributeCommonInfo &CI, Expr *E);
 
-  SYCLIntelFpgaPipelineAttr *
+  SYCLIntelFPGAPipelineAttr *
   BuildSYCLIntelFPGAPipelineAttr(const AttributeCommonInfo &CI, Expr *E);
-
-  bool checkPipelineAttrArgument(Expr *E,
-                                 const SYCLIntelFpgaPipelineAttr *TmpAttr,
-                                 ExprResult &Result);
 
   bool CheckQualifiedFunctionForTypeId(QualType T, SourceLocation Loc);
 

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -2277,6 +2277,13 @@ public:
   SYCLIntelFPGALoopCoalesceAttr *
   BuildSYCLIntelFPGALoopCoalesceAttr(const AttributeCommonInfo &CI, Expr *E);
 
+  SYCLIntelFpgaPipelineAttr *
+  BuildSYCLIntelFPGAPipelineAttr(const AttributeCommonInfo &CI, Expr *E);
+
+  bool checkPipelineAttrArgument(Expr *E,
+                                 const SYCLIntelFpgaPipelineAttr *TmpAttr,
+                                 ExprResult &Result);
+
   bool CheckQualifiedFunctionForTypeId(QualType T, SourceLocation Loc);
 
   bool CheckFunctionReturnType(QualType T, SourceLocation Loc);

--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -611,6 +611,14 @@ MDNode *LoopInfo::createMetadata(
                             llvm::Type::getInt32Ty(Ctx), VC.second))};
     LoopProperties.push_back(MDNode::get(Ctx, Vals));
   }
+
+  for (auto &FP : Attrs.SYCLIntelFPGANPipelines) {
+    Metadata *Vals[] = {MDString::get(Ctx, FP.first),
+                        ConstantAsMetadata::get(ConstantInt::get(
+                            llvm::Type::getInt32Ty(Ctx), FP.second))};
+    LoopProperties.push_back(MDNode::get(Ctx, Vals));
+  }
+
   LoopProperties.insert(LoopProperties.end(), AdditionalLoopProperties.begin(),
                         AdditionalLoopProperties.end());
   return createFullUnrollMetadata(Attrs, LoopProperties, HasUserTransforms);
@@ -654,6 +662,7 @@ void LoopAttributes::clear() {
   PipelineDisabled = false;
   PipelineInitiationInterval = 0;
   SYCLNofusionEnable = false;
+  SYCLIntelFPGANPipelines.clear();
   MustProgress = false;
 }
 
@@ -687,7 +696,8 @@ LoopInfo::LoopInfo(BasicBlock *Header, const LoopAttributes &Attrs,
       Attrs.UnrollEnable == LoopAttributes::Unspecified &&
       Attrs.UnrollAndJamEnable == LoopAttributes::Unspecified &&
       Attrs.DistributeEnable == LoopAttributes::Unspecified && !StartLoc &&
-      Attrs.SYCLNofusionEnable == false && !EndLoc && !Attrs.MustProgress)
+      Attrs.SYCLNofusionEnable == false &&
+      Attrs.SYCLIntelFPGANPipelines.empty() && !EndLoc && !Attrs.MustProgress)
     return;
 
   TempLoopID = MDNode::getTemporary(Header->getContext(), None);
@@ -1011,6 +1021,8 @@ void LoopInfoStack::push(BasicBlock *Header, clang::ASTContext &Ctx,
   // emitted
   // For attribute nofusion:
   // 'llvm.loop.fusion.disable' metadata will be emitted
+  // For attribute fpga_pipeline:
+  // n - 'llvm.loop.intel.pipelining.enable, i32 n' metadata will be emitted
   for (const auto *A : Attrs) {
     if (const auto *IntelFPGAIVDep = dyn_cast<SYCLIntelFPGAIVDepAttr>(A))
       addSYCLIVDepInfo(Header->getContext(), IntelFPGAIVDep->getSafelenValue(),
@@ -1075,6 +1087,15 @@ void LoopInfoStack::push(BasicBlock *Header, clang::ASTContext &Ctx,
 
     if (isa<SYCLIntelFPGANofusionAttr>(A))
       setSYCLNofusionEnable();
+
+    if (const auto *IntelFpgaPipeline =
+            dyn_cast<SYCLIntelFpgaPipelineAttr>(A)) {
+      const auto *CE = cast<ConstantExpr>(IntelFpgaPipeline->getValue());
+      Optional<llvm::APSInt> ArgVal = CE->getResultAsAPSInt();
+      unsigned int Value = ArgVal->getBoolValue() ? 1 : 0;
+      const char *Var = "llvm.loop.intel.pipelining.enable";
+      setSYCLIntelFPGANPipelines(Var, Value);
+    }
   }
 
   setMustProgress(MustProgress);

--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -612,7 +612,7 @@ MDNode *LoopInfo::createMetadata(
     LoopProperties.push_back(MDNode::get(Ctx, Vals));
   }
 
-  for (auto &FP : Attrs.SYCLIntelFPGANPipelines) {
+  for (auto &FP : Attrs.SYCLIntelFPGAPipeline) {
     Metadata *Vals[] = {MDString::get(Ctx, FP.first),
                         ConstantAsMetadata::get(ConstantInt::get(
                             llvm::Type::getInt32Ty(Ctx), FP.second))};
@@ -662,7 +662,7 @@ void LoopAttributes::clear() {
   PipelineDisabled = false;
   PipelineInitiationInterval = 0;
   SYCLNofusionEnable = false;
-  SYCLIntelFPGANPipelines.clear();
+  SYCLIntelFPGAPipeline.clear();
   MustProgress = false;
 }
 
@@ -697,7 +697,7 @@ LoopInfo::LoopInfo(BasicBlock *Header, const LoopAttributes &Attrs,
       Attrs.UnrollAndJamEnable == LoopAttributes::Unspecified &&
       Attrs.DistributeEnable == LoopAttributes::Unspecified && !StartLoc &&
       Attrs.SYCLNofusionEnable == false &&
-      Attrs.SYCLIntelFPGANPipelines.empty() && !EndLoc && !Attrs.MustProgress)
+      Attrs.SYCLIntelFPGAPipeline.empty() && !EndLoc && !Attrs.MustProgress)
     return;
 
   TempLoopID = MDNode::getTemporary(Header->getContext(), None);
@@ -1088,13 +1088,13 @@ void LoopInfoStack::push(BasicBlock *Header, clang::ASTContext &Ctx,
     if (isa<SYCLIntelFPGANofusionAttr>(A))
       setSYCLNofusionEnable();
 
-    if (const auto *IntelFpgaPipeline =
-            dyn_cast<SYCLIntelFpgaPipelineAttr>(A)) {
-      const auto *CE = cast<ConstantExpr>(IntelFpgaPipeline->getValue());
+    if (const auto *IntelFPGAPipeline =
+            dyn_cast<SYCLIntelFPGAPipelineAttr>(A)) {
+      const auto *CE = cast<ConstantExpr>(IntelFPGAPipeline->getValue());
       Optional<llvm::APSInt> ArgVal = CE->getResultAsAPSInt();
       unsigned int Value = ArgVal->getBoolValue() ? 1 : 0;
       const char *Var = "llvm.loop.intel.pipelining.enable";
-      setSYCLIntelFPGANPipelines(Var, Value);
+      setSYCLIntelFPGAPipeline(Var, Value);
     }
   }
 

--- a/clang/lib/CodeGen/CGLoopInfo.h
+++ b/clang/lib/CodeGen/CGLoopInfo.h
@@ -152,6 +152,10 @@ struct LoopAttributes {
   /// Flag for llvm.loop.fusion.disable metatdata.
   bool SYCLNofusionEnable;
 
+  /// Value for fpga_pipeline variant and metadata.
+  llvm::SmallVector<std::pair<const char *, unsigned int>, 2>
+      SYCLIntelFPGANPipelines;
+
   /// Value for whether the loop is required to make progress.
   bool MustProgress;
 };
@@ -406,6 +410,11 @@ public:
 
   /// Set flag of nofusion for the next loop pushed.
   void setSYCLNofusionEnable() { StagedAttrs.SYCLNofusionEnable = true; }
+
+  /// Set variant and value of fpga_pipeline for the next loop pushed.
+  void setSYCLIntelFPGANPipelines(const char *Var, unsigned int Value) {
+    StagedAttrs.SYCLIntelFPGANPipelines.push_back({Var, Value});
+  }
 
   /// Set no progress for the next loop pushed.
   void setMustProgress(bool P) { StagedAttrs.MustProgress = P; }

--- a/clang/lib/CodeGen/CGLoopInfo.h
+++ b/clang/lib/CodeGen/CGLoopInfo.h
@@ -154,7 +154,7 @@ struct LoopAttributes {
 
   /// Value for fpga_pipeline variant and metadata.
   llvm::SmallVector<std::pair<const char *, unsigned int>, 2>
-      SYCLIntelFPGANPipelines;
+      SYCLIntelFPGAPipeline;
 
   /// Value for whether the loop is required to make progress.
   bool MustProgress;
@@ -412,8 +412,8 @@ public:
   void setSYCLNofusionEnable() { StagedAttrs.SYCLNofusionEnable = true; }
 
   /// Set variant and value of fpga_pipeline for the next loop pushed.
-  void setSYCLIntelFPGANPipelines(const char *Var, unsigned int Value) {
-    StagedAttrs.SYCLIntelFPGANPipelines.push_back({Var, Value});
+  void setSYCLIntelFPGAPipeline(const char *Var, unsigned int Value) {
+    StagedAttrs.SYCLIntelFPGAPipeline.push_back({Var, Value});
   }
 
   /// Set no progress for the next loop pushed.

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -364,6 +364,14 @@ void Sema::CheckDeprecatedSYCLAttributeSpelling(const ParsedAttr &A,
     Diag(A.getLoc(), diag::ext_sycl_2020_attr_spelling) << A;
     return;
   }
+
+  // Deprecate [[intel::disable_loop_pipelining]] attribute spelling in favor
+  // of the SYCL FPGA attribute spelling [[intel::fpga_pipeline]].
+  if (A.hasScope() && A.getScopeName()->isStr("intel") &&
+      A.getAttrName()->isStr("disable_loop_pipelining")) {
+    DiagnoseDeprecatedAttribute(A, "intel", "fpga_pipeline");
+    return;
+  }
 }
 
 /// Check if IdxExpr is a valid parameter index for a function or

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -219,6 +219,44 @@ static Attr *handleSYCLIntelFPGADisableLoopPipeliningAttr(Sema &S, Stmt *,
   return new (S.Context) SYCLIntelFPGADisableLoopPipeliningAttr(S.Context, A);
 }
 
+// Handle [[intel:fpga_pipeline]] attribute.
+bool Sema::checkPipelineAttrArgument(Expr *E,
+                                     const SYCLIntelFpgaPipelineAttr *TmpAttr,
+                                     ExprResult &Result) {
+  llvm::APSInt Value;
+  // Validate that we have an integer constant expression.
+  Result = VerifyIntegerConstantExpression(E, &Value);
+  if (Result.isInvalid())
+    return true;
+  return false;
+}
+
+static Attr *handleSYCLIntelFPGAPipelineAttr(Sema &S, Stmt *,
+                                             const ParsedAttr &A) {
+  // If no attribute argument is specified, set to default value '1'.
+  Expr *E = A.isArgExpr(0)
+                ? A.getArgAsExpr(0)
+                : IntegerLiteral::Create(S.Context, llvm::APInt(32, 1),
+                                         S.Context.IntTy, A.getLoc());
+
+  return S.BuildSYCLIntelFPGAPipelineAttr(A, E);
+}
+
+SYCLIntelFpgaPipelineAttr *
+Sema::BuildSYCLIntelFPGAPipelineAttr(const AttributeCommonInfo &A, Expr *E) {
+  SYCLIntelFpgaPipelineAttr TmpAttr(Context, A, E);
+
+  if (!E->isValueDependent()) {
+    // Check if the expression is not value dependent.
+    ExprResult Res;
+    if (checkPipelineAttrArgument(E, &TmpAttr, Res))
+      return nullptr;
+    E = Res.get();
+  }
+
+  return new (Context) SYCLIntelFpgaPipelineAttr(Context, A, E);
+}
+
 static bool checkSYCLIntelFPGAIVDepSafeLen(Sema &S, llvm::APSInt &Value,
                                            Expr *E) {
   if (!Value.isStrictlyPositive())
@@ -821,6 +859,7 @@ static void CheckForIncompatibleSYCLLoopAttributes(
   CheckForDuplicationSYCLLoopAttribute<LoopUnrollHintAttr>(S, Attrs, false);
   CheckRedundantSYCLIntelFPGAIVDepAttrs(S, Attrs);
   CheckForDuplicationSYCLLoopAttribute<SYCLIntelFPGANofusionAttr>(S, Attrs);
+  CheckForDuplicationSYCLLoopAttribute<SYCLIntelFpgaPipelineAttr>(S, Attrs);
 }
 
 void CheckForIncompatibleUnrollHintAttributes(
@@ -966,6 +1005,8 @@ static Attr *ProcessStmtAttribute(Sema &S, Stmt *St, const ParsedAttr &A,
     return handleUnlikely(S, St, A, Range);
   case ParsedAttr::AT_SYCLIntelFPGANofusion:
     return handleIntelFPGANofusionAttr(S, St, A);
+  case ParsedAttr::AT_SYCLIntelFpgaPipeline:
+    return handleSYCLIntelFPGAPipelineAttr(S, St, A);
   default:
     // N.B., ClangAttrEmitter.cpp emits a diagnostic helper that ensures a
     // declaration attribute is not written on a statement, but this code is

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1110,8 +1110,8 @@ namespace {
         const SYCLIntelFPGASpeculatedIterationsAttr *SI);
     const SYCLIntelFPGALoopCountAttr *
     TransformSYCLIntelFPGALoopCountAttr(const SYCLIntelFPGALoopCountAttr *SI);
-    const SYCLIntelFpgaPipelineAttr *
-    TransformSYCLIntelFpgaPipelineAttr(const SYCLIntelFpgaPipelineAttr *SI);
+    const SYCLIntelFPGAPipelineAttr *
+    TransformSYCLIntelFPGAPipelineAttr(const SYCLIntelFPGAPipelineAttr *SI);
 
     ExprResult TransformPredefinedExpr(PredefinedExpr *E);
     ExprResult TransformDeclRefExpr(DeclRefExpr *E);
@@ -1603,9 +1603,9 @@ const LoopUnrollHintAttr *TemplateInstantiator::TransformLoopUnrollHintAttr(
   return getSema().BuildLoopUnrollHintAttr(*LU, TransformedExpr);
 }
 
-const SYCLIntelFpgaPipelineAttr *
-TemplateInstantiator::TransformSYCLIntelFpgaPipelineAttr(
-    const SYCLIntelFpgaPipelineAttr *PA) {
+const SYCLIntelFPGAPipelineAttr *
+TemplateInstantiator::TransformSYCLIntelFPGAPipelineAttr(
+    const SYCLIntelFPGAPipelineAttr *PA) {
   Expr *TransformedExpr = getDerived().TransformExpr(PA->getValue()).get();
   return getSema().BuildSYCLIntelFPGAPipelineAttr(*PA, TransformedExpr);
 }

--- a/clang/lib/Sema/SemaTemplateInstantiate.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiate.cpp
@@ -1110,6 +1110,8 @@ namespace {
         const SYCLIntelFPGASpeculatedIterationsAttr *SI);
     const SYCLIntelFPGALoopCountAttr *
     TransformSYCLIntelFPGALoopCountAttr(const SYCLIntelFPGALoopCountAttr *SI);
+    const SYCLIntelFpgaPipelineAttr *
+    TransformSYCLIntelFpgaPipelineAttr(const SYCLIntelFpgaPipelineAttr *SI);
 
     ExprResult TransformPredefinedExpr(PredefinedExpr *E);
     ExprResult TransformDeclRefExpr(DeclRefExpr *E);
@@ -1599,6 +1601,13 @@ const LoopUnrollHintAttr *TemplateInstantiator::TransformLoopUnrollHintAttr(
   Expr *TransformedExpr =
       getDerived().TransformExpr(LU->getUnrollHintExpr()).get();
   return getSema().BuildLoopUnrollHintAttr(*LU, TransformedExpr);
+}
+
+const SYCLIntelFpgaPipelineAttr *
+TemplateInstantiator::TransformSYCLIntelFpgaPipelineAttr(
+    const SYCLIntelFpgaPipelineAttr *PA) {
+  Expr *TransformedExpr = getDerived().TransformExpr(PA->getValue()).get();
+  return getSema().BuildSYCLIntelFPGAPipelineAttr(*PA, TransformedExpr);
 }
 
 ExprResult TemplateInstantiator::transformNonTypeTemplateParmRef(

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -161,19 +161,19 @@ void fpga_pipeline() {
   // CHECK: ![[MD_FP]] = distinct !{![[MD_FP]], ![[MP]], ![[MD_fpga_pipeline:[0-9]+]]}
   // CHECK-NEXT: ![[MD_fpga_pipeline]] = !{!"llvm.loop.intel.pipelining.enable", i32 1}
   [[intel::fpga_pipeline(A)]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+    a[i] = 0;
 
   // CHECK: ![[MD_FP_1]] = distinct !{![[MD_FP_1]], ![[MP]], ![[MD_fpga_pipeline]]}
   [[intel::fpga_pipeline(1)]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+    a[i] = 0;
 
   // CHECK: ![[MD_FP_2]] = distinct !{![[MD_FP_2]], ![[MP]], ![[MD_fpga_pipeline]]}
   [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+    a[i] = 0;
 
   // CHECK: ![[MD_FP_3]] = distinct !{![[MD_FP_3]], ![[MP]], ![[MD_dlp]]}
   [[intel::fpga_pipeline(0)]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+    a[i] = 0;
 }
 
 template <typename name, typename Func>

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -24,6 +24,9 @@
 // CHECK: br label %for.cond2, !llvm.loop ![[MD_FP_1:[0-9]+]]
 // CHECK: br label %for.cond13, !llvm.loop ![[MD_FP_2:[0-9]+]]
 // CHECK: br label %for.cond24, !llvm.loop ![[MD_FP_3:[0-9]+]]
+// CHECK: br label %while.cond, !llvm.loop ![[MD_FP_4:[0-9]+]]
+// CHECK: br i1 %cmp38, label %do.body, label %do.end, !llvm.loop ![[MD_FP_5:[0-9]+]]
+// CHECK: br label %for.cond40, !llvm.loop ![[MD_FP_6:[0-9]+]]
 
 void disable_loop_pipelining() {
   int a[10];
@@ -155,6 +158,7 @@ void loop_count_control() {
       a[i] = 0;
 }
 
+// Add CodeGen tests for Loop attribute: [[intel::fpga_pipeline()]].
 template <int A>
 void fpga_pipeline() {
   int a[10];
@@ -174,6 +178,23 @@ void fpga_pipeline() {
   // CHECK: ![[MD_FP_3]] = distinct !{![[MD_FP_3]], ![[MP]], ![[MD_dlp]]}
   [[intel::fpga_pipeline(0)]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
+
+  // CHECK: ![[MD_FP_4]] = distinct !{![[MD_FP_4]], ![[MP]], ![[MD_fpga_pipeline]]}
+  int j = 0;
+  [[intel::fpga_pipeline]] while (j < 10) {
+    a[j] += 3;
+  }
+
+  // CHECK: ![[MD_FP_5]] = distinct !{![[MD_FP_5]], ![[MP]], ![[MD_fpga_pipeline]]}
+  int b = 10;
+   [[intel::fpga_pipeline(1)]]
+    do {
+        b = b + 1;
+    }while( b < 20 );
+
+   // CHECK: ![[MD_FP_6]] = distinct !{![[MD_FP_6]], ![[MD_fpga_pipeline]]}
+   int c[] = {0, 1, 2, 3, 4, 5};
+   [[intel::fpga_pipeline(A)]] for (int n : c) { n *= 2; }
 }
 
 template <typename name, typename Func>

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -27,6 +27,7 @@
 // CHECK: br label %while.cond, !llvm.loop ![[MD_FP_4:[0-9]+]]
 // CHECK: br i1 %cmp38, label %do.body, label %do.end, !llvm.loop ![[MD_FP_5:[0-9]+]]
 // CHECK: br label %for.cond40, !llvm.loop ![[MD_FP_6:[0-9]+]]
+// CHECK: br label %while.cond47, !llvm.loop ![[MD_FP_7:[0-9]+]]
 
 void disable_loop_pipelining() {
   int a[10];
@@ -194,6 +195,10 @@ void fpga_pipeline() {
   // CHECK: ![[MD_FP_6]] = distinct !{![[MD_FP_6]], ![[MD_fpga_pipeline]]}
   int c[] = {0, 1, 2, 3, 4, 5};
   [[intel::fpga_pipeline(A)]] for (int n : c) { n *= 2; }
+
+  // CHECK: ![[MD_FP_7]] = distinct !{![[MD_FP_7]], ![[MP]], ![[MD_fpga_pipeline]]}
+  int k = 0;
+  [[intel::fpga_pipeline(-1)]] while (k < 20) { a[k] += 2; }
 }
 
 template <typename name, typename Func>

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -187,14 +187,13 @@ void fpga_pipeline() {
 
   // CHECK: ![[MD_FP_5]] = distinct !{![[MD_FP_5]], ![[MP]], ![[MD_fpga_pipeline]]}
   int b = 10;
-   [[intel::fpga_pipeline(1)]]
-    do {
-        b = b + 1;
-    }while( b < 20 );
+  [[intel::fpga_pipeline(1)]] do {
+    b = b + 1;
+  } while (b < 20);
 
-   // CHECK: ![[MD_FP_6]] = distinct !{![[MD_FP_6]], ![[MD_fpga_pipeline]]}
-   int c[] = {0, 1, 2, 3, 4, 5};
-   [[intel::fpga_pipeline(A)]] for (int n : c) { n *= 2; }
+  // CHECK: ![[MD_FP_6]] = distinct !{![[MD_FP_6]], ![[MD_fpga_pipeline]]}
+  int c[] = {0, 1, 2, 3, 4, 5};
+  [[intel::fpga_pipeline(A)]] for (int n : c) { n *= 2; }
 }
 
 template <typename name, typename Func>

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -133,8 +133,8 @@ void boo() {
 // Test for incorrect argument value for Intel FPGA loop attributes
 void goo() {
   int a[10];
-  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
-                                                                   // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
+  // no diagnostics are expected
+  [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
   // no diagnostics are expected
   [[intel::max_concurrency(0)]] for (int i = 0; i != 10; ++i)
@@ -272,11 +272,9 @@ void zoo() {
   [[intel::max_concurrency(2)]]
   [[intel::initiation_interval(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
-                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
-  // expected-error@+1 {{duplicate Intel FPGA loop attribute 'disable_loop_pipelining'}}
-  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
-                                                                   // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
+  [[intel::fpga_pipeline]]
+  // expected-error@+1 {{duplicate Intel FPGA loop attribute 'fpga_pipeline'}}
+  [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
   [[intel::loop_coalesce(2)]]
   // expected-error@+2 {{duplicate Intel FPGA loop attribute 'loop_coalesce'}}
@@ -365,8 +363,7 @@ void zoo() {
 // Test for Intel FPGA loop attributes compatibility
 void loop_attrs_compatibility() {
   int a[10];
-  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
-                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
+  [[intel::fpga_pipeline]]
   [[intel::loop_coalesce]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
   // expected-error@+4 {{'max_interleaving' and 'disable_loop_pipelining' attributes are not compatible}}
@@ -375,10 +372,10 @@ void loop_attrs_compatibility() {
                                      // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::max_interleaving(0)]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
-  // expected-error@+2 {{'disable_loop_pipelining' and 'speculated_iterations' attributes are not compatible}}
+
+  // expected-error@+2 {{'fpga_pipeline' and 'speculated_iterations' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::speculated_iterations(0)]] [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
-                                                                                                       // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
+  [[intel::speculated_iterations(0)]] [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
   // expected-error@+4 {{'max_concurrency' and 'disable_loop_pipelining' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
@@ -386,30 +383,15 @@ void loop_attrs_compatibility() {
                                      // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::max_concurrency(0)]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
-  // expected-error@+2 {{'disable_loop_pipelining' and 'initiation_interval' attributes are not compatible}}
+  // expected-error@+2 {{'fpga_pipeline' and 'initiation_interval' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::initiation_interval(10)]] [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
-                                                                                                      // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
+  [[intel::initiation_interval(10)]] [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
   // expected-error@+4 {{'ivdep' and 'disable_loop_pipelining' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
   [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
                                      // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::ivdep]] for (int i = 0; i != 10; ++i)
-    a[i] = 0;
-
-  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
-                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
-  [[intel::nofusion]] for (int i = 0; i != 10; ++i)
-    a[i] = 0;
-
-  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
-                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
-  [[intel::loop_count_avg(8)]] for (int i = 0; i != 10; ++i)
-    a[i] = 0;
-  [[intel::loop_count_min(8)]] for (int i = 0; i != 10; ++i)
-    a[i] = 0;
-  [[intel::loop_count_max(8)]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
 
   // no diagnostics are expected

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -363,8 +363,7 @@ void zoo() {
 // Test for Intel FPGA loop attributes compatibility
 void loop_attrs_compatibility() {
   int a[10];
-  [[intel::fpga_pipeline]]
-  [[intel::loop_coalesce]] for (int i = 0; i != 10; ++i)
+  [[intel::fpga_pipeline]] [[intel::loop_coalesce]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
   // expected-error@+4 {{'max_interleaving' and 'disable_loop_pipelining' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -127,7 +127,7 @@ void boo() {
 
   // expected-error@+1 {{'fpga_pipeline' attribute takes no more than 1 argument}}
   [[intel::fpga_pipeline(1, 2)]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+    a[i] = 0;
 }
 
 // Test for incorrect argument value for Intel FPGA loop attributes
@@ -135,7 +135,7 @@ void goo() {
   int a[10];
   [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
                                                                    // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
-      a[i] = 0;
+    a[i] = 0;
   // no diagnostics are expected
   [[intel::max_concurrency(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
@@ -224,17 +224,17 @@ void goo() {
       a[i] = 0;
 
   // no diagnostics are expected
-   [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
-       a[i] = 0;
+  [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
+    a[i] = 0;
   // no diagnostics are expected
   [[intel::fpga_pipeline(0)]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+    a[i] = 0;
   // no diagnostics are expected
   [[intel::fpga_pipeline(-1)]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+    a[i] = 0;
   // expected-error@+1 {{integral constant expression must have integral or unscoped enumeration type, not 'const char[4]'}}
   [[intel::fpga_pipeline("abc")]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+    a[i] = 0;
 }
 
 // Test for Intel FPGA loop attributes duplication
@@ -277,7 +277,7 @@ void zoo() {
   // expected-error@+1 {{duplicate Intel FPGA loop attribute 'disable_loop_pipelining'}}
   [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
                                                                    // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
-      a[i] = 0;
+    a[i] = 0;
   [[intel::loop_coalesce(2)]]
   // expected-error@+2 {{duplicate Intel FPGA loop attribute 'loop_coalesce'}}
   [[intel::max_interleaving(1)]]
@@ -359,7 +359,7 @@ void zoo() {
   [[intel::fpga_pipeline(1)]]
   // expected-error@+1{{duplicate Intel FPGA loop attribute 'fpga_pipeline'}}
   [[intel::fpga_pipeline(1)]] for (int i = 0; i != 10; ++i)
-       a[i] = 0;
+    a[i] = 0;
 }
 
 // Test for Intel FPGA loop attributes compatibility
@@ -368,69 +368,61 @@ void loop_attrs_compatibility() {
   [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
                                      // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::loop_coalesce]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+    a[i] = 0;
   // expected-error@+4 {{'max_interleaving' and 'disable_loop_pipelining' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
   [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
                                      // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::max_interleaving(0)]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+    a[i] = 0;
   // expected-error@+3 {{'disable_loop_pipelining' and 'speculated_iterations' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::speculated_iterations(0)]]
-  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
-                                                                   // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
-      a[i] = 0;
+  [[intel::speculated_iterations(0)]] [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                                                                                       // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
+    a[i] = 0;
   // expected-error@+4 {{'max_concurrency' and 'disable_loop_pipelining' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
   [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
                                      // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::max_concurrency(0)]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+    a[i] = 0;
   // expected-error@+3 {{'disable_loop_pipelining' and 'initiation_interval' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::initiation_interval(10)]]
-  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
-                                                                   // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
-      a[i] = 0;
+  [[intel::initiation_interval(10)]] [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                                                                                      // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
+    a[i] = 0;
   // expected-error@+4 {{'ivdep' and 'disable_loop_pipelining' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
   [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
                                      // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::ivdep]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+    a[i] = 0;
 
   [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
                                      // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::nofusion]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+    a[i] = 0;
 
   [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
                                      // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
-  [[intel::loop_count_avg(8)]]
-  for (int i = 0; i != 10; ++i)
-      a[i] = 0;
-  [[intel::loop_count_min(8)]]
-  for (int i = 0; i != 10; ++i)
-      a[i] = 0;
-  [[intel::loop_count_max(8)]]
-  for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+  [[intel::loop_count_avg(8)]] for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  [[intel::loop_count_min(8)]] for (int i = 0; i != 10; ++i)
+    a[i] = 0;
+  [[intel::loop_count_max(8)]] for (int i = 0; i != 10; ++i)
+    a[i] = 0;
 
   // no diagnostics are expected
-  [[intel::fpga_pipeline]]
-  [[intel::loop_coalesce]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+  [[intel::fpga_pipeline]] [[intel::loop_coalesce]] for (int i = 0; i != 10; ++i)
+    a[i] = 0;
 
   // no diagnostics are expected
-  [[intel::fpga_pipeline]]
-  [[intel::nofusion]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+  [[intel::fpga_pipeline]] [[intel::nofusion]] for (int i = 0; i != 10; ++i)
+    a[i] = 0;
   // no diagnostics are expected
-  [[intel::fpga_pipeline]]
-  [[intel::loop_count_avg(8)]]
+  [[intel::fpga_pipeline]] [[intel::loop_count_avg(8)]]
   for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+       a[i] = 0;
   [[intel::loop_count_min(8)]]
   for (int i = 0; i != 10; ++i)
       a[i] = 0;
@@ -442,33 +434,28 @@ void loop_attrs_compatibility() {
 
   // expected-error@+3 {{'fpga_pipeline' and 'max_concurrency' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::max_concurrency(2)]]
-  [[intel::fpga_pipeline(1)]] for (int i = 0; i != 10; ++i)
-       a[i] = 0;
+  [[intel::max_concurrency(2)]] [[intel::fpga_pipeline(1)]] for (int i = 0; i != 10; ++i)
+    a[i] = 0;
 
   // expected-error@+3 {{'fpga_pipeline' and 'initiation_interval' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::initiation_interval(2)]]
-  [[intel::fpga_pipeline(1)]] for (int i = 0; i != 10; ++i)
-       a[i] = 0;
+  [[intel::initiation_interval(2)]] [[intel::fpga_pipeline(1)]] for (int i = 0; i != 10; ++i)
+    a[i] = 0;
 
   // expected-error@+3 {{'fpga_pipeline' and 'max_interleaving' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::max_interleaving(2)]]
-  [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+  [[intel::max_interleaving(2)]] [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
+    a[i] = 0;
 
   // expected-error@+3 {{'fpga_pipeline' and 'speculated_iterations' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::speculated_iterations(0)]]
-  [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+  [[intel::speculated_iterations(0)]] [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
+    a[i] = 0;
 
   // expected-error@+3 {{'fpga_pipeline' and 'ivdep' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::ivdep]]
-  [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+  [[intel::ivdep]] [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
+    a[i] = 0;
 }
 
 template<int A, int B, int C>
@@ -632,12 +619,11 @@ template <int A, int B, int C>
 void fpga_pipeline_dependent() {
   int a[10];
   [[intel::fpga_pipeline(C)]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+    a[i] = 0;
 
   // expected-error@+2 {{duplicate Intel FPGA loop attribute 'fpga_pipeline'}}
-  [[intel::fpga_pipeline(A)]]
-  [[intel::fpga_pipeline(B)]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+  [[intel::fpga_pipeline(A)]] [[intel::fpga_pipeline(B)]] for (int i = 0; i != 10; ++i)
+    a[i] = 0;
 }
 
 void check_max_concurrency_expression() {
@@ -744,12 +730,12 @@ void check_loop_fpga_pipeline_expression() {
   // expected-error@+2{{expression is not an integral constant expression}}
   // expected-note@+1{{read of non-const variable 'foo' is not allowed in a constant expression}}
   [[intel::fpga_pipeline(foo + 1)]] for (int i = 0; i != 10; ++i)
-       a[i] = 0;
+    a[i] = 0;
 
   // Test that checks expression is a constant expression.
   constexpr int bar = 0;
   [[intel::fpga_pipeline(bar + 1)]] for (int i = 0; i != 10; ++i) // OK
-      a[i] = 0;
+    a[i] = 0;
 }
 
 // Test that checks wrong template instantiation and ensures that the type
@@ -797,7 +783,7 @@ void check_loop_attr_template_instantiation() {
   // expected-error@+2 {{integral constant expression must have integral or unscoped enumeration type, not 'S'}}
   // expected-error@+1 {{integral constant expression must have integral or unscoped enumeration type, not 'float'}}
   [[intel::fpga_pipeline(Ty{})]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
+    a[i] = 0;
 }
 
 int main() {

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -375,7 +375,7 @@ void loop_attrs_compatibility() {
                                      // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::max_interleaving(0)]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
-  // expected-error@+3 {{'disable_loop_pipelining' and 'speculated_iterations' attributes are not compatible}}
+  // expected-error@+2 {{'disable_loop_pipelining' and 'speculated_iterations' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
   [[intel::speculated_iterations(0)]] [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
                                                                                                        // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
@@ -386,7 +386,7 @@ void loop_attrs_compatibility() {
                                      // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::max_concurrency(0)]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
-  // expected-error@+3 {{'disable_loop_pipelining' and 'initiation_interval' attributes are not compatible}}
+  // expected-error@+2 {{'disable_loop_pipelining' and 'initiation_interval' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
   [[intel::initiation_interval(10)]] [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
                                                                                                       // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
@@ -431,27 +431,27 @@ void loop_attrs_compatibility() {
   [[intel::loop_count(8)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
-  // expected-error@+3 {{'fpga_pipeline' and 'max_concurrency' attributes are not compatible}}
+  // expected-error@+2 {{'fpga_pipeline' and 'max_concurrency' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
   [[intel::max_concurrency(2)]] [[intel::fpga_pipeline(1)]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
 
-  // expected-error@+3 {{'fpga_pipeline' and 'initiation_interval' attributes are not compatible}}
+  // expected-error@+2 {{'fpga_pipeline' and 'initiation_interval' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
   [[intel::initiation_interval(2)]] [[intel::fpga_pipeline(1)]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
 
-  // expected-error@+3 {{'fpga_pipeline' and 'max_interleaving' attributes are not compatible}}
+  // expected-error@+2 {{'fpga_pipeline' and 'max_interleaving' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
   [[intel::max_interleaving(2)]] [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
 
-  // expected-error@+3 {{'fpga_pipeline' and 'speculated_iterations' attributes are not compatible}}
+  // expected-error@+2 {{'fpga_pipeline' and 'speculated_iterations' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
   [[intel::speculated_iterations(0)]] [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
 
-  // expected-error@+3 {{'fpga_pipeline' and 'ivdep' attributes are not compatible}}
+  // expected-error@+2 {{'fpga_pipeline' and 'ivdep' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
   [[intel::ivdep]] [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
@@ -620,7 +620,7 @@ void fpga_pipeline_dependent() {
   [[intel::fpga_pipeline(C)]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
 
-  // expected-error@+2 {{duplicate Intel FPGA loop attribute 'fpga_pipeline'}}
+  // expected-error@+1 {{duplicate Intel FPGA loop attribute 'fpga_pipeline'}}
   [[intel::fpga_pipeline(A)]] [[intel::fpga_pipeline(B)]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
 }

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -420,9 +420,8 @@ void loop_attrs_compatibility() {
   [[intel::fpga_pipeline]] [[intel::nofusion]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
   // no diagnostics are expected
-  [[intel::fpga_pipeline]] [[intel::loop_count_avg(8)]]
-  for (int i = 0; i != 10; ++i)
-       a[i] = 0;
+  [[intel::fpga_pipeline]] [[intel::loop_count_avg(8)]] for (int i = 0; i != 10; ++i)
+    a[i] = 0;
   [[intel::loop_count_min(8)]]
   for (int i = 0; i != 10; ++i)
       a[i] = 0;

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -26,6 +26,8 @@ void foo() {
   [[intel::loop_count_avg(6)]] int l[10];
   // expected-error@+1{{'loop_count' attribute cannot be applied to a declaration}}
   [[intel::loop_count(8)]] int m[10];
+  // expected-error@+1{{'fpga_pipeline' attribute cannot be applied to a declaration}}
+  [[intel::fpga_pipeline(1)]] int n[10];
 }
 
 // Test for deprecated spelling of Intel FPGA loop attributes
@@ -122,13 +124,17 @@ void boo() {
   // expected-error@+1 {{'loop_count' attribute takes one argument}}
   [[intel::loop_count(6, 9)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
+
+  // expected-error@+1 {{'fpga_pipeline' attribute takes no more than 1 argument}}
+  [[intel::fpga_pipeline(1, 2)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
 }
 
 // Test for incorrect argument value for Intel FPGA loop attributes
 void goo() {
   int a[10];
-  // no diagnostics are expected
-  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
+  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                                                   // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
       a[i] = 0;
   // no diagnostics are expected
   [[intel::max_concurrency(0)]] for (int i = 0; i != 10; ++i)
@@ -216,6 +222,19 @@ void goo() {
   // expected-error@+1 {{'loop_count' attribute requires a non-negative integral compile time constant expression}}
   [[intel::loop_count(-1)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
+
+  // no diagnostics are expected
+   [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
+       a[i] = 0;
+  // no diagnostics are expected
+  [[intel::fpga_pipeline(0)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+  // no diagnostics are expected
+  [[intel::fpga_pipeline(-1)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+  // expected-error@+1 {{integral constant expression must have integral or unscoped enumeration type, not 'const char[4]'}}
+  [[intel::fpga_pipeline("abc")]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
 }
 
 // Test for Intel FPGA loop attributes duplication
@@ -253,9 +272,11 @@ void zoo() {
   [[intel::max_concurrency(2)]]
   [[intel::initiation_interval(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  [[intel::disable_loop_pipelining]]
+  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   // expected-error@+1 {{duplicate Intel FPGA loop attribute 'disable_loop_pipelining'}}
-  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
+  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                                                   // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
       a[i] = 0;
   [[intel::loop_coalesce(2)]]
   // expected-error@+2 {{duplicate Intel FPGA loop attribute 'loop_coalesce'}}
@@ -334,46 +355,79 @@ void zoo() {
   // expected-error@+1{{duplicate Intel FPGA loop attribute 'loop_count'}}
   [[intel::loop_count(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
+
+  [[intel::fpga_pipeline(1)]]
+  // expected-error@+1{{duplicate Intel FPGA loop attribute 'fpga_pipeline'}}
+  [[intel::fpga_pipeline(1)]] for (int i = 0; i != 10; ++i)
+       a[i] = 0;
 }
 
 // Test for Intel FPGA loop attributes compatibility
 void loop_attrs_compatibility() {
   int a[10];
-  // no diagnostics are expected
-  [[intel::disable_loop_pipelining]]
+  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::loop_coalesce]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+3 {{'max_interleaving' and 'disable_loop_pipelining' attributes are not compatible}}
+  // expected-error@+4 {{'max_interleaving' and 'disable_loop_pipelining' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::disable_loop_pipelining]]
+  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::max_interleaving(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   // expected-error@+3 {{'disable_loop_pipelining' and 'speculated_iterations' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
   [[intel::speculated_iterations(0)]]
-  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
+  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                                                   // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
       a[i] = 0;
-  // expected-error@+3 {{'max_concurrency' and 'disable_loop_pipelining' attributes are not compatible}}
+  // expected-error@+4 {{'max_concurrency' and 'disable_loop_pipelining' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::disable_loop_pipelining]]
+  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::max_concurrency(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   // expected-error@+3 {{'disable_loop_pipelining' and 'initiation_interval' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
   [[intel::initiation_interval(10)]]
-  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i)
+  [[intel::disable_loop_pipelining]] for (int i = 0; i != 10; ++i) // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                                                   // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
       a[i] = 0;
-  // expected-error@+3 {{'ivdep' and 'disable_loop_pipelining' attributes are not compatible}}
+  // expected-error@+4 {{'ivdep' and 'disable_loop_pipelining' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::disable_loop_pipelining]]
+  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
   [[intel::ivdep]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
+
+  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
+  [[intel::nofusion]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+
+  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
+                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
+  [[intel::loop_count_avg(8)]]
+  for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+  [[intel::loop_count_min(8)]]
+  for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+  [[intel::loop_count_max(8)]]
+  for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+
   // no diagnostics are expected
-  [[intel::disable_loop_pipelining]]
+  [[intel::fpga_pipeline]]
+  [[intel::loop_coalesce]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+
+  // no diagnostics are expected
+  [[intel::fpga_pipeline]]
   [[intel::nofusion]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   // no diagnostics are expected
-  [[intel::disable_loop_pipelining]]
+  [[intel::fpga_pipeline]]
   [[intel::loop_count_avg(8)]]
   for (int i = 0; i != 10; ++i)
       a[i] = 0;
@@ -384,6 +438,36 @@ void loop_attrs_compatibility() {
   for (int i = 0; i != 10; ++i)
       a[i] = 0;
   [[intel::loop_count(8)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+
+  // expected-error@+3 {{'fpga_pipeline' and 'max_concurrency' attributes are not compatible}}
+  // expected-note@+1 {{conflicting attribute is here}}
+  [[intel::max_concurrency(2)]]
+  [[intel::fpga_pipeline(1)]] for (int i = 0; i != 10; ++i)
+       a[i] = 0;
+
+  // expected-error@+3 {{'fpga_pipeline' and 'initiation_interval' attributes are not compatible}}
+  // expected-note@+1 {{conflicting attribute is here}}
+  [[intel::initiation_interval(2)]]
+  [[intel::fpga_pipeline(1)]] for (int i = 0; i != 10; ++i)
+       a[i] = 0;
+
+  // expected-error@+3 {{'fpga_pipeline' and 'max_interleaving' attributes are not compatible}}
+  // expected-note@+1 {{conflicting attribute is here}}
+  [[intel::max_interleaving(2)]]
+  [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+
+  // expected-error@+3 {{'fpga_pipeline' and 'speculated_iterations' attributes are not compatible}}
+  // expected-note@+1 {{conflicting attribute is here}}
+  [[intel::speculated_iterations(0)]]
+  [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+
+  // expected-error@+3 {{'fpga_pipeline' and 'ivdep' attributes are not compatible}}
+  // expected-note@+1 {{conflicting attribute is here}}
+  [[intel::ivdep]]
+  [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 }
 
@@ -544,6 +628,18 @@ void loop_count_control_dependent() {
       a[i] = 0;
 }
 
+template <int A, int B, int C>
+void fpga_pipeline_dependent() {
+  int a[10];
+  [[intel::fpga_pipeline(C)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+
+  // expected-error@+2 {{duplicate Intel FPGA loop attribute 'fpga_pipeline'}}
+  [[intel::fpga_pipeline(A)]]
+  [[intel::fpga_pipeline(B)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+}
+
 void check_max_concurrency_expression() {
   int a[10];
   // Test that checks expression is not a constant expression.
@@ -640,6 +736,22 @@ void check_loop_count_expression() {
       a[i] = 0;
 }
 
+void check_loop_fpga_pipeline_expression() {
+  int a[10];
+
+  // Test that checks expression is not a constant expression.
+  int foo; // expected-note {{declared here}}
+  // expected-error@+2{{expression is not an integral constant expression}}
+  // expected-note@+1{{read of non-const variable 'foo' is not allowed in a constant expression}}
+  [[intel::fpga_pipeline(foo + 1)]] for (int i = 0; i != 10; ++i)
+       a[i] = 0;
+
+  // Test that checks expression is a constant expression.
+  constexpr int bar = 0;
+  [[intel::fpga_pipeline(bar + 1)]] for (int i = 0; i != 10; ++i) // OK
+      a[i] = 0;
+}
+
 // Test that checks wrong template instantiation and ensures that the type
 // is checked properly when instantiating from the template definition.
 struct S {};
@@ -681,6 +793,11 @@ void check_loop_attr_template_instantiation() {
   // expected-error@+1 {{integral constant expression must have integral or unscoped enumeration type, not 'float'}}
   [[intel::loop_count(Ty{})]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
+
+  // expected-error@+2 {{integral constant expression must have integral or unscoped enumeration type, not 'S'}}
+  // expected-error@+1 {{integral constant expression must have integral or unscoped enumeration type, not 'float'}}
+  [[intel::fpga_pipeline(Ty{})]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
 }
 
 int main() {
@@ -703,12 +820,14 @@ int main() {
       speculated_iterations_dependent<1, 8, -3, 0>(); // expected-note{{in instantiation of function template specialization 'speculated_iterations_dependent<1, 8, -3, 0>' requested here}}
       loop_coalesce_dependent<-1, 4,  0>(); // expected-note{{in instantiation of function template specialization 'loop_coalesce_dependent<-1, 4, 0>' requested here}}
       loop_count_control_dependent<3, 2, -1>(); // expected-note{{in instantiation of function template specialization 'loop_count_control_dependent<3, 2, -1>' requested here}}
+      fpga_pipeline_dependent<1, 1, 0>();
       check_max_concurrency_expression();
       check_max_interleaving_expression();
       check_speculated_iterations_expression();
       check_loop_coalesce_expression();
       check_initiation_interval_expression();
       check_loop_count_expression();
+      check_loop_fpga_pipeline_expression();
       check_loop_attr_template_instantiation<S>(); //expected-note{{in instantiation of function template specialization 'check_loop_attr_template_instantiation<S>' requested here}}
       check_loop_attr_template_instantiation<float>(); //expected-note{{in instantiation of function template specialization 'check_loop_attr_template_instantiation<float>' requested here}}
     });

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -224,9 +224,6 @@ void goo() {
       a[i] = 0;
 
   // no diagnostics are expected
-  [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
-    a[i] = 0;
-  // no diagnostics are expected
   [[intel::fpga_pipeline(0)]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
   // no diagnostics are expected

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -353,11 +353,6 @@ void zoo() {
   // expected-error@+1{{duplicate Intel FPGA loop attribute 'loop_count'}}
   [[intel::loop_count(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-
-  [[intel::fpga_pipeline(1)]]
-  // expected-error@+1{{duplicate Intel FPGA loop attribute 'fpga_pipeline'}}
-  [[intel::fpga_pipeline(1)]] for (int i = 0; i != 10; ++i)
-    a[i] = 0;
 }
 
 // Test for Intel FPGA loop attributes compatibility
@@ -376,21 +371,9 @@ void loop_attrs_compatibility() {
   // expected-note@+1 {{conflicting attribute is here}}
   [[intel::speculated_iterations(0)]] [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
-  // expected-error@+4 {{'max_concurrency' and 'disable_loop_pipelining' attributes are not compatible}}
-  // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
-                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
-  [[intel::max_concurrency(0)]] for (int i = 0; i != 10; ++i)
-    a[i] = 0;
   // expected-error@+2 {{'fpga_pipeline' and 'initiation_interval' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
   [[intel::initiation_interval(10)]] [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
-    a[i] = 0;
-  // expected-error@+4 {{'ivdep' and 'disable_loop_pipelining' attributes are not compatible}}
-  // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::disable_loop_pipelining]] // expected-warning {{attribute 'intel::disable_loop_pipelining' is deprecated}} \
-                                     // expected-note {{did you mean to use 'intel::fpga_pipeline' instead?}}
-  [[intel::ivdep]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
 
   // no diagnostics are expected
@@ -417,19 +400,9 @@ void loop_attrs_compatibility() {
   [[intel::max_concurrency(2)]] [[intel::fpga_pipeline(1)]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
 
-  // expected-error@+2 {{'fpga_pipeline' and 'initiation_interval' attributes are not compatible}}
-  // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::initiation_interval(2)]] [[intel::fpga_pipeline(1)]] for (int i = 0; i != 10; ++i)
-    a[i] = 0;
-
   // expected-error@+2 {{'fpga_pipeline' and 'max_interleaving' attributes are not compatible}}
   // expected-note@+1 {{conflicting attribute is here}}
   [[intel::max_interleaving(2)]] [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
-    a[i] = 0;
-
-  // expected-error@+2 {{'fpga_pipeline' and 'speculated_iterations' attributes are not compatible}}
-  // expected-note@+1 {{conflicting attribute is here}}
-  [[intel::speculated_iterations(0)]] [[intel::fpga_pipeline]] for (int i = 0; i != 10; ++i)
     a[i] = 0;
 
   // expected-error@+2 {{'fpga_pipeline' and 'ivdep' attributes are not compatible}}

--- a/clang/test/SemaSYCL/intel-fpga-pipeline-ast.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-pipeline-ast.cpp
@@ -33,7 +33,7 @@ void fpga_pipeline() {
   // CHECK-NEXT:  value: Int 1
   // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
   for (int i = 0; i < 10; ++i) {
-    [[intel::fpga_pipeline(1)]]  for (int j = 0; j < 10; ++j) {
+    [[intel::fpga_pipeline(1)]] for (int j = 0; j < 10; ++j) {
       a1[i] += a1[j];
     }
   }
@@ -52,15 +52,14 @@ void fpga_pipeline() {
   // CHECK-NEXT:  value: Int 1
   // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
   int b = 10;
-  [[intel::fpga_pipeline(1)]]
-    do {
-        b = b + 1;
-    }while( b < 20 );
+  [[intel::fpga_pipeline(1)]] do {
+    b = b + 1;
+  } while (b < 20);
 
-   // CHECK: AttributedStmt
-   // CHECK-NEXT: SYCLIntelFPGAPipelineAttr
-   int c[] = {0, 1, 2, 3, 4, 5};
-   [[intel::fpga_pipeline(A)]] for (int n : c) { n *= 2; }
+  // CHECK: AttributedStmt
+  // CHECK-NEXT: SYCLIntelFPGAPipelineAttr
+  int c[] = {0, 1, 2, 3, 4, 5};
+  [[intel::fpga_pipeline(A)]] for (int n : c) { n *= 2; }
 }
 
 int main() {
@@ -69,4 +68,3 @@ int main() {
   });
   return 0;
 }
-

--- a/clang/test/SemaSYCL/intel-fpga-pipeline-ast.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-pipeline-ast.cpp
@@ -1,0 +1,72 @@
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -fsyntax-only -ast-dump -Wno-sycl-2017-compat -verify %s | FileCheck %s
+// expected-no-diagnostics
+
+// Add AST tests for Loop attribute: [[intel::fpga_pipeline()]].
+
+#include "sycl.hpp"
+
+using namespace cl::sycl;
+queue q;
+
+template <int A>
+void fpga_pipeline() {
+  int a1[10], a2[10];
+  // CHECK: AttributedStmt
+  // CHECK-NEXT: SYCLIntelFPGAPipelineAttr
+  [[intel::fpga_pipeline(A)]] for (int p = 0; p < 10; ++p) {
+    a1[p] = a2[p] = 0;
+  }
+
+  // CHECK: AttributedStmt
+  // CHECK-NEXT: SYCLIntelFPGAPipelineAttr
+  // CHECK-NEXT:  ConstantExpr{{.*}}'int'
+  // CHECK-NEXT:  value: Int 1
+  // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
+  int i = 0;
+  [[intel::fpga_pipeline]] while (i < 10) {
+    a1[i] += 3;
+  }
+
+  // CHECK: AttributedStmt
+  // CHECK-NEXT: SYCLIntelFPGAPipelineAttr
+  // CHECK-NEXT:  ConstantExpr{{.*}}'int'
+  // CHECK-NEXT:  value: Int 1
+  // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
+  for (int i = 0; i < 10; ++i) {
+    [[intel::fpga_pipeline(1)]]  for (int j = 0; j < 10; ++j) {
+      a1[i] += a1[j];
+    }
+  }
+
+  // CHECK: AttributedStmt
+  // CHECK-NEXT: SYCLIntelFPGAPipelineAttr
+  // CHECK-NEXT:  ConstantExpr{{.*}}'int'
+  // CHECK-NEXT:  value: Int 0
+  // CHECK-NEXT:  IntegerLiteral{{.*}}0{{$}}
+  [[intel::fpga_pipeline(0)]] for (int i = 0; i != 10; ++i)
+    a1[i] = 0;
+
+  // CHECK: AttributedStmt
+  // CHECK-NEXT: SYCLIntelFPGAPipelineAttr
+  // CHECK-NEXT:  ConstantExpr{{.*}}'int'
+  // CHECK-NEXT:  value: Int 1
+  // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
+  int b = 10;
+  [[intel::fpga_pipeline(1)]]
+    do {
+        b = b + 1;
+    }while( b < 20 );
+
+   // CHECK: AttributedStmt
+   // CHECK-NEXT: SYCLIntelFPGAPipelineAttr
+   int c[] = {0, 1, 2, 3, 4, 5};
+   [[intel::fpga_pipeline(A)]] for (int n : c) { n *= 2; }
+}
+
+int main() {
+  q.submit([&](handler &h) {
+    h.single_task<class kernel_function>([]() { fpga_pipeline<1>(); });
+  });
+  return 0;
+}
+


### PR DESCRIPTION
This patch adds support for new FPGA attribute called [[intel::fpga_pipeline(N)]] that takes a Boolean parameter.
N can be a template parameter or constexpr. If the user didn't provide a parameter, the default value of N would
be 1, which implies enable pipelining.

This attribute can be applied to loops.

Example syntax:

// will disable loop pipelining
[[intel::fpga_pipeline(0)]]
for (int i = 0; i<N; ++i) {...}

LLVM IR:
When applied on a loop, the LLVM IR should be attached to llvm.loop metadata:

!{!"llvm.loop.intel.pipelining.enable", i32 N}

The value of the !"llvm.loop.intel.pipelining.enable" metadata is an i32 value that corresponds to the boolean parameter N.
A value of 0 is used for not pipelining the loop.
A value of 1 is used for pipelining the loop.

If the parameter is not given, value of N will be the default value 1,  which implies we will pipeline the loop, and the IR will look like

!{!"llvm.loop.intel.pipelining.enable", i32 1}

Error Message:

We should emit an error when [[intel::initiation_interval(k)]] and [[intel::fpga_pipeline(0)]] are used together:

"error: initiation_interval and fpga_pipeline(0) attributes are not compatible"

We should emit an error when [[intel::max_concurrency(k)]] and [[intel::fpga_pipeline(0)]] are used together:

"error: max_concurrency and fpga_pipeline(0) attributes are not compatible"

Note: this basically performs very similar functionalities as [[intel::disable_loop_pipelining]], the plan is to deprecate disable_loop_pipelining in future releases and use [[intel::fpga_pipeline(n)]] instead.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>