### PR TITLE
[SYCL][ABI Break] Remove AccessorImplHost::MIsESIMDAcc field

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -30,7 +30,7 @@ set(SYCL_MINOR_VERSION 7)
 set(SYCL_PATCH_VERSION 0)
 # Don't forget to re-enable sycl_symbols_windows.dump once we leave ABI-breaking
 # window!
-set(SYCL_DEV_ABI_VERSION 13)
+set(SYCL_DEV_ABI_VERSION 14)
 if (SYCL_ADD_DEV_VERSION_POSTFIX)
   set(SYCL_VERSION_POSTFIX "-${SYCL_DEV_ABI_VERSION}")
 endif()

--- a/sycl/include/sycl/detail/accessor_impl.hpp
+++ b/sycl/include/sycl/detail/accessor_impl.hpp
@@ -82,14 +82,13 @@ public:
   AccessorImplHost(id<3> Offset, range<3> AccessRange, range<3> MemoryRange,
                    access::mode AccessMode, void *SYCLMemObject, int Dims,
                    int ElemSize, int OffsetInBytes = 0,
-                   bool IsSubBuffer = false, bool IsESIMDAcc = false,
+                   bool IsSubBuffer = false,
                    const property_list &PropertyList = {})
       : MOffset(Offset), MAccessRange(AccessRange), MMemoryRange(MemoryRange),
         MAccessMode(AccessMode),
         MSYCLMemObj((detail::SYCLMemObjI *)SYCLMemObject), MDims(Dims),
         MElemSize(ElemSize), MOffsetInBytes(OffsetInBytes),
-        MIsSubBuffer(IsSubBuffer), MIsESIMDAcc(IsESIMDAcc),
-        MPropertyList(PropertyList) {}
+        MIsSubBuffer(IsSubBuffer), MPropertyList(PropertyList) {}
 
   ~AccessorImplHost();
 
@@ -98,7 +97,7 @@ public:
         MMemoryRange(Other.MMemoryRange), MAccessMode(Other.MAccessMode),
         MSYCLMemObj(Other.MSYCLMemObj), MDims(Other.MDims),
         MElemSize(Other.MElemSize), MOffsetInBytes(Other.MOffsetInBytes),
-        MIsSubBuffer(Other.MIsSubBuffer), MIsESIMDAcc(Other.MIsESIMDAcc) {}
+        MIsSubBuffer(Other.MIsSubBuffer) {}
 
   // The resize method provides a way to change the size of the
   // allocated memory and corresponding properties for the accessor.
@@ -131,10 +130,6 @@ public:
 
   bool PerWI = false;
 
-  // Outdated, leaving to preserve ABI.
-  // TODO: Remove during next major release.
-  bool MIsESIMDAcc;
-
   // To preserve runtime properties
   property_list MPropertyList;
 };
@@ -149,12 +144,10 @@ public:
                    int ElemSize, int OffsetInBytes = 0,
                    bool IsSubBuffer = false,
                    const PropertyListT &PropertyList = {}) {
-    impl = std::shared_ptr<AccessorImplHost>(
-        new AccessorImplHost(Offset, AccessRange, MemoryRange, AccessMode,
-                             (detail::SYCLMemObjI *)SYCLMemObject, Dims,
-                             ElemSize, OffsetInBytes, IsSubBuffer,
-                             /* IsESIMDAcc = */ false,
-                             PropertyList));
+    impl = std::shared_ptr<AccessorImplHost>(new AccessorImplHost(
+        Offset, AccessRange, MemoryRange, AccessMode,
+        (detail::SYCLMemObjI *)SYCLMemObject, Dims, ElemSize, OffsetInBytes,
+        IsSubBuffer, PropertyList));
   }
 
 protected:

--- a/sycl/test/abi/layout_accessors_host.cpp
+++ b/sycl/test/abi/layout_accessors_host.cpp
@@ -8,42 +8,41 @@
 
 using namespace sycl;
 
-// CHECK:        0 | class sycl::detail::AccessorImplHost
-// CHECK-NEXT:   0 |   class sycl::id<3> MOffset
-// CHECK-NEXT:   0 |     class sycl::detail::array<3> (base)
-// CHECK-NEXT:   0 |       size_t[3] common_array
-// CHECK-NEXT:  24 |   class sycl::range<3> MAccessRange
-// CHECK-NEXT:  24 |     class sycl::detail::array<3> (base)
-// CHECK-NEXT:  24 |       size_t[3] common_array
-// CHECK-NEXT:  48 |   class sycl::range<3> MMemoryRange
-// CHECK-NEXT:  48 |     class sycl::detail::array<3> (base)
-// CHECK-NEXT:  48 |       size_t[3] common_array
-// CHECK-NEXT:  72 |   access::mode MAccessMode
-// CHECK-NEXT:  80 |   detail::SYCLMemObjI * MSYCLMemObj
-// CHECK-NEXT:  88 |   unsigned int MDims
-// CHECK-NEXT:  92 |   unsigned int MElemSize
-// CHECK-NEXT:  96 |   unsigned int MOffsetInBytes
-// CHECK-NEXT: 100 |   _Bool MIsSubBuffer
-// CHECK-NEXT: 104 |   void * MData
-// CHECK-NEXT: 112 |   Command * MBlockedCmd
-// CHECK-NEXT: 120 |   _Bool PerWI
-// CHECK-NEXT: 121 |   _Bool MIsESIMDAcc
-// CHECK-NEXT: 128 |   class sycl::property_list MPropertyList
-// CHECK-NEXT: 128 |     class sycl::detail::PropertyListBase (base)
-// CHECK-NEXT: 128 |       class std::bitset<32> MDataLessProps
-// CHECK-NEXT: 128 |         struct std::_Base_bitset<1> (base)
-// CHECK-NEXT: 128 |           _WordT _M_w
-// CHECK-NEXT: 136 |       class std::vector<class std::shared_ptr<class sycl::detail::PropertyWithDataBase> > MPropsWithData
-// CHECK-NEXT: 136 |         struct std::_Vector_base<class std::shared_ptr<class sycl::detail::PropertyWithDataBase>, class std::allocator<class std::shared_ptr<class sycl::detail::PropertyWithDataBase> > > (base)
-// CHECK-NEXT: 136 |           struct std::_Vector_base<class std::shared_ptr<class sycl::detail::PropertyWithDataBase>, class std::allocator<class std::shared_ptr<class sycl::detail::PropertyWithDataBase> > >::_Vector_impl _M_impl
-// CHECK-NEXT: 136 |             class std::allocator<class std::shared_ptr<class sycl::detail::PropertyWithDataBase> > (base) (empty)
-// CHECK-NEXT: 136 |               class __gnu_cxx::new_allocator<class std::shared_ptr<class sycl::detail::PropertyWithDataBase> > (base) (empty)
-// CHECK-NEXT: 136 |             struct std::_Vector_base<class std::shared_ptr<class sycl::detail::PropertyWithDataBase>, class std::allocator<class std::shared_ptr<class sycl::detail::PropertyWithDataBase> > >::_Vector_impl_data (base)
-// CHECK-NEXT: 136 |               pointer _M_start
-// CHECK-NEXT: 144 |               pointer _M_finish
-// CHECK-NEXT: 152 |               pointer _M_end_of_storage
-// CHECK-NEXT:     | [sizeof=160, dsize=160, align=8,
-// CHECK-NEXT:     |  nvsize=160, nvalign=8]
+// CHECK:       0 | class sycl::detail::AccessorImplHost
+// CHECK-NEXT:  0 |   class sycl::id<3> MOffset
+// CHECK-NEXT:  0 |     class sycl::detail::array<3> (base)
+// CHECK-NEXT:  0 |       size_t[3] common_array
+// CHECK-NEXT: 24 |   class sycl::range<3> MAccessRange
+// CHECK-NEXT: 24 |     class sycl::detail::array<3> (base)
+// CHECK-NEXT: 24 |       size_t[3] common_array
+// CHECK-NEXT: 48 |   class sycl::range<3> MMemoryRange
+// CHECK-NEXT: 48 |     class sycl::detail::array<3> (base)
+// CHECK-NEXT: 48 |       size_t[3] common_array
+// CHECK-NEXT: 72 |   access::mode MAccessMode
+// CHECK-NEXT: 80 |   detail::SYCLMemObjI * MSYCLMemObj
+// CHECK-NEXT: 88 |   unsigned int MDims
+// CHECK-NEXT: 92 |   unsigned int MElemSize
+// CHECK-NEXT: 96 |   unsigned int MOffsetInBytes
+// CHECK-NEXT: 00 |   _Bool MIsSubBuffer
+// CHECK-NEXT: 04 |   void * MData
+// CHECK-NEXT: 12 |   Command * MBlockedCmd
+// CHECK-NEXT: 20 |   _Bool PerWI
+// CHECK-NEXT: 28 |   class sycl::property_list MPropertyList
+// CHECK-NEXT: 28 |     class sycl::detail::PropertyListBase (base)
+// CHECK-NEXT: 28 |       class std::bitset<32> MDataLessProps
+// CHECK-NEXT: 28 |         struct std::_Base_bitset<1> (base)
+// CHECK-NEXT: 28 |           _WordT _M_w
+// CHECK-NEXT: 36 |       class std::vector<class std::shared_ptr<class sycl::detail::PropertyWithDataBase> > MPropsWithData
+// CHECK-NEXT: 36 |         struct std::_Vector_base<class std::shared_ptr<class sycl::detail::PropertyWithDataBase>, class std::allocator<class std::shared_ptr<class sycl::detail::PropertyWithDataBase> > > (base)
+// CHECK-NEXT: 36 |           struct std::_Vector_base<class std::shared_ptr<class sycl::detail::PropertyWithDataBase>, class std::allocator<class std::shared_ptr<class sycl::detail::PropertyWithDataBase> > >::_Vector_impl _M_impl
+// CHECK-NEXT: 36 |             class std::allocator<class std::shared_ptr<class sycl::detail::PropertyWithDataBase> > (base) (empty)
+// CHECK-NEXT: 36 |               class __gnu_cxx::new_allocator<class std::shared_ptr<class sycl::detail::PropertyWithDataBase> > (base) (empty)
+// CHECK-NEXT: 36 |             struct std::_Vector_base<class std::shared_ptr<class sycl::detail::PropertyWithDataBase>, class std::allocator<class std::shared_ptr<class sycl::detail::PropertyWithDataBase> > >::_Vector_impl_data (base)
+// CHECK-NEXT: 36 |               pointer _M_start
+// CHECK-NEXT: 44 |               pointer _M_finish
+// CHECK-NEXT: 52 |               pointer _M_end_of_storage
+// CHECK-NEXT:    | [sizeof=160, dsize=160, align=8,
+// CHECK-NEXT:    |  nvsize=160, nvalign=8]
 
 // CHECK:       0 | class sycl::detail::LocalAccessorImplHost
 // CHECK-NEXT:  0 |   class sycl::range<3> MSize


### PR DESCRIPTION
It had been marked for removal during ABI break window. Do it.