### PR TITLE
[SYCL][Windows] Fix DataMovement test

### DIFF
--- a/sycl/test/scheduler/DataMovement.cpp
+++ b/sycl/test/scheduler/DataMovement.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -I %sycl_source_dir %s -o %t.out -g
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -I %sycl_source_dir %s -o %t.out
 // RUN: env SYCL_DEVICE_FILTER=host %t.out
 //
 //==-------------------------- DataMovement.cpp ----------------------------==//


### PR DESCRIPTION
Using `-g` with the regular `clang` command line is not supported on Windows.

On Windows `clang-cl` and `/Mdd` should be used instead.

However it doesn't seem like this test is testing anything to do debug info and I couldn't find any reason for having it in the history, so removing `-g` is the simplest solution to make the test work on both Linux and Windows.

This should fix the post-commit issue that showed up in: https://github.com/intel/llvm/pull/6721