### PR TITLE
[SYCL-MLIR][ConvertPolygeistToLLVM]: Handle memref of SYCL type for polygeist.subindex

### DIFF
--- a/mlir-sycl/include/mlir/Conversion/SYCLToLLVM/SYCLToLLVM.h
+++ b/mlir-sycl/include/mlir/Conversion/SYCLToLLVM/SYCLToLLVM.h
@@ -26,6 +26,9 @@ void populateSYCLToLLVMTypeConversion(LLVMTypeConverter &typeConverter);
 void populateSYCLToLLVMConversionPatterns(LLVMTypeConverter &typeConverter,
                                           RewritePatternSet &patterns);
 
+/// Return true if the given \p type is a SYCL type.
+bool isSYCLType(Type type);
+
 } // namespace sycl
 } // namespace mlir
 

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -401,3 +401,11 @@ void mlir::sycl::populateSYCLToLLVMConversionPatterns(
   patterns.add<CastPattern>(typeConverter);
   patterns.add<ConstructorPattern>(typeConverter);
 }
+
+bool mlir::sycl::isSYCLType(Type type) {
+  return type
+      .isa<mlir::sycl::IDType, mlir::sycl::AccessorType, mlir::sycl::RangeType,
+           mlir::sycl::AccessorImplDeviceType, mlir::sycl::ArrayType,
+           mlir::sycl::ItemType, mlir::sycl::ItemBaseType,
+           mlir::sycl::NdItemType, mlir::sycl::GroupType>();
+}

--- a/polygeist/test/polygeist-opt/sycl/subindex.mlir
+++ b/polygeist/test/polygeist-opt/sycl/subindex.mlir
@@ -17,10 +17,13 @@ func.func @test_1(%arg0: memref<?x!llvm.struct<(!sycl.id<1>)>>) -> memref<?x!syc
 // CHECK-LABEL: @test_2
 // CHECK: llvm.return %{{.*}} : !llvm.struct<(ptr<struct<"class.cl::sycl::detail::AccessorImplDevice 
 
-func.func @test_2(%arg0 : memref<?x!sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>>) -> memref<?x!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>> { 
+!sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>
+!sycl_accessor_1_i32_read_write_global_buffer = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+
+func.func @test_2(%arg0 : memref<?x!sycl_accessor_1_i32_read_write_global_buffer>) -> memref<?x!sycl_accessor_impl_device_1_> { 
   %c0 = arith.constant 0 : index
-  %0 = "polygeist.subindex"(%arg0, %c0) : (memref<?x!sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>>, index) -> memref<?x!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>>
-  return %0 : memref<?x!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>> 
+  %0 = "polygeist.subindex"(%arg0, %c0) : (memref<?x!sycl_accessor_1_i32_read_write_global_buffer>, index) -> memref<?x!sycl_accessor_impl_device_1_>
+  return %0 : memref<?x!sycl_accessor_impl_device_1_>
 }
 
 // -----

--- a/polygeist/test/polygeist-opt/sycl/subindex.mlir
+++ b/polygeist/test/polygeist-opt/sycl/subindex.mlir
@@ -1,14 +1,26 @@
-// RUN: polygeist-opt --convert-polygeist-to-llvm %s | FileCheck %s
+// RUN: polygeist-opt --convert-polygeist-to-llvm --split-input-file %s | FileCheck %s
 
+// CHECK-LABEL: @test_1
 // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK: [[GEP:%.*]] = llvm.getelementptr {{.*}}[[[ZERO]], 0] : (!llvm.ptr<struct<([[SYCLIDSTRUCT:struct<"class.cl::sycl::id.1"]], {{.*}} -> !llvm.ptr<[[SYCLIDSTRUCT]], {{.*}}
 // CHECK: [[MEMREF:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<[[SYCLIDSTRUCT]], {{.*}}
 // CHECK: {{.*}} = llvm.insertvalue [[GEP]], [[MEMREF]][0] : !llvm.struct<(ptr<[[SYCLIDSTRUCT]], {{.*}}
 
-module {
-  func.func @test(%arg0: memref<?x!llvm.struct<(!sycl.id<1>)>>) -> memref<?x!sycl.id<1>> {
-    %c0 = arith.constant 0 : index
-    %0 = "polygeist.subindex"(%arg0, %c0) : (memref<?x!llvm.struct<(!sycl.id<1>)>>, index) -> memref<?x!sycl.id<1>>
-    return %0 : memref<?x!sycl.id<1>>
-  }
+func.func @test_1(%arg0: memref<?x!llvm.struct<(!sycl.id<1>)>>) -> memref<?x!sycl.id<1>> {
+  %c0 = arith.constant 0 : index
+  %0 = "polygeist.subindex"(%arg0, %c0) : (memref<?x!llvm.struct<(!sycl.id<1>)>>, index) -> memref<?x!sycl.id<1>>
+  return %0 : memref<?x!sycl.id<1>>
 }
+
+// -----
+
+// CHECK-LABEL: @test_2
+// CHECK: llvm.return %{{.*}} : !llvm.struct<(ptr<struct<"class.cl::sycl::detail::AccessorImplDevice 
+
+func.func @test_2(%arg0 : memref<?x!sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>>) -> memref<?x!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>> { 
+  %c0 = arith.constant 0 : index
+  %0 = "polygeist.subindex"(%arg0, %c0) : (memref<?x!sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>>, index) -> memref<?x!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>>
+  return %0 : memref<?x!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>> 
+}
+
+// -----


### PR DESCRIPTION
Before this PR, `polygeist.subindex` handles source type like `memref<?xstruct<sycl,...>>`, but not type like `memref<?xsycl>>`.
SYCL types are `llvm.struct` type when convert to LLVM, so we can use the same code to handle `memref<?xsycl>>`.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>