### PR TITLE
[SYCL] Fix spirv-to-ir-wrapper test dependencies

### DIFF
--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -174,6 +174,10 @@ if(TARGET LTO)
   set(LLVM_TEST_DEPENDS ${LLVM_TEST_DEPENDS} LTO)
 endif()
 
+if(TARGET spirv-to-ir-wrapper)
+  set(LLVM_TEST_DEPENDS ${LLVM_TEST_DEPENDS} llvm-spirv)
+endif()
+
 if(LLVM_BUILD_EXAMPLES)
   list(APPEND LLVM_TEST_DEPENDS
     Kaleidoscope-Ch3


### PR DESCRIPTION
If you build solely with with make target check-llvm, llvm-spirv won't be built. However, the tests for spirv-to-ir-wrapper call llvm-spirv, so we need to capture that dependency.

Signed-off-by: Sarnie, Nick <nick.sarnie@intel.com>