### PR TITLE
[SYCL][NFC] Stop using deprecated llvm::Optional API

### DIFF
--- a/llvm/tools/sycl-post-link/ModuleSplitter.cpp
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.cpp
@@ -505,7 +505,7 @@ void ModuleSplitterBase::verifyNoCrossModuleDeviceGlobalUsage() {
       auto EntryPointModulesIt = EntryPointModules.find(F);
       assert(EntryPointModulesIt != EntryPointModules.end() &&
              "There is no group for an entry point");
-      if (!VarEntryPointModule.hasValue()) {
+      if (!VarEntryPointModule.has_value()) {
         VarEntryPointModule = EntryPointModulesIt->second;
         return;
       }

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -286,7 +286,7 @@ std::vector<StringRef> getKernelNamesUsingAssert(const Module &M) {
   auto TraverseResult =
       traverseCGToFindSPIRKernels(DevicelibAssertFailFunction);
 
-  if (TraverseResult.hasValue())
+  if (TraverseResult.has_value())
     return std::move(*TraverseResult);
 
   // Here we reached "referenced-indirectly", so we need to find all kernels and


### PR DESCRIPTION
`hasValue` was deprecated in favor of `has_value` in b5f8d42efe3e246d582d4a1a328fac915e4ce8dc