### PR TITLE
[NFC][SYCL][Reduction] Remove dead code after #6646

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1759,34 +1759,9 @@ public:
   // TODO: this variant is currently enabled for 2+ reductions only as the
   // versions handling 1 reduction variable are more efficient right now.
   //
-  // Algorithm:
-  // 1) discard_write accessor (DWAcc), InitializeToIdentity = true:
-  //    a) Create uninitialized buffer and read_write accessor (RWAcc).
-  //    b) discard-write partial sums to RWAcc.
-  //    c) Repeat the steps (a) and (b) to get one final sum.
-  //    d) Copy RWAcc to DWAcc.
-  // 2) read_write accessor (RWAcc), InitializeToIdentity = false:
-  //    a) Create new uninitialized buffer (if #work-groups > 1) and RWAcc or
-  //       re-use user's RWAcc (if #work-groups is 1).
-  //    b) discard-write to RWAcc (#WG > 1), or update-write (#WG == 1).
-  //    c) Repeat the steps (a) and (b) to get one final sum.
-  // 3) read_write accessor (RWAcc), InitializeToIdentity = true:
-  //    a) Create new uninitialized buffer (if #work-groups > 1) and RWAcc or
-  //       re-use user's RWAcc (if #work-groups is 1).
-  //    b) discard-write to RWAcc.
-  //    c) Repeat the steps (a) and (b) to get one final sum.
-  // 4) USM pointer, InitializeToIdentity = false:
-  //    a) Create new uninitialized buffer (if #work-groups > 1) and RWAcc or
-  //       re-use user's USM pointer (if #work-groups is 1).
-  //    b) discard-write to RWAcc (#WG > 1) or
-  //       update-write to USM pointer (#WG == 1).
-  //    c) Repeat the steps (a) and (b) to get one final sum.
-  // 5) USM pointer, InitializeToIdentity = true:
-  //    a) Create new uninitialized buffer (if #work-groups > 1) and RWAcc or
-  //       re-use user's USM pointer (if #work-groups is 1).
-  //    b) discard-write to RWAcc (#WG > 1) or
-  //       discard-write to USM pointer (#WG == 1).
-  //    c) Repeat the steps (a) and (b) to get one final sum.
+  // This is basically a tree reduction where we re-use user's reduction
+  // variable instead of creating temporary storage for the last iteration
+  // (#WG == 1).
   template <typename KernelName = detail::auto_name, int Dims,
             typename... RestT>
   std::enable_if_t<(sizeof...(RestT) >= 3 &&
@@ -1823,11 +1798,6 @@ public:
             AuxHandler, NWorkItems, MaxWGSize, ReduTuple, ReduIndices);
       });
     } // end while (NWorkItems > 1)
-
-    auto CopyEvent = detail::reduSaveFinalResultToUserMem(
-        QueueCopy, MIsHost, ReduTuple, ReduIndices);
-    if (CopyEvent)
-      MLastEvent = *CopyEvent;
   }
 #endif // __cplusplus >= 201703L
 

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -2342,34 +2342,6 @@ size_t reduAuxCGFunc(handler &CGH, size_t NWorkItems, size_t MaxWGSize,
   return NWorkGroups;
 }
 
-inline void
-reduSaveFinalResultToUserMemHelper(std::vector<event> &,
-                                   std::shared_ptr<detail::queue_impl>, bool) {}
-
-template <typename Reduction, typename... RestT>
-void reduSaveFinalResultToUserMemHelper(
-    std::vector<event> &Events, std::shared_ptr<detail::queue_impl> Queue,
-    bool IsHost, Reduction &Redu, RestT... Rest) {
-  reduSaveFinalResultToUserMemHelper(Events, Queue, IsHost, Rest...);
-}
-
-/// Creates additional kernels that copy the accumulated/final results from
-/// reductions accessors to either user's accessor or user's USM memory.
-/// Returns the event to the last kernel copying data or nullptr if no
-/// additional kernels created.
-template <typename... Reduction, size_t... Is>
-std::shared_ptr<event>
-reduSaveFinalResultToUserMem(std::shared_ptr<detail::queue_impl> Queue,
-                             bool IsHost, std::tuple<Reduction...> &ReduTuple,
-                             std::index_sequence<Is...>) {
-  std::vector<event> Events;
-  reduSaveFinalResultToUserMemHelper(Events, Queue, IsHost,
-                                     std::get<Is>(ReduTuple)...);
-  if (!Events.empty())
-    return std::make_shared<event>(Events.back());
-  return std::shared_ptr<event>();
-}
-
 template <typename Reduction> size_t reduGetMemPerWorkItemHelper(Reduction &) {
   return sizeof(typename Reduction::result_type);
 }


### PR DESCRIPTION
Variadic version of reduSaveFinalResultToUserMem was only performing
work in case of discard-write accessor which isn't created after the
removal of ext::oneapi::reduction, the function is empty now. Remove it.