### PR TITLE
[GHA] Uplift Linux GPU RT version to 22.33.23949

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -1,9 +1,9 @@
 {
   "linux": {
     "compute_runtime": {
-      "github_tag": "22.32.23937",
-      "version": "22.32.23937",
-      "url": "https://github.com/intel/compute-runtime/releases/tag/22.32.23937",
+      "github_tag": "22.33.23949",
+      "version": "22.33.23949",
+      "url": "https://github.com/intel/compute-runtime/releases/tag/22.33.23949",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "igc": {


### PR DESCRIPTION
Scheduled drivers uplift