### PR TITLE
[SYCL] Fix properties_kernel_negative for Windows

### DIFF
--- a/sycl/test/extensions/properties/properties_kernel_negative.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_negative.cpp
@@ -84,77 +84,77 @@ void check_work_group_size() {
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
   // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.+}}: Template type is not a property list.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size<1>},
       KernelFunctorWithWGSize<2>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<1, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<1, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size<1, 1>},
       KernelFunctorWithWGSize<1, 2>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<2, 1>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<2, 1>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size<1, 1>},
       KernelFunctorWithWGSize<2, 1>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<2, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<2, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size<1, 1>},
       KernelFunctorWithWGSize<2, 2>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<1, 1, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<1, 1, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size<1, 1, 1>},
       KernelFunctorWithWGSize<1, 1, 2>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<1, 2, 1>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<1, 2, 1>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size<1, 1, 1>},
       KernelFunctorWithWGSize<1, 2, 1>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<2, 1, 1>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<2, 1, 1>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size<1, 1, 1>},
       KernelFunctorWithWGSize<2, 1, 1>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<1, 2, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<1, 2, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size<1, 1, 1>},
       KernelFunctorWithWGSize<1, 2, 2>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<2, 2, 1>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<2, 2, 1>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size<1, 1, 1>},
       KernelFunctorWithWGSize<2, 2, 1>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<2, 1, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<2, 1, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size<1, 1, 1>},
       KernelFunctorWithWGSize<2, 1, 2>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<2, 2, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSize<2, 2, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size<1, 1, 1>},
@@ -221,77 +221,77 @@ void check_work_group_size_hint() {
   sycl::queue Q;
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size_hint<1>},
       KernelFunctorWithWGSizeHint<2>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<1, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<1, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size_hint<1, 1>},
       KernelFunctorWithWGSizeHint<1, 2>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<2, 1>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<2, 1>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size_hint<1, 1>},
       KernelFunctorWithWGSizeHint<2, 1>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<2, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<2, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size_hint<1, 1>},
       KernelFunctorWithWGSizeHint<2, 2>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<1, 1, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<1, 1, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size_hint<1, 1, 1>},
       KernelFunctorWithWGSizeHint<1, 1, 2>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<1, 2, 1>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<1, 2, 1>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size_hint<1, 1, 1>},
       KernelFunctorWithWGSizeHint<1, 2, 1>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<2, 1, 1>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<2, 1, 1>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size_hint<1, 1, 1>},
       KernelFunctorWithWGSizeHint<2, 1, 1>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<1, 2, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<1, 2, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size_hint<1, 1, 1>},
       KernelFunctorWithWGSizeHint<1, 2, 2>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<2, 2, 1>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<2, 2, 1>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size_hint<1, 1, 1>},
       KernelFunctorWithWGSizeHint<2, 2, 1>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<2, 1, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<2, 1, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size_hint<1, 1, 1>},
       KernelFunctorWithWGSizeHint<2, 1, 2>{});
 
   // expected-error-re@sycl/ext/oneapi/properties/property_utils.hpp:* {{static assertion failed due to requirement {{.+}}: Failed to merge property lists due to conflicting properties.}}
-  // expected-note@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<2, 2, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>, std::integral_constant<unsigned long, 1>>>>>' requested here}}
+  // expected-note-re@+1 {{in instantiation of function template specialization 'sycl::queue::single_task<sycl::detail::auto_name, KernelFunctorWithWGSizeHint<2, 2, 2>, sycl::ext::oneapi::experimental::properties<std::tuple<sycl::ext::oneapi::experimental::property_value<sycl::ext::oneapi::experimental::work_group_size_hint_key, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>, std::integral_constant<unsigned long{{( long)?}}, 1>>>>>' requested here}}
   Q.single_task(
       sycl::ext::oneapi::experimental::properties{
           sycl::ext::oneapi::experimental::work_group_size_hint<1, 1, 1>},


### PR DESCRIPTION
Windows uses long long for uint62_t while the expected notes in properties_kernel_negative assumed long was the corresponding type. This commit makes the notes assume either long or long long.