### PR TITLE
[SYCL][NFC] Move SizeListToStr to utilities

### DIFF
--- a/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
@@ -10,6 +10,7 @@
 
 #include <sycl/aspects.hpp>
 #include <sycl/ext/oneapi/properties/property.hpp>
+#include <sycl/ext/oneapi/properties/property_utils.hpp>
 #include <sycl/ext/oneapi/properties/property_value.hpp>
 
 #include <array>
@@ -27,49 +28,6 @@ template <size_t... Xs> struct AllNonZero {
 template <size_t X, size_t... Xs> struct AllNonZero<X, Xs...> {
   static inline constexpr bool value = X > 0 && AllNonZero<Xs...>::value;
 };
-
-// Simple helpers for containing primitive types as template arguments.
-template <size_t... Sizes> struct SizeList {};
-template <char... Sizes> struct CharList {};
-
-// Helper for converting characters to a constexpr string.
-template <char... Chars> struct CharsToStr {
-  static inline constexpr const char value[] = {Chars..., '\0'};
-};
-
-// Helper for converting a list of size_t values to a comma-separated string
-// representation. This is done by extracting the digit one-by-one and when
-// finishing a value, the parsed result is added to a separate list of
-// "parsed" characters with the delimiter.
-template <typename List, typename ParsedList, char... Chars>
-struct SizeListToStrHelper;
-template <size_t Value, size_t... Values, char... ParsedChars, char... Chars>
-struct SizeListToStrHelper<SizeList<Value, Values...>, CharList<ParsedChars...>,
-                           Chars...>
-    : SizeListToStrHelper<SizeList<Value / 10, Values...>,
-                          CharList<ParsedChars...>, '0' + (Value % 10),
-                          Chars...> {};
-template <size_t... Values, char... ParsedChars, char... Chars>
-struct SizeListToStrHelper<SizeList<0, Values...>, CharList<ParsedChars...>,
-                           Chars...>
-    : SizeListToStrHelper<SizeList<Values...>,
-                          CharList<ParsedChars..., Chars..., ','>> {};
-template <size_t... Values, char... ParsedChars>
-struct SizeListToStrHelper<SizeList<0, Values...>, CharList<ParsedChars...>>
-    : SizeListToStrHelper<SizeList<Values...>,
-                          CharList<ParsedChars..., '0', ','>> {};
-template <char... ParsedChars, char... Chars>
-struct SizeListToStrHelper<SizeList<0>, CharList<ParsedChars...>, Chars...>
-    : CharsToStr<ParsedChars..., Chars...> {};
-template <char... ParsedChars>
-struct SizeListToStrHelper<SizeList<0>, CharList<ParsedChars...>>
-    : CharsToStr<ParsedChars..., '0'> {};
-template <>
-struct SizeListToStrHelper<SizeList<>, CharList<>> : CharsToStr<> {};
-
-// Converts size_t values to a comma-separated string representation.
-template <size_t... Sizes>
-struct SizeListToStr : SizeListToStrHelper<SizeList<Sizes...>, CharList<>> {};
 } // namespace detail
 
 struct properties_tag {};

--- a/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
@@ -272,6 +272,113 @@ struct MergeProperties<std::tuple<LHSPropertyTs...>,
   using type = typename PrependTuple<min, merge_tails>::type;
 };
 
+//******************************************************************************
+// Property value tooling
+//******************************************************************************
+
+// Simple helpers for containing primitive types as template arguments.
+template <size_t... Sizes> struct SizeList {};
+template <char... Sizes> struct CharList {};
+
+// Helper for converting characters to a constexpr string.
+template <char... Chars> struct CharsToStr {
+  static inline constexpr const char value[] = {Chars..., '\0'};
+};
+
+// Helper for converting a list of size_t values to a comma-separated string
+// representation. This is done by extracting the digit one-by-one and when
+// finishing a value, the parsed result is added to a separate list of
+// "parsed" characters with the delimiter.
+template <typename List, typename ParsedList, char... Chars>
+struct SizeListToStrHelper;
+
+// Specialization for when we are in the process of converting a non-zero value
+// (Value). Chars will have the already converted digits of the original value
+// being converted. Instantiation of this will convert the least significant
+// digit in Value.
+// Example:
+//  - Current: SizeListToStrHelper<SizeList<12>, CharList<'1', '0', ','>, '3'>
+//  - Next: SizeListToStrHelper<SizeList<1>, CharList<'1', '0', ','>, '2', '3'>
+//  - Outermost: SizeListToStrHelper<SizeList<10,123>, CharList<>>
+//  - Final: SizeListToStrHelper<SizeList<0>,
+//                               CharList<'1', '0', ','>, '1', '2', '3'>>
+//  - Result string: "10,123"
+template <size_t Value, size_t... Values, char... ParsedChars, char... Chars>
+struct SizeListToStrHelper<SizeList<Value, Values...>, CharList<ParsedChars...>,
+                           Chars...>
+    : SizeListToStrHelper<SizeList<Value / 10, Values...>,
+                          CharList<ParsedChars...>, '0' + (Value % 10),
+                          Chars...> {};
+
+// Specialization for when we have reached 0 in the current value we are
+// converting. In this case we are done with converting the current value and
+// we insert the converted digits from Chars into ParsedChars.
+// Example:
+//  - Current: SizeListToStrHelper<SizeList<0,123>, CharList<>, '1', '0'>
+//  - Next: SizeListToStrHelper<SizeList<123>, CharList<'1', '0', ','>>
+//  - Outermost: SizeListToStrHelper<SizeList<10,123>, CharList<>>
+//  - Final: SizeListToStrHelper<SizeList<0>,
+//                               CharList<'1', '0', ','>, '1', '2', '3'>>
+//  - Result string: "10,123"
+template <size_t... Values, char... ParsedChars, char... Chars>
+struct SizeListToStrHelper<SizeList<0, Values...>, CharList<ParsedChars...>,
+                           Chars...>
+    : SizeListToStrHelper<SizeList<Values...>,
+                          CharList<ParsedChars..., Chars..., ','>> {};
+
+// Specialization for the special case where the value we are converting is 0
+// but the list of converted digits is empty. This means there was a 0 value in
+// the list and we can add it to ParsedChars directly.
+// Example:
+//  - Current: SizeListToStrHelper<SizeList<0,123>, CharList<>>
+//  - Next: SizeListToStrHelper<SizeList<123>, CharList<'0', ','>>
+//  - Outermost: SizeListToStrHelper<SizeList<0,123>, CharList<>>
+//  - Final: SizeListToStrHelper<SizeList<0>,
+//                               CharList<'0', ','>, '1', '2', '3'>>
+//  - Result string: "0,123"
+template <size_t... Values, char... ParsedChars>
+struct SizeListToStrHelper<SizeList<0, Values...>, CharList<ParsedChars...>>
+    : SizeListToStrHelper<SizeList<Values...>,
+                          CharList<ParsedChars..., '0', ','>> {};
+
+// Specialization for when we have reached 0 in the current value we are
+// converting and there a no more values to parse. In this case we are done with
+// converting the current value and we insert the converted digits from Chars
+// into ParsedChars. We do not add a ',' as it is the end of the list.
+// Example:
+//  - Current: SizeListToStrHelper<SizeList<0>, CharList<'1', '0', ','>, '1', '2', '3'>>
+//  - Next: None.
+//  - Outermost: SizeListToStrHelper<SizeList<10,123>, CharList<>>
+//  - Final: SizeListToStrHelper<SizeList<0>,
+//                               CharList<'1', '0', ','>, '1', '2', '3'>>
+//  - Result string: "10,123"
+template <char... ParsedChars, char... Chars>
+struct SizeListToStrHelper<SizeList<0>, CharList<ParsedChars...>, Chars...>
+    : CharsToStr<ParsedChars..., Chars...> {};
+
+// Specialization for when we have reached 0 in the current value we are
+// converting and there a no more values to parse, but the list of converted
+// digits is empty. This means the last value in the list was a 0 so we can add
+// that to the ParsedChars and finish.
+// Example:
+//  - Current: SizeListToStrHelper<SizeList<0>, CharList<'1', '0', ','>>>
+//  - Next: None.
+//  - Outermost: SizeListToStrHelper<SizeList<10,0>, CharList<>>
+//  - Final: SizeListToStrHelper<SizeList<0>, CharList<>, '1', '0'>>
+//  - Result string: "10,0"
+template <char... ParsedChars>
+struct SizeListToStrHelper<SizeList<0>, CharList<ParsedChars...>>
+    : CharsToStr<ParsedChars..., '0'> {};
+
+// Specialization for the empty list of values to convert. This results in an
+// empty string.
+template <>
+struct SizeListToStrHelper<SizeList<>, CharList<>> : CharsToStr<> {};
+
+// Converts size_t values to a comma-separated string representation.
+template <size_t... Sizes>
+struct SizeListToStr : SizeListToStrHelper<SizeList<Sizes...>, CharList<>> {};
+
 } // namespace detail
 } // namespace experimental
 } // namespace oneapi

--- a/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
@@ -346,7 +346,8 @@ struct SizeListToStrHelper<SizeList<0, Values...>, CharList<ParsedChars...>>
 // converting the current value and we insert the converted digits from Chars
 // into ParsedChars. We do not add a ',' as it is the end of the list.
 // Example:
-//  - Current: SizeListToStrHelper<SizeList<0>, CharList<'1', '0', ','>, '1', '2', '3'>>
+//  - Current: SizeListToStrHelper<SizeList<0>, CharList<'1', '0', ','>, '1',
+//  '2', '3'>>
 //  - Next: None.
 //  - Outermost: SizeListToStrHelper<SizeList<10,123>, CharList<>>
 //  - Final: SizeListToStrHelper<SizeList<0>,

--- a/sycl/unittests/misc/CMakeLists.txt
+++ b/sycl/unittests/misc/CMakeLists.txt
@@ -3,4 +3,5 @@ add_definitions(-DSYCL_LIB_DIR="${sycl_lib_dir}")
 add_sycl_unittest(MiscTests SHARED
   CircularBuffer.cpp
   OsUtils.cpp
+  PropertyUtils.cpp
 )

--- a/sycl/unittests/misc/PropertyUtils.cpp
+++ b/sycl/unittests/misc/PropertyUtils.cpp
@@ -1,0 +1,38 @@
+//==---- PropertyUtils.cpp -------------------------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+
+#include <string_view>
+
+#include <sycl/ext/oneapi/properties/property_utils.hpp>
+
+using namespace sycl::ext::oneapi::experimental::detail;
+
+void checkEquality(std::string_view LHS, std::string_view RHS) {
+  ASSERT_EQ(LHS, RHS);
+}
+
+TEST(PropertyUtilsTest, SizeListToStrTest) {
+  checkEquality(SizeListToStr<>::value, "");
+  checkEquality(SizeListToStr<0>::value, "0");
+  checkEquality(SizeListToStr<1>::value, "1");
+  checkEquality(SizeListToStr<42>::value, "42");
+  checkEquality(SizeListToStr<123>::value, "123");
+  checkEquality(SizeListToStr<4321>::value, "4321");
+  checkEquality(SizeListToStr<0, 1>::value, "0,1");
+  checkEquality(SizeListToStr<1, 0>::value, "1,0");
+  checkEquality(SizeListToStr<42, 43>::value, "42,43");
+  checkEquality(SizeListToStr<0, 1, 42>::value, "0,1,42");
+  checkEquality(SizeListToStr<1, 0, 42>::value, "1,0,42");
+  checkEquality(SizeListToStr<1, 42, 0>::value, "1,42,0");
+  checkEquality(SizeListToStr<0, 1, 42, 4321>::value, "0,1,42,4321");
+  checkEquality(SizeListToStr<1, 0, 42, 4321>::value, "1,0,42,4321");
+  checkEquality(SizeListToStr<1, 42, 0, 4321>::value, "1,42,0,4321");
+  checkEquality(SizeListToStr<1, 42, 4321, 0>::value, "1,42,4321,0");
+}


### PR DESCRIPTION
This commit moves the utility from the kernel properties headers to the common property utiliites headers. This will allow for use in other properties that seek to use multiple integral values in their compile-time values.