### PR TITLE
[SYCL] Fix llvm.used removal when used with opaque pointers.

### DIFF
--- a/llvm/test/tools/sycl-post-link/erase_used_decl_opaque.ll
+++ b/llvm/test/tools/sycl-post-link/erase_used_decl_opaque.ll
@@ -1,0 +1,25 @@
+; This test checks that the post-link tool doesn't incorrectly remove function
+; declarations which are still in use while erasing the "llvm.used" global.
+;
+; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.files.table
+; RUN: FileCheck %s -input-file=%t.files_0.ll
+;
+target triple = "spir64-unknown-unknown"
+
+; CHECK-NOT: llvm.used
+@llvm.used = appending global [2 x ptr] [ptr @notused, ptr @stillused], section "llvm.metadata"
+
+; CHECK: declare spir_func void @stillused
+declare spir_func void @stillused() #0
+declare spir_func void @notused() #0
+
+define spir_kernel void @entry() #0 {
+  call spir_func void @stillused()
+  ret void
+}
+
+define spir_kernel void @bar() #0 {
+  ret void
+}
+
+attributes #0 = { "sycl-module-id"="erase_used_decl.cpp" }

--- a/llvm/test/tools/sycl-post-link/erase_used_opaque.ll
+++ b/llvm/test/tools/sycl-post-link/erase_used_opaque.ll
@@ -1,0 +1,28 @@
+; This test checks that the post-link tool does not add "llvm.used" global to
+; the output modules when splitting modules, creating a single row table,
+; and outputing IR only
+;
+; RUN: sycl-post-link -split=kernel -S %s -o %t.files.table
+; RUN: FileCheck %s -input-file=%t.files_0.ll
+; RUN: FileCheck %s -input-file=%t.files_1.ll
+;
+; RUN: sycl-post-link -S -split=auto -symbols -split-esimd -lower-esimd -O2 -spec-const=default %s -o %t.out.table
+; RUN: FileCheck %s --input-file=%t.out_0.ll
+;
+; RUN: sycl-post-link -S -split=auto -ir-output-only %s -o %t.out_ir_only.ll
+; RUN: FileCheck %s --input-file %t.out_ir_only.ll
+
+target triple = "spir64-unknown-unknown"
+
+; CHECK-NOT: llvm.used
+@llvm.used = appending global [2 x ptr] [ptr @foo, ptr @bar], section "llvm.metadata"
+
+define weak_odr spir_kernel void @foo() #0 {
+  ret void
+}
+
+define weak_odr spir_kernel void @bar() #0 {
+  ret void
+}
+
+attributes #0 = { "sycl-module-id"="a.cpp" }


### PR DESCRIPTION
The code priorily assumed that all functions when used in @llvm.used would be wrapped within a bitcast <fnptr type> to i8*; with opaque pointers, the values would be functions directly, causing a crash since functions don't have any operands.