### PR TITLE
[ESIMD] Follow-up fix for ESIMDOptimizeVecArgCallConv memory corruption.

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/ESIMDOptimizeVecArgCallConv.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/ESIMDOptimizeVecArgCallConv.cpp
@@ -478,7 +478,7 @@ static bool processFunction(Function *F) {
 
   // Copy users to a separate container, to enable safe eraseFromParent
   // within optimizeCall.
-  SmallVector<User*> FUsers;
+  SmallVector<User *> FUsers;
   std::copy(F->users().begin(), F->users().end(), std::back_inserter(FUsers));
 
   // Optimize calls to the function.

--- a/llvm/lib/SYCLLowerIR/ESIMD/ESIMDOptimizeVecArgCallConv.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/ESIMDOptimizeVecArgCallConv.cpp
@@ -476,8 +476,13 @@ static bool processFunction(Function *F) {
   // Optimize the function.
   Function *NewF = optimizeFunction(F, OptimizeableParams, NewParamTs);
 
+  // Copy users to a separate container, to enable safe eraseFromParent
+  // within optimizeCall.
+  SmallVector<User*> FUsers;
+  std::copy(F->users().begin(), F->users().end(), std::back_inserter(FUsers));
+
   // Optimize calls to the function.
-  for (auto *U : F->users()) {
+  for (auto *U : FUsers) {
     auto *Call = cast<CallInst>(U);
     assert(Call->getCalledFunction() == F);
     optimizeCall(Call, NewF, OptimizeableParams);


### PR DESCRIPTION
https://github.com/intel/llvm/pull/6557 rolled back necessary code, return it back with this patch. Problem somehow reproduced only in internal debug Windows build - the
SYCLLowerIR/ESIMD/vec_arg_call_conv.ll test crashed opt.

Signed-off-by: Konstantin S Bobrovsky <konstantin.s.bobrovsky@intel.com>