### PR TITLE
[SYCL] Remove incorrect property traits for image_accessor

### DIFF
--- a/sycl/include/sycl/properties/accessor_properties.hpp
+++ b/sycl/include/sycl/properties/accessor_properties.hpp
@@ -118,9 +118,6 @@ template <typename DataT, int Dimensions, access::mode AccessMode,
           access::target AccessTarget, access::placeholder IsPlaceholder,
           typename PropertyListT>
 class accessor;
-template <typename DataT, int Dimensions, access::mode AccessMode,
-          access::target AccessTarget, access::placeholder IsPlaceholder>
-class image_accessor;
 template <typename DataT, int Dimensions, access::mode AccessMode>
 class host_accessor;
 
@@ -167,19 +164,6 @@ struct is_property_of<ext::intel::property::buffer_location,
                       accessor<DataT, Dimensions, AccessMode, AccessTarget,
                                IsPlaceholder, PropertyListT>> : std::true_type {
 };
-
-template <typename DataT, int Dimensions, access::mode AccessMode,
-          access::target AccessTarget, access::placeholder IsPlaceholder>
-struct is_property_of<
-    property::noinit,
-    image_accessor<DataT, Dimensions, AccessMode, AccessTarget, IsPlaceholder>>
-    : std::true_type {};
-template <typename DataT, int Dimensions, access::mode AccessMode,
-          access::target AccessTarget, access::placeholder IsPlaceholder>
-struct is_property_of<
-    property::no_init,
-    image_accessor<DataT, Dimensions, AccessMode, AccessTarget, IsPlaceholder>>
-    : std::true_type {};
 
 template <typename DataT, int Dimensions, access::mode AccessMode>
 struct is_property_of<property::noinit,

--- a/sycl/test/basic_tests/property_traits.cpp
+++ b/sycl/test/basic_tests/property_traits.cpp
@@ -107,12 +107,6 @@ int main() {
       accessor<sycl::half, 2, access_mode::write, target::host_buffer,
                access::placeholder::false_t>);
 
-  // Image-accessor is_property_of
-  CHECK_IS_PROPERTY_OF(
-      property::no_init,
-      image_accessor<unsigned long, 2, access_mode::read, target::host_buffer,
-                     access::placeholder::true_t>);
-
   // Host-accessor is_property_of
   CHECK_IS_PROPERTY_OF(property::no_init,
                        host_accessor<unsigned long, 2, access_mode::read>);

--- a/sycl/test/basic_tests/property_traits.cpp
+++ b/sycl/test/basic_tests/property_traits.cpp
@@ -171,10 +171,6 @@ int main() {
 
   // Invalid properties with valid object type
   CHECK_IS_NOT_PROPERTY_OF(NotAProperty, accessor<int, 1>);
-  CHECK_IS_NOT_PROPERTY_OF(
-      NotAProperty,
-      image_accessor<float, 2, access_mode::read, target::host_buffer,
-                     access::placeholder::true_t>);
   CHECK_IS_NOT_PROPERTY_OF(NotAProperty, host_accessor<char, 2>);
   CHECK_IS_NOT_PROPERTY_OF(NotAProperty, buffer<int, 2>);
   CHECK_IS_NOT_PROPERTY_OF(NotAProperty, context);
@@ -243,12 +239,6 @@ int main() {
       accessor<sycl::half, 2, access_mode::write, target::host_buffer,
                access::placeholder::false_t>);
 
-  // Image-accessor is_property_of_v
-  CHECK_IS_PROPERTY_OF_V(
-      property::no_init,
-      image_accessor<unsigned long, 2, access_mode::read, target::host_buffer,
-                     access::placeholder::true_t>);
-
   // Host-accessor is_property_of_v
   CHECK_IS_PROPERTY_OF_V(property::no_init,
                          host_accessor<unsigned long, 2, access_mode::read>);
@@ -316,10 +306,6 @@ int main() {
 
   // Invalid properties with valid object type
   CHECK_IS_NOT_PROPERTY_OF_V(NotAProperty, accessor<int, 1>);
-  CHECK_IS_NOT_PROPERTY_OF_V(
-      NotAProperty,
-      image_accessor<float, 2, access_mode::read, target::host_buffer,
-                     access::placeholder::true_t>);
   CHECK_IS_NOT_PROPERTY_OF_V(NotAProperty, host_accessor<char, 2>);
   CHECK_IS_NOT_PROPERTY_OF_V(NotAProperty, buffer<int, 2>);
   CHECK_IS_NOT_PROPERTY_OF_V(NotAProperty, context);


### PR DESCRIPTION
That class is sycl::detail::image_accessor, not visible in public SYCL APIs yet we confused it thinking it's sycl::image_accessor.

In reality it's used in the implementation of sycl::accessor specialization for access::target::image so the properties are covered by property traits for sycl::accessor.