### PR TITLE
[SYCLToLLVM]: Teach cgeist to attach function  attributes

### DIFF
--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -5140,7 +5140,9 @@ mlir::Location MLIRASTConsumer::getMLIRLocation(clang::SourceLocation loc) {
 }
 
 void MLIRASTConsumer::setMLIRFunctionAttributes(mlir::func::FuncOp &function,
-    const FunctionDecl &FD, LLVM::Linkage lnk, MLIRContext *ctx) const {
+                                                const FunctionDecl &FD,
+                                                LLVM::Linkage lnk,
+                                                MLIRContext *ctx) const {
   bool isSycl = FD.hasAttr<SYCLDeviceAttr>() || FD.hasAttr<SYCLKernelAttr>();
 
   NamedAttrList attrs(function->getAttrDictionary());
@@ -5156,15 +5158,15 @@ void MLIRASTConsumer::setMLIRFunctionAttributes(mlir::func::FuncOp &function,
 
   // Calling conventions for SPIRV functions.
   attrs.set("llvm.cconv", mlir::LLVM::CConvAttr::get(
-                            ctx, FD.hasAttr<SYCLKernelAttr>()
-                                     ? mlir::LLVM::cconv::CConv::SPIR_KERNEL
-                                     : mlir::LLVM::cconv::CConv::SPIR_FUNC));
+                              ctx, FD.hasAttr<SYCLKernelAttr>()
+                                       ? mlir::LLVM::cconv::CConv::SPIR_KERNEL
+                                       : mlir::LLVM::cconv::CConv::SPIR_FUNC));
 
   // SYCL v1.2.1 s3.10:
   //   kernels and device function cannot include RTTI information,
   //   exception classes, recursive code, virtual functions or make use of
   //   C++ libraries that are not compiled for the device.
-  std::vector<mlir::Attribute> passThroughAttrs;  
+  std::vector<mlir::Attribute> passThroughAttrs;
   passThroughAttrs.push_back(StringAttr::get(ctx, "norecurse"));
   passThroughAttrs.push_back(StringAttr::get(ctx, "nounwind"));
 
@@ -5182,7 +5184,7 @@ void MLIRASTConsumer::setMLIRFunctionAttributes(mlir::func::FuncOp &function,
     passThroughAttrs.push_back(StringAttr::get(ctx, "mustprogress"));
 
   attrs.set("passthrough", ArrayAttr::get(ctx, {passThroughAttrs}));
-  
+
   function->setAttrs(attrs.getDictionary(ctx));
 }
 

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -141,6 +141,11 @@ struct MLIRASTConsumer : public ASTConsumer {
   llvm::Type *getLLVMType(clang::QualType t);
 
   mlir::Location getMLIRLocation(clang::SourceLocation loc);
+
+private:
+  void setMLIRFunctionAttributes(mlir::func::FuncOp &function,
+                                 const FunctionDecl &FD, LLVM::Linkage lnk,
+                                 MLIRContext *ctx) const;
 };
 
 class MLIRScanner : public StmtVisitor<MLIRScanner, ValueCategory> {

--- a/polygeist/tools/cgeist/Test/.clang-format
+++ b/polygeist/tools/cgeist/Test/.clang-format
@@ -1,0 +1,1 @@
+DisableFormat: true

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -22,7 +22,8 @@
 // CHECK:      func.func @_ZN4sycl3_V15rangeILi1EEC1ERKS2_(%arg0: memref<?x!sycl_range_1_>, %arg1: memref<?x!sycl_range_1_>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
 // CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl_range_1_>) -> memref<?x!sycl_array_1_>
 
-// CHECK-LLVM: define spir_func void @cons_0([[ID_TYPE:%"class.cl::sycl::id.1"]] [[ARG0:%.*]], [[RANGE_TYPE:%"class.cl::sycl::range.1"]] [[ARG1:%.*]]) {
+// CHECK-LLVM: ; Function Attrs: convergent mustprogress norecurse nounwind
+// CHECK-LLVM: define spir_func void @cons_0([[ID_TYPE:%"class.cl::sycl::id.1"]] [[ARG0:%.*]], [[RANGE_TYPE:%"class.cl::sycl::range.1"]] [[ARG1:%.*]])
 // CHECK-LLVM-DAG: [[RANGE1:%.*]] = alloca [[RANGE_TYPE]]
 // CHECK-LLVM-DAG: [[ID1:%.*]] = alloca [[ID_TYPE]]
 // CHECK-LLVM-DAG: [[RANGE2:%.*]] = alloca [[RANGE_TYPE]]
@@ -37,7 +38,8 @@ extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
   auto range = sycl::range<1>{r};
 }
 
-// CHECK: func.func @cons_1() attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>} {
+// CHECK: func.func @cons_1()
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-NEXT: %false = arith.constant false
 // CHECK-NEXT: %c0_i8 = arith.constant 0 : i8
 // CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
@@ -53,7 +55,8 @@ extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
 // Ensure declaration to have external linkage.
 // CHECK: func.func private @_ZN4sycl3_V12idILi2EEC1Ev(memref<?x!sycl_id_2_>) attributes {llvm.linkage = #llvm.linkage<external>}
 
-// CHECK-LLVM: define spir_func void @cons_1() {
+// CHECK-LLVM: ; Function Attrs: convergent mustprogress norecurse nounwind
+// CHECK-LLVM: define spir_func void @cons_1()
 // CHECK-LLVM: [[ID1:%.*]] = alloca [[ID_TYPE:%"class.cl::sycl::id.2"]]
 // CHECK-LLVM: [[CAST1:%.*]] = bitcast [[ID_TYPE]]* %1 to i8*
 // CHECK-LLVM: call void @llvm.memset.p0i8.i64(i8* %2, i8 0, i64 16, i1 false)
@@ -63,14 +66,16 @@ extern "C" SYCL_EXTERNAL void cons_1() {
   auto id = sycl::id<2>{};
 }
 
-// CHECK: func.func @cons_2(%arg0: i64, %arg1: i64) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>} {
+// CHECK: func.func @cons_2(%arg0: i64, %arg1: i64)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
 // CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
 // CHECK-NEXT: sycl.constructor(%1, %arg0, %arg1) {MangledName = @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, Type = @id} : (memref<?x!sycl_id_2_>, i64, i64) -> ()
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
-// CHECK-LLVM: define spir_func void @cons_2(i64 %0, i64 %1) {
+// CHECK-LLVM: ; Function Attrs: convergent mustprogress norecurse nounwind
+// CHECK-LLVM: define spir_func void @cons_2(i64 %0, i64 %1)
 // CHECK-LLVM: [[ID1:%.*]] = alloca [[ID_TYPE:%"class.cl::sycl::id.2"]]
 // CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm([[ID_TYPE]]* [[ID1]], [[ID_TYPE]]* [[ID1]], i64 0, i64 1, i64 1, i64 %0, i64 %1)
 
@@ -78,7 +83,8 @@ extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
   auto id = sycl::id<2>{a, b};
 }
 
-// CHECK: func.func @cons_3(%arg0: !sycl_item_2_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>} {
+// CHECK: func.func @cons_3(%arg0: !sycl_item_2_1_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
 // CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
 // CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl_item_2_1_>
@@ -88,7 +94,8 @@ extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
-// CHECK-LLVM: define spir_func void @cons_3([[ITEM_TYPE:%"class.cl::sycl::item.2.true"]] [[ARG0:%.*]]) {
+// CHECK-LLVM: ; Function Attrs: convergent mustprogress norecurse nounwind
+// CHECK-LLVM: define spir_func void @cons_3([[ITEM_TYPE:%"class.cl::sycl::item.2.true"]] [[ARG0:%.*]])
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE:%"class.cl::sycl::id.2"]]  
 // CHECK-LLVM-DAG: [[ITEM:%.*]] = alloca [[ITEM_TYPE]]
 // CHECK-LLVM: store [[ITEM_TYPE]] [[ARG0]], [[ITEM_TYPE]]* [[ITEM]], align 8
@@ -98,7 +105,8 @@ extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
   auto id = sycl::id<2>{val};
 }
 
-// CHECK: func.func @cons_4(%arg0: !sycl_id_2_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>} {
+// CHECK: func.func @cons_4(%arg0: !sycl_id_2_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
 // CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
 // CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl_id_2_>
@@ -108,7 +116,8 @@ extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
-// CHECK-LLVM: define spir_func void @cons_4([[ID_TYPE:%"class.cl::sycl::id.2"]] [[ARG0:%.*]]) {
+// CHECK-LLVM: ; Function Attrs: convergent mustprogress norecurse nounwind
+// CHECK-LLVM: define spir_func void @cons_4([[ID_TYPE:%"class.cl::sycl::id.2"]] [[ARG0:%.*]])
 // CHECK-LLVM-DAG: [[ID1:%.*]] = alloca [[ID_TYPE]]
 // CHECK-LLVM-DAG: [[ID2:%.*]] = alloca [[ID_TYPE]]
 // CHECK-LLVM: store [[ID_TYPE]] [[ARG0]], [[ID_TYPE]]* [[ID2]], align 8
@@ -122,7 +131,8 @@ extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
 // CHECK: [[I:%.*]] = "polygeist.subindex"(%arg0, %c0) : (memref<?x!sycl_accessor_1_i32_write_global_buffer>, index) -> memref<?x!sycl_accessor_impl_device_1_>
 // CHECK: sycl.constructor([[I]], {{%.*}}, {{%.*}}, {{%.*}}) {MangledName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_, Type = @AccessorImplDevice} : (memref<?x!sycl_accessor_impl_device_1_>, !sycl_id_1_, !sycl_range_1_, !sycl_range_1_) -> ()
 
-// CHECK-LLVM-LABEL: define spir_func void @cons_5() {
+// CHECK-LLVM: ; Function Attrs: convergent mustprogress norecurse nounwind
+// CHECK-LLVM-LABEL: define spir_func void @cons_5()
 // CHECK-LLVM: [[ACCESSOR:%.*]] = alloca [[ACCESSOR_TYPE:%"class.cl::sycl::accessor.1"]], i64 ptrtoint ([[ACCESSOR_TYPE]]* getelementptr ([[ACCESSOR_TYPE]], [[ACCESSOR_TYPE]]* null, i32 1) to i64), align 8
 // CHECK-LLVM: call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev([[ACCESSOR_TYPE]]* [[ACCESSOR]], [[ACCESSOR_TYPE]]* [[ACCESSOR]], i64 0, i64 1, i64 1)
 extern "C" SYCL_EXTERNAL void cons_5() {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -16,7 +16,8 @@
 // CHECK: !sycl_id_2_ = !sycl.id<2>
 // CHECK: !sycl_item_2_1_ = !sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>)>
 
-// CHECK: func.func @_Z8method_1N4sycl3_V14itemILi2ELb1EEE(%arg0: !sycl_item_2_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>} {
+// CHECK: func.func @_Z8method_1N4sycl3_V14itemILi2ELb1EEE(%arg0: !sycl_item_2_1_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-NEXT: %c0_i32 = arith.constant 0 : i32
 // CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_item_2_1_>
 // CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_item_2_1_> to memref<?x!sycl_item_2_1_>
@@ -29,7 +30,8 @@ SYCL_EXTERNAL void method_1(sycl::item<2, true> item) {
   auto id = item.get_id(0);
 }
 
-// CHECK: func.func @_Z8method_2N4sycl3_V14itemILi2ELb1EEE(%arg0: !sycl_item_2_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>} {
+// CHECK: func.func @_Z8method_2N4sycl3_V14itemILi2ELb1EEE(%arg0: !sycl_item_2_1_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_item_2_1_>
 // CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_item_2_1_> to memref<?x!sycl_item_2_1_>
 // CHECK-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl_item_2_1_>
@@ -41,7 +43,8 @@ SYCL_EXTERNAL void method_2(sycl::item<2, true> item) {
   auto id = item.operator==(item);
 }
 
-// CHECK: func.func @_Z4op_1N4sycl3_V12idILi2EEES2_(%arg0: !sycl_id_2_, %arg1: !sycl_id_2_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>} {
+// CHECK: func.func @_Z4op_1N4sycl3_V12idILi2EEES2_(%arg0: !sycl_id_2_, %arg1: !sycl_id_2_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
 // CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
 // CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl_id_2_>
@@ -56,7 +59,8 @@ SYCL_EXTERNAL void op_1(sycl::id<2> a, sycl::id<2> b) {
   auto id = a == b;
 }
 
-// CHECK: func.func @_Z8static_1N4sycl3_V12idILi2EEES2_(%arg0: !sycl_id_2_, %arg1: !sycl_id_2_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>} {
+// CHECK: func.func @_Z8static_1N4sycl3_V12idILi2EEES2_(%arg0: !sycl_id_2_, %arg1: !sycl_id_2_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-NEXT: %c1_i32 = arith.constant 1 : i32
 // CHECK-NEXT: %c0_i32 = arith.constant 0 : i32
 // CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -18,7 +18,8 @@
 // CHECK: !sycl_item_2_1_ = !sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>)>
 // CHECK: !sycl_range_1_ = !sycl.range<1>
 
-// CHECK: func.func @_ZTS8kernel_1(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_) attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>}
+// CHECK: func.func @_ZTS8kernel_1(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 // CHECK-NOT: SYCLKernel =
 
 class kernel_1 {
@@ -46,7 +47,8 @@ void host_1() {
   }
 }
 
-// CHECK: func.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_) attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>}
+// CHECK: func.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 // CHECK-NOT: SYCLKernel =
 
 void host_2() {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -27,56 +27,58 @@
 // CHECK: !sycl_range_1_ = !sycl.range<1>
 // CHECK: !sycl_range_2_ = !sycl.range<2>
 
-// CHECK: func.func @_Z4id_1N4sycl3_V12idILi1EEE(%arg0: !sycl_id_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>}
+// CHECK: func.func @_Z4id_1N4sycl3_V12idILi1EEE(%arg0: !sycl_id_1_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 SYCL_EXTERNAL void id_1(sycl::id<1> id) {}
 
-// CHECK: func.func @_Z4id_2N4sycl3_V12idILi2EEE(%arg0: !sycl_id_2_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>}
-
+// CHECK: func.func @_Z4id_2N4sycl3_V12idILi2EEE(%arg0: !sycl_id_2_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 SYCL_EXTERNAL void id_2(sycl::id<2> id) {}
 
-// CHECK: func.func @_Z5acc_1N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl_accessor_1_i32_read_write_global_buffer) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>}
+// CHECK: func.func @_Z5acc_1N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl_accessor_1_i32_read_write_global_buffer)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 SYCL_EXTERNAL void acc_1(sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write>) {}
 
-// CHECK: func.func @_Z5acc_2N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl_accessor_2_i32_read_write_global_buffer) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>}
-
+// CHECK: func.func @_Z5acc_2N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl_accessor_2_i32_read_write_global_buffer)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 SYCL_EXTERNAL void acc_2(sycl::accessor<sycl::cl_int, 2, sycl::access::mode::read_write>) {}
 
-// CHECK: func.func @_Z7range_1N4sycl3_V15rangeILi1EEE(%arg0: !sycl_range_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>}
-
+// CHECK: func.func @_Z7range_1N4sycl3_V15rangeILi1EEE(%arg0: !sycl_range_1_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 SYCL_EXTERNAL void range_1(sycl::range<1> range) {}
 
-// CHECK: func.func @_Z7range_2N4sycl3_V15rangeILi2EEE(%arg0: !sycl_range_2_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>}
-
+// CHECK: func.func @_Z7range_2N4sycl3_V15rangeILi2EEE(%arg0: !sycl_range_2_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 SYCL_EXTERNAL void range_2(sycl::range<2> range) {}
 
-// CHECK: func.func @_Z5arr_1N4sycl3_V16detail5arrayILi1EEE(%arg0: !sycl_array_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>}
-
+// CHECK: func.func @_Z5arr_1N4sycl3_V16detail5arrayILi1EEE(%arg0: !sycl_array_1_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 SYCL_EXTERNAL void arr_1(sycl::detail::array<1> arr) {}
 
-// CHECK: func.func @_Z5arr_2N4sycl3_V16detail5arrayILi2EEE(%arg0: !sycl_array_2_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>}
-
+// CHECK: func.func @_Z5arr_2N4sycl3_V16detail5arrayILi2EEE(%arg0: !sycl_array_2_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 SYCL_EXTERNAL void arr_2(sycl::detail::array<2> arr) {}
 
-// CHECK: func.func @_Z11item_1_trueN4sycl3_V14itemILi1ELb1EEE(%arg0: !sycl_item_1_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>}
-
+// CHECK: func.func @_Z11item_1_trueN4sycl3_V14itemILi1ELb1EEE(%arg0: !sycl_item_1_1_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 SYCL_EXTERNAL void item_1_true(sycl::item<1, true> item) {}
 
-// CHECK: func.func @_Z12item_2_falseN4sycl3_V14itemILi2ELb0EEE(%arg0: !sycl_item_2_0_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>}
-
+// CHECK: func.func @_Z12item_2_falseN4sycl3_V14itemILi2ELb0EEE(%arg0: !sycl_item_2_0_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 SYCL_EXTERNAL void item_2_false(sycl::item<2, false> item) {}
 
-// CHECK: func.func @_Z9nd_item_1N4sycl3_V17nd_itemILi1EEE(%arg0: !sycl_nd_item_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>}
-
+// CHECK: func.func @_Z9nd_item_1N4sycl3_V17nd_itemILi1EEE(%arg0: !sycl_nd_item_1_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 SYCL_EXTERNAL void nd_item_1(sycl::nd_item<1> nd_item) {}
 
-// CHECK: func.func @_Z9nd_item_2N4sycl3_V17nd_itemILi2EEE(%arg0: !sycl_nd_item_2_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>}
-
+// CHECK: func.func @_Z9nd_item_2N4sycl3_V17nd_itemILi2EEE(%arg0: !sycl_nd_item_2_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 SYCL_EXTERNAL void nd_item_2(sycl::nd_item<2> nd_item) {}
 
-// CHECK: func.func @_Z7group_1N4sycl3_V15groupILi1EEE(%arg0: !sycl_group_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>}
-
+// CHECK: func.func @_Z7group_1N4sycl3_V15groupILi1EEE(%arg0: !sycl_group_1_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 SYCL_EXTERNAL void group_1(sycl::group<1> group) {}
 
-// CHECK: func.func @_Z7group_2N4sycl3_V15groupILi2EEE(%arg0: !sycl_group_2_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>}
-
+// CHECK: func.func @_Z7group_2N4sycl3_V15groupILi2EEE(%arg0: !sycl_group_2_)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 SYCL_EXTERNAL void group_2(sycl::group<2> group) {}


### PR DESCRIPTION
This PR enhances `cgeist` to attach function attributes [convergent mustprogress norecurse nounwind] on SYCL device functions and kernels. Example:
``` 
; Function Attrs: convergent mustprogress norecurse
define dso_local spir_func void @ctor_1(i64 noundef %i) #0 { ... }
```
Signed-off-by: Tiotto, Ettore <ettore.tiotto@intel.com>