### PR TITLE
[SYCL] Fix usage of std::conditional_variable in sycl::event

### DIFF
--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -70,6 +70,7 @@ void event_impl::waitInternal() {
 
 void event_impl::setComplete() {
   if (MHostEvent || !MEvent) {
+    std::unique_lock lock(MMutex);
 #ifndef NDEBUG
     int Expected = HES_NotComplete;
     int Desired = HES_Complete;


### PR DESCRIPTION
PR #6245 introduced a misuse of it. I've misunderstood

   > The notifying thread does not need to hold the lock on the same mutex as the
   > one held by the waiting thread(s)

from https://en.cppreference.com/w/cpp/thread/condition_variable/notify_all

Instead, https://en.cppreference.com/w/cpp/thread/condition_variable

   > The thread that intends to modify the shared variable has to...

should be followed.