### PR TITLE
[SYCL-MLIR]: Generate sycl.cast instead of memref.cast for sycl.id or sycl.range to sycl.array

### DIFF
--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -9,18 +9,27 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: sycl-clang.py %s -S 2> /dev/null | FileCheck %s
-// Due to pass pipeline failure for the constructor (which is not being filtered
-// out), I am keeping this as expected failure, as making this pass will require
-// changing a lot of CHECK lines.  When the pass pipeline failure is fixed, we
-// will take the XFAIL out.
-
-// XFAIL: *
 
 #include <sycl/sycl.hpp>
 
-// CHECK: !sycl_id_2_ = !sycl.id<2>
-// CHECK: !sycl_item_2_1_ = !sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>)>
+// clang-format off
+// CHECK-DAG: !sycl_id_2_ = !sycl.id<2>
+// CHECK-DAG: !sycl_item_2_1_ = !sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>)>
+// CHECK-DAG: !sycl_range_1_ = !sycl.range<1>
 
+// Ensure the constructors are NOT filtered out, and sycl.cast is generated for cast from sycl.id or sycl.range to sycl.array.
+// CHECK:      func.func @_ZN4sycl3_V12idILi1EEC1ERKS2_(%arg0: memref<?x!sycl_id_1_>, %arg1: memref<?x!sycl_id_1_>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl_id_1_>) -> memref<?x!sycl_array_1_>
+// CHECK:      func.func @_ZN4sycl3_V15rangeILi1EEC1ERKS2_(%arg0: memref<?x!sycl_range_1_>, %arg1: memref<?x!sycl_range_1_>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl_range_1_>) -> memref<?x!sycl_array_1_>
+// clang-format on
+
+SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
+  auto id = sycl::id<1>{i};
+  auto range = sycl::range<1>{r};
+}
+
+// clang-format off
 // CHECK: func.func @_Z6cons_1v() attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT: %false = arith.constant false
 // CHECK-NEXT: %c0_i8 = arith.constant 0 : i8
@@ -30,9 +39,10 @@
 // CHECK-NEXT: %3 = "polygeist.typeSize"() {source = !sycl_id_2_} : () -> index
 // CHECK-NEXT: %4 = arith.index_cast %3 : index to i64
 // CHECK-NEXT: "llvm.intr.memset"(%2, %c0_i8, %4, %false) : (!llvm.ptr<i8>, i8, i64, i1) -> ()
-// CHECK-NEXT: sycl.constructor(%1) {Type = @id} : (memref<?x!sycl_id_2_>) -> ()
+// CHECK-NEXT: sycl.constructor(%1) {MangledName = @_ZN4sycl3_V12idILi2EEC1Ev, Type = @id} : (memref<?x!sycl_id_2_>) -> ()
 // CHECK-NEXT: return
 // CHECK-NEXT: }
+// clang-format on
 
 // clang-format off
 // Ensure declaration to have external linkage.
@@ -43,40 +53,46 @@ SYCL_EXTERNAL void cons_1() {
   auto id = sycl::id<2>{};
 }
 
+// clang-format off
 // CHECK: func.func @_Z6cons_2mm(%arg0: i64, %arg1: i64) attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
 // CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
-// CHECK-NEXT: sycl.constructor(%1, %arg0, %arg1) {Type = @id} : (memref<?x!sycl_id_2_>, i64, i64) -> ()
+// CHECK-NEXT: sycl.constructor(%1, %arg0, %arg1) {MangledName = @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, Type = @id} : (memref<?x!sycl_id_2_>, i64, i64) -> ()
 // CHECK-NEXT: return
 // CHECK-NEXT: }
+// clang-format on
 
 SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
   auto id = sycl::id<2>{a, b};
 }
 
-// CHECK: func.func @_Z6cons_3N2cl4sycl4itemILi2ELb1EEE(%arg0: !sycl_item_2_1_) attributes {llvm.linkage = #llvm.linkage<external>} {
+// clang-format off
+// CHECK: func.func @_Z6cons_3N4sycl3_V14itemILi2ELb1EEE(%arg0: !sycl_item_2_1_) attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
 // CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
 // CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl_item_2_1_>
 // CHECK-NEXT: %3 = memref.cast %2 : memref<1x!sycl_item_2_1_> to memref<?x!sycl_item_2_1_>
 // CHECK-NEXT: affine.store %arg0, %2[0] : memref<1x!sycl_item_2_1_>
-// CHECK-NEXT: sycl.constructor(%1, %3) {Type = @id} : (memref<?x!sycl_id_2_>, memref<?x!sycl_item_2_1_>) -> ()
+// CHECK-NEXT: sycl.constructor(%1, %3) {MangledName = @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE, Type = @id} : (memref<?x!sycl_id_2_>, memref<?x!sycl_item_2_1_>) -> ()
 // CHECK-NEXT: return
 // CHECK-NEXT: }
+// clang-format on
 
 SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
   auto id = sycl::id<2>{val};
 }
 
-// CHECK: func.func @_Z6cons_4N2cl4sycl2idILi2EEE(%arg0: !sycl_id_2_) attributes {llvm.linkage = #llvm.linkage<external>} {
+// clang-format off
+// CHECK: func.func @_Z6cons_4N4sycl3_V12idILi2EEE(%arg0: !sycl_id_2_) attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
 // CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
 // CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl_id_2_>
 // CHECK-NEXT: %3 = memref.cast %2 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
 // CHECK-NEXT: affine.store %arg0, %2[0] : memref<1x!sycl_id_2_>
-// CHECK-NEXT: sycl.constructor(%1, %3) {Type = @id} : (memref<?x!sycl_id_2_>, memref<?x!sycl_id_2_>) -> ()
+// CHECK-NEXT: sycl.constructor(%1, %3) {MangledName = @_ZN4sycl3_V12idILi2EEC1ERKS2_, Type = @id} : (memref<?x!sycl_id_2_>, memref<?x!sycl_id_2_>) -> ()
 // CHECK-NEXT: return
 // CHECK-NEXT: }
+// clang-format on
 
 SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
   auto id = sycl::id<2>{val};


### PR DESCRIPTION
Before this PR copy constructors for `sycl.id` and `sycl.range` generates operations like:
```
%1 = "polygeist.subindex"(%arg0, %0) : (memref<?x!sycl.id<1>>, index) -> memref<!sycl.id<1>>
%2 = "memref.cast"(%1) : (memref<!sycl.id<1>>) -> memref<?x!sycl.array<[1], (memref<1xi64>)>>
```
cast between sycl type should use `sycl.cast` operator instead of `memref.cast`. 
This PR limits the change to `sycl.id` or `sycl.range` to `sycl.array`.
cast operator expects memref shapes between input and output to be the same.
[According to the author of polygeist](https://github.com/llvm/Polygeist/issues/266), `polygeist.subindex` can both generate output type as `memref<sycl.id<1>>` or `memref<?xsycl.id<1>>`, assuming input type is `memref<?xsycl.id<1>>`.
This PR change the output type of `polygeist.subindex` to `memref<?xsycl.id<1>>`, to prevent dimension mismatch.
After this PR copy constructors for `sycl.id` and `sycl.range` generates operations like:
```
%1 = "polygeist.subindex"(%arg0, %0) : (memref<?x!sycl.id<1>>, index) -> memref<?x!sycl.id<1>>
%2 = "sycl.cast"(%1) : (memref<?x!sycl.id<1>>) -> memref<?x!sycl.array<[1], (memref<1xi64>)>>
```

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>