### PR TITLE
[SYCL] Remove runtime library calls to OpenCL

### DIFF
--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -86,7 +86,7 @@ function(add_sycl_rt_library LIB_NAME)
       ${CMAKE_CURRENT_SOURCE_DIR}
       "${sycl_inc_dir}"
   )
-  #TODO: Remove dependency on icd loader and opencl headers.
+  #TODO: Remove dependency on opencl headers.
   target_link_libraries(${LIB_OBJ_NAME}
     PRIVATE OpenCL-Headers
   )
@@ -95,7 +95,6 @@ function(add_sycl_rt_library LIB_NAME)
 
   target_link_libraries(${LIB_NAME}
     PRIVATE
-      OpenCL-ICD
       ${CMAKE_DL_LIBS}
       ${CMAKE_THREAD_LIBS_INIT}
   )

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -41,7 +41,7 @@ device::device(cl_device_id DeviceId) {
   auto Platform =
       detail::platform_impl::getPlatformFromPiDevice(Device, Plugin);
   impl = Platform->getOrMakeDeviceImpl(Device, Platform);
-  clRetainDevice(DeviceId);
+  Plugin.call<detail::PiApiKind::piDeviceRetain>(impl->getHandleRef());
 }
 
 device::device(const device_selector &deviceSelector) {

--- a/sycl/source/program.cpp
+++ b/sycl/source/program.cpp
@@ -45,7 +45,8 @@ program::program(const context &context, cl_program clProgram)
           detail::pi::cast<pi_native_handle>(clProgram))) {
   // The implementation constructor takes ownership of the native handle so we
   // must retain it in order to adhere to SYCL 1.2.1 spec (Rev6, section 4.3.1.)
-  clRetainProgram(clProgram);
+  impl->getPlugin().call<detail::PiApiKind::piProgramRetain>(
+      impl->getHandleRef());
 }
 
 backend program::get_backend() const noexcept { return getImplBackend(impl); }


### PR DESCRIPTION
This commit removes OpenCL calls from the runtime, replacing them with the corresponding PI calls. This removes the dependency on the OpenCL library from the runtime library.