### PR TITLE
[SYCL] Merge sycl_declared_aspects to sycl_used_aspects

### DIFF
--- a/llvm/test/SYCLLowerIR/PropagateAspectsUsage/PropageteDeclaredAspects/propagate-declared-1.ll
+++ b/llvm/test/SYCLLowerIR/PropagateAspectsUsage/PropageteDeclaredAspects/propagate-declared-1.ll
@@ -1,0 +1,49 @@
+; RUN: opt -passes=sycl-propagate-aspects-usage %s -S | FileCheck %s
+
+; kernel()
+;  |
+;  v
+; baz()
+;  |
+;  v
+; bar()
+;  |
+;  v
+; foo()
+
+source_filename = "main.cpp"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+; CHECK: void @kernel() !sycl_used_aspects ![[#ASPECT:]]
+define weak_odr dso_local spir_kernel void @kernel() {
+entry:
+  call spir_func void @_Z3bazv()
+  ret void
+}
+
+; CHECK: void @_Z3bazv() !sycl_used_aspects ![[#ASPECT]] {
+define dso_local spir_func void @_Z3bazv() {
+entry:
+  call spir_func void @_Z3barv()
+  ret void
+}
+
+; CHECK: void @_Z3barv() !sycl_used_aspects ![[#ASPECT]] {
+define dso_local spir_func void @_Z3barv() {
+entry:
+  call spir_func void @_Z3foov()
+  ret void
+}
+
+; CHECK: void @_Z3foov() !sycl_declared_aspects ![[#ASPECT]] !sycl_used_aspects ![[#ASPECT]] {
+define dso_local spir_func void @_Z3foov() !sycl_declared_aspects !2 {
+entry:
+  ret void
+}
+
+!sycl_aspects = !{!0, !1}
+
+!0 = !{!"gpu", i32 2}
+!1 = !{!"fp64", i32 6}
+!2 = !{i32 2}

--- a/llvm/test/SYCLLowerIR/PropagateAspectsUsage/PropageteDeclaredAspects/propagate-declared-2.ll
+++ b/llvm/test/SYCLLowerIR/PropagateAspectsUsage/PropageteDeclaredAspects/propagate-declared-2.ll
@@ -1,0 +1,43 @@
+; RUN: opt -passes=sycl-propagate-aspects-usage %s -S | FileCheck %s
+
+;    baz()
+;   /     \
+;  v       v
+; bar()   foo()
+
+source_filename = "main.cpp"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+; CHECK: void @_Z3bazv() !sycl_used_aspects ![[#ASPECT1:]]
+define dso_local spir_kernel void @_Z3bazv() {
+entry:
+  call spir_func void @_Z3barv()
+  call spir_func void @_Z3foov()
+  ret void
+}
+
+; CHECK: void @_Z3barv() !sycl_used_aspects ![[#ASPECT2:]] {
+define dso_local spir_func void @_Z3barv() !sycl_used_aspects !3 {
+entry:
+  ret void
+}
+
+; CHECK: void @_Z3foov() !sycl_used_aspects ![[#ASPECT3:]]
+; CHECK-SAME: !sycl_declared_aspects ![[#ASPECT3]] {
+define dso_local spir_func void @_Z3foov() !sycl_declared_aspects !4 {
+entry:
+  ret void
+}
+
+; CHECK: ![[#ASPECT1]] = !{i32 2, i32 1}
+; CHECK: ![[#ASPECT2]] = !{i32 2}
+; CHECK: ![[#ASPECT3]] = !{i32 1}
+
+!sycl_aspects = !{!0, !1, !2}
+
+!0 = !{!"cpu", i32 1}
+!1 = !{!"gpu", i32 2}
+!2 = !{!"fp64", i32 6}
+!3 = !{i32 2}
+!4 = !{i32 1}

--- a/llvm/test/SYCLLowerIR/PropagateAspectsUsage/PropageteDeclaredAspects/propagate-declared-3.ll
+++ b/llvm/test/SYCLLowerIR/PropagateAspectsUsage/PropageteDeclaredAspects/propagate-declared-3.ll
@@ -1,0 +1,51 @@
+; RUN: opt -passes=sycl-propagate-aspects-usage %s -S | FileCheck %s
+
+;   K
+;  /  \
+; F1  F2
+;  \  / \
+;   F3   F4
+
+; CHECK: spir_kernel void @kernel() !sycl_used_aspects ![[#ID1:]]
+define spir_kernel void @kernel() {
+  call spir_func void @func1()
+  call spir_func void @func2()
+  ret void
+}
+
+; CHECK: spir_func void @func1() !sycl_used_aspects ![[#ID2:]] {
+define spir_func void @func1() {
+  call spir_func void @func3()
+  ret void
+}
+
+; CHECK: spir_func void @func2() !sycl_used_aspects ![[#ID1]] {
+define spir_func void @func2() {
+  call spir_func void @func3()
+  call spir_func void @func4()
+  ret void
+}
+
+; CHECK: spir_func void @func3() !sycl_used_aspects ![[#ID2]] {
+define spir_func void @func3() !sycl_used_aspects !4 {
+  ret void
+}
+
+; CHECK: spir_func void @func4() !sycl_used_aspects ![[#ID3:]]
+; CHECK-SAME: !sycl_declared_aspects ![[#ID3]] {
+define spir_func void @func4() !sycl_declared_aspects !3 {
+  ret void
+}
+
+!sycl_aspects = !{!0, !1, !2}
+
+!0 = !{!"host", i32 0}
+!1 = !{!"cpu", i32 1}
+!2 = !{!"fp64", i32 6}
+!3 = !{i32 0}
+!4 = !{i32 1}
+!5 = !{i32 0, i32 1}
+
+; CHECK: ![[#ID1]] = !{i32 1, i32 0}
+; CHECK: ![[#ID2]] = !{i32 1}
+; CHECK: ![[#ID3]] = !{i32 0}


### PR DESCRIPTION
To make RT be able to throw an exception if device doesn't support the feature pass should also propagate sycl_declared aspects by merging it with sycl_used_aspects.
Spec: https://github.com/intel/llvm/pull/7415