### PR TITLE
[SYCL] Address tests failures after #6469 #6506

### DIFF
--- a/sycl/test/basic_tests/no_iostream.cpp
+++ b/sycl/test/basic_tests/no_iostream.cpp
@@ -1,6 +1,7 @@
 // RUN: %clangxx -fsycl %s -S -emit-llvm -o- | FileCheck %s
-// CHECK-NOT: {{^@}}
+// CHECK-NOT: {{^@llvm.global_ctors}}
 //
-// Tests if <sycl/sycl.hpp> headers include any <iostream> headers
+// Tests if inclusion <sycl/sycl.hpp> causes execution of global ctors
+// and related performance hit.
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/regression/fsycl-host-compiler-win.cpp
+++ b/sycl/test/regression/fsycl-host-compiler-win.cpp
@@ -14,6 +14,10 @@
 
 #include <sycl/sycl.hpp>
 
+// FIXME: Modify <sycl/details/iostream_proxy.hpp> so that it would require proper
+// libs via "#pragma comment(lib, ...)".
+#include <iostream>
+
 #ifndef DEFINE_CHECK
 #error predefined macro not set
 #endif // DEFINE_CHECK

--- a/sycl/test/regression/fsycl-host-compiler-win.cpp
+++ b/sycl/test/regression/fsycl-host-compiler-win.cpp
@@ -14,8 +14,8 @@
 
 #include <sycl/sycl.hpp>
 
-// FIXME: Modify <sycl/details/iostream_proxy.hpp> so that it would require proper
-// libs via "#pragma comment(lib, ...)".
+// FIXME: Modify <sycl/details/iostream_proxy.hpp> so that it would require
+// proper libs via "#pragma comment(lib, ...)".
 #include <iostream>
 
 #ifndef DEFINE_CHECK


### PR DESCRIPTION
Just a workaround in sycl/test/regression/fsycl-host-compiler-win.cpp
while the proper fix is being investigated/prepared.