### PR TITLE
https://github.com/intel/llvm/issues/6651: Fix lint

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -27,11 +27,13 @@ jobs:
     container:
       image: ghcr.io/intel/llvm/sycl_ubuntu2004_nightly:no-drivers
     steps:
+    - name: 'PR commits + 1'
+      run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
     - uses: actions/checkout@v2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         persist-credentials: false
-        fetch-depth: 2
+        fetch-depth: ${{ env.PR_FETCH_DEPTH }}
     - name: Run clang-format
       uses: ./devops/actions/clang-format
 

--- a/devops/actions/clang-format/action.yml
+++ b/devops/actions/clang-format/action.yml
@@ -7,7 +7,8 @@ runs:
     shell: bash {0}
     run: |
       git config --global --add safe.directory /__w/llvm/llvm
-      git clang-format ${GITHUB_SHA}^1
+      git fetch origin sycl
+      git clang-format ${GITHUB_SHA}
       git diff > ./clang-format.patch
   # Add patch with formatting fixes to CI job artifacts
   - uses: actions/upload-artifact@v1


### PR DESCRIPTION
Fix lint by fetching enough commits (number of commits in pull request plus one) and using GITHUB_SHA that corresponds to sycl HEAD for pull_request_target instead of GITHUB_SHA^1 that corresponds to the first parent (previous state of sycl branch) of merge commit for pull_request used before.