### PR TITLE
[SYCL-MLIR][NFC] Remove copyright headers from sycl lits

### DIFF
--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -1,12 +1,3 @@
-//===--- constructors.cpp -------------------------------------------------===//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
-// clang-format off
 // RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s -o - 2> /dev/null | FileCheck %s --check-prefixes=CHECK
 // RUN: clang++ -fsycl -fsycl-device-only -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefixes=CHECK-LLVM
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -1,13 +1,3 @@
-// Copyright (C) Codeplay Software Limited
-
-//===--- functions.cpp ----------------------------------------------------===//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
 // RUN: clang++ -fsycl -fsycl-device-only -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -1,14 +1,3 @@
-// Copyright (C) Codeplay Software Limited
-
-//===--- kernels.cpp ------------------------------------------------------===//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
-// clang-format off
 // RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s -o - 2> /dev/null| FileCheck %s --check-prefix=CHECK-MLIR
 // RUN: clang++ -fsycl -fsycl-device-only -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
@@ -1,13 +1,3 @@
-// Copyright (C) Intel
-
-//===--- kernels_funcs.cpp ------------------------------------------------===//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s -o - 2> /dev/null | FileCheck %s --check-prefix=CHECK-MLIR
 // RUN: clang++ -fsycl -fsycl-device-only -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -1,14 +1,3 @@
-// Copyright (C) Intel
-
-//===--- sycl_extern_func.cpp ---------------------------------------------===//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
-// clang-format off
 // RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s -o - 2> /dev/null | FileCheck %s --check-prefix=CHECK-MLIR
 // RUN: clang++ -fsycl -fsycl-device-only -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -1,13 +1,3 @@
-// Copyright (C) Codeplay Software Limited
-
-//===--- types.cpp --------------------------------------------------------===//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // RUN: clang++ -fsycl -fsycl-device-only -emit-mlir -o - %s 2> /dev/null | FileCheck %s
 
 #include <sycl/sycl.hpp>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
@@ -1,13 +1,3 @@
-// Copyright (C) Intel
-
-//===--- vec_add.cpp ------------------------------------------------------===//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-
 // RUN: clang++ -fsycl -fsycl-device-only -S -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
 // RUN: clang++ -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -S -emit-llvm %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 


### PR DESCRIPTION
As discussed in https://github.com/intel/llvm/pull/7066#discussion_r1000752924, 
1. No need to have copyright headers for the lit tests in `llvm/polygeist/tools/cgeist/Test/Verification/sycl`.
2. No need to have `clang-format off`, `.clang-format` file in the parent directory already disables clang-format for this directory. 

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>