### PR TITLE
[SYCL-MLIR] Fix bug when picking wrong SYCLMethodOp parent

### DIFF
--- a/mlir-sycl/lib/Transforms/SYCLMethodToSYCLCall.cpp
+++ b/mlir-sycl/lib/Transforms/SYCLMethodToSYCLCall.cpp
@@ -95,7 +95,7 @@ static LogicalResult convertMethod(SYCLMethodOpInterface method,
                 "the MangledFunctionName field of this operation.";
     }
 
-    SymbolTable Module(method->getParentOp()->getParentOp());
+    SymbolTable Module(method->getParentWithTrait<OpTrait::SymbolTable>());
     if (auto *Op = Module.lookup(Func->getName())) {
       // If the function has already been cloned to this module, use that.
       Func = cast<func::FuncOp>(Op);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -81,11 +81,6 @@ MLIRScanner::MLIRScanner(MLIRASTConsumer &Glob,
       LTInfo(LTInfo) {}
 
 void MLIRScanner::initUnsupportedFunctions() {
-  unsupportedFuncs.insert(
-      "_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_"
-      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
-      "listIJEEEE14getLinearIndexILi2EEEmNS0_2idIXT_EEE");
-
   // FIXME: cgeist: llvm/polygeist/tools/cgeist/Lib/clang-mlir.cc:119: void
   // checkFunctionParent(mlir::FunctionOpInterface, FunctionContext, const
   // mlir::OwningOpRef<mlir::ModuleOp>&): Assertion `(Context !=
@@ -93,6 +88,10 @@ void MLIRScanner::initUnsupportedFunctions() {
   // must be inserted into global module"' failed.
   unsupportedFuncs.insert("_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_");
   unsupportedFuncs.insert("_ZNK4sycl3_V14itemILi1ELb0EE13get_linear_idEv");
+  unsupportedFuncs.insert(
+      "_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_"
+      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
+      "listIJEEEE14getLinearIndexILi2EEEmNS0_2idIXT_EEE");
 
   // FIXME: cgeist: llvm/polygeist/tools/cgeist/Lib/CGCall.cc:94: void
   // castCallerArgs(mlir::func::FuncOp, llvm::SmallVectorImpl<mlir::Value>&,

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -81,12 +81,6 @@ MLIRScanner::MLIRScanner(MLIRASTConsumer &Glob,
       LTInfo(LTInfo) {}
 
 void MLIRScanner::initUnsupportedFunctions() {
-  // FIXME: -no-mangled-function-name: cgeist:
-  // llvm/mlir/lib/IR/SymbolTable.cpp:121:
-  // mlir::SymbolTable::SymbolTable(mlir::Operation*): Assertion
-  // `symbolTableOp->hasTrait<OpTrait::SymbolTable>() && "expected operation to
-  // have SymbolTable trait"' failed.
-  unsupportedFuncs.insert("_ZNK4sycl3_V15rangeILi2EE4sizeEv");
   unsupportedFuncs.insert(
       "_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_"
       "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"


### PR DESCRIPTION
For operations inside control-flow statements,
`method->getParentOp()->getParentOp()` would return the parent function. Using `method->getParentWithTrait<OpTrait::SymbolTable>()` fixes this issue.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>