### PR TITLE
[SYCL][NFC] Remove or ignore unused parameters and captures

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -881,7 +881,7 @@ pi_result _pi_context::initialize() {
   // Recursive helper to call createUSMAllocators for all sub-devices
   std::function<void(pi_device)> createUSMAllocatorsRecursive;
   createUSMAllocatorsRecursive =
-      [this, createUSMAllocators,
+      [createUSMAllocators,
        &createUSMAllocatorsRecursive](pi_device Device) -> void {
     createUSMAllocators(Device);
     for (auto &SubDevice : Device->SubDevices)

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -276,6 +276,9 @@ void *MemoryManager::allocate(ContextImplPtr TargetContext, SYCLMemObjI *MemObj,
 void *MemoryManager::allocateHostMemory(SYCLMemObjI *MemObj, void *UserPtr,
                                         bool HostPtrReadOnly, size_t Size,
                                         const sycl::property_list &) {
+  std::ignore = HostPtrReadOnly;
+  std::ignore = Size;
+
   // Can return user pointer directly if it is not a nullptr.
   if (UserPtr)
     return UserPtr;


### PR DESCRIPTION
This commit removes an unused capture in the PI L0 backend and ignores two parameters in MemoryManager::allocateHostMemory.