### PR TITLE
[NFC] Update libsycl file print test

### DIFF
--- a/clang/test/Driver/libsycl-print-file-name.c
+++ b/clang/test/Driver/libsycl-print-file-name.c
@@ -1,6 +1,6 @@
 // UNSUPPORTED: system-windows
 
 // -print-file-name=libsycl.so
-// RUN: %clangxx -print-file-name=libsycl.so 2>&1 | FileCheck %s --check-prefix=PRINT_LIBSYCL
-// RUN: %clangxx -fsycl -print-file-name=libsycl.so 2>&1 | FileCheck %s --check-prefix=PRINT_LIBSYCL
+// RUN: %clangxx -print-file-name=libsycl.so --sysroot=%S/Inputs/SYCL 2>&1 | FileCheck %s --check-prefix=PRINT_LIBSYCL
+// RUN: %clangxx -fsycl -print-file-name=libsycl.so --sysroot=%S/Inputs/SYCL 2>&1 | FileCheck %s --check-prefix=PRINT_LIBSYCL
 // PRINT_LIBSYCL: {{.*}}lib{{(\\\\|/)}}libsycl.so


### PR DESCRIPTION
The test which verifies the proper -print-file-name=libsycl.so output was to dependent on external existence of the library itself.  Update the test so we use an internal location check.