### PR TITLE
[SYCL-MLIR] Add build target `deploy-sycl-toolchain`

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -101,7 +101,7 @@ jobs:
           --cmake-opt="-DSYCL_PI_TESTS=OFF"
     - name: Compile
       id: build
-      run: cmake --build $GITHUB_WORKSPACE/build
+      run: cmake --build $GITHUB_WORKSPACE/build --target deploy-sycl-toolchain
     # TODO allow to optionally disable in-tree checks
     - name: check-mlir-sycl
       if: ${{ always() && !cancelled() && steps.build.outcome == 'success' }}


### PR DESCRIPTION
Build target `deploy-sycl-toolchain` is needed to build `libsycl-devicelib-host.a`.
`libsycl-devicelib-host.a` is needed to compile and link sycl source.

```
/usr/bin/ld: cannot find -lsycl-devicelib-host 
clang-16: error: linker command failed with exit code 1 (use -v to see invocation) 
```

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>