### PR TITLE
[SYCL][CUDA][libclc] Fix the casting of image coordinates

### DIFF
--- a/libclc/ptx-nvidiacl/libspirv/images/image.cl
+++ b/libclc/ptx-nvidiacl/libspirv/images/image.cl
@@ -889,7 +889,8 @@ _DEFINE_SAMPLED_LOADS(half, 16)
     /* Sampling algorithms are implemented assu__spirv_ocl_s_ming an                                                                              \
      * unnormalized floating point coordinate as input. Need to transform as                                                                      \
      * appropriate. */                                                                                                                            \
-    sampling_coord_t sampling_coord = as_##sampling_coord_t(input_coord);                                                                         \
+    sampling_coord_t sampling_coord =                                                                                                             \
+        cast_##input_coord_t##_to_##sampling_coord_t(input_coord);                                                                                \
     if (is_normalized_coords(sampler)) {                                                                                                          \
       sampling_coord = unnormalized_coord_##dims##d(sampling_coord, image);                                                                       \
     }                                                                                                                                             \


### PR DESCRIPTION
This patch fix the casting of integer coordinates in image samplers.

This solves https://github.com/intel/llvm/issues/6285, allowing to re-enable the tests disabled in https://github.com/intel/llvm-test-suite/pull/1052.