### PR TITLE
[SYCL] Fix interop-cuda-experimental test

### DIFF
--- a/sycl/test/basic_tests/interop-cuda-experimental.cpp
+++ b/sycl/test/basic_tests/interop-cuda-experimental.cpp
@@ -1,6 +1,7 @@
 // REQUIRES: cuda
 // RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
 // RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note -D__SYCL_INTERNAL_API %s -o %t.out
+// expected-no-diagnostics
 
 // Test for experimental CUDA interop API
 


### PR DESCRIPTION
Fix the test by adding a missing expected-no-diagnostics.