### PR TITLE
[SYCL-MLIR]: Set alignment and const on global variables

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -201,12 +201,10 @@ MLIRScanner::InitializeValueByInitListExpr(mlir::Value toInit,
 
   // Recursively visit the initialization expression following the linear
   // increment of the memory address.
- const auto
-      helper = [&](const Expr *expr, mlir::Value toInit,
-                   bool inner) -> mlir::DenseElementsAttr {
+  const auto helper = [&](const Expr *expr, mlir::Value toInit,
+                          bool inner) -> mlir::DenseElementsAttr {
     Location loc = toInit.getLoc();
-    if (const InitListExpr *initListExpr = dyn_cast<InitListExpr>(expr)) {
-
+    if (InitListExpr *initListExpr = dyn_cast<InitListExpr>(expr)) {
       if (inner) {
         if (auto mt = toInit.getType().dyn_cast<MemRefType>()) {
           auto shape = std::vector<int64_t>(mt.getShape());

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1246,7 +1246,8 @@ ValueCategory MLIRScanner::VisitDeclRefExpr(DeclRefExpr *E) {
     auto gv2 = builder.create<memref::GetGlobalOp>(loc, gv.first.getType(),
                                                    gv.first.getName());
     Value V = castToMemSpace(
-        gv2, Glob.getCGM().getContext().getTargetAddressSpace(VD->getType()));
+        reshapeRanklessGlobal(gv2),
+        Glob.getCGM().getContext().getTargetAddressSpace(VD->getType()));
 
     // TODO check reference
     return ValueCategory(V, /*isReference*/ true);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -2294,8 +2294,8 @@ MLIRASTConsumer::getOrCreateGlobal(const ValueDecl &VD, std::string Prefix,
       CGM.getContext().getTargetAddressSpace(CGM.GetGlobalVarAddressSpace(Var));
 
   // Global variables have always memref type. Their should always have a memref
-  // type with rank zero, however we currently do not yet handle global vector
-  // or arrays correctly.
+  // type with rank zero, however we currently do not yet handle global with ext
+  // vector type correctly.
   auto VarTy =
       (!IsArray && !IsExtVectorType)
           ? mlir::MemRefType::get({}, MLIRType, {}, MemSpace)

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -679,8 +679,8 @@ ValueCategory MLIRScanner::VisitVarDecl(clang::VarDecl *decl) {
                       decl, (function.getName() + "@static@").str()));
     } else {
       auto gv =
-          Glob.GetOrCreateGlobal(decl, (function.getName() + "@static@").str(),
-                                 /*tryInit*/ false);
+          Glob.getOrCreateGlobal(*decl, (function.getName() + "@static@").str(),
+                                 FunctionContext::Host);
       auto gv2 = abuilder.create<memref::GetGlobalOp>(
           varLoc, gv.first.getType(), gv.first.getName());
       op = reshapeRanklessGlobal(gv2);
@@ -2278,61 +2278,60 @@ MLIRASTConsumer::GetOrCreateLLVMGlobal(const ValueDecl *FD,
 }
 
 std::pair<mlir::memref::GlobalOp, bool>
-MLIRASTConsumer::GetOrCreateGlobal(const ValueDecl *FD, std::string prefix,
-                                   bool tryInit, FunctionContext funcContext) {
-  std::string name = prefix + CGM.getMangledName(FD).str();
+MLIRASTConsumer::getOrCreateGlobal(const ValueDecl &VD, std::string Prefix,
+                                   FunctionContext FuncContext) {
+  const std::string Name = PrefixABI + Prefix + CGM.getMangledName(&VD).str();
+  if (globals.find(Name) != globals.end())
+    return globals[Name];
 
-  name = (PrefixABI + name);
+  const bool IsArray = isa<clang::ArrayType>(VD.getType());
+  const bool IsExtVectorType =
+      isa<clang::ExtVectorType>(VD.getType()->getUnqualifiedDesugaredType());
 
-  if (globals.find(name) != globals.end()) {
-    return globals[name];
+  const mlir::Type MLIRType = getTypes().getMLIRType(VD.getType());
+  const clang::VarDecl *Var = cast<VarDecl>(VD).getCanonicalDecl();
+  const unsigned MemSpace =
+      CGM.getContext().getTargetAddressSpace(CGM.GetGlobalVarAddressSpace(Var));
+
+  // Global variables have always memref type. Their should always have a memref
+  // type with rank zero, however we currently do not yet handle global vector
+  // or arrays correctly.
+  auto VarTy =
+      (!IsArray && !IsExtVectorType)
+          ? mlir::MemRefType::get({}, MLIRType, {}, MemSpace)
+          : mlir::MemRefType::get(
+                MLIRType.cast<mlir::MemRefType>().getShape(),
+                MLIRType.cast<mlir::MemRefType>().getElementType(),
+                MemRefLayoutAttrInterface(),
+                wrapIntegerMemorySpace(MemSpace, module->getContext()));
+
+  // The insertion point depends on whether the global variable is in the host
+  // or the device context.
+  mlir::OpBuilder Builder(module->getContext());
+  if (FuncContext == FunctionContext::SYCLDevice)
+    Builder.setInsertionPointToStart(getDeviceModule(*module).getBody());
+  else {
+    assert(FuncContext == FunctionContext::Host);
+    Builder.setInsertionPointToStart(module->getBody());
   }
 
-  mlir::Type rt = getTypes().getMLIRType(FD->getType());
-  auto *VD = dyn_cast<VarDecl>(FD);
-  LLVM_DEBUG({
-    if (!VD)
-      FD->dump();
-  });
-  VD = VD->getCanonicalDecl();
-  unsigned memspace = VD ? CGM.getContext().getTargetAddressSpace(
-                               CGM.GetGlobalVarAddressSpace(VD))
-                         : CGM.getDataLayout().getDefaultGlobalsAddressSpace();
-  bool isArray = isa<clang::ArrayType>(FD->getType());
-  bool isExtVectorType =
-      isa<clang::ExtVectorType>(FD->getType()->getUnqualifiedDesugaredType());
+  // Create the global.
+  VarDecl::DefinitionKind DefKind = Var->isThisDeclarationADefinition();
+  mlir::Attribute InitialVal;
+  if (DefKind == VarDecl::Definition || DefKind == VarDecl::TentativeDefinition)
+    InitialVal = Builder.getUnitAttr();
 
-  mlir::MemRefType mr;
-  if (!isArray && !isExtVectorType) {
-    mr = mlir::MemRefType::get({}, rt, {}, memspace);
-  } else {
-    auto mt = rt.cast<mlir::MemRefType>();
-    mr = mlir::MemRefType::get(
-        mt.getShape(), mt.getElementType(), MemRefLayoutAttrInterface(),
-        wrapIntegerMemorySpace(memspace, mt.getContext()));
-  }
+  auto globalOp = Builder.create<mlir::memref::GlobalOp>(
+      module->getLoc(), Name, /*sym_visibility*/ mlir::StringAttr(), VarTy,
+      InitialVal, /*constant*/ false, /*alignment*/ nullptr);
 
-  mlir::SymbolTable::Visibility lnk;
-  mlir::Attribute initial_value;
-
-  mlir::OpBuilder builder(module->getContext());
-  if (funcContext == FunctionContext::SYCLDevice)
-    builder.setInsertionPointToStart(getDeviceModule(*module).getBody());
-  else
-    builder.setInsertionPointToStart(module->getBody());
-
-  if (VD->isThisDeclarationADefinition() == VarDecl::Definition) {
-    initial_value = builder.getUnitAttr();
-  } else if (VD->isThisDeclarationADefinition() ==
-             VarDecl::TentativeDefinition) {
-    initial_value = builder.getUnitAttr();
-  }
-
-  switch (CGM.getLLVMLinkageVarDefinition(VD,
+  // Set the visibility.
+  switch (CGM.getLLVMLinkageVarDefinition(Var,
                                           /*isConstant*/ false)) {
   case llvm::GlobalValue::LinkageTypes::InternalLinkage:
   case llvm::GlobalValue::LinkageTypes::PrivateLinkage:
-    lnk = mlir::SymbolTable::Visibility::Private;
+    SymbolTable::setSymbolVisibility(globalOp,
+                                     mlir::SymbolTable::Visibility::Private);
     break;
   case llvm::GlobalValue::LinkageTypes::ExternalLinkage:
   case llvm::GlobalValue::LinkageTypes::AvailableExternallyLinkage:
@@ -2343,64 +2342,49 @@ MLIRASTConsumer::GetOrCreateGlobal(const ValueDecl *FD, std::string prefix,
   case llvm::GlobalValue::LinkageTypes::AppendingLinkage:
   case llvm::GlobalValue::LinkageTypes::ExternalWeakLinkage:
   case llvm::GlobalValue::LinkageTypes::LinkOnceODRLinkage:
-    lnk = mlir::SymbolTable::Visibility::Public;
+    SymbolTable::setSymbolVisibility(globalOp,
+                                     mlir::SymbolTable::Visibility::Public);
     break;
   }
-  auto globalOp = builder.create<mlir::memref::GlobalOp>(
-      module->getLoc(), builder.getStringAttr(name),
-      /*sym_visibility*/ mlir::StringAttr(), mlir::TypeAttr::get(mr),
-      initial_value, mlir::UnitAttr(), /*alignment*/ nullptr);
-  SymbolTable::setSymbolVisibility(globalOp, lnk);
 
-  globals[name] = std::make_pair(globalOp, isArray);
+  // Initialize the global variable.
+  if (const Expr *Init = Var->getInit()) {
+    MLIRScanner MS(*this, module, LTInfo);
+    mlir::Block B;
+    // In case of device function, we will put the block in the forefront of
+    // the GPU module, else the block will go at the forefront of the main
+    // module.
+    if (FuncContext == FunctionContext::SYCLDevice) {
+      B.moveBefore(getDeviceModule(*module).getBody());
+      MS.getBuilder().setInsertionPointToStart(&B);
+    } else
+      MS.setEntryAndAllocBlock(&B);
 
-  if (tryInit)
-    if (auto init = VD->getInit()) {
-      MLIRScanner ms(*this, module, LTInfo);
-      mlir::Block *B = new Block();
-      // In case of device function, we will put the block in the forefront of
-      // the GPU module, else the block will go at the forefront of the main
-      // module.
-      if (funcContext == FunctionContext::SYCLDevice) {
-        B->moveBefore(getDeviceModule(*module).getBody());
-        ms.getBuilder().setInsertionPointToStart(B);
-      } else
-        ms.setEntryAndAllocBlock(B);
-      OpBuilder builder(module->getContext());
-      builder.setInsertionPointToEnd(B);
-      auto op = builder.create<memref::AllocaOp>(module->getLoc(), mr);
+    OpBuilder Builder(module->getContext());
+    Builder.setInsertionPointToEnd(&B);
+    auto Op = Builder.create<memref::AllocaOp>(module->getLoc(), VarTy);
 
-      bool initialized = false;
-      if (isa<InitListExpr>(init)) {
-        if (auto A = ms.InitializeValueByInitListExpr(
-                op, const_cast<clang::Expr *>(init))) {
-          initialized = true;
-          initial_value = A;
+    if (isa<InitListExpr>(Init)) {
+      mlir::Attribute InitValAttr = MS.InitializeValueByInitListExpr(Op, Init);
+      globalOp.setInitialValueAttr(InitValAttr);
+    } else {
+      bool Initialized = false;
+      ValueCategory VC = MS.Visit(const_cast<clang::Expr *>(Init));
+      if (!VC.isReference)
+        if (auto Op = VC.val.getDefiningOp<arith::ConstantOp>()) {
+          auto InitialVal = SplatElementsAttr::get(
+              RankedTensorType::get(VarTy.getShape(), VarTy.getElementType()),
+              Op.getValue());
+          globalOp.setInitialValueAttr(InitialVal);
+          Initialized = true;
         }
-      } else {
-        auto VC = ms.Visit(const_cast<clang::Expr *>(init));
-        if (!VC.isReference) {
-          if (auto cop = VC.val.getDefiningOp<arith::ConstantOp>()) {
-            initial_value = cop.getValue();
-            initial_value = SplatElementsAttr::get(
-                RankedTensorType::get(mr.getShape(), mr.getElementType()),
-                initial_value);
-            initialized = true;
-          }
-        }
-      }
-
-      if (!initialized) {
-        FD->dump();
-        init->dump();
-        llvm::errs() << " warning not initializing global: " << name << "\n";
-      } else {
-        globalOp.setInitialValueAttr(initial_value);
-      }
-      delete B;
+      assert(Initialized);
     }
+  }
 
-  return globals[name];
+  globals[Name] = std::make_pair(globalOp, IsArray);
+
+  return globals[Name];
 }
 
 mlir::Value MLIRASTConsumer::GetOrCreateGlobalLLVMString(

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -2368,7 +2368,8 @@ MLIRASTConsumer::getOrCreateGlobal(const ValueDecl &VD, std::string Prefix,
     auto Op = Builder.create<memref::AllocaOp>(module->getLoc(), VarTy);
 
     if (isa<InitListExpr>(Init)) {
-      mlir::Attribute InitValAttr = MS.InitializeValueByInitListExpr(Op, Init);
+      mlir::Attribute InitValAttr =
+          MS.InitializeValueByInitListExpr(Op, const_cast<clang::Expr *>(Init));
       globalOp.setInitialValueAttr(InitValAttr);
     } else {
       bool Initialized = false;

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -2321,13 +2321,14 @@ MLIRASTConsumer::getOrCreateGlobal(const ValueDecl &VD, std::string Prefix,
   if (DefKind == VarDecl::Definition || DefKind == VarDecl::TentativeDefinition)
     InitialVal = Builder.getUnitAttr();
 
+  const bool IsConst = VD.getType().isConstQualified();
+
   auto globalOp = Builder.create<mlir::memref::GlobalOp>(
       module->getLoc(), Name, /*sym_visibility*/ mlir::StringAttr(), VarTy,
-      InitialVal, /*constant*/ false, /*alignment*/ nullptr);
+      InitialVal, IsConst, /*alignment*/ nullptr);
 
   // Set the visibility.
-  switch (CGM.getLLVMLinkageVarDefinition(Var,
-                                          /*isConstant*/ false)) {
+  switch (CGM.getLLVMLinkageVarDefinition(Var, IsConst)) {
   case llvm::GlobalValue::LinkageTypes::InternalLinkage:
   case llvm::GlobalValue::LinkageTypes::PrivateLinkage:
     SymbolTable::setSymbolVisibility(globalOp,

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -2322,10 +2322,12 @@ MLIRASTConsumer::getOrCreateGlobal(const ValueDecl &VD, std::string Prefix,
     InitialVal = Builder.getUnitAttr();
 
   const bool IsConst = VD.getType().isConstQualified();
+  llvm::Align Align = CGM.getContext().getDeclAlign(&VD).getAsAlign();
 
   auto globalOp = Builder.create<mlir::memref::GlobalOp>(
       module->getLoc(), Name, /*sym_visibility*/ mlir::StringAttr(), VarTy,
-      InitialVal, IsConst, /*alignment*/ nullptr);
+      InitialVal, IsConst,
+      Builder.getIntegerAttr(Builder.getIntegerType(64), Align.value()));
 
   // Set the visibility.
   switch (CGM.getLLVMLinkageVarDefinition(Var, IsConst)) {

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -192,10 +192,10 @@ public:
                                           mlir::OpBuilder &Builder,
                                           clang::StringRef Value);
 
+  /// Create global variable and initialize it.
   std::pair<mlir::memref::GlobalOp, bool>
-  GetOrCreateGlobal(const clang::ValueDecl *VD, std::string Prefix,
-                    bool TryInit = true,
-                    FunctionContext FuncContext = FunctionContext::Host);
+  getOrCreateGlobal(const clang::ValueDecl &VD, std::string Prefix,
+                    FunctionContext FuncContext);
 
   const clang::CodeGen::CGFunctionInfo &
   GetOrCreateCGFunctionInfo(const clang::FunctionDecl *FD);
@@ -553,7 +553,7 @@ public:
   ValueCategory VisitCXXFunctionalCastExpr(clang::CXXFunctionalCastExpr *Expr);
 
   mlir::Attribute InitializeValueByInitListExpr(mlir::Value ToInit,
-                                                clang::Expr *Expr);
+                                                const clang::Expr *Expr);
 
   ValueCategory VisitInitListExpr(clang::InitListExpr *Expr);
 

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -350,6 +350,9 @@ private:
                      llvm::Optional<mlir::Type> ReturnType,
                      llvm::StringRef MangledFunctionName);
 
+  // Reshape memref<elemTy> to memref<1 x elemTy>.
+  mlir::Value reshapeRanklessGlobal(mlir::memref::GetGlobalOp GV);
+
 public:
   MLIRScanner(MLIRASTConsumer &Glob, mlir::OwningOpRef<mlir::ModuleOp> &Module,
               LowerToInfo &LTInfo);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -553,7 +553,7 @@ public:
   ValueCategory VisitCXXFunctionalCastExpr(clang::CXXFunctionalCastExpr *Expr);
 
   mlir::Attribute InitializeValueByInitListExpr(mlir::Value ToInit,
-                                                const clang::Expr *Expr);
+                                                clang::Expr *Expr);
 
   ValueCategory VisitInitListExpr(clang::InitListExpr *Expr);
 

--- a/polygeist/tools/cgeist/Test/Verification/global.c
+++ b/polygeist/tools/cgeist/Test/Verification/global.c
@@ -11,7 +11,7 @@ int main() {
   return 0;
 }
 
-// CHECK:  memref.global @A : memref<64x32xf32>
+// CHECK:  memref.global @A : memref<64x32xf32> = uninitialized {alignment = 16 : i64}
 // CHECK:  func @main() -> i32
 // CHECK-DAG:    %cst = arith.constant 3.000000e+00 : f32
 // CHECK-DAG:    %c0_i32 = arith.constant 0 : i32

--- a/polygeist/tools/cgeist/Test/Verification/globals.c
+++ b/polygeist/tools/cgeist/Test/Verification/globals.c
@@ -12,11 +12,11 @@ void kernel_deriche() {
     run(&local, &local_init, &internal, &internal_init, &external);
 }
 
-// CHECK-DAG:   memref.global @external : memref<i32>
-// CHECK-DAG:   memref.global "private" @internal_init : memref<i32> = dense<5>
-// CHECK-DAG:   memref.global "private" @internal : memref<i32> = uninitialized
-// CHECK-DAG:   memref.global @local_init : memref<i32> = dense<4>
-// CHECK-DAG:   memref.global @local : memref<i32> = uninitialized
+// CHECK-DAG:   memref.global @external : memref<i32> {alignment = 4 : i64}
+// CHECK-DAG:   memref.global "private" @internal_init : memref<i32> = dense<5> {alignment = 4 : i64}
+// CHECK-DAG:   memref.global "private" @internal : memref<i32> = uninitialized {alignment = 4 : i64}
+// CHECK-DAG:   memref.global @local_init : memref<i32> = dense<4> {alignment = 4 : i64}
+// CHECK-DAG:   memref.global @local : memref<i32> = uninitialized {alignment = 4 : i64}
 // CHECK:   func @kernel_deriche()
 // CHECK-NEXT:     %0 = memref.get_global @local : memref<i32>
 // CHECK-NEXT:     %alloca = memref.alloca() : memref<1xindex>
@@ -42,11 +42,11 @@ void kernel_deriche() {
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 
-// LLVM-DAG: @local = global i32 undef
-// LLVM-DAG: @local_init = global i32 4
-// LLVM-DAG: @internal = private global i32 undef
-// LLVM-DAG: @internal_init = private global i32 5
-// LLVM-DAG: @external = external global i32
+// LLVM-DAG: @local = global i32 undef, align 4
+// LLVM-DAG: @local_init = global i32 4, align 4
+// LLVM-DAG: @internal = private global i32 undef, align 4
+// LLVM-DAG: @internal_init = private global i32 5, align 4
+// LLVM-DAG: @external = external global i32, align 4
 // LLVM-LABEL: define void @kernel_deriche() {
 // LLVM-NEXT:   call void @run(i32* @local, i32* @local_init, i32* @internal, i32* @internal_init, i32* @external)
 // LLVM-NEXT:   ret void

--- a/polygeist/tools/cgeist/Test/Verification/globals.c
+++ b/polygeist/tools/cgeist/Test/Verification/globals.c
@@ -1,4 +1,5 @@
 // RUN: cgeist %s --function=kernel_deriche -S | FileCheck %s
+// RUN: cgeist %s --function=kernel_deriche -S -emit-llvm | FileCheck %s --check-prefix=LLVM
 
 int local;
 int local_init = 4;
@@ -11,22 +12,42 @@ void kernel_deriche() {
     run(&local, &local_init, &internal, &internal_init, &external);
 }
 
-// CHECK-DAG:   memref.global @external : memref<1xi32>
-// CHECK-DAG:   memref.global "private" @internal_init : memref<1xi32> = dense<5>
-// CHECK-DAG:   memref.global "private" @internal : memref<1xi32> = uninitialized
-// CHECK-DAG:   memref.global @local_init : memref<1xi32> = dense<4>
-// CHECK-DAG:   memref.global @local : memref<1xi32> = uninitialized
+// CHECK-DAG:   memref.global @external : memref<i32>
+// CHECK-DAG:   memref.global "private" @internal_init : memref<i32> = dense<5>
+// CHECK-DAG:   memref.global "private" @internal : memref<i32> = uninitialized
+// CHECK-DAG:   memref.global @local_init : memref<i32> = dense<4>
+// CHECK-DAG:   memref.global @local : memref<i32> = uninitialized
 // CHECK:   func @kernel_deriche()
-// CHECK-NEXT:     %0 = memref.get_global @local : memref<1xi32>
-// CHECK-NEXT:     %cast = memref.cast %0 : memref<1xi32> to memref<?xi32>
-// CHECK-NEXT:     %1 = memref.get_global @local_init : memref<1xi32>
-// CHECK-NEXT:     %cast_0 = memref.cast %1 : memref<1xi32> to memref<?xi32>
-// CHECK-NEXT:     %2 = memref.get_global @internal : memref<1xi32>
-// CHECK-NEXT:     %cast_1 = memref.cast %2 : memref<1xi32> to memref<?xi32>
-// CHECK-NEXT:     %3 = memref.get_global @internal_init : memref<1xi32>
-// CHECK-NEXT:     %cast_2 = memref.cast %3 : memref<1xi32> to memref<?xi32>
-// CHECK-NEXT:     %4 = memref.get_global @external : memref<1xi32>
-// CHECK-NEXT:     %cast_3 = memref.cast %4 : memref<1xi32> to memref<?xi32>
-// CHECK-NEXT:     call @run(%cast, %cast_0, %cast_1, %cast_2, %cast_3) : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> ()
+// CHECK-NEXT:     %0 = memref.get_global @local : memref<i32>
+// CHECK-NEXT:     %alloca = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:     %reshape = memref.reshape %0(%alloca) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
+// CHECK-NEXT:     %cast = memref.cast %reshape : memref<1xi32> to memref<?xi32>
+// CHECK-NEXT:     %1 = memref.get_global @local_init : memref<i32>
+// CHECK-NEXT:     %alloca_0 = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:     %reshape_1 = memref.reshape %1(%alloca_0) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
+// CHECK-NEXT:     %cast_2 = memref.cast %reshape_1 : memref<1xi32> to memref<?xi32>
+// CHECK-NEXT:     %2 = memref.get_global @internal : memref<i32>
+// CHECK-NEXT:     %alloca_3 = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:     %reshape_4 = memref.reshape %2(%alloca_3) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
+// CHECK-NEXT:     %cast_5 = memref.cast %reshape_4 : memref<1xi32> to memref<?xi32>
+// CHECK-NEXT:     %3 = memref.get_global @internal_init : memref<i32>
+// CHECK-NEXT:     %alloca_6 = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:     %reshape_7 = memref.reshape %3(%alloca_6) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
+// CHECK-NEXT:     %cast_8 = memref.cast %reshape_7 : memref<1xi32> to memref<?xi32>
+// CHECK-NEXT:     %4 = memref.get_global @external : memref<i32>
+// CHECK-NEXT:     %alloca_9 = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:     %reshape_10 = memref.reshape %4(%alloca_9) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
+// CHECK-NEXT:     %cast_11 = memref.cast %reshape_10 : memref<1xi32> to memref<?xi32>
+// CHECK-NEXT:     call @run(%cast, %cast_2, %cast_5, %cast_8, %cast_11) : (memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>, memref<?xi32>) -> ()
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
+
+// LLVM-DAG: @local = global i32 undef
+// LLVM-DAG: @local_init = global i32 4
+// LLVM-DAG: @internal = private global i32 undef
+// LLVM-DAG: @internal_init = private global i32 5
+// LLVM-DAG: @external = external global i32
+// LLVM-LABEL: define void @kernel_deriche() {
+// LLVM-NEXT:   call void @run(i32* @local, i32* @local_init, i32* @internal, i32* @internal_init, i32* @external)
+// LLVM-NEXT:   ret void
+// LLVM: declare void @run(i32*, i32*, i32*, i32*, i32*)

--- a/polygeist/tools/cgeist/Test/Verification/loop.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/loop.cpp
@@ -14,7 +14,7 @@ void div_(int* sizes) {
     }
 }
 
-// CHECK-LABEL:   memref.global @MAX_DIMS : memref<i32> = uninitialized
+// CHECK-LABEL:   memref.global @MAX_DIMS : memref<i32> = uninitialized {alignment = 4 : i64}
 
 // CHECK-LABEL:   func.func @_Z4div_Pi(
 // CHECK-SAME:                         %[[VAL_0:.*]]: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {

--- a/polygeist/tools/cgeist/Test/Verification/loop.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/loop.cpp
@@ -14,21 +14,32 @@ void div_(int* sizes) {
     }
 }
 
-// CHECK:   func @_Z4div_Pi(%arg0: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-DAG:     %c1_i64 = arith.constant 1 : i64
-// CHECK-DAG:     %c1 = arith.constant 1 : index
-// CHECK-DAG:     %c0 = arith.constant 0 : index
-// CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.array<25 x struct<(i32, f64)>> : (i64) -> !llvm.ptr<array<25 x struct<(i32, f64)>>>
-// CHECK-NEXT:     %1 = memref.get_global @MAX_DIMS : memref<1xi32>
-// CHECK-NEXT:     %2 = affine.load %1[0] : memref<1xi32>
-// CHECK-NEXT:     %3 = llvm.getelementptr %0[0, 0] : (!llvm.ptr<array<25 x struct<(i32, f64)>>>) -> !llvm.ptr<struct<(i32, f64)>>
-// CHECK-NEXT:     %4 = arith.index_cast %2 : i32 to index
-// CHECK-NEXT:     scf.for %arg1 = %c0 to %4 step %c1 {
-// CHECK-NEXT:       %5 = memref.load %arg0[%arg1] : memref<?xi32>
-// CHECK-NEXT:       %6 = arith.index_cast %arg1 : index to i64
-// CHECK-NEXT:       %7 = llvm.getelementptr %3[%6] : (!llvm.ptr<struct<(i32, f64)>>, i64) -> !llvm.ptr<struct<(i32, f64)>>
-// CHECK-NEXT:       %8 = llvm.getelementptr %7[0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:       llvm.store %5, %8 : !llvm.ptr<i32>
+// CHECK-LABEL:   memref.global @MAX_DIMS : memref<i32> = uninitialized
+
+// CHECK-LABEL:   func.func @_Z4div_Pi(
+// CHECK-SAME:                         %[[VAL_0:.*]]: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-DAG:        %[[VAL_1:.*]] = arith.constant 1 : i32
+// CHECK-DAG:        %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-DAG:        %[[VAL_3:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:       %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.array<25 x struct<(i32, f64)>> : (i64) -> !llvm.ptr<array<25 x struct<(i32, f64)>>>
+// CHECK-NEXT:       %[[VAL_5:.*]] = memref.get_global @MAX_DIMS : memref<i32>
+// CHECK-NEXT:       %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_4]][0, 0] : (!llvm.ptr<array<25 x struct<(i32, f64)>>>) -> !llvm.ptr<struct<(i32, f64)>>
+// CHECK-NEXT:       %[[VAL_7:.*]] = scf.while (%[[VAL_8:.*]] = %[[VAL_2]]) : (i32) -> i32 {
+// CHECK-NEXT:         %[[VAL_9:.*]] = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:         %[[VAL_10:.*]] = memref.reshape %[[VAL_5]](%[[VAL_9]]) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
+// CHECK-NEXT:         %[[VAL_11:.*]] = affine.load %[[VAL_10]][0] : memref<1xi32>
+// CHECK-NEXT:         %[[VAL_12:.*]] = arith.cmpi slt, %[[VAL_8]], %[[VAL_11]] : i32
+// CHECK-NEXT:         scf.condition(%[[VAL_12]]) %[[VAL_8]] : i32
+// CHECK-NEXT:       } do {
+// CHECK-NEXT:       ^bb0(%[[VAL_13:.*]]: i32):
+// CHECK-NEXT:         %[[VAL_14:.*]] = arith.index_cast %[[VAL_13]] : i32 to index
+// CHECK-NEXT:         %[[VAL_15:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_14]]] : memref<?xi32>
+// CHECK-NEXT:         %[[VAL_16:.*]] = arith.index_cast %[[VAL_14]] : index to i64
+// CHECK-NEXT:         %[[VAL_17:.*]] = llvm.getelementptr %[[VAL_6]]{{\[}}%[[VAL_16]]] : (!llvm.ptr<struct<(i32, f64)>>, i64) -> !llvm.ptr<struct<(i32, f64)>>
+// CHECK-NEXT:         %[[VAL_18:.*]] = llvm.getelementptr %[[VAL_17]][0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:         llvm.store %[[VAL_15]], %[[VAL_18]] : !llvm.ptr<i32>
+// CHECK-NEXT:         %[[VAL_19:.*]] = arith.addi %[[VAL_13]], %[[VAL_1]] : i32
+// CHECK-NEXT:         scf.yield %[[VAL_19]] : i32
+// CHECK-NEXT:       }
+// CHECK-NEXT:       return
 // CHECK-NEXT:     }
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }

--- a/polygeist/tools/cgeist/Test/Verification/multidim_init.c
+++ b/polygeist/tools/cgeist/Test/Verification/multidim_init.c
@@ -26,7 +26,7 @@ float foo(int i, int j) {
 
   return glob_A[i][j] + A[i][j] + B[j] + sum;
 }
-// CHECK: memref.global @glob_A : memref<3x4xf32> = dense{{.*}}1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00], [3.333330e+00, 3.333330e+00, 3.333330e+00, 3.333330e+00], [1.000000e-01, 2.000000e-01, 3.000000e-01, 4.000000e-01{{.*}}
+// CHECK: memref.global @glob_A : memref<3x4xf32> = dense{{.*}}1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00], [3.333330e+00, 3.333330e+00, 3.333330e+00, 3.333330e+00], [1.000000e-01, 2.000000e-01, 3.000000e-01, 4.000000e-01{{.*}} {alignment = 16 : i64}
 // CHECK-LABEL: func @foo
 // CHECK-DAG: %[[CST3:.*]] = arith.constant 3.33
 // CHECK-DAG: %[[CST1_23:.*]] = arith.constant 1.23

--- a/polygeist/tools/cgeist/Test/Verification/static.c
+++ b/polygeist/tools/cgeist/Test/Verification/static.c
@@ -6,7 +6,7 @@ int foo() {
   return bar[0];
 }
 
-// CHECK:   memref.global "private" @"foo@static@bar" : memref<8xi32> = uninitialized
+// CHECK:   memref.global "private" @"foo@static@bar" : memref<8xi32> = uninitialized {alignment = 16 : i64}
 // CHECK:   func @foo() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT:     %0 = memref.get_global @"foo@static@bar" : memref<8xi32>
 // CHECK-NEXT:     %1 = affine.load %0[0] : memref<8xi32>

--- a/polygeist/tools/cgeist/Test/Verification/staticint.c
+++ b/polygeist/tools/cgeist/Test/Verification/staticint.c
@@ -7,7 +7,7 @@ int adder(int x) {
 }
 
 // CHECK-DAG:   memref.global "private" @"adder@static@cur@init" : memref<i1> = dense<true>
-// CHECK-DAG:   memref.global "private" @"adder@static@cur" : memref<i32> = dense<0>
+// CHECK-DAG:   memref.global "private" @"adder@static@cur" : memref<i32> = dense<0> {alignment = 4 : i64}
 
 // CHECK-LABEL:   func.func @adder(
 // CHECK-SAME:                     %[[VAL_0:.*]]: i32) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {

--- a/polygeist/tools/cgeist/Test/Verification/staticint.c
+++ b/polygeist/tools/cgeist/Test/Verification/staticint.c
@@ -7,7 +7,7 @@ int adder(int x) {
 }
 
 // CHECK-DAG:   memref.global "private" @"adder@static@cur@init" : memref<i1> = dense<true>
-// CHECK-DAG:   memref.global "private" @"adder@static@cur" : memref<i32> = uninitialized
+// CHECK-DAG:   memref.global "private" @"adder@static@cur" : memref<i32> = dense<0>
 
 // CHECK-LABEL:   func.func @adder(
 // CHECK-SAME:                     %[[VAL_0:.*]]: i32) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {

--- a/polygeist/tools/cgeist/Test/Verification/staticint.c
+++ b/polygeist/tools/cgeist/Test/Verification/staticint.c
@@ -6,21 +6,26 @@ int adder(int x) {
     return cur;
 }
 
-// CHECK:   memref.global "private" @"adder@static@cur@init" : memref<1xi1> = dense<true>
-// CHECK:   memref.global "private" @"adder@static@cur" : memref<1xi32> = uninitialized
-// CHECK:   func @adder(%arg0: i32) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-DAG:     %false = arith.constant false
-// CHECK-DAG:     %c0_i32 = arith.constant 0 : i32
-// CHECK-DAG:     %0 = memref.get_global @"adder@static@cur" : memref<1xi32>
-// CHECK-DAG:     %1 = memref.get_global @"adder@static@cur@init" : memref<1xi1>
-// CHECK-NEXT:     %2 = affine.load %1[0] : memref<1xi1>
-// CHECK-NEXT:     scf.if %2 {
-// CHECK-NEXT:       affine.store %false, %1[0] : memref<1xi1>
-// CHECK-NEXT:       affine.store %c0_i32, %0[0] : memref<1xi32>
-// CHECK-NEXT:     }
-// CHECK-NEXT:     %3 = affine.load %0[0] : memref<1xi32>
-// CHECK-NEXT:     %4 = arith.addi %3, %arg0 : i32
-// CHECK-NEXT:     affine.store %4, %0[0] : memref<1xi32>
-// CHECK-NEXT:     return %4 : i32
-// CHECK-NEXT:   }
+// CHECK-DAG:   memref.global "private" @"adder@static@cur@init" : memref<i1> = dense<true>
+// CHECK-DAG:   memref.global "private" @"adder@static@cur" : memref<i32> = uninitialized
 
+// CHECK-LABEL:   func.func @adder(
+// CHECK-SAME:                     %[[VAL_0:.*]]: i32) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-DAG:        %[[VAL_1:.*]] = arith.constant false
+// CHECK-DAG:        %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:       %[[VAL_3:.*]] = memref.get_global @"adder@static@cur" : memref<i32>
+// CHECK-NEXT:       %[[VAL_4:.*]] = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:       %[[VAL_5:.*]] = memref.reshape %[[VAL_3]](%[[VAL_4]]) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
+// CHECK-NEXT:       %[[VAL_6:.*]] = memref.get_global @"adder@static@cur@init" : memref<i1>
+// CHECK-NEXT:       %[[VAL_7:.*]] = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:       %[[VAL_8:.*]] = memref.reshape %[[VAL_6]](%[[VAL_7]]) : (memref<i1>, memref<1xindex>) -> memref<1xi1>
+// CHECK-NEXT:       %[[VAL_9:.*]] = affine.load %[[VAL_8]][0] : memref<1xi1>
+// CHECK-NEXT:       scf.if %[[VAL_9]] {
+// CHECK-NEXT:         affine.store %[[VAL_1]], %[[VAL_8]][0] : memref<1xi1>
+// CHECK-NEXT:         affine.store %[[VAL_2]], %[[VAL_5]][0] : memref<1xi32>
+// CHECK-NEXT:       }
+// CHECK-NEXT:       %[[VAL_10:.*]] = affine.load %[[VAL_5]][0] : memref<1xi32>
+// CHECK-NEXT:       %[[VAL_11:.*]] = arith.addi %[[VAL_10]], %[[VAL_0]] : i32
+// CHECK-NEXT:       affine.store %[[VAL_11]], %[[VAL_5]][0] : memref<1xi32>
+// CHECK-NEXT:       return %[[VAL_11]] : i32
+// CHECK-NEXT:     }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -9,18 +9,18 @@
 
 // Check globals referenced in device functions are created in the GPU module
 // CHECK: gpu.module @device_functions {
-// CHECK-DAG: memref.global @__spirv_BuiltInSubgroupLocalInvocationId : memref<i32, 1>
-// CHECK-DAG: memref.global @__spirv_BuiltInSubgroupId : memref<i32, 1>
-// CHECK-DAG: memref.global @__spirv_BuiltInNumSubgroups : memref<i32, 1>
-// CHECK-DAG: memref.global @__spirv_BuiltInSubgroupMaxSize : memref<i32, 1>
-// CHECK-DAG: memref.global @__spirv_BuiltInSubgroupSize : memref<i32, 1>
-// CHECK-DAG: memref.global @__spirv_BuiltInLocalInvocationId : memref<3xi64, 1>
-// CHECK-DAG: memref.global @__spirv_BuiltInWorkgroupId : memref<3xi64, 1>
-// CHECK-DAG: memref.global @__spirv_BuiltInWorkgroupSize : memref<3xi64, 1>
-// CHECK-DAG: memref.global @__spirv_BuiltInNumWorkgroups : memref<3xi64, 1>
-// CHECK-DAG: memref.global @__spirv_BuiltInGlobalOffset : memref<3xi64, 1>
-// CHECK-DAG: memref.global @__spirv_BuiltInGlobalSize : memref<3xi64, 1>
-// CHECK-DAG: memref.global @__spirv_BuiltInGlobalInvocationId : memref<3xi64, 1>
+// CHECK-DAG: memref.global constant @__spirv_BuiltInSubgroupLocalInvocationId : memref<i32, 1>
+// CHECK-DAG: memref.global constant @__spirv_BuiltInSubgroupId : memref<i32, 1>
+// CHECK-DAG: memref.global constant @__spirv_BuiltInNumSubgroups : memref<i32, 1>
+// CHECK-DAG: memref.global constant @__spirv_BuiltInSubgroupMaxSize : memref<i32, 1>
+// CHECK-DAG: memref.global constant @__spirv_BuiltInSubgroupSize : memref<i32, 1>
+// CHECK-DAG: memref.global constant @__spirv_BuiltInLocalInvocationId : memref<3xi64, 1>
+// CHECK-DAG: memref.global constant @__spirv_BuiltInWorkgroupId : memref<3xi64, 1>
+// CHECK-DAG: memref.global constant @__spirv_BuiltInWorkgroupSize : memref<3xi64, 1>
+// CHECK-DAG: memref.global constant @__spirv_BuiltInNumWorkgroups : memref<3xi64, 1>
+// CHECK-DAG: memref.global constant @__spirv_BuiltInGlobalOffset : memref<3xi64, 1>
+// CHECK-DAG: memref.global constant @__spirv_BuiltInGlobalSize : memref<3xi64, 1>
+// CHECK-DAG: memref.global constant @__spirv_BuiltInGlobalInvocationId : memref<3xi64, 1>
 
 // Ensure the spirv functions that reference these globals are not filtered out
 // CHECK-DAG: func.func @_Z28__spirv_GlobalInvocationId_xv()

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -9,18 +9,18 @@
 
 // Check globals referenced in device functions are created in the GPU module
 // CHECK: gpu.module @device_functions {
-// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupLocalInvocationId : memref<1xi32, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupId : memref<1xi32, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInNumSubgroups : memref<1xi32, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupMaxSize : memref<1xi32, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInSubgroupSize : memref<1xi32, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInLocalInvocationId : memref<3xi64, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInWorkgroupId : memref<3xi64, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInWorkgroupSize : memref<3xi64, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInNumWorkgroups : memref<3xi64, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInGlobalOffset : memref<3xi64, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInGlobalSize : memref<3xi64, 1>
-// CHECK-NEXT: memref.global @__spirv_BuiltInGlobalInvocationId : memref<3xi64, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInSubgroupLocalInvocationId : memref<i32, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInSubgroupId : memref<i32, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInNumSubgroups : memref<i32, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInSubgroupMaxSize : memref<i32, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInSubgroupSize : memref<i32, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInLocalInvocationId : memref<3xi64, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInWorkgroupId : memref<3xi64, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInWorkgroupSize : memref<3xi64, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInNumWorkgroups : memref<3xi64, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInGlobalOffset : memref<3xi64, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInGlobalSize : memref<3xi64, 1>
+// CHECK-DAG: memref.global @__spirv_BuiltInGlobalInvocationId : memref<3xi64, 1>
 
 // Ensure the spirv functions that reference these globals are not filtered out
 // CHECK-DAG: func.func @_Z28__spirv_GlobalInvocationId_xv()

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -9,18 +9,18 @@
 
 // Check globals referenced in device functions are created in the GPU module
 // CHECK: gpu.module @device_functions {
-// CHECK-DAG: memref.global constant @__spirv_BuiltInSubgroupLocalInvocationId : memref<i32, 1>
-// CHECK-DAG: memref.global constant @__spirv_BuiltInSubgroupId : memref<i32, 1>
-// CHECK-DAG: memref.global constant @__spirv_BuiltInNumSubgroups : memref<i32, 1>
-// CHECK-DAG: memref.global constant @__spirv_BuiltInSubgroupMaxSize : memref<i32, 1>
-// CHECK-DAG: memref.global constant @__spirv_BuiltInSubgroupSize : memref<i32, 1>
-// CHECK-DAG: memref.global constant @__spirv_BuiltInLocalInvocationId : memref<3xi64, 1>
-// CHECK-DAG: memref.global constant @__spirv_BuiltInWorkgroupId : memref<3xi64, 1>
-// CHECK-DAG: memref.global constant @__spirv_BuiltInWorkgroupSize : memref<3xi64, 1>
-// CHECK-DAG: memref.global constant @__spirv_BuiltInNumWorkgroups : memref<3xi64, 1>
-// CHECK-DAG: memref.global constant @__spirv_BuiltInGlobalOffset : memref<3xi64, 1>
-// CHECK-DAG: memref.global constant @__spirv_BuiltInGlobalSize : memref<3xi64, 1>
-// CHECK-DAG: memref.global constant @__spirv_BuiltInGlobalInvocationId : memref<3xi64, 1>
+// CHECK-DAG: memref.global constant @__spirv_BuiltInSubgroupLocalInvocationId : memref<i32, 1> {alignment = 4 : i64}
+// CHECK-DAG: memref.global constant @__spirv_BuiltInSubgroupId : memref<i32, 1> {alignment = 4 : i64}
+// CHECK-DAG: memref.global constant @__spirv_BuiltInNumSubgroups : memref<i32, 1> {alignment = 4 : i64}
+// CHECK-DAG: memref.global constant @__spirv_BuiltInSubgroupMaxSize : memref<i32, 1> {alignment = 4 : i64}
+// CHECK-DAG: memref.global constant @__spirv_BuiltInSubgroupSize : memref<i32, 1> {alignment = 4 : i64}
+// CHECK-DAG: memref.global constant @__spirv_BuiltInLocalInvocationId : memref<3xi64, 1> {alignment = 32 : i64}
+// CHECK-DAG: memref.global constant @__spirv_BuiltInWorkgroupId : memref<3xi64, 1> {alignment = 32 : i64}
+// CHECK-DAG: memref.global constant @__spirv_BuiltInWorkgroupSize : memref<3xi64, 1> {alignment = 32 : i64}
+// CHECK-DAG: memref.global constant @__spirv_BuiltInNumWorkgroups : memref<3xi64, 1> {alignment = 32 : i64}
+// CHECK-DAG: memref.global constant @__spirv_BuiltInGlobalOffset : memref<3xi64, 1> {alignment = 32 : i64}
+// CHECK-DAG: memref.global constant @__spirv_BuiltInGlobalSize : memref<3xi64, 1> {alignment = 32 : i64}
+// CHECK-DAG: memref.global constant @__spirv_BuiltInGlobalInvocationId : memref<3xi64, 1> {alignment = 32 : i64}
 
 // Ensure the spirv functions that reference these globals are not filtered out
 // CHECK-DAG: func.func @_Z28__spirv_GlobalInvocationId_xv()


### PR DESCRIPTION
This PR enhances `MLIRASTConsumer::getOrCreateGlobal` by:
  - refactoring the function implementation
  - setting the 'const' for globals that are immutable
  - setting the alignment attribute on globals.