### PR TITLE
[SYCL] Fix accessor::swap() method

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -1945,7 +1945,12 @@ public:
 #endif
   }
 
-  void swap(accessor &other) { std::swap(impl, other.impl); }
+  void swap(accessor &other) {
+    std::swap(impl, other.impl);
+#ifndef __SYCL_DEVICE_ONLY__
+    std::swap(MAccData, other.MAccData);
+#endif
+  }
 
   constexpr bool is_placeholder() const { return IsPlaceH; }
 


### PR DESCRIPTION
Need to swap new member MAccData (added in 01e60f76b3484913fad27d8b0e5fe627d9151689) in addition to Impl.