### PR TITLE
[SYCL] Clear plugins after unload

### DIFF
--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -132,6 +132,8 @@ void GlobalHandler::unloadPlugins() {
       Plugin.unload();
     }
   }
+  // Clear after unload to avoid uses after unload.
+  GlobalHandler::instance().getPlugins().clear();
 }
 
 void shutdown() {


### PR DESCRIPTION
Unloading plugins was recently separated from the cleanup phase to allow the mock plugin ensure that the mock plugin is the lone plugin. However, after unloading the plugins vector is not currenly cleared. This commit clears the plugins vector after plugins have been unloaded.