### PR TITLE
[NFC][SYCL][Reduction] Call reduSaveFinalResultToUserMem once we know it's needed

### DIFF
--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -2345,9 +2345,8 @@ void reduction_parallel_for(handler &CGH,
           CGH, KernelFunc, Range, Properties, Redu);
     }
   } else {
-    reduction_parallel_for_basic_impl<KernelName>(CGH, Queue, Range, Properties,
-                                                  Redu, KernelFunc);
-    return;
+    return reduction_parallel_for_basic_impl<KernelName>(
+        CGH, Queue, Range, Properties, Redu, KernelFunc);
   }
 }
 


### PR DESCRIPTION
Previously we had to use a boolean return value to call it from the handler.hpp. Now private access to the sycl::handler is limited to a few helpers and we can call them immediately after realising the action is necessary.