### PR TITLE
[SYCL] Emit warning when ONEAPI_DEVICE_SELECTOR/SYCL_DEVICE_FILTER not satisfiable

### DIFF
--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -72,6 +72,10 @@ static void traceDeviceSelection(const device &Device, int Score, bool Chosen) {
 
 device select_device(DSelectorInvocableType DeviceSelectorInvocable,
                      std::vector<device> &Devices) {
+  if (Devices.empty()) {
+    std::cerr << "Warning: No devices satisfy the currently set filter!"
+              << std::endl;
+  }
   int score = detail::REJECT_DEVICE_SCORE;
   const device *res = nullptr;
 


### PR DESCRIPTION
Runtime exceptions regarding device selection failures sometimes do not give the full picture as they are usually coupled with a specific selector function. Therefore, it is nice to have a warning when the filters set by the user exclude all devices in the system so that it is not a selector problem. This would make debugging easier.