### PR TITLE
[SYCL][NFC] Add additional test case to emit_program_metadata

### DIFF
--- a/llvm/test/tools/sycl-post-link/emit_program_metadata.ll
+++ b/llvm/test/tools/sycl-post-link/emit_program_metadata.ll
@@ -1,14 +1,21 @@
 ; This test checks that the post-link tool generates SYCL program metadata.
 ;
-; RUN: sycl-post-link -emit-program-metadata -S %s -o %t.files.table
+; RUN: sycl-post-link -emit-program-metadata -device-globals -S %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files.table --check-prefixes CHECK-TABLE
 ; RUN: FileCheck %s -input-file=%t.files_0.prop --match-full-lines --check-prefixes CHECK-PROP
 
 target triple = "spir64-unknown-unknown"
 
+attributes #0 = { "sycl-work-group-size"="4,2,1" }
+
 !0 = !{i32 1, i32 2, i32 4}
 
 define weak_odr spir_kernel void @SpirKernel1(float %arg1) !reqd_work_group_size !0 {
+  call void @foo(float %arg1)
+  ret void
+}
+
+define weak_odr spir_kernel void @SpirKernel2(float %arg1) #0 {
   call void @foo(float %arg1)
   ret void
 }
@@ -18,6 +25,7 @@ declare void @foo(float)
 ; CHECK-PROP: [SYCL/program metadata]
 ; // Base64 encoding in the prop file (including 8 bytes length):
 ; CHECK-PROP-NEXT: SpirKernel1@reqd_work_group_size=2|gBAAAAAAAAQAAAAACAAAAQAAAAA
+; CHECK-PROP-NEXT: SpirKernel2@reqd_work_group_size=2|gBAAAAAAAAQAAAAACAAAAQAAAAA
 
 ; CHECK-TABLE: [Code|Properties]
 ; CHECK-TABLE-NEXT: {{.*}}files_0.prop


### PR DESCRIPTION
This commit adds an additional test case to emit_program_metadata for checking that the "sycl-work-group-size" gets correctly represented in program metadata.