### PR TITLE
[Driver][SYCL] Set /Zc:__cplusplus default for MSVC host compilation

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4627,6 +4627,13 @@ void Clang::ConstructHostCompilerJob(Compilation &C, const JobAction &JA,
     HostCompileArgs.push_back(TCArgs.MakeArgString(OutOpt));
     OutputAdded = true;
   };
+  // By default: pass /Zc:__cplusplus if we see a MSVC compiler.
+  // Users can disable this through
+  // -fsycl-host-compiler-options=/Zc:__cplusplus-
+  // It overrides the default option.
+  if (IsMSVCHostCompiler)
+    HostCompileArgs.push_back("/Zc:__cplusplus");
+
   // FIXME: Reuse existing toolchains which are already supported to put
   // together the options.
   // FIXME: For any potential obscure host compilers that do not use the

--- a/clang/test/Driver/sycl-host-compiler.cpp
+++ b/clang/test/Driver/sycl-host-compiler.cpp
@@ -67,3 +67,12 @@
 // RUN: %clangxx -fsycl -fsycl-host-compiler=g++ %t.o -### 2>&1 \
 // RUN:  | FileCheck -check-prefix=WARNING_HOST_COMPILER %s
 // WARNING_HOST_COMPILER-NOT: warning: argument unused during compilation: '-fsycl-host-compiler=g++' [-Wunused-command-line-argument]
+
+// Zc:__cplusplus, Zc:__cplusplus- check
+// RUN: %clang_cl -### -fsycl-host-compiler=cl -fsycl %s 2>&1 | FileCheck -check-prefix=CHECK-ZC-CPLUSPLUS %s
+// RUN: %clang_cl -### -fsycl-host-compiler=cl -fsycl /fsycl-host-compiler-options=/Zc:__cplusplus- %s 2>&1 | FileCheck -check-prefix=CHECK-ZC-CPLUSPLUS-MINUS %s
+// RUN: %clang_cl -### %s 2>&1 | FileCheck -check-prefix=CHECK-NO-ZC-CPLUSPLUS %s
+// RUN: %clang_cl -### -fsycl-host-compiler=g++ -fsycl %s 2>&1 | FileCheck -check-prefix=CHECK-NO-ZC-CPLUSPLUS %s
+// CHECK-ZC-CPLUSPLUS: "/Zc:__cplusplus"
+// CHECK-ZC-CPLUSPLUS-MINUS: "/Zc:__cplusplus-"
+// CHECK-NO-ZC-CPLUSPLUS-NOT: "/Zc:__cplusplus"

--- a/clang/test/Driver/sycl-host-compiler.cpp
+++ b/clang/test/Driver/sycl-host-compiler.cpp
@@ -70,7 +70,7 @@
 
 // Zc:__cplusplus, Zc:__cplusplus- check
 // RUN: %clang_cl -### -fsycl-host-compiler=cl -fsycl %s 2>&1 | FileCheck -check-prefix=CHECK-ZC-CPLUSPLUS %s
-// RUN: %clang_cl -### -fsycl-host-compiler=cl -fsycl /fsycl-host-compiler-options=/Zc:__cplusplus- %s 2>&1 | FileCheck -check-prefix=CHECK-ZC-CPLUSPLUS-MINUS %s
+// RUN: %clang_cl -### -fsycl-host-compiler=cl -fsycl -fsycl-host-compiler-options=/Zc:__cplusplus- %s 2>&1 | FileCheck -check-prefix=CHECK-ZC-CPLUSPLUS-MINUS %s
 // RUN: %clang_cl -### %s 2>&1 | FileCheck -check-prefix=CHECK-NO-ZC-CPLUSPLUS %s
 // RUN: %clang_cl -### -fsycl-host-compiler=g++ -fsycl %s 2>&1 | FileCheck -check-prefix=CHECK-NO-ZC-CPLUSPLUS %s
 // CHECK-ZC-CPLUSPLUS: "/Zc:__cplusplus"


### PR DESCRIPTION
By default, we pass the /Zc:__cplusplus to host compiler(cl)
When user passes /Zc:__cplusplus- on the icx/icpx commandline, we override the option to the host compiler to disable the default.
When user passes /Zc:_cplusplus- (OR) /Zc:_cplusplus through -fsycl-host-compiler-options, we pass such option as-is. This will have higher priority.