### PR TITLE
[SYCL] Fix ODS filtering bug when platforms have multiple devices

### DIFF
--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -153,8 +153,10 @@ std::vector<platform> platform_impl::get_platforms() {
 // to distinguish the case where we are working with ONEAPI_DEVICE_SELECTOR
 // in the places where the functionality diverges between these two
 // environment variables.
+// The return value is a vector that represents the indices of the chosen 
+// devices.
 template <typename ListT, typename FilterT>
-static int filterDeviceFilter(std::vector<RT::PiDevice> &PiDevices,
+static std::vector<int> filterDeviceFilter(std::vector<RT::PiDevice> &PiDevices,
                               RT::PiPlatform Platform, ListT *FilterList) {
 
   constexpr bool is_ods_target = std::is_same_v<FilterT, ods_target>;
@@ -184,14 +186,16 @@ static int filterDeviceFilter(std::vector<RT::PiDevice> &PiDevices,
   // in the if statement above because it will then be out of scope in the rest
   // of the function
   std::map<RT::PiDevice *, bool> Blacklist;
+  std::vector<int> original_indices;
 
   std::vector<plugin> &Plugins = RT::initialize();
   auto It =
       std::find_if(Plugins.begin(), Plugins.end(), [Platform](plugin &Plugin) {
         return Plugin.containsPiPlatform(Platform);
       });
-  if (It == Plugins.end())
-    return -1;
+  if (It == Plugins.end()) {
+    return original_indices;
+  }
   plugin &Plugin = *It;
   backend Backend = Plugin.getBackend();
   int InsertIDx = 0;
@@ -199,7 +203,6 @@ static int filterDeviceFilter(std::vector<RT::PiDevice> &PiDevices,
   // backend
   std::lock_guard<std::mutex> Guard(*Plugin.getPluginMutex());
   int DeviceNum = Plugin.getStartingDeviceId(Platform);
-  int StartingNum = DeviceNum;
   for (RT::PiDevice Device : PiDevices) {
     RT::PiDeviceType PiDevType;
     Plugin.call<PiApiKind::piDeviceGetInfo>(Device, PI_DEVICE_INFO_TYPE,
@@ -223,6 +226,7 @@ static int filterDeviceFilter(std::vector<RT::PiDevice> &PiDevices,
               if (!Blacklist[&Device]) {        // ensure it is not blacklisted
                 if (!Filter.IsNegativeTarget) { // is filter positive?
                   PiDevices[InsertIDx++] = Device;
+                  original_indices.push_back(DeviceNum);
                 } else {
                   // Filter is negative and the device matches the filter so
                   // blacklist the device.
@@ -231,6 +235,7 @@ static int filterDeviceFilter(std::vector<RT::PiDevice> &PiDevices,
               }
             } else { // dealing with SYCL_DEVICE_FILTER
               PiDevices[InsertIDx++] = Device;
+              original_indices.push_back(DeviceNum);
             }
             break;
           }
@@ -241,6 +246,7 @@ static int filterDeviceFilter(std::vector<RT::PiDevice> &PiDevices,
               if (!Blacklist[&Device]) {
                 if (!Filter.IsNegativeTarget) {
                   PiDevices[InsertIDx++] = Device;
+                  original_indices.push_back(DeviceNum);
                 } else {
                   // Filter is negative and the device matches the filter so
                   // blacklist the device.
@@ -249,6 +255,7 @@ static int filterDeviceFilter(std::vector<RT::PiDevice> &PiDevices,
               }
             } else {
               PiDevices[InsertIDx++] = Device;
+              original_indices.push_back(DeviceNum);
             }
             break;
           }
@@ -262,7 +269,7 @@ static int filterDeviceFilter(std::vector<RT::PiDevice> &PiDevices,
   // to assign a unique device id number across platforms that belong to
   // the same backend. For example, opencl:cpu:0, opencl:acc:1, opencl:gpu:2
   Plugin.setLastDeviceId(Platform, DeviceNum);
-  return StartingNum;
+  return original_indices;
 }
 
 std::shared_ptr<device_impl>
@@ -307,7 +314,7 @@ static bool supportsPartitionProperty(const device &dev,
 
 static std::vector<device> amendDeviceAndSubDevices(
     backend PlatformBackend, std::vector<device> &DeviceList,
-    ods_target_list *OdsTargetList, int PlatformDeviceIndex,
+    ods_target_list *OdsTargetList, const std::vector<int>& original_indices,
     PlatformImplPtr PlatformImpl) {
   constexpr info::partition_property partitionProperty =
       info::partition_property::partition_by_affinity_domain;
@@ -335,7 +342,7 @@ static std::vector<device> amendDeviceAndSubDevices(
 
         } else if (target.DeviceNum) { // opencl:0
           deviceMatch =
-              (target.DeviceNum.value() == PlatformDeviceIndex + (int)i);
+              (target.DeviceNum.value() == original_indices[i]);
         }
 
         if (deviceMatch) {
@@ -437,7 +444,6 @@ static std::vector<device> amendDeviceAndSubDevices(
       }
     } // /for
   }   // /for
-
   return FinalResult;
 }
 
@@ -500,17 +506,17 @@ platform_impl::get_devices(info::device_type DeviceType) const {
   // The first step is to filter out devices that are not compatible with
   // SYCL_DEVICE_FILTER or ONEAPI_DEVICE_SELECTOR. This is also the mechanism by
   // which top level device ids are assigned.
-  int PlatformDeviceIndex;
+  std::vector<int> PlatformDeviceIndices;
   if (OdsTargetList) {
     if (FilterList) {
       throw sycl::exception(sycl::make_error_code(errc::invalid),
                             "ONEAPI_DEVICE_SELECTOR cannot be used in "
                             "conjunction with SYCL_DEVICE_FILTER");
     }
-    PlatformDeviceIndex = filterDeviceFilter<ods_target_list, ods_target>(
+    PlatformDeviceIndices = filterDeviceFilter<ods_target_list, ods_target>(
         PiDevices, MPlatform, OdsTargetList);
   } else if (FilterList) {
-    PlatformDeviceIndex = filterDeviceFilter<device_filter_list, device_filter>(
+    PlatformDeviceIndices = filterDeviceFilter<device_filter_list, device_filter>(
         PiDevices, MPlatform, FilterList);
   }
 
@@ -533,7 +539,7 @@ platform_impl::get_devices(info::device_type DeviceType) const {
   // Otherwise, our last step is to revisit the devices, possibly replacing
   // them with subdevices (which have been ignored until now)
   return amendDeviceAndSubDevices(Backend, Res, OdsTargetList,
-                                  PlatformDeviceIndex, PlatformImpl);
+                                  PlatformDeviceIndices, PlatformImpl);
 }
 
 bool platform_impl::has_extension(const std::string &ExtensionName) const {


### PR DESCRIPTION
There is a filtering bug when ODS environment variable is used in environments where there are platforms with more than one device. One manifestation of this bug occurs in the form of valid devices being incorrectly excluded from the list of available devices. This PR attempts to fix this.