### PR TITLE
[SYCL] Change _NDEBUG -> NDEBUG (the correct macro) in sycl-post-link.

### DIFF
--- a/llvm/tools/sycl-post-link/ModuleSplitter.cpp
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.cpp
@@ -425,7 +425,7 @@ void ModuleSplitterBase::verifyNoCrossModuleDeviceGlobalUsage() {
   }
 }
 
-#ifndef _NDEBUG
+#ifndef NDEBUG
 
 const char *toString(SyclEsimdSplitStatus S) {
   switch (S) {
@@ -472,15 +472,17 @@ void dumpEntryPoints(const Module &M, bool OnlyKernelsAreEntryPoints,
   llvm::errs() << "}\n";
 }
 
+#endif // NDEBUG
+
 void ModuleDesc::renameDuplicatesOf(const Module &MA, StringRef Suff) {
   Module &MB = getModule();
-#ifndef _NDEBUG
+#ifndef NDEBUG
   DenseSet<StringRef> EntryNamesB;
   auto It0 = entries().cbegin();
   auto It1 = entries().cend();
   std::for_each(It0, It1,
                 [&](const Function *F) { EntryNamesB.insert(F->getName()); });
-#endif // _NDEBUG
+#endif // NDEBUG
   for (const GlobalObject &GoA : MA.global_objects()) {
     if (GoA.isDeclaration()) {
       continue;
@@ -495,12 +497,12 @@ void ModuleDesc::renameDuplicatesOf(const Module &MA, StringRef Suff) {
       // function or variable is not shared or is a declaration in MB
       continue;
     }
-#ifndef _NDEBUG
+#ifndef NDEBUG
     if (F) {
       // this is a shared function, must not be an entry point:
       assert(!EntryNamesB.contains(Name));
     }
-#endif // _NDEBUG
+#endif // NDEBUG
     // rename the global object in MB:
     GoB->setName(Name + Suff);
   }
@@ -514,12 +516,12 @@ void ModuleDesc::assignESIMDProperty() {
   } else {
     Props.HasEsimd = SyclEsimdSplitStatus::SYCL_AND_ESIMD;
   }
-#ifndef _NDEBUG
+#ifndef NDEBUG
   verifyESIMDProperty();
-#endif // _NDEBUG
+#endif // NDEBUG
 }
 
-#ifndef _NDEBUG
+#ifndef NDEBUG
 void ModuleDesc::verifyESIMDProperty() const {
   if (Props.HasEsimd == SyclEsimdSplitStatus::SYCL_AND_ESIMD) {
     return; // nothing to verify
@@ -550,7 +552,6 @@ void ModuleDesc::verifyESIMDProperty() const {
   //  }
   //}
 }
-#endif // _NDEBUG
 
 void ModuleDesc::dump() {
   llvm::errs() << "split_module::ModuleDesc[" << Name << "] {\n";
@@ -560,7 +561,7 @@ void ModuleDesc::dump() {
   dumpEntryPoints(entries(), EntryPoints.getId().str().c_str(), 1);
   llvm::errs() << "}\n";
 }
-#endif // _NDEBUG
+#endif // NDEBUG
 
 bool EntryPointGroup::isEsimd() const { return GroupId == ESIMD_SCOPE_NAME; }
 

--- a/llvm/tools/sycl-post-link/ModuleSplitter.h
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.h
@@ -119,13 +119,10 @@ public:
   // this module descriptor is a ESIMD/SYCL part of the ESIMD/SYCL module split.
   // Otherwise assumes the module has both SYCL and ESIMD.
   void assignESIMDProperty();
-#ifndef _NDEBUG
+#ifndef NDEBUG
   void verifyESIMDProperty() const;
-#endif // _NDEBUG
-
-#ifndef _NDEBUG
   void dump();
-#endif // _NDEBUG
+#endif // NDEBUG
 };
 
 // Module split support interface.
@@ -188,11 +185,11 @@ getSplitterByMode(std::unique_ptr<Module> M, IRSplitMode Mode,
                   bool AutoSplitIsGlobalScope,
                   bool EmitOnlyKernelsAsEntryPoints);
 
-#ifndef _NDEBUG
+#ifndef NDEBUG
 void dumpEntryPoints(const EntryPointVec &C, const char *msg = "", int Tab = 0);
 void dumpEntryPoints(const Module &M, bool OnlyKernelsAreEntryPoints = false,
                      const char *msg = "", int Tab = 0);
-#endif // _NDEBUG
+#endif // NDEBUG
 
 } // namespace module_split
 

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -61,7 +61,7 @@ using string_vector = std::vector<std::string>;
 
 namespace {
 
-#ifdef _NDEBUG
+#ifdef NDEBUG
 #define DUMP_ENTRY_POINTS(args...)
 #else
 constexpr int DebugPostLink = 0;
@@ -70,7 +70,7 @@ constexpr int DebugPostLink = 0;
   if (DebugPostLink > 0) {                                                     \
     llvm::module_split::dumpEntryPoints(__VA_ARGS__);                          \
   }
-#endif
+#endif // NDEBUG
 
 cl::OptionCategory PostLinkCat{"sycl-post-link options"};
 
@@ -451,7 +451,7 @@ std::string saveModuleProperties(module_split::ModuleDesc &MD,
 // Saves specified collection of symbols to a file.
 std::string saveModuleSymbolTable(const module_split::EntryPointVec &Es, int I,
                                   StringRef Suffix) {
-#ifndef _NDEBUG
+#ifndef NDEBUG
   if (DebugPostLink > 0) {
     llvm::errs() << "ENTRY POINTS saving Sym table {\n";
     for (const auto *F : Es) {
@@ -459,7 +459,7 @@ std::string saveModuleSymbolTable(const module_split::EntryPointVec &Es, int I,
     }
     llvm::errs() << "}\n";
   }
-#endif
+#endif // NDEBUG
   // Concatenate names of the input entry points with "\n".
   std::string SymT;
 
@@ -743,9 +743,9 @@ processInputModule(std::unique_ptr<Module> M) {
       MMs.emplace_back(std::move(MDesc1));
     }
     Modified |= MMs.size() > 1;
-#ifndef _NDEBUG
+#ifndef NDEBUG
     bool NoSplitOccurred = (MMs.size() == 1) && (Table->getNumRows() == 0);
-#endif // _NDEBUG
+#endif // NDEBUG
 
     if (!SplitEsimd && (MMs.size() > 1)) {
       // SYCL/ESIMD splitting is not requested, link back into single module.


### PR DESCRIPTION
Also fix #ifndef _NDEBUG/#endif pairing bug.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>