### PR TITLE
[Driver][SYCL] Introduce gpu specific device targets for AOT

### DIFF
--- a/clang/include/clang/Driver/Action.h
+++ b/clang/include/clang/Driver/Action.h
@@ -501,8 +501,21 @@ public:
 class CompileJobAction : public JobAction {
   void anchor() override;
 
+private:
+  /// String that keeps information about dependencies of this compile action.
+  /// This is used for device compilations for spir64_gen AOT targets
+  StringRef DependentBoundArch;
+
 public:
   CompileJobAction(Action *Input, types::ID OutputType);
+
+  /// Register information about a dependent action.
+  void registerDependentActionInfo(StringRef BoundArch) {
+    DependentBoundArch = BoundArch;
+  }
+
+  /// Return the information about all depending actions.
+  StringRef getDependentActionsInfo() const { return DependentBoundArch; }
 
   static bool classof(const Action *A) {
     return A->getKind() == CompileJobClass;
@@ -807,9 +820,22 @@ private:
 class BackendCompileJobAction : public JobAction {
   void anchor() override;
 
+private:
+  /// String that keeps information about dependencies of this backend compile
+  /// action.
+  StringRef DependentBoundArch;
+
 public:
   BackendCompileJobAction(ActionList &Inputs, types::ID OutputType);
   BackendCompileJobAction(Action *Input, types::ID OutputType);
+
+  /// Register information about a dependent action.
+  void registerDependentActionInfo(StringRef BoundArch) {
+    DependentBoundArch = BoundArch;
+  }
+
+  /// Return the information about all depending actions.
+  StringRef getDependentActionsInfo() const { return DependentBoundArch; }
 
   static bool classof(const Action *A) {
     return A->getKind() == BackendCompileJobClass;

--- a/clang/include/clang/Driver/Action.h
+++ b/clang/include/clang/Driver/Action.h
@@ -501,21 +501,8 @@ public:
 class CompileJobAction : public JobAction {
   void anchor() override;
 
-private:
-  /// String that keeps information about dependencies of this compile action.
-  /// This is used for device compilations for spir64_gen AOT targets
-  StringRef DependentBoundArch;
-
 public:
   CompileJobAction(Action *Input, types::ID OutputType);
-
-  /// Register information about a dependent action.
-  void registerDependentActionInfo(StringRef BoundArch) {
-    DependentBoundArch = BoundArch;
-  }
-
-  /// Return the information about all depending actions.
-  StringRef getDependentActionsInfo() const { return DependentBoundArch; }
 
   static bool classof(const Action *A) {
     return A->getKind() == CompileJobClass;
@@ -820,22 +807,9 @@ private:
 class BackendCompileJobAction : public JobAction {
   void anchor() override;
 
-private:
-  /// String that keeps information about dependencies of this backend compile
-  /// action.
-  StringRef DependentBoundArch;
-
 public:
   BackendCompileJobAction(ActionList &Inputs, types::ID OutputType);
   BackendCompileJobAction(Action *Input, types::ID OutputType);
-
-  /// Register information about a dependent action.
-  void registerDependentActionInfo(StringRef BoundArch) {
-    DependentBoundArch = BoundArch;
-  }
-
-  /// Return the information about all depending actions.
-  StringRef getDependentActionsInfo() const { return DependentBoundArch; }
 
   static bool classof(const Action *A) {
     return A->getKind() == BackendCompileJobClass;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -8231,12 +8231,8 @@ InputInfoList Driver::BuildJobsForActionNoCache(
           TargetDeviceOffloadKind == Action::OFK_SYCL) {
         if (UI.DependentOffloadKind == Action::OFK_Host)
           Arch = StringRef();
-        else {
-          if (TC->getTriple().isSPIR())
-            Arch = BoundArch;
-          else
-            Arch = UI.DependentBoundArch;
-        }
+        else
+          Arch = UI.DependentBoundArch;
       } else
         Arch = BoundArch;
       // When unbundling for SYCL and there is no Target offload, assume

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4816,9 +4816,7 @@ class OffloadingActionBuilder final {
           return ABRT_Success;
 
         Action *DeviceCompilerInput = nullptr;
-        for (auto TargetActionInfo :
-             llvm::zip(SYCLDeviceActions, SYCLTargetInfoList)) {
-          Action *&A = std::get<0>(TargetActionInfo);
+        for (Action *&A : SYCLDeviceActions) {
           types::ID OutputType = types::TY_LLVM_BC;
           if ((SYCLDeviceOnly || Args.hasArg(options::OPT_emit_llvm)) &&
               Args.hasArg(options::OPT_S))

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5794,7 +5794,8 @@ class OffloadingActionBuilder final {
               if (TT.isSPIR() &&
                   TT.getSubArch() == llvm::Triple::SPIRSubArch_gen) {
                 StringRef Device(GenDeviceList[J]);
-                SYCLTargetInfoList.emplace_back(*TCIt, Device.empty() ? nullptr : Device.data());
+                SYCLTargetInfoList.emplace_back(
+                    *TCIt, Device.empty() ? nullptr : Device.data());
                 ++J;
                 continue;
               }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5006,18 +5006,16 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
     // Add any predefined macros associated with intel_gpu* type targets
     // passed in with -fsycl-targets
-    if (auto *CA = dyn_cast<CompileJobAction>(&JA)) {
-      if (RawTriple.isSPIR() &&
-          RawTriple.getSubArch() == llvm::Triple::SPIRSubArch_gen) {
-        auto Device = CA->getDependentActionsInfo();
-        if (!Device.empty())
-          CmdArgs.push_back(Args.MakeArgString(
-              Twine("-D") + SYCL::gen::getGenDeviceMacro(Device)));
-      }
-      if (RawTriple.isSPIR() &&
-          RawTriple.getSubArch() == llvm::Triple::SPIRSubArch_x86_64)
-        CmdArgs.push_back("-D__SYCL_TARGET_INTEL_X86_64__");
+    if (RawTriple.isSPIR() &&
+        RawTriple.getSubArch() == llvm::Triple::SPIRSubArch_gen) {
+      StringRef Device = JA.getOffloadingArch();
+      if (!Device.empty())
+        CmdArgs.push_back(Args.MakeArgString(
+            Twine("-D") + SYCL::gen::getGenDeviceMacro(Device)));
     }
+    if (RawTriple.isSPIR() &&
+        RawTriple.getSubArch() == llvm::Triple::SPIRSubArch_x86_64)
+      CmdArgs.push_back("-D__SYCL_TARGET_INTEL_X86_64__");
   }
 
   if (IsSYCL) {

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -570,8 +570,7 @@ void SYCL::gen::BackendCompiler::ConstructJob(Compilation &C,
   // The next line prevents ocloc from modifying the image name
   CmdArgs.push_back("-output_no_suffix");
   CmdArgs.push_back("-spirv_input");
-  auto &BCA = cast<BackendCompileJobAction>(JA);
-  auto Device = BCA.getDependentActionsInfo();
+  StringRef Device = JA.getOffloadingArch();
 
   // Add -Xsycl-target* options.
   const toolchains::SYCLToolChain &TC =
@@ -827,8 +826,7 @@ void SYCLToolChain::AddImpliedTargetArgs(const llvm::Triple &Triple,
     // For GEN (spir64_gen) we have implied -device settings given usage
     // of intel_gpu_ as a target.  Handle those here, and also check that no
     // other -device was passed, as that is a conflict.
-    auto &BCA = cast<BackendCompileJobAction>(JA);
-    auto DepInfo = BCA.getDependentActionsInfo();
+    StringRef DepInfo = JA.getOffloadingArch();
     if (!DepInfo.empty()) {
       ArgStringList TargArgs;
       Args.AddAllArgValues(TargArgs, options::OPT_Xs, options::OPT_Xs_separate);

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -363,7 +363,7 @@ void SYCL::fpga::BackendCompiler::constructOpenCLAOTCommand(
   const toolchains::SYCLToolChain &TC =
       static_cast<const toolchains::SYCLToolChain &>(getToolChain());
   llvm::Triple CPUTriple("spir64_x86_64");
-  TC.AddImpliedTargetArgs(CPUTriple, Args, CmdArgs);
+  TC.AddImpliedTargetArgs(CPUTriple, Args, CmdArgs, JA);
   // Add the target args passed in
   TC.TranslateBackendTargetArgs(CPUTriple, Args, CmdArgs);
   TC.TranslateLinkerTargetArgs(CPUTriple, Args, CmdArgs);
@@ -522,7 +522,7 @@ void SYCL::fpga::BackendCompiler::ConstructJob(
         Twine("-output-report-folder=") + ReportOptArg));
 
   // Add any implied arguments before user defined arguments.
-  TC.AddImpliedTargetArgs(getToolChain().getTriple(), Args, CmdArgs);
+  TC.AddImpliedTargetArgs(getToolChain().getTriple(), Args, CmdArgs, JA);
 
   // Add -Xsycl-target* options.
   TC.TranslateBackendTargetArgs(getToolChain().getTriple(), Args, CmdArgs);
@@ -570,11 +570,15 @@ void SYCL::gen::BackendCompiler::ConstructJob(Compilation &C,
   // The next line prevents ocloc from modifying the image name
   CmdArgs.push_back("-output_no_suffix");
   CmdArgs.push_back("-spirv_input");
+  auto &BCA = cast<BackendCompileJobAction>(JA);
+  auto Device = BCA.getDependentActionsInfo();
+
   // Add -Xsycl-target* options.
   const toolchains::SYCLToolChain &TC =
       static_cast<const toolchains::SYCLToolChain &>(getToolChain());
-  TC.AddImpliedTargetArgs(getToolChain().getTriple(), Args, CmdArgs);
-  TC.TranslateBackendTargetArgs(getToolChain().getTriple(), Args, CmdArgs);
+  TC.AddImpliedTargetArgs(getToolChain().getTriple(), Args, CmdArgs, JA);
+  TC.TranslateBackendTargetArgs(getToolChain().getTriple(), Args, CmdArgs,
+                                Device);
   TC.TranslateLinkerTargetArgs(getToolChain().getTriple(), Args, CmdArgs);
   SmallString<128> ExecPath(
       getToolChain().GetProgramPath(makeExeName(C, "ocloc")));
@@ -588,6 +592,69 @@ void SYCL::gen::BackendCompiler::ConstructJob(Compilation &C,
                                 this, "", "out", ParallelJobs);
   } else
     C.addCommand(std::move(Cmd));
+}
+
+StringRef SYCL::gen::resolveGenDevice(StringRef DeviceName) {
+  StringRef Device;
+  Device = llvm::StringSwitch<StringRef>(DeviceName)
+               .Cases("bdw", "8_0_0", "bdw")
+               .Cases("skl", "9_0_9", "skl")
+               .Cases("kbl", "9_1_9", "kbl")
+               .Cases("cfl", "9_2_9", "cfl")
+               .Cases("apl", "9_3_0", "apl")
+               .Cases("glk", "9_4_0", "glk")
+               .Cases("whl", "9_5_0", "whl")
+               .Cases("aml", "9_6_0", "aml")
+               .Cases("cml", "9_7_0", "cml")
+               .Cases("icllp", "11_0_0", "icllp")
+               .Cases("ehl", "11_2_0", "ehl")
+               .Cases("tgllp", "12_0_0", "tgllp")
+               .Case("rkl", "rkl")
+               .Case("adl_s", "adl_s")
+               .Case("rpl_s", "rpl_s")
+               .Case("adl_p", "adl_p")
+               .Case("adl_n", "adl_n")
+               .Cases("dg1", "12_10_0", "dg1")
+               .Case("acm_g10", "acm_g10")
+               .Case("acm_g11", "acm_g11")
+               .Case("acm_g12", "acm_g12")
+               .Case("pvc", "pvc")
+               .Default("");
+  return Device;
+}
+
+StringRef SYCL::gen::getGenDeviceMacro(StringRef DeviceName) {
+  SmallString<64> Macro;
+  StringRef Ext = llvm::StringSwitch<StringRef>(DeviceName)
+                      .Case("bdw", "BDW")
+                      .Case("skl", "SKL")
+                      .Case("kbl", "KBL")
+                      .Case("cfl", "CFL")
+                      .Case("apl", "APL")
+                      .Case("glk", "GLK")
+                      .Case("whl", "WHL")
+                      .Case("aml", "AML")
+                      .Case("cml", "CML")
+                      .Case("icllp", "ICLLP")
+                      .Case("ehl", "EHL")
+                      .Case("tgllp", "TGLLP")
+                      .Case("rkl", "RKL")
+                      .Case("adl_s", "ADL_S")
+                      .Case("rpl_s", "RPL_S")
+                      .Case("adl_p", "ADL_P")
+                      .Case("adl_n", "ADL_N")
+                      .Case("dg1", "DG1")
+                      .Case("acm_g10", "ACM_G10")
+                      .Case("acm_g11", "ACM_G11")
+                      .Case("acm_g12", "ACM_G12")
+                      .Case("pvc", "PVC")
+                      .Default("");
+  if (!Ext.empty()) {
+    Macro = "__SYCL_TARGET_INTEL_GPU_";
+    Macro += Ext;
+    Macro += "__";
+  }
+  return Macro;
 }
 
 void SYCL::x86_64::BackendCompiler::ConstructJob(
@@ -608,7 +675,7 @@ void SYCL::x86_64::BackendCompiler::ConstructJob(
   const toolchains::SYCLToolChain &TC =
       static_cast<const toolchains::SYCLToolChain &>(getToolChain());
 
-  TC.AddImpliedTargetArgs(getToolChain().getTriple(), Args, CmdArgs);
+  TC.AddImpliedTargetArgs(getToolChain().getTriple(), Args, CmdArgs, JA);
   TC.TranslateBackendTargetArgs(getToolChain().getTriple(), Args, CmdArgs);
   TC.TranslateLinkerTargetArgs(getToolChain().getTriple(), Args, CmdArgs);
   SmallString<128> ExecPath(
@@ -695,8 +762,8 @@ static void parseTargetOpts(StringRef ArgString, const llvm::opt::ArgList &Args,
 // extract the arguments.
 void SYCLToolChain::TranslateTargetOpt(const llvm::opt::ArgList &Args,
                                        llvm::opt::ArgStringList &CmdArgs,
-                                       OptSpecifier Opt,
-                                       OptSpecifier Opt_EQ) const {
+                                       OptSpecifier Opt, OptSpecifier Opt_EQ,
+                                       StringRef Device) const {
   for (auto *A : Args) {
     bool OptNoTriple;
     OptNoTriple = A->getOption().matches(Opt);
@@ -705,6 +772,14 @@ void SYCLToolChain::TranslateTargetOpt(const llvm::opt::ArgList &Args,
       if (getDriver().MakeSYCLDeviceTriple(A->getValue()) != getTriple())
         // Provided triple does not match current tool chain.
         continue;
+      if (getTriple().isSPIR() &&
+          getTriple().getSubArch() == llvm::Triple::SPIRSubArch_gen) {
+        if (Device.empty() && StringRef(A->getValue()).startswith("intel_gpu"))
+          continue;
+        if (!Device.empty() &&
+            getDriver().MakeSYCLDeviceTriple(A->getValue()) == getTriple())
+          continue;
+      }
     } else if (!OptNoTriple)
       // Don't worry about any of the other args, we only want to pass what is
       // passed in -X<Opt>
@@ -732,9 +807,10 @@ void SYCLToolChain::TranslateTargetOpt(const llvm::opt::ArgList &Args,
   }
 }
 
-void SYCLToolChain::AddImpliedTargetArgs(
-    const llvm::Triple &Triple, const llvm::opt::ArgList &Args,
-    llvm::opt::ArgStringList &CmdArgs) const {
+void SYCLToolChain::AddImpliedTargetArgs(const llvm::Triple &Triple,
+                                         const llvm::opt::ArgList &Args,
+                                         llvm::opt::ArgStringList &CmdArgs,
+                                         const JobAction &JA) const {
   // Current implied args are for debug information and disabling of
   // optimizations.  They are passed along to the respective areas as follows:
   //  FPGA and default device:  -g -cl-opt-disable
@@ -747,6 +823,35 @@ void SYCLToolChain::AddImpliedTargetArgs(
       BeArgs.push_back("-g");
   if (Args.getLastArg(options::OPT_O0))
     BeArgs.push_back("-cl-opt-disable");
+  if (IsGen) {
+    // For GEN (spir64_gen) we have implied -device settings given usage
+    // of intel_gpu_ as a target.  Handle those here, and also check that no
+    // other -device was passed, as that is a conflict.
+    auto &BCA = cast<BackendCompileJobAction>(JA);
+    auto DepInfo = BCA.getDependentActionsInfo();
+    if (!DepInfo.empty()) {
+      ArgStringList TargArgs;
+      Args.AddAllArgValues(TargArgs, options::OPT_Xs, options::OPT_Xs_separate);
+      Args.AddAllArgValues(TargArgs, options::OPT_Xsycl_backend);
+      // For -Xsycl-target-backend=<triple> we need to scrutinize the triple
+      for (auto *A : Args) {
+        if (!A->getOption().matches(options::OPT_Xsycl_backend_EQ))
+          continue;
+        if (StringRef(A->getValue()).startswith("intel_gpu"))
+          TargArgs.push_back(A->getValue(1));
+      }
+      if (llvm::find_if(TargArgs, [&](auto Cur) {
+            return !strncmp(Cur, "-device", sizeof("-device") - 1);
+          }) != TargArgs.end()) {
+        SmallString<64> Target("intel_gpu_");
+        Target += DepInfo;
+        getDriver().Diag(diag::err_drv_unsupported_opt_for_target)
+            << "-device" << Target;
+      }
+      CmdArgs.push_back("-device");
+      CmdArgs.push_back(Args.MakeArgString(DepInfo));
+    }
+  }
   if (BeArgs.empty())
     return;
   if (Triple.getSubArch() == llvm::Triple::NoSubArch ||
@@ -770,7 +875,7 @@ void SYCLToolChain::AddImpliedTargetArgs(
 
 void SYCLToolChain::TranslateBackendTargetArgs(
     const llvm::Triple &Triple, const llvm::opt::ArgList &Args,
-    llvm::opt::ArgStringList &CmdArgs) const {
+    llvm::opt::ArgStringList &CmdArgs, StringRef Device) const {
   // Handle -Xs flags.
   for (auto *A : Args) {
     // When parsing the target args, the -Xs<opt> type option applies to all
@@ -808,7 +913,7 @@ void SYCLToolChain::TranslateBackendTargetArgs(
     return;
   // Handle -Xsycl-target-backend.
   TranslateTargetOpt(Args, CmdArgs, options::OPT_Xsycl_backend,
-                     options::OPT_Xsycl_backend_EQ);
+                     options::OPT_Xsycl_backend_EQ, Device);
 }
 
 void SYCLToolChain::TranslateLinkerTargetArgs(
@@ -820,7 +925,7 @@ void SYCLToolChain::TranslateLinkerTargetArgs(
     return;
   // Handle -Xsycl-target-linker.
   TranslateTargetOpt(Args, CmdArgs, options::OPT_Xsycl_linker,
-                     options::OPT_Xsycl_linker_EQ);
+                     options::OPT_Xsycl_linker_EQ, StringRef());
 }
 
 Tool *SYCLToolChain::buildBackendCompiler() const {

--- a/clang/lib/Driver/ToolChains/SYCL.h
+++ b/clang/lib/Driver/ToolChains/SYCL.h
@@ -105,6 +105,9 @@ public:
                     const char *LinkingOutput) const override;
 };
 
+StringRef resolveGenDevice(StringRef DeviceName);
+StringRef getGenDeviceMacro(StringRef DeviceName);
+
 } // end namespace gen
 
 namespace x86_64 {
@@ -146,10 +149,12 @@ public:
                          Action::OffloadKind DeviceOffloadKind) const override;
   void AddImpliedTargetArgs(const llvm::Triple &Triple,
                             const llvm::opt::ArgList &Args,
-                            llvm::opt::ArgStringList &CmdArgs) const;
+                            llvm::opt::ArgStringList &CmdArgs,
+                            const JobAction &JA) const;
   void TranslateBackendTargetArgs(const llvm::Triple &Triple,
                                   const llvm::opt::ArgList &Args,
-                                  llvm::opt::ArgStringList &CmdArgs) const;
+                                  llvm::opt::ArgStringList &CmdArgs,
+                                  StringRef Device = "") const;
   void TranslateLinkerTargetArgs(const llvm::Triple &Triple,
                                  const llvm::opt::ArgList &Args,
                                  llvm::opt::ArgStringList &CmdArgs) const;
@@ -180,8 +185,10 @@ protected:
 
 private:
   void TranslateTargetOpt(const llvm::opt::ArgList &Args,
-      llvm::opt::ArgStringList &CmdArgs, llvm::opt::OptSpecifier Opt,
-      llvm::opt::OptSpecifier Opt_EQ) const;
+                          llvm::opt::ArgStringList &CmdArgs,
+                          llvm::opt::OptSpecifier Opt,
+                          llvm::opt::OptSpecifier Opt_EQ,
+                          StringRef Device) const;
 };
 
 } // end namespace toolchains

--- a/clang/test/Driver/sycl-intel-gpu.cpp
+++ b/clang/test/Driver/sycl-intel-gpu.cpp
@@ -1,0 +1,118 @@
+/// Tests the behaviors of using -fsycl-targets=intel_gpu*
+
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_bdw -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=bdw -DMAC_STR=BDW
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_8_0_0 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=bdw -DMAC_STR=BDW
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_skl -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=skl -DMAC_STR=SKL
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_9_0_9 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=skl -DMAC_STR=SKL
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_kbl -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=kbl -DMAC_STR=KBL
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_9_1_9 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=kbl -DMAC_STR=KBL
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_cfl -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=cfl -DMAC_STR=CFL
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_9_2_9 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=cfl -DMAC_STR=CFL
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_apl -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=apl -DMAC_STR=APL
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_9_3_0 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=apl -DMAC_STR=APL
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_glk -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=glk -DMAC_STR=GLK
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_9_4_0 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=glk -DMAC_STR=GLK
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_whl -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=whl -DMAC_STR=WHL
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_9_5_0 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=whl -DMAC_STR=WHL
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_aml -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=aml -DMAC_STR=AML
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_9_6_0 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=aml -DMAC_STR=AML
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_cml -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=cml -DMAC_STR=CML
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_9_7_0 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=cml -DMAC_STR=CML
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_icllp -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=icllp \
+// RUN:             -DMAC_STR=ICLLP
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_11_0_0 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=icllp \
+// RUN:             -DMAC_STR=ICLLP
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_ehl -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=ehl -DMAC_STR=EHL
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_11_2_0 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=ehl -DMAC_STR=EHL
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_tgllp -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=tgllp \
+// RUN:             -DMAC_STR=TGLLP
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_12_0_0 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=tgllp \
+// RUN:             -DMAC_STR=TGLLP
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_rkl -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=rkl -DMAC_STR=RKL
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_adl_s -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=adl_s \
+// RUN:             -DMAC_STR=ADL_S
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_rpl_s -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=rpl_s \
+// RUN:             -DMAC_STR=RPL_S
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_adl_p -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=adl_p \
+// RUN:             -DMAC_STR=ADL_P
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_adl_n -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=adl_n \
+// RUN:             -DMAC_STR=ADL_N
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_dg1 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=dg1 -DMAC_STR=DG1
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_12_10_0 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=dg1 -DMAC_STR=DG1
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_acm_g10 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=acm_g10 \
+// RUN:             -DMAC_STR=ACM_G10
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_acm_g11 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=acm_g11 \
+// RUN:             -DMAC_STR=ACM_G11
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_acm_g12 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=acm_g12 \
+// RUN:             -DMAC_STR=ACM_G12
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_pvc -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=pvc -DMAC_STR=PVC
+// MACRO: clang{{.*}} "-triple" "spir64_gen-unknown-unknown"
+// MACRO: "-D__SYCL_TARGET_INTEL_GPU_[[MAC_STR]]__"
+// DEVICE: ocloc{{.*}} "-device" "[[DEV_STR]]"
+
+/// -fsycl-targets=spir64_x86_64 should set a specific macro
+// RUN: %clangxx -c -fsycl -fsycl-targets=spir64_x86_64 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefix=MACRO_X86_64
+// RUN: %clang_cl -c -fsycl -fsycl-targets=spir64_x86_64 -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefix=MACRO_X86_64
+// MACRO_X86_64: clang{{.*}} "-triple" "spir64_x86_64-unknown-unknown"
+// MACRO_X86_64: "-D__SYCL_TARGET_INTEL_X86_64__"
+
+/// test for invalid arch
+// RUN: %clangxx -c -fsycl -fsycl-targets=intel_gpu_bad -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefix=BAD_INPUT
+// RUN: %clang_cl -c -fsycl -fsycl-targets=intel_gpu_bad -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefix=BAD_INPUT
+// BAD_INPUT: error: SYCL target is invalid: 'intel_gpu_bad'
+
+/// Test for proper creation of fat object
+// RUN: %clangxx -c -fsycl -fsycl-targets=intel_gpu_skl \
+// RUN:   -target x86_64-unknown-linux-gnu -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefix=FATO
+// FATO: clang-offload-bundler{{.*}} "-type=o"
+// FATO: "-targets=sycl-spir64_gen-unknown-unknown-skl,host-x86_64-unknown-linux-gnu"
+
+/// Test for proper consumption of fat object
+// RUN: touch %t.o
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_skl \
+// RUN:   -target x86_64-unknown-linux-gnu -### %t.o 2>&1 | \
+// RUN:   FileCheck %s --check-prefix=CONSUME_FAT
+// CONSUME_FAT: clang-offload-bundler{{.*}} "-type=o"
+// CONSUME_FAT: "-targets=host-x86_64-unknown-linux-gnu,sycl-spir64_gen-unknown-unknown-skl"
+// CONSUME_FAT: "-unbundle" "-allow-missing-bundles"
+

--- a/clang/test/Driver/sycl-intel-gpu.cpp
+++ b/clang/test/Driver/sycl-intel-gpu.cpp
@@ -119,6 +119,7 @@
 /// Test phases, BoundArch settings used for -device target. Additional
 /// offload action used for compilation and backend compilation.
 // RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_skl -fno-sycl-device-lib=all \
+// RUN:   -fno-sycl-instrument-device-code \
 // RUN:   -target x86_64-unknown-linux-gnu -ccc-print-phases %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK_PHASES
 // CHECK_PHASES: 0: input, "[[INPUT:.+\.cpp]]", c++, (host-sycl)
@@ -134,21 +135,12 @@
 // CHECK_PHASES: 10: assembler, {9}, object, (host-sycl)
 // CHECK_PHASES: 11: linker, {10}, image, (host-sycl)
 // CHECK_PHASES: 12: linker, {6}, ir, (device-sycl)
-// CHECK_PHASES: 13: input, "{{.*libsycl-itt-user-wrappers.o.*}}", object
-// CHECK_PHASES: 14: clang-offload-unbundler, {13}, object
-// CHECK_PHASES: 15: offload, " (spir64_gen-unknown-unknown)" {14}, object
-// CHECK_PHASES: 16: input, "{{.*libsycl-itt-compiler-wrappers.o.*}}", object
-// CHECK_PHASES: 17: clang-offload-unbundler, {16}, object
-// CHECK_PHASES: 18: offload, " (spir64_gen-unknown-unknown)" {17}, object
-// CHECK_PHASES: 19: input, "{{.*libsycl-itt-stubs.o.*}}", object
-// CHECK_PHASES: 20: clang-offload-unbundler, {19}, object
-// CHECK_PHASES: 21: offload, " (spir64_gen-unknown-unknown)" {20}, object
-// CHECK_PHASES: 22: linker, {12, 15, 18, 21}, ir, (device-sycl)
-// CHECK_PHASES: 23: sycl-post-link, {22}, tempfiletable, (device-sycl)
-// CHECK_PHASES: 24: file-table-tform, {23}, tempfilelist, (device-sycl, skl)
-// CHECK_PHASES: 25: llvm-spirv, {24}, tempfilelist, (device-sycl, skl)
-// CHECK_PHASES: 26: backend-compiler, {25}, image, (device-sycl, skl)
-// CHECK_PHASES: 27: offload, "device-sycl (spir64_gen-unknown-unknown:skl)" {26}, image
-// CHECK_PHASES: 28: file-table-tform, {23, 27}, tempfiletable, (device-sycl)
-// CHECK_PHASES: 29: clang-offload-wrapper, {28}, object, (device-sycl)
-// CHECK_PHASES: 30: offload, "host-sycl (x86_64-unknown-linux-gnu)" {11}, "device-sycl (spir64_gen-unknown-unknown)" {29}, image
+// CHECK_PHASES: 13: sycl-post-link, {12}, tempfiletable, (device-sycl)
+// CHECK_PHASES: 14: file-table-tform, {13}, tempfilelist, (device-sycl, skl)
+// CHECK_PHASES: 15: llvm-spirv, {14}, tempfilelist, (device-sycl, skl)
+// CHECK_PHASES: 16: backend-compiler, {15}, image, (device-sycl, skl)
+// CHECK_PHASES: 17: offload, "device-sycl (spir64_gen-unknown-unknown:skl)" {16}, image
+// CHECK_PHASES: 18: file-table-tform, {13, 17}, tempfiletable, (device-sycl)
+// CHECK_PHASES: 19: clang-offload-wrapper, {18}, object, (device-sycl)
+// CHECK_PHASES: 20: offload, "host-sycl (x86_64-unknown-linux-gnu)" {11}, "device-sycl (spir64_gen-unknown-unknown)" {19}, image
+

--- a/sycl/doc/UsersManual.md
+++ b/sycl/doc/UsersManual.md
@@ -32,6 +32,31 @@ and not recommended to use in production environment.
       spir64_fpga-unknown-unknown, spir64_gen-unknown-unknown
     Available in special build configuration:
     * nvptx64-nvidia-cuda - generate code ahead of time for CUDA target;
+    Special target values specific to Intel Processor Graphics support are
+    accepted, providing a streamlined interface for AOT. Only one of these
+    values at a time is supported.
+    * intel_gpu_pvc - Ponte Vecchio Intel graphics architecture
+    * intel_gpu_acm_g12 - Alchemist G12 Intel graphics architecture
+    * intel_gpu_acm_g11 - Alchemist G11 Intel graphics architecture
+    * intel_gpu_acm_g10 - Alchemist G10 Intel graphics architecture
+    * intel_gpu_dg1, intel_gpu_12_10_0 - DG1 Intel graphics architecture
+    * intel_gpu_adl_n - Alder Lake N Intel graphics architecture
+    * intel_gpu_adl_p - Alder Lake P Intel graphics architecture
+    * intel_gpu_rpl_s - Raptor Lake Intel graphics architecture
+    * intel_gpu_adl_s - Alder Lake S Intel graphics architecture
+    * intel_gpu_rkl - Rocket Lake Intel graphics architecture
+    * intel_gpu_tgllp, intel_gpu_12_0_0 - Tiger Lake Intel graphics architecture
+    * intel_gpu_ehl, intel_gpu_11_2_0 - Elkhart Lake Intel graphics architecture
+    * intel_gpu_icllp, intel_gpu_11_0_0 - Ice Lake Intel graphics architecture
+    * intel_gpu_cml, intel_gpu_9_7_0 - Comet Lake Intel graphics architecture
+    * intel_gpu_aml, intel_gpu_9_6_0 - Amber Lake Intel graphics architecture
+    * intel_gpu_whl, intel_gpu_9_5_0 - Whiskey Lake Intel graphics architecture
+    * intel_gpu_glk, intel_gpu_9_4_0 - Gemini Lake Intel graphics architecture
+    * intel_gpu_apl, intel_gpu_9_3_0 - Apollo Lake Intel graphics architecture
+    * intel_gpu_cfl, intel_gpu_9_2_9 - Coffee Lake Intel graphics architecture
+    * intel_gpu_kbl, intel_gpu_9_1_9 - Kaby Lake Intel graphics architecture
+    * intel_gpu_skl, intel_gpu_9_0_9 - Skylake Intel graphics architecture
+    * intel_gpu_bdw, intel_gpu_8_0_0 - Broadwell Intel graphics architecture
 
 ## Language options
 


### PR DESCRIPTION
Expands spir64_gen target capabilities with -fsycl by introducing a number of GPU specific targets that can be specified via -fsycl-targets.  These targets (intel_gpu_* in format) are a set of reserved values which will correspond to spir64_gen target compilations with implied -device values.

Example:  -fsycl-targets=intel_gpu_skl
  - Passes '-device skl' to ocloc
  - Adds -D__SYCL_TARGET_INTEL_GPU_SKL__ to the device compilation step

For each value passed in -fsycl-targets, additional device specific compilations will be performed.  When bundling (using -c) the corresponding fat object will be generated with spir64_gen-unknown-unknown-skl to continue to be unique for extraction at a later time.