### PR TITLE
[SYCL] Add assert for device_global without device_image_scope

### DIFF
--- a/sycl/include/sycl/ext/oneapi/device_global/device_global.hpp
+++ b/sycl/include/sycl/ext/oneapi/device_global/device_global.hpp
@@ -101,6 +101,13 @@ public:
   static_assert(is_property_list<property_list_t>::value,
                 "Property list is invalid.");
 
+  // TODO: Remove when support has been added for device_global without the
+  // device_image_scope property.
+  static_assert(
+      property_list_t::template has_property<device_image_scope_key>(),
+      "device_global without the device_image_scope property is currently "
+      "unavailable.");
+
   device_global() = default;
 
   device_global(const device_global &) = delete;

--- a/sycl/test/extensions/device_global/device_global_properties.cpp
+++ b/sycl/test/extensions/device_global/device_global_properties.cpp
@@ -5,17 +5,25 @@
 
 using namespace sycl::ext::oneapi::experimental;
 
-static device_global<int> DeviceGlobal1;
+// TODO: device_global currently requires device_image_scope. When this
+// requirement is lifted the tests should include a case without any properties
+// and DeviceGlobal2, DeviceGlobal3, and DeviceGlobal4 should have
+// device_image_scope removed.
 static device_global<int, decltype(properties(device_image_scope))>
+    DeviceGlobal1;
+static device_global<int,
+                     decltype(properties(device_image_scope, host_access_none))>
     DeviceGlobal2;
-static device_global<int, decltype(properties(host_access_none))> DeviceGlobal3;
-static device_global<int, decltype(properties(init_mode_reset))> DeviceGlobal4;
-static device_global<int, decltype(properties(implement_in_csr_on))>
-    DeviceGlobal5;
+static device_global<int,
+                     decltype(properties(device_image_scope, init_mode_reset))>
+    DeviceGlobal3;
+static device_global<int, decltype(properties(device_image_scope,
+                                              implement_in_csr_on))>
+    DeviceGlobal4;
 static device_global<int, decltype(properties(
                               implement_in_csr_off, host_access_write,
                               device_image_scope, init_mode_reprogram))>
-    DeviceGlobal6;
+    DeviceGlobal5;
 
 // Checks is_property_key_of and is_property_value_of for T.
 template <typename T> void checkIsPropertyOf() {
@@ -53,54 +61,54 @@ int main() {
   static_assert(is_property_value<decltype(implement_in_csr_off)>::value);
 
   checkIsPropertyOf<decltype(DeviceGlobal1)>();
-  static_assert(!DeviceGlobal1.has_property<device_image_scope_key>());
+  static_assert(DeviceGlobal1.has_property<device_image_scope_key>());
   static_assert(!DeviceGlobal1.has_property<host_access_key>());
   static_assert(!DeviceGlobal1.has_property<init_mode_key>());
   static_assert(!DeviceGlobal1.has_property<implement_in_csr_key>());
+  static_assert(DeviceGlobal1.get_property<device_image_scope_key>() ==
+                device_image_scope);
 
   checkIsPropertyOf<decltype(DeviceGlobal2)>();
   static_assert(DeviceGlobal2.has_property<device_image_scope_key>());
-  static_assert(!DeviceGlobal2.has_property<host_access_key>());
+  static_assert(DeviceGlobal2.has_property<host_access_key>());
   static_assert(!DeviceGlobal2.has_property<init_mode_key>());
   static_assert(!DeviceGlobal2.has_property<implement_in_csr_key>());
   static_assert(DeviceGlobal2.get_property<device_image_scope_key>() ==
                 device_image_scope);
-
-  checkIsPropertyOf<decltype(DeviceGlobal3)>();
-  static_assert(!DeviceGlobal3.has_property<device_image_scope_key>());
-  static_assert(DeviceGlobal3.has_property<host_access_key>());
-  static_assert(!DeviceGlobal3.has_property<init_mode_key>());
-  static_assert(!DeviceGlobal3.has_property<implement_in_csr_key>());
-  static_assert(DeviceGlobal3.get_property<host_access_key>().value ==
+  static_assert(DeviceGlobal2.get_property<host_access_key>().value ==
                 host_access_enum::none);
 
-  checkIsPropertyOf<decltype(DeviceGlobal4)>();
-  static_assert(!DeviceGlobal4.has_property<device_image_scope_key>());
-  static_assert(!DeviceGlobal4.has_property<host_access_key>());
-  static_assert(DeviceGlobal4.has_property<init_mode_key>());
-  static_assert(!DeviceGlobal4.has_property<implement_in_csr_key>());
-  static_assert(DeviceGlobal4.get_property<init_mode_key>().value ==
+  checkIsPropertyOf<decltype(DeviceGlobal3)>();
+  static_assert(DeviceGlobal3.has_property<device_image_scope_key>());
+  static_assert(!DeviceGlobal3.has_property<host_access_key>());
+  static_assert(DeviceGlobal3.has_property<init_mode_key>());
+  static_assert(!DeviceGlobal3.has_property<implement_in_csr_key>());
+  static_assert(DeviceGlobal3.get_property<device_image_scope_key>() ==
+                device_image_scope);
+  static_assert(DeviceGlobal3.get_property<init_mode_key>().value ==
                 init_mode_enum::reset);
 
-  checkIsPropertyOf<decltype(DeviceGlobal5)>();
-  static_assert(!DeviceGlobal5.has_property<device_image_scope_key>());
-  static_assert(!DeviceGlobal5.has_property<host_access_key>());
-  static_assert(!DeviceGlobal5.has_property<init_mode_key>());
-  static_assert(DeviceGlobal5.has_property<implement_in_csr_key>());
-  static_assert(DeviceGlobal5.get_property<implement_in_csr_key>().value);
-
-  checkIsPropertyOf<decltype(DeviceGlobal6)>();
-  static_assert(DeviceGlobal6.has_property<device_image_scope_key>());
-  static_assert(DeviceGlobal6.has_property<host_access_key>());
-  static_assert(DeviceGlobal6.has_property<init_mode_key>());
-  static_assert(DeviceGlobal6.has_property<implement_in_csr_key>());
-  static_assert(DeviceGlobal6.get_property<device_image_scope_key>() ==
+  checkIsPropertyOf<decltype(DeviceGlobal4)>();
+  static_assert(DeviceGlobal4.has_property<device_image_scope_key>());
+  static_assert(!DeviceGlobal4.has_property<host_access_key>());
+  static_assert(!DeviceGlobal4.has_property<init_mode_key>());
+  static_assert(DeviceGlobal4.has_property<implement_in_csr_key>());
+  static_assert(DeviceGlobal4.get_property<device_image_scope_key>() ==
                 device_image_scope);
-  static_assert(DeviceGlobal6.get_property<host_access_key>().value ==
+  static_assert(DeviceGlobal4.get_property<implement_in_csr_key>().value);
+
+  checkIsPropertyOf<decltype(DeviceGlobal5)>();
+  static_assert(DeviceGlobal5.has_property<device_image_scope_key>());
+  static_assert(DeviceGlobal5.has_property<host_access_key>());
+  static_assert(DeviceGlobal5.has_property<init_mode_key>());
+  static_assert(DeviceGlobal5.has_property<implement_in_csr_key>());
+  static_assert(DeviceGlobal5.get_property<device_image_scope_key>() ==
+                device_image_scope);
+  static_assert(DeviceGlobal5.get_property<host_access_key>().value ==
                 host_access_enum::write);
-  static_assert(DeviceGlobal6.get_property<init_mode_key>().value ==
+  static_assert(DeviceGlobal5.get_property<init_mode_key>().value ==
                 init_mode_enum::reprogram);
-  static_assert(!DeviceGlobal6.get_property<implement_in_csr_key>().value);
+  static_assert(!DeviceGlobal5.get_property<implement_in_csr_key>().value);
 
   return 0;
 }


### PR DESCRIPTION
device_global is currently not fully supported but for backends that support it, they should be usable on device only when the device_image_scope property is present. This commit adds a temporary static assert to avoid prevent the use of device_global without device_image_scope until proper initialization has been implemented.