### PR TITLE
[SYCL] Make sure lit tests use absolute path for SPIRV tools

### DIFF
--- a/llvm/test/lit.cfg.py
+++ b/llvm/test/lit.cfg.py
@@ -167,11 +167,11 @@ tools.extend([
     'llvm-modextract', 'llvm-nm', 'llvm-objcopy', 'llvm-objdump', 'llvm-otool',
     'llvm-pdbutil', 'llvm-profdata', 'llvm-profgen', 'llvm-ranlib', 'llvm-rc', 'llvm-readelf',
     'llvm-readobj', 'llvm-remark-size-diff', 'llvm-rtdyld', 'llvm-sim',
-    'llvm-size', 'llvm-split', 'llvm-stress', 'llvm-strings', 'llvm-strip',
+    'llvm-size', 'llvm-spirv', 'llvm-split', 'llvm-stress', 'llvm-strings', 'llvm-strip',
     'llvm-tblgen', 'llvm-tapi-diff', 'llvm-undname', 'llvm-windres',
     'llvm-c-test', 'llvm-cxxfilt', 'llvm-xray', 'yaml2obj', 'obj2yaml',
     'yaml-bench', 'verify-uselistorder', 'bugpoint', 'llc', 'llvm-symbolizer',
-    'opt', 'sancov', 'sanstats'])
+    'opt', 'sancov', 'sanstats', 'spirv-to-ir-wrapper'])
 
 # The following tools are optional
 tools.extend([


### PR DESCRIPTION
llvm-lit has a list of tools where it uses the absolute path to make sure it's using the in-tree version. llvm-spirv and spirv-to-ir-wrapper weren't in the list so it used just the binary name, making it possible for another one on the path to be picked up

Signed-off-by: Sarnie, Nick <nick.sarnie@intel.com>