### PR TITLE
[SYCL-MLIR][NFC] Add isSYCLType()

### DIFF
--- a/mlir-sycl/include/mlir/Conversion/SYCLToLLVM/SYCLToLLVM.h
+++ b/mlir-sycl/include/mlir/Conversion/SYCLToLLVM/SYCLToLLVM.h
@@ -26,9 +26,6 @@ void populateSYCLToLLVMTypeConversion(LLVMTypeConverter &typeConverter);
 void populateSYCLToLLVMConversionPatterns(LLVMTypeConverter &typeConverter,
                                           RewritePatternSet &patterns);
 
-/// Return true if the given \p type is a SYCL type.
-bool isSYCLType(Type type);
-
 } // namespace sycl
 } // namespace mlir
 

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
@@ -502,6 +502,16 @@ public:
   llvm::ArrayRef<mlir::Type> getBody() const;
 };
 
+/// Return true if the given \p Ty is a SYCL type.
+inline bool isSYCLType(Type Ty) {
+  return Ty.isa<mlir::sycl::ArrayType, mlir::sycl::IDType,
+                mlir::sycl::AccessorCommonType, mlir::sycl::AccessorType,
+                mlir::sycl::RangeType, mlir::sycl::NdRangeType,
+                mlir::sycl::AccessorImplDeviceType, mlir::sycl::ItemType,
+                mlir::sycl::ItemBaseType, mlir::sycl::NdItemType,
+                mlir::sycl::GroupType>();
+}
+
 } // namespace sycl
 } // namespace mlir
 

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -408,12 +408,3 @@ void mlir::sycl::populateSYCLToLLVMConversionPatterns(
   patterns.add<CastPattern>(typeConverter);
   patterns.add<ConstructorPattern>(typeConverter);
 }
-
-bool mlir::sycl::isSYCLType(Type type) {
-  return type.isa<mlir::sycl::IDType, mlir::sycl::AccessorCommonType,
-                  mlir::sycl::AccessorType, mlir::sycl::RangeType,
-                  mlir::sycl::NdRangeType, mlir::sycl::AccessorImplDeviceType,
-                  mlir::sycl::ArrayType, mlir::sycl::ItemType,
-                  mlir::sycl::ItemBaseType, mlir::sycl::NdItemType,
-                  mlir::sycl::GroupType>();
-}


### PR DESCRIPTION
Added function `isSYCLType`, to determine if a given type is a SYCL type.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>