### PR TITLE
[SYCL-MLIR][NFCI]: Cleanup

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -1,6 +1,6 @@
 // Copyright (C) Codeplay Software Limited
 
-//===--- CGCall.cpp - Encapsulate calling convention details --------------===//
+//===--- CGCall.cc - Encapsulate calling convention details --------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -137,9 +137,10 @@ ValueCategory MLIRScanner::CallHelper(
         }
         assert(arg.isReference);
 
-        auto mt = Glob.getMLIRType(
-                          Glob.CGM.getContext().getLValueReferenceType(aType))
-                      .cast<MemRefType>();
+        auto mt =
+            Glob.getMLIRType(
+                    Glob.getCGM().getContext().getLValueReferenceType(aType))
+                .cast<MemRefType>();
         auto shape = std::vector<int64_t>(mt.getShape());
         assert(shape.size() == 2);
 
@@ -178,8 +179,8 @@ ValueCategory MLIRScanner::CallHelper(
     } else {
       assert(arg.isReference);
 
-      expectedType =
-          Glob.getMLIRType(Glob.CGM.getContext().getLValueReferenceType(aType));
+      expectedType = Glob.getMLIRType(
+          Glob.getCGM().getContext().getLValueReferenceType(aType));
 
       val = arg.val;
       if (arg.val.getType().isa<LLVM::LLVMPointerType>() &&
@@ -221,7 +222,8 @@ ValueCategory MLIRScanner::CallHelper(
   mlir::Value alloc;
   if (isArrayReturn) {
     auto mt =
-        Glob.getMLIRType(Glob.CGM.getContext().getLValueReferenceType(retType))
+        Glob.getMLIRType(
+                Glob.getCGM().getContext().getLValueReferenceType(retType))
             .cast<MemRefType>();
 
     auto shape = std::vector<int64_t>(mt.getShape());
@@ -399,13 +401,13 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
       if (auto *lhs = dyn_cast<CXXTypeidExpr>(expr->getArg(0))) {
         if (auto *rhs = dyn_cast<CXXTypeidExpr>(expr->getArg(1))) {
           QualType LT = lhs->isTypeOperand()
-                            ? lhs->getTypeOperand(Glob.CGM.getContext())
+                            ? lhs->getTypeOperand(Glob.getCGM().getContext())
                             : lhs->getExprOperand()->getType();
           QualType RT = rhs->isTypeOperand()
-                            ? rhs->getTypeOperand(Glob.CGM.getContext())
+                            ? rhs->getTypeOperand(Glob.getCGM().getContext())
                             : rhs->getExprOperand()->getType();
-          llvm::Constant *LC = Glob.CGM.GetAddrOfRTTIDescriptor(LT);
-          llvm::Constant *RC = Glob.CGM.GetAddrOfRTTIDescriptor(RT);
+          llvm::Constant *LC = Glob.getCGM().GetAddrOfRTTIDescriptor(LT);
+          llvm::Constant *RC = Glob.getCGM().GetAddrOfRTTIDescriptor(RT);
           auto postTy = getMLIRType(expr->getType()).cast<mlir::IntegerType>();
           return ValueCategory(
               builder.create<arith::ConstantIntOp>(loc, LC == RC, postTy),
@@ -421,9 +423,9 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
         if (auto *sr = dyn_cast<NamedDecl>(ic->getMemberDecl())) {
           if (sr->getIdentifier() && sr->getName() == "name") {
             QualType LT = lhs->isTypeOperand()
-                              ? lhs->getTypeOperand(Glob.CGM.getContext())
+                              ? lhs->getTypeOperand(Glob.getCGM().getContext())
                               : lhs->getExprOperand()->getType();
-            llvm::Constant *LC = Glob.CGM.GetAddrOfRTTIDescriptor(LT);
+            llvm::Constant *LC = Glob.getCGM().GetAddrOfRTTIDescriptor(LT);
             while (auto *CE = dyn_cast<llvm::ConstantExpr>(LC))
               LC = CE->getOperand(0);
             std::string val = cast<llvm::GlobalVariable>(LC)->getName().str();
@@ -511,9 +513,10 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
 
     if (isArray) {
       assert(sub.isReference);
-      auto mt = Glob.getMLIRType(Glob.CGM.getContext().getLValueReferenceType(
-                                     E->getType()))
-                    .cast<MemRefType>();
+      auto mt =
+          Glob.getMLIRType(Glob.getCGM().getContext().getLValueReferenceType(
+                               E->getType()))
+              .cast<MemRefType>();
       auto shape = std::vector<int64_t>(mt.getShape());
       assert(shape.size() == 2);
 
@@ -522,7 +525,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
       auto one = abuilder.create<ConstantIntOp>(loc, 1, 64);
       auto alloc = abuilder.create<mlir::LLVM::AllocaOp>(
           loc,
-          LLVM::LLVMPointerType::get(Glob.typeTranslator.translateType(
+          LLVM::LLVMPointerType::get(Glob.getTypeTranslator().translateType(
                                          anonymize(getLLVMType(E->getType()))),
                                      0),
           one, 0);
@@ -532,7 +535,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
     }
     auto val = sub.getValue(builder);
     if (auto mt = val.getType().dyn_cast<MemRefType>()) {
-      auto nt = Glob.typeTranslator
+      auto nt = Glob.getTypeTranslator()
                     .translateType(anonymize(getLLVMType(E->getType())))
                     .cast<LLVM::LLVMPointerType>();
       assert(nt.getAddressSpace() == mt.getMemorySpaceAsInt() &&
@@ -657,23 +660,24 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
                         .substr(std::string("__builtin_").length())
                         .str();
 
-        if (Glob.functions.find(name) == Glob.functions.end()) {
+        if (Glob.getFunctions().find(name) == Glob.getFunctions().end()) {
           std::vector<mlir::Type> types{V0.getType(), V1.getType()};
 
           auto RT = getMLIRType(expr->getType());
           std::vector<mlir::Type> rettypes{RT};
-          mlir::OpBuilder mbuilder(Glob.module->getContext());
+          mlir::OpBuilder mbuilder(module->getContext());
           auto funcType = mbuilder.getFunctionType(types, rettypes);
-          Glob.functions[name] = mlir::func::FuncOp(mlir::func::FuncOp::create(
-              builder.getUnknownLoc(), name, funcType));
-          SymbolTable::setSymbolVisibility(Glob.functions[name],
+          Glob.getFunctions()[name] =
+              mlir::func::FuncOp(mlir::func::FuncOp::create(
+                  builder.getUnknownLoc(), name, funcType));
+          SymbolTable::setSymbolVisibility(Glob.getFunctions()[name],
                                            SymbolTable::Visibility::Private);
-          Glob.module->push_back(Glob.functions[name]);
+          module->push_back(Glob.getFunctions()[name]);
         }
 
         mlir::Value vals[] = {V0, V1};
         return ValueCategory(
-            builder.create<CallOp>(loc, Glob.functions[name], vals)
+            builder.create<CallOp>(loc, Glob.getFunctions()[name], vals)
                 .getResult(0),
             false);
       }
@@ -684,23 +688,24 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
 
         const auto *name = "strlen";
 
-        if (Glob.functions.find(name) == Glob.functions.end()) {
+        if (Glob.getFunctions().find(name) == Glob.getFunctions().end()) {
           std::vector<mlir::Type> types{V0.getType()};
 
           auto RT = getMLIRType(expr->getType());
           std::vector<mlir::Type> rettypes{RT};
-          mlir::OpBuilder mbuilder(Glob.module->getContext());
+          mlir::OpBuilder mbuilder(module->getContext());
           auto funcType = mbuilder.getFunctionType(types, rettypes);
-          Glob.functions[name] = mlir::func::FuncOp(mlir::func::FuncOp::create(
-              builder.getUnknownLoc(), name, funcType));
-          SymbolTable::setSymbolVisibility(Glob.functions[name],
+          Glob.getFunctions()[name] =
+              mlir::func::FuncOp(mlir::func::FuncOp::create(
+                  builder.getUnknownLoc(), name, funcType));
+          SymbolTable::setSymbolVisibility(Glob.getFunctions()[name],
                                            SymbolTable::Visibility::Private);
-          Glob.module->push_back(Glob.functions[name]);
+          module->push_back(Glob.getFunctions()[name]);
         }
 
         mlir::Value vals[] = {V0};
         return ValueCategory(
-            builder.create<CallOp>(loc, Glob.functions[name], vals)
+            builder.create<CallOp>(loc, Glob.getFunctions()[name], vals)
                 .getResult(0),
             false);
       }
@@ -858,7 +863,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
 
         std::vector<mlir::Type> rettypes{RT};
 
-        mlir::OpBuilder mbuilder(Glob.module->getContext());
+        mlir::OpBuilder mbuilder(module->getContext());
         auto funcType = mbuilder.getFunctionType(types, rettypes);
         mlir::func::FuncOp function =
             mlir::func::FuncOp(mlir::func::FuncOp::create(
@@ -866,8 +871,8 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
         SymbolTable::setSymbolVisibility(function,
                                          SymbolTable::Visibility::Private);
 
-        Glob.functions[name] = function;
-        Glob.module->push_back(function);
+        Glob.getFunctions()[name] = function;
+        module->push_back(function);
         mlir::Value vals[] = {V, V2};
         V = builder.create<CallOp>(loc, function, vals).getResult(0);
         return ValueCategory(V, /*isRef*/ false);
@@ -1172,7 +1177,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
 
               if (dstArray) {
                 std::vector<mlir::Value> start = {getConstantIndex(0)};
-                auto mt = Glob.getMLIRType(Glob.CGM.getContext().getPointerType(
+                auto mt = Glob.getMLIRType(Glob.getCGM().getContext().getPointerType(
                                                QualType(elem, 0)))
                               .cast<MemRefType>();
                 auto shape = std::vector<int64_t>(mt.getShape());
@@ -1185,7 +1190,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
                     &affineOp.getLoopBody().front());
                 if (srcArray) {
                   auto smt =
-                      Glob.getMLIRType(Glob.CGM.getContext().getPointerType(
+                      Glob.getMLIRType(Glob.getCGM().getContext().getPointerType(
                                            QualType(elem, 0)))
                           .cast<MemRefType>();
                   auto sshape = std::vector<int64_t>(smt.getShape());
@@ -1202,7 +1207,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
               } else {
                 if (srcArray) {
                   auto smt =
-                      Glob.getMLIRType(Glob.CGM.getContext().getPointerType(
+                      Glob.getMLIRType(Glob.getCGM().getContext().getPointerType(
                                            QualType(selem, 0)))
                           .cast<MemRefType>();
                   auto sshape = std::vector<int64_t>(smt.getShape());
@@ -1353,7 +1358,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
               if (dstArray) {
                 std::vector<mlir::Value> start = {getConstantIndex(0)};
                 auto mt =
-                    Glob.getMLIRType(Glob.CGM.getContext().getPointerType(elem))
+                    Glob.getMLIRType(Glob.getCGM().getContext().getPointerType(elem))
                         .cast<MemRefType>();
                 auto shape = std::vector<int64_t>(mt.getShape());
                 auto affineOp = builder.create<scf::ForOp>(
@@ -1433,16 +1438,16 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
     if (auto *sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
       StringRef name;
       if (auto *CC = dyn_cast<CXXConstructorDecl>(sr->getDecl()))
-        name =
-            Glob.CGM.getMangledName(GlobalDecl(CC, CXXCtorType::Ctor_Complete));
+        name = Glob.getCGM().getMangledName(
+            GlobalDecl(CC, CXXCtorType::Ctor_Complete));
       else if (auto *CC = dyn_cast<CXXDestructorDecl>(sr->getDecl()))
-        name =
-            Glob.CGM.getMangledName(GlobalDecl(CC, CXXDtorType::Dtor_Complete));
+        name = Glob.getCGM().getMangledName(
+            GlobalDecl(CC, CXXDtorType::Dtor_Complete));
       else if (sr->getDecl()->hasAttr<CUDAGlobalAttr>())
-        name = Glob.CGM.getMangledName(GlobalDecl(
+        name = Glob.getCGM().getMangledName(GlobalDecl(
             cast<FunctionDecl>(sr->getDecl()), KernelReferenceKind::Kernel));
       else
-        name = Glob.CGM.getMangledName(sr->getDecl());
+        name = Glob.getCGM().getMangledName(sr->getDecl());
       if (funcs.count(name.str()) || name.startswith("mkl_") ||
           name.startswith("MKL_") || name.startswith("cublas") ||
           name.startswith("cblas_")) {
@@ -1459,7 +1464,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
                        .getResult(0);
         } else {
           args.insert(args.begin(), getLLVM(expr->getCallee()));
-          SmallVector<mlir::Type> RTs = {Glob.typeTranslator.translateType(
+          SmallVector<mlir::Type> RTs = {Glob.getTypeTranslator().translateType(
               anonymize(getLLVMType(expr->getType())))};
           if (RTs[0].isa<LLVM::LLVMVoidType>())
             RTs.clear();
@@ -1486,9 +1491,9 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
       args.insert(args.begin(), getLLVM(expr->getCallee()));
       auto CT = expr->getType();
       if (isReference)
-        CT = Glob.CGM.getContext().getLValueReferenceType(CT);
+        CT = Glob.getCGM().getContext().getLValueReferenceType(CT);
       SmallVector<mlir::Type> RTs = {
-          Glob.typeTranslator.translateType(anonymize(getLLVMType(CT)))};
+          Glob.getTypeTranslator().translateType(anonymize(getLLVMType(CT)))};
 
       auto ft = args[0]
                     .getType()
@@ -1520,7 +1525,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
   auto ShouldEmit =
       !mlirclang::isNamespaceSYCL(callee->getEnclosingNamespaceContext());
   std::string name;
-  MLIRScanner::getMangledFuncName(name, callee, Glob.CGM);
+  MLIRScanner::getMangledFuncName(name, callee, Glob.getCGM());
   if (isSupportedFunctions(name))
     ShouldEmit = true;
   auto ToCall = Glob.GetOrCreateMLIRFunction(callee, ShouldEmit);
@@ -1531,12 +1536,14 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
   if (auto *CC = dyn_cast<CXXMemberCallExpr>(expr)) {
     ValueCategory obj = Visit(CC->getImplicitObjectArgument());
     objType = CC->getObjectType();
+#ifdef DEBUG
     if (!obj.val) {
       function.dump();
       llvm::errs() << " objval: " << obj.val << "\n";
       expr->dump();
       CC->getImplicitObjectArgument()->dump();
     }
+#endif
     if (cast<MemberExpr>(CC->getCallee()->IgnoreParens())->isArrow()) {
       obj = obj.dereference(builder);
     }

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -15,8 +15,8 @@
 
 #define DEBUG_TYPE "CGCall"
 
+using namespace clang;
 using namespace mlir;
-using namespace std;
 using namespace mlir::arith;
 using namespace mlir::func;
 using namespace mlirclang;
@@ -357,12 +357,12 @@ MLIRScanner::EmitClangBuiltinCallExpr(clang::CallExpr *expr) {
   case clang::Builtin::BIforward:
   case clang::Builtin::BIas_const: {
     auto V = Visit(expr->getArg(0));
-    return make_pair(V, true);
+    return std::make_pair(V, true);
   }
   default:
     break;
   }
-  return make_pair(ValueCategory(), false);
+  return std::make_pair(ValueCategory(), false);
 }
 
 ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
@@ -1549,10 +1549,10 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
     }
     assert(obj.val);
     assert(obj.isReference);
-    args.emplace_back(make_pair(obj, (clang::Expr *)nullptr));
+    args.emplace_back(std::make_pair(obj, (clang::Expr *)nullptr));
   }
   for (auto *a : expr->arguments())
-    args.push_back(make_pair(Visit(a), a));
+    args.push_back(std::make_pair(Visit(a), a));
   return CallHelper(ToCall, objType, args, expr->getType(),
                     expr->isLValue() || expr->isXValue(), expr);
 }

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -1,6 +1,6 @@
 // Copyright (C) Codeplay Software Limited
 
-//===--- CGCall.cc - Encapsulate calling convention details --------------===//
+//===--- CGCall.cc - Encapsulate calling convention details ---------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/polygeist/tools/cgeist/Lib/CGStmt.cc
+++ b/polygeist/tools/cgeist/Lib/CGStmt.cc
@@ -16,6 +16,7 @@
 
 #define DEBUG_TYPE "CGStmt"
 
+using namespace clang;
 using namespace mlir;
 using namespace mlir::arith;
 
@@ -214,7 +215,7 @@ ValueCategory MLIRScanner::VisitForStmt(clang::ForStmt *fors) {
   auto loc = getMLIRLocation(fors->getForLoc());
 
   mlirclang::AffineLoopDescriptor affineLoopDescr;
-  if (Glob.scopLocList.isInScop(fors->getForLoc()) &&
+  if (Glob.getScopLocList().isInScop(fors->getForLoc()) &&
       isTrivialAffineLoop(fors, affineLoopDescr)) {
     buildAffineLoop(fors, loc, affineLoopDescr);
   } else {
@@ -490,8 +491,8 @@ ValueCategory MLIRScanner::VisitOMPForDirective(clang::OMPForDirective *fors) {
 
     bool LLVMABI = false;
     bool isArray = false;
-    if (Glob.getMLIRType(
-                Glob.CGM.getContext().getLValueReferenceType(name->getType()))
+    if (Glob.getMLIRType(Glob.getCGM().getContext().getLValueReferenceType(
+                             name->getType()))
             .isa<mlir::LLVM::LLVMPointerType>())
       LLVMABI = true;
     else
@@ -554,7 +555,7 @@ MLIRScanner::VisitOMPParallelDirective(clang::OMPParallelDirective *par) {
         bool LLVMABI = false;
         bool isArray = false;
         mlir::Type ty;
-        if (Glob.getMLIRType(Glob.CGM.getContext().getLValueReferenceType(
+        if (Glob.getMLIRType(Glob.getCGM().getContext().getLValueReferenceType(
                                  name->getType()))
                 .isa<mlir::LLVM::LLVMPointerType>()) {
           LLVMABI = true;
@@ -660,8 +661,8 @@ ValueCategory MLIRScanner::VisitOMPParallelForDirective(
 
     bool LLVMABI = false;
     bool isArray = false;
-    if (Glob.getMLIRType(
-                Glob.CGM.getContext().getLValueReferenceType(name->getType()))
+    if (Glob.getMLIRType(Glob.getCGM().getContext().getLValueReferenceType(
+                             name->getType()))
             .isa<mlir::LLVM::LLVMPointerType>())
       LLVMABI = true;
     else

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -229,7 +229,7 @@ void MLIRScanner::init(mlir::func::FuncOp func, const FunctionDecl *fd) {
 
   if (fd->hasAttr<CUDAGlobalAttr>() && Glob.getCGM().getLangOpts().CUDA &&
       !Glob.getCGM().getLangOpts().CUDAIsDevice) {
-    func::FuncOp deviceStub =
+    auto deviceStub =
         Glob.GetOrCreateMLIRFunction(fd, true, /* getDeviceStub */ true);
     builder.create<func::CallOp>(loc, deviceStub, function.getArguments());
     builder.create<ReturnOp>(loc);
@@ -5030,7 +5030,7 @@ void MLIRASTConsumer::run() {
 
     done.insert(name);
     MLIRScanner ms(*this, module, deviceModule, LTInfo);
-    func::FuncOp function = GetOrCreateMLIRFunction(FD, true);
+    auto function = GetOrCreateMLIRFunction(FD, true);
     ms.init(function, FD);
 
     LLVM_DEBUG({
@@ -5202,7 +5202,7 @@ mlir::Location MLIRASTConsumer::getMLIRLocation(clang::SourceLocation loc) {
   return FileLineColLoc::get(ctx, fileId, lineNumber, colNumber);
 }
 
-void MLIRASTConsumer::setMLIRFunctionAttributes(mlir::func::FuncOp &function,
+void MLIRASTConsumer::setMLIRFunctionAttributes(mlir::func::FuncOp function,
                                                 const FunctionDecl &FD,
                                                 LLVM::Linkage lnk,
                                                 MLIRContext *ctx) const {

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -41,8 +41,6 @@
 #include "clang/../../lib/CodeGen/CodeGenModule.h"
 #include "clang/AST/Mangle.h"
 
-using namespace clang;
-
 extern llvm::cl::opt<std::string> PrefixABI;
 
 struct LoopContext {
@@ -123,10 +121,10 @@ public:
   /// name, creating the string if necessary.
   mlir::Value GetOrCreateGlobalLLVMString(mlir::Location loc,
                                           mlir::OpBuilder &builder,
-                                          StringRef value);
+                                          clang::StringRef value);
 
   std::pair<mlir::memref::GlobalOp, bool>
-  GetOrCreateGlobal(const ValueDecl *VD, std::string prefix,
+  GetOrCreateGlobal(const clang::ValueDecl *VD, std::string prefix,
                     bool tryInit = true);
 
   void run();
@@ -167,12 +165,12 @@ private:
   llvm::SmallSet<std::string, 4> supportedFuncs;
   std::map<const void *, std::vector<mlir::LLVM::AllocaOp>> bufs;
   std::map<int, mlir::Value> constants;
-  std::map<LabelStmt *, mlir::Block *> labels;
+  std::map<clang::LabelStmt *, mlir::Block *> labels;
   const clang::FunctionDecl *EmittingFunctionDecl;
   std::map<const clang::ValueDecl *, ValueCategory> params;
   llvm::DenseMap<const clang::ValueDecl *, clang::FieldDecl *> Captures;
   llvm::DenseMap<const clang::ValueDecl *, clang::LambdaCaptureKind> CaptureKinds;
-  FieldDecl *ThisCapture;
+  clang::FieldDecl *ThisCapture;
   std::vector<mlir::Value> arrayinit;
   ValueCategory ThisVal;
   mlir::Value returnVal;
@@ -238,16 +236,17 @@ private:
 public:
   MLIRScanner(MLIRASTConsumer &Glob, mlir::OwningOpRef<mlir::ModuleOp> &module,
               LowerToInfo &LTInfo);
-
-  mlir::OpBuilder &getBuilder() { return builder; };
-  std::vector<LoopContext> &getLoops() { return loops; }
-  mlir::Location &getLoc() { return loc; }
+  
   void init(mlir::func::FuncOp function, const clang::FunctionDecl *fd);
 
   void setEntryAndAllocBlock(mlir::Block *B) {
     allocationScope = entryBlock = B;
     builder.setInsertionPointToStart(B);
   }
+
+  mlir::OpBuilder &getBuilder() { return builder; };
+  std::vector<LoopContext> &getLoops() { return loops; }
+  mlir::Location &getLoc() { return loc; }
 
   mlir::Value getConstantIndex(int x);
 
@@ -308,7 +307,7 @@ public:
 
   ValueCategory
   CallHelper(mlir::func::FuncOp tocall, clang::QualType objType,
-             ArrayRef<std::pair<ValueCategory, clang::Expr *>> arguments,
+             clang::ArrayRef<std::pair<ValueCategory, clang::Expr *>> arguments,
              clang::QualType retType, bool retReference, clang::Expr *expr);
 
   std::pair<ValueCategory, bool>
@@ -330,7 +329,7 @@ public:
   ValueCategory VisitCXXConstructExpr(clang::CXXConstructExpr *expr);
 
   ValueCategory VisitConstructCommon(clang::CXXConstructExpr *expr,
-                                     VarDecl *name, unsigned space,
+                                     clang::VarDecl *name, unsigned space,
                                      mlir::Value mem = nullptr,
                                      mlir::Value count = nullptr);
 
@@ -362,10 +361,11 @@ public:
 
   ValueCategory VisitCastExpr(clang::CastExpr *E);
 
-  mlir::Value GetAddressOfBaseClass(mlir::Value obj,
-                                    const clang::CXXRecordDecl *DerivedClass,
-                                    ArrayRef<const clang::Type *> BaseTypes,
-                                    ArrayRef<bool> BaseVirtuals);
+  mlir::Value
+  GetAddressOfBaseClass(mlir::Value obj,
+                        const clang::CXXRecordDecl *DerivedClass,
+                        clang::ArrayRef<const clang::Type *> BaseTypes,
+                        clang::ArrayRef<bool> BaseVirtuals);
 
   mlir::Value GetAddressOfDerivedClass(mlir::Value obj,
                                        const clang::CXXRecordDecl *DerivedClass,
@@ -438,7 +438,7 @@ public:
 
   static void getMangledFuncName(std::string &name,
                                  const clang::FunctionDecl *FD,
-                                 CodeGen::CodeGenModule &CGM);
+                                 clang::CodeGen::CodeGenModule &CGM);
 };
 
 #endif /* CLANG_MLIR_H */

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -150,7 +150,7 @@ public:
   mlir::Location getMLIRLocation(clang::SourceLocation loc);
 
 private:
-  void setMLIRFunctionAttributes(mlir::func::FuncOp &function,
+  void setMLIRFunctionAttributes(mlir::func::FuncOp function,
                                  const clang::FunctionDecl &FD,
                                  mlir::LLVM::Linkage lnk,
                                  mlir::MLIRContext *ctx) const;
@@ -255,7 +255,7 @@ public:
 
   mlir::OpBuilder &getBuilder() { return builder; };
   std::vector<LoopContext> &getLoops() { return loops; }
-  mlir::Location &getLoc() { return loc; }
+  mlir::Location getLoc() { return loc; }
 
   mlir::Value getConstantIndex(int x);
 


### PR DESCRIPTION
This PR cleans up the code a bit by:
   - making member data private where possible
   - avoid using declaration in header file
   - avoid using namespace std
   - remove dead code 