### PR TITLE
[CI] Enable independent build of libclc

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -16,7 +16,7 @@ def do_configure(args):
     llvm_external_projects = 'sycl;llvm-spirv;opencl;libdevice;xpti;xptifw'
 
     libclc_amd_target_names = ';amdgcn--;amdgcn--amdhsa'
-    libclc_nvidia_target_names = 'nvptx64--;nvptx64--nvidiacl'
+    libclc_nvidia_target_names = ';nvptx64--;nvptx64--nvidiacl'
 
     if args.llvm_external_projects:
         llvm_external_projects += ";" + args.llvm_external_projects.replace(",", ";")
@@ -115,6 +115,7 @@ def do_configure(args):
             libclc_targets_to_build += libclc_amd_target_names
         if libclc_nvidia_target_names not in libclc_targets_to_build:
             libclc_targets_to_build += libclc_nvidia_target_names
+        libclc_gen_remangled_variants = 'ON'
 
     if args.enable_plugin:
         sycl_enabled_plugins += args.enable_plugin

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -396,6 +396,11 @@ if("lld" IN_LIST LLVM_ENABLE_PROJECTS)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS lld)
 endif()
 
+if("libclc" IN_LIST LLVM_ENABLE_PROJECTS)
+  add_dependencies(sycl-toolchain libspirv-builtins)
+  list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS libspirv-builtins)
+endif()
+
 if("cuda" IN_LIST SYCL_ENABLE_PLUGINS)
   # Ensure that libclc is enabled.
   list(FIND LLVM_ENABLE_PROJECTS libclc LIBCLC_FOUND)
@@ -404,8 +409,8 @@ if("cuda" IN_LIST SYCL_ENABLE_PLUGINS)
       "CUDA support requires adding \"libclc\" to the CMake argument \"LLVM_ENABLE_PROJECTS\"")
   endif()
 
-  add_dependencies(sycl-toolchain libspirv-builtins pi_cuda)
-  list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS libspirv-builtins pi_cuda)
+  add_dependencies(sycl-toolchain pi_cuda)
+  list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS pi_cuda)
 endif()
 
 if("hip" IN_LIST SYCL_ENABLE_PLUGINS)
@@ -421,8 +426,8 @@ if("hip" IN_LIST SYCL_ENABLE_PLUGINS)
       "HIP support requires adding \"lld\" to the CMake argument \"LLVM_ENABLE_PROJECTS\"")
   endif()
 
-  add_dependencies(sycl-toolchain libspirv-builtins pi_hip)
-  list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS libspirv-builtins pi_hip)
+  add_dependencies(sycl-toolchain pi_hip)
+  list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS pi_hip)
 endif()
 
 if("esimd_emulator" IN_LIST SYCL_ENABLE_PLUGINS)


### PR DESCRIPTION
* Update CMakeLists to build libclc based on project presence in cmake command
* Add remangled versions build in --ci-defaults
* Fix issue on possible libclc targets strings concat