### PR TITLE
[SYCL-MLIR] Rename SYCLConstructorOp and SYCLCallOp attributes

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -123,7 +123,7 @@ def SYCLConstructorOp : SYCL_Op<"constructor", []> {
 
   let arguments = (ins
     FlatSymbolRefAttr:$Type,
-    FlatSymbolRefAttr:$MangledName,
+    FlatSymbolRefAttr:$MangledFunctionName,
     Variadic<ConstructorArgs>:$Args
   );
   let results = (outs);
@@ -169,9 +169,9 @@ def SYCLCallOp : SYCL_Op<"call", []> {
   }];
 
   let arguments = (ins
-    OptionalAttr<FlatSymbolRefAttr>:$Type,
-    FlatSymbolRefAttr:$Function,
-    FlatSymbolRefAttr:$MangledName,
+    OptionalAttr<FlatSymbolRefAttr>:$TypeName,
+    FlatSymbolRefAttr:$FunctionName,
+    FlatSymbolRefAttr:$MangledFunctionName,
     Variadic<AnyType>:$Args
   );
   let results = (outs Optional<AnyType>:$result);
@@ -180,16 +180,16 @@ def SYCLCallOp : SYCL_Op<"call", []> {
   let builders = [
     OpBuilder<(ins
     "::llvm::Optional<::mlir::Type>":$result,
-    "::llvm::Optional<::llvm::StringRef>":$Type,
-    "::llvm::StringRef":$Function,
-    "::llvm::StringRef":$MangledName,
+    "::llvm::Optional<::llvm::StringRef>":$TypeName,
+    "::llvm::StringRef":$FunctionName,
+    "::llvm::StringRef":$MangledFunctionName,
     "::mlir::ValueRange":$Args), [{
       odsState.addOperands(Args);
-      if (Type.has_value()) {
-        odsState.addAttribute(TypeAttrName(odsState.name), ::mlir::SymbolRefAttr::get(odsBuilder.getContext(), Type.value()));
+      if (TypeName.has_value()) {
+        odsState.addAttribute(getTypeNameAttrName(odsState.name), ::mlir::SymbolRefAttr::get(odsBuilder.getContext(), TypeName.value()));
       }
-      odsState.addAttribute(getFunctionAttrName(odsState.name), ::mlir::SymbolRefAttr::get(odsBuilder.getContext(), Function));
-      odsState.addAttribute(getMangledNameAttrName(odsState.name), ::mlir::SymbolRefAttr::get(odsBuilder.getContext(), MangledName));
+      odsState.addAttribute(getFunctionNameAttrName(odsState.name), ::mlir::SymbolRefAttr::get(odsBuilder.getContext(), FunctionName));
+      odsState.addAttribute(getMangledFunctionNameAttrName(odsState.name), ::mlir::SymbolRefAttr::get(odsBuilder.getContext(), MangledFunctionName));
       if (result.has_value()) {
         odsState.addTypes(result.value());
       }

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -236,7 +236,7 @@ private:
 
     bool producesResult = op.getNumResults() == 1;
     func::CallOp funcCall = builder.genCall(
-        op.getMangledName(),
+        op.getMangledFunctionName(),
         producesResult ? TypeRange(op.getResult().getType()) : TypeRange(),
         op.getOperands(), module);
 
@@ -344,8 +344,8 @@ private:
 
     ModuleOp module = op.getOperation()->getParentOfType<ModuleOp>();
     FuncBuilder builder(rewriter, op.getLoc());
-    func::CallOp funcCall = builder.genCall(op.getMangledName(), TypeRange(),
-                                            op.getOperands(), module);
+    func::CallOp funcCall = builder.genCall(
+        op.getMangledFunctionName(), TypeRange(), op.getOperands(), module);
     rewriter.eraseOp(op);
     (void)funcCall;
 

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-call-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-call-to-llvm.mlir
@@ -12,7 +12,7 @@
 func.func private @foo() -> (i32)
 
 func.func @test() -> (i32) {
-  %0 = sycl.call() {Function = @foo, MangledName = @foo, Type = @accessor} : () -> i32
+  %0 = sycl.call() {FunctionName = @foo, MangledFunctionName = @foo, TypeName = @accessor} : () -> i32
   return %0 : i32
 }
 
@@ -29,7 +29,7 @@ func.func private @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6target
 
 func.func @accessorInit1(%arg0: memref<?x!sycl_accessor_1_i32_read_write_global_buffer>, %arg1: memref<?xi32>, %arg2: !sycl.range<1>, %arg3: !sycl.range<1>, %arg4: !sycl.id<1>) {
   // CHECK: llvm.call @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE({{.*}}) : ([[ARG_TYPES]]) -> ()
-  sycl.call(%arg0, %arg1, %arg2, %arg3, %arg4) {Function = @__init, MangledName = @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE, Type = @accessor} : (memref<?x!sycl_accessor_1_i32_read_write_global_buffer>, memref<?xi32>, !sycl.range<1>, !sycl.range<1>, !sycl.id<1>) -> ()
+  sycl.call(%arg0, %arg1, %arg2, %arg3, %arg4) {FunctionName = @__init, MangledFunctionName = @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_read_write_global_buffer>, memref<?xi32>, !sycl.range<1>, !sycl.range<1>, !sycl.id<1>) -> ()
   return
 }
 

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-constructor-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-constructor-to-llvm.mlir
@@ -11,7 +11,7 @@ func.func private @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6target
 
 func.func @accessorInt1ReadWriteGlobalBufferFalseCtor(%arg0: memref<?x!sycl_accessor_1_i32_read_write_global_buffer>) {
   // CHECK: llvm.call @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC2Ev({{.*}}) : ([[THIS_PTR_TYPE]]) -> ()
-  sycl.constructor(%arg0) {MangledName = @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC2Ev, Type = @accessor} : (memref<?x!sycl_accessor_1_i32_read_write_global_buffer>) -> () 
+  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC2Ev, Type = @accessor} : (memref<?x!sycl_accessor_1_i32_read_write_global_buffer>) -> () 
   return
 }
 
@@ -26,7 +26,7 @@ func.func private @_ZN2cl4sycl2idILi1EEC2Ev(memref<?x!sycl.id<1>>)
 
 func.func @id1Ctor(%arg0: memref<?x!sycl.id<1>>) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi1EEC2Ev({{.*}}) : ([[THIS_PTR_TYPE]]) -> ()
-  sycl.constructor(%arg0) {MangledName = @_ZN2cl4sycl2idILi1EEC2Ev, Type = @id} : (memref<?x!sycl.id<1>>) -> ()
+  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl2idILi1EEC2Ev, Type = @id} : (memref<?x!sycl.id<1>>) -> ()
   return
 }
 
@@ -37,7 +37,7 @@ func.func private @_ZN2cl4sycl2idILi2EEC2Ev(memref<?x!sycl.id<2>>)
 
 func.func @id2Ctor(%arg0: memref<?x!sycl.id<2>>) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi2EEC2Ev({{.*}}) : ([[THIS_PTR_TYPE]]) -> ()
-  sycl.constructor(%arg0) {MangledName = @_ZN2cl4sycl2idILi2EEC2Ev, Type = @id} : (memref<?x!sycl.id<2>>) -> ()
+  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl2idILi2EEC2Ev, Type = @id} : (memref<?x!sycl.id<2>>) -> ()
   return
 }
 
@@ -48,7 +48,7 @@ func.func private @_ZN2cl4sycl2idILi3EEC2Ev(memref<?x!sycl.id<3>>)
 
 func.func @id3Ctor(%arg0: memref<?x!sycl.id<3>>) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi3EEC2Ev({{.*}}) : ([[THIS_PTR_TYPE]]) -> ()
-  sycl.constructor(%arg0) {MangledName = @_ZN2cl4sycl2idILi3EEC2Ev, Type = @id} : (memref<?x!sycl.id<3>>) -> ()
+  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl2idILi3EEC2Ev, Type = @id} : (memref<?x!sycl.id<3>>) -> ()
   return
 }
 
@@ -63,7 +63,7 @@ func.func private @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE
 
 func.func @id1CtorSizeT(%arg0: memref<?x!sycl.id<1>>, %arg1: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE({{.*}}, %arg5) : ([[THIS_PTR_TYPE]], i64) -> ()
-  sycl.constructor(%arg0, %arg1) {MangledName = @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE, Type = @id} : (memref<?x!sycl.id<1>>, i64) -> ()
+  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE, Type = @id} : (memref<?x!sycl.id<1>>, i64) -> ()
   return
 }
 
@@ -74,7 +74,7 @@ func.func private @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE
 
 func.func @id2CtorSizeT(%arg0: memref<?x!sycl.id<2>>, %arg1: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE({{.*}}, %arg5) : ([[THIS_PTR_TYPE]], i64) -> ()
-  sycl.constructor(%arg0, %arg1) {MangledName = @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE, Type = @id} : (memref<?x!sycl.id<2>>, i64) -> ()
+  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE, Type = @id} : (memref<?x!sycl.id<2>>, i64) -> ()
   return
 }
 
@@ -85,7 +85,7 @@ func.func private @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE
 
 func.func @id3CtorSizeT(%arg0: memref<?x!sycl.id<3>>, %arg1: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE({{.*}}, %arg5) : ([[THIS_PTR_TYPE]], i64) -> ()
-  sycl.constructor(%arg0, %arg1) {MangledName = @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE, Type = @id} : (memref<?x!sycl.id<3>>, i64) -> ()
+  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE, Type = @id} : (memref<?x!sycl.id<3>>, i64) -> ()
   return
 }
 
@@ -100,7 +100,7 @@ func.func private @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE
 
 func.func @id1CtorRange(%arg0: memref<?x!sycl.id<1>>, %arg1: i64, %arg2: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm({{.*}}, %arg5, %arg6) : ([[THIS_PTR_TYPE]], i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2) {MangledName = @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm, Type = @id} : (memref<?x!sycl.id<1>>, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2) {MangledFunctionName = @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm, Type = @id} : (memref<?x!sycl.id<1>>, i64, i64) -> ()
   return
 }
 
@@ -111,7 +111,7 @@ func.func private @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE
 
 func.func @id2CtorRange(%arg0: memref<?x!sycl.id<2>>, %arg1: i64, %arg2: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm({{.*}}, %arg5, %arg6) : ([[THIS_PTR_TYPE]], i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2) {MangledName = @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, Type = @id} : (memref<?x!sycl.id<2>>, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2) {MangledFunctionName = @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, Type = @id} : (memref<?x!sycl.id<2>>, i64, i64) -> ()
   return
 }
 
@@ -122,7 +122,7 @@ func.func private @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE
 
 func.func @id3CtorRange(%arg0: memref<?x!sycl.id<3>>, %arg1: i64, %arg2: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm({{.*}}, %arg5, %arg6) : ([[THIS_PTR_TYPE]], i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2) {MangledName = @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm, Type = @id} : (memref<?x!sycl.id<3>>, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2) {MangledFunctionName = @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm, Type = @id} : (memref<?x!sycl.id<3>>, i64, i64) -> ()
   return
 }
 
@@ -137,7 +137,7 @@ func.func private @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE
 
 func.func @id1CtorItem(%arg0: memref<?x!sycl.id<1>>, %arg1: i64, %arg2: i64, %arg3: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm({{.*}}, %arg5, %arg6, %arg7) : ([[THIS_PTR_TYPE]], i64, i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledName = @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm, Type = @id} : (memref<?x!sycl.id<1>>, i64, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledFunctionName = @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm, Type = @id} : (memref<?x!sycl.id<1>>, i64, i64, i64) -> ()
   return
 }
 
@@ -148,7 +148,7 @@ func.func private @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE
 
 func.func @id2CtorItem(%arg0: memref<?x!sycl.id<2>>, %arg1: i64, %arg2: i64, %arg3: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm({{.*}}, %arg5, %arg6, %arg7) : ([[THIS_PTR_TYPE]], i64, i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledName = @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm, Type = @id} : (memref<?x!sycl.id<2>>, i64, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledFunctionName = @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm, Type = @id} : (memref<?x!sycl.id<2>>, i64, i64, i64) -> ()
   return
 }
 
@@ -159,7 +159,7 @@ func.func private @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE
 
 func.func @id3CtorItem(%arg0: memref<?x!sycl.id<3>>, %arg1: i64, %arg2: i64, %arg3: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm({{.*}}, %arg5, %arg6, %arg7) : ([[THIS_PTR_TYPE]], i64, i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledName = @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm, Type = @id} : (memref<?x!sycl.id<3>>, i64, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledFunctionName = @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm, Type = @id} : (memref<?x!sycl.id<3>>, i64, i64, i64) -> ()
   return
 }
 
@@ -174,7 +174,7 @@ func.func private @_ZN2cl4sycl2idILi1EEC1ERKS2_(memref<?x!sycl.id<1>>, memref<?x
 
 func.func @id1CopyCtor(%arg0: memref<?x!sycl.id<1>>, %arg1: memref<?x!sycl.id<1>>) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi1EEC1ERKS2_({{.*}}, {{.*}}) : ([[THIS_PTR_TYPE]], [[THIS_PTR_TYPE]]) -> ()  
- "sycl.constructor"(%arg0, %arg1) {MangledName = @_ZN2cl4sycl2idILi1EEC1ERKS2_, Type = @id} : (memref<?x!sycl.id<1>>, memref<?x!sycl.id<1>>) -> ()
+ "sycl.constructor"(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl2idILi1EEC1ERKS2_, Type = @id} : (memref<?x!sycl.id<1>>, memref<?x!sycl.id<1>>) -> ()
   return
 }
 
@@ -185,7 +185,7 @@ func.func private @_ZN2cl4sycl2idILi2EEC1ERKS2_(memref<?x!sycl.id<2>>, memref<?x
 
 func.func @id2CopyCtor(%arg0: memref<?x!sycl.id<2>>, %arg1: memref<?x!sycl.id<2>>) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi2EEC1ERKS2_({{.*}}, {{.*}}) : ([[THIS_PTR_TYPE]], [[THIS_PTR_TYPE]]) -> ()
- "sycl.constructor"(%arg0, %arg1) {MangledName = @_ZN2cl4sycl2idILi2EEC1ERKS2_, Type = @id} : (memref<?x!sycl.id<2>>, memref<?x!sycl.id<2>>) -> ()  
+ "sycl.constructor"(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl2idILi2EEC1ERKS2_, Type = @id} : (memref<?x!sycl.id<2>>, memref<?x!sycl.id<2>>) -> ()  
   return
 }
 
@@ -196,7 +196,7 @@ func.func private @_ZN2cl4sycl2idILi3EEC1ERKS2_(memref<?x!sycl.id<3>>, memref<?x
 
 func.func @id3CopyCtor(%arg0: memref<?x!sycl.id<3>>, %arg1: memref<?x!sycl.id<3>>) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi3EEC1ERKS2_({{.*}}, {{.*}}) : ([[THIS_PTR_TYPE]], [[THIS_PTR_TYPE]]) -> ()
- "sycl.constructor"(%arg0, %arg1) {MangledName = @_ZN2cl4sycl2idILi3EEC1ERKS2_, Type = @id} : (memref<?x!sycl.id<3>>, memref<?x!sycl.id<3>>) -> ()
+ "sycl.constructor"(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl2idILi3EEC1ERKS2_, Type = @id} : (memref<?x!sycl.id<3>>, memref<?x!sycl.id<3>>) -> ()
   return
 }
 
@@ -211,7 +211,7 @@ func.func private @_ZN2cl4sycl5rangeILi1EEC2Ev(memref<?x!sycl.range<1>>)
 
 func.func @range1Ctor(%arg0: memref<?x!sycl.range<1>>) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi1EEC2Ev({{.*}}) : ([[THIS_PTR_TYPE]]) -> ()
-  sycl.constructor(%arg0) {MangledName = @_ZN2cl4sycl5rangeILi1EEC2Ev, Type = @range} : (memref<?x!sycl.range<1>>) -> ()
+  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl5rangeILi1EEC2Ev, Type = @range} : (memref<?x!sycl.range<1>>) -> ()
   return
 }
 
@@ -222,7 +222,7 @@ func.func private @_ZN2cl4sycl5rangeILi2EEC2Ev(memref<?x!sycl.range<2>>)
 
 func.func @range2Ctor(%arg0: memref<?x!sycl.range<2>>) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi2EEC2Ev({{.*}}) : ([[THIS_PTR_TYPE]]) -> ()
-  sycl.constructor(%arg0) {MangledName = @_ZN2cl4sycl5rangeILi2EEC2Ev, Type = @range} : (memref<?x!sycl.range<2>>) -> ()
+  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl5rangeILi2EEC2Ev, Type = @range} : (memref<?x!sycl.range<2>>) -> ()
   return
 }
 
@@ -233,7 +233,7 @@ func.func private @_ZN2cl4sycl5rangeILi3EEC2Ev(memref<?x!sycl.range<3>>)
 
 func.func @range3Ctor(%arg0: memref<?x!sycl.range<3>>) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi3EEC2Ev({{.*}}) : ([[THIS_PTR_TYPE]]) -> ()
-  sycl.constructor(%arg0) {MangledName = @_ZN2cl4sycl5rangeILi3EEC2Ev, Type = @range} : (memref<?x!sycl.range<3>>) -> ()
+  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl5rangeILi3EEC2Ev, Type = @range} : (memref<?x!sycl.range<3>>) -> ()
   return
 }
 
@@ -248,7 +248,7 @@ func.func private @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4ty
 
 func.func @range1CtorSizeT(%arg0: memref<?x!sycl.range<1>>, %arg1: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE({{.*}}, %arg5) : ([[THIS_PTR_TYPE]], i64) -> ()
-  sycl.constructor(%arg0, %arg1) {MangledName = @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE, Type = @range} : (memref<?x!sycl.range<1>>, i64) -> ()
+  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE, Type = @range} : (memref<?x!sycl.range<1>>, i64) -> ()
   return
 }
 
@@ -259,7 +259,7 @@ func.func private @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4ty
 
 func.func @range2CtorSizeT(%arg0: memref<?x!sycl.range<2>>, %arg1: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE({{.*}}, %arg5) : ([[THIS_PTR_TYPE]], i64) -> ()
-  sycl.constructor(%arg0, %arg1) {MangledName = @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE, Type = @range} : (memref<?x!sycl.range<2>>, i64) -> ()
+  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE, Type = @range} : (memref<?x!sycl.range<2>>, i64) -> ()
   return
 }
 
@@ -270,7 +270,7 @@ func.func private @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4ty
 
 func.func @range3CtorSizeT(%arg0: memref<?x!sycl.range<3>>, %arg1: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE({{.*}}, %arg5) : ([[THIS_PTR_TYPE]], i64) -> ()
-  sycl.constructor(%arg0, %arg1) {MangledName = @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE, Type = @range} : (memref<?x!sycl.range<3>>, i64) -> ()
+  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE, Type = @range} : (memref<?x!sycl.range<3>>, i64) -> ()
   return
 }
 
@@ -285,7 +285,7 @@ func.func private @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4ty
 
 func.func @range1Ctor2SizeT(%arg0: memref<?x!sycl.range<1>>, %arg1: i64, %arg2: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm({{.*}}, %arg5, %arg6) : ([[THIS_PTR_TYPE]], i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2) {MangledName = @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm, Type = @range} : (memref<?x!sycl.range<1>>, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2) {MangledFunctionName = @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm, Type = @range} : (memref<?x!sycl.range<1>>, i64, i64) -> ()
   return
 }
 
@@ -296,7 +296,7 @@ func.func private @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4ty
 
 func.func @range2Ctor2SizeT(%arg0: memref<?x!sycl.range<2>>, %arg1: i64, %arg2: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm({{.*}}, %arg5, %arg6) : ([[THIS_PTR_TYPE]], i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2) {MangledName = @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, Type = @range} : (memref<?x!sycl.range<2>>, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2) {MangledFunctionName = @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, Type = @range} : (memref<?x!sycl.range<2>>, i64, i64) -> ()
   return
 }
 
@@ -307,7 +307,7 @@ func.func private @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4ty
 
 func.func @range3Ctor2SizeT(%arg0: memref<?x!sycl.range<3>>, %arg1: i64, %arg2: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm({{.*}}, %arg5, %arg6) : ([[THIS_PTR_TYPE]], i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2) {MangledName = @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm, Type = @range} : (memref<?x!sycl.range<3>>, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2) {MangledFunctionName = @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm, Type = @range} : (memref<?x!sycl.range<3>>, i64, i64) -> ()
   return
 }
 
@@ -322,7 +322,7 @@ func.func private @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4ty
 
 func.func @range1Ctor3SizeT(%arg0: memref<?x!sycl.range<1>>, %arg1: i64, %arg2: i64, %arg3: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm({{.*}}, %arg5, %arg6, %arg7) : ([[THIS_PTR_TYPE]], i64, i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledName = @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm, Type = @range} : (memref<?x!sycl.range<1>>, i64, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledFunctionName = @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm, Type = @range} : (memref<?x!sycl.range<1>>, i64, i64, i64) -> ()
   return
 }
 
@@ -333,7 +333,7 @@ func.func private @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4ty
 
 func.func @range2Ctor3SizeT(%arg0: memref<?x!sycl.range<2>>, %arg1: i64, %arg2: i64, %arg3: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm({{.*}}, %arg5, %arg6, %arg7) : ([[THIS_PTR_TYPE]], i64, i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledName = @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm, Type = @range} : (memref<?x!sycl.range<2>>, i64, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledFunctionName = @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm, Type = @range} : (memref<?x!sycl.range<2>>, i64, i64, i64) -> ()
   return
 }
 
@@ -344,7 +344,7 @@ func.func private @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4ty
 
 func.func @range3Ctor3SizeT(%arg0: memref<?x!sycl.range<3>>, %arg1: i64, %arg2: i64, %arg3: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm({{.*}}, %arg5, %arg6, %arg7) : ([[THIS_PTR_TYPE]], i64, i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledName = @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm, Type = @range} : (memref<?x!sycl.range<3>>, i64, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledFunctionName = @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm, Type = @range} : (memref<?x!sycl.range<3>>, i64, i64, i64) -> ()
   return
 }
 
@@ -359,7 +359,7 @@ func.func private @_ZN2cl4sycl5rangeILi1EEC1ERKS2_(memref<?x!sycl.range<1>>, mem
 
 func.func @range1CopyCtor(%arg0: memref<?x!sycl.range<1>>, %arg1: memref<?x!sycl.range<1>>) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi1EEC1ERKS2_({{.*}}, {{.*}}) : ([[THIS_PTR_TYPE]], [[THIS_PTR_TYPE]]) -> ()
- "sycl.constructor"(%arg0, %arg1) {MangledName = @_ZN2cl4sycl5rangeILi1EEC1ERKS2_, Type = @range} : (memref<?x!sycl.range<1>>, memref<?x!sycl.range<1>>) -> ()
+ "sycl.constructor"(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl5rangeILi1EEC1ERKS2_, Type = @range} : (memref<?x!sycl.range<1>>, memref<?x!sycl.range<1>>) -> ()
   return
 }
 
@@ -370,7 +370,7 @@ func.func private @_ZN2cl4sycl5rangeILi2EEC1ERKS2_(memref<?x!sycl.range<2>>, mem
 
 func.func @range2CopyCtor(%arg0: memref<?x!sycl.range<2>>, %arg1: memref<?x!sycl.range<2>>) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi2EEC1ERKS2_({{.*}}, {{.*}}) : ([[THIS_PTR_TYPE]], [[THIS_PTR_TYPE]]) -> ()
- "sycl.constructor"(%arg0, %arg1) {MangledName = @_ZN2cl4sycl5rangeILi2EEC1ERKS2_, Type = @range} : (memref<?x!sycl.range<2>>, memref<?x!sycl.range<2>>) -> ()
+ "sycl.constructor"(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl5rangeILi2EEC1ERKS2_, Type = @range} : (memref<?x!sycl.range<2>>, memref<?x!sycl.range<2>>) -> ()
   return
 }
 
@@ -381,6 +381,6 @@ func.func private @_ZN2cl4sycl5rangeILi3EEC1ERKS2_(memref<?x!sycl.range<3>>, mem
 
 func.func @range3CopyCtor(%arg0: memref<?x!sycl.range<3>>, %arg1: memref<?x!sycl.range<3>>) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi3EEC1ERKS2_({{.*}}, {{.*}}) : ([[THIS_PTR_TYPE]], [[THIS_PTR_TYPE]]) -> ()
- "sycl.constructor"(%arg0, %arg1) {MangledName = @_ZN2cl4sycl5rangeILi3EEC1ERKS2_, Type = @range} : (memref<?x!sycl.range<3>>, memref<?x!sycl.range<3>>) -> ()
+ "sycl.constructor"(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl5rangeILi3EEC1ERKS2_, Type = @range} : (memref<?x!sycl.range<3>>, memref<?x!sycl.range<3>>) -> ()
   return
 }

--- a/mlir-sycl/test/Dialect/IR/SYCL/constructor.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/constructor.mlir
@@ -3,6 +3,6 @@
 // Ensure sycl.id and sycl.range types can be arguments of sycl.constructor.
 // CHECK-LABEL: func.func @AccessorImplDevice
 func.func @AccessorImplDevice(%arg0: memref<?x!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>>, %arg1: !sycl.id<1>, %arg2: !sycl.range<1>) {
-  sycl.constructor(%arg0, %arg1, %arg2, %arg2) {MangledName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_, Type = @AccessorImplDevice} : (memref<?x!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>>, !sycl.id<1>, !sycl.range<1>, !sycl.range<1>) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2, %arg2) {MangledFunctionName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_, Type = @AccessorImplDevice} : (memref<?x!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>>, !sycl.id<1>, !sycl.range<1>, !sycl.range<1>) -> ()
   return
 }

--- a/mlir-sycl/test/Transforms/sycl-method-to-sycl-call.mlir
+++ b/mlir-sycl/test/Transforms/sycl-method-to-sycl-call.mlir
@@ -8,7 +8,7 @@
 !sycl_range_2_ = !sycl.range<2>
 
 // CHECK-LABEL: func.func @accessor_subscript_operator(%arg0: memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, %arg1: memref<?x!sycl_id_2_>) -> memref<?xi32, 4> {
-// CHECK-NEXT: %0 = sycl.call(%arg0, %arg1) {Function = @"operator[]", MangledName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, Type = @accessor} : (memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
+// CHECK-NEXT: %0 = sycl.call(%arg0, %arg1) {FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
 
 func.func @accessor_subscript_operator(%arg0: memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, %arg1: memref<?x!sycl_id_2_>) -> memref<?xi32, 4> {
   %0 = sycl.accessor.subscript %arg0[%arg1] {BaseType = memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
@@ -17,7 +17,7 @@ func.func @accessor_subscript_operator(%arg0: memref<?x!sycl_accessor_2_i32_read
 
 // CHECK-LABEL: func.func @range_get(%arg0: memref<?x!sycl_range_2_, 4>, %arg1: i32) -> i64 {
 // CHECK-NEXT: %0 = sycl.cast(%arg0) : (memref<?x!sycl_range_2_, 4>) -> memref<?x!sycl_array_2_, 4>
-// CHECK-NEXT: %1 = sycl.call(%0, %arg1) {Function = @get, MangledName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, Type = @array} : (memref<?x!sycl_array_2_, 4>, i32) -> i64
+// CHECK-NEXT: %1 = sycl.call(%0, %arg1) {FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_array_2_, 4>, i32) -> i64
 
 func.func @range_get(%arg0: memref<?x!sycl_range_2_, 4>, %arg1: i32) -> i64 {
   %0 = "sycl.range.get"(%arg0, %arg1) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> i64
@@ -25,7 +25,7 @@ func.func @range_get(%arg0: memref<?x!sycl_range_2_, 4>, %arg1: i32) -> i64 {
 }
 
 // CHECK-LABEL: func.func @range_size(%arg0: memref<?x!sycl_range_2_, 4>) -> i64 {
-// CHECK-NEXT: %0 = sycl.call(%arg0) {Function = @size, MangledName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, Type = @range} : (memref<?x!sycl_range_2_, 4>) -> i64
+// CHECK-NEXT: %0 = sycl.call(%arg0) {FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl_range_2_, 4>) -> i64
 
 func.func @range_size(%arg0: memref<?x!sycl_range_2_, 4>) -> i64 {
   %0 = "sycl.range.size"(%arg0) {BaseType = memref<?x!sycl_range_2_, 4>, FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl_range_2_, 4>) -> i64
@@ -33,7 +33,7 @@ func.func @range_size(%arg0: memref<?x!sycl_range_2_, 4>) -> i64 {
 }
 
 // CHECK-LABEL: func.func @sycl_item_get_id(%arg0: memref<?x!sycl_item_1_1_, 4>) -> !sycl_id_1_ {
-// CHECK-NEXT: %0 = sycl.call(%arg0) {Function = @get_id, MangledName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, Type = @item} : (memref<?x!sycl_item_1_1_, 4>) -> !sycl_id_1_
+// CHECK-NEXT: %0 = sycl.call(%arg0) {FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> !sycl_id_1_
 
 func.func @sycl_item_get_id(%arg0: memref<?x!sycl_item_1_1_, 4>) -> !sycl_id_1_ {
   %0 = "sycl.item.get_id"(%arg0) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> !sycl_id_1_

--- a/polygeist/lib/polygeist/Passes/ConvertToLLVMABI.cpp
+++ b/polygeist/lib/polygeist/Passes/ConvertToLLVMABI.cpp
@@ -169,8 +169,9 @@ public:
     LLVM_DEBUG(llvm::dbgs() << "ConvertToLLVMABIPass: SYCLConstructorLowering: "
                             << op << "\n");
 
-    auto funcCallOp = rewriter.create<func::CallOp>(
-        op.getLoc(), op.getMangledName(), TypeRange(), op.getOperands());
+    auto funcCallOp =
+        rewriter.create<func::CallOp>(op.getLoc(), op.getMangledFunctionName(),
+                                      TypeRange(), op.getOperands());
     rewriter.replaceOp(op.getOperation(), funcCallOp.getResults());
     LLVM_DEBUG(llvm::dbgs() << "  Converted to: " << funcCallOp << "\n");
 

--- a/polygeist/test/polygeist-opt/sycl/convertToLLVMABI.mlir
+++ b/polygeist/test/polygeist-opt/sycl/convertToLLVMABI.mlir
@@ -4,11 +4,11 @@
 // CHECK-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-NEXT:      [[P2M:%.*]] = "polygeist.pointer2memref"([[A0]]) : (!llvm.ptr<i32, 1>) -> memref<?xi32, 1>
 // CHECK-NEXT:      [[M2P:%.*]] = "polygeist.memref2pointer"([[P2M]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
-// CHECK-NEXT:      sycl.call([[M2P]]) {Function = @foo, MangledName = @foo} : (!llvm.ptr<i32, 1>) -> ()
+// CHECK-NEXT:      sycl.call([[M2P]]) {FunctionName = @foo, MangledFunctionName = @foo} : (!llvm.ptr<i32, 1>) -> ()
 
 gpu.module @module {
 gpu.func @kernel(%arg0: memref<?xi32, 1>, %arg1: !sycl.range<1>, %arg2: !sycl.range<1>, %arg3: !sycl.id<1>) kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
-  sycl.call(%arg0) {Function = @foo, MangledName = @foo} : (memref<?xi32, 1>) -> ()
+  sycl.call(%arg0) {FunctionName = @foo, MangledFunctionName = @foo} : (memref<?xi32, 1>) -> ()
   gpu.return
 }
 }
@@ -16,14 +16,14 @@ gpu.func @kernel(%arg0: memref<?xi32, 1>, %arg1: !sycl.range<1>, %arg2: !sycl.ra
 // -----
 
 // CHECK-LABEL: gpu.func @return() -> (!llvm.ptr<i32, 1>, i64) {
-// CHECK-NEXT:    [[MEMREF:%.*]] = sycl.call() {Function = @foo, MangledName = @foo} : () -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:    [[MEMREF:%.*]] = sycl.call() {FunctionName = @foo, MangledFunctionName = @foo} : () -> !llvm.ptr<i32, 1>
 // CHECK-NEXT:    [[P2M:%.*]] = "polygeist.pointer2memref"([[MEMREF]]) : (!llvm.ptr<i32, 1>) -> memref<?xi32, 1>
 // CHECK:   [[M2P:%.*]] = "polygeist.memref2pointer"([[P2M]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
 // CHECK-NEXT:   gpu.return [[M2P]], {{.*}} : !llvm.ptr<i32, 1>, i64
 
 gpu.module @module {
 gpu.func @return() -> (memref<?xi32, 1>, i64) { 
-  %memref = sycl.call() {Function = @foo, MangledName = @foo} : () -> memref<?xi32, 1>
+  %memref = sycl.call() {FunctionName = @foo, MangledFunctionName = @foo} : () -> memref<?xi32, 1>
   %c0 = arith.constant 0 : i64
   gpu.return %memref, %c0: memref<?xi32, 1>, i64
 }
@@ -34,7 +34,7 @@ gpu.func @return() -> (memref<?xi32, 1>, i64) {
 // CHECK:  func.func @caller([[A0:.*]]: !llvm.ptr<i32, 1>) -> !llvm.ptr<i32, 1> {
 // CHECK-NEXT:    [[P2M:%.*]] = "polygeist.pointer2memref"([[A0]]) : (!llvm.ptr<i32, 1>) -> memref<?xi32, 1>
 // CHECK-NEXT:    [[M2P:%.*]] = "polygeist.memref2pointer"([[P2M]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
-// CHECK-NEXT:    [[SYCLCALL:%.*]] = sycl.call([[M2P]]) {Function = @callee, MangledName = @callee} : (!llvm.ptr<i32, 1>) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:    [[SYCLCALL:%.*]] = sycl.call([[M2P]]) {FunctionName = @callee, MangledFunctionName = @callee} : (!llvm.ptr<i32, 1>) -> !llvm.ptr<i32, 1>
 // CHECK-NEXT:    [[P2M:%.*]] = "polygeist.pointer2memref"([[SYCLCALL]]) : (!llvm.ptr<i32, 1>) -> memref<?xi32, 1>
 // CHECK-NEXT:    [[M2P:%.*]] = "polygeist.memref2pointer"([[P2M]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
 // CHECK-NEXT:    [[FUNCCALL:%.*]] = call @callee([[M2P]]) : (!llvm.ptr<i32, 1>) -> !llvm.ptr<i32, 1>
@@ -43,7 +43,7 @@ gpu.func @return() -> (memref<?xi32, 1>, i64) {
 // CHECK-NEXT:    return [[M2P]] : !llvm.ptr<i32, 1>
 
 func.func @caller(%arg0: memref<?xi32, 1>) -> memref<?xi32, 1> { 
-  %syclcall = sycl.call(%arg0) {Function = @callee, MangledName = @callee} : (memref<?xi32, 1>) -> memref<?xi32, 1>
+  %syclcall = sycl.call(%arg0) {FunctionName = @callee, MangledFunctionName = @callee} : (memref<?xi32, 1>) -> memref<?xi32, 1>
   %funccall = func.call @callee(%syclcall) : (memref<?xi32, 1>) -> memref<?xi32, 1>
   func.return %funccall: memref<?xi32, 1>
 }
@@ -60,7 +60,7 @@ func.func private @callee(%arg0: memref<?xi32, 1>) -> memref<?xi32, 1>
 // CHECK-NEXT:    call @constructor([[M2P]]) : (!llvm.ptr<!sycl_id_1_, 1>) -> ()
 
 func.func @constructor_caller(%arg0: memref<?x!sycl.id<1>, 1>) {
-  sycl.constructor(%arg0) {MangledName = @constructor, Type = @foo} : (memref<?x!sycl.id<1>, 1>) -> ()
+  sycl.constructor(%arg0) {MangledFunctionName = @constructor, Type = @foo} : (memref<?x!sycl.id<1>, 1>) -> ()
   func.return
 }
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -101,7 +101,7 @@ extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
 // CHECK-NEXT: %3 = "polygeist.memref2pointer"(%alloca) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
 // CHECK-NEXT: %4 = llvm.addrspacecast %3 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
 // CHECK-NEXT: %5 = "polygeist.pointer2memref"(%4) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
-// CHECK-NEXT: sycl.constructor(%5) {MangledName = @_ZN4sycl3_V12idILi2EEC1Ev, Type = @id} : (memref<?x!sycl_id_2_, 4>) -> ()
+// CHECK-NEXT: sycl.constructor(%5) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1Ev, Type = @id} : (memref<?x!sycl_id_2_, 4>) -> ()
 
 // Ensure declaration to have external linkage.
 // CHECK-LABEL: func.func private @_ZN4sycl3_V12idILi2EEC1Ev(memref<?x!sycl_id_2_, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 16 : i64, llvm.noundef})
@@ -124,7 +124,7 @@ extern "C" SYCL_EXTERNAL void cons_1() {
 // CHECK-NEXT: %0 = "polygeist.memref2pointer"(%alloca) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
 // CHECK-NEXT: %1 = llvm.addrspacecast %0 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
 // CHECK-NEXT: %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
-// CHECK-NEXT: sycl.constructor(%2, %arg0, %arg1) {MangledName = @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, Type = @id} : (memref<?x!sycl_id_2_, 4>, i64, i64) -> ()
+// CHECK-NEXT: sycl.constructor(%2, %arg0, %arg1) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, Type = @id} : (memref<?x!sycl_id_2_, 4>, i64, i64) -> ()
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_2(i64 noundef %0, i64 noundef %1) #1
 // CHECK-LLVM: [[ID1:%.*]] = alloca [[ID_TYPE:%"class.sycl::_V1::id.2"]]
@@ -144,7 +144,7 @@ extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
 // CHECK-NEXT: %3 = "polygeist.memref2pointer"(%arg0) : (memref<?x!sycl_item_2_1_>) -> !llvm.ptr<!sycl_item_2_1_>
 // CHECK-NEXT: %4 = llvm.addrspacecast %3 : !llvm.ptr<!sycl_item_2_1_> to !llvm.ptr<!sycl_item_2_1_, 4>
 // CHECK-NEXT: %5 = "polygeist.pointer2memref"(%4) : (!llvm.ptr<!sycl_item_2_1_, 4>) -> memref<?x!sycl_item_2_1_, 4>
-// CHECK-NEXT: sycl.constructor(%2, %5) {MangledName = @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE, Type = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_item_2_1_, 4>) -> ()
+// CHECK-NEXT: sycl.constructor(%2, %5) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE, Type = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_item_2_1_, 4>) -> ()
 
 // CHECK-LLVM: define spir_func void @cons_3([[ITEM_TYPE:%"class.sycl::_V1::item.2.true"]]* noundef byval(%"class.sycl::_V1::item.2.true") align 8 [[ARG0:%.*]]) #1
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE:%"class.sycl::_V1::id.2"]]  
@@ -165,7 +165,7 @@ extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
 // CHECK-NEXT: %3 = "polygeist.memref2pointer"(%arg0) : (memref<?x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
 // CHECK-NEXT: %4 = llvm.addrspacecast %3 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
 // CHECK-NEXT: %5 = "polygeist.pointer2memref"(%4) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
-// CHECK-NEXT: sycl.constructor(%2, %5) {MangledName = @_ZN4sycl3_V12idILi2EEC1ERKS2_, Type = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> ()
+// CHECK-NEXT: sycl.constructor(%2, %5) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ERKS2_, Type = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> ()
 
 // CHECK-LLVM: define spir_func void @cons_4([[ID_TYPE:%"class.sycl::_V1::id.2"]]*  noundef byval(%"class.sycl::_V1::id.2") align 8 [[ARG0:%.*]]) #1
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE]]
@@ -180,7 +180,7 @@ extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
 // CHECK-LABEL: func.func @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev({{.*}})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKONCE]], {{.*}}}
 // CHECK: [[I:%.*]] = "polygeist.subindex"(%arg0, %c0) : (memref<?x!sycl_accessor_1_i32_write_global_buffer, 4>, index) -> memref<?x!sycl_accessor_impl_device_1_, 4>
-// CHECK: sycl.constructor([[I]], {{%.*}}, {{%.*}}, {{%.*}}) {MangledName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_, Type = @AccessorImplDevice} : (memref<?x!sycl_accessor_impl_device_1_, 4>, memref<?x!sycl_id_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>) -> ()
+// CHECK: sycl.constructor([[I]], {{%.*}}, {{%.*}}, {{%.*}}) {MangledFunctionName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_, Type = @AccessorImplDevice} : (memref<?x!sycl_accessor_impl_device_1_, 4>, memref<?x!sycl_id_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>) -> ()
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_5() #1
 // CHECK-LLVM: [[ACCESSOR:%.*]] = alloca %"class.sycl::_V1::accessor.1", align 8

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -647,7 +647,7 @@ SYCL_EXTERNAL void group_get_local_linear_range(sycl::group<1> group) {
 // CHECK-MLIR-NEXT: %0 = "polygeist.memref2pointer"(%arg0) : (memref<?x!sycl_item_2_1_>) -> !llvm.ptr<!sycl_item_2_1_>
 // CHECK-MLIR-NEXT: %1 = llvm.addrspacecast %0 : !llvm.ptr<!sycl_item_2_1_> to !llvm.ptr<!sycl_item_2_1_, 4>
 // CHECK-MLIR-NEXT: %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<!sycl_item_2_1_, 4>) -> memref<?x!sycl_item_2_1_, 4>
-// CHECK-MLIR-NEXT: %3 = sycl.call(%2, %2) {Function = @"operator==", MangledName = @_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_, Type = @item} : (memref<?x!sycl_item_2_1_, 4>, memref<?x!sycl_item_2_1_, 4>) -> i8
+// CHECK-MLIR-NEXT: %3 = sycl.call(%2, %2) {FunctionName = @"operator==", MangledFunctionName = @_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_, TypeName = @item} : (memref<?x!sycl_item_2_1_, 4>, memref<?x!sycl_item_2_1_, 4>) -> i8
 // CHECK-MLIR-NEXT: return
 // CHECK-MLIR-NEXT: }
 
@@ -670,7 +670,7 @@ SYCL_EXTERNAL void method_2(sycl::item<2, true> item) {
 // CHECK-MLIR-NEXT: %3 = "polygeist.memref2pointer"(%arg1) : (memref<?x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
 // CHECK-MLIR-NEXT: %4 = llvm.addrspacecast %3 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
 // CHECK-MLIR-NEXT: %5 = "polygeist.pointer2memref"(%4) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
-// CHECK-MLIR-NEXT: %6 = sycl.call(%2, %5) {Function = @"operator==", MangledName = @_ZNK4sycl3_V12idILi2EEeqERKS2_, Type = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> i8
+// CHECK-MLIR-NEXT: %6 = sycl.call(%2, %5) {FunctionName = @"operator==", MangledFunctionName = @_ZNK4sycl3_V12idILi2EEeqERKS2_, TypeName = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> i8
 // CHECK-MLIR-NEXT: return
 // CHECK-MLIR-NEXT: }
 
@@ -696,7 +696,7 @@ SYCL_EXTERNAL void op_1(sycl::id<2> a, sycl::id<2> b) {
 // CHECK-MLIR-NEXT: %3 = "sycl.id.get"(%2, %c0_i32) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_id_2_, 4>, i32) -> i64
 // CHECK-MLIR-NEXT: %4 = "sycl.id.get"(%2, %c1_i32) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_id_2_, 4>, i32) -> i64
 // CHECK-MLIR-NEXT: %5 = arith.addi %3, %4 : i64
-// CHECK-MLIR-NEXT: %6 = sycl.call(%5) {Function = @abs, MangledName = @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_} : (i64) -> i64
+// CHECK-MLIR-NEXT: %6 = sycl.call(%5) {FunctionName = @abs, MangledFunctionName = @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_} : (i64) -> i64
 // CHECK-MLIR-NEXT: return
 // CHECK-MLIR-NEXT: }
 


### PR DESCRIPTION
Rename SYCLConstructorOp's and SYCLCallOp's MangledName and SYCLCallOp's Function attribute to MangledFunctionName and FunctionName respectively to follow naming rules for the rest of the operations.

Rename SYCLCallOp's Type attribute to TypeName to avoid overlaps, as Type is already in use; and follow naming conventions.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>