### PR TITLE
[SYCL] Move simple event_impl constructor to header

### DIFF
--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -117,10 +117,6 @@ void event_impl::setContextImpl(const ContextImplPtr &Context) {
   MIsContextInitialized = true;
 }
 
-event_impl::event_impl(std::optional<HostEventState> State)
-    : MIsInitialized(false), MHostEvent(State), MIsFlushed(true),
-      MState(State.value_or(HES_Complete)) {}
-
 event_impl::event_impl(RT::PiEvent Event, const context &SyclContext)
     : MIsContextInitialized(true), MEvent(Event),
       MContext(detail::getSyclObjImpl(SyclContext)), MHostEvent(false),

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -46,7 +46,9 @@ public:
   /// If the constructed SYCL event is waited on it will complete immediately.
   /// Normally constructs a host event, use std::nullopt to instead instantiate
   /// a device event.
-  event_impl(std::optional<HostEventState> State = HES_Complete);
+  event_impl(std::optional<HostEventState> State = HES_Complete)
+      : MIsInitialized(false), MHostEvent(State), MIsFlushed(true),
+        MState(State.value_or(HES_Complete)) {}
 
   /// Constructs an event instance from a plug-in event handle.
   ///


### PR DESCRIPTION
On certain systems unittests that uses the event_impl constructor with no arguments may disagree with the event_impl source file on the layout of the default std::optional argument. This can cause unexpected memory accesses when performing operations on the passed argument. This commit works around this issue by moving the body of the constructor to the header.