### PR TITLE
[SYCL-MLIR] Add noundef attribute to non-aggregate types if allowed

### DIFF
--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -148,6 +148,16 @@ public:
   /// function return value.
   static bool determineNoUndef(clang::QualType QTy,
                                const clang::CodeGen::ABIArgInfo &AI);
+
+  /// Return the argument kind for a SPIR target for the given type.
+  static clang::CodeGen::ABIArgInfo::Kind
+  classifySPIRCallArgumentType(clang::QualType QTy,
+                               const clang::ASTContext &Context);
+
+  /// Return the argument kind for a default target for the given type.
+  static clang::CodeGen::ABIArgInfo::Kind
+  classifyDefaultCallArgumentType(clang::QualType QTy,
+                                  const clang::ASTContext &Context);
 };
 
 class MLIRASTConsumer : public clang::ASTConsumer {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -28,24 +28,38 @@
 // CHECK-LLVM-DAG: %"struct.sycl::_V1::detail::ItemBase.1.true" = type { %"class.sycl::_V1::range.1", %"class.sycl::_V1::id.1", %"class.sycl::_V1::id.1" }
 
 // CHECK-MLIR: gpu.module @device_functions
-// CHECK-MLIR: gpu.func @_ZTS8kernel_1(%arg0: memref<?xi32, 1>, 
-// CHECK-MLIR-SAME:    %arg1: memref<?x!sycl_range_1_> [[PARM_ATTRS:{llvm.align = 8 : i64, llvm.byval, llvm.noundef}]],  
-// CHECK-MLIR-SAME:    %arg2: memref<?x!sycl_range_1_> [[PARM_ATTRS]], 
-// CHECK-MLIR-SAME:    %arg3: memref<?x!sycl_id_1_> [[PARM_ATTRS]]) 
+// COM: Although this is a pointer, we are not adding pointer-specific attributes by now.
+// CHECK-MLIR-LABEL: gpu.func @_ZTS8kernel_1(
+// CHECK-MLIR-SAME:    %arg0: memref<?xi32, 1> [[SCALAR_ATTRS:{llvm.noundef}]]
+// CHECK-MLIR-SAME:    %arg1: memref<?x!sycl_range_1_> [[STRUCT_ATTRS:{llvm.align = 8 : i64, llvm.byval, llvm.noundef}]]
+// CHECK-MLIR-SAME:    %arg2: memref<?x!sycl_range_1_> [[STRUCT_ATTRS]]
+// CHECK-MLIR-SAME:    %arg3: memref<?x!sycl_id_1_> [[STRUCT_ATTRS]]
+// CHECK-MLIR-SAME:    %arg4: i32 [[SCALAR_ATTRS]])
 // CHECK-MLIR-SAME:  kernel attributes {[[CCONV:llvm.cconv = #llvm.cconv<spir_kernelcc>]], [[LINKAGE:llvm.linkage = #llvm.linkage<weak_odr>]],
 // CHECK-MLIR-SAME:  [[PASSTHROUGH:passthrough = \[\["sycl-module-id", ".*/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp"\], "norecurse", "nounwind", "convergent", "mustprogress"\]]]} {
 // CHECK-MLIR-NOT: gpu.func kernel
 
-// CHECK-LLVM: define weak_odr spir_kernel void @_ZTS8kernel_1(i32 addrspace(1)* {{.*}}, [[RANGE_TY:%"class.sycl::_V1::range.1"]]* noundef byval([[RANGE_TY]]) align 8 {{.*}}, [[RANGE_TY]]* noundef byval([[RANGE_TY]]) align 8 {{.*}}, 
-// CHECK-LLVM-SAME:  [[ID_TY:%"class.sycl::_V1::id.1"]]* noundef byval([[ID_TY]]) align 8 {{.*}}) #1
+// COM: Although this is a pointer, we are not adding pointer-specific attributes by now.
+// CHECK-LLVM-LABEL: define weak_odr spir_kernel void @_ZTS8kernel_1(
+// CHECK-LLVM-SAME:    i32 addrspace(1)* [[SCALAR_ATTRS:noundef]] %0
+// CHECK-LLVM-SAME:    [[RANGE_TY:%"class.sycl::_V1::range.1"]]* noundef byval([[RANGE_TY]]) align 8 %1
+// CHECK-LLVM-SAME:    [[RANGE_TY]]* noundef byval([[RANGE_TY]]) align 8 %2
+// CHECK-LLVM-SAME:    [[ID_TY:%"class.sycl::_V1::id.1"]]* noundef byval([[ID_TY]]) align 8 %3
+// CHECK-LLVM-SAME:    i32 [[SCALAR_ATTRS]] %4
+// CHECK-LLVM-SAME:  ) #1
+
 class kernel_1 {
  sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write> A;
+ const sycl::cl_int B;
 
 public:
-	kernel_1(sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write> A) : A(A) {}
+  kernel_1(sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write> A,
+	   sycl::cl_int B)
+    : A(A),
+      B(B) {}
 
   void operator()(sycl::id<1> id) const {
-    A[id] = 42;
+    A[id] = B;
   }
 };
 
@@ -57,16 +71,17 @@ void host_1() {
     auto buf = sycl::buffer<int, 1>{nullptr, range};
     q.submit([&](sycl::handler &cgh) {
       auto A = buf.get_access<sycl::access::mode::read_write>(cgh);
-      auto ker =  kernel_1{A};
+      auto ker = kernel_1{A, 42};
       cgh.parallel_for<kernel_1>(range, ker);
     });
   }
 }
 
-// CHECK-MLIR: gpu.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2(%arg0: memref<?xi32, 1>, 
-// CHECK-MLIR-SAME:     %arg1: memref<?x!sycl_range_1_> [[PARM_ATTRS]], 
-// CHECK-MLIR-SAME:     %arg2: memref<?x!sycl_range_1_> [[PARM_ATTRS]], 
-// CHECK-MLIR-SAME:     %arg3: memref<?x!sycl_id_1_> [[PARM_ATTRS]])
+// COM: Although this is a pointer, we are not adding pointer-specific attributes by now.
+// CHECK-MLIR: gpu.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2(%arg0: memref<?xi32, 1> [[SCALAR_ATTRS]],
+// CHECK-MLIR-SAME:     %arg1: memref<?x!sycl_range_1_> [[STRUCT_ATTRS]],
+// CHECK-MLIR-SAME:     %arg2: memref<?x!sycl_range_1_> [[STRUCT_ATTRS]],
+// CHECK-MLIR-SAME:     %arg3: memref<?x!sycl_id_1_> [[STRUCT_ATTRS]])
 // CHECK-MLIR-SAME:     kernel attributes {[[CCONV]], [[LINKAGE]], [[PASSTHROUGH]]}
 // CHECK-MLIR-NOT: gpu.func kernel
 


### PR DESCRIPTION
Add this attribute if allowed taking into account the kernel argument kind.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>