### PR TITLE
[SYCL-MLIR] Use SmallString<0> to store arguments in ArgumentList

### DIFF
--- a/polygeist/tools/cgeist/Test/Verification/defines.c
+++ b/polygeist/tools/cgeist/Test/Verification/defines.c
@@ -1,0 +1,14 @@
+// RUN: cgeist -DPASS -DTEST0 -DTEST1 -DTEST2 %s -S -o -
+
+// CHECK-LABEL: func.func @main() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
+// CHECK-NEXT:    return %c0_i32 : i32
+// CHECK-NEXT:  }
+
+int main() {
+#ifdef PASS
+  return 0;
+#else
+  return 1;
+#endif
+}


### PR DESCRIPTION
std::string performs short string optimizations, so that moving an std::string might invalidate iterators to it. On the other hand, llvm::SmallString<0> is always heap-allocated, so moving does not involve invalidation.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>