### PR TITLE
[SYCL] Fix cleanup of deferred commands

### DIFF
--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -447,8 +447,12 @@ MemObjRecord *Scheduler::getMemObjRecord(const Requirement *const Req) {
 }
 
 void Scheduler::cleanupCommands(const std::vector<Command *> &Cmds) {
-  if (Cmds.empty() && MDeferredCleanupCommands.empty())
-    return;
+  if (Cmds.empty())
+  {
+    std::lock_guard<std::mutex> Lock{MDeferredCleanupMutex};
+    if (MDeferredCleanupCommands.empty())
+      return;
+  }
 
   WriteLockT Lock(MGraphLock, std::try_to_lock);
   // In order to avoid deadlocks related to blocked commands, defer cleanup if

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -447,8 +447,9 @@ MemObjRecord *Scheduler::getMemObjRecord(const Requirement *const Req) {
 }
 
 void Scheduler::cleanupCommands(const std::vector<Command *> &Cmds) {
-  if (Cmds.empty())
+  if (Cmds.empty() && MDeferredCleanupCommands.empty())
     return;
+
   WriteLockT Lock(MGraphLock, std::try_to_lock);
   // In order to avoid deadlocks related to blocked commands, defer cleanup if
   // the lock wasn't acquired.


### PR DESCRIPTION
When we work in multiple threads and lock on graph failed because of its ownership by another thread - we add command to cleanup to the pool with deferred commands. Sometimes it happens that this pool is never cleaned and even in scheduler destructor it is ignored because of not fully correct check.
Current solution let scheduler to cleanup deferred commands in its destructor. Although in most cases it will be cleaned up much earlier because in any place where vector ToCleanup was empty - we will check if there is deferred commands awaiting for destruction.

Signed-off-by: Tikhomirova, Kseniya <kseniya.tikhomirova@intel.com>