### PR TITLE
[SYCL] Fix deprecation warning for headers

### DIFF
--- a/sycl/include/sycl/backend/cuda.hpp
+++ b/sycl/include/sycl/backend/cuda.hpp
@@ -11,4 +11,8 @@
 
 #include <sycl/detail/defines_elementary.hpp>
 
-__SYCL_WARNING("sycl/backend/cuda.hpp is deprecated and no required anymore")
+#if !defined(_MSC_VER) || defined(__clang__)
+// MSVC doesn't support #warning and we cannot use other methods to report a
+// warning from inside a system header (which SYCL is considered to be).
+#warning sycl/backend/cuda.hpp is deprecated and not required anymore
+#endif

--- a/sycl/include/sycl/backend/level_zero.hpp
+++ b/sycl/include/sycl/backend/level_zero.hpp
@@ -10,7 +10,11 @@
 
 #include <sycl/detail/defines_elementary.hpp>
 
-__SYCL_WARNING("sycl/backend/level_zero.hpp usage is deprecated, include "
-               "sycl/ext/oneapi/backend/level_zero.hpp instead")
+#if !defined(_MSC_VER) || defined(__clang__)
+// MSVC doesn't support #warning and we cannot use other methods to report a
+// warning from inside a system header (which SYCL is considered to be).
+#warning sycl/backend/level_zero.hpp usage is deprecated, include \
+sycl/ext/oneapi/backend/level_zero.hpp instead
+#endif
 
 #include <sycl/ext/oneapi/backend/level_zero.hpp>

--- a/sycl/include/sycl/detail/defines_elementary.hpp
+++ b/sycl/include/sycl/detail/defines_elementary.hpp
@@ -92,18 +92,5 @@
 #define __SYCL_STRINGIFY(x) #x
 #endif // __SYCL_STRINGIFY
 
-// define __SYCL_WARNING convenience macro to report compiler warnings
-#if defined(__GNUC__)
-#define __SYCL_WARNING(msg) _Pragma(__SYCL_STRINGIFY(GCC warning msg))
-#elif defined(_MSC_VER) && !defined(__clang__)
-#define __SYCL_QUOTE1(x) #x
-#define __SYCL_QUOTE(x) __SYCL_QUOTE1(x)
-#define __SYCL_SRC_LOC __FILE__ ":" __SYCL_QUOTE(__LINE__)
-#define __SYCL_WARNING(msg) __pragma(message(__SYCL_SRC_LOC " warning: " msg))
-#else // clang et. al.
-// clang emits "warning:" in the message pragma output
-#define __SYCL_WARNING(msg) __pragma(message(msg))
-#endif // __GNUC__
-
 static_assert(__cplusplus >= 201703L,
               "DPCPP does not support C++ version earlier than C++17.");

--- a/sycl/include/sycl/ext/intel/online_compiler.hpp
+++ b/sycl/include/sycl/ext/intel/online_compiler.hpp
@@ -10,8 +10,11 @@
 
 #include <sycl/detail/defines_elementary.hpp>
 
-__SYCL_WARNING(
-    "sycl/ext/intel/online_compiler.hpp usage is deprecated, include "
-    "sycl/ext/intel/experimental/online_compiler.hpp instead")
+#if !defined(_MSC_VER) || defined(__clang__)
+// MSVC doesn't support #warning and we cannot use other methods to report a
+// warning from inside a system header (which SYCL is considered to be).
+#warning sycl/ext/intel/online_compiler.hpp usage is deprecated, \
+include sycl/ext/intel/experimental/online_compiler.hpp instead
+#endif
 
 #include <sycl/ext/intel/experimental/online_compiler.hpp>

--- a/sycl/test/warnings/deprecated_headers.cpp
+++ b/sycl/test/warnings/deprecated_headers.cpp
@@ -1,0 +1,11 @@
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
+#include <sycl/sycl.hpp>
+
+// expected-warning@sycl/backend/cuda.hpp:17 {{sycl/backend/cuda.hpp is deprecated and not required anymore}}
+#include <sycl/backend/cuda.hpp>
+
+// expected-warning@sycl/backend/level_zero.hpp:16 {{sycl/backend/level_zero.hpp usage is deprecated, include sycl/ext/oneapi/backend/level_zero.hpp instead}}
+#include <sycl/backend/level_zero.hpp>
+
+// expected-warning@sycl/ext/intel/online_compiler.hpp:16 {{sycl/ext/intel/online_compiler.hpp usage is deprecated, include sycl/ext/intel/experimental/online_compiler.hpp instead}}
+#include <sycl/ext/intel/online_compiler.hpp>

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -1,7 +1,7 @@
 // RUN: %clangxx %fsycl-host-only -fsyntax-only -ferror-limit=100 -sycl-std=2020 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
 
 #include <CL/sycl.hpp>
-#include <sycl/ext/intel/online_compiler.hpp>
+#include <sycl/ext/intel/experimental/online_compiler.hpp>
 
 int main() {
   cl_context ClCtx;


### PR DESCRIPTION
Using pragmas to emit warnings didn't work because SYCL headers are considered to be system headers and any warnings in them are suppressed.

Use "#warning" instead. Unfortunately, MSVC doesn't support it (although it's part of C23/C++23 and they'll have to add support eventually), so we need some #if guards. Also, #warning cannot be put inside a macro definition, thus we have to have some code duplication. Luckily, entire headers deprecations aren't as often and we can be a little bit verbose.