### PR TITLE
[SYCL-MLIR] Don't build with shared libraries

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -92,7 +92,6 @@ jobs:
         cd $GITHUB_WORKSPACE/build
         python3 $GITHUB_WORKSPACE/src/buildbot/configure.py -w $GITHUB_WORKSPACE \
           -s $GITHUB_WORKSPACE/src -o $GITHUB_WORKSPACE/build -t Release \
-          --shared-libs \
           --ci-defaults $ARGS \
           --cmake-opt="-DLLVM_CCACHE_BUILD=ON" \
           --cmake-opt="-DLLVM_CCACHE_DIR=$CACHE_ROOT/build_cache_$CACHE_SUFFIX" \


### PR DESCRIPTION
In https://github.com/intel/llvm/pull/6913, we have changed the buildbot to build the compiler using shared libraries.
The `install` directory in `build` is packed as a toolchain to be used for testing with `llvm_test_suite`.
```
    - name: Pack toolchain
      run: tar -cJf llvm_sycl.tar.xz -C $GITHUB_WORKSPACE/build/install .
```

Some shared objects (e.g., libLLVMX86CodeGen.so.16) are missing from the `install/lib` directory, which makes all compilation fail.
```
      /__w/llvm/llvm/toolchain/bin/clang++     -o CMakeFiles/cmTC_ed455.dir/testCXXCompiler.cxx.o -c testCXXCompiler.cxx
      /__w/llvm/llvm/toolchain/bin/clang++: error while loading shared libraries: libLLVMX86CodeGen.so.16git: cannot open shared object file: No such file or directory
```

This PR undo the shared libraries change, to unblock testing with test suite.
We should investigate why some shared objects are missing from the `install/lib` directory.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>