### PR TITLE
[ESIMD][NFC] Fix the warning "named variadic macros are a GNU extension"

### DIFF
--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -62,7 +62,7 @@ using string_vector = std::vector<std::string>;
 namespace {
 
 #ifdef NDEBUG
-#define DUMP_ENTRY_POINTS(args...)
+#define DUMP_ENTRY_POINTS(...)
 #else
 constexpr int DebugPostLink = 0;
 


### PR DESCRIPTION
Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>