### PR TITLE
[SYCL] Add missing sycl::span constructor

### DIFF
--- a/sycl/include/sycl/sycl_span.hpp
+++ b/sycl/include/sycl/sycl_span.hpp
@@ -217,6 +217,15 @@ public:
   constexpr span(const span &) noexcept = default;
   constexpr span &operator=(const span &) noexcept = default;
 
+  template <size_t _Sz = _Extent>
+  _SYCL_SPAN_INLINE_VISIBILITY constexpr explicit span(
+      element_type (&__arr)[_Sz])
+      : __data{__arr} {
+    (void)_Sz;
+    _SYCL_SPAN_ASSERT(_Extent == _Sz,
+                      "size mismatch in span's constructor (&_arr)[_Sz]");
+  }
+
   _SYCL_SPAN_INLINE_VISIBILITY constexpr explicit span(pointer __ptr,
                                                        size_type __count)
       : __data{__ptr} {

--- a/sycl/include/sycl/sycl_span.hpp
+++ b/sycl/include/sycl/sycl_span.hpp
@@ -618,10 +618,9 @@ as_writable_bytes(span<_Tp, _Extent> __s) noexcept
 
 //  Deduction guides
 
-// array arg deduction guide. dynamic_extent arg used to select
-// the correct template. The _Sz will be used for the __size of the span.
+// array arg deduction guide
 template <class _Tp, size_t _Sz>
-span(_Tp (&)[_Sz]) -> span<_Tp, dynamic_extent>;
+span(_Tp (&)[_Sz]) -> span<_Tp, _Sz>;
 
 template <class _Tp, size_t _Sz> span(std::array<_Tp, _Sz> &) -> span<_Tp, _Sz>;
 

--- a/sycl/test/basic_tests/span.cpp
+++ b/sycl/test/basic_tests/span.cpp
@@ -32,5 +32,14 @@ int main() {
   sycl::span<const int,3> fullSpecConstArray{constArr};
   sycl::span<int, 4> fullSpecVecArray{vec};
 
+  // check that the extent is deduced correctly
+  static_assert(decltype(fromArray)::extent == decltype(fullSpecArray)::extent,
+                "extent doesn't match between unspecialized and fully "
+                "specialized span from array");
+  static_assert(decltype(fromConstArray)::extent ==
+                    decltype(fullSpecConstArray)::extent,
+                "extent doesn't match between unspecialized and fully "
+                "specialized span from const array");
+
   return 0;
 }

--- a/sycl/test/basic_tests/span.cpp
+++ b/sycl/test/basic_tests/span.cpp
@@ -28,9 +28,8 @@ int main() {
   sycl::span<int> fromIntVec{vec};
 
   // fully specialized
-  // TODO: fix fully specialized span from array declaration support
-  // sycl::span<int,4> fullSpecArray{arr};
-  // sycl::span<const int,3> fullSpecConstArray{constArr};
+  sycl::span<int,4> fullSpecArray{arr};
+  sycl::span<const int,3> fullSpecConstArray{constArr};
   sycl::span<int, 4> fullSpecVecArray{vec};
 
   return 0;


### PR DESCRIPTION
Fixed a compilation issue with fully specialized `sycl::span` and extent deduction for unspecialized `sycl::span` created from an array.