### PR TITLE
[SYCL] Query USM buffer location extension only if property is passed to malloc_shared

### DIFF
--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -162,9 +162,9 @@ void *alignedAlloc(size_t Alignment, size_t Size, const context &Ctxt,
         *PropsIter++ = PI_MEM_ALLOC_DEVICE_READ_ONLY;
       }
 
-      if (Dev.has_extension("cl_intel_mem_alloc_buffer_location") &&
-          PropList.has_property<cl::sycl::ext::intel::experimental::property::
-                                    usm::buffer_location>()) {
+      if (PropList.has_property<cl::sycl::ext::intel::experimental::property::
+                                    usm::buffer_location>() &&
+          Dev.has_extension("cl_intel_mem_alloc_buffer_location")) {
         *PropsIter++ = PI_MEM_USM_ALLOC_BUFFER_LOCATION;
         *PropsIter++ = PropList
                            .get_property<cl::sycl::ext::intel::experimental::


### PR DESCRIPTION
This aligns the implementation with malloc_host and avoids an unneeded
call in the case where the FPGA backend is used without buffer location.

This amends https://github.com/intel/llvm/pull/6218

See also https://github.com/intel/llvm/pull/6220