### PR TITLE
[SYCL] Pass /Zc:__cplusplus in -fsycl-host-compiler-options in some tests

### DIFF
--- a/sycl/test/regression/bit_cast_win.cpp
+++ b/sycl/test/regression/bit_cast_win.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-host-compiler=cl -fsycl-host-compiler-options='/std:c++17' %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-host-compiler=cl -fsycl-host-compiler-options='/std:c++17 /Zc:__cplusplus' %s -o %t.out
 // UNSUPPORTED: linux
 
 #include "bit_cast.hpp"

--- a/sycl/test/regression/fsycl-host-compiler-win.cpp
+++ b/sycl/test/regression/fsycl-host-compiler-win.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cl -fsycl -fsycl-host-compiler=cl -DDEFINE_CHECK -fsycl-host-compiler-options="-DDEFINE_CHECK /std:c++17" /Fe%t1.exe %s
+// RUN: %clang_cl -fsycl -fsycl-host-compiler=cl -DDEFINE_CHECK -fsycl-host-compiler-options="-DDEFINE_CHECK /std:c++17 /Zc:__cplusplus" /Fe%t1.exe %s
 // RUN: %RUN_ON_HOST %t1.exe
 // REQUIRES: system-windows
 //


### PR DESCRIPTION
By default MSVC reports 199711L as the standard being used and needs that
option to report C++ version properly. This fixes current post-commit
failures on the tests modified.