### PR TITLE
[SYCL] fix for windows compilation

### DIFF
--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -19,6 +19,7 @@
 #include <atomic>
 #include <cassert>
 #include <condition_variable>
+#include <optional>
 
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {


### PR DESCRIPTION
PR6388 overlooked inclusion needed for windows
Signed-off-by: Chris Perkins <chris.perkins@intel.com>