### PR TITLE
[SYCL][NFC] Move ESIMD tests in-tree

### DIFF
--- a/sycl/test/esimd/vec_arg_call_conv_ext.cpp
+++ b/sycl/test/esimd/vec_arg_call_conv_ext.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -Xclang -opaque-pointers -fsycl-device-only -c -Xclang -emit-llvm -o %t.comp.ll %s
+// RUN: %clangxx -fsycl -Xclang -opaque-pointers -fsycl-device-only -Xclang -emit-llvm -o %t.comp.ll %s
 // RUN: sycl-post-link -ir-output-only -lower-esimd -S %t.comp.ll -o %t.out.ll
 // RUN: FileCheck --input-file=%t.out.ll %s
 

--- a/sycl/test/esimd/vec_arg_call_conv_smoke.cpp
+++ b/sycl/test/esimd/vec_arg_call_conv_smoke.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -Xclang -opaque-pointers -fsycl-device-only -c -Xclang -emit-llvm -o %t.comp.ll %s
+// RUN: %clangxx -fsycl -Xclang -opaque-pointers -fsycl-device-only -Xclang -emit-llvm -o %t.comp.ll %s
 // RUN: sycl-post-link -ir-output-only -lower-esimd -S %t.comp.ll -o %t.out.ll
 // RUN: FileCheck --input-file=%t.out.ll %s
 


### PR DESCRIPTION
Tests were added to intel/llvm-test-suite repo
(intel/llvm-test-suite#1289), but they are too low-level to be located in there. Moved them in-tree.