### PR TITLE
[SYCL] Adjust accessor for gdb pretty-printer

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -931,8 +931,9 @@ protected:
 
   ConcreteASPtrType getQualifiedPtr() const { return MData; }
 
-  template <typename, int, access::mode, access::target, access::placeholder,
-            typename>
+  template <typename DataT_, int Dimensions_, access::mode AccessMode_,
+            access::target AccessTarget_, access::placeholder IsPlaceholder_,
+            typename PropertyListT_>
   friend class accessor;
 
 #ifndef __SYCL_DEVICE_ONLY__

--- a/sycl/include/sycl/detail/accessor_impl.hpp
+++ b/sycl/include/sycl/detail/accessor_impl.hpp
@@ -16,8 +16,9 @@
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
-template <typename, int, access::mode, access::target, access::placeholder,
-          typename>
+template <typename DataT, int Dimensions, access::mode AccessMode,
+          access::target AccessTarget, access::placeholder IsPlaceholder,
+          typename PropertyListT>
 class accessor;
 
 namespace ext {
@@ -161,8 +162,9 @@ protected:
   template <class Obj>
   friend decltype(Obj::impl) getSyclObjImpl(const Obj &SyclObject);
 
-  template <typename, int, access::mode, access::target, access::placeholder,
-            typename>
+  template <typename DataT, int Dimensions, access::mode AccessMode,
+            access::target AccessTarget, access::placeholder IsPlaceholder,
+            typename PropertyListT>
   friend class accessor;
 
   AccessorImplPtr impl;

--- a/sycl/include/sycl/ext/oneapi/accessor_property_list.hpp
+++ b/sycl/include/sycl/ext/oneapi/accessor_property_list.hpp
@@ -16,7 +16,8 @@
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 // Forward declaration
-template <typename, int, access::mode, access::target, access::placeholder,
+template <typename DataT, int Dimensions, access::mode AccessMode,
+          access::target AccessTarget, access::placeholder IsPlaceholder,
           typename PropertyListT>
 class accessor;
 namespace detail {

--- a/sycl/test/gdb/accessors.cpp
+++ b/sycl/test/gdb/accessors.cpp
@@ -1,8 +1,11 @@
 // RUN: %clangxx -c -fno-color-diagnostics -std=c++17 -I %sycl_include/sycl -I %sycl_include -Xclang -ast-dump %s | FileCheck %s
+// RUN: %clangxx -c -fno-color-diagnostics -std=c++17 -I %sycl_include/sycl -I %sycl_include -Xclang -emit-llvm -g %s -o - | FileCheck %s --check-prefixes CHECK-DEBUG-INFO
 // UNSUPPORTED: windows
-#include <sycl/accessor.hpp>
+#include <sycl/sycl.hpp>
 
-typedef sycl::accessor<int, 1, sycl::access::mode::read> dummy;
+void foo(sycl::buffer<int, 1> &BufA) {
+  auto HostAcc = BufA.get_access<sycl::access_mode::read>();
+}
 
 // AccessorImplHost must have MMemoryRange, MOffset and MData fields
 
@@ -31,3 +34,14 @@ typedef sycl::accessor<int, 1, sycl::access::mode::read> dummy;
 // CHECK: CXXRecordDecl {{.*}} class accessor definition
 // CHECK-NOT: CXXRecordDecl {{.*}} definition
 // CHECK: public {{.*}}:'sycl::detail::AccessorBaseHost'
+
+
+// CHECK-DEBUG-INFO: !DICompositeType(tag: DW_TAG_class_type, name: "accessor<int, 1, (sycl::_V1::access::mode)1024, (sycl::_V1::access::target)2018, (sycl::_V1::access::placeholder)0, sycl::_V1::ext::oneapi::accessor_property_list<> >", {{.*}}, templateParams: ![[TEMPL_METADATA:[0-9]+]]
+// CHECK-DEBUG-INFO: ![[TEMPL_METADATA]] = !{![[DATA_T:[0-9]+]], ![[Dims:[0-9]+]], ![[AccMode:[0-9]+]], ![[AccTarget:[0-9]+]], ![[IsPlh:[0-9]+]], ![[PropListT:[0-9]+]]}
+// CHECK-DEBUG-INFO-NEXT: ![[DATA_T]] = !DITemplateTypeParameter(name: "DataT"
+// CHECK-DEBUG-INFO-NEXT: ![[Dims]] = !DITemplateValueParameter(name: "Dimensions"
+// CHECK-DEBUG-INFO-NEXT: ![[AccMode]] = !DITemplateValueParameter(name: "AccessMode"
+// CHECK-DEBUG-INFO-NEXT: ![[AccTarget]] = !DITemplateValueParameter(name: "AccessTarget"
+// CHECK-DEBUG-INFO-NEXT: ![[IsPlh]] = !DITemplateValueParameter(name: "IsPlaceholder"
+// CHECK-DEBUG-INFO-NEXT: ![[PropListT]] = !DITemplateTypeParameter(name: "PropertyListT"
+// CHECK-NOT: !DICompositeType(tag: DW_TAG_class_type, name: "accessor<i


### PR DESCRIPTION
GDB cannot parse template parameters correctly if there are forward
declarations of a type without template parameters names provided.
The patch adds names to all forward declarations of accessor and
improves the test so it should catch this problem if it appears again.