### PR TITLE
[Driver][SYCL] Fix issue using -fsycl-force-target with offload dependencies

### DIFF
--- a/clang/test/Driver/sycl-force-target.cpp
+++ b/clang/test/Driver/sycl-force-target.cpp
@@ -21,6 +21,18 @@
 // CHECK_FORCE_TARGET_GEN: llvm-foreach{{.*}} {{.*}}ocloc{{.*}}
 // CHECK_FORCE_TARGET_CPU: llvm-foreach{{.*}} {{.*}}opencl-aot{{.*}}
 
+/// Verify the usage of -fsycl-force-target applies to all expected unbundlings
+/// and also applies to clang-offload-deps step
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -fsycl-force-target=spir64 \
+// RUN:          -target x86_64-unknown-linux-gnu -fno-sycl-device-lib=all \
+// RUN:          %s %S/Inputs/SYCL/liblin64.a -### 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=CHECK_FORCE_TARGET_ARCHIVE
+// CHECK_FORCE_TARGET_ARCHIVE: clang-offload-deps{{.*}} "-targets=sycl-spir64-unknown-unknown" "-outputs={{.*}}"
+// CHECK_FORCE_TARGET_ARCHIVE: clang-offload-bundler{{.*}} "-type=aoo" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}liblin64.a" "-output=[[DEVICELISTOUT:.+]]" "-unbundle" "-allow-missing-bundles"
+// CHECK_FORCE_TARGET_ARCHIVE: spirv-to-ir-wrapper{{.*}} "[[DEVICELISTOUT]]" "-o" "[[DEVICELISTBC:.+\.txt]]"
+// CHECK_FORCE_TARGET_ARCHIVE: llvm-link{{.*}} "@[[DEVICELISTBC]]"{{.*}} "-o" "[[DEVICEARCHIVELINKED:.+\.bc]]" "--suppress-warnings"
+// CHECK_FORCE_TARGET_ARCHIVE: llvm-foreach{{.*}} {{.*}}ocloc{{.*}}
+
 /// -fsycl-force-target is only valid with -fsycl-target with single targets
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen,spir64_x86_64 \
 // RUN:          -fsycl-force-target=spir64 %s -### 2>&1 \


### PR DESCRIPTION
When using performing offloading with archives, an additional clang-offload-deps step is taken that determines the device dependencies during the link.  When using -fsycl-force-target, we need to be sure that the target in which the dependency information is associated with matches so the proper device objects are referenced and pulled out.