### PR TITLE
[SYCL][MacOS] Implement OSUtils::getCurrentDSODir for Darwin OS

### DIFF
--- a/sycl/source/detail/os_util.cpp
+++ b/sycl/source/detail/os_util.cpp
@@ -233,7 +233,20 @@ OSModuleHandle OSUtil::getOSModuleHandle(const void *VirtAddr) {
   return reinterpret_cast<OSModuleHandle>(Res.dli_fbase);
 }
 
-std::string OSUtil::getCurrentDSODir() { return ""; }
+std::string OSUtil::getCurrentDSODir() {
+  auto CurrentFunc = reinterpret_cast<const void *>(&getCurrentDSODir);
+  Dl_info Info;
+  int RetCode = dladdr(CurrentFunc, &Info);
+  if (0 == RetCode) {
+    // This actually indicates an error
+    return "";
+  }
+
+  auto Path = std::string(Info.dli_fname);
+  auto LastSlashPos = Path.find_last_of('/');
+
+  return Path.substr(0, LastSlashPos);
+}
 
 #endif // __SYCL_RT_OS
 

--- a/sycl/unittests/misc/OsUtils.cpp
+++ b/sycl/unittests/misc/OsUtils.cpp
@@ -39,12 +39,12 @@ bool isSameDir(const char* LHS, const char* RHS) {
   struct stat StatBuf;
   if (stat(LHS, &StatBuf)) {
     perror("stat failed");
-    exit(EXIT_FAILURE);
+    return false;
   }
   ino_t InodeLHS = StatBuf.st_ino;
   if (stat(RHS, &StatBuf)) {
     perror("stat failed");
-    exit(EXIT_FAILURE);
+    return false;
   }
   ino_t InodeRHS = StatBuf.st_ino;
   return InodeRHS == InodeLHS;


### PR DESCRIPTION
This patch fixes misc.OsUtils unit-test.

Signed-off-by: Alexey Sachkov <sachkov2011@gmail.com>