### PR TITLE
[CI] Enable llvm-test-suite in post-commit on l0_gen9

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -36,7 +36,7 @@ on:
       build_artifact_suffix:
         type: string
         required: true
-      lts:
+      lts_matrix:
         type: string
         required: false
         default: ""
@@ -159,12 +159,12 @@ jobs:
 
   llvm_test_suite:
     needs: build
-    if: ${{ inputs.lts != '' }}
+    if: ${{ inputs.lts_matrix != '' }}
     strategy:
       fail-fast: false
       max-parallel: ${{ inputs.max_parallel }}
       matrix:
-        include: ${{ fromJSON(inputs.lts) }}
+        include: ${{ fromJSON(inputs.lts_matrix) }}
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runs-on }}
     env: ${{ matrix.env }}

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -36,11 +36,7 @@ on:
       build_artifact_suffix:
         type: string
         required: true
-      intel_drivers_image:
-        type: string
-        required: false
-        default: "ghcr.io/intel/llvm/ubuntu2004_intel_drivers:latest"
-      lts_config:
+      lts:
         type: string
         required: false
         default: ""
@@ -48,14 +44,6 @@ on:
         type: string
         required: false
         default: ""
-      amdgpu_image:
-        type: string
-        required: false
-        default: "ghcr.io/intel/llvm/ubuntu2004_build:latest"
-      cuda_image:
-        type: string
-        required: false
-        default: "ghcr.io/intel/llvm/ubuntu2004_build:latest"
       lts_ref:
         type: string
         required: false
@@ -169,38 +157,14 @@ jobs:
         name: sycl_lit_${{ inputs.build_artifact_suffix }}
         path: lit.tar.xz
 
-  # This job generates matrix of tests for LLVM Test Suite
-  resolve_matrix:
-    name: Resolve Test Matrix
-    runs-on: ubuntu-latest
-    outputs:
-      lts: ${{ steps.work.outputs.lts }}
-    steps:
-    - name: Download scripts and configs
-      run: |
-        wget raw.githubusercontent.com/intel/llvm/${{ github.sha }}/devops/scripts/generate_test_matrix.js
-        wget raw.githubusercontent.com/intel/llvm/${{ github.sha }}/devops/test_configs.json
-        wget raw.githubusercontent.com/intel/llvm/sycl/devops/dependencies.json
-        mv dependencies.json dependencies.sycl.json
-        wget raw.githubusercontent.com/intel/llvm/${{ github.sha }}/devops/dependencies.json
-    - id: work
-      uses: actions/github-script@v6
-      name: Generate matrix
-      env:
-        GHA_INPUTS: ${{ toJSON(inputs) }}
-      with:
-        script: |
-          const script = require('./generate_test_matrix.js');
-          script({core, process});
-
   llvm_test_suite:
-    needs: [build, resolve_matrix]
-    if: ${{ inputs.lts_config != '' }}
+    needs: build
+    if: ${{ inputs.lts != '' }}
     strategy:
       fail-fast: false
       max-parallel: ${{ inputs.max_parallel }}
       matrix:
-        include: ${{ fromJSON(needs.resolve_matrix.outputs.lts) }}
+        include: ${{ fromJSON(inputs.lts) }}
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.runs-on }}
     env: ${{ matrix.env }}
@@ -241,4 +205,3 @@ jobs:
         check_sycl_all: ${{ matrix.check_sycl_all }}
         results_name_suffix: ${{ matrix.config }}_${{ inputs.build_artifact_suffix }}
         cmake_args: '${{ matrix.cmake_args }} ${{ inputs.lts_cmake_extra_args }}'
-

--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -23,7 +23,7 @@ jobs:
     uses: ./.github/workflows/sycl_linux_build_and_test.yml
     with:
       build_cache_root: "/__w/llvm"
-      build_artifact_suffix: default
+      build_artifact_suffix: "post_commit"
       lts_matrix: ${{ needs.resolve_matrix.outputs.lts_matrix }}
   linux_no_assert:
     name: Linux (no assert)

--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -11,12 +11,20 @@ on:
     - .github/workflows/sycl_post_commit.yml
 
 jobs:
+  # This job generates matrix of tests for LLVM Test Suite
+  resolve_matrix:
+    name: Resolve Test Matrix
+    uses: ./.github/workflows/sycl_resolve_test_matrix.yml
+    with:
+      lts_config: "l0_gen9"
   linux_default:
     name: Linux Default
+    needs: resolve_matrix
     uses: ./.github/workflows/sycl_linux_build_and_test.yml
     with:
       build_cache_root: "/__w/llvm"
       build_artifact_suffix: default
+      lts_matrix: ${{ needs.resolve_matrix.outputs.lts_matrix }}
   linux_no_assert:
     name: Linux (no assert)
     uses: ./.github/workflows/sycl_linux_build_and_test.yml

--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -48,4 +48,4 @@ jobs:
       build_cache_size: "8G"
       build_artifact_suffix: "default"
       build_cache_suffix: "default"
-      lts: ${{ needs.resolve_matrix.outputs.lts }}
+      lts_matrix: ${{ needs.resolve_matrix.outputs.lts_matrix }}

--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -29,11 +29,18 @@ jobs:
     - name: Run clang-format
       uses: ./devops/actions/clang-format
 
+  # This job generates matrix of tests for LLVM Test Suite
+  resolve_matrix:
+    name: Resolve Test Matrix
+    uses: ./.github/workflows/sycl_resolve_test_matrix.yml
+    with:
+      lts_config: "hip_amdgpu;ocl_x64;ocl_gen9;l0_gen9;esimd_emu;cuda"
+
   linux_default:
     name: Linux
     # Only build and test patches, that have passed all linter checks, because
     # the next commit is likely to be a follow-up on that job.
-    needs: lint
+    needs: [lint, resolve_matrix]
     if: always() && (success() || contains(github.event.pull_request.labels.*.name, 'ignore-lint'))
     uses: ./.github/workflows/sycl_linux_build_and_test.yml
     with:
@@ -41,4 +48,4 @@ jobs:
       build_cache_size: "8G"
       build_artifact_suffix: "default"
       build_cache_suffix: "default"
-      lts_config: "hip_amdgpu;ocl_x64;ocl_gen9;l0_gen9;esimd_emu;cuda"
+      lts: ${{ needs.resolve_matrix.outputs.lts }}

--- a/.github/workflows/sycl_resolve_test_matrix.yml
+++ b/.github/workflows/sycl_resolve_test_matrix.yml
@@ -1,0 +1,48 @@
+name: Reusable test matrix generation
+
+on:
+  workflow_call:
+    inputs:
+      intel_drivers_image:
+        type: string
+        required: false
+        default: "ghcr.io/intel/llvm/ubuntu2004_intel_drivers:latest"
+      amdgpu_image:
+        type: string
+        required: false
+        default: "ghcr.io/intel/llvm/ubuntu2004_build:latest"
+      cuda_image:
+        type: string
+        required: false
+        default: "ghcr.io/intel/llvm/ubuntu2004_build:latest"
+      lts_config:
+        type: string
+        required: true
+    outputs:
+      lts:
+        description: "Generated Matrix"
+        value: ${{ jobs.resolve_matrix.outputs.lts }}
+jobs:
+  resolve_matrix:
+    name: Resolve Test Matrix
+    runs-on: ubuntu-latest
+    outputs:
+      lts: ${{ steps.work.outputs.lts }}
+    steps:
+    - name: Download scripts and configs
+      shell: bash
+      run: |
+        wget raw.githubusercontent.com/intel/llvm/${{ github.sha }}/devops/scripts/generate_test_matrix.js
+        wget raw.githubusercontent.com/intel/llvm/${{ github.sha }}/devops/test_configs.json
+        wget raw.githubusercontent.com/intel/llvm/sycl/devops/dependencies.json
+        mv dependencies.json dependencies.sycl.json
+        wget raw.githubusercontent.com/intel/llvm/${{ github.sha }}/devops/dependencies.json
+    - id: work
+      uses: actions/github-script@v6
+      name: Generate matrix
+      env:
+        GHA_INPUTS: ${{ toJSON(inputs) }}
+      with:
+        script: |
+          const script = require('./generate_test_matrix.js');
+          script({core, process});

--- a/.github/workflows/sycl_resolve_test_matrix.yml
+++ b/.github/workflows/sycl_resolve_test_matrix.yml
@@ -18,16 +18,17 @@ on:
       lts_config:
         type: string
         required: true
+        default: ""
     outputs:
-      lts:
+      lts_matrix:
         description: "Generated Matrix"
-        value: ${{ jobs.resolve_matrix.outputs.lts }}
+        value: ${{ jobs.resolve_matrix.outputs.lts_matrix }}
 jobs:
   resolve_matrix:
     name: Resolve Test Matrix
     runs-on: ubuntu-latest
     outputs:
-      lts: ${{ steps.work.outputs.lts }}
+      lts_matrix: ${{ steps.work.outputs.lts_matrix }}
     steps:
     - name: Download scripts and configs
       shell: bash

--- a/.github/workflows/sycl_windows_build_and_test.yml
+++ b/.github/workflows/sycl_windows_build_and_test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Build + LIT
     runs-on: [Windows, build]
     # TODO use cached checkout
     steps:

--- a/devops/scripts/generate_test_matrix.js
+++ b/devops/scripts/generate_test_matrix.js
@@ -59,7 +59,7 @@ module.exports = ({core, process}) => {
             "ghcr.io/intel/llvm/ubuntu2004_base:latest");
       }
 
-      core.setOutput('lts', ltsString);
+      core.setOutput('lts_matrix', ltsString);
     }
   });
 }


### PR DESCRIPTION
* Level up llvm-test-suite matrix resolution to reusable workflow, to be reused by top level workflows such as pre-commit or post-commit on both Linux and Windows
* Update Windows task name to "Build + LIT" like on Linux
* Add l0_gen9 in post-commit testing