### PR TITLE
[SYCL] Match explicit offload arch for AMD and NVIDIA

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5806,7 +5806,15 @@ class OffloadingActionBuilder final {
               }
               SYCLTargetInfoList.emplace_back(*TCIt, nullptr);
             } else {
-              SYCLTargetInfoList.emplace_back(*TCIt, GpuArchList[I].second);
+              const char *OffloadArch = nullptr;
+              for (auto &A : GpuArchList) {
+                if (TT == A.first) {
+                  OffloadArch = A.second;
+                  break;
+                }
+              }
+              assert(OffloadArch && "Failed to find matching arch.");
+              SYCLTargetInfoList.emplace_back(*TCIt, OffloadArch);
               ++I;
             }
           }

--- a/clang/test/Driver/sycl.c
+++ b/clang/test/Driver/sycl.c
@@ -144,3 +144,8 @@
 // RUN: %clang_cl -### -fsycl -- %s 2>&1 | FileCheck %s --check-prefix=DEFAULT_STD
 
 // DEFAULT_STD: "-sycl-std=2020"
+
+/// Verify correct match of offload arch with multiple sycl targets
+// RUN: %clang -fsycl -fsycl-targets=nvptx64-nvidia-cuda,amdgcn-amd-amdhsa -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx908 -Xsycl-target-backend=nvptx64-nvidia-cuda --offload-arch=sm_86 -c -ccc-print-phases %s 2>&1 | FileCheck %s --check-prefix=MULTIPLE_TARGETS
+// MULTIPLE_TARGETS: offload, "device-sycl (nvptx64-nvidia-cuda:sm_86)"
+// MULTIPLE_TARGETS: offload, "device-sycl (amdgcn-amd-amdhsa:gfx908)"


### PR DESCRIPTION
Fixes: https://github.com/intel/llvm/issues/6792

When specifying multiple SYCL targets make sure that we correctly match offload arch with the target. Normally this is fixed up later on (when calling `SYCLActionBuilder::withBoundArchForToolChain`), but in case of creating libraries we might end up in a broken state, as the code relies on ordering of the gpu map.
See the phases of the following clang invocation:
`clang++ -fsycl -fsycl-targets=nvptx64-nvidia-cuda,amdgcn-amd-amdhsa -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx908 -Xsycl-target-backend=nvptx64-nvidia-cuda --offload-arch=sm_86 -c in.cpp -o out.o -ccc-print-phases`

```
         +- 0: input, "/dash_c_multiple_targets.cpp", c++, (device-sycl, gfx908)
      +- 1: preprocessor, {0}, c++-cpp-output, (device-sycl, gfx908)
   +- 2: compiler, {1}, ir, (device-sycl, gfx908)
+- 3: offload, "device-sycl (nvptx64-nvidia-cuda:gfx908)" {2}, ir
|        +- 4: input, "/dash_c_multiple_targets.cpp", c++, (device-sycl, sm_86)
|     +- 5: preprocessor, {4}, c++-cpp-output, (device-sycl, sm_86)
|  +- 6: compiler, {5}, ir, (device-sycl, sm_86)
|- 7: offload, "device-sycl (amdgcn-amd-amdhsa:sm_86)" {6}, ir
|                 +- 8: input, "/dash_c_multiple_targets.cpp", c++, (host-sycl)
|              +- 9: append-footer, {8}, c++, (host-sycl)
|           +- 10: preprocessor, {9}, c++-cpp-output, (host-sycl)
|        +- 11: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (amdgcn-amd-amdhsa:sm_86)" {6}, c++-cpp-output
|     +- 12: compiler, {11}, ir, (host-sycl)
|  +- 13: backend, {12}, assembler, (host-sycl)
|- 14: assembler, {13}, object, (host-sycl)
15: clang-offload-bundler, {3, 7, 14}, object, (host-sycl)
```
where we end up in mismatched offload arch.