### PR TITLE
[SYCL] Invert the KeepOwnership argument to match PI API definitions

### DIFF
--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -140,7 +140,7 @@ make_kernel_bundle(pi_native_handle NativeHandle, const context &TargetContext,
 
   pi::PiProgram PiProgram = nullptr;
   Plugin.call<PiApiKind::piextProgramCreateWithNativeHandle>(
-      NativeHandle, ContextImpl->getHandleRef(), KeepOwnership, &PiProgram);
+      NativeHandle, ContextImpl->getHandleRef(), !KeepOwnership, &PiProgram);
 
   std::vector<pi::PiDevice> ProgramDevices;
   size_t NumDevices = 0;
@@ -251,7 +251,7 @@ kernel make_kernel(const context &TargetContext,
   // Create PI kernel first.
   pi::PiKernel PiKernel = nullptr;
   Plugin.call<PiApiKind::piextKernelCreateWithNativeHandle>(
-      NativeHandle, ContextImpl->getHandleRef(), PiProgram, KeepOwnership,
+      NativeHandle, ContextImpl->getHandleRef(), PiProgram, !KeepOwnership,
       &PiKernel);
 
   if (Backend == backend::opencl)


### PR DESCRIPTION
The existing test https://github.com/intel/llvm-test-suite/blob/intel/SYCL/OnlineCompiler/online_compiler_L0.cpp caught this problem when run with ZE_DEBUG=4

Signed-off-by: Sergey V Maslov <sergey.v.maslov@intel.com>