### PR TITLE
[SYCL-MLIR] Change the default behavior to generate all SYCL functions if not explicitly mark unsupported

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
@@ -530,7 +530,8 @@ public:
 
 class ItemBaseType
     : public Type::TypeBase<ItemBaseType, Type, detail::ItemTypeStorage,
-                            mlir::MemRefElementTypeInterface::Trait> {
+                            mlir::MemRefElementTypeInterface::Trait,
+                            mlir::LLVM::PointerElementTypeInterface::Trait> {
 public:
   using Base::Base;
 

--- a/mlir-sycl/lib/Transforms/SYCLMethodToSYCLCall.cpp
+++ b/mlir-sycl/lib/Transforms/SYCLMethodToSYCLCall.cpp
@@ -54,7 +54,7 @@ static mlir::Value castToBaseType(PatternRewriter &Rewriter, mlir::Location Loc,
 
 static LogicalResult convertMethod(SYCLMethodOpInterface method,
                                    PatternRewriter &rewriter) {
-  LLVM_DEBUG(llvm::dbgs() << "ConvertToLLVMABIPass: SYCLMethodOpLowering: ";
+  LLVM_DEBUG(llvm::dbgs() << "SYCLMethodToSYCLCallPass: SYCLMethodOpLowering: ";
              method.dump(); llvm::dbgs() << "\n");
 
   SmallVector<mlir::Value> Args(method->getOperands());

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -1121,7 +1121,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
 
   std::string MangledName =
       MLIRScanner::getMangledFuncName(*Callee, Glob.getCGM());
-  if (GenerateAllSYCLFuncs || isSupportedFunctions(MangledName))
+  if (GenerateAllSYCLFuncs || !isUnsupportedFunctions(MangledName))
     ShouldEmit = true;
 
   FunctionToEmit F(*Callee, mlirclang::getInputContext(builder));

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -1121,7 +1121,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
 
   std::string MangledName =
       MLIRScanner::getMangledFuncName(*Callee, Glob.getCGM());
-  if (GenerateAllSYCLFuncs || !isUnsupportedFunctions(MangledName))
+  if (GenerateAllSYCLFuncs || !isUnsupportedFunction(MangledName))
     ShouldEmit = true;
 
   FunctionToEmit F(*Callee, mlirclang::getInputContext(builder));

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -850,7 +850,7 @@ ValueCategory MLIRScanner::VisitConstructCommon(clang::CXXConstructExpr *cons,
   std::string mangledName = MLIRScanner::getMangledFuncName(
       cast<FunctionDecl>(*ctorDecl), Glob.getCGM());
   mangledName = (PrefixABI + mangledName);
-  if (GenerateAllSYCLFuncs || !isUnsupportedFunctions(mangledName))
+  if (GenerateAllSYCLFuncs || !isUnsupportedFunction(mangledName))
     ShouldEmit = true;
 
   FunctionToEmit F(*ctorDecl, mlirclang::getInputContext(builder));

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -850,7 +850,7 @@ ValueCategory MLIRScanner::VisitConstructCommon(clang::CXXConstructExpr *cons,
   std::string mangledName = MLIRScanner::getMangledFuncName(
       cast<FunctionDecl>(*ctorDecl), Glob.getCGM());
   mangledName = (PrefixABI + mangledName);
-  if (GenerateAllSYCLFuncs || isSupportedFunctions(mangledName))
+  if (GenerateAllSYCLFuncs || !isUnsupportedFunctions(mangledName))
     ShouldEmit = true;
 
   FunctionToEmit F(*ctorDecl, mlirclang::getInputContext(builder));

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -61,7 +61,7 @@ using namespace mlirclang;
 cl::opt<std::string> PrefixABI("prefix-abi", cl::init(""),
                                cl::desc("Prefix for emitted symbols"));
 
-cl::opt<bool> GenerateAllSYCLFuncs("gen-all-sycl-funcs", cl::init(false),
+cl::opt<bool> GenerateAllSYCLFuncs("gen-all-sycl-funcs", cl::init(true),
                                    cl::desc("Generate all SYCL functions"));
 
 constexpr llvm::StringLiteral MLIRASTConsumer::DeviceModuleName;

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -61,7 +61,7 @@ using namespace mlirclang;
 cl::opt<std::string> PrefixABI("prefix-abi", cl::init(""),
                                cl::desc("Prefix for emitted symbols"));
 
-cl::opt<bool> GenerateAllSYCLFuncs("gen-all-sycl-funcs", cl::init(true),
+cl::opt<bool> GenerateAllSYCLFuncs("gen-all-sycl-funcs", cl::init(false),
                                    cl::desc("Generate all SYCL functions"));
 
 constexpr llvm::StringLiteral MLIRASTConsumer::DeviceModuleName;
@@ -75,124 +75,43 @@ MLIRScanner::MLIRScanner(MLIRASTConsumer &Glob,
                          LowerToInfo &LTInfo)
     : Glob(Glob), function(), module(module), builder(module->getContext()),
       loc(builder.getUnknownLoc()), entryBlock(nullptr), loops(),
-      allocationScope(nullptr), supportedFuncs(), bufs(), constants(), labels(),
-      EmittingFunctionDecl(nullptr), params(), Captures(), CaptureKinds(),
-      ThisCapture(nullptr), arrayinit(), ThisVal(), returnVal(),
+      allocationScope(nullptr), unsupportedFuncs(), bufs(), constants(),
+      labels(), EmittingFunctionDecl(nullptr), params(), Captures(),
+      CaptureKinds(), ThisCapture(nullptr), arrayinit(), ThisVal(), returnVal(),
       LTInfo(LTInfo) {}
 
-void MLIRScanner::initSupportedFunctions() {
-  // Functions needed for single_task with one dimensional write buffer.
+void MLIRScanner::initUnsupportedFunctions() {
+  // FIXME: -no-mangled-function-name: cgeist:
+  // llvm/mlir/lib/IR/SymbolTable.cpp:121:
+  // mlir::SymbolTable::SymbolTable(mlir::Operation*): Assertion
+  // `symbolTableOp->hasTrait<OpTrait::SymbolTable>() && "expected operation to
+  // have SymbolTable trait"' failed.
+  unsupportedFuncs.insert("_ZNK4sycl3_V15rangeILi2EE4sizeEv");
+  unsupportedFuncs.insert(
+      "_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_"
+      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
+      "listIJEEEE14getLinearIndexILi2EEEmNS0_2idIXT_EEE");
 
-  // SYCL constructors:
-  supportedFuncs.insert("_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_"
-                        "2idILi1EEENS0_5rangeILi1EEES7_");
-  supportedFuncs.insert(
-      "_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_"
-      "6targetE2014ELNS2_11placeholderE0ENS0_"
-      "3ext6oneapi22accessor_property_listIJEEEEC1Ev");
-  supportedFuncs.insert("_ZN4sycl3_V16detail5arrayILi1EEC1ILi1EEENSt9enable_"
-                        "ifIXeqT_Li1EEmE4typeE");
-  supportedFuncs.insert("_ZN4sycl3_V16detail5arrayILi1EEC1ERKS3_");
-  supportedFuncs.insert("_ZN4sycl3_V12idILi1EEC1Ev");
-  supportedFuncs.insert("_ZN4sycl3_V12idILi1EEC1ERKS2_");
-  supportedFuncs.insert(
-      "_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE");
-  supportedFuncs.insert("_ZN4sycl3_V15rangeILi1EEC1ERKS2_");
-  supportedFuncs.insert(
-      "_ZN4sycl3_V15rangeILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE");
+  // FIXME: cgeist: llvm/polygeist/tools/cgeist/Lib/clang-mlir.cc:119: void
+  // checkFunctionParent(mlir::FunctionOpInterface, FunctionContext, const
+  // mlir::OwningOpRef<mlir::ModuleOp>&): Assertion `(Context !=
+  // FunctionContext::Host || F->getParentOp() == module.get()) && "New function
+  // must be inserted into global module"' failed.
+  unsupportedFuncs.insert("_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_");
+  unsupportedFuncs.insert("_ZNK4sycl3_V14itemILi1ELb0EE13get_linear_idEv");
 
-  // Other SYCL functions:
-  supportedFuncs.insert(
-      "_ZN4sycl3_V13ext6oneapi22accessor_property_listIJEE12has_propertyINS2_"
-      "8property9no_offsetEEEbPNSt9enable_ifIXsr24is_compile_time_propertyIT_"
-      "EE5valueEvE4typeE");
-  supportedFuncs.insert(
-      "_ZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_"
+  // FIXME: cgeist: llvm/polygeist/tools/cgeist/Lib/CGCall.cc:94: void
+  // castCallerArgs(mlir::func::FuncOp, llvm::SmallVectorImpl<mlir::Value>&,
+  // mlir::OpBuilder&): Assertion `CalleeArgType == Args[I].getType() &&
+  // "Callsite argument mismatch"' failed.
+  unsupportedFuncs.insert(
+      "_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_"
       "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
-      "listIJEEEEixILi1EvEERiNS0_2idILi1EEE");
-  supportedFuncs.insert(
-      "_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_"
+      "listIJEEEEC1ERKSA_");
+  unsupportedFuncs.insert(
+      "_ZN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_"
       "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
-      "listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE");
-  supportedFuncs.insert(
-      "_ZZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_"
-      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
-      "listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEEENKUlmE_"
-      "clEm");
-  supportedFuncs.insert(
-      "_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_"
-      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
-      "listIJEEEE14getAccessRangeEv");
-  supportedFuncs.insert(
-      "_ZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_"
-      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
-      "listIJEEEE14getLinearIndexILi1EEEmNS0_2idIXT_EEE");
-  supportedFuncs.insert(
-      "_ZZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_"
-      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
-      "listIJEEEE14getLinearIndexILi1EEEmNS0_2idIXT_EEEENKUlmE_clEm");
-  supportedFuncs.insert(
-      "_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_"
-      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
-      "listIJEEEE14getMemoryRangeEv");
-  supportedFuncs.insert(
-      "_ZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_"
-      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
-      "listIJEEEE14getMemoryRangeEv");
-  supportedFuncs.insert(
-      "_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_"
-      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
-      "listIJEEEE9getOffsetEv");
-  supportedFuncs.insert(
-      "_ZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_"
-      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
-      "listIJEEEE14getTotalOffsetEv");
-  supportedFuncs.insert(
-      "_ZZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_"
-      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
-      "listIJEEEE14getTotalOffsetEvENKUlmE_clEm");
-  supportedFuncs.insert(
-      "_ZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_"
-      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
-      "listIJEEEE15getQualifiedPtrEv");
-  supportedFuncs.insert("_ZN4sycl3_V16detail5arrayILi1EEixEi");
-  supportedFuncs.insert("_ZNK4sycl3_V16detail5arrayILi1EEixEi");
-  supportedFuncs.insert("_ZNK4sycl3_V16detail5arrayILi1EE15check_dimensionEi");
-  supportedFuncs.insert("_ZN4sycl3_V16detail14InitializedValILi1ENS0_"
-                        "5rangeEE3getILi0EEENS3_ILi1EEEv");
-  supportedFuncs.insert(
-      "_ZN4sycl3_V16detail8dim_loopILm1EZNS0_8accessorIiLi1ELNS0_"
-      "6access4modeE1025ELNS4_6targetE2014ELNS4_11placeholderE0ENS0_"
-      "3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_"
-      "5rangeILi1EEESG_NS0_2idILi1EEEEUlmE_EEvOT0_");
-  supportedFuncs.insert(
-      "_ZN4sycl3_V16detail8dim_loopILm1EZNKS0_8accessorIiLi1ELNS0_"
-      "6access4modeE1025ELNS4_6targetE2014ELNS4_11placeholderE0ENS0_"
-      "3ext6oneapi22accessor_property_listIJEEEE14getLinearIndexILi1EEEmNS0_"
-      "2idIXT_EEEEUlmE_EEvOT0_");
-  supportedFuncs.insert(
-      "_ZN4sycl3_V16detail8dim_loopILm1EZNKS0_8accessorIiLi1ELNS0_"
-      "6access4modeE1025ELNS4_6targetE2014ELNS4_11placeholderE0ENS0_"
-      "3ext6oneapi22accessor_property_listIJEEEE14getTotalOffsetEvEUlmE_"
-      "EEvOT0_");
-  supportedFuncs.insert(
-      "_ZN4sycl3_V16detail13dim_loop_implIJLm0EEZNS0_8accessorIiLi1ELNS0_"
-      "6access4modeE1025ELNS4_6targetE2014ELNS4_11placeholderE0ENS0_"
-      "3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_"
-      "5rangeILi1EEESG_NS0_2idILi1EEEEUlmE_EEvSt16integer_sequenceImJXspT_"
-      "EEEOT0_");
-  supportedFuncs.insert(
-      "_ZN4sycl3_V16detail13dim_loop_implIJLm0EEZNKS0_8accessorIiLi1ELNS0_"
-      "6access4modeE1025ELNS4_6targetE2014ELNS4_11placeholderE0ENS0_"
-      "3ext6oneapi22accessor_property_listIJEEEE14getLinearIndexILi1EEEmNS0_"
-      "2idIXT_EEEEUlmE_EEvSt16integer_sequenceImJXspT_EEEOT0_");
-  supportedFuncs.insert(
-      "_ZN4sycl3_V16detail13dim_loop_implIJLm0EEZNKS0_8accessorIiLi1ELNS0_"
-      "6access4modeE1025ELNS4_6targetE2014ELNS4_11placeholderE0ENS0_"
-      "3ext6oneapi22accessor_property_listIJEEEE14getTotalOffsetEvEUlmE_"
-      "EEvSt16integer_sequenceImJXspT_EEEOT0_");
-
-  supportedFuncs.insert("_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv");
+      "listIJEEEEC1ERKSA_");
 }
 
 static void checkFunctionParent(const FunctionOpInterface F,
@@ -244,7 +163,7 @@ void MLIRScanner::init(mlir::FunctionOpInterface func,
                  << "\tfunctionDecl:" << *FD << "\n"
                  << "function:" << function << "\n";
 
-  initSupportedFunctions();
+  initUnsupportedFunctions();
   // This is needed, as GPUFuncOps are already created with an entry block.
   setEntryAndAllocBlock(isa<gpu::GPUFuncOp>(function)
                             ? &function.getBlocks().front()

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1543,6 +1543,16 @@ ValueCategory MLIRScanner::CommonFieldLookup(clang::QualType CT,
 
     Result = builder.create<polygeist::SubIndexOp>(loc, ResultType, val,
                                                    getConstantIndex(fnum));
+  } else if (auto AT = mt.getElementType()
+                           .dyn_cast<mlir::sycl::AccessorSubscriptType>()) {
+    assert(fnum < AT.getBody().size() && "ERROR");
+
+    const auto ElementType = AT.getBody()[fnum];
+    const auto ResultType = mlir::MemRefType::get(
+        shape, ElementType, MemRefLayoutAttrInterface(), mt.getMemorySpace());
+
+    Result = builder.create<polygeist::SubIndexOp>(loc, ResultType, val,
+                                                   getConstantIndex(fnum));
   } else if (auto AT = mt.getElementType().dyn_cast<mlir::sycl::ArrayType>()) {
     assert(fnum < AT.getBody().size() && "ERROR");
     const auto elemType = AT.getBody()[fnum].cast<MemRefType>();

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -259,7 +259,7 @@ private:
   mlir::Block *entryBlock;
   std::vector<LoopContext> loops;
   mlir::Block *allocationScope;
-  llvm::SmallSet<std::string, 4> supportedFuncs;
+  llvm::SmallSet<std::string, 4> unsupportedFuncs;
   std::map<const void *, std::vector<mlir::LLVM::AllocaOp>> bufs;
   std::map<int, mlir::Value> constants;
   std::map<clang::LabelStmt *, mlir::Block *> labels;
@@ -274,11 +274,11 @@ private:
   mlir::Value returnVal;
   LowerToInfo &LTInfo;
 
-  // Initialize a whitelist of SYCL functions to emit instead just the
+  // Initialize a exclude list of SYCL functions to emit instead just the
   // declaration. Eventually, this list should be removed.
-  void initSupportedFunctions();
-  bool isSupportedFunctions(std::string Name) const {
-    return supportedFuncs.contains(Name);
+  void initUnsupportedFunctions();
+  bool isUnsupportedFunctions(std::string Name) const {
+    return unsupportedFuncs.contains(Name);
   }
 
   mlir::LLVM::AllocaOp allocateBuffer(size_t i, mlir::LLVM::LLVMPointerType t) {

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -277,7 +277,7 @@ private:
   // Initialize a exclude list of SYCL functions to emit instead just the
   // declaration. Eventually, this list should be removed.
   void initUnsupportedFunctions();
-  bool isUnsupportedFunctions(std::string Name) const {
+  bool isUnsupportedFunction(std::string Name) const {
     return unsupportedFuncs.contains(Name);
   }
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -4,8 +4,9 @@
 #include <sycl/sycl.hpp>
 
 // CHECK-DAG: !sycl_id_2_ = !sycl.id<2>
-// CHECK-DAG: !sycl_item_2_1_ = !sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl.range<2>, !sycl_id_2_, !sycl_id_2_)>)>
 // CHECK-DAG: !sycl_range_1_ = !sycl.range<1>
+// CHECK-DAG: !sycl_item_base_2_1_ = !sycl.item_base<[2, true], (!sycl.range<2>, !sycl_id_2_, !sycl_id_2_)>
+// CHECK-DAG: !sycl_item_2_1_ = !sycl.item<[2, true], (!sycl_item_base_2_1_)>
 
 // Check globals referenced in device functions are created in the GPU module
 // CHECK: gpu.module @device_functions {
@@ -102,10 +103,6 @@ extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
 // CHECK-NEXT: %4 = llvm.addrspacecast %3 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
 // CHECK-NEXT: %5 = "polygeist.pointer2memref"(%4) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
 // CHECK-NEXT: sycl.constructor(%5) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1Ev, TypeName = @id} : (memref<?x!sycl_id_2_, 4>) -> ()
-
-// Ensure declaration to have external linkage.
-// CHECK-LABEL: func.func private @_ZN4sycl3_V12idILi2EEC1Ev(memref<?x!sycl_id_2_, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 16 : i64, llvm.noundef})
-// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXTERNAL]], {{.*}}}
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_1()
 // CHECK-LLVM-SAME:  #[[FUNCATTRS]]

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -12,7 +12,8 @@
 // CHECK-MLIR-DAG: !sycl_id_2_ = !sycl.id<2>
 // CHECK-MLIR-DAG: !sycl_range_1_ = !sycl.range<1>
 // CHECK-MLIR-DAG: !sycl_range_2_ = !sycl.range<2>
-// CHECK-MLIR-DAG: !sycl_accessor_1_i32_read_write_global_buffer = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
+// CHECK-MLIR-DAG: !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
+// CHECK-MLIR-DAG: !sycl_accessor_1_i32_read_write_global_buffer = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
 // CHECK-MLIR-DAG: !sycl_accessor_2_i32_read_write_global_buffer = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>, !llvm.struct<(ptr<i32, 1>)>)>
 // CHECK-MLIR-DAG: !sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
 // CHECK-MLIR-DAG: !sycl_array_2_ = !sycl.array<[2], (memref<2xi64, 4>)>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -219,10 +219,6 @@ SYCL_EXTERNAL void id_get_2(const sycl::id<1> id, int dimension) {
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}
 // CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}) {BaseType = memref<?x!sycl_id_1_, 4>, FunctionName = @"operator unsigned long", MangledFunctionName = @_ZNK4sycl3_V12idILi1EEcvmEv, TypeName = @id} : (memref<?x!sycl_id_1_, 4>) -> i64
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_3N4sycl3_V12idILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0) #[[FUNCATTRS]]      
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V12idILi1EEcvmEv(%"class.sycl::_V1::id.1" addrspace(4)* %{{.*}})
-
 SYCL_EXTERNAL void id_get_3(sycl::id<1> id) {
   keep(static_cast<size_t>(id));
 }
@@ -243,10 +239,6 @@ SYCL_EXTERNAL void item_get_id_0(sycl::item<1> item) {
 // CHECK-MLIR:           %arg0: memref<?x!sycl_item_1_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEi, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>, i32) -> i64
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_1N4sycl3_V14itemILi1ELb1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEi(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}}, i32 %1)
-
 SYCL_EXTERNAL void item_get_id_1(sycl::item<1> item, int dimension) {
   keep(item.get_id(dimension));
 }
@@ -254,10 +246,6 @@ SYCL_EXTERNAL void item_get_id_1(sycl::item<1> item, int dimension) {
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_2N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_item_1_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EEixEi, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>, i32) -> i64
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_2N4sycl3_V14itemILi1ELb1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]  
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V14itemILi1ELb1EEixEi(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void item_get_id_2(sycl::item<1> item, int dimension) {
   keep(item[dimension]);
@@ -291,10 +279,6 @@ SYCL_EXTERNAL void item_get_range_0(sycl::item<1> item) {
 // CHECK-MLIR:           %arg0: memref<?x!sycl_item_1_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = "sycl.item.get_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEi, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>, i32) -> i64
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z16item_get_range_1N4sycl3_V14itemILi1ELb1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEi(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}}, i32 %1)
-
 SYCL_EXTERNAL void item_get_range_1(sycl::item<1> item, int dimension) {
   keep(item.get_range(dimension));
 }
@@ -302,10 +286,6 @@ SYCL_EXTERNAL void item_get_range_1(sycl::item<1> item, int dimension) {
 // CHECK-MLIR-LABEL: func.func @_Z18item_get_linear_idN4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_item_1_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_1_, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = "sycl.item.get_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_item_1_1_, 4>, FunctionName = @get_linear_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE13get_linear_idEv, TypeName = @item} : (memref<?x!sycl_item_1_1_, 4>) -> i64
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z18item_get_linear_idN4sycl3_V14itemILi1ELb1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]      
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V14itemILi1ELb1EE13get_linear_idEv(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void item_get_linear_id(sycl::item<1> item) {
   keep(item.get_linear_id());
@@ -327,10 +307,6 @@ SYCL_EXTERNAL void nd_item_get_global_id_0(sycl::nd_item<1> nd_item) {
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z23nd_item_get_global_id_1N4sycl3_V17nd_itemILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
-
 SYCL_EXTERNAL void nd_item_get_global_id_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_global_id(dimension));
 }
@@ -338,10 +314,6 @@ SYCL_EXTERNAL void nd_item_get_global_id_1(sycl::nd_item<1> nd_item, int dimensi
 // CHECK-MLIR-LABEL: func.func @_Z28nd_item_get_global_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE20get_global_linear_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> i64
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z28nd_item_get_global_linear_idN4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]    
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE20get_global_linear_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_global_linear_id(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_global_linear_id());
@@ -362,10 +334,6 @@ SYCL_EXTERNAL void nd_item_get_local_id_0(sycl::nd_item<1> nd_item) {
 // CHECK-MLIR-LABEL: func.func @_Z22nd_item_get_local_id_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_id"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z22nd_item_get_local_id_1N4sycl3_V17nd_itemILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]  
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void nd_item_get_local_id_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_local_id(dimension));
@@ -399,10 +367,6 @@ SYCL_EXTERNAL void nd_item_get_group_0(sycl::nd_item<1> nd_item) {
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z19nd_item_get_group_1N4sycl3_V17nd_itemILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]    
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
-
 SYCL_EXTERNAL void nd_item_get_group_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_group(dimension));
 }
@@ -410,10 +374,6 @@ SYCL_EXTERNAL void nd_item_get_group_1(sycl::nd_item<1> nd_item, int dimension) 
 // CHECK-MLIR-LABEL: func.func @_Z27nd_item_get_group_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_linear_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE19get_group_linear_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> i64
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z27nd_item_get_group_linear_idN4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]      
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE19get_group_linear_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_group_linear_id(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_group_linear_id());
@@ -434,10 +394,6 @@ SYCL_EXTERNAL void nd_item_get_group_range_0(sycl::nd_item<1> nd_item) {
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_group_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_range"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>, i32) -> i64
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_group_range_1N4sycl3_V17nd_itemILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]    
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void nd_item_get_group_range_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_group_range(dimension));

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -5,8 +5,8 @@
 
 // CHECK-MLIR-DAG: !sycl_id_1_ = !sycl.id<1>
 // CHECK-MLIR-DAG: !sycl_range_1_ = !sycl.range<1>
-// CHECK-MLIR-DAG: !sycl_accessor_1_i32_read_write_global_buffer = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
-// CHECK-MLIR-DAG: !sycl_item_1_1_ = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>)>
+// CHECK-MLIR-DAG: !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
+// CHECK-MLIR-DAG: !sycl_accessor_1_i32_read_write_global_buffer = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
 
 // CHECK-LLVM-DAG: %"class.sycl::_V1::accessor.1" = type { %"class.sycl::_V1::detail::AccessorImplDevice.1", { i32 addrspace(1)* } }
 // CHECK-LLVM-DAG: %"class.sycl::_V1::detail::AccessorImplDevice.1" = type { %"class.sycl::_V1::id.1", %"class.sycl::_V1::range.1", %"class.sycl::_V1::range.1" }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/parallel_for.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/parallel_for.cpp
@@ -1,6 +1,6 @@
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Xcgeist -gen-all-sycl-funcs %s -o %t.out 2>&1 | FileCheck %s --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.out 2>&1 | FileCheck %s --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -fsycl -fsycl-device-only -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir -Xcgeist -gen-all-sycl-funcs %s -o %t.bc 2>/dev/null
+// RUN: clang++ -fsycl -fsycl-device-only -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc 2>/dev/null
 
 // Test that the LLVMIR generated is verifiable.
 // RUN: opt -verify -disable-output < %t.bc
@@ -18,7 +18,7 @@
 
 #include <sycl/sycl.hpp>
 using namespace sycl;
-#define N 8
+static constexpr unsigned N = 8;
 
 void host_parallel_for(std::array<int, N> &A) {
   auto q = queue{};

--- a/polygeist/tools/cgeist/Test/Verification/sycl/stream-copy.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/stream-copy.cpp
@@ -1,6 +1,6 @@
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Xcgeist -gen-all-sycl-funcs %s -o %t.out 2>&1 | FileCheck %s --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.out 2>&1 | FileCheck %s --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -fsycl -fsycl-device-only -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir -Xcgeist -gen-all-sycl-funcs %s -o %t.bc 2>/dev/null
+// RUN: clang++ -fsycl -fsycl-device-only -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc 2>/dev/null
 
 // Test that the LLVMIR generated is verifiable.
 // RUN: opt -verify -disable-output < %t.bc

--- a/polygeist/tools/cgeist/Test/Verification/sycl/stream-triad.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/stream-triad.cpp
@@ -1,6 +1,6 @@
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Xcgeist -gen-all-sycl-funcs %s -o %t.out 2>&1 | FileCheck %s --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.out 2>&1 | FileCheck %s --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -fsycl -fsycl-device-only -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir -Xcgeist -gen-all-sycl-funcs %s -o %t.bc 2>/dev/null
+// RUN: clang++ -fsycl -fsycl-device-only -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc 2>/dev/null
 
 // Test that the LLVMIR generated is verifiable.
 // RUN: opt -verify -disable-output < %t.bc

--- a/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
@@ -16,7 +16,7 @@
 // CHECK-MLIR-NEXT: [[RESULT:%.*]] = arith.addf [[V1]], [[V2]] : f32
 // CHECK-MLIR:      affine.store [[RESULT]], {{.*}}[0] : memref<?xf32, 4>
 
-// CHECK-LLVM:       define internal spir_func void [[FUNC:@.*vec_add_device_simple.*_]]({{.*}}) #[[FUNCATTRS2:[0-9]+]]
+// CHECK-LLVM:       define internal spir_func void [[FUNC:@.*vec_add_device_simple.*_]]({ %"class.sycl::_V1::accessor.1", %"class.sycl::_V1::accessor.1", %"class.sycl::_V1::accessor.1" }{{.*}}) #[[FUNCATTRS2:[0-9]+]]
 // CHECK-LLVM-DAG:   [[V1:%.*]] = load float, float addrspace(4)* {{.*}}, align 4
 // CHECK-LLVM-DAG:   [[V2:%.*]] = load float, float addrspace(4)* {{.*}}, align 4
 // CHECK-LLVM:       [[RESULT:%.*]] = fadd float [[V1]], [[V2]]


### PR DESCRIPTION
Removed the `supportedFuncs` list, and replaced with a `unsupportedFuncs` list. 
We mark functions that cannot yet supported in the `unsupportedFuncs` list, and by default generate all other SYCL functions.
When `-gen-all-sycl-funcs` is used, then all SYCL functions are generated.
This PR also includes some small changes to improve codegen.

Signed-off-by: Tsang, Whitney [whitney.tsang@intel.com](mailto:whitney.tsang@intel.com)