### PR TITLE
[Driver][SYCL] Allow for -fcf-protection to run on host only

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -700,7 +700,8 @@ SYCLToolChain::SYCLToolChain(const Driver &D, const llvm::Triple &Triple,
 
   // Diagnose unsupported options only once.
   // All sanitizer options are not currently supported.
-  for (auto A : Args.filtered(options::OPT_fsanitize_EQ))
+  for (auto A :
+       Args.filtered(options::OPT_fsanitize_EQ, options::OPT_fcf_protection_EQ))
     D.getDiags().Report(clang::diag::warn_drv_unsupported_option_for_target)
         << A->getAsString(Args) << getTriple().str();
 }
@@ -725,6 +726,7 @@ SYCLToolChain::TranslateArgs(const llvm::opt::DerivedArgList &Args,
       // compilation.
       switch ((options::ID)A->getOption().getID()) {
       case options::OPT_fsanitize_EQ:
+      case options::OPT_fcf_protection_EQ:
         break;
       default:
         DAL->append(A);

--- a/clang/test/Driver/sycl-unsupported.cpp
+++ b/clang/test/Driver/sycl-unsupported.cpp
@@ -1,10 +1,20 @@
 /// Diagnose unsupported options specific to SYCL compilations
 // RUN: %clangxx -fsycl -fsanitize=address -fsycl-targets=spir64 -### %s 2>&1 \
-// RUN:  | FileCheck %s --check-prefix=SANITIZE -DARCH=spir64
+// RUN:  | FileCheck %s -DARCH=spir64 -DOPT=-fsanitize=address
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -fsanitize=address -### %s 2>&1 \
-// RUN:  | FileCheck %s --check-prefix=SANITIZE -DARCH=spir64_gen
+// RUN:  | FileCheck %s -DARCH=spir64_gen -DOPT=-fsanitize=address
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_fpga -fsanitize=address -### %s 2>&1 \
-// RUN:  | FileCheck %s --check-prefix=SANITIZE -DARCH=spir64_fpga
+// RUN:  | FileCheck %s -DARCH=spir64_fpga -DOPT=-fsanitize=address
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fsanitize=address -### %s 2>&1 \
-// RUN:  | FileCheck %s --check-prefix=SANITIZE -DARCH=spir64_x86_64
-// SANITIZE: ignoring '-fsanitize=address' option as it is not currently supported for target '[[ARCH]]{{.*}}' [-Woption-ignored]
+// RUN:  | FileCheck %s -DARCH=spir64_x86_64 -DOPT=-fsanitize=address
+
+// RUN: %clangxx -fsycl -fcf-protection -fsycl-targets=spir64 -### %s 2>&1 \
+// RUN:  | FileCheck %s -DARCH=spir64 -DOPT=-fcf-protection
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -fcf-protection -### %s 2>&1 \
+// RUN:  | FileCheck %s -DARCH=spir64_gen -DOPT=-fcf-protection
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_fpga -fcf-protection -### %s 2>&1 \
+// RUN:  | FileCheck %s -DARCH=spir64_fpga -DOPT=-fcf-protection
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fcf-protection -### %s 2>&1 \
+// RUN:  | FileCheck %s -DARCH=spir64_x86_64 -DOPT=-fcf-protection
+
+// CHECK: ignoring '[[OPT]]' option as it is not currently supported for target '[[ARCH]]{{.*}}' [-Woption-ignored]


### PR DESCRIPTION
The -fcf-protection option is not supported for spir64 targets.  This causes an error during device compilation when compiled with -fsycl.  Allow the option to be accepted and work on the host compilation side only, emitting a diagnostic that the option is being ignored for the target compiles.

before: clang++ -fsycl -fcf-protection -c a.cpp
error: option 'cf-protection=return' cannot be specified on this target error: option 'cf-protection=branch' cannot be specified on this target 2 errors generated.

after: clang++ -fsycl -fcf-protection -c a.cpp
clang-16: warning: ignoring '-fcf-protection' option as it is not currently supported for target 'spir64-unknown-unknown' [-Woption-ignored]