### PR TITLE
[SYCL] Fix memory leak in program link

### DIFF
--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -297,8 +297,8 @@ void program_impl::link(std::string LinkOptions) {
 
     // Plugin resets MProgram with a new pi_program as a result of the call to "piProgramLink".
     // Thus, we need to release MProgram before the call to piProgramLink.
-    //if (MProgram != nullptr)
-    //  Plugin.call<PiApiKind::piProgramRelease>(MProgram);
+    if (MProgram != nullptr)
+      Plugin.call<PiApiKind::piProgramRelease>(MProgram);
     
     RT::PiResult Err = Plugin.call_nocheck<PiApiKind::piProgramLink>(
         MContext->getHandleRef(), Devices.size(), Devices.data(), LinkOpts,

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -294,6 +294,12 @@ void program_impl::link(std::string LinkOptions) {
     if (!LinkOpts) {
       LinkOpts = LinkOptions.c_str();
     }
+
+    // Plugin resets MProgram with a new pi_program as a result of the call to "piProgramLink".
+    // Thus, we need to release MProgram before the call to piProgramLink.
+    if (MProgram != nullptr)
+      Plugin.call<PiApiKind::piProgramRelease>(MProgram);
+    
     RT::PiResult Err = Plugin.call_nocheck<PiApiKind::piProgramLink>(
         MContext->getHandleRef(), Devices.size(), Devices.data(), LinkOpts,
         /*num_input_programs*/ 1, &MProgram, nullptr, nullptr, &MProgram);

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -297,8 +297,8 @@ void program_impl::link(std::string LinkOptions) {
 
     // Plugin resets MProgram with a new pi_program as a result of the call to "piProgramLink".
     // Thus, we need to release MProgram before the call to piProgramLink.
-    if (MProgram != nullptr)
-      Plugin.call<PiApiKind::piProgramRelease>(MProgram);
+    //if (MProgram != nullptr)
+    //  Plugin.call<PiApiKind::piProgramRelease>(MProgram);
     
     RT::PiResult Err = Plugin.call_nocheck<PiApiKind::piProgramLink>(
         MContext->getHandleRef(), Devices.size(), Devices.data(), LinkOpts,


### PR DESCRIPTION
This PR fixes the memory leak caused by missing the call to program release.

Signed-off-by: Byoungro So <byoungro.so@intel.com>