### PR TITLE
[SYCL-MLIR] Accept arbitrary types as accessor data types

### DIFF
--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -5624,10 +5624,7 @@ mlir::Type MLIRASTConsumer::getSYCLType(const clang::RecordType *RT) {
       return mlir::sycl::AccessorCommonType::get(module->getContext());
     }
     if (CTS->getName() == "accessor") {
-      const auto TypeInfo = RT->getDecl()->getASTContext().getTypeInfo(
-          CTS->getTemplateArgs().get(0).getAsType());
-      const auto Type =
-          mlir::IntegerType::get(module->getContext(), TypeInfo.Width);
+      const auto Type = getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
       const auto Dim =
           CTS->getTemplateArgs().get(1).getAsIntegral().getExtValue();
       const auto MemAccessMode = static_cast<mlir::sycl::MemoryAccessMode>(

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -43,6 +43,10 @@ SYCL_EXTERNAL void acc_1(sycl::accessor<sycl::cl_int, 1, sycl::access::mode::rea
 // CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 SYCL_EXTERNAL void acc_2(sycl::accessor<sycl::cl_int, 2, sycl::access::mode::read_write>) {}
 
+// CHECK: func.func @_Z5acc_3N4sycl3_V18accessorIfLi3ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl_accessor_3_f32_read_write_global_buffer)
+// CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
+SYCL_EXTERNAL void acc_3(sycl::accessor<sycl::cl_float, 3, sycl::access::mode::read_write>) {}
+
 // CHECK: func.func @_Z7range_1N4sycl3_V15rangeILi1EEE(%arg0: !sycl_range_1_)
 // CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 SYCL_EXTERNAL void range_1(sycl::range<1> range) {}


### PR DESCRIPTION
For the sycl::accessor type, use the specified data type instead of using an integer type of the same width as the intended data type (e.g. for sycl::accessor<sycl::cl_float, 3, sycl::access::mode::read_write> the element type to use is sycl::cl_float).

Signed-off-by: Victor Perez <victor.perez@codeplay.com>