### PR TITLE
[SYCL-MLIR] Add main() to `single_task.cpp` lit test

### DIFF
--- a/polygeist/tools/cgeist/Test/CMakeLists.txt
+++ b/polygeist/tools/cgeist/Test/CMakeLists.txt
@@ -10,10 +10,12 @@ configure_lit_site_cfg(
 
 list(APPEND MLIR_CLANG_TEST_DEPS
   llvm-config 
+  llvm-dis
   FileCheck count not
   cgeist
   split-file
   clang
+  opt
   )
 
 add_lit_testsuite(check-cgeist "Running the clang-to-mlir regression tests"

--- a/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
@@ -1,32 +1,58 @@
 // clang-format off
-// RUN: clang++ -fsycl -fsycl-device-only -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
+
+// TODO: Investigate and remove all "Warning"s.
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.out 2>&1 | FileCheck %s --implicit-check-not="{{warning|error|Error}}:"
+// RUN: env SYCL_DEVICE_FILTER=host %t.out | FileCheck %s --check-prefix=HOST
+
+// RUN: clang++ -fsycl -fsycl-device-only -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc 2>/dev/null
+
 // Test that the LLVMIR generated is verifiable.
 // RUN: opt -verify -disable-output < %t.bc
+
 // Verify that LLVMIR generated is translatable to SPIRV.
 // RUN: llvm-spirv %t.bc
+
 // RUN: llvm-dis %t.bc
-// RUN: cat %t.ll | FileCheck %s
-// XFAIL: *
+// RUN: cat %t.ll | FileCheck %s --check-prefix=LLVM
 
 // Test that the kernel named `kernel_single_task` is generated with the correct signature.
-// CHECK: define weak_odr spir_kernel void {{.*}}kernel_single_task(i32 addrspace(1)* {{.*}}, [[RANGE_TY:%"class.sycl::_V1::range.1"]]* byval([[RANGE_TY]]) {{.*}}, [[RANGE_TY]]* byval([[RANGE_TY]]) {{.*}}, [[ID_TY:%"class.sycl::_V1::id.1"]]* byval([[ID_TY]]) {{.*}})
+// LLVM: define weak_odr spir_kernel void {{.*}}kernel_single_task(
+// LLVM-SAME:  i32 addrspace(1)* {{.*}}, [[RANGE_TY:%"class.sycl::_V1::range.1"]]* byval([[RANGE_TY]]) {{.*}}, [[RANGE_TY]]* byval([[RANGE_TY]]) {{.*}}, [[ID_TY:%"class.sycl::_V1::id.1"]]* byval([[ID_TY]]) {{.*}})
 
 // Test that all referenced sycl header functions are generated.
-// CHECK-NOT: declare {{.*}} spir_func
+// LLVM-NOT: declare {{.*}} spir_func
+
+// HOST: Using SYCL host device
+// HOST-NEXT: A[0]=2
 
 #include <sycl/sycl.hpp>
 
-void host_single_task() {
+void host_single_task(std::array<int, 1> &A) {
   auto q = sycl::queue{};
+  sycl::device d = q.get_device();
+  std::cout << "Using " << d.get_info<sycl::info::device::name>() << "\n";
+
   auto range = sycl::range<1>{1};
 
   {
-    auto buf = sycl::buffer<int, 1>{nullptr, range};
+    auto buf = sycl::buffer<int, 1>{A.data(), range};
     q.submit([&](sycl::handler &cgh) {
       auto A = buf.get_access<sycl::access::mode::write>(cgh);
       cgh.single_task<class kernel_single_task>([=]() {
-        A[0] = 42;
+#ifdef __SYCL_DEVICE_ONLY__
+        A[0] = 1;
+#else
+        A[0] = 2;
+#endif
       });
     });
   }
+}
+
+int main() {
+  std::array<int, 1> A = {0};
+  A[0] = 0;
+  host_single_task(A);
+
+  std::cout << "A[0]=" << A[0] << "\n";
 }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
@@ -3,6 +3,9 @@
 // TODO: Investigate and remove all "Warning"s.
 // RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.out 2>&1 | FileCheck %s --implicit-check-not="{{warning|error|Error}}:"
 // RUN: env SYCL_DEVICE_FILTER=host %t.out | FileCheck %s --check-prefix=HOST
+// TODO: Add device run:
+// env SYCL_DEVICE_FILTER=cpu %t.out | FileCheck %s --check-prefix=DEVICE
+// REQUIRES: linux
 
 // RUN: clang++ -fsycl -fsycl-device-only -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc 2>/dev/null
 
@@ -24,6 +27,9 @@
 
 // HOST: Using SYCL host device
 // HOST-NEXT: A[0]=2
+
+// DEVICE: Using {{.*}} CPU
+// DEVICE-NEXT: A[0]=1
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/lit.cfg
+++ b/polygeist/tools/cgeist/Test/lit.cfg
@@ -3,6 +3,7 @@
 # Configuration file for the 'lit' test runner.
 
 import os
+import platform
 import lit.formats
 
 from lit.llvm import llvm_config
@@ -63,6 +64,12 @@ llvm_config.add_tool_substitutions(tools, tool_dirs)
 import subprocess
 
 resource_dir = subprocess.check_output([config.llvm_tools_dir + "/clang", "-print-resource-dir"]).decode('utf-8').strip()
+
+if platform.system() == "Linux":
+    config.available_features.add('linux')
+    llvm_config.with_system_environment('LD_LIBRARY_PATH')
+    llvm_config.with_environment('LD_LIBRARY_PATH', config.sycl_libs_dir, append_path=True)
+config.substitutions.append(('%sycl_libs_dir',  config.sycl_libs_dir))
 
 config.substitutions.append(('%stdinclude', '-resource-dir=' + resource_dir + " -I " + config.test_source_root + "/polybench/utilities"))
 config.substitutions.append(('%resourcedir', '-resource-dir=' + resource_dir))

--- a/polygeist/tools/cgeist/Test/lit.site.cfg.in
+++ b/polygeist/tools/cgeist/Test/lit.site.cfg.in
@@ -8,6 +8,7 @@ config.lit_tools_dir = "@LLVM_LIT_TOOLS_DIR@"
 config.mlir_clang_obj_root = "@MLIR_CLANG_BINARY_DIR@"
 config.target_triple = "@TARGET_TRIPLE@"
 config.llvm_obj_root = path(r"@LLVM_BINARY_DIR@")
+config.sycl_libs_dir = lit_config.params.get('SYCL_LIBS_DIR', "@LLVM_LIBS_DIR@")
 
 # Support substitution of the tools and build_mode with user parameters.
 # This is used when we can't determine the tool dir at configuration time.


### PR DESCRIPTION
Added a `main` function to first select a device, then invoke `host_single_task`, which contains the kernel `kernel_single_task`.
Added a run line to ensure the whole compilation, from source code to executable, is successful.
Added a run line to execute the executable on the host. 

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>