### PR TITLE
[SYCL-MLIR] Call cgeist from clang

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -826,6 +826,9 @@ def Xassembler : Separate<["-"], "Xassembler">,
 def Xclang : Separate<["-"], "Xclang">,
   HelpText<"Pass <arg> to the clang compiler">, MetaVarName<"<arg>">,
   Flags<[NoXarchOption, CoreOption]>, Group<CompileOnly_Group>;
+def Xcgeist : Separate<["-"], "Xcgeist">,
+  HelpText<"Pass <arg> to the cgeist compiler">, MetaVarName<"<arg>">,
+  Flags<[NoXarchOption, CoreOption]>, Group<CompileOnly_Group>;
 def Xcuda_fatbinary : Separate<["-"], "Xcuda-fatbinary">,
   HelpText<"Pass <arg> to fatbinary invocation">, MetaVarName<"<arg>">;
 def Xcuda_ptxas : Separate<["-"], "Xcuda-ptxas">,
@@ -5115,6 +5118,11 @@ def J : JoinedOrSeparate<["-"], "J">,
 // FC1 Options
 //===----------------------------------------------------------------------===//
 
+// move out of the next block make it accessible by code clang
+def emit_mlir : Flag<["-"], "emit-mlir">, Group<Action_Group>,
+  Flags<[CoreOption, FC1Option]>,
+  HelpText<"Build the parse tree, then lower it to MLIR">;
+
 let Flags = [FC1Option, FlangOnlyOption] in {
 
 def fget_definition : MultiArg<["-"], "fget-definition", 3>,
@@ -5165,8 +5173,6 @@ def fno_reformat : Flag<["-"], "fno-reformat">, Group<Preprocessor_Group>,
   HelpText<"Dump the cooked character stream in -E mode">;
 defm analyzed_objects_for_unparse : OptOutFC1FFlag<"analyzed-objects-for-unparse", "", "Do not use the analyzed objects when unparsing">;
 
-def emit_mlir : Flag<["-"], "emit-mlir">, Group<Action_Group>,
-  HelpText<"Build the parse tree, then lower it to MLIR">;
 def emit_fir : Flag<["-"], "emit-fir">, Alias<emit_mlir>;
 
 } // let Flags = [FC1Option, FlangOnlyOption]

--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -161,6 +161,7 @@ private:
   mutable std::unique_ptr<Tool> FileTableTform;
   mutable std::unique_ptr<Tool> SpirvToIrWrapper;
   mutable std::unique_ptr<Tool> LinkerWrapper;
+  mutable std::unique_ptr<Tool> Cgeist;
 
   Tool *getClang() const;
   Tool *getFlang() const;
@@ -181,6 +182,7 @@ private:
   Tool *getTableTform() const;
   Tool *getSpirvToIrWrapper() const;
   Tool *getLinkerWrapper() const;
+  Tool *getCgeist() const;
 
   mutable bool SanitizerArgsChecked = false;
   mutable std::unique_ptr<XRayArgs> XRayArguments;

--- a/clang/include/clang/Driver/Types.def
+++ b/clang/include/clang/Driver/Types.def
@@ -88,6 +88,8 @@ TYPE("ir",                       LLVM_BC,      INVALID,         "bc",     phases
 TYPE("lto-ir",                   LTO_IR,       INVALID,         "s",      phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("lto-bc",                   LTO_BC,       INVALID,         "o",      phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 
+TYPE("mlir",                     MLIR_IR,      INVALID,         "mlir",   phases::Compile, phases::Backend, phases::Assemble, phases::Link)
+
 // Misc.
 TYPE("ast",                      AST,          INVALID,         "ast",    phases::Compile, phases::Backend, phases::Assemble, phases::Link)
 TYPE("ifs",                      IFS,          INVALID,         "ifs",    phases::IfsMerge)

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4787,7 +4787,7 @@ class OffloadingActionBuilder final {
 
         Action *DeviceCompilerInput = nullptr;
         for (auto TargetActionInfo :
-               llvm::zip(SYCLDeviceActions, SYCLTargetInfoList)) {
+             llvm::zip(SYCLDeviceActions, SYCLTargetInfoList)) {
           Action *&A = std::get<0>(TargetActionInfo);
           auto &TargetInfo = std::get<1>(TargetActionInfo);
           types::ID OutputType = types::TY_LLVM_BC;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4794,10 +4794,7 @@ class OffloadingActionBuilder final {
           if ((SYCLDeviceOnly || Args.hasArg(options::OPT_emit_llvm)) &&
               Args.hasArg(options::OPT_S))
             OutputType = types::TY_LLVM_IR;
-          if (SYCLDeviceOnly &&
-              TargetInfo.TC->getTriple().getEnvironment() ==
-                  llvm::Triple::SYCLMLIR &&
-              Args.hasArg(options::OPT_emit_mlir)) {
+          if (SYCLDeviceOnly && Args.hasArg(options::OPT_emit_mlir)) {
             OutputType = types::TY_MLIR_IR;
           }
           // Use of -fsycl-device-obj=spirv converts the original LLVM-IR

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4786,11 +4786,20 @@ class OffloadingActionBuilder final {
           return ABRT_Success;
 
         Action *DeviceCompilerInput = nullptr;
-        for (Action *&A : SYCLDeviceActions) {
+        for (auto TargetActionInfo :
+               llvm::zip(SYCLDeviceActions, SYCLTargetInfoList)) {
+          Action *&A = std::get<0>(TargetActionInfo);
+          auto &TargetInfo = std::get<1>(TargetActionInfo);
           types::ID OutputType = types::TY_LLVM_BC;
           if ((SYCLDeviceOnly || Args.hasArg(options::OPT_emit_llvm)) &&
               Args.hasArg(options::OPT_S))
             OutputType = types::TY_LLVM_IR;
+          if (SYCLDeviceOnly &&
+              TargetInfo.TC->getTriple().getEnvironment() ==
+                  llvm::Triple::SYCLMLIR &&
+              Args.hasArg(options::OPT_emit_mlir)) {
+            OutputType = types::TY_MLIR_IR;
+          }
           // Use of -fsycl-device-obj=spirv converts the original LLVM-IR
           // file to SPIR-V for later consumption.
           if ((SYCLDeviceOnly || FinalPhase != phases::Link) &&

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -681,9 +681,10 @@ bool ToolChain::needsGCovInstrumentation(const llvm::opt::ArgList &Args) {
 Tool *ToolChain::SelectTool(const JobAction &JA) const {
   if (D.IsFlangMode() && getDriver().ShouldUseFlangCompiler(JA)) return getFlang();
   if (getDriver().ShouldUseClangCompiler(JA)) {
-    if (JA.getOffloadingToolChain() &&
-        JA.getOffloadingToolChain()->getTriple().getEnvironment() ==
-            llvm::Triple::SYCLMLIR) {
+    if (JA.getType() == types::TY_MLIR_IR ||
+        (JA.getOffloadingToolChain() &&
+         JA.getOffloadingToolChain()->getTriple().getEnvironment() ==
+             llvm::Triple::SYCLMLIR)) {
       return getCgeist();
     }
     return getClang();

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9915,10 +9915,10 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
 }
 
 // Build an invocation to cgeist by stealing a clang invocation.
-// TODO: cgeist's driver actually replicate large part of clang.
-//       This make sense given the object and structure of the upstream project
+// TODO: cgeist's driver actually replicates large part of clang.
+//       This makes sense given the object and structure of the upstream project
 //       but given our context, a clang plugin would do just fine. We simply
-//       need to provide the frontend action (which already exist) via the
+//       need to provide the frontend action (which already exists) via the
 //       plugin interface. As we control clang, we can make driver adjustments
 //       where needed.
 void Cgeist::ConstructJob(Compilation &C, const JobAction &JA,

--- a/clang/lib/Driver/ToolChains/Clang.h
+++ b/clang/lib/Driver/ToolChains/Clang.h
@@ -311,15 +311,17 @@ public:
 
 /// Offload bundler tool.
 class LLVM_LIBRARY_VISIBILITY Cgeist final : public Tool {
-  const Tool* Clang;
+  const Tool *Clang;
 
 public:
-  Cgeist(const ToolChain &TC, const Tool* Clang)
-    : Tool("cgeist", "cgeist", TC), Clang(Clang) {}
+  Cgeist(const ToolChain &TC, const Tool *Clang)
+      : Tool("cgeist", "cgeist", TC), Clang(Clang) {}
 
   bool hasGoodDiagnostics() const override { return true; }
   bool hasIntegratedAssembler() const override { return true; }
-  bool hasIntegratedBackend() const override { return Clang->hasIntegratedBackend(); }
+  bool hasIntegratedBackend() const override {
+    return Clang->hasIntegratedBackend();
+  }
   bool hasIntegratedCPP() const override { return true; }
   bool canEmitIR() const override { return true; }
 

--- a/clang/lib/Driver/ToolChains/Clang.h
+++ b/clang/lib/Driver/ToolChains/Clang.h
@@ -309,7 +309,7 @@ public:
                     const char *LinkingOutput) const override;
 };
 
-/// Offload bundler tool.
+/// Cgeist tool.
 class LLVM_LIBRARY_VISIBILITY Cgeist final : public Tool {
   const Tool *Clang;
 

--- a/clang/lib/Driver/ToolChains/Clang.h
+++ b/clang/lib/Driver/ToolChains/Clang.h
@@ -309,6 +309,26 @@ public:
                     const char *LinkingOutput) const override;
 };
 
+/// Offload bundler tool.
+class LLVM_LIBRARY_VISIBILITY Cgeist final : public Tool {
+  const Tool* Clang;
+
+public:
+  Cgeist(const ToolChain &TC, const Tool* Clang)
+    : Tool("cgeist", "cgeist", TC), Clang(Clang) {}
+
+  bool hasGoodDiagnostics() const override { return true; }
+  bool hasIntegratedAssembler() const override { return true; }
+  bool hasIntegratedBackend() const override { return Clang->hasIntegratedBackend(); }
+  bool hasIntegratedCPP() const override { return true; }
+  bool canEmitIR() const override { return true; }
+
+  void ConstructJob(Compilation &C, const JobAction &JA,
+                    const InputInfo &Output, const InputInfoList &Inputs,
+                    const llvm::opt::ArgList &TCArgs,
+                    const char *LinkingOutput) const override;
+};
+
 enum class DwarfFissionKind { None, Split, Single };
 
 DwarfFissionKind getDebugFissionKind(const Driver &D,

--- a/clang/lib/Driver/Types.cpp
+++ b/clang/lib/Driver/Types.cpp
@@ -155,6 +155,7 @@ bool types::isAcceptedByClang(ID Id) {
   case TY_AST: case TY_ModuleFile: case TY_PCH:
   case TY_LLVM_IR: case TY_LLVM_BC:
   case TY_SPIRV:
+  case TY_MLIR_IR:
   case TY_API_INFO:
     return true;
   }

--- a/clang/test/Driver/sycl-mlir.cpp
+++ b/clang/test/Driver/sycl-mlir.cpp
@@ -22,6 +22,16 @@
 // CHK-PHASES-MLIR: 3: offload, "device-sycl (spir64-unknown-unknown-syclmlir)" {2}, mlir
 
 
+// RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL             \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
+// RUN: -fsycl-targets=spir64-unknown-unknown -emit-mlir %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHK-PHASES-MLIR-NO-TRIPLE %s
+//
+// CHK-PHASES-MLIR-NO-TRIPLE: 0: input, "{{.*}}.cpp", c++, (device-sycl)
+// CHK-PHASES-MLIR-NO-TRIPLE: 1: preprocessor, {0}, c++-cpp-output, (device-sycl)
+// CHK-PHASES-MLIR-NO-TRIPLE: 2: compiler, {1}, mlir, (device-sycl)
+// CHK-PHASES-MLIR-NO-TRIPLE: 3: offload, "device-sycl (spir64-unknown-unknown)" {2}, mlir
+
 // RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \

--- a/clang/test/Driver/sycl-mlir.cpp
+++ b/clang/test/Driver/sycl-mlir.cpp
@@ -1,0 +1,80 @@
+/// Tests specific to -syclmlir
+
+/// Check phases w/out specifying a compute capability.
+// RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL             \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
+// RUN: | FileCheck -check-prefix=CHK-PHASES-LLVM %s
+//
+// CHK-PHASES-LLVM: 0: input, "{{.*}}.cpp", c++, (device-sycl)
+// CHK-PHASES-LLVM: 1: preprocessor, {0}, c++-cpp-output, (device-sycl)
+// CHK-PHASES-LLVM: 2: compiler, {1}, ir, (device-sycl)
+// CHK-PHASES-LLVM: 3: offload, "device-sycl (spir64-unknown-unknown-syclmlir)" {2}, ir
+
+// RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL             \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHK-PHASES-MLIR %s
+//
+// CHK-PHASES-MLIR: 0: input, "{{.*}}.cpp", c++, (device-sycl)
+// CHK-PHASES-MLIR: 1: preprocessor, {0}, c++-cpp-output, (device-sycl)
+// CHK-PHASES-MLIR: 2: compiler, {1}, mlir, (device-sycl)
+// CHK-PHASES-MLIR: 3: offload, "device-sycl (spir64-unknown-unknown-syclmlir)" {2}, mlir
+
+
+// RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
+// RUN: | FileCheck -check-prefix=CHK-BINDINGS-LLVM %s
+//
+// CHK-BINDINGS-LLVM: # "spir64-unknown-unknown-syclmlir" - "cgeist", inputs: ["{{.*}}.cpp"], output: "{{.*}}.bc"
+
+// RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHK-BINDINGS-MLIR %s
+//
+// CHK-BINDINGS-MLIR: # "spir64-unknown-unknown-syclmlir" - "cgeist", inputs: ["{{.*}}.cpp"], output: "{{.*}}.mlir"
+
+// RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL      \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c                 \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1     \
+// RUN: | FileCheck -check-prefix=CHK-BINDINGS-FULL-LLVM %s
+//
+// RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHK-BINDINGS-FULL-LLVM %s
+//
+// CHK-BINDINGS-FULL-LLVM: # "spir64-unknown-unknown-syclmlir" - "cgeist", inputs: ["{{.*}}.cpp"], output: "{{.*}}.bc"
+// CHK-BINDINGS-FULL-LLVM: # "x86_64-unknown-linux-gnu" - "Append Footer to source", inputs: ["{{.*}}.cpp"], output: "{{.*}}.cpp"
+// CHK-BINDINGS-FULL-LLVM: # "x86_64-unknown-linux-gnu" - "clang", inputs: ["{{.*}}.cpp", "{{.*}}.bc"], output: "{{.*}}.o"
+// CHK-BINDINGS-FULL-LLVM: # "x86_64-unknown-linux-gnu" - "offload bundler", inputs: ["{{.*}}.bc", "{{.*}}.o"], output: "{{.*}}.o"
+
+// RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
+// RUN: | FileCheck -check-prefix=CHK-INVOKE-LLVM-BC %s
+//
+// CHK-INVOKE-LLVM-BC: "{{.*}}cgeist" "-emit-llvm" "{{.*}}.cpp" "--args" "-cc1"
+
+// RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c  -S -emit-llvm       \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
+// RUN: | FileCheck -check-prefix=CHK-INVOKE-LLVM %s
+//
+// CHK-INVOKE-LLVM: "{{.*}}cgeist" "-emit-llvm" "-S" "{{.*}}.cpp" "--args" "-cc1"
+
+// RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only      \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c -emit-mlir          \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1         \
+// RUN: | FileCheck -check-prefix=CHK-INVOKE-MLIR %s
+//
+// CHK-INVOKE-MLIR: "{{.*}}cgeist" "-S" "{{.*}}.cpp" "--args" "-cc1"
+
+// RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c -Xcgeist -S          \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
+// RUN: | FileCheck -check-prefix=CHK-INVOKE-ARG-PASS %s
+//
+// CHK-INVOKE-ARG-PASS: "{{.*}}cgeist" "-emit-llvm" "-S" "{{.*}}.cpp" "--args" "-cc1"

--- a/llvm/include/llvm/ADT/Triple.h
+++ b/llvm/include/llvm/ADT/Triple.h
@@ -245,6 +245,7 @@ public:
     MuslEABI,
     MuslEABIHF,
     MuslX32,
+    SYCLMLIR,
 
     MSVC,
     Itanium,

--- a/llvm/include/llvm/ADT/Triple.h
+++ b/llvm/include/llvm/ADT/Triple.h
@@ -251,9 +251,9 @@ public:
     Itanium,
     Cygnus,
     CoreCLR,
-    Simulator,  // Simulator variants of other systems, e.g., Apple's iOS
-    MacABI, // Mac Catalyst variant of Apple's iOS deployment target.
-    
+    Simulator, // Simulator variants of other systems, e.g., Apple's iOS
+    MacABI,    // Mac Catalyst variant of Apple's iOS deployment target.
+
     // Shader Stages
     Pixel,
     Vertex,

--- a/llvm/lib/Support/Triple.cpp
+++ b/llvm/lib/Support/Triple.cpp
@@ -288,7 +288,8 @@ StringRef Triple::getEnvironmentTypeName(EnvironmentType Kind) {
   case Callable: return "callable";
   case Mesh: return "mesh";
   case Amplification: return "amplification";
-  case SYCLMLIR: return "syclmlir";
+  case SYCLMLIR:
+    return "syclmlir";
   }
 
   llvm_unreachable("Invalid EnvironmentType!");

--- a/llvm/lib/Support/Triple.cpp
+++ b/llvm/lib/Support/Triple.cpp
@@ -288,6 +288,7 @@ StringRef Triple::getEnvironmentTypeName(EnvironmentType Kind) {
   case Callable: return "callable";
   case Mesh: return "mesh";
   case Amplification: return "amplification";
+  case SYCLMLIR: return "syclmlir";
   }
 
   llvm_unreachable("Invalid EnvironmentType!");
@@ -635,6 +636,7 @@ static Triple::EnvironmentType parseEnvironment(StringRef EnvironmentName) {
       .StartsWith("callable", Triple::Callable)
       .StartsWith("mesh", Triple::Mesh)
       .StartsWith("amplification", Triple::Amplification)
+      .StartsWith("syclmlir", Triple::SYCLMLIR)
       .Default(Triple::UnknownEnvironment);
 }
 


### PR DESCRIPTION
When appending `-syclmlir` to the target triple, the driver will invoke cgeist instead of clang.
The default setup is to call cgeist to emit LLVM IR. This allow the insertion into the SYCL compilation flow.
To produce an mlir output, clang can be invoked with `-fsycl-device-only -emit-mlir`.

@etiotto @whitneywhtsang I picked the triple approach to avoid adding a flag to ease up integration overall, that should help with sycl tests later on (as you have to pass a triple).

Signed-off-by: Victor Lomuller <victor@codeplay.com>