### PR TITLE
[SYCL] Allow ESIMD backend only when explicitly set by ONEAPI_DEVICE_SELECTOR

### DIFF
--- a/sycl/source/detail/device_filter.cpp
+++ b/sycl/source/detail/device_filter.cpp
@@ -237,10 +237,12 @@ ods_target_list::ods_target_list(const std::string &envStr) {
 // 1. Filter backend is '*' which means ANY backend.
 // 2. Filter backend match exactly with the given 'Backend'
 bool ods_target_list::backendCompatible(backend Backend) {
+  
+  bool isESIMD= Backend == backend::ext_intel_esimd_emulator;
   return std::any_of(
       TargetList.begin(), TargetList.end(), [&](ods_target &Target) {
         backend TargetBackend = Target.Backend.value_or(backend::all);
-        return (TargetBackend == Backend) || (TargetBackend == backend::all);
+        return isESIMD ? (TargetBackend == Backend) : (TargetBackend == Backend) || (TargetBackend == backend::all);
       });
 }
 

--- a/sycl/source/detail/device_filter.cpp
+++ b/sycl/source/detail/device_filter.cpp
@@ -237,12 +237,14 @@ ods_target_list::ods_target_list(const std::string &envStr) {
 // 1. Filter backend is '*' which means ANY backend.
 // 2. Filter backend match exactly with the given 'Backend'
 bool ods_target_list::backendCompatible(backend Backend) {
-  
-  bool isESIMD= Backend == backend::ext_intel_esimd_emulator;
+
+  bool isESIMD = Backend == backend::ext_intel_esimd_emulator;
   return std::any_of(
       TargetList.begin(), TargetList.end(), [&](ods_target &Target) {
         backend TargetBackend = Target.Backend.value_or(backend::all);
-        return isESIMD ? (TargetBackend == Backend) : (TargetBackend == Backend) || (TargetBackend == backend::all);
+        return isESIMD ? (TargetBackend == Backend)
+                       : (TargetBackend == Backend) ||
+                             (TargetBackend == backend::all);
       });
 }
 

--- a/sycl/source/detail/device_filter.cpp
+++ b/sycl/source/detail/device_filter.cpp
@@ -242,9 +242,8 @@ bool ods_target_list::backendCompatible(backend Backend) {
   return std::any_of(
       TargetList.begin(), TargetList.end(), [&](ods_target &Target) {
         backend TargetBackend = Target.Backend.value_or(backend::all);
-        return isESIMD ? (TargetBackend == Backend)
-                       : (TargetBackend == Backend) ||
-                             (TargetBackend == backend::all);
+        return (TargetBackend == Backend) ||
+               (TargetBackend == backend::all && !isESIMD);
       });
 }
 


### PR DESCRIPTION
ONEAPI_DEVICE_SELECTOR would previously implicitly allow ESIMD backends . This isn't desired behavior; desired behavior is to only allow ESIMD backend only when explicitly specified by ONEAPI_DEVICE_SELECTOR.
Fix suggested by @lbushi25 
Signed-off-by: Rauf, Rana <rana.rauf@intel.com>