### PR TITLE
Emit a diagnostic if a generic lambda is used to name a kernel

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11699,6 +11699,9 @@ def err_sycl_kernel_incorrectly_named : Error<
   "'-fsycl-unnamed-lambda' to enable unnamed kernel lambdas"
   "}0">;
 
+def err_sycl_kernel_generic_lambda_unsupported: Error<
+  "generic lambda cannot be used to name a kernel">;
+
 def err_sycl_kernel_not_function_object
     : Error<"kernel parameter must be a lambda or function object">;
 def err_sycl_restrict : Error<

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3486,6 +3486,16 @@ void Sema::CheckSYCLKernelCall(FunctionDecl *KernelFunc, SourceRange CallLoc,
     return;
   }
 
+  // Emit error if lambda or operator() that is not fully instantiated
+  // are used to name a SYCL kernel.
+  if (auto *lambda = KernelNameType->getAsCXXRecordDecl()) {
+    if (lambda->isGenericLambda()) {
+      Diag(KernelObj->getLocation(),
+           diag::err_sycl_kernel_generic_lambda_unsupported)
+          << KernelObj;
+    }
+  }
+
   if (KernelObj->isLambda()) {
     for (const LambdaCapture &LC : KernelObj->captures())
       if (LC.capturesThis() && LC.isImplicit()) {
@@ -3649,18 +3659,6 @@ void Sema::ConstructOpenCLKernel(FunctionDecl *KernelCallerFunc,
     return;
 
   {
-    // Emit error if lambda or operator() that is not fully instantiated
-    // are used to name a SYCL kernel.
-    QualType KernelNameType =
-        calculateKernelNameType(Context, KernelCallerFunc);
-    if (auto *lambda = KernelNameType->getAsCXXRecordDecl()) {
-      if (lambda->isGenericLambda()) {
-        Diag(KernelObj->getLocation(),
-             diag::err_sycl_kernel_generic_lambda_unsupported)
-            << KernelObj;
-      }
-    }
-
     // Do enough to calculate the StableName for the purposes of the hackery
     // below for __pf_kernel_wrapper. Placed in a scope so that we don't
     // accidentially use these values below, before the names are stabililzed.

--- a/sycl/test/check_device_code/no_offset.cpp
+++ b/sycl/test/check_device_code/no_offset.cpp
@@ -16,9 +16,7 @@ int main() {
             sycl::accessor acc_a(a, cgh, sycl::write_only, PL);
             sycl::accessor acc_b{b, cgh, sycl::read_only};
             // CHECK: define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_EUliE_(i32 addrspace(1)* {{.*}}, i32 addrspace(1)* noundef readonly {{.*}}, %"class.cl::sycl::id"* noundef byval(%"class.cl::sycl::id") align 8 {{.*}})
-            cgh.parallel_for(size, [=](int i) {
-                acc_a[i] = acc_b[i];
-            });
+            cgh.parallel_for(size, [=](int i) { acc_a[i] = acc_b[i]; });
         });
 
         q.wait();
@@ -34,9 +32,7 @@ int main() {
             sycl::accessor acc_a(a, cgh, sycl::write_only);
             sycl::accessor acc_b{b, cgh, sycl::read_only};
             // CHECK: define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE0_clES2_EUliE_(i32 addrspace(1)* {{.*}}, %"class.cl::sycl::id"* noundef byval(%"class.cl::sycl::id") align 8 {{.*}}, i32 addrspace(1)* noundef readonly {{.*}}, %"class.cl::sycl::id"* noundef byval(%"class.cl::sycl::id") align 8 {{.*}})
-            cgh.parallel_for(size, [=](int i) {
-                acc_a[i] = acc_b[i];
-            });
+            cgh.parallel_for(size, [=](int i) { acc_a[i] = acc_b[i]; });
         });
 
         q.wait();

--- a/sycl/test/check_device_code/no_offset.cpp
+++ b/sycl/test/check_device_code/no_offset.cpp
@@ -15,8 +15,8 @@ int main() {
             sycl::ext::oneapi::accessor_property_list PL{sycl::ext::oneapi::no_offset, sycl::no_init};
             sycl::accessor acc_a(a, cgh, sycl::write_only, PL);
             sycl::accessor acc_b{b, cgh, sycl::read_only};
-            // CHECK: define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_EUlT_E_(i32 addrspace(1)* {{.*}}, i32 addrspace(1)* noundef readonly {{.*}}, %"class.cl::sycl::id"* noundef byval(%"class.cl::sycl::id") align 8 {{.*}})
-            cgh.parallel_for(size, [=](auto i) {
+            // CHECK: define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE_clES2_EUliE_(i32 addrspace(1)* {{.*}}, i32 addrspace(1)* noundef readonly {{.*}}, %"class.cl::sycl::id"* noundef byval(%"class.cl::sycl::id") align 8 {{.*}})
+            cgh.parallel_for(size, [=](int i) {
                 acc_a[i] = acc_b[i];
             });
         });
@@ -33,8 +33,8 @@ int main() {
         q.submit([&](sycl::handler &cgh) {
             sycl::accessor acc_a(a, cgh, sycl::write_only);
             sycl::accessor acc_b{b, cgh, sycl::read_only};
-            // CHECK: define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE0_clES2_EUlT_E_(i32 addrspace(1)* {{.*}}, %"class.cl::sycl::id"* noundef byval(%"class.cl::sycl::id") align 8 {{.*}}, i32 addrspace(1)* noundef readonly {{.*}}, %"class.cl::sycl::id"* noundef byval(%"class.cl::sycl::id") align 8 {{.*}})
-            cgh.parallel_for(size, [=](auto i) {
+            // CHECK: define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN2cl4sycl7handlerEE0_clES2_EUliE_(i32 addrspace(1)* {{.*}}, %"class.cl::sycl::id"* noundef byval(%"class.cl::sycl::id") align 8 {{.*}}, i32 addrspace(1)* noundef readonly {{.*}}, %"class.cl::sycl::id"* noundef byval(%"class.cl::sycl::id") align 8 {{.*}})
+            cgh.parallel_for(size, [=](int i) {
                 acc_a[i] = acc_b[i];
             });
         });

--- a/sycl/test/regression/unnamed-lambda-split-order.cpp
+++ b/sycl/test/regression/unnamed-lambda-split-order.cpp
@@ -7,8 +7,8 @@
 // builtin being invalidated, causing a compile error. The redesigned
 // implementation should no longer have a problem with this pattern.
 int main() {
-  auto w = [](auto i) {};
+  auto w = [](int i) {};
   sycl::queue q;
-  q.parallel_for(10, [](auto i) {});
+  q.parallel_for(10, [](int i) {});
   q.parallel_for(10, w);
 }


### PR DESCRIPTION
This patch implements:
1. Diagnostic to throw an error if an generic lambda/uninstantiated type is used to name a SYCL kernel. 
2. Modifies (failing) lit tests which use generic lambda(s) for naming a kernel.