### PR TITLE
[SYCL-MLIR] Insert SYCL device code in the device module

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -1528,7 +1528,8 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
   MLIRScanner::getMangledFuncName(name, callee, Glob.getCGM());
   if (isSupportedFunctions(name))
     ShouldEmit = true;
-  auto ToCall = Glob.GetOrCreateMLIRFunction(callee, ShouldEmit);
+  FunctionToEmit F{*callee, mlirclang::getInputContext(builder)};
+  auto ToCall = cast<func::FuncOp>(Glob.GetOrCreateMLIRFunction(F, ShouldEmit));
 
   SmallVector<std::pair<ValueCategory, clang::Expr *>> args;
   QualType objType;

--- a/polygeist/tools/cgeist/Lib/utils.cc
+++ b/polygeist/tools/cgeist/Lib/utils.cc
@@ -78,3 +78,9 @@ bool mlirclang::isNamespaceSYCL(const clang::DeclContext *DC) {
 
   return false;
 }
+
+FunctionContext mlirclang::getInputContext(const OpBuilder &Builder) {
+  return Builder.getInsertionBlock()->getParentOp()->getParentOfType<ModuleOp>()
+             ? FunctionContext::Host
+             : FunctionContext::SYCLDevice;
+}

--- a/polygeist/tools/cgeist/Lib/utils.h
+++ b/polygeist/tools/cgeist/Lib/utils.h
@@ -11,9 +11,10 @@
 #ifndef MLIR_TOOLS_MLIRCLANG_UTILS_H
 #define MLIR_TOOLS_MLIRCLANG_UTILS_H
 
-#include "llvm/ADT/ArrayRef.h"
+#include "Lib/clang-mlir.h"
 #include "clang/AST/DeclBase.h"
 #include "llvm/ADT/APInt.h"
+#include "llvm/ADT/ArrayRef.h"
 
 namespace mlir {
 class Operation;
@@ -50,6 +51,9 @@ replaceFuncByOperation(mlir::func::FuncOp f, llvm::StringRef opName,
                        llvm::SmallVectorImpl<mlir::Value> &output);
 
 bool isNamespaceSYCL(const clang::DeclContext *DC);
+
+/// Return the insertion context of the input builder.
+FunctionContext getInputContext(const mlir::OpBuilder &Builder);
 } // namespace mlirclang
 
 #endif

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -12,15 +12,17 @@
 
 #include <sycl/sycl.hpp>
 
+// CHECK-NOT: module
+
 // CHECK: !sycl_accessor_1_i32_read_write_global_buffer = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>
 // CHECK: !sycl_id_1_ = !sycl.id<1>
 // CHECK: !sycl_item_1_1_ = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>
-// CHECK: !sycl_item_2_1_ = !sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>)>
 // CHECK: !sycl_range_1_ = !sycl.range<1>
 
-// CHECK: func.func @_ZTS8kernel_1(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
-// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
-// CHECK-NOT: SYCLKernel =
+// CHECK: gpu.module @device_functions
+// CHECK: gpu.func @_ZTS8kernel_1(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
+// CHECK-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
+// CHECK-NOT: gpu.func kernel
 
 class kernel_1 {
  sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write> A;
@@ -47,9 +49,9 @@ void host_1() {
   }
 }
 
-// CHECK: func.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
-// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
-// CHECK-NOT: SYCLKernel =
+// CHECK: gpu.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
+// CHECK-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
+// CHECK-NOT: gpu.func kernel
 
 void host_2() {
   auto q = sycl::queue{};

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
@@ -1,0 +1,95 @@
+// Copyright (C) Intel
+
+//===--- kernels_funcs.cpp ------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: sycl-clang.py %s -S | FileCheck %s
+
+#include <sycl/sycl.hpp>
+
+// CHECK-NOT: module
+
+// CHECK: gpu.module @device_functions
+//
+// CHECK-DAG: gpu.func @_ZTS8kernel_1
+// CHECK-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
+// CHECK-DAG: gpu.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2
+// CHECK-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
+// CHECK-DAG: func.func @_ZN12StoreWrapperIiLi1ELN4sycl3_V16access4modeE1026EEC1ENS1_8accessorIiLi1ELS3_1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS1_3ext6oneapi22accessor_property_listIJEEEEENS1_2idILi1EEERKi
+// CHECK-SAME: attributes {llvm.linkage = #llvm.linkage<linkonce_odr>}
+// COM: StoreWrapper constructor:
+// CHECK-DAG: func.func @_ZN12StoreWrapperIiLi1ELN4sycl3_V16access4modeE1026EEclEv
+// CHECK-SAME: attributes {llvm.linkage = #llvm.linkage<linkonce_odr>}
+
+template <typename DataT,
+          int Dimensions = 1,
+          sycl::access::mode AccessMode = (std::is_const_v<DataT>
+                                           ? sycl::access_mode::read
+                                           : sycl::access_mode::read_write)>
+class StoreWrapper {
+public:
+  StoreWrapper(sycl::accessor<DataT, Dimensions, AccessMode> acc,
+               sycl::id<Dimensions> index,
+               const DataT& el)
+    : acc{acc}, index{index}, el{el} {}
+
+  void operator()() {
+    acc[index] = el;
+  }
+
+private:
+  sycl::accessor<DataT, Dimensions, AccessMode> acc;
+  sycl::id<Dimensions> index;
+  DataT el;
+};
+
+class kernel_1 {
+  sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write> A;
+
+public:
+  kernel_1(sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write> A)
+    : A(A) {}
+
+  void operator()(sycl::id<1> id) const {
+    StoreWrapper W{A, id, 42};
+    W();
+  }
+};
+
+void host_1() {
+  auto q = sycl::queue{};
+  auto range = sycl::range<1>{1};
+
+  {
+    auto buf = sycl::buffer<int, 1>{nullptr, range};
+    q.submit([&](sycl::handler &cgh) {
+	       auto A = buf.get_access<sycl::access::mode::read_write>(cgh);
+	       auto ker =  kernel_1{A};
+	       cgh.parallel_for<kernel_1>(range, ker);
+	     });
+  }
+}
+
+void host_2() {
+  auto q = sycl::queue{};
+  auto range = sycl::range<1>{1};
+
+  {
+    auto buf = sycl::buffer<int, 1>{nullptr, range};
+    q.submit([&](sycl::handler &cgh) {
+	       auto A = buf.get_access<sycl::access::mode::read_write>(cgh);
+	       cgh.parallel_for<class kernel_2>(range, [=](sycl::id<1> id) {
+							 A[id] = 42;
+						       });
+	     });
+  }
+}
+
+SYCL_EXTERNAL void function_1(sycl::item<2, true> item) {
+  auto id = item.get_id(0);
+}


### PR DESCRIPTION
Represent SYCL kernels as kernel GPUFuncOps. Functions called from
SYCL kernels will be represented as FuncOps in the device module.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>