### PR TITLE
[SYCL] [CI] Add OCL dev env to containers.

### DIFF
--- a/devops/scripts/install_build_tools.sh
+++ b/devops/scripts/install_build_tools.sh
@@ -11,7 +11,8 @@ apt update && apt install -yqq \
       python-is-python3 \
       python3-pip \
       zstd \
-      ocl-icd-libopencl1 \
+      ocl-icd-opencl-dev \
+      intel-level-zero-gpu \
       vim \
       libffi-dev \
       libva-dev \

--- a/devops/scripts/install_build_tools.sh
+++ b/devops/scripts/install_build_tools.sh
@@ -12,7 +12,6 @@ apt update && apt install -yqq \
       python3-pip \
       zstd \
       ocl-icd-opencl-dev \
-      intel-level-zero-gpu \
       vim \
       libffi-dev \
       libva-dev \


### PR DESCRIPTION
Adding OpenCL dev env to our containers. At minimum, this will allow our containers to be used for interop testing on GitHub Actions (which is being skipped presently).

L0 drivers are present on the "drivers" image and don't need to be installed. Plus the L0 interop tests are not being skipped. 

Signed-off-by: Chris Perkins <chris.perkins@intel.com>