### PR TITLE
[SYCL] Reset signalled command lists before requesting one

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -5016,6 +5016,10 @@ piEnqueueKernelLaunch(pi_queue Queue, pi_kernel Kernel, pi_uint32 WorkDim,
   PI_ASSERT(Event, PI_ERROR_INVALID_EVENT);
   PI_ASSERT((WorkDim > 0) && (WorkDim < 4), PI_ERROR_INVALID_WORK_DIMENSION);
 
+  // We need a command list to submit the command, that's why reset signalled
+  // command lists to avoid creating new one.
+  resetCommandLists(Queue);
+
   // Lock automatically releases when this goes out of scope.
   std::scoped_lock Lock(Queue->Mutex, Kernel->Mutex, Kernel->Program->Mutex);
   if (GlobalWorkOffset != NULL) {
@@ -5213,6 +5217,10 @@ pi_result piextKernelGetNativeHandle(pi_kernel Kernel,
 pi_result
 _pi_event::getOrCreateHostVisibleEvent(ze_event_handle_t &ZeHostVisibleEvent) {
   PI_ASSERT(Queue, PI_ERROR_INVALID_EVENT);
+
+  // We need a command list to submit the command, that's why reset signalled
+  // command lists to avoid creating new one.
+  resetCommandLists(Queue);
 
   std::scoped_lock Lock(Queue->Mutex, this->Mutex);
 
@@ -5898,6 +5906,10 @@ pi_result piEnqueueEventsWait(pi_queue Queue, pi_uint32 NumEventsInWaitList,
 
     bool UseCopyEngine = false;
 
+    // We need a command list to submit the command, that's why reset signalled
+    // command lists to avoid creating new one.
+    resetCommandLists(Queue);
+
     // Lock automatically releases when this goes out of scope.
     std::scoped_lock lock(Queue->Mutex);
 
@@ -5966,6 +5978,10 @@ pi_result piEnqueueEventsWaitWithBarrier(pi_queue Queue,
   PI_ASSERT(Queue, PI_ERROR_INVALID_QUEUE);
   PI_ASSERT(Event, PI_ERROR_INVALID_EVENT);
 
+  // We need a command list to submit the command, that's why reset signalled
+  // command lists to avoid creating new one.
+  resetCommandLists(Queue);
+
   // Lock automatically releases when this goes out of scope.
   std::scoped_lock lock(Queue->Mutex);
 
@@ -6009,6 +6025,10 @@ pi_result piEnqueueMemBufferRead(pi_queue Queue, pi_mem Src,
   PI_ASSERT(Src, PI_ERROR_INVALID_MEM_OBJECT);
   PI_ASSERT(Queue, PI_ERROR_INVALID_QUEUE);
 
+  // We need a command list to submit the command, that's why reset signalled
+  // command lists to avoid creating new one.
+  resetCommandLists(Queue);
+
   std::shared_lock SrcLock(Src->Mutex, std::defer_lock);
   std::scoped_lock LockAll(SrcLock, Queue->Mutex);
 
@@ -6029,6 +6049,10 @@ pi_result piEnqueueMemBufferReadRect(
 
   PI_ASSERT(Buffer, PI_ERROR_INVALID_MEM_OBJECT);
   PI_ASSERT(Queue, PI_ERROR_INVALID_QUEUE);
+
+  // We need a command list to submit the command, that's why reset signalled
+  // command lists to avoid creating new one.
+  resetCommandLists(Queue);
 
   std::shared_lock SrcLock(Buffer->Mutex, std::defer_lock);
   std::scoped_lock LockAll(SrcLock, Queue->Mutex);
@@ -6264,6 +6288,10 @@ pi_result piEnqueueMemBufferWrite(pi_queue Queue, pi_mem Buffer,
   PI_ASSERT(Buffer, PI_ERROR_INVALID_MEM_OBJECT);
   PI_ASSERT(Queue, PI_ERROR_INVALID_QUEUE);
 
+  // We need a command list to submit the command, that's why reset signalled
+  // command lists to avoid creating new one.
+  resetCommandLists(Queue);
+
   std::scoped_lock Lock(Queue->Mutex, Buffer->Mutex);
 
   char *ZeHandleDst;
@@ -6285,6 +6313,10 @@ pi_result piEnqueueMemBufferWriteRect(
 
   PI_ASSERT(Buffer, PI_ERROR_INVALID_MEM_OBJECT);
   PI_ASSERT(Queue, PI_ERROR_INVALID_QUEUE);
+
+  // We need a command list to submit the command, that's why reset signalled
+  // command lists to avoid creating new one.
+  resetCommandLists(Queue);
 
   std::scoped_lock Lock(Queue->Mutex, Buffer->Mutex);
 
@@ -6310,6 +6342,10 @@ pi_result piEnqueueMemBufferCopy(pi_queue Queue, pi_mem SrcMem, pi_mem DstMem,
   PI_ASSERT(!DstMem->isImage(), PI_ERROR_INVALID_MEM_OBJECT);
   auto SrcBuffer = pi_cast<pi_buffer>(SrcMem);
   auto DstBuffer = pi_cast<pi_buffer>(DstMem);
+
+  // We need a command list to submit the command, that's why reset signalled
+  // command lists to avoid creating new one.
+  resetCommandLists(Queue);
 
   std::shared_lock SrcLock(SrcBuffer->Mutex, std::defer_lock);
   std::scoped_lock LockAll(SrcLock, DstBuffer->Mutex, Queue->Mutex);
@@ -6348,6 +6384,10 @@ pi_result piEnqueueMemBufferCopyRect(
   PI_ASSERT(!DstMem->isImage(), PI_ERROR_INVALID_MEM_OBJECT);
   auto SrcBuffer = pi_cast<pi_buffer>(SrcMem);
   auto DstBuffer = pi_cast<pi_buffer>(DstMem);
+
+  // We need a command list to submit the command, that's why reset signalled
+  // command lists to avoid creating new one.
+  resetCommandLists(Queue);
 
   std::shared_lock SrcLock(SrcBuffer->Mutex, std::defer_lock);
   std::scoped_lock LockAll(SrcLock, DstBuffer->Mutex, Queue->Mutex);
@@ -6474,6 +6514,10 @@ pi_result piEnqueueMemBufferFill(pi_queue Queue, pi_mem Buffer,
   PI_ASSERT(Buffer, PI_ERROR_INVALID_MEM_OBJECT);
   PI_ASSERT(Queue, PI_ERROR_INVALID_QUEUE);
 
+  // We need a command list to submit the command, that's why reset signalled
+  // command lists to avoid creating new one.
+  resetCommandLists(Queue);
+
   std::scoped_lock Lock(Queue->Mutex, Buffer->Mutex);
 
   char *ZeHandleDst;
@@ -6598,6 +6642,10 @@ pi_result piEnqueueMemBufferMap(pi_queue Queue, pi_mem Mem, pi_bool BlockingMap,
     (*Event)->Completed = true;
     return PI_SUCCESS;
   }
+
+  // We may need a command list to submit the command, that's why reset
+  // signalled command lists to avoid creating new one.
+  resetCommandLists(Queue);
 
   // Lock automatically releases when this goes out of scope.
   std::scoped_lock Lock(Queue->Mutex, Buffer->Mutex);
@@ -6739,6 +6787,10 @@ pi_result piEnqueueMemUnmap(pi_queue Queue, pi_mem Mem, void *MappedPtr,
     (*Event)->Completed = true;
     return PI_SUCCESS;
   }
+
+  // We need a command list to submit the command, that's why reset signalled
+  // command lists to avoid creating new one.
+  resetCommandLists(Queue);
 
   // Lock automatically releases when this goes out of scope.
   std::scoped_lock Lock(Queue->Mutex, Buffer->Mutex);
@@ -6994,6 +7046,10 @@ pi_result piEnqueueMemImageRead(pi_queue Queue, pi_mem Image,
                                 pi_event *Event) {
   PI_ASSERT(Queue, PI_ERROR_INVALID_QUEUE);
 
+  // We need a command list to submit the command, that's why reset signalled
+  // command lists to avoid creating new one.
+  resetCommandLists(Queue);
+
   std::shared_lock SrcLock(Image->Mutex, std::defer_lock);
   std::scoped_lock LockAll(SrcLock, Queue->Mutex);
   return enqueueMemImageCommandHelper(
@@ -7016,6 +7072,10 @@ pi_result piEnqueueMemImageWrite(pi_queue Queue, pi_mem Image,
 
   PI_ASSERT(Queue, PI_ERROR_INVALID_QUEUE);
 
+  // We need a command list to submit the command, that's why reset signalled
+  // command lists to avoid creating new one.
+  resetCommandLists(Queue);
+
   std::scoped_lock Lock(Queue->Mutex, Image->Mutex);
   return enqueueMemImageCommandHelper(PI_COMMAND_TYPE_IMAGE_WRITE, Queue,
                                       Ptr,   // src
@@ -7035,6 +7095,10 @@ piEnqueueMemImageCopy(pi_queue Queue, pi_mem SrcImage, pi_mem DstImage,
                       const pi_event *EventWaitList, pi_event *Event) {
 
   PI_ASSERT(Queue, PI_ERROR_INVALID_QUEUE);
+
+  // We need a command list to submit the command, that's why reset signalled
+  // command lists to avoid creating new one.
+  resetCommandLists(Queue);
 
   std::shared_lock SrcLock(SrcImage->Mutex, std::defer_lock);
   std::scoped_lock LockAll(SrcLock, DstImage->Mutex, Queue->Mutex);
@@ -7762,6 +7826,10 @@ pi_result piextUSMEnqueueMemset(pi_queue Queue, void *Ptr, pi_int32 Value,
 
   PI_ASSERT(Queue, PI_ERROR_INVALID_QUEUE);
 
+  // We need a command list to submit the command, that's why reset signalled
+  // command lists to avoid creating new one.
+  resetCommandLists(Queue);
+
   std::scoped_lock Lock(Queue->Mutex);
   return enqueueMemFillHelper(
       // TODO: do we need a new command type for USM memset?
@@ -7795,6 +7863,10 @@ pi_result piextUSMEnqueueMemcpy(pi_queue Queue, pi_bool Blocking, void *DstPtr,
   }
 
   PI_ASSERT(Queue, PI_ERROR_INVALID_QUEUE);
+
+  // We need a command list to submit the command, that's why reset signalled
+  // command lists to avoid creating new one.
+  resetCommandLists(Queue);
 
   std::scoped_lock lock(Queue->Mutex);
 
@@ -7831,6 +7903,10 @@ pi_result piextUSMEnqueuePrefetch(pi_queue Queue, const void *Ptr, size_t Size,
   PI_ASSERT(Flags == 0, PI_ERROR_INVALID_VALUE);
   PI_ASSERT(Queue, PI_ERROR_INVALID_QUEUE);
   PI_ASSERT(Event, PI_ERROR_INVALID_EVENT);
+
+  // We need a command list to submit the command, that's why reset signalled
+  // command lists to avoid creating new one.
+  resetCommandLists(Queue);
 
   // Lock automatically releases when this goes out of scope.
   std::scoped_lock lock(Queue->Mutex);
@@ -7897,6 +7973,10 @@ pi_result piextUSMEnqueueMemAdvise(pi_queue Queue, const void *Ptr,
                                    pi_event *Event) {
   PI_ASSERT(Queue, PI_ERROR_INVALID_QUEUE);
   PI_ASSERT(Event, PI_ERROR_INVALID_EVENT);
+
+  // We need a command list to submit the command, that's why reset signalled
+  // command lists to avoid creating new one.
+  resetCommandLists(Queue);
 
   // Lock automatically releases when this goes out of scope.
   std::scoped_lock lock(Queue->Mutex);


### PR DESCRIPTION
Resetting command lists only in sycnhronization points caused
performance regression because we reuse less command lists and
new command lists are getting created more often which adds
performance overhead.

Return the old behavior back: reset signalled command lists
each time before requesting a command list to submit a command.