### PR TITLE
[SYCL] Fix constexpr string size in mock plugin

### DIFF
--- a/sycl/unittests/helpers/PiMockPlugin.hpp
+++ b/sycl/unittests/helpers/PiMockPlugin.hpp
@@ -49,8 +49,8 @@ inline pi_result mock_piPlatformGetInfo(pi_platform platform,
     return PI_SUCCESS;
   }
   default: {
-    constexpr const char *FallbackValue = "str";
-    constexpr size_t FallbackValueSize = std::strlen(FallbackValue) + 1;
+    constexpr const char FallbackValue[] = "str";
+    constexpr size_t FallbackValueSize = sizeof(FallbackValue);
     if (param_value_size_ret)
       *param_value_size_ret = FallbackValueSize;
 


### PR DESCRIPTION
https://github.com/intel/llvm/pull/6852 incidentally used a non-constexpr solution for determining the size of a string, which causes failures in select build configurations. This commit amends this by using sizeof on a static array of characters instead of std::strlen.