### PR TITLE
[SYCL] Relax checks in host_acc_opt LIT test

### DIFF
--- a/sycl/test/basic_tests/accessor/host_acc_opt.cpp
+++ b/sycl/test/basic_tests/accessor/host_acc_opt.cpp
@@ -7,14 +7,12 @@
 #include <sycl/sycl.hpp>
 
 // CHECK: define {{.*}}foo{{.*}} {
-// CHECK-NOT: call{{.*}}getOffset
-// CHECK-NOT: invoke{{.*}}getOffset
-// CHECK-NOT: call{{.*}}getMemoryRange
-// CHECK-NOT: invoke{{.*}}getMemoryRange
+// CHECK-NOT: call
+// CHECK-NOT: invoke
 // CHECK: }
 void foo(sycl::accessor<int, 1, sycl::access::mode::read_write,
                         sycl::target::host_buffer> &Acc,
          int *Src) {
   for (size_t I = 0; I < 64; ++I)
-    Acc[I] = Src[I];
+    Acc[I] += Src[I];
 }

--- a/sycl/test/basic_tests/accessor/host_acc_opt.cpp
+++ b/sycl/test/basic_tests/accessor/host_acc_opt.cpp
@@ -1,20 +1,16 @@
-// RUN: %clangxx -O2 -std=c++17 -I %sycl_include/sycl -I %sycl_include -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clangxx -O2 -isystem %sycl_include/sycl -isystem %sycl_include -S -emit-llvm %s -o - | FileCheck %s
 
 // The test verifies that the accessor::operator[] implementation is
 // good enough for compiler to optimize away calls to getOffset and
-// getMemoryRange and vectorize the loop.
+// getMemoryRange.
 
 #include <sycl/sycl.hpp>
 
 // CHECK: define {{.*}}foo{{.*}} {
-// CHECK-NOT: call
-// CHECK-NOT: invoke
-// CHECK: load <4 x i32>
-// CHECK-NOT: call
-// CHECK-NOT: invoke
-// CHECK: store <4 x i32>
-// CHECK-NOT: call
-// CHECK-NOT: invoke
+// CHECK-NOT: call{{.*}}getOffset
+// CHECK-NOT: invoke{{.*}}getOffset
+// CHECK-NOT: call{{.*}}getMemoryRange
+// CHECK-NOT: invoke{{.*}}getMemoryRange
 // CHECK: }
 void foo(sycl::accessor<int, 1, sycl::access::mode::read_write,
                         sycl::target::host_buffer> &Acc,


### PR DESCRIPTION
It turns out to be non-robust to expect compiler to vectorize the code. The code can be optmized in different ways. So relax the checks to verify that there are no calls to accessor helper methods (getOffset and getMemoryRange) in the loop. Absence of these calls should be enough to optimize the code.