### PR TITLE
[SYCL] Allow non-conforming lambda syntax for work-group-size-hint attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -3427,6 +3427,7 @@ def WorkGroupSizeHint :  InheritableAttr {
     }
   }];
   let Documentation = [WorkGroupSizeHintAttrDocs];
+  let SupportsNonconformingLambdaSyntax = 1;
 }
 
 def InitPriority : InheritableAttr, TargetSpecificAttr<TargetSupportsInitPriority> {

--- a/clang/test/CodeGenSYCL/check-direct-attribute-propagation.cpp
+++ b/clang/test/CodeGenSYCL/check-direct-attribute-propagation.cpp
@@ -3,7 +3,7 @@
 // Tests for IR of [[intel::scheduler_target_fmax_mhz()]], [[intel::num_simd_work_items()]],
 // [[intel::no_global_work_offset()]], [[intel::max_global_work_dim()]], [[sycl::reqd_sub_group_size()]],
 // [[sycl::reqd_work_group_size()]], [[intel::kernel_args_restrict]], [[intel::max_work_group_size()]],
-// and [[intel::sycl_explicit_simd]] function attributes in SYCL 2020.
+// [[sycl::work_group_size_hint()]] and [[intel::sycl_explicit_simd]] function attributes in SYCL 2020.
 
 #include "sycl.hpp"
 
@@ -143,6 +143,19 @@ public:
     foo8();
   }
 };
+
+class Foo11 {
+public:
+  [[sycl::work_group_size_hint(1, 2, 3)]] void operator()() const {}
+};
+
+template <int SIZE, int SIZE1, int SIZE2>
+class Functor11 {
+public:
+  [[sycl::work_group_size_hint(SIZE, SIZE1, SIZE2)]] void operator()() const {}
+};
+
+[[sycl::work_group_size_hint(1, 2, 3)]] void foo11() {}
 
 int main() {
   q.submit([&](handler &h) {
@@ -320,6 +333,27 @@ int main() {
     // CHECK: define {{.*}}spir_func void @{{.*}}(ptr addrspace(4) noalias noundef align 1 dereferenceable_or_null(1) %this) #4 align 2
     h.single_task<class kernel_name34>(
         []() [[intel::kernel_args_restrict]]{});
+
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name35() #0 {{.*}} !work_group_size_hint ![[NUM123:[0-9]+]]
+    Foo11 boo11;
+    h.single_task<class kernel_name35>(boo11);
+
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name36() #0 {{.*}} !work_group_size_hint ![[NUM123]]
+    Functor11<1, 2, 3> f11;
+    h.single_task<class kernel_name36>(f11);
+
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name37() #0 {{.*}} !work_group_size_hint ![[NUM123]]
+    h.single_task<class kernel_name37>(
+        []() [[sycl::work_group_size_hint(1, 2, 3)]]{});
+
+    // Test attribute is not propagated.
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name38()
+    // CHECK-NOT: !work_group_size_hint
+    // CHECK-SAME: {
+    // CHECK: define dso_local spir_func void @_Z5foo11v()
+    h.single_task<class kernel_name38>(
+        []() { foo11(); });
+
   });
   return 0;
 }
@@ -333,3 +367,4 @@ int main() {
 // CHECK: ![[NUM32]] = !{i32 16, i32 16, i32 32}
 // CHECK: ![[NUM88]] = !{i32 8, i32 8, i32 8}
 // CHECK: ![[NUM22]] = !{i32 2, i32 2, i32 2}
+// CHECK: ![[NUM123]] = !{i32 1, i32 2, i32 3}

--- a/clang/test/CodeGenSYCL/no_opaque_check-direct-attribute-propagation.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_check-direct-attribute-propagation.cpp
@@ -3,7 +3,7 @@
 // Tests for IR of [[intel::scheduler_target_fmax_mhz()]], [[intel::num_simd_work_items()]],
 // [[intel::no_global_work_offset()]], [[intel::max_global_work_dim()]], [[sycl::reqd_sub_group_size()]],
 // [[sycl::reqd_work_group_size()]], [[intel::kernel_args_restrict]], [[intel::max_work_group_size()]],
-// and [[intel::sycl_explicit_simd]] function attributes in SYCL 2020.
+// [[sycl::work_group_size_hint()]] and [[intel::sycl_explicit_simd]] function attributes in SYCL 2020.
 
 #include "sycl.hpp"
 
@@ -143,6 +143,19 @@ public:
     foo8();
   }
 };
+
+class Foo11 {
+public:
+  [[sycl::work_group_size_hint(1, 2, 3)]] void operator()() const {}
+};
+
+template <int SIZE, int SIZE1, int SIZE2>
+class Functor11 {
+public:
+  [[sycl::work_group_size_hint(SIZE, SIZE1, SIZE2)]] void operator()() const {}
+};
+
+[[sycl::work_group_size_hint(1, 2, 3)]] void foo11() {}
 
 int main() {
   q.submit([&](handler &h) {
@@ -320,6 +333,27 @@ int main() {
     // CHECK: define {{.*}}spir_func void @{{.*}}(%class.anon{{.*}} addrspace(4)* noalias noundef align 1 dereferenceable_or_null(1) %this) #4 align 2
     h.single_task<class kernel_name34>(
         []() [[intel::kernel_args_restrict]]{});
+
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name35() #0 {{.*}} !work_group_size_hint ![[NUM123:[0-9]+]]
+    Foo11 boo11;
+    h.single_task<class kernel_name35>(boo11);
+
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name36() #0 {{.*}} !work_group_size_hint ![[NUM123]]
+    Functor11<1, 2, 3> f11;
+    h.single_task<class kernel_name36>(f11);
+
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name37() #0 {{.*}} !work_group_size_hint ![[NUM123]]
+    h.single_task<class kernel_name37>(
+        []() [[sycl::work_group_size_hint(1, 2, 3)]]{});
+
+    // Test attribute is not propagated.
+    // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name38()
+    // CHECK-NOT: !work_group_size_hint
+    // CHECK-SAME: {
+    // CHECK: define dso_local spir_func void @_Z5foo11v()
+    h.single_task<class kernel_name38>(
+        []() { foo11(); });
+
   });
   return 0;
 }
@@ -333,3 +367,4 @@ int main() {
 // CHECK: ![[NUM32]] = !{i32 16, i32 16, i32 32}
 // CHECK: ![[NUM88]] = !{i32 8, i32 8, i32 8}
 // CHECK: ![[NUM22]] = !{i32 2, i32 2, i32 2}
+// CHECK: ![[NUM123]] = !{i32 1, i32 2, i32 3}

--- a/clang/test/SemaSYCL/check-work-group-size-hint-device.cpp
+++ b/clang/test/SemaSYCL/check-work-group-size-hint-device.cpp
@@ -166,6 +166,19 @@ void invoke() {
     // CHECK: FunctionDecl {{.*}} {{.*}}kernel_3
     // CHECK-NOT: WorkGroupSizeHintAttr
 
+    h.single_task<class kernel_name4>([]() [[sycl::work_group_size_hint(4,4,4)]] {});
+    // CHECK: FunctionDecl {{.*}}kernel_name4
+    // CHECK: WorkGroupSizeHintAttr {{.*}}
+    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
+    // CHECK-NEXT:  value: Int 4
+    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
+    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
+    // CHECK-NEXT:  value: Int 4
+    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
+    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
+    // CHECK-NEXT:  value: Int 4
+    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
+
   });
 
   // FIXME: Add tests with the C++23 lambda attribute syntax.


### PR DESCRIPTION
We missed this attribute when support for non-conforming lambda syntax was originally implemented. Adding to maintain consistency.

Please note - now that clang supports attributes on lambdas, discussions are underway on removing this non-conforming syntax support for all SYCL attributes in the future.

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>