### PR TITLE
[SYCLToLLVM]: Use LLVM_DEBUG in cgeist

### DIFF
--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -437,8 +437,11 @@ mlir::Value MLIRScanner::createAllocOp(mlir::Type t, VarDecl *name,
     } else {
       mr = mlir::MemRefType::get(1, t, {}, memspace);
       alloc = abuilder.create<mlir::memref::AllocaOp>(varLoc, mr);
-      LLVM_DEBUG(llvm::dbgs() << "MLIRScanner::createAllocOp: created: ";
-                 alloc.dump(); llvm::dbgs() << "\n");
+      LLVM_DEBUG({
+        llvm::dbgs() << "MLIRScanner::createAllocOp: created: ";
+        alloc.dump();
+        llvm::dbgs() << "\n"
+      });
 
       if (memspace != 0) {
         alloc = abuilder.create<polygeist::Pointer2MemrefOp>(
@@ -448,8 +451,11 @@ mlir::Value MLIRScanner::createAllocOp(mlir::Type t, VarDecl *name,
       }
       alloc = abuilder.create<mlir::memref::CastOp>(
           varLoc, mlir::MemRefType::get(-1, t, {}, 0), alloc);
-      LLVM_DEBUG(llvm::dbgs() << "MLIRScanner::createAllocOp: created: ";
-                 alloc.dump(); llvm::dbgs() << "\n");
+      LLVM_DEBUG({
+        llvm::dbgs() << "MLIRScanner::createAllocOp: created: ";
+        alloc.dump();
+        llvm::dbgs() << "\n"
+      });
 
       if (t.isa<mlir::IntegerType, mlir::FloatType>()) {
         mlir::Value idxs[] = {abuilder.create<ConstantIndexOp>(loc, 0)};

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -440,7 +440,7 @@ mlir::Value MLIRScanner::createAllocOp(mlir::Type t, VarDecl *name,
       LLVM_DEBUG({
         llvm::dbgs() << "MLIRScanner::createAllocOp: created: ";
         alloc.dump();
-        llvm::dbgs() << "\n"
+        llvm::dbgs() << "\n";
       });
 
       if (memspace != 0) {
@@ -454,7 +454,7 @@ mlir::Value MLIRScanner::createAllocOp(mlir::Type t, VarDecl *name,
       LLVM_DEBUG({
         llvm::dbgs() << "MLIRScanner::createAllocOp: created: ";
         alloc.dump();
-        llvm::dbgs() << "\n"
+        llvm::dbgs() << "\n";
       });
 
       if (t.isa<mlir::IntegerType, mlir::FloatType>()) {

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -46,8 +46,6 @@
 #include "mlir/Dialect/SYCL/IR/SYCLOpsDialect.h.inc"
 #include "mlir/Dialect/SYCL/IR/SYCLOpsTypes.h"
 
-static bool BREAKPOINT_FUNCTION = false;
-
 using namespace std;
 using namespace clang;
 using namespace llvm;
@@ -68,10 +66,6 @@ static cl::opt<bool> memRefABI("memref-abi", cl::init(true),
 
 cl::opt<std::string> PrefixABI("prefix-abi", cl::init(""),
                                cl::desc("Prefix for emitted symbols"));
-
-static cl::opt<bool> DebugFunction(
-    "debug-function", cl::init(false),
-    cl::desc("Print informations about functions being processed."));
 
 static cl::opt<bool>
     CombinedStructABI("struct-abi", cl::init(true),
@@ -443,6 +437,9 @@ mlir::Value MLIRScanner::createAllocOp(mlir::Type t, VarDecl *name,
     } else {
       mr = mlir::MemRefType::get(1, t, {}, memspace);
       alloc = abuilder.create<mlir::memref::AllocaOp>(varLoc, mr);
+      LLVM_DEBUG(llvm::dbgs() << "MLIRScanner::createAllocOp: created: ";
+                 alloc.dump(); llvm::dbgs() << "\n");
+
       if (memspace != 0) {
         alloc = abuilder.create<polygeist::Pointer2MemrefOp>(
             varLoc, mlir::MemRefType::get(-1, t, {}, memspace),
@@ -451,6 +448,9 @@ mlir::Value MLIRScanner::createAllocOp(mlir::Type t, VarDecl *name,
       }
       alloc = abuilder.create<mlir::memref::CastOp>(
           varLoc, mlir::MemRefType::get(-1, t, {}, 0), alloc);
+      LLVM_DEBUG(llvm::dbgs() << "MLIRScanner::createAllocOp: created: ";
+                 alloc.dump(); llvm::dbgs() << "\n");
+
       if (t.isa<mlir::IntegerType, mlir::FloatType>()) {
         mlir::Value idxs[] = {abuilder.create<ConstantIndexOp>(loc, 0)};
         abuilder.create<mlir::memref::StoreOp>(
@@ -1510,13 +1510,11 @@ ValueCategory MLIRScanner::VisitConstructCommon(clang::CXXConstructExpr *cons,
     MLIRScanner::getMangledFuncName(name, FuncDecl, Glob.CGM);
     name = (PrefixABI + name);
 
-    if (DebugFunction) {
-      llvm::dbgs() << "Starting codegen of " << name << "\n";
-    }
+    LLVM_DEBUG(llvm::dbgs() << "Starting codegen of " << name << "\n");
+
     if (isSupportedFunctions(name)) {
-      if (DebugFunction) {
-        llvm::dbgs() << "Function found in registry, continue codegen-ing...\n";
-      }
+      LLVM_DEBUG(llvm::dbgs()
+                 << "Function found in registry, continue codegen-ing...\n");
       ShouldEmit = true;
     }
   }
@@ -4934,12 +4932,8 @@ void MLIRASTConsumer::run() {
   while (functionsToEmit.size()) {
     const FunctionDecl *FD = functionsToEmit.front();
 
-    if (BREAKPOINT_FUNCTION && DebugFunction) {
-      printf("\n");
-      printf("-- FUNCTION BEING EMITTED : \033[0;32m %s \033[0m -- \n",
-             FD->getNameAsString().c_str());
-      printf("\n");
-    }
+    LLVM_DEBUG(llvm::dbgs() << "\n-- FUNCTION BEING EMITTED: "
+                            << FD->getNameAsString() << " --\n\n";);
 
     assert(FD->getBody());
     functionsToEmit.pop_front();
@@ -4958,28 +4952,27 @@ void MLIRASTConsumer::run() {
     auto Function = GetOrCreateMLIRFunction(FD, true);
     ms.init(Function, FD);
 
-    if (BREAKPOINT_FUNCTION && DebugFunction) {
-      printf("\n");
+    LLVM_DEBUG({
+      llvm::dbgs() << "\n";
       Function.dump();
-      printf("\n");
+      llvm::dbgs() << "\n";
 
       if (functionsToEmit.size()) {
-        printf("-- FUNCTION(S) LEFT TO BE EMITTED --\n");
+        llvm::dbgs() << "-- FUNCTION(S) LEFT TO BE EMITTED --\n";
 
         for (const auto *FD : functionsToEmit) {
-          printf("  [+] %s(", FD->getNameAsString().c_str());
+          llvm::dbgs() << "  [+] " << FD->getNameAsString() << "(";
           for (unsigned int index = 0; index < FD->getNumParams(); index += 1) {
             printf("%s",
                    FD->getParamDecl(index)->getType().getAsString().c_str());
-            if (index + 1 != FD->getNumParams()) {
-              printf(", ");
-            }
+            if (index + 1 != FD->getNumParams())
+              llvm::dbgs() << ", ";
           }
-          printf(")\n");
+          llvm::dbgs() << ")\n";
         }
-        printf("\n");
+        llvm::dbgs() << "\n";
       }
-    }
+    });
   }
 }
 


### PR DESCRIPTION
This PR modifies `cgeist` to use the LLVM_DEBUG infrastructure to emit traces.

Signed-off-by: Tiotto, Ettore <ettore.tiotto@intel.com>