### PR TITLE
[sycl-post-link] Allow deletion of 'entry point' functions after full inlining.

### DIFF
--- a/llvm/tools/sycl-post-link/ModuleSplitter.cpp
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.cpp
@@ -146,6 +146,9 @@ groupEntryPointsByKernelType(const ModuleDesc &MD,
     if (!isEntryPoint(F, EmitOnlyKernelsAsEntryPoints) ||
         !MD.isEntryPointCandidate(F))
       continue;
+    // Entry points should not be inlined
+    auto F1 = MD.getModule().getFunction(F.getName());
+    F1->addFnAttr(Attribute::NoInline);
 
     if (isESIMDFunction(F))
       EntryPointMap[ESIMD_SCOPE_NAME].insert(&F);
@@ -196,6 +199,9 @@ EntryPointGroupVec groupEntryPointsByScope(const ModuleDesc &MD,
     if (!isEntryPoint(F, EmitOnlyKernelsAsEntryPoints) ||
         !MD.isEntryPointCandidate(F))
       continue;
+    // Entry points should not be inlined
+    auto F1 = MD.getModule().getFunction(F.getName());
+    F1->addFnAttr(Attribute::NoInline);
 
     switch (EntryScope) {
     case Scope_PerKernel:
@@ -255,6 +261,10 @@ groupEntryPointsByAttribute(const ModuleDesc &MD, StringRef AttrName,
         !MD.isEntryPointCandidate(F)) {
       continue;
     }
+    // Entry points should not be inlined
+    auto F1 = MD.getModule().getFunction(F.getName());
+    F1->addFnAttr(Attribute::NoInline);
+
     if (F.hasFnAttribute(AttrName)) {
       EntryPointMap[AttrName].insert(&F);
     } else {

--- a/llvm/tools/sycl-post-link/ModuleSplitter.cpp
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.cpp
@@ -647,7 +647,7 @@ void EntryPointGroup::rebuildFromNames(const std::vector<std::string> &Names,
   auto It1 = Names.cend();
   std::for_each(It0, It1, [&](const std::string &Name) {
     const Function *F = M.getFunction(Name);
-    // Some functions could be lost due to inlining followed by DCE. 
+    // Some functions could be lost due to inlining followed by DCE.
     // This is expected to NOT cause any issues in later compilation stages.
     // TODO: Avoid deletion of entry points in DCE.
     if (F)

--- a/llvm/tools/sycl-post-link/ModuleSplitter.cpp
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.cpp
@@ -146,13 +146,13 @@ groupEntryPointsByKernelType(const ModuleDesc &MD,
     if (!isEntryPoint(F, EmitOnlyKernelsAsEntryPoints) ||
         !MD.isEntryPointCandidate(F))
       continue;
-    // Entry points should not be inlined
-    auto F1 = MD.getModule().getFunction(F.getName());
-    F1->addFnAttr(Attribute::NoInline);
 
-    if (isESIMDFunction(F))
+    if (isESIMDFunction(F)) {
       EntryPointMap[ESIMD_SCOPE_NAME].insert(&F);
-    else
+      // Entry points should not be inlined
+      auto F1 = MD.getModule().getFunction(F.getName());
+      F1->addFnAttr(Attribute::NoInline);
+    } else
       EntryPointMap[SYCL_SCOPE_NAME].insert(&F);
   }
 
@@ -199,9 +199,6 @@ EntryPointGroupVec groupEntryPointsByScope(const ModuleDesc &MD,
     if (!isEntryPoint(F, EmitOnlyKernelsAsEntryPoints) ||
         !MD.isEntryPointCandidate(F))
       continue;
-    // Entry points should not be inlined
-    auto F1 = MD.getModule().getFunction(F.getName());
-    F1->addFnAttr(Attribute::NoInline);
 
     switch (EntryScope) {
     case Scope_PerKernel:
@@ -261,9 +258,6 @@ groupEntryPointsByAttribute(const ModuleDesc &MD, StringRef AttrName,
         !MD.isEntryPointCandidate(F)) {
       continue;
     }
-    // Entry points should not be inlined
-    auto F1 = MD.getModule().getFunction(F.getName());
-    F1->addFnAttr(Attribute::NoInline);
 
     if (F.hasFnAttribute(AttrName)) {
       EntryPointMap[AttrName].insert(&F);


### PR DESCRIPTION
Signed-off-by: Arvind Sudarsanam <arvind.sudarsanam@intel.com>