### PR TITLE
[CI] Ignore in-tree LIT tests status for E2E tests

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -157,7 +157,7 @@ jobs:
 
   llvm_test_suite:
     needs: build
-    if: ${{ inputs.lts_matrix != '' }}
+    if: ${{ always() && build.steps.build.outcome == 'success' }} && ${{ inputs.lts_matrix != '' }}
     strategy:
       fail-fast: false
       max-parallel: ${{ inputs.max_parallel }}


### PR DESCRIPTION
Run llvm-test-suite tests even if in-tree LIT tests failed. We need only
"build" step to build all the tools we need for running llvm-test-suite.