### PR TITLE
[Driver][SYCL] Fix issue with using deprecated sycldevice triple

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1108,14 +1108,13 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
             UserTargetName = "spir64_gen";
           }
 
-          llvm::Triple TT(MakeSYCLDeviceTriple(UserTargetName));
           if (!isValidSYCLTriple(MakeSYCLDeviceTriple(UserTargetName))) {
             Diag(clang::diag::err_drv_invalid_sycl_target) << Val;
             continue;
           }
-          std::string NormalizedName = TT.normalize();
 
           // Make sure we don't have a duplicate triple.
+          std::string NormalizedName = MakeSYCLDeviceTriple(Val).normalize();
           auto Duplicate = FoundNormalizedTriples.find(NormalizedName);
           if (Duplicate != FoundNormalizedTriples.end()) {
             Diag(clang::diag::warn_drv_sycl_offload_target_duplicate)
@@ -1124,6 +1123,7 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
           }
 
           // Warn about deprecated `sycldevice` environment component.
+          llvm::Triple TT(MakeSYCLDeviceTriple(UserTargetName));
           if (TT.getEnvironmentName() == "sycldevice") {
             // Build a string with suggested target triple.
             std::string SuggestedTriple = TT.getArchName().str();

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1108,7 +1108,7 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
             UserTargetName = "spir64_gen";
           }
 
-          llvm::Triple TT(MakeSYCLDeviceTriple(Val));
+          llvm::Triple TT(MakeSYCLDeviceTriple(UserTargetName));
           if (!isValidSYCLTriple(MakeSYCLDeviceTriple(UserTargetName))) {
             Diag(clang::diag::err_drv_invalid_sycl_target) << Val;
             continue;
@@ -1147,7 +1147,7 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
           // Store the current triple so that we can check for duplicates in
           // the following iterations.
           FoundNormalizedTriples[NormalizedName] = Val;
-          UniqueSYCLTriplesVec.push_back(MakeSYCLDeviceTriple(UserTargetName));
+          UniqueSYCLTriplesVec.push_back(TT);
         }
         addSYCLDefaultTriple(C, UniqueSYCLTriplesVec);
       } else

--- a/clang/test/Driver/sycl.c
+++ b/clang/test/Driver/sycl.c
@@ -28,9 +28,11 @@
 // DISABLED-NOT: "-sycl-std={{.*}}"
 // DISABLED-NOT: "-fsycl-std-layout-kernel-params"
 
-// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice,nvptx64-nvidia-cuda-sycldevice -fno-sycl-libspirv -nocudalib -c %s 2>&1 | FileCheck %s --check-prefix=CHECK_WARNING
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64-unknown-unknown-sycldevice,nvptx64-nvidia-cuda-sycldevice -fno-sycl-libspirv -nocudalib -### -c %s 2>&1 | FileCheck %s --check-prefix=CHECK_WARNING
 // CHECK_WARNING: argument 'spir64-unknown-unknown-sycldevice' is deprecated, use 'spir64' instead
 // CHECK_WARNING: argument 'nvptx64-nvidia-cuda-sycldevice' is deprecated, use 'nvptx64-nvidia-cuda' instead
+// CHECK_WARNING: clang{{.*}} "-triple" "spir64-unknown-unknown"
+// CHECK_WARNING: clang{{.*}} "-triple" "nvptx64-nvidia-cuda"
 
 // RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl-device-only -c %s 2>&1 | FileCheck %s --check-prefix=DEFAULT -DSPIRARCH=spir64
 // RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl-device-only %s 2>&1 | FileCheck %s --check-prefix=DEFAULT -DSPIRARCH=spir64


### PR DESCRIPTION
The changes to introduce the intel_gpu_* target support inadvertently broke the steps that do a cleanout of any use of the sycldevice environment setting in a user provided triple.

Fix this issue, and introduce a test which tests for this functionality.