### PR TITLE
[CI] Update GPU driver uplift process

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'
     - '.github/CODEOWNERS'
+    - '.github/workflows/sycl_update_gpu_driver.yml'
     - 'devops/containers/**'
     - 'devops/scripts/install_drivers.sh'
     - 'devops/scripts/install_build_tools.sh'

--- a/.github/workflows/sycl_update_gpu_driver.yml
+++ b/.github/workflows/sycl_update_gpu_driver.yml
@@ -23,7 +23,6 @@ jobs:
     - name: Create Pull Request
       env:
         BRANCH: ci/update_gpu_driver-linux-${{ env.NEW_DRIVER_VERSION }}
-        LLVMBOT_TOKEN: ${{ secrets.LLVM_MAIN_SYNC_BBSYCL_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.LLVM_MAIN_SYNC_BBSYCL_TOKEN }}
       run: |
         cd $GITHUB_WORKSPACE
@@ -33,5 +32,5 @@ jobs:
         git checkout -B $BRANCH
         git add -u
         git commit -m "[GHA] Uplift Linux GPU RT version to $NEW_DRIVER_VERSION" || exit 0   # exit if commit is empty
-        git push https://$LLVMBOT_TOKEN@github.com/${{ github.repository }} ${BRANCH}
+        git push https://$GITHUB_TOKEN@github.com/${{ github.repository }} ${BRANCH}
         gh pr create --head $BRANCH --title "[GHA] Uplift GPU RT version for Linux CI" --body "Uplift GPU RT version for Linux to $NEW_DRIVER_VERSION"

--- a/.github/workflows/sycl_update_gpu_driver.yml
+++ b/.github/workflows/sycl_update_gpu_driver.yml
@@ -14,7 +14,7 @@ jobs:
   update_driver_linux:
     runs-on: ubuntu-latest
     if: github.repository == 'intel/llvm'
-    environment: deps_aaaaa
+    environment: deps_uplift
     steps:
     - uses: actions/checkout@v2
     - name: Update dependencies file

--- a/.github/workflows/sycl_update_gpu_driver.yml
+++ b/.github/workflows/sycl_update_gpu_driver.yml
@@ -3,6 +3,9 @@ name: Update GPU driver
 on:
   schedule:
     - cron:  '0 3 * * 2'
+  push:
+    branches:
+    - driver-upgrade
   pull_request:
     branches:
     - sycl

--- a/.github/workflows/sycl_update_gpu_driver.yml
+++ b/.github/workflows/sycl_update_gpu_driver.yml
@@ -3,6 +3,11 @@ name: Update GPU driver
 on:
   schedule:
     - cron:  '0 3 * * 2'
+  pull_request:
+    branches:
+    - sycl
+    paths:
+    - .github/workflows/sycl_update_gpu_driver.yml
   workflow_dispatch:
 
 jobs:
@@ -19,7 +24,7 @@ jobs:
       env:
         BRANCH: ci/update_gpu_driver-linux-${{ env.NEW_DRIVER_VERSION }}
         LLVMBOT_TOKEN: ${{ secrets.LLVM_MAIN_SYNC_BBSYCL_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.LLVM_MAIN_SYNC_BBSYCL_TOKEN }}
       run: |
         cd $GITHUB_WORKSPACE
         # Set fake identity to fulfil git requirements
@@ -27,32 +32,6 @@ jobs:
         git config --global user.email "actions@github.com"
         git checkout -B $BRANCH
         git add -u
-        git commit -m "[GHA] Uplift GPU RT version for Linux CI" || exit 0   # exit if commit is empty
+        git commit -m "[GHA] Uplift GPU RT version for Linux CI" -m "Uplift GPU RT version for Linux to $NEW_DRIVER_VERSION" || exit 0   # exit if commit is empty
         git push https://$LLVMBOT_TOKEN@github.com/${{ github.repository }} ${BRANCH}
         gh pr create --head $BRANCH --title "[GHA] Uplift GPU RT version for Linux CI" --body "Uplift GPU RT version for Linux to $NEW_DRIVER_VERSION"
-
-  update_driver_linux_staging:
-    runs-on: ubuntu-latest
-    if: github.repository == 'intel/llvm'
-    steps:
-    - uses: actions/checkout@v2
-    - name: Update dependencies file
-      run: |
-        version="$(python3 devops/scripts/update_drivers.py linux_staging)"
-        echo 'NEW_DRIVER_VERSION='$version >> $GITHUB_ENV
-    - name: Update sycl Branch
-      env:
-        BRANCH: ci/update_gpu_driver-linux_staging-${{ env.NEW_DRIVER_VERSION }}
-        LLVMBOT_TOKEN: ${{ secrets.LLVM_MAIN_SYNC_BBSYCL_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        cd $GITHUB_WORKSPACE
-        # Set fake identity to fulfil git requirements
-        git config --global user.name "GitHub Actions"
-        git config --global user.email "actions@github.com"
-        git checkout -B $BRANCH
-        git add -u
-        git commit -m "[GHA] Uplift GPU RT version for Nightly Builds" || exit 0   # exit if commit is empty
-        git push https://$LLVMBOT_TOKEN@github.com/${{ github.repository }} ${BRANCH}
-        gh pr create --head $BRANCH --title "[GHA] Uplift GPU RT version for Nightly Builds" --body "Uplift GPU RT version for Linux to $NEW_DRIVER_VERSION"
-

--- a/.github/workflows/sycl_update_gpu_driver.yml
+++ b/.github/workflows/sycl_update_gpu_driver.yml
@@ -14,6 +14,7 @@ jobs:
   update_driver_linux:
     runs-on: ubuntu-latest
     if: github.repository == 'intel/llvm'
+    environment: deps_aaaaa
     steps:
     - uses: actions/checkout@v2
     - name: Update dependencies file
@@ -24,6 +25,7 @@ jobs:
       env:
         BRANCH: ci/update_gpu_driver-linux-${{ env.NEW_DRIVER_VERSION }}
         GITHUB_TOKEN: ${{ secrets.LLVM_MAIN_SYNC_BBSYCL_TOKEN }}
+        MYTOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
       run: |
         cd $GITHUB_WORKSPACE
         git config --global user.name "Buildbot for SYCL"
@@ -32,7 +34,7 @@ jobs:
         git add -u
         git commit -m "[GHA] Uplift Linux GPU RT version to $NEW_DRIVER_VERSION" || exit 0   # exit if commit is empty
         echo AAAA
-        echo ${#GITHUB_TOKEN}
+        echo ${#MYTOKEN}
         echo AAAAAA
         git push https://$GITHUB_TOKEN@github.com/${{ github.repository }} ${BRANCH}
         echo BBBB

--- a/.github/workflows/sycl_update_gpu_driver.yml
+++ b/.github/workflows/sycl_update_gpu_driver.yml
@@ -23,15 +23,11 @@ jobs:
     - name: Create Pull Request
       env:
         BRANCH: ci/update_gpu_driver-linux-${{ env.NEW_DRIVER_VERSION }}
-        LLVMBOT_TOKEN: ${{ secrets.LLVM_MAIN_SYNC_BBSYCL_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.LLVM_MAIN_SYNC_BBSYCL_TOKEN }}
       run: |
         cd $GITHUB_WORKSPACE
-        # Set fake identity to fulfil git requirements
-        git config --global user.name "GitHub Actions"
-        git config --global user.email "actions@github.com"
         git checkout -B $BRANCH
         git add -u
         git commit -m "[GHA] Uplift Linux GPU RT version to $NEW_DRIVER_VERSION" || exit 0   # exit if commit is empty
-        git push https://$LLVMBOT_TOKEN@github.com/${{ github.repository }} ${BRANCH}
+        git push https://$GITHUB_TOKEN@github.com/${{ github.repository }} ${BRANCH}
         gh pr create --head $BRANCH --title "[GHA] Uplift GPU RT version for Linux CI" --body "Uplift GPU RT version for Linux to $NEW_DRIVER_VERSION"

--- a/.github/workflows/sycl_update_gpu_driver.yml
+++ b/.github/workflows/sycl_update_gpu_driver.yml
@@ -3,21 +3,12 @@ name: Update GPU driver
 on:
   schedule:
     - cron:  '0 3 * * 2'
-  push:
-    branches:
-    - driver-upgrade
-  pull_request:
-    branches:
-    - sycl
-    paths:
-    - .github/workflows/sycl_update_gpu_driver.yml
   workflow_dispatch:
 
 jobs:
   update_driver_linux:
     runs-on: ubuntu-latest
     if: github.repository == 'intel/llvm'
-    environment: deps_uplift
     steps:
     - uses: actions/checkout@v2
     - name: Update dependencies file
@@ -28,20 +19,12 @@ jobs:
       env:
         BRANCH: ci/update_gpu_driver-linux-${{ env.NEW_DRIVER_VERSION }}
         GITHUB_TOKEN: ${{ secrets.LLVM_MAIN_SYNC_BBSYCL_TOKEN }}
-        MYTOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
       run: |
         cd $GITHUB_WORKSPACE
-        git config --global user.name "Buildbot for SYCL"
-        git config --global user.email "bb-sycl@github.com"
+        git config --global user.name "GitHub Actions"
+        git config --global user.email "actions@github.com"
         git checkout -B $BRANCH
         git add -u
         git commit -m "[GHA] Uplift Linux GPU RT version to $NEW_DRIVER_VERSION" || exit 0   # exit if commit is empty
-        echo AAAA
-        echo ${#BRANCH}
-        echo AAAAA
-        echo ${#MYTOKEN}
-        echo AAAAAA
         git push https://$GITHUB_TOKEN@github.com/${{ github.repository }} ${BRANCH}
-        echo BBBB
-        gh pr create --head $BRANCH --title "[GHA] Uplift GPU RT version for Linux CI" --body "Uplift GPU RT version for Linux to $NEW_DRIVER_VERSION"
-        echo CCCC
+        gh pr create --head $BRANCH --title "[GHA] Uplift Linux GPU RT version to $NEW_DRIVER_VERSION" --body "Scheduled drivers uplift"

--- a/.github/workflows/sycl_update_gpu_driver.yml
+++ b/.github/workflows/sycl_update_gpu_driver.yml
@@ -31,5 +31,10 @@ jobs:
         git checkout -B $BRANCH
         git add -u
         git commit -m "[GHA] Uplift Linux GPU RT version to $NEW_DRIVER_VERSION" || exit 0   # exit if commit is empty
+        echo AAAA
+        echo ${#GITHUB_TOKEN}
+        echo AAAAAA
         git push https://$GITHUB_TOKEN@github.com/${{ github.repository }} ${BRANCH}
+        echo BBBB
         gh pr create --head $BRANCH --title "[GHA] Uplift GPU RT version for Linux CI" --body "Uplift GPU RT version for Linux to $NEW_DRIVER_VERSION"
+        echo CCCC

--- a/.github/workflows/sycl_update_gpu_driver.yml
+++ b/.github/workflows/sycl_update_gpu_driver.yml
@@ -26,6 +26,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.LLVM_MAIN_SYNC_BBSYCL_TOKEN }}
       run: |
         cd $GITHUB_WORKSPACE
+        git config --global user.name "Buildbot for SYCL"
+        git config --global user.email "bb-sycl@github.com"
         git checkout -B $BRANCH
         git add -u
         git commit -m "[GHA] Uplift Linux GPU RT version to $NEW_DRIVER_VERSION" || exit 0   # exit if commit is empty

--- a/.github/workflows/sycl_update_gpu_driver.yml
+++ b/.github/workflows/sycl_update_gpu_driver.yml
@@ -32,6 +32,6 @@ jobs:
         git config --global user.email "actions@github.com"
         git checkout -B $BRANCH
         git add -u
-        git commit -m "[GHA] Uplift GPU RT version for Linux CI" -m "Uplift GPU RT version for Linux to $NEW_DRIVER_VERSION" || exit 0   # exit if commit is empty
+        git commit -m "[GHA] Uplift Linux GPU RT version to $NEW_DRIVER_VERSION" || exit 0   # exit if commit is empty
         git push https://$LLVMBOT_TOKEN@github.com/${{ github.repository }} ${BRANCH}
         gh pr create --head $BRANCH --title "[GHA] Uplift GPU RT version for Linux CI" --body "Uplift GPU RT version for Linux to $NEW_DRIVER_VERSION"

--- a/.github/workflows/sycl_update_gpu_driver.yml
+++ b/.github/workflows/sycl_update_gpu_driver.yml
@@ -23,6 +23,7 @@ jobs:
     - name: Create Pull Request
       env:
         BRANCH: ci/update_gpu_driver-linux-${{ env.NEW_DRIVER_VERSION }}
+        LLVMBOT_TOKEN: ${{ secrets.LLVM_MAIN_SYNC_BBSYCL_TOKEN }}
         GITHUB_TOKEN: ${{ secrets.LLVM_MAIN_SYNC_BBSYCL_TOKEN }}
       run: |
         cd $GITHUB_WORKSPACE
@@ -32,5 +33,5 @@ jobs:
         git checkout -B $BRANCH
         git add -u
         git commit -m "[GHA] Uplift Linux GPU RT version to $NEW_DRIVER_VERSION" || exit 0   # exit if commit is empty
-        git push https://$GITHUB_TOKEN@github.com/${{ github.repository }} ${BRANCH}
+        git push https://$LLVMBOT_TOKEN@github.com/${{ github.repository }} ${BRANCH}
         gh pr create --head $BRANCH --title "[GHA] Uplift GPU RT version for Linux CI" --body "Uplift GPU RT version for Linux to $NEW_DRIVER_VERSION"

--- a/.github/workflows/sycl_update_gpu_driver.yml
+++ b/.github/workflows/sycl_update_gpu_driver.yml
@@ -34,6 +34,8 @@ jobs:
         git add -u
         git commit -m "[GHA] Uplift Linux GPU RT version to $NEW_DRIVER_VERSION" || exit 0   # exit if commit is empty
         echo AAAA
+        echo ${#BRANCH}
+        echo AAAAA
         echo ${#MYTOKEN}
         echo AAAAAA
         git push https://$GITHUB_TOKEN@github.com/${{ github.repository }} ${BRANCH}


### PR DESCRIPTION
* Ignore sycl_update_gpu_driver job change in sycl_precommit. Full pre-commit is expected to be done in PRs generated by sycl_update_gpu_driver, not the change in sycl_update_gpu_driver.
* Add driver version to commit title.
* Remove linux_staging drivers update. linux_staging versions are used
to produce "unstable" containers in SYCL nightly workflow, but in
fact "unstable" matching "latest" currently and there are no testing
processes in the CI currently which use "unstable" containers. Not sure what
the original intention was, but until we have any *separate* testing processes
for "unstable" containers it doesn't make sense to update the versions.
* Use personal access token to kick off pre-commit testing automatically in PR created by this job.