### PR TITLE
[SYCL] Remove experimental/builtins.hpp from sycl.hpp due to C++17

### DIFF
--- a/sycl/include/CL/sycl.hpp
+++ b/sycl/include/CL/sycl.hpp
@@ -61,7 +61,6 @@
 #include <sycl/ext/oneapi/backend/level_zero.hpp>
 #endif
 #include <sycl/ext/oneapi/device_global/properties.hpp>
-#include <sycl/ext/oneapi/experimental/builtins.hpp>
 #include <sycl/ext/oneapi/experimental/cuda/barrier.hpp>
 #include <sycl/ext/oneapi/filter_selector.hpp>
 #include <sycl/ext/oneapi/group_algorithm.hpp>

--- a/sycl/test/basic_tests/built-ins.cpp
+++ b/sycl/test/basic_tests/built-ins.cpp
@@ -7,7 +7,8 @@
 // Hits an assertion with AMD:
 // XFAIL: hip_amd
 
-#include <CL/sycl.hpp>
+#include <sycl/ext/oneapi/experimental/builtins.hpp>
+#include <sycl/sycl.hpp>
 
 #include <cassert>
 

--- a/sycl/test/extensions/experimental-printf.cpp
+++ b/sycl/test/extensions/experimental-printf.cpp
@@ -16,7 +16,8 @@
 // CHECK: Constant [[#TYPE]] [[#CONST:]]
 // CHECK: ExtInst [[#]] [[#]] [[#]] printf [[#]] [[#CONST]]
 
-#include <CL/sycl.hpp>
+#include <sycl/ext/oneapi/experimental/builtins.hpp>
+#include <sycl/sycl.hpp>
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define __SYCL_CONSTANT_AS __attribute__((opencl_constant))


### PR DESCRIPTION
C++17 usage of `if constexpr` etc was added to experimental/builtins.hpp as requested in https://github.com/intel/llvm/pull/5964, but I did not remove this header from sycl.hpp since there were no failing tests and I didn't notice it was included in sycl.hpp. Apparently sycl.hpp should not include any usage of C++17. This may be related to some of the failing tests that appear only on the CI: https://github.com/intel/llvm-test-suite/pull/975#issuecomment-1171981161. Necessary changes to the tests are added here : https://github.com/intel/llvm-test-suite/pull/1072

Signed-off-by: JackAKirk <jack.kirk@codeplay.com>