### PR TITLE
[SYCL] Make invoke_simd convert its arguments to appropriate type.

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/LowerInvokeSimd.h
+++ b/llvm/include/llvm/SYCLLowerIR/LowerInvokeSimd.h
@@ -24,4 +24,8 @@ public:
 
 ModulePass *createSYCLLowerInvokeSimdPass();
 void initializeSYCLLowerInvokeSimdLegacyPassPass(PassRegistry &);
+
+// Attribute added to functions which are known to be invoke_simd targets.
+constexpr char INVOKE_SIMD_DIRECT_TARGET_ATTR[] = "__invoke_simd_target";
+
 } // namespace llvm

--- a/llvm/lib/SYCLLowerIR/LowerInvokeSimd.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerInvokeSimd.cpp
@@ -103,16 +103,6 @@ Value *stripCasts(Value *V) {
   return V;
 }
 
-const Value *getSingleUserSkipCasts(const Value *V) {
-  while (isCast(V)) {
-    if (V->getNumUses() != 1) {
-      return nullptr;
-    }
-    V = *(V->user_begin());
-  }
-  return V;
-}
-
 void collectUsesLookThroughCasts(Value *V, SmallPtrSetImpl<const Use *> &Uses) {
   for (Use &U : V->uses()) {
     Value *VV = U.getUser();
@@ -385,7 +375,6 @@ bool processInvokeSimdCall(CallInst *InvokeSimd,
   auto *Helper = cast<Function>(H);
   // Mark helper as explicit SIMD function. Some BEs need this info.
   {
-    LLVMContext &C = Helper->getContext();
     markFunctionAsESIMD(Helper);
     // Fixup helper's linkage, which is linkonce_odr after the FE. It is dropped
     // from the ESIMD module after global DCE in post-link if not fixed up.

--- a/llvm/lib/SYCLLowerIR/LowerInvokeSimd.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerInvokeSimd.cpp
@@ -493,7 +493,6 @@ PreservedAnalyses SYCLLowerInvokeSimdPass::run(Module &M,
       F->eraseFromParent();
     }
   }
-  verifyModule(M, &llvm::errs());
   return Modified ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }
 } // namespace llvm

--- a/llvm/lib/SYCLLowerIR/LowerInvokeSimd.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerInvokeSimd.cpp
@@ -25,7 +25,10 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IR/Operator.h"
+#include "llvm/IR/Verifier.h"
 #include "llvm/Pass.h"
+#include "llvm/Transforms/Utils/Cloning.h"
+#include "llvm/Transforms/Utils/ValueMapper.h"
 
 #define DEBUG_TYPE "LowerInvokeSimd"
 
@@ -105,36 +108,43 @@ const Value *getSingleUserSkipCasts(const Value *V) {
   return V;
 }
 
-void collectUsesSkipThroughCasts(Value *V, SmallPtrSetImpl<const Use *> &Uses) {
+void collectUsesLookThroughCasts(Value *V, SmallPtrSetImpl<const Use *> &Uses) {
   for (Use &U : V->uses()) {
     Value *VV = U.getUser();
 
     if (isCast(VV)) {
-      collectUsesSkipThroughCasts(VV, Uses);
+      collectUsesLookThroughCasts(VV, Uses);
     } else {
       Uses.insert(&U);
     }
   }
 }
 
-Value *getInvokeeIfInvokeSimdCall(const CallInst *CI) {
+// Expects a call instruction in the form
+// __builtin_invoke_simd(simd_func_call_helper, f,...);
+// and returns <simd_func_call_helper, f> pair or
+// <nullptr, nullptr> otherwise.
+std::pair<Value *, Value *>
+getHelperAndInvokeeIfInvokeSimdCall(const CallInst *CI) {
   Function *F = CI->getCalledFunction();
 
   if (F && F->getName().startswith(INVOKE_SIMD_PREF)) {
-    return CI->getArgOperand(0);
+    return {CI->getArgOperand(0), CI->getArgOperand(1)};
   }
-  return nullptr;
+  return {nullptr, nullptr};
 }
 
-void getPossibleStoredVals(Value *Addr, ValueSetImpl &Vals) {
+// Tries to find possible values stored into given address.
+// Returns true if the set of values could be reliably found, false otherwise.
+bool collectPossibleStoredVals(Value *Addr, ValueSetImpl &Vals) {
   ValueSet Visited;
   AllocaInst *LocalVar = dyn_cast_or_null<AllocaInst>(stripCasts(Addr));
 
   if (!LocalVar) {
-    llvm_unreachable("unsupported data flow pattern for invoke_simd 10");
+    return false;
   }
   SmallPtrSet<const Use *, 4> Uses;
-  collectUsesSkipThroughCasts(LocalVar, Uses);
+  collectUsesLookThroughCasts(LocalVar, Uses);
 
   for (const Use *U : Uses) {
     Value *V = U->getUser();
@@ -145,14 +155,16 @@ void getPossibleStoredVals(Value *Addr, ValueSetImpl &Vals) {
       if (U != &StI->getOperandUse(StoreInst::getPointerOperandIndex())) {
         assert(U == &StI->getOperandUse(StoreInstValueOperandIndex));
         // this is double indirection - not supported
-        llvm_unreachable("unsupported data flow pattern for invoke_simd 11");
+        return false;
       }
       V = stripCasts(StI->getValueOperand());
 
       if (auto *LI = dyn_cast<LoadInst>(V)) {
         // A value loaded from another address is stored at this address -
         // recurse into the other address
-        getPossibleStoredVals(LI->getPointerOperand(), Vals);
+        if (!collectPossibleStoredVals(LI->getPointerOperand(), Vals)) {
+          return false;
+        }
       } else {
         Vals.insert(V);
       }
@@ -160,78 +172,299 @@ void getPossibleStoredVals(Value *Addr, ValueSetImpl &Vals) {
     }
     if (const auto *CI = dyn_cast<CallInst>(V)) {
       // only __builtin_invoke_simd is allowed, otherwise the pointer escapes
-      if (!getInvokeeIfInvokeSimdCall(CI)) {
-        llvm_unreachable("unsupported data flow pattern for invoke_simd 12");
+      if (!getHelperAndInvokeeIfInvokeSimdCall(CI).first) {
+        return false;
       }
       continue;
     }
-    if (const auto *LI = dyn_cast<LoadInst>(V)) {
+    if (isa<LoadInst>(V)) {
       // LoadInst from this addr is OK, as it does not affect what can be stored
       // through the addr
       continue;
     }
-    llvm_unreachable("unsupported data flow pattern for invoke_simd 13");
+    return false;
   }
+  return true;
 }
 
-// Example1 (function is direct argument to
-// _Z33__regcall3____builtin_invoke_simd):
-// %call6.i = call spir_func float @_Z33__regcall3____builtin_invoke_simd...(
-//   <16 x float> (float addrspace(4)*, <16 x float>, i32)* %28, <== function
-//   pointer float addrspace(4)* %arg1, float %arg2, i32 %arg3)
-//
-// Example 2 (invoke_simd's target function pointer flows through IR):
-// %fptr_t = <16 x float> (float addrspace(4)*, <16 x float>, i32)*
-// ...
-// %fa_as0 = alloca %fptr_t
-// ...
-// %fa = addrspacecast %fptr_t* %fa_as0 to %fptr_t addrspace(4)*
-// ...
-// store %fptr_t @__SIMD_CALLEE, %fptr_t addrspace(4)* %fa
-// ...
-// %f = load %fptr_t, %fptr_t addrspace(4)* %fa
-// ...
-// %res = call spir_func float @_Z33__regcall3____builtin_invoke_simd...(
-//   %fptr_t %f, <== function pointer
-//  float addrspace(4)* %arg1,
-//  float %arg2,
-//  i32 %arg3)
-//
-bool processInvokeSimdCall(CallInst *CI) {
-  Value *V = getInvokeeIfInvokeSimdCall(CI);
+// Deduce a single function whose address this value can only contain and
+// return it, otherwise (if can't be deduced or multiple functions deduced)
+// return nullptr.
+Function *deduceFunction(Value *I) {
+  while (true) {
+    I = stripCasts(I);
+    Function *Res = dyn_cast<Function>(I);
 
-  if (!V) {
-    llvm_unreachable(("bad use of " + Twine(INVOKE_SIMD_PREF)).str().c_str());
-  }
-  auto *SimdF = dyn_cast<Function>(V);
-  bool Modified = false;
+    if (Res) {
+      return Res;
+    }
+    if (Argument *Arg = dyn_cast<Argument>(I)) {
+      // invoke_simd target is a function pointer which came via a formal
+      // parameter - do inter-procedural analysis trying to determine
+      // actual target
+      Function *Parent = Arg->getParent();
+      // follow all calls to F and see what functions were passed as actual
+      // argument
+      for (const User *U : Parent->users()) {
+        const auto *CI = dyn_cast<CallInst>(U);
 
-  if (!SimdF) {
-    auto *LI = dyn_cast<LoadInst>(stripCasts(V));
+        if (!CI || (CI->getCalledFunction() != Parent)) {
+          llvm_unreachable("unsupported data flow pattern for invoke_simd A");
+        }
+        Value *ActualArg = CI->getArgOperand(Arg->getArgNo());
+        Function *F = deduceFunction(ActualArg);
+
+        if (!F || (Res && (Res != F))) {
+          // deduction failed or a different (from previous iteration) function
+          // deduced
+          return nullptr;
+        }
+        Res = F;
+      }
+      return Res;
+    }
+    auto *LI = dyn_cast<LoadInst>(I);
 
     if (!LI) {
-      llvm_unreachable("unsupported data flow pattern for invoke_simd 0");
+      // Function object can't be deduced
+      break;
     }
     ValueSet Vals;
-    getPossibleStoredVals(LI->getPointerOperand(), Vals);
+    Value *Addr = LI->getPointerOperand();
 
-    if (Vals.size() != 1 || !(SimdF = dyn_cast<Function>(*Vals.begin()))) {
-      llvm_unreachable("unsupported data flow pattern for invoke_simd 1");
+    if (!collectPossibleStoredVals(Addr, Vals) || Vals.size() != 1) {
+      // data flow through the address of the load instruction is too
+      // complicated
+      break;
     }
-    // _Z33__regcall3____builtin_invoke_simd invokee is an SSA value, replace it
-    // with the link-time constant SimdF as computed by getPossibleStoredVals
-    auto *CI1 = cast<CallInst>(CI->clone());
-    constexpr int SimdInvokeInvokeeArgIndex = 0;
-    CI1->setOperand(SimdInvokeInvokeeArgIndex, SimdF);
-    CI1->insertAfter(CI);
-    CI->replaceAllUsesWith(CI1);
-    CI->eraseFromParent();
-    Modified = true;
+    I = *Vals.begin();
   }
-  if (!SimdF->hasFnAttribute(llvm::genx::VCFunctionMD::VCStackCall)) {
-    SimdF->addFnAttr(llvm::genx::VCFunctionMD::VCStackCall);
+  return nullptr;
+}
+
+bool collectUsesLookTrhoughMemAndCasts(Value *V,
+                                       SmallPtrSetImpl<const Use *> &Uses) {
+  SmallPtrSet<const Use *, 4> TmpVUses;
+  collectUsesLookThroughCasts(V, TmpVUses);
+
+  for (const Use *U : TmpVUses) {
+    User *UU = U->getUser();
+    assert(!isCast(UU));
+    auto *St = dyn_cast<StoreInst>(UU);
+
+    if (!St) {
+      Uses.insert(U);
+      continue;
+    }
+    // Current user is a store (of V) instruction, see if...
+    assert((V = St->getValueOperand()) &&
+           "bad V param in collectUsesLookTrhoughMemAndCasts");
+    Value *Addr = stripCasts(St->getPointerOperand());
+
+    if (!isa<AllocaInst>(Addr)) {
+      return false; // unsupported case of data flow through non-local memory
+    }
+    ValueSet StoredVals;
+
+    // ... 1) V is the only possible stored value
+    if (!collectPossibleStoredVals(Addr, StoredVals) ||
+        (StoredVals.size() != 1) || (*StoredVals.begin() != V)) {
+      return false;
+    }
+    // ... 2) What are uses of the values loaded from the address?
+    SmallPtrSet<const Use *, 4> AddrUses;
+    collectUsesLookThroughCasts(Addr, AddrUses);
+
+    for (const Use *AddrU : AddrUses) {
+      User *AddrUU = AddrU->getUser();
+      assert(!isCast(AddrUU));
+
+      if (isa<StoreInst>(AddrUU)) {
+        if (AddrUU == St) {
+          continue;
+        }
+        return false; // some unexpected store detected
+      }
+      if (isa<LoadInst>(AddrUU)) {
+        collectUsesLookThroughCasts(AddrUU, Uses);
+        continue;
+      }
+      return false; // some unexpected use of the store address detected
+    }
   }
-  return Modified;
+  return true;
+}
+
+// Shifts parameter attribute sets left by 1 and removes the rightmost.
+// The index of the last paremter attribute in the result is NParams-2.
+AttributeList removeFirstParamAttrAndShrink(LLVMContext &C, AttributeList Src,
+                                            unsigned NParams) {
+  AttributeList Dst;
+  AttrBuilder FnAB(C, Src.getFnAttrs());
+  Dst = Dst.addFnAttributes(C, FnAB);
+
+  for (unsigned ParamNo = 0; ParamNo < NParams - 1; ++ParamNo) {
+    AttrBuilder AB(C, Src.getParamAttrs(ParamNo + 1));
+    Dst = Dst.addParamAttributes(C, ParamNo, AB);
+  }
+  return Dst;
+}
+
+// TODO W/a IGC crash on functions with names containing '.' (e.g.
+// CloneFunction creates such name) - replace '.' with '_'.
+void fixFunctionName(Function *F) {
+  constexpr unsigned N = 5;
+  std::string Name = F->getName().str();
+
+  for (unsigned i = 0; (i < N) && (Name.find('.') != std::string::npos); ++i) {
+    std::replace(Name.begin(), Name.end(), '.', '_');
+    F->setName(Name); // setName can actually add '.<suff>' if non-unique
+    Name = F->getName().str();
+  }
+  assert(Name.find('.') == std::string::npos);
+}
+
+// Process 'invoke_simd(sub_group_obj, f, spmd_args...);' call.
+//
+// If f is a function name or a function pointer, this call is lowered into
+//   >  __builtin_invoke_simd(simd_func_call_helper, f, unwrap(spmd_args)...);
+// where simd_func_call_helper is a helper function defined by the SYCL library
+// which performs parameter conversion and then calls f via a pointer to f:
+//   > Ret simd_func_call_helper(Callable f, T ... args) {
+//   >   args_conv... = C++-convert(args)...;
+//   >   return f(args_conv...);
+//   > }
+// This function tries to determine actual function (F) given the pointer f. If
+// successful, it transforms the __builtin_invoke_simd invocation and the helper
+// to git rid of the indirect call of f:
+// - clone simd_func_call_helper into simd_func_call_helper_unique_clone and
+//   transform it as follows:
+//   > Ret simd_func_call_helper_unique_clone(T ... args) {
+//   >   args_conv... = C++-convert(args)...;
+//   >   return F(args_conv...);
+//   > }
+// - remove f in __builtin_invoke_simd invocation and redirect it to the clone:
+//   > __builtin_invoke_simd(
+//   >   simd_func_call_helper_unique_clone,
+//   >   unwrap(spmd_args)...
+//   > );
+bool processInvokeSimdCall(CallInst *InvokeSimd,
+                           SmallPtrSetImpl<Function *> &ClonedHelpers) {
+  std::pair<Value *, Value *> HandI =
+      getHelperAndInvokeeIfInvokeSimdCall(InvokeSimd);
+  Value *H = HandI.first;
+  Value *I = HandI.second;
+
+  if (!H) {
+    llvm_unreachable(("bad use of " + Twine(INVOKE_SIMD_PREF)).str().c_str());
+  }
+  // "helper" defined in invoke_simd.hpp which convetrs arguments.
+  auto *Helper = cast<Function>(H);
+  // Fixup helper's linkage, which is linkonce_odr after the FE. It is dropped
+  // from the resulting module after linkage if not fixed up.
+  Helper->setLinkage(GlobalValue::LinkageTypes::ExternalLinkage);
+
+  Function *SimdF = deduceFunction(I);
+
+  if (!SimdF) {
+    // Call target is not known - don't do anything.
+    return false;
+  }
+  if (!Helper->hasFnAttribute(llvm::genx::VCFunctionMD::VCStackCall)) {
+    Helper->addFnAttr(llvm::genx::VCFunctionMD::VCStackCall);
+  }
+  // The invoke_simd target is known at compile-time - optimize.
+  // 1) find the call to f within the cloned helper - it is its first parameter
+  constexpr unsigned SimdCallTargetArgNo = 0;
+  SmallPtrSet<const Use *, 4> Uses;
+  Argument *SimdCallTargetArg = Helper->getArg(SimdCallTargetArgNo);
+
+  if (!collectUsesLookTrhoughMemAndCasts(SimdCallTargetArg, Uses)) {
+    llvm_unreachable("simd_func_call_helper broken");
+  }
+  CallInst *TheCall = nullptr;
+
+  for (const Use *U : Uses) {
+    auto *CI = dyn_cast<CallInst>(U->getUser());
+
+    if (!CI) {
+      continue;
+    }
+    assert(CI->getCalledOperand() == U->get());
+    assert(!TheCall && "unexpected multiple calls to SIMD target");
+    TheCall = CI;
+#ifndef NDEBUG
+    break;
+#endif
+  }
+  assert(TheCall && "simd_func_call_helper broken 1");
+
+  // 2. Clone and transform simd_func_call_helper signature and code.
+  Function *NewHelper = nullptr;
+  {
+    ValueToValueMapTy VMap;
+    // mark the 'f' paremeter for deletion:
+    VMap[SimdCallTargetArg] = PoisonValue::get(SimdCallTargetArg->getType());
+    NewHelper = CloneFunction(Helper, VMap);
+    // make the call to the user simd function direct:
+    CallInst *TheTformedCall = cast<CallInst>(VMap[TheCall]);
+    TheTformedCall->setCalledFunction(SimdF);
+    // fixup helper clone's linkage as well:
+    NewHelper->setLinkage(GlobalValue::LinkageTypes::ExternalLinkage);
+    fixFunctionName(NewHelper);
+  }
+
+  // 3. Clone and transform __builtin_invoke_simd call:
+  //    - remove the 'f' formal parameter from the declaration
+  //    - remove the 'f' actual argument (SIMD target function pointer)
+  {
+    // 3.1. Create a new declaration for the intrinsic (with 1 parameter less):
+    constexpr unsigned HelperArgNo = 0;
+    Function *InvokeSimdF = InvokeSimd->getCalledFunction();
+    // - type of the obsolete (unmodified) helper:
+    Type *HelperArgTy = InvokeSimdF->getArg(HelperArgNo)->getType();
+    unsigned AS = dyn_cast<PointerType>(HelperArgTy)->getAddressSpace();
+    FunctionType *InvokeSimdFTy = InvokeSimdF->getFunctionType();
+    // - create the list of new formal parameter types (the old one, with the
+    //   second element removed):
+    SmallVector<Type *, 8> NewArgTys;
+    NewArgTys.push_back(PointerType::get(NewHelper->getFunctionType(), AS));
+    std::copy(std::next(InvokeSimdFTy->param_begin(), 2),
+              InvokeSimdFTy->param_end(), std::back_inserter(NewArgTys));
+    FunctionType *NewInvokeSimdFTy =
+        FunctionType::get(InvokeSimdFTy->getReturnType(), NewArgTys, false);
+    // - create the new declaration:
+    Function *NewInvokeSimdF =
+        Function::Create(NewInvokeSimdFTy, InvokeSimdF->getLinkage(),
+                         InvokeSimdF->getName(), InvokeSimdF->getParent());
+    fixFunctionName(NewInvokeSimdF);
+    LLVMContext &C = NewInvokeSimdF->getContext();
+    // - truncate and shift-left parameter attributes in the new declaration:
+    AttributeList NewAttrsF = removeFirstParamAttrAndShrink(
+        C, InvokeSimdF->getAttributes(), InvokeSimdF->arg_size());
+    NewInvokeSimdF->setAttributes(NewAttrsF);
+
+    // 3.2. Create the new __builtin_invoke_simd call.
+    // - create a list of new arguments (the old one with the second element
+    //   removed):
+    SmallVector<Value *, 4> NewInvokeSimdArgs;
+    NewInvokeSimdArgs.push_back(NewHelper);
+    auto ThirdArg = std::next(InvokeSimd->arg_begin(), 2);
+    NewInvokeSimdArgs.append(ThirdArg, InvokeSimd->arg_end());
+    CallInst *NewInvokeSimd =
+        CallInst::Create(NewInvokeSimdF, NewInvokeSimdArgs, "", InvokeSimd);
+    // - transfer flags, attributes (with shrinking), calling convention:
+    NewInvokeSimd->copyIRFlags(InvokeSimd);
+    NewInvokeSimd->setCallingConv(InvokeSimd->getCallingConv());
+    AttributeList NewAttrs = removeFirstParamAttrAndShrink(
+        C, InvokeSimd->getAttributes(), InvokeSimd->arg_size());
+    NewInvokeSimd->setAttributes(NewAttrs);
+
+    InvokeSimd->replaceAllUsesWith(NewInvokeSimd);
+    InvokeSimd->eraseFromParent();
+  }
+  ClonedHelpers.insert(Helper);
+  return true;
 }
 } // namespace
 
@@ -239,6 +472,10 @@ namespace llvm {
 PreservedAnalyses SYCLLowerInvokeSimdPass::run(Module &M,
                                                ModuleAnalysisManager &MAM) {
   bool Modified = false;
+  // A set of encountered instances of the 'simd_func_call_helper' function
+  // template defined in the invoke_simd.hpp, which are cloned. Those might no
+  // longer be used after the pass finishes.
+  SmallPtrSet<Function *, 4> ClonedHelpers;
 
   for (Function &F : M) {
     if (!F.isDeclaration() || !F.getName().startswith(INVOKE_SIMD_PREF)) {
@@ -248,9 +485,15 @@ PreservedAnalyses SYCLLowerInvokeSimdPass::run(Module &M,
     for (User *Usr : Users) {
       // a call can be the only use of the invoke_simd built-in
       CallInst *CI = cast<CallInst>(Usr);
-      Modified |= processInvokeSimdCall(CI);
+      Modified |= processInvokeSimdCall(CI, ClonedHelpers);
     }
   }
+  for (Function *F : ClonedHelpers) {
+    if (F->getNumUses() == 0) {
+      F->eraseFromParent();
+    }
+  }
+  verifyModule(M, &llvm::errs());
   return Modified ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }
 } // namespace llvm

--- a/llvm/test/SYCLLowerIR/ESIMD/lower_invoke_simd.ll
+++ b/llvm/test/SYCLLowerIR/ESIMD/lower_invoke_simd.ll
@@ -1,73 +1,100 @@
 ; RUN: opt -passes=lower-invoke-simd -S < %s | FileCheck %s
+; This test checks basic functionality of the LowerInvokeSimd pass:
+; - __builtin_invoke_simd gets lowered as expected
+; - actual call targets are successfully deduced in practical cases where they
+;   are specified as function names in the user code
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"
 
-; Function Attrs: convergent
-declare dso_local spir_func <16 x float> @__dummy_read(i64) #4
+$_ZN4sycl3ext6oneapi12experimental6detail14unwrap_uniformIfE4implEf = comdat any
 
-; Function Attrs: convergent
-declare dso_local spir_func float @_Z33__regcall3____builtin_invoke_simdXX(<16 x float> (float addrspace(4)*, <16 x float>, i32)*, float addrspace(4)*, float, i32) local_unnamed_addr #3
+$SIMD_CALL_HELPER = comdat any
 
-; Function Attrs: convergent mustprogress noinline norecurse optnone
-define dso_local x86_regcallcc <16 x float> @_SIMD_CALLEE(float addrspace(4)* %A, <16 x float> %non_uni_val, i32 %uni_val) #0 !sycl_explicit_simd !0 !intel_reqd_sub_group_size !0 {
-; Verify that correct attributes are attached to the function:
-; CHECK: {{.*}} @_SIMD_CALLEE(float addrspace(4)* %A, <16 x float> %non_uni_val, i32 %uni_val) #0
-entry:
-  %AA = ptrtoint float addrspace(4)* %A to i64
-  %ii = zext i32 %uni_val to i64
-  %addr = add nuw nsw i64 %ii, %AA
-  %data = call spir_func <16 x float> @__dummy_read(i64 %addr)
-  %add = fadd <16 x float> %non_uni_val, %data
-  ret <16 x float> %add
+declare dso_local spir_func <16 x float> @__dummy_read() #4
+
+define dso_local x86_regcallcc <16 x float> @SIMD_CALLEE(<16 x float> %x) #0 !sycl_explicit_simd !0 !intel_reqd_sub_group_size !1 {
+  %y = call spir_func <16 x float> @__dummy_read()
+  %z = fadd <16 x float> %x, %y
+  ret <16 x float> %z
 }
 
-; Function Attrs: convergent mustprogress noinline norecurse optnone
-define dso_local x86_regcallcc <16 x float> @_ANOTHER_SIMD_CALLEE(float addrspace(4)* %A, <16 x float> %non_uni_val, i32 %uni_val) #1 !sycl_explicit_simd !0 !intel_reqd_sub_group_size !0 {
-; Verify that correct attributes are attached to the function:
-; CHECK: {{.*}} @_ANOTHER_SIMD_CALLEE(float addrspace(4)* %A, <16 x float> %non_uni_val, i32 %uni_val) #1
-entry:
-  %AA = ptrtoint float addrspace(4)* %A to i64
-  %ii = zext i32 %uni_val to i64
-  %addr = add nuw nsw i64 %ii, %AA
-  %data = call spir_func <16 x float> @__dummy_read(i64 %addr)
-  %add = fadd <16 x float> %non_uni_val, %data
-  ret <16 x float> %add
+define dso_local x86_regcallcc <16 x float> @ANOTHER_SIMD_CALLEE(<16 x float> %x) #0 !sycl_explicit_simd !0 !intel_reqd_sub_group_size !1 {
+  %y = call spir_func <16 x float> @__dummy_read()
+  %z = fadd <16 x float> %x, %y
+  ret <16 x float> %z
 }
 
-define internal spir_func float @foo(float addrspace(1)* %ptr, <16 x float> (float addrspace(4)*, <16 x float>, i32)* %raw_fptr) align 2 {
-entry:
-;------------- Typical data flow of the @_SIMD_CALLEE function address in worst
-;------------- case (-O0), when invoke_simd uses function name:
-;------------- float res = invoke_simd(sg, SIMD_CALLEE, uniform{ A }, x, uniform{ y });
-  %f.addr.i = alloca <16 x float> (float addrspace(4)*, <16 x float>, i32)*, align 8
-  %f.addr.ascast.i = addrspacecast <16 x float> (float addrspace(4)*, <16 x float>, i32)** %f.addr.i to <16 x float> (float addrspace(4)*, <16 x float>, i32)* addrspace(4)*
-  store <16 x float> (float addrspace(4)*, <16 x float>, i32)* @_SIMD_CALLEE, <16 x float> (float addrspace(4)*, <16 x float>, i32)* addrspace(4)* %f.addr.ascast.i, align 8
-  %FUNC_PTR = load <16 x float> (float addrspace(4)*, <16 x float>, i32)*, <16 x float> (float addrspace(4)*, <16 x float>, i32)* addrspace(4)* %f.addr.ascast.i, align 8
+define dso_local spir_func noundef float @SPMD_CALLER(float noundef %x, <16 x float> (<16 x float>)* %raw_fptr) #0 {
+; CHECK: define {{.*}} float @SPMD_CALLER(
 
-;------------- Data flow for the parameters of SIMD_CALLEE
-  %param_A = addrspacecast float addrspace(1)* %ptr to float addrspace(4)*
-  %param_non_uni_val = load float, float addrspace(4)* %param_A, align 4
+;---- Typical data flow of the @SIMD_CALLEE function address in worst
+;---- case (-O0), when invoke_simd uses function name:
+;---- float res = invoke_simd(sg, SIMD_CALLEE, x);
+  %f.addr.i = alloca <16 x float> (<16 x float>)*, align 8
+  %f.addr.ascast.i = addrspacecast <16 x float> (<16 x float>)** %f.addr.i to <16 x float> (<16 x float>)* addrspace(4)*
+  store <16 x float> (<16 x float>)* @SIMD_CALLEE, <16 x float> (<16 x float>)* addrspace(4)* %f.addr.ascast.i, align 8
+  ;---- duplicated store of the same function pointer should be OK
+  store <16 x float> (<16 x float>)* @SIMD_CALLEE, <16 x float> (<16 x float>)* addrspace(4)* %f.addr.ascast.i, align 8
+  %FUNC_PTR = load <16 x float> (<16 x float>)*, <16 x float> (<16 x float>)* addrspace(4)* %f.addr.ascast.i, align 8
 
-;------------- The invoke_simd calls.
-  %res1 = call spir_func float @_Z33__regcall3____builtin_invoke_simdXX(<16 x float> (float addrspace(4)*, <16 x float>, i32)* %FUNC_PTR, float addrspace(4)* %param_A, float %param_non_uni_val, i32 10)
-; Verify that %FUNC_PTR is replaced with @_SIMD_CALLEE:
-; CHECK: %{{.*}} = call spir_func float @_Z33__regcall3____builtin_invoke_simdXX(<16 x float> (float addrspace(4)*, <16 x float>, i32)* @_SIMD_CALLEE, float addrspace(4)* %param_A, float %param_non_uni_val, i32 10)
+;---- The invoke_simd calls.
+; Test case when function pointer (%FUNC_PTR) is passed the __builtin_invoke_simd,
+; but the actual function can be deduced.
+  %res1 = call spir_func float @_Z33__regcall3____builtin_invoke_simdXX(<16 x float> (<16 x float> (<16 x float>)*, <16 x float>)* @SIMD_CALL_HELPER, <16 x float> (<16 x float>)* %FUNC_PTR, float %x)
+; Verify that
+; 1) the second argument (function pointer) is removed
+; 2) The call target (helper) is changed to the optimized one
+; CHECK: %{{.*}} = call spir_func float @_Z33__regcall3____builtin_invoke_simdXX_{{.+}}(<16 x float> (<16 x float>)* @[[NAME1:SIMD_CALL_HELPER.+]], float %{{.*}})
 
-  %res2 = call spir_func float @_Z33__regcall3____builtin_invoke_simdXX(<16 x float> (float addrspace(4)*, <16 x float>, i32)* @_ANOTHER_SIMD_CALLEE, float addrspace(4)* %param_A, float %param_non_uni_val, i32 10)
-; Verify that function address link-time constant is accepted by the pass and left as is:
-; CHECK: = call spir_func float @_Z33__regcall3____builtin_invoke_simdXX(<16 x float> (float addrspace(4)*, <16 x float>, i32)* @_ANOTHER_SIMD_CALLEE, float addrspace(4)* %param_A, float %param_non_uni_val, i32 10)
+; Test case when function name is passed directly to the __builtin_invoke_simd.
+  %res2 = call spir_func float @_Z33__regcall3____builtin_invoke_simdXX(<16 x float> (<16 x float> (<16 x float>)*, <16 x float>)* @SIMD_CALL_HELPER, <16 x float> (<16 x float>)* @ANOTHER_SIMD_CALLEE, float %x)
+; CHECK: %{{.*}} = call spir_func float @_Z33__regcall3____builtin_invoke_simdXX_{{.+}}(<16 x float> (<16 x float>)* @[[NAME2:SIMD_CALL_HELPER.+]], float %{{.*}})
 
-; TODO: enable in the test and LowerInvokeSimd when BE is ready, crash for now:
-  ;%res3 %{{.*}} = call spir_func float @_Z33__regcall3____builtin_invoke_simdXX(<16 x float> (float addrspace(4)*, <16 x float>, i32)* %raw_fptr, float addrspace(4)* %param_A, float %param_non_uni_val, i32 10)
-  %res = fadd float %res1, %res2
+; Test case when function pointer (%raw_fptr) is passed the __builtin_invoke_simd
+; and actual function can't be deduced.
+; Verify that there are no changes to the __builtin_invoke_simd call.
+  %res3 = call spir_func float @_Z33__regcall3____builtin_invoke_simdXX(<16 x float> (<16 x float> (<16 x float>)*, <16 x float>)* @SIMD_CALL_HELPER, <16 x float> (<16 x float>)* %raw_fptr,  float %x)
+; CHECK: %{{.*}} = call spir_func float @_Z33__regcall3____builtin_invoke_simdXX(<16 x float> (<16 x float> (<16 x float>)*, <16 x float>)* @SIMD_CALL_HELPER, <16 x float> (<16 x float>)* %{{.*}}, float %{{.*}})
+
+  %res4 = fadd float %res1, %res2
+  %res = fadd float %res3, %res4
   ret float %res
 }
+; CHECK: }
+
+;---- Simd call helper library function mock.
+define linkonce_odr dso_local x86_regcallcc <16 x float> @SIMD_CALL_HELPER(<16 x float> (<16 x float>)* noundef nonnull %f, <16 x float> %simd_args) #0 !sycl_explicit_simd !0 !intel_reqd_sub_group_size !1 {
+  %f.addr = alloca <16 x float> (<16 x float>)*, align 8
+  %f.addr.ascast = addrspacecast <16 x float> (<16 x float>)** %f.addr to <16 x float> (<16 x float>)* addrspace(4)*
+  store <16 x float> (<16 x float>)* %f, <16 x float> (<16 x float>)* addrspace(4)* %f.addr.ascast, align 8
+  %1 = load <16 x float> (<16 x float>)*, <16 x float> (<16 x float>)* addrspace(4)* %f.addr.ascast, align 8
+  %call = call x86_regcallcc <16 x float> %1(<16 x float> %simd_args)
+  ret <16 x float> %call
+}
+
+;---- Check that original SIMD_CALL_HELPER retained, because there are
+;---- invoke_simd calls where simd target can't be inferred.
+; CHECK: define {{.*}} <16 x float> @SIMD_CALL_HELPER(<16 x float> (<16 x float>)* {{.*}}%{{.*}}, <16 x float> %{{.*}}) #1
+; CHECK:   %{{.*}} = call x86_regcallcc <16 x float> %{{.*}}(<16 x float> %{{.*}})
+; CHECK: }
+
+;---- Optimized version for the SIMD_CALLEE call
+; CHECK: define {{.*}} <16 x float> @[[NAME1]](<16 x float> %{{.*}}) #1
+; Verify that indirect call is converted to direct
+; CHECK: %{{.*}} = call x86_regcallcc <16 x float> @SIMD_CALLEE(<16 x float> %{{.*}})
+; CHECK: }
+
+;---- Optimized version for the ANOTHER_SIMD_CALLEE call
+; CHECK: define {{.*}} <16 x float> @[[NAME2]](<16 x float> %{{.*}}) #1
+; Verify that indirect call is converted to direct
+; CHECK: %{{.*}} = call x86_regcallcc <16 x float> @ANOTHER_SIMD_CALLEE(<16 x float> %{{.*}})
+; CHECK: }
+
+declare dso_local x86_regcallcc noundef float @_Z33__regcall3____builtin_invoke_simdXX(<16 x float> (<16 x float> (<16 x float>)*, <16 x float>)* noundef, <16 x float> (<16 x float>)* noundef, float noundef)
 
 ; Check that VCStackCall attribute is added to the invoke_simd target functions:
-attributes #0 = { convergent mustprogress norecurse "frame-pointer"="all" "min-legal-vector-width"="512" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="invoke_simd.cpp" }
-; CHECK: attributes #0 = { convergent mustprogress norecurse "VCStackCall" {{.*}} "sycl-module-id"="invoke_simd.cpp" }
-attributes #1 = { convergent mustprogress norecurse "sycl-module-id"="invoke_simd.cpp" }
-; CHECK: attributes #1 = { convergent mustprogress norecurse "VCStackCall" "sycl-module-id"="invoke_simd.cpp" }
+attributes #0 = { "sycl-module-id"="invoke_simd.cpp" }
+; CHECK: attributes #1 = { "VCStackCall" "sycl-module-id"="invoke_simd.cpp" }
 
 !0 = !{}
 !1 = !{i32 16}

--- a/llvm/test/SYCLLowerIR/ESIMD/lower_invoke_simd.ll
+++ b/llvm/test/SYCLLowerIR/ESIMD/lower_invoke_simd.ll
@@ -74,18 +74,18 @@ define linkonce_odr dso_local x86_regcallcc <16 x float> @SIMD_CALL_HELPER(<16 x
 
 ;---- Check that original SIMD_CALL_HELPER retained, because there are
 ;---- invoke_simd calls where simd target can't be inferred.
-; CHECK: define {{.*}} <16 x float> @SIMD_CALL_HELPER(<16 x float> (<16 x float>)* {{.*}}%{{.*}}, <16 x float> %{{.*}}) #1
+; CHECK: define {{.*}} <16 x float> @SIMD_CALL_HELPER(<16 x float> (<16 x float>)* {{.*}}%{{.*}}, <16 x float> %{{.*}}) #[[HELPER_ATTRS:[0-9]+]] !sycl_explicit_simd !0 !intel_reqd_sub_group_size !1
 ; CHECK:   %{{.*}} = call x86_regcallcc <16 x float> %{{.*}}(<16 x float> %{{.*}})
 ; CHECK: }
 
 ;---- Optimized version for the SIMD_CALLEE call
-; CHECK: define {{.*}} <16 x float> @[[NAME1]](<16 x float> %{{.*}}) #1
+; CHECK: define {{.*}} <16 x float> @[[NAME1]](<16 x float> %{{.*}}) #[[HELPER_ATTRS]]
 ; Verify that indirect call is converted to direct
 ; CHECK: %{{.*}} = call x86_regcallcc <16 x float> @SIMD_CALLEE(<16 x float> %{{.*}})
 ; CHECK: }
 
 ;---- Optimized version for the ANOTHER_SIMD_CALLEE call
-; CHECK: define {{.*}} <16 x float> @[[NAME2]](<16 x float> %{{.*}}) #1
+; CHECK: define {{.*}} <16 x float> @[[NAME2]](<16 x float> %{{.*}}) #[[HELPER_ATTRS]]
 ; Verify that indirect call is converted to direct
 ; CHECK: %{{.*}} = call x86_regcallcc <16 x float> @ANOTHER_SIMD_CALLEE(<16 x float> %{{.*}})
 ; CHECK: }
@@ -94,7 +94,7 @@ declare dso_local x86_regcallcc noundef float @_Z33__regcall3____builtin_invoke_
 
 ; Check that VCStackCall attribute is added to the invoke_simd target functions:
 attributes #0 = { "sycl-module-id"="invoke_simd.cpp" }
-; CHECK: attributes #1 = { "VCStackCall" "sycl-module-id"="invoke_simd.cpp" }
+; CHECK: attributes #[[HELPER_ATTRS]] = { "VCStackCall" "sycl-module-id"="invoke_simd.cpp" }
 
 !0 = !{}
 !1 = !{i32 16}

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/no-sycl-esimd-split-shared-func.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/no-sycl-esimd-split-shared-func.ll
@@ -1,24 +1,25 @@
 ; This test checks "integrated" invoke_simd support by the sycl-post-link tool:
-; - data flow analysis is able to determine actual target of
-;   _Z33__regcall3____builtin_invoke_simd*
+; - library helper function used in _Z33__regcall3____builtin_invoke_simd* is
+;   optimized
 ; - functions shared by SYCL and ESIMD callgraphs get cloned and renamed, thus
 ;   making sure no functions are shared by the callgraphs (currently required by
 ;   IGC)
 
 ; RUN: sycl-post-link -lower-esimd -symbols -split=auto -S %s -o %t.table
-; RUN: FileCheck %s -input-file=%t.table
-; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-IR
+; RUN: FileCheck %s -input-file=%t.table --check-prefixes CHECK-TABLE
+; RUN: FileCheck %s -input-file=%t_0.ll
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefixes CHECK-SYM
 
-;------------- Verify generated table file.
-; CHECK: [Code|Properties|Symbols]
-; CHECK: {{.*}}_0.ll|{{.*}}_0.prop|{{.*}}_0.sym
-; CHECK-EMPTY:
+;---------------- Verify generated table file.
+; CHECK-TABLE: [Code|Properties|Symbols]
+; CHECK-TABLE: {{.*}}_0.ll|{{.*}}_0.prop|{{.*}}_0.sym
+; CHECK-TABLE-EMPTY:
 
-;------------- Verify generated symbol file.
+;---------------- Verify generated symbol file.
+; CHECK-SYM: SPMD_CALLER
 ; CHECK-SYM: SYCL_kernel
-; CHECK-SYM: SIMD_CALLEE
 ; CHECK-SYM: ESIMD_kernel
+; CHECK-SYM: SIMD_CALL_HELPER_{{[0-9]+}}
 ; CHECK-SYM-EMPTY:
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
@@ -28,49 +29,32 @@ target triple = "spir64-unknown-unknown"
 
 declare dso_local spir_func <4 x float> @__intrin(i64)
 
-define dso_local spir_func <4 x float> @SHARED_FUNCTION(i64 %addr) noinline {
-;------------- This function is participates in both SYCL and ESIMD callgraphs -
-;------------- check that it is duplicated:
-; CHECK-IR-DAG: define dso_local spir_func <4 x float> @SHARED_FUNCTION.esimd
+;---- Function calleed from both SYCL and ESIMD callgraphs.
+;---- Must be cloned for ESIMD.
+define dso_local spir_func <4 x float> @SHARED_F(i64 %addr) noinline {
   %res = call spir_func <4 x float> @__intrin(i64 %addr)
   ret <4 x float> %res
 }
 
 declare dso_local x86_regcallcc noundef float @_Z33__regcall3____builtin_invoke_simdXX(<4 x float> (<4 x float> (<4 x float>)*, <4 x float>)* noundef, <4 x float> (<4 x float>)* noundef, float noundef)
 
-;------------- This is also an entry point, because of the "sycl-module-id" attribute #0.
-define linkonce_odr x86_regcallcc <4 x float> @SIMD_CALLEE(<4 x float> %val) #0 !sycl_explicit_simd !0 !intel_reqd_sub_group_size !0 {
-; Verify that correct attributes are attached to the function:
-; CHECK-IR-DAG: {{.*}} @SIMD_CALLEE(<4 x float> %{{.*}}) #[[ATTR1:[0-9]+]]
-  %data = call spir_func <4 x float> @SHARED_FUNCTION(i64 100)
+;---- This has linkonce_odr, so it should be removed after inlining into the
+;---- helper.
+define linkonce_odr x86_regcallcc <4 x float> @SIMD_CALLEE(<4 x float> %val) #3 !sycl_explicit_simd !0 !intel_reqd_sub_group_size !1 {
+; CHECK-NOT: {{.*}} @SIMD_CALLEE(
+  %data = call spir_func <4 x float> @SHARED_F(i64 100)
   %add = fadd <4 x float> %val, %data
   ret <4 x float> %add
 }
 
-define dso_local spir_func float @SPMD_CALLER(float %x) #0 align 2 {
-;---- Typical data flow of the @SIMD_CALLEE function address in worst
-;---- case (-O0), when invoke_simd uses function name:
-;---- float res = invoke_simd(sg, SIMD_CALLEE, x);
-  %f.addr.i = alloca <4 x float> (<4 x float>)*, align 8
-  %f.addr.ascast.i = addrspacecast <4 x float> (<4 x float>)** %f.addr.i to <4 x float> (<4 x float>)* addrspace(4)*
-  store <4 x float> (<4 x float>)* @SIMD_CALLEE, <4 x float> (<4 x float>)* addrspace(4)* %f.addr.ascast.i, align 8
-  %FUNC_PTR = load <4 x float> (<4 x float>)*, <4 x float> (<4 x float>)* addrspace(4)* %f.addr.ascast.i, align 8
-
-;---- The invoke_simd call.
-; Test case when function pointer (%FUNC_PTR) is passed the __builtin_invoke_simd,
-; but the actual function can be deduced.
-  %res = call spir_func float @_Z33__regcall3____builtin_invoke_simdXX(<4 x float> (<4 x float> (<4 x float>)*, <4 x float>)* @SIMD_CALL_HELPER, <4 x float> (<4 x float>)* %FUNC_PTR, float %x)
-; Verify that
-; 1) the second argument (function pointer) is removed
-; 2) The call target (helper) is changed to the optimized one
-; CHECK: %{{.*}} = call spir_func float @_Z33__regcall3____builtin_invoke_simdXX_{{.+}}(<4 x float> (<4 x float>)* @[[NAME1:SIMD_CALL_HELPER.+]], float %{{.*}})
-
+;---- Function containing the invoke_simd call.
+define dso_local spir_func float @SPMD_CALLER(float %x) #0 !intel_reqd_sub_group_size !2 {
+  %res = call spir_func float @_Z33__regcall3____builtin_invoke_simdXX(<4 x float> (<4 x float> (<4 x float>)*, <4 x float>)* @SIMD_CALL_HELPER, <4 x float> (<4 x float>)* @SIMD_CALLEE, float %x)
   ret float %res
 }
-; CHECK: }
 
 ;---- Simd call helper library function mock.
-define linkonce_odr dso_local x86_regcallcc <4 x float> @SIMD_CALL_HELPER(<4 x float> (<4 x float>)* noundef nonnull %f, <4 x float> %simd_args) #0 !sycl_explicit_simd !0 !intel_reqd_sub_group_size !1 {
+define linkonce_odr dso_local x86_regcallcc <4 x float> @SIMD_CALL_HELPER(<4 x float> (<4 x float>)* noundef nonnull %f, <4 x float> %simd_args) #0 {
   %f.addr = alloca <4 x float> (<4 x float>)*, align 8
   %f.addr.ascast = addrspacecast <4 x float> (<4 x float>)** %f.addr to <4 x float> (<4 x float>)* addrspace(4)*
   store <4 x float> (<4 x float>)* %f, <4 x float> (<4 x float>)* addrspace(4)* %f.addr.ascast, align 8
@@ -79,25 +63,19 @@ define linkonce_odr dso_local x86_regcallcc <4 x float> @SIMD_CALL_HELPER(<4 x f
   ret <4 x float> %call
 }
 
-;---- Output optimized version for the SIMD_CALLEE call
-; CHECK: define {{.*}} <4 x float> @[[NAME1]](<4 x float> %{{.*}}) #1
-; Verify that indirect call is converted to direct
-; CHECK: %{{.*}} = call x86_regcallcc <4 x float> @SIMD_CALLEE(<4 x float> %{{.*}})
-; CHECK: }
-
-;------------- SYCL kernel, an entry point
+;---- SYCL kernel, an entry point
 define dso_local spir_kernel void @SYCL_kernel(float addrspace(1)* %ptr, float %x) #1 {
 entry:
   %res1 = call spir_func float @SPMD_CALLER(float %x)
   %ptri = ptrtoint float addrspace(1)* %ptr to i64
-  %vec = call spir_func <4 x float> @SHARED_FUNCTION(i64 %ptri)
+  %vec = call spir_func <4 x float> @SHARED_F(i64 %ptri)
   %res2 = extractelement <4 x float> %vec, i32 0
   %res = fadd float %res1, %res2
   store float %res, float addrspace(1)* %ptr
   ret void
 }
 
-;------------- ESIMD kernel, an entry point
+;---- ESIMD kernel, an entry point
 define dso_local spir_kernel void @ESIMD_kernel(float addrspace(1)* %ptr) #2 !sycl_explicit_simd !0 {
 entry:
   %ptr_as4 = addrspacecast float addrspace(1)* %ptr to float addrspace(4)*
@@ -107,23 +85,43 @@ entry:
   ret void
 }
 
-; Check that VCStackCall attribute is added to the invoke_simd helpers functions:
 attributes #0 = { "sycl-module-id"="invoke_simd.cpp" }
-; CHECK-IR-DAG: attributes #[[ATTR1]] = { "VCStackCall" {{.*}}"sycl-module-id"="invoke_simd.cpp" }
-
 attributes #1 = { "sycl-module-id"="a.cpp" }
 attributes #2 = { "sycl-module-id"="b.cpp" }
-
-
-attributes #0 = { noinline }
-attributes #1 = { "sycl-module-id"="invoke_simd.cpp" }
-attributes #2 = { "sycl-module-id"="a.cpp" }
-attributes #3 = { noinline "VCFunction" }
-attributes #4 = { alwaysinline "VCFunction" "sycl-module-id"="invoke_simd.cpp" }
-attributes #5 = { "CMGenxMain" "VCFunction" "VCNamedBarrierCount"="0" "VCSLMSize"="0" "oclrt"="1" "sycl-module-id"="b.cpp" }
-attributes #6 = { nounwind readnone "VCFunction" }
-attributes #7 = { "VCFunction" "VCStackCall" "sycl-module-id"="invoke_simd.cpp" }
-
+attributes #3 = { "referenced-indirectly" }
 
 !0 = !{}
-!1 = !{i32 16}
+!1 = !{i32 1}
+!2 = !{i32 4}
+
+;---------------- Verify IR. Outlined to avoid complications with reordering.
+; Check the original version (for SYCL call graph) is retained
+; CHECK: define dso_local spir_func <4 x float> @SHARED_F(
+
+; Verify __builtin_invoke_simd lowering
+; 1) the second argument (function pointer) is removed
+; 2) The call target (helper) is changed to the optimized one
+; CHECK: define dso_local spir_func float @SPMD_CALLER(float %{{.*}})
+; CHECK:   %{{.*}} = call spir_func float @_Z33__regcall3____builtin_invoke_simdXX_{{.+}}(<4 x float> (<4 x float>)* @[[NEW_HELPER_NAME:SIMD_CALL_HELPER_[0-9]+]], float %{{.*}})
+; CHECK:   ret float %{{.*}}
+
+; Check the original version (for SYCL call graph) is retained
+; CHECK: define dso_local spir_func <4 x float> @SHARED_F.esimd(i64 %{{.*}}) #[[SHARED_F_ATTRS:[0-9]+]] {
+; CHECK:   %{{.*}} = call spir_func <4 x float> @__intrin(i64 %{{.*}})
+; CHECK:   ret <4 x float> %{{.*}}
+
+;---- Verify that the helper has been transformed and optimized:
+;---- * %f removed
+;---- * indirect call replaced with direct and inlined
+;---- * linkonce_odr linkage replaced with weak_odr
+;---- * sycl_explicit_simd and intel_reqd_sub_group_size attributes added, which
+;----   is required for correct processing by LowerESIMD
+; CHECK: define weak_odr dso_local x86_regcallcc <4 x float> @[[NEW_HELPER_NAME]](<4 x float> %{{.*}}) #[[NEW_HELPER_ATTRS:[0-9]+]] !sycl_explicit_simd !1 !intel_reqd_sub_group_size !2 {
+; CHECK-NEXT:  %{{.*}} = call spir_func <4 x float> @SHARED_F.esimd(i64 100)
+; CHECK-NEXT:  %{{.*}} = fadd <4 x float> %{{.*}}, %{{.*}}
+; CHECK-NEXT:  ret <4 x float> {{.*}}
+
+; Check that VCStackCall attribute is added to the invoke_simd helpers functions:
+; CHECK: attributes #[[SHARED_F_ATTRS]] = { noinline "VCFunction" }
+; CHECK: attributes #[[NEW_HELPER_ATTRS]] = { "VCFunction" "VCStackCall" "sycl-module-id"="invoke_simd.cpp" }
+

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/no-sycl-esimd-split-shared-func.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/no-sycl-esimd-split-shared-func.ll
@@ -105,7 +105,7 @@ attributes #3 = { "referenced-indirectly" }
 ; CHECK:   %{{.*}} = call spir_func float @_Z33__regcall3____builtin_invoke_simdXX_{{.+}}(<4 x float> (<4 x float>)* @[[NEW_HELPER_NAME:SIMD_CALL_HELPER_[0-9]+]], float %{{.*}})
 ; CHECK:   ret float %{{.*}}
 
-; Check the original version (for SYCL call graph) is retained
+; Check the function is cloned for ESIMD call graph.
 ; CHECK: define dso_local spir_func <4 x float> @SHARED_F.esimd(i64 %{{.*}}) #[[SHARED_F_ATTRS:[0-9]+]] {
 ; CHECK:   %{{.*}} = call spir_func <4 x float> @__intrin(i64 %{{.*}})
 ; CHECK:   ret <4 x float> %{{.*}}

--- a/llvm/tools/sycl-post-link/ModuleSplitter.cpp
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.cpp
@@ -139,14 +139,14 @@ bool isESIMDFunction(const Function &F) {
 
 // This function makes one or two groups depending on kernel types (SYCL, ESIMD)
 EntryPointGroupVec
-groupEntryPointsByKernelType(const ModuleDesc &MD,
+groupEntryPointsByKernelType(ModuleDesc &MD,
                              bool EmitOnlyKernelsAsEntryPoints) {
-  const Module &M = MD.getModule();
+  Module &M = MD.getModule();
   EntryPointGroupVec EntryPointGroups{};
   std::map<StringRef, EntryPointSet> EntryPointMap;
 
   // Only process module entry points:
-  for (const auto &F : M.functions()) {
+  for (Function &F : M.functions()) {
     if (!isEntryPoint(F, EmitOnlyKernelsAsEntryPoints) ||
         !MD.isEntryPointCandidate(F))
       continue;
@@ -187,16 +187,16 @@ groupEntryPointsByKernelType(const ModuleDesc &MD,
 // which contains pairs of group id and entry points for that group. Each such
 // group along with IR it depends on (globals, functions from its call graph,
 // ...) will constitute a separate module.
-EntryPointGroupVec groupEntryPointsByScope(const ModuleDesc &MD,
+EntryPointGroupVec groupEntryPointsByScope(ModuleDesc &MD,
                                            EntryPointsGroupScope EntryScope,
                                            bool EmitOnlyKernelsAsEntryPoints) {
   EntryPointGroupVec EntryPointGroups{};
   // Use MapVector for deterministic order of traversal (helps tests).
   MapVector<StringRef, EntryPointSet> EntryPointMap;
-  const Module &M = MD.getModule();
+  Module &M = MD.getModule();
 
   // Only process module entry points:
-  for (const auto &F : M.functions()) {
+  for (Function &F : M.functions()) {
     if (!isEntryPoint(F, EmitOnlyKernelsAsEntryPoints) ||
         !MD.isEntryPointCandidate(F))
       continue;
@@ -246,15 +246,15 @@ EntryPointGroupVec groupEntryPointsByScope(const ModuleDesc &MD,
 
 template <class EntryPoinGroupFunc>
 EntryPointGroupVec
-groupEntryPointsByAttribute(const ModuleDesc &MD, StringRef AttrName,
+groupEntryPointsByAttribute(ModuleDesc &MD, StringRef AttrName,
                             bool EmitOnlyKernelsAsEntryPoints,
                             EntryPoinGroupFunc F) {
   EntryPointGroupVec EntryPointGroups{};
   std::map<StringRef, EntryPointSet> EntryPointMap;
-  const Module &M = MD.getModule();
+  Module &M = MD.getModule();
 
   // Only process module entry points:
-  for (const auto &F : M.functions()) {
+  for (auto &F : M.functions()) {
     if (!isEntryPoint(F, EmitOnlyKernelsAsEntryPoints) ||
         !MD.isEntryPointCandidate(F)) {
       continue;
@@ -669,7 +669,7 @@ void EntryPointGroup::rebuildFromNames(const std::vector<std::string> &Names,
   auto It0 = Names.cbegin();
   auto It1 = Names.cend();
   std::for_each(It0, It1, [&](const std::string &Name) {
-    const Function *F = M.getFunction(Name);
+    Function *F = M.getFunction(Name);
     assert(F && "entry point lost");
     Functions.insert(F);
   });

--- a/llvm/tools/sycl-post-link/ModuleSplitter.cpp
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.cpp
@@ -603,6 +603,9 @@ void ModuleDesc::renameDuplicatesOf(const Module &MA, StringRef Suff) {
   }
 }
 
+// Attribute to save current function linkage in before replacement.
+// See more comments in ModuleSplitter::fixupLinkageOfDirectInvokeSimdTargets
+// declaration.
 constexpr char SYCL_ORIG_LINKAGE_ATTR[] = "__sycl_orig_linkage";
 
 void ModuleDesc::fixupLinkageOfDirectInvokeSimdTargets() {
@@ -636,8 +639,8 @@ void ModuleDesc::restoreLinkageOfDirectInvokeSimdTargets() {
   }
 }
 
-// TODO: try to move including all passes (cleanup, spec consts, compile time
-// properties) in one place and execute MPM.run() only once.
+// TODO: try to move all passes (cleanup, spec consts, compile time properties)
+// in one place and execute MPM.run() only once.
 void ModuleDesc::cleanup() {
   ModuleAnalysisManager MAM;
   MAM.registerPass([&] { return PassInstrumentationAnalysis(); });

--- a/llvm/tools/sycl-post-link/ModuleSplitter.h
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.h
@@ -35,7 +35,7 @@ enum IRSplitMode {
 };
 
 // A vector that contains all entry point functions in a split module.
-using EntryPointSet = SetVector<const Function *>;
+using EntryPointSet = SetVector<Function *>;
 
 enum class SyclEsimdSplitStatus { SYCL_ONLY, ESIMD_ONLY, SYCL_AND_ESIMD };
 
@@ -126,18 +126,43 @@ public:
              const Properties &Props)
       : M(std::move(M)), EntryPoints(std::move(EntryPoints)), Props(Props) {
     Name = this->EntryPoints.GroupId.str();
+    fixupEntryPointsLinkage();
   }
 
   ModuleDesc(std::unique_ptr<Module> &&M, const std::vector<std::string> &Names,
              StringRef Name = "NoName")
       : M(std::move(M)), Name(Name) {
     rebuildEntryPoints(Names);
+    fixupEntryPointsLinkage();
+  }
+
+  // Some entry points may have linkonce_odr linkage, which does not really work
+  // for an entry point, because either inliner pass or LLVM linker will remove
+  // functions with such linkage, and entry point must be always available by
+  // definition. This function changes linkage of linkonce_odr entry points.
+  // An example of a such entry point is an instantiation of a function template
+  // even marked SYCL_EXTERNAL.
+  // TODO: is it practical to fix FE instead to assign different linkage for
+  // SYCL_EXTERNAL functions which get linkonce_odr currently?
+  bool fixupEntryPointsLinkage() {
+    bool Changed = false;
+
+    for (Function *F : EntryPoints.Functions) {
+      GlobalValue::LinkageTypes L = F->getLinkage();
+
+      if ((L == GlobalValue::LinkageTypes::LinkOnceODRLinkage) ||
+          (L == GlobalValue::LinkageTypes::LinkOnceAnyLinkage)) {
+        F->setLinkage(GlobalValue::LinkageTypes::ExternalLinkage);
+        Changed = true;
+      }
+    }
+    return Changed;
   }
 
   // Filters out functions which are not part of this module's entry point set.
   bool isEntryPointCandidate(const Function &F) const {
     if (EntryPoints.Functions.size() > 0) {
-      return EntryPoints.Functions.contains(&F);
+      return EntryPoints.Functions.contains(const_cast<Function *>(&F));
     }
     return IsTopLevel; // Top level module does not limit entry points set.
   }

--- a/llvm/tools/sycl-post-link/ModuleSplitter.h
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.h
@@ -160,6 +160,9 @@ public:
   // example, GenXSPIRVWriterAdaptor). Entry points need to be updated to
   // include the replacement function. save/rebuild pair of functions is
   // provided to automate this process.
+  // TODO: this scheme is unnecessarily complex. The simpler and easier
+  // maintainable one would be using a special function attribute for the
+  // duration of post-link transformations.
   void saveEntryPointNames(std::vector<std::string> &Dest) {
     EntryPoints.saveNames(Dest);
   }
@@ -171,6 +174,20 @@ public:
   void rebuildEntryPoints(const Module &M) { EntryPoints.rebuild(M); }
 
   void renameDuplicatesOf(const Module &M, StringRef Suff);
+
+  // Fixups an invoke_simd target linkage so that it is not dropped by global
+  // DCE performed on an ESIMD module after it splits out. If SimdF can't be
+  // deduced, then we have real function pointer, and user code is assumed to
+  // define proper linkage for the potential target functions.
+  // Also saves old linkage into a function attribute.
+  void fixupLinkageOfDirectInvokeSimdTargets();
+
+  // Restores original linkage of invoke_simd targets. This effectively
+  // re-enables DCE on invoke_simd targets with linkonce linkage.
+  void restoreLinkageOfDirectInvokeSimdTargets();
+
+  // Cleans up module IR - removes dead globals, debug info etc.
+  void cleanup();
 
 #ifndef NDEBUG
   void verifyESIMDProperty() const;

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -696,9 +696,9 @@ processInputModule(std::unique_ptr<Module> M) {
   // Violation of this invariant is user error and must've been reported.
   // However, if split mode is "auto", then entry point filtering is still
   // performed.
-  assert(!IROutputOnly || (SplitMode == module_split::SPLIT_NONE) ||
-         (SplitMode == module_split::SPLIT_AUTO) &&
-             "invalid split mode for IR-only output");
+  assert((!IROutputOnly || (SplitMode == module_split::SPLIT_NONE) ||
+          (SplitMode == module_split::SPLIT_AUTO)) &&
+         "invalid split mode for IR-only output");
 
   // Top-level per-kernel/per-source splitter. SYCL/ESIMD splitting is applied
   // to modules resulting from all other kinds of splitting.
@@ -780,8 +780,8 @@ processInputModule(std::unique_ptr<Module> M) {
       if (!SplitEsimd && (MMs.size() > 1)) {
         // SYCL/ESIMD splitting is not requested, link back into single module.
         assert(MMs.size() == 2);
-        assert(MMs[0].isESIMD() && MMs[1].isSYCL() ||
-               MMs[1].isESIMD() && MMs[0].isSYCL());
+        assert((MMs[0].isESIMD() && MMs[1].isSYCL()) ||
+               (MMs[1].isESIMD() && MMs[0].isSYCL()));
         int ESIMDInd = MMs[0].isESIMD() ? 0 : 1;
         int SYCLInd = MMs[0].isESIMD() ? 1 : 0;
         // ... but before that, make sure no link conflicts will occur.

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -734,6 +734,7 @@ processInputModule(std::unique_ptr<Module> M) {
     while (DoubleGRFSplitter->hasMoreSplits()) {
       module_split::ModuleDesc MDesc1 = DoubleGRFSplitter->nextSplit();
       DUMP_ENTRY_POINTS(MDesc1.entries(), MDesc1.Name.c_str(), 2);
+      MDesc1.fixupLinkageOfDirectInvokeSimdTargets();
 
       // Do SYCL/ESIMD splitting. It happens always, as ESIMD and SYCL must
       // undergo different set of LLVMIR passes. After this they are linked back
@@ -787,6 +788,8 @@ processInputModule(std::unique_ptr<Module> M) {
         MMs[ESIMDInd].renameDuplicatesOf(MMs[SYCLInd].getModule(), ".esimd");
         module_split::ModuleDesc M2 =
             link(std::move(MMs[0]), std::move(MMs[1]));
+        M2.restoreLinkageOfDirectInvokeSimdTargets();
+        M2.cleanup();
         MMs.clear();
         MMs.emplace_back(std::move(M2));
         Modified = true;

--- a/sycl/include/std/experimental/simd.hpp
+++ b/sycl/include/std/experimental/simd.hpp
@@ -1382,6 +1382,9 @@ public:
 // TODO: implement simd
 template <class _Tp, class _Abi>
 class simd {
+#ifdef ENABLE_SYCL_EXT_ONEAPI_INVOKE_SIMD
+  template <class, class> friend class simd;
+#endif // ENABLE_SYCL_EXT_ONEAPI_INVOKE_SIMD
 public:
   using value_type = _Tp;
   using reference = __simd_reference<_Tp, _Tp, _Abi>;
@@ -1454,6 +1457,15 @@ private:
 
 public:
   // implicit type conversion constructor
+#ifdef ENABLE_SYCL_EXT_ONEAPI_INVOKE_SIMD
+  template <class _Up,
+    class = typename std::enable_if<
+      std::is_same<_Abi, __simd_abi<_StorageKind::_VecExt, size()>>::value &&
+    __is_non_narrowing_arithmetic_convertible<_Up, _Tp>()>::type>
+    simd(const simd<_Up, _Abi>& __v) {
+    __s_.__storage_ = __builtin_convertvector(__v.__s_.__storage_, raw_storage_type);
+  }
+#endif // ENABLE_SYCL_EXT_ONEAPI_INVOKE_SIMD
   template <class _Up,
             class = typename std::enable_if<
                 std::is_same<_Abi, simd_abi::fixed_size<size()>>::value &&

--- a/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
@@ -235,16 +235,15 @@ simd_obj_call_helper(const void *obj_ptr,
   auto f =
       *reinterpret_cast<const std::remove_reference_t<Callable> *>(obj_ptr);
   return f(simd_args...);
-};
+}
 
 // This function is a wrapper around a call to a function.
 template <int N, class Callable, class... T>
 SYCL_EXTERNAL __regcall detail::SimdRetType<N, Callable, T...>
 simd_func_call_helper(Callable f,
-                      typename detail::spmd2simd<T, N>::type... simd_args)
-    SYCL_ESIMD_FUNCTION {
+                      typename detail::spmd2simd<T, N>::type... simd_args) {
   return f(simd_args...);
-};
+}
 
 #ifdef _GLIBCXX_RELEASE
 #if _GLIBCXX_RELEASE < 10

--- a/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
@@ -134,6 +134,16 @@ struct simd2spmd<T, std::enable_if_t<std::is_arithmetic_v<T>>> {
   using type = uniform<T>;
 };
 
+// Determine number of elements in a simd type.
+template <class T> struct simd_size {
+  static constexpr int value = 1; // 1 element in any type by default
+};
+
+// * Specialization for the simd type.
+template <class T, int N> struct simd_size<simd<T, N>> {
+  static constexpr int value = N;
+};
+
 // Check if given type is uniform.
 template <class T> struct is_uniform_type : std::false_type {};
 template <class T> struct is_uniform_type<uniform<T>> : std::true_type {
@@ -147,19 +157,11 @@ struct is_simd_or_mask_type<simd<T, N>> : std::true_type {};
 template <class T, int N>
 struct is_simd_or_mask_type<simd_mask<T, N>> : std::true_type {};
 
-// Checks if the return value type and the types of arguments of given
-// SimdCallable are all uniform.
-template <class SimdCallable, class... SpmdArgs> struct has_uniform_signature {
+// Checks if all the types in the parameter pack are uniform<T>.
+template <class... SpmdArgs> struct all_uniform_types {
   constexpr operator bool() {
-    using ArgTypeList = __MP11_NS::mp_list<SpmdArgs...>;
-
-    if constexpr (__MP11_NS::mp_all_of<ArgTypeList, is_uniform_type>::value) {
-      using SimdRet = std::invoke_result_t<SimdCallable, SpmdArgs...>;
-      return is_uniform_type<SimdRet>::value ||
-             !is_simd_or_mask_type<SimdRet>::value;
-    } else {
-      return false;
-    }
+    using TypeList = __MP11_NS::mp_list<SpmdArgs...>;
+    return __MP11_NS::mp_all_of<TypeList, is_uniform_type>::value;
   }
 };
 
@@ -186,7 +188,7 @@ template <class SimdCallable, class... SpmdArgs> struct sg_size {
   using IsInvocableSgSize = __MP11_NS::mp_bool<std::is_invocable_v<
       SimdCallable, typename spmd2simd<SpmdArgs, N::value>::type...>>;
 
-  constexpr operator int() {
+  SYCL_EXTERNAL constexpr operator int() {
     using SupportedSgSizes = __MP11_NS::mp_list_c<int, 1, 2, 4, 8, 16, 32>;
     using InvocableSgSizes =
         __MP11_NS::mp_copy_if<SupportedSgSizes, IsInvocableSgSize>;
@@ -209,8 +211,15 @@ using SpmdRetType =
 
 template <class SimdCallable, class... SpmdArgs>
 static constexpr int get_sg_size() {
-  if constexpr (has_uniform_signature<SimdCallable, SpmdArgs...>()) {
-    return 0; // subgroup size does not matter then
+  if constexpr (all_uniform_types<SpmdArgs...>()) {
+    using SimdRet = std::invoke_result_t<SimdCallable, SpmdArgs...>;
+
+    if constexpr (is_simd_or_mask_type<SimdRet>::value) {
+      return simd_size<SimdRet>::value;
+    } else {
+      // fully uniform function - subgroup size does not matter
+      return 0;
+    }
   } else {
     return sg_size<SimdCallable, SpmdArgs...>();
   }
@@ -220,11 +229,20 @@ static constexpr int get_sg_size() {
 // with captures. Note __regcall - this is needed for efficient argument
 // forwarding.
 template <int N, class Callable, class... T>
-__regcall detail::SimdRetType<N, Callable, T...>
-simd_call_helper(const void *obj_ptr,
-                 typename detail::spmd2simd<T, N>::type... simd_args) {
+SYCL_EXTERNAL __regcall detail::SimdRetType<N, Callable, T...>
+simd_obj_call_helper(const void *obj_ptr,
+                     typename detail::spmd2simd<T, N>::type... simd_args) {
   auto f =
       *reinterpret_cast<const std::remove_reference_t<Callable> *>(obj_ptr);
+  return f(simd_args...);
+};
+
+// This function is a wrapper around a call to a function.
+template <int N, class Callable, class... T>
+SYCL_EXTERNAL __regcall detail::SimdRetType<N, Callable, T...>
+simd_func_call_helper(Callable f,
+                      typename detail::spmd2simd<T, N>::type... simd_args)
+    SYCL_ESIMD_FUNCTION {
   return f(simd_args...);
 };
 
@@ -268,6 +286,7 @@ static constexpr bool is_function_ptr_or_ref_v =
     || is_regcall_function_ptr_or_ref_v<Callable>
 #endif // __INVOKE_SIMD_USE_STD_IS_FUNCTION_WA
     ;
+
 } // namespace detail
 
 // --- The main API
@@ -301,15 +320,16 @@ __attribute__((always_inline)) auto invoke_simd(sycl::sub_group sg,
   constexpr bool is_function = detail::is_function_ptr_or_ref_v<Callable>;
 
   if constexpr (is_function) {
-    return __builtin_invoke_simd<is_function, RetSpmd>(
-        f, detail::unwrap_uniform<T>::impl(args)...);
+    return __builtin_invoke_simd<true /*function*/, RetSpmd>(
+        detail::simd_func_call_helper<N, Callable, T...>, f,
+        detail::unwrap_uniform<T>::impl(args)...);
   } else {
     // TODO support functors and lambdas which are handled in this branch.
     // The limiting factor for now is that the LLVMIR data flow analysis
     // implemented in LowerInvokeSimd.cpp which, finds actual invoke_simd
     // target function, can't handle this case yet.
-    return __builtin_invoke_simd<is_function, RetSpmd>(
-        detail::simd_call_helper<N, Callable, T...>, &f,
+    return __builtin_invoke_simd<false /*functor/lambda*/, RetSpmd>(
+        detail::simd_obj_call_helper<N, Callable, T...>, &f,
         detail::unwrap_uniform<T>::impl(args)...);
   }
 // TODO Temporary macro and assert to enable API compilation testing.

--- a/sycl/include/sycl/ext/oneapi/experimental/uniform.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/uniform.hpp
@@ -15,6 +15,8 @@
 // 1 - Initial extension version. Base features are supported.
 #define SYCL_EXT_ONEAPI_UNIFORM 1
 
+#include <sycl/detail/defines_elementary.hpp> // for __SYCL_INLINE_NAMESPACE
+
 #include <type_traits>
 
 // Forward declarations of types not allowed to be wrapped in uniform:
@@ -29,6 +31,7 @@ struct sub_group;
 } // namespace ext
 
 template <int, bool> class item;
+template <int> class id;
 template <int> class nd_item;
 template <int> class h_item;
 template <int> class group;

--- a/sycl/test/invoke_simd/invoke_simd.cpp
+++ b/sycl/test/invoke_simd/invoke_simd.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -c -fsycl %s
+// RUN: %clangxx -c -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %s
 
 // The tests checks that invoke_simd API is compileable.
 
@@ -35,9 +35,9 @@ ESIMD_CALLEE(float *A, esimd::simd<float, VL> b, int i) SYCL_ESIMD_FUNCTION {
   return a + b;
 }
 
-SYCL_EXTERNAL
-simd<float, VL> __regcall SIMD_CALLEE(float *A, simd<float, VL> b,
-                                      int i) SYCL_ESIMD_FUNCTION;
+[[intel::device_indirectly_callable]] SYCL_EXTERNAL
+    simd<float, VL> __regcall SIMD_CALLEE(float *A, simd<float, VL> b,
+                                          int i) SYCL_ESIMD_FUNCTION;
 
 float SPMD_CALLEE(float *A, float b, int i) { return A[i] + b; }
 
@@ -151,9 +151,9 @@ int main(void) {
   return err_cnt > 0 ? 1 : 0;
 }
 
-SYCL_EXTERNAL
-simd<float, VL> __regcall SIMD_CALLEE(float *A, simd<float, VL> b,
-                                      int i) SYCL_ESIMD_FUNCTION {
+[[intel::device_indirectly_callable]] SYCL_EXTERNAL
+    simd<float, VL> __regcall SIMD_CALLEE(float *A, simd<float, VL> b,
+                                          int i) SYCL_ESIMD_FUNCTION {
   esimd::simd<float, VL> res = ESIMD_CALLEE(A, b, i);
   return res;
 }
@@ -307,4 +307,3 @@ void check_not_f(char ch) {
   assert_is_not_func(capt_lambda);
   assert_is_not_func(non_capt_lambda);
 }
-// }


### PR DESCRIPTION
- Introduce an intermediate lambda in invoke_simd and call SIMD target
from the lambda with given (SIMD) arguments coming from the lambda's
formal parameters. This way compiler automatically performs necessary
argument type conversion.

- Introduce a new implicit constructor for simd to allow conversion
of simd objects with _VecExt storage kind (used in invoke_simd
extension).

- Fix linkonce_odr linkage of entry points : change it to external
  linkage to avoid removal by the inliner and llvm-linker.

This new scheme complicates the SIMD target function pointer flow, so
LowerInvokeSimd.cpp update is needed to accommodate the new flow.

E2E tests: https://github.com/intel/llvm-test-suite/pull/1146

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>