### PR TITLE
[SYCL] Mark half class to use aspect

### DIFF
--- a/sycl/include/sycl/half_type.hpp
+++ b/sycl/include/sycl/half_type.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <sycl/aspects.hpp>
 #include <sycl/detail/defines.hpp>
 #include <sycl/detail/export.hpp>
 #include <sycl/detail/iostream_proxy.hpp>
@@ -265,7 +266,11 @@ using Vec8StorageT = half_vec<8>;
 using Vec16StorageT = half_vec<16>;
 #endif
 
+#ifndef __SYCL_DEVICE_ONLY__
 class half {
+#else
+class [[__sycl_detail__::__uses_aspects__(aspect::fp16)]] half {
+#endif
 public:
   half() = default;
   constexpr half(const half &) = default;

--- a/sycl/test/optional_kernel_features/half-aspect.cpp
+++ b/sycl/test/optional_kernel_features/half-aspect.cpp
@@ -1,10 +1,9 @@
-// RUN: %clangxx %s -o %t.bc -fsycl-device-only
-// RUN: llvm-dis %t.bc -o %t.ll
+// RUN: %clangxx %s -S -o %t.ll -fsycl-device-only
 // RUN: FileCheck %s --input-file %t.ll
 
 // CHECK: !sycl_types_that_use_aspects = !{![[#MDNUM:]]}
-// CHECK: ![[#MDNUM]] = !{!"class.sycl::_V1::detail::half_impl::half", i32 5}
-// CHECK: !{{.*}} = !{!"fp16", i32 5}
+// CHECK: ![[#MDNUM]] = !{!"class.sycl::_V1::detail::half_impl::half", i32 [[#ASPECT_NUM:]]}
+// CHECK: !{{.*}} = !{!"fp16", i32 [[#ASPECT_NUM]]}
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/optional_kernel_features/half-aspect.cpp
+++ b/sycl/test/optional_kernel_features/half-aspect.cpp
@@ -1,0 +1,20 @@
+// RUN: %clangxx %s -o %t.bc -fsycl-device-only
+// RUN: llvm-dis %t.bc -o %t.ll
+// RUN: FileCheck %s --input-file %t.ll
+
+// CHECK: !sycl_types_that_use_aspects = !{![[#MDNUM:]]}
+// CHECK: ![[#MDNUM]] = !{!"class.sycl::_V1::detail::half_impl::half", i32 5}
+// CHECK: !{{.*}} = !{!"fp16", i32 5}
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  sycl::queue q;
+  q.submit([&](sycl::handler &h) {
+    h.single_task([=]() {
+      sycl::half h;
+      h = 10.0;
+    });
+  });
+  return 0;
+}


### PR DESCRIPTION
As part of an optional kernel feature implementation types that using special aspect should be marked appropriately.