### PR TITLE
[SYCL-MLIR]: Fold alloca

### DIFF
--- a/polygeist/include/polygeist/Passes/Passes.h
+++ b/polygeist/include/polygeist/Passes/Passes.h
@@ -21,6 +21,7 @@ std::unique_ptr<Pass> createBarrierRemovalContinuation();
 std::unique_ptr<Pass> detectReductionPass();
 std::unique_ptr<Pass> createRemoveTrivialUsePass();
 std::unique_ptr<Pass> createParallelLowerPass();
+std::unique_ptr<Pass> createLegalizeForSPIRVPass();
 std::unique_ptr<Pass>
 createConvertPolygeistToLLVMPass(const LowerToLLVMOptions &options);
 std::unique_ptr<Pass> createConvertPolygeistToLLVMPass();

--- a/polygeist/include/polygeist/Passes/Passes.td
+++ b/polygeist/include/polygeist/Passes/Passes.td
@@ -42,6 +42,12 @@ def InnerSerialization : Pass<"inner-serialize"> {
       ["memref::MemRefDialect", "func::FuncDialect", "LLVM::LLVMDialect"];
 }
 
+def LLVMLegalizeForSPIRV : Pass<"legalize-for-spirv"> {
+  let summary = "Legalize dialect to be convertible to SPIRV IR";
+  let constructor = "::mlir::polygeist::createLegalizeForSPIRVPass()";
+  let dependentDialects = ["LLVM::LLVMDialect"];  
+}
+
 def SCFBarrierRemovalContinuation : InterfacePass<"barrier-removal-continuation", "FunctionOpInterface"> {
   let summary = "Remove scf.barrier using continuations";
   let constructor = "mlir::polygeist::createBarrierRemovalContinuation()";

--- a/polygeist/lib/polygeist/Passes/CMakeLists.txt
+++ b/polygeist/lib/polygeist/Passes/CMakeLists.txt
@@ -1,18 +1,19 @@
 add_mlir_dialect_library(MLIRPolygeistTransforms
   AffineCFG.cpp
   AffineReduction.cpp
+  BarrierRemovalContinuation.cpp  
   CanonicalizeFor.cpp
+  ConvertPolygeistToLLVM.cpp  
+  InnerSerialization.cpp  
+  LegalizeForSPIRV.cpp  
   LoopRestructure.cpp
   Mem2Reg.cpp
-  ParallelLoopDistribute.cpp
-  ParallelLICM.cpp
   OpenMPOpt.cpp
-  BarrierRemovalContinuation.cpp
-  RaiseToAffine.cpp
+  ParallelLICM.cpp
+  ParallelLoopDistribute.cpp
   ParallelLower.cpp
+  RaiseToAffine.cpp
   TrivialUse.cpp
-  ConvertPolygeistToLLVM.cpp
-  InnerSerialization.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Affine

--- a/polygeist/lib/polygeist/Passes/LegalizeForSPIRV.cpp
+++ b/polygeist/lib/polygeist/Passes/LegalizeForSPIRV.cpp
@@ -33,11 +33,11 @@ public:
     if (!ptrToIntOp)
       return failure();
 
-    auto gepOp = ptrToIntOp.getArg().getDefiningOp<LLVM::GEPOp>();      
+    auto gepOp = ptrToIntOp.getArg().getDefiningOp<LLVM::GEPOp>();
     if (!gepOp)
       return failure();
 
-    Value nullOp = gepOp.getBase().getDefiningOp<LLVM::NullOp>();      
+    Value nullOp = gepOp.getBase().getDefiningOp<LLVM::NullOp>();
     if (!nullOp)
       return failure();
 
@@ -63,7 +63,7 @@ struct LegalizeForSPIRVPass final
     : public mlir::polygeist::LLVMLegalizeForSPIRVBase<LegalizeForSPIRVPass> {
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
-    patterns.add<AllocaOpOfPtrToIntFolder>(patterns.getContext());    
+    patterns.add<AllocaOpOfPtrToIntFolder>(patterns.getContext());
     (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
   }
 };

--- a/polygeist/lib/polygeist/Passes/LegalizeForSPIRV.cpp
+++ b/polygeist/lib/polygeist/Passes/LegalizeForSPIRV.cpp
@@ -1,0 +1,75 @@
+//===- LegalizeForSPIRV.cpp - Prepare for translation to SPIRV IR ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+
+namespace {
+
+/// Transform the following pattern:
+///    %null = llvm.mlir.null : !llvm.ptr<i64>
+///    %gep = llvm.getelementptr %null[1] : (!llvm.ptr<i64>) -> !llvm.ptr<i64>
+///    %size = llvm.ptrtoint %gep : !llvm.ptr<i64> to i64
+///    %ptr = llvm.alloca %size x i64 : (i64) -> !llvm.ptr<i64>
+/// To:
+///    %size = llvm.mlir.constant(1 : i64) : i64
+///    %ptr = llvm.alloca %size x i64 : (i64) -> !llvm.ptr<i64>
+///
+class AllocaOpOfPtrToIntFolder final : public OpRewritePattern<LLVM::AllocaOp> {
+public:
+  using OpRewritePattern<LLVM::AllocaOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LLVM::AllocaOp allocaOp,
+                                PatternRewriter &rewriter) const override {
+    auto ptrToIntOp = allocaOp.getArraySize().getDefiningOp<LLVM::PtrToIntOp>();
+    if (!ptrToIntOp)
+      return failure();
+
+    auto gepOp = ptrToIntOp.getArg().getDefiningOp<LLVM::GEPOp>();      
+    if (!gepOp)
+      return failure();
+
+    Value nullOp = gepOp.getBase().getDefiningOp<LLVM::NullOp>();      
+    if (!nullOp)
+      return failure();
+
+    if (!gepOp.getDynamicIndices().empty())
+      return failure();
+
+    llvm::ArrayRef<int32_t> constIndices = gepOp.getRawConstantIndices();
+    if (constIndices.size() != 1)
+      return failure();
+
+    Value size = rewriter.create<LLVM::ConstantOp>(
+        allocaOp.getLoc(), IntegerType::get(rewriter.getContext(), 32),
+        rewriter.getIntegerAttr(rewriter.getI32Type(), constIndices.front()));
+
+    rewriter.replaceOpWithNewOp<LLVM::AllocaOp>(
+        allocaOp, allocaOp.getRes().getType(), size);
+
+    return success();
+  }
+};
+
+struct LegalizeForSPIRVPass final
+    : public mlir::polygeist::LLVMLegalizeForSPIRVBase<LegalizeForSPIRVPass> {
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<AllocaOpOfPtrToIntFolder>(patterns.getContext());    
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::polygeist::createLegalizeForSPIRVPass() {
+  return std::make_unique<LegalizeForSPIRVPass>();
+}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -124,8 +124,8 @@ extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
 // CHECK: sycl.constructor([[I]], {{%.*}}, {{%.*}}, {{%.*}}) {MangledName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_, Type = @AccessorImplDevice} : (memref<?x!sycl_accessor_impl_device_1_>, !sycl_id_1_, !sycl_range_1_, !sycl_range_1_) -> ()
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_5() #0
-// CHECK-LLVM: [[ACCESSOR:%.*]] = alloca [[ACCESSOR_TYPE:%"class.cl::sycl::accessor.1"]], i64 ptrtoint ([[ACCESSOR_TYPE]]* getelementptr ([[ACCESSOR_TYPE]], [[ACCESSOR_TYPE]]* null, i32 1) to i64), align 8
-// CHECK-LLVM: call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev([[ACCESSOR_TYPE]]* [[ACCESSOR]], [[ACCESSOR_TYPE]]* [[ACCESSOR]], i64 0, i64 1, i64 1)
+// CHECK-LLVM: [[ACCESSOR:%.*]] = alloca %"class.cl::sycl::accessor.1", align 8
+// CHECK-LLVM: call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.cl::sycl::accessor.1"* [[ACCESSOR]], %"class.cl::sycl::accessor.1"* [[ACCESSOR]], i64 0, i64 1, i64 1)
 
 extern "C" SYCL_EXTERNAL void cons_5() {
   auto accessor = sycl::accessor<sycl::cl_int, 1, sycl::access::mode::write>{};

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -34,7 +34,7 @@
 // CHECK: call void @cons_5()
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_5() #0 {
-// CHECK-LLVM-NEXT:  [[ACCESSOR:%.*]] = alloca %"class.cl::sycl::accessor.1"
+// CHECK-LLVM-NEXT:  [[ACCESSOR:%.*]] = alloca %"class.cl::sycl::accessor.1", align 8
 // CHECK-LLVM-NEXT:  call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.cl::sycl::accessor.1"* [[ACCESSOR]], %"class.cl::sycl::accessor.1"* [[ACCESSOR]], i64 0, i64 1, i64 1)
 
 extern "C" SYCL_EXTERNAL void cons_5() {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -34,11 +34,8 @@
 // CHECK: call void @cons_5()
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_5() #0 {
-// CHECK-LLVM-NEXT:  %{{.*}} = alloca %"class.cl::sycl::accessor.1", i64 ptrtoint (%"class.cl::sycl::accessor.1"* getelementptr (%"class.cl::sycl::accessor.1", %"class.cl::sycl::accessor.1"* null, i32 1) to i64), align 8
-// CHECK-LLVM-NEXT:  call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.cl::sycl::accessor.1"* %1, %"class.cl::sycl::accessor.1"* %1, i64 0, i64 1, i64 1)
-// CHECK-LLVM-NEXT:  ret void
-
-// CHECK-LLVM: attributes #0 = { convergent mustprogress norecurse nounwind }
+// CHECK-LLVM-NEXT:  [[ACCESSOR:%.*]] = alloca %"class.cl::sycl::accessor.1"
+// CHECK-LLVM-NEXT:  call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.cl::sycl::accessor.1"* [[ACCESSOR]], %"class.cl::sycl::accessor.1"* [[ACCESSOR]], i64 0, i64 1, i64 1)
 
 extern "C" SYCL_EXTERNAL void cons_5() {
   sycl::accessor<sycl::cl_int, 1, sycl::access::mode::write> accessor;
@@ -56,3 +53,6 @@ void host_single_task() {
     });
   });
 }
+
+// Keep at the end of the file.
+// CHECK-LLVM: attributes #0 = { convergent mustprogress norecurse nounwind }

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -643,6 +643,8 @@ static int finalize(mlir::MLIRContext &context,
       // options.useBarePtrCallConv = true;
       pm3.addPass(polygeist::createConvertPolygeistToLLVMPass(options));
       // pm3.addPass(mlir::createLowerFuncToLLVMPass(options));
+      pm3.addPass(polygeist::createLegalizeForSPIRVPass());
+
       pm3.addPass(mlir::createCanonicalizerPass(canonicalizerConfig, {}, {}));
       if (mlir::failed(pm3.run(module.get()))) {
         llvm::errs() << "*** Finalize failed (phase 3). Module: ***\n";


### PR DESCRIPTION
This PR adds a pattern to transform an alloca with size given by a ptrtoint that evaluates to a constant literal into an equivalent alloca where the size is constant. For example the following alloca:

  ```alloca i64, i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 4) to i64), align 8``` 

is transformed into:

  ```alloca 4 x i64, align 8``` 

Signed-off-by: Tiotto, Ettore <ettore.tiotto@intel.com>