### PR TITLE
[SYCL][ABI-Break] Remove sycl::exception error code member workaround

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -30,7 +30,7 @@ set(SYCL_MINOR_VERSION 7)
 set(SYCL_PATCH_VERSION 0)
 # Don't forget to re-enable sycl_symbols_windows.dump once we leave ABI-breaking
 # window!
-set(SYCL_DEV_ABI_VERSION 7)
+set(SYCL_DEV_ABI_VERSION 8)
 if (SYCL_ADD_DEV_VERSION_POSTFIX)
   set(SYCL_VERSION_POSTFIX "-${SYCL_DEV_ABI_VERSION}")
 endif()

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -102,6 +102,7 @@ private:
   std::shared_ptr<std::string> MMsg;
   pi_int32 MPIErr;
   std::shared_ptr<context> MContext;
+  std::error_code MErrC = make_error_code(sycl::errc::invalid);
 
 protected:
   // these two constructors are no longer used. Kept for ABI compatability.

--- a/sycl/source/exception.cpp
+++ b/sycl/source/exception.cpp
@@ -15,12 +15,6 @@
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 
-namespace { // anonymous
-constexpr char ReservedForErrorcode[] =
-    "01234567812345678"; // 17 (string terminator plus error code)
-std::error_code SYCL121ProxyErrorcode = make_error_code(sycl::errc::invalid);
-} // namespace
-
 exception::exception(std::error_code EC, const char *Msg)
     : exception(EC, nullptr, Msg) {}
 
@@ -65,35 +59,11 @@ exception::exception(context Ctx, int EV, const std::error_category &ECat)
 // protected base constructor for all SYCL 2020 constructors
 exception::exception(std::error_code EC, std::shared_ptr<context> SharedPtrCtx,
                      const std::string &WhatArg)
-    : MMsg(std::make_shared<std::string>(WhatArg + ReservedForErrorcode)),
-      MPIErr(PI_ERROR_INVALID_VALUE), MContext(SharedPtrCtx) {
-  // For compatibility with previous implementation, we are "hiding" the
-  // std::error_code in the MMsg string, behind the null string terminator
-  const int StringTermPoint = MMsg->length() - strlen(ReservedForErrorcode);
-  char *ReservedPtr = &(*MMsg)[StringTermPoint];
-  ReservedPtr[0] = '\0';
-  ReservedPtr++;
-  // insert error code
-  std::error_code *ECPtr = reinterpret_cast<std::error_code *>(ReservedPtr);
-  memcpy(ECPtr, &EC, sizeof(std::error_code));
-}
+    : MMsg(std::make_shared<std::string>(WhatArg)),
+      MPIErr(PI_ERROR_INVALID_VALUE), MContext(SharedPtrCtx), MErrC(EC) {}
 
 const std::error_code &exception::code() const noexcept {
-  const char *WhatStr = MMsg->c_str();
-  // advance to inner string-terminator
-  int StringTermPoint = MMsg->length() - strlen(ReservedForErrorcode);
-  if (StringTermPoint >= 0) {
-    const char *ReservedPtr = &WhatStr[StringTermPoint];
-    // check for string terminator, which denotes a SYCL 2020 exception
-    if (ReservedPtr[0] == '\0') {
-      ReservedPtr++;
-      const std::error_code *ECPtr =
-          reinterpret_cast<const std::error_code *>(ReservedPtr);
-      return *ECPtr;
-    }
-  }
-  // else the exception originates from some SYCL 1.2.1 source
-  return SYCL121ProxyErrorcode;
+  return MErrC;
 }
 
 const std::error_category &exception::category() const noexcept {


### PR DESCRIPTION
To avoid ABI break, sycl::exception would embed the error code into the error string. With the ABI-break window open, this commit promotes the embedded error code to a member of sycl::exception.