### PR TITLE
[SYCL-MLIR] Improve code generation for the rest of binary operators

### DIFF
--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -101,10 +101,37 @@ public:
   ValueCategory FCmpUNE(mlir::OpBuilder &builder, mlir::Location Loc,
                         mlir::Value RHS) const;
 
+  ValueCategory Mul(mlir::OpBuilder &Builder, mlir::Location Loc,
+                    mlir::Value RHS, bool HasNUW = false,
+                    bool HasNSW = false) const;
+  ValueCategory FMul(mlir::OpBuilder &Builder, mlir::Location Loc,
+                     mlir::Value RHS) const;
+
+  ValueCategory UDiv(mlir::OpBuilder &Builder, mlir::Location Loc,
+                     mlir::Value RHS, bool IsExact = false) const;
   ValueCategory SDiv(mlir::OpBuilder &Builder, mlir::Location Loc,
                      mlir::Value RHS, bool IsExact = false) const;
   ValueCategory ExactSDiv(mlir::OpBuilder &Builder, mlir::Location Loc,
                           mlir::Value RHS) const;
+
+  ValueCategory ExactUDiv(mlir::OpBuilder &Builder, mlir::Location Loc,
+                          mlir::Value RHS) const;
+  ValueCategory FDiv(mlir::OpBuilder &Builder, mlir::Location Loc,
+                     mlir::Value RHS) const;
+
+  ValueCategory URem(mlir::OpBuilder &Builder, mlir::Location Loc,
+                     mlir::Value RHS) const;
+  ValueCategory SRem(mlir::OpBuilder &Builder, mlir::Location Loc,
+                     mlir::Value RHS) const;
+
+  ValueCategory LShr(mlir::OpBuilder &Builder, mlir::Location Loc,
+                     mlir::Value RHS, bool IsExact = false) const;
+  ValueCategory AShr(mlir::OpBuilder &Builder, mlir::Location Loc,
+                     mlir::Value RHS, bool IsExact = false) const;
+  ValueCategory Shl(mlir::OpBuilder &Builder, mlir::Location Loc,
+                    mlir::Value RHS, bool HasNUW = false,
+                    bool HasNSW = false) const;
+
   ValueCategory FNeg(mlir::OpBuilder &Builder, mlir::Location Loc) const;
   ValueCategory Neg(mlir::OpBuilder &Builder, mlir::Location Loc,
                     bool HasNUW = false, bool HasNSW = false) const;
@@ -118,6 +145,13 @@ public:
                     bool HasNSW = false) const;
   ValueCategory FSub(mlir::OpBuilder &Builder, mlir::Location Loc,
                      mlir::Value RHS) const;
+
+  ValueCategory And(mlir::OpBuilder &Builder, mlir::Location Loc,
+                    mlir::Value RHS) const;
+  ValueCategory Or(mlir::OpBuilder &Builder, mlir::Location Loc,
+                   mlir::Value RHS) const;
+  ValueCategory Xor(mlir::OpBuilder &Builder, mlir::Location Loc,
+                    mlir::Value RHS) const;
 };
 
 #endif /* CLANG_MLIR_VALUE_CATEGORY */

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -531,6 +531,8 @@ public:
 #include "Expressions.def"
 #undef HANDLEUNARYOP
 
+  ValueCategory ConstrainShiftValue(ValueCategory LHS, ValueCategory RHS);
+
   ValueCategory VisitCXXNoexceptExpr(clang::CXXNoexceptExpr *AS);
 
   ValueCategory VisitAttributedStmt(clang::AttributedStmt *AS);

--- a/polygeist/tools/cgeist/Test/Verification/and.c
+++ b/polygeist/tools/cgeist/Test/Verification/and.c
@@ -1,0 +1,190 @@
+// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+
+typedef char char_vec __attribute__((ext_vector_type(3)));
+typedef short short_vec __attribute__((ext_vector_type(3)));
+typedef int int_vec __attribute__((ext_vector_type(3)));
+typedef long long_vec __attribute__((ext_vector_type(3)));
+typedef unsigned char unsigned_char_vec __attribute__((ext_vector_type(3)));
+typedef unsigned short unsigned_short_vec __attribute__((ext_vector_type(3)));
+typedef unsigned int unsigned_int_vec __attribute__((ext_vector_type(3)));
+typedef unsigned long unsigned_long_vec __attribute__((ext_vector_type(3)));
+
+
+// CHECK-LABEL:   func.func @and_i8(
+// CHECK-SAME:                      %[[VAL_0:.*]]: i8,
+// CHECK-SAME:                      %[[VAL_1:.*]]: i8) -> i8
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.andi %[[VAL_0]], %[[VAL_1]] : i8
+// CHECK-NEXT:      return %[[VAL_2]] : i8
+// CHECK-NEXT:    }
+char and_i8(char a, char b) {
+  return a & b;
+}
+
+
+// CHECK-LABEL:   func.func @and_i16(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i16,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i16) -> i16
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.andi %[[VAL_0]], %[[VAL_1]] : i16
+// CHECK-NEXT:      return %[[VAL_2]] : i16
+// CHECK-NEXT:    }
+short and_i16(short a, short b) {
+  return a & b;
+}
+
+
+// CHECK-LABEL:   func.func @and_i32(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i32) -> i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.andi %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK-NEXT:      return %[[VAL_2]] : i32
+// CHECK-NEXT:    }
+int and_i32(int a, int b) {
+  return a & b;
+}
+
+
+// CHECK-LABEL:   func.func @and_i64(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i64,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i64) -> i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.andi %[[VAL_0]], %[[VAL_1]] : i64
+// CHECK-NEXT:      return %[[VAL_2]] : i64
+// CHECK-NEXT:    }
+long and_i64(long a, long b) {
+  return a & b;
+}
+
+
+// CHECK-LABEL:   func.func @and_ui8(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i8,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i8) -> i8
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.andi %[[VAL_0]], %[[VAL_1]] : i8
+// CHECK-NEXT:      return %[[VAL_2]] : i8
+// CHECK-NEXT:    }
+unsigned char and_ui8(unsigned char a, unsigned char b) {
+  return a & b;
+}
+
+
+// CHECK-LABEL:   func.func @and_ui16(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i16,
+// CHECK-SAME:                        %[[VAL_1:.*]]: i16) -> i16
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.andi %[[VAL_0]], %[[VAL_1]] : i16
+// CHECK-NEXT:      return %[[VAL_2]] : i16
+// CHECK-NEXT:    }
+unsigned short and_ui16(unsigned short a, unsigned short b) {
+  return a & b;
+}
+
+
+// CHECK-LABEL:   func.func @and_ui32(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                        %[[VAL_1:.*]]: i32) -> i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.andi %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK-NEXT:      return %[[VAL_2]] : i32
+// CHECK-NEXT:    }
+unsigned int and_ui32(unsigned int a, unsigned int b) {
+  return a & b;
+}
+
+
+// CHECK-LABEL:   func.func @and_ui64(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i64,
+// CHECK-SAME:                        %[[VAL_1:.*]]: i64) -> i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.andi %[[VAL_0]], %[[VAL_1]] : i64
+// CHECK-NEXT:      return %[[VAL_2]] : i64
+// CHECK-NEXT:    }
+unsigned long and_ui64(unsigned long a, unsigned long b) {
+  return a & b;
+}
+
+
+// CHECK-LABEL:   func.func @and_vi8(
+// CHECK-SAME:                       %[[VAL_0:.*]]: vector<3xi8>,
+// CHECK-SAME:                       %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.andi %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
+// CHECK-NEXT:      return %[[VAL_2]] : vector<3xi8>
+// CHECK-NEXT:    }
+char_vec and_vi8(char_vec a, char_vec b) {
+  return a & b;
+}
+
+
+// CHECK-LABEL:   func.func @and_vi16(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi16>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.andi %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
+// CHECK-NEXT:      return %[[VAL_2]] : vector<3xi16>
+// CHECK-NEXT:    }
+short_vec and_vi16(short_vec a, short_vec b) {
+  return a & b;
+}
+
+
+// CHECK-LABEL:   func.func @and_vi32(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi32>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.andi %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
+// CHECK-NEXT:      return %[[VAL_2]] : vector<3xi32>
+// CHECK-NEXT:    }
+int_vec and_vi32(int_vec a, int_vec b) {
+  return a & b;
+}
+
+
+// CHECK-LABEL:   func.func @and_vi64(
+// CHECK-SAME:                        %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
+// CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.andi %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xi64>
+// CHECK-NEXT:    }
+long_vec and_vi64(long_vec a, long_vec b) {
+  return a & b;
+}
+
+
+// CHECK-LABEL:   func.func @and_vui8(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi8>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.andi %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
+// CHECK-NEXT:      return %[[VAL_2]] : vector<3xi8>
+// CHECK-NEXT:    }
+unsigned_char_vec and_vui8(unsigned_char_vec a, unsigned_char_vec b) {
+  return a & b;
+}
+
+
+// CHECK-LABEL:   func.func @and_vui16(
+// CHECK-SAME:                         %[[VAL_0:.*]]: vector<3xi16>,
+// CHECK-SAME:                         %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.andi %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
+// CHECK-NEXT:      return %[[VAL_2]] : vector<3xi16>
+// CHECK-NEXT:    }
+unsigned_short_vec and_vui16(unsigned_short_vec a, unsigned_short_vec b) {
+  return a & b;
+}
+
+
+// CHECK-LABEL:   func.func @and_vui32(
+// CHECK-SAME:                         %[[VAL_0:.*]]: vector<3xi32>,
+// CHECK-SAME:                         %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.andi %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
+// CHECK-NEXT:      return %[[VAL_2]] : vector<3xi32>
+// CHECK-NEXT:    }
+unsigned_int_vec and_vui32(unsigned_int_vec a, unsigned_int_vec b) {
+  return a & b;
+}
+
+
+// CHECK-LABEL:   func.func @and_vui64(
+// CHECK-SAME:                         %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
+// CHECK-SAME:                         %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
+// CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.andi %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xi64>
+// CHECK-NEXT:    }
+unsigned_long_vec and_vui64(unsigned_long_vec a, unsigned_long_vec b) {
+  return a & b;
+}

--- a/polygeist/tools/cgeist/Test/Verification/div.c
+++ b/polygeist/tools/cgeist/Test/Verification/div.c
@@ -8,215 +8,243 @@ typedef unsigned char unsigned_char_vec __attribute__((ext_vector_type(3)));
 typedef unsigned short unsigned_short_vec __attribute__((ext_vector_type(3)));
 typedef unsigned int unsigned_int_vec __attribute__((ext_vector_type(3)));
 typedef unsigned long unsigned_long_vec __attribute__((ext_vector_type(3)));
-
-// CHECK-LABEL:   func.func @foo(
-// CHECK-SAME:                   %[[VAL_0:.*]]: memref<?xi32>,
-// CHECK-SAME:                   %[[VAL_1:.*]]: i32)
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 10 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:      scf.for %[[VAL_6:.*]] = %[[VAL_3]] to %[[VAL_2]] step %[[VAL_4]] {
-// CHECK-NEXT:        %[[VAL_7:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_6]]] : memref<?xi32>
-// CHECK-NEXT:        %[[VAL_8:.*]] = arith.addi %[[VAL_7]], %[[VAL_5]] : i32
-// CHECK-NEXT:        %[[VAL_9:.*]] = arith.xori %[[VAL_1]], %[[VAL_8]] : i32
-// CHECK-NEXT:        %[[VAL_10:.*]] = arith.xori %[[VAL_7]], %[[VAL_9]] : i32
-// CHECK-NEXT:        memref.store %[[VAL_10]], %[[VAL_0]]{{\[}}%[[VAL_6]]] : memref<?xi32>
-// CHECK-NEXT:      }
-// CHECK-NEXT:      return
-// CHECK-NEXT:    }
-void foo(int A[10], int a) {
-  for (int i = 0; i < 10; ++i)
-    A[i] ^= (a ^ (A[i] + 1));
-}
+typedef float float_vec __attribute__((ext_vector_type(3)));
+typedef double double_vec __attribute__((ext_vector_type(3)));
 
 
-// CHECK-LABEL:   func.func @xor_i8(
+// CHECK-LABEL:   func.func @div_i8(
 // CHECK-SAME:                      %[[VAL_0:.*]]: i8,
 // CHECK-SAME:                      %[[VAL_1:.*]]: i8) -> i8
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.extsi %[[VAL_0]] : i8 to i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.extsi %[[VAL_1]] : i8 to i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.divsi %[[VAL_2]], %[[VAL_3]] : i32
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i8
 // CHECK-NEXT:      return %[[VAL_5]] : i8
 // CHECK-NEXT:    }
-char xor_i8(char a, char b) {
-  return a ^ b;
+char div_i8(char a, char b) {
+  return a / b;
 }
 
-// CHECK-LABEL:   func.func @xor_i16(
+
+// CHECK-LABEL:   func.func @div_i16(
 // CHECK-SAME:                       %[[VAL_0:.*]]: i16,
 // CHECK-SAME:                       %[[VAL_1:.*]]: i16) -> i16
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.extsi %[[VAL_0]] : i16 to i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.extsi %[[VAL_1]] : i16 to i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.divsi %[[VAL_2]], %[[VAL_3]] : i32
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i16
 // CHECK-NEXT:      return %[[VAL_5]] : i16
 // CHECK-NEXT:    }
-short xor_i16(short a, short b) {
-  return a ^ b;
+short div_i16(short a, short b) {
+  return a / b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_i32(
+// CHECK-LABEL:   func.func @div_i32(
 // CHECK-SAME:                       %[[VAL_0:.*]]: i32,
 // CHECK-SAME:                       %[[VAL_1:.*]]: i32) -> i32
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.divsi %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK-NEXT:      return %[[VAL_2]] : i32
 // CHECK-NEXT:    }
-int xor_i32(int a, int b) {
-  return a ^ b;
+int div_i32(int a, int b) {
+  return a / b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_i64(
+// CHECK-LABEL:   func.func @div_i64(
 // CHECK-SAME:                       %[[VAL_0:.*]]: i64,
 // CHECK-SAME:                       %[[VAL_1:.*]]: i64) -> i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.divsi %[[VAL_0]], %[[VAL_1]] : i64
 // CHECK-NEXT:      return %[[VAL_2]] : i64
 // CHECK-NEXT:    }
-long xor_i64(long a, long b) {
-  return a ^ b;
+long div_i64(long a, long b) {
+  return a / b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_ui8(
+// CHECK-LABEL:   func.func @div_ui8(
 // CHECK-SAME:                       %[[VAL_0:.*]]: i8,
 // CHECK-SAME:                       %[[VAL_1:.*]]: i8) -> i8
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.extui %[[VAL_0]] : i8 to i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_1]] : i8 to i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.divsi %[[VAL_2]], %[[VAL_3]] : i32
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i8
 // CHECK-NEXT:      return %[[VAL_5]] : i8
 // CHECK-NEXT:    }
-unsigned char xor_ui8(unsigned char a, unsigned char b) {
-  return a ^ b;
+unsigned char div_ui8(unsigned char a, unsigned char b) {
+  return a / b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_ui16(
+// CHECK-LABEL:   func.func @div_ui16(
 // CHECK-SAME:                        %[[VAL_0:.*]]: i16,
 // CHECK-SAME:                        %[[VAL_1:.*]]: i16) -> i16
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.extui %[[VAL_0]] : i16 to i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_1]] : i16 to i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.divsi %[[VAL_2]], %[[VAL_3]] : i32
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i16
 // CHECK-NEXT:      return %[[VAL_5]] : i16
 // CHECK-NEXT:    }
-unsigned short xor_ui16(unsigned short a, unsigned short b) {
-  return a ^ b;
+unsigned short div_ui16(unsigned short a, unsigned short b) {
+  return a / b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_ui32(
+// CHECK-LABEL:   func.func @div_ui32(
 // CHECK-SAME:                        %[[VAL_0:.*]]: i32,
 // CHECK-SAME:                        %[[VAL_1:.*]]: i32) -> i32
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.divui %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK-NEXT:      return %[[VAL_2]] : i32
 // CHECK-NEXT:    }
-unsigned int xor_ui32(unsigned int a, unsigned int b) {
-  return a ^ b;
+unsigned int div_ui32(unsigned int a, unsigned int b) {
+  return a / b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_ui64(
+// CHECK-LABEL:   func.func @div_ui64(
 // CHECK-SAME:                        %[[VAL_0:.*]]: i64,
 // CHECK-SAME:                        %[[VAL_1:.*]]: i64) -> i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.divui %[[VAL_0]], %[[VAL_1]] : i64
 // CHECK-NEXT:      return %[[VAL_2]] : i64
 // CHECK-NEXT:    }
-unsigned long xor_ui64(unsigned long a, unsigned long b) {
-  return a ^ b;
+unsigned long div_ui64(unsigned long a, unsigned long b) {
+  return a / b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vi8(
+// CHECK-LABEL:   func.func @div_f32(
+// CHECK-SAME:                       %[[VAL_0:.*]]: f32,
+// CHECK-SAME:                       %[[VAL_1:.*]]: f32) -> f32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.divf %[[VAL_0]], %[[VAL_1]] : f32
+// CHECK-NEXT:      return %[[VAL_2]] : f32
+// CHECK-NEXT:    }
+float div_f32(float a, float b) {
+  return a / b;
+}
+
+
+// CHECK-LABEL:   func.func @div_f64(
+// CHECK-SAME:                       %[[VAL_0:.*]]: f64,
+// CHECK-SAME:                       %[[VAL_1:.*]]: f64) -> f64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.divf %[[VAL_0]], %[[VAL_1]] : f64
+// CHECK-NEXT:      return %[[VAL_2]] : f64
+// CHECK-NEXT:    }
+double div_f64(double a, double b) {
+  return a / b;
+}
+
+
+// CHECK-LABEL:   func.func @div_vi8(
 // CHECK-SAME:                       %[[VAL_0:.*]]: vector<3xi8>,
 // CHECK-SAME:                       %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.divsi %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi8>
 // CHECK-NEXT:    }
-char_vec xor_vi8(char_vec a, char_vec b) {
-  return a ^ b;
+char_vec div_vi8(char_vec a, char_vec b) {
+  return a / b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vi16(
+// CHECK-LABEL:   func.func @div_vi16(
 // CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi16>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.divsi %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi16>
 // CHECK-NEXT:    }
-short_vec xor_vi16(short_vec a, short_vec b) {
-  return a ^ b;
+short_vec div_vi16(short_vec a, short_vec b) {
+  return a / b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vi32(
+// CHECK-LABEL:   func.func @div_vi32(
 // CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi32>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.divsi %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi32>
 // CHECK-NEXT:    }
-int_vec xor_vi32(int_vec a, int_vec b) {
-  return a ^ b;
+int_vec div_vi32(int_vec a, int_vec b) {
+  return a / b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vi64(
+// CHECK-LABEL:   func.func @div_vi64(
 // CHECK-SAME:                        %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
 // CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
 // CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.divsi %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
 // CHECK-NEXT:      return %[[VAL_4]] : vector<3xi64>
 // CHECK-NEXT:    }
-long_vec xor_vi64(long_vec a, long_vec b) {
-  return a ^ b;
+long_vec div_vi64(long_vec a, long_vec b) {
+  return a / b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vui8(
+// CHECK-LABEL:   func.func @div_vui8(
 // CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi8>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.divui %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi8>
 // CHECK-NEXT:    }
-unsigned_char_vec xor_vui8(unsigned_char_vec a, unsigned_char_vec b) {
-  return a ^ b;
+unsigned_char_vec div_vui8(unsigned_char_vec a, unsigned_char_vec b) {
+  return a / b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vui16(
+// CHECK-LABEL:   func.func @div_vui16(
 // CHECK-SAME:                         %[[VAL_0:.*]]: vector<3xi16>,
 // CHECK-SAME:                         %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.divui %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi16>
 // CHECK-NEXT:    }
-unsigned_short_vec xor_vui16(unsigned_short_vec a, unsigned_short_vec b) {
-  return a ^ b;
+unsigned_short_vec div_vui16(unsigned_short_vec a, unsigned_short_vec b) {
+  return a / b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vui32(
+// CHECK-LABEL:   func.func @div_vui32(
 // CHECK-SAME:                         %[[VAL_0:.*]]: vector<3xi32>,
 // CHECK-SAME:                         %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.divui %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi32>
 // CHECK-NEXT:    }
-unsigned_int_vec xor_vui32(unsigned_int_vec a, unsigned_int_vec b) {
-  return a ^ b;
+unsigned_int_vec div_vui32(unsigned_int_vec a, unsigned_int_vec b) {
+  return a / b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vui64(
+// CHECK-LABEL:   func.func @div_vui64(
 // CHECK-SAME:                         %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
 // CHECK-SAME:                         %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
 // CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
 // CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.divui %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
 // CHECK-NEXT:      return %[[VAL_4]] : vector<3xi64>
 // CHECK-NEXT:    }
-unsigned_long_vec xor_vui64(unsigned_long_vec a, unsigned_long_vec b) {
-  return a ^ b;
+unsigned_long_vec div_vui64(unsigned_long_vec a, unsigned_long_vec b) {
+  return a / b;
+}
+
+
+// CHECK-LABEL:   func.func @div_vf32(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xf32>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xf32>) -> vector<3xf32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.divf %[[VAL_0]], %[[VAL_1]] : vector<3xf32>
+// CHECK-NEXT:      return %[[VAL_2]] : vector<3xf32>
+// CHECK-NEXT:    }
+float_vec div_vf32(float_vec a, float_vec b) {
+  return a / b;
+}
+
+
+// CHECK-LABEL:   func.func @div_vf64(
+// CHECK-SAME:                        %[[VAL_0:.*]]: memref<?xvector<3xf64>>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: memref<?xvector<3xf64>>) -> vector<3xf64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xf64>>
+// CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xf64>>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.divf %[[VAL_2]], %[[VAL_3]] : vector<3xf64>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xf64>
+// CHECK-NEXT:    }
+double_vec div_vf64(double_vec a, double_vec b) {
+  return a / b;
 }

--- a/polygeist/tools/cgeist/Test/Verification/mul.c
+++ b/polygeist/tools/cgeist/Test/Verification/mul.c
@@ -1,0 +1,150 @@
+// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+
+typedef char char_vec __attribute__((ext_vector_type(3)));
+typedef short short_vec __attribute__((ext_vector_type(3)));
+typedef int int_vec __attribute__((ext_vector_type(3)));
+typedef long long_vec __attribute__((ext_vector_type(3)));
+typedef float float_vec __attribute__((ext_vector_type(3)));
+typedef double double_vec __attribute__((ext_vector_type(3)));
+
+
+// CHECK-LABEL:   func.func @mul_i8(
+// CHECK-SAME:                      %[[VAL_0:.*]]: i8,
+// CHECK-SAME:                      %[[VAL_1:.*]]: i8) -> i8
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.extsi %[[VAL_0]] : i8 to i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extsi %[[VAL_1]] : i8 to i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.muli %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i8
+// CHECK-NEXT:      return %[[VAL_5]] : i8
+// CHECK-NEXT:    }
+char mul_i8(char a, char b) {
+  return a * b;
+}
+
+
+// CHECK-LABEL:   func.func @mul_i16(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i16,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i16) -> i16
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.extsi %[[VAL_0]] : i16 to i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extsi %[[VAL_1]] : i16 to i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.muli %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i16
+// CHECK-NEXT:      return %[[VAL_5]] : i16
+// CHECK-NEXT:    }
+short mul_i16(short a, short b) {
+  return a * b;
+}
+
+
+// CHECK-LABEL:   func.func @mul_i32(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i32) -> i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.muli %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK-NEXT:      return %[[VAL_2]] : i32
+// CHECK-NEXT:    }
+int mul_i32(int a, int b) {
+  return a * b;
+}
+
+
+// CHECK-LABEL:   func.func @mul_i64(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i64,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i64) -> i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.muli %[[VAL_0]], %[[VAL_1]] : i64
+// CHECK-NEXT:      return %[[VAL_2]] : i64
+// CHECK-NEXT:    }
+long mul_i64(long a, long b) {
+  return a * b;
+}
+
+
+// CHECK-LABEL:   func.func @mul_f32(
+// CHECK-SAME:                       %[[VAL_0:.*]]: f32,
+// CHECK-SAME:                       %[[VAL_1:.*]]: f32) -> f32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.mulf %[[VAL_0]], %[[VAL_1]] : f32
+// CHECK-NEXT:      return %[[VAL_2]] : f32
+// CHECK-NEXT:    }
+float mul_f32(float a, float b) {
+  return a * b;
+}
+
+
+// CHECK-LABEL:   func.func @mul_f64(
+// CHECK-SAME:                       %[[VAL_0:.*]]: f32,
+// CHECK-SAME:                       %[[VAL_1:.*]]: f32) -> f32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.mulf %[[VAL_0]], %[[VAL_1]] : f32
+// CHECK-NEXT:      return %[[VAL_2]] : f32
+// CHECK-NEXT:    }
+float mul_f64(float a, float b) {
+  return a * b;
+}
+
+
+// CHECK-LABEL:   func.func @mul_vi8(
+// CHECK-SAME:                       %[[VAL_0:.*]]: vector<3xi8>,
+// CHECK-SAME:                       %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.muli %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
+// CHECK-NEXT:      return %[[VAL_2]] : vector<3xi8>
+// CHECK-NEXT:    }
+char_vec mul_vi8(char_vec a, char_vec b) {
+  return a * b;
+}
+
+
+// CHECK-LABEL:   func.func @mul_vi16(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi16>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.muli %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
+// CHECK-NEXT:      return %[[VAL_2]] : vector<3xi16>
+// CHECK-NEXT:    }
+short_vec mul_vi16(short_vec a, short_vec b) {
+  return a * b;
+}
+
+
+// CHECK-LABEL:   func.func @mul_vi32(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi32>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.muli %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
+// CHECK-NEXT:      return %[[VAL_2]] : vector<3xi32>
+// CHECK-NEXT:    }
+int_vec mul_vi32(int_vec a, int_vec b) {
+  return a * b;
+}
+
+
+// CHECK-LABEL:   func.func @mul_vi64(
+// CHECK-SAME:                        %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
+// CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.muli %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xi64>
+// CHECK-NEXT:    }
+long_vec mul_vi64(long_vec a, long_vec b) {
+  return a * b;
+}
+
+
+// CHECK-LABEL:   func.func @mul_vf32(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xf32>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xf32>) -> vector<3xf32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.mulf %[[VAL_0]], %[[VAL_1]] : vector<3xf32>
+// CHECK-NEXT:      return %[[VAL_2]] : vector<3xf32>
+// CHECK-NEXT:    }
+float_vec mul_vf32(float_vec a, float_vec b) {
+  return a * b;
+}
+
+
+// CHECK-LABEL:   func.func @mul_vf64(
+// CHECK-SAME:                        %[[VAL_0:.*]]: memref<?xvector<3xf64>>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: memref<?xvector<3xf64>>) -> vector<3xf64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xf64>>
+// CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xf64>>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.mulf %[[VAL_2]], %[[VAL_3]] : vector<3xf64>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xf64>
+// CHECK-NEXT:    }
+double_vec mul_vf64(double_vec a, double_vec b) {
+  return a * b;
+}

--- a/polygeist/tools/cgeist/Test/Verification/or.c
+++ b/polygeist/tools/cgeist/Test/Verification/or.c
@@ -1,0 +1,189 @@
+// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+
+typedef char char_vec __attribute__((ext_vector_type(3)));
+typedef short short_vec __attribute__((ext_vector_type(3)));
+typedef int int_vec __attribute__((ext_vector_type(3)));
+typedef long long_vec __attribute__((ext_vector_type(3)));
+typedef unsigned char unsigned_char_vec __attribute__((ext_vector_type(3)));
+typedef unsigned short unsigned_short_vec __attribute__((ext_vector_type(3)));
+typedef unsigned int unsigned_int_vec __attribute__((ext_vector_type(3)));
+typedef unsigned long unsigned_long_vec __attribute__((ext_vector_type(3)));
+
+// CHECK-LABEL:   func.func @or_i8(
+// CHECK-SAME:                      %[[VAL_0:.*]]: i8,
+// CHECK-SAME:                      %[[VAL_1:.*]]: i8) -> i8
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.ori %[[VAL_0]], %[[VAL_1]] : i8
+// CHECK-NEXT:      return %[[VAL_2]] : i8
+// CHECK-NEXT:    }
+char or_i8(char a, char b) {
+  return a | b;
+}
+
+
+// CHECK-LABEL:   func.func @or_i16(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i16,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i16) -> i16
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.ori %[[VAL_0]], %[[VAL_1]] : i16
+// CHECK-NEXT:      return %[[VAL_2]] : i16
+// CHECK-NEXT:    }
+short or_i16(short a, short b) {
+  return a | b;
+}
+
+
+// CHECK-LABEL:   func.func @or_i32(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i32) -> i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.ori %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK-NEXT:      return %[[VAL_2]] : i32
+// CHECK-NEXT:    }
+int or_i32(int a, int b) {
+  return a | b;
+}
+
+
+// CHECK-LABEL:   func.func @or_i64(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i64,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i64) -> i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.ori %[[VAL_0]], %[[VAL_1]] : i64
+// CHECK-NEXT:      return %[[VAL_2]] : i64
+// CHECK-NEXT:    }
+long or_i64(long a, long b) {
+  return a | b;
+}
+
+
+// CHECK-LABEL:   func.func @or_ui8(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i8,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i8) -> i8
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.ori %[[VAL_0]], %[[VAL_1]] : i8
+// CHECK-NEXT:      return %[[VAL_2]] : i8
+// CHECK-NEXT:    }
+unsigned char or_ui8(unsigned char a, unsigned char b) {
+  return a | b;
+}
+
+
+// CHECK-LABEL:   func.func @or_ui16(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i16,
+// CHECK-SAME:                        %[[VAL_1:.*]]: i16) -> i16
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.ori %[[VAL_0]], %[[VAL_1]] : i16
+// CHECK-NEXT:      return %[[VAL_2]] : i16
+// CHECK-NEXT:    }
+unsigned short or_ui16(unsigned short a, unsigned short b) {
+  return a | b;
+}
+
+
+// CHECK-LABEL:   func.func @or_ui32(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                        %[[VAL_1:.*]]: i32) -> i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.ori %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK-NEXT:      return %[[VAL_2]] : i32
+// CHECK-NEXT:    }
+unsigned int or_ui32(unsigned int a, unsigned int b) {
+  return a | b;
+}
+
+
+// CHECK-LABEL:   func.func @or_ui64(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i64,
+// CHECK-SAME:                        %[[VAL_1:.*]]: i64) -> i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.ori %[[VAL_0]], %[[VAL_1]] : i64
+// CHECK-NEXT:      return %[[VAL_2]] : i64
+// CHECK-NEXT:    }
+unsigned long or_ui64(unsigned long a, unsigned long b) {
+  return a | b;
+}
+
+
+// CHECK-LABEL:   func.func @or_vi8(
+// CHECK-SAME:                       %[[VAL_0:.*]]: vector<3xi8>,
+// CHECK-SAME:                       %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.ori %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
+// CHECK-NEXT:      return %[[VAL_2]] : vector<3xi8>
+// CHECK-NEXT:    }
+char_vec or_vi8(char_vec a, char_vec b) {
+  return a | b;
+}
+
+
+// CHECK-LABEL:   func.func @or_vi16(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi16>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.ori %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
+// CHECK-NEXT:      return %[[VAL_2]] : vector<3xi16>
+// CHECK-NEXT:    }
+short_vec or_vi16(short_vec a, short_vec b) {
+  return a | b;
+}
+
+
+// CHECK-LABEL:   func.func @or_vi32(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi32>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.ori %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
+// CHECK-NEXT:      return %[[VAL_2]] : vector<3xi32>
+// CHECK-NEXT:    }
+int_vec or_vi32(int_vec a, int_vec b) {
+  return a | b;
+}
+
+
+// CHECK-LABEL:   func.func @or_vi64(
+// CHECK-SAME:                        %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
+// CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.ori %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xi64>
+// CHECK-NEXT:    }
+long_vec or_vi64(long_vec a, long_vec b) {
+  return a | b;
+}
+
+
+// CHECK-LABEL:   func.func @or_vui8(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi8>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.ori %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
+// CHECK-NEXT:      return %[[VAL_2]] : vector<3xi8>
+// CHECK-NEXT:    }
+unsigned_char_vec or_vui8(unsigned_char_vec a, unsigned_char_vec b) {
+  return a | b;
+}
+
+
+// CHECK-LABEL:   func.func @or_vui16(
+// CHECK-SAME:                         %[[VAL_0:.*]]: vector<3xi16>,
+// CHECK-SAME:                         %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.ori %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
+// CHECK-NEXT:      return %[[VAL_2]] : vector<3xi16>
+// CHECK-NEXT:    }
+unsigned_short_vec or_vui16(unsigned_short_vec a, unsigned_short_vec b) {
+  return a | b;
+}
+
+
+// CHECK-LABEL:   func.func @or_vui32(
+// CHECK-SAME:                         %[[VAL_0:.*]]: vector<3xi32>,
+// CHECK-SAME:                         %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.ori %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
+// CHECK-NEXT:      return %[[VAL_2]] : vector<3xi32>
+// CHECK-NEXT:    }
+unsigned_int_vec or_vui32(unsigned_int_vec a, unsigned_int_vec b) {
+  return a | b;
+}
+
+
+// CHECK-LABEL:   func.func @or_vui64(
+// CHECK-SAME:                         %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
+// CHECK-SAME:                         %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
+// CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.ori %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xi64>
+// CHECK-NEXT:    }
+unsigned_long_vec or_vui64(unsigned_long_vec a, unsigned_long_vec b) {
+  return a | b;
+}

--- a/polygeist/tools/cgeist/Test/Verification/rem.c
+++ b/polygeist/tools/cgeist/Test/Verification/rem.c
@@ -9,214 +9,194 @@ typedef unsigned short unsigned_short_vec __attribute__((ext_vector_type(3)));
 typedef unsigned int unsigned_int_vec __attribute__((ext_vector_type(3)));
 typedef unsigned long unsigned_long_vec __attribute__((ext_vector_type(3)));
 
-// CHECK-LABEL:   func.func @foo(
-// CHECK-SAME:                   %[[VAL_0:.*]]: memref<?xi32>,
-// CHECK-SAME:                   %[[VAL_1:.*]]: i32)
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 10 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:      scf.for %[[VAL_6:.*]] = %[[VAL_3]] to %[[VAL_2]] step %[[VAL_4]] {
-// CHECK-NEXT:        %[[VAL_7:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_6]]] : memref<?xi32>
-// CHECK-NEXT:        %[[VAL_8:.*]] = arith.addi %[[VAL_7]], %[[VAL_5]] : i32
-// CHECK-NEXT:        %[[VAL_9:.*]] = arith.xori %[[VAL_1]], %[[VAL_8]] : i32
-// CHECK-NEXT:        %[[VAL_10:.*]] = arith.xori %[[VAL_7]], %[[VAL_9]] : i32
-// CHECK-NEXT:        memref.store %[[VAL_10]], %[[VAL_0]]{{\[}}%[[VAL_6]]] : memref<?xi32>
-// CHECK-NEXT:      }
-// CHECK-NEXT:      return
-// CHECK-NEXT:    }
-void foo(int A[10], int a) {
-  for (int i = 0; i < 10; ++i)
-    A[i] ^= (a ^ (A[i] + 1));
-}
 
-
-// CHECK-LABEL:   func.func @xor_i8(
+// CHECK-LABEL:   func.func @rem_i8(
 // CHECK-SAME:                      %[[VAL_0:.*]]: i8,
 // CHECK-SAME:                      %[[VAL_1:.*]]: i8) -> i8
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.extsi %[[VAL_0]] : i8 to i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.extsi %[[VAL_1]] : i8 to i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.remsi %[[VAL_2]], %[[VAL_3]] : i32
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i8
 // CHECK-NEXT:      return %[[VAL_5]] : i8
 // CHECK-NEXT:    }
-char xor_i8(char a, char b) {
-  return a ^ b;
+char rem_i8(char a, char b) {
+  return a % b;
 }
 
-// CHECK-LABEL:   func.func @xor_i16(
+
+// CHECK-LABEL:   func.func @rem_i16(
 // CHECK-SAME:                       %[[VAL_0:.*]]: i16,
 // CHECK-SAME:                       %[[VAL_1:.*]]: i16) -> i16
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.extsi %[[VAL_0]] : i16 to i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.extsi %[[VAL_1]] : i16 to i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.remsi %[[VAL_2]], %[[VAL_3]] : i32
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i16
 // CHECK-NEXT:      return %[[VAL_5]] : i16
 // CHECK-NEXT:    }
-short xor_i16(short a, short b) {
-  return a ^ b;
+short rem_i16(short a, short b) {
+  return a % b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_i32(
+// CHECK-LABEL:   func.func @rem_i32(
 // CHECK-SAME:                       %[[VAL_0:.*]]: i32,
 // CHECK-SAME:                       %[[VAL_1:.*]]: i32) -> i32
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.remsi %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK-NEXT:      return %[[VAL_2]] : i32
 // CHECK-NEXT:    }
-int xor_i32(int a, int b) {
-  return a ^ b;
+int rem_i32(int a, int b) {
+  return a % b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_i64(
+// CHECK-LABEL:   func.func @rem_i64(
 // CHECK-SAME:                       %[[VAL_0:.*]]: i64,
 // CHECK-SAME:                       %[[VAL_1:.*]]: i64) -> i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.remsi %[[VAL_0]], %[[VAL_1]] : i64
 // CHECK-NEXT:      return %[[VAL_2]] : i64
 // CHECK-NEXT:    }
-long xor_i64(long a, long b) {
-  return a ^ b;
+long rem_i64(long a, long b) {
+  return a % b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_ui8(
+// CHECK-LABEL:   func.func @rem_ui8(
 // CHECK-SAME:                       %[[VAL_0:.*]]: i8,
 // CHECK-SAME:                       %[[VAL_1:.*]]: i8) -> i8
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.extui %[[VAL_0]] : i8 to i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_1]] : i8 to i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.remsi %[[VAL_2]], %[[VAL_3]] : i32
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i8
 // CHECK-NEXT:      return %[[VAL_5]] : i8
 // CHECK-NEXT:    }
-unsigned char xor_ui8(unsigned char a, unsigned char b) {
-  return a ^ b;
+unsigned char rem_ui8(unsigned char a, unsigned char b) {
+  return a % b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_ui16(
+// CHECK-LABEL:   func.func @rem_ui16(
 // CHECK-SAME:                        %[[VAL_0:.*]]: i16,
 // CHECK-SAME:                        %[[VAL_1:.*]]: i16) -> i16
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.extui %[[VAL_0]] : i16 to i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_1]] : i16 to i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.remsi %[[VAL_2]], %[[VAL_3]] : i32
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i16
 // CHECK-NEXT:      return %[[VAL_5]] : i16
 // CHECK-NEXT:    }
-unsigned short xor_ui16(unsigned short a, unsigned short b) {
-  return a ^ b;
+unsigned short rem_ui16(unsigned short a, unsigned short b) {
+  return a % b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_ui32(
+// CHECK-LABEL:   func.func @rem_ui32(
 // CHECK-SAME:                        %[[VAL_0:.*]]: i32,
 // CHECK-SAME:                        %[[VAL_1:.*]]: i32) -> i32
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.remui %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK-NEXT:      return %[[VAL_2]] : i32
 // CHECK-NEXT:    }
-unsigned int xor_ui32(unsigned int a, unsigned int b) {
-  return a ^ b;
+unsigned int rem_ui32(unsigned int a, unsigned int b) {
+  return a % b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_ui64(
+// CHECK-LABEL:   func.func @rem_ui64(
 // CHECK-SAME:                        %[[VAL_0:.*]]: i64,
 // CHECK-SAME:                        %[[VAL_1:.*]]: i64) -> i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.remui %[[VAL_0]], %[[VAL_1]] : i64
 // CHECK-NEXT:      return %[[VAL_2]] : i64
 // CHECK-NEXT:    }
-unsigned long xor_ui64(unsigned long a, unsigned long b) {
-  return a ^ b;
+unsigned long rem_ui64(unsigned long a, unsigned long b) {
+  return a % b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vi8(
+// CHECK-LABEL:   func.func @rem_vi8(
 // CHECK-SAME:                       %[[VAL_0:.*]]: vector<3xi8>,
 // CHECK-SAME:                       %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.remsi %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi8>
 // CHECK-NEXT:    }
-char_vec xor_vi8(char_vec a, char_vec b) {
-  return a ^ b;
+char_vec rem_vi8(char_vec a, char_vec b) {
+  return a % b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vi16(
+// CHECK-LABEL:   func.func @rem_vi16(
 // CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi16>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.remsi %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi16>
 // CHECK-NEXT:    }
-short_vec xor_vi16(short_vec a, short_vec b) {
-  return a ^ b;
+short_vec rem_vi16(short_vec a, short_vec b) {
+  return a % b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vi32(
+// CHECK-LABEL:   func.func @rem_vi32(
 // CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi32>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.remsi %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi32>
 // CHECK-NEXT:    }
-int_vec xor_vi32(int_vec a, int_vec b) {
-  return a ^ b;
+int_vec rem_vi32(int_vec a, int_vec b) {
+  return a % b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vi64(
+// CHECK-LABEL:   func.func @rem_vi64(
 // CHECK-SAME:                        %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
 // CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
 // CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.remsi %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
 // CHECK-NEXT:      return %[[VAL_4]] : vector<3xi64>
 // CHECK-NEXT:    }
-long_vec xor_vi64(long_vec a, long_vec b) {
-  return a ^ b;
+long_vec rem_vi64(long_vec a, long_vec b) {
+  return a % b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vui8(
+// CHECK-LABEL:   func.func @rem_vui8(
 // CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi8>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.remui %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi8>
 // CHECK-NEXT:    }
-unsigned_char_vec xor_vui8(unsigned_char_vec a, unsigned_char_vec b) {
-  return a ^ b;
+unsigned_char_vec rem_vui8(unsigned_char_vec a, unsigned_char_vec b) {
+  return a % b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vui16(
+// CHECK-LABEL:   func.func @rem_vui16(
 // CHECK-SAME:                         %[[VAL_0:.*]]: vector<3xi16>,
 // CHECK-SAME:                         %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.remui %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi16>
 // CHECK-NEXT:    }
-unsigned_short_vec xor_vui16(unsigned_short_vec a, unsigned_short_vec b) {
-  return a ^ b;
+unsigned_short_vec rem_vui16(unsigned_short_vec a, unsigned_short_vec b) {
+  return a % b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vui32(
+// CHECK-LABEL:   func.func @rem_vui32(
 // CHECK-SAME:                         %[[VAL_0:.*]]: vector<3xi32>,
 // CHECK-SAME:                         %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.remui %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi32>
 // CHECK-NEXT:    }
-unsigned_int_vec xor_vui32(unsigned_int_vec a, unsigned_int_vec b) {
-  return a ^ b;
+unsigned_int_vec rem_vui32(unsigned_int_vec a, unsigned_int_vec b) {
+  return a % b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vui64(
+// CHECK-LABEL:   func.func @rem_vui64(
 // CHECK-SAME:                         %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
 // CHECK-SAME:                         %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
 // CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
 // CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.remui %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
 // CHECK-NEXT:      return %[[VAL_4]] : vector<3xi64>
 // CHECK-NEXT:    }
-unsigned_long_vec xor_vui64(unsigned_long_vec a, unsigned_long_vec b) {
-  return a ^ b;
+unsigned_long_vec rem_vui64(unsigned_long_vec a, unsigned_long_vec b) {
+  return a % b;
 }

--- a/polygeist/tools/cgeist/Test/Verification/shl.c
+++ b/polygeist/tools/cgeist/Test/Verification/shl.c
@@ -9,214 +9,194 @@ typedef unsigned short unsigned_short_vec __attribute__((ext_vector_type(3)));
 typedef unsigned int unsigned_int_vec __attribute__((ext_vector_type(3)));
 typedef unsigned long unsigned_long_vec __attribute__((ext_vector_type(3)));
 
-// CHECK-LABEL:   func.func @foo(
-// CHECK-SAME:                   %[[VAL_0:.*]]: memref<?xi32>,
-// CHECK-SAME:                   %[[VAL_1:.*]]: i32)
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 10 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:      scf.for %[[VAL_6:.*]] = %[[VAL_3]] to %[[VAL_2]] step %[[VAL_4]] {
-// CHECK-NEXT:        %[[VAL_7:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_6]]] : memref<?xi32>
-// CHECK-NEXT:        %[[VAL_8:.*]] = arith.addi %[[VAL_7]], %[[VAL_5]] : i32
-// CHECK-NEXT:        %[[VAL_9:.*]] = arith.xori %[[VAL_1]], %[[VAL_8]] : i32
-// CHECK-NEXT:        %[[VAL_10:.*]] = arith.xori %[[VAL_7]], %[[VAL_9]] : i32
-// CHECK-NEXT:        memref.store %[[VAL_10]], %[[VAL_0]]{{\[}}%[[VAL_6]]] : memref<?xi32>
-// CHECK-NEXT:      }
-// CHECK-NEXT:      return
-// CHECK-NEXT:    }
-void foo(int A[10], int a) {
-  for (int i = 0; i < 10; ++i)
-    A[i] ^= (a ^ (A[i] + 1));
-}
 
-
-// CHECK-LABEL:   func.func @xor_i8(
+// CHECK-LABEL:   func.func @shl_i8(
 // CHECK-SAME:                      %[[VAL_0:.*]]: i8,
 // CHECK-SAME:                      %[[VAL_1:.*]]: i8) -> i8
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.extsi %[[VAL_0]] : i8 to i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.extsi %[[VAL_1]] : i8 to i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shli %[[VAL_2]], %[[VAL_3]] : i32
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i8
 // CHECK-NEXT:      return %[[VAL_5]] : i8
 // CHECK-NEXT:    }
-char xor_i8(char a, char b) {
-  return a ^ b;
+char shl_i8(char a, char b) {
+  return a << b;
 }
 
-// CHECK-LABEL:   func.func @xor_i16(
+
+// CHECK-LABEL:   func.func @shl_i16(
 // CHECK-SAME:                       %[[VAL_0:.*]]: i16,
 // CHECK-SAME:                       %[[VAL_1:.*]]: i16) -> i16
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.extsi %[[VAL_0]] : i16 to i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.extsi %[[VAL_1]] : i16 to i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shli %[[VAL_2]], %[[VAL_3]] : i32
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i16
 // CHECK-NEXT:      return %[[VAL_5]] : i16
 // CHECK-NEXT:    }
-short xor_i16(short a, short b) {
-  return a ^ b;
+short shl_i16(short a, short b) {
+  return a << b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_i32(
+// CHECK-LABEL:   func.func @shl_i32(
 // CHECK-SAME:                       %[[VAL_0:.*]]: i32,
 // CHECK-SAME:                       %[[VAL_1:.*]]: i32) -> i32
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shli %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK-NEXT:      return %[[VAL_2]] : i32
 // CHECK-NEXT:    }
-int xor_i32(int a, int b) {
-  return a ^ b;
+int shl_i32(int a, int b) {
+  return a << b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_i64(
+// CHECK-LABEL:   func.func @shl_i64(
 // CHECK-SAME:                       %[[VAL_0:.*]]: i64,
 // CHECK-SAME:                       %[[VAL_1:.*]]: i64) -> i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shli %[[VAL_0]], %[[VAL_1]] : i64
 // CHECK-NEXT:      return %[[VAL_2]] : i64
 // CHECK-NEXT:    }
-long xor_i64(long a, long b) {
-  return a ^ b;
+long shl_i64(long a, long b) {
+  return a << b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_ui8(
+// CHECK-LABEL:   func.func @shl_ui8(
 // CHECK-SAME:                       %[[VAL_0:.*]]: i8,
 // CHECK-SAME:                       %[[VAL_1:.*]]: i8) -> i8
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.extui %[[VAL_0]] : i8 to i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_1]] : i8 to i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shli %[[VAL_2]], %[[VAL_3]] : i32
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i8
 // CHECK-NEXT:      return %[[VAL_5]] : i8
 // CHECK-NEXT:    }
-unsigned char xor_ui8(unsigned char a, unsigned char b) {
-  return a ^ b;
+unsigned char shl_ui8(unsigned char a, unsigned char b) {
+  return a << b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_ui16(
+// CHECK-LABEL:   func.func @shl_ui16(
 // CHECK-SAME:                        %[[VAL_0:.*]]: i16,
 // CHECK-SAME:                        %[[VAL_1:.*]]: i16) -> i16
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.extui %[[VAL_0]] : i16 to i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_1]] : i16 to i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shli %[[VAL_2]], %[[VAL_3]] : i32
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i16
 // CHECK-NEXT:      return %[[VAL_5]] : i16
 // CHECK-NEXT:    }
-unsigned short xor_ui16(unsigned short a, unsigned short b) {
-  return a ^ b;
+unsigned short shl_ui16(unsigned short a, unsigned short b) {
+  return a << b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_ui32(
+// CHECK-LABEL:   func.func @shl_ui32(
 // CHECK-SAME:                        %[[VAL_0:.*]]: i32,
 // CHECK-SAME:                        %[[VAL_1:.*]]: i32) -> i32
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shli %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK-NEXT:      return %[[VAL_2]] : i32
 // CHECK-NEXT:    }
-unsigned int xor_ui32(unsigned int a, unsigned int b) {
-  return a ^ b;
+unsigned int shl_ui32(unsigned int a, unsigned int b) {
+  return a << b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_ui64(
+// CHECK-LABEL:   func.func @shl_ui64(
 // CHECK-SAME:                        %[[VAL_0:.*]]: i64,
 // CHECK-SAME:                        %[[VAL_1:.*]]: i64) -> i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shli %[[VAL_0]], %[[VAL_1]] : i64
 // CHECK-NEXT:      return %[[VAL_2]] : i64
 // CHECK-NEXT:    }
-unsigned long xor_ui64(unsigned long a, unsigned long b) {
-  return a ^ b;
+unsigned long shl_ui64(unsigned long a, unsigned long b) {
+  return a << b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vi8(
+// CHECK-LABEL:   func.func @shl_vi8(
 // CHECK-SAME:                       %[[VAL_0:.*]]: vector<3xi8>,
 // CHECK-SAME:                       %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shli %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi8>
 // CHECK-NEXT:    }
-char_vec xor_vi8(char_vec a, char_vec b) {
-  return a ^ b;
+char_vec shl_vi8(char_vec a, char_vec b) {
+  return a << b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vi16(
+// CHECK-LABEL:   func.func @shl_vi16(
 // CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi16>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shli %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi16>
 // CHECK-NEXT:    }
-short_vec xor_vi16(short_vec a, short_vec b) {
-  return a ^ b;
+short_vec shl_vi16(short_vec a, short_vec b) {
+  return a << b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vi32(
+// CHECK-LABEL:   func.func @shl_vi32(
 // CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi32>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shli %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi32>
 // CHECK-NEXT:    }
-int_vec xor_vi32(int_vec a, int_vec b) {
-  return a ^ b;
+int_vec shl_vi32(int_vec a, int_vec b) {
+  return a << b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vi64(
+// CHECK-LABEL:   func.func @shl_vi64(
 // CHECK-SAME:                        %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
 // CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
 // CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shli %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
 // CHECK-NEXT:      return %[[VAL_4]] : vector<3xi64>
 // CHECK-NEXT:    }
-long_vec xor_vi64(long_vec a, long_vec b) {
-  return a ^ b;
+long_vec shl_vi64(long_vec a, long_vec b) {
+  return a << b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vui8(
+// CHECK-LABEL:   func.func @shl_vui8(
 // CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi8>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shli %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi8>
 // CHECK-NEXT:    }
-unsigned_char_vec xor_vui8(unsigned_char_vec a, unsigned_char_vec b) {
-  return a ^ b;
+unsigned_char_vec shl_vui8(unsigned_char_vec a, unsigned_char_vec b) {
+  return a << b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vui16(
+// CHECK-LABEL:   func.func @shl_vui16(
 // CHECK-SAME:                         %[[VAL_0:.*]]: vector<3xi16>,
 // CHECK-SAME:                         %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shli %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi16>
 // CHECK-NEXT:    }
-unsigned_short_vec xor_vui16(unsigned_short_vec a, unsigned_short_vec b) {
-  return a ^ b;
+unsigned_short_vec shl_vui16(unsigned_short_vec a, unsigned_short_vec b) {
+  return a << b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vui32(
+// CHECK-LABEL:   func.func @shl_vui32(
 // CHECK-SAME:                         %[[VAL_0:.*]]: vector<3xi32>,
 // CHECK-SAME:                         %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shli %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi32>
 // CHECK-NEXT:    }
-unsigned_int_vec xor_vui32(unsigned_int_vec a, unsigned_int_vec b) {
-  return a ^ b;
+unsigned_int_vec shl_vui32(unsigned_int_vec a, unsigned_int_vec b) {
+  return a << b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vui64(
+// CHECK-LABEL:   func.func @shl_vui64(
 // CHECK-SAME:                         %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
 // CHECK-SAME:                         %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
 // CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
 // CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shli %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
 // CHECK-NEXT:      return %[[VAL_4]] : vector<3xi64>
 // CHECK-NEXT:    }
-unsigned_long_vec xor_vui64(unsigned_long_vec a, unsigned_long_vec b) {
-  return a ^ b;
+unsigned_long_vec shl_vui64(unsigned_long_vec a, unsigned_long_vec b) {
+  return a << b;
 }

--- a/polygeist/tools/cgeist/Test/Verification/shl.cl
+++ b/polygeist/tools/cgeist/Test/Verification/shl.cl
@@ -1,0 +1,234 @@
+// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+
+typedef char char_vec __attribute__((ext_vector_type(3)));
+typedef short short_vec __attribute__((ext_vector_type(3)));
+typedef int int_vec __attribute__((ext_vector_type(3)));
+typedef long long_vec __attribute__((ext_vector_type(3)));
+typedef unsigned char unsigned_char_vec __attribute__((ext_vector_type(3)));
+typedef unsigned short unsigned_short_vec __attribute__((ext_vector_type(3)));
+typedef unsigned int unsigned_int_vec __attribute__((ext_vector_type(3)));
+typedef unsigned long unsigned_long_vec __attribute__((ext_vector_type(3)));
+
+
+// CHECK-LABEL:   func.func @shl_i8(
+// CHECK-SAME:                      %[[VAL_0:.*]]: i8,
+// CHECK-SAME:                      %[[VAL_1:.*]]: i8) -> i8
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 31 : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extsi %[[VAL_0]] : i8 to i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.extsi %[[VAL_1]] : i8 to i32
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.andi %[[VAL_4]], %[[VAL_2]] : i32
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.shli %[[VAL_3]], %[[VAL_5]] : i32
+// CHECK-NEXT:      %[[VAL_7:.*]] = arith.trunci %[[VAL_6]] : i32 to i8
+// CHECK-NEXT:      return %[[VAL_7]] : i8
+// CHECK-NEXT:    }
+char shl_i8(char a, char b) {
+  return a << b;
+}
+
+
+// CHECK-LABEL:   func.func @shl_i16(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i16,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i16) -> i16
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 31 : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extsi %[[VAL_0]] : i16 to i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.extsi %[[VAL_1]] : i16 to i32
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.andi %[[VAL_4]], %[[VAL_2]] : i32
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.shli %[[VAL_3]], %[[VAL_5]] : i32
+// CHECK-NEXT:      %[[VAL_7:.*]] = arith.trunci %[[VAL_6]] : i32 to i16
+// CHECK-NEXT:      return %[[VAL_7]] : i16
+// CHECK-NEXT:    }
+short shl_i16(short a, short b) {
+  return a << b;
+}
+
+
+// CHECK-LABEL:   func.func @shl_i32(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i32) -> i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 31 : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shli %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK-NEXT:      return %[[VAL_4]] : i32
+// CHECK-NEXT:    }
+int shl_i32(int a, int b) {
+  return a << b;
+}
+
+
+// CHECK-LABEL:   func.func @shl_i64(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i64,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i64) -> i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 63 : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shli %[[VAL_0]], %[[VAL_3]] : i64
+// CHECK-NEXT:      return %[[VAL_4]] : i64
+// CHECK-NEXT:    }
+long shl_i64(long a, long b) {
+  return a << b;
+}
+
+
+// CHECK-LABEL:   func.func @shl_ui8(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i8,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i8) -> i8
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 31 : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_0]] : i8 to i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.extui %[[VAL_1]] : i8 to i32
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.andi %[[VAL_4]], %[[VAL_2]] : i32
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.shli %[[VAL_3]], %[[VAL_5]] : i32
+// CHECK-NEXT:      %[[VAL_7:.*]] = arith.trunci %[[VAL_6]] : i32 to i8
+// CHECK-NEXT:      return %[[VAL_7]] : i8
+// CHECK-NEXT:    }
+unsigned char shl_ui8(unsigned char a, unsigned char b) {
+  return a << b;
+}
+
+
+// CHECK-LABEL:   func.func @shl_ui16(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i16,
+// CHECK-SAME:                        %[[VAL_1:.*]]: i16) -> i16
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 31 : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_0]] : i16 to i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.extui %[[VAL_1]] : i16 to i32
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.andi %[[VAL_4]], %[[VAL_2]] : i32
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.shli %[[VAL_3]], %[[VAL_5]] : i32
+// CHECK-NEXT:      %[[VAL_7:.*]] = arith.trunci %[[VAL_6]] : i32 to i16
+// CHECK-NEXT:      return %[[VAL_7]] : i16
+// CHECK-NEXT:    }
+unsigned short shl_ui16(unsigned short a, unsigned short b) {
+  return a << b;
+}
+
+
+// CHECK-LABEL:   func.func @shl_ui32(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                        %[[VAL_1:.*]]: i32) -> i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 31 : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shli %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK-NEXT:      return %[[VAL_4]] : i32
+// CHECK-NEXT:    }
+unsigned int shl_ui32(unsigned int a, unsigned int b) {
+  return a << b;
+}
+
+
+// CHECK-LABEL:   func.func @shl_ui64(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i64,
+// CHECK-SAME:                        %[[VAL_1:.*]]: i64) -> i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 63 : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shli %[[VAL_0]], %[[VAL_3]] : i64
+// CHECK-NEXT:      return %[[VAL_4]] : i64
+// CHECK-NEXT:    }
+unsigned long shl_ui64(unsigned long a, unsigned long b) {
+  return a << b;
+}
+
+
+// CHECK-LABEL:   func.func @shl_vi8(
+// CHECK-SAME:                       %[[VAL_0:.*]]: vector<3xi8>,
+// CHECK-SAME:                       %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<7> : vector<3xi8>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : vector<3xi8>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shli %[[VAL_0]], %[[VAL_3]] : vector<3xi8>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xi8>
+// CHECK-NEXT:    }
+char_vec shl_vi8(char_vec a, char_vec b) {
+  return a << b;
+}
+
+
+// CHECK-LABEL:   func.func @shl_vi16(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi16>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<15> : vector<3xi16>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : vector<3xi16>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shli %[[VAL_0]], %[[VAL_3]] : vector<3xi16>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xi16>
+// CHECK-NEXT:    }
+short_vec shl_vi16(short_vec a, short_vec b) {
+  return a << b;
+}
+
+
+// CHECK-LABEL:   func.func @shl_vi32(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi32>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<31> : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shli %[[VAL_0]], %[[VAL_3]] : vector<3xi32>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xi32>
+// CHECK-NEXT:    }
+int_vec shl_vi32(int_vec a, int_vec b) {
+  return a << b;
+}
+
+
+// CHECK-LABEL:   func.func @shl_vi64(
+// CHECK-SAME:                        %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<63> : vector<3xi64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
+// CHECK-NEXT:      %[[VAL_4:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.andi %[[VAL_4]], %[[VAL_2]] : vector<3xi64>
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.shli %[[VAL_3]], %[[VAL_5]] : vector<3xi64>
+// CHECK-NEXT:      return %[[VAL_6]] : vector<3xi64>
+// CHECK-NEXT:    }
+long_vec shl_vi64(long_vec a, long_vec b) {
+  return a << b;
+}
+
+
+// CHECK-LABEL:   func.func @shl_vui8(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi8>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<7> : vector<3xi8>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : vector<3xi8>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shli %[[VAL_0]], %[[VAL_3]] : vector<3xi8>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xi8>
+// CHECK-NEXT:    }
+unsigned_char_vec shl_vui8(unsigned_char_vec a, unsigned_char_vec b) {
+  return a << b;
+}
+
+
+// CHECK-LABEL:   func.func @shl_vui16(
+// CHECK-SAME:                         %[[VAL_0:.*]]: vector<3xi16>,
+// CHECK-SAME:                         %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<15> : vector<3xi16>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : vector<3xi16>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shli %[[VAL_0]], %[[VAL_3]] : vector<3xi16>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xi16>
+// CHECK-NEXT:    }
+unsigned_short_vec shl_vui16(unsigned_short_vec a, unsigned_short_vec b) {
+  return a << b;
+}
+
+
+// CHECK-LABEL:   func.func @shl_vui32(
+// CHECK-SAME:                         %[[VAL_0:.*]]: vector<3xi32>,
+// CHECK-SAME:                         %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<31> : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shli %[[VAL_0]], %[[VAL_3]] : vector<3xi32>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xi32>
+// CHECK-NEXT:    }
+unsigned_int_vec shl_vui32(unsigned_int_vec a, unsigned_int_vec b) {
+  return a << b;
+}
+
+
+// CHECK-LABEL:   func.func @shl_vui64(
+// CHECK-SAME:                         %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
+// CHECK-SAME:                         %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<63> : vector<3xi64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
+// CHECK-NEXT:      %[[VAL_4:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.andi %[[VAL_4]], %[[VAL_2]] : vector<3xi64>
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.shli %[[VAL_3]], %[[VAL_5]] : vector<3xi64>
+// CHECK-NEXT:      return %[[VAL_6]] : vector<3xi64>
+// CHECK-NEXT:    }
+unsigned_long_vec shl_vui64(unsigned_long_vec a, unsigned_long_vec b) {
+  return a << b;
+}

--- a/polygeist/tools/cgeist/Test/Verification/shr.c
+++ b/polygeist/tools/cgeist/Test/Verification/shr.c
@@ -9,214 +9,194 @@ typedef unsigned short unsigned_short_vec __attribute__((ext_vector_type(3)));
 typedef unsigned int unsigned_int_vec __attribute__((ext_vector_type(3)));
 typedef unsigned long unsigned_long_vec __attribute__((ext_vector_type(3)));
 
-// CHECK-LABEL:   func.func @foo(
-// CHECK-SAME:                   %[[VAL_0:.*]]: memref<?xi32>,
-// CHECK-SAME:                   %[[VAL_1:.*]]: i32)
-// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 10 : index
-// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : index
-// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 1 : index
-// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:      scf.for %[[VAL_6:.*]] = %[[VAL_3]] to %[[VAL_2]] step %[[VAL_4]] {
-// CHECK-NEXT:        %[[VAL_7:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_6]]] : memref<?xi32>
-// CHECK-NEXT:        %[[VAL_8:.*]] = arith.addi %[[VAL_7]], %[[VAL_5]] : i32
-// CHECK-NEXT:        %[[VAL_9:.*]] = arith.xori %[[VAL_1]], %[[VAL_8]] : i32
-// CHECK-NEXT:        %[[VAL_10:.*]] = arith.xori %[[VAL_7]], %[[VAL_9]] : i32
-// CHECK-NEXT:        memref.store %[[VAL_10]], %[[VAL_0]]{{\[}}%[[VAL_6]]] : memref<?xi32>
-// CHECK-NEXT:      }
-// CHECK-NEXT:      return
-// CHECK-NEXT:    }
-void foo(int A[10], int a) {
-  for (int i = 0; i < 10; ++i)
-    A[i] ^= (a ^ (A[i] + 1));
-}
 
-
-// CHECK-LABEL:   func.func @xor_i8(
+// CHECK-LABEL:   func.func @shr_i8(
 // CHECK-SAME:                      %[[VAL_0:.*]]: i8,
 // CHECK-SAME:                      %[[VAL_1:.*]]: i8) -> i8
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.extsi %[[VAL_0]] : i8 to i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.extsi %[[VAL_1]] : i8 to i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shrsi %[[VAL_2]], %[[VAL_3]] : i32
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i8
 // CHECK-NEXT:      return %[[VAL_5]] : i8
 // CHECK-NEXT:    }
-char xor_i8(char a, char b) {
-  return a ^ b;
+char shr_i8(char a, char b) {
+  return a >> b;
 }
 
-// CHECK-LABEL:   func.func @xor_i16(
+
+// CHECK-LABEL:   func.func @shr_i16(
 // CHECK-SAME:                       %[[VAL_0:.*]]: i16,
 // CHECK-SAME:                       %[[VAL_1:.*]]: i16) -> i16
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.extsi %[[VAL_0]] : i16 to i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.extsi %[[VAL_1]] : i16 to i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shrsi %[[VAL_2]], %[[VAL_3]] : i32
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i16
 // CHECK-NEXT:      return %[[VAL_5]] : i16
 // CHECK-NEXT:    }
-short xor_i16(short a, short b) {
-  return a ^ b;
+short shr_i16(short a, short b) {
+  return a >> b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_i32(
+// CHECK-LABEL:   func.func @shr_i32(
 // CHECK-SAME:                       %[[VAL_0:.*]]: i32,
 // CHECK-SAME:                       %[[VAL_1:.*]]: i32) -> i32
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shrsi %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK-NEXT:      return %[[VAL_2]] : i32
 // CHECK-NEXT:    }
-int xor_i32(int a, int b) {
-  return a ^ b;
+int shr_i32(int a, int b) {
+  return a >> b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_i64(
+// CHECK-LABEL:   func.func @shr_i64(
 // CHECK-SAME:                       %[[VAL_0:.*]]: i64,
 // CHECK-SAME:                       %[[VAL_1:.*]]: i64) -> i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shrsi %[[VAL_0]], %[[VAL_1]] : i64
 // CHECK-NEXT:      return %[[VAL_2]] : i64
 // CHECK-NEXT:    }
-long xor_i64(long a, long b) {
-  return a ^ b;
+long shr_i64(long a, long b) {
+  return a >> b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_ui8(
+// CHECK-LABEL:   func.func @shr_ui8(
 // CHECK-SAME:                       %[[VAL_0:.*]]: i8,
 // CHECK-SAME:                       %[[VAL_1:.*]]: i8) -> i8
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.extui %[[VAL_0]] : i8 to i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_1]] : i8 to i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shrsi %[[VAL_2]], %[[VAL_3]] : i32
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i8
 // CHECK-NEXT:      return %[[VAL_5]] : i8
 // CHECK-NEXT:    }
-unsigned char xor_ui8(unsigned char a, unsigned char b) {
-  return a ^ b;
+unsigned char shr_ui8(unsigned char a, unsigned char b) {
+  return a >> b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_ui16(
+// CHECK-LABEL:   func.func @shr_ui16(
 // CHECK-SAME:                        %[[VAL_0:.*]]: i16,
 // CHECK-SAME:                        %[[VAL_1:.*]]: i16) -> i16
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.extui %[[VAL_0]] : i16 to i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_1]] : i16 to i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shrsi %[[VAL_2]], %[[VAL_3]] : i32
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i32 to i16
 // CHECK-NEXT:      return %[[VAL_5]] : i16
 // CHECK-NEXT:    }
-unsigned short xor_ui16(unsigned short a, unsigned short b) {
-  return a ^ b;
+unsigned short shr_ui16(unsigned short a, unsigned short b) {
+  return a >> b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_ui32(
+// CHECK-LABEL:   func.func @shr_ui32(
 // CHECK-SAME:                        %[[VAL_0:.*]]: i32,
 // CHECK-SAME:                        %[[VAL_1:.*]]: i32) -> i32
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shrui %[[VAL_0]], %[[VAL_1]] : i32
 // CHECK-NEXT:      return %[[VAL_2]] : i32
 // CHECK-NEXT:    }
-unsigned int xor_ui32(unsigned int a, unsigned int b) {
-  return a ^ b;
+unsigned int shr_ui32(unsigned int a, unsigned int b) {
+  return a >> b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_ui64(
+// CHECK-LABEL:   func.func @shr_ui64(
 // CHECK-SAME:                        %[[VAL_0:.*]]: i64,
 // CHECK-SAME:                        %[[VAL_1:.*]]: i64) -> i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shrui %[[VAL_0]], %[[VAL_1]] : i64
 // CHECK-NEXT:      return %[[VAL_2]] : i64
 // CHECK-NEXT:    }
-unsigned long xor_ui64(unsigned long a, unsigned long b) {
-  return a ^ b;
+unsigned long shr_ui64(unsigned long a, unsigned long b) {
+  return a >> b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vi8(
+// CHECK-LABEL:   func.func @shr_vi8(
 // CHECK-SAME:                       %[[VAL_0:.*]]: vector<3xi8>,
 // CHECK-SAME:                       %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shrsi %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi8>
 // CHECK-NEXT:    }
-char_vec xor_vi8(char_vec a, char_vec b) {
-  return a ^ b;
+char_vec shr_vi8(char_vec a, char_vec b) {
+  return a >> b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vi16(
+// CHECK-LABEL:   func.func @shr_vi16(
 // CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi16>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shrsi %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi16>
 // CHECK-NEXT:    }
-short_vec xor_vi16(short_vec a, short_vec b) {
-  return a ^ b;
+short_vec shr_vi16(short_vec a, short_vec b) {
+  return a >> b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vi32(
+// CHECK-LABEL:   func.func @shr_vi32(
 // CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi32>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shrsi %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi32>
 // CHECK-NEXT:    }
-int_vec xor_vi32(int_vec a, int_vec b) {
-  return a ^ b;
+int_vec shr_vi32(int_vec a, int_vec b) {
+  return a >> b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vi64(
+// CHECK-LABEL:   func.func @shr_vi64(
 // CHECK-SAME:                        %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
 // CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
 // CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shrsi %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
 // CHECK-NEXT:      return %[[VAL_4]] : vector<3xi64>
 // CHECK-NEXT:    }
-long_vec xor_vi64(long_vec a, long_vec b) {
-  return a ^ b;
+long_vec shr_vi64(long_vec a, long_vec b) {
+  return a >> b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vui8(
+// CHECK-LABEL:   func.func @shr_vui8(
 // CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi8>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shrui %[[VAL_0]], %[[VAL_1]] : vector<3xi8>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi8>
 // CHECK-NEXT:    }
-unsigned_char_vec xor_vui8(unsigned_char_vec a, unsigned_char_vec b) {
-  return a ^ b;
+unsigned_char_vec shr_vui8(unsigned_char_vec a, unsigned_char_vec b) {
+  return a >> b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vui16(
+// CHECK-LABEL:   func.func @shr_vui16(
 // CHECK-SAME:                         %[[VAL_0:.*]]: vector<3xi16>,
 // CHECK-SAME:                         %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shrui %[[VAL_0]], %[[VAL_1]] : vector<3xi16>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi16>
 // CHECK-NEXT:    }
-unsigned_short_vec xor_vui16(unsigned_short_vec a, unsigned_short_vec b) {
-  return a ^ b;
+unsigned_short_vec shr_vui16(unsigned_short_vec a, unsigned_short_vec b) {
+  return a >> b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vui32(
+// CHECK-LABEL:   func.func @shr_vui32(
 // CHECK-SAME:                         %[[VAL_0:.*]]: vector<3xi32>,
 // CHECK-SAME:                         %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.xori %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.shrui %[[VAL_0]], %[[VAL_1]] : vector<3xi32>
 // CHECK-NEXT:      return %[[VAL_2]] : vector<3xi32>
 // CHECK-NEXT:    }
-unsigned_int_vec xor_vui32(unsigned_int_vec a, unsigned_int_vec b) {
-  return a ^ b;
+unsigned_int_vec shr_vui32(unsigned_int_vec a, unsigned_int_vec b) {
+  return a >> b;
 }
 
 
-// CHECK-LABEL:   func.func @xor_vui64(
+// CHECK-LABEL:   func.func @shr_vui64(
 // CHECK-SAME:                         %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
 // CHECK-SAME:                         %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
 // CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
 // CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.xori %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shrui %[[VAL_2]], %[[VAL_3]] : vector<3xi64>
 // CHECK-NEXT:      return %[[VAL_4]] : vector<3xi64>
 // CHECK-NEXT:    }
-unsigned_long_vec xor_vui64(unsigned_long_vec a, unsigned_long_vec b) {
-  return a ^ b;
+unsigned_long_vec shr_vui64(unsigned_long_vec a, unsigned_long_vec b) {
+  return a >> b;
 }

--- a/polygeist/tools/cgeist/Test/Verification/shr.cl
+++ b/polygeist/tools/cgeist/Test/Verification/shr.cl
@@ -1,0 +1,234 @@
+// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+
+typedef char char_vec __attribute__((ext_vector_type(3)));
+typedef short short_vec __attribute__((ext_vector_type(3)));
+typedef int int_vec __attribute__((ext_vector_type(3)));
+typedef long long_vec __attribute__((ext_vector_type(3)));
+typedef unsigned char unsigned_char_vec __attribute__((ext_vector_type(3)));
+typedef unsigned short unsigned_short_vec __attribute__((ext_vector_type(3)));
+typedef unsigned int unsigned_int_vec __attribute__((ext_vector_type(3)));
+typedef unsigned long unsigned_long_vec __attribute__((ext_vector_type(3)));
+
+
+// CHECK-LABEL:   func.func @shr_i8(
+// CHECK-SAME:                      %[[VAL_0:.*]]: i8,
+// CHECK-SAME:                      %[[VAL_1:.*]]: i8) -> i8
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 31 : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extsi %[[VAL_0]] : i8 to i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.extsi %[[VAL_1]] : i8 to i32
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.andi %[[VAL_4]], %[[VAL_2]] : i32
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.shrsi %[[VAL_3]], %[[VAL_5]] : i32
+// CHECK-NEXT:      %[[VAL_7:.*]] = arith.trunci %[[VAL_6]] : i32 to i8
+// CHECK-NEXT:      return %[[VAL_7]] : i8
+// CHECK-NEXT:    }
+char shr_i8(char a, char b) {
+  return a >> b;
+}
+
+
+// CHECK-LABEL:   func.func @shr_i16(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i16,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i16) -> i16
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 31 : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extsi %[[VAL_0]] : i16 to i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.extsi %[[VAL_1]] : i16 to i32
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.andi %[[VAL_4]], %[[VAL_2]] : i32
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.shrsi %[[VAL_3]], %[[VAL_5]] : i32
+// CHECK-NEXT:      %[[VAL_7:.*]] = arith.trunci %[[VAL_6]] : i32 to i16
+// CHECK-NEXT:      return %[[VAL_7]] : i16
+// CHECK-NEXT:    }
+short shr_i16(short a, short b) {
+  return a >> b;
+}
+
+
+// CHECK-LABEL:   func.func @shr_i32(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i32) -> i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 31 : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shrsi %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK-NEXT:      return %[[VAL_4]] : i32
+// CHECK-NEXT:    }
+int shr_i32(int a, int b) {
+  return a >> b;
+}
+
+
+// CHECK-LABEL:   func.func @shr_i64(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i64,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i64) -> i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 63 : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shrsi %[[VAL_0]], %[[VAL_3]] : i64
+// CHECK-NEXT:      return %[[VAL_4]] : i64
+// CHECK-NEXT:    }
+long shr_i64(long a, long b) {
+  return a >> b;
+}
+
+
+// CHECK-LABEL:   func.func @shr_ui8(
+// CHECK-SAME:                       %[[VAL_0:.*]]: i8,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i8) -> i8
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 31 : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_0]] : i8 to i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.extui %[[VAL_1]] : i8 to i32
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.andi %[[VAL_4]], %[[VAL_2]] : i32
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.shrsi %[[VAL_3]], %[[VAL_5]] : i32
+// CHECK-NEXT:      %[[VAL_7:.*]] = arith.trunci %[[VAL_6]] : i32 to i8
+// CHECK-NEXT:      return %[[VAL_7]] : i8
+// CHECK-NEXT:    }
+unsigned char shr_ui8(unsigned char a, unsigned char b) {
+  return a >> b;
+}
+
+
+// CHECK-LABEL:   func.func @shr_ui16(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i16,
+// CHECK-SAME:                        %[[VAL_1:.*]]: i16) -> i16
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 31 : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_0]] : i16 to i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.extui %[[VAL_1]] : i16 to i32
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.andi %[[VAL_4]], %[[VAL_2]] : i32
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.shrsi %[[VAL_3]], %[[VAL_5]] : i32
+// CHECK-NEXT:      %[[VAL_7:.*]] = arith.trunci %[[VAL_6]] : i32 to i16
+// CHECK-NEXT:      return %[[VAL_7]] : i16
+// CHECK-NEXT:    }
+unsigned short shr_ui16(unsigned short a, unsigned short b) {
+  return a >> b;
+}
+
+
+// CHECK-LABEL:   func.func @shr_ui32(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                        %[[VAL_1:.*]]: i32) -> i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 31 : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shrui %[[VAL_0]], %[[VAL_3]] : i32
+// CHECK-NEXT:      return %[[VAL_4]] : i32
+// CHECK-NEXT:    }
+unsigned int shr_ui32(unsigned int a, unsigned int b) {
+  return a >> b;
+}
+
+
+// CHECK-LABEL:   func.func @shr_ui64(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i64,
+// CHECK-SAME:                        %[[VAL_1:.*]]: i64) -> i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 63 : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shrui %[[VAL_0]], %[[VAL_3]] : i64
+// CHECK-NEXT:      return %[[VAL_4]] : i64
+// CHECK-NEXT:    }
+unsigned long shr_ui64(unsigned long a, unsigned long b) {
+  return a >> b;
+}
+
+
+// CHECK-LABEL:   func.func @shr_vi8(
+// CHECK-SAME:                       %[[VAL_0:.*]]: vector<3xi8>,
+// CHECK-SAME:                       %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<7> : vector<3xi8>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : vector<3xi8>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shrsi %[[VAL_0]], %[[VAL_3]] : vector<3xi8>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xi8>
+// CHECK-NEXT:    }
+char_vec shr_vi8(char_vec a, char_vec b) {
+  return a >> b;
+}
+
+
+// CHECK-LABEL:   func.func @shr_vi16(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi16>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<15> : vector<3xi16>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : vector<3xi16>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shrsi %[[VAL_0]], %[[VAL_3]] : vector<3xi16>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xi16>
+// CHECK-NEXT:    }
+short_vec shr_vi16(short_vec a, short_vec b) {
+  return a >> b;
+}
+
+
+// CHECK-LABEL:   func.func @shr_vi32(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi32>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<31> : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shrsi %[[VAL_0]], %[[VAL_3]] : vector<3xi32>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xi32>
+// CHECK-NEXT:    }
+int_vec shr_vi32(int_vec a, int_vec b) {
+  return a >> b;
+}
+
+
+// CHECK-LABEL:   func.func @shr_vi64(
+// CHECK-SAME:                        %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<63> : vector<3xi64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
+// CHECK-NEXT:      %[[VAL_4:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.andi %[[VAL_4]], %[[VAL_2]] : vector<3xi64>
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.shrsi %[[VAL_3]], %[[VAL_5]] : vector<3xi64>
+// CHECK-NEXT:      return %[[VAL_6]] : vector<3xi64>
+// CHECK-NEXT:    }
+long_vec shr_vi64(long_vec a, long_vec b) {
+  return a >> b;
+}
+
+
+// CHECK-LABEL:   func.func @shr_vui8(
+// CHECK-SAME:                        %[[VAL_0:.*]]: vector<3xi8>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: vector<3xi8>) -> vector<3xi8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<7> : vector<3xi8>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : vector<3xi8>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shrui %[[VAL_0]], %[[VAL_3]] : vector<3xi8>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xi8>
+// CHECK-NEXT:    }
+unsigned_char_vec shr_vui8(unsigned_char_vec a, unsigned_char_vec b) {
+  return a >> b;
+}
+
+
+// CHECK-LABEL:   func.func @shr_vui16(
+// CHECK-SAME:                         %[[VAL_0:.*]]: vector<3xi16>,
+// CHECK-SAME:                         %[[VAL_1:.*]]: vector<3xi16>) -> vector<3xi16>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<15> : vector<3xi16>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : vector<3xi16>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shrui %[[VAL_0]], %[[VAL_3]] : vector<3xi16>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xi16>
+// CHECK-NEXT:    }
+unsigned_short_vec shr_vui16(unsigned_short_vec a, unsigned_short_vec b) {
+  return a >> b;
+}
+
+
+// CHECK-LABEL:   func.func @shr_vui32(
+// CHECK-SAME:                         %[[VAL_0:.*]]: vector<3xi32>,
+// CHECK-SAME:                         %[[VAL_1:.*]]: vector<3xi32>) -> vector<3xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<31> : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.andi %[[VAL_1]], %[[VAL_2]] : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.shrui %[[VAL_0]], %[[VAL_3]] : vector<3xi32>
+// CHECK-NEXT:      return %[[VAL_4]] : vector<3xi32>
+// CHECK-NEXT:    }
+unsigned_int_vec shr_vui32(unsigned_int_vec a, unsigned_int_vec b) {
+  return a >> b;
+}
+
+
+// CHECK-LABEL:   func.func @shr_vui64(
+// CHECK-SAME:                         %[[VAL_0:.*]]: memref<?xvector<3xi64>>,
+// CHECK-SAME:                         %[[VAL_1:.*]]: memref<?xvector<3xi64>>) -> vector<3xi64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<63> : vector<3xi64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi64>>
+// CHECK-NEXT:      %[[VAL_4:.*]] = affine.load %[[VAL_1]][0] : memref<?xvector<3xi64>>
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.andi %[[VAL_4]], %[[VAL_2]] : vector<3xi64>
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.shrui %[[VAL_3]], %[[VAL_5]] : vector<3xi64>
+// CHECK-NEXT:      return %[[VAL_6]] : vector<3xi64>
+// CHECK-NEXT:    }
+unsigned_long_vec shr_vui64(unsigned_long_vec a, unsigned_long_vec b) {
+  return a >> b;
+}


### PR DESCRIPTION
9ac759f12e55 improved code generation for addition and subtraction. This commit addresses the rest of binary arithmetic operators (mul, div, rem, shl, shr, and, or, xor):

- Enable code generation for mul and div operators and vector operands;
- Mask shl and shr operands in OpenCL
- Always generate signed/unsigned operations for vector operands.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>