### PR TITLE
[SYCL-MLIR] Promote F16 to F32 before arithmetic binary operations

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -2340,6 +2340,7 @@ private:
 };
 
 ValueCategory MLIRScanner::EmitPromoted(Expr *E, QualType PromotionType) {
+  assert(E && "Invalid input expression.");
   E = E->IgnoreParens();
   if (auto *BO = dyn_cast<BinaryOperator>(E)) {
     switch (BO->getOpcode()) {

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -9,6 +9,7 @@
 #include "clang-mlir.h"
 #include "utils.h"
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/WithColor.h"
 
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"
 #include "mlir/Dialect/SYCL/IR/SYCLOpsDialect.h"

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1906,5 +1906,18 @@ bool CodeGenTypes::getCPUAndFeaturesAttributes(
   return AddedAttr;
 }
 
+QualType CodeGenTypes::getPromotionType(QualType Ty) const {
+  if (CGM.getTarget().shouldEmitFloat16WithExcessPrecision()) {
+    if (Ty->isAnyComplexType()) {
+      QualType ElementType = Ty->castAs<clang::ComplexType>()->getElementType();
+      if (ElementType->isFloat16Type())
+        return CGM.getContext().getComplexType(CGM.getContext().FloatTy);
+    }
+    if (Ty->isFloat16Type())
+      return CGM.getContext().FloatTy;
+  }
+  return QualType();
+}
+
 } // namespace CodeGen
 } // namespace mlirclang

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.h
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.h
@@ -94,7 +94,6 @@ public:
   static bool IsLLVMStructABI(const clang::RecordDecl *RD,
                               llvm::StructType *ST);
 
-
   clang::QualType getPromotionType(clang::QualType Ty) const;
 
 private:

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.h
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.h
@@ -94,6 +94,9 @@ public:
   static bool IsLLVMStructABI(const clang::RecordDecl *RD,
                               llvm::StructType *ST);
 
+
+  clang::QualType getPromotionType(clang::QualType Ty) const;
+
 private:
   void getDefaultFunctionAttributes(llvm::StringRef Name, bool HasOptnone,
                                     bool AttrOnCallSite,

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -273,12 +273,19 @@ void ValueCategory::store(mlir::OpBuilder &builder, ValueCategory toStore,
   }
 }
 
-#define UNCONSTRAINED_CAST(FuncName, Op)                                       \
-  ValueCategory ValueCategory::FuncName(OpBuilder &Builder,                    \
-                                        Type PromotionType) const {            \
-    llvm::WithColor::warning() << "Creating unconstrained " #Op "\n";          \
-    return Cast<arith::Op>(Builder, PromotionType);                            \
-  }
-UNCONSTRAINED_CAST(FPTrunc, TruncFOp)
-UNCONSTRAINED_CAST(FPExt, ExtFOp)
-#undef UNCONSTRAINED_CAST
+template <typename OpTy> inline void warnUnconstrainedCast() {
+  llvm::WithColor::warning()
+      << "Creating unconstrained " << OpTy::getOperationName() << "\n";
+}
+
+ValueCategory ValueCategory::FPTrunc(OpBuilder &Builder,
+                                     Type PromotionType) const {
+  warnUnconstrainedCast<arith::TruncFOp>();
+  return Cast<arith::TruncFOp>(Builder, PromotionType);
+}
+
+ValueCategory ValueCategory::FPExt(OpBuilder &Builder,
+                                   Type PromotionType) const {
+  warnUnconstrainedCast<arith::ExtFOp>();
+  return Cast<arith::ExtFOp>(Builder, PromotionType);
+}

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -16,6 +16,7 @@
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 #include "polygeist/Ops.h"
+#include "llvm/Support/WithColor.h"
 
 using namespace mlir;
 using namespace mlir::arith;

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -272,3 +272,13 @@ void ValueCategory::store(mlir::OpBuilder &builder, ValueCategory toStore,
     store(builder, toStore.getValue(builder));
   }
 }
+
+#define UNCONSTRAINED_CAST(FuncName, Op)                                       \
+  ValueCategory ValueCategory::FuncName(OpBuilder &Builder,                    \
+                                        Type PromotionType) const {            \
+    llvm::WithColor::warning() << "Creating unconstrained " #Op "\n";          \
+    return Cast<arith::Op>(Builder, PromotionType);                            \
+  }
+UNCONSTRAINED_CAST(FPTrunc, TruncFOp)
+UNCONSTRAINED_CAST(FPExt, ExtFOp)
+#undef UNCONSTRAINED_CAST

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -16,10 +16,7 @@
 
 // Represents a rhs or lhs value.
 class ValueCategory {
-public:
-  mlir::Value val;
-  bool isReference;
-
+private:
   template <typename OpTy>
   ValueCategory Cast(mlir::OpBuilder &builder, mlir::Type PromotionType) const {
     if (val.getType() == PromotionType)
@@ -27,6 +24,10 @@ public:
     return {builder.createOrFold<OpTy>(val.getLoc(), PromotionType, val),
             false};
   }
+
+public:
+  mlir::Value val;
+  bool isReference;
 
 public:
   ValueCategory() : val(nullptr), isReference(false) {}

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -21,8 +21,9 @@ private:
   ValueCategory Cast(mlir::OpBuilder &builder, mlir::Type PromotionType) const {
     if (val.getType() == PromotionType)
       return *this;
-    return {builder.createOrFold<OpTy>(val.getLoc(), PromotionType, val),
-            false};
+    return {
+        builder.createOrFold<OpTy>(builder.getUnknownLoc(), PromotionType, val),
+        false};
   }
 
 public:

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -9,14 +9,24 @@
 #ifndef CLANG_MLIR_VALUE_CATEGORY
 #define CLANG_MLIR_VALUE_CATEGORY
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Value.h"
+#include "llvm/Support/WithColor.h"
 
 // Represents a rhs or lhs value.
 class ValueCategory {
 public:
   mlir::Value val;
   bool isReference;
+
+  template <typename OpTy>
+  ValueCategory Cast(mlir::OpBuilder &builder, mlir::Type PromotionType) const {
+    if (val.getType() == PromotionType)
+      return *this;
+    return {builder.createOrFold<OpTy>(val.getLoc(), PromotionType, val),
+            false};
+  }
 
 public:
   ValueCategory() : val(nullptr), isReference(false) {}
@@ -30,6 +40,11 @@ public:
   // TODO: rename to storeVariable?
   void store(mlir::OpBuilder &builder, mlir::Value toStore) const;
   ValueCategory dereference(mlir::OpBuilder &builder) const;
+
+  ValueCategory FPTrunc(mlir::OpBuilder &builder,
+                        mlir::Type PromotionType) const;
+
+  ValueCategory FPExt(mlir::OpBuilder &builder, mlir::Type PromotionType) const;
 };
 
 #endif /* CLANG_MLIR_VALUE_CATEGORY */

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -12,7 +12,6 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Value.h"
-#include "llvm/Support/WithColor.h"
 
 // Represents a rhs or lhs value.
 class ValueCategory {

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -465,7 +465,17 @@ public:
 
   ValueCategory VisitBinaryOperator(clang::BinaryOperator *BO);
   ValueCategory VisitBinAssign(clang::BinaryOperator *BO);
-  BinOpInfo EmitBinOps(clang::BinaryOperator *E);
+
+  ValueCategory EmitPromoted(clang::Expr *E, clang::QualType PromotionType);
+  ValueCategory EmitPromotedScalarExpr(clang::Expr *E,
+                                       clang::QualType PromotionType);
+  ValueCategory EmitPromotedValue(ValueCategory Result,
+                                  clang::QualType PromotionType);
+  ValueCategory EmitUnPromotedValue(ValueCategory Result,
+                                    clang::QualType PromotionType);
+
+  BinOpInfo EmitBinOps(clang::BinaryOperator *E,
+                       clang::QualType PromotionTy = clang::QualType());
 #define HANDLEBINOP(OP)                                                        \
   ValueCategory EmitBin##OP(const BinOpInfo &E);                               \
   ValueCategory VisitBin##OP(clang::BinaryOperator *E);

--- a/polygeist/tools/cgeist/Test/Verification/float16.c
+++ b/polygeist/tools/cgeist/Test/Verification/float16.c
@@ -19,12 +19,18 @@ _Float16 type(_Float16 arg) {
 }
 
 // CHECK-EXTEND-LABEL:  func.func @arith(%arg0: f16, %arg1: f16, %arg2: f16, %arg3: f16, %arg4: f16) -> f16
-// CHECK-EXTEND-NEXT:     %[[ADD:.*]] = arith.addf %arg0, %arg1 : f16
+// CHECK-EXTEND-NEXT:     %[[EXT0:.*]] = arith.extf %arg0 : f16 to f32
+// CHECK-EXTEND-NEXT:     %[[EXT1:.*]] = arith.extf %arg1 : f16 to f32
+// CHECK-EXTEND-NEXT:     %[[ADD:.*]] = arith.addf %[[EXT0]], %[[EXT1]] : f32
+// CHECK-EXTEND-NEXT:     %[[EXT2:.*]] = arith.extf %arg2 : f16 to f32
 // CHECK-EXTEND-NEXT:     %[[NEG:.*]] = arith.negf %arg3 : f16
-// CHECK-EXTEND-NEXT:     %[[MUL:.*]] = arith.mulf %arg2, %[[NEG]] : f16
-// CHECK-EXTEND-NEXT:     %[[DIV:.*]] = arith.divf %[[MUL]], %arg4 : f16
-// CHECK-EXTEND-NEXT:     %[[SUB:.*]] = arith.subf %[[ADD]], %[[DIV]] : f16
-// CHECK-EXTEND-NEXT:     return %[[SUB]] : f16
+// CHECK-EXTEND-NEXT:     %[[EXTNEG:.*]] = arith.extf %[[NEG]] : f16 to f32
+// CHECK-EXTEND-NEXT:     %[[MUL:.*]] = arith.mulf %[[EXT2]], %[[EXTNEG]] : f32
+// CHECK-EXTEND-NEXT:     %[[EXT4:.*]] = arith.extf %arg4 : f16 to f32
+// CHECK-EXTEND-NEXT:     %[[DIV:.*]] = arith.divf %[[MUL]], %[[EXT4]] : f32
+// CHECK-EXTEND-NEXT:     %[[SUB:.*]] = arith.subf %[[ADD]], %[[DIV]] : f32
+// CHECK-EXTEND-NEXT:     %[[RES:.*]] = arith.truncf %[[SUB]] : f32 to f16
+// CHECK-EXTEND-NEXT:     return %[[RES]] : f16
 // CHECK-EXTEND-NEXT:   }
 
 // CHECK-NATIVE-LABEL:  func.func @arith(%arg0: f16, %arg1: f16, %arg2: f16, %arg3: f16, %arg4: f16) -> f16


### PR DESCRIPTION
If it is required by the target, extend arguments of F16 binary 
arithmetic operations before performing the operation and truncate
 their results afterwards.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>