### PR TITLE
[SYCL] Fix narrowing type conversion in marray

### DIFF
--- a/sycl/include/sycl/marray.hpp
+++ b/sycl/include/sycl/marray.hpp
@@ -64,7 +64,7 @@ public:
   template <
       typename... ArgTN, typename = EnableIfSuitableTypes<ArgTN...>,
       typename = typename std::enable_if<sizeof...(ArgTN) == NumElements>::type>
-  constexpr marray(const ArgTN &...Args) : MData{Args...} {}
+  constexpr marray(const ArgTN &...Args) : MData{static_cast<Type>(Args)...} {}
 
   constexpr marray(const marray<Type, NumElements> &Rhs) = default;
 

--- a/sycl/test/basic_tests/known_identity.cpp
+++ b/sycl/test/basic_tests/known_identity.cpp
@@ -246,7 +246,7 @@ typename std::enable_if<!std::is_same_v<T, half> && !std::is_same_v<T, float> &&
 checkMarrayKnownIdentity() {
   constexpr marray<T, Num> zeros(T(0));
   constexpr marray<T, Num> ones(T(1));
-  constexpr marray<T, Num> bit_ones(T(~0));
+  constexpr marray<T, Num> bit_ones(~T(0));
 
   static_assert(has_known_identity<plus<>, marray<T, Num>>::value);
   static_assert(


### PR DESCRIPTION
On Windows with -Wc++-narrowing (enabled by default) known-identity test fails because initializer list has limitations and doesn't allow narrowing conversions. It may occur when e.g. we use operator~ which upgrades type. In this case check EnableIfSuitableTypes succeeds but initializer list limitations may cause compilation errors. Inserting static_cast is valid since we already have a check for allowed types.

Signed-off-by: Tikhomirova, Kseniya [kseniya.tikhomirova@intel.com](mailto:kseniya.tikhomirova@intel.com)