### PR TITLE
[SYCL] Keep used function declarations during llvm.used removal

### DIFF
--- a/llvm/test/tools/sycl-post-link/erase_used_decl.ll
+++ b/llvm/test/tools/sycl-post-link/erase_used_decl.ll
@@ -1,0 +1,25 @@
+; This test checks that the post-link tool doesn't incorrectly remove function
+; declarations which are still in use while erasing the "llvm.used" global.
+;
+; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.files.table
+; RUN: FileCheck %s -input-file=%t.files_0.ll
+;
+target triple = "spir64-unknown-unknown"
+
+; CHECK-NOT: llvm.used
+@llvm.used = appending global [2 x i8*] [i8* bitcast (void ()* @notused to i8*), i8* bitcast (void ()* @stillused to i8*)], section "llvm.metadata"
+
+; CHECK: declare spir_func void @stillused
+declare spir_func void @stillused() #0
+declare spir_func void @notused() #0
+
+define spir_kernel void @entry() #0 {
+  call spir_func void @stillused()
+  ret void
+}
+
+define spir_kernel void @bar() #0 {
+  ret void
+}
+
+attributes #0 = { "sycl-module-id"="erase_used_decl.cpp" }

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -651,7 +651,7 @@ static bool removeSYCLKernelsConstRefArray(Module &M) {
     }
 
     // Remove unused kernel declarations to avoid LLVM IR check fails.
-    if (F && F->isDeclaration())
+    if (F && F->isDeclaration() && F->use_empty())
       F->eraseFromParent();
   }
   return true;


### PR DESCRIPTION
It is possible for a function declaration to be used by both @llvm.used
and, e.g., a spir_func definition. Ensure that we don't attempt to erase
such declarations when removing @llvm.used.