### PR TITLE
[SYCL] Extend static_assert's message for lambda captures' size

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -730,10 +730,14 @@ private:
     // Some host compilers may have different captures from Clang. Currently
     // there is no stable way of handling this when extracting the captures, so
     // a static assert is made to fail for incompatible kernel lambdas.
-    static_assert(!KernelHasName || sizeof(KernelFunc) == KI::getKernelSize(),
-                  "Unexpected kernel lambda size. This can be caused by an "
-                  "external host compiler producing a lambda with an "
-                  "unexpected layout. This is a limitation of the compiler.");
+    static_assert(
+        !KernelHasName || sizeof(KernelFunc) == KI::getKernelSize(),
+        "Unexpected kernel lambda size. This can be caused by an "
+        "external host compiler producing a lambda with an "
+        "unexpected layout. This is a limitation of the compiler."
+        "In many cases the difference is related to capturing constexpr "
+        "variables. In such cases removing constexpr specifier aligns the "
+        "captures between host/device compilers.");
 
     // Empty name indicates that the compilation happens without integration
     // header, so don't perform things that require it.

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -737,7 +737,7 @@ private:
         "unexpected layout. This is a limitation of the compiler."
         "In many cases the difference is related to capturing constexpr "
         "variables. In such cases removing constexpr specifier aligns the "
-        "captures between host/device compilers.");
+        "captures between the host compiler and the device compiler.");
 
     // Empty name indicates that the compilation happens without integration
     // header, so don't perform things that require it.


### PR DESCRIPTION
Most often that is caused by capturing constexper variables. Let the
user know about that.