### PR TITLE
[SYCL] Relax kernel bundle device check to allow descendent devices

### DIFF
--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -30,11 +30,9 @@ namespace detail {
 
 static bool checkAllDevicesAreInContext(const std::vector<device> &Devices,
                                         const context &Context) {
-  const std::vector<device> &ContextDevices = Context.get_devices();
   return std::all_of(
-      Devices.begin(), Devices.end(), [&ContextDevices](const device &Dev) {
-        return ContextDevices.end() !=
-               std::find(ContextDevices.begin(), ContextDevices.end(), Dev);
+      Devices.begin(), Devices.end(), [&Context](const device &Dev) {
+        return getSyclObjImpl(Context)->isDeviceValid(getSyclObjImpl(Dev));
       });
 }
 

--- a/sycl/unittests/helpers/PiMock.hpp
+++ b/sycl/unittests/helpers/PiMock.hpp
@@ -192,10 +192,12 @@ public:
   /// within the given context. A separate platform instance will be
   /// held by the PiMock instance.
   ///
-  PiMock() {
+  /// \param Backend is the backend type to mock, intended for testing backend
+  /// specific runtime logic.
+  PiMock(backend Backend = backend::opencl) {
     // Create new mock plugin platform and plugin handles
     // Note: Mock plugin will be generated if it has not been yet.
-    MPlatformImpl = GetMockPlatformImpl();
+    MPlatformImpl = GetMockPlatformImpl(Backend);
     std::shared_ptr<detail::plugin> NewPluginPtr;
     {
       const detail::plugin &OriginalPiPlugin = MPlatformImpl->getPlugin();
@@ -328,7 +330,9 @@ public:
   /// in the global handler. Additionally, all existing plugins will be removed
   /// and unloaded to avoid them being accidentally picked up by tests using
   /// selectors.
-  static void EnsureMockPluginInitialized() {
+  /// \param Backend is the backend type to mock, intended for testing backend
+  /// specific runtime logic.
+  static void EnsureMockPluginInitialized(backend Backend = backend::opencl) {
     // Only initialize the plugin once.
     if (MMockPluginPtr)
       return;
@@ -346,8 +350,7 @@ public:
         RT::PiPlugin{"pi.ver.mock", "plugin.ver.mock", /*Targets=*/nullptr,
                      getProxyMockedFunctionPointers()});
 
-    // FIXME: which backend to pass here? does it affect anything?
-    MMockPluginPtr = std::make_unique<detail::plugin>(RTPlugin, backend::opencl,
+    MMockPluginPtr = std::make_unique<detail::plugin>(RTPlugin, Backend,
                                                       /*Library=*/nullptr);
     Plugins.push_back(*MMockPluginPtr);
   }
@@ -357,8 +360,9 @@ private:
   /// platform_impl from it.
   ///
   /// \return a shared_ptr to a platform_impl created from the mock PI plugin.
-  static std::shared_ptr<sycl::detail::platform_impl> GetMockPlatformImpl() {
-    EnsureMockPluginInitialized();
+  static std::shared_ptr<sycl::detail::platform_impl>
+  GetMockPlatformImpl(backend Backend) {
+    EnsureMockPluginInitialized(Backend);
 
     pi_uint32 NumPlatforms = 0;
     MMockPluginPtr->call_nocheck<detail::PiApiKind::piPlatformsGet>(


### PR DESCRIPTION
Change kernel_bundle_impl constructors to treat descendent devices of context members as valid in accordance with SYCL 2020.