### PR TITLE
[SYCL][CUDA] Use context mutex in refcount inc/dec

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -201,9 +201,15 @@ struct _pi_context {
 
   bool is_primary() const noexcept { return kind_ == kind::primary; }
 
-  pi_uint32 increment_reference_count() noexcept { return ++refCount_; }
+  pi_uint32 increment_reference_count() noexcept {
+    std::lock_guard<std::mutex> guard(mutex_);
+    return ++refCount_;
+  }
 
-  pi_uint32 decrement_reference_count() noexcept { return --refCount_; }
+  pi_uint32 decrement_reference_count() noexcept {
+    std::lock_guard<std::mutex> guard(mutex_);
+    return --refCount_;
+  }
 
   pi_uint32 get_reference_count() const noexcept { return refCount_; }
 


### PR DESCRIPTION
context wasn't using its mutex when incrementing/decrementing the ref count, even though multiple threads may attempt this at the same time in multithreaded applications such as in assert_in_simultaneously_multiple_tus.cpp. This may fix https://github.com/intel/llvm/issues/6463 but I can't be sure of this because I can't reproduce flaky CI test failures in #6463 locally.

Signed-off-by: JackAKirk <jack.kirk@codeplay.com>