### PR TITLE
[SYCL] Turn read-only accessor iterator into const_iterator

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -1205,18 +1205,17 @@ private:
   friend class sycl::ext::intel::esimd::detail::AccessorPrivateProxy;
 
 public:
-  using value_type = DataT;
+  // 4.7.6.9.1. Interface for buffer command accessors
+  // value_type is defined as const DataT for read_only accessors, DataT
+  // otherwise
+  using value_type = typename std::conditional<AccessMode == access_mode::read,
+                                               const DataT, DataT>::type;
   using reference = DataT &;
   using const_reference = const DataT &;
 
-  // When accessor is read-only, we should not be able to modify it through the
-  // iterator and therefore, effectively returning const_iterator here
-  using iterator = typename detail::accessor_iterator<
-      typename std::conditional<AccessMode == access_mode::read, const DataT,
-                                DataT>::type,
-      Dimensions>;
+  using iterator = typename detail::accessor_iterator<value_type, Dimensions>;
   using const_iterator =
-      typename detail::accessor_iterator<const DataT, Dimensions>;
+      typename detail::accessor_iterator<const value_type, Dimensions>;
   using difference_type =
       typename std::iterator_traits<iterator>::difference_type;
 

--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -1209,7 +1209,12 @@ public:
   using reference = DataT &;
   using const_reference = const DataT &;
 
-  using iterator = typename detail::accessor_iterator<DataT, Dimensions>;
+  // When accessor is read-only, we should not be able to modify it through the
+  // iterator and therefore, effectively returning const_iterator here
+  using iterator = typename detail::accessor_iterator<
+      typename std::conditional<AccessMode == access_mode::read, const DataT,
+                                DataT>::type,
+      Dimensions>;
   using const_iterator =
       typename detail::accessor_iterator<const DataT, Dimensions>;
   using difference_type =

--- a/sycl/test/basic_tests/accessor/iterator-member-types.cpp
+++ b/sycl/test/basic_tests/accessor/iterator-member-types.cpp
@@ -11,36 +11,29 @@
 template <typename DataT, int Dimensions, sycl::access_mode AccessMode,
           sycl::target AccessTarget = sycl::target::device>
 void check_accessor() {
-  using IteratorDataT =
-      typename std::conditional<AccessMode == sycl::access_mode::read,
-                                const DataT, DataT>::type;
-  static_assert(
-      std::is_same_v<sycl::detail::accessor_iterator<IteratorDataT, Dimensions>,
-                     typename sycl::accessor<DataT, Dimensions, AccessMode,
-                                             AccessTarget>::iterator>);
+  using AccessorT =
+      typename sycl::accessor<DataT, Dimensions, AccessMode, AccessTarget>;
+  static_assert(std::is_same_v<sycl::detail::accessor_iterator<
+                                   typename AccessorT::value_type, Dimensions>,
+                               typename AccessorT::iterator>);
 
-  // const_iterator should always be specialized as const DataT
-  static_assert(std::is_same_v<
-                sycl::detail::accessor_iterator<const DataT, Dimensions>,
-                typename sycl::accessor<DataT, Dimensions, AccessMode,
-                                             AccessTarget>::const_iterator>);
+  static_assert(
+      std::is_same_v<sycl::detail::accessor_iterator<
+                         const typename AccessorT::value_type, Dimensions>,
+                     typename AccessorT::const_iterator>);
 }
 
 template <typename DataT, int Dimensions, sycl::access_mode AccessMode>
 void check_host_accessor() {
-  using IteratorDataT =
-      typename std::conditional<AccessMode == sycl::access_mode::read,
-                                const DataT, DataT>::type;
-  static_assert(
-      std::is_same_v<sycl::detail::accessor_iterator<IteratorDataT, Dimensions>,
-                     typename sycl::host_accessor<DataT, Dimensions,
-                                                  AccessMode>::iterator>);
+  using AccessorT = typename sycl::host_accessor<DataT, Dimensions, AccessMode>;
+  static_assert(std::is_same_v<sycl::detail::accessor_iterator<
+                                   typename AccessorT::value_type, Dimensions>,
+                               typename AccessorT::iterator>);
 
-  // const_iterator should always be specialized as const DataT
   static_assert(
-      std::is_same_v<sycl::detail::accessor_iterator<const DataT, Dimensions>,
-                     typename sycl::host_accessor<DataT, Dimensions,
-                                                  AccessMode>::const_iterator>);
+      std::is_same_v<sycl::detail::accessor_iterator<
+                         const typename AccessorT::value_type, Dimensions>,
+                     typename AccessorT::const_iterator>);
 }
 
 struct user_defined_t {
@@ -61,5 +54,4 @@ int main() {
   check_host_accessor<float, 3, sycl::access_mode::read_write>();
 
   return 0;
-
 }

--- a/sycl/test/basic_tests/accessor/iterator-member-types.cpp
+++ b/sycl/test/basic_tests/accessor/iterator-member-types.cpp
@@ -1,0 +1,65 @@
+// RUN: %clangxx -fsycl -c %s
+//
+// Purpose of this test is to check that [accessor|host_accessor]::iterator and
+// ::const_iterator are aliased to the correct type.
+// FIXME: extend this test to also check ::reverse_iterator and
+// ::const_reverse_iterator
+#include <sycl/sycl.hpp>
+
+#include <type_traits>
+
+template <typename DataT, int Dimensions, sycl::access_mode AccessMode,
+          sycl::target AccessTarget = sycl::target::device>
+void check_accessor() {
+  using IteratorDataT =
+      typename std::conditional<AccessMode == sycl::access_mode::read,
+                                const DataT, DataT>::type;
+  static_assert(
+      std::is_same_v<sycl::detail::accessor_iterator<IteratorDataT, Dimensions>,
+                     typename sycl::accessor<DataT, Dimensions, AccessMode,
+                                             AccessTarget>::iterator>);
+
+  // const_iterator should always be specialized as const DataT
+  static_assert(std::is_same_v<
+                sycl::detail::accessor_iterator<const DataT, Dimensions>,
+                typename sycl::accessor<DataT, Dimensions, AccessMode,
+                                             AccessTarget>::const_iterator>);
+}
+
+template <typename DataT, int Dimensions, sycl::access_mode AccessMode>
+void check_host_accessor() {
+  using IteratorDataT =
+      typename std::conditional<AccessMode == sycl::access_mode::read,
+                                const DataT, DataT>::type;
+  static_assert(
+      std::is_same_v<sycl::detail::accessor_iterator<IteratorDataT, Dimensions>,
+                     typename sycl::host_accessor<DataT, Dimensions,
+                                                  AccessMode>::iterator>);
+
+  // const_iterator should always be specialized as const DataT
+  static_assert(
+      std::is_same_v<sycl::detail::accessor_iterator<const DataT, Dimensions>,
+                     typename sycl::host_accessor<DataT, Dimensions,
+                                                  AccessMode>::const_iterator>);
+}
+
+struct user_defined_t {
+  char c;
+  float f;
+  double d;
+  sycl::vec<int, 3> v3;
+};
+
+int main() {
+
+  check_accessor<int, 1, sycl::access_mode::read>();
+  check_accessor<float, 2, sycl::access_mode::write>();
+  check_accessor<user_defined_t, 3, sycl::access_mode::read_write>();
+
+  check_host_accessor<user_defined_t, 1, sycl::access_mode::read>();
+  check_host_accessor<int, 2, sycl::access_mode::write>();
+  check_host_accessor<float, 3, sycl::access_mode::read_write>();
+
+  return 0;
+
+}


### PR DESCRIPTION
This is done to prevent ability to write to read-only accessor through iterators.