### PR TITLE
[SYCL-MLIR] Handle AddressSpaceConversion

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
@@ -11,6 +11,7 @@
 #ifndef MLIR_SYCL_OPS_TYPES_H_
 #define MLIR_SYCL_OPS_TYPES_H_
 
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dialect.h"
@@ -299,7 +300,8 @@ namespace sycl {
 
 class ArrayType
     : public Type::TypeBase<ArrayType, Type, detail::ArrayTypeStorage,
-                            mlir::MemRefElementTypeInterface::Trait> {
+                            mlir::MemRefElementTypeInterface::Trait,
+                            mlir::LLVM::PointerElementTypeInterface::Trait> {
 public:
   using Base::Base;
 
@@ -311,10 +313,12 @@ public:
   llvm::ArrayRef<mlir::Type> getBody() const;
 };
 
-class IDType : public Type::TypeBase<IDType, Type, detail::IDTypeStorage,
-                                     mlir::MemRefElementTypeInterface::Trait,
-                                     mlir::sycl::SYCLInheritanceTypeInterface<
-                                         mlir::sycl::ArrayType>::Trait> {
+class IDType
+    : public Type::TypeBase<IDType, Type, detail::IDTypeStorage,
+                            mlir::MemRefElementTypeInterface::Trait,
+                            mlir::LLVM::PointerElementTypeInterface::Trait,
+                            mlir::sycl::SYCLInheritanceTypeInterface<
+                                mlir::sycl::ArrayType>::Trait> {
 public:
   using Base::Base;
 
@@ -338,6 +342,7 @@ public:
 class AccessorType
     : public Type::TypeBase<AccessorType, Type, detail::AccessorTypeStorage,
                             mlir::MemRefElementTypeInterface::Trait,
+                            mlir::LLVM::PointerElementTypeInterface::Trait,
                             mlir::sycl::SYCLInheritanceTypeInterface<
                                 mlir::sycl::AccessorCommonType>::Trait> {
 public:
@@ -362,6 +367,7 @@ public:
 class RangeType
     : public Type::TypeBase<RangeType, Type, detail::RangeTypeStorage,
                             mlir::MemRefElementTypeInterface::Trait,
+                            mlir::LLVM::PointerElementTypeInterface::Trait,
                             mlir::sycl::SYCLInheritanceTypeInterface<
                                 mlir::sycl::ArrayType>::Trait> {
 public:
@@ -392,7 +398,8 @@ public:
 
 class ItemType
     : public Type::TypeBase<ItemType, Type, detail::ItemTypeStorage,
-                            mlir::MemRefElementTypeInterface::Trait> {
+                            mlir::MemRefElementTypeInterface::Trait,
+                            mlir::LLVM::PointerElementTypeInterface::Trait> {
 public:
   using Base::Base;
 

--- a/mlir-sycl/lib/Dialect/IR/CMakeLists.txt
+++ b/mlir-sycl/lib/Dialect/IR/CMakeLists.txt
@@ -20,6 +20,7 @@ else()
     MLIRIR
     MLIRSideEffectInterfaces
     MLIRVectorInterfaces
+    MLIRLLVMDialect
     MLIRMemRefDialect
     MLIRSCFDialect
     )

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -188,6 +188,12 @@ ValueCategory MLIRScanner::CallHelper(
         val =
             builder.create<polygeist::Pointer2MemrefOp>(loc, expectedType, val);
       }
+
+      if (val.getType().isa<MemRefType>() ||
+          val.getType().isa<LLVM::LLVMPointerType>())
+        if (expectedType.isa<MemRefType>() ||
+            expectedType.isa<LLVM::LLVMPointerType>())
+          val = performAddrSpaceCast(val, expectedType);
     }
     assert(val);
     args.push_back(val);

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -93,11 +93,13 @@ ValueCategory MLIRScanner::CallHelper(
   for (auto pair : arguments) {
 
     ValueCategory arg = std::get<0>(pair);
-    auto *a = std::get<1>(pair);
+    clang::Expr *a = std::get<1>(pair);
+#ifdef DEBUG
     if (!arg.val) {
       expr->dump();
       a->dump();
     }
+#endif
     assert(arg.val && "expect not null");
 
     if (auto *ice = dyn_cast_or_null<ImplicitCastExpr>(a))
@@ -106,14 +108,17 @@ ValueCategory MLIRScanner::CallHelper(
             make_pair(dre->getDecl()->getName().str(), arg.val));
 
     if (i >= fnType.getInputs().size() || (i != 0 && a == nullptr)) {
+#ifdef DEBUG
       expr->dump();
       tocall.dump();
       fnType.dump();
       for (auto a : arguments) {
         std::get<1>(a)->dump();
       }
+#endif
       assert(0 && "too many arguments in calls");
     }
+
     bool isReference =
         (i == 0 && a == nullptr) || a->isLValue() || a->isXValue();
 
@@ -130,11 +135,13 @@ ValueCategory MLIRScanner::CallHelper(
     mlir::Value val = nullptr;
     if (!isReference) {
       if (isArray) {
+#ifdef DEBUG
         if (!arg.isReference) {
           expr->dump();
           a->dump();
           llvm::errs() << " v: " << arg.val << "\n";
         }
+#endif
         assert(arg.isReference);
 
         auto mt =
@@ -183,17 +190,12 @@ ValueCategory MLIRScanner::CallHelper(
           Glob.getCGM().getContext().getLValueReferenceType(aType));
 
       val = arg.val;
-      if (arg.val.getType().isa<LLVM::LLVMPointerType>() &&
-          expectedType.isa<MemRefType>()) {
+      if (val.getType().isa<LLVM::LLVMPointerType>() &&
+          expectedType.isa<MemRefType>())
         val =
             builder.create<polygeist::Pointer2MemrefOp>(loc, expectedType, val);
-      }
 
-      if (val.getType().isa<MemRefType>() ||
-          val.getType().isa<LLVM::LLVMPointerType>())
-        if (expectedType.isa<MemRefType>() ||
-            expectedType.isa<LLVM::LLVMPointerType>())
-          val = performAddrSpaceCast(val, expectedType);
+      val = castToMemSpaceOfType(val, expectedType);
     }
     assert(val);
     args.push_back(val);

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1309,47 +1309,6 @@ ValueCategory MLIRScanner::VisitMemberExpr(MemberExpr *ME) {
           field->getType()->getUnqualifiedDesugaredType()));
 }
 
-static mlir::Type getElementType(mlir::Type ty) {
-  if (auto memRef = ty.dyn_cast<MemRefType>())
-    return memRef.getElementType();
-
-  return ty.cast<LLVM::LLVMPointerType>().getElementType();
-}
-
-static unsigned getAddressSpace(mlir::Type ty) {
-  if (auto memRef = ty.dyn_cast<MemRefType>())
-    return memRef.getMemorySpaceAsInt();
-
-  return ty.cast<LLVM::LLVMPointerType>().getAddressSpace();
-}
-
-Value MLIRScanner::performAddrSpaceCast(Value val, mlir::Type postTy) {
-  assert((val.getType().isa<MemRefType>() ||
-          val.getType().isa<LLVM::LLVMPointerType>()) &&
-         "Expecting memref or pointer val");
-  assert((postTy.isa<MemRefType>() || postTy.isa<LLVM::LLVMPointerType>()) &&
-         "Expecting memref or pointer type postTy");
-  mlir::Type elemTy = getElementType(val.getType());
-  assert(elemTy == getElementType(postTy) && "Element types mismatch");
-
-  unsigned valAddrSpace = getAddressSpace(val.getType());
-  unsigned postAddrSpace = getAddressSpace(postTy);
-  if (valAddrSpace == postAddrSpace)
-    return val;
-
-  if (auto valMemRefType = val.getType().dyn_cast<MemRefType>())
-    val = builder.create<polygeist::Memref2PointerOp>(
-        loc, LLVM::LLVMPointerType::get(elemTy, valAddrSpace), val);
-
-  val = builder.create<LLVM::AddrSpaceCastOp>(
-      loc, LLVM::LLVMPointerType::get(elemTy, postAddrSpace), val);
-
-  if (auto postMemRefType = postTy.dyn_cast<MemRefType>())
-    val = builder.create<polygeist::Pointer2MemrefOp>(loc, postTy, val);
-
-  return val;
-}
-
 ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
   auto loc = getMLIRLocation(E->getExprLoc());
   switch (E->getCastKind()) {
@@ -1375,7 +1334,7 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
     // JLE_QUEL::TODO (II-201)
     // assert(scalar.isReference);
     auto postTy = returnVal.getType().cast<MemRefType>().getElementType();
-    return ValueCategory(performAddrSpaceCast(scalar.val, postTy),
+    return ValueCategory(castToMemSpaceOfType(scalar.val, postTy),
                          scalar.isReference);
   }
   case clang::CastKind::CK_Dynamic: {

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -299,6 +299,8 @@ private:
                            mlir::Value lb, mlir::Value ub,
                            const mlirclang::AffineLoopDescriptor &descr);
 
+  mlir::Value performAddrSpaceCast(mlir::Value val, mlir::Type postTy);
+
 public:
   MLIRScanner(MLIRASTConsumer &Glob, mlir::OwningOpRef<mlir::ModuleOp> &module,
               LowerToInfo &LTInfo);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -280,6 +280,14 @@ private:
 
   mlir::Value castToIndex(mlir::Location loc, mlir::Value val);
 
+  /// Converts the \p val to the memory space \p memSpace and returns the
+  /// converted value.
+  mlir::Value castToMemSpace(mlir::Value val, unsigned memSpace);
+
+  /// Converts the \p val to the memory space of \p t and returns the converted
+  /// value.
+  mlir::Value castToMemSpaceOfType(mlir::Value val, mlir::Type targetType);
+
   bool isTrivialAffineLoop(clang::ForStmt *fors,
                            mlirclang::AffineLoopDescriptor &descr);
 
@@ -298,8 +306,6 @@ private:
   void buildAffineLoopImpl(clang::ForStmt *fors, mlir::Location loc,
                            mlir::Value lb, mlir::Value ub,
                            const mlirclang::AffineLoopDescriptor &descr);
-
-  mlir::Value performAddrSpaceCast(mlir::Value val, mlir::Type postTy);
 
 public:
   MLIRScanner(MLIRASTConsumer &Glob, mlir::OwningOpRef<mlir::ModuleOp> &module,

--- a/polygeist/tools/cgeist/Test/Verification/addressspace.c
+++ b/polygeist/tools/cgeist/Test/Verification/addressspace.c
@@ -1,0 +1,16 @@
+// RUN: cgeist %s --function=* -S | FileCheck %s
+
+// CHECK:  func.func @test() -> memref<?xi32, 4> attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK:    [[CALL:%.*]] = call @foo() : () -> memref<?xi32, 1>
+// CHECK:    [[M2P:%.*]] = "polygeist.memref2pointer"([[CALL]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
+// CHECK:    [[ACAST:%.*]] = llvm.addrspacecast [[M2P]] : !llvm.ptr<i32, 1> to !llvm.ptr<i32, 4>
+// CHECK:    [[P2M:%.*]] = "polygeist.pointer2memref"([[ACAST]]) : (!llvm.ptr<i32, 4>) -> memref<?xi32, 4>
+// CHECK:    return [[P2M]] : memref<?xi32, 4>
+// CHECK:  }
+// CHECK:  func.func private @foo() -> memref<?xi32, 1>
+
+int __attribute__((address_space(1))) *foo();
+
+int __attribute__((address_space(4))) *test() {
+  return (int __attribute__((address_space(4))) *)foo();
+}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -17,13 +17,13 @@
 // CHECK-DAG: !sycl_range_1_ = !sycl.range<1>
 
 // Ensure the constructors are NOT filtered out, and sycl.cast is generated for cast from sycl.id or sycl.range to sycl.array.
-// CHECK-LABEL: func.func @_ZN4sycl3_V12idILi1EEC1ERKS2_(%arg0: memref<?x!sycl_id_1_>, %arg1: memref<?x!sycl_id_1_>)
+// CHECK-LABEL: func.func @_ZN4sycl3_V12idILi1EEC1ERKS2_(%arg0: memref<?x!sycl_id_1_, 4>, %arg1: memref<?x!sycl_id_1_, 4>)
 // CHECK-SAME:  attributes {[[SPIR_FUNCCC:llvm.cconv = #llvm.cconv<spir_funccc>]], [[LINKONCE:llvm.linkage = #llvm.linkage<linkonce_odr>]], 
 // CHECK-SAME:  [[PASSTHROUGH:passthrough = \["norecurse", "nounwind", "convergent", "mustprogress"\]]]} {
-// CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl_id_1_>) -> memref<?x!sycl_array_1_>
-// CHECK-LABEL: func.func @_ZN4sycl3_V15rangeILi1EEC1ERKS2_(%arg0: memref<?x!sycl_range_1_>, %arg1: memref<?x!sycl_range_1_>)
+// CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl_id_1_, 4>) -> memref<?x!sycl_array_1_, 4>
+// CHECK-LABEL: func.func @_ZN4sycl3_V15rangeILi1EEC1ERKS2_(%arg0: memref<?x!sycl_range_1_, 4>, %arg1: memref<?x!sycl_range_1_, 4>)
 // CHECK-SAME:  attributes {[[SPIR_FUNCCC]], [[LINKONCE]], [[PASSTHROUGH]]}
-// CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl_range_1_>) -> memref<?x!sycl_array_1_>
+// CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl_range_1_, 4>) -> memref<?x!sycl_array_1_, 4>
 
 // CHECK-LLVM: define spir_func void @cons_0([[ID_TYPE:%"class.cl::sycl::id.1"]] [[ARG0:%.*]], [[RANGE_TYPE:%"class.cl::sycl::range.1"]] [[ARG1:%.*]]) #0
 // CHECK-LLVM-DAG: [[RANGE1:%.*]] = alloca [[RANGE_TYPE]]
@@ -32,8 +32,10 @@
 // CHECK-LLVM-DAG: [[ID2:%.*]] = alloca [[ID_TYPE]]
 // CHECK-LLVM: store [[ID_TYPE]] [[ARG0]], [[ID_TYPE]]* [[ID2]]
 // CHECK-LLVM: store [[RANGE_TYPE]] [[ARG1]], [[RANGE_TYPE]]* [[RANGE2]]
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi1EEC1ERKS2_([[ID_TYPE]]* [[ID1]], 
-// CHECK-LLVM: call void @_ZN4sycl3_V15rangeILi1EEC1ERKS2_([[RANGE_TYPE]]* [[RANGE1]],
+// CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID1]] to [[ID_TYPE]] addrspace(4)*
+// CHECK-LLVM: call void @_ZN4sycl3_V12idILi1EEC1ERKS2_([[ID_TYPE]] addrspace(4)* [[ID1_AS]], 
+// CHECK-LLVM: [[RANGE1_AS:%.*]] = addrspacecast [[RANGE_TYPE]]* [[RANGE1]] to [[RANGE_TYPE]] addrspace(4)*
+// CHECK-LLVM: call void @_ZN4sycl3_V15rangeILi1EEC1ERKS2_([[RANGE_TYPE]] addrspace(4)* [[RANGE1_AS]],
 
 extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
   auto id = sycl::id<1>{i};
@@ -45,22 +47,25 @@ extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
 // CHECK-NEXT: %false = arith.constant false
 // CHECK-NEXT: %c0_i8 = arith.constant 0 : i8
 // CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
-// CHECK-NEXT: %2 = "polygeist.memref2pointer"(%0) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<i8>
-// CHECK-NEXT: %3 = "polygeist.typeSize"() {source = !sycl_id_2_} : () -> index
-// CHECK-NEXT: %4 = arith.index_cast %3 : index to i64
-// CHECK-NEXT: "llvm.intr.memset"(%2, %c0_i8, %4, %false) : (!llvm.ptr<i8>, i8, i64, i1) -> ()
-// CHECK-NEXT: sycl.constructor(%1) {MangledName = @_ZN4sycl3_V12idILi2EEC1Ev, Type = @id} : (memref<?x!sycl_id_2_>) -> ()
+// CHECK-NEXT: %1 = "polygeist.memref2pointer"(%0) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<i8>
+// CHECK-NEXT: %2 = "polygeist.typeSize"() {source = !sycl_id_2_} : () -> index
+// CHECK-NEXT: %3 = arith.index_cast %2 : index to i64
+// CHECK-NEXT: "llvm.intr.memset"(%1, %c0_i8, %3, %false) : (!llvm.ptr<i8>, i8, i64, i1) -> ()
+// CHECK-NEXT: %4 = "polygeist.memref2pointer"(%0) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
+// CHECK-NEXT: %5 = llvm.addrspacecast %4 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
+// CHECK-NEXT: %6 = "polygeist.pointer2memref"(%5) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
+// CHECK-NEXT: sycl.constructor(%6) {MangledName = @_ZN4sycl3_V12idILi2EEC1Ev, Type = @id} : (memref<?x!sycl_id_2_, 4>) -> ()
 
 // Ensure declaration to have external linkage.
-// CHECK-LABEL: func.func private @_ZN4sycl3_V12idILi2EEC1Ev(memref<?x!sycl_id_2_>)
+// CHECK-LABEL: func.func private @_ZN4sycl3_V12idILi2EEC1Ev(memref<?x!sycl_id_2_, 4>)
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXTERNAL]], [[PASSTHROUGH]]}
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_1() #0
 // CHECK-LLVM: [[ID1:%.*]] = alloca [[ID_TYPE:%"class.cl::sycl::id.2"]]
 // CHECK-LLVM: [[CAST1:%.*]] = bitcast [[ID_TYPE]]* %1 to i8*
 // CHECK-LLVM: call void @llvm.memset.p0i8.i64(i8* %2, i8 0, i64 16, i1 false)
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1Ev([[ID_TYPE]]* [[ID1]], [[ID_TYPE]]* [[ID1]], i64 0, i64 1, i64 1)  
+// CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID1]] to [[ID_TYPE]] addrspace(4)*
+// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1Ev([[ID_TYPE]] addrspace(4)* [[ID1_AS]], [[ID_TYPE]] addrspace(4)* [[ID1_AS]], i64 0, i64 -1, i64 1)  
 
 extern "C" SYCL_EXTERNAL void cons_1() {
   auto id = sycl::id<2>{};
@@ -69,12 +74,15 @@ extern "C" SYCL_EXTERNAL void cons_1() {
 // CHECK-LABEL: func.func @cons_2(%arg0: i64, %arg1: i64)
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXTERNAL]], [[PASSTHROUGH]]}
 // CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
-// CHECK-NEXT: sycl.constructor(%1, %arg0, %arg1) {MangledName = @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, Type = @id} : (memref<?x!sycl_id_2_>, i64, i64) -> ()
+// CHECK-NEXT: %1 = "polygeist.memref2pointer"(%0) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
+// CHECK-NEXT: %2 = llvm.addrspacecast %1 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
+// CHECK-NEXT: %3 = "polygeist.pointer2memref"(%2) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
+// CHECK-NEXT: sycl.constructor(%3, %arg0, %arg1) {MangledName = @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, Type = @id} : (memref<?x!sycl_id_2_, 4>, i64, i64) -> ()
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_2(i64 %0, i64 %1) #0
 // CHECK-LLVM: [[ID1:%.*]] = alloca [[ID_TYPE:%"class.cl::sycl::id.2"]]
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm([[ID_TYPE]]* [[ID1]], [[ID_TYPE]]* [[ID1]], i64 0, i64 1, i64 1, i64 %0, i64 %1)
+// CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID1]] to [[ID_TYPE]] addrspace(4)*
+// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm([[ID_TYPE]] addrspace(4)* [[ID1_AS]], [[ID_TYPE]] addrspace(4)* [[ID1_AS]], i64 0, i64 -1, i64 1, i64 %0, i64 %1)
 
 extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
   auto id = sycl::id<2>{a, b};
@@ -83,17 +91,23 @@ extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
 // CHECK-LABEL: func.func @cons_3(%arg0: !sycl_item_2_1_)
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXTERNAL]], [[PASSTHROUGH]]}
 // CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
-// CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl_item_2_1_>
-// CHECK-NEXT: %3 = memref.cast %2 : memref<1x!sycl_item_2_1_> to memref<?x!sycl_item_2_1_>
-// CHECK-NEXT: affine.store %arg0, %2[0] : memref<1x!sycl_item_2_1_>
-// CHECK-NEXT: sycl.constructor(%1, %3) {MangledName = @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE, Type = @id} : (memref<?x!sycl_id_2_>, memref<?x!sycl_item_2_1_>) -> ()
+// CHECK-NEXT: %1 = memref.alloca() : memref<1x!sycl_item_2_1_>
+// CHECK-NEXT: affine.store %arg0, %1[0] : memref<1x!sycl_item_2_1_>
+// CHECK-NEXT: %2 = "polygeist.memref2pointer"(%0) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
+// CHECK-NEXT: %3 = llvm.addrspacecast %2 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
+// CHECK-NEXT: %4 = "polygeist.pointer2memref"(%3) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
+// CHECK-NEXT: %5 = "polygeist.memref2pointer"(%1) : (memref<1x!sycl_item_2_1_>) -> !llvm.ptr<!sycl_item_2_1_>
+// CHECK-NEXT: %6 = llvm.addrspacecast %5 : !llvm.ptr<!sycl_item_2_1_> to !llvm.ptr<!sycl_item_2_1_, 4>
+// CHECK-NEXT: %7 = "polygeist.pointer2memref"(%6) : (!llvm.ptr<!sycl_item_2_1_, 4>) -> memref<?x!sycl_item_2_1_, 4>
+// CHECK-NEXT: sycl.constructor(%4, %7) {MangledName = @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE, Type = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_item_2_1_, 4>) -> ()
 
 // CHECK-LLVM: define spir_func void @cons_3([[ITEM_TYPE:%"class.cl::sycl::item.2.true"]] [[ARG0:%.*]]) #0
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE:%"class.cl::sycl::id.2"]]  
 // CHECK-LLVM-DAG: [[ITEM:%.*]] = alloca [[ITEM_TYPE]]
 // CHECK-LLVM: store [[ITEM_TYPE]] [[ARG0]], [[ITEM_TYPE]]* [[ITEM]], align 8
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE([[ID_TYPE]]* [[ID]], [[ID_TYPE]]* [[ID]], i64 0, i64 1, i64 1, [[ITEM_TYPE]]* [[ITEM]], [[ITEM_TYPE]]* [[ITEM]], i64 0, i64 1, i64 1)
+// CHECK-LLVM: [[ID_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID]] to [[ID_TYPE]] addrspace(4)*
+// CHECK-LLVM: [[ITEM_AS:%.*]] = addrspacecast [[ITEM_TYPE]]* [[ITEM]] to [[ITEM_TYPE]] addrspace(4)*
+// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE([[ID_TYPE]] addrspace(4)* [[ID_AS]], [[ID_TYPE]] addrspace(4)* [[ID_AS]], i64 0, i64 -1, i64 1, [[ITEM_TYPE]] addrspace(4)* [[ITEM_AS]], [[ITEM_TYPE]] addrspace(4)* [[ITEM_AS]], i64 0, i64 -1, i64 1)
 
 extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
   auto id = sycl::id<2>{val};
@@ -102,17 +116,23 @@ extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
 // CHECK-LABEL: func.func @cons_4(%arg0: !sycl_id_2_)
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXTERNAL]], [[PASSTHROUGH]]}
 // CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
-// CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl_id_2_>
-// CHECK-NEXT: %3 = memref.cast %2 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
-// CHECK-NEXT: affine.store %arg0, %2[0] : memref<1x!sycl_id_2_>
-// CHECK-NEXT: sycl.constructor(%1, %3) {MangledName = @_ZN4sycl3_V12idILi2EEC1ERKS2_, Type = @id} : (memref<?x!sycl_id_2_>, memref<?x!sycl_id_2_>) -> ()
+// CHECK-NEXT: %1 = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: affine.store %arg0, %1[0] : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %2 = "polygeist.memref2pointer"(%0) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
+// CHECK-NEXT: %3 = llvm.addrspacecast %2 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
+// CHECK-NEXT: %4 = "polygeist.pointer2memref"(%3) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
+// CHECK-NEXT: %5 = "polygeist.memref2pointer"(%1) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
+// CHECK-NEXT: %6 = llvm.addrspacecast %5 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
+// CHECK-NEXT: %7 = "polygeist.pointer2memref"(%6) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
+// CHECK-NEXT: sycl.constructor(%4, %7) {MangledName = @_ZN4sycl3_V12idILi2EEC1ERKS2_, Type = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> ()
 
 // CHECK-LLVM: define spir_func void @cons_4([[ID_TYPE:%"class.cl::sycl::id.2"]] [[ARG0:%.*]]) #0
 // CHECK-LLVM-DAG: [[ID1:%.*]] = alloca [[ID_TYPE]]
 // CHECK-LLVM-DAG: [[ID2:%.*]] = alloca [[ID_TYPE]]
 // CHECK-LLVM: store [[ID_TYPE]] [[ARG0]], [[ID_TYPE]]* [[ID2]], align 8
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ERKS2_([[ID_TYPE]]* [[ID1]], [[ID_TYPE]]* [[ID1]], i64 0, i64 1, i64 1, [[ID_TYPE]]* [[ID2]], [[ID_TYPE]]* [[ID2]], i64 0, i64 1, i64 1)
+// CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID1]] to [[ID_TYPE]] addrspace(4)*
+// CHECK-LLVM: [[ID2_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID2]] to [[ID_TYPE]] addrspace(4)*
+// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ERKS2_([[ID_TYPE]] addrspace(4)* [[ID1_AS]], [[ID_TYPE]] addrspace(4)* [[ID1_AS]], i64 0, i64 -1, i64 1, [[ID_TYPE]] addrspace(4)* [[ID2_AS]], [[ID_TYPE]] addrspace(4)* [[ID2_AS]], i64 0, i64 -1, i64 1)
 
 extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
   auto id = sycl::id<2>{val};
@@ -120,12 +140,13 @@ extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
 
 // CHECK-LABEL: func.func @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev({{.*}})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKONCE]], [[PASSTHROUGH]]}
-// CHECK: [[I:%.*]] = "polygeist.subindex"(%arg0, %c0) : (memref<?x!sycl_accessor_1_i32_write_global_buffer>, index) -> memref<?x!sycl_accessor_impl_device_1_>
-// CHECK: sycl.constructor([[I]], {{%.*}}, {{%.*}}, {{%.*}}) {MangledName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_, Type = @AccessorImplDevice} : (memref<?x!sycl_accessor_impl_device_1_>, !sycl_id_1_, !sycl_range_1_, !sycl_range_1_) -> ()
+// CHECK: [[I:%.*]] = "polygeist.subindex"(%arg0, %c0) : (memref<?x!sycl_accessor_1_i32_write_global_buffer, 4>, index) -> memref<?x!sycl_accessor_impl_device_1_, 4>
+// CHECK: sycl.constructor([[I]], {{%.*}}, {{%.*}}, {{%.*}}) {MangledName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_, Type = @AccessorImplDevice} : (memref<?x!sycl_accessor_impl_device_1_, 4>, !sycl_id_1_, !sycl_range_1_, !sycl_range_1_) -> ()
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_5() #0
 // CHECK-LLVM: [[ACCESSOR:%.*]] = alloca %"class.cl::sycl::accessor.1", align 8
-// CHECK-LLVM: call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.cl::sycl::accessor.1"* [[ACCESSOR]], %"class.cl::sycl::accessor.1"* [[ACCESSOR]], i64 0, i64 1, i64 1)
+// CHECK-LLVM: [[ACAST:%.*]] = addrspacecast %"class.cl::sycl::accessor.1"* [[ACCESSOR]] to %"class.cl::sycl::accessor.1" addrspace(4)*
+// CHECK-LLVM: call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.cl::sycl::accessor.1" addrspace(4)* [[ACAST]], %"class.cl::sycl::accessor.1" addrspace(4)* [[ACAST]], i64 0, i64 -1, i64 1)
 
 extern "C" SYCL_EXTERNAL void cons_5() {
   auto accessor = sycl::accessor<sycl::cl_int, 1, sycl::access::mode::write>{};

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -20,9 +20,11 @@
 // CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-NEXT: %c0_i32 = arith.constant 0 : i32
 // CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_item_2_1_>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_item_2_1_> to memref<?x!sycl_item_2_1_>
 // CHECK-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl_item_2_1_>
-// CHECK-NEXT: %2 = sycl.call(%1, %c0_i32) {Function = @get_id, MangledName = @_ZNK4sycl3_V14itemILi2ELb1EE6get_idEi, Type = @item} : (memref<?x!sycl_item_2_1_>, i32) -> i64
+// CHECK-NEXT: %1 = "polygeist.memref2pointer"(%0) : (memref<1x!sycl_item_2_1_>) -> !llvm.ptr<!sycl_item_2_1_>
+// CHECK-NEXT: %2 = llvm.addrspacecast %1 : !llvm.ptr<!sycl_item_2_1_> to !llvm.ptr<!sycl_item_2_1_, 4>
+// CHECK-NEXT: %3 = "polygeist.pointer2memref"(%2) : (!llvm.ptr<!sycl_item_2_1_, 4>) -> memref<?x!sycl_item_2_1_, 4>
+// CHECK-NEXT: %4 = sycl.call(%3, %c0_i32) {Function = @get_id, MangledName = @_ZNK4sycl3_V14itemILi2ELb1EE6get_idEi, Type = @item} : (memref<?x!sycl_item_2_1_, 4>, i32) -> i64
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
@@ -33,9 +35,11 @@ SYCL_EXTERNAL void method_1(sycl::item<2, true> item) {
 // CHECK: func.func @_Z8method_2N4sycl3_V14itemILi2ELb1EEE(%arg0: !sycl_item_2_1_)
 // CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_item_2_1_>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_item_2_1_> to memref<?x!sycl_item_2_1_>
 // CHECK-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl_item_2_1_>
-// CHECK-NEXT: %2 = sycl.call(%1, %1) {Function = @"operator==", MangledName = @_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_, Type = @item} : (memref<?x!sycl_item_2_1_>, memref<?x!sycl_item_2_1_>) -> i8
+// CHECK-NEXT: %1 = "polygeist.memref2pointer"(%0) : (memref<1x!sycl_item_2_1_>) -> !llvm.ptr<!sycl_item_2_1_>
+// CHECK-NEXT: %2 = llvm.addrspacecast %1 : !llvm.ptr<!sycl_item_2_1_> to !llvm.ptr<!sycl_item_2_1_, 4>
+// CHECK-NEXT: %3 = "polygeist.pointer2memref"(%2) : (!llvm.ptr<!sycl_item_2_1_, 4>) -> memref<?x!sycl_item_2_1_, 4>
+// CHECK-NEXT: %4 = sycl.call(%3, %3) {Function = @"operator==", MangledName = @_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_, Type = @item} : (memref<?x!sycl_item_2_1_, 4>, memref<?x!sycl_item_2_1_, 4>) -> i8
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
@@ -46,12 +50,16 @@ SYCL_EXTERNAL void method_2(sycl::item<2, true> item) {
 // CHECK: func.func @_Z4op_1N4sycl3_V12idILi2EEES2_(%arg0: !sycl_id_2_, %arg1: !sycl_id_2_)
 // CHECK-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-NEXT: %0 = memref.alloca() : memref<1x!sycl_id_2_>
-// CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
-// CHECK-NEXT: %2 = memref.alloca() : memref<1x!sycl_id_2_>
-// CHECK-NEXT: %3 = memref.cast %2 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
-// CHECK-NEXT: affine.store %arg0, %2[0] : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %1 = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: affine.store %arg0, %1[0] : memref<1x!sycl_id_2_>
 // CHECK-NEXT: affine.store %arg1, %0[0] : memref<1x!sycl_id_2_>
-// CHECK-NEXT: %4 = sycl.call(%3, %1) {Function = @"operator==", MangledName = @_ZNK4sycl3_V12idILi2EEeqERKS2_, Type = @id} : (memref<?x!sycl_id_2_>, memref<?x!sycl_id_2_>) -> i8
+// CHECK-NEXT: %2 = "polygeist.memref2pointer"(%1) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
+// CHECK-NEXT: %3 = llvm.addrspacecast %2 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
+// CHECK-NEXT: %4 = "polygeist.pointer2memref"(%3) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
+// CHECK-NEXT: %5 = "polygeist.memref2pointer"(%0) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
+// CHECK-NEXT: %6 = llvm.addrspacecast %5 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
+// CHECK-NEXT: %7 = "polygeist.pointer2memref"(%6) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
+// CHECK-NEXT: %8 = sycl.call(%4, %7) {Function = @"operator==", MangledName = @_ZNK4sycl3_V12idILi2EEeqERKS2_, Type = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> i8
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 
@@ -67,10 +75,13 @@ SYCL_EXTERNAL void op_1(sycl::id<2> a, sycl::id<2> b) {
 // CHECK-NEXT: %1 = memref.cast %0 : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
 // CHECK-NEXT: affine.store %arg0, %0[0] : memref<1x!sycl_id_2_>
 // CHECK-NEXT: %2 = sycl.cast(%1) : (memref<?x!sycl_id_2_>) -> memref<?x!sycl_array_2_>
-// CHECK-NEXT: %3 = sycl.call(%2, %c0_i32) {Function = @get, MangledName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, Type = @array} : (memref<?x!sycl_array_2_>, i32) -> i64
-// CHECK-NEXT: %4 = sycl.call(%2, %c1_i32) {Function = @get, MangledName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, Type = @array} : (memref<?x!sycl_array_2_>, i32) -> i64
-// CHECK-NEXT: %5 = arith.addi %3, %4 : i64
-// CHECK-NEXT: %6 = sycl.call(%5) {Function = @abs, MangledName = @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_} : (i64) -> i64
+// CHECK-NEXT: %3 = "polygeist.memref2pointer"(%2) : (memref<?x!sycl_array_2_>) -> !llvm.ptr<!sycl_array_2_>
+// CHECK-NEXT: %4 = llvm.addrspacecast %3 : !llvm.ptr<!sycl_array_2_> to !llvm.ptr<!sycl_array_2_, 4>
+// CHECK-NEXT: %5 = "polygeist.pointer2memref"(%4) : (!llvm.ptr<!sycl_array_2_, 4>) -> memref<?x!sycl_array_2_, 4>
+// CHECK-NEXT: %6 = sycl.call(%5, %c0_i32) {Function = @get, MangledName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, Type = @array} : (memref<?x!sycl_array_2_, 4>, i32) -> i64
+// CHECK-NEXT: %7 = sycl.call(%5, %c1_i32) {Function = @get, MangledName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, Type = @array} : (memref<?x!sycl_array_2_, 4>, i32) -> i64
+// CHECK-NEXT: %8 = arith.addi %6, %7 : i64
+// CHECK-NEXT: %9 = sycl.call(%8) {Function = @abs, MangledName = @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_} : (i64) -> i64
 // CHECK-NEXT: return
 // CHECK-NEXT: }
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -27,7 +27,7 @@
 // CHECK-LLVM-DAG: %"class.cl::sycl::detail::ItemBase.1.true" = type { %"class.cl::sycl::range.1", %"class.cl::sycl::id.1", %"class.cl::sycl::id.1" }
 
 // CHECK-MLIR: gpu.module @device_functions
-// CHECK-MLIR: gpu.func @_ZTS8kernel_1(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
+// CHECK-MLIR: gpu.func @_ZTS8kernel_1(%arg0: memref<?xi32, 1>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
 // CHECK-MLIR-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 // CHECK-MLIR-NOT: gpu.func kernel
 
@@ -58,7 +58,7 @@ void host_1() {
   }
 }
 
-// CHECK-MLIR: gpu.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
+// CHECK-MLIR: gpu.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2(%arg0: memref<?xi32, 1>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
 // CHECK-MLIR-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]}
 // CHECK-MLIR-NOT: gpu.func kernel
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -35,7 +35,8 @@
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_5() #0 {
 // CHECK-LLVM-NEXT:  [[ACCESSOR:%.*]] = alloca %"class.cl::sycl::accessor.1", align 8
-// CHECK-LLVM-NEXT:  call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.cl::sycl::accessor.1"* [[ACCESSOR]], %"class.cl::sycl::accessor.1"* [[ACCESSOR]], i64 0, i64 1, i64 1)
+// CHECK-LLVM-NEXT:  [[ACAST:%.*]] = addrspacecast %"class.cl::sycl::accessor.1"* [[ACCESSOR]] to %"class.cl::sycl::accessor.1" addrspace(4)*
+// CHECK-LLVM-NEXT:  call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.cl::sycl::accessor.1" addrspace(4)* [[ACAST]], %"class.cl::sycl::accessor.1" addrspace(4)* [[ACAST]], i64 0, i64 -1, i64 1)
 
 extern "C" SYCL_EXTERNAL void cons_5() {
   sycl::accessor<sycl::cl_int, 1, sycl::access::mode::write> accessor;

--- a/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
@@ -21,16 +21,16 @@
 
 // CHECK-MLIR:      func.func private [[FUNC]]({{.*}})
 // CHECK-SAME:      attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<internal>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
-// CHECK-MLIR-DAG:  [[V1:%.*]] = affine.load {{.*}}[0] : memref<?xf32>
-// CHECK-MLIR-DAG:  [[V2:%.*]] = affine.load {{.*}}[0] : memref<?xf32>
+// CHECK-MLIR-DAG:  [[V1:%.*]] = affine.load {{.*}}[0] : memref<?xf32, 4>
+// CHECK-MLIR-DAG:  [[V2:%.*]] = affine.load {{.*}}[0] : memref<?xf32, 4>
 // CHECK-MLIR-NEXT: [[RESULT:%.*]] = arith.addf [[V1]], [[V2]] : f32
-// CHECK-MLIR-NEXT: affine.store [[RESULT]], {{.*}}[0] : memref<?xf32>
+// CHECK-MLIR-NEXT: affine.store [[RESULT]], {{.*}}[0] : memref<?xf32, 4>
 
-// CHECK-LLVM:       define internal spir_func void [[FUNC:@.*vec_add_device_simple.*]]({{.*}}) #0
-// CHECK-LLVM-DAG:   [[V1:%.*]] = load float, float* {{.*}}, align 4
-// CHECK-LLVM-DAG:   [[V2:%.*]] = load float, float* {{.*}}, align 4
+// CHECK-LLVM:       define internal spir_func void [[FUNC:@.*vec_add_device_simple.*_]]({{.*}}) #0
+// CHECK-LLVM-DAG:   [[V1:%.*]] = load float, float addrspace(4)* {{.*}}, align 4
+// CHECK-LLVM-DAG:   [[V2:%.*]] = load float, float addrspace(4)* {{.*}}, align 4
 // CHECK-LLVM:       [[RESULT:%.*]] = fadd float [[V1]], [[V2]]
-// CHECK-LLVM:       store float [[RESULT]], float* {{.*}}, align 4
+// CHECK-LLVM:       store float [[RESULT]], float addrspace(4)* {{.*}}, align 4
 
 // CHECK-LLVM:       define weak_odr spir_kernel void @{{.*}}vec_add_simple({{.*}}) #0
 // CHECK-LLVM:       call void [[FUNC]]

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -983,7 +983,7 @@ int main(int argc, char **argv) {
     eraseHostCode(*module);
     module.get()->setAttr(mlir::gpu::GPUDialect::getContainerModuleAttrName(),
                           Builder.getUnitAttr());
-  } else
+  } else if (!deviceModule.body().empty())
     deviceModule.erase();
 
   LLVM_DEBUG({

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -983,7 +983,7 @@ int main(int argc, char **argv) {
     eraseHostCode(*module);
     module.get()->setAttr(mlir::gpu::GPUDialect::getContainerModuleAttrName(),
                           Builder.getUnitAttr());
-  } else if (!deviceModule.body().empty())
+  } else
     deviceModule.erase();
 
   LLVM_DEBUG({


### PR DESCRIPTION
- Add `PointerElementTypeInterface::Trait` to SYCL types, so we can do `memref2pointer -> addrspacecast -> pointer2memref` on SYCL types.
- Perform address space conversion for arguments of function calls.
- Handle CK_AddressSpaceConversion expression.
- In `getMLIRType`, get pointer type address space based on pointee type.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>

Co-authored-by: Tiotto, Ettore <ettore.tiotto@intel.com>
Co-authored-by: Tsang, Whitney <whitney.tsang@intel.com>