### PR TITLE
[SYCL] Fix ESIMD with double GRF

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -419,7 +419,9 @@ static void appendCompileOptionsFromImage(std::string &CompileOpts,
   if (isDoubleGRF) {
     if (!CompileOpts.empty())
       CompileOpts += " ";
-    CompileOpts += "-ze-opt-large-register-file";
+    // TODO: Always use -ze-opt-large-register-file once IGC VC bug ignoring it
+    // is fixed
+    CompileOpts += isEsimdImage ? "-doubleGRF" : "-ze-opt-large-register-file";
   }
 }
 


### PR DESCRIPTION
The ze-opt-large-register-file flag is supposed to work with both the IGC scalar and vector backend, but there is a bug in IGC where it does not work for the vector backend. To workaround this and fix a regression, use -doubleGRF for the vector backend

This will be tested in llvm-test-suites

Signed-off-by: Sarnie, Nick <nick.sarnie@intel.com>