### PR TITLE
[SYCL] Prevent use of double in stream implementation

### DIFF
--- a/sycl/include/sycl/stream.hpp
+++ b/sycl/include/sycl/stream.hpp
@@ -265,14 +265,14 @@ EnableIfFP<T, unsigned> floatingPointToDecStr(T AbsVal, char *Digits,
   int Exp = 0;
 
   // For the case that the value is larger than 10.0
-  while (AbsVal >= 10.0) {
+  while (AbsVal >= T{10.0}) {
     ++Exp;
-    AbsVal /= 10.0;
+    AbsVal /= T{10.0};
   }
   // For the case that the value is less than 1.0
-  while (AbsVal > 0.0 && AbsVal < 1.0) {
+  while (AbsVal > T{0.0} && AbsVal < T{1.0}) {
     --Exp;
-    AbsVal *= 10.0;
+    AbsVal *= T{10.0};
   }
 
   auto IntegralPart = static_cast<int>(AbsVal);
@@ -292,7 +292,7 @@ EnableIfFP<T, unsigned> floatingPointToDecStr(T AbsVal, char *Digits,
     FractionLength = MAX_FLOATING_POINT_DIGITS - 5;
 
   for (unsigned I = 0; I < FractionLength; ++I) {
-    FractionPart *= 10.0;
+    FractionPart *= T{10.0};
     FractionDigits[I] = static_cast<int>(FractionPart);
     FractionPart -= static_cast<int>(FractionPart);
   }


### PR DESCRIPTION
The current implementation of stream uses double literals for some generalized floating point operations. To avoid this inadvertently requiring support for fp64, this commit makes appropriate conversions.