### PR TITLE
[SYCL-MLIR] Add special casting to bool

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -2417,18 +2417,14 @@ ValueCategory MLIRScanner::EmitConversionToBool(ValueCategory Src,
                                                 QualType SrcType) {
   assert(SrcType.isCanonical() && "EmitScalarConversion strips typedefs");
   assert(!isa<MemberPointerType>(SrcType) && "Not implemented yet");
-  return TypeSwitch<mlir::Type, ValueCategory>(Src.val.getType())
-      .Case<FloatType>(
-          [this](auto Ty) { return EmitFloatToBoolConversion(Ty); })
-      .Case<IntegerType>(
-          [this](auto Ty) { return EmitIntToBoolConversion(Ty); })
-      .Case<LLVM::LLVMPointerType>(
-          [this](auto Ty) { return EmitPointerToBoolConversion(Ty); })
-      .Case<MemRefType>(
-          [this](auto Ty) { return EmitPointerToBoolConversion(Ty); })
-      .Default([](auto) -> ValueCategory {
-        llvm_unreachable("Unknown scalar type to convert");
-      });
+  const auto ValTy = Src.val.getType();
+  if (ValTy.isa<FloatType>())
+    return EmitFloatToBoolConversion(Src);
+  if (ValTy.isa<IntegerType>())
+    return EmitIntToBoolConversion(Src);
+  if (ValTy.isa<LLVM::LLVMPointerType, MemRefType>())
+    return EmitPointerToBoolConversion(Src);
+  llvm_unreachable("Unknown scalar type to convert");
 }
 
 ValueCategory

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -2418,19 +2418,17 @@ ValueCategory MLIRScanner::EmitConversionToBool(ValueCategory Src,
                                                 QualType SrcType) {
   assert(SrcType.isCanonical() && "EmitScalarConversion strips typedefs");
 
-  if (SrcType->isRealFloatingType())
+  const auto ValTy = Src.val.getType();
+  if (ValTy.isa<FloatType>())
     return EmitFloatToBoolConversion(Src);
 
   assert(!isa<MemberPointerType>(SrcType) && "Not implemented yet");
 
-  assert((SrcType->isIntegerType() ||
-          isa<MemRefType, LLVM::LLVMPointerType>(Src.val.getType())) &&
+  assert((ValTy.isa<IntegerType, MemRefType, LLVM::LLVMPointerType>()) &&
          "Unknown scalar type to convert");
 
-  if (SrcType->isIntegerType())
+  if (ValTy.isa<IntegerType>())
     return EmitIntToBoolConversion(Src);
-
-  assert((isa<MemRefType, LLVM::LLVMPointerType>(Src.val.getType())));
   return EmitPointerToBoolConversion(Src, SrcType);
 }
 

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -2388,12 +2388,12 @@ ValueCategory MLIRScanner::EmitPointerToBoolConversion(ValueCategory Src) {
           false};
 }
 
-ValueCategory MLIRScanner::EmitIntToBoolConversion(ValueCategory V) {
-  assert(V.val.getType().isa<IntegerType>() && "Expecting an integer value");
+ValueCategory MLIRScanner::EmitIntToBoolConversion(ValueCategory Src) {
+  assert(Src.val.getType().isa<IntegerType>() && "Expecting an integer value");
   // Because of the type rules of C, we often end up computing a
   // logical value, then zero extending it to int, then wanting it
   // as a logical value again.  Optimize this common case.
-  if (auto ZI = V.val.getDefiningOp<arith::ExtUIOp>()) {
+  if (auto ZI = Src.val.getDefiningOp<arith::ExtUIOp>()) {
     if (ZI->getOperand(0).getType().isInteger(/*width*/ 1)) {
       mlir::Value Result = ZI->getOperand(0);
       // If there aren't any more uses, zap the instruction to save space.
@@ -2409,8 +2409,8 @@ ValueCategory MLIRScanner::EmitIntToBoolConversion(ValueCategory V) {
   SubBuilder.setInsertionPointToStart(entryBlock);
   auto Zero = SubBuilder.create<ConstantIntOp>(
       builder.getUnknownLoc(), 0,
-      V.val.getType().cast<IntegerType>().getWidth());
-  return V.ICmpNE(builder, {Zero, false});
+      Src.val.getType().cast<IntegerType>().getWidth());
+  return Src.ICmpNE(builder, {Zero, false});
 }
 
 ValueCategory MLIRScanner::EmitConversionToBool(ValueCategory Src,

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -2427,7 +2427,7 @@ ValueCategory MLIRScanner::EmitConversionToBool(ValueCategory Src,
           isa<MemRefType, LLVM::LLVMPointerType>(Src.val.getType())) &&
          "Unknown scalar type to convert");
 
-  if (isa<IntegerType>(Src.val.getType()))
+  if (SrcType->isIntegerType())
     return EmitIntToBoolConversion(Src);
 
   assert((isa<MemRefType, LLVM::LLVMPointerType>(Src.val.getType())));

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -2359,10 +2359,10 @@ ValueCategory MLIRScanner::EmitScalarConversion(ValueCategory Src,
 
 ValueCategory MLIRScanner::EmitFloatToBoolConversion(ValueCategory Src) {
   assert(Src.val.getType().isa<FloatType>() && "Expecting a float value");
-  mlir::OpBuilder subbuilder(builder.getContext());
-  subbuilder.setInsertionPointToStart(entryBlock);
+  mlir::OpBuilder SubBuilder(builder.getContext());
+  SubBuilder.setInsertionPointToStart(entryBlock);
   auto FloatTy = cast<FloatType>(Src.val.getType());
-  auto Zero = subbuilder.create<ConstantFloatOp>(
+  auto Zero = SubBuilder.create<ConstantFloatOp>(
       builder.getUnknownLoc(),
       mlir::APFloat::getZero(FloatTy.getFloatSemantics()), FloatTy);
   return Src.FCmpUNE(builder, {Zero, false});
@@ -2379,9 +2379,9 @@ ValueCategory MLIRScanner::EmitPointerToBoolConversion(ValueCategory Src) {
   }
   assert(Src.val.getType().isa<LLVM::LLVMPointerType>() &&
          "Expecting a pointer");
-  mlir::OpBuilder subbuilder(builder.getContext());
-  subbuilder.setInsertionPointToStart(entryBlock);
-  auto Zero = subbuilder.create<LLVM::NullOp>(builder.getUnknownLoc(),
+  mlir::OpBuilder SubBuilder(builder.getContext());
+  SubBuilder.setInsertionPointToStart(entryBlock);
+  auto Zero = SubBuilder.create<LLVM::NullOp>(builder.getUnknownLoc(),
                                               Src.val.getType());
   return {builder.createOrFold<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::ne,
                                              Src.val, Zero),
@@ -2405,9 +2405,9 @@ ValueCategory MLIRScanner::EmitIntToBoolConversion(ValueCategory V) {
     }
   }
 
-  mlir::OpBuilder subbuilder(builder.getContext());
-  subbuilder.setInsertionPointToStart(entryBlock);
-  auto Zero = subbuilder.create<ConstantIntOp>(
+  mlir::OpBuilder SubBuilder(builder.getContext());
+  SubBuilder.setInsertionPointToStart(entryBlock);
+  auto Zero = SubBuilder.create<ConstantIntOp>(
       builder.getUnknownLoc(), 0,
       V.val.getType().cast<IntegerType>().getWidth());
   return V.ICmpNE(builder, {Zero, false});

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -2365,7 +2365,7 @@ ValueCategory MLIRScanner::EmitFloatToBoolConversion(ValueCategory Src) {
   auto Zero = SubBuilder.create<ConstantFloatOp>(
       builder.getUnknownLoc(),
       mlir::APFloat::getZero(FloatTy.getFloatSemantics()), FloatTy);
-  return Src.FCmpUNE(builder, {Zero, false});
+  return Src.FCmpUNE(builder, Zero);
 }
 
 ValueCategory MLIRScanner::EmitPointerToBoolConversion(ValueCategory Src) {
@@ -2395,7 +2395,7 @@ ValueCategory MLIRScanner::EmitIntToBoolConversion(ValueCategory Src) {
   auto Zero = SubBuilder.create<ConstantIntOp>(
       builder.getUnknownLoc(), 0,
       Src.val.getType().cast<IntegerType>().getWidth());
-  return Src.ICmpNE(builder, {Zero, false});
+  return Src.ICmpNE(builder, Zero);
 }
 
 ValueCategory MLIRScanner::EmitConversionToBool(ValueCategory Src,

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -2375,7 +2375,7 @@ ValueCategory MLIRScanner::EmitPointerToBoolConversion(ValueCategory Src) {
     Src = {
         builder.create<polygeist::Memref2PointerOp>(
             loc, LLVM::LLVMPointerType::get(ElementTy, AddressSpace), Src.val),
-        true};
+        Src.isReference};
   }
   assert(Src.val.getType().isa<LLVM::LLVMPointerType>() &&
          "Expecting a pointer");

--- a/polygeist/tools/cgeist/Lib/CGStmt.cc
+++ b/polygeist/tools/cgeist/Lib/CGStmt.cc
@@ -1138,10 +1138,10 @@ ValueCategory MLIRScanner::VisitReturnStmt(clang::ReturnStmt *stmt) {
 
       auto postTy = returnVal.getType().cast<MemRefType>().getElementType();
       if (auto prevTy = val.getType().dyn_cast<mlir::IntegerType>()) {
-        auto ipostTy = postTy.cast<mlir::IntegerType>();
-        if (prevTy != ipostTy) {
-          val = builder.create<arith::TruncIOp>(loc, ipostTy, val);
-        }
+        const auto SrcTy = stmt->getRetValue()->getType();
+        const auto IsSigned =
+            SrcTy->isBooleanType() ? false : SrcTy->isSignedIntegerType();
+        val = rv.IntCast(builder, postTy, IsSigned).val;
       } else if (val.getType().isa<MemRefType>() &&
                  postTy.isa<LLVM::LLVMPointerType>())
         val = builder.create<polygeist::Memref2PointerOp>(loc, postTy, val);

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -58,13 +58,12 @@ void ValueCategory::store(mlir::OpBuilder &builder, mlir::Value toStore) const {
   assert(val && "expect not-null");
   if (toStore.getType().isInteger(1)) {
     // Ad-hoc extension of booleans
-    const auto GetElementType = [](auto Ty) -> Type {
-      return Ty.getElementType();
-    };
     auto ElementType =
         llvm::TypeSwitch<Type, Type>(val.getType())
-            .Case<LLVM::LLVMPointerType>(GetElementType)
-            .Case<MemRefType>(GetElementType)
+            .Case<LLVM::LLVMPointerType>(
+                [](auto Ty) -> Type { return Ty.getElementType(); })
+            .Case<MemRefType>(
+                [](auto Ty) -> Type { return Ty.getElementType(); })
             .Default([](auto) -> Type { llvm_unreachable("Unhandled type"); });
     toStore = builder.createOrFold<arith::ExtUIOp>(builder.getUnknownLoc(),
                                                    ElementType, toStore);

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -395,33 +395,33 @@ ValueCategory ValueCategory::IntCast(OpBuilder &Builder, Type PromotionType,
 }
 
 ValueCategory ValueCategory::ICmpNE(mlir::OpBuilder &builder,
-                                    ValueCategory RHS) const {
+                                    mlir::Value RHS) const {
   return ICmp(builder, arith::CmpIPredicate::ne, RHS);
 }
 
 ValueCategory ValueCategory::FCmpUNE(mlir::OpBuilder &builder,
-                                     ValueCategory RHS) const {
+                                     mlir::Value RHS) const {
   return FCmp(builder, arith::CmpFPredicate::UNE, RHS);
 }
 
 ValueCategory ValueCategory::ICmp(OpBuilder &builder,
                                   arith::CmpIPredicate predicate,
-                                  ValueCategory RHS) const {
-  assert(val.getType() == RHS.val.getType() &&
+                                  mlir::Value RHS) const {
+  assert(val.getType() == RHS.getType() &&
          "Cannot compare values of different types");
   assert(val.getType().isa<IntegerType>() && "Expecting integer inputs");
   return {builder.createOrFold<arith::CmpIOp>(builder.getUnknownLoc(),
-                                              predicate, val, RHS.val),
+                                              predicate, val, RHS),
           false};
 }
 
 ValueCategory ValueCategory::FCmp(OpBuilder &builder,
                                   arith::CmpFPredicate predicate,
-                                  ValueCategory RHS) const {
-  assert(val.getType() == RHS.val.getType() &&
+                                  mlir::Value RHS) const {
+  assert(val.getType() == RHS.getType() &&
          "Cannot compare values of different types");
   assert(val.getType().isa<FloatType>() && "Expecting floatint point inputs");
   return {builder.createOrFold<arith::CmpFOp>(builder.getUnknownLoc(),
-                                              predicate, val, RHS.val),
+                                              predicate, val, RHS),
           false};
 }

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -25,6 +25,13 @@ private:
         false};
   }
 
+  ValueCategory ICmp(mlir::OpBuilder &builder,
+                     mlir::arith::CmpIPredicate predicate,
+                     ValueCategory RHS) const;
+  ValueCategory FCmp(mlir::OpBuilder &builder,
+                     mlir::arith::CmpFPredicate predicate,
+                     ValueCategory RHS) const;
+
 public:
   mlir::Value val;
   bool isReference;
@@ -56,6 +63,9 @@ public:
                        mlir::Type PromotionType) const;
   ValueCategory FPToSI(mlir::OpBuilder &Builder,
                        mlir::Type PromotionType) const;
+
+  ValueCategory ICmpNE(mlir::OpBuilder &builder, ValueCategory RHS) const;
+  ValueCategory FCmpUNE(mlir::OpBuilder &builder, ValueCategory RHS) const;
 };
 
 #endif /* CLANG_MLIR_VALUE_CATEGORY */

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -27,10 +27,10 @@ private:
 
   ValueCategory ICmp(mlir::OpBuilder &builder,
                      mlir::arith::CmpIPredicate predicate,
-                     ValueCategory RHS) const;
+                     mlir::Value RHS) const;
   ValueCategory FCmp(mlir::OpBuilder &builder,
                      mlir::arith::CmpFPredicate predicate,
-                     ValueCategory RHS) const;
+                     mlir::Value RHS) const;
 
 public:
   mlir::Value val;
@@ -64,8 +64,8 @@ public:
   ValueCategory FPToSI(mlir::OpBuilder &Builder,
                        mlir::Type PromotionType) const;
 
-  ValueCategory ICmpNE(mlir::OpBuilder &builder, ValueCategory RHS) const;
-  ValueCategory FCmpUNE(mlir::OpBuilder &builder, ValueCategory RHS) const;
+  ValueCategory ICmpNE(mlir::OpBuilder &builder, mlir::Value RHS) const;
+  ValueCategory FCmpUNE(mlir::OpBuilder &builder, mlir::Value RHS) const;
 };
 
 #endif /* CLANG_MLIR_VALUE_CATEGORY */

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -362,8 +362,7 @@ private:
                                      clang::QualType DstType,
                                      clang::SourceLocation Loc);
 
-  ValueCategory EmitPointerToBoolConversion(ValueCategory Src,
-                                            clang::QualType SrcType);
+  ValueCategory EmitPointerToBoolConversion(ValueCategory Src);
   ValueCategory EmitIntToBoolConversion(ValueCategory Src);
   ValueCategory EmitFloatToBoolConversion(ValueCategory Src);
   ValueCategory EmitConversionToBool(ValueCategory Src,

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -362,6 +362,13 @@ private:
                                      clang::QualType DstType,
                                      clang::SourceLocation Loc);
 
+  ValueCategory EmitPointerToBoolConversion(ValueCategory Src,
+                                            clang::QualType SrcType);
+  ValueCategory EmitIntToBoolConversion(ValueCategory Src);
+  ValueCategory EmitFloatToBoolConversion(ValueCategory Src);
+  ValueCategory EmitConversionToBool(ValueCategory Src,
+                                     clang::QualType SrcType);
+
 public:
   MLIRScanner(MLIRASTConsumer &Glob, mlir::OwningOpRef<mlir::ModuleOp> &Module,
               LowerToInfo &LTInfo);

--- a/polygeist/tools/cgeist/Test/Verification/binaryaddptr.c
+++ b/polygeist/tools/cgeist/Test/Verification/binaryaddptr.c
@@ -1,0 +1,10 @@
+// RUN: cgeist %s --function=* -S -o - | FileCheck %s
+// XFAIL: *
+
+#include <stdbool.h>
+
+// COM: Currently not working for how operator+ is implemented for pointers.
+
+bool f(bool *a, void *b) {
+  return *a += b;
+}

--- a/polygeist/tools/cgeist/Test/Verification/compoundassign.c
+++ b/polygeist/tools/cgeist/Test/Verification/compoundassign.c
@@ -191,15 +191,7 @@ bool f13(bool *a, unsigned b) {
   return *a += b;
 }
 
-// COM: Currently not working for how +operator is implemented for pointers.
-
-#if 0
-bool f14(bool *a, void *b) {
-  return *a += b;
-}
-#endif
-
-// CHECK-LABEL:   func.func @f15(
+// CHECK-LABEL:   func.func @f14(
 // CHECK-SAME:                   %[[VAL_0:.*]]: memref<?xi8>,
 // CHECK-SAME:                   %[[VAL_1:.*]]: f32) -> i8
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0.000000e+00 : f32
@@ -212,11 +204,11 @@ bool f14(bool *a, void *b) {
 // CHECK:           return %[[VAL_7]] : i8
 // CHECK:         }
 
-bool f15(bool *a, float b) {
+bool f14(bool *a, float b) {
   return *a += b;
 }
 
-// CHECK-LABEL:   func.func @f16(
+// CHECK-LABEL:   func.func @f15(
 // CHECK-SAME:                   %[[VAL_0:.*]]: memref<?xi8>,
 // CHECK-SAME:                   %[[VAL_1:.*]]: f64) -> i8
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0.000000e+00 : f64
@@ -229,6 +221,6 @@ bool f15(bool *a, float b) {
 // CHECK:           return %[[VAL_7]] : i8
 // CHECK:         }
 
-bool f16(bool *a, double b) {
+bool f15(bool *a, double b) {
   return *a += b;
 }

--- a/polygeist/tools/cgeist/Test/Verification/compoundassign.c
+++ b/polygeist/tools/cgeist/Test/Verification/compoundassign.c
@@ -174,8 +174,6 @@ unsigned f12(unsigned *a, unsigned b) {
   return *a ^= b;
 }
 
-// COM: This test is incorrect due to signedness detection issues.
-
 // CHECK-LABEL:   func.func @f13(
 // CHECK-SAME:                   %[[VAL_0:.*]]: memref<?xi8>,
 // CHECK-SAME:                   %[[VAL_1:.*]]: i32) -> i8

--- a/polygeist/tools/cgeist/Test/Verification/compoundassign.c
+++ b/polygeist/tools/cgeist/Test/Verification/compoundassign.c
@@ -1,5 +1,7 @@
 // RUN: cgeist %s --function=* -S -o - | FileCheck %s
 
+#include <stdbool.h>
+
 // CHECK-LABEL:   func.func @f1(
 // CHECK-SAME:                  %[[VAL_0:.*]]: memref<?xi32>,
 // CHECK-SAME:                  %[[VAL_1:.*]]: i32) -> i32
@@ -170,4 +172,65 @@ unsigned f11(unsigned *a, unsigned b) {
 
 unsigned f12(unsigned *a, unsigned b) {
   return *a ^= b;
+}
+
+// COM: This test is incorrect due to signedness detection issues.
+
+// CHECK-LABEL:   func.func @f13(
+// CHECK-SAME:                   %[[VAL_0:.*]]: memref<?xi8>,
+// CHECK-SAME:                   %[[VAL_1:.*]]: i32) -> i8
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_3:.*]] = affine.load %[[VAL_0]][0] : memref<?xi8>
+// CHECK:           %[[VAL_4:.*]] = arith.extui %[[VAL_3]] : i8 to i32
+// CHECK:           %[[VAL_5:.*]] = arith.addi %[[VAL_4]], %[[VAL_1]] : i32
+// CHECK:           %[[VAL_6:.*]] = arith.cmpi ne, %[[VAL_5]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_7:.*]] = arith.extui %[[VAL_6]] : i1 to i8
+// CHECK:           affine.store %[[VAL_7]], %[[VAL_0]][0] : memref<?xi8>
+// CHECK:           return %[[VAL_7]] : i8
+// CHECK:         }
+
+bool f13(bool *a, unsigned b) {
+  return *a += b;
+}
+
+// COM: Currently not working for how +operator is implemented for pointers.
+
+#if 0
+bool f14(bool *a, void *b) {
+  return *a += b;
+}
+#endif
+
+// CHECK-LABEL:   func.func @f15(
+// CHECK-SAME:                   %[[VAL_0:.*]]: memref<?xi8>,
+// CHECK-SAME:                   %[[VAL_1:.*]]: f32) -> i8
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK:           %[[VAL_3:.*]] = affine.load %[[VAL_0]][0] : memref<?xi8>
+// CHECK:           %[[VAL_4:.*]] = arith.uitofp %[[VAL_3]] : i8 to f32
+// CHECK:           %[[VAL_5:.*]] = arith.addf %[[VAL_4]], %[[VAL_1]] : f32
+// CHECK:           %[[VAL_6:.*]] = arith.cmpf une, %[[VAL_5]], %[[VAL_2]] : f32
+// CHECK:           %[[VAL_7:.*]] = arith.extui %[[VAL_6]] : i1 to i8
+// CHECK:           affine.store %[[VAL_7]], %[[VAL_0]][0] : memref<?xi8>
+// CHECK:           return %[[VAL_7]] : i8
+// CHECK:         }
+
+bool f15(bool *a, float b) {
+  return *a += b;
+}
+
+// CHECK-LABEL:   func.func @f16(
+// CHECK-SAME:                   %[[VAL_0:.*]]: memref<?xi8>,
+// CHECK-SAME:                   %[[VAL_1:.*]]: f64) -> i8
+// CHECK:           %[[VAL_2:.*]] = arith.constant 0.000000e+00 : f64
+// CHECK:           %[[VAL_3:.*]] = affine.load %[[VAL_0]][0] : memref<?xi8>
+// CHECK:           %[[VAL_4:.*]] = arith.uitofp %[[VAL_3]] : i8 to f64
+// CHECK:           %[[VAL_5:.*]] = arith.addf %[[VAL_4]], %[[VAL_1]] : f64
+// CHECK:           %[[VAL_6:.*]] = arith.cmpf une, %[[VAL_5]], %[[VAL_2]] : f64
+// CHECK:           %[[VAL_7:.*]] = arith.extui %[[VAL_6]] : i1 to i8
+// CHECK:           affine.store %[[VAL_7]], %[[VAL_0]][0] : memref<?xi8>
+// CHECK:           return %[[VAL_7]] : i8
+// CHECK:         }
+
+bool f16(bool *a, double b) {
+  return *a += b;
 }


### PR DESCRIPTION
Casting to `bool` should not be performed as if it were a regular int:
1. For integers and float types, compare to 0;
2. For pointers, compare to `nullptr`.

Fix bug when returning a narrower int.
Extend `i1` to target type (`i8`) before storing.