### PR TITLE
[SYCL-MLIR]: Fix naming ambiguity

### DIFF
--- a/polygeist/include/polygeist/Ops.h
+++ b/polygeist/include/polygeist/Ops.h
@@ -85,10 +85,10 @@ public:
       return failure();
 
     {
-      SmallVector<MemoryEffects::EffectInstance> beforeEffects;
+      SmallVector<mlir::MemoryEffects::EffectInstance> beforeEffects;
       getEffectsBefore(op, beforeEffects, /*stopAtBarrier*/ true);
 
-      SmallVector<MemoryEffects::EffectInstance> afterEffects;
+      SmallVector<mlir::MemoryEffects::EffectInstance> afterEffects;
       getEffectsAfter(op, afterEffects, /*stopAtBarrier*/ false);
 
       bool conflict = false;
@@ -96,8 +96,8 @@ public:
         for (auto after : afterEffects) {
           if (mayAlias(before, after)) {
             // Read, read is okay
-            if (isa<MemoryEffects::Read>(before.getEffect()) &&
-                isa<MemoryEffects::Read>(after.getEffect())) {
+            if (isa<mlir::MemoryEffects::Read>(before.getEffect()) &&
+                isa<mlir::MemoryEffects::Read>(after.getEffect())) {
               continue;
             }
 
@@ -115,10 +115,10 @@ public:
     }
 
     {
-      SmallVector<MemoryEffects::EffectInstance> beforeEffects;
+      SmallVector<mlir::MemoryEffects::EffectInstance> beforeEffects;
       getEffectsBefore(op, beforeEffects, /*stopAtBarrier*/ false);
 
-      SmallVector<MemoryEffects::EffectInstance> afterEffects;
+      SmallVector<mlir::MemoryEffects::EffectInstance> afterEffects;
       getEffectsAfter(op, afterEffects, /*stopAtBarrier*/ true);
 
       bool conflict = false;
@@ -126,8 +126,8 @@ public:
         for (auto after : afterEffects) {
           if (mayAlias(before, after)) {
             // Read, read is okay
-            if (isa<MemoryEffects::Read>(before.getEffect()) &&
-                isa<MemoryEffects::Read>(after.getEffect())) {
+            if (isa<mlir::MemoryEffects::Read>(before.getEffect()) &&
+                isa<mlir::MemoryEffects::Read>(after.getEffect())) {
               continue;
             }
             // Write, write is not okay because may be different offsets and the


### PR DESCRIPTION
`MemoryEffects` is deemed ambiguous (could be either `class MemoryEffect` or in the mlir namespace):
```
polygeist/include/polygeist/Ops.h:118:19: error: reference to 'MemoryEffects' is ambiguous
      SmallVector<MemoryEffects::EffectInstance> beforeEffects;

.../llvm/../mlir/include/mlir/Interfaces/SideEffectInterfaces.h:262:11: note: candidate found by name lookup is 'mlir::MemoryEffects'
namespace MemoryEffects {
          ^
.../llvm/include/llvm/IR/Attributes.h:45:7: note: candidate found by name lookup is 'llvm::MemoryEffects'
class MemoryEffects;
      ^
```
This PR resolves the ambiguity. 

Signed-off-by: Tiotto, Ettore <ettore.tiotto@intel.com>