### PR TITLE
[SYCL] Assign code owners for LowerInvokeSimd IR pass.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,6 +63,8 @@ llvm/lib/SYCLLowerIR/CMakeLists.txt @intel/dpcpp-tools-reviewers @intel/dpcpp-es
 # invoke_simd
 sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp @rolandschulz @kbobrovs
 sycl/include/std/experimental/simd.hpp @rolandschulz @kbobrovs
+llvm/lib/SYCLLowerIR/LowerInvokeSimd.cpp @kbobrovs @v-klochkov @rolandschulz
+llvm/include/llvm/SYCLLowerIR/LowerInvokeSimd.h @kbobrovs @v-klochkov @rolandschulz
 
 # DevOps configs
 .github/workflows/ @intel/dpcpp-devops-reviewers


### PR DESCRIPTION
Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>