### PR TITLE
[SYCL][Reduction] Minor refactoring/simplification

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1746,7 +1746,7 @@ public:
       });
     } // end while (NWorkItems > 1)
 
-    if (Reduction::is_usm || Reduction::is_dw_acc) {
+    if (Reduction::is_usm) {
       MLastEvent = withAuxHandler(QueueCopy, [&](handler &CopyHandler) {
         detail::reduSaveFinalResultToUserMem<KernelName>(CopyHandler, Redu);
       });


### PR DESCRIPTION
Mostly enabled by the removal of ext::oneapi::reduction support. 

 * Drop placeholder accessor support (never create it, deprecated in SYCL2020 as part of the static type)
 * Drop discard_write accessor support (likewise)
 * Eliminate several constexpr bool is_*, is_sum is now enough
 * Prefer "auto" to explicit rw_acessor_type
 * Our partial sums buffer is always 1-dimensional, don't need a variable for it