### PR TITLE
Update experimental/fpga_lsu.hpp to pass latency controls parameters directly to the LSU builtin

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/fpga_lsu.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_lsu.hpp
@@ -67,21 +67,16 @@ public:
     // Get latency control property values
     static constexpr int32_t _anchor_id = _latency_anchor_id_prop::value;
     static constexpr int32_t _target_anchor = _latency_constraint_prop::target;
-    static constexpr latency_control_type _control_type =
+    static constexpr latency_control_type _control_type_enum =
         _latency_constraint_prop::type;
+    static constexpr int32_t _control_type =
+        detail::get_latency_control_type(_control_type_enum);
     static constexpr int32_t _relative_cycle = _latency_constraint_prop::cycle;
 
-    int32_t _control_type_code = 0; // latency_control_type::none is default
-    if constexpr (_control_type == latency_control_type::exact) {
-      _control_type_code = 1;
-    } else if constexpr (_control_type == latency_control_type::max) {
-      _control_type_code = 2;
-    } else if constexpr (_control_type == latency_control_type::min) {
-      _control_type_code = 3;
-    }
-
-    return *__latency_control_mem_wrapper((_T *)Ptr, _anchor_id, _target_anchor,
-                                          _control_type_code, _relative_cycle);
+    return *__builtin_intel_fpga_mem(
+        (_T *)Ptr,
+        _burst_coalesce | _cache | _dont_statically_coalesce | _prefetch,
+        _cache_val, _anchor_id, _target_anchor, _control_type, _relative_cycle);
 #else
     (void)Properties;
     return *Ptr;
@@ -110,21 +105,17 @@ public:
     // Get latency control property values
     static constexpr int32_t _anchor_id = _latency_anchor_id_prop::value;
     static constexpr int32_t _target_anchor = _latency_constraint_prop::target;
-    static constexpr latency_control_type _control_type =
+    static constexpr latency_control_type _control_type_enum =
         _latency_constraint_prop::type;
+    static constexpr int32_t _control_type =
+        detail::get_latency_control_type(_control_type_enum);
     static constexpr int32_t _relative_cycle = _latency_constraint_prop::cycle;
 
-    int32_t _control_type_code = 0; // latency_control_type::none is default
-    if constexpr (_control_type == latency_control_type::exact) {
-      _control_type_code = 1;
-    } else if constexpr (_control_type == latency_control_type::max) {
-      _control_type_code = 2;
-    } else if constexpr (_control_type == latency_control_type::min) {
-      _control_type_code = 3;
-    }
-
-    *__latency_control_mem_wrapper((_T *)Ptr, _anchor_id, _target_anchor,
-                                   _control_type_code, _relative_cycle) = Val;
+    *__builtin_intel_fpga_mem((_T *)Ptr,
+                              _burst_coalesce | _cache |
+                                  _dont_statically_coalesce | _prefetch,
+                              _cache_val, _anchor_id, _target_anchor,
+                              _control_type, _relative_cycle) = Val;
 #else
     (void)Properties;
     *Ptr = Val;
@@ -181,19 +172,6 @@ private:
     static_assert(_prefetch == 0,
                   "unable to implement a store LSU with a prefetcher.");
   }
-
-#if defined(__SYCL_DEVICE_ONLY__) && __has_builtin(__builtin_intel_fpga_mem)
-  // FPGA BE will recognize this function and extract its arguments.
-  // TODO: Pass latency control params via __builtin_intel_fpga_mem when ready.
-  template <typename _T>
-  static _T *__latency_control_mem_wrapper(_T *Ptr, int32_t AnchorID,
-                                           int32_t TargetAnchor, int32_t Type,
-                                           int32_t Cycle) {
-    return __builtin_intel_fpga_mem(
-        Ptr, _burst_coalesce | _cache | _dont_statically_coalesce | _prefetch,
-        _cache_val);
-  }
-#endif
 };
 
 } // namespace experimental

--- a/sycl/include/sycl/ext/intel/experimental/fpga_utils.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_utils.hpp
@@ -54,5 +54,23 @@ using defaultLatencyAnchorIdProperty = latency_anchor_id_key::value_t<-1>;
 using defaultLatencyConstraintProperty =
     latency_constraint_key::value_t<0, latency_control_type::none, 0>;
 
+// Map from a sycl::ext::intel::experimental::latency_control_type
+// strongly-typed enumerator to the corresponding integer code.
+constexpr int32_t get_latency_control_type(
+    const sycl::ext::intel::experimental::latency_control_type
+        _control_type_enum) {
+  if (_control_type_enum ==
+      sycl::ext::intel::experimental::latency_control_type::exact) {
+    return 1;
+  } else if (_control_type_enum ==
+             sycl::ext::intel::experimental::latency_control_type::max) {
+    return 2;
+  } else if (_control_type_enum ==
+             sycl::ext::intel::experimental::latency_control_type::min) {
+    return 3;
+  }
+  return 0; // sycl::ext::intel::experimental::latency_control_type::none
+}
+
 } // namespace sycl::ext::intel::experimental::detail
 } // __SYCL_INLINE_NAMESPACE(cl)


### PR DESCRIPTION
https://github.com/intel/llvm/pull/6357 supports passing latency controls parameters to the LSU builtin `__builtin_intel_fpga_mem`. So the LSU header can get rid of the `__latency_control_mem_wrapper` layer.