### PR TITLE
[SYCL-MLIR] Add temp. option `-use-gpu-module`

### DIFF
--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -70,6 +70,10 @@ static cl::opt<bool>
     CombinedStructABI("struct-abi", cl::init(true),
                       cl::desc("Use literal LLVM ABI for structs"));
 
+static cl::opt<bool>
+    useGPUModule("use-gpu-module", cl::init(false),
+                 cl::desc("Use GPUModuleOp for SYCL kernels."));
+
 bool isLLVMStructABI(const RecordDecl *RD, llvm::StructType *ST) {
   if (!CombinedStructABI)
     return true;
@@ -5089,7 +5093,7 @@ mlir::FunctionOpInterface MLIRASTConsumer::GetOrCreateMLIRFunction(
     auto funcType = builder.getFunctionType(types, rettypes);
     const auto loc = getMLIRLocation(FD->getLocation());
 
-    if (FD->hasAttr<SYCLKernelAttr>()) {
+    if (useGPUModule && FD->hasAttr<SYCLKernelAttr>()) {
       auto function = builder.create<gpu::GPUFuncOp>(loc, name, funcType,
                                                      TypeRange{}, TypeRange{});
       // SYCL kernels must be always located in a SYCL device context.

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -9,6 +9,8 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: sycl-clang.py %s -S | FileCheck %s
+// XFAIL: *
+// xfailed because of issue #6915
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
@@ -9,6 +9,8 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: sycl-clang.py %s -S | FileCheck %s
+// XFAIL: *
+// xfailed because of issue #6915
 
 #include <sycl/sycl.hpp>
 


### PR DESCRIPTION
Disable adding SYCL kernel functions to GPUModuleOp by default. Use `-use-gpu-module` to change the default behaviour.

Signed-off-by: Tiotto, Ettore <ettore.tiotto@intel.com>