### PR TITLE
[CI][NFC] Make lint for commits in PR change only 

### DIFF
--- a/devops/actions/clang-format/action.yml
+++ b/devops/actions/clang-format/action.yml
@@ -7,8 +7,7 @@ runs:
     shell: bash {0}
     run: |
       git config --global --add safe.directory /__w/llvm/llvm
-      git fetch origin sycl
-      git clang-format ${GITHUB_SHA}
+      git clang-format ${{ github.event.pull_request.base.sha }}
       git diff > ./clang-format.patch
   # Add patch with formatting fixes to CI job artifacts
   - uses: actions/upload-artifact@v1


### PR DESCRIPTION
Make lint for commits in PR change only not taking into account sycl branch HEAD. Should fix issues like in https://github.com/intel/llvm/pull/6705 where lint reported errors for files not affected in PR. To overcome current PRs stuck because of this they need to use ignore-lint tag until PR will be based on devops directory changes made here.