### PR TITLE
[SYCL] Fix compilation fail on Windows

### DIFF
--- a/sycl/include/CL/sycl/usm.hpp
+++ b/sycl/include/CL/sycl/usm.hpp
@@ -174,7 +174,7 @@ T *aligned_alloc_device(
     size_t Alignment, size_t Count, const device &Dev, const context &Ctxt,
     const property_list &PropList = {},
     const detail::code_location CodeLoc = detail::code_location::current()) {
-  return static_cast<T *>(aligned_alloc_device(std::max(Alignment, alignof(T)),
+  return static_cast<T *>(aligned_alloc_device(max(Alignment, alignof(T)),
                                                Count * sizeof(T), Dev, Ctxt,
                                                PropList, CodeLoc));
 }
@@ -244,7 +244,7 @@ T *aligned_alloc_shared(
     size_t Alignment, size_t Count, const device &Dev, const context &Ctxt,
     const property_list &PropList = {},
     const detail::code_location CodeLoc = detail::code_location::current()) {
-  return static_cast<T *>(aligned_alloc_shared(std::max(Alignment, alignof(T)),
+  return static_cast<T *>(aligned_alloc_shared(max(Alignment, alignof(T)),
                                                Count * sizeof(T), Dev, Ctxt,
                                                PropList, CodeLoc));
 }
@@ -281,7 +281,7 @@ T *aligned_alloc(
     size_t Alignment, size_t Count, const device &Dev, const context &Ctxt,
     usm::alloc Kind, const property_list &PropList = {},
     const detail::code_location CodeLoc = detail::code_location::current()) {
-  return static_cast<T *>(aligned_alloc(std::max(Alignment, alignof(T)),
+  return static_cast<T *>(aligned_alloc(max(Alignment, alignof(T)),
                                         Count * sizeof(T), Dev, Ctxt, Kind,
                                         PropList, CodeLoc));
 }

--- a/sycl/include/CL/sycl/usm/usm_allocator.hpp
+++ b/sycl/include/CL/sycl/usm/usm_allocator.hpp
@@ -117,7 +117,8 @@ public:
 
 private:
   constexpr size_t getAlignment() const {
-    return std::max(alignof(T), Alignment);
+    using std::max; // Cause of MS Windows' macro...
+    return max(alignof(T), Alignment);
   }
 
   template <class U, usm::alloc AllocKindU, size_t AlignmentU>

--- a/sycl/include/CL/sycl/usm/usm_allocator.hpp
+++ b/sycl/include/CL/sycl/usm/usm_allocator.hpp
@@ -116,9 +116,7 @@ public:
   }
 
 private:
-  constexpr size_t getAlignment() const {
-    return max(alignof(T), Alignment);
-  }
+  constexpr size_t getAlignment() const { return max(alignof(T), Alignment); }
 
   template <class U, usm::alloc AllocKindU, size_t AlignmentU>
   friend class usm_allocator;

--- a/sycl/include/CL/sycl/usm/usm_allocator.hpp
+++ b/sycl/include/CL/sycl/usm/usm_allocator.hpp
@@ -117,7 +117,6 @@ public:
 
 private:
   constexpr size_t getAlignment() const {
-    using std::max; // Cause of MS Windows' macro...
     return max(alignof(T), Alignment);
   }
 


### PR DESCRIPTION
Apparently, std::max(smth) cannot be used...