### PR TITLE
[SYCL][NFC][DOC] Fix description of -f[no-]sycl-unnamed-lambda in Use…

### DIFF
--- a/sycl/doc/UsersManual.md
+++ b/sycl/doc/UsersManual.md
@@ -49,7 +49,8 @@ and not recommended to use in production environment.
 **`-f[no-]sycl-unnamed-lambda`**
 
     Enables/Disables unnamed SYCL lambda kernels support.
-    Disabled by default.
+    The default value depends on the SYCL language standard: it is enabled
+    by default for SYCL 2020, and disabled for SYCL 1.2.1.
 
 **`-f[no-]sycl-explicit-simd`** [DEPRECATED]
 


### PR DESCRIPTION
…rManual

The default value of the option depends on the SYCL language standard.
Unnamed lamda is supported by default with SYCL 2020 (default now) and
disabled for SYCL 1.2.1.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>