### PR TITLE
[SYCL] Make SYCL 2020 style FPGA selectors inline

### DIFF
--- a/sycl/include/sycl/ext/intel/fpga_device_selector.hpp
+++ b/sycl/include/sycl/ext/intel/fpga_device_selector.hpp
@@ -61,15 +61,15 @@ static constexpr auto EMULATION_PLATFORM_NAME =
 static constexpr auto HARDWARE_PLATFORM_NAME =
     "Intel(R) FPGA SDK for OpenCL(TM)";
 
-int fpga_selector_v(const device &device) {
+inline int fpga_selector_v(const device &device) {
   return detail::selectDeviceByPlatform(HARDWARE_PLATFORM_NAME, device);
 }
 
-int fpga_emulator_selector_v(const device &device) {
+inline int fpga_emulator_selector_v(const device &device) {
   return detail::selectDeviceByPlatform(EMULATION_PLATFORM_NAME, device);
 }
 
-int fpga_simulator_selector_v(const device &device) {
+inline int fpga_simulator_selector_v(const device &device) {
   static bool IsFirstCall = true;
   if (IsFirstCall) {
     detail::enableFPGASimulator();


### PR DESCRIPTION
The SYCL 2020 style FPGA selectors (`fpga_selector_v`, `fpga_emulator_selector_v`, and `fpga_simulator_selector_v`) were not previously marked inline which may cause failures in the linker due to multiple definitions. This commit makes them inline.