### PR TITLE
[NFC][SYCL] Remove FIXME comment

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -1961,8 +1961,6 @@ void CodeGenModule::GenOpenCLArgMetadata(llvm::Function *Fn,
                     llvm::MDNode::get(VMContext, argBaseTypeNames));
     Fn->setMetadata("kernel_arg_type_qual",
                     llvm::MDNode::get(VMContext, argTypeQuals));
-    // FIXME: What is the purpose of this metadata for ESIMD? Can we
-    // reuse kernel_arg_exclusive_ptr or kernel_arg_runtime_aligned ?
     if (IsEsimdFunction)
       Fn->setMetadata("kernel_arg_accessor_ptr",
                       llvm::MDNode::get(VMContext, argSYCLAccessorPtrs));


### PR DESCRIPTION
Metadata kernel_arg_accessor_ptr is conveying to the BE the
requirement that the corresponding argument be
implemented using a surface.

This is different from information conveyed by metadata
kernel_arg_exclusive_ptr and kernel_arg_runtime_aligned.

Therefore, we cannot replace kernel_arg_accessor_ptr.

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>