### PR TITLE
[SYCL] match existing device_impl from context, rather than creating a new one. 

### DIFF
--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -199,6 +199,15 @@ bool context_impl::hasDevice(
   return false;
 }
 
+DeviceImplPtr
+context_impl::findMatchingDeviceImpl(RT::PiDevice &DevicePI) const {
+  for (device D : MDevices)
+    if (getSyclObjImpl(D)->getHandleRef() == DevicePI)
+      return getSyclObjImpl(D);
+
+  return nullptr;
+}
+
 pi_native_handle context_impl::getNative() const {
   auto Plugin = getPlugin();
   if (Plugin.getBackend() == backend::opencl)

--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -165,6 +165,10 @@ public:
   /// Returns true if and only if context contains the given device.
   bool hasDevice(std::shared_ptr<detail::device_impl> Device) const;
 
+  /// Given a PiDevice, returns the matching shared_ptr<device_impl>
+  /// within this context. May return nullptr if no match discovered.
+  DeviceImplPtr findMatchingDeviceImpl(RT::PiDevice &DevicePI) const;
+
   /// Gets the native handle of the SYCL context.
   ///
   /// \return a native handle.

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -151,13 +151,16 @@ public:
 
     MQueues.push_back(pi::cast<RT::PiQueue>(PiQueue));
 
-    RT::PiDevice Device{};
+    RT::PiDevice DevicePI{};
     const detail::plugin &Plugin = getPlugin();
     // TODO catch an exception and put it to list of asynchronous exceptions
-    Plugin.call<PiApiKind::piQueueGetInfo>(MQueues[0], PI_QUEUE_INFO_DEVICE,
-                                           sizeof(Device), &Device, nullptr);
-    MDevice =
-        DeviceImplPtr(new device_impl(Device, Context->getPlatformImpl()));
+    Plugin.call<PiApiKind::piQueueGetInfo>(
+        MQueues[0], PI_QUEUE_INFO_DEVICE, sizeof(DevicePI), &DevicePI, nullptr);
+    MDevice = MContext->findMatchingDeviceImpl(DevicePI);
+    if (MDevice == nullptr)
+      throw sycl::exception(
+          make_error_code(errc::invalid),
+          "internal error.  Device on PiQueue not found in Context.");
   }
 
   ~queue_impl() {

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -160,7 +160,7 @@ public:
     if (MDevice == nullptr)
       throw sycl::exception(
           make_error_code(errc::invalid),
-          "internal error.  Device on PiQueue not found in Context.");
+          "Device provided by native Queue not found in Context.");
   }
 
   ~queue_impl() {


### PR DESCRIPTION
the queue_impl(PI) constructor is creating a new device_impl, but that is not strictly correct. Presently this SYCL implementation assumes there is a 1:1 relationship between devicePI and device_impl. By creating a new one, there will now be two device_impls (one already in the context) for the same devicePI. In this PR we are simply finding the matching device_impl in the Context and using that rather than creating a new one, preserving the 1:1 relationship.

Signed-off-by: Chris Perkins <chris.perkins@intel.com>