### PR TITLE
[ESIMD] Enable Dead Arguments Elimination for ESIMD kernels

### DIFF
--- a/sycl/test/esimd/genx_func_attr.cpp
+++ b/sycl/test/esimd/genx_func_attr.cpp
@@ -15,24 +15,24 @@ __attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
   kernelFunc();
 }
 
-SYCL_ESIMD_FUNCTION SYCL_EXTERNAL ESIMD_NOINLINE void callee(int x) {
+SYCL_ESIMD_FUNCTION SYCL_EXTERNAL ESIMD_NOINLINE void callee() {
   slm_init<1234>();
   sycl::ext::intel::experimental::esimd::named_barrier_init<13>();
 }
 
 // inherits SLMSize and NBarrierCount from callee
-void caller_abc(int x) {
-  kernel<class kernel_abc>([=]() SYCL_ESIMD_KERNEL { callee(x); });
-  // CHECK: define dso_local spir_kernel void @_ZTSZ10caller_abciE10kernel_abc(i32 noundef "VCArgumentIOKind"="0" %{{.*}}) local_unnamed_addr #2
+void caller_abc() {
+  kernel<class kernel_abc>([=]() SYCL_ESIMD_KERNEL { callee(); });
+  // CHECK: define dso_local spir_kernel void @_ZTSZ10caller_abcvE10kernel_abc() local_unnamed_addr #2
 }
 
 // inherits only NBarrierCount from callee
-void caller_xyz(int x) {
+void caller_xyz() {
   kernel<class kernel_xyz>([=]() SYCL_ESIMD_KERNEL {
     slm_init(1235); // also works in non-O0
-    callee(x);
+    callee();
   });
-  // CHECK: define dso_local spir_kernel void @_ZTSZ10caller_xyziE10kernel_xyz(i32 noundef "VCArgumentIOKind"="0" %{{.*}}) local_unnamed_addr #3
+  // CHECK: define dso_local spir_kernel void @_ZTSZ10caller_xyzvE10kernel_xyz() local_unnamed_addr #3
 }
 
 // CHECK: attributes #2 = { {{.*}} "VCNamedBarrierCount"="13" "VCSLMSize"="1234"


### PR DESCRIPTION
The optimization is turned on for non-ESIMD path even with -O0.
It also work-arounds the  SegFault on host when specialization constants
are set on host, but not used on device. In  this case it completely
removes the kernel parameter holding the address of spec const buffer.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>