### PR TITLE
[SYCL][NFC] Fix bug with dereference null return value

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3498,7 +3498,7 @@ public:
   bool enterArray(FieldDecl *FD, QualType ArrayType,
                   QualType ElementType) final {
     const ConstantArrayType *CAT =
-        SemaRef.getASTContext().getAsConstantArrayType(ArrayTy);
+        SemaRef.getASTContext().getAsConstantArrayType(ArrayType);
     assert(CAT && "Should only be called on constant-size array.");
     uint64_t ArraySize = CAT->getSize().getZExtValue();
     addCollectionInitListExpr(ArrayType, ArraySize);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -3497,10 +3497,10 @@ public:
 
   bool enterArray(FieldDecl *FD, QualType ArrayType,
                   QualType ElementType) final {
-    uint64_t ArraySize = SemaRef.getASTContext()
-                             .getAsConstantArrayType(ArrayType)
-                             ->getSize()
-                             .getZExtValue();
+    const ConstantArrayType *CAT =
+        SemaRef.getASTContext().getAsConstantArrayType(ArrayTy);
+    assert(CAT && "Should only be called on constant-size array.");
+    uint64_t ArraySize = CAT->getSize().getZExtValue();
     addCollectionInitListExpr(ArrayType, ArraySize);
     ArrayInfos.emplace_back(getFieldEntity(FD, ArrayType), 0);
 


### PR DESCRIPTION
Reported by static analyzer tool. 

Dereference null return value:

In <unnamed>::SyclKernelBodyCreator::enterArray(clang::FieldDecl *, clang::QualType, clang::QualType): Return value of function which returns null is dereferenced without checking 


bool enterArray(FieldDecl *FD, QualType ArrayType,
                  QualType ElementType) final {

   // returned_null: getAsConstantArrayType returns nullptr
   // identity_transfer: Member function call this->SemaRef->getASTContext()->getAsConstantArrayType(ArrayType)->getSize()
   // returns an offset off this->SemaRef->getASTContext()->getAsConstantArrayType(ArrayType) (this).

   // Dereference null return value (NULL_RETURNS) dereference: Dereferencing a pointer that might be nullptr
      this->SemaRef->getASTContext()->getAsConstantArrayType(ArrayType)->getSize() when calling getZExtValue

    uint64_t ArraySize = SemaRef.getASTContext()
                             .getAsConstantArrayType(ArrayType)
                             ->getSize()
                             .getZExtValue();
    addCollectionInitListExpr(ArrayType, ArraySize);
    ArrayInfos.emplace_back(getFieldEntity(FD, ArrayType), 0);

This patch updates the codes to resolve the bug.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>