### PR TITLE
[SYCL] Make the mock plugin report cl_khr_il_program as supported

### DIFF
--- a/sycl/unittests/helpers/PiMockPlugin.hpp
+++ b/sycl/unittests/helpers/PiMockPlugin.hpp
@@ -91,7 +91,9 @@ inline pi_result mock_piDeviceGetInfo(pi_device device,
                                       size_t param_value_size,
                                       void *param_value,
                                       size_t *param_value_size_ret) {
-  constexpr char MockSupportedExtensions[] = "cl_khr_fp64 cl_khr_fp16";
+  constexpr char MockDeviceName[] = "Mock device";
+  constexpr char MockSupportedExtensions[] =
+      "cl_khr_fp64 cl_khr_fp16 cl_khr_il_program";
   switch (param_name) {
   case PI_DEVICE_INFO_TYPE: {
     // Act like any device is a GPU.
@@ -100,6 +102,15 @@ inline pi_result mock_piDeviceGetInfo(pi_device device,
       *static_cast<_pi_device_type *>(param_value) = PI_DEVICE_TYPE_GPU;
     if (param_value_size_ret)
       *param_value_size_ret = sizeof(PI_DEVICE_TYPE_GPU);
+    return PI_SUCCESS;
+  }
+  case PI_DEVICE_INFO_NAME: {
+    if (param_value) {
+      assert(param_value_size == sizeof(MockDeviceName));
+      std::memcpy(param_value, MockDeviceName, sizeof(MockDeviceName));
+    }
+    if (param_value_size_ret)
+      *param_value_size_ret = sizeof(MockDeviceName);
     return PI_SUCCESS;
   }
   case PI_DEVICE_INFO_PARENT_DEVICE: {

--- a/sycl/unittests/program_manager/BuildLog.cpp
+++ b/sycl/unittests/program_manager/BuildLog.cpp
@@ -47,37 +47,10 @@ static pi_result redefinedProgramGetBuildInfo(
   return PI_SUCCESS;
 }
 
-static pi_result redefinedDeviceGetInfo(pi_device device,
-                                        pi_device_info param_name,
-                                        size_t param_value_size,
-                                        void *param_value,
-                                        size_t *param_value_size_ret) {
-  if (param_name == PI_DEVICE_INFO_NAME) {
-    const std::string name = "Test Device";
-    if (param_value_size_ret) {
-      *param_value_size_ret = name.size();
-    }
-    if (param_value) {
-      auto *val = static_cast<char *>(param_value);
-      strcpy(val, name.data());
-    }
-  }
-  if (param_name == PI_DEVICE_INFO_COMPILER_AVAILABLE) {
-    if (param_value_size_ret) {
-      *param_value_size_ret = sizeof(cl_bool);
-    }
-    if (param_value) {
-      auto *val = static_cast<cl_bool *>(param_value);
-      *val = 1;
-    }
-  }
-  return PI_SUCCESS;
-}
 
 static void setupCommonTestAPIs(sycl::unittest::PiMock &Mock) {
   using namespace sycl::detail;
   Mock.redefine<PiApiKind::piProgramGetBuildInfo>(redefinedProgramGetBuildInfo);
-  Mock.redefine<PiApiKind::piDeviceGetInfo>(redefinedDeviceGetInfo);
 }
 
 TEST(BuildLog, OutputNothingOnLevel1) {

--- a/sycl/unittests/program_manager/BuildLog.cpp
+++ b/sycl/unittests/program_manager/BuildLog.cpp
@@ -47,7 +47,6 @@ static pi_result redefinedProgramGetBuildInfo(
   return PI_SUCCESS;
 }
 
-
 static void setupCommonTestAPIs(sycl::unittest::PiMock &Mock) {
   using namespace sycl::detail;
   Mock.redefine<PiApiKind::piProgramGetBuildInfo>(redefinedProgramGetBuildInfo);


### PR DESCRIPTION
To make build-log tests not depend on the binary type, this commit makes the mock plugin report that the cl_khr_il_program is supported. Together with adding PI_DEVICE_INFO_NAME to mock_piDeviceGetInfo, the corresponding redefinition from the build-log tests can be removed.