### PR TITLE
[SYCL][LIT] Remove sycl tests from check-all in Windows Debug mode

### DIFF
--- a/sycl/test/CMakeLists.txt
+++ b/sycl/test/CMakeLists.txt
@@ -42,6 +42,13 @@ list(APPEND SYCL_DEPLOY_TEST_DEPS
   deploy-sycl-toolchain
   )
 
+set(SYCL_TEST_EXCLUDE "")
+if (WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  # Debug compiler on Windows is very slow, tests may timeout sporadically
+  set(SYCL_TEST_EXCLUDE EXCLUDE_FROM_CHECK_ALL)
+  message(STATUS "Note: SYCL tests are excluded in check-all for Debug compiler on Windows")
+endif()
+
 add_lit_testsuite(check-sycl-deploy "Running the SYCL regression tests"
   ${CMAKE_CURRENT_BINARY_DIR}
   ARGS ${DEPLOY_RT_TEST_ARGS}
@@ -56,6 +63,7 @@ add_lit_testsuite(check-sycl-spirv "Running device-agnostic SYCL regression test
   ARGS ${RT_TEST_ARGS}
   PARAMS "SYCL_TRIPLE=spir64-unknown-unknown"
   DEPENDS ${SYCL_TEST_DEPS}
+  ${SYCL_TEST_EXCLUDE}
   )
 
 add_custom_target(check-sycl)
@@ -68,6 +76,7 @@ if(SYCL_BUILD_PI_CUDA)
     ARGS ${RT_TEST_ARGS}
     PARAMS "SYCL_TRIPLE=nvptx64-nvidia-cuda;SYCL_PLUGIN=cuda"
     DEPENDS ${SYCL_TEST_DEPS}
+    ${SYCL_TEST_EXCLUDE}
   )
 
   add_custom_target(check-sycl-cuda)
@@ -83,6 +92,7 @@ if(SYCL_BUILD_PI_HIP)
       ARGS ${RT_TEST_ARGS}
       PARAMS "SYCL_TRIPLE=nvptx64-nvidia-cuda;SYCL_PLUGIN=hip"
       DEPENDS ${SYCL_TEST_DEPS}
+      ${SYCL_TEST_EXCLUDE}
     )
 
     add_dependencies(check-sycl-hip check-sycl-hip-ptx)
@@ -92,6 +102,7 @@ if(SYCL_BUILD_PI_HIP)
       ARGS ${RT_TEST_ARGS}
       PARAMS "SYCL_TRIPLE=amdgcn-amd-amdhsa;SYCL_PLUGIN=hip"
       DEPENDS ${SYCL_TEST_DEPS}
+      ${SYCL_TEST_EXCLUDE}
     )
 
     add_dependencies(check-sycl-hip check-sycl-hip-gcn)


### PR DESCRIPTION
They are extremely slow for Windows Debug compiler and sporadically timeout.
It would be still possible to run these through check-sycl target.

This is NFC for Github Actions CI since we don't use check-all and call all targets separately.