### PR TITLE
[SYCL][L0] Allow empty properties in USMHostAlloc

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -7278,7 +7278,7 @@ static pi_result USMHostAllocImpl(void **ResultPtr, pi_context Context,
   PI_ASSERT(Context, PI_INVALID_CONTEXT);
 
   // Check that incorrect bits are not set in the properties.
-  PI_ASSERT(!Properties ||
+  PI_ASSERT(!Properties || *Properties == 0 ||
                 (*Properties == PI_MEM_ALLOC_FLAGS && *(Properties + 2) == 0),
             PI_INVALID_VALUE);
 


### PR DESCRIPTION
See https://github.com/intel/llvm/pull/6220#discussion_r891017817

This is a prerequisite of https://github.com/intel/llvm/pull/6220