### PR TITLE
Revert "[SYCLToLLVM]: Fix alloca emission to use addrspace(4) (#6887)"

### DIFF
--- a/polygeist/lib/polygeist/Passes/ConvertPolygeistToLLVM.cpp
+++ b/polygeist/lib/polygeist/Passes/ConvertPolygeistToLLVM.cpp
@@ -127,9 +127,7 @@ struct SubIndexOpLowering : public ConvertOpToLLVMPattern<SubIndexOp> {
     // a memref element type is a struct type, the return type of a
     // polygeist.subindex operation should be a memref of the element type of
     // the struct.
-    auto elemPtrTy = LLVM::LLVMPointerType::get(
-        convViewElemType,
-        prev.getType().cast<LLVM::LLVMPointerType>().getAddressSpace());
+    auto elemPtrTy = LLVM::LLVMPointerType::get(convViewElemType);
     auto gep = rewriter.create<LLVM::GEPOp>(loc, elemPtrTy, prev, indices);
     auto memRefDesc = createMemRefDescriptor(loc, viewMemRefType, gep, gep,
                                              sizes, strides, rewriter);

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -1517,28 +1517,17 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
   }
 
   /// If the callee is part of the SYCL namespace, we may not want the
-  /// GetOrCreateMLIRFunction to add this FuncOp to the functionsToEmit deque,
+  /// GetOrCreateMLIRFunction to add this FuncOp to the functionsToEmit dequeu,
   /// since we will create it's equivalent with SYCL operations. Please note
   /// that we still generate some functions that we need for lowering some
   /// sycl op.  Therefore, in those case, we set ShouldEmit back to "true" by
   /// looking them up in our "registry" of supported functions.
-  bool isSyclFunc =
-      mlirclang::isNamespaceSYCL(callee->getEnclosingNamespaceContext());
-  bool ShouldEmit = !isSyclFunc;
-
-  std::string mangledName;
-  MLIRScanner::getMangledFuncName(mangledName, callee, Glob.getCGM());
-
-  if (isSyclFunc) {
-    LLVM_DEBUG(llvm::dbgs()
-               << "Adding device attribute to " << mangledName << "\n");
-    const_cast<FunctionDecl *>(callee)->addAttr(
-        SYCLDeviceAttr::CreateImplicit(Glob.getCGM().getContext()));
-  }
-
-  if (isSupportedFunctions(mangledName))
+  auto ShouldEmit =
+      !mlirclang::isNamespaceSYCL(callee->getEnclosingNamespaceContext());
+  std::string name;
+  MLIRScanner::getMangledFuncName(name, callee, Glob.getCGM());
+  if (isSupportedFunctions(name))
     ShouldEmit = true;
-
   auto ToCall = Glob.GetOrCreateMLIRFunction(callee, ShouldEmit);
 
   SmallVector<std::pair<ValueCategory, clang::Expr *>> args;

--- a/polygeist/tools/cgeist/Lib/CGStmt.cc
+++ b/polygeist/tools/cgeist/Lib/CGStmt.cc
@@ -225,7 +225,7 @@ ValueCategory MLIRScanner::VisitForStmt(clang::ForStmt *fors) {
     }
 
     auto i1Ty = builder.getIntegerType(1);
-    auto type = mlir::MemRefType::get({}, i1Ty, {}, defaultAddrSpace);
+    auto type = mlir::MemRefType::get({}, i1Ty, {}, 0);
     auto truev = builder.create<ConstantIntOp>(loc, true, 1);
 
     LoopContext lctx{builder.create<mlir::memref::AllocaOp>(loc, type),
@@ -311,7 +311,7 @@ ValueCategory MLIRScanner::VisitCXXForRangeStmt(clang::CXXForRangeStmt *fors) {
   Visit(fors->getEndStmt());
 
   auto i1Ty = builder.getIntegerType(1);
-  auto type = mlir::MemRefType::get({}, i1Ty, {}, defaultAddrSpace);
+  auto type = mlir::MemRefType::get({}, i1Ty, {}, 0);
   auto truev = builder.create<ConstantIntOp>(loc, true, 1);
 
   LoopContext lctx{builder.create<mlir::memref::AllocaOp>(loc, type),
@@ -697,7 +697,7 @@ ValueCategory MLIRScanner::VisitDoStmt(clang::DoStmt *fors) {
   auto loc = getMLIRLocation(fors->getDoLoc());
 
   auto i1Ty = builder.getIntegerType(1);
-  auto type = mlir::MemRefType::get({}, i1Ty, {}, defaultAddrSpace);
+  auto type = mlir::MemRefType::get({}, i1Ty, {}, 0);
   auto truev = builder.create<ConstantIntOp>(loc, true, 1);
   loops.push_back({builder.create<mlir::memref::AllocaOp>(loc, type),
                    builder.create<mlir::memref::AllocaOp>(loc, type)});
@@ -758,7 +758,7 @@ ValueCategory MLIRScanner::VisitWhileStmt(clang::WhileStmt *fors) {
   auto loc = getMLIRLocation(fors->getLParenLoc());
 
   auto i1Ty = builder.getIntegerType(1);
-  auto type = mlir::MemRefType::get({}, i1Ty, {}, defaultAddrSpace);
+  auto type = mlir::MemRefType::get({}, i1Ty, {}, 0);
   auto truev = builder.create<ConstantIntOp>(loc, true, 1);
   loops.push_back({builder.create<mlir::memref::AllocaOp>(loc, type),
                    builder.create<mlir::memref::AllocaOp>(loc, type)});
@@ -909,7 +909,7 @@ ValueCategory MLIRScanner::VisitSwitchStmt(clang::SwitchStmt *stmt) {
       builder.setInsertionPointToStart(&condB);
 
       auto i1Ty = builder.getIntegerType(1);
-      auto type = mlir::MemRefType::get({}, i1Ty, {}, defaultAddrSpace);
+      auto type = mlir::MemRefType::get({}, i1Ty, {}, 0);
       auto truev = builder.create<ConstantIntOp>(loc, true, 1);
       loops.push_back({builder.create<mlir::memref::AllocaOp>(loc, type),
                        builder.create<mlir::memref::AllocaOp>(loc, type)});
@@ -932,7 +932,7 @@ ValueCategory MLIRScanner::VisitSwitchStmt(clang::SwitchStmt *stmt) {
       builder.setInsertionPointToStart(&condB);
 
       auto i1Ty = builder.getIntegerType(1);
-      auto type = mlir::MemRefType::get({}, i1Ty, {}, defaultAddrSpace);
+      auto type = mlir::MemRefType::get({}, i1Ty, {}, 0);
       auto truev = builder.create<ConstantIntOp>(loc, true, 1);
       loops.push_back({builder.create<mlir::memref::AllocaOp>(loc, type),
                        builder.create<mlir::memref::AllocaOp>(loc, type)});

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -180,7 +180,6 @@ private:
       CaptureKinds;
   clang::FieldDecl *ThisCapture;
   std::vector<mlir::Value> arrayinit;
-  unsigned defaultAddrSpace;
   ValueCategory ThisVal;
   mlir::Value returnVal;
   LowerToInfo &LTInfo;
@@ -201,8 +200,7 @@ private:
     subbuilder.setInsertionPointToStart(allocationScope);
 
     auto one = subbuilder.create<mlir::arith::ConstantIntOp>(loc, 1, 64);
-    auto rs =
-        subbuilder.create<mlir::LLVM::AllocaOp>(loc, t, one, defaultAddrSpace);
+    auto rs = subbuilder.create<mlir::LLVM::AllocaOp>(loc, t, one, 0);
     vec.push_back(rs);
     return rs;
   }
@@ -242,15 +240,6 @@ private:
   void buildAffineLoopImpl(clang::ForStmt *fors, mlir::Location loc,
                            mlir::Value lb, mlir::Value ub,
                            const mlirclang::AffineLoopDescriptor &descr);
-
-  static unsigned getDefaultAddrSpace(const clang::FunctionDecl &FD) {
-    // For SYCL we generate LLVM code that is then translated to SPIRV.
-    // The generic SPIRV address space is addrspace(4).
-    if (FD.hasAttr<clang::SYCLDeviceAttr>() ||
-        FD.hasAttr<clang::SYCLKernelAttr>())
-      return 4;
-    return 0;
-  }
 
 public:
   MLIRScanner(MLIRASTConsumer &Glob, mlir::OwningOpRef<mlir::ModuleOp> &module,

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -17,12 +17,10 @@
 // CHECK-DAG: !sycl_range_1_ = !sycl.range<1>
 
 // Ensure the constructors are NOT filtered out, and sycl.cast is generated for cast from sycl.id or sycl.range to sycl.array.
-// CHECK:      func.func @_ZN4sycl3_V12idILi1EEC1ERKS2_(%arg0: memref<?x!sycl_id_1_, 4>, %arg1: memref<?x!sycl_id_1_, 4>)
-// CHECK-SAME:   attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<linkonce_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
-// CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl_id_1_, 4>) -> memref<?x!sycl_array_1_, 4>
-// CHECK:      func.func @_ZN4sycl3_V15rangeILi1EEC1ERKS2_(%arg0: memref<?x!sycl_range_1_, 4>, %arg1: memref<?x!sycl_range_1_, 4>)
-// CHECK-SAME:   attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<linkonce_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
-// CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl_range_1_, 4>) -> memref<?x!sycl_array_1_, 4>
+// CHECK:      func.func @_ZN4sycl3_V12idILi1EEC1ERKS2_(%arg0: memref<?x!sycl_id_1_>, %arg1: memref<?x!sycl_id_1_>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl_id_1_>) -> memref<?x!sycl_array_1_>
+// CHECK:      func.func @_ZN4sycl3_V15rangeILi1EEC1ERKS2_(%arg0: memref<?x!sycl_range_1_>, %arg1: memref<?x!sycl_range_1_>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl_range_1_>) -> memref<?x!sycl_array_1_>
 
 // CHECK-LLVM: ; Function Attrs: convergent mustprogress norecurse nounwind
 // CHECK-LLVM: define spir_func void @cons_0([[ID_TYPE:%"class.cl::sycl::id.1"]] [[ARG0:%.*]], [[RANGE_TYPE:%"class.cl::sycl::range.1"]] [[ARG1:%.*]])
@@ -30,10 +28,10 @@
 // CHECK-LLVM-DAG: [[ID1:%.*]] = alloca [[ID_TYPE]]
 // CHECK-LLVM-DAG: [[RANGE2:%.*]] = alloca [[RANGE_TYPE]]
 // CHECK-LLVM-DAG: [[ID2:%.*]] = alloca [[ID_TYPE]]
-// CHECK-LLVM: store [[ID_TYPE]] [[ARG0]], [[ID_TYPE]] addrspace(4)* [[ID2]]
-// CHECK-LLVM: store [[RANGE_TYPE]] [[ARG1]], [[RANGE_TYPE]] addrspace(4)* [[RANGE2]]
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi1EEC1ERKS2_([[ID_TYPE]] addrspace(4)* [[ID1]], 
-// CHECK-LLVM: call void @_ZN4sycl3_V15rangeILi1EEC1ERKS2_([[RANGE_TYPE]] addrspace(4)* [[RANGE1]],
+// CHECK-LLVM: store [[ID_TYPE]] [[ARG0]], [[ID_TYPE]]* [[ID2]]
+// CHECK-LLVM: store [[RANGE_TYPE]] [[ARG1]], [[RANGE_TYPE]]* [[RANGE2]]
+// CHECK-LLVM: call void @_ZN4sycl3_V12idILi1EEC1ERKS2_([[ID_TYPE]]* [[ID1]], 
+// CHECK-LLVM: call void @_ZN4sycl3_V15rangeILi1EEC1ERKS2_([[RANGE_TYPE]]* [[RANGE1]],
 
 extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
   auto id = sycl::id<1>{i};
@@ -44,26 +42,25 @@ extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
 // CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-NEXT: %false = arith.constant false
 // CHECK-NEXT: %c0_i8 = arith.constant 0 : i8
-// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_, 4>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_, 4> to memref<?x!sycl_id_2_, 4>
-// CHECK-NEXT: %2 = "polygeist.memref2pointer"(%0) : (memref<1x!sycl_id_2_, 4>) -> !llvm.ptr<i8, 4>
+// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
+// CHECK-NEXT: %2 = "polygeist.memref2pointer"(%0) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<i8>
 // CHECK-NEXT: %3 = "polygeist.typeSize"() {source = !sycl_id_2_} : () -> index
 // CHECK-NEXT: %4 = arith.index_cast %3 : index to i64
-// CHECK-NEXT: "llvm.intr.memset"(%2, %c0_i8, %4, %false) : (!llvm.ptr<i8, 4>, i8, i64, i1) -> ()
-// CHECK-NEXT: sycl.constructor(%1) {MangledName = @_ZN4sycl3_V12idILi2EEC1Ev, Type = @id} : (memref<?x!sycl_id_2_, 4>) -> ()
+// CHECK-NEXT: "llvm.intr.memset"(%2, %c0_i8, %4, %false) : (!llvm.ptr<i8>, i8, i64, i1) -> ()
+// CHECK-NEXT: sycl.constructor(%1) {MangledName = @_ZN4sycl3_V12idILi2EEC1Ev, Type = @id} : (memref<?x!sycl_id_2_>) -> ()
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
 // Ensure declaration to have external linkage.
-// CHECK: func.func private @_ZN4sycl3_V12idILi2EEC1Ev(memref<?x!sycl_id_2_, 4>)
-// CHECK-SAME:  attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
+// CHECK: func.func private @_ZN4sycl3_V12idILi2EEC1Ev(memref<?x!sycl_id_2_>) attributes {llvm.linkage = #llvm.linkage<external>}
 
 // CHECK-LLVM: ; Function Attrs: convergent mustprogress norecurse nounwind
 // CHECK-LLVM: define spir_func void @cons_1()
 // CHECK-LLVM: [[ID1:%.*]] = alloca [[ID_TYPE:%"class.cl::sycl::id.2"]]
-// CHECK-LLVM: [[CAST1:%.*]] = bitcast [[ID_TYPE]] addrspace(4)* %1 to i8 addrspace(4)*
-// CHECK-LLVM: call void @llvm.memset.p4i8.i64(i8 addrspace(4)* %2, i8 0, i64 16, i1 false)
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1Ev([[ID_TYPE]] addrspace(4)* [[ID1]], [[ID_TYPE]] addrspace(4)* [[ID1]], i64 0, i64 1, i64 1)  
+// CHECK-LLVM: [[CAST1:%.*]] = bitcast [[ID_TYPE]]* %1 to i8*
+// CHECK-LLVM: call void @llvm.memset.p0i8.i64(i8* %2, i8 0, i64 16, i1 false)
+// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1Ev([[ID_TYPE]]* [[ID1]], [[ID_TYPE]]* [[ID1]], i64 0, i64 1, i64 1)  
 
 extern "C" SYCL_EXTERNAL void cons_1() {
   auto id = sycl::id<2>{};
@@ -71,16 +68,16 @@ extern "C" SYCL_EXTERNAL void cons_1() {
 
 // CHECK: func.func @cons_2(%arg0: i64, %arg1: i64)
 // CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
-// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_, 4>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_, 4> to memref<?x!sycl_id_2_, 4>
-// CHECK-NEXT: sycl.constructor(%1, %arg0, %arg1) {MangledName = @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, Type = @id} : (memref<?x!sycl_id_2_, 4>, i64, i64) -> ()
+// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
+// CHECK-NEXT: sycl.constructor(%1, %arg0, %arg1) {MangledName = @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, Type = @id} : (memref<?x!sycl_id_2_>, i64, i64) -> ()
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
 // CHECK-LLVM: ; Function Attrs: convergent mustprogress norecurse nounwind
 // CHECK-LLVM: define spir_func void @cons_2(i64 %0, i64 %1)
 // CHECK-LLVM: [[ID1:%.*]] = alloca [[ID_TYPE:%"class.cl::sycl::id.2"]]
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm([[ID_TYPE]] addrspace(4)* [[ID1]], [[ID_TYPE]] addrspace(4)* [[ID1]], i64 0, i64 1, i64 1, i64 %0, i64 %1)
+// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm([[ID_TYPE]]* [[ID1]], [[ID_TYPE]]* [[ID1]], i64 0, i64 1, i64 1, i64 %0, i64 %1)
 
 extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
   auto id = sycl::id<2>{a, b};
@@ -88,12 +85,12 @@ extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
 
 // CHECK: func.func @cons_3(%arg0: !sycl_item_2_1_)
 // CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
-// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_, 4>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_, 4> to memref<?x!sycl_id_2_, 4>
-// CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl_item_2_1_, 4>
-// CHECK-NEXT: %3 = memref.cast %2 : memref<1x!sycl_item_2_1_, 4> to memref<?x!sycl_item_2_1_, 4>
-// CHECK-NEXT: affine.store %arg0, %2[0] : memref<1x!sycl_item_2_1_, 4>
-// CHECK-NEXT: sycl.constructor(%1, %3) {MangledName = @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE, Type = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_item_2_1_, 4>) -> ()
+// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
+// CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl_item_2_1_>
+// CHECK-NEXT: %3 = memref.cast %2 : memref<1x!sycl_item_2_1_> to memref<?x!sycl_item_2_1_>
+// CHECK-NEXT: affine.store %arg0, %2[0] : memref<1x!sycl_item_2_1_>
+// CHECK-NEXT: sycl.constructor(%1, %3) {MangledName = @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE, Type = @id} : (memref<?x!sycl_id_2_>, memref<?x!sycl_item_2_1_>) -> ()
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
@@ -101,9 +98,8 @@ extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
 // CHECK-LLVM: define spir_func void @cons_3([[ITEM_TYPE:%"class.cl::sycl::item.2.true"]] [[ARG0:%.*]])
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE:%"class.cl::sycl::id.2"]]  
 // CHECK-LLVM-DAG: [[ITEM:%.*]] = alloca [[ITEM_TYPE]]
-// CHECK-LLVM: store [[ITEM_TYPE]] [[ARG0]], [[ITEM_TYPE]] addrspace(4)* [[ITEM]], align 8
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE([[ID_TYPE]] addrspace(4)* [[ID]], [[ID_TYPE]] addrspace(4)* [[ID]], i64 0, i64 1, i64 1, 
-// CHECK-SAME-LLVM: [[ITEM_TYPE]] addrspace(4)* [[ITEM]], [[ITEM_TYPE]] addrspace(4)* [[ITEM]], i64 0, i64 1, i64 1)
+// CHECK-LLVM: store [[ITEM_TYPE]] [[ARG0]], [[ITEM_TYPE]]* [[ITEM]], align 8
+// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE([[ID_TYPE]]* [[ID]], [[ID_TYPE]]* [[ID]], i64 0, i64 1, i64 1, [[ITEM_TYPE]]* [[ITEM]], [[ITEM_TYPE]]* [[ITEM]], i64 0, i64 1, i64 1)
 
 extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
   auto id = sycl::id<2>{val};
@@ -111,12 +107,12 @@ extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
 
 // CHECK: func.func @cons_4(%arg0: !sycl_id_2_)
 // CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
-// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_, 4>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_, 4> to memref<?x!sycl_id_2_, 4>
-// CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl_id_2_, 4>
-// CHECK-NEXT: %3 = memref.cast %2 : memref<1x!sycl_id_2_, 4> to memref<?x!sycl_id_2_, 4>
-// CHECK-NEXT: affine.store %arg0, %2[0] : memref<1x!sycl_id_2_, 4>
-// CHECK-NEXT: sycl.constructor(%1, %3) {MangledName = @_ZN4sycl3_V12idILi2EEC1ERKS2_, Type = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> ()
+// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
+// CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %3 = memref.cast %2 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
+// CHECK-NEXT: affine.store %arg0, %2[0] : memref<1x!sycl_id_2_>
+// CHECK-NEXT: sycl.constructor(%1, %3) {MangledName = @_ZN4sycl3_V12idILi2EEC1ERKS2_, Type = @id} : (memref<?x!sycl_id_2_>, memref<?x!sycl_id_2_>) -> ()
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
@@ -124,24 +120,22 @@ extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
 // CHECK-LLVM: define spir_func void @cons_4([[ID_TYPE:%"class.cl::sycl::id.2"]] [[ARG0:%.*]])
 // CHECK-LLVM-DAG: [[ID1:%.*]] = alloca [[ID_TYPE]]
 // CHECK-LLVM-DAG: [[ID2:%.*]] = alloca [[ID_TYPE]]
-// CHECK-LLVM: store [[ID_TYPE]] [[ARG0]], [[ID_TYPE]] addrspace(4)* [[ID2]], align 8
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ERKS2_([[ID_TYPE]] addrspace(4)* [[ID1]], [[ID_TYPE]] addrspace(4)* [[ID1]], i64 0, i64 1, i64 1, [[ID_TYPE]] addrspace(4)* [[ID2]], [[ID_TYPE]] addrspace(4)* [[ID2]], i64 0, i64 1, i64 1)
+// CHECK-LLVM: store [[ID_TYPE]] [[ARG0]], [[ID_TYPE]]* [[ID2]], align 8
+// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ERKS2_([[ID_TYPE]]* [[ID1]], [[ID_TYPE]]* [[ID1]], i64 0, i64 1, i64 1, [[ID_TYPE]]* [[ID2]], [[ID_TYPE]]* [[ID2]], i64 0, i64 1, i64 1)
 
 extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
   auto id = sycl::id<2>{val};
 }
 
 // CHECK-LABEL: func.func @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev
-// CHECK: [[I:%.*]] = "polygeist.subindex"(%arg0, %c0) : (memref<?x!sycl_accessor_1_i32_write_global_buffer, 4>, index) -> memref<?x!sycl_accessor_impl_device_1_, 4>
-// CHECK: sycl.constructor([[I]], {{%.*}}, {{%.*}}, {{%.*}}) {MangledName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_, Type = @AccessorImplDevice} 
-// CHECK-SAME: (memref<?x!sycl_accessor_impl_device_1_, 4>, !sycl_id_1_, !sycl_range_1_, !sycl_range_1_) -> ()
+// CHECK: [[I:%.*]] = "polygeist.subindex"(%arg0, %c0) : (memref<?x!sycl_accessor_1_i32_write_global_buffer>, index) -> memref<?x!sycl_accessor_impl_device_1_>
+// CHECK: sycl.constructor([[I]], {{%.*}}, {{%.*}}, {{%.*}}) {MangledName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_, Type = @AccessorImplDevice} : (memref<?x!sycl_accessor_impl_device_1_>, !sycl_id_1_, !sycl_range_1_, !sycl_range_1_) -> ()
 
 // CHECK-LLVM: ; Function Attrs: convergent mustprogress norecurse nounwind
 // CHECK-LLVM-LABEL: define spir_func void @cons_5()
-// CHECK-LLVM: [[ACCESSOR:%.*]] = alloca [[ACCESSOR_TYPE:%"class.cl::sycl::accessor.1"]], i64 ptrtoint ([[ACCESSOR_TYPE]] addrspace(4)* getelementptr ([[ACCESSOR_TYPE]], [[ACCESSOR_TYPE]] addrspace(4)* null, i32 1) to i64), align 8
-// CHECK-LLVM: call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(
-// CHECK-SAME-LLVM: [[ACCESSOR_TYPE]] addrspace(4)* [[ACCESSOR]], [[ACCESSOR_TYPE]] addrspace(4)* [[ACCESSOR]], i64 0, i64 1, i64 1)
-
+// CHECK-LLVM: [[ACCESSOR:%.*]] = alloca [[ACCESSOR_TYPE:%"class.cl::sycl::accessor.1"]], i64 ptrtoint ([[ACCESSOR_TYPE]]* getelementptr ([[ACCESSOR_TYPE]], [[ACCESSOR_TYPE]]* null, i32 1) to i64), align 8
+// CHECK-LLVM: call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev([[ACCESSOR_TYPE]]* [[ACCESSOR]], [[ACCESSOR_TYPE]]* [[ACCESSOR]], i64 0, i64 1, i64 1)
 extern "C" SYCL_EXTERNAL void cons_5() {
   auto accessor = sycl::accessor<sycl::cl_int, 1, sycl::access::mode::write>{};
+  return;
 }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -19,10 +19,10 @@
 // CHECK: func.func @_Z8method_1N4sycl3_V14itemILi2ELb1EEE(%arg0: !sycl_item_2_1_)
 // CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-NEXT: %c0_i32 = arith.constant 0 : i32
-// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_item_2_1_, 4>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_item_2_1_, 4> to memref<?x!sycl_item_2_1_, 4>
-// CHECK-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl_item_2_1_, 4>
-// CHECK-NEXT: %2 = sycl.call(%1, %c0_i32) {Function = @get_id, MangledName = @_ZNK4sycl3_V14itemILi2ELb1EE6get_idEi, Type = @item} : (memref<?x!sycl_item_2_1_, 4>, i32) -> i64
+// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_item_2_1_>
+// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_item_2_1_> to memref<?x!sycl_item_2_1_>
+// CHECK-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl_item_2_1_>
+// CHECK-NEXT: %2 = sycl.call(%1, %c0_i32) {Function = @get_id, MangledName = @_ZNK4sycl3_V14itemILi2ELb1EE6get_idEi, Type = @item} : (memref<?x!sycl_item_2_1_>, i32) -> i64
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
@@ -32,10 +32,10 @@ SYCL_EXTERNAL void method_1(sycl::item<2, true> item) {
 
 // CHECK: func.func @_Z8method_2N4sycl3_V14itemILi2ELb1EEE(%arg0: !sycl_item_2_1_)
 // CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
-// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_item_2_1_, 4>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_item_2_1_, 4> to memref<?x!sycl_item_2_1_, 4>
-// CHECK-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl_item_2_1_, 4>
-// CHECK-NEXT: %2 = sycl.call(%1, %1) {Function = @"operator==", MangledName = @_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_, Type = @item} : (memref<?x!sycl_item_2_1_, 4>, memref<?x!sycl_item_2_1_, 4>) -> i8
+// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_item_2_1_>
+// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_item_2_1_> to memref<?x!sycl_item_2_1_>
+// CHECK-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl_item_2_1_>
+// CHECK-NEXT: %2 = sycl.call(%1, %1) {Function = @"operator==", MangledName = @_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_, Type = @item} : (memref<?x!sycl_item_2_1_>, memref<?x!sycl_item_2_1_>) -> i8
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
@@ -45,13 +45,13 @@ SYCL_EXTERNAL void method_2(sycl::item<2, true> item) {
 
 // CHECK: func.func @_Z4op_1N4sycl3_V12idILi2EEES2_(%arg0: !sycl_id_2_, %arg1: !sycl_id_2_)
 // CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
-// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_, 4>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_, 4> to memref<?x!sycl_id_2_, 4>
-// CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl_id_2_, 4>
-// CHECK-NEXT: %3 = memref.cast %2 : memref<1x!sycl_id_2_, 4> to memref<?x!sycl_id_2_, 4>
-// CHECK-NEXT: affine.store %arg0, %2[0] : memref<1x!sycl_id_2_, 4>
-// CHECK-NEXT: affine.store %arg1, %0[0] : memref<1x!sycl_id_2_, 4>
-// CHECK-NEXT: %4 = sycl.call(%3, %1) {Function = @"operator==", MangledName = @_ZNK4sycl3_V12idILi2EEeqERKS2_, Type = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> i8
+// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
+// CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %3 = memref.cast %2 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
+// CHECK-NEXT: affine.store %arg0, %2[0] : memref<1x!sycl_id_2_>
+// CHECK-NEXT: affine.store %arg1, %0[0] : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %4 = sycl.call(%3, %1) {Function = @"operator==", MangledName = @_ZNK4sycl3_V12idILi2EEeqERKS2_, Type = @id} : (memref<?x!sycl_id_2_>, memref<?x!sycl_id_2_>) -> i8
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
@@ -63,12 +63,12 @@ SYCL_EXTERNAL void op_1(sycl::id<2> a, sycl::id<2> b) {
 // CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-NEXT: %c1_i32 = arith.constant 1 : i32
 // CHECK-NEXT: %c0_i32 = arith.constant 0 : i32
-// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_, 4>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_, 4> to memref<?x!sycl_id_2_, 4>
-// CHECK-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl_id_2_, 4>
-// CHECK-NEXT: %2 = sycl.cast(%1) : (memref<?x!sycl_id_2_, 4>) -> memref<?x!sycl_array_2_, 4>
-// CHECK-NEXT: %3 = sycl.call(%2, %c0_i32) {Function = @get, MangledName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, Type = @array} : (memref<?x!sycl_array_2_, 4>, i32) -> i64
-// CHECK-NEXT: %4 = sycl.call(%2, %c1_i32) {Function = @get, MangledName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, Type = @array} : (memref<?x!sycl_array_2_, 4>, i32) -> i64
+// CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
+// CHECK-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %2 = sycl.cast(%1) : (memref<?x!sycl_id_2_>) -> memref<?x!sycl_array_2_>
+// CHECK-NEXT: %3 = sycl.call(%2, %c0_i32) {Function = @get, MangledName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, Type = @array} : (memref<?x!sycl_array_2_>, i32) -> i64
+// CHECK-NEXT: %4 = sycl.call(%2, %c1_i32) {Function = @get, MangledName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, Type = @array} : (memref<?x!sycl_array_2_>, i32) -> i64
 // CHECK-NEXT: %5 = arith.addi %3, %4 : i64
 // CHECK-NEXT: %6 = sycl.call(%5) {Function = @abs, MangledName = @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_} : (i64) -> i64
 // CHECK-NEXT: return

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -18,7 +18,7 @@
 // CHECK: !sycl_item_2_1_ = !sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>)>
 // CHECK: !sycl_range_1_ = !sycl.range<1>
 
-// CHECK: func.func @_ZTS8kernel_1(%arg0: memref<?xi32, 1>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
+// CHECK: func.func @_ZTS8kernel_1(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
 // CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 // CHECK-NOT: SYCLKernel =
 
@@ -47,7 +47,7 @@ void host_1() {
   }
 }
 
-// CHECK: func.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2(%arg0: memref<?xi32, 1>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
+// CHECK: func.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
 // CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 // CHECK-NOT: SYCLKernel =
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
@@ -14,10 +14,10 @@
 #define N 32
 // clang-format off
 // CHECK: func.func private {{.*}}vec_add_device_simple{{.*}}sycl{{.*}}handler{{.*}}
-// CHECK-DAG: %[[VEC1:.*]] = affine.load %[[ACCESSOR1:.*]][0] : memref<?xf32, 4>
-// CHECK-DAG: %[[VEC2:.*]] = affine.load %[[ACCESSOR2:.*]][0] : memref<?xf32, 4>
+// CHECK-DAG: %[[VEC1:.*]] = affine.load %[[ACCESSOR1:.*]][0] : memref<?xf32>
+// CHECK-DAG: %[[VEC2:.*]] = affine.load %[[ACCESSOR2:.*]][0] : memref<?xf32>
 // CHECK-NEXT: %[[RESULT:.*]] = arith.addf %[[VEC1]], %[[VEC2]] : f32
-// CHECK-NEXT: affine.store %[[RESULT]], %[[VEC3:.*]][0] : memref<?xf32, 4>
+// CHECK-NEXT: affine.store %[[RESULT]], %[[VEC3:.*]][0] : memref<?xf32>
 // CHECK-NEXT: return
 // clang-format on
 


### PR DESCRIPTION
This reverts commit 68d8c2066ec361ff502f4ee1268c039af86f999b.