### PR TITLE
[SYCL] fix for kernel_work_group_size_hint test on Windows

### DIFF
--- a/sycl/test/extensions/properties/properties_kernel_work_group_size_hint.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_work_group_size_hint.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl-device-only -S -Xclang -emit-llvm %s -o - | FileCheck %s --check-prefix CHECK-IR
-// RUN: %clangxx -fsycl -Xclang -verify %s
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
 // expected-no-diagnostics
 
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
don't need to build to verify. also confuses windows run of tests.