### PR TITLE
[SYCL] Throw exception for pipe extension on host

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/pipes.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/pipes.hpp
@@ -75,7 +75,9 @@ public:
 #else
     (void)Success;
     (void)Properties;
-    assert(!"Pipes are not supported on a host device!");
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Pipes are not supported on a host device.");
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -122,7 +124,9 @@ public:
     (void)Success;
     (void)Data;
     (void)Properties;
-    assert(!"Pipes are not supported on a host device!");
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Pipes are not supported on a host device.");
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -169,7 +173,9 @@ public:
     return TempData;
 #else
     (void)Properties;
-    assert(!"Pipes are not supported on a host device!");
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Pipes are not supported on a host device.");
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -212,7 +218,9 @@ public:
 #else
     (void)Data;
     (void)Properties;
-    assert(!"Pipes are not supported on a host device!");
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Pipes are not supported on a host device.");
 #endif // __SYCL_DEVICE_ONLY__
   }
 

--- a/sycl/include/sycl/ext/intel/pipes.hpp
+++ b/sycl/include/sycl/ext/intel/pipes.hpp
@@ -34,7 +34,9 @@ public:
     return TempData;
 #else
     (void)_Success;
-    assert(!"Pipes are not supported on a host device!");
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Pipes are not supported on a host device.");
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -49,7 +51,9 @@ public:
 #else
     (void)_Success;
     (void)_Data;
-    assert(!"Pipes are not supported on a host device!");
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Pipes are not supported on a host device.");
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -64,7 +68,9 @@ public:
     __spirv_ReadPipeBlockingINTEL(_RPipe, &TempData, m_Size, m_Alignment);
     return TempData;
 #else
-    assert(!"Pipes are not supported on a host device!");
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Pipes are not supported on a host device.");
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -77,7 +83,9 @@ public:
     __spirv_WritePipeBlockingINTEL(_WPipe, &_Data, m_Size, m_Alignment);
 #else
     (void)_Data;
-    assert(!"Pipes are not supported on a host device!");
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Pipes are not supported on a host device.");
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -128,7 +136,9 @@ public:
     return TempData;
 #else
     (void)_Success;
-    assert(!"Pipes are not supported on a host device!");
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Pipes are not supported on a host device.");
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -143,7 +153,9 @@ public:
     __spirv_ReadPipeBlockingINTEL(_RPipe, &TempData, m_Size, m_Alignment);
     return TempData;
 #else
-    assert(!"Pipes are not supported on a host device!");
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Pipes are not supported on a host device.");
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -174,7 +186,9 @@ public:
 #else
     (void)_Data;
     (void)_Success;
-    assert(!"Pipes are not supported on a host device!");
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Pipes are not supported on a host device.");
 #endif // __SYCL_DEVICE_ONLY__
   }
 
@@ -188,7 +202,9 @@ public:
     __spirv_WritePipeBlockingINTEL(_WPipe, &_Data, m_Size, m_Alignment);
 #else
     (void)_Data;
-    assert(!"Pipes are not supported on a host device!");
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Pipes are not supported on a host device.");
 #endif // __SYCL_DEVICE_ONLY__
   }
 


### PR DESCRIPTION
The implementation of the pipes extension currently uses a failing assert when pipe operations are done on host. This commit changes these assertions into throwing a SYCL exception, both allowing for failure recovery and makes the failures independent on whether assertions are enabled.