### PR TITLE
[SYCL-MLIR] Load Vector dialect

### DIFF
--- a/polygeist/lib/polygeist/Passes/CMakeLists.txt
+++ b/polygeist/lib/polygeist/Passes/CMakeLists.txt
@@ -43,4 +43,5 @@ add_mlir_dialect_library(MLIRPolygeistTransforms
   MLIRSYCLDialect
   MLIRSYCLToLLVM
   MLIRTransformUtils
+  MLIRVectorToLLVM
   )

--- a/polygeist/lib/polygeist/Passes/ConvertPolygeistToLLVM.cpp
+++ b/polygeist/lib/polygeist/Passes/ConvertPolygeistToLLVM.cpp
@@ -22,6 +22,7 @@
 #include "mlir/Conversion/OpenMPToLLVM/ConvertOpenMPToLLVM.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Conversion/SYCLToLLVM/SYCLToLLVM.h"
+#include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
 #include "mlir/Dialect/Async/IR/Async.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Func/Transforms/Passes.h"
@@ -820,6 +821,7 @@ struct ConvertPolygeistToLLVMPass
       populateMathToLLVMConversionPatterns(converter, patterns);
       populateOpenMPToLLVMConversionPatterns(converter, patterns);
       arith::populateArithToLLVMConversionPatterns(converter, patterns);
+      populateVectorToLLVMConversionPatterns(converter, patterns);
 
       converter.addConversion([&](async::TokenType type) { return type; });
 

--- a/polygeist/tools/cgeist/CMakeLists.txt
+++ b/polygeist/tools/cgeist/CMakeLists.txt
@@ -72,6 +72,7 @@ target_link_libraries(cgeist PRIVATE
   MLIROpenMPToLLVMIRTranslation
   MLIRSYCLToLLVM
   MLIRSYCLTransforms
+  MLIRVectorDialect
   
   LLVMSYCLLowerIR
   LLVMPasses

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -34,6 +34,7 @@
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/Passes.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 
 #include "mlir/Dialect/SYCL/IR/SYCLOpsDialect.h"
 #include "mlir/Dialect/SYCL/Transforms/Passes.h"
@@ -235,6 +236,7 @@ static void loadDialects(MLIRContext &context, const bool syclIsDevice) {
   context.getOrLoadDialect<mlir::memref::MemRefDialect>();
   context.getOrLoadDialect<mlir::linalg::LinalgDialect>();
   context.getOrLoadDialect<mlir::polygeist::PolygeistDialect>();
+  context.getOrLoadDialect<mlir::vector::VectorDialect>();
 
   if (syclIsDevice) {
     context.getOrLoadDialect<mlir::sycl::SYCLDialect>();


### PR DESCRIPTION
Load this dialect to be able to use some of its useful operations. It will be useful for vector splatting for now.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>