### PR TITLE
[SYCL-MLIR] Improve CodeGen for Add and Sub expressions

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "Lib/TypeUtils.h"
 #include "clang-mlir.h"
 #include "utils.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -2185,6 +2186,16 @@ ValueCategory MLIRScanner::EmitPromoted(Expr *E, QualType PromotionType) {
   return Res;
 }
 
+ValueCategory MLIRScanner::CastToVoidPtr(ValueCategory Ptr) {
+  assert(mlirclang::isPointerOrMemRefTy(Ptr.val.getType()) &&
+         "Expecting pointer or memref");
+
+  const auto DestType =
+      mlirclang::getPtrTyWithNewType(Ptr.val.getType(), builder.getI8Type());
+
+  return Ptr.BitCast(builder, loc, DestType);
+}
+
 ValueCategory MLIRScanner::EmitPromotedValue(Location Loc, ValueCategory Result,
                                              QualType PromotionType) {
   return Result.FPExt(builder, Loc, Glob.getTypes().getMLIRType(PromotionType));
@@ -2576,6 +2587,12 @@ BinOpInfo MLIRScanner::EmitBinOps(BinaryOperator *E, QualType PromotionType) {
   return {LHS, RHS, Ty, Opcode, E};
 }
 
+static void informNoOverflowCheck(LangOptions::SignedOverflowBehaviorTy SOB,
+                                  llvm::StringRef OpName) {
+  if (SOB != clang::LangOptions::SOB_Defined)
+    llvm::errs() << "Not emitting overflow-checked " << OpName << "\n";
+}
+
 ValueCategory MLIRScanner::EmitBinMul(const BinOpInfo &Info) {
   auto lhs_v = Info.getLHS().getValue(builder);
   auto rhs_v = Info.getRHS().getValue(builder);
@@ -2620,91 +2637,215 @@ ValueCategory MLIRScanner::EmitBinRem(const BinOpInfo &Info) {
   }
 }
 
-ValueCategory MLIRScanner::EmitBinAdd(const BinOpInfo &Info) {
-  auto lhs_v = Info.getLHS().getValue(builder);
-  auto rhs_v = Info.getRHS().getValue(builder);
-  if (lhs_v.getType().isa<mlir::FloatType>()) {
-    return ValueCategory(builder.create<AddFOp>(loc, lhs_v, rhs_v),
-                         /*isReference*/ false);
-  } else if (auto mt = lhs_v.getType().dyn_cast<mlir::MemRefType>()) {
-    auto shape = std::vector<int64_t>(mt.getShape());
-    shape[0] = -1;
-    auto mt0 =
-        mlir::MemRefType::get(shape, mt.getElementType(),
-                              MemRefLayoutAttrInterface(), mt.getMemorySpace());
-    auto ptradd = rhs_v;
-    ptradd = castToIndex(loc, ptradd);
-    return ValueCategory(
-        builder.create<polygeist::SubIndexOp>(loc, mt0, lhs_v, ptradd),
-        /*isReference*/ false);
-  } else if (auto pt =
-                 lhs_v.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
-    return ValueCategory(builder.create<LLVM::GEPOp>(
-                             loc, pt, lhs_v, std::vector<mlir::Value>({rhs_v})),
-                         /*isReference*/ false);
-  } else {
-    if (auto lhs_c = lhs_v.getDefiningOp<ConstantIntOp>()) {
-      if (auto rhs_c = rhs_v.getDefiningOp<ConstantIntOp>()) {
-        return ValueCategory(
-            builder.create<arith::ConstantIntOp>(
-                loc, lhs_c.value() + rhs_c.value(), lhs_c.getType()),
-            false);
-      }
-    }
-    return ValueCategory(builder.create<AddIOp>(loc, lhs_v, rhs_v),
-                         /*isReference*/ false);
+/// Casts index of subindex operation conditionally.
+static Optional<Value> castSubIndexOpIndex(OpBuilder &Builder, Location Loc,
+                                           ValueCategory Pointer,
+                                           ValueRange IdxList, bool IsSigned) {
+  if (Pointer.val.getType().isa<MemRefType>()) {
+    assert(IdxList.size() == 1 && "SubIndexOP accepts just an index");
+    return ValueCategory(IdxList.front(), false)
+        .IntCast(Builder, Loc, Builder.getIndexType(), IsSigned)
+        .val;
   }
+  return llvm::None;
+}
+
+ValueCategory MLIRScanner::EmitCheckedInBoundsGEP(mlir::Type ElemTy,
+                                                  ValueCategory Pointer,
+                                                  ValueRange IdxList,
+                                                  bool IsSigned, bool) {
+  assert(mlirclang::isPointerOrMemRefTy(Pointer.val.getType()) &&
+         "Expecting pointer or MemRef");
+  assert(std::all_of(IdxList.begin(), IdxList.end(),
+                     [](mlir::Value Val) {
+                       return Val.getType().isa<IntegerType>();
+                     }) &&
+         "Expecting indices list");
+
+  if (Optional<Value> NewValue =
+          castSubIndexOpIndex(builder, loc, Pointer, IdxList, IsSigned))
+    IdxList = *NewValue;
+
+  return Pointer.InBoundsGEPOrSubIndex(builder, loc, ElemTy, IdxList);
+}
+
+ValueCategory MLIRScanner::EmitPointerArithmetic(const BinOpInfo &Info) {
+  const auto *Expr = cast<BinaryOperator>(Info.getExpr());
+
+  ValueCategory Pointer = Info.getLHS();
+  auto *PointerOperand = Expr->getLHS();
+  ValueCategory Index = Info.getRHS();
+  auto *IndexOperand = Expr->getRHS();
+
+  const auto Opcode = Info.getOpcode();
+  const auto IsSubtraction =
+      Opcode == clang::BO_Sub || Opcode == clang::BO_SubAssign;
+
+  // In a subtraction, the LHS is always the pointer.
+  if (!IsSubtraction &&
+      !mlirclang::isPointerOrMemRefTy(Pointer.val.getType())) {
+    std::swap(Pointer, Index);
+    std::swap(PointerOperand, IndexOperand);
+  }
+
+  assert(Index.val.getType().isa<IntegerType>() && "Expecting integer type");
+
+  const auto IsSigned =
+      IndexOperand->getType()->isSignedIntegerOrEnumerationType();
+
+  const unsigned Width = Index.val.getType().getIntOrFloatBitWidth();
+
+  auto PtrTy = Pointer.val.getType();
+
+  assert(mlirclang::isPointerOrMemRefTy(PtrTy) && "Expecting pointer type");
+
+  auto &CGM = Glob.getCGM();
+
+  // Some versions of glibc and gcc use idioms (particularly in their malloc
+  // routines) that add a pointer-sized integer (known to be a pointer
+  // value) to a null pointer in order to cast the value back to an integer
+  // or as part of a pointer alignment algorithm.  This is undefined
+  // behavior, but we'd like to be able to compile programs that use it.
+  //
+  // Normally, we'd generate a GEP with a null-pointer base here in response
+  // to that code, but it's also UB to dereference a pointer created that
+  // way.  Instead (as an acknowledged hack to tolerate the idiom) we will
+  // generate a direct cast of the integer value to a pointer.
+  //
+  // The idiom (p = nullptr + N) is not met if any of the following are
+  // true:
+  //
+  //   The operation is subtraction.
+  //   The index is not pointer-sized.
+  //   The pointer type is not byte-sized.
+  //
+  if (BinaryOperator::isNullPointerArithmeticExtension(
+          CGM.getContext(), Opcode, PointerOperand, IndexOperand)) {
+    return Index.IntToPtr(builder, loc, PtrTy);
+  }
+
+  auto &DL = CGM.getDataLayout();
+  const unsigned IndexTypeSize = DL.getIndexTypeSizeInBits(
+      CGM.getTypes().ConvertType(PointerOperand->getType()));
+  if (Width != IndexTypeSize) {
+    // Zero-extend or sign-extend the pointer value according to
+    // whether the index is signed or not.
+    Index = Index.IntCast(builder, loc, builder.getIntegerType(IndexTypeSize),
+                          IsSigned);
+  }
+
+  // If this is subtraction, negate the index.
+  if (IsSubtraction)
+    Index = Index.Neg(builder, loc);
+
+  const auto *PointerType =
+      PointerOperand->getType()->getAs<clang::PointerType>();
+
+  assert(PointerType && "Not pointer type");
+
+  QualType ElementType = PointerType->getPointeeType();
+  assert(!CGM.getContext().getAsVariableArrayType(ElementType) &&
+         "Not implemented yet");
+
+  // Explicitly handle GNU void* and function pointer arithmetic extensions.
+  // The GNU void* casts amount to no-ops since our void* type is i8*, but
+  // this is future proof.
+  if (ElementType->isVoidType() || ElementType->isFunctionType()) {
+    assert(PtrTy.isa<LLVM::LLVMPointerType>() && "Expecting pointer type");
+    auto Result = CastToVoidPtr(Pointer);
+    Result = Result.GEP(builder, loc, builder.getI8Type(), Index.val);
+    return Result.BitCast(builder, loc, Pointer.val.getType());
+  }
+
+  auto ElemTy = Glob.getTypes().getMLIRType(ElementType);
+  if (CGM.getLangOpts().isSignedOverflowDefined()) {
+    if (Optional<Value> NewIndex =
+            castSubIndexOpIndex(builder, loc, Pointer, Index.val, IsSigned))
+      Index.val = *NewIndex;
+    return Pointer.GEPOrSubIndex(builder, loc, ElemTy, Index.val);
+  }
+
+  return EmitCheckedInBoundsGEP(ElemTy, Pointer, Index.val, IsSigned,
+                                IsSubtraction);
+}
+
+ValueCategory MLIRScanner::EmitBinAdd(const BinOpInfo &Info) {
+  const auto Loc = getMLIRLocation(Info.getExpr()->getExprLoc());
+  const auto LHS = Info.getLHS();
+  const auto RHS = Info.getRHS().val;
+
+  if (mlirclang::isPointerOrMemRefTy(LHS.val.getType()) ||
+      mlirclang::isPointerOrMemRefTy(RHS.getType())) {
+    loc = Loc;
+    return EmitPointerArithmetic(Info);
+  }
+
+  if (Info.getType()->isSignedIntegerOrEnumerationType()) {
+    informNoOverflowCheck(
+        Glob.getCGM().getLangOpts().getSignedOverflowBehavior(), "add");
+    return LHS.Add(builder, Loc, RHS);
+  }
+
+  assert(!Info.getType()->isConstantMatrixType() && "Not yet implemented");
+
+  if (mlirclang::isFPOrFPVectorTy(LHS.val.getType()))
+    return LHS.FAdd(builder, Loc, RHS);
+  return LHS.Add(builder, Loc, RHS);
 }
 
 ValueCategory MLIRScanner::EmitBinSub(const BinOpInfo &Info) {
-  auto lhs_v = Info.getLHS().getValue(builder);
-  auto rhs_v = Info.getRHS().getValue(builder);
-  if (auto mt = lhs_v.getType().dyn_cast<mlir::MemRefType>()) {
-    lhs_v = builder.create<polygeist::Memref2PointerOp>(
-        loc,
-        LLVM::LLVMPointerType::get(mt.getElementType(),
-                                   mt.getMemorySpaceAsInt()),
-        lhs_v);
-  }
-  if (auto mt = rhs_v.getType().dyn_cast<mlir::MemRefType>()) {
-    rhs_v = builder.create<polygeist::Memref2PointerOp>(
-        loc,
-        LLVM::LLVMPointerType::get(mt.getElementType(),
-                                   mt.getMemorySpaceAsInt()),
-        rhs_v);
-  }
-  if (lhs_v.getType().isa<mlir::FloatType>()) {
-    assert(rhs_v.getType() == lhs_v.getType());
-    return ValueCategory(builder.create<SubFOp>(loc, lhs_v, rhs_v),
-                         /*isReference*/ false);
-  } else if (auto pt =
-                 lhs_v.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
-    if (auto IT = rhs_v.getType().dyn_cast<mlir::IntegerType>()) {
-      mlir::Value vals[1] = {builder.create<SubIOp>(
-          loc, builder.create<ConstantIntOp>(loc, 0, IT.getWidth()), rhs_v)};
-      return ValueCategory(
-          builder.create<LLVM::GEPOp>(loc, lhs_v.getType(), lhs_v,
-                                      ArrayRef<mlir::Value>(vals)),
-          false);
+  const auto Loc = getMLIRLocation(Info.getExpr()->getExprLoc());
+  auto LHS = Info.getLHS();
+  auto RHS = Info.getRHS();
+
+  // The LHS is always a pointer if either side is.
+  if (!mlirclang::isPointerOrMemRefTy(LHS.val.getType())) {
+    if (Info.getType()->isSignedIntegerOrEnumerationType()) {
+      informNoOverflowCheck(
+          Glob.getCGM().getLangOpts().getSignedOverflowBehavior(), "sub");
+      return LHS.Sub(builder, Loc, RHS.val);
     }
-    mlir::Value val = builder.create<SubIOp>(
-        loc,
-        builder.create<LLVM::PtrToIntOp>(
-            loc, Glob.getTypes().getMLIRType(Info.getType()), lhs_v),
-        builder.create<LLVM::PtrToIntOp>(
-            loc, Glob.getTypes().getMLIRType(Info.getType()), rhs_v));
-    val = builder.create<DivSIOp>(
-        loc, val,
-        builder.create<IndexCastOp>(
-            loc, val.getType(),
-            builder.create<polygeist::TypeSizeOp>(
-                loc, builder.getIndexType(),
-                mlir::TypeAttr::get(pt.getElementType()))));
-    return ValueCategory(val, /*isReference*/ false);
-  } else {
-    return ValueCategory(builder.create<SubIOp>(loc, lhs_v, rhs_v),
-                         /*isReference*/ false);
+    assert(!Info.getType()->isConstantMatrixType() && "Not yet implemented");
+    if (mlirclang::isFPOrFPVectorTy(LHS.val.getType()))
+      return LHS.FSub(builder, Loc, RHS.val);
+    return LHS.Sub(builder, Loc, RHS.val);
   }
+
+  // If the RHS is not a pointer, then we have normal pointer
+  // arithmetic.
+  if (!mlirclang::isPointerOrMemRefTy(RHS.val.getType())) {
+    loc = Loc;
+    return EmitPointerArithmetic(Info);
+  }
+
+  // Otherwise, this is a pointer subtraction.
+
+  // Do the raw subtraction part.
+  const auto PtrDiffTy = builder.getIntegerType(
+      Glob.getCGM().getDataLayout().getPointerSizeInBits());
+  LHS = LHS.MemRef2Ptr(builder, Loc).PtrToInt(builder, Loc, PtrDiffTy);
+  RHS = RHS.MemRef2Ptr(builder, Loc).PtrToInt(builder, Loc, PtrDiffTy);
+  const auto DiffInChars = LHS.Sub(builder, Loc, RHS.val);
+
+  // Okay, figure out the element size.
+  const QualType ElementType =
+      Info.getExpr()->getLHS()->getType()->getPointeeType();
+
+  assert(!Glob.getCGM().getContext().getAsVariableArrayType(ElementType) &&
+         "Not implemented yet");
+
+  const CharUnits ElementSize =
+      (ElementType->isVoidType() || ElementType->isFunctionType())
+          ? CharUnits::One()
+          : Glob.getCGM().getContext().getTypeSizeInChars(ElementType);
+
+  if (ElementSize.isOne())
+    return DiffInChars;
+
+  const auto Divisor = builder.createOrFold<arith::ConstantIntOp>(
+      Loc, ElementSize.getQuantity(), PtrDiffTy);
+
+  return DiffInChars.ExactSDiv(builder, Loc, Divisor);
 }
 
 ValueCategory MLIRScanner::EmitBinShl(const BinOpInfo &Info) {

--- a/polygeist/tools/cgeist/Lib/TypeUtils.cc
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.cc
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"
 #include "mlir/IR/Types.h"
 
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/Support/Casting.h"
 
@@ -74,6 +75,19 @@ mlir::IntegerAttr wrapIntegerMemorySpace(unsigned MemorySpace,
   return MemorySpace ? mlir::IntegerAttr::get(mlir::IntegerType::get(Ctx, 64),
                                               MemorySpace)
                      : nullptr;
+}
+
+mlir::Type getPtrTyWithNewType(mlir::Type Orig, mlir::Type NewElementType) {
+  return llvm::TypeSwitch<mlir::Type, mlir::Type>(Orig)
+      .Case<mlir::MemRefType>([NewElementType](auto Ty) {
+        return mlir::MemRefType::get(Ty.getShape(), NewElementType,
+                                     Ty.getLayout(), Ty.getMemorySpace());
+      })
+      .Case<mlir::LLVM::LLVMPointerType>([NewElementType](auto Ty) {
+        return mlir::LLVM::LLVMPointerType::get(NewElementType,
+                                                Ty.getAddressSpace());
+      })
+      .Default([](auto) -> mlir::Type { llvm_unreachable("Invalid type"); });
 }
 
 mlir::Type getSYCLType(const clang::RecordType *RT,
@@ -175,6 +189,21 @@ llvm::Type *getLLVMType(const clang::QualType QT,
     return llvm::Type::getVoidTy(CGM.getModule().getContext());
 
   return CGM.getTypes().ConvertType(QT);
+}
+
+template <typename MLIRTy> static bool isTyOrTyVectorTy(mlir::Type Ty) {
+  if (Ty.isa<MLIRTy>())
+    return true;
+  const auto VecTy = Ty.dyn_cast<mlir::VectorType>();
+  return VecTy && VecTy.getElementType().isa<MLIRTy>();
+}
+
+bool isFPOrFPVectorTy(mlir::Type Ty) {
+  return isTyOrTyVectorTy<mlir::FloatType>(Ty);
+}
+
+bool isIntOrIntVectorTy(mlir::Type Ty) {
+  return isTyOrTyVectorTy<mlir::IntegerType>(Ty);
 }
 
 } // namespace mlirclang

--- a/polygeist/tools/cgeist/Lib/TypeUtils.h
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.h
@@ -9,6 +9,8 @@
 #ifndef MLIR_TOOLS_MLIRCLANG_TYPE_UTILS_H
 #define MLIR_TOOLS_MLIRCLANG_TYPE_UTILS_H
 
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
 namespace clang {
@@ -46,10 +48,19 @@ bool isRecursiveStruct(llvm::Type *T, llvm::Type *Meta,
 mlir::IntegerAttr wrapIntegerMemorySpace(unsigned MemorySpace,
                                          mlir::MLIRContext *Ctx);
 
+mlir::Type getPtrTyWithNewType(mlir::Type Orig, mlir::Type NewElementType);
+
 mlir::Type getSYCLType(const clang::RecordType *RT,
                        mlirclang::CodeGen::CodeGenTypes &CGT);
 
 llvm::Type *getLLVMType(clang::QualType QT, clang::CodeGen::CodeGenModule &CGM);
+
+bool isFPOrFPVectorTy(mlir::Type Ty);
+bool isIntOrIntVectorTy(mlir::Type Ty);
+
+inline bool isPointerOrMemRefTy(mlir::Type Ty) {
+  return Ty.isa<mlir::MemRefType, mlir::LLVM::LLVMPointerType>();
+}
 
 } // namespace mlirclang
 

--- a/polygeist/tools/cgeist/Lib/TypeUtils.h
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.h
@@ -10,6 +10,7 @@
 #define MLIR_TOOLS_MLIRCLANG_TYPE_UTILS_H
 
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/Dialect/SYCL/IR/SYCLOpsTypes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
@@ -48,6 +49,8 @@ bool isRecursiveStruct(llvm::Type *T, llvm::Type *Meta,
 mlir::IntegerAttr wrapIntegerMemorySpace(unsigned MemorySpace,
                                          mlir::MLIRContext *Ctx);
 
+unsigned getAddressSpace(mlir::Type Ty);
+
 /// Given a MemRefType or LLVMPointerType, change the element type, keeping the
 /// rest of the parameters.
 mlir::Type getPtrTyWithNewType(mlir::Type Orig, mlir::Type NewElementType);
@@ -63,6 +66,19 @@ bool isIntOrIntVectorTy(mlir::Type Ty);
 inline bool isPointerOrMemRefTy(mlir::Type Ty) {
   return Ty.isa<mlir::MemRefType, mlir::LLVM::LLVMPointerType>();
 }
+
+inline bool isFirstClassType(mlir::Type Ty) {
+  return Ty.isa<mlir::IntegerType, mlir::IndexType, mlir::FloatType,
+                mlir::VectorType, mlir::MemRefType, mlir::LLVM::LLVMPointerType,
+                mlir::LLVM::LLVMStructType>() ||
+         mlir::sycl::isSYCLType(Ty);
+}
+
+inline bool isAggregateType(mlir::Type Ty) {
+  return Ty.isa<mlir::LLVM::LLVMStructType>() || mlir::sycl::isSYCLType(Ty);
+}
+
+unsigned getPrimitiveSizeInBits(mlir::Type Ty);
 
 } // namespace mlirclang
 

--- a/polygeist/tools/cgeist/Lib/TypeUtils.h
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.h
@@ -48,6 +48,8 @@ bool isRecursiveStruct(llvm::Type *T, llvm::Type *Meta,
 mlir::IntegerAttr wrapIntegerMemorySpace(unsigned MemorySpace,
                                          mlir::MLIRContext *Ctx);
 
+/// Given a MemRefType or LLVMPointerType, change the element type, keeping the
+/// rest of the parameters.
 mlir::Type getPtrTyWithNewType(mlir::Type Orig, mlir::Type NewElementType);
 
 mlir::Type getSYCLType(const clang::RecordType *RT,

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -48,6 +48,25 @@ public:
   void store(mlir::OpBuilder &Builder, mlir::Value toStore) const;
   ValueCategory dereference(mlir::OpBuilder &Builder) const;
 
+  ValueCategory SubIndex(mlir::OpBuilder &Builder, mlir::Location Loc,
+                         mlir::Type Type, mlir::Value Index,
+                         bool IsInBounds = false) const;
+  ValueCategory InBoundsSubIndex(mlir::OpBuilder &Builder, mlir::Location Loc,
+                                 mlir::Type Type, mlir::Value Index) const;
+
+  ValueCategory GEP(mlir::OpBuilder &Builder, mlir::Location Loc,
+                    mlir::Type Type, mlir::ValueRange IdxList,
+                    bool IsInBounds = false) const;
+  ValueCategory InBoundsGEP(mlir::OpBuilder &Builder, mlir::Location Loc,
+                            mlir::Type Type, mlir::ValueRange IdxList) const;
+
+  ValueCategory GEPOrSubIndex(mlir::OpBuilder &Builder, mlir::Location Loc,
+                              mlir::Type Type, mlir::ValueRange IdxList,
+                              bool IsInBounds = false) const;
+  ValueCategory InBoundsGEPOrSubIndex(mlir::OpBuilder &Builder,
+                                      mlir::Location Loc, mlir::Type Type,
+                                      mlir::ValueRange IdxList) const;
+
   ValueCategory FPTrunc(mlir::OpBuilder &Builder, mlir::Location Loc,
                         mlir::Type PromotionType) const;
 
@@ -63,11 +82,35 @@ public:
                        mlir::Type PromotionType) const;
   ValueCategory FPToSI(mlir::OpBuilder &Builder, mlir::Location Loc,
                        mlir::Type PromotionType) const;
+  ValueCategory PtrToInt(mlir::OpBuilder &Builder, mlir::Location Loc,
+                         mlir::Type DestTy) const;
+  ValueCategory IntToPtr(mlir::OpBuilder &Builder, mlir::Location Loc,
+                         mlir::Type DestTy) const;
+  ValueCategory BitCast(mlir::OpBuilder &Builder, mlir::Location Loc,
+                        mlir::Type DestTy) const;
+  ValueCategory MemRef2Ptr(mlir::OpBuilder &Builder, mlir::Location Loc) const;
 
   ValueCategory ICmpNE(mlir::OpBuilder &builder, mlir::Location Loc,
                        mlir::Value RHS) const;
   ValueCategory FCmpUNE(mlir::OpBuilder &builder, mlir::Location Loc,
                         mlir::Value RHS) const;
+
+  ValueCategory SDiv(mlir::OpBuilder &Builder, mlir::Location Loc,
+                     mlir::Value RHS, bool IsExact = false) const;
+  ValueCategory ExactSDiv(mlir::OpBuilder &Builder, mlir::Location Loc,
+                          mlir::Value RHS) const;
+  ValueCategory Neg(mlir::OpBuilder &Builder, mlir::Location Loc,
+                    bool HasNUW = false, bool HasNSW = false) const;
+  ValueCategory Add(mlir::OpBuilder &Builder, mlir::Location Loc,
+                    mlir::Value RHS, bool HasNUW = false,
+                    bool HasNSW = false) const;
+  ValueCategory FAdd(mlir::OpBuilder &Builder, mlir::Location Loc,
+                     mlir::Value RHS) const;
+  ValueCategory Sub(mlir::OpBuilder &Builder, mlir::Location Loc,
+                    mlir::Value RHS, bool HasNUW = false,
+                    bool HasNSW = false) const;
+  ValueCategory FSub(mlir::OpBuilder &Builder, mlir::Location Loc,
+                     mlir::Value RHS) const;
 };
 
 #endif /* CLANG_MLIR_VALUE_CATEGORY */

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -507,9 +507,11 @@ public:
   EmitCompoundAssign(clang::CompoundAssignOperator *E,
                      ValueCategory (MLIRScanner::*F)(const BinOpInfo &));
 
-  ValueCategory EmitCheckedInBoundsGEP(mlir::Type ElemTy, ValueCategory Pointer,
-                                       mlir::ValueRange IdxList, bool IsSigned,
-                                       bool IsSubtraction);
+  ValueCategory EmitCheckedInBoundsPtrOffsetOp(mlir::Type ElemTy,
+                                               ValueCategory Pointer,
+                                               mlir::ValueRange IdxList,
+                                               bool IsSigned,
+                                               bool IsSubtraction);
   ValueCategory EmitPointerArithmetic(const BinOpInfo &Info);
 
   BinOpInfo EmitBinOps(clang::BinaryOperator *E,

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -353,6 +353,8 @@ private:
   // Reshape memref<elemTy> to memref<1 x elemTy>.
   mlir::Value reshapeRanklessGlobal(mlir::memref::GetGlobalOp GV);
 
+  ValueCategory CastToVoidPtr(ValueCategory Ptr);
+
   /// TODO: Add ScalarConversion options
   ValueCategory EmitScalarCast(mlir::Location Loc, ValueCategory Src,
                                clang::QualType SrcType, clang::QualType DstType,
@@ -504,6 +506,11 @@ public:
   ValueCategory
   EmitCompoundAssign(clang::CompoundAssignOperator *E,
                      ValueCategory (MLIRScanner::*F)(const BinOpInfo &));
+
+  ValueCategory EmitCheckedInBoundsGEP(mlir::Type ElemTy, ValueCategory Pointer,
+                                       mlir::ValueRange IdxList, bool IsSigned,
+                                       bool IsSubtraction);
+  ValueCategory EmitPointerArithmetic(const BinOpInfo &Info);
 
   BinOpInfo EmitBinOps(clang::BinaryOperator *E,
                        clang::QualType PromotionTy = clang::QualType());

--- a/polygeist/tools/cgeist/Test/Verification/add.c
+++ b/polygeist/tools/cgeist/Test/Verification/add.c
@@ -1,0 +1,48 @@
+// RUN: cgeist %s --function=* -S | FileCheck %s
+
+typedef int int_vec __attribute__((ext_vector_type(3)));
+typedef float float_vec __attribute__((ext_vector_type(3)));
+
+// CHECK-LABEL:   func.func @f0(
+// CHECK-SAME:                  %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                  %[[VAL_1:.*]]: i32) -> i32
+// CHECK:           %[[ADD:.*]] = arith.addi %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           return %[[ADD]] : i32
+// CHECK:         }
+
+int f0(int a, int b) {
+  return a + b;
+}
+
+// CHECK-LABEL:   func.func @f1(
+// CHECK-SAME:                  %[[VAL_0:.*]]: f32,
+// CHECK-SAME:                  %[[VAL_1:.*]]: f32) -> f32
+// CHECK:           %[[ADD:.*]] = arith.addf %[[VAL_0]], %[[VAL_1]] : f32
+// CHECK:           return %[[ADD]] : f32
+// CHECK:         }
+
+float f1(float a, float b) {
+  return a + b;
+}
+
+// CHECK-LABEL:   func.func @f2(
+// CHECK-SAME:                  %[[VAL_0:.*]]: vector<3xi32>,
+// CHECK-SAME:                  %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
+// CHECK:           %[[ADD:.*]] = arith.addi %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
+// CHECK:           return %[[ADD]] : vector<3xi32>
+// CHECK:         }
+
+int_vec f2(int_vec a, int_vec b) {
+  return a + b;
+}
+
+// CHECK-LABEL:   func.func @f4(
+// CHECK-SAME:                  %[[VAL_0:.*]]: vector<3xf32>,
+// CHECK-SAME:                  %[[VAL_1:.*]]: vector<3xf32>) -> vector<3xf32>
+// CHECK:           %[[ADD:.*]] = arith.addf %[[VAL_0]], %[[VAL_1]] : vector<3xf32>
+// CHECK:           return %[[ADD]] : vector<3xf32>
+// CHECK:         }
+
+float_vec f4(float_vec a, float_vec b) {
+  return a + b;
+}

--- a/polygeist/tools/cgeist/Test/Verification/add.c
+++ b/polygeist/tools/cgeist/Test/Verification/add.c
@@ -1,48 +1,150 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
 
+typedef char char_vec __attribute__((ext_vector_type(3)));
+typedef short short_vec __attribute__((ext_vector_type(3)));
 typedef int int_vec __attribute__((ext_vector_type(3)));
+typedef long long_vec __attribute__((ext_vector_type(3)));
 typedef float float_vec __attribute__((ext_vector_type(3)));
+typedef double double_vec __attribute__((ext_vector_type(3)));
 
-// CHECK-LABEL:   func.func @f0(
+// CHECK-LABEL:   func.func @add_i8(
+// CHECK-SAME:                      %[[VAL_0:.*]]: i8,
+// CHECK-SAME:                      %[[VAL_1:.*]]: i8) -> i8
+// CHECK:           %[[VAL_2:.*]] = arith.extsi %[[VAL_0]] : i8 to i32
+// CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_1]] : i8 to i32
+// CHECK:           %[[VAL_4:.*]] = arith.addi %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i8
+// CHECK:           return %[[VAL_5]] : i8
+// CHECK:         }
+
+char add_i8(char a, char b) {
+  return a + b;
+}
+
+// CHECK-LABEL:   func.func @add_i16(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i16,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i16) -> i16
+// CHECK:           %[[VAL_2:.*]] = arith.extsi %[[VAL_0]] : i16 to i32
+// CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_1]] : i16 to i32
+// CHECK:           %[[VAL_4:.*]] = arith.addi %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i16
+// CHECK:           return %[[VAL_5]] : i16
+// CHECK:         }
+
+short add_i16(short a, short b) {
+  return a + b;
+}
+
+// CHECK-LABEL:   func.func @add_i32(
 // CHECK-SAME:                  %[[VAL_0:.*]]: i32,
 // CHECK-SAME:                  %[[VAL_1:.*]]: i32) -> i32
 // CHECK:           %[[ADD:.*]] = arith.addi %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK:           return %[[ADD]] : i32
 // CHECK:         }
 
-int f0(int a, int b) {
+int add_i32(int a, int b) {
   return a + b;
 }
 
-// CHECK-LABEL:   func.func @f1(
+// CHECK-LABEL:   func.func @add_i64(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i64,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i64) -> i64
+// CHECK:           %[[VAL_2:.*]] = arith.addi %[[VAL_0]], %[[VAL_1]] : i64
+// CHECK:           return %[[VAL_2]] : i64
+// CHECK:         }
+
+long add_i64(long a, long b) {
+  return a + b;
+}
+
+// CHECK-LABEL:   func.func @add_f32(
 // CHECK-SAME:                  %[[VAL_0:.*]]: f32,
 // CHECK-SAME:                  %[[VAL_1:.*]]: f32) -> f32
 // CHECK:           %[[ADD:.*]] = arith.addf %[[VAL_0]], %[[VAL_1]] : f32
 // CHECK:           return %[[ADD]] : f32
 // CHECK:         }
 
-float f1(float a, float b) {
+float add_f32(float a, float b) {
   return a + b;
 }
 
-// CHECK-LABEL:   func.func @f2(
+// CHECK-LABEL:   func.func @add_f64(
+// CHECK-SAME:                       %[[VAL_0:.*]]: f32,
+// CHECK-SAME:                       %[[VAL_1:.*]]: f32) -> f32
+// CHECK:           %[[VAL_2:.*]] = arith.addf %[[VAL_0]], %[[VAL_1]] : f32
+// CHECK:           return %[[VAL_2]] : f32
+// CHECK:         }
+
+float add_f64(float a, float b) {
+  return a + b;
+}
+
+// CHECK-LABEL:   func.func @add_vi8(
+// CHECK-SAME:                  %[[VAL_0:.*]]: vector<3xi8>,
+// CHECK-SAME:                  %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
+// CHECK:           %[[ADD:.*]] = arith.addi %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
+// CHECK:           return %[[ADD]] : vector<3xi8>
+// CHECK:         }
+
+char_vec add_vi8(char_vec a, char_vec b) {
+  return a + b;
+}
+
+// CHECK-LABEL:   func.func @add_vi16(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi16>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
+// CHECK:           %[[VAL_2:.*]] = arith.addi %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
+// CHECK:           return %[[VAL_2]] : vector<3xi16>
+// CHECK:         }
+
+short_vec add_vi16(short_vec a, short_vec b) {
+  return a + b;
+}
+
+// CHECK-LABEL:   func.func @add_vi32(
 // CHECK-SAME:                  %[[VAL_0:.*]]: vector<3xi32>,
 // CHECK-SAME:                  %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
 // CHECK:           %[[ADD:.*]] = arith.addi %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
 // CHECK:           return %[[ADD]] : vector<3xi32>
 // CHECK:         }
 
-int_vec f2(int_vec a, int_vec b) {
+int_vec add_vi32(int_vec a, int_vec b) {
   return a + b;
 }
 
-// CHECK-LABEL:   func.func @f4(
+// CHECK-LABEL:   func.func @add_vi64(
+// CHECK-SAME:                        %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
+// CHECK:           %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
+// CHECK:           %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
+// CHECK:           %[[VAL_4:.*]] = arith.addi %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
+// CHECK:           return %[[VAL_4]] : vector<3xi64>
+// CHECK:         }
+
+long_vec add_vi64(long_vec a, long_vec b) {
+  return a + b;
+}
+
+// CHECK-LABEL:   func.func @add_vf32(
 // CHECK-SAME:                  %[[VAL_0:.*]]: vector<3xf32>,
 // CHECK-SAME:                  %[[VAL_1:.*]]: vector<3xf32>) -> vector<3xf32>
 // CHECK:           %[[ADD:.*]] = arith.addf %[[VAL_0]], %[[VAL_1]] : vector<3xf32>
 // CHECK:           return %[[ADD]] : vector<3xf32>
 // CHECK:         }
 
-float_vec f4(float_vec a, float_vec b) {
+float_vec add_vf32(float_vec a, float_vec b) {
+  return a + b;
+}
+
+// CHECK-LABEL:   func.func @add_vf64(
+// CHECK-SAME:                        %[[VAL_0:.*]]: memref<?xvector<3xf64>>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: memref<?xvector<3xf64>>) -> vector<3xf64>
+// CHECK:           %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xf64>>
+// CHECK:           %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xf64>>
+// CHECK:           %[[VAL_4:.*]] = arith.addf %[[VAL_2]], %[[VAL_3]] : vector<3xf64>
+// CHECK:           return %[[VAL_4]] : vector<3xf64>
+// CHECK:         }
+
+double_vec add_vf64(double_vec a, double_vec b) {
   return a + b;
 }

--- a/polygeist/tools/cgeist/Test/Verification/ptrarith.c
+++ b/polygeist/tools/cgeist/Test/Verification/ptrarith.c
@@ -1,0 +1,76 @@
+// RUN: cgeist %s --function=* -S | FileCheck %s
+
+#include <stddef.h>
+
+// CHECK-LABEL:   func.func @f0(
+// CHECK-SAME:                  %[[VAL_0:.*]]: memref<?xi32>,
+// CHECK-SAME:                  %[[VAL_1:.*]]: i32) -> memref<?xi32>
+// CHECK:           %[[INDEX:.*]] = arith.index_cast %[[VAL_1]] : i32 to index
+// CHECK:           %[[ADD:.*]] = "polygeist.subindex"(%[[VAL_0]], %[[INDEX]]) : (memref<?xi32>, index) -> memref<?xi32>
+// CHECK:           return %[[ADD]] : memref<?xi32>
+// CHECK:         }
+
+int *f0(int *ptr, int index) {
+  return ptr + index;
+}
+
+// CHECK-LABEL:   func.func @f1(
+// CHECK-SAME:                  %[[VAL_0:.*]]: i64,
+// CHECK-SAME:                  %[[VAL_1:.*]]: memref<?xi32>) -> memref<?xi32>
+// CHECK:           %[[INDEX:.*]] = arith.index_castui %[[VAL_0]] : i64 to index
+// CHECK:           %[[ADD:.*]] = "polygeist.subindex"(%[[VAL_1]], %[[INDEX]]) : (memref<?xi32>, index) -> memref<?xi32>
+// CHECK:           return %[[ADD]] : memref<?xi32>
+// CHECK:         }
+
+int *f1(size_t index, int *ptr) {
+  return index + ptr;
+}
+
+// CHECK-LABEL:   func.func @f2(
+// CHECK-SAME:                  %[[VAL_0:.*]]: i64) -> !llvm.ptr<i8>
+// CHECK:           %[[PTR_0:.*]] = llvm.inttoptr %[[VAL_0]] : i64 to !llvm.ptr<i8>
+// CHECK:           return %[[PTR_0]] : !llvm.ptr<i8>
+// CHECK:         }
+
+void *f2(size_t index) {
+  return ((char*) NULL) + index;
+}
+
+// CHECK-LABEL:   func.func @f3(
+// CHECK-SAME:                  %[[VAL_0:.*]]: memref<?xi32>,
+// CHECK-SAME:                  %[[VAL_1:.*]]: i64) -> memref<?xi32>
+// CHECK:           %[[I64_0:.*]] = arith.constant 0 : i64
+// CHECK:           %[[NEG:.*]] = arith.subi %[[I64_0]], %[[VAL_1]] : i64
+// CHECK:           %[[INDEX:.*]] = arith.index_castui %[[NEG]] : i64 to index
+// CHECK:           %[[ADD:.*]] = "polygeist.subindex"(%[[VAL_0]], %[[INDEX]]) : (memref<?xi32>, index) -> memref<?xi32>
+// CHECK:           return %[[ADD]] : memref<?xi32>
+// CHECK:         }
+
+int *f3(int *ptr, size_t index) {
+  return ptr - index;
+}
+
+// CHECK-LABEL:   func.func @f4(
+// CHECK-SAME:                  %[[VAL_0:.*]]: !llvm.ptr<i8>,
+// CHECK-SAME:                  %[[VAL_1:.*]]: i64) -> !llvm.ptr<i8>
+// CHECK:           %[[ADD:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<i8>, i64) -> !llvm.ptr<i8>
+// CHECK:           return %[[ADD]] : !llvm.ptr<i8>
+// CHECK:         }
+
+void *f4(void *ptr, size_t index) {
+  return ptr + index;
+}
+
+// CHECK-LABEL:   func.func @f5(
+// CHECK-SAME:                  %[[VAL_0:.*]]: !llvm.ptr<func<i32 ()>>,
+// CHECK-SAME:                  %[[VAL_1:.*]]: i64) -> i32
+// CHECK:           %[[VOIDPTR_0:.*]] = llvm.bitcast %[[VAL_0]] : !llvm.ptr<func<i32 ()>> to !llvm.ptr<i8>
+// CHECK:           %[[PTR:.*]] = llvm.getelementptr %[[VOIDPTR_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<i8>, i64) -> !llvm.ptr<i8>
+// CHECK:           %[[FUNCPTR:.*]] = llvm.bitcast %[[PTR]] : !llvm.ptr<i8> to !llvm.ptr<func<i32 ()>>
+// CHECK:           %[[RES:.*]] = llvm.call %[[FUNCPTR]]() : () -> i32
+// CHECK:           return %[[RES]] : i32
+// CHECK:         }
+
+int f5(int (*ptr)(void), size_t index) {
+  return (ptr + index)();
+}

--- a/polygeist/tools/cgeist/Test/Verification/sub.c
+++ b/polygeist/tools/cgeist/Test/Verification/sub.c
@@ -1,0 +1,80 @@
+// RUN: cgeist %s --function=* -S | FileCheck %s
+
+#include <stddef.h>
+
+typedef int int_vec __attribute__((ext_vector_type(3)));
+typedef float float_vec __attribute__((ext_vector_type(3)));
+
+// CHECK-LABEL:   func.func @f0(
+// CHECK-SAME:                  %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                  %[[VAL_1:.*]]: i32) -> i32
+// CHECK:           %[[SUB:.*]] = arith.subi %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           return %[[SUB]] : i32
+// CHECK:         }
+
+int f0(int a, int b) {
+  return a - b;
+}
+
+// CHECK-LABEL:   func.func @f1(
+// CHECK-SAME:                  %[[VAL_0:.*]]: f32,
+// CHECK-SAME:                  %[[VAL_1:.*]]: f32) -> f32
+// CHECK:           %[[SUB:.*]] = arith.subf %[[VAL_0]], %[[VAL_1]] : f32
+// CHECK:           return %[[SUB]] : f32
+// CHECK:         }
+
+float f1(float a, float b) {
+  return a - b;
+}
+
+// CHECK-LABEL:   func.func @f2(
+// CHECK-SAME:                  %[[VAL_0:.*]]: vector<3xi32>,
+// CHECK-SAME:                  %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
+// CHECK:           %[[SUB:.*]] = arith.subi %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
+// CHECK:           return %[[SUB]] : vector<3xi32>
+// CHECK:         }
+
+int_vec f2(int_vec a, int_vec b) {
+  return a - b;
+}
+
+// CHECK-LABEL:   func.func @f3(
+// CHECK-SAME:                  %[[VAL_0:.*]]: vector<3xf32>,
+// CHECK-SAME:                  %[[VAL_1:.*]]: vector<3xf32>) -> vector<3xf32>
+// CHECK:           %[[SUB:.*]] = arith.subf %[[VAL_0]], %[[VAL_1]] : vector<3xf32>
+// CHECK:           return %[[SUB]] : vector<3xf32>
+// CHECK:         }
+
+float_vec f3(float_vec a, float_vec b) {
+  return a - b;
+}
+
+// CHECK-LABEL:   func.func @f4(
+// CHECK-SAME:                  %[[VAL_0:.*]]: !llvm.ptr<i8>,
+// CHECK-SAME:                  %[[VAL_1:.*]]: !llvm.ptr<i8>) -> i64
+// CHECK:           %[[INT_0:.*]] = llvm.ptrtoint %[[VAL_0]] : !llvm.ptr<i8> to i64
+// CHECK:           %[[INT_1:.*]] = llvm.ptrtoint %[[VAL_1]] : !llvm.ptr<i8> to i64
+// CHECK:           %[[SUB:.*]] = arith.subi %[[INT_0]], %[[INT_1]] : i64
+// CHECK:           return %[[SUB]] : i64
+// CHECK:         }
+
+size_t f4(char *a, char *b) {
+  return a - b;
+}
+
+// CHECK-LABEL:   func.func @f5(
+// CHECK-SAME:                  %[[VAL_0:.*]]: memref<?xf32>,
+// CHECK-SAME:                  %[[VAL_1:.*]]: memref<?xf32>) -> i64
+// CHECK:           %[[I64_0:.*]] = arith.constant 4 : i64
+// CHECK:           %[[PTR_0:.*]] = "polygeist.memref2pointer"(%[[VAL_0]]) : (memref<?xf32>) -> !llvm.ptr<f32>
+// CHECK:           %[[INT_0:.*]] = llvm.ptrtoint %[[PTR_0]] : !llvm.ptr<f32> to i64
+// CHECK:           %[[PTR_1:.*]] = "polygeist.memref2pointer"(%[[VAL_1]]) : (memref<?xf32>) -> !llvm.ptr<f32>
+// CHECK:           %[[INT_1:.*]] = llvm.ptrtoint %[[PTR_1]] : !llvm.ptr<f32> to i64
+// CHECK:           %[[DIFF:.*]] = arith.subi %[[INT_0]], %[[INT_1]] : i64
+// CHECK:           %[[SUB:.*]] = arith.divsi %[[DIFF]], %[[I64_0]] : i64
+// CHECK:           return %[[SUB]] : i64
+// CHECK:         }
+
+size_t f5(float *a, float *b) {
+  return a - b;
+}

--- a/polygeist/tools/cgeist/Test/Verification/sub.c
+++ b/polygeist/tools/cgeist/Test/Verification/sub.c
@@ -1,68 +1,170 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
 
 #include <stddef.h>
 
+typedef char char_vec __attribute__((ext_vector_type(3)));
+typedef short short_vec __attribute__((ext_vector_type(3)));
 typedef int int_vec __attribute__((ext_vector_type(3)));
+typedef long long_vec __attribute__((ext_vector_type(3)));
 typedef float float_vec __attribute__((ext_vector_type(3)));
+typedef double double_vec __attribute__((ext_vector_type(3)));
 
-// CHECK-LABEL:   func.func @f0(
-// CHECK-SAME:                  %[[VAL_0:.*]]: i32,
-// CHECK-SAME:                  %[[VAL_1:.*]]: i32) -> i32
-// CHECK:           %[[SUB:.*]] = arith.subi %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK:           return %[[SUB]] : i32
+// CHECK-LABEL:   func.func @sub_i8(
+// CHECK-SAME:                      %[[VAL_0:.*]]: i8,
+// CHECK-SAME:                      %[[VAL_1:.*]]: i8) -> i8
+// CHECK:           %[[VAL_2:.*]] = arith.extsi %[[VAL_0]] : i8 to i32
+// CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_1]] : i8 to i32
+// CHECK:           %[[VAL_4:.*]] = arith.subi %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i8
+// CHECK:           return %[[VAL_5]] : i8
 // CHECK:         }
 
-int f0(int a, int b) {
+char sub_i8(char a, char b) {
   return a - b;
 }
 
-// CHECK-LABEL:   func.func @f1(
+// CHECK-LABEL:   func.func @sub_i16(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i16,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i16) -> i16
+// CHECK:           %[[VAL_2:.*]] = arith.extsi %[[VAL_0]] : i16 to i32
+// CHECK:           %[[VAL_3:.*]] = arith.extsi %[[VAL_1]] : i16 to i32
+// CHECK:           %[[VAL_4:.*]] = arith.subi %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK:           %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i16
+// CHECK:           return %[[VAL_5]] : i16
+// CHECK:         }
+
+short sub_i16(short a, short b) {
+  return a - b;
+}
+
+// CHECK-LABEL:   func.func @sub_i32(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i32) -> i32
+// CHECK:           %[[VAL_2:.*]] = arith.subi %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK:           return %[[VAL_2]] : i32
+// CHECK:         }
+
+int sub_i32(int a, int b) {
+  return a - b;
+}
+
+// CHECK-LABEL:   func.func @sub_i64(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i64,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i64) -> i64
+// CHECK:           %[[VAL_2:.*]] = arith.subi %[[VAL_0]], %[[VAL_1]] : i64
+// CHECK:           return %[[VAL_2]] : i64
+// CHECK:         }
+
+long sub_i64(long a, long b) {
+  return a - b;
+}
+
+// CHECK-LABEL:   func.func @sub_f32(
 // CHECK-SAME:                  %[[VAL_0:.*]]: f32,
 // CHECK-SAME:                  %[[VAL_1:.*]]: f32) -> f32
 // CHECK:           %[[SUB:.*]] = arith.subf %[[VAL_0]], %[[VAL_1]] : f32
 // CHECK:           return %[[SUB]] : f32
 // CHECK:         }
 
-float f1(float a, float b) {
+float sub_f32(float a, float b) {
   return a - b;
 }
 
-// CHECK-LABEL:   func.func @f2(
-// CHECK-SAME:                  %[[VAL_0:.*]]: vector<3xi32>,
-// CHECK-SAME:                  %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
-// CHECK:           %[[SUB:.*]] = arith.subi %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
-// CHECK:           return %[[SUB]] : vector<3xi32>
+// CHECK-LABEL:   func.func @sub_f64(
+// CHECK-SAME:                       %[[VAL_0:.*]]: f32,
+// CHECK-SAME:                       %[[VAL_1:.*]]: f32) -> f32
+// CHECK:           %[[VAL_2:.*]] = arith.subf %[[VAL_0]], %[[VAL_1]] : f32
+// CHECK:           return %[[VAL_2]] : f32
 // CHECK:         }
 
-int_vec f2(int_vec a, int_vec b) {
+float sub_f64(float a, float b) {
   return a - b;
 }
 
-// CHECK-LABEL:   func.func @f3(
+// CHECK-LABEL:   func.func @sub_vi8(
+// CHECK-SAME:                       %[[VAL_0:.*]]: vector<3xi8>,
+// CHECK-SAME:                       %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
+// CHECK:           %[[VAL_2:.*]] = arith.subi %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
+// CHECK:           return %[[VAL_2]] : vector<3xi8>
+// CHECK:         }
+
+char_vec sub_vi8(char_vec a, char_vec b) {
+  return a - b;
+}
+
+// CHECK-LABEL:   func.func @sub_vi16(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi16>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
+// CHECK:           %[[VAL_2:.*]] = arith.subi %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
+// CHECK:           return %[[VAL_2]] : vector<3xi16>
+// CHECK:         }
+
+short_vec sub_vi16(short_vec a, short_vec b) {
+  return a - b;
+}
+
+// CHECK-LABEL:   func.func @sub_vi32(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi32>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
+// CHECK:           %[[VAL_2:.*]] = arith.subi %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
+// CHECK:           return %[[VAL_2]] : vector<3xi32>
+// CHECK:         }
+
+int_vec sub_vi32(int_vec a, int_vec b) {
+  return a - b;
+}
+
+// CHECK-LABEL:   func.func @sub_vi64(
+// CHECK-SAME:                        %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
+// CHECK:           %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
+// CHECK:           %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
+// CHECK:           %[[VAL_4:.*]] = arith.subi %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
+// CHECK:           return %[[VAL_4]] : vector<3xi64>
+// CHECK:         }
+
+long_vec sub_vi64(long_vec a, long_vec b) {
+  return a - b;
+}
+
+// CHECK-LABEL:   func.func @sub_vf32(
 // CHECK-SAME:                  %[[VAL_0:.*]]: vector<3xf32>,
 // CHECK-SAME:                  %[[VAL_1:.*]]: vector<3xf32>) -> vector<3xf32>
 // CHECK:           %[[SUB:.*]] = arith.subf %[[VAL_0]], %[[VAL_1]] : vector<3xf32>
 // CHECK:           return %[[SUB]] : vector<3xf32>
 // CHECK:         }
 
-float_vec f3(float_vec a, float_vec b) {
+float_vec sub_vf32(float_vec a, float_vec b) {
   return a - b;
 }
 
-// CHECK-LABEL:   func.func @f4(
-// CHECK-SAME:                  %[[VAL_0:.*]]: !llvm.ptr<i8>,
-// CHECK-SAME:                  %[[VAL_1:.*]]: !llvm.ptr<i8>) -> i64
-// CHECK:           %[[INT_0:.*]] = llvm.ptrtoint %[[VAL_0]] : !llvm.ptr<i8> to i64
-// CHECK:           %[[INT_1:.*]] = llvm.ptrtoint %[[VAL_1]] : !llvm.ptr<i8> to i64
-// CHECK:           %[[SUB:.*]] = arith.subi %[[INT_0]], %[[INT_1]] : i64
-// CHECK:           return %[[SUB]] : i64
+// CHECK-LABEL:   func.func @sub_vf64(
+// CHECK-SAME:                        %[[VAL_0:.*]]: memref<?xvector<3xf64>>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: memref<?xvector<3xf64>>) -> vector<3xf64>
+// CHECK:           %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xf64>>
+// CHECK:           %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xf64>>
+// CHECK:           %[[VAL_4:.*]] = arith.subf %[[VAL_2]], %[[VAL_3]] : vector<3xf64>
+// CHECK:           return %[[VAL_4]] : vector<3xf64>
 // CHECK:         }
 
-size_t f4(char *a, char *b) {
+double_vec sub_vf64(double_vec a, double_vec b) {
   return a - b;
 }
 
-// CHECK-LABEL:   func.func @f5(
+// CHECK-LABEL:   func.func @ptr_diff_i8(
+// CHECK-SAME:                  %[[VAL_0:.*]]: !llvm.ptr<i8>,
+// CHECK-SAME:                  %[[VAL_1:.*]]: !llvm.ptr<i8>) -> i64
+// CHECK:           %[[VAL_2:.*]] = llvm.ptrtoint %[[VAL_0]] : !llvm.ptr<i8> to i64
+// CHECK:           %[[VAL_3:.*]] = llvm.ptrtoint %[[VAL_1]] : !llvm.ptr<i8> to i64
+// CHECK:           %[[VAL_4:.*]] = arith.subi %[[VAL_2]], %[[VAL_3]] : i64
+// CHECK:           return %[[VAL_4]] : i64
+// CHECK:         }
+
+size_t ptr_diff_i8(char *a, char *b) {
+  return a - b;
+}
+
+// CHECK-LABEL:   func.func @ptr_diff_f32(
 // CHECK-SAME:                  %[[VAL_0:.*]]: memref<?xf32>,
 // CHECK-SAME:                  %[[VAL_1:.*]]: memref<?xf32>) -> i64
 // CHECK:           %[[I64_0:.*]] = arith.constant 4 : i64
@@ -75,6 +177,6 @@ size_t f4(char *a, char *b) {
 // CHECK:           return %[[SUB]] : i64
 // CHECK:         }
 
-size_t f5(float *a, float *b) {
+size_t ptr_diff_f32(float *a, float *b) {
   return a - b;
 }


### PR DESCRIPTION
Enable addition/subtraction of floating point vectors.

Make integer and pointer addition commutative.

Instead of generating an incorrect `getelementptr` instruction with a `null` pointer argument, generate an `inttoptr` using the index as an argument.

Use polygeist.subindex instead of
polygeist.memref2pointer+llvm.getelementptr+polygeist.pointer2memref when subtracting an index to a pointer.

Cast pointers to void and functions to i8 before operating.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>