### PR TITLE
[WIP] add opencl_icd support to test suite runs. 

### DIFF
--- a/devops/actions/llvm_test_suite/action.yml
+++ b/devops/actions/llvm_test_suite/action.yml
@@ -72,7 +72,8 @@ runs:
       echo "::group::CMake configuration"
       mkdir build
       export PATH=$PWD/toolchain/bin/:$PATH
-      cmake -GNinja -B./build -S./llvm_test_suite -DTEST_SUITE_SUBDIRS=SYCL -DCHECK_SYCL_ALL="${{ inputs.check_sycl_all }}" -DCMAKE_CXX_COMPILER="$PWD/toolchain/bin/clang++" -DTEST_SUITE_LIT="$PWD/lit/lit.py" ${{ inputs.cmake_args }}
+      ls $PWD/toolchain/
+      cmake -GNinja -B./build -S./llvm_test_suite -DTEST_SUITE_SUBDIRS=SYCL -DCHECK_SYCL_ALL="${{ inputs.check_sycl_all }}" -DCMAKE_CXX_COMPILER="$PWD/toolchain/bin/clang++" -DOpenCL_LIBRARY="$PWD/toolchain/lib" -DTEST_SUITE_LIT="$PWD/lit/lit.py" ${{ inputs.cmake_args }}
       echo "::endgroup::"
   - name: Run testing
     shell: bash


### PR DESCRIPTION
several of the tests in llvm-test-suite have a dependency on `opencl_icd` which will be defined when the suite is configured with the opencl library path. Presently, the testing we do via GitHub actions does not do this, and so these tests are always skipped as unsupported.  

initial commit to get interop tests running on the GHA runs of the llvm-test-suite.