### PR TITLE
[NFC][SYCL] Simplify usage of associateWithHandler

### DIFF
--- a/sycl/include/sycl/detail/handler_proxy.hpp
+++ b/sycl/include/sycl/detail/handler_proxy.hpp
@@ -20,8 +20,15 @@ namespace detail {
 
 class AccessorBaseHost;
 
+#ifndef __SYCL_DEVICE_ONLY__
 __SYCL_EXPORT void associateWithHandler(handler &, AccessorBaseHost *,
                                         access::target);
+#else
+// In device compilation accessor isn't inherited from AccessorBaseHost, so
+// can't detect by it. Since we don't expect it to be ever called in device
+// execution, just use blind void *.
+inline void associateWithHandler(handler &, void *, access::target) {}
+#endif
 } // namespace detail
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/sycl/detail/handler_proxy.hpp
+++ b/sycl/include/sycl/detail/handler_proxy.hpp
@@ -20,14 +20,14 @@ namespace detail {
 
 class AccessorBaseHost;
 
-#ifndef __SYCL_DEVICE_ONLY__
-__SYCL_EXPORT void associateWithHandler(handler &, AccessorBaseHost *,
-                                        access::target);
-#else
+#ifdef __SYCL_DEVICE_ONLY__
 // In device compilation accessor isn't inherited from AccessorBaseHost, so
 // can't detect by it. Since we don't expect it to be ever called in device
 // execution, just use blind void *.
 inline void associateWithHandler(handler &, void *, access::target) {}
+#else
+__SYCL_EXPORT void associateWithHandler(handler &, AccessorBaseHost *,
+                                        access::target);
 #endif
 } // namespace detail
 } // namespace sycl

--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -563,14 +563,10 @@ public:
   /// to keep the accessor alive until the command group finishes the work.
   /// This function does not do anything for USM reductions.
   void associateWithHandler(handler &CGH) {
-#ifndef __SYCL_DEVICE_ONLY__
     if (MRWAcc)
       CGH.associateWithHandler(MRWAcc.get(), access::target::device);
     else if (MDWAcc)
       CGH.associateWithHandler(MDWAcc.get(), access::target::device);
-#else
-    (void)CGH;
-#endif
   }
 
   /// Creates and returns a local accessor with the \p Size elements.

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -495,14 +495,14 @@ private:
 
   bool is_host() { return MIsHost; }
 
-#ifndef __SYCL_DEVICE_ONLY__
-  void associateWithHandler(detail::AccessorBaseHost *AccBase,
-                            access::target AccTarget);
-#else
+#ifdef __SYCL_DEVICE_ONLY__
   // In device compilation accessor isn't inherited from AccessorBaseHost, so
   // can't detect by it. Since we don't expect it to be ever called in device
   // execution, just use blind void *.
   void associateWithHandler(void *AccBase, access::target AccTarget);
+#else
+  void associateWithHandler(detail::AccessorBaseHost *AccBase,
+                            access::target AccTarget);
 #endif
 
   // Recursively calls itself until arguments pack is fully processed.

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -495,8 +495,16 @@ private:
 
   bool is_host() { return MIsHost; }
 
+#ifndef __SYCL_DEVICE_ONLY__
   void associateWithHandler(detail::AccessorBaseHost *AccBase,
                             access::target AccTarget);
+#else
+  // In device compilation accessor isn't inherited from AccessorBaseHost, so
+  // can't detect by it. Since we don't expect it to be ever called in device
+  // execution, just use blind void *.
+  void associateWithHandler(void *AccBase,
+                            access::target AccTarget);
+#endif
 
   // Recursively calls itself until arguments pack is fully processed.
   // The version for regular(standard layout) argument.
@@ -1386,11 +1394,7 @@ public:
   void
   require(accessor<DataT, Dims, AccMode, AccTarget, access::placeholder::true_t>
               Acc) {
-#ifndef __SYCL_DEVICE_ONLY__
     associateWithHandler(&Acc, AccTarget);
-#else
-    (void)Acc;
-#endif
   }
 
   /// Registers event dependencies on this command group.
@@ -2667,9 +2671,11 @@ private:
             class Algorithm>
   friend class ext::oneapi::detail::reduction_impl_algo;
 
+#ifndef __SYCL_DEVICE_ONLY__
   friend void detail::associateWithHandler(handler &,
                                            detail::AccessorBaseHost *,
                                            access::target);
+#endif
 
   friend class ::MockHandler;
   friend class detail::queue_impl;

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -502,8 +502,7 @@ private:
   // In device compilation accessor isn't inherited from AccessorBaseHost, so
   // can't detect by it. Since we don't expect it to be ever called in device
   // execution, just use blind void *.
-  void associateWithHandler(void *AccBase,
-                            access::target AccTarget);
+  void associateWithHandler(void *AccBase, access::target AccTarget);
 #endif
 
   // Recursively calls itself until arguments pack is fully processed.


### PR DESCRIPTION
After https://github.com/intel/llvm/pull/1770 some uses of associateWithHandler
have to be guarded by "#ifndef __SYCL_DEVICE_ONLY__" as the accessor's
inheritance chain differs between host/device compilation.

Put the burden of that into the handler's implementation instead of paying the
price at uses.