### PR TITLE
[SYCL-MLIR] Avoid memory leaks when passing arguments to drivers

### DIFF
--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -4135,50 +4135,30 @@ static bool parseMLIR(const char *Argv0, std::vector<std::string> filenames,
   const char *binary = Argv0; // CudaLower ? "clang++" : "clang";
   const std::unique_ptr<Driver> driver(
       new Driver(binary, llvm::sys::getDefaultTargetTriple(), Diags));
-  std::vector<const char *> Argv;
+  ArgumentList Argv;
   Argv.push_back(binary);
-  for (auto a : filenames) {
-    char *chars = (char *)malloc(a.length() + 1);
-    memcpy(chars, a.data(), a.length());
-    chars[a.length()] = 0;
-    Argv.push_back(chars);
+  for (const auto &filename : filenames) {
+    Argv.push_back(filename);
   }
   if (FOpenMP)
     Argv.push_back("-fopenmp");
   if (TargetTripleOpt != "") {
-    char *chars = (char *)malloc(TargetTripleOpt.length() + 1);
-    memcpy(chars, TargetTripleOpt.data(), TargetTripleOpt.length());
-    chars[TargetTripleOpt.length()] = 0;
     Argv.push_back("-target");
-    Argv.push_back(chars);
+    Argv.push_back(TargetTripleOpt);
   }
   if (McpuOpt != "") {
-    auto a = "-mcpu=" + McpuOpt;
-    char *chars = (char *)malloc(a.length() + 1);
-    memcpy(chars, a.data(), a.length());
-    chars[a.length()] = 0;
-    Argv.push_back(chars);
+    Argv.emplace_back("-mcpu=", McpuOpt);
   }
   if (Standard != "") {
-    auto a = "-std=" + Standard;
-    char *chars = (char *)malloc(a.length() + 1);
-    memcpy(chars, a.data(), a.length());
-    chars[a.length()] = 0;
-    Argv.push_back(chars);
+    Argv.emplace_back("-std=", Standard);
   }
   if (ResourceDir != "") {
     Argv.push_back("-resource-dir");
-    char *chars = (char *)malloc(ResourceDir.length() + 1);
-    memcpy(chars, ResourceDir.data(), ResourceDir.length());
-    chars[ResourceDir.length()] = 0;
-    Argv.push_back(chars);
+    Argv.push_back(ResourceDir);
   }
   if (SysRoot != "") {
     Argv.push_back("--sysroot");
-    char *chars = (char *)malloc(SysRoot.length() + 1);
-    memcpy(chars, SysRoot.data(), SysRoot.length());
-    chars[SysRoot.length()] = 0;
-    Argv.push_back(chars);
+    Argv.push_back(SysRoot);
   }
   if (Verbose) {
     Argv.push_back("-v");
@@ -4190,47 +4170,24 @@ static bool parseMLIR(const char *Argv0, std::vector<std::string> filenames,
     Argv.push_back("-nocudalib");
   }
   if (CUDAGPUArch != "") {
-    auto a = "--cuda-gpu-arch=" + CUDAGPUArch;
-    char *chars = (char *)malloc(a.length() + 1);
-    memcpy(chars, a.data(), a.length());
-    chars[a.length()] = 0;
-    Argv.push_back(chars);
+    Argv.emplace_back("--cuda-gpu-arch=", CUDAGPUArch);
   }
   if (CUDAPath != "") {
-    auto a = "--cuda-path=" + CUDAPath;
-    char *chars = (char *)malloc(a.length() + 1);
-    memcpy(chars, a.data(), a.length());
-    chars[a.length()] = 0;
-    Argv.push_back(chars);
+    Argv.emplace_back("--cuda-path=", CUDAPath);
   }
   if (MArch != "") {
-    auto a = "-march=" + MArch;
-    char *chars = (char *)malloc(a.length() + 1);
-    memcpy(chars, a.data(), a.length());
-    chars[a.length()] = 0;
-    Argv.push_back(chars);
+    Argv.emplace_back("-march=", MArch);
   }
-  for (auto a : includeDirs) {
+  for (const auto &dir : includeDirs) {
     Argv.push_back("-I");
-    char *chars = (char *)malloc(a.length() + 1);
-    memcpy(chars, a.data(), a.length());
-    chars[a.length()] = 0;
-    Argv.push_back(chars);
+    Argv.push_back(dir);
   }
-  for (auto a : defines) {
-    char *chars = (char *)malloc(a.length() + 3);
-    chars[0] = '-';
-    chars[1] = 'D';
-    memcpy(chars + 2, a.data(), a.length());
-    chars[2 + a.length()] = 0;
-    Argv.push_back(chars);
+  for (const auto &define : defines) {
+    Argv.emplace_back("-D", define);
   }
-  for (auto a : Includes) {
-    char *chars = (char *)malloc(a.length() + 1);
-    memcpy(chars, a.data(), a.length());
-    chars[a.length()] = 0;
+  for (const auto &include : Includes) {
     Argv.push_back("-include");
-    Argv.push_back(chars);
+    Argv.push_back(include);
   }
 
   Argv.push_back("-emit-ast");
@@ -4241,8 +4198,7 @@ static bool parseMLIR(const char *Argv0, std::vector<std::string> filenames,
   std::unique_ptr<Compilation> compilation;
 
   if (InputCommandArgs.empty()) {
-    compilation.reset(std::move(
-        driver->BuildCompilation(llvm::ArrayRef<const char *>(Argv))));
+    compilation.reset(driver->BuildCompilation(Argv.getArguments()));
 
     JobList &Jobs = compilation->getJobs();
     if (Jobs.size() < 1)

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -150,7 +150,7 @@ static int emitBinary(const char *Argv0, const char *filename,
   const char *binary = Argv0;
   const unique_ptr<Driver> driver(new Driver(binary, TargetTriple, Diags));
   driver->CC1Main = &ExecuteCC1Tool;
-  std::vector<const char *> Argv;
+  ArgumentList Argv;
   Argv.push_back(Argv0);
   // Argv.push_back("-x");
   // Argv.push_back("ir");
@@ -159,27 +159,16 @@ static int emitBinary(const char *Argv0, const char *filename,
     Argv.push_back("-fopenmp");
   if (ResourceDir != "") {
     Argv.push_back("-resource-dir");
-    char *chars = (char *)malloc(ResourceDir.length() + 1);
-    memcpy(chars, ResourceDir.data(), ResourceDir.length());
-    chars[ResourceDir.length()] = 0;
-    Argv.push_back(chars);
+    Argv.push_back(ResourceDir);
   }
   if (Verbose) {
     Argv.push_back("-v");
   }
   if (CUDAGPUArch != "") {
-    auto a = "--cuda-gpu-arch=" + CUDAGPUArch;
-    char *chars = (char *)malloc(a.length() + 1);
-    memcpy(chars, a.data(), a.length());
-    chars[a.length()] = 0;
-    Argv.push_back(chars);
+    Argv.emplace_back("--cuda-gpu-arch=", CUDAGPUArch);
   }
   if (CUDAPath != "") {
-    auto a = "--cuda-path=" + CUDAPath;
-    char *chars = (char *)malloc(a.length() + 1);
-    memcpy(chars, a.data(), a.length());
-    chars[a.length()] = 0;
-    Argv.push_back(chars);
+    Argv.emplace_back("--cuda-path=", CUDAPath);
   }
   if (Opt0) {
     Argv.push_back("-O0");
@@ -195,16 +184,13 @@ static int emitBinary(const char *Argv0, const char *filename,
   }
   if (Output != "") {
     Argv.push_back("-o");
-    char *chars = (char *)malloc(Output.length() + 1);
-    memcpy(chars, Output.data(), Output.length());
-    chars[Output.length()] = 0;
-    Argv.push_back(chars);
+    Argv.push_back(Output);
   }
   for (const auto *arg : LinkArgs)
     Argv.push_back(arg);
 
   const unique_ptr<Compilation> compilation(
-      driver->BuildCompilation(llvm::ArrayRef<const char *>(Argv)));
+      driver->BuildCompilation(Argv.getArguments()));
 
   if (ResourceDir != "")
     driver->ResourceDir = ResourceDir;


### PR DESCRIPTION
Use a new ArgumentList class instead of malloced pointers to pass arguments to drivers.

This new class will not own all arguments passed, just those which were created inplace (via `emplace_back`) to avoid unnecessary copying.