### PR TITLE
[SYCL] Make half stream operators friend functions

### DIFF
--- a/sycl/include/CL/sycl/half_type.hpp
+++ b/sycl/include/CL/sycl/half_type.hpp
@@ -585,6 +585,20 @@ public:
     return static_cast<float>(Data);
   }
 
+  // Operator << and >>
+  inline friend std::ostream &operator<<(std::ostream &O,
+                                         cl::sycl::half const &rhs) {
+    O << static_cast<float>(rhs);
+    return O;
+  }
+
+  inline friend std::istream &operator>>(std::istream &I, cl::sycl::half &rhs) {
+    float ValFloat = 0.0f;
+    I >> ValFloat;
+    rhs = ValFloat;
+    return I;
+  }
+
   template <typename Key> friend struct std::hash;
 
   friend class sycl::ext::intel::esimd::detail::WrapperElementTypeProxy;
@@ -693,18 +707,6 @@ template <> struct numeric_limits<cl::sycl::half> {
 };
 
 } // namespace std
-
-inline std::ostream &operator<<(std::ostream &O, cl::sycl::half const &rhs) {
-  O << static_cast<float>(rhs);
-  return O;
-}
-
-inline std::istream &operator>>(std::istream &I, cl::sycl::half &rhs) {
-  float ValFloat = 0.0f;
-  I >> ValFloat;
-  rhs = ValFloat;
-  return I;
-}
 
 #undef __SYCL_CONSTEXPR_HALF
 #undef _CPP14_CONSTEXPR

--- a/sycl/test/type_traits/half_operator_types.cpp
+++ b/sycl/test/type_traits/half_operator_types.cpp
@@ -82,6 +82,17 @@ void check_half_logical_operator_types(sycl::queue &Queue) {
   });
 }
 
+template <typename T1>
+void check_half_stream_operator_type(sycl::queue &Queue) {
+
+  // Host only stream test
+  std::istringstream iss;
+  std::ostringstream oss;
+  sycl::half val;
+  static_assert(is_same_v<decltype(iss >> val), std::istream &>);
+  static_assert(is_same_v<decltype(oss << val), std::ostream &>);
+}
+
 int main() {
 
   sycl::queue Queue;


### PR DESCRIPTION
This PR moves the half stream operators from outside of the half class to a friend member function.

The change is necessary as otherwise the operators are not available if the user calls them outside of the global namespace.
There is no change in function behaviour.