### PR TITLE
[NFC][SYCL][SPIR-V] Remove JointMatrixINTEL type W/A

### DIFF
--- a/sycl/include/CL/__spirv/spirv_types.hpp
+++ b/sycl/include/CL/__spirv/spirv_types.hpp
@@ -123,36 +123,15 @@ enum class MatrixUse : uint32_t {
   Unnecessary = 3
 };
 
-// TODO: replace the following W/A with a better solution when we have it.
-// The following structure is used to represent the joint matrix type in the
-// LLVM IR. The structure has a pointer to a multidimensional array member which
-// makes the encoding of the matrix type information within the LLVM IR looks
-// like this:
-// %struct.__spirv_JointMatrixINTEL = type { [42 x [6 x [2 x [1 x float]]]]* }
-// Note that an array cannot be of zero size but MatrixLayout and Scope
-// parameters can; hence '+ 1' is added to the 3rd and 4th dimensions.
-// In general, representing a matrix type information like this is a bit odd
-// (especially for MatrixLayout and Scope parameters). But with the current
-// tools we have in Clang, this is the only way to preserve and communicate this
-// information to SPIRV translator.
-// The long term solution would be to introduce a matrix type in Clang and use
-// it instead of this member.
 #if (SYCL_EXT_ONEAPI_MATRIX_VERSION > 1)
 template <typename T, std::size_t R, std::size_t C, MatrixLayout L,
           Scope::Flag S = Scope::Flag::Subgroup,
           MatrixUse U = MatrixUse::Unnecessary>
-struct __spirv_JointMatrixINTEL {
-  T(*Value)
-  [R][C][static_cast<size_t>(L) + 1][static_cast<size_t>(S) + 1]
-     [static_cast<size_t>(U) + 1];
-};
+struct __spirv_JointMatrixINTEL;
 #else
 template <typename T, std::size_t R, std::size_t C, MatrixLayout L,
           Scope::Flag S = Scope::Flag::Subgroup>
-struct __spirv_JointMatrixINTEL {
-  T(*Value)
-  [R][C][static_cast<size_t>(L) + 1][static_cast<size_t>(S) + 1];
-};
+struct __spirv_JointMatrixINTEL;
 #endif // SYCL_EXT_ONEAPI_MATRIX_VERSION
 
 } // namespace __spv

--- a/sycl/test/matrix/matrix-int8-test-use.cpp
+++ b/sycl/test/matrix/matrix-int8-test-use.cpp
@@ -1,8 +1,8 @@
 // RUN: %clangxx -fsycl -fsycl-device-only -DSYCL_EXT_ONEAPI_MATRIX_VERSION=2 -O2 -S -emit-llvm -o - %s | FileCheck %s
 
-// CHECK-DAG: %spirv.JointMatrixINTEL._char_12_48_4_3_0 = type { [12 x [48 x [5 x [4 x [1 x i8]]]]] addrspace(4)* }
-// CHECK-DAG: %spirv.JointMatrixINTEL._int_12_12_4_3_2 = type { [12 x [12 x [5 x [4 x [3 x i32]]]]] addrspace(4)* }
-// CHECK-DAG: %spirv.JointMatrixINTEL._char_48_12_4_3_1 = type { [48 x [12 x [5 x [4 x [2 x i8]]]]] addrspace(4)* }
+// CHECK-DAG: %spirv.JointMatrixINTEL._char_12_48_4_3_0 = type opaque
+// CHECK-DAG: %spirv.JointMatrixINTEL._int_12_12_4_3_2 = type opaque
+// CHECK-DAG: %spirv.JointMatrixINTEL._char_48_12_4_3_1 = type opaque
 
 #include <iostream>
 #include <sycl/sycl.hpp>

--- a/sycl/test/matrix/matrix-int8-test.cpp
+++ b/sycl/test/matrix/matrix-int8-test.cpp
@@ -1,8 +1,8 @@
 // RUN: %clangxx -fsycl -fsycl-device-only -O2 -S -emit-llvm -o - %s | FileCheck %s
 
-// CHECK-DAG: %spirv.JointMatrixINTEL._char_12_48_0_3 = type { [12 x [48 x [1 x [4 x i8]]]] addrspace(4)* }
-// CHECK-DAG: %spirv.JointMatrixINTEL._int_12_12_0_3 = type { [12 x [12 x [1 x [4 x i32]]]] addrspace(4)* }
-// CHECK-DAG: %spirv.JointMatrixINTEL._char_48_12_3_3 = type { [48 x [12 x [4 x [4 x i8]]]] addrspace(4)* }
+// CHECK-DAG: %spirv.JointMatrixINTEL._char_12_48_0_3 = type opaque
+// CHECK-DAG: %spirv.JointMatrixINTEL._int_12_12_0_3 = type opaque
+// CHECK-DAG: %spirv.JointMatrixINTEL._char_48_12_3_3 = type opaque
 
 #include <iostream>
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
It's no longer needed after https://github.com/intel/llvm/pull/6535

Signed-off-by: Sidorov, Dmitry <dmitry.sidorov@intel.com>