### PR TITLE
[SYCL][CUDA] Fix sycl-cuda-tu-offload test

### DIFF
--- a/clang/test/Driver/sycl-cuda-tu-offload.cu
+++ b/clang/test/Driver/sycl-cuda-tu-offload.cu
@@ -1,4 +1,4 @@
-// RUN: %clang++ -ccc-print-phases -target x86_64-unknown-linux-gnu  -fsycl -fsycl-targets=nvptx64-nvidia-cuda  -Xsycl-target-backend  --cuda-gpu-arch=sm_80 --cuda-gpu-arch=sm_80 -c %s 2>&1 | FileCheck %s --check-prefix=DEFAULT-PHASES
+// RUN: %clangxx -ccc-print-phases -target x86_64-unknown-linux-gnu  -fsycl -fsycl-targets=nvptx64-nvidia-cuda  -Xsycl-target-backend  --cuda-gpu-arch=sm_80 --cuda-gpu-arch=sm_80 -c %s 2>&1 | FileCheck %s --check-prefix=DEFAULT-PHASES
 
 // Test the correct placement of the offloading actions for compiling CUDA sources (*.cu) in SYCL.
 


### PR DESCRIPTION
This patch fix `%clangxx` in test invocation.