### PR TITLE
[NFCI][SYCL][L0] Introduce RAII-style wrapper for pi_queue

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -1320,7 +1320,10 @@ struct _pi_ze_event_list_t {
 class pi_queue_ref {
 public:
   pi_queue_ref() = default;
-  pi_queue_ref(pi_queue Queue) : Queue(Queue) { Queue->RefCount.increment(); }
+  pi_queue_ref(pi_queue Queue) : Queue(Queue) {
+    if (Queue)
+      Queue->RefCount.increment();
+  }
   ~pi_queue_ref();
 
   pi_queue_ref(const pi_queue_ref &) = delete;


### PR DESCRIPTION
It is supposed to be used internally to the plugin to simplify resource management. I expect to make more similar changes for other objects later, so this is just a first step.

For this particular scenario it might seem that the extra code is even bigger than existing manual RefCount updates and (to the best of my knowledge) it doesn't fix any existing bugs. However, it makes it much easier to see how there is no such leak. Before this change one had to look through entire pluging to see where and how this counter is implemented/decremented for this particular ownership scenario and ensure that it's done on every code path. Now it's enough to just verify the implementation of the wrapper to guarantee that there is no leak (module circular dependencies that would be an issue under any implementation).

I suppose the exact implementation of the(se) RAII class(es) to evolve once other parts of the code are updated, but this PR should be a good enough start.