### PR TITLE
[SYCL-MLIR] Lower SYCLMethodOpInterface instances to sycl.call

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td
@@ -28,7 +28,7 @@ def SYCLMethodOpInterface : SYCL_OpInterface<"SYCLMethodOpInterface"> {
     `BaseType` method, returning the SYCL type representing the class this
     method is a member of; the `Type` method, returning the original name of the
     type this operation is a member of; and the `Funcion` method, returning the
-    name of the function implementing this operation.
+    unmangled name of the function implementing this operation.
 
     Operations implementing this interface are registered as methods in the
     `SYCLDialect`. See the `SYCLDialect` documentation.

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td
@@ -23,7 +23,7 @@ def SYCLMethodOpInterface : SYCL_OpInterface<"SYCLMethodOpInterface"> {
     type.
 
     Operations implementing this interface should inherit
-    `SYCLMethodOpInterfaceImpl` and also implement the `MangledName` method,
+    `SYCLMethodOpInterfaceImpl` and also implement the `MangledFunctionName` method,
     returning the mangled name of the function implementing this operation; the
     `BaseType` method, returning the SYCL type representing the class this
     method is a member of; the `Type` method, returning the original name of the

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td
@@ -23,12 +23,12 @@ def SYCLMethodOpInterface : SYCL_OpInterface<"SYCLMethodOpInterface"> {
     type.
 
     Operations implementing this interface should inherit
-    `SYCLMethodOpInterfaceImpl` and also implement the `MangledFunctionName` method,
-    returning the mangled name of the function implementing this operation; the
-    `BaseType` method, returning the SYCL type representing the class this
-    method is a member of; the `Type` method, returning the original name of the
-    type this operation is a member of; and the `Funcion` method, returning the
-    unmangled name of the function implementing this operation.
+    `SYCLMethodOpInterfaceImpl` and also implement the `BaseType` method,
+    returning the SYCL type representing the class this method is a member of;
+    the `MangledFunctionName` method, returning the mangled name of the function
+    implementing this operation; the `Funcion` method, returning the unmangled
+    name of the function implementing this operation; and the `Type` method,
+    returning the original name of the type this operation is a member of.
 
     Operations implementing this interface are registered as methods in the
     `SYCLDialect`. See the `SYCLDialect` documentation.

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td
@@ -26,7 +26,7 @@ def SYCLMethodOpInterface : SYCL_OpInterface<"SYCLMethodOpInterface"> {
     `SYCLMethodOpInterfaceImpl` and also implement the `BaseType` method,
     returning the SYCL type representing the class this method is a member of;
     the `MangledFunctionName` method, returning the mangled name of the function
-    implementing this operation; the `FuncionName` method, returning the
+    implementing this operation; the `FunctionName` method, returning the
     unmangled name of the function implementing this operation; and the
     `TypeName` method, returning the original name of the type this operation is
     a member of.

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td
@@ -26,9 +26,10 @@ def SYCLMethodOpInterface : SYCL_OpInterface<"SYCLMethodOpInterface"> {
     `SYCLMethodOpInterfaceImpl` and also implement the `BaseType` method,
     returning the SYCL type representing the class this method is a member of;
     the `MangledFunctionName` method, returning the mangled name of the function
-    implementing this operation; the `Funcion` method, returning the unmangled
-    name of the function implementing this operation; and the `Type` method,
-    returning the original name of the type this operation is a member of.
+    implementing this operation; the `FuncionName` method, returning the
+    unmangled name of the function implementing this operation; and the
+    `TypeName` method, returning the original name of the type this operation is
+    a member of.
 
     Operations implementing this interface are registered as methods in the
     `SYCLDialect`. See the `SYCLDialect` documentation.

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td
@@ -22,6 +22,14 @@ def SYCLMethodOpInterface : SYCL_OpInterface<"SYCLMethodOpInterface"> {
     This interface describes an operation that calls a member function of a SYCL
     type.
 
+    Operations implementing this interface should inherit
+    `SYCLMethodOpInterfaceImpl` and also implement the `MangledName` method,
+    returning the mangled name of the function implementing this operation; the
+    `BaseType` method, returning the SYCL type representing the class this
+    method is a member of; the `Type` method, returning the original name of the
+    type this operation is a member of; and the `Funcion` method, returning the
+    name of the function implementing this operation.
+
     Operations implementing this interface are registered as methods in the
     `SYCLDialect`. See the `SYCLDialect` documentation.
   }];
@@ -34,6 +42,18 @@ def SYCLMethodOpInterface : SYCL_OpInterface<"SYCLMethodOpInterface"> {
       Return the list of the method names to be replaced by this
       operation.
     }], "llvm::ArrayRef<llvm::StringLiteral>", "getMethodNames">,
+    InterfaceMethod<[{
+      Return the SYCL type this method is implemented in.
+    }], "::mlir::Type", "getBaseType">,
+    InterfaceMethod<[{
+      Return the mangled name of the function implementing this operation.
+    }], "llvm::StringRef", "getMangledFunctionName">,
+    InterfaceMethod<[{
+      Return the name of the function implementing this operation.
+    }], "llvm::StringRef", "getFunctionName">,
+    InterfaceMethod<[{
+      Return the original name of the type this method is implemented in.
+    }], "llvm::StringRef", "getType">,
   ];
 }
 

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td
@@ -43,7 +43,7 @@ def SYCLMethodOpInterface : SYCL_OpInterface<"SYCLMethodOpInterface"> {
       operation.
     }], "llvm::ArrayRef<llvm::StringLiteral>", "getMethodNames">,
     InterfaceMethod<[{
-      Return the SYCL type this method is implemented in.
+      Return the SYCL type this method is a member of.
     }], "::mlir::Type", "getBaseType">,
     InterfaceMethod<[{
       Return the mangled name of the function implementing this operation.
@@ -53,7 +53,7 @@ def SYCLMethodOpInterface : SYCL_OpInterface<"SYCLMethodOpInterface"> {
     }], "llvm::StringRef", "getFunctionName">,
     InterfaceMethod<[{
       Return the original name of the type this method is implemented in.
-    }], "llvm::StringRef", "getType">,
+    }], "llvm::StringRef", "getTypeName">,
   ];
 }
 

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -45,6 +45,30 @@ def SYCL_Dialect : Dialect {
 class SYCL_Op<string mnemonic, list<Trait> traits = []>
     : Op<SYCL_Dialect, mnemonic, traits>;
 
+class SYCLMethodOpInterfaceImpl<
+    string mnemonic, string type, list<string> methodNames, list<Trait> traits = []>
+        : SYCL_Op<mnemonic, !listconcat(traits, [SYCLMethodOpInterface])> {
+  string baseType = type;
+  list<string> memberFunctionNames = methodNames;
+  int arrSize = !size(memberFunctionNames);
+
+  let extraClassDeclaration = [{
+    static constexpr std::array<llvm::StringLiteral, }] # arrSize # [{> methods{{ }] #
+      !interleave(!foreach(name, memberFunctionNames, "\"" # name # "\""), ", ") # [{
+     }};
+    static ::mlir::TypeID getTypeID() { return ::mlir::sycl::}] # type # [{::getTypeID(); }
+    static constexpr llvm::ArrayRef<llvm::StringLiteral> getMethodNames() { return methods; }
+    ::mlir::Type getBaseType() { return BaseType(); }
+    llvm::StringRef getFunctionName() { return Function(); }
+    llvm::StringRef getMangledFunctionName() { return MangledName(); }
+    llvm::StringRef getType() { return Type(); }
+  }];
+
+  let extraClassDefinition = [{
+  constexpr std::array<llvm::StringLiteral, }] # arrSize # [{> $cppClass::methods;
+  }];
+}
+
 def SYCL_IDType : DialectType<SYCL_Dialect, CPred<"$_self.isa<IDType>()">, "sycl::id type">;
 def SYCL_AccessorCommonType : DialectType<SYCL_Dialect, CPred<"$_self.isa<AccessorCommonType>()">, "sycl::accessor_common type">;
 def SYCL_AccessorType : DialectType<SYCL_Dialect, CPred<"$_self.isa<AccessorType>()">, "sycl::accessor type">;

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -59,9 +59,9 @@ class SYCLMethodOpInterfaceImpl<
     static ::mlir::TypeID getTypeID() { return ::mlir::sycl::}] # type # [{::getTypeID(); }
     static constexpr llvm::ArrayRef<llvm::StringLiteral> getMethodNames() { return methods; }
     ::mlir::Type getBaseType() { return BaseType(); }
-    llvm::StringRef getFunctionName() { return Function(); }
-    llvm::StringRef getMangledFunctionName() { return MangledName(); }
-    llvm::StringRef getType() { return Type(); }
+    llvm::StringRef getFunctionName() { return FunctionName(); }
+    llvm::StringRef getMangledFunctionName() { return MangledFunctionName(); }
+    llvm::StringRef getTypeName() { return TypeName(); }
   }];
 
   let extraClassDefinition = [{

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -59,8 +59,8 @@ class SYCLMethodOpInterfaceImpl<
     static ::mlir::TypeID getTypeID() { return ::mlir::sycl::}] # type # [{::getTypeID(); }
     static constexpr llvm::ArrayRef<llvm::StringLiteral> getMethodNames() { return methods; }
     ::mlir::Type getBaseType() { return BaseType(); }
-    llvm::StringRef getFunctionName() { return FunctionName(); }
     llvm::StringRef getMangledFunctionName() { return MangledFunctionName(); }
+    llvm::StringRef getFunctionName() { return FunctionName(); }
     llvm::StringRef getTypeName() { return TypeName(); }
   }];
 

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -362,7 +362,7 @@ static LogicalResult convertMethod(SYCLMethodOpInterface op,
   LLVM_DEBUG(llvm::dbgs() << "MethodPattern: Rewriting op: "; op.dump();
              llvm::dbgs() << "\n");
 
-  SmallVector<mlir::Value> MethodArgs(op->getOperands());
+  SmallVector<mlir::Value> methodArgs(op->getOperands());
 
   if (op.getBaseType() != MethodArgs[0].getType()) {
     auto Cast = rewriter.create<SYCLCastOp>(op.getLoc(), op.getBaseType(),

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -364,14 +364,12 @@ static LogicalResult convertMethod(SYCLMethodOpInterface op,
 
   SmallVector<mlir::Value> methodArgs(op->getOperands());
 
-  if (op.getBaseType() != methodArgs[0].getType()) {
-    auto Cast = rewriter.create<SYCLCastOp>(op.getLoc(), op.getBaseType(),
-                                            op->getOperand(0));
-    methodArgs[0] = Cast;
-  }
+  if (op.getBaseType() != methodArgs[0].getType())
+    methodArgs[0] = rewriter.create<SYCLCastOp>(op.getLoc(), op.getBaseType(),
+                                                op->getOperand(0));
 
   rewriter.replaceOpWithNewOp<SYCLCallOp>(
-      op, op->getResult(0).getType(), op.getType(), op.getFunctionName(),
+      op, op->getResult(0).getType(), op.getTypeName(), op.getFunctionName(),
       op.getMangledFunctionName(), methodArgs);
 
   return success();

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -354,6 +354,43 @@ private:
 };
 
 //===----------------------------------------------------------------------===//
+// MethodPattern - Converts SYCLMethodOpInterface to LLVM.
+//===----------------------------------------------------------------------===//
+
+static LogicalResult convertMethod(SYCLMethodOpInterface op,
+                                   ConversionPatternRewriter &rewriter) {
+  LLVM_DEBUG(llvm::dbgs() << "MethodPattern: Rewriting op: "; op.dump();
+             llvm::dbgs() << "\n");
+
+  SmallVector<mlir::Value> MethodArgs(op->getOperands());
+
+  if (op.getBaseType() != MethodArgs[0].getType()) {
+    auto Cast = rewriter.create<SYCLCastOp>(op.getLoc(), op.getBaseType(),
+                                            op->getOperand(0));
+    MethodArgs[0] = Cast;
+  }
+
+  rewriter.replaceOpWithNewOp<SYCLCallOp>(
+      op, op->getResult(0).getType(), op.getType(), op.getFunctionName(),
+      op.getMangledFunctionName(), MethodArgs);
+
+  return success();
+}
+
+template <typename T, typename = std::enable_if_t<isSYCLMethod<T>::value>>
+class MethodPattern final : public ConvertOpToLLVMPattern<T> {
+public:
+  using ConvertOpToLLVMPattern<T>::ConvertOpToLLVMPattern;
+  using OpAdaptor = typename T::Adaptor;
+
+  LogicalResult
+  matchAndRewrite(T op, OpAdaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    return convertMethod(op, rewriter);
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // Pattern population
 //===----------------------------------------------------------------------===//
 
@@ -390,6 +427,27 @@ void mlir::sycl::populateSYCLToLLVMTypeConversion(
   });
 }
 
+// If the operation is a method, add the SYCLMethod pattern for that
+// operation.
+template <typename T>
+static typename std::enable_if_t<isSYCLMethod<T>::value>
+addSYCLMethodPattern(LLVMTypeConverter &typeConverter,
+                     RewritePatternSet &patterns) {
+  patterns.add<MethodPattern<T>>(typeConverter);
+}
+
+// If the operation is not a method, do nothing.
+template <typename T>
+static typename std::enable_if_t<!isSYCLMethod<T>::value>
+addSYCLMethodPattern(LLVMTypeConverter &, RewritePatternSet &) {}
+
+template <typename... Args>
+static void addSYCLMethodPatterns(LLVMTypeConverter &typeConverter,
+                                  RewritePatternSet &patterns) {
+  (void)std::initializer_list<int>{
+      0, (addSYCLMethodPattern<Args>(typeConverter, patterns), 0)...};
+}
+
 void mlir::sycl::populateSYCLToLLVMConversionPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns) {
   populateSYCLToLLVMTypeConversion(typeConverter);
@@ -397,6 +455,10 @@ void mlir::sycl::populateSYCLToLLVMConversionPatterns(
   patterns.add<CallPattern>(typeConverter);
   patterns.add<CastPattern>(typeConverter);
   patterns.add<ConstructorPattern>(typeConverter);
+  addSYCLMethodPatterns<
+#define GET_OP_LIST
+#include "mlir/Dialect/SYCL/IR/SYCLOps.cpp.inc"
+      >(typeConverter, patterns);
 }
 
 bool mlir::sycl::isSYCLType(Type type) {

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -364,15 +364,15 @@ static LogicalResult convertMethod(SYCLMethodOpInterface op,
 
   SmallVector<mlir::Value> methodArgs(op->getOperands());
 
-  if (op.getBaseType() != MethodArgs[0].getType()) {
+  if (op.getBaseType() != methodArgs[0].getType()) {
     auto Cast = rewriter.create<SYCLCastOp>(op.getLoc(), op.getBaseType(),
                                             op->getOperand(0));
-    MethodArgs[0] = Cast;
+    methodArgs[0] = Cast;
   }
 
   rewriter.replaceOpWithNewOp<SYCLCallOp>(
       op, op->getResult(0).getType(), op.getType(), op.getFunctionName(),
-      op.getMangledFunctionName(), MethodArgs);
+      op.getMangledFunctionName(), methodArgs);
 
   return success();
 }


### PR DESCRIPTION
Use the newly introduced `Function`, `MangledName` and `Type` to build                                                                                                                                              
the new operation and `BaseType` to know whether a cast is needed when                                                                                                                                              
lowering.

Signed-off-by: Victor Perez <victor.perez@codeplay.com> 