### PR TITLE
[SYCL] Workaround clang-cl exports for "= default" constexpr ctors

### DIFF
--- a/sycl/include/sycl/half_type.hpp
+++ b/sycl/include/sycl/half_type.hpp
@@ -137,8 +137,10 @@ namespace host_half_impl {
 class __SYCL_EXPORT half {
 public:
   half() = default;
-  constexpr half(const half &) = default;
-  constexpr half(half &&) = default;
+  // clang-cl doesn't create required exports on Windows for " = default"
+  // because of "constexpr", workaround by providing explicit implementation.
+  constexpr half(const half &Other) : Buf(Other.Buf) {}
+  constexpr half(half &&Other) : Buf(std::move(Other.Buf)) {}
 
   __SYCL_CONSTEXPR_HALF half(const float &rhs) : Buf(float2Half(rhs)) {}
 


### PR DESCRIPTION
Unlike MSVC, clang-cl doesn't put explicitly defaulted constexpr copy/move ctors of dllexport classes into exports leading to different exported symbols in the library depending what toolchain is used for the build.

Workaround that by providing explicit implementation instead of using "= default;". The change is expected to be NFC for MSVC toolchain that is used in our CI.