### PR TITLE
[SYCL] Change "static constexpr int" -> "constexpr int"

### DIFF
--- a/sycl/source/detail/image_impl.hpp
+++ b/sycl/source/detail/image_impl.hpp
@@ -220,7 +220,7 @@ private:
 
     // MRange<> is [width], [width,height], or [width,height,depth] (which
     // is different than MAccessRange, etc in bufffers)
-    static constexpr int XTermPos = 0, YTermPos = 1, ZTermPos = 2;
+    constexpr int XTermPos = 0, YTermPos = 1, ZTermPos = 2;
     Desc.image_width = MRange[XTermPos];
     Desc.image_height = MDimensions > 1 ? MRange[YTermPos] : 1;
     Desc.image_depth = MDimensions > 2 ? MRange[ZTermPos] : 1;


### PR DESCRIPTION
in sycl/source/detail/image_impl.hpp. clang-cl and MSVC produce different exports for this. However, the static here doesn't bring any functional value, so just remove it as a quick solution to align the behavior between two toolchains that could be used to compile the project.

The change is expected to be NFC for the MSVC toolchain used in our CI.