### PR TITLE
[SYCL] Add diagnostic for annotated_pointers and annotated_args

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1302,11 +1302,11 @@ def SYCLType: InheritableAttr {
                            ["accessor", "local_accessor", "spec_constant",
                             "specialization_id", "kernel_handler", "buffer_location",
                             "no_alias", "accessor_property_list", "group",
-                            "private_memory", "aspect"],
+                            "private_memory", "aspect", "annotated_ptr", "annotated_arg"],
                            ["accessor", "local_accessor", "spec_constant",
                             "specialization_id", "kernel_handler", "buffer_location",
                             "no_alias", "accessor_property_list", "group",
-                            "private_memory", "aspect"]>];
+                            "private_memory", "aspect", "annotated_ptr", "annotated_arg"]>];
   // Only used internally by SYCL implementation
   let Documentation = [InternalOnly];
 }

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11819,6 +11819,8 @@ def err_sycl_num_kernel_wrong_reqd_wg_size : Error<
   "%0 attribute must evenly divide the work-group size for the %1 attribute">;
 def err_sycl_invalid_aspect_argument : Error<
   "%0 attribute argument is invalid; argument must be device aspect of type sycl::aspect">;
+def err_sycl_invalid_usage_annotated_ptr_arg : Error<
+  "Kernel argument of type %0 cannot be nested">;
 
 def warn_sycl_pass_by_value_deprecated 
     : Warning<"passing kernel functions by value is deprecated in SYCL 2020">,

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -10390,8 +10390,8 @@ def warn_opencl_generic_address_space_arg : Warning<
   "passing non-generic address space pointer to %0"
   " may cause dynamic conversion affecting performance">,
   InGroup<Conversion>, DefaultIgnore;
-def err_bad_union_kernel_param_members : Error<
-  "%0 cannot be used inside a union kernel parameter">;
+def err_bad_kernel_param_data_members : Error<
+  "%0 cannot be a data member of a %select{union|struct}1 kernel parameter">;
 
 // OpenCL v2.0 s6.13.6 -- Builtin Pipe Functions
 def err_opencl_builtin_pipe_first_arg : Error<
@@ -11819,8 +11819,6 @@ def err_sycl_num_kernel_wrong_reqd_wg_size : Error<
   "%0 attribute must evenly divide the work-group size for the %1 attribute">;
 def err_sycl_invalid_aspect_argument : Error<
   "%0 attribute argument is invalid; argument must be device aspect of type sycl::aspect">;
-def err_sycl_invalid_usage_annotated_ptr_arg : Error<
-  "Kernel argument of type %0 cannot be nested">;
 
 def warn_sycl_pass_by_value_deprecated 
     : Warning<"passing kernel functions by value is deprecated in SYCL 2020">,

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -1528,11 +1528,11 @@ class SyclKernelFieldChecker : public SyclKernelFieldHandler {
   DiagnosticsEngine &Diag;
   bool IsSIMD = false;
   // Keeps track of whether we are currently handling fields inside a struct.
-  // Fields of kernel functor or direct kernel captures will have a depth 0
+  // Fields of kernel functor or direct kernel captures will have a depth 0.
   int StructFieldDepth = 0;
-  // Initialize with -1 to treat fields of kernel functor base class with depth
-  // 0. Visitor method enterStruct increments this to 0 when the base class is
-  // entered.
+  // Initialize with -1 so that fields of a base class of the kernel functor
+  // has depth 0. Visitor method enterStruct increments this to 0 when the base
+  // class is entered.
   int StructBaseDepth = -1;
 
   // Check whether the object should be disallowed from being copied to kernel.

--- a/clang/test/SemaSYCL/Inputs/sycl.hpp
+++ b/clang/test/SemaSYCL/Inputs/sycl.hpp
@@ -403,6 +403,23 @@ public:
 private:
   T DefaultValue;
 };
+
+template <typename T, typename... Props>
+class __attribute__((sycl_special_class)) __SYCL_TYPE(annotated_arg) annotated_arg {
+  T obj;
+  #ifdef __SYCL_DEVICE_ONLY__
+    void __init(T _obj) {}
+  #endif
+};
+
+template <typename T, typename... Props>
+class __attribute__((sycl_special_class)) __SYCL_TYPE(annotated_ptr) annotated_ptr {
+  T* obj;
+  #ifdef __SYCL_DEVICE_ONLY__
+    void __init(T* _obj) {}
+  #endif
+};
+
 } // namespace experimental
 } // namespace oneapi
 } // namespace ext

--- a/clang/test/SemaSYCL/annotated_arg_or_ptr.cpp
+++ b/clang/test/SemaSYCL/annotated_arg_or_ptr.cpp
@@ -1,0 +1,51 @@
+// RUN: %clang_cc1 -fsyntax-only -fsycl-is-device -internal-isystem %S/Inputs -verify %s
+
+#include "sycl.hpp"
+
+sycl::queue myQueue;
+
+
+struct MockProperty {};
+
+struct WrappedAnnotatedTypes {
+  // expected-error@+1 2{{Kernel argument of type 'sycl::ext::oneapi::experimental::annotated_arg<int, MockProperty>' cannot be nested}}
+  sycl::ext::oneapi::experimental::annotated_arg<int, MockProperty> AA;
+  // expected-error@+1 2{{Kernel argument of type 'sycl::ext::oneapi::experimental::annotated_ptr<int, MockProperty>' cannot be nested}}
+  sycl::ext::oneapi::experimental::annotated_ptr<int, MockProperty> AP;
+  sycl::accessor<int, 1, sycl::access::mode::read_write> Acc;
+};
+
+struct KernelBase {
+  sycl::ext::oneapi::experimental::annotated_arg<int, MockProperty> BaseAA;
+  sycl::ext::oneapi::experimental::annotated_ptr<int, MockProperty> BaseAP;
+  WrappedAnnotatedTypes NestedInBase;
+};
+
+struct KernelFunctor : KernelBase  {
+  sycl::ext::oneapi::experimental::annotated_arg<int, MockProperty> AA;
+  sycl::ext::oneapi::experimental::annotated_ptr<int, MockProperty> AP;
+  void operator()() const {}
+};
+
+int main() {
+  sycl::ext::oneapi::experimental::annotated_arg<int, MockProperty> AA;
+  sycl::ext::oneapi::experimental::annotated_ptr<int, MockProperty> AP;
+  WrappedAnnotatedTypes Obj;
+  myQueue.submit([&](sycl::handler &h) {
+    // expected-note@+1 {{in instantiation of}}
+    h.single_task<class kernel_half>(
+        [=]() {
+          (void)AA;  // OK
+	  (void)AP;  // OK
+	  (void)Obj; // Error
+        });
+  });
+
+  myQueue.submit([&](sycl::handler &h) {
+    KernelFunctor f;
+    // expected-note@+1 {{in instantiation of}}
+    h.single_task(f);
+  });
+
+}
+

--- a/clang/test/SemaSYCL/annotated_arg_or_ptr.cpp
+++ b/clang/test/SemaSYCL/annotated_arg_or_ptr.cpp
@@ -9,9 +9,9 @@ sycl::queue myQueue;
 struct MockProperty {};
 
 struct WrappedAnnotatedTypes {
-  // expected-error@+1 3{{Kernel argument of type 'sycl::ext::oneapi::experimental::annotated_arg<int, MockProperty>' cannot be nested}}
+  // expected-error@+1 3{{'sycl::ext::oneapi::experimental::annotated_arg<int, MockProperty>' cannot be a data member of a struct kernel parameter}}
   sycl::ext::oneapi::experimental::annotated_arg<int, MockProperty> AA;
-  // expected-error@+1 3{{Kernel argument of type 'sycl::ext::oneapi::experimental::annotated_ptr<int, MockProperty>' cannot be nested}}
+  // expected-error@+1 3{{'sycl::ext::oneapi::experimental::annotated_ptr<int, MockProperty>' cannot be a data member of a struct kernel parameter}}
   sycl::ext::oneapi::experimental::annotated_ptr<int, MockProperty> AP;
   sycl::accessor<int, 1, sycl::access::mode::read_write> Acc;
 };

--- a/clang/test/SemaSYCL/annotated_arg_or_ptr.cpp
+++ b/clang/test/SemaSYCL/annotated_arg_or_ptr.cpp
@@ -4,26 +4,30 @@
 
 sycl::queue myQueue;
 
-
 struct MockProperty {};
 
 struct WrappedAnnotatedTypes {
-  // expected-error@+1 2{{Kernel argument of type 'sycl::ext::oneapi::experimental::annotated_arg<int, MockProperty>' cannot be nested}}
+  // expected-error@+1 3{{Kernel argument of type 'sycl::ext::oneapi::experimental::annotated_arg<int, MockProperty>' cannot be nested}}
   sycl::ext::oneapi::experimental::annotated_arg<int, MockProperty> AA;
-  // expected-error@+1 2{{Kernel argument of type 'sycl::ext::oneapi::experimental::annotated_ptr<int, MockProperty>' cannot be nested}}
+  // expected-error@+1 3{{Kernel argument of type 'sycl::ext::oneapi::experimental::annotated_ptr<int, MockProperty>' cannot be nested}}
   sycl::ext::oneapi::experimental::annotated_ptr<int, MockProperty> AP;
   sycl::accessor<int, 1, sycl::access::mode::read_write> Acc;
 };
 
 struct KernelBase {
-  sycl::ext::oneapi::experimental::annotated_arg<int, MockProperty> BaseAA;
-  sycl::ext::oneapi::experimental::annotated_ptr<int, MockProperty> BaseAP;
-  WrappedAnnotatedTypes NestedInBase;
+  sycl::ext::oneapi::experimental::annotated_arg<int, MockProperty> BaseAA; // OK
+  sycl::ext::oneapi::experimental::annotated_ptr<int, MockProperty> BaseAP; // OK
+  WrappedAnnotatedTypes NestedInBase; // Error
 };
 
 struct KernelFunctor : KernelBase  {
-  sycl::ext::oneapi::experimental::annotated_arg<int, MockProperty> AA;
-  sycl::ext::oneapi::experimental::annotated_ptr<int, MockProperty> AP;
+  sycl::ext::oneapi::experimental::annotated_arg<int, MockProperty> AA; // OK
+  sycl::ext::oneapi::experimental::annotated_ptr<int, MockProperty> AP; // OK
+  void operator()() const {}
+};
+
+struct KernelFunctor2  {
+  WrappedAnnotatedTypes NestedInField; // Error
   void operator()() const {}
 };
 
@@ -47,5 +51,10 @@ int main() {
     h.single_task(f);
   });
 
+  myQueue.submit([&](sycl::handler &h) {
+    KernelFunctor2 f2;
+    // expected-note@+1 {{in instantiation of}}
+    h.single_task(f2);
+  });
 }
 

--- a/clang/test/SemaSYCL/annotated_arg_or_ptr.cpp
+++ b/clang/test/SemaSYCL/annotated_arg_or_ptr.cpp
@@ -1,5 +1,7 @@
 // RUN: %clang_cc1 -fsyntax-only -fsycl-is-device -internal-isystem %S/Inputs -verify %s
 
+// Test diagnostic for nested annotated_arg and annotated_ptr type.
+
 #include "sycl.hpp"
 
 sycl::queue myQueue;

--- a/clang/test/SemaSYCL/union-kernel-param-neg.cpp
+++ b/clang/test/SemaSYCL/union-kernel-param-neg.cpp
@@ -8,7 +8,7 @@ using namespace sycl;
 
 union union_with_sampler {
   sycl::sampler smpl;
-  // expected-error@-1 {{'sycl::sampler' cannot be used inside a union kernel parameter}}
+  // expected-error@-1 {{'sycl::sampler' cannot be a data member of a union kernel parameter}}
 };
 
 template <typename name, typename Func>
@@ -23,7 +23,7 @@ int main() {
 
   union union_with_accessor {
     Accessor member_acc[1];
-    // expected-error@-1 {{'Accessor' (aka 'accessor<int, 1, access::mode::read_write, access::target::global_buffer>') cannot be used inside a union kernel parameter}}
+    // expected-error@-1 {{'Accessor' (aka 'accessor<int, 1, access::mode::read_write, access::target::global_buffer>') cannot be a data member of a union kernel parameter}}
   } union_acc;
 
   union_with_sampler Sampler;


### PR DESCRIPTION
Types cannot be nested.

Signed-off-by: Elizabeth Andrews <elizabeth.andrews@intel.com>