### PR TITLE
[SYCL][CUDA][DOC] State how to pass ptxas options

### DIFF
--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -644,11 +644,15 @@ clang++ -fsycl -fsycl-targets=amdgcn-amd-amdhsa \
 The target architecture may also be specified for the CUDA backend, with 
 `-Xsycl-target-backend --cuda-gpu-arch=<arch>`. Specifying the architecture is 
 necessary if an application aims to use newer hardware features, such as
-native atomic operations or tensor core operations. 
+native atomic operations or tensor core operations.
+Moreover, it is possible to pass specific options to CUDA `ptxas` (such as
+`--maxrregcount=<n>` for limiting the register usage or `--verbose` for
+printing generation statitistics) using the `-Xcuda-ptxas` flag.
 
 ```bash
 clang++ -fsycl -fsycl-targets=nvptx64-nvidia-cuda \
   simple-sycl-app.cpp -o simple-sycl-app-cuda.exe \
+  -Xcuda-ptxas --maxrregcount=128 -Xcuda-ptxas --verbose \
   -Xsycl-target-backend --cuda-gpu-arch=sm_80
 ```
 


### PR DESCRIPTION
This patch documents the utilization of `-Xcuda-ptxas` in SYCL.

Refer to https://github.com/intel/llvm/issues/6821 and https://github.com/intel/llvm/issues/6942.