### PR TITLE
[LIBCLC] Fix mangling in atomic functions

### DIFF
--- a/libclc/ptx-nvidiacl/libspirv/atomic/atomic_add.cl
+++ b/libclc/ptx-nvidiacl/libspirv/atomic/atomic_add.cl
@@ -20,7 +20,7 @@ __CLC_NVVM_ATOMIC(float, f, float, f, add, _Z21__spirv_AtomicFAddEXT)
 
 #define __CLC_NVVM_ATOMIC_ADD_DOUBLE_IMPL(ADDR_SPACE, ADDR_SPACE_MANGLED,                                                                                     \
                                           ADDR_SPACE_NV, SUBSTITUTION1,                                                                                       \
-                                          SUBSTITUTION2)                                                                                                      \
+                                          SUBSTITUTION2, SUBSTITUTION3)                                                                                       \
   long                                                                                                                                                        \
       _Z18__spirv_AtomicLoadP##ADDR_SPACE_MANGLED##KlN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagE(                                                      \
           volatile ADDR_SPACE const long *, enum Scope,                                                                                                       \
@@ -30,7 +30,7 @@ __CLC_NVVM_ATOMIC(float, f, float, f, add, _Z21__spirv_AtomicFAddEXT)
           volatile ADDR_SPACE long *, enum Scope, enum MemorySemanticsMask,                                                                                   \
           enum MemorySemanticsMask, long, long);                                                                                                              \
   __attribute__((always_inline)) _CLC_DECL double                                                                                                             \
-      _Z21__spirv_AtomicFAddEXT##P##ADDR_SPACE_MANGLED##d##N5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagE##d(                                             \
+      _Z21__spirv_AtomicFAddEXT##P##ADDR_SPACE_MANGLED##d##N5__spv5Scope4FlagENS##SUBSTITUTION3##_19MemorySemanticsMask4FlagE##d(                             \
           volatile ADDR_SPACE double *pointer, enum Scope scope,                                                                                              \
           enum MemorySemanticsMask semantics, double value) {                                                                                                 \
     /* Semantics mask may include memory order, storage class and other info                                                                                  \
@@ -105,9 +105,9 @@ Memory order is stored in the lowest 5 bits */                                  
     }                                                                                                                                                         \
   }
 
-__CLC_NVVM_ATOMIC_ADD_DOUBLE_IMPL(, , _gen_, 0, 4)
-__CLC_NVVM_ATOMIC_ADD_DOUBLE_IMPL(__global, U3AS1, _global_, 1, 5)
-__CLC_NVVM_ATOMIC_ADD_DOUBLE_IMPL(__local, U3AS3, _shared_, 1, 5)
+__CLC_NVVM_ATOMIC_ADD_DOUBLE_IMPL(, , _gen_, 0, 4, 0)
+__CLC_NVVM_ATOMIC_ADD_DOUBLE_IMPL(__global, U3AS1, _global_, 1, 5, 1)
+__CLC_NVVM_ATOMIC_ADD_DOUBLE_IMPL(__local, U3AS3, _shared_, 1, 5, 1)
 
 #endif
 

--- a/libclc/ptx-nvidiacl/libspirv/atomic/atomic_inc.cl
+++ b/libclc/ptx-nvidiacl/libspirv/atomic/atomic_inc.cl
@@ -10,8 +10,8 @@
 #include <spirv/spirv.h>
 #include <spirv/spirv_types.h>
 
-__CLC_NVVM_ATOMIC_INCDEC(unsigned int, j, Increment, 1)
-__CLC_NVVM_ATOMIC_INCDEC(unsigned long, m, Increment, 1)
+__CLC_NVVM_ATOMIC_INCDEC(unsigned int, j, IIncrement, 1)
+__CLC_NVVM_ATOMIC_INCDEC(unsigned long, m, IIncrement, 1)
 
 #undef __CLC_NVVM_ATOMIC_TYPES
 #undef __CLC_NVVM_ATOMIC


### PR DESCRIPTION
Hard coding the substitution for `AtomicFAddEXT` meant that for the case without AS specified, it was pushing the `MemorySemanticFlag` inside `Scope` namespace creating:
```cpp
__spirv_AtomicFAddEXT(double*, __spv::Scope::Flag, __spv::Scope::MemorySemanticsMask::Flag, double)
```

For the `Increment`, the number of chars for the mangled name `_Z24` was correct, but the typo in the op name was resulting in the pointer being lost, resulting in the first argument being just a value:
```cpp
__spirv_AtomicIncrementP(unsigned long AS1, __spv::Scope::Flag, __spv::Scope::MemorySemanticsMask::Flag)
```