### PR TITLE
[SYCL] Native event for default-ctored sycl::event has to be in COMPLETE state

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -5964,9 +5964,12 @@ pi_result piEventSetCallback(pi_event Event, pi_int32 CommandExecCallbackType,
 }
 
 pi_result piEventSetStatus(pi_event Event, pi_int32 ExecutionStatus) {
-  (void)Event;
-  (void)ExecutionStatus;
-  die("piEventSetStatus: deprecated, to be removed");
+  if (ExecutionStatus == PI_EVENT_COMPLETE)
+    zeEventHostSignal(Event->ZeEvent);
+  else
+    // We don't expect this path ever to be executed when called from SYCL RT.
+    die("piEventSetStatus: with anything but PI_EVENT_COMPLETE is "
+        "unsupported!");
   return PI_SUCCESS;
 }
 

--- a/sycl/source/detail/backend_impl.hpp
+++ b/sycl/source/detail/backend_impl.hpp
@@ -15,6 +15,8 @@ __SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace detail {
 
 template <class T> backend getImplBackend(const T &Impl) {
+  // If that would ever become possible, event_impl::getNative needs to be
+  // updated too.
   assert(!Impl->is_host() && "Cannot get the backend for host.");
   return Impl->getPlugin().getBackend();
 }

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -375,6 +375,12 @@ pi_native_handle event_impl::getNative() {
     MIsInitialized = true;
     auto TempContext = MContext.get()->getHandleRef();
     Plugin.call<PiApiKind::piEventCreate>(TempContext, &MEvent);
+    // See an assert in sycl::detail::getImplBackend.
+    assert(!MHostEvent && "Can't get native event from a host event!");
+    assert(!isDiscarded() && "Can't ask getNative of a discarded event!");
+    // Wouldn't be true if MHostEvent could be true.
+    assert(MState == HES_Complete && "Expected to have a completed event!");
+    Plugin.call<PiApiKind::piEventSetStatus>(MEvent, PI_EVENT_COMPLETE);
   }
   if (Plugin.getBackend() == backend::opencl)
     Plugin.call<PiApiKind::piEventRetain>(getHandleRef());


### PR DESCRIPTION
Per SYCL 2020 for event():

   > Constructs an event that is immediately ready. The event has no
   > dependencies and no associated commands. Waiting on this event will
   > return immediately and querying its status will return
   > info::event_command_status::complete.

piEventCreate on the other hand creates an event that isn't completed. As such an extra call to piEventSetStatus is needed making that API not-deprecated.

There is a more general problem that isn't addressed here:

  auto e = q.submit(... h.host_task(...) ..)

This event would be a host one and we assert that no get_native could be called on it (see existing sycl::detail::getImplBackend). If we will ever want to support such scenario we'd need to implement some tracking of host/backed events in the SYCL RT and keep updating the latter whenever the host one changes the state.