### PR TITLE
[SYCL][ESIMD] Fix an issue causing incorrect half conversion under ESIMD emulator

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/detail/elem_type_traits.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/elem_type_traits.hpp
@@ -582,7 +582,7 @@ public:
   template <class T = sycl::half>
   static inline T bitcast_to_half(__raw_t<T> Bits) {
 #ifndef __SYCL_DEVICE_ONLY__
-    return sycl::half{Bits};
+    return sycl::half(::sycl::detail::host_half_impl::half_v2(Bits));
 #else
     sycl::half Res;
     Res.Data = Bits;


### PR DESCRIPTION
The purpose of this PR is to fix an incorrect half conversion issue under ESIMD emulator