### PR TITLE
[SYCL] Remove use of host device in CI device filters

### DIFF
--- a/devops/test_configs.json
+++ b/devops/test_configs.json
@@ -9,7 +9,7 @@
       ],
       "image": "${{ inputs.intel_drivers_image }}",
       "container_options": "-u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN",
-      "check_sycl_all": "level_zero:gpu,host",
+      "check_sycl_all": "level_zero:gpu",
       "cmake_args": ""
     },
     {
@@ -21,7 +21,7 @@
       ],
       "image": "${{ inputs.intel_drivers_image }}",
       "container_options": "-u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN",
-      "check_sycl_all": "opencl:gpu,host",
+      "check_sycl_all": "opencl:gpu",
       "cmake_args": ""
     },
     {
@@ -33,7 +33,7 @@
       ],
       "image": "${{ inputs.intel_drivers_image }}",
       "container_options": "-u 1001",
-      "check_sycl_all": "opencl:cpu,host",
+      "check_sycl_all": "opencl:cpu",
       "cmake_args": ""
     },
     {
@@ -57,7 +57,7 @@
       ],
       "image": "${{ inputs.amdgpu_image }}",
       "container_options": "--device=/dev/dri --device=/dev/kfd",
-      "check_sycl_all": "hip:gpu,host",
+      "check_sycl_all": "hip:gpu",
       "cmake_args": "-DHIP_PLATFORM=\"AMD\" -DAMD_ARCH=\"gfx1031\""
     },
     {
@@ -69,7 +69,7 @@
       ],
       "image": "${{ inputs.cuda_image }}",
       "container_options": "--gpus all",
-      "check_sycl_all": "cuda:gpu,host",
+      "check_sycl_all": "cuda:gpu",
       "cmake_args": ""
     }
   ],
@@ -83,7 +83,7 @@
       ],
       "image": "${{ inputs.cuda_image }}",
       "container_options": "--gpus all",
-      "sycl_device_filter": "ext_oneapi_cuda:gpu,host",
+      "sycl_device_filter": "ext_oneapi_cuda:gpu",
       "cmake_args": "-DDPCPP_TARGET_TRIPLES=nvptx64-nvidia-cuda"
     }
   ]


### PR DESCRIPTION
With the removal of the host device, the use of `host` should be removed from the device filter in the CI configurations. This commit removes this.