### PR TITLE
[SYCL][Doc] Add documentation to use iostream_proxy.hpp instead of <iostream>

### DIFF
--- a/sycl/doc/developer/ContributeToDPCPP.md
+++ b/sycl/doc/developer/ContributeToDPCPP.md
@@ -33,7 +33,8 @@ to signify the component changed, e.g.: `[PI]`, `[CUDA]`, `[Doc]`.
 
 ## Using \<iostream\> 
 
-According to [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#include-iostream-is-forbidden), the use `#include <iostream>` is forbidden in library files. Thereby it's suggested to use the `<sycl/detail/iostream_proxy.hpp>` header instead, as it has the functionality of `<iostream>` without it's static constructor.
+According to [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#include-iostream-is-forbidden), the use `#include <iostream>` is forbidden in library files. Instead, the sycl/detail/iostream_proxy.hpp header offers the functionality of <iostream> without its static constructor. This header should be used in place of <iostream> in DPC++ headers and runtime library files.
+
 ## Tests development
 
 Every product change should be accompanied with corresponding test modification

--- a/sycl/doc/developer/ContributeToDPCPP.md
+++ b/sycl/doc/developer/ContributeToDPCPP.md
@@ -33,7 +33,8 @@ to signify the component changed, e.g.: `[PI]`, `[CUDA]`, `[Doc]`.
 
 ## Using \<iostream\> 
 
-According to [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#include-iostream-is-forbidden), the use `#include <iostream>` is forbidden in library files. Instead, the sycl/detail/iostream_proxy.hpp header offers the functionality of <iostream> without its static constructor. This header should be used in place of <iostream> in DPC++ headers and runtime library files.
+According to [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#include-iostream-is-forbidden), the use `#include <iostream>` is forbidden in library files. Instead, the sycl/detail/iostream_proxy.hpp header offers the functionality of <iostream> without its static constructor. 
+This header should be used in place of <iostream> in DPC++ headers and runtime library files.
 
 ## Tests development
 

--- a/sycl/doc/developer/ContributeToDPCPP.md
+++ b/sycl/doc/developer/ContributeToDPCPP.md
@@ -33,7 +33,8 @@ to signify the component changed, e.g.: `[PI]`, `[CUDA]`, `[Doc]`.
 
 ## Using \<iostream\> 
 
-According to [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#include-iostream-is-forbidden), the use `#include <iostream>` is forbidden in library files. Instead, the sycl/detail/iostream_proxy.hpp header offers the functionality of <iostream> without its static constructor. 
+According to [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#include-iostream-is-forbidden), the use `#include <iostream>` is forbidden in library files. 
+Instead, the sycl/detail/iostream_proxy.hpp header offers the functionality of <iostream> without its static constructor. 
 This header should be used in place of <iostream> in DPC++ headers and runtime library files.
 
 ## Tests development

--- a/sycl/doc/developer/ContributeToDPCPP.md
+++ b/sycl/doc/developer/ContributeToDPCPP.md
@@ -32,10 +32,12 @@ commit message title. To a reasonable extent, additional tags can be used
 to signify the component changed, e.g.: `[PI]`, `[CUDA]`, `[Doc]`.
 
 ## Using \<iostream\> 
-
-According to [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#include-iostream-is-forbidden), the use `#include <iostream>` is forbidden in library files. 
-Instead, the sycl/detail/iostream_proxy.hpp header offers the functionality of <iostream> without its static constructor. 
-This header should be used in place of <iostream> in DPC++ headers and runtime library files.
+According to [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#include-iostream-is-forbidden),
+the use `#include <iostream>` is forbidden in library files. Instead, the
+sycl/detail/iostream_proxy.hpp header offers the functionality of <iostream>
+without its static constructor.
+This header should be used in place of <iostream> in DPC++ headers 
+and runtime library files.
 
 ## Tests development
 

--- a/sycl/doc/developer/ContributeToDPCPP.md
+++ b/sycl/doc/developer/ContributeToDPCPP.md
@@ -31,6 +31,9 @@ For any DPC++-related commit, the `[SYCL]` tag should be present in the
 commit message title. To a reasonable extent, additional tags can be used
 to signify the component changed, e.g.: `[PI]`, `[CUDA]`, `[Doc]`.
 
+## Using \<iostream\> 
+
+According to [LLVM Coding Standards](https://llvm.org/docs/CodingStandards.html#include-iostream-is-forbidden), the use `#include <iostream>` is forbidden in library files. Thereby it's suggested to use the `<sycl/detail/iostream_proxy.hpp>` header instead, as it has the functionality of `<iostream>` without it's static constructor.
 ## Tests development
 
 Every product change should be accompanied with corresponding test modification


### PR DESCRIPTION
This is to complement this [PR](https://github.com/intel/llvm/pull/6469) which removes \<iostream\> headers to comply with LLVM Coding Standards.

Signed-off-by: Rauf, Rana <rana.rauf@intel.com>