### PR TITLE
[SYCL] Fix bfloat16::to_float() host implementation.

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/bfloat16.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/bfloat16.hpp
@@ -13,7 +13,6 @@
 
 #if !defined(__SYCL_DEVICE_ONLY__)
 #include <cmath>
-#include <cstring> // for std::memcpy
 #endif
 
 namespace sycl {
@@ -64,11 +63,13 @@ public:
     return __spirv_ConvertBF16ToFINTEL(a);
 #endif
 #else
-    uint32_t bits = a;
-    bits <<= 16;
-    float res;
-    std::memcpy(&res, &bits, sizeof(res));
-    return res;
+    union {
+      uint32_t bits;
+      float res;
+    } val;
+    val.bits = a;
+    val.bits <<= 16;
+    return val.res;
 #endif
   }
 

--- a/sycl/include/sycl/ext/oneapi/experimental/bfloat16.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/bfloat16.hpp
@@ -63,13 +63,9 @@ public:
     return __spirv_ConvertBF16ToFINTEL(a);
 #endif
 #else
-    union {
-      uint32_t bits;
-      float res;
-    } val;
-    val.bits = a;
-    val.bits <<= 16;
-    return val.res;
+    uint32_t bits = a;
+    bits <<= 16;
+    return sycl::bit_cast<float>(bits);
 #endif
   }
 

--- a/sycl/include/sycl/ext/oneapi/experimental/bfloat16.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/bfloat16.hpp
@@ -63,10 +63,9 @@ public:
     return __spirv_ConvertBF16ToFINTEL(a);
 #endif
 #else
-    // Shift temporary variable to silence the warning
     uint32_t bits = a;
     bits <<= 16;
-    return static_cast<float>(bits);
+    return *(reinterpret_cast<float *>(&bits));
 #endif
   }
 

--- a/sycl/include/sycl/ext/oneapi/experimental/bfloat16.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/bfloat16.hpp
@@ -13,6 +13,7 @@
 
 #if !defined(__SYCL_DEVICE_ONLY__)
 #include <cmath>
+#include <cstring> // for std::memcpy
 #endif
 
 namespace sycl {
@@ -65,7 +66,9 @@ public:
 #else
     uint32_t bits = a;
     bits <<= 16;
-    return *(reinterpret_cast<float *>(&bits));
+    float res;
+    std::memcpy(&res, &bits, sizeof(res));
+    return res;
 #endif
   }
 

--- a/sycl/test/extensions/bfloat16_host.cpp
+++ b/sycl/test/extensions/bfloat16_host.cpp
@@ -73,15 +73,17 @@ int main() {
   Success &= check_bf16_from_float(std::numeric_limits<float>::quiet_NaN(),
                                    std::stoi("1111111111000001", nullptr, 2));
 
+  // see https://float.exposed/b0xffff
   Success &= check_bf16_to_float(
       0, bitsToFloatConv(std::string("00000000000000000000000000000000")));
   Success &= check_bf16_to_float(
-      1, bitsToFloatConv(std::string("01000111100000000000000000000000")));
+      1, bitsToFloatConv(std::string("00000000000000010000000000000000")));
   Success &= check_bf16_to_float(
-      42, bitsToFloatConv(std::string("01001010001010000000000000000000")));
+      42, bitsToFloatConv(std::string("00000000001010100000000000000000")));
   Success &= check_bf16_to_float(
-      std::numeric_limits<uint16_t>::max(),
-      bitsToFloatConv(std::string("01001111011111111111111100000000")));
+      // std::numeric_limits<uint16_t>::max() - 0xffff is bfloat16 -Nan and
+      // -Nan == -Nan check in check_bf16_to_float would fail, so use not Nan:
+      65407, bitsToFloatConv(std::string("11111111011111110000000000000000")));
   if (!Success)
     return -1;
   return 0;


### PR DESCRIPTION
- Fix bfloat16::to_float() host implementation
- Fix bugs in the existing sycl/test/extensions/bfloat16_host.cpp test.

New E2E test: https://github.com/intel/llvm-test-suite/pull/1189

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>