### PR TITLE
[SYCL-MLIR] Make SYCLMethodInterfaceOp's MangledFunctionName optional

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td
@@ -46,7 +46,7 @@ def SYCLMethodOpInterface : SYCL_OpInterface<"SYCLMethodOpInterface"> {
     }], "::mlir::Type", "getBaseType">,
     InterfaceMethod<[{
       Return the mangled name of the function implementing this operation.
-    }], "llvm::StringRef", "getMangledFunctionName">,
+    }], "llvm::Optional<llvm::StringRef>", "getMangledFunctionName">,
     InterfaceMethod<[{
       Return the name of the function implementing this operation.
     }], "llvm::StringRef", "getFunctionName">,

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -42,6 +42,33 @@ def SYCL_Dialect : Dialect {
     /// first.
     llvm::Optional<llvm::StringRef> findMethod(::mlir::TypeID Type,
                                                llvm::StringRef Name) const;
+
+    /// Returns the name of the operation implementing the queried
+    /// method, if present.
+    ///
+    /// For a method to be queried, it must have been registered
+    /// first.
+    ///
+    /// This function is similar to findMethod(), but also works for
+    /// methods registered as members of classes derived from \p BaseType.
+    llvm::Optional<llvm::StringRef>
+    findMethodFromBaseClass(::mlir::TypeID BaseType,
+                            llvm::StringRef Name) const;
+
+
+    /// Add a definition for the given method to be used when lowering
+    /// SYCLMethodOpInterface instances.
+    ///
+    /// A call to this function will fail if \p MayOverride is false and we try to
+    /// override an already present definition.
+    void registerMethodDefinition(llvm::StringRef Name, mlir::func::FuncOp Func,
+                                  bool MayOverride = false);
+
+    /// Retrieve a function definition previously registered with
+    /// provideMethodDefinition().
+    llvm::Optional<mlir::func::FuncOp>
+    lookupMethodDefinition(llvm::StringRef Name,
+                           mlir::FunctionType Type) const;
   }];
 }
 
@@ -219,7 +246,7 @@ def SYCLAccessorSubscriptOp
                        SYCLAccessorSubscriptIndex:$Index,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs AnyType:$Res);
@@ -248,7 +275,7 @@ def SYCLRangeGetOp
                        I32:$Index,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs SYCLGetResult:$Res);
@@ -269,7 +296,7 @@ def SYCLRangeSizeOp
   let arguments = (ins RangeMemRef:$Range,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs I64:$Res);
@@ -290,7 +317,7 @@ def SYCLNdRangeGetGlobalRange
   let arguments = (ins NDRangeMemRef:$ND,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs SYCL_RangeType:$Res);
@@ -311,7 +338,7 @@ def SYCLNdRangeGetLocalRange
   let arguments = (ins NDRangeMemRef:$ND,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs SYCL_RangeType:$Res);
@@ -332,7 +359,7 @@ def SYCLNdRangeGetGroupRange
   let arguments = (ins NDRangeMemRef:$ND,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs SYCL_RangeType:$Res);
@@ -355,7 +382,7 @@ def SYCLIDGetOp
                        Optional<I32>:$Index,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs SYCLGetResult:$Res);
@@ -378,7 +405,7 @@ def SYCLItemGetIDOp
                        Optional<I32>:$Index,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs SYCLGetIDResult:$Res);
@@ -400,7 +427,7 @@ def SYCLItemGetRangeOp
                        Optional<I32>:$Index,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs SYCLGetRangeResult:$Res);
@@ -421,7 +448,7 @@ def SYCLItemGetLinearIDOp
   let arguments = (ins ItemMemRef:$Item,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs I64:$Res);
@@ -443,7 +470,7 @@ def SYCLNDItemGetGlobalIDOp
                        Optional<I32>:$Index,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs SYCLGetIDResult:$Res);
@@ -464,7 +491,7 @@ def SYCLNDItemGetGlobalLinearIDOp
   let arguments = (ins NDItemMemRef:$NDItem,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs I64:$Res);
@@ -486,7 +513,7 @@ def SYCLNDItemGetLocalIDOp
                        Optional<I32>:$Index,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs SYCLGetIDResult:$Res);
@@ -507,7 +534,7 @@ def SYCLNDItemGetLocalLinearIDOp
   let arguments = (ins NDItemMemRef:$NDItem,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs I64:$Res);
@@ -529,7 +556,7 @@ def SYCLNDItemGetGroupOp
                        Optional<I32>:$Index,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs AnyTypeOf<[I64, SYCL_GroupType]>:$Res);
@@ -550,7 +577,7 @@ def SYCLNDItemGetGroupLinearIDOp
   let arguments = (ins NDItemMemRef:$NDItem,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs I64:$Res);
@@ -573,7 +600,7 @@ def SYCLNDItemGetGroupRangeOp
                        Optional<I32>:$Index,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs SYCLGetRangeResult:$Res);
@@ -596,7 +623,7 @@ def SYCLNDItemGetGlobalRangeOp
                        Optional<I32>:$Index,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs SYCLGetRangeResult:$Res);
@@ -619,7 +646,7 @@ def SYCLNDItemGetLocalRangeOp
                        Optional<I32>:$Index,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs SYCLGetRangeResult:$Res);
@@ -640,7 +667,7 @@ def SYCLNDItemGetNdRangeOp
   let arguments = (ins NDItemMemRef:$NDItem,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs SYCL_NdRangeType:$Res);
@@ -663,7 +690,7 @@ def SYCLGroupGetGroupIDOp
                        Optional<I32>:$Index,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs SYCLGetIDResult:$Res);
@@ -686,7 +713,7 @@ def SYCLGroupGetLocalIDOp
                        Optional<I32>:$Index,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs SYCLGetIDResult:$Res);
@@ -709,7 +736,7 @@ def SYCLGroupGetLocalRangeOp
                        Optional<I32>:$Index,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs SYCLGetRangeResult:$Res);
@@ -732,7 +759,7 @@ def SYCLGroupGetGroupRangeOp
                        Optional<I32>:$Index,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs SYCLGetRangeResult:$Res);
@@ -753,7 +780,7 @@ def SYCLGroupGetMaxLocalRangeOp
   let arguments = (ins GroupMemRef:$Group,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs SYCL_RangeType:$Res);
@@ -774,7 +801,7 @@ def SYCLGroupGetGroupLinearIDOp
   let arguments = (ins GroupMemRef:$Group,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs I64:$Res);
@@ -795,7 +822,7 @@ def SYCLGroupGetLocalLinearIDOp
   let arguments = (ins GroupMemRef:$Group,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs I64:$Res);
@@ -816,7 +843,7 @@ def SYCLGroupGetLocalLinearIDOp
   let arguments = (ins GroupMemRef:$Group,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs I64:$Res);
@@ -837,7 +864,7 @@ def SYCLGroupGetLocalLinearRangeOp
   let arguments = (ins GroupMemRef:$Group,
                        TypeAttr:$BaseType,
                        FlatSymbolRefAttr:$FunctionName,
-                       FlatSymbolRefAttr:$MangledFunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
   let results = (outs I64:$Res);

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -57,11 +57,7 @@ def SYCL_Dialect : Dialect {
 
     /// Add a definition for the given method to be used when lowering
     /// SYCLMethodOpInterface instances.
-    ///
-    /// A call to this function will fail if \p MayOverride is false and we try to
-    /// override an already present definition.
-    void registerMethodDefinition(llvm::StringRef Name, mlir::func::FuncOp Func,
-                                  bool MayOverride = false);
+    void registerMethodDefinition(llvm::StringRef Name, mlir::func::FuncOp Func);
 
     /// Retrieve a function definition previously registered with
     /// registerMethodDefinition().

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -55,7 +55,6 @@ def SYCL_Dialect : Dialect {
     findMethodFromBaseClass(::mlir::TypeID BaseType,
                             llvm::StringRef Name) const;
 
-
     /// Add a definition for the given method to be used when lowering
     /// SYCLMethodOpInterface instances.
     ///
@@ -65,7 +64,7 @@ def SYCL_Dialect : Dialect {
                                   bool MayOverride = false);
 
     /// Retrieve a function definition previously registered with
-    /// provideMethodDefinition().
+    /// registerMethodDefinition().
     llvm::Optional<mlir::func::FuncOp>
     lookupMethodDefinition(llvm::StringRef Name,
                            mlir::FunctionType Type) const;

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsDialect.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsDialect.h
@@ -41,12 +41,8 @@ public:
 
   /// Add a definition for the given method to be used when lowering
   /// SYCLMethodOpInterface instances.
-  ///
-  /// A call to this function will fail if \p MayOverride is false and we try to
-  /// override an already present definition.
   void registerDefinition(llvm::StringRef MethodName,
-                          mlir::func::FuncOp Definition,
-                          bool MayOverride = false);
+                          mlir::func::FuncOp Definition);
 
   /// Retrieve a function definition previously registered with
   /// registerMethodDefinition().

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsDialect.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsDialect.h
@@ -54,7 +54,7 @@ private:
   static constexpr llvm::StringLiteral ModuleName{"SYCLDefs"};
 
   llvm::DenseMap<std::pair<mlir::TypeID, llvm::StringRef>, llvm::StringRef>
-      methods;
+      Methods;
   llvm::DenseMap<std::pair<llvm::SmallString<0>, mlir::FunctionType>,
                  mlir::func::FuncOp>
       Definitions;

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsDialect.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsDialect.h
@@ -44,14 +44,14 @@ public:
   ///
   /// A call to this function will fail if \p MayOverride is false and we try to
   /// override an already present definition.
-  void registerDefinition(llvm::StringRef methodName,
+  void registerDefinition(llvm::StringRef MethodName,
                           mlir::func::FuncOp Definition,
                           bool MayOverride = false);
 
   /// Retrieve a function definition previously registered with
-  /// provideMethodDefinition().
+  /// registerMethodDefinition().
   llvm::Optional<mlir::func::FuncOp>
-  lookupDefinition(llvm::StringRef methodName,
+  lookupDefinition(llvm::StringRef MethodName,
                    mlir::FunctionType FunctionType) const;
 
 private:
@@ -61,7 +61,7 @@ private:
       methods;
   llvm::DenseMap<std::pair<llvm::SmallString<0>, mlir::FunctionType>,
                  mlir::func::FuncOp>
-      definitions;
+      Definitions;
   mlir::ModuleOp Module;
 };
 } // namespace sycl

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
@@ -506,6 +506,11 @@ public:
 /// Return true if the given \p Ty is a SYCL type.
 inline bool isSYCLType(Type Ty) { return isa<SYCLDialect>(Ty.getDialect()); }
 
+// TODO: Modify SYCLDialect::addType() to avoid ever having to modify this
+// function when adding new types.
+
+/// Return the list of types derived from the input type.
+llvm::SmallVector<mlir::TypeID> getDerivedTypes(mlir::TypeID TypeID);
 } // namespace sycl
 } // namespace mlir
 

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
@@ -231,7 +231,7 @@ void mlir::sycl::MethodRegistry::registerDefinition(llvm::StringRef Name,
   auto Clone = Func.clone();
   const auto FuncType = Clone.getFunctionType();
   auto Iter =
-      definitions.insert_as<std::pair<llvm::StringRef, mlir::FunctionType>>(
+      Definitions.insert_as<std::pair<llvm::StringRef, mlir::FunctionType>>(
           {{Name, FuncType}, Clone}, {Name, FuncType});
   if (!Iter.second) {
     // Override current function.
@@ -251,9 +251,9 @@ llvm::Optional<mlir::func::FuncOp> mlir::sycl::MethodRegistry::lookupDefinition(
                           << "\" with type: " << FuncType << "\n");
 
   const auto Iter =
-      definitions.find_as<std::pair<llvm::StringRef, mlir::FunctionType>>(
+      Definitions.find_as<std::pair<llvm::StringRef, mlir::FunctionType>>(
           {Name, FuncType});
-  if (Iter == definitions.end()) {
+  if (Iter == Definitions.end()) {
     llvm::WithColor::warning() << "Could not find function \"" << Name
                                << "\" with type " << FuncType << "\n";
     return llvm::None;

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsTypes.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsTypes.cpp
@@ -781,3 +781,13 @@ unsigned int mlir::sycl::GroupType::getDimension() const {
 llvm::ArrayRef<mlir::Type> mlir::sycl::GroupType::getBody() const {
   return getImpl()->Body;
 }
+
+llvm::SmallVector<mlir::TypeID>
+mlir::sycl::getDerivedTypes(mlir::TypeID TypeID) {
+  if (TypeID == mlir::sycl::AccessorCommonType::getTypeID())
+    return {mlir::sycl::AccessorType::getTypeID()};
+  if (TypeID == mlir::sycl::ArrayType::getTypeID())
+    return {mlir::sycl::IDType::getTypeID(),
+            mlir::sycl::RangeType::getTypeID()};
+  return {};
+}

--- a/mlir-sycl/lib/Transforms/SYCLMethodToSYCLCall.cpp
+++ b/mlir-sycl/lib/Transforms/SYCLMethodToSYCLCall.cpp
@@ -72,7 +72,8 @@ static LogicalResult convertMethod(SYCLMethodOpInterface method,
     return ResTys[0];
   };
 
-  auto MangledFunctionName = method.getMangledFunctionName();
+  llvm::Optional<llvm::StringRef> MangledFunctionName =
+      method.getMangledFunctionName();
   if (!MangledFunctionName) {
     // If the optional MangledFunctionName attribute is not present, we try to
     // obtain the name of the function to call from the dialect's register.

--- a/mlir-sycl/lib/Transforms/SYCLMethodToSYCLCall.cpp
+++ b/mlir-sycl/lib/Transforms/SYCLMethodToSYCLCall.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Dialect/SYCL/IR/SYCLOpsDialect.h"
 #include "mlir/Dialect/SYCL/Transforms/Passes.h"
 
 #include "PassDetail.h"
@@ -71,9 +72,36 @@ static LogicalResult convertMethod(SYCLMethodOpInterface method,
     return ResTys[0];
   };
 
+  const auto *Dialect =
+      method.getContext()->getLoadedDialect<sycl::SYCLDialect>();
+  assert(Dialect && "SYCLDialect not loaded");
+
+  auto Func = Dialect->lookupMethodDefinition(
+      method.getFunctionName(),
+      mlir::FunctionType::get(Dialect->getContext(),
+                              ValueRange(Args).getTypes(),
+                              method->getResultTypes()));
+  if (!Func) {
+    return method->emitError(
+               "Could not obtain a valid definition for operation ")
+           << method
+           << " provide a definition using "
+              "mlir::sycl::SYCLDialect::registerMethodDefinition() or using "
+              "the MangledFunctionName field of this operation.";
+  }
+
+  SymbolTable Module(method->getParentOp()->getParentOp());
+  if (auto *Op = Module.lookup(Func->getName())) {
+    // If the function has already been cloned to this module, use that.
+    Func = cast<func::FuncOp>(Op);
+  } else {
+    // If the function has not been inserted yet, do it now.
+    Func = Func->clone();
+    Module.insert(*Func);
+  }
   auto CallOp = rewriter.replaceOpWithNewOp<sycl::SYCLCallOp>(
       method, ResTyOrNone(), method.getTypeName(), method.getFunctionName(),
-      method.getMangledFunctionName(), Args);
+      Func->getName(), Args);
 
   LLVM_DEBUG(llvm::dbgs() << "  Converted to: " << CallOp << "\n");
 

--- a/mlir-sycl/lib/Transforms/SYCLMethodToSYCLCall.cpp
+++ b/mlir-sycl/lib/Transforms/SYCLMethodToSYCLCall.cpp
@@ -72,36 +72,43 @@ static LogicalResult convertMethod(SYCLMethodOpInterface method,
     return ResTys[0];
   };
 
-  const auto *Dialect =
-      method.getContext()->getLoadedDialect<sycl::SYCLDialect>();
-  assert(Dialect && "SYCLDialect not loaded");
+  auto MangledFunctionName = method.getMangledFunctionName();
+  if (!MangledFunctionName) {
+    // If the optional MangledFunctionName attribute is not present, we try to
+    // obtain the name of the function to call from the dialect's register.
+    const auto *Dialect =
+        method.getContext()->getLoadedDialect<sycl::SYCLDialect>();
+    assert(Dialect && "SYCLDialect not loaded");
 
-  auto Func = Dialect->lookupMethodDefinition(
-      method.getFunctionName(),
-      mlir::FunctionType::get(Dialect->getContext(),
-                              ValueRange(Args).getTypes(),
-                              method->getResultTypes()));
-  if (!Func) {
-    return method->emitError(
-               "Could not obtain a valid definition for operation ")
-           << method
-           << " provide a definition using "
-              "mlir::sycl::SYCLDialect::registerMethodDefinition() or using "
-              "the MangledFunctionName field of this operation.";
+    auto Func = Dialect->lookupMethodDefinition(
+        method.getFunctionName(),
+        mlir::FunctionType::get(Dialect->getContext(),
+                                ValueRange(Args).getTypes(),
+                                method->getResultTypes()));
+    if (!Func) {
+      return method->emitError(
+                 "Could not obtain a valid definition for operation ")
+             << method
+             << " provide a definition using "
+                "mlir::sycl::SYCLDialect::registerMethodDefinition() or using "
+                "the MangledFunctionName field of this operation.";
+    }
+
+    SymbolTable Module(method->getParentOp()->getParentOp());
+    if (auto *Op = Module.lookup(Func->getName())) {
+      // If the function has already been cloned to this module, use that.
+      Func = cast<func::FuncOp>(Op);
+    } else {
+      // If the function has not been inserted yet, do it now.
+      Func = Func->clone();
+      Module.insert(*Func);
+    }
+    MangledFunctionName = Func->getName();
   }
 
-  SymbolTable Module(method->getParentOp()->getParentOp());
-  if (auto *Op = Module.lookup(Func->getName())) {
-    // If the function has already been cloned to this module, use that.
-    Func = cast<func::FuncOp>(Op);
-  } else {
-    // If the function has not been inserted yet, do it now.
-    Func = Func->clone();
-    Module.insert(*Func);
-  }
   auto CallOp = rewriter.replaceOpWithNewOp<sycl::SYCLCallOp>(
       method, ResTyOrNone(), method.getTypeName(), method.getFunctionName(),
-      Func->getName(), Args);
+      *MangledFunctionName, Args);
 
   LLVM_DEBUG(llvm::dbgs() << "  Converted to: " << CallOp << "\n");
 

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -21,6 +21,7 @@ using namespace mlir;
 using namespace mlir::arith;
 
 extern llvm::cl::opt<bool> GenerateAllSYCLFuncs;
+extern llvm::cl::opt<bool> AddOptionalMangledFunctionName;
 
 ValueCategory
 MLIRScanner::VisitExtVectorElementExpr(clang::ExtVectorElementExpr *expr) {
@@ -941,8 +942,11 @@ static NamedAttrList getSYCLMethodOpAttrs(OpBuilder &builder,
             mlir::TypeAttr::get(baseType));
   attrs.set(mlir::sycl::SYCLDialect::getFunctionNameAttrName(),
             FlatSymbolRefAttr::get(builder.getStringAttr(functionName)));
-  attrs.set(mlir::sycl::SYCLDialect::getMangledFunctionNameAttrName(),
-            FlatSymbolRefAttr::get(builder.getStringAttr(mangledFunctionName)));
+  if (AddOptionalMangledFunctionName) {
+    attrs.set(
+        mlir::sycl::SYCLDialect::getMangledFunctionNameAttrName(),
+        FlatSymbolRefAttr::get(builder.getStringAttr(mangledFunctionName)));
+  }
   attrs.set(mlir::sycl::SYCLDialect::getTypeNameAttrName(),
             FlatSymbolRefAttr::get(builder.getStringAttr(typeName)));
   return attrs;

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -21,7 +21,7 @@ using namespace mlir;
 using namespace mlir::arith;
 
 extern llvm::cl::opt<bool> GenerateAllSYCLFuncs;
-extern llvm::cl::opt<bool> AddOptionalMangledFunctionName;
+extern llvm::cl::opt<bool> OmitOptionalMangledFunctionName;
 
 ValueCategory
 MLIRScanner::VisitExtVectorElementExpr(clang::ExtVectorElementExpr *expr) {
@@ -942,7 +942,7 @@ static NamedAttrList getSYCLMethodOpAttrs(OpBuilder &builder,
             mlir::TypeAttr::get(baseType));
   attrs.set(mlir::sycl::SYCLDialect::getFunctionNameAttrName(),
             FlatSymbolRefAttr::get(builder.getStringAttr(functionName)));
-  if (AddOptionalMangledFunctionName) {
+  if (!OmitOptionalMangledFunctionName) {
     attrs.set(
         mlir::sycl::SYCLDialect::getMangledFunctionNameAttrName(),
         FlatSymbolRefAttr::get(builder.getStringAttr(mangledFunctionName)));

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -205,12 +205,9 @@ static void checkFunctionParent(const FunctionOpInterface F,
 }
 
 /// If \p FD corresponds to a function implementing a SYCL method, registers
-/// \p Func as the function implementing the corrsponding operation. \p
-/// MayOverride states whether overriding an already present function is
-/// expected.
+/// \p Func as the function implementing the corrsponding operation.
 static void tryToRegisterSYCLMethod(const FunctionDecl &FD,
-                                    FunctionOpInterface Func,
-                                    bool MayOverride = false) {
+                                    FunctionOpInterface Func) {
   if (!mlirclang::isNamespaceSYCL(FD.getEnclosingNamespaceContext()) ||
       !isa<CXXMethodDecl>(FD) ||
       isa<CXXConstructorDecl, CXXDestructorDecl>(FD) ||
@@ -232,8 +229,7 @@ static void tryToRegisterSYCLMethod(const FunctionDecl &FD,
     // Only add a definition for functions registered as SYCL methods.
     return;
   }
-  SYCLDialect->registerMethodDefinition(MethodName, cast<func::FuncOp>(Func),
-                                        MayOverride);
+  SYCLDialect->registerMethodDefinition(MethodName, cast<func::FuncOp>(Func));
 }
 
 void MLIRScanner::init(mlir::FunctionOpInterface func,
@@ -496,7 +492,7 @@ void MLIRScanner::init(mlir::FunctionOpInterface func,
   else
     builder.create<ReturnOp>(loc);
 
-  tryToRegisterSYCLMethod(*FD, function, true /*MayOverride*/);
+  tryToRegisterSYCLMethod(*FD, function);
 
   checkFunctionParent(function, FTE.getContext(), module);
 }

--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -202,8 +202,8 @@ static llvm::cl::opt<std::string> McpuOpt("mcpu", llvm::cl::init(""),
                                           llvm::cl::desc("Target CPU"),
                                           llvm::cl::cat(ToolOptions));
 
-llvm::cl::opt<bool> AddOptionalMangledFunctionName(
-    "fadd-mangled-function-name", llvm::cl::init(false),
-    llvm::cl::desc("Whether to use optional \"MangledFunctionName\" fields"));
+llvm::cl::opt<bool> OmitOptionalMangledFunctionName(
+    "no-mangled-function-name", llvm::cl::init(false),
+    llvm::cl::desc("Whether to omit optional \"MangledFunctionName\" fields"));
 
 #endif /* CGEIST_OPTIONS_H_ */

--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -202,4 +202,8 @@ static llvm::cl::opt<std::string> McpuOpt("mcpu", llvm::cl::init(""),
                                           llvm::cl::desc("Target CPU"),
                                           llvm::cl::cat(ToolOptions));
 
+llvm::cl::opt<bool> AddOptionalMangledFunctionName(
+    "fadd-mangled-function-name", llvm::cl::init(false),
+    llvm::cl::desc("Whether to use optional \"MangledFunctionName\" fields"));
+
 #endif /* CGEIST_OPTIONS_H_ */

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -76,7 +76,7 @@
 // CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl_range_1_, 4>) -> memref<?x!sycl_array_1_, 4>
 
 // CHECK-LLVM: define spir_func void @cons_0([[ID_TYPE:%"class.sycl::_V1::id.1"]]* noundef byval(%"class.sycl::_V1::id.1") align 8 [[ARG0:%.*]], 
-// CHECK-LLVM-SAME:                          [[RANGE_TYPE:%"class.sycl::_V1::range.1"]]* noundef byval(%"class.sycl::_V1::range.1") align 8 [[ARG1:%.*]]) #1
+// CHECK-LLVM-SAME:                          [[RANGE_TYPE:%"class.sycl::_V1::range.1"]]* noundef byval(%"class.sycl::_V1::range.1") align 8 [[ARG1:%.*]]) #[[FUNCATTRS:[0-9]+]]
 // CHECK-LLVM-DAG: [[RANGE:%.*]] = alloca [[RANGE_TYPE]]
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE]]
 // CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID]] to [[ID_TYPE]] addrspace(4)*
@@ -107,7 +107,8 @@ extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
 // CHECK-LABEL: func.func private @_ZN4sycl3_V12idILi2EEC1Ev(memref<?x!sycl_id_2_, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 16 : i64, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXTERNAL]], {{.*}}}
 
-// CHECK-LLVM-LABEL: define spir_func void @cons_1() #1
+// CHECK-LLVM-LABEL: define spir_func void @cons_1()
+// CHECK-LLVM-SAME:  #[[FUNCATTRS]]
 // CHECK-LLVM: [[ID1:%.*]] = alloca [[ID_TYPE:%"class.sycl::_V1::id.2"]]
 // CHECK-LLVM: [[CAST1:%.*]] = bitcast [[ID_TYPE]]* %1 to i8*
 // CHECK-LLVM: call void @llvm.memset.p0i8.i64(i8* %2, i8 0, i64 16, i1 false)
@@ -126,7 +127,8 @@ extern "C" SYCL_EXTERNAL void cons_1() {
 // CHECK-NEXT: %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
 // CHECK-NEXT: sycl.constructor(%2, %arg0, %arg1) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, Type = @id} : (memref<?x!sycl_id_2_, 4>, i64, i64) -> ()
 
-// CHECK-LLVM-LABEL: define spir_func void @cons_2(i64 noundef %0, i64 noundef %1) #1
+// CHECK-LLVM-LABEL: define spir_func void @cons_2(i64 noundef %0, i64 noundef %1)
+// CHECK-LLVM-SAME:  #[[FUNCATTRS]]
 // CHECK-LLVM: [[ID1:%.*]] = alloca [[ID_TYPE:%"class.sycl::_V1::id.2"]]
 // CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID1]] to [[ID_TYPE]] addrspace(4)*
 // CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm([[ID_TYPE]] addrspace(4)* [[ID1_AS]], i64 %0, i64 %1)
@@ -146,7 +148,7 @@ extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
 // CHECK-NEXT: %5 = "polygeist.pointer2memref"(%4) : (!llvm.ptr<!sycl_item_2_1_, 4>) -> memref<?x!sycl_item_2_1_, 4>
 // CHECK-NEXT: sycl.constructor(%2, %5) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE, Type = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_item_2_1_, 4>) -> ()
 
-// CHECK-LLVM: define spir_func void @cons_3([[ITEM_TYPE:%"class.sycl::_V1::item.2.true"]]* noundef byval(%"class.sycl::_V1::item.2.true") align 8 [[ARG0:%.*]]) #1
+// CHECK-LLVM: define spir_func void @cons_3([[ITEM_TYPE:%"class.sycl::_V1::item.2.true"]]* noundef byval(%"class.sycl::_V1::item.2.true") align 8 [[ARG0:%.*]]) #[[FUNCATTRS]]
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE:%"class.sycl::_V1::id.2"]]  
 // CHECK-LLVM: [[ID_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID]] to [[ID_TYPE]] addrspace(4)*
 // CHECK-LLVM: [[ITEM_AS:%.*]] = addrspacecast [[ITEM_TYPE]]* [[ARG0]] to [[ITEM_TYPE]] addrspace(4)*
@@ -167,7 +169,7 @@ extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
 // CHECK-NEXT: %5 = "polygeist.pointer2memref"(%4) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
 // CHECK-NEXT: sycl.constructor(%2, %5) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ERKS2_, Type = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> ()
 
-// CHECK-LLVM: define spir_func void @cons_4([[ID_TYPE:%"class.sycl::_V1::id.2"]]*  noundef byval(%"class.sycl::_V1::id.2") align 8 [[ARG0:%.*]]) #1
+// CHECK-LLVM: define spir_func void @cons_4([[ID_TYPE:%"class.sycl::_V1::id.2"]]*  noundef byval(%"class.sycl::_V1::id.2") align 8 [[ARG0:%.*]]) #[[FUNCATTRS]]
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE]]
 // CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID]] to [[ID_TYPE]] addrspace(4)*
 // CHECK-LLVM: [[ID2_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ARG0]] to [[ID_TYPE]] addrspace(4)*
@@ -182,7 +184,8 @@ extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
 // CHECK: [[I:%.*]] = "polygeist.subindex"(%arg0, %c0) : (memref<?x!sycl_accessor_1_i32_write_global_buffer, 4>, index) -> memref<?x!sycl_accessor_impl_device_1_, 4>
 // CHECK: sycl.constructor([[I]], {{%.*}}, {{%.*}}, {{%.*}}) {MangledFunctionName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_, Type = @AccessorImplDevice} : (memref<?x!sycl_accessor_impl_device_1_, 4>, memref<?x!sycl_id_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>) -> ()
 
-// CHECK-LLVM-LABEL: define spir_func void @cons_5() #1
+// CHECK-LLVM-LABEL: define spir_func void @cons_5()
+// CHECK-LLVM-SAME:  #[[FUNCATTRS]]
 // CHECK-LLVM: [[ACCESSOR:%.*]] = alloca %"class.sycl::_V1::accessor.1", align 8
 // CHECK-LLVM: [[ACAST:%.*]] = addrspacecast %"class.sycl::_V1::accessor.1"* [[ACCESSOR]] to %"class.sycl::_V1::accessor.1" addrspace(4)*
 // CHECK-LLVM: call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]])
@@ -192,4 +195,4 @@ extern "C" SYCL_EXTERNAL void cons_5() {
 }
 
 // Keep at the end.
-// CHECK-LLVM: attributes #1 = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/Test/Verification/sycl/constructors.cpp" }
+// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/Test/Verification/sycl/constructors.cpp" }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -6,7 +6,7 @@
 
 #include <sycl/sycl.hpp>
 
-// CHECK-MLIR-NO-MANGLED-FUNCTION-NAME-NOT: MangledFunctionName
+// CHECK-MLIR-NO-MANGLED-FUNCTION-NAME-NOT: {{^(sycl\.constructor|sycl\.call){,0}.*}} MangledFunctionName
 
 // CHECK-MLIR-DAG: !sycl_id_1_ = !sycl.id<1>
 // CHECK-MLIR-DAG: !sycl_id_2_ = !sycl.id<2>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -1,7 +1,11 @@
 // RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s -o - -Xcgeist -no-mangled-function-name | FileCheck %s --check-prefix=CHECK-MLIR-NO-MANGLED-FUNCTION-NAME
 // RUN: clang++ -fsycl -fsycl-device-only -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -fsycl -fsycl-device-only -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - -Xcgeist -no-mangled-function-name | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
+
+// CHECK-MLIR-NO-MANGLED-FUNCTION-NAME-NOT: MangledFunctionName
 
 // CHECK-MLIR-DAG: !sycl_id_1_ = !sycl.id<1>
 // CHECK-MLIR-DAG: !sycl_id_2_ = !sycl.id<2>
@@ -28,7 +32,7 @@ template <typename T> SYCL_EXTERNAL void keep(T);
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_0N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEENS0_2idILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_read_write_global_buffer> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_read_write_global_buffer, llvm.noundef}, 
 // CHECK_MLIR_SAME:      %{{.*}}: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {BaseType = memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {BaseType = memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_0N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEENS0_2idILi2EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0, %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %1) #[[FUNCATTRS:[0-9]+]]
@@ -40,7 +44,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_0(sycl::accessor<sycl::cl_int, 2>
 
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_1N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK_MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_read_write_global_buffer>, %{{.*}}: i64)
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {BaseType = memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, i64) -> !llvm.struct<(!sycl_id_2_, !sycl_accessor_2_i32_read_write_global_buffer)>
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {BaseType = memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEEDam, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, i64) -> !llvm.struct<(!sycl_id_2_, !sycl_accessor_2_i32_read_write_global_buffer)>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_1N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0, i64 noundef %1) #[[FUNCATTRS]]
@@ -53,7 +57,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_1(sycl::accessor<sycl::cl_int, 2>
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_2N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_1_i32_read_write_global_buffer> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_1_i32_read_write_global_buffer, llvm.noundef}, 
 // CHECK-MLIR-SAME:      %{{.*}}: i64 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {BaseType = memref<?x!sycl_accessor_1_i32_read_write_global_buffer, 4>, FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_read_write_global_buffer, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {BaseType = memref<?x!sycl_accessor_1_i32_read_write_global_buffer, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERiNS0_2idILi1EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_read_write_global_buffer, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_2N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-LLVM:           %"class.sycl::_V1::accessor.1"* noundef byval(%"class.sycl::_V1::accessor.1") align 8 %0, i64 noundef %1) #[[FUNCATTRS]]  
@@ -66,7 +70,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_2(sycl::accessor<sycl::cl_int, 1>
 // CHECK-MLIR-LABEL: func.func @_Z11range_get_0N4sycl3_V15rangeILi2EEEi(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef}, 
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.range.get"(%{{.*}}, %{{.*}}) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.range.get"(%{{.*}}, %{{.*}}) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z11range_get_0N4sycl3_V15rangeILi2EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #[[FUNCATTRS]] 
@@ -79,7 +83,7 @@ SYCL_EXTERNAL void range_get_0(sycl::range<2> r, int dimension) {
 // CHECK-MLIR-LABEL: func.func @_Z11range_get_1N4sycl3_V15rangeILi2EEEi(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef}
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.range.get"(%{{.*}}, %{{.*}}) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @"operator[]", TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> memref<?xi64, 4>
+// CHECK-MLIR: %{{.*}} = "sycl.range.get"(%{{.*}}, %{{.*}}) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZN4sycl3_V16detail5arrayILi2EEixEi, TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> memref<?xi64, 4>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z11range_get_1N4sycl3_V15rangeILi2EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]   
@@ -92,7 +96,7 @@ SYCL_EXTERNAL void range_get_1(sycl::range<2> r, int dimension) {
 // CHECK-MLIR-LABEL: func.func @_Z11range_get_2N4sycl3_V15rangeILi2EEEi(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef}
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.range.get"(%{{.*}}, %{{.*}}) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @"operator[]", TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.range.get"(%{{.*}}, %{{.*}}) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EEixEi, TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z11range_get_2N4sycl3_V15rangeILi2EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]     
@@ -104,7 +108,7 @@ SYCL_EXTERNAL void range_get_2(const sycl::range<2> r, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z10range_sizeN4sycl3_V15rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.range.size"(%{{.*}}) {BaseType = memref<?x!sycl_range_2_, 4>, FunctionName = @size, TypeName = @range} : (memref<?x!sycl_range_2_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.range.size"(%{{.*}}) {BaseType = memref<?x!sycl_range_2_, 4>, FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl_range_2_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z10range_sizeN4sycl3_V15rangeILi2EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0) #[[FUNCATTRS]]       
@@ -116,7 +120,7 @@ SYCL_EXTERNAL void range_size(sycl::range<2> r) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_range_get_global_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_range.get_global_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_range_2_, 4>, FunctionName = @get_global_range, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_, 4>) -> !sycl_range_2_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_range.get_global_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_range_2_, 4>, FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_, 4>) -> !sycl_range_2_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_range_get_global_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #[[FUNCATTRS]]  
@@ -128,7 +132,7 @@ SYCL_EXTERNAL void nd_range_get_global_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-MLIR-LABEL: func.func @_Z24nd_range_get_local_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_range.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_range_2_, 4>, FunctionName = @get_local_range, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_, 4>) -> !sycl_range_2_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_range.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_range_2_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE15get_local_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_, 4>) -> !sycl_range_2_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z24nd_range_get_local_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #[[FUNCATTRS]]
@@ -140,7 +144,7 @@ SYCL_EXTERNAL void nd_range_get_local_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-MLIR-LABEL: func.func @_Z24nd_range_get_group_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_range.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_range_2_, 4>, FunctionName = @get_group_range, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_, 4>) -> !sycl_range_2_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_range.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_range_2_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE15get_group_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_, 4>) -> !sycl_range_2_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z24nd_range_get_group_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #[[FUNCATTRS]]  
@@ -152,7 +156,7 @@ SYCL_EXTERNAL void nd_range_get_group_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_0N4sycl3_V12idILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @get, TypeName = @array} : (memref<?x!sycl_id_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi1EE3getEi, TypeName = @array} : (memref<?x!sycl_id_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_0N4sycl3_V12idILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
@@ -164,7 +168,7 @@ SYCL_EXTERNAL void id_get_0(sycl::id<1> id, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_1N4sycl3_V12idILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})  
-// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @"operator[]", TypeName = @array} : (memref<?x!sycl_id_1_, 4>, i32) -> memref<?xi64, 4>
+// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZN4sycl3_V16detail5arrayILi1EEixEi, TypeName = @array} : (memref<?x!sycl_id_1_, 4>, i32) -> memref<?xi64, 4>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_1N4sycl3_V12idILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]  
@@ -176,7 +180,7 @@ SYCL_EXTERNAL void id_get_1(sycl::id<1> id, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_2N4sycl3_V12idILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})    
-// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @"operator[]", TypeName = @array} : (memref<?x!sycl_id_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi1EEixEi, TypeName = @array} : (memref<?x!sycl_id_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_2N4sycl3_V12idILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]    
@@ -188,7 +192,7 @@ SYCL_EXTERNAL void id_get_2(const sycl::id<1> id, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_3N4sycl3_V12idILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}
-// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}) {BaseType = memref<?x!sycl_id_1_, 4>, FunctionName = @"operator unsigned long", TypeName = @id} : (memref<?x!sycl_id_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}) {BaseType = memref<?x!sycl_id_1_, 4>, FunctionName = @"operator unsigned long", MangledFunctionName = @_ZNK4sycl3_V12idILi1EEcvmEv, TypeName = @id} : (memref<?x!sycl_id_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_3N4sycl3_V12idILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0) #[[FUNCATTRS]]      
@@ -200,7 +204,7 @@ SYCL_EXTERNAL void id_get_3(sycl::id<1> id) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_item_1_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_id, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]
@@ -212,7 +216,7 @@ SYCL_EXTERNAL void item_get_id_0(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_1N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_item_1_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_id, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEi, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_1N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
@@ -224,7 +228,7 @@ SYCL_EXTERNAL void item_get_id_1(sycl::item<1> item, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_2N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_item_1_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @"operator[]", TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EEixEi, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_2N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]  
@@ -236,7 +240,7 @@ SYCL_EXTERNAL void item_get_id_2(sycl::item<1> item, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_3N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_item_1_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @"operator unsigned long", TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @"operator unsigned long", MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EEcvmEv, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_3N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]  
@@ -248,7 +252,7 @@ SYCL_EXTERNAL void item_get_id_3(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z16item_get_range_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_item_1_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.item.get_range"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_range, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_range"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEv, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z16item_get_range_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]    
@@ -260,7 +264,7 @@ SYCL_EXTERNAL void item_get_range_0(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z16item_get_range_1N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_item_1_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.item.get_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_range, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEi, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z16item_get_range_1N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
@@ -272,7 +276,7 @@ SYCL_EXTERNAL void item_get_range_1(sycl::item<1> item, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z18item_get_linear_idN4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_item_1_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.item.get_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_linear_id, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_linear_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE13get_linear_idEv, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z18item_get_linear_idN4sycl3_V14itemILi1ELb1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]      
@@ -284,7 +288,7 @@ SYCL_EXTERNAL void item_get_linear_id(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23nd_item_get_global_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23nd_item_get_global_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]
@@ -296,7 +300,7 @@ SYCL_EXTERNAL void nd_item_get_global_id_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23nd_item_get_global_id_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23nd_item_get_global_id_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
@@ -308,7 +312,7 @@ SYCL_EXTERNAL void nd_item_get_global_id_1(sycl::nd_item<1> nd_item, int dimensi
 
 // CHECK-MLIR-LABEL: func.func @_Z28nd_item_get_global_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_linear_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE20get_global_linear_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z28nd_item_get_global_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]    
@@ -320,7 +324,7 @@ SYCL_EXTERNAL void nd_item_get_global_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z22nd_item_get_local_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z22nd_item_get_local_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]  
@@ -332,7 +336,7 @@ SYCL_EXTERNAL void nd_item_get_local_id_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z22nd_item_get_local_id_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z22nd_item_get_local_id_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]  
@@ -344,7 +348,7 @@ SYCL_EXTERNAL void nd_item_get_local_id_1(sycl::nd_item<1> nd_item, int dimensio
 
 // CHECK-MLIR-LABEL: func.func @_Z27nd_item_get_local_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_linear_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE19get_local_linear_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z27nd_item_get_local_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]    
@@ -356,7 +360,7 @@ SYCL_EXTERNAL void nd_item_get_local_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z19nd_item_get_group_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})  
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_group_1_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_group_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z19nd_item_get_group_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]      
@@ -368,7 +372,7 @@ SYCL_EXTERNAL void nd_item_get_group_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z19nd_item_get_group_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z19nd_item_get_group_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]    
@@ -380,7 +384,7 @@ SYCL_EXTERNAL void nd_item_get_group_1(sycl::nd_item<1> nd_item, int dimension) 
 
 // CHECK-MLIR-LABEL: func.func @_Z27nd_item_get_group_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_linear_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE19get_group_linear_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z27nd_item_get_group_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]      
@@ -392,7 +396,7 @@ SYCL_EXTERNAL void nd_item_get_group_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_group_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_group_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]        
@@ -404,7 +408,7 @@ SYCL_EXTERNAL void nd_item_get_group_range_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_group_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_group_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]    
@@ -416,7 +420,7 @@ SYCL_EXTERNAL void nd_item_get_group_range_1(sycl::nd_item<1> nd_item, int dimen
 
 // CHECK-MLIR-LABEL: func.func @_Z26nd_item_get_global_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z26nd_item_get_global_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]
@@ -428,7 +432,7 @@ SYCL_EXTERNAL void nd_item_get_global_range_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z26nd_item_get_global_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z26nd_item_get_global_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]      
@@ -440,7 +444,7 @@ SYCL_EXTERNAL void nd_item_get_global_range_1(sycl::nd_item<1> nd_item, int dime
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_local_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_local_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]
@@ -452,7 +456,7 @@ SYCL_EXTERNAL void nd_item_get_local_range_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_local_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_local_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]        
@@ -464,7 +468,7 @@ SYCL_EXTERNAL void nd_item_get_local_range_1(sycl::nd_item<1> nd_item, int dimen
 
 // CHECK-MLIR-LABEL: func.func @_Z20nd_item_get_nd_rangeN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_nd_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_nd_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_nd_range_1_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_nd_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_nd_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_nd_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_nd_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20nd_item_get_nd_rangeN4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]          
@@ -476,7 +480,7 @@ SYCL_EXTERNAL void nd_item_get_nd_range(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_id, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_group_idEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_0N4sycl3_V15groupILi1EEE(
 
@@ -488,7 +492,7 @@ SYCL_EXTERNAL void group_get_group_id_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_id, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_group_idEi, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_1N4sycl3_V15groupILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
@@ -500,7 +504,7 @@ SYCL_EXTERNAL void group_get_group_id_1(sycl::group<1> group, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_2N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @"operator[]", TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V15groupILi1EEixEi, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_2N4sycl3_V15groupILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
@@ -512,7 +516,7 @@ SYCL_EXTERNAL void group_get_group_id_2(sycl::group<1> group, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_local_id_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_id, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_local_idEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_local_id_0N4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]   
@@ -524,7 +528,7 @@ SYCL_EXTERNAL void group_get_local_id_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_local_id_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_id, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_local_idEi, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_local_id_1N4sycl3_V15groupILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]  
@@ -536,7 +540,7 @@ SYCL_EXTERNAL void group_get_local_id_1(sycl::group<1> group, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_local_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_range, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_local_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]     
@@ -548,7 +552,7 @@ SYCL_EXTERNAL void group_get_local_range_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_local_range_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_range, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEi, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_local_range_1N4sycl3_V15groupILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]    
@@ -560,7 +564,7 @@ SYCL_EXTERNAL void group_get_local_range_1(sycl::group<1> group, int dimension) 
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_group_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}  
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_range, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_group_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]       
@@ -572,7 +576,7 @@ SYCL_EXTERNAL void group_get_group_range_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_group_range_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}    
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_range, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEi, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_group_range_1N4sycl3_V15groupILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]      
@@ -584,7 +588,7 @@ SYCL_EXTERNAL void group_get_group_range_1(sycl::group<1> group, int dimension) 
 
 // CHECK-MLIR-LABEL: func.func @_Z25group_get_max_local_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}      
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_max_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_max_local_range, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_max_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_max_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_max_local_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_max_local_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]         
@@ -596,7 +600,7 @@ SYCL_EXTERNAL void group_get_max_local_range(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25group_get_group_linear_idN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}        
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_linear_id, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_linear_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_group_linear_idEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_group_linear_idN4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]           
@@ -608,7 +612,7 @@ SYCL_EXTERNAL void group_get_group_linear_id(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25group_get_local_linear_idN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}          
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_linear_id, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_linear_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_local_linear_idEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_local_linear_idN4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]         
@@ -620,7 +624,7 @@ SYCL_EXTERNAL void group_get_local_linear_id(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z28group_get_group_linear_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}            
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_linear_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_linear_range, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_linear_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_linear_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE22get_group_linear_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z28group_get_group_linear_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]           
@@ -632,7 +636,7 @@ SYCL_EXTERNAL void group_get_group_linear_range(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z28group_get_local_linear_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_linear_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_linear_range, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_linear_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_linear_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE22get_local_linear_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z28group_get_local_linear_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]             
@@ -693,8 +697,8 @@ SYCL_EXTERNAL void op_1(sycl::id<2> a, sycl::id<2> b) {
 // CHECK-MLIR-NEXT: %0 = "polygeist.memref2pointer"(%arg0) : (memref<?x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
 // CHECK-MLIR-NEXT: %1 = llvm.addrspacecast %0 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
 // CHECK-MLIR-NEXT: %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
-// CHECK-MLIR-NEXT: %3 = "sycl.id.get"(%2, %c0_i32) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, TypeName = @array} : (memref<?x!sycl_id_2_, 4>, i32) -> i64
-// CHECK-MLIR-NEXT: %4 = "sycl.id.get"(%2, %c1_i32) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, TypeName = @array} : (memref<?x!sycl_id_2_, 4>, i32) -> i64
+// CHECK-MLIR-NEXT: %3 = "sycl.id.get"(%2, %c0_i32) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_id_2_, 4>, i32) -> i64
+// CHECK-MLIR-NEXT: %4 = "sycl.id.get"(%2, %c1_i32) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_id_2_, 4>, i32) -> i64
 // CHECK-MLIR-NEXT: %5 = arith.addi %3, %4 : i64
 // CHECK-MLIR-NEXT: %6 = sycl.call(%5) {FunctionName = @abs, MangledFunctionName = @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_} : (i64) -> i64
 // CHECK-MLIR-NEXT: return

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -28,10 +28,10 @@ template <typename T> SYCL_EXTERNAL void keep(T);
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_0N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEENS0_2idILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_read_write_global_buffer> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_read_write_global_buffer, llvm.noundef}, 
 // CHECK_MLIR_SAME:      %{{.*}}: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {BaseType = memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {BaseType = memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_0N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEENS0_2idILi2EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0, %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %1) #1
+// CHECK-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0, %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %1) #[[FUNCATTRS:[0-9]+]]
 // CHECK-LLVM:  %{{.*}} = call i32 addrspace(4)* @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE(%"class.sycl::_V1::accessor.2" addrspace(4)* %{{.*}}, %"class.sycl::_V1::id.2"* %{{.*}})
 
 SYCL_EXTERNAL void accessor_subscript_operator_0(sycl::accessor<sycl::cl_int, 2> acc, sycl::id<2> index) {
@@ -40,10 +40,10 @@ SYCL_EXTERNAL void accessor_subscript_operator_0(sycl::accessor<sycl::cl_int, 2>
 
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_1N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK_MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_read_write_global_buffer>, %{{.*}}: i64)
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {BaseType = memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEEDam, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, i64) -> !llvm.struct<(!sycl_id_2_, !sycl_accessor_2_i32_read_write_global_buffer)>
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {BaseType = memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, i64) -> !llvm.struct<(!sycl_id_2_, !sycl_accessor_2_i32_read_write_global_buffer)>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_1N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
-// CHECK-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0, i64 noundef %1) #1
+// CHECK-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0, i64 noundef %1) #[[FUNCATTRS]]
 // CHECK-LLVM: %{{.*}} = call { %"class.sycl::_V1::id.2", %"class.sycl::_V1::accessor.2" } @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEEDam(%"class.sycl::_V1::accessor.2" addrspace(4)* %{{.*}}, i64 %1)
 
 SYCL_EXTERNAL void accessor_subscript_operator_1(sycl::accessor<sycl::cl_int, 2> acc, size_t index) {
@@ -53,10 +53,10 @@ SYCL_EXTERNAL void accessor_subscript_operator_1(sycl::accessor<sycl::cl_int, 2>
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_2N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_1_i32_read_write_global_buffer> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_1_i32_read_write_global_buffer, llvm.noundef}, 
 // CHECK-MLIR-SAME:      %{{.*}}: i64 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {BaseType = memref<?x!sycl_accessor_1_i32_read_write_global_buffer, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERiNS0_2idILi1EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_read_write_global_buffer, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {BaseType = memref<?x!sycl_accessor_1_i32_read_write_global_buffer, 4>, FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_read_write_global_buffer, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_2N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
-// CHECK-LLVM:           %"class.sycl::_V1::accessor.1"* noundef byval(%"class.sycl::_V1::accessor.1") align 8 %0, i64 noundef %1) #1  
+// CHECK-LLVM:           %"class.sycl::_V1::accessor.1"* noundef byval(%"class.sycl::_V1::accessor.1") align 8 %0, i64 noundef %1) #[[FUNCATTRS]]  
 // CHECK-LLVM:  %{{.*}} = call i32 addrspace(4)* @_ZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERiNS0_2idILi1EEE(%"class.sycl::_V1::accessor.1" addrspace(4)* %{{.*}}, %"class.sycl::_V1::id.1"* %{{.*}})
 
 SYCL_EXTERNAL void accessor_subscript_operator_2(sycl::accessor<sycl::cl_int, 1> acc, size_t index) {
@@ -66,10 +66,10 @@ SYCL_EXTERNAL void accessor_subscript_operator_2(sycl::accessor<sycl::cl_int, 1>
 // CHECK-MLIR-LABEL: func.func @_Z11range_get_0N4sycl3_V15rangeILi2EEEi(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef}, 
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.range.get"(%{{.*}}, %{{.*}}) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.range.get"(%{{.*}}, %{{.*}}) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z11range_get_0N4sycl3_V15rangeILi2EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #1 
+// CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #[[FUNCATTRS]] 
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V16detail5arrayILi2EE3getEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void range_get_0(sycl::range<2> r, int dimension) {
@@ -79,10 +79,10 @@ SYCL_EXTERNAL void range_get_0(sycl::range<2> r, int dimension) {
 // CHECK-MLIR-LABEL: func.func @_Z11range_get_1N4sycl3_V15rangeILi2EEEi(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef}
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.range.get"(%{{.*}}, %{{.*}}) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZN4sycl3_V16detail5arrayILi2EEixEi, TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> memref<?xi64, 4>
+// CHECK-MLIR: %{{.*}} = "sycl.range.get"(%{{.*}}, %{{.*}}) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @"operator[]", TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> memref<?xi64, 4>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z11range_get_1N4sycl3_V15rangeILi2EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #1   
+// CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]   
 // CHECK-LLVM: %{{.*}} = call i64 addrspace(4)* @_ZN4sycl3_V16detail5arrayILi2EEixEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void range_get_1(sycl::range<2> r, int dimension) {
@@ -92,10 +92,10 @@ SYCL_EXTERNAL void range_get_1(sycl::range<2> r, int dimension) {
 // CHECK-MLIR-LABEL: func.func @_Z11range_get_2N4sycl3_V15rangeILi2EEEi(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef}
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.range.get"(%{{.*}}, %{{.*}}) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EEixEi, TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.range.get"(%{{.*}}, %{{.*}}) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @"operator[]", TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z11range_get_2N4sycl3_V15rangeILi2EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #1     
+// CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]     
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V16detail5arrayILi2EEixEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void range_get_2(const sycl::range<2> r, int dimension) {
@@ -104,10 +104,10 @@ SYCL_EXTERNAL void range_get_2(const sycl::range<2> r, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z10range_sizeN4sycl3_V15rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.range.size"(%{{.*}}) {BaseType = memref<?x!sycl_range_2_, 4>, FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl_range_2_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.range.size"(%{{.*}}) {BaseType = memref<?x!sycl_range_2_, 4>, FunctionName = @size, TypeName = @range} : (memref<?x!sycl_range_2_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z10range_sizeN4sycl3_V15rangeILi2EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0) #1       
+// CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0) #[[FUNCATTRS]]       
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15rangeILi2EE4sizeEv(%"class.sycl::_V1::range.2" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void range_size(sycl::range<2> r) {
@@ -116,10 +116,10 @@ SYCL_EXTERNAL void range_size(sycl::range<2> r) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_range_get_global_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_range.get_global_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_range_2_, 4>, FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_, 4>) -> !sycl_range_2_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_range.get_global_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_range_2_, 4>, FunctionName = @get_global_range, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_, 4>) -> !sycl_range_2_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_range_get_global_rangeN4sycl3_V18nd_rangeILi2EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #1  
+// CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #[[FUNCATTRS]]  
 // CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_range_get_global_range(sycl::nd_range<2> nd_range) {
@@ -128,10 +128,10 @@ SYCL_EXTERNAL void nd_range_get_global_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-MLIR-LABEL: func.func @_Z24nd_range_get_local_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_range.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_range_2_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE15get_local_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_, 4>) -> !sycl_range_2_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_range.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_range_2_, 4>, FunctionName = @get_local_range, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_, 4>) -> !sycl_range_2_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z24nd_range_get_local_rangeN4sycl3_V18nd_rangeILi2EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #1
+// CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #[[FUNCATTRS]]
 // CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE15get_local_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_range_get_local_range(sycl::nd_range<2> nd_range) {
@@ -140,10 +140,10 @@ SYCL_EXTERNAL void nd_range_get_local_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-MLIR-LABEL: func.func @_Z24nd_range_get_group_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_range.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_range_2_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE15get_group_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_, 4>) -> !sycl_range_2_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_range.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_range_2_, 4>, FunctionName = @get_group_range, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_, 4>) -> !sycl_range_2_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z24nd_range_get_group_rangeN4sycl3_V18nd_rangeILi2EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #1  
+// CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #[[FUNCATTRS]]  
 // CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE15get_group_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_range_get_group_range(sycl::nd_range<2> nd_range) {
@@ -152,10 +152,10 @@ SYCL_EXTERNAL void nd_range_get_group_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_0N4sycl3_V12idILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi1EE3getEi, TypeName = @array} : (memref<?x!sycl_id_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @get, TypeName = @array} : (memref<?x!sycl_id_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_0N4sycl3_V12idILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #1
+// CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V16detail5arrayILi1EE3getEi(%"class.sycl::_V1::detail::array.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void id_get_0(sycl::id<1> id, int dimension) {
@@ -164,10 +164,10 @@ SYCL_EXTERNAL void id_get_0(sycl::id<1> id, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_1N4sycl3_V12idILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})  
-// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZN4sycl3_V16detail5arrayILi1EEixEi, TypeName = @array} : (memref<?x!sycl_id_1_, 4>, i32) -> memref<?xi64, 4>
+// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @"operator[]", TypeName = @array} : (memref<?x!sycl_id_1_, 4>, i32) -> memref<?xi64, 4>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_1N4sycl3_V12idILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #1  
+// CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]  
 // CHECK-LLVM: %{{.*}} = call i64 addrspace(4)* @_ZN4sycl3_V16detail5arrayILi1EEixEi(%"class.sycl::_V1::detail::array.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void id_get_1(sycl::id<1> id, int dimension) {
@@ -176,10 +176,10 @@ SYCL_EXTERNAL void id_get_1(sycl::id<1> id, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_2N4sycl3_V12idILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})    
-// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi1EEixEi, TypeName = @array} : (memref<?x!sycl_id_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @"operator[]", TypeName = @array} : (memref<?x!sycl_id_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_2N4sycl3_V12idILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #1    
+// CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]    
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V16detail5arrayILi1EEixEi(%"class.sycl::_V1::detail::array.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void id_get_2(const sycl::id<1> id, int dimension) {
@@ -188,10 +188,10 @@ SYCL_EXTERNAL void id_get_2(const sycl::id<1> id, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_3N4sycl3_V12idILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}
-// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}) {BaseType = memref<?x!sycl_id_1_, 4>, FunctionName = @"operator unsigned long", MangledFunctionName = @_ZNK4sycl3_V12idILi1EEcvmEv, TypeName = @id} : (memref<?x!sycl_id_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}) {BaseType = memref<?x!sycl_id_1_, 4>, FunctionName = @"operator unsigned long", TypeName = @id} : (memref<?x!sycl_id_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_3N4sycl3_V12idILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0) #1      
+// CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0) #[[FUNCATTRS]]      
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V12idILi1EEcvmEv(%"class.sycl::_V1::id.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void id_get_3(sycl::id<1> id) {
@@ -200,10 +200,10 @@ SYCL_EXTERNAL void id_get_3(sycl::id<1> id) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_item_1_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_id, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_0N4sycl3_V14itemILi1ELb1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #1
+// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]
 // CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::id.1" @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void item_get_id_0(sycl::item<1> item) {
@@ -212,10 +212,10 @@ SYCL_EXTERNAL void item_get_id_0(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_1N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_item_1_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEi, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_id, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_1N4sycl3_V14itemILi1ELb1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0, i32 noundef %1) #1
+// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEi(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void item_get_id_1(sycl::item<1> item, int dimension) {
@@ -224,10 +224,10 @@ SYCL_EXTERNAL void item_get_id_1(sycl::item<1> item, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_2N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_item_1_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EEixEi, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @"operator[]", TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_2N4sycl3_V14itemILi1ELb1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0, i32 noundef %1) #1  
+// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]  
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V14itemILi1ELb1EEixEi(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void item_get_id_2(sycl::item<1> item, int dimension) {
@@ -236,10 +236,10 @@ SYCL_EXTERNAL void item_get_id_2(sycl::item<1> item, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_3N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_item_1_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @"operator unsigned long", MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EEcvmEv, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @"operator unsigned long", TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_3N4sycl3_V14itemILi1ELb1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #1  
+// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]  
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V14itemILi1ELb1EEcvmEv(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void item_get_id_3(sycl::item<1> item) {
@@ -248,10 +248,10 @@ SYCL_EXTERNAL void item_get_id_3(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z16item_get_range_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_item_1_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.item.get_range"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEv, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_range"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_range, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z16item_get_range_0N4sycl3_V14itemILi1ELb1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #1    
+// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]    
 // CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEv(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void item_get_range_0(sycl::item<1> item) {
@@ -260,10 +260,10 @@ SYCL_EXTERNAL void item_get_range_0(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z16item_get_range_1N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_item_1_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.item.get_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEi, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_range, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z16item_get_range_1N4sycl3_V14itemILi1ELb1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0, i32 noundef %1) #1
+// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEi(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void item_get_range_1(sycl::item<1> item, int dimension) {
@@ -272,10 +272,10 @@ SYCL_EXTERNAL void item_get_range_1(sycl::item<1> item, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z18item_get_linear_idN4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_item_1_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.item.get_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_linear_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE13get_linear_idEv, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_linear_id, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z18item_get_linear_idN4sycl3_V14itemILi1ELb1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #1      
+// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]      
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V14itemILi1ELb1EE13get_linear_idEv(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void item_get_linear_id(sycl::item<1> item) {
@@ -284,10 +284,10 @@ SYCL_EXTERNAL void item_get_linear_id(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23nd_item_get_global_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23nd_item_get_global_id_0N4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #1
+// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]
 // CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::id.1" @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_global_id_0(sycl::nd_item<1> nd_item) {
@@ -296,10 +296,10 @@ SYCL_EXTERNAL void nd_item_get_global_id_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23nd_item_get_global_id_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23nd_item_get_global_id_1N4sycl3_V17nd_itemILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #1
+// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void nd_item_get_global_id_1(sycl::nd_item<1> nd_item, int dimension) {
@@ -308,10 +308,10 @@ SYCL_EXTERNAL void nd_item_get_global_id_1(sycl::nd_item<1> nd_item, int dimensi
 
 // CHECK-MLIR-LABEL: func.func @_Z28nd_item_get_global_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE20get_global_linear_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_linear_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z28nd_item_get_global_linear_idN4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #1    
+// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]    
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE20get_global_linear_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_global_linear_id(sycl::nd_item<1> nd_item) {
@@ -320,10 +320,10 @@ SYCL_EXTERNAL void nd_item_get_global_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z22nd_item_get_local_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z22nd_item_get_local_id_0N4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #1  
+// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]  
 // CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::id.1" @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_local_id_0(sycl::nd_item<1> nd_item) {
@@ -332,10 +332,10 @@ SYCL_EXTERNAL void nd_item_get_local_id_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z22nd_item_get_local_id_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z22nd_item_get_local_id_1N4sycl3_V17nd_itemILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #1  
+// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]  
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void nd_item_get_local_id_1(sycl::nd_item<1> nd_item, int dimension) {
@@ -344,10 +344,10 @@ SYCL_EXTERNAL void nd_item_get_local_id_1(sycl::nd_item<1> nd_item, int dimensio
 
 // CHECK-MLIR-LABEL: func.func @_Z27nd_item_get_local_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE19get_local_linear_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_linear_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z27nd_item_get_local_linear_idN4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #1    
+// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]    
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE19get_local_linear_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_local_linear_id(sycl::nd_item<1> nd_item) {
@@ -356,10 +356,10 @@ SYCL_EXTERNAL void nd_item_get_local_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z19nd_item_get_group_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})  
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_group_1_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_group_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z19nd_item_get_group_0N4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #1      
+// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]      
 // CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::group.1" @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_group_0(sycl::nd_item<1> nd_item) {
@@ -368,10 +368,10 @@ SYCL_EXTERNAL void nd_item_get_group_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z19nd_item_get_group_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z19nd_item_get_group_1N4sycl3_V17nd_itemILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #1    
+// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]    
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void nd_item_get_group_1(sycl::nd_item<1> nd_item, int dimension) {
@@ -380,10 +380,10 @@ SYCL_EXTERNAL void nd_item_get_group_1(sycl::nd_item<1> nd_item, int dimension) 
 
 // CHECK-MLIR-LABEL: func.func @_Z27nd_item_get_group_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE19get_group_linear_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_linear_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z27nd_item_get_group_linear_idN4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #1      
+// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]      
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE19get_group_linear_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_group_linear_id(sycl::nd_item<1> nd_item) {
@@ -392,10 +392,10 @@ SYCL_EXTERNAL void nd_item_get_group_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_group_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_group_range_0N4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #1        
+// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]        
 // CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_group_range_0(sycl::nd_item<1> nd_item) {
@@ -404,10 +404,10 @@ SYCL_EXTERNAL void nd_item_get_group_range_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_group_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_group_range_1N4sycl3_V17nd_itemILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #1    
+// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]    
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void nd_item_get_group_range_1(sycl::nd_item<1> nd_item, int dimension) {
@@ -416,10 +416,10 @@ SYCL_EXTERNAL void nd_item_get_group_range_1(sycl::nd_item<1> nd_item, int dimen
 
 // CHECK-MLIR-LABEL: func.func @_Z26nd_item_get_global_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z26nd_item_get_global_range_0N4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #1
+// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]
 // CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_global_range_0(sycl::nd_item<1> nd_item) {
@@ -428,10 +428,10 @@ SYCL_EXTERNAL void nd_item_get_global_range_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z26nd_item_get_global_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z26nd_item_get_global_range_1N4sycl3_V17nd_itemILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #1      
+// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]      
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void nd_item_get_global_range_1(sycl::nd_item<1> nd_item, int dimension) {
@@ -440,10 +440,10 @@ SYCL_EXTERNAL void nd_item_get_global_range_1(sycl::nd_item<1> nd_item, int dime
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_local_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_local_range_0N4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #1
+// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]
 // CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_local_range_0(sycl::nd_item<1> nd_item) {
@@ -452,10 +452,10 @@ SYCL_EXTERNAL void nd_item_get_local_range_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_local_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_local_range_1N4sycl3_V17nd_itemILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #1        
+// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]        
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void nd_item_get_local_range_1(sycl::nd_item<1> nd_item, int dimension) {
@@ -464,10 +464,10 @@ SYCL_EXTERNAL void nd_item_get_local_range_1(sycl::nd_item<1> nd_item, int dimen
 
 // CHECK-MLIR-LABEL: func.func @_Z20nd_item_get_nd_rangeN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_nd_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_nd_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_nd_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_nd_range_1_
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_nd_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_nd_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_nd_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20nd_item_get_nd_rangeN4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #1          
+// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]          
 // CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::nd_range.1" @_ZNK4sycl3_V17nd_itemILi1EE12get_nd_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_nd_range(sycl::nd_item<1> nd_item) {
@@ -476,7 +476,7 @@ SYCL_EXTERNAL void nd_item_get_nd_range(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_group_idEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_id, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_0N4sycl3_V15groupILi1EEE(
 
@@ -488,10 +488,10 @@ SYCL_EXTERNAL void group_get_group_id_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_group_idEi, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_id, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_1N4sycl3_V15groupILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #1
+// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE12get_group_idEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void group_get_group_id_1(sycl::group<1> group, int dimension) {
@@ -500,10 +500,10 @@ SYCL_EXTERNAL void group_get_group_id_1(sycl::group<1> group, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_2N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V15groupILi1EEixEi, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @"operator[]", TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_2N4sycl3_V15groupILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #1
+// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EEixEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void group_get_group_id_2(sycl::group<1> group, int dimension) {
@@ -512,10 +512,10 @@ SYCL_EXTERNAL void group_get_group_id_2(sycl::group<1> group, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_local_id_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_local_idEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_id, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_local_id_0N4sycl3_V15groupILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #1   
+// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]   
 // CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::id.1" @_ZNK4sycl3_V15groupILi1EE12get_local_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_local_id_0(sycl::group<1> group) {
@@ -524,10 +524,10 @@ SYCL_EXTERNAL void group_get_local_id_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_local_id_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_local_idEi, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_id, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_local_id_1N4sycl3_V15groupILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #1  
+// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]  
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE12get_local_idEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void group_get_local_id_1(sycl::group<1> group, int dimension) {
@@ -536,10 +536,10 @@ SYCL_EXTERNAL void group_get_local_id_1(sycl::group<1> group, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_local_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_range, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_local_range_0N4sycl3_V15groupILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #1     
+// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]     
 // CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_local_range_0(sycl::group<1> group) {
@@ -548,10 +548,10 @@ SYCL_EXTERNAL void group_get_local_range_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_local_range_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEi, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_range, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_local_range_1N4sycl3_V15groupILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #1    
+// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]    
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void group_get_local_range_1(sycl::group<1> group, int dimension) {
@@ -560,10 +560,10 @@ SYCL_EXTERNAL void group_get_local_range_1(sycl::group<1> group, int dimension) 
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_group_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}  
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_range, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_group_range_0N4sycl3_V15groupILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #1       
+// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]       
 // CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_group_range_0(sycl::group<1> group) {
@@ -572,10 +572,10 @@ SYCL_EXTERNAL void group_get_group_range_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_group_range_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}    
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEi, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_range, TypeName = @group} : (memref<?x!sycl_group_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_group_range_1N4sycl3_V15groupILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #1      
+// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]      
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void group_get_group_range_1(sycl::group<1> group, int dimension) {
@@ -584,10 +584,10 @@ SYCL_EXTERNAL void group_get_group_range_1(sycl::group<1> group, int dimension) 
 
 // CHECK-MLIR-LABEL: func.func @_Z25group_get_max_local_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}      
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_max_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_max_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_max_local_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_max_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_max_local_range, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_max_local_rangeN4sycl3_V15groupILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #1         
+// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]         
 // CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V15groupILi1EE19get_max_local_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_max_local_range(sycl::group<1> group) {
@@ -596,10 +596,10 @@ SYCL_EXTERNAL void group_get_max_local_range(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25group_get_group_linear_idN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}        
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_linear_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_group_linear_idEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_linear_id, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_group_linear_idN4sycl3_V15groupILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #1           
+// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]           
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE19get_group_linear_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_group_linear_id(sycl::group<1> group) {
@@ -608,10 +608,10 @@ SYCL_EXTERNAL void group_get_group_linear_id(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25group_get_local_linear_idN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}          
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_linear_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_local_linear_idEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_linear_id, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_local_linear_idN4sycl3_V15groupILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #1         
+// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]         
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE19get_local_linear_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_local_linear_id(sycl::group<1> group) {
@@ -620,10 +620,10 @@ SYCL_EXTERNAL void group_get_local_linear_id(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z28group_get_group_linear_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}            
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_linear_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_linear_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE22get_group_linear_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_linear_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_linear_range, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z28group_get_group_linear_rangeN4sycl3_V15groupILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #1           
+// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]           
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE22get_group_linear_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_group_linear_range(sycl::group<1> group) {
@@ -632,10 +632,10 @@ SYCL_EXTERNAL void group_get_group_linear_range(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z28group_get_local_linear_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_linear_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_linear_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE22get_local_linear_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_linear_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_linear_range, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z28group_get_local_linear_rangeN4sycl3_V15groupILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #1             
+// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]             
 // CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE22get_local_linear_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_local_linear_range(sycl::group<1> group) {
@@ -652,7 +652,7 @@ SYCL_EXTERNAL void group_get_local_linear_range(sycl::group<1> group) {
 // CHECK-MLIR-NEXT: }
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8method_2N4sycl3_V14itemILi2ELb1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::item.2.true"* noundef byval(%"class.sycl::_V1::item.2.true") align 8 %0) #1
+// CHECK-LLVM:           %"class.sycl::_V1::item.2.true"* noundef byval(%"class.sycl::_V1::item.2.true") align 8 %0) #[[FUNCATTRS]]
 // CHECK-LLVM-NEXT:  %2 = addrspacecast %"class.sycl::_V1::item.2.true"* %0 to %"class.sycl::_V1::item.2.true" addrspace(4)*
 // CHECK-LLVM-NEXT:  %3 = call i8 @_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_(%"class.sycl::_V1::item.2.true" addrspace(4)* %2, %"class.sycl::_V1::item.2.true" addrspace(4)* %2)
 // CHECK-LLVM-NEXT:  ret void
@@ -675,7 +675,7 @@ SYCL_EXTERNAL void method_2(sycl::item<2, true> item) {
 // CHECK-MLIR-NEXT: }
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z4op_1N4sycl3_V12idILi2EEES2_(
-// CHECK-LLVM            %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %0, %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %1) #1
+// CHECK-LLVM            %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %0, %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %1) #[[FUNCATTRS]]
 // CHECK-LLVM-NEXT: %3 = addrspacecast %"class.sycl::_V1::id.2"* %0 to %"class.sycl::_V1::id.2" addrspace(4)*
 // CHECK-LLVM-NEXT: %4 = addrspacecast %"class.sycl::_V1::id.2"* %1 to %"class.sycl::_V1::id.2" addrspace(4)*
 // CHECK-LLVM-NEXT: %5 = call i8 @_ZNK4sycl3_V12idILi2EEeqERKS2_(%"class.sycl::_V1::id.2" addrspace(4)* %3, %"class.sycl::_V1::id.2" addrspace(4)* %4)
@@ -693,15 +693,15 @@ SYCL_EXTERNAL void op_1(sycl::id<2> a, sycl::id<2> b) {
 // CHECK-MLIR-NEXT: %0 = "polygeist.memref2pointer"(%arg0) : (memref<?x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
 // CHECK-MLIR-NEXT: %1 = llvm.addrspacecast %0 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
 // CHECK-MLIR-NEXT: %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
-// CHECK-MLIR-NEXT: %3 = "sycl.id.get"(%2, %c0_i32) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_id_2_, 4>, i32) -> i64
-// CHECK-MLIR-NEXT: %4 = "sycl.id.get"(%2, %c1_i32) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_id_2_, 4>, i32) -> i64
+// CHECK-MLIR-NEXT: %3 = "sycl.id.get"(%2, %c0_i32) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, TypeName = @array} : (memref<?x!sycl_id_2_, 4>, i32) -> i64
+// CHECK-MLIR-NEXT: %4 = "sycl.id.get"(%2, %c1_i32) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, TypeName = @array} : (memref<?x!sycl_id_2_, 4>, i32) -> i64
 // CHECK-MLIR-NEXT: %5 = arith.addi %3, %4 : i64
 // CHECK-MLIR-NEXT: %6 = sycl.call(%5) {FunctionName = @abs, MangledFunctionName = @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_} : (i64) -> i64
 // CHECK-MLIR-NEXT: return
 // CHECK-MLIR-NEXT: }
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8static_1N4sycl3_V12idILi2EEES2_(
-// CHECK-LLVM            %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %0, %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %1) #1  
+// CHECK-LLVM            %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %0, %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %1) #[[FUNCATTRS]]  
 // CHECK-LLVM-NEXT: %3 = addrspacecast %"class.sycl::_V1::id.2"* %0 to %"class.sycl::_V1::id.2" addrspace(4)*
 // CHECK-LLVM-NEXT: %4 = bitcast %"class.sycl::_V1::id.2" addrspace(4)* %3 to %"class.sycl::_V1::detail::array.2" addrspace(4)*
 // CHECK-LLVM-NEXT: %5 = call i64 @_ZNK4sycl3_V16detail5arrayILi2EE3getEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %4, i32 0)
@@ -715,4 +715,4 @@ SYCL_EXTERNAL void static_1(sycl::id<2> a, sycl::id<2> b) {
   auto abs = sycl::abs(a.get(0) + a.get(1));
 }
 
-// CHECK-LLVM: attributes #1 = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp" }
+// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp" }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -1,5 +1,6 @@
 // RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
 // RUN: clang++ -fsycl -fsycl-device-only -emit-mlir %s -o - -Xcgeist -no-mangled-function-name | FileCheck %s --check-prefix=CHECK-MLIR-NO-MANGLED-FUNCTION-NAME
+// COM: These two should obtain the same results.
 // RUN: clang++ -fsycl -fsycl-device-only -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 // RUN: clang++ -fsycl -fsycl-device-only -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - -Xcgeist -no-mangled-function-name | FileCheck %s --check-prefix=CHECK-LLVM
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -26,7 +26,7 @@
 // CHECK-MLIR-NOT: gpu.func kernel
 
 // CHECK-LLVM: define weak_odr spir_kernel void @_ZTS8kernel_1(i32 addrspace(1)* {{.*}}, [[RANGE_TY:%"class.sycl::_V1::range.1"]]* noundef byval([[RANGE_TY]]) align 8 {{.*}}, [[RANGE_TY]]* noundef byval([[RANGE_TY]]) align 8 {{.*}}, 
-// CHECK-LLVM-SAME:  [[ID_TY:%"class.sycl::_V1::id.1"]]* noundef byval([[ID_TY]]) align 8 {{.*}}) #1
+// CHECK-LLVM-SAME:  [[ID_TY:%"class.sycl::_V1::id.1"]]* noundef byval([[ID_TY]]) align 8 {{.*}}) #[[FUNCATTRS:[0-9]+]]
 class kernel_1 {
  sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write> A;
 
@@ -60,7 +60,7 @@ void host_1() {
 // CHECK-MLIR-SAME:     kernel attributes {[[CCONV]], [[LINKAGE]], {{.*}}}
 // CHECK-MLIR-NOT: gpu.func kernel
 
-// CHECK-LLVM: define weak_odr spir_kernel void @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2({{.*}}) #1
+// CHECK-LLVM: define weak_odr spir_kernel void @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2({{.*}}) #[[FUNCATTRS]]
 
 void host_2() {
   auto q = sycl::queue{};
@@ -83,4 +83,4 @@ SYCL_EXTERNAL void function_1(sycl::item<2, true> item) {
 }
 
 // Keep at the end of the file.
-// CHECK-LLVM: attributes #1 = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp" }
+// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp" }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
@@ -17,11 +17,12 @@
 // CHECK-MLIR-SAME: attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<linkonce_odr>, {{.*}}
 
 // COM: StoreWrapper constructor:
-// CHECK-LLVM-DAG:      define linkonce_odr spir_func void @_ZN12StoreWrapperIiLi1ELN4sycl3_V16access4modeE1026EEclEv({{.*}}) #2
-// CHECK-LLVM-DAG:      define weak_odr spir_kernel void @_ZTS8kernel_1({{.*}}) #1
-// CHECK-LLVM-DAG:      define weak_odr spir_kernel void @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2({{.*}}) #1
-// CHECK-LLVM: attributes #1 = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp" }
-// CHECK-LLVM-NEXT: attributes #2 = { alwaysinline convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp" }
+// CHECK-LLVM-DAG:      define linkonce_odr spir_func void @_ZN12StoreWrapperIiLi1ELN4sycl3_V16access4modeE1026EEclEv({{.*}}) #[[FUNCATTRS2:[0-9]+]]
+// CHECK-LLVM-DAG:      define weak_odr spir_kernel void @_ZTS8kernel_1({{.*}}) #[[FUNCATTRS1:[0-9]+]]
+// CHECK-LLVM-DAG:      define weak_odr spir_kernel void @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2({{.*}}) #[[FUNCATTRS1]]
+
+// CHECK-LLVM-DAG: attributes #[[FUNCATTRS1]] = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp" }
+// CHECK-LLVM-DAG: attributes #[[FUNCATTRS2]] = { alwaysinline convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp" }
 
 template <typename DataT,
           int Dimensions = 1,

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -15,17 +15,18 @@
 // CHECK-MLIR:           sycl.constructor(%{{.*}})
 // CHECK-MLIR-NEXT:      return
 
-// CHECK-LLMV-LABEL: define weak_odr spir_kernel void @_ZTSZZ16host_single_taskvENKUlRN4sycl3_V17handlerEE_clES2_E18kernel_single_task
-// CHECK-SAME: #1
-
 // CHECK-LLVM-LABEL: define internal spir_func void @_ZZZ16host_single_taskvENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEv
-// CHECK-LLVM-SAME: #2
+// CHECK-LLVM-SAME: #[[FUNCATTRS2:[0-9]+]]
 // CHECK: call void @cons_5()
 
-// CHECK-LLVM-LABEL: define spir_func void @cons_5() #1 {
+// CHECK-LLVM-LABEL: define spir_func void @cons_5()
+// CHECK-LLVM-SAME:  #[[FUNCATTRS1:[0-9]+]] {
 // CHECK-LLVM-NEXT:  [[ACCESSOR:%.*]] = alloca %"class.sycl::_V1::accessor.1", align 8
 // CHECK-LLVM-NEXT:  [[ACAST:%.*]] = addrspacecast %"class.sycl::_V1::accessor.1"* [[ACCESSOR]] to %"class.sycl::_V1::accessor.1" addrspace(4)*
 // CHECK-LLVM-NEXT:  call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]])
+
+// CHECK-LLVM-LABEL: define weak_odr spir_kernel void @_ZTSZZ16host_single_taskvENKUlRN4sycl3_V17handlerEE_clES2_E18kernel_single_task
+// CHECK-LLVM-SAME: #[[FUNCATTRS1]]
 
 extern "C" SYCL_EXTERNAL void cons_5() {
   sycl::accessor<sycl::cl_int, 1, sycl::access::mode::write> accessor;
@@ -45,5 +46,5 @@ void host_single_task() {
 }
 
 // Keep at the end of the file.
-// CHECK-LLVM: attributes #1 = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp" }
-// CHECK-LLVM-NEXT: attributes #2 = { alwaysinline convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp" }
+// CHECK-LLVM: attributes #[[FUNCATTRS1]] = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp" }
+// CHECK-LLVM-NEXT: attributes #[[FUNCATTRS2]] = { alwaysinline convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp" }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
@@ -16,13 +16,13 @@
 // CHECK-MLIR-NEXT: [[RESULT:%.*]] = arith.addf [[V1]], [[V2]] : f32
 // CHECK-MLIR:      affine.store [[RESULT]], {{.*}}[0] : memref<?xf32, 4>
 
-// CHECK-LLVM:       define internal spir_func void [[FUNC:@.*vec_add_device_simple.*_]]({{.*}}) #2
+// CHECK-LLVM:       define internal spir_func void [[FUNC:@.*vec_add_device_simple.*_]]({{.*}}) #[[FUNCATTRS2:[0-9]+]]
 // CHECK-LLVM-DAG:   [[V1:%.*]] = load float, float addrspace(4)* {{.*}}, align 4
 // CHECK-LLVM-DAG:   [[V2:%.*]] = load float, float addrspace(4)* {{.*}}, align 4
 // CHECK-LLVM:       [[RESULT:%.*]] = fadd float [[V1]], [[V2]]
 // CHECK-LLVM:       store float [[RESULT]], float addrspace(4)* {{.*}}, align 4
 
-// CHECK-LLVM:       define weak_odr spir_kernel void @{{.*}}vec_add_simple({{.*}}) #1
+// CHECK-LLVM:       define weak_odr spir_kernel void @{{.*}}vec_add_simple({{.*}}) #[[FUNCATTRS1:[0-9]+]]
 // CHECK-LLVM:       call void [[FUNC]]
 
 void vec_add_device_simple(std::array<float, N> &VA, std::array<float, N> &VB,
@@ -95,5 +95,5 @@ int main() {
 }
 
 // Keep at the end of the file.
-// CHECK-LLVM: attributes #1 = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp" }
-// CHECK-LLVM-NEXT: attributes #2 = { alwaysinline convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp" }
+// CHECK-LLVM-DAG: attributes #[[FUNCATTRS1]] = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp" }
+// CHECK-LLVM-DAG: attributes #[[FUNCATTRS2]] = { alwaysinline convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp" }


### PR DESCRIPTION
Make MangledFunctionName optional by adding definition registering capabilities to the SYCL dialect.

Add "-no-mangled-function-name" option in cgeist to omit the mangled name optional field.
