### PR TITLE
[SYCL] Fix naming and use of deprecated address spaces

### DIFF
--- a/sycl/include/CL/sycl/access/access.hpp
+++ b/sycl/include/CL/sycl/access/access.hpp
@@ -48,13 +48,16 @@ enum class address_space : int {
   constant_space = 2,
   local_space = 3,
   ext_intel_global_device_space = 4,
-  ext_intel_host_device_space = 5,
+  ext_intel_global_host_space = 5,
   global_device_space __SYCL2020_DEPRECATED(
       "use 'ext_intel_global_device_space' instead") =
       ext_intel_global_device_space,
   global_host_space __SYCL2020_DEPRECATED(
-      "use 'ext_intel_host_device_space' instead") =
-      ext_intel_host_device_space,
+      "use 'ext_intel_global_host_space' instead") =
+      ext_intel_global_host_space,
+  ext_intel_host_device_space __SYCL2020_DEPRECATED(
+      "use 'ext_intel_global_host_space' instead") =
+      ext_intel_global_host_space,
   generic_space = 6, // TODO generic_space address space is not supported yet
 };
 
@@ -141,7 +144,7 @@ template <access::target accessTarget> struct TargetToAS {
 #ifdef __ENABLE_USM_ADDR_SPACE__
 template <> struct TargetToAS<access::target::device> {
   constexpr static access::address_space AS =
-      access::address_space::global_device_space;
+      access::address_space::ext_intel_global_device_space;
 };
 #endif // __ENABLE_USM_ADDR_SPACE__
 
@@ -174,12 +177,14 @@ struct DecoratedType<ElementType, access::address_space::global_space> {
 };
 
 template <typename ElementType>
-struct DecoratedType<ElementType, access::address_space::global_device_space> {
+struct DecoratedType<ElementType,
+                     access::address_space::ext_intel_global_device_space> {
   using type = __OPENCL_GLOBAL_DEVICE_AS__ ElementType;
 };
 
 template <typename ElementType>
-struct DecoratedType<ElementType, access::address_space::global_host_space> {
+struct DecoratedType<ElementType,
+                     access::address_space::ext_intel_global_host_space> {
   using type = __OPENCL_GLOBAL_HOST_AS__ ElementType;
 };
 
@@ -222,12 +227,12 @@ template <class T> struct remove_AS<__OPENCL_GLOBAL_HOST_AS__ T> {
 
 template <class T> struct deduce_AS<__OPENCL_GLOBAL_DEVICE_AS__ T> {
   static const access::address_space value =
-      access::address_space::global_device_space;
+      access::address_space::ext_intel_global_device_space;
 };
 
 template <class T> struct deduce_AS<__OPENCL_GLOBAL_HOST_AS__ T> {
   static const access::address_space value =
-      access::address_space::global_host_space;
+      access::address_space::ext_intel_global_host_space;
 };
 #endif // __ENABLE_USM_ADDR_SPACE__
 

--- a/sycl/include/CL/sycl/atomic.hpp
+++ b/sycl/include/CL/sycl/atomic.hpp
@@ -48,7 +48,7 @@ template <cl::sycl::access::address_space AS> struct IsValidAtomicAddressSpace {
   static constexpr bool value =
       (AS == access::address_space::global_space ||
        AS == access::address_space::local_space ||
-       AS == access::address_space::global_device_space);
+       AS == access::address_space::ext_intel_global_device_space);
 };
 
 // Type trait to translate a cl::sycl::access::address_space to
@@ -58,7 +58,8 @@ template <> struct GetSpirvMemoryScope<access::address_space::global_space> {
   static constexpr auto scope = __spv::Scope::Device;
 };
 template <>
-struct GetSpirvMemoryScope<access::address_space::global_device_space> {
+struct GetSpirvMemoryScope<
+    access::address_space::ext_intel_global_device_space> {
   static constexpr auto scope = __spv::Scope::Device;
 };
 template <> struct GetSpirvMemoryScope<access::address_space::local_space> {
@@ -177,7 +178,7 @@ class __SYCL2020_DEPRECATED(
                 "long long, float");
   static_assert(detail::IsValidAtomicAddressSpace<addressSpace>::value,
                 "Invalid SYCL atomic address_space. Valid address spaces are: "
-                "global_space, local_space, global_device_space");
+                "global_space, local_space, ext_intel_global_device_space");
   static constexpr auto SpirvScope =
       detail::GetSpirvMemoryScope<addressSpace>::scope;
 
@@ -196,12 +197,13 @@ public:
   }
 
 #ifdef __ENABLE_USM_ADDR_SPACE__
-  // Create atomic in global_space with one from global_device_space
+  // Create atomic in global_space with one from ext_intel_global_device_space
   template <access::address_space _Space = addressSpace,
             typename = typename detail::enable_if_t<
                 _Space == addressSpace &&
                 addressSpace == access::address_space::global_space>>
-  atomic(const atomic<T, access::address_space::global_device_space> &RHS) {
+  atomic(const atomic<T, access::address_space::ext_intel_global_device_space>
+             &RHS) {
     Ptr = RHS.Ptr;
   }
 
@@ -209,7 +211,8 @@ public:
             typename = typename detail::enable_if_t<
                 _Space == addressSpace &&
                 addressSpace == access::address_space::global_space>>
-  atomic(atomic<T, access::address_space::global_device_space> &&RHS) {
+  atomic(
+      atomic<T, access::address_space::ext_intel_global_device_space> &&RHS) {
     Ptr = RHS.Ptr;
   }
 #endif // __ENABLE_USM_ADDR_SPACE__

--- a/sycl/include/CL/sycl/atomic_ref.hpp
+++ b/sycl/include/CL/sycl/atomic_ref.hpp
@@ -44,7 +44,7 @@ struct IsValidAtomicRefAddressSpace {
   static constexpr bool value =
       (AS == access::address_space::global_space ||
        AS == access::address_space::local_space ||
-       AS == access::address_space::global_device_space ||
+       AS == access::address_space::ext_intel_global_device_space ||
        AS == access::address_space::generic_space);
 };
 
@@ -119,10 +119,10 @@ class atomic_ref_base {
       "Invalid atomic type.  Valid types are int, unsigned int, long, "
       "unsigned long, long long, unsigned long long, float, double "
       "and pointer types");
-  static_assert(
-      detail::IsValidAtomicRefAddressSpace<AddressSpace>::value,
-      "Invalid atomic address_space.  Valid address spaces are: "
-      "global_space, local_space, global_device_space, generic_space");
+  static_assert(detail::IsValidAtomicRefAddressSpace<AddressSpace>::value,
+                "Invalid atomic address_space.  Valid address spaces are: "
+                "global_space, local_space, ext_intel_global_device_space, "
+                "generic_space");
   static_assert(
       detail::IsValidDefaultOrder<DefaultOrder>::value,
       "Invalid default memory_order for atomics.  Valid defaults are: "

--- a/sycl/include/CL/sycl/detail/generic_type_lists.hpp
+++ b/sycl/include/CL/sycl/detail/generic_type_lists.hpp
@@ -539,22 +539,22 @@ namespace gvl {
 using all_address_space_list = address_space_list<
     access::address_space::local_space, access::address_space::global_space,
     access::address_space::private_space, access::address_space::constant_space,
-    access::address_space::global_device_space,
-    access::address_space::global_host_space>;
+    access::address_space::ext_intel_global_device_space,
+    access::address_space::ext_intel_global_host_space>;
 
 using nonconst_address_space_list =
     address_space_list<access::address_space::local_space,
                        access::address_space::global_space,
                        access::address_space::private_space,
-                       access::address_space::global_device_space,
-                       access::address_space::global_host_space>;
+                       access::address_space::ext_intel_global_device_space,
+                       access::address_space::ext_intel_global_host_space>;
 
 using nonlocal_address_space_list =
     address_space_list<access::address_space::global_space,
                        access::address_space::private_space,
                        access::address_space::constant_space,
-                       access::address_space::global_device_space,
-                       access::address_space::global_host_space>;
+                       access::address_space::ext_intel_global_device_space,
+                       access::address_space::ext_intel_global_host_space>;
 } // namespace gvl
 } // namespace detail
 } // namespace sycl

--- a/sycl/include/CL/sycl/multi_ptr.hpp
+++ b/sycl/include/CL/sycl/multi_ptr.hpp
@@ -125,14 +125,14 @@ public:
 
   // Only if Space is in
   // {global_space, ext_intel_global_device_space, generic_space}
-  template <int dimensions, access::mode Mode,
-            access::placeholder isPlaceholder, typename PropertyListT,
-            access::address_space _Space = Space,
-            typename = typename detail::enable_if_t<
-                _Space == Space &&
-                (Space == access::address_space::generic_space ||
-                 Space == access::address_space::global_space ||
-                 Space == access::address_space::ext_intel_global_device_space)>>
+  template <
+      int dimensions, access::mode Mode, access::placeholder isPlaceholder,
+      typename PropertyListT, access::address_space _Space = Space,
+      typename = typename detail::enable_if_t<
+          _Space == Space &&
+          (Space == access::address_space::generic_space ||
+           Space == access::address_space::global_space ||
+           Space == access::address_space::ext_intel_global_device_space)>>
   multi_ptr(accessor<ElementType, dimensions, Mode, access::target::device,
                      isPlaceholder, PropertyListT>
                 Accessor) {

--- a/sycl/include/CL/sycl/multi_ptr.hpp
+++ b/sycl/include/CL/sycl/multi_ptr.hpp
@@ -123,7 +123,8 @@ public:
     return reinterpret_cast<ReturnPtr>(m_Pointer)[index];
   }
 
-  // Only if Space == global_space || global_device_space || generic_space
+  // Only if Space is in
+  // {global_space, ext_intel_global_device_space, generic_space}
   template <int dimensions, access::mode Mode,
             access::placeholder isPlaceholder, typename PropertyListT,
             access::address_space _Space = Space,
@@ -131,7 +132,7 @@ public:
                 _Space == Space &&
                 (Space == access::address_space::generic_space ||
                  Space == access::address_space::global_space ||
-                 Space == access::address_space::global_device_space)>>
+                 Space == access::address_space::ext_intel_global_device_space)>>
   multi_ptr(accessor<ElementType, dimensions, Mode, access::target::device,
                      isPlaceholder, PropertyListT>
                 Accessor) {
@@ -170,8 +171,9 @@ public:
   //    2. from multi_ptr<ElementType, Space> to multi_ptr<const ElementType,
   //    Space>
 
-  // Only if Space == global_space || global_device_space || generic_space and
-  // element type is const
+  // Only if Space is in
+  // {global_space, ext_intel_global_device_space, generic_space} and element
+  // type is const
   template <
       int dimensions, access::mode Mode, access::placeholder isPlaceholder,
       typename PropertyListT, access::address_space _Space = Space,
@@ -180,7 +182,7 @@ public:
           _Space == Space &&
           (Space == access::address_space::generic_space ||
            Space == access::address_space::global_space ||
-           Space == access::address_space::global_device_space) &&
+           Space == access::address_space::ext_intel_global_device_space) &&
           std::is_const<ET>::value && std::is_same<ET, ElementType>::value>>
   multi_ptr(accessor<typename detail::remove_const_t<ET>, dimensions, Mode,
                      access::target::device, isPlaceholder, PropertyListT>
@@ -302,13 +304,14 @@ public:
 
 #ifdef __ENABLE_USM_ADDR_SPACE__
   // Explicit conversion to global_space
-  // Only available if Space == address_space::global_device_space ||
-  // Space == address_space::global_host_space
-  template <access::address_space _Space = Space,
-            typename = typename detail::enable_if_t<
-                _Space == Space &&
-                (Space == access::address_space::global_device_space ||
-                 Space == access::address_space::global_host_space)>>
+  // Only available if Space == address_space::ext_intel_global_device_space ||
+  // Space == address_space::ext_intel_global_host_space
+  template <
+      access::address_space _Space = Space,
+      typename = typename detail::enable_if_t<
+          _Space == Space &&
+          (Space == access::address_space::ext_intel_global_device_space ||
+           Space == access::address_space::ext_intel_global_host_space)>>
   explicit
   operator multi_ptr<ElementType, access::address_space::global_space>() const {
     using global_pointer_t = typename detail::DecoratedType<
@@ -392,14 +395,16 @@ public:
     return *this;
   }
 
-  // Only if Space == global_space || global_device_space || generic_space
-  template <typename ElementType, int dimensions, access::mode Mode,
-            typename PropertyListT, access::address_space _Space = Space,
-            typename = typename detail::enable_if_t<
-                _Space == Space &&
-                (Space == access::address_space::generic_space ||
-                 Space == access::address_space::global_space ||
-                 Space == access::address_space::global_device_space)>>
+  // Only if Space is in
+  // {global_space, ext_intel_global_device_space, generic_space}
+  template <
+      typename ElementType, int dimensions, access::mode Mode,
+      typename PropertyListT, access::address_space _Space = Space,
+      typename = typename detail::enable_if_t<
+          _Space == Space &&
+          (Space == access::address_space::generic_space ||
+           Space == access::address_space::global_space ||
+           Space == access::address_space::ext_intel_global_device_space)>>
   multi_ptr(accessor<ElementType, dimensions, Mode, access::target::device,
                      access::placeholder::false_t, PropertyListT>
                 Accessor)
@@ -515,14 +520,16 @@ public:
     return *this;
   }
 
-  // Only if Space == global_space || global_device_space || generic_space
-  template <typename ElementType, int dimensions, access::mode Mode,
-            typename PropertyListT, access::address_space _Space = Space,
-            typename = typename detail::enable_if_t<
-                _Space == Space &&
-                (Space == access::address_space::generic_space ||
-                 Space == access::address_space::global_space ||
-                 Space == access::address_space::global_device_space)>>
+  // Only if Space is in
+  // {global_space, ext_intel_global_device_space, generic_space}
+  template <
+      typename ElementType, int dimensions, access::mode Mode,
+      typename PropertyListT, access::address_space _Space = Space,
+      typename = typename detail::enable_if_t<
+          _Space == Space &&
+          (Space == access::address_space::generic_space ||
+           Space == access::address_space::global_space ||
+           Space == access::address_space::ext_intel_global_device_space)>>
   multi_ptr(accessor<ElementType, dimensions, Mode, access::target::device,
                      access::placeholder::false_t, PropertyListT>
                 Accessor)

--- a/sycl/include/CL/sycl/pointers.hpp
+++ b/sycl/include/CL/sycl/pointers.hpp
@@ -25,11 +25,12 @@ using global_ptr = multi_ptr<ElementType, access::address_space::global_space>;
 
 template <typename ElementType>
 using device_ptr =
-    multi_ptr<ElementType, access::address_space::global_device_space>;
+    multi_ptr<ElementType,
+              access::address_space::ext_intel_global_device_space>;
 
 template <typename ElementType>
 using host_ptr =
-    multi_ptr<ElementType, access::address_space::global_host_space>;
+    multi_ptr<ElementType, access::address_space::ext_intel_global_host_space>;
 
 template <typename ElementType>
 using local_ptr = multi_ptr<ElementType, access::address_space::local_space>;

--- a/sycl/include/sycl/ext/intel/experimental/fpga_lsu.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_lsu.hpp
@@ -158,11 +158,12 @@ private:
   static_assert(_cache_val >= 0, "cache size parameter must be non-negative");
 
   template <access::address_space _space> static void check_space() {
-    static_assert(_space == access::address_space::global_space ||
-                      _space == access::address_space::global_device_space ||
-                      _space == access::address_space::global_host_space,
-                  "lsu controls are only supported for global_ptr, "
-                  "device_ptr, and host_ptr objects");
+    static_assert(
+        _space == access::address_space::global_space ||
+            _space == access::address_space::ext_intel_global_device_space ||
+            _space == access::address_space::ext_intel_global_host_space,
+        "lsu controls are only supported for global_ptr, "
+        "device_ptr, and host_ptr objects");
   }
 
   static void check_load() {

--- a/sycl/include/sycl/ext/intel/fpga_lsu.hpp
+++ b/sycl/include/sycl/ext/intel/fpga_lsu.hpp
@@ -98,11 +98,12 @@ private:
   static_assert(_cache_val >= 0, "cache size parameter must be non-negative");
 
   template <access::address_space _space> static void check_space() {
-    static_assert(_space == access::address_space::global_space ||
-                      _space == access::address_space::global_device_space ||
-                      _space == access::address_space::global_host_space,
-                  "lsu controls are only supported for global_ptr, "
-                  "device_ptr, and host_ptr objects");
+    static_assert(
+        _space == access::address_space::global_space ||
+            _space == access::address_space::ext_intel_global_device_space ||
+            _space == access::address_space::ext_intel_global_host_space,
+        "lsu controls are only supported for global_ptr, "
+        "device_ptr, and host_ptr objects");
   }
 
   static void check_load() {

--- a/sycl/include/sycl/ext/oneapi/atomic_ref.hpp
+++ b/sycl/include/sycl/ext/oneapi/atomic_ref.hpp
@@ -47,7 +47,7 @@ template <cl::sycl::access::address_space AS>
 using IsValidAtomicAddressSpace =
     bool_constant<AS == access::address_space::global_space ||
                   AS == access::address_space::local_space ||
-                  AS == access::address_space::global_device_space>;
+                  AS == access::address_space::ext_intel_global_device_space>;
 
 // DefaultOrder parameter is limited to read-modify-write orders
 template <memory_order Order>
@@ -122,7 +122,7 @@ class atomic_ref_base {
       "and pointer types");
   static_assert(detail::IsValidAtomicAddressSpace<AddressSpace>::value,
                 "Invalid atomic address_space.  Valid address spaces are: "
-                "global_space, local_space, global_device_space");
+                "global_space, local_space, ext_intel_global_device_space");
   static_assert(
       detail::IsValidDefaultOrder<DefaultOrder>::value,
       "Invalid default memory_order for atomics.  Valid defaults are: "


### PR DESCRIPTION
This commit makes the following changes:
* Adds `ext_intel_global_host_space` in accordance with the `sycl_ext_intel_usm_address_spaces` extensions.
* Deprecates `ext_intel_host_device_space` as it was misspelled and has been replaced by `ext_intel_global_host_space`.
* Replaces uses of deprecated address spaces with `ext_intel_global_device_space` and `ext_intel_global_host_space`