### PR TITLE
[SYCL] Use -fsemantic-interposition for device_selector.cpp

### DIFF
--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -210,6 +210,9 @@ if (MSVC)
   set(SYCL_EXTRA_OPTS "/MD")
 endif()
 
+# See https://github.com/llvm/llvm-project/issues/58295.
+set_source_files_properties(device_selector.cpp PROPERTIES COMPILE_FLAGS -fsemantic-interposition)
+
 if (WIN32)
 set(LIB_NAME "sycl${SYCL_MAJOR_VERSION}")
 else()


### PR DESCRIPTION
We build the whole project with -fno-semantic-interposition by default and it gets miscompiled by clang after https://github.com/intel/llvm/pull/6896.

It's not yet clear if this would be a permanent fix or if there is a bug in clang. The issue is being tracked at https://github.com/llvm/llvm-project/issues/58295.