### PR TITLE
[SYCL-MLIR] Handle `__builtin_assume`

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -630,6 +630,13 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *expr) {
     return val;
   };
 
+  switch (expr->getBuiltinCallee()) {
+  case clang::Builtin::BI__builtin_assume:
+    mlir::Value V0 = getLLVM(expr->getArg(0));
+    return ValueCategory(builder.create<LLVM::AssumeOp>(loc, V0)->getResult(0),
+                         false);
+  };
+
   if (auto *ic = dyn_cast<ImplicitCastExpr>(expr->getCallee()))
     if (auto *sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
       if (sr->getDecl()->getIdentifier() &&

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1806,7 +1806,7 @@ ValueCategory MLIRScanner::VisitBinaryOperator(clang::BinaryOperator *BO) {
     } else {
       res = builder.create<arith::CmpIOp>(loc, IPred, lhs_v, rhs_v);
     }
-    return fixInteger(res);
+    return ValueCategory(res, /*isReference*/ false);
   }
 
   case clang::BinaryOperator::Opcode::BO_Comma: {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/parallel_for.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/parallel_for.cpp
@@ -10,7 +10,7 @@
 
 // Test that all referenced sycl header functions are generated.
 // RUN: llvm-dis %t.bc
-// RUN: cat %t.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func{{^__builtin_}}"
+// RUN: cat %t.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
 
 // Test that the kernel named `kernel_parallel_for` is generated with the correct signature.
 // LLVM: define weak_odr spir_kernel void {{.*}}kernel_parallel_for(
@@ -38,10 +38,7 @@ void host_parallel_for(std::array<int, N> &A) {
 }
 
 int main() {
-  std::array<int, N> A;
-  for (unsigned i = 0; i < N; ++i) {
-    A[i] = 0;
-  }
+  std::array<int, N> A{0};
   host_parallel_for(A);
   for (unsigned i = 0; i < N; ++i) {
     assert(A[i] == i);


### PR DESCRIPTION
Generate `LLVM::AssumeOp` for `BI__builtin_assume`.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>