### PR TITLE
[SYCL-MLIR]: Update supported functions

### DIFF
--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -136,10 +136,11 @@ void MLIRScanner::initSupportedFunctions() {
                         "ifIXeqT_Li1EEmE4typeE");
   supportedFuncs.insert("_ZN4sycl3_V16detail5arrayILi1EEC1ERKS3_");
   supportedFuncs.insert("_ZN4sycl3_V12idILi1EEC1Ev");
-  supportedFuncs.insert("_ZN4sycl3_V12idILi1EEC1ERKS2_");
+  // TODO: Add support to the commented out functions.
+  // supportedFuncs.insert("_ZN4sycl3_V12idILi1EEC1ERKS2_");
   supportedFuncs.insert(
       "_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE");
-  supportedFuncs.insert("_ZN4sycl3_V15rangeILi1EEC1ERKS2_");
+  // supportedFuncs.insert("_ZN4sycl3_V15rangeILi1EEC1ERKS2_");
 }
 
 void MLIRScanner::init(mlir::func::FuncOp function, const FunctionDecl *fd) {

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -3664,7 +3664,7 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
     }
     assert(se.val);
     auto Derived =
-        (E->isLValue() || E->isXValue())
+         (E->isLValue() || E->isXValue())
             ? cast<CXXRecordDecl>(
                   E->getSubExpr()->getType()->castAs<RecordType>()->getDecl())
             : E->getSubExpr()->getType()->getPointeeCXXRecordDecl();

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -116,32 +116,30 @@ MLIRScanner::MLIRScanner(MLIRASTConsumer &Glob,
     : Glob(Glob), module(module), builder(module->getContext()),
       loc(builder.getUnknownLoc()), ThisCapture(nullptr), LTInfo(LTInfo) {}
 
-void MLIRScanner::initSupportedConstructors() {
-  // List from SYCLFuncRegistry.cpp Please modify as new constructors are
-  // added to that file.
-  supportedCons.insert("_ZN2cl4sycl2idILi1EEC1Ev");
-  supportedCons.insert("_ZN2cl4sycl2idILi2EEC1Ev");
-  supportedCons.insert("_ZN2cl4sycl2idILi3EEC1Ev");
-  supportedCons.insert(
-      "_ZN2cl4sycl2idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE");
-  supportedCons.insert(
-      "_ZN2cl4sycl2idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE");
-  supportedCons.insert(
-      "_ZN2cl4sycl2idILi3EEC1ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE");
-  supportedCons.insert(
-      "_ZN2cl4sycl2idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm");
-  supportedCons.insert(
-      "_ZN2cl4sycl2idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm");
-  supportedCons.insert(
-      "_ZN2cl4sycl2idILi3EEC1ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm");
-  supportedCons.insert(
-      "_ZN2cl4sycl2idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm");
-  supportedCons.insert(
-      "_ZN2cl4sycl2idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm");
-  supportedCons.insert(
-      "_ZN2cl4sycl2idILi3EEC1ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm");
-  supportedCons.insert("_ZN2cl4sycl6detail5arrayILi1EEC1ILi1EEENSt9enable_"
-                       "ifIXeqT_Li1EEmE4typeE");
+void MLIRScanner::initSupportedFunctions() {
+  // Functions needed for single_task with one dimensional write buffer.
+  supportedFuncs.insert("_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_"
+                        "2idILi1EEENS0_5rangeILi1EEES7_");
+  supportedFuncs.insert(
+      "_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_"
+      "6targetE2014ELNS2_11placeholderE0ENS0_"
+      "3ext6oneapi22accessor_property_listIJEEEEC1Ev");
+  supportedFuncs.insert(
+      "_ZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_"
+      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
+      "listIJEEEEixILi1EvEERiNS0_2idILi1EEE");
+  supportedFuncs.insert(
+      "_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_"
+      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
+      "listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE");
+  supportedFuncs.insert("_ZN4sycl3_V16detail5arrayILi1EEC1ILi1EEENSt9enable_"
+                        "ifIXeqT_Li1EEmE4typeE");
+  supportedFuncs.insert("_ZN4sycl3_V16detail5arrayILi1EEC1ERKS3_");
+  supportedFuncs.insert("_ZN4sycl3_V12idILi1EEC1Ev");
+  supportedFuncs.insert("_ZN4sycl3_V12idILi1EEC1ERKS2_");
+  supportedFuncs.insert(
+      "_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE");
+  supportedFuncs.insert("_ZN4sycl3_V15rangeILi1EEC1ERKS2_");
 }
 
 void MLIRScanner::init(mlir::func::FuncOp function, const FunctionDecl *fd) {
@@ -153,7 +151,7 @@ void MLIRScanner::init(mlir::func::FuncOp function, const FunctionDecl *fd) {
     llvm::errs() << *fd << "\n";
   }
 
-  initSupportedConstructors();
+  initSupportedFunctions();
   setEntryAndAllocBlock(function.addEntryBlock());
 
   unsigned i = 0;
@@ -1502,7 +1500,7 @@ ValueCategory MLIRScanner::VisitConstructCommon(clang::CXXConstructExpr *cons,
     if (DebugFunction) {
       llvm::dbgs() << "Starting codegen of " << name << "\n";
     }
-    if (isSupportedConstructor(name)) {
+    if (isSupportedFunctions(name)) {
       if (DebugFunction) {
         llvm::dbgs() << "Function found in registry, continue codegen-ing...\n";
       }
@@ -3664,7 +3662,7 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
     }
     assert(se.val);
     auto Derived =
-         (E->isLValue() || E->isXValue())
+        (E->isLValue() || E->isXValue())
             ? cast<CXXRecordDecl>(
                   E->getSubExpr()->getType()->castAs<RecordType>()->getDecl())
             : E->getSubExpr()->getType()->getPointeeCXXRecordDecl();

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -137,6 +137,7 @@ void MLIRScanner::initSupportedFunctions() {
   supportedFuncs.insert("_ZN4sycl3_V16detail5arrayILi1EEC1ERKS3_");
   supportedFuncs.insert("_ZN4sycl3_V12idILi1EEC1Ev");
   // TODO: Add support to the commented out functions.
+  // These commented out require fixes to their codegen.
   // supportedFuncs.insert("_ZN4sycl3_V12idILi1EEC1ERKS2_");
   supportedFuncs.insert(
       "_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE");

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -155,10 +155,10 @@ private:
   std::vector<LoopContext> loops;
   mlir::Block *allocationScope;
 
-  llvm::SmallSet<std::string, 4> supportedCons;
-  void initSupportedConstructors();
-  bool isSupportedConstructor(std::string name) const {
-    return supportedCons.contains(name);
+  llvm::SmallSet<std::string, 4> supportedFuncs;
+  void initSupportedFunctions();
+  bool isSupportedFunctions(std::string name) const {
+    return supportedFuncs.contains(name);
   }
 
   // ValueCategory getValue(std::string name);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -156,6 +156,8 @@ private:
   mlir::Block *allocationScope;
 
   llvm::SmallSet<std::string, 4> supportedFuncs;
+  // Initialize a whitelist of SYCL functions to emit instead just the
+  // declaration. Eventually, this list should be removed.
   void initSupportedFunctions();
   bool isSupportedFunctions(std::string name) const {
     return supportedFuncs.contains(name);

--- a/polygeist/tools/cgeist/Test/Verification/gettimeofday.c
+++ b/polygeist/tools/cgeist/Test/Verification/gettimeofday.c
@@ -9,7 +9,6 @@ double alloc() {
 }
 
 // clang-format off
-
 // CHECK:   func @alloc() -> f64
 // CHECK-NEXT:     %cst = arith.constant 9.9999999999999995E-7 : f64
 // CHECK-NEXT:     %0 = memref.alloca() : memref<1x2xi64>


### PR DESCRIPTION
We decided to create a whitelist of SYCL functions to emit instead just the declaration. 
Eventually, this list should be removed.

As we are focusing on the single_task with one dimensional write buffer scenario, update the list to just the SYCL functions that are required by that scenario .

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>