### PR TITLE
[SYCL-MLIR] Replace calls to some methods with new operations

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -110,6 +110,8 @@ def SYCLMemref : AnyTypeOf<[
 ]>;
 def IndexType : AnyTypeOf<[I32, I64, Index]>;
 def SYCLGetResult : AnyTypeOf<[I64, MemRefOf<[I64]>]>;
+def SYCLGetIDResult : AnyTypeOf<[I64, SYCL_IDType]>;
+def SYCLGetRangeResult : AnyTypeOf<[I64, SYCL_RangeType]>;
 
 ////////////////////////////////////////////////////////////////////////////////
 // CONSTRUCTOR OPERATION
@@ -238,14 +240,16 @@ def SYCLAccessorSubscriptOp
 
 def SYCLRangeGetOp
     : SYCLMethodOpInterfaceImpl<"range.get", "RangeType",
-                                ["get", "operator[]"], [NoSideEffect]> {
-  let summary = "Call to range::get/operator[]";
+                                ["get", "operator[]", "operator unsigned long"],
+                                [NoSideEffect]> {
+  let summary = "Call to range::get/operator[]/operator unsigned long";
   let description = [{
-    This operation represents a call to the range::get/operator[] functions.
+    This operation represents a call to the
+    range::get/operator[]/operator unsigned long functions.
   }];
 
   let arguments = (ins RangeMemRef:$Range,
-                       I32:$Index,
+                       Optional<I32>:$Index,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
                        FlatSymbolRefAttr:$MangledFunctionName,
@@ -269,6 +273,509 @@ def SYCLRangeSizeOp
   }];
 
   let arguments = (ins RangeMemRef:$Range,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs I64:$Res);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// id.get OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLIDGetOp
+    : SYCLMethodOpInterfaceImpl<"id.get", "IDType",
+                                ["get", "operator[]", "operator unsigned long"],
+                                [NoSideEffect]> {
+  let summary = "Call to id::get/operator[]/operator size_t";
+  let description = [{
+    This operation represents a call to the id::get/operator[]/operator size_t functions.
+  }];
+
+  let arguments = (ins IDMemRef:$ID,
+                       Optional<I32>:$Index,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs SYCLGetResult:$Res);
+
+  let hasVerifier = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// item.get_id OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLItemGetIDOp
+    : SYCLMethodOpInterfaceImpl<"item.get_id", "ItemType",
+                                ["get_id", "operator[]", "operator unsigned long"],
+                                [NoSideEffect]> {
+  let summary = "Call to item::get/operator[]/operator size_t";
+  let description = [{
+    This operation represents a call to the item::get/operator[]/operator size_t functions.
+  }];
+
+  let arguments = (ins ItemMemRef:$Item,
+                       Optional<I32>:$Index,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs SYCLGetIDResult:$Res);
+
+  let hasVerifier = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// item.get_range OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLItemGetRangeOp
+    : SYCLMethodOpInterfaceImpl<"item.get_range", "ItemType",
+                                ["get_range"], [NoSideEffect]> {
+  let summary = "Call to item::get_range";
+  let description = [{
+    This operation represents a call to the item::get_range function.
+  }];
+
+  let arguments = (ins ItemMemRef:$Item,
+                       Optional<I32>:$Index,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs SYCLGetRangeResult:$Res);
+
+  let hasVerifier = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// item.get_linear_id OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLItemGetLinearIDOp
+    : SYCLMethodOpInterfaceImpl<"item.get_linear_id", "ItemType",
+                                ["get_linear_id"], [NoSideEffect]> {
+  let summary = "Call to item::get_linear_id";
+  let description = [{
+    This operation represents a call to the item::get_linear_id function.
+  }];
+
+  let arguments = (ins ItemMemRef:$Item,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs I64:$Res);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// nd_item.get_global_id OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLNDItemGetGlobalIDOp
+    : SYCLMethodOpInterfaceImpl<"nd_item.get_global_id", "NdItemType",
+                                ["get_global_id"], [NoSideEffect]> {
+  let summary = "Call to nd_item::get_global_id";
+  let description = [{
+    This operation represents a call to the nd_item::get_global_id function.
+  }];
+
+  let arguments = (ins NDItemMemRef:$NDItem,
+                       Optional<I32>:$Index,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs SYCLGetIDResult:$Res);
+
+  let hasVerifier = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// nd_item.get_global_linear_id OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLNDItemGetGlobalLinearIDOp
+    : SYCLMethodOpInterfaceImpl<"nd_item.get_global_linear_id", "NdItemType",
+                                ["get_global_linear_id"], [NoSideEffect]> {
+  let summary = "Call to nd_item::get_global_linear_id";
+  let description = [{
+    This operation represents a call to the nd_item::get_global_linear_id function.
+  }];
+
+  let arguments = (ins NDItemMemRef:$NDItem,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs I64:$Res);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// nd_item.get_local_id OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLNDItemGetLocalIDOp
+    : SYCLMethodOpInterfaceImpl<"nd_item.get_local_id", "NdItemType",
+                                ["get_local_id"], [NoSideEffect]> {
+  let summary = "Call to nd_item::get_local_id";
+  let description = [{
+    This operation represents a call to the nd_item::get_local_id function.
+  }];
+
+  let arguments = (ins NDItemMemRef:$NDItem,
+                       Optional<I32>:$Index,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs SYCLGetIDResult:$Res);
+
+  let hasVerifier = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// nd_item.get_local_linear_id OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLNDItemGetLocalLinearIDOp
+    : SYCLMethodOpInterfaceImpl<"nd_item.get_local_linear_id", "NdItemType",
+                                ["get_local_linear_id"], [NoSideEffect]> {
+  let summary = "Call to nd_item::get_local_linear_id";
+  let description = [{
+    This operation represents a call to the nd_item::get_local_linear_id function.
+  }];
+
+  let arguments = (ins NDItemMemRef:$NDItem,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs I64:$Res);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// nd_item.get_group OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLNDItemGetGroupOp
+    : SYCLMethodOpInterfaceImpl<"nd_item.get_group", "NdItemType",
+                                ["get_group"], [NoSideEffect]> {
+  let summary = "Call to nd_item::get_group";
+  let description = [{
+    This operation represents a call to the nd_item::get_group function.
+  }];
+
+  let arguments = (ins NDItemMemRef:$NDItem,
+                       Optional<I32>:$Index,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs AnyTypeOf<[I64, SYCL_GroupType]>:$Res);
+
+  let hasVerifier = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// nd_item.get_group_linear_id OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLNDItemGetGroupLinearIDOp
+    : SYCLMethodOpInterfaceImpl<"nd_item.get_group_linear_id", "NdItemType",
+                                ["get_group_linear_id"], [NoSideEffect]> {
+  let summary = "Call to nd_item::get_group_linear_id";
+  let description = [{
+    This operation represents a call to the nd_item::get_group_linear_id function.
+  }];
+
+  let arguments = (ins NDItemMemRef:$NDItem,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs I64:$Res);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// nd_item.get_group_range OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLNDItemGetGroupRangeOp
+    : SYCLMethodOpInterfaceImpl<"nd_item.get_group_range", "NdItemType",
+                                ["get_group_range"], [NoSideEffect]> {
+  let summary = "Call to nd_item::get_group_range";
+  let description = [{
+    This operation represents a call to the nd_item::get_group_range function.
+  }];
+
+  let arguments = (ins NDItemMemRef:$NDItem,
+                       Optional<I32>:$Index,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs SYCLGetRangeResult:$Res);
+
+  let hasVerifier = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// nd_item.get_global_range OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLNDItemGetGlobalRangeOp
+    : SYCLMethodOpInterfaceImpl<"nd_item.get_global_range", "NdItemType",
+                                ["get_global_range"], [NoSideEffect]> {
+  let summary = "Call to nd_item::get_global_range";
+  let description = [{
+    This operation represents a call to the nd_item::get_global_range function.
+  }];
+
+  let arguments = (ins NDItemMemRef:$NDItem,
+                       Optional<I32>:$Index,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs SYCLGetRangeResult:$Res);
+
+  let hasVerifier = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// nd_item.get_local_range OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLNDItemGetLocalRangeOp
+    : SYCLMethodOpInterfaceImpl<"nd_item.get_local_range", "NdItemType",
+                                ["get_local_range"], [NoSideEffect]> {
+  let summary = "Call to nd_item::get_local_range";
+  let description = [{
+    This operation represents a call to the nd_item::get_local_range function.
+  }];
+
+  let arguments = (ins NDItemMemRef:$NDItem,
+                       Optional<I32>:$Index,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs SYCLGetRangeResult:$Res);
+
+  let hasVerifier = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// group.get_group_id OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLGroupGetGroupIDOp
+    : SYCLMethodOpInterfaceImpl<"group.get_group_id", "GroupType",
+                                ["get_group_id", "operator[]"], [NoSideEffect]> {
+  let summary = "Call to group::get_group_id/operator[]";
+  let description = [{
+    This operation represents a call to the group::get_group_id/operator[] functions.
+  }];
+
+  let arguments = (ins GroupMemRef:$Group,
+                       Optional<I32>:$Index,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs SYCLGetIDResult:$Res);
+
+  let hasVerifier = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// group.get_local_id OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLGroupGetLocalIDOp
+    : SYCLMethodOpInterfaceImpl<"group.get_local_id", "GroupType",
+                                ["get_local_id"], [NoSideEffect]> {
+  let summary = "Call to group::get_local_id";
+  let description = [{
+    This operation represents a call to the group::get_local_id function.
+  }];
+
+  let arguments = (ins GroupMemRef:$Group,
+                       Optional<I32>:$Index,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs SYCLGetIDResult:$Res);
+
+  let hasVerifier = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// group.get_local_range OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLGroupGetLocalRangeOp
+    : SYCLMethodOpInterfaceImpl<"group.get_local_range", "GroupType",
+                                ["get_local_range"], [NoSideEffect]> {
+  let summary = "Call to group::get_local_range";
+  let description = [{
+    This operation represents a call to the group::get_local_range function.
+  }];
+
+  let arguments = (ins GroupMemRef:$Group,
+                       Optional<I32>:$Index,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs SYCLGetRangeResult:$Res);
+
+  let hasVerifier = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// group.get_group_range OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLGroupGetGroupRangeOp
+    : SYCLMethodOpInterfaceImpl<"group.get_group_range", "GroupType",
+                                ["get_group_range"], [NoSideEffect]> {
+  let summary = "Call to group::get_group_range";
+  let description = [{
+    This operation represents a call to the group::get_group_range function.
+  }];
+
+  let arguments = (ins GroupMemRef:$Group,
+                       Optional<I32>:$Index,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs SYCLGetRangeResult:$Res);
+
+  let hasVerifier = 1;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// group.get_max_local_range OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLGroupGetMaxLocalRangeOp
+    : SYCLMethodOpInterfaceImpl<"group.get_max_local_range", "GroupType",
+                                ["get_max_local_range"], [NoSideEffect]> {
+  let summary = "Call to group::get_max_local_range";
+  let description = [{
+    This operation represents a call to the group::get_max_local_range function.
+  }];
+
+  let arguments = (ins GroupMemRef:$Group,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs SYCL_RangeType:$Res);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// group.get_group_linear_id OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLGroupGetGroupLinearIDOp
+    : SYCLMethodOpInterfaceImpl<"group.get_group_linear_id", "GroupType",
+                                ["get_group_linear_id"], [NoSideEffect]> {
+  let summary = "Call to group::get_group_linear_id";
+  let description = [{
+    This operation represents a call to the group::get_group_linear_id function.
+  }];
+
+  let arguments = (ins GroupMemRef:$Group,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs I64:$Res);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// group.get_local_linear_id OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLGroupGetLocalLinearIDOp
+    : SYCLMethodOpInterfaceImpl<"group.get_local_linear_id", "GroupType",
+                                ["get_local_linear_id"], [NoSideEffect]> {
+  let summary = "Call to group::get_local_linear_id";
+  let description = [{
+    This operation represents a call to the group::get_local_linear_id function.
+  }];
+
+  let arguments = (ins GroupMemRef:$Group,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs I64:$Res);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// group.get_group_linear_range OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+ def SYCLGroupGetGroupLinearRangeOp
+    : SYCLMethodOpInterfaceImpl<"group.get_group_linear_range", "GroupType",
+                                ["get_group_linear_range"], [NoSideEffect]> {
+  let summary = "Call to group::get_group_linear_range";
+  let description = [{
+    This operation represents a call to the group::get_group_linear_range function.
+  }];
+
+  let arguments = (ins GroupMemRef:$Group,
+                       TypeAttr:$BaseType,
+                       FlatSymbolRefAttr:$FunctionName,
+                       FlatSymbolRefAttr:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs I64:$Res);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// group.get_local_linear_range OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLGroupGetLocalLinearRangeOp
+    : SYCLMethodOpInterfaceImpl<"group.get_local_linear_range", "GroupType",
+                                ["get_local_linear_range"], [NoSideEffect]> {
+  let summary = "Call to group::get_local_linear_range";
+  let description = [{
+    This operation represents a call to the group::get_local_linear_range function.
+  }];
+
+  let arguments = (ins GroupMemRef:$Group,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
                        FlatSymbolRefAttr:$MangledFunctionName,

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
@@ -448,7 +448,8 @@ public:
 
 class GroupType
     : public Type::TypeBase<GroupType, Type, detail::GroupTypeStorage,
-                            mlir::MemRefElementTypeInterface::Trait> {
+                            mlir::MemRefElementTypeInterface::Trait,
+                            mlir::LLVM::PointerElementTypeInterface::Trait> {
 public:
   using Base::Base;
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -101,28 +101,404 @@ SYCL_EXTERNAL void range_size(sycl::range<2> r) {
   keep(r.size());
 }
 
-// CHECK-MLIR: func.func @_Z8method_1N4sycl3_V14itemILi2ELb1EEE(%arg0: !sycl_item_2_1_)
-// CHECK-MLIR-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
-// CHECK-MLIR-NEXT: %c0_i32 = arith.constant 0 : i32
-// CHECK-MLIR-NEXT: %0 = memref.alloca() : memref<1x!sycl_item_2_1_>
-// CHECK-MLIR-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl_item_2_1_>
-// CHECK-MLIR-NEXT: %1 = "polygeist.memref2pointer"(%0) : (memref<1x!sycl_item_2_1_>) -> !llvm.ptr<!sycl_item_2_1_>
-// CHECK-MLIR-NEXT: %2 = llvm.addrspacecast %1 : !llvm.ptr<!sycl_item_2_1_> to !llvm.ptr<!sycl_item_2_1_, 4>
-// CHECK-MLIR-NEXT: %3 = "polygeist.pointer2memref"(%2) : (!llvm.ptr<!sycl_item_2_1_, 4>) -> memref<?x!sycl_item_2_1_, 4>
-// CHECK-MLIR-NEXT: %4 = sycl.call(%3, %c0_i32) {Function = @get_id, MangledName = @_ZNK4sycl3_V14itemILi2ELb1EE6get_idEi, Type = @item} : (memref<?x!sycl_item_2_1_, 4>, i32) -> i64
-// CHECK-MLIR-NEXT: return
-// CHECK-MLIR-NEXT: }
+// CHECK-MLIR-LABEL: func.func @_Z8id_get_0N4sycl3_V12idILi1EEEi(%arg0: !sycl_id_1_, %arg1: i32) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi1EE3getEi, TypeName = @array} : (memref<?x!sycl_id_1_, 4>, i32) -> i64
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z8method_1N4sycl3_V14itemILi2ELb1EEE(%"class.sycl::_V1::item.2.true" %0) #0 {
-// CHECK-LLVM-NEXT:  %2 = alloca %"class.sycl::_V1::item.2.true", align 8
-// CHECK-LLVM-NEXT:  store %"class.sycl::_V1::item.2.true" %0, %"class.sycl::_V1::item.2.true"* %2, align 8
-// CHECK-LLVM-NEXT:  %3 = addrspacecast %"class.sycl::_V1::item.2.true"* %2 to %"class.sycl::_V1::item.2.true" addrspace(4)*
-// CHECK-LLVM-NEXT:  %4 = call i64 @_ZNK4sycl3_V14itemILi2ELb1EE6get_idEi(%"class.sycl::_V1::item.2.true" addrspace(4)* %3, i32 0)
-// CHECK-LLVM-NEXT:  ret void
-// CHECK-LLVM-NEXT: }
+// CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_0N4sycl3_V12idILi1EEEi(%"class.sycl::_V1::id.1" %0, i32 %1) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V16detail5arrayILi1EE3getEi(%"class.sycl::_V1::detail::array.1" addrspace(4)* %{{.*}}, i32 %1)
 
-SYCL_EXTERNAL void method_1(sycl::item<2, true> item) {
-  auto id = item.get_id(0);
+SYCL_EXTERNAL void id_get_0(sycl::id<1> id, int dimension) {
+  keep(id.get(dimension));
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z8id_get_1N4sycl3_V12idILi1EEEi(%arg0: !sycl_id_1_, %arg1: i32) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZN4sycl3_V16detail5arrayILi1EEixEi, TypeName = @array} : (memref<?x!sycl_id_1_, 4>, i32) -> memref<?xi64, 4>
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_1N4sycl3_V12idILi1EEEi(%"class.sycl::_V1::id.1" %0, i32 %1) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 addrspace(4)* @_ZN4sycl3_V16detail5arrayILi1EEixEi(%"class.sycl::_V1::detail::array.1" addrspace(4)* %{{.*}}, i32 %1)
+
+SYCL_EXTERNAL void id_get_1(sycl::id<1> id, int dimension) {
+  keep(id[dimension]);
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z8id_get_2N4sycl3_V12idILi1EEEi(%arg0: !sycl_id_1_, %arg1: i32) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi1EEixEi, TypeName = @array} : (memref<?x!sycl_id_1_, 4>, i32) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_2N4sycl3_V12idILi1EEEi(%"class.sycl::_V1::id.1" %0, i32 %1) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V16detail5arrayILi1EEixEi(%"class.sycl::_V1::detail::array.1" addrspace(4)* %{{.*}}, i32 %1)
+
+SYCL_EXTERNAL void id_get_2(const sycl::id<1> id, int dimension) {
+  keep(id[dimension]);
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z8id_get_3N4sycl3_V12idILi1EEE(%arg0: !sycl_id_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}) {BaseType = memref<?x!sycl_id_1_, 4>, FunctionName = @"operator unsigned long", MangledFunctionName = @_ZNK4sycl3_V12idILi1EEcvmEv, TypeName = @id} : (memref<?x!sycl_id_1_, 4>) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_3N4sycl3_V12idILi1EEE(%"class.sycl::_V1::id.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V12idILi1EEcvmEv(%"class.sycl::_V1::id.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void id_get_3(sycl::id<1> id) {
+  keep(static_cast<size_t>(id));
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z13item_get_id_0N4sycl3_V14itemILi1ELb1EEE(%arg0: !sycl_item_1_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> !sycl_id_1_
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_0N4sycl3_V14itemILi1ELb1EEE(%"class.sycl::_V1::item.1.true" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::id.1" @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void item_get_id_0(sycl::item<1> item) {
+  keep(item.get_id());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z13item_get_id_1N4sycl3_V14itemILi1ELb1EEEi(%arg0: !sycl_item_1_1_, %arg1: i32) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEi, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>, i32) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_1N4sycl3_V14itemILi1ELb1EEEi(%"class.sycl::_V1::item.1.true" %0, i32 %1) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEi(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}}, i32 %1)
+
+SYCL_EXTERNAL void item_get_id_1(sycl::item<1> item, int dimension) {
+  keep(item.get_id(dimension));
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z13item_get_id_2N4sycl3_V14itemILi1ELb1EEEi(%arg0: !sycl_item_1_1_, %arg1: i32) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EEixEi, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>, i32) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_2N4sycl3_V14itemILi1ELb1EEEi(%"class.sycl::_V1::item.1.true" %0, i32 %1) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V14itemILi1ELb1EEixEi(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}}, i32 %1)
+
+SYCL_EXTERNAL void item_get_id_2(sycl::item<1> item, int dimension) {
+  keep(item[dimension]);
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z13item_get_id_3N4sycl3_V14itemILi1ELb1EEE(%arg0: !sycl_item_1_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @"operator unsigned long", MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EEcvmEv, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_3N4sycl3_V14itemILi1ELb1EEE(%"class.sycl::_V1::item.1.true" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V14itemILi1ELb1EEcvmEv(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void item_get_id_3(sycl::item<1> item) {
+  keep(static_cast<size_t>(item));
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z16item_get_range_0N4sycl3_V14itemILi1ELb1EEE(%arg0: !sycl_item_1_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_range"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEv, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> !sycl_range_1_
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z16item_get_range_0N4sycl3_V14itemILi1ELb1EEE(%"class.sycl::_V1::item.1.true" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEv(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void item_get_range_0(sycl::item<1> item) {
+  keep(item.get_range());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z16item_get_range_1N4sycl3_V14itemILi1ELb1EEEi(%arg0: !sycl_item_1_1_, %arg1: i32) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEi, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>, i32) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z16item_get_range_1N4sycl3_V14itemILi1ELb1EEEi(%"class.sycl::_V1::item.1.true" %0, i32 %1) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEi(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}}, i32 %1)
+
+SYCL_EXTERNAL void item_get_range_1(sycl::item<1> item, int dimension) {
+  keep(item.get_range(dimension));
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z18item_get_linear_idN4sycl3_V14itemILi1ELb1EEE(%arg0: !sycl_item_1_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_linear_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE13get_linear_idEv, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z18item_get_linear_idN4sycl3_V14itemILi1ELb1EEE(%"class.sycl::_V1::item.1.true" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V14itemILi1ELb1EE13get_linear_idEv(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void item_get_linear_id(sycl::item<1> item) {
+  keep(item.get_linear_id());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z23nd_item_get_global_id_0N4sycl3_V17nd_itemILi1EEE(%arg0: !sycl_nd_item_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_id_1_
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z23nd_item_get_global_id_0N4sycl3_V17nd_itemILi1EEE(%"class.sycl::_V1::nd_item.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::id.1" @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void nd_item_get_global_id_0(sycl::nd_item<1> nd_item) {
+  keep(nd_item.get_global_id());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z23nd_item_get_global_id_1N4sycl3_V17nd_itemILi1EEEi(%arg0: !sycl_nd_item_1_, %arg1: i32) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z23nd_item_get_global_id_1N4sycl3_V17nd_itemILi1EEEi(%"class.sycl::_V1::nd_item.1" %{{.*}}, i32 %{{.*}}) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
+
+SYCL_EXTERNAL void nd_item_get_global_id_1(sycl::nd_item<1> nd_item, int dimension) {
+  keep(nd_item.get_global_id(dimension));
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z28nd_item_get_global_linear_idN4sycl3_V17nd_itemILi1EEE(%arg0: !sycl_nd_item_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE20get_global_linear_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z28nd_item_get_global_linear_idN4sycl3_V17nd_itemILi1EEE(%"class.sycl::_V1::nd_item.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE20get_global_linear_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void nd_item_get_global_linear_id(sycl::nd_item<1> nd_item) {
+  keep(nd_item.get_global_linear_id());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z22nd_item_get_local_id_0N4sycl3_V17nd_itemILi1EEE(%arg0: !sycl_nd_item_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_id_1_
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z22nd_item_get_local_id_0N4sycl3_V17nd_itemILi1EEE(%"class.sycl::_V1::nd_item.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::id.1" @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void nd_item_get_local_id_0(sycl::nd_item<1> nd_item) {
+  keep(nd_item.get_local_id());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z22nd_item_get_local_id_1N4sycl3_V17nd_itemILi1EEEi(%arg0: !sycl_nd_item_1_, %arg1: i32) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z22nd_item_get_local_id_1N4sycl3_V17nd_itemILi1EEEi(%"class.sycl::_V1::nd_item.1" %0, i32 %1) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
+
+SYCL_EXTERNAL void nd_item_get_local_id_1(sycl::nd_item<1> nd_item, int dimension) {
+  keep(nd_item.get_local_id(dimension));
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z27nd_item_get_local_linear_idN4sycl3_V17nd_itemILi1EEE(%arg0: !sycl_nd_item_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE19get_local_linear_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z27nd_item_get_local_linear_idN4sycl3_V17nd_itemILi1EEE(%"class.sycl::_V1::nd_item.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE19get_local_linear_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void nd_item_get_local_linear_id(sycl::nd_item<1> nd_item) {
+  keep(nd_item.get_local_linear_id());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z19nd_item_get_group_0N4sycl3_V17nd_itemILi1EEE(%arg0: !sycl_nd_item_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_group_1_
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z19nd_item_get_group_0N4sycl3_V17nd_itemILi1EEE(%"class.sycl::_V1::nd_item.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::group.1" @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void nd_item_get_group_0(sycl::nd_item<1> nd_item) {
+  keep(nd_item.get_group());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z19nd_item_get_group_1N4sycl3_V17nd_itemILi1EEEi(%arg0: !sycl_nd_item_1_, %arg1: i32) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z19nd_item_get_group_1N4sycl3_V17nd_itemILi1EEEi(%"class.sycl::_V1::nd_item.1" %0, i32 %1) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
+
+SYCL_EXTERNAL void nd_item_get_group_1(sycl::nd_item<1> nd_item, int dimension) {
+  keep(nd_item.get_group(dimension));
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z27nd_item_get_group_linear_idN4sycl3_V17nd_itemILi1EEE(%arg0: !sycl_nd_item_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE19get_group_linear_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z27nd_item_get_group_linear_idN4sycl3_V17nd_itemILi1EEE(%"class.sycl::_V1::nd_item.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE19get_group_linear_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void nd_item_get_group_linear_id(sycl::nd_item<1> nd_item) {
+  keep(nd_item.get_group_linear_id());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_group_range_0N4sycl3_V17nd_itemILi1EEE(%arg0: !sycl_nd_item_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_range_1_
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_group_range_0N4sycl3_V17nd_itemILi1EEE(%"class.sycl::_V1::nd_item.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void nd_item_get_group_range_0(sycl::nd_item<1> nd_item) {
+  keep(nd_item.get_group_range());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_group_range_1N4sycl3_V17nd_itemILi1EEEi(%arg0: !sycl_nd_item_1_, %arg1: i32) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_group_range_1N4sycl3_V17nd_itemILi1EEEi(%"class.sycl::_V1::nd_item.1" %0, i32 %1) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
+
+SYCL_EXTERNAL void nd_item_get_group_range_1(sycl::nd_item<1> nd_item, int dimension) {
+  keep(nd_item.get_group_range(dimension));
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z26nd_item_get_global_range_0N4sycl3_V17nd_itemILi1EEE(%arg0: !sycl_nd_item_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_range_1_
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z26nd_item_get_global_range_0N4sycl3_V17nd_itemILi1EEE(%"class.sycl::_V1::nd_item.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void nd_item_get_global_range_0(sycl::nd_item<1> nd_item) {
+  keep(nd_item.get_global_range());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z26nd_item_get_global_range_1N4sycl3_V17nd_itemILi1EEEi(%arg0: !sycl_nd_item_1_, %arg1: i32) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z26nd_item_get_global_range_1N4sycl3_V17nd_itemILi1EEEi(%"class.sycl::_V1::nd_item.1" %0, i32 %1) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
+
+SYCL_EXTERNAL void nd_item_get_global_range_1(sycl::nd_item<1> nd_item, int dimension) {
+  keep(nd_item.get_global_range(dimension));
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_local_range_0N4sycl3_V17nd_itemILi1EEE(%arg0: !sycl_nd_item_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_range_1_
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_local_range_0N4sycl3_V17nd_itemILi1EEE(%"class.sycl::_V1::nd_item.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void nd_item_get_local_range_0(sycl::nd_item<1> nd_item) {
+  keep(nd_item.get_local_range());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_local_range_1N4sycl3_V17nd_itemILi1EEEi(%arg0: !sycl_nd_item_1_, %arg1: i32) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_local_range_1N4sycl3_V17nd_itemILi1EEEi(%"class.sycl::_V1::nd_item.1" %0, i32 %1) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
+
+SYCL_EXTERNAL void nd_item_get_local_range_1(sycl::nd_item<1> nd_item, int dimension) {
+  keep(nd_item.get_local_range(dimension));
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_0N4sycl3_V15groupILi1EEE(%arg0: !sycl_group_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_group_idEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_id_1_
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_0N4sycl3_V15groupILi1EEE(%"class.sycl::_V1::group.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::id.1" @_ZNK4sycl3_V15groupILi1EE12get_group_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void group_get_group_id_0(sycl::group<1> group) {
+  keep(group.get_group_id());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_1N4sycl3_V15groupILi1EEEi(%arg0: !sycl_group_1_, %arg1: i32) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_group_idEi, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_1N4sycl3_V15groupILi1EEEi(%"class.sycl::_V1::group.1" %0, i32 %1) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE12get_group_idEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
+
+SYCL_EXTERNAL void group_get_group_id_1(sycl::group<1> group, int dimension) {
+  keep(group.get_group_id(dimension));
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_2N4sycl3_V15groupILi1EEEi(%arg0: !sycl_group_1_, %arg1: i32) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V15groupILi1EEixEi, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_2N4sycl3_V15groupILi1EEEi(%"class.sycl::_V1::group.1" %0, i32 %1) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EEixEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
+
+SYCL_EXTERNAL void group_get_group_id_2(sycl::group<1> group, int dimension) {
+  keep(group[dimension]);
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z20group_get_local_id_0N4sycl3_V15groupILi1EEE(%arg0: !sycl_group_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_local_idEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_id_1_
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_local_id_0N4sycl3_V15groupILi1EEE(%"class.sycl::_V1::group.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::id.1" @_ZNK4sycl3_V15groupILi1EE12get_local_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void group_get_local_id_0(sycl::group<1> group) {
+  keep(group.get_local_id());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z20group_get_local_id_1N4sycl3_V15groupILi1EEEi(%arg0: !sycl_group_1_, %arg1: i32) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_local_idEi, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_local_id_1N4sycl3_V15groupILi1EEEi(%"class.sycl::_V1::group.1" %0, i32 %1) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE12get_local_idEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
+
+SYCL_EXTERNAL void group_get_local_id_1(sycl::group<1> group, int dimension) {
+  keep(group.get_local_id(dimension));
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z23group_get_local_range_0N4sycl3_V15groupILi1EEE(%arg0: !sycl_group_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_range_1_
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_local_range_0N4sycl3_V15groupILi1EEE(%"class.sycl::_V1::group.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void group_get_local_range_0(sycl::group<1> group) {
+  keep(group.get_local_range());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z23group_get_local_range_1N4sycl3_V15groupILi1EEEi(%arg0: !sycl_group_1_, %arg1: i32) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEi, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_local_range_1N4sycl3_V15groupILi1EEEi(%"class.sycl::_V1::group.1" %0, i32 %1) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
+
+SYCL_EXTERNAL void group_get_local_range_1(sycl::group<1> group, int dimension) {
+  keep(group.get_local_range(dimension));
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z23group_get_group_range_0N4sycl3_V15groupILi1EEE(%arg0: !sycl_group_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_range_1_
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_group_range_0N4sycl3_V15groupILi1EEE(%"class.sycl::_V1::group.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void group_get_group_range_0(sycl::group<1> group) {
+  keep(group.get_group_range());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z23group_get_group_range_1N4sycl3_V15groupILi1EEEi(%arg0: !sycl_group_1_, %arg1: i32) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEi, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_group_range_1N4sycl3_V15groupILi1EEEi(%"class.sycl::_V1::group.1" %0, i32 %1) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
+
+SYCL_EXTERNAL void group_get_group_range_1(sycl::group<1> group, int dimension) {
+  keep(group.get_group_range(dimension));
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z25group_get_max_local_rangeN4sycl3_V15groupILi1EEE(%arg0: !sycl_group_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_max_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_max_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_max_local_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_range_1_
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_max_local_rangeN4sycl3_V15groupILi1EEE(%"class.sycl::_V1::group.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V15groupILi1EE19get_max_local_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void group_get_max_local_range(sycl::group<1> group) {
+  keep(group.get_max_local_range());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z25group_get_group_linear_idN4sycl3_V15groupILi1EEE(%arg0: !sycl_group_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_linear_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_group_linear_idEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_group_linear_idN4sycl3_V15groupILi1EEE(%"class.sycl::_V1::group.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE19get_group_linear_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void group_get_group_linear_id(sycl::group<1> group) {
+  keep(group.get_group_linear_id());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z25group_get_local_linear_idN4sycl3_V15groupILi1EEE(%arg0: !sycl_group_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_linear_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_local_linear_idEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_local_linear_idN4sycl3_V15groupILi1EEE(%"class.sycl::_V1::group.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE19get_local_linear_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void group_get_local_linear_id(sycl::group<1> group) {
+  keep(group.get_local_linear_id());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z28group_get_group_linear_rangeN4sycl3_V15groupILi1EEE(%arg0: !sycl_group_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_linear_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_linear_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE22get_group_linear_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z28group_get_group_linear_rangeN4sycl3_V15groupILi1EEE(%"class.sycl::_V1::group.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE22get_group_linear_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void group_get_group_linear_range(sycl::group<1> group) {
+  keep(group.get_group_linear_range());
+}
+
+// CHECK-MLIR-LABEL: func.func @_Z28group_get_local_linear_rangeN4sycl3_V15groupILi1EEE(%arg0: !sycl_group_1_) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_linear_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_linear_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE22get_local_linear_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z28group_get_local_linear_rangeN4sycl3_V15groupILi1EEE(%"class.sycl::_V1::group.1" %0) #0 {
+// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE22get_local_linear_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void group_get_local_linear_range(sycl::group<1> group) {
+  keep(group.get_local_linear_range());
 }
 
 // CHECK-MLIR: func.func @_Z8method_2N4sycl3_V14itemILi2ELb1EEE(%arg0: !sycl_item_2_1_)
@@ -146,28 +522,6 @@ SYCL_EXTERNAL void method_1(sycl::item<2, true> item) {
 
 SYCL_EXTERNAL void method_2(sycl::item<2, true> item) {
   auto id = item.operator==(item);
-}
-
-// CHECK-MLIR: func.func @_Z21nd_item_get_global_idN4sycl3_V17nd_itemILi2EEE(%arg0: !sycl_nd_item_2_)
-// CHECK-MLIR-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
-// CHECK-MLIR-NEXT: %0 = memref.alloca() : memref<1x!sycl_nd_item_2_>
-// CHECK-MLIR-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl_nd_item_2_>
-// CHECK-MLIR-NEXT: %1 = "polygeist.memref2pointer"(%0) : (memref<1x!sycl_nd_item_2_>) -> !llvm.ptr<!sycl_nd_item_2_>
-// CHECK-MLIR-NEXT: %2 = llvm.addrspacecast %1 : !llvm.ptr<!sycl_nd_item_2_> to !llvm.ptr<!sycl_nd_item_2_, 4>
-// CHECK-MLIR-NEXT: %3 = "polygeist.pointer2memref"(%2) : (!llvm.ptr<!sycl_nd_item_2_, 4>) -> memref<?x!sycl_nd_item_2_, 4>
-// CHECK-MLIR-NEXT: %4 = sycl.call(%3) {Function = @get_global_id, MangledName = @_ZNK4sycl3_V17nd_itemILi2EE13get_global_idEv, Type = @nd_item} : (memref<?x!sycl_nd_item_2_, 4>) -> !sycl_id_2_
-// CHECK-MLIR-NEXT: return
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z21nd_item_get_global_idN4sycl3_V17nd_itemILi2EEE(%"class.sycl::_V1::nd_item.2" %0) #0 {
-// CHECK-LLVM-NEXT:  %2 = alloca %"class.sycl::_V1::nd_item.2", align 8
-// CHECK-LLVM-NEXT:  store %"class.sycl::_V1::nd_item.2" %0, %"class.sycl::_V1::nd_item.2"* %2, align 8
-// CHECK-LLVM-NEXT:  %3 = addrspacecast %"class.sycl::_V1::nd_item.2"* %2 to %"class.sycl::_V1::nd_item.2" addrspace(4)*
-// CHECK-LLVM-NEXT:  %4 = call %"class.sycl::_V1::id.2" @_ZNK4sycl3_V17nd_itemILi2EE13get_global_idEv(%"class.sycl::_V1::nd_item.2" addrspace(4)* %3)
-// CHECK-LLVM-NEXT:  ret void
-// CHECK-LLVM-NEXT: }
-
-SYCL_EXTERNAL void nd_item_get_global_id(sycl::nd_item<2> ndItem) {
-  auto id = ndItem.get_global_id();
 }
 
 // CHECK-MLIR: func.func @_Z4op_1N4sycl3_V12idILi2EEES2_(%arg0: !sycl_id_2_, %arg1: !sycl_id_2_)
@@ -206,24 +560,22 @@ SYCL_EXTERNAL void op_1(sycl::id<2> a, sycl::id<2> b) {
 // CHECK-MLIR-NEXT: %c1_i32 = arith.constant 1 : i32
 // CHECK-MLIR-NEXT: %c0_i32 = arith.constant 0 : i32
 // CHECK-MLIR-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
-// CHECK-MLIR-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
 // CHECK-MLIR-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl_id_2_>
-// CHECK-MLIR-NEXT: %2 = sycl.cast(%1) : (memref<?x!sycl_id_2_>) -> memref<?x!sycl_array_2_>
-// CHECK-MLIR-NEXT: %3 = "polygeist.memref2pointer"(%2) : (memref<?x!sycl_array_2_>) -> !llvm.ptr<!sycl_array_2_>
-// CHECK-MLIR-NEXT: %4 = llvm.addrspacecast %3 : !llvm.ptr<!sycl_array_2_> to !llvm.ptr<!sycl_array_2_, 4>
-// CHECK-MLIR-NEXT: %5 = "polygeist.pointer2memref"(%4) : (!llvm.ptr<!sycl_array_2_, 4>) -> memref<?x!sycl_array_2_, 4>
-// CHECK-MLIR-NEXT: %6 = sycl.call(%5, %c0_i32) {Function = @get, MangledName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, Type = @array} : (memref<?x!sycl_array_2_, 4>, i32) -> i64
-// CHECK-MLIR-NEXT: %7 = sycl.call(%5, %c1_i32) {Function = @get, MangledName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, Type = @array} : (memref<?x!sycl_array_2_, 4>, i32) -> i64
-// CHECK-MLIR-NEXT: %8 = arith.addi %6, %7 : i64
-// CHECK-MLIR-NEXT: %9 = sycl.call(%8) {Function = @abs, MangledName = @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_} : (i64) -> i64
+// CHECK-MLIR-NEXT: %1 = "polygeist.memref2pointer"(%0) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
+// CHECK-MLIR-NEXT: %2 = llvm.addrspacecast %1 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
+// CHECK-MLIR-NEXT: %3 = "polygeist.pointer2memref"(%2) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
+// CHECK-MLIR-NEXT: %4 = "sycl.id.get"(%3, %c0_i32) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_id_2_, 4>, i32) -> i64
+// CHECK-MLIR-NEXT: %5 = "sycl.id.get"(%3, %c1_i32) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_id_2_, 4>, i32) -> i64
+// CHECK-MLIR-NEXT: %6 = arith.addi %4, %5 : i64
+// CHECK-MLIR-NEXT: %7 = sycl.call(%6) {Function = @abs, MangledName = @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_} : (i64) -> i64
 // CHECK-MLIR-NEXT: return
 // CHECK-MLIR-NEXT: }
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8static_1N4sycl3_V12idILi2EEES2_(%"class.sycl::_V1::id.2" %0, %"class.sycl::_V1::id.2" %1) #0 {
 // CHECK-LLVM-NEXT: %3 = alloca %"class.sycl::_V1::id.2", align 8
 // CHECK-LLVM-NEXT: store %"class.sycl::_V1::id.2" %0, %"class.sycl::_V1::id.2"* %3, align 8
-// CHECK-LLVM-NEXT: %4 = bitcast %"class.sycl::_V1::id.2"* %3 to %"class.sycl::_V1::detail::array.2"*
-// CHECK-LLVM-NEXT: %5 = addrspacecast %"class.sycl::_V1::detail::array.2"* %4 to %"class.sycl::_V1::detail::array.2" addrspace(4)*
+// CHECK-LLVM-NEXT: %4 = addrspacecast %"class.sycl::_V1::id.2"* %3 to %"class.sycl::_V1::id.2" addrspace(4)*
+// CHECK-LLVM-NEXT: %5 = bitcast %"class.sycl::_V1::id.2" addrspace(4)* %4 to %"class.sycl::_V1::detail::array.2" addrspace(4)*
 // CHECK-LLVM-NEXT: %6 = call i64 @_ZNK4sycl3_V16detail5arrayILi2EE3getEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %5, i32 0)
 // CHECK-LLVM-NEXT: %7 = call i64 @_ZNK4sycl3_V16detail5arrayILi2EE3getEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %5, i32 1)
 // CHECK-LLVM-NEXT: %8 = add i64 %6, %7

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -639,6 +639,10 @@ static int finalize(mlir::MLIRContext &context,
       module->walk([&](mlir::omp::ParallelOp) { LinkOMP = true; });
       mlir::PassManager pm3(&context);
       pm3.addPass(polygeist::createConvertToLLVMABIPass());
+      // Needed because SYCLMethodOps lowering might introduce redundant
+      // operations.
+      pm3.addPass(mlir::createCSEPass());
+      pm3.addPass(mlir::createCanonicalizerPass(canonicalizerConfig, {}, {}));
       LowerToLLVMOptions options(&context);
       options.dataLayout = DL;
       // invalid for gemm.c init array


### PR DESCRIPTION
Define an operations interface that all operations implementing SYCL methods should implement. This way, adding new methods should involve adding no new code for generating the operations/lowering.

Modify how operations are registered so that operations implementing SYCL methods are registered as well.

Before emitting a SYCLCallOp, check if the function to be called is registered as a method and emit a method operation instead.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>