### PR TITLE
[SYCL-MLIR][NFC] Use `clang::Builtin` enum when possible

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -954,145 +954,100 @@ MLIRScanner::EmitBuiltinOps(clang::CallExpr *expr) {
             true);
       }
 
+  std::vector<mlir::Value> args;
+  auto VisitArgs = [&]() {
+    assert(args.empty() && "Expecting empty args");
+    for (auto a : expr->arguments())
+      args.push_back(Visit(a).getValue(builder));
+  };
   Optional<Value> V = None;
   switch (expr->getBuiltinCallee()) {
   case Builtin::BIceil: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     V = builder.create<math::CeilOp>(loc, args[0]);
   } break;
   case Builtin::BIcos: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     V = builder.create<mlir::math::CosOp>(loc, args[0]);
   } break;
   case Builtin::BIexp:
   case Builtin::BIexpf: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     V = builder.create<mlir::math::ExpOp>(loc, args[0]);
   } break;
   case Builtin::BIlog: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     V = builder.create<mlir::math::LogOp>(loc, args[0]);
   } break;
   case Builtin::BIsin: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     V = builder.create<mlir::math::SinOp>(loc, args[0]);
   } break;
   case Builtin::BIsqrt:
   case Builtin::BIsqrtf: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     V = builder.create<mlir::math::SqrtOp>(loc, args[0]);
   } break;
   case Builtin::BI__builtin_atanh:
   case Builtin::BI__builtin_atanhf:
   case Builtin::BI__builtin_atanhl: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     V = builder.create<math::AtanOp>(loc, args[0]);
   } break;
   case Builtin::BI__builtin_copysign:
   case Builtin::BI__builtin_copysignf:
   case Builtin::BI__builtin_copysignl: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     V = builder.create<LLVM::CopySignOp>(loc, args[0], args[1]);
   } break;
   case Builtin::BI__builtin_exp2:
   case Builtin::BI__builtin_exp2f:
   case Builtin::BI__builtin_exp2l: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     V = builder.create<math::Exp2Op>(loc, args[0]);
   } break;
   case Builtin::BI__builtin_expm1:
   case Builtin::BI__builtin_expm1f:
   case Builtin::BI__builtin_expm1l: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     V = builder.create<math::ExpM1Op>(loc, args[0]);
   } break;
   case Builtin::BI__builtin_fma:
   case Builtin::BI__builtin_fmaf:
   case Builtin::BI__builtin_fmal: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     V = builder.create<LLVM::FMAOp>(loc, args[0], args[1], args[2]);
   } break;
   case Builtin::BI__builtin_fmax:
   case Builtin::BI__builtin_fmaxf:
   case Builtin::BI__builtin_fmaxl: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     V = builder.create<LLVM::MaxNumOp>(loc, args[0], args[1]);
   } break;
   case Builtin::BI__builtin_fmin:
   case Builtin::BI__builtin_fminf:
   case Builtin::BI__builtin_fminl: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     V = builder.create<LLVM::MinNumOp>(loc, args[0], args[1]);
   } break;
   case Builtin::BI__builtin_log1p:
   case Builtin::BI__builtin_log1pf:
   case Builtin::BI__builtin_log1pl: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     V = builder.create<math::Log1pOp>(loc, args[0]);
   } break;
   case Builtin::BI__builtin_pow:
   case Builtin::BI__builtin_powf:
   case Builtin::BI__builtin_powl: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     V = builder.create<math::PowFOp>(loc, args[0], args[1]);
   } break;
   case Builtin::BI__builtin_assume: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     V = builder.create<LLVM::AssumeOp>(loc, args[0])->getResult(0);
   } break;
   case Builtin::BI__builtin_isgreater: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     auto postTy =
         Glob.getTypes().getMLIRType(expr->getType()).cast<mlir::IntegerType>();
     V = builder.create<ExtUIOp>(
@@ -1100,10 +1055,7 @@ MLIRScanner::EmitBuiltinOps(clang::CallExpr *expr) {
         builder.create<CmpFOp>(loc, CmpFPredicate::OGT, args[0], args[1]));
   } break;
   case Builtin::BI__builtin_isgreaterequal: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     auto postTy =
         Glob.getTypes().getMLIRType(expr->getType()).cast<mlir::IntegerType>();
     V = builder.create<ExtUIOp>(
@@ -1111,10 +1063,7 @@ MLIRScanner::EmitBuiltinOps(clang::CallExpr *expr) {
         builder.create<CmpFOp>(loc, CmpFPredicate::OGE, args[0], args[1]));
   } break;
   case Builtin::BI__builtin_isless: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     auto postTy =
         Glob.getTypes().getMLIRType(expr->getType()).cast<mlir::IntegerType>();
     V = builder.create<ExtUIOp>(
@@ -1122,10 +1071,7 @@ MLIRScanner::EmitBuiltinOps(clang::CallExpr *expr) {
         builder.create<CmpFOp>(loc, CmpFPredicate::OLT, args[0], args[1]));
   } break;
   case Builtin::BI__builtin_islessequal: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     auto postTy =
         Glob.getTypes().getMLIRType(expr->getType()).cast<mlir::IntegerType>();
     V = builder.create<ExtUIOp>(
@@ -1133,10 +1079,7 @@ MLIRScanner::EmitBuiltinOps(clang::CallExpr *expr) {
         builder.create<CmpFOp>(loc, CmpFPredicate::OLE, args[0], args[1]));
   } break;
   case Builtin::BI__builtin_islessgreater: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     auto postTy =
         Glob.getTypes().getMLIRType(expr->getType()).cast<mlir::IntegerType>();
     V = builder.create<ExtUIOp>(
@@ -1144,10 +1087,7 @@ MLIRScanner::EmitBuiltinOps(clang::CallExpr *expr) {
         builder.create<CmpFOp>(loc, CmpFPredicate::ONE, args[0], args[1]));
   } break;
   case Builtin::BI__builtin_isunordered: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     auto postTy =
         Glob.getTypes().getMLIRType(expr->getType()).cast<mlir::IntegerType>();
     V = builder.create<ExtUIOp>(
@@ -1156,10 +1096,7 @@ MLIRScanner::EmitBuiltinOps(clang::CallExpr *expr) {
   } break;
   case Builtin::BImemmove:
   case Builtin::BI__builtin_memmove: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     builder.create<LLVM::MemmoveOp>(
         loc, args[0], args[1], args[2],
         /*isVolatile*/ builder.create<ConstantIntOp>(loc, false, 1));
@@ -1167,10 +1104,7 @@ MLIRScanner::EmitBuiltinOps(clang::CallExpr *expr) {
   } break;
   case Builtin::BImemset:
   case Builtin::BI__builtin_memset: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     builder.create<LLVM::MemsetOp>(
         loc, args[0],
         builder.create<TruncIOp>(loc, builder.getI8Type(), args[1]), args[2],
@@ -1179,10 +1113,7 @@ MLIRScanner::EmitBuiltinOps(clang::CallExpr *expr) {
   } break;
   case Builtin::BImemcpy:
   case Builtin::BI__builtin_memcpy: {
-    std::vector<mlir::Value> args;
-    for (auto a : expr->arguments()) {
-      args.push_back(Visit(a).getValue(builder));
-    }
+    VisitArgs();
     builder.create<LLVM::MemcpyOp>(
         loc, args[0], args[1], args[2],
         /*isVolatile*/ builder.create<ConstantIntOp>(loc, false, 1));


### PR DESCRIPTION
1. Used  `clang::Builtin` enum instead of string comparison when possible
2. Moved some builtin handling to `EmitBuiltinOps()`
3. Refactored `EmitBuiltinOps()`

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>