### PR TITLE
[SYCL] Add note for -fintelfpga about future support

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -163,6 +163,9 @@ def err_intel_fpga_mem_arg_mismatch
     : Error<"builtin parameter must be %select{"
             "a pointer"
             "|a non-negative integer constant}0">;
+def note_intel_fpga_future_support
+    : Note<"in the future, Intel FPGA compilations will support 'device_global'"
+           " variables that retain state between invocations">;
 
 // C99 variable-length arrays
 def ext_vla : Extension<"variable length arrays are a C99 feature">,

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7717,9 +7717,13 @@ NamedDecl *Sema::ActOnVariableDeclarator(
     // attribute.
     if (SCSpec == DeclSpec::SCS_static && !R.isConstant(Context) &&
         !isTypeDecoratedWithDeclAttribute<SYCLGlobalVariableAllowedAttr>(
-            NewVD->getType()))
+            NewVD->getType())) {
       SYCLDiagIfDeviceCode(D.getIdentifierLoc(), diag::err_sycl_restrict)
           << Sema::KernelNonConstStaticDataVariable;
+      if (getLangOpts().IntelFPGA)
+        SYCLDiagIfDeviceCode(D.getIdentifierLoc(),
+                             diag::note_intel_fpga_future_support);
+    }
   }
 
   switch (D.getDeclSpec().getConstexprSpecifier()) {

--- a/clang/lib/Sema/SemaExpr.cpp
+++ b/clang/lib/Sema/SemaExpr.cpp
@@ -236,9 +236,13 @@ bool Sema::DiagnoseUseOfDecl(NamedDecl *D, ArrayRef<SourceLocation> Locs,
           VD->getStorageClass() == SC_Static &&
           !VD->hasAttr<SYCLGlobalVarAttr>() &&
           !isTypeDecoratedWithDeclAttribute<SYCLGlobalVariableAllowedAttr>(
-              VD->getType()))
+              VD->getType())) {
         SYCLDiagIfDeviceCode(*Locs.begin(), diag::err_sycl_restrict)
             << Sema::KernelNonConstStaticDataVariable;
+        if (getLangOpts().IntelFPGA)
+          SYCLDiagIfDeviceCode(*Locs.begin(),
+                               diag::note_intel_fpga_future_support);
+      }
       // Non-const globals are not allowed in SYCL except for ESIMD or with the
       // SYCLGlobalVar or SYCLGlobalVariableAllowed attribute.
       else if (IsRuntimeEvaluated && !IsEsimdPrivateGlobal && !IsConst &&

--- a/clang/test/SemaSYCL/intel-fpga-device-global-future.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-device-global-future.cpp
@@ -1,0 +1,57 @@
+// RUN: %clang_cc1 -fsycl-is-device -verify=expected,fpga -fsyntax-only -fintelfpga -internal-isystem %S/Inputs %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only -internal-isystem %S/Inputs %s
+
+#include "sycl.hpp"
+
+// This test - created largley from sycl-restrict.cpp - tests that
+// when the 'SYCL kernel cannot use a non-const static data variable'
+// error diagnostic is generated, and -fintelfpga option is enabled,
+// we also generate the note that 'in the future, Intel FPGA compilations
+// will support 'device_global' variables that retain state between
+// invocations'
+
+// This note is expected to be temporary and when the feature is supported
+// in the future, this message and likely this test too, will be removed.
+
+// This test also checks that this note is not generated (i.e. retains
+// previous behavior) when -fintelfpga is not specified.
+
+typedef struct A {
+  static int stat_member;
+
+  int fm(void) {
+    // expected-error@+2{{SYCL kernel cannot use a non-const static data variable}}
+    // fpga-note@+1{{in the future, Intel FPGA compilations will support 'device_global' variables that retain state between invocations}}
+    return stat_member; 
+  }
+} a_type;
+
+int use2(a_type ab, a_type *abp) {
+  if (ab.fm()) // expected-note {{called by 'use2'}}
+    return 0;
+
+  // expected-error@+2{{SYCL kernel cannot use a non-const static data variable}}
+  // fpga-note@+1{{in the future, Intel FPGA compilations will support 'device_global' variables that retain state between invocations}}
+  if (ab.stat_member) 
+    return 0;
+  // expected-error@+2{{SYCL kernel cannot use a non-const static data variable}}
+  // fpga-note@+1{{in the future, Intel FPGA compilations will support 'device_global' variables that retain state between invocations}}
+  if (abp->stat_member)
+    return 0;
+}
+
+// expected-note@#KernelSingleTaskKernelFuncCall 3{{called by 'kernel_single_task}}
+
+int main() {
+  sycl::handler h;
+  a_type ab;
+
+  h.single_task([=]() {
+    a_type *p;
+    // expected-error@+2{{SYCL kernel cannot use a non-const static data variable}}
+    // fpga-note@+1{{in the future, Intel FPGA compilations will support 'device_global' variables that retain state between invocations}}
+    static int i; 
+    use2(ab, p); // expected-note 2{{called by 'operator()'}}
+  });
+  return 0;
+}


### PR DESCRIPTION
When non-const static data members are used in devices, we currently generate an
error diagnostic.  When -fintelfpga is in effect, this change adds a note after such
diagnostics, informing that we intend to support an alternative for this via 'device_global'
in the future.