### PR TITLE
[SYCL] Build fixes for Apple silicon

### DIFF
--- a/sycl/source/detail/platform_util.cpp
+++ b/sycl/source/detail/platform_util.cpp
@@ -41,37 +41,6 @@ uint32_t PlatformUtil::getMaxClockFrequency() {
   throw runtime_error(
       "max_clock_frequency parameter is not supported for host device",
       PI_ERROR_INVALID_DEVICE);
-#if defined(__x86_64__) || defined(__i386__)
-  uint32_t CPUInfo[4];
-  std::string Buff(sizeof(CPUInfo) * 3 + 1, 0);
-  size_t Offset = 0;
-
-  for (uint32_t i = 0x80000002; i <= 0x80000004; i++) {
-    cpuid(CPUInfo, i);
-    std::copy(reinterpret_cast<char *>(CPUInfo),
-              reinterpret_cast<char *>(CPUInfo) + sizeof(CPUInfo),
-              Buff.begin() + Offset);
-    Offset += sizeof(CPUInfo);
-  }
-  std::size_t Found = Buff.rfind("Hz");
-  // Bail out if frequency is not found in CPUID string
-  if (Found == std::string::npos)
-    return 0;
-
-  Buff = Buff.substr(0, Found);
-  uint32_t Freq = 0;
-  switch (Buff[Buff.size() - 1]) {
-  case 'M':
-    Freq = 1;
-    break;
-  case 'G':
-    Freq = 1000;
-    break;
-  }
-  Buff = Buff.substr(Buff.rfind(' '), Buff.length());
-  Freq *= std::stod(Buff);
-  return Freq;
-#endif
   return 0;
 }
 

--- a/sycl/source/detail/platform_util.cpp
+++ b/sycl/source/detail/platform_util.cpp
@@ -18,7 +18,7 @@
 #endif
 #elif defined(__SYCL_RT_OS_WINDOWS)
 #include <intrin.h>
-#elif defined(__SYCL_RT_OS_DARWIN)
+#elif defined(__SYCL_RT_OS_DARWIN) && defined(__x86_64__)
 #include <cpuid.h>
 #endif
 

--- a/sycl/source/detail/platform_util.cpp
+++ b/sycl/source/detail/platform_util.cpp
@@ -18,8 +18,10 @@
 #endif
 #elif defined(__SYCL_RT_OS_WINDOWS)
 #include <intrin.h>
-#elif defined(__SYCL_RT_OS_DARWIN) && defined(__x86_64__)
+#elif defined(__SYCL_RT_OS_DARWIN)
+#if defined(__x86_64__) || defined(__i386__)
 #include <cpuid.h>
+#endif
 #endif
 
 namespace sycl {

--- a/xptifw/include/spin_lock.hpp
+++ b/xptifw/include/spin_lock.hpp
@@ -12,7 +12,7 @@
 #define __has_include(x)
 #endif
 
-#if __has_include(<immintrin.h>)
+#if __has_include(<immintrin.h>) && defined(__x86_64__)
 #define HAS_PAUSE
 #include <immintrin.h>
 #endif


### PR DESCRIPTION
Added more macro guards when including `immintrin.h` and `cpuid.h`.
Removed dead code from `PlatformUtil::getMaxClockFrequency`.

With this fixes, the project can be built on Apple silicon (M1).

Signed-off-by: Alexey Sachkov <sachkov2011@gmail.com>