### PR TITLE
[SYCL-MLIR]: Add sycl-mlir branch to sycl precommits

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     branches:
     - sycl
+    - sycl-mlir
     # Do not run builds if changes are only in the following locations
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'


### PR DESCRIPTION
This PR adds the sycl-mlir branch to the sycl_precommit.yml.

Signed-off-by: Tiotto, Ettore <ettore.tiotto@intel.com>