### PR TITLE
[SYCL] Move integer conversion out of assert

### DIFF
--- a/llvm/lib/SYCLLowerIR/SYCLPropagateAspectsUsage.cpp
+++ b/llvm/lib/SYCLLowerIR/SYCLPropagateAspectsUsage.cpp
@@ -343,7 +343,10 @@ void validateUsedAspectsForFunctions(const FunctionToAspectsMapTy &Map,
           AspectValStrs, ',', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
       for (StringRef AspectValStr : AspectValStrs) {
         int AspectVal = -1;
-        assert(!AspectValStr.getAsInteger(10, AspectVal) &&
+        bool AspectValStrConverted = !AspectValStr.getAsInteger(10, AspectVal);
+        // Avoid unused warning when asserts are disabled.
+        std::ignore = AspectValStrConverted;
+        assert(AspectValStrConverted &&
                "Aspect value in sycl-device-has is not an integer.");
         DeviceHasAspectSet.insert(AspectVal);
       }


### PR DESCRIPTION
Converting the aspect values in sycl-device-has in the SYCL propagate aspect usage pass was unintentionally done inside an assert. This causes the conversion to not take place when asserts are disabled. This commit moves the conversion out of the assertion.