### PR TITLE
[SYCL-MLIR]: Allow sycl.id as argument type of sycl.constructor

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -65,7 +65,7 @@ def IndexType : AnyTypeOf<[I32, I64, Index]>;
 // CONSTRUCTOR OPERATION
 ////////////////////////////////////////////////////////////////////////////////
 
-def ConstructorArgs : AnyTypeOf<[SYCLMemref, IndexType, SYCL_RangeType]>;
+def ConstructorArgs : AnyTypeOf<[SYCLMemref, IndexType, SYCL_IDType, SYCL_RangeType]>;
 def SYCLConstructorOp : SYCL_Op<"constructor", []> {
   let summary = "Generic constructor operation";
   let description = [{

--- a/mlir-sycl/test/Dialect/IR/SYCL/constructor.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/constructor.mlir
@@ -1,0 +1,8 @@
+// RUN: sycl-mlir-opt -allow-unregistered-dialect %s -split-input-file | FileCheck %s
+
+// Ensure sycl.id and sycl.range types can be arguments of sycl.constructor.
+// CHECK-LABEL: func.func @AccessorImplDevice
+func.func @AccessorImplDevice(%arg0: memref<?x!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>>, %arg1: !sycl.id<1>, %arg2: !sycl.range<1>) {
+  sycl.constructor(%arg0, %arg1, %arg2, %arg2) {MangledName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_, Type = @AccessorImplDevice} : (memref<?x!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>>, !sycl.id<1>, !sycl.range<1>, !sycl.range<1>) -> ()
+  return
+}


### PR DESCRIPTION
This PR allows a `sycl.constructor` operator to take a `sycl::id` as an argument. This is necessary to support construction of, for example, a `AccessorImplDevice` object which has a constructor that takes that type:

 `sycl::_V1::detail::AccessorImplDevice<1>::AccessorImplDevice(sycl::_V1::id<1>, sycl::_V1::range<1>, sycl::_V1::range<1>)`

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>