### PR TITLE
[SYCL-MLIR] Remove Warning outputs

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1145,14 +1145,6 @@ MLIRScanner::EmitSYCLOps(const clang::Expr *Expr,
       if (const auto *RD = dyn_cast<clang::CXXRecordDecl>(Func->getParent()))
         if (!RD->getName().empty())
           OptFuncType = RD->getName();
-      if (!OptFuncType) {
-        /// JLE_QUEL::TODO
-        /// Handle case where we can't get the parent because the callee is not
-        /// a member function
-        llvm::errs()
-            << "Warning: generating sycl call op from unqualified function '"
-            << Func->getNameAsString() << "'\n";
-      }
 
       auto OptRetType = llvm::Optional<mlir::Type>{llvm::None};
       const mlir::Type RetType =

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -195,8 +195,11 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType qt, bool *implicitRef,
           TypeName == "group") {
         return getSYCLType(RT, *this);
       }
-      llvm::errs() << "Warning: SYCL type '" << ST->getName()
-                   << "' has not been converted to SYCL MLIR\n";
+      // No need special handling for types that doesn't have record declaration
+      // name.
+      if (TypeName != "")
+        llvm::errs() << "Warning: SYCL type '" << ST->getName()
+                     << "' has not been converted to SYCL MLIR\n";
     }
 
     auto CXRD = dyn_cast<CXXRecordDecl>(RT->getDecl());

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -195,7 +195,7 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType qt, bool *implicitRef,
           TypeName == "group") {
         return getSYCLType(RT, *this);
       }
-      // No need special handling for types that doesn't have record declaration
+      // No need special handling for types that don't have record declaration
       // name.
       if (TypeName != "")
         llvm::errs() << "Warning: SYCL type '" << ST->getName()

--- a/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
@@ -1,5 +1,4 @@
-// TODO: Investigate and remove all "Warning"s.
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.out 2>&1 | FileCheck %s --implicit-check-not="{{warning|error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.out 2>&1 | FileCheck %s --implicit-check-not="{{warning|Warning|error|Error}}:"
 
 // RUN: clang++ -fsycl -fsycl-device-only -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc 2>/dev/null
 


### PR DESCRIPTION
Remove warnings from the cases below:
- The case where callee is not a member function is handled.
- No need special handling for types that doesn't have record declaration name.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>