### PR TITLE
[SYCL] Align USM buffer location implementation for malloc_device with malloc_shared

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -7214,7 +7214,7 @@ static pi_result USMDeviceAllocImpl(void **ResultPtr, pi_context Context,
   PI_ASSERT(Device, PI_INVALID_DEVICE);
 
   // Check that incorrect bits are not set in the properties.
-  PI_ASSERT(!Properties ||
+  PI_ASSERT(!Properties || *Properties == 0 ||
                 (*Properties == PI_MEM_ALLOC_FLAGS && *(Properties + 2) == 0),
             PI_INVALID_VALUE);
 


### PR DESCRIPTION
Use the same call to USMDeviceAlloc with a possibly empty property list
in all cases, to allow for straight-forward extension with future properties.

Query buffer location extension only if buffer location property is passed.

This amends https://github.com/intel/llvm/pull/5634

See also https://github.com/intel/llvm/pull/6220