### PR TITLE
[SYCL-MLIR]: constructAttributeList returns CallingConv

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -1133,11 +1133,13 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
   if (auto *CC = dyn_cast<CXXMemberCallExpr>(Expr)) {
     ValueCategory Obj = Visit(CC->getImplicitObjectArgument());
     ObjType = CC->getObjectType();
-    LLVM_DEBUG(if (!Obj.val) {
-      function.dump();
-      llvm::errs() << " objval: " << Obj.val << "\n";
-      Expr->dump();
-      CC->getImplicitObjectArgument()->dump();
+    LLVM_DEBUG({
+      if (!Obj.val) {
+        function.dump();
+        llvm::errs() << " objval: " << Obj.val << "\n";
+        Expr->dump();
+        CC->getImplicitObjectArgument()->dump();
+      }
     });
 
     if (cast<MemberExpr>(CC->getCallee()->IgnoreParens())->isArrow())

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -100,21 +100,21 @@ static void castCallerArgs(mlir::func::FuncOp Callee,
 /******************************************************************************/
 
 ValueCategory MLIRScanner::callHelper(
-    mlir::func::FuncOp Tocall, QualType ObjType,
+    mlir::func::FuncOp ToCall, QualType ObjType,
     ArrayRef<std::pair<ValueCategory, clang::Expr *>> Arguments,
     QualType RetType, bool RetReference, clang::Expr *Expr,
-    const FunctionDecl *Callee) {
+    const FunctionDecl &Callee) {
   SmallVector<mlir::Value, 4> Args;
-  auto FnType = Tocall.getFunctionType();
-  const clang::CodeGen::CGFunctionInfo &FI =
-      Glob.GetOrCreateCGFunctionInfo(Callee);
-  auto FIArgs = FI.arguments();
+  mlir::FunctionType FnType = ToCall.getFunctionType();
+  const clang::CodeGen::CGFunctionInfo &CalleeInfo =
+      Glob.GetOrCreateCGFunctionInfo(&Callee);
+  auto CalleeArgs = CalleeInfo.arguments();
 
   size_t I = 0;
   // map from declaration name to mlir::value
   std::map<std::string, mlir::Value> MapFuncOperands;
 
-  for (auto Pair : Arguments) {
+  for (const std::pair<ValueCategory, clang::Expr *> &Pair : Arguments) {
     ValueCategory Arg = std::get<0>(Pair);
     clang::Expr *A = std::get<1>(Pair);
 
@@ -134,10 +134,10 @@ ValueCategory MLIRScanner::callHelper(
     if (I >= FnType.getInputs().size() || (I != 0 && A == nullptr)) {
       LLVM_DEBUG({
         Expr->dump();
-        Tocall.dump();
+        ToCall.dump();
         FnType.dump();
-        for (auto a : Arguments)
-          std::get<1>(a)->dump();
+        for (auto A : Arguments)
+          std::get<1>(A)->dump();
       });
       assert(false && "too many arguments in calls");
     }
@@ -175,21 +175,21 @@ ValueCategory MLIRScanner::callHelper(
         });
         assert(Arg.isReference);
 
-        auto Mt =
+        auto MT =
             Glob.getTypes()
                 .getMLIRType(
                     Glob.getCGM().getContext().getLValueReferenceType(AType))
                 .cast<MemRefType>();
 
         LLVM_DEBUG({
-          llvm::dbgs() << "mt: " << Mt << "\n";
+          llvm::dbgs() << "MT: " << MT << "\n";
           llvm::dbgs() << "getLValueReferenceType(aType): "
                        << Glob.getCGM().getContext().getLValueReferenceType(
                               AType)
                        << "\n";
         });
 
-        auto Shape = std::vector<int64_t>(Mt.getShape());
+        auto Shape = std::vector<int64_t>(MT.getShape());
         assert(Shape.size() == 2);
 
         auto Pshape = Shape[0];
@@ -199,21 +199,22 @@ ValueCategory MLIRScanner::callHelper(
         OpBuilder Abuilder(builder.getContext());
         Abuilder.setInsertionPointToStart(allocationScope);
         auto Alloc = Abuilder.create<mlir::memref::AllocaOp>(
-            loc, mlir::MemRefType::get(Shape, Mt.getElementType(),
+            loc, mlir::MemRefType::get(Shape, MT.getElementType(),
                                        MemRefLayoutAttrInterface(),
-                                       Mt.getMemorySpace()));
+                                       MT.getMemorySpace()));
         ValueCategory(Alloc, /*isRef*/ true)
             .store(builder, Arg, /*isArray*/ IsArray);
         Shape[0] = Pshape;
         Val = builder.create<mlir::memref::CastOp>(
             loc,
-            mlir::MemRefType::get(Shape, Mt.getElementType(),
+            mlir::MemRefType::get(Shape, MT.getElementType(),
                                   MemRefLayoutAttrInterface(),
-                                  Mt.getMemorySpace()),
+                                  MT.getMemorySpace()),
             Alloc);
       } else {
-        if (FIArgs[I].info.getKind() == clang::CodeGen::ABIArgInfo::Indirect ||
-            FIArgs[I].info.getKind() ==
+        if (CalleeArgs[I].info.getKind() ==
+                clang::CodeGen::ABIArgInfo::Indirect ||
+            CalleeArgs[I].info.getKind() ==
                 clang::CodeGen::ABIArgInfo::IndirectAliased) {
           OpBuilder Abuilder(builder.getContext());
           Abuilder.setInsertionPointToStart(allocationScope);
@@ -226,20 +227,20 @@ ValueCategory MLIRScanner::callHelper(
             Val = Abuilder.create<mlir::memref::CastOp>(
                 loc, mlir::MemRefType::get(-1, Arg.getValue(builder).getType()),
                 Val);
-          } else {
+          } else
             Val = Abuilder.create<mlir::LLVM::AllocaOp>(
                 loc, Ty, Abuilder.create<arith::ConstantIntOp>(loc, 1, 64), 0);
-          }
+
           ValueCategory(Val, /*isRef*/ true)
               .store(builder, Arg.getValue(builder));
         } else
           Val = Arg.getValue(builder);
 
         if (Val.getType().isa<LLVM::LLVMPointerType>() &&
-            ExpectedType.isa<MemRefType>()) {
+            ExpectedType.isa<MemRefType>())
           Val = builder.create<polygeist::Pointer2MemrefOp>(loc, ExpectedType,
                                                             Val);
-        }
+
         if (auto PrevTy = Val.getType().dyn_cast<mlir::IntegerType>()) {
           auto IPostTy = ExpectedType.cast<mlir::IntegerType>();
           if (PrevTy != IPostTy)
@@ -266,7 +267,7 @@ ValueCategory MLIRScanner::callHelper(
   }
 
   // handle lowerto pragma.
-  if (LTInfo.SymbolTable.count(Tocall.getName())) {
+  if (LTInfo.SymbolTable.count(ToCall.getName())) {
     SmallVector<mlir::Value> InputOperands;
     SmallVector<mlir::Value> OutputOperands;
     for (StringRef Input : LTInfo.InputSymbol)
@@ -280,7 +281,7 @@ ValueCategory MLIRScanner::callHelper(
       InputOperands.append(Args);
 
     return ValueCategory(mlirclang::replaceFuncByOperation(
-                             Tocall, LTInfo.SymbolTable[Tocall.getName()],
+                             ToCall, LTInfo.SymbolTable[ToCall.getName()],
                              builder, InputOperands, OutputOperands)
                              ->getResult(0),
                          /*isReference=*/false);
@@ -292,13 +293,13 @@ ValueCategory MLIRScanner::callHelper(
 
   mlir::Value Alloc;
   if (IsArrayReturn) {
-    auto Mt =
+    auto MT =
         Glob.getTypes()
             .getMLIRType(
                 Glob.getCGM().getContext().getLValueReferenceType(RetType))
             .cast<MemRefType>();
 
-    auto Shape = std::vector<int64_t>(Mt.getShape());
+    auto Shape = std::vector<int64_t>(MT.getShape());
     assert(Shape.size() == 2);
 
     auto Pshape = Shape[0];
@@ -308,14 +309,14 @@ ValueCategory MLIRScanner::callHelper(
     OpBuilder Abuilder(builder.getContext());
     Abuilder.setInsertionPointToStart(allocationScope);
     Alloc = Abuilder.create<mlir::memref::AllocaOp>(
-        loc, mlir::MemRefType::get(Shape, Mt.getElementType(),
+        loc, mlir::MemRefType::get(Shape, MT.getElementType(),
                                    MemRefLayoutAttrInterface(),
-                                   Mt.getMemorySpace()));
+                                   MT.getMemorySpace()));
     Shape[0] = Pshape;
     Alloc = builder.create<mlir::memref::CastOp>(
         loc,
-        mlir::MemRefType::get(Shape, Mt.getElementType(),
-                              MemRefLayoutAttrInterface(), Mt.getMemorySpace()),
+        mlir::MemRefType::get(Shape, MT.getElementType(),
+                              MemRefLayoutAttrInterface(), MT.getMemorySpace()),
         Alloc);
     Args.push_back(Alloc);
   }
@@ -391,19 +392,19 @@ ValueCategory MLIRScanner::callHelper(
     auto Oldpoint = builder.getInsertionPoint();
     auto *Oldblock = builder.getInsertionBlock();
     builder.setInsertionPointToStart(&Op.getRegion().front());
-    builder.create<CallOp>(loc, Tocall, Args);
+    builder.create<CallOp>(loc, ToCall, Args);
     builder.create<gpu::TerminatorOp>(loc);
     builder.setInsertionPoint(Oldblock, Oldpoint);
     return nullptr;
   }
 
   // Try to rescue some mismatched types.
-  castCallerArgs(Tocall, Args, builder);
+  castCallerArgs(ToCall, Args, builder);
 
   /// Try to emit SYCL operations before creating a CallOp
   mlir::Operation *Op = emitSYCLOps(Expr, Args);
   if (!Op)
-    Op = builder.create<CallOp>(loc, Tocall, Args);
+    Op = builder.create<CallOp>(loc, ToCall, Args);
 
   if (IsArrayReturn) {
     // TODO remedy return
@@ -412,13 +413,12 @@ ValueCategory MLIRScanner::callHelper(
     assert(!RetReference);
     return ValueCategory(Alloc, /*isReference*/ true);
   }
-  if (Op->getNumResults()) {
+
+  if (Op->getNumResults())
     return ValueCategory(Op->getResult(0),
                          /*isReference*/ RetReference);
-  }
+
   return nullptr;
-  llvm::errs() << "do not support indirecto call of " << Tocall << "\n";
-  assert(0 && "no indirect");
 }
 
 std::pair<ValueCategory, bool>
@@ -445,21 +445,6 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
   });
 
   auto Loc = getMLIRLocation(Expr->getExprLoc());
-  /*
-  if (auto ic = dyn_cast<ImplicitCastExpr>(expr->getCallee()))
-    if (auto sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
-      if (sr->getDecl()->getIdentifier() &&
-          sr->getDecl()->getName() == "__shfl_up_sync") {
-        std::vector<mlir::Value> args;
-        for (auto a : expr->arguments()) {
-          args.push_back(Visit(a).getValue(builder));
-        }
-        builder.create<gpu::ShuffleOp>(loc, );
-        assert(0 && "__shfl_up_sync unhandled");
-        return nullptr;
-      }
-    }
-  */
 
   auto ValEmitted = emitGPUCallExpr(Expr);
   if (ValEmitted.second)
@@ -498,7 +483,6 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
 
   if (auto *Oc = dyn_cast<CXXMemberCallExpr>(Expr)) {
     if (auto *LHS = dyn_cast<CXXTypeidExpr>(Oc->getImplicitObjectArgument())) {
-      Expr->getCallee()->dump();
       if (auto *Ic = dyn_cast<MemberExpr>(Expr->getCallee()))
         if (auto *Sr = dyn_cast<NamedDecl>(Ic->getMemberDecl())) {
           if (Sr->getIdentifier() && Sr->getName() == "name") {
@@ -946,8 +930,8 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
           (isa<CXXOperatorCallExpr>(Expr) &&
            cast<CXXOperatorCallExpr>(Expr)->getOperator() ==
                OO_GreaterGreater)) {
-        const auto *Tocall = EmitCallee(Expr->getCallee());
-        auto StrcmpF = Glob.GetOrCreateLLVMFunction(Tocall);
+        const auto *ToCall = EmitCallee(Expr->getCallee());
+        auto StrcmpF = Glob.GetOrCreateLLVMFunction(ToCall);
 
         std::vector<mlir::Value> Args;
         std::vector<std::pair<mlir::Value, mlir::Value>> Ops;
@@ -1149,17 +1133,16 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
   if (auto *CC = dyn_cast<CXXMemberCallExpr>(Expr)) {
     ValueCategory Obj = Visit(CC->getImplicitObjectArgument());
     ObjType = CC->getObjectType();
-#ifdef DEBUG
-    if (!obj.val) {
+    LLVM_DEBUG(if (!Obj.val) {
       function.dump();
-      llvm::errs() << " objval: " << obj.val << "\n";
-      expr->dump();
+      llvm::errs() << " objval: " << Obj.val << "\n";
+      Expr->dump();
       CC->getImplicitObjectArgument()->dump();
-    }
-#endif
-    if (cast<MemberExpr>(CC->getCallee()->IgnoreParens())->isArrow()) {
+    });
+
+    if (cast<MemberExpr>(CC->getCallee()->IgnoreParens())->isArrow())
       Obj = Obj.dereference(builder);
-    }
+
     assert(Obj.val);
     assert(Obj.isReference);
     Args.emplace_back(std::make_pair(Obj, (clang::Expr *)nullptr));
@@ -1169,7 +1152,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
     Args.push_back(std::make_pair(Visit(A), A));
 
   return callHelper(ToCall, ObjType, Args, Expr->getType(),
-                    Expr->isLValue() || Expr->isXValue(), Expr, Callee);
+                    Expr->isLValue() || Expr->isXValue(), Expr, *Callee);
 }
 
 std::pair<ValueCategory, bool>

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -862,19 +862,20 @@ ValueCategory MLIRScanner::VisitConstructCommon(clang::CXXConstructExpr *cons,
     ShouldEmit = true;
 
   FunctionToEmit F(*ctorDecl, mlirclang::getInputContext(builder));
-  auto tocall = cast<func::FuncOp>(Glob.GetOrCreateMLIRFunction(F, ShouldEmit));
+  auto ToCall = cast<func::FuncOp>(Glob.GetOrCreateMLIRFunction(F, ShouldEmit));
 
-  SmallVector<std::pair<ValueCategory, clang::Expr *>> args;
-  args.emplace_back(std::make_pair(obj, (clang::Expr *)nullptr));
-  for (auto a : cons->arguments())
-    args.push_back(std::make_pair(Visit(a), a));
-  callHelper(tocall, innerType, args,
+  SmallVector<std::pair<ValueCategory, clang::Expr *>> Args;
+  Args.emplace_back(std::make_pair(obj, (clang::Expr *)nullptr));
+  for (auto A : cons->arguments())
+    Args.push_back(std::make_pair(Visit(A), A));
+
+  callHelper(ToCall, innerType, Args,
              /*retType*/ Glob.getCGM().getContext().VoidTy, false, cons,
-             ctorDecl);
+             *ctorDecl);
 
-  if (Glob.getCGM().getContext().getAsArrayType(cons->getType())) {
+  if (Glob.getCGM().getContext().getAsArrayType(cons->getType()))
     builder.setInsertionPoint(oldblock, oldpoint);
-  }
+
   return endobj;
 }
 

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -864,10 +864,10 @@ ValueCategory MLIRScanner::VisitConstructCommon(clang::CXXConstructExpr *cons,
   FunctionToEmit F(*ctorDecl, mlirclang::getInputContext(builder));
   auto ToCall = cast<func::FuncOp>(Glob.GetOrCreateMLIRFunction(F, ShouldEmit));
 
-  SmallVector<std::pair<ValueCategory, clang::Expr *>> Args;
-  Args.emplace_back(std::make_pair(obj, (clang::Expr *)nullptr));
+  SmallVector<std::pair<ValueCategory, clang::Expr *>> Args{{obj, nullptr}};
+  Args.reserve(cons->getNumArgs() + 1);
   for (auto A : cons->arguments())
-    Args.push_back(std::make_pair(Visit(A), A));
+    Args.emplace_back(Visit(A), A);
 
   callHelper(ToCall, innerType, Args,
              /*retType*/ Glob.getCGM().getContext().VoidTy, false, cons,

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -646,16 +646,12 @@ CodeGenTypes::getFunctionType(const clang::CodeGen::CGFunctionInfo &FI,
 void CodeGenTypes::constructAttributeList(
     StringRef Name, const clang::CodeGen::CGFunctionInfo &FI,
     clang::CodeGen::CGCalleeInfo CalleeInfo, mlirclang::AttributeList &AttrList,
-    bool AttrOnCallSite, bool IsThunk) {
+    unsigned &CallingConv, bool AttrOnCallSite, bool IsThunk) {
   MLIRContext *Ctx = TheModule->getContext();
   mlirclang::AttrBuilder FuncAttrsBuilder(*Ctx);
   mlirclang::AttrBuilder RetAttrsBuilder(*Ctx);
 
-  unsigned CC = FI.getEffectiveCallingConvention();
-  FuncAttrsBuilder.addAttribute(
-      "llvm.cconv", mlir::LLVM::CConvAttr::get(
-                        Ctx, static_cast<mlir::LLVM::cconv::CConv>(CC)));
-
+  CallingConv = FI.getEffectiveCallingConvention();
   if (FI.isNoReturn())
     FuncAttrsBuilder.addPassThroughAttribute(llvm::Attribute::NoReturn);
   if (FI.isCmseNSCall())

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.h
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.h
@@ -79,7 +79,8 @@ public:
                               const clang::CodeGen::CGFunctionInfo &FI,
                               clang::CodeGen::CGCalleeInfo CalleeInfo,
                               mlirclang::AttributeList &AttrList,
-                              bool AttrOnCallSite, bool IsThunk);
+                              unsigned &CallingConv, bool AttrOnCallSite,
+                              bool IsThunk);
 
   // TODO: Possibly create a SYCLTypeCache
   mlir::Type getMLIRType(clang::QualType QT, bool *ImplicitRef = nullptr,

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -423,10 +423,10 @@ public:
   ValueCategory VisitCallExpr(clang::CallExpr *Expr);
 
   ValueCategory
-  callHelper(mlir::func::FuncOp Tocall, clang::QualType ObjType,
+  callHelper(mlir::func::FuncOp ToCall, clang::QualType ObjType,
              clang::ArrayRef<std::pair<ValueCategory, clang::Expr *>> Arguments,
              clang::QualType RetType, bool RetReference, clang::Expr *Expr,
-             const clang::FunctionDecl *Callee);
+             const clang::FunctionDecl &Callee);
 
   std::pair<ValueCategory, bool>
   emitClangBuiltinCallExpr(clang::CallExpr *Expr);


### PR DESCRIPTION
This PR modifies `constructAttributeList` to pass CallingConv as a reference argument (same as clang). The PR also applies a few clang-tidy related changes.