### PR TITLE
[SYCL][NFC] Properly use emplace_back in sycl-post-link

### DIFF
--- a/llvm/tools/sycl-post-link/ModuleSplitter.cpp
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.cpp
@@ -178,8 +178,8 @@ groupEntryPointsByKernelType(ModuleDesc &MD,
 
   if (!EntryPointMap.empty()) {
     for (auto &EPG : EntryPointMap) {
-      EntryPointGroups.emplace_back(EntryPointGroup{
-          EPG.first, std::move(EPG.second), MD.getEntryPointGroup().Props});
+      EntryPointGroups.emplace_back(EPG.first, std::move(EPG.second),
+                                    MD.getEntryPointGroup().Props);
       EntryPointGroup &G = EntryPointGroups.back();
 
       if (G.GroupId == ESIMD_SCOPE_NAME) {
@@ -191,8 +191,7 @@ groupEntryPointsByKernelType(ModuleDesc &MD,
     }
   } else {
     // No entry points met, record this.
-    EntryPointGroups.emplace_back(
-        EntryPointGroup{SYCL_SCOPE_NAME, EntryPointSet{}});
+    EntryPointGroups.emplace_back(SYCL_SCOPE_NAME, EntryPointSet{});
     EntryPointGroup &G = EntryPointGroups.back();
     G.Props.HasESIMD = SyclEsimdSplitStatus::SYCL_ONLY;
   }
@@ -250,15 +249,14 @@ EntryPointGroupVec groupEntryPointsByScope(ModuleDesc &MD,
   if (!EntryPointMap.empty()) {
     EntryPointGroups.reserve(EntryPointMap.size());
     for (auto &EPG : EntryPointMap) {
-      EntryPointGroups.emplace_back(EntryPointGroup{
-          EPG.first, std::move(EPG.second), MD.getEntryPointGroup().Props});
+      EntryPointGroups.emplace_back(EPG.first, std::move(EPG.second),
+                                    MD.getEntryPointGroup().Props);
       EntryPointGroup &G = EntryPointGroups.back();
       G.Props.Scope = EntryScope;
     }
   } else {
     // No entry points met, record this.
-    EntryPointGroups.emplace_back(
-        EntryPointGroup{GLOBAL_SCOPE_NAME, EntryPointSet{}});
+    EntryPointGroups.emplace_back(GLOBAL_SCOPE_NAME, EntryPointSet{});
   }
   return EntryPointGroups;
 }
@@ -287,13 +285,13 @@ groupEntryPointsByAttribute(ModuleDesc &MD, StringRef AttrName,
   if (!EntryPointMap.empty()) {
     EntryPointGroups.reserve(EntryPointMap.size());
     for (auto &EPG : EntryPointMap) {
-      EntryPointGroups.emplace_back(EntryPointGroup{
-          EPG.first, std::move(EPG.second), MD.getEntryPointGroup().Props});
+      EntryPointGroups.emplace_back(EPG.first, std::move(EPG.second),
+                                    MD.getEntryPointGroup().Props);
       F(EntryPointGroups.back());
     }
   } else {
     // No entry points met, record this.
-    EntryPointGroups.push_back({GLOBAL_SCOPE_NAME, {}});
+    EntryPointGroups.emplace_back(GLOBAL_SCOPE_NAME, EntryPointSet{});
     F(EntryPointGroups.back());
   }
   return EntryPointGroups;


### PR DESCRIPTION
We used to create a temporary object and pass it to `emplace_back`. Refactored code so we pass arguments to constructor directly without creating a temporary object.