### PR TITLE
[SYCL-MLIR][NFC]: Code Cleanup

### DIFF
--- a/polygeist/tools/cgeist/Lib/AffineUtils.cc
+++ b/polygeist/tools/cgeist/Lib/AffineUtils.cc
@@ -13,49 +13,47 @@
 
 #include <limits>
 
+using namespace mlir;
+
 namespace mlirclang {
 
 struct AffineLoopDescriptorImpl {
-  mlir::Value upperBound = nullptr;
-  mlir::Value lowerBound = nullptr;
-  int64_t step = std::numeric_limits<int64_t>::max();
-  mlir::Type indVarType = nullptr;
-  clang::VarDecl *indVar = nullptr;
-  bool forwardMode = true;
+  Value UpperBound = nullptr;
+  Value LowerBound = nullptr;
+  int64_t Step = std::numeric_limits<int64_t>::max();
+  Type IndVarType = nullptr;
+  clang::VarDecl *IndVar = nullptr;
+  bool ForwardMode = true;
 };
 
 AffineLoopDescriptor::AffineLoopDescriptor()
-    : impl(std::make_unique<AffineLoopDescriptorImpl>()) {}
+    : Impl(std::make_unique<AffineLoopDescriptorImpl>()) {}
 AffineLoopDescriptor::~AffineLoopDescriptor() = default;
 
-mlir::Value AffineLoopDescriptor::getLowerBound() const {
-  return impl->lowerBound;
-}
-void AffineLoopDescriptor::setLowerBound(mlir::Value value) {
-  impl->lowerBound = value;
+Value AffineLoopDescriptor::getLowerBound() const { return Impl->LowerBound; }
+void AffineLoopDescriptor::setLowerBound(Value Value) {
+  Impl->LowerBound = Value;
 }
 
-mlir::Value AffineLoopDescriptor::getUpperBound() const {
-  return impl->upperBound;
-}
-void AffineLoopDescriptor::setUpperBound(mlir::Value value) {
-  impl->upperBound = value;
+Value AffineLoopDescriptor::getUpperBound() const { return Impl->UpperBound; }
+void AffineLoopDescriptor::setUpperBound(Value Value) {
+  Impl->UpperBound = Value;
 }
 
-int AffineLoopDescriptor::getStep() const { return impl->step; }
-void AffineLoopDescriptor::setStep(int value) { impl->step = value; }
+int AffineLoopDescriptor::getStep() const { return Impl->Step; }
+void AffineLoopDescriptor::setStep(int Value) { Impl->Step = Value; }
 
-clang::VarDecl *AffineLoopDescriptor::getName() const { return impl->indVar; }
-void AffineLoopDescriptor::setName(clang::VarDecl *value) {
-  impl->indVar = value;
+clang::VarDecl *AffineLoopDescriptor::getName() const { return Impl->IndVar; }
+void AffineLoopDescriptor::setName(clang::VarDecl *Value) {
+  Impl->IndVar = Value;
 }
 
-mlir::Type AffineLoopDescriptor::getType() const { return impl->indVarType; }
-void AffineLoopDescriptor::setType(mlir::Type type) { impl->indVarType = type; }
+Type AffineLoopDescriptor::getType() const { return Impl->IndVarType; }
+void AffineLoopDescriptor::setType(Type Type) { Impl->IndVarType = Type; }
 
-bool AffineLoopDescriptor::getForwardMode() const { return impl->forwardMode; }
-void AffineLoopDescriptor::setForwardMode(bool value) {
-  impl->forwardMode = value;
+bool AffineLoopDescriptor::getForwardMode() const { return Impl->ForwardMode; }
+void AffineLoopDescriptor::setForwardMode(bool Value) {
+  Impl->ForwardMode = Value;
 }
 
 } // namespace mlirclang

--- a/polygeist/tools/cgeist/Lib/AffineUtils.h
+++ b/polygeist/tools/cgeist/Lib/AffineUtils.h
@@ -26,7 +26,7 @@ struct AffineLoopDescriptorImpl;
 
 class AffineLoopDescriptor {
 private:
-  std::unique_ptr<AffineLoopDescriptorImpl> impl;
+  std::unique_ptr<AffineLoopDescriptorImpl> Impl;
 
 public:
   AffineLoopDescriptor();
@@ -34,24 +34,24 @@ public:
   AffineLoopDescriptor(const AffineLoopDescriptor &) = delete;
 
   mlir::Value getLowerBound() const;
-  void setLowerBound(mlir::Value value);
+  void setLowerBound(mlir::Value Value);
 
   mlir::Value getUpperBound() const;
-  void setUpperBound(mlir::Value value);
+  void setUpperBound(mlir::Value Value);
 
   int getStep() const;
-  void setStep(int value);
+  void setStep(int Value);
 
   clang::VarDecl *getName() const;
-  void setName(clang::VarDecl *value);
+  void setName(clang::VarDecl *Value);
 
   mlir::Type getType() const;
-  void setType(mlir::Type type);
+  void setType(mlir::Type Type);
 
   bool getForwardMode() const;
-  void setForwardMode(bool value);
+  void setForwardMode(bool Value);
 };
 
 } // end namespace mlirclang
 
-#endif
+#endif // MLIR_CLANG_AFFINE_UTILS_H

--- a/polygeist/tools/cgeist/Lib/IfScope.cc
+++ b/polygeist/tools/cgeist/Lib/IfScope.cc
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
 #include "IfScope.h"
 #include "clang-mlir.h"
 
@@ -13,27 +14,27 @@
 
 using namespace mlir;
 
-IfScope::IfScope(MLIRScanner &scanner) : scanner(scanner), prevBlock(nullptr) {
-  if (scanner.loops.size() && scanner.loops.back().keepRunning) {
-    auto lop = scanner.builder.create<memref::LoadOp>(
-        scanner.loc, scanner.loops.back().keepRunning);
-    auto ifOp = scanner.builder.create<scf::IfOp>(scanner.loc, lop,
+IfScope::IfScope(MLIRScanner &Scanner) : Scanner(Scanner), PrevBlock(nullptr) {
+  if (Scanner.loops.size() && Scanner.loops.back().keepRunning) {
+    auto Lop = Scanner.builder.create<memref::LoadOp>(
+        Scanner.loc, Scanner.loops.back().keepRunning);
+    auto IfOp = Scanner.builder.create<scf::IfOp>(Scanner.loc, Lop,
                                                   /*hasElse*/ false);
-    prevBlock = scanner.builder.getInsertionBlock();
-    prevIterator = scanner.builder.getInsertionPoint();
-    ifOp.getThenRegion().back().clear();
-    scanner.builder.setInsertionPointToStart(&ifOp.getThenRegion().back());
-    auto er = scanner.builder.create<scf::ExecuteRegionOp>(
-        scanner.loc, ArrayRef<mlir::Type>());
-    scanner.builder.create<scf::YieldOp>(scanner.loc);
-    er.getRegion().push_back(new Block());
-    scanner.builder.setInsertionPointToStart(&er.getRegion().back());
+    PrevBlock = Scanner.builder.getInsertionBlock();
+    PrevIterator = Scanner.builder.getInsertionPoint();
+    IfOp.getThenRegion().back().clear();
+    Scanner.builder.setInsertionPointToStart(&IfOp.getThenRegion().back());
+    auto Er = Scanner.builder.create<scf::ExecuteRegionOp>(
+        Scanner.loc, ArrayRef<mlir::Type>());
+    Scanner.builder.create<scf::YieldOp>(Scanner.loc);
+    Er.getRegion().push_back(new Block());
+    Scanner.builder.setInsertionPointToStart(&Er.getRegion().back());
   }
 }
 
 IfScope::~IfScope() {
-  if (scanner.loops.size() && scanner.loops.back().keepRunning) {
-    scanner.builder.create<scf::YieldOp>(scanner.loc);
-    scanner.builder.setInsertionPoint(prevBlock, prevIterator);
+  if (Scanner.loops.size() && Scanner.loops.back().keepRunning) {
+    Scanner.builder.create<scf::YieldOp>(Scanner.loc);
+    Scanner.builder.setInsertionPoint(PrevBlock, PrevIterator);
   }
 }

--- a/polygeist/tools/cgeist/Lib/IfScope.h
+++ b/polygeist/tools/cgeist/Lib/IfScope.h
@@ -14,11 +14,11 @@ class MLIRScanner;
 
 class IfScope {
 public:
-  MLIRScanner &scanner;
-  mlir::Block *prevBlock;
-  mlir::Block::iterator prevIterator;
-  IfScope(MLIRScanner &scanner);
+  MLIRScanner &Scanner;
+  mlir::Block *PrevBlock;
+  mlir::Block::iterator PrevIterator;
+  IfScope(MLIRScanner &Scanner);
   ~IfScope();
 };
 
-#endif
+#endif // IF_SCOPE_H

--- a/polygeist/tools/cgeist/Lib/pragmaHandler.h
+++ b/polygeist/tools/cgeist/Lib/pragmaHandler.h
@@ -29,37 +29,37 @@ struct LowerToInfo {
 /// endscop pragmas.
 /// "start_line" is the line number of the start position.
 struct ScopLoc {
-  ScopLoc() : end(0) {}
+  ScopLoc() : End(0) {}
 
-  clang::SourceLocation scop;
-  clang::SourceLocation endscop;
-  unsigned startLine;
-  unsigned start;
-  unsigned end;
+  clang::SourceLocation Scop;
+  clang::SourceLocation EndScop;
+  unsigned StartLine;
+  unsigned Start;
+  unsigned End;
 };
 
 /// Taken from pet.cc
 /// List of pairs of #pragma scop and #pragma endscop locations.
 struct ScopLocList {
-  std::vector<ScopLoc> list;
+  std::vector<ScopLoc> List;
 
   // Add a new start (#pragma scop) location to the list.
   // If the last #pragma scop did not have a matching
   // #pragma endscop then overwrite it.
   // "start" points to the location of the scop pragma.
 
-  void addStart(clang::SourceManager &SM, clang::SourceLocation start) {
-    ScopLoc loc;
+  void addStart(clang::SourceManager &SM, clang::SourceLocation Start) {
+    ScopLoc Loc;
 
-    loc.scop = start;
-    int line = SM.getExpansionLineNumber(start);
-    start = SM.translateLineCol(SM.getFileID(start), line, 1);
-    loc.startLine = line;
-    loc.start = SM.getFileOffset(start);
-    if (list.size() == 0 || list[list.size() - 1].end != 0)
-      list.push_back(loc);
+    Loc.Scop = Start;
+    int Line = SM.getExpansionLineNumber(Start);
+    Start = SM.translateLineCol(SM.getFileID(Start), Line, 1);
+    Loc.StartLine = Line;
+    Loc.Start = SM.getFileOffset(Start);
+    if (List.size() == 0 || List[List.size() - 1].End != 0)
+      List.push_back(Loc);
     else
-      list[list.size() - 1] = loc;
+      List[List.size() - 1] = Loc;
   }
 
   // Set the end location (#pragma endscop) of the last pair
@@ -68,29 +68,29 @@ struct ScopLocList {
   // is already set, then ignore the spurious #pragma endscop.
   // "end" points to the location of the endscop pragma.
 
-  void addEnd(clang::SourceManager &SM, clang::SourceLocation end) {
-    if (list.size() == 0 || list[list.size() - 1].end != 0)
+  void addEnd(clang::SourceManager &SM, clang::SourceLocation End) {
+    if (List.size() == 0 || List[List.size() - 1].End != 0)
       return;
-    list[list.size() - 1].endscop = end;
-    int line = SM.getExpansionLineNumber(end);
-    end = SM.translateLineCol(SM.getFileID(end), line + 1, 1);
-    list[list.size() - 1].end = SM.getFileOffset(end);
+    List[List.size() - 1].EndScop = End;
+    int Line = SM.getExpansionLineNumber(End);
+    End = SM.translateLineCol(SM.getFileID(End), Line + 1, 1);
+    List[List.size() - 1].End = SM.getFileOffset(End);
   }
 
   // Check if the current location is in the scop.
-  bool isInScop(clang::SourceLocation target) {
-    if (!list.size())
+  bool isInScop(clang::SourceLocation Target) {
+    if (!List.size())
       return false;
-    for (auto &scopLoc : list)
-      if ((target >= scopLoc.scop) && (target <= scopLoc.endscop))
+    for (auto &ScopLoc : List)
+      if ((Target >= ScopLoc.Scop) && (Target <= ScopLoc.EndScop))
         return true;
     return false;
   }
 };
 
 void addPragmaLowerToHandlers(clang::Preprocessor &PP, LowerToInfo &LTInfo);
-void addPragmaScopHandlers(clang::Preprocessor &PP, ScopLocList &scopLocList);
+void addPragmaScopHandlers(clang::Preprocessor &PP, ScopLocList &ScopLocList);
 void addPragmaEndScopHandlers(clang::Preprocessor &PP,
-                              ScopLocList &scopLocList);
+                              ScopLocList &ScopLocList);
 
-#endif
+#endif // MLIR_TOOLS_MLIRCLANG_LIB_PRAGMAHANDLER_H

--- a/polygeist/tools/cgeist/Lib/utils.cc
+++ b/polygeist/tools/cgeist/Lib/utils.cc
@@ -1,5 +1,3 @@
-// Copyright (C) Codeplay Software Limited
-
 //===- utils.cc -------------------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -12,82 +10,75 @@
 #include "clang-mlir.h"
 
 #include "mlir/IR/Builders.h"
-#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/OperationSupport.h"
 #include "mlir/IR/Value.h"
 
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/StringRef.h"
-
-#include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
-
-#include "clang/AST/Expr.h"
+#include "llvm/ADT/SmallVector.h"
 
 using namespace mlir;
-using namespace llvm;
-using namespace clang;
 
-Operation *buildLinalgOp(StringRef name, OpBuilder &b,
-                         SmallVectorImpl<mlir::Value> &input,
-                         SmallVectorImpl<mlir::Value> &output) {
-  if (name.compare("memref.copy") == 0) {
-    assert(input.size() == 1 && "memref::copyOp requires 1 input");
-    assert(output.size() == 1 && "memref::CopyOp requires 1 output");
-    return b.create<memref::CopyOp>(b.getUnknownLoc(), input[0], output[0]);
-  } else {
-    llvm::report_fatal_error(llvm::Twine("builder not supported for: ") + name);
-    return nullptr;
+namespace mlirclang {
+
+Operation *buildLinalgOp(llvm::StringRef Name, OpBuilder &B,
+                         llvm::SmallVectorImpl<Value> &Input,
+                         llvm::SmallVectorImpl<Value> &Output) {
+  if (Name.compare("memref.copy") == 0) {
+    assert(Input.size() == 1 && "memref::copyOp requires 1 input");
+    assert(Output.size() == 1 && "memref::CopyOp requires 1 output");
+    return B.create<memref::CopyOp>(B.getUnknownLoc(), Input[0], Output[0]);
   }
+
+  llvm::report_fatal_error(llvm::Twine("builder not supported for: ") + Name);
+  return nullptr;
 }
 
-Operation *mlirclang::replaceFuncByOperation(
-    func::FuncOp f, StringRef opName, OpBuilder &b,
-    SmallVectorImpl<mlir::Value> &input, SmallVectorImpl<mlir::Value> &output) {
-  MLIRContext *ctx = f->getContext();
-  assert(ctx->isOperationRegistered(opName) &&
+Operation *replaceFuncByOperation(func::FuncOp F, llvm::StringRef OpName,
+                                  OpBuilder &B,
+                                  llvm::SmallVectorImpl<Value> &Input,
+                                  llvm::SmallVectorImpl<Value> &Output) {
+  MLIRContext *Ctx = F->getContext();
+  assert(Ctx->isOperationRegistered(OpName) &&
          "Provided lower_to opName should be registered.");
 
-  if (opName.startswith("memref"))
-    return buildLinalgOp(opName, b, input, output);
+  if (OpName.startswith("memref"))
+    return buildLinalgOp(OpName, B, Input, Output);
 
   // NOTE: The attributes of the provided FuncOp is ignored.
-  OperationState opState(b.getUnknownLoc(), opName, input,
-                         f.getCallableResults(), {});
-  return b.create(opState);
+  OperationState OpState(B.getUnknownLoc(), OpName, Input,
+                         F.getCallableResults(), {});
+  return B.create(OpState);
 }
 
-bool mlirclang::isNamespaceSYCL(const clang::DeclContext *DC) {
-  if (!DC) {
+bool isNamespaceSYCL(const clang::DeclContext *DC) {
+  if (!DC)
     return false;
-  }
 
   if (const auto *ND = dyn_cast<clang::NamespaceDecl>(DC)) {
     if (const auto *II = ND->getIdentifier()) {
-      if (II->isStr("sycl")) {
+      if (II->isStr("sycl"))
         return true;
-      }
     }
   }
 
-  if (DC->getParent()) {
-    return mlirclang::isNamespaceSYCL(DC->getParent());
-  }
+  if (DC->getParent())
+    return isNamespaceSYCL(DC->getParent());
 
   return false;
 }
 
-FunctionContext mlirclang::getInputContext(const OpBuilder &Builder) {
-  return Builder.getInsertionBlock()
+FunctionContext getInputContext(const OpBuilder &B) {
+  return B.getInsertionBlock()
                  ->getParentOp()
                  ->getParentOfType<gpu::GPUModuleOp>()
              ? FunctionContext::SYCLDevice
              : FunctionContext::Host;
 }
 
-mlir::gpu::GPUModuleOp mlirclang::getDeviceModule(mlir::ModuleOp Module) {
-  return cast<mlir::gpu::GPUModuleOp>(
+gpu::GPUModuleOp getDeviceModule(ModuleOp Module) {
+  return cast<gpu::GPUModuleOp>(
       Module.lookupSymbol(MLIRASTConsumer::DeviceModuleName));
 }
+
+} // namespace mlirclang

--- a/polygeist/tools/cgeist/Lib/utils.h
+++ b/polygeist/tools/cgeist/Lib/utils.h
@@ -1,5 +1,3 @@
-// Copyright (C) Codeplay Software Limited
-
 //===- utils.h --------------------------------------------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -11,32 +9,31 @@
 #ifndef MLIR_TOOLS_MLIRCLANG_UTILS_H
 #define MLIR_TOOLS_MLIRCLANG_UTILS_H
 
-#include "Lib/clang-mlir.h"
-#include "mlir/Dialect/GPU/IR/GPUDialect.h"
-#include "clang/AST/DeclBase.h"
-#include "llvm/ADT/APInt.h"
-#include "llvm/ADT/ArrayRef.h"
+namespace clang {
+class DeclContext;
+}
 
 namespace mlir {
+class OpBuilder;
 class Operation;
+class ModuleOp;
+class Value;
+
 namespace func {
 class FuncOp;
 }
-class Value;
-class OpBuilder;
-class AbstractOperation;
-class Type;
+
+namespace gpu {
+class GPUModuleOp;
+}
 } // namespace mlir
 
 namespace llvm {
+template <typename> class SmallVectorImpl;
 class StringRef;
 } // namespace llvm
 
-namespace clang {
-class Expr;
-}
-
-class MLIRScanner;
+enum class FunctionContext;
 
 namespace mlirclang {
 
@@ -46,10 +43,10 @@ namespace mlirclang {
 /// operands %a and %b. The new op will be inserted at where the insertion point
 /// of the provided OpBuilder is.
 mlir::Operation *
-replaceFuncByOperation(mlir::func::FuncOp f, llvm::StringRef opName,
-                       mlir::OpBuilder &b,
-                       llvm::SmallVectorImpl<mlir::Value> &input,
-                       llvm::SmallVectorImpl<mlir::Value> &output);
+replaceFuncByOperation(mlir::func::FuncOp F, llvm::StringRef OpName,
+                       mlir::OpBuilder &B,
+                       llvm::SmallVectorImpl<mlir::Value> &Input,
+                       llvm::SmallVectorImpl<mlir::Value> &Output);
 
 bool isNamespaceSYCL(const clang::DeclContext *DC);
 
@@ -58,6 +55,7 @@ FunctionContext getInputContext(const mlir::OpBuilder &Builder);
 
 /// Return the device module in the input module.
 mlir::gpu::GPUModuleOp getDeviceModule(mlir::ModuleOp Module);
+
 } // namespace mlirclang
 
-#endif
+#endif // MLIR_TOOLS_MLIRCLANG_UTILS_H


### PR DESCRIPTION
This PR fixes some clang-tidy warnings:
   - change variable names to start with upper case
   - remove use of else after if branch with a return