### PR TITLE
[SYCL][NFC] Remove unnecessary NULL check for 'Fn'

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -1600,7 +1600,7 @@ void CodeGenFunction::GenerateCode(GlobalDecl GD, llvm::Function *Fn,
   StartFunction(GD, ResTy, Fn, FnInfo, Args, Loc, BodyRange.getBegin());
   if (!getLangOpts().OptRecordFile.empty()) {
     SyclOptReportHandler &SyclOptReport = CGM.getDiags().getSYCLOptReport();
-    if (Fn && SyclOptReport.HasOptReportInfo(FD)) {
+    if (SyclOptReport.HasOptReportInfo(FD)) {
       llvm::OptimizationRemarkEmitter ORE(Fn);
       for (auto ORI : llvm::enumerate(SyclOptReport.GetInfo(FD))) {
         llvm::DiagnosticLocation DL =


### PR DESCRIPTION
Klocwork thinks that it is possible for 'Fn' to be a nullptr due to this 
check but there's already an assert at the beginning of 
CodeGenFunction::GenerateCode to avoid that possibility. 