### PR TITLE
Revert "Cherry-pick of "Add SPIR-V 1.4 checks""

### DIFF
--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVDecorate.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVDecorate.h
@@ -94,8 +94,6 @@ public:
 
     case DecorationMaxByteOffset:
       return static_cast<SPIRVWord>(VersionNumber::SPIRV_1_1);
-    case DecorationUserSemantic:
-      return static_cast<SPIRVWord>(VersionNumber::SPIRV_1_4);
 
     default:
       return static_cast<SPIRVWord>(VersionNumber::SPIRV_1_0);
@@ -129,6 +127,9 @@ public:
 
   llvm::Optional<ExtensionID> getRequiredExtension() const override {
     switch (static_cast<size_t>(Dec)) {
+    case DecorationNoSignedWrap:
+    case DecorationNoUnsignedWrap:
+      return ExtensionID::SPV_KHR_no_integer_wrap_decoration;
     case DecorationRegisterINTEL:
     case DecorationMemoryINTEL:
     case DecorationNumbanksINTEL:

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -843,6 +843,12 @@ public:
 
   llvm::Optional<ExtensionID> getRequiredExtension() const override {
     switch (static_cast<unsigned>(Kind)) {
+    case CapabilityDenormPreserve:
+    case CapabilityDenormFlushToZero:
+    case CapabilitySignedZeroInfNanPreserve:
+    case CapabilityRoundingModeRTE:
+    case CapabilityRoundingModeRTZ:
+      return ExtensionID::SPV_KHR_float_controls;
     case CapabilityRoundToInfinityINTEL:
     case CapabilityFloatingPointModeINTEL:
     case CapabilityFunctionFloatControlINTEL:

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVValue.cpp
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVValue.cpp
@@ -75,8 +75,43 @@ bool SPIRVValue::hasNoSignedWrap() const {
   return hasDecorate(DecorationNoSignedWrap);
 }
 
+void SPIRVValue::setNoSignedWrap(bool HasNoSignedWrap) {
+  if (!HasNoSignedWrap) {
+    eraseDecorate(DecorationNoSignedWrap);
+  }
+  if (Module->isAllowedToUseExtension(
+          ExtensionID::SPV_KHR_no_integer_wrap_decoration)) {
+    // NoSignedWrap decoration is available only if it is allowed to use SPIR-V
+    // 1.4 or if SPV_KHR_no_integer_wrap_decoration extension is allowed
+    // FIXME: update this 'if' to include check for SPIR-V 1.4 once translator
+    // support this version
+    addDecorate(new SPIRVDecorate(DecorationNoSignedWrap, this));
+    SPIRVDBG(spvdbgs() << "Set nsw for obj " << Id << "\n")
+  } else {
+    SPIRVDBG(spvdbgs() << "Skip setting nsw for obj " << Id << "\n")
+  }
+}
+
 bool SPIRVValue::hasNoUnsignedWrap() const {
   return hasDecorate(DecorationNoUnsignedWrap);
+}
+
+void SPIRVValue::setNoUnsignedWrap(bool HasNoUnsignedWrap) {
+  if (!HasNoUnsignedWrap) {
+    eraseDecorate(DecorationNoUnsignedWrap);
+    return;
+  }
+  if (Module->isAllowedToUseExtension(
+          ExtensionID::SPV_KHR_no_integer_wrap_decoration)) {
+    // NoUnsignedWrap decoration is available only if it is allowed to use
+    // SPIR-V 1.4 or if SPV_KHR_no_integer_wrap_decoration extension is allowed
+    // FIXME: update this 'if' to include check for SPIR-V 1.4 once translator
+    // support this version
+    addDecorate(new SPIRVDecorate(DecorationNoUnsignedWrap, this));
+    SPIRVDBG(spvdbgs() << "Set nuw for obj " << Id << "\n")
+  } else {
+    SPIRVDBG(spvdbgs() << "Skip setting nuw for obj " << Id << "\n")
+  }
 }
 
 void SPIRVValue::setFPFastMathMode(SPIRVWord M) {
@@ -88,39 +123,6 @@ void SPIRVValue::setFPFastMathMode(SPIRVWord M) {
   SPIRVDBG(spvdbgs() << "Set fast math mode to " << M << " for obj " << Id
                      << "\n")
 }
-
-template <spv::Decoration NoIntegerWrapDecoration>
-void SPIRVValue::setNoIntegerDecorationWrap(bool HasNoIntegerWrap) {
-  if (!HasNoIntegerWrap) {
-    eraseDecorate(NoIntegerWrapDecoration);
-    return;
-  }
-  // NoSignedWrap and NoUnsignedWrap decorations are available only if it is
-  // allowed to use SPIR-V 1.4 or if SPV_KHR_no_integer_wrap_decoration
-  // extension is enabled
-#ifdef _SPIRVDBG
-  const std::string InstStr =
-      NoIntegerWrapDecoration == DecorationNoSignedWrap ? "nsw" : "nuw";
-#endif // _SPIRVDBG
-  if (Module->isAllowedToUseVersion(VersionNumber::SPIRV_1_4)) {
-    Module->setMinSPIRVVersion(VersionNumber::SPIRV_1_4);
-    addDecorate(new SPIRVDecorate(NoIntegerWrapDecoration, this));
-    SPIRVDBG(spvdbgs() << "Set " << InstStr << " for obj " << Id << "\n")
-  } else if (Module->isAllowedToUseExtension(
-                 ExtensionID::SPV_KHR_no_integer_wrap_decoration)) {
-    Module->addExtension(ExtensionID::SPV_KHR_no_integer_wrap_decoration);
-    addDecorate(new SPIRVDecorate(NoIntegerWrapDecoration, this));
-    SPIRVDBG(spvdbgs() << "Set " << InstStr << " for obj " << Id << "\n")
-  } else {
-    SPIRVDBG(spvdbgs() << "Skip setting " << InstStr << " for obj " << Id
-                       << "\n")
-  }
-}
-
-template void
-SPIRVValue::setNoIntegerDecorationWrap<DecorationNoSignedWrap>(bool);
-template void
-SPIRVValue::setNoIntegerDecorationWrap<DecorationNoUnsignedWrap>(bool);
 
 template <spv::Op OC>
 void SPIRVConstantBase<OC>::setWords(const uint64_t *TheValue) {

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVValue.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVValue.h
@@ -98,10 +98,8 @@ public:
 
   void setAlignment(SPIRVWord);
   void setVolatile(bool IsVolatile);
-
-  template <spv::Decoration NoIntegerWrapDecoration>
-  void setNoIntegerDecorationWrap(bool HasNoIntegerWrap);
-
+  void setNoSignedWrap(bool HasNoSignedWrap);
+  void setNoUnsignedWrap(bool HasNoUnsignedWrap);
   void setFPFastMathMode(SPIRVWord FPFastMathMode);
 
   void validate() const override {

--- a/llvm-spirv/test/exec_mode_float_control_khr.ll
+++ b/llvm-spirv/test/exec_mode_float_control_khr.ll
@@ -1,13 +1,7 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -o %t.spv --spirv-max-version=1.1 --spirv-ext=+SPV_KHR_float_controls
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_KHR_float_controls
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
-; RUN: FileCheck %s --input-file %t.spt -check-prefixes=SPV,SPVEXT
-; RUN: llvm-spirv %t.bc -o %t.spv --spirv-max-version=1.4
-; RUN: llvm-spirv %t.spv -o %t.spt --to-text
-; RUN: FileCheck %s --input-file %t.spt -check-prefixes=SPV,SPV14
-; RUN: llvm-spirv %t.bc -o %t.spv --spirv-max-version=1.1
-; RUN: llvm-spirv %t.spv -o %t.spt --to-text
-; RUN: FileCheck %s --input-file %t.spt -check-prefix=SPV-NEGATIVE
+; RUN: FileCheck %s --input-file %t.spt -check-prefix=SPV
 
 ; ModuleID = 'float_control.bc'
 source_filename = "float_control.cpp"
@@ -49,10 +43,6 @@ entry:
 !llvm.ident = !{!13}
 !spirv.EntryPoint = !{}
 !spirv.ExecutionMode = !{!15, !16, !17, !18, !19, !20, !21, !22, !23, !24, !25, !26, !27, !28, !29}
-
-; SPVEXT-DAG: Extension "SPV_KHR_float_controls"
-; SPV14-NOT: Extension "SPV_KHR_float_controls"
-; SPV-NEGATIVE-NOT: Extension "SPV_KHR_float_controls"
 
 ; SPV-DAG: EntryPoint {{[0-9]+}} [[KERNEL0:[0-9]+]] "k_float_controls_0"
 ; SPV-DAG: EntryPoint {{[0-9]+}} [[KERNEL1:[0-9]+]] "k_float_controls_1"

--- a/llvm-spirv/test/transcoding/LoopUnroll.ll
+++ b/llvm-spirv/test/transcoding/LoopUnroll.ll
@@ -42,13 +42,6 @@
 ; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV
 ; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
 ; RUN: llvm-dis %t.rev.bc -o - | FileCheck %s --check-prefixes=CHECK-LLVM
-; RUN: llvm-spirv %t.bc -o %t.spv --spirv-max-version=1.1
-; RUN: llvm-spirv -to-text %t.spv -o %t.spt
-; RUN: FileCheck < %t.spt %s --check-prefix=CHECK-SPIRV-NEGATIVE
-
-; Check SPIR-V versions in a format magic number + version
-; CHECK-SPIRV: 119734787 66560
-; CHECK-SPIRV-NEGATIVE: 119734787 65536
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64"
@@ -122,7 +115,6 @@ while.cond:                                       ; preds = %if.end, %if.then, %
 ; Per SPIRV spec p3.23 "Unroll" loop control = 0x1
 ; CHECK-SPIRV: LoopMerge [[#MERGEBLOCK:]] [[#CONTINUE:]] 256 8
 ; CHECK-SPIRV: BranchConditional [[#]] [[#]] [[#MERGEBLOCK]]
-; CHECK-SPIRV-NEGATIVE-NOT: LoopMerge {{.*}} 256
   br i1 %cmp, label %while.body, label %while.end
 
 while.body:                                       ; preds = %while.cond

--- a/llvm-spirv/test/transcoding/NoSignedUnsignedWrap.ll
+++ b/llvm-spirv/test/transcoding/NoSignedUnsignedWrap.ll
@@ -8,15 +8,10 @@
 ; Positive tests:
 ;
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc --spirv-max-version=1.1 --spirv-ext=+SPV_KHR_no_integer_wrap_decoration -spirv-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-EXT
-; RUN: llvm-spirv %t.bc --spirv-max-version=1.1 --spirv-ext=+SPV_KHR_no_integer_wrap_decoration -o %t.spv
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_KHR_no_integer_wrap_decoration -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_KHR_no_integer_wrap_decoration -o %t.spv
 ; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv --spirv-max-version=1.1 --spirv-ext=+SPV_KHR_no_integer_wrap_decoration -o %t.rev.bc
-; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
-; RUN: llvm-spirv %t.bc --spirv-max-version=1.4 -spirv-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV,CHECK-SPIRV-NOEXT
-; RUN: llvm-spirv %t.bc --spirv-max-version=1.4 -o %t.spv
-; RUN: spirv-val %t.spv
-; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv --spirv-max-version=1.4 -o %t.rev.bc
+; RUN: llvm-spirv -r %t.spv --spirv-ext=+SPV_KHR_no_integer_wrap_decoration -o %t.rev.bc
 ; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM
 ;
 ; During consumption, any SPIR-V extension must be accepted by default
@@ -26,29 +21,29 @@
 ;
 ; Negative tests:
 ;
-; Check that translator is able to skip nsw/nuw attributes if extension is
-; disabled implicitly or explicitly and if max SPIR-V version is lower then 1.4
+; Check that translator is able to reject SPIR-V if extension is disallowed
 ;
-; RUN: llvm-spirv %t.bc --spirv-max-version=1.1 -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV-NEGATIVE
-; RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -o %t.spv
-; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
-; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM-NEGATIVE
+; RUN: not llvm-spirv -r %t.spv --spirv-ext=-SPV_KHR_no_integer_wrap_decoration -o - 2>&1 | FileCheck %s --check-prefix=CHECK-INVALID-SPIRV
 ;
-; RUN: llvm-spirv %t.bc --spirv-max-version=1.1 --spirv-ext=-SPV_KHR_no_integer_wrap_decoration -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV-NEGATIVE
-; RUN: llvm-spirv %t.bc --spirv-max-version=1.1 --spirv-ext=-SPV_KHR_no_integer_wrap_decoration -o %t.spv
-; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.rev.bc
-; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM-NEGATIVE
+; Check that translator is able to skip nsw/nuw attributes if extension is disabled implicitly or explicitly
+;
+; RUN: llvm-spirv %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV-NOEXT
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM-NOEXT
+;
+; RUN: llvm-spirv %t.bc --spirv-ext=-SPV_KHR_no_integer_wrap_decoration -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV-NOEXT
+; RUN: llvm-spirv %t.bc --spirv-ext=-SPV_KHR_no_integer_wrap_decoration -o %t.spv
+; RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+; RUN: llvm-dis < %t.rev.bc | FileCheck %s --check-prefix=CHECK-LLVM-NOEXT
 
-; Check SPIR-V versions in a format magic number + version
-; CHECK-SPIRV-EXT: 119734787 65536
-; CHECK-SPIRV-EXT: Extension "SPV_KHR_no_integer_wrap_decoration"
-; CHECK-SPIRV-NOEXT: 119734787 66560
+; CHECK-SPIRV: Extension "SPV_KHR_no_integer_wrap_decoration"
 ; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} NoSignedWrap
 ; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} NoUnsignedWrap
 ;
-; CHECK-SPIRV-NEGATIVE-NOT: Extension "SPV_KHR_no_integer_wrap_decoration"
-; CHECK-SPIRV-NEGATIVE-NOT: Decorate {{[0-9]+}} NoSignedWrap
-; CHECK-SPIRV-NEGATIVE-NOT: Decorate {{[0-9]+}} NoUnsignedWrap
+; CHECK-SPIRV-NOEXT-NOT: Extension "SPV_KHR_no_integer_wrap_decoration"
+; CHECK-SPIRV-NOEXT-NOT: Decorate {{[0-9]+}} NoSignedWrap
+; CHECK-SPIRV-NOEXT-NOT: Decorate {{[0-9]+}} NoUnsignedWrap
 ;
 ; CHECK-INVALID-SPIRV: input SPIR-V module uses extension 'SPV_KHR_no_integer_wrap_decoration' which were disabled
 
@@ -60,7 +55,7 @@ define spir_func i32 @square(i16 zeroext %a) local_unnamed_addr #0 {
 entry:
   %conv = zext i16 %a to i32
   ; CHECK-LLVM: mul nuw nsw
-  ; CHECK-LLVM-NEGATIVE: mul i32
+  ; CHECK-LLVM-NOEXT: mul i32
   %mul = mul nuw nsw i32 %conv, %conv
   ret i32 %mul
 }

--- a/llvm-spirv/test/transcoding/SPV_INTEL_vector_compute/exec_mode_float_control.ll
+++ b/llvm-spirv/test/transcoding/SPV_INTEL_vector_compute/exec_mode_float_control.ll
@@ -1,14 +1,10 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -o %t.spv --spirv-max-version=1.1 --spirv-ext=+SPV_INTEL_vector_compute,+SPV_KHR_float_controls,+SPV_INTEL_float_controls2
+; RUN: llvm-spirv %t.bc -o %t.spv --spirv-ext=+SPV_INTEL_vector_compute,+SPV_KHR_float_controls,+SPV_INTEL_float_controls2
 ; RUN: llvm-spirv %t.spv -o %t.spt --to-text
 ; RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o %t.bc
 ; RUN: llvm-dis %t.bc -o %t.ll
-; RUN: FileCheck %s --input-file %t.spt -check-prefixes=SPV,SPVEXT
+; RUN: FileCheck %s --input-file %t.spt -check-prefix=SPV
 ; RUN: FileCheck %s --input-file %t.ll  -check-prefix=LLVM
-
-; RUN: llvm-spirv %t.bc -o %t.spv --spirv-max-version=1.4 --spirv-ext=+SPV_INTEL_vector_compute,+SPV_INTEL_float_controls2
-; RUN: llvm-spirv %t.spv -o %t.spt --to-text
-; RUN: FileCheck %s --input-file %t.spt -check-prefixes=SPV,SPV14
 
 
 ; ModuleID = 'float_control.bc'
@@ -17,8 +13,7 @@ target datalayout = "e-p:64:64-i64:64-n8:16:32"
 target triple = "spir"
 
 
-; SPVEXT-DAG: Extension "SPV_KHR_float_controls"
-; SPV14-NOT: Extension "SPV_KHR_float_controls"
+; SPV-DAG: Extension "SPV_KHR_float_controls"
 ; SPV-DAG: Extension "SPV_INTEL_float_controls2"
 
 ; LLVM-DAG: @k_rte{{[^a-zA-Z0-9_][^#]*}}#[[K_RTE:[0-9]+]]

--- a/llvm-spirv/test/transcoding/annotate_attribute.ll
+++ b/llvm-spirv/test/transcoding/annotate_attribute.ll
@@ -10,9 +10,6 @@
 ; RUN: llvm-as %s -o %t.bc
 ; RUN: llvm-spirv %t.bc --spirv-ext=+SPV_INTEL_fpga_memory_accesses,+SPV_INTEL_fpga_memory_attributes -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
-; Check SPIR-V versions in a format magic number + version
-; CHECK-SPIRV: 119734787 66560
-
 ; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} UserSemantic "42"
 ; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} UserSemantic "bar"
 ; CHECK-SPIRV-DAG: Decorate {{[0-9]+}} UserSemantic "{FOO}"

--- a/llvm-spirv/test/transcoding/block_w_struct_return.cl
+++ b/llvm-spirv/test/transcoding/block_w_struct_return.cl
@@ -1,19 +1,18 @@
 // RUN: %clang_cc1 -triple spir -cl-std=cl2.0 -disable-llvm-passes -fdeclare-opencl-builtins -finclude-default-header %s -emit-llvm-bc -o %t.bc -no-opaque-pointers
-// TODO: currently max version is limited to 1.1 for this test. Issues here
-// that the SPIR-V module generated for blocks is invalid for versions starting
-// from 1.4, spirv-val is failing with:
-//   error: line 63: Interface variable id <13> is used by entry point
-//                   'block_kernel' id <24>, but is not listed as an interface
-//   %__block_literal_global = OpVariable %_ptr_CrossWorkgroup__struct_10
-//                         CrossWorkgroup %11
-// details can be found in:
-// – Public issue #35: OpEntryPoint must list all global variables in the
-//   interface. Additionally, duplication in the list is not allowed.
-// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -spirv-text -o %t.spv.txt
-// RUN: FileCheck < %t.spv.txt %s --check-prefix=CHECK-SPIRV
-// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -o %t.spv
-// RUN: spirv-val %t.spv
-// RUN: llvm-spirv -r %t.spv -o %t.rev.bc
+
+// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -spirv-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV
+// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -o %t.spirv1.1.spv
+// RUN: spirv-val --target-env spv1.1 %t.spirv1.1.spv
+// RUN: llvm-spirv -r -emit-opaque-pointers %t.spirv1.1.spv -o %t.rev.bc
+// RUN: llvm-dis %t.rev.bc
+// RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
+
+// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -spirv-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV
+// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -o %t.spirv1.4.spv
+// RUN: spirv-val --target-env spv1.4 %t.spirv1.4.spv
+// RUN: llvm-spirv -r -emit-opaque-pointers %t.spirv1.4.spv -o %t.rev.bc
+// RUN: llvm-dis %t.rev.bc
+// RUN: FileCheck < %t.rev.ll %s --check-prefix=CHECK-LLVM
 
 kernel void block_ret_struct(__global int* res)
 {
@@ -31,13 +30,6 @@ kernel void block_ret_struct(__global int* res)
   aa.a = 5;
   res[tid] = kernelBlock(aa).a - 6;
 }
-
-// CHECK-SPIRV1_4: EntryPoint 6 [[#]] "block_ret_struct" [[#InterdaceId1:]] [[#InterdaceId2:]]
-// CHECK-SPIRV1_4: Name [[#InterdaceId1]] "__block_literal_global"
-// CHECK-SPIRV1_4: Name [[#InterdaceId2]] "__spirv_BuiltInGlobalInvocationId"
-
-// CHECK-SPIRV1_1: EntryPoint 6 [[#]] "block_ret_struct" [[#InterdaceId1:]]
-// CHECK-SPIRV1_1: Name [[#InterdaceId1]] "__spirv_BuiltInGlobalInvocationId"
 
 // CHECK-SPIRV: Name [[BlockInv:[0-9]+]] "__block_ret_struct_block_invoke"
 

--- a/llvm-spirv/test/transcoding/global_block.cl
+++ b/llvm-spirv/test/transcoding/global_block.cl
@@ -4,20 +4,16 @@
 // removed
 
 // RUN: %clang_cc1 -O0 -triple spir-unknown-unknown -cl-std=CL2.0 -x cl %s -emit-llvm-bc -o %t.bc -no-opaque-pointers
-// TODO: currently max version is limited to 1.1 for this test. Issues here
-// that the SPIR-V module generated for blocks is invalid for versions starting
-// from 1.4, spirv-val is failing with:
-//   error: line 63: Interface variable id <13> is used by entry point
-//                   'block_kernel' id <24>, but is not listed as an interface
-//   %__block_literal_global = OpVariable %_ptr_CrossWorkgroup__struct_10
-//                         CrossWorkgroup %11
-// details can be found in:
-// – Public issue #35: OpEntryPoint must list all global variables in the
-//   interface. Additionally, duplication in the list is not allowed.
+
 // RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -spirv-text -o - | FileCheck %s --check-prefix=CHECK-SPIRV
-// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -o %t.spv
-// RUN: spirv-val %t.spv
-// RUN: llvm-spirv -r -emit-opaque-pointers %t.spv -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: llvm-spirv --spirv-max-version=1.1 %t.bc -o %t.spirv1.1.spv
+// RUN: spirv-val --target-env spv1.1 %t.spirv1.1.spv
+// RUN: llvm-spirv -r -emit-opaque-pointers %t.spirv1.1.spv -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
+
+// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -spirv-text -o - | FileCheck %s --check-prefixes=CHECK-SPIRV
+// RUN: llvm-spirv --spirv-max-version=1.4 %t.bc -o %t.spirv1.4.spv
+// RUN: spirv-val --target-env spv1.4 %t.spirv1.4.spv
+// RUN: llvm-spirv -r -emit-opaque-pointers %t.spirv1.4.spv -o - | llvm-dis | FileCheck %s --check-prefix=CHECK-LLVM
 
 kernel void block_kernel(__global int* res) {
   typedef int (^block_t)(int);


### PR DESCRIPTION
Reverts intel/llvm#6899
It causes regressions of ESIMD tests on Windows