### PR TITLE
[SYCL] Fix ignored_symbols processing in aby_check.py

### DIFF
--- a/sycl/test/abi/sycl_symbols_windows.dump
+++ b/sycl/test/abi/sycl_symbols_windows.dump
@@ -412,9 +412,7 @@
 ??0gpu_selector@_V1@sycl@@QEAA@$$QEAV012@@Z
 ??0gpu_selector@_V1@sycl@@QEAA@AEBV012@@Z
 ??0gpu_selector@_V1@sycl@@QEAA@XZ
-??0half@host_half_impl@detail@_V1@sycl@@QEAA@$$QEAV01234@@Z
 ??0half@host_half_impl@detail@_V1@sycl@@QEAA@AEBM@Z
-??0half@host_half_impl@detail@_V1@sycl@@QEAA@AEBV01234@@Z
 ??0half@host_half_impl@detail@_V1@sycl@@QEAA@G@Z
 ??0handler@_V1@sycl@@AEAA@V?$shared_ptr@Vqueue_impl@detail@_V1@sycl@@@std@@00_N@Z
 ??0handler@_V1@sycl@@AEAA@V?$shared_ptr@Vqueue_impl@detail@_V1@sycl@@@std@@_N@Z

--- a/sycl/tools/abi_check.py
+++ b/sycl/tools/abi_check.py
@@ -51,6 +51,53 @@ def parse_readobj_output(output):
       sym_section = re.search(r"(?<=Section:\s)[\.\w]+", sym)
       if match_symbol(sym_binding, sym_type, sym_section):
         parsed_symbols.append(name.group())
+
+  # Presence of _dl_relocate_static_pie depends on whether ld.gold or ld.lld
+  # is used. Ignore it for the purpose of the library ABI check.
+  ignore_symbols = ["_dl_relocate_static_pie"]
+
+  # In some scenarios MSVC and clang-cl exhibit differences in regards to the exported symbols they generate.
+  # Some of them happen in the SYCL RT library and we think clang-cl's behavior is more reasonable.
+  #
+  # Case 1:
+  # pi.hpp:
+  #   template <backend BE> __SYCL_EXPORT const plugin &getPlugin();
+  #
+  # pi.cpp:
+  #   template <backend BE> const plugin &getPlugin() {
+  #     static const plugin *Plugin = nullptr;
+  #     ...
+  #   }
+  #   // explicit dllexport instantiations.
+  #
+  # clang-cl generates exported symbols for the static variables Plugin. These are never referenced
+  # in the user's headers so cannot be used outside DLL and not exporting them should not affect any
+  # usage scenario.
+  #
+  # In general, the compiler doesn't know if the definition is in the DLL or in the header and inline
+  # dllexport/dllimport functions have to be supported, hence clang-cl's behavior.
+  #
+  # See also https://devblogs.microsoft.com/oldnewthing/20140109-00/?p=2123.
+  ignore_symbols += ["?Plugin@?1???$getPlugin@$01@pi@detail@_V1@sycl@@YAAEBVplugin@234@XZ@4PEBV5234@EB",
+                     "?Plugin@?1???$getPlugin@$00@pi@detail@_V1@sycl@@YAAEBVplugin@234@XZ@4PEBV5234@EB",
+                     "?Plugin@?1???$getPlugin@$04@pi@detail@_V1@sycl@@YAAEBVplugin@234@XZ@4PEBV5234@EB",
+                     "?Plugin@?1???$getPlugin@$02@pi@detail@_V1@sycl@@YAAEBVplugin@234@XZ@4PEBV5234@EB"]
+  # Case 2:
+  # half_type.hpp:
+  #   class __SYCL_EXPORT half {
+  #     ...
+  #     constexpr half(const half &) = default;
+  #     constexpr half(half &&) = default;
+  #     ...
+  #   };
+  #
+  # For some reason MSVC creates exported symbols for the constexpr versions of those defaulted ctors
+  # although it never calls them at use point. Instead, those trivially copyable/moveable objects are
+  # memcpy/memmove'ed. We don't expect these symbols are ever referenced directly so having or not
+  # having them won't cause ABI issues.
+  ignore_symbols += ["??0half@host_half_impl@detail@_V1@sycl@@QEAA@AEBV01234@@Z",
+                     "??0half@host_half_impl@detail@_V1@sycl@@QEAA@$$QEAV01234@@Z"]
+  parsed_symbols = [s for s in parsed_symbols if s not in ignore_symbols]
   return parsed_symbols
 
 
@@ -102,53 +149,6 @@ def check_symbols(ref_path, target_path):
     readobj_out = subprocess.check_output([get_llvm_bin_path()+"llvm-readobj",
                                            readobj_opts, target_path])
     symbols = parse_readobj_output(readobj_out)
-
-    # Presence of _dl_relocate_static_pie depends on whether ld.gold or ld.lld
-    # is used. Ignore it for the purpose of the library ABI check.
-    ignore_symbols = ["_dl_relocate_static_pie"]
-
-    # In some scenarios MSVC and clang-cl exhibit differences in regards to the exported symbols they generate.
-    # Some of them happen in the SYCL RT library and we think clang-cl's behavior is more reasonable.
-    #
-    # Case 1:
-    # pi.hpp:
-    #   template <backend BE> __SYCL_EXPORT const plugin &getPlugin();
-    #
-    # pi.cpp:
-    #   template <backend BE> const plugin &getPlugin() {
-    #     static const plugin *Plugin = nullptr;
-    #     ...
-    #   }
-    #   // explicit dllexport instantiations.
-    #
-    # clang-cl generates exported symbols for the static variables Plugin. These are never referenced
-    # in the user's headers so cannot be used outside DLL and not exporting them should not affect any
-    # usage scenario.
-    #
-    # In general, the compiler doesn't know if the definition is in the DLL or in the header and inline
-    # dllexport/dllimport functions have to be supported, hence clang-cl's behavior.
-    #
-    # See also https://devblogs.microsoft.com/oldnewthing/20140109-00/?p=2123.
-    ignore_symbols += ["?Plugin@?1???$getPlugin@$01@pi@detail@_V1@sycl@@YAAEBVplugin@234@XZ@4PEBV5234@EB",
-                       "?Plugin@?1???$getPlugin@$00@pi@detail@_V1@sycl@@YAAEBVplugin@234@XZ@4PEBV5234@EB",
-                       "?Plugin@?1???$getPlugin@$04@pi@detail@_V1@sycl@@YAAEBVplugin@234@XZ@4PEBV5234@EB",
-                       "?Plugin@?1???$getPlugin@$02@pi@detail@_V1@sycl@@YAAEBVplugin@234@XZ@4PEBV5234@EB"]
-    # Case 2:
-    # half_type.hpp:
-    #   class __SYCL_EXPORT half {
-    #     ...
-    #     constexpr half(const half &) = default;
-    #     constexpr half(half &&) = default;
-    #     ...
-    #   };
-    #
-    # For some reason MSVC creates exported symbols for the constexpr versions of those defaulted ctors
-    # although it never calls them at use point. Instead, those trivially copyable/moveable objects are
-    # memcpy/memmove'ed. We don't expect these symbols are ever referenced directly so having or not
-    # having them won't cause ABI issues.
-    ignore_symbols += ["??0half@host_half_impl@detail@_V1@sycl@@QEAA@AEBV01234@@Z",
-                       "??0half@host_half_impl@detail@_V1@sycl@@QEAA@$$QEAV01234@@Z"]
-    symbols = [s for s in symbols if s not in ignore_symbols]
 
     missing_symbols, new_symbols = compare_results(ref_symbols, symbols)
 


### PR DESCRIPTION
Same should be done both when checking the symbols and when generating the ref list.