### PR TITLE
[SYCL-MLIR]: Add AttrBuilder and use it to set LLVM IR attributes

### DIFF
--- a/polygeist/tools/cgeist/CMakeLists.txt
+++ b/polygeist/tools/cgeist/CMakeLists.txt
@@ -33,6 +33,7 @@ add_clang_executable(cgeist
   "${LLVM_SOURCE_DIR}/../clang/tools/driver/cc1gen_reproducer_main.cpp"
   Lib/pragmaHandler.cc
   Lib/AffineUtils.cc
+  Lib/Attributes.cc
   Lib/ValueCategory.cc
   Lib/utils.cc
   Lib/IfScope.cc

--- a/polygeist/tools/cgeist/Lib/Attributes.cc
+++ b/polygeist/tools/cgeist/Lib/Attributes.cc
@@ -1,0 +1,329 @@
+//===- Attributes.cc - Construct LLVMIR attributes ------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "Attributes.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "attributes"
+
+using namespace llvm;
+using namespace mlir;
+
+namespace mlirclang {
+
+//===----------------------------------------------------------------------===//
+// AttrBuilder Method Implementations
+//===----------------------------------------------------------------------===//
+
+AttrBuilder &AttrBuilder::addAttribute(llvm::Attribute::AttrKind kind) {
+  OpBuilder builder(&ctx);
+  UnitAttr unitAttr = builder.getUnitAttr();
+  constexpr StringLiteral dialect = LLVM::LLVMDialect::getDialectNamespace();
+
+  switch (kind) {
+  /// Pass structure by value.
+  case llvm::Attribute::AttrKind::ByVal: {
+    NamedAttribute namedAttr =
+        createNamedAttr(createStringAttr("byval", dialect), unitAttr);
+    addAttribute(namedAttr);
+  } break;
+  /// Function can only be moved to control-equivalent blocks.
+  case llvm::Attribute::AttrKind::Convergent: {
+    NamedAttribute namedAttr =
+        createNamedAttr(createStringAttr("convergent", dialect), unitAttr);
+    addAttribute(namedAttr);
+  } break;
+  /// Function is required to make forward progress.
+  case llvm::Attribute::AttrKind::MustProgress: {
+    NamedAttribute namedAttr =
+        createNamedAttr(createStringAttr("mustprogress", dialect), unitAttr);
+    addAttribute(namedAttr);
+  } break;
+  /// Nested function static chain.
+  case llvm::Attribute::AttrKind::Nest: {
+    NamedAttribute namedAttr =
+        createNamedAttr(createStringAttr("nest", dialect), unitAttr);
+    addAttribute(namedAttr);
+  } break;
+  /// Considered to not alias after call.
+  case llvm::Attribute::AttrKind::NoAlias: {
+    NamedAttribute namedAttr =
+        createNamedAttr(createStringAttr("noalias", dialect), unitAttr);
+    addAttribute(namedAttr);
+  } break;
+  /// Function creates no aliases of pointer.
+  case llvm::Attribute::AttrKind::NoCapture: {
+    NamedAttribute namedAttr =
+        createNamedAttr(createStringAttr("nocapture", dialect), unitAttr);
+    addAttribute(namedAttr);
+  } break;
+  /// Function does not deallocate memory.
+  case llvm::Attribute::AttrKind::NoFree: {
+    NamedAttribute namedAttr =
+        createNamedAttr(createStringAttr("nofree", dialect), unitAttr);
+    addAttribute(namedAttr);
+  } break;
+  /// Function is never inlined.
+  case llvm::Attribute::AttrKind::NoInline: {
+    NamedAttribute namedAttr =
+        createNamedAttr(createStringAttr("noinline", dialect), unitAttr);
+    addAttribute(namedAttr);
+  } break;
+  /// Pointer is known to be not null.
+  case llvm::Attribute::AttrKind::NonNull: {
+    NamedAttribute namedAttr =
+        createNamedAttr(createStringAttr("nonnull", dialect), unitAttr);
+    addAttribute(namedAttr);
+  } break;
+  /// Function does not recurse.
+  case llvm::Attribute::AttrKind::NoRecurse: {
+    NamedAttribute namedAttr =
+        createNamedAttr(createStringAttr("norecurse", dialect), unitAttr);
+    addAttribute(namedAttr);
+  } break;
+  /// Function does not return.
+  case llvm::Attribute::AttrKind::NoReturn: {
+    NamedAttribute namedAttr =
+        createNamedAttr(createStringAttr("noreturn", dialect), unitAttr);
+    addAttribute(namedAttr);
+  } break;
+  /// Parameter or return value may not contain uninitialized or poison bits.
+  case llvm::Attribute::AttrKind::NoUndef: {
+    NamedAttribute namedAttr =
+        createNamedAttr(createStringAttr("noundef", dialect), unitAttr);
+    addAttribute(namedAttr);
+  } break;
+  /// Function doesn't unwind stack.
+  case llvm::Attribute::AttrKind::NoUnwind: {
+    NamedAttribute namedAttr =
+        createNamedAttr(createStringAttr("nounwind", dialect), unitAttr);
+    addAttribute(namedAttr);
+  } break;
+  /// Function does not access memory.
+  case llvm::Attribute::AttrKind::ReadNone: {
+    NamedAttribute namedAttr =
+        createNamedAttr(createStringAttr("readnone", dialect), unitAttr);
+    addAttribute(namedAttr);
+  } break;
+  /// Function only reads from memory.
+  case llvm::Attribute::AttrKind::ReadOnly: {
+    NamedAttribute namedAttr =
+        createNamedAttr(createStringAttr("readonly", dialect), unitAttr);
+    addAttribute(namedAttr);
+  } break;
+  /// Hidden pointer to structure to return.
+  case llvm::Attribute::AttrKind::StructRet: {
+    NamedAttribute namedAttr =
+        createNamedAttr(createStringAttr("sret", dialect), unitAttr);
+    addAttribute(namedAttr);
+  } break;
+  /// Function always comes back to callsite.
+  case llvm::Attribute::AttrKind::WillReturn: {
+    NamedAttribute namedAttr =
+        createNamedAttr(createStringAttr("willreturn", dialect), unitAttr);
+    addAttribute(namedAttr);
+  } break;
+  /// Function only writes to memory.
+  case llvm::Attribute::AttrKind::WriteOnly: {
+    NamedAttribute namedAttr =
+        createNamedAttr(createStringAttr("writeonly", dialect), unitAttr);
+    addAttribute(namedAttr);
+  } break;
+  default:
+    llvm_unreachable("Unexpected attribute kind");
+  }
+
+  return *this;
+}
+
+AttrBuilder &AttrBuilder::addAttribute(llvm::Attribute::AttrKind kind,
+                                       int64_t val) {
+  OpBuilder builder(&ctx);
+  constexpr StringLiteral dialect = LLVM::LLVMDialect::getDialectNamespace();
+
+  switch (kind) {
+  /// Alignment of parameter.
+  case llvm::Attribute::AttrKind::Alignment: {
+    assert(val > 0 && "Invalid alignment value");
+    assert(val <= 0x100 && "Alignment too large");
+    NamedAttribute namedAttr = createNamedAttr(
+        createStringAttr("align", dialect),
+        builder.getIntegerAttr(builder.getIntegerType(32), val));
+    addAttribute(namedAttr);
+  } break;
+  /// Pointer is known to be dereferenceable.
+  case llvm::Attribute::AttrKind::Dereferenceable: {
+    assert(val > 0 && "Invalid number of bytes");
+    NamedAttribute namedAttr = createNamedAttr(
+        createStringAttr("dereferenceable", dialect),
+        builder.getIntegerAttr(builder.getIntegerType(64), val));
+    addAttribute(namedAttr);
+  } break;
+  /// Pointer is either null or dereferenceable.
+  case llvm::Attribute::AttrKind::DereferenceableOrNull: {
+    assert(val > 0 && "Invalid number of bytes");
+    NamedAttribute namedAttr = createNamedAttr(
+        createStringAttr("dereferenceable_or_null", dialect),
+        builder.getIntegerAttr(builder.getIntegerType(64), val));
+    addAttribute(namedAttr);
+  } break;
+  default:
+    llvm_unreachable("Unexpected attribute kind");
+  }
+
+  return *this;
+}
+
+AttrBuilder &AttrBuilder::addAttribute(StringRef attrName,
+                                       mlir::Attribute attr) {
+  NamedAttribute namedAttr = createNamedAttr(createStringAttr(attrName), attr);
+  return addAttribute(namedAttr);
+}
+
+AttrBuilder &
+AttrBuilder::addPassThroughAttribute(llvm::Attribute::AttrKind kind) {
+  switch (kind) {
+  /// Pass structure by value.
+  case llvm::Attribute::AttrKind::ByVal:
+    addPassThroughAttribute(createStringAttr("byval"));
+    break;
+  /// Function can only be moved to control-equivalent blocks.
+  case llvm::Attribute::AttrKind::Convergent:
+    addPassThroughAttribute(createStringAttr("convergent"));
+    break;
+  /// Function is required to make forward progress.
+  case llvm::Attribute::AttrKind::MustProgress:
+    addPassThroughAttribute(createStringAttr("mustprogress"));
+    break;
+  /// Nested function static chain.
+  case llvm::Attribute::AttrKind::Nest:
+    addPassThroughAttribute(createStringAttr("nest"));
+    break;
+  /// Considered to not alias after call.
+  case llvm::Attribute::AttrKind::NoAlias:
+    addPassThroughAttribute(createStringAttr("noalias"));
+    break;
+  /// Function creates no aliases of pointer.
+  case llvm::Attribute::AttrKind::NoCapture:
+    addPassThroughAttribute(createStringAttr("nocapture"));
+    break;
+  /// Function does not deallocate memory.
+  case llvm::Attribute::AttrKind::NoFree:
+    addPassThroughAttribute(createStringAttr("nofree"));
+    break;
+  /// Function is never inlined.
+  case llvm::Attribute::AttrKind::NoInline:
+    addPassThroughAttribute(createStringAttr("noinline"));
+    break;
+  /// Pointer is known to be not null.
+  case llvm::Attribute::AttrKind::NonNull:
+    addPassThroughAttribute(createStringAttr("nonnull"));
+    break;
+  /// Function does not recurse.
+  case llvm::Attribute::AttrKind::NoRecurse:
+    addPassThroughAttribute(createStringAttr("norecurse"));
+    break;
+  /// Function does not return.
+  case llvm::Attribute::AttrKind::NoReturn:
+    addPassThroughAttribute(createStringAttr("noreturn"));
+    break;
+  /// Parameter or return value may not contain uninitialized or poison bits.
+  case llvm::Attribute::AttrKind::NoUndef:
+    addPassThroughAttribute(createStringAttr("noundef"));
+    break;
+  /// Function doesn't unwind stack.
+  case llvm::Attribute::AttrKind::NoUnwind:
+    addPassThroughAttribute(createStringAttr("nounwind"));
+    break;
+  /// Function does not access memory.
+  case llvm::Attribute::AttrKind::ReadNone:
+    addPassThroughAttribute(createStringAttr("readnone"));
+    break;
+  /// Function only reads from memory.
+  case llvm::Attribute::AttrKind::ReadOnly:
+    addPassThroughAttribute(createStringAttr("readonly"));
+    break;
+  /// Hidden pointer to structure to return.
+  case llvm::Attribute::AttrKind::StructRet:
+    addPassThroughAttribute(createStringAttr("sret"));
+    break;
+  /// Function always comes back to callsite.
+  case llvm::Attribute::AttrKind::WillReturn:
+    addPassThroughAttribute(createStringAttr("willreturn"));
+    break;
+  /// Function only writes to memory.
+  case llvm::Attribute::AttrKind::WriteOnly:
+    addPassThroughAttribute(createStringAttr("writeonly"));
+    break;
+  default:
+    llvm_unreachable("Unexpected attribute kind");
+  }
+
+  return *this;
+}
+
+AttrBuilder &AttrBuilder::addPassThroughAttribute(mlir::Attribute attr) {
+  NamedAttribute passThrough = getOrCreatePassThroughAttr();
+  assert(passThrough.getValue().isa<ArrayAttr>() &&
+         "PassThrough attribute should have an ArrayAttr as value");
+
+  LLVM_DEBUG(llvm::dbgs() << "Adding attribute " << attr
+                          << " to 'passthrough'.\n");
+  std::vector<mlir::Attribute> vec =
+      passThrough.getValue().cast<ArrayAttr>().getValue().vec();
+  vec.push_back(attr);
+  passThrough.setValue(ArrayAttr::get(&ctx, vec));
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "  passthrough: ( ";
+    for (auto item : vec)
+      llvm::dbgs() << item << " ";
+    llvm::dbgs() << ")\n";
+  });
+
+  return addAttribute(passThrough);
+}
+
+bool AttrBuilder::contains(StringRef attrName) const {
+  return getAttr(attrName).hasValue();
+}
+
+Optional<NamedAttribute> AttrBuilder::getAttr(StringRef attrName) const {
+  return attrs.getNamed(attrName);
+}
+
+NamedAttribute AttrBuilder::getOrCreatePassThroughAttr() const {
+  const char *name = "passthrough";
+  Optional<NamedAttribute> passThrough = attrs.getNamed(name);
+  if (!passThrough) {
+    LLVM_DEBUG(llvm::dbgs() << "Creating empty 'passthrough' attribute\n");
+    passThrough =
+        NamedAttribute(createStringAttr(name), ArrayAttr::get(&ctx, {}));
+  }
+  return *passThrough;
+}
+
+NamedAttribute AttrBuilder::createNamedAttr(StringAttr attrName,
+                                            mlir::Attribute attr) const {
+  NamedAttribute namedAttr(attrName, attr);
+  return namedAttr;
+}
+
+StringAttr AttrBuilder::createStringAttr(Twine attrName) const {
+  return StringAttr::get(&ctx, attrName);
+}
+
+StringAttr AttrBuilder::createStringAttr(Twine attrName,
+                                         StringLiteral prefix) const {
+  return createStringAttr(prefix + "." + attrName);
+}
+
+} // end namespace mlirclang

--- a/polygeist/tools/cgeist/Lib/Attributes.h
+++ b/polygeist/tools/cgeist/Lib/Attributes.h
@@ -1,0 +1,88 @@
+//===- Attributes.h - Construct LLVMIR attributes ---------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CGEIST_ATTRIBUTES_H
+#define CGEIST_ATTRIBUTES_H
+
+#include "mlir/IR/Attributes.h"
+#include "mlir/IR/OperationSupport.h"
+#include "llvm/IR/Attributes.h"
+
+namespace mlirclang {
+
+/// \class
+/// Facilitates the construction of LLVMIR dialect attributes for a particular
+/// argument, parameter, function, or return value.
+class AttrBuilder {
+public:
+  AttrBuilder(mlir::MLIRContext &ctx) : ctx(ctx) {}
+  AttrBuilder(const AttrBuilder &) = delete;
+  AttrBuilder(AttrBuilder &&) = default;
+
+  /// Add the LLVM attribute identified by \p kind to the builder.
+  /// Note: only unit attributes can be added using this member function.
+  AttrBuilder &addAttribute(llvm::Attribute::AttrKind kind);
+
+  /// Add the LLVM attribute identified by \p kind with a value given by \p val
+  /// to the builder.
+  AttrBuilder &addAttribute(llvm::Attribute::AttrKind kind, int64_t val);
+
+  /// Create a NamedAttribute with name \p attrName and value \p attr and add it
+  /// to the builder.
+  AttrBuilder &addAttribute(llvm::StringRef attrName, mlir::Attribute attr);
+
+  /// Add the given named attribute \p attr to the builder.
+  AttrBuilder &addAttribute(mlir::NamedAttribute attr) {
+    attrs.set(attr.getName(), attr.getValue());
+    return *this;
+  }
+
+  /// Add the LLVM attribute identified by \p kind to the builder "passthrough"
+  /// named attribute.
+  AttrBuilder &addPassThroughAttribute(llvm::Attribute::AttrKind kind);
+
+  /// Add the given attribute \p attr to the builder "passthrough" named
+  /// attribute.
+  AttrBuilder &addPassThroughAttribute(mlir::Attribute attr);
+
+  /// Return true if the builder has the specified attribute.
+  bool contains(llvm::StringRef attrName) const;
+
+  /// Return true if the builder contains any attribute and false otherwise.
+  bool hasAttributes() const { return !attrs.empty(); }
+
+  /// Return the attribute identified by \p attrName if it exists and llvm::None
+  /// otherwise.
+  llvm::Optional<mlir::NamedAttribute> getAttr(llvm::StringRef attrName) const;
+
+  /// Returns the attributes in the builder.
+  llvm::ArrayRef<mlir::NamedAttribute> getAttrs() const { return attrs; }
+
+private:
+  /// Retrieve the "passthrough" named attribute if present, create it with an
+  /// empty list otherwise.
+  mlir::NamedAttribute getOrCreatePassThroughAttr() const;
+
+  /// returns a NamedAttribute with name \p attrName , and value \p attr.
+  mlir::NamedAttribute createNamedAttr(mlir::StringAttr attrName,
+                                       mlir::Attribute attr) const;
+
+  /// Returns a StringAttr of the form 'attrName'.
+  mlir::StringAttr createStringAttr(llvm::Twine attrName) const;
+
+  /// Returns a StringAttr of the form 'prefix.attrName'.
+  mlir::StringAttr createStringAttr(llvm::Twine attrName,
+                                    llvm::StringLiteral prefix) const;
+
+  mlir::MLIRContext &ctx;
+  mlir::NamedAttrList attrs;
+};
+
+} // end namespace mlirclang
+
+#endif // CGEIST_ATTRIBUTES_H

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -1,5 +1,3 @@
-// Copyright (C) Codeplay Software Limited
-
 //===- clang-mlir.h - Emit MLIR IRs by walking clang AST---------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -105,6 +103,8 @@ private:
 
 class CodeGenUtils {
 public:
+  /// This class groups the type and attributes of a value (e.g. a parameter or
+  /// return value).
   class TypeAndAttrs {
   public:
     mlir::Type type;
@@ -114,9 +114,11 @@ public:
     TypeAndAttrs(mlir::Type type, std::vector<mlir::NamedAttribute> attrs)
         : type(type), attrs(attrs) {}
 
-    // Collect the types of the given parameter descriptors.
+    // Collect the types of the given \p descriptors in \p types.
     static void getTypes(const llvm::SmallVectorImpl<TypeAndAttrs> &descriptors,
                          llvm::SmallVectorImpl<mlir::Type> &types);
+
+    // Collect the attributes of the given \p descriptors in \p attrs.
     static void getAttributes(
         const llvm::SmallVectorImpl<TypeAndAttrs> &descriptors,
         llvm::SmallVectorImpl<std::vector<mlir::NamedAttribute>> &attrs);
@@ -135,6 +137,11 @@ public:
 
   static bool isLLVMStructABI(const clang::RecordDecl *RD,
                               llvm::StructType *ST);
+
+  /// Determine whether to use the "noundef" attribute on a parameter or
+  /// function return value.
+  static bool determineNoUndef(clang::QualType QTy,
+                               const clang::CodeGen::ABIArgInfo &AI);
 };
 
 class MLIRASTConsumer : public clang::ASTConsumer {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -28,13 +28,16 @@
 // CHECK-LLVM-DAG: %"struct.sycl::_V1::detail::ItemBase.1.true" = type { %"class.sycl::_V1::range.1", %"class.sycl::_V1::id.1", %"class.sycl::_V1::id.1" }
 
 // CHECK-MLIR: gpu.module @device_functions
-// CHECK-MLIR: gpu.func @_ZTS8kernel_1(%arg0: memref<?xi32, 1>, %arg1: memref<?x!sycl_range_1_> {llvm.byval}, %arg2: memref<?x!sycl_range_1_> {llvm.byval}, %arg3: memref<?x!sycl_id_1_> {llvm.byval})
-// CHECK-MLIR-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>,
-// CHECK-MLIR-SAME: [[PASSTHROUGH:passthrough = \[\["sycl-module-id", ".*/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp"\], "norecurse", "nounwind", "convergent", "mustprogress"\]]]} {
+// CHECK-MLIR: gpu.func @_ZTS8kernel_1(%arg0: memref<?xi32, 1>, 
+// CHECK-MLIR-SAME:    %arg1: memref<?x!sycl_range_1_> [[PARM_ATTRS:{llvm.align = 8 : i32, llvm.byval, llvm.noundef}]],  
+// CHECK-MLIR-SAME:    %arg2: memref<?x!sycl_range_1_> [[PARM_ATTRS]], 
+// CHECK-MLIR-SAME:    %arg3: memref<?x!sycl_id_1_> [[PARM_ATTRS]]) 
+// CHECK-MLIR-SAME:  kernel attributes {[[CCONV:llvm.cconv = #llvm.cconv<spir_kernelcc>]], [[LINKAGE:llvm.linkage = #llvm.linkage<weak_odr>]],
+// CHECK-MLIR-SAME:  [[PASSTHROUGH:passthrough = \[\["sycl-module-id", ".*/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp"\], "norecurse", "nounwind", "convergent", "mustprogress"\]]]} {
 // CHECK-MLIR-NOT: gpu.func kernel
 
-// CHECK-LLVM: define weak_odr spir_kernel void @_ZTS8kernel_1(i32 addrspace(1)* {{.*}}, [[RANGE_TY:%"class.sycl::_V1::range.1"]]* byval([[RANGE_TY]]) {{.*}}, [[RANGE_TY]]* byval([[RANGE_TY]]) {{.*}}, [[ID_TY:%"class.sycl::_V1::id.1"]]* byval([[ID_TY]]) {{.*}}) #1
-
+// CHECK-LLVM: define weak_odr spir_kernel void @_ZTS8kernel_1(i32 addrspace(1)* {{.*}}, [[RANGE_TY:%"class.sycl::_V1::range.1"]]* byval([[RANGE_TY]]) align 8 {{.*}}, [[RANGE_TY]]* byval([[RANGE_TY]]) align 8 {{.*}}, 
+// CHECK-LLVM-SAME:  [[ID_TY:%"class.sycl::_V1::id.1"]]* byval([[ID_TY]]) align 8 {{.*}}) #1
 class kernel_1 {
  sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write> A;
 
@@ -42,26 +45,26 @@ public:
 	kernel_1(sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write> A) : A(A) {}
 
   void operator()(sycl::id<1> id) const {
-   A[id] = 42;
- }
+    A[id] = 42;
+  }
 };
 
 void host_1() {
   auto q = sycl::queue{};
   auto range = sycl::range<1>{1};
-
-  {
-    auto buf = sycl::buffer<int, 1>{nullptr, range};
-    q.submit([&](sycl::handler &cgh) {
-      auto A = buf.get_access<sycl::access::mode::read_write>(cgh);
-      auto ker =  kernel_1{A};
-      cgh.parallel_for<kernel_1>(range, ker);
-    });
-  }
+  auto buf = sycl::buffer<int, 1>{nullptr, range};
+  q.submit([&](sycl::handler &cgh) {
+    auto A = buf.get_access<sycl::access::mode::read_write>(cgh);
+    auto ker =  kernel_1{A};
+    cgh.parallel_for<kernel_1>(range, ker);
+  });
 }
 
-// CHECK-MLIR: gpu.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2(%arg0: memref<?xi32, 1>, %arg1: memref<?x!sycl_range_1_> {llvm.byval}, %arg2: memref<?x!sycl_range_1_> {llvm.byval}, %arg3: memref<?x!sycl_id_1_> {llvm.byval})
-// CHECK-MLIR-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, [[PASSTHROUGH]]
+// CHECK-MLIR: gpu.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2(%arg0: memref<?xi32, 1>, 
+// CHECK-MLIR-SAME:     %arg1: memref<?x!sycl_range_1_> [[PARM_ATTRS]], 
+// CHECK-MLIR-SAME:     %arg2: memref<?x!sycl_range_1_> [[PARM_ATTRS]], 
+// CHECK-MLIR-SAME:     %arg3: memref<?x!sycl_id_1_> [[PARM_ATTRS]])
+// CHECK-MLIR-SAME:     kernel attributes {[[CCONV]], [[LINKAGE]], [[PASSTHROUGH]]}
 // CHECK-MLIR-NOT: gpu.func kernel
 
 // CHECK-LLVM: define weak_odr spir_kernel void @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2({{.*}}) #1
@@ -69,16 +72,13 @@ void host_1() {
 void host_2() {
   auto q = sycl::queue{};
   auto range = sycl::range<1>{1};
-
-  {
-    auto buf = sycl::buffer<int, 1>{nullptr, range};
-    q.submit([&](sycl::handler &cgh) {
-      auto A = buf.get_access<sycl::access::mode::read_write>(cgh);
-      cgh.parallel_for<class kernel_2>(range, [=](sycl::id<1> id) {
-        A[id] = 42;
-      });
+  auto buf = sycl::buffer<int, 1>{nullptr, range};
+  q.submit([&](sycl::handler &cgh) {
+    auto A = buf.get_access<sycl::access::mode::read_write>(cgh);
+    cgh.parallel_for<class kernel_2>(range, [=](sycl::id<1> id) {
+      A[id] = 42;
     });
-  }
+  });
 }
 
 // CHECK-MLIR-NOT: SYCLKernel =


### PR DESCRIPTION
Introduce the `AttrBuilder` class which is used to manage IR attributes for functions, parameters, etc... 
Use it to set SYCL kernel parameter attributes (this PR adds the `align` and `noundef` attributes on kernel pointer parameters).   

Signed-off-by: Tiotto, Ettore <ettore.tiotto@intel.com>