### PR TITLE
[SYCL] Drop get_native class functions

### DIFF
--- a/sycl/include/sycl/backend.hpp
+++ b/sycl/include/sycl/backend.hpp
@@ -127,7 +127,19 @@ auto get_native(const SyclObjectT &Obj)
     throw sycl::runtime_error(errc::backend_mismatch, "Backends mismatch",
                               PI_ERROR_INVALID_OPERATION);
   }
-  return Obj.template get_native<BackendName>();
+  return reinterpret_cast<backend_return_t<BackendName, SyclObjectT>>(
+      Obj.getNative());
+}
+
+template <backend BackendName, bundle_state State>
+auto get_native(const kernel_bundle<State> &Obj)
+    -> backend_return_t<BackendName, kernel_bundle<State>> {
+  // TODO use SYCL 2020 exception when implemented
+  if (Obj.get_backend() != BackendName) {
+    throw sycl::runtime_error(errc::backend_mismatch, "Backends mismatch",
+                              PI_ERROR_INVALID_OPERATION);
+  }
+  return Obj.template getNative<BackendName>();
 }
 
 template <backend BackendName, typename DataT, int Dimensions,

--- a/sycl/include/sycl/context.hpp
+++ b/sycl/include/sycl/context.hpp
@@ -217,15 +217,6 @@ public:
   /// \return a vector of valid SYCL device instances.
   std::vector<device> get_devices() const;
 
-  /// Gets the native handle of the SYCL context.
-  ///
-  /// \return a native handle, the type of which defined by the backend.
-  template <backend Backend>
-  __SYCL_DEPRECATED("Use SYCL 2020 sycl::get_native free function")
-  backend_return_t<Backend, context> get_native() const {
-    return reinterpret_cast<backend_return_t<Backend, context>>(getNative());
-  }
-
 private:
   /// Constructs a SYCL context object from a valid context_impl instance.
   context(std::shared_ptr<detail::context_impl> Impl);

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -24,6 +24,9 @@ __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 // Forward declarations
 class device_selector;
+template <backend BackendName, class SyclObjectT>
+auto get_native(const SyclObjectT &Obj)
+    -> backend_return_t<BackendName, SyclObjectT>;
 namespace detail {
 class device_impl;
 auto getDeviceComparisonLambda();
@@ -184,19 +187,6 @@ public:
   /// \return the backend associated with this device.
   backend get_backend() const noexcept;
 
-  /// Gets the native handle of the SYCL device.
-  ///
-  /// \return a native handle, the type of which defined by the backend.
-  template <backend Backend>
-  __SYCL_DEPRECATED("Use SYCL 2020 sycl::get_native free function")
-  backend_return_t<Backend, device> get_native() const {
-    // In CUDA CUdevice isn't an opaque pointer, unlike a lot of the others,
-    // but instead a 32-bit int (on all relevant systems). Different
-    // backends use the same function for this purpose so static_cast is
-    // needed in some cases but not others, so a C-style cast was chosen.
-    return (backend_return_t<Backend, device>)getNative();
-  }
-
   /// Indicates if the SYCL device has the given feature.
   ///
   /// \param Aspect is one of the values in Table 4.20 of the SYCL 2020
@@ -223,6 +213,10 @@ private:
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 
   friend auto detail::getDeviceComparisonLambda();
+
+  template <backend BackendName, class SyclObjectT>
+  friend auto get_native(const SyclObjectT &Obj)
+      -> backend_return_t<BackendName, SyclObjectT>;
 };
 
 } // namespace sycl

--- a/sycl/include/sycl/event.hpp
+++ b/sycl/include/sycl/event.hpp
@@ -21,6 +21,11 @@ __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 // Forward declaration
 class context;
+
+template <backend BackendName, class SyclObjectT>
+auto get_native(const SyclObjectT &Obj)
+    -> backend_return_t<BackendName, SyclObjectT>;
+
 namespace detail {
 class event_impl;
 }
@@ -127,15 +132,6 @@ public:
   ///
   /// \return the backend associated with this platform
   backend get_backend() const noexcept;
-
-  /// Gets the native handle of the SYCL event.
-  ///
-  /// \return a native handle, the type of which defined by the backend.
-  template <backend Backend>
-  __SYCL_DEPRECATED("Use SYCL 2020 sycl::get_native free function")
-  backend_return_t<Backend, event> get_native() const {
-    return reinterpret_cast<backend_return_t<Backend, event>>(getNative());
-  }
 
 private:
   event(std::shared_ptr<detail::event_impl> EventImpl);

--- a/sycl/include/sycl/ext/oneapi/backend/level_zero.hpp
+++ b/sycl/include/sycl/ext/oneapi/backend/level_zero.hpp
@@ -221,21 +221,6 @@ make_buffer(
       !(BackendObject.Ownership == ext::oneapi::level_zero::ownership::keep));
 }
 
-// TODO: remove this specialization when generic is changed to call
-// .GetNative() instead of .get_native() member of kernel_bundle.
-template <>
-inline auto get_native<backend::ext_oneapi_level_zero>(
-    const kernel_bundle<bundle_state::executable> &Obj)
-    -> backend_return_t<backend::ext_oneapi_level_zero,
-                        kernel_bundle<bundle_state::executable>> {
-  // TODO use SYCL 2020 exception when implemented
-  if (Obj.get_backend() != backend::ext_oneapi_level_zero)
-    throw runtime_error(errc::backend_mismatch, "Backends mismatch",
-                        PI_ERROR_INVALID_OPERATION);
-
-  return Obj.template getNative<backend::ext_oneapi_level_zero>();
-}
-
 namespace __SYCL2020_DEPRECATED("use 'ext::oneapi::level_zero' instead")
     level_zero {
   using namespace ext::oneapi::level_zero;

--- a/sycl/include/sycl/ext/oneapi/experimental/backend/cuda.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/backend/cuda.hpp
@@ -10,6 +10,7 @@
 
 #include <sycl/backend.hpp>
 #include <sycl/context.hpp>
+#include <sycl/ext/oneapi/experimental/backend/backend_traits_cuda.hpp>
 
 #include <vector>
 

--- a/sycl/include/sycl/ext/oneapi/experimental/backend/cuda.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/backend/cuda.hpp
@@ -52,13 +52,6 @@ inline auto get_native<backend::ext_oneapi_cuda, context>(const context &C)
   return ret;
 }
 
-// Specialisation of non-free context get_native
-template <>
-inline backend_return_t<backend::ext_oneapi_cuda, context>
-context::get_native<backend::ext_oneapi_cuda>() const {
-  return sycl::get_native<backend::ext_oneapi_cuda, context>(*this);
-}
-
 // Specialisation of interop_handles get_native_context
 template <>
 inline backend_return_t<backend::ext_oneapi_cuda, context>
@@ -77,6 +70,20 @@ inline device make_device<backend::ext_oneapi_cuda>(
     const backend_input_t<backend::ext_oneapi_cuda, device> &BackendObject) {
   pi_native_handle NativeHandle = static_cast<pi_native_handle>(BackendObject);
   return ext::oneapi::cuda::make_device(NativeHandle);
+}
+
+template <>
+backend_return_t<backend::ext_oneapi_cuda, device>
+get_native<backend::ext_oneapi_cuda, device>(const device &Obj) {
+  // TODO use SYCL 2020 exception when implemented
+  if (Obj.get_backend() != backend::ext_oneapi_cuda) {
+    throw sycl::runtime_error(errc::backend_mismatch, "Backends mismatch",
+                              PI_ERROR_INVALID_OPERATION);
+  }
+  // CUDA uses a 32-bit int instead of an opaque pointer like other backends,
+  // so we need a specialization with static_cast instead of reinterpret_cast.
+  return static_cast<backend_return_t<backend::ext_oneapi_cuda, device>>(
+      Obj.getNative());
 }
 
 // CUDA event specialization

--- a/sycl/include/sycl/kernel.hpp
+++ b/sycl/include/sycl/kernel.hpp
@@ -27,6 +27,9 @@ class program;
 class context;
 template <backend Backend> class backend_traits;
 template <bundle_state State> class kernel_bundle;
+template <backend BackendName, class SyclObjectT>
+auto get_native(const SyclObjectT &Obj)
+    -> backend_return_t<BackendName, SyclObjectT>;
 
 namespace detail {
 class kernel_impl;
@@ -190,12 +193,6 @@ public:
                      param>::input_type Value) const;
   // clang-format on
 
-  template <backend Backend>
-  __SYCL_DEPRECATED("Use SYCL 2020 sycl::get_native free function")
-  backend_return_t<Backend, kernel> get_native() const {
-    return detail::pi::cast<backend_return_t<Backend, kernel>>(getNative());
-  }
-
 private:
   /// Constructs a SYCL kernel object from a valid kernel_impl instance.
   kernel(std::shared_ptr<detail::kernel_impl> Impl);
@@ -211,6 +208,9 @@ private:
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
   template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
+  template <backend BackendName, class SyclObjectT>
+  friend auto get_native(const SyclObjectT &Obj)
+      -> backend_return_t<BackendName, SyclObjectT>;
 };
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/sycl/kernel_bundle.hpp
+++ b/sycl/include/sycl/kernel_bundle.hpp
@@ -26,8 +26,9 @@ __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 // Forward declaration
 template <backend Backend> class backend_traits;
-template <backend Backend, class SyclT>
-auto get_native(const SyclT &Obj) -> backend_return_t<Backend, SyclT>;
+template <backend Backend, bundle_state State>
+auto get_native(const kernel_bundle<State> &Obj)
+    -> backend_return_t<Backend, kernel_bundle<State>>;
 
 namespace detail {
 class kernel_id_impl;
@@ -310,12 +311,6 @@ public:
     return reinterpret_cast<device_image_iterator>(kernel_bundle_plain::end());
   }
 
-  template <backend Backend>
-  __SYCL_DEPRECATED("Use SYCL 2020 sycl::get_native free function")
-  backend_return_t<Backend, kernel_bundle<State>> get_native() const {
-    return getNative<Backend>();
-  }
-
 private:
   kernel_bundle(detail::KernelBundleImplPtr Impl)
       : kernel_bundle_plain(std::move(Impl)) {}
@@ -326,8 +321,9 @@ private:
   template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 
-  template <backend Backend, class SyclT>
-  friend auto get_native(const SyclT &Obj) -> backend_return_t<Backend, SyclT>;
+  template <backend Backend, bundle_state StateB>
+  friend auto get_native(const kernel_bundle<StateB> &Obj)
+      -> backend_return_t<Backend, kernel_bundle<StateB>>;
 
   template <backend Backend>
   backend_return_t<Backend, kernel_bundle<State>> getNative() const {

--- a/sycl/include/sycl/platform.hpp
+++ b/sycl/include/sycl/platform.hpp
@@ -24,6 +24,9 @@ namespace sycl {
 // Forward declaration
 class device_selector;
 class device;
+template <backend BackendName, class SyclObjectT>
+auto get_native(const SyclObjectT &Obj)
+    -> backend_return_t<BackendName, SyclObjectT>;
 namespace detail {
 class platform_impl;
 }
@@ -117,15 +120,6 @@ public:
   /// \return the backend associated with this platform
   backend get_backend() const noexcept;
 
-  /// Gets the native handle of the SYCL platform.
-  ///
-  /// \return a native handle, the type of which defined by the backend.
-  template <backend Backend>
-  __SYCL_DEPRECATED("Use SYCL 2020 sycl::get_native free function")
-  backend_return_t<Backend, platform> get_native() const {
-    return reinterpret_cast<backend_return_t<Backend, platform>>(getNative());
-  }
-
   /// Indicates if all of the SYCL devices on this platform have the
   /// given feature.
   ///
@@ -152,6 +146,9 @@ private:
   template <class Obj>
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 
+  template <backend BackendName, class SyclObjectT>
+  friend auto get_native(const SyclObjectT &Obj)
+      -> backend_return_t<BackendName, SyclObjectT>;
 }; // class platform
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/sycl/program.hpp
+++ b/sycl/include/sycl/program.hpp
@@ -28,6 +28,10 @@ namespace sycl {
 // Forward declarations
 class context;
 class device;
+template <backend BackendName, class SyclObjectT>
+auto get_native(const SyclObjectT &Obj)
+    -> backend_return_t<BackendName, SyclObjectT>;
+
 namespace detail {
 class program_impl;
 }
@@ -365,15 +369,6 @@ public:
   /// \return the backend associated with this program.
   backend get_backend() const noexcept;
 
-  /// Gets the native handle of the SYCL platform.
-  ///
-  /// \return a native handle, the type of which defined by the backend.
-  template <backend Backend>
-  __SYCL_DEPRECATED("Use SYCL 2020 sycl::get_native free function")
-  backend_return_t<Backend, program> get_native() const {
-    return reinterpret_cast<backend_return_t<Backend, program>>(getNative());
-  }
-
 private:
   pi_native_handle getNative() const;
   program(std::shared_ptr<detail::program_impl> impl);
@@ -419,6 +414,9 @@ private:
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
   template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
+  template <backend BackendName, class SyclObjectT>
+  friend auto get_native(const SyclObjectT &Obj)
+      -> backend_return_t<BackendName, SyclObjectT>;
 };
 } // namespace sycl
 } // __SYCL_INLINE_NAMESPACE(cl)

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -81,8 +81,13 @@ class context;
 class device;
 class queue;
 
+template <backend BackendName, class SyclObjectT>
+auto get_native(const SyclObjectT &Obj)
+    -> backend_return_t<BackendName, SyclObjectT>;
+
 namespace detail {
 class queue_impl;
+
 #if __SYCL_USE_FALLBACK_ASSERT
 static event submitAssertCapture(queue &, event &, queue *,
                                  const detail::code_location &);
@@ -1033,15 +1038,6 @@ public:
   /// \return the backend associated with this queue.
   backend get_backend() const noexcept;
 
-  /// Gets the native handle of the SYCL queue.
-  ///
-  /// \return a native handle, the type of which defined by the backend.
-  template <backend Backend>
-  __SYCL_DEPRECATED("Use SYCL 2020 sycl::get_native free function")
-  backend_return_t<Backend, queue> get_native() const {
-    return reinterpret_cast<backend_return_t<Backend, queue>>(getNative());
-  }
-
 private:
   pi_native_handle getNative() const;
 
@@ -1052,6 +1048,10 @@ private:
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
   template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
+
+  template <backend BackendName, class SyclObjectT>
+  friend auto get_native(const SyclObjectT &Obj)
+      -> backend_return_t<BackendName, SyclObjectT>;
 
 #if __SYCL_USE_FALLBACK_ASSERT
   friend event detail::submitAssertCapture(queue &, event &, queue *,

--- a/sycl/test/basic_tests/interop-cuda-experimental.cpp
+++ b/sycl/test/basic_tests/interop-cuda-experimental.cpp
@@ -56,20 +56,6 @@ int main() {
   cu_event = get_native<backend::ext_oneapi_cuda>(Event);
   cu_queue = get_native<backend::ext_oneapi_cuda>(Queue);
 
-  // Check deprecated
-  // expected-warning@+2 {{'get_native' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  // expected-warning@+1 {{'get_native<sycl::backend::ext_oneapi_cuda>' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  cu_device = Device.get_native<backend::ext_oneapi_cuda>();
-  // expected-warning@+2 {{'get_native' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  // expected-warning@+1 {{'get_native<sycl::backend::ext_oneapi_cuda>' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  cu_context = Context.get_native<backend::ext_oneapi_cuda>();
-  // expected-warning@+2 {{'get_native' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  // expected-warning@+1 {{'get_native<sycl::backend::ext_oneapi_cuda>' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  cu_event = Event.get_native<backend::ext_oneapi_cuda>();
-  // expected-warning@+2 {{'get_native' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  // expected-warning@+1 {{'get_native<sycl::backend::ext_oneapi_cuda>' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  cu_queue = Queue.get_native<backend::ext_oneapi_cuda>();
-
   // 4.5.1.1 For each SYCL runtime class T which supports SYCL application
   // interoperability with the SYCL backend, a specialization of input_type must
   // be defined as the type of SYCL application interoperability native backend

--- a/sycl/test/basic_tests/interop-level-zero-2020.cpp
+++ b/sycl/test/basic_tests/interop-level-zero-2020.cpp
@@ -75,30 +75,6 @@ int main() {
   ZeKernelBundle = get_native<backend::ext_oneapi_level_zero>(KernelBundle);
   ZeKernel = get_native<backend::ext_oneapi_level_zero>(Kernel);
 
-  // Check deprecated
-  // expected-warning@+2 {{'get_native' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  // expected-warning@+1 {{'get_native<sycl::backend::ext_oneapi_level_zero>' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  ZeDriver = Platform.get_native<backend::ext_oneapi_level_zero>();
-  // expected-warning@+2 {{'get_native' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  // expected-warning@+1 {{'get_native<sycl::backend::ext_oneapi_level_zero>' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  ZeDevice = Device.get_native<backend::ext_oneapi_level_zero>();
-  // expected-warning@+2 {{'get_native' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  // expected-warning@+1 {{'get_native<sycl::backend::ext_oneapi_level_zero>' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  ZeContext = Context.get_native<backend::ext_oneapi_level_zero>();
-  // expected-warning@+2 {{'get_native' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  // expected-warning@+1 {{'get_native<sycl::backend::ext_oneapi_level_zero>' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  ZeQueue = Queue.get_native<backend::ext_oneapi_level_zero>();
-  // expected-warning@+2 {{'get_native' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  // expected-warning@+1 {{'get_native<sycl::backend::ext_oneapi_level_zero>' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  ZeEvent = Event.get_native<backend::ext_oneapi_level_zero>();
-  // expected-warning@+3 {{'get_native' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  // expected-warning@+2 {{'get_native<sycl::backend::ext_oneapi_level_zero>' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  /*ZeKernelBundle*/ (
-      void)KernelBundle.get_native<backend::ext_oneapi_level_zero>();
-  // expected-warning@+2 {{'get_native' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  // expected-warning@+1 {{'get_native<sycl::backend::ext_oneapi_level_zero>' is deprecated: Use SYCL 2020 sycl::get_native free function}}
-  ZeKernel = Kernel.get_native<backend::ext_oneapi_level_zero>();
-
   // 4.5.1.1 For each SYCL runtime class T which supports SYCL application
   // interoperability with the SYCL backend, a specialization of input_type must
   // be defined as the type of SYCL application interoperability native backend


### PR DESCRIPTION
Drop deprecated get_native class functions in favor of get_native
free functions.