### PR TITLE
[SYCL][HIP] Add `cl_khr_fp64` in device extensions

### DIFF
--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -1655,9 +1655,16 @@ pi_result hip_piDeviceGetInfo(pi_device device, pi_device_info param_name,
     // DEVICELIB_ASSERT extension is set so fallback assert
     // postprocessing is NOP. HIP 4.3 docs indicate support for
     // native asserts are in progress
-    std::string SupportedExtensions = "cl_khr_fp64 ";
+    std::string SupportedExtensions = "";
     SupportedExtensions += PI_DEVICE_INFO_EXTENSION_DEVICELIB_ASSERT;
     SupportedExtensions += " ";
+
+    hipDeviceProp_t props;
+    sycl::detail::pi::assertion(hipGetDeviceProperties(&props, device->get()) ==
+                                hipSuccess);
+    if (props.arch.hasDoubles) {
+      SupportedExtensions += "cl_khr_fp64 ";
+    }
 
     return getInfo(param_value_size, param_value, param_value_size_ret,
                    SupportedExtensions.c_str());

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -1655,7 +1655,7 @@ pi_result hip_piDeviceGetInfo(pi_device device, pi_device_info param_name,
     // DEVICELIB_ASSERT extension is set so fallback assert
     // postprocessing is NOP. HIP 4.3 docs indicate support for
     // native asserts are in progress
-    std::string SupportedExtensions = "";
+    std::string SupportedExtensions = "cl_khr_fp64 ";
     SupportedExtensions += PI_DEVICE_INFO_EXTENSION_DEVICELIB_ASSERT;
     SupportedExtensions += " ";
 


### PR DESCRIPTION
HIP plugin didn't have `cl_khr_fp64` in SupportedExtensions, so any kernel uses fp64 cannot be launched because `ProgramManager::getBuiltPIProgram` checks `has(aspect::fp64)` which is actually `has_extension("cl_khr_fp64")`.