### PR TITLE
[SYCL] Require aspect::online_compiler for build-log unittests

### DIFF
--- a/sycl/unittests/program_manager/BuildLog.cpp
+++ b/sycl/unittests/program_manager/BuildLog.cpp
@@ -94,11 +94,16 @@ TEST(BuildLog, OutputNothingOnLevel1) {
     GTEST_SKIP_("Test is not supported on this platform");
   }
 
+  const sycl::device Dev = Plt.get_devices()[0];
+  if (!Dev.has(sycl::aspect::online_compiler)) {
+    GTEST_SKIP_("Test is not supported on this device due to missing support "
+                "for sycl::aspect::online_compiler");
+  }
+
   sycl::unittest::PiMock Mock{Plt};
   setupDefaultMockAPIs(Mock);
   setupCommonTestAPIs(Mock);
 
-  const sycl::device Dev = Plt.get_devices()[0];
   sycl::context Ctx{Dev};
   sycl::queue Queue{Ctx, Dev};
 
@@ -127,11 +132,16 @@ TEST(BuildLog, OutputLogOnLevel2) {
     GTEST_SKIP_("Test is not supported on this platform");
   }
 
+  const sycl::device Dev = Plt.get_devices()[0];
+  if (!Dev.has(sycl::aspect::online_compiler)) {
+    GTEST_SKIP_("Test is not supported on this device due to missing support "
+                "for sycl::aspect::online_compiler");
+  }
+
   sycl::unittest::PiMock Mock{Plt};
   setupDefaultMockAPIs(Mock);
   setupCommonTestAPIs(Mock);
 
-  const sycl::device Dev = Plt.get_devices()[0];
   sycl::context Ctx{Dev};
   sycl::queue Queue{Ctx, Dev};
 


### PR DESCRIPTION
Unittests for build-logs use kernel bundles in input state. In accordance with the SYCL 2020 specification a program using kernel
bundles in input state should check that the corresponding devices support aspect::online_compiler. These changes adds a check for this device aspect when deciding if the test is supported.