### PR TITLE
[SYCL][DOC] Fix sample CMakeLists.txt to specify language

### DIFF
--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -735,7 +735,7 @@ cmake_minimum_required(VERSION 3.14)
 set(CMAKE_CXX_COMPILER "clang++")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl")
 
-project(simple-sycl-app)
+project(simple-sycl-app LANGUAGES CXX)
 
 add_executable(simple-sycl-app simple-sycl-app.cpp)
 ```


### PR DESCRIPTION
This is necessary when using it on Windows and doesn't hurt on Linux.

See: https://github.com/intel/llvm/issues/6026