### PR TITLE
[SYCL] Implement support for generic_space

### DIFF
--- a/clang/include/clang/AST/Type.h
+++ b/clang/include/clang/AST/Type.h
@@ -512,7 +512,7 @@ public:
            (A == LangAS::Default &&
             (B == LangAS::sycl_private || B == LangAS::sycl_local ||
              B == LangAS::sycl_global || B == LangAS::sycl_global_device ||
-             B == LangAS::sycl_global_host)) ||
+             B == LangAS::sycl_global_host || B == LangAS::sycl_generic)) ||
            // In HIP device compilation, any cuda address space is allowed
            // to implicitly cast into the default address space.
            (A == LangAS::Default &&

--- a/clang/include/clang/Basic/AddressSpaces.h
+++ b/clang/include/clang/Basic/AddressSpaces.h
@@ -50,6 +50,7 @@ enum class LangAS : unsigned {
   sycl_global_host,
   sycl_local,
   sycl_private,
+  sycl_generic,
 
   // Pointer size and extension address spaces.
   ptr32_sptr,
@@ -99,6 +100,8 @@ inline LangAS asSYCLLangAS(LangAS AS) {
     return LangAS::sycl_local;
   case LangAS::opencl_private:
     return LangAS::sycl_private;
+  case LangAS::opencl_generic:
+    return LangAS::sycl_generic;
   default:
     return AS;
   }
@@ -116,6 +119,8 @@ inline LangAS asOpenCLLangAS(LangAS AS) {
     return LangAS::opencl_local;
   case LangAS::sycl_private:
     return LangAS::opencl_private;
+  case LangAS::sycl_generic:
+    return LangAS::opencl_generic;
   default:
     return AS;
   }

--- a/clang/include/clang/Sema/ParsedAttr.h
+++ b/clang/include/clang/Sema/ParsedAttr.h
@@ -718,6 +718,7 @@ public:
     case ParsedAttr::AT_OpenCLPrivateAddressSpace:
       return LangAS::sycl_private;
     case ParsedAttr::AT_OpenCLGenericAddressSpace:
+      return LangAS::sycl_generic;
     default:
       return LangAS::Default;
     }

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -946,6 +946,7 @@ static const LangASMap *getAddressSpaceMap(const TargetInfo &T,
         6,  // sycl_global_host
         3,  // sycl_local
         0,  // sycl_private
+        4,  // sycl_generic
         10, // ptr32_sptr
         11, // ptr32_uptr
         12  // ptr64

--- a/clang/lib/AST/ItaniumMangle.cpp
+++ b/clang/lib/AST/ItaniumMangle.cpp
@@ -2649,7 +2649,7 @@ void CXXNameMangler::mangleQualifiers(Qualifiers Quals, const DependentAddressSp
         ASString = "CLgeneric";
         break;
       //  <SYCL-addrspace> ::= "SY" [ "global" | "local" | "private" |
-      //                              "device" | "host" ]
+      //                              "device" | "host" | "generic" ]
       case LangAS::sycl_global:
         ASString = "SYglobal";
         break;
@@ -2664,6 +2664,9 @@ void CXXNameMangler::mangleQualifiers(Qualifiers Quals, const DependentAddressSp
         break;
       case LangAS::sycl_private:
         ASString = "SYprivate";
+        break;
+      case LangAS::sycl_generic:
+        ASString = "SYgeneric";
         break;
       //  <CUDA-addrspace> ::= "CU" [ "device" | "constant" | "shared" ]
       case LangAS::cuda_device:

--- a/clang/lib/AST/MicrosoftMangle.cpp
+++ b/clang/lib/AST/MicrosoftMangle.cpp
@@ -2230,6 +2230,9 @@ void MicrosoftCXXNameMangler::mangleAddressSpaceType(QualType T,
     case LangAS::sycl_private:
       Extra.mangleSourceName("_ASSYprivate");
       break;
+    case LangAS::sycl_generic:
+      Extra.mangleSourceName("_ASSYgeneric");
+      break;
     case LangAS::cuda_constant:
       Extra.mangleSourceName("_ASCUconstant");
       break;

--- a/clang/lib/AST/TypePrinter.cpp
+++ b/clang/lib/AST/TypePrinter.cpp
@@ -2228,6 +2228,7 @@ std::string Qualifiers::getAddrSpaceAsString(LangAS AS) {
   case LangAS::opencl_constant:
     return "__constant";
   case LangAS::opencl_generic:
+  case LangAS::sycl_generic:
     return "__generic";
   case LangAS::opencl_global_device:
   case LangAS::sycl_global_device:

--- a/clang/lib/Basic/Targets/AMDGPU.cpp
+++ b/clang/lib/Basic/Targets/AMDGPU.cpp
@@ -73,15 +73,15 @@ const LangASMap AMDGPUTargetInfo::AMDGPUDefIsPrivMap = {
     Constant, // cuda_constant
     Local,    // cuda_shared
     // SYCL address space values for this map are dummy
-    Generic,  // sycl_global
-    Generic,  // sycl_global_device
-    Generic,  // sycl_global_host
-    Generic,  // sycl_local
-    Generic,  // sycl_private
-    Generic,  // sycl_generic
-    Generic,  // ptr32_sptr
-    Generic,  // ptr32_uptr
-    Generic   // ptr64
+    Generic, // sycl_global
+    Generic, // sycl_global_device
+    Generic, // sycl_global_host
+    Generic, // sycl_local
+    Generic, // sycl_private
+    Generic, // sycl_generic
+    Generic, // ptr32_sptr
+    Generic, // ptr32_uptr
+    Generic  // ptr64
 
 };
 } // namespace targets

--- a/clang/lib/Basic/Targets/AMDGPU.cpp
+++ b/clang/lib/Basic/Targets/AMDGPU.cpp
@@ -54,6 +54,7 @@ const LangASMap AMDGPUTargetInfo::AMDGPUDefIsGenMap = {
     Global,   // sycl_global_host
     Local,    // sycl_local
     Private,  // sycl_private
+    Generic,  // sycl_generic
     Generic,  // ptr32_sptr
     Generic,  // ptr32_uptr
     Generic   // ptr64
@@ -77,6 +78,7 @@ const LangASMap AMDGPUTargetInfo::AMDGPUDefIsPrivMap = {
     Generic,  // sycl_global_host
     Generic,  // sycl_local
     Generic,  // sycl_private
+    Generic,  // sycl_generic
     Generic,  // ptr32_sptr
     Generic,  // ptr32_uptr
     Generic   // ptr64

--- a/clang/lib/Basic/Targets/DirectX.h
+++ b/clang/lib/Basic/Targets/DirectX.h
@@ -38,6 +38,7 @@ static const unsigned DirectXAddrSpaceMap[] = {
     0, // sycl_global_host
     0, // sycl_local
     0, // sycl_private
+    0, // sycl_generic
     0, // ptr32_sptr
     0, // ptr32_uptr
     0  // ptr64

--- a/clang/lib/Basic/Targets/NVPTX.h
+++ b/clang/lib/Basic/Targets/NVPTX.h
@@ -40,6 +40,8 @@ static const unsigned NVPTXAddrSpaceMap[] = {
     1, // sycl_global_host
     3, // sycl_local
     0, // sycl_private
+    // FIXME: generic has to be added to the target
+    0, // sycl_generic
     0, // ptr32_sptr
     0, // ptr32_uptr
     0  // ptr64

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -42,6 +42,7 @@ static const unsigned SPIRDefIsPrivMap[] = {
     0, // sycl_global_host
     0, // sycl_local
     0, // sycl_private
+    0, // sycl_generic
     0, // ptr32_sptr
     0, // ptr32_uptr
     0  // ptr64
@@ -74,6 +75,7 @@ static const unsigned SPIRDefIsGenMap[] = {
     6, // sycl_global_host
     3, // sycl_local
     0, // sycl_private
+    4, // sycl_generic
     0, // ptr32_sptr
     0, // ptr32_uptr
     0  // ptr64

--- a/clang/lib/Basic/Targets/TCE.h
+++ b/clang/lib/Basic/Targets/TCE.h
@@ -47,6 +47,7 @@ static const unsigned TCEOpenCLAddrSpaceMap[] = {
     0, // sycl_global_host
     0, // sycl_local
     0, // sycl_private
+    0, // sycl_generic
     0, // ptr32_sptr
     0, // ptr32_uptr
     0, // ptr64

--- a/clang/lib/Basic/Targets/X86.h
+++ b/clang/lib/Basic/Targets/X86.h
@@ -41,6 +41,7 @@ static const unsigned X86AddrSpaceMap[] = {
     0,   // sycl_global_host
     0,   // sycl_local
     0,   // sycl_private
+    0,   // sycl_generic
     270, // ptr32_sptr
     271, // ptr32_uptr
     272  // ptr64

--- a/clang/lib/Sema/SPIRVBuiltins.td
+++ b/clang/lib/Sema/SPIRVBuiltins.td
@@ -39,7 +39,7 @@ def PrivateAS    : AddressSpace<"clang::LangAS::sycl_private">;
 def GlobalAS     : AddressSpace<"clang::LangAS::sycl_global">;
 def ConstantAS   : AddressSpace<"clang::LangAS::opencl_constant">;
 def LocalAS      : AddressSpace<"clang::LangAS::sycl_local">;
-def GenericAS    : AddressSpace<"clang::LangAS::opencl_generic">;
+def GenericAS    : AddressSpace<"clang::LangAS::sycl_generic">;
 
 // TODO: Manage capabilities. Unused for now.
 class AbstractExtension<string _Ext> {

--- a/clang/test/SemaSYCL/Inputs/sycl.hpp
+++ b/clang/test/SemaSYCL/Inputs/sycl.hpp
@@ -352,7 +352,7 @@ struct DecoratedType<ElementType, access::address_space::private_space> {
 
 template <typename ElementType>
 struct DecoratedType<ElementType, access::address_space::generic_space> {
-  using type = ElementType;
+  using type = __attribute__((opencl_generic)) ElementType;
 };
 
 template <typename ElementType>

--- a/sycl/include/CL/__spirv/spirv_ops.hpp
+++ b/sycl/include/CL/__spirv/spirv_ops.hpp
@@ -261,7 +261,8 @@ extern SYCL_EXTERNAL TempRetT __spirv_ImageSampleExplicitLod(SampledType,
 
 #define __SPIRV_ATOMICS(macro, Arg)                                            \
   macro(__attribute__((opencl_global)), Arg)                                   \
-      macro(__attribute__((opencl_local)), Arg) macro(, Arg)
+      macro(__attribute__((opencl_local)), Arg)                                \
+          macro(__attribute__((opencl_generic)), Arg) macro(, Arg)
 
 __SPIRV_ATOMICS(__SPIRV_ATOMIC_FLOAT, float)
 __SPIRV_ATOMICS(__SPIRV_ATOMIC_FLOAT, double)

--- a/sycl/include/sycl/access/access.hpp
+++ b/sycl/include/sycl/access/access.hpp
@@ -127,6 +127,7 @@ constexpr bool modeWritesNewData(access::mode m) {
 #define __OPENCL_LOCAL_AS__ __attribute__((opencl_local))
 #define __OPENCL_CONSTANT_AS__ __attribute__((opencl_constant))
 #define __OPENCL_PRIVATE_AS__ __attribute__((opencl_private))
+#define __OPENCL_GENERIC_AS__ __attribute__((opencl_generic))
 #else
 #define __OPENCL_GLOBAL_AS__
 #define __OPENCL_GLOBAL_DEVICE_AS__
@@ -134,6 +135,7 @@ constexpr bool modeWritesNewData(access::mode m) {
 #define __OPENCL_LOCAL_AS__
 #define __OPENCL_CONSTANT_AS__
 #define __OPENCL_PRIVATE_AS__
+#define __OPENCL_GENERIC_AS__
 #endif
 
 template <access::target accessTarget> struct TargetToAS {
@@ -168,7 +170,7 @@ struct DecoratedType<ElementType, access::address_space::private_space> {
 
 template <typename ElementType>
 struct DecoratedType<ElementType, access::address_space::generic_space> {
-  using type = ElementType;
+  using type = __OPENCL_GENERIC_AS__ ElementType;
 };
 
 template <typename ElementType>
@@ -252,6 +254,10 @@ template <class T> struct remove_AS<__OPENCL_CONSTANT_AS__ T> {
   typedef T type;
 };
 
+template <class T> struct remove_AS<__OPENCL_GENERIC_AS__ T> {
+  typedef T type;
+};
+
 template <class T> struct deduce_AS<__OPENCL_GLOBAL_AS__ T> {
   static const access::address_space value =
       access::address_space::global_space;
@@ -260,6 +266,11 @@ template <class T> struct deduce_AS<__OPENCL_GLOBAL_AS__ T> {
 template <class T> struct deduce_AS<__OPENCL_PRIVATE_AS__ T> {
   static const access::address_space value =
       access::address_space::private_space;
+};
+
+template <class T> struct deduce_AS<__OPENCL_GENERIC_AS__ T> {
+  static const access::address_space value =
+      access::address_space::generic_space;
 };
 
 template <class T> struct deduce_AS<__OPENCL_LOCAL_AS__ T> {
@@ -278,6 +289,7 @@ template <class T> struct deduce_AS<__OPENCL_CONSTANT_AS__ T> {
 #undef __OPENCL_LOCAL_AS__
 #undef __OPENCL_CONSTANT_AS__
 #undef __OPENCL_PRIVATE_AS__
+#undef __OPENCL_GENERIC_AS__
 } // namespace detail
 
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)

--- a/sycl/test/basic_tests/address_space_traits.cpp
+++ b/sycl/test/basic_tests/address_space_traits.cpp
@@ -22,6 +22,10 @@ int main() {
               access::address_space::private_space,
           "Unexpected address space");
       static_assert(
+          detail::deduce_AS<__attribute__((opencl_generic)) int>::value ==
+              access::address_space::generic_space,
+          "Unexpected address space");
+      static_assert(
           detail::deduce_AS<__attribute__((opencl_constant)) int>::value ==
               access::address_space::constant_space,
           "Unexpected address space");


### PR DESCRIPTION
These changes add the following:
 * A new `sycl_generic` address space in clang, mapping to `opencl_generic` where applicable.
 * `opencl_generic` attribute to pointers decorated with `access::address_space::generic_space`.
 * Make `__spirv_Atomic*` builtins accept pointers with generic address space.