### PR TITLE
[Clang] Improve generation of GV for virtual funcs

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -141,6 +141,8 @@ CodeGenModule::CodeGenModule(ASTContext &C,
   const llvm::DataLayout &DL = M.getDataLayout();
   AllocaInt8PtrTy = Int8Ty->getPointerTo(DL.getAllocaAddrSpace());
   GlobalsInt8PtrTy = Int8Ty->getPointerTo(DL.getDefaultGlobalsAddressSpace());
+  TargetInt8PtrTy =
+      Int8Ty->getPointerTo(getContext().getTargetAddressSpace(LangAS::Default));
   ASTAllocaAddressSpace = getTargetCodeGenInfo().getASTAllocaAddressSpace();
 
   // Build C++20 Module initializers.

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -141,7 +141,7 @@ CodeGenModule::CodeGenModule(ASTContext &C,
   const llvm::DataLayout &DL = M.getDataLayout();
   AllocaInt8PtrTy = Int8Ty->getPointerTo(DL.getAllocaAddrSpace());
   GlobalsInt8PtrTy = Int8Ty->getPointerTo(DL.getDefaultGlobalsAddressSpace());
-  TargetInt8PtrTy =
+  DefaultInt8PtrTy =
       Int8Ty->getPointerTo(getContext().getTargetAddressSpace(LangAS::Default));
   ASTAllocaAddressSpace = getTargetCodeGenInfo().getASTAllocaAddressSpace();
 

--- a/clang/lib/CodeGen/CodeGenTypeCache.h
+++ b/clang/lib/CodeGen/CodeGenTypeCache.h
@@ -69,6 +69,9 @@ struct CodeGenTypeCache {
     llvm::PointerType *AllocaInt8PtrTy;
   };
 
+  /// void* in target address space
+  llvm::PointerType *TargetInt8PtrTy;
+
   /// void* in default globals address space
   union {
     llvm::PointerType *GlobalsVoidPtrTy;

--- a/clang/lib/CodeGen/CodeGenTypeCache.h
+++ b/clang/lib/CodeGen/CodeGenTypeCache.h
@@ -70,7 +70,7 @@ struct CodeGenTypeCache {
   };
 
   /// void* in target address space
-  llvm::PointerType *TargetInt8PtrTy;
+  llvm::PointerType *DefaultInt8PtrTy;
 
   /// void* in default globals address space
   union {

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -3575,7 +3575,7 @@ void ItaniumRTTIBuilder::BuildVTablePointer(const Type *Ty) {
     VTable = CGM.getModule().getNamedAlias(VTableName);
 
   if (!VTable)
-    VTable = CGM.CreateRuntimeVariable(CGM.TargetInt8PtrTy, VTableName);
+    VTable = CGM.CreateRuntimeVariable(CGM.DefaultInt8PtrTy, VTableName);
 
   CGM.setDSOLocal(cast<llvm::GlobalValue>(VTable->stripPointerCasts()));
 
@@ -3587,15 +3587,15 @@ void ItaniumRTTIBuilder::BuildVTablePointer(const Type *Ty) {
     // The vtable address point is 8 bytes after its start:
     // 4 for the offset to top + 4 for the relative offset to rtti.
     llvm::Constant *Eight = llvm::ConstantInt::get(CGM.Int32Ty, 8);
-    VTable = llvm::ConstantExpr::getBitCast(VTable, CGM.TargetInt8PtrTy);
+    VTable = llvm::ConstantExpr::getBitCast(VTable, CGM.DefaultInt8PtrTy);
     VTable =
         llvm::ConstantExpr::getInBoundsGetElementPtr(CGM.Int8Ty, VTable, Eight);
   } else {
     llvm::Constant *Two = llvm::ConstantInt::get(PtrDiffTy, 2);
-    VTable =
-        llvm::ConstantExpr::getInBoundsGetElementPtr(CGM.TargetInt8PtrTy, VTable, Two);
+    VTable = llvm::ConstantExpr::getInBoundsGetElementPtr(CGM.DefaultInt8PtrTy,
+                                                          VTable, Two);
   }
-  VTable = llvm::ConstantExpr::getBitCast(VTable, CGM.TargetInt8PtrTy);
+  VTable = llvm::ConstantExpr::getBitCast(VTable, CGM.DefaultInt8PtrTy);
 
   Fields.push_back(VTable);
 }

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -23,6 +23,7 @@
 #include "CGVTables.h"
 #include "CodeGenFunction.h"
 #include "CodeGenModule.h"
+#include "CodeGenTypeCache.h"
 #include "TargetInfo.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/Mangle.h"
@@ -3573,32 +3574,8 @@ void ItaniumRTTIBuilder::BuildVTablePointer(const Type *Ty) {
   if (CGM.getItaniumVTableContext().isRelativeLayout())
     VTable = CGM.getModule().getNamedAlias(VTableName);
 
-  // To generate valid device code global pointers should have global address
-  // space in SYCL.
-  bool GenTyInfoGVWithGlobalAS =
-      CGM.getLangOpts().SYCLIsDevice &&
-      CGM.getLangOpts().SYCLAllowVirtualFunctions &&
-      (VTableName == ClassTypeInfo || VTableName == SIClassTypeInfo);
-  auto VTableTy =
-      GenTyInfoGVWithGlobalAS
-          ? CGM.Int8Ty->getPointerTo(
-                CGM.getContext().getTargetAddressSpace(LangAS::sycl_global))
-          : CGM.Int8PtrTy;
-  if (!VTable) {
-    if (GenTyInfoGVWithGlobalAS) {
-      VTable = CGM.getModule().getOrInsertGlobal(VTableName, VTableTy, [&] {
-        return new llvm::GlobalVariable(
-            CGM.getModule(), VTableTy, /*isConstant=*/false,
-            llvm::GlobalVariable::ExternalLinkage, /*Initializer=*/nullptr,
-            VTableName, /*InsertBefore=*/nullptr,
-            llvm::GlobalValue::ThreadLocalMode::NotThreadLocal,
-            llvm::Optional<unsigned>(
-                CGM.getContext().getTargetAddressSpace(LangAS::sycl_global)));
-      });
-    } else {
-      VTable = CGM.getModule().getOrInsertGlobal(VTableName, VTableTy);
-    }
-  }
+  if (!VTable)
+    VTable = CGM.CreateRuntimeVariable(CGM.TargetInt8PtrTy, VTableName);
 
   CGM.setDSOLocal(cast<llvm::GlobalValue>(VTable->stripPointerCasts()));
 
@@ -3610,15 +3587,15 @@ void ItaniumRTTIBuilder::BuildVTablePointer(const Type *Ty) {
     // The vtable address point is 8 bytes after its start:
     // 4 for the offset to top + 4 for the relative offset to rtti.
     llvm::Constant *Eight = llvm::ConstantInt::get(CGM.Int32Ty, 8);
-    VTable = llvm::ConstantExpr::getBitCast(VTable, VTableTy);
+    VTable = llvm::ConstantExpr::getBitCast(VTable, CGM.TargetInt8PtrTy);
     VTable =
         llvm::ConstantExpr::getInBoundsGetElementPtr(CGM.Int8Ty, VTable, Eight);
   } else {
     llvm::Constant *Two = llvm::ConstantInt::get(PtrDiffTy, 2);
     VTable =
-        llvm::ConstantExpr::getInBoundsGetElementPtr(VTableTy, VTable, Two);
+        llvm::ConstantExpr::getInBoundsGetElementPtr(CGM.TargetInt8PtrTy, VTable, Two);
   }
-  VTable = llvm::ConstantExpr::getBitCast(VTable, VTableTy);
+  VTable = llvm::ConstantExpr::getBitCast(VTable, CGM.TargetInt8PtrTy);
 
   Fields.push_back(VTable);
 }

--- a/clang/test/CodeGenSYCL/no_opaque_virtual-types.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_virtual-types.cpp
@@ -20,9 +20,9 @@ int main() {
 // Struct layout big enough for vtable.
 // CHECK: %struct.Struct = type { i32 (...)** }
 // VTable:
-// CHECK: @_ZTV6Struct = linkonce_odr unnamed_addr constant { [3 x i8*] } { [3 x i8*] [i8* null, i8* bitcast ({ i8*, i8* }* @_ZTI6Struct to i8*), i8* bitcast (void (%struct.Struct addrspace(4)*)* @_ZN6Struct3fooEv to i8*)] }, comdat, align 8
-// CHECK: @[[TYPEINFO:.+]] = external global i8*
+// CHECK: @_ZTV6Struct = linkonce_odr unnamed_addr constant { [3 x i8*] } { [3 x i8*] [i8* null, i8* bitcast ({ i8 addrspace(4)*, i8* }* @_ZTI6Struct to i8*), i8* bitcast (void (%struct.Struct addrspace(4)*)* @_ZN6Struct3fooEv to i8*)] }, comdat, align 8
+// CHECK: @[[TYPEINFO:.+]] = external addrspace(1) global i8 addrspace(4)*
 // TypeInfo Name:
 // CHECK: @_ZTS6Struct = linkonce_odr constant [8 x i8] c"6Struct\00", comdat, align 1
 // TypeInfo:
-// CHECK: @_ZTI6Struct = linkonce_odr constant { i8*, i8* } { i8* bitcast (i8** getelementptr inbounds (i8*, i8** @[[TYPEINFO]], i64 2) to i8*), i8* getelementptr inbounds ([8 x i8], [8 x i8]* @_ZTS6Struct, i32 0, i32 0) }, comdat, align 8
+// CHECK: @_ZTI6Struct = linkonce_odr constant { i8 addrspace(4)*, i8* } { i8 addrspace(4)* bitcast (i8 addrspace(4)* addrspace(4)* getelementptr inbounds (i8 addrspace(4)*, i8 addrspace(4)* addrspace(4)* addrspacecast (i8 addrspace(4)* addrspace(1)* @[[TYPEINFO]] to i8 addrspace(4)* addrspace(4)*), i64 2) to i8 addrspace(4)*), i8* getelementptr inbounds ([8 x i8], [8 x i8]* @_ZTS6Struct, i32 0, i32 0) }, comdat, align 8

--- a/clang/test/CodeGenSYCL/simple-sycl-virtual-function.cpp
+++ b/clang/test/CodeGenSYCL/simple-sycl-virtual-function.cpp
@@ -5,12 +5,12 @@
 // RUN: %clang_cc1 -triple spir64 -fsycl-allow-virtual-functions -fsycl-is-device -emit-llvm %s -o - | FileCheck %s  --check-prefixes CHECK,CHECK-PTR
 // RUN: %clang_cc1 -triple spir64 -fsycl-allow-virtual-functions -fsycl-is-device -fexperimental-relative-c++-abi-vtables -emit-llvm %s -o - | FileCheck %s --check-prefixes CHECK,CHECK-REL
 
-// CHECK: @_ZTVN10__cxxabiv120__si_class_type_infoE = external addrspace(1) global ptr addrspace(1)
-// CHECK: @_ZTVN10__cxxabiv117__class_type_infoE = external addrspace(1) global ptr addrspace(1)
-// CHECK-PTR: @_ZTI4Base = linkonce_odr constant { ptr addrspace(1), ptr } { ptr addrspace(1) getelementptr inbounds (ptr addrspace(1), ptr addrspace(1) @_ZTVN10__cxxabiv117__class_type_infoE, i64 2)
-// CHECK-PTR: @_ZTI8Derived1 = linkonce_odr constant { ptr addrspace(1), ptr, ptr } { ptr addrspace(1) getelementptr inbounds (ptr addrspace(1), ptr addrspace(1) @_ZTVN10__cxxabiv120__si_class_type_infoE, i64 2)
-// CHECK-REL: @_ZTI4Base = linkonce_odr constant { ptr addrspace(1), ptr } { ptr addrspace(1) getelementptr inbounds (i8, ptr addrspace(1) @_ZTVN10__cxxabiv117__class_type_infoE, i32 8)
-// CHECK-REL: @_ZTI8Derived1 = linkonce_odr constant { ptr addrspace(1), ptr, ptr } { ptr addrspace(1) getelementptr inbounds (i8, ptr addrspace(1) @_ZTVN10__cxxabiv120__si_class_type_infoE, i32 8)
+// CHECK: @_ZTVN10__cxxabiv120__si_class_type_infoE = external addrspace(1) global ptr addrspace(4)
+// CHECK: @_ZTVN10__cxxabiv117__class_type_infoE = external addrspace(1) global ptr addrspace(4)
+// CHECK-PTR: @_ZTI4Base = linkonce_odr constant { ptr addrspace(4), ptr } { ptr addrspace(4) getelementptr inbounds (ptr addrspace(4), ptr addrspace(4) addrspacecast (ptr addrspace(1) @_ZTVN10__cxxabiv117__class_type_infoE to ptr addrspace(4)), i64 2)
+// CHECK-PTR: @_ZTI8Derived1 = linkonce_odr constant { ptr addrspace(4), ptr, ptr } { ptr addrspace(4) getelementptr inbounds (ptr addrspace(4), ptr addrspace(4) addrspacecast (ptr addrspace(1) @_ZTVN10__cxxabiv120__si_class_type_infoE to ptr addrspace(4)), i64 2)
+// CHECK-REL: @_ZTI4Base = linkonce_odr constant { ptr addrspace(4), ptr } { ptr addrspace(4) getelementptr inbounds (i8, ptr addrspace(4) addrspacecast (ptr addrspace(1) @_ZTVN10__cxxabiv117__class_type_infoE to ptr addrspace(4)), i32 8)
+// CHECK-REL: @_ZTI8Derived1 = linkonce_odr constant { ptr addrspace(4), ptr, ptr } { ptr addrspace(4) getelementptr inbounds (i8, ptr addrspace(4) addrspacecast (ptr addrspace(1) @_ZTVN10__cxxabiv120__si_class_type_infoE to ptr addrspace(4)), i32 8)
 
 SYCL_EXTERNAL bool rand();
 

--- a/clang/test/CodeGenSYCL/virtual-types.cpp
+++ b/clang/test/CodeGenSYCL/virtual-types.cpp
@@ -21,8 +21,8 @@ int main() {
 // CHECK: %struct.Struct = type { ptr }
 // VTable:
 // CHECK: @_ZTV6Struct = linkonce_odr unnamed_addr constant { [3 x ptr] } { [3 x ptr] [ptr null, ptr @_ZTI6Struct, ptr @_ZN6Struct3fooEv] }, comdat, align 8
-// CHECK: @[[TYPEINFO:.+]] = external global ptr
+// CHECK: @[[TYPEINFO:.+]] = external addrspace(1) global ptr addrspace(4)
 // TypeInfo Name:
 // CHECK: @_ZTS6Struct = linkonce_odr constant [8 x i8] c"6Struct\00", comdat, align 1
 // TypeInfo:
-// CHECK: @_ZTI6Struct = linkonce_odr constant { ptr, ptr } { ptr getelementptr inbounds (ptr, ptr @[[TYPEINFO]], i64 2), ptr @_ZTS6Struct }, comdat, align 8
+// CHECK: @_ZTI6Struct = linkonce_odr constant { ptr addrspace(4), ptr } { ptr addrspace(4) getelementptr inbounds (ptr addrspace(4), ptr addrspace(4) addrspacecast (ptr addrspace(1) @[[TYPEINFO]] to ptr addrspace(4)), i64 2), ptr @_ZTS6Struct }, comdat, align 8


### PR DESCRIPTION
Reduce the code intended to generate valid device code global pointers with global address space in SYCL by introducing a new `DefaultInt8PtrTy` type.