### PR TITLE
[SYCL-MLIR]: Modify linkage to external for declaration

### DIFF
--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -4715,7 +4715,7 @@ mlir::func::FuncOp MLIRASTConsumer::GetOrCreateMLIRFunction(
   assert(name != "free");
 
   llvm::GlobalValue::LinkageTypes LV;
-  if (!FD->hasBody())
+  if (!FD->hasBody() || !ShouldEmit)
     LV = llvm::GlobalValue::LinkageTypes::ExternalLinkage;
   else if (auto CC = dyn_cast<CXXConstructorDecl>(FD))
     LV = CGM.getFunctionLinkage(GlobalDecl(CC, CXXCtorType::Ctor_Complete));

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -34,6 +34,11 @@
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
+// clang-format off
+// Ensure declaration to have external linkage.
+// CHECK: func.func private @_ZN4sycl3_V12idILi2EEC1Ev(memref<?x!sycl_id_2_>) attributes {llvm.linkage = #llvm.linkage<external>}
+// clang-format on
+
 SYCL_EXTERNAL void cons_1() {
   auto id = sycl::id<2>{};
 }


### PR DESCRIPTION
Function declarations are created in `clang-mlir.cc` for SYCL constructors used in a device kernel.
e.g., `func.func private @_ZN4sycl3_V15rangeILi1EEC1ERKS2_(memref<?x!sycl.range<1>>, memref<?x!sycl.range<1>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>}`
During LLVMIR generation, in `LLVMDialect.cpp`, it verifies that external functions have external linkage.
It determines that declarations are external functions. The declarations generated in `clang-mlir.cc` don't have external linkage.
So there is an error generated from `LLVMDialect.cpp`.
This PR generates the linkage for these declarations as external in `clang-mlir.cc`.

```
bash-4.4$ cat t.mlir
func.func private @foo() attributes {llvm.linkage = #llvm.linkage<linkonce_odr>}
bash-4.4$ cgeist t.mlir -S -emit-llvm
loc("module.mlir":1:1): error: 'llvm.func' op external functions must have 'external' or 'extern_weak' linkage
*** Finalize failed (phase 3). Module: ***
"builtin.module"() ({
  "llvm.func"() ({
  }) {CConv = #llvm.cconv<ccc>, function_type = !llvm.func<void ()>, linkage = #llvm.linkage<linkonce_odr>, sym_name = "foo", sym_visibility = "private"} : () -> ()
}) : () -> ()
Failed to execute pass pipeline correctly, rc = 14.
```

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>