### PR TITLE
[SYCL][CUDA][HIP] Support zero range SYCL kernels for hip and cuda backends

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -2608,6 +2608,10 @@ pi_result cuda_piEnqueueKernelLaunch(
   assert(work_dim > 0);
   assert(work_dim < 4);
 
+  if (*global_work_size == 0) {
+    return PI_SUCCESS;
+  }
+
   // Set the number of threads per block to the number of threads per warp
   // by default unless user has provided a better number
   int threadsPerBlock[3] = {32, 1, 1};

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -2489,6 +2489,10 @@ pi_result hip_piEnqueueKernelLaunch(
   assert(work_dim > 0);
   assert(work_dim < 4);
 
+  if (*global_work_size == 0) {
+    return PI_SUCCESS;
+  }
+
   // Set the number of threads per block to the number of threads per warp
   // by default unless user has provided a better number
   int threadsPerBlock[3] = {32, 1, 1};

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1710,7 +1710,7 @@ static void adjustNDRangePerKernel(NDRDescT &NDR, RT::PiKernel Kernel,
   if (NDR.GlobalSize[0] != 0)
     return; // GlobalSize is set - no need to adjust
   // check the prerequisites:
-  assert(NDR.NumWorkGroups[0] != 0 && NDR.LocalSize[0] == 0);
+  assert(NDR.LocalSize[0] == 0);
   // TODO might be good to cache this info together with the kernel info to
   // avoid get_kernel_work_group_info on every kernel run
   range<3> WGSize = get_kernel_device_specific_info<

--- a/sycl/test/basic_tests/range_zero_size.cpp
+++ b/sycl/test/basic_tests/range_zero_size.cpp
@@ -13,5 +13,5 @@ using namespace sycl;
 
 int main() {
   queue q;
-  q.submit([&](handler cgh) { cgh.parallel_for(range<1>(0), [=](id<1> i) {}); });
+  q.submit([&](handler& cgh) { cgh.parallel_for(range<1>(0), [=](id<1> i) {}); });
 }

--- a/sycl/test/basic_tests/range_zero_size.cpp
+++ b/sycl/test/basic_tests/range_zero_size.cpp
@@ -1,4 +1,4 @@
-// REQUIRES:cuda || hip_amd
+// REQUIRES:cuda || hip_amd || opencl || host
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 //==--------------- range_zero_size.cpp - SYCL range test ----------------------==//
 //

--- a/sycl/test/basic_tests/range_zero_size.cpp
+++ b/sycl/test/basic_tests/range_zero_size.cpp
@@ -1,6 +1,6 @@
 // REQUIRES:cuda || hip_amd || opencl || host
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-//==--------------- range_zero_size.cpp - SYCL range test ----------------------==//
+//==--------------- range_zero_size.cpp - SYCL range test ------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -13,5 +13,6 @@ using namespace sycl;
 
 int main() {
   queue q;
-  q.submit([&](handler& cgh) { cgh.parallel_for(range<1>(0), [=](id<1> i) {}); });
+  q.submit(
+      [&](handler &cgh) { cgh.parallel_for(range<1>(0), [=](id<1> i) {}); });
 }

--- a/sycl/test/basic_tests/range_zero_size.cpp
+++ b/sycl/test/basic_tests/range_zero_size.cpp
@@ -1,0 +1,17 @@
+// REQUIRES:cuda || hip_amd
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+//==--------------- range_zero_size.cpp - SYCL range test ----------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <sycl/sycl.hpp>
+using namespace sycl;
+
+int main() {
+  queue q;
+  q.submit([&](handler cgh) { cgh.parallel_for(range<1>(0), [=](id<1> i) {}); });
+}


### PR DESCRIPTION
Fixes the issue [6963](https://github.com/intel/llvm/issues/6963) to allow kernels with zero size range.
- Lit test added.