### PR TITLE
[SYCL] Strengthen split-with-func-ptrs.ll test.

### DIFF
--- a/llvm/test/tools/sycl-post-link/split-with-func-ptrs.ll
+++ b/llvm/test/tools/sycl-post-link/split-with-func-ptrs.ll
@@ -38,6 +38,19 @@ define linkonce_odr dso_local spir_func void @foo() unnamed_addr #0 comdat align
   ret void
 }
 
+; -- Also check that function called from an addr-taken function is also added
+;    to every split module.
+; Function Attrs: mustprogress norecurse nounwind
+define weak dso_local spir_func void @baz() #3 {
+; CHECK-A0: define weak dso_local spir_func void @baz
+; CHECK-A1: define weak dso_local spir_func void @baz
+; CHECK-B0: define weak dso_local spir_func void @baz
+; CHECK-B1: define weak dso_local spir_func void @baz
+; CHECK-C0: define weak dso_local spir_func void @baz
+; CHECK-C1: define weak dso_local spir_func void @baz
+  ret void
+}
+
 ; Function Attrs: mustprogress norecurse nounwind
 define linkonce_odr dso_local spir_func void @bar() unnamed_addr #1 comdat align 2 {
 ; CHECK-A0: define linkonce_odr dso_local spir_func void @bar
@@ -46,6 +59,7 @@ define linkonce_odr dso_local spir_func void @bar() unnamed_addr #1 comdat align
 ; CHECK-B1: define linkonce_odr dso_local spir_func void @bar
 ; CHECK-C0: define linkonce_odr dso_local spir_func void @bar
 ; CHECK-C1: define linkonce_odr dso_local spir_func void @bar
+  call void @baz()
   ret void
 }
 


### PR DESCRIPTION
Add a tescase which checks that the definition of a function called from an
address-taken function is also added to all split modules.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>