### PR TITLE
[SYCL] Improve mock PI plugin

### DIFF
--- a/sycl/unittests/SYCL2020/GetNativeOpenCL.cpp
+++ b/sycl/unittests/SYCL2020/GetNativeOpenCL.cpp
@@ -86,16 +86,18 @@ TEST(GetNative, GetNativeHandle) {
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
 
-  Mock.redefine<detail::PiApiKind::piEventGetInfo>(redefinedEventGetInfo);
-  Mock.redefine<detail::PiApiKind::piContextRetain>(redefinedContextRetain);
-  Mock.redefine<detail::PiApiKind::piQueueRetain>(redefinedQueueRetain);
-  Mock.redefine<detail::PiApiKind::piDeviceRetain>(redefinedDeviceRetain);
-  Mock.redefine<detail::PiApiKind::piProgramRetain>(redefinedProgramRetain);
-  Mock.redefine<detail::PiApiKind::piEventRetain>(redefinedEventRetain);
-  Mock.redefine<detail::PiApiKind::piMemRetain>(redefinedMemRetain);
-  Mock.redefine<sycl::detail::PiApiKind::piMemBufferCreate>(
+  Mock.redefineBefore<detail::PiApiKind::piEventGetInfo>(redefinedEventGetInfo);
+  Mock.redefineBefore<detail::PiApiKind::piContextRetain>(
+      redefinedContextRetain);
+  Mock.redefineBefore<detail::PiApiKind::piQueueRetain>(redefinedQueueRetain);
+  Mock.redefineBefore<detail::PiApiKind::piDeviceRetain>(redefinedDeviceRetain);
+  Mock.redefineBefore<detail::PiApiKind::piProgramRetain>(
+      redefinedProgramRetain);
+  Mock.redefineBefore<detail::PiApiKind::piEventRetain>(redefinedEventRetain);
+  Mock.redefineBefore<detail::PiApiKind::piMemRetain>(redefinedMemRetain);
+  Mock.redefineBefore<sycl::detail::PiApiKind::piMemBufferCreate>(
       redefinedMemBufferCreate);
-  Mock.redefine<detail::PiApiKind::piextUSMEnqueueMemset>(
+  Mock.redefineBefore<detail::PiApiKind::piextUSMEnqueueMemset>(
       redefinedUSMEnqueueMemset);
 
   context Context(Plt);

--- a/sycl/unittests/assert/assert.cpp
+++ b/sycl/unittests/assert/assert.cpp
@@ -175,11 +175,9 @@ static int MemoryMapCounter = MemoryMapCounterBase;
 static constexpr int PauseWaitOnIdx = KernelLaunchCounterBase + 1;
 
 // Mock redifinitions
-static pi_result redefinedKernelGetGroupInfo(pi_kernel kernel, pi_device device,
-                                             pi_kernel_group_info param_name,
-                                             size_t param_value_size,
-                                             void *param_value,
-                                             size_t *param_value_size_ret) {
+static pi_result redefinedKernelGetGroupInfoAfter(
+    pi_kernel kernel, pi_device device, pi_kernel_group_info param_name,
+    size_t param_value_size, void *param_value, size_t *param_value_size_ret) {
   if (param_name == PI_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE) {
     if (param_value_size_ret) {
       *param_value_size_ret = 3 * sizeof(size_t);
@@ -194,25 +192,23 @@ static pi_result redefinedKernelGetGroupInfo(pi_kernel kernel, pi_device device,
   return PI_SUCCESS;
 }
 
-static pi_result redefinedEnqueueKernelLaunch(pi_queue, pi_kernel, pi_uint32,
-                                              const size_t *, const size_t *,
-                                              const size_t *LocalSize,
-                                              pi_uint32 N, const pi_event *Deps,
-                                              pi_event *RetEvent) {
-  int *Ret = new int[1];
-  *Ret = KernelLaunchCounter++;
+static pi_result
+redefinedEnqueueKernelLaunchAfter(pi_queue, pi_kernel, pi_uint32,
+                                  const size_t *, const size_t *,
+                                  const size_t *LocalSize, pi_uint32 NDeps,
+                                  const pi_event *Deps, pi_event *RetEvent) {
+  static pi_event UserKernelEvent = *RetEvent;
+  int Val = KernelLaunchCounter++;
   // This output here is to reduce amount of time requried to debug/reproduce a
   // failing test upon feature break
-  printf("Enqueued %i\n", *Ret);
+  printf("Enqueued %i\n", Val);
 
-  if (PauseWaitOnIdx == *Ret) {
+  if (PauseWaitOnIdx == Val) {
     // It should be copier kernel. Check if it depends on user's one.
-    EXPECT_EQ(N, 1U);
-    int EventIdx = reinterpret_cast<int *>(Deps[0])[0];
-    EXPECT_EQ(EventIdx, 0);
+    EXPECT_EQ(NDeps, 1U);
+    EXPECT_EQ(Deps[0], UserKernelEvent);
   }
 
-  *RetEvent = reinterpret_cast<pi_event>(Ret);
   return PI_SUCCESS;
 }
 
@@ -243,56 +239,30 @@ static pi_result redefinedEventsWaitNegative(pi_uint32 num_events,
   return PI_SUCCESS;
 }
 
-static pi_result
-redefinedMemBufferCreate(pi_context context, pi_mem_flags flags, size_t size,
-                         void *host_ptr, pi_mem *ret_mem,
-                         const pi_mem_properties *properties = nullptr) {
-  static size_t MemAddrCounter = 1;
-  *ret_mem = (pi_mem)MemAddrCounter++;
-  return PI_SUCCESS;
-}
-
-static pi_result redefinedMemRelease(pi_mem mem) { return PI_SUCCESS; }
-
-static pi_result redefinedKernelSetArg(pi_kernel kernel, pi_uint32 arg_index,
-                                       size_t arg_size, const void *arg_value) {
-  return PI_SUCCESS;
-}
-
-static pi_result redefinedEnqueueMemBufferMap(
+static pi_result redefinedEnqueueMemBufferMapAfter(
     pi_queue command_queue, pi_mem buffer, pi_bool blocking_map,
     pi_map_flags map_flags, size_t offset, size_t size,
     pi_uint32 num_events_in_wait_list, const pi_event *event_wait_list,
     pi_event *RetEvent, void **RetMap) {
-  int *Ret = new int[1];
-  *Ret = MemoryMapCounter++;
+  MemoryMapCounter++;
   // This output here is to reduce amount of time requried to debug/reproduce a
   // failing test upon feature break
-  printf("Memory map %i\n", *Ret);
-  *RetEvent = reinterpret_cast<pi_event>(Ret);
+  printf("Memory map %i\n", MemoryMapCounter);
 
   *RetMap = (void *)&ExpectedToOutput;
 
   return PI_SUCCESS;
 }
 
-static pi_result redefinedExtKernelSetArgMemObj(pi_kernel kernel,
-                                                pi_uint32 arg_index,
-                                                const pi_mem *arg_value) {
-  return PI_SUCCESS;
-}
-
 static void setupMock(sycl::unittest::PiMock &Mock) {
   using namespace sycl::detail;
-  Mock.redefine<PiApiKind::piKernelGetGroupInfo>(redefinedKernelGetGroupInfo);
-  Mock.redefine<PiApiKind::piEnqueueKernelLaunch>(redefinedEnqueueKernelLaunch);
-  Mock.redefine<PiApiKind::piMemBufferCreate>(redefinedMemBufferCreate);
-  Mock.redefine<PiApiKind::piMemRelease>(redefinedMemRelease);
-  Mock.redefine<PiApiKind::piKernelSetArg>(redefinedKernelSetArg);
-  Mock.redefine<PiApiKind::piEnqueueMemBufferMap>(redefinedEnqueueMemBufferMap);
-  Mock.redefine<PiApiKind::piEventsWait>(redefinedEventsWaitPositive);
-  Mock.redefine<PiApiKind::piextKernelSetArgMemObj>(
-      redefinedExtKernelSetArgMemObj);
+  Mock.redefineAfter<PiApiKind::piKernelGetGroupInfo>(
+      redefinedKernelGetGroupInfoAfter);
+  Mock.redefineAfter<PiApiKind::piEnqueueKernelLaunch>(
+      redefinedEnqueueKernelLaunchAfter);
+  Mock.redefineAfter<PiApiKind::piEnqueueMemBufferMap>(
+      redefinedEnqueueMemBufferMapAfter);
+  Mock.redefineBefore<PiApiKind::piEventsWait>(redefinedEventsWaitPositive);
 }
 
 namespace TestInteropKernel {
@@ -317,12 +287,15 @@ static pi_result redefinedKernelGetInfo(pi_kernel Kernel,
   }
 
   if (PI_KERNEL_INFO_PROGRAM == ParamName) {
-    cl_program X = (cl_program)1;
+    pi_program PIProgram = nullptr;
+    pi_result Res = mock_piProgramCreate(/*pi_context=*/0x0, /**il*/ nullptr,
+                                         /*length=*/0, &PIProgram);
+    assert(PI_SUCCESS == Res);
 
     if (ParamValue)
-      memcpy(ParamValue, &X, sizeof(X));
+      memcpy(ParamValue, &PIProgram, sizeof(PIProgram));
     if (ParamValueSizeRet)
-      *ParamValueSizeRet = sizeof(X);
+      *ParamValueSizeRet = sizeof(PIProgram);
 
     return PI_SUCCESS;
   }
@@ -350,13 +323,11 @@ static pi_result redefinedEnqueueKernelLaunch(pi_queue, pi_kernel, pi_uint32,
                                               const size_t *LocalSize,
                                               pi_uint32 N, const pi_event *Deps,
                                               pi_event *RetEvent) {
-  int *Ret = new int[1];
-  *Ret = KernelLaunchCounter++;
+  int Val = KernelLaunchCounter++;
   // This output here is to reduce amount of time requried to debug/reproduce a
   // failing test upon feature break
-  printf("Enqueued %i\n", *Ret);
+  printf("Enqueued %i\n", Val);
 
-  *RetEvent = reinterpret_cast<pi_event>(Ret);
   return PI_SUCCESS;
 }
 
@@ -426,21 +397,18 @@ static void setupMockForInterop(sycl::unittest::PiMock &Mock,
   TestInteropKernel::Device = &Dev;
   TestInteropKernel::Context = &Ctx;
 
-  Mock.redefine<PiApiKind::piKernelGetGroupInfo>(redefinedKernelGetGroupInfo);
-  Mock.redefine<PiApiKind::piEnqueueKernelLaunch>(
+  Mock.redefineAfter<PiApiKind::piKernelGetGroupInfo>(
+      redefinedKernelGetGroupInfoAfter);
+  Mock.redefineBefore<PiApiKind::piEnqueueKernelLaunch>(
       TestInteropKernel::redefinedEnqueueKernelLaunch);
-  Mock.redefine<PiApiKind::piMemBufferCreate>(redefinedMemBufferCreate);
-  Mock.redefine<PiApiKind::piMemRelease>(redefinedMemRelease);
-  Mock.redefine<PiApiKind::piKernelSetArg>(redefinedKernelSetArg);
-  Mock.redefine<PiApiKind::piEnqueueMemBufferMap>(redefinedEnqueueMemBufferMap);
-  Mock.redefine<PiApiKind::piEventsWait>(redefinedEventsWaitNegative);
-  Mock.redefine<PiApiKind::piextKernelSetArgMemObj>(
-      redefinedExtKernelSetArgMemObj);
-  Mock.redefine<PiApiKind::piKernelGetInfo>(
+  Mock.redefineAfter<PiApiKind::piEnqueueMemBufferMap>(
+      redefinedEnqueueMemBufferMapAfter);
+  Mock.redefineBefore<PiApiKind::piEventsWait>(redefinedEventsWaitNegative);
+  Mock.redefineBefore<PiApiKind::piKernelGetInfo>(
       TestInteropKernel::redefinedKernelGetInfo);
-  Mock.redefine<PiApiKind::piProgramGetInfo>(
+  Mock.redefineBefore<PiApiKind::piProgramGetInfo>(
       TestInteropKernel::redefinedProgramGetInfo);
-  Mock.redefine<PiApiKind::piProgramGetBuildInfo>(
+  Mock.redefineBefore<PiApiKind::piProgramGetBuildInfo>(
       TestInteropKernel::redefinedProgramGetBuildInfo);
 }
 
@@ -581,10 +549,15 @@ TEST(Assert, TestInteropKernelNegative) {
 
   sycl::queue Queue{Ctx, Dev};
 
-  cl_kernel CLKernel = (cl_kernel)(0x01);
+  pi_kernel PIKernel = nullptr;
+
+  pi_result Res = mock_piKernelCreate(
+      /*pi_program=*/0x0, /*kernel_name=*/"dummy_kernel", &PIKernel);
+  assert(PI_SUCCESS == Res);
+
   // TODO use make_kernel. This requires a fix in backend.cpp to get plugin
   // from context instead of free getPlugin to alllow for mocking of its methods
-  sycl::kernel KInterop(CLKernel, Ctx);
+  sycl::kernel KInterop((cl_kernel)PIKernel, Ctx);
 
   Queue.submit([&](sycl::handler &H) { H.single_task(KInterop); });
 

--- a/sycl/unittests/buffer/BufferLocation.cpp
+++ b/sycl/unittests/buffer/BufferLocation.cpp
@@ -43,11 +43,11 @@ pi_result redefinedMemBufferCreate(pi_context, pi_mem_flags, size_t size,
   return PI_SUCCESS;
 }
 
-static pi_result redefinedDeviceGetInfo(pi_device device,
-                                        pi_device_info param_name,
-                                        size_t param_value_size,
-                                        void *param_value,
-                                        size_t *param_value_size_ret) {
+static pi_result redefinedDeviceGetInfoAfter(pi_device device,
+                                             pi_device_info param_name,
+                                             size_t param_value_size,
+                                             void *param_value,
+                                             size_t *param_value_size_ret) {
   if (param_name == PI_DEVICE_INFO_TYPE) {
     auto *Result = reinterpret_cast<_pi_device_type *>(param_value);
     *Result = PI_DEVICE_TYPE_ACC;
@@ -58,9 +58,15 @@ static pi_result redefinedDeviceGetInfo(pi_device device,
   }
   if (param_name == PI_DEVICE_INFO_EXTENSIONS) {
     const std::string name = "cl_intel_mem_alloc_buffer_location";
+
+    // Increase size by one for the null terminator
+    const size_t nameSize = name.size() + 1;
+
     if (!param_value) {
-      // Increase size by one for the null terminator
-      *param_value_size_ret = name.size() + 1;
+      // Choose bigger size so that both original and redefined function
+      // has enough memory for storing the extension string
+      *param_value_size_ret =
+          nameSize > *param_value_size_ret ? nameSize : *param_value_size_ret;
     } else {
       char *dst = static_cast<char *>(param_value);
       strcpy(dst, name.data());
@@ -75,10 +81,10 @@ public:
 
 protected:
   void SetUp() override {
-    Mock.redefine<sycl::detail::PiApiKind::piMemBufferCreate>(
+    Mock.redefineBefore<sycl::detail::PiApiKind::piMemBufferCreate>(
         redefinedMemBufferCreate);
-    Mock.redefine<sycl::detail::PiApiKind::piDeviceGetInfo>(
-        redefinedDeviceGetInfo);
+    Mock.redefineAfter<sycl::detail::PiApiKind::piDeviceGetInfo>(
+        redefinedDeviceGetInfoAfter);
   }
 
 protected:

--- a/sycl/unittests/event/EventDestruction.cpp
+++ b/sycl/unittests/event/EventDestruction.cpp
@@ -33,8 +33,9 @@ public:
 
 protected:
   void SetUp() override {
-    Mock.redefine<detail::PiApiKind::piEventRelease>(redefinedEventRelease);
-    Mock.redefine<detail::PiApiKind::piMemBufferCreate>(
+    Mock.redefineBefore<detail::PiApiKind::piEventRelease>(
+        redefinedEventRelease);
+    Mock.redefineBefore<detail::PiApiKind::piMemBufferCreate>(
         redefinedMemBufferCreate);
   }
 

--- a/sycl/unittests/helpers/PiMock.hpp
+++ b/sycl/unittests/helpers/PiMock.hpp
@@ -51,22 +51,113 @@ namespace unittest {
 namespace detail = sycl::detail;
 namespace RT = detail::pi;
 
-/// Overwrites the input PiPlugin's PiFunctionTable entry for the given PI API
-/// with a given function pointer.
+/// The macro below defines a proxy functions for each PI API call.
+/// This proxy function calls all the functions regestered in CallBefore*
+/// function pointer array, then calls Original function, then calls functions
+/// registered in CallAfter* array.
 ///
-/// \param MPlugin is a pointer to the PiPlugin instance that will be modified.
-/// \param FuncPtr is a pointer to the function that will override the original.
-///        function table entry
+/// If a function from CallBefore* returns a non-PI_SUCCESS return code the
+/// proxy function bails out.
+
+/// Number of functions that can be regestered as CallBefore and CallAfter
+inline constexpr size_t CallStackSize = 16;
 #define _PI_API(api)                                                           \
+                                                                               \
+  inline decltype(&::api) CallBefore_##api[CallStackSize] = {nullptr};         \
+  inline decltype(&::api) CallOriginal_##api = mock_##api;                     \
+  inline decltype(&::api) CallAfter_##api[CallStackSize] = {nullptr};          \
+                                                                               \
+  template <class RetT, class... ArgsT> RetT proxy_mock_##api(ArgsT... Args) { \
+    for (size_t I = 0; I < CallStackSize && CallBefore_##api[I]; ++I) {        \
+      /* If before function returns an error bail out */                       \
+      const RetT Res = CallBefore_##api[I](Args...);                           \
+      if (Res != PI_SUCCESS)                                                   \
+        return Res;                                                            \
+    }                                                                          \
+                                                                               \
+    RetT Ret = CallOriginal_##api(Args...);                                    \
+                                                                               \
+    for (size_t I = 0; I < CallStackSize && CallAfter_##api[I]; ++I)           \
+      CallAfter_##api[I](Args...);                                             \
+                                                                               \
+    return Ret;                                                                \
+  }                                                                            \
+                                                                               \
+  /* A helper structure for instantiating proxy functions for a given */       \
+  /* PI API signature */                                                       \
+  template <class RetT_, class... ArgsT_> class ConverterT_##api {             \
+  public:                                                                      \
+    ConverterT_##api(RetT_ (*Func)(ArgsT_...)){};                              \
+    constexpr static RetT_ (*Func)(ArgsT_...) =                                \
+        proxy_mock_##api<RetT_, ArgsT_...>;                                    \
+  };                                                                           \
+  inline ConverterT_##api Anchor_##api{decltype(&::api)(0x0)};                 \
+                                                                               \
+  /*Overrides a plugin PI function with a given one */                         \
   template <detail::PiApiKind PiApiOffset>                                     \
   inline void setFuncPtr(RT::PiPlugin *MPlugin, decltype(&::api) FuncPtr);     \
   template <>                                                                  \
   inline void setFuncPtr<detail::PiApiKind::api>(RT::PiPlugin * MPlugin,       \
                                                  decltype(&::api) FuncPtr) {   \
-    MPlugin->PiFunctionTable.api = FuncPtr;                                    \
+    CallOriginal_##api = FuncPtr;                                              \
+  }                                                                            \
+                                                                               \
+  /*Adds a function to be called before the PI function*/                      \
+  template <detail::PiApiKind PiApiOffset>                                     \
+  inline void setFuncPtrBefore(RT::PiPlugin *MPlugin,                          \
+                               decltype(&::api) FuncPtr);                      \
+  template <>                                                                  \
+  inline void setFuncPtrBefore<detail::PiApiKind::api>(                        \
+      RT::PiPlugin * MPlugin, decltype(&::api) FuncPtr) {                      \
+    /* Find free slot */                                                       \
+    size_t I = 0;                                                              \
+    for (; I < CallStackSize && CallBefore_##api[I]; ++I)                      \
+      ;                                                                        \
+    assert(I < CallStackSize && "Too many calls before");                      \
+    CallBefore_##api[I] = FuncPtr;                                             \
+  }                                                                            \
+                                                                               \
+  /*Adds a function to be called after the PI function*/                       \
+  template <detail::PiApiKind PiApiOffset>                                     \
+  inline void setFuncPtrAfter(RT::PiPlugin *MPlugin,                           \
+                              decltype(&::api) FuncPtr);                       \
+  template <>                                                                  \
+  inline void setFuncPtrAfter<detail::PiApiKind::api>(                         \
+      RT::PiPlugin * MPlugin, decltype(&::api) FuncPtr) {                      \
+    /* Find free slot */                                                       \
+    size_t I = 0;                                                              \
+    for (; I < CallStackSize && CallAfter_##api[I]; ++I)                       \
+      ;                                                                        \
+    assert(I < CallStackSize && "Too many calls after");                       \
+    CallAfter_##api[I] = FuncPtr;                                              \
   }
 #include <sycl/detail/pi.def>
 #undef _PI_API
+
+// Unregister functions set for calling before and after PI API
+inline void clearRedefinedCalls() {
+  for (size_t I = 0; I < CallStackSize; ++I) {
+#define _PI_API(api)                                                           \
+  CallBefore_##api[I] = nullptr;                                               \
+  CallAfter_##api[I] = nullptr;
+#include <sycl/detail/pi.def>
+#undef _PI_API
+  }
+}
+
+#define _PI_MOCK_PLUGIN_CONCAT(A, B) A##B
+#define PI_MOCK_PLUGIN_CONCAT(A, B) _PI_MOCK_PLUGIN_CONCAT(A, B)
+
+inline pi_plugin::FunctionPointers getProxyMockedFunctionPointers() {
+  return {
+#define _PI_API(api) PI_MOCK_PLUGIN_CONCAT(proxy_mock_, api),
+#include <sycl/detail/pi.def>
+#undef _PI_API
+  };
+}
+
+#undef PI_MOCK_PLUGIN_CONCAT
+#undef _PI_MOCK_PLUGIN_CONCAT
 
 /// The PiMock class manages the mock PI plugin and wraps an instance of a SYCL
 /// platform class created from this plugin. Additionally it allows for the
@@ -86,7 +177,7 @@ namespace RT = detail::pi;
 /// pi_result redefinePiProgramRetain(pi_program program) { /*code*/ }
 /// /*...*/
 /// unittest::PiMock Mock;
-/// Mock.redefine<PiApiKind::piProgramRetain>(redefinePiProgramRetain);
+/// Mock.redefineBefore<PiApiKind::piProgramRetain>(redefinePiProgramRetain);
 /// platform &MockP = Mock.getPlatform();
 /// /*...*/
 /// ```
@@ -130,6 +221,10 @@ public:
   PiMock(const PiMock &) = delete;
   PiMock &operator=(const PiMock &) = delete;
   ~PiMock() {
+    // Since the plugin relies on the global vars to store function pointers we
+    // need to reset them for the new PiMock plugin instance
+    // TODO: Make function pointers array for each PiMock instance?
+    clearRedefinedCalls();
     if (!OrigFuncTable)
       return;
 
@@ -148,6 +243,31 @@ public:
   template <detail::PiApiKind PiApiOffset>
   using SignatureT = typename std::remove_pointer<FuncPtrT<PiApiOffset>>::type;
 
+  /// Adds a function to be called before a given PI API
+  ///
+  /// \param Replacement is a mock std::function instance to be
+  ///        called instead of the given PI API. This function must
+  ///        not have been constructed from a lambda.
+  template <detail::PiApiKind PiApiOffset>
+  void
+  redefineBefore(const std::function<SignatureT<PiApiOffset>> &Replacement) {
+    FuncPtrT<PiApiOffset> FuncPtr =
+        *Replacement.template target<FuncPtrT<PiApiOffset>>();
+    assert(FuncPtr &&
+           "Function target is empty, try passing a lambda directly");
+    setFuncPtrBefore<PiApiOffset>(MPiPluginMockPtr, *FuncPtr);
+  }
+
+  /// redefineBefore overload for function pointer/captureless lambda arguments.
+  ///
+  /// \param Replacement is a mock callable assignable to a function
+  ///        pointer (function pointer/captureless lambda).
+
+  template <detail::PiApiKind PiApiOffset, typename FunctorT>
+  void redefineBefore(const FunctorT &Replacement) {
+    // TODO: Check for matching signatures/assignability
+    setFuncPtrBefore<PiApiOffset>(MPiPluginMockPtr, Replacement);
+  }
   /// Redefines the implementation of a given PI API to the input
   /// function object.
   ///
@@ -178,6 +298,31 @@ public:
     setFuncPtr<PiApiOffset>(MPiPluginMockPtr, Replacement);
   }
 
+  /// Adds a function to be called after a given PI API
+  ///
+  /// \param Replacement is a mock std::function instance to be
+  ///        called instead of the given PI API. This function must
+  ///        not have been constructed from a lambda.
+  template <detail::PiApiKind PiApiOffset>
+  void
+  redefineAfter(const std::function<SignatureT<PiApiOffset>> &Replacement) {
+    FuncPtrT<PiApiOffset> FuncPtr =
+        *Replacement.template target<FuncPtrT<PiApiOffset>>();
+    assert(FuncPtr &&
+           "Function target is empty, try passing a lambda directly");
+    setFuncPtrAfter<PiApiOffset>(MPiPluginMockPtr, *FuncPtr);
+  }
+
+  /// redefineAfter overload for function pointer/captureless lambda arguments.
+  ///
+  /// \param Replacement is a mock callable assignable to a function
+  ///        pointer (function pointer/captureless lambda).
+  template <detail::PiApiKind PiApiOffset, typename FunctorT>
+  void redefineAfter(const FunctorT &Replacement) {
+    // TODO: Check for matching signatures/assignability
+    setFuncPtrAfter<PiApiOffset>(MPiPluginMockPtr, Replacement);
+  }
+
   /// Ensures that the mock plugin has been initialized and has been registered
   /// in the global handler. Additionally, all existing plugins will be removed
   /// and unloaded to avoid them being accidentally picked up by tests using
@@ -198,7 +343,7 @@ public:
 
     auto RTPlugin = std::make_shared<RT::PiPlugin>(
         RT::PiPlugin{"pi.ver.mock", "plugin.ver.mock", /*Targets=*/nullptr,
-                     getMockedFunctionPointers()});
+                     getProxyMockedFunctionPointers()});
 
     // FIXME: which backend to pass here? does it affect anything?
     MMockPluginPtr = std::make_unique<detail::plugin>(RTPlugin, backend::opencl,

--- a/sycl/unittests/helpers/PiMockPlugin.hpp
+++ b/sycl/unittests/helpers/PiMockPlugin.hpp
@@ -11,8 +11,45 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cstring>
 #include <sycl/detail/pi.hpp>
+
+#include <atomic>
+#include <cstring>
+
+// Helpers for dymmy handles
+
+struct DummyHandleT {
+  DummyHandleT(size_t DataSize = 0)
+      : MStorage(DataSize), MData(MStorage.data()) {}
+  std::atomic<size_t> MRefCounter = 1;
+  std::vector<unsigned char> MStorage;
+  unsigned char *MData = nullptr;
+};
+
+using DummyHandlePtrT = DummyHandleT *;
+
+// Allocates a dummy handle of type T with support of reference counting.
+// Takes optional 'Size' parameter which can be used to allocate additional
+// memory. The handle has to be deallocated using 'releaseDummyHandle'.
+template <class T> inline T createDummyHandle(size_t Size = 0) {
+  DummyHandlePtrT DummyHandlePtr = new DummyHandleT(Size);
+  return reinterpret_cast<T>(DummyHandlePtr);
+}
+
+// Decrement reference counter for the handle and deallocates it if the
+// reference counter becomes zero
+template <class T> inline void releaseDummyHandle(T Handle) {
+  auto DummyHandlePtr = reinterpret_cast<DummyHandlePtrT>(Handle);
+  const size_t NewValue = --DummyHandlePtr->MRefCounter;
+  if (NewValue == 0)
+    delete DummyHandlePtr;
+}
+
+// Increment reference counter for the handle
+template <class T> inline void retainDummyHandle(T Handle) {
+  auto DummyHandlePtr = reinterpret_cast<DummyHandlePtrT>(Handle);
+  ++DummyHandlePtr->MRefCounter;
+}
 
 //
 // Platform
@@ -72,6 +109,8 @@ mock_piextPlatformGetNativeHandle(pi_platform platform,
 inline pi_result
 mock_piextPlatformCreateWithNativeHandle(pi_native_handle nativeHandle,
                                          pi_platform *platform) {
+  *platform = reinterpret_cast<pi_platform>(nativeHandle);
+  retainDummyHandle(*platform);
   return PI_SUCCESS;
 }
 
@@ -124,7 +163,7 @@ inline pi_result mock_piDeviceGetInfo(pi_device device,
   }
   case PI_DEVICE_INFO_EXTENSIONS: {
     if (param_value) {
-      assert(param_value_size == sizeof(MockSupportedExtensions));
+      assert(param_value_size >= sizeof(MockSupportedExtensions));
       std::memcpy(param_value, MockSupportedExtensions,
                   sizeof(MockSupportedExtensions));
     }
@@ -168,6 +207,8 @@ mock_piextDeviceGetNativeHandle(pi_device device,
 
 inline pi_result mock_piextDeviceCreateWithNativeHandle(
     pi_native_handle nativeHandle, pi_platform platform, pi_device *device) {
+  *device = reinterpret_cast<pi_device>(nativeHandle);
+  retainDummyHandle(*device);
   return PI_SUCCESS;
 }
 
@@ -195,8 +236,7 @@ inline pi_result mock_piContextCreate(
     void (*pfn_notify)(const char *errinfo, const void *private_info, size_t cb,
                        void *user_data),
     void *user_data, pi_context *ret_context) {
-  static uintptr_t NextContext = 0;
-  *ret_context = reinterpret_cast<pi_context>(++NextContext);
+  *ret_context = createDummyHandle<pi_context>();
   return PI_SUCCESS;
 }
 
@@ -218,9 +258,13 @@ inline pi_result mock_piContextGetInfo(pi_context context,
   }
 }
 
-inline pi_result mock_piContextRetain(pi_context context) { return PI_SUCCESS; }
+inline pi_result mock_piContextRetain(pi_context context) {
+  retainDummyHandle(context);
+  return PI_SUCCESS;
+}
 
 inline pi_result mock_piContextRelease(pi_context context) {
+  releaseDummyHandle(context);
   return PI_SUCCESS;
 }
 
@@ -240,6 +284,8 @@ inline pi_result mock_piextContextCreateWithNativeHandle(
     pi_native_handle nativeHandle, pi_uint32 numDevices,
     const pi_device *devices, bool pluginOwnsNativeHandle,
     pi_context *context) {
+  *context = reinterpret_cast<pi_context>(nativeHandle);
+  retainDummyHandle(*context);
   return PI_SUCCESS;
 }
 
@@ -249,8 +295,7 @@ inline pi_result mock_piextContextCreateWithNativeHandle(
 inline pi_result mock_piQueueCreate(pi_context context, pi_device device,
                                     pi_queue_properties properties,
                                     pi_queue *queue) {
-  static uintptr_t NextQueue = 0;
-  *queue = reinterpret_cast<pi_queue>(++NextQueue);
+  *queue = createDummyHandle<pi_queue>();
   return PI_SUCCESS;
 }
 
@@ -272,10 +317,12 @@ inline pi_result mock_piQueueGetInfo(pi_queue command_queue,
 }
 
 inline pi_result mock_piQueueRetain(pi_queue command_queue) {
+  retainDummyHandle(command_queue);
   return PI_SUCCESS;
 }
 
 inline pi_result mock_piQueueRelease(pi_queue command_queue) {
+  releaseDummyHandle(command_queue);
   return PI_SUCCESS;
 }
 
@@ -296,6 +343,8 @@ mock_piextQueueGetNativeHandle(pi_queue queue, pi_native_handle *nativeHandle) {
 inline pi_result mock_piextQueueCreateWithNativeHandle(
     pi_native_handle nativeHandle, pi_context context, pi_device device,
     bool pluginOwnsNativeHandle, pi_queue *queue) {
+  *queue = reinterpret_cast<pi_queue>(nativeHandle);
+  retainDummyHandle(*queue);
   return PI_SUCCESS;
 }
 
@@ -306,8 +355,7 @@ inline pi_result
 mock_piMemBufferCreate(pi_context context, pi_mem_flags flags, size_t size,
                        void *host_ptr, pi_mem *ret_mem,
                        const pi_mem_properties *properties = nullptr) {
-  static uintptr_t NextMem = 0;
-  *ret_mem = reinterpret_cast<pi_mem>(++NextMem);
+  *ret_mem = createDummyHandle<pi_mem>(size);
   return PI_SUCCESS;
 }
 
@@ -315,8 +363,9 @@ inline pi_result mock_piMemImageCreate(pi_context context, pi_mem_flags flags,
                                        const pi_image_format *image_format,
                                        const pi_image_desc *image_desc,
                                        void *host_ptr, pi_mem *ret_mem) {
-  static uintptr_t NextMem = 0;
-  *ret_mem = reinterpret_cast<pi_mem>(++NextMem);
+  assert(false &&
+         "TODO: mock_piMemImageCreate handle allocation size correctly");
+  *ret_mem = createDummyHandle<pi_mem>(/*size=*/1024 * 16);
   return PI_SUCCESS;
 }
 
@@ -333,14 +382,31 @@ inline pi_result mock_piMemImageGetInfo(pi_mem image, pi_image_info param_name,
   return PI_SUCCESS;
 }
 
-inline pi_result mock_piMemRetain(pi_mem mem) { return PI_SUCCESS; }
+inline pi_result mock_piMemRetain(pi_mem mem) {
+  retainDummyHandle(mem);
+  return PI_SUCCESS;
+}
 
-inline pi_result mock_piMemRelease(pi_mem mem) { return PI_SUCCESS; }
+inline pi_result mock_piMemRelease(pi_mem mem) {
+  releaseDummyHandle(mem);
+  return PI_SUCCESS;
+}
 
 inline pi_result
 mock_piMemBufferPartition(pi_mem buffer, pi_mem_flags flags,
                           pi_buffer_create_type buffer_create_type,
                           void *buffer_create_info, pi_mem *ret_mem) {
+  // Create a sub buf without memory as we will reuse parant's one
+  *ret_mem = createDummyHandle<pi_mem>(/*size=*/0);
+
+  auto parentDummyHandle = reinterpret_cast<DummyHandlePtrT>(buffer);
+  auto childDummyHandle = reinterpret_cast<DummyHandlePtrT>(*ret_mem);
+
+  auto region = reinterpret_cast<pi_buffer_region>(buffer_create_info);
+
+  // Point the sub buf to the original buf memory
+  childDummyHandle->MData = parentDummyHandle->MData + region->origin;
+
   return PI_SUCCESS;
 }
 
@@ -354,6 +420,8 @@ inline pi_result
 mock_piextMemCreateWithNativeHandle(pi_native_handle nativeHandle,
                                     pi_context context, bool ownNativeHandle,
                                     pi_mem *mem) {
+  *mem = reinterpret_cast<pi_mem>(nativeHandle);
+  retainDummyHandle(*mem);
   return PI_SUCCESS;
 }
 
@@ -363,8 +431,7 @@ mock_piextMemCreateWithNativeHandle(pi_native_handle nativeHandle,
 
 inline pi_result mock_piProgramCreate(pi_context context, const void *il,
                                       size_t length, pi_program *res_program) {
-  static uintptr_t NextProgram = 0;
-  *res_program = reinterpret_cast<pi_program>(++NextProgram);
+  *res_program = createDummyHandle<pi_program>();
   return PI_SUCCESS;
 }
 
@@ -373,8 +440,7 @@ inline pi_result mock_piclProgramCreateWithSource(pi_context context,
                                                   const char **strings,
                                                   const size_t *lengths,
                                                   pi_program *ret_program) {
-  static uintptr_t NextProgram = 100;
-  *ret_program = reinterpret_cast<pi_program>(++NextProgram);
+  *ret_program = createDummyHandle<pi_program>();
   return PI_SUCCESS;
 }
 
@@ -383,8 +449,7 @@ inline pi_result mock_piProgramCreateWithBinary(
     const size_t *lengths, const unsigned char **binaries,
     size_t num_metadata_entries, const pi_device_binary_property *metadata,
     pi_int32 *binary_status, pi_program *ret_program) {
-  static uintptr_t NextProgram = 200;
-  *ret_program = reinterpret_cast<pi_program>(++NextProgram);
+  *ret_program = createDummyHandle<pi_program>();
   return PI_SUCCESS;
 }
 
@@ -411,7 +476,7 @@ inline pi_result mock_piProgramGetInfo(pi_program program,
   }
   case PI_PROGRAM_INFO_BINARIES: {
     if (param_value)
-      *static_cast<unsigned char *>(param_value) = 1;
+      **static_cast<unsigned char **>(param_value) = 1;
     if (param_value_size_ret)
       *param_value_size_ret = sizeof(unsigned char);
     return PI_SUCCESS;
@@ -433,8 +498,7 @@ mock_piProgramLink(pi_context context, pi_uint32 num_devices,
                    const pi_program *input_programs,
                    void (*pfn_notify)(pi_program program, void *user_data),
                    void *user_data, pi_program *ret_program) {
-  static uintptr_t NextProgram = 300;
-  *ret_program = reinterpret_cast<pi_program>(++NextProgram);
+  *ret_program = createDummyHandle<pi_program>();
   return PI_SUCCESS;
 }
 
@@ -460,9 +524,13 @@ inline pi_result mock_piProgramGetBuildInfo(
   return PI_SUCCESS;
 }
 
-inline pi_result mock_piProgramRetain(pi_program program) { return PI_SUCCESS; }
+inline pi_result mock_piProgramRetain(pi_program program) {
+  retainDummyHandle(program);
+  return PI_SUCCESS;
+}
 
 inline pi_result mock_piProgramRelease(pi_program program) {
+  releaseDummyHandle(program);
   return PI_SUCCESS;
 }
 
@@ -483,6 +551,8 @@ mock_piextProgramGetNativeHandle(pi_program program,
 inline pi_result mock_piextProgramCreateWithNativeHandle(
     pi_native_handle nativeHandle, pi_context context,
     bool pluginOwnsNativeHandle, pi_program *program) {
+  *program = reinterpret_cast<pi_program>(nativeHandle);
+  retainDummyHandle(*program);
   return PI_SUCCESS;
 }
 
@@ -493,8 +563,7 @@ inline pi_result mock_piextProgramCreateWithNativeHandle(
 inline pi_result mock_piKernelCreate(pi_program program,
                                      const char *kernel_name,
                                      pi_kernel *ret_kernel) {
-  static uintptr_t NextKernel = 0;
-  *ret_kernel = reinterpret_cast<pi_kernel>(++NextKernel);
+  *ret_kernel = createDummyHandle<pi_kernel>();
   return PI_SUCCESS;
 }
 
@@ -541,9 +610,15 @@ inline pi_result mock_piKernelGetSubGroupInfo(
   return PI_SUCCESS;
 }
 
-inline pi_result mock_piKernelRetain(pi_kernel kernel) { return PI_SUCCESS; }
+inline pi_result mock_piKernelRetain(pi_kernel kernel) {
+  retainDummyHandle(kernel);
+  return PI_SUCCESS;
+}
 
-inline pi_result mock_piKernelRelease(pi_kernel kernel) { return PI_SUCCESS; }
+inline pi_result mock_piKernelRelease(pi_kernel kernel) {
+  releaseDummyHandle(kernel);
+  return PI_SUCCESS;
+}
 
 inline pi_result mock_piextKernelSetArgPointer(pi_kernel kernel,
                                                pi_uint32 arg_index,
@@ -562,6 +637,9 @@ inline pi_result mock_piKernelSetExecInfo(pi_kernel kernel,
 inline pi_result mock_piextKernelCreateWithNativeHandle(
     pi_native_handle nativeHandle, pi_context context, pi_program program,
     bool pluginOwnsNativeHandle, pi_kernel *kernel) {
+
+  *kernel = reinterpret_cast<pi_kernel>(nativeHandle);
+  retainDummyHandle(*kernel);
   return PI_SUCCESS;
 }
 
@@ -576,8 +654,7 @@ mock_piextKernelGetNativeHandle(pi_kernel kernel,
 // Events
 //
 inline pi_result mock_piEventCreate(pi_context context, pi_event *ret_event) {
-  static uintptr_t NextEvent = 0;
-  *ret_event = reinterpret_cast<pi_event>(++NextEvent);
+  *ret_event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -624,9 +701,15 @@ inline pi_result mock_piEventSetStatus(pi_event event,
   return PI_SUCCESS;
 }
 
-inline pi_result mock_piEventRetain(pi_event event) { return PI_SUCCESS; }
+inline pi_result mock_piEventRetain(pi_event event) {
+  retainDummyHandle(event);
+  return PI_SUCCESS;
+}
 
-inline pi_result mock_piEventRelease(pi_event event) { return PI_SUCCESS; }
+inline pi_result mock_piEventRelease(pi_event event) {
+  releaseDummyHandle(event);
+  return PI_SUCCESS;
+}
 
 inline pi_result
 mock_piextEventGetNativeHandle(pi_event event, pi_native_handle *nativeHandle) {
@@ -638,6 +721,8 @@ inline pi_result
 mock_piextEventCreateWithNativeHandle(pi_native_handle nativeHandle,
                                       pi_context context, bool ownNativeHandle,
                                       pi_event *event) {
+  *event = reinterpret_cast<pi_event>(nativeHandle);
+  retainDummyHandle(*event);
   return PI_SUCCESS;
 }
 
@@ -648,8 +733,7 @@ inline pi_result
 mock_piSamplerCreate(pi_context context,
                      const pi_sampler_properties *sampler_properties,
                      pi_sampler *result_sampler) {
-  static uintptr_t NextSampler = 0;
-  *result_sampler = reinterpret_cast<pi_sampler>(++NextSampler);
+  *result_sampler = createDummyHandle<pi_sampler>();
   return PI_SUCCESS;
 }
 
@@ -661,9 +745,13 @@ inline pi_result mock_piSamplerGetInfo(pi_sampler sampler,
   return PI_SUCCESS;
 }
 
-inline pi_result mock_piSamplerRetain(pi_sampler sampler) { return PI_SUCCESS; }
+inline pi_result mock_piSamplerRetain(pi_sampler sampler) {
+  retainDummyHandle(sampler);
+  return PI_SUCCESS;
+}
 
 inline pi_result mock_piSamplerRelease(pi_sampler sampler) {
+  releaseDummyHandle(sampler);
   return PI_SUCCESS;
 }
 
@@ -675,8 +763,7 @@ inline pi_result mock_piEnqueueKernelLaunch(
     const size_t *global_work_offset, const size_t *global_work_size,
     const size_t *local_work_size, pi_uint32 num_events_in_wait_list,
     const pi_event *event_wait_list, pi_event *event) {
-  static uintptr_t NextEvent = 1000;
-  *event = reinterpret_cast<pi_event>(++NextEvent);
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -685,6 +772,7 @@ inline pi_result mock_piEnqueueNativeKernel(
     pi_uint32 num_mem_objects, const pi_mem *mem_list,
     const void **args_mem_loc, pi_uint32 num_events_in_wait_list,
     const pi_event *event_wait_list, pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -692,12 +780,14 @@ inline pi_result mock_piEnqueueEventsWait(pi_queue command_queue,
                                           pi_uint32 num_events_in_wait_list,
                                           const pi_event *event_wait_list,
                                           pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
 inline pi_result mock_piEnqueueEventsWaitWithBarrier(
     pi_queue command_queue, pi_uint32 num_events_in_wait_list,
     const pi_event *event_wait_list, pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -706,6 +796,7 @@ mock_piEnqueueMemBufferRead(pi_queue queue, pi_mem buffer,
                             pi_bool blocking_read, size_t offset, size_t size,
                             void *ptr, pi_uint32 num_events_in_wait_list,
                             const pi_event *event_wait_list, pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -716,6 +807,7 @@ inline pi_result mock_piEnqueueMemBufferReadRect(
     size_t buffer_slice_pitch, size_t host_row_pitch, size_t host_slice_pitch,
     void *ptr, pi_uint32 num_events_in_wait_list,
     const pi_event *event_wait_list, pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -724,6 +816,7 @@ mock_piEnqueueMemBufferWrite(pi_queue command_queue, pi_mem buffer,
                              pi_bool blocking_write, size_t offset, size_t size,
                              const void *ptr, pi_uint32 num_events_in_wait_list,
                              const pi_event *event_wait_list, pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -734,6 +827,7 @@ inline pi_result mock_piEnqueueMemBufferWriteRect(
     size_t buffer_slice_pitch, size_t host_row_pitch, size_t host_slice_pitch,
     const void *ptr, pi_uint32 num_events_in_wait_list,
     const pi_event *event_wait_list, pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -743,6 +837,7 @@ mock_piEnqueueMemBufferCopy(pi_queue command_queue, pi_mem src_buffer,
                             size_t dst_offset, size_t size,
                             pi_uint32 num_events_in_wait_list,
                             const pi_event *event_wait_list, pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -753,6 +848,7 @@ inline pi_result mock_piEnqueueMemBufferCopyRect(
     size_t dst_row_pitch, size_t dst_slice_pitch,
     pi_uint32 num_events_in_wait_list, const pi_event *event_wait_list,
     pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -763,6 +859,7 @@ inline pi_result mock_piEnqueueMemBufferFill(pi_queue command_queue,
                                              pi_uint32 num_events_in_wait_list,
                                              const pi_event *event_wait_list,
                                              pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -771,6 +868,7 @@ inline pi_result mock_piEnqueueMemImageRead(
     pi_image_offset origin, pi_image_region region, size_t row_pitch,
     size_t slice_pitch, void *ptr, pi_uint32 num_events_in_wait_list,
     const pi_event *event_wait_list, pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -781,6 +879,7 @@ mock_piEnqueueMemImageWrite(pi_queue command_queue, pi_mem image,
                             size_t input_slice_pitch, const void *ptr,
                             pi_uint32 num_events_in_wait_list,
                             const pi_event *event_wait_list, pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -790,6 +889,7 @@ mock_piEnqueueMemImageCopy(pi_queue command_queue, pi_mem src_image,
                            pi_image_offset dst_origin, pi_image_region region,
                            pi_uint32 num_events_in_wait_list,
                            const pi_event *event_wait_list, pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -799,6 +899,7 @@ mock_piEnqueueMemImageFill(pi_queue command_queue, pi_mem image,
                            const size_t *region,
                            pi_uint32 num_events_in_wait_list,
                            const pi_event *event_wait_list, pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -809,6 +910,10 @@ inline pi_result mock_piEnqueueMemBufferMap(pi_queue command_queue,
                                             pi_uint32 num_events_in_wait_list,
                                             const pi_event *event_wait_list,
                                             pi_event *event, void **ret_map) {
+  *event = createDummyHandle<pi_event>();
+
+  auto parentDummyHandle = reinterpret_cast<DummyHandlePtrT>(buffer);
+  *ret_map = (void *)(parentDummyHandle->MData);
   return PI_SUCCESS;
 }
 
@@ -817,6 +922,7 @@ inline pi_result mock_piEnqueueMemUnmap(pi_queue command_queue, pi_mem memobj,
                                         pi_uint32 num_events_in_wait_list,
                                         const pi_event *event_wait_list,
                                         pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -838,7 +944,8 @@ inline pi_result mock_piextKernelSetArgSampler(pi_kernel kernel,
 inline pi_result mock_piextUSMHostAlloc(void **result_ptr, pi_context context,
                                         pi_usm_mem_properties *properties,
                                         size_t size, pi_uint32 alignment) {
-  *result_ptr = (void *)0x1;
+  assert(alignment < 16 && "TODO: mock_piextUSMHostAlloc handle alignment");
+  *result_ptr = createDummyHandle<void *>(size);
   return PI_SUCCESS;
 }
 
@@ -846,7 +953,8 @@ inline pi_result mock_piextUSMDeviceAlloc(void **result_ptr, pi_context context,
                                           pi_device device,
                                           pi_usm_mem_properties *properties,
                                           size_t size, pi_uint32 alignment) {
-  *result_ptr = (void *)0x1;
+  assert(alignment < 16 && "TODO: mock_piextUSMHostAlloc handle alignment");
+  *result_ptr = createDummyHandle<void *>(size);
   return PI_SUCCESS;
 }
 
@@ -854,7 +962,8 @@ inline pi_result mock_piextUSMSharedAlloc(void **result_ptr, pi_context context,
                                           pi_device device,
                                           pi_usm_mem_properties *properties,
                                           size_t size, pi_uint32 alignment) {
-  *result_ptr = (void *)0x1;
+  assert(alignment < 16 && "TODO: mock_piextUSMHostAlloc handle alignment");
+  *result_ptr = createDummyHandle<void *>(size);
   return PI_SUCCESS;
 }
 
@@ -867,6 +976,7 @@ inline pi_result mock_piextUSMEnqueueMemset(pi_queue queue, void *ptr,
                                             pi_uint32 num_events_in_waitlist,
                                             const pi_event *events_waitlist,
                                             pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -876,6 +986,7 @@ inline pi_result mock_piextUSMEnqueueMemcpy(pi_queue queue, pi_bool blocking,
                                             pi_uint32 num_events_in_waitlist,
                                             const pi_event *events_waitlist,
                                             pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -885,6 +996,7 @@ inline pi_result mock_piextUSMEnqueuePrefetch(pi_queue queue, const void *ptr,
                                               pi_uint32 num_events_in_waitlist,
                                               const pi_event *events_waitlist,
                                               pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -892,6 +1004,7 @@ inline pi_result mock_piextUSMEnqueueMemAdvise(pi_queue queue, const void *ptr,
                                                size_t length,
                                                pi_mem_advice advice,
                                                pi_event *event) {
+  *event = createDummyHandle<pi_event>();
   return PI_SUCCESS;
 }
 
@@ -911,16 +1024,3 @@ inline pi_result mock_piTearDown(void *PluginParameter) { return PI_SUCCESS; }
 inline pi_result mock_piPluginGetLastError(char **message) {
   return PI_SUCCESS;
 }
-
-#define _PI_MOCK_PLUGIN_CONCAT(A, B) A##B
-#define PI_MOCK_PLUGIN_CONCAT(A, B) _PI_MOCK_PLUGIN_CONCAT(A, B)
-
-inline pi_plugin::FunctionPointers getMockedFunctionPointers() {
-  return {
-#define _PI_API(api) PI_MOCK_PLUGIN_CONCAT(mock_, api),
-#include <sycl/detail/pi.def>
-  };
-}
-
-#undef PI_MOCK_PLUGIN_CONCAT
-#undef _PI_MOCK_PLUGIN_CONCAT

--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -110,7 +110,8 @@ public:
 
 protected:
   void SetUp() override {
-    Mock.redefine<detail::PiApiKind::piKernelGetInfo>(redefinedKernelGetInfo);
+    Mock.redefineBefore<detail::PiApiKind::piKernelGetInfo>(
+        redefinedKernelGetInfo);
   }
 
 protected:

--- a/sycl/unittests/kernel-and-program/DeviceInfo.cpp
+++ b/sycl/unittests/kernel-and-program/DeviceInfo.cpp
@@ -54,7 +54,8 @@ public:
 
 protected:
   void SetUp() override {
-    Mock.redefine<detail::PiApiKind::piDeviceGetInfo>(redefinedDeviceGetInfo);
+    Mock.redefineBefore<detail::PiApiKind::piDeviceGetInfo>(
+        redefinedDeviceGetInfo);
   }
 
 protected:

--- a/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
+++ b/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
@@ -79,9 +79,9 @@ static pi_result redefinedProgramLink(pi_context, pi_uint32, const pi_device *,
 
 static void setupCommonMockAPIs(sycl::unittest::PiMock &Mock) {
   using namespace sycl::detail;
-  Mock.redefine<PiApiKind::piProgramCompile>(redefinedProgramCompile);
-  Mock.redefine<PiApiKind::piProgramLink>(redefinedProgramLink);
-  Mock.redefine<PiApiKind::piProgramBuild>(redefinedProgramBuild);
+  Mock.redefineBefore<PiApiKind::piProgramCompile>(redefinedProgramCompile);
+  Mock.redefineBefore<PiApiKind::piProgramLink>(redefinedProgramLink);
+  Mock.redefineBefore<PiApiKind::piProgramBuild>(redefinedProgramBuild);
 }
 
 static sycl::unittest::PiImage generateDefaultImage() {

--- a/sycl/unittests/kernel-and-program/KernelInfo.cpp
+++ b/sycl/unittests/kernel-and-program/KernelInfo.cpp
@@ -38,32 +38,6 @@ static pi_result redefinedKernelGetGroupInfo(pi_kernel kernel, pi_device device,
   return PI_SUCCESS;
 }
 
-static pi_result redefinedProgramCreateWithSource(pi_context context,
-                                                  pi_uint32 count,
-                                                  const char **strings,
-                                                  const size_t *lengths,
-                                                  pi_program *ret_program) {
-  return PI_SUCCESS;
-}
-
-static pi_result
-redefinedProgramBuild(pi_program program, pi_uint32 num_devices,
-                      const pi_device *device_list, const char *options,
-                      void (*pfn_notify)(pi_program program, void *user_data),
-                      void *user_data) {
-  return PI_SUCCESS;
-}
-
-static pi_result redefinedKernelCreate(pi_program program,
-                                       const char *kernel_name,
-                                       pi_kernel *ret_kernel) {
-  return PI_SUCCESS;
-}
-
-static pi_result redefinedKernelRetain(pi_kernel kernel) { return PI_SUCCESS; }
-
-static pi_result redefinedKernelRelease(pi_kernel kernel) { return PI_SUCCESS; }
-
 static pi_result redefinedKernelGetInfo(pi_kernel kernel,
                                         pi_kernel_info param_name,
                                         size_t param_value_size,
@@ -78,30 +52,16 @@ static pi_result redefinedKernelGetInfo(pi_kernel kernel,
   return PI_SUCCESS;
 }
 
-static pi_result redefinedKernelSetExecInfo(pi_kernel kernel,
-                                            pi_kernel_exec_info param_name,
-                                            size_t param_value_size,
-                                            const void *param_value) {
-  return PI_SUCCESS;
-}
-
 class KernelInfoTest : public ::testing::Test {
 public:
   KernelInfoTest() : Mock{}, Plt{Mock.getPlatform()} {}
 
 protected:
   void SetUp() override {
-    Mock.redefine<detail::PiApiKind::piKernelGetGroupInfo>(
+    Mock.redefineBefore<detail::PiApiKind::piKernelGetGroupInfo>(
         redefinedKernelGetGroupInfo);
-    Mock.redefine<detail::PiApiKind::piclProgramCreateWithSource>(
-        redefinedProgramCreateWithSource);
-    Mock.redefine<detail::PiApiKind::piProgramBuild>(redefinedProgramBuild);
-    Mock.redefine<detail::PiApiKind::piKernelCreate>(redefinedKernelCreate);
-    Mock.redefine<detail::PiApiKind::piKernelRetain>(redefinedKernelRetain);
-    Mock.redefine<detail::PiApiKind::piKernelRelease>(redefinedKernelRelease);
-    Mock.redefine<detail::PiApiKind::piKernelGetInfo>(redefinedKernelGetInfo);
-    Mock.redefine<detail::PiApiKind::piKernelSetExecInfo>(
-        redefinedKernelSetExecInfo);
+    Mock.redefineBefore<detail::PiApiKind::piKernelGetInfo>(
+        redefinedKernelGetInfo);
   }
 
 protected:

--- a/sycl/unittests/kernel-and-program/KernelRelease.cpp
+++ b/sycl/unittests/kernel-and-program/KernelRelease.cpp
@@ -29,22 +29,6 @@ struct TestCtx {
 
 static std::unique_ptr<TestCtx> TestContext;
 
-static pi_result redefinedProgramCreateWithSource(pi_context context,
-                                                  pi_uint32 count,
-                                                  const char **strings,
-                                                  const size_t *lengths,
-                                                  pi_program *ret_program) {
-  return PI_SUCCESS;
-}
-
-static pi_result
-redefinedProgramBuild(pi_program program, pi_uint32 num_devices,
-                      const pi_device *device_list, const char *options,
-                      void (*pfn_notify)(pi_program program, void *user_data),
-                      void *user_data) {
-  return PI_SUCCESS;
-}
-
 static pi_result redefinedKernelCreate(pi_program program,
                                        const char *kernel_name,
                                        pi_kernel *ret_kernel) {
@@ -76,24 +60,14 @@ static pi_result redefinedKernelGetInfo(pi_kernel kernel,
   return PI_SUCCESS;
 }
 
-static pi_result redefinedKernelSetExecInfo(pi_kernel kernel,
-                                            pi_kernel_exec_info param_name,
-                                            size_t param_value_size,
-                                            const void *param_value) {
-  return PI_SUCCESS;
-}
-
 TEST(KernelReleaseTest, DISABLED_GetKernelRelease) {
   sycl::unittest::PiMock Mock;
-  Mock.redefine<detail::PiApiKind::piclProgramCreateWithSource>(
-      redefinedProgramCreateWithSource);
-  Mock.redefine<detail::PiApiKind::piProgramBuild>(redefinedProgramBuild);
-  Mock.redefine<detail::PiApiKind::piKernelCreate>(redefinedKernelCreate);
-  Mock.redefine<detail::PiApiKind::piKernelRetain>(redefinedKernelRetain);
-  Mock.redefine<detail::PiApiKind::piKernelRelease>(redefinedKernelRelease);
-  Mock.redefine<detail::PiApiKind::piKernelGetInfo>(redefinedKernelGetInfo);
-  Mock.redefine<detail::PiApiKind::piKernelSetExecInfo>(
-      redefinedKernelSetExecInfo);
+  Mock.redefineBefore<detail::PiApiKind::piKernelCreate>(redefinedKernelCreate);
+  Mock.redefineBefore<detail::PiApiKind::piKernelRetain>(redefinedKernelRetain);
+  Mock.redefineBefore<detail::PiApiKind::piKernelRelease>(
+      redefinedKernelRelease);
+  Mock.redefineBefore<detail::PiApiKind::piKernelGetInfo>(
+      redefinedKernelGetInfo);
 
   context Ctx{Mock.getPlatform().get_devices()[0]};
   TestContext.reset(new TestCtx(Ctx));

--- a/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
+++ b/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
@@ -21,24 +21,11 @@
 
 using namespace sycl;
 
-static pi_result redefinedContextCreate(
-    const pi_context_properties *properties, pi_uint32 num_devices,
-    const pi_device *devices,
-    void (*pfn_notify)(const char *errinfo, const void *private_info, size_t cb,
-                       void *user_data),
-    void *user_data, pi_context *ret_context) {
-  *ret_context = reinterpret_cast<pi_context>(123);
-  return PI_SUCCESS;
-}
-
-static pi_result redefinedContextRelease(pi_context context) {
-  return PI_SUCCESS;
-}
-
-static pi_result redefinedDevicesGet(pi_platform platform,
-                                     pi_device_type device_type,
-                                     pi_uint32 num_entries, pi_device *devices,
-                                     pi_uint32 *num_devices) {
+static pi_result redefinedDevicesGetAfter(pi_platform platform,
+                                          pi_device_type device_type,
+                                          pi_uint32 num_entries,
+                                          pi_device *devices,
+                                          pi_uint32 *num_devices) {
   if (num_devices) {
     *num_devices = static_cast<pi_uint32>(2);
     return PI_SUCCESS;
@@ -67,31 +54,6 @@ static pi_result redefinedDeviceGetInfo(pi_device device,
   return PI_SUCCESS;
 }
 
-static pi_result redefinedDeviceRetain(pi_device device) { return PI_SUCCESS; }
-
-static pi_result redefinedDeviceRelease(pi_device device) { return PI_SUCCESS; }
-
-static pi_result redefinedQueueCreate(pi_context context, pi_device device,
-                                      pi_queue_properties properties,
-                                      pi_queue *queue) {
-  *queue = reinterpret_cast<pi_queue>(1234);
-  return PI_SUCCESS;
-}
-
-static pi_result redefinedQueueRelease(pi_queue command_queue) {
-  return PI_SUCCESS;
-}
-
-static size_t ProgramNum = 12345;
-static pi_result redefinedProgramCreate(pi_context context, const void *il,
-                                        size_t length,
-                                        pi_program *res_program) {
-  size_t CurrentProgram = ProgramNum;
-  *res_program = reinterpret_cast<pi_program>(CurrentProgram);
-  ++ProgramNum;
-  return PI_SUCCESS;
-}
-
 static int RetainCounter = 0;
 static pi_result redefinedProgramRetain(pi_program program) {
   ++RetainCounter;
@@ -110,17 +72,14 @@ public:
 
 protected:
   void SetUp() override {
-    Mock.redefine<detail::PiApiKind::piDevicesGet>(redefinedDevicesGet);
-    Mock.redefine<detail::PiApiKind::piDeviceGetInfo>(redefinedDeviceGetInfo);
-    Mock.redefine<detail::PiApiKind::piDeviceRetain>(redefinedDeviceRetain);
-    Mock.redefine<detail::PiApiKind::piDeviceRelease>(redefinedDeviceRelease);
-    Mock.redefine<detail::PiApiKind::piContextCreate>(redefinedContextCreate);
-    Mock.redefine<detail::PiApiKind::piContextRelease>(redefinedContextRelease);
-    Mock.redefine<detail::PiApiKind::piQueueCreate>(redefinedQueueCreate);
-    Mock.redefine<detail::PiApiKind::piQueueRelease>(redefinedQueueRelease);
-    Mock.redefine<detail::PiApiKind::piProgramRetain>(redefinedProgramRetain);
-    Mock.redefine<detail::PiApiKind::piProgramCreate>(redefinedProgramCreate);
-    Mock.redefine<detail::PiApiKind::piKernelRelease>(redefinedKernelRelease);
+    Mock.redefineAfter<detail::PiApiKind::piDevicesGet>(
+        redefinedDevicesGetAfter);
+    Mock.redefineBefore<detail::PiApiKind::piDeviceGetInfo>(
+        redefinedDeviceGetInfo);
+    Mock.redefineBefore<detail::PiApiKind::piProgramRetain>(
+        redefinedProgramRetain);
+    Mock.redefineBefore<detail::PiApiKind::piKernelRelease>(
+        redefinedKernelRelease);
   }
 
 protected:

--- a/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
+++ b/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
@@ -52,11 +52,11 @@ std::vector<std::vector<int>> Progs = {
 
 static unsigned char DeviceCodeID = 2;
 
-static pi_result redefinedProgramGetInfo(pi_program program,
-                                         pi_program_info param_name,
-                                         size_t param_value_size,
-                                         void *param_value,
-                                         size_t *param_value_size_ret) {
+static pi_result redefinedProgramGetInfoAfter(pi_program program,
+                                              pi_program_info param_name,
+                                              size_t param_value_size,
+                                              void *param_value,
+                                              size_t *param_value_size_ret) {
   if (param_name == PI_PROGRAM_INFO_NUM_DEVICES) {
     auto value = reinterpret_cast<unsigned int *>(param_value);
     *value = Progs[DeviceCodeID].size();
@@ -70,9 +70,11 @@ static pi_result redefinedProgramGetInfo(pi_program program,
 
   if (param_name == PI_PROGRAM_INFO_BINARIES) {
     auto value = reinterpret_cast<unsigned char **>(param_value);
-    for (size_t i = 0; i < Progs[DeviceCodeID].size(); ++i)
-      for (int j = 0; j < Progs[DeviceCodeID][i]; ++j)
+    for (size_t i = 0; i < Progs[DeviceCodeID].size(); ++i) {
+      for (int j = 0; j < Progs[DeviceCodeID][i]; ++j) {
         value[i][j] = i;
+      }
+    }
   }
 
   return PI_SUCCESS;
@@ -169,7 +171,8 @@ public:
     RootSYCLCacheDir = SYCLCacheDir;
 
     Dev = Plt.get_devices()[0];
-    Mock.redefine<detail::PiApiKind::piProgramGetInfo>(redefinedProgramGetInfo);
+    Mock.redefineAfter<detail::PiApiKind::piProgramGetInfo>(
+        redefinedProgramGetInfoAfter);
   }
 
   /* Helper function for concurent cache item read/write from diffrent number

--- a/sycl/unittests/pi/PiMock.cpp
+++ b/sycl/unittests/pi/PiMock.cpp
@@ -14,14 +14,42 @@
 
 using namespace sycl;
 
+static bool GpiProgramBuildRedefineCalled = false;
+static bool GpiKernelCreateRedefineCalled = false;
+static bool GpiProgramRetainCalled = false;
+static bool GpiContextCreateRedefineCalledAfter = false;
+static bool GpiQueueCreateRedefineCalledBefore = false;
+
+pi_result piQueueCreateRedefineBefore(pi_context context, pi_device device,
+                                      pi_queue_properties properties,
+                                      pi_queue *queue) {
+  // The context should have been set by the original function
+  GpiQueueCreateRedefineCalledBefore = *queue == nullptr;
+  // Returning an error should stop calls to all redefined functions
+  return PI_ERROR_INVALID_OPERATION;
+}
+
+pi_result piContextCreateRedefineAfter(
+    const pi_context_properties *properties, pi_uint32 num_devices,
+    const pi_device *devices,
+    void (*pfn_notify)(const char *errinfo, const void *private_info, size_t cb,
+                       void *user_data),
+    void *user_data, pi_context *ret_context) {
+  // The context should have been set by the original function
+  GpiContextCreateRedefineCalledAfter = *ret_context != nullptr;
+  return PI_SUCCESS;
+}
+
 pi_result piProgramBuildRedefine(pi_program, pi_uint32, const pi_device *,
                                  const char *, void (*)(pi_program, void *),
                                  void *) {
-  return PI_ERROR_INVALID_BINARY;
+  GpiProgramBuildRedefineCalled = true;
+  return PI_SUCCESS;
 }
 
 pi_result piKernelCreateRedefine(pi_program, const char *, pi_kernel *) {
-  return PI_ERROR_INVALID_DEVICE;
+  GpiKernelCreateRedefineCalled = true;
+  return PI_SUCCESS;
 }
 
 TEST(PiMockTest, ConstructFromQueue) {
@@ -70,24 +98,70 @@ TEST(PiMockTest, RedefineAPI) {
 
   // Pass a function pointer
   Mock.redefine<detail::PiApiKind::piProgramBuild>(piProgramBuildRedefine);
-  EXPECT_EQ(Table.piProgramBuild, &piProgramBuildRedefine)
+  Table.piProgramBuild(/*pi_program*/ nullptr, /*num_devices=*/0,
+                       /*device_list = */ nullptr,
+                       /*options=*/nullptr, /*pfn_notify=*/nullptr,
+                       /*user_data=*/nullptr);
+
+  EXPECT_TRUE(GpiProgramBuildRedefineCalled)
       << "Function redefinition didn't propagate to the mock plugin";
 
   // Pass a std::function
   Mock.redefine<detail::PiApiKind::piKernelCreate>({piKernelCreateRedefine});
-  EXPECT_EQ(Table.piKernelCreate, &piKernelCreateRedefine)
+
+  Table.piKernelCreate(/*pi_program=*/nullptr, /*kernel_name=*/nullptr,
+                       /*pi_kernel=*/nullptr);
+  EXPECT_TRUE(GpiKernelCreateRedefineCalled)
       << "Function redefinition didn't propagate to the mock plugin";
 
   // Pass a captureless lambda
-  auto *OldFuncPtr = Table.piProgramRetain;
   auto Lambda = [](pi_program) -> pi_result {
-    return PI_ERROR_INVALID_PROGRAM;
+    GpiProgramRetainCalled = true;
+    return PI_SUCCESS;
   };
-  EXPECT_FALSE(OldFuncPtr == Lambda)
-      << "Lambda is the same as the existing function.";
   Mock.redefine<detail::PiApiKind::piProgramRetain>(Lambda);
-  EXPECT_FALSE(Table.piProgramRetain == OldFuncPtr)
+  Table.piProgramRetain(/*pi_program=*/nullptr);
+
+  EXPECT_TRUE(GpiProgramRetainCalled)
       << "Passing a lambda didn't change the function table entry";
-  ASSERT_FALSE(Table.piProgramRetain == nullptr)
-      << "Passing a lambda set the table entry to a null pointer";
+}
+
+TEST(PiMockTest, RedefineAfterAPI) {
+  sycl::unittest::PiMock Mock;
+
+  const auto &MockPiPlugin =
+      detail::getSyclObjImpl(Mock.getPlatform())->getPlugin().getPiPlugin();
+  const auto &Table = MockPiPlugin.PiFunctionTable;
+
+  // Pass a function pointer
+  Mock.redefineAfter<detail::PiApiKind::piContextCreate>(
+      piContextCreateRedefineAfter);
+
+  pi_context PIContext = nullptr;
+  Table.piContextCreate(
+      /*pi_context_properties=*/nullptr, /*num_devices=*/0,
+      /*devices=*/nullptr, /*pfn_notify=*/nullptr,
+      /*user_data=*/nullptr, &PIContext);
+
+  EXPECT_TRUE(GpiContextCreateRedefineCalledAfter)
+      << "The additional function is not called after the original one";
+}
+
+TEST(PiMockTest, RedefineBeforeAPI) {
+  sycl::unittest::PiMock Mock;
+
+  const auto &MockPiPlugin =
+      detail::getSyclObjImpl(Mock.getPlatform())->getPlugin().getPiPlugin();
+  const auto &Table = MockPiPlugin.PiFunctionTable;
+
+  // Pass a function pointer
+  Mock.redefineBefore<detail::PiApiKind::piQueueCreate>(
+      piQueueCreateRedefineBefore);
+
+  pi_queue Queue = nullptr;
+  Table.piQueueCreate(/*pi_context=*/nullptr, /*pi_device=*/nullptr,
+                      /*pi_queue_properties=*/0, &Queue);
+
+  EXPECT_TRUE(GpiQueueCreateRedefineCalledBefore)
+      << "The additional function is not called after the original one";
 }

--- a/sycl/unittests/pi/piInteropRetain.cpp
+++ b/sycl/unittests/pi/piInteropRetain.cpp
@@ -30,7 +30,7 @@ TEST(PiInteropTest, CheckRetain) {
 
   // The queue construction should not call to piQueueRetain. Instead
   // piQueueCreate should return the "retained" queue.
-  Mock.redefine<detail::PiApiKind::piQueueRetain>(redefinedQueueRetain);
+  Mock.redefineBefore<detail::PiApiKind::piQueueRetain>(redefinedQueueRetain);
   queue Q{Ctx, default_selector()};
   EXPECT_TRUE(QueueRetainCalled == 0);
 

--- a/sycl/unittests/program_manager/BuildLog.cpp
+++ b/sycl/unittests/program_manager/BuildLog.cpp
@@ -49,7 +49,8 @@ static pi_result redefinedProgramGetBuildInfo(
 
 static void setupCommonTestAPIs(sycl::unittest::PiMock &Mock) {
   using namespace sycl::detail;
-  Mock.redefine<PiApiKind::piProgramGetBuildInfo>(redefinedProgramGetBuildInfo);
+  Mock.redefineBefore<PiApiKind::piProgramGetBuildInfo>(
+      redefinedProgramGetBuildInfo);
 }
 
 TEST(BuildLog, OutputNothingOnLevel1) {

--- a/sycl/unittests/program_manager/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/EliminatedArgMask.cpp
@@ -194,7 +194,7 @@ sycl::detail::ProgramManager::KernelArgMask getKernelArgMaskFromBundle(
 TEST(EliminatedArgMask, KernelBundleWith2Kernels) {
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<sycl::detail::PiApiKind::piProgramCreate>(
+  Mock.redefineBefore<sycl::detail::PiApiKind::piProgramCreate>(
       redefinedProgramCreateEAM);
 
   const sycl::device Dev = Plt.get_devices()[0];

--- a/sycl/unittests/program_manager/SubDevices.cpp
+++ b/sycl/unittests/program_manager/SubDevices.cpp
@@ -99,15 +99,17 @@ TEST(SubDevices, DISABLED_BuildProgramForSubdevices) {
   // Setup Mock APIs
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<sycl::detail::PiApiKind::piDeviceGetInfo>(
+  Mock.redefineBefore<sycl::detail::PiApiKind::piDeviceGetInfo>(
       redefinedDeviceGetInfo);
-  Mock.redefine<sycl::detail::PiApiKind::piDevicePartition>(
+  Mock.redefineBefore<sycl::detail::PiApiKind::piDevicePartition>(
       redefinedDevicePartition);
-  Mock.redefine<sycl::detail::PiApiKind::piDeviceRetain>(redefinedDeviceRetain);
-  Mock.redefine<sycl::detail::PiApiKind::piDeviceRelease>(
+  Mock.redefineBefore<sycl::detail::PiApiKind::piDeviceRetain>(
+      redefinedDeviceRetain);
+  Mock.redefineBefore<sycl::detail::PiApiKind::piDeviceRelease>(
       redefinedDeviceRelease);
-  Mock.redefine<sycl::detail::PiApiKind::piProgramBuild>(redefinedProgramBuild);
-  Mock.redefine<sycl::detail::PiApiKind::piContextCreate>(
+  Mock.redefineBefore<sycl::detail::PiApiKind::piProgramBuild>(
+      redefinedProgramBuild);
+  Mock.redefineBefore<sycl::detail::PiApiKind::piContextCreate>(
       redefinedContextCreate);
 
   // Create 2 sub-devices and use first platform device as a root device

--- a/sycl/unittests/program_manager/itt_annotations.cpp
+++ b/sycl/unittests/program_manager/itt_annotations.cpp
@@ -64,7 +64,8 @@ TEST(ITTNotify, UseKernelBundle) {
 
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<sycl::detail::PiApiKind::piextProgramSetSpecializationConstant>(
+  Mock.redefineBefore<
+      sycl::detail::PiApiKind::piextProgramSetSpecializationConstant>(
       redefinedProgramSetSpecializationConstant);
 
   const sycl::device Dev = Plt.get_devices()[0];
@@ -91,7 +92,8 @@ TEST(ITTNotify, VarNotSet) {
 
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<sycl::detail::PiApiKind::piextProgramSetSpecializationConstant>(
+  Mock.redefineBefore<
+      sycl::detail::PiApiKind::piextProgramSetSpecializationConstant>(
       redefinedProgramSetSpecializationConstant);
 
   const sycl::device Dev = Plt.get_devices()[0];

--- a/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
+++ b/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
@@ -146,9 +146,10 @@ inline pi_result redefinedProgramBuild(
 TEST(Link_Compile_Options, compile_link_Options_Test_empty_options) {
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<sycl::detail::PiApiKind::piProgramCompile>(
+  Mock.redefineBefore<sycl::detail::PiApiKind::piProgramCompile>(
       redefinedProgramCompile);
-  Mock.redefine<sycl::detail::PiApiKind::piProgramLink>(redefinedProgramLink);
+  Mock.redefineBefore<sycl::detail::PiApiKind::piProgramLink>(
+      redefinedProgramLink);
   const sycl::device Dev = Plt.get_devices()[0];
   current_link_options.clear();
   current_compile_options.clear();
@@ -172,9 +173,10 @@ TEST(Link_Compile_Options, compile_link_Options_Test_empty_options) {
 TEST(Link_Compile_Options, compile_link_Options_Test_filled_options) {
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<sycl::detail::PiApiKind::piProgramCompile>(
+  Mock.redefineBefore<sycl::detail::PiApiKind::piProgramCompile>(
       redefinedProgramCompile);
-  Mock.redefine<sycl::detail::PiApiKind::piProgramLink>(redefinedProgramLink);
+  Mock.redefineBefore<sycl::detail::PiApiKind::piProgramLink>(
+      redefinedProgramLink);
   const sycl::device Dev = Plt.get_devices()[0];
   current_link_options.clear();
   current_compile_options.clear();
@@ -206,10 +208,12 @@ TEST(Link_Compile_Options, compile_link_Options_Test_filled_options) {
 TEST(Link_Compile_Options, check_sycl_build) {
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<sycl::detail::PiApiKind::piProgramCompile>(
+  Mock.redefineBefore<sycl::detail::PiApiKind::piProgramCompile>(
       redefinedProgramCompile);
-  Mock.redefine<sycl::detail::PiApiKind::piProgramLink>(redefinedProgramLink);
-  Mock.redefine<sycl::detail::PiApiKind::piProgramBuild>(redefinedProgramBuild);
+  Mock.redefineBefore<sycl::detail::PiApiKind::piProgramLink>(
+      redefinedProgramLink);
+  Mock.redefineBefore<sycl::detail::PiApiKind::piProgramBuild>(
+      redefinedProgramBuild);
   const sycl::device Dev = Plt.get_devices()[0];
   current_link_options.clear();
   current_compile_options.clear();

--- a/sycl/unittests/queue/DeviceCheck.cpp
+++ b/sycl/unittests/queue/DeviceCheck.cpp
@@ -103,14 +103,19 @@ TEST(QueueDeviceCheck, CheckDeviceRestriction) {
   context DefaultCtx = Plt.ext_oneapi_get_default_context();
   device Dev = DefaultCtx.get_devices()[0];
 
-  Mock.redefine<detail::PiApiKind::piContextCreate>(redefinedContextCreate);
-  Mock.redefine<detail::PiApiKind::piContextRelease>(redefinedContextRelease);
-  Mock.redefine<detail::PiApiKind::piDeviceGetInfo>(redefinedDeviceGetInfo);
-  Mock.redefine<detail::PiApiKind::piDevicePartition>(redefinedDevicePartition);
-  Mock.redefine<detail::PiApiKind::piDeviceRelease>(redefinedDeviceRelease);
-  Mock.redefine<detail::PiApiKind::piDeviceRetain>(redefinedDeviceRetain);
-  Mock.redefine<detail::PiApiKind::piQueueCreate>(redefinedQueueCreate);
-  Mock.redefine<detail::PiApiKind::piQueueRelease>(redefinedQueueRelease);
+  Mock.redefineBefore<detail::PiApiKind::piContextCreate>(
+      redefinedContextCreate);
+  Mock.redefineBefore<detail::PiApiKind::piContextRelease>(
+      redefinedContextRelease);
+  Mock.redefineBefore<detail::PiApiKind::piDeviceGetInfo>(
+      redefinedDeviceGetInfo);
+  Mock.redefineBefore<detail::PiApiKind::piDevicePartition>(
+      redefinedDevicePartition);
+  Mock.redefineBefore<detail::PiApiKind::piDeviceRelease>(
+      redefinedDeviceRelease);
+  Mock.redefineBefore<detail::PiApiKind::piDeviceRetain>(redefinedDeviceRetain);
+  Mock.redefineBefore<detail::PiApiKind::piQueueCreate>(redefinedQueueCreate);
+  Mock.redefineBefore<detail::PiApiKind::piQueueRelease>(redefinedQueueRelease);
 
   // Device is a member of the context.
   {

--- a/sycl/unittests/queue/EventClear.cpp
+++ b/sycl/unittests/queue/EventClear.cpp
@@ -36,27 +36,15 @@ pi_result redefinedQueueCreate(pi_context context, pi_device device,
   return PI_SUCCESS;
 }
 
-pi_result redefinedQueueRelease(pi_queue Queue) { return PI_SUCCESS; }
-
-pi_result redefinedUSMEnqueueMemset(pi_queue queue, void *ptr, pi_int32 value,
-                                    size_t count,
-                                    pi_uint32 num_events_in_waitlist,
-                                    const pi_event *events_waitlist,
-                                    pi_event *event) {
-  // Provide a dummy non-nullptr value
-  *event = reinterpret_cast<pi_event>(1);
-  return PI_SUCCESS;
-}
-
 pi_result redefinedEventsWait(pi_uint32 num_events,
                               const pi_event *event_list) {
   ++TestContext->NEventsWaitedFor;
   return PI_SUCCESS;
 }
 
-pi_result redefinedEventGetInfo(pi_event event, pi_event_info param_name,
-                                size_t param_value_size, void *param_value,
-                                size_t *param_value_size_ret) {
+pi_result redefinedEventGetInfoAfter(pi_event event, pi_event_info param_name,
+                                     size_t param_value_size, void *param_value,
+                                     size_t *param_value_size_ret) {
   EXPECT_EQ(param_name, PI_EVENT_INFO_COMMAND_EXECUTION_STATUS)
       << "Unexpected event info requested";
   // Report first half of events as complete.
@@ -83,14 +71,12 @@ pi_result redefinedEventRelease(pi_event event) {
 }
 
 void preparePiMock(unittest::PiMock &Mock) {
-  Mock.redefine<detail::PiApiKind::piQueueCreate>(redefinedQueueCreate);
-  Mock.redefine<detail::PiApiKind::piQueueRelease>(redefinedQueueRelease);
-  Mock.redefine<detail::PiApiKind::piextUSMEnqueueMemset>(
-      redefinedUSMEnqueueMemset);
-  Mock.redefine<detail::PiApiKind::piEventsWait>(redefinedEventsWait);
-  Mock.redefine<detail::PiApiKind::piEventGetInfo>(redefinedEventGetInfo);
-  Mock.redefine<detail::PiApiKind::piEventRetain>(redefinedEventRetain);
-  Mock.redefine<detail::PiApiKind::piEventRelease>(redefinedEventRelease);
+  Mock.redefineBefore<detail::PiApiKind::piQueueCreate>(redefinedQueueCreate);
+  Mock.redefineBefore<detail::PiApiKind::piEventsWait>(redefinedEventsWait);
+  Mock.redefineAfter<detail::PiApiKind::piEventGetInfo>(
+      redefinedEventGetInfoAfter);
+  Mock.redefineBefore<detail::PiApiKind::piEventRetain>(redefinedEventRetain);
+  Mock.redefineBefore<detail::PiApiKind::piEventRelease>(redefinedEventRelease);
 }
 
 // Check that the USM events are cleared from the queue upon call to wait(),

--- a/sycl/unittests/queue/GetProfilingInfo.cpp
+++ b/sycl/unittests/queue/GetProfilingInfo.cpp
@@ -71,7 +71,7 @@ redefinedPiEventGetProfilingInfo(pi_event event, pi_profiling_info param_name,
 TEST(GetProfilingInfo, normal_pass_without_exception) {
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<sycl::detail::PiApiKind::piEventGetProfilingInfo>(
+  Mock.redefineBefore<sycl::detail::PiApiKind::piEventGetProfilingInfo>(
       redefinedPiEventGetProfilingInfo);
   const sycl::device Dev = Plt.get_devices()[0];
   sycl::context Ctx{Dev};
@@ -109,7 +109,7 @@ TEST(GetProfilingInfo, normal_pass_without_exception) {
 TEST(GetProfilingInfo, command_exception_check) {
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<sycl::detail::PiApiKind::piEventGetProfilingInfo>(
+  Mock.redefineBefore<sycl::detail::PiApiKind::piEventGetProfilingInfo>(
       redefinedPiEventGetProfilingInfo);
 
   const sycl::device Dev = Plt.get_devices()[0];
@@ -212,7 +212,7 @@ TEST(GetProfilingInfo, exception_check_no_queue) {
 TEST(GetProfilingInfo, check_if_now_dead_queue_property_set) {
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<sycl::detail::PiApiKind::piEventGetProfilingInfo>(
+  Mock.redefineBefore<sycl::detail::PiApiKind::piEventGetProfilingInfo>(
       redefinedPiEventGetProfilingInfo);
   const sycl::device Dev = Plt.get_devices()[0];
   sycl::context Ctx{Dev};
@@ -253,7 +253,7 @@ TEST(GetProfilingInfo, check_if_now_dead_queue_property_set) {
 TEST(GetProfilingInfo, check_if_now_dead_queue_property_not_set) {
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<sycl::detail::PiApiKind::piEventGetProfilingInfo>(
+  Mock.redefineBefore<sycl::detail::PiApiKind::piEventGetProfilingInfo>(
       redefinedPiEventGetProfilingInfo);
   const sycl::device Dev = Plt.get_devices()[0];
   sycl::context Ctx{Dev};

--- a/sycl/unittests/queue/USM.cpp
+++ b/sycl/unittests/queue/USM.cpp
@@ -21,41 +21,38 @@ struct {
 } TestContext;
 
 // Dummy event values for bookkeeping
-pi_event WAIT = reinterpret_cast<pi_event>(1);
-pi_event MEMCPY = reinterpret_cast<pi_event>(2);
-pi_event MEMSET = reinterpret_cast<pi_event>(3);
+pi_event WAIT = nullptr;
+pi_event MEMCPY = nullptr;
+pi_event MEMSET = nullptr;
 
 template <typename T> auto getVal(T obj) {
   return detail::getSyclObjImpl(obj)->getHandleRef();
 }
 
-pi_result redefinedEnqueueEventsWait(pi_queue, pi_uint32 NumDeps,
-                                     const pi_event *Deps, pi_event *Event) {
+pi_result redefinedEnqueueEventsWaitAfter(pi_queue, pi_uint32 NumDeps,
+                                          const pi_event *Deps,
+                                          pi_event *Event) {
   EXPECT_EQ(NumDeps, TestContext.Deps.size());
   for (size_t i = 0; i < NumDeps; ++i) {
     EXPECT_EQ(Deps[i], getVal(TestContext.Deps[i]));
   }
-  *Event = WAIT;
+  WAIT = *Event;
   return PI_SUCCESS;
 }
 
-pi_result redefinedUSMEnqueueMemcpy(pi_queue, pi_bool, void *, const void *,
-                                    size_t, pi_uint32, const pi_event *,
-                                    pi_event *Event) {
-  *Event = MEMCPY;
+pi_result redefinedUSMEnqueueMemcpyAfter(pi_queue, pi_bool, void *,
+                                         const void *, size_t, pi_uint32,
+                                         const pi_event *, pi_event *Event) {
+  // Set MEMCPY to the event produced by the original USMEnqueueMemcpy
+  MEMCPY = *Event;
   return PI_SUCCESS;
 }
 
-pi_result redefinedUSMEnqueueMemset(pi_queue, void *, pi_int32, size_t,
-                                    pi_uint32, const pi_event *,
-                                    pi_event *Event) {
-  *Event = MEMSET;
-  return PI_SUCCESS;
-}
-
-pi_result redefinedEventRelease(pi_event) { return PI_SUCCESS; }
-pi_result redefinedEventsWait(pi_uint32 /* num_events */,
-                              const pi_event * /* event_list  */) {
+pi_result redefinedUSMEnqueueMemsetAfter(pi_queue, void *, pi_int32, size_t,
+                                         pi_uint32, const pi_event *,
+                                         pi_event *Event) {
+  // Set MEMSET to the event produced by the original USMEnqueueMemcpy
+  MEMSET = *Event;
   return PI_SUCCESS;
 }
 
@@ -63,14 +60,12 @@ pi_result redefinedEventsWait(pi_uint32 /* num_events */,
 TEST(USM, NoOpPreservesDependencyChain) {
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<detail::PiApiKind::piEnqueueEventsWait>(
-      redefinedEnqueueEventsWait);
-  Mock.redefine<detail::PiApiKind::piextUSMEnqueueMemcpy>(
-      redefinedUSMEnqueueMemcpy);
-  Mock.redefine<detail::PiApiKind::piextUSMEnqueueMemset>(
-      redefinedUSMEnqueueMemset);
-  Mock.redefine<detail::PiApiKind::piEventRelease>(redefinedEventRelease);
-  Mock.redefine<detail::PiApiKind::piEventsWait>(redefinedEventsWait);
+  Mock.redefineAfter<detail::PiApiKind::piEnqueueEventsWait>(
+      redefinedEnqueueEventsWaitAfter);
+  Mock.redefineAfter<detail::PiApiKind::piextUSMEnqueueMemcpy>(
+      redefinedUSMEnqueueMemcpyAfter);
+  Mock.redefineAfter<detail::PiApiKind::piextUSMEnqueueMemset>(
+      redefinedUSMEnqueueMemsetAfter);
 
   context Ctx{Plt.get_devices()[0]};
   queue Q{Ctx, default_selector()};

--- a/sycl/unittests/queue/Wait.cpp
+++ b/sycl/unittests/queue/Wait.cpp
@@ -36,16 +36,12 @@ pi_result redefinedQueueCreate(pi_context context, pi_device device,
   return PI_SUCCESS;
 }
 
-pi_result redefinedQueueRelease(pi_queue Queue) { return PI_SUCCESS; }
-
 pi_result redefinedUSMEnqueueMemset(pi_queue Queue, void *Ptr, pi_int32 Value,
                                     size_t Count,
                                     pi_uint32 Num_events_in_waitlist,
                                     const pi_event *Events_waitlist,
                                     pi_event *Event) {
-  // Provide a dummy non-nullptr value
   TestContext.EventReferenceCount = 1;
-  *Event = reinterpret_cast<pi_event>(1);
   return PI_SUCCESS;
 }
 pi_result redefinedEnqueueMemBufferFill(pi_queue Queue, pi_mem Buffer,
@@ -54,9 +50,7 @@ pi_result redefinedEnqueueMemBufferFill(pi_queue Queue, pi_mem Buffer,
                                         pi_uint32 NumEventsInWaitList,
                                         const pi_event *EventWaitList,
                                         pi_event *Event) {
-  // Provide a dummy non-nullptr value
   TestContext.EventReferenceCount = 1;
-  *Event = reinterpret_cast<pi_event>(1);
   return PI_SUCCESS;
 }
 
@@ -67,12 +61,6 @@ pi_result redefinedQueueFinish(pi_queue Queue) {
 pi_result redefinedEventsWait(pi_uint32 num_events,
                               const pi_event *event_list) {
   ++TestContext.NEventsWaitedFor;
-  return PI_SUCCESS;
-}
-
-pi_result redefinedEventGetInfo(pi_event event, pi_event_info param_name,
-                                size_t param_value_size, void *param_value,
-                                size_t *param_value_size_ret) {
   return PI_SUCCESS;
 }
 
@@ -89,17 +77,15 @@ pi_result redefinedEventRelease(pi_event event) {
 TEST(QueueWait, QueueWaitTest) {
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<detail::PiApiKind::piQueueCreate>(redefinedQueueCreate);
-  Mock.redefine<detail::PiApiKind::piQueueRelease>(redefinedQueueRelease);
-  Mock.redefine<detail::PiApiKind::piQueueFinish>(redefinedQueueFinish);
-  Mock.redefine<detail::PiApiKind::piextUSMEnqueueMemset>(
+  Mock.redefineBefore<detail::PiApiKind::piQueueCreate>(redefinedQueueCreate);
+  Mock.redefineBefore<detail::PiApiKind::piQueueFinish>(redefinedQueueFinish);
+  Mock.redefineBefore<detail::PiApiKind::piextUSMEnqueueMemset>(
       redefinedUSMEnqueueMemset);
-  Mock.redefine<detail::PiApiKind::piEventsWait>(redefinedEventsWait);
-  Mock.redefine<detail::PiApiKind::piEnqueueMemBufferFill>(
+  Mock.redefineBefore<detail::PiApiKind::piEventsWait>(redefinedEventsWait);
+  Mock.redefineBefore<detail::PiApiKind::piEnqueueMemBufferFill>(
       redefinedEnqueueMemBufferFill);
-  Mock.redefine<detail::PiApiKind::piEventGetInfo>(redefinedEventGetInfo);
-  Mock.redefine<detail::PiApiKind::piEventRetain>(redefinedEventRetain);
-  Mock.redefine<detail::PiApiKind::piEventRelease>(redefinedEventRelease);
+  Mock.redefineBefore<detail::PiApiKind::piEventRetain>(redefinedEventRetain);
+  Mock.redefineBefore<detail::PiApiKind::piEventRelease>(redefinedEventRelease);
   context Ctx{Plt.get_devices()[0]};
   queue Q{Ctx, default_selector()};
 

--- a/sycl/unittests/scheduler/Commands.cpp
+++ b/sycl/unittests/scheduler/Commands.cpp
@@ -34,10 +34,6 @@ pi_result redefinePiEventGetInfo(pi_event, pi_event_info, size_t,
   return PI_SUCCESS;
 }
 
-pi_result redefinePiEventRetain(pi_event) { return PI_SUCCESS; }
-
-pi_result redefinePiEventRelease(pi_event) { return PI_SUCCESS; }
-
 //
 // This test checks a handling of empty events in WaitWithBarrier command.
 // Original reproducer for l0 plugin led to segfault(nullptr dereference):
@@ -53,7 +49,7 @@ TEST_F(SchedulerTest, WaitEmptyEventWithBarrier) {
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
 
-  Mock.redefine<detail::PiApiKind::piEnqueueEventsWaitWithBarrier>(
+  Mock.redefineBefore<detail::PiApiKind::piEnqueueEventsWaitWithBarrier>(
       redefinePiEnqueueEventsWaitWithBarrier);
 
   queue Queue{Plt.get_devices()[0]};
@@ -62,13 +58,17 @@ TEST_F(SchedulerTest, WaitEmptyEventWithBarrier) {
   queue_global_context =
       detail::getSyclObjImpl(Queue.get_context())->getHandleRef();
 
-  Mock.redefine<detail::PiApiKind::piEventGetInfo>(redefinePiEventGetInfo);
-  Mock.redefine<detail::PiApiKind::piEventRetain>(redefinePiEventRetain);
-  Mock.redefine<detail::PiApiKind::piEventRelease>(redefinePiEventRelease);
+  Mock.redefineBefore<detail::PiApiKind::piEventGetInfo>(
+      redefinePiEventGetInfo);
 
   auto EmptyEvent = std::make_shared<detail::event_impl>();
-  auto Event = std::make_shared<detail::event_impl>(
-      reinterpret_cast<RT::PiEvent>(0x01), Queue.get_context());
+
+  pi_event PIEvent = nullptr;
+  pi_result Res = mock_piEventCreate(/*context = */ (pi_context)0x1, &PIEvent);
+  assert(PI_SUCCESS == Res);
+
+  auto Event =
+      std::make_shared<detail::event_impl>(PIEvent, Queue.get_context());
 
   using EventList = std::vector<detail::EventImplPtr>;
   std::vector<EventList> InputEventWaitLists = {

--- a/sycl/unittests/scheduler/EnqueueWithDependsOnDeps.cpp
+++ b/sycl/unittests/scheduler/EnqueueWithDependsOnDeps.cpp
@@ -303,8 +303,9 @@ TEST_F(SchedulerTest, InOrderEnqueueNoMemObjDoubleKernelDepHost) {
   if (!CheckTestExecutionRequirements(Plt))
     return;
 
-  Mock.redefine<detail::PiApiKind::piEventsWait>(redefinedEventsWaitCustom);
-  Mock.redefine<detail::PiApiKind::piEnqueueKernelLaunch>(
+  Mock.redefineBefore<detail::PiApiKind::piEventsWait>(
+      redefinedEventsWaitCustom);
+  Mock.redefineBefore<detail::PiApiKind::piEnqueueKernelLaunch>(
       redefinedEnqueueKernelLaunchCustom);
 
   {

--- a/sycl/unittests/scheduler/InOrderQueueDeps.cpp
+++ b/sycl/unittests/scheduler/InOrderQueueDeps.cpp
@@ -79,17 +79,19 @@ pi_result redefinedEventRelease(pi_event event) { return PI_SUCCESS; }
 TEST_F(SchedulerTest, InOrderQueueDeps) {
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<detail::PiApiKind::piMemBufferCreate>(redefinedMemBufferCreate);
-  Mock.redefine<detail::PiApiKind::piMemRelease>(redefinedMemRelease);
-  Mock.redefine<detail::PiApiKind::piEnqueueMemBufferReadRect>(
+  Mock.redefineBefore<detail::PiApiKind::piMemBufferCreate>(
+      redefinedMemBufferCreate);
+  Mock.redefineBefore<detail::PiApiKind::piMemRelease>(redefinedMemRelease);
+  Mock.redefineBefore<detail::PiApiKind::piEnqueueMemBufferReadRect>(
       redefinedEnqueueMemBufferReadRect);
-  Mock.redefine<detail::PiApiKind::piEnqueueMemBufferWriteRect>(
+  Mock.redefineBefore<detail::PiApiKind::piEnqueueMemBufferWriteRect>(
       redefinedEnqueueMemBufferWriteRect);
-  Mock.redefine<detail::PiApiKind::piEnqueueMemBufferMap>(
+  Mock.redefineBefore<detail::PiApiKind::piEnqueueMemBufferMap>(
       redefinedEnqueueMemBufferMap);
-  Mock.redefine<detail::PiApiKind::piEnqueueMemUnmap>(redefinedEnqueueMemUnmap);
-  Mock.redefine<detail::PiApiKind::piEventsWait>(redefinedEventsWait);
-  Mock.redefine<detail::PiApiKind::piEventRelease>(redefinedEventRelease);
+  Mock.redefineBefore<detail::PiApiKind::piEnqueueMemUnmap>(
+      redefinedEnqueueMemUnmap);
+  Mock.redefineBefore<detail::PiApiKind::piEventsWait>(redefinedEventsWait);
+  Mock.redefineBefore<detail::PiApiKind::piEventRelease>(redefinedEventRelease);
 
   context Ctx{Plt.get_devices()[0]};
   queue InOrderQueue{Ctx, default_selector_v, property::queue::in_order()};

--- a/sycl/unittests/scheduler/InOrderQueueHostTaskDeps.cpp
+++ b/sycl/unittests/scheduler/InOrderQueueHostTaskDeps.cpp
@@ -34,7 +34,7 @@ inline pi_result redefinedEventsWait(pi_uint32 num_events,
 TEST_F(SchedulerTest, InOrderQueueHostTaskDeps) {
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<detail::PiApiKind::piEventsWait>(redefinedEventsWait);
+  Mock.redefineBefore<detail::PiApiKind::piEventsWait>(redefinedEventsWait);
 
   context Ctx{Plt};
   queue InOrderQueue{Ctx, default_selector_v, property::queue::in_order()};

--- a/sycl/unittests/scheduler/NoHostUnifiedMemory.cpp
+++ b/sycl/unittests/scheduler/NoHostUnifiedMemory.cpp
@@ -18,10 +18,11 @@
 
 using namespace sycl;
 
-static pi_result redefinedDeviceGetInfo(pi_device Device,
-                                        pi_device_info ParamName,
-                                        size_t ParamValueSize, void *ParamValue,
-                                        size_t *ParamValueSizeRet) {
+static pi_result redefinedDeviceGetInfoAfter(pi_device Device,
+                                             pi_device_info ParamName,
+                                             size_t ParamValueSize,
+                                             void *ParamValue,
+                                             size_t *ParamValueSizeRet) {
   if (ParamName == PI_DEVICE_INFO_HOST_UNIFIED_MEMORY) {
     auto *Result = reinterpret_cast<pi_bool *>(ParamValue);
     *Result = false;
@@ -40,33 +41,11 @@ redefinedMemBufferCreate(pi_context context, pi_mem_flags flags, size_t size,
   return PI_SUCCESS;
 }
 
-static pi_result redefinedEnqueueMemBufferReadRect(
-    pi_queue command_queue, pi_mem buffer, pi_bool blocking_read,
-    pi_buff_rect_offset buffer_offset, pi_buff_rect_offset host_offset,
-    pi_buff_rect_region region, size_t buffer_row_pitch,
-    size_t buffer_slice_pitch, size_t host_row_pitch, size_t host_slice_pitch,
-    void *ptr, pi_uint32 num_events_in_wait_list,
-    const pi_event *event_wait_list, pi_event *event) {
-  return PI_SUCCESS;
-}
-
-static pi_result redefinedEnqueueMemBufferWriteRect(
-    pi_queue command_queue, pi_mem buffer, pi_bool blocking_write,
-    pi_buff_rect_offset buffer_offset, pi_buff_rect_offset host_offset,
-    pi_buff_rect_region region, size_t buffer_row_pitch,
-    size_t buffer_slice_pitch, size_t host_row_pitch, size_t host_slice_pitch,
-    const void *ptr, pi_uint32 num_events_in_wait_list,
-    const pi_event *event_wait_list, pi_event *event) {
-  return PI_SUCCESS;
-}
-
-static pi_result redefinedMemRetain(pi_mem mem) { return PI_SUCCESS; }
-static pi_result redefinedMemRelease(pi_mem mem) { return PI_SUCCESS; }
-
 static pi_context InteropPiContext = nullptr;
-static pi_result redefinedMemGetInfo(pi_mem mem, pi_mem_info param_name,
-                                     size_t param_value_size, void *param_value,
-                                     size_t *param_value_size_ret) {
+static pi_result redefinedMemGetInfoAfter(pi_mem mem, pi_mem_info param_name,
+                                          size_t param_value_size,
+                                          void *param_value,
+                                          size_t *param_value_size_ret) {
   auto *Result = reinterpret_cast<pi_context *>(param_value);
   *Result = InteropPiContext;
   return PI_SUCCESS;
@@ -90,16 +69,12 @@ redefinedMemCreateWithNativeHandle(pi_native_handle native_handle,
 TEST_F(SchedulerTest, NoHostUnifiedMemory) {
   unittest::PiMock Mock;
   queue Q{Mock.getPlatform().get_devices()[0]};
-  Mock.redefine<detail::PiApiKind::piDeviceGetInfo>(redefinedDeviceGetInfo);
-  Mock.redefine<detail::PiApiKind::piMemBufferCreate>(redefinedMemBufferCreate);
-  Mock.redefine<detail::PiApiKind::piEnqueueMemBufferReadRect>(
-      redefinedEnqueueMemBufferReadRect);
-  Mock.redefine<detail::PiApiKind::piEnqueueMemBufferWriteRect>(
-      redefinedEnqueueMemBufferWriteRect);
-  Mock.redefine<detail::PiApiKind::piMemRetain>(redefinedMemRetain);
-  Mock.redefine<detail::PiApiKind::piMemRelease>(redefinedMemRelease);
-  Mock.redefine<detail::PiApiKind::piMemGetInfo>(redefinedMemGetInfo);
-  Mock.redefine<detail::PiApiKind::piextMemCreateWithNativeHandle>(
+  Mock.redefineAfter<detail::PiApiKind::piDeviceGetInfo>(
+      redefinedDeviceGetInfoAfter);
+  Mock.redefineBefore<detail::PiApiKind::piMemBufferCreate>(
+      redefinedMemBufferCreate);
+  Mock.redefineAfter<detail::PiApiKind::piMemGetInfo>(redefinedMemGetInfoAfter);
+  Mock.redefineBefore<detail::PiApiKind::piextMemCreateWithNativeHandle>(
       redefinedMemCreateWithNativeHandle);
   sycl::detail::QueueImplPtr QImpl = detail::getSyclObjImpl(Q);
 
@@ -213,7 +188,12 @@ TEST_F(SchedulerTest, NoHostUnifiedMemory) {
   }
   // Check that interoperability memory objects are initialized.
   {
-    cl_mem MockInteropBuffer = reinterpret_cast<cl_mem>(1);
+    pi_mem MockInteropBuffer = nullptr;
+    pi_result PIRes = mock_piMemBufferCreate(
+        /*pi_context=*/0x0, /*pi_mem_flags=*/PI_MEM_FLAGS_ACCESS_RW, /*size=*/1,
+        /*host_ptr=*/nullptr, &MockInteropBuffer);
+    assert(PI_SUCCESS == PIRes);
+
     context InteropContext = Q.get_context();
     InteropPiContext = detail::getSyclObjImpl(InteropContext)->getHandleRef();
     auto BufI = std::make_shared<detail::buffer_impl>(

--- a/sycl/unittests/scheduler/PostEnqueueCleanup.cpp
+++ b/sycl/unittests/scheduler/PostEnqueueCleanup.cpp
@@ -205,10 +205,11 @@ TEST_F(SchedulerTest, PostEnqueueCleanup) {
       detail::SYCLConfig<detail::SYCL_HOST_UNIFIED_MEMORY>::reset};
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<detail::PiApiKind::piEnqueueMemBufferMap>(
+  Mock.redefineBefore<detail::PiApiKind::piEnqueueMemBufferMap>(
       redefinedEnqueueMemBufferMap);
-  Mock.redefine<detail::PiApiKind::piEnqueueMemUnmap>(redefinedEnqueueMemUnmap);
-  Mock.redefine<detail::PiApiKind::piEnqueueMemBufferFill>(
+  Mock.redefineBefore<detail::PiApiKind::piEnqueueMemUnmap>(
+      redefinedEnqueueMemUnmap);
+  Mock.redefineBefore<detail::PiApiKind::piEnqueueMemBufferFill>(
       redefinedEnqueueMemBufferFill);
 
   context Ctx{Plt};

--- a/sycl/unittests/scheduler/QueueFlushing.cpp
+++ b/sycl/unittests/scheduler/QueueFlushing.cpp
@@ -26,64 +26,16 @@ static pi_result redefinedQueueFlush(pi_queue Queue) {
   return PI_SUCCESS;
 }
 
-static pi_result redefinedEventGetInfo(pi_event event, pi_event_info param_name,
-                                       size_t param_value_size,
-                                       void *param_value,
-                                       size_t *param_value_size_ret) {
+static pi_result redefinedEventGetInfoAfter(pi_event event,
+                                            pi_event_info param_name,
+                                            size_t param_value_size,
+                                            void *param_value,
+                                            size_t *param_value_size_ret) {
   if (param_name == PI_EVENT_INFO_COMMAND_EXECUTION_STATUS) {
     auto *Status = reinterpret_cast<pi_event_status *>(param_value);
     *Status = EventStatus;
     EventStatusQueried = true;
   }
-  return PI_SUCCESS;
-}
-
-static pi_result redefinedEnqueueMemBufferReadRect(
-    pi_queue command_queue, pi_mem buffer, pi_bool blocking_read,
-    pi_buff_rect_offset buffer_offset, pi_buff_rect_offset host_offset,
-    pi_buff_rect_region region, size_t buffer_row_pitch,
-    size_t buffer_slice_pitch, size_t host_row_pitch, size_t host_slice_pitch,
-    void *ptr, pi_uint32 num_events_in_wait_list,
-    const pi_event *event_wait_list, pi_event *event) {
-  *event = reinterpret_cast<pi_event>(new int{});
-  return PI_SUCCESS;
-}
-
-static pi_result redefinedEnqueueMemBufferWriteRect(
-    pi_queue command_queue, pi_mem buffer, pi_bool blocking_write,
-    pi_buff_rect_offset buffer_offset, pi_buff_rect_offset host_offset,
-    pi_buff_rect_region region, size_t buffer_row_pitch,
-    size_t buffer_slice_pitch, size_t host_row_pitch, size_t host_slice_pitch,
-    const void *ptr, pi_uint32 num_events_in_wait_list,
-    const pi_event *event_wait_list, pi_event *event) {
-  *event = reinterpret_cast<pi_event>(new int{});
-  return PI_SUCCESS;
-}
-
-static pi_result redefinedEnqueueMemBufferMap(
-    pi_queue command_queue, pi_mem buffer, pi_bool blocking_map,
-    pi_map_flags map_flags, size_t offset, size_t size,
-    pi_uint32 num_events_in_wait_list, const pi_event *event_wait_list,
-    pi_event *event, void **ret_map) {
-  *event = reinterpret_cast<pi_event>(new int{});
-  return PI_SUCCESS;
-}
-
-static pi_result redefinedEnqueueMemUnmap(pi_queue command_queue, pi_mem memobj,
-                                          void *mapped_ptr,
-                                          pi_uint32 num_events_in_wait_list,
-                                          const pi_event *event_wait_list,
-                                          pi_event *event) {
-  *event = reinterpret_cast<pi_event>(new int{});
-  return PI_SUCCESS;
-}
-
-static pi_result redefinedEnqueueMemBufferFill(
-    pi_queue command_queue, pi_mem buffer, const void *pattern,
-    size_t pattern_size, size_t offset, size_t size,
-    pi_uint32 num_events_in_wait_list, const pi_event *event_wait_list,
-    pi_event *event) {
-  *event = reinterpret_cast<pi_event>(new int{});
   return PI_SUCCESS;
 }
 
@@ -98,7 +50,12 @@ static void addDepAndEnqueue(detail::Command *Cmd,
                              detail::Requirement &MockReq) {
   MockCommand DepCmd(DepQueue);
   std::vector<detail::Command *> ToCleanUp;
-  DepCmd.getEvent()->getHandleRef() = reinterpret_cast<pi_event>(new int{});
+
+  pi_event PIEvent = nullptr;
+  pi_result CallRet = mock_piEventCreate(/*pi_context=*/0x0, &PIEvent);
+  assert(PI_SUCCESS == CallRet);
+
+  DepCmd.getEvent()->getHandleRef() = PIEvent;
   (void)Cmd->addDep(detail::DepDesc{&DepCmd, &MockReq, nullptr}, ToCleanUp);
 
   detail::EnqueueResultT Res;
@@ -127,17 +84,9 @@ static void testEventStatusCheck(detail::Command *Cmd,
 TEST_F(SchedulerTest, QueueFlushing) {
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<detail::PiApiKind::piQueueFlush>(redefinedQueueFlush);
-  Mock.redefine<detail::PiApiKind::piEventGetInfo>(redefinedEventGetInfo);
-  Mock.redefine<detail::PiApiKind::piEnqueueMemBufferReadRect>(
-      redefinedEnqueueMemBufferReadRect);
-  Mock.redefine<detail::PiApiKind::piEnqueueMemBufferWriteRect>(
-      redefinedEnqueueMemBufferWriteRect);
-  Mock.redefine<detail::PiApiKind::piEnqueueMemBufferMap>(
-      redefinedEnqueueMemBufferMap);
-  Mock.redefine<detail::PiApiKind::piEnqueueMemUnmap>(redefinedEnqueueMemUnmap);
-  Mock.redefine<detail::PiApiKind::piEnqueueMemBufferFill>(
-      redefinedEnqueueMemBufferFill);
+  Mock.redefineBefore<detail::PiApiKind::piQueueFlush>(redefinedQueueFlush);
+  Mock.redefineAfter<detail::PiApiKind::piEventGetInfo>(
+      redefinedEventGetInfoAfter);
 
   context Ctx{Plt};
   queue QueueA{Ctx, default_selector_v};
@@ -149,7 +98,15 @@ TEST_F(SchedulerTest, QueueFlushing) {
   int val;
   buffer<int, 1> Buf(&val, range<1>(1));
   detail::Requirement MockReq = getMockRequirement(Buf);
+
+  pi_mem PIBuf = nullptr;
+  pi_result Ret = mock_piMemBufferCreate(/*pi_context=*/0x0,
+                                         PI_MEM_FLAGS_ACCESS_RW, /*size=*/1,
+                                         /*host_ptr=*/nullptr, &PIBuf);
+  assert(Ret == PI_SUCCESS);
+
   detail::AllocaCommand AllocaCmd = detail::AllocaCommand(QueueImplA, MockReq);
+  AllocaCmd.MMemAllocation = PIBuf;
   void *MockHostPtr;
   detail::EnqueueResultT Res;
   std::vector<detail::Command *> ToCleanUp;
@@ -201,7 +158,12 @@ TEST_F(SchedulerTest, QueueFlushing) {
                                 access::mode::read_write};
     detail::EventImplPtr DepEvent{new detail::event_impl(QueueImplB)};
     DepEvent->setContextImpl(QueueImplB->getContextImplPtr());
-    DepEvent->getHandleRef() = reinterpret_cast<pi_event>(new int{});
+
+    pi_event PIEvent = nullptr;
+    pi_result CallRet = mock_piEventCreate(/*pi_context=*/0x0, &PIEvent);
+    assert(PI_SUCCESS == CallRet);
+
+    DepEvent->getHandleRef() = PIEvent;
     (void)Cmd.addDep(DepEvent, ToCleanUp);
     MockScheduler::enqueueCommand(&Cmd, Res, detail::NON_BLOCKING);
     EXPECT_TRUE(QueueFlushed);
@@ -218,7 +180,12 @@ TEST_F(SchedulerTest, QueueFlushing) {
       detail::QueueImplPtr TempQueueImpl = detail::getSyclObjImpl(TempQueue);
       DepEvent.reset(new detail::event_impl(TempQueueImpl));
       DepEvent->setContextImpl(TempQueueImpl->getContextImplPtr());
-      DepEvent->getHandleRef() = reinterpret_cast<pi_event>(new int{});
+
+      pi_event PIEvent = nullptr;
+      pi_result CallRet = mock_piEventCreate(/*pi_context=*/0x0, &PIEvent);
+      assert(PI_SUCCESS == CallRet);
+
+      DepEvent->getHandleRef() = PIEvent;
     }
     (void)Cmd.addDep(DepEvent, ToCleanUp);
     MockScheduler::enqueueCommand(&Cmd, Res, detail::NON_BLOCKING);
@@ -239,10 +206,20 @@ TEST_F(SchedulerTest, QueueFlushing) {
     detail::MapMemObject Cmd = {&AllocaCmd, MockReq, &MockHostPtr, QueueImplA,
                                 access::mode::read_write};
     MockCommand DepCmdA(QueueImplB);
-    DepCmdA.getEvent()->getHandleRef() = reinterpret_cast<pi_event>(new int{});
+
+    pi_event PIEvent = nullptr;
+    pi_result CallRet = mock_piEventCreate(/*pi_context=*/0x0, &PIEvent);
+    assert(PI_SUCCESS == CallRet);
+
+    DepCmdA.getEvent()->getHandleRef() = PIEvent;
     (void)Cmd.addDep(detail::DepDesc{&DepCmdA, &MockReq, nullptr}, ToCleanUp);
     MockCommand DepCmdB(QueueImplB);
-    DepCmdB.getEvent()->getHandleRef() = reinterpret_cast<pi_event>(new int{});
+
+    PIEvent = nullptr;
+    CallRet = mock_piEventCreate(/*pi_context=*/0x0, &PIEvent);
+    assert(PI_SUCCESS == CallRet);
+
+    DepCmdB.getEvent()->getHandleRef() = PIEvent;
     (void)Cmd.addDep(detail::DepDesc{&DepCmdB, &MockReq, nullptr}, ToCleanUp);
     // The check is performed in redefinedQueueFlush
     MockScheduler::enqueueCommand(&Cmd, Res, detail::NON_BLOCKING);
@@ -254,7 +231,12 @@ TEST_F(SchedulerTest, QueueFlushing) {
     detail::MapMemObject CmdA{&AllocaCmd, MockReq, &MockHostPtr, QueueImplA,
                               access::mode::read_write};
     MockCommand DepCmd(QueueImplB);
-    DepCmd.getEvent()->getHandleRef() = reinterpret_cast<pi_event>(new int{});
+
+    pi_event PIEvent = nullptr;
+    pi_result CallRet = mock_piEventCreate(/*pi_context=*/0x0, &PIEvent);
+    assert(PI_SUCCESS == CallRet);
+
+    DepCmd.getEvent()->getHandleRef() = PIEvent;
     (void)CmdA.addDep(detail::DepDesc{&DepCmd, &MockReq, nullptr}, ToCleanUp);
     MockScheduler::enqueueCommand(&CmdA, Res, detail::NON_BLOCKING);
 

--- a/sycl/unittests/scheduler/Regression.cpp
+++ b/sycl/unittests/scheduler/Regression.cpp
@@ -57,7 +57,7 @@ static pi_result redefinedEnqueueNativeKernel(
 TEST_F(SchedulerTest, CheckArgsBlobInPiEnqueueNativeKernelIsValid) {
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<detail::PiApiKind::piEnqueueNativeKernel>(
+  Mock.redefineBefore<detail::PiApiKind::piEnqueueNativeKernel>(
       redefinedEnqueueNativeKernel);
 
   auto Kernel = []() { std::cout << "Blablabla"; };

--- a/sycl/unittests/scheduler/RequiredWGSize.cpp
+++ b/sycl/unittests/scheduler/RequiredWGSize.cpp
@@ -66,9 +66,9 @@ static void reset() {
 static void performChecks() {
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<sycl::detail::PiApiKind::piEnqueueKernelLaunch>(
+  Mock.redefineBefore<sycl::detail::PiApiKind::piEnqueueKernelLaunch>(
       redefinedEnqueueKernelLaunch);
-  Mock.redefine<sycl::detail::PiApiKind::piKernelGetGroupInfo>(
+  Mock.redefineBefore<sycl::detail::PiApiKind::piKernelGetGroupInfo>(
       redefinedKernelGetGroupInfo);
 
   const sycl::device Dev = Plt.get_devices()[0];

--- a/sycl/unittests/stream/stream.cpp
+++ b/sycl/unittests/stream/stream.cpp
@@ -31,7 +31,7 @@ redefinedMemBufferCreate(pi_context context, pi_mem_flags flags, size_t size,
 TEST(Stream, TestStreamConstructorExceptionNoAllocation) {
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<sycl::detail::PiApiKind::piMemBufferCreate>(
+  Mock.redefineBefore<sycl::detail::PiApiKind::piMemBufferCreate>(
       redefinedMemBufferCreate);
 
   const sycl::device Dev = Plt.get_devices()[0];

--- a/sycl/unittests/windows/dllmain.cpp
+++ b/sycl/unittests/windows/dllmain.cpp
@@ -38,7 +38,7 @@ TEST(Windows, DllMainCall) {
 #ifdef _WIN32
   sycl::unittest::PiMock Mock;
   sycl::platform Plt = Mock.getPlatform();
-  Mock.redefine<sycl::detail::PiApiKind::piTearDown>(redefinedTearDown);
+  Mock.redefineBefore<sycl::detail::PiApiKind::piTearDown>(redefinedTearDown);
 
   // Teardown calls are only expected on sycl.dll library unload, not when
   // process gets terminated.


### PR DESCRIPTION
The patch adds more logic to default redefinitions of PI APIs:
1. Allocate, refcount and deallocated various handles
2. Handle sub-buffer creation

Also the patch adds support for adding PI functions to be called in addition (before or after) to the original function. This allows intersecting PI API calls for introspection while still allowing original function take care of handles. Or add some post processing of the returned values.