### PR TITLE
[DO NOT MERGE] [SYCL][ABI break] Make sycl::vec trivially_copyable and align layout

### DIFF
--- a/sycl/include/sycl/half_type.hpp
+++ b/sycl/include/sycl/half_type.hpp
@@ -246,23 +246,11 @@ using BIsRepresentationT = half;
 // for vec because they are actually defined as an integer type under the
 // hood. As a result half values will be converted to the integer and passed
 // as a kernel argument which is expected to be floating point number.
-template <int NumElements> struct half_vec {
-  alignas(detail::vector_alignment<StorageT, NumElements>::value)
-      StorageT s[NumElements];
-
-  __SYCL_CONSTEXPR_HALF half_vec() : s{0.0f} { initialize_data(); }
-  constexpr void initialize_data() {
-    for (size_t i = 0; i < NumElements; ++i) {
-      s[i] = StorageT(0.0f);
-    }
-  }
-};
-
-using Vec2StorageT = half_vec<2>;
-using Vec3StorageT = half_vec<3>;
-using Vec4StorageT = half_vec<4>;
-using Vec8StorageT = half_vec<8>;
-using Vec16StorageT = half_vec<16>;
+using Vec2StorageT = std::array<StorageT, 2>;
+using Vec3StorageT = std::array<StorageT, 3>;
+using Vec4StorageT = std::array<StorageT, 4>;
+using Vec8StorageT = std::array<StorageT, 8>;
+using Vec16StorageT = std::array<StorageT, 16>;
 #endif
 
 class half {

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -821,7 +821,7 @@ public:
   // base types are match and that the NumElements == sum of lengths of args.
   template <typename... argTN, typename = EnableIfSuitableTypes<argTN...>,
             typename = EnableIfSuitableNumElements<argTN...>>
-  constexpr vec(const argTN &...args): m_Data{} {
+  constexpr vec(const argTN &...args) : m_Data{} {
     vaargCtorHelper(0, args...);
   }
 
@@ -2087,7 +2087,6 @@ __SYCL_RELLOGOP(||)
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl
 
-
 #ifdef __HAS_EXT_VECTOR_TYPE__
 
 #define __SYCL_DECLARE_TYPE_VIA_CL_T(type)                                     \
@@ -2131,7 +2130,6 @@ __SYCL_DECLARE_TYPE_VIA_CL_T(double)
 #undef __SYCL_DECLARE_TYPE_T
 
 #endif // __HAS_EXT_VECTOR_TYPE__
-
 
 #ifdef __SYCL_DEVICE_ONLY__
 

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -1098,7 +1098,7 @@ public:
 #else
 #define __SYCL_RELLOGOP(RELLOGOP)                                              \
   vec<rel_t, NumElements> operator RELLOGOP(const vec &Rhs) const {            \
-    vec<rel_t, NumElements> Ret;                                               \
+    vec<rel_t, NumElements> Ret{0};                                            \
     for (size_t I = 0; I < NumElements; ++I) {                                 \
       Ret.setValue(I, -(vec_data<DataT>::get(getValue(I))                      \
                             RELLOGOP vec_data<DataT>::get(Rhs.getValue(I))));  \

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -63,6 +63,8 @@ function(add_sycl_rt_library LIB_NAME LIB_OBJ_NAME)
   else()
     target_compile_options(${LIB_OBJ_NAME} PUBLIC
                            -fvisibility=hidden -fvisibility-inlines-hidden)
+
+    target_compile_options(${LIB_OBJ_NAME} PUBLIC -Wno-psabi)
     set(linker_script "${CMAKE_CURRENT_SOURCE_DIR}/ld-version-script.txt")
     target_link_libraries(
         ${LIB_NAME} PRIVATE "-Wl,--version-script=${linker_script}")

--- a/sycl/test/basic_tests/valid_kernel_args.cpp
+++ b/sycl/test/basic_tests/valid_kernel_args.cpp
@@ -33,9 +33,9 @@ struct SomeMarrayStructure {
   static_assert(std::is_trivially_copyable<Type>::value,                       \
                 "Is not trivially copyable type.");
 
-#ifdef __SYCL_DEVICE_ONLY__
 CHECK_PASSING_TO_KERNEL_BY_VALUE(int)
 CHECK_PASSING_TO_KERNEL_BY_VALUE(sycl::cl_uchar4)
 CHECK_PASSING_TO_KERNEL_BY_VALUE(SomeStructure)
-#endif
+CHECK_PASSING_TO_KERNEL_BY_VALUE(sycl::int4)
+CHECK_PASSING_TO_KERNEL_BY_VALUE(sycl::long16)
 CHECK_PASSING_TO_KERNEL_BY_VALUE(SomeMarrayStructure)


### PR DESCRIPTION
Before the patch the data sycl::vec used underneath was either cl_* types or clang vector types(aka ext_vector_type) depending on the host compiler.

This was causing binary compatibility issues because such types are passed differently according to the SysV calling convention. The way such types are passed also depends on the instruction set a compiler allowed to use(aka -avx).

The vector types were used underneath in order speed up sycl::vec operations on the host when available(when compiling with clang). So, to avoid performance degradation we need to continue doing the operations using vector types.

The patch solves this problem by changing the underlying type to std::array in all the cases for the host compilation. And adds conversions to vector types when the host compiler is clang to avoid loosing performance. The GCC vector_size could be used to cover both compiler, but it has some problems to solve, e.g. it does not support vector of lenght 3.

This also allows us to untie sycl::vec from OpenCL types.

The are things to improve:
1. Use vectors data type in more sycl::vec methods
2. Use vectors for half type
3. Refactor several ifdef SYCL_DEVICE_ONLY to if constexpr constructs.