### PR TITLE
[SYCL] Cache and reuse events in the Level Zero plugin.

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -5466,7 +5466,7 @@ pi_result _pi_event::reset() {
   CommandData = nullptr;
   CommandType = PI_COMMAND_TYPE_USER;
   WaitList = {};
-  RefCount.reset(1);
+  RefCount.reset();
 
   if (!isHostVisible())
     HostVisibleEvent = nullptr;

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -274,9 +274,10 @@ template <class T> struct ZeCache : private T {
 // thread can reach ref count equal to zero, i.e. only a single thread can pass
 // through this check.
 struct ReferenceCounter {
-  ReferenceCounter(pi_uint32 InitVal) : RefCount{InitVal} {}
+  ReferenceCounter() : RefCount{1} {}
 
-  void reset(pi_uint32 InitVal) { RefCount = InitVal; }
+  // Reset the counter to the initial value.
+  void reset() { RefCount = 1; }
 
   // Used when retaining an object.
   void increment() { RefCount++; }
@@ -308,7 +309,7 @@ private:
 
 // Base class to store common data
 struct _pi_object {
-  _pi_object() : RefCount{1} {}
+  _pi_object() : RefCount{} {}
 
   // Level Zero doesn't do the reference counting, so we have to do.
   // Must be atomic to prevent data race when incrementing/decrementing.


### PR DESCRIPTION
Avoid creating new pi_event objects. Reset pi_event objects
and put them in the cache instead of removing.