### PR TITLE
Small fix to example in device global spec

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_global.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_global.asciidoc
@@ -474,7 +474,7 @@ namespace {
 inline namespace other {
   device_global<int> same_name; // ILLEGAL: shadows "device_global" variable
 }                               // with same name in enclosing namespace scope
-inline namespace {
+inline namespace other2 {
   namespace foo {               // ILLEGAL: namespace name shadows "::foo"
   }                             // namespace which contains "device_global"
                                 // variable.


### PR DESCRIPTION
This example demonstrates an illegal construct with `device_global`,
in order to illustrate a limitation.  However, the example
inadvertently had a C++ syntax error also.  Fix that error.