### PR TITLE
[SYCL] fix for flaky Windows test link failures.

### DIFF
--- a/sycl/test/extensions/properties/properties_kernel_device_has.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_device_has.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl-device-only -S -Xclang -emit-llvm %s -o - | FileCheck %s --check-prefix CHECK-IR
-// RUN: %clangxx -fsycl -Xclang -verify %s
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
 // expected-no-diagnostics
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/extensions/properties/properties_kernel_device_has_macro.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_device_has_macro.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl-device-only -S -Xclang -emit-llvm %s -o - | FileCheck %s --check-prefix CHECK-IR
-// RUN: %clangxx -fsycl -Xclang -verify %s
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
 // expected-no-diagnostics
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/extensions/properties/properties_kernel_sub_group_size.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_sub_group_size.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl-device-only -S -Xclang -emit-llvm %s -o - | FileCheck %s --check-prefix CHECK-IR
-// RUN: %clangxx -fsycl -Xclang -verify %s
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
 // expected-no-diagnostics
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/extensions/properties/properties_kernel_work_group_size.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_work_group_size.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl-device-only -S -Xclang -emit-llvm %s -o - | FileCheck %s --check-prefix CHECK-IR
-// RUN: %clangxx -fsycl -Xclang -verify %s
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
 // expected-no-diagnostics
 
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
I am not sure why these Windows link failures are flaky, but, regardless, we don't need to actually link anything for some of these tests. If the cause is the same as pull/7260 then this should fix it.