### PR TITLE
[SYCL] Remove remaining deprecated APIs

### DIFF
--- a/sycl/include/sycl/detail/backend_traits_level_zero.hpp
+++ b/sycl/include/sycl/detail/backend_traits_level_zero.hpp
@@ -135,16 +135,6 @@ template <> struct BackendInput<backend::ext_oneapi_level_zero, queue> {
 
     device Device;
 
-    type()
-        : Ownership(ext::oneapi::level_zero::ownership::transfer), Device() {}
-
-    __SYCL_DEPRECATED("Use backend_input_t<backend::ext_oneapi_level_zero, "
-                      "queue> constructor with device parameter")
-    type(interop<backend::ext_oneapi_level_zero, queue>::type nativeHandle,
-         ext::oneapi::level_zero::ownership ownership =
-             ext::oneapi::level_zero::ownership::transfer)
-        : NativeHandle(nativeHandle), Ownership(ownership), Device() {}
-
     type(interop<backend::ext_oneapi_level_zero, queue>::type nativeHandle,
          device dev,
          ext::oneapi::level_zero::ownership ownership =

--- a/sycl/test/basic_tests/interop-level-zero-2020.cpp
+++ b/sycl/test/basic_tests/interop-level-zero-2020.cpp
@@ -137,10 +137,6 @@ int main() {
   // expected-warning@+1 {{'make<sycl::event, nullptr>' is deprecated: Use SYCL 2020 sycl::make_event free function}}
   auto E = ext::oneapi::level_zero::make<event>(
       Context, ZeEvent, ext::oneapi::level_zero::ownership::keep);
-  // expected-warning@+2 {{'type' is deprecated: Use backend_input_t<backend::ext_oneapi_level_zero, queue> constructor with device parameter}}
-  backend_input_t<backend::ext_oneapi_level_zero, queue>
-      InteropQueueInputDeprecated{ZeQueue,
-                                  ext::oneapi::level_zero::ownership::keep};
 
   return 0;
 }


### PR DESCRIPTION
Two make-queue APIs were missed in previous ABI-breaking changes.
This is a part of planned breakage.

Signed-off-by: Byoungro So <byoungro.so@intel.com>