### PR TITLE
[SYCL-MLIR] Add LLVM::PointerElementTypeInterface trait to NDItem

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
@@ -432,7 +432,8 @@ public:
 
 class NdItemType
     : public Type::TypeBase<NdItemType, Type, detail::NdItemTypeStorage,
-                            mlir::MemRefElementTypeInterface::Trait> {
+                            mlir::MemRefElementTypeInterface::Trait,
+                            mlir::LLVM::PointerElementTypeInterface::Trait> {
 public:
   using Base::Base;
 


### PR DESCRIPTION
Signed-off-by: Victor Perez <victor.perez@codeplay.com>