### PR TITLE
[SYCL] Remove use of potentially invalid parameter from aspect queries

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -261,7 +261,6 @@ pi_native_handle device_impl::getNative() const {
 
 bool device_impl::has(aspect Aspect) const {
   size_t return_size = 0;
-  pi_device_type device_type;
 
   switch (Aspect) {
   case aspect::host:
@@ -319,44 +318,39 @@ bool device_impl::has(aspect Aspect) const {
     return get_info<info::device::usm_system_allocations>();
   case aspect::ext_intel_device_id:
     return getPlugin().call_nocheck<detail::PiApiKind::piDeviceGetInfo>(
-               MDevice, PI_DEVICE_INFO_DEVICE_ID, 0,
-               nullptr, &return_size) == PI_SUCCESS;
+               MDevice, PI_DEVICE_INFO_DEVICE_ID, 0, nullptr, &return_size) ==
+           PI_SUCCESS;
   case aspect::ext_intel_pci_address:
     return getPlugin().call_nocheck<detail::PiApiKind::piDeviceGetInfo>(
                MDevice, PI_DEVICE_INFO_PCI_ADDRESS, 0, nullptr, &return_size) ==
            PI_SUCCESS;
   case aspect::ext_intel_gpu_eu_count:
     return getPlugin().call_nocheck<detail::PiApiKind::piDeviceGetInfo>(
-               MDevice, PI_DEVICE_INFO_GPU_EU_COUNT, sizeof(pi_device_type),
-               &device_type, &return_size) == PI_SUCCESS;
+               MDevice, PI_DEVICE_INFO_GPU_EU_COUNT, 0, nullptr,
+               &return_size) == PI_SUCCESS;
   case aspect::ext_intel_gpu_eu_simd_width:
     return getPlugin().call_nocheck<detail::PiApiKind::piDeviceGetInfo>(
-               MDevice, PI_DEVICE_INFO_GPU_EU_SIMD_WIDTH,
-               sizeof(pi_device_type), &device_type,
+               MDevice, PI_DEVICE_INFO_GPU_EU_SIMD_WIDTH, 0, nullptr,
                &return_size) == PI_SUCCESS;
   case aspect::ext_intel_gpu_slices:
     return getPlugin().call_nocheck<detail::PiApiKind::piDeviceGetInfo>(
-               MDevice, PI_DEVICE_INFO_GPU_SLICES, sizeof(pi_device_type),
-               &device_type, &return_size) == PI_SUCCESS;
+               MDevice, PI_DEVICE_INFO_GPU_SLICES, 0, nullptr, &return_size) ==
+           PI_SUCCESS;
   case aspect::ext_intel_gpu_subslices_per_slice:
     return getPlugin().call_nocheck<detail::PiApiKind::piDeviceGetInfo>(
-               MDevice, PI_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE,
-               sizeof(pi_device_type), &device_type,
+               MDevice, PI_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE, 0, nullptr,
                &return_size) == PI_SUCCESS;
   case aspect::ext_intel_gpu_eu_count_per_subslice:
     return getPlugin().call_nocheck<detail::PiApiKind::piDeviceGetInfo>(
-               MDevice, PI_DEVICE_INFO_GPU_EU_COUNT_PER_SUBSLICE,
-               sizeof(pi_device_type), &device_type,
+               MDevice, PI_DEVICE_INFO_GPU_EU_COUNT_PER_SUBSLICE, 0, nullptr,
                &return_size) == PI_SUCCESS;
   case aspect::ext_intel_gpu_hw_threads_per_eu:
     return getPlugin().call_nocheck<detail::PiApiKind::piDeviceGetInfo>(
-               MDevice, PI_DEVICE_INFO_GPU_HW_THREADS_PER_EU,
-               sizeof(pi_device_type), &device_type,
+               MDevice, PI_DEVICE_INFO_GPU_HW_THREADS_PER_EU, 0, nullptr,
                &return_size) == PI_SUCCESS;
   case aspect::ext_intel_free_memory:
     return getPlugin().call_nocheck<detail::PiApiKind::piDeviceGetInfo>(
-               MDevice, PI_EXT_INTEL_DEVICE_INFO_FREE_MEMORY,
-               sizeof(pi_device_type), &device_type,
+               MDevice, PI_EXT_INTEL_DEVICE_INFO_FREE_MEMORY, 0, nullptr,
                &return_size) == PI_SUCCESS;
   case aspect::ext_intel_device_info_uuid: {
     auto Result = getPlugin().call_nocheck<detail::PiApiKind::piDeviceGetInfo>(


### PR DESCRIPTION
Select device aspect queries were using an output type for extension device queries that did not match the output type of the corresponding info query. This commit changes these to not specify the size of the output but instead base the aspect checks on whether the backend is able to return a size of the output.

Fixes https://github.com/intel/llvm/issues/7011.