### PR TITLE
[SYCL] Fix invalid use of std::move in SemaTemplateInstantiateDecl.cpp

### DIFF
--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -6845,8 +6845,8 @@ void Sema::PerformPendingInstantiations(bool LocalOnly) {
                                 TSK_ExplicitInstantiationDefinition;
       if (Function->isMultiVersion())
         getASTContext().forEachMultiversionedFunctionVersion(
-            Function, [this, Inst, DefinitionRequired,
-                       MangleCtx = move(MangleCtx)](FunctionDecl *CurFD) {
+            Function,
+            [this, Inst, DefinitionRequired, &MangleCtx](FunctionDecl *CurFD) {
               processFunctionInstantiation(*this, Inst.second, CurFD,
                                            DefinitionRequired, *MangleCtx);
             });


### PR DESCRIPTION
This being used in a loop with more than one multiversion function would likely cause that mangle-context to be invalid.  Also, the unqualified move is discouraged.

This patch just changes the code slightly to have the lambda capture the entire unique_ptr by reference.