### PR TITLE
[SYCL][CUDA] Compile .cu files with SYCL 

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -1643,6 +1643,7 @@ void CodeGenFunction::GenerateCode(GlobalDecl GD, llvm::Function *Fn,
   else if (getLangOpts().CUDA && !getLangOpts().CUDAIsDevice &&
            getLangOpts().SYCLIsHost && !FD->hasAttr<CUDAHostAttr>() &&
            FD->hasAttr<CUDADeviceAttr>()) {
+    // Generate a dummy __host__ function for compiling CUDA sources in SYCL.
     Fn->setLinkage(llvm::Function::WeakODRLinkage);
     if (FD->getReturnType()->isVoidType())
       Builder.CreateRetVoid();

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -1640,8 +1640,17 @@ void CodeGenFunction::GenerateCode(GlobalDecl GD, llvm::Function *Fn,
            !getLangOpts().CUDAIsDevice &&
            FD->hasAttr<CUDAGlobalAttr>())
     CGM.getCUDARuntime().emitDeviceStub(*this, Args);
-  else if (isa<CXXMethodDecl>(FD) &&
-           cast<CXXMethodDecl>(FD)->isLambdaStaticInvoker()) {
+  else if (getLangOpts().CUDA && !getLangOpts().CUDAIsDevice &&
+           getLangOpts().SYCLIsHost && !FD->hasAttr<CUDAHostAttr>() &&
+           FD->hasAttr<CUDADeviceAttr>()) {
+    Fn->setLinkage(llvm::Function::WeakODRLinkage);
+    if (FD->getReturnType()->isVoidType())
+      Builder.CreateRetVoid();
+    else
+      Builder.CreateRet(llvm::UndefValue::get(Fn->getReturnType()));
+    return;
+  } else if (isa<CXXMethodDecl>(FD) &&
+             cast<CXXMethodDecl>(FD)->isLambdaStaticInvoker()) {
     // The lambda static invoker function is special, because it forwards or
     // clones the body of the function call operator (but is actually static).
     EmitLambdaStaticInvokeBody(cast<CXXMethodDecl>(FD));

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -1650,7 +1650,8 @@ void CodeGenFunction::GenerateCode(GlobalDecl GD, llvm::Function *Fn,
     else
       Builder.CreateRet(llvm::UndefValue::get(Fn->getReturnType()));
     return;
-  } else if (isa<CXXMethodDecl>(FD) &&
+  }
+  if (isa<CXXMethodDecl>(FD) &&
              cast<CXXMethodDecl>(FD)->isLambdaStaticInvoker()) {
     // The lambda static invoker function is special, because it forwards or
     // clones the body of the function call operator (but is actually static).

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2708,6 +2708,8 @@ void CodeGenModule::EmitDeferred() {
   CurDeclsToEmit.swap(DeferredDeclsToEmit);
 
   for (GlobalDecl &D : CurDeclsToEmit) {
+    // Emit a dummy __host__ function if a legit one is not already present in
+    // case of SYCL compilation of CUDA sources.
     if (LangOpts.CUDA && LangOpts.SYCLIsHost) {
       GlobalDecl OtherD;
       if (lookupRepresentativeDecl(getMangledName(D), OtherD) &&
@@ -3336,9 +3338,12 @@ void CodeGenModule::EmitGlobal(GlobalDecl GD) {
       // size and host-side address in order to provide access to
       // their device-side incarnations.
 
-      // So device-only functions are the only things we skip.
+      // So device-only functions are the only things we skip, except for SYCL.
       if (isa<FunctionDecl>(Global) && !Global->hasAttr<CUDAHostAttr>() &&
           Global->hasAttr<CUDADeviceAttr>()) {
+        // In SYCL, every (CUDA) __device__ function needs to have an __host__
+        // counterpart that will be emitted in case of it is not already
+        // present.
         if (LangOpts.SYCLIsHost && MustBeEmitted(Global) &&
             MayBeEmittedEagerly(Global))
           addDeferredDeclToEmit(GD);

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -3341,7 +3341,7 @@ void CodeGenModule::EmitGlobal(GlobalDecl GD) {
       // So device-only functions are the only things we skip, except for SYCL.
       if (isa<FunctionDecl>(Global) && !Global->hasAttr<CUDAHostAttr>() &&
           Global->hasAttr<CUDADeviceAttr>()) {
-        // In SYCL, every (CUDA) __device__ function needs to have an __host__
+        // In SYCL, every (CUDA) __device__ function needs to have a __host__
         // counterpart that will be emitted in case of it is not already
         // present.
         if (LangOpts.SYCLIsHost && MustBeEmitted(Global) &&

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2710,7 +2710,7 @@ void CodeGenModule::EmitDeferred() {
   for (GlobalDecl &D : CurDeclsToEmit) {
     // Emit a dummy __host__ function if a legit one is not already present in
     // case of SYCL compilation of CUDA sources.
-    if (LangOpts.CUDA && LangOpts.SYCLIsHost) {
+    if (LangOpts.CUDA && !LangOpts.CUDAIsDevice && LangOpts.SYCLIsHost) {
       GlobalDecl OtherD;
       if (lookupRepresentativeDecl(getMangledName(D), OtherD) &&
           (D.getCanonicalDecl().getDecl() !=

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5581,9 +5581,8 @@ public:
 
   void pushForeignAction(Action *A) {
     for (auto *SB : SpecializedBuilders) {
-      if (SB->isValid()) {
+      if (SB->isValid())
         SB->pushForeignAction(A);
-      }
     }
   }
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3520,6 +3520,9 @@ class OffloadingActionBuilder final {
     Action::OffloadKind getAssociatedOffloadKind() {
       return AssociatedOffloadKind;
     }
+
+    /// Push an action from a different DeviceActionBuilder (i.e., foreign
+    /// action) in the current one
     virtual void pushForeignAction(Action *A) {}
   };
 
@@ -4524,6 +4527,8 @@ class OffloadingActionBuilder final {
     }
 
     void pushForeignAction(Action *A) override {
+      // Accept a foreign action from the CudaActionBuilder for compiling CUDA
+      // sources
       if (A->getOffloadingDeviceKind() == Action::OFK_Cuda) {
         ExternalCudaAction = A;
       }
@@ -5579,6 +5584,8 @@ public:
       delete SB;
   }
 
+  /// Push an action coming from a specialized DeviceActionBuilder (i.e.,
+  /// foreign action) to the other ones
   void pushForeignAction(Action *A) {
     for (auto *SB : SpecializedBuilders) {
       if (SB->isValid())

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3458,12 +3458,17 @@ class OffloadingActionBuilder final {
     /// The associated offload kind.
     Action::OffloadKind AssociatedOffloadKind = Action::OFK_None;
 
+    /// The OffloadingActionBuilder reference.
+    OffloadingActionBuilder &OffloadingActionBuilderRef;
+
   public:
     DeviceActionBuilder(Compilation &C, DerivedArgList &Args,
                         const Driver::InputList &Inputs,
-                        Action::OffloadKind AssociatedOffloadKind)
+                        Action::OffloadKind AssociatedOffloadKind,
+                        OffloadingActionBuilder &OAB)
         : C(C), Args(Args), Inputs(Inputs),
-          AssociatedOffloadKind(AssociatedOffloadKind) {}
+          AssociatedOffloadKind(AssociatedOffloadKind),
+          OffloadingActionBuilderRef(OAB) {}
     virtual ~DeviceActionBuilder() {}
 
     /// Fill up the array \a DA with all the device dependences that should be
@@ -3515,6 +3520,7 @@ class OffloadingActionBuilder final {
     Action::OffloadKind getAssociatedOffloadKind() {
       return AssociatedOffloadKind;
     }
+    virtual void pushForeignAction(Action *A) {}
   };
 
   /// Base class for CUDA/HIP action builder. It injects device code in
@@ -3569,8 +3575,9 @@ class OffloadingActionBuilder final {
   public:
     CudaActionBuilderBase(Compilation &C, DerivedArgList &Args,
                           const Driver::InputList &Inputs,
-                          Action::OffloadKind OFKind)
-        : DeviceActionBuilder(C, Args, Inputs, OFKind) {}
+                          Action::OffloadKind OFKind,
+                          OffloadingActionBuilder &OAB)
+        : DeviceActionBuilder(C, Args, Inputs, OFKind, OAB) {}
 
     ActionBuilderReturnCode addDeviceDepences(Action *HostAction) override {
       // While generating code for CUDA, we only depend on the host input action
@@ -3826,8 +3833,9 @@ class OffloadingActionBuilder final {
   class CudaActionBuilder final : public CudaActionBuilderBase {
   public:
     CudaActionBuilder(Compilation &C, DerivedArgList &Args,
-                      const Driver::InputList &Inputs)
-        : CudaActionBuilderBase(C, Args, Inputs, Action::OFK_Cuda) {
+                      const Driver::InputList &Inputs,
+                      OffloadingActionBuilder &OAB)
+        : CudaActionBuilderBase(C, Args, Inputs, Action::OFK_Cuda, OAB) {
       DefaultCudaArch = CudaArch::SM_35;
     }
 
@@ -3844,6 +3852,10 @@ class OffloadingActionBuilder final {
     getConflictOffloadArchCombination(
         const std::set<StringRef> &GpuArchs) override {
       return llvm::None;
+    }
+
+    bool canUseBundlerUnbundler() const override {
+      return Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false);
     }
 
     ActionBuilderReturnCode
@@ -3943,8 +3955,21 @@ class OffloadingActionBuilder final {
                                            "before the backend phase!");
 
       // By default, we produce an action for each device arch.
-      for (Action *&A : CudaDeviceActions)
-        A = C.getDriver().ConstructPhaseAction(C, Args, CurPhase, A);
+      for (unsigned I = 0, E = GpuArchList.size(); I != E; ++I) {
+
+        CudaDeviceActions[I] = C.getDriver().ConstructPhaseAction(
+            C, Args, CurPhase, CudaDeviceActions[I]);
+
+        if (CurPhase == phases::Compile) {
+          OffloadAction::DeviceDependences DDep;
+          DDep.add(*CudaDeviceActions[I], *ToolChains.front(), GpuArchList[I],
+                   Action::OFK_Cuda);
+
+          OffloadingActionBuilderRef.pushForeignAction(
+              C.MakeAction<OffloadAction>(
+                  DDep, DDep.getActions().front()->getType()));
+        }
+      }
 
       return ABRT_Success;
     }
@@ -3963,8 +3988,9 @@ class OffloadingActionBuilder final {
 
   public:
     HIPActionBuilder(Compilation &C, DerivedArgList &Args,
-                     const Driver::InputList &Inputs)
-        : CudaActionBuilderBase(C, Args, Inputs, Action::OFK_HIP) {
+                     const Driver::InputList &Inputs,
+                     OffloadingActionBuilder &OAB)
+        : CudaActionBuilderBase(C, Args, Inputs, Action::OFK_HIP, OAB) {
       DefaultCudaArch = CudaArch::GFX803;
       if (Args.hasArg(options::OPT_gpu_bundle_output,
                       options::OPT_no_gpu_bundle_output))
@@ -4205,8 +4231,9 @@ class OffloadingActionBuilder final {
 
   public:
     OpenMPActionBuilder(Compilation &C, DerivedArgList &Args,
-                        const Driver::InputList &Inputs)
-        : DeviceActionBuilder(C, Args, Inputs, Action::OFK_OpenMP) {}
+                        const Driver::InputList &Inputs,
+                        OffloadingActionBuilder &OAB)
+        : DeviceActionBuilder(C, Args, Inputs, Action::OFK_OpenMP, OAB) {}
 
     ActionBuilderReturnCode
     getDeviceDependences(OffloadAction::DeviceDependences &DA,
@@ -4475,10 +4502,13 @@ class OffloadingActionBuilder final {
       return HIPFatBinary;
     }
 
+    Action *ExternalCudaAction = nullptr;
+
   public:
     SYCLActionBuilder(Compilation &C, DerivedArgList &Args,
-                      const Driver::InputList &Inputs)
-        : DeviceActionBuilder(C, Args, Inputs, Action::OFK_SYCL) {}
+                      const Driver::InputList &Inputs,
+                      OffloadingActionBuilder &OAB)
+        : DeviceActionBuilder(C, Args, Inputs, Action::OFK_SYCL, OAB) {}
 
     void withBoundArchForToolChain(const ToolChain *TC,
                                    llvm::function_ref<void(const char *)> Op) {
@@ -4491,6 +4521,12 @@ class OffloadingActionBuilder final {
 
       // no bound arch for this toolchain
       Op(nullptr);
+    }
+
+    void pushForeignAction(Action *A) override {
+      if (A->getOffloadingDeviceKind() == Action::OFK_Cuda) {
+        ExternalCudaAction = A;
+      }
     }
 
     ActionBuilderReturnCode
@@ -4527,6 +4563,12 @@ class OffloadingActionBuilder final {
 
       // Device compilation generates LLVM BC.
       if (CurPhase == phases::Compile && !SYCLTargetInfoList.empty()) {
+        // TODO: handle stubfile handling when mix and matching programming
+        // model.
+        if (SYCLDeviceActions.empty()) {
+          return ABRT_Success;
+        }
+
         Action *DeviceCompilerInput = nullptr;
         for (Action *&A : SYCLDeviceActions) {
           types::ID OutputType = types::TY_LLVM_BC;
@@ -4575,6 +4617,14 @@ class OffloadingActionBuilder final {
 
             LinkerList.push_back(A);
           }
+        }
+
+        if (ExternalCudaAction) {
+          assert(DeviceLinkerInputs.size() == 1 &&
+                 "Number of SYCL actions and toolchains/boundarch pairs do not "
+                 "match.");
+          DeviceLinkerInputs[0].push_back(ExternalCudaAction);
+          ExternalCudaAction = nullptr;
         }
 
         // With -fsycl-link-targets, we will take the unbundled binaries
@@ -4682,6 +4732,10 @@ class OffloadingActionBuilder final {
       if (auto *IA = dyn_cast<InputAction>(HostAction)) {
         SYCLDeviceActions.clear();
 
+        // Skip CUDA Actions
+        if (IA->getType() == types::TY_CUDA)
+          return ABRT_Inactive;
+
         // Options that are considered LinkerInput are not valid input actions
         // to the device tool chain.
         if (IA->getInputArg().getOption().hasFlag(options::LinkerInput))
@@ -4760,26 +4814,33 @@ class OffloadingActionBuilder final {
     }
 
     void appendTopLevelActions(ActionList &AL) override {
-      if (SYCLDeviceActions.empty())
-        return;
-
       // We should always have an action for each input.
-      assert(SYCLDeviceActions.size() == SYCLTargetInfoList.size() &&
-             "Number of SYCL actions and toolchains/boundarch pairs do not "
-             "match.");
+      if (!SYCLDeviceActions.empty()) {
+        assert(SYCLDeviceActions.size() == SYCLTargetInfoList.size() &&
+               "Number of SYCL actions and toolchains/boundarch pairs do not "
+               "match.");
 
-      // Append all device actions followed by the proper offload action.
-      for (auto TargetActionInfo :
-           llvm::zip(SYCLDeviceActions, SYCLTargetInfoList)) {
-        Action *A = std::get<0>(TargetActionInfo);
-        DeviceTargetInfo &TargetInfo = std::get<1>(TargetActionInfo);
+        // Append all device actions followed by the proper offload action.
+        for (auto TargetActionInfo :
+             llvm::zip(SYCLDeviceActions, SYCLTargetInfoList)) {
+          Action *A = std::get<0>(TargetActionInfo);
+          DeviceTargetInfo &TargetInfo = std::get<1>(TargetActionInfo);
 
-        OffloadAction::DeviceDependences Dep;
-        Dep.add(*A, *TargetInfo.TC, TargetInfo.BoundArch, Action::OFK_SYCL);
-        AL.push_back(C.MakeAction<OffloadAction>(Dep, A->getType()));
+          OffloadAction::DeviceDependences Dep;
+          Dep.add(*A, *TargetInfo.TC, TargetInfo.BoundArch, Action::OFK_SYCL);
+          AL.push_back(C.MakeAction<OffloadAction>(Dep, A->getType()));
+        }
+        // We no longer need the action stored in this builder.
+        SYCLDeviceActions.clear();
       }
-      // We no longer need the action stored in this builder.
-      SYCLDeviceActions.clear();
+
+      if (ExternalCudaAction) {
+        assert(SYCLTargetInfoList.size() == 1 &&
+               "Number of SYCL actions and toolchains/boundarch pairs do not "
+               "match.");
+        AL.push_back(ExternalCudaAction);
+        ExternalCudaAction = nullptr;
+      }
     }
 
     bool addSYCLDeviceLibs(const ToolChain *TC, ActionList &DeviceLinkObjects,
@@ -5477,16 +5538,19 @@ public:
     IsValid = true;
 
     // Create a specialized builder for CUDA.
-    SpecializedBuilders.push_back(new CudaActionBuilder(C, Args, Inputs));
+    SpecializedBuilders.push_back(
+        new CudaActionBuilder(C, Args, Inputs, *this));
 
     // Create a specialized builder for HIP.
-    SpecializedBuilders.push_back(new HIPActionBuilder(C, Args, Inputs));
+    SpecializedBuilders.push_back(new HIPActionBuilder(C, Args, Inputs, *this));
 
     // Create a specialized builder for OpenMP.
-    SpecializedBuilders.push_back(new OpenMPActionBuilder(C, Args, Inputs));
+    SpecializedBuilders.push_back(
+        new OpenMPActionBuilder(C, Args, Inputs, *this));
 
     // Create a specialized builder for SYCL.
-    SpecializedBuilders.push_back(new SYCLActionBuilder(C, Args, Inputs));
+    SpecializedBuilders.push_back(
+        new SYCLActionBuilder(C, Args, Inputs, *this));
 
     //
     // TODO: Build other specialized builders here.
@@ -5513,6 +5577,14 @@ public:
   ~OffloadingActionBuilder() {
     for (auto *SB : SpecializedBuilders)
       delete SB;
+  }
+
+  void pushForeignAction(Action *A) {
+    for (auto *SB : SpecializedBuilders) {
+      if (SB->isValid()) {
+        SB->pushForeignAction(A);
+      }
+    }
   }
 
   /// Record a host action and its originating input argument.
@@ -5818,6 +5890,25 @@ public:
   }
 
   void makeHostLinkAction(ActionList &LinkerInputs) {
+
+    bool IsCUinSYCL = false;
+    for (auto &I : InputArgToOffloadKindMap) {
+      if (I.second == (Action::OFK_Cuda | Action::OFK_SYCL)) {
+        IsCUinSYCL = true;
+      }
+    }
+
+    // Add offload action for the SYCL compilation of .cu files
+    if (IsCUinSYCL) {
+      for (size_t i = 0; i < LinkerInputs.size(); ++i) {
+        OffloadAction::HostDependence HDep(
+            *LinkerInputs[i], *C.getSingleOffloadToolChain<Action::OFK_Host>(),
+            nullptr,
+            InputArgToOffloadKindMap[HostActionToInputArgMap[LinkerInputs[i]]]);
+        LinkerInputs[i] = C.MakeAction<OffloadAction>(HDep);
+      }
+    }
+
     // Build a list of device linking actions.
     ActionList DeviceAL;
     appendDeviceLinkActions(DeviceAL);
@@ -6126,15 +6217,17 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     }
     for (auto &I : Inputs) {
       std::string SrcFileName(I.second->getAsString(Args));
-      if (I.first == types::TY_PP_C || I.first == types::TY_PP_CXX ||
-          types::isSrcFile(I.first)) {
-        // Unique ID is generated for source files and preprocessed files.
-        SmallString<128> ResultID;
-        llvm::sys::fs::createUniquePath("%%%%%%%%%%%%%%%%", ResultID, false);
-        addSYCLUniqueID(Args.MakeArgString(ResultID.str()), SrcFileName);
+      if (I.first != types::TY_CUDA) {
+        if ((I.first == types::TY_PP_C || I.first == types::TY_PP_CXX ||
+             types::isSrcFile(I.first))) {
+          // Unique ID is generated for source files and preprocessed files.
+          SmallString<128> ResultID;
+          llvm::sys::fs::createUniquePath("%%%%%%%%%%%%%%%%", ResultID, false);
+          addSYCLUniqueID(Args.MakeArgString(ResultID.str()), SrcFileName);
+        }
+        if (!types::isSrcFile(I.first))
+          continue;
       }
-      if (!types::isSrcFile(I.first))
-        continue;
 
       std::string TmpFileNameHeader;
       std::string TmpFileNameFooter;
@@ -6246,9 +6339,11 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
       // When performing -fsycl based compilations and generating dependency
       // information, perform a specific dependency generation compilation which
       // is not based on the source + footer compilation.
+      // TODO: Support SYCL offloading with CUDA files
       if (Phase == phases::Preprocess && Args.hasArg(options::OPT_fsycl) &&
           Args.hasArg(options::OPT_M_Group) &&
-          !Args.hasArg(options::OPT_fno_sycl_use_footer)) {
+          !Args.hasArg(options::OPT_fno_sycl_use_footer) &&
+          I.first != types::TY_CUDA) {
         Action *PreprocessAction =
             C.MakeAction<PreprocessJobAction>(Current, types::TY_Dependencies);
         PreprocessAction->propagateHostOffloadInfo(Action::OFK_SYCL,
@@ -6727,9 +6822,12 @@ Action *Driver::ConstructPhaseAction(
              "Cannot preprocess this input type!");
     }
     types::ID HostPPType = types::getPreprocessedType(Input->getType());
+    // TODO: Support SYCL offloading with CUDA files
     if (Args.hasArg(options::OPT_fsycl) && HostPPType != types::TY_INVALID &&
         !Args.hasArg(options::OPT_fno_sycl_use_footer) &&
-        TargetDeviceOffloadKind == Action::OFK_None) {
+        TargetDeviceOffloadKind == Action::OFK_None &&
+        Input->getType() != types::TY_CUDA &&
+        Input->getType() != types::TY_CUDA_DEVICE) {
       // Performing a host compilation with -fsycl.  Append the integration
       // footer to the source file.
       auto *AppendFooter =
@@ -8585,9 +8683,10 @@ const ToolChain &Driver::getToolChain(const ArgList &Args,
 const ToolChain &Driver::getOffloadingDeviceToolChain(const ArgList &Args,
                   const llvm::Triple &Target, const ToolChain &HostTC,
                   const Action::OffloadKind &TargetDeviceOffloadKind) const {
-  // Use device / host triples as the key into the ToolChains map because the
-  // device ToolChain we create depends on both.
-  auto &TC = ToolChains[Target.str() + "/" + HostTC.getTriple().str()];
+  // Use device / host triples offload kind as the key into the ToolChains map
+  // because the device ToolChain we create depends on both.
+  auto &TC = ToolChains[Target.str() + "/" + HostTC.getTriple().str() +
+                        std::to_string(TargetDeviceOffloadKind)];
   if (!TC) {
     // Categorized by offload kind > arch rather than OS > arch like
     // the normal getToolChain call, as it seems a reasonable way to categorize

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4529,9 +4529,8 @@ class OffloadingActionBuilder final {
     void pushForeignAction(Action *A) override {
       // Accept a foreign action from the CudaActionBuilder for compiling CUDA
       // sources
-      if (A->getOffloadingDeviceKind() == Action::OFK_Cuda) {
+      if (A->getOffloadingDeviceKind() == Action::OFK_Cuda)
         ExternalCudaAction = A;
-      }
     }
 
     ActionBuilderReturnCode
@@ -4570,9 +4569,8 @@ class OffloadingActionBuilder final {
       if (CurPhase == phases::Compile && !SYCLTargetInfoList.empty()) {
         // TODO: handle stubfile handling when mix and matching programming
         // model.
-        if (SYCLDeviceActions.empty()) {
+        if (SYCLDeviceActions.empty())
           return ABRT_Success;
-        }
 
         Action *DeviceCompilerInput = nullptr;
         for (Action *&A : SYCLDeviceActions) {

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8668,7 +8668,12 @@ void OffloadBundler::ConstructJob(Compilation &C, const JobAction &JA,
         CurTC = TC;
       });
     }
-    Triples += Action::GetOffloadKindName(CurKind);
+
+    bool IsSYCL =
+        TCArgs.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false);
+    Triples += (IsSYCL && (CurKind == Action::OFK_Cuda))
+                   ? Action::GetOffloadKindName(Action::OFK_SYCL)
+                   : Action::GetOffloadKindName(CurKind);
     Triples += '-';
     Triples += CurTC->getTriple().normalize();
     if ((CurKind == Action::OFK_HIP || CurKind == Action::OFK_OpenMP ||

--- a/clang/test/CodeGenSYCL/cuda-dummy-host-function.cu
+++ b/clang/test/CodeGenSYCL/cuda-dummy-host-function.cu
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -triple spir64-unknown-unknown -fsycl-is-host -emit-llvm %s -o - | FileCheck %s
 
-// Test if a dummy __host__ function (returning undef) is generated for every __device__ function without an host counterpart.
+// Test if a dummy __host__ function (returning undef) is generated for every __device__ function without a host counterpart.
 
 #include "../CodeGenCUDA/Inputs/cuda.h"
 #include "Inputs/sycl.hpp"

--- a/clang/test/CodeGenSYCL/cuda-dummy-host-function.cu
+++ b/clang/test/CodeGenSYCL/cuda-dummy-host-function.cu
@@ -1,5 +1,7 @@
 // RUN: %clang_cc1 -triple spir64-unknown-unknown -fsycl-is-host -emit-llvm %s -o - | FileCheck %s
 
+// Test if a dummy __host__ function (returning undef) is generated for every __device__ function without an host counterpart.
+
 #include "../CodeGenCUDA/Inputs/cuda.h"
 #include "Inputs/sycl.hpp"
 

--- a/clang/test/CodeGenSYCL/cuda-dummy-host-function.cu
+++ b/clang/test/CodeGenSYCL/cuda-dummy-host-function.cu
@@ -1,0 +1,14 @@
+// RUN: %clang_cc1 -triple spir64-unknown-unknown -fsycl-is-host -emit-llvm %s -o - | FileCheck %s
+
+#include "../CodeGenCUDA/Inputs/cuda.h"
+#include "Inputs/sycl.hpp"
+
+// CHECK: ret i32 2
+__device__ int fun0() { return 1; }
+__host__ int fun0() { return 2; }
+
+// CHECK: ret i32 3
+__host__ __device__ int fun1() { return 3; }
+
+// CHECK: ret i32 undef
+__device__ int fun2() { return 4; }

--- a/clang/test/Driver/sycl-cuda-tu-offload.cu
+++ b/clang/test/Driver/sycl-cuda-tu-offload.cu
@@ -1,5 +1,7 @@
 // RUN: %clang++ -ccc-print-phases -target x86_64-unknown-linux-gnu  -fsycl -fsycl-targets=nvptx64-nvidia-cuda  -Xsycl-target-backend  --cuda-gpu-arch=sm_80 --cuda-gpu-arch=sm_80 -c %s 2>&1 | FileCheck %s --check-prefix=DEFAULT-PHASES
 
+// Test the correct placement of the offloading actions for compiling CUDA sources (*.cu) in SYCL.
+
 // DEFAULT-PHASES:         +- 0: input, "{{.*}}", cuda, (device-cuda, sm_80)
 // DEFAULT-PHASES:      +- 1: preprocessor, {0}, cuda-cpp-output, (device-cuda, sm_80)
 // DEFAULT-PHASES:   +- 2: compiler, {1}, ir, (device-cuda, sm_80)

--- a/clang/test/Driver/sycl-cuda-tu-offload.cu
+++ b/clang/test/Driver/sycl-cuda-tu-offload.cu
@@ -1,0 +1,48 @@
+// RUN: %clang++ -ccc-print-phases -target x86_64-unknown-linux-gnu  -fsycl -fsycl-targets=nvptx64-nvidia-cuda  -Xsycl-target-backend  --cuda-gpu-arch=sm_80 --cuda-gpu-arch=sm_80 -c %s 2>&1 | FileCheck %s --check-prefix=DEFAULT-PHASES
+
+// DEFAULT-PHASES:         +- 0: input, "{{.*}}", cuda, (device-cuda, sm_80)
+// DEFAULT-PHASES:      +- 1: preprocessor, {0}, cuda-cpp-output, (device-cuda, sm_80)
+// DEFAULT-PHASES:   +- 2: compiler, {1}, ir, (device-cuda, sm_80)
+// DEFAULT-PHASES:+- 3: offload, "device-cuda (nvptx64-nvidia-cuda:sm_80)" {2}, ir
+// DEFAULT-PHASES:|              +- 4: input, "{{.*}}", cuda, (host-cuda)
+// DEFAULT-PHASES:|           +- 5: preprocessor, {4}, cuda-cpp-output, (host-cuda)
+// DEFAULT-PHASES:|        +- 6: compiler, {5}, ir, (host-cuda)
+// DEFAULT-PHASES:|        |        +- 7: backend, {2}, assembler, (device-cuda, sm_80)
+// DEFAULT-PHASES:|        |     +- 8: assembler, {7}, object, (device-cuda, sm_80)
+// DEFAULT-PHASES:|        |  +- 9: offload, "device-cuda (nvptx64-nvidia-cuda:sm_80)" {8}, object
+// DEFAULT-PHASES:|        |  |- 10: offload, "device-cuda (nvptx64-nvidia-cuda:sm_80)" {7}, assembler
+// DEFAULT-PHASES:|        |- 11: linker, {9, 10}, cuda-fatbin, (device-cuda)
+// DEFAULT-PHASES:|     +- 12: offload, "host-cuda (x86_64-unknown-linux-gnu)" {6}, "device-cuda (nvptx64-nvidia-cuda)" {11}, ir
+// DEFAULT-PHASES:|  +- 13: backend, {12}, assembler, (host-cuda-sycl)
+// DEFAULT-PHASES:|- 14: assembler, {13}, object, (host-cuda-sycl)
+// DEFAULT-PHASES:15: clang-offload-bundler, {3, 14}, object, (host-cuda-sycl)
+
+// RUN: %clang++ -ccc-print-phases -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=nvptx64-nvidia-cuda  -Xsycl-target-backend  --cuda-gpu-arch=sm_80 --cuda-gpu-arch=sm_80 %s 2>&1 | FileCheck %s --check-prefix=DEFAULT-PHASES2
+
+// DEFAULT-PHASES2:                     +- 0: input, "{{.*}}", cuda, (host-cuda)
+// DEFAULT-PHASES2:                  +- 1: preprocessor, {0}, cuda-cpp-output, (host-cuda)
+// DEFAULT-PHASES2:               +- 2: compiler, {1}, ir, (host-cuda)
+// DEFAULT-PHASES2:               |                 +- 3: input, "{{.*}}", cuda, (device-cuda, sm_80)
+// DEFAULT-PHASES2:               |              +- 4: preprocessor, {3}, cuda-cpp-output, (device-cuda, sm_80)
+// DEFAULT-PHASES2:               |           +- 5: compiler, {4}, ir, (device-cuda, sm_80)
+// DEFAULT-PHASES2:               |        +- 6: backend, {5}, assembler, (device-cuda, sm_80)
+// DEFAULT-PHASES2:               |     +- 7: assembler, {6}, object, (device-cuda, sm_80)
+// DEFAULT-PHASES2:               |  +- 8: offload, "device-cuda (nvptx64-nvidia-cuda:sm_80)" {7}, object
+// DEFAULT-PHASES2:               |  |- 9: offload, "device-cuda (nvptx64-nvidia-cuda:sm_80)" {6}, assembler
+// DEFAULT-PHASES2:               |- 10: linker, {8, 9}, cuda-fatbin, (device-cuda)
+// DEFAULT-PHASES2:            +- 11: offload, "host-cuda (x86_64-unknown-linux-gnu)" {2}, "device-cuda (nvptx64-nvidia-cuda)" {10}, ir
+// DEFAULT-PHASES2:         +- 12: backend, {11}, assembler, (host-cuda-sycl)
+// DEFAULT-PHASES2:      +- 13: assembler, {12}, object, (host-cuda-sycl)
+// DEFAULT-PHASES2:   +- 14: offload, "host-cuda-sycl (x86_64-unknown-linux-gnu)" {13}, object
+// DEFAULT-PHASES2:+- 15: linker, {14}, image, (host-cuda-sycl)
+// DEFAULT-PHASES2:|           +- 16: offload, "device-cuda (nvptx64-nvidia-cuda:sm_80)" {5}, ir
+// DEFAULT-PHASES2:|        +- 17: linker, {16}, ir, (device-sycl, sm_80)
+// DEFAULT-PHASES2:|     +- 18: sycl-post-link, {17}, ir, (device-sycl, sm_80)
+// DEFAULT-PHASES2:|     |  +- 19: file-table-tform, {18}, ir, (device-sycl, sm_80)
+// DEFAULT-PHASES2:|     |  |  +- 20: backend, {19}, assembler, (device-sycl, sm_80)
+// DEFAULT-PHASES2:|     |  |  |- 21: assembler, {20}, object, (device-sycl, sm_80)
+// DEFAULT-PHASES2:|     |  |- 22: linker, {20, 21}, cuda-fatbin, (device-sycl, sm_80)
+// DEFAULT-PHASES2:|     |- 23: foreach, {19, 22}, cuda-fatbin, (device-sycl, sm_80)
+// DEFAULT-PHASES2:|  +- 24: file-table-tform, {18, 23}, tempfiletable, (device-sycl, sm_80)
+// DEFAULT-PHASES2:|- 25: clang-offload-wrapper, {24}, object, (device-sycl, sm_80)
+// DEFAULT-PHASES2:26: offload, "host-cuda-sycl (x86_64-unknown-linux-gnu)" {15}, "device-sycl (nvptx64-nvidia-cuda:sm_80)" {25}, image


### PR DESCRIPTION
This PR allows to compile `.cu` files with SYCL, i.e.,

1. Compile `.cu` sources in order to generate `.o` files for SYCL.
2. Compile `.cu` and `.cpp` files for obtaining a SYCL executable.
3. Create a dummy (CUDA) `__host__` function for each (CUDA) `__device__` function that hasn't one.