### PR TITLE
[SYCL] Disable  the LIT test 'debug-info-file-checksum.cpp' for Windows.

### DIFF
--- a/clang/test/CodeGenSYCL/debug-info-file-checksum.cpp
+++ b/clang/test/CodeGenSYCL/debug-info-file-checksum.cpp
@@ -31,3 +31,9 @@
 // COMP2: !DICompileUnit({{.*}} file: ![[#FILE2:]]
 // COMP2: ![[#FILE2]] = !DIFile(filename: "{{.*}}clang{{.+}}test{{.+}}CodeGenSYCL{{.+}}checksum.cpp"
 // COMP2-SAME: checksumkind: CSK_MD5, checksum: "259269f735d83ec32c46a11352458493")
+
+// TODO: Fails on windows because of the use of append-file command that returns
+// path with "\\" on windows. getPresumedLoc is failing with Literal String
+// parser returning erroneous filename.
+// XFAIL: windows-msvc
+


### PR DESCRIPTION
The LIT test is using append-file. This command seems to have some escape character issue on Windows.
Talked off-line to @pvchupin and agreed that for now the test case can be disabled for windows.

Signed-off-by: Zahira Ammarguellat <zahira.ammarguellat@intel.com>