### PR TITLE
[SYCL-MLIR] Change `sycl_containers.yaml` push branch to `sycl-mlir`

### DIFF
--- a/.github/workflows/sycl_containers.yaml
+++ b/.github/workflows/sycl_containers.yaml
@@ -6,7 +6,7 @@ on:
     - cron: '0 0 1,15 * *'
   push:
     branches:
-      - sycl
+      - sycl-mlir
     paths:
       - 'devops/containers/**'
       - 'devops/dependencies.json'


### PR DESCRIPTION
Change `sycl_containers.yaml` push branch from `sycl` to `sycl-mlir`.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>