### PR TITLE
[SYCL][NFC] Remove end iterator dereference in unit tests

### DIFF
--- a/sycl/unittests/helpers/PiImage.hpp
+++ b/sycl/unittests/helpers/PiImage.hpp
@@ -129,13 +129,20 @@ public:
       updateEntries();
     }
 
+    if (MEntries.empty())
+      return nullptr;
+
     return &*MEntries.begin();
   }
   typename T::NativeType *end() {
     if (MEntriesNeedUpdate) {
       updateEntries();
     }
-    return &*MEntries.end();
+
+    if (MEntries.empty())
+      return nullptr;
+
+    return &*MEntries.rbegin() + 1;
   }
 
 private:

--- a/sycl/unittests/helpers/PiImage.hpp
+++ b/sycl/unittests/helpers/PiImage.hpp
@@ -183,7 +183,7 @@ public:
   _pi_device_binary_property_set_struct *end() {
     if (MProperties.empty())
       return nullptr;
-    return &*MProperties.end();
+    return &*MProperties.rbegin() + 1;
   }
 
 private:


### PR DESCRIPTION
Dereferencing vector::end() is UB and leads to errors in debug Windows builds.