### PR TITLE
[SYCL] Fix image::get_size method

### DIFF
--- a/sycl/source/buffer.cpp
+++ b/sycl/source/buffer.cpp
@@ -119,7 +119,7 @@ void buffer_plain::addOrReplaceAccessorProperties(
   impl->addOrReplaceAccessorProperties(PropertyList);
 }
 
-size_t buffer_plain::getSize() const { return impl->getSize(); }
+size_t buffer_plain::getSize() const { return impl->getSizeInBytes(); }
 
 } // namespace detail
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)

--- a/sycl/source/detail/buffer_impl.cpp
+++ b/sycl/source/detail/buffer_impl.cpp
@@ -28,8 +28,9 @@ void *buffer_impl::allocateMem(ContextImplPtr Context, bool InitFromUserData,
          "Internal error. Allocating memory on the host "
          "while having use_host_ptr property");
   return MemoryManager::allocateMemBuffer(
-      std::move(Context), this, HostPtr, HostPtrReadOnly, BaseT::getSize(),
-      BaseT::MInteropEvent, BaseT::MInteropContext, MProps, OutEventToWait);
+      std::move(Context), this, HostPtr, HostPtrReadOnly,
+      BaseT::getSizeInBytes(), BaseT::MInteropEvent, BaseT::MInteropContext,
+      MProps, OutEventToWait);
 }
 void buffer_impl::constructorNotification(const detail::code_location &CodeLoc,
                                           void *UserObj, const void *HostObj,

--- a/sycl/source/detail/image_impl.cpp
+++ b/sycl/source/detail/image_impl.cpp
@@ -311,9 +311,9 @@ void *image_impl::allocateMem(ContextImplPtr Context, bool InitFromUserData,
          "The check an image format failed.");
 
   return MemoryManager::allocateMemImage(
-      std::move(Context), this, HostPtr, HostPtrReadOnly, BaseT::getSize(),
-      Desc, Format, BaseT::MInteropEvent, BaseT::MInteropContext, MProps,
-      OutEventToWait);
+      std::move(Context), this, HostPtr, HostPtrReadOnly,
+      BaseT::getSizeInBytes(), Desc, Format, BaseT::MInteropEvent,
+      BaseT::MInteropContext, MProps, OutEventToWait);
 }
 
 bool image_impl::checkImageDesc(const RT::PiMemImageDesc &Desc,

--- a/sycl/source/detail/plugin.hpp
+++ b/sycl/source/detail/plugin.hpp
@@ -174,6 +174,7 @@ public:
     // If arguments need to be captured, then a data structure can be sent in
     // the per_instance_user_data field.
     const char *PIFnName = PiCallInfo.getFuncName();
+    printf("%s\n", PIFnName);
     uint64_t CorrelationID = pi::emitFunctionBeginTrace(PIFnName);
     uint64_t CorrelationIDWithArgs = 0;
     unsigned char *ArgsDataPtr = nullptr;

--- a/sycl/source/detail/plugin.hpp
+++ b/sycl/source/detail/plugin.hpp
@@ -174,7 +174,6 @@ public:
     // If arguments need to be captured, then a data structure can be sent in
     // the per_instance_user_data field.
     const char *PIFnName = PiCallInfo.getFuncName();
-    printf("%s\n", PIFnName);
     uint64_t CorrelationID = pi::emitFunctionBeginTrace(PIFnName);
     uint64_t CorrelationIDWithArgs = 0;
     unsigned char *ArgsDataPtr = nullptr;

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -638,7 +638,8 @@ AllocaCommandBase *Scheduler::GraphBuilder::findAllocaForReq(
       const Requirement *TmpReq = AllocaCmd->getRequirement();
       Res &= AllocaCmd->getType() == Command::CommandType::ALLOCA_SUB_BUF;
       Res &= TmpReq->MOffsetInBytes == Req->MOffsetInBytes;
-      Res &= TmpReq->MSYCLMemObj->getSize() == Req->MSYCLMemObj->getSize();
+      Res &= TmpReq->MSYCLMemObj->getSizeInBytes() ==
+             Req->MSYCLMemObj->getSizeInBytes();
       Res &= AllowConst || !AllocaCmd->MIsConst;
     }
     return Res;
@@ -678,7 +679,7 @@ AllocaCommandBase *Scheduler::GraphBuilder::getOrCreateAllocaForReq(
     if (IsSuitableSubReq(Req)) {
       // Get parent requirement. It's hard to get right parents' range
       // so full parent requirement has range represented in bytes
-      range<3> ParentRange{Req->MSYCLMemObj->getSize(), 1, 1};
+      range<3> ParentRange{Req->MSYCLMemObj->getSizeInBytes(), 1, 1};
       Requirement ParentRequirement(/*Offset*/ {0, 0, 0}, ParentRange,
                                     ParentRange, access::mode::read_write,
                                     Req->MSYCLMemObj, /*Dims*/ 1,

--- a/sycl/source/detail/sycl_mem_obj_i.hpp
+++ b/sycl/source/detail/sycl_mem_obj_i.hpp
@@ -59,7 +59,7 @@ public:
   virtual void releaseHostMem(void *Ptr) = 0;
 
   // Returns size of object in bytes
-  virtual size_t getSize() const = 0;
+  virtual size_t getSizeInBytes() const = 0;
 
   // Returns the context which is passed if a memory object is created using
   // interoperability constructor, nullptr otherwise.

--- a/sycl/source/detail/sycl_mem_obj_t.hpp
+++ b/sycl/source/detail/sycl_mem_obj_t.hpp
@@ -82,12 +82,12 @@ public:
 
   const plugin &getPlugin() const;
 
-  size_t getSize() const override { return MSizeInBytes; }
+  size_t getSizeInBytes() const override { return MSizeInBytes; }
   __SYCL2020_DEPRECATED("get_count() is deprecated, please use size() instead")
   size_t get_count() const { return size(); }
   size_t size() const noexcept {
     size_t AllocatorValueSize = MAllocator->getValueSize();
-    return (getSize() + AllocatorValueSize - 1) / AllocatorValueSize;
+    return (getSizeInBytes() + AllocatorValueSize - 1) / AllocatorValueSize;
   }
 
   template <typename propertyT> bool has_property() const noexcept {

--- a/sycl/source/image.cpp
+++ b/sycl/source/image.cpp
@@ -111,7 +111,7 @@ range<3> image_plain::get_range() const { return impl->get_range(); }
 
 range<2> image_plain::get_pitch() const { return impl->get_pitch(); }
 
-size_t image_plain::get_size() const { return impl->size(); }
+size_t image_plain::get_size() const { return impl->getSizeInBytes(); }
 
 size_t image_plain::get_count() const { return impl->get_count(); }
 

--- a/sycl/unittests/buffer/CMakeLists.txt
+++ b/sycl/unittests/buffer/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_sycl_unittest(BufferTests OBJECT
   BufferLocation.cpp
+  Image.cpp
 )

--- a/sycl/unittests/buffer/Image.cpp
+++ b/sycl/unittests/buffer/Image.cpp
@@ -1,0 +1,21 @@
+//==-------- buffer_location.cpp --- check buffer_location property --------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#define SYCL2020_DISABLE_DEPRECATION_WARNINGS
+
+#include <sycl/sycl.hpp>
+
+#include <gtest/gtest.h>
+
+TEST(ImageTest, ImageGetSize) {
+  constexpr size_t ElementsCount = 4;
+  constexpr size_t ChannelsCount = 4;
+  sycl::image<1> Image(sycl::image_channel_order::rgba,
+                       sycl::image_channel_type::fp32, sycl::range<1>(ElementsCount));
+
+  EXPECT_EQ(ElementsCount * ChannelsCount * sizeof(float), Image.get_size());
+}

--- a/sycl/unittests/scheduler/LinkedAllocaDependencies.cpp
+++ b/sycl/unittests/scheduler/LinkedAllocaDependencies.cpp
@@ -31,7 +31,7 @@ public:
   void *allocateHostMem() { return nullptr; }
   void releaseMem(ContextImplPtr, void *) {}
   void releaseHostMem(void *) {}
-  size_t getSize() const override { return 10; }
+  size_t getSizeInBytes() const override { return 10; }
   detail::ContextImplPtr getInteropContext() const override { return nullptr; }
 };
 


### PR DESCRIPTION
https://github.com/intel/llvm/pull/6600 changed behavior of  sycl::image::get_size() to return number of elements rather
than number of bytes which an image uses. This is not correct.
Changing it back and rename the internal method so it's
more clear about what it returns. 