### PR TITLE
[SYCL-MLIR]: Zero initialize global variables

### DIFF
--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -2146,7 +2146,7 @@ MLIRASTConsumer::getOrCreateGlobal(const ValueDecl &VD, std::string Prefix,
   const Expr *InitExpr = Var->getAnyInitializer(InitDecl);
 
   if (!InitExpr) {
-    if (DefKind == VarDecl::TentativeDefinition) {
+    if (DefKind != VarDecl::DeclarationOnly) {
       // Tentative definitions are initialized to {0}.
       assert(!VD.getType()->isIncompleteType() && "Unexpected incomplete type");
 

--- a/polygeist/tools/cgeist/Test/Verification/global.c
+++ b/polygeist/tools/cgeist/Test/Verification/global.c
@@ -11,7 +11,8 @@ int main() {
   return 0;
 }
 
-// CHECK:  memref.global @A : memref<64x32xf32> = uninitialized {alignment = 16 : i64}
+// CHECK:  memref.global @A : memref<64x32xf32> = dense<0.000000e+00> {alignment = 16 : i64}
+
 // CHECK:  func @main() -> i32
 // CHECK-DAG:    %cst = arith.constant 3.000000e+00 : f32
 // CHECK-DAG:    %c0_i32 = arith.constant 0 : i32

--- a/polygeist/tools/cgeist/Test/Verification/globals.c
+++ b/polygeist/tools/cgeist/Test/Verification/globals.c
@@ -14,10 +14,11 @@ void kernel_deriche() {
 
 // CHECK-DAG:   memref.global @external : memref<i32> {alignment = 4 : i64}
 // CHECK-DAG:   memref.global "private" @internal_init : memref<i32> = dense<5> {alignment = 4 : i64}
-// CHECK-DAG:   memref.global "private" @internal : memref<i32> = uninitialized {alignment = 4 : i64}
+// CHECK-DAG:   memref.global "private" @internal : memref<i32> = dense<0> {alignment = 4 : i64}
 // CHECK-DAG:   memref.global @local_init : memref<i32> = dense<4> {alignment = 4 : i64}
-// CHECK-DAG:   memref.global @local : memref<i32> = uninitialized {alignment = 4 : i64}
-// CHECK:   func @kernel_deriche()
+// CHECK-DAG:   memref.global @local : memref<i32> = dense<0> {alignment = 4 : i64}
+
+// CHECK-LABEL: func @kernel_deriche()
 // CHECK-NEXT:     %0 = memref.get_global @local : memref<i32>
 // CHECK-NEXT:     %alloca = memref.alloca() : memref<1xindex>
 // CHECK-NEXT:     %reshape = memref.reshape %0(%alloca) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
@@ -42,12 +43,13 @@ void kernel_deriche() {
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 
-// LLVM-DAG: @local = global i32 undef, align 4
+// LLVM-DAG: @local = global i32 0, align 4
 // LLVM-DAG: @local_init = global i32 4, align 4
-// LLVM-DAG: @internal = private global i32 undef, align 4
+// LLVM-DAG: @internal = private global i32 0, align 4
 // LLVM-DAG: @internal_init = private global i32 5, align 4
 // LLVM-DAG: @external = external global i32, align 4
+
 // LLVM-LABEL: define void @kernel_deriche() {
 // LLVM-NEXT:   call void @run(i32* @local, i32* @local_init, i32* @internal, i32* @internal_init, i32* @external)
 // LLVM-NEXT:   ret void
-// LLVM: declare void @run(i32*, i32*, i32*, i32*, i32*)
+// LLVM-LABEL: declare void @run(i32*, i32*, i32*, i32*, i32*)

--- a/polygeist/tools/cgeist/Test/Verification/loop.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/loop.cpp
@@ -1,27 +1,34 @@
 // RUN: cgeist %s --function=* -S | FileCheck %s
 
 int MAX_DIMS;
+static short S;
 
 struct A {
-    int x;
-    double y;
+  int x;
+  double y;
 };
 
-void div_(int* sizes) {
-    A data[25];
-    for (int i=0; i < MAX_DIMS; ++i) {
-            data[i].x = sizes[i];
-    }
+void div_(int* sizes, short k) {
+  A data[25];
+  S = k;
+  for (int i=0; i < MAX_DIMS; ++i) {
+    data[i].x = sizes[i] + S;
+  }
 }
 
-// CHECK-LABEL:   memref.global @MAX_DIMS : memref<i32> = uninitialized {alignment = 4 : i64}
+// CHECK-LABEL: memref.global @MAX_DIMS : memref<i32> = dense<0> {alignment = 4 : i64}
+// CHECK-LABEL: memref.global "private" @_ZL1S : memref<i16> = dense<0> {alignment = 2 : i64}
 
-// CHECK-LABEL:   func.func @_Z4div_Pi(
-// CHECK-SAME:                         %[[VAL_0:.*]]: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-LABEL: func.func @_Z4div_Pis(
+// CHECK-SAME:    %[[VAL_0:.*]]: memref<?xi32>, %[[ARG_K:.*]]: i16) attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-DAG:        %[[VAL_1:.*]] = arith.constant 1 : i32
 // CHECK-DAG:        %[[VAL_2:.*]] = arith.constant 0 : i32
 // CHECK-DAG:        %[[VAL_3:.*]] = arith.constant 1 : i64
 // CHECK-NEXT:       %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.array<25 x struct<(i32, f64)>> : (i64) -> !llvm.ptr<array<25 x struct<(i32, f64)>>>
+// CHECK-NEXT:       %[[VAL_K:.*]] = memref.get_global @_ZL1S : memref<i16>
+// CHECK-NEXT:       %alloca = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:       %reshape = memref.reshape %[[VAL_K]](%alloca) : (memref<i16>, memref<1xindex>) -> memref<1xi16>
+// CHECK-NEXT:       affine.store %[[ARG_K]], %reshape[0] : memref<1xi16>
 // CHECK-NEXT:       %[[VAL_5:.*]] = memref.get_global @MAX_DIMS : memref<i32>
 // CHECK-NEXT:       %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_4]][0, 0] : (!llvm.ptr<array<25 x struct<(i32, f64)>>>) -> !llvm.ptr<struct<(i32, f64)>>
 // CHECK-NEXT:       %[[VAL_7:.*]] = scf.while (%[[VAL_8:.*]] = %[[VAL_2]]) : (i32) -> i32 {
@@ -34,10 +41,15 @@ void div_(int* sizes) {
 // CHECK-NEXT:       ^bb0(%[[VAL_13:.*]]: i32):
 // CHECK-NEXT:         %[[VAL_14:.*]] = arith.index_cast %[[VAL_13]] : i32 to index
 // CHECK-NEXT:         %[[VAL_15:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_14]]] : memref<?xi32>
+// CHECK-NEXT:         %alloca_0 = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:         %reshape_1 = memref.reshape %1(%alloca_0) : (memref<i16>, memref<1xindex>) -> memref<1xi16>
+// CHECK-NEXT:         %[[LOAD:.*]] = affine.load %reshape_1[0] : memref<1xi16>
+// CHECK-NEXT:         %[[EXTSI:.*]] = arith.extsi %[[LOAD]] : i16 to i32
+// CHECK-NEXT:         %[[ADDI:.*]] = arith.addi %[[VAL_15]], %[[EXTSI]] : i32
 // CHECK-NEXT:         %[[VAL_16:.*]] = arith.index_cast %[[VAL_14]] : index to i64
 // CHECK-NEXT:         %[[VAL_17:.*]] = llvm.getelementptr %[[VAL_6]]{{\[}}%[[VAL_16]]] : (!llvm.ptr<struct<(i32, f64)>>, i64) -> !llvm.ptr<struct<(i32, f64)>>
 // CHECK-NEXT:         %[[VAL_18:.*]] = llvm.getelementptr %[[VAL_17]][0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:         llvm.store %[[VAL_15]], %[[VAL_18]] : !llvm.ptr<i32>
+// CHECK-NEXT:         llvm.store %[[ADDI]], %[[VAL_18]] : !llvm.ptr<i32>
 // CHECK-NEXT:         %[[VAL_19:.*]] = arith.addi %[[VAL_13]], %[[VAL_1]] : i32
 // CHECK-NEXT:         scf.yield %[[VAL_19]] : i32
 // CHECK-NEXT:       }

--- a/polygeist/tools/cgeist/Test/Verification/static.c
+++ b/polygeist/tools/cgeist/Test/Verification/static.c
@@ -6,7 +6,7 @@ int foo() {
   return bar[0];
 }
 
-// CHECK-DAG:   memref.global "private" @"foo@static@bar" : memref<8xi32> = dense<0> {alignment = 16 : i64}
+// CHECK: memref.global "private" @"foo@static@bar" : memref<8xi32> = dense<0> {alignment = 16 : i64}
 // CHECK-LABEL:   func @foo() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT:     %0 = memref.get_global @"foo@static@bar" : memref<8xi32>
 // CHECK-NEXT:     %1 = affine.load %0[0] : memref<8xi32>

--- a/polygeist/tools/cgeist/Test/Verification/static.c
+++ b/polygeist/tools/cgeist/Test/Verification/static.c
@@ -6,8 +6,8 @@ int foo() {
   return bar[0];
 }
 
-// CHECK:   memref.global "private" @"foo@static@bar" : memref<8xi32> = uninitialized {alignment = 16 : i64}
-// CHECK:   func @foo() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-DAG:   memref.global "private" @"foo@static@bar" : memref<8xi32> = dense<0> {alignment = 16 : i64}
+// CHECK-LABEL:   func @foo() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT:     %0 = memref.get_global @"foo@static@bar" : memref<8xi32>
 // CHECK-NEXT:     %1 = affine.load %0[0] : memref<8xi32>
 // CHECK-NEXT:     return %1 : i32


### PR DESCRIPTION
This patch initializes tentative definition for global variable to {0}.

Fixes https://github.com/intel/llvm/issues/7355