### PR TITLE
[SYCL-MLIR] Register SYCL operations implementing the SYCLMethodOpInterface

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/CMakeLists.txt
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/CMakeLists.txt
@@ -1,2 +1,8 @@
 add_mlir_dialect(SYCLOps sycl)
-add_mlir_doc(SYCLOps SYCLOps Dialects/ -gen-op-doc)
+add_mlir_doc(SYCLOps SYCLOps Dialects/ -gen-op-doc -gen-op-interface-doc)
+
+set(LLVM_TARGET_DEFINITIONS SYCLOpInterfaces.td)
+mlir_tablegen(SYCLOpInterfaces.h.inc -gen-op-interface-decls)
+mlir_tablegen(SYCLOpInterfaces.cpp.inc -gen-op-interface-defs)
+add_public_tablegen_target(SYCLOpInterfacesIncGen)
+add_dependencies(mlir-generic-headers SYCLOpInterfacesIncGen)

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.h
@@ -1,0 +1,27 @@
+// Copyright (C) Intel
+
+//===--- SYCLOpInterfaces.h -----------------------------------------------===//
+//
+// MLIR-SYCL is under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_SYCL_OPS_INTERFACES_H_
+#define MLIR_SYCL_OPS_INTERFACES_H_
+
+#include <type_traits>
+
+#include "mlir/Dialect/SYCL/IR/SYCLOpsTypes.h"
+
+#include "mlir/Dialect/SYCL/IR/SYCLOpInterfaces.h.inc"
+
+namespace mlir {
+namespace sycl {
+template <typename T>
+using isSYCLMethod = std::is_base_of<SYCLMethodOpInterface::Trait<T>, T>;
+} // namespace sycl
+} // namespace mlir
+
+#endif // MLIR_SYCL_OPS_INTERFACES_H_

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td
@@ -1,0 +1,40 @@
+// Copyright (C) Intel
+
+//===--- SYCLOpInterfaces.td ----------------------------------------------===//
+//
+// MLIR-SYCL is under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SYCL_OP_INTERFACES
+#define SYCL_OP_INTERFACES
+
+include "mlir/IR/OpBase.td"
+
+class SYCL_OpInterface<string name> : OpInterface<name> {
+  let cppNamespace = "::mlir::sycl";
+}
+
+def SYCLMethodOpInterface : SYCL_OpInterface<"SYCLMethodOpInterface"> {
+  let description =[{
+    This interface describes an operation that calls a member function of a SYCL
+    type.
+
+    Operations implementing this interface are registered as methods in the
+    `SYCLDialect`. See the `SYCLDialect` documentation.
+  }];
+
+  let methods = [
+    StaticInterfaceMethod<[{
+      Return the ID of the type this method is a member of.
+    }], "::mlir::TypeID", "getTypeID">,
+    StaticInterfaceMethod<[{
+      Return the list of the method names to be replaced by this
+      operation.
+    }], "llvm::ArrayRef<llvm::StringLiteral>", "getMethodNames">,
+  ];
+}
+
+#endif // SYCL_OP_INTERFACES

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -15,6 +15,7 @@ include "mlir/IR/OpBase.td"
 include "mlir/Dialect/MemRef/IR/MemRefBase.td"
 include "mlir/Interfaces/CastInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "SYCLOpInterfaces.td"
 
 ////////////////////////////////////////////////////////////////////////////////
 // TYPE DECLARATIONS
@@ -24,6 +25,34 @@ def SYCL_Dialect : Dialect {
   let name = "sycl";
   let cppNamespace = "::mlir::sycl";
   let useDefaultTypePrinterParser = 1;
+  let extraClassDeclaration = [{
+    llvm::DenseMap<std::pair<::mlir::TypeID, llvm::StringRef>, llvm::StringRef>
+        Methods;
+
+    /// Register a SYCL operation as a method
+    ///
+    /// Calls to `findMethod(TypeID, name)` (being name present in
+    /// `MethodNames`), will return `Opname`.
+    void addSYCLMethod(
+        mlir::TypeID TypeID, llvm::ArrayRef<llvm::StringLiteral> MethodNames,
+        llvm::StringRef OpName);
+
+    /// If T implements the SYCLMethodOpInterface interface, it will
+    /// be registered as a method. Do nmothing otherwise.
+    template <typename T> void addSYCLMethod();
+
+    /// Each operation will be registered as usual in an MLIR dialect
+    /// and also will be registered as a SYCL method if it implements one.
+    template <typename... Args> void addOperations();
+
+    /// Returns the name of the operation implementing the queried
+    /// method, if present.
+    ///
+    /// For a method to be queried, it must have been registered
+    /// first.
+    llvm::Optional<llvm::StringRef> findMethod(::mlir::TypeID Type,
+                                               llvm::StringRef Name) const;
+  }];
 }
 
 class SYCL_Op<string mnemonic, list<Trait> traits = []>

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsDialect.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsDialect.h
@@ -21,6 +21,10 @@
 /// sycl dialect.
 #include "mlir/Dialect/SYCL/IR/SYCLOpsDialect.h.inc"
 
+/// Include the header file containing the declaration of the sycl operation
+/// interfaces.
+#include "mlir/Dialect/SYCL/IR/SYCLOpInterfaces.h"
+
 /// Include the auto-generated header file containing the declarations of the
 /// sycl operations.
 #define GET_OP_CLASSES


### PR DESCRIPTION
Modify how operations are registered so that operations implementing SYCL methods are registered as well.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>