### PR TITLE
[SYCL][L0] Fix piEnqueueEventsWaitWithBarrier for L0

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -705,13 +705,16 @@ struct _pi_context : _pi_object {
   // If AllowBatching is true, then the command list returned may already have
   // command in it, if AllowBatching is false, any open command lists that
   // already exist in Queue will be closed and executed.
+  // If ForcedCmdQueue is not nullptr, the resulting command list must be tied
+  // to the contained command queue. This option is ignored if immediate
+  // command lists are used.
   // When using immediate commandlists, retrieves an immediate command list
   // for executing on this device. Immediate commandlists are created only
   // once for each SYCL Queue and after that they are reused.
-  pi_result getAvailableCommandList(pi_queue Queue,
-                                    pi_command_list_ptr_t &CommandList,
-                                    bool UseCopyEngine,
-                                    bool AllowBatching = false);
+  pi_result
+  getAvailableCommandList(pi_queue Queue, pi_command_list_ptr_t &CommandList,
+                          bool UseCopyEngine, bool AllowBatching = false,
+                          ze_command_queue_handle_t *ForcedCmdQueue = nullptr);
 
   // Get index of the free slot in the available pool. If there is no available
   // pool then create new one. The HostVisible parameter tells if we need a
@@ -831,6 +834,9 @@ struct _pi_queue : _pi_object {
     // Return the index of the next queue to use based on a
     // round robin strategy and the queue group ordinal.
     uint32_t getQueueIndex(uint32_t *QueueGroupOrdinal, uint32_t *QueueIndex);
+
+    // Get the ordinal for a command queue handle.
+    int32_t getCmdQueueOrdinal(ze_command_queue_handle_t CmdQueue);
 
     // This function will return one of possibly multiple available native
     // queues and the value of the queue group ordinal.
@@ -1001,6 +1007,13 @@ struct _pi_queue : _pi_object {
       return Res;
     return PI_SUCCESS;
   }
+
+  pi_result insertBarrier(pi_uint32 NumEventsInWaitList,
+                          const pi_event *EventWaitList, pi_event *Event);
+  pi_result insertActiveBarriers(pi_command_list_ptr_t &CmdList,
+                                 bool UseCopyEngine);
+
+  std::vector<pi_event> ActiveBarriers;
 
   // Besides each PI object keeping a total reference count in
   // _pi_object::RefCount we keep special track of the queue *external*
@@ -1229,8 +1242,7 @@ struct _pi_ze_event_list_t {
   // so this will be used to make list destruction thread-safe.
   pi_mutex PiZeEventListMutex;
 
-  // Initialize this using the array of events in EventList, and retain
-  // all the pi_events in the created data structure.
+  // Initialize this using the array of events in EventList.
   // CurQueue is the pi_queue that the command with this event wait
   // list is going to be added to.  That is needed to flush command
   // batches for wait events that are in other queues.
@@ -1238,9 +1250,21 @@ struct _pi_ze_event_list_t {
   // event wait-list is for) is going to go to copy or compute
   // queue. This is used to properly submit the dependent open
   // command-lists.
+  // RetainEvents indicates that the events in the event list should be
+  // retained.
+  pi_result createPiZeEventList(pi_uint32 EventListLength,
+                                const pi_event *EventList, pi_queue CurQueue,
+                                bool UseCopyEngine, bool RetainEvents);
+
+  // Same as createPiZeEventList(EventListLength, EventList, CurQueue,
+  // UseCopyEngine, true).
   pi_result createAndRetainPiZeEventList(pi_uint32 EventListLength,
                                          const pi_event *EventList,
-                                         pi_queue CurQueue, bool UseCopyEngine);
+                                         pi_queue CurQueue,
+                                         bool UseCopyEngine) {
+    return createPiZeEventList(EventListLength, EventList, CurQueue,
+                               UseCopyEngine, /*RetainEvents=*/true);
+  }
 
   // Add all the events in this object's PiEventList to the end
   // of the list EventsToBeReleased. Destroy pi_ze_event_list_t data


### PR DESCRIPTION
When calling `piEnqueueEventsWaitWithBarrier` while using the level zero backend, the barrier is only inserted into an available command list. However, this leaves other command lists unaffected.

This commit fixes this unexpected behavior by making later command-lists insert a barrier on events from `piEnqueueEventsWaitWithBarrier` until they finish.

The resulting event will be either the result of a single barrier, if events were passed to `piEnqueueEventsWaitWithBarrier`, or a wait on generic barriers on all queues if no events were passed to `piEnqueueEventsWaitWithBarrier`.