### PR TITLE
[Driver][SYCL] sycl-unsupported.cpp is forced to 64 bit target

### DIFF
--- a/clang/test/Driver/sycl-unsupported.cpp
+++ b/clang/test/Driver/sycl-unsupported.cpp
@@ -1,5 +1,5 @@
 /// Diagnose unsupported options specific to SYCL compilations
-// RUN: %clangxx -fsycl -fsanitize=address -### %s 2>&1 \
+// RUN: %clangxx -fsycl -fsanitize=address -fsycl-targets=spir64 -### %s 2>&1 \
 // RUN:  | FileCheck %s --check-prefix=SANITIZE -DARCH=spir64
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -fsanitize=address -### %s 2>&1 \
 // RUN:  | FileCheck %s --check-prefix=SANITIZE -DARCH=spir64_gen


### PR DESCRIPTION
Signed-off-by: Harini Chilamantula <harini.chilamantula@intel.com>