### PR TITLE
[SYCL] Change sycl::reqd_work_group_size with optional dimensions

### DIFF
--- a/clang-tools-extra/clang-tidy/altera/SingleWorkItemBarrierCheck.cpp
+++ b/clang-tools-extra/clang-tidy/altera/SingleWorkItemBarrierCheck.cpp
@@ -57,8 +57,8 @@ void SingleWorkItemBarrierCheck::check(const MatchFinder::MatchResult &Result) {
     bool IsNDRange = false;
     if (MatchedDecl->hasAttr<ReqdWorkGroupSizeAttr>()) {
       const auto *Attribute = MatchedDecl->getAttr<ReqdWorkGroupSizeAttr>();
-      if (*Attribute->getXDimVal() > 1 || *Attribute->getYDimVal() > 1 ||
-          *Attribute->getZDimVal() > 1)
+      if (Attribute->getXDim() > 1 || Attribute->getYDim() > 1 ||
+          Attribute->getZDim() > 1)
         IsNDRange = true;
     }
     if (IsNDRange) // No warning if kernel is treated as an NDRange.

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -3429,17 +3429,18 @@ def ReqdWorkGroupSize : InheritableAttr {
   let Subjects = SubjectList<[Function], ErrorDiag>;
   let AdditionalMembers = [{
     Optional<llvm::APSInt> getXDimVal() const {
+      // X-dimension is not optional.
       if (const auto *CE = dyn_cast<ConstantExpr>(getXDim()))
         return CE->getResultAsAPSInt();
       return None;
     }
     Optional<llvm::APSInt> getYDimVal() const {
-      if (const auto *CE = dyn_cast<ConstantExpr>(getYDim()))
+      if (const auto *CE = dyn_cast_or_null<ConstantExpr>(getYDim()))
         return CE->getResultAsAPSInt();
       return None;
     }
     Optional<llvm::APSInt> getZDimVal() const {
-      if (const auto *CE = dyn_cast<ConstantExpr>(getZDim()))
+      if (const auto *CE = dyn_cast_or_null<ConstantExpr>(getZDim()))
         return CE->getResultAsAPSInt();
       return None;
     }

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -3435,11 +3435,13 @@ def ReqdWorkGroupSize : InheritableAttr {
       return None;
     }
     Optional<llvm::APSInt> getYDimVal() const {
+      // Y-dimension is not optional so a nullptr value is allowed.
       if (const auto *CE = dyn_cast_or_null<ConstantExpr>(getYDim()))
         return CE->getResultAsAPSInt();
       return None;
     }
     Optional<llvm::APSInt> getZDimVal() const {
+      // Z-dimension is not optional so a nullptr value is allowed.
       if (const auto *CE = dyn_cast_or_null<ConstantExpr>(getZDim()))
         return CE->getResultAsAPSInt();
       return None;

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -3472,13 +3472,13 @@ def SYCLReqdWorkGroupSize : InheritableAttr, LanguageOptionsSpecificAttr {
       return None;
     }
     Optional<llvm::APSInt> getYDimVal() const {
-      // Y-dimension is not optional so a nullptr value is allowed.
+      // Y-dimension is optional so a nullptr value is allowed.
       if (const auto *CE = dyn_cast_or_null<ConstantExpr>(getYDim()))
         return CE->getResultAsAPSInt();
       return None;
     }
     Optional<llvm::APSInt> getZDimVal() const {
-      // Z-dimension is not optional so a nullptr value is allowed.
+      // Z-dimension is optional so a nullptr value is allowed.
       if (const auto *CE = dyn_cast_or_null<ConstantExpr>(getZDim()))
         return CE->getResultAsAPSInt();
       return None;

--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -370,6 +370,7 @@ def SYCL : LangOpt<"SYCL">;
 def SYCLIsDevice : LangOpt<"SYCLIsDevice">;
 def SYCLIsHost : LangOpt<"SYCLIsHost">;
 def SilentlyIgnoreSYCLIsHost : LangOpt<"SYCLIsHost", "", 1>;
+def NotSYCL : LangOpt<"", "!LangOpts.SYCLIsDevice && !LangOpts.SYCLIsHost">;
 def COnly : LangOpt<"", "!LangOpts.CPlusPlus">;
 def CPlusPlus : LangOpt<"CPlusPlus">;
 def OpenCL : LangOpt<"OpenCL">;
@@ -662,6 +663,27 @@ class TargetSpecificAttr<TargetSpec target> {
   // spellings match exactly between the attributes, and if the arguments or
   // subjects differ, should specify HasCustomParsing = 1 and implement their
   // own parsing and semantic handling requirements as-needed.
+  string ParseKind;
+}
+
+/// A language-option-specific attribute.  This class is meant to be used as a
+/// mixin with InheritableAttr or Attr depending on the attribute's needs.
+class LanguageOptionsSpecificAttr {
+  // Attributes are generally required to have unique spellings for their names
+  // so that the parser can determine what kind of attribute it has parsed.
+  // However, language-option-specific attributes are special as they have
+  // different semantics based on the language options specified.  To support
+  // this, a Kind can be explicitly specified for a language-option-specific
+  // attribute. This corresponds to the ParsedAttr::AT_* enum that is generated
+  // and it should contain a shared value between the attributes.
+  // The language options these attributes are unique for are specified in the
+  // LangOpts member of Attr.
+  //
+  // Language-option-specific attributes which use this feature should ensure
+  // that the spellings match exactly between the attributes, and if the
+  // arguments or subjects differ, should specify HasCustomParsing = 1 and
+  // implement their own parsing and semantic handling requirements as-needed.
+  // Additionally, they should ensure that the language options do not overlap.
   string ParseKind;
 }
 
@@ -3419,7 +3441,21 @@ def NoDeref : TypeAttr {
 
 // Default arguments can only be used with the sycl::reqd_work_group_size
 // spelling.
-def ReqdWorkGroupSize : InheritableAttr {
+def ReqdWorkGroupSize : InheritableAttr, LanguageOptionsSpecificAttr {
+  let Spellings = [GNU<"reqd_work_group_size">,
+                   CXX11<"cl", "reqd_work_group_size">,
+                   CXX11<"sycl", "reqd_work_group_size">];
+  let Args = [UnsignedArgument<"XDim">, UnsignedArgument<"YDim">,
+              UnsignedArgument<"ZDim">];
+  let Subjects = SubjectList<[Function], ErrorDiag>;
+  let LangOpts = [NotSYCL];
+  let Documentation = [ReqdWorkGroupSizeAttrDocs];
+  let SupportsNonconformingLambdaSyntax = 1;
+  let ParseKind = "ReqdWorkGroupSize";
+  let HasCustomParsing = 1;
+}
+
+def SYCLReqdWorkGroupSize : InheritableAttr, LanguageOptionsSpecificAttr {
   let Spellings = [GNU<"reqd_work_group_size">,
                    CXX11<"cl", "reqd_work_group_size">,
                    CXX11<"sycl", "reqd_work_group_size">];
@@ -3427,6 +3463,7 @@ def ReqdWorkGroupSize : InheritableAttr {
               ExprArgument<"YDim", /*optional*/1>,
               ExprArgument<"ZDim", /*optional*/1>];
   let Subjects = SubjectList<[Function], ErrorDiag>;
+  let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
   let AdditionalMembers = [{
     Optional<llvm::APSInt> getXDimVal() const {
       // X-dimension is not optional.
@@ -3449,6 +3486,8 @@ def ReqdWorkGroupSize : InheritableAttr {
   }];
   let Documentation = [ReqdWorkGroupSizeAttrDocs];
   let SupportsNonconformingLambdaSyntax = 1;
+  let ParseKind = "ReqdWorkGroupSize";
+  let HasCustomParsing = 1;
 }
 
 def WorkGroupSizeHint :  InheritableAttr {

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -10975,6 +10975,12 @@ public:
 
   void AddIntelFPGABankBitsAttr(Decl *D, const AttributeCommonInfo &CI,
                                 Expr **Exprs, unsigned Size);
+  bool AnyWorkGroupSizesDiffer(const Expr *LHSXDim, const Expr *LHSYDim,
+                               const Expr *LHSZDim, const Expr *RHSXDim,
+                               const Expr *RHSYDim, const Expr *RHSZDim);
+  bool AllWorkGroupSizesSame(const Expr *LHSXDim, const Expr *LHSYDim,
+                             const Expr *LHSZDim, const Expr *RHSXDim,
+                             const Expr *RHSYDim, const Expr *RHSZDim);
   void AddWorkGroupSizeHintAttr(Decl *D, const AttributeCommonInfo &CI,
                                 Expr *XDim, Expr *YDim, Expr *ZDim);
   WorkGroupSizeHintAttr *
@@ -11049,6 +11055,9 @@ public:
                                                 const SYCLUsesAspectsAttr &A);
   void AddSYCLUsesAspectsAttr(Decl *D, const AttributeCommonInfo &CI,
                               Expr **Exprs, unsigned Size);
+  bool CheckMaxAllowedWorkGroupSize(const Expr *RWGSXDim, const Expr *RWGSYDim,
+                                    const Expr *RWGSZDim, const Expr *MWGSXDim,
+                                    const Expr *MWGSYDim, const Expr *MWGSZDim);
   void AddSYCLIntelMaxWorkGroupSizeAttr(Decl *D, const AttributeCommonInfo &CI,
                                         Expr *XDim, Expr *YDim, Expr *ZDim);
   SYCLIntelMaxWorkGroupSizeAttr *

--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -11086,10 +11086,10 @@ public:
                                       const SYCLAddIRAnnotationsMemberAttr &A);
   void AddSYCLAddIRAnnotationsMemberAttr(Decl *D, const AttributeCommonInfo &CI,
                                          MutableArrayRef<Expr *> Args);
-  void AddReqdWorkGroupSizeAttr(Decl *D, const AttributeCommonInfo &CI,
-                                Expr *XDim, Expr *YDim, Expr *ZDim);
-  ReqdWorkGroupSizeAttr *
-  MergeReqdWorkGroupSizeAttr(Decl *D, const ReqdWorkGroupSizeAttr &A);
+  void AddSYCLReqdWorkGroupSizeAttr(Decl *D, const AttributeCommonInfo &CI,
+                                    Expr *XDim, Expr *YDim, Expr *ZDim);
+  SYCLReqdWorkGroupSizeAttr *
+  MergeSYCLReqdWorkGroupSizeAttr(Decl *D, const SYCLReqdWorkGroupSizeAttr &A);
 
   SYCLTypeAttr *MergeSYCLTypeAttr(Decl *D, const AttributeCommonInfo &CI,
                                   SYCLTypeAttr::SYCLType TypeName);

--- a/clang/lib/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CodeGen/TargetInfo.cpp
@@ -8496,16 +8496,16 @@ void TCETargetCodeGenInfo::setTargetAttributes(
 
         SmallVector<llvm::Metadata *, 5> Operands;
         Operands.push_back(llvm::ConstantAsMetadata::get(F));
-        unsigned XDim = Attr->getXDimVal()->getZExtValue();
-        unsigned YDim = Attr->getYDimVal()->getZExtValue();
-        unsigned ZDim = Attr->getZDimVal()->getZExtValue();
 
-        Operands.push_back(llvm::ConstantAsMetadata::get(
-            llvm::Constant::getIntegerValue(M.Int32Ty, llvm::APInt(32, XDim))));
-        Operands.push_back(llvm::ConstantAsMetadata::get(
-            llvm::Constant::getIntegerValue(M.Int32Ty, llvm::APInt(32, YDim))));
-        Operands.push_back(llvm::ConstantAsMetadata::get(
-            llvm::Constant::getIntegerValue(M.Int32Ty, llvm::APInt(32, ZDim))));
+        Operands.push_back(
+            llvm::ConstantAsMetadata::get(llvm::Constant::getIntegerValue(
+                M.Int32Ty, llvm::APInt(32, Attr->getXDim()))));
+        Operands.push_back(
+            llvm::ConstantAsMetadata::get(llvm::Constant::getIntegerValue(
+                M.Int32Ty, llvm::APInt(32, Attr->getYDim()))));
+        Operands.push_back(
+            llvm::ConstantAsMetadata::get(llvm::Constant::getIntegerValue(
+                M.Int32Ty, llvm::APInt(32, Attr->getZDim()))));
 
         // Add a boolean constant operand for "required" (true) or "hint"
         // (false) for implementing the work_group_size_hint attr later.
@@ -9380,21 +9380,16 @@ void AMDGPUTargetCodeGenInfo::setFunctionDeclAttributes(
   if (ReqdWGS || FlatWGS) {
     unsigned Min = 0;
     unsigned Max = 0;
-    unsigned XDim = 0;
-    unsigned YDim = 0;
-    unsigned ZDim = 0;
-    ASTContext &Ctx = M.getContext();
     if (FlatWGS) {
-      Min = FlatWGS->getMin()->EvaluateKnownConstInt(Ctx).getExtValue();
-      Max = FlatWGS->getMax()->EvaluateKnownConstInt(Ctx).getExtValue();
-    }
-    if (ReqdWGS) {
-      XDim = ReqdWGS->getXDimVal()->getZExtValue();
-      YDim = ReqdWGS->getYDimVal()->getZExtValue();
-      ZDim = ReqdWGS->getZDimVal()->getZExtValue();
+      Min = FlatWGS->getMin()
+                ->EvaluateKnownConstInt(M.getContext())
+                .getExtValue();
+      Max = FlatWGS->getMax()
+                ->EvaluateKnownConstInt(M.getContext())
+                .getExtValue();
     }
     if (ReqdWGS && Min == 0 && Max == 0)
-      Min = Max = XDim * YDim * ZDim;
+      Min = Max = ReqdWGS->getXDim() * ReqdWGS->getYDim() * ReqdWGS->getZDim();
 
     if (Min != 0) {
       assert(Min <= Max && "Min must be less than or equal Max");

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -3000,8 +3000,8 @@ static bool mergeDeclAttribute(Sema &S, NamedDecl *D,
     NewAttr = S.MergeSYCLAddIRAttributesGlobalVariableAttr(D, *A);
   else if (const auto *A = dyn_cast<SYCLAddIRAnnotationsMemberAttr>(Attr))
     NewAttr = S.MergeSYCLAddIRAnnotationsMemberAttr(D, *A);
-  else if (const auto *A = dyn_cast<ReqdWorkGroupSizeAttr>(Attr))
-    NewAttr = S.MergeReqdWorkGroupSizeAttr(D, *A);
+  else if (const auto *A = dyn_cast<SYCLReqdWorkGroupSizeAttr>(Attr))
+    NewAttr = S.MergeSYCLReqdWorkGroupSizeAttr(D, *A);
   else if (const auto *NT = dyn_cast<HLSLNumThreadsAttr>(Attr))
     NewAttr =
         S.mergeHLSLNumThreadsAttr(D, *NT, NT->getX(), NT->getY(), NT->getZ());

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -3743,14 +3743,10 @@ static bool CheckWorkGroupSize(Sema &S, const Expr *NSWIValue,
   if ((!RWGSYDimExpr && RWGSYDim) || (!RWGSZDimExpr && RWGSZDim))
     return false;
 
-  // Otherwise, check which argument increments the fastest
-  // in OpenCL vs SYCL mode.
+  // Otherwise, check which argument increments the fastest.
   const ConstantExpr *LastRWGSDimExpr =
       RWGSZDim ? RWGSZDimExpr : (RWGSYDim ? RWGSYDimExpr : RWGSXDimExpr);
-  unsigned WorkGroupSize =
-      S.getLangOpts().SYCLIsDevice
-          ? (LastRWGSDimExpr->getResultAsAPSInt()).getZExtValue()
-          : (RWGSXDimExpr->getResultAsAPSInt()).getZExtValue();
+  unsigned WorkGroupSize = LastRWGSDimExpr->getResultAsAPSInt().getZExtValue();
 
   // Check if the required work group size specified by 'num_simd_work_items'
   // attribute evenly divides the index that increments fastest in the
@@ -3942,7 +3938,7 @@ static void handleSYCLReqdWorkGroupSize(Sema &S, Decl *D, const ParsedAttr &AL){
     if (!AL.checkExactlyNumArgs(S, 3))
       return;
   } else if (!AL.checkAtLeastNumArgs(S, 1) || !AL.checkAtMostNumArgs(S, 3))
-      return;
+    return;
 
   size_t NumArgs = AL.getNumArgs();
   Expr *XDimExpr = NumArgs > 0 ? AL.getArgAsExpr(0) : nullptr;

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4354,9 +4354,9 @@ static void PropagateAndDiagnoseDeviceAttr(
   case attr::Kind::ReqdWorkGroupSize: {
     auto *RWGSA = cast<ReqdWorkGroupSizeAttr>(A);
     if (auto *Existing = SYCLKernel->getAttr<ReqdWorkGroupSizeAttr>()) {
-      if (*Existing->getXDimVal() != *RWGSA->getXDimVal() ||
-          *Existing->getYDimVal() != *RWGSA->getYDimVal() ||
-          *Existing->getZDimVal() != *RWGSA->getZDimVal()) {
+      if (S.AnyWorkGroupSizesDiffer(Existing->getXDim(), Existing->getYDim(),
+                                    Existing->getZDim(), RWGSA->getXDim(),
+                                    RWGSA->getYDim(), RWGSA->getZDim())) {
         S.Diag(SYCLKernel->getLocation(),
                diag::err_conflicting_sycl_kernel_attributes);
         S.Diag(Existing->getLocation(), diag::note_conflicting_attribute);
@@ -4365,9 +4365,9 @@ static void PropagateAndDiagnoseDeviceAttr(
       }
     } else if (auto *Existing =
                    SYCLKernel->getAttr<SYCLIntelMaxWorkGroupSizeAttr>()) {
-      if (*Existing->getXDimVal() < *RWGSA->getXDimVal() ||
-          *Existing->getYDimVal() < *RWGSA->getYDimVal() ||
-          *Existing->getZDimVal() < *RWGSA->getZDimVal()) {
+      if (S.CheckMaxAllowedWorkGroupSize(
+              RWGSA->getXDim(), RWGSA->getYDim(), RWGSA->getZDim(),
+              Existing->getXDim(), Existing->getYDim(), Existing->getZDim())) {
         S.Diag(SYCLKernel->getLocation(),
                diag::err_conflicting_sycl_kernel_attributes);
         S.Diag(Existing->getLocation(), diag::note_conflicting_attribute);
@@ -4384,9 +4384,9 @@ static void PropagateAndDiagnoseDeviceAttr(
   case attr::Kind::WorkGroupSizeHint: {
     auto *WGSH = cast<WorkGroupSizeHintAttr>(A);
     if (auto *Existing = SYCLKernel->getAttr<WorkGroupSizeHintAttr>()) {
-      if (Existing->getXDimVal() != WGSH->getXDimVal() ||
-          Existing->getYDimVal() != WGSH->getYDimVal() ||
-          Existing->getZDimVal() != WGSH->getZDimVal()) {
+      if (S.AnyWorkGroupSizesDiffer(Existing->getXDim(), Existing->getYDim(),
+                                    Existing->getZDim(), WGSH->getXDim(),
+                                    WGSH->getYDim(), WGSH->getZDim())) {
         S.Diag(SYCLKernel->getLocation(),
                diag::err_conflicting_sycl_kernel_attributes);
         S.Diag(Existing->getLocation(), diag::note_conflicting_attribute);
@@ -4400,9 +4400,9 @@ static void PropagateAndDiagnoseDeviceAttr(
   case attr::Kind::SYCLIntelMaxWorkGroupSize: {
     auto *SIMWGSA = cast<SYCLIntelMaxWorkGroupSizeAttr>(A);
     if (auto *Existing = SYCLKernel->getAttr<ReqdWorkGroupSizeAttr>()) {
-      if (*Existing->getXDimVal() > *SIMWGSA->getXDimVal() ||
-          *Existing->getYDimVal() > *SIMWGSA->getYDimVal() ||
-          *Existing->getZDimVal() > *SIMWGSA->getZDimVal()) {
+      if (S.CheckMaxAllowedWorkGroupSize(
+              Existing->getXDim(), Existing->getYDim(), Existing->getZDim(),
+              SIMWGSA->getXDim(), SIMWGSA->getYDim(), SIMWGSA->getZDim())) {
         S.Diag(SYCLKernel->getLocation(),
                diag::err_conflicting_sycl_kernel_attributes);
         S.Diag(Existing->getLocation(), diag::note_conflicting_attribute);

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -529,7 +529,7 @@ static void collectSYCLAttributes(Sema &S, FunctionDecl *FD,
     llvm::copy_if(FD->getAttrs(), std::back_inserter(Attrs), [](Attr *A) {
       // FIXME: Make this list self-adapt as new SYCL attributes are added.
       return isa<IntelReqdSubGroupSizeAttr, IntelNamedSubGroupSizeAttr,
-                 ReqdWorkGroupSizeAttr, WorkGroupSizeHintAttr,
+                 SYCLReqdWorkGroupSizeAttr, WorkGroupSizeHintAttr,
                  SYCLIntelKernelArgsRestrictAttr, SYCLIntelNumSimdWorkItemsAttr,
                  SYCLIntelSchedulerTargetFmaxMhzAttr,
                  SYCLIntelMaxWorkGroupSizeAttr, SYCLIntelMaxGlobalWorkDimAttr,
@@ -4351,9 +4351,9 @@ static void PropagateAndDiagnoseDeviceAttr(
     }
     break;
   }
-  case attr::Kind::ReqdWorkGroupSize: {
-    auto *RWGSA = cast<ReqdWorkGroupSizeAttr>(A);
-    if (auto *Existing = SYCLKernel->getAttr<ReqdWorkGroupSizeAttr>()) {
+  case attr::Kind::SYCLReqdWorkGroupSize: {
+    auto *RWGSA = cast<SYCLReqdWorkGroupSizeAttr>(A);
+    if (auto *Existing = SYCLKernel->getAttr<SYCLReqdWorkGroupSizeAttr>()) {
       if (S.AnyWorkGroupSizesDiffer(Existing->getXDim(), Existing->getYDim(),
                                     Existing->getZDim(), RWGSA->getXDim(),
                                     RWGSA->getYDim(), RWGSA->getZDim())) {
@@ -4399,7 +4399,7 @@ static void PropagateAndDiagnoseDeviceAttr(
   }
   case attr::Kind::SYCLIntelMaxWorkGroupSize: {
     auto *SIMWGSA = cast<SYCLIntelMaxWorkGroupSizeAttr>(A);
-    if (auto *Existing = SYCLKernel->getAttr<ReqdWorkGroupSizeAttr>()) {
+    if (auto *Existing = SYCLKernel->getAttr<SYCLReqdWorkGroupSizeAttr>()) {
       if (S.CheckMaxAllowedWorkGroupSize(
               Existing->getXDim(), Existing->getYDim(), Existing->getZDim(),
               SIMWGSA->getXDim(), SIMWGSA->getYDim(), SIMWGSA->getZDim())) {

--- a/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/clang/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -880,9 +880,9 @@ static void instantiateSYCLIntelMaxWorkGroupSizeAttr(
                                      ZResult.get());
 }
 
-static void instantiateReqdWorkGroupSizeAttr(
+static void instantiateSYCLReqdWorkGroupSizeAttr(
     Sema &S, const MultiLevelTemplateArgumentList &TemplateArgs,
-    const ReqdWorkGroupSizeAttr *A, Decl *New) {
+    const SYCLReqdWorkGroupSizeAttr *A, Decl *New) {
   EnterExpressionEvaluationContext Unevaluated(
       S, Sema::ExpressionEvaluationContext::ConstantEvaluated);
   ExprResult XResult = S.SubstExpr(A->getXDim(), TemplateArgs);
@@ -895,8 +895,8 @@ static void instantiateReqdWorkGroupSizeAttr(
   if (ZResult.isInvalid())
     return;
 
-  S.AddReqdWorkGroupSizeAttr(New, *A, XResult.get(), YResult.get(),
-                             ZResult.get());
+  S.AddSYCLReqdWorkGroupSizeAttr(New, *A, XResult.get(), YResult.get(),
+                                 ZResult.get());
 }
 
 // This doesn't take any template parameters, but we have a custom action that
@@ -1147,10 +1147,10 @@ void Sema::InstantiateAttrs(const MultiLevelTemplateArgumentList &TemplateArgs,
           *this, TemplateArgs, SYCLIntelNoGlobalWorkOffset, New);
       continue;
     }
-    if (const auto *ReqdWorkGroupSize =
-            dyn_cast<ReqdWorkGroupSizeAttr>(TmplAttr)) {
-      instantiateReqdWorkGroupSizeAttr(*this, TemplateArgs, ReqdWorkGroupSize,
-                                       New);
+    if (const auto *SYCLReqdWorkGroupSize =
+            dyn_cast<SYCLReqdWorkGroupSizeAttr>(TmplAttr)) {
+      instantiateSYCLReqdWorkGroupSizeAttr(*this, TemplateArgs,
+                                           SYCLReqdWorkGroupSize, New);
       continue;
     }
     if (const auto *SYCLIntelMaxWorkGroupSize =

--- a/clang/test/CodeGenSYCL/reqd-work-group-size.cpp
+++ b/clang/test/CodeGenSYCL/reqd-work-group-size.cpp
@@ -5,62 +5,201 @@
 using namespace sycl;
 queue q;
 
+class Functor32 {
+public:
+  [[sycl::reqd_work_group_size(32)]] void operator()() const {}
+};
+class Functor32x16 {
+public:
+  [[sycl::reqd_work_group_size(32, 16)]] void operator()() const {}
+};
 class Functor32x16x16 {
+public:
+  [[sycl::reqd_work_group_size(32, 16, 16)]] void operator()() const {}
+};
+class CLFunctor32x16x16 {
 public:
   [[cl::reqd_work_group_size(32, 16, 16)]] void operator()() const {}
 };
 
-[[cl::reqd_work_group_size(8, 1, 1)]] void f8x1x1() {}
+[[sycl::reqd_work_group_size(8)]] void f8() {}
+[[sycl::reqd_work_group_size(8, 1)]] void f8x1() {}
+[[sycl::reqd_work_group_size(8, 1, 1)]] void f8x1x1() {}
+[[cl::reqd_work_group_size(8, 1, 1)]] void clf8x1x1() {}
 
-class Functor {
+class Functor1D {
+public:
+  void operator()() const {
+    f8();
+  }
+};
+class Functor2D {
+public:
+  void operator()() const {
+    f8x1();
+  }
+};
+class Functor3D {
 public:
   void operator()() const {
     f8x1x1();
   }
 };
+class CLFunctor3D {
+public:
+  void operator()() const {
+    clf8x1x1();
+  }
+};
 
+template <int SIZE>
+class FunctorTemp1D {
+public:
+  [[sycl::reqd_work_group_size(SIZE)]] void operator()() const {}
+};
+template <int SIZE, int SIZE1>
+class FunctorTemp2D {
+public:
+  [[sycl::reqd_work_group_size(SIZE, SIZE1)]] void operator()() const {}
+};
 template <int SIZE, int SIZE1, int SIZE2>
-class FunctorTemp {
+class FunctorTemp3D {
+public:
+  [[sycl::reqd_work_group_size(SIZE, SIZE1, SIZE2)]] void operator()() const {}
+};
+template <int SIZE, int SIZE1, int SIZE2>
+class CLFunctorTemp3D {
 public:
   [[cl::reqd_work_group_size(SIZE, SIZE1, SIZE2)]] void operator()() const {}
 };
 
+template <int N>
+[[sycl::reqd_work_group_size(N)]] void func1D() {}
+template <int N, int N1>
+[[sycl::reqd_work_group_size(N, N1)]] void func2D() {}
 template <int N, int N1, int N2>
-[[cl::reqd_work_group_size(N, N1, N2)]] void func() {}
+[[sycl::reqd_work_group_size(N, N1, N2)]] void func3D() {}
+template <int N, int N1, int N2>
+[[cl::reqd_work_group_size(N, N1, N2)]] void clfunc3D() {}
 
 int main() {
   q.submit([&](handler &h) {
-    Functor32x16x16 f32x16x16;
-    h.single_task<class kernel_name1>(f32x16x16);
+    CLFunctor32x16x16 clf32x16x16;
+    h.single_task<class kernel_name1>(clf32x16x16);
 
-    Functor f;
-    h.single_task<class kernel_name2>(f);
+    CLFunctor3D clf3d;
+    h.single_task<class kernel_name2>(clf3d);
 
     h.single_task<class kernel_name3>(
         []() [[cl::reqd_work_group_size(8, 8, 8)]]{});
 
-    FunctorTemp<2, 2, 2> ft;
-    h.single_task<class kernel_name4>(ft);
+    CLFunctorTemp3D<2, 2, 2> clft3d;
+    h.single_task<class kernel_name4>(clft3d);
 
     h.single_task<class kernel_name5>([]() {
-      func<8, 4, 4>();
+      clfunc3D<8, 4, 4>();
     });
 
     h.single_task<class kernel_name6>(
         []() [[cl::reqd_work_group_size(1, 8, 2)]]{});
+
+    Functor32x16x16 f32x16x16;
+    h.single_task<class kernel_name7>(f32x16x16);
+
+    Functor3D f3d;
+    h.single_task<class kernel_name8>(f3d);
+
+    h.single_task<class kernel_name9>(
+        []() [[sycl::reqd_work_group_size(8, 8, 8)]]{});
+
+    FunctorTemp3D<2, 2, 2> ft3d;
+    h.single_task<class kernel_name10>(ft3d);
+
+    h.single_task<class kernel_name11>([]() {
+      func3D<8, 4, 4>();
+    });
+
+    h.single_task<class kernel_name12>(
+        []() [[sycl::reqd_work_group_size(1, 8, 2)]]{});
+
+    Functor32x16 f32x16;
+    h.single_task<class kernel_name13>(f32x16);
+
+    Functor2D f2d;
+    h.single_task<class kernel_name14>(f2d);
+
+    h.single_task<class kernel_name15>(
+        []() [[sycl::reqd_work_group_size(8, 8)]]{});
+
+    FunctorTemp2D<2, 2> ft2d;
+    h.single_task<class kernel_name16>(ft2d);
+
+    h.single_task<class kernel_name17>([]() {
+      func2D<8, 4>();
+    });
+
+    h.single_task<class kernel_name18>(
+        []() [[sycl::reqd_work_group_size(1, 8)]]{});
+
+    Functor32 f32;
+    h.single_task<class kernel_name19>(f32);
+
+    Functor1D f1d;
+    h.single_task<class kernel_name20>(f1d);
+
+    h.single_task<class kernel_name21>(
+        []() [[sycl::reqd_work_group_size(8)]]{});
+
+    FunctorTemp1D<2> ft1d;
+    h.single_task<class kernel_name22>(ft1d);
+
+    h.single_task<class kernel_name23>([]() {
+      func1D<8>();
+    });
+
+    h.single_task<class kernel_name24>(
+        []() [[sycl::reqd_work_group_size(1)]]{});
   });
   return 0;
 }
 
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name1() #0 {{.*}} !reqd_work_group_size ![[WGSIZE32:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name2() #0 {{.*}} !reqd_work_group_size ![[WGSIZE8:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name3() #0 {{.*}} !reqd_work_group_size ![[WGSIZE88:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name4() #0 {{.*}} !reqd_work_group_size ![[WGSIZE22:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name5() #0 {{.*}} !reqd_work_group_size ![[WGSIZE44:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name6() #0 {{.*}} !reqd_work_group_size ![[WGSIZE2:[0-9]+]]
-// CHECK: ![[WGSIZE32]] = !{i32 16, i32 16, i32 32}
-// CHECK: ![[WGSIZE8]] = !{i32 1, i32 1, i32 8}
-// CHECK: ![[WGSIZE88]] = !{i32 8, i32 8, i32 8}
-// CHECK: ![[WGSIZE22]] = !{i32 2, i32 2, i32 2}
-// CHECK: ![[WGSIZE44]] = !{i32 4, i32 4, i32 8}
-// CHECK: ![[WGSIZE2]] = !{i32 2, i32 8, i32 1}
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name1() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D32:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name2() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D8:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name3() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D88:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name4() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D22:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name5() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D44:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name6() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D2:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name7() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D32]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name8() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D8]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name9() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D88]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name10() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D22]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name11() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D44]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name12() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D2]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name13() #0 {{.*}} !reqd_work_group_size ![[WGSIZE2D32:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name14() #0 {{.*}} !reqd_work_group_size ![[WGSIZE2D8:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name15() #0 {{.*}} !reqd_work_group_size ![[WGSIZE2D88:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name16() #0 {{.*}} !reqd_work_group_size ![[WGSIZE2D22:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name17() #0 {{.*}} !reqd_work_group_size ![[WGSIZE2D44:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name18() #0 {{.*}} !reqd_work_group_size ![[WGSIZE2D2:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name19() #0 {{.*}} !reqd_work_group_size ![[WGSIZE1D32:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name20() #0 {{.*}} !reqd_work_group_size ![[WGSIZE1D8:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name21() #0 {{.*}} !reqd_work_group_size ![[WGSIZE1D8]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name22() #0 {{.*}} !reqd_work_group_size ![[WGSIZE1D22:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name23() #0 {{.*}} !reqd_work_group_size ![[WGSIZE1D8]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name24() #0 {{.*}} !reqd_work_group_size ![[WGSIZE1D2:[0-9]+]]
+// CHECK: ![[WGSIZE3D32]] = !{i32 16, i32 16, i32 32}
+// CHECK: ![[WGSIZE3D8]] = !{i32 1, i32 1, i32 8}
+// CHECK: ![[WGSIZE3D88]] = !{i32 8, i32 8, i32 8}
+// CHECK: ![[WGSIZE3D22]] = !{i32 2, i32 2, i32 2}
+// CHECK: ![[WGSIZE3D44]] = !{i32 4, i32 4, i32 8}
+// CHECK: ![[WGSIZE3D2]] = !{i32 2, i32 8, i32 1}
+// CHECK: ![[WGSIZE2D32]] = !{i32 16, i32 32}
+// CHECK: ![[WGSIZE2D8]] = !{i32 1, i32 8}
+// CHECK: ![[WGSIZE2D88]] = !{i32 8, i32 8}
+// CHECK: ![[WGSIZE2D22]] = !{i32 2, i32 2}
+// CHECK: ![[WGSIZE2D44]] = !{i32 4, i32 8}
+// CHECK: ![[WGSIZE2D2]] = !{i32 8, i32 1}
+// CHECK: ![[WGSIZE1D32]] = !{i32 32}
+// CHECK: ![[WGSIZE1D8]] = !{i32 8}
+// CHECK: ![[WGSIZE1D22]] = !{i32 2}
+// CHECK: ![[WGSIZE1D2]] = !{i32 1}

--- a/clang/test/SemaOpenCL/invalid-kernel-attrs.cl
+++ b/clang/test/SemaOpenCL/invalid-kernel-attrs.cl
@@ -32,9 +32,9 @@ void f_kernel_image2d_t( kernel image2d_t image ) { // expected-error {{'kernel'
   int __kernel x; // expected-error {{'__kernel' attribute only applies to functions}}
 }
 
-kernel __attribute__((reqd_work_group_size(1,2,0))) void kernel11(){} // expected-error {{'reqd_work_group_size' attribute requires a positive integral compile time constant expression}}
-kernel __attribute__((reqd_work_group_size(1,0,2))) void kernel12(){} // expected-error {{'reqd_work_group_size' attribute requires a positive integral compile time constant expression}}
-kernel __attribute__((reqd_work_group_size(0,1,2))) void kernel13(){} // expected-error {{'reqd_work_group_size' attribute requires a positive integral compile time constant expression}}
+kernel __attribute__((reqd_work_group_size(1,2,0))) void kernel11(){} // expected-error {{'reqd_work_group_size' attribute must be greater than 0}}
+kernel __attribute__((reqd_work_group_size(1,0,2))) void kernel12(){} // expected-error {{'reqd_work_group_size' attribute must be greater than 0}}
+kernel __attribute__((reqd_work_group_size(0,1,2))) void kernel13(){} // expected-error {{'reqd_work_group_size' attribute must be greater than 0}}
 
 __attribute__((intel_reqd_sub_group_size(8))) void kernel14(){} // expected-error {{attribute 'intel_reqd_sub_group_size' can only be applied to an OpenCL kernel}}
 kernel __attribute__((intel_reqd_sub_group_size(0))) void kernel15() {} // expected-error {{'intel_reqd_sub_group_size' attribute requires a positive integral compile time constant expression}}

--- a/clang/test/SemaSYCL/check-direct-attribute-propagation.cpp
+++ b/clang/test/SemaSYCL/check-direct-attribute-propagation.cpp
@@ -177,7 +177,7 @@ int main() {
         []() [[intel::max_work_group_size(8, 8, 8)]]{});
 
     // CHECK:       FunctionDecl {{.*}}test_kernel13
-    // CHECK:       ReqdWorkGroupSizeAttr
+    // CHECK:       SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 2
     // CHECK-NEXT:  IntegerLiteral {{.*}} 'int' 2
@@ -192,12 +192,12 @@ int main() {
 
     // Test attribute is not propagated.
     // CHECK:      FunctionDecl {{.*}}test_kernel14
-    // CHECK-NOT:  ReqdWorkGroupSizeAttr
+    // CHECK-NOT:  SYCLReqdWorkGroupSizeAttr
     h.single_task<class test_kernel14>(
         []() { func4(); });
 
     // CHECK:       FunctionDecl {{.*}}test_kernel15
-    // CHECK:       ReqdWorkGroupSizeAttr
+    // CHECK:       SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 8
     // CHECK-NEXT:  IntegerLiteral {{.*}} 'int' 8

--- a/clang/test/SemaSYCL/intel-max-global-work-dim-device-ast.cpp
+++ b/clang/test/SemaSYCL/intel-max-global-work-dim-device-ast.cpp
@@ -157,7 +157,7 @@ int main() {
     // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
     // CHECK-NEXT:  value: Int 1
     // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
-    // CHECK:       ReqdWorkGroupSizeAttr {{.*}}
+    // CHECK:       SYCLReqdWorkGroupSizeAttr {{.*}}
     // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
     // CHECK-NEXT:  value: Int 1
     // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
@@ -184,7 +184,7 @@ int main() {
     // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
     // CHECK-NEXT:  value: Int 1
     // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
-    // CHECK:       ReqdWorkGroupSizeAttr
+    // CHECK:       SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
     // CHECK-NEXT:  value: Int 4
     // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
@@ -197,7 +197,7 @@ int main() {
 
     h.single_task<class test_kernel5>(TRIFuncObjGood3());
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel5
-    // CHECK:       ReqdWorkGroupSizeAttr
+    // CHECK:       SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
     // CHECK-NEXT:  value: Int 1
     // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
@@ -208,7 +208,7 @@ int main() {
 
     h.single_task<class test_kernel6>(TRIFuncObjGood4());
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel6
-    // CHECK:       ReqdWorkGroupSizeAttr
+    // CHECK:       SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
     // CHECK-NEXT:  value: Int 1
     // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
@@ -242,7 +242,7 @@ int main() {
 
     h.single_task<class test_kernel8>(TRIFuncObjGood6());
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel8
-    // CHECK:       ReqdWorkGroupSizeAttr
+    // CHECK:       SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
     // CHECK-NEXT:  value: Int 4
     // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
@@ -259,7 +259,7 @@ int main() {
 
     h.single_task<class test_kernel9>(TRIFuncObjGood7());
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel9
-    // CHECK:       ReqdWorkGroupSizeAttr
+    // CHECK:       SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
     // CHECK-NEXT:  value: Int 4
     // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}

--- a/clang/test/SemaSYCL/intel-max-global-work-dim-device-ast.cpp
+++ b/clang/test/SemaSYCL/intel-max-global-work-dim-device-ast.cpp
@@ -201,12 +201,6 @@ int main() {
     // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
     // CHECK-NEXT:  value: Int 1
     // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
-    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
-    // CHECK-NEXT:  value: Int 1
-    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
-    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
-    // CHECK-NEXT:  value: Int 1
-    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
     // CHECK:       SYCLIntelMaxGlobalWorkDimAttr
     // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
     // CHECK-NEXT:  value: Int 0

--- a/clang/test/SemaSYCL/intel-max-work-group-size.cpp
+++ b/clang/test/SemaSYCL/intel-max-work-group-size.cpp
@@ -101,10 +101,10 @@ f15() {} // OK
 [[intel::max_work_group_size(1, 2, 3)]] [[sycl::reqd_work_group_size(1, 2, 3)]] void f17(){}; // OK
 
 [[sycl::reqd_work_group_size(16)]]            // expected-note {{conflicting attribute is here}}
-[[intel::max_work_group_size(1, 1, 16)]] void // expected-error {{'max_work_group_size' attribute conflicts with 'reqd_work_group_size' attribute}}
+[[intel::max_work_group_size(16, 1, 1)]] void // expected-error {{'max_work_group_size' attribute conflicts with 'reqd_work_group_size' attribute}}
 f18();
 
-[[intel::max_work_group_size(16, 16, 1)]] void f19();
+[[intel::max_work_group_size(1, 16, 16)]] void f19();
 [[sycl::reqd_work_group_size(16, 16)]] void f19(); // OK
 
 // Test that checks wrong function template instantiation and ensures that the type

--- a/clang/test/SemaSYCL/intel-reqd-work-group-size-ast-device.cpp
+++ b/clang/test/SemaSYCL/intel-reqd-work-group-size-ast-device.cpp
@@ -21,7 +21,7 @@ void test() {
 // CHECK: ClassTemplateDecl {{.*}} {{.*}} KernelFunctor
 // CHECK: ClassTemplateSpecializationDecl {{.*}} {{.*}} class KernelFunctor definition
 // CHECK: CXXRecordDecl {{.*}} {{.*}} implicit class KernelFunctor
-// CHECK: ReqdWorkGroupSizeAttr
+// CHECK: SYCLReqdWorkGroupSizeAttr
 // CHECK-NEXT: ConstantExpr{{.*}}'int'
 // CHECK-NEXT: value: Int 16
 // CHECK-NEXT: SubstNonTypeTemplateParmExpr {{.*}}
@@ -48,7 +48,7 @@ int check() {
 }
 // CHECK: FunctionTemplateDecl {{.*}} {{.*}} func3
 // CHECK: FunctionDecl {{.*}} {{.*}} used func3 'void ()'
-// CHECK: ReqdWorkGroupSizeAttr
+// CHECK: SYCLReqdWorkGroupSizeAttr
 // CHECK-NEXT: ConstantExpr{{.*}}'int'
 // CHECK-NEXT: value: Int 8
 // CHECK: SubstNonTypeTemplateParmExpr {{.*}}
@@ -99,7 +99,7 @@ public:
 int main() {
   q.submit([&](handler &h) {
     // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name1
-    // CHECK: ReqdWorkGroupSizeAttr
+    // CHECK: SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 16
     // CHECK-NEXT:  IntegerLiteral{{.*}}16{{$}}
@@ -107,7 +107,7 @@ int main() {
     h.single_task<class kernel_name1>(f16);
 
     // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name2
-    // CHECK: ReqdWorkGroupSizeAttr
+    // CHECK: SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 4
     // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
@@ -115,7 +115,7 @@ int main() {
     h.single_task<class kernel_name2>(f);
 
     // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name3
-    // CHECK: ReqdWorkGroupSizeAttr
+    // CHECK: SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 16
     // CHECK-NEXT:  IntegerLiteral{{.*}}16{{$}}
@@ -129,7 +129,7 @@ int main() {
     h.single_task<class kernel_name3>(f16x16x16);
 
     // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name4
-    // CHECK: ReqdWorkGroupSizeAttr
+    // CHECK: SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 128
     // CHECK-NEXT:  IntegerLiteral{{.*}}128{{$}}
@@ -143,7 +143,7 @@ int main() {
     h.single_task<class kernel_name4>(fattr);
 
     // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name5
-    // CHECK: ReqdWorkGroupSizeAttr
+    // CHECK: SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 32
     // CHECK-NEXT:  IntegerLiteral{{.*}}32{{$}}
@@ -172,7 +172,7 @@ int main() {
     // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
     // CHECK-NEXT:  value: Int 4
     // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
-    // CHECK: ReqdWorkGroupSizeAttr
+    // CHECK: SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
     // CHECK-NEXT:  value: Int 2
     // CHECK-NEXT:  IntegerLiteral{{.*}}2{{$}}

--- a/clang/test/SemaSYCL/intel-reqd-work-group-size-ast-device.cpp
+++ b/clang/test/SemaSYCL/intel-reqd-work-group-size-ast-device.cpp
@@ -65,7 +65,7 @@ int check() {
 // CHECK-NEXT: NonTypeTemplateParmDecl {{.*}}
 // CHECK-NEXT: IntegerLiteral{{.*}}8{{$}}
 
-[[sycl::reqd_work_group_size(4)]] void f4x1x1() {}
+[[sycl::reqd_work_group_size(4)]] void f4() {}
 
 class Functor16 {
 public:
@@ -80,7 +80,7 @@ public:
 class Functor {
 public:
   void operator()() const {
-    f4x1x1();
+    f4();
   }
 };
 
@@ -103,12 +103,6 @@ int main() {
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 16
     // CHECK-NEXT:  IntegerLiteral{{.*}}16{{$}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 1
-    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 1
-    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
     Functor16 f16;
     h.single_task<class kernel_name1>(f16);
 
@@ -117,12 +111,6 @@ int main() {
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 4
     // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 1
-    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 1
-    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
     Functor f;
     h.single_task<class kernel_name2>(f);
 

--- a/clang/test/SemaSYCL/intel-reqd-work-group-size-device.cpp
+++ b/clang/test/SemaSYCL/intel-reqd-work-group-size-device.cpp
@@ -7,13 +7,13 @@
 using namespace sycl;
 queue q;
 
-[[sycl::reqd_work_group_size(4)]] void f4x1x1() {} // expected-note {{conflicting attribute is here}}
+[[sycl::reqd_work_group_size(4)]] void f4() {} // expected-note {{conflicting attribute is here}}
 // expected-note@-1 {{conflicting attribute is here}}
-[[sycl::reqd_work_group_size(32)]] void f32x1x1() {} // expected-note {{conflicting attribute is here}}
-[[sycl::reqd_work_group_size(16)]] void f16x1x1() {}      // expected-note {{conflicting attribute is here}}
-[[sycl::reqd_work_group_size(16, 16)]] void f16x16x1() {} // expected-note {{conflicting attribute is here}}
+[[sycl::reqd_work_group_size(32)]] void f32() {} // expected-note {{conflicting attribute is here}}
+[[sycl::reqd_work_group_size(16)]] void f16() {}      // expected-note {{conflicting attribute is here}}
+[[sycl::reqd_work_group_size(16, 16)]] void f16x16() {} // expected-note {{conflicting attribute is here}}
 
-[[sycl::reqd_work_group_size(32, 32)]] void f32x32x1() {}      // expected-note {{conflicting attribute is here}}
+[[sycl::reqd_work_group_size(32, 32)]] void f32x32() {}      // expected-note {{conflicting attribute is here}}
 [[sycl::reqd_work_group_size(32, 32, 32)]] void f32x32x32() {} // expected-note {{conflicting attribute is here}}
 
 [[intel::reqd_work_group_size(4, 2, 9)]] void unknown() {} // expected-warning{{unknown attribute 'reqd_work_group_size' ignored}}
@@ -21,7 +21,7 @@ queue q;
 class Functor8 { // expected-error {{conflicting attributes applied to a SYCL kernel}}
 public:
   [[sycl::reqd_work_group_size(8)]] void operator()() const { // expected-note {{conflicting attribute is here}}
-    f4x1x1();
+    f4();
   }
 };
 
@@ -38,18 +38,18 @@ int main() {
     h.single_task<class kernel_name1>(f8);
 
     h.single_task<class kernel_name2>([]() { // expected-error {{conflicting attributes applied to a SYCL kernel}}
-      f4x1x1();
-      f32x1x1();
+      f4();
+      f32();
     });
 
     h.single_task<class kernel_name3>([]() { // expected-error {{conflicting attributes applied to a SYCL kernel}}
-      f16x1x1();
-      f16x16x1();
+      f16();
+      f16x16();
     });
 
     h.single_task<class kernel_name4>([]() { // expected-error {{conflicting attributes applied to a SYCL kernel}}
       f32x32x32();
-      f32x32x1();
+      f32x32();
     });
 
     // expected-error@+1 {{expected variable name or 'this' in lambda capture list}}

--- a/clang/test/SemaSYCL/num_simd_work_items.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items.cpp
@@ -38,58 +38,30 @@ struct TRIFuncObjBad2 {
 
 // Tests for the default values of [[sycl::reqd_work_group_size()]].
 
-// FIXME: This should be accepted instead of error which turns out to be
-// an implementation bug that shouldn't be visible to the user as there
-// aren't really any default values. The dimensionality of the attribute
-// must match the kernel, so three different forms of the attribute
-// (one, two, and three argument) can be used instead of assuming default
-// values. This prevents redeclaring the function with a different
-// dimensionality.
-struct TRIFuncObjBad3 {
-  [[intel::num_simd_work_items(3)]] // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
-  [[sycl::reqd_work_group_size(3)]] // expected-note{{conflicting attribute is here}}
+struct TRIFuncObjGood3 {
+  [[intel::num_simd_work_items(3)]]
+  [[sycl::reqd_work_group_size(3)]]
   void
   operator()() const {}
 };
 
-// FIXME: This should be accepted instead of error which turns out to be
-// an implementation bug that shouldn't be visible to the user as there
-// aren't really any default values. The dimensionality of the attribute
-// must match the kernel, so three different forms of the attribute
-// (one, two, and three argument) can be used instead of assuming default
-// values. This prevents redeclaring the function with a different
-// dimensionality.
-struct TRIFuncObjBad4 {
-  [[sycl::reqd_work_group_size(3)]] // expected-note{{conflicting attribute is here}}
-  [[intel::num_simd_work_items(3)]] // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
+struct TRIFuncObjGood4 {
+  [[sycl::reqd_work_group_size(3)]]
+  [[intel::num_simd_work_items(3)]]
   void
   operator()() const {}
 };
 
-// FIXME: This should be accepted instead of error which turns out to be
-// an implementation bug that shouldn't be visible to the user as there
-// aren't really any default values. The dimensionality of the attribute
-// must match the kernel, so three different forms of the attribute
-// (one, two, and three argument) can be used instead of assuming default
-// values. This prevents redeclaring the function with a different
-// dimensionality.
-struct TRIFuncObjBad5 {
-  [[intel::num_simd_work_items(4)]]     // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
-  [[sycl::reqd_work_group_size(4, 64)]] // expected-note{{conflicting attribute is here}}
+struct TRIFuncObjGood5 {
+  [[intel::num_simd_work_items(4)]]
+  [[sycl::reqd_work_group_size(4, 64)]]
   void
   operator()() const {}
 };
 
-// FIXME: This should be accepted instead of error which turns out to be
-// an implementation bug that shouldn't be visible to the user as there
-// aren't really any default values. The dimensionality of the attribute
-// must match the kernel, so three different forms of the attribute
-// (one, two, and three argument) can be used instead of assuming default
-// values. This prevents redeclaring the function with a different
-// dimensionality.
-struct TRIFuncObjBad6 {
-  [[sycl::reqd_work_group_size(4, 64)]] // expected-note{{conflicting attribute is here}}
-  [[intel::num_simd_work_items(4)]]     // expected-error{{'num_simd_work_items' attribute must evenly divide the work-group size for the 'reqd_work_group_size' attribute}}
+struct TRIFuncObjGood6 {
+  [[sycl::reqd_work_group_size(4, 64)]]
+  [[intel::num_simd_work_items(4)]]
   void
   operator()() const {}
 };
@@ -225,13 +197,13 @@ int main() {
 
     h.single_task<class test_kernel4>(TRIFuncObjBad2());
 
-    h.single_task<class test_kernel5>(TRIFuncObjBad3());
+    h.single_task<class test_kernel5>(TRIFuncObjGood3());
 
-    h.single_task<class test_kernel6>(TRIFuncObjBad4());
+    h.single_task<class test_kernel6>(TRIFuncObjGood4());
 
-    h.single_task<class test_kernel7>(TRIFuncObjBad5());
+    h.single_task<class test_kernel7>(TRIFuncObjGood5());
 
-    h.single_task<class test_kernel8>(TRIFuncObjBad6());
+    h.single_task<class test_kernel8>(TRIFuncObjGood6());
 
     h.single_task<class test_kernel9>(TRIFuncObjBad7());
 

--- a/clang/test/SemaSYCL/num_simd_work_items_ast.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items_ast.cpp
@@ -130,7 +130,7 @@ int main() {
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 4
     // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
-    // CHECK:       ReqdWorkGroupSizeAttr {{.*}}
+    // CHECK:       SYCLReqdWorkGroupSizeAttr {{.*}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 3
     // CHECK-NEXT:  IntegerLiteral{{.*}}3{{$}}
@@ -143,7 +143,7 @@ int main() {
 
     h.single_task<class test_kernel5>(TRIFuncObjGood2());
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel5
-    // CHECK:       ReqdWorkGroupSizeAttr {{.*}}
+    // CHECK:       SYCLReqdWorkGroupSizeAttr {{.*}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 3
     // CHECK-NEXT:  IntegerLiteral{{.*}}3{{$}}
@@ -164,7 +164,7 @@ int main() {
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 4
     // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
-    // CHECK:       ReqdWorkGroupSizeAttr {{.*}}
+    // CHECK:       SYCLReqdWorkGroupSizeAttr {{.*}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 3
     // CHECK-NEXT:  IntegerLiteral{{.*}}3{{$}}
@@ -177,7 +177,7 @@ int main() {
 
     h.single_task<class test_kernel7>(TRIFuncObjGood4());
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel7
-    // CHECK:       ReqdWorkGroupSizeAttr {{.*}}
+    // CHECK:       SYCLReqdWorkGroupSizeAttr {{.*}}
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 3
     // CHECK-NEXT:  IntegerLiteral{{.*}}3{{$}}
@@ -198,7 +198,7 @@ int main() {
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 5
     // CHECK-NEXT:  IntegerLiteral{{.*}}5{{$}}
-    // CHECK:       ReqdWorkGroupSizeAttr
+    // CHECK:       SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 3
     // CHECK-NEXT:  IntegerLiteral{{.*}}3{{$}}
@@ -211,7 +211,7 @@ int main() {
 
     h.single_task<class test_kernel9>(TRIFuncObjGood6());
     // CHECK-LABEL: FunctionDecl {{.*}}test_kernel9
-    // CHECK:       ReqdWorkGroupSizeAttr
+    // CHECK:       SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 3
     // CHECK-NEXT:  IntegerLiteral{{.*}}3{{$}}

--- a/clang/test/SemaSYCL/reqd-work-group-size-device-direct-prop.cpp
+++ b/clang/test/SemaSYCL/reqd-work-group-size-device-direct-prop.cpp
@@ -38,7 +38,7 @@ public:
 int main() {
   q.submit([&](handler &h) {
     // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name1
-    // CHECK: ReqdWorkGroupSizeAttr
+    // CHECK: SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 16
     // CHECK-NEXT:  IntegerLiteral {{.*}} 'int' 16
@@ -52,7 +52,7 @@ int main() {
     h.single_task<class kernel_name1>(f16x16x16);
 
     // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name2
-    // CHECK: ReqdWorkGroupSizeAttr
+    // CHECK: SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 128
     // CHECK-NEXT:  IntegerLiteral {{.*}} 'int' 128
@@ -79,7 +79,7 @@ int main() {
     h.single_task<class test_kernel3>(TRIFuncObjGood());
 
     // CHECK: FunctionDecl {{.*}} {{.*}}test_kernel4
-    // CHECK: ReqdWorkGroupSizeAttr
+    // CHECK: SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 16
     // CHECK-NEXT:  IntegerLiteral {{.*}} 'int' 16
@@ -87,7 +87,7 @@ int main() {
     h.single_task<class test_kernel4>(f16);
 
     // CHECK: FunctionDecl {{.*}} {{.*}}test_kernel5
-    // CHECK: ReqdWorkGroupSizeAttr
+    // CHECK: SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 64
     // CHECK-NEXT:  IntegerLiteral {{.*}} 'int' 64

--- a/clang/test/SemaSYCL/reqd-work-group-size-device-direct-prop.cpp
+++ b/clang/test/SemaSYCL/reqd-work-group-size-device-direct-prop.cpp
@@ -83,12 +83,6 @@ int main() {
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 16
     // CHECK-NEXT:  IntegerLiteral {{.*}} 'int' 16
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 1
-    // CHECK-NEXT:  IntegerLiteral {{.*}} 'int' 1
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 1
-    // CHECK-NEXT:  IntegerLiteral {{.*}} 'int' 1
     Functor16 f16;
     h.single_task<class test_kernel4>(f16);
 
@@ -100,9 +94,6 @@ int main() {
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 64
     // CHECK-NEXT:  IntegerLiteral {{.*}} 'int' 64
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 1
-    // CHECK-NEXT:  IntegerLiteral {{.*}} 'int' 1
     Functor64 f64;
     h.single_task<class test_kernel5>(f64);
   });

--- a/clang/test/SemaSYCL/reqd-work-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-work-group-size-device.cpp
@@ -18,19 +18,25 @@ queue q;
 [[sycl::reqd_work_group_size(32, 32, 32)]] void f32x32x32() {} // expected-note {{conflicting attribute is here}}
 
 // No diagnostic because the attributes are synonyms with identical behavior.
-[[sycl::reqd_work_group_size(4, 4, 4)]] void four();
-[[sycl::reqd_work_group_size(4, 4, 4)]] void four(); // OK
+[[sycl::reqd_work_group_size(4, 4, 4)]] void four1();
+[[sycl::reqd_work_group_size(4, 4, 4)]] void four1(); // OK
+[[sycl::reqd_work_group_size(4, 4)]] void four2();
+[[sycl::reqd_work_group_size(4, 4)]] void four2(); // OK
+[[sycl::reqd_work_group_size(4)]] void four3();
+[[sycl::reqd_work_group_size(4)]] void four3(); // OK
 
 #ifdef TRIGGER_ERROR
 // Althrough optional values are effectively representing 1's, the attributes
 // should be considered different when there is a different in the arguments
 // given.
-[[sycl::reqd_work_group_size(4)]] void four_again();
-[[sycl::reqd_work_group_size(4)]] void four_again(); // expected-note {{previous attribute is here}}
-[[sycl::reqd_work_group_size(4, 1)]] void four_again(); // expected-error {{attribute 'reqd_work_group_size' is already applied with different arguments}} expected-note {{previous attribute is here}}
-[[sycl::reqd_work_group_size(4, 1, 1)]] void four_again(); // expected-error {{attribute 'reqd_work_group_size' is already applied with different arguments}} expected-note {{previous attribute is here}}
-[[sycl::reqd_work_group_size(1, 4)]] void four_again(); // expected-error {{attribute 'reqd_work_group_size' is already applied with different arguments}} expected-note {{previous attribute is here}}
-[[sycl::reqd_work_group_size(1, 1, 4)]] void four_again(); // expected-error {{attribute 'reqd_work_group_size' is already applied with different arguments}}
+[[sycl::reqd_work_group_size(4)]] void four4(); // expected-note {{previous attribute is here}}
+[[sycl::reqd_work_group_size(4, 1)]] void four4(); // expected-error {{attribute 'reqd_work_group_size' is already applied with different arguments}}
+[[sycl::reqd_work_group_size(4)]] void four5(); // expected-note {{previous attribute is here}}
+[[sycl::reqd_work_group_size(4, 1, 1)]] void four5(); // expected-error {{attribute 'reqd_work_group_size' is already applied with different arguments}}
+[[sycl::reqd_work_group_size(4)]] void four6(); // expected-note {{previous attribute is here}}
+[[sycl::reqd_work_group_size(1, 4)]] void four6(); // expected-error {{attribute 'reqd_work_group_size' is already applied with different arguments}}
+[[sycl::reqd_work_group_size(4)]] void four7(); // expected-note {{previous attribute is here}}
+[[sycl::reqd_work_group_size(1, 1, 4)]] void four7(); // expected-error {{attribute 'reqd_work_group_size' is already applied with different arguments}}
 #endif
 
 // Make sure there's at least one argument passed for the SYCL spelling.

--- a/clang/test/SemaSYCL/reqd-work-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-work-group-size-device.cpp
@@ -21,19 +21,17 @@ queue q;
 [[sycl::reqd_work_group_size(4, 4, 4)]] void four();
 [[sycl::reqd_work_group_size(4, 4, 4)]] void four(); // OK
 
-// Same for the default values.
-// FIXME: This turns out to be wrong as there aren't really default values
-// (that is an implementation detail we use but shouldn't expose to the user).
-// Instead, the dimensionality of the attribute needs to match that of the
-// kernel, so the one, two, and three arg forms of the attribute are actually
-// *different* attributes. This means that you should not be able to redeclare
-// the function with a different dimensionality.
+#ifdef TRIGGER_ERROR
+// Althrough optional values are effectively representing 1's, the attributes
+// should be considered different when there is a different in the arguments
+// given.
 [[sycl::reqd_work_group_size(4)]] void four_again();
-[[sycl::reqd_work_group_size(4)]] void four_again(); // OK
-[[sycl::reqd_work_group_size(4, 1)]] void four_again(); // OK
-[[sycl::reqd_work_group_size(4, 1)]] void four_again(); // OK
-[[sycl::reqd_work_group_size(4, 1, 1)]] void four_again(); // OK
-[[sycl::reqd_work_group_size(4, 1, 1)]] void four_again(); // OK
+[[sycl::reqd_work_group_size(4)]] void four_again(); // expected-note {{previous attribute is here}}
+[[sycl::reqd_work_group_size(4, 1)]] void four_again(); // expected-error {{attribute 'reqd_work_group_size' is already applied with different arguments}} expected-note {{previous attribute is here}}
+[[sycl::reqd_work_group_size(4, 1, 1)]] void four_again(); // expected-error {{attribute 'reqd_work_group_size' is already applied with different arguments}} expected-note {{previous attribute is here}}
+[[sycl::reqd_work_group_size(1, 4)]] void four_again(); // expected-error {{attribute 'reqd_work_group_size' is already applied with different arguments}} expected-note {{previous attribute is here}}
+[[sycl::reqd_work_group_size(1, 1, 4)]] void four_again(); // expected-error {{attribute 'reqd_work_group_size' is already applied with different arguments}}
+#endif
 
 // Make sure there's at least one argument passed for the SYCL spelling.
 #ifdef TRIGGER_ERROR

--- a/clang/test/SemaSYCL/reqd-work-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-work-group-size-device.cpp
@@ -128,7 +128,7 @@ int main() {
 }
 
 // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name1
-// CHECK: ReqdWorkGroupSizeAttr {{.*}}
+// CHECK: SYCLReqdWorkGroupSizeAttr {{.*}}
 // CHECK-NEXT:  ConstantExpr{{.*}}'int'
 // CHECK-NEXT:  value: Int 16
 // CHECK-NEXT:  IntegerLiteral{{.*}}16{{$}}
@@ -139,7 +139,7 @@ int main() {
 // CHECK-NEXT:  value: Int 1
 // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
 // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name2
-// CHECK: ReqdWorkGroupSizeAttr {{.*}}
+// CHECK: SYCLReqdWorkGroupSizeAttr {{.*}}
 // CHECK-NEXT:  ConstantExpr{{.*}}'int'
 // CHECK-NEXT:  value: Int 4
 // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
@@ -150,7 +150,7 @@ int main() {
 // CHECK-NEXT:  value: Int 1
 // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
 // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name3
-// CHECK: ReqdWorkGroupSizeAttr {{.*}}
+// CHECK: SYCLReqdWorkGroupSizeAttr {{.*}}
 // CHECK-NEXT:  ConstantExpr{{.*}}'int'
 // CHECK-NEXT:  value: Int 16
 // CHECK-NEXT:  IntegerLiteral{{.*}}16{{$}}
@@ -161,7 +161,7 @@ int main() {
 // CHECK-NEXT:  value: Int 16
 // CHECK-NEXT:  IntegerLiteral{{.*}}16{{$}}
 // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name5
-// CHECK: ReqdWorkGroupSizeAttr {{.*}}
+// CHECK: SYCLReqdWorkGroupSizeAttr {{.*}}
 // CHECK-NEXT:  ConstantExpr{{.*}}'int'
 // CHECK-NEXT:  value: Int 32
 // CHECK-NEXT:  IntegerLiteral{{.*}}32{{$}}
@@ -173,7 +173,7 @@ int main() {
 // CHECK-NEXT:  IntegerLiteral{{.*}}32{{$}}
 //
 // CHECK: FunctionDecl {{.*}}test_kernel11
-// CHECK: ReqdWorkGroupSizeAttr
+// CHECK: SYCLReqdWorkGroupSizeAttr
 // CHECK-NEXT:  ConstantExpr{{.*}}'int'
 // CHECK-NEXT:  value: Int 2
 // CHECK-NEXT:  IntegerLiteral{{.*}}2{{$}}
@@ -183,4 +183,4 @@ int main() {
 // CHECK-NEXT:  ConstantExpr{{.*}}'int'
 // CHECK-NEXT:  value: Int 2
 // CHECK-NEXT:  IntegerLiteral{{.*}}2{{$}}
-// CHECK-NOT:   ReqdWorkGroupSizeAttr
+// CHECK-NOT:   SYCLReqdWorkGroupSizeAttr

--- a/clang/test/SemaSYCL/reqd_work_group_size.cpp
+++ b/clang/test/SemaSYCL/reqd_work_group_size.cpp
@@ -114,7 +114,8 @@ void instantiate() {
 [[sycl::reqd_work_group_size(1, 1, 8)]] void // expected-error {{attribute 'reqd_work_group_size' is already applied with different arguments}}
 f8(){};
 
-[[sycl::reqd_work_group_size(32, 32, 1)]] [[sycl::reqd_work_group_size(32, 32)]] void f9() {} // OK
+[[sycl::reqd_work_group_size(32, 32, 1)]]            // expected-note {{previous attribute is here}}
+[[sycl::reqd_work_group_size(32, 32)]] void f9() {}  // expected-error {{attribute 'reqd_work_group_size' is already applied with different arguments}}
 
 // Test that template redeclarations also get diagnosed properly.
 template <int X, int Y, int Z>

--- a/clang/test/SemaSYCL/sycl-device-intel-reqd-work-group-size-template.cpp
+++ b/clang/test/SemaSYCL/sycl-device-intel-reqd-work-group-size-template.cpp
@@ -40,7 +40,7 @@ int main() {
 // CHECK: ClassTemplateDecl {{.*}} {{.*}} KernelFunctor
 // CHECK: ClassTemplateSpecializationDecl {{.*}} {{.*}} class KernelFunctor definition
 // CHECK: CXXRecordDecl {{.*}} {{.*}} implicit class KernelFunctor
-// CHECK: ReqdWorkGroupSizeAttr {{.*}}
+// CHECK: SYCLReqdWorkGroupSizeAttr {{.*}}
 // CHECK-NEXT: ConstantExpr{{.*}}'int'
 // CHECK-NEXT: value: Int 16
 // CHECK-NEXT: SubstNonTypeTemplateParmExpr {{.*}}
@@ -68,7 +68,7 @@ int check() {
 
 // CHECK: FunctionTemplateDecl {{.*}} {{.*}} func3
 // CHECK: FunctionDecl {{.*}} {{.*}} used func3 'void ()'
-// CHECK: ReqdWorkGroupSizeAttr {{.*}}
+// CHECK: SYCLReqdWorkGroupSizeAttr {{.*}}
 // CHECK-NEXT: ConstantExpr{{.*}}'int'
 // CHECK-NEXT: value: Int 8
 // CHECK-NEXT: SubstNonTypeTemplateParmExpr {{.*}}
@@ -88,7 +88,7 @@ int check() {
 // No diagnostic is emitted because the arguments match. Duplicate attribute is silently ignored.
 [[sycl::reqd_work_group_size(4, 4, 4)]] [[sycl::reqd_work_group_size(4, 4, 4)]] void func4() {}
 // CHECK: FunctionDecl {{.*}} {{.*}} func4 'void ()'
-// CHECK:       ReqdWorkGroupSizeAttr
+// CHECK:       SYCLReqdWorkGroupSizeAttr
 // CHECK-NEXT:  ConstantExpr{{.*}}'int'
 // CHECK-NEXT:  value: Int 4
 // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
@@ -98,4 +98,4 @@ int check() {
 // CHECK-NEXT:  ConstantExpr{{.*}}'int'
 // CHECK-NEXT:  value: Int 4
 // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
-// CHECK-NOT:   ReqdWorkGroupSizeAttr
+// CHECK-NOT:   SYCLReqdWorkGroupSizeAttr

--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -4062,12 +4062,10 @@ static void GenerateLangOptRequirements(const Record &R,
   // use the default handler.
   std::vector<Record *> LangOpts = R.getValueAsListOfDefs("LangOpts");
 
-  // If there are other attributes which share the same parsed attribute kind,
-  // such as target-specific attributes with a shared spelling, collapse the
-  // duplicate architectures. This is required because a shared target-specific
-  // attribute has only one ParsedAttr::Kind enumeration value, but it
-  // applies to multiple target architectures. In order for the attribute to be
-  // considered valid, all of its architectures need to be included.
+  // Attributes inheriting from LanguageOptionsSpecificAttr may share their
+  // ParseKind name with other attributes. Attributes like these are considered
+  // valid for a given language option if any of the attributes they share
+  // ParseKind with accepts it.
   if (R.isSubClassOf("LanguageOptionsSpecificAttr") &&
       !R.isValueUnset("ParseKind")) {
     const StringRef APK = R.getValueAsString("ParseKind");


### PR DESCRIPTION
In the current implementation the sycl::reqd_work_group_size attribute sets the Y and Z dimension arguments optional. However, when the internal representation of the attribute is created it will be padded with 1's in the additional dimensions. An effect of this padding is that dimensionality information is lost, which has three big drawbacks:
 1. SYCL work-group sizes are reversed, but only the specified dimensions are reversed. For example `sycl::reqd_work_group_size(1, 2, 3)` is for the backends the same as a backend work-group of size `<3,2,1>`, but `sycl::reqd_work_group_size(3)` corresonds to a backend work-group of `<3,1,1>` rather than `<1,1,3>`.
 2. The SYCL runtime is supposed to throw an exception when a kernel is launched with a number of dimensions that does not match the `sycl::reqd_work_group_size`'s dimensionality. sycl-post-link generates kernel meta-information for the runtime which could be used to diagnose these, but since the attribute is padded with 1's the `reqd_work_group_size` metadata node knows no difference between it and a user-specified attribute with trailing 1's.
 3. Sema cannot know the difference between two attributes where one was padded with 1's by the user and one was not, so it currently thinks these are equivalent.
 
To fix these, this patch changes Sema to not add the padding and instead consider cases where the Y and Z dimensions are unset. This only affects the SYCL spelling of the attribute.
Additionally, when generating the `reqd_work_group_size` attribute CodeGen will only generate a metadata value for dimensions that have been set.