### PR TITLE
[SYCL-MLIR] Implement sycl-method-to-sycl-call pass

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.h
@@ -13,15 +13,18 @@
 #ifndef MLIR_DIALECT_SYCL_TRANSFORMS_PASSES_H
 #define MLIR_DIALECT_SYCL_TRANSFORMS_PASSES_H
 
+#include <memory>
+
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
-namespace sycl {  
-  
+namespace sycl {
+
 //===----------------------------------------------------------------------===//
 // Passes
 //===----------------------------------------------------------------------===//
 
+std::unique_ptr<Pass> createSYCLMethodToSYCLCallPass();
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.td
@@ -11,4 +11,12 @@
 
 include "mlir/Pass/PassBase.td"
 
+def SYCLMethodToSYCLCall : Pass<"sycl-method-to-sycl-call", "ModuleOp"> {
+  let summary = "Convert SYCLMethodOpInterface instances to SYCLCallOps";
+  let description = [{
+    Replace SYCLMethodOpInterface instances by SYCLCallOps.
+  }];
+  let constructor = "mlir::sycl::createSYCLMethodToSYCLCallPass()";
+}
+
 #endif // MLIR_DIALECT_SYCL_TRANSFORMS_PASSES

--- a/mlir-sycl/lib/CMakeLists.txt
+++ b/mlir-sycl/lib/CMakeLists.txt
@@ -3,3 +3,4 @@ add_flag_if_supported("-Werror=global-constructors" WERROR_GLOBAL_CONSTRUCTOR)
 
 add_subdirectory(Conversion)
 add_subdirectory(Dialect)
+add_subdirectory(Transforms)

--- a/mlir-sycl/lib/Transforms/CMakeLists.txt
+++ b/mlir-sycl/lib/Transforms/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_mlir_library(MLIRSYCLTransforms
+  SYCLMethodToSYCLCall.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_MAIN_INCLUDE_DIR}/mlir/Transforms
+
+  DEPENDS
+  MLIRSYCLTransformsIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRPass
+  MLIRTransformUtils
+  MLIRSYCLDialect
+  )

--- a/mlir-sycl/lib/Transforms/PassDetail.h
+++ b/mlir-sycl/lib/Transforms/PassDetail.h
@@ -1,0 +1,24 @@
+//===- PassDetail.h - Transforms Pass class details -------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TRANSFORMS_PASSDETAIL_H_
+#define TRANSFORMS_PASSDETAIL_H_
+
+#include "mlir/Dialect/SYCL/IR/SYCLOpInterfaces.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace mlir {
+namespace sycl {
+#define GEN_PASS_CLASSES
+#include "mlir/Dialect/SYCL/Transforms/Passes.h.inc"
+} // namespace sycl
+} // namespace mlir
+
+#endif // TRANSFORMS_PASSDETAIL_H_

--- a/mlir-sycl/lib/Transforms/SYCLMethodToSYCLCall.cpp
+++ b/mlir-sycl/lib/Transforms/SYCLMethodToSYCLCall.cpp
@@ -1,0 +1,140 @@
+//===- SYCLMethodToSYCLCall.cpp - SYCLMethodOpInterface to SYCLCallOp -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a pass to generate SYCLCallOp operations from
+// SYCLMethodOpInterface instances.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/SYCL/Transforms/Passes.h"
+
+#include "PassDetail.h"
+#include "mlir/Dialect/SYCL/IR/SYCLOpInterfaces.h"
+#include "mlir/Dialect/SYCL/IR/SYCLOpsDialect.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Rewrite/FrozenRewritePatternSet.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "sycl-method-to-sycl-call"
+
+using namespace mlir;
+using namespace sycl;
+
+static mlir::Value castToBaseType(PatternRewriter &Rewriter, mlir::Location Loc,
+                                  mlir::Value Original,
+                                  mlir::MemRefType BaseType) {
+  const auto ThisType = Original.getType().cast<MemRefType>();
+  const llvm::ArrayRef<int64_t> TargetShape = BaseType.getShape();
+  const mlir::Type TargetElementType = BaseType.getElementType();
+  const unsigned TargetMemSpace = BaseType.getMemorySpaceAsInt();
+
+  assert(TargetShape == ThisType.getShape() &&
+         "Shape should not change when casting to base class for a member "
+         "function call.");
+  assert(TargetMemSpace == ThisType.getMemorySpaceAsInt() &&
+         "Memory space of the `this` argument should be preserved when "
+         "creating a SYCLMethodOp instance.");
+
+  // The element type will always change here.
+  mlir::Value Cast = Rewriter.create<sycl::SYCLCastOp>(
+      Loc,
+      MemRefType::get(TargetShape, TargetElementType, {},
+                      ThisType.getMemorySpaceAsInt()),
+      Original);
+
+  LLVM_DEBUG(llvm::dbgs() << "  Cast inserted: " << Cast << "\n");
+
+  return Cast;
+}
+
+static LogicalResult convertMethod(SYCLMethodOpInterface method,
+                                   PatternRewriter &rewriter) {
+  LLVM_DEBUG(llvm::dbgs() << "ConvertToLLVMABIPass: SYCLMethodOpLowering: ";
+             method.dump(); llvm::dbgs() << "\n");
+
+  SmallVector<mlir::Value> Args(method->getOperands());
+
+  const auto BaseType = method.getBaseType().cast<MemRefType>();
+  if (BaseType != Args[0].getType().cast<MemRefType>())
+    Args[0] = castToBaseType(rewriter, method->getLoc(), Args[0], BaseType);
+
+  const auto ResTyOrNone = [=]() -> llvm::Optional<mlir::Type> {
+    const auto ResTys = method->getResultTypes();
+    if (ResTys.empty())
+      return llvm::None;
+    assert(ResTys.size() == 1 && "Returning multiple values is not allowed in "
+                                 "SYCLMethodOpInterface instances");
+    return ResTys[0];
+  };
+
+  auto CallOp = rewriter.replaceOpWithNewOp<sycl::SYCLCallOp>(
+      method, ResTyOrNone(), method.getTypeName(), method.getFunctionName(),
+      method.getMangledFunctionName(), Args);
+
+  LLVM_DEBUG(llvm::dbgs() << "  Converted to: " << CallOp << "\n");
+
+  return success();
+}
+
+template <typename Op,
+          typename = std::enable_if_t<mlir::sycl::isSYCLMethod<Op>::value>>
+class SYCLMethodToSYCLCallPattern : public OpRewritePattern<Op> {
+public:
+  explicit SYCLMethodToSYCLCallPattern(MLIRContext *context)
+      : OpRewritePattern<Op>(context, /*benefit*/ 1) {}
+
+  LogicalResult matchAndRewrite(Op op, PatternRewriter &rewriter) const final {
+    return convertMethod(static_cast<SYCLMethodOpInterface>(op), rewriter);
+  }
+};
+
+// If the operation is a method, add the SYCLMethod pattern for that
+// operation.
+template <typename T>
+static typename std::enable_if_t<mlir::sycl::isSYCLMethod<T>::value>
+addSYCLMethodPattern(RewritePatternSet &patterns) {
+  patterns.add<SYCLMethodToSYCLCallPattern<T>>(patterns.getContext());
+}
+
+// If the operation is not a method, do nothing.
+template <typename T>
+static typename std::enable_if_t<!mlir::sycl::isSYCLMethod<T>::value>
+addSYCLMethodPattern(RewritePatternSet &) {}
+
+template <typename... Args>
+static void addSYCLMethodPatterns(RewritePatternSet &patterns) {
+  (void)std::initializer_list<int>{
+      0, (addSYCLMethodPattern<Args>(patterns), 0)...};
+}
+
+static void addSYCLMethodPatterns(RewritePatternSet &patterns) {
+  addSYCLMethodPatterns<
+#define GET_OP_LIST
+#include "mlir/Dialect/SYCL/IR/SYCLOps.cpp.inc"
+      >(patterns);
+}
+
+struct SYCLMethodToSYCLCall : SYCLMethodToSYCLCallBase<SYCLMethodToSYCLCall> {
+  LogicalResult initialize(MLIRContext *context) final {
+    RewritePatternSet owningPatterns(context);
+    addSYCLMethodPatterns(owningPatterns);
+    patterns = FrozenRewritePatternSet(std::move(owningPatterns));
+    return success();
+  }
+
+  void runOnOperation() final {
+    (void)applyPatternsAndFoldGreedily(getOperation(), patterns);
+  }
+
+  FrozenRewritePatternSet patterns;
+};
+
+/// Creates a pass that lowers SYCLMethodOpInterface instances to SYCLCallOps.
+std::unique_ptr<Pass> mlir::sycl::createSYCLMethodToSYCLCallPass() {
+  return std::make_unique<SYCLMethodToSYCLCall>();
+}

--- a/mlir-sycl/test/Transforms/sycl-method-to-sycl-call.mlir
+++ b/mlir-sycl/test/Transforms/sycl-method-to-sycl-call.mlir
@@ -1,0 +1,41 @@
+// RUN: sycl-mlir-opt -sycl-method-to-sycl-call -split-input-file -verify-diagnostics %s | FileCheck %s
+
+!sycl_accessor_2_i32_read_write_global_buffer = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl.id<2>, !sycl.range<2>, !sycl.range<2>)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_array_2_ = !sycl.array<[2], (memref<2xi64, 4>)>
+!sycl_id_1_ = !sycl.id<1>
+!sycl_id_2_ = !sycl.id<2>
+!sycl_item_1_1_ = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>
+!sycl_range_2_ = !sycl.range<2>
+
+// CHECK-LABEL: func.func @accessor_subscript_operator(%arg0: memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, %arg1: !sycl_id_2_) -> memref<?xi32, 4> {
+// CHECK-NEXT: %0 = sycl.call(%arg0, %arg1) {Function = @"operator[]", MangledName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, Type = @accessor} : (memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, !sycl_id_2_) -> memref<?xi32, 4>
+
+func.func @accessor_subscript_operator(%arg0: memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, %arg1: !sycl_id_2_) -> memref<?xi32, 4> {
+  %0 = sycl.accessor.subscript %arg0[%arg1] {BaseType = memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, !sycl_id_2_) -> memref<?xi32, 4>
+  return %0 : memref<?xi32, 4>
+}
+
+// CHECK-LABEL: func.func @range_get(%arg0: memref<?x!sycl_range_2_, 4>, %arg1: i32) -> i64 {
+// CHECK-NEXT: %0 = sycl.cast(%arg0) : (memref<?x!sycl_range_2_, 4>) -> memref<?x!sycl_array_2_, 4>
+// CHECK-NEXT: %1 = sycl.call(%0, %arg1) {Function = @get, MangledName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, Type = @array} : (memref<?x!sycl_array_2_, 4>, i32) -> i64
+
+func.func @range_get(%arg0: memref<?x!sycl_range_2_, 4>, %arg1: i32) -> i64 {
+  %0 = "sycl.range.get"(%arg0, %arg1) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> i64
+  return %0 : i64
+}
+
+// CHECK-LABEL: func.func @range_size(%arg0: memref<?x!sycl_range_2_, 4>) -> i64 {
+// CHECK-NEXT: %0 = sycl.call(%arg0) {Function = @size, MangledName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, Type = @range} : (memref<?x!sycl_range_2_, 4>) -> i64
+
+func.func @range_size(%arg0: memref<?x!sycl_range_2_, 4>) -> i64 {
+  %0 = "sycl.range.size"(%arg0) {BaseType = memref<?x!sycl_range_2_, 4>, FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl_range_2_, 4>) -> i64
+  return %0 : i64
+}
+
+// CHECK-LABEL: func.func @sycl_item_get_id(%arg0: memref<?x!sycl_item_1_1_, 4>) -> !sycl_id_1_ {
+// CHECK-NEXT: %0 = sycl.call(%arg0) {Function = @get_id, MangledName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, Type = @item} : (memref<?x!sycl_item_1_1_, 4>) -> !sycl_id_1_
+
+func.func @sycl_item_get_id(%arg0: memref<?x!sycl_item_1_1_, 4>) -> !sycl_id_1_ {
+  %0 = "sycl.item.get_id"(%arg0) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> !sycl_id_1_
+  return %0 : !sycl_id_1_
+}

--- a/mlir-sycl/tools/sycl-mlir-opt/CMakeLists.txt
+++ b/mlir-sycl/tools/sycl-mlir-opt/CMakeLists.txt
@@ -2,6 +2,7 @@ set(LIBS
   MLIRMlirOptMain
   MLIRSYCLDialect
   MLIRSYCLToLLVM
+  MLIRSYCLTransforms
 )
 
 add_mlir_tool(sycl-mlir-opt

--- a/mlir-sycl/tools/sycl-mlir-opt/sycl-mlir-opt.cpp
+++ b/mlir-sycl/tools/sycl-mlir-opt/sycl-mlir-opt.cpp
@@ -44,6 +44,7 @@ int main(int argc, char **argv) {
   mlir::memref::registerMemRefPasses();
   mlir::sycl::registerSYCLPasses();
   mlir::sycl::registerConvertSYCLToLLVMPass();
+  mlir::sycl::registerSYCLMethodToSYCLCallPass();
 
   // Register command line options.
   mlir::registerAsmPrinterCLOptions();

--- a/polygeist/lib/polygeist/Passes/ConvertToLLVMABI.cpp
+++ b/polygeist/lib/polygeist/Passes/ConvertToLLVMABI.cpp
@@ -178,94 +178,6 @@ public:
   }
 };
 
-static mlir::Value castToBaseType(PatternRewriter &Rewriter, mlir::Location Loc,
-                                  mlir::Value Original,
-                                  mlir::MemRefType BaseType) {
-  const auto ThisType = Original.getType().cast<MemRefType>();
-  const llvm::ArrayRef<int64_t> TargetShape = BaseType.getShape();
-  const mlir::Type TargetElementType = BaseType.getElementType();
-  const unsigned TargetMemSpace = BaseType.getMemorySpaceAsInt();
-
-  assert(TargetShape == ThisType.getShape() &&
-         "Shape should not change when casting to base class for a member "
-         "function call.");
-  assert(TargetMemSpace == ThisType.getMemorySpaceAsInt() &&
-         "Memory space of the `this` argument should be preserved when "
-         "creating a SYCLMethodOp instance.");
-
-  // The element type will always change here.
-  mlir::Value Cast = Rewriter.create<sycl::SYCLCastOp>(
-      Loc,
-      MemRefType::get(TargetShape, TargetElementType, {},
-                      ThisType.getMemorySpaceAsInt()),
-      Original);
-
-  LLVM_DEBUG(llvm::dbgs() << "  Cast inserted: " << Cast << "\n");
-
-  return Cast;
-}
-
-static LogicalResult convertMethod(sycl::SYCLMethodOpInterface method,
-                                   PatternRewriter &rewriter) {
-  LLVM_DEBUG(llvm::dbgs() << "ConvertToLLVMABIPass: SYCLMethodOpLowering: ";
-             method.dump(); llvm::dbgs() << "\n");
-
-  SmallVector<mlir::Value> Args(method->getOperands());
-
-  const auto BaseType = method.getBaseType().cast<MemRefType>();
-  if (BaseType != Args[0].getType().cast<MemRefType>())
-    Args[0] = castToBaseType(rewriter, method->getLoc(), Args[0], BaseType);
-
-  const auto ResTyOrNone = [=]() -> llvm::Optional<mlir::Type> {
-    const auto ResTys = method->getResultTypes();
-    if (ResTys.empty())
-      return llvm::None;
-    assert(ResTys.size() == 1 && "Returning multiple values is not allowed in "
-                                 "SYCLMethodOpInterface instances");
-    return ResTys[0];
-  };
-
-  auto CallOp = rewriter.replaceOpWithNewOp<sycl::SYCLCallOp>(
-      method, ResTyOrNone(), method.getTypeName(), method.getFunctionName(),
-      method.getMangledFunctionName(), Args);
-
-  LLVM_DEBUG(llvm::dbgs() << "  Converted to: " << CallOp << "\n");
-
-  return convertOperation(*method, rewriter);
-}
-
-template <typename T, typename = std::enable_if_t<sycl::isSYCLMethod<T>::value>>
-class SYCLMethodOpLowering final : public OpRewritePattern<T> {
-public:
-  using OpRewritePattern<T>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(T op, PatternRewriter &rewriter) const final {
-    return convertMethod(op, rewriter);
-  }
-};
-
-// If the operation is a method, add the SYCLMethod pattern for that
-// operation.
-template <typename T>
-static typename std::enable_if_t<mlir::sycl::isSYCLMethod<T>::value>
-addSYCLMethodPattern(RewritePatternSet &patterns, ConversionTarget &target,
-                     MLIRContext *ctx) {
-  patterns.add<SYCLMethodOpLowering<T>>(ctx);
-  target.addIllegalOp<T>();
-}
-
-// If the operation is not a method, do nothing.
-template <typename T>
-static typename std::enable_if_t<!mlir::sycl::isSYCLMethod<T>::value>
-addSYCLMethodPattern(RewritePatternSet &, ConversionTarget &, MLIRContext *) {}
-
-template <typename... Args>
-static void addSYCLMethodPatterns(RewritePatternSet &patterns,
-                                  ConversionTarget &target, MLIRContext *ctx) {
-  (void)std::initializer_list<int>{
-      0, (addSYCLMethodPattern<Args>(patterns, target, ctx), 0)...};
-}
-
 struct ConvertToLLVMABIPass final
     : public mlir::polygeist::ConvertToLLVMABIBase<ConvertToLLVMABIPass> {
   void runOnOperation() override {
@@ -281,12 +193,6 @@ struct ConvertToLLVMABIPass final
     patterns.add<SYCLConstructorLowering>(&getContext());
 
     ConversionTarget target(getContext());
-
-    // Add SYCLMethodOp conversion patterns and illegalize these operations.
-    addSYCLMethodPatterns<
-#define GET_OP_LIST
-#include "mlir/Dialect/SYCL/IR/SYCLOps.cpp.inc"
-        >(patterns, target, &getContext());
 
     auto checkFuncTy = [](FunctionType funcTy) {
       bool hasMemRef = llvm::any_of(

--- a/polygeist/tools/cgeist/CMakeLists.txt
+++ b/polygeist/tools/cgeist/CMakeLists.txt
@@ -68,6 +68,7 @@ target_link_libraries(cgeist PRIVATE
   MLIROpenMPToLLVM
   MLIROpenMPToLLVMIRTranslation
   MLIRSYCLToLLVM
+  MLIRSYCLTransforms
   
   LLVMSYCLLowerIR
 

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -37,6 +37,7 @@
 
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h.inc"
 #include "mlir/Dialect/SYCL/IR/SYCLOpsTypes.h.inc"
+#include "mlir/Dialect/SYCL/Transforms/Passes.h"
 
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/MLIRContext.h"
@@ -638,6 +639,7 @@ static int finalize(mlir::MLIRContext &context,
     if (!EmitOpenMPIR) {
       module->walk([&](mlir::omp::ParallelOp) { LinkOMP = true; });
       mlir::PassManager pm3(&context);
+      pm3.addPass(mlir::sycl::createSYCLMethodToSYCLCallPass());
       pm3.addPass(polygeist::createConvertToLLVMABIPass());
       LowerToLLVMOptions options(&context);
       options.dataLayout = DL;


### PR DESCRIPTION
Implement pass to transform SYCLMethodOpInterface instances to SYCLCallOps.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>