### PR TITLE
[SYCL] Remove and deprecate address spaces

### DIFF
--- a/sycl/include/sycl/access/access.hpp
+++ b/sycl/include/sycl/access/access.hpp
@@ -45,19 +45,12 @@ enum class placeholder { false_t = 0, true_t = 1 };
 enum class address_space : int {
   private_space = 0,
   global_space = 1,
-  constant_space = 2,
+  constant_space __SYCL2020_DEPRECATED("sycl::access::address_space::constant_"
+                                       "space is deprecated since SYCL 2020") =
+      2,
   local_space = 3,
   ext_intel_global_device_space = 4,
   ext_intel_global_host_space = 5,
-  global_device_space __SYCL2020_DEPRECATED(
-      "use 'ext_intel_global_device_space' instead") =
-      ext_intel_global_device_space,
-  global_host_space __SYCL2020_DEPRECATED(
-      "use 'ext_intel_global_host_space' instead") =
-      ext_intel_global_host_space,
-  ext_intel_host_device_space __SYCL2020_DEPRECATED(
-      "use 'ext_intel_global_host_space' instead") =
-      ext_intel_global_host_space,
   generic_space = 6, // TODO generic_space address space is not supported yet
 };
 

--- a/sycl/test/basic_tests/address_space_traits.cpp
+++ b/sycl/test/basic_tests/address_space_traits.cpp
@@ -27,11 +27,11 @@ int main() {
           "Unexpected address space");
       static_assert(
           detail::deduce_AS<__attribute__((opencl_global_device)) int>::value ==
-              access::address_space::global_device_space,
+              access::address_space::ext_intel_global_device_space,
           "Unexpected address space");
       static_assert(
           detail::deduce_AS<__attribute__((opencl_global_host)) int>::value ==
-              access::address_space::global_host_space,
+              access::address_space::ext_intel_global_host_space,
           "Unexpected address space");
     });
   });

--- a/sycl/test/extensions/fpga.cpp
+++ b/sycl/test/extensions/fpga.cpp
@@ -100,8 +100,8 @@ int main() {
         cgh.single_task<class HostAnnotation>([=]() {
           sycl::host_ptr<int> input_ptr(in_ptr);
           sycl::host_ptr<int> output_ptr(out_ptr);
-          intelfpga::lsu_body<int,
-                              sycl::access::address_space::global_host_space>(
+          intelfpga::lsu_body<
+              int, sycl::access::address_space::ext_intel_global_host_space>(
               input_ptr, output_ptr);
         });
       });
@@ -113,8 +113,8 @@ int main() {
         cgh.single_task<class DeviceAnnotation>([=]() {
           sycl::device_ptr<int> input_ptr(in_ptr);
           sycl::device_ptr<int> output_ptr(out_ptr);
-          intelfpga::lsu_body<int,
-                              sycl::access::address_space::global_device_space>(
+          intelfpga::lsu_body<
+              int, sycl::access::address_space::ext_intel_global_device_space>(
               input_ptr, output_ptr);
         });
       });


### PR DESCRIPTION
DPC++ has a selection of extension address spaces with deprecated namings. This commit removes these old namings for the address spaces. Additionally, this PR adds a deprecation warning for sycl::access::address_space::constant_space as it is deprecated in SYCL2020.