### PR TITLE
[SYCL] Finally fix iostream_proxy.hpp

### DIFF
--- a/sycl/include/sycl/detail/iostream_proxy.hpp
+++ b/sycl/include/sycl/detail/iostream_proxy.hpp
@@ -3,11 +3,12 @@
 #include <ostream>
 
 namespace std {
-#ifdef _WIN32
+#if defined(_MT) && defined(_DLL)
 #define __SYCL_EXTERN_STREAM_ATTRS __declspec(dllimport)
 #else
 #define __SYCL_EXTERN_STREAM_ATTRS
-#endif // _WIN32
+#endif // defined(_MT) && defined(_DLL)
+
 /// Linked to standard input
 extern __SYCL_EXTERN_STREAM_ATTRS istream cin;
 /// Linked to standard output

--- a/sycl/test/regression/fsycl-host-compiler-win.cpp
+++ b/sycl/test/regression/fsycl-host-compiler-win.cpp
@@ -14,10 +14,6 @@
 
 #include <sycl/sycl.hpp>
 
-// FIXME: Modify <sycl/details/iostream_proxy.hpp> so that it would require
-// proper libs via "#pragma comment(lib, ...)".
-#include <iostream>
-
 #ifndef DEFINE_CHECK
 #error predefined macro not set
 #endif // DEFINE_CHECK


### PR DESCRIPTION
When _MT and _DLL are both defined, the user has passed /MD or /MDd and
is dynamically linking in the runtimes. Because std::cout etc are data,
they need to be marked dllimport in that case or else the linker cannot
find them.