### PR TITLE
[SYCL-MLIR]: sycl.call Type attribute is optional

### DIFF
--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -229,8 +229,6 @@ public:
   LogicalResult
   matchAndRewrite(sycl::SYCLCallOp op, OpAdaptor opAdaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    assert(op.Type().has_value() &&
-           "Expecting op.Type() to have a valid value");
     return rewriteCall(op, opAdaptor, rewriter);
   }
 
@@ -257,7 +255,7 @@ private:
     LLVM_DEBUG({
       Operation *func = funcCall->getParentOfType<LLVM::LLVMFuncOp>();
       assert(func && "Could not find parent function");
-      llvm::dbgs() << "CastPattern: Function after rewrite:\n" << *func << "\n";
+      llvm::dbgs() << "CallPattern: Function after rewrite:\n" << *func << "\n";
     });
 
     return success();

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -2032,9 +2032,10 @@ MLIRScanner::EmitSYCLOps(const clang::Expr *Expr,
 
     if (mlirclang::isNamespaceSYCL(Func->getEnclosingNamespaceContext())) {
       auto OptFuncType = llvm::Optional<llvm::StringRef>{llvm::None};
-      if (const auto *RD = dyn_cast<clang::CXXRecordDecl>(Func->getParent())) {
-        OptFuncType = RD->getName();
-      } else {
+      if (const auto *RD = dyn_cast<clang::CXXRecordDecl>(Func->getParent()))
+        if (!RD->getName().empty())
+          OptFuncType = RD->getName();
+      if (!OptFuncType) {
         /// JLE_QUEL::TODO
         /// Handle case where we can't get the parent because the callee is not
         /// a member function


### PR DESCRIPTION
Given that not all SYCL functions are member functions, `sycl.call` Type attribute may not exists.
For example, `dim_loop()` in `llvm/sycl/include/sycl/accessor.hpp` is not a member function:
```
namespace detail {
// To ensure loop unrolling is done when processing dimensions.
template <size_t... Inds, class F>
void dim_loop_impl(std::integer_sequence<size_t, Inds...>, F &&f) {
#if __cplusplus >= 201703L
  (f(Inds), ...);
#else
  (void)std::initializer_list<int>{((void)(f(Inds)), 0)...};
#endif
}

template <size_t count, class F> void dim_loop(F &&f) {
  dim_loop_impl(std::make_index_sequence<count>{}, std::forward<F>(f));
}
...
};
```

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>