### PR TITLE
[ESIMD] Introduce atomic_update<native::lsc::fadd>(...) and similar ops.

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd.hpp
+++ b/sycl/include/sycl/ext/intel/esimd.hpp
@@ -81,8 +81,6 @@
 
 #include <sycl/ext/intel/esimd/alt_ui.hpp>
 #include <sycl/ext/intel/esimd/common.hpp>
-#include <sycl/ext/intel/esimd/math.hpp>
-#include <sycl/ext/intel/esimd/memory.hpp>
 #include <sycl/ext/intel/esimd/simd.hpp>
 #include <sycl/ext/intel/esimd/simd_view.hpp>
 #include <sycl/ext/intel/experimental/esimd/kernel_properties.hpp>

--- a/sycl/include/sycl/ext/intel/esimd/common.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/common.hpp
@@ -10,6 +10,10 @@
 
 #pragma once
 
+#include <sycl/ext/intel/esimd/detail/defines_elementary.hpp>
+#include <sycl/ext/intel/esimd/native/common.hpp>
+#include <sycl/ext/intel/experimental/esimd/common.hpp>
+
 #include <sycl/detail/defines.hpp>
 
 #include <cstdint> // for uint* types
@@ -18,64 +22,20 @@
 /// @cond ESIMD_DETAIL
 
 #ifdef __SYCL_DEVICE_ONLY__
-#define SYCL_ESIMD_KERNEL __attribute__((sycl_explicit_simd))
-#define SYCL_ESIMD_FUNCTION __attribute__((sycl_explicit_simd))
-
-// Mark a function being nodebug.
-#define ESIMD_NODEBUG __attribute__((nodebug))
-// Mark a "ESIMD global": accessible from all functions in current translation
-// unit, separate copy per subgroup (work-item), mapped to SPIR-V private
-// storage class.
-#define ESIMD_PRIVATE                                                          \
-  __attribute__((opencl_private)) __attribute__((sycl_explicit_simd))
-// Bind a ESIMD global variable to a specific register.
-#define ESIMD_REGISTER(n) __attribute__((register_num(n)))
-
-#define __ESIMD_API ESIMD_NODEBUG ESIMD_INLINE
-
 #define __ESIMD_UNSUPPORTED_ON_HOST
-
 #else // __SYCL_DEVICE_ONLY__
-#define SYCL_ESIMD_KERNEL
-#define SYCL_ESIMD_FUNCTION
-
-// TODO ESIMD define what this means on Windows host
-#define ESIMD_NODEBUG
-// On host device ESIMD global is a thread local static var. This assumes that
-// each work-item is mapped to a separate OS thread on host device.
-#define ESIMD_PRIVATE thread_local
-#define ESIMD_REGISTER(n)
-
-#define __ESIMD_API ESIMD_INLINE
-
 #define __ESIMD_UNSUPPORTED_ON_HOST                                            \
   throw sycl::exception(sycl::errc::feature_not_supported,                     \
                         "This ESIMD feature is not supported on HOST")
-
 #endif // __SYCL_DEVICE_ONLY__
-
-// Mark a function being noinline
-#define ESIMD_NOINLINE __attribute__((noinline))
-// Force a function to be inlined. 'inline' is used to preserve ODR for
-// functions defined in a header.
-#define ESIMD_INLINE inline __attribute__((always_inline))
-
-// Macros for internal use
-#define __ESIMD_NS sycl::ext::intel::esimd
-#define __ESIMD_DNS sycl::ext::intel::esimd::detail
-#define __ESIMD_EMU_DNS sycl::ext::intel::esimd::emu::detail
-
-#define __ESIMD_QUOTE1(m) #m
-#define __ESIMD_QUOTE(m) __ESIMD_QUOTE1(m)
-#define __ESIMD_NS_QUOTED __ESIMD_QUOTE(__ESIMD_NS)
-#define __ESIMD_DEPRECATED(new_api)                                            \
-  __SYCL_DEPRECATED("use " __ESIMD_NS_QUOTED "::" __ESIMD_QUOTE(new_api))
 
 /// @endcond ESIMD_DETAIL
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
-namespace ext::intel::esimd {
+namespace ext {
+namespace intel {
+namespace esimd {
 
 /// @addtogroup sycl_esimd_core
 /// @{
@@ -106,6 +66,16 @@ enum class rgba_channel : uint8_t { R, G, B, A };
 using SurfaceIndex = unsigned int;
 
 namespace detail {
+
+/// Check if a given 32 bit positive integer is a power of 2 at compile time.
+ESIMD_INLINE constexpr bool isPowerOf2(unsigned int n) {
+  return (n & (n - 1)) == 0;
+}
+
+ESIMD_INLINE constexpr bool isPowerOf2(unsigned int n, unsigned int limit) {
+  return (n & (n - 1)) == 0 && n <= limit;
+}
+
 template <rgba_channel Ch>
 static inline constexpr uint8_t ch = 1 << static_cast<int>(Ch);
 static inline constexpr uint8_t chR = ch<rgba_channel::R>;
@@ -151,6 +121,10 @@ constexpr int get_num_channels_enabled(rgba_channel_mask M) {
          is_channel_enabled(M, rgba_channel::A);
 }
 
+#define __ESIMD_USM_DWORD_ATOMIC_TO_LSC                                        \
+  " is supported only on ACM, PVC. USM-based atomic will be auto-converted "   \
+  "to LSC version."
+
 /// Represents an atomic operation. Operations always return the old value(s) of
 /// the target memory location(s) as it was before the operation was applied.
 /// Each operation is annotated with a pseudocode illustrating its semantics,
@@ -185,14 +159,14 @@ enum class atomic_op : uint8_t {
   /// Maximum (signed integer): <code>*addr = max(*addr, src0)</code>.
   maxsint = 0xc,
   /// Minimum (floating point): <code>*addr = min(*addr, src0)</code>.
-  fmax = 0x10,
+  fmax __SYCL_DEPRECATED("fmax" __ESIMD_USM_DWORD_ATOMIC_TO_LSC) = 0x10,
   /// Maximum (floating point): <code>*addr = max(*addr, src0)</code>.
-  fmin = 0x11,
+  fmin __SYCL_DEPRECATED("fmin" __ESIMD_USM_DWORD_ATOMIC_TO_LSC) = 0x11,
   /// Compare and exchange (floating point).
   /// <code>if (*addr == src0) *addr = src1;</code>
-  fcmpwr = 0x12,
-  fadd = 0x13,
-  fsub = 0x14,
+  fcmpwr __SYCL_DEPRECATED("fcmpwr" __ESIMD_USM_DWORD_ATOMIC_TO_LSC) = 0x12,
+  fadd __SYCL_DEPRECATED("fadd" __ESIMD_USM_DWORD_ATOMIC_TO_LSC) = 0x13,
+  fsub __SYCL_DEPRECATED("fsub" __ESIMD_USM_DWORD_ATOMIC_TO_LSC) = 0x14,
   load = 0x15,
   store = 0x16,
   /// Decrement: <code>*addr = *addr - 1</code>. The only operation which
@@ -200,8 +174,157 @@ enum class atomic_op : uint8_t {
   predec = 0xff,
 };
 
+#undef __ESIMD_USM_DWORD_TO_LSC_MSG
+
 /// @} sycl_esimd_core
 
-} // namespace ext::intel::esimd
+namespace detail {
+template <__ESIMD_NS::native::lsc::atomic_op Op> constexpr int get_num_args() {
+  if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::inc ||
+                Op == __ESIMD_NS::native::lsc::atomic_op::dec ||
+                Op == __ESIMD_NS::native::lsc::atomic_op::load) {
+    return 0;
+  } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::store ||
+                       Op == __ESIMD_NS::native::lsc::atomic_op::add ||
+                       Op == __ESIMD_NS::native::lsc::atomic_op::sub ||
+                       Op == __ESIMD_NS::native::lsc::atomic_op::minsint ||
+                       Op == __ESIMD_NS::native::lsc::atomic_op::maxsint ||
+                       Op == __ESIMD_NS::native::lsc::atomic_op::min ||
+                       Op == __ESIMD_NS::native::lsc::atomic_op::max ||
+                       Op == __ESIMD_NS::native::lsc::atomic_op::fadd ||
+                       Op == __ESIMD_NS::native::lsc::atomic_op::fsub ||
+                       Op == __ESIMD_NS::native::lsc::atomic_op::fmin ||
+                       Op == __ESIMD_NS::native::lsc::atomic_op::fmax ||
+                       Op == __ESIMD_NS::native::lsc::atomic_op::bit_and ||
+                       Op == __ESIMD_NS::native::lsc::atomic_op::bit_or ||
+                       Op == __ESIMD_NS::native::lsc::atomic_op::bit_xor) {
+    return 1;
+  } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::cmpxchg ||
+                       Op == __ESIMD_NS::native::lsc::atomic_op::fcmpwr) {
+    return 2;
+  } else {
+    return -1; // error
+  }
+}
+
+template <__ESIMD_NS::atomic_op Op> constexpr bool has_lsc_equivalent() {
+  switch (Op) {
+  case __ESIMD_NS::atomic_op::xchg:
+  case __ESIMD_NS::atomic_op::predec:
+    return false;
+  default:
+    return true;
+  }
+}
+
+template <__ESIMD_NS::atomic_op Op>
+constexpr __ESIMD_NS::native::lsc::atomic_op to_lsc_atomic_op() {
+  switch (Op) {
+  case __ESIMD_NS::atomic_op::add:
+    return __ESIMD_NS::native::lsc::atomic_op::add;
+  case __ESIMD_NS::atomic_op::sub:
+    return __ESIMD_NS::native::lsc::atomic_op::sub;
+  case __ESIMD_NS::atomic_op::inc:
+    return __ESIMD_NS::native::lsc::atomic_op::inc;
+  case __ESIMD_NS::atomic_op::dec:
+    return __ESIMD_NS::native::lsc::atomic_op::dec;
+  case __ESIMD_NS::atomic_op::min:
+    return __ESIMD_NS::native::lsc::atomic_op::min;
+  case __ESIMD_NS::atomic_op::max:
+    return __ESIMD_NS::native::lsc::atomic_op::max;
+  case __ESIMD_NS::atomic_op::cmpxchg:
+    return __ESIMD_NS::native::lsc::atomic_op::cmpxchg;
+  case __ESIMD_NS::atomic_op::bit_and:
+    return __ESIMD_NS::native::lsc::atomic_op::bit_and;
+  case __ESIMD_NS::atomic_op::bit_or:
+    return __ESIMD_NS::native::lsc::atomic_op::bit_or;
+  case __ESIMD_NS::atomic_op::bit_xor:
+    return __ESIMD_NS::native::lsc::atomic_op::bit_xor;
+  case __ESIMD_NS::atomic_op::minsint:
+    return __ESIMD_NS::native::lsc::atomic_op::minsint;
+  case __ESIMD_NS::atomic_op::maxsint:
+    return __ESIMD_NS::native::lsc::atomic_op::maxsint;
+  case __ESIMD_NS::atomic_op::fmax:
+    return __ESIMD_NS::native::lsc::atomic_op::fmax;
+  case __ESIMD_NS::atomic_op::fmin:
+    return __ESIMD_NS::native::lsc::atomic_op::fmin;
+  case __ESIMD_NS::atomic_op::fcmpwr:
+    return __ESIMD_NS::native::lsc::atomic_op::fcmpwr;
+  case __ESIMD_NS::atomic_op::fadd:
+    return __ESIMD_NS::native::lsc::atomic_op::fadd;
+  case __ESIMD_NS::atomic_op::fsub:
+    return __ESIMD_NS::native::lsc::atomic_op::fsub;
+  case __ESIMD_NS::atomic_op::load:
+    return __ESIMD_NS::native::lsc::atomic_op::load;
+  case __ESIMD_NS::atomic_op::store:
+    return __ESIMD_NS::native::lsc::atomic_op::store;
+  default:
+    static_assert(has_lsc_equivalent<Op>() && "Unsupported LSC atomic op");
+  }
+}
+
+template <__ESIMD_NS::native::lsc::atomic_op Op>
+constexpr __ESIMD_NS::atomic_op to_atomic_op() {
+  switch (Op) {
+  case __ESIMD_NS::native::lsc::atomic_op::add:
+    return __ESIMD_NS::atomic_op::add;
+  case __ESIMD_NS::native::lsc::atomic_op::sub:
+    return __ESIMD_NS::atomic_op::sub;
+  case __ESIMD_NS::native::lsc::atomic_op::inc:
+    return __ESIMD_NS::atomic_op::inc;
+  case __ESIMD_NS::native::lsc::atomic_op::dec:
+    return __ESIMD_NS::atomic_op::dec;
+  case __ESIMD_NS::native::lsc::atomic_op::min:
+    return __ESIMD_NS::atomic_op::min;
+  case __ESIMD_NS::native::lsc::atomic_op::max:
+    return __ESIMD_NS::atomic_op::max;
+  case __ESIMD_NS::native::lsc::atomic_op::cmpxchg:
+    return __ESIMD_NS::atomic_op::cmpxchg;
+  case __ESIMD_NS::native::lsc::atomic_op::bit_and:
+    return __ESIMD_NS::atomic_op::bit_and;
+  case __ESIMD_NS::native::lsc::atomic_op::bit_or:
+    return __ESIMD_NS::atomic_op::bit_or;
+  case __ESIMD_NS::native::lsc::atomic_op::bit_xor:
+    return __ESIMD_NS::atomic_op::bit_xor;
+  case __ESIMD_NS::native::lsc::atomic_op::minsint:
+    return __ESIMD_NS::atomic_op::minsint;
+  case __ESIMD_NS::native::lsc::atomic_op::maxsint:
+    return __ESIMD_NS::atomic_op::maxsint;
+  case __ESIMD_NS::native::lsc::atomic_op::fmax:
+    return __ESIMD_NS::atomic_op::fmax;
+  case __ESIMD_NS::native::lsc::atomic_op::fmin:
+    return __ESIMD_NS::atomic_op::fmin;
+  case __ESIMD_NS::native::lsc::atomic_op::fcmpwr:
+    return __ESIMD_NS::atomic_op::fcmpwr;
+  case __ESIMD_NS::native::lsc::atomic_op::fadd:
+    return __ESIMD_NS::atomic_op::fadd;
+  case __ESIMD_NS::native::lsc::atomic_op::fsub:
+    return __ESIMD_NS::atomic_op::fsub;
+  case __ESIMD_NS::native::lsc::atomic_op::load:
+    return __ESIMD_NS::atomic_op::load;
+  case __ESIMD_NS::native::lsc::atomic_op::store:
+    return __ESIMD_NS::atomic_op::store;
+  }
+}
+
+template <__ESIMD_NS::atomic_op Op> constexpr int get_num_args() {
+  if constexpr (has_lsc_equivalent<Op>()) {
+    return get_num_args<to_lsc_atomic_op<Op>()>();
+  } else {
+    switch (Op) {
+    case __ESIMD_NS::atomic_op::xchg:
+    case __ESIMD_NS::atomic_op::predec:
+      return 1;
+    default:
+      return -1; // error
+    }
+  }
+}
+
+} // namespace detail
+
+} // namespace esimd
+} // namespace intel
+} // namespace ext
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/esimd/common.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/common.hpp
@@ -142,9 +142,11 @@ enum class atomic_op : uint8_t {
   /// Decrement: <code>*addr = *addr - 1</code>.
   dec = 0x3,
   /// Minimum: <code>*addr = min(*addr, src0)</code>.
-  min = 0x4,
+  umin = 0x4,
+  min __SYCL_DEPRECATED("use umin") = umin,
   /// Maximum: <code>*addr = max(*addr, src0)</code>.
-  max = 0x5,
+  umax = 0x5,
+  max __SYCL_DEPRECATED("use smax") = umax,
   /// Exchange. <code>*addr == src0;</code>
   xchg = 0x6,
   /// Compare and exchange. <code>if (*addr == src0) *sddr = src1;</code>
@@ -156,16 +158,19 @@ enum class atomic_op : uint8_t {
   /// Bit \c xor: <code>*addr = *addr | src0</code>.
   bit_xor = 0xa,
   /// Minimum (signed integer): <code>*addr = min(*addr, src0)</code>.
-  minsint = 0xb,
+  smin = 0xb,
+  minsint __SYCL_DEPRECATED("use smin") = smin,
   /// Maximum (signed integer): <code>*addr = max(*addr, src0)</code>.
-  maxsint = 0xc,
+  smax = 0xc,
+  maxsint __SYCL_DEPRECATED("use smax") = 0xc,
   /// Minimum (floating point): <code>*addr = min(*addr, src0)</code>.
   fmax __SYCL_DEPRECATED("fmax" __ESIMD_USM_DWORD_ATOMIC_TO_LSC) = 0x10,
   /// Maximum (floating point): <code>*addr = max(*addr, src0)</code>.
   fmin __SYCL_DEPRECATED("fmin" __ESIMD_USM_DWORD_ATOMIC_TO_LSC) = 0x11,
   /// Compare and exchange (floating point).
   /// <code>if (*addr == src0) *addr = src1;</code>
-  fcmpwr __SYCL_DEPRECATED("fcmpwr" __ESIMD_USM_DWORD_ATOMIC_TO_LSC) = 0x12,
+  fcmpxchg = 0x12,
+  fcmpwr __SYCL_DEPRECATED("fcmpwr" __ESIMD_USM_DWORD_ATOMIC_TO_LSC) = fcmpxchg,
   fadd __SYCL_DEPRECATED("fadd" __ESIMD_USM_DWORD_ATOMIC_TO_LSC) = 0x13,
   fsub __SYCL_DEPRECATED("fsub" __ESIMD_USM_DWORD_ATOMIC_TO_LSC) = 0x14,
   load = 0x15,

--- a/sycl/include/sycl/ext/intel/esimd/common.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/common.hpp
@@ -33,9 +33,7 @@
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
-namespace ext {
-namespace intel {
-namespace esimd {
+namespace ext::intel::esimd {
 
 /// @addtogroup sycl_esimd_core
 /// @{
@@ -72,6 +70,9 @@ ESIMD_INLINE constexpr bool isPowerOf2(unsigned int n) {
   return (n & (n - 1)) == 0;
 }
 
+/// Check at compile time if given 32 bit positive integer is both:
+/// - a power of 2
+/// - less or equal to given limit
 ESIMD_INLINE constexpr bool isPowerOf2(unsigned int n, unsigned int limit) {
   return (n & (n - 1)) == 0 && n <= limit;
 }
@@ -187,10 +188,10 @@ template <__ESIMD_NS::native::lsc::atomic_op Op> constexpr int get_num_args() {
   } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::store ||
                        Op == __ESIMD_NS::native::lsc::atomic_op::add ||
                        Op == __ESIMD_NS::native::lsc::atomic_op::sub ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::minsint ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::maxsint ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::min ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::max ||
+                       Op == __ESIMD_NS::native::lsc::atomic_op::smin ||
+                       Op == __ESIMD_NS::native::lsc::atomic_op::smax ||
+                       Op == __ESIMD_NS::native::lsc::atomic_op::umin ||
+                       Op == __ESIMD_NS::native::lsc::atomic_op::umax ||
                        Op == __ESIMD_NS::native::lsc::atomic_op::fadd ||
                        Op == __ESIMD_NS::native::lsc::atomic_op::fsub ||
                        Op == __ESIMD_NS::native::lsc::atomic_op::fmin ||
@@ -200,7 +201,7 @@ template <__ESIMD_NS::native::lsc::atomic_op Op> constexpr int get_num_args() {
                        Op == __ESIMD_NS::native::lsc::atomic_op::bit_xor) {
     return 1;
   } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::cmpxchg ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::fcmpwr) {
+                       Op == __ESIMD_NS::native::lsc::atomic_op::fcmpxchg) {
     return 2;
   } else {
     return -1; // error
@@ -229,9 +230,9 @@ constexpr __ESIMD_NS::native::lsc::atomic_op to_lsc_atomic_op() {
   case __ESIMD_NS::atomic_op::dec:
     return __ESIMD_NS::native::lsc::atomic_op::dec;
   case __ESIMD_NS::atomic_op::min:
-    return __ESIMD_NS::native::lsc::atomic_op::min;
+    return __ESIMD_NS::native::lsc::atomic_op::umin;
   case __ESIMD_NS::atomic_op::max:
-    return __ESIMD_NS::native::lsc::atomic_op::max;
+    return __ESIMD_NS::native::lsc::atomic_op::umax;
   case __ESIMD_NS::atomic_op::cmpxchg:
     return __ESIMD_NS::native::lsc::atomic_op::cmpxchg;
   case __ESIMD_NS::atomic_op::bit_and:
@@ -241,15 +242,15 @@ constexpr __ESIMD_NS::native::lsc::atomic_op to_lsc_atomic_op() {
   case __ESIMD_NS::atomic_op::bit_xor:
     return __ESIMD_NS::native::lsc::atomic_op::bit_xor;
   case __ESIMD_NS::atomic_op::minsint:
-    return __ESIMD_NS::native::lsc::atomic_op::minsint;
+    return __ESIMD_NS::native::lsc::atomic_op::smin;
   case __ESIMD_NS::atomic_op::maxsint:
-    return __ESIMD_NS::native::lsc::atomic_op::maxsint;
+    return __ESIMD_NS::native::lsc::atomic_op::smax;
   case __ESIMD_NS::atomic_op::fmax:
     return __ESIMD_NS::native::lsc::atomic_op::fmax;
   case __ESIMD_NS::atomic_op::fmin:
     return __ESIMD_NS::native::lsc::atomic_op::fmin;
   case __ESIMD_NS::atomic_op::fcmpwr:
-    return __ESIMD_NS::native::lsc::atomic_op::fcmpwr;
+    return __ESIMD_NS::native::lsc::atomic_op::fcmpxchg;
   case __ESIMD_NS::atomic_op::fadd:
     return __ESIMD_NS::native::lsc::atomic_op::fadd;
   case __ESIMD_NS::atomic_op::fsub:
@@ -274,9 +275,9 @@ constexpr __ESIMD_NS::atomic_op to_atomic_op() {
     return __ESIMD_NS::atomic_op::inc;
   case __ESIMD_NS::native::lsc::atomic_op::dec:
     return __ESIMD_NS::atomic_op::dec;
-  case __ESIMD_NS::native::lsc::atomic_op::min:
+  case __ESIMD_NS::native::lsc::atomic_op::umin:
     return __ESIMD_NS::atomic_op::min;
-  case __ESIMD_NS::native::lsc::atomic_op::max:
+  case __ESIMD_NS::native::lsc::atomic_op::umax:
     return __ESIMD_NS::atomic_op::max;
   case __ESIMD_NS::native::lsc::atomic_op::cmpxchg:
     return __ESIMD_NS::atomic_op::cmpxchg;
@@ -286,15 +287,15 @@ constexpr __ESIMD_NS::atomic_op to_atomic_op() {
     return __ESIMD_NS::atomic_op::bit_or;
   case __ESIMD_NS::native::lsc::atomic_op::bit_xor:
     return __ESIMD_NS::atomic_op::bit_xor;
-  case __ESIMD_NS::native::lsc::atomic_op::minsint:
+  case __ESIMD_NS::native::lsc::atomic_op::smin:
     return __ESIMD_NS::atomic_op::minsint;
-  case __ESIMD_NS::native::lsc::atomic_op::maxsint:
+  case __ESIMD_NS::native::lsc::atomic_op::smax:
     return __ESIMD_NS::atomic_op::maxsint;
   case __ESIMD_NS::native::lsc::atomic_op::fmax:
     return __ESIMD_NS::atomic_op::fmax;
   case __ESIMD_NS::native::lsc::atomic_op::fmin:
     return __ESIMD_NS::atomic_op::fmin;
-  case __ESIMD_NS::native::lsc::atomic_op::fcmpwr:
+  case __ESIMD_NS::native::lsc::atomic_op::fcmpxchg:
     return __ESIMD_NS::atomic_op::fcmpwr;
   case __ESIMD_NS::native::lsc::atomic_op::fadd:
     return __ESIMD_NS::atomic_op::fadd;
@@ -323,8 +324,6 @@ template <__ESIMD_NS::atomic_op Op> constexpr int get_num_args() {
 
 } // namespace detail
 
-} // namespace esimd
-} // namespace intel
-} // namespace ext
+} // namespace ext::intel::esimd
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/esimd/detail/atomic_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/atomic_intrin.hpp
@@ -84,13 +84,18 @@ template <typename Ty> Ty atomic_min(Ty *ptr, Ty val) {
   // TODO: Windows will be supported soon
   __ESIMD_UNSUPPORTED_ON_HOST;
 #else
-  Ty _old, _new;
-  do {
-    _old = *ptr;
-    _new = std::min<Ty>(_old, val);
-  } while (!__atomic_compare_exchange_n(ptr, &_old, _new, false,
-                                        __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST));
-  return _new;
+  // TODO FIXME: fix implementation for FP types.
+  if constexpr (std::is_integral_v<Ty>) {
+    Ty _old, _new;
+    do {
+      _old = *ptr;
+      _new = std::min<Ty>(_old, val);
+    } while (!__atomic_compare_exchange_n(ptr, &_old, _new, false,
+                                          __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST));
+    return _new;
+  } else {
+    __ESIMD_UNSUPPORTED_ON_HOST;
+  }
 #endif
 }
 
@@ -99,13 +104,18 @@ template <typename Ty> Ty atomic_max(Ty *ptr, Ty val) {
   // TODO: Windows will be supported soon
   __ESIMD_UNSUPPORTED_ON_HOST;
 #else
-  Ty _old, _new;
-  do {
-    _old = *ptr;
-    _new = std::max<Ty>(_old, val);
-  } while (!__atomic_compare_exchange_n(ptr, &_old, _new, false,
-                                        __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST));
-  return _new;
+  // TODO FIXME: fix implementation for FP types.
+  if constexpr (std::is_integral_v<Ty>) {
+    Ty _old, _new;
+    do {
+      _old = *ptr;
+      _new = std::max<Ty>(_old, val);
+    } while (!__atomic_compare_exchange_n(ptr, &_old, _new, false,
+                                          __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST));
+    return _new;
+  } else {
+    __ESIMD_UNSUPPORTED_ON_HOST;
+  }
 #endif
 }
 
@@ -114,10 +124,15 @@ template <typename Ty> Ty atomic_cmpxchg(Ty *ptr, Ty expected, Ty desired) {
   // TODO: Windows will be supported soon
   __ESIMD_UNSUPPORTED_ON_HOST;
 #else
-  Ty _old = expected;
-  __atomic_compare_exchange_n(ptr, &_old, desired, false, __ATOMIC_SEQ_CST,
-                              __ATOMIC_SEQ_CST);
-  return *ptr;
+  // TODO FIXME: fix implementation for FP types.
+  if constexpr (std::is_integral_v<Ty>) {
+    Ty _old = expected;
+    __atomic_compare_exchange_n(ptr, &_old, desired, false, __ATOMIC_SEQ_CST,
+                                __ATOMIC_SEQ_CST);
+    return *ptr;
+  } else {
+    __ESIMD_UNSUPPORTED_ON_HOST;
+  }
 #endif
 }
 

--- a/sycl/include/sycl/ext/intel/esimd/detail/defines_elementary.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/defines_elementary.hpp
@@ -1,0 +1,63 @@
+//==---------------- defines_elementary.hpp - DPC++ Explicit SIMD API ------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Elementary definitions used in Explicit SIMD APIs.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+/// @cond ESIMD_DETAIL
+
+#ifdef __SYCL_DEVICE_ONLY__
+#define SYCL_ESIMD_KERNEL __attribute__((sycl_explicit_simd))
+#define SYCL_ESIMD_FUNCTION __attribute__((sycl_explicit_simd))
+
+// Mark a function being nodebug.
+#define ESIMD_NODEBUG __attribute__((nodebug))
+// Mark a "ESIMD global": accessible from all functions in current translation
+// unit, separate copy per subgroup (work-item), mapped to SPIR-V private
+// storage class.
+#define ESIMD_PRIVATE                                                          \
+  __attribute__((opencl_private)) __attribute__((sycl_explicit_simd))
+// Bind a ESIMD global variable to a specific register.
+#define ESIMD_REGISTER(n) __attribute__((register_num(n)))
+
+#define __ESIMD_API ESIMD_NODEBUG ESIMD_INLINE
+#else // __SYCL_DEVICE_ONLY__
+#define SYCL_ESIMD_KERNEL
+#define SYCL_ESIMD_FUNCTION
+
+// TODO ESIMD define what this means on Windows host
+#define ESIMD_NODEBUG
+// On host device ESIMD global is a thread local static var. This assumes that
+// each work-item is mapped to a separate OS thread on host device.
+#define ESIMD_PRIVATE thread_local
+#define ESIMD_REGISTER(n)
+
+#define __ESIMD_API ESIMD_INLINE
+#endif // __SYCL_DEVICE_ONLY__
+
+// Mark a function being noinline
+#define ESIMD_NOINLINE __attribute__((noinline))
+// Force a function to be inlined. 'inline' is used to preserve ODR for
+// functions defined in a header.
+#define ESIMD_INLINE inline __attribute__((always_inline))
+
+// Macros for internal use
+#define __ESIMD_NS sycl::ext::intel::esimd
+#define __ESIMD_DNS sycl::ext::intel::esimd::detail
+#define __ESIMD_EMU_DNS sycl::ext::intel::esimd::emu::detail
+#define __ESIMD_ENS sycl::ext::intel::experimental::esimd
+#define __ESIMD_EDNS sycl::ext::intel::experimental::esimd::detail
+
+#define __ESIMD_QUOTE1(m) #m
+#define __ESIMD_QUOTE(m) __ESIMD_QUOTE1(m)
+#define __ESIMD_NS_QUOTED __ESIMD_QUOTE(__ESIMD_NS)
+#define __ESIMD_DEPRECATED(new_api)                                            \
+  __SYCL_DEPRECATED("use " __ESIMD_NS_QUOTED "::" __ESIMD_QUOTE(new_api))
+
+/// @endcond ESIMD_DETAIL

--- a/sycl/include/sycl/ext/intel/esimd/detail/types.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/types.hpp
@@ -36,8 +36,6 @@ template <typename BaseTy, typename RegionTy> class simd_view;
 
 namespace detail {
 
-namespace sd = sycl::detail;
-
 template <int N>
 using uint_type_t = std::conditional_t<
     N == 1, uint8_t,
@@ -82,7 +80,8 @@ static inline constexpr bool is_clang_vector_type_v =
 // @}
 
 template <typename T>
-using remove_cvref_t = sd::remove_cv_t<sd::remove_reference_t<T>>;
+using remove_cvref_t =
+    sycl::detail::remove_cv_t<sycl::detail::remove_reference_t<T>>;
 
 // is_esimd_arithmetic_type
 template <class...> struct make_esimd_void {
@@ -353,18 +352,9 @@ std::enable_if_t<is_clang_vector_type_v<To> && is_clang_vector_type_v<From>, To>
   }
 }
 
-/// Base case for checking if a type U is one of the types.
-template <typename U> constexpr bool is_type() { return false; }
-
-template <typename U, typename T, typename... Ts> constexpr bool is_type() {
-  using UU = typename sd::remove_const_t<U>;
-  using TT = typename sd::remove_const_t<T>;
-  return std::is_same<UU, TT>::value || is_type<UU, Ts...>();
-}
-
 // calculates the number of elements in "To" type
 template <typename ToEltTy, typename FromEltTy, int FromN,
-          typename = sd::enable_if_t<is_vectorizable<ToEltTy>::value>>
+          typename = std::enable_if_t<is_vectorizable<ToEltTy>::value>>
 struct bitcast_helper {
   static inline constexpr int nToElems() {
     constexpr int R1 = sizeof(ToEltTy) / sizeof(FromEltTy);
@@ -376,8 +366,8 @@ struct bitcast_helper {
 
 // Change the element type of a simd vector.
 template <typename ToEltTy, typename FromEltTy, int FromN,
-          typename = sd::enable_if_t<is_vectorizable<ToEltTy>::value>>
-ESIMD_INLINE typename sd::conditional_t<
+          typename = std::enable_if_t<is_vectorizable<ToEltTy>::value>>
+ESIMD_INLINE typename std::conditional_t<
     std::is_same<FromEltTy, ToEltTy>::value, vector_type_t<FromEltTy, FromN>,
     vector_type_t<ToEltTy,
                   bitcast_helper<ToEltTy, FromEltTy, FromN>::nToElems()>>

--- a/sycl/include/sycl/ext/intel/esimd/detail/types.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/types.hpp
@@ -36,6 +36,15 @@ template <typename BaseTy, typename RegionTy> class simd_view;
 
 namespace detail {
 
+/// Base case for checking if a type U is one of the types.
+template <typename U> constexpr bool is_type() { return false; }
+
+template <typename U, typename T, typename... Ts> constexpr bool is_type() {
+  using UU = typename std::remove_const_t<U>;
+  using TT = typename std::remove_const_t<T>;
+  return std::is_same<UU, TT>::value || is_type<UU, Ts...>();
+}
+
 template <int N>
 using uint_type_t = std::conditional_t<
     N == 1, uint8_t,

--- a/sycl/include/sycl/ext/intel/esimd/detail/types.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/types.hpp
@@ -36,15 +36,6 @@ template <typename BaseTy, typename RegionTy> class simd_view;
 
 namespace detail {
 
-/// Base case for checking if a type U is one of the types.
-template <typename U> constexpr bool is_type() { return false; }
-
-template <typename U, typename T, typename... Ts> constexpr bool is_type() {
-  using UU = typename std::remove_const_t<U>;
-  using TT = typename std::remove_const_t<T>;
-  return std::is_same<UU, TT>::value || is_type<UU, Ts...>();
-}
-
 template <int N>
 using uint_type_t = std::conditional_t<
     N == 1, uint8_t,
@@ -359,6 +350,15 @@ std::enable_if_t<is_clang_vector_type_v<To> && is_clang_vector_type_v<From>, To>
   } else {
     return __builtin_convertvector(Val, To);
   }
+}
+
+/// Base case for checking if a type U is one of the types.
+template <typename U> constexpr bool is_type() { return false; }
+
+template <typename U, typename T, typename... Ts> constexpr bool is_type() {
+  using UU = typename std::remove_const_t<U>;
+  using TT = typename std::remove_const_t<T>;
+  return std::is_same<UU, TT>::value || is_type<UU, Ts...>();
 }
 
 // calculates the number of elements in "To" type

--- a/sycl/include/sycl/ext/intel/esimd/detail/util.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/util.hpp
@@ -70,16 +70,6 @@ template <unsigned int N> constexpr unsigned int log2() {
   return Log2<N, (N > 1)>::get();
 }
 
-/// Check if a given 32 bit positive integer is a power of 2 at compile time.
-static ESIMD_INLINE constexpr bool isPowerOf2(unsigned int n) {
-  return (n & (n - 1)) == 0;
-}
-
-static ESIMD_INLINE constexpr bool isPowerOf2(unsigned int n,
-                                              unsigned int limit) {
-  return (n & (n - 1)) == 0 && n <= limit;
-}
-
 /// type traits
 template <typename T> struct is_esimd_vector : public std::false_type {};
 

--- a/sycl/include/sycl/ext/intel/esimd/math.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/math.hpp
@@ -679,10 +679,10 @@ pack_mask(simd_mask<N> src0) {
 /// @return an \c uint, where each bit is set if the corresponding element of
 /// the source operand is non-zero and unset otherwise.
 template <typename T, int N>
-__ESIMD_API
-    std::enable_if_t<detail::is_type<T, ushort, uint>() && (N > 0 && N <= 32),
-                     uint>
-    ballot(simd<T, N> mask) {
+__ESIMD_API std::enable_if_t<(std::is_same_v<T, ushort> ||
+                              std::is_same_v<T, uint>)&&(N > 0 && N <= 32),
+                             uint>
+ballot(simd<T, N> mask) {
   simd_mask<N> cmp = (mask != 0);
   if constexpr (N == 8 || N == 16 || N == 32) {
     return __esimd_pack_mask<N>(cmp.data());

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -759,16 +759,6 @@ constexpr void check_atomic() {
 /// @addtogroup sycl_esimd_memory_atomics
 /// @{
 
-/// LSC version of no argument variant of the \c atomic_update - accepts
-/// <tt>native::lsc::atomic_op</tt> instead of <tt>atomic_op</tt> as atomic
-/// operation template argument.
-template <native::lsc::atomic_op Op, typename T, int N>
-__ESIMD_API simd<T, N> atomic_update(T *p, simd<unsigned, N> offset,
-                                     simd_mask<N> mask) {
-  return __ESIMD_ENS::lsc_atomic_update<detail::to_atomic_op<Op>(), T, N>(
-      p, offset, mask);
-}
-
 /// @anchor usm_atomic_update0
 /// @brief No-argument variant of the atomic update operation.
 ///
@@ -797,14 +787,6 @@ __ESIMD_API simd<Tx, N> atomic_update(Tx *p, simd<unsigned, N> offset,
   vAddr += offset_i1;
   using T = typename detail::__raw_t<Tx>;
   return __esimd_svm_atomic0<Op, T, N>(vAddr.data(), mask.data());
-}
-
-/// LSC version of the single-argument atomic update.
-template <native::lsc::atomic_op Op, typename T, int N>
-__ESIMD_API simd<T, N> atomic_update(T *p, simd<unsigned, N> offset,
-                                     simd<T, N> src0, simd_mask<N> mask) {
-  return __ESIMD_ENS::lsc_atomic_update<detail::to_atomic_op<Op>(), T, N>(
-      p, offset, src0, mask);
 }
 
 /// @anchor usm_atomic_update1
@@ -847,15 +829,6 @@ __ESIMD_API simd<Tx, N> atomic_update(Tx *p, simd<unsigned, N> offset,
     return __esimd_svm_atomic1<Op, T, N>(vAddr.data(), src0.data(),
                                          mask.data());
   }
-}
-
-/// LSC version of the two-argument atomic update.
-template <native::lsc::atomic_op Op, typename T, int N>
-__ESIMD_API simd<T, N> atomic_update(T *p, simd<unsigned, N> offset,
-                                     simd<T, N> src0, simd<T, N> src1,
-                                     simd_mask<N> mask) {
-  return __ESIMD_ENS::lsc_atomic_update<detail::to_atomic_op<Op>(), T, N>(
-      p, offset, src0, src1, mask);
 }
 
 /// @anchor usm_atomic_update2

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -67,8 +67,6 @@ __ESIMD_API SurfaceIndex get_surface_index(AccessorTy acc) {
   }
 }
 
-#define __ESIMD_GET_SURF_HANDLE(acc) get_surface_index(acc)
-
 // TODO @Pennycook
 // {quote}
 // ...I'd like us to think more about what we can do to make these interfaces
@@ -345,7 +343,7 @@ ESIMD_INLINE
   constexpr int TypeSizeLog2 = detail::ElemsPerAddrEncoding<sizeof(T)>();
   // TODO (performance) use hardware-supported scale once BE supports it
   constexpr int16_t scale = 0;
-  const auto si = __ESIMD_GET_SURF_HANDLE(acc);
+  const auto si = __ESIMD_NS::get_surface_index(acc);
 
   if constexpr (sizeof(T) < 4) {
     using Tint = std::conditional_t<std::is_integral_v<T>, T,
@@ -690,103 +688,90 @@ scatter_rgba(AccessorT acc, simd<uint32_t, N> offsets,
 
 /// @} sycl_esimd_memory
 
-/// @cond ESIMD_DETAIL
-
 namespace detail {
 /// Check the legality of an atomic call in terms of size and type.
 ///
-template <atomic_op Op, typename T, int N, unsigned NumSrc>
-constexpr bool check_atomic() {
+template <__ESIMD_NS::atomic_op Op, typename T, int N, unsigned NumSrc>
+constexpr void check_atomic() {
   if constexpr (!detail::isPowerOf2(N, 32)) {
     static_assert((detail::isPowerOf2(N, 32)),
                   "Execution size 1, 2, 4, 8, 16, 32 are supported");
-    return false;
   }
-
-  // No source operands.
-  if constexpr (Op == atomic_op::inc || Op == atomic_op::dec) {
-    if constexpr (NumSrc != 0) {
-      static_assert(NumSrc == 0, "No source operands are expected");
-      return false;
-    }
-    if constexpr (!is_type<T, uint16_t, uint32_t, uint64_t>()) {
-      static_assert((is_type<T, uint16_t, uint32_t, uint64_t>()),
-                    "Type UW, UD or UQ is expected");
-      return false;
-    }
-    return true;
+  if constexpr (NumSrc != __ESIMD_DNS::get_num_args<Op>()) {
+    static_assert(NumSrc == __ESIMD_DNS::get_num_args<Op>(),
+                  "wrong number of operands");
   }
+  constexpr bool IsInt2BytePlus =
+      std::is_integral_v<T> && (sizeof(T) >= sizeof(uint16_t));
 
-  // One source integer operand.
-  if constexpr (Op == atomic_op::add || Op == atomic_op::sub ||
-                Op == atomic_op::min || Op == atomic_op::max ||
-                Op == atomic_op::xchg || Op == atomic_op::bit_and ||
-                Op == atomic_op::bit_or || Op == atomic_op::bit_xor ||
-                Op == atomic_op::minsint || Op == atomic_op::maxsint) {
-    if constexpr (NumSrc != 1) {
-      static_assert(NumSrc == 1, "One source operand is expected");
-      return false;
+  if constexpr (Op == __ESIMD_NS::atomic_op::xchg ||
+                Op == __ESIMD_NS::atomic_op::cmpxchg ||
+                Op == __ESIMD_NS::atomic_op::predec ||
+                Op == __ESIMD_NS::atomic_op::inc ||
+                Op == __ESIMD_NS::atomic_op::dec ||
+                Op == __ESIMD_NS::atomic_op::load) {
+
+    if constexpr (!IsInt2BytePlus) {
+      static_assert(IsInt2BytePlus,
+                    "Integral 16-bit or wider type is expected");
     }
-    if constexpr ((Op != atomic_op::minsint && Op != atomic_op::maxsint) &&
-                  !is_type<T, uint16_t, uint32_t, uint64_t>()) {
-      static_assert((is_type<T, uint16_t, uint32_t, uint64_t>()),
-                    "Type UW, UD or UQ is expected");
-      return false;
-    }
-    if constexpr ((Op == atomic_op::minsint || Op == atomic_op::maxsint) &&
-                  !is_type<T, int16_t, int32_t, int64_t>()) {
-      static_assert((is_type<T, int16_t, int32_t, int64_t>()),
-                    "Type W, D or Q is expected");
-      return false;
-    }
-    return true;
   }
-
-  // One source float operand.
-  if constexpr (Op == atomic_op::fmax || Op == atomic_op::fmin ||
-                Op == atomic_op::fadd || Op == atomic_op::fsub) {
-    if constexpr (NumSrc != 1) {
-      static_assert(NumSrc == 1, "One source operand is expected");
-      return false;
-    }
+  // FP ops (are always delegated to native::lsc::<Op>)
+  if constexpr (Op == __ESIMD_NS::atomic_op::fmax ||
+                Op == __ESIMD_NS::atomic_op::fmin ||
+                Op == __ESIMD_NS::atomic_op::fadd ||
+                Op == __ESIMD_NS::atomic_op::fsub) {
     if constexpr (!is_type<T, float, sycl::half>()) {
       static_assert((is_type<T, float, sycl::half>()),
                     "Type F or HF is expected");
-      return false;
     }
-    return true;
   }
+  if constexpr (Op == __ESIMD_NS::atomic_op::add ||
+                Op == __ESIMD_NS::atomic_op::sub ||
+                Op == __ESIMD_NS::atomic_op::min ||
+                Op == __ESIMD_NS::atomic_op::max ||
+                Op == __ESIMD_NS::atomic_op::bit_and ||
+                Op == __ESIMD_NS::atomic_op::bit_or ||
+                Op == __ESIMD_NS::atomic_op::bit_xor ||
+                Op == __ESIMD_NS::atomic_op::minsint ||
+                Op == __ESIMD_NS::atomic_op::maxsint) {
+    if constexpr (!IsInt2BytePlus) {
+      static_assert(IsInt2BytePlus,
+                    "Integral 16-bit or wider type is expected");
+    }
+    constexpr bool IsSignedMinmax = (Op == __ESIMD_NS::atomic_op::minsint) ||
+                                    (Op == __ESIMD_NS::atomic_op::maxsint);
+    constexpr bool IsUnsignedMinmax = (Op == __ESIMD_NS::atomic_op::min) ||
+                                      (Op == __ESIMD_NS::atomic_op::max);
 
-  // Two source operands.
-  if constexpr (Op == atomic_op::cmpxchg || Op == atomic_op::fcmpwr) {
-    if constexpr (NumSrc != 2) {
-      static_assert(NumSrc == 2, "Two source operands are expected");
-      return false;
+    if constexpr (IsSignedMinmax || IsUnsignedMinmax) {
+      constexpr bool SignOK = std::is_signed_v<T> == IsSignedMinmax;
+
+      if constexpr (!SignOK) {
+        static_assert(SignOK, "Signed/unsigned integer type expected for "
+                              "signed/unsigned min/max operation");
+      }
     }
-    if constexpr (Op == atomic_op::cmpxchg &&
-                  !is_type<T, uint16_t, uint32_t, uint64_t>()) {
-      static_assert((is_type<T, uint16_t, uint32_t, uint64_t>()),
-                    "Type UW, UD or UQ is expected");
-      return false;
-    }
-    if constexpr (Op == atomic_op::fcmpwr && !is_type<T, float, sycl::half>()) {
-      static_assert((is_type<T, float, sycl::half>()),
-                    "Type F or HF is expected");
-      return false;
-    }
-    return true;
   }
-  // Unsupported svm atomic Op.
-  return false;
 }
 } // namespace detail
-
-/// @endcond ESIMD_DETAIL
 
 /// @addtogroup sycl_esimd_memory_atomics
 /// @{
 
+/// LSC version of no argument variant of the \c atomic_update - accepts
+/// <tt>native::lsc::atomic_op</tt> instead of <tt>atomic_op</tt> as atomic
+/// operation template argument.
+template <native::lsc::atomic_op Op, typename T, int N>
+__ESIMD_API simd<T, N> atomic_update(T *p, simd<unsigned, N> offset,
+                                     simd_mask<N> mask) {
+  return __ESIMD_ENS::lsc_atomic_update<detail::to_atomic_op<Op>(), T, N>(
+      p, offset, mask);
+}
+
 /// @anchor usm_atomic_update0
+/// @brief No-argument variant of the atomic update operation.
+///
 /// Atomically updates \c N memory locations represented by a USM pointer and
 /// a vector of offsets relative to the pointer, and returns a vector of old
 /// values found at the memory locations before update. The update operation
@@ -803,16 +788,28 @@ constexpr bool check_atomic() {
 /// @return A vector of the old values at the memory locations before the
 ///   update.
 ///
-template <atomic_op Op, typename Tx, int N, class T = detail::__raw_t<Tx>>
-__ESIMD_API std::enable_if_t<detail::check_atomic<Op, Tx, N, 0>(), simd<Tx, N>>
-atomic_update(Tx *p, simd<unsigned, N> offset, simd_mask<N> mask) {
+template <atomic_op Op, typename Tx, int N>
+__ESIMD_API simd<Tx, N> atomic_update(Tx *p, simd<unsigned, N> offset,
+                                      simd_mask<N> mask) {
+  detail::check_atomic<Op, Tx, N, 0>();
   simd<uintptr_t, N> vAddr(reinterpret_cast<uintptr_t>(p));
   simd<uintptr_t, N> offset_i1 = convert<uintptr_t>(offset);
   vAddr += offset_i1;
+  using T = typename detail::__raw_t<Tx>;
   return __esimd_svm_atomic0<Op, T, N>(vAddr.data(), mask.data());
 }
 
+/// LSC version of the single-argument atomic update.
+template <native::lsc::atomic_op Op, typename T, int N>
+__ESIMD_API simd<T, N> atomic_update(T *p, simd<unsigned, N> offset,
+                                     simd<T, N> src0, simd_mask<N> mask) {
+  return __ESIMD_ENS::lsc_atomic_update<detail::to_atomic_op<Op>(), T, N>(
+      p, offset, src0, mask);
+}
+
 /// @anchor usm_atomic_update1
+/// @brief Single-argument variant of the atomic update operation.
+///
 /// Atomically updates \c N memory locations represented by a USM pointer and
 /// a vector of offsets relative to the pointer, and returns a vector of old
 /// values found at the memory locations before update. The update operation
@@ -833,14 +830,32 @@ atomic_update(Tx *p, simd<unsigned, N> offset, simd_mask<N> mask) {
 /// @return A vector of the old values at the memory locations before the
 ///   update.
 ///
-template <atomic_op Op, typename Tx, int N, class T = detail::__raw_t<Tx>>
-__ESIMD_API std::enable_if_t<detail::check_atomic<Op, Tx, N, 1>(), simd<Tx, N>>
-atomic_update(Tx *p, simd<unsigned, N> offset, simd<Tx, N> src0,
-              simd_mask<N> mask) {
-  simd<uintptr_t, N> vAddr(reinterpret_cast<uintptr_t>(p));
-  simd<uintptr_t, N> offset_i1 = convert<uintptr_t>(offset);
-  vAddr += offset_i1;
-  return __esimd_svm_atomic1<Op, T, N>(vAddr.data(), src0.data(), mask.data());
+template <atomic_op Op, typename Tx, int N>
+__ESIMD_API simd<Tx, N> atomic_update(Tx *p, simd<unsigned, N> offset,
+                                      simd<Tx, N> src0, simd_mask<N> mask) {
+  if constexpr ((Op == atomic_op::fmin) || (Op == atomic_op::fmax) ||
+                (Op == atomic_op::fadd) || (Op == atomic_op::fsub)) {
+    // Auto-convert FP atomics to LSC version. Warning is given - see enum.
+    return atomic_update<detail::to_lsc_atomic_op<Op>(), Tx, N>(p, offset, src0,
+                                                                mask);
+  } else {
+    detail::check_atomic<Op, Tx, N, 1>();
+    simd<uintptr_t, N> vAddr(reinterpret_cast<uintptr_t>(p));
+    simd<uintptr_t, N> offset_i1 = convert<uintptr_t>(offset);
+    vAddr += offset_i1;
+    using T = typename detail::__raw_t<Tx>;
+    return __esimd_svm_atomic1<Op, T, N>(vAddr.data(), src0.data(),
+                                         mask.data());
+  }
+}
+
+/// LSC version of the two-argument atomic update.
+template <native::lsc::atomic_op Op, typename T, int N>
+__ESIMD_API simd<T, N> atomic_update(T *p, simd<unsigned, N> offset,
+                                     simd<T, N> src0, simd<T, N> src1,
+                                     simd_mask<N> mask) {
+  return __ESIMD_ENS::lsc_atomic_update<detail::to_atomic_op<Op>(), T, N>(
+      p, offset, src0, src1, mask);
 }
 
 /// @anchor usm_atomic_update2
@@ -862,15 +877,23 @@ atomic_update(Tx *p, simd<unsigned, N> offset, simd<Tx, N> src0,
 /// @return A vector of the old values at the memory locations before the
 ///   update.
 ///
-template <atomic_op Op, typename Tx, int N, class T = detail::__raw_t<Tx>>
-__ESIMD_API std::enable_if_t<detail::check_atomic<Op, Tx, N, 2>(), simd<Tx, N>>
-atomic_update(Tx *p, simd<unsigned, N> offset, simd<Tx, N> src0,
-              simd<Tx, N> src1, simd_mask<N> mask) {
-  simd<uintptr_t, N> vAddr(reinterpret_cast<uintptr_t>(p));
-  simd<uintptr_t, N> offset_i1 = convert<uintptr_t>(offset);
-  vAddr += offset_i1;
-  return __esimd_svm_atomic2<Op, T, N>(vAddr.data(), src0.data(), src1.data(),
-                                       mask.data());
+template <atomic_op Op, typename Tx, int N>
+__ESIMD_API simd<Tx, N> atomic_update(Tx *p, simd<unsigned, N> offset,
+                                      simd<Tx, N> src0, simd<Tx, N> src1,
+                                      simd_mask<N> mask) {
+  if constexpr (Op == atomic_op::fcmpwr) {
+    // Auto-convert FP atomics to LSC version. Warning is given - see enum.
+    return atomic_update<detail::to_lsc_atomic_op<Op>(), Tx, N>(p, offset, src0,
+                                                                src1, mask);
+  } else {
+    detail::check_atomic<Op, Tx, N, 2>();
+    simd<uintptr_t, N> vAddr(reinterpret_cast<uintptr_t>(p));
+    simd<uintptr_t, N> offset_i1 = convert<uintptr_t>(offset);
+    vAddr += offset_i1;
+    using T = typename detail::__raw_t<Tx>;
+    return __esimd_svm_atomic2<Op, T, N>(vAddr.data(), src0.data(), src1.data(),
+                                         mask.data());
+  }
 }
 
 /// @} sycl_esimd_memory_atomics
@@ -999,7 +1022,7 @@ __ESIMD_API std::enable_if_t<(N == 8 || N == 16 || N == 32) && (sizeof(T) == 4),
                              simd<T, N * get_num_channels_enabled(RGBAMask)>>
 slm_gather_rgba(simd<uint32_t, N> offsets, simd_mask<N> mask = 1) {
 
-  const auto SI = __ESIMD_GET_SURF_HANDLE(detail::LocalAccessorMarker());
+  const auto SI = __ESIMD_NS::get_surface_index(detail::LocalAccessorMarker());
   return __esimd_gather4_masked_scaled2<T, N, RGBAMask>(
       SI, 0 /*global_offset*/, offsets.data(), mask.data());
 }
@@ -1020,7 +1043,7 @@ slm_scatter_rgba(simd<uint32_t, N> offsets,
                  simd<T, N * get_num_channels_enabled(Mask)> vals,
                  simd_mask<N> mask = 1) {
   detail::validate_rgba_write_channel_mask<Mask>();
-  const auto si = __ESIMD_GET_SURF_HANDLE(detail::LocalAccessorMarker());
+  const auto si = __ESIMD_NS::get_surface_index(detail::LocalAccessorMarker());
   constexpr int16_t Scale = 0;
   constexpr int global_offset = 0;
   __esimd_scatter4_scaled<T, N, decltype(si), Mask, Scale>(
@@ -1047,7 +1070,7 @@ __ESIMD_API simd<T, N> slm_block_load(uint32_t offset) {
   static_assert(Sz <= 16 * detail::OperandSize::OWORD,
                 "block size must be at most 16 owords");
 
-  const auto si = __ESIMD_GET_SURF_HANDLE(detail::LocalAccessorMarker());
+  const auto si = __ESIMD_NS::get_surface_index(detail::LocalAccessorMarker());
   return __esimd_oword_ld<detail::__raw_t<T>, N>(si, offset >> 4);
 }
 
@@ -1070,7 +1093,7 @@ __ESIMD_API void slm_block_store(uint32_t offset, simd<T, N> vals) {
                 "block must be 1, 2, 4 or 8 owords long");
   static_assert(Sz <= 8 * detail::OperandSize::OWORD,
                 "block size must be at most 8 owords");
-  const auto si = __ESIMD_GET_SURF_HANDLE(detail::LocalAccessorMarker());
+  const auto si = __ESIMD_NS::get_surface_index(detail::LocalAccessorMarker());
   // offset in genx.oword.st is in owords
   __esimd_oword_st<detail::__raw_t<T>, N>(si, offset >> 4, vals.data());
 }
@@ -1079,9 +1102,10 @@ __ESIMD_API void slm_block_store(uint32_t offset, simd<T, N> vals) {
 /// See description of template and function parameters in @ref
 /// usm_atomic_update0 "atomic update" operation docs.
 template <atomic_op Op, typename Tx, int N, class T = detail::__raw_t<Tx>>
-__ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, N, 0>(), simd<Tx, N>>
-slm_atomic_update(simd<uint32_t, N> offsets, simd_mask<N> mask) {
-  const auto si = __ESIMD_GET_SURF_HANDLE(detail::LocalAccessorMarker());
+__ESIMD_API simd<Tx, N> slm_atomic_update(simd<uint32_t, N> offsets,
+                                          simd_mask<N> mask) {
+  detail::check_atomic<Op, T, N, 0>();
+  const auto si = __ESIMD_NS::get_surface_index(detail::LocalAccessorMarker());
   return __esimd_dword_atomic0<Op, T, N>(mask.data(), si, offsets.data());
 }
 
@@ -1089,10 +1113,10 @@ slm_atomic_update(simd<uint32_t, N> offsets, simd_mask<N> mask) {
 /// See description of template and function parameters in @ref
 /// usm_atomic_update1 "atomic update" operation docs.
 template <atomic_op Op, typename Tx, int N, class T = detail::__raw_t<Tx>>
-__ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, N, 1>(), simd<Tx, N>>
-slm_atomic_update(simd<uint32_t, N> offsets, simd<Tx, N> src0,
-                  simd_mask<N> mask) {
-  const auto si = __ESIMD_GET_SURF_HANDLE(detail::LocalAccessorMarker());
+__ESIMD_API simd<Tx, N> slm_atomic_update(simd<uint32_t, N> offsets,
+                                          simd<Tx, N> src0, simd_mask<N> mask) {
+  detail::check_atomic<Op, T, N, 1>();
+  const auto si = __ESIMD_NS::get_surface_index(detail::LocalAccessorMarker());
   return __esimd_dword_atomic1<Op, T, N>(mask.data(), si, offsets.data(),
                                          src0.data());
 }
@@ -1101,10 +1125,11 @@ slm_atomic_update(simd<uint32_t, N> offsets, simd<Tx, N> src0,
 /// See description of template and function parameters in @ref
 /// usm_atomic_update2 "atomic update" operation docs.
 template <atomic_op Op, typename Tx, int N, class T = detail::__raw_t<Tx>>
-__ESIMD_API std::enable_if_t<detail::check_atomic<Op, T, N, 2>(), simd<Tx, N>>
-slm_atomic_update(simd<uint32_t, N> offsets, simd<Tx, N> src0, simd<Tx, N> src1,
-                  simd_mask<N> mask) {
-  const auto si = __ESIMD_GET_SURF_HANDLE(detail::LocalAccessorMarker());
+__ESIMD_API simd<Tx, N> slm_atomic_update(simd<uint32_t, N> offsets,
+                                          simd<Tx, N> src0, simd<Tx, N> src1,
+                                          simd_mask<N> mask) {
+  detail::check_atomic<Op, T, N, 2>();
+  const auto si = __ESIMD_NS::get_surface_index(detail::LocalAccessorMarker());
   return __esimd_dword_atomic2<Op, T, N>(mask.data(), si, offsets.data(),
                                          src0.data(), src1.data());
 }
@@ -1137,7 +1162,7 @@ __ESIMD_API simd<T, m * N> media_block_load(AccessorTy acc, unsigned x,
   static_assert(m <= 64u, "valid block height is in range [1, 64]");
   static_assert(plane <= 3u, "valid plane index is in range [0, 3]");
 
-  const auto si = __ESIMD_GET_SURF_HANDLE(acc);
+  const auto si = __ESIMD_NS::get_surface_index(acc);
   using SurfIndTy = decltype(si);
   constexpr unsigned int RoundedWidth =
       Width < 4 ? 4 : detail::getNextPowerOf2<Width>();
@@ -1177,7 +1202,7 @@ __ESIMD_API void media_block_store(AccessorTy acc, unsigned x, unsigned y,
   static_assert(Width <= 64u, "valid block width is in range [1, 64]");
   static_assert(m <= 64u, "valid block height is in range [1, 64]");
   static_assert(plane <= 3u, "valid plane index is in range [0, 3]");
-  const auto si = __ESIMD_GET_SURF_HANDLE(acc);
+  const auto si = __ESIMD_NS::get_surface_index(acc);
   using SurfIndTy = decltype(si);
   constexpr unsigned int RoundedWidth =
       Width < 4 ? 4 : detail::getNextPowerOf2<Width>();
@@ -1200,8 +1225,6 @@ __ESIMD_API void media_block_store(AccessorTy acc, unsigned x, unsigned y,
 #endif // !__ESIMD_FORCE_STATELESS_MEM
 
 /// @} sycl_esimd_memory
-
-#undef __ESIMD_GET_SURF_HANDLE
 
 /// @cond EXCLUDE
 

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -693,14 +693,10 @@ namespace detail {
 ///
 template <__ESIMD_NS::atomic_op Op, typename T, int N, unsigned NumSrc>
 constexpr void check_atomic() {
-  if constexpr (!detail::isPowerOf2(N, 32)) {
-    static_assert((detail::isPowerOf2(N, 32)),
-                  "Execution size 1, 2, 4, 8, 16, 32 are supported");
-  }
-  if constexpr (NumSrc != __ESIMD_DNS::get_num_args<Op>()) {
-    static_assert(NumSrc == __ESIMD_DNS::get_num_args<Op>(),
-                  "wrong number of operands");
-  }
+  static_assert((detail::isPowerOf2(N, 32)),
+                "Execution size 1, 2, 4, 8, 16, 32 are supported");
+  static_assert(NumSrc == __ESIMD_DNS::get_num_args<Op>(),
+                "wrong number of operands");
   constexpr bool IsInt2BytePlus =
       std::is_integral_v<T> && (sizeof(T) >= sizeof(uint16_t));
 
@@ -711,20 +707,15 @@ constexpr void check_atomic() {
                 Op == __ESIMD_NS::atomic_op::dec ||
                 Op == __ESIMD_NS::atomic_op::load) {
 
-    if constexpr (!IsInt2BytePlus) {
-      static_assert(IsInt2BytePlus,
-                    "Integral 16-bit or wider type is expected");
-    }
+    static_assert(IsInt2BytePlus, "Integral 16-bit or wider type is expected");
   }
   // FP ops (are always delegated to native::lsc::<Op>)
   if constexpr (Op == __ESIMD_NS::atomic_op::fmax ||
                 Op == __ESIMD_NS::atomic_op::fmin ||
                 Op == __ESIMD_NS::atomic_op::fadd ||
                 Op == __ESIMD_NS::atomic_op::fsub) {
-    if constexpr (!is_type<T, float, sycl::half>()) {
-      static_assert((is_type<T, float, sycl::half>()),
-                    "Type F or HF is expected");
-    }
+    static_assert((is_type<T, float, sycl::half>()),
+                  "Type F or HF is expected");
   }
   if constexpr (Op == __ESIMD_NS::atomic_op::add ||
                 Op == __ESIMD_NS::atomic_op::sub ||
@@ -735,10 +726,7 @@ constexpr void check_atomic() {
                 Op == __ESIMD_NS::atomic_op::bit_xor ||
                 Op == __ESIMD_NS::atomic_op::minsint ||
                 Op == __ESIMD_NS::atomic_op::maxsint) {
-    if constexpr (!IsInt2BytePlus) {
-      static_assert(IsInt2BytePlus,
-                    "Integral 16-bit or wider type is expected");
-    }
+    static_assert(IsInt2BytePlus, "Integral 16-bit or wider type is expected");
     constexpr bool IsSignedMinmax = (Op == __ESIMD_NS::atomic_op::minsint) ||
                                     (Op == __ESIMD_NS::atomic_op::maxsint);
     constexpr bool IsUnsignedMinmax = (Op == __ESIMD_NS::atomic_op::min) ||
@@ -746,11 +734,8 @@ constexpr void check_atomic() {
 
     if constexpr (IsSignedMinmax || IsUnsignedMinmax) {
       constexpr bool SignOK = std::is_signed_v<T> == IsSignedMinmax;
-
-      if constexpr (!SignOK) {
-        static_assert(SignOK, "Signed/unsigned integer type expected for "
-                              "signed/unsigned min/max operation");
-      }
+      static_assert(SignOK, "Signed/unsigned integer type expected for "
+                            "signed/unsigned min/max operation");
     }
   }
 }

--- a/sycl/include/sycl/ext/intel/esimd/native/common.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/native/common.hpp
@@ -1,0 +1,73 @@
+//==-------------- native/memory.hpp - DPC++ Explicit SIMD API -------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Explicit SIMD API types used in native ESIMD APIs.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <sycl/detail/defines_elementary.hpp>
+
+#include <cstdint>
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+namespace ext {
+namespace intel {
+namespace esimd {
+namespace native {
+namespace lsc {
+
+/// @addtogroup sycl_esimd_memory
+/// @{
+
+/// @defgroup sycl_esimd_memory_lsc LSC-specific memory access APIs.
+/// This group combines types and functions specific to LSC, which is available
+/// in Intel GPUs starting from PVC and ACM.
+
+/// @} sycl_esimd_memory
+
+/// @addtogroup sycl_esimd_memory_lsc
+/// @{
+
+// TODO move all LSC-related "common" APIs here
+
+/// LSC atomic operation codes.
+/// <tt>atomic_update<native::lsc::atomic_op::inc>(...);</tt> is a short-cut to
+/// <tt>lsc_atomic_update<atomic_op::inc>(...);</tt> with default cache and data
+/// size controls.
+enum class atomic_op : uint8_t {
+  inc = 0x08,     // atomic integer increment
+  dec = 0x09,     // atomic integer decrement
+  load = 0x0a,    // atomic load
+  store = 0x0b,   // atomic store
+  add = 0x0c,     // atomic integer add
+  sub = 0x0d,     // atomic integer subtract
+  minsint = 0x0e, // atomic signed int min
+  maxsint = 0x0f, // atomic signed int max
+  min = 0x10,     // atomic unsigned int min
+  max = 0x11,     // atomic unsigned int max
+  cmpxchg = 0x12, // atomic int compare and swap
+  fadd = 0x13,    // floating-point add
+  fsub = 0x14,    // floating-point subtract
+  fmin = 0x15,    // floating-point min
+  fmax = 0x16,    // floating-point max
+  fcmpwr = 0x17,  // floating-point CAS
+  bit_and = 0x18, // logical (bitwise) AND
+  bit_or = 0x19,  // logical (bitwise) OR
+  bit_xor = 0x1a, // logical (bitwise) XOR
+};
+
+/// @} sycl_esimd_memory_lsc
+
+} // namespace lsc
+} // namespace native
+} // namespace esimd
+} // namespace intel
+} // namespace ext
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
+} // namespace sycl

--- a/sycl/include/sycl/ext/intel/esimd/native/common.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/native/common.hpp
@@ -16,9 +16,7 @@
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
-namespace ext {
-namespace intel {
-namespace esimd {
+namespace ext::intel::esimd {
 namespace native {
 namespace lsc {
 
@@ -41,33 +39,31 @@ namespace lsc {
 /// <tt>lsc_atomic_update<atomic_op::inc>(...);</tt> with default cache and data
 /// size controls.
 enum class atomic_op : uint8_t {
-  inc = 0x08,     // atomic integer increment
-  dec = 0x09,     // atomic integer decrement
-  load = 0x0a,    // atomic load
-  store = 0x0b,   // atomic store
-  add = 0x0c,     // atomic integer add
-  sub = 0x0d,     // atomic integer subtract
-  minsint = 0x0e, // atomic signed int min
-  maxsint = 0x0f, // atomic signed int max
-  min = 0x10,     // atomic unsigned int min
-  max = 0x11,     // atomic unsigned int max
-  cmpxchg = 0x12, // atomic int compare and swap
-  fadd = 0x13,    // floating-point add
-  fsub = 0x14,    // floating-point subtract
-  fmin = 0x15,    // floating-point min
-  fmax = 0x16,    // floating-point max
-  fcmpwr = 0x17,  // floating-point CAS
-  bit_and = 0x18, // logical (bitwise) AND
-  bit_or = 0x19,  // logical (bitwise) OR
-  bit_xor = 0x1a, // logical (bitwise) XOR
+  inc = 0x08,      // atomic integer increment
+  dec = 0x09,      // atomic integer decrement
+  load = 0x0a,     // atomic load
+  store = 0x0b,    // atomic store
+  add = 0x0c,      // atomic integer add
+  sub = 0x0d,      // atomic integer subtract
+  smin = 0x0e,     // atomic signed int min
+  smax = 0x0f,     // atomic signed int max
+  umin = 0x10,     // atomic unsigned int min
+  umax = 0x11,     // atomic unsigned int max
+  cmpxchg = 0x12,  // atomic int compare and swap
+  fadd = 0x13,     // floating-point add
+  fsub = 0x14,     // floating-point subtract
+  fmin = 0x15,     // floating-point min
+  fmax = 0x16,     // floating-point max
+  fcmpxchg = 0x17, // floating-point CAS
+  bit_and = 0x18,  // logical (bitwise) AND
+  bit_or = 0x19,   // logical (bitwise) OR
+  bit_xor = 0x1a,  // logical (bitwise) XOR
 };
 
 /// @} sycl_esimd_memory_lsc
 
 } // namespace lsc
 } // namespace native
-} // namespace esimd
-} // namespace intel
-} // namespace ext
+} // namespace ext::intel::esimd
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/experimental/esimd/common.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/common.hpp
@@ -5,24 +5,23 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// definitions used in experimental Explicit SIMD APIs.
+// Common definitions used in experimental Explicit SIMD APIs.
 //===----------------------------------------------------------------------===//
 
 #pragma once
 
-#include <sycl/ext/intel/esimd/common.hpp>
+#include <sycl/ext/intel/esimd/detail/defines_elementary.hpp>
+#include <sycl/ext/intel/esimd/native/common.hpp>
 
-/// @cond ESIMD_DETAIL
-
-// Macros for internal use
-#define __ESIMD_ENS sycl::ext::intel::experimental::esimd
-#define __ESIMD_EDNS sycl::ext::intel::experimental::esimd::detail
-
-/// @endcond ESIMD_DETAIL
+#include <cstdint>
+#include <type_traits>
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
-namespace ext::intel::experimental::esimd {
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
 
 /// @addtogroup sycl_esimd_core
 /// @{
@@ -87,28 +86,6 @@ enum class lsc_data_size : uint8_t {
 };
 
 namespace detail {
-/// LSC atomic operations op codes
-enum class lsc_atomic_op : uint8_t {
-  iinc = 0x08,    // atomic integer increment
-  idec = 0x09,    // atomic integer decrement
-  load = 0x0a,    // atomic load
-  store = 0x0b,   // atomic store
-  iadd = 0x0c,    // atomic integer add
-  isub = 0x0d,    // atomic integer subtract
-  smin = 0x0e,    // atomic signed int min
-  smax = 0x0f,    // atomic signed int max
-  umin = 0x10,    // atomic unsigned int min
-  umax = 0x11,    // atomic unsigned int max
-  icas = 0x12,    // atomic int compare and swap
-  fadd = 0x13,    // floating-point add
-  fsub = 0x14,    // floating-point subtract
-  fmin = 0x15,    // floating-point min
-  fmax = 0x16,    // floating-point max
-  fcas = 0x17,    // floating-point CAS
-  bit_and = 0x18, // logical (bitwise) AND
-  bit_or = 0x19,  // logical (bitwise) OR
-  bit_xor = 0x1a, // logical (bitwise) XOR
-};
 
 enum class lsc_vector_size : uint8_t {
   n1 = 1,
@@ -144,106 +121,6 @@ template <typename T, lsc_data_size DS> constexpr void check_lsc_data_size() {
   static_assert(DS != lsc_data_size::default_size || sizeof(T) == 1 ||
                     sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8,
                 "Unsupported data type");
-}
-
-template <__ESIMD_NS::atomic_op Op> constexpr void check_lsc_atomic_op() {
-  static_assert(Op == __ESIMD_NS::atomic_op::add ||
-                    Op == __ESIMD_NS::atomic_op::sub ||
-                    Op == __ESIMD_NS::atomic_op::inc ||
-                    Op == __ESIMD_NS::atomic_op::dec ||
-                    Op == __ESIMD_NS::atomic_op::min ||
-                    Op == __ESIMD_NS::atomic_op::max ||
-                    Op == __ESIMD_NS::atomic_op::cmpxchg ||
-                    Op == __ESIMD_NS::atomic_op::bit_and ||
-                    Op == __ESIMD_NS::atomic_op::bit_or ||
-                    Op == __ESIMD_NS::atomic_op::bit_xor ||
-                    Op == __ESIMD_NS::atomic_op::minsint ||
-                    Op == __ESIMD_NS::atomic_op::maxsint ||
-                    Op == __ESIMD_NS::atomic_op::fmax ||
-                    Op == __ESIMD_NS::atomic_op::fmin ||
-                    Op == __ESIMD_NS::atomic_op::fcmpwr ||
-                    Op == __ESIMD_NS::atomic_op::fadd ||
-                    Op == __ESIMD_NS::atomic_op::fsub ||
-                    Op == __ESIMD_NS::atomic_op::load ||
-                    Op == __ESIMD_NS::atomic_op::store,
-                "Unsupported operation for LSC atomics");
-}
-
-/// Check the legality of lsc xatomic call in terms of size and type.
-template <__ESIMD_NS::atomic_op Op, unsigned NumSrc>
-constexpr void check_lsc_atomic() {
-  check_lsc_atomic_op<Op>();
-  if constexpr (Op == __ESIMD_NS::atomic_op::inc ||
-                Op == __ESIMD_NS::atomic_op::dec ||
-                Op == __ESIMD_NS::atomic_op::load) {
-    static_assert(NumSrc == 0, "No source operands are expected");
-  }
-  if constexpr (Op == __ESIMD_NS::atomic_op::store ||
-                Op == __ESIMD_NS::atomic_op::add ||
-                Op == __ESIMD_NS::atomic_op::sub ||
-                Op == __ESIMD_NS::atomic_op::minsint ||
-                Op == __ESIMD_NS::atomic_op::maxsint ||
-                Op == __ESIMD_NS::atomic_op::min ||
-                Op == __ESIMD_NS::atomic_op::max ||
-                Op == __ESIMD_NS::atomic_op::fadd ||
-                Op == __ESIMD_NS::atomic_op::fsub ||
-                Op == __ESIMD_NS::atomic_op::fmin ||
-                Op == __ESIMD_NS::atomic_op::fmax ||
-                Op == __ESIMD_NS::atomic_op::bit_and ||
-                Op == __ESIMD_NS::atomic_op::bit_or ||
-                Op == __ESIMD_NS::atomic_op::bit_xor) {
-    static_assert(NumSrc == 1, "One source operand is expected");
-  }
-  if constexpr (Op == __ESIMD_NS::atomic_op::cmpxchg ||
-                Op == __ESIMD_NS::atomic_op::fcmpwr) {
-    static_assert(NumSrc == 2, "Two source operands are expected");
-  }
-}
-
-template <__ESIMD_NS::atomic_op Op> constexpr lsc_atomic_op to_lsc_atomic_op() {
-  check_lsc_atomic_op<Op>();
-  switch (Op) {
-  case __ESIMD_NS::atomic_op::add:
-    return lsc_atomic_op::iadd;
-  case __ESIMD_NS::atomic_op::sub:
-    return lsc_atomic_op::isub;
-  case __ESIMD_NS::atomic_op::inc:
-    return lsc_atomic_op::iinc;
-  case __ESIMD_NS::atomic_op::dec:
-    return lsc_atomic_op::idec;
-  case __ESIMD_NS::atomic_op::min:
-    return lsc_atomic_op::umin;
-  case __ESIMD_NS::atomic_op::max:
-    return lsc_atomic_op::umax;
-  case __ESIMD_NS::atomic_op::cmpxchg:
-    return lsc_atomic_op::icas;
-  case __ESIMD_NS::atomic_op::bit_and:
-    return lsc_atomic_op::bit_and;
-  case __ESIMD_NS::atomic_op::bit_or:
-    return lsc_atomic_op::bit_or;
-  case __ESIMD_NS::atomic_op::bit_xor:
-    return lsc_atomic_op::bit_xor;
-  case __ESIMD_NS::atomic_op::minsint:
-    return lsc_atomic_op::smin;
-  case __ESIMD_NS::atomic_op::maxsint:
-    return lsc_atomic_op::smax;
-  case __ESIMD_NS::atomic_op::fmax:
-    return lsc_atomic_op::fmax;
-  case __ESIMD_NS::atomic_op::fmin:
-    return lsc_atomic_op::fmin;
-  case __ESIMD_NS::atomic_op::fcmpwr:
-    return lsc_atomic_op::fcas;
-  case __ESIMD_NS::atomic_op::fadd:
-    return lsc_atomic_op::fadd;
-  case __ESIMD_NS::atomic_op::fsub:
-    return lsc_atomic_op::fsub;
-  case __ESIMD_NS::atomic_op::load:
-    return lsc_atomic_op::load;
-  case __ESIMD_NS::atomic_op::store:
-    return lsc_atomic_op::store;
-  default:
-    return lsc_atomic_op::iinc;
-  }
 }
 
 template <lsc_vector_size VS> constexpr uint8_t to_int() {
@@ -421,6 +298,9 @@ enum class split_barrier_action : uint8_t {
 
 /// @} sycl_esimd_core
 
-} // namespace ext::intel::experimental::esimd
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/experimental/esimd/common.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/common.hpp
@@ -18,10 +18,7 @@
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
-namespace ext {
-namespace intel {
-namespace experimental {
-namespace esimd {
+namespace ext::intel::experimental::esimd {
 
 /// @addtogroup sycl_esimd_core
 /// @{
@@ -298,9 +295,6 @@ enum class split_barrier_action : uint8_t {
 
 /// @} sycl_esimd_core
 
-} // namespace esimd
-} // namespace experimental
-} // namespace intel
-} // namespace ext
+} // namespace ext::intel::experimental::esimd
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/math_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/math_intrin.hpp
@@ -14,7 +14,6 @@
 
 #include <sycl/ext/intel/esimd/detail/defines_elementary.hpp>
 #include <sycl/ext/intel/esimd/detail/types.hpp>
-// #include <sycl/ext/intel/esimd/detail/math_intrin.hpp>
 
 #define __ESIMD_raw_vec_t(T, SZ)                                               \
   sycl::ext::intel::esimd::detail::vector_type_t<                              \

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/math_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/math_intrin.hpp
@@ -12,12 +12,16 @@
 
 /// @cond ESIMD_DETAIL
 
-#include <sycl/ext/intel/esimd/detail/math_intrin.hpp>
+#include <sycl/ext/intel/esimd/detail/defines_elementary.hpp>
+#include <sycl/ext/intel/esimd/detail/types.hpp>
+// #include <sycl/ext/intel/esimd/detail/math_intrin.hpp>
 
 #define __ESIMD_raw_vec_t(T, SZ)                                               \
-  __ESIMD_DNS::vector_type_t<__ESIMD_DNS::__raw_t<T>, SZ>
+  sycl::ext::intel::esimd::detail::vector_type_t<                              \
+      sycl::ext::intel::esimd::detail::__raw_t<T>, SZ>
 #define __ESIMD_cpp_vec_t(T, SZ)                                               \
-  __ESIMD_DNS::vector_type_t<__ESIMD_DNS::__cpp_t<T>, SZ>
+  sycl::ext::intel::esimd::detail::vector_type_t<                              \
+      sycl::ext::intel::esimd::detail::__cpp_t<T>, SZ>
 
 template <typename T0, typename T1, int SZ>
 __ESIMD_INTRIN __ESIMD_raw_vec_t(T0, SZ)

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <sycl/ext/intel/esimd/detail/atomic_intrin.hpp>
+#include <sycl/ext/intel/esimd/detail/defines_elementary.hpp>
 #include <sycl/ext/intel/esimd/detail/memory_intrin.hpp>
 
 // generic work-group split barrier
@@ -576,8 +577,8 @@ void __esimd_emu_write_2d(__ESIMD_DNS::simd_mask_storage_t<N> Pred,
 
 /// Helper function for zero-source LSC-atomic operation accessing BTI
 /// or SLM
-template <typename Ty, __ESIMD_EDNS::lsc_atomic_op Op, uint16_t AddressScale,
-          int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
+template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
+          uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
           __ESIMD_EDNS::lsc_vector_size VS,
           __ESIMD_EDNS::lsc_data_order _Transposed, int N, uint32_t MASK>
 auto __esimd_emu_lsc_xatomic_offset_access_0(
@@ -609,10 +610,10 @@ auto __esimd_emu_lsc_xatomic_offset_access_0(
 
       if ((ByteDistance >= 0) && (ByteDistance < BufByteWidth)) {
         Output[VecIdx] = *((Ty *)(BaseAddr + ByteDistance));
-        if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::iinc) {
+        if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::inc) {
           __ESIMD_DNS::atomic_add_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                             static_cast<Ty>(1));
-        } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::idec) {
+        } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::dec) {
           __ESIMD_DNS::atomic_sub_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                             static_cast<Ty>(1));
         }
@@ -624,8 +625,8 @@ auto __esimd_emu_lsc_xatomic_offset_access_0(
 
 /// Helper function for one-source LSC-atomic operation accessing BTI
 /// or SLM
-template <typename Ty, __ESIMD_EDNS::lsc_atomic_op Op, uint16_t AddressScale,
-          int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
+template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
+          uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
           __ESIMD_EDNS::lsc_vector_size VS,
           __ESIMD_EDNS::lsc_data_order _Transposed, int N, uint32_t MASK>
 auto __esimd_emu_lsc_xatomic_offset_access_1(
@@ -665,60 +666,64 @@ auto __esimd_emu_lsc_xatomic_offset_access_1(
         // Keeping original values for return
         Output[VecIdx] = *((Ty *)(BaseAddr + ByteDistance));
 
-        if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::store) {
+        if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::store) {
           __ESIMD_DNS::atomic_store<Ty>((Ty *)(BaseAddr + ByteDistance),
                                         src0[VecIdx]);
-        } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::iadd) {
+        } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::add) {
           __ESIMD_DNS::atomic_add_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                             src0[VecIdx]);
-        } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::isub) {
+        } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::sub) {
           __ESIMD_DNS::atomic_sub_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                             src0[VecIdx]);
-        } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::smin) {
+        } else if constexpr (Op ==
+                             __ESIMD_NS::native::lsc::atomic_op::minsint) {
           __ESIMD_DNS::atomic_min<Ty>((Ty *)(BaseAddr + ByteDistance),
                                       src0[VecIdx]);
-        } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::smax) {
+        } else if constexpr (Op ==
+                             __ESIMD_NS::native::lsc::atomic_op::maxsint) {
           __ESIMD_DNS::atomic_max<Ty>((Ty *)(BaseAddr + ByteDistance),
                                       src0[VecIdx]);
-        } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::umin) {
+        } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::min) {
           if constexpr (!__ESIMD_DNS::is_fp_type<Ty>::value) {
             __ESIMD_DNS::atomic_min<Ty>((Ty *)(BaseAddr + ByteDistance),
                                         src0[VecIdx]);
           }
-        } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::umax) {
+        } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::max) {
           if constexpr (!__ESIMD_DNS::is_fp_type<Ty>::value) {
             __ESIMD_DNS::atomic_max<Ty>((Ty *)(BaseAddr + ByteDistance),
                                         src0[VecIdx]);
           }
-        } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::fadd) {
+        } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::fadd) {
           if constexpr (__ESIMD_DNS::is_fp_type<Ty>::value) {
             __ESIMD_DNS::atomic_add_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                               src0[VecIdx]);
           }
-        } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::fsub) {
+        } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::fsub) {
           if constexpr (__ESIMD_DNS::is_fp_type<Ty>::value) {
             __ESIMD_DNS::atomic_sub_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                               src0[VecIdx]);
           }
-        } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::fmin) {
+        } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::fmin) {
           if constexpr (__ESIMD_DNS::is_fp_type<Ty>::value) {
             __ESIMD_DNS::atomic_min<Ty>((Ty *)(BaseAddr + ByteDistance),
                                         src0[VecIdx]);
           }
-        } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::fmax) {
+        } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::fmax) {
           if constexpr (__ESIMD_DNS::is_fp_type<Ty>::value) {
             __ESIMD_DNS::atomic_max<Ty>((Ty *)(BaseAddr + ByteDistance),
                                         src0[VecIdx]);
           }
-        } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::bit_and) {
+        } else if constexpr (Op ==
+                             __ESIMD_NS::native::lsc::atomic_op::bit_and) {
           // TODO : Type Check? Integral type only?
           __ESIMD_DNS::atomic_and_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                             src0[VecIdx]);
-        } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::bit_or) {
+        } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::bit_or) {
           // TODO : Type Check? Integral type only?
           __ESIMD_DNS::atomic_or_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                            src0[VecIdx]);
-        } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::bit_xor) {
+        } else if constexpr (Op ==
+                             __ESIMD_NS::native::lsc::atomic_op::bit_xor) {
           // TODO : Type Check? Integral type only?
           __ESIMD_DNS::atomic_xor_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                             src0[VecIdx]);
@@ -731,8 +736,8 @@ auto __esimd_emu_lsc_xatomic_offset_access_1(
 
 /// Helper function for two-source LSC-atomic operation accessing BTI
 /// or SLM
-template <typename Ty, __ESIMD_EDNS::lsc_atomic_op Op, uint16_t AddressScale,
-          int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
+template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
+          uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
           __ESIMD_EDNS::lsc_vector_size VS,
           __ESIMD_EDNS::lsc_data_order _Transposed, int N, uint32_t MASK>
 auto __esimd_emu_lsc_xatomic_offset_access_2(
@@ -773,10 +778,10 @@ auto __esimd_emu_lsc_xatomic_offset_access_2(
         // Keeping original values for return
         Output[VecIdx] = *((Ty *)(BaseAddr + ByteDistance));
 
-        if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::icas) {
+        if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::cmpxchg) {
           __ESIMD_DNS::atomic_cmpxchg((Ty *)(BaseAddr + ByteDistance),
                                       src0[VecIdx], src1[VecIdx]);
-        } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::fcas) {
+        } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::fcmpwr) {
           if constexpr (__ESIMD_DNS::is_fp_type<Ty>::value) {
             __ESIMD_DNS::atomic_cmpxchg((Ty *)(BaseAddr + ByteDistance),
                                         src0[VecIdx], src1[VecIdx]);
@@ -1327,7 +1332,7 @@ __esimd_lsc_store2d_stateless(__ESIMD_DNS::simd_mask_storage_t<N> Pred,
 /// @tparam N is the SIMD size of operation (the number of addresses to access)
 /// @param pred is predicates.
 /// @param offsets is the zero-based offsets.
-template <typename Ty, __ESIMD_EDNS::lsc_atomic_op Op,
+template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
           __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
           uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
           __ESIMD_EDNS::lsc_vector_size VS,
@@ -1365,7 +1370,7 @@ __esimd_lsc_xatomic_slm_0(__ESIMD_DNS::simd_mask_storage_t<N> pred,
 /// @param pred is predicates.
 /// @param offsets is the zero-based offsets.
 /// @param src0 is the first atomic operand.
-template <typename Ty, __ESIMD_EDNS::lsc_atomic_op Op,
+template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
           __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
           uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
           __ESIMD_EDNS::lsc_vector_size VS,
@@ -1406,7 +1411,7 @@ __esimd_lsc_xatomic_slm_1(
 /// @param offsets is the zero-based offsets.
 /// @param src0 is the first atomic operand.
 /// @param src1 is the second atomic operand.
-template <typename Ty, __ESIMD_EDNS::lsc_atomic_op Op,
+template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
           __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
           uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
           __ESIMD_EDNS::lsc_vector_size VS,
@@ -1448,11 +1453,12 @@ __esimd_lsc_xatomic_slm_2(
 /// @param pred is predicates.
 /// @param offsets is the zero-based offsets.
 /// @param surf_ind is the surface index.
-template <
-    typename Ty, __ESIMD_EDNS::lsc_atomic_op Op, __ESIMD_ENS::cache_hint L1H,
-    __ESIMD_ENS::cache_hint L3H, uint16_t AddressScale, int ImmOffset,
-    __ESIMD_ENS::lsc_data_size DS, __ESIMD_EDNS::lsc_vector_size VS,
-    __ESIMD_EDNS::lsc_data_order _Transposed, int N, typename SurfIndAliasTy>
+template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
+          __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
+          uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
+          __ESIMD_EDNS::lsc_vector_size VS,
+          __ESIMD_EDNS::lsc_data_order _Transposed, int N,
+          typename SurfIndAliasTy>
 __ESIMD_INTRIN __ESIMD_DNS::vector_type_t<Ty, N * __ESIMD_EDNS::to_int<VS>()>
 __esimd_lsc_xatomic_bti_0(__ESIMD_DNS::simd_mask_storage_t<N> pred,
                           __ESIMD_DNS::vector_type_t<uint32_t, N> offsets,
@@ -1498,11 +1504,12 @@ __esimd_lsc_xatomic_bti_0(__ESIMD_DNS::simd_mask_storage_t<N> pred,
 /// @param offsets is the zero-based offsets.
 /// @param src0 is the first atomic operand.
 /// @param surf_ind is the surface index.
-template <
-    typename Ty, __ESIMD_EDNS::lsc_atomic_op Op, __ESIMD_ENS::cache_hint L1H,
-    __ESIMD_ENS::cache_hint L3H, uint16_t AddressScale, int ImmOffset,
-    __ESIMD_ENS::lsc_data_size DS, __ESIMD_EDNS::lsc_vector_size VS,
-    __ESIMD_EDNS::lsc_data_order _Transposed, int N, typename SurfIndAliasTy>
+template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
+          __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
+          uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
+          __ESIMD_EDNS::lsc_vector_size VS,
+          __ESIMD_EDNS::lsc_data_order _Transposed, int N,
+          typename SurfIndAliasTy>
 __ESIMD_INTRIN __ESIMD_DNS::vector_type_t<Ty, N * __ESIMD_EDNS::to_int<VS>()>
 __esimd_lsc_xatomic_bti_1(
     __ESIMD_DNS::simd_mask_storage_t<N> pred,
@@ -1552,11 +1559,12 @@ __esimd_lsc_xatomic_bti_1(
 /// @param src0 is the first atomic operand.
 /// @param src1 is the second atomic operand.
 /// @param surf_ind is the surface index.
-template <
-    typename Ty, __ESIMD_EDNS::lsc_atomic_op Op, __ESIMD_ENS::cache_hint L1H,
-    __ESIMD_ENS::cache_hint L3H, uint16_t AddressScale, int ImmOffset,
-    __ESIMD_ENS::lsc_data_size DS, __ESIMD_EDNS::lsc_vector_size VS,
-    __ESIMD_EDNS::lsc_data_order _Transposed, int N, typename SurfIndAliasTy>
+template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
+          __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
+          uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
+          __ESIMD_EDNS::lsc_vector_size VS,
+          __ESIMD_EDNS::lsc_data_order _Transposed, int N,
+          typename SurfIndAliasTy>
 __ESIMD_INTRIN __ESIMD_DNS::vector_type_t<Ty, N * __ESIMD_EDNS::to_int<VS>()>
 __esimd_lsc_xatomic_bti_2(
     __ESIMD_DNS::simd_mask_storage_t<N> pred,
@@ -1603,7 +1611,7 @@ __esimd_lsc_xatomic_bti_2(
 /// @tparam N is the SIMD size of operation (the number of addresses to access)
 /// @param pred is predicates.
 /// @param addrs is the prefetch addresses.
-template <typename Ty, __ESIMD_EDNS::lsc_atomic_op Op,
+template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
           __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
           uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
           __ESIMD_EDNS::lsc_vector_size VS,
@@ -1644,10 +1652,10 @@ __esimd_lsc_xatomic_stateless_0(__ESIMD_DNS::simd_mask_storage_t<N> pred,
       // Keeping original values for return + 'load'
       Output[VecIdx] = *((Ty *)(BaseAddr + ByteDistance));
 
-      if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::iinc) {
+      if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::inc) {
         __ESIMD_DNS::atomic_add_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                           static_cast<Ty>(1));
-      } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::idec) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::dec) {
         __ESIMD_DNS::atomic_sub_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                           static_cast<Ty>(1));
       }
@@ -1674,7 +1682,7 @@ __esimd_lsc_xatomic_stateless_0(__ESIMD_DNS::simd_mask_storage_t<N> pred,
 /// @param pred is predicates.
 /// @param addrs is the prefetch addresses.
 /// @param src0 is the first atomic operand.
-template <typename Ty, __ESIMD_EDNS::lsc_atomic_op Op,
+template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
           __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
           uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
           __ESIMD_EDNS::lsc_vector_size VS,
@@ -1717,60 +1725,60 @@ __esimd_lsc_xatomic_stateless_1(
       // Keeping original values for return
       Output[VecIdx] = *((Ty *)(BaseAddr + ByteDistance));
 
-      if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::store) {
+      if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::store) {
         __ESIMD_DNS::atomic_store<Ty>((Ty *)(BaseAddr + ByteDistance),
                                       src0[VecIdx]);
-      } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::iadd) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::add) {
         __ESIMD_DNS::atomic_add_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                           src0[VecIdx]);
-      } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::isub) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::sub) {
         __ESIMD_DNS::atomic_sub_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                           src0[VecIdx]);
-      } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::smin) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::minsint) {
         __ESIMD_DNS::atomic_min<Ty>((Ty *)(BaseAddr + ByteDistance),
                                     src0[VecIdx]);
-      } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::smax) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::maxsint) {
         __ESIMD_DNS::atomic_max<Ty>((Ty *)(BaseAddr + ByteDistance),
                                     src0[VecIdx]);
-      } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::umin) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::min) {
         if constexpr (!__ESIMD_DNS::is_fp_type<Ty>::value) {
           __ESIMD_DNS::atomic_min<Ty>((Ty *)(BaseAddr + ByteDistance),
                                       src0[VecIdx]);
         }
-      } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::umax) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::max) {
         if constexpr (!__ESIMD_DNS::is_fp_type<Ty>::value) {
           __ESIMD_DNS::atomic_max<Ty>((Ty *)(BaseAddr + ByteDistance),
                                       src0[VecIdx]);
         }
-      } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::fadd) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::fadd) {
         if constexpr (__ESIMD_DNS::is_fp_type<Ty>::value) {
           __ESIMD_DNS::atomic_add_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                             src0[VecIdx]);
         }
-      } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::fsub) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::fsub) {
         if constexpr (__ESIMD_DNS::is_fp_type<Ty>::value) {
           __ESIMD_DNS::atomic_sub_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                             src0[VecIdx]);
         }
-      } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::fmin) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::fmin) {
         if constexpr (__ESIMD_DNS::is_fp_type<Ty>::value) {
           __ESIMD_DNS::atomic_min<Ty>((Ty *)(BaseAddr + ByteDistance),
                                       src0[VecIdx]);
         }
-      } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::fmax) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::fmax) {
         if constexpr (__ESIMD_DNS::is_fp_type<Ty>::value) {
           __ESIMD_DNS::atomic_max<Ty>((Ty *)(BaseAddr + ByteDistance),
                                       src0[VecIdx]);
         }
-      } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::bit_and) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::bit_and) {
         // TODO : Type Check? Integral type only?
         __ESIMD_DNS::atomic_and_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                           src0[VecIdx]);
-      } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::bit_or) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::bit_or) {
         // TODO : Type Check? Integral type only?
         __ESIMD_DNS::atomic_or_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                          src0[VecIdx]);
-      } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::bit_xor) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::bit_xor) {
         // TODO : Type Check? Integral type only?
         __ESIMD_DNS::atomic_xor_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                           src0[VecIdx]);
@@ -1798,7 +1806,7 @@ __esimd_lsc_xatomic_stateless_1(
 /// @param addrs is the prefetch addresses.
 /// @param src0 is the first atomic operand.
 /// @param src1 is the second atomic operand.
-template <typename Ty, __ESIMD_EDNS::lsc_atomic_op Op,
+template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
           __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
           uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
           __ESIMD_EDNS::lsc_vector_size VS,
@@ -1842,10 +1850,10 @@ __esimd_lsc_xatomic_stateless_2(
       // Keeping original values for return
       Output[VecIdx] = *((Ty *)(BaseAddr + ByteDistance));
 
-      if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::icas) {
+      if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::cmpxchg) {
         __ESIMD_DNS::atomic_cmpxchg((Ty *)(BaseAddr + ByteDistance),
                                     src0[VecIdx], src1[VecIdx]);
-      } else if constexpr (Op == __ESIMD_EDNS::lsc_atomic_op::fcas) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::fcmpwr) {
         if constexpr (__ESIMD_DNS::is_fp_type<Ty>::value) {
           __ESIMD_DNS::atomic_cmpxchg((Ty *)(BaseAddr + ByteDistance),
                                       src0[VecIdx], src1[VecIdx]);

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
@@ -675,20 +675,18 @@ auto __esimd_emu_lsc_xatomic_offset_access_1(
         } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::sub) {
           __ESIMD_DNS::atomic_sub_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                             src0[VecIdx]);
-        } else if constexpr (Op ==
-                             __ESIMD_NS::native::lsc::atomic_op::minsint) {
+        } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::smin) {
           __ESIMD_DNS::atomic_min<Ty>((Ty *)(BaseAddr + ByteDistance),
                                       src0[VecIdx]);
-        } else if constexpr (Op ==
-                             __ESIMD_NS::native::lsc::atomic_op::maxsint) {
+        } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::smax) {
           __ESIMD_DNS::atomic_max<Ty>((Ty *)(BaseAddr + ByteDistance),
                                       src0[VecIdx]);
-        } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::min) {
+        } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::umin) {
           if constexpr (!__ESIMD_DNS::is_fp_type<Ty>::value) {
             __ESIMD_DNS::atomic_min<Ty>((Ty *)(BaseAddr + ByteDistance),
                                         src0[VecIdx]);
           }
-        } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::max) {
+        } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::umax) {
           if constexpr (!__ESIMD_DNS::is_fp_type<Ty>::value) {
             __ESIMD_DNS::atomic_max<Ty>((Ty *)(BaseAddr + ByteDistance),
                                         src0[VecIdx]);
@@ -781,7 +779,8 @@ auto __esimd_emu_lsc_xatomic_offset_access_2(
         if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::cmpxchg) {
           __ESIMD_DNS::atomic_cmpxchg((Ty *)(BaseAddr + ByteDistance),
                                       src0[VecIdx], src1[VecIdx]);
-        } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::fcmpwr) {
+        } else if constexpr (Op ==
+                             __ESIMD_NS::native::lsc::atomic_op::fcmpxchg) {
           if constexpr (__ESIMD_DNS::is_fp_type<Ty>::value) {
             __ESIMD_DNS::atomic_cmpxchg((Ty *)(BaseAddr + ByteDistance),
                                         src0[VecIdx], src1[VecIdx]);
@@ -1734,18 +1733,18 @@ __esimd_lsc_xatomic_stateless_1(
       } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::sub) {
         __ESIMD_DNS::atomic_sub_fetch<Ty>((Ty *)(BaseAddr + ByteDistance),
                                           src0[VecIdx]);
-      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::minsint) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::smin) {
         __ESIMD_DNS::atomic_min<Ty>((Ty *)(BaseAddr + ByteDistance),
                                     src0[VecIdx]);
-      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::maxsint) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::smax) {
         __ESIMD_DNS::atomic_max<Ty>((Ty *)(BaseAddr + ByteDistance),
                                     src0[VecIdx]);
-      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::min) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::umin) {
         if constexpr (!__ESIMD_DNS::is_fp_type<Ty>::value) {
           __ESIMD_DNS::atomic_min<Ty>((Ty *)(BaseAddr + ByteDistance),
                                       src0[VecIdx]);
         }
-      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::max) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::umax) {
         if constexpr (!__ESIMD_DNS::is_fp_type<Ty>::value) {
           __ESIMD_DNS::atomic_max<Ty>((Ty *)(BaseAddr + ByteDistance),
                                       src0[VecIdx]);
@@ -1853,7 +1852,7 @@ __esimd_lsc_xatomic_stateless_2(
       if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::cmpxchg) {
         __ESIMD_DNS::atomic_cmpxchg((Ty *)(BaseAddr + ByteDistance),
                                     src0[VecIdx], src1[VecIdx]);
-      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::fcmpwr) {
+      } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::fcmpxchg) {
         if constexpr (__ESIMD_DNS::is_fp_type<Ty>::value) {
           __ESIMD_DNS::atomic_cmpxchg((Ty *)(BaseAddr + ByteDistance),
                                       src0[VecIdx], src1[VecIdx]);

--- a/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <sycl/ext/intel/esimd/detail/defines_elementary.hpp>
+#include <sycl/ext/intel/esimd/detail/types.hpp>
 #include <sycl/ext/intel/esimd/math.hpp>
 #include <sycl/ext/intel/experimental/esimd/common.hpp>
 #include <sycl/ext/intel/experimental/esimd/detail/math_intrin.hpp>
@@ -1976,8 +1978,9 @@ __ESIMD_API __ESIMD_NS::simd<T, N>
 dpasw(__ESIMD_NS::simd<T, N> src0, __ESIMD_NS::simd<T1, N1> src1,
       __ESIMD_NS::simd<T2, N2> src2, Sat sat = {}) {
   constexpr bool is_4xhf =
-      (__ESIMD_DNS::is_type<T, sycl::detail::half_impl::StorageT>()) &&
-      src1_precision == src2_precision && src1_precision == argument_type::FP16;
+      std::is_same_v<T, __ESIMD_DNS::__raw_t<sycl::half>> &&
+      (src1_precision == src2_precision) &&
+      (src1_precision == argument_type::FP16);
 
   constexpr bool is_4xbf = __ESIMD_DNS::is_word_type<T>::value &&
                            src1_precision == src2_precision &&
@@ -2049,7 +2052,7 @@ __ESIMD_API __ESIMD_NS::simd<T, N> dpasw2(__ESIMD_NS::simd<T1, N1> src1,
                                           __ESIMD_NS::simd<T2, N2> src2,
                                           Sat sat = {}) {
   constexpr bool is_4xhf =
-      (__ESIMD_DNS::is_type<T, sycl::detail::half_impl::StorageT>()) &&
+      std::is_same_v<T, __ESIMD_DNS::__raw_t<sycl::half>> &&
       src1_precision == src2_precision && src1_precision == argument_type::FP16;
 
   constexpr bool is_4xbf = __ESIMD_DNS::is_word_type<T>::value &&

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -283,15 +283,6 @@ lsc_format_ret(__ESIMD_NS::simd<T1, N> Vals) {
   return Formatted.template select<N, Stride>(0);
 }
 
-/// Base case for checking if a type U is one of the types.
-template <typename U> constexpr bool is_type() { return false; }
-
-template <typename U, typename T, typename... Ts> constexpr bool is_type() {
-  using UU = typename std::remove_const_t<U>;
-  using TT = typename std::remove_const_t<T>;
-  return std::is_same<UU, TT>::value || is_type<UU, Ts...>();
-}
-
 /// Check the legality of lsc atomic call in terms of size and type.
 template <__ESIMD_NS::native::lsc::atomic_op Op, typename T, int N,
           unsigned NumSrc>
@@ -1607,6 +1598,39 @@ __ESIMD_API void lsc_fence(__ESIMD_NS::simd_mask<N> pred = 1) {
 
 } // namespace esimd
 } // namespace experimental
+
+namespace esimd {
+
+/// LSC version of no argument variant of the \c atomic_update - accepts
+/// <tt>native::lsc::atomic_op</tt> instead of <tt>atomic_op</tt> as atomic
+/// operation template argument.
+template <native::lsc::atomic_op Op, typename T, int N>
+__ESIMD_API simd<T, N> atomic_update(T *p, simd<unsigned, N> offset,
+                                     simd_mask<N> mask) {
+  return __ESIMD_ENS::lsc_atomic_update<detail::to_atomic_op<Op>(), T, N>(
+      p, offset, mask);
+}
+
+/// LSC version of the single-argument atomic update.
+template <native::lsc::atomic_op Op, typename T, int N>
+__ESIMD_API simd<T, N> atomic_update(T *p, simd<unsigned, N> offset,
+                                     simd<T, N> src0, simd_mask<N> mask) {
+  return __ESIMD_ENS::lsc_atomic_update<detail::to_atomic_op<Op>(), T, N>(
+      p, offset, src0, mask);
+}
+
+/// LSC version of the two-argument atomic update.
+template <native::lsc::atomic_op Op, typename T, int N>
+__ESIMD_API simd<T, N> atomic_update(T *p, simd<unsigned, N> offset,
+                                     simd<T, N> src0, simd<T, N> src1,
+                                     simd_mask<N> mask) {
+  return __ESIMD_ENS::lsc_atomic_update<detail::to_atomic_op<Op>(), T, N>(
+      p, offset, src0, src1, mask);
+}
+
+} // namespace esimd
+
+
 } // namespace intel
 } // namespace ext
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -10,16 +10,17 @@
 
 #pragma once
 
+#include <sycl/ext/intel/esimd/common.hpp>
 #include <sycl/ext/intel/esimd/memory.hpp>
-#include <sycl/ext/intel/experimental/esimd/common.hpp>
 #include <sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp>
 #include <sycl/ext/intel/experimental/esimd/detail/util.hpp>
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
-namespace ext::intel::experimental::esimd {
-
-#define __ESIMD_GET_SURF_HANDLE(acc) __ESIMD_NS::get_surface_index(acc)
+namespace ext {
+namespace intel {
+namespace experimental {
+namespace esimd {
 
 /// @addtogroup sycl_esimd_memory
 /// @{
@@ -281,6 +282,38 @@ lsc_format_ret(__ESIMD_NS::simd<T1, N> Vals) {
   constexpr int Stride = Formatted.length / N;
   return Formatted.template select<N, Stride>(0);
 }
+
+/// Base case for checking if a type U is one of the types.
+template <typename U> constexpr bool is_type() { return false; }
+
+template <typename U, typename T, typename... Ts> constexpr bool is_type() {
+  using UU = typename std::remove_const_t<U>;
+  using TT = typename std::remove_const_t<T>;
+  return std::is_same<UU, TT>::value || is_type<UU, Ts...>();
+}
+
+/// Check the legality of lsc atomic call in terms of size and type.
+template <__ESIMD_NS::native::lsc::atomic_op Op, typename T, int N,
+          unsigned NumSrc>
+constexpr void check_lsc_atomic() {
+  if constexpr (!__ESIMD_DNS::isPowerOf2(N, 32)) {
+    static_assert((__ESIMD_DNS::isPowerOf2(N, 32)),
+                  "Execution size 1, 2, 4, 8, 16, 32 are supported");
+  }
+  if constexpr (NumSrc != __ESIMD_DNS::get_num_args<Op>()) {
+    static_assert(NumSrc == __ESIMD_DNS::get_num_args<Op>(),
+                  "wrong number of operands");
+  }
+  if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::fcmpwr) {
+    if constexpr (!is_type<T, float, sycl::half>()) {
+      static_assert((is_type<T, float, sycl::half>()),
+                    "Type F or HF is expected");
+    }
+  } else {
+    __ESIMD_DNS::check_atomic<__ESIMD_DNS::to_atomic_op<Op>(), T, N, NumSrc>();
+  }
+}
+
 } // namespace detail
 
 /// SLM gather.
@@ -395,7 +428,7 @@ lsc_gather(AccessorTy acc, __ESIMD_NS::simd<uint32_t, N> offsets,
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
   using _MsgT = typename detail::lsc_expand_type<T>::type;
-  auto si = __ESIMD_GET_SURF_HANDLE(acc);
+  auto si = __ESIMD_NS::get_surface_index(acc);
   __ESIMD_NS::simd<_MsgT, N *NElts> Tmp =
       __esimd_lsc_load_bti<_MsgT, L1H, L3H, _AddressScale, _ImmOffset, _DS, _VS,
                            _Transposed, N>(pred.data(), offsets.data(), si);
@@ -445,7 +478,7 @@ lsc_block_load(AccessorTy acc, uint32_t offset) {
   constexpr int N = 1;
   __ESIMD_NS::simd_mask<N> pred = 1;
   __ESIMD_NS::simd<uint32_t, N> offsets = offset;
-  auto si = __ESIMD_GET_SURF_HANDLE(acc);
+  auto si = __ESIMD_NS::get_surface_index(acc);
   return __esimd_lsc_load_bti<T, L1H, L3H, _AddressScale, _ImmOffset, _DS, _VS,
                               _Transposed, N>(pred.data(), offsets.data(), si);
 #endif
@@ -573,7 +606,7 @@ lsc_prefetch(AccessorTy acc, __ESIMD_NS::simd<uint32_t, N> offsets,
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
   using _MsgT = typename detail::lsc_expand_type<T>::type;
-  auto si = __ESIMD_GET_SURF_HANDLE(acc);
+  auto si = __ESIMD_NS::get_surface_index(acc);
   __esimd_lsc_prefetch_bti<_MsgT, L1H, L3H, _AddressScale, _ImmOffset, _DS, _VS,
                            _Transposed, N>(pred.data(), offsets.data(), si);
 #endif
@@ -619,7 +652,7 @@ lsc_prefetch(AccessorTy acc, uint32_t offset) {
   constexpr int N = 1;
   __ESIMD_NS::simd_mask<N> pred = 1;
   __ESIMD_NS::simd<uint32_t, N> offsets = offset;
-  auto si = __ESIMD_GET_SURF_HANDLE(acc);
+  auto si = __ESIMD_NS::get_surface_index(acc);
   __esimd_lsc_prefetch_bti<T, L1H, L3H, _AddressScale, _ImmOffset, _DS, _VS,
                            _Transposed, N>(pred.data(), offsets.data(), si);
 #endif
@@ -815,7 +848,7 @@ lsc_scatter(AccessorTy acc, __ESIMD_NS::simd<uint32_t, N> offsets,
   using _MsgT = typename detail::lsc_expand_type<T>::type;
   using _CstT = typename detail::lsc_bitcast_type<T>::type;
   __ESIMD_NS::simd<_MsgT, N *NElts> Tmp = vals.template bit_cast_view<_CstT>();
-  auto si = __ESIMD_GET_SURF_HANDLE(acc);
+  auto si = __ESIMD_NS::get_surface_index(acc);
   __esimd_lsc_store_bti<_MsgT, L1H, L3H, _AddressScale, _ImmOffset, _DS, _VS,
                         _Transposed, N>(pred.data(), offsets.data(), Tmp.data(),
                                         si);
@@ -863,7 +896,7 @@ lsc_block_store(AccessorTy acc, uint32_t offset,
   constexpr int N = 1;
   __ESIMD_NS::simd_mask<N> pred = 1;
   __ESIMD_NS::simd<uint32_t, N> offsets = offset;
-  auto si = __ESIMD_GET_SURF_HANDLE(acc);
+  auto si = __ESIMD_NS::get_surface_index(acc);
   __esimd_lsc_store_bti<T, L1H, L3H, _AddressScale, _ImmOffset, _DS, _VS,
                         _Transposed, N>(pred.data(), offsets.data(),
                                         vals.data(), si);
@@ -1165,9 +1198,11 @@ template <__ESIMD_NS::atomic_op Op, typename T, int N,
 __ESIMD_API __ESIMD_NS::simd<T, N>
 lsc_slm_atomic_update(__ESIMD_NS::simd<uint32_t, N> offsets,
                       __ESIMD_NS::simd_mask<N> pred) {
-  detail::check_lsc_vector_size<1>();
-  detail::check_lsc_data_size<T, DS>();
-  detail::check_lsc_atomic<Op, 0>();
+  __ESIMD_EDNS::check_lsc_vector_size<1>();
+  __ESIMD_EDNS::check_lsc_data_size<T, DS>();
+  constexpr __ESIMD_NS::native::lsc::atomic_op _Op =
+      __ESIMD_DNS::to_lsc_atomic_op<Op>();
+  __ESIMD_EDNS::check_lsc_atomic<_Op, T, N, 0>();
   constexpr uint16_t _AddressScale = 1;
   constexpr int _ImmOffset = 0;
   constexpr lsc_data_size _DS =
@@ -1175,7 +1210,6 @@ lsc_slm_atomic_update(__ESIMD_NS::simd<uint32_t, N> offsets,
   constexpr detail::lsc_vector_size _VS = detail::to_lsc_vector_size<1>();
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
-  constexpr detail::lsc_atomic_op _Op = detail::to_lsc_atomic_op<Op>();
   using _MsgT = typename detail::lsc_expand_type<T>::type;
   __ESIMD_NS::simd<_MsgT, N> Tmp =
       __esimd_lsc_xatomic_slm_0<_MsgT, _Op, cache_hint::none, cache_hint::none,
@@ -1204,7 +1238,9 @@ lsc_slm_atomic_update(__ESIMD_NS::simd<uint32_t, N> offsets,
                       __ESIMD_NS::simd_mask<N> pred) {
   detail::check_lsc_vector_size<1>();
   detail::check_lsc_data_size<T, DS>();
-  detail::check_lsc_atomic<Op, 1>();
+  constexpr __ESIMD_NS::native::lsc::atomic_op _Op =
+      __ESIMD_DNS::to_lsc_atomic_op<Op>();
+  __ESIMD_EDNS::check_lsc_atomic<_Op, T, N, 1>();
   constexpr uint16_t _AddressScale = 1;
   constexpr int _ImmOffset = 0;
   constexpr lsc_data_size _DS =
@@ -1212,7 +1248,6 @@ lsc_slm_atomic_update(__ESIMD_NS::simd<uint32_t, N> offsets,
   constexpr detail::lsc_vector_size _VS = detail::to_lsc_vector_size<1>();
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
-  constexpr detail::lsc_atomic_op _Op = detail::to_lsc_atomic_op<Op>();
   using _MsgT = typename detail::lsc_expand_type<T>::type;
   __ESIMD_NS::simd<_MsgT, N> Tmp =
       __esimd_lsc_xatomic_slm_1<_MsgT, _Op, cache_hint::none, cache_hint::none,
@@ -1243,7 +1278,9 @@ lsc_slm_atomic_update(__ESIMD_NS::simd<uint32_t, N> offsets,
                       __ESIMD_NS::simd_mask<N> pred) {
   detail::check_lsc_vector_size<1>();
   detail::check_lsc_data_size<T, DS>();
-  detail::check_lsc_atomic<Op, 2>();
+  constexpr __ESIMD_NS::native::lsc::atomic_op _Op =
+      __ESIMD_DNS::to_lsc_atomic_op<Op>();
+  __ESIMD_EDNS::check_lsc_atomic<_Op, T, N, 2>();
   constexpr uint16_t _AddressScale = 1;
   constexpr int _ImmOffset = 0;
   constexpr lsc_data_size _DS =
@@ -1251,7 +1288,6 @@ lsc_slm_atomic_update(__ESIMD_NS::simd<uint32_t, N> offsets,
   constexpr detail::lsc_vector_size _VS = detail::to_lsc_vector_size<1>();
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
-  constexpr detail::lsc_atomic_op _Op = detail::to_lsc_atomic_op<Op>();
   using _MsgT = typename detail::lsc_expand_type<T>::type;
   __ESIMD_NS::simd<_MsgT, N> Tmp =
       __esimd_lsc_xatomic_slm_2<_MsgT, _Op, cache_hint::none, cache_hint::none,
@@ -1290,7 +1326,9 @@ lsc_atomic_update(AccessorTy acc, __ESIMD_NS::simd<uint32_t, N> offsets,
 #else
   detail::check_lsc_vector_size<1>();
   detail::check_lsc_data_size<T, DS>();
-  detail::check_lsc_atomic<Op, 0>();
+  constexpr __ESIMD_NS::native::lsc::atomic_op _Op =
+      __ESIMD_DNS::to_lsc_atomic_op<Op>();
+  __ESIMD_EDNS::check_lsc_atomic<_Op, T, N, 0>();
   detail::check_lsc_cache_hint<detail::lsc_action::atomic, L1H, L3H>();
   constexpr uint16_t _AddressScale = 1;
   constexpr int _ImmOffset = 0;
@@ -1299,9 +1337,8 @@ lsc_atomic_update(AccessorTy acc, __ESIMD_NS::simd<uint32_t, N> offsets,
   constexpr detail::lsc_vector_size _VS = detail::to_lsc_vector_size<1>();
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
-  constexpr detail::lsc_atomic_op _Op = detail::to_lsc_atomic_op<Op>();
   using _MsgT = typename detail::lsc_expand_type<T>::type;
-  auto si = __ESIMD_GET_SURF_HANDLE(acc);
+  auto si = __ESIMD_NS::get_surface_index(acc);
   __ESIMD_NS::simd<_MsgT, N> Tmp =
       __esimd_lsc_xatomic_bti_0<_MsgT, _Op, L1H, L3H, _AddressScale, _ImmOffset,
                                 _DS, _VS, _Transposed, N>(pred.data(),
@@ -1340,7 +1377,9 @@ lsc_atomic_update(AccessorTy acc, __ESIMD_NS::simd<uint32_t, N> offsets,
 #else
   detail::check_lsc_vector_size<1>();
   detail::check_lsc_data_size<T, DS>();
-  detail::check_lsc_atomic<Op, 1>();
+  constexpr __ESIMD_NS::native::lsc::atomic_op _Op =
+      __ESIMD_DNS::to_lsc_atomic_op<Op>();
+  __ESIMD_EDNS::check_lsc_atomic<_Op, T, N, 1>();
   detail::check_lsc_cache_hint<detail::lsc_action::atomic, L1H, L3H>();
   constexpr uint16_t _AddressScale = 1;
   constexpr int _ImmOffset = 0;
@@ -1349,9 +1388,8 @@ lsc_atomic_update(AccessorTy acc, __ESIMD_NS::simd<uint32_t, N> offsets,
   constexpr detail::lsc_vector_size _VS = detail::to_lsc_vector_size<1>();
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
-  constexpr detail::lsc_atomic_op _Op = detail::to_lsc_atomic_op<Op>();
   using _MsgT = typename detail::lsc_expand_type<T>::type;
-  auto si = __ESIMD_GET_SURF_HANDLE(acc);
+  auto si = __ESIMD_NS::get_surface_index(acc);
   __ESIMD_NS::simd<_MsgT, N> Tmp =
       __esimd_lsc_xatomic_bti_1<_MsgT, _Op, L1H, L3H, _AddressScale, _ImmOffset,
                                 _DS, _VS, _Transposed, N>(
@@ -1392,7 +1430,9 @@ lsc_atomic_update(AccessorTy acc, __ESIMD_NS::simd<uint32_t, N> offsets,
 #else
   detail::check_lsc_vector_size<1>();
   detail::check_lsc_data_size<T, DS>();
-  detail::check_lsc_atomic<Op, 2>();
+  constexpr __ESIMD_NS::native::lsc::atomic_op _Op =
+      __ESIMD_DNS::to_lsc_atomic_op<Op>();
+  __ESIMD_EDNS::check_lsc_atomic<_Op, T, N, 2>();
   detail::check_lsc_cache_hint<detail::lsc_action::atomic, L1H, L3H>();
   constexpr uint16_t _AddressScale = 1;
   constexpr int _ImmOffset = 0;
@@ -1401,9 +1441,8 @@ lsc_atomic_update(AccessorTy acc, __ESIMD_NS::simd<uint32_t, N> offsets,
   constexpr detail::lsc_vector_size _VS = detail::to_lsc_vector_size<1>();
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
-  constexpr detail::lsc_atomic_op _Op = detail::to_lsc_atomic_op<Op>();
   using _MsgT = typename detail::lsc_expand_type<T>::type;
-  auto si = __ESIMD_GET_SURF_HANDLE(acc);
+  auto si = __ESIMD_NS::get_surface_index(acc);
   __ESIMD_NS::simd<_MsgT, N> Tmp =
       __esimd_lsc_xatomic_bti_2<_MsgT, _Op, L1H, L3H, _AddressScale, _ImmOffset,
                                 _DS, _VS, _Transposed, N>(
@@ -1434,7 +1473,9 @@ lsc_atomic_update(T *p, __ESIMD_NS::simd<uint32_t, N> offsets,
                   __ESIMD_NS::simd_mask<N> pred) {
   detail::check_lsc_vector_size<1>();
   detail::check_lsc_data_size<T, DS>();
-  detail::check_lsc_atomic<Op, 0>();
+  constexpr __ESIMD_NS::native::lsc::atomic_op _Op =
+      __ESIMD_DNS::to_lsc_atomic_op<Op>();
+  __ESIMD_EDNS::check_lsc_atomic<_Op, T, N, 0>();
   detail::check_lsc_cache_hint<detail::lsc_action::atomic, L1H, L3H>();
   constexpr uint16_t _AddressScale = 1;
   constexpr int _ImmOffset = 0;
@@ -1443,7 +1484,6 @@ lsc_atomic_update(T *p, __ESIMD_NS::simd<uint32_t, N> offsets,
   constexpr detail::lsc_vector_size _VS = detail::to_lsc_vector_size<1>();
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
-  constexpr detail::lsc_atomic_op _Op = detail::to_lsc_atomic_op<Op>();
   using _MsgT = typename detail::lsc_expand_type<T>::type;
   __ESIMD_NS::simd<uintptr_t, N> addrs = reinterpret_cast<uintptr_t>(p);
   addrs += convert<uintptr_t>(offsets);
@@ -1477,7 +1517,9 @@ lsc_atomic_update(T *p, __ESIMD_NS::simd<uint32_t, N> offsets,
                   __ESIMD_NS::simd<T, N> src0, __ESIMD_NS::simd_mask<N> pred) {
   detail::check_lsc_vector_size<1>();
   detail::check_lsc_data_size<T, DS>();
-  detail::check_lsc_atomic<Op, 1>();
+  constexpr __ESIMD_NS::native::lsc::atomic_op _Op =
+      __ESIMD_DNS::to_lsc_atomic_op<Op>();
+  __ESIMD_EDNS::check_lsc_atomic<_Op, T, N, 1>();
   detail::check_lsc_cache_hint<detail::lsc_action::atomic, L1H, L3H>();
   constexpr uint16_t _AddressScale = 1;
   constexpr int _ImmOffset = 0;
@@ -1486,7 +1528,6 @@ lsc_atomic_update(T *p, __ESIMD_NS::simd<uint32_t, N> offsets,
   constexpr detail::lsc_vector_size _VS = detail::to_lsc_vector_size<1>();
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
-  constexpr detail::lsc_atomic_op _Op = detail::to_lsc_atomic_op<Op>();
   using _MsgT = typename detail::lsc_expand_type<T>::type;
   __ESIMD_NS::simd<uintptr_t, N> addrs = reinterpret_cast<uintptr_t>(p);
   addrs += convert<uintptr_t>(offsets);
@@ -1522,7 +1563,9 @@ lsc_atomic_update(T *p, __ESIMD_NS::simd<uint32_t, N> offsets,
                   __ESIMD_NS::simd_mask<N> pred) {
   detail::check_lsc_vector_size<1>();
   detail::check_lsc_data_size<T, DS>();
-  detail::check_lsc_atomic<Op, 2>();
+  constexpr __ESIMD_NS::native::lsc::atomic_op _Op =
+      __ESIMD_DNS::to_lsc_atomic_op<Op>();
+  __ESIMD_EDNS::check_lsc_atomic<_Op, T, N, 2>();
   detail::check_lsc_cache_hint<detail::lsc_action::atomic, L1H, L3H>();
   constexpr uint16_t _AddressScale = 1;
   constexpr int _ImmOffset = 0;
@@ -1531,7 +1574,6 @@ lsc_atomic_update(T *p, __ESIMD_NS::simd<uint32_t, N> offsets,
   constexpr detail::lsc_vector_size _VS = detail::to_lsc_vector_size<1>();
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
-  constexpr detail::lsc_atomic_op _Op = detail::to_lsc_atomic_op<Op>();
   using _MsgT = typename detail::lsc_expand_type<T>::type;
   __ESIMD_NS::simd<uintptr_t, N> addrs = reinterpret_cast<uintptr_t>(p);
   addrs += convert<uintptr_t>(offsets);
@@ -1563,8 +1605,9 @@ __ESIMD_API void lsc_fence(__ESIMD_NS::simd_mask<N> pred = 1) {
 
 /// @} sycl_esimd_memory_lsc
 
-#undef __ESIMD_GET_SURF_HANDLE
-
-} // namespace ext::intel::experimental::esimd
+} // namespace esimd
+} // namespace experimental
+} // namespace intel
+} // namespace ext
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -295,7 +295,7 @@ constexpr void check_lsc_atomic() {
     static_assert(NumSrc == __ESIMD_DNS::get_num_args<Op>(),
                   "wrong number of operands");
   }
-  if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::fcmpwr) {
+  if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::fcmpxchg) {
     if constexpr (!is_type<T, float, sycl::half>()) {
       static_assert((is_type<T, float, sycl::half>()),
                     "Type F or HF is expected");
@@ -1629,8 +1629,6 @@ __ESIMD_API simd<T, N> atomic_update(T *p, simd<unsigned, N> offset,
 }
 
 } // namespace esimd
-
-
 } // namespace intel
 } // namespace ext
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)

--- a/sycl/test/esimd/enums.cpp
+++ b/sycl/test/esimd/enums.cpp
@@ -3,7 +3,7 @@
 // This test checks compilation of various ESIMD enum types. Those which are
 // deprecated must produce deprecation messages.
 
-#include <sycl/ext/intel/experimental/esimd/common.hpp>
+#include <sycl/ext/intel/esimd/common.hpp>
 
 using namespace sycl::ext::intel::esimd;
 using namespace sycl::ext::intel::experimental::esimd;

--- a/sycl/test/esimd/lsc.cpp
+++ b/sycl/test/esimd/lsc.cpp
@@ -5,18 +5,20 @@
 // Checks ESIMD intrinsic translation.
 // NOTE: must be run in -O0, as optimizer optimizes away some of the code
 
-#include <sycl/detail/image_ocl_types.hpp>
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>
 
 using namespace sycl::ext::intel::esimd;
 using namespace sycl::ext::intel::experimental::esimd;
 
-SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void foo();
+using AccType = sycl::accessor<uint8_t, 1, sycl::access::mode::read_write>;
+
+SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void foo(AccType &);
 
 class EsimdFunctor {
 public:
-  void operator()() __attribute__((sycl_explicit_simd)) { foo(); }
+  AccType acc;
+  void operator()() __attribute__((sycl_explicit_simd)) { foo(acc); }
 };
 
 template <typename name, typename Func>
@@ -24,12 +26,12 @@ __attribute__((sycl_kernel)) void kernel(Func kernelFunc) {
   kernelFunc();
 }
 
-void bar() {
-  EsimdFunctor esimdf;
+void bar(AccType &acc) {
+  EsimdFunctor esimdf{acc};
   kernel<class kernel_esimd>(esimdf);
 }
 
-SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void foo() {
+SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void foo(AccType &acc) {
   constexpr int VL = 4;
   int *ptr = 0;
   uintptr_t addr = reinterpret_cast<uintptr_t>(ptr);
@@ -57,7 +59,6 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void foo() {
   lsc_prefetch<int, 1, lsc_data_size::default_size, cache_hint::uncached,
                cache_hint::cached>(ptr, offsets);
 
-  sycl::accessor<uint8_t, 1, sycl::access::mode::read_write> acc;
   uint32_t surf_offset = 1 * VL * sizeof(int);
 
   // CHECK: call void @llvm.genx.lsc.store.bti.v1i1.v1i32.v4i32(<1 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 {{[^)]+}})


### PR DESCRIPTION
1) Introduce `sycl::ext::intel::esimd::native::lsc::atomic_op`
2) When `esimd::atomic_update` is invoked with `esimd::native::lsc::atomic_op` (rather than `esimd::atomic_op`), then implementation is redirected to Xe-specific LSC-based implementation (won't run until Gen12)
3) Using FP operations from `esimd::atomic_op` cause warning and are replaced with corresponding LSC operations.
4) A number of code chunks moved to fit header inclusion order (distribution of auxiliary code in headers needs to be revised some day)

Complementary E2E test: https://github.com/intel/llvm-test-suite/pull/1171

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>