### PR TITLE
[Driver][SYCL] Properly tag temporary list file for archive unbundling

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7788,8 +7788,8 @@ InputInfoList Driver::BuildJobsForActionNoCache(
         std::string TmpFileName = C.getDriver().GetTemporaryPath(
             llvm::sys::path::stem(BaseInput),
             JA->getType() == types::TY_Archive ? "a" : "txt");
-        const char *TmpFile =
-            C.addTempFile(C.getArgs().MakeArgString(TmpFileName));
+        const char *TmpFile = C.addTempFile(
+            C.getArgs().MakeArgString(TmpFileName), JA->getType());
         CurI = InputInfo(JA->getType(), TmpFile, TmpFile);
       } else if (types::isFPGA(JA->getType())) {
         std::string Ext(types::getTypeTempSuffix(JA->getType()));

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7822,8 +7822,8 @@ InputInfoList Driver::BuildJobsForActionNoCache(
         }
         std::string TmpFileName = C.getDriver().GetTemporaryPath(
             llvm::sys::path::stem(BaseInput), Ext);
-        const char *TmpFile = C.addTempFile(
-            C.getArgs().MakeArgString(TmpFileName), TI);
+        const char *TmpFile =
+            C.addTempFile(C.getArgs().MakeArgString(TmpFileName), TI);
         CurI = InputInfo(TI, TmpFile, TmpFile);
       } else {
         // Host part of the unbundled object is not used when -fsycl-link is

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7822,8 +7822,8 @@ InputInfoList Driver::BuildJobsForActionNoCache(
         }
         std::string TmpFileName = C.getDriver().GetTemporaryPath(
             llvm::sys::path::stem(BaseInput), Ext);
-        const char *TmpFile =
-                        C.addTempFile(C.getArgs().MakeArgString(TmpFileName));
+        const char *TmpFile = C.addTempFile(
+            C.getArgs().MakeArgString(TmpFileName), TI);
         CurI = InputInfo(TI, TmpFile, TmpFile);
       } else {
         // Host part of the unbundled object is not used when -fsycl-link is
@@ -7880,7 +7880,7 @@ InputInfoList Driver::BuildJobsForActionNoCache(
       std::string TmpFileName =
           C.getDriver().GetTemporaryPath(llvm::sys::path::stem(BaseInput), Ext);
       const char *TmpFile =
-          C.addTempFile(C.getArgs().MakeArgString(TmpFileName));
+          C.addTempFile(C.getArgs().MakeArgString(TmpFileName), JA->getType());
       Result = InputInfo(JA->getType(), TmpFile, TmpFile);
       UnbundlingResults.push_back(Result);
     } else {

--- a/clang/test/Driver/sycl-offload-tempfile.cpp
+++ b/clang/test/Driver/sycl-offload-tempfile.cpp
@@ -3,7 +3,8 @@
 
 // RUN: mkdir -p %t_dir
 // RUN: env TMPDIR=%t_dir TEMP=%t_dir TMP=%t_dir                           \
-// RUN: %clang -### -fsycl -fsycl-device-code-split %s 2>&1 | \
+// RUN: %clang -### -target x86_64-unknown-linux-gnu %S/Inputs/SYCL/liblin64.a \
+// RUN:       -fsycl -fsycl-device-code-split %s 2>&1 | \
 // RUN:       FileCheck -DDIRNAME=%t_dir --check-prefix=CHECK-TEMPFILE-SPLIT %s
 // RUN: not ls %t_dir/*
 // CHECK-TEMPFILE-SPLIT: sycl-post-link{{.*}} "-o" "[[DIRNAME]]{{\/|\\}}[[TABLE:.+\.table]]"


### PR DESCRIPTION
When unbundling archives, we were not properly tagging the type of file
being generated as a temporary list file.  This was causing the cleanup
to miss the generated unbundled objects from the unbundle step.