### PR TITLE
[NFCI] Move reductions implementation from handler.hpp to reduction.hpp

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -293,9 +293,8 @@ template <typename KernelName, int Dims, typename PropertiesT,
           typename KernelType, typename Reduction>
 void reduction_parallel_for(handler &CGH,
                             std::shared_ptr<detail::queue_impl> Queue,
-                            nd_range<Dims> Range,
-                            PropertiesT Properties, Reduction Redu,
-                            KernelType KernelFunc);
+                            nd_range<Dims> Range, PropertiesT Properties,
+                            Reduction Redu, KernelType KernelFunc);
 
 template <typename KernelName, int Dims, typename PropertiesT,
           typename... RestT>
@@ -2077,7 +2076,7 @@ public:
       (sizeof...(RestT) > 1) &&
       detail::AreAllButLastReductions<RestT...>::value &&
       ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  parallel_for(nd_range<Dims> Range, PropertiesT Properties, RestT &&... Rest) {
+  parallel_for(nd_range<Dims> Range, PropertiesT Properties, RestT &&...Rest) {
     detail::reduction_parallel_for<KernelName>(*this, MQueue, Range, Properties,
                                                std::forward<RestT>(Rest)...);
   }
@@ -2085,7 +2084,7 @@ public:
   template <typename KernelName = detail::auto_name, int Dims,
             typename... RestT>
   std::enable_if_t<detail::AreAllButLastReductions<RestT...>::value>
-  parallel_for(nd_range<Dims> Range, RestT &&... Rest) {
+  parallel_for(nd_range<Dims> Range, RestT &&...Rest) {
     parallel_for<KernelName>(
         Range, ext::oneapi::experimental::detail::empty_properties_t{},
         std::forward<RestT>(Rest)...);

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -304,6 +304,13 @@ void reduction_parallel_for(handler &CGH,
                             nd_range<Dims> Range, PropertiesT Properties,
                             RestT... Rest);
 
+template <typename KernelName, int Dims, typename PropertiesT,
+          typename KernelType, typename Reduction>
+void reduction_parallel_for_basic_impl(
+    handler &CGH, std::shared_ptr<detail::queue_impl> Queue,
+    nd_range<Dims> Range, PropertiesT Properties, Reduction Redu,
+    KernelType KernelFunc);
+
 // Kernels with single reduction
 
 /// If we are given sycl::range and not sycl::nd_range we have more freedom in
@@ -1804,7 +1811,8 @@ public:
     if constexpr (!Reduction::has_fast_atomics &&
                   !Reduction::has_float64_atomics) {
       // The most basic implementation.
-      parallel_for_basic_impl<KernelName>(Range, Properties, Redu, KernelFunc);
+      detail::reduction_parallel_for_basic_impl<KernelName>(
+          *this, MQueue, Range, Properties, Redu, KernelFunc);
       return;
     } else { // Can't "early" return for "if constexpr".
       if constexpr (Reduction::has_float64_atomics) {
@@ -1821,8 +1829,8 @@ public:
                                                  Properties, Redu);
         } else {
           // Resort to basic implementation as well.
-          parallel_for_basic_impl<KernelName>(Range, Properties, Redu,
-                                              KernelFunc);
+          detail::reduction_parallel_for_basic_impl<KernelName>(
+              *this, MQueue, Range, Properties, Redu, KernelFunc);
           return;
         }
       } else {
@@ -1845,79 +1853,6 @@ public:
           detail::reduSaveFinalResultToUserMem<KernelName>(CopyHandler, Redu);
         });
       }
-    }
-  }
-
-  template <typename KernelName, int Dims, typename PropertiesT,
-            typename KernelType, typename Reduction>
-  std::enable_if_t<
-      detail::IsReduction<Reduction>::value &&
-      ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  parallel_for_basic_impl(nd_range<Dims> Range, PropertiesT Properties,
-                          Reduction Redu, KernelType KernelFunc) {
-    // This parallel_for() is lowered to the following sequence:
-    // 1) Call a kernel that a) call user's lambda function and b) performs
-    //    one iteration of reduction, storing the partial reductions/sums
-    //    to either a newly created global buffer or to user's reduction
-    //    accessor. So, if the original 'Range' has totally
-    //    N1 elements and work-group size is W, then after the first iteration
-    //    there will be N2 partial sums where N2 = N1 / W.
-    //    If (N2 == 1) then the partial sum is written to user's accessor.
-    //    Otherwise, a new global buffer is created and partial sums are written
-    //    to it.
-    // 2) Call an aux kernel (if necessary, i.e. if N2 > 1) as many times as
-    //    necessary to reduce all partial sums into one final sum.
-
-    // Before running the kernels, check that device has enough local memory
-    // to hold local arrays that may be required for the reduction algorithm.
-    // TODO: If the work-group-size is limited by the local memory, then
-    // a special version of the main kernel may be created. The one that would
-    // not use local accessors, which means it would not do the reduction in
-    // the main kernel, but simply generate Range.get_global_range.size() number
-    // of partial sums, leaving the reduction work to the additional/aux
-    // kernels.
-    constexpr bool HFR = Reduction::has_fast_reduce;
-    size_t OneElemSize = HFR ? 0 : sizeof(typename Reduction::result_type);
-    // TODO: currently the maximal work group size is determined for the given
-    // queue/device, while it may be safer to use queries to the kernel compiled
-    // for the device.
-    size_t MaxWGSize = detail::reduGetMaxWGSize(MQueue, OneElemSize);
-    if (Range.get_local_range().size() > MaxWGSize)
-      throw sycl::runtime_error("The implementation handling parallel_for with"
-                                " reduction requires work group size not bigger"
-                                " than " +
-                                    std::to_string(MaxWGSize),
-                                PI_ERROR_INVALID_WORK_GROUP_SIZE);
-
-    // 1. Call the kernel that includes user's lambda function.
-    detail::reduCGFunc<KernelName>(*this, KernelFunc, Range, Properties, Redu);
-    this->finalize();
-
-    // 2. Run the additional kernel as many times as needed to reduce
-    // all partial sums into one scalar.
-
-    // TODO: Create a special slow/sequential version of the kernel that would
-    // handle the reduction instead of reporting an assert below.
-    if (MaxWGSize <= 1)
-      throw sycl::runtime_error("The implementation handling parallel_for with "
-                                "reduction requires the maximal work group "
-                                "size to be greater than 1 to converge. "
-                                "The maximal work group size depends on the "
-                                "device and the size of the objects passed to "
-                                "the reduction.",
-                                PI_ERROR_INVALID_WORK_GROUP_SIZE);
-    size_t NWorkItems = Range.get_group_range().size();
-    while (NWorkItems > 1) {
-      withAuxHandler([&](handler &AuxHandler) {
-        NWorkItems = detail::reduAuxCGFunc<KernelName, KernelType>(
-            AuxHandler, NWorkItems, MaxWGSize, Redu);
-      });
-    } // end while (NWorkItems > 1)
-
-    if (Reduction::is_usm) {
-      withAuxHandler([&](handler &CopyHandler) {
-        detail::reduSaveFinalResultToUserMem<KernelName>(CopyHandler, Redu);
-      });
     }
   }
 


### PR DESCRIPTION
This is done by limiting friend access to `sycl::handler` to two helper functions:

  - `sycl::detail::reduction::finalizeHandler`
  - `sycl::detail::reduction::withAuxHandler`

so that rest of the code could be moved out of handler.hpp.