### PR TITLE
[SYCL] Remove cl namespace deprecation warning

### DIFF
--- a/sycl/include/CL/sycl.hpp
+++ b/sycl/include/CL/sycl.hpp
@@ -10,7 +10,6 @@
 
 #include <sycl/sycl.hpp>
 
-namespace __SYCL2020_DEPRECATED(
-    "cl::sycl is deprecated, use ::sycl instead.") cl {
+namespace cl {
 namespace sycl = ::sycl;
 }


### PR DESCRIPTION
According to the SYCL 2020 specification, CL/sycl.hpp should supply the cl prefix namespace for backwards compatibility, but it does not specify that the namespace is deprecated. This commit removes the deprecation message.