### PR TITLE
[SYCL] Collect sycl_declared_aspects metadata

### DIFF
--- a/llvm/test/tools/sycl-post-link/device-requirements/sycl-declared-aspects.ll
+++ b/llvm/test/tools/sycl-post-link/device-requirements/sycl-declared-aspects.ll
@@ -1,0 +1,67 @@
+; RUN: sycl-post-link -split=auto %s -o %t.files.table
+; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefix CHECK-AUTO
+
+; RUN: sycl-post-link -split=kernel %s -o %t.files.table
+; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefix CHECK-KERNEL-0
+; RUN: FileCheck %s -input-file=%t.files_1.prop --check-prefix CHECK-KERNEL-1
+; RUN: FileCheck %s -input-file=%t.files_2.prop --check-prefix CHECK-KERNEL-2
+
+; CHECK: aspects=2|gBAAAAAAAAQBAAAAGAAAAkAAAAA
+; CHECK-KERNEL-0: aspects=2|gBAAAAAAAAQBAAAAGAAAAkAAAAA
+; CHECK-KERNEL-1: aspects=2|ABAAAAAAAAQBAAAAGAAAAA
+; CHECK-KERNEL-2: aspects=2|gAAAAAAAAAQBAAAA
+
+source_filename = "source.cpp"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+$_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_EUlvE_ = comdat any
+
+$_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE0_clES2_EUlvE_ = comdat any
+
+$_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE1_clES2_EUlvE_ = comdat any
+
+define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_EUlvE_() #0 {
+entry:
+  call spir_func void @_Z3foov()
+  ret void
+}
+
+define dso_local spir_func void @_Z3foov() !sycl_declared_aspects !47 {
+entry:
+  ret void
+}
+
+define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE0_clES2_EUlvE_() #0 {
+entry:
+  call spir_func void @_Z3barv()
+  ret void
+}
+
+define dso_local spir_func void @_Z3barv() !sycl_declared_aspects !50 {
+entry:
+  ret void
+}
+
+define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE1_clES2_EUlvE_() #0 {
+entry:
+  call spir_func void @_Z3bazv()
+  ret void
+}
+
+define dso_local spir_func void @_Z3bazv() !sycl_declared_aspects !53 {
+entry:
+  ret void
+}
+
+attributes #0 = { "sycl-module-id"="throw-exception-for-unsupported-aspect.cpp" }
+
+
+!sycl_aspects = !{!9, !10, !11}
+
+!9 = !{!"fp16", i32 5}
+!10 = !{!"fp64", i32 6}
+!11 = !{!"image", i32 9}
+!47 = !{i32 5}
+!50 = !{i32 5, i32 6}
+!53 = !{i32 5, i32 6, i32 9}

--- a/llvm/test/tools/sycl-post-link/device-requirements/sycl-declared-aspects.ll
+++ b/llvm/test/tools/sycl-post-link/device-requirements/sycl-declared-aspects.ll
@@ -6,7 +6,7 @@
 ; RUN: FileCheck %s -input-file=%t.files_1.prop --check-prefix CHECK-KERNEL-1
 ; RUN: FileCheck %s -input-file=%t.files_2.prop --check-prefix CHECK-KERNEL-2
 
-; CHECK: aspects=2|gBAAAAAAAAQBAAAAGAAAAkAAAAA
+; CHECK-AUTO: aspects=2|gBAAAAAAAAQBAAAAGAAAAkAAAAA
 ; CHECK-KERNEL-0: aspects=2|gBAAAAAAAAQBAAAAGAAAAkAAAAA
 ; CHECK-KERNEL-1: aspects=2|ABAAAAAAAAQBAAAAGAAAAA
 ; CHECK-KERNEL-2: aspects=2|gAAAAAAAAAQBAAAA
@@ -15,41 +15,41 @@ source_filename = "source.cpp"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"
 
-$_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_EUlvE_ = comdat any
+$kernel1 = comdat any
 
-$_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE0_clES2_EUlvE_ = comdat any
+$kernel2 = comdat any
 
-$_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE1_clES2_EUlvE_ = comdat any
+$kernel3 = comdat any
 
-define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_EUlvE_() #0 {
+define weak_odr dso_local spir_kernel void @kernel1() #0 {
 entry:
   call spir_func void @_Z3foov()
   ret void
 }
 
-define dso_local spir_func void @_Z3foov() !sycl_declared_aspects !47 {
+define dso_local spir_func void @_Z3foov() !sycl_declared_aspects !4 {
 entry:
   ret void
 }
 
-define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE0_clES2_EUlvE_() #0 {
+define weak_odr dso_local spir_kernel void @kernel2() #0 {
 entry:
   call spir_func void @_Z3barv()
   ret void
 }
 
-define dso_local spir_func void @_Z3barv() !sycl_declared_aspects !50 {
+define dso_local spir_func void @_Z3barv() !sycl_declared_aspects !5 {
 entry:
   ret void
 }
 
-define weak_odr dso_local spir_kernel void @_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE1_clES2_EUlvE_() #0 {
+define weak_odr dso_local spir_kernel void @kernel3() #0 {
 entry:
   call spir_func void @_Z3bazv()
   ret void
 }
 
-define dso_local spir_func void @_Z3bazv() !sycl_declared_aspects !53 {
+define dso_local spir_func void @_Z3bazv() !sycl_declared_aspects !6 {
 entry:
   ret void
 }
@@ -57,11 +57,11 @@ entry:
 attributes #0 = { "sycl-module-id"="throw-exception-for-unsupported-aspect.cpp" }
 
 
-!sycl_aspects = !{!9, !10, !11}
+!sycl_aspects = !{!1, !2, !3}
 
-!9 = !{!"fp16", i32 5}
-!10 = !{!"fp64", i32 6}
-!11 = !{!"image", i32 9}
-!47 = !{i32 5}
-!50 = !{i32 5, i32 6}
-!53 = !{i32 5, i32 6, i32 9}
+!1 = !{!"fp16", i32 5}
+!2 = !{!"fp64", i32 6}
+!3 = !{!"image", i32 9}
+!4 = !{i32 5}
+!5 = !{i32 5, i32 6}
+!6 = !{i32 5, i32 6, i32 9}

--- a/llvm/test/tools/sycl-post-link/device-requirements/sycl-declared-aspects.ll
+++ b/llvm/test/tools/sycl-post-link/device-requirements/sycl-declared-aspects.ll
@@ -54,7 +54,7 @@ entry:
   ret void
 }
 
-attributes #0 = { "sycl-module-id"="throw-exception-for-unsupported-aspect.cpp" }
+attributes #0 = { "sycl-module-id"="source.cpp" }
 
 
 !sycl_aspects = !{!1, !2, !3}

--- a/llvm/test/tools/sycl-post-link/device-requirements/sycl-declared-aspects.ll
+++ b/llvm/test/tools/sycl-post-link/device-requirements/sycl-declared-aspects.ll
@@ -56,7 +56,6 @@ entry:
 
 attributes #0 = { "sycl-module-id"="source.cpp" }
 
-
 !sycl_aspects = !{!1, !2, !3}
 
 !1 = !{!"fp16", i32 5}

--- a/llvm/tools/sycl-post-link/SYCLDeviceRequirements.cpp
+++ b/llvm/tools/sycl-post-link/SYCLDeviceRequirements.cpp
@@ -29,6 +29,8 @@ void llvm::getSYCLDeviceRequirements(
       }
   };
 
+  // Scan the module and if the metadata is present fill the corresponing
+  // property with metadata's aspects
   for (const Function &F : M) {
     FindAspectsByMDName(F, "sycl_used_aspects");
     FindAspectsByMDName(F, "sycl_declared_aspects");


### PR DESCRIPTION
In scope of optional kernel features implementation we should also collect sycl_declared_aspects metadata to create right "aspects" property
spec: https://github.com/intel/llvm/blob/sycl/sycl/doc/design/OptionalDeviceFeatures.md#create-the-sycldevice-requirements-property-set