### PR TITLE
[sycl-bisect] Add missing exit

### DIFF
--- a/devops/scripts/test-commit-sycl-bisect.bash
+++ b/devops/scripts/test-commit-sycl-bisect.bash
@@ -129,6 +129,7 @@ fi
 cd "$TEST_WD"
 if [[ "$COMMAND_ALLOW_BISECT_CODES" == "" ]]; then
   bash -c "$COMMAND" || exit 1
+  exit
 fi
 
 # Otherwise, just run the command.


### PR DESCRIPTION
This script has been missing one call to exit, which causes control to fall through and run successful tests a second time when using --command without --command-allow-bisect-codes. This didn't change the results of the script, but it did make it slower if the test command takes a while to run.