### PR TITLE
[SYCL-MLIR]: Add single_task.cpp lit test

### DIFF
--- a/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
@@ -1,12 +1,15 @@
 // RUN: sycl-clang.py %s -S -emit-llvm -o %t.ll
 // Test that the LLVMIR generated is verifiable.
 // RUN: opt -verify -disable-output < %t.ll
+// Verify that LLVMIR generated is translatable to SPIRV.
+// RUN: llvm-as %t.ll
+// RUN: llvm-spirv %t.bc
 // RUN: cat %t.ll | FileCheck %s
 // XFAIL: *
 
 // Test that the kernel named `kernel_single_task` is generated.
 // CHECK: define weak_odr spir_kernel void {{.*}}kernel_single_task
-// Test that all referred sycl header functions are generated.
+// Test that all referenced sycl header functions are generated.
 // CHECK-NOT: declare {{.*}} spir_func
 
 #include <sycl/sycl.hpp>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
@@ -1,0 +1,27 @@
+// RUN: sycl-clang.py %s -S -emit-llvm -o %t.ll
+// Test that the LLVMIR generated is verifiable.
+// RUN: opt -verify -disable-output < %t.ll
+// RUN: cat %t.ll | FileCheck %s
+// XFAIL: *
+
+// Test that the kernel named `kernel_single_task` is generated.
+// CHECK: define weak_odr spir_kernel void {{.*}}kernel_single_task
+// Test that all referred sycl header functions are generated.
+// CHECK-NOT: declare {{.*}} spir_func
+
+#include <sycl/sycl.hpp>
+
+void host_single_task() {
+  auto q = sycl::queue{};
+  auto range = sycl::range<1>{1};
+
+  {
+    auto buf = sycl::buffer<int, 1>{nullptr, range};
+    q.submit([&](sycl::handler &cgh) {
+      auto A = buf.get_access<sycl::access::mode::write>(cgh);
+      cgh.single_task<class kernel_single_task>([=]() {
+        A[0] = 42;
+      });
+    });
+  }
+}


### PR DESCRIPTION
Add the single_task test that we aim to support as our first end to end test case.
Currently it is XFAIL, more changes are needed to have it working.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>