### PR TITLE
[SYCL-MLIR][ConvertToLLVMABI] Handle `gpu.func` with non void return type(s)

### DIFF
--- a/polygeist/lib/polygeist/Passes/ConvertToLLVMABI.cpp
+++ b/polygeist/lib/polygeist/Passes/ConvertToLLVMABI.cpp
@@ -104,7 +104,7 @@ public:
     // Notify MLIR we're updating the function in place
     rewriter.startRootUpdate(op);
 
-    bool Changed = false;
+    bool changed = false;
     for (const auto &en : llvm::enumerate(op.getOperands())) {
       auto MT = en.value().getType().dyn_cast<MemRefType>();
       if (!MT)
@@ -115,19 +115,19 @@ public:
       auto memref2Ptr = rewriter.create<polygeist::Memref2PointerOp>(
           en.value().getLoc(), PT, en.value());
       op.setOperand(en.index(), memref2Ptr);
-      Changed = true;
+      changed = true;
     }
     LLVM_DEBUG({
-      if (Changed)
+      if (changed)
         llvm::dbgs() << "  New ReturnOp: " << op << "\n";
       else
-        llvm::dbgs() << " unchanged\n";
+        llvm::dbgs() << "  unchanged\n";
     });
 
     // Notify MLIR in place updates are done
     rewriter.finalizeRootUpdate(op);
 
-    return Changed ? success() : failure();
+    return changed ? success() : failure();
   }
 };
 

--- a/polygeist/lib/polygeist/Passes/ConvertToLLVMABI.cpp
+++ b/polygeist/lib/polygeist/Passes/ConvertToLLVMABI.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This pass currently only handles SYCL Kernel functions.
+// This pass currently only handles GPU functions.
 // This pass converts all arguments with MemRef type to LLVM pointer type,
 // and replace all uses of the original argument with a
 // `polygeist.pointer2memref` of the new argument.
@@ -34,7 +34,6 @@ public:
 
   LogicalResult matchAndRewrite(gpu::GPUFuncOp op,
                                 PatternRewriter &rewriter) const override {
-    assert(op.isKernel() && "Expecting SYCL Kernel");
     LLVM_DEBUG(llvm::dbgs() << "ConvertToLLVMABIPass: GPUFuncLowering: "
                             << op.getName() << "\n");
 
@@ -71,11 +70,17 @@ public:
       funcBody.eraseArgument(en.index() + 1);
     }
 
-    assert(funcTy.getNumResults() == 0 &&
-           "Expecting SYCL kernel to return void");
+    SmallVector<Type, 1> convertedResultTys;
+    for (Type ty : funcTy.getResults()) {
+      if (auto MT = ty.dyn_cast<MemRefType>())
+        convertedResultTys.push_back(LLVM::LLVMPointerType::get(
+            MT.getElementType(), MT.getMemorySpaceAsInt()));
+      else
+        convertedResultTys.push_back(ty);
+    }
 
     auto newFuncTy = FunctionType::get(
-        op.getContext(), conversion.getConvertedTypes(), funcTy.getResults());
+        op.getContext(), conversion.getConvertedTypes(), convertedResultTys);
     op->setAttr(FunctionOpInterface::getTypeAttrName(),
                 TypeAttr::get(newFuncTy));
     LLVM_DEBUG(llvm::dbgs() << "  New FunctionType: " << newFuncTy << "\n");
@@ -87,6 +92,45 @@ public:
   }
 };
 
+class GPUReturnLowering : public OpRewritePattern<gpu::ReturnOp> {
+public:
+  using OpRewritePattern<gpu::ReturnOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(gpu::ReturnOp op,
+                                PatternRewriter &rewriter) const override {
+    LLVM_DEBUG(llvm::dbgs()
+               << "ConvertToLLVMABIPass: GPUReturnLowering: " << op << "\n");
+
+    // Notify MLIR we're updating the function in place
+    rewriter.startRootUpdate(op);
+
+    bool Changed = false;
+    for (const auto &en : llvm::enumerate(op.getOperands())) {
+      auto MT = en.value().getType().dyn_cast<MemRefType>();
+      if (!MT)
+        continue;
+
+      Type PT = LLVM::LLVMPointerType::get(MT.getElementType(),
+                                           MT.getMemorySpaceAsInt());
+      auto memref2Ptr = rewriter.create<polygeist::Memref2PointerOp>(
+          en.value().getLoc(), PT, en.value());
+      op.setOperand(en.index(), memref2Ptr);
+      Changed = true;
+    }
+    LLVM_DEBUG({
+      if (Changed)
+        llvm::dbgs() << "  New ReturnOp: " << op << "\n";
+      else
+        llvm::dbgs() << " unchanged\n";
+    });
+
+    // Notify MLIR in place updates are done
+    rewriter.finalizeRootUpdate(op);
+
+    return Changed ? success() : failure();
+  }
+};
+
 struct ConvertToLLVMABIPass final
     : public mlir::polygeist::ConvertToLLVMABIBase<ConvertToLLVMABIPass> {
   void runOnOperation() override {
@@ -94,15 +138,23 @@ struct ConvertToLLVMABIPass final
 
     RewritePatternSet patterns(&getContext());
     patterns.add<GPUFuncLowering>(&getContext());
+    patterns.add<GPUReturnLowering>(&getContext());
 
     ConversionTarget target(getContext());
     target.addDynamicallyLegalOp<gpu::GPUFuncOp>([](gpu::GPUFuncOp op) {
       FunctionType funcTy = op.getFunctionType();
-      assert(funcTy.getNumResults() == 0 &&
-             "Expecting SYCL kernel to return void");
-      return llvm::none_of(funcTy.getInputs(),
-                           [](Type ty) { return ty.isa<MemRefType>(); });
+      bool hasMemRef = llvm::any_of(
+          funcTy.getResults(), [](Type ty) { return ty.isa<MemRefType>(); });
+      hasMemRef |= llvm::any_of(funcTy.getInputs(),
+                                [](Type ty) { return ty.isa<MemRefType>(); });
+      return !hasMemRef;
     });
+    target.addDynamicallyLegalOp<gpu::ReturnOp>([](gpu::ReturnOp op) {
+      return llvm::none_of(op.getOperands(), [](Value v) {
+        return v.getType().isa<MemRefType>();
+      });
+    });
+    target.addLegalOp<polygeist::Memref2PointerOp>();
     target.addLegalOp<polygeist::Pointer2MemrefOp>();
 
     if (failed(applyPartialConversion(m, target, std::move(patterns))))

--- a/polygeist/test/polygeist-opt/sycl/convertToLLVMABI.mlir
+++ b/polygeist/test/polygeist-opt/sycl/convertToLLVMABI.mlir
@@ -5,9 +5,24 @@
 // CHECK-NEXT:      [[P2M:%.*]] = "polygeist.pointer2memref"([[A0]]) : (!llvm.ptr<i32, 1>) -> memref<?xi32, 1>
 // CHECK-NEXT:      sycl.call([[P2M]]) {Function = @foo, MangledName = @foo} : (memref<?xi32, 1>) -> ()
 
-gpu.module @device_functions {
+gpu.module @module {
 gpu.func @kernel(%arg0: memref<?xi32, 1>, %arg1: !sycl.range<1>, %arg2: !sycl.range<1>, %arg3: !sycl.id<1>) kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
   sycl.call(%arg0) {Function = @foo, MangledName = @foo} : (memref<?xi32, 1>) -> ()
   gpu.return
+}
+}
+
+// -----
+
+// CHECK-LABEL: gpu.func @return() -> (!llvm.ptr<i32, 1>, i64) {
+// CHECK:   [[MEMREF:%.*]] = sycl.call() {Function = @foo, MangledName = @foo} : () -> memref<?xi32, 1>
+// CHECK:   [[M2P:%.*]] = "polygeist.memref2pointer"([[MEMREF]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:   gpu.return [[M2P]], {{.*}} : !llvm.ptr<i32, 1>, i64
+
+gpu.module @module {
+gpu.func @return() -> (memref<?xi32, 1>, i64) { 
+  %memref = sycl.call() {Function = @foo, MangledName = @foo} : () -> memref<?xi32, 1>
+  %c0 = arith.constant 0 : i64
+  gpu.return %memref, %c0: memref<?xi32, 1>, i64
 }
 }


### PR DESCRIPTION
When a return type is `MemRefType`, modify the return operator to return the `polygeist.memref2pointer` of the original return value.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>