### PR TITLE
[SYCL] Fix an issue with queue shortcuts with offsets

### DIFF
--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -862,6 +862,54 @@ public:
     return parallel_for_impl<KernelName>(Range, DepEvents, Rest...);
   }
 
+  // While other shortcuts with offsets are able to go through parallel_for(...,
+  // RestT &&...Rest), those that accept dependency events vector have to be
+  // overloaded to allow implicit construction from an init-list.
+  /// parallel_for version with a kernel represented as a lambda + range and
+  /// offset that specify global size and global offset correspondingly.
+  ///
+  /// \param Range specifies the global work space of the kernel
+  /// \param WorkItemOffset specifies the offset for each work item id
+  /// \param KernelFunc is the Kernel functor or lambda
+  /// \param CodeLoc contains the code location of user code
+  template <typename KernelName = detail::auto_name, typename KernelType>
+  event parallel_for(range<1> Range, id<1> WorkItemOffset,
+                     const std::vector<event> &DepEvents,
+                     _KERNELFUNCPARAM(KernelFunc)) {
+    return parallel_for_impl<KernelName>(Range, WorkItemOffset, DepEvents,
+                                         KernelFunc);
+  }
+
+  /// parallel_for version with a kernel represented as a lambda + range and
+  /// offset that specify global size and global offset correspondingly.
+  ///
+  /// \param Range specifies the global work space of the kernel
+  /// \param WorkItemOffset specifies the offset for each work item id
+  /// \param KernelFunc is the Kernel functor or lambda
+  /// \param CodeLoc contains the code location of user code
+  template <typename KernelName = detail::auto_name, typename KernelType>
+  event parallel_for(range<2> Range, id<2> WorkItemOffset,
+                     const std::vector<event> &DepEvents,
+                     _KERNELFUNCPARAM(KernelFunc)) {
+    return parallel_for_impl<KernelName>(Range, WorkItemOffset, DepEvents,
+                                         KernelFunc);
+  }
+
+  /// parallel_for version with a kernel represented as a lambda + range and
+  /// offset that specify global size and global offset correspondingly.
+  ///
+  /// \param Range specifies the global work space of the kernel
+  /// \param WorkItemOffset specifies the offset for each work item id
+  /// \param KernelFunc is the Kernel functor or lambda
+  /// \param CodeLoc contains the code location of user code
+  template <typename KernelName = detail::auto_name, typename KernelType>
+  event parallel_for(range<3> Range, id<3> WorkItemOffset,
+                     const std::vector<event> &DepEvents,
+                     _KERNELFUNCPARAM(KernelFunc)) {
+    return parallel_for_impl<KernelName>(Range, WorkItemOffset, DepEvents,
+                                         KernelFunc);
+  }
+
   /// parallel_for version with a kernel represented as a lambda + range and
   /// offset that specify global size and global offset correspondingly.
   ///

--- a/sycl/test/basic_tests/queue/queue_offset_shortcut_initlist.cpp
+++ b/sycl/test/basic_tests/queue/queue_offset_shortcut_initlist.cpp
@@ -1,0 +1,25 @@
+// RUN: %clangxx -fsycl -fsyntax-only %s -o %t.out
+//=---queue_offset_shortcut_initlist.cpp - SYCL queue offset shortcuts test--=//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <sycl/sycl.hpp>
+
+class KernelNameA;
+class KernelNameB;
+class KernelNameC;
+
+int main() {
+  sycl::queue q;
+  // Check that init-list works here.
+  sycl::event e = q.parallel_for<KernelNameA>(sycl::range<1>{1}, sycl::id<1>{0},
+                              [=](sycl::item<1> i) { });
+  q.parallel_for<KernelNameB>(sycl::range<2>{1, 1}, sycl::id<2>{0, 0}, e,
+                              [=](sycl::item<2> i) { });
+  q.parallel_for<KernelNameC>(sycl::range<3>{1, 1, 1}, sycl::id<3>{0, 0, 0}, {e},
+                              [=](sycl::item<3> i) { });
+}

--- a/sycl/test/basic_tests/queue/queue_offset_shortcut_initlist.cpp
+++ b/sycl/test/basic_tests/queue/queue_offset_shortcut_initlist.cpp
@@ -15,11 +15,12 @@ class KernelNameC;
 
 int main() {
   sycl::queue q;
+  sycl::event e;
   // Check that init-list works here.
-  sycl::event e = q.parallel_for<KernelNameA>(sycl::range<1>{1}, sycl::id<1>{0},
-                              [=](sycl::item<1> i) { });
-  q.parallel_for<KernelNameB>(sycl::range<2>{1, 1}, sycl::id<2>{0, 0}, e,
-                              [=](sycl::item<2> i) { });
-  q.parallel_for<KernelNameC>(sycl::range<3>{1, 1, 1}, sycl::id<3>{0, 0, 0}, {e},
-                              [=](sycl::item<3> i) { });
+  q.parallel_for<KernelNameA>(sycl::range<1>{1}, sycl::id<1>{0}, {e},
+                              [=](sycl::item<1> i) {});
+  q.parallel_for<KernelNameB>(sycl::range<2>{1, 1}, sycl::id<2>{0, 0}, {e},
+                              [=](sycl::item<2> i) {});
+  q.parallel_for<KernelNameC>(sycl::range<3>{1, 1, 1}, sycl::id<3>{0, 0, 0},
+                              {e}, [=](sycl::item<3> i) {});
 }


### PR DESCRIPTION
Fix an issue where it wasn't possible to pass an init-list for dependency
events vector due to an error during template parameter pack resolution.