### PR TITLE
[SYCL][HIP] Fix CMake lld dependency

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -151,8 +151,6 @@ jobs:
         cmake --build $GITHUB_WORKSPACE/build --target install-llvm-cov
         cmake --build $GITHUB_WORKSPACE/build --target install-llvm-profdata
         cmake --build $GITHUB_WORKSPACE/build --target install-compiler-rt
-        # TODO this should be resolved in CMakeLists.txt
-        cmake --build $GITHUB_WORKSPACE/build --target install-lld || echo "skipped"
 
     - name: Pack toolchain
       run: tar -cJf llvm_sycl.tar.xz -C $GITHUB_WORKSPACE/build/install .

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -403,6 +403,12 @@ if("hip" IN_LIST SYCL_ENABLE_PLUGINS)
 
   add_dependencies(sycl-toolchain libspirv-builtins pi_hip)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS libspirv-builtins pi_hip)
+
+  # On AMD platform lld is also needed
+  if("${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "AMD")
+    add_dependencies(sycl-toolchain lld)
+    list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS lld)
+  endif()
 endif()
 
 if("esimd_emulator" IN_LIST SYCL_ENABLE_PLUGINS)

--- a/sycl/plugins/hip/CMakeLists.txt
+++ b/sycl/plugins/hip/CMakeLists.txt
@@ -36,9 +36,6 @@ if("${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "AMD")
 
   # Set HIP define to select AMD platform
   target_compile_definitions(pi_hip PRIVATE __HIP_PLATFORM_AMD__)
-
-  # Make sure lld is built as part of the toolchain
-  add_dependencies(sycl-toolchain lld)
 elseif("${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "NVIDIA")
   # Import CUDA libraries
   find_package(CUDA REQUIRED)


### PR DESCRIPTION
The dependency on lld for AMD HIP plugin was not wired up correctly
which led to lld not being installed by default when the HIP plugin is
enabled.

This patch fixes: https://github.com/intel/llvm/issues/6338