### PR TITLE
[SYCL] Fix sycl-prof JSON output

### DIFF
--- a/sycl/tools/sycl-prof/writer.hpp
+++ b/sycl/tools/sycl-prof/writer.hpp
@@ -72,6 +72,10 @@ public:
     if (!MOutFile.is_open())
       return;
 
+    // add an empty element for not ending with '}, ]'
+    MOutFile << "{\"name\": \"\", \"cat\": \"\", \"ph\": \"\", \"pid\": \"\", "
+                "\"tid\": \"\", \"ts\": \"\"}\n";
+
     MOutFile << "],\n";
     MOutFile << "\"displayTimeUnit\":\"ns\"\n}\n";
     MOutFile.close();


### PR DESCRIPTION
This patch fixes a problem related to the JSON output. Every element of `"traceEvents"` has a comma appended, this is a problem in the case of the last element, e.g.,
```
{
  "traceEvents": [ 
 ...
{"name": "piTearDown", ... , "ts": "16..81"}, <-- here is  
],
"displayTimeUnit":"ns"
}
```
This comma prevents the display of the JSON output in `chrome://tracing/` or [speedscope](https://www.speedscope.app/) due to its invalid format. This patch solves the problem by adding an empty element before finalizing the JSON output.