### PR TITLE
[SYCL] Fix c++14 mode compilation after #6343

### DIFF
--- a/sycl/include/sycl/ext/oneapi/reduction.hpp
+++ b/sycl/include/sycl/ext/oneapi/reduction.hpp
@@ -8,9 +8,6 @@
 
 #pragma once
 
-#if __cplusplus >= 201703L
-// Entire feature is dependent on C++17.
-
 #include <sycl/accessor.hpp>
 #include <sycl/atomic.hpp>
 #include <sycl/atomic_ref.hpp>
@@ -23,6 +20,41 @@
 
 #include <tuple>
 
+__SYCL_INLINE_NAMESPACE(cl) {
+namespace sycl {
+namespace ext {
+namespace oneapi {
+namespace detail {
+
+/// Base non-template class which is a base class for all reduction
+/// implementation classes. It is needed to detect the reduction classes.
+class reduction_impl_base {};
+
+/// Predicate returning true if all template type parameters except the last one
+/// are reductions.
+template <typename FirstT, typename... RestT> struct AreAllButLastReductions {
+  static constexpr bool value =
+      std::is_base_of<reduction_impl_base,
+                      std::remove_reference_t<FirstT>>::value &&
+      AreAllButLastReductions<RestT...>::value;
+};
+
+/// Helper specialization of AreAllButLastReductions for one element only.
+/// Returns true if the template parameter is not a reduction.
+template <typename T> struct AreAllButLastReductions<T> {
+  static constexpr bool value =
+      !std::is_base_of<reduction_impl_base, std::remove_reference_t<T>>::value;
+};
+} // namespace detail
+} // namespace oneapi
+} // namespace ext
+} // namespace sycl
+} // __SYCL_INLINE_NAMESPACE(cl)
+
+#if __cplusplus >= 201703L
+// Entire feature is dependent on C++17. We still have to make the trait above
+// available as queue shortcuts use them unconditionally, including on
+// non-reduction path.
 __SYCL_INLINE_NAMESPACE(cl) {
 namespace sycl {
 namespace ext {
@@ -456,10 +488,6 @@ private:
   marray<T, Extent> MValue;
 };
 
-/// Base non-template class which is a base class for all reduction
-/// implementation classes. It is needed to detect the reduction classes.
-class reduction_impl_base {};
-
 /// Templated class for common functionality of all reduction implementation
 /// classes.
 template <typename T, class BinaryOperation> class reduction_impl_common {
@@ -712,22 +740,6 @@ private:
 
   /// User's accessor/USM pointer to where the reduction must be written.
   RedOutVar MRedOut;
-};
-
-/// Predicate returning true if all template type parameters except the last one
-/// are reductions.
-template <typename FirstT, typename... RestT> struct AreAllButLastReductions {
-  static constexpr bool value =
-      std::is_base_of<reduction_impl_base,
-                      std::remove_reference_t<FirstT>>::value &&
-      AreAllButLastReductions<RestT...>::value;
-};
-
-/// Helper specialization of AreAllButLastReductions for one element only.
-/// Returns true if the template parameter is not a reduction.
-template <typename T> struct AreAllButLastReductions<T> {
-  static constexpr bool value =
-      !std::is_base_of<reduction_impl_base, std::remove_reference_t<T>>::value;
 };
 /// This class encapsulates the reduction variable/accessor,
 /// the reduction operator and an optional operator identity.


### PR DESCRIPTION
Some reduction code is used on non-reduction path and must be available
in C++14 even though the rest of the feature is guarded to be available
in C++17 and above only.