### PR TITLE
[SYCL-MLIR]: Derived class type should not include empty base

### DIFF
--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -91,11 +91,9 @@ bool isLLVMStructABI(const RecordDecl *RD, llvm::StructType *ST) {
       if (m->isVirtualAsWritten() || m->isPure())
         return true;
     }
-    for (const auto &Base : CXRD->bases()) {
-      const CXXRecordDecl *BaseDecl = Base.getType()->getAsCXXRecordDecl();
-      if (BaseDecl->isEmpty())
+    for (const auto &Base : CXRD->bases())
+      if (Base.getType()->getAsCXXRecordDecl()->isEmpty())
         return true;
-    }
   }
   if (ST) {
     if (!ST->isLiteral() && (ST->getName() == "struct._IO_FILE" ||

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -91,6 +91,11 @@ bool isLLVMStructABI(const RecordDecl *RD, llvm::StructType *ST) {
       if (m->isVirtualAsWritten() || m->isPure())
         return true;
     }
+    for (const auto &Base : CXRD->bases()) {
+      const CXXRecordDecl *BaseDecl = Base.getType()->getAsCXXRecordDecl();
+      if (BaseDecl->isEmpty())
+        return true;
+    }
   }
   if (ST) {
     if (!ST->isLiteral() && (ST->getName() == "struct._IO_FILE" ||

--- a/polygeist/tools/cgeist/Test/Verification/base_with_virt.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/base_with_virt.cpp
@@ -33,14 +33,15 @@ void a() {
     mbasic_stringbuf a;
 }
 
+// clang-format off
 // CHECK:   func @_Z1av() attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT:     %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(struct<(i8)>, ptr<i8>)>)> : (i64) -> !llvm.ptr<struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(struct<(i8)>, ptr<i8>)>)>>
-// CHECK-NEXT:     call @_ZN16mbasic_stringbufC1Ev(%0) : (!llvm.ptr<struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(struct<(i8)>, ptr<i8>)>)>>) -> ()
+// CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)> : (i64) -> !llvm.ptr<struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)>>
+// CHECK-NEXT:     call @_ZN16mbasic_stringbufC1Ev(%0) : (!llvm.ptr<struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)>>) -> ()
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
-// CHECK:   func @_ZN16mbasic_stringbufC1Ev(%arg0: !llvm.ptr<struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(struct<(i8)>, ptr<i8>)>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(struct<(i8)>, ptr<i8>)>)>>) -> !llvm.ptr<struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>>
+// CHECK:   func @_ZN16mbasic_stringbufC1Ev(%arg0: !llvm.ptr<struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)>>) -> !llvm.ptr<struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>>
 // CHECK-NEXT:     call @_ZN1AC1Ev(%0) : (!llvm.ptr<struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>>) -> ()
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
@@ -50,6 +51,6 @@ void a() {
 // CHECK-NEXT:     llvm.store %c3_i32, %0 : !llvm.ptr<i32>
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
-// CHECK-NEXT:   func @_ZN12_Alloc_hiderC1Ev(%arg0: !llvm.ptr<struct<(struct<(i8)>, ptr<i8>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:   func @_ZN12_Alloc_hiderC1Ev(%arg0: !llvm.ptr<struct<(ptr<i8>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }

--- a/polygeist/tools/cgeist/Test/Verification/base_with_virt2.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/base_with_virt2.cpp
@@ -34,15 +34,16 @@ void a() {
     mbasic_stringbuf a;
 }
 
+// clang-format off
 // CHECK:   func @_Z1av() attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
-// CHECK:   func @_ZN16mbasic_stringbufC1Ev(%arg0: !llvm.ptr<struct<(struct<(ptr<ptr<func<i32 (...)>>>)>, struct<(struct<(i8)>, ptr<i8>)>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK:   func @_ZN16mbasic_stringbufC1Ev(%arg0: !llvm.ptr<struct<(struct<(ptr<ptr<func<i32 (...)>>>)>, struct<(ptr<i8>)>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK:   func @_ZN15basic_streambufC1Ev(%arg0: !llvm.ptr<struct<(ptr<ptr<func<i32 (...)>>>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
-// CHECK:   func @_ZN12_Alloc_hiderC1Ev(%arg0: !llvm.ptr<struct<(struct<(i8)>, ptr<i8>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK:   func @_ZN12_Alloc_hiderC1Ev(%arg0: !llvm.ptr<struct<(ptr<i8>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }

--- a/polygeist/tools/cgeist/Test/Verification/virt2.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/virt2.cpp
@@ -27,22 +27,21 @@ void make() {
     Sub s(3, 3.14);
 }
 
+// clang-format off
 // CHECK:   func @_Z4makev() attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-DAG:     %cst = arith.constant 3.140000e+00 : f64
 // CHECK-DAG:     %c3_i32 = arith.constant 3 : i32
 // CHECK-DAG:     %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:    %0 = llvm.alloca %c1_i64 x !llvm.struct<(struct<(i8)>, struct<(i8)>)> : (i64) -> !llvm.ptr<struct<(struct<(i8)>, struct<(i8)>)>>
-// CHECK-NEXT:     call @_ZN3SubC1Eid(%0, %c3_i32, %cst) : (!llvm.ptr<struct<(struct<(i8)>, struct<(i8)>)>>, i32, f64) -> ()
+// CHECK-NEXT:    %0 = llvm.alloca %c1_i64 x !llvm.struct<(i8)> : (i64) -> !llvm.ptr<struct<(i8)>>
+// CHECK-NEXT:     call @_ZN3SubC1Eid(%0, %c3_i32, %cst) : (!llvm.ptr<struct<(i8)>>, i32, f64) -> ()
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
-// CHECK:   func @_ZN3SubC1Eid(%arg0: !llvm.ptr<struct<(struct<(i8)>, struct<(i8)>)>>, %arg1: i32, %arg2: f64) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>}
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(struct<(i8)>, struct<(i8)>)>>) -> !llvm.ptr<struct<(i8)>>
-// CHECK-NEXT:     call @_ZN4RootC1Ei(%0, %arg1) : (!llvm.ptr<struct<(i8)>>, i32) -> ()
-// CHECK-NEXT:     %1 = llvm.getelementptr %arg0[0, 1] : (!llvm.ptr<struct<(struct<(i8)>, struct<(i8)>)>>) -> !llvm.ptr<struct<(i8)>>
-// CHECK-NEXT:     call @_ZN5FRootC1Ev(%1) : (!llvm.ptr<struct<(i8)>>) -> ()
-// CHECK-NEXT:     %2 = llvm.mlir.addressof @str0 : !llvm.ptr<array<12 x i8>>
-// CHECK-NEXT:     %3 = llvm.getelementptr %2[0, 0] : (!llvm.ptr<array<12 x i8>>) -> !llvm.ptr<i8>
-// CHECK-NEXT:     call @_Z5printPc(%3) : (!llvm.ptr<i8>) -> ()
+// CHECK:   func @_ZN3SubC1Eid(%arg0: !llvm.ptr<struct<(i8)>>, %arg1: i32, %arg2: f64) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>}
+// CHECK-NEXT:     call @_ZN4RootC1Ei(%arg0, %arg1) : (!llvm.ptr<struct<(i8)>>, i32) -> ()
+// CHECK-NEXT:     call @_ZN5FRootC1Ev(%arg0) : (!llvm.ptr<struct<(i8)>>) -> ()
+// CHECK-NEXT:     %0 = llvm.mlir.addressof @str0 : !llvm.ptr<array<12 x i8>>
+// CHECK-NEXT:     %1 = llvm.getelementptr %0[0, 0] : (!llvm.ptr<array<12 x i8>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:     call @_Z5printPc(%1) : (!llvm.ptr<i8>) -> ()
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK:   func @_ZN4RootC1Ei(%arg0: !llvm.ptr<struct<(i8)>>, %arg1: i32) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {


### PR DESCRIPTION
According to `CGRecordLowering::accumulateBases()` in `clang/lib/CodeGen/CGRecordLayoutBuilder.cpp`, the derived class struct type should not include the base class when the base class is empty.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>