### PR TITLE
[SYCL] empty event constructor, more explicit host event handling

### DIFF
--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -128,12 +128,9 @@ void event_impl::setContextImpl(const ContextImplPtr &Context) {
   MIsContextInitialized = true;
 }
 
-event_impl::event_impl(bool)
-    : MIsInitialized(false), MHostEvent(false), MIsFlushed(true),
-      MState(HES_Complete) {}
-
-event_impl::event_impl(HostEventState State)
-    : MIsInitialized(false), MIsFlushed(true), MState(State) {}
+event_impl::event_impl(std::optional<HostEventState> State)
+    : MIsInitialized(false), MHostEvent(State), MIsFlushed(true),
+      MState(State.value_or(HES_Complete)) {}
 
 event_impl::event_impl(RT::PiEvent Event, const context &SyclContext)
     : MIsContextInitialized(true), MEvent(Event),

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -40,10 +40,14 @@ public:
     HES_Discarded
   };
 
+  /// Construct empty SYCL event
+  event_impl(bool);
+
   /// Constructs a ready SYCL event.
   ///
   /// If the constructed SYCL event is waited on it will complete immediately.
   event_impl(HostEventState State = HES_Complete);
+
   /// Constructs an event instance from a plug-in event handle.
   ///
   /// The SyclContext must match the plug-in context associated with the

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -40,13 +40,12 @@ public:
     HES_Discarded
   };
 
-  /// Construct empty SYCL event
-  event_impl(bool);
-
   /// Constructs a ready SYCL event.
   ///
   /// If the constructed SYCL event is waited on it will complete immediately.
-  event_impl(HostEventState State = HES_Complete);
+  /// Normally constructs a host event, use std::nullopt to instead instantiate
+  /// a device event.
+  event_impl(std::optional<HostEventState> State = HES_Complete);
 
   /// Constructs an event instance from a plug-in event handle.
   ///

--- a/sycl/source/detail/helpers.cpp
+++ b/sycl/source/detail/helpers.cpp
@@ -23,10 +23,11 @@ std::vector<RT::PiEvent> getOrWaitEvents(std::vector<cl::sycl::event> DepEvents,
   std::vector<RT::PiEvent> Events;
   for (auto SyclEvent : DepEvents) {
     auto SyclEventImplPtr = detail::getSyclObjImpl(SyclEvent);
-    // throwaway events created with default constructor will not have a context
-    // (which is set lazily) calling is_host(), getContextImpl() would set that
+    // throwaway events created with empty constructor will not have a context
+    // (which is set lazily) calling getContextImpl() would set that
     // context, which we wish to avoid as it is expensive.
-    if (SyclEventImplPtr->MIsContextInitialized == false) {
+    if (SyclEventImplPtr->MIsContextInitialized == false &&
+        !SyclEventImplPtr->is_host()) {
       continue;
     }
     if (SyclEventImplPtr->is_host() ||

--- a/sycl/source/event.cpp
+++ b/sycl/source/event.cpp
@@ -22,7 +22,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
-event::event() : impl(std::make_shared<detail::event_impl>()) {}
+event::event() : impl(std::make_shared<detail::event_impl>(true)) {}
 
 event::event(cl_event ClEvent, const context &SyclContext)
     : impl(std::make_shared<detail::event_impl>(

--- a/sycl/source/event.cpp
+++ b/sycl/source/event.cpp
@@ -22,7 +22,7 @@
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 
-event::event() : impl(std::make_shared<detail::event_impl>(true)) {}
+event::event() : impl(std::make_shared<detail::event_impl>(std::nullopt)) {}
 
 event::event(cl_event ClEvent, const context &SyclContext)
     : impl(std::make_shared<detail::event_impl>(


### PR DESCRIPTION
making host events more explicit. simplifies the logic, makes checking for host (or not) simpler, and reduces potential contention.  This is a follow up to https://github.com/intel/llvm/pull/6296

Signed-off-by: Chris Perkins <chris.perkins@intel.com>