### PR TITLE
[SYCL][CI] Update nightly to use resolve_matrix properly

### DIFF
--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -10,24 +10,30 @@ on:
       - '.github/workflows/sycl_nightly.yml'
 
 jobs:
+  resolve_matrix:
+    name: Resolve Test Matrix
+    uses: ./.github/workflows/sycl_resolve_test_matrix.yml
+    with:
+      lts_config: "ocl_gen9;ocl_x64"
+
   ubuntu2004_build_test:
     if: github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl_linux_build_and_test.yml
+    needs: resolve_matrix
     with:
       build_cache_root: "/__w/"
       build_artifact_suffix: default
       build_configure_extra_args: ''
-      lts_config: "ocl_gen9;ocl_x64"
 
   ubuntu2004_opaque_pointers_build_test:
     if: github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl_linux_build_and_test.yml
+    needs: resolve_matrix
     with:
       build_cache_root: "/__w/"
       build_cache_suffix: opaque_pointers
       build_artifact_suffix: opaque_pointers
       build_configure_extra_args: "--hip --cuda --enable-esimd-emulator --cmake-opt=-DDPCPP_ENABLE_OPAQUE_POINTERS=TRUE"
-      lts_config: "ocl_gen9;ocl_x64"
 
   windows_default:
     name: Windows


### PR DESCRIPTION
Change https://github.com/intel/llvm/pull/6352 done earlier introduced
regression to SYCL nightly workflow. This change is to fix it.