### PR TITLE
[SYCL-MLIR]: Emit SYCL non-constructor functions from the supported list

### DIFF
--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -424,6 +424,9 @@ public:
                                   bool removeIndex = true);
 
   ValueCategory CommonArrayToPointer(ValueCategory val);
+
+  static void getMangledFuncName(std::string &name, const FunctionDecl *FD,
+                                 CodeGen::CodeGenModule &CGM);
 };
 
 #endif


### PR DESCRIPTION
Before this PR, only the constructors from the supported list are emitted. 
This PR allows non-constructor functions from the supported list to also be emitted.
Also, added more functions, which are needed for single_task case, to the supported list.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>