### PR TITLE
[SYCL][CUDA] Retain context with CUDA event interop

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -476,7 +476,9 @@ _pi_event::_pi_event(pi_context context, CUevent eventNative)
       hasBeenWaitedOn_{false}, isRecorded_{false}, isStarted_{false},
       streamToken_{std::numeric_limits<pi_uint32>::max()}, evEnd_{eventNative},
       evStart_{nullptr}, evQueued_{nullptr}, queue_{nullptr}, context_{
-                                                                  context} {}
+                                                                  context} {
+  cuda_piContextRetain(context_);
+}
 
 _pi_event::~_pi_event() {
   if (queue_ != nullptr) {


### PR DESCRIPTION
This PR fixes an issue found in the SYCL-CTS cuda interop tests. 
Where the context had not been properly retained when creating a native event with CUDA interop.