### PR TITLE
[SYCL] Fix a couple of memory corruptions.

### DIFF
--- a/sycl/source/detail/persistent_device_code_cache.cpp
+++ b/sycl/source/detail/persistent_device_code_cache.cpp
@@ -333,8 +333,10 @@ std::string PersistentDeviceCodeCache::getCacheItemPath(
     return {};
   }
 
-  std::string ImgString{(const char *)Img.getRawData().BinaryStart,
-                        Img.getSize()};
+  std::string ImgString = "";
+  if (Img.getRawData().BinaryStart)
+    ImgString.assign((const char *)Img.getRawData().BinaryStart, Img.getSize());
+
   std::string DeviceString{getDeviceIDString(Device)};
   std::string SpecConstsString{(const char *)SpecConsts.data(),
                                SpecConsts.size()};

--- a/sycl/unittests/helpers/PiMockPlugin.hpp
+++ b/sycl/unittests/helpers/PiMockPlugin.hpp
@@ -127,7 +127,7 @@ inline pi_result mock_piDeviceGetInfo(pi_device device,
   }
   case PI_DEVICE_INFO_PARENT_DEVICE: {
     if (param_value)
-      *static_cast<pi_device **>(param_value) = nullptr;
+      *static_cast<pi_device *>(param_value) = nullptr;
     if (param_value_size_ret)
       *param_value_size_ret = sizeof(pi_device *);
     return PI_SUCCESS;
@@ -407,7 +407,7 @@ inline pi_result mock_piProgramGetInfo(pi_program program,
   switch (param_name) {
   case PI_PROGRAM_INFO_NUM_DEVICES: {
     if (param_value)
-      *static_cast<size_t *>(param_value) = 1;
+      *static_cast<unsigned int *>(param_value) = 1;
     if (param_value_size_ret)
       *param_value_size_ret = sizeof(size_t);
     return PI_SUCCESS;


### PR DESCRIPTION
1. It's UB to construct std::string using nullptr which may happen with mock device images in SYCL unittests
2. Fixed a couple of mock "getInfo" PI APIs that were casting param_value to an incorrect type.