### PR TITLE
[SYCL] Add default for max_work_item_sizes

### DIFF
--- a/sycl/include/sycl/info/info_desc.hpp
+++ b/sycl/include/sycl/info/info_desc.hpp
@@ -98,7 +98,7 @@ namespace device {
 #include <sycl/info/device_traits_deprecated.def>
 #undef __SYCL_PARAM_TRAITS_DEPRECATED
 
-template <int Dimensions> struct max_work_item_sizes;
+template <int Dimensions = 3> struct max_work_item_sizes;
 #define __SYCL_PARAM_TRAITS_TEMPLATE_SPEC(DescType, Desc, ReturnT, PiCode)     \
   template <> struct Desc {                                                    \
     using return_type = ReturnT;                                               \


### PR DESCRIPTION
Hi,

This is a minor enhancement to add a default template argument to `info::device::max_work_item_sizes` in accordance with the [spec](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#appendix.device.descriptors).

Cheers,
-Nuno