### PR TITLE
[SYCL] Make device comparison method to analyze impl not native handles

### DIFF
--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -234,6 +234,8 @@ private:
   template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 
+  friend auto detail::getDeviceComparisonLambda();
+
   template <backend BackendName, class SyclObjectT>
   friend auto get_native(const SyclObjectT &Obj)
       -> backend_return_t<BackendName, SyclObjectT>;

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -234,8 +234,6 @@ private:
   template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 
-  friend auto detail::getDeviceComparisonLambda();
-
   template <backend BackendName, class SyclObjectT>
   friend auto get_native(const SyclObjectT &Obj)
       -> backend_return_t<BackendName, SyclObjectT>;

--- a/sycl/source/kernel_bundle.cpp
+++ b/sycl/source/kernel_bundle.cpp
@@ -115,14 +115,10 @@ bool kernel_bundle_plain::is_specialization_constant_set(
 
 const std::vector<device>
 removeDuplicateDevices(const std::vector<device> &Devs) {
-  auto compareDevices = [](device a, device b) {
-    return getSyclObjImpl(a)->getHandleRef() <
-           getSyclObjImpl(b)->getHandleRef();
-  };
-  std::set<device, decltype(compareDevices)> UniqueDeviceSet(
-      Devs.begin(), Devs.end(), compareDevices);
-  std::vector<device> UniqueDevices(UniqueDeviceSet.begin(),
-                                    UniqueDeviceSet.end());
+  std::vector<device> UniqueDevices(Devs.begin(), Devs.end());
+  auto last = std::unique(UniqueDevices.begin(), UniqueDevices.end());
+  UniqueDevices.erase(last, UniqueDevices.end());
+
   return UniqueDevices;
 }
 

--- a/sycl/source/kernel_bundle.cpp
+++ b/sycl/source/kernel_bundle.cpp
@@ -115,9 +115,11 @@ bool kernel_bundle_plain::is_specialization_constant_set(
 
 const std::vector<device>
 removeDuplicateDevices(const std::vector<device> &Devs) {
-  std::vector<device> UniqueDevices(Devs.begin(), Devs.end());
-  auto last = std::unique(UniqueDevices.begin(), UniqueDevices.end());
-  UniqueDevices.erase(last, UniqueDevices.end());
+  auto compareDevices = [](device a, device b) { return a != b; };
+  std::set<device, decltype(compareDevices)> UniqueDeviceSet(
+      Devs.begin(), Devs.end(), compareDevices);
+  std::vector<device> UniqueDevices(UniqueDeviceSet.begin(),
+                                    UniqueDeviceSet.end());
 
   return UniqueDevices;
 }

--- a/sycl/source/kernel_bundle.cpp
+++ b/sycl/source/kernel_bundle.cpp
@@ -112,10 +112,13 @@ bool kernel_bundle_plain::is_specialization_constant_set(
 //////////////////////////////////
 ///// sycl::detail free functions
 //////////////////////////////////
+inline auto getDeviceComparisonLambda() {
+  return [](device a, device b) { return a.impl < b.impl; };
+}
 
 const std::vector<device>
 removeDuplicateDevices(const std::vector<device> &Devs) {
-  auto compareDevices = [](device a, device b) { return a != b; };
+  auto compareDevices = getDeviceComparisonLambda();
   std::set<device, decltype(compareDevices)> UniqueDeviceSet(
       Devs.begin(), Devs.end(), compareDevices);
   std::vector<device> UniqueDevices(UniqueDeviceSet.begin(),

--- a/sycl/source/kernel_bundle.cpp
+++ b/sycl/source/kernel_bundle.cpp
@@ -112,13 +112,12 @@ bool kernel_bundle_plain::is_specialization_constant_set(
 //////////////////////////////////
 ///// sycl::detail free functions
 //////////////////////////////////
-inline auto getDeviceComparisonLambda() {
-  return [](device a, device b) { return a.impl < b.impl; };
-}
 
 const std::vector<device>
 removeDuplicateDevices(const std::vector<device> &Devs) {
-  auto compareDevices = getDeviceComparisonLambda();
+  auto compareDevices = [](device a, device b) {
+    return getSyclObjImpl(a) < getSyclObjImpl(b);
+  };
   std::set<device, decltype(compareDevices)> UniqueDeviceSet(
       Devs.begin(), Devs.end(), compareDevices);
   std::vector<device> UniqueDevices(UniqueDeviceSet.begin(),


### PR DESCRIPTION
Initial issue was sycl::link failure with many devices passed when esimd_emulator backend is enabled.
esimd_emulator does not have getNative method implemented while we checked object equality by comparison of native handles.
It seems to be not fully valid and we need to check it using operator. GetNative implementation for esimd_emulator is not needed.

Signed-off-by: Tikhomirova, Kseniya <kseniya.tikhomirova@intel.com>