### PR TITLE
[SYCL][NFC] Remove unused parameter from multi_ptr operator

### DIFF
--- a/sycl/include/sycl/multi_ptr.hpp
+++ b/sycl/include/sycl/multi_ptr.hpp
@@ -1472,7 +1472,7 @@ bool operator<=(const multi_ptr<ElementType, Space, DecorateAddress> &lhs,
 template <typename ElementType, access::address_space Space,
           access::decorated DecorateAddress>
 bool operator<=(std::nullptr_t,
-                const multi_ptr<ElementType, Space, DecorateAddress> &rhs) {
+                const multi_ptr<ElementType, Space, DecorateAddress> &) {
   return true;
 }
 


### PR DESCRIPTION
https://github.com/intel/llvm/pull/6893 added support for SYCL 2020 multi_ptr as well as a fix to one of the operators. The fixed operator did however retain an unused parameter. This commit removes this unused parameter.