### PR TITLE
[NFC][Reduction] Remove C++17 guards

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1756,10 +1756,6 @@ public:
         KernelFunc);
   }
 
-// "if constexpr" simplifies implementation/increases readability in comparison
-// with SFINAE-based approach.
-#if __cplusplus >= 201703L
-
   /// Defines and invokes a SYCL kernel function for the specified nd_range.
   ///
   /// The SYCL kernel function is defined as a lambda function or a named
@@ -1982,7 +1978,6 @@ public:
       });
     } // end while (NWorkItems > 1)
   }
-#endif // __cplusplus >= 201703L
 
   /// Hierarchical kernel invocation method of a kernel defined as a lambda
   /// encoding the body of each work-group to launch.

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -49,16 +49,6 @@ template <typename T> struct AreAllButLastReductions<T> {
   static constexpr bool value = !IsReduction<T>::value;
 };
 } // namespace detail
-} // __SYCL_INLINE_VER_NAMESPACE(_V1)
-} // namespace sycl
-
-#if __cplusplus >= 201703L
-// Entire feature is dependent on C++17. We still have to make the trait above
-// available as queue shortcuts use them unconditionally, including on
-// non-reduction path.
-namespace sycl {
-__SYCL_INLINE_VER_NAMESPACE(_V1) {
-
 
 /// Class that is used to represent objects that are passed to user's lambda
 /// functions and representing users' reduction variable.
@@ -2477,7 +2467,6 @@ auto reduction(T *Var, const T &Identity, BinaryOperation Combiner,
                                                        InitializeToIdentity);
 }
 
-#if __cplusplus >= 201703L
 /// Constructs a reduction object using the reduction variable referenced by
 /// the given sycl::span \p Span, reduction operation \p Combiner, and
 /// optional reduction properties.
@@ -2524,9 +2513,5 @@ auto reduction(span<T, Extent> Span, const T &Identity,
   return detail::make_reduction<BinaryOperation, 1, Extent>(
       Span.data(), Identity, Combiner, InitializeToIdentity);
 }
-#endif
-
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl
-
-#endif // __cplusplus >= 201703L


### PR DESCRIPTION
We only support C++17 and above through the whole SYCL RT.