### PR TITLE
[SYCL][NFC] Add a missing symbol

### DIFF
--- a/sycl/source/detail/accessor_impl.hpp
+++ b/sycl/source/detail/accessor_impl.hpp
@@ -59,6 +59,18 @@ public:
         MElemSize(Other.MElemSize), MOffsetInBytes(Other.MOffsetInBytes),
         MIsSubBuffer(Other.MIsSubBuffer), MPropertyList(Other.MPropertyList) {}
 
+  AccessorImplHost &operator=(const AccessorImplHost &Other) {
+    MAccData = Other.MAccData;
+    MAccessMode = Other.MAccessMode;
+    MSYCLMemObj = Other.MSYCLMemObj;
+    MDims = Other.MDims;
+    MElemSize = Other.MElemSize;
+    MOffsetInBytes = Other.MOffsetInBytes;
+    MIsSubBuffer = Other.MIsSubBuffer;
+    MPropertyList = Other.MPropertyList;
+    return *this;
+  }
+
   // The resize method provides a way to change the size of the
   // allocated memory and corresponding properties for the accessor.
   // These are normally fixed for the accessor, but this capability

--- a/sycl/test/basic_tests/accessor/host_acc_opt.cpp
+++ b/sycl/test/basic_tests/accessor/host_acc_opt.cpp
@@ -9,8 +9,6 @@
 // CHECK: define {{.*}}foo{{.*}} {
 // CHECK-NOT: call
 // CHECK-NOT: invoke
-// CHECK-NOT: call
-// CHECK-NOT: invoke
 // CHECK: load <4 x i32>
 // CHECK-NOT: call
 // CHECK-NOT: invoke


### PR DESCRIPTION
While the copy assignment operator of AccessorImplHost is not used, it was auto generated by the compiler until recent changes and being checked in the ABI tests.
The safest way to fix this is to just manually define it.

Also removed 2 redundant lines in host_acc_opt test.