### PR TITLE
[SYCL][NFC] Fix a C string size bug in buffer location unit test

### DIFF
--- a/sycl/unittests/buffer/BufferLocation.cpp
+++ b/sycl/unittests/buffer/BufferLocation.cpp
@@ -59,7 +59,8 @@ static pi_result redefinedDeviceGetInfo(pi_device device,
   if (param_name == PI_DEVICE_INFO_EXTENSIONS) {
     const std::string name = "cl_intel_mem_alloc_buffer_location";
     if (!param_value) {
-      *param_value_size_ret = name.size();
+      // Increase size by one for the null terminator
+      *param_value_size_ret = name.size() + 1;
     } else {
       char *dst = static_cast<char *>(param_value);
       strcpy(dst, name.data());


### PR DESCRIPTION
Increase the size returned by redefinedDeviceGetInfo by one to leave space for the null terminator.