### PR TITLE
[SYCL] Implement device_has kernel property and macro

### DIFF
--- a/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <sycl/aspects.hpp>
 #include <sycl/ext/oneapi/properties/property.hpp>
 #include <sycl/ext/oneapi/properties/property_value.hpp>
 
@@ -53,9 +54,18 @@ struct SizeListToStrHelper<SizeList<0, Values...>, CharList<ParsedChars...>,
                            Chars...>
     : SizeListToStrHelper<SizeList<Values...>,
                           CharList<ParsedChars..., Chars..., ','>> {};
+template <size_t... Values, char... ParsedChars>
+struct SizeListToStrHelper<SizeList<0, Values...>, CharList<ParsedChars...>>
+    : SizeListToStrHelper<SizeList<Values...>,
+                          CharList<ParsedChars..., '0', ','>> {};
 template <char... ParsedChars, char... Chars>
 struct SizeListToStrHelper<SizeList<0>, CharList<ParsedChars...>, Chars...>
     : CharsToStr<ParsedChars..., Chars...> {};
+template <char... ParsedChars>
+struct SizeListToStrHelper<SizeList<0>, CharList<ParsedChars...>>
+    : CharsToStr<ParsedChars..., '0'> {};
+template <>
+struct SizeListToStrHelper<SizeList<>, CharList<>> : CharsToStr<> {};
 
 // Converts size_t values to a comma-separated string representation.
 template <size_t... Sizes>
@@ -80,6 +90,12 @@ struct sub_group_size_key {
   template <uint32_t Size>
   using value_t = property_value<sub_group_size_key,
                                  std::integral_constant<uint32_t, Size>>;
+};
+
+struct device_has_key {
+  template <aspect... Aspects>
+  using value_t = property_value<device_has_key,
+                                 std::integral_constant<aspect, Aspects>...>;
 };
 
 template <size_t Dim0, size_t... Dims>
@@ -127,6 +143,13 @@ struct property_value<sub_group_size_key,
   static constexpr uint32_t value = Size;
 };
 
+template <aspect... Aspects>
+struct property_value<device_has_key,
+                      std::integral_constant<aspect, Aspects>...> {
+  using key_t = device_has_key;
+  static constexpr std::array<aspect, sizeof...(Aspects)> value{Aspects...};
+};
+
 template <size_t Dim0, size_t... Dims>
 inline constexpr work_group_size_key::value_t<Dim0, Dims...> work_group_size;
 
@@ -137,10 +160,14 @@ inline constexpr work_group_size_hint_key::value_t<Dim0, Dims...>
 template <uint32_t Size>
 inline constexpr sub_group_size_key::value_t<Size> sub_group_size;
 
+template <aspect... Aspects>
+inline constexpr device_has_key::value_t<Aspects...> device_has;
+
 template <> struct is_property_key<work_group_size_key> : std::true_type {};
 template <>
 struct is_property_key<work_group_size_hint_key> : std::true_type {};
 template <> struct is_property_key<sub_group_size_key> : std::true_type {};
+template <> struct is_property_key<device_has_key> : std::true_type {};
 
 namespace detail {
 template <> struct PropertyToKind<work_group_size_key> {
@@ -152,6 +179,9 @@ template <> struct PropertyToKind<work_group_size_hint_key> {
 template <> struct PropertyToKind<sub_group_size_key> {
   static constexpr PropKind Kind = PropKind::SubGroupSize;
 };
+template <> struct PropertyToKind<device_has_key> {
+  static constexpr PropKind Kind = PropKind::DeviceHas;
+};
 
 template <>
 struct IsCompileTimeProperty<work_group_size_key> : std::true_type {};
@@ -159,6 +189,8 @@ template <>
 struct IsCompileTimeProperty<work_group_size_hint_key> : std::true_type {};
 template <>
 struct IsCompileTimeProperty<sub_group_size_key> : std::true_type {};
+template <>
+struct IsCompileTimeProperty<device_has_key> : std::true_type {};
 
 template <size_t Dim0, size_t... Dims>
 struct PropertyMetaInfo<work_group_size_key::value_t<Dim0, Dims...>> {
@@ -174,6 +206,12 @@ template <uint32_t Size>
 struct PropertyMetaInfo<sub_group_size_key::value_t<Size>> {
   static constexpr const char *name = "sycl-sub-group-size";
   static constexpr uint32_t value = Size;
+};
+template <aspect... Aspects>
+struct PropertyMetaInfo<device_has_key::value_t<Aspects...>> {
+  static constexpr const char *name = "sycl-device-has";
+  static constexpr const char *value =
+      SizeListToStr<static_cast<size_t>(Aspects)...>::value;
 };
 
 template <typename T, typename = void>
@@ -193,3 +231,15 @@ struct HasKernelPropertiesGetMethod<
 } // namespace ext
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl
+
+#ifdef __SYCL_DEVICE_ONLY__
+#define SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(PROP)                                \
+  [[__sycl_detail__::add_ir_attributes_function(                               \
+      {"sycl-device-has"},                                                     \
+      sycl::ext::oneapi::experimental::detail::PropertyMetaInfo<               \
+          std::remove_cv_t<std::remove_reference_t<decltype(PROP)>>>::name,    \
+      sycl::ext::oneapi::experimental::detail::PropertyMetaInfo<               \
+          std::remove_cv_t<std::remove_reference_t<decltype(PROP)>>>::value)]]
+#else
+#define SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(PROP)
+#endif

--- a/sycl/include/sycl/ext/oneapi/properties/property.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property.hpp
@@ -172,8 +172,9 @@ enum PropKind : uint32_t {
   WorkGroupSize = 6,
   WorkGroupSizeHint = 7,
   SubGroupSize = 8,
+  DeviceHas = 9,
   // PropKindSize must always be the last value.
-  PropKindSize = 9,
+  PropKindSize = 10,
 };
 
 // This trait must be specialized for all properties and must have a unique

--- a/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
@@ -20,7 +20,7 @@ namespace oneapi {
 namespace experimental {
 
 // Forward declaration
-template <typename PropertyT, typename T, typename... Ts> struct property_value;
+template <typename PropertyT, typename... Ts> struct property_value;
 
 namespace detail {
 

--- a/sycl/include/sycl/ext/oneapi/properties/property_value.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_value.hpp
@@ -18,33 +18,29 @@ namespace oneapi {
 namespace experimental {
 namespace detail {
 
-// Base class for property values with a single type value.
-struct SingleTypePropertyValueBase {};
-
-// Base class for properties with 0 or more than 1 values.
-struct EmptyPropertyValueBase {};
-
 // Base class for property values with a single non-type value
-template <typename T> struct SingleNontypePropertyValueBase {
+template <typename T, typename = void>
+struct SingleNontypePropertyValueBase {};
+
+template <typename T>
+struct SingleNontypePropertyValueBase<T, std::enable_if_t<HasValue<T>::value>> {
   static constexpr auto value = T::value;
 };
 
-// Helper class for property values with a single value
+// Helper base class for property_value.
+template <typename... Ts>
+struct PropertyValueBase {};
+
 template <typename T>
-struct SinglePropertyValue
-    : public sycl::detail::conditional_t<HasValue<T>::value,
-                                         SingleNontypePropertyValueBase<T>,
-                                         SingleTypePropertyValueBase> {
+struct PropertyValueBase<T>
+    : public detail::SingleNontypePropertyValueBase<T> {
   using value_t = T;
 };
 
 } // namespace detail
 
-template <typename PropertyT, typename T = void, typename... Ts>
-struct property_value
-    : public sycl::detail::conditional_t<
-          sizeof...(Ts) == 0 && !std::is_same<T, void>::value,
-          detail::SinglePropertyValue<T>, detail::EmptyPropertyValueBase> {
+template <typename PropertyT, typename... Ts>
+struct property_value : public detail::PropertyValueBase<Ts...> {
   using key_t = PropertyT;
 };
 

--- a/sycl/test/extensions/properties/properties_kernel.cpp
+++ b/sycl/test/extensions/properties/properties_kernel.cpp
@@ -3,7 +3,30 @@
 
 #include <sycl/sycl.hpp>
 
+using namespace sycl;
 using namespace sycl::ext::oneapi::experimental;
+
+using device_has_all =
+    decltype(device_has<
+             aspect::host, aspect::cpu, aspect::gpu, aspect::accelerator,
+             aspect::custom, aspect::fp16, aspect::fp64, aspect::image,
+             aspect::online_compiler, aspect::online_linker,
+             aspect::queue_profiling, aspect::usm_device_allocations,
+             aspect::usm_host_allocations, aspect::usm_shared_allocations,
+             aspect::usm_restricted_shared_allocations,
+             aspect::usm_system_allocations, aspect::ext_intel_pci_address,
+             aspect::ext_intel_gpu_eu_count,
+             aspect::ext_intel_gpu_eu_simd_width, aspect::ext_intel_gpu_slices,
+             aspect::ext_intel_gpu_subslices_per_slice,
+             aspect::ext_intel_gpu_eu_count_per_subslice,
+             aspect::ext_intel_max_mem_bandwidth, aspect::ext_intel_mem_channel,
+             aspect::usm_atomic_host_allocations,
+             aspect::usm_atomic_shared_allocations, aspect::atomic64,
+             aspect::ext_intel_device_info_uuid, aspect::ext_oneapi_srgb,
+             aspect::ext_oneapi_native_assert, aspect::host_debuggable,
+             aspect::ext_intel_gpu_hw_threads_per_eu,
+             aspect::ext_oneapi_cuda_async_barrier, aspect::ext_oneapi_bfloat16,
+             aspect::ext_intel_free_memory, aspect::ext_intel_device_id>);
 
 int main() {
   static_assert(is_property_key<work_group_size_key>::value);
@@ -18,6 +41,87 @@ int main() {
   static_assert(
       is_property_value<decltype(work_group_size_hint<6, 6, 6>)>::value);
   static_assert(is_property_value<decltype(sub_group_size<7>)>::value);
+  static_assert(is_property_value<decltype(sub_group_size<7>)>::value);
+  static_assert(is_property_value<decltype(device_has<>)>::value);
+  static_assert(is_property_value<decltype(device_has<aspect::host>)>::value);
+  static_assert(is_property_value<decltype(device_has<aspect::cpu>)>::value);
+  static_assert(is_property_value<decltype(device_has<aspect::gpu>)>::value);
+  static_assert(
+      is_property_value<decltype(device_has<aspect::accelerator>)>::value);
+  static_assert(is_property_value<decltype(device_has<aspect::custom>)>::value);
+  static_assert(is_property_value<decltype(device_has<aspect::fp16>)>::value);
+  static_assert(is_property_value<decltype(device_has<aspect::fp64>)>::value);
+  static_assert(is_property_value<decltype(device_has<aspect::image>)>::value);
+  static_assert(
+      is_property_value<decltype(device_has<aspect::online_compiler>)>::value);
+  static_assert(
+      is_property_value<decltype(device_has<aspect::online_linker>)>::value);
+  static_assert(
+      is_property_value<decltype(device_has<aspect::queue_profiling>)>::value);
+  static_assert(is_property_value<
+                decltype(device_has<aspect::usm_device_allocations>)>::value);
+  static_assert(is_property_value<
+                decltype(device_has<aspect::usm_host_allocations>)>::value);
+  static_assert(is_property_value<
+                decltype(device_has<aspect::usm_shared_allocations>)>::value);
+  static_assert(
+      is_property_value<
+          decltype(device_has<aspect::usm_restricted_shared_allocations>)>::
+          value);
+  static_assert(is_property_value<
+                decltype(device_has<aspect::usm_system_allocations>)>::value);
+  static_assert(is_property_value<
+                decltype(device_has<aspect::ext_intel_pci_address>)>::value);
+  static_assert(is_property_value<
+                decltype(device_has<aspect::ext_intel_gpu_eu_count>)>::value);
+  static_assert(
+      is_property_value<
+          decltype(device_has<aspect::ext_intel_gpu_eu_simd_width>)>::value);
+  static_assert(is_property_value<
+                decltype(device_has<aspect::ext_intel_gpu_slices>)>::value);
+  static_assert(
+      is_property_value<
+          decltype(device_has<aspect::ext_intel_gpu_subslices_per_slice>)>::
+          value);
+  static_assert(
+      is_property_value<
+          decltype(device_has<aspect::ext_intel_gpu_eu_count_per_subslice>)>::
+          value);
+  static_assert(
+      is_property_value<
+          decltype(device_has<aspect::ext_intel_max_mem_bandwidth>)>::value);
+  static_assert(is_property_value<
+                decltype(device_has<aspect::ext_intel_mem_channel>)>::value);
+  static_assert(
+      is_property_value<
+          decltype(device_has<aspect::usm_atomic_host_allocations>)>::value);
+  static_assert(
+      is_property_value<
+          decltype(device_has<aspect::usm_atomic_shared_allocations>)>::value);
+  static_assert(
+      is_property_value<decltype(device_has<aspect::atomic64>)>::value);
+  static_assert(
+      is_property_value<
+          decltype(device_has<aspect::ext_intel_device_info_uuid>)>::value);
+  static_assert(
+      is_property_value<decltype(device_has<aspect::ext_oneapi_srgb>)>::value);
+  static_assert(is_property_value<
+                decltype(device_has<aspect::ext_oneapi_native_assert>)>::value);
+  static_assert(
+      is_property_value<decltype(device_has<aspect::host_debuggable>)>::value);
+  static_assert(is_property_value<
+                decltype(device_has<aspect::ext_intel_gpu_hw_threads_per_eu>)>::
+                    value);
+  static_assert(
+      is_property_value<
+          decltype(device_has<aspect::ext_oneapi_cuda_async_barrier>)>::value);
+  static_assert(is_property_value<
+                decltype(device_has<aspect::ext_oneapi_bfloat16>)>::value);
+  static_assert(is_property_value<
+                decltype(device_has<aspect::ext_intel_free_memory>)>::value);
+  static_assert(is_property_value<
+                decltype(device_has<aspect::ext_intel_device_id>)>::value);
+  static_assert(is_property_value<device_has_all>::value);
 
   static_assert(
       std::is_same_v<work_group_size_key, decltype(work_group_size<8>)::key_t>);
@@ -34,6 +138,119 @@ int main() {
                      decltype(work_group_size_hint<13, 13, 13>)::key_t>);
   static_assert(
       std::is_same_v<sub_group_size_key, decltype(sub_group_size<14>)::key_t>);
+  static_assert(std::is_same_v<device_has_key, decltype(device_has<>)::key_t>);
+  static_assert(std::is_same_v<device_has_key, decltype(device_has<>)::key_t>);
+  static_assert(std::is_same_v<device_has_key,
+                               decltype(device_has<aspect::host>)::key_t>);
+  static_assert(
+      std::is_same_v<device_has_key, decltype(device_has<aspect::cpu>)::key_t>);
+  static_assert(
+      std::is_same_v<device_has_key, decltype(device_has<aspect::gpu>)::key_t>);
+  static_assert(
+      std::is_same_v<device_has_key,
+                     decltype(device_has<aspect::accelerator>)::key_t>);
+  static_assert(std::is_same_v<device_has_key,
+                               decltype(device_has<aspect::custom>)::key_t>);
+  static_assert(std::is_same_v<device_has_key,
+                               decltype(device_has<aspect::fp16>)::key_t>);
+  static_assert(std::is_same_v<device_has_key,
+                               decltype(device_has<aspect::fp64>)::key_t>);
+  static_assert(std::is_same_v<device_has_key,
+                               decltype(device_has<aspect::image>)::key_t>);
+  static_assert(
+      std::is_same_v<device_has_key,
+                     decltype(device_has<aspect::online_compiler>)::key_t>);
+  static_assert(
+      std::is_same_v<device_has_key,
+                     decltype(device_has<aspect::online_linker>)::key_t>);
+  static_assert(
+      std::is_same_v<device_has_key,
+                     decltype(device_has<aspect::queue_profiling>)::key_t>);
+  static_assert(std::is_same_v<
+                device_has_key,
+                decltype(device_has<aspect::usm_device_allocations>)::key_t>);
+  static_assert(std::is_same_v<
+                device_has_key,
+                decltype(device_has<aspect::usm_host_allocations>)::key_t>);
+  static_assert(std::is_same_v<
+                device_has_key,
+                decltype(device_has<aspect::usm_shared_allocations>)::key_t>);
+  static_assert(std::is_same_v<
+                device_has_key,
+                decltype(device_has<
+                         aspect::usm_restricted_shared_allocations>)::key_t>);
+  static_assert(std::is_same_v<
+                device_has_key,
+                decltype(device_has<aspect::usm_system_allocations>)::key_t>);
+  static_assert(std::is_same_v<
+                device_has_key,
+                decltype(device_has<aspect::ext_intel_pci_address>)::key_t>);
+  static_assert(std::is_same_v<
+                device_has_key,
+                decltype(device_has<aspect::ext_intel_gpu_eu_count>)::key_t>);
+  static_assert(
+      std::is_same_v<
+          device_has_key,
+          decltype(device_has<aspect::ext_intel_gpu_eu_simd_width>)::key_t>);
+  static_assert(std::is_same_v<
+                device_has_key,
+                decltype(device_has<aspect::ext_intel_gpu_slices>)::key_t>);
+  static_assert(std::is_same_v<
+                device_has_key,
+                decltype(device_has<
+                         aspect::ext_intel_gpu_subslices_per_slice>)::key_t>);
+  static_assert(std::is_same_v<
+                device_has_key,
+                decltype(device_has<
+                         aspect::ext_intel_gpu_eu_count_per_subslice>)::key_t>);
+  static_assert(
+      std::is_same_v<
+          device_has_key,
+          decltype(device_has<aspect::ext_intel_max_mem_bandwidth>)::key_t>);
+  static_assert(std::is_same_v<
+                device_has_key,
+                decltype(device_has<aspect::ext_intel_mem_channel>)::key_t>);
+  static_assert(
+      std::is_same_v<
+          device_has_key,
+          decltype(device_has<aspect::usm_atomic_host_allocations>)::key_t>);
+  static_assert(
+      std::is_same_v<
+          device_has_key,
+          decltype(device_has<aspect::usm_atomic_shared_allocations>)::key_t>);
+  static_assert(std::is_same_v<device_has_key,
+                               decltype(device_has<aspect::atomic64>)::key_t>);
+  static_assert(
+      std::is_same_v<
+          device_has_key,
+          decltype(device_has<aspect::ext_intel_device_info_uuid>)::key_t>);
+  static_assert(
+      std::is_same_v<device_has_key,
+                     decltype(device_has<aspect::ext_oneapi_srgb>)::key_t>);
+  static_assert(std::is_same_v<
+                device_has_key,
+                decltype(device_has<aspect::ext_oneapi_native_assert>)::key_t>);
+  static_assert(
+      std::is_same_v<device_has_key,
+                     decltype(device_has<aspect::host_debuggable>)::key_t>);
+  static_assert(std::is_same_v<
+                device_has_key,
+                decltype(device_has<
+                         aspect::ext_intel_gpu_hw_threads_per_eu>)::key_t>);
+  static_assert(
+      std::is_same_v<
+          device_has_key,
+          decltype(device_has<aspect::ext_oneapi_cuda_async_barrier>)::key_t>);
+  static_assert(
+      std::is_same_v<device_has_key,
+                     decltype(device_has<aspect::ext_oneapi_bfloat16>)::key_t>);
+  static_assert(std::is_same_v<
+                device_has_key,
+                decltype(device_has<aspect::ext_intel_free_memory>)::key_t>);
+  static_assert(
+      std::is_same_v<device_has_key,
+                     decltype(device_has<aspect::ext_intel_device_id>)::key_t>);
+  static_assert(std::is_same_v<device_has_key, device_has_all::key_t>);
 
   static_assert(work_group_size<15>[0] == 15);
   static_assert(work_group_size<16, 17>[0] == 16);
@@ -48,6 +265,214 @@ int main() {
   static_assert(work_group_size_hint<24, 25, 26>[1] == 25);
   static_assert(work_group_size_hint<24, 25, 26>[2] == 26);
   static_assert(sub_group_size<27>.value == 27);
+
+  static_assert(decltype(device_has<>)::value.size() == 0);
+  static_assert(decltype(device_has<aspect::host>)::value.size() == 1);
+  static_assert(decltype(device_has<aspect::cpu>)::value.size() == 1);
+  static_assert(decltype(device_has<aspect::gpu>)::value.size() == 1);
+  static_assert(decltype(device_has<aspect::accelerator>)::value.size() == 1);
+  static_assert(decltype(device_has<aspect::custom>)::value.size() == 1);
+  static_assert(decltype(device_has<aspect::fp16>)::value.size() == 1);
+  static_assert(decltype(device_has<aspect::fp64>)::value.size() == 1);
+  static_assert(decltype(device_has<aspect::image>)::value.size() == 1);
+  static_assert(decltype(device_has<aspect::online_compiler>)::value.size() ==
+                1);
+  static_assert(decltype(device_has<aspect::online_linker>)::value.size() == 1);
+  static_assert(decltype(device_has<aspect::queue_profiling>)::value.size() ==
+                1);
+  static_assert(
+      decltype(device_has<aspect::usm_device_allocations>)::value.size() == 1);
+  static_assert(
+      decltype(device_has<aspect::usm_host_allocations>)::value.size() == 1);
+  static_assert(
+      decltype(device_has<aspect::usm_shared_allocations>)::value.size() == 1);
+  static_assert(
+      decltype(device_has<aspect::usm_restricted_shared_allocations>)::value
+          .size() == 1);
+  static_assert(
+      decltype(device_has<aspect::usm_system_allocations>)::value.size() == 1);
+  static_assert(
+      decltype(device_has<aspect::ext_intel_pci_address>)::value.size() == 1);
+  static_assert(
+      decltype(device_has<aspect::ext_intel_gpu_eu_count>)::value.size() == 1);
+  static_assert(
+      decltype(device_has<aspect::ext_intel_gpu_eu_simd_width>)::value.size() ==
+      1);
+  static_assert(
+      decltype(device_has<aspect::ext_intel_gpu_slices>)::value.size() == 1);
+  static_assert(
+      decltype(device_has<aspect::ext_intel_gpu_subslices_per_slice>)::value
+          .size() == 1);
+  static_assert(
+      decltype(device_has<aspect::ext_intel_gpu_eu_count_per_subslice>)::value
+          .size() == 1);
+  static_assert(
+      decltype(device_has<aspect::ext_intel_max_mem_bandwidth>)::value.size() ==
+      1);
+  static_assert(
+      decltype(device_has<aspect::ext_intel_mem_channel>)::value.size() == 1);
+  static_assert(
+      decltype(device_has<aspect::usm_atomic_host_allocations>)::value.size() ==
+      1);
+  static_assert(
+      decltype(device_has<aspect::usm_atomic_shared_allocations>)::value
+          .size() == 1);
+  static_assert(decltype(device_has<aspect::atomic64>)::value.size() == 1);
+  static_assert(
+      decltype(device_has<aspect::ext_intel_device_info_uuid>)::value.size() ==
+      1);
+  static_assert(decltype(device_has<aspect::ext_oneapi_srgb>)::value.size() ==
+                1);
+  static_assert(
+      decltype(device_has<aspect::ext_oneapi_native_assert>)::value.size() ==
+      1);
+  static_assert(decltype(device_has<aspect::host_debuggable>)::value.size() ==
+                1);
+  static_assert(
+      decltype(device_has<aspect::ext_intel_gpu_hw_threads_per_eu>)::value
+          .size() == 1);
+  static_assert(
+      decltype(device_has<aspect::ext_oneapi_cuda_async_barrier>)::value
+          .size() == 1);
+  static_assert(
+      decltype(device_has<aspect::ext_oneapi_bfloat16>)::value.size() == 1);
+  static_assert(
+      decltype(device_has<aspect::ext_intel_free_memory>)::value.size() == 1);
+  static_assert(
+      decltype(device_has<aspect::ext_intel_device_id>)::value.size() == 1);
+  static_assert(device_has_all::value.size() == 36);
+
+  static_assert(decltype(device_has<aspect::host>)::value[0] == aspect::host);
+  static_assert(decltype(device_has<aspect::cpu>)::value[0] == aspect::cpu);
+  static_assert(decltype(device_has<aspect::gpu>)::value[0] == aspect::gpu);
+  static_assert(decltype(device_has<aspect::accelerator>)::value[0] ==
+                aspect::accelerator);
+  static_assert(decltype(device_has<aspect::custom>)::value[0] ==
+                aspect::custom);
+  static_assert(decltype(device_has<aspect::fp16>)::value[0] == aspect::fp16);
+  static_assert(decltype(device_has<aspect::fp64>)::value[0] == aspect::fp64);
+  static_assert(decltype(device_has<aspect::image>)::value[0] == aspect::image);
+  static_assert(decltype(device_has<aspect::online_compiler>)::value[0] ==
+                aspect::online_compiler);
+  static_assert(decltype(device_has<aspect::online_linker>)::value[0] ==
+                aspect::online_linker);
+  static_assert(decltype(device_has<aspect::queue_profiling>)::value[0] ==
+                aspect::queue_profiling);
+  static_assert(
+      decltype(device_has<aspect::usm_device_allocations>)::value[0] ==
+      aspect::usm_device_allocations);
+  static_assert(decltype(device_has<aspect::usm_host_allocations>)::value[0] ==
+                aspect::usm_host_allocations);
+  static_assert(
+      decltype(device_has<aspect::usm_shared_allocations>)::value[0] ==
+      aspect::usm_shared_allocations);
+  static_assert(
+      decltype(device_has<
+               aspect::usm_restricted_shared_allocations>)::value[0] ==
+      aspect::usm_restricted_shared_allocations);
+  static_assert(
+      decltype(device_has<aspect::usm_system_allocations>)::value[0] ==
+      aspect::usm_system_allocations);
+  static_assert(decltype(device_has<aspect::ext_intel_pci_address>)::value[0] ==
+                aspect::ext_intel_pci_address);
+  static_assert(
+      decltype(device_has<aspect::ext_intel_gpu_eu_count>)::value[0] ==
+      aspect::ext_intel_gpu_eu_count);
+  static_assert(
+      decltype(device_has<aspect::ext_intel_gpu_eu_simd_width>)::value[0] ==
+      aspect::ext_intel_gpu_eu_simd_width);
+  static_assert(decltype(device_has<aspect::ext_intel_gpu_slices>)::value[0] ==
+                aspect::ext_intel_gpu_slices);
+  static_assert(
+      decltype(device_has<
+               aspect::ext_intel_gpu_subslices_per_slice>)::value[0] ==
+      aspect::ext_intel_gpu_subslices_per_slice);
+  static_assert(
+      decltype(device_has<
+               aspect::ext_intel_gpu_eu_count_per_subslice>)::value[0] ==
+      aspect::ext_intel_gpu_eu_count_per_subslice);
+  static_assert(
+      decltype(device_has<aspect::ext_intel_max_mem_bandwidth>)::value[0] ==
+      aspect::ext_intel_max_mem_bandwidth);
+  static_assert(decltype(device_has<aspect::ext_intel_mem_channel>)::value[0] ==
+                aspect::ext_intel_mem_channel);
+  static_assert(
+      decltype(device_has<aspect::usm_atomic_host_allocations>)::value[0] ==
+      aspect::usm_atomic_host_allocations);
+  static_assert(
+      decltype(device_has<aspect::usm_atomic_shared_allocations>)::value[0] ==
+      aspect::usm_atomic_shared_allocations);
+  static_assert(decltype(device_has<aspect::atomic64>)::value[0] ==
+                aspect::atomic64);
+  static_assert(
+      decltype(device_has<aspect::ext_intel_device_info_uuid>)::value[0] ==
+      aspect::ext_intel_device_info_uuid);
+  static_assert(decltype(device_has<aspect::ext_oneapi_srgb>)::value[0] ==
+                aspect::ext_oneapi_srgb);
+  static_assert(
+      decltype(device_has<aspect::ext_oneapi_native_assert>)::value[0] ==
+      aspect::ext_oneapi_native_assert);
+  static_assert(decltype(device_has<aspect::host_debuggable>)::value[0] ==
+                aspect::host_debuggable);
+  static_assert(
+      decltype(device_has<aspect::ext_intel_gpu_hw_threads_per_eu>)::value[0] ==
+      aspect::ext_intel_gpu_hw_threads_per_eu);
+  static_assert(
+      decltype(device_has<aspect::ext_oneapi_cuda_async_barrier>)::value[0] ==
+      aspect::ext_oneapi_cuda_async_barrier);
+  static_assert(decltype(device_has<aspect::ext_oneapi_bfloat16>)::value[0] ==
+                aspect::ext_oneapi_bfloat16);
+  static_assert(decltype(device_has<aspect::ext_intel_free_memory>)::value[0] ==
+                aspect::ext_intel_free_memory);
+  static_assert(decltype(device_has<aspect::ext_intel_device_id>)::value[0] ==
+                aspect::ext_intel_device_id);
+
+  static_assert(device_has_all::value[0] == aspect::host);
+  static_assert(device_has_all::value[1] == aspect::cpu);
+  static_assert(device_has_all::value[2] == aspect::gpu);
+  static_assert(device_has_all::value[3] == aspect::accelerator);
+  static_assert(device_has_all::value[4] == aspect::custom);
+  static_assert(device_has_all::value[5] == aspect::fp16);
+  static_assert(device_has_all::value[6] == aspect::fp64);
+  static_assert(device_has_all::value[7] == aspect::image);
+  static_assert(device_has_all::value[8] == aspect::online_compiler);
+  static_assert(device_has_all::value[9] == aspect::online_linker);
+  static_assert(device_has_all::value[10] == aspect::queue_profiling);
+  static_assert(device_has_all::value[11] == aspect::usm_device_allocations);
+  static_assert(device_has_all::value[12] == aspect::usm_host_allocations);
+  static_assert(device_has_all::value[13] == aspect::usm_shared_allocations);
+  static_assert(device_has_all::value[14] ==
+                aspect::usm_restricted_shared_allocations);
+  static_assert(device_has_all::value[15] == aspect::usm_system_allocations);
+  static_assert(device_has_all::value[16] == aspect::ext_intel_pci_address);
+  static_assert(device_has_all::value[17] == aspect::ext_intel_gpu_eu_count);
+  static_assert(device_has_all::value[18] ==
+                aspect::ext_intel_gpu_eu_simd_width);
+  static_assert(device_has_all::value[19] == aspect::ext_intel_gpu_slices);
+  static_assert(device_has_all::value[20] ==
+                aspect::ext_intel_gpu_subslices_per_slice);
+  static_assert(device_has_all::value[21] ==
+                aspect::ext_intel_gpu_eu_count_per_subslice);
+  static_assert(device_has_all::value[22] ==
+                aspect::ext_intel_max_mem_bandwidth);
+  static_assert(device_has_all::value[23] == aspect::ext_intel_mem_channel);
+  static_assert(device_has_all::value[24] ==
+                aspect::usm_atomic_host_allocations);
+  static_assert(device_has_all::value[25] ==
+                aspect::usm_atomic_shared_allocations);
+  static_assert(device_has_all::value[26] == aspect::atomic64);
+  static_assert(device_has_all::value[27] ==
+                aspect::ext_intel_device_info_uuid);
+  static_assert(device_has_all::value[28] == aspect::ext_oneapi_srgb);
+  static_assert(device_has_all::value[29] == aspect::ext_oneapi_native_assert);
+  static_assert(device_has_all::value[30] == aspect::host_debuggable);
+  static_assert(device_has_all::value[31] ==
+                aspect::ext_intel_gpu_hw_threads_per_eu);
+  static_assert(device_has_all::value[32] ==
+                aspect::ext_oneapi_cuda_async_barrier);
+  static_assert(device_has_all::value[33] == aspect::ext_oneapi_bfloat16);
+  static_assert(device_has_all::value[34] == aspect::ext_intel_free_memory);
+  static_assert(device_has_all::value[35] == aspect::ext_intel_device_id);
 
   static_assert(std::is_same_v<decltype(sub_group_size<28>)::value_t,
                                std::integral_constant<uint32_t, 28>>);

--- a/sycl/test/extensions/properties/properties_kernel_device_has.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_device_has.cpp
@@ -1,0 +1,172 @@
+// RUN: %clangxx -fsycl-device-only -S -Xclang -emit-llvm %s -o - | FileCheck %s --check-prefix CHECK-IR
+// RUN: %clangxx -fsycl -Xclang -verify %s
+// expected-no-diagnostics
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+using namespace ext::oneapi::experimental;
+
+static constexpr auto device_has_all = device_has<
+    aspect::ext_oneapi_cuda_async_barrier, aspect::ext_oneapi_bfloat16,
+    aspect::custom, aspect::fp16, aspect::fp64, aspect::image,
+    aspect::online_compiler, aspect::online_linker, aspect::queue_profiling,
+    aspect::usm_device_allocations, aspect::usm_restricted_shared_allocations,
+    aspect::usm_system_allocations, aspect::ext_intel_pci_address, aspect::host,
+    aspect::cpu, aspect::gpu, aspect::accelerator,
+    aspect::ext_intel_gpu_eu_count, aspect::ext_intel_gpu_subslices_per_slice,
+    aspect::ext_intel_gpu_eu_count_per_subslice,
+    aspect::ext_intel_max_mem_bandwidth, aspect::ext_intel_mem_channel,
+    aspect::usm_atomic_host_allocations, aspect::usm_atomic_shared_allocations,
+    aspect::atomic64, aspect::ext_intel_device_info_uuid,
+    aspect::ext_oneapi_srgb, aspect::ext_intel_gpu_eu_simd_width,
+    aspect::ext_intel_gpu_slices, aspect::ext_oneapi_native_assert,
+    aspect::host_debuggable, aspect::ext_intel_gpu_hw_threads_per_eu,
+    aspect::usm_host_allocations, aspect::usm_shared_allocations,
+    aspect::ext_intel_free_memory, aspect::ext_intel_device_id>;
+
+int main() {
+  queue Q;
+  event Ev;
+
+  range<1> R1{1};
+  nd_range<1> NDR1{R1, R1};
+
+  constexpr auto Props = properties{device_has_all};
+
+  auto Redu1 = reduction<int>(nullptr, plus<int>());
+  auto Redu2 = reduction<float>(nullptr, multiplies<float>());
+
+  // CHECK-IR: spir_kernel void @{{.*}}WGSizeKernel0(){{.*}} #[[DHAttr1:[0-9]+]]
+  Q.single_task<class WGSizeKernel0>(Props, []() {});
+  // CHECK-IR: spir_kernel void @{{.*}}WGSizeKernel1(){{.*}} #[[DHAttr1]]
+  Q.single_task<class WGSizeKernel1>(Ev, Props, []() {});
+  // CHECK-IR: spir_kernel void @{{.*}}WGSizeKernel2(){{.*}} #[[DHAttr1]]
+  Q.single_task<class WGSizeKernel2>({Ev}, Props, []() {});
+
+  // CHECK-IR: spir_kernel void @{{.*}}WGSizeKernel3(){{.*}} #[[DHAttr2:[0-9]+]]
+  Q.parallel_for<class WGSizeKernel3>(R1, Props, [](id<1>) {});
+  // CHECK-IR: spir_kernel void @{{.*}}WGSizeKernel4(){{.*}} #[[DHAttr2]]
+  Q.parallel_for<class WGSizeKernel4>(R1, Ev, Props, [](id<1>) {});
+  // CHECK-IR: spir_kernel void @{{.*}}WGSizeKernel5(){{.*}} #[[DHAttr2]]
+  Q.parallel_for<class WGSizeKernel5>(R1, {Ev}, Props, [](id<1>) {});
+
+  // CHECK-IR: spir_kernel void @{{.*}}main_krn{{.*}}WGSizeKernel6{{.*}}{{.*}} #[[DHAttr3:[0-9]+]]
+  Q.parallel_for<class WGSizeKernel6>(R1, Props, Redu1, [](id<1>, auto &) {});
+  // CHECK-IR: spir_kernel void @{{.*}}main_krn{{.*}}WGSizeKernel7{{.*}}{{.*}} #[[DHAttr3]]
+  Q.parallel_for<class WGSizeKernel7>(R1, Ev, Props, Redu1,
+                                      [](id<1>, auto &) {});
+  // CHECK-IR: spir_kernel void @{{.*}}main_krn{{.*}}WGSizeKernel8{{.*}}{{.*}} #[[DHAttr3]]
+  Q.parallel_for<class WGSizeKernel8>(R1, {Ev}, Props, Redu1,
+                                      [](id<1>, auto &) {});
+
+  // CHECK-IR: spir_kernel void @{{.*}}WGSizeKernel9(){{.*}} #[[DHAttr2]]
+  Q.parallel_for<class WGSizeKernel9>(NDR1, Props, [](nd_item<1>) {});
+  // CHECK-IR: spir_kernel void @{{.*}}WGSizeKernel10(){{.*}} #[[DHAttr2]]
+  Q.parallel_for<class WGSizeKernel10>(NDR1, Ev, Props, [](nd_item<1>) {});
+  // CHECK-IR: spir_kernel void @{{.*}}WGSizeKernel11(){{.*}} #[[DHAttr2]]
+  Q.parallel_for<class WGSizeKernel11>(NDR1, {Ev}, Props, [](nd_item<1>) {});
+
+  // CHECK-IR: spir_kernel void @{{.*}}main_krn{{.*}}WGSizeKernel12{{.*}}{{.*}} #[[DHAttr3]]
+  Q.parallel_for<class WGSizeKernel12>(NDR1, Props, Redu1,
+                                       [](nd_item<1>, auto &) {});
+  // CHECK-IR: spir_kernel void @{{.*}}main_krn{{.*}}WGSizeKernel13{{.*}}{{.*}} #[[DHAttr3]]
+  Q.parallel_for<class WGSizeKernel13>(NDR1, Ev, Props, Redu1,
+                                       [](nd_item<1>, auto &) {});
+  // CHECK-IR: spir_kernel void @{{.*}}main_krn{{.*}}WGSizeKernel14{{.*}}{{.*}} #[[DHAttr3]]
+  Q.parallel_for<class WGSizeKernel14>(NDR1, {Ev}, Props, Redu1,
+                                       [](nd_item<1>, auto &) {});
+
+  // CHECK-IR: spir_kernel void @{{.*}}main_krn{{.*}}WGSizeKernel15{{.*}}{{.*}} #[[DHAttr3]]
+  Q.parallel_for<class WGSizeKernel15>(NDR1, Props, Redu1, Redu2,
+                                       [](nd_item<1>, auto &, auto &) {});
+  // CHECK-IR: spir_kernel void @{{.*}}main_krn{{.*}}WGSizeKernel16{{.*}}{{.*}} #[[DHAttr3]]
+  Q.parallel_for<class WGSizeKernel16>(NDR1, Ev, Props, Redu1, Redu2,
+                                       [](nd_item<1>, auto &, auto &) {});
+  // CHECK-IR: spir_kernel void @{{.*}}main_krn{{.*}}WGSizeKernel17{{.*}}{{.*}} #[[DHAttr3]]
+  Q.parallel_for<class WGSizeKernel17>(NDR1, {Ev}, Props, Redu1, Redu2,
+                                       [](nd_item<1>, auto &, auto &) {});
+
+  // CHECK-IR: spir_kernel void @{{.*}}WGSizeKernel18(){{.*}} #[[DHAttr1]]
+  Q.submit([&](handler &CGH) {
+    CGH.single_task<class WGSizeKernel18>(Props, []() {});
+  });
+
+  // CHECK-IR: spir_kernel void @{{.*}}WGSizeKernel19(){{.*}} #[[DHAttr2]]
+  Q.submit([&](handler &CGH) {
+    CGH.parallel_for<class WGSizeKernel19>(R1, Props, [](id<1>) {});
+  });
+
+  // CHECK-IR: spir_kernel void @{{.*}}main_krn{{.*}}WGSizeKernel20{{.*}}{{.*}} #[[DHAttr3]]
+  Q.submit([&](handler &CGH) {
+    CGH.parallel_for<class WGSizeKernel20>(R1, Props, Redu1,
+                                           [](id<1>, auto &) {});
+  });
+
+  // CHECK-IR: spir_kernel void @{{.*}}WGSizeKernel21(){{.*}} #[[DHAttr2]]
+  Q.submit([&](handler &CGH) {
+    CGH.parallel_for<class WGSizeKernel21>(NDR1, Props, [](nd_item<1>) {});
+  });
+
+  // CHECK-IR: spir_kernel void @{{.*}}main_krn{{.*}}WGSizeKernel22{{.*}}{{.*}} #[[DHAttr3]]
+  Q.submit([&](handler &CGH) {
+    CGH.parallel_for<class WGSizeKernel22>(NDR1, Props, Redu1,
+                                           [](nd_item<1>, auto &) {});
+  });
+
+  // CHECK-IR: spir_kernel void @{{.*}}main_krn{{.*}}WGSizeKernel23{{.*}}{{.*}} #[[DHAttr3]]
+  Q.submit([&](handler &CGH) {
+    CGH.parallel_for<class WGSizeKernel23>(NDR1, Props, Redu1, Redu2,
+                                           [](nd_item<1>, auto &, auto &) {});
+  });
+
+  // CHECK-IR: spir_kernel void @{{.*}}WGSizeKernel24(){{.*}} #[[DHAttr3]]
+  Q.submit([&](handler &CGH) {
+    CGH.parallel_for_work_group<class WGSizeKernel24>(
+        R1, Props,
+        [](group<1> G) { G.parallel_for_work_item([&](h_item<1>) {}); });
+  });
+
+  return 0;
+}
+
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_oneapi_cuda_async_barrier", i32 [[ext_oneapi_cuda_async_barrier_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_oneapi_bfloat16", i32 [[ext_oneapi_bfloat16_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"custom", i32 [[custom_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"fp16", i32 [[fp16_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"fp64", i32 [[fp64_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"image", i32 [[image_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"online_compiler", i32 [[online_compiler_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"online_linker", i32 [[online_linker_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"queue_profiling", i32 [[queue_profiling_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"usm_device_allocations", i32 [[usm_device_allocations_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"usm_restricted_shared_allocations", i32 [[usm_restricted_shared_allocations_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"usm_system_allocations", i32 [[usm_system_allocations_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_pci_address", i32 [[ext_intel_pci_address_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"host", i32 [[host_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"cpu", i32 [[cpu_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"gpu", i32 [[gpu_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"accelerator", i32 [[accelerator_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_gpu_eu_count", i32 [[ext_intel_gpu_eu_count_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_gpu_subslices_per_slice", i32 [[ext_intel_gpu_subslices_per_slice_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_gpu_eu_count_per_subslice", i32 [[ext_intel_gpu_eu_count_per_subslice_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_max_mem_bandwidth", i32 [[ext_intel_max_mem_bandwidth_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_mem_channel", i32 [[ext_intel_mem_channel_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"usm_atomic_host_allocations", i32 [[usm_atomic_host_allocations_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"usm_atomic_shared_allocations", i32 [[usm_atomic_shared_allocations_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"atomic64", i32 [[atomic64_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_device_info_uuid", i32 [[ext_intel_device_info_uuid_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_oneapi_srgb", i32 [[ext_oneapi_srgb_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_gpu_eu_simd_width", i32 [[ext_intel_gpu_eu_simd_width_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_gpu_slices", i32 [[ext_intel_gpu_slices_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_oneapi_native_assert", i32 [[ext_oneapi_native_assert_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"host_debuggable", i32 [[host_debuggable_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_gpu_hw_threads_per_eu", i32 [[ext_intel_gpu_hw_threads_per_eu_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"usm_host_allocations", i32 [[usm_host_allocations_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"usm_shared_allocations", i32 [[usm_shared_allocations_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_free_memory", i32 [[ext_intel_free_memory_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_device_id", i32 [[ext_intel_device_id_ASPECT_MD:[0-9]+]]}
+
+// CHECK-IR-DAG: attributes #[[DHAttr1]] = { {{.*}}"sycl-device-has"="[[ext_oneapi_cuda_async_barrier_ASPECT_MD]],[[ext_oneapi_bfloat16_ASPECT_MD]],[[custom_ASPECT_MD]],[[fp16_ASPECT_MD]],[[fp64_ASPECT_MD]],[[image_ASPECT_MD]],[[online_compiler_ASPECT_MD]],[[online_linker_ASPECT_MD]],[[queue_profiling_ASPECT_MD]],[[usm_device_allocations_ASPECT_MD]],[[usm_restricted_shared_allocations_ASPECT_MD]],[[usm_system_allocations_ASPECT_MD]],[[ext_intel_pci_address_ASPECT_MD]],[[host_ASPECT_MD]],[[cpu_ASPECT_MD]],[[gpu_ASPECT_MD]],[[accelerator_ASPECT_MD]],[[ext_intel_gpu_eu_count_ASPECT_MD]],[[ext_intel_gpu_subslices_per_slice_ASPECT_MD]],[[ext_intel_gpu_eu_count_per_subslice_ASPECT_MD]],[[ext_intel_max_mem_bandwidth_ASPECT_MD]],[[ext_intel_mem_channel_ASPECT_MD]],[[usm_atomic_host_allocations_ASPECT_MD]],[[usm_atomic_shared_allocations_ASPECT_MD]],[[atomic64_ASPECT_MD]],[[ext_intel_device_info_uuid_ASPECT_MD]],[[ext_oneapi_srgb_ASPECT_MD]],[[ext_intel_gpu_eu_simd_width_ASPECT_MD]],[[ext_intel_gpu_slices_ASPECT_MD]],[[ext_oneapi_native_assert_ASPECT_MD]],[[host_debuggable_ASPECT_MD]],[[ext_intel_gpu_hw_threads_per_eu_ASPECT_MD]],[[usm_host_allocations_ASPECT_MD]],[[usm_shared_allocations_ASPECT_MD]],[[ext_intel_free_memory_ASPECT_MD]],[[ext_intel_device_id_ASPECT_MD]]"
+// CHECK-IR-DAG: attributes #[[DHAttr2]] = { {{.*}}"sycl-device-has"="[[ext_oneapi_cuda_async_barrier_ASPECT_MD]],[[ext_oneapi_bfloat16_ASPECT_MD]],[[custom_ASPECT_MD]],[[fp16_ASPECT_MD]],[[fp64_ASPECT_MD]],[[image_ASPECT_MD]],[[online_compiler_ASPECT_MD]],[[online_linker_ASPECT_MD]],[[queue_profiling_ASPECT_MD]],[[usm_device_allocations_ASPECT_MD]],[[usm_restricted_shared_allocations_ASPECT_MD]],[[usm_system_allocations_ASPECT_MD]],[[ext_intel_pci_address_ASPECT_MD]],[[host_ASPECT_MD]],[[cpu_ASPECT_MD]],[[gpu_ASPECT_MD]],[[accelerator_ASPECT_MD]],[[ext_intel_gpu_eu_count_ASPECT_MD]],[[ext_intel_gpu_subslices_per_slice_ASPECT_MD]],[[ext_intel_gpu_eu_count_per_subslice_ASPECT_MD]],[[ext_intel_max_mem_bandwidth_ASPECT_MD]],[[ext_intel_mem_channel_ASPECT_MD]],[[usm_atomic_host_allocations_ASPECT_MD]],[[usm_atomic_shared_allocations_ASPECT_MD]],[[atomic64_ASPECT_MD]],[[ext_intel_device_info_uuid_ASPECT_MD]],[[ext_oneapi_srgb_ASPECT_MD]],[[ext_intel_gpu_eu_simd_width_ASPECT_MD]],[[ext_intel_gpu_slices_ASPECT_MD]],[[ext_oneapi_native_assert_ASPECT_MD]],[[host_debuggable_ASPECT_MD]],[[ext_intel_gpu_hw_threads_per_eu_ASPECT_MD]],[[usm_host_allocations_ASPECT_MD]],[[usm_shared_allocations_ASPECT_MD]],[[ext_intel_free_memory_ASPECT_MD]],[[ext_intel_device_id_ASPECT_MD]]"
+// CHECK-IR-DAG: attributes #[[DHAttr3]] = { {{.*}}"sycl-device-has"="[[ext_oneapi_cuda_async_barrier_ASPECT_MD]],[[ext_oneapi_bfloat16_ASPECT_MD]],[[custom_ASPECT_MD]],[[fp16_ASPECT_MD]],[[fp64_ASPECT_MD]],[[image_ASPECT_MD]],[[online_compiler_ASPECT_MD]],[[online_linker_ASPECT_MD]],[[queue_profiling_ASPECT_MD]],[[usm_device_allocations_ASPECT_MD]],[[usm_restricted_shared_allocations_ASPECT_MD]],[[usm_system_allocations_ASPECT_MD]],[[ext_intel_pci_address_ASPECT_MD]],[[host_ASPECT_MD]],[[cpu_ASPECT_MD]],[[gpu_ASPECT_MD]],[[accelerator_ASPECT_MD]],[[ext_intel_gpu_eu_count_ASPECT_MD]],[[ext_intel_gpu_subslices_per_slice_ASPECT_MD]],[[ext_intel_gpu_eu_count_per_subslice_ASPECT_MD]],[[ext_intel_max_mem_bandwidth_ASPECT_MD]],[[ext_intel_mem_channel_ASPECT_MD]],[[usm_atomic_host_allocations_ASPECT_MD]],[[usm_atomic_shared_allocations_ASPECT_MD]],[[atomic64_ASPECT_MD]],[[ext_intel_device_info_uuid_ASPECT_MD]],[[ext_oneapi_srgb_ASPECT_MD]],[[ext_intel_gpu_eu_simd_width_ASPECT_MD]],[[ext_intel_gpu_slices_ASPECT_MD]],[[ext_oneapi_native_assert_ASPECT_MD]],[[host_debuggable_ASPECT_MD]],[[ext_intel_gpu_hw_threads_per_eu_ASPECT_MD]],[[usm_host_allocations_ASPECT_MD]],[[usm_shared_allocations_ASPECT_MD]],[[ext_intel_free_memory_ASPECT_MD]],[[ext_intel_device_id_ASPECT_MD]]"

--- a/sycl/test/extensions/properties/properties_kernel_device_has_macro.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_device_has_macro.cpp
@@ -1,0 +1,90 @@
+// RUN: %clangxx -fsycl-device-only -S -Xclang -emit-llvm %s -o - | FileCheck %s --check-prefix CHECK-IR
+// RUN: %clangxx -fsycl -Xclang -verify %s
+// expected-no-diagnostics
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+using namespace ext::oneapi::experimental;
+
+static constexpr auto device_has_all = device_has<
+    aspect::ext_oneapi_cuda_async_barrier, aspect::ext_oneapi_bfloat16,
+    aspect::custom, aspect::fp16, aspect::fp64, aspect::image,
+    aspect::online_compiler, aspect::online_linker, aspect::queue_profiling,
+    aspect::usm_device_allocations, aspect::usm_restricted_shared_allocations,
+    aspect::usm_system_allocations, aspect::ext_intel_pci_address, aspect::host,
+    aspect::cpu, aspect::gpu, aspect::accelerator,
+    aspect::ext_intel_gpu_eu_count, aspect::ext_intel_gpu_subslices_per_slice,
+    aspect::ext_intel_gpu_eu_count_per_subslice,
+    aspect::ext_intel_max_mem_bandwidth, aspect::ext_intel_mem_channel,
+    aspect::usm_atomic_host_allocations, aspect::usm_atomic_shared_allocations,
+    aspect::atomic64, aspect::ext_intel_device_info_uuid,
+    aspect::ext_oneapi_srgb, aspect::ext_intel_gpu_eu_simd_width,
+    aspect::ext_intel_gpu_slices, aspect::ext_oneapi_native_assert,
+    aspect::host_debuggable, aspect::ext_intel_gpu_hw_threads_per_eu,
+    aspect::usm_host_allocations, aspect::usm_shared_allocations,
+    aspect::ext_intel_free_memory, aspect::ext_intel_device_id>;
+
+// CHECK-IR: spir_func void @{{.*}}Func0{{.*}}(){{.*}} #[[DHAttr1:[0-9]+]]
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(device_has_all) void Func0() {}
+
+// CHECK-IR: spir_func void @{{.*}}Func1{{.*}}(){{.*}} #[[DHAttr2:[0-9]+]]
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((device_has<>)) void Func1() {}
+
+// CHECK-IR: spir_func void @{{.*}}Func2{{.*}}(){{.*}} #[[DHAttr3:[0-9]+]]
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((device_has<aspect::fp16, aspect::atomic64>))
+void Func2() {}
+
+// TODO: Check that SYCL_EXTERNAL when the attributes are correctly attached to
+//       device functions with external linkage.
+
+int main() {
+  queue Q;
+  Q.single_task([]() {
+    Func0();
+    Func1();
+    Func2();
+  });
+  return 0;
+}
+
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_oneapi_cuda_async_barrier", i32 [[ext_oneapi_cuda_async_barrier_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_oneapi_bfloat16", i32 [[ext_oneapi_bfloat16_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"custom", i32 [[custom_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"fp16", i32 [[fp16_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"fp64", i32 [[fp64_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"image", i32 [[image_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"online_compiler", i32 [[online_compiler_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"online_linker", i32 [[online_linker_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"queue_profiling", i32 [[queue_profiling_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"usm_device_allocations", i32 [[usm_device_allocations_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"usm_restricted_shared_allocations", i32 [[usm_restricted_shared_allocations_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"usm_system_allocations", i32 [[usm_system_allocations_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_pci_address", i32 [[ext_intel_pci_address_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"host", i32 [[host_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"cpu", i32 [[cpu_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"gpu", i32 [[gpu_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"accelerator", i32 [[accelerator_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_gpu_eu_count", i32 [[ext_intel_gpu_eu_count_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_gpu_subslices_per_slice", i32 [[ext_intel_gpu_subslices_per_slice_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_gpu_eu_count_per_subslice", i32 [[ext_intel_gpu_eu_count_per_subslice_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_max_mem_bandwidth", i32 [[ext_intel_max_mem_bandwidth_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_mem_channel", i32 [[ext_intel_mem_channel_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"usm_atomic_host_allocations", i32 [[usm_atomic_host_allocations_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"usm_atomic_shared_allocations", i32 [[usm_atomic_shared_allocations_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"atomic64", i32 [[atomic64_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_device_info_uuid", i32 [[ext_intel_device_info_uuid_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_oneapi_srgb", i32 [[ext_oneapi_srgb_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_gpu_eu_simd_width", i32 [[ext_intel_gpu_eu_simd_width_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_gpu_slices", i32 [[ext_intel_gpu_slices_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_oneapi_native_assert", i32 [[ext_oneapi_native_assert_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"host_debuggable", i32 [[host_debuggable_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_gpu_hw_threads_per_eu", i32 [[ext_intel_gpu_hw_threads_per_eu_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"usm_host_allocations", i32 [[usm_host_allocations_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"usm_shared_allocations", i32 [[usm_shared_allocations_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_free_memory", i32 [[ext_intel_free_memory_ASPECT_MD:[0-9]+]]}
+// CHECK-IR-DAG: !{{[0-9]+}} = !{!"ext_intel_device_id", i32 [[ext_intel_device_id_ASPECT_MD:[0-9]+]]}
+
+// CHECK-IR-DAG: attributes #[[DHAttr1]] = { {{.*}}"sycl-device-has"="[[ext_oneapi_cuda_async_barrier_ASPECT_MD]],[[ext_oneapi_bfloat16_ASPECT_MD]],[[custom_ASPECT_MD]],[[fp16_ASPECT_MD]],[[fp64_ASPECT_MD]],[[image_ASPECT_MD]],[[online_compiler_ASPECT_MD]],[[online_linker_ASPECT_MD]],[[queue_profiling_ASPECT_MD]],[[usm_device_allocations_ASPECT_MD]],[[usm_restricted_shared_allocations_ASPECT_MD]],[[usm_system_allocations_ASPECT_MD]],[[ext_intel_pci_address_ASPECT_MD]],[[host_ASPECT_MD]],[[cpu_ASPECT_MD]],[[gpu_ASPECT_MD]],[[accelerator_ASPECT_MD]],[[ext_intel_gpu_eu_count_ASPECT_MD]],[[ext_intel_gpu_subslices_per_slice_ASPECT_MD]],[[ext_intel_gpu_eu_count_per_subslice_ASPECT_MD]],[[ext_intel_max_mem_bandwidth_ASPECT_MD]],[[ext_intel_mem_channel_ASPECT_MD]],[[usm_atomic_host_allocations_ASPECT_MD]],[[usm_atomic_shared_allocations_ASPECT_MD]],[[atomic64_ASPECT_MD]],[[ext_intel_device_info_uuid_ASPECT_MD]],[[ext_oneapi_srgb_ASPECT_MD]],[[ext_intel_gpu_eu_simd_width_ASPECT_MD]],[[ext_intel_gpu_slices_ASPECT_MD]],[[ext_oneapi_native_assert_ASPECT_MD]],[[host_debuggable_ASPECT_MD]],[[ext_intel_gpu_hw_threads_per_eu_ASPECT_MD]],[[usm_host_allocations_ASPECT_MD]],[[usm_shared_allocations_ASPECT_MD]],[[ext_intel_free_memory_ASPECT_MD]],[[ext_intel_device_id_ASPECT_MD]]"
+// CHECK-IR-DAG: attributes #[[DHAttr2]] = { {{.*}}"sycl-device-has" {{.*}}
+// CHECK-IR-DAG: attributes #[[DHAttr3]] = { {{.*}}"sycl-device-has"="[[fp16_ASPECT_MD]],[[atomic64_ASPECT_MD]]"


### PR DESCRIPTION
This commit implements the `device_has` kernel property and the SYCL_EXT_ONEAPI_FUNCTION_PROPERTY macro from the
[sycl_ext_oneapi_kernel_properties](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_properties.asciidoc) extension.

Known current limitations:
- The LLVM IR attributes from add_ir_attributes_function are not correctly generated on SYCL_EXTERNAL functions.
- The SYCL_EXT_ONEAPI_FUNCTION_PROPERTY cannot currently be placed after SYCL_EXTERNAL.