### PR TITLE
Revert "[SYCL-MLIR] Use `ubuntu2004_intel_drivers` docker image"

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -14,7 +14,7 @@ on:
       build_image:
         type: string
         required: false
-        default: "ghcr.io/intel/llvm/ubuntu2004_intel_drivers:latest"
+        default: "ghcr.io/intel/llvm/ubuntu2004_build:latest"
       build_ref:
         type: string
         required: false


### PR DESCRIPTION
```
CMake Error at /__w/llvm/llvm/src/sycl/plugins/hip/CMakeLists.txt:11 (message):
  Couldn't find ROCm installation in '/opt/rocm', please set
  SYCL_BUILD_PI_HIP_ROCM_DIR to the path of the ROCm installation.
```

Reverts intel/llvm#7071