### PR TITLE
[SYCL] Switch _ExtInt to _BitInt in spirv_types.hpp

### DIFF
--- a/sycl/include/CL/__spirv/spirv_types.hpp
+++ b/sycl/include/CL/__spirv/spirv_types.hpp
@@ -180,7 +180,7 @@ namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace detail {
 // Arbitrary precision integer type
-template <int Bits> using ap_int = _ExtInt(Bits);
+template <int Bits> using ap_int = _BitInt(Bits);
 } // namespace detail
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl


### PR DESCRIPTION
_ExtInt has been deprecated in favor for _BitInt in the intel/llvm compiler, so the spirv_types.hpp header needs to be updated to using the right datatype. 