### PR TITLE
[SYCL][NFC] Add none DecoValueTy to avoid switch-case warnings

### DIFF
--- a/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
+++ b/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
@@ -35,6 +35,7 @@ constexpr uint32_t SPIRV_HOST_ACCESS_DEFAULT_VALUE = 2; // Read/Write
 enum class DecorValueTy {
   uint32,
   boolean,
+  none,
 };
 
 struct Decor {


### PR DESCRIPTION
On some systems having default cases in exhaustive switch-case statements will cause a warning. To avoid this warning for switches on DecoValueTy we add a "none" value to make existing switches non-exhaustive.