### PR TITLE
[SYCL-MLIR] Add option to generate all SYCL functions

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -21,6 +21,8 @@ using namespace mlir::arith;
 using namespace mlir::func;
 using namespace mlirclang;
 
+extern llvm::cl::opt<bool> GenerateAllSYCLFuncs;
+
 /// Try to typecast the caller arg of type MemRef to fit the corresponding
 /// callee arg type. We only deal with the cast where src and dst have the same
 /// shape size and elem type, and just the first shape differs: src has -1 and
@@ -1536,7 +1538,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
 
   std::string mangledName =
       MLIRScanner::getMangledFuncName(*callee, Glob.getCGM());
-  if (isSupportedFunctions(mangledName))
+  if (GenerateAllSYCLFuncs || isSupportedFunctions(mangledName))
     ShouldEmit = true;
 
   FunctionToEmit F(*callee, mlirclang::getInputContext(builder));

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -19,6 +19,8 @@ using namespace clang;
 using namespace mlir;
 using namespace mlir::arith;
 
+extern llvm::cl::opt<bool> GenerateAllSYCLFuncs;
+
 ValueCategory
 MLIRScanner::VisitExtVectorElementExpr(clang::ExtVectorElementExpr *expr) {
   auto base = Visit(expr->getBase());
@@ -839,7 +841,7 @@ ValueCategory MLIRScanner::VisitConstructCommon(clang::CXXConstructExpr *cons,
   std::string mangledName = MLIRScanner::getMangledFuncName(
       cast<FunctionDecl>(*ctorDecl), Glob.getCGM());
   mangledName = (PrefixABI + mangledName);
-  if (isSupportedFunctions(mangledName))
+  if (GenerateAllSYCLFuncs || isSupportedFunctions(mangledName))
     ShouldEmit = true;
 
   FunctionToEmit F(*ctorDecl, mlirclang::getInputContext(builder));

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -69,6 +69,9 @@ static cl::opt<bool>
     CombinedStructABI("struct-abi", cl::init(true),
                       cl::desc("Use literal LLVM ABI for structs"));
 
+cl::opt<bool> GenerateAllSYCLFuncs("gen-all-sycl-funcs", cl::init(false),
+                                   cl::desc("Generate all SYCL functions"));
+
 constexpr llvm::StringLiteral MLIRASTConsumer::DeviceModuleName;
 
 /******************************************************************************/


### PR DESCRIPTION
Added an option `gen-all-sycl-funcs` to emit all SYCL functions.
We are currently using a white list `supportedFuncs` to determine which SYCL functions to generate.
We need an easier way to emit all SYCL functions for testing.
Eventually the white list should be removed.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>