### PR TITLE
[SYCL-MLIR] Remove Memref2PointerIndex canonicalization pattern

### DIFF
--- a/polygeist/lib/polygeist/Ops.cpp
+++ b/polygeist/lib/polygeist/Ops.cpp
@@ -1159,44 +1159,6 @@ public:
     return success();
   }
 };
-/// Simplify memref2pointer(subindex(x)) to getelementptr(memref2pointer(x))
-class Memref2PointerIndex final : public OpRewritePattern<Memref2PointerOp> {
-public:
-  using OpRewritePattern<Memref2PointerOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(Memref2PointerOp op,
-                                PatternRewriter &rewriter) const override {
-    auto src = op.getSource().getDefiningOp<SubIndexOp>();
-    if (!src)
-      return failure();
-
-    if (src.getSource().getType().cast<MemRefType>().getShape().size() != 1)
-      return failure();
-
-    auto MET = src.getSource().getType().cast<MemRefType>().getElementType();
-    if (MET.isa<LLVM::LLVMStructType>())
-      return failure();
-
-    Value idx[] = {src.getIndex()};
-    auto PET = op.getType().cast<LLVM::LLVMPointerType>().getElementType();
-    if (PET != MET) {
-      auto ps = rewriter.create<polygeist::TypeSizeOp>(
-          op.getLoc(), rewriter.getIndexType(), mlir::TypeAttr::get(PET));
-      auto ms = rewriter.create<polygeist::TypeSizeOp>(
-          op.getLoc(), rewriter.getIndexType(), mlir::TypeAttr::get(MET));
-      idx[0] = rewriter.create<MulIOp>(op.getLoc(), idx[0], ms);
-      idx[0] = rewriter.create<DivUIOp>(op.getLoc(), idx[0], ps);
-    }
-    idx[0] = rewriter.create<arith::IndexCastOp>(op.getLoc(),
-                                                 rewriter.getI64Type(), idx[0]);
-    rewriter.replaceOpWithNewOp<LLVM::GEPOp>(
-        op, op.getType(),
-        rewriter.create<Memref2PointerOp>(op.getLoc(), op.getType(),
-                                          src.getSource()),
-        idx);
-    return success();
-  }
-};
 
 /// Simplify pointer2memref(memref2pointer(x)) to cast(x)
 template <typename T>
@@ -1433,8 +1395,7 @@ OpFoldResult Memref2PointerOp::fold(ArrayRef<Attribute> operands) {
 
 void Memref2PointerOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                                    MLIRContext *context) {
-  results.insert<Memref2Pointer2MemrefCast, Memref2PointerIndex,
-                 SetSimplification<LLVM::MemsetOp>,
+  results.insert<Memref2Pointer2MemrefCast, SetSimplification<LLVM::MemsetOp>,
                  CopySimplification<LLVM::MemcpyOp>,
                  CopySimplification<LLVM::MemmoveOp>>(context);
 }

--- a/polygeist/test/polygeist-opt/canonicalization.mlir
+++ b/polygeist/test/polygeist-opt/canonicalization.mlir
@@ -41,15 +41,3 @@ func.func @main(%arg0 : index) -> memref<1000xi32> {
 // CHECK-NEXT:     %1 = "polygeist.pointer2memref"(%0) : (!llvm.ptr<i32>) -> memref<?xi32>
 // CHECK-NEXT:     return %1 : memref<?xi32>
 // CHECK-NEXT:   }
-
-func.func @memref2ptr(%arg0: memref<10xi32>) -> !llvm.ptr<i8> {
-     %c2 = arith.constant 2 : index
-     %0 = "polygeist.subindex"(%arg0, %c2) : (memref<10xi32>, index) -> memref<?xi32>
-     %1 = "polygeist.memref2pointer"(%0) : (memref<?xi32>) -> !llvm.ptr<i8>
-     return %1 : !llvm.ptr<i8>
-}
-// CHECK: func.func @memref2ptr(%arg0: memref<10xi32>) -> !llvm.ptr<i8> {
-// CHECK-NEXT: %0 = "polygeist.memref2pointer"(%arg0) : (memref<10xi32>) -> !llvm.ptr<i8>
-// CHECK-NEXT: %1 = llvm.getelementptr %0[8] : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
-// CHECK-NEXT: return %1 : !llvm.ptr<i8>
-// CHECK-NEXT: }

--- a/polygeist/test/polygeist-opt/invalid_canonicalization.mlir
+++ b/polygeist/test/polygeist-opt/invalid_canonicalization.mlir
@@ -46,19 +46,3 @@ func.func @SimplifySubIndexUsers(%arg0: memref<?x!llvm.struct<(i32)>>) -> memref
 }
 
 // -----
-
-// CHECK:  func.func @Memref2PointerIndex([[A0:%.*]]: memref<?x!llvm.struct<(i32, i32)>>) -> !llvm.ptr<i32> {
-// CHECK-NEXT:    [[C1:%.*]] = arith.constant 1 : index
-// CHECK-NEXT:    [[T0:%.*]] = "polygeist.subindex"([[A0]], [[C1]]) : (memref<?x!llvm.struct<(i32, i32)>>, index) -> memref<?xi32>
-// CHECK-NEXT:    [[T1:%.*]] = "polygeist.memref2pointer"([[T0]]) : (memref<?xi32>) -> !llvm.ptr<i32>
-// CHECK-NEXT:    return [[T1]] : !llvm.ptr<i32>
-// CHECK-NEXT:  }
-
-func.func @Memref2PointerIndex(%arg0: memref<?x!llvm.struct<(i32, i32)>>) -> !llvm.ptr<i32> {
-  %c1 = arith.constant 1 : index
-  %0 = "polygeist.subindex"(%arg0, %c1) : (memref<?x!llvm.struct<(i32, i32)>>, index) -> memref<?xi32>
-  %1 = "polygeist.memref2pointer"(%0) : (memref<?xi32>) -> !llvm.ptr<i32>
-  return %1 : !llvm.ptr<i32>
-}
-
-// -----

--- a/polygeist/tools/cgeist/Test/Verification/ptraddsub.c
+++ b/polygeist/tools/cgeist/Test/Verification/ptraddsub.c
@@ -11,18 +11,20 @@ int* add (int* in) {
 	return &in[7];
 }
 
-// CHECK:   func @sub() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-DAG:     %c4_i64 = arith.constant 4 : i64
-// CHECK-NEXT:     %alloca = memref.alloca() : memref<10xi32>
-// CHECK-NEXT:     %0 = "polygeist.memref2pointer"(%alloca) : (memref<10xi32>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     %1 = llvm.getelementptr %0[7] : (!llvm.ptr<i32>) -> !llvm.ptr<i32>
-// CHECK-DAG:     %[[i3:.+]] = llvm.ptrtoint %0 : !llvm.ptr<i32> to i64
-// CHECK-DAG:     %[[i4:.+]] = llvm.ptrtoint %1 : !llvm.ptr<i32> to i64
-// CHECK-NEXT:     %4 = arith.subi %[[i4]], %[[i3]] : i64
-// CHECK-NEXT:     %5 = arith.divsi %4, %c4_i64 : i64
-// CHECK-NEXT:     %6 = arith.trunci %5 : i64 to i32
-// CHECK-NEXT:     return %6 : i32
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @sub() -> i32
+// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 4 : i64
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 7 : index
+// CHECK-NEXT:      %[[VAL_2:.*]] = memref.alloca() : memref<10xi32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = "polygeist.subindex"(%[[VAL_2]], %[[VAL_1]]) : (memref<10xi32>, index) -> memref<?xi32>
+// CHECK-NEXT:      %[[VAL_4:.*]] = "polygeist.memref2pointer"(%[[VAL_3]]) : (memref<?xi32>) -> !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_5:.*]] = "polygeist.memref2pointer"(%[[VAL_2]]) : (memref<10xi32>) -> !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.ptrtoint %[[VAL_5]] : !llvm.ptr<i32> to i64
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.ptrtoint %[[VAL_4]] : !llvm.ptr<i32> to i64
+// CHECK-NEXT:      %[[VAL_8:.*]] = arith.subi %[[VAL_7]], %[[VAL_6]] : i64
+// CHECK-NEXT:      %[[VAL_9:.*]] = arith.divsi %[[VAL_8]], %[[VAL_0]] : i64
+// CHECK-NEXT:      %[[VAL_10:.*]] = arith.trunci %[[VAL_9]] : i64 to i32
+// CHECK-NEXT:      return %[[VAL_10]] : i32
+// CHECK-NEXT:    }
 
 // CHECK:   func @add(%arg0: memref<?xi32>) -> memref<?xi32> attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT:     %c7 = arith.constant 7 : index


### PR DESCRIPTION
This pattern performs lowering to the LLVM dialect. No polygeist pass is altered by this, as all of the passes dealing with GEPOp operations also deal with SubIndexOp in an equivalent way.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>