### PR TITLE
[SYCL][Fusion] API for kernel fusion library

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -70,3 +70,6 @@ llvm/include/llvm/SYCLLowerIR/LowerInvokeSimd.h @kbobrovs @v-klochkov @rolandsch
 .github/workflows/ @intel/dpcpp-devops-reviewers
 buildbot/ @intel/dpcpp-devops-reviewers
 devops/ @intel/dpcpp-devops-reviewers
+
+# Kernel fusion JIT compiler
+sycl-fusion/ @victor-eds @Naghasan @sommerlukas

--- a/sycl-fusion/CMakeLists.txt
+++ b/sycl-fusion/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+
+# Define a variable holding the root directory of the JIT compiler project
+# for use in includes etc.
+set(SYCL_JIT_BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+# For some reason, the LLVMSPIRVLib does not define any public includes.
+# To link against the library, define the following link to its include
+# directories, similar to how clang/CMakeLists.txt does it.
+set(LLVM_SPIRV_INCLUDE_DIRS "${LLVM_MAIN_SRC_DIR}/../llvm-spirv/include")
+
+add_subdirectory(jit-compiler)

--- a/sycl-fusion/README.md
+++ b/sycl-fusion/README.md
@@ -1,0 +1,9 @@
+# SYCL Kernel Fusion Compiler
+
+Basic JIT compiler infrastructure to perform online kernel fusion of SYCL kernels at runtime.
+
+The experimental SYCL extension for kernel fusion is described in 
+[this proposal](../sycl/doc/extensions/experimental/sycl_ext_codeplay_kernel_fusion.asciidoc).
+
+The design of the JIT compiler is described in this 
+[design document](../sycl/doc/design/KernelFusionJIT.md).

--- a/sycl-fusion/common/include/Kernel.h
+++ b/sycl-fusion/common/include/Kernel.h
@@ -1,0 +1,155 @@
+//==------- Kernel.h - Representation of a SYCL kernel for JIT compiler ----==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SYCL_FUSION_COMMON_KERNEL_H
+#define SYCL_FUSION_COMMON_KERNEL_H
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace jit_compiler {
+
+using BinaryAddress = const unsigned char *;
+
+///
+/// Enumerate possible kinds of parameters.
+/// 1:1 correspondence with the definition in kernel_desc.hpp in the DPC++ SYCL
+/// runtime.
+enum class ParameterKind : unsigned {
+  Accessor = 0,
+  StdLayout = 1,
+  Sampler = 2,
+  Pointer = 3,
+  SpecConstBuffer = 4,
+  Stream = 5,
+  Invalid = 0xF,
+};
+
+/// Different binary formats supported as input to the JIT compiler.
+enum class BinaryFormat { INVALID, LLVM, SPIRV };
+
+/// Information about a device intermediate representation module (e.g., SPIR-V,
+/// LLVM IR) from DPC++.
+struct SYCLKernelBinaryInfo {
+
+  BinaryFormat Format = BinaryFormat::INVALID;
+
+  size_t AddressBits = 0;
+
+  BinaryAddress BinaryStart = nullptr;
+
+  size_t BinarySize = 0;
+};
+
+///
+/// Describe a SYCL/OpenCL kernel attribute by its name and values.
+struct SYCLKernelAttribute {
+  using AttributeValueList = std::vector<std::string>;
+
+  // Explicit constructor for compatibility with LLVM YAML I/O.
+  SYCLKernelAttribute() : Values{} {};
+  SYCLKernelAttribute(std::string Name)
+      : AttributeName{std::move(Name)}, Values{} {}
+
+  std::string AttributeName;
+  AttributeValueList Values;
+};
+
+enum ArgUsage : unsigned char {
+  // Used to indicate that an argument is not used by the kernel
+  Unused = 0,
+  // Used to indicate that an argument is used by the kernel
+  Used = 1u,
+  // Used to indicate that the accessor/pointer argument has been promoted to
+  // private memory
+  PromotedPrivate = 1u << 4,
+  // Used to indicate that the accessor/pointer argument has been promoted to
+  // local memory
+  PromotedLocal = 1u << 5,
+};
+
+///
+/// Encode usage of parameters for the actual kernel function.
+// This is a vector of unsigned char, because std::vector<bool> is a weird
+// construct and unlike all other std::vectors, and LLVM YAML I/O is having a
+// hard time coping with it.
+using ArgUsageMask = std::vector<std::underlying_type_t<ArgUsage>>;
+
+///
+/// Describe the list of arguments by their kind.
+struct SYCLArgumentDescriptor {
+
+  // Explicit constructor for compatibility with LLVM YAML I/O.
+  SYCLArgumentDescriptor() : Kinds{}, UsageMask{} {}
+
+  std::vector<ParameterKind> Kinds;
+
+  ArgUsageMask UsageMask;
+};
+
+///
+/// List of SYCL/OpenCL kernel attributes.
+using AttributeList = std::vector<SYCLKernelAttribute>;
+
+/// Information about a kernel from DPC++.
+struct SYCLKernelInfo {
+
+  std::string Name;
+
+  SYCLArgumentDescriptor Args;
+
+  AttributeList Attributes;
+
+  SYCLKernelBinaryInfo BinaryInfo;
+
+  //// Explicit constructor for compatibility with LLVM YAML I/O.
+  SYCLKernelInfo() : Name{}, Args{}, Attributes{}, BinaryInfo{} {}
+
+  SYCLKernelInfo(const std::string &KernelName,
+                 const SYCLArgumentDescriptor &ArgDesc,
+                 const SYCLKernelBinaryInfo &BinInfo)
+      : Name{KernelName}, Args{ArgDesc}, Attributes{}, BinaryInfo{BinInfo} {}
+
+  explicit SYCLKernelInfo(const std::string &KernelName)
+      : Name{KernelName}, Args{}, Attributes{}, BinaryInfo{} {}
+};
+
+///
+/// Represents a SPIR-V translation unit containing SYCL kernels by the
+/// KernelInfo for each of the contained kernels.
+class SYCLModuleInfo {
+public:
+  using KernelInfoList = std::vector<SYCLKernelInfo>;
+
+  void addKernel(SYCLKernelInfo &Kernel) { Kernels.push_back(Kernel); }
+
+  KernelInfoList &kernels() { return Kernels; }
+
+  bool hasKernelFor(const std::string &KernelName) {
+    return findKernelFor(KernelName) != nullptr;
+  }
+
+  SYCLKernelInfo *getKernelFor(const std::string &KernelName) {
+    return findKernelFor(KernelName);
+  }
+
+private:
+  SYCLKernelInfo *findKernelFor(const std::string &KernelName) {
+    auto It =
+        std::find_if(Kernels.begin(), Kernels.end(),
+                     [&](SYCLKernelInfo &K) { return K.Name == KernelName; });
+    return (It != Kernels.end()) ? &*It : nullptr;
+  }
+
+  KernelInfoList Kernels;
+};
+
+} // namespace jit_compiler
+
+#endif // SYCL_FUSION_COMMON_KERNEL_H

--- a/sycl-fusion/common/include/Kernel.h
+++ b/sycl-fusion/common/include/Kernel.h
@@ -132,21 +132,17 @@ public:
   KernelInfoList &kernels() { return Kernels; }
 
   bool hasKernelFor(const std::string &KernelName) {
-    return findKernelFor(KernelName) != nullptr;
+    return getKernelFor(KernelName) != nullptr;
   }
 
   SYCLKernelInfo *getKernelFor(const std::string &KernelName) {
-    return findKernelFor(KernelName);
-  }
-
-private:
-  SYCLKernelInfo *findKernelFor(const std::string &KernelName) {
     auto It =
         std::find_if(Kernels.begin(), Kernels.end(),
                      [&](SYCLKernelInfo &K) { return K.Name == KernelName; });
     return (It != Kernels.end()) ? &*It : nullptr;
   }
 
+private:
   KernelInfoList Kernels;
 };
 

--- a/sycl-fusion/common/include/KernelIO.h
+++ b/sycl-fusion/common/include/KernelIO.h
@@ -1,0 +1,95 @@
+//==----- KernelIO.h - YAML output of internal SYCL kernel representation --==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SYCL_FUSION_COMMON_KERNELIO_H
+#define SYCL_FUSION_COMMON_KERNELIO_H
+
+#include "Kernel.h"
+#include "llvm/Support/YAMLParser.h"
+#include "llvm/Support/YAMLTraits.h"
+
+using llvm::yaml::IO;
+using llvm::yaml::MappingTraits;
+using llvm::yaml::ScalarEnumerationTraits;
+
+// Specify how to map std::vectors of different user-defined types to YAML
+// sequences.
+LLVM_YAML_IS_SEQUENCE_VECTOR(jit_compiler::ArgUsageMask)
+LLVM_YAML_IS_FLOW_SEQUENCE_VECTOR(jit_compiler::ParameterKind)
+LLVM_YAML_IS_SEQUENCE_VECTOR(jit_compiler::SYCLArgumentDescriptor)
+LLVM_YAML_IS_SEQUENCE_VECTOR(jit_compiler::SYCLKernelAttribute)
+LLVM_YAML_IS_SEQUENCE_VECTOR(jit_compiler::SYCLKernelInfo)
+
+//
+// Mapping traits for the different elements of KernelInfo.
+namespace llvm {
+namespace yaml {
+
+template <> struct ScalarEnumerationTraits<jit_compiler::ParameterKind> {
+  static void enumeration(IO &IO, jit_compiler::ParameterKind &PK) {
+    IO.enumCase(PK, "Accessor", jit_compiler::ParameterKind::Accessor);
+    IO.enumCase(PK, "StdLayout", jit_compiler::ParameterKind::StdLayout);
+    IO.enumCase(PK, "Sampler", jit_compiler::ParameterKind::Sampler);
+    IO.enumCase(PK, "Pointer", jit_compiler::ParameterKind::Pointer);
+    IO.enumCase(PK, "SpecConstantBuffer",
+                jit_compiler::ParameterKind::SpecConstBuffer);
+    IO.enumCase(PK, "Stream", jit_compiler::ParameterKind::Stream);
+    IO.enumCase(PK, "Invalid", jit_compiler::ParameterKind::Invalid);
+  }
+};
+
+template <> struct ScalarEnumerationTraits<jit_compiler::BinaryFormat> {
+  static void enumeration(IO &IO, jit_compiler::BinaryFormat &BF) {
+    IO.enumCase(BF, "LLVM", jit_compiler::BinaryFormat::LLVM);
+    IO.enumCase(BF, "SPIRV", jit_compiler::BinaryFormat::SPIRV);
+    IO.enumCase(BF, "INVALID", jit_compiler::BinaryFormat::INVALID);
+  }
+};
+
+template <> struct MappingTraits<jit_compiler::SYCLKernelBinaryInfo> {
+  static void mapping(IO &IO, jit_compiler::SYCLKernelBinaryInfo &BI) {
+    IO.mapRequired("Format", BI.Format);
+    IO.mapRequired("AddressBits", BI.AddressBits);
+    // We do not serialize the pointer here on purpose.
+    IO.mapRequired("BinarySize", BI.BinarySize);
+  }
+};
+
+template <> struct MappingTraits<jit_compiler::SYCLArgumentDescriptor> {
+  static void mapping(IO &IO, jit_compiler::SYCLArgumentDescriptor &AD) {
+    IO.mapRequired("Kinds", AD.Kinds);
+    IO.mapRequired("Mask", AD.UsageMask);
+  }
+};
+
+template <> struct MappingTraits<jit_compiler::SYCLKernelAttribute> {
+  static void mapping(IO &IO, jit_compiler::SYCLKernelAttribute &KA) {
+    IO.mapRequired("AttrName", KA.AttributeName);
+    IO.mapRequired("Values", KA.Values);
+  }
+};
+
+template <> struct MappingTraits<jit_compiler::SYCLKernelInfo> {
+  static void mapping(IO &IO, jit_compiler::SYCLKernelInfo &KI) {
+    IO.mapRequired("KernelName", KI.Name);
+    IO.mapRequired("Args", KI.Args);
+    IO.mapOptional("Attributes", KI.Attributes);
+    IO.mapRequired("BinInfo", KI.BinaryInfo);
+  }
+};
+
+template <> struct MappingTraits<jit_compiler::SYCLModuleInfo> {
+  static void mapping(IO &IO, jit_compiler::SYCLModuleInfo &SMI) {
+    IO.mapRequired("Kernels", SMI.kernels());
+  }
+};
+
+} // namespace yaml
+} // namespace llvm
+
+#endif // SYCL_FUSION_COMMON_KERNELIO_H

--- a/sycl-fusion/jit-compiler/CMakeLists.txt
+++ b/sycl-fusion/jit-compiler/CMakeLists.txt
@@ -1,0 +1,42 @@
+
+add_llvm_library(sycl-fusion
+  SHARED
+   lib/KernelFusion.cpp
+   lib/JITContext.cpp
+   lib/translation/SPIRVLLVMTranslation.cpp
+   lib/fusion/FusionHelper.cpp
+   lib/fusion/ModuleHelper.cpp
+   lib/helper/ConfigHelper.cpp
+
+   LINK_COMPONENTS
+   Core
+   Support
+   Analysis
+   TransformUtils
+   Passes
+   Linker
+   ScalarOpts
+   InstCombine
+)
+
+target_include_directories(sycl-fusion
+  PUBLIC
+  $<INSTALL_INTERFACE:include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${SYCL_JIT_BASE_DIR}/common/include>
+  PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/lib
+  ${LLVM_SPIRV_INCLUDE_DIRS}
+)
+
+find_package(Threads REQUIRED)
+
+target_link_libraries(sycl-fusion
+  PRIVATE
+  LLVMSPIRVLib
+  ${CMAKE_THREAD_LIBS_INIT}
+)
+
+install(TARGETS sycl-fusion
+  LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT sycl-fusion
+  RUNTIME DESTINATION "bin" COMPONENT sycl-fusion)

--- a/sycl-fusion/jit-compiler/include/JITContext.h
+++ b/sycl-fusion/jit-compiler/include/JITContext.h
@@ -1,0 +1,65 @@
+//==------- JITContext.h - Context holding data for the JIT compiler -------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SYCL_FUSION_JIT_COMPILER_JITCONTEXT_H
+#define SYCL_FUSION_JIT_COMPILER_JITCONTEXT_H
+
+#include "llvm/IR/LLVMContext.h"
+#include <shared_mutex>
+#include <unordered_map>
+
+#include "Kernel.h"
+#include "Parameter.h"
+
+namespace jit_compiler {
+
+///
+/// Wrapper around a SPIR-V binary.
+class SPIRVBinary {
+public:
+  explicit SPIRVBinary(std::string Binary);
+
+  jit_compiler::BinaryAddress address() const;
+
+  size_t size() const;
+
+private:
+  std::string Blob;
+};
+
+///
+/// Context to persistenly store information across invocations of the JIT
+/// compiler and manage lifetimes of binaries.
+class JITContext {
+
+public:
+  JITContext();
+
+  ~JITContext();
+
+  llvm::LLVMContext *getLLVMContext();
+
+  SPIRVBinary &emplaceSPIRVBinary(std::string Binary);
+
+private:
+  // FIXME: Change this to std::shared_mutex after switching to C++17.
+  using MutexT = std::shared_timed_mutex;
+
+  using ReadLockT = std::shared_lock<MutexT>;
+
+  using WriteLockT = std::unique_lock<MutexT>;
+
+  std::unique_ptr<llvm::LLVMContext> LLVMCtx;
+
+  MutexT BinariesMutex;
+
+  std::vector<SPIRVBinary> Binaries;
+};
+} // namespace jit_compiler
+
+#endif // SYCL_FUSION_JIT_COMPILER_JITCONTEXT_H

--- a/sycl-fusion/jit-compiler/include/KernelFusion.h
+++ b/sycl-fusion/jit-compiler/include/KernelFusion.h
@@ -1,0 +1,69 @@
+//==- KernelFusion.h - Public interface of JIT compiler for kernel fusion --==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SYCL_FUSION_JIT_COMPILER_KERNELFUSION_H
+#define SYCL_FUSION_JIT_COMPILER_KERNELFUSION_H
+
+#include "JITContext.h"
+#include "Kernel.h"
+#include "Options.h"
+#include "Parameter.h"
+#include <string>
+#include <vector>
+
+namespace jit_compiler {
+
+class FusionResult {
+public:
+  explicit FusionResult(std::string &&ErrorMessage)
+      : Type{FusionResultType::FAILED}, Value{std::move(ErrorMessage)} {}
+
+  explicit FusionResult(SYCLKernelInfo KernelInfo, bool Cached = false)
+      : Type{(Cached) ? FusionResultType::CACHED : FusionResultType::NEW},
+        Value{std::forward<SYCLKernelInfo>(KernelInfo)} {}
+
+  bool failed() const { return Type == FusionResultType::FAILED; }
+
+  bool cached() const { return Type == FusionResultType::CACHED; }
+
+  const std::string &getErrorMessage() const {
+    assert(failed() && std::holds_alternative<std::string>(Value) &&
+           "No error message present");
+    return std::get<std::string>(Value);
+  }
+
+  const SYCLKernelInfo &getKernelInfo() const {
+    assert(!failed() && std::holds_alternative<SYCLKernelInfo>(Value) &&
+           "No kernel info");
+    return std::get<SYCLKernelInfo>(Value);
+  }
+
+private:
+  enum class FusionResultType { FAILED, CACHED, NEW };
+  FusionResultType Type;
+
+  std::variant<std::string, SYCLKernelInfo> Value;
+};
+
+class KernelFusion {
+
+public:
+  static FusionResult
+  fuseKernels(JITContext &JITCtx, Config &&JITConfig,
+              const std::vector<SYCLKernelInfo> &KernelInformation,
+              const std::vector<std::string> &KernelsToFuse,
+              const std::string &FusedKernelName,
+              jit_compiler::ParamIdentList &Identities, int BarriersFlags,
+              const std::vector<jit_compiler::ParameterInternalization>
+                  &Internalization,
+              const std::vector<jit_compiler::JITConstant> &JITConstants);
+};
+
+} // namespace jit_compiler
+
+#endif // SYCL_FUSION_JIT_COMPILER_KERNELFUSION_H

--- a/sycl-fusion/jit-compiler/include/Options.h
+++ b/sycl-fusion/jit-compiler/include/Options.h
@@ -1,0 +1,82 @@
+//==-------- Options.h - Option infrastructure for the JIT compiler --------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SYCL_FUSION_JIT_COMPILER_OPTIONS_H
+#define SYCL_FUSION_JIT_COMPILER_OPTIONS_H
+
+#include <memory>
+#include <unordered_map>
+
+namespace jit_compiler {
+
+enum OptionID { VerboseOutput, EnableCaching };
+
+class OptionPtrBase {};
+
+class Config {
+
+public:
+  template <typename Opt> void set(typename Opt::ValueType Value) {
+    Opt::set(*this, Value);
+  }
+
+  template <typename Opt> typename Opt::ValueType get() {
+    return Opt::get(*this);
+  }
+
+private:
+  std::unordered_map<OptionID, std::unique_ptr<OptionPtrBase>> OptionValues;
+
+  void set(OptionID ID, std::unique_ptr<OptionPtrBase> Value) {
+    OptionValues[ID] = std::move(Value);
+  }
+
+  OptionPtrBase *get(OptionID ID) {
+    if (OptionValues.count(ID)) {
+      return OptionValues.at(ID).get();
+    }
+    return nullptr;
+  }
+
+  template <OptionID ID, typename T> friend class OptionBase;
+};
+
+template <OptionID ID, typename T> class OptionBase : public OptionPtrBase {
+public:
+  using ValueType = T;
+
+protected:
+  static void set(Config &Cfg, T Value) {
+    Cfg.set(ID,
+            std::unique_ptr<OptionBase<ID, T>>{new OptionBase<ID, T>{Value}});
+  }
+
+  static const T get(Config &Cfg) {
+    auto *ConfigValue = Cfg.get(ID);
+    if (!ConfigValue) {
+      return T{};
+    }
+    return static_cast<OptionBase<ID, T> *>(ConfigValue)->Value;
+  }
+
+private:
+  T Value;
+
+  OptionBase(T Val) : Value{Val} {}
+
+  friend Config;
+};
+
+namespace option {
+
+struct JITEnableVerbose : public OptionBase<OptionID::VerboseOutput, bool> {};
+
+} // namespace option
+} // namespace jit_compiler
+
+#endif // SYCL_FUSION_JIT_COMPILER_OPTIONS_H

--- a/sycl-fusion/jit-compiler/include/Parameter.h
+++ b/sycl-fusion/jit-compiler/include/Parameter.h
@@ -1,0 +1,122 @@
+//==--- Parameter.h - JIT compiler representations for SYCL kernel params --==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SYCL_FUSION_JIT_COMPILER_PARAMETER_H
+#define SYCL_FUSION_JIT_COMPILER_PARAMETER_H
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace jit_compiler {
+///
+/// Parameters are identified by the index of the defining kernel
+/// in the list of input kernels and the parameter's index in that
+/// kernel's parameter list.
+struct Parameter {
+  unsigned KernelIdx;
+  unsigned ParamIdx;
+
+  ///
+  /// Compares two instances of Parameter
+  friend bool operator==(const Parameter &LHS, const Parameter &RHS) noexcept {
+    return LHS.KernelIdx == RHS.KernelIdx && LHS.ParamIdx == RHS.ParamIdx;
+  }
+
+  ///
+  /// Compares two instances of Parameter
+  friend bool operator!=(const Parameter &LHS, const Parameter &RHS) noexcept {
+    return !(LHS == RHS);
+  }
+};
+
+///
+/// Express that two parameters, identified by kernel and parameter
+/// index have identical value.
+struct ParameterIdentity {
+  Parameter LHS;
+  Parameter RHS;
+
+  ///
+  /// Compares two instances of ParameterIdentity
+  friend bool operator==(const ParameterIdentity &LHS,
+                         const ParameterIdentity &RHS) noexcept {
+    return (LHS.LHS == RHS.LHS && LHS.RHS == RHS.RHS) ||
+           (LHS.LHS == RHS.RHS && LHS.RHS == RHS.LHS);
+  }
+
+  ///
+  /// Compares two instances of ParameterIdentity
+  friend bool operator!=(const ParameterIdentity &LHS,
+                         const ParameterIdentity &RHS) noexcept {
+    return !(LHS == RHS);
+  }
+};
+
+using ParamIdentList = std::vector<ParameterIdentity>;
+
+///
+/// Express how a parameter can be lowered using promotion to local or global
+/// memory.
+///
+/// 1:1 correspondence with the enum in include/SYCL/common.h (SYCL runtime)
+enum class Internalization : unsigned {
+  None = 0, /// Not used. Introduced for symmetry with the original enum
+  Local = 1,
+  Private = 2,
+};
+
+///
+/// Express that a parameter can be internalized by local or private promotion
+/// or that it cannot be internalized at all.
+struct ParameterInternalization {
+  Parameter Param;
+  Internalization Intern;
+  std::size_t LocalSize;
+  ParameterInternalization() = default;
+  ParameterInternalization(const Parameter &Param, Internalization Intern,
+                           std::size_t LocalSize)
+      : Param{Param}, Intern{Intern}, LocalSize{LocalSize} {}
+
+  friend bool operator==(const ParameterInternalization &LHS,
+                         const ParameterInternalization &RHS) noexcept {
+    return LHS.LocalSize == RHS.LocalSize && LHS.Intern == RHS.Intern &&
+           LHS.Param == RHS.Param;
+  }
+
+  friend bool operator!=(const ParameterInternalization &LHS,
+                         const ParameterInternalization &RHS) noexcept {
+    return !(LHS == RHS);
+  }
+};
+
+///
+/// Express that a parameter is a scalar or aggregate whose value is known at
+/// JIT-compilation time.
+/// Client of the API owns the data held by `ValPtr`.
+struct JITConstant {
+  Parameter Param;
+  std::string Value;
+  JITConstant() = default;
+  JITConstant(const Parameter &Parameter, void *Ptr, size_t Size)
+      : Param{Parameter}, Value{reinterpret_cast<const char *>(Ptr), Size} {}
+
+  friend bool operator==(const JITConstant &LHS,
+                         const JITConstant &RHS) noexcept {
+
+    return LHS.Param == RHS.Param && LHS.Value == RHS.Value;
+  }
+
+  friend bool operator!=(const JITConstant &LHS,
+                         const JITConstant &RHS) noexcept {
+    return !(LHS == RHS);
+  }
+};
+} // namespace jit_compiler
+
+#endif // SYCL_FUSION_JIT_COMPILER_PARAMETER_H

--- a/sycl-fusion/jit-compiler/lib/JITContext.cpp
+++ b/sycl-fusion/jit-compiler/lib/JITContext.cpp
@@ -1,0 +1,34 @@
+//==---------------------------- JITContext.cpp ----------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "JITContext.h"
+
+using namespace jit_compiler;
+
+SPIRVBinary::SPIRVBinary(std::string Binary) : Blob{std::move(Binary)} {}
+
+jit_compiler::BinaryAddress SPIRVBinary::address() const {
+  // FIXME: Verify it's a good idea to perform this reinterpret_cast here.
+  return reinterpret_cast<jit_compiler::BinaryAddress>(Blob.c_str());
+}
+
+size_t SPIRVBinary::size() const { return Blob.size(); }
+
+JITContext::JITContext() : LLVMCtx{new llvm::LLVMContext}, Binaries{} {}
+
+JITContext::~JITContext() = default;
+
+llvm::LLVMContext *JITContext::getLLVMContext() { return LLVMCtx.get(); }
+
+SPIRVBinary &JITContext::emplaceSPIRVBinary(std::string Binary) {
+  WriteLockT WriteLock{BinariesMutex};
+  // NOTE: With C++17, which returns a reference from emplace_back, the
+  // following code would be even simpler.
+  Binaries.emplace_back(std::move(Binary));
+  return Binaries.back();
+}

--- a/sycl-fusion/jit-compiler/lib/KernelFusion.cpp
+++ b/sycl-fusion/jit-compiler/lib/KernelFusion.cpp
@@ -1,0 +1,116 @@
+//==-------------------------- KernelFusion.cpp ----------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "KernelFusion.h"
+#include "Kernel.h"
+#include "KernelIO.h"
+#include "Options.h"
+#include "fusion/FusionHelper.h"
+#include "helper/ConfigHelper.h"
+#include "helper/ErrorHandling.h"
+#include "translation/SPIRVLLVMTranslation.h"
+#include <llvm/Support/Error.h>
+#include <sstream>
+
+using namespace jit_compiler;
+
+using FusedFunction = helper::FusionHelper::FusedFunction;
+using FusedFunctionList = std::vector<FusedFunction>;
+
+static FusionResult errorToFusionResult(llvm::Error &&Err,
+                                        const std::string &Msg) {
+  std::stringstream ErrMsg;
+  ErrMsg << Msg << "\nDetailed information:\n";
+  llvm::handleAllErrors(std::move(Err),
+                        [&ErrMsg](const llvm::StringError &Err) {
+                          // Cannot throw an exception here if LLVM itself is
+                          // compiled without exception support.
+                          ErrMsg << "\t" << Err.getMessage() << "\n";
+                        });
+  return FusionResult{ErrMsg.str()};
+}
+
+FusionResult KernelFusion::fuseKernels(
+    JITContext &JITCtx, Config &&JITConfig,
+    const std::vector<SYCLKernelInfo> &KernelInformation,
+    const std::vector<std::string> &KernelsToFuse,
+    const std::string &FusedKernelName, ParamIdentList &Identities,
+    int BarriersFlags,
+    const std::vector<jit_compiler::ParameterInternalization> &Internalization,
+    const std::vector<jit_compiler::JITConstant> &Constants) {
+
+  // Initialize the configuration helper to make the options for this invocation
+  // available (on a per-thread basis).
+  ConfigHelper::setConfig(std::move(JITConfig));
+
+  SYCLModuleInfo ModuleInfo;
+  // Copy the kernel information for the input kernels to the module
+  // information. We could remove the copy, if we removed the const from the
+  // input interface, so it depends on the guarantees we want to give to
+  // callers.
+  ModuleInfo.kernels().insert(ModuleInfo.kernels().end(),
+                              KernelInformation.begin(),
+                              KernelInformation.end());
+  // Load all input kernels from their respective SPIR-V modules into a single
+  // LLVM IR module.
+  auto ModOrError = translation::SPIRVLLVMTranslator::loadSPIRVKernels(
+      *JITCtx.getLLVMContext(), ModuleInfo.kernels());
+  if (auto Error = ModOrError.takeError()) {
+    return errorToFusionResult(std::move(Error), "SPIR-V translation failed");
+  }
+  auto LLVMMod = std::move(*ModOrError);
+
+  // Add information about the kernel that should be fused as metadata into the
+  // LLVM module.
+  FusedFunction FusedKernel{FusedKernelName, KernelsToFuse,
+                            std::move(Identities), Internalization, Constants};
+  FusedFunctionList FusedKernelList;
+  FusedKernelList.push_back(FusedKernel);
+  auto NewModOrError =
+      helper::FusionHelper::addFusedKernel(LLVMMod.get(), FusedKernelList);
+  if (auto Error = NewModOrError.takeError()) {
+    return errorToFusionResult(std::move(Error),
+                               "Insertion of fused kernel stub failed");
+  }
+  auto NewMod = std::move(*NewModOrError);
+
+  // TODO: Invoke the actual fusion via LLVM pass manager.
+  // This will be added in a later PR.
+  auto NewModInfo = std::make_unique<SYCLModuleInfo>();
+
+  // Get the updated kernel info for the fused kernel and add the information to
+  // the existing KernelInfo.
+  if (!NewModInfo->hasKernelFor(FusedKernelName)) {
+    return FusionResult{"No KernelInfo for fused kernel"};
+  }
+
+  auto &FusedKernelInfo = *NewModInfo->getKernelFor(FusedKernelName);
+
+  // Translate the LLVM IR module resulting from the fusion pass into SPIR-V.
+  auto BinaryOrError =
+      translation::SPIRVLLVMTranslator::translateLLVMtoSPIRV(*NewMod, JITCtx);
+  if (auto Error = BinaryOrError.takeError()) {
+    return errorToFusionResult(std::move(Error),
+                               "Translation to SPIR-V failed");
+  }
+  auto *SPIRVBin = *BinaryOrError;
+
+  // Update the KernelInfo for the fused kernel with the address and size of the
+  // SPIR-V binary resulting from translation.
+  auto &FusedBinaryInfo = FusedKernelInfo.BinaryInfo;
+  FusedBinaryInfo.Format = BinaryFormat::SPIRV;
+  // Output SPIR-V should use the same number of address bits as the input
+  // SPIR-V. SPIR-V translation requires all modules to use the same number of
+  // address bits, so it's safe to take the value from the first one.
+  FusedBinaryInfo.AddressBits =
+      ModuleInfo.kernels().front().BinaryInfo.AddressBits;
+  FusedBinaryInfo.BinaryStart = SPIRVBin->address();
+  FusedBinaryInfo.BinarySize = SPIRVBin->size();
+
+  return FusionResult{FusedKernelInfo};
+}

--- a/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.cpp
+++ b/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.cpp
@@ -1,0 +1,186 @@
+//==-------------------------- FusionHelper.cpp ----------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "FusionHelper.h"
+
+#include "ModuleHelper.h"
+#include "helper/ErrorHandling.h"
+#include "llvm/IR/Constants.h"
+
+using namespace llvm;
+
+template <typename T>
+static Metadata *getConstantIntMD(llvm::LLVMContext &LLVMContext, T Val) {
+  return ConstantAsMetadata::get(
+      ConstantInt::get(Type::getInt64Ty(LLVMContext), Val));
+}
+
+static Metadata *getConstantMD(llvm::LLVMContext &LLVMCtx,
+                               llvm::StringRef Data) {
+  return MDString::get(LLVMCtx, Data);
+}
+
+static Metadata *getMDParam(LLVMContext &LLVMCtx,
+                            const jit_compiler::Parameter &Param) {
+  return MDNode::get(LLVMCtx,
+                     {getConstantIntMD<unsigned>(LLVMCtx, Param.KernelIdx),
+                      getConstantIntMD<unsigned>(LLVMCtx, Param.ParamIdx)});
+}
+
+Expected<std::unique_ptr<Module>> helper::FusionHelper::addFusedKernel(
+    llvm::Module *LLVMModule,
+    const std::vector<FusedFunction> &FusedFunctions) {
+
+  // Get a clean module, containing only the input functions for fusion and
+  // functions (transitively) called from there.
+  PROPAGATE_ERROR(NewMod, getCleanModule(LLVMModule, FusedFunctions))
+
+  llvm::LLVMContext &LLVMCtx = NewMod->getContext();
+
+  const char *MetadataKind = "sycl.kernel.fused";
+  const char *ParameterMDKind = "sycl.kernel.param";
+  const char *InternalizationMDKind = "sycl.kernel.promote";
+  const char *InternalizationLSMDKind = "sycl.kernel.promote.localsize";
+  const char *ConstantsMDKind = "sycl.kernel.constants";
+  // The function type of each kernel stub is identical ("void()"),
+  // the fusion pass will insert the correct arguments based on
+  // the fused functions later on.
+  auto *FT = FunctionType::get(Type::getVoidTy(LLVMCtx), false);
+
+  // Create a function stub for each fused kernel with metadata information
+  // about which kernels should be fused into this kernel.
+  for (const auto &FF : FusedFunctions) {
+    // The function stub has a generic name (not the specified name of
+    // the fused kernel), because we cannot change a function's signature
+    // in-place in the fusion pass. Instead, we create a function stub
+    // with generic name and create the actual fused function with the
+    // correct name and signature only during the fusion pass.
+    auto *F = Function::Create(FT, GlobalValue::LinkageTypes::ExternalLinkage,
+                               "fused_kernel", *NewMod);
+
+    // Attach metadata to the function stub.
+    // The metadata specifies the name of the fused kernel (as the
+    // stub only has a generic name, see note above) and lists the names
+    // of all kernels that should be fused into this function.
+    // Kernel names may appear multiple times, resulting in
+    // the corresponding function to be included multiple times. The functions
+    // are included in the same order as given by the list.
+    SmallVector<Metadata *> MDFusedKernels;
+    for (const auto &FK : FF.FusedKernels) {
+      MDFusedKernels.push_back(MDString::get(LLVMCtx, FK));
+    }
+    auto *FusedKernelList = MDNode::get(LLVMCtx, MDFusedKernels);
+    auto *FusedNameMD = MDString::get(LLVMCtx, FF.FusedName);
+    auto *MDList = MDNode::get(LLVMCtx, {FusedNameMD, FusedKernelList});
+    assert(!F->hasMetadata(MetadataKind));
+    // The metadata can be identified by this fixed string providing a kind.
+    F->setMetadata(MetadataKind, MDList);
+
+    // The user of this API may be able to determine that
+    // the same value is used for multiple input functions in the fused kernel,
+    // e.g. when using the output of one kernel as the input to another kernel.
+    // This information is also given as metadata, more specifically a list of
+    // tuples. Each tuple contains two pairs identifying the two identical
+    // parameters, e.g. ((0,1),(2,3)) means that the second argument of the
+    // first kernel is identical to the fourth argument to the third kernel.
+    // Attach this information as metadata here.
+    if (!FF.ParameterIdentities.empty()) {
+      SmallVector<Metadata *> MDParameterIdentities;
+      for (const auto &PI : FF.ParameterIdentities) {
+        auto *LHS = getMDParam(LLVMCtx, PI.LHS);
+        auto *RHS = getMDParam(LLVMCtx, PI.RHS);
+        MDParameterIdentities.push_back(MDNode::get(LLVMCtx, {LHS, RHS}));
+      }
+      assert(!F->hasMetadata(ParameterMDKind));
+      F->setMetadata(ParameterMDKind,
+                     MDNode::get(LLVMCtx, MDParameterIdentities));
+    }
+
+    // The user of this API may provide information about what arguments should
+    // be internalized via promotion to local or private memory. This
+    // information is given as metadata, as two list of tuples (one for each
+    // kind of internalization) representing what parameters should be
+    // internalized.
+    {
+      const auto &Internalization = FF.ParameterInternalization;
+      if (!Internalization.empty()) {
+        SmallVector<Metadata *> MDInternalizationKind;
+        SmallVector<Metadata *> MDInternalizationLocalSize;
+        const auto EmplaceBackIntern = [&](const auto &Info, auto Str) {
+          std::array<Metadata *, 2> MDs;
+          MDs[0] = getMDParam(LLVMCtx, Info.Param);
+          MDs[1] = MDString::get(LLVMCtx, Str);
+          MDInternalizationKind.emplace_back(MDNode::get(LLVMCtx, MDs));
+          MDs[1] = getConstantIntMD<std::size_t>(LLVMCtx, Info.LocalSize);
+          MDInternalizationLocalSize.emplace_back(MDNode::get(LLVMCtx, MDs));
+        };
+        for (const auto &Info : Internalization) {
+          constexpr StringLiteral LocalInternalizationStr{"local"};
+          constexpr StringLiteral PrivateInternalizationStr{"private"};
+
+          const auto S = [&]() -> StringRef {
+            switch (Info.Intern) {
+            case jit_compiler::Internalization::None:
+              llvm_unreachable(
+                  "Only a valid internalization kind should be used");
+            case jit_compiler::Internalization::Local:
+              return LocalInternalizationStr;
+            case jit_compiler::Internalization::Private:
+              return PrivateInternalizationStr;
+            }
+          }();
+          EmplaceBackIntern(Info, S);
+        }
+        assert(!F->hasMetadata(InternalizationMDKind));
+        assert(!F->hasMetadata(InternalizationLSMDKind));
+        F->setMetadata(InternalizationMDKind,
+                       MDNode::get(LLVMCtx, MDInternalizationKind));
+        F->setMetadata(InternalizationLSMDKind,
+                       MDNode::get(LLVMCtx, MDInternalizationLocalSize));
+      }
+    }
+
+    // The user of this API may provide information about what scalar values
+    // should be used to specialize the fused kernel.
+    {
+      const auto &Constants = FF.Constants;
+      if (!Constants.empty()) {
+        SmallVector<Metadata *> MDConstants;
+        for (const auto &C : Constants) {
+          std::array<Metadata *, 2> MDs;
+          MDs[0] = getMDParam(LLVMCtx, C.Param);
+          MDs[1] = getConstantMD(LLVMCtx, C.Value);
+          MDConstants.emplace_back(MDNode::get(LLVMCtx, MDs));
+        }
+        assert(!F->hasMetadata(ConstantsMDKind));
+        F->setMetadata(ConstantsMDKind, MDNode::get(LLVMCtx, MDConstants));
+      }
+    }
+  }
+  return std::move(NewMod);
+}
+
+Expected<std::unique_ptr<llvm::Module>> helper::FusionHelper::getCleanModule(
+    llvm::Module *LLVMMod, const std::vector<FusedFunction> &FusedFunctions) {
+  // Find all input functions in the input module. Report an error and return
+  // nothing in case one of the input functions is not present in the input
+  // module.
+  SmallVector<Function *, 5> InputFunctions;
+  for (const auto &FF : FusedFunctions) {
+    for (const auto &IF : FF.FusedKernels) {
+      auto *InputFunction = LLVMMod->getFunction(IF);
+      if (!InputFunction) {
+        return createStringError(
+            inconvertibleErrorCode(),
+            "Input function %s not present in the input module\n", IF.c_str());
+      }
+      InputFunctions.push_back(InputFunction);
+    }
+  }
+  return helper::ModuleHelper::cloneAndPruneModule(LLVMMod, InputFunctions);
+}

--- a/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.h
+++ b/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.h
@@ -1,0 +1,56 @@
+//==--------- FusionHelper.h - helpers to insert fused kernel stub ---------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SYCL_FUSION_JIT_COMPILER_FUSION_FUSIONHELPER_H
+#define SYCL_FUSION_JIT_COMPILER_FUSION_FUSIONHELPER_H
+
+#include "Parameter.h"
+#include "llvm/IR/Module.h"
+#include <llvm/ADT/ArrayRef.h>
+#include <vector>
+
+namespace helper {
+
+///
+/// Simple helper to insert stubs and metadata for fused kernels into an LLVM
+/// module.
+class FusionHelper {
+public:
+  ///
+  /// Representation of a fused kernel named FusedName and fusing
+  /// all the kernels listed in FusedKernels.
+  struct FusedFunction {
+    std::string FusedName;
+    std::vector<std::string> FusedKernels;
+    jit_compiler::ParamIdentList ParameterIdentities;
+    llvm::ArrayRef<jit_compiler::ParameterInternalization>
+        ParameterInternalization;
+    llvm::ArrayRef<jit_compiler::JITConstant> Constants;
+  };
+
+  ///
+  /// Insert a function stub and metadata into the given LLVMModule,
+  /// representing a fused kernel resulting from the fusion of all kernels
+  /// listed in FusedFunctions. The actual fusion is performed by an LLVM pass,
+  /// which will consume the metadata and extend the function stub accordingly.
+  static llvm::Expected<std::unique_ptr<llvm::Module>>
+  addFusedKernel(llvm::Module *LLVMModule,
+                 const std::vector<FusedFunction> &FusedFunctions);
+
+private:
+  ///
+  /// Create a fresh, "clean" module from LLVMMod, containing only the input
+  /// functions from FusedFunctions and functions reachable from there.
+  static llvm::Expected<std::unique_ptr<llvm::Module>>
+  getCleanModule(llvm::Module *LLVMMod,
+                 const std::vector<FusedFunction> &FusedFunctions);
+};
+
+} // namespace helper
+
+#endif // SYCL_FUSION_JIT_COMPILER_FUSION_FUSIONHELPER_H

--- a/sycl-fusion/jit-compiler/lib/fusion/ModuleHelper.cpp
+++ b/sycl-fusion/jit-compiler/lib/fusion/ModuleHelper.cpp
@@ -1,0 +1,82 @@
+//==-------------------------- ModuleHelper.cpp ----------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ModuleHelper.h"
+
+#include "llvm/Analysis/CallGraph.h"
+#include "llvm/IR/Function.h"
+#include "llvm/Transforms/Utils/Cloning.h"
+
+using namespace llvm;
+
+std::unique_ptr<Module>
+helper::ModuleHelper::cloneAndPruneModule(Module *Mod,
+                                          ArrayRef<Function *> CGRoots) {
+  // Identify unused functions, i.e., functions not reachable from
+  // one of the root nodes in CGRoots.
+  SmallPtrSet<Function *, 16> UnusedFunctions;
+  identifyUnusedFunctions(Mod, CGRoots, UnusedFunctions);
+
+  // Clone the module, but use an external reference in place of the global
+  // definition for unused functions.
+  auto FunctionCloneMask = [&](const GlobalValue *GV) -> bool {
+    if (const auto *F = dyn_cast<Function>(GV)) {
+      return !UnusedFunctions.count(F);
+    }
+    return true;
+  };
+  ValueToValueMapTy VMap;
+  auto NewMod = llvm::CloneModule(*Mod, VMap, FunctionCloneMask);
+
+  // Remove the external references for unused functions from the clone module.
+  for (auto *UF : UnusedFunctions) {
+    auto *ExternalDef = NewMod->getFunction(UF->getName());
+    assert(ExternalDef && "No external definition with this name");
+    ExternalDef->eraseFromParent();
+  }
+  return NewMod;
+}
+
+void helper::ModuleHelper::identifyUnusedFunctions(
+    Module *Mod, ArrayRef<Function *> CGRoots,
+    SmallPtrSetImpl<llvm::Function *> &UnusedFunctions) {
+
+  // Get the call-graph for this module.
+  CallGraph CG(*Mod);
+  // CG.dump();
+  SmallPtrSet<Function *, 32> UsedFunctions;
+  // Worklist algorithm: Retrieve a function from the work list, mark it as used
+  // and add all functions called from this function to the worklist. Repeat
+  // until the worklist is empty.
+  SmallVector<Function *> Worklist;
+  for (auto *Root : CGRoots) {
+    Worklist.push_back(Root);
+  }
+  for (size_t I = 0; I < Worklist.size(); ++I) {
+    auto *F = Worklist[I];
+    UsedFunctions.insert(F);
+    for (auto &CGR : *CG[F]) {
+      auto *CF = CGR.second->getFunction();
+      if (CF && !UsedFunctions.count(CF)) {
+        // Only added previously unused functions to the worklist.
+        Worklist.push_back(CF);
+      }
+    }
+  }
+
+  // Identify all functions in the input module, which have not been marked as
+  // "used" in the previous step, as unused functions.
+  // NOTE: LLVM intrinsic functions do not participate in the call-graph and
+  // could falsely be detected as unused. Therefore, we never add them to the
+  // list of unused functions and never erase them.
+  for (auto &F : *Mod) {
+    if (!UsedFunctions.count(&F) && !F.isIntrinsic()) {
+      UnusedFunctions.insert(&F);
+    }
+  }
+}

--- a/sycl-fusion/jit-compiler/lib/fusion/ModuleHelper.cpp
+++ b/sycl-fusion/jit-compiler/lib/fusion/ModuleHelper.cpp
@@ -54,11 +54,11 @@ void helper::ModuleHelper::identifyUnusedFunctions(
   // and add all functions called from this function to the worklist. Repeat
   // until the worklist is empty.
   SmallVector<Function *> Worklist;
-  for (auto *Root : CGRoots) {
+  for (llvm::Function *Root : CGRoots) {
     Worklist.push_back(Root);
   }
   for (size_t I = 0; I < Worklist.size(); ++I) {
-    auto *F = Worklist[I];
+    llvm::Function *F = Worklist[I];
     UsedFunctions.insert(F);
     for (auto &CGR : *CG[F]) {
       auto *CF = CGR.second->getFunction();

--- a/sycl-fusion/jit-compiler/lib/fusion/ModuleHelper.h
+++ b/sycl-fusion/jit-compiler/lib/fusion/ModuleHelper.h
@@ -1,0 +1,35 @@
+//== ModuleHelper.h - Helper to prune unnecesary functions from LLVM module ==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SYCL_FUSION_JIT_COMPILER_FUSION_MODULEHELPER_H
+#define SYCL_FUSION_JIT_COMPILER_FUSION_MODULEHELPER_H
+
+#include "llvm/IR/Module.h"
+
+namespace helper {
+
+class ModuleHelper {
+public:
+  ///
+  /// Clone the module and prune unused functions, i.e., functions not reachable
+  /// from the functions in CGRoots.
+  static std::unique_ptr<llvm::Module>
+  cloneAndPruneModule(llvm::Module *Mod,
+                      llvm::ArrayRef<llvm::Function *> CGRoots);
+
+private:
+  ///
+  /// Identify functions not reachable from the function in CGRoots.
+  static void identifyUnusedFunctions(
+      llvm::Module *Mod, llvm::ArrayRef<llvm::Function *> CGRoots,
+      llvm::SmallPtrSetImpl<llvm::Function *> &UnusedFunctions);
+};
+
+} // namespace helper
+
+#endif // SYCL_FUSION_JIT_COMPILER_FUSION_MODULEHELPER_H

--- a/sycl-fusion/jit-compiler/lib/helper/ConfigHelper.cpp
+++ b/sycl-fusion/jit-compiler/lib/helper/ConfigHelper.cpp
@@ -1,0 +1,11 @@
+//==-------------------------- ConfigHelper.cpp ----------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ConfigHelper.h"
+
+thread_local jit_compiler::Config jit_compiler::ConfigHelper::Cfg;

--- a/sycl-fusion/jit-compiler/lib/helper/ConfigHelper.h
+++ b/sycl-fusion/jit-compiler/lib/helper/ConfigHelper.h
@@ -1,0 +1,29 @@
+//==---- ConfigHelper.h - Helper to manage compilation options for JIT -----==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SYCL_FUSION_JIT_COMPILER_HELPER_CONFIGHELPER_H
+#define SYCL_FUSION_JIT_COMPILER_HELPER_CONFIGHELPER_H
+
+#include "Options.h"
+
+namespace jit_compiler {
+
+class ConfigHelper {
+public:
+  static void setConfig(Config &&JITConfig) { Cfg = std::move(JITConfig); }
+
+  template <typename Opt> static typename Opt::ValueType get() {
+    return Cfg.get<Opt>();
+  }
+
+private:
+  static thread_local Config Cfg;
+};
+} // namespace jit_compiler
+
+#endif // SYCL_FUSION_JIT_COMPILER_HELPER_CONFIGHELPER_H

--- a/sycl-fusion/jit-compiler/lib/helper/ErrorHandling.h
+++ b/sycl-fusion/jit-compiler/lib/helper/ErrorHandling.h
@@ -1,0 +1,41 @@
+//==-- ErrorHandling.h - Helpers for error handling in the JIT compiler ----==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SYCL_FUSION_JIT_COMPILER_HELPER_ERRORHANDLING_H
+#define SYCL_FUSION_JIT_COMPILER_HELPER_ERRORHANDLING_H
+
+#include "ConfigHelper.h"
+#include "Options.h"
+#include <llvm/Support/Error.h>
+
+///
+/// Call a function returning llvm::Expected and propagate the error if it
+/// fails.
+///
+/// @param Var The variable the value should be assigned to if the call does not
+/// fail.
+/// @param F The function call.
+#define PROPAGATE_ERROR(Var, F)                                                \
+  auto VarOrErr = F;                                                           \
+  if (auto Err = VarOrErr.takeError()) {                                       \
+    return std::move(Err);                                                     \
+  }                                                                            \
+  auto &Var = *VarOrErr;
+
+namespace helper {
+
+static inline void printDebugMessage(llvm::StringRef Message) {
+  if (jit_compiler::ConfigHelper::get<
+          jit_compiler::option::JITEnableVerbose>()) {
+    llvm::errs() << "JIT DEBUG: " << Message << "\n";
+  }
+}
+
+} // namespace helper
+
+#endif // SYCL_FUSION_JIT_COMPILER_HELPER_ERRORHANDLING_H

--- a/sycl-fusion/jit-compiler/lib/translation/SPIRVLLVMTranslation.cpp
+++ b/sycl-fusion/jit-compiler/lib/translation/SPIRVLLVMTranslation.cpp
@@ -1,0 +1,190 @@
+//==---------------------- SPIRVLLVMTranslation.cpp ------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "SPIRVLLVMTranslation.h"
+
+#include "Kernel.h"
+#include "LLVMSPIRVLib.h"
+#include "helper/ErrorHandling.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/Linker/Linker.h"
+#include "llvm/Support/raw_ostream.h"
+#include <iostream>
+#include <sstream>
+
+using namespace jit_compiler;
+using namespace jit_compiler::translation;
+using namespace llvm;
+
+void SPIRVLLVMTranslator::getAttributeValues(std::vector<std::string> &Values,
+                                             MDNode *MD, size_t NumValues) {
+  assert(MD->getNumOperands() == NumValues && "Incorrect number of values");
+  for (const auto &MDOp : MD->operands()) {
+    auto *ConstantMD = cast<ConstantAsMetadata>(MDOp);
+    auto *ConstInt = cast<ConstantInt>(ConstantMD->getValue());
+    Values.push_back(std::to_string(ConstInt->getZExtValue()));
+  }
+}
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+static const char *REQD_WORK_GROUP_SIZE_ATTR = "reqd_work_group_size";
+// NOLINTNEXTLINE(readability-identifier-naming)
+static const char *WORK_GROUP_SIZE_HINT_ATTR = "work_group_size_hint";
+
+void SPIRVLLVMTranslator::restoreKernelAttributes(Module *Mod,
+                                                  SYCLKernelInfo &Info) {
+  auto *KernelFunction = Mod->getFunction(Info.Name);
+  assert(KernelFunction && "Kernel function not present in module");
+  if (auto *MD = KernelFunction->getMetadata(REQD_WORK_GROUP_SIZE_ATTR)) {
+    SYCLKernelAttribute ReqdAttr{REQD_WORK_GROUP_SIZE_ATTR};
+    getAttributeValues(ReqdAttr.Values, MD, 3);
+    Info.Attributes.push_back(ReqdAttr);
+  }
+  if (auto *MD = KernelFunction->getMetadata(WORK_GROUP_SIZE_HINT_ATTR)) {
+    SYCLKernelAttribute HintAttr{WORK_GROUP_SIZE_HINT_ATTR};
+    getAttributeValues(HintAttr.Values, MD, 3);
+    Info.Attributes.push_back(HintAttr);
+  }
+}
+
+SPIRV::TranslatorOpts &SPIRVLLVMTranslator::translatorOpts() {
+  static auto Opts = []() -> SPIRV::TranslatorOpts {
+    // Options for translation between SPIR-V and LLVM IR.
+    // Set SPIRV-V 1.2 as the maximum version number for now.
+    SPIRV::TranslatorOpts TransOpt{SPIRV::VersionNumber::SPIRV_1_2};
+    // Enable attachment of kernel arg names as metadata.
+    TransOpt.enableGenArgNameMD();
+    // Enable mem2reg.
+    TransOpt.setMemToRegEnabled(true);
+    // Enable all extensions.
+    // TODO: Specifically enable only the
+    // extensions listed in the KernelInfo.
+    // FIXME: Because there's no size provided,
+    // there's currently no obvious way to iterate the
+    // array of extensions in KernelInfo.
+    TransOpt.enableAllExtensions();
+    TransOpt.setDesiredBIsRepresentation(
+        SPIRV::BIsRepresentation::SPIRVFriendlyIR);
+    // TODO: We need to take care of specialization constants, either by
+    // instantiating them by the user-supplied value from the SYCL runtime or by
+    // making sure they are correctly represented in the output of the fusion
+    // process.
+    return TransOpt;
+  }();
+  return Opts;
+}
+
+Expected<std::unique_ptr<Module>>
+SPIRVLLVMTranslator::readAndTranslateSPIRV(LLVMContext &LLVMCtx,
+                                           BinaryBlob Input) {
+  // Create an input stream for the binary blob.
+  std::stringstream SPIRStream(
+      std::string(reinterpret_cast<const char *>(Input.first), Input.second),
+      std::ios_base::in | std::ios_base::binary);
+  std::string ErrMsg;
+  // Create a raw pointer. readSpirv accepts a reference to a pointer,
+  // so it will reset the pointer to point to an actual LLVM module.
+  Module *LLVMMod;
+  auto Success =
+      llvm::readSpirv(LLVMCtx, translatorOpts(), SPIRStream, LLVMMod, ErrMsg);
+  if (!Success) {
+    return createStringError(
+        inconvertibleErrorCode(),
+        "Failed to load and translate SPIR-V module with error %s",
+        ErrMsg.c_str());
+  }
+  return std::unique_ptr<Module>(LLVMMod);
+}
+
+Expected<std::unique_ptr<llvm::Module>>
+SPIRVLLVMTranslator::loadSPIRVKernels(llvm::LLVMContext &LLVMCtx,
+                                      std::vector<SYCLKernelInfo> &Kernels) {
+  std::unique_ptr<Module> Result{nullptr};
+  bool First = true;
+  DenseSet<BinaryBlob> ParsedSPIRVModules;
+  size_t AddressBits = 0;
+  for (auto &Kernel : Kernels) {
+    // FIXME: Currently, we use the front of the list.
+    // Do we need to iterate to find the most suitable
+    // SPIR-V module?
+    auto &BinInfo = Kernel.BinaryInfo;
+    // TODO(Lukas, ONNX-399): Also support LLVM IR as input but simply skipping
+    // the translation from SPIR-V to LLVM.
+    assert(BinInfo.Format == BinaryFormat::SPIRV &&
+           "Only SPIR-V supported as input");
+    const auto *SPRModulePtr = BinInfo.BinaryStart;
+    auto SPRModuleSize = BinInfo.BinarySize;
+    BinaryBlob BinBlob{SPRModulePtr, SPRModuleSize};
+    if (ParsedSPIRVModules.contains(BinBlob)) {
+      // Multiple kernels can be stored in the same SPIR-V module.
+      // If we encountered the same SPIR-V module before, skip.
+      // NOTE: We compare the pointer as well as the size, in case
+      // a previous kernel only referenced part of the SPIR-V module.
+      // Not sure this can actually happen, but better safe than sorry.
+      continue;
+    }
+    // Simply load and translate the SPIR-V into the currently still empty
+    // module.
+    PROPAGATE_ERROR(NewMod, readAndTranslateSPIRV(LLVMCtx, BinBlob));
+
+    // We do not assume that the input binary information has the address bits
+    // set, but rather retrieve this information from the SPIR-V/LLVM module's
+    // data-layout.
+    BinInfo.AddressBits = NewMod->getDataLayout().getPointerSizeInBits();
+    assert((First || BinInfo.AddressBits == AddressBits) &&
+           "Address bits do not match");
+    // Restore SYCL/OpenCL kernel attributes such as 'reqd_work_group_size' or
+    // 'work_group_size_hint' from metadata attached to the kernel function and
+    // store it in the SYCLKernelInfo.
+    // TODO(Lukas, ONNX-399): Validate that DPC++ used metadata to represent
+    // that information.
+    restoreKernelAttributes(NewMod.get(), Kernel);
+
+    if (First) {
+      // We can simply assign the module we just loaded from SPIR-V to the
+      // empty pointer on the first iteration.
+      Result = std::move(NewMod);
+      // The first module will dictate the address bits for the remaining.
+      AddressBits = BinInfo.AddressBits;
+      First = false;
+    } else {
+      // We have already loaded some module, so now we need to
+      // link the module we just loaded with the result so far.
+      // FIXME: We allow duplicates to be overridden by the module
+      // read last. This could cause problems if different modules contain
+      // definitions with the same name, but different body/content.
+      // Check that this is not problematic.
+      Linker::linkModules(*Result, std::move(NewMod),
+                          Linker::Flags::OverrideFromSrc);
+      if (AddressBits != BinInfo.AddressBits) {
+        return createStringError(
+            inconvertibleErrorCode(),
+            "Number of address bits between SPIR-V modules does not match");
+      }
+    }
+  }
+  return std::move(Result);
+}
+
+Expected<jit_compiler::SPIRVBinary *>
+SPIRVLLVMTranslator::translateLLVMtoSPIRV(Module &Mod, JITContext &JITCtx) {
+  std::ostringstream BinaryStream;
+  std::string ErrMsg;
+  auto Success = llvm::writeSpirv(&Mod, translatorOpts(), BinaryStream, ErrMsg);
+  if (!Success) {
+    return createStringError(
+        inconvertibleErrorCode(),
+        "Translation of LLVM IR to SPIR-V failed with error %s",
+        ErrMsg.c_str());
+  }
+  return &JITCtx.emplaceSPIRVBinary(BinaryStream.str());
+}

--- a/sycl-fusion/jit-compiler/lib/translation/SPIRVLLVMTranslation.cpp
+++ b/sycl-fusion/jit-compiler/lib/translation/SPIRVLLVMTranslation.cpp
@@ -116,13 +116,13 @@ SPIRVLLVMTranslator::loadSPIRVKernels(llvm::LLVMContext &LLVMCtx,
     // FIXME: Currently, we use the front of the list.
     // Do we need to iterate to find the most suitable
     // SPIR-V module?
-    auto &BinInfo = Kernel.BinaryInfo;
+    SYCLKernelBinaryInfo &BinInfo = Kernel.BinaryInfo;
     // TODO(Lukas, ONNX-399): Also support LLVM IR as input but simply skipping
     // the translation from SPIR-V to LLVM.
     assert(BinInfo.Format == BinaryFormat::SPIRV &&
            "Only SPIR-V supported as input");
-    const auto *SPRModulePtr = BinInfo.BinaryStart;
-    auto SPRModuleSize = BinInfo.BinarySize;
+    const unsigned char *SPRModulePtr = BinInfo.BinaryStart;
+    size_t SPRModuleSize = BinInfo.BinarySize;
     BinaryBlob BinBlob{SPRModulePtr, SPRModuleSize};
     if (ParsedSPIRVModules.contains(BinBlob)) {
       // Multiple kernels can be stored in the same SPIR-V module.

--- a/sycl-fusion/jit-compiler/lib/translation/SPIRVLLVMTranslation.h
+++ b/sycl-fusion/jit-compiler/lib/translation/SPIRVLLVMTranslation.h
@@ -1,0 +1,70 @@
+//==--- SPIRVLLVMTranslation.h - Translation between LLVM IR and SPIR-V ----==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SYCL_FUSION_JIT_COMPILER_TRANSLATION_SPIRVLLVMTRANSLATION_H
+#define SYCL_FUSION_JIT_COMPILER_TRANSLATION_SPIRVLLVMTRANSLATION_H
+
+#include "JITContext.h"
+#include "Kernel.h"
+#include "LLVMSPIRVOpts.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include <llvm/Support/Error.h>
+#include <vector>
+
+namespace jit_compiler {
+namespace translation {
+
+class SPIRVLLVMTranslator {
+public:
+  ///
+  /// Load a list of SPIR-V kernels into a single LLVM module.
+  static llvm::Expected<std::unique_ptr<llvm::Module>>
+  loadSPIRVKernels(llvm::LLVMContext &LLVMCtx,
+                   std::vector<SYCLKernelInfo> &Kernels);
+
+  ///
+  /// Translate the LLVM IR module Mod to SPIR-V, store it in the JITContext and
+  /// return a pointer to its container.
+  static llvm::Expected<SPIRVBinary *> translateLLVMtoSPIRV(llvm::Module &Mod,
+                                                            JITContext &JITCtx);
+
+private:
+  ///
+  /// Pair of address and size to represent a binary blob.
+  using BinaryBlob = std::pair<BinaryAddress, size_t>;
+
+  ///
+  /// Get an attribute value consisting of NumValues scalar constant integers
+  /// from the MDNode.
+  static void getAttributeValues(std::vector<std::string> &Values,
+                                 llvm::MDNode *MD, size_t NumValues);
+
+  ///
+  /// Restore kernel attributes for the kernel in Info from the metadata
+  /// attached to its kernel function in the LLVM module Mod.
+  /// Currently supported attributes:
+  ///   - reqd_work_group_size
+  ///   - work_group_size_hint
+  static void restoreKernelAttributes(llvm::Module *Mod, SYCLKernelInfo &Info);
+
+  ///
+  /// Read the given SPIR-V binary and translate it to a new LLVM module
+  /// associated with the given context.
+  static llvm::Expected<std::unique_ptr<llvm::Module>>
+  readAndTranslateSPIRV(llvm::LLVMContext &LLVMCtx, BinaryBlob Input);
+
+  ///
+  /// Default settings for the SPIRV translation options.
+  static SPIRV::TranslatorOpts &translatorOpts();
+};
+
+} // namespace translation
+} // namespace jit_compiler
+
+#endif // SYCL_FUSION_JIT_COMPILER_TRANSLATION_SPIRVLLVMTRANSLATION_H


### PR DESCRIPTION
This is the second patch in a series of patches to add an implementation of the[kernel fusion extension](https://github.com/intel/llvm/pull/7098). We have split the implementation into multiple patches to make them more easy to review.

This patch can be reviewed and merged independently of #7416. 

This patch adds the first components for the JIT compiler used for implementation of kernel fusion at runtime , concretely:
* API definitions
* Input translation from SPIR-V to LLVM IR
* Insertion of fused kernel function stub and metadata
* Supporting infrastructure such as compiler options.

CMake logic to link and code to invoke this JIT from the SYCL runtime will follow in a later patch.

Co-authored-by: Lukas Sommer <lukas.sommer@codeplay.com>
Co-authored-by: Victor Perez <victor.perez@codeplay.com>
Signed-off-by: Lukas Sommer <lukas.sommer@codeplay.com>