### PR TITLE
[SYCL][ABI-Break] Make sycl::exception has_context noexcept

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -30,7 +30,7 @@ set(SYCL_MINOR_VERSION 7)
 set(SYCL_PATCH_VERSION 0)
 # Don't forget to re-enable sycl_symbols_windows.dump once we leave ABI-breaking
 # window!
-set(SYCL_DEV_ABI_VERSION 9)
+set(SYCL_DEV_ABI_VERSION 10)
 if (SYCL_ADD_DEV_VERSION_POSTFIX)
   set(SYCL_VERSION_POSTFIX "-${SYCL_DEV_ABI_VERSION}")
 endif()

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -89,7 +89,7 @@ public:
 
   const char *what() const noexcept final;
 
-  bool has_context() const;
+  bool has_context() const noexcept;
 
   context get_context() const;
 

--- a/sycl/source/exception.cpp
+++ b/sycl/source/exception.cpp
@@ -72,7 +72,7 @@ const std::error_category &exception::category() const noexcept {
 
 const char *exception::what() const noexcept { return MMsg->c_str(); }
 
-bool exception::has_context() const { return (MContext != nullptr); }
+bool exception::has_context() const noexcept { return (MContext != nullptr); }
 
 context exception::get_context() const {
   if (!has_context())


### PR DESCRIPTION
According to the SYCL 2020 specification the `has_context` member in `sycl::exception` must be `noexcept`. This commit adds `noexcept` to the member function.