### PR TITLE
[SYCL-MLIR][cgeist][test] Update lit test files to use the new clang driver (that uses cgeist).

### DIFF
--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -8,7 +8,7 @@
 
 // clang-format off
 // RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s 2> /dev/null | FileCheck %s --check-prefixes=CHECK
-// RUN: clang++ -fsycl -fsycl-device-only -target x86_64-unknown-linux-gnu -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s | FileCheck %s --check-prefixes=CHECK-LLVM
+// RUN: clang++ -fsycl -fsycl-device-only -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s | FileCheck %s --check-prefixes=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 // clang-format off
-// RUN: sycl-clang.py %s -S 2> /dev/null | FileCheck %s --check-prefixes=CHECK
-// RUN: sycl-clang.py %s -S -emit-llvm | FileCheck %s --check-prefixes=CHECK-LLVM
+// RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s 2> /dev/null | FileCheck %s --check-prefixes=CHECK
+// RUN: clang++ -fsycl -fsycl-device-only -target x86_64-unknown-linux-gnu -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s | FileCheck %s --check-prefixes=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: sycl-clang.py %s -S | FileCheck %s
+// RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s | FileCheck %s
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: sycl-clang.py %s -S | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: sycl-clang.py %s -S -emit-llvm | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s 2> /dev/null| FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: clang++ -fsycl -fsycl-device-only -target x86_64-unknown-linux-gnu -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 
@@ -18,11 +18,11 @@
 // CHECK-MLIR: !sycl_item_1_1_ = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>
 // CHECK-MLIR: !sycl_range_1_ = !sycl.range<1>
 
+// CHECK-LLVM: %"class.cl::sycl::range.1" = type { %"class.cl::sycl::detail::array.1" }
+// CHECK-LLVM: %"class.cl::sycl::detail::array.1" = type { [1 x i64] }
 // CHECK-LLVM: %"class.cl::sycl::accessor.1" = type { %"class.cl::sycl::detail::AccessorImplDevice.1", { i32 addrspace(1)* }, { i32 addrspace(1)* } }
 // CHECK-LLVM: %"class.cl::sycl::detail::AccessorImplDevice.1" = type { %"class.cl::sycl::id.1", %"class.cl::sycl::range.1", %"class.cl::sycl::range.1" }
 // CHECK-LLVM: %"class.cl::sycl::id.1" = type { %"class.cl::sycl::detail::array.1" }
-// CHECK-LLVM: %"class.cl::sycl::detail::array.1" = type { [1 x i64] }
-// CHECK-LLVM: %"class.cl::sycl::range.1" = type { %"class.cl::sycl::detail::array.1" }
 // CHECK-LLVM: %"class.cl::sycl::item.1.true" = type { %"class.cl::sycl::detail::ItemBase.1.true" }
 // CHECK-LLVM: %"class.cl::sycl::detail::ItemBase.1.true" = type { %"class.cl::sycl::range.1", %"class.cl::sycl::id.1", %"class.cl::sycl::id.1" }
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s 2> /dev/null| FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -fsycl -fsycl-device-only -target x86_64-unknown-linux-gnu -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -fsycl -fsycl-device-only -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 
@@ -18,13 +18,13 @@
 // CHECK-MLIR: !sycl_item_1_1_ = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>
 // CHECK-MLIR: !sycl_range_1_ = !sycl.range<1>
 
-// CHECK-LLVM: %"class.cl::sycl::range.1" = type { %"class.cl::sycl::detail::array.1" }
-// CHECK-LLVM: %"class.cl::sycl::detail::array.1" = type { [1 x i64] }
-// CHECK-LLVM: %"class.cl::sycl::accessor.1" = type { %"class.cl::sycl::detail::AccessorImplDevice.1", { i32 addrspace(1)* }, { i32 addrspace(1)* } }
-// CHECK-LLVM: %"class.cl::sycl::detail::AccessorImplDevice.1" = type { %"class.cl::sycl::id.1", %"class.cl::sycl::range.1", %"class.cl::sycl::range.1" }
-// CHECK-LLVM: %"class.cl::sycl::id.1" = type { %"class.cl::sycl::detail::array.1" }
-// CHECK-LLVM: %"class.cl::sycl::item.1.true" = type { %"class.cl::sycl::detail::ItemBase.1.true" }
-// CHECK-LLVM: %"class.cl::sycl::detail::ItemBase.1.true" = type { %"class.cl::sycl::range.1", %"class.cl::sycl::id.1", %"class.cl::sycl::id.1" }
+// CHECK-LLVM-DAG: %"class.cl::sycl::accessor.1" = type { %"class.cl::sycl::detail::AccessorImplDevice.1", { i32 addrspace(1)* }, { i32 addrspace(1)* } }
+// CHECK-LLVM-DAG: %"class.cl::sycl::detail::AccessorImplDevice.1" = type { %"class.cl::sycl::id.1", %"class.cl::sycl::range.1", %"class.cl::sycl::range.1" }
+// CHECK-LLVM-DAG: %"class.cl::sycl::id.1" = type { %"class.cl::sycl::detail::array.1" }
+// CHECK-LLVM-DAG: %"class.cl::sycl::detail::array.1" = type { [1 x i64] }
+// CHECK-LLVM-DAG: %"class.cl::sycl::range.1" = type { %"class.cl::sycl::detail::array.1" }
+// CHECK-LLVM-DAG: %"class.cl::sycl::item.1.true" = type { %"class.cl::sycl::detail::ItemBase.1.true" }
+// CHECK-LLVM-DAG: %"class.cl::sycl::detail::ItemBase.1.true" = type { %"class.cl::sycl::range.1", %"class.cl::sycl::id.1", %"class.cl::sycl::id.1" }
 
 // CHECK-MLIR: gpu.module @device_functions
 // CHECK-MLIR: gpu.func @_ZTS8kernel_1(%arg0: memref<?xi32>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: sycl-clang.py %s -S | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: sycl-clang.py %s -S -emit-llvm | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s 2> /dev/null | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: clang++ -fsycl -fsycl-device-only -target x86_64-unknown-linux-gnu -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s 2> /dev/null | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -fsycl -fsycl-device-only -target x86_64-unknown-linux-gnu -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -fsycl -fsycl-device-only -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
@@ -1,4 +1,4 @@
-// RUN: sycl-clang.py %s -S -emit-llvm -o %t.ll
+// RUN: clang++ -fsycl -fsycl-device-only -target x86_64-unknown-linux-gnu -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.ll
 // Test that the LLVMIR generated is verifiable.
 // RUN: opt -verify -disable-output < %t.ll
 // Verify that LLVMIR generated is translatable to SPIRV.

--- a/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
@@ -1,4 +1,4 @@
-// RUN: clang++ -fsycl -fsycl-device-only -target x86_64-unknown-linux-gnu -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.ll
+// RUN: clang++ -fsycl -fsycl-device-only -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.ll
 // Test that the LLVMIR generated is verifiable.
 // RUN: opt -verify -disable-output < %t.ll
 // Verify that LLVMIR generated is translatable to SPIRV.

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: sycl-clang.py %s -S | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: sycl-clang.py %s -S -emit-llvm | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s 2> /dev/null | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: clang++ -fsycl -fsycl-device-only -target x86_64-unknown-linux-gnu -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -9,7 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 // RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s 2> /dev/null | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -fsycl -fsycl-device-only -target x86_64-unknown-linux-gnu -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -fsycl -fsycl-device-only -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -8,7 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: sycl-clang.py %s -S | FileCheck %s
+// RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s 2> /dev/null | FileCheck %s
 
 #include <sycl/sycl.hpp>
 


### PR DESCRIPTION
We get rid of the use of sycl-clang.py in lit tests.