### PR TITLE
[SYCL-MLIR] Generate memref with no shape for non-array (and non-vector) element types

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1437,6 +1437,16 @@ ValueCategory MLIRScanner::VisitDeclRefExpr(DeclRefExpr *E) {
                                                    gv.first.getName());
     Value V = castToMemSpace(
         gv2, Glob.getCGM().getContext().getTargetAddressSpace(VD->getType()));
+    MemRefType mt = V.getType().cast<MemRefType>();
+    if (mt.getShape().empty()) {
+      auto Shape = builder.create<memref::AllocaOp>(
+          loc,
+          mlir::MemRefType::get(1, mlir::IndexType::get(builder.getContext())));
+      mt = mlir::MemRefType::get(1, mt.getElementType(),
+                                 MemRefLayoutAttrInterface(),
+                                 mt.getMemorySpace());
+      V = builder.create<memref::ReshapeOp>(loc, mt, V, Shape);
+    }
 
     // TODO check reference
     return ValueCategory(V, /*isReference*/ true);

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1435,8 +1435,12 @@ ValueCategory MLIRScanner::VisitDeclRefExpr(DeclRefExpr *E) {
 
     auto gv2 = builder.create<memref::GetGlobalOp>(loc, gv.first.getType(),
                                                    gv.first.getName());
+    Value V = castToMemSpace(
+        reshapeRanklessGlobal(gv2),
+        Glob.getCGM().getContext().getTargetAddressSpace(VD->getType()));
+
     // TODO check reference
-    return ValueCategory(prepareGlobal(gv2, VD), /*isReference*/ true);
+    return ValueCategory(V, /*isReference*/ true);
   }
   E->dump();
   E->getDecl()->dump();

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1435,21 +1435,8 @@ ValueCategory MLIRScanner::VisitDeclRefExpr(DeclRefExpr *E) {
 
     auto gv2 = builder.create<memref::GetGlobalOp>(loc, gv.first.getType(),
                                                    gv.first.getName());
-    Value V = castToMemSpace(
-        gv2, Glob.getCGM().getContext().getTargetAddressSpace(VD->getType()));
-    MemRefType mt = V.getType().cast<MemRefType>();
-    if (mt.getShape().empty()) {
-      auto Shape = builder.create<memref::AllocaOp>(
-          loc,
-          mlir::MemRefType::get(1, mlir::IndexType::get(builder.getContext())));
-      mt = mlir::MemRefType::get(1, mt.getElementType(),
-                                 MemRefLayoutAttrInterface(),
-                                 mt.getMemorySpace());
-      V = builder.create<memref::ReshapeOp>(loc, mt, V, Shape);
-    }
-
     // TODO check reference
-    return ValueCategory(V, /*isReference*/ true);
+    return ValueCategory(prepareGlobal(gv2, VD), /*isReference*/ true);
   }
   E->dump();
   E->getDecl()->dump();

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -350,6 +350,8 @@ private:
                      llvm::Optional<mlir::Type> returnType,
                      llvm::StringRef mangledFunctionName);
 
+  mlir::Value prepareGlobal(mlir::memref::GetGlobalOp GV, clang::ValueDecl *VD);
+
 public:
   MLIRScanner(MLIRASTConsumer &Glob, mlir::OwningOpRef<mlir::ModuleOp> &module,
               LowerToInfo &LTInfo);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -350,7 +350,8 @@ private:
                      llvm::Optional<mlir::Type> returnType,
                      llvm::StringRef mangledFunctionName);
 
-  mlir::Value prepareGlobal(mlir::memref::GetGlobalOp GV, clang::ValueDecl *VD);
+  // Reshape memref<elemTy> to memref<1 x elemTy>.
+  mlir::Value reshapeRanklessGlobal(mlir::memref::GetGlobalOp GV);
 
 public:
   MLIRScanner(MLIRASTConsumer &Glob, mlir::OwningOpRef<mlir::ModuleOp> &module,

--- a/polygeist/tools/cgeist/Test/Verification/globals.c
+++ b/polygeist/tools/cgeist/Test/Verification/globals.c
@@ -48,6 +48,6 @@ void kernel_deriche() {
 // LLVM-DAG: @internal_init = private global i32 5
 // LLVM-DAG: @external = external global i32
 // LLVM-LABEL: define void @kernel_deriche() {
-// LLVM:        call void @run(i32* @local, i32* @local_init, i32* @internal, i32* @internal_init, i32* @external)
+// LLVM-NEXT:   call void @run(i32* @local, i32* @local_init, i32* @internal, i32* @internal_init, i32* @external)
 // LLVM-NEXT:   ret void
 // LLVM: declare void @run(i32*, i32*, i32*, i32*, i32*)

--- a/polygeist/tools/cgeist/Test/Verification/globals.c
+++ b/polygeist/tools/cgeist/Test/Verification/globals.c
@@ -1,4 +1,5 @@
 // RUN: cgeist %s --function=kernel_deriche -S | FileCheck %s
+// RUN: cgeist %s --function=kernel_deriche -S -emit-llvm | FileCheck %s --check-prefix=LLVM
 
 int local;
 int local_init = 4;
@@ -11,22 +12,43 @@ void kernel_deriche() {
     run(&local, &local_init, &internal, &internal_init, &external);
 }
 
-// CHECK-DAG:   memref.global @external : memref<1xi32>
-// CHECK-DAG:   memref.global "private" @internal_init : memref<1xi32> = dense<5>
-// CHECK-DAG:   memref.global "private" @internal : memref<1xi32> = uninitialized
-// CHECK-DAG:   memref.global @local_init : memref<1xi32> = dense<4>
-// CHECK-DAG:   memref.global @local : memref<1xi32> = uninitialized
+// LLVM-DAG: @local = global i32 undef
+// LLVM-DAG: @local_init = global i32 4
+// LLVM-DAG: @internal = private global i32 undef
+// LLVM-DAG: @internal_init = private global i32 5
+// LLVM-DAG: @external = external global i32
+// LLVM-LABAL: define void @kernel_deriche() {
+// LLVM:        call void @run(i32* @local, i32* @local_init, i32* @internal, i32* @internal_init, i32* @external)
+// LLVM-NEXT:   ret void
+// LLVM-NEXT: }
+// LLVM: declare void @run(i32*, i32*, i32*, i32*, i32*)
+
+// CHECK-DAG:   memref.global @external : memref<i32>
+// CHECK-DAG:   memref.global "private" @internal_init : memref<i32> = dense<5>
+// CHECK-DAG:   memref.global "private" @internal : memref<i32> = uninitialized
+// CHECK-DAG:   memref.global @local_init : memref<i32> = dense<4>
+// CHECK-DAG:   memref.global @local : memref<i32> = uninitialized
 // CHECK:   func @kernel_deriche()
-// CHECK-NEXT:     %0 = memref.get_global @local : memref<1xi32>
-// CHECK-NEXT:     %cast = memref.cast %0 : memref<1xi32> to memref<?xi32>
-// CHECK-NEXT:     %1 = memref.get_global @local_init : memref<1xi32>
-// CHECK-NEXT:     %cast_0 = memref.cast %1 : memref<1xi32> to memref<?xi32>
-// CHECK-NEXT:     %2 = memref.get_global @internal : memref<1xi32>
-// CHECK-NEXT:     %cast_1 = memref.cast %2 : memref<1xi32> to memref<?xi32>
-// CHECK-NEXT:     %3 = memref.get_global @internal_init : memref<1xi32>
-// CHECK-NEXT:     %cast_2 = memref.cast %3 : memref<1xi32> to memref<?xi32>
-// CHECK-NEXT:     %4 = memref.get_global @external : memref<1xi32>
-// CHECK-NEXT:     %cast_3 = memref.cast %4 : memref<1xi32> to memref<?xi32>
-// CHECK-NEXT:     call @run(%cast, %cast_0, %cast_1, %cast_2, %cast_3) : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> ()
+// CHECK-NEXT:     %0 = memref.get_global @local : memref<i32>
+// CHECK-NEXT:     %alloca = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:     %reshape = memref.reshape %0(%alloca) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
+// CHECK-NEXT:     %cast = memref.cast %reshape : memref<1xi32> to memref<?xi32>
+// CHECK-NEXT:     %1 = memref.get_global @local_init : memref<i32>
+// CHECK-NEXT:     %alloca_0 = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:     %reshape_1 = memref.reshape %1(%alloca_0) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
+// CHECK-NEXT:     %cast_2 = memref.cast %reshape_1 : memref<1xi32> to memref<?xi32>
+// CHECK-NEXT:     %2 = memref.get_global @internal : memref<i32>
+// CHECK-NEXT:     %alloca_3 = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:     %reshape_4 = memref.reshape %2(%alloca_3) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
+// CHECK-NEXT:     %cast_5 = memref.cast %reshape_4 : memref<1xi32> to memref<?xi32>
+// CHECK-NEXT:     %3 = memref.get_global @internal_init : memref<i32>
+// CHECK-NEXT:     %alloca_6 = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:     %reshape_7 = memref.reshape %3(%alloca_6) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
+// CHECK-NEXT:     %cast_8 = memref.cast %reshape_7 : memref<1xi32> to memref<?xi32>
+// CHECK-NEXT:     %4 = memref.get_global @external : memref<i32>
+// CHECK-NEXT:     %alloca_9 = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:     %reshape_10 = memref.reshape %4(%alloca_9) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
+// CHECK-NEXT:     %cast_11 = memref.cast %reshape_10 : memref<1xi32> to memref<?xi32>
+// CHECK-NEXT:     call @run(%cast, %cast_2, %cast_5, %cast_8, %cast_11) : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> ()
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }

--- a/polygeist/tools/cgeist/Test/Verification/globals.c
+++ b/polygeist/tools/cgeist/Test/Verification/globals.c
@@ -12,17 +12,6 @@ void kernel_deriche() {
     run(&local, &local_init, &internal, &internal_init, &external);
 }
 
-// LLVM-DAG: @local = global i32 undef
-// LLVM-DAG: @local_init = global i32 4
-// LLVM-DAG: @internal = private global i32 undef
-// LLVM-DAG: @internal_init = private global i32 5
-// LLVM-DAG: @external = external global i32
-// LLVM-LABAL: define void @kernel_deriche() {
-// LLVM:        call void @run(i32* @local, i32* @local_init, i32* @internal, i32* @internal_init, i32* @external)
-// LLVM-NEXT:   ret void
-// LLVM-NEXT: }
-// LLVM: declare void @run(i32*, i32*, i32*, i32*, i32*)
-
 // CHECK-DAG:   memref.global @external : memref<i32>
 // CHECK-DAG:   memref.global "private" @internal_init : memref<i32> = dense<5>
 // CHECK-DAG:   memref.global "private" @internal : memref<i32> = uninitialized
@@ -52,3 +41,13 @@ void kernel_deriche() {
 // CHECK-NEXT:     call @run(%cast, %cast_2, %cast_5, %cast_8, %cast_11) : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> ()
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
+
+// LLVM-DAG: @local = global i32 undef
+// LLVM-DAG: @local_init = global i32 4
+// LLVM-DAG: @internal = private global i32 undef
+// LLVM-DAG: @internal_init = private global i32 5
+// LLVM-DAG: @external = external global i32
+// LLVM-LABEL: define void @kernel_deriche() {
+// LLVM:        call void @run(i32* @local, i32* @local_init, i32* @internal, i32* @internal_init, i32* @external)
+// LLVM-NEXT:   ret void
+// LLVM: declare void @run(i32*, i32*, i32*, i32*, i32*)

--- a/polygeist/tools/cgeist/Test/Verification/loop.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/loop.cpp
@@ -18,9 +18,9 @@ void div_(int* sizes) {
 
 // CHECK-LABEL:   func.func @_Z4div_Pi(
 // CHECK-SAME:                         %[[VAL_0:.*]]: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:       %[[VAL_1:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:       %[[VAL_2:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:       %[[VAL_3:.*]] = arith.constant 1 : i64
+// CHECK-DAG:        %[[VAL_1:.*]] = arith.constant 1 : i32
+// CHECK-DAG:        %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-DAG:        %[[VAL_3:.*]] = arith.constant 1 : i64
 // CHECK-NEXT:       %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.array<25 x struct<(i32, f64)>> : (i64) -> !llvm.ptr<array<25 x struct<(i32, f64)>>>
 // CHECK-NEXT:       %[[VAL_5:.*]] = memref.get_global @MAX_DIMS : memref<i32>
 // CHECK-NEXT:       %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_4]][0, 0] : (!llvm.ptr<array<25 x struct<(i32, f64)>>>) -> !llvm.ptr<struct<(i32, f64)>>

--- a/polygeist/tools/cgeist/Test/Verification/loop.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/loop.cpp
@@ -14,21 +14,32 @@ void div_(int* sizes) {
     }
 }
 
-// CHECK:   func @_Z4div_Pi(%arg0: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-DAG:     %c1_i64 = arith.constant 1 : i64
-// CHECK-DAG:     %c1 = arith.constant 1 : index
-// CHECK-DAG:     %c0 = arith.constant 0 : index
-// CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.array<25 x struct<(i32, f64)>> : (i64) -> !llvm.ptr<array<25 x struct<(i32, f64)>>>
-// CHECK-NEXT:     %1 = memref.get_global @MAX_DIMS : memref<1xi32>
-// CHECK-NEXT:     %2 = affine.load %1[0] : memref<1xi32>
-// CHECK-NEXT:     %3 = llvm.getelementptr %0[0, 0] : (!llvm.ptr<array<25 x struct<(i32, f64)>>>) -> !llvm.ptr<struct<(i32, f64)>>
-// CHECK-NEXT:     %4 = arith.index_cast %2 : i32 to index
-// CHECK-NEXT:     scf.for %arg1 = %c0 to %4 step %c1 {
-// CHECK-NEXT:       %5 = memref.load %arg0[%arg1] : memref<?xi32>
-// CHECK-NEXT:       %6 = arith.index_cast %arg1 : index to i64
-// CHECK-NEXT:       %7 = llvm.getelementptr %3[%6] : (!llvm.ptr<struct<(i32, f64)>>, i64) -> !llvm.ptr<struct<(i32, f64)>>
-// CHECK-NEXT:       %8 = llvm.getelementptr %7[0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:       llvm.store %5, %8 : !llvm.ptr<i32>
+// CHECK-LABEL:   memref.global @MAX_DIMS : memref<i32> = uninitialized
+
+// CHECK-LABEL:   func.func @_Z4div_Pi(
+// CHECK-SAME:                         %[[VAL_0:.*]]: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:       %[[VAL_1:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:       %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:       %[[VAL_3:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:       %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.array<25 x struct<(i32, f64)>> : (i64) -> !llvm.ptr<array<25 x struct<(i32, f64)>>>
+// CHECK-NEXT:       %[[VAL_5:.*]] = memref.get_global @MAX_DIMS : memref<i32>
+// CHECK-NEXT:       %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_4]][0, 0] : (!llvm.ptr<array<25 x struct<(i32, f64)>>>) -> !llvm.ptr<struct<(i32, f64)>>
+// CHECK-NEXT:       %[[VAL_7:.*]] = scf.while (%[[VAL_8:.*]] = %[[VAL_2]]) : (i32) -> i32 {
+// CHECK-NEXT:         %[[VAL_9:.*]] = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:         %[[VAL_10:.*]] = memref.reshape %[[VAL_5]](%[[VAL_9]]) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
+// CHECK-NEXT:         %[[VAL_11:.*]] = affine.load %[[VAL_10]][0] : memref<1xi32>
+// CHECK-NEXT:         %[[VAL_12:.*]] = arith.cmpi slt, %[[VAL_8]], %[[VAL_11]] : i32
+// CHECK-NEXT:         scf.condition(%[[VAL_12]]) %[[VAL_8]] : i32
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:       ^bb0(%[[VAL_13:.*]]: i32):
+// CHECK-NEXT:         %[[VAL_14:.*]] = arith.index_cast %[[VAL_13]] : i32 to index
+// CHECK-NEXT:         %[[VAL_15:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_14]]] : memref<?xi32>
+// CHECK-NEXT:         %[[VAL_16:.*]] = arith.index_cast %[[VAL_14]] : index to i64
+// CHECK-NEXT:         %[[VAL_17:.*]] = llvm.getelementptr %[[VAL_6]]{{\[}}%[[VAL_16]]] : (!llvm.ptr<struct<(i32, f64)>>, i64) -> !llvm.ptr<struct<(i32, f64)>>
+// CHECK-NEXT:         %[[VAL_18:.*]] = llvm.getelementptr %[[VAL_17]][0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:         llvm.store %[[VAL_15]], %[[VAL_18]] : !llvm.ptr<i32>
+// CHECK-NEXT:         %[[VAL_19:.*]] = arith.addi %[[VAL_13]], %[[VAL_1]] : i32
+// CHECK-NEXT:         scf.yield %[[VAL_19]] : i32
+// CHECK-NEXT:       }
+// CHECK-NEXT:       return
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }

--- a/polygeist/tools/cgeist/Test/Verification/staticint.c
+++ b/polygeist/tools/cgeist/Test/Verification/staticint.c
@@ -6,7 +6,7 @@ int adder(int x) {
     return cur;
 }
 
-// CHECK-DAG:   memref.global "private" @"adder@static@cur@init" : memref<1xi1> = dense<true>
+// CHECK-DAG:   memref.global "private" @"adder@static@cur@init" : memref<i1> = dense<true>
 // CHECK-DAG:   memref.global "private" @"adder@static@cur" : memref<i32> = uninitialized
 
 // CHECK-LABEL:   func.func @adder(
@@ -16,14 +16,16 @@ int adder(int x) {
 // CHECK-NEXT:       %[[VAL_3:.*]] = memref.get_global @"adder@static@cur" : memref<i32>
 // CHECK-NEXT:       %[[VAL_4:.*]] = memref.alloca() : memref<1xindex>
 // CHECK-NEXT:       %[[VAL_5:.*]] = memref.reshape %[[VAL_3]](%[[VAL_4]]) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
-// CHECK-NEXT:       %[[VAL_6:.*]] = memref.get_global @"adder@static@cur@init" : memref<1xi1>
-// CHECK-NEXT:       %[[VAL_7:.*]] = affine.load %[[VAL_6]][0] : memref<1xi1>
-// CHECK-NEXT:       scf.if %[[VAL_7]] {
-// CHECK-NEXT:         affine.store %[[VAL_1]], %[[VAL_6]][0] : memref<1xi1>
+// CHECK-NEXT:       %[[VAL_6:.*]] = memref.get_global @"adder@static@cur@init" : memref<i1>
+// CHECK-NEXT:       %[[VAL_7:.*]] = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:       %[[VAL_8:.*]] = memref.reshape %[[VAL_6]](%[[VAL_7]]) : (memref<i1>, memref<1xindex>) -> memref<1xi1>
+// CHECK-NEXT:       %[[VAL_9:.*]] = affine.load %[[VAL_8]][0] : memref<1xi1>
+// CHECK-NEXT:       scf.if %[[VAL_9]] {
+// CHECK-NEXT:         affine.store %[[VAL_1]], %[[VAL_8]][0] : memref<1xi1>
 // CHECK-NEXT:         affine.store %[[VAL_2]], %[[VAL_5]][0] : memref<1xi32>
 // CHECK-NEXT:       }
-// CHECK-NEXT:       %[[VAL_8:.*]] = affine.load %[[VAL_5]][0] : memref<1xi32>
-// CHECK-NEXT:       %[[VAL_9:.*]] = arith.addi %[[VAL_8]], %[[VAL_0]] : i32
-// CHECK-NEXT:       affine.store %[[VAL_9]], %[[VAL_5]][0] : memref<1xi32>
-// CHECK-NEXT:       return %[[VAL_9]] : i32
+// CHECK-NEXT:       %[[VAL_10:.*]] = affine.load %[[VAL_5]][0] : memref<1xi32>
+// CHECK-NEXT:       %[[VAL_11:.*]] = arith.addi %[[VAL_10]], %[[VAL_0]] : i32
+// CHECK-NEXT:       affine.store %[[VAL_11]], %[[VAL_5]][0] : memref<1xi32>
+// CHECK-NEXT:       return %[[VAL_11]] : i32
 // CHECK-NEXT:     }

--- a/polygeist/tools/cgeist/Test/Verification/staticint.c
+++ b/polygeist/tools/cgeist/Test/Verification/staticint.c
@@ -11,8 +11,8 @@ int adder(int x) {
 
 // CHECK-LABEL:   func.func @adder(
 // CHECK-SAME:                     %[[VAL_0:.*]]: i32) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:       %[[VAL_1:.*]] = arith.constant false
-// CHECK-NEXT:       %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-DAG:        %[[VAL_1:.*]] = arith.constant false
+// CHECK-DAG:        %[[VAL_2:.*]] = arith.constant 0 : i32
 // CHECK-NEXT:       %[[VAL_3:.*]] = memref.get_global @"adder@static@cur" : memref<i32>
 // CHECK-NEXT:       %[[VAL_4:.*]] = memref.alloca() : memref<1xindex>
 // CHECK-NEXT:       %[[VAL_5:.*]] = memref.reshape %[[VAL_3]](%[[VAL_4]]) : (memref<i32>, memref<1xindex>) -> memref<1xi32>

--- a/polygeist/tools/cgeist/Test/Verification/staticint.c
+++ b/polygeist/tools/cgeist/Test/Verification/staticint.c
@@ -6,21 +6,24 @@ int adder(int x) {
     return cur;
 }
 
-// CHECK:   memref.global "private" @"adder@static@cur@init" : memref<1xi1> = dense<true>
-// CHECK:   memref.global "private" @"adder@static@cur" : memref<1xi32> = uninitialized
-// CHECK:   func @adder(%arg0: i32) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-DAG:     %false = arith.constant false
-// CHECK-DAG:     %c0_i32 = arith.constant 0 : i32
-// CHECK-DAG:     %0 = memref.get_global @"adder@static@cur" : memref<1xi32>
-// CHECK-DAG:     %1 = memref.get_global @"adder@static@cur@init" : memref<1xi1>
-// CHECK-NEXT:     %2 = affine.load %1[0] : memref<1xi1>
-// CHECK-NEXT:     scf.if %2 {
-// CHECK-NEXT:       affine.store %false, %1[0] : memref<1xi1>
-// CHECK-NEXT:       affine.store %c0_i32, %0[0] : memref<1xi32>
-// CHECK-NEXT:     }
-// CHECK-NEXT:     %3 = affine.load %0[0] : memref<1xi32>
-// CHECK-NEXT:     %4 = arith.addi %3, %arg0 : i32
-// CHECK-NEXT:     affine.store %4, %0[0] : memref<1xi32>
-// CHECK-NEXT:     return %4 : i32
-// CHECK-NEXT:   }
+// CHECK-DAG:   memref.global "private" @"adder@static@cur@init" : memref<1xi1> = dense<true>
+// CHECK-DAG:   memref.global "private" @"adder@static@cur" : memref<i32> = uninitialized
 
+// CHECK-LABEL:   func.func @adder(
+// CHECK-SAME:                     %[[VAL_0:.*]]: i32) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:       %[[VAL_1:.*]] = arith.constant false
+// CHECK-NEXT:       %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:       %[[VAL_3:.*]] = memref.get_global @"adder@static@cur" : memref<i32>
+// CHECK-NEXT:       %[[VAL_4:.*]] = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:       %[[VAL_5:.*]] = memref.reshape %[[VAL_3]](%[[VAL_4]]) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
+// CHECK-NEXT:       %[[VAL_6:.*]] = memref.get_global @"adder@static@cur@init" : memref<1xi1>
+// CHECK-NEXT:       %[[VAL_7:.*]] = affine.load %[[VAL_6]][0] : memref<1xi1>
+// CHECK-NEXT:       scf.if %[[VAL_7]] {
+// CHECK-NEXT:         affine.store %[[VAL_1]], %[[VAL_6]][0] : memref<1xi1>
+// CHECK-NEXT:         affine.store %[[VAL_2]], %[[VAL_5]][0] : memref<1xi32>
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %[[VAL_8:.*]] = affine.load %[[VAL_5]][0] : memref<1xi32>
+// CHECK-NEXT:       %[[VAL_9:.*]] = arith.addi %[[VAL_8]], %[[VAL_0]] : i32
+// CHECK-NEXT:       affine.store %[[VAL_9]], %[[VAL_5]][0] : memref<1xi32>
+// CHECK-NEXT:       return %[[VAL_9]] : i32
+// CHECK-NEXT:     }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -9,11 +9,11 @@
 
 // Check globals referenced in device functions are created in the GPU module
 // CHECK: gpu.module @device_functions {
-// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupLocalInvocationId : memref<1xi32, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupId : memref<1xi32, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInNumSubgroups : memref<1xi32, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupMaxSize : memref<1xi32, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupSize : memref<1xi32, 1>
+// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupLocalInvocationId : memref<i32, 1>
+// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupId : memref<i32, 1>
+// CHECK-NEXT: memref.global @__spirv_BuiltInNumSubgroups : memref<i32, 1>
+// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupMaxSize : memref<i32, 1>
+// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupSize : memref<i32, 1>
 // CHECK-NEXT: memref.global @__spirv_BuiltInLocalInvocationId : memref<3xi64, 1>
 // CHECK-NEXT: memref.global @__spirv_BuiltInWorkgroupId : memref<3xi64, 1>
 // CHECK-NEXT: memref.global @__spirv_BuiltInWorkgroupSize : memref<3xi64, 1>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -9,18 +9,18 @@
 
 // Check globals referenced in device functions are created in the GPU module
 // CHECK: gpu.module @device_functions {
-// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupLocalInvocationId : memref<i32, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupId : memref<i32, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInNumSubgroups : memref<i32, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupMaxSize : memref<i32, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupSize : memref<i32, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInLocalInvocationId : memref<3xi64, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInWorkgroupId : memref<3xi64, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInWorkgroupSize : memref<3xi64, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInNumWorkgroups : memref<3xi64, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInGlobalOffset : memref<3xi64, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInGlobalSize : memref<3xi64, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInGlobalInvocationId : memref<3xi64, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInSubgroupLocalInvocationId : memref<i32, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInSubgroupId : memref<i32, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInNumSubgroups : memref<i32, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInSubgroupMaxSize : memref<i32, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInSubgroupSize : memref<i32, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInLocalInvocationId : memref<3xi64, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInWorkgroupId : memref<3xi64, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInWorkgroupSize : memref<3xi64, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInNumWorkgroups : memref<3xi64, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInGlobalOffset : memref<3xi64, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInGlobalSize : memref<3xi64, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInGlobalInvocationId : memref<3xi64, 1>
 
 // Ensure the spirv functions that reference these globals are not filtered out
 // CHECK-DAG: func.func @_Z28__spirv_GlobalInvocationId_xv()


### PR DESCRIPTION
In `GetOrCreateGlobal`, when element types are not array or vector, then it generates `memref<1 x elemTy>`, 
which is converted to `[1 x elemTy]*`. When linking with files compiled with `clang`, the same global will have type `elemTy*`, so the types are mismatched. 
This PR changes `GetOrCreateGlobal` to generate `memref<elemTy>`, which will convert to `elemTy*` in LLVM IR.
We use `memref.reshape` to change the type to `memref<1 x elemTy>`, as `cgeist` has a lot of code that expects `memref` of rank 1.

Example:
C source: `int g = 3;`
clang LLVM IR: `@g = dso_local global i32 3, align 4`
cgeist LLVM IR (before this PR): `@g = global [1 x i32] [i32 3]`
cgeist LLVM IR (after this PR): `@g = global i32 3`

Note: global with vector types will also need to be handled. Will do that in future PR.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>