### PR TITLE
[SYCL-MLIR] Use `ubuntu2004_intel_drivers` docker image

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -14,7 +14,7 @@ on:
       build_image:
         type: string
         required: false
-        default: "ghcr.io/intel/llvm/ubuntu2004_build:latest"
+        default: "ghcr.io/intel/llvm/ubuntu2004_intel_drivers:latest"
       build_ref:
         type: string
         required: false


### PR DESCRIPTION
`ubuntu2004_intel_drivers` docker image executes `install_drivers.sh`, 
where `install_drivers.sh` install the Intel OpenCL CPU Runtime.
If we want to run SYCL on CPU as device in LIT, then we need to have a CPU Runtime installed.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>