### PR TITLE
[SYCL-MLIR]: Allow setting the build compilers to use, allow cmake verbose

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -47,6 +47,10 @@ def do_configure(args):
     sycl_enable_xpti_tracing = 'ON'
     xpti_enable_werror = 'OFF'
 
+    build_compiler_c = '/usr/bin/gcc'
+    build_compiler_cpp = '/usr/bin/g++'
+    verbose = 'OFF'
+
     # replace not append, so ARM ^ X86
     if args.arm:
         llvm_targets_to_build = 'ARM;AArch64'
@@ -124,6 +128,16 @@ def do_configure(args):
     if args.enable_plugin:
         sycl_enabled_plugins += args.enable_plugin
 
+    if args.build_compiler_c:
+        build_compiler_c = args.build_compiler_c
+
+    if args.build_compiler_cpp:
+        build_compiler_cpp = args.build_compiler_cpp
+
+    if args.verbose:
+        verbose = args.verbose
+        
+
     install_dir = os.path.join(abs_obj_dir, "install")
 
     cmake_cmd = [
@@ -157,7 +171,10 @@ def do_configure(args):
         "-DLLVM_ENABLE_LLD={}".format(llvm_enable_lld),
         "-DXPTI_ENABLE_WERROR={}".format(xpti_enable_werror),
         "-DSYCL_CLANG_EXTRA_FLAGS={}".format(sycl_clang_extra_flags),
-        "-DSYCL_ENABLE_PLUGINS={}".format(';'.join(set(sycl_enabled_plugins)))
+        "-DSYCL_ENABLE_PLUGINS={}".format(';'.join(set(sycl_enabled_plugins))),
+        "-DCMAKE_C_COMPILER={}".format(build_compiler_c),
+        "-DCMAKE_CXX_COMPILER={}".format(build_compiler_cpp),
+        "-DCMAKE_VERBOSE_MAKEFILE={}".format(verbose)
     ]
 
     if args.l0_headers and args.l0_loader:
@@ -235,6 +252,10 @@ def main():
     parser.add_argument("--llvm-external-projects", help="Add external projects to build. Add as comma seperated list.")
     parser.add_argument("--ci-defaults", action="store_true", help="Enable default CI parameters")
     parser.add_argument("--enable-plugin", action='append', help="Enable SYCL plugin")
+    parser.add_argument("--build-compiler-c", metavar="BUILD_COMPILER_C", help="C compiler to use to build the project")
+    parser.add_argument("--build-compiler-cpp", metavar="BUILD_COMPILER_CPP", help="C++ compiler to use to build the project"),
+    parser.add_argument("--verbose", default='OFF', help="Verbose build"),
+
     args = parser.parse_args()
 
     print("args:{}".format(args))

--- a/mlir-sycl/include/mlir/Conversion/SYCLToLLVM/SYCLFuncRegistry.h
+++ b/mlir-sycl/include/mlir/Conversion/SYCLToLLVM/SYCLFuncRegistry.h
@@ -36,6 +36,8 @@ class SYCLFuncDescriptor {
                                        const SYCLFuncDescriptor &);
 
 public:
+  virtual ~SYCLFuncDescriptor() {}
+
   /// Enumerates SYCL functions.
   // clang-format off
   enum class FuncId {
@@ -102,7 +104,6 @@ public:
       assert(kind != Kind::Unknown && "Illegal descriptor kind");
     }
 
-    /// Maps a Kind to a descriptive name.
     static std::map<SYCLFuncDescriptor::Kind, std::string> kindToName;
 
     /// Maps a descriptive name to a Kind.
@@ -141,7 +142,7 @@ private:
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                                      const SYCLFuncDescriptor::Id &id) {
   os << "funcId=" << (int)id.funcId
-     << ", kind=" << SYCLFuncDescriptor::Id::kindToName[id.kind];
+     << ", kind=" << SYCLFuncDescriptor::Id::kindToName.at(id.kind);
   return os;
 }
 
@@ -168,6 +169,7 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
         : SYCLFuncDescriptor(funcId, ClassKind, name, outputTy, argTys) {      \
       assert(isValid(funcId) && "Invalid function id");                        \
     }                                                                          \
+    virtual ~ClassName() {}                                                    \
     bool isValid(FuncId) const override;                                       \
   };
 DEFINE_CLASS(SYCLAccessorFuncDescriptor, Kind::Accessor)

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLFuncRegistry.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLFuncRegistry.cpp
@@ -27,6 +27,7 @@ using namespace mlir::sycl;
 //===----------------------------------------------------------------------===//
 // SYCLFuncDescriptor::Id
 //===----------------------------------------------------------------------===//
+#pragma clang diagnostic ignored "-Wglobal-constructors"
 
 std::map<SYCLFuncDescriptor::Kind, std::string>
     SYCLFuncDescriptor::Id::kindToName = {


### PR DESCRIPTION
This PR allow users to pass which build compilers (e.g. clang, clang++) to use when building the project.  The default is gcc/g++.  It also allow setting `cmake` to be verbose.

Example:
```
C_COMPILER=/usr/bin/clang
CXX_COMPILER=/usr/bin/clang++

python3 $SYCL_MLIR_PROJ/buildbot/configure.py --build-type Debug --build-compiler-c=$C_COMPILER --build-compiler-cpp=$CXX_COMPILER --verbose=ON
```

Signed-off-by: Tiotto, Ettore <ettore.tiotto@intel.com>