### PR TITLE
[SYCL][GDB] Fix op[] when called with typedef argument

### DIFF
--- a/sycl/gdb/libsycl.so-gdb.py
+++ b/sycl/gdb/libsycl.so-gdb.py
@@ -28,7 +28,7 @@ class Accessor:
         self.depth = depth
 
     def index(self, arg):
-        if arg.type.code == gdb.TYPE_CODE_INT:
+        if arg.type.unqualified().strip_typedefs().code == gdb.TYPE_CODE_INT:
             return int(arg)
         # unwrap if inside item
         try:


### PR DESCRIPTION
The implementation of 'index' did not strip typedefs from the argument
passed to it, when passed as a single number.  Instead, TYPE_CODE_INT was
expected.

This leads to failures when calling 'accessor[arg]' using an arg that is
either a typedef or something like size_t, which are considered
TYPE_CODE_TYPEDEF inside GDB.  The check fails and the function
continues on and fails even though the argument could have been used in
the int cast.

Typedef stripping was added to the if condition to fix this.

Signed-off-by: Nils-Christian Kempke <nils-christian.kempke@intel.com>