### PR TITLE
[SYCL] [L0] Fix for L0 Event object leakage.

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -3528,7 +3528,9 @@ pi_result piQueueRelease(pi_queue Queue) {
       // For immediate commandlists we don't need to do an L0 reset of the
       // commandlist but do need to do event cleanup which is also in the
       // resetCommandList function.
-      if (it->second.ZeFence != nullptr && it->second.ZeFenceInUse) {
+      // If the fence is a nullptr we are using immediate commandlists,
+      // otherwise regular commandlists which use a fence.
+      if (it->second.ZeFence == nullptr || it->second.ZeFenceInUse) {
         Queue->resetCommandList(it, true, EventListToCleanup);
       }
       // TODO: remove "if" when the problem is fixed in the level zero


### PR DESCRIPTION
This change does Event cleanup as part of resetting commandlists when immediate commandlists are being used.

Signed-off-by: Rajiv Deodhar <rajiv.deodhar@intel.com>