### PR TITLE
[SYCL] Implement PI cast for vectors and fix OpenCL specializations

### DIFF
--- a/sycl/include/CL/sycl/detail/backend_traits_opencl.hpp
+++ b/sycl/include/CL/sycl/detail/backend_traits_opencl.hpp
@@ -19,6 +19,7 @@
 #include <CL/sycl/context.hpp>
 #include <CL/sycl/detail/backend_traits.hpp>
 #include <CL/sycl/detail/defines.hpp>
+#include <CL/sycl/detail/pi.hpp>
 #include <CL/sycl/device.hpp>
 #include <CL/sycl/event.hpp>
 #include <CL/sycl/kernel_bundle.hpp>
@@ -200,12 +201,12 @@ template <class To> inline To cast(std::vector<cl_event> value) {
 }
 
 // These conversions should use PI interop API.
-template <> inline pi::PiProgram cast(cl_program) {
+template <> inline PiProgram cast(cl_program) {
   RT::assertion(false, "pi::cast -> use piextCreateProgramWithNativeHandle");
   return {};
 }
 
-template <> inline pi::PiDevice cast(cl_device_id) {
+template <> inline PiDevice cast(cl_device_id) {
   RT::assertion(false, "pi::cast -> use piextCreateDeviceWithNativeHandle");
   return {};
 }

--- a/sycl/include/CL/sycl/detail/backend_traits_opencl.hpp
+++ b/sycl/include/CL/sycl/detail/backend_traits_opencl.hpp
@@ -197,7 +197,7 @@ template <class To> inline To cast(std::vector<cl_event> value) {
   RT::assertion(value.size() == 1,
                 "Temporary workaround requires that the "
                 "size of the input vector for make_event be equal to one.");
-  return (To)(value[0]);
+  return cast<To>(value[0]);
 }
 
 // These conversions should use PI interop API.

--- a/sycl/include/CL/sycl/detail/backend_traits_opencl.hpp
+++ b/sycl/include/CL/sycl/detail/backend_traits_opencl.hpp
@@ -188,6 +188,28 @@ template <> struct InteropFeatureSupportMap<backend::opencl> {
   static constexpr bool MakeKernel = true;
   static constexpr bool MakeKernelBundle = true;
 };
+
+namespace pi {
+// Cast for std::vector<cl_event>, according to the spec, make_event
+// should create one(?) event from a vector of cl_event
+template <class To> inline To cast(std::vector<cl_event> value) {
+  RT::assertion(value.size() == 1,
+                "Temporary workaround requires that the "
+                "size of the input vector for make_event be equal to one.");
+  return (To)(value[0]);
+}
+
+// These conversions should use PI interop API.
+template <> inline pi::PiProgram cast(cl_program) {
+  RT::assertion(false, "pi::cast -> use piextCreateProgramWithNativeHandle");
+  return {};
+}
+
+template <> inline pi::PiDevice cast(cl_device_id) {
+  RT::assertion(false, "pi::cast -> use piextCreateDeviceWithNativeHandle");
+  return {};
+}
+} // namespace pi
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/CL/sycl/detail/backend_traits_opencl.hpp
+++ b/sycl/include/CL/sycl/detail/backend_traits_opencl.hpp
@@ -201,15 +201,13 @@ template <class To> inline To cast(std::vector<cl_event> value) {
 }
 
 // These conversions should use PI interop API.
-template <> inline PiProgram cast(cl_program) {
-  RT::assertion(false, "pi::cast -> use piextCreateProgramWithNativeHandle");
-  return {};
-}
+template <>
+inline PiProgram
+    cast(cl_program) = delete; // Use piextCreateProgramWithNativeHandle
 
-template <> inline PiDevice cast(cl_device_id) {
-  RT::assertion(false, "pi::cast -> use piextCreateDeviceWithNativeHandle");
-  return {};
-}
+template <>
+inline PiDevice
+    cast(cl_device_id) = delete; // Use piextCreateDeviceWithNativeHandle
 } // namespace pi
 } // namespace detail
 } // namespace sycl

--- a/sycl/plugins/opencl/CMakeLists.txt
+++ b/sycl/plugins/opencl/CMakeLists.txt
@@ -19,5 +19,3 @@ add_sycl_plugin(opencl
 )
 
 set_target_properties(pi_opencl PROPERTIES LINKER_LANGUAGE CXX)
-
-target_compile_definitions(pi_opencl PRIVATE PI_OPENCL_AVAILABLE)

--- a/sycl/unittests/pi/CMakeLists.txt
+++ b/sycl/unittests/pi/CMakeLists.txt
@@ -4,6 +4,7 @@ add_sycl_unittest(PiTests OBJECT
   EnqueueMemTest.cpp
   PiMock.cpp
   PlatformTest.cpp
+  PiUtility.cpp
   pi_arguments_handler.cpp
   piInteropRetain.cpp
 )

--- a/sycl/unittests/pi/PiUtility.cpp
+++ b/sycl/unittests/pi/PiUtility.cpp
@@ -1,0 +1,49 @@
+//==--------------------- PiUtility.cpp -- check for internal PI utilities -==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <CL/opencl.h>
+#include <CL/sycl.hpp>
+#include <CL/sycl/backend/opencl.hpp>
+
+#include <gtest/gtest.h>
+
+namespace {
+using namespace cl::sycl;
+
+TEST(PiUtilityTest, CheckPiCastScalar) {
+  std::int32_t I = 42;
+  std::int64_t L = 1234;
+  float F = 31.2f;
+  double D = 4321.1234;
+  float ItoF = detail::pi::cast<float>(I);
+  double LtoD = detail::pi::cast<double>(L);
+  std::int32_t FtoI = detail::pi::cast<std::int32_t>(F);
+  std::int32_t DtoL = detail::pi::cast<std::int64_t>(D);
+  EXPECT_EQ((std::int32_t)F, FtoI);
+  EXPECT_EQ((float)I, ItoF);
+  EXPECT_EQ((std::int64_t)D, DtoL);
+  EXPECT_EQ((double)L, LtoD);
+}
+
+TEST(PiUtilityTest, CheckPiCastVector) {
+  std::vector<std::int32_t> IVec{6, 1, 5, 2, 3, 4};
+  std::vector<float> IVecToFVec = detail::pi::cast<std::vector<float>>(IVec);
+  ASSERT_EQ(IVecToFVec.size(), IVec.size());
+  for (size_t I = 0; I < IVecToFVec.size(); ++I)
+    EXPECT_EQ(IVecToFVec[I], (float)IVec[I]);
+}
+
+TEST(PiUtilityTest, CheckPiCastOCLEventVector) {
+  // Current special case for vectors of OpenCL vectors. This may change in the
+  // future.
+  std::vector<cl_event> EVec{(cl_event)0};
+  pi_native_handle ENativeHandle = detail::pi::cast<pi_native_handle>(EVec);
+  EXPECT_EQ(ENativeHandle, (pi_native_handle)EVec[0]);
+}
+
+} // namespace


### PR DESCRIPTION
This commit makes two changes related to pi::cast:
* Implements pi::cast between vectors by applying pi::cast to the individual elements of the input vector, storing the casted values in a new vector.
* Moves the OpenCL specializations into the backend traits file for OpenCL. Additionally, PI_OPENCL_AVAILABLE is removed as it was only defined in the pi_opencl subproject whereas pi::cast, including the moved specializations, are used by the SYCL interop headers.