### PR TITLE
[SYCL][doc] Add mention of cuda gpu arch for enabling cuda-arch specific features

### DIFF
--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -631,7 +631,6 @@ clang++ -fsycl -fsycl-targets=nvptx64-nvidia-cuda \
   simple-sycl-app.cpp -o simple-sycl-app-cuda.exe
 ```
 
-
 When building for HIP AMD, use the AMD target triple and specify the
 target architecture with `-Xsycl-target-backend --offload-arch=<arch>`
 as follows:

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -631,6 +631,7 @@ clang++ -fsycl -fsycl-targets=nvptx64-nvidia-cuda \
   simple-sycl-app.cpp -o simple-sycl-app-cuda.exe
 ```
 
+
 When building for HIP AMD, use the AMD target triple and specify the
 target architecture with `-Xsycl-target-backend --offload-arch=<arch>`
 as follows:
@@ -639,6 +640,17 @@ as follows:
 clang++ -fsycl -fsycl-targets=amdgcn-amd-amdhsa \
   -Xsycl-target-backend --offload-arch=gfx906              \
   simple-sycl-app.cpp -o simple-sycl-app-amd.exe
+```
+
+The target architecture may also be specified for the CUDA backend, with 
+`-Xsycl-target-backend --cuda-gpu-arch=<arch>`. Specifying the architecture is 
+necessary if an application aims to use newer hardware features, such as
+native atomic operations or tensor core operations. 
+
+```bash
+clang++ -fsycl -fsycl-targets=nvptx64-nvidia-cuda \
+  simple-sycl-app.cpp -o simple-sycl-app-cuda.exe \
+  -Xsycl-target-backend --cuda-gpu-arch=sm_80
 ```
 
 To build simple-sycl-app ahead of time for GPU, CPU or Accelerator devices,


### PR DESCRIPTION
Some users were mistakenly thinking that native atomics are not supported in DPC++ for CUDA.

The doc now mentions that you need to provide correct arch flags when compiling if you wish to use native atomics as well as other features.