### PR TITLE
[ESIMD] Refactor simd vector element type traits infra. 

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd.hpp
+++ b/sycl/include/sycl/ext/intel/esimd.hpp
@@ -81,6 +81,7 @@
 
 #include <sycl/ext/intel/esimd/alt_ui.hpp>
 #include <sycl/ext/intel/esimd/common.hpp>
+#include <sycl/ext/intel/esimd/detail/half_type_traits.hpp>
 #include <sycl/ext/intel/esimd/simd.hpp>
 #include <sycl/ext/intel/esimd/simd_view.hpp>
 #include <sycl/ext/intel/experimental/esimd/kernel_properties.hpp>

--- a/sycl/include/sycl/ext/intel/esimd/detail/elem_type_traits.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/elem_type_traits.hpp
@@ -113,15 +113,6 @@ enum class CmpOp { lt, lte, gte, gt, eq, ne };
 
 enum class UnaryOp { minus, plus, bit_not, log_not };
 
-// If given type is a special "wrapper" element type.
-template <class T>
-static inline constexpr bool is_wrapper_elem_type_v =
-    std::is_same_v<T, sycl::half>;
-
-template <class T>
-static inline constexpr bool is_valid_simd_elem_type_v =
-    (is_vectorizable_v<T> || is_wrapper_elem_type_v<T>);
-
 struct invalid_raw_element_type;
 
 // Default (unusable) definition of the element type traits.
@@ -150,6 +141,17 @@ struct element_type_traits<T, std::enable_if_t<is_vectorizable_v<T>>> {
   static inline constexpr bool use_native_cpp_ops = true;
   static inline constexpr bool is_floating_point = std::is_floating_point_v<T>;
 };
+
+// If given type is a special "wrapper" element type.
+template <class T> using raw_t = typename element_type_traits<T>::RawT;
+template <class T>
+static inline constexpr bool is_wrapper_elem_type_v =
+    !std::is_same_v<raw_t<T>, invalid_raw_element_type> &&
+    !std::is_same_v<raw_t<T>, T>;
+
+template <class T>
+static inline constexpr bool is_valid_simd_elem_type_v =
+    (is_vectorizable_v<T> || is_wrapper_elem_type_v<T>);
 
 // --- Type conversions
 

--- a/sycl/include/sycl/ext/intel/esimd/detail/elem_type_traits.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/elem_type_traits.hpp
@@ -45,8 +45,6 @@
 //   "_Float16" natively supported by the device compiler and hardware, then
 //   using standard C++, operations such as '+', on _Float16 values. For other
 //   types like bfloat16 this will require mapping to appropriate intrinsics.
-// 5) The type must be marked as wrapper type explicitly, for the API to behave
-//   correctly.
 // Important note: some of these components might have different definition for
 // the same wrapper type depending on host vs device compilation. E.g. for SYCL
 // half the raw type is uint16_t on host and _Float16 on device.
@@ -54,29 +52,27 @@
 // - The mechanism to define components 1) and 2) for a new wrapper type is to
 //   provide a specialization of the `element_type_traits` structure for this
 //   type.
-// - Component 3) is provided via implementing specializations of the following
-//   intrinsics:
-//   * __esimd_wrapper_type_bitcast_to/__esimd_wrapper_type_bitcast_from (should
-//     not be necessary with C++ 20 where there is a standard bitcast operation)
-//     to bitcast between the raw and the wrapper types.
-//   * __esimd_convertvector_to/__esimd_convertvector_from to type-convert
-//     between clang vectors of the wrapper type (bit-represented with the raw
-//     type) and clang vectors the the enclosing std type values.
+// - Component 3) is provided via implementing specializations of the
+//   conversion traits:
+//   * scalar_conversion_traits: functions to bitcast between the raw and the
+//     wrapper types (should not be necessary with C++ 20 where there is a
+//     standard bitcast operation)
+//   * vector_conversion_traits: functions to type-convert between clang
+//     vectors of the wrapper type (bit-represented with the raw type) and clang
+//     vectors the the enclosing std type values.
 // - Component 4) is provided via:
 //   * (primitive operations) Specializations of the
-//       __esimd_binary_op
-//       __esimd_unary_op
-//       __esimd_cmp_op
-//       __esimd_vector_binary_op
-//       __esimd_vector_unary_op
-//       __esimd_vector_cmp_op
-//     intrinsics. If the `use_native_cpp_ops` element type trait is true, then
-//     implementing those intrinsics is not necessary and std C++ operations
-//     will be used.
+//     - scalar_binary_op_traits
+//     - vector_binary_op_traits
+//     - scalar_unary_op_traits
+//     - vector_unary_op_traits
+//     - scalar_comparison_op_traits
+//     - vector_comparison_op_traits
+//     structs. If the `use_native_cpp_ops` element type trait is true, then
+//     implementing those specializations is not necessary and std C++
+//     operations will be used.
 //   * (math operations) Overloading std math functions for the new wrapper
 //     type.
-// - Component 5) is provided via adding the new type to the list of types in
-//   `is_wrapper_elem_type_v` meta function.
 //===----------------------------------------------------------------------===//
 
 #pragma once
@@ -85,13 +81,15 @@
 #include <sycl/ext/intel/esimd/detail/defines_elementary.hpp>
 #include <sycl/ext/intel/esimd/detail/types_elementary.hpp>
 
-#include <sycl/half_type.hpp>
-
 /// @cond ESIMD_DETAIL
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace ext::intel::esimd::detail {
+
+// -----------------------------------------------------------------------------
+// General declarations
+// -----------------------------------------------------------------------------
 
 // Primitive C++ operations supported by simd objects and templated upon by some
 // of the functions/classes.
@@ -116,6 +114,13 @@ enum class CmpOp { lt, lte, gte, gt, eq, ne };
 enum class UnaryOp { minus, plus, bit_not, log_not };
 
 struct invalid_raw_element_type;
+
+// -----------------------------------------------------------------------------
+// Traits to be implemented for wrapper types (interleaving with some useful
+// meta-functions and declarations).
+// -----------------------------------------------------------------------------
+
+// ------------------- Basic type traits
 
 // Default (unusable) definition of the element type traits.
 template <class T, class SFINAE = void> struct element_type_traits {
@@ -144,12 +149,24 @@ struct element_type_traits<T, std::enable_if_t<is_vectorizable_v<T>>> {
   static inline constexpr bool is_floating_point = std::is_floating_point_v<T>;
 };
 
+// ------------------- Useful meta-functions and declarations
+
 template <class T>
 using __raw_t = typename __ESIMD_DNS::element_type_traits<T>::RawT;
 template <class T>
 using __cpp_t = typename __ESIMD_DNS::element_type_traits<T>::EnclosingCppT;
 
-// If given type is a special "wrapper" element type.
+template <class T, int N>
+using __raw_vec_t =
+    vector_type_t<typename __ESIMD_DNS::element_type_traits<T>::RawT, N>;
+
+// Note: using RawVecT in comparison result type calculation does *not* mean
+// the comparison is actually performed on the raw types.
+template <class T, int N>
+using __cmp_t = decltype(std::declval<__raw_vec_t<T, N>>() <
+                         std::declval<__raw_vec_t<T, N>>());
+
+// Is given type is a special "wrapper" element type?
 template <class T>
 static inline constexpr bool is_wrapper_elem_type_v =
     !std::is_same_v<__raw_t<T>, invalid_raw_element_type> &&
@@ -159,90 +176,96 @@ template <class T>
 static inline constexpr bool is_valid_simd_elem_type_v =
     (is_vectorizable_v<T> || is_wrapper_elem_type_v<T>);
 
-// --- Type conversions
+// ------------------- Type conversion traits
 
-// Low-level conversion functions to and from a wrapper element type.
-// Must be implemented for each supported
-// <wrapper element type, C++ std type pair>.
+template <class WrapperT, int N> struct vector_conversion_traits {
+  static_assert(is_wrapper_elem_type_v<WrapperT>, "");
+  using StdT = __cpp_t<WrapperT>;
+  using RawT = __raw_t<WrapperT>;
 
-// These are default implementations for wrapper types with native cpp
-// operations support for their corresponding raw type.
-template <class WrapperTy, class StdTy, int N>
-ESIMD_INLINE vector_type_t<__raw_t<WrapperTy>, N>
-__esimd_convertvector_to(vector_type_t<StdTy, N> Val)
-#ifdef __SYCL_DEVICE_ONLY__
-    ; // needs to be implemented for WrapperTy's for which
-      // element_type_traits<WrapperTy>::use_native_cpp_ops is false.
-#else
-{
-  vector_type_t<__raw_t<WrapperTy>, N> Output = 0;
+  static vector_type_t<RawT, N> convert_to_raw(vector_type_t<StdT, N>);
+  static vector_type_t<StdT, N> convert_to_cpp(vector_type_t<RawT, N>);
+};
 
-  if constexpr (std::is_same_v<WrapperTy, sycl::half>) {
-    for (int i = 0; i < N; i += 1) {
-      // 1. Convert Val[i] to float (x) using c++ static_cast
-      // 2. Convert x to half (using float2half)
-      // 3. Output[i] = half_of(x)
-      Output[i] = ::sycl::detail::float2Half(static_cast<float>(Val[i]));
-    }
-  } else {
-    __ESIMD_UNSUPPORTED_ON_HOST;
-  }
+template <class WrapperT> struct scalar_conversion_traits {
+  static_assert(is_wrapper_elem_type_v<WrapperT>, "");
+  using RawT = __raw_t<WrapperT>;
 
-  return Output;
-}
-#endif // __SYCL_DEVICE_ONLY__
+  static RawT bitcast_to_raw(WrapperT);
+  static WrapperT bitcast_to_wrapper(RawT);
+};
 
-template <class WrapperTy, class StdTy, int N>
-ESIMD_INLINE vector_type_t<StdTy, N>
-__esimd_convertvector_from(vector_type_t<__raw_t<WrapperTy>, N> Val)
-#ifdef __SYCL_DEVICE_ONLY__
-    ; // needs to be implemented for WrapperTy's for which
-      // element_type_traits<WrapperTy>::use_native_cpp_ops is false.
-#else
-{
-  vector_type_t<StdTy, N> Output;
+// ------------------- Binary operation traits
 
-  if constexpr (std::is_same_v<WrapperTy, sycl::half>) {
-    for (int i = 0; i < N; i += 1) {
-      // 1. Convert Val[i] to float y(using half2float)
-      // 2. Convert y to StdTy using c++ static_cast
-      // 3. Store in Output[i]
-      Output[i] = static_cast<StdTy>(::sycl::detail::half2Float(Val[i]));
-    }
-  } else {
-    __ESIMD_UNSUPPORTED_ON_HOST;
-  }
+template <BinOp Op, class WrapperT> struct scalar_binary_op_traits {
+  static_assert(is_wrapper_elem_type_v<WrapperT>, "");
 
-  return Output;
-}
-#endif // __SYCL_DEVICE_ONLY__
+  static WrapperT impl(WrapperT X, WrapperT Y);
+};
 
-// TODO should be replaced by std::bit_cast once C++20 is supported.
-template <class WrapperTy>
-WrapperTy __esimd_wrapper_type_bitcast_to(__raw_t<WrapperTy> Val);
-template <class WrapperTy>
-__raw_t<WrapperTy> __esimd_wrapper_type_bitcast_from(WrapperTy Val);
+template <BinOp Op, class WrapperT, int N> struct vector_binary_op_traits {
+  static_assert(is_wrapper_elem_type_v<WrapperT>, "");
+  using RawVecT = __raw_vec_t<WrapperT, N>;
 
-template <class WrapperTy, class StdTy> struct wrapper_type_converter {
-  using RawTy = __raw_t<WrapperTy>;
+  static RawVecT impl(RawVecT X, RawVecT Y);
+};
 
-  template <int N>
-  ESIMD_INLINE static vector_type_t<RawTy, N>
-  to_vector(vector_type_t<StdTy, N> Val) {
-    if constexpr (element_type_traits<WrapperTy>::use_native_cpp_ops) {
-      return __builtin_convertvector(Val, vector_type_t<RawTy, N>);
-    } else {
-      return __esimd_convertvector_to<WrapperTy, StdTy, N>(Val);
-    }
-  }
+// ------------------- Comparison operation traits
+
+template <CmpOp Op, class WrapperT> struct scalar_comparison_op_traits {
+  static_assert(is_wrapper_elem_type_v<WrapperT>, "");
+
+  static bool impl(WrapperT X, WrapperT Y);
+};
+
+template <CmpOp Op, class WrapperT, int N> struct vector_comparison_op_traits {
+  static_assert(is_wrapper_elem_type_v<WrapperT>, "");
+  using RawVecT = __raw_vec_t<WrapperT, N>;
+
+  static __cmp_t<WrapperT, N> impl(RawVecT X, RawVecT Y);
+};
+
+// ------------------- Unary operation traits
+
+template <UnaryOp Op, class WrapperT> struct scalar_unary_op_traits {
+  static_assert(is_wrapper_elem_type_v<WrapperT>, "");
+
+  static WrapperT impl(WrapperT X);
+};
+
+template <UnaryOp Op, class WrapperT, int N> struct vector_unary_op_traits {
+  static_assert(is_wrapper_elem_type_v<WrapperT>, "");
+  using RawVecT = __raw_vec_t<WrapperT, N>;
+
+  static RawVecT impl(RawVecT X);
+};
+
+// -----------------------------------------------------------------------------
+// Main type conversion meta-functions used in traits implementations and other
+// ESIMD components.
+// -----------------------------------------------------------------------------
+
+template <class WrapperT> struct wrapper_type_converter {
+  using StdT = __cpp_t<WrapperT>;
+  using RawT = __raw_t<WrapperT>;
 
   template <int N>
-  ESIMD_INLINE static vector_type_t<StdTy, N>
-  from_vector(vector_type_t<RawTy, N> Val) {
-    if constexpr (element_type_traits<WrapperTy>::use_native_cpp_ops) {
-      return __builtin_convertvector(Val, vector_type_t<StdTy, N>);
+  ESIMD_INLINE static vector_type_t<RawT, N>
+  to_vector(vector_type_t<StdT, N> Val) {
+    if constexpr (element_type_traits<WrapperT>::use_native_cpp_ops) {
+      return __builtin_convertvector(Val, vector_type_t<RawT, N>);
     } else {
-      return __esimd_convertvector_from<WrapperTy, StdTy, N>(Val);
+      return vector_conversion_traits<WrapperT, N>::convert_to_raw(Val);
+    }
+  }
+
+  template <int N>
+  ESIMD_INLINE static vector_type_t<StdT, N>
+  from_vector(vector_type_t<RawT, N> Val) {
+    if constexpr (element_type_traits<WrapperT>::use_native_cpp_ops) {
+      return __builtin_convertvector(Val, vector_type_t<StdT, N>);
+    } else {
+      return vector_conversion_traits<WrapperT, N>::convert_to_cpp(Val);
     }
   }
 };
@@ -262,20 +285,20 @@ ESIMD_INLINE DstRawVecTy convert_vector(SrcRawVecTy Val) {
   } else {
     // The chain of conversions (some can be no-op if types match):
     // SrcRawVecTy (of SrcWrapperTy)
-    //     | step A [wrapper_type_converter<SrcWrapperTy, SrcStdT>]::from_vector
+    //     | step A [wrapper_type_converter<SrcWrapperTy>]::from_vector
     //     v
     //  SrcStdT
     //     | step B [__builtin_convertvector]
     //     v
     //  DstStdT
-    //     | step C [wrapper_type_converter<DstWrapperTy, DstStdT>]::to_vector
+    //     | step C [wrapper_type_converter<DstWrapperTy>]::to_vector
     //     v
     // DstRawVecTy (of DstWrapperTy)
     //
-    using DstStdT = __cpp_t<DstWrapperTy>;
-    using SrcStdT = __cpp_t<SrcWrapperTy>;
-    using SrcConv = wrapper_type_converter<SrcWrapperTy, SrcStdT>;
-    using DstConv = wrapper_type_converter<DstWrapperTy, DstStdT>;
+    using SrcConv = wrapper_type_converter<SrcWrapperTy>;
+    using DstConv = wrapper_type_converter<DstWrapperTy>;
+    using SrcStdT = typename SrcConv::StdT;
+    using DstStdT = typename DstConv::StdT;
     using DstStdVecT = vector_type_t<DstStdT, N>;
     using SrcStdVecT = vector_type_t<SrcStdT, N>;
     SrcStdVecT TmpSrcVal;
@@ -304,11 +327,16 @@ ESIMD_INLINE DstRawVecTy convert_vector(SrcRawVecTy Val) {
   }
 }
 
+// -----------------------------------------------------------------------------
+// Implementations of standard C++ operations - (comparison, binary and unary)
+// for the vectors and scalars of wrapper types based the traits declared above.
+// -----------------------------------------------------------------------------
+
 template <class Ty> ESIMD_INLINE __raw_t<Ty> bitcast_to_raw_type(Ty Val) {
   if constexpr (!is_wrapper_elem_type_v<Ty>) {
     return Val;
   } else {
-    return __esimd_wrapper_type_bitcast_from<Ty>(Val);
+    return scalar_conversion_traits<Ty>::bitcast_to_raw(Val);
   }
 }
 
@@ -316,7 +344,7 @@ template <class Ty> ESIMD_INLINE Ty bitcast_to_wrapper_type(__raw_t<Ty> Val) {
   if constexpr (!is_wrapper_elem_type_v<Ty>) {
     return Val;
   } else {
-    return __esimd_wrapper_type_bitcast_to<Ty>(Val);
+    return scalar_conversion_traits<Ty>::bitcast_to_wrapper(Val);
   }
 }
 
@@ -342,6 +370,8 @@ ESIMD_INLINE DstWrapperTy convert_scalar(SrcWrapperTy Val) {
   }
 }
 
+// Default implementation of a binary arithmetic operation. Works for both
+// scalar and vector types.
 template <BinOp Op, class T> T binary_op_default_impl(T X, T Y) {
   T Res{};
   if constexpr (Op == BinOp::add)
@@ -371,6 +401,8 @@ template <BinOp Op, class T> T binary_op_default_impl(T X, T Y) {
   return Res;
 }
 
+// Default implementation of a comparison operation. Works for both scalar and
+// vector types.
 template <CmpOp Op, class T> auto comparison_op_default_impl(T X, T Y) {
   decltype(X < Y) Res{};
   if constexpr (Op == CmpOp::lt)
@@ -388,6 +420,8 @@ template <CmpOp Op, class T> auto comparison_op_default_impl(T X, T Y) {
   return Res;
 }
 
+// Default implementation of an unary operation. Works for both scalar and
+// vector types.
 template <UnaryOp Op, class T> auto unary_op_default_impl(T X) {
   if constexpr (Op == UnaryOp::minus)
     return -X;
@@ -399,20 +433,7 @@ template <UnaryOp Op, class T> auto unary_op_default_impl(T X) {
     return !X;
 }
 
-template <class ElemT, int N> struct __hlp {
-  using RawElemT = __raw_t<ElemT>;
-  using RawVecT = vector_type_t<RawElemT, N>;
-  using BinopT = decltype(std::declval<RawVecT>() + std::declval<RawVecT>());
-  using CmpT = decltype(std::declval<RawVecT>() < std::declval<RawVecT>());
-};
-
-template <class Hlp> using __re_t = typename Hlp::RawElemT;
-template <class Hlp> using __rv_t = typename Hlp::RawVecT;
-template <class Hlp> using __cmp_t = typename Hlp::CmpT;
-
 // --- Scalar versions of binary operations
-
-template <BinOp Op, class T> ESIMD_INLINE T __esimd_binary_op(T X, T Y);
 
 template <BinOp Op, class T,
           class = std::enable_if_t<is_valid_simd_elem_type_v<T>>>
@@ -425,59 +446,34 @@ ESIMD_INLINE T binary_op_default(T X, T Y) {
   return bitcast_to_wrapper_type<T>(Res);
 }
 
-// Default (inefficient) implementation of a scalar binary operation, which
-// involves conversion to an std C++ type, performing the op and converting
-// back.
-template <BinOp Op, class T> ESIMD_INLINE T __esimd_binary_op(T X, T Y) {
-  using T1 = __cpp_t<T>;
-  T1 X1 = convert_scalar<T1, T>(X);
-  T1 Y1 = convert_scalar<T1, T>(Y);
-  return convert_scalar<T>(binary_op_default<Op, T1>(X1, Y1));
-}
-
 template <BinOp Op, class T,
           class = std::enable_if_t<is_valid_simd_elem_type_v<T>>>
 ESIMD_INLINE T binary_op(T X, T Y) {
   if constexpr (element_type_traits<T>::use_native_cpp_ops) {
     return binary_op_default<Op>(X, Y);
   } else {
-    return __esimd_binary_op<Op>(X, Y);
+    return scalar_binary_op_traits<Op, T>::impl(X, Y);
   }
 }
 
 // --- Vector versions of binary operations
 
-template <BinOp Op, class ElemT, int N, class RawVecT = __rv_t<__hlp<ElemT, N>>>
+template <BinOp Op, class ElemT, int N, class RawVecT = __raw_vec_t<ElemT, N>>
 ESIMD_INLINE RawVecT vector_binary_op_default(RawVecT X, RawVecT Y) {
   static_assert(element_type_traits<ElemT>::use_native_cpp_ops);
   return binary_op_default_impl<Op, RawVecT>(X, Y);
 }
 
-// Default (inefficient) implementation of a vector binary operation, which
-// involves conversion to an std C++ type, performing the op and converting
-// back.
-template <BinOp Op, class ElemT, int N, class RawVecT = __rv_t<__hlp<ElemT, N>>>
-ESIMD_INLINE RawVecT __esimd_vector_binary_op(RawVecT X, RawVecT Y) {
-  using T1 = __cpp_t<ElemT>;
-  using VecT1 = vector_type_t<T1, N>;
-  VecT1 X1 = convert_vector<T1, ElemT, N>(X);
-  VecT1 Y1 = convert_vector<T1, ElemT, N>(Y);
-  return convert_vector<ElemT, T1, N>(
-      vector_binary_op_default<Op, T1, N>(X1, Y1));
-}
-
-template <BinOp Op, class ElemT, int N, class RawVecT = __rv_t<__hlp<ElemT, N>>>
+template <BinOp Op, class ElemT, int N, class RawVecT = __raw_vec_t<ElemT, N>>
 ESIMD_INLINE RawVecT vector_binary_op(RawVecT X, RawVecT Y) {
   if constexpr (element_type_traits<ElemT>::use_native_cpp_ops) {
     return vector_binary_op_default<Op, ElemT, N>(X, Y);
   } else {
-    return __esimd_vector_binary_op<Op, ElemT, N>(X, Y);
+    return vector_binary_op_traits<Op, ElemT, N>::impl(X, Y);
   }
 }
 
 // --- Scalar versions of unary operations
-
-template <UnaryOp Op, class T> ESIMD_INLINE T __esimd_unary_op(T X);
 
 template <UnaryOp Op, class T,
           class = std::enable_if_t<is_valid_simd_elem_type_v<T>>>
@@ -489,114 +485,135 @@ ESIMD_INLINE T unary_op_default(T X) {
   return bitcast_to_wrapper_type<T>(Res);
 }
 
-// Default (inefficient) implementation of a scalar unary operation, which
-// involves conversion to an std C++ type, performing the op and converting
-// back.
-template <UnaryOp Op, class T> ESIMD_INLINE T __esimd_unary_op(T X) {
-  using T1 = __cpp_t<T>;
-  T1 X1 = convert_scalar<T1, T>(X);
-  return convert_scalar<T>(unary_op_default<Op, T1>(X1));
-}
-
 template <UnaryOp Op, class T,
           class = std::enable_if_t<is_valid_simd_elem_type_v<T>>>
 ESIMD_INLINE T unary_op(T X) {
   if constexpr (element_type_traits<T>::use_native_cpp_ops) {
     return unary_op_default<Op>(X);
   } else {
-    return __esimd_unary_op<Op>(X);
+    return scalar_unary_op_traits<Op, T>::impl(X);
   }
 }
 
 // --- Vector versions of unary operations
 
-template <UnaryOp Op, class ElemT, int N,
-          class RawVecT = __rv_t<__hlp<ElemT, N>>>
+template <UnaryOp Op, class ElemT, int N, class RawVecT = __raw_vec_t<ElemT, N>>
 ESIMD_INLINE RawVecT vector_unary_op_default(RawVecT X) {
   static_assert(element_type_traits<ElemT>::use_native_cpp_ops);
   return unary_op_default_impl<Op, RawVecT>(X);
 }
 
-// Default (inefficient) implementation of a vector unary operation, which
-// involves conversion to an std C++ type, performing the op and converting
-// back.
-template <UnaryOp Op, class ElemT, int N,
-          class RawVecT = __rv_t<__hlp<ElemT, N>>>
-ESIMD_INLINE RawVecT __esimd_vector_unary_op(RawVecT X) {
-  using T1 = __cpp_t<ElemT>;
-  using VecT1 = vector_type_t<T1, N>;
-  VecT1 X1 = convert_vector<T1, ElemT, N>(X);
-  return convert_vector<ElemT, T1, N>(vector_unary_op_default<Op, T1, N>(X1));
-}
-
-template <UnaryOp Op, class ElemT, int N,
-          class RawVecT = __rv_t<__hlp<ElemT, N>>>
+template <UnaryOp Op, class ElemT, int N, class RawVecT = __raw_vec_t<ElemT, N>>
 ESIMD_INLINE RawVecT vector_unary_op(RawVecT X) {
   if constexpr (element_type_traits<ElemT>::use_native_cpp_ops) {
     return vector_unary_op_default<Op, ElemT, N>(X);
   } else {
-    return __esimd_vector_unary_op<Op, ElemT, N>(X);
+    return vector_unary_op_traits<Op, ElemT, N>::impl(X);
   }
 }
 
 // --- Vector versions of comparison operations
 
-template <CmpOp Op, class ElemT, int N, class H = __hlp<ElemT, N>,
-          class RetT = __cmp_t<H>, class RawVecT = __rv_t<H>>
+template <CmpOp Op, class ElemT, int N, class RetT = __cmp_t<ElemT, N>,
+          class RawVecT = __raw_vec_t<ElemT, N>>
 ESIMD_INLINE RetT vector_comparison_op_default(RawVecT X, RawVecT Y) {
   static_assert(element_type_traits<ElemT>::use_native_cpp_ops);
   return comparison_op_default_impl<Op, RawVecT>(X, Y);
 }
 
-// Default (inefficient) implementation of a vector comparison operation, which
-// involves conversion to an std C++ type, performing the op and converting
-// back.
-template <CmpOp Op, class ElemT, int N, class H = __hlp<ElemT, N>,
-          class RetT = __cmp_t<H>, class RawVecT = __rv_t<H>>
-ESIMD_INLINE RetT __esimd_vector_comparison_op(RawVecT X, RawVecT Y) {
-  using T1 = __cpp_t<ElemT>;
-  using VecT1 = vector_type_t<T1, N>;
-  VecT1 X1 = convert_vector<T1, ElemT, N>(X);
-  VecT1 Y1 = convert_vector<T1, ElemT, N>(Y);
-  return convert_vector<element_type_t<RetT>, T1, N>(
-      vector_comparison_op_default<Op, T1, N>(X1, Y1));
-}
-
-template <CmpOp Op, class ElemT, int N, class H = __hlp<ElemT, N>,
-          class RetT = __cmp_t<H>, class RawVecT = __rv_t<H>>
+template <CmpOp Op, class ElemT, int N, class RetT = __cmp_t<ElemT, N>,
+          class RawVecT = __raw_vec_t<ElemT, N>>
 ESIMD_INLINE RetT vector_comparison_op(RawVecT X, RawVecT Y) {
   if constexpr (element_type_traits<ElemT>::use_native_cpp_ops) {
     return vector_comparison_op_default<Op, ElemT, N>(X, Y);
   } else {
-    return __esimd_vector_comparison_op<Op, ElemT, N>(X, Y);
+    return vector_comparison_op_traits<Op, ElemT, N>::impl(X, Y);
   }
 }
 
+// -----------------------------------------------------------------------------
+// Default implementations of the traits (used in the operations above).
+// -----------------------------------------------------------------------------
+
+// Default (inefficient) implementation of a scalar binary operation, which
+// involves conversion to an std C++ type, performing the op and converting
+// back.
+template <BinOp Op, class WrapperT>
+ESIMD_INLINE WrapperT scalar_binary_op_traits<Op, WrapperT>::impl(WrapperT X,
+                                                                  WrapperT Y) {
+  using T1 = __cpp_t<WrapperT>;
+  T1 X1 = convert_scalar<T1, WrapperT>(X);
+  T1 Y1 = convert_scalar<T1, WrapperT>(Y);
+  return convert_scalar<WrapperT>(binary_op_default<Op, T1>(X1, Y1));
+}
+
+// Default (inefficient) implementation of a vector binary operation, which
+// involves conversion to an std C++ type, performing the op and converting
+// back.
+template <BinOp Op, class WrapperT, int N>
+ESIMD_INLINE __raw_vec_t<WrapperT, N>
+vector_binary_op_traits<Op, WrapperT, N>::impl(__raw_vec_t<WrapperT, N> X,
+                                               __raw_vec_t<WrapperT, N> Y) {
+  using T1 = __cpp_t<WrapperT>;
+  using VecT1 = vector_type_t<T1, N>;
+  VecT1 X1 = convert_vector<T1, WrapperT, N>(X);
+  VecT1 Y1 = convert_vector<T1, WrapperT, N>(Y);
+  return convert_vector<WrapperT, T1, N>(
+      vector_binary_op_default<Op, T1, N>(X1, Y1));
+}
+
+// Default (inefficient) implementation of a scalar unary operation, which
+// involves conversion to an std C++ type, performing the op and converting
+// back.
+template <UnaryOp Op, class WrapperT>
+ESIMD_INLINE WrapperT scalar_unary_op_traits<Op, WrapperT>::impl(WrapperT X) {
+  using T1 = __cpp_t<WrapperT>;
+  T1 X1 = convert_scalar<T1, WrapperT>(X);
+  return convert_scalar<T>(unary_op_default<Op, T1>(X1));
+}
+
+// Default (inefficient) implementation of a vector unary operation, which
+// involves conversion to an std C++ type, performing the op and converting
+// back.
+template <UnaryOp Op, class WrapperT, int N>
+ESIMD_INLINE __raw_vec_t<WrapperT, N>
+vector_unary_op_traits<Op, WrapperT, N>::impl(__raw_vec_t<WrapperT, N> X) {
+  using T1 = __cpp_t<WrapperT>;
+  using VecT1 = vector_type_t<T1, N>;
+  VecT1 X1 = convert_vector<T1, WrapperT, N>(X);
+  return convert_vector<WrapperT, T1, N>(
+      vector_unary_op_default<Op, T1, N>(X1));
+}
+
+// Default (inefficient) implementation of a vector comparison operation, which
+// involves conversion to an std C++ type, performing the op and converting
+// back.
+template <CmpOp Op, class WrapperT, int N>
+ESIMD_INLINE __cmp_t<WrapperT, N>
+vector_comparison_op_traits<Op, WrapperT, N>::impl(__raw_vec_t<WrapperT, N> X,
+                                                   __raw_vec_t<WrapperT, N> Y) {
+  using T1 = __cpp_t<WrapperT>;
+  using VecT1 = vector_type_t<T1, N>;
+  VecT1 X1 = convert_vector<T1, WrapperT, N>(X);
+  VecT1 Y1 = convert_vector<T1, WrapperT, N>(Y);
+  return convert_vector<element_type_t<__cmp_t<WrapperT, N>>, T1, N>(
+      vector_comparison_op_default<Op, T1, N>(X1, Y1));
+}
+
 // Proxy class to access bit representation of a wrapper type both on host and
-// device.
+// device. Declared as friend to the wrapper types (e.g. sycl::half).
+// Specific type traits implementations (scalar_conversion_traits) can use
+// concrete wrapper type specializations of the static functions in this class
+// to access private fields in the wrapper type (e.g. sycl::half).
 // TODO add this functionality to sycl type implementation? With C++20,
 // std::bit_cast should be a good replacement.
 class WrapperElementTypeProxy {
 public:
-  template <class T = sycl::half>
-  static inline __raw_t<T> bitcast_from_half(T Val) {
-#ifdef __SYCL_DEVICE_ONLY__
-    return Val.Data;
-#else
-    return Val.Data.Buf;
-#endif // __SYCL_DEVICE_ONLY__
-  }
+  template <class WrapperT>
+  static inline __raw_t<WrapperT> bitcast_to_raw_scalar(WrapperT Val);
 
-  template <class T = sycl::half>
-  static inline T bitcast_to_half(__raw_t<T> Bits) {
-#ifndef __SYCL_DEVICE_ONLY__
-    return sycl::half(::sycl::detail::host_half_impl::half(Bits));
-#else
-    sycl::half Res;
-    Res.Data = Bits;
-    return Res;
-#endif // __SYCL_DEVICE_ONLY__
-  }
+  template <class WrapperT>
+  static inline WrapperT bitcast_to_wrapper_scalar(__raw_t<WrapperT> Val);
 };
 
 // "Generic" version of std::is_floating_point_v which returns "true" also for
@@ -604,72 +621,6 @@ public:
 template <typename T>
 static inline constexpr bool is_generic_floating_point_v =
     element_type_traits<T>::is_floating_point;
-
-////////////////////////////////////////////////////////////////////////////////
-// sycl::half traits
-////////////////////////////////////////////////////////////////////////////////
-
-template <class T>
-struct element_type_traits<T, std::enable_if_t<std::is_same_v<T, sycl::half>>> {
-  // Can't use sycl::detail::half_impl::StorageT as RawT for both host and
-  // device as it still maps to struct on/ host (even though the struct is a
-  // trivial wrapper around uint16_t), and for ESIMD we need a type which can be
-  // an element of clang vector.
-#ifdef __SYCL_DEVICE_ONLY__
-  using RawT = sycl::detail::half_impl::StorageT;
-  // On device, _Float16 is native Cpp type, so it is the enclosing C++ type
-  using EnclosingCppT = RawT;
-  // On device, operations on half are translated to operations on _Float16,
-  // which is natively supported by the device compiler
-  static inline constexpr bool use_native_cpp_ops = true;
-#else
-  using RawT = uint16_t;
-  using EnclosingCppT = float;
-  // On host, we can't use native Cpp '+', '-' etc. over uint16_t to emulate the
-  // operations on half type.
-  static inline constexpr bool use_native_cpp_ops = false;
-#endif // __SYCL_DEVICE_ONLY__
-
-  static inline constexpr bool is_floating_point = true;
-};
-
-using half_raw = __raw_t<sycl::half>;
-
-template <>
-ESIMD_INLINE sycl::half
-__esimd_wrapper_type_bitcast_to<sycl::half>(half_raw Val) {
-  return WrapperElementTypeProxy::bitcast_to_half(Val);
-}
-
-template <>
-ESIMD_INLINE half_raw
-__esimd_wrapper_type_bitcast_from<sycl::half>(sycl::half Val) {
-  return WrapperElementTypeProxy::bitcast_from_half(Val);
-}
-
-template <>
-struct is_esimd_arithmetic_type<__raw_t<sycl::half>, void> : std::true_type {};
-
-// Misc
-inline std::ostream &operator<<(std::ostream &O, sycl::half const &rhs) {
-  O << static_cast<float>(rhs);
-  return O;
-}
-
-inline std::istream &operator>>(std::istream &I, sycl::half &rhs) {
-  float ValFloat = 0.0f;
-  I >> ValFloat;
-  rhs = ValFloat;
-  return I;
-}
-
-// The only other place which needs to be updated to support a new type is
-// the is_wrapper_elem_type_v meta function.
-
-////////////////////////////////////////////////////////////////////////////////
-// sycl::bfloat16 traits
-////////////////////////////////////////////////////////////////////////////////
-// TODO
 
 } // namespace ext::intel::esimd::detail
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)

--- a/sycl/include/sycl/ext/intel/esimd/detail/elem_type_traits.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/elem_type_traits.hpp
@@ -81,6 +81,8 @@
 #include <sycl/ext/intel/esimd/detail/defines_elementary.hpp>
 #include <sycl/ext/intel/esimd/detail/types_elementary.hpp>
 
+#include <utility>
+
 /// @cond ESIMD_DETAIL
 
 namespace sycl {
@@ -569,7 +571,7 @@ template <UnaryOp Op, class WrapperT>
 ESIMD_INLINE WrapperT scalar_unary_op_traits<Op, WrapperT>::impl(WrapperT X) {
   using T1 = __cpp_t<WrapperT>;
   T1 X1 = convert_scalar<T1, WrapperT>(X);
-  return convert_scalar<T>(unary_op_default<Op, T1>(X1));
+  return convert_scalar<WrapperT>(unary_op_default<Op, T1>(X1));
 }
 
 // Default (inefficient) implementation of a vector unary operation, which
@@ -596,7 +598,7 @@ vector_comparison_op_traits<Op, WrapperT, N>::impl(__raw_vec_t<WrapperT, N> X,
   using VecT1 = vector_type_t<T1, N>;
   VecT1 X1 = convert_vector<T1, WrapperT, N>(X);
   VecT1 Y1 = convert_vector<T1, WrapperT, N>(Y);
-  return convert_vector<element_type_t<__cmp_t<WrapperT, N>>, T1, N>(
+  return convert_vector<vector_element_type_t<__cmp_t<WrapperT, N>>, T1, N>(
       vector_comparison_op_default<Op, T1, N>(X1, Y1));
 }
 

--- a/sycl/include/sycl/ext/intel/esimd/detail/half_type_traits.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/half_type_traits.hpp
@@ -1,0 +1,151 @@
+//==-------------- half_type_traits.hpp - DPC++ Explicit SIMD API ----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Implementation of SIMD element type traits for the sycl::half type.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <sycl/ext/intel/esimd/detail/elem_type_traits.hpp>
+
+#include <sycl/half_type.hpp>
+
+/// @cond ESIMD_DETAIL
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+namespace ext::intel::esimd::detail {
+
+template <class T>
+struct element_type_traits<T, std::enable_if_t<std::is_same_v<T, sycl::half>>> {
+  // Can't use sycl::detail::half_impl::StorageT as RawT for both host and
+  // device as it still maps to struct on/ host (even though the struct is a
+  // trivial wrapper around uint16_t), and for ESIMD we need a type which can be
+  // an element of clang vector.
+#ifdef __SYCL_DEVICE_ONLY__
+  using RawT = sycl::detail::half_impl::StorageT;
+  // On device, _Float16 is native Cpp type, so it is the enclosing C++ type
+  using EnclosingCppT = RawT;
+  // On device, operations on half are translated to operations on _Float16,
+  // which is natively supported by the device compiler
+  static inline constexpr bool use_native_cpp_ops = true;
+#else
+  using RawT = uint16_t;
+  using EnclosingCppT = float;
+  // On host, we can't use native Cpp '+', '-' etc. over uint16_t to emulate the
+  // operations on half type.
+  static inline constexpr bool use_native_cpp_ops = false;
+#endif // __SYCL_DEVICE_ONLY__
+
+  static inline constexpr bool is_floating_point = true;
+};
+
+// ------------------- Type conversion traits
+
+template <int N> struct vector_conversion_traits<sycl::half, N> {
+  using StdT = __cpp_t<sycl::half>;
+  using RawT = __raw_t<sycl::half>;
+
+  static ESIMD_INLINE vector_type_t<RawT, N>
+  convert_to_raw(vector_type_t<StdT, N> Val)
+#ifdef __SYCL_DEVICE_ONLY__
+      // use_native_cpp_ops trait is true, so must not be implemented
+      ;
+#else
+  {
+    vector_type_t<__raw_t<sycl::half>, N> Output = 0;
+
+    for (int i = 0; i < N; i += 1) {
+      // 1. Convert Val[i] to float (x) using c++ static_cast
+      // 2. Convert x to half (using float2half)
+      // 3. Output[i] = half_of(x)
+      Output[i] = ::sycl::detail::float2Half(static_cast<float>(Val[i]));
+    }
+    return Output;
+  }
+#endif // __SYCL_DEVICE_ONLY__
+
+  static ESIMD_INLINE vector_type_t<StdT, N>
+  convert_to_cpp(vector_type_t<RawT, N> Val)
+#ifdef __SYCL_DEVICE_ONLY__
+      // use_native_cpp_ops trait is true, so must not be implemented
+      ;
+#else
+  {
+    vector_type_t<StdT, N> Output;
+
+    for (int i = 0; i < N; i += 1) {
+      // 1. Convert Val[i] to float y(using half2float)
+      // 2. Convert y to StdT using c++ static_cast
+      // 3. Store in Output[i]
+      Output[i] = static_cast<StdT>(::sycl::detail::half2Float(Val[i]));
+    }
+    return Output;
+  }
+#endif // __SYCL_DEVICE_ONLY__
+};
+
+// WrapperElementTypeProxy (a friend of sycl::half) must be used to access
+// private fields of the sycl::half.
+template <>
+ESIMD_INLINE __raw_t<sycl::half>
+WrapperElementTypeProxy::bitcast_to_raw_scalar<sycl::half>(sycl::half Val) {
+#ifdef __SYCL_DEVICE_ONLY__
+  return Val.Data;
+#else
+  return Val.Data.Buf;
+#endif // __SYCL_DEVICE_ONLY__
+}
+
+template <>
+ESIMD_INLINE sycl::half
+WrapperElementTypeProxy::bitcast_to_wrapper_scalar<sycl::half>(
+    __raw_t<sycl::half> Val) {
+#ifndef __SYCL_DEVICE_ONLY__
+  return sycl::half(::sycl::detail::host_half_impl::half(Val));
+#else
+  sycl::half Res;
+  Res.Data = Val;
+  return Res;
+#endif // __SYCL_DEVICE_ONLY__
+}
+
+template <> struct scalar_conversion_traits<sycl::half> {
+  using RawT = __raw_t<sycl::half>;
+
+  static ESIMD_INLINE RawT bitcast_to_raw(sycl::half Val) {
+    return WrapperElementTypeProxy::bitcast_to_raw_scalar<sycl::half>(Val);
+  }
+
+  static ESIMD_INLINE sycl::half bitcast_to_wrapper(RawT Val) {
+    return WrapperElementTypeProxy::bitcast_to_wrapper_scalar<sycl::half>(Val);
+  }
+};
+
+#ifdef __SYCL_DEVICE_ONLY__
+template <>
+struct is_esimd_arithmetic_type<__raw_t<sycl::half>, void> : std::true_type {};
+#endif // __SYCL_DEVICE_ONLY__
+
+// Misc
+inline std::ostream &operator<<(std::ostream &O, sycl::half const &rhs) {
+  O << static_cast<float>(rhs);
+  return O;
+}
+
+inline std::istream &operator>>(std::istream &I, sycl::half &rhs) {
+  float ValFloat = 0.0f;
+  I >> ValFloat;
+  rhs = ValFloat;
+  return I;
+}
+
+} // namespace ext::intel::esimd::detail
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
+} // namespace sycl
+
+/// @endcond ESIMD_DETAIL

--- a/sycl/include/sycl/ext/intel/esimd/detail/types.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/types.hpp
@@ -13,7 +13,9 @@
 #include <sycl/detail/defines.hpp>
 #include <sycl/detail/stl_type_traits.hpp> // to define C++14,17 extensions
 #include <sycl/ext/intel/esimd/common.hpp>
+#include <sycl/ext/intel/esimd/detail/elem_type_traits.hpp>
 #include <sycl/ext/intel/esimd/detail/region.hpp>
+#include <sycl/ext/intel/esimd/detail/types_elementary.hpp>
 #include <sycl/half_type.hpp>
 
 #if defined(__ESIMD_DBG_HOST) && !defined(__SYCL_DEVICE_ONLY__)
@@ -36,14 +38,6 @@ template <typename BaseTy, typename RegionTy> class simd_view;
 
 namespace detail {
 
-template <int N>
-using uint_type_t = std::conditional_t<
-    N == 1, uint8_t,
-    std::conditional_t<
-        N == 2, uint16_t,
-        std::conditional_t<N == 4, uint32_t,
-                           std::conditional_t<N == 8, uint64_t, void>>>>;
-
 // forward declarations of major internal simd classes
 template <typename Ty, int N> class simd_mask_impl;
 template <typename RawT, int N, class Derived, class SFINAE = void>
@@ -56,83 +50,12 @@ class simd_obj_impl;
 using simd_mask_elem_type = unsigned short;
 template <int N> using simd_mask_type = simd_mask_impl<simd_mask_elem_type, N>;
 
-// @{
-// Checks if given type T is a raw clang vector type, plus provides some info
-// about it if it is.
-
-struct invalid_element_type;
-
-template <class T> struct is_clang_vector_type : std::false_type {
-  static inline constexpr int length = 0;
-  using element_type = invalid_element_type;
-};
-
-template <class T, int N>
-struct is_clang_vector_type<T __attribute__((ext_vector_type(N)))>
-    : std::true_type {
-  static inline constexpr int length = N;
-  using element_type = T;
-};
-template <class T>
-static inline constexpr bool is_clang_vector_type_v =
-    is_clang_vector_type<T>::value;
-
-// @}
-
-template <typename T>
-using remove_cvref_t =
-    sycl::detail::remove_cv_t<sycl::detail::remove_reference_t<T>>;
-
-// is_esimd_arithmetic_type
-template <class...> struct make_esimd_void {
-  using type = void;
-};
-template <class... Tys>
-using __esimd_void_t = typename make_esimd_void<Tys...>::type;
-
-template <class Ty, class = void>
-struct is_esimd_arithmetic_type : std::false_type {};
-
-template <class Ty>
-struct is_esimd_arithmetic_type<
-    Ty, __esimd_void_t<std::enable_if_t<std::is_arithmetic_v<Ty>>,
-                       decltype(std::declval<Ty>() + std::declval<Ty>()),
-                       decltype(std::declval<Ty>() - std::declval<Ty>()),
-                       decltype(std::declval<Ty>() * std::declval<Ty>()),
-                       decltype(std::declval<Ty>() / std::declval<Ty>())>>
-    : std::true_type {};
-
-template <typename Ty>
-static inline constexpr bool is_esimd_arithmetic_type_v =
-    is_esimd_arithmetic_type<Ty>::value;
-
-// is_vectorizable_type
-template <typename Ty>
-struct is_vectorizable : std::conditional_t<is_esimd_arithmetic_type_v<Ty>,
-                                            std::true_type, std::false_type> {};
-
-template <typename Ty>
-static inline constexpr bool is_vectorizable_v = is_vectorizable<Ty>::value;
-
 template <typename T>
 static inline constexpr bool is_esimd_scalar_v =
     sycl::detail::is_arithmetic<T>::value;
 
 template <typename T>
 using is_esimd_scalar = typename std::bool_constant<is_esimd_scalar_v<T>>;
-
-// raw_vector_type, using clang vector type extension.
-template <typename Ty, int N> struct raw_vector_type {
-  static_assert(!std::is_const<Ty>::value, "const element type not supported");
-  static_assert(is_vectorizable_v<Ty>, "element type not supported");
-  static_assert(N > 0, "zero-element vector not supported");
-
-  static constexpr int length = N;
-  using type = Ty __attribute__((ext_vector_type(N)));
-};
-
-template <typename Ty, int N>
-using vector_type_t = typename raw_vector_type<Ty, N>::type;
 
 // @{
 // Checks if given type T derives from simd_obj_impl or is equal to it.
@@ -143,12 +66,6 @@ struct is_simd_obj_impl_derivative : public std::false_type {};
 template <typename RawT, int N, class Derived>
 struct is_simd_obj_impl_derivative<simd_obj_impl<RawT, N, Derived>>
     : public std::true_type {};
-
-template <class T, class SFINAE = void> struct element_type_traits;
-template <class T>
-using __raw_t = typename __ESIMD_DNS::element_type_traits<T>::RawT;
-template <class T>
-using __cpp_t = typename __ESIMD_DNS::element_type_traits<T>::EnclosingCppT;
 
 // Specialization for all other types.
 template <typename T, int N, template <typename, int> class Derived>
@@ -352,15 +269,6 @@ std::enable_if_t<is_clang_vector_type_v<To> && is_clang_vector_type_v<From>, To>
   }
 }
 
-/// Base case for checking if a type U is one of the types.
-template <typename U> constexpr bool is_type() { return false; }
-
-template <typename U, typename T, typename... Ts> constexpr bool is_type() {
-  using UU = typename std::remove_const_t<U>;
-  using TT = typename std::remove_const_t<T>;
-  return std::is_same<UU, TT>::value || is_type<UU, Ts...>();
-}
-
 // calculates the number of elements in "To" type
 template <typename ToEltTy, typename FromEltTy, int FromN,
           typename = std::enable_if_t<is_vectorizable<ToEltTy>::value>>
@@ -390,6 +298,91 @@ bitcast(vector_type_t<FromEltTy, FromN> Val) {
   using VTy = vector_type_t<ToEltTy, ToN>;
   return reinterpret_cast<VTy>(Val);
 }
+
+// Get computation type of a binary operator given its operand types:
+// - if both types are arithmetic - return CPP's "common real type" of the
+//   computation (matches C++)
+// - if both types are simd types, they must be of the same length N,
+//   and the returned type is simd<T, N>, where N is the "common real type" of
+//   the element type of the operands (diverges from clang)
+// - otherwise, one type is simd and another is arithmetic - the simd type is
+//   returned (matches clang)
+
+struct invalid_computation_type;
+
+template <class T1, class T2, class SFINAE = void> struct computation_type {
+  using type = invalid_computation_type;
+};
+
+template <class T1, class T2>
+struct computation_type<T1, T2,
+                        std::enable_if_t<is_valid_simd_elem_type_v<T1> &&
+                                         is_valid_simd_elem_type_v<T2>>> {
+private:
+  template <class T> using tr = element_type_traits<T>;
+  template <class T>
+  using native_t =
+      std::conditional_t<tr<T>::use_native_cpp_ops, typename tr<T>::RawT,
+                         typename tr<T>::EnclosingCppT>;
+  static inline constexpr bool is_wr1 = is_wrapper_elem_type_v<T1>;
+  static inline constexpr bool is_wr2 = is_wrapper_elem_type_v<T2>;
+  static inline constexpr bool is_fp1 = is_generic_floating_point_v<T1>;
+  static inline constexpr bool is_fp2 = is_generic_floating_point_v<T2>;
+
+public:
+  using type = std::conditional_t<
+      !is_wr1 && !is_wr2,
+      // T1 and T2 are both std C++ types - use std C++ type promotion
+      decltype(std::declval<T1>() + std::declval<T2>()),
+      std::conditional_t<
+          std::is_same_v<T1, T2>,
+          // Types are the same wrapper type - return any
+          T1,
+          std::conditional_t<is_fp1 != is_fp2,
+                             // One of the types is floating-point - return it
+                             // (e.g. computation_type<int, sycl::half> will
+                             // yield sycl::half)
+                             std::conditional_t<is_fp1, T1, T2>,
+                             // both are either floating point or integral -
+                             // return result of C++ promotion of the native
+                             // types
+                             decltype(std::declval<native_t<T1>>() +
+                                      std::declval<native_t<T2>>())>>>;
+};
+
+template <class T1, class T2>
+struct computation_type<
+    T1, T2,
+    std::enable_if_t<is_simd_like_type_v<T1> || is_simd_like_type_v<T2>>> {
+private:
+  using Ty1 = element_type_t<T1>;
+  using Ty2 = element_type_t<T2>;
+  using EltTy = typename computation_type<Ty1, Ty2>::type;
+
+  static constexpr int N1 = [] {
+    if constexpr (is_simd_like_type_v<T1>) {
+      return T1::length;
+    } else {
+      return 0;
+    }
+  }();
+  static constexpr int N2 = [] {
+    if constexpr (is_simd_like_type_v<T2>) {
+      return T2::length;
+    } else {
+      return 0;
+    }
+  }();
+  static_assert((N1 == N2) || (N1 == 0) || (N2 == 0), "size mismatch");
+  static constexpr int N = N1 ? N1 : N2;
+
+public:
+  using type = simd<EltTy, N>;
+};
+
+template <class T1, class T2 = T1>
+using computation_type_t =
+    typename computation_type<remove_cvref_t<T1>, remove_cvref_t<T2>>::type;
 
 } // namespace detail
 

--- a/sycl/include/sycl/ext/intel/esimd/detail/types_elementary.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/types_elementary.hpp
@@ -110,6 +110,20 @@ template <class T>
 static inline constexpr bool is_clang_vector_type_v =
     is_clang_vector_type<T>::value;
 
+template <class T> struct vector_element_type;
+
+template <class T, int N> struct vector_element_type<vector_type_t<T, N>> {
+  using type = T;
+};
+
+template <class T, int N>
+struct vector_element_type<T __attribute__((ext_vector_type(N)))> {
+  using type = T;
+};
+
+template <class T>
+using vector_element_type_t = typename vector_element_type<T>::type;
+
 } // namespace detail
 
 /// @endcond ESIMD_DETAIL

--- a/sycl/include/sycl/ext/intel/esimd/detail/types_elementary.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/types_elementary.hpp
@@ -1,0 +1,119 @@
+//==------------- types_elementary.hpp - DPC++ Explicit SIMD API -----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Definitions and declarations which are used in ESIMD type system, and which
+// don't depend on other ESIMD types.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+// ONLY C++ STANDARD HEADERS SHOULD BE INCLUDED:
+#include <cstdint>
+#include <type_traits>
+
+namespace sycl {
+inline namespace _V1 {
+namespace ext::intel::esimd {
+
+/// @cond ESIMD_DETAIL
+
+namespace detail {
+
+// Unsigned integer type of given byte size or 'void'.
+template <int N>
+using uint_type_t = std::conditional_t<
+    N == 1, uint8_t,
+    std::conditional_t<
+        N == 2, uint16_t,
+        std::conditional_t<N == 4, uint32_t,
+                           std::conditional_t<N == 8, uint64_t, void>>>>;
+
+template <typename T>
+using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
+
+/// Base case for checking if a type U is one of the types.
+template <typename U> constexpr bool is_type() { return false; }
+
+template <typename U, typename T, typename... Ts> constexpr bool is_type() {
+  using UU = typename std::remove_const_t<U>;
+  using TT = typename std::remove_const_t<T>;
+  return std::is_same<UU, TT>::value || is_type<UU, Ts...>();
+}
+
+// Converts types to single 'void' type (used for SFINAE).
+template <class...> struct make_esimd_void {
+  using type = void;
+};
+template <class... Tys>
+using __esimd_void_t = typename make_esimd_void<Tys...>::type;
+
+// Checks if standard arithmetic operations can be applied to given type.
+template <class Ty, class = void>
+struct is_esimd_arithmetic_type : std::false_type {};
+
+template <class Ty>
+struct is_esimd_arithmetic_type<
+    Ty, __esimd_void_t<std::enable_if_t<std::is_arithmetic_v<Ty>>,
+                       decltype(std::declval<Ty>() + std::declval<Ty>()),
+                       decltype(std::declval<Ty>() - std::declval<Ty>()),
+                       decltype(std::declval<Ty>() * std::declval<Ty>()),
+                       decltype(std::declval<Ty>() / std::declval<Ty>())>>
+    : std::true_type {};
+
+template <typename Ty>
+static inline constexpr bool is_esimd_arithmetic_type_v =
+    is_esimd_arithmetic_type<Ty>::value;
+
+// Checks if given type can serve as clang vector element type.
+template <typename Ty>
+struct is_vectorizable : std::conditional_t<is_esimd_arithmetic_type_v<Ty>,
+                                            std::true_type, std::false_type> {};
+
+template <typename Ty>
+static inline constexpr bool is_vectorizable_v = is_vectorizable<Ty>::value;
+
+// Raw vector type, using clang vector type extension.
+template <typename Ty, int N> struct raw_vector_type {
+  static_assert(!std::is_const<Ty>::value, "const element type not supported");
+  static_assert(is_vectorizable_v<Ty>, "element type not supported");
+  static_assert(N > 0, "zero-element vector not supported");
+
+  static constexpr int length = N;
+  using type = Ty __attribute__((ext_vector_type(N)));
+};
+
+// Alias for clang vector type with given element type and number of elements.
+template <typename Ty, int N>
+using vector_type_t = typename raw_vector_type<Ty, N>::type;
+
+// Checks if given type T is a raw clang vector type, plus provides some info
+// about it if it is.
+
+struct invalid_element_type;
+
+template <class T> struct is_clang_vector_type : std::false_type {
+  static inline constexpr int length = 0;
+  using element_type = invalid_element_type;
+};
+
+template <class T, int N>
+struct is_clang_vector_type<T __attribute__((ext_vector_type(N)))>
+    : std::true_type {
+  static inline constexpr int length = N;
+  using element_type = T;
+};
+template <class T>
+static inline constexpr bool is_clang_vector_type_v =
+    is_clang_vector_type<T>::value;
+
+} // namespace detail
+
+/// @endcond ESIMD_DETAIL
+
+} // namespace ext::intel::esimd
+} // namespace _V1
+} // namespace sycl

--- a/sycl/include/sycl/ext/intel/esimd/detail/types_elementary.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/types_elementary.hpp
@@ -11,7 +11,7 @@
 
 #pragma once
 
-// ONLY C++ STANDARD HEADERS SHOULD BE INCLUDED:
+// ESIMD HEADERS SHOULD NOT BE INCLUDED HERE
 #include <cstdint>
 #include <type_traits>
 

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -296,8 +296,8 @@ constexpr void check_lsc_atomic() {
                   "wrong number of operands");
   }
   if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::fcmpxchg) {
-    if constexpr (!is_type<T, float, sycl::half>()) {
-      static_assert((is_type<T, float, sycl::half>()),
+    if constexpr (!__ESIMD_DNS::is_type<T, float, sycl::half>()) {
+      static_assert((__ESIMD_DNS::is_type<T, float, sycl::half>()),
                     "Type F or HF is expected");
     }
   } else {


### PR DESCRIPTION
These changes make the type traits infrastructure significantly better
structured, more readable, more suitable for addition of a new wrapper
type. Particularly:
- no cyclic dependence between elem_type_traits.hpp and types.hpp any
  more, which protects against hard to solve template instantiation
  errors
- move traits implementation for sycl::half into a separate header,
  now elem_type_traits.hpp don't depend on any specific wrapper type, it
  only provides generic infra
- improve "traits" model - now __esimd* "intrinsics" which implement
  conversions and operations are replaced with *traits structures
  templated on the wrapper type, operation and number of elements. This
  allows partial specializations and makes it easy to identify what
  needs to be done to implement new wrapper type (implement *traits
  specializations)
- create a new types_elementary.hpp as a container for basic definitions
  not depending on the rest of ESIMD
- remove dependence of is_wrapper_elem_type_v on specific types

The patch is split into 3 commits for easier review.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>