### PR TITLE
[CI] enable post-commit as a workflow action. 

### DIFF
--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -15,7 +15,6 @@ on:
     - .github/workflows/sycl_macos_build_and_test.yml
   workflow_dispatch:
 
-
 jobs:
   # This job generates matrix of tests for LLVM Test Suite
   test_matrix:

--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -13,6 +13,7 @@ on:
     - .github/workflows/sycl_linux_build_and_test.yml
     - .github/workflows/sycl_windows_build_and_test.yml
     - .github/workflows/sycl_macos_build_and_test.yml
+  workflow_dispatch:
 
 
 jobs:


### PR DESCRIPTION
It'd be nice to be able to trigger post-commit checks, especially when we aren't able to test locally. This PR makes post-commit as a dispatchable workflow.  Liberte, Egalite, Fraternite