### PR TITLE
[SYCL-MLIR] Implement `sycl.accessor_subscript` type

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -96,6 +96,7 @@ def SYCL_AccessorType : DialectType<SYCL_Dialect, CPred<"$_self.isa<AccessorType
 def SYCL_RangeType : DialectType<SYCL_Dialect, CPred<"$_self.isa<RangeType>()">, "sycl::range type">;
 def SYCL_NdRangeType : DialectType<SYCL_Dialect, CPred<"$_self.isa<NdRangeType>()">, "sycl::nd_range type">;
 def SYCL_AccessorImplType : DialectType<SYCL_Dialect, CPred<"$_self.isa<AccessorImplDeviceType>()">, "sycl::accessor_impl_device type">;
+def SYCL_AccessorSubscriptType : DialectType<SYCL_Dialect, CPred<"$_self.isa<AccessorSubscriptType>()">, "sycl::accessor_subscript type">;
 def SYCL_ArrayType : DialectType<SYCL_Dialect, CPred<"$_self.isa<ArrayType>()">, "sycl::array type">;
 def SYCL_ItemType : DialectType<SYCL_Dialect, CPred<"$_self.isa<ItemType>()">, "sycl::item type">;
 def SYCL_ItemBaseType : DialectType<SYCL_Dialect, CPred<"$_self.isa<ItemBaseType>()">, "sycl::item_base type">;
@@ -109,6 +110,7 @@ def AccessorMemRef : MemRefOf<[SYCL_AccessorType]>;
 def RangeMemRef : MemRefOf<[SYCL_RangeType]>;
 def NDRangeMemRef : MemRefOf<[SYCL_NdRangeType]>;
 def AccessorImplMemRef : MemRefOf<[SYCL_AccessorImplType]>;
+def AccessorSubscriptMemRef : MemRefOf<[SYCL_AccessorSubscriptType]>;
 def ArrayMemRef : MemRefOf<[SYCL_ArrayType]>;
 def ItemMemRef : MemRefOf<[SYCL_ItemType]>;
 def ItemBaseMemRef : MemRefOf<[SYCL_ItemBaseType]>;
@@ -123,6 +125,7 @@ def SYCLMemref : AnyTypeOf<[
   RangeMemRef,
   NDRangeMemRef,
   AccessorImplMemRef,
+  AccessorSubscriptMemRef,
   ArrayMemRef,
   ItemMemRef,
   ItemBaseMemRef,

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
@@ -507,6 +507,7 @@ public:
   static mlir::Type parseType(mlir::DialectAsmParser &Parser);
 
   int getCurrentDimension() const;
+  mlir::sycl::AccessorType getAccessorType() const;
   llvm::ArrayRef<mlir::Type> getBody() const;
 };
 

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
@@ -196,7 +196,7 @@ struct AccessorImplDeviceStorage : public TypeStorage {
 };
 
 struct AccessorSubscriptStorage : public TypeStorage {
-  using KeyTy = std::tuple<unsigned int, llvm::SmallVector<mlir::Type, 4>>;
+  using KeyTy = std::tuple<int, llvm::SmallVector<mlir::Type, 4>>;
 
   AccessorSubscriptStorage(const KeyTy &Key)
       : CurrentDimension(std::get<0>(Key)), Body(std::get<1>(Key)) {}
@@ -217,7 +217,7 @@ struct AccessorSubscriptStorage : public TypeStorage {
         AccessorSubscriptStorage(Key);
   }
 
-  unsigned int CurrentDimension;
+  int CurrentDimension;
   llvm::SmallVector<mlir::Type, 4> Body;
 };
 
@@ -502,11 +502,11 @@ public:
   using Base::Base;
 
   static mlir::sycl::AccessorSubscriptType
-  get(MLIRContext *Context, unsigned int CurrentDimension,
+  get(MLIRContext *Context, int CurrentDimension,
       llvm::SmallVector<mlir::Type, 4> Body);
   static mlir::Type parseType(mlir::DialectAsmParser &Parser);
 
-  unsigned int getCurrentDimension() const;
+  int getCurrentDimension() const;
   llvm::ArrayRef<mlir::Type> getBody() const;
 };
 

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -101,6 +101,16 @@ convertAccessorImplDeviceType(sycl::AccessorImplDeviceType type,
                          type.getBody(), converter);
 }
 
+/// Converts SYCL accessor subscript type to LLVM type.
+static Optional<Type>
+convertAccessorSubscriptType(sycl::AccessorSubscriptType type,
+                             LLVMTypeConverter &converter) {
+  return convertBodyType(
+      "class.sycl::_V1::detail::accessor_common.AccessorSubscript." +
+          std::to_string(type.getCurrentDimension()),
+      type.getBody(), converter);
+}
+
 /// Converts SYCL accessor common type to LLVM type.
 static Optional<Type> convertAccessorCommonType(sycl::AccessorCommonType type,
                                                 LLVMTypeConverter &converter) {
@@ -377,6 +387,9 @@ void mlir::sycl::populateSYCLToLLVMTypeConversion(
   });
   typeConverter.addConversion([&](sycl::AccessorImplDeviceType type) {
     return convertAccessorImplDeviceType(type, typeConverter);
+  });
+  typeConverter.addConversion([&](sycl::AccessorSubscriptType type) {
+    return convertAccessorSubscriptType(type, typeConverter);
   });
   typeConverter.addConversion([&](sycl::AccessorType type) {
     return convertAccessorType(type, typeConverter);

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsAlias.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsAlias.cpp
@@ -41,6 +41,10 @@ SYCLOpAsmInterface::getAlias(mlir::Type Type, llvm::raw_ostream &OS) const {
     OS << "sycl_accessor_impl_device_" << AccDev.getDimension();
     return AliasResult::FinalAlias;
   }
+  if (const auto AccSub = Type.dyn_cast<mlir::sycl::AccessorSubscriptType>()) {
+    OS << "sycl_accessor_subscript_" << AccSub.getCurrentDimension();
+    return AliasResult::FinalAlias;
+  }
   if (const auto Arr = Type.dyn_cast<mlir::sycl::ArrayType>()) {
     OS << "sycl_array_" << Arr.getDimension();
     return AliasResult::FinalAlias;

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
@@ -31,9 +31,9 @@ void mlir::sycl::SYCLDialect::initialize() {
   mlir::Dialect::addTypes<
       mlir::sycl::IDType, mlir::sycl::AccessorCommonType,
       mlir::sycl::AccessorType, mlir::sycl::RangeType, mlir::sycl::NdRangeType,
-      mlir::sycl::AccessorImplDeviceType, mlir::sycl::ArrayType,
-      mlir::sycl::ItemType, mlir::sycl::ItemBaseType, mlir::sycl::NdItemType,
-      mlir::sycl::GroupType, mlir::sycl::VecType>();
+      mlir::sycl::AccessorImplDeviceType, mlir::sycl::AccessorSubscriptType,
+      mlir::sycl::ArrayType, mlir::sycl::ItemType, mlir::sycl::ItemBaseType,
+      mlir::sycl::NdItemType, mlir::sycl::GroupType, mlir::sycl::VecType>();
 
   mlir::Dialect::addInterfaces<SYCLOpAsmInterface>();
 }
@@ -62,6 +62,9 @@ mlir::sycl::SYCLDialect::parseType(mlir::DialectAsmParser &Parser) const {
   }
   if (Keyword == "accessor_impl_device") {
     return mlir::sycl::AccessorImplDeviceType::parseType(Parser);
+  }
+  if (Keyword == "accessor_subscript") {
+    return mlir::sycl::AccessorSubscriptType::parseType(Parser);
   }
   if (Keyword == "array") {
     return mlir::sycl::ArrayType::parseType(Parser);
@@ -110,6 +113,11 @@ void mlir::sycl::SYCLDialect::printType(
                  Type.dyn_cast<mlir::sycl::AccessorImplDeviceType>()) {
     Printer << "accessor_impl_device<[" << AccDev.getDimension() << "], (";
     llvm::interleaveComma(AccDev.getBody(), Printer);
+    Printer << ")>";
+  } else if (const auto AccSub =
+                 Type.dyn_cast<mlir::sycl::AccessorSubscriptType>()) {
+    Printer << "accessor_subscript<[" << AccSub.getCurrentDimension() << "], (";
+    llvm::interleaveComma(AccSub.getBody(), Printer);
     Printer << ")>";
   } else if (const auto Arr = Type.dyn_cast<mlir::sycl::ArrayType>()) {
     Printer << "array<[" << Arr.getDimension() << "], (";

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsTypes.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsTypes.cpp
@@ -421,7 +421,7 @@ llvm::ArrayRef<mlir::Type> mlir::sycl::AccessorImplDeviceType::getBody() const {
 
 mlir::sycl::AccessorSubscriptType
 mlir::sycl::AccessorSubscriptType::get(MLIRContext *Context,
-                                       unsigned int CurrentDimension,
+                                       int CurrentDimension,
                                        llvm::SmallVector<mlir::Type, 4> Body) {
   return Base::get(Context, CurrentDimension, Body);
 }
@@ -474,7 +474,7 @@ mlir::sycl::AccessorSubscriptType::parseType(mlir::DialectAsmParser &Parser) {
                                                 Subtypes);
 }
 
-unsigned int mlir::sycl::AccessorSubscriptType::getCurrentDimension() const {
+int mlir::sycl::AccessorSubscriptType::getCurrentDimension() const {
   return getImpl()->CurrentDimension;
 }
 

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsTypes.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsTypes.cpp
@@ -416,6 +416,73 @@ llvm::ArrayRef<mlir::Type> mlir::sycl::AccessorImplDeviceType::getBody() const {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// AccessorSubscriptType Operations
+////////////////////////////////////////////////////////////////////////////////
+
+mlir::sycl::AccessorSubscriptType
+mlir::sycl::AccessorSubscriptType::get(MLIRContext *Context,
+                                       unsigned int CurrentDimension,
+                                       llvm::SmallVector<mlir::Type, 4> Body) {
+  return Base::get(Context, CurrentDimension, Body);
+}
+
+mlir::Type
+mlir::sycl::AccessorSubscriptType::parseType(mlir::DialectAsmParser &Parser) {
+  if (mlir::failed(Parser.parseLess())) {
+    return nullptr;
+  }
+
+  if (mlir::failed(Parser.parseLSquare())) {
+    return nullptr;
+  }
+
+  unsigned int CurDim;
+  if (Parser.parseInteger<unsigned int>(CurDim)) {
+    return nullptr;
+  }
+
+  if (mlir::failed(Parser.parseRSquare())) {
+    return nullptr;
+  }
+
+  if (mlir::failed(Parser.parseComma())) {
+    return nullptr;
+  }
+
+  if (mlir::failed(Parser.parseLParen())) {
+    return nullptr;
+  }
+
+  mlir::SmallVector<Type, 4> Subtypes;
+  do {
+    mlir::Type Type;
+    if (mlir::failed(Parser.parseType(Type))) {
+      return nullptr;
+    }
+    Subtypes.push_back(Type);
+  } while (succeeded(Parser.parseOptionalComma()));
+
+  if (mlir::failed(Parser.parseRParen())) {
+    return nullptr;
+  }
+
+  if (mlir::failed(Parser.parseGreater())) {
+    return nullptr;
+  }
+
+  return mlir::sycl::AccessorSubscriptType::get(Parser.getContext(), CurDim,
+                                                Subtypes);
+}
+
+unsigned int mlir::sycl::AccessorSubscriptType::getCurrentDimension() const {
+  return getImpl()->CurrentDimension;
+}
+
+llvm::ArrayRef<mlir::Type> mlir::sycl::AccessorSubscriptType::getBody() const {
+  return getImpl()->Body;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // Array Operations
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsTypes.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsTypes.cpp
@@ -478,6 +478,14 @@ int mlir::sycl::AccessorSubscriptType::getCurrentDimension() const {
   return getImpl()->CurrentDimension;
 }
 
+mlir::sycl::AccessorType
+mlir::sycl::AccessorSubscriptType::getAccessorType() const {
+  mlir::Type Ty = getImpl()->Body[1];
+  assert(Ty.isa<AccessorType>() &&
+         "Expecting the second element to be AccessorType");
+  return Ty.cast<AccessorType>();
+}
+
 llvm::ArrayRef<mlir::Type> mlir::sycl::AccessorSubscriptType::getBody() const {
   return getImpl()->Body;
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
@@ -9,8 +9,9 @@
 // CHECK: llvm.func @test_nd_range.2(%arg0: !llvm.[[ND_RANGE_2:struct<"class.sycl::_V1::nd_range.*", \(]][[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[ID_2:struct<"class.sycl::_V1::id.*", \(]][[ARRAY_2]][[SUFFIX]][[SUFFIX]]) {
 // CHECK: llvm.func @test_accessorImplDevice(%arg0: !llvm.[[ACCESSORIMPLDEVICE_1:struct<"class.sycl::_V1::detail::AccessorImplDevice.*", \(]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
 // CHECK: llvm.func @test_accessor_common(%arg0: !llvm.[[ACCESSOR_COMMON:struct<"class.sycl::_V1::detail::accessor_common", \(i8\)>]])
-// CHECK: llvm.func @test_accessor.1(%arg0: !llvm.[[ACCESSOR_1:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_1]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>)>)
-// CHECK: llvm.func @test_accessor.2(%arg0: !llvm.[[ACCESSOR_2:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_2:struct<"class.sycl::_V1::detail::AccessorImplDevice.*", \(]][[ID_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>)>)
+// CHECK: llvm.func @test_accessor.1(%arg0: !llvm.[[ACCESSOR_1:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_1]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>[[SUFFIX]])
+// CHECK: llvm.func @test_accessor.2(%arg0: !llvm.[[ACCESSOR_2:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_2:struct<"class.sycl::_V1::detail::AccessorImplDevice.*", \(]][[ID_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>[[SUFFIX]])
+// CHECK: llvm.func @test_accessorSubscript(%arg0: !llvm.[[ACCESSORSUBSCRIPT_1:struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.*", \(]][[ID_2]][[ARRAY_2]][[SUFFIX]], [[ACCESSOR_2]][[ACCESSORIMPLDEVICE_2]][[ID_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>[[SUFFIX]]) 
 // CHECK: llvm.func @test_itemBase.true(%arg0: !llvm.[[ITEM_BASE_1_TRUE:struct<"struct.sycl::_V1::detail::ItemBase.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
 // CHECK: llvm.func @test_itemBase.false(%arg0: !llvm.[[ITEM_BASE_1_FALSE:struct<"struct.sycl::_V1::detail::ItemBase.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
 // CHECK: llvm.func @test_item.true(%arg0: !llvm.[[ITEM_1_TRUE:struct<"class.sycl::_V1::item.*", \(]][[ITEM_BASE_1_TRUE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
@@ -27,6 +28,7 @@
 !sycl_accessor_impl_device_2 = !sycl.accessor_impl_device<[2], (!sycl.id<2>, !sycl.range<2>, !sycl.range<2>)>
 !sycl_accessor_1 = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1, !llvm.struct<(ptr<i32, 1>)>)>
 !sycl_accessor_2 = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_subscript_1 = !sycl.accessor_subscript<[1], (!sycl.id<2>, !sycl_accessor_2)>
 !sycl_item_base_1_true = !sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>
 !sycl_item_base_1_false = !sycl.item_base<[1, false], (!sycl.range<1>, !sycl.id<1>)>
 !sycl_item_1_true = !sycl.item<[1, true], (!sycl_item_base_1_true)>
@@ -66,6 +68,9 @@ module {
     return
   }
   func.func @test_accessor.2(%arg0: !sycl_accessor_2) {
+    return
+  }
+  func.func @test_accessorSubscript(%arg0: !sycl_accessor_subscript_1) {
     return
   }
   func.func @test_itemBase.true(%arg0: !sycl_item_base_1_true) {

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
@@ -11,19 +11,34 @@
 // CHECK: llvm.func @test_accessor_common(%arg0: !llvm.[[ACCESSOR_COMMON:struct<"class.sycl::_V1::detail::accessor_common", \(i8\)>]])
 // CHECK: llvm.func @test_accessor.1(%arg0: !llvm.[[ACCESSOR_1:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_1]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>)>)
 // CHECK: llvm.func @test_accessor.2(%arg0: !llvm.[[ACCESSOR_2:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_2:struct<"class.sycl::_V1::detail::AccessorImplDevice.*", \(]][[ID_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>)>)
-// CHECK: llvm.func @test_item_base.true(%arg0: !llvm.[[ITEM_BASE_1_TRUE:struct<"struct.sycl::_V1::detail::ItemBase.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
-// CHECK: llvm.func @test_item_base.false(%arg0: !llvm.[[ITEM_BASE_1_FALSE:struct<"struct.sycl::_V1::detail::ItemBase.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
+// CHECK: llvm.func @test_itemBase.true(%arg0: !llvm.[[ITEM_BASE_1_TRUE:struct<"struct.sycl::_V1::detail::ItemBase.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
+// CHECK: llvm.func @test_itemBase.false(%arg0: !llvm.[[ITEM_BASE_1_FALSE:struct<"struct.sycl::_V1::detail::ItemBase.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
 // CHECK: llvm.func @test_item.true(%arg0: !llvm.[[ITEM_1_TRUE:struct<"class.sycl::_V1::item.*", \(]][[ITEM_BASE_1_TRUE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
 // CHECK: llvm.func @test_item.false(%arg0: !llvm.[[ITEM_1_FALSE:struct<"class.sycl::_V1::item.*", \(]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
 // CHECK: llvm.func @test_group(%arg0: !llvm.[[GROUP_1:struct<"class.sycl::_V1::group.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
 // CHECK: llvm.func @test_nd_item(%arg0: !llvm.[[ND_ITEM_1:struct<"class.sycl::_V1::nd_item.*", \(]][[ITEM_1_TRUE]][[ITEM_BASE_1_TRUE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[ITEM_1_FALSE]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[GROUP_1]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
 // CHECK: llvm.func @test_vec(%arg0: !llvm.[[VEC:struct<"class.sycl::_V1::vec", \(vector<4xf32>\)>]])
 
+!sycl_array_1 = !sycl.array<[1], (memref<1xi64>)>
+!sycl_array_2 = !sycl.array<[2], (memref<2xi64>)>
+!sycl_nd_range_1 = !sycl.nd_range<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>
+!sycl_nd_range_2 = !sycl.nd_range<[2], (!sycl.range<2>, !sycl.range<2>, !sycl.id<2>)>
+!sycl_accessor_impl_device_1 = !sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>
+!sycl_accessor_impl_device_2 = !sycl.accessor_impl_device<[2], (!sycl.id<2>, !sycl.range<2>, !sycl.range<2>)>
+!sycl_accessor_1 = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_2 = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_item_base_1_true = !sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>
+!sycl_item_base_1_false = !sycl.item_base<[1, false], (!sycl.range<1>, !sycl.id<1>)>
+!sycl_item_1_true = !sycl.item<[1, true], (!sycl_item_base_1_true)>
+!sycl_item_1_false = !sycl.item<[1, false], (!sycl_item_base_1_false)>
+!sycl_group_1 = !sycl.group<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>
+!sycl_nd_item_1 = !sycl.nd_item<[1], (!sycl_item_1_true, !sycl_item_1_false, !sycl_group_1)>
+
 module {
-  func.func @test_array.1(%arg0: !sycl.array<[1], (memref<1xi64>)>) {
+  func.func @test_array.1(%arg0: !sycl_array_1) {
     return
   }
-  func.func @test_array.2(%arg0: !sycl.array<[2], (memref<2xi64>)>) {
+  func.func @test_array.2(%arg0: !sycl_array_2) {
     return
   }
   func.func @test_id(%arg0: !sycl.id<1>, %arg1: !sycl.id<1>) {
@@ -35,40 +50,40 @@ module {
   func.func @test_range.2(%arg0: !sycl.range<2>) {
     return
   }
-  func.func @test_nd_range.1(%arg0: !sycl.nd_range<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>) {
+  func.func @test_nd_range.1(%arg0: !sycl_nd_range_1) {
     return
   }
-  func.func @test_nd_range.2(%arg0: !sycl.nd_range<[2], (!sycl.range<2>, !sycl.range<2>, !sycl.id<2>)>) {
+  func.func @test_nd_range.2(%arg0: !sycl_nd_range_2) {
     return
   }
-  func.func @test_accessorImplDevice(%arg0: !sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>) {
+  func.func @test_accessorImplDevice(%arg0: !sycl_accessor_impl_device_1) {
     return
   }
   func.func @test_accessor_common(%arg0: !sycl.accessor_common) {
     return
   }
-  func.func @test_accessor.1(%arg0: !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>) {
+  func.func @test_accessor.1(%arg0: !sycl_accessor_1) {
     return
   }
-  func.func @test_accessor.2(%arg0: !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl.id<2>, !sycl.range<2>, !sycl.range<2>)>, !llvm.struct<(ptr<i32, 1>)>)>) {
+  func.func @test_accessor.2(%arg0: !sycl_accessor_2) {
     return
   }
-  func.func @test_item_base.true(%arg0: !sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>) {
+  func.func @test_itemBase.true(%arg0: !sycl_item_base_1_true) {
     return
   }
-  func.func @test_item_base.false(%arg0: !sycl.item_base<[1, false], (!sycl.range<1>, !sycl.id<1>)>) {
+  func.func @test_itemBase.false(%arg0: !sycl_item_base_1_false) {
     return
   }
-  func.func @test_item.true(%arg0: !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>) {
+  func.func @test_item.true(%arg0: !sycl_item_1_true) {
     return
   }
-  func.func @test_item.false(%arg0: !sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>) {
+  func.func @test_item.false(%arg0: !sycl_item_1_false) {
     return
   }
-  func.func @test_group(%arg0: !sycl.group<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>) {
+  func.func @test_group(%arg0: !sycl_group_1) {
     return
   }
-  func.func @test_nd_item(%arg0: !sycl.nd_item<[1], (!sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>, !sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl.range<1>, !sycl.id<1>)>)>, !sycl.group<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>)>) {
+  func.func @test_nd_item(%arg0: !sycl_nd_item_1) {
     return
   }
   func.func @test_vec(%arg0: !sycl.vec<[f32, 4], (vector<4xf32>)>) {

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1336,9 +1336,9 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
       if (TypeName == "range" || TypeName == "nd_range" ||
           TypeName == "array" || TypeName == "id" ||
           TypeName == "accessor_common" || TypeName == "accessor" ||
-          TypeName == "AccessorImplDevice" || TypeName == "item" ||
-          TypeName == "ItemBase" || TypeName == "nd_item" ||
-          TypeName == "group") {
+          TypeName == "AccessorImplDevice" || TypeName == "AccessorSubscript" ||
+          TypeName == "item" || TypeName == "ItemBase" ||
+          TypeName == "nd_item" || TypeName == "group") {
         return getSYCLType(RT, *this);
       }
       // No need special handling for types that don't have record declaration

--- a/polygeist/tools/cgeist/Lib/TypeUtils.cc
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.cc
@@ -130,6 +130,12 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
       return mlir::sycl::AccessorImplDeviceType::get(
           CGT.getModule()->getContext(), Dim, Body);
     }
+    if (CTS->getName() == "AccessorSubscript") {
+      const auto CurDim =
+          CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
+      return mlir::sycl::AccessorSubscriptType::get(
+          CGT.getModule()->getContext(), CurDim, Body);
+    }
     if (CTS->getName() == "item") {
       const auto Dim =
           CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -16,17 +16,19 @@
 // CHECK-MLIR-DAG: !sycl_accessor_2_i32_read_write_global_buffer = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>, !llvm.struct<(ptr<i32, 1>)>)>
 // CHECK-MLIR-DAG: !sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
 // CHECK-MLIR-DAG: !sycl_array_2_ = !sycl.array<[2], (memref<2xi64, 4>)>
+// CHECK-MLIR-DAG: !sycl_accessor_subscript_1_ = !sycl.accessor_subscript<[1], (!sycl_id_2_, !sycl_accessor_2_i32_read_write_global_buffer)>
 
-// CHECK-LLVM-DAG: %"class.sycl::_V1::accessor.2" = type { %"class.sycl::_V1::detail::AccessorImplDevice.2", { i32 addrspace(1)* } }
-// CHECK-LLVM-DAG: %"class.sycl::_V1::detail::AccessorImplDevice.2" = type { %"class.sycl::_V1::id.2", %"class.sycl::_V1::range.2", %"class.sycl::_V1::range.2" }
-// CHECK-LLVM-DAG: %"class.sycl::_V1::range.2" = type { %"class.sycl::_V1::detail::array.2" }
-// CHECK-LLVM-DAG: %"class.sycl::_V1::id.2" = type { %"class.sycl::_V1::detail::array.2" }
-// CHECK-LLVM-DAG: %"class.sycl::_V1::detail::array.2" = type { [2 x i64] }
-// CHECK-LLVM-DAG: %"class.sycl::_V1::accessor.1" = type { %"class.sycl::_V1::detail::AccessorImplDevice.1", { i32 addrspace(1)* } }
-// CHECK-LLVM-DAG: %"class.sycl::_V1::detail::AccessorImplDevice.1" = type { %"class.sycl::_V1::id.1", %"class.sycl::_V1::range.1", %"class.sycl::_V1::range.1" }
-// CHECK-LLVM-DAG: %"class.sycl::_V1::id.1" = type { %"class.sycl::_V1::detail::array.1" }
 // CHECK-LLVM-DAG: %"class.sycl::_V1::detail::array.1" = type { [1 x i64] }
+// CHECK-LLVM-DAG: %"class.sycl::_V1::detail::array.2" = type { [2 x i64] }
+// CHECK-LLVM-DAG: %"class.sycl::_V1::id.1" = type { %"class.sycl::_V1::detail::array.1" }
+// CHECK-LLVM-DAG: %"class.sycl::_V1::id.2" = type { %"class.sycl::_V1::detail::array.2" }
 // CHECK-LLVM-DAG: %"class.sycl::_V1::range.1" = type { %"class.sycl::_V1::detail::array.1" }
+// CHECK-LLVM-DAG: %"class.sycl::_V1::range.2" = type { %"class.sycl::_V1::detail::array.2" }
+// CHECK-LLVM-DAG: %"class.sycl::_V1::detail::AccessorImplDevice.1" = type { %"class.sycl::_V1::id.1", %"class.sycl::_V1::range.1", %"class.sycl::_V1::range.1" }
+// CHECK-LLVM-DAG: %"class.sycl::_V1::detail::AccessorImplDevice.2" = type { %"class.sycl::_V1::id.2", %"class.sycl::_V1::range.2", %"class.sycl::_V1::range.2" }
+// CHECK-LLVM-DAG: %"class.sycl::_V1::accessor.1" = type { %"class.sycl::_V1::detail::AccessorImplDevice.1", { i32 addrspace(1)* } }
+// CHECK-LLVM-DAG: %"class.sycl::_V1::accessor.2" = type { %"class.sycl::_V1::detail::AccessorImplDevice.2", { i32 addrspace(1)* } }
+// CHECK-LLVM-DAG: %"class.sycl::_V1::detail::accessor_common.AccessorSubscript.1" = type { %"class.sycl::_V1::id.2", %"class.sycl::_V1::accessor.2" }
 
 template <typename T> SYCL_EXTERNAL void keep(T);
 
@@ -45,11 +47,11 @@ SYCL_EXTERNAL void accessor_subscript_operator_0(sycl::accessor<sycl::cl_int, 2>
 
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_1N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK_MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_read_write_global_buffer>, %{{.*}}: i64)
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {BaseType = memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEEDam, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, i64) -> !llvm.struct<(!sycl_id_2_, !sycl_accessor_2_i32_read_write_global_buffer)>
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {BaseType = memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEEDam, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_read_write_global_buffer, 4>, i64) -> !sycl_accessor_subscript_1
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_1N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0, i64 noundef %1) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call { %"class.sycl::_V1::id.2", %"class.sycl::_V1::accessor.2" } @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEEDam(%"class.sycl::_V1::accessor.2" addrspace(4)* %{{.*}}, i64 %1)
+// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::detail::accessor_common.AccessorSubscript.1" @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEEDam(%"class.sycl::_V1::accessor.2" addrspace(4)* %{{.*}}, i64 %1)
 
 SYCL_EXTERNAL void accessor_subscript_operator_1(sycl::accessor<sycl::cl_int, 2> acc, size_t index) {
   keep(acc[index]);


### PR DESCRIPTION
This PR implements the `AccessorSubscript` type (we already support the `Accessor` type). The `AccessorSubscript` class is defined by the SYCL runtime as an inner class:
```
class accessor_common {
protected:
  ...
  // The class which allows to access value of N dimensional accessor using N
  // subscript operators, e.g. accessor[2][2][3]
  template <int SubDims,
            typename AccType =
                accessor<DataT, Dimensions, AccessMode, AccessTarget,
                         IsPlaceholder, PropertyListT>>
  class AccessorSubscript {
    static constexpr int Dims = Dimensions;

    mutable id<Dims> MIDs;
    AccType MAccessor;
    ...
  };
};
```
We will generate the same type descriptor as `clang`:
```
%"class.sycl::_V1::detail::array" = type { [2 x i64] }
%"class.sycl::_V1::id" = type { %"class.sycl::_V1::detail::array" }
%"class.sycl::_V1::detail::AccessorImplDevice" = type { %"class.sycl::_V1::id", %"class.sycl::_V1::range", %"class.sycl::_V1::range" }
%union.anon = type { i32 addrspace(1)* }
%"class.sycl::_V1::accessor" = type { %"class.sycl::_V1::detail::AccessorImplDevice", %union.anon }
%"class.sycl::_V1::detail::accessor_common<int, 2, sycl::_V1::access::mode::read_write, sycl::_V1::access::target::global_buffer, sycl::_V1::access::placeholder::false_t>::AccessorSubscript" = type { %"class.sycl::_V1::id", %"class.sycl::_V1::accessor" }
```