### PR TITLE
[SYCL] Fail on kernel lambda size mismatch

### DIFF
--- a/clang/test/SemaSYCL/Inputs/CL/sycl/detail/kernel_desc.hpp
+++ b/clang/test/SemaSYCL/Inputs/CL/sycl/detail/kernel_desc.hpp
@@ -43,6 +43,7 @@ __SYCL_INLINE_NAMESPACE(cl) {
     }
     static constexpr const char *getName() { return ""; }
     static constexpr bool isESIMD() { return 0; }
+    static constexpr long getKernelSize() { return 0; }
   };
   } // namespace detail
   } // namespace sycl

--- a/clang/test/SemaSYCL/Inputs/CL/sycl/detail/kernel_desc.hpp
+++ b/clang/test/SemaSYCL/Inputs/CL/sycl/detail/kernel_desc.hpp
@@ -35,6 +35,17 @@ __SYCL_INLINE_NAMESPACE(cl) {
     int offset;
   };
 
+  template <bool Cond, typename TrueT, typename FalseT>
+  struct conditional {
+    using type = TrueT;
+  };
+  template <typename TrueT, typename FalseT>
+  struct conditional<false, TrueT, FalseT> {
+    using type = FalseT;
+  };
+
+  using int64_t = conditional<sizeof(long) == 8, long, long long>::type;
+
   template <class KernelNameType> struct KernelInfo {
     static constexpr unsigned getNumParams() { return 0; }
     static const kernel_param_desc_t &getParamDesc(int) {
@@ -43,7 +54,7 @@ __SYCL_INLINE_NAMESPACE(cl) {
     }
     static constexpr const char *getName() { return ""; }
     static constexpr bool isESIMD() { return 0; }
-    static constexpr long getKernelSize() { return 0; }
+    static constexpr int64_t getKernelSize() { return 0; }
   };
   } // namespace detail
   } // namespace sycl

--- a/sycl/include/CL/sycl/detail/kernel_desc.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_desc.hpp
@@ -79,6 +79,7 @@ template <class KernelNameType> struct KernelInfo {
   static constexpr const char *getFunctionName() { return ""; }
   static constexpr unsigned getLineNumber() { return 0; }
   static constexpr unsigned getColumnNumber() { return 0; }
+  static constexpr long getKernelSize() { return 0; }
 };
 #else
 template <char...> struct KernelInfoData {
@@ -93,6 +94,7 @@ template <char...> struct KernelInfoData {
   static constexpr const char *getFunctionName() { return ""; }
   static constexpr unsigned getLineNumber() { return 0; }
   static constexpr unsigned getColumnNumber() { return 0; }
+  static constexpr long getKernelSize() { return 0; }
 };
 
 // C++14 like index_sequence and make_index_sequence
@@ -135,6 +137,9 @@ template <class KernelNameType> struct KernelInfo {
   static constexpr const char *getFunctionName() { return ""; }
   static constexpr unsigned getLineNumber() { return 0; }
   static constexpr unsigned getColumnNumber() { return 0; }
+  static constexpr long getKernelSize() {
+    return SubKernelInfo::getKernelSize();
+  }
 };
 #endif //__SYCL_UNNAMED_LAMBDA__
 

--- a/sycl/include/CL/sycl/detail/kernel_desc.hpp
+++ b/sycl/include/CL/sycl/detail/kernel_desc.hpp
@@ -13,6 +13,8 @@
 #include <CL/sycl/detail/defines_elementary.hpp>
 #include <CL/sycl/detail/export.hpp>
 
+#include <cstdint>
+
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
@@ -79,7 +81,7 @@ template <class KernelNameType> struct KernelInfo {
   static constexpr const char *getFunctionName() { return ""; }
   static constexpr unsigned getLineNumber() { return 0; }
   static constexpr unsigned getColumnNumber() { return 0; }
-  static constexpr long getKernelSize() { return 0; }
+  static constexpr int64_t getKernelSize() { return 0; }
 };
 #else
 template <char...> struct KernelInfoData {
@@ -94,7 +96,7 @@ template <char...> struct KernelInfoData {
   static constexpr const char *getFunctionName() { return ""; }
   static constexpr unsigned getLineNumber() { return 0; }
   static constexpr unsigned getColumnNumber() { return 0; }
-  static constexpr long getKernelSize() { return 0; }
+  static constexpr int64_t getKernelSize() { return 0; }
 };
 
 // C++14 like index_sequence and make_index_sequence
@@ -137,7 +139,7 @@ template <class KernelNameType> struct KernelInfo {
   static constexpr const char *getFunctionName() { return ""; }
   static constexpr unsigned getLineNumber() { return 0; }
   static constexpr unsigned getColumnNumber() { return 0; }
-  static constexpr long getKernelSize() {
+  static constexpr int64_t getKernelSize() {
     return SubKernelInfo::getKernelSize();
   }
 };

--- a/sycl/test/basic_tests/kernel_size_mismatch.cpp
+++ b/sycl/test/basic_tests/kernel_size_mismatch.cpp
@@ -1,0 +1,19 @@
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning -o - %s
+
+// Tests for static assertion failure when kernel lambda mismatches between host
+// and device.
+
+#include <CL/sycl.hpp>
+
+int main() {
+  sycl::queue Q;
+  int A = 1;
+  Q.single_task([=]() {
+#ifdef __SYCL_DEVICE_ONLY__
+     (void)A;
+     // expected-no-diagnostics
+#else
+     // expected-error-re@CL/sycl/handler.hpp:* {{static_assert failed due to requirement '{{.*}}' "Unexpected kernel lambda size. This can be caused by an external host compiler producing a lambda with an unexpected layout. This is a limitation of the compiler."}}
+#endif
+   }).wait();
+}

--- a/sycl/test/basic_tests/kernel_size_mismatch.cpp
+++ b/sycl/test/basic_tests/kernel_size_mismatch.cpp
@@ -11,9 +11,9 @@ int main() {
   Q.single_task([=]() {
 #ifdef __SYCL_DEVICE_ONLY__
      (void)A;
-     // expected-no-diagnostics
+    // expected-no-diagnostics
 #else
-     // expected-error-re@CL/sycl/handler.hpp:* {{static_assert failed due to requirement '{{.*}}' "Unexpected kernel lambda size. This can be caused by an external host compiler producing a lambda with an unexpected layout. This is a limitation of the compiler."}}
+  // expected-error-re@CL/sycl/handler.hpp:* {{static_assert failed due to requirement '{{.*}}' "Unexpected kernel lambda size. This can be caused by an external host compiler producing a lambda with an unexpected layout. This is a limitation of the compiler."}}
 #endif
    }).wait();
 }

--- a/sycl/unittests/SYCL2020/GetNativeOpenCL.cpp
+++ b/sycl/unittests/SYCL2020/GetNativeOpenCL.cpp
@@ -127,7 +127,8 @@ TEST(GetNative, GetNativeHandle) {
   sycl::buffer<int, 1> Buffer(&Data[0], sycl::range<1>(1));
   Queue.submit([&](sycl::handler &cgh) {
     auto Acc = Buffer.get_access<sycl::access::mode::read_write>(cgh);
-    cgh.single_task<TestKernel>([=]() { (void)Acc; });
+    constexpr size_t KS = sizeof(decltype(Acc));
+    cgh.single_task<TestKernel<KS>>([=]() { (void)Acc; });
   });
 
   get_native<backend::opencl>(Context);

--- a/sycl/unittests/SYCL2020/KernelBundle.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundle.cpp
@@ -31,6 +31,7 @@ template <> struct KernelInfo<TestKernel> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
+  static constexpr long getKernelSize() { return 1; }
 };
 
 template <> struct KernelInfo<TestKernelExeOnly> {
@@ -43,6 +44,7 @@ template <> struct KernelInfo<TestKernelExeOnly> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
+  static constexpr long getKernelSize() { return 1; }
 };
 
 } // namespace detail

--- a/sycl/unittests/SYCL2020/KernelBundle.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundle.cpp
@@ -31,7 +31,7 @@ template <> struct KernelInfo<TestKernel> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
-  static constexpr long getKernelSize() { return 1; }
+  static constexpr int64_t getKernelSize() { return 1; }
 };
 
 template <> struct KernelInfo<TestKernelExeOnly> {
@@ -44,7 +44,7 @@ template <> struct KernelInfo<TestKernelExeOnly> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
-  static constexpr long getKernelSize() { return 1; }
+  static constexpr int64_t getKernelSize() { return 1; }
 };
 
 } // namespace detail

--- a/sycl/unittests/SYCL2020/KernelID.cpp
+++ b/sycl/unittests/SYCL2020/KernelID.cpp
@@ -32,6 +32,7 @@ template <> struct KernelInfo<TestKernel1> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
+  static constexpr long getKernelSize() { return 1; }
 };
 
 template <> struct KernelInfo<TestKernel2> {
@@ -44,6 +45,7 @@ template <> struct KernelInfo<TestKernel2> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
+  static constexpr long getKernelSize() { return 1; }
 };
 
 template <> struct KernelInfo<TestKernel3> {
@@ -56,6 +58,7 @@ template <> struct KernelInfo<TestKernel3> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
+  static constexpr long getKernelSize() { return 1; }
 };
 
 template <> struct KernelInfo<ServiceKernel1> {
@@ -70,6 +73,7 @@ template <> struct KernelInfo<ServiceKernel1> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
+  static constexpr long getKernelSize() { return 1; }
 };
 } // namespace detail
 } // namespace sycl

--- a/sycl/unittests/SYCL2020/KernelID.cpp
+++ b/sycl/unittests/SYCL2020/KernelID.cpp
@@ -32,7 +32,7 @@ template <> struct KernelInfo<TestKernel1> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
-  static constexpr long getKernelSize() { return 1; }
+  static constexpr int64_t getKernelSize() { return 1; }
 };
 
 template <> struct KernelInfo<TestKernel2> {
@@ -45,7 +45,7 @@ template <> struct KernelInfo<TestKernel2> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
-  static constexpr long getKernelSize() { return 1; }
+  static constexpr int64_t getKernelSize() { return 1; }
 };
 
 template <> struct KernelInfo<TestKernel3> {
@@ -58,7 +58,7 @@ template <> struct KernelInfo<TestKernel3> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
-  static constexpr long getKernelSize() { return 1; }
+  static constexpr int64_t getKernelSize() { return 1; }
 };
 
 template <> struct KernelInfo<ServiceKernel1> {
@@ -73,7 +73,7 @@ template <> struct KernelInfo<ServiceKernel1> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
-  static constexpr long getKernelSize() { return 1; }
+  static constexpr int64_t getKernelSize() { return 1; }
 };
 } // namespace detail
 } // namespace sycl

--- a/sycl/unittests/SYCL2020/SpecializationConstant.cpp
+++ b/sycl/unittests/SYCL2020/SpecializationConstant.cpp
@@ -35,7 +35,7 @@ template <> struct KernelInfo<TestKernel> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
-  static constexpr long getKernelSize() { return 1; }
+  static constexpr int64_t getKernelSize() { return 1; }
 };
 
 template <> const char *get_spec_constant_symbolic_ID<SpecConst1>() {

--- a/sycl/unittests/SYCL2020/SpecializationConstant.cpp
+++ b/sycl/unittests/SYCL2020/SpecializationConstant.cpp
@@ -35,6 +35,7 @@ template <> struct KernelInfo<TestKernel> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
+  static constexpr long getKernelSize() { return 1; }
 };
 
 template <> const char *get_spec_constant_symbolic_ID<SpecConst1>() {

--- a/sycl/unittests/assert/assert.cpp
+++ b/sycl/unittests/assert/assert.cpp
@@ -50,7 +50,7 @@ template <> struct KernelInfo<TestKernel> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
-  static constexpr long getKernelSize() { return 1; }
+  static constexpr int64_t getKernelSize() { return 1; }
 };
 
 static constexpr const kernel_param_desc_t Signatures[] = {
@@ -69,7 +69,7 @@ struct KernelInfo<::sycl::detail::__sycl_service_kernel__::AssertInfoCopier> {
   static constexpr bool isESIMD() { return 0; }
   static constexpr bool callsThisItem() { return 0; }
   static constexpr bool callsAnyThisFreeFunction() { return 0; }
-  static constexpr long getKernelSize() {
+  static constexpr int64_t getKernelSize() {
     // The AssertInfoCopier service kernel lambda captures an accessor.
     return sizeof(sycl::accessor<sycl::detail::AssertHappened, 1,
                                  sycl::access::mode::write>);

--- a/sycl/unittests/assert/assert.cpp
+++ b/sycl/unittests/assert/assert.cpp
@@ -50,6 +50,7 @@ template <> struct KernelInfo<TestKernel> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
+  static constexpr long getKernelSize() { return 1; }
 };
 
 static constexpr const kernel_param_desc_t Signatures[] = {
@@ -68,6 +69,11 @@ struct KernelInfo<::sycl::detail::__sycl_service_kernel__::AssertInfoCopier> {
   static constexpr bool isESIMD() { return 0; }
   static constexpr bool callsThisItem() { return 0; }
   static constexpr bool callsAnyThisFreeFunction() { return 0; }
+  static constexpr long getKernelSize() {
+    // The AssertInfoCopier service kernel lambda captures an accessor.
+    return sizeof(sycl::accessor<sycl::detail::AssertHappened, 1,
+                                 sycl::access::mode::write>);
+  }
 };
 } // namespace detail
 } // namespace sycl

--- a/sycl/unittests/buffer/BufferLocation.cpp
+++ b/sycl/unittests/buffer/BufferLocation.cpp
@@ -116,7 +116,8 @@ TEST_F(BufferTest, BufferLocationOnly) {
             cl::sycl::ext::oneapi::accessor_property_list<
                 cl::sycl::ext::intel::property::buffer_location::instance<2>>>
             Acc{Buf, cgh, sycl::read_write, PL};
-        cgh.single_task<TestKernel>([=]() { Acc[0] = 4; });
+        constexpr size_t KS = sizeof(decltype(Acc));
+        cgh.single_task<TestKernel<KS>>([=]() { Acc[0] = 4; });
       })
       .wait();
   EXPECT_EQ(PassedLocation, (uint64_t)2);
@@ -149,7 +150,8 @@ TEST_F(BufferTest, BufferLocationWithAnotherProp) {
                 cl::sycl::ext::intel::property::buffer_location::instance<5>>>
             Acc{Buf, cgh, sycl::write_only, PL};
 
-        cgh.single_task<TestKernel>([=]() { Acc[0] = 4; });
+        constexpr size_t KS = sizeof(decltype(Acc));
+        cgh.single_task<TestKernel<KS>>([=]() { Acc[0] = 4; });
       })
       .wait();
   EXPECT_EQ(PassedLocation, (uint64_t)5);
@@ -209,7 +211,8 @@ TEST_F(BufferTest, WOBufferLocation) {
                        cl::sycl::access::placeholder::false_t,
                        cl::sycl::ext::oneapi::accessor_property_list<>>
             Acc{Buf, cgh, sycl::read_write};
-        cgh.single_task<TestKernel>([=]() { Acc[0] = 4; });
+        constexpr size_t KS = sizeof(decltype(Acc));
+        cgh.single_task<TestKernel<KS>>([=]() { Acc[0] = 4; });
       })
       .wait();
   EXPECT_EQ(PassedLocation, DEFAULT_VALUE);

--- a/sycl/unittests/event/EventDestruction.cpp
+++ b/sycl/unittests/event/EventDestruction.cpp
@@ -68,11 +68,11 @@ TEST_F(EventDestructionTest, EventDestruction) {
 
     {
       sycl::event E0 = Queue.submit([&](cl::sycl::handler &cgh) {
-        cgh.single_task<TestKernel>([]() {});
+        cgh.single_task<TestKernel<>>([]() {});
       });
       E1 = Queue.submit([&](cl::sycl::handler &cgh) {
         cgh.depends_on(E0);
-        cgh.single_task<TestKernel>([]() {});
+        cgh.single_task<TestKernel<>>([]() {});
       });
       E1.wait();
     }
@@ -85,7 +85,7 @@ TEST_F(EventDestructionTest, EventDestruction) {
 
     sycl::event E2 = Queue.submit([&](cl::sycl::handler &cgh) {
       cgh.depends_on(E1);
-      cgh.single_task<TestKernel>([]() {});
+      cgh.single_task<TestKernel<>>([]() {});
     });
     E2.wait();
     // Dependencies of E1 should be cleared here. It depends on E0.
@@ -93,7 +93,7 @@ TEST_F(EventDestructionTest, EventDestruction) {
 
     sycl::event E3 = Queue.submit([&](cl::sycl::handler &cgh) {
       cgh.depends_on({E1, E2});
-      cgh.single_task<TestKernel>([]() {});
+      cgh.single_task<TestKernel<>>([]() {});
     });
     E3.wait();
     // Dependency of E1 has already cleared. E2 depends on E1 that
@@ -107,20 +107,20 @@ TEST_F(EventDestructionTest, EventDestruction) {
     sycl::buffer<int, 1> Buf(&data[0], sycl::range<1>(2));
     Queue.submit([&](cl::sycl::handler &cgh) {
       auto Acc = Buf.get_access<sycl::access::mode::read_write>(cgh);
-      cgh.single_task<TestKernel>([=]() {});
+      cgh.single_task<TestKernel<>>([=]() {});
     });
 
     Queue.submit([&](cl::sycl::handler &cgh) {
       auto Acc = Buf.get_access<sycl::access::mode::read_write>(cgh);
-      cgh.single_task<TestKernel>([=]() {});
+      cgh.single_task<TestKernel<>>([=]() {});
     });
     sycl::event E1 = Queue.submit([&](cl::sycl::handler &cgh) {
       auto Acc = Buf.get_access<sycl::access::mode::read_write>(cgh);
-      cgh.single_task<TestKernel>([=]() {});
+      cgh.single_task<TestKernel<>>([=]() {});
     });
     sycl::event E2 = Queue.submit([&](cl::sycl::handler &cgh) {
       auto Acc = Buf.get_access<sycl::access::mode::read_write>(cgh);
-      cgh.single_task<TestKernel>([=]() {});
+      cgh.single_task<TestKernel<>>([=]() {});
     });
     E2.wait();
     // Dependencies are deleted through one level of dependencies. When
@@ -172,11 +172,11 @@ TEST_F(EventDestructionTest, GetWaitList) {
 
     {
       sycl::event E0 = Queue.submit([&](cl::sycl::handler &cgh) {
-        cgh.single_task<TestKernel>([]() {});
+        cgh.single_task<TestKernel<>>([]() {});
       });
       E1 = Queue.submit([&](cl::sycl::handler &cgh) {
         cgh.depends_on(E0);
-        cgh.single_task<TestKernel>([]() {});
+        cgh.single_task<TestKernel<>>([]() {});
       });
       E1.wait();
       auto wait_list = E1.get_wait_list();
@@ -190,13 +190,13 @@ TEST_F(EventDestructionTest, GetWaitList) {
 
     sycl::event E2 = Queue.submit([&](cl::sycl::handler &cgh) {
       cgh.depends_on(E1);
-      cgh.single_task<TestKernel>([]() {});
+      cgh.single_task<TestKernel<>>([]() {});
     });
     E2.wait();
 
     sycl::event E3 = Queue.submit([&](cl::sycl::handler &cgh) {
       cgh.depends_on({E1, E2});
-      cgh.single_task<TestKernel>([]() {});
+      cgh.single_task<TestKernel<>>([]() {});
     });
     E3.wait();
 

--- a/sycl/unittests/helpers/TestKernel.hpp
+++ b/sycl/unittests/helpers/TestKernel.hpp
@@ -25,7 +25,7 @@ template <size_t KernelSize> struct KernelInfo<TestKernel<KernelSize>> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
-  static constexpr long getKernelSize() { return KernelSize; }
+  static constexpr int64_t getKernelSize() { return KernelSize; }
 };
 
 } // namespace detail

--- a/sycl/unittests/helpers/TestKernel.hpp
+++ b/sycl/unittests/helpers/TestKernel.hpp
@@ -10,12 +10,12 @@
 
 #include "PiImage.hpp"
 
-class TestKernel;
+template <size_t KernelSize = 1> class TestKernel;
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace detail {
-template <> struct KernelInfo<TestKernel> {
+template <size_t KernelSize> struct KernelInfo<TestKernel<KernelSize>> {
   static constexpr unsigned getNumParams() { return 0; }
   static const kernel_param_desc_t &getParamDesc(int) {
     static kernel_param_desc_t Dummy;
@@ -25,6 +25,7 @@ template <> struct KernelInfo<TestKernel> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
+  static constexpr long getKernelSize() { return KernelSize; }
 };
 
 } // namespace detail

--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -46,6 +46,7 @@ struct MockKernelInfo {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
+  static constexpr long getKernelSize() { return 1; }
 };
 
 template <> struct KernelInfo<TestKernel> : public MockKernelInfo {

--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -46,7 +46,7 @@ struct MockKernelInfo {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
-  static constexpr long getKernelSize() { return 1; }
+  static constexpr int64_t getKernelSize() { return 1; }
 };
 
 template <> struct KernelInfo<TestKernel> : public MockKernelInfo {

--- a/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
+++ b/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
@@ -151,11 +151,12 @@ TEST_F(MultipleDeviceCacheTest, ProgramRetain) {
 
     auto Bundle = cl::sycl::get_kernel_bundle<sycl::bundle_state::input>(
         Queue.get_context());
-    Queue.submit(
-        [&](cl::sycl::handler &cgh) { cgh.single_task<TestKernel>([]() {}); });
+    Queue.submit([&](cl::sycl::handler &cgh) {
+      cgh.single_task<TestKernel<>>([]() {});
+    });
 
     auto BundleObject = cl::sycl::build(Bundle, Bundle.get_devices());
-    auto KernelID = cl::sycl::get_kernel_id<TestKernel>();
+    auto KernelID = cl::sycl::get_kernel_id<TestKernel<>>();
     auto Kernel = BundleObject.get_kernel(KernelID);
 
     // Because of emulating 2 devices program is retained for each one in

--- a/sycl/unittests/misc/KernelBuildOptions.cpp
+++ b/sycl/unittests/misc/KernelBuildOptions.cpp
@@ -33,7 +33,7 @@ template <> struct KernelInfo<TestKernel> {
   static constexpr bool isESIMD() { return true; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
-  static constexpr long getKernelSize() { return 1; }
+  static constexpr int64_t getKernelSize() { return 1; }
 };
 
 } // namespace detail

--- a/sycl/unittests/misc/KernelBuildOptions.cpp
+++ b/sycl/unittests/misc/KernelBuildOptions.cpp
@@ -33,6 +33,7 @@ template <> struct KernelInfo<TestKernel> {
   static constexpr bool isESIMD() { return true; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
+  static constexpr long getKernelSize() { return 1; }
 };
 
 } // namespace detail

--- a/sycl/unittests/program_manager/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/EliminatedArgMask.cpp
@@ -20,8 +20,8 @@
 
 class EAMTestKernel;
 class EAMTestKernel2;
-const char EAMTestKernelName[] = "EAMTestKernel";
-const char EAMTestKernel2Name[] = "EAMTestKernel2";
+constexpr const char EAMTestKernelName[] = "EAMTestKernel";
+constexpr const char EAMTestKernel2Name[] = "EAMTestKernel2";
 constexpr unsigned EAMTestKernelNumArgs = 4;
 
 __SYCL_INLINE_NAMESPACE(cl) {
@@ -37,6 +37,7 @@ template <> struct KernelInfo<EAMTestKernel> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
+  static constexpr long getKernelSize() { return 1; }
 };
 
 template <> struct KernelInfo<EAMTestKernel2> {
@@ -49,6 +50,7 @@ template <> struct KernelInfo<EAMTestKernel2> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
+  static constexpr long getKernelSize() { return 1; }
 };
 
 } // namespace detail

--- a/sycl/unittests/program_manager/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/EliminatedArgMask.cpp
@@ -37,7 +37,7 @@ template <> struct KernelInfo<EAMTestKernel> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
-  static constexpr long getKernelSize() { return 1; }
+  static constexpr int64_t getKernelSize() { return 1; }
 };
 
 template <> struct KernelInfo<EAMTestKernel2> {
@@ -50,7 +50,7 @@ template <> struct KernelInfo<EAMTestKernel2> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
-  static constexpr long getKernelSize() { return 1; }
+  static constexpr int64_t getKernelSize() { return 1; }
 };
 
 } // namespace detail

--- a/sycl/unittests/program_manager/SubDevices.cpp
+++ b/sycl/unittests/program_manager/SubDevices.cpp
@@ -145,11 +145,11 @@ TEST(SubDevices, DISABLED_BuildProgramForSubdevices) {
   sycl::detail::ProgramManager::getInstance().getBuiltPIProgram(
       sycl::detail::OSUtil::getOSModuleHandle(&devBin),
       sycl::detail::getSyclObjImpl(Ctx), subDev1,
-      sycl::detail::KernelInfo<TestKernel>::getName());
+      sycl::detail::KernelInfo<TestKernel<>>::getName());
   // This call should re-use built binary from the cache. If piProgramBuild is
   // called again, the test will fail as second call of redefinedProgramBuild
   sycl::detail::ProgramManager::getInstance().getBuiltPIProgram(
       sycl::detail::OSUtil::getOSModuleHandle(&devBin),
       sycl::detail::getSyclObjImpl(Ctx), subDev2,
-      sycl::detail::KernelInfo<TestKernel>::getName());
+      sycl::detail::KernelInfo<TestKernel<>>::getName());
 }

--- a/sycl/unittests/program_manager/itt_annotations.cpp
+++ b/sycl/unittests/program_manager/itt_annotations.cpp
@@ -234,7 +234,7 @@ TEST(ITTNotify, UseKernelBundle) {
   auto ExecBundle = sycl::build(KernelBundle);
   Queue.submit([&](sycl::handler &CGH) {
     CGH.use_kernel_bundle(ExecBundle);
-    CGH.single_task<TestKernel>([] {}); // Actual kernel does not matter
+    CGH.single_task<TestKernel<>>([] {}); // Actual kernel does not matter
   });
 
   EXPECT_EQ(HasITTEnabled, true);
@@ -275,7 +275,7 @@ TEST(ITTNotify, VarNotSet) {
   auto ExecBundle = sycl::build(KernelBundle);
   Queue.submit([&](sycl::handler &CGH) {
     CGH.use_kernel_bundle(ExecBundle);
-    CGH.single_task<TestKernel>([] {}); // Actual kernel does not matter
+    CGH.single_task<TestKernel<>>([] {}); // Actual kernel does not matter
   });
 
   EXPECT_EQ(HasITTEnabled, false);

--- a/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
+++ b/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
@@ -37,7 +37,7 @@ template <> struct KernelInfo<EAMTestKernel1> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
-  static constexpr long getKernelSize() { return 1; }
+  static constexpr int64_t getKernelSize() { return 1; }
 };
 
 template <> struct KernelInfo<EAMTestKernel2> {
@@ -50,7 +50,7 @@ template <> struct KernelInfo<EAMTestKernel2> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
-  static constexpr long getKernelSize() { return 1; }
+  static constexpr int64_t getKernelSize() { return 1; }
 };
 
 } // namespace detail

--- a/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
+++ b/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
@@ -37,6 +37,7 @@ template <> struct KernelInfo<EAMTestKernel1> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
+  static constexpr long getKernelSize() { return 1; }
 };
 
 template <> struct KernelInfo<EAMTestKernel2> {
@@ -49,6 +50,7 @@ template <> struct KernelInfo<EAMTestKernel2> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
+  static constexpr long getKernelSize() { return 1; }
 };
 
 } // namespace detail

--- a/sycl/unittests/queue/GetProfilingInfo.cpp
+++ b/sycl/unittests/queue/GetProfilingInfo.cpp
@@ -34,7 +34,7 @@ template <> struct KernelInfo<InfoTestKernel> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
-  static constexpr long getKernelSize() { return 1; }
+  static constexpr int64_t getKernelSize() { return 1; }
 };
 
 } // namespace detail

--- a/sycl/unittests/queue/GetProfilingInfo.cpp
+++ b/sycl/unittests/queue/GetProfilingInfo.cpp
@@ -34,6 +34,7 @@ template <> struct KernelInfo<InfoTestKernel> {
   static constexpr bool isESIMD() { return false; }
   static constexpr bool callsThisItem() { return false; }
   static constexpr bool callsAnyThisFreeFunction() { return false; }
+  static constexpr long getKernelSize() { return 1; }
 };
 
 } // namespace detail

--- a/sycl/unittests/scheduler/InOrderQueueHostTaskDeps.cpp
+++ b/sycl/unittests/scheduler/InOrderQueueHostTaskDeps.cpp
@@ -59,7 +59,7 @@ TEST_F(SchedulerTest, InOrderQueueHostTaskDeps) {
 
   event Evt = InOrderQueue.submit([&](sycl::handler &CGH) {
     CGH.use_kernel_bundle(ExecBundle);
-    CGH.single_task<TestKernel>([] {});
+    CGH.single_task<TestKernel<>>([] {});
   });
   InOrderQueue
       .submit([&](sycl::handler &CGH) {

--- a/sycl/unittests/scheduler/RequiredWGSize.cpp
+++ b/sycl/unittests/scheduler/RequiredWGSize.cpp
@@ -221,7 +221,7 @@ static void performChecks() {
   auto ExecBundle = sycl::build(KernelBundle);
   Queue.submit([&](sycl::handler &CGH) {
     CGH.use_kernel_bundle(ExecBundle);
-    CGH.single_task<TestKernel>([] {}); // Actual kernel does not matter
+    CGH.single_task<TestKernel<>>([] {}); // Actual kernel does not matter
   });
 
   EXPECT_EQ(KernelGetGroupInfoCalled, true);

--- a/sycl/unittests/stream/stream.cpp
+++ b/sycl/unittests/stream/stream.cpp
@@ -73,7 +73,7 @@ TEST(Stream, TestStreamConstructorExceptionNoAllocation) {
       FAIL() << "Unexpected exception was thrown.";
     }
 
-    CGH.single_task<TestKernel>([=]() {});
+    CGH.single_task<TestKernel<>>([=]() {});
   });
 
   ASSERT_EQ(GBufferCreateCounter, 0u) << "Buffers were unexpectedly created.";


### PR DESCRIPTION
Some host-compilers may create lambdas with captures that do not match the ones used when extracting kernel descriptors. The compiler does not currently have a stable way of handling these cases, so instead this PR adds a static assertion that the sizes match with a message informing about the limitation.