### PR TITLE
[SYCL][FPGA] Code and format clean up for FPGA extensions

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/fpga_lsu.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_lsu.hpp
@@ -14,9 +14,7 @@
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
-namespace ext {
-namespace intel {
-namespace experimental {
+namespace ext::intel::experimental {
 
 constexpr uint8_t BURST_COALESCE = 0x1;
 constexpr uint8_t CACHE = 0x2;
@@ -196,8 +194,6 @@ private:
 #endif
 };
 
-} // namespace experimental
-} // namespace intel
-} // namespace ext
+} // namespace ext::intel::experimental
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/experimental/online_compiler.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/online_compiler.hpp
@@ -17,9 +17,7 @@
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
-namespace ext {
-namespace intel {
-namespace experimental {
+namespace ext::intel::experimental {
 
 using byte = unsigned char;
 
@@ -216,8 +214,6 @@ online_compiler<source_language::cm>::compile(const std::string &src) {
   return compile(src, std::vector<std::string>{});
 }
 
-} // namespace experimental
-} // namespace intel
-} // namespace ext
+} // namespace ext::intel::experimental
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/experimental/pipes.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/pipes.hpp
@@ -17,9 +17,7 @@
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
-namespace ext {
-namespace intel {
-namespace experimental {
+namespace ext::intel::experimental {
 
 template <class Name, class DataT, int32_t MinCapacity = 0,
           class _propertiesT = decltype(oneapi::experimental::properties{}),
@@ -278,8 +276,6 @@ private:
 #endif // __SYCL_DEVICE_ONLY__
 };
 
-} // namespace experimental
-} // namespace intel
-} // namespace ext
+} // namespace ext::intel::experimental
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/experimental/pipes.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/pipes.hpp
@@ -21,7 +21,7 @@ namespace ext {
 namespace intel {
 namespace experimental {
 
-template <class _name, class _dataT, int32_t _min_capacity = 0,
+template <class Name, class DataT, int32_t MinCapacity = 0,
           class _propertiesT = decltype(oneapi::experimental::properties{}),
           class = void>
 class pipe {
@@ -30,8 +30,8 @@ class pipe {
                 "experimental pipe properties are not yet implemented");
 };
 
-template <class _name, class _dataT, int32_t _min_capacity, class _propertiesT>
-class pipe<_name, _dataT, _min_capacity, _propertiesT,
+template <class Name, class DataT, int32_t MinCapacity, class _propertiesT>
+class pipe<Name, DataT, MinCapacity, _propertiesT,
            std::enable_if_t<std::is_same_v<
                _propertiesT, decltype(oneapi::experimental::properties{})>>> {
 public:
@@ -39,7 +39,7 @@ public:
   // Reading from pipe is lowered to SPIR-V instruction OpReadPipe via SPIR-V
   // friendly LLVM IR.
   template <typename _functionPropertiesT>
-  static _dataT read(bool &Success, _functionPropertiesT Properties) {
+  static DataT read(bool &Success, _functionPropertiesT Properties) {
 #ifdef __SYCL_DEVICE_ONLY__
     // Get latency control properties
     using _latency_anchor_id_prop = typename detail::GetOrDefaultValT<
@@ -65,9 +65,9 @@ public:
       _control_type_code = 3;
     }
 
-    __ocl_RPipeTy<_dataT> _RPipe =
-        __spirv_CreatePipeFromPipeStorage_read<_dataT>(&m_Storage);
-    _dataT TempData;
+    __ocl_RPipeTy<DataT> _RPipe =
+        __spirv_CreatePipeFromPipeStorage_read<DataT>(&m_Storage);
+    DataT TempData;
     Success = !static_cast<bool>(__latency_control_nb_read_wrapper(
         _RPipe, &TempData, _anchor_id, _target_anchor, _control_type_code,
         _relative_cycle));
@@ -81,14 +81,14 @@ public:
 #endif // __SYCL_DEVICE_ONLY__
   }
 
-  static _dataT read(bool &Success) {
+  static DataT read(bool &Success) {
     return read(Success, oneapi::experimental::properties{});
   }
 
   // Writing to pipe is lowered to SPIR-V instruction OpWritePipe via SPIR-V
   // friendly LLVM IR.
   template <typename _functionPropertiesT>
-  static void write(const _dataT &Data, bool &Success,
+  static void write(const DataT &Data, bool &Success,
                     _functionPropertiesT Properties) {
 #ifdef __SYCL_DEVICE_ONLY__
     // Get latency control properties
@@ -115,8 +115,8 @@ public:
       _control_type_code = 3;
     }
 
-    __ocl_WPipeTy<_dataT> _WPipe =
-        __spirv_CreatePipeFromPipeStorage_write<_dataT>(&m_Storage);
+    __ocl_WPipeTy<DataT> _WPipe =
+        __spirv_CreatePipeFromPipeStorage_write<DataT>(&m_Storage);
     Success = !static_cast<bool>(__latency_control_nb_write_wrapper(
         _WPipe, &Data, _anchor_id, _target_anchor, _control_type_code,
         _relative_cycle));
@@ -130,7 +130,7 @@ public:
 #endif // __SYCL_DEVICE_ONLY__
   }
 
-  static void write(const _dataT &Data, bool &Success) {
+  static void write(const DataT &Data, bool &Success) {
     write(Data, Success, oneapi::experimental::properties{});
   }
 
@@ -138,7 +138,7 @@ public:
   // Reading from pipe is lowered to SPIR-V instruction OpReadPipe via SPIR-V
   // friendly LLVM IR.
   template <typename _functionPropertiesT>
-  static _dataT read(_functionPropertiesT Properties) {
+  static DataT read(_functionPropertiesT Properties) {
 #ifdef __SYCL_DEVICE_ONLY__
     // Get latency control properties
     using _latency_anchor_id_prop = typename detail::GetOrDefaultValT<
@@ -164,9 +164,9 @@ public:
       _control_type_code = 3;
     }
 
-    __ocl_RPipeTy<_dataT> _RPipe =
-        __spirv_CreatePipeFromPipeStorage_read<_dataT>(&m_Storage);
-    _dataT TempData;
+    __ocl_RPipeTy<DataT> _RPipe =
+        __spirv_CreatePipeFromPipeStorage_read<DataT>(&m_Storage);
+    DataT TempData;
     __latency_control_bl_read_wrapper(_RPipe, &TempData, _anchor_id,
                                       _target_anchor, _control_type_code,
                                       _relative_cycle);
@@ -179,12 +179,12 @@ public:
 #endif // __SYCL_DEVICE_ONLY__
   }
 
-  static _dataT read() { return read(oneapi::experimental::properties{}); }
+  static DataT read() { return read(oneapi::experimental::properties{}); }
 
   // Writing to pipe is lowered to SPIR-V instruction OpWritePipe via SPIR-V
   // friendly LLVM IR.
   template <typename _functionPropertiesT>
-  static void write(const _dataT &Data, _functionPropertiesT Properties) {
+  static void write(const DataT &Data, _functionPropertiesT Properties) {
 #ifdef __SYCL_DEVICE_ONLY__
     // Get latency control properties
     using _latency_anchor_id_prop = typename detail::GetOrDefaultValT<
@@ -210,8 +210,8 @@ public:
       _control_type_code = 3;
     }
 
-    __ocl_WPipeTy<_dataT> _WPipe =
-        __spirv_CreatePipeFromPipeStorage_write<_dataT>(&m_Storage);
+    __ocl_WPipeTy<DataT> _WPipe =
+        __spirv_CreatePipeFromPipeStorage_write<DataT>(&m_Storage);
     __latency_control_bl_write_wrapper(_WPipe, &Data, _anchor_id,
                                        _target_anchor, _control_type_code,
                                        _relative_cycle);
@@ -224,14 +224,14 @@ public:
 #endif // __SYCL_DEVICE_ONLY__
   }
 
-  static void write(const _dataT &Data) {
+  static void write(const DataT &Data) {
     write(Data, oneapi::experimental::properties{});
   }
 
 private:
-  static constexpr int32_t m_Size = sizeof(_dataT);
-  static constexpr int32_t m_Alignment = alignof(_dataT);
-  static constexpr int32_t m_Capacity = _min_capacity;
+  static constexpr int32_t m_Size = sizeof(DataT);
+  static constexpr int32_t m_Alignment = alignof(DataT);
+  static constexpr int32_t m_Capacity = MinCapacity;
 #ifdef __SYCL_DEVICE_ONLY__
   static constexpr struct ConstantPipeStorage m_Storage = {m_Size, m_Alignment,
                                                            m_Capacity};

--- a/sycl/include/sycl/ext/intel/experimental/pipes.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/pipes.hpp
@@ -20,31 +20,31 @@ __SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace ext::intel::experimental {
 
 template <class Name, class DataT, int32_t MinCapacity = 0,
-          class _propertiesT = decltype(oneapi::experimental::properties{}),
+          class PropertiesT = decltype(oneapi::experimental::properties{}),
           class = void>
 class pipe {
-  static_assert(std::is_same_v<_propertiesT,
+  static_assert(std::is_same_v<PropertiesT,
                                decltype(oneapi::experimental::properties{})>,
                 "experimental pipe properties are not yet implemented");
 };
 
-template <class Name, class DataT, int32_t MinCapacity, class _propertiesT>
-class pipe<Name, DataT, MinCapacity, _propertiesT,
+template <class Name, class DataT, int32_t MinCapacity, class PropertiesT>
+class pipe<Name, DataT, MinCapacity, PropertiesT,
            std::enable_if_t<std::is_same_v<
-               _propertiesT, decltype(oneapi::experimental::properties{})>>> {
+               PropertiesT, decltype(oneapi::experimental::properties{})>>> {
 public:
   // Non-blocking pipes
   // Reading from pipe is lowered to SPIR-V instruction OpReadPipe via SPIR-V
   // friendly LLVM IR.
-  template <typename _functionPropertiesT>
-  static DataT read(bool &Success, _functionPropertiesT Properties) {
+  template <typename FunctionPropertiesT>
+  static DataT read(bool &Success, FunctionPropertiesT Properties) {
 #ifdef __SYCL_DEVICE_ONLY__
     // Get latency control properties
     using _latency_anchor_id_prop = typename detail::GetOrDefaultValT<
-        _functionPropertiesT, latency_anchor_id_key,
+        FunctionPropertiesT, latency_anchor_id_key,
         detail::defaultLatencyAnchorIdProperty>::type;
     using _latency_constraint_prop = typename detail::GetOrDefaultValT<
-        _functionPropertiesT, latency_constraint_key,
+        FunctionPropertiesT, latency_constraint_key,
         detail::defaultLatencyConstraintProperty>::type;
 
     // Get latency control property values
@@ -85,16 +85,16 @@ public:
 
   // Writing to pipe is lowered to SPIR-V instruction OpWritePipe via SPIR-V
   // friendly LLVM IR.
-  template <typename _functionPropertiesT>
+  template <typename FunctionPropertiesT>
   static void write(const DataT &Data, bool &Success,
-                    _functionPropertiesT Properties) {
+                    FunctionPropertiesT Properties) {
 #ifdef __SYCL_DEVICE_ONLY__
     // Get latency control properties
     using _latency_anchor_id_prop = typename detail::GetOrDefaultValT<
-        _functionPropertiesT, latency_anchor_id_key,
+        FunctionPropertiesT, latency_anchor_id_key,
         detail::defaultLatencyAnchorIdProperty>::type;
     using _latency_constraint_prop = typename detail::GetOrDefaultValT<
-        _functionPropertiesT, latency_constraint_key,
+        FunctionPropertiesT, latency_constraint_key,
         detail::defaultLatencyConstraintProperty>::type;
 
     // Get latency control property values
@@ -135,15 +135,15 @@ public:
   // Blocking pipes
   // Reading from pipe is lowered to SPIR-V instruction OpReadPipe via SPIR-V
   // friendly LLVM IR.
-  template <typename _functionPropertiesT>
-  static DataT read(_functionPropertiesT Properties) {
+  template <typename FunctionPropertiesT>
+  static DataT read(FunctionPropertiesT Properties) {
 #ifdef __SYCL_DEVICE_ONLY__
     // Get latency control properties
     using _latency_anchor_id_prop = typename detail::GetOrDefaultValT<
-        _functionPropertiesT, latency_anchor_id_key,
+        FunctionPropertiesT, latency_anchor_id_key,
         detail::defaultLatencyAnchorIdProperty>::type;
     using _latency_constraint_prop = typename detail::GetOrDefaultValT<
-        _functionPropertiesT, latency_constraint_key,
+        FunctionPropertiesT, latency_constraint_key,
         detail::defaultLatencyConstraintProperty>::type;
 
     // Get latency control property values
@@ -181,15 +181,15 @@ public:
 
   // Writing to pipe is lowered to SPIR-V instruction OpWritePipe via SPIR-V
   // friendly LLVM IR.
-  template <typename _functionPropertiesT>
-  static void write(const DataT &Data, _functionPropertiesT Properties) {
+  template <typename FunctionPropertiesT>
+  static void write(const DataT &Data, FunctionPropertiesT Properties) {
 #ifdef __SYCL_DEVICE_ONLY__
     // Get latency control properties
     using _latency_anchor_id_prop = typename detail::GetOrDefaultValT<
-        _functionPropertiesT, latency_anchor_id_key,
+        FunctionPropertiesT, latency_anchor_id_key,
         detail::defaultLatencyAnchorIdProperty>::type;
     using _latency_constraint_prop = typename detail::GetOrDefaultValT<
-        _functionPropertiesT, latency_constraint_key,
+        FunctionPropertiesT, latency_constraint_key,
         detail::defaultLatencyConstraintProperty>::type;
 
     // Get latency control property values
@@ -236,9 +236,9 @@ private:
 
   // FPGA BE will recognize this function and extract its arguments.
   // TODO: Pass latency control parameters via the __spirv_* builtin when ready.
-  template <typename _T>
+  template <typename T>
   static int32_t
-  __latency_control_nb_read_wrapper(__ocl_RPipeTy<_T> Pipe, _T *Data,
+  __latency_control_nb_read_wrapper(__ocl_RPipeTy<T> Pipe, T *Data,
                                     int32_t AnchorID, int32_t TargetAnchor,
                                     int32_t Type, int32_t Cycle) {
     return __spirv_ReadPipe(Pipe, Data, m_Size, m_Alignment);
@@ -246,9 +246,9 @@ private:
 
   // FPGA BE will recognize this function and extract its arguments.
   // TODO: Pass latency control parameters via the __spirv_* builtin when ready.
-  template <typename _T>
+  template <typename T>
   static int32_t
-  __latency_control_nb_write_wrapper(__ocl_WPipeTy<_T> Pipe, const _T *Data,
+  __latency_control_nb_write_wrapper(__ocl_WPipeTy<T> Pipe, const T *Data,
                                      int32_t AnchorID, int32_t TargetAnchor,
                                      int32_t Type, int32_t Cycle) {
     return __spirv_WritePipe(Pipe, Data, m_Size, m_Alignment);
@@ -256,9 +256,9 @@ private:
 
   // FPGA BE will recognize this function and extract its arguments.
   // TODO: Pass latency control parameters via the __spirv_* builtin when ready.
-  template <typename _T>
-  static void __latency_control_bl_read_wrapper(__ocl_RPipeTy<_T> Pipe,
-                                                _T *Data, int32_t AnchorID,
+  template <typename T>
+  static void __latency_control_bl_read_wrapper(__ocl_RPipeTy<T> Pipe,
+                                                T *Data, int32_t AnchorID,
                                                 int32_t TargetAnchor,
                                                 int32_t Type, int32_t Cycle) {
     return __spirv_ReadPipeBlockingINTEL(Pipe, Data, m_Size, m_Alignment);
@@ -266,9 +266,9 @@ private:
 
   // FPGA BE will recognize this function and extract its arguments.
   // TODO: Pass latency control parameters via the __spirv_* builtin when ready.
-  template <typename _T>
+  template <typename T>
   static void
-  __latency_control_bl_write_wrapper(__ocl_WPipeTy<_T> Pipe, const _T *Data,
+  __latency_control_bl_write_wrapper(__ocl_WPipeTy<T> Pipe, const T *Data,
                                      int32_t AnchorID, int32_t TargetAnchor,
                                      int32_t Type, int32_t Cycle) {
     return __spirv_WritePipeBlockingINTEL(Pipe, Data, m_Size, m_Alignment);

--- a/sycl/include/sycl/ext/intel/experimental/usm_properties.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/usm_properties.hpp
@@ -8,22 +8,15 @@ namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace ext {
 
-namespace oneapi {
-namespace property {
-namespace usm {
+namespace oneapi::property::usm {
 class device_read_only
     : public sycl::detail::DataLessProperty<sycl::detail::DeviceReadOnly> {
 public:
   device_read_only() = default;
 };
-} // namespace usm
-} // namespace property
-} // namespace oneapi
+} // namespace oneapi::property::usm
 
-namespace intel {
-namespace experimental {
-namespace property {
-namespace usm {
+namespace intel::experimental::property::usm {
 
 class buffer_location
     : public sycl::detail::PropertyWithData<
@@ -36,10 +29,7 @@ private:
   uint64_t MLocation;
 };
 
-} // namespace usm
-} // namespace property
-} // namespace experimental
-} // namespace intel
+} // namespace intel::experimental::property::usm
 } // namespace ext
 
 template <>

--- a/sycl/include/sycl/ext/intel/fpga_device_selector.hpp
+++ b/sycl/include/sycl/ext/intel/fpga_device_selector.hpp
@@ -19,8 +19,7 @@ __SYCL_INLINE_VER_NAMESPACE(_V1) {
 // Forward declaration
 class platform;
 
-namespace ext {
-namespace intel {
+namespace ext::intel {
 
 class platform_selector : public device_selector {
 private:
@@ -68,8 +67,7 @@ public:
   }
 };
 
-} // namespace intel
-} // namespace ext
+} // namespace ext::intel
 
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/fpga_dsp_control.hpp
+++ b/sycl/include/sycl/ext/intel/fpga_dsp_control.hpp
@@ -9,8 +9,8 @@
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
-namespace ext {
-namespace intel {
+
+namespace ext::intel {
 
 enum class Preference { DSP, Softlogic, Compiler_default };
 enum class Propagate { On, Off };
@@ -87,7 +87,6 @@ void math_dsp_control(Function f) {
   }
 }
 
-} // namespace intel
-} // namespace ext
+} // namespace ext::intel
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/fpga_loop_fuse.hpp
+++ b/sycl/include/sycl/ext/intel/fpga_loop_fuse.hpp
@@ -9,8 +9,8 @@
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
-namespace ext {
-namespace intel {
+
+namespace ext::intel {
 
 template <int N = 1, typename F>
 void fpga_loop_fuse [[intel::loop_fuse(N)]] (F f) {
@@ -22,7 +22,6 @@ void fpga_loop_fuse_independent [[intel::loop_fuse_independent(N)]] (F f) {
   f();
 }
 
-} // namespace intel
-} // namespace ext
+} // namespace ext::intel
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/fpga_loop_fuse.hpp
+++ b/sycl/include/sycl/ext/intel/fpga_loop_fuse.hpp
@@ -12,13 +12,13 @@ __SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace ext {
 namespace intel {
 
-template <int _N = 1, typename _F>
-void fpga_loop_fuse [[intel::loop_fuse(_N)]] (_F f) {
+template <int N = 1, typename F>
+void fpga_loop_fuse [[intel::loop_fuse(N)]] (F f) {
   f();
 }
 
-template <int _N = 1, typename _F>
-void fpga_loop_fuse_independent [[intel::loop_fuse_independent(_N)]] (_F f) {
+template <int N = 1, typename F>
+void fpga_loop_fuse_independent [[intel::loop_fuse_independent(N)]] (F f) {
   f();
 }
 

--- a/sycl/include/sycl/ext/intel/fpga_lsu.hpp
+++ b/sycl/include/sycl/ext/intel/fpga_lsu.hpp
@@ -13,8 +13,7 @@
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
-namespace ext {
-namespace intel {
+namespace ext::intel {
 constexpr uint8_t BURST_COALESCE = 0x1;
 constexpr uint8_t CACHE = 0x2;
 constexpr uint8_t STATICALLY_COALESCE = 0x4;
@@ -122,8 +121,7 @@ private:
                   "unable to implement a store LSU with a prefetcher.");
   }
 };
-} // namespace intel
-} // namespace ext
+} // namespace ext::intel
 
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/fpga_lsu.hpp
+++ b/sycl/include/sycl/ext/intel/fpga_lsu.hpp
@@ -99,9 +99,9 @@ private:
 
   template <access::address_space Space> static void check_space() {
     static_assert(
-        _space == access::address_space::global_space ||
-            _space == access::address_space::ext_intel_global_device_space ||
-            _space == access::address_space::ext_intel_global_host_space,
+        Space == access::address_space::global_space ||
+            Space == access::address_space::ext_intel_global_device_space ||
+            Space == access::address_space::ext_intel_global_host_space,
         "lsu controls are only supported for global_ptr, "
         "device_ptr, and host_ptr objects");
   }

--- a/sycl/include/sycl/ext/intel/fpga_reg.hpp
+++ b/sycl/include/sycl/ext/intel/fpga_reg.hpp
@@ -19,9 +19,9 @@ namespace intel {
 // Returns a registered copy of the input
 // This function is intended for FPGA users to instruct the compiler to insert
 // at least one register stage between the input and the return value.
-template <typename _T>
-typename std::enable_if<std::is_trivially_copyable<_T>::value, _T>::type
-fpga_reg(_T t) {
+template <typename T>
+typename std::enable_if<std::is_trivially_copyable<T>::value, T>::type
+fpga_reg(T t) {
 #if __has_builtin(__builtin_intel_fpga_reg)
   return __builtin_intel_fpga_reg(t);
 #else
@@ -29,13 +29,13 @@ fpga_reg(_T t) {
 #endif
 }
 
-template <typename _T>
+template <typename T>
 [[deprecated(
     "ext::intel::fpga_reg will only support trivially_copyable types in a "
     "future release. The type used here will be disallowed.")]]
-typename std::enable_if<std::is_trivially_copyable<_T>::value == false,
-                        _T>::type
-fpga_reg(_T t) {
+typename std::enable_if<std::is_trivially_copyable<T>::value == false,
+                        T>::type
+fpga_reg(T t) {
 #if __has_builtin(__builtin_intel_fpga_reg)
   return __builtin_intel_fpga_reg(t);
 #else
@@ -52,9 +52,9 @@ fpga_reg(_T t) {
 // Keep it consistent with FPGA attributes like intelfpga::memory()
 // Currently clang does not support nested namespace for attributes
 namespace intelfpga {
-template <typename _T>
-[[deprecated("intelfpga::fpga_reg will be removed in a future release.")]] _T
-fpga_reg(const _T &t) {
+template <typename T>
+[[deprecated("intelfpga::fpga_reg will be removed in a future release.")]] T
+fpga_reg(const T &t) {
   return sycl::ext::intel::fpga_reg(t);
 }
 } // namespace intelfpga

--- a/sycl/include/sycl/ext/intel/fpga_reg.hpp
+++ b/sycl/include/sycl/ext/intel/fpga_reg.hpp
@@ -13,8 +13,7 @@
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
-namespace ext {
-namespace intel {
+namespace ext::intel {
 
 // Returns a registered copy of the input
 // This function is intended for FPGA users to instruct the compiler to insert
@@ -43,8 +42,7 @@ fpga_reg(T t) {
 #endif
 }
 
-} // namespace intel
-} // namespace ext
+} // namespace ext::intel
 
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/fpga_utils.hpp
+++ b/sycl/include/sycl/ext/intel/fpga_utils.hpp
@@ -14,8 +14,7 @@
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
-namespace ext {
-namespace intel {
+namespace ext::intel {
 
 template <template <int32_t> class Type, class T>
 struct _MatchType : std::is_same<Type<T::value>, T> {};
@@ -30,8 +29,7 @@ struct _GetValue<Type, T1, T...> {
       detail::conditional_t<_MatchType<Type, T1>::value, T1,
                             _GetValue<Type, T...>>::value;
 };
-} // namespace intel
-} // namespace ext
+} // namespace ext::intel
 
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/fpga_utils.hpp
+++ b/sycl/include/sycl/ext/intel/fpga_utils.hpp
@@ -17,18 +17,18 @@ __SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace ext {
 namespace intel {
 
-template <template <int32_t> class _Type, class _T>
-struct _MatchType : std::is_same<_Type<_T::value>, _T> {};
+template <template <int32_t> class Type, class T>
+struct _MatchType : std::is_same<Type<T::value>, T> {};
 
-template <template <int32_t> class _Type, class... _T> struct _GetValue {
-  static constexpr auto value = _Type<0>::default_value;
+template <template <int32_t> class Type, class... T> struct _GetValue {
+  static constexpr auto value = Type<0>::default_value;
 };
 
-template <template <int32_t> class _Type, class _T1, class... _T>
-struct _GetValue<_Type, _T1, _T...> {
+template <template <int32_t> class Type, class T1, class... T>
+struct _GetValue<Type, T1, T...> {
   static constexpr auto value =
-      detail::conditional_t<_MatchType<_Type, _T1>::value, _T1,
-                            _GetValue<_Type, _T...>>::value;
+      detail::conditional_t<_MatchType<Type, T1>::value, T1,
+                            _GetValue<Type, T...>>::value;
 };
 } // namespace intel
 } // namespace ext

--- a/sycl/include/sycl/ext/intel/math.hpp
+++ b/sycl/include/sycl/ext/intel/math.hpp
@@ -30,9 +30,7 @@ _iml_half_internal __imf_copysignf16(_iml_half_internal, _iml_half_internal);
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
-namespace ext {
-namespace intel {
-namespace math {
+namespace ext::intel::math {
 
 #if __cplusplus >= 201703L
 template <typename Tp>
@@ -61,8 +59,6 @@ std::enable_if_t<std::is_same_v<Tp, sycl::half>, sycl::half> copysign(Tp x,
 }
 
 #endif
-} // namespace math
-} // namespace intel
-} // namespace ext
+} // namespace ext::intel::math
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/pipes.hpp
+++ b/sycl/include/sycl/ext/intel/pipes.hpp
@@ -17,18 +17,18 @@ __SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace ext {
 namespace intel {
 
-template <class _name, class _dataT, int32_t _min_capacity = 0> class pipe {
+template <class Name, class DataT, int32_t MinCapacity = 0> class pipe {
 public:
-  using value_type = _dataT;
-  static constexpr int32_t min_capacity = _min_capacity;
+  using value_type = DataT;
+  static constexpr int32_t min_capacity = MinCapacity;
   // Non-blocking pipes
   // Reading from pipe is lowered to SPIR-V instruction OpReadPipe via SPIR-V
   // friendly LLVM IR.
-  static _dataT read(bool &_Success) {
+  static DataT read(bool &_Success) {
 #ifdef __SYCL_DEVICE_ONLY__
-    __ocl_RPipeTy<_dataT> _RPipe =
-        __spirv_CreatePipeFromPipeStorage_read<_dataT>(&m_Storage);
-    _dataT TempData;
+    __ocl_RPipeTy<DataT> _RPipe =
+        __spirv_CreatePipeFromPipeStorage_read<DataT>(&m_Storage);
+    DataT TempData;
     _Success = !static_cast<bool>(
         __spirv_ReadPipe(_RPipe, &TempData, m_Size, m_Alignment));
     return TempData;
@@ -42,10 +42,10 @@ public:
 
   // Writing to pipe is lowered to SPIR-V instruction OpWritePipe via SPIR-V
   // friendly LLVM IR.
-  static void write(const _dataT &_Data, bool &_Success) {
+  static void write(const DataT &_Data, bool &_Success) {
 #ifdef __SYCL_DEVICE_ONLY__
-    __ocl_WPipeTy<_dataT> _WPipe =
-        __spirv_CreatePipeFromPipeStorage_write<_dataT>(&m_Storage);
+    __ocl_WPipeTy<DataT> _WPipe =
+        __spirv_CreatePipeFromPipeStorage_write<DataT>(&m_Storage);
     _Success = !static_cast<bool>(
         __spirv_WritePipe(_WPipe, &_Data, m_Size, m_Alignment));
 #else
@@ -60,11 +60,11 @@ public:
   // Blocking pipes
   // Reading from pipe is lowered to SPIR-V instruction OpReadPipe via SPIR-V
   // friendly LLVM IR.
-  static _dataT read() {
+  static DataT read() {
 #ifdef __SYCL_DEVICE_ONLY__
-    __ocl_RPipeTy<_dataT> _RPipe =
-        __spirv_CreatePipeFromPipeStorage_read<_dataT>(&m_Storage);
-    _dataT TempData;
+    __ocl_RPipeTy<DataT> _RPipe =
+        __spirv_CreatePipeFromPipeStorage_read<DataT>(&m_Storage);
+    DataT TempData;
     __spirv_ReadPipeBlockingINTEL(_RPipe, &TempData, m_Size, m_Alignment);
     return TempData;
 #else
@@ -76,10 +76,10 @@ public:
 
   // Writing to pipe is lowered to SPIR-V instruction OpWritePipe via SPIR-V
   // friendly LLVM IR.
-  static void write(const _dataT &_Data) {
+  static void write(const DataT &_Data) {
 #ifdef __SYCL_DEVICE_ONLY__
-    __ocl_WPipeTy<_dataT> _WPipe =
-        __spirv_CreatePipeFromPipeStorage_write<_dataT>(&m_Storage);
+    __ocl_WPipeTy<DataT> _WPipe =
+        __spirv_CreatePipeFromPipeStorage_write<DataT>(&m_Storage);
     __spirv_WritePipeBlockingINTEL(_WPipe, &_Data, m_Size, m_Alignment);
 #else
     (void)_Data;
@@ -90,8 +90,8 @@ public:
   }
 
 private:
-  static constexpr int32_t m_Size = sizeof(_dataT);
-  static constexpr int32_t m_Alignment = alignof(_dataT);
+  static constexpr int32_t m_Size = sizeof(DataT);
+  static constexpr int32_t m_Alignment = alignof(DataT);
 #ifdef __SYCL_DEVICE_ONLY__
   static constexpr struct ConstantPipeStorage m_Storage = {m_Size, m_Alignment,
                                                            min_capacity};
@@ -109,28 +109,28 @@ struct ethernet_pipe_id {
   static constexpr int32_t id = ID;
 };
 
-template <class _dataT, size_t _min_capacity>
+template <class DataT, size_t MinCapacity>
 using ethernet_read_pipe =
-  kernel_readable_io_pipe<ethernet_pipe_id<0>, _dataT, _min_capacity>;
+  kernel_readable_io_pipe<ethernet_pipe_id<0>, DataT, MinCapacity>;
 
-template <class _dataT, size_t _min_capacity>
+template <class DataT, size_t MinCapacity>
 using ethernet_write_pipe =
-  kernel_writeable_io_pipe<ethernet_pipe_id<1>, _dataT, _min_capacity>;
+  kernel_writeable_io_pipe<ethernet_pipe_id<1>, DataT, MinCapacity>;
 } // namespace intelfpga */
 
-template <class _name, class _dataT, size_t _min_capacity = 0>
+template <class Name, class DataT, size_t MinCapacity = 0>
 class kernel_readable_io_pipe {
 public:
-  using value_type = _dataT;
-  static constexpr int32_t min_capacity = _min_capacity;
+  using value_type = DataT;
+  static constexpr int32_t min_capacity = MinCapacity;
   // Non-blocking pipes
   // Reading from pipe is lowered to SPIR-V instruction OpReadPipe via SPIR-V
   // friendly LLVM IR.
-  static _dataT read(bool &_Success) {
+  static DataT read(bool &_Success) {
 #ifdef __SYCL_DEVICE_ONLY__
-    __ocl_RPipeTy<_dataT> _RPipe =
-        __spirv_CreatePipeFromPipeStorage_read<_dataT>(&m_Storage);
-    _dataT TempData;
+    __ocl_RPipeTy<DataT> _RPipe =
+        __spirv_CreatePipeFromPipeStorage_read<DataT>(&m_Storage);
+    DataT TempData;
     _Success = !static_cast<bool>(
         __spirv_ReadPipe(_RPipe, &TempData, m_Size, m_Alignment));
     return TempData;
@@ -145,11 +145,11 @@ public:
   // Blocking pipes
   // Reading from pipe is lowered to SPIR-V instruction OpReadPipe via SPIR-V
   // friendly LLVM IR.
-  static _dataT read() {
+  static DataT read() {
 #ifdef __SYCL_DEVICE_ONLY__
-    __ocl_RPipeTy<_dataT> _RPipe =
-        __spirv_CreatePipeFromPipeStorage_read<_dataT>(&m_Storage);
-    _dataT TempData;
+    __ocl_RPipeTy<DataT> _RPipe =
+        __spirv_CreatePipeFromPipeStorage_read<DataT>(&m_Storage);
+    DataT TempData;
     __spirv_ReadPipeBlockingINTEL(_RPipe, &TempData, m_Size, m_Alignment);
     return TempData;
 #else
@@ -160,27 +160,27 @@ public:
   }
 
 private:
-  static constexpr int32_t m_Size = sizeof(_dataT);
-  static constexpr int32_t m_Alignment = alignof(_dataT);
-  static constexpr int32_t ID = _name::id;
+  static constexpr int32_t m_Size = sizeof(DataT);
+  static constexpr int32_t m_Alignment = alignof(DataT);
+  static constexpr int32_t ID = Name::id;
 #ifdef __SYCL_DEVICE_ONLY__
   static constexpr struct ConstantPipeStorage m_Storage
       __attribute__((io_pipe_id(ID))) = {m_Size, m_Alignment, min_capacity};
 #endif // __SYCL_DEVICE_ONLY__
 };
 
-template <class _name, class _dataT, size_t _min_capacity = 0>
+template <class Name, class DataT, size_t MinCapacity = 0>
 class kernel_writeable_io_pipe {
 public:
-  using value_type = _dataT;
-  static constexpr int32_t min_capacity = _min_capacity;
+  using value_type = DataT;
+  static constexpr int32_t min_capacity = MinCapacity;
   // Non-blocking pipes
   // Writing to pipe is lowered to SPIR-V instruction OpWritePipe via SPIR-V
   // friendly LLVM IR.
-  static void write(const _dataT &_Data, bool &_Success) {
+  static void write(const DataT &_Data, bool &_Success) {
 #ifdef __SYCL_DEVICE_ONLY__
-    __ocl_WPipeTy<_dataT> _WPipe =
-        __spirv_CreatePipeFromPipeStorage_write<_dataT>(&m_Storage);
+    __ocl_WPipeTy<DataT> _WPipe =
+        __spirv_CreatePipeFromPipeStorage_write<DataT>(&m_Storage);
     _Success = !static_cast<bool>(
         __spirv_WritePipe(_WPipe, &_Data, m_Size, m_Alignment));
 #else
@@ -195,10 +195,10 @@ public:
   // Blocking pipes
   // Writing to pipe is lowered to SPIR-V instruction OpWritePipe via SPIR-V
   // friendly LLVM IR.
-  static void write(const _dataT &_Data) {
+  static void write(const DataT &_Data) {
 #ifdef __SYCL_DEVICE_ONLY__
-    __ocl_WPipeTy<_dataT> _WPipe =
-        __spirv_CreatePipeFromPipeStorage_write<_dataT>(&m_Storage);
+    __ocl_WPipeTy<DataT> _WPipe =
+        __spirv_CreatePipeFromPipeStorage_write<DataT>(&m_Storage);
     __spirv_WritePipeBlockingINTEL(_WPipe, &_Data, m_Size, m_Alignment);
 #else
     (void)_Data;
@@ -209,9 +209,9 @@ public:
   }
 
 private:
-  static constexpr int32_t m_Size = sizeof(_dataT);
-  static constexpr int32_t m_Alignment = alignof(_dataT);
-  static constexpr int32_t ID = _name::id;
+  static constexpr int32_t m_Size = sizeof(DataT);
+  static constexpr int32_t m_Alignment = alignof(DataT);
+  static constexpr int32_t ID = Name::id;
 #ifdef __SYCL_DEVICE_ONLY__
   static constexpr struct ConstantPipeStorage m_Storage
       __attribute__((io_pipe_id(ID))) = {m_Size, m_Alignment, min_capacity};

--- a/sycl/include/sycl/ext/intel/pipes.hpp
+++ b/sycl/include/sycl/ext/intel/pipes.hpp
@@ -14,8 +14,7 @@
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
-namespace ext {
-namespace intel {
+namespace ext::intel {
 
 template <class Name, class DataT, int32_t MinCapacity = 0> class pipe {
 public:
@@ -218,8 +217,7 @@ private:
 #endif // __SYCL_DEVICE_ONLY__
 };
 
-} // namespace intel
-} // namespace ext
+} // namespace ext::intel
 
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/pipes.hpp
+++ b/sycl/include/sycl/ext/intel/pipes.hpp
@@ -23,16 +23,16 @@ public:
   // Non-blocking pipes
   // Reading from pipe is lowered to SPIR-V instruction OpReadPipe via SPIR-V
   // friendly LLVM IR.
-  static DataT read(bool &_Success) {
+  static DataT read(bool &Success) {
 #ifdef __SYCL_DEVICE_ONLY__
     __ocl_RPipeTy<DataT> _RPipe =
         __spirv_CreatePipeFromPipeStorage_read<DataT>(&m_Storage);
     DataT TempData;
-    _Success = !static_cast<bool>(
+    Success = !static_cast<bool>(
         __spirv_ReadPipe(_RPipe, &TempData, m_Size, m_Alignment));
     return TempData;
 #else
-    (void)_Success;
+    (void)Success;
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Pipes are not supported on a host device.");
@@ -41,15 +41,15 @@ public:
 
   // Writing to pipe is lowered to SPIR-V instruction OpWritePipe via SPIR-V
   // friendly LLVM IR.
-  static void write(const DataT &_Data, bool &_Success) {
+  static void write(const DataT &Data, bool &Success) {
 #ifdef __SYCL_DEVICE_ONLY__
     __ocl_WPipeTy<DataT> _WPipe =
         __spirv_CreatePipeFromPipeStorage_write<DataT>(&m_Storage);
-    _Success = !static_cast<bool>(
-        __spirv_WritePipe(_WPipe, &_Data, m_Size, m_Alignment));
+    Success = !static_cast<bool>(
+        __spirv_WritePipe(_WPipe, &Data, m_Size, m_Alignment));
 #else
-    (void)_Success;
-    (void)_Data;
+    (void)Success;
+    (void)Data;
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Pipes are not supported on a host device.");
@@ -75,13 +75,13 @@ public:
 
   // Writing to pipe is lowered to SPIR-V instruction OpWritePipe via SPIR-V
   // friendly LLVM IR.
-  static void write(const DataT &_Data) {
+  static void write(const DataT &Data) {
 #ifdef __SYCL_DEVICE_ONLY__
     __ocl_WPipeTy<DataT> _WPipe =
         __spirv_CreatePipeFromPipeStorage_write<DataT>(&m_Storage);
-    __spirv_WritePipeBlockingINTEL(_WPipe, &_Data, m_Size, m_Alignment);
+    __spirv_WritePipeBlockingINTEL(_WPipe, &Data, m_Size, m_Alignment);
 #else
-    (void)_Data;
+    (void)Data;
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Pipes are not supported on a host device.");
@@ -125,16 +125,16 @@ public:
   // Non-blocking pipes
   // Reading from pipe is lowered to SPIR-V instruction OpReadPipe via SPIR-V
   // friendly LLVM IR.
-  static DataT read(bool &_Success) {
+  static DataT read(bool &Success) {
 #ifdef __SYCL_DEVICE_ONLY__
     __ocl_RPipeTy<DataT> _RPipe =
         __spirv_CreatePipeFromPipeStorage_read<DataT>(&m_Storage);
     DataT TempData;
-    _Success = !static_cast<bool>(
+    Success = !static_cast<bool>(
         __spirv_ReadPipe(_RPipe, &TempData, m_Size, m_Alignment));
     return TempData;
 #else
-    (void)_Success;
+    (void)Success;
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Pipes are not supported on a host device.");
@@ -176,15 +176,15 @@ public:
   // Non-blocking pipes
   // Writing to pipe is lowered to SPIR-V instruction OpWritePipe via SPIR-V
   // friendly LLVM IR.
-  static void write(const DataT &_Data, bool &_Success) {
+  static void write(const DataT &Data, bool &Success) {
 #ifdef __SYCL_DEVICE_ONLY__
     __ocl_WPipeTy<DataT> _WPipe =
         __spirv_CreatePipeFromPipeStorage_write<DataT>(&m_Storage);
-    _Success = !static_cast<bool>(
-        __spirv_WritePipe(_WPipe, &_Data, m_Size, m_Alignment));
+    Success = !static_cast<bool>(
+        __spirv_WritePipe(_WPipe, &Data, m_Size, m_Alignment));
 #else
-    (void)_Data;
-    (void)_Success;
+    (void)Data;
+    (void)Success;
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Pipes are not supported on a host device.");
@@ -194,13 +194,13 @@ public:
   // Blocking pipes
   // Writing to pipe is lowered to SPIR-V instruction OpWritePipe via SPIR-V
   // friendly LLVM IR.
-  static void write(const DataT &_Data) {
+  static void write(const DataT &Data) {
 #ifdef __SYCL_DEVICE_ONLY__
     __ocl_WPipeTy<DataT> _WPipe =
         __spirv_CreatePipeFromPipeStorage_write<DataT>(&m_Storage);
-    __spirv_WritePipeBlockingINTEL(_WPipe, &_Data, m_Size, m_Alignment);
+    __spirv_WritePipeBlockingINTEL(_WPipe, &Data, m_Size, m_Alignment);
 #else
-    (void)_Data;
+    (void)Data;
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Pipes are not supported on a host device.");


### PR DESCRIPTION
As per requested, convert _snake_case code to CamelCase for template arguments.

Valid since template arguments don't have the case that it will collide with customer code.