### PR TITLE
[SYCL] Keep the original ordering of devices during uniquifying

### DIFF
--- a/sycl/source/kernel_bundle.cpp
+++ b/sycl/source/kernel_bundle.cpp
@@ -115,13 +115,13 @@ bool kernel_bundle_plain::is_specialization_constant_set(
 
 const std::vector<device>
 removeDuplicateDevices(const std::vector<device> &Devs) {
-  auto compareDevices = [](device a, device b) {
-    return getSyclObjImpl(a) < getSyclObjImpl(b);
-  };
-  std::set<device, decltype(compareDevices)> UniqueDeviceSet(
-      Devs.begin(), Devs.end(), compareDevices);
-  std::vector<device> UniqueDevices(UniqueDeviceSet.begin(),
-                                    UniqueDeviceSet.end());
+  std::vector<device> UniqueDevices;
+
+  // Building a new vector with unique elements and keep original order
+  std::unordered_set<device> UniqueDeviceSet;
+  for (const device &Dev : Devs)
+    if (UniqueDeviceSet.insert(Dev).second)
+      UniqueDevices.push_back(Dev);
 
   return UniqueDevices;
 }


### PR DESCRIPTION
While it might be a little bit slower in general, in our
case the number of elements should be small, so it
shouldn't cause any noticeable perf impact.

This should help us to get more stable results in our tests.