### PR TITLE
[SYCL] Fix unintended use of fp64 math in complex maths

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/sycl_complex.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/sycl_complex.hpp
@@ -1029,7 +1029,7 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> __sqr(const complex<_Tp> &__x) {
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
 SYCL_EXTERNAL complex<_Tp> asinh(const complex<_Tp> &__x) {
-  const _Tp __pi(sycl::atan2(+0., -0.));
+  const _Tp __pi(sycl::atan2(_Tp(+0.), _Tp(-0.)));
   if (sycl::isinf(__x.real())) {
     if (sycl::isnan(__x.imag()))
       return __x;
@@ -1057,7 +1057,7 @@ SYCL_EXTERNAL complex<_Tp> asinh(const complex<_Tp> &__x) {
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
 SYCL_EXTERNAL complex<_Tp> acosh(const complex<_Tp> &__x) {
-  const _Tp __pi(sycl::atan2(+0., -0.));
+  const _Tp __pi(sycl::atan2(_Tp(+0.), _Tp(-0.)));
   if (sycl::isinf(__x.real())) {
     if (sycl::isnan(__x.imag()))
       return complex<_Tp>(sycl::fabs(__x.real()), __x.imag());
@@ -1090,7 +1090,7 @@ SYCL_EXTERNAL complex<_Tp> acosh(const complex<_Tp> &__x) {
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
 SYCL_EXTERNAL complex<_Tp> atanh(const complex<_Tp> &__x) {
-  const _Tp __pi(sycl::atan2(+0., -0.));
+  const _Tp __pi(sycl::atan2(_Tp(+0.), _Tp(-0.)));
   if (sycl::isinf(__x.imag())) {
     return complex<_Tp>(sycl::copysign(_Tp(0), __x.real()),
                         sycl::copysign(__pi / _Tp(2), __x.imag()));
@@ -1180,7 +1180,7 @@ SYCL_EXTERNAL complex<_Tp> asin(const complex<_Tp> &__x) {
 
 template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
 SYCL_EXTERNAL complex<_Tp> acos(const complex<_Tp> &__x) {
-  const _Tp __pi(sycl::atan2(+0., -0.));
+  const _Tp __pi(sycl::atan2(_Tp(+0.), _Tp(-0.)));
   if (sycl::isinf(__x.real())) {
     if (sycl::isnan(__x.imag()))
       return complex<_Tp>(__x.imag(), __x.real());


### PR DESCRIPTION
Select complex math operations unintentionally uses double-precision floating point math in all variants of that builtin. This can cause tests to fail on devices that do not support doubles. This commit fixes these math operations.