### PR TITLE
[SYCL][PI][CUDA] Fix too many streams getting synchronized

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -535,7 +535,7 @@ struct _pi_queue {
       } else {
         start %= size;
         end %= size;
-        if (start < end) {
+        if (start <= end) {
           sync_compute(start, end);
         } else {
           sync_compute(start, size);
@@ -557,7 +557,7 @@ struct _pi_queue {
         } else {
           start %= size;
           end %= size;
-          if (start < end) {
+          if (start <= end) {
             sync_transfer(start, end);
           } else {
             sync_transfer(start, size);


### PR DESCRIPTION
Fixed off-by-one error introduced in https://github.com/intel/llvm/pull/6201 that would cause queue synchronization to synchronize all streams when no stream has been used. The code worked correctly, but this can in some cases impact performance.