### PR TITLE
[SYCL] Specify kernels in kernel_bundle for MultipleDevsCache

### DIFF
--- a/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
+++ b/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
@@ -137,15 +137,15 @@ TEST_F(MultipleDeviceCacheTest, ProgramRetain) {
     sycl::queue Queue(Context, Devices[0]);
     assert(Devices.size() == 2 && Context.get_devices().size() == 2);
 
-    auto Bundle =
-        sycl::get_kernel_bundle<sycl::bundle_state::input>(Queue.get_context());
+    auto KernelID = sycl::get_kernel_id<TestKernel<>>();
+    auto Bundle = sycl::get_kernel_bundle<sycl::bundle_state::input>(
+        Queue.get_context(), {KernelID});
     assert(Bundle.get_devices().size() == 2);
 
     Queue.submit(
         [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
 
     auto BundleObject = sycl::build(Bundle, Bundle.get_devices());
-    auto KernelID = sycl::get_kernel_id<TestKernel<>>();
     auto Kernel = BundleObject.get_kernel(KernelID);
 
     // Because of emulating 2 devices program is retained for each one in


### PR DESCRIPTION
This commit changes the ProgramRetain test in MultipleDevsCache to be explicit about which kernels should be included in the corresponding kernel bundle. This prevents the kernel bundle from inadvertently building programs that are unrelated to the test.