### PR TITLE
[SYCL-MLIR]: Expect the source and result types of Pointer2Memref and Memref2Pointer to have the same address space

### DIFF
--- a/polygeist/lib/polygeist/Ops.cpp
+++ b/polygeist/lib/polygeist/Ops.cpp
@@ -1887,12 +1887,8 @@ void Pointer2MemrefOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 OpFoldResult Pointer2MemrefOp::fold(ArrayRef<Attribute> operands) {
-  /// Simplify pointer2memref(cast(x)) to pointer2memref(x)
+  /// Simplify pointer2memref(bitcast(x)) to pointer2memref(x)
   if (auto mc = source().getDefiningOp<LLVM::BitcastOp>()) {
-    sourceMutable().assign(mc.getArg());
-    return result();
-  }
-  if (auto mc = source().getDefiningOp<LLVM::AddrSpaceCastOp>()) {
     sourceMutable().assign(mc.getArg());
     return result();
   }

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -102,11 +102,10 @@ void ValueCategory::store(mlir::OpBuilder &builder, mlir::Value toStore) const {
     if (auto RHS = toStore.getType().dyn_cast<mlir::MemRefType>()) {
       if (auto LHS =
               mt.getElementType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
-        if (LHS.getElementType() != RHS.getElementType()) {
-          llvm::errs() << "warning potential store type mismatch:\n";
-          llvm::errs() << "lhs: " << val << "rhs: " << toStore << "\n";
-          llvm::errs() << "lhs: " << LHS << "rhs: " << RHS << "\n";
-        }
+        assert(LHS.getElementType() == RHS.getElementType() &&
+               "Store types mismatch");
+        assert(LHS.getAddressSpace() == RHS.getMemorySpaceAsInt() &&
+               "Store address spaces mismatch");
         toStore =
             builder.create<polygeist::Memref2PointerOp>(loc, LHS, toStore);
       }


### PR DESCRIPTION
- Remove folding of `AddrSpaceCastOp` from source of `Pointer2MemrefOp`, as we assume that the source and result types of Pointer2Memref to have the same address space.
- Add assertions to the lowering of `Pointer2MemrefOp` and `Memref2Pointer` to ensure the expectation is correct.
- Add assertion to an insertion point of `Memref2Pointer` to ensure the expectation is correct.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>