### PR TITLE
[SYCL] Make device and platform default to default_selector_v

### DIFF
--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -46,7 +46,7 @@ class filter_selector;
 /// \ingroup sycl_api
 class __SYCL_EXPORT device {
 public:
-  /// Constructs a SYCL device instance as a host device.
+  /// Constructs a SYCL device instance using the default device.
   device();
 
   /// Constructs a SYCL device instance from an OpenCL cl_device_id

--- a/sycl/include/sycl/platform.hpp
+++ b/sycl/include/sycl/platform.hpp
@@ -44,7 +44,7 @@ class filter_selector;
 /// \ingroup sycl_api
 class __SYCL_EXPORT platform {
 public:
-  /// Constructs a SYCL platform as a host platform.
+  /// Constructs a SYCL platform using the default device.
   platform();
 
   /// Constructs a SYCL platform instance from an OpenCL cl_platform_id.

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -140,7 +140,8 @@ uint32_t context_impl::get_info<info::context::reference_count>() const {
 }
 template <> platform context_impl::get_info<info::context::platform>() const {
   if (is_host())
-    return platform();
+    return createSyclObjFromImpl<platform>(
+        platform_impl::getHostPlatformImpl());
   return createSyclObjFromImpl<platform>(MPlatform);
 }
 template <>

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -1135,7 +1135,7 @@ get_device_info_host<info::device::built_in_kernels>() {
 }
 
 template <> inline platform get_device_info_host<info::device::platform>() {
-  return platform();
+  return createSyclObjFromImpl<platform>(platform_impl::getHostPlatformImpl());
 }
 
 template <> inline std::string get_device_info_host<info::device::name>() {

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -142,7 +142,8 @@ std::vector<platform> platform_impl::get_platforms() {
   detail::device_filter_list *FilterList =
       detail::SYCLConfig<detail::SYCL_DEVICE_FILTER>::get();
   if (!FilterList || FilterList->backendCompatible(backend::host))
-    Platforms.emplace_back(platform());
+    Platforms.emplace_back(
+        createSyclObjFromImpl<platform>(platform_impl::getHostPlatformImpl()));
 
   return Platforms;
 }
@@ -240,7 +241,8 @@ platform_impl::get_devices(info::device_type DeviceType) const {
     // If SYCL_DEVICE_FILTER is set, check if filter contains host.
     device_filter_list *FilterList = SYCLConfig<SYCL_DEVICE_FILTER>::get();
     if (!FilterList || FilterList->containsHost()) {
-      Res.push_back(device());
+      Res.push_back(
+          createSyclObjFromImpl<device>(device_impl::getHostDeviceImpl()));
     }
   }
 

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -391,7 +391,8 @@ void Scheduler::deallocateStreamBuffers(stream_impl *Impl) {
 }
 
 Scheduler::Scheduler() {
-  sycl::device HostDevice;
+  sycl::device HostDevice =
+      createSyclObjFromImpl<device>(device_impl::getHostDeviceImpl());
   sycl::context HostContext{HostDevice};
   DefaultHostQueue = QueueImplPtr(
       new queue_impl(detail::getSyclObjImpl(HostDevice),

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -29,7 +29,7 @@ void force_type(info::device_type &t, const info::device_type &ft) {
 }
 } // namespace detail
 
-device::device() : impl(detail::device_impl::getHostDeviceImpl()) {}
+device::device() : device(default_selector_v) {}
 
 device::device(cl_device_id DeviceId) {
   // The implementation constructor takes ownership of the native handle so we

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -19,7 +19,7 @@
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 
-platform::platform() : impl(detail::platform_impl::getHostPlatformImpl()) {}
+platform::platform() : platform(default_selector_v) {}
 
 platform::platform(cl_platform_id PlatformId) {
   impl = detail::platform_impl::getOrMakePlatformImpl(

--- a/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
+++ b/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
@@ -91,7 +91,7 @@ TEST_F(SchedulerTest, CommandsWaitForEvents) {
   std::shared_ptr<detail::event_impl> E2(
       new detail::event_impl(TestContext->EventCtx2, Q2.get_context()));
 
-  sycl::device HostDevice;
+  sycl::device HostDevice{host_selector{}};
   std::shared_ptr<detail::queue_impl> DefaultHostQueue(new detail::queue_impl(
       detail::getSyclObjImpl(HostDevice), /*AsyncHandler=*/{},
       /*PropList=*/{}));

--- a/sycl/unittests/scheduler/InOrderQueueDeps.cpp
+++ b/sycl/unittests/scheduler/InOrderQueueDeps.cpp
@@ -102,7 +102,7 @@ TEST_F(SchedulerTest, InOrderQueueDeps) {
   sycl::detail::QueueImplPtr InOrderQueueImpl =
       detail::getSyclObjImpl(InOrderQueue);
 
-  device HostDevice;
+  device HostDevice{host_selector{}};
   std::shared_ptr<detail::queue_impl> DefaultHostQueue{
       new detail::queue_impl(detail::getSyclObjImpl(HostDevice), {}, {})};
 

--- a/sycl/unittests/scheduler/LeavesCollection.cpp
+++ b/sycl/unittests/scheduler/LeavesCollection.cpp
@@ -28,7 +28,7 @@ protected:
       }
     }
   };
-  sycl::queue MQueue = sycl::queue(sycl::device(), MAsyncHandler);
+  sycl::queue MQueue = sycl::queue(sycl::host_selector{}, MAsyncHandler);
 };
 
 std::shared_ptr<Command>

--- a/sycl/unittests/scheduler/LinkedAllocaDependencies.cpp
+++ b/sycl/unittests/scheduler/LinkedAllocaDependencies.cpp
@@ -60,7 +60,7 @@ TEST_F(SchedulerTest, LinkedAllocaDependencies) {
   sycl::queue Queue1{Dev};
   sycl::detail::QueueImplPtr Q1 = sycl::detail::getSyclObjImpl(Queue1);
 
-  sycl::device HostDevice;
+  sycl::device HostDevice{host_selector{}};
   std::shared_ptr<detail::queue_impl> DefaultHostQueue(new detail::queue_impl(
       detail::getSyclObjImpl(HostDevice), /*AsyncHandler=*/{},
       /*PropList=*/{}));

--- a/sycl/unittests/scheduler/NoHostUnifiedMemory.cpp
+++ b/sycl/unittests/scheduler/NoHostUnifiedMemory.cpp
@@ -107,7 +107,7 @@ TEST_F(SchedulerTest, NoHostUnifiedMemory) {
       redefinedMemCreateWithNativeHandle);
   sycl::detail::QueueImplPtr QImpl = detail::getSyclObjImpl(Q);
 
-  device HostDevice;
+  device HostDevice{host_selector{}};
   std::shared_ptr<detail::queue_impl> DefaultHostQueue{
       new detail::queue_impl(detail::getSyclObjImpl(HostDevice), {}, {})};
 

--- a/sycl/unittests/scheduler/PostEnqueueCleanup.cpp
+++ b/sycl/unittests/scheduler/PostEnqueueCleanup.cpp
@@ -249,7 +249,7 @@ TEST_F(SchedulerTest, PostEnqueueCleanup) {
         MS.addEmptyCmd(Leaf, {&MockReq}, QueueImpl,
                        detail::Command::BlockReason::HostTask, ToEnqueue);
       });
-  device HostDevice;
+  device HostDevice{host_selector{}};
   detail::QueueImplPtr DefaultHostQueue{
       new detail::queue_impl(detail::getSyclObjImpl(HostDevice), {}, {})};
   checkCleanupOnLeafUpdate(

--- a/sycl/unittests/scheduler/QueueFlushing.cpp
+++ b/sycl/unittests/scheduler/QueueFlushing.cpp
@@ -172,7 +172,7 @@ TEST_F(SchedulerTest, QueueFlushing) {
                                     QueueImplA};
     testCommandEnqueue(&UnmapCmd, QueueImplB, MockReq);
 
-    device HostDevice;
+    device HostDevice{host_selector{}};
     detail::QueueImplPtr DefaultHostQueue{
         new detail::queue_impl(detail::getSyclObjImpl(HostDevice), {}, {})};
     detail::AllocaCommand HostAllocaCmd =

--- a/sycl/unittests/scheduler/SchedulerTest.hpp
+++ b/sycl/unittests/scheduler/SchedulerTest.hpp
@@ -25,5 +25,5 @@ protected:
       }
     }
   };
-  sycl::queue MQueue = sycl::queue(sycl::device(), MAsyncHandler);
+  sycl::queue MQueue = sycl::queue(sycl::host_selector{}, MAsyncHandler);
 };


### PR DESCRIPTION
SYCL2020 changes default constructors of device and platform to pick the objects associated with the device returned by `default_selector_v` rather than the host device. This commit changes these default constructors to adhere to this behaviour.