### PR TITLE
[SYCL] Fix post-commit warning treated as error

### DIFF
--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -469,7 +469,7 @@ protected:
     // It is a deadlock on UNIX in implementation of lock and lock_shared, if
     // try_lock in the loop above will be executed, so using a single lock here
 #endif // _WIN32
-    return std::move(Lock);
+    return Lock;
   }
 
   /// Provides shared access to std::shared_timed_mutex object with deadlock


### PR DESCRIPTION
Compiler emits a warning when there is a return of std::move of a local variable.