### PR TITLE
[SYCL-MLIR] Lower SYCL device module to LLVM

### DIFF
--- a/polygeist/lib/polygeist/Passes/ConvertPolygeistToLLVM.cpp
+++ b/polygeist/lib/polygeist/Passes/ConvertPolygeistToLLVM.cpp
@@ -799,7 +799,7 @@ struct ConvertPolygeistToLLVMPass
           .add<LLVMOpLowering, GlobalOpTypeConversion, ReturnOpTypeConversion>(
               converter);
 
-      // TODO: This is a temporal solution. In the future, we might want to
+      // TODO: This is a temporary solution. In the future, we might want to
       // handle GPUDialect lowering by extending the GpuToLLVMConversionPass.
       patterns.add<GPUFuncOpToFuncOpConversion, GPUModuleOpToModuleOpConversion,
                    GPUReturnOpLowering, GPUModuleEndOpLowering>(converter);

--- a/polygeist/lib/polygeist/Passes/ConvertPolygeistToLLVM.cpp
+++ b/polygeist/lib/polygeist/Passes/ConvertPolygeistToLLVM.cpp
@@ -25,6 +25,7 @@
 #include "mlir/Dialect/Async/IR/Async.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Func/Transforms/Passes.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
@@ -692,6 +693,68 @@ struct ReturnOpTypeConversion : public ConvertOpToLLVMPattern<LLVM::ReturnOp> {
   }
 };
 
+struct GPUModuleOpToModuleOpConversion
+    : public ConvertOpToLLVMPattern<gpu::GPUModuleOp> {
+  using ConvertOpToLLVMPattern<gpu::GPUModuleOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(gpu::GPUModuleOp deviceModule, gpu::GPUModuleOp::Adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Copy contents to the parent module and erase the operation.
+    auto module = deviceModule->getParentOfType<ModuleOp>();
+    rewriter.mergeBlocks(deviceModule.getBody(), module.getBody(), {});
+    rewriter.eraseOp(deviceModule);
+    return success();
+  }
+};
+
+struct GPUFuncOpToFuncOpConversion
+    : public ConvertOpToLLVMPattern<gpu::GPUFuncOp> {
+  using ConvertOpToLLVMPattern<gpu::GPUFuncOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(gpu::GPUFuncOp gpuFuncOp, gpu::GPUFuncOp::Adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto module = gpuFuncOp->getParentOfType<ModuleOp>();
+
+    rewriter.setInsertionPointToEnd(module.getBody());
+    auto NewFuncOp = rewriter.create<func::FuncOp>(
+        gpuFuncOp.getLoc(), gpuFuncOp.getName(), gpuFuncOp.getFunctionType());
+    NewFuncOp->setAttrs(gpuFuncOp->getAttrs());
+    rewriter.notifyOperationInserted(NewFuncOp);
+
+    rewriter.inlineRegionBefore(gpuFuncOp.getBody(), NewFuncOp.getBody(),
+                                NewFuncOp.getBody().end());
+
+    rewriter.eraseOp(gpuFuncOp);
+
+    return success();
+  }
+};
+
+struct GPUModuleEndOpLowering
+    : public ConvertOpToLLVMPattern<gpu::ModuleEndOp> {
+  using ConvertOpToLLVMPattern<gpu::ModuleEndOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(gpu::ModuleEndOp op, gpu::ModuleEndOp::Adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct GPUReturnOpLowering : public ConvertOpToLLVMPattern<gpu::ReturnOp> {
+  using ConvertOpToLLVMPattern<gpu::ReturnOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(gpu::ReturnOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<LLVM::ReturnOp>(op, adaptor.getOperands());
+    return success();
+  }
+};
+
 struct ConvertPolygeistToLLVMPass
     : public ConvertPolygeistToLLVMBase<ConvertPolygeistToLLVMPass> {
   ConvertPolygeistToLLVMPass() = default;
@@ -735,6 +798,12 @@ struct ConvertPolygeistToLLVMPass
       patterns
           .add<LLVMOpLowering, GlobalOpTypeConversion, ReturnOpTypeConversion>(
               converter);
+
+      // TODO: This is a temporal solution. In the future, we might want to
+      // handle GPUDialect lowering by extending the GpuToLLVMConversionPass.
+      patterns.add<GPUFuncOpToFuncOpConversion, GPUModuleOpToModuleOpConversion,
+                   GPUReturnOpLowering, GPUModuleEndOpLowering>(converter);
+
       patterns.add<URLLVMOpLowering>(converter);
 
       // Legality callback for operations that checks whether their operand and
@@ -755,6 +824,7 @@ struct ConvertPolygeistToLLVMPass
       LLVMConversionTarget target(getContext());
       target.addDynamicallyLegalOp<omp::ParallelOp, omp::WsLoopOp>(
           [&](Operation *op) { return converter.isLegal(&op->getRegion(0)); });
+      target.addIllegalDialect<gpu::GPUDialect>();
       target.addIllegalOp<scf::ForOp, scf::IfOp, scf::ParallelOp, scf::WhileOp,
                           scf::ExecuteRegionOp, func::FuncOp>();
       target.addLegalOp<omp::TerminatorOp, omp::TaskyieldOp, omp::FlushOp,

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -77,7 +77,7 @@ private:
   std::map<const clang::RecordType *, mlir::LLVM::LLVMStructType> typeCache;
   std::deque<FunctionToEmit> functionsToEmit;
   mlir::OwningOpRef<mlir::ModuleOp> &module;
-  mlir::OwningOpRef<mlir::gpu::GPUModuleOp> &deviceModule;
+  mlir::gpu::GPUModuleOp deviceModule;
   clang::SourceManager &SM;
   llvm::LLVMContext lcontext;
   llvm::Module llvmMod;
@@ -101,8 +101,8 @@ public:
       std::map<std::string, mlir::LLVM::LLVMFuncOp> &llvmFunctions,
       clang::Preprocessor &PP, clang::ASTContext &astContext,
       mlir::OwningOpRef<mlir::ModuleOp> &module,
-      mlir::OwningOpRef<mlir::gpu::GPUModuleOp> &deviceModule,
-      clang::SourceManager &SM, clang::CodeGenOptions &codegenops)
+      mlir::gpu::GPUModuleOp deviceModule, clang::SourceManager &SM,
+      clang::CodeGenOptions &codegenops)
       : emitIfFound(emitIfFound), done(done),
         llvmStringGlobals(llvmStringGlobals), globals(globals),
         functions(functions), deviceFunctions(deviceFunctions),
@@ -180,7 +180,7 @@ private:
   MLIRASTConsumer &Glob;
   mlir::FunctionOpInterface function;
   mlir::OwningOpRef<mlir::ModuleOp> &module;
-  mlir::OwningOpRef<mlir::gpu::GPUModuleOp> &deviceModule;
+  mlir::gpu::GPUModuleOp deviceModule;
   mlir::OpBuilder builder;
   mlir::Location loc;
   mlir::Block *entryBlock;
@@ -261,8 +261,7 @@ private:
 
 public:
   MLIRScanner(MLIRASTConsumer &Glob, mlir::OwningOpRef<mlir::ModuleOp> &module,
-              mlir::OwningOpRef<mlir::gpu::GPUModuleOp> &deviceModule,
-              LowerToInfo &LTInfo);
+              mlir::gpu::GPUModuleOp deviceModule, LowerToInfo &LTInfo);
 
   void init(mlir::FunctionOpInterface function, const FunctionToEmit &fd);
 

--- a/polygeist/tools/cgeist/Lib/utils.cc
+++ b/polygeist/tools/cgeist/Lib/utils.cc
@@ -80,7 +80,9 @@ bool mlirclang::isNamespaceSYCL(const clang::DeclContext *DC) {
 }
 
 FunctionContext mlirclang::getInputContext(const OpBuilder &Builder) {
-  return Builder.getInsertionBlock()->getParentOp()->getParentOfType<ModuleOp>()
-             ? FunctionContext::Host
-             : FunctionContext::SYCLDevice;
+  return Builder.getInsertionBlock()
+                 ->getParentOp()
+                 ->getParentOfType<gpu::GPUModuleOp>()
+             ? FunctionContext::SYCLDevice
+             : FunctionContext::Host;
 }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -8,21 +8,31 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: sycl-clang.py %s -S | FileCheck %s
+// RUN: sycl-clang.py %s -S | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: sycl-clang.py %s -S -emit-llvm | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 
-// CHECK-NOT: module
+// CHECK-MLIR: !sycl_accessor_1_i32_read_write_global_buffer = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>
+// CHECK-MLIR: !sycl_id_1_ = !sycl.id<1>
+// CHECK-MLIR: !sycl_item_1_1_ = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>
+// CHECK-MLIR: !sycl_range_1_ = !sycl.range<1>
 
-// CHECK: !sycl_accessor_1_i32_read_write_global_buffer = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>
-// CHECK: !sycl_id_1_ = !sycl.id<1>
-// CHECK: !sycl_item_1_1_ = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>
-// CHECK: !sycl_range_1_ = !sycl.range<1>
+// CHECK-LLVM: %"class.cl::sycl::accessor.1" = type { %"class.cl::sycl::detail::AccessorImplDevice.1", { i32 addrspace(1)* }, { i32 addrspace(1)* } }
+// CHECK-LLVM: %"class.cl::sycl::detail::AccessorImplDevice.1" = type { %"class.cl::sycl::id.1", %"class.cl::sycl::range.1", %"class.cl::sycl::range.1" }
+// CHECK-LLVM: %"class.cl::sycl::id.1" = type { %"class.cl::sycl::detail::array.1" }
+// CHECK-LLVM: %"class.cl::sycl::detail::array.1" = type { [1 x i64] }
+// CHECK-LLVM: %"class.cl::sycl::range.1" = type { %"class.cl::sycl::detail::array.1" }
+// CHECK-LLVM: %"class.cl::sycl::item.1.true" = type { %"class.cl::sycl::detail::ItemBase.1.true" }
+// CHECK-LLVM: %"class.cl::sycl::detail::ItemBase.1.true" = type { %"class.cl::sycl::range.1", %"class.cl::sycl::id.1", %"class.cl::sycl::id.1" }
 
-// CHECK: gpu.module @device_functions
-// CHECK: gpu.func @_ZTS8kernel_1(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
-// CHECK-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
-// CHECK-NOT: gpu.func kernel
+// CHECK-MLIR: gpu.module @device_functions
+// CHECK-MLIR: gpu.func @_ZTS8kernel_1(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
+// CHECK-MLIR-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
+// CHECK-MLIR-NOT: gpu.func kernel
+
+// CHECK-LLVM:      ; Function Attrs: convergent mustprogress norecurse nounwind
+// CHECK-LLVM-NEXT: define weak_odr spir_kernel void @_ZTS8kernel_1(i32* %0, i32* %1, i64 %2, i64 %3, i64 %4, %"class.cl::sycl::range.1" %5, %"class.cl::sycl::range.1" %6, %"class.cl::sycl::id.1" %7) #0 {
 
 class kernel_1 {
  sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write> A;
@@ -49,9 +59,12 @@ void host_1() {
   }
 }
 
-// CHECK: gpu.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
-// CHECK-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
-// CHECK-NOT: gpu.func kernel
+// CHECK-MLIR: gpu.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
+// CHECK-MLIR-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
+// CHECK-MLIR-NOT: gpu.func kernel
+
+// CHECK-LLVM:      ; Function Attrs: convergent mustprogress norecurse nounwind
+// CHECK-LLVM-NEXT: define weak_odr spir_kernel void @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2(i32* %0, i32* %1, i64 %2, i64 %3, i64 %4, %"class.cl::sycl::range.1" %5, %"class.cl::sycl::range.1" %6, %"class.cl::sycl::id.1" %7) #0 {
 
 void host_2() {
   auto q = sycl::queue{};
@@ -68,7 +81,7 @@ void host_2() {
   }
 }
 
-// CHECK-NOT: SYCLKernel =
+// CHECK-MLIR-NOT: SYCLKernel =
 SYCL_EXTERNAL void function_1(sycl::item<2, true> item) {
   auto id = item.get_id(0);
 }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
@@ -8,23 +8,29 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: sycl-clang.py %s -S | FileCheck %s
+// RUN: sycl-clang.py %s -S | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: sycl-clang.py %s -S -emit-llvm | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 
-// CHECK-NOT: module
-
-// CHECK: gpu.module @device_functions
+// CHECK-MLIR: gpu.module @device_functions
 //
-// CHECK-DAG: gpu.func @_ZTS8kernel_1
-// CHECK-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
-// CHECK-DAG: gpu.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2
-// CHECK-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
-// CHECK-DAG: func.func @_ZN12StoreWrapperIiLi1ELN4sycl3_V16access4modeE1026EEC1ENS1_8accessorIiLi1ELS3_1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS1_3ext6oneapi22accessor_property_listIJEEEEENS1_2idILi1EEERKi
-// CHECK-SAME: attributes {llvm.linkage = #llvm.linkage<linkonce_odr>}
+// CHECK-MLIR-DAG:  gpu.func @_ZTS8kernel_1
+// CHECK-MLIR-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
+// CHECK-MLIR-DAG:  gpu.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2
+// CHECK-MLIR-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
+// CHECK-MLIR-DAG:  func.func @_ZN12StoreWrapperIiLi1ELN4sycl3_V16access4modeE1026EEC1ENS1_8accessorIiLi1ELS3_1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS1_3ext6oneapi22accessor_property_listIJEEEEENS1_2idILi1EEERKi
+// CHECK-MLIR-SAME: attributes {llvm.linkage = #llvm.linkage<linkonce_odr>}
 // COM: StoreWrapper constructor:
-// CHECK-DAG: func.func @_ZN12StoreWrapperIiLi1ELN4sycl3_V16access4modeE1026EEclEv
-// CHECK-SAME: attributes {llvm.linkage = #llvm.linkage<linkonce_odr>}
+// CHECK-MLIR-DAG: func.func @_ZN12StoreWrapperIiLi1ELN4sycl3_V16access4modeE1026EEclEv
+// CHECK-MLIR-SAME: attributes {llvm.linkage = #llvm.linkage<linkonce_odr>}
+
+// COM: StoreWrapper constructor:
+// CHECK-LLVM:      define linkonce_odr void @_ZN12StoreWrapperIiLi1ELN4sycl3_V16access4modeE1026EEclEv({ %"class.cl::sycl::accessor.1", %"class.cl::sycl::id.1", i32 }* %0, { %"class.cl::sycl::accessor.1", %"class.cl::sycl::id.1", i32 }* %1, i64 %2, i64 %3, i64 %4) {
+
+// CHECK-LLVM:      define weak_odr spir_kernel void @_ZTS8kernel_1(i32* %0, i32* %1, i64 %2, i64 %3, i64 %4, %"class.cl::sycl::range.1" %5, %"class.cl::sycl::range.1" %6, %"class.cl::sycl::id.1" %7) #0 {
+// CHECK-LLVM:      ; Function Attrs: convergent mustprogress norecurse nounwind
+// CHECK-LLVM-NEXT: define weak_odr spir_kernel void @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2(i32* %0, i32* %1, i64 %2, i64 %3, i64 %4, %"class.cl::sycl::range.1" %5, %"class.cl::sycl::range.1" %6, %"class.cl::sycl::id.1" %7) #0 {
 
 template <typename DataT,
           int Dimensions = 1,

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -931,9 +931,8 @@ static void eraseHostCode(mlir::ModuleOp module) {
   SmallVector<std::reference_wrapper<Operation>> ToRemove;
   std::copy_if(module.begin(), module.end(), std::back_inserter(ToRemove),
                [](Operation &Op) { return !isa<mlir::gpu::GPUModuleOp>(Op); });
-  for (auto Op : ToRemove) {
+  for (auto Op : ToRemove)
     Op.get().erase();
-  }
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Introduce SYCL device module inside the host module, which should be marked as a "gpu_container" if it contains device code. Also, the device module is no longer held in an OwningOpRef, as it will be removed by the lowering pass.

Define a temportal solution to lower GPU operations, which are lowered as if they were their regular counterparts:

- GPUReturnOp: replace by an LLVM return (as in the original GPU to LLVM pass);
- GPUModuleOp: Copy code to parent module and erase;
- ModuleEndOp: Erase;
- GPUFuncOp: Copy code to a new FuncOp in the host module and erase.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>