### PR TITLE
[SYCL] Extend SPIR TargetInfo with atomics info

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -98,6 +98,11 @@ protected:
     // Define available target features
     // These must be defined in sorted order!
     NoAsmVariants = true;
+
+    // 32-bit atomics are mandatory in OpenCL, so it should be OK here
+    MaxAtomicInlineWidth = 32;
+    // 64-bit atomics are optional, but possible
+    MaxAtomicPromoteWidth = 64;
   }
 
 public:


### PR DESCRIPTION
The change is resulted from an experiment of compiling a SYCL application on MacOS using C++ headers from Xcode installation. Compilation failed with the following error:

```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/atomic:26 80:16: error:
      use of undeclared identifier '__libcpp_signed_lock_free'; did you mean '__libcpp_aligned_free'?
typedef atomic<__libcpp_signed_lock_free> atomic_signed_lock_free;
               ^
```

This happened because `atomic` header assumed that there are no lock-free atomics available, because none of `ATOMIC_*_LOCK_FREE` defines was set to 2, which in turn happened because of missing `MaxAtomicInlineWidth`
property of `SPIR` target.