### PR TITLE
[SYCL][ABI-Break] Promote binary image properties and make it extendible

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -30,7 +30,7 @@ set(SYCL_MINOR_VERSION 7)
 set(SYCL_PATCH_VERSION 0)
 # Don't forget to re-enable sycl_symbols_windows.dump once we leave ABI-breaking
 # window!
-set(SYCL_DEV_ABI_VERSION 16)
+set(SYCL_DEV_ABI_VERSION 17)
 if (SYCL_ADD_DEV_VERSION_POSTFIX)
   set(SYCL_VERSION_POSTFIX "-${SYCL_DEV_ABI_VERSION}")
 endif()

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -590,6 +590,16 @@ std::ostream &operator<<(std::ostream &Out, const DeviceBinaryProperty &P) {
   return Out;
 }
 
+DeviceBinaryImage::DeviceBinaryImage(pi_device_binary Bin)
+    : BinProperties(
+          static_cast<size_t>(PropertyOffsetID::PropertyOffsetIDSize)) {
+  init(Bin);
+}
+
+DeviceBinaryImage::DeviceBinaryImage()
+    : Bin(nullptr), BinProperties(static_cast<size_t>(
+                        PropertyOffsetID::PropertyOffsetIDSize)) {}
+
 void DeviceBinaryImage::print() const {
   std::cerr << "  --- Image " << Bin << "\n";
   if (!Bin)
@@ -836,10 +846,22 @@ void DeviceBinaryImage::init(pi_device_binary Bin) {
     // try to determine the format; may remain "NONE"
     Format = getBinaryImageFormat(Bin->BinaryStart, getSize());
 
-  SpecConstIDMap.init(Bin, __SYCL_PI_PROPERTY_SET_SPEC_CONST_MAP);
-  DeviceLibReqMask.init(Bin, __SYCL_PI_PROPERTY_SET_DEVICELIB_REQ_MASK);
-  KernelParamOptInfo.init(Bin, __SYCL_PI_PROPERTY_SET_KERNEL_PARAM_OPT_INFO);
-  ProgramMetadata.init(Bin, __SYCL_PI_PROPERTY_SET_PROGRAM_METADATA);
+  getBinProperty(PropertyOffsetID::SpecConstIDMap)
+      .init(Bin, __SYCL_PI_PROPERTY_SET_SPEC_CONST_MAP);
+  getBinProperty(PropertyOffsetID::SpecConstDefaultValuesMap)
+      .init(Bin, __SYCL_PI_PROPERTY_SET_SPEC_CONST_DEFAULT_VALUES_MAP);
+  getBinProperty(PropertyOffsetID::DeviceLibReqMask)
+      .init(Bin, __SYCL_PI_PROPERTY_SET_DEVICELIB_REQ_MASK);
+  getBinProperty(PropertyOffsetID::KernelParamOptInfo)
+      .init(Bin, __SYCL_PI_PROPERTY_SET_KERNEL_PARAM_OPT_INFO);
+  getBinProperty(PropertyOffsetID::AssertUsed)
+      .init(Bin, __SYCL_PI_PROPERTY_SET_SYCL_ASSERT_USED);
+  getBinProperty(PropertyOffsetID::ProgramMetadata)
+      .init(Bin, __SYCL_PI_PROPERTY_SET_PROGRAM_METADATA);
+  getBinProperty(PropertyOffsetID::ExportedSymbols)
+      .init(Bin, __SYCL_PI_PROPERTY_SET_SYCL_EXPORTED_SYMBOLS);
+  getBinProperty(PropertyOffsetID::DeviceGlobals)
+      .init(Bin, __SYCL_PI_PROPERTY_SET_SYCL_DEVICE_GLOBALS);
 }
 
 } // namespace pi


### PR DESCRIPTION
Previously adding parsing of new properties from sycl-post-link in the runtime required repeat initialization of the corresponding property ranges as making them members would break ABI.
This commit moves the members into a vector which is initialized by the constructors inside the source of the runtime library. Doing this ensures that the corresponding vector will have at least as much space as the headers on the user-side needs and exactly the amount that the runtime library expects, preventing out-of-bounds accesses while allowing future extendibility without breaking ABI.