### PR TITLE
[SYCL] Fix ModuleSplitterBase::totalSplits usage

### DIFF
--- a/llvm/tools/sycl-post-link/ModuleSplitter.h
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.h
@@ -236,10 +236,12 @@ public:
   // submodule containing these entry points and their dependencies.
   virtual ModuleDesc nextSplit() = 0;
 
-  size_t totalSplits() const { return Groups.size(); }
+  // Returns a number of remaining modules, which can be split out using this
+  // splitter. The value is reduced by 1 each time nextSplit is called.
+  size_t remainingSplits() const { return Groups.size(); }
 
   // Check that there are still submodules to split.
-  bool hasMoreSplits() const { return totalSplits() > 0; }
+  bool hasMoreSplits() const { return remainingSplits() > 0; }
 };
 
 std::unique_ptr<ModuleSplitterBase>

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -763,7 +763,7 @@ processInputModule(std::unique_ptr<Module> M) {
   if (DeviceGlobals)
     ScopedSplitter->verifyNoCrossModuleDeviceGlobalUsage();
 
-  const bool SplitByScope = ScopedSplitter->totalSplits() > 1;
+  const bool SplitByScope = ScopedSplitter->remainingSplits() > 1;
   bool SplitByOptionalFeatures = false;
 
   while (ScopedSplitter->hasMoreSplits()) {
@@ -784,7 +784,7 @@ processInputModule(std::unique_ptr<Module> M) {
     // This step is mandatory, because it is required for functional
     // correctness, i.e. to prevent speculative compilation of kernels that use
     // optional features on a HW which doesn't support them.
-    SplitByOptionalFeatures |= OptionalFeaturesSplitter->totalSplits() > 1;
+    SplitByOptionalFeatures |= OptionalFeaturesSplitter->remainingSplits() > 1;
 
     while (OptionalFeaturesSplitter->hasMoreSplits()) {
       TopLevelModules.emplace_back(OptionalFeaturesSplitter->nextSplit());
@@ -810,7 +810,7 @@ processInputModule(std::unique_ptr<Module> M) {
     std::unique_ptr<module_split::ModuleSplitterBase> LargeGRFSplitter =
         module_split::getLargeGRFSplitter(std::move(MDesc),
                                           EmitOnlyKernelsAsEntryPoints);
-    const bool SplitByLargeGRF = LargeGRFSplitter->totalSplits() > 1;
+    const bool SplitByLargeGRF = LargeGRFSplitter->remainingSplits() > 1;
     Modified |= SplitByLargeGRF;
 
     // Now split further by "large-grf" attribute.
@@ -828,7 +828,7 @@ processInputModule(std::unique_ptr<Module> M) {
       std::unique_ptr<module_split::ModuleSplitterBase> ESIMDSplitter =
           module_split::getSplitterByKernelType(std::move(MDesc1),
                                                 EmitOnlyKernelsAsEntryPoints);
-      const bool SplitByESIMD = ESIMDSplitter->totalSplits() > 1;
+      const bool SplitByESIMD = ESIMDSplitter->remainingSplits() > 1;
       Modified |= SplitByESIMD;
 
       if (SplitByESIMD && SplitByScope &&


### PR DESCRIPTION
`ModuleSplitterBase::totalSplits` method returns the amount of _remaining_ splits, i.e. every call to `ModuleSplitterBase::nextSplit` decrements that value.

Fixed an incorrect initialization of `SplitByMode` and `SplitByOptionalFeatures` variables by re-arranging code so we ask for amount of splits _before_ we extract them. Previously, those two variables were always initialized with `false`: from what I see in a code this shouldn't have resulted in any major issues, but it caused a problem in a downstream.