### PR TITLE
[SYCL][CUDA] Ignore and warn for mem-advise when requirement not met

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -4906,7 +4906,7 @@ pi_result cuda_piextUSMEnqueueMemAdvise(pi_queue queue, const void *ptr,
       setErrorMessage("Mem advise ignored as device does not support "
                       "concurrent managed access",
                       PI_SUCCESS);
-      return PI_PLUGIN_SPECIFIC_ERROR;
+      return PI_ERROR_PLUGIN_SPECIFIC_ERROR;
     }
 
     // TODO: If ptr points to valid system-allocated pageable memory we should


### PR DESCRIPTION
Similar to cuMemPrefetchAsync, cuMemAdvise may require that a device supports concurrent managed memory access. These changes makes cuda_piextUSMEnqueueMemAdvise ignore and warn for a number of memory advises if the device does not meet the aforementioned requirement.