### PR TITLE
[SYCL] Fix AccessorSubscript windows build issue

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -1760,8 +1760,7 @@ public:
         multi_ptr<DataT, AS>(getQualifiedPtr() + LinearIndex));
   }
   template <int Dims = Dimensions, typename = detail::enable_if_t<(Dims > 1)>>
-  typename AccessorCommonT::template AccessorSubscript<Dims - 1>
-  operator[](size_t Index) const {
+  auto operator[](size_t Index) const {
     return AccessorSubscript<Dims - 1>(*this, Index);
   }
 


### PR DESCRIPTION
This PR fixes an issue caused when building on Windows with MSVC. The problem was introduced in #6341. 
MSVC does not correctly infer the default template for its return type. This is fixed by setting the return type to auto and letting the compiler infer the return type.