### PR TITLE
[SYCL][CUDA] Add concurrent memory check to mem_advice

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -5114,7 +5114,7 @@ pi_result cuda_piextUSMEnqueueMemAdvise(pi_queue queue, const void *ptr,
   PI_CHECK_ERROR(cuPointerGetAttribute(
       &is_managed, CU_POINTER_ATTRIBUTE_IS_MANAGED, (CUdeviceptr)ptr));
   if (!is_managed) {
-    setErrorMessage("Prefetch hint ignored as prefetch only works with USM",
+    setErrorMessage("Memory advice ignored as memory advices only works with USM",
                     PI_SUCCESS);
     return PI_ERROR_PLUGIN_SPECIFIC_ERROR;
   }

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -5110,6 +5110,15 @@ pi_result cuda_piextUSMEnqueueMemAdvise(pi_queue queue, const void *ptr,
     // CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS property.
   }
 
+  unsigned int is_managed;
+  PI_CHECK_ERROR(cuPointerGetAttribute(
+      &is_managed, CU_POINTER_ATTRIBUTE_IS_MANAGED, (CUdeviceptr)ptr));
+  if (!is_managed) {
+    setErrorMessage("Prefetch hint ignored as prefetch only works with USM",
+                    PI_SUCCESS);
+    return PI_ERROR_PLUGIN_SPECIFIC_ERROR;
+  }
+
   pi_result result = PI_SUCCESS;
   std::unique_ptr<_pi_event> event_ptr{nullptr};
 

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -5114,8 +5114,9 @@ pi_result cuda_piextUSMEnqueueMemAdvise(pi_queue queue, const void *ptr,
   PI_CHECK_ERROR(cuPointerGetAttribute(
       &is_managed, CU_POINTER_ATTRIBUTE_IS_MANAGED, (CUdeviceptr)ptr));
   if (!is_managed) {
-    setErrorMessage("Memory advice ignored as memory advices only works with USM",
-                    PI_SUCCESS);
+    setErrorMessage(
+        "Memory advice ignored as memory advices only works with USM",
+        PI_SUCCESS);
     return PI_ERROR_PLUGIN_SPECIFIC_ERROR;
   }
 


### PR DESCRIPTION
This PR adds a check to CUDA's mem advice to make sure the memory passed is managed memory. This change makes `mem_advise` line up with `prefetch` in terms of checking that both the device supports concurrent managed memory and that the memory passed to the function is managed. 

This is to prevent `cuMemAdvise` from failing on the SYCL `mem_advise` CTS tests.