### PR TITLE
[SYCL-MLIR] Allow `sycl.cast(sycl.accessor) -> sycl.accessor_common`

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -165,8 +165,8 @@ def SYCLConstructorOp : SYCL_Op<"constructor", []> {
 // CAST OPERATION
 ////////////////////////////////////////////////////////////////////////////////
 
-def CastArg : AnyTypeOf<[IDMemRef, RangeMemRef]>;
-def CastRes : AnyTypeOf<[ArrayMemRef]>;
+def CastArg : AnyTypeOf<[IDMemRef, RangeMemRef, AccessorMemRef]>;
+def CastRes : AnyTypeOf<[ArrayMemRef, AccessorCommonMemRef]>;
 def SYCLCastOp : SYCL_Op<"cast", [DeclareOpInterfaceMethods<CastOpInterface>, 
   Pure, MemRefsNormalizable]
 > {

--- a/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
@@ -42,7 +42,19 @@ bool mlir::sycl::SYCLCastOp::areCastCompatible(::mlir::TypeRange Inputs,
           .hasTrait<mlir::sycl::SYCLInheritanceTypeInterface<
               mlir::sycl::ArrayType>::Trait>();
   const bool IsArray = Output.getElementType().isa<mlir::sycl::ArrayType>();
-  return HasArrayTrait && IsArray;
+  if (HasArrayTrait && IsArray)
+    return true;
+
+  const bool HasAccessorCommonTrait =
+      Input.getElementType()
+          .hasTrait<mlir::sycl::SYCLInheritanceTypeInterface<
+              mlir::sycl::AccessorCommonType>::Trait>();
+  const bool IsAccessorCommon =
+      Output.getElementType().isa<mlir::sycl::AccessorCommonType>();
+  if (HasAccessorCommonTrait && IsAccessorCommon)
+    return true;
+
+  return false;
 }
 
 mlir::LogicalResult mlir::sycl::SYCLAccessorSubscriptOp::verify() {

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-cast-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-cast-to-llvm.mlir
@@ -63,3 +63,37 @@ func.func @test2(%arg0: memref<?x!sycl.id<1>>) -> memref<?x!sycl_array1> {
   %0 = "sycl.cast"(%arg0) : (memref<?x!sycl.id<1>>) -> memref<?x!sycl_array1>
   func.return %0: memref<?x!sycl_array1>
 }
+
+// -----
+
+!sycl_accessor_impl_device = !sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>
+!sycl_accessor = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device, !llvm.struct<(ptr<i32, 1>)>)>
+func.func @test3(%arg0: memref<?x!sycl_accessor>) -> memref<?x!sycl.accessor_common> {
+  // CHECK-LABEL: llvm.func @test3
+  // CHECK: [[SRC:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.sycl::_V1::accessor.1"
+  // CHECK-DAG: [[SRC_IV0:%.*]] = llvm.insertvalue %arg0, [[SRC]][0]
+  // CHECK-DAG: [[SRC_IV1:%.*]] = llvm.insertvalue %arg1, [[SRC_IV0]][1]
+  // CHECK-DAG: [[SRC_IV2:%.*]] = llvm.insertvalue %arg2, [[SRC_IV1]][2]
+  // CHECK-DAG: [[SRC_IV3:%.*]] = llvm.insertvalue %arg3, [[SRC_IV2]][3, 0]
+  // CHECK-DAG: [[SRC_IV4:%.*]] = llvm.insertvalue %arg4, [[SRC_IV3]][4, 0]      
+
+  // CHECK: [[SRC_FIELD0:%.*]] = llvm.extractvalue [[SRC_IV4]][0]
+  // CHECK-NEXT: [[BITCAST0:%.*]] = llvm.bitcast [[SRC_FIELD0]] : !llvm.ptr<struct<"class.sycl::_V1::accessor.1", {{.*}} to !llvm.ptr<struct<"class.sycl::_V1::detail::accessor_common"
+  // CHECK-NEXT: [[SRC_FIELD1:%.*]] = llvm.extractvalue [[SRC_IV4]][1]
+  // CHECK-NEXT: [[BITCAST1:%.*]] = llvm.bitcast [[SRC_FIELD1]] : !llvm.ptr<struct<"class.sycl::_V1::accessor.1", {{.*}} to !llvm.ptr<struct<"class.sycl::_V1::detail::accessor_common"
+  // CHECK-DAG: [[SRC_FIELD2:%.*]] = llvm.extractvalue [[SRC_IV4]][2]      
+  // CHECK-DAG: [[SRC_FIELD3:%.*]] = llvm.extractvalue [[SRC_IV4]][3, 0]
+  // CHECK-DAG: [[SRC_FIELD4:%.*]] = llvm.extractvalue [[SRC_IV4]][4, 0]
+
+  // CHECK-DAG: [[RES:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.sycl::_V1::detail::accessor_common"
+  // CHECK-DAG: [[RES_IV0:%.*]] = llvm.insertvalue [[BITCAST0]], [[RES]][0] {{.*}}
+  // CHECK-DAG: [[RES_IV1:%.*]] = llvm.insertvalue [[BITCAST1]], {{.*}}[1] {{.*}}  
+  // CHECK-DAG: [[RES_IV2:%.*]] = llvm.insertvalue [[SRC_FIELD2]], {{.*}}[2]  
+  // CHECK-DAG: [[RES_IV3:%.*]] = llvm.insertvalue [[SRC_FIELD3]], {{.*}}[3, 0]
+  // CHECK-DAG: [[RES_IV4:%.*]] = llvm.insertvalue [[SRC_FIELD4]], {{.*}}[4, 0]
+
+  // CHECK: llvm.return [[RES_IV2]] : !llvm.struct<(ptr<struct<"class.sycl::_V1::detail::accessor_common"  
+
+  %0 = "sycl.cast"(%arg0) : (memref<?x!sycl_accessor>) -> memref<?x!sycl.accessor_common>
+  func.return %0: memref<?x!sycl.accessor_common>
+}

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1703,10 +1703,18 @@ ValueCategory MLIRScanner::CommonFieldLookup(clang::QualType CT,
   return ValueCategory(Result, /*isReference*/ true);
 }
 
-static bool isSyclIDorRangetoArray(mlir::Type &nt, mlir::Value &value) {
+static bool isSYCLInheritType(mlir::Type &nt, mlir::Value &value) {
   mlir::Type elemTy = value.getType().dyn_cast<MemRefType>().getElementType();
-  return ((elemTy.isa<sycl::IDType>() || elemTy.isa<sycl::RangeType>()) &&
-          nt.dyn_cast<MemRefType>().getElementType().isa<sycl::ArrayType>());
+  if ((elemTy.isa<sycl::IDType>() || elemTy.isa<sycl::RangeType>()) &&
+      nt.dyn_cast<MemRefType>().getElementType().isa<sycl::ArrayType>())
+    return true;
+  if ((elemTy.isa<sycl::AccessorType>()) &&
+      nt.dyn_cast<MemRefType>()
+          .getElementType()
+          .isa<sycl::AccessorCommonType>())
+    return true;
+
+  return false;
 }
 
 mlir::Value MLIRScanner::GetAddressOfDerivedClass(
@@ -1845,7 +1853,7 @@ mlir::Value MLIRScanner::GetAddressOfBaseClass(
         auto shape = std::vector<int64_t>(mt.getShape());
         // We do not remove dimensions for an id->array or range->array, because
         // the later cast will be incompatible due to dimension mismatch.
-        if (!isSyclIDorRangetoArray(nt, value))
+        if (!isSYCLInheritType(nt, value))
           shape.erase(shape.begin());
         auto mt0 = mlir::MemRefType::get(shape, mt.getElementType(),
                                          MemRefLayoutAttrInterface(),
@@ -1901,7 +1909,7 @@ mlir::Value MLIRScanner::GetAddressOfBaseClass(
         value = builder.create<polygeist::Memref2PointerOp>(loc, pt, value);
       } else {
         if (value.getType() != nt) {
-          if (isSyclIDorRangetoArray(nt, value))
+          if (isSYCLInheritType(nt, value))
             value = builder.create<sycl::SYCLCastOp>(loc, nt, value);
           else
             value = builder.create<memref::CastOp>(loc, nt, value);


### PR DESCRIPTION
Similar to `sycl.cast(sycl.id) -> sycl.array`, this PR allows `sycl.cast(sycl.accessor) -> sycl.accessor_common`.
`accessor_common` is the base class of `accessor`, so it should be allowed to cast from `accessor` to `accessor_common`.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>