### PR TITLE
[SYCL-MLIR][cgeist] Fix global definition

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1193,8 +1193,11 @@ ValueCategory MLIRScanner::VisitDeclRefExpr(DeclRefExpr *E) {
     // function, the global should be in the gpu module (which is nested inside
     // another main module).
     std::pair<mlir::memref::GlobalOp, bool> gv;
-    gv = Glob.GetOrCreateGlobal(VD, /*prefix=*/"", true,
-                                function->getParentOp() != module.get());
+    if (isa<mlir::gpu::GPUModuleOp>(function->getParentOp()))
+      gv = Glob.GetOrCreateGlobal(VD, /*prefix=*/"", true,
+                                FunctionContext::SYCLDevice);
+    else
+      gv = Glob.GetOrCreateGlobal(VD, /*prefix=*/"", true);
 
     auto gv2 = builder.create<memref::GetGlobalOp>(loc, gv.first.type(),
                                                    gv.first.getName());

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1193,11 +1193,7 @@ ValueCategory MLIRScanner::VisitDeclRefExpr(DeclRefExpr *E) {
     // function, the global should be in the gpu module (which is nested inside
     // another main module).
     std::pair<mlir::memref::GlobalOp, bool> gv;
-    if (function->getParentOp() != module.get()) {
-      // Device function
-      gv = Glob.GetOrCreateGlobal(VD, /*prefix=*/"", true, true);
-    } else
-      gv = Glob.GetOrCreateGlobal(VD, /*prefix=*/"", true, false);
+    gv = Glob.GetOrCreateGlobal(VD, /*prefix=*/"", true, function->getParentOp() != module.get());
 
     auto gv2 = builder.create<memref::GetGlobalOp>(loc, gv.first.type(),
                                                    gv.first.getName());

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1195,7 +1195,7 @@ ValueCategory MLIRScanner::VisitDeclRefExpr(DeclRefExpr *E) {
     std::pair<mlir::memref::GlobalOp, bool> gv;
     if (isa<mlir::gpu::GPUModuleOp>(function->getParentOp()))
       gv = Glob.GetOrCreateGlobal(VD, /*prefix=*/"", true,
-                                FunctionContext::SYCLDevice);
+                                  FunctionContext::SYCLDevice);
     else
       gv = Glob.GetOrCreateGlobal(VD, /*prefix=*/"", true);
 

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1192,12 +1192,11 @@ ValueCategory MLIRScanner::VisitDeclRefExpr(DeclRefExpr *E) {
     // We need to decide where to put the Global.  If we are in a device
     // function, the global should be in the gpu module (which is nested inside
     // another main module).
-    std::pair<mlir::memref::GlobalOp, bool> gv;
-    if (isa<mlir::gpu::GPUModuleOp>(function->getParentOp()))
-      gv = Glob.GetOrCreateGlobal(VD, /*prefix=*/"", true,
-                                  FunctionContext::SYCLDevice);
-    else
-      gv = Glob.GetOrCreateGlobal(VD, /*prefix=*/"", true);
+    std::pair<mlir::memref::GlobalOp, bool> gv = Glob.GetOrCreateGlobal(
+        VD, /*prefix=*/"", true,
+        isa<mlir::gpu::GPUModuleOp>(function->getParentOp())
+            ? FunctionContext::SYCLDevice
+            : FunctionContext::Host);
 
     auto gv2 = builder.create<memref::GetGlobalOp>(loc, gv.first.type(),
                                                    gv.first.getName());

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1193,7 +1193,8 @@ ValueCategory MLIRScanner::VisitDeclRefExpr(DeclRefExpr *E) {
     // function, the global should be in the gpu module (which is nested inside
     // another main module).
     std::pair<mlir::memref::GlobalOp, bool> gv;
-    gv = Glob.GetOrCreateGlobal(VD, /*prefix=*/"", true, function->getParentOp() != module.get());
+    gv = Glob.GetOrCreateGlobal(VD, /*prefix=*/"", true,
+                                function->getParentOp() != module.get());
 
     auto gv2 = builder.create<memref::GetGlobalOp>(loc, gv.first.type(),
                                                    gv.first.getName());

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1190,7 +1190,7 @@ ValueCategory MLIRScanner::VisitDeclRefExpr(DeclRefExpr *E) {
     }
 
     // We need to decide where to put the Global.  If we are in a device
-    // function, the global should be in the gpu module (which is nested inside
+    // module, the global should be in the gpu module (which is nested inside
     // another main module).
     std::pair<mlir::memref::GlobalOp, bool> gv = Glob.GetOrCreateGlobal(
         VD, /*prefix=*/"", true,

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -2833,7 +2833,7 @@ MLIRASTConsumer::GetOrCreateGlobal(const ValueDecl *FD, std::string prefix,
       MLIRScanner ms(*this, module, LTInfo);
       mlir::Block *B = new Block();
       // In case of device function, we will put the block in the forefront of
-      // the GPU module, else the blokc will go at the forefront of the main
+      // the GPU module, else the block will go at the forefront of the main
       // module.
       if (isGPU) {
         B->moveBefore(&(getDeviceModule(*module).body().front()));

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -2755,7 +2755,7 @@ MLIRASTConsumer::GetOrCreateLLVMGlobal(const ValueDecl *FD,
 
 std::pair<mlir::memref::GlobalOp, bool>
 MLIRASTConsumer::GetOrCreateGlobal(const ValueDecl *FD, std::string prefix,
-                                   bool tryInit, bool isGPU) {
+                                   bool tryInit, FunctionContext funcContext) {
   std::string name = prefix + CGM.getMangledName(FD).str();
 
   name = (PrefixABI + name);
@@ -2784,7 +2784,7 @@ MLIRASTConsumer::GetOrCreateGlobal(const ValueDecl *FD, std::string prefix,
   mlir::Attribute initial_value;
 
   mlir::OpBuilder builder(module->getContext());
-  if (isGPU)
+  if (funcContext == FunctionContext::SYCLDevice)
     builder.setInsertionPointToStart(
         &(getDeviceModule(*module).body().front()));
   else
@@ -2835,7 +2835,7 @@ MLIRASTConsumer::GetOrCreateGlobal(const ValueDecl *FD, std::string prefix,
       // In case of device function, we will put the block in the forefront of
       // the GPU module, else the block will go at the forefront of the main
       // module.
-      if (isGPU) {
+      if (funcContext == FunctionContext::SYCLDevice) {
         B->moveBefore(&(getDeviceModule(*module).body().front()));
         ms.getBuilder().setInsertionPointToStart(B);
       } else

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -2834,7 +2834,7 @@ MLIRASTConsumer::GetOrCreateGlobal(const ValueDecl *FD, std::string prefix,
       mlir::Block *B = new Block();
       // In case of device function, we will put the block in the forefront of
       // the GPU module, else the blokc will go at the forefront of the main
-      // module
+      // module.
       if (isGPU) {
         B->moveBefore(&(getDeviceModule(*module).body().front()));
         ms.getBuilder().setInsertionPointToStart(B);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -686,8 +686,9 @@ ValueCategory MLIRScanner::VisitVarDecl(clang::VarDecl *decl) {
           varLoc, Glob.GetOrCreateLLVMGlobal(
                       decl, (function.getName() + "@static@").str()));
     } else {
-      auto gv = Glob.GetOrCreateGlobal(
-          decl, (function.getName() + "@static@").str(), /*tryInit*/ false);
+      auto gv =
+          Glob.GetOrCreateGlobal(decl, (function.getName() + "@static@").str(),
+                                 /*tryInit*/ false);
       op = abuilder.create<memref::GetGlobalOp>(varLoc, gv.first.type(),
                                                 gv.first.getName());
     }
@@ -2782,7 +2783,7 @@ MLIRASTConsumer::GetOrCreateLLVMGlobal(const ValueDecl *FD,
 
 std::pair<mlir::memref::GlobalOp, bool>
 MLIRASTConsumer::GetOrCreateGlobal(const ValueDecl *FD, std::string prefix,
-                                   bool tryInit) {
+                                   bool tryInit, bool isGPU) {
   std::string name = prefix + CGM.getMangledName(FD).str();
 
   name = (PrefixABI + name);
@@ -2811,7 +2812,11 @@ MLIRASTConsumer::GetOrCreateGlobal(const ValueDecl *FD, std::string prefix,
   mlir::Attribute initial_value;
 
   mlir::OpBuilder builder(module->getContext());
-  builder.setInsertionPointToStart(module->getBody());
+  if (isGPU)
+    builder.setInsertionPointToStart(
+        &(getDeviceModule(*module).body().front()));
+  else
+    builder.setInsertionPointToStart(module->getBody());
 
   auto VD = dyn_cast<VarDecl>(FD);
   if (!VD)
@@ -2861,7 +2866,6 @@ MLIRASTConsumer::GetOrCreateGlobal(const ValueDecl *FD, std::string prefix,
     lnk = mlir::SymbolTable::Visibility::Private;
     break;
   }
-
   auto globalOp = builder.create<mlir::memref::GlobalOp>(
       module->getLoc(), builder.getStringAttr(name),
       /*sym_visibility*/ mlir::StringAttr(), mlir::TypeAttr::get(mr),
@@ -2874,7 +2878,14 @@ MLIRASTConsumer::GetOrCreateGlobal(const ValueDecl *FD, std::string prefix,
     if (auto init = VD->getInit()) {
       MLIRScanner ms(*this, module, LTInfo);
       mlir::Block *B = new Block();
-      ms.setEntryAndAllocBlock(B);
+      // In case of device function, we will put the block in the forefront of
+      // the GPU module, else the blokc will go at the forefront of the main
+      // module
+      if (isGPU) {
+        B->moveBefore(&(getDeviceModule(*module).body().front()));
+        ms.getBuilder().setInsertionPointToStart(B);
+      } else
+        ms.setEntryAndAllocBlock(B);
       OpBuilder builder(module->getContext());
       builder.setInsertionPointToEnd(B);
       auto op = builder.create<memref::AllocaOp>(module->getLoc(), mr);
@@ -3377,36 +3388,6 @@ bool MLIRASTConsumer::HandleTopLevelDecl(DeclGroupRef dg) {
     if (StringRef(name).startswith("_ZN9__gnu"))
       continue;
     if (name == "cudaGetDevice" || name == "cudaMalloc")
-      continue;
-
-    // Temp HACK: filter out SPIRV builtins that reference global variables.
-    // The correct fix is to bring into the GPU module the global variable these
-    // builtin function reference.
-    if (StringRef(name).startswith("_Z28__spirv_GlobalInvocationId"))
-      continue;
-    if (StringRef(name).startswith("_Z20__spirv_GlobalSize"))
-      continue;
-    if (StringRef(name).startswith("_Z22__spirv_GlobalOffset"))
-      continue;
-    if (StringRef(name).startswith("_Z23__spirv_NumWorkgroups"))
-      continue;
-    if (StringRef(name).startswith("_Z23__spirv_WorkgroupSize"))
-      continue;
-    if (StringRef(name).startswith("_Z23__spirv_WorkgroupSize"))
-      continue;
-    if (StringRef(name).startswith("_Z21__spirv_WorkgroupId"))
-      continue;
-    if (StringRef(name).startswith("_Z27__spirv_LocalInvocationId"))
-      continue;
-    if (StringRef(name).startswith("_Z20__spirv_SubgroupSizev"))
-      continue;
-    if (StringRef(name).startswith("_Z23__spirv_SubgroupMaxSizev"))
-      continue;
-    if (StringRef(name).startswith("_Z20__spirv_NumSubgroupsv"))
-      continue;
-    if (StringRef(name).startswith("_Z18__spirv_SubgroupIdv"))
-      continue;
-    if (StringRef(name).startswith("_Z33__spirv_SubgroupLocalInvocationIdv"))
       continue;
 
     if ((emitIfFound.count("*") && name != "fpclassify" && !fd->isStatic() &&

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -200,7 +200,8 @@ public:
 
   std::pair<mlir::memref::GlobalOp, bool>
   GetOrCreateGlobal(const clang::ValueDecl *VD, std::string prefix,
-                    bool tryInit = true, FunctionContext funcContext = FunctionContext::Host);
+                    bool tryInit = true,
+                    FunctionContext funcContext = FunctionContext::Host);
 
   void run();
 

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -200,7 +200,7 @@ public:
 
   std::pair<mlir::memref::GlobalOp, bool>
   GetOrCreateGlobal(const clang::ValueDecl *VD, std::string prefix,
-                    bool tryInit = true, bool isGPU = false);
+                    bool tryInit = true, FunctionContext funcContext = FunctionContext::Host);
 
   void run();
 

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -186,7 +186,7 @@ public:
 
   std::pair<mlir::memref::GlobalOp, bool>
   GetOrCreateGlobal(const clang::ValueDecl *VD, std::string prefix,
-                    bool tryInit = true);
+                    bool tryInit = true, bool isGPU = false);
 
   void run();
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -16,6 +16,49 @@
 // CHECK-DAG: !sycl_item_2_1_ = !sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>)>
 // CHECK-DAG: !sycl_range_1_ = !sycl.range<1>
 
+// Check globals referenced in device functions are created in the GPU module
+// CHECK: gpu.module @device_functions {
+// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupLocalInvocationId : memref<1xi32>
+// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupId : memref<1xi32>
+// CHECK-NEXT: memref.global @__spirv_BuiltInNumSubgroups : memref<1xi32>
+// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupMaxSize : memref<1xi32>
+// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupSize : memref<1xi32>
+// CHECK-NEXT: memref.global @__spirv_BuiltInLocalInvocationId : memref<3xi64>
+// CHECK-NEXT: memref.global @__spirv_BuiltInWorkgroupId : memref<3xi64>
+// CHECK-NEXT: memref.global @__spirv_BuiltInWorkgroupSize : memref<3xi64>
+// CHECK-NEXT: memref.global @__spirv_BuiltInNumWorkgroups : memref<3xi64>
+// CHECK-NEXT: memref.global @__spirv_BuiltInGlobalOffset : memref<3xi64>
+// CHECK-NEXT: memref.global @__spirv_BuiltInGlobalSize : memref<3xi64>
+// CHECK-NEXT: memref.global @__spirv_BuiltInGlobalInvocationId : memref<3xi64>
+
+// Ensure the spriv functions that reference these globals are not filtered out
+// CHECK-DAG: func.func @_Z28__spirv_GlobalInvocationId_xv()
+// CHECK-DAG: func.func @_Z28__spirv_GlobalInvocationId_yv()
+// CHECK-DAG: func.func @_Z28__spirv_GlobalInvocationId_zv()
+// CHECK-DAG: func.func @_Z20__spirv_GlobalSize_xv()
+// CHECK-DAG: func.func @_Z20__spirv_GlobalSize_yv()
+// CHECK-DAG: func.func @_Z20__spirv_GlobalSize_zv()
+// CHECK-DAG: func.func @_Z22__spirv_GlobalOffset_xv()
+// CHECK-DAG: func.func @_Z22__spirv_GlobalOffset_yv()
+// CHECK-DAG: func.func @_Z22__spirv_GlobalOffset_zv()
+// CHECK-DAG: func.func @_Z23__spirv_NumWorkgroups_xv()
+// CHECK-DAG: func.func @_Z23__spirv_NumWorkgroups_yv()
+// CHECK-DAG: func.func @_Z23__spirv_NumWorkgroups_zv()
+// CHECK-DAG: func.func @_Z23__spirv_WorkgroupSize_xv()
+// CHECK-DAG: func.func @_Z23__spirv_WorkgroupSize_yv()
+// CHECK-DAG: func.func @_Z23__spirv_WorkgroupSize_zv()
+// CHECK-DAG: func.func @_Z21__spirv_WorkgroupId_xv()
+// CHECK-DAG: func.func @_Z21__spirv_WorkgroupId_yv()
+// CHECK-DAG: func.func @_Z21__spirv_WorkgroupId_zv()
+// CHECK-DAG: func.func @_Z27__spirv_LocalInvocationId_xv()
+// CHECK-DAG: func.func @_Z27__spirv_LocalInvocationId_yv()
+// CHECK-DAG: func.func @_Z27__spirv_LocalInvocationId_zv()
+// CHECK-DAG: func.func @_Z18__spirv_SubgroupIdv()
+// CHECK-DAG: func.func @_Z33__spirv_SubgroupLocalInvocationIdv()
+// CHECK-DAG: func.func @_Z23__spirv_SubgroupMaxSizev()
+// CHECK-DAG: func.func @_Z20__spirv_NumSubgroupsv()
+
+
 // Ensure the constructors are NOT filtered out, and sycl.cast is generated for cast from sycl.id or sycl.range to sycl.array.
 // CHECK-LABEL: func.func @_ZN4sycl3_V12idILi1EEC1ERKS2_(%arg0: memref<?x!sycl_id_1_, 4>, %arg1: memref<?x!sycl_id_1_, 4>)
 // CHECK-SAME:  attributes {[[SPIR_FUNCCC:llvm.cconv = #llvm.cconv<spir_funccc>]], [[LINKONCE:llvm.linkage = #llvm.linkage<linkonce_odr>]], 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -31,7 +31,7 @@
 // CHECK-NEXT: memref.global @__spirv_BuiltInGlobalSize : memref<3xi64>
 // CHECK-NEXT: memref.global @__spirv_BuiltInGlobalInvocationId : memref<3xi64>
 
-// Ensure the spriv functions that reference these globals are not filtered out
+// Ensure the spirv functions that reference these globals are not filtered out
 // CHECK-DAG: func.func @_Z28__spirv_GlobalInvocationId_xv()
 // CHECK-DAG: func.func @_Z28__spirv_GlobalInvocationId_yv()
 // CHECK-DAG: func.func @_Z28__spirv_GlobalInvocationId_zv()


### PR DESCRIPTION
This patch makes sure that the globals created go in the right module, especially making sure that for device functions, the globals go into the GPU module and not the main module.