### PR TITLE
[SYCL] Fix shared libs build in post-commit

### DIFF
--- a/clang/lib/Driver/CMakeLists.txt
+++ b/clang/lib/Driver/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LLVM_LINK_COMPONENTS
   BinaryFormat
   BitWriter
+  Core
   IRReader
   MC
   Object


### PR DESCRIPTION
Guess it happened after a recent pulldown:
https://github.com/intel/llvm/pull/6494