### PR TITLE
[SYCL-MLIR]: Introduce AttributeList and enhance AttrBuilder.

### DIFF
--- a/polygeist/tools/cgeist/Lib/Attributes.cc
+++ b/polygeist/tools/cgeist/Lib/Attributes.cc
@@ -292,8 +292,10 @@ AttrBuilder::addAttributeImpl(llvm::Attribute::AttrKind Kind, uint64_t Val,
 
   switch (Kind) {
   case llvm::Attribute::AttrKind::Alignment:
-  case llvm::Attribute::AttrKind::StackAlignment:
     assert(Val <= llvm::Value::MaximumAlignment && "Alignment too large");
+    LLVM_FALLTHROUGH;
+  case llvm::Attribute::AttrKind::StackAlignment:
+    assert(Val <= 0x100 && "Alignment too large.");
     LLVM_FALLTHROUGH;
   case llvm::Attribute::AttrKind::Dereferenceable:
   case llvm::Attribute::AttrKind::DereferenceableOrNull:

--- a/polygeist/tools/cgeist/Lib/Attributes.cc
+++ b/polygeist/tools/cgeist/Lib/Attributes.cc
@@ -126,15 +126,12 @@ AttrBuilder &AttrBuilder::addAttribute(llvm::Attribute::AttrKind Kind,
 
   switch (Kind) {
   case llvm::Attribute::AttrKind::Alignment:
-    LLVM_FALLTHROUGH;
   case llvm::Attribute::AttrKind::StackAlignment:
     assert(Val <= llvm::Value::MaximumAlignment && "Alignment too large");
     return (!Val) ? *this : Invoke(AddRawIntAttrPtr, Kind, Val);
 
   case llvm::Attribute::AttrKind::Dereferenceable:
-    LLVM_FALLTHROUGH;
   case llvm::Attribute::AttrKind::DereferenceableOrNull:
-    LLVM_FALLTHROUGH;
   case llvm::Attribute::AttrKind::UWTable:
     return (!Val) ? *this : Invoke(AddRawIntAttrPtr, Kind, Val);
 

--- a/polygeist/tools/cgeist/Lib/Attributes.cc
+++ b/polygeist/tools/cgeist/Lib/Attributes.cc
@@ -24,171 +24,11 @@ namespace mlirclang {
 static constexpr StringLiteral PassThroughAttrName = "passthrough";
 
 //===----------------------------------------------------------------------===//
-// AttributeList Method Implementations
+// Helper functions.
 //===----------------------------------------------------------------------===//
 
-AttributeList &
-AttributeList::addAttrs(const AttrBuilder &FnAttrB, const AttrBuilder &RetAttrB,
-                        llvm::ArrayRef<mlir::NamedAttrList> Attrs) {
-  return addFnAttrs(FnAttrB).addRetAttrs(RetAttrB).addParmAttrs(Attrs);
-}
-
-AttributeList &AttributeList::addFnAttrs(const AttrBuilder &B) {
-  for (const NamedAttribute &NewNamedAttr : B.getAttrs()) {
-    Optional<NamedAttribute> ExistingAttr =
-        FnAttrs.getNamed(NewNamedAttr.getName());
-    if (!ExistingAttr) {
-      FnAttrs.append(NewNamedAttr);
-      continue;
-    }
-
-    // Merge the 'passthrough' attribute lists.
-    if (ExistingAttr->getName() == PassThroughAttrName) {
-      auto Attrs = NewNamedAttr.getValue().cast<ArrayAttr>();
-      AttrBuilder::addToPassThroughAttr(*ExistingAttr, Attrs, B.getContext());
-      FnAttrs.set(ExistingAttr->getName(), ExistingAttr->getValue());
-    }
-  }
-
-  return *this;
-}
-
-AttributeList &AttributeList::addRetAttrs(const AttrBuilder &B) {
-  RetAttrs.append(B.getAttrs());
-  return *this;
-}
-
-AttributeList &
-AttributeList::addParmAttrs(llvm::ArrayRef<mlir::NamedAttrList> Attrs) {
-  ParmAttrs.reserve(Attrs.size());
-  llvm::append_range(ParmAttrs, Attrs);
-  return *this;
-}
-
-mlir::NamedAttrList AttributeList::getParmAttrs(unsigned Index) const {
-  assert(Index < ParmAttrs.size() && "Index out of range");
-  return ParmAttrs[Index];
-}
-
-//===----------------------------------------------------------------------===//
-// AttrBuilder Method Implementations
-//===----------------------------------------------------------------------===//
-
-AttrBuilder &AttrBuilder::addAttribute(llvm::Attribute::AttrKind Kind,
-                                       Optional<StringLiteral> Dialect,
-                                       AddAttrFuncPtr AddAttrPtr) {
-  assert(AddAttrPtr && "'AddAttrPtr' should be a valid function pointer");
-
-  // TODO: Replace with std::invoke once C++17 headers are available.
-  auto Invoke = [this](AddAttrFuncPtr AddAttrPtr,
-                       auto... Args) -> AttrBuilder & {
-    return (this->*AddAttrPtr)(Args...);
-  };
-
-  OpBuilder Builder(&Ctx);
-  StringRef AttrName = llvm::Attribute::getNameFromAttrKind(Kind);
-  NamedAttribute NamedAttr = createNamedAttr(
-      createStringAttr(AttrName, Dialect, Ctx), Builder.getUnitAttr());
-  return Invoke(AddAttrPtr, NamedAttr);
-}
-
-AttrBuilder &AttrBuilder::addAttribute(llvm::Attribute::AttrKind Kind,
-                                       mlir::Type Ty,
-                                       Optional<StringLiteral> Dialect,
-                                       AddAttrFuncPtr AddAttrPtr) {
-  assert(AddAttrPtr && "'AddAttrPtr' should be a valid function pointer");
-
-  // TODO: Replace with std::invoke once C++17 headers are available.
-  auto Invoke = [this](AddAttrFuncPtr AddAttrPtr,
-                       auto... Args) -> AttrBuilder & {
-    return (this->*AddAttrPtr)(Args...);
-  };
-
-  OpBuilder Builder(&Ctx);
-  StringRef AttrName = llvm::Attribute::getNameFromAttrKind(Kind);
-  NamedAttribute NamedAttr = createNamedAttr(
-      createStringAttr(AttrName, Dialect, Ctx), mlir::TypeAttr::get(Ty));
-
-  return Invoke(AddAttrPtr, NamedAttr);
-}
-
-AttrBuilder &AttrBuilder::addAttribute(llvm::Attribute::AttrKind Kind,
-                                       uint64_t Val,
-                                       AddRawIntAttrFuncPtr AddRawIntAttrPtr) {
-  assert(AddRawIntAttrPtr &&
-         "'AddRawIntAttrPtr' should be a valid function pointer");
-
-  // TODO: Replace with std::invoke once C++17 headers are available.
-  auto Invoke = [this](AddRawIntAttrFuncPtr AddRawIntAttrPtr,
-                       auto... Args) -> AttrBuilder & {
-    return (this->*AddRawIntAttrPtr)(Args...);
-  };
-
-  switch (Kind) {
-  case llvm::Attribute::AttrKind::Alignment:
-  case llvm::Attribute::AttrKind::StackAlignment:
-    assert(Val <= llvm::Value::MaximumAlignment && "Alignment too large");
-    return (!Val) ? *this : Invoke(AddRawIntAttrPtr, Kind, Val);
-
-  case llvm::Attribute::AttrKind::Dereferenceable:
-  case llvm::Attribute::AttrKind::DereferenceableOrNull:
-  case llvm::Attribute::AttrKind::UWTable:
-    return (!Val) ? *this : Invoke(AddRawIntAttrPtr, Kind, Val);
-
-  default:
-    llvm_unreachable("Unexpected attribute kind");
-  }
-
-  return *this;
-}
-
-AttrBuilder &AttrBuilder::addAttribute(Twine AttrName, mlir::Attribute Attr,
-                                       AddAttrFuncPtr AddAttrPtr) {
-  assert(AddAttrPtr && "'AddAttrPtr' should be a valid function pointer");
-
-  // TODO: Replace with std::invoke once C++17 headers are available.
-  auto Invoke = [this](AddAttrFuncPtr AddAttrPtr,
-                       auto... Args) -> AttrBuilder & {
-    return (this->*AddAttrPtr)(Args...);
-  };
-
-  NamedAttribute NamedAttr =
-      createNamedAttr(createStringAttr(AttrName, Ctx), Attr);
-  return Invoke(AddAttrPtr, NamedAttr);
-}
-
-AttrBuilder &
-AttrBuilder::addPassThroughAttribute(llvm::Attribute::AttrKind Kind) {
-  return addAttribute(Kind, llvm::None, &AttrBuilder::addPassThroughAttribute);
-}
-
-AttrBuilder &
-AttrBuilder::addPassThroughAttribute(llvm::Attribute::AttrKind Kind,
-                                     mlir::Type Ty) {
-  return addAttribute(Kind, Ty, llvm::None,
-                      &AttrBuilder::addPassThroughAttribute);
-}
-
-AttrBuilder &
-AttrBuilder::addPassThroughAttribute(llvm::Attribute::AttrKind Kind,
-                                     uint64_t Val) {
-  return addAttribute(Kind, Val, &AttrBuilder::addPassThroughRawIntAttr);
-}
-
-AttrBuilder &AttrBuilder::addPassThroughAttribute(StringRef AttrName,
-                                                  mlir::Attribute Attr) {
-  return addAttribute(AttrName, Attr, &AttrBuilder::addPassThroughAttribute);
-}
-
-AttrBuilder &AttrBuilder::addPassThroughAttribute(mlir::NamedAttribute Attr) {
-  NamedAttribute PassThroughAttr = getOrCreatePassThroughAttr();
-  addToPassThroughAttr(PassThroughAttr, Attr, Ctx);
-  return addAttribute(PassThroughAttr);
-}
-
-void AttrBuilder::addToPassThroughAttr(NamedAttribute &PassThroughAttr,
-                                       mlir::NamedAttribute Attr,
-                                       MLIRContext &Ctx) {
+static void addToPassThroughAttr(NamedAttribute &PassThroughAttr,
+                                 mlir::NamedAttribute Attr, MLIRContext &Ctx) {
   assert(PassThroughAttr.getName() == PassThroughAttrName &&
          "PassThroughAttr is not valid");
   assert(PassThroughAttr.getValue().isa<ArrayAttr>() &&
@@ -217,9 +57,8 @@ void AttrBuilder::addToPassThroughAttr(NamedAttribute &PassThroughAttr,
   });
 }
 
-void AttrBuilder::addToPassThroughAttr(mlir::NamedAttribute &PassThroughAttr,
-                                       mlir::ArrayAttr NewAttrs,
-                                       MLIRContext &Ctx) {
+static void addToPassThroughAttr(mlir::NamedAttribute &PassThroughAttr,
+                                 mlir::ArrayAttr NewAttrs, MLIRContext &Ctx) {
   assert(PassThroughAttr.getName() == PassThroughAttrName &&
          "PassThroughAttr is not valid");
   assert(PassThroughAttr.getValue().isa<ArrayAttr>() &&
@@ -229,17 +68,117 @@ void AttrBuilder::addToPassThroughAttr(mlir::NamedAttribute &PassThroughAttr,
     if (NewAttr.isa<ArrayAttr>()) {
       auto ArrAttr = NewAttr.cast<ArrayAttr>();
       assert(ArrAttr.size() == 2 && ArrAttr[0].isa<StringAttr>());
-      addToPassThroughAttr(
-          PassThroughAttr,
-          createNamedAttr(ArrAttr[0].cast<StringAttr>(), ArrAttr[1]), Ctx);
-    } else if (NewAttr.isa<StringAttr>())
-      addToPassThroughAttr(
-          PassThroughAttr,
-          createNamedAttr(NewAttr.cast<StringAttr>(), UnitAttr::get(&Ctx)),
-          Ctx);
-    else
+      NamedAttribute NamedAttr(ArrAttr[0].cast<StringAttr>(), ArrAttr[1]);
+      addToPassThroughAttr(PassThroughAttr, NamedAttr, Ctx);
+    } else if (NewAttr.isa<StringAttr>()) {
+      NamedAttribute NamedAttr(NewAttr.cast<StringAttr>(), UnitAttr::get(&Ctx));
+      addToPassThroughAttr(PassThroughAttr, NamedAttr, Ctx);
+    } else
       llvm_unreachable("Unexpected attribute kind");
   }
+}
+
+//===----------------------------------------------------------------------===//
+// AttributeList Method Implementations
+//===----------------------------------------------------------------------===//
+
+AttributeList &
+AttributeList::addAttrs(const AttrBuilder &FnAttrB, const AttrBuilder &RetAttrB,
+                        llvm::ArrayRef<mlir::NamedAttrList> Attrs) {
+  return addFnAttrs(FnAttrB).addRetAttrs(RetAttrB).addParamAttrs(Attrs);
+}
+
+AttributeList &AttributeList::addFnAttrs(const AttrBuilder &B) {
+  for (const NamedAttribute &NewNamedAttr : B.getAttrs()) {
+    Optional<NamedAttribute> ExistingAttr =
+        FnAttrs.getNamed(NewNamedAttr.getName());
+    if (!ExistingAttr) {
+      FnAttrs.append(NewNamedAttr);
+      continue;
+    }
+
+    // Merge the 'passthrough' attribute lists.
+    if (ExistingAttr->getName() == PassThroughAttrName) {
+      auto Attrs = NewNamedAttr.getValue().cast<ArrayAttr>();
+      addToPassThroughAttr(*ExistingAttr, Attrs, B.getContext());
+      FnAttrs.set(ExistingAttr->getName(), ExistingAttr->getValue());
+      continue;
+    }
+
+    llvm_unreachable("Function attribute already exists");
+  }
+
+  return *this;
+}
+
+AttributeList &AttributeList::addRetAttrs(const AttrBuilder &B) {
+  for (const NamedAttribute &NewNamedAttr : B.getAttrs()) {
+    Optional<NamedAttribute> ExistingAttr =
+        RetAttrs.getNamed(NewNamedAttr.getName());
+    if (!ExistingAttr) {
+      RetAttrs.append(NewNamedAttr);
+      continue;
+    }
+    llvm_unreachable("Return value attribute already exits");
+  }
+
+  return *this;
+}
+
+AttributeList &
+AttributeList::addParamAttrs(llvm::ArrayRef<mlir::NamedAttrList> Attrs) {
+  ParamAttrs.reserve(Attrs.size());
+  llvm::append_range(ParamAttrs, Attrs);
+  return *this;
+}
+
+//===----------------------------------------------------------------------===//
+// AttrBuilder Method Implementations
+//===----------------------------------------------------------------------===//
+
+AttrBuilder &AttrBuilder::addAttribute(llvm::Attribute::AttrKind Kind) {
+  return addAttributeImpl(Kind, LLVM::LLVMDialect::getDialectNamespace(),
+                          &AttrBuilder::addAttributeImpl);
+}
+
+AttrBuilder &AttrBuilder::addAttribute(llvm::Attribute::AttrKind Kind,
+                                       mlir::Type Ty) {
+  return addAttributeImpl(Kind, Ty, LLVM::LLVMDialect::getDialectNamespace(),
+                          &AttrBuilder::addAttributeImpl);
+}
+
+AttrBuilder &AttrBuilder::addAttribute(llvm::Attribute::AttrKind Kind,
+                                       uint64_t Val) {
+  return addAttributeImpl(Kind, Val, &AttrBuilder::addRawIntAttr);
+}
+
+AttrBuilder &AttrBuilder::addAttribute(Twine AttrName, mlir::Attribute Attr) {
+  return addAttributeImpl(AttrName, Attr, &AttrBuilder::addAttributeImpl);
+}
+
+AttrBuilder &
+AttrBuilder::addPassThroughAttribute(llvm::Attribute::AttrKind Kind) {
+  return addAttributeImpl(Kind, llvm::None,
+                          &AttrBuilder::addPassThroughAttributeImpl);
+}
+
+AttrBuilder &
+AttrBuilder::addPassThroughAttribute(llvm::Attribute::AttrKind Kind,
+                                     mlir::Type Ty) {
+  return addAttributeImpl(Kind, Ty, llvm::None,
+                          &AttrBuilder::addPassThroughAttributeImpl);
+}
+
+AttrBuilder &
+AttrBuilder::addPassThroughAttribute(llvm::Attribute::AttrKind Kind,
+                                     uint64_t Val) {
+  return addAttributeImpl(Kind, Val, &AttrBuilder::addPassThroughRawIntAttr);
+}
+
+AttrBuilder &AttrBuilder::addPassThroughAttribute(StringRef AttrName,
+                                                  mlir::Attribute Attr) {
+  return addAttributeImpl(AttrName, Attr,
+                          &AttrBuilder::addPassThroughAttributeImpl);
 }
 
 AttrBuilder &AttrBuilder::removeAttribute(llvm::StringRef AttrName) {
@@ -295,41 +234,127 @@ AttrBuilder::getAttr(llvm::Attribute::AttrKind Kind) const {
   return getAttr(AttrName);
 }
 
-NamedAttribute AttrBuilder::createNamedAttr(StringAttr AttrName,
-                                            mlir::Attribute Attr) {
-  NamedAttribute NamedAttr(AttrName, Attr);
-  return NamedAttr;
-}
-
-StringAttr AttrBuilder::createStringAttr(Twine AttrName, MLIRContext &Ctx) {
-  return StringAttr::get(&Ctx, AttrName);
-}
-
 StringAttr AttrBuilder::createStringAttr(Twine AttrName,
                                          Optional<StringLiteral> Prefix,
                                          MLIRContext &Ctx) {
-  return (Prefix) ? createStringAttr(*Prefix + "." + AttrName, Ctx)
-                  : createStringAttr(AttrName, Ctx);
+  return (Prefix) ? StringAttr::get(&Ctx, *Prefix + "." + AttrName)
+                  : StringAttr::get(&Ctx, AttrName);
+}
+
+AttrBuilder &AttrBuilder::addAttributeImpl(llvm::Attribute::AttrKind Kind,
+                                           Optional<StringLiteral> Dialect,
+                                           AddAttrFuncPtr AddAttrPtr) {
+  assert(AddAttrPtr && "'AddAttrPtr' should be a valid function pointer");
+  llvm::dbgs() << "at line " << __LINE__ << "\n";
+
+  // TODO: Replace with std::invoke once C++17 headers are available.
+  auto Invoke = [this](AddAttrFuncPtr AddAttrPtr,
+                       auto... Args) -> AttrBuilder & {
+    return (this->*AddAttrPtr)(Args...);
+  };
+
+  OpBuilder Builder(&Ctx);
+  StringRef AttrName = llvm::Attribute::getNameFromAttrKind(Kind);
+  NamedAttribute NamedAttr(createStringAttr(AttrName, Dialect, Ctx),
+                           Builder.getUnitAttr());
+  llvm::dbgs() << "at line " << __LINE__ << "\n";
+  return Invoke(AddAttrPtr, NamedAttr);
+}
+
+AttrBuilder &AttrBuilder::addAttributeImpl(llvm::Attribute::AttrKind Kind,
+                                           mlir::Type Ty,
+                                           Optional<StringLiteral> Dialect,
+                                           AddAttrFuncPtr AddAttrPtr) {
+  assert(AddAttrPtr && "'AddAttrPtr' should be a valid function pointer");
+  llvm::dbgs() << "at line " << __LINE__ << "\n";
+  // TODO: Replace with std::invoke once C++17 headers are available.
+  auto Invoke = [this](AddAttrFuncPtr AddAttrPtr,
+                       auto... Args) -> AttrBuilder & {
+    return (this->*AddAttrPtr)(Args...);
+  };
+
+  OpBuilder Builder(&Ctx);
+  StringRef AttrName = llvm::Attribute::getNameFromAttrKind(Kind);
+  NamedAttribute NamedAttr(createStringAttr(AttrName, Dialect, Ctx),
+                           mlir::TypeAttr::get(Ty));
+  llvm::dbgs() << "at line " << __LINE__ << "\n";
+  return Invoke(AddAttrPtr, NamedAttr);
+}
+
+AttrBuilder &
+AttrBuilder::addAttributeImpl(llvm::Attribute::AttrKind Kind, uint64_t Val,
+                              AddRawIntAttrFuncPtr AddRawIntAttrPtr) {
+  assert(AddRawIntAttrPtr &&
+         "'AddRawIntAttrPtr' should be a valid function pointer");
+
+  // TODO: Replace with std::invoke once C++17 headers are available.
+  auto Invoke = [this](AddRawIntAttrFuncPtr AddRawIntAttrPtr,
+                       auto... Args) -> AttrBuilder & {
+    return (this->*AddRawIntAttrPtr)(Args...);
+  };
+
+  switch (Kind) {
+  case llvm::Attribute::AttrKind::Alignment:
+  case llvm::Attribute::AttrKind::StackAlignment:
+    assert(Val <= llvm::Value::MaximumAlignment && "Alignment too large");
+    LLVM_FALLTHROUGH;
+  case llvm::Attribute::AttrKind::Dereferenceable:
+  case llvm::Attribute::AttrKind::DereferenceableOrNull:
+  case llvm::Attribute::AttrKind::UWTable:
+    return (!Val) ? *this : Invoke(AddRawIntAttrPtr, Kind, Val);
+
+  default:
+    llvm_unreachable("Unexpected attribute kind");
+  }
+
+  return *this;
+}
+
+AttrBuilder &AttrBuilder::addAttributeImpl(Twine AttrName, mlir::Attribute Attr,
+                                           AddAttrFuncPtr AddAttrPtr) {
+  assert(AddAttrPtr && "'AddAttrPtr' should be a valid function pointer");
+
+  // TODO: Replace with std::invoke once C++17 headers are available.
+  auto Invoke = [this](AddAttrFuncPtr AddAttrPtr,
+                       auto... Args) -> AttrBuilder & {
+    return (this->*AddAttrPtr)(Args...);
+  };
+
+  NamedAttribute NamedAttr(StringAttr::get(&Ctx, AttrName), Attr);
+  return Invoke(AddAttrPtr, NamedAttr);
+}
+
+AttrBuilder &AttrBuilder::addAttributeImpl(mlir::NamedAttribute Attr) {
+  llvm::dbgs() << "at line " << __LINE__ << "\n";
+  Attrs.set(Attr.getName(), Attr.getValue());
+  return *this;
+}
+
+AttrBuilder &
+AttrBuilder::addPassThroughAttributeImpl(mlir::NamedAttribute Attr) {
+  NamedAttribute PassThroughAttr = getOrCreatePassThroughAttr();
+  addToPassThroughAttr(PassThroughAttr, Attr, Ctx);
+  return addAttributeImpl(PassThroughAttr);
 }
 
 AttrBuilder &AttrBuilder::addRawIntAttr(llvm::Attribute::AttrKind Kind,
                                         uint64_t Value) {
   OpBuilder Builder(&Ctx);
-  NamedAttribute NamedAttr = createNamedAttr(
+  NamedAttribute NamedAttr(
       createStringAttr(llvm::Attribute::getNameFromAttrKind(Kind),
                        LLVM::LLVMDialect::getDialectNamespace(), Ctx),
       Builder.getIntegerAttr(Builder.getIntegerType(64), Value));
-  return addAttribute(NamedAttr);
+  return addAttributeImpl(NamedAttr);
 }
 
 AttrBuilder &
 AttrBuilder::addPassThroughRawIntAttr(llvm::Attribute::AttrKind Kind,
                                       uint64_t Value) {
   OpBuilder Builder(&Ctx);
-  NamedAttribute NamedAttr = createNamedAttr(
-      createStringAttr(llvm::Attribute::getNameFromAttrKind(Kind), Ctx),
+  NamedAttribute NamedAttr(
+      StringAttr::get(&Ctx, llvm::Attribute::getNameFromAttrKind(Kind)),
       Builder.getIntegerAttr(Builder.getIntegerType(64), Value));
-  return addPassThroughAttribute(NamedAttr);
+  return addPassThroughAttributeImpl(NamedAttr);
 }
 
 NamedAttribute AttrBuilder::getOrCreatePassThroughAttr() const {
@@ -337,7 +362,7 @@ NamedAttribute AttrBuilder::getOrCreatePassThroughAttr() const {
   if (!PassThroughAttr) {
     LLVM_DEBUG(llvm::dbgs()
                << "Creating empty '" << PassThroughAttrName << "' attribute\n");
-    PassThroughAttr = NamedAttribute(createStringAttr(PassThroughAttrName, Ctx),
+    PassThroughAttr = NamedAttribute(StringAttr::get(&Ctx, PassThroughAttrName),
                                      ArrayAttr::get(&Ctx, {}));
   }
   return *PassThroughAttr;

--- a/polygeist/tools/cgeist/Lib/Attributes.cc
+++ b/polygeist/tools/cgeist/Lib/Attributes.cc
@@ -1,4 +1,4 @@
-//===- Attributes.cc - Construct LLVMIR attributes ------------------------===//
+//===- Attributes.cc - Construct MLIR attributes --------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -7,10 +7,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "Attributes.h"
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "llvm/Support/Debug.h"
+
+#include <algorithm>
+#include <functional>
 
 #define DEBUG_TYPE "attributes"
 
@@ -19,50 +21,123 @@ using namespace mlir;
 
 namespace mlirclang {
 
-static constexpr StringLiteral passThroughAttrName = "passthrough";
+static constexpr StringLiteral PassThroughAttrName = "passthrough";
+
+//===----------------------------------------------------------------------===//
+// AttributeList Method Implementations
+//===----------------------------------------------------------------------===//
+
+AttributeList &
+AttributeList::addAttrs(const AttrBuilder &FnAttrB, const AttrBuilder &RetAttrB,
+                        llvm::ArrayRef<mlir::NamedAttrList> Attrs) {
+  return addFnAttrs(FnAttrB).addRetAttrs(RetAttrB).addParmAttrs(Attrs);
+}
+
+AttributeList &AttributeList::addFnAttrs(const AttrBuilder &B) {
+  for (const NamedAttribute &NewNamedAttr : B.getAttrs()) {
+    Optional<NamedAttribute> ExistingAttr =
+        FnAttrs.getNamed(NewNamedAttr.getName());
+    if (!ExistingAttr) {
+      FnAttrs.append(NewNamedAttr);
+      continue;
+    }
+
+    // Merge the 'passthrough' attribute lists.
+    if (ExistingAttr->getName() == PassThroughAttrName) {
+      auto Attrs = NewNamedAttr.getValue().cast<ArrayAttr>();
+      AttrBuilder::addToPassThroughAttr(*ExistingAttr, Attrs, B.getContext());
+      FnAttrs.set(ExistingAttr->getName(), ExistingAttr->getValue());
+    }
+  }
+
+  return *this;
+}
+
+AttributeList &AttributeList::addRetAttrs(const AttrBuilder &B) {
+  RetAttrs.append(B.getAttrs());
+  return *this;
+}
+
+AttributeList &
+AttributeList::addParmAttrs(llvm::ArrayRef<mlir::NamedAttrList> Attrs) {
+  ParmAttrs.reserve(Attrs.size());
+  llvm::append_range(ParmAttrs, Attrs);
+  return *this;
+}
+
+mlir::NamedAttrList AttributeList::getParmAttrs(unsigned Index) const {
+  assert(Index < ParmAttrs.size() && "Index out of range");
+  return ParmAttrs[Index];
+}
 
 //===----------------------------------------------------------------------===//
 // AttrBuilder Method Implementations
 //===----------------------------------------------------------------------===//
 
-AttrBuilder &AttrBuilder::addAttribute(llvm::Attribute::AttrKind kind) {
-  OpBuilder builder(&ctx);
-  constexpr StringLiteral dialect = LLVM::LLVMDialect::getDialectNamespace();
-  StringRef attrName = llvm::Attribute::getNameFromAttrKind(kind);
-  NamedAttribute namedAttr = createNamedAttr(
-      createStringAttr(attrName, dialect), builder.getUnitAttr());
-  return addAttribute(namedAttr);
+AttrBuilder &AttrBuilder::addAttribute(llvm::Attribute::AttrKind Kind,
+                                       Optional<StringLiteral> Dialect,
+                                       AddAttrFuncPtr AddAttrPtr) {
+  assert(AddAttrPtr && "'AddAttrPtr' should be a valid function pointer");
+
+  // TODO: Replace with std::invoke once C++17 headers are available.
+  auto Invoke = [this](AddAttrFuncPtr AddAttrPtr,
+                       auto... Args) -> AttrBuilder & {
+    return (this->*AddAttrPtr)(Args...);
+  };
+
+  OpBuilder Builder(&Ctx);
+  StringRef AttrName = llvm::Attribute::getNameFromAttrKind(Kind);
+  NamedAttribute NamedAttr = createNamedAttr(
+      createStringAttr(AttrName, Dialect, Ctx), Builder.getUnitAttr());
+  return Invoke(AddAttrPtr, NamedAttr);
 }
 
-AttrBuilder &AttrBuilder::addAttribute(llvm::Attribute::AttrKind kind,
-                                       mlir::Type Ty) {
-  OpBuilder builder(&ctx);
-  constexpr StringLiteral dialect = LLVM::LLVMDialect::getDialectNamespace();
-  StringRef attrName = llvm::Attribute::getNameFromAttrKind(kind);
-  return addAttribute(dialect + "." + attrName, mlir::TypeAttr::get(Ty));
+AttrBuilder &AttrBuilder::addAttribute(llvm::Attribute::AttrKind Kind,
+                                       mlir::Type Ty,
+                                       Optional<StringLiteral> Dialect,
+                                       AddAttrFuncPtr AddAttrPtr) {
+  assert(AddAttrPtr && "'AddAttrPtr' should be a valid function pointer");
+
+  // TODO: Replace with std::invoke once C++17 headers are available.
+  auto Invoke = [this](AddAttrFuncPtr AddAttrPtr,
+                       auto... Args) -> AttrBuilder & {
+    return (this->*AddAttrPtr)(Args...);
+  };
+
+  OpBuilder Builder(&Ctx);
+  StringRef AttrName = llvm::Attribute::getNameFromAttrKind(Kind);
+  NamedAttribute NamedAttr = createNamedAttr(
+      createStringAttr(AttrName, Dialect, Ctx), mlir::TypeAttr::get(Ty));
+
+  return Invoke(AddAttrPtr, NamedAttr);
 }
 
-AttrBuilder &AttrBuilder::addAttribute(llvm::Attribute::AttrKind kind,
-                                       uint64_t val) {
-  OpBuilder builder(&ctx);
-  constexpr StringLiteral dialect = LLVM::LLVMDialect::getDialectNamespace();
-  StringRef attrName = llvm::Attribute::getNameFromAttrKind(kind);
-  using AttrKind = llvm::Attribute::AttrKind;
+AttrBuilder &AttrBuilder::addAttribute(llvm::Attribute::AttrKind Kind,
+                                       uint64_t Val,
+                                       AddRawIntAttrFuncPtr AddRawIntAttrPtr) {
+  assert(AddRawIntAttrPtr &&
+         "'AddRawIntAttrPtr' should be a valid function pointer");
 
-  switch (kind) {
-  case AttrKind::Alignment:
-    assert(val <= llvm::Value::MaximumAlignment && "Alignment too large");
+  // TODO: Replace with std::invoke once C++17 headers are available.
+  auto Invoke = [this](AddRawIntAttrFuncPtr AddRawIntAttrPtr,
+                       auto... Args) -> AttrBuilder & {
+    return (this->*AddRawIntAttrPtr)(Args...);
+  };
+
+  switch (Kind) {
+  case llvm::Attribute::AttrKind::Alignment:
     LLVM_FALLTHROUGH;
-  case AttrKind::Dereferenceable:
+  case llvm::Attribute::AttrKind::StackAlignment:
+    assert(Val <= llvm::Value::MaximumAlignment && "Alignment too large");
+    return (!Val) ? *this : Invoke(AddRawIntAttrPtr, Kind, Val);
+
+  case llvm::Attribute::AttrKind::Dereferenceable:
     LLVM_FALLTHROUGH;
-  case AttrKind::DereferenceableOrNull: {
-    if (val > 0) {
-      NamedAttribute namedAttr = createNamedAttr(
-          createStringAttr(attrName, dialect),
-          builder.getIntegerAttr(builder.getIntegerType(64), val));
-      addAttribute(namedAttr);
-    }
-  } break;
+  case llvm::Attribute::AttrKind::DereferenceableOrNull:
+    LLVM_FALLTHROUGH;
+  case llvm::Attribute::AttrKind::UWTable:
+    return (!Val) ? *this : Invoke(AddRawIntAttrPtr, Kind, Val);
+
   default:
     llvm_unreachable("Unexpected attribute kind");
   }
@@ -70,103 +145,232 @@ AttrBuilder &AttrBuilder::addAttribute(llvm::Attribute::AttrKind kind,
   return *this;
 }
 
-AttrBuilder &AttrBuilder::addAttribute(Twine attrName, mlir::Attribute attr) {
-  NamedAttribute namedAttr = createNamedAttr(createStringAttr(attrName), attr);
-  return addAttribute(namedAttr);
+AttrBuilder &AttrBuilder::addAttribute(Twine AttrName, mlir::Attribute Attr,
+                                       AddAttrFuncPtr AddAttrPtr) {
+  assert(AddAttrPtr && "'AddAttrPtr' should be a valid function pointer");
+
+  // TODO: Replace with std::invoke once C++17 headers are available.
+  auto Invoke = [this](AddAttrFuncPtr AddAttrPtr,
+                       auto... Args) -> AttrBuilder & {
+    return (this->*AddAttrPtr)(Args...);
+  };
+
+  NamedAttribute NamedAttr =
+      createNamedAttr(createStringAttr(AttrName, Ctx), Attr);
+  return Invoke(AddAttrPtr, NamedAttr);
 }
 
 AttrBuilder &
-AttrBuilder::addPassThroughAttribute(llvm::Attribute::AttrKind kind) {
-  StringRef attrName = llvm::Attribute::getNameFromAttrKind(kind);
-  return addPassThroughAttribute(createStringAttr(attrName));
+AttrBuilder::addPassThroughAttribute(llvm::Attribute::AttrKind Kind) {
+  return addAttribute(Kind, llvm::None, &AttrBuilder::addPassThroughAttribute);
 }
 
-AttrBuilder &AttrBuilder::addPassThroughAttribute(mlir::Attribute attr) {
-  NamedAttribute passThrough = getOrCreatePassThroughAttr();
-  assert(passThrough.getValue().isa<ArrayAttr>() &&
-         "passthrough attribute should have an ArrayAttr as value");
+AttrBuilder &
+AttrBuilder::addPassThroughAttribute(llvm::Attribute::AttrKind Kind,
+                                     mlir::Type Ty) {
+  return addAttribute(Kind, Ty, llvm::None,
+                      &AttrBuilder::addPassThroughAttribute);
+}
 
-  LLVM_DEBUG(llvm::dbgs() << "Adding attribute " << attr << " to '"
-                          << passThroughAttrName << "'.\n");
-  std::vector<mlir::Attribute> vec =
-      passThrough.getValue().cast<ArrayAttr>().getValue().vec();
-  vec.push_back(attr);
-  passThrough.setValue(ArrayAttr::get(&ctx, vec));
+AttrBuilder &
+AttrBuilder::addPassThroughAttribute(llvm::Attribute::AttrKind Kind,
+                                     uint64_t Val) {
+  return addAttribute(Kind, Val, &AttrBuilder::addPassThroughRawIntAttr);
+}
+
+AttrBuilder &AttrBuilder::addPassThroughAttribute(StringRef AttrName,
+                                                  mlir::Attribute Attr) {
+  return addAttribute(AttrName, Attr, &AttrBuilder::addPassThroughAttribute);
+}
+
+AttrBuilder &AttrBuilder::addPassThroughAttribute(mlir::NamedAttribute Attr) {
+  NamedAttribute PassThroughAttr = getOrCreatePassThroughAttr();
+  addToPassThroughAttr(PassThroughAttr, Attr, Ctx);
+  return addAttribute(PassThroughAttr);
+}
+
+void AttrBuilder::addToPassThroughAttr(NamedAttribute &PassThroughAttr,
+                                       mlir::NamedAttribute Attr,
+                                       MLIRContext &Ctx) {
+  assert(PassThroughAttr.getName() == PassThroughAttrName &&
+         "PassThroughAttr is not valid");
+  assert(PassThroughAttr.getValue().isa<ArrayAttr>() &&
+         "PassThroughAttr should have an ArrayAttr as value");
+
+  LLVM_DEBUG(llvm::dbgs() << "Adding attribute " << Attr.getName() << " to '"
+                          << PassThroughAttrName << "'.\n";);
+
+  std::vector<mlir::Attribute> Vec =
+      PassThroughAttr.getValue().cast<ArrayAttr>().getValue().vec();
+
+  // TODO: find a way to add the attributes only if one does not exist already,
+  // and keep the list in sorted order.
+  if (Attr.getValue().isa<UnitAttr>())
+    Vec.push_back(Attr.getName());
+  else
+    Vec.push_back(ArrayAttr::get(&Ctx, {Attr.getName(), Attr.getValue()}));
+
+  PassThroughAttr.setValue(ArrayAttr::get(&Ctx, Vec));
 
   LLVM_DEBUG({
-    llvm::dbgs().indent(2) << passThroughAttrName << ": ( ";
-    for (auto item : vec)
-      llvm::dbgs() << item << " ";
+    llvm::dbgs().indent(2) << PassThroughAttrName << ": ( ";
+    for (auto Item : Vec)
+      llvm::dbgs() << Item << " ";
     llvm::dbgs() << ")\n";
   });
-
-  return addAttribute(passThrough);
 }
 
-bool AttrBuilder::contains(StringRef attrName) const {
-  return getAttr(attrName).has_value();
+void AttrBuilder::addToPassThroughAttr(mlir::NamedAttribute &PassThroughAttr,
+                                       mlir::ArrayAttr NewAttrs,
+                                       MLIRContext &Ctx) {
+  assert(PassThroughAttr.getName() == PassThroughAttrName &&
+         "PassThroughAttr is not valid");
+  assert(PassThroughAttr.getValue().isa<ArrayAttr>() &&
+         "PassThroughAttr should have an ArrayAttr as value");
+
+  for (mlir::Attribute NewAttr : NewAttrs) {
+    if (NewAttr.isa<ArrayAttr>()) {
+      auto ArrAttr = NewAttr.cast<ArrayAttr>();
+      assert(ArrAttr.size() == 2 && ArrAttr[0].isa<StringAttr>());
+      addToPassThroughAttr(
+          PassThroughAttr,
+          createNamedAttr(ArrAttr[0].cast<StringAttr>(), ArrAttr[1]), Ctx);
+    } else if (NewAttr.isa<StringAttr>())
+      addToPassThroughAttr(
+          PassThroughAttr,
+          createNamedAttr(NewAttr.cast<StringAttr>(), UnitAttr::get(&Ctx)),
+          Ctx);
+    else
+      llvm_unreachable("Unexpected attribute kind");
+  }
 }
 
-bool AttrBuilder::contains(llvm::Attribute::AttrKind kind) const {
-  StringRef attrName = llvm::Attribute::getNameFromAttrKind(kind);
-  return contains(attrName);
+AttrBuilder &AttrBuilder::removeAttribute(llvm::StringRef AttrName) {
+  if (containsInPassThrough(AttrName)) {
+    NamedAttribute PassThroughAttr = getAttr(PassThroughAttrName).value();
+    auto ArrAttr = PassThroughAttr.getValue().cast<ArrayAttr>();
+    std::vector<mlir::Attribute> Vec = ArrAttr.getValue().vec();
+
+    std::remove_if(Vec.begin(), Vec.end(), [AttrName](mlir::Attribute &Attr) {
+      if (Attr.isa<StringAttr>())
+        return (Attr.cast<StringAttr>().strref() == AttrName);
+      if (Attr.isa<ArrayAttr>()) {
+        auto ArrAttr = Attr.cast<ArrayAttr>();
+        assert(ArrAttr.size() == 2 && ArrAttr[0].isa<StringAttr>());
+        return (ArrAttr[0].cast<StringAttr>().strref() == AttrName);
+      }
+      return false;
+    });
+
+    PassThroughAttr.setValue(ArrayAttr::get(&Ctx, Vec));
+    return *this;
+  }
+
+  Attrs.erase(AttrName);
+  return *this;
 }
 
-bool AttrBuilder::containsInPassThrough(StringRef attrName) const {
-  if (!contains(passThroughAttrName))
-    return false;
-
-  NamedAttribute passThrough = getAttr(passThroughAttrName).value();
-  assert(passThrough.getValue().isa<ArrayAttr>() &&
-         "passthrough attribute value should be an ArrayAttr");
-
-  return llvm::any_of(passThrough.getValue().cast<ArrayAttr>(),
-                      [attrName](mlir::Attribute attr) {
-                        assert(attr.isa<StringAttr>() &&
-                               "Unexpected attribute kind");
-                        return attr.cast<StringAttr>() == attrName;
-                      });
+AttrBuilder &AttrBuilder::removeAttribute(llvm::Attribute::AttrKind Kind) {
+  assert((unsigned)Kind < llvm::Attribute::EndAttrKinds &&
+         "Attribute out of range!");
+  StringRef AttrName = llvm::Attribute::getNameFromAttrKind(Kind);
+  return removeAttribute(AttrName);
 }
 
-bool AttrBuilder::containsInPassThrough(llvm::Attribute::AttrKind kind) const {
-  StringRef attrName = llvm::Attribute::getNameFromAttrKind(kind);
-  return containsInPassThrough(attrName);
+bool AttrBuilder::contains(StringRef AttrName) const {
+  if (containsInPassThrough(AttrName))
+    return true;
+  return getAttr(AttrName).has_value();
 }
 
-Optional<NamedAttribute> AttrBuilder::getAttr(StringRef attrName) const {
-  return attrs.getNamed(attrName);
+bool AttrBuilder::contains(llvm::Attribute::AttrKind Kind) const {
+  StringRef AttrName = llvm::Attribute::getNameFromAttrKind(Kind);
+  return contains(AttrName);
+}
+
+Optional<NamedAttribute> AttrBuilder::getAttr(StringRef AttrName) const {
+  return Attrs.getNamed(AttrName);
 }
 
 Optional<NamedAttribute>
-AttrBuilder::getAttr(llvm::Attribute::AttrKind kind) const {
-  StringRef attrName = llvm::Attribute::getNameFromAttrKind(kind);
-  return getAttr(attrName);
+AttrBuilder::getAttr(llvm::Attribute::AttrKind Kind) const {
+  StringRef AttrName = llvm::Attribute::getNameFromAttrKind(Kind);
+  return getAttr(AttrName);
+}
+
+NamedAttribute AttrBuilder::createNamedAttr(StringAttr AttrName,
+                                            mlir::Attribute Attr) {
+  NamedAttribute NamedAttr(AttrName, Attr);
+  return NamedAttr;
+}
+
+StringAttr AttrBuilder::createStringAttr(Twine AttrName, MLIRContext &Ctx) {
+  return StringAttr::get(&Ctx, AttrName);
+}
+
+StringAttr AttrBuilder::createStringAttr(Twine AttrName,
+                                         Optional<StringLiteral> Prefix,
+                                         MLIRContext &Ctx) {
+  return (Prefix) ? createStringAttr(*Prefix + "." + AttrName, Ctx)
+                  : createStringAttr(AttrName, Ctx);
+}
+
+AttrBuilder &AttrBuilder::addRawIntAttr(llvm::Attribute::AttrKind Kind,
+                                        uint64_t Value) {
+  OpBuilder Builder(&Ctx);
+  NamedAttribute NamedAttr = createNamedAttr(
+      createStringAttr(llvm::Attribute::getNameFromAttrKind(Kind),
+                       LLVM::LLVMDialect::getDialectNamespace(), Ctx),
+      Builder.getIntegerAttr(Builder.getIntegerType(64), Value));
+  return addAttribute(NamedAttr);
+}
+
+AttrBuilder &
+AttrBuilder::addPassThroughRawIntAttr(llvm::Attribute::AttrKind Kind,
+                                      uint64_t Value) {
+  OpBuilder Builder(&Ctx);
+  NamedAttribute NamedAttr = createNamedAttr(
+      createStringAttr(llvm::Attribute::getNameFromAttrKind(Kind), Ctx),
+      Builder.getIntegerAttr(Builder.getIntegerType(64), Value));
+  return addPassThroughAttribute(NamedAttr);
 }
 
 NamedAttribute AttrBuilder::getOrCreatePassThroughAttr() const {
-  Optional<NamedAttribute> passThrough = getAttr(passThroughAttrName);
-  if (!passThrough) {
+  Optional<NamedAttribute> PassThroughAttr = getAttr(PassThroughAttrName);
+  if (!PassThroughAttr) {
     LLVM_DEBUG(llvm::dbgs()
-               << "Creating empty '" << passThroughAttrName << "' attribute\n");
-    passThrough = NamedAttribute(createStringAttr(passThroughAttrName),
-                                 ArrayAttr::get(&ctx, {}));
+               << "Creating empty '" << PassThroughAttrName << "' attribute\n");
+    PassThroughAttr = NamedAttribute(createStringAttr(PassThroughAttrName, Ctx),
+                                     ArrayAttr::get(&Ctx, {}));
   }
-  return *passThrough;
+  return *PassThroughAttr;
 }
 
-NamedAttribute AttrBuilder::createNamedAttr(StringAttr attrName,
-                                            mlir::Attribute attr) const {
-  NamedAttribute namedAttr(attrName, attr);
-  return namedAttr;
+bool AttrBuilder::containsInPassThrough(StringRef AttrName) const {
+  if (!getAttr(PassThroughAttrName).has_value())
+    return false;
+
+  NamedAttribute PassThroughAttr = getAttr(PassThroughAttrName).value();
+  assert(PassThroughAttr.getValue().isa<ArrayAttr>() &&
+         "passthrough attribute value should be an ArrayAttr");
+
+  return llvm::any_of(
+      PassThroughAttr.getValue().cast<ArrayAttr>(),
+      [AttrName](mlir::Attribute Attr) {
+        if (Attr.isa<ArrayAttr>()) {
+          auto ArrAttr = Attr.cast<ArrayAttr>();
+          assert(ArrAttr.size() == 2 && ArrAttr[0].isa<StringAttr>());
+          return ArrAttr[0].cast<StringAttr>() == AttrName;
+        }
+
+        assert(Attr.isa<StringAttr>() && "Unexpected attribute Kind");
+        return Attr.cast<StringAttr>() == AttrName;
+      });
 }
 
-StringAttr AttrBuilder::createStringAttr(Twine attrName) const {
-  return StringAttr::get(&ctx, attrName);
-}
-
-StringAttr AttrBuilder::createStringAttr(Twine attrName,
-                                         StringLiteral prefix) const {
-  return createStringAttr(prefix + "." + attrName);
+bool AttrBuilder::containsInPassThrough(llvm::Attribute::AttrKind Kind) const {
+  StringRef AttrName = llvm::Attribute::getNameFromAttrKind(Kind);
+  return containsInPassThrough(AttrName);
 }
 
 } // end namespace mlirclang

--- a/polygeist/tools/cgeist/Lib/Attributes.h
+++ b/polygeist/tools/cgeist/Lib/Attributes.h
@@ -70,11 +70,6 @@ public:
   AttrBuilder(const AttrBuilder &) = delete;
   AttrBuilder(AttrBuilder &&) = default;
 
-  using AddAttrFuncPtr =
-      AttrBuilder &(AttrBuilder::*)(mlir::NamedAttribute Attr);
-  using AddRawIntAttrFuncPtr = AttrBuilder &(
-      AttrBuilder::*)(llvm::Attribute::AttrKind Kind, uint64_t Value);
-
   /// Add the LLVM attribute identified by \p Kind to the builder.
   AttrBuilder &addAttribute(llvm::Attribute::AttrKind Kind);
 
@@ -142,6 +137,11 @@ public:
                    mlir::MLIRContext &Ctx);
 
 private:
+  using AddAttrFuncPtr =
+      AttrBuilder &(AttrBuilder::*)(mlir::NamedAttribute Attr);
+  using AddRawIntAttrFuncPtr = AttrBuilder &(
+      AttrBuilder::*)(llvm::Attribute::AttrKind Kind, uint64_t Value);
+
   /// Add the LLVM attribute identified by \p Kind to the builder, optionally
   /// prefixing the attribute name with \p Dialect.
   /// Note: \p AddAttrPtr is used to provide a concrete implementation

--- a/polygeist/tools/cgeist/Lib/Attributes.h
+++ b/polygeist/tools/cgeist/Lib/Attributes.h
@@ -1,4 +1,4 @@
-//===- Attributes.h - Construct LLVMIR attributes ---------------*- C++ -*-===//
+//===- Attributes.h - Construct MLIR attributes -----------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,90 +9,216 @@
 #ifndef CGEIST_ATTRIBUTES_H
 #define CGEIST_ATTRIBUTES_H
 
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/OperationSupport.h"
 #include "llvm/IR/Attributes.h"
 
 namespace mlirclang {
 
+class AttrBuilder;
+
+/// \class
+/// This class holds the attributes for a function, its return value, and
+/// its parameters. You access the attributes for each of them via an index into
+/// the AttributeList object. The function attributes are at index
+/// `AttributeList::FunctionIndex', the return value is at index
+/// `AttributeList::ReturnIndex', and the attributes for the parameters start at
+/// index `AttributeList::FirstArgIndex'.
+class AttributeList {
+public:
+  AttributeList() = default;
+
+  //===--------------------------------------------------------------------===//
+  // AttributeList Mutation
+  //===--------------------------------------------------------------------===//
+
+  /// Add function. return value, and parameters attributes to the list.
+  AttributeList &addAttrs(const AttrBuilder &FnAttrB,
+                          const AttrBuilder &RetAttrB,
+                          llvm::ArrayRef<mlir::NamedAttrList> Attrs);
+
+  /// Add function attributes to the list.
+  AttributeList &addFnAttrs(const AttrBuilder &B);
+
+  /// Add return value attributes to the list.
+  AttributeList &addRetAttrs(const AttrBuilder &B);
+
+  /// Add parameters attributes to the list.
+  AttributeList &addParmAttrs(llvm::ArrayRef<mlir::NamedAttrList> Attrs);
+
+  /// The function attributes are returned.
+  mlir::NamedAttrList getFnAttrs() const { return FnAttrs; }
+
+  /// The attributes for the ret value are returned.
+  mlir::NamedAttrList getRetAttrs() const { return RetAttrs; }
+
+  /// The attributes for the parameters are returned.
+  mlir::ArrayRef<mlir::NamedAttrList> getParmAttrs() const { return ParmAttrs; }
+
+  /// The attributes for the parameter at the given index are returned.
+  mlir::NamedAttrList getParmAttrs(unsigned Index) const;
+
+private:
+  /// The attributes that we are managing.
+  mlir::NamedAttrList FnAttrs;
+  mlir::NamedAttrList RetAttrs;
+  llvm::SmallVector<mlir::NamedAttrList, 8> ParmAttrs;
+};
+
 /// \class
 /// Facilitates the construction of LLVM dialect attributes for a particular
 /// argument, parameter, function, or return value.
 class AttrBuilder {
 public:
-  AttrBuilder(mlir::MLIRContext &ctx) : ctx(ctx) {}
+  AttrBuilder(mlir::MLIRContext &Ctx) : Ctx(Ctx) {}
   AttrBuilder(const AttrBuilder &) = delete;
   AttrBuilder(AttrBuilder &&) = default;
 
-  /// Add the LLVM attribute identified by \p kind to the builder.
-  /// Note: only unit attributes can be added using this member function.
-  AttrBuilder &addAttribute(llvm::Attribute::AttrKind kind);
+  using AddAttrFuncPtr =
+      AttrBuilder &(AttrBuilder::*)(mlir::NamedAttribute Attr);
+  using AddRawIntAttrFuncPtr = AttrBuilder &(
+      AttrBuilder::*)(llvm::Attribute::AttrKind Kind, uint64_t Value);
 
-  /// Add the LLVM attribute identified by \p kind with a type given by \p Ty
+  /// Add the LLVM attribute identified by \p Kind to the builder, optionally
+  /// prefixing the attribute name with \p Dialect.
+  /// Note: \p AddAttrPtr is used to provide a concrete implementation
+  /// controlling where to add the attribute (to the 'passthrough' list or not).
+  AttrBuilder &
+  addAttribute(llvm::Attribute::AttrKind Kind,
+               llvm::Optional<llvm::StringLiteral> Dialect =
+                   mlir::LLVM::LLVMDialect::getDialectNamespace(),
+               AddAttrFuncPtr AddAttrPtr = &AttrBuilder::addAttribute);
+
+  /// Add the LLVM attribute identified by \p Kind with a type given by \p Ty
+  /// to the builder, optionally prefixing the attribute name with \p Dialect.
+  /// Note: \p AddAttrPtr is used to provide a concrete implementation
+  /// controlling where to add the attribute (to the 'passthrough' list or not).
+  AttrBuilder &
+  addAttribute(llvm::Attribute::AttrKind Kind, mlir::Type Ty,
+               llvm::Optional<llvm::StringLiteral> Dialect =
+                   mlir::LLVM::LLVMDialect::getDialectNamespace(),
+               AddAttrFuncPtr AddAttrPtr = &AttrBuilder::addAttribute);
+
+  /// Add the LLVM attribute identified by \p Kind with a value given by \p Val
   /// to the builder.
-  AttrBuilder &addAttribute(llvm::Attribute::AttrKind kind, mlir::Type Ty);
+  /// Note: \p AddRawIntAttrPtr is used to provide a concrete implementation
+  /// controlling where to add the attribute (to the 'passthrough' list or not).
+  AttrBuilder &addAttribute(
+      llvm::Attribute::AttrKind Kind, uint64_t Val,
+      AddRawIntAttrFuncPtr AddRawIntAttrPtr = &AttrBuilder::addRawIntAttr);
 
-  /// Add the LLVM attribute identified by \p kind with a value given by \p val
+  /// Create a NamedAttribute with name \p AttrName and value \p Attr and add it
   /// to the builder.
-  AttrBuilder &addAttribute(llvm::Attribute::AttrKind kind, uint64_t val);
+  /// Note: \p AddAttrPtr is used to provide a concrete implementation
+  /// controlling where to add the attribute (to the 'passthrough' list or not).
+  AttrBuilder &
+  addAttribute(llvm::Twine AttrName, mlir::Attribute Attr,
+               AddAttrFuncPtr AddAttrPtr = &AttrBuilder::addAttribute);
 
-  /// Create a NamedAttribute with name \p attrName and value \p attr and add it
-  /// to the builder.
-  AttrBuilder &addAttribute(llvm::Twine attrName, mlir::Attribute attr);
-
-  /// Add the given named attribute \p attr to the builder.
-  AttrBuilder &addAttribute(mlir::NamedAttribute attr) {
-    attrs.set(attr.getName(), attr.getValue());
+  /// Add the given named attribute \p Attr to the builder.
+  AttrBuilder &addAttribute(mlir::NamedAttribute Attr) {
+    Attrs.set(Attr.getName(), Attr.getValue());
     return *this;
   }
 
-  /// Add the LLVM attribute identified by \p kind to the builder "passthrough"
+  /// Add the LLVM attribute identified by \p Kind to the builder "passthrough"
   /// named attribute.
-  AttrBuilder &addPassThroughAttribute(llvm::Attribute::AttrKind kind);
+  AttrBuilder &addPassThroughAttribute(llvm::Attribute::AttrKind Kind);
 
-  /// Add the given attribute \p attr to the builder "passthrough" named
+  /// Add the LLVM attribute identified by \p Kind with a type given by \p Ty
+  /// to the builder "passthrough" named attribute.
+  AttrBuilder &addPassThroughAttribute(llvm::Attribute::AttrKind Kind,
+                                       mlir::Type Ty);
+
+  /// Add the LLVM attribute identified by \p Kind with a value given by \p Val
+  /// to the builder "passthrough" named attribute.
+  AttrBuilder &addPassThroughAttribute(llvm::Attribute::AttrKind Kind,
+                                       uint64_t Val);
+
+  /// Create a NamedAttribute with name \p AttrName and value \p Attr and add it
+  /// to the builder "passthrough" named attribute.
+  AttrBuilder &addPassThroughAttribute(llvm::StringRef AttrName,
+                                       mlir::Attribute Attr);
+
+  /// Add the given named attribute \p Attr to the builder "passthrough" named
   /// attribute.
-  AttrBuilder &addPassThroughAttribute(mlir::Attribute attr);
+  AttrBuilder &addPassThroughAttribute(mlir::NamedAttribute Attr);
+
+  /// Add \p Attr to the \p PassThroughAttr list.
+  /// Note: \p PassThroughAttr must have name "passthrough" and value of type
+  /// ArrayAttr.
+  static void addToPassThroughAttr(mlir::NamedAttribute &PassThroughAttr,
+                                   mlir::NamedAttribute Attr,
+                                   mlir::MLIRContext &Ctx);
+
+  /// Add \p NewAttrs into the attribute list of \p PassThroughAttr.
+  /// Note: \p PassThroughAttr must have name "passthrough" and value of type
+  /// ArrayAttr.
+  static void addToPassThroughAttr(mlir::NamedAttribute &PassThroughAttr,
+                                   mlir::ArrayAttr NewAttrs,
+                                   mlir::MLIRContext &Ctx);
+
+  /// Remove an attribute from the builder (if present).
+  /// Note: the given attribute will be removed even if it is contained by the
+  /// 'passthrough' named attribute.
+  AttrBuilder &removeAttribute(llvm::StringRef AttrName);
+  AttrBuilder &removeAttribute(llvm::Attribute::AttrKind Kind);
 
   /// Return true if the builder contains the specified attribute.
-  bool contains(llvm::StringRef attrName) const;
-  bool contains(llvm::Attribute::AttrKind kind) const;
-
-  /// Return true if the builder contains the specified attribute within the
-  /// 'passthrough' attribute.
-  bool containsInPassThrough(llvm::StringRef attrName) const;
-  bool containsInPassThrough(llvm::Attribute::AttrKind kind) const;
+  /// Note: these member functions also lookup for the given attribute in the
+  /// 'passthrough' named attribute if it exists.
+  bool contains(llvm::StringRef AttrName) const;
+  bool contains(llvm::Attribute::AttrKind Kind) const;
 
   /// Return true if the builder contains any attribute and false otherwise.
-  bool hasAttributes() const { return !attrs.empty(); }
+  bool hasAttributes() const { return !Attrs.empty(); }
 
   /// Return the given attribute if the builder contains it and llvm::None
   /// otherwise.
-  llvm::Optional<mlir::NamedAttribute> getAttr(llvm::StringRef attrName) const;
+  llvm::Optional<mlir::NamedAttribute> getAttr(llvm::StringRef AttrName) const;
   llvm::Optional<mlir::NamedAttribute>
-  getAttr(llvm::Attribute::AttrKind kind) const;
+  getAttr(llvm::Attribute::AttrKind Kind) const;
 
   /// Returns the attributes contained in the builder.
-  llvm::ArrayRef<mlir::NamedAttribute> getAttrs() const { return attrs; }
+  llvm::ArrayRef<mlir::NamedAttribute> getAttrs() const { return Attrs; }
+
+  mlir::MLIRContext &getContext() const { return Ctx; }
+
+  /// returns a NamedAttribute with name \p AttrName , and value \p Attr.
+  static mlir::NamedAttribute createNamedAttr(mlir::StringAttr AttrName,
+                                              mlir::Attribute Attr);
+
+  /// Returns a StringAttr of the form 'AttrName'.
+  static mlir::StringAttr createStringAttr(llvm::Twine AttrName,
+                                           mlir::MLIRContext &Ctx);
+
+  /// Returns a StringAttr of the form 'prefix.AttrName'.
+  static mlir::StringAttr
+  createStringAttr(llvm::Twine AttrName,
+                   llvm::Optional<llvm::StringLiteral> Prefix,
+                   mlir::MLIRContext &Ctx);
 
 private:
+  /// Add integer attribute with raw value (packed/encoded if necessary).
+  AttrBuilder &addRawIntAttr(llvm::Attribute::AttrKind Kind, uint64_t Value);
+
+  /// Add integer attribute with raw value (packed/encoded if necessary) to the
+  /// builder "passthrough" named attribute.
+  AttrBuilder &addPassThroughRawIntAttr(llvm::Attribute::AttrKind Kind,
+                                        uint64_t Value);
+
   /// Retrieve the "passthrough" named attribute if present, create it with an
   /// empty list otherwise.
   mlir::NamedAttribute getOrCreatePassThroughAttr() const;
 
-  /// returns a NamedAttribute with name \p attrName , and value \p attr.
-  mlir::NamedAttribute createNamedAttr(mlir::StringAttr attrName,
-                                       mlir::Attribute attr) const;
+  /// Return true if the builder contains the specified attribute within the
+  /// 'passthrough' attribute.
+  bool containsInPassThrough(llvm::StringRef AttrName) const;
+  bool containsInPassThrough(llvm::Attribute::AttrKind Kind) const;
 
-  /// Returns a StringAttr of the form 'attrName'.
-  mlir::StringAttr createStringAttr(llvm::Twine attrName) const;
-
-  /// Returns a StringAttr of the form 'prefix.attrName'.
-  mlir::StringAttr createStringAttr(llvm::Twine attrName,
-                                    llvm::StringLiteral prefix) const;
-
-  mlir::MLIRContext &ctx;
-  mlir::NamedAttrList attrs;
+  mlir::MLIRContext &Ctx;
+  mlir::NamedAttrList Attrs;
 };
 
 } // end namespace mlirclang

--- a/polygeist/tools/cgeist/Lib/Attributes.h
+++ b/polygeist/tools/cgeist/Lib/Attributes.h
@@ -70,7 +70,6 @@ public:
   AttrBuilder(const AttrBuilder &) = delete;
   AttrBuilder(AttrBuilder &&) = default;
 
-  using const_iterator = mlir::NamedAttrList::const_iterator;
   using AddAttrFuncPtr =
       AttrBuilder &(AttrBuilder::*)(mlir::NamedAttribute Attr);
   using AddRawIntAttrFuncPtr = AttrBuilder &(

--- a/polygeist/tools/cgeist/Lib/Attributes.h
+++ b/polygeist/tools/cgeist/Lib/Attributes.h
@@ -70,6 +70,7 @@ public:
   AttrBuilder(const AttrBuilder &) = delete;
   AttrBuilder(AttrBuilder &&) = default;
 
+  using const_iterator = mlir::NamedAttrList::const_iterator;
   using AddAttrFuncPtr =
       AttrBuilder &(AttrBuilder::*)(mlir::NamedAttribute Attr);
   using AddRawIntAttrFuncPtr = AttrBuilder &(

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -3506,9 +3506,9 @@ void MLIRASTConsumer::setMLIRFunctionAttributes(
     attrBuilder
         .addAttribute(gpu::GPUDialect::getKernelFuncAttrName(),
                       UnitAttr::get(ctx))
-        .addPassThroughAttribute(ArrayAttr::get(
-            ctx, {StringAttr::get(ctx, "sycl-module-id"),
-                  StringAttr::get(ctx, llvmMod.getModuleIdentifier())}));
+        .addPassThroughAttribute(mlirclang::AttrBuilder::createNamedAttr(
+            StringAttr::get(ctx, "sycl-module-id"),
+            StringAttr::get(ctx, llvmMod.getModuleIdentifier())));
   }
 
   // Calling conventions for SPIRV functions.

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -3506,9 +3506,9 @@ void MLIRASTConsumer::setMLIRFunctionAttributes(
     attrBuilder
         .addAttribute(gpu::GPUDialect::getKernelFuncAttrName(),
                       UnitAttr::get(ctx))
-        .addPassThroughAttribute(mlirclang::AttrBuilder::createNamedAttr(
-            StringAttr::get(ctx, "sycl-module-id"),
-            StringAttr::get(ctx, llvmMod.getModuleIdentifier())));
+        .addPassThroughAttribute(
+            "sycl-module-id",
+            StringAttr::get(ctx, llvmMod.getModuleIdentifier()));
   }
 
   // Calling conventions for SPIRV functions.


### PR DESCRIPTION
This PR introduces the `mlirclang::AttributeList` class which will be uses to collect attributes into a list (in future PRs).
The `mlirclang::AttrBuilder` class is enhanced to:
   - reduce code duplication for the member functions that add attributes to the "passthrough" list
   - make `contains` check for the requested attribute also in the 'passthrough' list
   - make `removeAttribute` remove also from the 'passthrough' list
   - name all variable using a capital case to abide by the coding conventions   

Signed-off-by: Tiotto, Ettore <ettore.tiotto@intel.com>