### PR TITLE
[SYCL] Remove CG/handler extended members mechanism

### DIFF
--- a/sycl/doc/developer/ABIPolicyGuide.md
+++ b/sycl/doc/developer/ABIPolicyGuide.md
@@ -123,10 +123,3 @@ Whenever you need to change the existing ABI, please, follow these steps:
    part of version, as described above)
 
 At the end of this window we will increment major version of the DPC++ library
-
-## BKMs on avoiding changing ABI
-
-1. If there is a need to add a new field in `sycl::handler` or/and
-   `sycl::detail::CG` classes it can be done without breaking ABI using the
-   approach described in the comment at the beggining of
-   [cg.hpp](../../include/sycl/detail/cg.hpp)

--- a/sycl/include/sycl/detail/cg.hpp
+++ b/sycl/include/sycl/detail/cg.hpp
@@ -46,10 +46,12 @@ class stream_impl;
 class queue_impl;
 class kernel_bundle_impl;
 
+// If there's a need to add new members to CG classes without breaking ABI
+// compatibility, we can bring back the extended members mechanism. See
+// https://github.com/intel/llvm/pull/6759
 /// Base class for all types of command groups.
 class CG {
 public:
-
   /// Type of the command group.
   enum CGTYPE : unsigned int {
     None = 0,

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -381,13 +381,11 @@ private:
   }
 
   void setType(detail::CG::CGTYPE Type) {
-    constexpr detail::CG::CG_VERSION Version = detail::CG::CG_VERSION::V1;
-    MCGType = static_cast<detail::CG::CGTYPE>(
-        getVersionedCGType(Type, static_cast<int>(Version)));
+    MCGType = Type;
   }
 
   detail::CG::CGTYPE getType() {
-    return static_cast<detail::CG::CGTYPE>(getUnversionedCGType(MCGType));
+    return MCGType;
   }
 
   void throwIfActionIsCreated() {

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -380,13 +380,9 @@ private:
     return Storage;
   }
 
-  void setType(detail::CG::CGTYPE Type) {
-    MCGType = Type;
-  }
+  void setType(detail::CG::CGTYPE Type) { MCGType = Type; }
 
-  detail::CG::CGTYPE getType() {
-    return MCGType;
-  }
+  detail::CG::CGTYPE getType() { return MCGType; }
 
   void throwIfActionIsCreated() {
     if (detail::CG::None != getType())

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -87,10 +87,6 @@ XPTIRegistry &GlobalHandler::getXPTIRegistry() {
   return getOrCreate(MXPTIRegistry);
 }
 
-std::mutex &GlobalHandler::getHandlerExtendedMembersMutex() {
-  return getOrCreate(MHandlerExtendedMembersMutex);
-}
-
 ThreadPool &GlobalHandler::getHostTaskThreadPool() {
   int Size = SYCLConfig<SYCL_QUEUE_THREAD_POOL_SIZE>::get();
   ThreadPool &TP = getOrCreate(MHostTaskThreadPool, Size);

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -67,7 +67,6 @@ public:
   std::vector<plugin> &getPlugins();
   device_filter_list &getDeviceFilterList(const std::string &InitValue);
   XPTIRegistry &getXPTIRegistry();
-  std::mutex &getHandlerExtendedMembersMutex();
   ThreadPool &getHostTaskThreadPool();
 
   static void registerDefaultContextReleaseHandler();
@@ -101,8 +100,6 @@ private:
   InstWithLock<std::vector<plugin>> MPlugins;
   InstWithLock<device_filter_list> MDeviceFilterList;
   InstWithLock<XPTIRegistry> MXPTIRegistry;
-  // The mutex for synchronizing accesses to handlers extended members
-  InstWithLock<std::mutex> MHandlerExtendedMembersMutex;
   // Thread pool for host task and event callbacks execution
   InstWithLock<ThreadPool> MHostTaskThreadPool;
 };

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -38,10 +38,6 @@ handler::handler(std::shared_ptr<detail::queue_impl> Queue,
     : MImpl(std::make_shared<detail::handler_impl>(std::move(PrimaryQueue),
                                                    std::move(SecondaryQueue))),
       MQueue(std::move(Queue)), MIsHost(IsHost) {
-  // Create extended members
-  auto ExtendedMembers =
-      std::make_shared<std::vector<detail::ExtendedMemberT>>();
-  MSharedPtrStorage.push_back(std::move(ExtendedMembers));
 }
 
 // Sets the submission state to indicate that an explicit kernel bundle has been

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -37,8 +37,7 @@ handler::handler(std::shared_ptr<detail::queue_impl> Queue,
                  bool IsHost)
     : MImpl(std::make_shared<detail::handler_impl>(std::move(PrimaryQueue),
                                                    std::move(SecondaryQueue))),
-      MQueue(std::move(Queue)), MIsHost(IsHost) {
-}
+      MQueue(std::move(Queue)), MIsHost(IsHost) {}
 
 // Sets the submission state to indicate that an explicit kernel bundle has been
 // set. Throws a sycl::exception with errc::invalid if the current state


### PR DESCRIPTION
Now that the extended members have been promoted to proper fields of CG/handler classes, the extended member mechanism can be removed until it's needed again.