### PR TITLE
[SYCL] Implement fixed target property generation

### DIFF
--- a/llvm/test/tools/sycl-post-link/device-requirements/fixed-target.ll
+++ b/llvm/test/tools/sycl-post-link/device-requirements/fixed-target.ll
@@ -1,0 +1,32 @@
+; RUN: sycl-post-link -split=auto %s -o %t.files.table
+; RUN: FileCheck %s -input-file=%t.files_0.prop
+
+; CHECK: [SYCL/device requirements]
+; CHECK: fixed_target=2|gAAAAAAAAAQAAAAA
+
+source_filename = "main.cpp"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+$_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_EUlvE_ = comdat any
+
+; Function Attrs: convergent mustprogress noinline norecurse optnone
+define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_EUlvE_() #0 comdat {
+entry:
+  call spir_func void @_Z3foov()
+  ret void
+}
+
+; Function Attrs: convergent mustprogress noinline norecurse nounwind optnone
+define dso_local spir_func void @_Z3foov() !sycl_fixed_targets !3 {
+entry:
+  ret void
+}
+
+attributes #0 = { "sycl-module-id"="main.cpp" }
+
+!sycl_aspects = !{!1, !2}
+
+!1 = !{!"cpu", i32 1}
+!2 = !{!"fp64", i32 6}
+!3 = !{i32 1}

--- a/llvm/tools/sycl-post-link/SYCLDeviceRequirements.cpp
+++ b/llvm/tools/sycl-post-link/SYCLDeviceRequirements.cpp
@@ -28,19 +28,19 @@ void llvm::getSYCLDeviceRequirements(
   std::vector<std::pair<std::string, const char *>> ReqdMDs = {
       {"sycl_used_aspects", "aspects"}, {"sycl_fixed_targets", "fixed_target"}};
 
-  for (const Function &F : M) {
     for (const auto &MD : ReqdMDs) {
       std::set<uint32_t> Aspects;
-      if (F.hasMetadata(MD.first)) {
-        const MDNode *MDN = F.getMetadata(MD.first);
-        for (size_t I = 0, E = MDN->getNumOperands(); I < E; ++I)
-          Aspects.insert(ExtractIntegerFromMDNodeOperand(MDN, I));
+      for (const Function &F : M) {
+        if (F.hasMetadata(MD.first)) {
+          const MDNode *MDN = F.getMetadata(MD.first);
+          for (size_t I = 0, E = MDN->getNumOperands(); I < E; ++I)
+            Aspects.insert(ExtractIntegerFromMDNodeOperand(MDN, I));
+        }
       }
       // We don't need the "fixed_target" property if it's empty
       if (MD.first == "sycl_fixed_targets" && Aspects.empty())
         continue;
       Requirements[MD.second] =
           std::vector<uint32_t>(Aspects.begin(), Aspects.end());
-    }
   }
 }

--- a/llvm/tools/sycl-post-link/SYCLDeviceRequirements.cpp
+++ b/llvm/tools/sycl-post-link/SYCLDeviceRequirements.cpp
@@ -28,19 +28,19 @@ void llvm::getSYCLDeviceRequirements(
   std::vector<std::pair<std::string, const char *>> ReqdMDs = {
       {"sycl_used_aspects", "aspects"}, {"sycl_fixed_targets", "fixed_target"}};
 
-    for (const auto &MD : ReqdMDs) {
-      std::set<uint32_t> Aspects;
-      for (const Function &F : M) {
-        if (F.hasMetadata(MD.first)) {
-          const MDNode *MDN = F.getMetadata(MD.first);
-          for (size_t I = 0, E = MDN->getNumOperands(); I < E; ++I)
-            Aspects.insert(ExtractIntegerFromMDNodeOperand(MDN, I));
-        }
+  for (const auto &MD : ReqdMDs) {
+    std::set<uint32_t> Aspects;
+    for (const Function &F : M) {
+      if (F.hasMetadata(MD.first)) {
+        const MDNode *MDN = F.getMetadata(MD.first);
+        for (size_t I = 0, E = MDN->getNumOperands(); I < E; ++I)
+          Aspects.insert(ExtractIntegerFromMDNodeOperand(MDN, I));
       }
-      // We don't need the "fixed_target" property if it's empty
-      if (MD.first == "sycl_fixed_targets" && Aspects.empty())
-        continue;
-      Requirements[MD.second] =
-          std::vector<uint32_t>(Aspects.begin(), Aspects.end());
+    }
+    // We don't need the "fixed_target" property if it's empty
+    if (MD.first == "sycl_fixed_targets" && Aspects.empty())
+      continue;
+    Requirements[MD.second] =
+        std::vector<uint32_t>(Aspects.begin(), Aspects.end());
   }
 }

--- a/llvm/tools/sycl-post-link/SYCLDeviceRequirements.cpp
+++ b/llvm/tools/sycl-post-link/SYCLDeviceRequirements.cpp
@@ -25,20 +25,19 @@ void llvm::getSYCLDeviceRequirements(
     return static_cast<uint32_t>(C->getUniqueInteger().getZExtValue());
   };
 
-  std::vector<std::pair<std::string, const char *>> ReqdMDs = {
+  constexpr std::pair<const char *, const char *> ReqdMDs[] = {
       {"sycl_used_aspects", "aspects"}, {"sycl_fixed_targets", "fixed_target"}};
 
   for (const auto &MD : ReqdMDs) {
     std::set<uint32_t> Aspects;
     for (const Function &F : M) {
-      if (F.hasMetadata(MD.first)) {
-        const MDNode *MDN = F.getMetadata(MD.first);
+      if (const MDNode *MDN = F.getMetadata(MD.first)) {
         for (size_t I = 0, E = MDN->getNumOperands(); I < E; ++I)
           Aspects.insert(ExtractIntegerFromMDNodeOperand(MDN, I));
       }
     }
     // We don't need the "fixed_target" property if it's empty
-    if (MD.first == "sycl_fixed_targets" && Aspects.empty())
+    if (std::string(MD.first) == "sycl_fixed_targets" && Aspects.empty())
       continue;
     Requirements[MD.second] =
         std::vector<uint32_t>(Aspects.begin(), Aspects.end());

--- a/llvm/tools/sycl-post-link/SYCLDeviceRequirements.cpp
+++ b/llvm/tools/sycl-post-link/SYCLDeviceRequirements.cpp
@@ -25,6 +25,10 @@ void llvm::getSYCLDeviceRequirements(
     return static_cast<uint32_t>(C->getUniqueInteger().getZExtValue());
   };
 
+  // { LLVM-IR metadata name , [SYCL/Device requirements] property name }, see:
+  // https://github.com/intel/llvm/blob/sycl/sycl/doc/design/OptionalDeviceFeatures.md#create-the-sycldevice-requirements-property-set
+  // Scan the module and if the metadata is present fill the corresponing
+  // property with metadata's aspects
   constexpr std::pair<const char *, const char *> ReqdMDs[] = {
       {"sycl_used_aspects", "aspects"}, {"sycl_fixed_targets", "fixed_target"}};
 

--- a/llvm/tools/sycl-post-link/SYCLDeviceRequirements.cpp
+++ b/llvm/tools/sycl-post-link/SYCLDeviceRequirements.cpp
@@ -16,26 +16,31 @@
 
 using namespace llvm;
 
-std::map<StringRef, std::vector<uint32_t>>
-llvm::getSYCLDeviceRequirements(const Module &M) {
-  std::map<StringRef, std::vector<uint32_t>> Result;
+void llvm::getSYCLDeviceRequirements(
+    const Module &M, std::map<StringRef, std::vector<uint32_t>> &Requirements) {
   auto ExtractIntegerFromMDNodeOperand = [=](const MDNode *N,
                                              unsigned OpNo) -> unsigned {
     Constant *C =
         cast<ConstantAsMetadata>(N->getOperand(OpNo).get())->getValue();
     return static_cast<uint32_t>(C->getUniqueInteger().getZExtValue());
   };
-  std::set<uint32_t> Aspects;
-  for (const Function &F : M) {
-    if (!F.hasMetadata("sycl_used_aspects"))
-      continue;
 
-    const MDNode *MD = F.getMetadata("sycl_used_aspects");
-    for (size_t I = 0, E = MD->getNumOperands(); I < E; ++I) {
-      Aspects.insert(ExtractIntegerFromMDNodeOperand(MD, I));
+  std::vector<std::pair<std::string, const char *>> ReqdMDs = {
+      {"sycl_used_aspects", "aspects"}, {"sycl_fixed_targets", "fixed_target"}};
+
+  for (const Function &F : M) {
+    for (const auto &MD : ReqdMDs) {
+      std::set<uint32_t> Aspects;
+      if (F.hasMetadata(MD.first)) {
+        const MDNode *MDN = F.getMetadata(MD.first);
+        for (size_t I = 0, E = MDN->getNumOperands(); I < E; ++I)
+          Aspects.insert(ExtractIntegerFromMDNodeOperand(MDN, I));
+      }
+      // We don't need the "fixed_target" property if it's empty
+      if (MD.first == "sycl_fixed_targets" && Aspects.empty())
+        continue;
+      Requirements[MD.second] =
+          std::vector<uint32_t>(Aspects.begin(), Aspects.end());
     }
   }
-
-  Result["aspects"] = std::vector<uint32_t>(Aspects.begin(), Aspects.end());
-  return Result;
 }

--- a/llvm/tools/sycl-post-link/SYCLDeviceRequirements.h
+++ b/llvm/tools/sycl-post-link/SYCLDeviceRequirements.h
@@ -17,7 +17,7 @@ namespace llvm {
 class Module;
 class StringRef;
 
-std::map<StringRef, std::vector<uint32_t>>
-getSYCLDeviceRequirements(const Module &M);
+void getSYCLDeviceRequirements(
+    const Module &M, std::map<StringRef, std::vector<uint32_t>> &Requirements);
 
 } // namespace llvm

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -365,8 +365,8 @@ std::string saveModuleProperties(module_split::ModuleDesc &MD,
     PropSet.add(PropSetRegTy::SYCL_DEVICELIB_REQ_MASK, RMEntry);
   }
   {
-    std::map<StringRef, std::vector<uint32_t>> Requirements =
-        getSYCLDeviceRequirements(M);
+    std::map<StringRef, std::vector<uint32_t>> Requirements;
+    getSYCLDeviceRequirements(M, Requirements);
     PropSet.add(PropSetRegTy::SYCL_DEVICE_REQUIREMENTS, Requirements);
   }
   if (MD.Props.SpecConstsMet) {


### PR DESCRIPTION
In scope of implementation of the "SYCL/Device requirements" property set we need to create a "fixed_target" property if the "!sycl_fixed_targets" metadata is present in the IR and fill it with the corresponding aspects.