### PR TITLE
[DO NOT MERGE] retesting pkg failure

### DIFF
--- a/devops/containers/ubuntu2004_base.Dockerfile
+++ b/devops/containers/ubuntu2004_base.Dockerfile
@@ -7,6 +7,7 @@ USER root
 # Install SYCL prerequisites
 COPY scripts/install_build_tools.sh /install.sh
 RUN /install.sh
+RUN apt-get -y install intel-level-zero-gpu
 
 # By default Ubuntu sets an arbitrary UID value, that is different from host
 # system. When CI passes default UID value of 1001, some of LLVM tools fail to


### PR DESCRIPTION
`intel-level-zero-gpu` has no trouble installing directly when testing locally, but failed on initial CI attempt.