### PR TITLE
[NFCI][SYCL] Refactor reduction implementation

### DIFF
--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -522,28 +522,24 @@ struct is_placeholder_t<accessor<T, AccessorDims, Mode, access::target::device,
                                  access::placeholder::true_t, PropList>>
     : public std::true_type {};
 
-/// Types representing specific reduction algorithms
-/// Enables reduction_impl_algo to take additional algorithm-specific templates
-template <int AccessorDims>
-class default_reduction_algorithm {};
 
-/// Templated class for implementations of specific reduction algorithms
-template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          class Algorithm, typename RedOutVar>
-class reduction_impl_algo;
+template <class T>
+struct accessor_dim_t {
+  static constexpr int value = 1;
+};
 
-/// Original reduction algorithm is the default. It supports both USM and
-/// accessors via a single class
+template <class T, int AccessorDims, access::mode Mode,
+          access::placeholder IsPH, typename PropList>
+struct accessor_dim_t<
+    accessor<T, AccessorDims, Mode, access::target::device, IsPH, PropList>> {
+  static constexpr int value = AccessorDims;
+};
+
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          int AccessorDims, typename RedOutVar>
-class reduction_impl_algo<
-    T, BinaryOperation, Dims, Extent,
-    default_reduction_algorithm<AccessorDims>, RedOutVar>
-    : public reduction_impl_common<T, BinaryOperation> {
+          typename RedOutVar>
+class reduction_impl_algo : public reduction_impl_common<T, BinaryOperation> {
   using base = reduction_impl_common<T, BinaryOperation>;
-  using self =
-      reduction_impl_algo<T, BinaryOperation, Dims, Extent,
-                          default_reduction_algorithm<AccessorDims>, RedOutVar>;
+  using self = reduction_impl_algo<T, BinaryOperation, Dims, Extent, RedOutVar>;
 
 public:
   using reducer_type = reducer<T, BinaryOperation, Dims, Extent>;
@@ -553,12 +549,12 @@ public:
   // Buffers and accessors always describe scalar reductions (i.e. Dims == 0)
   // The input buffer/accessor is allowed to have different dimensionality
   // AccessorDims also determines the dimensionality of some temp storage
-  static constexpr int accessor_dim = AccessorDims;
-  static constexpr int buffer_dim = (AccessorDims == 0) ? 1 : AccessorDims;
+  static constexpr int accessor_dim = accessor_dim_t<RedOutVar>::value;
+  static constexpr int buffer_dim = (accessor_dim == 0) ? 1 : accessor_dim;
   static constexpr access::placeholder is_placeholder =
       is_placeholder_t<RedOutVar>::value ? access::placeholder::true_t
                                          : access::placeholder::false_t;
-  using rw_accessor_type = accessor<T, AccessorDims, access::mode::read_write,
+  using rw_accessor_type = accessor<T, accessor_dim, access::mode::read_write,
                                     access::target::device, is_placeholder,
                                     ext::oneapi::accessor_property_list<>>;
   static constexpr bool has_atomic_add_float64 =
@@ -746,16 +742,13 @@ template <typename T> struct AreAllButLastReductions<T> {
 /// This class encapsulates the reduction variable/accessor,
 /// the reduction operator and an optional operator identity.
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          class Algorithm, typename RedOutVar>
+          typename RedOutVar>
 class reduction_impl
     : private reduction_impl_base,
-      public reduction_impl_algo<T, BinaryOperation, Dims, Extent, Algorithm,
-                                 RedOutVar> {
+      public reduction_impl_algo<T, BinaryOperation, Dims, Extent, RedOutVar> {
 private:
-  using algo = reduction_impl_algo<T, BinaryOperation, Dims, Extent,
-                                   Algorithm, RedOutVar>;
-  using self =
-      reduction_impl<T, BinaryOperation, Dims, Extent, Algorithm, RedOutVar>;
+  using algo = reduction_impl_algo<T, BinaryOperation, Dims, Extent, RedOutVar>;
+  using self = reduction_impl<T, BinaryOperation, Dims, Extent, RedOutVar>;
 
   static constexpr bool is_known_identity =
       sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value;
@@ -2466,7 +2459,6 @@ tuple_select_elements(TupleT Tuple, std::index_sequence<Is...>) {
 template <typename T, class BinaryOperation, int Dims, access::mode AccMode,
           access::placeholder IsPH>
 detail::reduction_impl<T, BinaryOperation, 0, 1,
-                       detail::default_reduction_algorithm<Dims>,
                        accessor<T, Dims, AccMode, access::target::device, IsPH>>
 reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
           const T &Identity, BinaryOperation BOp) {
@@ -2482,7 +2474,6 @@ template <typename T, class BinaryOperation, int Dims, access::mode AccMode,
 std::enable_if_t<sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value,
                  detail::reduction_impl<
                      T, BinaryOperation, 0, 1,
-                     detail::default_reduction_algorithm<Dims>,
                      accessor<T, Dims, AccMode, access::target::device, IsPH>>>
 reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
           BinaryOperation) {
@@ -2494,8 +2485,7 @@ reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
 /// the computed reduction must be stored \param VarPtr, identity value
 /// \param Identity, and the binary operation used in the reduction.
 template <typename T, class BinaryOperation>
-detail::reduction_impl<T, BinaryOperation, 0, 1,
-                       detail::default_reduction_algorithm<1>, T *>
+detail::reduction_impl<T, BinaryOperation, 0, 1, T *>
 reduction(T *VarPtr, const T &Identity, BinaryOperation BOp) {
   return {VarPtr, Identity, BOp};
 }
@@ -2506,10 +2496,8 @@ reduction(T *VarPtr, const T &Identity, BinaryOperation BOp) {
 /// operation used in the reduction.
 /// The identity value is not passed to this version as it is statically known.
 template <typename T, class BinaryOperation>
-std::enable_if_t<
-    sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value,
-    detail::reduction_impl<T, BinaryOperation, 0, 1,
-                           detail::default_reduction_algorithm<1>, T *>>
+std::enable_if_t<sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value,
+                 detail::reduction_impl<T, BinaryOperation, 0, 1, T *>>
 reduction(T *VarPtr, BinaryOperation) {
   return {VarPtr};
 }

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -124,17 +124,17 @@ __SYCL_EXPORT size_t reduComputeWGSize(size_t NWorkItems, size_t MaxWGSize,
 /// functions and representing users' reduction variable.
 /// The generic version of the class represents those reductions of those
 /// types and operations for which the identity value is not known.
-/// The Algorithm template can be used to specialize reducers for different
-/// reduction algorithms. The View template describes whether the reducer
-/// owns its data or not: if View is 'true', then the reducer does not own
-/// its data and instead provides a view of data allocated elsewhere (i.e.
-/// via a reference or pointer member); if View is 'false', then the reducer
-/// owns its data. With the current default reduction algorithm, the top-level
-/// reducers that are passed to the user's lambda contain a private copy of
-/// the reduction variable, whereas any reducer created by a subscript operator
-/// contains a reference to a reduction variable allocated elsewhere.
+/// The View template describes whether the reducer owns its data or not: if
+/// View is 'true', then the reducer does not own its data and instead provides
+/// a view of data allocated elsewhere (i.e. via a reference or pointer member);
+/// if View is 'false', then the reducer owns its data. With the current default
+/// reduction algorithm, the top-level reducers that are passed to the user's
+/// lambda contain a private copy of the reduction variable, whereas any reducer
+/// created by a subscript operator contains a reference to a reduction variable
+/// allocated elsewhere. The Subst parameter is an implementation detail and is
+/// used to spell out restrictions using 'enable_if'.
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          class Algorithm, bool View = false, typename Subst = void>
+          bool View = false, typename Subst = void>
 class reducer;
 
 /// Helper class for accessing reducer-defined types in CRTP
@@ -142,9 +142,8 @@ class reducer;
 template <typename Reducer> struct ReducerTraits;
 
 template <typename T, class BinaryOperation, int Dims, std::size_t Extent,
-          class Algorithm, bool View, typename Subst>
-struct ReducerTraits<
-    reducer<T, BinaryOperation, Dims, Extent, Algorithm, View, Subst>> {
+          bool View, typename Subst>
+struct ReducerTraits<reducer<T, BinaryOperation, Dims, Extent, View, Subst>> {
   using type = T;
   using op = BinaryOperation;
   static constexpr int dims = Dims;
@@ -319,14 +318,13 @@ public:
 ///
 /// It stores a copy of the identity and binary operation associated with the
 /// reduction.
-template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          class Algorithm, bool View>
+template <typename T, class BinaryOperation, int Dims, size_t Extent, bool View>
 class reducer<
-    T, BinaryOperation, Dims, Extent, Algorithm, View,
+    T, BinaryOperation, Dims, Extent, View,
     enable_if_t<Dims == 0 && Extent == 1 && View == false &&
                 !sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value>>
     : public combiner<
-          reducer<T, BinaryOperation, Dims, Extent, Algorithm, View,
+          reducer<T, BinaryOperation, Dims, Extent, View,
                   enable_if_t<Dims == 0 && Extent == 1 && View == false &&
                               !sycl::detail::IsKnownIdentityOp<
                                   T, BinaryOperation>::value>>> {
@@ -352,14 +350,13 @@ private:
 ///
 /// It allows to reduce the size of the 'reducer' object by not holding
 /// the identity field inside it and allows to add a default constructor.
-template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          class Algorithm, bool View>
+template <typename T, class BinaryOperation, int Dims, size_t Extent, bool View>
 class reducer<
-    T, BinaryOperation, Dims, Extent, Algorithm, View,
+    T, BinaryOperation, Dims, Extent, View,
     enable_if_t<Dims == 0 && Extent == 1 && View == false &&
                 sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value>>
     : public combiner<
-          reducer<T, BinaryOperation, Dims, Extent, Algorithm, View,
+          reducer<T, BinaryOperation, Dims, Extent, View,
                   enable_if_t<Dims == 0 && Extent == 1 && View == false &&
                               sycl::detail::IsKnownIdentityOp<
                                   T, BinaryOperation>::value>>> {
@@ -383,11 +380,10 @@ public:
 
 /// Component of 'reducer' class for array reductions, representing a single
 /// element of the span (as returned by the subscript operator).
-template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          class Algorithm, bool View>
-class reducer<T, BinaryOperation, Dims, Extent, Algorithm, View,
+template <typename T, class BinaryOperation, int Dims, size_t Extent, bool View>
+class reducer<T, BinaryOperation, Dims, Extent, View,
               enable_if_t<Dims == 0 && View == true>>
-    : public combiner<reducer<T, BinaryOperation, Dims, Extent, Algorithm, View,
+    : public combiner<reducer<T, BinaryOperation, Dims, Extent, View,
                               enable_if_t<Dims == 0 && View == true>>> {
 public:
   reducer(T &Ref, BinaryOperation BOp) : MElement(Ref), MBinaryOp(BOp) {}
@@ -401,13 +397,12 @@ private:
 
 /// Specialization of 'reducer' class for array reductions exposing the
 /// subscript operator.
-template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          class Algorithm, bool View>
+template <typename T, class BinaryOperation, int Dims, size_t Extent, bool View>
 class reducer<
-    T, BinaryOperation, Dims, Extent, Algorithm, View,
+    T, BinaryOperation, Dims, Extent, View,
     enable_if_t<Dims == 1 && View == false &&
                 !sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value>>
-    : public combiner<reducer<T, BinaryOperation, Dims, Extent, Algorithm, View,
+    : public combiner<reducer<T, BinaryOperation, Dims, Extent, View,
                               enable_if_t<Dims == 1 && View == false &&
                                           !sycl::detail::IsKnownIdentityOp<
                                               T, BinaryOperation>::value>>> {
@@ -415,8 +410,7 @@ public:
   reducer(const T &Identity, BinaryOperation BOp)
       : MValue(Identity), MIdentity(Identity), MBinaryOp(BOp) {}
 
-  reducer<T, BinaryOperation, Dims - 1, Extent, Algorithm, true>
-  operator[](size_t Index) {
+  reducer<T, BinaryOperation, Dims - 1, Extent, true> operator[](size_t Index) {
     return {MValue[Index], MBinaryOp};
   }
 
@@ -432,13 +426,12 @@ private:
 
 /// Specialization of 'reducer' class for array reductions accepting a span
 /// in cases where the identity value is known.
-template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          class Algorithm, bool View>
+template <typename T, class BinaryOperation, int Dims, size_t Extent, bool View>
 class reducer<
-    T, BinaryOperation, Dims, Extent, Algorithm, View,
+    T, BinaryOperation, Dims, Extent, View,
     enable_if_t<Dims == 1 && View == false &&
                 sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value>>
-    : public combiner<reducer<T, BinaryOperation, Dims, Extent, Algorithm, View,
+    : public combiner<reducer<T, BinaryOperation, Dims, Extent, View,
                               enable_if_t<Dims == 1 && View == false &&
                                           sycl::detail::IsKnownIdentityOp<
                                               T, BinaryOperation>::value>>> {
@@ -448,8 +441,7 @@ public:
 
   // SYCL 2020 revision 4 says this should be const, but this is a bug
   // see https://github.com/KhronosGroup/SYCL-Docs/pull/252
-  reducer<T, BinaryOperation, Dims - 1, Extent, Algorithm, true>
-  operator[](size_t Index) {
+  reducer<T, BinaryOperation, Dims - 1, Extent, true> operator[](size_t Index) {
     return {MValue[Index], BinaryOperation()};
   }
 
@@ -525,9 +517,7 @@ class reduction_impl_algo<
   using base = reduction_impl_common<T, BinaryOperation>;
 
 public:
-  using reducer_type =
-      reducer<T, BinaryOperation, Dims, Extent,
-              default_reduction_algorithm<IsUSM, IsPlaceholder, AccessorDims>>;
+  using reducer_type = reducer<T, BinaryOperation, Dims, Extent>;
   using result_type = T;
   using binary_operation = BinaryOperation;
 

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -519,13 +519,14 @@ struct is_placeholder_t<accessor<T, AccessorDims, Mode, access::target::device,
                                  access::placeholder::true_t, PropList>>
     : public std::true_type {};
 
-template <class T> struct accessor_dim_t {
+// Used for determining dimensions for temporary storage (mainly).
+template <class T> struct data_dim_t {
   static constexpr int value = 1;
 };
 
 template <class T, int AccessorDims, access::mode Mode,
           access::placeholder IsPH, typename PropList>
-struct accessor_dim_t<
+struct data_dim_t<
     accessor<T, AccessorDims, Mode, access::target::device, IsPH, PropList>> {
   static constexpr int value = AccessorDims;
 };
@@ -556,7 +557,7 @@ public:
   // Buffers and accessors always describe scalar reductions (i.e. Dims == 0)
   // The input buffer/accessor is allowed to have different dimensionality
   // AccessorDims also determines the dimensionality of some temp storage
-  static constexpr int accessor_dim = accessor_dim_t<RedOutVar>::value;
+  static constexpr int accessor_dim = data_dim_t<RedOutVar>::value;
   static constexpr int buffer_dim = (accessor_dim == 0) ? 1 : accessor_dim;
   static constexpr access::placeholder is_placeholder =
       is_placeholder_t<RedOutVar>::value ? access::placeholder::true_t

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -577,7 +577,7 @@ public:
   static constexpr bool is_dw_acc = is_dw_acc_t<RedOutVar>::value;
   static constexpr bool is_acc = is_rw_acc | is_dw_acc;
   static_assert(!is_rw_acc || !is_dw_acc, "Can be only one at once!");
-  static_assert(!is_usm || !is_acc, "Ca be only one at once!");
+  static_assert(!is_usm || !is_acc, "Can be only one at once!");
 
   static constexpr size_t dims = Dims;
   static constexpr size_t num_elements = Extent;

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -503,15 +503,16 @@ class default_reduction_algorithm {};
 
 /// Templated class for implementations of specific reduction algorithms
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          class Algorithm>
+          typename RedOutVar, class Algorithm>
 class reduction_impl_algo;
 
 /// Original reduction algorithm is the default. It supports both USM and
 /// accessors via a single class
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          bool IsUSM, access::placeholder IsPlaceholder, int AccessorDims>
+          typename RedOutVar, bool IsUSM, access::placeholder IsPlaceholder,
+          int AccessorDims>
 class reduction_impl_algo<
-    T, BinaryOperation, Dims, Extent,
+    T, BinaryOperation, Dims, Extent, RedOutVar,
     default_reduction_algorithm<IsUSM, IsPlaceholder, AccessorDims>>
     : public reduction_impl_common<T, BinaryOperation> {
   using base = reduction_impl_common<T, BinaryOperation>;
@@ -533,6 +534,7 @@ public:
       accessor<T, AccessorDims, access::mode::discard_write,
                access::target::device, IsPlaceholder,
                ext::oneapi::accessor_property_list<>>;
+
 
   static constexpr bool has_atomic_add_float64 =
       IsReduOptForAtomic64Add<T, BinaryOperation>::value;
@@ -705,6 +707,7 @@ private:
     return Acc;
   }
 
+  RedOutVar *MRedOut;
   /// User's accessor to where the reduction must be written.
   std::shared_ptr<rw_accessor_type> MRWAcc;
   std::shared_ptr<dw_accessor_type> MDWAcc;
@@ -731,16 +734,38 @@ template <typename T> struct AreAllButLastReductions<T> {
   static constexpr bool value =
       !std::is_base_of<reduction_impl_base, std::remove_reference_t<T>>::value;
 };
+template <class T>
+struct is_rw_acc_t : public std::false_type {};
+
+template <class T, int AccessorDims, access::placeholder IsPlaceholder>
+struct is_rw_acc_t<
+    accessor<T, AccessorDims, access::mode::read_write, access::target::device,
+             IsPlaceholder, ext::oneapi::accessor_property_list<>>>
+    : public std::true_type {};
+
+template <class T>
+struct is_dw_acc_t : public std::false_type {};
+
+template <class T, int AccessorDims, access::placeholder IsPlaceholder>
+struct is_dw_acc_t<accessor<T, AccessorDims, access::mode::discard_write,
+                            access::target::device, IsPlaceholder,
+                            ext::oneapi::accessor_property_list<>>>
+    : public std::true_type {};
 
 /// This class encapsulates the reduction variable/accessor,
 /// the reduction operator and an optional operator identity.
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          class Algorithm>
+          typename RedOutVar, class Algorithm>
 class reduction_impl
     : private reduction_impl_base,
-      public reduction_impl_algo<T, BinaryOperation, Dims, Extent, Algorithm> {
+      public reduction_impl_algo<T, BinaryOperation, Dims, Extent, RedOutVar,
+                                 Algorithm> {
 private:
-  using algo = reduction_impl_algo<T, BinaryOperation, Dims, Extent, Algorithm>;
+  using algo = reduction_impl_algo<T, BinaryOperation, Dims, Extent, RedOutVar,
+                                   Algorithm>;
+  static constexpr bool my_is_usm = std::is_same_v<RedOutVar, T *>;
+  static constexpr bool my_is_rw_acc = is_rw_acc_t<RedOutVar>::value;
+  static constexpr bool my_is_dw_acc = is_dw_acc_t<RedOutVar>::value;
 
 public:
   using reducer_type = typename algo::reducer_type;
@@ -753,8 +778,9 @@ public:
   /// SYCL-2020.
   /// Constructs reduction_impl when the identity value is statically known.
   template <typename _T, typename AllocatorT,
-            std::enable_if_t<sycl::detail::IsKnownIdentityOp<
-                _T, BinaryOperation>::value> * = nullptr>
+            std::enable_if_t<
+                sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
+                my_is_rw_acc> * = nullptr>
   reduction_impl(buffer<_T, 1, AllocatorT> Buffer, handler &CGH,
                  bool InitializeToIdentity)
       : algo(reducer_type::getIdentity(), BinaryOperation(),
@@ -767,8 +793,10 @@ public:
   }
 
   /// Constructs reduction_impl when the identity value is statically known.
-  template <typename _T = T, enable_if_t<sycl::detail::IsKnownIdentityOp<
-                                 _T, BinaryOperation>::value> * = nullptr>
+  template <
+      typename _T = T,
+      enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
+                  my_is_rw_acc> * = nullptr>
   reduction_impl(rw_accessor_type &Acc)
       : algo(reducer_type::getIdentity(), BinaryOperation(), false,
              std::make_shared<rw_accessor_type>(Acc)) {
@@ -779,8 +807,10 @@ public:
   }
 
   /// Constructs reduction_impl when the identity value is statically known.
-  template <typename _T = T, enable_if_t<sycl::detail::IsKnownIdentityOp<
-                                 _T, BinaryOperation>::value> * = nullptr>
+  template <
+      typename _T = T,
+      enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
+                  my_is_dw_acc> * = nullptr>
   reduction_impl(dw_accessor_type &Acc)
       : algo(reducer_type::getIdentity(), BinaryOperation(), true,
              std::make_shared<dw_accessor_type>(Acc)) {
@@ -795,8 +825,8 @@ public:
   /// and user still passed the identity value.
   template <
       typename _T, typename AllocatorT,
-      enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value>
-          * = nullptr>
+      enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
+                  my_is_rw_acc> * = nullptr>
   reduction_impl(buffer<_T, 1, AllocatorT> Buffer, handler &CGH,
                  const T & /*Identity*/, BinaryOperation,
                  bool InitializeToIdentity)
@@ -822,8 +852,10 @@ public:
 
   /// Constructs reduction_impl when the identity value is statically known,
   /// and user still passed the identity value.
-  template <typename _T = T, enable_if_t<sycl::detail::IsKnownIdentityOp<
-                                 _T, BinaryOperation>::value> * = nullptr>
+  template <
+      typename _T = T,
+      enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
+                  my_is_rw_acc> * = nullptr>
   reduction_impl(rw_accessor_type &Acc, const T & /*Identity*/, BinaryOperation)
       : algo(reducer_type::getIdentity(), BinaryOperation(), false,
              std::make_shared<rw_accessor_type>(Acc)) {
@@ -846,8 +878,10 @@ public:
 
   /// Constructs reduction_impl when the identity value is statically known,
   /// and user still passed the identity value.
-  template <typename _T = T, enable_if_t<sycl::detail::IsKnownIdentityOp<
-                                 _T, BinaryOperation>::value> * = nullptr>
+  template <
+      typename _T = T,
+      enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
+                  my_is_dw_acc> * = nullptr>
   reduction_impl(dw_accessor_type &Acc, const T & /*Identity*/, BinaryOperation)
       : algo(reducer_type::getIdentity(), BinaryOperation(), true,
              std::make_shared<dw_accessor_type>(Acc)) {
@@ -870,10 +904,10 @@ public:
 
   /// SYCL-2020.
   /// Constructs reduction_impl when the identity value is NOT known statically.
-  template <
-      typename _T, typename AllocatorT,
-      enable_if_t<!sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value>
-          * = nullptr>
+  template <typename _T, typename AllocatorT,
+            enable_if_t<
+                !sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
+                my_is_rw_acc> * = nullptr>
   reduction_impl(buffer<_T, 1, AllocatorT> Buffer, handler &CGH,
                  const T &Identity, BinaryOperation BOp,
                  bool InitializeToIdentity)
@@ -888,7 +922,8 @@ public:
 
   /// Constructs reduction_impl when the identity value is unknown.
   template <typename _T = T, enable_if_t<!sycl::detail::IsKnownIdentityOp<
-                                 _T, BinaryOperation>::value> * = nullptr>
+                                             _T, BinaryOperation>::value &&
+                                         my_is_rw_acc> * = nullptr>
   reduction_impl(rw_accessor_type &Acc, const T &Identity, BinaryOperation BOp)
       : algo(Identity, BOp, false, std::make_shared<rw_accessor_type>(Acc)) {
     if (Acc.size() != 1)
@@ -899,7 +934,8 @@ public:
 
   /// Constructs reduction_impl when the identity value is unknown.
   template <typename _T = T, enable_if_t<!sycl::detail::IsKnownIdentityOp<
-                                 _T, BinaryOperation>::value> * = nullptr>
+                                             _T, BinaryOperation>::value &&
+                                         my_is_dw_acc> * = nullptr>
   reduction_impl(dw_accessor_type &Acc, const T &Identity, BinaryOperation BOp)
       : algo(Identity, BOp, true, std::make_shared<dw_accessor_type>(Acc)) {
     if (Acc.size() != 1)
@@ -912,8 +948,10 @@ public:
   /// The \param VarPtr is a USM pointer to memory, to where the computed
   /// reduction value is added using BinaryOperation, i.e. it is expected that
   /// the memory is pre-initialized with some meaningful value.
-  template <typename _T = T, enable_if_t<sycl::detail::IsKnownIdentityOp<
-                                 _T, BinaryOperation>::value> * = nullptr>
+  template <
+      typename _T = T,
+      enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
+                  my_is_usm> * = nullptr>
   reduction_impl(T *VarPtr, bool InitializeToIdentity = false)
       : algo(reducer_type::getIdentity(), BinaryOperation(),
              InitializeToIdentity, VarPtr) {}
@@ -923,8 +961,10 @@ public:
   /// The \param VarPtr is a USM pointer to memory, to where the computed
   /// reduction value is added using BinaryOperation, i.e. it is expected that
   /// the memory is pre-initialized with some meaningful value.
-  template <typename _T = T, enable_if_t<sycl::detail::IsKnownIdentityOp<
-                                 _T, BinaryOperation>::value> * = nullptr>
+  template <
+      typename _T = T,
+      enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
+                  my_is_usm> * = nullptr>
   reduction_impl(T *VarPtr, const T &Identity, BinaryOperation,
                  bool InitializeToIdentity = false)
       : algo(Identity, BinaryOperation(), InitializeToIdentity, VarPtr) {
@@ -946,7 +986,8 @@ public:
   /// reduction value is added using BinaryOperation, i.e. it is expected that
   /// the memory is pre-initialized with some meaningful value.
   template <typename _T = T, enable_if_t<!sycl::detail::IsKnownIdentityOp<
-                                 _T, BinaryOperation>::value> * = nullptr>
+                                             _T, BinaryOperation>::value &&
+                                         my_is_usm> * = nullptr>
   reduction_impl(T *VarPtr, const T &Identity, BinaryOperation BOp,
                  bool InitializeToIdentity = false)
       : algo(Identity, BOp, InitializeToIdentity, VarPtr) {}
@@ -960,8 +1001,10 @@ public:
 
   /// Constructs reduction_impl when the identity value is statically known
   /// and user passed an identity value anyway
-  template <typename _T = T, enable_if_t<sycl::detail::IsKnownIdentityOp<
-                                 _T, BinaryOperation>::value> * = nullptr>
+  template <
+      typename _T = T,
+      enable_if_t<sycl::detail::IsKnownIdentityOp<_T, BinaryOperation>::value &&
+                  my_is_usm> * = nullptr>
   reduction_impl(span<_T, Extent> Span, const T & /* Identity */,
                  BinaryOperation BOp, bool InitializeToIdentity = false)
       : algo(reducer_type::getIdentity(), BOp, InitializeToIdentity,
@@ -969,7 +1012,8 @@ public:
 
   /// Constructs reduction_impl when the identity value is not statically known
   template <typename _T = T, enable_if_t<!sycl::detail::IsKnownIdentityOp<
-                                 _T, BinaryOperation>::value> * = nullptr>
+                                             _T, BinaryOperation>::value &&
+                                         my_is_usm> * = nullptr>
   reduction_impl(span<T, Extent> Span, const T &Identity, BinaryOperation BOp,
                  bool InitializeToIdentity = false)
       : algo(Identity, BOp, InitializeToIdentity, Span.data()) {}
@@ -2566,6 +2610,7 @@ tuple_select_elements(TupleT Tuple, std::index_sequence<Is...>) {
 template <typename T, class BinaryOperation, int Dims, access::mode AccMode,
           access::placeholder IsPH>
 detail::reduction_impl<T, BinaryOperation, 0, 1,
+                       accessor<T, Dims, AccMode, access::target::device, IsPH>,
                        detail::default_reduction_algorithm<false, IsPH, Dims>>
 reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
           const T &Identity, BinaryOperation BOp) {
@@ -2581,6 +2626,7 @@ template <typename T, class BinaryOperation, int Dims, access::mode AccMode,
 std::enable_if_t<sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value,
                  detail::reduction_impl<
                      T, BinaryOperation, 0, 1,
+                     accessor<T, Dims, AccMode, access::target::device, IsPH>,
                      detail::default_reduction_algorithm<false, IsPH, Dims>>>
 reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
           BinaryOperation) {
@@ -2593,7 +2639,7 @@ reduction(accessor<T, Dims, AccMode, access::target::device, IsPH> &Acc,
 /// \param Identity, and the binary operation used in the reduction.
 template <typename T, class BinaryOperation>
 detail::reduction_impl<
-    T, BinaryOperation, 0, 1,
+    T, BinaryOperation, 0, 1, T *,
     detail::default_reduction_algorithm<true, access::placeholder::false_t, 1>>
 reduction(T *VarPtr, const T &Identity, BinaryOperation BOp) {
   return {VarPtr, Identity, BOp};
@@ -2607,7 +2653,7 @@ reduction(T *VarPtr, const T &Identity, BinaryOperation BOp) {
 template <typename T, class BinaryOperation>
 std::enable_if_t<
     sycl::detail::IsKnownIdentityOp<T, BinaryOperation>::value,
-    detail::reduction_impl<T, BinaryOperation, 0, 1,
+    detail::reduction_impl<T, BinaryOperation, 0, 1, T *,
                            detail::default_reduction_algorithm<
                                true, access::placeholder::false_t, 1>>>
 reduction(T *VarPtr, BinaryOperation) {

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -579,16 +579,19 @@ public:
             std::enable_if_t<_self::my_is_rw_acc> * = nullptr>
   reduction_impl_algo(const T &Identity, BinaryOperation BinaryOp, bool Init,
                       std::shared_ptr<rw_accessor_type> AccPointer)
-      : base(Identity, BinaryOp, Init), MRWAcc(AccPointer){};
+      : base(Identity, BinaryOp, Init), MRWAcc(AccPointer),
+        MRedOut(*AccPointer){};
   template <class _self = self,
             std::enable_if_t<_self::my_is_dw_acc> * = nullptr>
   reduction_impl_algo(const T &Identity, BinaryOperation BinaryOp, bool Init,
                       std::shared_ptr<dw_accessor_type> AccPointer)
-      : base(Identity, BinaryOp, Init), MDWAcc(AccPointer){};
+      : base(Identity, BinaryOp, Init), MDWAcc(AccPointer),
+        MRedOut(*AccPointer){};
   template <class _self = self, std::enable_if_t<_self::my_is_usm> * = nullptr>
   reduction_impl_algo(const T &Identity, BinaryOperation BinaryOp, bool Init,
                       T *USMPointer)
-      : base(Identity, BinaryOp, Init), MUSMPointer(USMPointer){};
+      : base(Identity, BinaryOp, Init), MUSMPointer(USMPointer),
+        MRedOut(MUSMPointer){};
 
   /// Associates the reduction accessor to user's memory with \p CGH handler
   /// to keep the accessor alive until the command group finishes the work.
@@ -738,7 +741,6 @@ private:
     return Acc;
   }
 
-  RedOutVar *MRedOut;
   /// User's accessor to where the reduction must be written.
   std::shared_ptr<rw_accessor_type> MRWAcc;
   std::shared_ptr<dw_accessor_type> MDWAcc;
@@ -748,6 +750,8 @@ private:
   /// USM pointer referencing the memory to where the result of the reduction
   /// must be written. Applicable/used only for USM reductions.
   T *MUSMPointer = nullptr;
+
+  RedOutVar &MRedOut;
 };
 
 /// Predicate returning true if all template type parameters except the last one

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -496,8 +496,7 @@ protected:
   bool InitializeToIdentity;
 };
 
-template <class T>
-struct is_rw_acc_t : public std::false_type {};
+template <class T> struct is_rw_acc_t : public std::false_type {};
 
 template <class T, int AccessorDims, access::placeholder IsPlaceholder,
           typename PropList>
@@ -505,8 +504,7 @@ struct is_rw_acc_t<accessor<T, AccessorDims, access::mode::read_write,
                             access::target::device, IsPlaceholder, PropList>>
     : public std::true_type {};
 
-template <class T>
-struct is_dw_acc_t : public std::false_type {};
+template <class T> struct is_dw_acc_t : public std::false_type {};
 
 template <class T, int AccessorDims, access::placeholder IsPlaceholder,
           typename PropList>
@@ -514,17 +512,14 @@ struct is_dw_acc_t<accessor<T, AccessorDims, access::mode::discard_write,
                             access::target::device, IsPlaceholder, PropList>>
     : public std::true_type {};
 
-template <class T>
-struct is_placeholder_t : public std::false_type {};
+template <class T> struct is_placeholder_t : public std::false_type {};
 
 template <class T, int AccessorDims, access::mode Mode, typename PropList>
 struct is_placeholder_t<accessor<T, AccessorDims, Mode, access::target::device,
                                  access::placeholder::true_t, PropList>>
     : public std::true_type {};
 
-
-template <class T>
-struct accessor_dim_t {
+template <class T> struct accessor_dim_t {
   static constexpr int value = 1;
 };
 
@@ -536,7 +531,7 @@ struct accessor_dim_t<
 };
 
 template <class T> struct get_red_t;
-template <class T> struct get_red_t<T*> {
+template <class T> struct get_red_t<T *> {
   using type = T;
 };
 
@@ -790,10 +785,10 @@ private:
   }
 
 public:
-  using algo::is_usm;
-  using algo::is_rw_acc;
-  using algo::is_dw_acc;
   using algo::is_acc;
+  using algo::is_dw_acc;
+  using algo::is_rw_acc;
+  using algo::is_usm;
 
   using reducer_type = typename algo::reducer_type;
   using rw_accessor_type = typename algo::rw_accessor_type;
@@ -816,8 +811,8 @@ public:
   /// The \param VarPtr is a USM pointer to memory, to where the computed
   /// reduction value is added using BinaryOperation, i.e. it is expected that
   /// the memory is pre-initialized with some meaningful value.
-  template <typename _self = self, enable_if_t<_self::is_known_identity &&
-                                               _self::is_usm> * = nullptr>
+  template <typename _self = self,
+            enable_if_t<_self::is_known_identity && _self::is_usm> * = nullptr>
   reduction_impl(RedOutVar VarPtr, bool InitializeToIdentity = false)
       : algo(reducer_type::getIdentity(), BinaryOperation(),
              InitializeToIdentity, VarPtr) {}
@@ -870,9 +865,10 @@ public:
 
 template <class BinaryOp, int Dims, size_t Extent, typename RedOutVar,
           typename... RestTy>
-auto make_reduction(RedOutVar RedVar, RestTy &&... Rest) {
+auto make_reduction(RedOutVar RedVar, RestTy &&...Rest) {
   return reduction_impl<typename get_red_t<RedOutVar>::type, BinaryOp, Dims,
-                        Extent, RedOutVar>{RedVar, std::forward<RestTy>(Rest)...};
+                        Extent, RedOutVar>{RedVar,
+                                           std::forward<RestTy>(Rest)...};
 }
 
 /// A helper to pass undefined (sycl::detail::auto_name) names unmodified. We
@@ -1277,7 +1273,6 @@ void reduCGFuncForNDRangeFastAtomicsOnly(
     if (LID == 0) {
       Reducer.atomic_combine(Reduction::getOutPointer(Out));
     }
-
   });
 }
 
@@ -1805,7 +1800,9 @@ struct IsNonUsmReductionPredicate {
 };
 
 struct EmptyReductionPredicate {
-  template <typename T> struct Func { static constexpr bool value = false; };
+  template <typename T> struct Func {
+    static constexpr bool value = false;
+  };
 };
 
 template <bool Cond, size_t I> struct FilterElement {
@@ -2119,7 +2116,7 @@ void associateReduAccsWithHandlerHelper(handler &CGH, ReductionT &Redu) {
 template <typename ReductionT, typename... RestT,
           enable_if_t<(sizeof...(RestT) > 0), int> Z = 0>
 void associateReduAccsWithHandlerHelper(handler &CGH, ReductionT &Redu,
-                                        RestT &... Rest) {
+                                        RestT &...Rest) {
   Redu.associateWithHandler(CGH);
   associateReduAccsWithHandlerHelper(CGH, Rest...);
 }
@@ -2518,15 +2515,15 @@ __SYCL_INLINE_CONSTEXPR AccumulatorT known_identity_v =
 
 #ifdef __SYCL_INTERNAL_API
 namespace __SYCL2020_DEPRECATED("use 'ext::oneapi' instead") ONEAPI {
-  using namespace ext::oneapi;
-  namespace detail {
-  using cl::sycl::detail::queue_impl;
-  __SYCL_EXPORT size_t reduGetMaxWGSize(std::shared_ptr<queue_impl> Queue,
-                                        size_t LocalMemBytesPerWorkItem);
-  __SYCL_EXPORT size_t reduComputeWGSize(size_t NWorkItems, size_t MaxWGSize,
-                                         size_t &NWorkGroups);
-  } // namespace detail
-} // namespace ONEAPI
+using namespace ext::oneapi;
+namespace detail {
+using cl::sycl::detail::queue_impl;
+__SYCL_EXPORT size_t reduGetMaxWGSize(std::shared_ptr<queue_impl> Queue,
+                                      size_t LocalMemBytesPerWorkItem);
+__SYCL_EXPORT size_t reduComputeWGSize(size_t NWorkItems, size_t MaxWGSize,
+                                       size_t &NWorkGroups);
+} // namespace detail
+} // namespace __SYCL2020_DEPRECATED("use 'ext::oneapi' instead")ONEAPI
 #endif // __SYCL_INTERNAL_API
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -534,6 +534,9 @@ class reduction_impl_algo<
     default_reduction_algorithm<IsUSM, IsPlaceholder, AccessorDims>>
     : public reduction_impl_common<T, BinaryOperation> {
   using base = reduction_impl_common<T, BinaryOperation>;
+  using self = reduction_impl_algo<
+      T, BinaryOperation, Dims, Extent, RedOutVar,
+      default_reduction_algorithm<IsUSM, IsPlaceholder, AccessorDims>>;
 
 protected:
   static constexpr bool my_is_usm = std::is_same_v<RedOutVar, T *>;
@@ -572,12 +575,17 @@ public:
   static constexpr size_t dims = Dims;
   static constexpr size_t num_elements = Extent;
 
+  template <class _self = self,
+            std::enable_if_t<_self::my_is_rw_acc> * = nullptr>
   reduction_impl_algo(const T &Identity, BinaryOperation BinaryOp, bool Init,
                       std::shared_ptr<rw_accessor_type> AccPointer)
       : base(Identity, BinaryOp, Init), MRWAcc(AccPointer){};
+  template <class _self = self,
+            std::enable_if_t<_self::my_is_dw_acc> * = nullptr>
   reduction_impl_algo(const T &Identity, BinaryOperation BinaryOp, bool Init,
                       std::shared_ptr<dw_accessor_type> AccPointer)
       : base(Identity, BinaryOp, Init), MDWAcc(AccPointer){};
+  template <class _self = self, std::enable_if_t<_self::my_is_usm> * = nullptr>
   reduction_impl_algo(const T &Identity, BinaryOperation BinaryOp, bool Init,
                       T *USMPointer)
       : base(Identity, BinaryOp, Init), MUSMPointer(USMPointer){};

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -606,6 +606,12 @@ public:
 
   template <bool IsOneWG>
   auto getWriteMemForPartialReds(size_t Size, handler &CGH) {
+    // If there is only one WG we can avoid creation of temporary buffer with
+    // partial sums and write directly into user's reduction variable.
+    //
+    // Current implementation doesn't allow that in case of DW accessor used for
+    // reduction because C++ types for it and for temporary storage don't match,
+    // hence the second part of the check.
     if constexpr (IsOneWG && !is_dw_acc) {
       return MRedOut;
     } else {

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -774,7 +774,7 @@ public:
   template <typename _self = self,
             enable_if_t<_self::is_known_identity && _self::is_acc> * = nullptr>
   reduction_impl(RedOutVar &Acc)
-      : algo(reducer_type::getIdentity(), BinaryOperation(), false, Acc) {
+      : algo(reducer_type::getIdentity(), BinaryOperation(), is_dw_acc, Acc) {
     if (Acc.size() != 1)
       throw sycl::runtime_error(errc::invalid,
                                 "Reduction variable must be a scalar.",

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -242,7 +242,7 @@ namespace ext {
 namespace oneapi {
 namespace detail {
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          class Algorithm>
+          typename RedOutVar, class Algorithm>
 class reduction_impl_algo;
 
 using cl::sycl::detail::enable_if_t;
@@ -2667,7 +2667,7 @@ private:
   // Make reduction friends to store buffers and arrays created for it
   // in handler from reduction methods.
   template <typename T, class BinaryOperation, int Dims, size_t Extent,
-            class Algorithm>
+            typename RedOutVar, class Algorithm>
   friend class ext::oneapi::detail::reduction_impl_algo;
 
 #ifndef __SYCL_DEVICE_ONLY__

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -242,7 +242,7 @@ namespace ext {
 namespace oneapi {
 namespace detail {
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          typename RedOutVar, class Algorithm>
+          class Algorithm, typename RedOutVar>
 class reduction_impl_algo;
 
 using cl::sycl::detail::enable_if_t;
@@ -2667,7 +2667,7 @@ private:
   // Make reduction friends to store buffers and arrays created for it
   // in handler from reduction methods.
   template <typename T, class BinaryOperation, int Dims, size_t Extent,
-            typename RedOutVar, class Algorithm>
+            class Algorithm, typename RedOutVar>
   friend class ext::oneapi::detail::reduction_impl_algo;
 
 #ifndef __SYCL_DEVICE_ONLY__

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1655,7 +1655,7 @@ public:
         *this, KernelFunc, Range, MaxWGSize, NumConcurrentWorkGroups, Redu);
     if (Reduction::is_usm ||
         (Reduction::has_fast_atomics && Redu.initializeToIdentity()) ||
-        (!Reduction::has_fast_atomics && Redu.hasUserDiscardWriteAccessor())) {
+        (!Reduction::has_fast_atomics && Reduction::my_is_dw_acc)) {
       this->finalize();
       MLastEvent = withAuxHandler(QueueCopy, [&](handler &CopyHandler) {
         ext::oneapi::detail::reduSaveFinalResultToUserMem<KernelName>(
@@ -1782,7 +1782,7 @@ public:
       });
     } // end while (NWorkItems > 1)
 
-    if (Reduction::is_usm || Redu.hasUserDiscardWriteAccessor()) {
+    if (Reduction::is_usm || Reduction::my_is_dw_acc) {
       MLastEvent = withAuxHandler(QueueCopy, [&](handler &CopyHandler) {
         ext::oneapi::detail::reduSaveFinalResultToUserMem<KernelName>(
             CopyHandler, Redu);

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -242,7 +242,7 @@ namespace ext {
 namespace oneapi {
 namespace detail {
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
-          class Algorithm, typename RedOutVar>
+          typename RedOutVar>
 class reduction_impl_algo;
 
 using cl::sycl::detail::enable_if_t;
@@ -2667,7 +2667,7 @@ private:
   // Make reduction friends to store buffers and arrays created for it
   // in handler from reduction methods.
   template <typename T, class BinaryOperation, int Dims, size_t Extent,
-            class Algorithm, typename RedOutVar>
+            typename RedOutVar>
   friend class ext::oneapi::detail::reduction_impl_algo;
 
 #ifndef __SYCL_DEVICE_ONLY__

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1655,7 +1655,7 @@ public:
         *this, KernelFunc, Range, MaxWGSize, NumConcurrentWorkGroups, Redu);
     if (Reduction::is_usm ||
         (Reduction::has_fast_atomics && Redu.initializeToIdentity()) ||
-        (!Reduction::has_fast_atomics && Reduction::my_is_dw_acc)) {
+        (!Reduction::has_fast_atomics && Reduction::is_dw_acc)) {
       this->finalize();
       MLastEvent = withAuxHandler(QueueCopy, [&](handler &CopyHandler) {
         ext::oneapi::detail::reduSaveFinalResultToUserMem<KernelName>(
@@ -1782,7 +1782,7 @@ public:
       });
     } // end while (NWorkItems > 1)
 
-    if (Reduction::is_usm || Reduction::my_is_dw_acc) {
+    if (Reduction::is_usm || Reduction::is_dw_acc) {
       MLastEvent = withAuxHandler(QueueCopy, [&](handler &CopyHandler) {
         ext::oneapi::detail::reduSaveFinalResultToUserMem<KernelName>(
             CopyHandler, Redu);

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -21,11 +21,15 @@ namespace sycl {
 /// Constructs a reduction object using the given buffer \p Var, handler \p CGH,
 /// reduction operation \p Combiner, and optional reduction properties.
 template <typename T, typename AllocatorT, typename BinaryOperation>
-std::enable_if_t<has_known_identity<BinaryOperation, T>::value,
-                 ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 0, 1,
-                     ext::oneapi::detail::default_reduction_algorithm<
-                         false, access::placeholder::true_t, 1>>>
+std::enable_if_t<
+    has_known_identity<BinaryOperation, T>::value,
+    ext::oneapi::detail::reduction_impl<
+        T, BinaryOperation, 0, 1,
+        accessor<T, 0, access::mode::read_write, access::target::device,
+                 access::placeholder::true_t,
+                 ext::oneapi::accessor_property_list<>>,
+        ext::oneapi::detail::default_reduction_algorithm<
+            false, access::placeholder::true_t, 1>>>
 reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, BinaryOperation,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -38,11 +42,15 @@ reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, BinaryOperation,
 /// The reduction algorithm may be less efficient for this variant as the
 /// reduction identity is not known statically and it is not provided by user.
 template <typename T, typename AllocatorT, typename BinaryOperation>
-std::enable_if_t<!has_known_identity<BinaryOperation, T>::value,
-                 ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 0, 1,
-                     ext::oneapi::detail::default_reduction_algorithm<
-                         false, access::placeholder::true_t, 1>>>
+std::enable_if_t<
+    !has_known_identity<BinaryOperation, T>::value,
+    ext::oneapi::detail::reduction_impl<
+        T, BinaryOperation, 0, 1,
+        accessor<T, 0, access::mode::read_write, access::target::device,
+                 access::placeholder::true_t,
+                 ext::oneapi::accessor_property_list<>>,
+        ext::oneapi::detail::default_reduction_algorithm<
+            false, access::placeholder::true_t, 1>>>
 reduction(buffer<T, 1, AllocatorT>, handler &, BinaryOperation,
           const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
@@ -58,7 +66,7 @@ reduction(buffer<T, 1, AllocatorT>, handler &, BinaryOperation,
 template <typename T, typename BinaryOperation>
 std::enable_if_t<has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 0, 1,
+                     T, BinaryOperation, 0, 1, T *,
                      ext::oneapi::detail::default_reduction_algorithm<
                          true, access::placeholder::false_t, 1>>>
 reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
@@ -75,7 +83,7 @@ reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
 template <typename T, typename BinaryOperation>
 std::enable_if_t<!has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 0, 1,
+                     T, BinaryOperation, 0, 1, T *,
                      ext::oneapi::detail::default_reduction_algorithm<
                          true, access::placeholder::false_t, 1>>>
 reduction(T *, BinaryOperation, const property_list &PropList = {}) {
@@ -92,6 +100,9 @@ reduction(T *, BinaryOperation, const property_list &PropList = {}) {
 template <typename T, typename AllocatorT, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
     T, BinaryOperation, 0, 1,
+    accessor<T, 0, access::mode::read_write, access::target::device,
+             access::placeholder::true_t,
+             ext::oneapi::accessor_property_list<>>,
     ext::oneapi::detail::default_reduction_algorithm<
         false, access::placeholder::true_t, 1>>
 reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
@@ -106,7 +117,7 @@ reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
 /// binary operation \p Combiner, and optional reduction properties.
 template <typename T, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
-    T, BinaryOperation, 0, 1,
+    T, BinaryOperation, 0, 1, T *,
     ext::oneapi::detail::default_reduction_algorithm<
         true, access::placeholder::false_t, 1>>
 reduction(T *Var, const T &Identity, BinaryOperation Combiner,
@@ -124,7 +135,7 @@ template <typename T, size_t Extent, typename BinaryOperation>
 std::enable_if_t<Extent != dynamic_extent &&
                      has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, Extent,
+                     T, BinaryOperation, 1, Extent, T *,
                      ext::oneapi::detail::default_reduction_algorithm<
                          true, access::placeholder::false_t, 1>>>
 reduction(span<T, Extent> Span, BinaryOperation,
@@ -143,7 +154,7 @@ template <typename T, size_t Extent, typename BinaryOperation>
 std::enable_if_t<Extent != dynamic_extent &&
                      !has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, Extent,
+                     T, BinaryOperation, 1, Extent, T *,
                      ext::oneapi::detail::default_reduction_algorithm<
                          true, access::placeholder::false_t, 1>>>
 reduction(span<T, Extent>, BinaryOperation,
@@ -161,7 +172,7 @@ reduction(span<T, Extent>, BinaryOperation,
 template <typename T, size_t Extent, typename BinaryOperation>
 std::enable_if_t<Extent != dynamic_extent,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, Extent,
+                     T, BinaryOperation, 1, Extent, T *,
                      ext::oneapi::detail::default_reduction_algorithm<
                          true, access::placeholder::false_t, 1>>>
 reduction(span<T, Extent> Span, const T &Identity, BinaryOperation Combiner,

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -89,9 +89,8 @@ reduction(T *, BinaryOperation, const property_list &PropList = {}) {
 /// reduction identity value \p Identity, reduction operation \p Combiner,
 /// and optional reduction properties.
 template <typename T, typename AllocatorT, typename BinaryOperation>
-auto
-reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
-          BinaryOperation Combiner, const property_list &PropList = {}) {
+auto reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
+               BinaryOperation Combiner, const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
   return ext::oneapi::detail::make_reduction<BinaryOperation, 0, 1>(

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -25,11 +25,11 @@ std::enable_if_t<
     has_known_identity<BinaryOperation, T>::value,
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
+        ext::oneapi::detail::default_reduction_algorithm<
+            false, access::placeholder::true_t, 1>,
         accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
-                 ext::oneapi::accessor_property_list<>>,
-        ext::oneapi::detail::default_reduction_algorithm<
-            false, access::placeholder::true_t, 1>>>
+                 ext::oneapi::accessor_property_list<>>>>
 reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, BinaryOperation,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -46,11 +46,11 @@ std::enable_if_t<
     !has_known_identity<BinaryOperation, T>::value,
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
+        ext::oneapi::detail::default_reduction_algorithm<
+            false, access::placeholder::true_t, 1>,
         accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
-                 ext::oneapi::accessor_property_list<>>,
-        ext::oneapi::detail::default_reduction_algorithm<
-            false, access::placeholder::true_t, 1>>>
+                 ext::oneapi::accessor_property_list<>>>>
 reduction(buffer<T, 1, AllocatorT>, handler &, BinaryOperation,
           const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
@@ -66,9 +66,10 @@ reduction(buffer<T, 1, AllocatorT>, handler &, BinaryOperation,
 template <typename T, typename BinaryOperation>
 std::enable_if_t<has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 0, 1, T *,
+                     T, BinaryOperation, 0, 1,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>>>
+                         true, access::placeholder::false_t, 1>,
+                     T *>>
 reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
@@ -83,9 +84,10 @@ reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
 template <typename T, typename BinaryOperation>
 std::enable_if_t<!has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 0, 1, T *,
+                     T, BinaryOperation, 0, 1,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>>>
+                         true, access::placeholder::false_t, 1>,
+                     T *>>
 reduction(T *, BinaryOperation, const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
   (void)PropList;
@@ -100,11 +102,11 @@ reduction(T *, BinaryOperation, const property_list &PropList = {}) {
 template <typename T, typename AllocatorT, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
     T, BinaryOperation, 0, 1,
+    ext::oneapi::detail::default_reduction_algorithm<
+        false, access::placeholder::true_t, 1>,
     accessor<T, 1, access::mode::read_write, access::target::device,
              access::placeholder::true_t,
-             ext::oneapi::accessor_property_list<>>,
-    ext::oneapi::detail::default_reduction_algorithm<
-        false, access::placeholder::true_t, 1>>
+             ext::oneapi::accessor_property_list<>>>
 reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
           BinaryOperation Combiner, const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -117,9 +119,10 @@ reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
 /// binary operation \p Combiner, and optional reduction properties.
 template <typename T, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
-    T, BinaryOperation, 0, 1, T *,
+    T, BinaryOperation, 0, 1,
     ext::oneapi::detail::default_reduction_algorithm<
-        true, access::placeholder::false_t, 1>>
+        true, access::placeholder::false_t, 1>,
+    T *>
 reduction(T *Var, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -135,9 +138,9 @@ template <typename T, size_t Extent, typename BinaryOperation>
 std::enable_if_t<Extent != dynamic_extent &&
                      has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, Extent, T *,
+                     T, BinaryOperation, 1, Extent,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>>>
+                         true, access::placeholder::false_t, 1>, T *>>
 reduction(span<T, Extent> Span, BinaryOperation,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -154,9 +157,10 @@ template <typename T, size_t Extent, typename BinaryOperation>
 std::enable_if_t<Extent != dynamic_extent &&
                      !has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, Extent, T *,
+                     T, BinaryOperation, 1, Extent,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>>>
+                         true, access::placeholder::false_t, 1>,
+                     T *>>
 reduction(span<T, Extent>, BinaryOperation,
           const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
@@ -172,9 +176,10 @@ reduction(span<T, Extent>, BinaryOperation,
 template <typename T, size_t Extent, typename BinaryOperation>
 std::enable_if_t<Extent != dynamic_extent,
                  ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, Extent, T *,
+                     T, BinaryOperation, 1, Extent,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>>>
+                         true, access::placeholder::false_t, 1>,
+                     T *>>
 reduction(span<T, Extent> Span, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -25,8 +25,7 @@ std::enable_if_t<
     has_known_identity<BinaryOperation, T>::value,
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
-        ext::oneapi::detail::default_reduction_algorithm<
-            access::placeholder::true_t, 1>,
+        ext::oneapi::detail::default_reduction_algorithm<1>,
         accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
                  ext::oneapi::accessor_property_list<>>>>
@@ -46,8 +45,7 @@ std::enable_if_t<
     !has_known_identity<BinaryOperation, T>::value,
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
-        ext::oneapi::detail::default_reduction_algorithm<
-            access::placeholder::true_t, 1>,
+        ext::oneapi::detail::default_reduction_algorithm<1>,
         accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
                  ext::oneapi::accessor_property_list<>>>>
@@ -67,9 +65,7 @@ template <typename T, typename BinaryOperation>
 std::enable_if_t<has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 0, 1,
-                     ext::oneapi::detail::default_reduction_algorithm<
-                         access::placeholder::false_t, 1>,
-                     T *>>
+                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
 reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
@@ -85,9 +81,7 @@ template <typename T, typename BinaryOperation>
 std::enable_if_t<!has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 0, 1,
-                     ext::oneapi::detail::default_reduction_algorithm<
-                         access::placeholder::false_t, 1>,
-                     T *>>
+                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
 reduction(T *, BinaryOperation, const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
   (void)PropList;
@@ -102,8 +96,7 @@ reduction(T *, BinaryOperation, const property_list &PropList = {}) {
 template <typename T, typename AllocatorT, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
     T, BinaryOperation, 0, 1,
-    ext::oneapi::detail::default_reduction_algorithm<
-        access::placeholder::true_t, 1>,
+    ext::oneapi::detail::default_reduction_algorithm<1>,
     accessor<T, 1, access::mode::read_write, access::target::device,
              access::placeholder::true_t,
              ext::oneapi::accessor_property_list<>>>
@@ -120,9 +113,7 @@ reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
 template <typename T, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
     T, BinaryOperation, 0, 1,
-    ext::oneapi::detail::default_reduction_algorithm<
-        access::placeholder::false_t, 1>,
-    T *>
+    ext::oneapi::detail::default_reduction_algorithm<1>, T *>
 reduction(T *Var, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -139,9 +130,7 @@ std::enable_if_t<Extent != dynamic_extent &&
                      has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 1, Extent,
-                     ext::oneapi::detail::default_reduction_algorithm<
-                         access::placeholder::false_t, 1>,
-                     T *>>
+                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
 reduction(span<T, Extent> Span, BinaryOperation,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -159,9 +148,7 @@ std::enable_if_t<Extent != dynamic_extent &&
                      !has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 1, Extent,
-                     ext::oneapi::detail::default_reduction_algorithm<
-                         access::placeholder::false_t, 1>,
-                     T *>>
+                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
 reduction(span<T, Extent>, BinaryOperation,
           const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
@@ -178,9 +165,7 @@ template <typename T, size_t Extent, typename BinaryOperation>
 std::enable_if_t<Extent != dynamic_extent,
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 1, Extent,
-                     ext::oneapi::detail::default_reduction_algorithm<
-                         access::placeholder::false_t, 1>,
-                     T *>>
+                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
 reduction(span<T, Extent> Span, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -25,7 +25,7 @@ std::enable_if_t<
     has_known_identity<BinaryOperation, T>::value,
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
-        accessor<T, 0, access::mode::read_write, access::target::device,
+        accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
                  ext::oneapi::accessor_property_list<>>,
         ext::oneapi::detail::default_reduction_algorithm<
@@ -46,7 +46,7 @@ std::enable_if_t<
     !has_known_identity<BinaryOperation, T>::value,
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
-        accessor<T, 0, access::mode::read_write, access::target::device,
+        accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
                  ext::oneapi::accessor_property_list<>>,
         ext::oneapi::detail::default_reduction_algorithm<
@@ -100,7 +100,7 @@ reduction(T *, BinaryOperation, const property_list &PropList = {}) {
 template <typename T, typename AllocatorT, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
     T, BinaryOperation, 0, 1,
-    accessor<T, 0, access::mode::read_write, access::target::device,
+    accessor<T, 1, access::mode::read_write, access::target::device,
              access::placeholder::true_t,
              ext::oneapi::accessor_property_list<>>,
     ext::oneapi::detail::default_reduction_algorithm<

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -28,10 +28,7 @@ auto reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, BinaryOperation,
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
   return ext::oneapi::detail::make_reduction<BinaryOperation, 0, 1>(
-      accessor<T, 1, access::mode::read_write, access::target::device,
-               access::placeholder::true_t,
-               ext::oneapi::accessor_property_list<>>{Var},
-      CGH, InitializeToIdentity);
+      accessor{Var}, CGH, InitializeToIdentity);
 }
 
 /// Constructs a reduction object using the given buffer \p Var, handler \p CGH,
@@ -94,10 +91,7 @@ auto reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
   return ext::oneapi::detail::make_reduction<BinaryOperation, 0, 1>(
-      accessor<T, 1, access::mode::read_write, access::target::device,
-               access::placeholder::true_t,
-               ext::oneapi::accessor_property_list<>>{Var},
-      CGH, Identity, Combiner, InitializeToIdentity);
+      accessor{Var}, CGH, Identity, Combiner, InitializeToIdentity);
 }
 
 /// Constructs a reduction object using the reduction variable referenced by

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -25,7 +25,6 @@ std::enable_if_t<
     has_known_identity<BinaryOperation, T>::value,
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
-        ext::oneapi::detail::default_reduction_algorithm<1>,
         accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
                  ext::oneapi::accessor_property_list<>>>>
@@ -45,7 +44,6 @@ std::enable_if_t<
     !has_known_identity<BinaryOperation, T>::value,
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
-        ext::oneapi::detail::default_reduction_algorithm<1>,
         accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
                  ext::oneapi::accessor_property_list<>>>>
@@ -62,10 +60,9 @@ reduction(buffer<T, 1, AllocatorT>, handler &, BinaryOperation,
 /// the given USM pointer \p Var, handler \p CGH, reduction operation
 /// \p Combiner, and optional reduction properties.
 template <typename T, typename BinaryOperation>
-std::enable_if_t<has_known_identity<BinaryOperation, T>::value,
-                 ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 0, 1,
-                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
+std::enable_if_t<
+    has_known_identity<BinaryOperation, T>::value,
+    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 0, 1, T *>>
 reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
@@ -78,10 +75,9 @@ reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
 /// The reduction algorithm may be less efficient for this variant as the
 /// reduction identity is not known statically and it is not provided by user.
 template <typename T, typename BinaryOperation>
-std::enable_if_t<!has_known_identity<BinaryOperation, T>::value,
-                 ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 0, 1,
-                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
+std::enable_if_t<
+    !has_known_identity<BinaryOperation, T>::value,
+    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 0, 1, T *>>
 reduction(T *, BinaryOperation, const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
   (void)PropList;
@@ -96,7 +92,6 @@ reduction(T *, BinaryOperation, const property_list &PropList = {}) {
 template <typename T, typename AllocatorT, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
     T, BinaryOperation, 0, 1,
-    ext::oneapi::detail::default_reduction_algorithm<1>,
     accessor<T, 1, access::mode::read_write, access::target::device,
              access::placeholder::true_t,
              ext::oneapi::accessor_property_list<>>>
@@ -111,9 +106,7 @@ reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
 /// the given USM pointer \p Var, reduction identity value \p Identity,
 /// binary operation \p Combiner, and optional reduction properties.
 template <typename T, typename BinaryOperation>
-ext::oneapi::detail::reduction_impl<
-    T, BinaryOperation, 0, 1,
-    ext::oneapi::detail::default_reduction_algorithm<1>, T *>
+ext::oneapi::detail::reduction_impl<T, BinaryOperation, 0, 1, T *>
 reduction(T *Var, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -126,11 +119,9 @@ reduction(T *Var, const T &Identity, BinaryOperation Combiner,
 /// the given sycl::span \p Span, reduction operation \p Combiner, and
 /// optional reduction properties.
 template <typename T, size_t Extent, typename BinaryOperation>
-std::enable_if_t<Extent != dynamic_extent &&
-                     has_known_identity<BinaryOperation, T>::value,
-                 ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, Extent,
-                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
+std::enable_if_t<
+    Extent != dynamic_extent && has_known_identity<BinaryOperation, T>::value,
+    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, Extent, T *>>
 reduction(span<T, Extent> Span, BinaryOperation,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -144,11 +135,9 @@ reduction(span<T, Extent> Span, BinaryOperation,
 /// The reduction algorithm may be less efficient for this variant as the
 /// reduction identity is not known statically and it is not provided by user.
 template <typename T, size_t Extent, typename BinaryOperation>
-std::enable_if_t<Extent != dynamic_extent &&
-                     !has_known_identity<BinaryOperation, T>::value,
-                 ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, Extent,
-                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
+std::enable_if_t<
+    Extent != dynamic_extent && !has_known_identity<BinaryOperation, T>::value,
+    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, Extent, T *>>
 reduction(span<T, Extent>, BinaryOperation,
           const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
@@ -162,10 +151,9 @@ reduction(span<T, Extent>, BinaryOperation,
 /// the given sycl::span \p Span, reduction identity value \p Identity,
 /// reduction operation \p Combiner, and optional reduction properties.
 template <typename T, size_t Extent, typename BinaryOperation>
-std::enable_if_t<Extent != dynamic_extent,
-                 ext::oneapi::detail::reduction_impl<
-                     T, BinaryOperation, 1, Extent,
-                     ext::oneapi::detail::default_reduction_algorithm<1>, T *>>
+std::enable_if_t<
+    Extent != dynamic_extent,
+    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, Extent, T *>>
 reduction(span<T, Extent> Span, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -20,33 +20,32 @@ namespace sycl {
 
 /// Constructs a reduction object using the given buffer \p Var, handler \p CGH,
 /// reduction operation \p Combiner, and optional reduction properties.
-template <typename T, typename AllocatorT, typename BinaryOperation>
-std::enable_if_t<
-    has_known_identity<BinaryOperation, T>::value,
-    ext::oneapi::detail::reduction_impl<
-        T, BinaryOperation, 0, 1,
-        accessor<T, 1, access::mode::read_write, access::target::device,
-                 access::placeholder::true_t,
-                 ext::oneapi::accessor_property_list<>>>>
-reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, BinaryOperation,
-          const property_list &PropList = {}) {
+template <
+    typename T, typename AllocatorT, typename BinaryOperation,
+    typename = std::enable_if_t<has_known_identity<BinaryOperation, T>::value>>
+auto reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, BinaryOperation,
+               const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
-  return {Var, CGH, InitializeToIdentity};
+  return ext::oneapi::detail::make_reduction<BinaryOperation, 0, 1>(
+      accessor<T, 1, access::mode::read_write, access::target::device,
+               access::placeholder::true_t,
+               ext::oneapi::accessor_property_list<>>{Var},
+      CGH, InitializeToIdentity);
 }
 
 /// Constructs a reduction object using the given buffer \p Var, handler \p CGH,
 /// reduction operation \p Combiner, and optional reduction properties.
 /// The reduction algorithm may be less efficient for this variant as the
 /// reduction identity is not known statically and it is not provided by user.
-template <typename T, typename AllocatorT, typename BinaryOperation>
-std::enable_if_t<
-    !has_known_identity<BinaryOperation, T>::value,
-    ext::oneapi::detail::reduction_impl<
-        T, BinaryOperation, 0, 1,
-        accessor<T, 1, access::mode::read_write, access::target::device,
-                 access::placeholder::true_t,
-                 ext::oneapi::accessor_property_list<>>>>
+template <
+    typename T, typename AllocatorT, typename BinaryOperation,
+    typename = std::enable_if_t<!has_known_identity<BinaryOperation, T>::value>>
+ext::oneapi::detail::reduction_impl<
+    T, BinaryOperation, 0, 1,
+    accessor<T, 1, access::mode::read_write, access::target::device,
+             access::placeholder::true_t,
+             ext::oneapi::accessor_property_list<>>>
 reduction(buffer<T, 1, AllocatorT>, handler &, BinaryOperation,
           const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
@@ -59,14 +58,14 @@ reduction(buffer<T, 1, AllocatorT>, handler &, BinaryOperation,
 /// Constructs a reduction object using the reduction variable referenced by
 /// the given USM pointer \p Var, handler \p CGH, reduction operation
 /// \p Combiner, and optional reduction properties.
-template <typename T, typename BinaryOperation>
-std::enable_if_t<
-    has_known_identity<BinaryOperation, T>::value,
-    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 0, 1, T *>>
-reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
+template <
+    typename T, typename BinaryOperation,
+    typename = std::enable_if_t<has_known_identity<BinaryOperation, T>::value>>
+auto reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
-  return {Var, InitializeToIdentity};
+  return ext::oneapi::detail::make_reduction<BinaryOperation, 0, 1>(
+      Var, InitializeToIdentity);
 }
 
 /// Constructs a reduction object using the reduction variable referenced by
@@ -74,10 +73,10 @@ reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
 /// \p Combiner, and optional reduction properties.
 /// The reduction algorithm may be less efficient for this variant as the
 /// reduction identity is not known statically and it is not provided by user.
-template <typename T, typename BinaryOperation>
-std::enable_if_t<
-    !has_known_identity<BinaryOperation, T>::value,
-    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 0, 1, T *>>
+template <
+    typename T, typename BinaryOperation,
+    typename = std::enable_if_t<!has_known_identity<BinaryOperation, T>::value>>
+ext::oneapi::detail::reduction_impl<T, BinaryOperation, 0, 1, T *>
 reduction(T *, BinaryOperation, const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
   (void)PropList;
@@ -90,43 +89,44 @@ reduction(T *, BinaryOperation, const property_list &PropList = {}) {
 /// reduction identity value \p Identity, reduction operation \p Combiner,
 /// and optional reduction properties.
 template <typename T, typename AllocatorT, typename BinaryOperation>
-ext::oneapi::detail::reduction_impl<
-    T, BinaryOperation, 0, 1,
-    accessor<T, 1, access::mode::read_write, access::target::device,
-             access::placeholder::true_t,
-             ext::oneapi::accessor_property_list<>>>
+auto
 reduction(buffer<T, 1, AllocatorT> Var, handler &CGH, const T &Identity,
           BinaryOperation Combiner, const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
-  return {Var, CGH, Identity, Combiner, InitializeToIdentity};
+  return ext::oneapi::detail::make_reduction<BinaryOperation, 0, 1>(
+      accessor<T, 1, access::mode::read_write, access::target::device,
+               access::placeholder::true_t,
+               ext::oneapi::accessor_property_list<>>{Var},
+      CGH, Identity, Combiner, InitializeToIdentity);
 }
 
 /// Constructs a reduction object using the reduction variable referenced by
 /// the given USM pointer \p Var, reduction identity value \p Identity,
 /// binary operation \p Combiner, and optional reduction properties.
 template <typename T, typename BinaryOperation>
-ext::oneapi::detail::reduction_impl<T, BinaryOperation, 0, 1, T *>
-reduction(T *Var, const T &Identity, BinaryOperation Combiner,
-          const property_list &PropList = {}) {
+auto reduction(T *Var, const T &Identity, BinaryOperation Combiner,
+               const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
-  return {Var, Identity, Combiner, InitializeToIdentity};
+  return ext::oneapi::detail::make_reduction<BinaryOperation, 0, 1>(
+      Var, Identity, Combiner, InitializeToIdentity);
 }
 
 #if __cplusplus >= 201703L
 /// Constructs a reduction object using the reduction variable referenced by
 /// the given sycl::span \p Span, reduction operation \p Combiner, and
 /// optional reduction properties.
-template <typename T, size_t Extent, typename BinaryOperation>
-std::enable_if_t<
-    Extent != dynamic_extent && has_known_identity<BinaryOperation, T>::value,
-    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, Extent, T *>>
-reduction(span<T, Extent> Span, BinaryOperation,
-          const property_list &PropList = {}) {
+template <
+    typename T, size_t Extent, typename BinaryOperation,
+    typename = std::enable_if_t<Extent != dynamic_extent &&
+                                has_known_identity<BinaryOperation, T>::value>>
+auto reduction(span<T, Extent> Span, BinaryOperation,
+               const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
-  return {Span, InitializeToIdentity};
+  return ext::oneapi::detail::make_reduction<BinaryOperation, 1, Extent>(
+      Span.data(), InitializeToIdentity);
 }
 
 /// Constructs a reduction object using the reduction variable referenced by
@@ -134,10 +134,11 @@ reduction(span<T, Extent> Span, BinaryOperation,
 /// optional reduction properties.
 /// The reduction algorithm may be less efficient for this variant as the
 /// reduction identity is not known statically and it is not provided by user.
-template <typename T, size_t Extent, typename BinaryOperation>
-std::enable_if_t<
-    Extent != dynamic_extent && !has_known_identity<BinaryOperation, T>::value,
-    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, Extent, T *>>
+template <
+    typename T, size_t Extent, typename BinaryOperation,
+    typename = std::enable_if_t<Extent != dynamic_extent &&
+                                !has_known_identity<BinaryOperation, T>::value>>
+ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, Extent, T *>
 reduction(span<T, Extent>, BinaryOperation,
           const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
@@ -150,15 +151,14 @@ reduction(span<T, Extent>, BinaryOperation,
 /// Constructs a reduction object using the reduction variable referenced by
 /// the given sycl::span \p Span, reduction identity value \p Identity,
 /// reduction operation \p Combiner, and optional reduction properties.
-template <typename T, size_t Extent, typename BinaryOperation>
-std::enable_if_t<
-    Extent != dynamic_extent,
-    ext::oneapi::detail::reduction_impl<T, BinaryOperation, 1, Extent, T *>>
-reduction(span<T, Extent> Span, const T &Identity, BinaryOperation Combiner,
-          const property_list &PropList = {}) {
+template <typename T, size_t Extent, typename BinaryOperation,
+          typename = std::enable_if_t<Extent != dynamic_extent>>
+auto reduction(span<T, Extent> Span, const T &Identity,
+               BinaryOperation Combiner, const property_list &PropList = {}) {
   bool InitializeToIdentity =
       PropList.has_property<property::reduction::initialize_to_identity>();
-  return {Span, Identity, Combiner, InitializeToIdentity};
+  return ext::oneapi::detail::make_reduction<BinaryOperation, 1, Extent>(
+      Span.data(), Identity, Combiner, InitializeToIdentity);
 }
 #endif
 

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -26,7 +26,7 @@ std::enable_if_t<
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
         ext::oneapi::detail::default_reduction_algorithm<
-            false, access::placeholder::true_t, 1>,
+            access::placeholder::true_t, 1>,
         accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
                  ext::oneapi::accessor_property_list<>>>>
@@ -47,7 +47,7 @@ std::enable_if_t<
     ext::oneapi::detail::reduction_impl<
         T, BinaryOperation, 0, 1,
         ext::oneapi::detail::default_reduction_algorithm<
-            false, access::placeholder::true_t, 1>,
+            access::placeholder::true_t, 1>,
         accessor<T, 1, access::mode::read_write, access::target::device,
                  access::placeholder::true_t,
                  ext::oneapi::accessor_property_list<>>>>
@@ -68,7 +68,7 @@ std::enable_if_t<has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 0, 1,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>,
+                         access::placeholder::false_t, 1>,
                      T *>>
 reduction(T *Var, BinaryOperation, const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -86,7 +86,7 @@ std::enable_if_t<!has_known_identity<BinaryOperation, T>::value,
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 0, 1,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>,
+                         access::placeholder::false_t, 1>,
                      T *>>
 reduction(T *, BinaryOperation, const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.
@@ -103,7 +103,7 @@ template <typename T, typename AllocatorT, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
     T, BinaryOperation, 0, 1,
     ext::oneapi::detail::default_reduction_algorithm<
-        false, access::placeholder::true_t, 1>,
+        access::placeholder::true_t, 1>,
     accessor<T, 1, access::mode::read_write, access::target::device,
              access::placeholder::true_t,
              ext::oneapi::accessor_property_list<>>>
@@ -121,7 +121,7 @@ template <typename T, typename BinaryOperation>
 ext::oneapi::detail::reduction_impl<
     T, BinaryOperation, 0, 1,
     ext::oneapi::detail::default_reduction_algorithm<
-        true, access::placeholder::false_t, 1>,
+        access::placeholder::false_t, 1>,
     T *>
 reduction(T *Var, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {
@@ -140,7 +140,8 @@ std::enable_if_t<Extent != dynamic_extent &&
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 1, Extent,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>, T *>>
+                         access::placeholder::false_t, 1>,
+                     T *>>
 reduction(span<T, Extent> Span, BinaryOperation,
           const property_list &PropList = {}) {
   bool InitializeToIdentity =
@@ -159,7 +160,7 @@ std::enable_if_t<Extent != dynamic_extent &&
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 1, Extent,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>,
+                         access::placeholder::false_t, 1>,
                      T *>>
 reduction(span<T, Extent>, BinaryOperation,
           const property_list &PropList = {}) {
@@ -178,7 +179,7 @@ std::enable_if_t<Extent != dynamic_extent,
                  ext::oneapi::detail::reduction_impl<
                      T, BinaryOperation, 1, Extent,
                      ext::oneapi::detail::default_reduction_algorithm<
-                         true, access::placeholder::false_t, 1>,
+                         access::placeholder::false_t, 1>,
                      T *>>
 reduction(span<T, Extent> Span, const T &Identity, BinaryOperation Combiner,
           const property_list &PropList = {}) {


### PR DESCRIPTION
The core part of it is adding the user's reduction variable type as an
explicit template parameter and modifying reduction to store just that,
instead of having three members (RWAcc/DWAcc/UsmPtr) of which only one
is used to store it.

That, in turn, made the whole default_reduction_algorithm redundant as
all it was used for was to propagate that exact information in an
obscure way.

Once done, it enabled some further simplifications:

  * Simplifying some methods to use compile-time "if constexpr" instead
    of checking the type of the user reduction variable in runtime
    (i.e., previous "if (MRWAcc)" check).

  * Making reduction_impl_algo::reduction_impl_algo ctor generic and
    having a single instance of it, eliminating three version for
    different types of user's reduction variable.

  * Unify reduction_impl::reduction_impl ctors accessing RW/DW accessor
    eliminating code duplication

  * create make_reduction helper function to make creation of
    reduction_impl require less boilerplate code by using template type
    parameters deduction (couldn't use CTAD as some of the params can't
    be deduced and there is no such thing as partial CTAD).

  * Simplify reduction_impl creation further by benefiting from
    accessor's CTAD.