### PR TITLE
[SYCL][DOCS] Remove references to host device in top-level docs

### DIFF
--- a/sycl/doc/FAQ.md
+++ b/sycl/doc/FAQ.md
@@ -16,13 +16,7 @@ compiler provides you with both host and device side compilation. Another
 requirement for code offloading to specialized devices is a compatible OpenCL
 runtime. Our [Get Started Guide](GetStartedGuide.md) will help you
 set up a proper environment. To learn more about using the DPC++ compiler,
-please refer to [Users Manual](UsersManual.md). If using a special compiler
-is not an option for you and/or you would like to experiment without offloading
-code to non-host devices, you can exploit SYCL's host device feature. This
-gives you the ability to use any C++17 compiler. You will need to link your
-application with the DPC++ Runtime library and provide a path to the SYCL
-headers directory. Please, refer to your compiler manual to learn about
-specific build options.
+please refer to [Users Manual](UsersManual.md).
 
 ### Q: How are DPC++ compilation phases different from those of a usual C++ compiler? Can I customize this flow for my applications?
 **A:** Due to the fact that both host and device code need to be compiled and
@@ -63,10 +57,11 @@ design/CompilerAndRuntimeDesign.md) document.
 
 ## Using applications built with DPC++
 
-### Q: What happens if I run my application on a machine without OpenCL?
-**A:** If you use the default SYCL device selector (or any other selector that
-allows host device), then a fallback to the host device will take place.
-Otherwise, an exception will be thrown.
+### Q: What happens if I run my SYCL application on a machine without a supported backend?
+**A:** If a SYCL application is unable to find a suitable device, the SYCL
+objects (`sycl::context`, `sycl::queue`, etc.) or the SYCL device selector (See
+[SYCL 2020 specificaion 4.6.1.1](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:device-selection))
+will throw a `sycl::exception` with `errc::runtime` error code.
 
 
 ## Common issues
@@ -141,12 +136,6 @@ to offload code to specialized devices. DPC++ compiler currently makes use of
 SPIR-V, a portable intermediate representation format. It is a core feature of
 OpenCL 2.1, so any device, capable of OpenCL 2.1, should be supported.
 Otherwise, your OpenCL device must support `cl_khr_il_program` extension.
-
-Apart from that, there's also the so-called host device, which can be used when
-no suitable OpenCL device is found. The host device will use your host CPU as
-the offload target for kernel execution. Since the device code is also compiled
-for the host CPU and no JIT is required, you can easily use any classic C++
-debugging tools of your choice for the host device code.
 
 Furthermore, developers can extend capabilities of the DPC++ Runtime to
 non-OpenCL devices by writing correspondent plugins. To learn more, please

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -670,7 +670,7 @@ more. To find available options, execute:
 
 The `simple-sycl-app.exe` application doesn't specify SYCL device for
 execution, so SYCL runtime will use `default_selector` logic to select one
-of accelerators available in the system or SYCL host device.
+of accelerators available in the system.
 In this case, the behavior of the `default_selector` can be altered
 using the `SYCL_BE` environment variable, setting `PI_CUDA` forces
 the usage of the CUDA backend (if available), `PI_HIP` forces
@@ -682,9 +682,6 @@ SYCL_BE=PI_CUDA ./simple-sycl-app-cuda.exe
 ```
 
 The default is the OpenCL backend if available.
-If there are no OpenCL or CUDA devices available, the SYCL host device is used.
-The SYCL host device executes the SYCL application directly in the host,
-without using any low-level API.
 
 **NOTE**: `nvptx64-nvidia-cuda` is usable with `-fsycl-targets`
 if clang was built with the cmake option `SYCL_ENABLE_PLUGINS=cuda`.
@@ -825,7 +822,6 @@ which contains all the symbols required.
 
 * DPC++ device compiler fails if the same kernel was used in different
   translation units.
-* SYCL host device is not fully supported.
 * SYCL 2020 support work is in progress.
 * 32-bit host/target is not supported.
 * DPC++ works only with OpenCL low level runtimes which support out-of-order


### PR DESCRIPTION
This commit removes references to the host device from the Getting Started Guide and the FAQ documents.