### PR TITLE
[SYCL] Return back c++17 option to the test

### DIFF
--- a/sycl/test/basic_tests/accessor/host_acc_opt.cpp
+++ b/sycl/test/basic_tests/accessor/host_acc_opt.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -O2 -isystem %sycl_include/sycl -isystem %sycl_include -S -emit-llvm %s -o - | FileCheck %s
+// RUN: %clangxx -std=c++17 -O2 -isystem %sycl_include/sycl -isystem %sycl_include -S -emit-llvm %s -o - | FileCheck %s
 
 // The test verifies that the accessor::operator[] implementation is
 // good enough for compiler to optimize away calls to getOffset and


### PR DESCRIPTION
It seems that without -fsycl the default version of c++ is less than c++17 which is required for SYCL headers.