### PR TITLE
[SYCL-MLIR] Fix test suite buildbots

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -43,7 +43,7 @@ jobs:
     name: Resolve Test Matrix
     uses: ./.github/workflows/sycl_resolve_test_matrix.yml
     with:
-      lts_config: "hip_amdgpu;ocl_x64;ocl_gen9;l0_gen9;esimd_emu;cuda"
+      lts_config: "ocl_x64;ocl_gen9;l0_gen9"
 
   linux_default:
     name: Linux

--- a/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
@@ -1,5 +1,3 @@
-// clang-format off
-
 // TODO: Investigate and remove all "Warning"s.
 // RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.out 2>&1 | FileCheck %s --implicit-check-not="{{warning|error|Error}}:"
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
@@ -2,10 +2,6 @@
 
 // TODO: Investigate and remove all "Warning"s.
 // RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.out 2>&1 | FileCheck %s --implicit-check-not="{{warning|error|Error}}:"
-// RUN: env SYCL_DEVICE_FILTER=host %t.out | FileCheck %s --check-prefix=HOST
-// TODO: Add device run:
-// env SYCL_DEVICE_FILTER=cpu %t.out | FileCheck %s --check-prefix=DEVICE
-// REQUIRES: linux
 
 // RUN: clang++ -fsycl -fsycl-device-only -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc 2>/dev/null
 
@@ -24,12 +20,6 @@
 
 // Test that all referenced sycl header functions are generated.
 // LLVM-NOT: declare {{.*}} spir_func
-
-// HOST: Using SYCL host device
-// HOST-NEXT: A[0]=2
-
-// DEVICE: Using {{.*}} CPU
-// DEVICE-NEXT: A[0]=1
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -268,6 +268,7 @@ endif()
 # SYCL toolchain builds all components: compiler, libraries, headers, etc.
 add_custom_target(sycl-compiler
   DEPENDS append-file
+          cgeist
           clang
           clang-offload-wrapper
           clang-offload-bundler
@@ -340,6 +341,7 @@ get_property(SYCL_TOOLCHAIN_DEPS GLOBAL PROPERTY SYCL_TOOLCHAIN_INSTALL_COMPONEN
 set( SYCL_TOOLCHAIN_DEPLOY_COMPONENTS
      append-file
      boost_mp11-headers
+     cgeist
      clang
      clang-offload-wrapper
      clang-offload-bundler


### PR DESCRIPTION
1. Remove run line from single_task.cpp
    - `single_task.cpp` is added in `llvm_test_suite`, so no need to execute it here.
2. Add cgeist to sycl-compiler target
    - cgeist needs to be added in the `install` directory for test suite to use it.
3. Do not run test suite for ESIMD, HIP and CUDA
    - `sycl-mlir` branch of `llvm_test_suite` only executes one test case (single_task.cpp), which is not supported for ESIMD, HIP and CUDA.
4. Make `single_task.cpp` consistent between `intel/llvm` and `intel/llvm-test-suite`.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>