### PR TITLE
[SYCL][Windows] Enable building lld by default on Windows

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -44,6 +44,10 @@ def do_configure(args):
     sycl_enable_xpti_tracing = 'ON'
     xpti_enable_werror = 'OFF'
 
+    # lld is needed on Windows or for the HIP plugin on AMD
+    if platform.system() == 'Windows' or (args.hip and args.hip_platform == 'AMD'):
+        llvm_enable_projects += ';lld'
+
     # replace not append, so ARM ^ X86
     if args.arm:
         llvm_targets_to_build = 'ARM;AArch64'
@@ -65,8 +69,6 @@ def do_configure(args):
             llvm_targets_to_build += ';AMDGPU'
             libclc_targets_to_build += libclc_amd_target_names
 
-            # The HIP plugin for AMD uses lld for linking
-            llvm_enable_projects += ';lld'
         elif args.hip_platform == 'NVIDIA' and not args.cuda:
             llvm_targets_to_build += ';NVPTX'
             libclc_targets_to_build += libclc_nvidia_target_names

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -383,6 +383,12 @@ if(OpenCL_INSTALL_KHRONOS_ICD_LOADER AND TARGET OpenCL-ICD)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS OpenCL-ICD)
 endif()
 
+# On Windows or for HIP AMD lld is also needed
+if(WIN32 OR ("hip" IN_LIST SYCL_ENABLE_PLUGINS AND "${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "AMD"))
+  add_dependencies(sycl-toolchain lld)
+  list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS lld)
+endif()
+
 if("cuda" IN_LIST SYCL_ENABLE_PLUGINS)
   # Ensure that libclc is enabled.
   list(FIND LLVM_ENABLE_PROJECTS libclc LIBCLC_FOUND)
@@ -405,12 +411,6 @@ if("hip" IN_LIST SYCL_ENABLE_PLUGINS)
 
   add_dependencies(sycl-toolchain libspirv-builtins pi_hip)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS libspirv-builtins pi_hip)
-
-  # On AMD platform lld is also needed
-  if("${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "AMD")
-    add_dependencies(sycl-toolchain lld)
-    list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS lld)
-  endif()
 endif()
 
 if("esimd_emulator" IN_LIST SYCL_ENABLE_PLUGINS)

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -383,8 +383,8 @@ if(OpenCL_INSTALL_KHRONOS_ICD_LOADER AND TARGET OpenCL-ICD)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS OpenCL-ICD)
 endif()
 
-# On Windows or for HIP AMD lld is also needed
-if(WIN32 OR ("hip" IN_LIST SYCL_ENABLE_PLUGINS AND "${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "AMD"))
+# Build and install lld as part of the sycl-toolchain if available
+if(TARGET lld)
   add_dependencies(sycl-toolchain lld)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS lld)
 endif()
@@ -407,6 +407,11 @@ if("hip" IN_LIST SYCL_ENABLE_PLUGINS)
   if( LIBCLC_FOUND EQUAL -1 )
     message(FATAL_ERROR
       "HIP support requires adding \"libclc\" to the CMake argument \"LLVM_ENABLE_PROJECTS\"")
+  endif()
+
+  if(NOT TARGET lld AND "${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "AMD")
+    message(FATAL_ERROR
+      "HIP support requires adding \"lld\" to the CMake argument \"LLVM_ENABLE_PROJECTS\"")
   endif()
 
   add_dependencies(sycl-toolchain libspirv-builtins pi_hip)

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -384,7 +384,7 @@ if(OpenCL_INSTALL_KHRONOS_ICD_LOADER AND TARGET OpenCL-ICD)
 endif()
 
 # Build and install lld as part of the sycl-toolchain if available
-if(TARGET lld)
+if("lld" IN_LIST LLVM_ENABLE_PROJECTS)
   add_dependencies(sycl-toolchain lld)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS lld)
 endif()


### PR DESCRIPTION
The Windows-Clang CMake module uses `lld-link` by default, so
having lld built on windows is helpful for people wanting to build SYCL
applications using CMake.

Related to: https://github.com/intel/llvm/issues/6026