### PR TITLE
[SYCL-MLIR] Fix SYCL accessor type lowering and rename SYCL types

### DIFF
--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -61,7 +61,7 @@ static Optional<Type> getArrayTy(MLIRContext &context, unsigned dimNum,
   assert((dimNum == 1 || dimNum == 2 || dimNum == 3) &&
          "Expecting number of dimensions to be 1, 2, or 3.");
   auto structTy = LLVM::LLVMStructType::getIdentified(
-      &context, "class.cl::sycl::detail::array." + std::to_string(dimNum));
+      &context, "class.sycl::_V1::detail::array." + std::to_string(dimNum));
   if (!structTy.isInitialized()) {
     auto arrayTy = LLVM::LLVMArrayType::get(type, dimNum);
     if (failed(structTy.setBody(arrayTy, /*isPacked=*/false)))
@@ -97,7 +97,7 @@ static Optional<Type> convertBodyType(StringRef name,
 static Optional<Type>
 convertAccessorImplDeviceType(sycl::AccessorImplDeviceType type,
                               LLVMTypeConverter &converter) {
-  return convertBodyType("class.cl::sycl::detail::AccessorImplDevice." +
+  return convertBodyType("class.sycl::_V1::detail::AccessorImplDevice." +
                              std::to_string(type.getDimension()),
                          type.getBody(), converter);
 }
@@ -117,25 +117,9 @@ static Optional<Type> convertAccessorCommonType(sycl::AccessorCommonType type,
 /// Converts SYCL accessor type to LLVM type.
 static Optional<Type> convertAccessorType(sycl::AccessorType type,
                                           LLVMTypeConverter &converter) {
-  auto convertedTy = LLVM::LLVMStructType::getIdentified(
-      &converter.getContext(),
-      "class.cl::sycl::accessor." + std::to_string(type.getDimension()));
-  if (!convertedTy.isInitialized()) {
-    SmallVector<Type> convertedElemTypes;
-    convertedElemTypes.reserve(type.getBody().size());
-    if (failed(converter.convertTypes(type.getBody(), convertedElemTypes)))
-      return llvm::None;
-
-    auto ptrTy = LLVM::LLVMPointerType::get(type.getType(), /*addressSpace=*/1);
-    auto structTy =
-        LLVM::LLVMStructType::getLiteral(&converter.getContext(), ptrTy);
-    convertedElemTypes.push_back(structTy);
-
-    if (failed(convertedTy.setBody(convertedElemTypes, /*isPacked=*/false)))
-      return llvm::None;
-  }
-
-  return convertedTy;
+  return convertBodyType("class.sycl::_V1::accessor." +
+                             std::to_string(type.getDimension()),
+                         type.getBody(), converter);
 }
 
 /// Converts SYCL array type to LLVM type.
@@ -155,7 +139,7 @@ static Optional<Type> convertArrayType(sycl::ArrayType type,
 /// Converts SYCL group type to LLVM type.
 static Optional<Type> convertGroupType(sycl::GroupType type,
                                        LLVMTypeConverter &converter) {
-  return convertBodyType("class.cl::sycl::group." +
+  return convertBodyType("class.sycl::_V1::group." +
                              std::to_string(type.getDimension()),
                          type.getBody(), converter);
 }
@@ -181,14 +165,14 @@ static Optional<Type> convertRangeOrIDTy(unsigned dimNum, StringRef name,
 /// Converts SYCL id type to LLVM type.
 static Optional<Type> convertIDType(sycl::IDType type,
                                     LLVMTypeConverter &converter) {
-  return convertRangeOrIDTy(type.getDimension(), "class.cl::sycl::id",
+  return convertRangeOrIDTy(type.getDimension(), "class.sycl::_V1::id",
                             converter);
 }
 
 /// Converts SYCL item base type to LLVM type.
 static Optional<Type> convertItemBaseType(sycl::ItemBaseType type,
                                           LLVMTypeConverter &converter) {
-  return convertBodyType("class.cl::sycl::detail::ItemBase." +
+  return convertBodyType("struct.sycl::_V1::detail::ItemBase." +
                              std::to_string(type.getDimension()) +
                              (type.getWithOffset() ? ".true" : ".false"),
                          type.getBody(), converter);
@@ -197,7 +181,7 @@ static Optional<Type> convertItemBaseType(sycl::ItemBaseType type,
 /// Converts SYCL item type to LLVM type.
 static Optional<Type> convertItemType(sycl::ItemType type,
                                       LLVMTypeConverter &converter) {
-  return convertBodyType("class.cl::sycl::item." +
+  return convertBodyType("class.sycl::_V1::item." +
                              std::to_string(type.getDimension()) +
                              (type.getWithOffset() ? ".true" : ".false"),
                          type.getBody(), converter);
@@ -206,7 +190,7 @@ static Optional<Type> convertItemType(sycl::ItemType type,
 /// Converts SYCL nd item type to LLVM type.
 static Optional<Type> convertNdItemType(sycl::NdItemType type,
                                         LLVMTypeConverter &converter) {
-  return convertBodyType("class.cl::sycl::nd_item." +
+  return convertBodyType("class.sycl::_V1::nd_item." +
                              std::to_string(type.getDimension()),
                          type.getBody(), converter);
 }
@@ -214,7 +198,7 @@ static Optional<Type> convertNdItemType(sycl::NdItemType type,
 /// Converts SYCL range type to LLVM type.
 static Optional<Type> convertRangeType(sycl::RangeType type,
                                        LLVMTypeConverter &converter) {
-  return convertRangeOrIDTy(type.getDimension(), "class.cl::sycl::range",
+  return convertRangeOrIDTy(type.getDimension(), "class.sycl::_V1::range",
                             converter);
 }
 

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-call-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-call-to-llvm.mlir
@@ -24,7 +24,7 @@ func.func @test() -> (i32) {
 
 !sycl_accessor_1_i32_read_write_global_buffer = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>
 
-// CHECK: llvm.func @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE([[ARG_TYPES:!llvm.ptr<struct<"class.cl::sycl::accessor.1",.*]])
+// CHECK: llvm.func @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE([[ARG_TYPES:!llvm.ptr<struct<"class.sycl::_V1::accessor.1",.*]])
 func.func private @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE(memref<?x!sycl_accessor_1_i32_read_write_global_buffer>, memref<?xi32>, !sycl.range<1>, !sycl.range<1>, !sycl.id<1>)
 
 func.func @accessorInit1(%arg0: memref<?x!sycl_accessor_1_i32_read_write_global_buffer>, %arg1: memref<?xi32>, %arg2: !sycl.range<1>, %arg3: !sycl.range<1>, %arg4: !sycl.id<1>) {

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-cast-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-cast-to-llvm.mlir
@@ -3,7 +3,7 @@
 !sycl_array1 = !sycl.array<[1], (memref<1xi64>)>
 func.func @test1(%arg0: memref<?x!sycl.range<1>>) -> memref<?x!sycl_array1> {
   // CHECK: llvm.func @test1
-  // CHECK: [[SRC:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.cl::sycl::range.1"
+  // CHECK: [[SRC:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.sycl::_V1::range.1"
   // CHECK-DAG: [[SRC_IV0:%.*]] = llvm.insertvalue %arg0, [[SRC]][0]
   // CHECK-DAG: [[SRC_IV1:%.*]] = llvm.insertvalue %arg1, [[SRC_IV0]][1]
   // CHECK-DAG: [[SRC_IV2:%.*]] = llvm.insertvalue %arg2, [[SRC_IV1]][2]
@@ -11,21 +11,21 @@ func.func @test1(%arg0: memref<?x!sycl.range<1>>) -> memref<?x!sycl_array1> {
   // CHECK-DAG: [[SRC_IV4:%.*]] = llvm.insertvalue %arg4, [[SRC_IV3]][4, 0]      
 
   // CHECK: [[SRC_FIELD0:%.*]] = llvm.extractvalue [[SRC_IV4]][0]
-  // CHECK-NEXT: [[BITCAST0:%.*]] = llvm.bitcast [[SRC_FIELD0]] : !llvm.ptr<struct<"class.cl::sycl::range.1", {{.*}} to !llvm.ptr<struct<"class.cl::sycl::detail::array.1"
+  // CHECK-NEXT: [[BITCAST0:%.*]] = llvm.bitcast [[SRC_FIELD0]] : !llvm.ptr<struct<"class.sycl::_V1::range.1", {{.*}} to !llvm.ptr<struct<"class.sycl::_V1::detail::array.1"
   // CHECK-NEXT: [[SRC_FIELD1:%.*]] = llvm.extractvalue [[SRC_IV4]][1]
-  // CHECK-NEXT: [[BITCAST1:%.*]] = llvm.bitcast [[SRC_FIELD1]] : !llvm.ptr<struct<"class.cl::sycl::range.1", {{.*}} to !llvm.ptr<struct<"class.cl::sycl::detail::array.1"
+  // CHECK-NEXT: [[BITCAST1:%.*]] = llvm.bitcast [[SRC_FIELD1]] : !llvm.ptr<struct<"class.sycl::_V1::range.1", {{.*}} to !llvm.ptr<struct<"class.sycl::_V1::detail::array.1"
   // CHECK-DAG: [[SRC_FIELD2:%.*]] = llvm.extractvalue [[SRC_IV4]][2]      
   // CHECK-DAG: [[SRC_FIELD3:%.*]] = llvm.extractvalue [[SRC_IV4]][3, 0]
   // CHECK-DAG: [[SRC_FIELD4:%.*]] = llvm.extractvalue [[SRC_IV4]][4, 0]
 
-  // CHECK-DAG: [[RES:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.cl::sycl::detail::array.1"
+  // CHECK-DAG: [[RES:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.sycl::_V1::detail::array.1"
   // CHECK-DAG: [[RES_IV0:%.*]] = llvm.insertvalue [[BITCAST0]], [[RES]][0] {{.*}}
   // CHECK-DAG: [[RES_IV1:%.*]] = llvm.insertvalue [[BITCAST1]], {{.*}}[1] {{.*}}  
   // CHECK-DAG: [[RES_IV2:%.*]] = llvm.insertvalue [[SRC_FIELD2]], {{.*}}[2]  
   // CHECK-DAG: [[RES_IV3:%.*]] = llvm.insertvalue [[SRC_FIELD3]], {{.*}}[3, 0]
   // CHECK-DAG: [[RES_IV4:%.*]] = llvm.insertvalue [[SRC_FIELD4]], {{.*}}[4, 0]
 
-  // CHECK: llvm.return [[RES_IV2]] : !llvm.struct<(ptr<struct<"class.cl::sycl::detail::array.1"  
+  // CHECK: llvm.return [[RES_IV2]] : !llvm.struct<(ptr<struct<"class.sycl::_V1::detail::array.1"  
 
   %0 = "sycl.cast"(%arg0) : (memref<?x!sycl.range<1>>) -> memref<?x!sycl_array1>
   func.return %0 : memref<?x!sycl_array1>
@@ -36,7 +36,7 @@ func.func @test1(%arg0: memref<?x!sycl.range<1>>) -> memref<?x!sycl_array1> {
 !sycl_array1 = !sycl.array<[1], (memref<1xi64>)>
 func.func @test2(%arg0: memref<?x!sycl.id<1>>) -> memref<?x!sycl_array1> {
   // CHECK: llvm.func @test2
-  // CHECK: [[SRC:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.cl::sycl::id.1"
+  // CHECK: [[SRC:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.sycl::_V1::id.1"
   // CHECK-DAG: [[SRC_IV0:%.*]] = llvm.insertvalue %arg0, [[SRC]][0]
   // CHECK-DAG: [[SRC_IV1:%.*]] = llvm.insertvalue %arg1, [[SRC_IV0]][1]
   // CHECK-DAG: [[SRC_IV2:%.*]] = llvm.insertvalue %arg2, [[SRC_IV1]][2]
@@ -44,21 +44,21 @@ func.func @test2(%arg0: memref<?x!sycl.id<1>>) -> memref<?x!sycl_array1> {
   // CHECK-DAG: [[SRC_IV4:%.*]] = llvm.insertvalue %arg4, [[SRC_IV3]][4, 0]      
 
   // CHECK: [[SRC_FIELD0:%.*]] = llvm.extractvalue [[SRC_IV4]][0]
-  // CHECK-NEXT: [[BITCAST0:%.*]] = llvm.bitcast [[SRC_FIELD0]] : !llvm.ptr<struct<"class.cl::sycl::id.1", {{.*}} to !llvm.ptr<struct<"class.cl::sycl::detail::array.1"
+  // CHECK-NEXT: [[BITCAST0:%.*]] = llvm.bitcast [[SRC_FIELD0]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", {{.*}} to !llvm.ptr<struct<"class.sycl::_V1::detail::array.1"
   // CHECK-NEXT: [[SRC_FIELD1:%.*]] = llvm.extractvalue [[SRC_IV4]][1]
-  // CHECK-NEXT: [[BITCAST1:%.*]] = llvm.bitcast [[SRC_FIELD1]] : !llvm.ptr<struct<"class.cl::sycl::id.1", {{.*}} to !llvm.ptr<struct<"class.cl::sycl::detail::array.1"
+  // CHECK-NEXT: [[BITCAST1:%.*]] = llvm.bitcast [[SRC_FIELD1]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", {{.*}} to !llvm.ptr<struct<"class.sycl::_V1::detail::array.1"
   // CHECK-DAG: [[SRC_FIELD2:%.*]] = llvm.extractvalue [[SRC_IV4]][2]      
   // CHECK-DAG: [[SRC_FIELD3:%.*]] = llvm.extractvalue [[SRC_IV4]][3, 0]
   // CHECK-DAG: [[SRC_FIELD4:%.*]] = llvm.extractvalue [[SRC_IV4]][4, 0]
 
-  // CHECK-DAG: [[RES:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.cl::sycl::detail::array.1"
+  // CHECK-DAG: [[RES:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.sycl::_V1::detail::array.1"
   // CHECK-DAG: [[RES_IV0:%.*]] = llvm.insertvalue [[BITCAST0]], [[RES]][0] {{.*}}
   // CHECK-DAG: [[RES_IV1:%.*]] = llvm.insertvalue [[BITCAST1]], {{.*}}[1] {{.*}}  
   // CHECK-DAG: [[RES_IV2:%.*]] = llvm.insertvalue [[SRC_FIELD2]], {{.*}}[2]  
   // CHECK-DAG: [[RES_IV3:%.*]] = llvm.insertvalue [[SRC_FIELD3]], {{.*}}[3, 0]
   // CHECK-DAG: [[RES_IV4:%.*]] = llvm.insertvalue [[SRC_FIELD4]], {{.*}}[4, 0]
 
-  // CHECK: llvm.return [[RES_IV2]] : !llvm.struct<(ptr<struct<"class.cl::sycl::detail::array.1"  
+  // CHECK: llvm.return [[RES_IV2]] : !llvm.struct<(ptr<struct<"class.sycl::_V1::detail::array.1"  
 
   %0 = "sycl.cast"(%arg0) : (memref<?x!sycl.id<1>>) -> memref<?x!sycl_array1>
   func.return %0: memref<?x!sycl_array1>

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-constructor-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-constructor-to-llvm.mlir
@@ -6,7 +6,7 @@
 
 !sycl_accessor_1_i32_read_write_global_buffer = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>
 
-// CHECK: llvm.func @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::accessor.1",.*]])
+// CHECK: llvm.func @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::accessor.1",.*]])
 func.func private @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC2Ev(memref<?x!sycl_accessor_1_i32_read_write_global_buffer>)
 
 func.func @accessorInt1ReadWriteGlobalBufferFalseCtor(%arg0: memref<?x!sycl_accessor_1_i32_read_write_global_buffer>) {
@@ -21,7 +21,7 @@ func.func @accessorInt1ReadWriteGlobalBufferFalseCtor(%arg0: memref<?x!sycl_acce
 // Constructors for sycl::id<n>::id()
 //===-------------------------------------------------------------------------------------------------===//
 
-// CHECK: llvm.func @_ZN2cl4sycl2idILi1EEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::id.1",.*]])
+// CHECK: llvm.func @_ZN2cl4sycl2idILi1EEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.1",.*]])
 func.func private @_ZN2cl4sycl2idILi1EEC2Ev(memref<?x!sycl.id<1>>)
 
 func.func @id1Ctor(%arg0: memref<?x!sycl.id<1>>) {
@@ -32,7 +32,7 @@ func.func @id1Ctor(%arg0: memref<?x!sycl.id<1>>) {
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl2idILi2EEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::id.2",.*]])
+// CHECK: llvm.func @_ZN2cl4sycl2idILi2EEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.2",.*]])
 func.func private @_ZN2cl4sycl2idILi2EEC2Ev(memref<?x!sycl.id<2>>)
 
 func.func @id2Ctor(%arg0: memref<?x!sycl.id<2>>) {
@@ -43,7 +43,7 @@ func.func @id2Ctor(%arg0: memref<?x!sycl.id<2>>) {
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl2idILi3EEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::id.3",.*]])
+// CHECK: llvm.func @_ZN2cl4sycl2idILi3EEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.3",.*]])
 func.func private @_ZN2cl4sycl2idILi3EEC2Ev(memref<?x!sycl.id<3>>)
 
 func.func @id3Ctor(%arg0: memref<?x!sycl.id<3>>) {
@@ -58,7 +58,7 @@ func.func @id3Ctor(%arg0: memref<?x!sycl.id<3>>) {
 // Constructors for cl::sycl::id<n>::id<n>(std::enable_if<(n)==(n), unsigned long>::type)
 //===-------------------------------------------------------------------------------------------------===//
 
-// CHECK: llvm.func @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::id.1",.*]], i64)
+// CHECK: llvm.func @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.1",.*]], i64)
 func.func private @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE(memref<?x!sycl.id<1>>, i64)
 
 func.func @id1CtorSizeT(%arg0: memref<?x!sycl.id<1>>, %arg1: i64) {
@@ -69,7 +69,7 @@ func.func @id1CtorSizeT(%arg0: memref<?x!sycl.id<1>>, %arg1: i64) {
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::id.2",.*]], i64)
+// CHECK: llvm.func @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.2",.*]], i64)
 func.func private @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE(memref<?x!sycl.id<2>>, i64)
 
 func.func @id2CtorSizeT(%arg0: memref<?x!sycl.id<2>>, %arg1: i64) {
@@ -80,7 +80,7 @@ func.func @id2CtorSizeT(%arg0: memref<?x!sycl.id<2>>, %arg1: i64) {
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::id.3",.*]], i64)
+// CHECK: llvm.func @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.3",.*]], i64)
 func.func private @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE(memref<?x!sycl.id<3>>, i64)
 
 func.func @id3CtorSizeT(%arg0: memref<?x!sycl.id<3>>, %arg1: i64) {
@@ -95,7 +95,7 @@ func.func @id3CtorSizeT(%arg0: memref<?x!sycl.id<3>>, %arg1: i64) {
 // Constructors for cl::sycl::id<n>::id<n>(std::enable_if<(n)==(n), unsigned long>::type, unsigned long)
 //===-------------------------------------------------------------------------------------------------===//
 
-// CHECK: llvm.func @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::id.1",.*]], i64, i64)
+// CHECK: llvm.func @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.1",.*]], i64, i64)
 func.func private @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm(memref<?x!sycl.id<1>>, i64, i64)
 
 func.func @id1CtorRange(%arg0: memref<?x!sycl.id<1>>, %arg1: i64, %arg2: i64) {
@@ -106,7 +106,7 @@ func.func @id1CtorRange(%arg0: memref<?x!sycl.id<1>>, %arg1: i64, %arg2: i64) {
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::id.2",.*]], i64, i64)
+// CHECK: llvm.func @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.2",.*]], i64, i64)
 func.func private @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm(memref<?x!sycl.id<2>>, i64, i64)
 
 func.func @id2CtorRange(%arg0: memref<?x!sycl.id<2>>, %arg1: i64, %arg2: i64) {
@@ -117,7 +117,7 @@ func.func @id2CtorRange(%arg0: memref<?x!sycl.id<2>>, %arg1: i64, %arg2: i64) {
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::id.3",.*]], i64, i64)
+// CHECK: llvm.func @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.3",.*]], i64, i64)
 func.func private @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm(memref<?x!sycl.id<3>>, i64, i64)
 
 func.func @id3CtorRange(%arg0: memref<?x!sycl.id<3>>, %arg1: i64, %arg2: i64) {
@@ -132,7 +132,7 @@ func.func @id3CtorRange(%arg0: memref<?x!sycl.id<3>>, %arg1: i64, %arg2: i64) {
 // Constructors for cl::sycl::id<n>::id<n>(std::enable_if<(n)==(n), unsigned long>::type, unsigned long, unsigned long)
 //===-------------------------------------------------------------------------------------------------===//
 
-// CHECK: llvm.func @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::id.1",.*]], i64, i64, i64)
+// CHECK: llvm.func @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.1",.*]], i64, i64, i64)
 func.func private @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm(memref<?x!sycl.id<1>>, i64, i64, i64)
 
 func.func @id1CtorItem(%arg0: memref<?x!sycl.id<1>>, %arg1: i64, %arg2: i64, %arg3: i64) {
@@ -143,7 +143,7 @@ func.func @id1CtorItem(%arg0: memref<?x!sycl.id<1>>, %arg1: i64, %arg2: i64, %ar
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::id.2",.*]], i64, i64, i64)
+// CHECK: llvm.func @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.2",.*]], i64, i64, i64)
 func.func private @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm(memref<?x!sycl.id<2>>, i64, i64, i64)
 
 func.func @id2CtorItem(%arg0: memref<?x!sycl.id<2>>, %arg1: i64, %arg2: i64, %arg3: i64) {
@@ -154,7 +154,7 @@ func.func @id2CtorItem(%arg0: memref<?x!sycl.id<2>>, %arg1: i64, %arg2: i64, %ar
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::id.3",.*]], i64, i64, i64)
+// CHECK: llvm.func @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.3",.*]], i64, i64, i64)
 func.func private @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm(memref<?x!sycl.id<3>>, i64, i64, i64)
 
 func.func @id3CtorItem(%arg0: memref<?x!sycl.id<3>>, %arg1: i64, %arg2: i64, %arg3: i64) {
@@ -169,7 +169,7 @@ func.func @id3CtorItem(%arg0: memref<?x!sycl.id<3>>, %arg1: i64, %arg2: i64, %ar
 // Constructors sycl::id<n>::id(sycl::id<n> const&, sycl::id<n> const&)
 //===-------------------------------------------------------------------------------------------------===//
 
-// CHECK: llvm.func @_ZN2cl4sycl2idILi1EEC1ERKS2_([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::id.1",.*]], [[THIS_PTR_TYPE]])
+// CHECK: llvm.func @_ZN2cl4sycl2idILi1EEC1ERKS2_([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.1",.*]], [[THIS_PTR_TYPE]])
 func.func private @_ZN2cl4sycl2idILi1EEC1ERKS2_(memref<?x!sycl.id<1>>, memref<?x!sycl.id<1>>)
 
 func.func @id1CopyCtor(%arg0: memref<?x!sycl.id<1>>, %arg1: memref<?x!sycl.id<1>>) {
@@ -180,7 +180,7 @@ func.func @id1CopyCtor(%arg0: memref<?x!sycl.id<1>>, %arg1: memref<?x!sycl.id<1>
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl2idILi2EEC1ERKS2_([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::id.2",.*]], [[THIS_PTR_TYPE]])
+// CHECK: llvm.func @_ZN2cl4sycl2idILi2EEC1ERKS2_([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.2",.*]], [[THIS_PTR_TYPE]])
 func.func private @_ZN2cl4sycl2idILi2EEC1ERKS2_(memref<?x!sycl.id<2>>, memref<?x!sycl.id<2>>)
 
 func.func @id2CopyCtor(%arg0: memref<?x!sycl.id<2>>, %arg1: memref<?x!sycl.id<2>>) {
@@ -191,7 +191,7 @@ func.func @id2CopyCtor(%arg0: memref<?x!sycl.id<2>>, %arg1: memref<?x!sycl.id<2>
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl2idILi3EEC1ERKS2_([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::id.3",.*]], [[THIS_PTR_TYPE]])
+// CHECK: llvm.func @_ZN2cl4sycl2idILi3EEC1ERKS2_([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.3",.*]], [[THIS_PTR_TYPE]])
 func.func private @_ZN2cl4sycl2idILi3EEC1ERKS2_(memref<?x!sycl.id<3>>, memref<?x!sycl.id<3>>)
 
 func.func @id3CopyCtor(%arg0: memref<?x!sycl.id<3>>, %arg1: memref<?x!sycl.id<3>>) {
@@ -206,7 +206,7 @@ func.func @id3CopyCtor(%arg0: memref<?x!sycl.id<3>>, %arg1: memref<?x!sycl.id<3>
 // Constructors for sycl::range<n>::range()
 //===-------------------------------------------------------------------------------------------------===//
 
-// CHECK: llvm.func @_ZN2cl4sycl5rangeILi1EEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::range.1",.*]])
+// CHECK: llvm.func @_ZN2cl4sycl5rangeILi1EEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.1",.*]])
 func.func private @_ZN2cl4sycl5rangeILi1EEC2Ev(memref<?x!sycl.range<1>>)
 
 func.func @range1Ctor(%arg0: memref<?x!sycl.range<1>>) {
@@ -217,7 +217,7 @@ func.func @range1Ctor(%arg0: memref<?x!sycl.range<1>>) {
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl5rangeILi2EEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::range.2",.*]])
+// CHECK: llvm.func @_ZN2cl4sycl5rangeILi2EEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.2",.*]])
 func.func private @_ZN2cl4sycl5rangeILi2EEC2Ev(memref<?x!sycl.range<2>>)
 
 func.func @range2Ctor(%arg0: memref<?x!sycl.range<2>>) {
@@ -228,7 +228,7 @@ func.func @range2Ctor(%arg0: memref<?x!sycl.range<2>>) {
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl5rangeILi3EEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::range.3",.*]])
+// CHECK: llvm.func @_ZN2cl4sycl5rangeILi3EEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.3",.*]])
 func.func private @_ZN2cl4sycl5rangeILi3EEC2Ev(memref<?x!sycl.range<3>>)
 
 func.func @range3Ctor(%arg0: memref<?x!sycl.range<3>>) {
@@ -243,7 +243,7 @@ func.func @range3Ctor(%arg0: memref<?x!sycl.range<3>>) {
 // Constructors for cl::sycl::range<n>::range<n>(std::enable_if<(n)==(n), unsigned long>::type)
 //===-------------------------------------------------------------------------------------------------===//
 
-// CHECK: llvm.func @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::range.1",.*]], i64)
+// CHECK: llvm.func @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.1",.*]], i64)
 func.func private @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE(memref<?x!sycl.range<1>>, i64)
 
 func.func @range1CtorSizeT(%arg0: memref<?x!sycl.range<1>>, %arg1: i64) {
@@ -254,7 +254,7 @@ func.func @range1CtorSizeT(%arg0: memref<?x!sycl.range<1>>, %arg1: i64) {
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::range.2",.*]], i64)
+// CHECK: llvm.func @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.2",.*]], i64)
 func.func private @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE( memref<?x!sycl.range<2>>, i64)
 
 func.func @range2CtorSizeT(%arg0: memref<?x!sycl.range<2>>, %arg1: i64) {
@@ -265,7 +265,7 @@ func.func @range2CtorSizeT(%arg0: memref<?x!sycl.range<2>>, %arg1: i64) {
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::range.3",.*]], i64)
+// CHECK: llvm.func @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.3",.*]], i64)
 func.func private @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE(memref<?x!sycl.range<3>>, i64)
 
 func.func @range3CtorSizeT(%arg0: memref<?x!sycl.range<3>>, %arg1: i64) {
@@ -280,7 +280,7 @@ func.func @range3CtorSizeT(%arg0: memref<?x!sycl.range<3>>, %arg1: i64) {
 // Constructors for cl::sycl::range<n>::range<n>(std::enable_if<(n)==(n), unsigned long>::type, unsigned long)
 //===-------------------------------------------------------------------------------------------------===//
 
-// CHECK: llvm.func @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::range.1",.*]], i64, i64)
+// CHECK: llvm.func @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.1",.*]], i64, i64)
 func.func private @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm(memref<?x!sycl.range<1>>, i64, i64)
 
 func.func @range1Ctor2SizeT(%arg0: memref<?x!sycl.range<1>>, %arg1: i64, %arg2: i64) {
@@ -291,7 +291,7 @@ func.func @range1Ctor2SizeT(%arg0: memref<?x!sycl.range<1>>, %arg1: i64, %arg2: 
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::range.2",.*]], i64, i64)
+// CHECK: llvm.func @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.2",.*]], i64, i64)
 func.func private @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm(memref<?x!sycl.range<2>>, i64, i64)
 
 func.func @range2Ctor2SizeT(%arg0: memref<?x!sycl.range<2>>, %arg1: i64, %arg2: i64) {
@@ -302,7 +302,7 @@ func.func @range2Ctor2SizeT(%arg0: memref<?x!sycl.range<2>>, %arg1: i64, %arg2: 
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::range.3",.*]], i64, i64)
+// CHECK: llvm.func @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.3",.*]], i64, i64)
 func.func private @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm(memref<?x!sycl.range<3>>, i64, i64)
 
 func.func @range3Ctor2SizeT(%arg0: memref<?x!sycl.range<3>>, %arg1: i64, %arg2: i64) {
@@ -317,7 +317,7 @@ func.func @range3Ctor2SizeT(%arg0: memref<?x!sycl.range<3>>, %arg1: i64, %arg2: 
 // Constructors for cl::sycl::range<n>::range<n>(std::enable_if<(n)==(n), unsigned long>::type, unsigned long, unsigned long)
 //===-------------------------------------------------------------------------------------------------===//
 
-// CHECK: llvm.func @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::range.1",.*]], i64, i64, i64)
+// CHECK: llvm.func @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.1",.*]], i64, i64, i64)
 func.func private @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm(memref<?x!sycl.range<1>>, i64, i64, i64)
 
 func.func @range1Ctor3SizeT(%arg0: memref<?x!sycl.range<1>>, %arg1: i64, %arg2: i64, %arg3: i64) {
@@ -328,7 +328,7 @@ func.func @range1Ctor3SizeT(%arg0: memref<?x!sycl.range<1>>, %arg1: i64, %arg2: 
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::range.2",.*]], i64, i64, i64)
+// CHECK: llvm.func @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.2",.*]], i64, i64, i64)
 func.func private @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm(memref<?x!sycl.range<2>>, i64, i64, i64)
 
 func.func @range2Ctor3SizeT(%arg0: memref<?x!sycl.range<2>>, %arg1: i64, %arg2: i64, %arg3: i64) {
@@ -339,7 +339,7 @@ func.func @range2Ctor3SizeT(%arg0: memref<?x!sycl.range<2>>, %arg1: i64, %arg2: 
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::range.3",.*]], i64, i64, i64)
+// CHECK: llvm.func @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.3",.*]], i64, i64, i64)
 func.func private @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm(memref<?x!sycl.range<3>>, i64, i64, i64)
 
 func.func @range3Ctor3SizeT(%arg0: memref<?x!sycl.range<3>>, %arg1: i64, %arg2: i64, %arg3: i64) {
@@ -354,7 +354,7 @@ func.func @range3Ctor3SizeT(%arg0: memref<?x!sycl.range<3>>, %arg1: i64, %arg2: 
 // Constructors sycl::range<n>::id(sycl::range<n> const&, sycl::range<n> const&)
 //===-------------------------------------------------------------------------------------------------===//
 
-// CHECK: llvm.func @_ZN2cl4sycl5rangeILi1EEC1ERKS2_([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::range.1",.*]], [[THIS_PTR_TYPE]])
+// CHECK: llvm.func @_ZN2cl4sycl5rangeILi1EEC1ERKS2_([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.1",.*]], [[THIS_PTR_TYPE]])
 func.func private @_ZN2cl4sycl5rangeILi1EEC1ERKS2_(memref<?x!sycl.range<1>>, memref<?x!sycl.range<1>>)
 
 func.func @range1CopyCtor(%arg0: memref<?x!sycl.range<1>>, %arg1: memref<?x!sycl.range<1>>) {
@@ -365,7 +365,7 @@ func.func @range1CopyCtor(%arg0: memref<?x!sycl.range<1>>, %arg1: memref<?x!sycl
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl5rangeILi2EEC1ERKS2_([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::range.2",.*]], [[THIS_PTR_TYPE]])
+// CHECK: llvm.func @_ZN2cl4sycl5rangeILi2EEC1ERKS2_([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.2",.*]], [[THIS_PTR_TYPE]])
 func.func private @_ZN2cl4sycl5rangeILi2EEC1ERKS2_(memref<?x!sycl.range<2>>, memref<?x!sycl.range<2>>)
 
 func.func @range2CopyCtor(%arg0: memref<?x!sycl.range<2>>, %arg1: memref<?x!sycl.range<2>>) {
@@ -376,7 +376,7 @@ func.func @range2CopyCtor(%arg0: memref<?x!sycl.range<2>>, %arg1: memref<?x!sycl
 
 // -----
 
-// CHECK: llvm.func @_ZN2cl4sycl5rangeILi3EEC1ERKS2_([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.cl::sycl::range.3",.*]], [[THIS_PTR_TYPE]])
+// CHECK: llvm.func @_ZN2cl4sycl5rangeILi3EEC1ERKS2_([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.3",.*]], [[THIS_PTR_TYPE]])
 func.func private @_ZN2cl4sycl5rangeILi3EEC1ERKS2_(memref<?x!sycl.range<3>>, memref<?x!sycl.range<3>>)
 
 func.func @range3CopyCtor(%arg0: memref<?x!sycl.range<3>>, %arg1: memref<?x!sycl.range<3>>) {

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
@@ -1,20 +1,20 @@
 // RUN: sycl-mlir-opt -split-input-file -convert-sycl-to-llvm -verify-diagnostics %s | FileCheck %s
 
-// CHECK: llvm.func @test_array.1(%arg0: !llvm.[[ARRAY_1:struct<"class.cl::sycl::detail::array.*", \(array<1 x i64>\)>]])
-// CHECK: llvm.func @test_array.2(%arg0: !llvm.[[ARRAY_2:struct<"class.cl::sycl::detail::array.*", \(array<2 x i64>\)>]])
-// CHECK: llvm.func @test_id(%arg0: !llvm.[[ID_1:struct<"class.cl::sycl::id.*", \(]][[ARRAY_1]][[SUFFIX:\)>]], %arg1: !llvm.[[ID_1]][[ARRAY_1]][[SUFFIX]])
-// CHECK: llvm.func @test_range.1(%arg0: !llvm.[[RANGE_1:struct<"class.cl::sycl::range.*", \(]][[ARRAY_1]][[SUFFIX]])
-// CHECK: llvm.func @test_range.2(%arg0: !llvm.[[RANGE_2:struct<"class.cl::sycl::range.*", \(]][[ARRAY_2]][[SUFFIX]])
-// CHECK: llvm.func @test_accessorImplDevice(%arg0: !llvm.[[ACCESSORIMPLDEVICE_1:struct<"class.cl::sycl::detail::AccessorImplDevice.*", \(]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
+// CHECK: llvm.func @test_array.1(%arg0: !llvm.[[ARRAY_1:struct<"class.sycl::_V1::detail::array.*", \(array<1 x i64>\)>]])
+// CHECK: llvm.func @test_array.2(%arg0: !llvm.[[ARRAY_2:struct<"class.sycl::_V1::detail::array.*", \(array<2 x i64>\)>]])
+// CHECK: llvm.func @test_id(%arg0: !llvm.[[ID_1:struct<"class.sycl::_V1::id.*", \(]][[ARRAY_1]][[SUFFIX:\)>]], %arg1: !llvm.[[ID_1]][[ARRAY_1]][[SUFFIX]])
+// CHECK: llvm.func @test_range.1(%arg0: !llvm.[[RANGE_1:struct<"class.sycl::_V1::range.*", \(]][[ARRAY_1]][[SUFFIX]])
+// CHECK: llvm.func @test_range.2(%arg0: !llvm.[[RANGE_2:struct<"class.sycl::_V1::range.*", \(]][[ARRAY_2]][[SUFFIX]])
+// CHECK: llvm.func @test_accessorImplDevice(%arg0: !llvm.[[ACCESSORIMPLDEVICE_1:struct<"class.sycl::_V1::detail::AccessorImplDevice.*", \(]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
 // CHECK: llvm.func @test_accessor_common(%arg0: !llvm.[[ACCESSOR_COMMON:struct<"class.sycl::_V1::detail::accessor_common", \(i8\)>]])
-// CHECK: llvm.func @test_accessor.1(%arg0: !llvm.[[ACCESSOR_1:struct<"class.cl::sycl::accessor.*", \(]][[ACCESSORIMPLDEVICE_1]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>)>)
-// CHECK: llvm.func @test_accessor.2(%arg0: !llvm.[[ACCESSOR_2:struct<"class.cl::sycl::accessor.*", \(]][[ACCESSORIMPLDEVICE_2:struct<"class.cl::sycl::detail::AccessorImplDevice.*", \(]][[ID_2:struct<"class.cl::sycl::id.*", \(]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]][[SUFFIX]], struct<(ptr<i64, 1>)>)>)
-// CHECK: llvm.func @test_item_base.true(%arg0: !llvm.[[ITEM_BASE_1_TRUE:struct<"class.cl::sycl::detail::ItemBase.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
-// CHECK: llvm.func @test_item_base.false(%arg0: !llvm.[[ITEM_BASE_1_FALSE:struct<"class.cl::sycl::detail::ItemBase.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
-// CHECK: llvm.func @test_item.true(%arg0: !llvm.[[ITEM_1_TRUE:struct<"class.cl::sycl::item.*", \(]][[ITEM_BASE_1_TRUE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
-// CHECK: llvm.func @test_item.false(%arg0: !llvm.[[ITEM_1_FALSE:struct<"class.cl::sycl::item.*", \(]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
-// CHECK: llvm.func @test_group(%arg0: !llvm.[[GROUP_1:struct<"class.cl::sycl::group.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
-// CHECK: llvm.func @test_nd_item(%arg0: !llvm.[[ND_ITEM_1:struct<"class.cl::sycl::nd_item.*", \(]][[ITEM_1_TRUE]][[ITEM_BASE_1_TRUE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[ITEM_1_FALSE]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[GROUP_1]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
+// CHECK: llvm.func @test_accessor.1(%arg0: !llvm.[[ACCESSOR_1:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_1]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>)>)
+// CHECK: llvm.func @test_accessor.2(%arg0: !llvm.[[ACCESSOR_2:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_2:struct<"class.sycl::_V1::detail::AccessorImplDevice.*", \(]][[ID_2:struct<"class.sycl::_V1::id.*", \(]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>)>)
+// CHECK: llvm.func @test_item_base.true(%arg0: !llvm.[[ITEM_BASE_1_TRUE:struct<"struct.sycl::_V1::detail::ItemBase.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
+// CHECK: llvm.func @test_item_base.false(%arg0: !llvm.[[ITEM_BASE_1_FALSE:struct<"struct.sycl::_V1::detail::ItemBase.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
+// CHECK: llvm.func @test_item.true(%arg0: !llvm.[[ITEM_1_TRUE:struct<"class.sycl::_V1::item.*", \(]][[ITEM_BASE_1_TRUE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
+// CHECK: llvm.func @test_item.false(%arg0: !llvm.[[ITEM_1_FALSE:struct<"class.sycl::_V1::item.*", \(]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
+// CHECK: llvm.func @test_group(%arg0: !llvm.[[GROUP_1:struct<"class.sycl::_V1::group.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
+// CHECK: llvm.func @test_nd_item(%arg0: !llvm.[[ND_ITEM_1:struct<"class.sycl::_V1::nd_item.*", \(]][[ITEM_1_TRUE]][[ITEM_BASE_1_TRUE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[ITEM_1_FALSE]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[GROUP_1]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
 
 module {
   func.func @test_array.1(%arg0: !sycl.array<[1], (memref<1xi64>)>) {
@@ -38,10 +38,10 @@ module {
   func.func @test_accessor_common(%arg0: !sycl.accessor_common) {
     return
   }
-  func.func @test_accessor.1(%arg0: !sycl.accessor<[1, i32, write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>)>) {
+  func.func @test_accessor.1(%arg0: !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>) {
     return
   }
-  func.func @test_accessor.2(%arg0: !sycl.accessor<[2, i64, write, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl.id<2>, !sycl.range<2>, !sycl.range<2>)>)>) {
+  func.func @test_accessor.2(%arg0: !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl.id<2>, !sycl.range<2>, !sycl.range<2>)>, !llvm.struct<(ptr<i32, 1>)>)>) {
     return
   }
   func.func @test_item_base.true(%arg0: !sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>) {

--- a/polygeist/test/polygeist-opt/sycl/subindex.mlir
+++ b/polygeist/test/polygeist-opt/sycl/subindex.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: @test_1
 // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK: [[GEP:%.*]] = llvm.getelementptr %{{.*}}[[[ZERO]], 0] : (!llvm.ptr<struct<([[SYCLIDSTRUCT:struct<"class.cl::sycl::id.1"]], {{.*}} -> !llvm.ptr<[[SYCLIDSTRUCT]], {{.*}}
+// CHECK: [[GEP:%.*]] = llvm.getelementptr %{{.*}}[[[ZERO]], 0] : (!llvm.ptr<struct<([[SYCLIDSTRUCT:struct<"class.sycl::_V1::id.1"]], {{.*}} -> !llvm.ptr<[[SYCLIDSTRUCT]], {{.*}}
 // CHECK: [[MEMREF:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<[[SYCLIDSTRUCT]], {{.*}}
 // CHECK: %{{.*}} = llvm.insertvalue [[GEP]], [[MEMREF]][0] : !llvm.struct<(ptr<[[SYCLIDSTRUCT]], {{.*}}
 
@@ -15,7 +15,7 @@ func.func @test_1(%arg0: memref<?x!llvm.struct<(!sycl.id<1>)>>) -> memref<?x!syc
 // -----
 
 // CHECK-LABEL: @test_2
-// CHECK: llvm.return %{{.*}} : !llvm.struct<(ptr<struct<"class.cl::sycl::detail::AccessorImplDevice 
+// CHECK: llvm.return %{{.*}} : !llvm.struct<(ptr<struct<"class.sycl::_V1::detail::AccessorImplDevice 
 
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>
 !sycl_accessor_1_i32_read_write_global_buffer = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
@@ -49,7 +49,7 @@ func.func @test_3(%arg0: memref<?x!llvm.struct<(i32)>>) -> memref<?xi32> {
 
 // -----
 
-// CHECK: llvm.func @test_4([[A0:%.*]]: !llvm.ptr<struct<([[IDTYPE:struct<"class.cl::sycl::id.1", \(struct<"class.cl::sycl::detail::array.1", \(array<1 x i64>\)>\)>]])>>, [[A1:%.*]]: !llvm.ptr<struct<([[IDTYPE]])>>, [[A2:%.*]]: i64, [[A3:%.*]]: i64, [[A4:%.*]]: i64, [[A5:%.*]]: i64) -> !llvm.struct<(ptr<struct<([[IDTYPE]])>>, ptr<struct<([[IDTYPE]])>>, i64, array<1 x i64>, array<1 x i64>)> {
+// CHECK: llvm.func @test_4([[A0:%.*]]: !llvm.ptr<struct<([[IDTYPE:struct<"class.sycl::_V1::id.1", \(struct<"class.sycl::_V1::detail::array.1", \(array<1 x i64>\)>\)>]])>>, [[A1:%.*]]: !llvm.ptr<struct<([[IDTYPE]])>>, [[A2:%.*]]: i64, [[A3:%.*]]: i64, [[A4:%.*]]: i64, [[A5:%.*]]: i64) -> !llvm.struct<(ptr<struct<([[IDTYPE]])>>, ptr<struct<([[IDTYPE]])>>, i64, array<1 x i64>, array<1 x i64>)> {
 // CHECK:      [[ORIG_MEMREF0:%.*]] = llvm.mlir.undef
 // CHECK-NEXT: [[ORIG_MEMREF1:%.*]] = llvm.insertvalue [[A0]], [[ORIG_MEMREF0]][0]
 // CHECK-NEXT: [[ORIG_MEMREF2:%.*]] = llvm.insertvalue [[A1]], [[ORIG_MEMREF1]][1]
@@ -69,7 +69,7 @@ func.func @test_4(%arg0: memref<1x!llvm.struct<(!sycl.id<1>)>>, %arg1: index) ->
 
 // -----
 
-// CHECK: llvm.func @test_5([[A0:%.*]]: !llvm.ptr<[[ARRTYPE:struct<"class.cl::sycl::detail::array.1", \(array<1 x i64>\)>]], 4>, [[A1:%.*]]: !llvm.ptr<[[ARRTYPE]], 4>, [[A2:%.*]]: i64, [[A3:%.*]]: i64, [[A4:%.*]]: i64) -> !llvm.struct<(ptr<i64, 4>, ptr<i64, 4>, i64, array<1 x i64>, array<1 x i64>)> {
+// CHECK: llvm.func @test_5([[A0:%.*]]: !llvm.ptr<[[ARRTYPE:struct<"class.sycl::_V1::detail::array.1", \(array<1 x i64>\)>]], 4>, [[A1:%.*]]: !llvm.ptr<[[ARRTYPE]], 4>, [[A2:%.*]]: i64, [[A3:%.*]]: i64, [[A4:%.*]]: i64) -> !llvm.struct<(ptr<i64, 4>, ptr<i64, 4>, i64, array<1 x i64>, array<1 x i64>)> {
 // CHECK:      [[ORIG_MEMREF0:%.*]] = llvm.mlir.undef
 // CHECK-NEXT: [[ORIG_MEMREF1:%.*]] = llvm.insertvalue [[A0]], [[ORIG_MEMREF0]][0]
 // CHECK-NEXT: [[ORIG_MEMREF2:%.*]] = llvm.insertvalue [[A1]], [[ORIG_MEMREF1]][1]

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -25,7 +25,7 @@
 // CHECK-SAME:  attributes {[[SPIR_FUNCCC]], [[LINKONCE]], [[PASSTHROUGH]]}
 // CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl_range_1_, 4>) -> memref<?x!sycl_array_1_, 4>
 
-// CHECK-LLVM: define spir_func void @cons_0([[ID_TYPE:%"class.cl::sycl::id.1"]] [[ARG0:%.*]], [[RANGE_TYPE:%"class.cl::sycl::range.1"]] [[ARG1:%.*]]) #0
+// CHECK-LLVM: define spir_func void @cons_0([[ID_TYPE:%"class.sycl::_V1::id.1"]] [[ARG0:%.*]], [[RANGE_TYPE:%"class.sycl::_V1::range.1"]] [[ARG1:%.*]]) #0
 // CHECK-LLVM-DAG: [[RANGE1:%.*]] = alloca [[RANGE_TYPE]]
 // CHECK-LLVM-DAG: [[ID1:%.*]] = alloca [[ID_TYPE]]
 // CHECK-LLVM-DAG: [[RANGE2:%.*]] = alloca [[RANGE_TYPE]]
@@ -61,7 +61,7 @@ extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXTERNAL]], [[PASSTHROUGH]]}
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_1() #0
-// CHECK-LLVM: [[ID1:%.*]] = alloca [[ID_TYPE:%"class.cl::sycl::id.2"]]
+// CHECK-LLVM: [[ID1:%.*]] = alloca [[ID_TYPE:%"class.sycl::_V1::id.2"]]
 // CHECK-LLVM: [[CAST1:%.*]] = bitcast [[ID_TYPE]]* %1 to i8*
 // CHECK-LLVM: call void @llvm.memset.p0i8.i64(i8* %2, i8 0, i64 16, i1 false)
 // CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID1]] to [[ID_TYPE]] addrspace(4)*
@@ -80,7 +80,7 @@ extern "C" SYCL_EXTERNAL void cons_1() {
 // CHECK-NEXT: sycl.constructor(%3, %arg0, %arg1) {MangledName = @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, Type = @id} : (memref<?x!sycl_id_2_, 4>, i64, i64) -> ()
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_2(i64 %0, i64 %1) #0
-// CHECK-LLVM: [[ID1:%.*]] = alloca [[ID_TYPE:%"class.cl::sycl::id.2"]]
+// CHECK-LLVM: [[ID1:%.*]] = alloca [[ID_TYPE:%"class.sycl::_V1::id.2"]]
 // CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID1]] to [[ID_TYPE]] addrspace(4)*
 // CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm([[ID_TYPE]] addrspace(4)* [[ID1_AS]], [[ID_TYPE]] addrspace(4)* [[ID1_AS]], i64 0, i64 -1, i64 1, i64 %0, i64 %1)
 
@@ -101,8 +101,8 @@ extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
 // CHECK-NEXT: %7 = "polygeist.pointer2memref"(%6) : (!llvm.ptr<!sycl_item_2_1_, 4>) -> memref<?x!sycl_item_2_1_, 4>
 // CHECK-NEXT: sycl.constructor(%4, %7) {MangledName = @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE, Type = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_item_2_1_, 4>) -> ()
 
-// CHECK-LLVM: define spir_func void @cons_3([[ITEM_TYPE:%"class.cl::sycl::item.2.true"]] [[ARG0:%.*]]) #0
-// CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE:%"class.cl::sycl::id.2"]]  
+// CHECK-LLVM: define spir_func void @cons_3([[ITEM_TYPE:%"class.sycl::_V1::item.2.true"]] [[ARG0:%.*]]) #0
+// CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE:%"class.sycl::_V1::id.2"]]  
 // CHECK-LLVM-DAG: [[ITEM:%.*]] = alloca [[ITEM_TYPE]]
 // CHECK-LLVM: store [[ITEM_TYPE]] [[ARG0]], [[ITEM_TYPE]]* [[ITEM]], align 8
 // CHECK-LLVM: [[ID_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID]] to [[ID_TYPE]] addrspace(4)*
@@ -126,7 +126,7 @@ extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
 // CHECK-NEXT: %7 = "polygeist.pointer2memref"(%6) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
 // CHECK-NEXT: sycl.constructor(%4, %7) {MangledName = @_ZN4sycl3_V12idILi2EEC1ERKS2_, Type = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> ()
 
-// CHECK-LLVM: define spir_func void @cons_4([[ID_TYPE:%"class.cl::sycl::id.2"]] [[ARG0:%.*]]) #0
+// CHECK-LLVM: define spir_func void @cons_4([[ID_TYPE:%"class.sycl::_V1::id.2"]] [[ARG0:%.*]]) #0
 // CHECK-LLVM-DAG: [[ID1:%.*]] = alloca [[ID_TYPE]]
 // CHECK-LLVM-DAG: [[ID2:%.*]] = alloca [[ID_TYPE]]
 // CHECK-LLVM: store [[ID_TYPE]] [[ARG0]], [[ID_TYPE]]* [[ID2]], align 8
@@ -144,9 +144,9 @@ extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
 // CHECK: sycl.constructor([[I]], {{%.*}}, {{%.*}}, {{%.*}}) {MangledName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_, Type = @AccessorImplDevice} : (memref<?x!sycl_accessor_impl_device_1_, 4>, !sycl_id_1_, !sycl_range_1_, !sycl_range_1_) -> ()
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_5() #0
-// CHECK-LLVM: [[ACCESSOR:%.*]] = alloca %"class.cl::sycl::accessor.1", align 8
-// CHECK-LLVM: [[ACAST:%.*]] = addrspacecast %"class.cl::sycl::accessor.1"* [[ACCESSOR]] to %"class.cl::sycl::accessor.1" addrspace(4)*
-// CHECK-LLVM: call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.cl::sycl::accessor.1" addrspace(4)* [[ACAST]], %"class.cl::sycl::accessor.1" addrspace(4)* [[ACAST]], i64 0, i64 -1, i64 1)
+// CHECK-LLVM: [[ACCESSOR:%.*]] = alloca %"class.sycl::_V1::accessor.1", align 8
+// CHECK-LLVM: [[ACAST:%.*]] = addrspacecast %"class.sycl::_V1::accessor.1"* [[ACCESSOR]] to %"class.sycl::_V1::accessor.1" addrspace(4)*
+// CHECK-LLVM: call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]], %"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]], i64 0, i64 -1, i64 1)
 
 extern "C" SYCL_EXTERNAL void cons_5() {
   auto accessor = sycl::accessor<sycl::cl_int, 1, sycl::access::mode::write>{};

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -18,13 +18,13 @@
 // CHECK-MLIR: !sycl_item_1_1_ = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>
 // CHECK-MLIR: !sycl_range_1_ = !sycl.range<1>
 
-// CHECK-LLVM-DAG: %"class.cl::sycl::accessor.1" = type { %"class.cl::sycl::detail::AccessorImplDevice.1", { i32 addrspace(1)* }, { i32 addrspace(1)* } }
-// CHECK-LLVM-DAG: %"class.cl::sycl::detail::AccessorImplDevice.1" = type { %"class.cl::sycl::id.1", %"class.cl::sycl::range.1", %"class.cl::sycl::range.1" }
-// CHECK-LLVM-DAG: %"class.cl::sycl::id.1" = type { %"class.cl::sycl::detail::array.1" }
-// CHECK-LLVM-DAG: %"class.cl::sycl::detail::array.1" = type { [1 x i64] }
-// CHECK-LLVM-DAG: %"class.cl::sycl::range.1" = type { %"class.cl::sycl::detail::array.1" }
-// CHECK-LLVM-DAG: %"class.cl::sycl::item.1.true" = type { %"class.cl::sycl::detail::ItemBase.1.true" }
-// CHECK-LLVM-DAG: %"class.cl::sycl::detail::ItemBase.1.true" = type { %"class.cl::sycl::range.1", %"class.cl::sycl::id.1", %"class.cl::sycl::id.1" }
+// CHECK-LLVM-DAG: %"class.sycl::_V1::accessor.1" = type { %"class.sycl::_V1::detail::AccessorImplDevice.1", { i32 addrspace(1)* } }
+// CHECK-LLVM-DAG: %"class.sycl::_V1::detail::AccessorImplDevice.1" = type { %"class.sycl::_V1::id.1", %"class.sycl::_V1::range.1", %"class.sycl::_V1::range.1" }
+// CHECK-LLVM-DAG: %"class.sycl::_V1::id.1" = type { %"class.sycl::_V1::detail::array.1" }
+// CHECK-LLVM-DAG: %"class.sycl::_V1::detail::array.1" = type { [1 x i64] }
+// CHECK-LLVM-DAG: %"class.sycl::_V1::range.1" = type { %"class.sycl::_V1::detail::array.1" }
+// CHECK-LLVM-DAG: %"class.sycl::_V1::item.1.true" = type { %"struct.sycl::_V1::detail::ItemBase.1.true" }
+// CHECK-LLVM-DAG: %"struct.sycl::_V1::detail::ItemBase.1.true" = type { %"class.sycl::_V1::range.1", %"class.sycl::_V1::id.1", %"class.sycl::_V1::id.1" }
 
 // CHECK-MLIR: gpu.module @device_functions
 // CHECK-MLIR: gpu.func @_ZTS8kernel_1(%arg0: memref<?xi32, 1>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -34,9 +34,9 @@
 // CHECK: call void @cons_5()
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_5() #0 {
-// CHECK-LLVM-NEXT:  [[ACCESSOR:%.*]] = alloca %"class.cl::sycl::accessor.1", align 8
-// CHECK-LLVM-NEXT:  [[ACAST:%.*]] = addrspacecast %"class.cl::sycl::accessor.1"* [[ACCESSOR]] to %"class.cl::sycl::accessor.1" addrspace(4)*
-// CHECK-LLVM-NEXT:  call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.cl::sycl::accessor.1" addrspace(4)* [[ACAST]], %"class.cl::sycl::accessor.1" addrspace(4)* [[ACAST]], i64 0, i64 -1, i64 1)
+// CHECK-LLVM-NEXT:  [[ACCESSOR:%.*]] = alloca %"class.sycl::_V1::accessor.1", align 8
+// CHECK-LLVM-NEXT:  [[ACAST:%.*]] = addrspacecast %"class.sycl::_V1::accessor.1"* [[ACCESSOR]] to %"class.sycl::_V1::accessor.1" addrspace(4)*
+// CHECK-LLVM-NEXT:  call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]], %"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]], i64 0, i64 -1, i64 1)
 
 extern "C" SYCL_EXTERNAL void cons_5() {
   sycl::accessor<sycl::cl_int, 1, sycl::access::mode::write> accessor;


### PR DESCRIPTION
Wrong:
```
 %"class.sycl::_V1::accessor.1" = type { %"class.sycl::_V1::detail::AccessorImplDevice.1", { i32 addrspace(1)* }, { i32 addrspace(1)* } }
 ```

Correct: 
```
 %"class.sycl::_V1::accessor.1" = type { %"class.sycl::_V1::detail::AccessorImplDevice.1", { i32 addrspace(1)* } }
 ```

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>