### PR TITLE
[SYCL][ESIMD][EMU] Updating kernel-launch API for ESIMD_EMULATOR BE

### DIFF
--- a/sycl/plugins/esimd_emulator/CMakeLists.txt
+++ b/sycl/plugins/esimd_emulator/CMakeLists.txt
@@ -22,7 +22,7 @@ else()
   set(LIBIGFXCMRT_EMU ${LLVM_BINARY_DIR}/pi_esimd_emulator_deps/lib/libigfxcmrt_emu${CMAKE_SHARED_LIBRARY_SUFFIX})
 endif()
 
-set (DEFAULT_CM_EMU_PREBUILT_PACKAGE "https://github.com/intel/cm-cpu-emulation/releases/download/v2022-05-06/intel-cmemu-1.0.22.u20.04-release.x86_64.tar.xz")
+set (DEFAULT_CM_EMU_PREBUILT_PACKAGE "https://github.com/intel/cm-cpu-emulation/releases/download/v2022-07-06/intel-cmemu-1.0.23.u20.04-release.x86_64.tar.xz")
 set (DEFAULT_CM_EMU_SOURCE_URL "https://github.com/intel/cm-cpu-emulation.git")
 
 if ((DEFINED USE_DEFAULT_CM_EMU_SOURCE) OR (DEFINED USE_LOCAL_CM_EMU_SOURCE))

--- a/sycl/plugins/esimd_emulator/pi_esimd_emulator.cpp
+++ b/sycl/plugins/esimd_emulator/pi_esimd_emulator.cpp
@@ -263,8 +263,8 @@ public:
     const auto InvokeKernelArg = KernelInvocationContext<DIMS>{
         MKernel, LocalSize, GlobalSize, GlobalOffset};
 
-    EsimdemuKernel{reinterpret_cast<fptrVoid>(InvokeKernel<DIMS>), GroupDim,
-                   SpaceDim}
+    EsimdemuKernel{reinterpret_cast<fptrVoid>(InvokeKernel<DIMS>),
+                   GroupDim.data(), SpaceDim.data()}
         .launchMT(sizeof(InvokeKernelArg), &InvokeKernelArg);
   }
 };


### PR DESCRIPTION
- Kernel launching API for ESIMD_EMULATOR is updated in order to
remove dependency on std::vector type

- Download URL for pre-built CM_EMU library package is updated
accordingly