### PR TITLE
[SYCL][Doc] Fix shared libraries design doc typo

### DIFF
--- a/sycl/doc/design/SharedLibraries.md
+++ b/sycl/doc/design/SharedLibraries.md
@@ -31,8 +31,8 @@ SYCL_EXTERNAL int LibDeviceFunc(int i) {
 
 ```bash
 ; Commands
-clang++ -fsycl lib.cpp -shared -o helpers.so
-clang++ -fsycl app.cpp -lhelpers -o a.out
+clang++ -fsycl lib.cpp -shared -o libhelpers.so
+clang++ -fsycl app.cpp -L. -lhelpers -o a.out
 ./a.out
 Output: 0 2 4 6 ...
 ```


### PR DESCRIPTION
Two problems with this example:

1)  shared object name needs lib prefix as that's what ld looks for
2) Need to include pwd as path for ld to look for


Signed-off-by: Sarnie, Nick <nick.sarnie@intel.com>