### PR TITLE
[SYCL][HIP] Implement PI_DEVICE_INFO_ATOMIC_64 for HIP

### DIFF
--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -1767,8 +1767,17 @@ pi_result hip_piDeviceGetInfo(pi_device device, pi_device_info param_name,
     return getInfo(param_value_size, param_value, param_value_size_ret, value);
   }
 
+  case PI_DEVICE_INFO_ATOMIC_64: {
+    // TODO: Reconsider it when AMD supports SYCL_USE_NATIVE_FP_ATOMICS.
+    hipDeviceProp_t props;
+    cl::sycl::detail::pi::assertion(
+        hipGetDeviceProperties(&props, device->get()) == hipSuccess);
+    return getInfo(param_value_size, param_value, param_value_size_ret,
+                   props.arch.hasGlobalInt64Atomics &&
+                       props.arch.hasSharedInt64Atomics);
+  }
+
   // TODO: Implement.
-  case PI_DEVICE_INFO_ATOMIC_64:
   case PI_DEVICE_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES:
   // TODO: Investigate if this information is available on HIP.
   case PI_DEVICE_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES:


### PR DESCRIPTION
This patch implements `aspect::atomic64` by querying the information related to the 64-bit integer atomic operations. At the moment, the floating-point atomics are not supported at all (single and double precision) for AMD devices. The `SYCL_USE_NATIVE_FP_ATOMICS` is not set for AMD, and the `atomc_ref` class handles the lack of double and single precision atomic operations.

We may want to revisit this implementation when the floating-point atomics will be supported by AMD too. 

However, I think this is not necessary for three reasons:

1. the `atomic64` aspect "Indicates that kernels submitted to the device may perform 64-bit atomic operations." It expresses a possibility, not specifying any kind of operations or data types.
2. the SYCL specifications for `atomic_ref` say "For floating-point types, the member functions of the atomic_ref class may be emulated, and may use a different floating-point environment to ..."  implying that the floating-point operations in `atomic_ref` do not need to be supported natively by the hardware.
3. both [L0](https://github.com/intel/llvm/blob/354d057ba956a598adee8ac55ae7386bad2dffcf/sycl/plugins/level_zero/pi_level_zero.cpp#L2575-L2576) and [OpenCL](https://github.com/intel/llvm/blob/354d057ba956a598adee8ac55ae7386bad2dffcf/sycl/plugins/opencl/pi_opencl.cpp#L223-L224) backends check only for 64-bit integer atomics.

This solves https://github.com/intel/llvm/issues/5570, https://github.com/intel/llvm/issues/6054, and allows to re-enable tests in https://github.com/intel/llvm-test-suite/pull/861.