### PR TITLE
[SYCL-MLIR] Fix cgeist 'BinAssign' evaluation order and return value

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -2164,3 +2164,46 @@ ValueCategory MLIRScanner::VisitStmtExpr(clang::StmtExpr *stmt) {
   }
   return off;
 }
+
+ValueCategory MLIRScanner::VisitBinAssign(BinaryOperator *e) {
+  LLVM_DEBUG({
+    llvm::dbgs() << "VisitBinAssign: ";
+    e->dump();
+    llvm::dbgs() << "\n";
+  });
+  auto rhs = Visit(e->getRHS());
+  auto lhs = Visit(e->getLHS());
+
+  assert(lhs.isReference);
+  mlir::Value tostore = rhs.getValue(builder);
+  mlir::Type subType;
+  if (auto PT = lhs.val.getType().dyn_cast<mlir::LLVM::LLVMPointerType>())
+    subType = PT.getElementType();
+  else
+    subType = lhs.val.getType().cast<MemRefType>().getElementType();
+  if (tostore.getType() != subType) {
+    if (auto prevTy = tostore.getType().dyn_cast<mlir::IntegerType>()) {
+      if (auto postTy = subType.dyn_cast<mlir::IntegerType>()) {
+        bool signedType = true;
+        if (auto bit = dyn_cast<BuiltinType>(&*e->getType())) {
+          if (bit->isUnsignedInteger())
+            signedType = false;
+          if (bit->isSignedInteger())
+            signedType = true;
+        }
+
+        if (prevTy.getWidth() < postTy.getWidth()) {
+          if (signedType) {
+            tostore = builder.create<arith::ExtSIOp>(loc, postTy, tostore);
+          } else {
+            tostore = builder.create<arith::ExtUIOp>(loc, postTy, tostore);
+          }
+        } else if (prevTy.getWidth() > postTy.getWidth()) {
+          tostore = builder.create<arith::TruncIOp>(loc, postTy, tostore);
+        }
+      }
+    }
+  }
+  lhs.store(builder, tostore);
+  return rhs;
+}

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1993,40 +1993,6 @@ ValueCategory MLIRScanner::VisitBinaryOperator(clang::BinaryOperator *BO) {
                            /*isReference*/ false);
     }
   }
-  case clang::BinaryOperator::Opcode::BO_Assign: {
-    assert(lhs.isReference);
-    mlir::Value tostore = rhs.getValue(builder);
-    mlir::Type subType;
-    if (auto PT = lhs.val.getType().dyn_cast<mlir::LLVM::LLVMPointerType>())
-      subType = PT.getElementType();
-    else
-      subType = lhs.val.getType().cast<MemRefType>().getElementType();
-    if (tostore.getType() != subType) {
-      if (auto prevTy = tostore.getType().dyn_cast<mlir::IntegerType>()) {
-        if (auto postTy = subType.dyn_cast<mlir::IntegerType>()) {
-          bool signedType = true;
-          if (auto bit = dyn_cast<clang::BuiltinType>(&*BO->getType())) {
-            if (bit->isUnsignedInteger())
-              signedType = false;
-            if (bit->isSignedInteger())
-              signedType = true;
-          }
-
-          if (prevTy.getWidth() < postTy.getWidth()) {
-            if (signedType) {
-              tostore = builder.create<arith::ExtSIOp>(loc, postTy, tostore);
-            } else {
-              tostore = builder.create<arith::ExtUIOp>(loc, postTy, tostore);
-            }
-          } else if (prevTy.getWidth() > postTy.getWidth()) {
-            tostore = builder.create<arith::TruncIOp>(loc, postTy, tostore);
-          }
-        }
-      }
-    }
-    lhs.store(builder, tostore);
-    return lhs;
-  }
 
   case clang::BinaryOperator::Opcode::BO_Comma: {
     return rhs;

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -517,6 +517,7 @@ public:
   VisitUnaryExprOrTypeTraitExpr(clang::UnaryExprOrTypeTraitExpr *Uop);
 
   ValueCategory VisitBinaryOperator(clang::BinaryOperator *BO);
+  ValueCategory VisitBinAssign(clang::BinaryOperator *BO);
 
   ValueCategory VisitCXXNoexceptExpr(clang::CXXNoexceptExpr *AS);
 

--- a/polygeist/tools/cgeist/Test/Verification/assign.c
+++ b/polygeist/tools/cgeist/Test/Verification/assign.c
@@ -1,0 +1,56 @@
+// RUN: cgeist %s --function=* -S -o - | FileCheck %s
+
+// CHECK-LABEL: func.func @f0(%arg0: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
+// CHECK-NEXT:    affine.store %c0_i32, %arg0[0] : memref<?xi32>
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+
+void f0(int *x) {
+  int i = 0;
+  x[i++] = i;
+}
+
+// CHECK-LABEL: func.func @f1(%arg0: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
+// CHECK-NEXT:    affine.store %c0_i32, %arg0[1] : memref<?xi32>
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+
+void f1(int *x) {
+  int i = 0;
+  x[++i] = i;
+}
+
+// CHECK-LABEL: func.func @f2(%arg0: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:    %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:    affine.store %c1_i32, %arg0[1] : memref<?xi32>
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+
+void f2(int *x) {
+  int i = 0;
+  x[i] = ++i;
+}
+
+// CHECK-LABEL: func.func @f3(%arg0: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
+// CHECK-NEXT:    affine.store %c0_i32, %arg0[1] : memref<?xi32>
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+
+void f3(int *x) {
+  int i = 0;
+  x[i] = i++;
+}
+
+// CHECK-LABEL: func.func @f4(%arg0: memref<?xi32>, %arg1: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:    %c1_i32 = arith.constant 1 : i32
+// CHECK-NEXT:    affine.store %c1_i32, %arg0[0] : memref<?xi32>
+// CHECK-NEXT:    affine.store %c1_i32, %arg1[0] : memref<?xi32>
+// CHECK-NEXT:    return %c1_i32 : i32
+// CHECK-NEXT:  }
+
+int f4(int *x, int *y) {
+  return *y = *x = 1;
+}

--- a/polygeist/tools/cgeist/Test/Verification/loop.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/loop.cpp
@@ -24,11 +24,11 @@ void div_(int* sizes) {
 // CHECK-NEXT:     %3 = llvm.getelementptr %0[0, 0] : (!llvm.ptr<array<25 x struct<(i32, f64)>>>) -> !llvm.ptr<struct<(i32, f64)>>
 // CHECK-NEXT:     %4 = arith.index_cast %2 : i32 to index
 // CHECK-NEXT:     scf.for %arg1 = %c0 to %4 step %c1 {
-// CHECK-NEXT:       %5 = arith.index_cast %arg1 : index to i64
-// CHECK-NEXT:       %6 = llvm.getelementptr %3[%5] : (!llvm.ptr<struct<(i32, f64)>>, i64) -> !llvm.ptr<struct<(i32, f64)>>
-// CHECK-NEXT:       %7 = llvm.getelementptr %6[0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:       %8 = memref.load %arg0[%arg1] : memref<?xi32>
-// CHECK-NEXT:       llvm.store %8, %7 : !llvm.ptr<i32>
+// CHECK-NEXT:       %5 = memref.load %arg0[%arg1] : memref<?xi32>
+// CHECK-NEXT:       %6 = arith.index_cast %arg1 : index to i64
+// CHECK-NEXT:       %7 = llvm.getelementptr %3[%6] : (!llvm.ptr<struct<(i32, f64)>>, i64) -> !llvm.ptr<struct<(i32, f64)>>
+// CHECK-NEXT:       %8 = llvm.getelementptr %7[0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:       llvm.store %5, %8 : !llvm.ptr<i32>
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }

--- a/polygeist/tools/cgeist/Test/Verification/omp2.c
+++ b/polygeist/tools/cgeist/Test/Verification/omp2.c
@@ -33,10 +33,10 @@ void square2(double** x, int sstart, int send, int sinc, int tstart, int tend, i
 // CHECK-NEXT:     scf.parallel (%arg7, %arg8) = (%0, %1) to (%8, %15) step (%16, %17) {
 // CHECK-NEXT:       %18 = arith.index_cast %arg7 : index to i64
 // CHECK-NEXT:       %19 = arith.index_cast %arg8 : index to i64
-// CHECK-NEXT:       %20 = memref.load %arg0[%arg7] : memref<?xmemref<?xf64>>
-// CHECK-NEXT:       %21 = arith.addi %18, %19 : i64
-// CHECK-NEXT:       %22 = arith.sitofp %21 : i64 to f64
-// CHECK-NEXT:       memref.store %22, %20[%arg8] : memref<?xf64>
+// CHECK-NEXT:       %20 = arith.addi %18, %19 : i64
+// CHECK-NEXT:       %21 = arith.sitofp %20 : i64 to f64
+// CHECK-NEXT:       %22 = memref.load %arg0[%arg7] : memref<?xmemref<?xf64>>
+// CHECK-NEXT:       memref.store %21, %22[%arg8] : memref<?xf64>
 // CHECK-NEXT:       scf.yield
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return

--- a/polygeist/tools/cgeist/Test/Verification/omp3.c
+++ b/polygeist/tools/cgeist/Test/Verification/omp3.c
@@ -20,9 +20,9 @@ void square(double* x) {
 // CHECK-NEXT:       %1 = arith.sitofp %0 : i32 to f64
 // CHECK-NEXT:       memref.store %1, %arg0[%arg1] : memref<?xf64>
 // CHECK-NEXT:       %2 = arith.addi %0, %c1_i32 : i32
-// CHECK-NEXT:       %3 = arith.index_cast %2 : i32 to index
-// CHECK-NEXT:       %4 = arith.sitofp %2 : i32 to f64
-// CHECK-NEXT:       memref.store %4, %arg0[%3] : memref<?xf64>
+// CHECK-NEXT:       %3 = arith.sitofp %2 : i32 to f64
+// CHECK-NEXT:       %4 = arith.index_cast %2 : i32 to index
+// CHECK-NEXT:       memref.store %3, %arg0[%4] : memref<?xf64>
 // CHECK-NEXT:       scf.yield
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return

--- a/polygeist/tools/cgeist/Test/Verification/omp4.c
+++ b/polygeist/tools/cgeist/Test/Verification/omp4.c
@@ -30,8 +30,8 @@ void square(double* x, int ss) {
 // CHECK-NEXT:       %[[a7:.+]] = arith.sitofp %[[a6]] : i32 to f64
 // CHECK-NEXT:       memref.store %[[a7]], %arg0[%arg2] : memref<?xf64>
 // CHECK-NEXT:       %[[a8:.+]] = arith.addi %[[a6]], %c1_i32 : i32
-// CHECK-NEXT:       %[[a9:.+]] = arith.index_cast %[[a8]] : i32 to index
-// CHECK-NEXT:       %[[a10:.+]] = arith.sitofp %[[a8]] : i32 to f64
-// CHECK-NEXT:       memref.store %[[a10:.+]], %arg0[%[[a9]]] : memref<?xf64>
+// CHECK-NEXT:       %[[a9:.+]] = arith.sitofp %[[a8]] : i32 to f64
+// CHECK-NEXT:       %[[a10:.+]] = arith.index_cast %[[a8]] : i32 to index
+// CHECK-NEXT:       memref.store %[[a9]], %arg0[%[[a10]]] : memref<?xf64>
 // CHECK-NEXT:       scf.yield
 // CHECK-NEXT:     }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
@@ -25,7 +25,7 @@
 // CHECK-MLIR-DAG:  [[V1:%.*]] = affine.load {{.*}}[0] : memref<?xf32, 4>
 // CHECK-MLIR-DAG:  [[V2:%.*]] = affine.load {{.*}}[0] : memref<?xf32, 4>
 // CHECK-MLIR-NEXT: [[RESULT:%.*]] = arith.addf [[V1]], [[V2]] : f32
-// CHECK-MLIR-NEXT: affine.store [[RESULT]], {{.*}}[0] : memref<?xf32, 4>
+// CHECK-MLIR:      affine.store [[RESULT]], {{.*}}[0] : memref<?xf32, 4>
 
 // CHECK-LLVM:       define internal spir_func void [[FUNC:@.*vec_add_device_simple.*_]]({{.*}}) #0
 // CHECK-LLVM-DAG:   [[V1:%.*]] = load float, float addrspace(4)* {{.*}}, align 4


### PR DESCRIPTION
Evaluate the RHS before the LHS and return the RHS instead of the LHS.

Previous evaluation order differed from clang's and did not follow the C++ standard (https://timsong-cpp.github.io/cppwp/expr.ass).

Signed-off-by: Victor Perez <victor.perez@codeplay.com>