### PR TITLE
[CI][NFC] Fix github actions warnings

### DIFF
--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -9,6 +9,8 @@ on:
     - sycl
     paths:
     - .github/workflows/sycl_post_commit.yml
+    - .github/workflows/sycl_windows_build_and_test.yml
+    - .github/workflows/sycl_macos_build_and_test.yml
 
 jobs:
   # This job generates matrix of tests for LLVM Test Suite

--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -9,6 +9,8 @@ on:
     - sycl
     paths:
     - .github/workflows/sycl_post_commit.yml
+    - .github/workflows/sycl_gen_test_matrix.yml
+    - .github/workflows/sycl_linux_build_and_test.yml
     - .github/workflows/sycl_windows_build_and_test.yml
     - .github/workflows/sycl_macos_build_and_test.yml
 

--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -9,6 +9,8 @@ on:
     - '.github/ISSUE_TEMPLATE/**'
     - '.github/CODEOWNERS'
     - '.github/workflows/sycl_update_gpu_driver.yml'
+    - '.github/workflows/sycl_windows_build_and_test.yml'
+    - '.github/workflows/sycl_macos_build_and_test.yml'
     - 'devops/containers/**'
     - 'devops/scripts/install_drivers.sh'
     - 'devops/scripts/install_build_tools.sh'

--- a/.github/workflows/sycl_windows_build_and_test.yml
+++ b/.github/workflows/sycl_windows_build_and_test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: [Windows, build]
     # TODO use cached checkout
     steps:
-    - uses: ilammy/msvc-dev-cmd@674ff850cbd739c402260838fa45b7114f750570
+    - uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d
       with:
         arch: amd64
     - name: Set env

--- a/.github/workflows/sycl_windows_build_and_test.yml
+++ b/.github/workflows/sycl_windows_build_and_test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: [Windows, build]
     # TODO use cached checkout
     steps:
-    - uses: ilammy/msvc-dev-cmd@9f8ae839b01883414208f29e3e24524387f48e1f
+    - uses: ilammy/msvc-dev-cmd@674ff850cbd739c402260838fa45b7114f750570
       with:
         arch: amd64
     - name: Set env


### PR DESCRIPTION
One more fix became available.
Also update some CI workflows according to current testing setup:
* Trigger post commit testing load in pre-commit time if corresponding sub-workflows changed
* Ignore Windows/MacOS sub-workflows changes in pre-commit testing load, they are not actually tested by pre-commit