### PR TITLE
[SYCL] Fix Driver test after PR#6295

### DIFF
--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -89,7 +89,7 @@
 /// Check that -aux-triple is passed with -fsycl -fintelfpga
 // RUN:    %clang -### -fsycl -fintelfpga %s 2>&1 \
 // RUN:    | FileCheck -DARCH=x86_64 -DARCH2=spir64_fpga -check-prefix=CHK-SYCL-FPGA-AUX-TRIPLE %s
-// CHK-SYCL-FPGA-AUX-TRIPLE: clang{{.*}} "-cc1" "-triple" "[[ARCH]]-unknown-linux-gnu"{{.*}} "-aux-triple" "[[ARCH2]]-unknown-unknown"{{.*}} "-fsycl-is-host"
+// CHK-SYCL-FPGA-AUX-TRIPLE: clang{{.*}} "-cc1" "-triple" "[[ARCH]]-{{.*}}"{{.*}} "-aux-triple" "[[ARCH2]]-{{.*}}"{{.*}} "-fsycl-is-host"
 /// ###########################################################################
 
 /// Validate SYCL option values


### PR DESCRIPTION
PR #6295 modified Driver/sycl-offload.c incorrectly.  It used a triple specific to Linux, and this failed on Windows.
This PR fixes that by checking a wildcard pattern for the other triple values.