### PR TITLE
[CMake] Disable STL-internal assertions in device code

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 option(SYCL_ENABLE_WERROR "Treat all warnings as errors in SYCL project" OFF)
-option(SYCL_DISABLE_STL_ASSERTIONS "Disable assertions in STL containers" OFF)
+option(SYCL_DISABLE_STL_ASSERTIONS "Disable assertions in STL containers" ON)
 option(SYCL_ADD_DEV_VERSION_POSTFIX "Adds -V postfix to version string" ON)
 option(SYCL_ENABLE_COVERAGE "Enables code coverage for runtime and unit tests" OFF)
 


### PR DESCRIPTION
SYCL_DISABLE_STL_ASSERTIONS=ON

Unless we maintain our own STL for SYCL we can't know the visibility of the internal assertion mechanism of libstdc++ and friends.

This caused random-looking build failures in device code for which we have no reliable method of avoision when I adopted gcc12.2.

