### PR TITLE
[SYCL] Relax work-group metadata generation and processing in sycl-post-link

### DIFF
--- a/llvm/test/tools/sycl-post-link/emit_program_metadata.ll
+++ b/llvm/test/tools/sycl-post-link/emit_program_metadata.ll
@@ -7,8 +7,12 @@
 target triple = "spir64-unknown-unknown"
 
 attributes #0 = { "sycl-work-group-size"="4,2,1" }
+attributes #1 = { "sycl-work-group-size"="4,2" }
+attributes #2 = { "sycl-work-group-size"="4" }
 
 !0 = !{i32 1, i32 2, i32 4}
+!1 = !{i32 2, i32 4}
+!2 = !{i32 4}
 
 define weak_odr spir_kernel void @SpirKernel1(float %arg1) !reqd_work_group_size !0 {
   call void @foo(float %arg1)
@@ -20,12 +24,36 @@ define weak_odr spir_kernel void @SpirKernel2(float %arg1) #0 {
   ret void
 }
 
+define weak_odr spir_kernel void @SpirKernel3(float %arg1) !reqd_work_group_size !1 {
+  call void @foo(float %arg1)
+  ret void
+}
+
+define weak_odr spir_kernel void @SpirKernel4(float %arg1) #1 {
+  call void @foo(float %arg1)
+  ret void
+}
+
+define weak_odr spir_kernel void @SpirKernel5(float %arg1) !reqd_work_group_size !2 {
+  call void @foo(float %arg1)
+  ret void
+}
+
+define weak_odr spir_kernel void @SpirKernel6(float %arg1) #2 {
+  call void @foo(float %arg1)
+  ret void
+}
+
 declare void @foo(float)
 
 ; CHECK-PROP: [SYCL/program metadata]
 ; // Base64 encoding in the prop file (including 8 bytes length):
 ; CHECK-PROP-NEXT: SpirKernel1@reqd_work_group_size=2|gBAAAAAAAAQAAAAACAAAAQAAAAA
 ; CHECK-PROP-NEXT: SpirKernel2@reqd_work_group_size=2|gBAAAAAAAAQAAAAACAAAAQAAAAA
+; CHECK-PROP-NEXT: SpirKernel3@reqd_work_group_size=2|ABAAAAAAAAgAAAAAEAAAAA
+; CHECK-PROP-NEXT: SpirKernel4@reqd_work_group_size=2|ABAAAAAAAAgAAAAAEAAAAA
+; CHECK-PROP-NEXT: SpirKernel5@reqd_work_group_size=2|gAAAAAAAAAABAAAA
+; CHECK-PROP-NEXT: SpirKernel6@reqd_work_group_size=2|gAAAAAAAAAABAAAA
 
 ; CHECK-TABLE: [Code|Properties]
 ; CHECK-TABLE-NEXT: {{.*}}files_0.prop

--- a/llvm/test/tools/sycl-post-link/kernel-properties.ll
+++ b/llvm/test/tools/sycl-post-link/kernel-properties.ll
@@ -36,7 +36,6 @@ attributes #2 = { convergent norecurse "frame-pointer"="all" "min-legal-vector-w
 !3 = !{i32 1, !"wchar_size", i32 4}
 !4 = !{i32 7, !"frame-pointer", i32 2}
 
-; Note that work-group sizes are padded with 1's after being reversed.
 ; CHECK-IR-DAG: ![[SGSizeMD0]] = !{i32 3}
 ; CHECK-IR-DAG: ![[WGSizeMD0]] = !{i{{[0-9]+}} 1}
 ; CHECK-IR-DAG: ![[WGSizeHintMD0]] = !{i{{[0-9]+}} 2}

--- a/llvm/test/tools/sycl-post-link/kernel-properties.ll
+++ b/llvm/test/tools/sycl-post-link/kernel-properties.ll
@@ -38,9 +38,9 @@ attributes #2 = { convergent norecurse "frame-pointer"="all" "min-legal-vector-w
 
 ; Note that work-group sizes are padded with 1's after being reversed.
 ; CHECK-IR-DAG: ![[SGSizeMD0]] = !{i32 3}
-; CHECK-IR-DAG: ![[WGSizeMD0]] = !{i{{[0-9]+}} 1, i{{[0-9]+}} 1, i{{[0-9]+}} 1}
-; CHECK-IR-DAG: ![[WGSizeHintMD0]] = !{i{{[0-9]+}} 2, i{{[0-9]+}} 1, i{{[0-9]+}} 1}
-; CHECK-IR-DAG: ![[WGSizeMD1]] = !{i{{[0-9]+}} 5, i{{[0-9]+}} 4, i{{[0-9]+}} 1}
-; CHECK-IR-DAG: ![[WGSizeHintMD1]] = !{i{{[0-9]+}} 7, i{{[0-9]+}} 6, i{{[0-9]+}} 1}
+; CHECK-IR-DAG: ![[WGSizeMD0]] = !{i{{[0-9]+}} 1}
+; CHECK-IR-DAG: ![[WGSizeHintMD0]] = !{i{{[0-9]+}} 2}
+; CHECK-IR-DAG: ![[WGSizeMD1]] = !{i{{[0-9]+}} 5, i{{[0-9]+}} 4}
+; CHECK-IR-DAG: ![[WGSizeHintMD1]] = !{i{{[0-9]+}} 7, i{{[0-9]+}} 6}
 ; CHECK-IR-DAG: ![[WGSizeMD2]] = !{i{{[0-9]+}} 10, i{{[0-9]+}} 9, i{{[0-9]+}} 8}
 ; CHECK-IR-DAG: ![[WGSizeHintMD2]] = !{i{{[0-9]+}} 13, i{{[0-9]+}} 12, i{{[0-9]+}} 11}

--- a/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
+++ b/llvm/tools/sycl-post-link/CompileTimePropertiesPass.cpp
@@ -186,12 +186,6 @@ attributeToExecModeMetadata(Module &M, const Attribute &Attr) {
       MDVals.push_back(ConstantAsMetadata::get(Constant::getIntegerValue(
           SizeTTy, APInt(SizeTBitSize, ValStr, 10))));
 
-    // The SPIR-V translator expects 3 values, so we pad the remaining
-    // dimensions with 1.
-    for (size_t I = MDVals.size(); I < 3; ++I)
-      MDVals.push_back(ConstantAsMetadata::get(
-          Constant::getIntegerValue(SizeTTy, APInt(SizeTBitSize, 1))));
-
     const char *MDName = (AttrKindStr == "sycl-work-group-size")
                              ? "reqd_work_group_size"
                              : "work_group_size_hint";


### PR DESCRIPTION
When generating program metadata for `reqd_work_group_size` information sycl-post-link currently expects the existence of all three dimensions in the metadata. As a result the compile-time kernel property `work_group_size` needs to pad itself to adhere to this requirement. This commit relaxes the requirement by instead allowing fewer than three metadata operands in both `reqd_work_group_size` and `work_group_size_hint` when generating the program metadata. Additionally, padding will no longer be added when converting "sycl-work-group-size" and "sycl-work-group-size-hint" into the corresponding metadata.