### PR TITLE
[SYCL] add device_type to SYCL_PI_TRACE and device_selector exception

### DIFF
--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -106,6 +106,25 @@ device select_device(DSelectorInvocableType DeviceSelectorInvocable,
     return *res;
   }
 
+  auto Selector = DeviceSelectorInvocable.target<int (*)(const sycl::device &)>();
+  if ((Selector && *Selector == gpu_selector_v)
+          || DeviceSelectorInvocable.target<sycl::gpu_selector>()) {
+    throw sycl::runtime_error(
+        "No device of requested type 'info::device_type::gpu' available.",
+        PI_ERROR_DEVICE_NOT_FOUND);
+  }
+  if ((Selector && *Selector == cpu_selector_v)
+          || DeviceSelectorInvocable.target<sycl::cpu_selector>()) {
+    throw sycl::runtime_error(
+        "No device of requested type 'info::device_type::cpu' available.",
+        PI_ERROR_DEVICE_NOT_FOUND);
+  }
+  if ((Selector && *Selector == accelerator_selector_v)
+          || DeviceSelectorInvocable.target<sycl::accelerator_selector>()) {
+    throw sycl::runtime_error("No device of requested type "
+                              "'info::device_type::accelerator' available.",
+                              PI_ERROR_DEVICE_NOT_FOUND);
+  }
   throw sycl::runtime_error("No device of requested type available.",
                             PI_ERROR_DEVICE_NOT_FOUND);
 }
@@ -137,10 +156,20 @@ select_device(const DSelectorInvocableType &DeviceSelectorInvocable,
 /// 2. CPU
 /// 3. Host
 /// 4. Accelerator
+
+static void traceDeviceSelector(const std::string &DeviceType) {
+  bool ShouldTrace = false;
+  ShouldTrace = detail::pi::trace(detail::pi::TraceLevel::PI_TRACE_BASIC);
+  if (ShouldTrace) {
+    std::cout << "SYCL_PI_TRACE[all]: Requested device_type: " << DeviceType << std::endl;
+  }
+}
+
 __SYCL_EXPORT int default_selector_v(const device &dev) {
   // The default selector doesn't reject any devices.
   int Score = 0;
 
+  traceDeviceSelector("info::device_type::automatic");
   if (dev.get_info<info::device::device_type>() == detail::get_forced_type())
     Score += 2000;
 
@@ -165,6 +194,7 @@ __SYCL_EXPORT int default_selector_v(const device &dev) {
 __SYCL_EXPORT int gpu_selector_v(const device &dev) {
   int Score = detail::REJECT_DEVICE_SCORE;
 
+  traceDeviceSelector("info::device_type::gpu");
   if (dev.is_gpu()) {
     Score = 1000;
     Score += detail::getDevicePreference(dev);
@@ -175,6 +205,7 @@ __SYCL_EXPORT int gpu_selector_v(const device &dev) {
 __SYCL_EXPORT int cpu_selector_v(const device &dev) {
   int Score = detail::REJECT_DEVICE_SCORE;
 
+  traceDeviceSelector("info::device_type::cpu");
   if (dev.is_cpu()) {
     Score = 1000;
     Score += detail::getDevicePreference(dev);
@@ -185,6 +216,7 @@ __SYCL_EXPORT int cpu_selector_v(const device &dev) {
 __SYCL_EXPORT int accelerator_selector_v(const device &dev) {
   int Score = detail::REJECT_DEVICE_SCORE;
 
+  traceDeviceSelector("info::device_type::accelerator");
   if (dev.is_accelerator()) {
     Score = 1000;
     Score += detail::getDevicePreference(dev);
@@ -196,6 +228,7 @@ int host_selector::operator()(const device &dev) const {
   // Host device has been removed and host_selector has been deprecated, so this
   // should never be able to select a device.
   std::ignore = dev;
+  traceDeviceSelector("info::device_type::host");
   return detail::REJECT_DEVICE_SCORE;
 }
 

--- a/sycl/test/basic_tests/device-selectors-exception.cpp
+++ b/sycl/test/basic_tests/device-selectors-exception.cpp
@@ -1,0 +1,45 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: env SYCL_DEVICE_FILTER="" %t.out
+
+#include <sycl/sycl.hpp>
+using namespace sycl;
+
+int refuse_any_device_f(const device &d) { return -1; }
+
+int main() {
+
+  // Check exception message for custom device selector
+  try {
+    queue custom_queue(refuse_any_device_f);
+  } catch (exception &E) {
+    assert(std::string(E.what()).find("info::device_type::") ==
+               std::string::npos &&
+           "Incorrect device type in exception message for custom selector.");
+  }
+
+  // Check exception message for pre-defined devices
+  try {
+    queue gpu_queue(gpu_selector_v);
+  } catch (exception &E) {
+    assert(std::string(E.what()).find("info::device_type::gpu") !=
+               std::string::npos &&
+           "Incorrect device type in exception message for GPU device.");
+  }
+  try {
+    queue cpu_queue(cpu_selector_v);
+  } catch (exception &E) {
+    assert(std::string(E.what()).find("info::device_type::cpu") !=
+               std::string::npos &&
+           "Incorrect device type in exception message for CPU device.");
+  }
+  try {
+    queue acc_queue(accelerator_selector_v);
+  } catch (exception &E) {
+    assert(
+        std::string(E.what()).find("info::device_type::accelerator") !=
+            std::string::npos &&
+        "Incorrect device type in exception message for Accelerator device.");
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Device selector exception message and SYCL_PI_TRACE are extended with device type info for better debuggability in case of missed device in application that works with multiple devices.

Current exception message:
```
 No device of requested type available. -1 (PI_ERROR_DEVICE_NOT_FOUND) # in case of any device selector
```

Example of the current output from SYCL_PI_TRACE:
```
SYCL_PI_TRACE[all]: Selected device: -> final score = 1000
SYCL_PI_TRACE[all]:   platform: Intel(R) OpenCL
SYCL_PI_TRACE[all]:   device: Intel(R) Xeon(R) Gold 6354 CPU @ 3.00GHz
```

New exception message: 
```
No device of requested type available. -1 (PI_ERROR_DEVICE_NOT_FOUND)                                  # in case of custom/default selector
No device of requested type 'info::device_type::gpu' available. -1 (PI_ERROR_DEVICE_NOT_FOUND)         # in case of gpu selector
No device of requested type 'info::device_type::cpu' available. -1 (PI_ERROR_DEVICE_NOT_FOUND)         # in case of cpu selector
No device of requested type 'info::device_type::accelerator' available. -1 (PI_ERROR_DEVICE_NOT_FOUND) # in case of accelerator selector
```

Example of SYCL_PI_TRACE output with extra line about requested device_type:
```
SYCL_PI_TRACE[all]: Requested device_type: info::device_type::cpu
SYCL_PI_TRACE[all]: Selected device: -> final score = 1000
SYCL_PI_TRACE[all]:   platform: Intel(R) OpenCL
SYCL_PI_TRACE[all]:   device: Intel(R) Xeon(R) Gold 6354 CPU @ 3.00GHz
```