### PR TITLE
[SYCL] Fix SYCL unittest CMake

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -336,7 +336,7 @@ if(SYCL_INCLUDE_TESTS)
       message(FATAL_ERROR
         "Can't build SYCL tests without LLVM_INCLUDE_TESTS enabled.")
   endif()
-  if(EXISTS ${LLVM_MAIN_SRC_DIR}/utils/unittest/googletest/include/gtest/gtest.h)
+  if(EXISTS ${LLVM_THIRD_PARTY_DIR}/unittest/googletest/include/gtest/gtest.h)
     add_subdirectory(unittests)
     list(APPEND SYCL_TEST_DEPS SYCLUnitTests)
   endif()


### PR DESCRIPTION
a11cd0d94ed3cabf0998a0289aead05da94c86eb moved gtest to another directory which causes the SYCL CMake to not find it and effectively skip configuring the unittests entirely. This commit adjusts the gtest search in accordance with the new location.