### PR TITLE
[SYCL][CUDA][HIP] Fix incorrectly constructed guards

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -3922,7 +3922,7 @@ pi_result cuda_piEnqueueEventsWaitWithBarrier(pi_queue command_queue,
     CUstream cuStream = command_queue->get_next_compute_stream(
         num_events_in_wait_list, event_wait_list, guard, &stream_token);
     {
-      std::lock_guard(command_queue->barrier_mutex_);
+      std::lock_guard<std::mutex> guard(command_queue->barrier_mutex_);
       if (command_queue->barrier_event_ == nullptr) {
         PI_CHECK_ERROR(cuEventCreate(&command_queue->barrier_event_,
                                      CU_EVENT_DISABLE_TIMING));

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -3747,7 +3747,7 @@ pi_result hip_piEnqueueEventsWaitWithBarrier(pi_queue command_queue,
     hipStream_t hipStream = command_queue->get_next_compute_stream(
         num_events_in_wait_list, event_wait_list, guard, &stream_token);
     {
-      std::lock_guard(command_queue->barrier_mutex_);
+      std::lock_guard<std::mutex> guard(command_queue->barrier_mutex_);
       if (command_queue->barrier_event_ == nullptr) {
         PI_CHECK_ERROR(hipEventCreate(&command_queue->barrier_event_));
       }


### PR DESCRIPTION
This showed up as a warning in the Windows build, I'm unsure if it's related but it may fix the sporadic barrier issue we've been seeing.