### PR TITLE
[SYCL] Make sycl::exception nothrow copy constructible

### DIFF
--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -97,6 +97,8 @@ public:
   cl_int get_cl_code() const;
 
 private:
+  // Exceptions must be noexcept copy constructible, so cannot use std::string
+  // directly.
   std::shared_ptr<std::string> MMsg;
   pi_int32 MPIErr;
   std::shared_ptr<context> MContext;

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -97,7 +97,7 @@ public:
   cl_int get_cl_code() const;
 
 private:
-  std::string MMsg;
+  std::shared_ptr<std::string> MMsg;
   pi_int32 MPIErr;
   std::shared_ptr<context> MContext;
 
@@ -108,8 +108,9 @@ protected:
       : exception(std::string(Msg), PIErr, Context) {}
   exception(const std::string &Msg, const pi_int32 PIErr,
             std::shared_ptr<context> Context = nullptr)
-      : MMsg(Msg + " " + detail::codeToString(PIErr)), MPIErr(PIErr),
-        MContext(Context) {}
+      : MMsg(std::make_shared<std::string>(Msg + " " +
+                                           detail::codeToString(PIErr))),
+        MPIErr(PIErr), MContext(Context) {}
 
   // base constructors used by SYCL 1.2.1 exception subclasses
   exception(std::error_code ec, const char *Msg, const pi_int32 PIErr,
@@ -122,7 +123,8 @@ protected:
     MPIErr = PIErr;
   }
 
-  exception(const std::string &Msg) : MMsg(Msg), MContext(nullptr) {}
+  exception(const std::string &Msg)
+      : MMsg(std::make_shared<std::string>(Msg)), MContext(nullptr) {}
 
   // base constructor for all SYCL 2020 constructors
   // exception(context *ctxPtr, std::error_code ec, const std::string

--- a/sycl/test/regression/exception_nothrow_copy_constructible.cpp
+++ b/sycl/test/regression/exception_nothrow_copy_constructible.cpp
@@ -1,0 +1,11 @@
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
+// expected-no-diagnostics
+
+#include <sycl/sycl.hpp>
+#include <type_traits>
+
+int main() {
+  static_assert(std::is_nothrow_copy_constructible_v<sycl::exception>,
+                "sycl::exception is not nothrow copy constructible.");
+  return 0;
+}


### PR DESCRIPTION
Due to std::string not being nothrow copy constructible, neither is sycl::exception. As a throw in the copy constructor when throwing an exception will cause a termination of the program, sycl::exception should never be able to throw. These changes make sycl::exception nothrow copy constructible by making its std::string member a shared pointer.