### PR TITLE
[SYCL][NFC] Fix bug with dereference null return value

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -2087,6 +2087,7 @@ public:
 
     const ConstantArrayType *CAT =
         SemaRef.getASTContext().getAsConstantArrayType(ArrayTy);
+    assert(CAT && "Should only be called on constant-size array.");
     QualType ModifiedArray = SemaRef.getASTContext().getConstantArrayType(
         ModifiedArrayElement, CAT->getSize(),
         const_cast<Expr *>(CAT->getSizeExpr()), CAT->getSizeModifier(),


### PR DESCRIPTION
Reported by static analyzer tool:

Dereference null return value
If the function actually returns a null value, a null pointer dereference will occur.

In <unnamed>::SyclKernelPointerHandler::leaveArray(clang::FieldDecl *, clang::QualType, clang::QualType): Return value of function which returns null is dereferenced without checking

bool leaveArray(FieldDecl *FD, QualType ArrayTy, QualType ET) final {
    QualType ModifiedArrayElement = ModifiedArrayElementsOrArray.pop_back_val();

    	// returned_null: getAsConstantArrayType returns nullptr (checked 73 out of 88 times).
    	// var_assigned: Assigning: CAT = nullptr return value from getAsConstantArrayType.
        const ConstantArrayType *CAT =
        SemaRef.getASTContext().getAsConstantArrayType(ArrayTy);

       // Dereference null return value (NULL_RETURNS)
       // dereference: Dereferencing a pointer that might be nullptr CAT when calling getSizeExpr.
       QualType ModifiedArray = SemaRef.getASTContext().getConstantArrayType(
          ModifiedArrayElement, CAT->getSize(),
          const_cast<Expr *>(CAT->getSizeExpr()), CAT->getSizeModifier(),
          CAT->getIndexTypeCVRQualifiers());

This patch adds assert to resolve the bug.

Signed-off-by: Soumi Manna <soumi.manna@intel.com>