### PR TITLE
[SYCL-MLIR]: Remove -no-opt-mlir

### DIFF
--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -102,10 +102,6 @@ static llvm::cl::opt<bool> OpenMPOpt("openmp-opt", llvm::cl::init(true),
                                      llvm::cl::desc("Turn on openmp opt"));
 
 static llvm::cl::opt<bool>
-    DoNotOptimizeMLIR("no-opt-mlir", llvm::cl::init(false),
-                      llvm::cl::desc("Do not optimize MLIR"));
-
-static llvm::cl::opt<bool>
     ParallelLICM("parallel-licm", llvm::cl::init(true),
                  llvm::cl::desc("Turn on parallel licm"));
 

--- a/polygeist/tools/cgeist/Test/Verification/affine_loop.c
+++ b/polygeist/tools/cgeist/Test/Verification/affine_loop.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=kernel_deriche -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=kernel_deriche -S | FileCheck %s
 
 void kernel_deriche(int w, int h, double alpha, double** y2) {
     int i,j;

--- a/polygeist/tools/cgeist/Test/Verification/base_with_virt.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/base_with_virt.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
 
 class M {
 };

--- a/polygeist/tools/cgeist/Test/Verification/base_with_virt2.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/base_with_virt2.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
 
 class M {
 };

--- a/polygeist/tools/cgeist/Test/Verification/canonicalization.c
+++ b/polygeist/tools/cgeist/Test/Verification/canonicalization.c
@@ -1,4 +1,4 @@
-// RUN: cgeist --S --function=* --memref-fullrank %s | FileCheck %s
+// RUN: cgeist --S -O2 --function=* --memref-fullrank %s | FileCheck %s
 
 // The following should be able to fully lower to memref ops without memref
 // subviews.

--- a/polygeist/tools/cgeist/Test/Verification/capture.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/capture.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
 
 extern "C" {
 

--- a/polygeist/tools/cgeist/Test/Verification/classrefmem.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/classrefmem.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
 
 extern int& moo;
 void oadd(int& x) {

--- a/polygeist/tools/cgeist/Test/Verification/consabi.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/consabi.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
 
 class D {
   double a;

--- a/polygeist/tools/cgeist/Test/Verification/cudaglobalcodegen.cu
+++ b/polygeist/tools/cgeist/Test/Verification/cudaglobalcodegen.cu
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --cuda-gpu-arch=sm_60 -nocudalib -nocudainc %resourcedir --function=* -S | FileCheck %s
+// RUN: cgeist %s -O2 --cuda-gpu-arch=sm_60 -nocudalib -nocudainc %resourcedir --function=* -S | FileCheck %s
 
 #include "Inputs/cuda.h"
 

--- a/polygeist/tools/cgeist/Test/Verification/dynalloc.c
+++ b/polygeist/tools/cgeist/Test/Verification/dynalloc.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=create_matrix -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=create_matrix -S | FileCheck %s
 
 void create_matrix(float *m, int size) {
   float coe[2 * size + 1];

--- a/polygeist/tools/cgeist/Test/Verification/fscanf.c
+++ b/polygeist/tools/cgeist/Test/Verification/fscanf.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s %stdinclude --function=alloc -S | FileCheck %s
+// RUN: cgeist %s -O2 %stdinclude --function=alloc -S | FileCheck %s
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/polygeist/tools/cgeist/Test/Verification/hist.c
+++ b/polygeist/tools/cgeist/Test/Verification/hist.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
 
 void histo_kernel(int i);
 

--- a/polygeist/tools/cgeist/Test/Verification/ident.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/ident.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
 
 struct MOperandInfo {
   char device;

--- a/polygeist/tools/cgeist/Test/Verification/loop.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/loop.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
 
 int MAX_DIMS;
 static short S;

--- a/polygeist/tools/cgeist/Test/Verification/nus.c
+++ b/polygeist/tools/cgeist/Test/Verification/nus.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s --function=kernel_nussinov -S | FileCheck %s
-// RUN: cgeist %s --function=kernel_nussinov -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist %s -O2 --function=kernel_nussinov -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=kernel_nussinov -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 #define N 5500
 #define max_score(s1, s2) ((s1 >= s2) ? s1 : s2)

--- a/polygeist/tools/cgeist/Test/Verification/ptraddsub.c
+++ b/polygeist/tools/cgeist/Test/Verification/ptraddsub.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
 
 int sub() {
     int data[10];

--- a/polygeist/tools/cgeist/Test/Verification/ref.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/ref.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
 
 extern "C" {
 

--- a/polygeist/tools/cgeist/Test/Verification/refptrabi.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/refptrabi.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=ll -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=ll -S | FileCheck %s
 
 struct alignas(2) Half {
   unsigned short x;

--- a/polygeist/tools/cgeist/Test/Verification/reverseRaise.c
+++ b/polygeist/tools/cgeist/Test/Verification/reverseRaise.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=kernel_correlation --raise-scf-to-affine -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=kernel_correlation --raise-scf-to-affine -S | FileCheck %s
 
 #define DATA_TYPE double
 

--- a/polygeist/tools/cgeist/Test/Verification/scor.c
+++ b/polygeist/tools/cgeist/Test/Verification/scor.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s --function=kernel_correlation -S | FileCheck %s
-// RUN: cgeist %s --function=kernel_correlation -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist %s -O2 --function=kernel_correlation -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=kernel_correlation -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 #define DATA_TYPE double
 

--- a/polygeist/tools/cgeist/Test/Verification/sgesv.c
+++ b/polygeist/tools/cgeist/Test/Verification/sgesv.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s --function=kernel_correlation --raise-scf-to-affine -S | FileCheck %s
-// RUN: cgeist %s --function=kernel_correlation --raise-scf-to-affine -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist %s -O2 --function=kernel_correlation --raise-scf-to-affine -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=kernel_correlation --raise-scf-to-affine -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 #define DATA_TYPE double
 

--- a/polygeist/tools/cgeist/Test/Verification/signcmp.c
+++ b/polygeist/tools/cgeist/Test/Verification/signcmp.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
 
 void run();
 unsigned int cmp(int a, int b) {

--- a/polygeist/tools/cgeist/Test/Verification/snus.c
+++ b/polygeist/tools/cgeist/Test/Verification/snus.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s -detect-reduction --function=kernel_nussinov -S | FileCheck %s
-// RUN: cgeist %s -detect-reduction --function=kernel_nussinov -S -memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist %s -O2 -detect-reduction --function=kernel_nussinov -S | FileCheck %s
+// RUN: cgeist %s -O2 -detect-reduction --function=kernel_nussinov -S -memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 #define max_score(s1, s2) ((s1 >= s2) ? s1 : s2)
 

--- a/polygeist/tools/cgeist/Test/Verification/stream.cu
+++ b/polygeist/tools/cgeist/Test/Verification/stream.cu
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --cuda-gpu-arch=sm_60 -nocudalib -nocudainc %resourcedir --function=* -S | FileCheck %s
+// RUN: cgeist %s -O2 --cuda-gpu-arch=sm_60 -nocudalib -nocudainc %resourcedir --function=* -S | FileCheck %s
 
 #include "Inputs/cuda.h"
 

--- a/polygeist/tools/cgeist/Test/Verification/tobits.c
+++ b/polygeist/tools/cgeist/Test/Verification/tobits.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=fp32_from_bits -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=fp32_from_bits -S | FileCheck %s
 
 #include <stdint.h>
 float fp32_from_bits(uint32_t w) {

--- a/polygeist/tools/cgeist/Test/Verification/whiletofor.c
+++ b/polygeist/tools/cgeist/Test/Verification/whiletofor.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s --function=whiletofor -S | FileCheck %s
-// RUN: cgeist %s --function=whiletofor -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist %s -O2 --function=whiletofor -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=whiletofor -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 void use(int a[100][100]);
 

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/2mm/2mm.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/2mm/2mm.c
@@ -1,16 +1,16 @@
-// RUN: cgeist %s %stdinclude -S | FileCheck %s
+// RUN: cgeist %s -O2 %stdinclude -S | FileCheck %s
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist %s -O3 %polyverify %stdinclude -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist %s -O3 %polyexec %stdinclude -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
-// RUN: cgeist -raise-scf-to-affine %s %stdinclude -S | FileCheck %s
+// RUN: cgeist -O2 -raise-scf-to-affine %s %stdinclude -S | FileCheck %s
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist %s -O3 %polyverify %stdinclude -detect-reduction -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/medley/floyd-warshall/floyd-warshall.c
+++ b/polygeist/tools/cgeist/Test/polybench/medley/floyd-warshall/floyd-warshall.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s %stdinclude -S | FileCheck %s
+// RUN: cgeist %s -O2 %stdinclude -S | FileCheck %s
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
 // RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm

--- a/polygeist/tools/cgeist/Test/polybench/stencils/jacobi-1d/jacobi-1d.c
+++ b/polygeist/tools/cgeist/Test/polybench/stencils/jacobi-1d/jacobi-1d.c
@@ -1,15 +1,15 @@
-// RUN: cgeist %s %stdinclude -S | FileCheck %s
+// RUN: cgeist %s -O2 %stdinclude -S | FileCheck %s
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist %s -O3 %polyverify %stdinclude -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist %s -O3 %polyexec %stdinclude -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist %s -O3 %polyverify %stdinclude -detect-reduction -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/stencils/jacobi-2d/jacobi-2d.c
+++ b/polygeist/tools/cgeist/Test/polybench/stencils/jacobi-2d/jacobi-2d.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s %stdinclude -S | FileCheck %s
+// RUN: cgeist %s -O2 %stdinclude -S | FileCheck %s
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
 // RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm

--- a/polygeist/tools/cgeist/Test/polybench/stencils/seidel-2d/seidel-2d.c
+++ b/polygeist/tools/cgeist/Test/polybench/stencils/seidel-2d/seidel-2d.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s %stdinclude -S | FileCheck %s
+// RUN: cgeist %s -O2 %stdinclude -S | FileCheck %s
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
 // RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm


### PR DESCRIPTION
Instead of using `-no-opt-mlir` to control the MLIR optimization pipeline we should use the proper options (i.e. -O0). 

Signed-off-by: Tiotto, Ettore <ettore.tiotto@intel.com>