### PR TITLE
[SYCL] Fix unittests on MSVC

### DIFF
--- a/sycl/unittests/pi/PiMock.cpp
+++ b/sycl/unittests/pi/PiMock.cpp
@@ -80,8 +80,12 @@ TEST(PiMockTest, RedefineAPI) {
 
   // Pass a captureless lambda
   auto *OldFuncPtr = Table.piProgramRetain;
-  Mock.redefine<detail::PiApiKind::piProgramRetain>(
-      [](pi_program) -> pi_result { return PI_SUCCESS; });
+  auto Lambda = [](pi_program) -> pi_result {
+    return PI_ERROR_INVALID_PROGRAM;
+  };
+  EXPECT_FALSE(OldFuncPtr == Lambda)
+      << "Lambda is the same as the existing function.";
+  Mock.redefine<detail::PiApiKind::piProgramRetain>(Lambda);
   EXPECT_FALSE(Table.piProgramRetain == OldFuncPtr)
       << "Passing a lambda didn't change the function table entry";
   ASSERT_FALSE(Table.piProgramRetain == nullptr)

--- a/sycl/unittests/queue/DeviceCheck.cpp
+++ b/sycl/unittests/queue/DeviceCheck.cpp
@@ -68,7 +68,7 @@ pi_result redefinedDevicePartition(
     pi_device device, const pi_device_partition_property *properties,
     pi_uint32 num_devices, pi_device *out_devices, pi_uint32 *out_num_devices) {
   if (out_devices) {
-    for (pi_uint32 I = 0; I < num_devices; ++I) {
+    for (size_t I = 0; I < num_devices; ++I) {
       out_devices[I] = reinterpret_cast<pi_device>(1000 + I);
     }
   }


### PR DESCRIPTION
This commit makes two changes:
* Fixes a cast of incompatible size in the PI mock plugin that caused a warning on MSVC.
* Changes the definition of the captureless lambda function in the RedefineAPI PiMock unittest to avoid MSVC considering it equal to the function defined by the PI mock plugin.