### PR TITLE
[SYCL] Mark joint_group_conflict as unsupported on Windows

### DIFF
--- a/sycl/test/regression/joint_group_conflict.cpp
+++ b/sycl/test/regression/joint_group_conflict.cpp
@@ -1,6 +1,9 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fPIC -DCASE1 %s -c -o %t.1.o
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fPIC -DCASE2 %s -c -o %t.2.o
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -shared %t.1.o %t.2.o -o %t.so
+//
+// Some of the above compiler options will not work on Windows.
+// UNSUPPORTED: windows
 
 // Tests that creating a shared library with multiple object files using joint
 // group operations does not cause conflicting definitions.


### PR DESCRIPTION
The joint_group_conflict test uses compiler flags for the test that are not recognized when running on Windows. As such, the test is marked as unsupported for Windows.