### PR TITLE
[SYCL] Fix post-commit failures

### DIFF
--- a/sycl/unittests/assert/assert.cpp
+++ b/sycl/unittests/assert/assert.cpp
@@ -290,7 +290,7 @@ static pi_result redefinedKernelGetInfo(pi_kernel Kernel,
     pi_program PIProgram = nullptr;
     pi_result Res = mock_piProgramCreate(/*pi_context=*/0x0, /**il*/ nullptr,
                                          /*length=*/0, &PIProgram);
-    assert(PI_SUCCESS == Res);
+    EXPECT_TRUE(PI_SUCCESS == Res);
 
     if (ParamValue)
       memcpy(ParamValue, &PIProgram, sizeof(PIProgram));
@@ -553,7 +553,7 @@ TEST(Assert, TestInteropKernelNegative) {
 
   pi_result Res = mock_piKernelCreate(
       /*pi_program=*/0x0, /*kernel_name=*/"dummy_kernel", &PIKernel);
-  assert(PI_SUCCESS == Res);
+  EXPECT_TRUE(PI_SUCCESS == Res);
 
   // TODO use make_kernel. This requires a fix in backend.cpp to get plugin
   // from context instead of free getPlugin to alllow for mocking of its methods

--- a/sycl/unittests/helpers/PiMock.hpp
+++ b/sycl/unittests/helpers/PiMock.hpp
@@ -139,6 +139,7 @@ inline void clearRedefinedCalls() {
   for (size_t I = 0; I < CallStackSize; ++I) {
 #define _PI_API(api)                                                           \
   CallBefore_##api[I] = nullptr;                                               \
+  CallOriginal_##api = mock_##api;                                             \
   CallAfter_##api[I] = nullptr;
 #include <sycl/detail/pi.def>
 #undef _PI_API

--- a/sycl/unittests/queue/DeviceCheck.cpp
+++ b/sycl/unittests/queue/DeviceCheck.cpp
@@ -20,19 +20,6 @@ namespace {
 inline constexpr auto EnableDefaultContextsName =
     "SYCL_ENABLE_DEFAULT_CONTEXTS";
 
-pi_result redefinedContextCreate(const pi_context_properties *properties,
-                                 pi_uint32 num_devices,
-                                 const pi_device *devices,
-                                 void (*pfn_notify)(const char *errinfo,
-                                                    const void *private_info,
-                                                    size_t cb, void *user_data),
-                                 void *user_data, pi_context *ret_context) {
-  *ret_context = reinterpret_cast<pi_context>(1);
-  return PI_SUCCESS;
-}
-
-pi_result redefinedContextRelease(pi_context context) { return PI_SUCCESS; }
-
 pi_device ParentDevice = nullptr;
 pi_platform PiPlatform = nullptr;
 
@@ -66,7 +53,7 @@ pi_result redefinedDeviceGetInfoAfter(pi_device device,
   return PI_SUCCESS;
 }
 
-pi_result redefinedDevicePartition(
+pi_result redefinedDevicePartitionAfter(
     pi_device device, const pi_device_partition_property *properties,
     pi_uint32 num_devices, pi_device *out_devices, pi_uint32 *out_num_devices) {
   if (out_devices) {
@@ -78,18 +65,6 @@ pi_result redefinedDevicePartition(
     *out_num_devices = num_devices;
   return PI_SUCCESS;
 }
-
-pi_result redefinedDeviceRetain(pi_device device) { return PI_SUCCESS; }
-
-pi_result redefinedDeviceRelease(pi_device device) { return PI_SUCCESS; }
-
-pi_result redefinedQueueCreate(pi_context context, pi_device device,
-                               pi_queue_properties properties,
-                               pi_queue *queue) {
-  return PI_SUCCESS;
-}
-
-pi_result redefinedQueueRelease(pi_queue queue) { return PI_SUCCESS; }
 
 // Check that the device is verified to be either a member of the context or a
 // descendant of its member.
@@ -105,19 +80,10 @@ TEST(QueueDeviceCheck, CheckDeviceRestriction) {
   context DefaultCtx = Plt.ext_oneapi_get_default_context();
   device Dev = DefaultCtx.get_devices()[0];
 
-  Mock.redefineBefore<detail::PiApiKind::piContextCreate>(
-      redefinedContextCreate);
-  Mock.redefineBefore<detail::PiApiKind::piContextRelease>(
-      redefinedContextRelease);
   Mock.redefineAfter<detail::PiApiKind::piDeviceGetInfo>(
       redefinedDeviceGetInfoAfter);
-  Mock.redefineBefore<detail::PiApiKind::piDevicePartition>(
-      redefinedDevicePartition);
-  Mock.redefineBefore<detail::PiApiKind::piDeviceRelease>(
-      redefinedDeviceRelease);
-  Mock.redefineBefore<detail::PiApiKind::piDeviceRetain>(redefinedDeviceRetain);
-  Mock.redefineBefore<detail::PiApiKind::piQueueCreate>(redefinedQueueCreate);
-  Mock.redefineBefore<detail::PiApiKind::piQueueRelease>(redefinedQueueRelease);
+  Mock.redefineAfter<detail::PiApiKind::piDevicePartition>(
+      redefinedDevicePartitionAfter);
 
   // Device is a member of the context.
   {

--- a/sycl/unittests/scheduler/Commands.cpp
+++ b/sycl/unittests/scheduler/Commands.cpp
@@ -65,7 +65,7 @@ TEST_F(SchedulerTest, WaitEmptyEventWithBarrier) {
 
   pi_event PIEvent = nullptr;
   pi_result Res = mock_piEventCreate(/*context = */ (pi_context)0x1, &PIEvent);
-  assert(PI_SUCCESS == Res);
+  EXPECT_TRUE(PI_SUCCESS == Res);
 
   auto Event =
       std::make_shared<detail::event_impl>(PIEvent, Queue.get_context());

--- a/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
+++ b/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
@@ -34,10 +34,10 @@ struct TestCtx {
         Ctx2{detail::getSyclObjImpl(Q2.get_context())} {
 
     pi_result Res = mock_piEventCreate((pi_context)0x0, &EventCtx1);
-    assert(PI_SUCCESS == Res);
+    EXPECT_TRUE(PI_SUCCESS == Res);
 
     Res = mock_piEventCreate((pi_context)0x0, &EventCtx2);
-    assert(PI_SUCCESS == Res);
+    EXPECT_TRUE(PI_SUCCESS == Res);
   }
 };
 

--- a/sycl/unittests/scheduler/NoHostUnifiedMemory.cpp
+++ b/sycl/unittests/scheduler/NoHostUnifiedMemory.cpp
@@ -205,7 +205,7 @@ TEST_F(SchedulerTest, NoHostUnifiedMemory) {
     pi_result PIRes = mock_piMemBufferCreate(
         /*pi_context=*/0x0, /*pi_mem_flags=*/PI_MEM_FLAGS_ACCESS_RW, /*size=*/1,
         /*host_ptr=*/nullptr, &MockInteropBuffer);
-    assert(PI_SUCCESS == PIRes);
+    EXPECT_TRUE(PI_SUCCESS == PIRes);
 
     context InteropContext = Q.get_context();
     InteropPiContext = detail::getSyclObjImpl(InteropContext)->getHandleRef();

--- a/sycl/unittests/scheduler/QueueFlushing.cpp
+++ b/sycl/unittests/scheduler/QueueFlushing.cpp
@@ -54,7 +54,7 @@ static void addDepAndEnqueue(detail::Command *Cmd,
 
   pi_event PIEvent = nullptr;
   pi_result CallRet = mock_piEventCreate(/*pi_context=*/0x0, &PIEvent);
-  assert(PI_SUCCESS == CallRet);
+  EXPECT_TRUE(PI_SUCCESS == CallRet);
 
   DepCmd.getEvent()->getHandleRef() = PIEvent;
   (void)Cmd->addDep(detail::DepDesc{&DepCmd, &MockReq, nullptr}, ToCleanUp);
@@ -104,7 +104,7 @@ TEST_F(SchedulerTest, QueueFlushing) {
   pi_result Ret = mock_piMemBufferCreate(/*pi_context=*/0x0,
                                          PI_MEM_FLAGS_ACCESS_RW, /*size=*/1,
                                          /*host_ptr=*/nullptr, &PIBuf);
-  assert(Ret == PI_SUCCESS);
+  EXPECT_TRUE(Ret == PI_SUCCESS);
 
   detail::AllocaCommand AllocaCmd = detail::AllocaCommand(QueueImplA, MockReq);
   AllocaCmd.MMemAllocation = PIBuf;
@@ -162,7 +162,7 @@ TEST_F(SchedulerTest, QueueFlushing) {
 
     pi_event PIEvent = nullptr;
     pi_result CallRet = mock_piEventCreate(/*pi_context=*/0x0, &PIEvent);
-    assert(PI_SUCCESS == CallRet);
+    EXPECT_TRUE(PI_SUCCESS == CallRet);
 
     DepEvent->getHandleRef() = PIEvent;
     (void)Cmd.addDep(DepEvent, ToCleanUp);
@@ -184,7 +184,7 @@ TEST_F(SchedulerTest, QueueFlushing) {
 
       pi_event PIEvent = nullptr;
       pi_result CallRet = mock_piEventCreate(/*pi_context=*/0x0, &PIEvent);
-      assert(PI_SUCCESS == CallRet);
+      EXPECT_TRUE(PI_SUCCESS == CallRet);
 
       DepEvent->getHandleRef() = PIEvent;
     }
@@ -210,7 +210,7 @@ TEST_F(SchedulerTest, QueueFlushing) {
 
     pi_event PIEvent = nullptr;
     pi_result CallRet = mock_piEventCreate(/*pi_context=*/0x0, &PIEvent);
-    assert(PI_SUCCESS == CallRet);
+    EXPECT_TRUE(PI_SUCCESS == CallRet);
 
     DepCmdA.getEvent()->getHandleRef() = PIEvent;
     (void)Cmd.addDep(detail::DepDesc{&DepCmdA, &MockReq, nullptr}, ToCleanUp);
@@ -218,7 +218,7 @@ TEST_F(SchedulerTest, QueueFlushing) {
 
     PIEvent = nullptr;
     CallRet = mock_piEventCreate(/*pi_context=*/0x0, &PIEvent);
-    assert(PI_SUCCESS == CallRet);
+    EXPECT_TRUE(PI_SUCCESS == CallRet);
 
     DepCmdB.getEvent()->getHandleRef() = PIEvent;
     (void)Cmd.addDep(detail::DepDesc{&DepCmdB, &MockReq, nullptr}, ToCleanUp);
@@ -235,7 +235,7 @@ TEST_F(SchedulerTest, QueueFlushing) {
 
     pi_event PIEvent = nullptr;
     pi_result CallRet = mock_piEventCreate(/*pi_context=*/0x0, &PIEvent);
-    assert(PI_SUCCESS == CallRet);
+    EXPECT_TRUE(PI_SUCCESS == CallRet);
 
     DepCmd.getEvent()->getHandleRef() = PIEvent;
     (void)CmdA.addDep(detail::DepDesc{&DepCmd, &MockReq, nullptr}, ToCleanUp);


### PR DESCRIPTION
1. Replaced assert with EXPECT_EQ to avoid unused variable error
2. Fully reset PI mock functions
3. Update new test to use new PI mock utility API