### PR TITLE
[SYCL][Windows] Improve windows sycl.lib linking

### DIFF
--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -131,10 +131,11 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-defaultlib:oldnames");
   }
 
-  if ((!C.getDriver().IsCLMode() && !Args.hasArg(options::OPT_nostdlib) &&
-       Args.hasArg(options::OPT_fsycl) &&
+  if ((!C.getDriver().IsCLMode() && Args.hasArg(options::OPT_fsycl) &&
        !Args.hasArg(options::OPT_nolibsycl)) ||
       Args.hasArg(options::OPT_fsycl_host_compiler_EQ)) {
+    CmdArgs.push_back(Args.MakeArgString(std::string("-libpath:") +
+                                         TC.getDriver().Dir + "/../lib"));
     if (Args.hasArg(options::OPT__SLASH_MDd))
       CmdArgs.push_back("-defaultlib:sycld.lib");
     else

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -634,6 +634,11 @@
 // CHECK-LD-NOLIBSYCL: "{{.*}}ld{{(.exe)?}}"
 // CHECK-LD-NOLIBSYCL-NOT: "-lsycl"
 
+/// Check no SYCL runtime is linked with -nostdlib
+// RUN: %clang -fsycl -nostdlib -target x86_64-unknown-linux-gnu %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LD-NOSTDLIB %s
+// CHECK-LD-NOSTDLIB: "{{.*}}ld{{(.exe)?}}"
+// CHECK-LD-NOSTDLIB-NOT: "-lsycl"
+
 /// Check for default linking of sycl.lib with -fsycl usage
 // RUN: %clang -fsycl -target x86_64-unknown-windows-msvc %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL %s
 // RUN: %clang_cl -fsycl %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL-CL %s
@@ -643,10 +648,18 @@
 
 /// Check no SYCL runtime is linked with -nolibsycl
 // RUN: %clang -fsycl -nolibsycl -target x86_64-unknown-windows-msvc %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-NOLIBSYCL %s
-// RUN: %clang_cl -fsycl -nolibsycl %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-NOLIBSYCL %s
-// CHECK-LINK-NOLIBSYCL-NOT: "--dependent-lib=sycl"
+// RUN: %clang_cl -fsycl -nolibsycl %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-NOLIBSYCL-CL %s
+// CHECK-LINK-NOLIBSYCL-CL-NOT: "--dependent-lib=sycl"
 // CHECK-LINK-NOLIBSYCL: "{{.*}}link{{(.exe)?}}"
 // CHECK-LINK-NOLIBSYCL-NOT: "-defaultlib:sycl.lib"
+
+/// Check SYCL runtime is linked despite -nostdlib on Windows, this is
+/// necessary for the Windows Clang CMake to work
+// RUN: %clang -fsycl -nostdlib -target x86_64-unknown-windows-msvc %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-NOSTDLIB %s
+// RUN: %clang_cl -fsycl -nostdlib %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-NOSTDLIB-CL %s
+// CHECK-LINK-NOSTDLIB-CL: "--dependent-lib=sycl"
+// CHECK-LINK-NOSTDLIB: "{{.*}}link{{(.exe)?}}"
+// CHECK-LINK-NOSTDLIB: "-defaultlib:sycl.lib"
 
 /// Check sycld.lib is chosen with /MDd
 // RUN:  %clang_cl -fsycl /MDd %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL-DEBUG %s


### PR DESCRIPTION
This patch does two things, first it makes `-fsycl` ignore `-nostdlib`
when linking the SYCL library. This is necessary because for Clang on
Windows CMake will generate link commands using `-nostdlib` and
explicitly list the system libraries, but of course it doesn't do it for
SYCL, so we currently end up never linking the SYCL library when this is
used.

Ignoring `-nostdlib` for `-fsycl` on Windows seems like a reasonnable
solution for this as this is also what is done for the OpenMP runtime
libraries.

See the CMake module:
* https://github.com/Kitware/CMake/blob/aa2de7cd2a04699744a224ab84e0ca483559c5d3/Modules/Platform/Windows-Clang.cmake#L79

In addition this patch also adds a linker parameter to help clang find
the `sycl.lib` file without requiring users to tweak their environments
to link against it.