### PR TITLE
[SYCL] Fix post commit fails.

### DIFF
--- a/sycl/test/abi/sycl_symbols_windows.dump
+++ b/sycl/test/abi/sycl_symbols_windows.dump
@@ -768,6 +768,7 @@
 ?get@kernel@_V1@sycl@@QEBAPEAU_cl_kernel@@XZ
 ?get@platform@_V1@sycl@@QEBAPEAU_cl_platform_id@@XZ
 ?get@queue@_V1@sycl@@QEBAPEAU_cl_command_queue@@XZ
+?getAccData@AccessorBaseHost@detail@_V1@sycl@@QEAAAEAUAccHostDataT@234@XZ
 ?getAccessRange@AccessorBaseHost@detail@_V1@sycl@@QEAAAEAV?$range@$02@34@XZ
 ?getAccessRange@AccessorBaseHost@detail@_V1@sycl@@QEBAAEBV?$range@$02@34@XZ
 ?getAssertHappenedBuffer@queue@_V1@sycl@@AEAAAEAV?$buffer@UAssertHappened@detail@_V1@sycl@@$00V?$aligned_allocator@UAssertHappened@detail@_V1@sycl@@@234@X@23@XZ

--- a/sycl/test/basic_tests/accessor/host_acc_opt.cpp
+++ b/sycl/test/basic_tests/accessor/host_acc_opt.cpp
@@ -9,7 +9,6 @@
 // CHECK: define {{.*}}foo{{.*}} {
 // CHECK-NOT: call
 // CHECK-NOT: invoke
-// CHECK: vector.body:
 // CHECK-NOT: call
 // CHECK-NOT: invoke
 // CHECK: load <4 x i32>
@@ -18,6 +17,7 @@
 // CHECK: store <4 x i32>
 // CHECK-NOT: call
 // CHECK-NOT: invoke
+// CHECK: }
 void foo(sycl::accessor<int, 1, sycl::access::mode::read_write,
                         sycl::target::host_buffer> &Acc,
          int *Src) {


### PR DESCRIPTION
1. Updated checks to be more be more robust and work when clang discards names of values in the LLVM IR.
2. Added a new symbol to the windows sybmols test.