### PR TITLE
[SYCL] Implement SYCL 2020 default async_handler behavior

### DIFF
--- a/sycl/include/sycl/exception_list.hpp
+++ b/sycl/include/sycl/exception_list.hpp
@@ -57,17 +57,17 @@ namespace detail {
 // Default implementation of async_handler used by queue and context when no
 // user-defined async_handler is specified.
 inline void defaultAsyncHandler(exception_list Exceptions) {
-  std::cout << "Default async_handler caught exceptions:";
+  std::cerr << "Default async_handler caught exceptions:";
   for (auto &EIt : Exceptions) {
     try {
       if (EIt) {
         std::rethrow_exception(EIt);
       }
     } catch (const std::exception &E) {
-      std::cout << "\n\t" << E.what();
+      std::cerr << "\n\t" << E.what();
     }
   }
-  std::cout << std::endl;
+  std::cerr << std::endl;
   std::terminate();
 }
 } // namespace detail

--- a/sycl/include/sycl/exception_list.hpp
+++ b/sycl/include/sycl/exception_list.hpp
@@ -12,6 +12,7 @@
 
 #include <sycl/detail/defines.hpp>
 #include <sycl/detail/export.hpp>
+#include <sycl/detail/iostream_proxy.hpp>
 #include <sycl/stl.hpp>
 
 #include <cstddef>
@@ -52,5 +53,23 @@ private:
 
 using async_handler = std::function<void(sycl::exception_list)>;
 
+namespace detail {
+// Default implementation of async_handler used by queue and context when no
+// user-defined async_handler is specified.
+inline void defaultAsyncHandler(exception_list Exceptions) {
+  std::cout << "Default async_handler caught exceptions:";
+  for (auto &EIt : Exceptions) {
+    try {
+      if (EIt) {
+        std::rethrow_exception(EIt);
+      }
+    } catch (const std::exception &E) {
+      std::cout << "\n\t" << E.what();
+    }
+  }
+  std::cout << std::endl;
+  std::terminate();
+}
+} // namespace detail
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -90,7 +90,7 @@ public:
   ///
   /// \param PropList is a list of properties for queue construction.
   explicit queue(const property_list &PropList = {})
-      : queue(default_selector(), async_handler{}, PropList) {}
+      : queue(default_selector(), detail::defaultAsyncHandler, PropList) {}
 
   /// Constructs a SYCL queue instance with an async_handler using the device
   /// returned by an instance of default_selector.
@@ -125,8 +125,8 @@ public:
                 detail::EnableIfSYCL2020DeviceSelectorInvocable<DeviceSelector>>
   explicit queue(const DeviceSelector &deviceSelector,
                  const property_list &PropList = {})
-      : queue(detail::select_device(deviceSelector), async_handler{},
-              PropList) {}
+      : queue(detail::select_device(deviceSelector),
+              detail::defaultAsyncHandler, PropList) {}
 
   /// Constructs a SYCL queue instance using the device identified by the
   /// device selector provided.
@@ -171,7 +171,8 @@ public:
                         "use SYCL 2020 device selectors instead.")
   queue(const device_selector &DeviceSelector,
         const property_list &PropList = {})
-      : queue(DeviceSelector.select_device(), async_handler{}, PropList) {}
+      : queue(DeviceSelector.select_device(), detail::defaultAsyncHandler,
+              PropList) {}
 
   /// Constructs a SYCL queue instance with an async_handler using the device
   /// returned by the DeviceSelector provided.
@@ -190,7 +191,7 @@ public:
   /// \param SyclDevice is an instance of SYCL device.
   /// \param PropList is a list of properties for queue construction.
   explicit queue(const device &SyclDevice, const property_list &PropList = {})
-      : queue(SyclDevice, async_handler{}, PropList) {}
+      : queue(SyclDevice, detail::defaultAsyncHandler, PropList) {}
 
   /// Constructs a SYCL queue instance with an async_handler using the device
   /// provided.

--- a/sycl/source/backend/level_zero.cpp
+++ b/sycl/source/backend/level_zero.cpp
@@ -57,8 +57,8 @@ __SYCL_EXPORT context make_context(const std::vector<device> &DeviceList,
       NativeHandle, DeviceHandles.size(), DeviceHandles.data(), !KeepOwnership,
       &PiContext);
   // Construct the SYCL context from PI context.
-  return detail::createSyclObjFromImpl<context>(
-      std::make_shared<context_impl>(PiContext, async_handler{}, Plugin));
+  return detail::createSyclObjFromImpl<context>(std::make_shared<context_impl>(
+      PiContext, detail::defaultAsyncHandler, Plugin));
 }
 
 //----------------------------------------------------------------------------

--- a/sycl/source/backend/opencl.cpp
+++ b/sycl/source/backend/opencl.cpp
@@ -36,7 +36,8 @@ __SYCL_EXPORT device make_device(pi_native_handle NativeHandle) {
 //----------------------------------------------------------------------------
 // Implementation of opencl::make<context>
 __SYCL_EXPORT context make_context(pi_native_handle NativeHandle) {
-  return detail::make_context(NativeHandle, async_handler{}, backend::opencl);
+  return detail::make_context(NativeHandle, detail::defaultAsyncHandler,
+                              backend::opencl);
 }
 
 //----------------------------------------------------------------------------

--- a/sycl/source/context.cpp
+++ b/sycl/source/context.cpp
@@ -26,6 +26,7 @@
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
+
 context::context(const property_list &PropList)
     : context(default_selector().select_device(), PropList) {}
 
@@ -49,7 +50,7 @@ context::context(const platform &Platform, async_handler AsyncHandler,
 
 context::context(const std::vector<device> &DeviceList,
                  const property_list &PropList)
-    : context(DeviceList, async_handler{}, PropList) {}
+    : context(DeviceList, detail::defaultAsyncHandler, PropList) {}
 
 context::context(const std::vector<device> &DeviceList,
                  async_handler AsyncHandler, const property_list &PropList) {

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -230,10 +230,6 @@ public:
     try {
       return submit_impl(CGF, Self, Self, SecondQueue, Loc, PostProcess);
     } catch (...) {
-      {
-        std::lock_guard<std::mutex> Lock(MMutex);
-        MExceptions.PushBack(std::current_exception());
-      }
       return SecondQueue->submit_impl(CGF, SecondQueue, Self, SecondQueue, Loc,
                                       PostProcess);
     }


### PR DESCRIPTION
SYCL 2020 specifies that if no async_handler is given to either the queue nor the context a default async_handler will be used. This default handler must report the problems reported and call `std::terminate` or similar. This commit adds an implementation of the default async_handler.