### PR TITLE
[Driver][SYCL] Add additional debug settings when using -g on Windows

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5983,6 +5983,12 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   if (D.IsCLMode())
     AddClangCLArgs(Args, InputType, CmdArgs, &DebugInfoKind, &EmitCodeView);
 
+  // Add debug macro for debug library usage when using non-cl driver on
+  // Windows as we are using the debug sycld.lib with -g
+  if (!D.IsCLMode() && TC.getTriple().isWindowsMSVCEnvironment() &&
+      Args.hasArg(options::OPT_fsycl) && Args.hasArg(options::OPT_g_Flag))
+    CmdArgs.push_back("-D_DEBUG");
+
   DwarfFissionKind DwarfFission = DwarfFissionKind::None;
   renderDebugOptions(TC, D, RawTriple, Args, EmitCodeView,
                      types::isLLVMIR(InputType), CmdArgs, DebugInfoKind,

--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -125,7 +125,10 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
   if (!Args.hasArg(options::OPT_nostdlib, options::OPT_nostartfiles) &&
       !C.getDriver().IsCLMode() && !C.getDriver().IsFlangMode()) {
     if (Args.hasArg(options::OPT_fsycl) && !Args.hasArg(options::OPT_nolibsycl))
-      CmdArgs.push_back("-defaultlib:msvcrt");
+      if (Args.hasArg(options::OPT_g_Flag))
+        CmdArgs.push_back("-defaultlib:msvcrtd");
+      else
+        CmdArgs.push_back("-defaultlib:msvcrt");
     else
       CmdArgs.push_back("-defaultlib:libcmt");
     CmdArgs.push_back("-defaultlib:oldnames");

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -666,6 +666,8 @@
 // RUN:  %clang_cl -fsycl /MDd %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL-DEBUG-CL %s
 // CHECK-LINK-SYCL-DEBUG-CL: "--dependent-lib=sycl{{[0-9]*}}d"
 // CHECK-LINK-SYCL-DEBUG-CL-NOT: "-defaultlib:sycl{{[0-9]*}}d.lib"
+// CHECK-LINK-SYCL-DEBUG: "-D_DEBUG"
+// CHECK-LINK-SYCL-DEBUG: "-defaultlib:msvcrtd"
 // CHECK-LINK-SYCL-DEBUG: "-defaultlib:sycl{{[0-9]*}}d.lib"
 // CHECK-LINK-SYCL-DEBUG-NOT: "--dependent-lib=sycl{{[0-9]*}}d"
 


### PR DESCRIPTION
A recent addition of adding sycld.lib on Windows when using the Linux based driver was performed.  There is additional tie-ins needed for general usage of debug libraries, which includes adding -D_DEBUG. Add the needed macro and also pull in the debug runtime library to match. This is done only for -fsycl based compilations as that is when we are pulling in these particular libraries.