### PR TITLE
[SYCL-MLIR] Take into account function context in the done set

### DIFF
--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -5149,7 +5149,9 @@ void MLIRASTConsumer::run() {
     std::string mangledName;
     MLIRScanner::getMangledFuncName(mangledName, FD, CGM);
 
-    if (done.count(mangledName))
+    const std::pair<FunctionContext, std::string> doneKey(F.getContext(),
+                                                          mangledName);
+    if (done.count(doneKey))
       continue;
 
     LLVM_DEBUG({
@@ -5162,7 +5164,7 @@ void MLIRASTConsumer::run() {
                    << " --\n\n";
     });
 
-    done.insert(mangledName);
+    done.insert(doneKey);
     MLIRScanner ms(*this, module, deviceModule, LTInfo);
     FunctionOpInterface function = GetOrCreateMLIRFunction(F, true);
     ms.init(function, F);
@@ -5929,7 +5931,7 @@ llvm::Type *MLIRASTConsumer::getLLVMType(clang::QualType t) {
 class MLIRAction : public clang::ASTFrontendAction {
 public:
   std::set<std::string> emitIfFound;
-  std::set<std::string> done;
+  std::set<std::pair<FunctionContext, std::string>> done;
   mlir::OwningOpRef<mlir::ModuleOp> &module;
   mlir::gpu::GPUModuleOp deviceModule;
   std::map<std::string, mlir::LLVM::GlobalOp> llvmStringGlobals;

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -106,7 +106,7 @@ private:
 struct MLIRASTConsumer : public clang::ASTConsumer {
 private:
   std::set<std::string> &emitIfFound;
-  std::set<std::string> &done;
+  std::set<std::pair<FunctionContext, std::string>> &done;
   std::map<std::string, mlir::LLVM::GlobalOp> &llvmStringGlobals;
   std::map<std::string, std::pair<mlir::memref::GlobalOp, bool>> &globals;
   std::map<std::string, mlir::func::FuncOp> &functions;
@@ -131,7 +131,8 @@ private:
 
 public:
   MLIRASTConsumer(
-      std::set<std::string> &emitIfFound, std::set<std::string> &done,
+      std::set<std::string> &emitIfFound,
+      std::set<std::pair<FunctionContext, std::string>> &done,
       std::map<std::string, mlir::LLVM::GlobalOp> &llvmStringGlobals,
       std::map<std::string, std::pair<mlir::memref::GlobalOp, bool>> &globals,
       std::map<std::string, mlir::func::FuncOp> &functions,

--- a/polygeist/tools/cgeist/Test/Verification/sycl/extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/extern_func.cpp
@@ -1,0 +1,31 @@
+#include <sycl/sycl.hpp>
+
+// RUN: sycl-clang.py %s -S | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: sycl-clang.py %s -S -emit-llvm | FileCheck %s --check-prefix=CHECK-LLVM
+
+// CHECK-MLIR-LABEL: func.func @cons_5() attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR:           sycl.constructor(%{{.*}})
+// CHECK-MLIR-NEXT:      return
+
+// CHECK-LLVM-LABEL: define spir_func void @cons_5() #0 {
+// CHECK-LLVM-NEXT:  %{{.*}} = alloca %"class.cl::sycl::accessor.1", i64 ptrtoint (%"class.cl::sycl::accessor.1"* getelementptr (%"class.cl::sycl::accessor.1", %"class.cl::sycl::accessor.1"* null, i32 1) to i64), align 8
+// CHECK-LLVM-NEXT:  call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.cl::sycl::accessor.1"* %1, %"class.cl::sycl::accessor.1"* %1, i64 0, i64 1, i64 1)
+// CHECK-LLVM-NEXT:  ret void
+
+
+extern "C" SYCL_EXTERNAL void cons_5() {
+  sycl::accessor<sycl::cl_int, 1, sycl::access::mode::write> accessor;
+}
+
+void host_single_task() {
+  auto q = sycl::queue{};
+  auto range = sycl::range<1>{1};
+  auto buf = sycl::buffer<int, 1>{nullptr, range};
+  q.submit([&](sycl::handler &cgh) {
+    auto A = buf.get_access<sycl::access::mode::write>(cgh);
+    cgh.single_task<class kernel_single_task>([=]() {
+      cons_5();
+      A[0] = 42;
+    });
+  });
+}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -1,7 +1,17 @@
-#include <sycl/sycl.hpp>
+// Copyright (C) Intel
+
+//===--- sycl_extern_func.cpp ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
 
 // RUN: sycl-clang.py %s -S | FileCheck %s --check-prefix=CHECK-MLIR
 // RUN: sycl-clang.py %s -S -emit-llvm | FileCheck %s --check-prefix=CHECK-LLVM
+
+#include <sycl/sycl.hpp>
 
 // CHECK-MLIR-LABEL: func.func @cons_5() attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-MLIR:           sycl.constructor(%{{.*}})

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -13,15 +13,32 @@
 
 #include <sycl/sycl.hpp>
 
+// CHECK-MLIR: gpu.module @device_functions
+
+// CHECK-MLIR-LABEL: gpu.func @_ZTSZZ16host_single_taskvENKUlRN4sycl3_V17handlerEE_clES2_E18kernel_single_task
+// CHECK-MLIR-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+
+// CHECK-MLIR-LABEL: func.func private @_ZZZ16host_single_taskvENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEv
+// CHECK-MLIR-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<internal>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: call @cons_5() : () -> ()
+
 // CHECK-MLIR-LABEL: func.func @cons_5() attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-MLIR:           sycl.constructor(%{{.*}})
 // CHECK-MLIR-NEXT:      return
+
+// CHECK-LLMV-LABEL: define weak_odr spir_kernel void @_ZTSZZ16host_single_taskvENKUlRN4sycl3_V17handlerEE_clES2_E18kernel_single_task
+// CHECK-SAME: #0
+
+// CHECK-LLVM-LABEL: define internal spir_func void @_ZZZ16host_single_taskvENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEv
+// CHECK-LLVM-SAME: #0
+// CHECK: call void @cons_5()
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_5() #0 {
 // CHECK-LLVM-NEXT:  %{{.*}} = alloca %"class.cl::sycl::accessor.1", i64 ptrtoint (%"class.cl::sycl::accessor.1"* getelementptr (%"class.cl::sycl::accessor.1", %"class.cl::sycl::accessor.1"* null, i32 1) to i64), align 8
 // CHECK-LLVM-NEXT:  call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.cl::sycl::accessor.1"* %1, %"class.cl::sycl::accessor.1"* %1, i64 0, i64 1, i64 1)
 // CHECK-LLVM-NEXT:  ret void
 
+// CHECK-LLVM: attributes #0 = { convergent mustprogress norecurse nounwind }
 
 extern "C" SYCL_EXTERNAL void cons_5() {
   sycl::accessor<sycl::cl_int, 1, sycl::access::mode::write> accessor;


### PR DESCRIPTION
The done set now contains pairs with the names and contexts of functions already emited. In order to make this work, we have to sort the calls to done and GetOrCreateMLIRFunction when emitting functions:

1. GetOrCreateMLIRFunction (to override context as per the function's attributes);
2. Check if it is done;
3. Skip if done, else mark as done

Signed-off-by: Victor Perez <victor.perez@codeplay.com>