### PR TITLE
[SYCL] missing SYCL_EXPORT leading to downstream troubles

### DIFF
--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -128,7 +128,8 @@ device::get_info() const {
 }
 
 // Explicit override. Not fulfilled by #include device_traits.def below.
-template <> device device::get_info<info::device::parent_device>() const {
+template <>
+__SYCL_EXPORT device device::get_info<info::device::parent_device>() const {
   // With ONEAPI_DEVICE_SELECTOR the impl.MRootDevice is preset and may be
   // overridden (ie it may be nullptr on a sub-device) The PI of the sub-devices
   // have parents, but we don't want to return them. They must pretend to be


### PR DESCRIPTION
my earlier post-commit fix caused an ABI symbols problem downstream. But the original problem is that the custom specialization of `get_info<parent_device>` is merely missing an export declaration. If I'm right, or just dumb lucky, then this will fix all downstream failures, including post-commit. And if not, well, the symbol update is correct regardless

Signed-off-by: Chris Perkins <chris.perkins@intel.com>