### PR TITLE
[SYCL] Fix unittest initialization of queue with selector

### DIFF
--- a/sycl/unittests/queue/Wait.cpp
+++ b/sycl/unittests/queue/Wait.cpp
@@ -174,7 +174,7 @@ TEST(QueueWait, QueueWaitTest) {
   // Test behaviour for emulating an OOO queue with multiple in-order ones.
   TestContext = {};
   TestContext.SupportOOO = false;
-  Q = {Ctx, default_selector()};
+  Q = queue{Ctx, default_selector()};
   Q.memset(HostAlloc, 42, 1);
   // The event is kept alive in this case to call wait.
   ASSERT_EQ(TestContext.EventReferenceCount, 1);


### PR DESCRIPTION
https://github.com/intel/llvm/pull/6486 added new queue constructors for the use of callable device selectors. In accordance with SYCL 2020 these constructors are marked explicit and as such implicit conversion from initializer lists does not work. These changes fixes the Wait.cpp unittest to use the explicit constructor.