### PR TITLE
[SYCL][Windows] Fix debug build in non cl mode 

### DIFF
--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -136,7 +136,7 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
       Args.hasArg(options::OPT_fsycl_host_compiler_EQ)) {
     CmdArgs.push_back(Args.MakeArgString(std::string("-libpath:") +
                                          TC.getDriver().Dir + "/../lib"));
-    if (Args.hasArg(options::OPT__SLASH_MDd))
+    if (Args.hasArg(options::OPT_g_Flag))
       CmdArgs.push_back("-defaultlib:sycld.lib");
     else
       CmdArgs.push_back("-defaultlib:sycl.lib");

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -661,10 +661,13 @@
 // CHECK-LINK-NOSTDLIB: "{{.*}}link{{(.exe)?}}"
 // CHECK-LINK-NOSTDLIB: "-defaultlib:sycl.lib"
 
-/// Check sycld.lib is chosen with /MDd
-// RUN:  %clang_cl -fsycl /MDd %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL-DEBUG %s
-// CHECK-LINK-SYCL-DEBUG: "--dependent-lib=sycld"
-// CHECK-LINK-SYCL-DEBUG-NOT: "-defaultlib:sycld.lib"
+/// Check sycld.lib is chosen with /MDd or -g
+// RUN:  %clang -fsycl -g -target x86_64-unknown-windows-msvc %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL-DEBUG %s
+// RUN:  %clang_cl -fsycl /MDd %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL-DEBUG-CL %s
+// CHECK-LINK-SYCL-DEBUG-CL: "--dependent-lib=sycld"
+// CHECK-LINK-SYCL-DEBUG-CL-NOT: "-defaultlib:sycld.lib"
+// CHECK-LINK-SYCL-DEBUG: "-defaultlib:sycld.lib"
+// CHECK-LINK-SYCL-DEBUG-NOT: "--dependent-lib=sycld"
 
 /// Check "-spirv-allow-unknown-intrinsics=llvm.genx." option is emitted for llvm-spirv tool
 // RUN: %clangxx %s -fsycl -### 2>&1 | FileCheck %s --check-prefix=CHK-ALLOW-INTRIN


### PR DESCRIPTION
This fixes building SYCL programs in Debug mode with
`Windows-Clang.cmake`.

The issue is that the code was using `OPT__SLASH_MDd` to select
`sycld.lib` but under the  `!C.getDriver.IsCLMode()` condition this flag
will never be set, `OPT_g_Flag` should be used instead (`-g` rather than
`/MDd`).

Note that using the regular `clang` command line to manually build with
`-g` still doesn't work as it will link against `msvcrt` rather than
`msvcrtd` and will miss required defines for debug builds on Windows
(`_DEBUG`). This is correctly done by the CMake module or simply when
using `clang-cl`.