### PR TITLE
[SYCL] Improve error messages on unsupported device partitioning

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -161,7 +161,10 @@ std::vector<device> device_impl::create_sub_devices(size_t ComputeUnits) const {
         PI_ERROR_INVALID_DEVICE);
 
   if (!is_partition_supported(info::partition_property::partition_equally)) {
-    throw sycl::feature_not_supported();
+    throw sycl::feature_not_supported(
+        "Device does not support "
+        "sycl::info::partition_property::partition_equally.",
+        PI_ERROR_INVALID_OPERATION);
   }
   // If count exceeds the total number of compute units in the device, an
   // exception with the errc::invalid error code must be thrown.
@@ -187,7 +190,10 @@ device_impl::create_sub_devices(const std::vector<size_t> &Counts) const {
         PI_ERROR_INVALID_DEVICE);
 
   if (!is_partition_supported(info::partition_property::partition_by_counts)) {
-    throw sycl::feature_not_supported();
+    throw sycl::feature_not_supported(
+        "Device does not support "
+        "sycl::info::partition_property::partition_by_counts.",
+        PI_ERROR_INVALID_OPERATION);
   }
   static const pi_device_partition_property P[] = {
       PI_DEVICE_PARTITION_BY_COUNTS, PI_DEVICE_PARTITION_BY_COUNTS_LIST_END, 0};
@@ -232,9 +238,17 @@ std::vector<device> device_impl::create_sub_devices(
         PI_ERROR_INVALID_DEVICE);
 
   if (!is_partition_supported(
-          info::partition_property::partition_by_affinity_domain) ||
-      !is_affinity_supported(AffinityDomain)) {
-    throw sycl::feature_not_supported();
+          info::partition_property::partition_by_affinity_domain)) {
+    throw sycl::feature_not_supported(
+        "Device does not support "
+        "sycl::info::partition_property::partition_by_affinity_domain.",
+        PI_ERROR_INVALID_OPERATION);
+  }
+  if (!is_affinity_supported(AffinityDomain)) {
+    throw sycl::feature_not_supported(
+        "Device does not support " + affinityDomainToString(AffinityDomain) +
+            ".",
+        PI_ERROR_INVALID_VALUE);
   }
   const pi_device_partition_property Properties[3] = {
       PI_DEVICE_PARTITION_BY_AFFINITY_DOMAIN,

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -77,6 +77,31 @@ read_execution_bitfield(pi_device_exec_capabilities bits) {
   return result;
 }
 
+inline std::string
+affinityDomainToString(info::partition_affinity_domain AffinityDomain) {
+  switch (AffinityDomain) {
+#define __SYCL_AFFINITY_DOMAIN_STRING_CASE(DOMAIN)                             \
+  case DOMAIN:                                                                 \
+    return #DOMAIN;
+    __SYCL_AFFINITY_DOMAIN_STRING_CASE(
+        sycl::info::partition_affinity_domain::numa)
+    __SYCL_AFFINITY_DOMAIN_STRING_CASE(
+        sycl::info::partition_affinity_domain::L4_cache)
+    __SYCL_AFFINITY_DOMAIN_STRING_CASE(
+        sycl::info::partition_affinity_domain::L3_cache)
+    __SYCL_AFFINITY_DOMAIN_STRING_CASE(
+        sycl::info::partition_affinity_domain::L2_cache)
+    __SYCL_AFFINITY_DOMAIN_STRING_CASE(
+        sycl::info::partition_affinity_domain::L1_cache)
+    __SYCL_AFFINITY_DOMAIN_STRING_CASE(
+        sycl::info::partition_affinity_domain::next_partitionable)
+#undef __SYCL_AFFINITY_DOMAIN_STRING_CASE
+  default:
+    assert(false && "Missing case for affinity domain.");
+    return "unknown";
+  }
+}
+
 // Mapping expected SYCL return types to those returned by PI calls
 template <typename T> struct sycl_to_pi {
   using type = T;


### PR DESCRIPTION
Previously `sycl::feature_not_supported` thrown by the `create_sub_devices` member functions did not have an error message. This commit adds an error message to each failure case with information about the unsupported partitioning.