### PR TITLE
[SYCL-MLIR] Add sycl-toolchain dependency to check-cgeist

### DIFF
--- a/polygeist/tools/cgeist/Test/CMakeLists.txt
+++ b/polygeist/tools/cgeist/Test/CMakeLists.txt
@@ -16,6 +16,7 @@ list(APPEND MLIR_CLANG_TEST_DEPS
   split-file
   clang
   opt
+  sycl-toolchain
   )
 
 add_lit_testsuite(check-cgeist "Running the clang-to-mlir regression tests"


### PR DESCRIPTION
Some tests need this target to be built.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>