### PR TITLE
[SYCL-MLIR] Add a pass to change ABI from memref to LLVM pointer

### DIFF
--- a/polygeist/include/polygeist/Passes/Passes.h
+++ b/polygeist/include/polygeist/Passes/Passes.h
@@ -25,6 +25,7 @@ std::unique_ptr<Pass> createLegalizeForSPIRVPass();
 std::unique_ptr<Pass>
 createConvertPolygeistToLLVMPass(const LowerToLLVMOptions &options);
 std::unique_ptr<Pass> createConvertPolygeistToLLVMPass();
+std::unique_ptr<Pass> createConvertToLLVMABIPass();
 
 } // namespace polygeist
 } // namespace mlir

--- a/polygeist/include/polygeist/Passes/Passes.td
+++ b/polygeist/include/polygeist/Passes/Passes.td
@@ -131,4 +131,10 @@ def ConvertPolygeistToLLVM : Pass<"convert-polygeist-to-llvm", "mlir::ModuleOp">
   ];
 }
 
+def ConvertToLLVMABI : Pass<"convert-to-llvm-abi", "mlir::ModuleOp"> {
+  let summary = "Convert MemRef ABI to LLVM Pointer ABI";
+  let constructor = "::mlir::polygeist::createConvertToLLVMABIPass()";
+  let dependentDialects = ["LLVM::LLVMDialect"];
+}
+
 #endif // POLYGEIST_PASSES

--- a/polygeist/lib/polygeist/Passes/CMakeLists.txt
+++ b/polygeist/lib/polygeist/Passes/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_dialect_library(MLIRPolygeistTransforms
   BarrierRemovalContinuation.cpp  
   CanonicalizeFor.cpp
   ConvertPolygeistToLLVM.cpp  
+  ConvertToLLVMABI.cpp
   InnerSerialization.cpp  
   LegalizeForSPIRV.cpp  
   LoopRestructure.cpp

--- a/polygeist/lib/polygeist/Passes/ConvertToLLVMABI.cpp
+++ b/polygeist/lib/polygeist/Passes/ConvertToLLVMABI.cpp
@@ -1,0 +1,123 @@
+//===- ConvertToLLVMABI.cpp - Convert to LLVM Pointer ABI -----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass currently only handles SYCL Kernel functions.
+// This pass converts all arguments with MemRef type to LLVM pointer type,
+// and replace all uses of the original argument with a
+// `polygeist.pointer2memref` of the new argument.
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetails.h"
+#include "mlir/Conversion/LLVMCommon/Pattern.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "convert-to-llvm-abi"
+
+using namespace mlir;
+
+namespace {
+
+class GPUFuncLowering : public OpRewritePattern<gpu::GPUFuncOp> {
+public:
+  using OpRewritePattern<gpu::GPUFuncOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(gpu::GPUFuncOp op,
+                                PatternRewriter &rewriter) const override {
+    assert(op->getAttr("llvm.cconv") ==
+               mlir::LLVM::CConvAttr::get(op.getContext(),
+                                          LLVM::cconv::CConv::SPIR_KERNEL) &&
+           "Expecting SYCL Kernel");
+    LLVM_DEBUG(llvm::dbgs() << "ConvertToLLVMABIPass: GPUFuncLowering: "
+                            << op.getName() << "\n");
+
+    // Notify MLIR we're updating the function in place
+    rewriter.startRootUpdate(op);
+
+    FunctionType funcTy = op.getFunctionType();
+    TypeConverter::SignatureConversion conversion(funcTy.getNumInputs());
+
+    rewriter.setInsertionPointToStart(&op.getBody().front());
+    Region &funcBody = op.getBody();
+    SmallVector<BlockArgument, 8> Args(funcBody.getArguments().begin(),
+                                       funcBody.getArguments().end());
+    for (auto &en : llvm::enumerate(Args)) {
+      Value arg = en.value();
+      auto MT = arg.getType().dyn_cast<MemRefType>();
+      if (!MT) {
+        conversion.addInputs(en.index(), {arg.getType()});
+        continue;
+      }
+
+      LLVM_DEBUG(llvm::dbgs() << "  Replace argument " << en.index() << ": \""
+                              << arg << "\"");
+      Type PT = LLVM::LLVMPointerType::get(MT.getElementType(),
+                                           MT.getMemorySpaceAsInt());
+      Value newArg = funcBody.insertArgument(en.index(), PT, arg.getLoc());
+      LLVM_DEBUG(llvm::dbgs() << " -> \"" << newArg << "\"\n");
+      conversion.addInputs(en.index(), {PT});
+
+      auto Ptr2Memref = rewriter.create<polygeist::Pointer2MemrefOp>(
+          arg.getLoc(), MT, newArg);
+
+      arg.replaceAllUsesWith(Ptr2Memref);
+      funcBody.eraseArgument(en.index() + 1);
+    }
+
+    assert(funcTy.getNumResults() == 0 &&
+           "Expecting SYCL kernel to return void");
+
+    auto newFuncTy = FunctionType::get(
+        op.getContext(), conversion.getConvertedTypes(), funcTy.getResults());
+    op->setAttr(FunctionOpInterface::getTypeAttrName(),
+                TypeAttr::get(newFuncTy));
+    LLVM_DEBUG(llvm::dbgs() << "  New FunctionType: " << newFuncTy << "\n");
+
+    // Notify MLIR in place updates are done
+    rewriter.finalizeRootUpdate(op);
+
+    return success();
+  }
+};
+
+struct ConvertToLLVMABIPass final
+    : public mlir::polygeist::ConvertToLLVMABIBase<ConvertToLLVMABIPass> {
+  void runOnOperation() override {
+    ModuleOp m = getOperation();
+
+    RewritePatternSet patterns(&getContext());
+    patterns.add<GPUFuncLowering>(&getContext());
+
+    ConversionTarget target(getContext());
+    target.addDynamicallyLegalOp<gpu::GPUFuncOp>([](gpu::GPUFuncOp op) {
+      return llvm::none_of(op.getFunctionType().getInputs(),
+                           [](Type ty) { return ty.isa<MemRefType>(); });
+    });
+    target.addLegalOp<polygeist::Pointer2MemrefOp>();
+
+    if (failed(applyPartialConversion(m, target, std::move(patterns))))
+      signalPassFailure();
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "ConvertToLLVMABIPass: Module after:\n";
+      m->dump();
+      llvm::dbgs() << "\n";
+    });
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::polygeist::createConvertToLLVMABIPass() {
+  return std::make_unique<ConvertToLLVMABIPass>();
+}

--- a/polygeist/test/polygeist-opt/sycl/convertToLLVMABI.mlir
+++ b/polygeist/test/polygeist-opt/sycl/convertToLLVMABI.mlir
@@ -1,0 +1,13 @@
+// RUN: polygeist-opt --convert-to-llvm-abi --split-input-file %s | FileCheck %s
+
+// CHECK: gpu.func @kernel([[A0:%.*]]: !llvm.ptr<i32, 1>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_) 
+// CHECK-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+// CHECK-NEXT:      [[P2M:%.*]] = "polygeist.pointer2memref"([[A0]]) : (!llvm.ptr<i32, 1>) -> memref<?xi32, 1>
+// CHECK-NEXT:      sycl.call([[P2M]]) {Function = @foo, MangledName = @foo} : (memref<?xi32, 1>) -> ()
+
+gpu.module @device_functions {
+gpu.func @kernel(%arg0: memref<?xi32, 1>, %arg1: !sycl.range<1>, %arg2: !sycl.range<1>, %arg3: !sycl.id<1>) kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+  sycl.call(%arg0) {Function = @foo, MangledName = @foo} : (memref<?xi32, 1>) -> ()
+  gpu.return
+}
+}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
@@ -8,8 +8,8 @@
 // BUG: clang++ -o doesn't redirect the output to the file specified.
 // XFAIL: *
 
-// Test that the kernel named `kernel_single_task` is generated.
-// CHECK: define weak_odr spir_kernel void {{.*}}kernel_single_task
+// Test that the kernel named `kernel_single_task` is generated with the correct signature.
+// CHECK: define weak_odr spir_kernel void {{.*}}kernel_single_task(i32 addrspace(1)* {{.*}}, %"class.sycl::_V1::range.1" {{.*}}, %"class.sycl::_V1::range.1" {{.*}}, %"class.sycl::_V1::id.1" {{.*}})
 // Test that all referenced sycl header functions are generated.
 // CHECK-NOT: declare {{.*}} spir_func
 

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -637,6 +637,7 @@ static int finalize(mlir::MLIRContext &context,
     if (!EmitOpenMPIR) {
       module->walk([&](mlir::omp::ParallelOp) { LinkOMP = true; });
       mlir::PassManager pm3(&context);
+      pm3.addPass(polygeist::createConvertToLLVMABIPass());
       LowerToLLVMOptions options(&context);
       options.dataLayout = DL;
       // invalid for gemm.c init array


### PR DESCRIPTION
In order to have matching ABI between cgeist generated code and non cgeist generated code, `ConvertToLLVMABIPass` is added.

This pass currently only handles SYCL Kernel functions. (a short-term limitation)
This pass converts all arguments with MemRef type to LLVM pointer type and replace all uses of the original argument with a `polygeist.pointer2memref` of the new argument.

This pass is added right before lowering to LLVM dialect, to maximize the usage of MemRef type.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>