### PR TITLE
[SYCL-MLIR][SYCLToLLVM][DialectBuilder]: CallOp should not check whether func exits

### DIFF
--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/DialectBuilder.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/DialectBuilder.cpp
@@ -128,10 +128,7 @@ LLVM::CallOp LLVMBuilder::genCall(FlatSymbolRefAttr funcSym, TypeRange resTypes,
 LLVM::CallOp LLVMBuilder::genCall(StringRef funcName, TypeRange resTypes,
                                   ValueRange operands, ModuleOp &module) const {
   assert(!funcName.contains('@') && "funcName should not contain '@'");
-  assert(module.lookupSymbol<LLVM::LLVMFuncOp>(funcName) &&
-         "Expecting to find a function declaration");
-  auto funcSym = SymbolRefAttr::get(builder.getContext(), funcName);
-  return genCall(funcSym, resTypes, operands);
+  return create<LLVM::CallOp>(resTypes, funcName, operands);
 }
 
 LLVM::ConstantOp LLVMBuilder::genConstant(Type type, double val) const {

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/DialectBuilder.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/DialectBuilder.cpp
@@ -96,10 +96,7 @@ func::CallOp FuncBuilder::genCall(FlatSymbolRefAttr funcSym, TypeRange resTypes,
 func::CallOp FuncBuilder::genCall(StringRef funcName, TypeRange resTypes,
                                   ValueRange operands, ModuleOp &module) const {
   assert(!funcName.contains('@') && "funcName should not contain '@'");
-  assert(module.lookupSymbol<LLVM::LLVMFuncOp>(funcName) &&
-         "Expecting to find a function declaration");
-  auto funcSym = SymbolRefAttr::get(builder.getContext(), funcName);
-  return genCall(funcSym, resTypes, operands);
+  return create<func::CallOp>(funcName, resTypes, operands);
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
When generating a `func::CallOp` we currently try to lookup the func declaration/definition in the MLIR module and assert if one is not found. This is unnecessary because the function declaration/definition might appear later in the module. Removing the assertion is fine because, when the code is lowered to the LLVM dialect, if a call to a inexistent function is found the program fails to compile cleanly. 