### PR TITLE
[SYCL][NFC] Avoid MSVC's max macro in allocator_traits

### DIFF
--- a/sycl/include/sycl/detail/aligned_allocator.hpp
+++ b/sycl/include/sycl/detail/aligned_allocator.hpp
@@ -131,7 +131,7 @@ struct allocator_traits<sycl::detail::aligned_allocator<T>> {
   }
 
   static size_type max_size(const allocator_type &) noexcept {
-    return std::numeric_limits<size_type>::max() / sizeof(value_type);
+    return (std::numeric_limits<size_type>::max)() / sizeof(value_type);
   }
 
   static allocator_type


### PR DESCRIPTION
Compiling aligned_allocator.hpp with MSVC causes a problem as max is defined as a macro. This commit works around this issue.