### PR TITLE
[CI][2/3] Add Ubuntu 22 containers build

### DIFF
--- a/.github/workflows/sycl_containers.yaml
+++ b/.github/workflows/sycl_containers.yaml
@@ -190,11 +190,10 @@ jobs:
         id: deps
         run: |
           DEPS=`cat devops/dependencies.json`
-          DEPS="${DEPS//'%'/'%25'}"
-          DEPS="${DEPS//$'\n'/'%0A'}"
-          DEPS="${DEPS//$'\r'/'%0D'}"
+          DEPS="${DEPS//$'\r'/''}"
+          DEPS="${DEPS//$'\n'/' '}"
           echo $DEPS
-          echo "::set-output name=deps::$DEPS"
+          echo "deps=$DEPS" >>$GITHUB_OUTPUT
       - name: Build and Push Container
         uses: ./devops/actions/build_container
         with:
@@ -228,11 +227,10 @@ jobs:
         id: deps
         run: |
           DEPS=`cat devops/dependencies.json`
-          DEPS="${DEPS//'%'/'%25'}"
-          DEPS="${DEPS//$'\n'/'%0A'}"
-          DEPS="${DEPS//$'\r'/'%0D'}"
+          DEPS="${DEPS//$'\r'/''}"
+          DEPS="${DEPS//$'\n'/' '}"
           echo $DEPS
-          echo "::set-output name=deps::$DEPS"
+          echo "deps=$DEPS" >>$GITHUB_OUTPUT
       - name: Build and Push Container
         uses: ./devops/actions/build_container
         with:

--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     paths:
       - 'devops/containers/ubuntu2004_preinstalled.Dockerfile'
+      - 'devops/containers/ubuntu2204_preinstalled.Dockerfile'
       - '.github/workflows/sycl_nightly.yml'
 
 jobs:
@@ -26,6 +27,17 @@ jobs:
       build_artifact_suffix: default
       build_configure_extra_args: ''
 
+  ubuntu2204_build_test:
+    if: github.repository == 'intel/llvm'
+    uses: ./.github/workflows/sycl_linux_build_and_test.yml
+    needs: test_matrix
+    secrets: inherit
+    with:
+      build_cache_root: "/__w/"
+      build_artifact_suffix: default
+      build_configure_extra_args: ''
+      build_image: "ghcr.io/intel/llvm/ubuntu2204_build:latest"
+
   ubuntu2004_opaque_pointers_build_test:
     if: github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl_linux_build_and_test.yml
@@ -36,6 +48,18 @@ jobs:
       build_cache_suffix: opaque_pointers
       build_artifact_suffix: opaque_pointers
       build_configure_extra_args: "--hip --cuda --enable-esimd-emulator --cmake-opt=-DDPCPP_ENABLE_OPAQUE_POINTERS=TRUE"
+
+  ubuntu2204_opaque_pointers_build_test:
+    if: github.repository == 'intel/llvm'
+    uses: ./.github/workflows/sycl_linux_build_and_test.yml
+    needs: test_matrix
+    secrets: inherit
+    with:
+      build_cache_root: "/__w/"
+      build_cache_suffix: opaque_pointers
+      build_artifact_suffix: opaque_pointers
+      build_configure_extra_args: "--hip --cuda --enable-esimd-emulator --cmake-opt=-DDPCPP_ENABLE_OPAQUE_POINTERS=TRUE"
+      build_image: "ghcr.io/intel/llvm/ubuntu2204_build:latest"
 
   windows_default:
     name: Windows
@@ -78,3 +102,40 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository }}/sycl_ubuntu2004_nightly:no-drivers-${{ github.sha }}
           ghcr.io/${{ github.repository }}/sycl_ubuntu2004_nightly:no-drivers
+
+  ubuntu2204_docker_build_push:
+    if: github.repository == 'intel/llvm'
+    runs-on: ubuntu-latest
+    needs: ubuntu2204_build_test
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/download-artifact@v3
+      with:
+        name: sycl_linux_default
+        path: devops/
+    - name: Build and Push Container (with drivers)
+      uses: ./devops/actions/build_container
+      with:
+        push: ${{ github.event_name != 'pull_request' }}
+        file: ubuntu2204_preinstalled
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        build-args: |
+          base_image=ghcr.io/intel/llvm/ubuntu2204_intel_drivers
+          base_tag=latest
+        tags: |
+          ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:${{ github.sha }}
+          ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:latest
+    - name: Build and Push Container (no drivers)
+      uses: ./devops/actions/build_container
+      with:
+        push: ${{ github.event_name != 'pull_request' }}
+        file: ubuntu2204_preinstalled
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        build-args: |
+          base_image=ghcr.io/intel/llvm/ubuntu2204_base
+          base_tag=latest
+        tags: |
+          ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:no-drivers-${{ github.sha }}
+          ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:no-drivers

--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -10,6 +10,8 @@ on:
     - '.github/CODEOWNERS'
     - '.github/workflows/sycl_update_gpu_driver.yml'
     - '.github/workflows/sycl_containers.yaml'
+    - '.github/workflows/sycl_nightly.yml'
+    - '.github/workflows/sycl_post_commit.yml'
     - '.github/workflows/sycl_windows_build_and_test.yml'
     - '.github/workflows/sycl_macos_build_and_test.yml'
     - 'devops/containers/**'

--- a/devops/containers/ubuntu2204_preinstalled.Dockerfile
+++ b/devops/containers/ubuntu2204_preinstalled.Dockerfile
@@ -1,0 +1,14 @@
+ARG base_tag=latest
+ARG base_image=ghcr.io/intel/llvm/ubuntu2204_intel_drivers
+
+FROM $base_image:$base_tag
+
+COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
+RUN mkdir -p /opt/sycl
+ADD llvm_sycl.tar.xz /opt/sycl
+
+ENV PATH /opt/sycl/bin:$PATH
+ENV LD_LIBRARY_PATH /opt/sycl/lib:$LD_LIBRARY_PATH
+
+ENTRYPOINT ["/bin/bash", "/drivers_entrypoint.sh"]
+


### PR DESCRIPTION
Follow up on #7106, this is patch 2 of 3 patches expected:

Start running nightly on 22.04 containers in addition to 20.04 ones and push nightly containers.
This is basically a copy-paste from 20.04 parts.

As before push is not expected to happen until this change is actually merged. Based on the previous patch testing it seems it works well after merge and doesn't really work in pull_request mode.

Adding more workflows to ignore in sycl_precommit.