### PR TITLE
[SYCL] Bump SYCL_MINOR_VERSION

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -27,9 +27,14 @@ include(SYCLUtils)
 
 # The change in SYCL_MAJOR_VERSION must be accompanied with the same update in
 # llvm/clang/lib/Driver/CMakeLists.txt.
+#
+# For the current development cycles MINOR has been bumped up and MAJOR wasn't.
+# Make sure to increase MAJOR and drop MINOR to zero as soon as ABI-breaking
+# change is done, without waiting for an actual release to happen.
 set(SYCL_MAJOR_VERSION 6)
-set(SYCL_MINOR_VERSION 0)
+set(SYCL_MINOR_VERSION 1)
 set(SYCL_PATCH_VERSION 0)
+
 set(SYCL_DEV_ABI_VERSION 0)
 if (SYCL_ADD_DEV_VERSION_POSTFIX)
   set(SYCL_VERSION_POSTFIX "-${SYCL_DEV_ABI_VERSION}")

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -28,9 +28,8 @@ include(SYCLUtils)
 # The change in SYCL_MAJOR_VERSION must be accompanied with the same update in
 # llvm/clang/lib/Driver/CMakeLists.txt.
 #
-# For the current development cycles MINOR has been bumped up and MAJOR wasn't.
-# Make sure to increase MAJOR and drop MINOR to zero as soon as ABI-breaking
-# change is done, without waiting for an actual release to happen.
+# See doc/developer/ABIPolicyGuide.md for the meaning when in the middle of
+# development cycle.
 set(SYCL_MAJOR_VERSION 6)
 set(SYCL_MINOR_VERSION 1)
 set(SYCL_PATCH_VERSION 0)

--- a/sycl/doc/developer/ABIPolicyGuide.md
+++ b/sycl/doc/developer/ABIPolicyGuide.md
@@ -35,12 +35,13 @@ Adding a new exported symbol is considered to be non-breaking change.
 The release version of the DPC++ runtime library follows
 [Semantic Versioning](https://semver.org/) scheme: `MAJOR.MINOR.PATCH`. `MAJOR`
 version indicates breaking change. Version `X` is backwards incompatible with
-version `X-1`. `MINOR` indicates a non-breaking change. We only bump each of
-them once per development cycles between releases. Immediately after the release
-branch has been brached off, the `MINOR` version is incremented. If an
-ABI-breaking change is introduced then it should be accompanied with the bump of
-a `MAJOR` version in the same PR (unless it had been bumped before in this
-development cycle).
+version `X-1`. `MINOR` indicates a non-breaking change. The development version
+of the library has a postfix `-V` that indicates breaking changes between
+releases. Every time a pull request introduces a breaking change, it must also
+uplift `V`. It is pull request author responsibility to accordingly update
+`V` part of library version. If `V > 0` on release date, then `MAJOR_VERSION`
+is uplifted and `V` is set to zero. `MAJOR`, `MINOR`, and `PATCH` versions are
+not updated between releases.
 
 ## `__SYCL_EXPORT` Macro
 

--- a/sycl/doc/developer/ABIPolicyGuide.md
+++ b/sycl/doc/developer/ABIPolicyGuide.md
@@ -35,13 +35,12 @@ Adding a new exported symbol is considered to be non-breaking change.
 The release version of the DPC++ runtime library follows
 [Semantic Versioning](https://semver.org/) scheme: `MAJOR.MINOR.PATCH`. `MAJOR`
 version indicates breaking change. Version `X` is backwards incompatible with
-version `X-1`. `MINOR` indicates a non-breaking change. The development version
-of the library has a postfix `-V` that indicates breaking changes between
-releases. Every time a pull request introduces a breaking change, it must also
-uplift `V`. It is pull request author responsibility to accordingly update
-`V` part of library version. If `V > 0` on release date, then `MAJOR_VERSION`
-is uplifted and `V` is set to zero. `MAJOR`, `MINOR`, and `PATCH` versions are
-not updated between releases.
+version `X-1`. `MINOR` indicates a non-breaking change. We only bump each of
+them once per development cycles between releases. Immediately after the release
+branch has been brached off, the `MINOR` version is incremented. If an
+ABI-breaking change is introduced then it should be accompanied with the bump of
+a `MAJOR` version in the same PR (unless it had been bumped before in this
+development cycle).
 
 ## `__SYCL_EXPORT` Macro
 


### PR DESCRIPTION
Unlike previous releases we change the policy of bumping the version to be done at the beginning of the development cycle instead of its end. That allows customers who are using development snapshots to guard their code in a way that would keep working after the actual release is done.

The documentation for this is being done as https://github.com/intel/llvm/pull/6856

We have consensus on how/when MAJOR/MINOR have to be bumped, so do it now. There are some debates regarding PATCH/DEV versions updates so the documentation would be updated later.