### PR TITLE
[SYCL-MLIR][SYCLToLLVM]: Fix sycl.call codegen when return type is non-void

### DIFF
--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-call-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-call-to-llvm.mlir
@@ -5,11 +5,11 @@
 //===-------------------------------------------------------------------------------------------------===//
 
 // CHECK: llvm.func @foo() -> [[MEMREF:!llvm.struct<\(ptr<i32>, ptr<i32>, i64, array<1 x i64>, array<1 x i64>\)>]]
-// CHECK: llvm.func @test() -> !llvm.struct<(ptr<i32>, ptr<i32>, i64, array<1 x i64>, array<1 x i64>)> {
-// CHECK-NEXT:  %0 = llvm.call @foo() : () -> !llvm.struct<(ptr<i32>, ptr<i32>, i64, array<1 x i64>, array<1 x i64>)>
-// CHECK-NEXT:  llvm.return %0 : !llvm.struct<(ptr<i32>, ptr<i32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK: llvm.func @test() -> [[MEMREF]] {
+// CHECK-NEXT:  %0 = llvm.call @foo() : () -> [[MEMREF]]
+// CHECK-NEXT:  llvm.return %0 : [[MEMREF]]
 func.func @test() -> (memref<?xi32>) {
-  %0 = sycl.call() {Function = @"foo", MangledName = @foo, Type = @accessor} : () -> memref<?xi32>
+  %0 = sycl.call() {Function = @foo, MangledName = @foo, Type = @accessor} : () -> memref<?xi32>
   return %0 : memref<?xi32>
 }
 

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-call-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-call-to-llvm.mlir
@@ -1,6 +1,21 @@
 // RUN: sycl-mlir-opt -split-input-file -convert-sycl-to-llvm -verify-diagnostics %s | FileCheck %s
 
 //===-------------------------------------------------------------------------------------------------===//
+// sycl.call with non void return type
+//===-------------------------------------------------------------------------------------------------===//
+
+// CHECK: llvm.func @foo() -> [[MEMREF:!llvm.struct<\(ptr<i32>, ptr<i32>, i64, array<1 x i64>, array<1 x i64>\)>]]
+// CHECK: llvm.func @test() -> !llvm.struct<(ptr<i32>, ptr<i32>, i64, array<1 x i64>, array<1 x i64>)> {
+// CHECK-NEXT:  %0 = llvm.call @foo() : () -> !llvm.struct<(ptr<i32>, ptr<i32>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK-NEXT:  llvm.return %0 : !llvm.struct<(ptr<i32>, ptr<i32>, i64, array<1 x i64>, array<1 x i64>)>
+func.func @test() -> (memref<?xi32>) {
+  %0 = sycl.call() {Function = @"foo", MangledName = @foo, Type = @accessor} : () -> memref<?xi32>
+  return %0 : memref<?xi32>
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
 // Member functions for sycl::accessor
 //===-------------------------------------------------------------------------------------------------===//
 


### PR DESCRIPTION
This PR fixes two issues:
1. Instead of adding `llvm.call` and removing `sycl.call`, this PR replaces `sycl.call` with `llvm.call`, so the users of the call returned value can be updated correctly. 
2. The return type of the function called and the `llvm.call` returned value should both use the LLVM dialect type (i.e. the converted type) rather than the original (unconverted) type.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>