### PR TITLE
[SYCL][CUDA] Make `piextKernelSetArgMemObj` setting an error message

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -2824,9 +2824,10 @@ pi_result cuda_piextKernelSetArgMemObj(pi_kernel kernel, pi_uint32 arg_index,
           arrayDesc.Format != CU_AD_FORMAT_SIGNED_INT32 &&
           arrayDesc.Format != CU_AD_FORMAT_HALF &&
           arrayDesc.Format != CU_AD_FORMAT_FLOAT) {
-        sycl::detail::pi::die(
-            "PI CUDA kernels only support images with channel types int32, "
-            "uint32, float, and half.");
+        setErrorMessage("PI CUDA kernels only support images with channel "
+                        "types int32, uint32, float, and half.",
+                        PI_ERROR_PLUGIN_SPECIFIC_ERROR);
+        return PI_ERROR_PLUGIN_SPECIFIC_ERROR;
       }
       CUsurfObject cuSurf = arg_mem->mem_.surface_mem_.get_surface();
       kernel->set_kernel_arg(arg_index, sizeof(cuSurf), (void *)&cuSurf);


### PR DESCRIPTION
This patch makes `cuda_piextKernelSetArgMemObj` setting an error message instead of `std::terminate` in case of the image format is not supported. This error message is encapsulated in an exception thrown by the RT.

This allows to continue the SYCL-CTS execution in case of tests using unsupported channel types, see https://github.com/intel/llvm/issues/2119#issuecomment-1201548912.