### PR TITLE
[NFC] Remove MatrixUse::Unnecessary

### DIFF
--- a/sycl/include/CL/__spirv/spirv_ops.hpp
+++ b/sycl/include/CL/__spirv/spirv_ops.hpp
@@ -24,120 +24,191 @@
 #ifdef __SYCL_DEVICE_ONLY__
 
 #if (SYCL_EXT_ONEAPI_MATRIX_VERSION > 1)
-#define JOINT_MATRIX_INTEL(T, R, C, L, S, U)                                   \
-  __spv::__spirv_JointMatrixINTEL<T, R, C, L, S, U>
-#else
-#define JOINT_MATRIX_INTEL(T, R, C, L, S, U)                                   \
-  __spv::__spirv_JointMatrixINTEL<T, R, C, L, S>
-#endif // SYCL_EXT_ONEAPI_MATRIX_VERSION
-
-template <typename T, std::size_t R, std::size_t C,
-          __spv::MatrixUse U = __spv::MatrixUse::Unnecessary,
+template <typename T, std::size_t R, std::size_t C, __spv::MatrixUse U,
           __spv::MatrixLayout L = __spv::MatrixLayout::RowMajor,
           __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
-extern SYCL_EXTERNAL JOINT_MATRIX_INTEL(T, R, C, L, S, U) *
+extern SYCL_EXTERNAL __spv::__spirv_JointMatrixINTEL<T, R, C, L, S, U> *
+__spirv_JointMatrixLoadINTEL(T *Ptr, std::size_t Stride,
+                             __spv::MatrixLayout Layout = L,
+                             __spv::Scope::Flag Sc = S, int MemOperand = 0);
+
+template <typename T, std::size_t R, std::size_t C, __spv::MatrixUse U,
+          __spv::MatrixLayout L = __spv::MatrixLayout::RowMajor,
+          __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
+extern SYCL_EXTERNAL void __spirv_JointMatrixStoreINTEL(
+    T *Ptr, __spv::__spirv_JointMatrixINTEL<T, R, C, L, S, U> *Object,
+    std::size_t Stride, __spv::MatrixLayout Layout = L,
+    __spv::Scope::Flag Sc = S, int MemOperand = 0);
+
+template <typename T1, typename T2, std::size_t M, std::size_t K, std::size_t N,
+          __spv::MatrixUse UA, __spv::MatrixUse UB, __spv::MatrixUse UC,
+          __spv::MatrixLayout LA = __spv::MatrixLayout::RowMajor,
+          __spv::MatrixLayout LB = __spv::MatrixLayout::RowMajor,
+          __spv::MatrixLayout LC = __spv::MatrixLayout::RowMajor,
+          __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
+extern SYCL_EXTERNAL __spv::__spirv_JointMatrixINTEL<T2, M, N, LC, S, UC> *
+__spirv_JointMatrixMadINTEL(
+    __spv::__spirv_JointMatrixINTEL<T1, M, K, LA, S, UA> *A,
+    __spv::__spirv_JointMatrixINTEL<T1, K, N, LB, S, UB> *B,
+    __spv::__spirv_JointMatrixINTEL<T2, M, N, LC, S, UC> *C,
+    __spv::Scope::Flag Sc = __spv::Scope::Flag::Subgroup);
+
+template <typename T1, typename T2, typename T3, std::size_t M, std::size_t K,
+          std::size_t N, __spv::MatrixUse UA, __spv::MatrixUse UB,
+          __spv::MatrixUse UC,
+          __spv::MatrixLayout LA = __spv::MatrixLayout::RowMajor,
+          __spv::MatrixLayout LB = __spv::MatrixLayout::RowMajor,
+          __spv::MatrixLayout LC = __spv::MatrixLayout::RowMajor,
+          __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
+extern SYCL_EXTERNAL __spv::__spirv_JointMatrixINTEL<T3, M, N, LC, S, UC> *
+__spirv_JointMatrixUUMadINTEL(
+    __spv::__spirv_JointMatrixINTEL<T1, M, K, LA, S, UA> *A,
+    __spv::__spirv_JointMatrixINTEL<T2, K, N, LB, S, UB> *B,
+    __spv::__spirv_JointMatrixINTEL<T3, M, N, LC, S, UC> *C,
+    __spv::Scope::Flag Sc = __spv::Scope::Flag::Subgroup);
+
+template <typename T1, typename T2, typename T3, std::size_t M, std::size_t K,
+          std::size_t N, __spv::MatrixUse UA, __spv::MatrixUse UB,
+          __spv::MatrixUse UC,
+          __spv::MatrixLayout LA = __spv::MatrixLayout::RowMajor,
+          __spv::MatrixLayout LB = __spv::MatrixLayout::RowMajor,
+          __spv::MatrixLayout LC = __spv::MatrixLayout::RowMajor,
+          __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
+extern SYCL_EXTERNAL __spv::__spirv_JointMatrixINTEL<T3, M, N, LC, S, UC> *
+__spirv_JointMatrixUSMadINTEL(
+    __spv::__spirv_JointMatrixINTEL<T1, M, K, LA, S, UA> *A,
+    __spv::__spirv_JointMatrixINTEL<T2, K, N, LB, S, UB> *B,
+    __spv::__spirv_JointMatrixINTEL<T3, M, N, LC, S, UC> *C,
+    __spv::Scope::Flag Sc = __spv::Scope::Flag::Subgroup);
+
+template <typename T1, typename T2, typename T3, std::size_t M, std::size_t K,
+          std::size_t N, __spv::MatrixUse UA, __spv::MatrixUse UB,
+          __spv::MatrixUse UC,
+          __spv::MatrixLayout LA = __spv::MatrixLayout::RowMajor,
+          __spv::MatrixLayout LB = __spv::MatrixLayout::RowMajor,
+          __spv::MatrixLayout LC = __spv::MatrixLayout::RowMajor,
+          __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
+extern SYCL_EXTERNAL __spv::__spirv_JointMatrixINTEL<T3, M, N, LC, S, UC> *
+__spirv_JointMatrixSUMadINTEL(
+    __spv::__spirv_JointMatrixINTEL<T1, M, K, LA, S, UA> *A,
+    __spv::__spirv_JointMatrixINTEL<T2, K, N, LB, S, UB> *B,
+    __spv::__spirv_JointMatrixINTEL<T3, M, N, LC, S, UC> *C,
+    __spv::Scope::Flag Sc = __spv::Scope::Flag::Subgroup);
+
+template <typename T, std::size_t R, std::size_t C, __spv::MatrixUse U,
+          __spv::MatrixLayout L = __spv::MatrixLayout::RowMajor,
+          __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
+extern SYCL_EXTERNAL __spv::__spirv_JointMatrixINTEL<T, R, C, L, S, U> *
+__spirv_CompositeConstruct(const T v);
+
+template <typename T, std::size_t R, std::size_t C, __spv::MatrixUse U,
+          __spv::MatrixLayout L = __spv::MatrixLayout::RowMajor,
+          __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
+extern SYCL_EXTERNAL size_t __spirv_JointMatrixWorkItemLengthINTEL(
+    __spv::__spirv_JointMatrixINTEL<T, R, C, L, S, U> *);
+
+template <typename T, std::size_t R, std::size_t C, __spv::MatrixUse U,
+          __spv::MatrixLayout L = __spv::MatrixLayout::RowMajor,
+          __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
+extern SYCL_EXTERNAL T __spirv_VectorExtractDynamic(
+    __spv::__spirv_JointMatrixINTEL<T, R, C, L, S, U> *, size_t i);
+
+template <typename T, std::size_t R, std::size_t C, __spv::MatrixUse U,
+          __spv::MatrixLayout L = __spv::MatrixLayout::RowMajor,
+          __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
+extern SYCL_EXTERNAL __spv::__spirv_JointMatrixINTEL<T, R, C, L, S, U> *
+__spirv_VectorInsertDynamic(__spv::__spirv_JointMatrixINTEL<T, R, C, L, S, U> *,
+                            T val, size_t i);
+#else
+template <typename T, std::size_t R, std::size_t C,
+          __spv::MatrixLayout L = __spv::MatrixLayout::RowMajor,
+          __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
+extern SYCL_EXTERNAL __spv::__spirv_JointMatrixINTEL<T, R, C, L, S> *
 __spirv_JointMatrixLoadINTEL(T *Ptr, std::size_t Stride,
                              __spv::MatrixLayout Layout = L,
                              __spv::Scope::Flag Sc = S, int MemOperand = 0);
 
 template <typename T, std::size_t R, std::size_t C,
-          __spv::MatrixUse U = __spv::MatrixUse::Unnecessary,
           __spv::MatrixLayout L = __spv::MatrixLayout::RowMajor,
           __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
 extern SYCL_EXTERNAL void __spirv_JointMatrixStoreINTEL(
-    T *Ptr, JOINT_MATRIX_INTEL(T, R, C, L, S, U) *Object,
+    T *Ptr, __spv::__spirv_JointMatrixINTEL<T, R, C, L, S> *Object,
     std::size_t Stride, __spv::MatrixLayout Layout = L,
     __spv::Scope::Flag Sc = S, int MemOperand = 0);
 
 template <typename T1, typename T2, std::size_t M, std::size_t K, std::size_t N,
-          __spv::MatrixUse UA = __spv::MatrixUse::Unnecessary,
-          __spv::MatrixUse UB = __spv::MatrixUse::Unnecessary,
-          __spv::MatrixUse UC = __spv::MatrixUse::Unnecessary,
           __spv::MatrixLayout LA = __spv::MatrixLayout::RowMajor,
           __spv::MatrixLayout LB = __spv::MatrixLayout::RowMajor,
           __spv::MatrixLayout LC = __spv::MatrixLayout::RowMajor,
           __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
-extern SYCL_EXTERNAL JOINT_MATRIX_INTEL(T2, M, N, LC, S, UC) *
+extern SYCL_EXTERNAL __spv::__spirv_JointMatrixINTEL<T2, M, N, LC, S> *
 __spirv_JointMatrixMadINTEL(
-    JOINT_MATRIX_INTEL(T1, M, K, LA, S, UA) *A,
-    JOINT_MATRIX_INTEL(T1, K, N, LB, S, UB) *B,
-    JOINT_MATRIX_INTEL(T2, M, N, LC, S, UC) *C,
+    __spv::__spirv_JointMatrixINTEL<T1, M, K, LA, S> *A,
+    __spv::__spirv_JointMatrixINTEL<T1, K, N, LB, S> *B,
+    __spv::__spirv_JointMatrixINTEL<T2, M, N, LC, S> *C,
     __spv::Scope::Flag Sc = __spv::Scope::Flag::Subgroup);
 
 template <typename T1, typename T2, typename T3, std::size_t M, std::size_t K,
-          std::size_t N, __spv::MatrixUse UA = __spv::MatrixUse::Unnecessary,
-          __spv::MatrixUse UB = __spv::MatrixUse::Unnecessary,
-          __spv::MatrixUse UC = __spv::MatrixUse::Unnecessary,
-          __spv::MatrixLayout LA = __spv::MatrixLayout::RowMajor,
+          std::size_t N, __spv::MatrixLayout LA = __spv::MatrixLayout::RowMajor,
           __spv::MatrixLayout LB = __spv::MatrixLayout::RowMajor,
           __spv::MatrixLayout LC = __spv::MatrixLayout::RowMajor,
           __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
-extern SYCL_EXTERNAL JOINT_MATRIX_INTEL(T3, M, N, LC, S, UC) *
+extern SYCL_EXTERNAL __spv::__spirv_JointMatrixINTEL<T2, M, N, LC, S> *
 __spirv_JointMatrixUUMadINTEL(
-    JOINT_MATRIX_INTEL(T1, M, K, LA, S, UA) *A,
-    JOINT_MATRIX_INTEL(T2, K, N, LB, S, UB) *B,
-    JOINT_MATRIX_INTEL(T3, M, N, LC, S, UC) *C,
+    __spv::__spirv_JointMatrixINTEL<T1, M, K, LA, S> *A,
+    __spv::__spirv_JointMatrixINTEL<T2, K, N, LB, S> *B,
+    __spv::__spirv_JointMatrixINTEL<T3, M, N, LC, S> *C,
     __spv::Scope::Flag Sc = __spv::Scope::Flag::Subgroup);
 
 template <typename T1, typename T2, typename T3, std::size_t M, std::size_t K,
-          std::size_t N, __spv::MatrixUse UA = __spv::MatrixUse::Unnecessary,
-          __spv::MatrixUse UB = __spv::MatrixUse::Unnecessary,
-          __spv::MatrixUse UC = __spv::MatrixUse::Unnecessary,
-          __spv::MatrixLayout LA = __spv::MatrixLayout::RowMajor,
+          std::size_t N, __spv::MatrixLayout LA = __spv::MatrixLayout::RowMajor,
           __spv::MatrixLayout LB = __spv::MatrixLayout::RowMajor,
           __spv::MatrixLayout LC = __spv::MatrixLayout::RowMajor,
           __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
-extern SYCL_EXTERNAL JOINT_MATRIX_INTEL(T3, M, N, LC, S, UC) *
+extern SYCL_EXTERNAL __spv::__spirv_JointMatrixINTEL<T3, M, N, LC, S> *
 __spirv_JointMatrixUSMadINTEL(
-    JOINT_MATRIX_INTEL(T1, M, K, LA, S, UA) *A,
-    JOINT_MATRIX_INTEL(T2, K, N, LB, S, UB) *B,
-    JOINT_MATRIX_INTEL(T3, M, N, LC, S, UC) *C,
+    __spv::__spirv_JointMatrixINTEL<T1, M, K, LA, S> *A,
+    __spv::__spirv_JointMatrixINTEL<T2, K, N, LB, S> *B,
+    __spv::__spirv_JointMatrixINTEL<T3, M, N, LC, S> *C,
     __spv::Scope::Flag Sc = __spv::Scope::Flag::Subgroup);
 
 template <typename T1, typename T2, typename T3, std::size_t M, std::size_t K,
-          std::size_t N, __spv::MatrixUse UA = __spv::MatrixUse::Unnecessary,
-          __spv::MatrixUse UB = __spv::MatrixUse::Unnecessary,
-          __spv::MatrixUse UC = __spv::MatrixUse::Unnecessary,
-          __spv::MatrixLayout LA = __spv::MatrixLayout::RowMajor,
+          std::size_t N, __spv::MatrixLayout LA = __spv::MatrixLayout::RowMajor,
           __spv::MatrixLayout LB = __spv::MatrixLayout::RowMajor,
           __spv::MatrixLayout LC = __spv::MatrixLayout::RowMajor,
           __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
-extern SYCL_EXTERNAL JOINT_MATRIX_INTEL(T3, M, N, LC, S, UC) *
+extern SYCL_EXTERNAL __spv::__spirv_JointMatrixINTEL<T3, M, N, LC, S> *
 __spirv_JointMatrixSUMadINTEL(
-    JOINT_MATRIX_INTEL(T1, M, K, LA, S, UA) *A,
-    JOINT_MATRIX_INTEL(T2, K, N, LB, S, UB) *B,
-    JOINT_MATRIX_INTEL(T3, M, N, LC, S, UC) *C,
+    __spv::__spirv_JointMatrixINTEL<T1, M, K, LA, S> *A,
+    __spv::__spirv_JointMatrixINTEL<T2, K, N, LB, S> *B,
+    __spv::__spirv_JointMatrixINTEL<T3, M, N, LC, S> *C,
     __spv::Scope::Flag Sc = __spv::Scope::Flag::Subgroup);
 
 template <typename T, std::size_t R, std::size_t C,
-          __spv::MatrixUse U = __spv::MatrixUse::Unnecessary,
           __spv::MatrixLayout L = __spv::MatrixLayout::RowMajor,
           __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
-extern SYCL_EXTERNAL JOINT_MATRIX_INTEL(T, R, C, L, S, U) *
+extern SYCL_EXTERNAL __spv::__spirv_JointMatrixINTEL<T, R, C, L, S> *
 __spirv_CompositeConstruct(const T v);
 
 template <typename T, std::size_t R, std::size_t C,
-          __spv::MatrixUse U = __spv::MatrixUse::Unnecessary,
           __spv::MatrixLayout L = __spv::MatrixLayout::RowMajor,
           __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
 extern SYCL_EXTERNAL size_t __spirv_JointMatrixWorkItemLengthINTEL(
-    JOINT_MATRIX_INTEL(T, R, C, L, S, U) *);
+    __spv::__spirv_JointMatrixINTEL<T, R, C, L, S> *);
 
 template <typename T, std::size_t R, std::size_t C,
-          __spv::MatrixUse U = __spv::MatrixUse::Unnecessary,
           __spv::MatrixLayout L = __spv::MatrixLayout::RowMajor,
           __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
 extern SYCL_EXTERNAL T __spirv_VectorExtractDynamic(
-    JOINT_MATRIX_INTEL(T, R, C, L, S, U) *, size_t i);
+    __spv::__spirv_JointMatrixINTEL<T, R, C, L, S> *, size_t i);
 
 template <typename T, std::size_t R, std::size_t C,
-         __spv::MatrixUse U = __spv::MatrixUse::Unnecessary,
           __spv::MatrixLayout L = __spv::MatrixLayout::RowMajor,
           __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
-extern SYCL_EXTERNAL JOINT_MATRIX_INTEL(T, R, C, L, S, U) *
-__spirv_VectorInsertDynamic(JOINT_MATRIX_INTEL(T, R, C, L, S, U) *,
+extern SYCL_EXTERNAL __spv::__spirv_JointMatrixINTEL<T, R, C, L, S> *
+__spirv_VectorInsertDynamic(__spv::__spirv_JointMatrixINTEL<T, R, C, L, S> *,
                             T val, size_t i);
-#undef JOINT_MATRIX_INTEL
+#endif // SYCL_EXT_ONEAPI_MATRIX_VERSION
 
 #ifndef __SPIRV_BUILTIN_DECLARATIONS__
 #error                                                                         \

--- a/sycl/include/CL/__spirv/spirv_types.hpp
+++ b/sycl/include/CL/__spirv/spirv_types.hpp
@@ -116,11 +116,7 @@ enum class MatrixLayout : uint32_t {
   Unused = 4
 };
 
-enum class MatrixUse : uint32_t {
-  MatrixA = 0,
-  MatrixB = 1,
-  Accumulator = 2
-};
+enum class MatrixUse : uint32_t { MatrixA = 0, MatrixB = 1, Accumulator = 2 };
 
 #if (SYCL_EXT_ONEAPI_MATRIX_VERSION > 1)
 template <typename T, std::size_t R, std::size_t C, MatrixLayout L,

--- a/sycl/include/CL/__spirv/spirv_types.hpp
+++ b/sycl/include/CL/__spirv/spirv_types.hpp
@@ -119,14 +119,13 @@ enum class MatrixLayout : uint32_t {
 enum class MatrixUse : uint32_t {
   MatrixA = 0,
   MatrixB = 1,
-  Accumulator = 2,
-  Unnecessary = 3
+  Accumulator = 2
 };
 
 #if (SYCL_EXT_ONEAPI_MATRIX_VERSION > 1)
 template <typename T, std::size_t R, std::size_t C, MatrixLayout L,
           Scope::Flag S = Scope::Flag::Subgroup,
-          MatrixUse U = MatrixUse::Unnecessary>
+          MatrixUse U = MatrixUse::MatrixA>
 struct __spirv_JointMatrixINTEL;
 #else
 template <typename T, std::size_t R, std::size_t C, MatrixLayout L,

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-jit-use.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-jit-use.hpp
@@ -39,9 +39,7 @@ SPV_MATRIX_LAYOUT_TRAITS(layout::packed_a, __spv::MatrixLayout::PackedA)
 SPV_MATRIX_LAYOUT_TRAITS(layout::packed_b, __spv::MatrixLayout::PackedB)
 SPV_MATRIX_LAYOUT_TRAITS(layout::unused, __spv::MatrixLayout::Unused)
 
-// unnecessary was introduced for backward compatibility.
-// Once the use implementation is stable, "unnecessary" value will be omitted
-enum class use { a, b, accumulator, unnecessary };
+enum class use { a, b, accumulator };
 
 template <use Use> struct spv_matrix_use_traits {
   static constexpr __spv::MatrixUse value = __spv::MatrixUse::MatrixA;
@@ -55,7 +53,6 @@ template <use Use> struct spv_matrix_use_traits {
 SPV_MATRIX_USE_TRAITS(use::a, __spv::MatrixUse::MatrixA)
 SPV_MATRIX_USE_TRAITS(use::b, __spv::MatrixUse::MatrixB)
 SPV_MATRIX_USE_TRAITS(use::accumulator, __spv::MatrixUse::Accumulator)
-SPV_MATRIX_USE_TRAITS(use::unnecessary, __spv::MatrixUse::Unnecessary)
 
 template <typename G> struct spv_scope_traits {};
 template <> struct spv_scope_traits<sycl::sub_group> {

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-jit.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-jit.hpp
@@ -38,11 +38,6 @@ SPV_MATRIX_LAYOUT_TRAITS(matrix_layout::col_major,
 SPV_MATRIX_LAYOUT_TRAITS(matrix_layout::packed_a, __spv::MatrixLayout::PackedA)
 SPV_MATRIX_LAYOUT_TRAITS(matrix_layout::packed_b, __spv::MatrixLayout::PackedB)
 
-#define SPV_MATRIX_USE_TRAITS(USE, SPV_USE)                                    \
-  template <> struct spv_matrix_use_traits<USE> {                              \
-    static constexpr __spv::MatrixUse value = SPV_USE;                         \
-  };
-
 template <typename G> struct spv_scope_traits {};
 template <> struct spv_scope_traits<sycl::sub_group> {
   constexpr static auto value = __spv::Scope::Subgroup;
@@ -630,6 +625,8 @@ public:
     return wi_element<T, NumRows, NumCols, Layout, Group>(M, i);
   }
 };
+
+#undef SPV_MATRIX_LAYOUT_TRAITS
 
 } // namespace matrix
 } // namespace experimental

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-jit.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-jit.hpp
@@ -90,32 +90,32 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load(
   default:
     assert(false && "Invalid Memory Layout!");
   case matrix_layout::row_major:
-    res.spvm = __spirv_JointMatrixLoadINTEL<
-        T, NumRows, NumCols,
-        spv_matrix_layout_traits<Layout>::value>(
-        Ptr, stride, __spv::MatrixLayout::RowMajor,
-        spv_scope_traits<Group>::value);
+    res.spvm =
+        __spirv_JointMatrixLoadINTEL<T, NumRows, NumCols,
+                                     spv_matrix_layout_traits<Layout>::value>(
+            Ptr, stride, __spv::MatrixLayout::RowMajor,
+            spv_scope_traits<Group>::value);
     break;
   case matrix_layout::col_major:
-    res.spvm = __spirv_JointMatrixLoadINTEL<
-        T, NumRows, NumCols,
-        spv_matrix_layout_traits<Layout>::value>(
-        Ptr, stride, __spv::MatrixLayout::ColumnMajor,
-        spv_scope_traits<Group>::value);
+    res.spvm =
+        __spirv_JointMatrixLoadINTEL<T, NumRows, NumCols,
+                                     spv_matrix_layout_traits<Layout>::value>(
+            Ptr, stride, __spv::MatrixLayout::ColumnMajor,
+            spv_scope_traits<Group>::value);
     break;
   case matrix_layout::packed_a:
-    res.spvm = __spirv_JointMatrixLoadINTEL<
-        T, NumRows, NumCols,
-        spv_matrix_layout_traits<Layout>::value>(
-        Ptr, stride, __spv::MatrixLayout::PackedA,
-        spv_scope_traits<Group>::value);
+    res.spvm =
+        __spirv_JointMatrixLoadINTEL<T, NumRows, NumCols,
+                                     spv_matrix_layout_traits<Layout>::value>(
+            Ptr, stride, __spv::MatrixLayout::PackedA,
+            spv_scope_traits<Group>::value);
     break;
   case matrix_layout::packed_b:
-    res.spvm = __spirv_JointMatrixLoadINTEL<
-        T, NumRows, NumCols,
-        spv_matrix_layout_traits<Layout>::value>(
-        Ptr, stride, __spv::MatrixLayout::PackedB,
-        spv_scope_traits<Group>::value);
+    res.spvm =
+        __spirv_JointMatrixLoadINTEL<T, NumRows, NumCols,
+                                     spv_matrix_layout_traits<Layout>::value>(
+            Ptr, stride, __spv::MatrixLayout::PackedB,
+            spv_scope_traits<Group>::value);
     break;
   }
 #else
@@ -141,32 +141,28 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
   default:
     assert(false && "Invalid Memory Layout!");
   case matrix_layout::row_major:
-    __spirv_JointMatrixStoreINTEL<
-        T, NumRows, NumCols,
-        spv_matrix_layout_traits<MatL>::value>(Ptr, src.spvm, stride,
-                                               __spv::MatrixLayout::RowMajor,
-                                               spv_scope_traits<Group>::value);
+    __spirv_JointMatrixStoreINTEL<T, NumRows, NumCols,
+                                  spv_matrix_layout_traits<MatL>::value>(
+        Ptr, src.spvm, stride, __spv::MatrixLayout::RowMajor,
+        spv_scope_traits<Group>::value);
     break;
   case matrix_layout::col_major:
-    __spirv_JointMatrixStoreINTEL<
-        T, NumRows, NumCols,
-        spv_matrix_layout_traits<MatL>::value>(Ptr, src.spvm, stride,
-                                               __spv::MatrixLayout::ColumnMajor,
-                                               spv_scope_traits<Group>::value);
+    __spirv_JointMatrixStoreINTEL<T, NumRows, NumCols,
+                                  spv_matrix_layout_traits<MatL>::value>(
+        Ptr, src.spvm, stride, __spv::MatrixLayout::ColumnMajor,
+        spv_scope_traits<Group>::value);
     break;
   case matrix_layout::packed_a:
-    __spirv_JointMatrixStoreINTEL<
-        T, NumRows, NumCols,
-        spv_matrix_layout_traits<MatL>::value>(Ptr, src.spvm, stride,
-                                               __spv::MatrixLayout::PackedA,
-                                               spv_scope_traits<Group>::value);
+    __spirv_JointMatrixStoreINTEL<T, NumRows, NumCols,
+                                  spv_matrix_layout_traits<MatL>::value>(
+        Ptr, src.spvm, stride, __spv::MatrixLayout::PackedA,
+        spv_scope_traits<Group>::value);
     break;
   case matrix_layout::packed_b:
-    __spirv_JointMatrixStoreINTEL<
-        T, NumRows, NumCols,
-        spv_matrix_layout_traits<MatL>::value>(Ptr, src.spvm, stride,
-                                               __spv::MatrixLayout::PackedB,
-                                               spv_scope_traits<Group>::value);
+    __spirv_JointMatrixStoreINTEL<T, NumRows, NumCols,
+                                  spv_matrix_layout_traits<MatL>::value>(
+        Ptr, src.spvm, stride, __spv::MatrixLayout::PackedB,
+        spv_scope_traits<Group>::value);
     break;
   }
 #else
@@ -224,9 +220,10 @@ joint_matrix_fill(Group sg,
   // functions
   (void)sg;
 #ifdef __SYCL_DEVICE_ONLY__
-  res.spvm = __spirv_CompositeConstruct<
-      T, NumRows, NumCols,
-      spv_matrix_layout_traits<Layout>::value>(static_cast<T>(v));
+  res.spvm =
+      __spirv_CompositeConstruct<T, NumRows, NumCols,
+                                 spv_matrix_layout_traits<Layout>::value>(
+          static_cast<T>(v));
 
 #else
   (void)res;

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-jit.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-jit.hpp
@@ -38,21 +38,11 @@ SPV_MATRIX_LAYOUT_TRAITS(matrix_layout::col_major,
 SPV_MATRIX_LAYOUT_TRAITS(matrix_layout::packed_a, __spv::MatrixLayout::PackedA)
 SPV_MATRIX_LAYOUT_TRAITS(matrix_layout::packed_b, __spv::MatrixLayout::PackedB)
 
-enum class matrix_use { matrix_a, matrix_b, accumulator, unnecessary };
-
-template <matrix_use Use> struct spv_matrix_use_traits {
-  static constexpr __spv::MatrixUse value = __spv::MatrixUse::MatrixA;
-};
-
 #define SPV_MATRIX_USE_TRAITS(USE, SPV_USE)                                    \
   template <> struct spv_matrix_use_traits<USE> {                              \
     static constexpr __spv::MatrixUse value = SPV_USE;                         \
   };
 
-SPV_MATRIX_USE_TRAITS(matrix_use::matrix_a, __spv::MatrixUse::MatrixA)
-SPV_MATRIX_USE_TRAITS(matrix_use::matrix_b, __spv::MatrixUse::MatrixB)
-SPV_MATRIX_USE_TRAITS(matrix_use::accumulator, __spv::MatrixUse::Accumulator)
-SPV_MATRIX_USE_TRAITS(matrix_use::unnecessary, __spv::MatrixUse::Unnecessary)
 template <typename G> struct spv_scope_traits {};
 template <> struct spv_scope_traits<sycl::sub_group> {
   constexpr static auto value = __spv::Scope::Subgroup;
@@ -102,7 +92,6 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load(
   case matrix_layout::row_major:
     res.spvm = __spirv_JointMatrixLoadINTEL<
         T, NumRows, NumCols,
-        spv_matrix_use_traits<matrix_use::unnecessary>::value,
         spv_matrix_layout_traits<Layout>::value>(
         Ptr, stride, __spv::MatrixLayout::RowMajor,
         spv_scope_traits<Group>::value);
@@ -110,7 +99,6 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load(
   case matrix_layout::col_major:
     res.spvm = __spirv_JointMatrixLoadINTEL<
         T, NumRows, NumCols,
-        spv_matrix_use_traits<matrix_use::unnecessary>::value,
         spv_matrix_layout_traits<Layout>::value>(
         Ptr, stride, __spv::MatrixLayout::ColumnMajor,
         spv_scope_traits<Group>::value);
@@ -118,7 +106,6 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load(
   case matrix_layout::packed_a:
     res.spvm = __spirv_JointMatrixLoadINTEL<
         T, NumRows, NumCols,
-        spv_matrix_use_traits<matrix_use::unnecessary>::value,
         spv_matrix_layout_traits<Layout>::value>(
         Ptr, stride, __spv::MatrixLayout::PackedA,
         spv_scope_traits<Group>::value);
@@ -126,7 +113,6 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_load(
   case matrix_layout::packed_b:
     res.spvm = __spirv_JointMatrixLoadINTEL<
         T, NumRows, NumCols,
-        spv_matrix_use_traits<matrix_use::unnecessary>::value,
         spv_matrix_layout_traits<Layout>::value>(
         Ptr, stride, __spv::MatrixLayout::PackedB,
         spv_scope_traits<Group>::value);
@@ -157,7 +143,6 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
   case matrix_layout::row_major:
     __spirv_JointMatrixStoreINTEL<
         T, NumRows, NumCols,
-        spv_matrix_use_traits<matrix_use::unnecessary>::value,
         spv_matrix_layout_traits<MatL>::value>(Ptr, src.spvm, stride,
                                                __spv::MatrixLayout::RowMajor,
                                                spv_scope_traits<Group>::value);
@@ -165,7 +150,6 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
   case matrix_layout::col_major:
     __spirv_JointMatrixStoreINTEL<
         T, NumRows, NumCols,
-        spv_matrix_use_traits<matrix_use::unnecessary>::value,
         spv_matrix_layout_traits<MatL>::value>(Ptr, src.spvm, stride,
                                                __spv::MatrixLayout::ColumnMajor,
                                                spv_scope_traits<Group>::value);
@@ -173,7 +157,6 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
   case matrix_layout::packed_a:
     __spirv_JointMatrixStoreINTEL<
         T, NumRows, NumCols,
-        spv_matrix_use_traits<matrix_use::unnecessary>::value,
         spv_matrix_layout_traits<MatL>::value>(Ptr, src.spvm, stride,
                                                __spv::MatrixLayout::PackedA,
                                                spv_scope_traits<Group>::value);
@@ -181,7 +164,6 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_store(
   case matrix_layout::packed_b:
     __spirv_JointMatrixStoreINTEL<
         T, NumRows, NumCols,
-        spv_matrix_use_traits<matrix_use::unnecessary>::value,
         spv_matrix_layout_traits<MatL>::value>(Ptr, src.spvm, stride,
                                                __spv::MatrixLayout::PackedB,
                                                spv_scope_traits<Group>::value);
@@ -244,7 +226,6 @@ joint_matrix_fill(Group sg,
 #ifdef __SYCL_DEVICE_ONLY__
   res.spvm = __spirv_CompositeConstruct<
       T, NumRows, NumCols,
-      spv_matrix_use_traits<matrix_use::unnecessary>::value,
       spv_matrix_layout_traits<Layout>::value>(static_cast<T>(v));
 
 #else


### PR DESCRIPTION
It was previously introduced for backwards compatibility with legacy (without Use matrix parameter) API. It is actually not needed.

Signed-off-by: Sidorov, Dmitry <dmitry.sidorov@intel.com>