### PR TITLE
[SYCL-MLIR] Create GPUModuleOp to host SYCL code

### DIFF
--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -961,7 +961,7 @@ int main(int argc, char **argv) {
   registerDialects(context, syclKernelsOnly);
 
   // Generate MLIR for the input files.
-  constexpr llvm::StringLiteral DeviceModuleName{"device_code"};
+  constexpr llvm::StringLiteral DeviceModuleName{"device_functions"};
 
   mlir::OpBuilder Builder(&context);
   const auto loc = Builder.getUnknownLoc();

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -928,7 +928,7 @@ static void processInputFiles(const cl::list<std::string> &inputFiles,
             triple, DL, commands);
 }
 
-static bool hasKernels(mlir::gpu::GPUModuleOp deviceModule) {
+static bool hasDeviceFuncs(mlir::gpu::GPUModuleOp deviceModule) {
   return !deviceModule.getRegion().getOps<mlir::gpu::GPUFuncOp>().empty();
 }
 
@@ -996,7 +996,7 @@ int main(int argc, char **argv) {
   // the host code otherwise.
   //
   // Lower the MLIR to LLVM IR, compile the generated LLVM IR.
-  return hasKernels(*deviceModule)
+  return hasDeviceFuncs(*deviceModule)
              ? compileModule(deviceModule, context, DL, triple, LinkageArgs,
                              argv[0],
                              {func::FuncOp::getOperationName(),


### PR DESCRIPTION
Just create the module, do not insert device code there. Device code is still hosted in the global module.

If a kernel is inserted in the device module, the pipeline is run on it; the pipeline is run on the global module otherwise.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>