### PR TITLE
[SYCL-MLIR][ConvertToLLVMABI] Remove limitations

### DIFF
--- a/polygeist/test/polygeist-opt/sycl/convertToLLVMABI.mlir
+++ b/polygeist/test/polygeist-opt/sycl/convertToLLVMABI.mlir
@@ -3,7 +3,8 @@
 // CHECK: gpu.func @kernel([[A0:%.*]]: !llvm.ptr<i32, 1>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_) 
 // CHECK-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-NEXT:      [[P2M:%.*]] = "polygeist.pointer2memref"([[A0]]) : (!llvm.ptr<i32, 1>) -> memref<?xi32, 1>
-// CHECK-NEXT:      sycl.call([[P2M]]) {Function = @foo, MangledName = @foo} : (memref<?xi32, 1>) -> ()
+// CHECK-NEXT:      [[M2P:%.*]] = "polygeist.memref2pointer"([[P2M]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:      sycl.call([[M2P]]) {Function = @foo, MangledName = @foo} : (!llvm.ptr<i32, 1>) -> ()
 
 gpu.module @module {
 gpu.func @kernel(%arg0: memref<?xi32, 1>, %arg1: !sycl.range<1>, %arg2: !sycl.range<1>, %arg3: !sycl.id<1>) kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
@@ -15,8 +16,9 @@ gpu.func @kernel(%arg0: memref<?xi32, 1>, %arg1: !sycl.range<1>, %arg2: !sycl.ra
 // -----
 
 // CHECK-LABEL: gpu.func @return() -> (!llvm.ptr<i32, 1>, i64) {
-// CHECK:   [[MEMREF:%.*]] = sycl.call() {Function = @foo, MangledName = @foo} : () -> memref<?xi32, 1>
-// CHECK:   [[M2P:%.*]] = "polygeist.memref2pointer"([[MEMREF]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:    [[MEMREF:%.*]] = sycl.call() {Function = @foo, MangledName = @foo} : () -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:    [[P2M:%.*]] = "polygeist.pointer2memref"([[MEMREF]]) : (!llvm.ptr<i32, 1>) -> memref<?xi32, 1>
+// CHECK:   [[M2P:%.*]] = "polygeist.memref2pointer"([[P2M]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
 // CHECK-NEXT:   gpu.return [[M2P]], {{.*}} : !llvm.ptr<i32, 1>, i64
 
 gpu.module @module {
@@ -26,3 +28,41 @@ gpu.func @return() -> (memref<?xi32, 1>, i64) {
   gpu.return %memref, %c0: memref<?xi32, 1>, i64
 }
 }
+
+// -----
+
+// CHECK:  func.func @caller([[A0:.*]]: !llvm.ptr<i32, 1>) -> !llvm.ptr<i32, 1> {
+// CHECK-NEXT:    [[P2M:%.*]] = "polygeist.pointer2memref"([[A0]]) : (!llvm.ptr<i32, 1>) -> memref<?xi32, 1>
+// CHECK-NEXT:    [[M2P:%.*]] = "polygeist.memref2pointer"([[P2M]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:    [[SYCLCALL:%.*]] = sycl.call([[M2P]]) {Function = @callee, MangledName = @callee} : (!llvm.ptr<i32, 1>) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:    [[P2M:%.*]] = "polygeist.pointer2memref"([[SYCLCALL]]) : (!llvm.ptr<i32, 1>) -> memref<?xi32, 1>
+// CHECK-NEXT:    [[M2P:%.*]] = "polygeist.memref2pointer"([[P2M]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:    [[FUNCCALL:%.*]] = call @callee([[M2P]]) : (!llvm.ptr<i32, 1>) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:    [[P2M:%.*]] = "polygeist.pointer2memref"([[FUNCCALL]]) : (!llvm.ptr<i32, 1>) -> memref<?xi32, 1>
+// CHECK-NEXT:    [[M2P:%.*]] = "polygeist.memref2pointer"([[P2M]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:    return [[M2P]] : !llvm.ptr<i32, 1>
+
+func.func @caller(%arg0: memref<?xi32, 1>) -> memref<?xi32, 1> { 
+  %syclcall = sycl.call(%arg0) {Function = @callee, MangledName = @callee} : (memref<?xi32, 1>) -> memref<?xi32, 1>
+  %funccall = func.call @callee(%syclcall) : (memref<?xi32, 1>) -> memref<?xi32, 1>
+  func.return %funccall: memref<?xi32, 1>
+}
+
+// CHECK: func.func private @callee(!llvm.ptr<i32, 1>) -> !llvm.ptr<i32, 1>
+func.func private @callee(%arg0: memref<?xi32, 1>) -> memref<?xi32, 1>
+
+// -----
+
+// CHECK: !sycl_id_1_ = !sycl.id<1>
+// CHECK: func.func @constructor_caller([[A0:%.*]]: !llvm.ptr<!sycl_id_1_, 1>) {
+// CHECK-NEXT:    [[P2M:%.*]] = "polygeist.pointer2memref"([[A0]]) : (!llvm.ptr<!sycl_id_1_, 1>) -> memref<?x!sycl_id_1_, 1>
+// CHECK-NEXT:    [[M2P:%.*]] = "polygeist.memref2pointer"([[P2M]]) : (memref<?x!sycl_id_1_, 1>) -> !llvm.ptr<!sycl_id_1_, 1>
+// CHECK-NEXT:    call @constructor([[M2P]]) : (!llvm.ptr<!sycl_id_1_, 1>) -> ()
+
+func.func @constructor_caller(%arg0: memref<?x!sycl.id<1>, 1>) {
+  sycl.constructor(%arg0) {MangledName = @constructor, Type = @foo} : (memref<?x!sycl.id<1>, 1>) -> ()
+  func.return
+}
+
+// CHECK: func.func private @constructor(!llvm.ptr<!sycl_id_1_, 1>)
+func.func private @constructor(%arg0: memref<?x!sycl.id<1>, 1>)

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -65,7 +65,7 @@ extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
 // CHECK-LLVM: [[CAST1:%.*]] = bitcast [[ID_TYPE]]* %1 to i8*
 // CHECK-LLVM: call void @llvm.memset.p0i8.i64(i8* %2, i8 0, i64 16, i1 false)
 // CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID1]] to [[ID_TYPE]] addrspace(4)*
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1Ev([[ID_TYPE]] addrspace(4)* [[ID1_AS]], [[ID_TYPE]] addrspace(4)* [[ID1_AS]], i64 0, i64 -1, i64 1)  
+// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1Ev([[ID_TYPE]] addrspace(4)* [[ID1_AS]])  
 
 extern "C" SYCL_EXTERNAL void cons_1() {
   auto id = sycl::id<2>{};
@@ -82,7 +82,7 @@ extern "C" SYCL_EXTERNAL void cons_1() {
 // CHECK-LLVM-LABEL: define spir_func void @cons_2(i64 %0, i64 %1) #0
 // CHECK-LLVM: [[ID1:%.*]] = alloca [[ID_TYPE:%"class.sycl::_V1::id.2"]]
 // CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID1]] to [[ID_TYPE]] addrspace(4)*
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm([[ID_TYPE]] addrspace(4)* [[ID1_AS]], [[ID_TYPE]] addrspace(4)* [[ID1_AS]], i64 0, i64 -1, i64 1, i64 %0, i64 %1)
+// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm([[ID_TYPE]] addrspace(4)* [[ID1_AS]], i64 %0, i64 %1)
 
 extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
   auto id = sycl::id<2>{a, b};
@@ -107,7 +107,7 @@ extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
 // CHECK-LLVM: store [[ITEM_TYPE]] [[ARG0]], [[ITEM_TYPE]]* [[ITEM]], align 8
 // CHECK-LLVM: [[ID_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID]] to [[ID_TYPE]] addrspace(4)*
 // CHECK-LLVM: [[ITEM_AS:%.*]] = addrspacecast [[ITEM_TYPE]]* [[ITEM]] to [[ITEM_TYPE]] addrspace(4)*
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE([[ID_TYPE]] addrspace(4)* [[ID_AS]], [[ID_TYPE]] addrspace(4)* [[ID_AS]], i64 0, i64 -1, i64 1, [[ITEM_TYPE]] addrspace(4)* [[ITEM_AS]], [[ITEM_TYPE]] addrspace(4)* [[ITEM_AS]], i64 0, i64 -1, i64 1)
+// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE([[ID_TYPE]] addrspace(4)* [[ID_AS]], [[ITEM_TYPE]] addrspace(4)* [[ITEM_AS]])
 
 extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
   auto id = sycl::id<2>{val};
@@ -132,7 +132,7 @@ extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
 // CHECK-LLVM: store [[ID_TYPE]] [[ARG0]], [[ID_TYPE]]* [[ID2]], align 8
 // CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID1]] to [[ID_TYPE]] addrspace(4)*
 // CHECK-LLVM: [[ID2_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID2]] to [[ID_TYPE]] addrspace(4)*
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ERKS2_([[ID_TYPE]] addrspace(4)* [[ID1_AS]], [[ID_TYPE]] addrspace(4)* [[ID1_AS]], i64 0, i64 -1, i64 1, [[ID_TYPE]] addrspace(4)* [[ID2_AS]], [[ID_TYPE]] addrspace(4)* [[ID2_AS]], i64 0, i64 -1, i64 1)
+// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ERKS2_([[ID_TYPE]] addrspace(4)* [[ID1_AS]], [[ID_TYPE]] addrspace(4)* [[ID2_AS]])
 
 extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
   auto id = sycl::id<2>{val};
@@ -146,7 +146,7 @@ extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
 // CHECK-LLVM-LABEL: define spir_func void @cons_5() #0
 // CHECK-LLVM: [[ACCESSOR:%.*]] = alloca %"class.sycl::_V1::accessor.1", align 8
 // CHECK-LLVM: [[ACAST:%.*]] = addrspacecast %"class.sycl::_V1::accessor.1"* [[ACCESSOR]] to %"class.sycl::_V1::accessor.1" addrspace(4)*
-// CHECK-LLVM: call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]], %"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]], i64 0, i64 -1, i64 1)
+// CHECK-LLVM: call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]])
 
 extern "C" SYCL_EXTERNAL void cons_5() {
   auto accessor = sycl::accessor<sycl::cl_int, 1, sycl::access::mode::write>{};

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -36,7 +36,7 @@
 // CHECK-LLVM-LABEL: define spir_func void @cons_5() #0 {
 // CHECK-LLVM-NEXT:  [[ACCESSOR:%.*]] = alloca %"class.sycl::_V1::accessor.1", align 8
 // CHECK-LLVM-NEXT:  [[ACAST:%.*]] = addrspacecast %"class.sycl::_V1::accessor.1"* [[ACCESSOR]] to %"class.sycl::_V1::accessor.1" addrspace(4)*
-// CHECK-LLVM-NEXT:  call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]], %"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]], i64 0, i64 -1, i64 1)
+// CHECK-LLVM-NEXT:  call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]])
 
 extern "C" SYCL_EXTERNAL void cons_5() {
   sycl::accessor<sycl::cl_int, 1, sycl::access::mode::write> accessor;


### PR DESCRIPTION
This PR removes the GPU limitation. The pass now also converts `FuncDialect` and call operations.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>