### PR TITLE
[SYCL] Use checkArgCountAtLeast instead

### DIFF
--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -123,6 +123,21 @@ static bool checkArgCountAtLeast(Sema &S, CallExpr *Call,
          << Call->getSourceRange();
 }
 
+/// Checks that a call expression's argument count is at most the desired
+/// number. This is useful when doing custom type-checking on a variadic
+/// function. Returns true on error.
+static bool checkArgCountAtMost(Sema &S, CallExpr *Call,
+                                unsigned MaxArgCount) {
+  unsigned ArgCount = Call->getNumArgs();
+  if (ArgCount <= MaxArgCount)
+    return false;
+
+  return S.Diag(Call->getEndLoc(),
+                diag::err_typecheck_call_too_many_args_at_most)
+         << 0 /*function call*/ << MaxArgCount << ArgCount
+         << Call->getSourceRange();
+}
+
 /// Checks that a call expression's argument count is the desired number.
 /// This is useful when doing custom type-checking.  Returns true on error.
 static bool checkArgCount(Sema &S, CallExpr *Call, unsigned DesiredArgCount) {
@@ -5493,11 +5508,8 @@ bool Sema::CheckIntelFPGAMemBuiltinFunctionCall(CallExpr *TheCall) {
     return true;
 
   // Make sure we don't have too many arguments.
-  if (NumArgs > MaxNumArgs)
-    return Diag(TheCall->getEndLoc(),
-                diag::err_typecheck_call_too_many_args_at_most)
-           << 0 /*function call*/ << MaxNumArgs << NumArgs
-           << TheCall->getSourceRange();
+  if (checkArgCountAtMost(*this, TheCall, MaxNumArgs))
+    return true;
 
   Expr *PointerArg = TheCall->getArg(0);
   QualType PointerArgType = PointerArg->getType();
@@ -7660,10 +7672,8 @@ ExprResult Sema::SemaConvertVectorExpr(Expr *E, TypeSourceInfo *TInfo,
 bool Sema::SemaBuiltinPrefetch(CallExpr *TheCall) {
   unsigned NumArgs = TheCall->getNumArgs();
 
-  if (NumArgs > 3)
-    return Diag(TheCall->getEndLoc(),
-                diag::err_typecheck_call_too_many_args_at_most)
-           << 0 /*function call*/ << 3 << NumArgs << TheCall->getSourceRange();
+  if (checkArgCountAtMost(*this, TheCall, 3))
+    return true;
 
   // Argument 0 is checked for us and the remaining arguments must be
   // constant integers.
@@ -7751,10 +7761,8 @@ bool Sema::SemaBuiltinAllocaWithAlign(CallExpr *TheCall) {
 bool Sema::SemaBuiltinAssumeAligned(CallExpr *TheCall) {
   unsigned NumArgs = TheCall->getNumArgs();
 
-  if (NumArgs > 3)
-    return Diag(TheCall->getEndLoc(),
-                diag::err_typecheck_call_too_many_args_at_most)
-           << 0 /*function call*/ << 3 << NumArgs << TheCall->getSourceRange();
+  if (checkArgCountAtMost(*this, TheCall, 3))
+    return true;
 
   // The alignment must be a constant integer.
   Expr *Arg = TheCall->getArg(1);
@@ -7798,12 +7806,8 @@ bool Sema::SemaBuiltinOSLogFormat(CallExpr *TheCall) {
            << 0 /* function call */ << NumRequiredArgs << NumArgs
            << TheCall->getSourceRange();
   }
-  if (NumArgs >= NumRequiredArgs + 0x100) {
-    return Diag(TheCall->getEndLoc(),
-                diag::err_typecheck_call_too_many_args_at_most)
-           << 0 /* function call */ << (NumRequiredArgs + 0xff) << NumArgs
-           << TheCall->getSourceRange();
-  }
+  if (checkArgCountAtMost(*this, TheCall, NumRequiredArgs + 0xff))
+    return true;
   unsigned i = 0;
 
   // For formatting call, check buffer arg.

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -5489,11 +5489,8 @@ bool Sema::CheckIntelFPGAMemBuiltinFunctionCall(CallExpr *TheCall) {
   unsigned NumArgs = TheCall->getNumArgs();
 
   // Make sure we have the minimum number of provided arguments.
-  if (NumArgs < MinNumArgs)
-    return Diag(TheCall->getEndLoc(),
-                diag::err_typecheck_call_too_few_args_at_least)
-           << 0 /* function call */ << MinNumArgs << NumArgs
-           << TheCall->getSourceRange();
+  if (checkArgCountAtLeast(*this, TheCall, MinNumArgs))
+    return true;
 
   // Make sure we don't have too many arguments.
   if (NumArgs > MaxNumArgs)

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -126,8 +126,7 @@ static bool checkArgCountAtLeast(Sema &S, CallExpr *Call,
 /// Checks that a call expression's argument count is at most the desired
 /// number. This is useful when doing custom type-checking on a variadic
 /// function. Returns true on error.
-static bool checkArgCountAtMost(Sema &S, CallExpr *Call,
-                                unsigned MaxArgCount) {
+static bool checkArgCountAtMost(Sema &S, CallExpr *Call, unsigned MaxArgCount) {
   unsigned ArgCount = Call->getNumArgs();
   if (ArgCount <= MaxArgCount)
     return false;

--- a/clang/test/SemaSYCL/intel-fpga-mem-builtin.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-mem-builtin.cpp
@@ -32,7 +32,7 @@ void foo(float *A, int *B, State *C) {
   x = __builtin_intel_fpga_mem(A, PARAM_1 | PARAM_2, -1);
   // expected-error@-1{{builtin parameter must be a non-negative integer constant}}
   x = __builtin_intel_fpga_mem(A, PARAM_1 | PARAM_2);
-  // expected-error@-1{{too few arguments to function call, expected at least 3, have 2}}
+  // expected-error@-1{{too few arguments to function call, expected 3, have 2}}
   y = __builtin_intel_fpga_mem(B, 0, i);
   // expected-error@-1{{argument to '__builtin_intel_fpga_mem' must be a constant integer}}
   z = __builtin_intel_fpga_mem(C, i, 0);


### PR DESCRIPTION
Rather than replicate the code, call existing routine checkArgCountAtLeast
for similar functionality.

Add a similar routine checkArgCountAtMost to check if a call expression's
argument count exceeds the most expected.  Replace where equivalent
with calls to this routine.