### PR TITLE
[SYCL-MLIR][SYCL-TO-LLVM]: Convert sycl.cast operator

### DIFF
--- a/mlir-sycl/include/mlir/Conversion/SYCLToLLVM/SYCLToLLVM.h
+++ b/mlir-sycl/include/mlir/Conversion/SYCLToLLVM/SYCLToLLVM.h
@@ -14,25 +14,10 @@
 #define MLIR_CONVERSION_SYCLTOLLVM_SYCLTOLLVM_H
 
 #include "mlir/Transforms/DialectConversion.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 
 namespace mlir {
 class LLVMTypeConverter;
-class MLIRContext;
-class ModuleOp;
-
 namespace sycl {
-template <typename SYCLOp>
-class SYCLToLLVMConversion : public OpConversionPattern<SYCLOp> {
-public:
-  SYCLToLLVMConversion(MLIRContext *context, LLVMTypeConverter &typeConverter,
-                       PatternBenefit benefit = 1)
-      : OpConversionPattern<SYCLOp>(typeConverter, context, benefit),
-        typeConverter(typeConverter) {}
-
-protected:
-  LLVMTypeConverter &typeConverter;
-};
 
 /// Populates type conversions with additional SYCL types.
 void populateSYCLToLLVMTypeConversion(LLVMTypeConverter &typeConverter);

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -12,8 +12,10 @@
 #define SYCL_OPS
 
 include "mlir/IR/OpBase.td"
-include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Dialect/MemRef/IR/MemRefBase.td"
 include "mlir/Interfaces/CastInterfaces.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Interfaces/ViewLikeInterface.td"
 
 ////////////////////////////////////////////////////////////////////////////////
 // TYPE DECLARATIONS
@@ -88,12 +90,11 @@ def SYCLConstructorOp : SYCL_Op<"constructor", []> {
 // CAST OPERATION
 ////////////////////////////////////////////////////////////////////////////////
 
-def CastArgs : AnyTypeOf<[IDMemRef, RangeMemRef]>;
+def CastArg : AnyTypeOf<[IDMemRef, RangeMemRef]>;
 def CastRes : AnyTypeOf<[ArrayMemRef]>;
-def SYCLCastOp : SYCL_Op<"cast", [
-    DeclareOpInterfaceMethods<CastOpInterface>,
-    NoSideEffect]
-  > {
+def SYCLCastOp : Op<SYCL_Dialect, "cast", [DeclareOpInterfaceMethods<CastOpInterface>, 
+  NoSideEffect, MemRefsNormalizable]
+> {
   let summary = "Derive to base cast operation";
   let description = [{
     This operation is used when a method of the base type is called with its
@@ -101,11 +102,11 @@ def SYCLCastOp : SYCL_Op<"cast", [
     cast the type to its base type.
   }];
 
-  let arguments = (ins CastArgs:$Args);
-  let results = (outs CastRes:$Result);
+  let arguments = (ins CastArg:$source);
+  let results = (outs CastRes:$result);
 
   let assemblyFormat = [{
-    `(` $Args `)` attr-dict `:` functional-type($Args, results)
+    `(` $source `)` attr-dict `:` functional-type($source, results)
   }];
 }
 
@@ -126,12 +127,12 @@ def SYCLCallOp : SYCL_Op<"call", []> {
     FlatSymbolRefAttr:$MangledName,
     Variadic<AnyType>:$Args
   );
-  let results = (outs Optional<AnyType>:$Result);
+  let results = (outs Optional<AnyType>:$result);
 
   let skipDefaultBuilders = 1;
   let builders = [
     OpBuilder<(ins
-    "::llvm::Optional<::mlir::Type>":$Result,
+    "::llvm::Optional<::mlir::Type>":$result,
     "::llvm::Optional<::llvm::StringRef>":$Type,
     "::llvm::StringRef":$Function,
     "::llvm::StringRef":$MangledName,
@@ -142,8 +143,8 @@ def SYCLCallOp : SYCL_Op<"call", []> {
       }
       odsState.addAttribute(FunctionAttrName(odsState.name), ::mlir::SymbolRefAttr::get(odsBuilder.getContext(), Function));
       odsState.addAttribute(MangledNameAttrName(odsState.name), ::mlir::SymbolRefAttr::get(odsBuilder.getContext(), MangledName));
-      if (Result.hasValue()) {
-        odsState.addTypes(Result.getValue());
+      if (result.hasValue()) {
+        odsState.addTypes(result.getValue());
       }
     }]>
   ];
@@ -151,6 +152,13 @@ def SYCLCallOp : SYCL_Op<"call", []> {
   let assemblyFormat = [{
     `(` $Args `)` attr-dict `:` functional-type($Args, results)
   }];
+
+  let extraClassDeclaration = [{
+    /// Return the result type of a sycl.call operation.
+    ::mlir::Type getType() { 
+      assert(!getODSResults(0).empty() && "CallOp does not return a value");
+      return getResult(0).getType(); }
+  }];  
 }
 
 #endif // SYCL_OPS

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -15,7 +15,6 @@ include "mlir/IR/OpBase.td"
 include "mlir/Dialect/MemRef/IR/MemRefBase.td"
 include "mlir/Interfaces/CastInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
-include "mlir/Interfaces/ViewLikeInterface.td"
 
 ////////////////////////////////////////////////////////////////////////////////
 // TYPE DECLARATIONS
@@ -92,7 +91,7 @@ def SYCLConstructorOp : SYCL_Op<"constructor", []> {
 
 def CastArg : AnyTypeOf<[IDMemRef, RangeMemRef]>;
 def CastRes : AnyTypeOf<[ArrayMemRef]>;
-def SYCLCastOp : Op<SYCL_Dialect, "cast", [DeclareOpInterfaceMethods<CastOpInterface>, 
+def SYCLCastOp : SYCL_Op<"cast", [DeclareOpInterfaceMethods<CastOpInterface>, 
   NoSideEffect, MemRefsNormalizable]
 > {
   let summary = "Derive to base cast operation";
@@ -152,13 +151,6 @@ def SYCLCallOp : SYCL_Op<"call", []> {
   let assemblyFormat = [{
     `(` $Args `)` attr-dict `:` functional-type($Args, results)
   }];
-
-  let extraClassDeclaration = [{
-    /// Return the result type of a sycl.call operation.
-    ::mlir::Type getType() { 
-      assert(!getODSResults(0).empty() && "CallOp does not return a value");
-      return getResult(0).getType(); }
-  }];  
 }
 
 #endif // SYCL_OPS

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -290,7 +290,7 @@ private:
 
     // Cast the source memref descriptor's allocate & aligned pointers to the
     // type of those pointers in the results memref.
-    Location loc = op.getLoc();    
+    Location loc = op.getLoc();
     LLVMBuilder builder(rewriter, loc);
     MemRefDescriptor srcMemRefDesc(opAdaptor.source());
     Value allocatedPtr = builder.genBitcast(
@@ -306,8 +306,8 @@ private:
     }
 
     MemRefDescriptor resMemRefDesc = createMemRefDescriptor(
-          loc, resType, allocatedPtr, alignedPtr, sizes, strides, rewriter);
-    resMemRefDesc.setOffset(rewriter, loc, srcMemRefDesc.offset(rewriter, loc));          
+        loc, resType, allocatedPtr, alignedPtr, sizes, strides, rewriter);
+    resMemRefDesc.setOffset(rewriter, loc, srcMemRefDesc.offset(rewriter, loc));
 
     rewriter.replaceOp(op.getOperation(), {resMemRefDesc});
 

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -284,7 +284,7 @@ private:
            "The result source type should be a memref type");
 
     Location loc = op.getLoc();
-    LLVMBuilder builder(rewriter, loc);    
+    LLVMBuilder builder(rewriter, loc);
 
     // Ensure the input and result types are legal.
     auto srcType = op.source().getType().cast<MemRefType>();
@@ -301,7 +301,8 @@ private:
     auto resMemRefDesc = MemRefDescriptor::undef(rewriter, loc, convResType);
 
     // Cast the allocated and aligned pointer fields of the source memref
-    // descriptor to the type of the same fields in the result memref descriptor.
+    // descriptor to the type of the same fields in the result memref
+    // descriptor.
     MemRefDescriptor srcMemRefDesc(opAdaptor.source());
     Value allocatedPtr =
         builder.genBitcast(resMemRefDesc.getElementPtrType(),
@@ -316,8 +317,10 @@ private:
     resMemRefDesc.setOffset(rewriter, loc, srcMemRefDesc.offset(rewriter, loc));
 
     for (int pos = 0; pos < resType.getRank(); ++pos) {
-      resMemRefDesc.setSize(rewriter, loc, pos, srcMemRefDesc.size(rewriter, loc, pos));
-      resMemRefDesc.setStride(rewriter, loc, pos, srcMemRefDesc.stride(rewriter, loc, pos));     
+      resMemRefDesc.setSize(rewriter, loc, pos,
+                            srcMemRefDesc.size(rewriter, loc, pos));
+      resMemRefDesc.setStride(rewriter, loc, pos,
+                              srcMemRefDesc.stride(rewriter, loc, pos));
     }
 
     rewriter.replaceOp(op.getOperation(), {resMemRefDesc});
@@ -387,47 +390,47 @@ private:
     rewriter.eraseOp(op);
     return success();
   }
-  };
+};
 
-  //===----------------------------------------------------------------------===//
-  // Pattern population
-  //===----------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
+// Pattern population
+//===----------------------------------------------------------------------===//
 
-  void mlir::sycl::populateSYCLToLLVMTypeConversion(
-      LLVMTypeConverter &typeConverter) {
-    typeConverter.addConversion([&](sycl::AccessorImplDeviceType type) {
-      return convertAccessorImplDeviceType(type, typeConverter);
-    });
-    typeConverter.addConversion([&](sycl::AccessorType type) {
-      return convertAccessorType(type, typeConverter);
-    });
-    typeConverter.addConversion([&](sycl::ArrayType type) {
-      return convertArrayType(type, typeConverter);
-    });
-    typeConverter.addConversion([&](sycl::GroupType type) {
-      return convertGroupType(type, typeConverter);
-    });
-    typeConverter.addConversion(
-        [&](sycl::IDType type) { return convertIDType(type, typeConverter); });
-    typeConverter.addConversion([&](sycl::ItemBaseType type) {
-      return convertItemBaseType(type, typeConverter);
-    });
-    typeConverter.addConversion([&](sycl::ItemType type) {
-      return convertItemType(type, typeConverter);
-    });
-    typeConverter.addConversion([&](sycl::NdItemType type) {
-      return convertNdItemType(type, typeConverter);
-    });
-    typeConverter.addConversion([&](sycl::RangeType type) {
-      return convertRangeType(type, typeConverter);
-    });
-  }
+void mlir::sycl::populateSYCLToLLVMTypeConversion(
+    LLVMTypeConverter &typeConverter) {
+  typeConverter.addConversion([&](sycl::AccessorImplDeviceType type) {
+    return convertAccessorImplDeviceType(type, typeConverter);
+  });
+  typeConverter.addConversion([&](sycl::AccessorType type) {
+    return convertAccessorType(type, typeConverter);
+  });
+  typeConverter.addConversion([&](sycl::ArrayType type) {
+    return convertArrayType(type, typeConverter);
+  });
+  typeConverter.addConversion([&](sycl::GroupType type) {
+    return convertGroupType(type, typeConverter);
+  });
+  typeConverter.addConversion(
+      [&](sycl::IDType type) { return convertIDType(type, typeConverter); });
+  typeConverter.addConversion([&](sycl::ItemBaseType type) {
+    return convertItemBaseType(type, typeConverter);
+  });
+  typeConverter.addConversion([&](sycl::ItemType type) {
+    return convertItemType(type, typeConverter);
+  });
+  typeConverter.addConversion([&](sycl::NdItemType type) {
+    return convertNdItemType(type, typeConverter);
+  });
+  typeConverter.addConversion([&](sycl::RangeType type) {
+    return convertRangeType(type, typeConverter);
+  });
+}
 
-  void mlir::sycl::populateSYCLToLLVMConversionPatterns(
-      LLVMTypeConverter &typeConverter, RewritePatternSet &patterns) {
-    populateSYCLToLLVMTypeConversion(typeConverter);
+void mlir::sycl::populateSYCLToLLVMConversionPatterns(
+    LLVMTypeConverter &typeConverter, RewritePatternSet &patterns) {
+  populateSYCLToLLVMTypeConversion(typeConverter);
 
-    patterns.add<CallPattern>(patterns.getContext(), typeConverter);
-    patterns.add<CastPattern>(patterns.getContext(), typeConverter);    
-    patterns.add<ConstructorPattern>(patterns.getContext(), typeConverter);
-  }
+  patterns.add<CallPattern>(patterns.getContext(), typeConverter);
+  patterns.add<CastPattern>(patterns.getContext(), typeConverter);
+  patterns.add<ConstructorPattern>(patterns.getContext(), typeConverter);
+}

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -242,7 +242,7 @@ private:
     auto newOp = rewriter.replaceOpWithNewOp<LLVM::CallOp>(
         op.getOperation(), op.getNumResults() == 0 ? TypeRange() : retType,
         funcRef, opAdaptor.getOperands());
-    (void) newOp;
+    (void)newOp;
 
     LLVM_DEBUG({
       Operation *func = newOp->getParentOfType<LLVM::LLVMFuncOp>();

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-cast-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-cast-to-llvm.mlir
@@ -1,7 +1,6 @@
 // RUN: sycl-mlir-opt -split-input-file -convert-sycl-to-llvm -verify-diagnostics %s | FileCheck %s
 
 !sycl_array1 = !sycl.array<[1], (memref<1xi64>)>
-
 func.func @test1(%arg0: memref<?x!sycl.range<1>>) -> memref<?x!sycl_array1> {
   // CHECK: llvm.func @test1
   // CHECK: [[SRC:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.cl::sycl::range.1"
@@ -30,4 +29,37 @@ func.func @test1(%arg0: memref<?x!sycl.range<1>>) -> memref<?x!sycl_array1> {
 
   %0 = "sycl.cast"(%arg0) : (memref<?x!sycl.range<1>>) -> memref<?x!sycl_array1>
   func.return %0 : memref<?x!sycl_array1>
+}
+
+// -----
+
+!sycl_array1 = !sycl.array<[1], (memref<1xi64>)>
+func.func @test2(%arg0: memref<?x!sycl.id<1>>) -> memref<?x!sycl_array1> {
+  // CHECK: llvm.func @test2
+  // CHECK: [[SRC:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.cl::sycl::id.1"
+  // CHECK-DAG: [[SRC_IV0:%.*]] = llvm.insertvalue %arg0, [[SRC]][0]
+  // CHECK-DAG: [[SRC_IV1:%.*]] = llvm.insertvalue %arg1, [[SRC_IV0]][1]
+  // CHECK-DAG: [[SRC_IV2:%.*]] = llvm.insertvalue %arg2, [[SRC_IV1]][2]
+  // CHECK-DAG: [[SRC_IV3:%.*]] = llvm.insertvalue %arg3, [[SRC_IV2]][3, 0]
+  // CHECK-DAG: [[SRC_IV4:%.*]] = llvm.insertvalue %arg4, [[SRC_IV3]][4, 0]      
+
+  // CHECK: [[SRC_FIELD0:%.*]] = llvm.extractvalue [[SRC_IV4]][0]
+  // CHECK-NEXT: [[BITCAST0:%.*]] = llvm.bitcast [[SRC_FIELD0]] : !llvm.ptr<struct<"class.cl::sycl::id.1", {{.*}} to !llvm.ptr<struct<"class.cl::sycl::detail::array.1"
+  // CHECK-NEXT: [[SRC_FIELD1:%.*]] = llvm.extractvalue [[SRC_IV4]][1]
+  // CHECK-NEXT: [[BITCAST1:%.*]] = llvm.bitcast [[SRC_FIELD1]] : !llvm.ptr<struct<"class.cl::sycl::id.1", {{.*}} to !llvm.ptr<struct<"class.cl::sycl::detail::array.1"
+  // CHECK-DAG: [[SRC_FIELD2:%.*]] = llvm.extractvalue [[SRC_IV4]][2]      
+  // CHECK-DAG: [[SRC_FIELD3:%.*]] = llvm.extractvalue [[SRC_IV4]][3, 0]
+  // CHECK-DAG: [[SRC_FIELD4:%.*]] = llvm.extractvalue [[SRC_IV4]][4, 0]
+
+  // CHECK-DAG: [[RES:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.cl::sycl::detail::array.1"
+  // CHECK-DAG: [[RES_IV0:%.*]] = llvm.insertvalue [[BITCAST0]], [[RES]][0] {{.*}}
+  // CHECK-DAG: [[RES_IV1:%.*]] = llvm.insertvalue [[BITCAST1]], {{.*}}[1] {{.*}}  
+  // CHECK-DAG: [[RES_IV2:%.*]] = llvm.insertvalue [[SRC_FIELD2]], {{.*}}[2]  
+  // CHECK-DAG: [[RES_IV3:%.*]] = llvm.insertvalue [[SRC_FIELD3]], {{.*}}[3, 0]
+  // CHECK-DAG: [[RES_IV4:%.*]] = llvm.insertvalue [[SRC_FIELD4]], {{.*}}[4, 0]
+
+  // CHECK: llvm.return [[RES_IV2]] : !llvm.struct<(ptr<struct<"class.cl::sycl::detail::array.1"  
+
+  %0 = "sycl.cast"(%arg0) : (memref<?x!sycl.id<1>>) -> memref<?x!sycl_array1>
+  func.return %0: memref<?x!sycl_array1>
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-cast-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-cast-to-llvm.mlir
@@ -1,0 +1,31 @@
+// RUN: sycl-mlir-opt -split-input-file -convert-sycl-to-llvm -verify-diagnostics %s | FileCheck %s
+
+!sycl_array1 = !sycl.array<[1], (memref<1xi64>)>
+
+func.func @test1(%arg0: memref<?x!sycl.range<1>>) -> memref<?x!sycl_array1> {
+  // CHECK: llvm.func @test1
+  // CHECK: [[SRC:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.cl::sycl::range.1"
+  // CHECK-NEXT: [[SRC_IV0:%.*]] = llvm.insertvalue %arg0, [[SRC]][0]
+  // CHECK-NEXT: [[SRC_IV1:%.*]] = llvm.insertvalue %arg1, [[SRC_IV0]][1]
+  // CHECK-NEXT: [[SRC_IV2:%.*]] = llvm.insertvalue %arg2, [[SRC_IV1]][2]
+  // CHECK-NEXT: [[SRC_IV3:%.*]] = llvm.insertvalue %arg3, [[SRC_IV2]][3, 0]
+  // CHECK-NEXT: [[SRC_IV4:%.*]] = llvm.insertvalue %arg4, [[SRC_IV3]][4, 0]      
+  // CHECK: [[RES:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.cl::sycl::detail::array.1"
+
+  // CHECK: [[SRC_FIELD0:%.*]] = llvm.extractvalue [[SRC_IV4]][0]
+  // CHECK-NEXT: [[BITCAST0:%.*]] = llvm.bitcast [[SRC_FIELD0]] : !llvm.ptr<struct<"class.cl::sycl::range.1", {{.*}} to !llvm.ptr<struct<"class.cl::sycl::detail::array.1"
+  // CHECK-NEXT: [[SRC_FIELD1:%.*]] = llvm.extractvalue [[SRC_IV4]][1]
+  // CHECK-NEXT: [[BITCAST1:%.*]] = llvm.bitcast [[SRC_FIELD1]] : !llvm.ptr<struct<"class.cl::sycl::range.1", {{.*}} to !llvm.ptr<struct<"class.cl::sycl::detail::array.1"
+  // CHECK-NEXT: [[RES_IV0:%.*]] = llvm.insertvalue [[BITCAST0]], [[RES]][0] {{.*}}
+  // CHECK-NEXT: [[RES_IV1:%.*]] = llvm.insertvalue [[BITCAST1]], [[RES_IV0]][1] {{.*}}  
+  // CHECK-NEXT: [[SRC_FIELD2:%.*]] = llvm.extractvalue [[SRC_IV4]][2]
+  // CHECK-NEXT: [[RES_IV2:%.*]] = llvm.insertvalue [[SRC_FIELD2]], [[RES_IV1]][2]
+  // CHECK-NEXT: [[SRC_FIELD3:%.*]] = llvm.extractvalue [[SRC_IV4]][3, 0] 
+  // CHECK-NEXT: [[RES_IV3:%.*]] = llvm.insertvalue [[SRC_FIELD3]], [[RES_IV2]][3, 0]
+  // CHECK-NEXT: [[SRC_FIELD4:%.*]] = llvm.extractvalue [[SRC_IV4]][4, 0] 
+  // CHECK-NEXT: [[RES_IV4:%.*]] = llvm.insertvalue [[SRC_FIELD4]], [[RES_IV3]][4, 0]
+  // CHECK-NEXT: llvm.return [[RES_IV4]] : !llvm.struct<(ptr<struct<"class.cl::sycl::detail::array.1"
+
+  %0 = "sycl.cast"(%arg0) : (memref<?x!sycl.range<1>>) -> memref<?x!sycl_array1>
+  func.return %0 : memref<?x!sycl_array1>
+}

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-cast-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-cast-to-llvm.mlir
@@ -5,26 +5,28 @@
 func.func @test1(%arg0: memref<?x!sycl.range<1>>) -> memref<?x!sycl_array1> {
   // CHECK: llvm.func @test1
   // CHECK: [[SRC:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.cl::sycl::range.1"
-  // CHECK-NEXT: [[SRC_IV0:%.*]] = llvm.insertvalue %arg0, [[SRC]][0]
-  // CHECK-NEXT: [[SRC_IV1:%.*]] = llvm.insertvalue %arg1, [[SRC_IV0]][1]
-  // CHECK-NEXT: [[SRC_IV2:%.*]] = llvm.insertvalue %arg2, [[SRC_IV1]][2]
-  // CHECK-NEXT: [[SRC_IV3:%.*]] = llvm.insertvalue %arg3, [[SRC_IV2]][3, 0]
-  // CHECK-NEXT: [[SRC_IV4:%.*]] = llvm.insertvalue %arg4, [[SRC_IV3]][4, 0]      
-  // CHECK: [[RES:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.cl::sycl::detail::array.1"
+  // CHECK-DAG: [[SRC_IV0:%.*]] = llvm.insertvalue %arg0, [[SRC]][0]
+  // CHECK-DAG: [[SRC_IV1:%.*]] = llvm.insertvalue %arg1, [[SRC_IV0]][1]
+  // CHECK-DAG: [[SRC_IV2:%.*]] = llvm.insertvalue %arg2, [[SRC_IV1]][2]
+  // CHECK-DAG: [[SRC_IV3:%.*]] = llvm.insertvalue %arg3, [[SRC_IV2]][3, 0]
+  // CHECK-DAG: [[SRC_IV4:%.*]] = llvm.insertvalue %arg4, [[SRC_IV3]][4, 0]      
 
   // CHECK: [[SRC_FIELD0:%.*]] = llvm.extractvalue [[SRC_IV4]][0]
   // CHECK-NEXT: [[BITCAST0:%.*]] = llvm.bitcast [[SRC_FIELD0]] : !llvm.ptr<struct<"class.cl::sycl::range.1", {{.*}} to !llvm.ptr<struct<"class.cl::sycl::detail::array.1"
   // CHECK-NEXT: [[SRC_FIELD1:%.*]] = llvm.extractvalue [[SRC_IV4]][1]
   // CHECK-NEXT: [[BITCAST1:%.*]] = llvm.bitcast [[SRC_FIELD1]] : !llvm.ptr<struct<"class.cl::sycl::range.1", {{.*}} to !llvm.ptr<struct<"class.cl::sycl::detail::array.1"
-  // CHECK-NEXT: [[RES_IV0:%.*]] = llvm.insertvalue [[BITCAST0]], [[RES]][0] {{.*}}
-  // CHECK-NEXT: [[RES_IV1:%.*]] = llvm.insertvalue [[BITCAST1]], [[RES_IV0]][1] {{.*}}  
-  // CHECK-NEXT: [[SRC_FIELD2:%.*]] = llvm.extractvalue [[SRC_IV4]][2]
-  // CHECK-NEXT: [[RES_IV2:%.*]] = llvm.insertvalue [[SRC_FIELD2]], [[RES_IV1]][2]
-  // CHECK-NEXT: [[SRC_FIELD3:%.*]] = llvm.extractvalue [[SRC_IV4]][3, 0] 
-  // CHECK-NEXT: [[RES_IV3:%.*]] = llvm.insertvalue [[SRC_FIELD3]], [[RES_IV2]][3, 0]
-  // CHECK-NEXT: [[SRC_FIELD4:%.*]] = llvm.extractvalue [[SRC_IV4]][4, 0] 
-  // CHECK-NEXT: [[RES_IV4:%.*]] = llvm.insertvalue [[SRC_FIELD4]], [[RES_IV3]][4, 0]
-  // CHECK-NEXT: llvm.return [[RES_IV4]] : !llvm.struct<(ptr<struct<"class.cl::sycl::detail::array.1"
+  // CHECK-DAG: [[SRC_FIELD2:%.*]] = llvm.extractvalue [[SRC_IV4]][2]      
+  // CHECK-DAG: [[SRC_FIELD3:%.*]] = llvm.extractvalue [[SRC_IV4]][3, 0]
+  // CHECK-DAG: [[SRC_FIELD4:%.*]] = llvm.extractvalue [[SRC_IV4]][4, 0]
+
+  // CHECK-DAG: [[RES:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.cl::sycl::detail::array.1"
+  // CHECK-DAG: [[RES_IV0:%.*]] = llvm.insertvalue [[BITCAST0]], [[RES]][0] {{.*}}
+  // CHECK-DAG: [[RES_IV1:%.*]] = llvm.insertvalue [[BITCAST1]], {{.*}}[1] {{.*}}  
+  // CHECK-DAG: [[RES_IV2:%.*]] = llvm.insertvalue [[SRC_FIELD2]], {{.*}}[2]  
+  // CHECK-DAG: [[RES_IV3:%.*]] = llvm.insertvalue [[SRC_FIELD3]], {{.*}}[3, 0]
+  // CHECK-DAG: [[RES_IV4:%.*]] = llvm.insertvalue [[SRC_FIELD4]], {{.*}}[4, 0]
+
+  // CHECK: llvm.return [[RES_IV2]] : !llvm.struct<(ptr<struct<"class.cl::sycl::detail::array.1"  
 
   %0 = "sycl.cast"(%arg0) : (memref<?x!sycl.range<1>>) -> memref<?x!sycl_array1>
   func.return %0 : memref<?x!sycl_array1>


### PR DESCRIPTION
This PR adds the code to a `sycl.cast` operator to LLVM IR. 