### PR TITLE
[SYCL-MLIR] Fix SYCLGetGroup verification error message

### DIFF
--- a/mlir-sycl/lib/Dialect/IR/SYCLTraits.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLTraits.cpp
@@ -179,5 +179,5 @@ mlir::LogicalResult mlir::sycl::verifySYCLGetRangeTrait(Operation *Op) {
 
 mlir::LogicalResult mlir::sycl::verifySYCLGetGroupTrait(Operation *Op) {
   return verifyGetSYCLTyOperation(cast<mlir::sycl::SYCLMethodOpInterface>(Op),
-                                  "range");
+                                  "group");
 }


### PR DESCRIPTION
Display proper type name when there is a mismatch in the return type.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>