### PR TITLE
[SYCL-MLIR][NFC]: Cleanup code

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -16,11 +16,8 @@
 
 #define DEBUG_TYPE "CGCall"
 
-using namespace clang;
+// using namespace clang;
 using namespace mlir;
-using namespace mlir::arith;
-using namespace mlir::func;
-using namespace mlirclang;
 
 extern llvm::cl::opt<bool> CudaLower;
 extern llvm::cl::opt<bool> GenerateAllSYCLFuncs;
@@ -100,10 +97,10 @@ static void castCallerArgs(mlir::func::FuncOp Callee,
 /******************************************************************************/
 
 ValueCategory MLIRScanner::callHelper(
-    mlir::func::FuncOp ToCall, QualType ObjType,
+    mlir::func::FuncOp ToCall, clang::QualType ObjType,
     ArrayRef<std::pair<ValueCategory, clang::Expr *>> Arguments,
-    QualType RetType, bool RetReference, clang::Expr *Expr,
-    const FunctionDecl &Callee) {
+    clang::QualType RetType, bool RetReference, clang::Expr *Expr,
+    const clang::FunctionDecl &Callee) {
   SmallVector<mlir::Value, 4> Args;
   mlir::FunctionType FnType = ToCall.getFunctionType();
   const clang::CodeGen::CGFunctionInfo &CalleeInfo =
@@ -126,8 +123,8 @@ ValueCategory MLIRScanner::callHelper(
     });
     assert(Arg.val && "expect not null");
 
-    if (auto *Ice = dyn_cast_or_null<ImplicitCastExpr>(A))
-      if (auto *Dre = dyn_cast<DeclRefExpr>(Ice->getSubExpr()))
+    if (auto *Ice = dyn_cast_or_null<clang::ImplicitCastExpr>(A))
+      if (auto *Dre = dyn_cast<clang::DeclRefExpr>(Ice->getSubExpr()))
         MapFuncOperands.insert(
             make_pair(Dre->getDecl()->getName().str(), Arg.val));
 
@@ -146,7 +143,7 @@ ValueCategory MLIRScanner::callHelper(
         (I == 0 && A == nullptr) || A->isLValue() || A->isXValue();
 
     bool IsArray = false;
-    QualType AType = (I == 0 && A == nullptr) ? ObjType : A->getType();
+    clang::QualType AType = (I == 0 && A == nullptr) ? ObjType : A->getType();
     mlir::Type ExpectedType = Glob.getTypes().getMLIRType(AType, &IsArray);
 
     LLVM_DEBUG({
@@ -321,7 +318,7 @@ ValueCategory MLIRScanner::callHelper(
     Args.push_back(Alloc);
   }
 
-  if (auto *CU = dyn_cast<CUDAKernelCallExpr>(Expr)) {
+  if (auto *CU = dyn_cast<clang::CUDAKernelCallExpr>(Expr)) {
     auto L0 = Visit(CU->getConfig()->getArg(0));
     assert(L0.isReference);
     mlir::Value Blocks[3];
@@ -330,7 +327,7 @@ ValueCategory MLIRScanner::callHelper(
       if (auto MT = Val.getType().dyn_cast<MemRefType>()) {
         mlir::Value Idx[] = {getConstantIndex(0), getConstantIndex(I)};
         assert(MT.getShape().size() == 2);
-        Blocks[I] = builder.create<IndexCastOp>(
+        Blocks[I] = builder.create<arith::IndexCastOp>(
             loc, mlir::IndexType::get(builder.getContext()),
             builder.create<mlir::memref::LoadOp>(loc, Val, Idx));
       } else {
@@ -338,7 +335,7 @@ ValueCategory MLIRScanner::callHelper(
                              builder.create<arith::ConstantIntOp>(loc, I, 32)};
         auto PT = Val.getType().cast<LLVM::LLVMPointerType>();
         auto ET = PT.getElementType().cast<LLVM::LLVMStructType>().getBody()[I];
-        Blocks[I] = builder.create<IndexCastOp>(
+        Blocks[I] = builder.create<arith::IndexCastOp>(
             loc, mlir::IndexType::get(builder.getContext()),
             builder.create<LLVM::LoadOp>(
                 loc,
@@ -356,7 +353,7 @@ ValueCategory MLIRScanner::callHelper(
       if (auto MT = Val.getType().dyn_cast<MemRefType>()) {
         mlir::Value Idx[] = {getConstantIndex(0), getConstantIndex(I)};
         assert(MT.getShape().size() == 2);
-        Threads[I] = builder.create<IndexCastOp>(
+        Threads[I] = builder.create<arith::IndexCastOp>(
             loc, mlir::IndexType::get(builder.getContext()),
             builder.create<mlir::memref::LoadOp>(loc, Val, Idx));
       } else {
@@ -364,7 +361,7 @@ ValueCategory MLIRScanner::callHelper(
                              builder.create<arith::ConstantIntOp>(loc, I, 32)};
         auto PT = Val.getType().cast<LLVM::LLVMPointerType>();
         auto ET = PT.getElementType().cast<LLVM::LLVMStructType>().getBody()[I];
-        Threads[I] = builder.create<IndexCastOp>(
+        Threads[I] = builder.create<arith::IndexCastOp>(
             loc, mlir::IndexType::get(builder.getContext()),
             builder.create<LLVM::LoadOp>(
                 loc,
@@ -376,7 +373,7 @@ ValueCategory MLIRScanner::callHelper(
     mlir::Value Stream = nullptr;
     SmallVector<mlir::Value, 1> AsyncDependencies;
     if (3 < CU->getConfig()->getNumArgs() &&
-        !isa<CXXDefaultArgExpr>(CU->getConfig()->getArg(3))) {
+        !isa<clang::CXXDefaultArgExpr>(CU->getConfig()->getArg(3))) {
       Stream = Visit(CU->getConfig()->getArg(3)).getValue(builder);
       Stream = builder.create<polygeist::StreamToTokenOp>(
           loc, builder.getType<gpu::AsyncTokenType>(), Stream);
@@ -392,7 +389,7 @@ ValueCategory MLIRScanner::callHelper(
     auto Oldpoint = builder.getInsertionPoint();
     auto *Oldblock = builder.getInsertionBlock();
     builder.setInsertionPointToStart(&Op.getRegion().front());
-    builder.create<CallOp>(loc, ToCall, Args);
+    builder.create<func::CallOp>(loc, ToCall, Args);
     builder.create<gpu::TerminatorOp>(loc);
     builder.setInsertionPoint(Oldblock, Oldpoint);
     return nullptr;
@@ -404,7 +401,7 @@ ValueCategory MLIRScanner::callHelper(
   /// Try to emit SYCL operations before creating a CallOp
   mlir::Operation *Op = emitSYCLOps(Expr, Args);
   if (!Op)
-    Op = builder.create<CallOp>(loc, ToCall, Args);
+    Op = builder.create<func::CallOp>(loc, ToCall, Args);
 
   if (IsArrayReturn) {
     // TODO remedy return
@@ -458,16 +455,18 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
   if (ValEmitted.second)
     return ValEmitted.first;
 
-  if (auto *Oc = dyn_cast<CXXOperatorCallExpr>(Expr)) {
+  if (auto *Oc = dyn_cast<clang::CXXOperatorCallExpr>(Expr)) {
     if (Oc->getOperator() == clang::OO_EqualEqual) {
-      if (auto *LHS = dyn_cast<CXXTypeidExpr>(Expr->getArg(0))) {
-        if (auto *RHS = dyn_cast<CXXTypeidExpr>(Expr->getArg(1))) {
-          QualType LT = LHS->isTypeOperand()
-                            ? LHS->getTypeOperand(Glob.getCGM().getContext())
-                            : LHS->getExprOperand()->getType();
-          QualType RT = RHS->isTypeOperand()
-                            ? RHS->getTypeOperand(Glob.getCGM().getContext())
-                            : RHS->getExprOperand()->getType();
+      if (auto *LHS = dyn_cast<clang::CXXTypeidExpr>(Expr->getArg(0))) {
+        if (auto *RHS = dyn_cast<clang::CXXTypeidExpr>(Expr->getArg(1))) {
+          clang::QualType LT =
+              LHS->isTypeOperand()
+                  ? LHS->getTypeOperand(Glob.getCGM().getContext())
+                  : LHS->getExprOperand()->getType();
+          clang::QualType RT =
+              RHS->isTypeOperand()
+                  ? RHS->getTypeOperand(Glob.getCGM().getContext())
+                  : RHS->getExprOperand()->getType();
           llvm::Constant *LC = Glob.getCGM().GetAddrOfRTTIDescriptor(LT);
           llvm::Constant *RC = Glob.getCGM().GetAddrOfRTTIDescriptor(RT);
           auto PostTy = Glob.getTypes()
@@ -481,14 +480,16 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
     }
   }
 
-  if (auto *Oc = dyn_cast<CXXMemberCallExpr>(Expr)) {
-    if (auto *LHS = dyn_cast<CXXTypeidExpr>(Oc->getImplicitObjectArgument())) {
-      if (auto *Ic = dyn_cast<MemberExpr>(Expr->getCallee()))
-        if (auto *Sr = dyn_cast<NamedDecl>(Ic->getMemberDecl())) {
+  if (auto *Oc = dyn_cast<clang::CXXMemberCallExpr>(Expr)) {
+    if (auto *LHS =
+            dyn_cast<clang::CXXTypeidExpr>(Oc->getImplicitObjectArgument())) {
+      if (auto *Ic = dyn_cast<clang::MemberExpr>(Expr->getCallee()))
+        if (auto *Sr = dyn_cast<clang::NamedDecl>(Ic->getMemberDecl())) {
           if (Sr->getIdentifier() && Sr->getName() == "name") {
-            QualType LT = LHS->isTypeOperand()
-                              ? LHS->getTypeOperand(Glob.getCGM().getContext())
-                              : LHS->getExprOperand()->getType();
+            clang::QualType LT =
+                LHS->isTypeOperand()
+                    ? LHS->getTypeOperand(Glob.getCGM().getContext())
+                    : LHS->getExprOperand()->getType();
             llvm::Constant *LC = Glob.getCGM().GetAddrOfRTTIDescriptor(LT);
             while (auto *CE = dyn_cast<llvm::ConstantExpr>(LC))
               LC = CE->getOperand(0);
@@ -501,11 +502,11 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
     }
   }
 
-  if (auto *Ps = dyn_cast<CXXPseudoDestructorExpr>(Expr->getCallee()))
+  if (auto *Ps = dyn_cast<clang::CXXPseudoDestructorExpr>(Expr->getCallee()))
     return Visit(Ps);
 
-  if (auto *Ic = dyn_cast<ImplicitCastExpr>(Expr->getCallee()))
-    if (auto *Sr = dyn_cast<DeclRefExpr>(Ic->getSubExpr())) {
+  if (auto *Ic = dyn_cast<clang::ImplicitCastExpr>(Expr->getCallee()))
+    if (auto *Sr = dyn_cast<clang::DeclRefExpr>(Ic->getSubExpr())) {
       if (Sr->getDecl()->getIdentifier() &&
           (Sr->getDecl()->getName() == "atomicAdd" ||
            Sr->getDecl()->getName() == "atomicOr" ||
@@ -516,21 +517,21 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
 
         auto A0 = Args[0].getValue(builder);
         auto A1 = Args[1].getValue(builder);
-        AtomicRMWKind Op;
+        arith::AtomicRMWKind Op;
         LLVM::AtomicBinOp Lop;
         if (Sr->getDecl()->getName() == "atomicAdd") {
           if (A1.getType().isa<mlir::IntegerType>()) {
-            Op = AtomicRMWKind::addi;
+            Op = arith::AtomicRMWKind::addi;
             Lop = LLVM::AtomicBinOp::add;
           } else {
-            Op = AtomicRMWKind::addf;
+            Op = arith::AtomicRMWKind::addf;
             Lop = LLVM::AtomicBinOp::fadd;
           }
         } else if (Sr->getDecl()->getName() == "atomicOr") {
-          Op = AtomicRMWKind::ori;
+          Op = arith::AtomicRMWKind::ori;
           Lop = LLVM::AtomicBinOp::_or;
         } else if (Sr->getDecl()->getName() == "atomicAnd") {
-          Op = AtomicRMWKind::andi;
+          Op = arith::AtomicRMWKind::andi;
           Lop = LLVM::AtomicBinOp::_and;
         } else
           assert(0);
@@ -587,12 +588,12 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
 
       OpBuilder Abuilder(builder.getContext());
       Abuilder.setInsertionPointToStart(allocationScope);
-      auto One = Abuilder.create<ConstantIntOp>(Loc, 1, 64);
+      auto One = Abuilder.create<arith::ConstantIntOp>(Loc, 1, 64);
       auto Alloc = Abuilder.create<mlir::LLVM::AllocaOp>(
           Loc,
           LLVM::LLVMPointerType::get(
-              TypeTranslator.translateType(
-                  anonymize(getLLVMType(E->getType(), Glob.getCGM()))),
+              TypeTranslator.translateType(mlirclang::anonymize(
+                  mlirclang::getLLVMType(E->getType(), Glob.getCGM()))),
               0),
           One, 0);
       ValueCategory(Alloc, /*isRef*/ true)
@@ -602,8 +603,8 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
     auto Val = Sub.getValue(builder);
     if (auto MT = Val.getType().dyn_cast<MemRefType>()) {
       auto Nt = TypeTranslator
-                    .translateType(
-                        anonymize(getLLVMType(E->getType(), Glob.getCGM())))
+                    .translateType(mlirclang::anonymize(
+                        mlirclang::getLLVMType(E->getType(), Glob.getCGM())))
                     .cast<LLVM::LLVMPointerType>();
       assert(Nt.getAddressSpace() == MT.getMemorySpaceAsInt() &&
              "val does not have the same memory space as nt");
@@ -613,8 +614,8 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
   };
 
   switch (Expr->getBuiltinCallee()) {
-  case Builtin::BI__builtin_strlen:
-  case Builtin::BIstrlen: {
+  case clang::Builtin::BI__builtin_strlen:
+  case clang::Builtin::BIstrlen: {
     mlir::Value V0 = GetLLVM(Expr->getArg(0));
 
     const std::string Name("strlen");
@@ -635,44 +636,46 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
 
     mlir::Value Vals[] = {V0};
     return ValueCategory(
-        builder.create<CallOp>(Loc, Glob.getFunctions()[Name], Vals)
+        builder.create<func::CallOp>(Loc, Glob.getFunctions()[Name], Vals)
             .getResult(0),
         false);
   }
-  case Builtin::BI__builtin_isnormal: {
+  case clang::Builtin::BI__builtin_isnormal: {
     mlir::Value V = GetLLVM(Expr->getArg(0));
     auto Ty = V.getType().cast<mlir::FloatType>();
-    mlir::Value Eq = builder.create<CmpFOp>(Loc, CmpFPredicate::OEQ, V, V);
+    mlir::Value Eq =
+        builder.create<arith::CmpFOp>(Loc, arith::CmpFPredicate::OEQ, V, V);
 
     mlir::Value Abs = builder.create<math::AbsFOp>(Loc, V);
-    auto Infinity = builder.create<ConstantFloatOp>(
+    auto Infinity = builder.create<arith::ConstantFloatOp>(
         Loc, APFloat::getInf(Ty.getFloatSemantics()), Ty);
-    mlir::Value IsLessThanInf =
-        builder.create<CmpFOp>(Loc, CmpFPredicate::ULT, Abs, Infinity);
+    mlir::Value IsLessThanInf = builder.create<arith::CmpFOp>(
+        Loc, arith::CmpFPredicate::ULT, Abs, Infinity);
     APFloat Smallest = APFloat::getSmallestNormalized(Ty.getFloatSemantics());
-    auto SmallestV = builder.create<ConstantFloatOp>(Loc, Smallest, Ty);
-    mlir::Value IsNormal =
-        builder.create<CmpFOp>(Loc, CmpFPredicate::UGE, Abs, SmallestV);
-    V = builder.create<AndIOp>(Loc, Eq, IsLessThanInf);
-    V = builder.create<AndIOp>(Loc, V, IsNormal);
+    auto SmallestV = builder.create<arith::ConstantFloatOp>(Loc, Smallest, Ty);
+    mlir::Value IsNormal = builder.create<arith::CmpFOp>(
+        Loc, arith::CmpFPredicate::UGE, Abs, SmallestV);
+    V = builder.create<arith::AndIOp>(Loc, Eq, IsLessThanInf);
+    V = builder.create<arith::AndIOp>(Loc, V, IsNormal);
     auto PostTy =
         Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
-    mlir::Value Res = builder.create<ExtUIOp>(Loc, PostTy, V);
+    mlir::Value Res = builder.create<arith::ExtUIOp>(Loc, PostTy, V);
     return ValueCategory(Res, /*isRef*/ false);
   }
-  case Builtin::BI__builtin_signbit: {
+  case clang::Builtin::BI__builtin_signbit: {
     mlir::Value V = GetLLVM(Expr->getArg(0));
     auto Ty = V.getType().cast<mlir::FloatType>();
     auto ITy = builder.getIntegerType(Ty.getWidth());
-    mlir::Value BC = builder.create<BitcastOp>(Loc, ITy, V);
-    auto ZeroV = builder.create<ConstantIntOp>(Loc, 0, ITy);
-    V = builder.create<CmpIOp>(Loc, CmpIPredicate::slt, BC, ZeroV);
+    mlir::Value BC = builder.create<arith::BitcastOp>(Loc, ITy, V);
+    auto ZeroV = builder.create<arith::ConstantIntOp>(Loc, 0, ITy);
+    V = builder.create<arith::CmpIOp>(Loc, arith::CmpIPredicate::slt, BC,
+                                      ZeroV);
     auto PostTy =
         Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
-    mlir::Value Res = builder.create<ExtUIOp>(Loc, PostTy, V);
+    mlir::Value Res = builder.create<arith::ExtUIOp>(Loc, PostTy, V);
     return ValueCategory(Res, /*isRef*/ false);
   }
-  case Builtin::BI__builtin_addressof: {
+  case clang::Builtin::BI__builtin_addressof: {
     auto V = Visit(Expr->getArg(0));
     assert(V.isReference);
     mlir::Value Val = V.val;
@@ -710,18 +713,18 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
 
   auto BuiltinCallee = Expr->getBuiltinCallee();
 
-  if (auto *Ic = dyn_cast<ImplicitCastExpr>(Expr->getCallee()))
-    if (auto *Sr = dyn_cast<DeclRefExpr>(Ic->getSubExpr())) {
+  if (auto *Ic = dyn_cast<clang::ImplicitCastExpr>(Expr->getCallee()))
+    if (auto *Sr = dyn_cast<clang::DeclRefExpr>(Ic->getSubExpr())) {
       if (Sr->getDecl()->getIdentifier() &&
           (Sr->getDecl()->getName() == "__powf" ||
-           BuiltinCallee == Builtin::BIpow ||
+           BuiltinCallee == clang::Builtin::BIpow ||
            Sr->getDecl()->getName() == "__nv_pow" ||
            Sr->getDecl()->getName() == "__nv_powf" ||
            Sr->getDecl()->getName() == "__powi" ||
            Sr->getDecl()->getName() == "powi" ||
            Sr->getDecl()->getName() == "__nv_powi" ||
            Sr->getDecl()->getName() == "__nv_powi" ||
-           BuiltinCallee == Builtin::BIpowf)) {
+           BuiltinCallee == clang::Builtin::BIpowf)) {
         mlir::Type MLIRType = Glob.getTypes().getMLIRType(Expr->getType());
         std::vector<mlir::Value> Args;
         for (auto *A : Expr->arguments()) {
@@ -737,16 +740,16 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
       }
     }
 
-  if (auto *Ic = dyn_cast<ImplicitCastExpr>(Expr->getCallee()))
-    if (auto *Sr = dyn_cast<DeclRefExpr>(Ic->getSubExpr())) {
+  if (auto *Ic = dyn_cast<clang::ImplicitCastExpr>(Expr->getCallee()))
+    if (auto *Sr = dyn_cast<clang::DeclRefExpr>(Ic->getSubExpr())) {
       if (Sr->getDecl()->getIdentifier() &&
           (Sr->getDecl()->getName() == "__nv_fabsf" ||
            Sr->getDecl()->getName() == "__nv_fabs" ||
            Sr->getDecl()->getName() == "__nv_abs" ||
-           BuiltinCallee == Builtin::BIfabs ||
-           BuiltinCallee == Builtin::BIfabsf ||
-           BuiltinCallee == Builtin::BI__builtin_fabs ||
-           BuiltinCallee == Builtin::BI__builtin_fabsf)) {
+           BuiltinCallee == clang::Builtin::BIfabs ||
+           BuiltinCallee == clang::Builtin::BIfabsf ||
+           BuiltinCallee == clang::Builtin::BI__builtin_fabs ||
+           BuiltinCallee == clang::Builtin::BI__builtin_fabsf)) {
         // isinf(x)    --> fabs(x) == infinity
         // isfinite(x) --> fabs(x) != infinity
         // x != NaN via the ordered compare in either case.
@@ -757,9 +760,10 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
         else {
           auto Zero = builder.create<arith::ConstantIntOp>(
               Loc, 0, V.getType().cast<mlir::IntegerType>().getWidth());
-          Fabs = builder.create<SelectOp>(
+          Fabs = builder.create<arith::SelectOp>(
               Loc,
-              builder.create<arith::CmpIOp>(Loc, CmpIPredicate::sge, V, Zero),
+              builder.create<arith::CmpIOp>(Loc, arith::CmpIPredicate::sge, V,
+                                            Zero),
               V, builder.create<arith::SubIOp>(Loc, Zero, V));
         }
         return ValueCategory(Fabs, /*isRef*/ false);
@@ -773,12 +777,12 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
         V0 = builder.create<arith::ShRUIOp>(Loc, V0, C8);
         V1 = builder.create<arith::ShLIOp>(Loc, V1, C8);
         V1 = builder.create<arith::ShRUIOp>(Loc, V1, C8);
-        return ValueCategory(builder.create<MulIOp>(Loc, V0, V1), false);
+        return ValueCategory(builder.create<arith::MulIOp>(Loc, V0, V1), false);
       }
-      if (BuiltinCallee == Builtin::BI__builtin_frexp ||
-          BuiltinCallee == Builtin::BI__builtin_frexpf ||
-          BuiltinCallee == Builtin::BI__builtin_frexpl ||
-          BuiltinCallee == Builtin::BI__builtin_frexpf128) {
+      if (BuiltinCallee == clang::Builtin::BI__builtin_frexp ||
+          BuiltinCallee == clang::Builtin::BI__builtin_frexpf ||
+          BuiltinCallee == clang::Builtin::BI__builtin_frexpl ||
+          BuiltinCallee == clang::Builtin::BI__builtin_frexpf128) {
         mlir::Value V0 = GetLLVM(Expr->getArg(0));
         mlir::Value V1 = GetLLVM(Expr->getArg(1));
 
@@ -804,13 +808,13 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
 
         mlir::Value Vals[] = {V0, V1};
         return ValueCategory(
-            builder.create<CallOp>(Loc, Glob.getFunctions()[Name], Vals)
+            builder.create<func::CallOp>(Loc, Glob.getFunctions()[Name], Vals)
                 .getResult(0),
             false);
       }
       if (Sr->getDecl()->getIdentifier() &&
-          (BuiltinCallee == Builtin::BI__builtin_isfinite ||
-           BuiltinCallee == Builtin::BI__builtin_isinf ||
+          (BuiltinCallee == clang::Builtin::BI__builtin_isfinite ||
+           BuiltinCallee == clang::Builtin::BI__builtin_isinf ||
            Sr->getDecl()->getName() == "__nv_isinff")) {
         // isinf(x)    --> fabs(x) == infinity
         // isfinite(x) --> fabs(x) != infinity
@@ -818,28 +822,30 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
         mlir::Value V = GetLLVM(Expr->getArg(0));
         auto Ty = V.getType().cast<mlir::FloatType>();
         mlir::Value Fabs = builder.create<math::AbsFOp>(Loc, V);
-        auto Infinity = builder.create<ConstantFloatOp>(
+        auto Infinity = builder.create<arith::ConstantFloatOp>(
             Loc, APFloat::getInf(Ty.getFloatSemantics()), Ty);
-        auto Pred = (BuiltinCallee == Builtin::BI__builtin_isinf ||
+        auto Pred = (BuiltinCallee == clang::Builtin::BI__builtin_isinf ||
                      Sr->getDecl()->getName() == "__nv_isinff")
-                        ? CmpFPredicate::OEQ
-                        : CmpFPredicate::ONE;
-        mlir::Value FCmp = builder.create<CmpFOp>(Loc, Pred, Fabs, Infinity);
+                        ? arith::CmpFPredicate::OEQ
+                        : arith::CmpFPredicate::ONE;
+        mlir::Value FCmp =
+            builder.create<arith::CmpFOp>(Loc, Pred, Fabs, Infinity);
         auto PostTy = Glob.getTypes()
                           .getMLIRType(Expr->getType())
                           .cast<mlir::IntegerType>();
-        mlir::Value Res = builder.create<ExtUIOp>(Loc, PostTy, FCmp);
+        mlir::Value Res = builder.create<arith::ExtUIOp>(Loc, PostTy, FCmp);
         return ValueCategory(Res, /*isRef*/ false);
       }
       if (Sr->getDecl()->getIdentifier() &&
-          (BuiltinCallee == Builtin::BI__builtin_isnan ||
+          (BuiltinCallee == clang::Builtin::BI__builtin_isnan ||
            Sr->getDecl()->getName() == "__nv_isnanf")) {
         mlir::Value V = GetLLVM(Expr->getArg(0));
-        mlir::Value Eq = builder.create<CmpFOp>(Loc, CmpFPredicate::UNO, V, V);
+        mlir::Value Eq =
+            builder.create<arith::CmpFOp>(Loc, arith::CmpFPredicate::UNO, V, V);
         auto PostTy = Glob.getTypes()
                           .getMLIRType(Expr->getType())
                           .cast<mlir::IntegerType>();
-        mlir::Value Res = builder.create<ExtUIOp>(Loc, PostTy, Eq);
+        mlir::Value Res = builder.create<arith::ExtUIOp>(Loc, PostTy, Eq);
         return ValueCategory(Res, /*isRef*/ false);
       }
       if (Sr->getDecl()->getIdentifier() &&
@@ -872,34 +878,34 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
         Glob.getFunctions()[Name] = Function;
         module->push_back(Function);
         mlir::Value Vals[] = {V, V2};
-        V = Builder.create<CallOp>(Loc, Function, Vals).getResult(0);
+        V = Builder.create<func::CallOp>(Loc, Function, Vals).getResult(0);
         return ValueCategory(V, /*isRef*/ false);
       }
       if (Sr->getDecl()->getIdentifier() &&
           (Sr->getDecl()->getName() == "__nv_dmul_rn")) {
         mlir::Value V = GetLLVM(Expr->getArg(0));
         mlir::Value V2 = GetLLVM(Expr->getArg(1));
-        V = builder.create<MulFOp>(Loc, V, V2);
+        V = builder.create<arith::MulFOp>(Loc, V, V2);
         return ValueCategory(V, /*isRef*/ false);
       }
       if (Sr->getDecl()->getIdentifier() &&
           (Sr->getDecl()->getName() == "__nv_dadd_rn")) {
         mlir::Value V = GetLLVM(Expr->getArg(0));
         mlir::Value V2 = GetLLVM(Expr->getArg(1));
-        V = builder.create<AddFOp>(Loc, V, V2);
+        V = builder.create<arith::AddFOp>(Loc, V, V2);
         return ValueCategory(V, /*isRef*/ false);
       }
       if (Sr->getDecl()->getIdentifier() &&
           (Sr->getDecl()->getName() == "__nv_dsub_rn")) {
         mlir::Value V = GetLLVM(Expr->getArg(0));
         mlir::Value V2 = GetLLVM(Expr->getArg(1));
-        V = builder.create<SubFOp>(Loc, V, V2);
+        V = builder.create<arith::SubFOp>(Loc, V, V2);
         return ValueCategory(V, /*isRef*/ false);
       }
       if (Sr->getDecl()->getIdentifier() &&
-          (BuiltinCallee == Builtin::BI__builtin_log2 ||
-           BuiltinCallee == Builtin::BI__builtin_log2f ||
-           BuiltinCallee == Builtin::BI__builtin_log2l ||
+          (BuiltinCallee == clang::Builtin::BI__builtin_log2 ||
+           BuiltinCallee == clang::Builtin::BI__builtin_log2f ||
+           BuiltinCallee == clang::Builtin::BI__builtin_log2l ||
            Sr->getDecl()->getName() == "__nv_log2" ||
            Sr->getDecl()->getName() == "__nv_log2f" ||
            Sr->getDecl()->getName() == "__nv_log2l")) {
@@ -908,9 +914,9 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
         return ValueCategory(V, /*isRef*/ false);
       }
       if (Sr->getDecl()->getIdentifier() &&
-          (BuiltinCallee == Builtin::BI__builtin_log10 ||
-           BuiltinCallee == Builtin::BI__builtin_log10f ||
-           BuiltinCallee == Builtin::BI__builtin_log10l ||
+          (BuiltinCallee == clang::Builtin::BI__builtin_log10 ||
+           BuiltinCallee == clang::Builtin::BI__builtin_log10f ||
+           BuiltinCallee == clang::Builtin::BI__builtin_log10l ||
            Sr->getDecl()->getName() == "__nv_log10" ||
            Sr->getDecl()->getName() == "__nv_log10f" ||
            Sr->getDecl()->getName() == "__nv_log10l")) {
@@ -920,16 +926,16 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
       }
     }
 
-  if (auto *Ic = dyn_cast<ImplicitCastExpr>(Expr->getCallee()))
-    if (auto *Sr = dyn_cast<DeclRefExpr>(Ic->getSubExpr())) {
+  if (auto *Ic = dyn_cast<clang::ImplicitCastExpr>(Expr->getCallee()))
+    if (auto *Sr = dyn_cast<clang::DeclRefExpr>(Ic->getSubExpr())) {
       if ((Sr->getDecl()->getIdentifier() &&
-           (BuiltinCallee == Builtin::BIfscanf ||
-            BuiltinCallee == Builtin::BIscanf ||
+           (BuiltinCallee == clang::Builtin::BIfscanf ||
+            BuiltinCallee == clang::Builtin::BIscanf ||
             Sr->getDecl()->getName() == "__isoc99_sscanf" ||
-            BuiltinCallee == Builtin::BIsscanf)) ||
-          (isa<CXXOperatorCallExpr>(Expr) &&
-           cast<CXXOperatorCallExpr>(Expr)->getOperator() ==
-               OO_GreaterGreater)) {
+            BuiltinCallee == clang::Builtin::BIsscanf)) ||
+          (isa<clang::CXXOperatorCallExpr>(Expr) &&
+           cast<clang::CXXOperatorCallExpr>(Expr)->getOperator() ==
+               clang::OO_GreaterGreater)) {
         const auto *ToCall = EmitCallee(Expr->getCallee());
         auto StrcmpF = Glob.GetOrCreateLLVMFunction(ToCall);
 
@@ -958,14 +964,14 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
       }
     }
 
-  if (auto *Ic = dyn_cast<ImplicitCastExpr>(Expr->getCallee()))
-    if (auto *Sr = dyn_cast<DeclRefExpr>(Ic->getSubExpr())) {
+  if (auto *Ic = dyn_cast<clang::ImplicitCastExpr>(Expr->getCallee()))
+    if (auto *Sr = dyn_cast<clang::DeclRefExpr>(Ic->getSubExpr())) {
       if (Sr->getDecl()->getIdentifier() &&
           (Sr->getDecl()->getName() == "cudaMemcpy" ||
            Sr->getDecl()->getName() == "cudaMemcpyAsync" ||
            Sr->getDecl()->getName() == "cudaMemcpyToSymbol" ||
-           BuiltinCallee == Builtin::BImemcpy ||
-           BuiltinCallee == Builtin::BI__builtin_memcpy)) {
+           BuiltinCallee == clang::Builtin::BImemcpy ||
+           BuiltinCallee == clang::Builtin::BI__builtin_memcpy)) {
         auto *DstSub = Expr->getArg(0);
         while (auto *BC = dyn_cast<clang::CastExpr>(DstSub))
           DstSub = BC->getSubExpr();
@@ -975,7 +981,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
       }
     }
 
-  const FunctionDecl *Callee = EmitCallee(Expr->getCallee());
+  const clang::FunctionDecl *Callee = EmitCallee(Expr->getCallee());
 
   std::set<std::string> Funcs = {
       "fread",
@@ -1025,18 +1031,19 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
       "cudaOccupancyMaxActiveBlocksPerMultiprocessor",
       "cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags",
       "cudaEventRecord"};
-  if (auto *Ic = dyn_cast<ImplicitCastExpr>(Expr->getCallee()))
-    if (auto *Sr = dyn_cast<DeclRefExpr>(Ic->getSubExpr())) {
+  if (auto *Ic = dyn_cast<clang::ImplicitCastExpr>(Expr->getCallee()))
+    if (auto *Sr = dyn_cast<clang::DeclRefExpr>(Ic->getSubExpr())) {
       StringRef Name;
-      if (auto *CC = dyn_cast<CXXConstructorDecl>(Sr->getDecl()))
+      if (auto *CC = dyn_cast<clang::CXXConstructorDecl>(Sr->getDecl()))
         Name = Glob.getCGM().getMangledName(
-            GlobalDecl(CC, CXXCtorType::Ctor_Complete));
-      else if (auto *CC = dyn_cast<CXXDestructorDecl>(Sr->getDecl()))
+            clang::GlobalDecl(CC, clang::CXXCtorType::Ctor_Complete));
+      else if (auto *CC = dyn_cast<clang::CXXDestructorDecl>(Sr->getDecl()))
         Name = Glob.getCGM().getMangledName(
-            GlobalDecl(CC, CXXDtorType::Dtor_Complete));
-      else if (Sr->getDecl()->hasAttr<CUDAGlobalAttr>())
-        Name = Glob.getCGM().getMangledName(GlobalDecl(
-            cast<FunctionDecl>(Sr->getDecl()), KernelReferenceKind::Kernel));
+            clang::GlobalDecl(CC, clang::CXXDtorType::Dtor_Complete));
+      else if (Sr->getDecl()->hasAttr<clang::CUDAGlobalAttr>())
+        Name = Glob.getCGM().getMangledName(
+            clang::GlobalDecl(cast<clang::FunctionDecl>(Sr->getDecl()),
+                              clang::KernelReferenceKind::Kernel));
       else
         Name = Glob.getCGM().getMangledName(Sr->getDecl());
       if (Funcs.count(Name.str()) || Name.startswith("mkl_") ||
@@ -1055,8 +1062,9 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
                        .getResult();
         } else {
           Args.insert(Args.begin(), GetLLVM(Expr->getCallee()));
-          SmallVector<mlir::Type> RTs = {TypeTranslator.translateType(
-              anonymize(getLLVMType(Expr->getType(), Glob.getCGM())))};
+          SmallVector<mlir::Type> RTs = {
+              TypeTranslator.translateType(mlirclang::anonymize(
+                  mlirclang::getLLVMType(Expr->getType(), Glob.getCGM())))};
           if (RTs[0].isa<LLVM::LLVMVoidType>())
             RTs.clear();
           Called =
@@ -1084,7 +1092,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
       if (IsReference)
         CT = Glob.getCGM().getContext().getLValueReferenceType(CT);
       SmallVector<mlir::Type> RTs = {TypeTranslator.translateType(
-          anonymize(getLLVMType(CT, Glob.getCGM())))};
+          mlirclang::anonymize(mlirclang::getLLVMType(CT, Glob.getCGM())))};
 
       auto Ft = Args[0]
                     .getType()
@@ -1128,9 +1136,9 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
   auto ToCall = cast<func::FuncOp>(Glob.GetOrCreateMLIRFunction(F, ShouldEmit));
 
   SmallVector<std::pair<ValueCategory, clang::Expr *>> Args;
-  QualType ObjType;
+  clang::QualType ObjType;
 
-  if (auto *CC = dyn_cast<CXXMemberCallExpr>(Expr)) {
+  if (auto *CC = dyn_cast<clang::CXXMemberCallExpr>(Expr)) {
     ValueCategory Obj = Visit(CC->getImplicitObjectArgument());
     ObjType = CC->getObjectType();
     LLVM_DEBUG({
@@ -1142,7 +1150,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
       }
     });
 
-    if (cast<MemberExpr>(CC->getCallee()->IgnoreParens())->isArrow())
+    if (cast<clang::MemberExpr>(CC->getCallee()->IgnoreParens())->isArrow())
       Obj = Obj.dereference(builder);
 
     assert(Obj.val);
@@ -1160,8 +1168,8 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
 std::pair<ValueCategory, bool>
 MLIRScanner::emitGPUCallExpr(clang::CallExpr *Expr) {
   auto Loc = getMLIRLocation(Expr->getExprLoc());
-  if (auto *Ic = dyn_cast<ImplicitCastExpr>(Expr->getCallee())) {
-    if (auto *Sr = dyn_cast<DeclRefExpr>(Ic->getSubExpr())) {
+  if (auto *Ic = dyn_cast<clang::ImplicitCastExpr>(Expr->getCallee())) {
+    if (auto *Sr = dyn_cast<clang::DeclRefExpr>(Ic->getSubExpr())) {
       if (Sr->getDecl()->getIdentifier() &&
           Sr->getDecl()->getName() == "__syncthreads") {
         builder.create<mlir::NVVM::Barrier0Op>(Loc);
@@ -1195,7 +1203,7 @@ MLIRScanner::emitGPUCallExpr(clang::CallExpr *Expr) {
         if (Sr->getDecl()->getName() == "cudaFree" ||
             Sr->getDecl()->getName() == "cudaFreeHost") {
           auto Ty = Glob.getTypes().getMLIRType(Expr->getType());
-          auto Op = builder.create<ConstantIntOp>(Loc, 0, Ty);
+          auto Op = builder.create<arith::ConstantIntOp>(Loc, 0, Ty);
           return std::make_pair(ValueCategory(Op, /*isReference*/ false), true);
         }
         // TODO remove me when the free is removed.
@@ -1229,20 +1237,21 @@ MLIRScanner::emitGPUCallExpr(clang::CallExpr *Expr) {
                 Visit(Expr->getArg(1))
                     .dereference(builder)
                     .store(builder, Width);
-                AllocSize = builder.create<MulIOp>(Loc, Width, Height);
+                AllocSize = builder.create<arith::MulIOp>(Loc, Width, Height);
               } else
                 AllocSize = Visit(Expr->getArg(1)).getValue(builder);
               auto IdxType = mlir::IndexType::get(builder.getContext());
-              mlir::Value Args[1] = {builder.create<DivUIOp>(
-                  Loc, builder.create<IndexCastOp>(Loc, IdxType, AllocSize),
+              mlir::Value Args[1] = {builder.create<arith::DivUIOp>(
+                  Loc,
+                  builder.create<arith::IndexCastOp>(Loc, IdxType, AllocSize),
                   ElemSize)};
               auto Alloc = builder.create<mlir::memref::AllocOp>(
                   Loc,
                   (Sr->getDecl()->getName() != "cudaMallocHost" && !CudaLower)
-                      ? mlir::MemRefType::get(
-                            Shape, MT.getElementType(),
-                            MemRefLayoutAttrInterface(),
-                            wrapIntegerMemorySpace(1, MT.getContext()))
+                      ? mlir::MemRefType::get(Shape, MT.getElementType(),
+                                              MemRefLayoutAttrInterface(),
+                                              mlirclang::wrapIntegerMemorySpace(
+                                                  1, MT.getContext()))
                       : MT,
                   Args);
               ValueCategory(Dst, /*isReference*/ true)
@@ -1250,8 +1259,9 @@ MLIRScanner::emitGPUCallExpr(clang::CallExpr *Expr) {
                          builder.create<mlir::memref::CastOp>(Loc, MT, Alloc));
               auto RetTy = Glob.getTypes().getMLIRType(Expr->getType());
               return std::make_pair(
-                  ValueCategory(builder.create<ConstantIntOp>(Loc, 0, RetTy),
-                                /*isReference*/ false),
+                  ValueCategory(
+                      builder.create<arith::ConstantIntOp>(Loc, 0, RetTy),
+                      /*isReference*/ false),
                   true);
             }
           }
@@ -1261,7 +1271,7 @@ MLIRScanner::emitGPUCallExpr(clang::CallExpr *Expr) {
 
     auto CreateBlockIdOp = [&](gpu::Dimension Str,
                                mlir::Type MLIRType) -> mlir::Value {
-      return builder.create<IndexCastOp>(
+      return builder.create<arith::IndexCastOp>(
           Loc, MLIRType,
           builder.create<mlir::gpu::BlockIdOp>(
               Loc, mlir::IndexType::get(builder.getContext()), Str));
@@ -1269,7 +1279,7 @@ MLIRScanner::emitGPUCallExpr(clang::CallExpr *Expr) {
 
     auto CreateBlockDimOp = [&](gpu::Dimension Str,
                                 mlir::Type MLIRType) -> mlir::Value {
-      return builder.create<IndexCastOp>(
+      return builder.create<arith::IndexCastOp>(
           Loc, MLIRType,
           builder.create<mlir::gpu::BlockDimOp>(
               Loc, mlir::IndexType::get(builder.getContext()), Str));
@@ -1277,7 +1287,7 @@ MLIRScanner::emitGPUCallExpr(clang::CallExpr *Expr) {
 
     auto CreateThreadIdOp = [&](gpu::Dimension Str,
                                 mlir::Type MLIRType) -> mlir::Value {
-      return builder.create<IndexCastOp>(
+      return builder.create<arith::IndexCastOp>(
           Loc, MLIRType,
           builder.create<mlir::gpu::ThreadIdOp>(
               Loc, mlir::IndexType::get(builder.getContext()), Str));
@@ -1285,17 +1295,17 @@ MLIRScanner::emitGPUCallExpr(clang::CallExpr *Expr) {
 
     auto CreateGridDimOp = [&](gpu::Dimension Str,
                                mlir::Type MLIRType) -> mlir::Value {
-      return builder.create<IndexCastOp>(
+      return builder.create<arith::IndexCastOp>(
           Loc, MLIRType,
           builder.create<mlir::gpu::GridDimOp>(
               Loc, mlir::IndexType::get(builder.getContext()), Str));
     };
 
-    if (auto *ME = dyn_cast<MemberExpr>(Ic->getSubExpr())) {
+    if (auto *ME = dyn_cast<clang::MemberExpr>(Ic->getSubExpr())) {
       auto MemberName = ME->getMemberDecl()->getName();
 
-      if (auto *Sr2 = dyn_cast<OpaqueValueExpr>(ME->getBase())) {
-        if (auto *Sr = dyn_cast<DeclRefExpr>(Sr2->getSourceExpr())) {
+      if (auto *Sr2 = dyn_cast<clang::OpaqueValueExpr>(ME->getBase())) {
+        if (auto *Sr = dyn_cast<clang::DeclRefExpr>(Sr2->getSourceExpr())) {
           if (Sr->getDecl()->getName() == "blockIdx") {
             auto MLIRType = Glob.getTypes().getMLIRType(Expr->getType());
             if (MemberName == "__fetch_builtin_x") {
@@ -1389,8 +1399,8 @@ MLIRScanner::emitGPUCallExpr(clang::CallExpr *Expr) {
 
 std::pair<ValueCategory, bool>
 MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
-  if (auto *Ic = dyn_cast<ImplicitCastExpr>(Expr->getCallee()))
-    if (auto *Sr = dyn_cast<DeclRefExpr>(Ic->getSubExpr()))
+  if (auto *Ic = dyn_cast<clang::ImplicitCastExpr>(Expr->getCallee()))
+    if (auto *Sr = dyn_cast<clang::DeclRefExpr>(Ic->getSubExpr()))
       if (Sr->getDecl()->getIdentifier() &&
           Sr->getDecl()->getName() == "__log2f") {
         std::vector<mlir::Value> Args;
@@ -1411,161 +1421,168 @@ MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
   };
   Optional<Value> V = None;
   switch (Expr->getBuiltinCallee()) {
-  case Builtin::BIceil: {
+  case clang::Builtin::BIceil: {
     VisitArgs();
     V = builder.create<math::CeilOp>(loc, Args[0]);
   } break;
-  case Builtin::BIcos: {
+  case clang::Builtin::BIcos: {
     VisitArgs();
     V = builder.create<mlir::math::CosOp>(loc, Args[0]);
   } break;
-  case Builtin::BIexp:
-  case Builtin::BIexpf: {
+  case clang::Builtin::BIexp:
+  case clang::Builtin::BIexpf: {
     VisitArgs();
     V = builder.create<mlir::math::ExpOp>(loc, Args[0]);
   } break;
-  case Builtin::BIlog: {
+  case clang::Builtin::BIlog: {
     VisitArgs();
     V = builder.create<mlir::math::LogOp>(loc, Args[0]);
   } break;
-  case Builtin::BIsin: {
+  case clang::Builtin::BIsin: {
     VisitArgs();
     V = builder.create<mlir::math::SinOp>(loc, Args[0]);
   } break;
-  case Builtin::BIsqrt:
-  case Builtin::BIsqrtf: {
+  case clang::Builtin::BIsqrt:
+  case clang::Builtin::BIsqrtf: {
     VisitArgs();
     V = builder.create<mlir::math::SqrtOp>(loc, Args[0]);
   } break;
-  case Builtin::BI__builtin_atanh:
-  case Builtin::BI__builtin_atanhf:
-  case Builtin::BI__builtin_atanhl: {
+  case clang::Builtin::BI__builtin_atanh:
+  case clang::Builtin::BI__builtin_atanhf:
+  case clang::Builtin::BI__builtin_atanhl: {
     VisitArgs();
     V = builder.create<math::AtanOp>(loc, Args[0]);
   } break;
-  case Builtin::BI__builtin_copysign:
-  case Builtin::BI__builtin_copysignf:
-  case Builtin::BI__builtin_copysignl: {
+  case clang::Builtin::BI__builtin_copysign:
+  case clang::Builtin::BI__builtin_copysignf:
+  case clang::Builtin::BI__builtin_copysignl: {
     VisitArgs();
     V = builder.create<LLVM::CopySignOp>(loc, Args[0], Args[1]);
   } break;
-  case Builtin::BI__builtin_exp2:
-  case Builtin::BI__builtin_exp2f:
-  case Builtin::BI__builtin_exp2l: {
+  case clang::Builtin::BI__builtin_exp2:
+  case clang::Builtin::BI__builtin_exp2f:
+  case clang::Builtin::BI__builtin_exp2l: {
     VisitArgs();
     V = builder.create<math::Exp2Op>(loc, Args[0]);
   } break;
-  case Builtin::BI__builtin_expm1:
-  case Builtin::BI__builtin_expm1f:
-  case Builtin::BI__builtin_expm1l: {
+  case clang::Builtin::BI__builtin_expm1:
+  case clang::Builtin::BI__builtin_expm1f:
+  case clang::Builtin::BI__builtin_expm1l: {
     VisitArgs();
     V = builder.create<math::ExpM1Op>(loc, Args[0]);
   } break;
-  case Builtin::BI__builtin_fma:
-  case Builtin::BI__builtin_fmaf:
-  case Builtin::BI__builtin_fmal: {
+  case clang::Builtin::BI__builtin_fma:
+  case clang::Builtin::BI__builtin_fmaf:
+  case clang::Builtin::BI__builtin_fmal: {
     VisitArgs();
     V = builder.create<LLVM::FMAOp>(loc, Args[0], Args[1], Args[2]);
   } break;
-  case Builtin::BI__builtin_fmax:
-  case Builtin::BI__builtin_fmaxf:
-  case Builtin::BI__builtin_fmaxl: {
+  case clang::Builtin::BI__builtin_fmax:
+  case clang::Builtin::BI__builtin_fmaxf:
+  case clang::Builtin::BI__builtin_fmaxl: {
     VisitArgs();
     V = builder.create<LLVM::MaxNumOp>(loc, Args[0], Args[1]);
   } break;
-  case Builtin::BI__builtin_fmin:
-  case Builtin::BI__builtin_fminf:
-  case Builtin::BI__builtin_fminl: {
+  case clang::Builtin::BI__builtin_fmin:
+  case clang::Builtin::BI__builtin_fminf:
+  case clang::Builtin::BI__builtin_fminl: {
     VisitArgs();
     V = builder.create<LLVM::MinNumOp>(loc, Args[0], Args[1]);
   } break;
-  case Builtin::BI__builtin_log1p:
-  case Builtin::BI__builtin_log1pf:
-  case Builtin::BI__builtin_log1pl: {
+  case clang::Builtin::BI__builtin_log1p:
+  case clang::Builtin::BI__builtin_log1pf:
+  case clang::Builtin::BI__builtin_log1pl: {
     VisitArgs();
     V = builder.create<math::Log1pOp>(loc, Args[0]);
   } break;
-  case Builtin::BI__builtin_pow:
-  case Builtin::BI__builtin_powf:
-  case Builtin::BI__builtin_powl: {
+  case clang::Builtin::BI__builtin_pow:
+  case clang::Builtin::BI__builtin_powf:
+  case clang::Builtin::BI__builtin_powl: {
     VisitArgs();
     V = builder.create<math::PowFOp>(loc, Args[0], Args[1]);
   } break;
-  case Builtin::BI__builtin_assume: {
+  case clang::Builtin::BI__builtin_assume: {
     VisitArgs();
     V = builder.create<LLVM::AssumeOp>(loc, Args[0])->getResult(0);
   } break;
-  case Builtin::BI__builtin_isgreater: {
+  case clang::Builtin::BI__builtin_isgreater: {
     VisitArgs();
     auto PostTy =
         Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
-    V = builder.create<ExtUIOp>(
+    V = builder.create<arith::ExtUIOp>(
         loc, PostTy,
-        builder.create<CmpFOp>(loc, CmpFPredicate::OGT, Args[0], Args[1]));
+        builder.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OGT, Args[0],
+                                      Args[1]));
   } break;
-  case Builtin::BI__builtin_isgreaterequal: {
+  case clang::Builtin::BI__builtin_isgreaterequal: {
     VisitArgs();
     auto PostTy =
         Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
-    V = builder.create<ExtUIOp>(
+    V = builder.create<arith::ExtUIOp>(
         loc, PostTy,
-        builder.create<CmpFOp>(loc, CmpFPredicate::OGE, Args[0], Args[1]));
+        builder.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OGE, Args[0],
+                                      Args[1]));
   } break;
-  case Builtin::BI__builtin_isless: {
+  case clang::Builtin::BI__builtin_isless: {
     VisitArgs();
     auto PostTy =
         Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
-    V = builder.create<ExtUIOp>(
+    V = builder.create<arith::ExtUIOp>(
         loc, PostTy,
-        builder.create<CmpFOp>(loc, CmpFPredicate::OLT, Args[0], Args[1]));
+        builder.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OLT, Args[0],
+                                      Args[1]));
   } break;
-  case Builtin::BI__builtin_islessequal: {
+  case clang::Builtin::BI__builtin_islessequal: {
     VisitArgs();
     auto PostTy =
         Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
-    V = builder.create<ExtUIOp>(
+    V = builder.create<arith::ExtUIOp>(
         loc, PostTy,
-        builder.create<CmpFOp>(loc, CmpFPredicate::OLE, Args[0], Args[1]));
+        builder.create<arith::CmpFOp>(loc, arith::CmpFPredicate::OLE, Args[0],
+                                      Args[1]));
   } break;
-  case Builtin::BI__builtin_islessgreater: {
+  case clang::Builtin::BI__builtin_islessgreater: {
     VisitArgs();
     auto PostTy =
         Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
-    V = builder.create<ExtUIOp>(
+    V = builder.create<arith::ExtUIOp>(
         loc, PostTy,
-        builder.create<CmpFOp>(loc, CmpFPredicate::ONE, Args[0], Args[1]));
+        builder.create<arith::CmpFOp>(loc, arith::CmpFPredicate::ONE, Args[0],
+                                      Args[1]));
   } break;
-  case Builtin::BI__builtin_isunordered: {
+  case clang::Builtin::BI__builtin_isunordered: {
     VisitArgs();
     auto PostTy =
         Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
-    V = builder.create<ExtUIOp>(
+    V = builder.create<arith::ExtUIOp>(
         loc, PostTy,
-        builder.create<CmpFOp>(loc, CmpFPredicate::UNO, Args[0], Args[1]));
+        builder.create<arith::CmpFOp>(loc, arith::CmpFPredicate::UNO, Args[0],
+                                      Args[1]));
   } break;
-  case Builtin::BImemmove:
-  case Builtin::BI__builtin_memmove: {
+  case clang::Builtin::BImemmove:
+  case clang::Builtin::BI__builtin_memmove: {
     VisitArgs();
     builder.create<LLVM::MemmoveOp>(
         loc, Args[0], Args[1], Args[2],
-        /*isVolatile*/ builder.create<ConstantIntOp>(loc, false, 1));
+        /*isVolatile*/ builder.create<arith::ConstantIntOp>(loc, false, 1));
     V = Args[0];
   } break;
-  case Builtin::BImemset:
-  case Builtin::BI__builtin_memset: {
+  case clang::Builtin::BImemset:
+  case clang::Builtin::BI__builtin_memset: {
     VisitArgs();
     builder.create<LLVM::MemsetOp>(
         loc, Args[0],
-        builder.create<TruncIOp>(loc, builder.getI8Type(), Args[1]), Args[2],
-        /*isVolatile*/ builder.create<ConstantIntOp>(loc, false, 1));
+        builder.create<arith::TruncIOp>(loc, builder.getI8Type(), Args[1]),
+        Args[2],
+        /*isVolatile*/ builder.create<arith::ConstantIntOp>(loc, false, 1));
     V = Args[0];
   } break;
-  case Builtin::BImemcpy:
-  case Builtin::BI__builtin_memcpy: {
+  case clang::Builtin::BImemcpy:
+  case clang::Builtin::BI__builtin_memcpy: {
     VisitArgs();
     builder.create<LLVM::MemcpyOp>(
         loc, Args[0], Args[1], Args[2],
-        /*isVolatile*/ builder.create<ConstantIntOp>(loc, false, 1));
+        /*isVolatile*/ builder.create<arith::ConstantIntOp>(loc, false, 1));
     V = Args[0];
   } break;
   }

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -96,7 +96,7 @@ static void castCallerArgs(mlir::func::FuncOp Callee,
 /******************************************************************************/
 
 ValueCategory MLIRScanner::callHelper(
-    mlir::func::FuncOp ToCall, clang::QualType ObjType,
+    func::FuncOp ToCall, clang::QualType ObjType,
     ArrayRef<std::pair<ValueCategory, clang::Expr *>> Arguments,
     clang::QualType RetType, bool RetReference, clang::Expr *Expr,
     const clang::FunctionDecl &Callee) {
@@ -385,12 +385,12 @@ ValueCategory MLIRScanner::callHelper(
         /*dynamic shmem size*/ nullptr,
         /*token type*/ Stream ? Stream.getType() : nullptr,
         /*dependencies*/ AsyncDependencies);
-    auto Oldpoint = builder.getInsertionPoint();
-    auto *Oldblock = builder.getInsertionBlock();
+    auto OldPoint = builder.getInsertionPoint();
+    auto *OldBlock = builder.getInsertionBlock();
     builder.setInsertionPointToStart(&Op.getRegion().front());
     builder.create<func::CallOp>(loc, ToCall, Args);
     builder.create<gpu::TerminatorOp>(loc);
-    builder.setInsertionPoint(Oldblock, Oldpoint);
+    builder.setInsertionPoint(OldBlock, OldPoint);
     return nullptr;
   }
 

--- a/polygeist/tools/cgeist/Lib/CGStmt.cc
+++ b/polygeist/tools/cgeist/Lib/CGStmt.cc
@@ -616,13 +616,13 @@ ValueCategory MLIRScanner::VisitOMPParallelForDirective(
   SmallVector<Value> Incs;
   for (auto *F : Fors->updates()) {
     F = cast<clang::BinaryOperator>(F)->getRHS();
-    while (auto *Ce = dyn_cast<clang::CastExpr>(F))
-      F = Ce->getSubExpr();
+    while (auto *CE = dyn_cast<clang::CastExpr>(F))
+      F = CE->getSubExpr();
     auto *BO = cast<clang::BinaryOperator>(F);
     assert(BO->getOpcode() == clang::BinaryOperator::Opcode::BO_Add);
     F = BO->getRHS();
-    while (auto *Ce = dyn_cast<clang::CastExpr>(F))
-      F = Ce->getSubExpr();
+    while (auto *CE = dyn_cast<clang::CastExpr>(F))
+      F = CE->getSubExpr();
     BO = cast<clang::BinaryOperator>(F);
     assert(BO->getOpcode() == clang::BinaryOperator::Opcode::BO_Mul);
     F = BO->getRHS();

--- a/polygeist/tools/cgeist/Lib/CGStmt.cc
+++ b/polygeist/tools/cgeist/Lib/CGStmt.cc
@@ -16,32 +16,30 @@
 
 #define DEBUG_TYPE "CGStmt"
 
-using namespace clang;
 using namespace mlir;
-using namespace mlir::arith;
 
-static bool isTerminator(Operation *op) {
-  return op->mightHaveTrait<OpTrait::IsTerminator>();
+static bool isTerminator(Operation *Op) {
+  return Op->mightHaveTrait<OpTrait::IsTerminator>();
 }
 
-bool MLIRScanner::getLowerBound(clang::ForStmt *fors,
-                                mlirclang::AffineLoopDescriptor &descr) {
-  auto *init = fors->getInit();
-  if (auto *declStmt = dyn_cast<DeclStmt>(init))
-    if (declStmt->isSingleDecl()) {
-      auto *decl = declStmt->getSingleDecl();
-      if (auto *varDecl = dyn_cast<VarDecl>(decl)) {
-        if (varDecl->hasInit()) {
-          mlir::Value val = VisitVarDecl(varDecl).getValue(builder);
-          descr.setName(varDecl);
-          descr.setType(val.getType());
-          LLVM_DEBUG(descr.getType().print(llvm::dbgs()));
+bool MLIRScanner::getLowerBound(clang::ForStmt *Fors,
+                                mlirclang::AffineLoopDescriptor &Descr) {
+  auto *Init = Fors->getInit();
+  if (auto *DeclStmt = dyn_cast<clang::DeclStmt>(Init))
+    if (DeclStmt->isSingleDecl()) {
+      auto *Decl = DeclStmt->getSingleDecl();
+      if (auto *VarDecl = dyn_cast<clang::VarDecl>(Decl)) {
+        if (VarDecl->hasInit()) {
+          Value Val = VisitVarDecl(VarDecl).getValue(builder);
+          Descr.setName(VarDecl);
+          Descr.setType(Val.getType());
+          LLVM_DEBUG(Descr.getType().print(llvm::dbgs()));
 
-          if (descr.getForwardMode())
-            descr.setLowerBound(val);
+          if (Descr.getForwardMode())
+            Descr.setLowerBound(Val);
           else {
-            val = builder.create<AddIOp>(loc, val, getConstantIndex(1));
-            descr.setUpperBound(val);
+            Val = builder.create<arith::AddIOp>(loc, Val, getConstantIndex(1));
+            Descr.setUpperBound(Val);
           }
           return true;
         }
@@ -51,20 +49,20 @@ bool MLIRScanner::getLowerBound(clang::ForStmt *fors,
   // BinaryOperator 0x7ff7aa17e938 'int' '='
   // |-DeclRefExpr 0x7ff7aa17e8f8 'int' lvalue Var 0x7ff7aa17e758 'i' 'int'
   // -IntegerLiteral 0x7ff7aa17e918 'int' 0
-  if (auto *binOp = dyn_cast<clang::BinaryOperator>(init))
-    if (binOp->getOpcode() == clang::BinaryOperator::Opcode::BO_Assign)
-      if (auto *declRefStmt = dyn_cast<DeclRefExpr>(binOp->getLHS())) {
-        mlir::Value val = Visit(binOp->getRHS()).getValue(builder);
-        val = builder.create<IndexCastOp>(
-            loc, mlir::IndexType::get(builder.getContext()), val);
-        descr.setName(cast<VarDecl>(declRefStmt->getDecl()));
-        descr.setType(
-            Glob.getTypes().getMLIRType(declRefStmt->getDecl()->getType()));
-        if (descr.getForwardMode())
-          descr.setLowerBound(val);
+  if (auto *BinOp = dyn_cast<clang::BinaryOperator>(Init))
+    if (BinOp->getOpcode() == clang::BinaryOperator::Opcode::BO_Assign)
+      if (auto *DeclRefStmt = dyn_cast<clang::DeclRefExpr>(BinOp->getLHS())) {
+        Value Val = Visit(BinOp->getRHS()).getValue(builder);
+        Val = builder.create<arith::IndexCastOp>(
+            loc, IndexType::get(builder.getContext()), Val);
+        Descr.setName(cast<clang::VarDecl>(DeclRefStmt->getDecl()));
+        Descr.setType(
+            Glob.getTypes().getMLIRType(DeclRefStmt->getDecl()->getType()));
+        if (Descr.getForwardMode())
+          Descr.setLowerBound(Val);
         else {
-          val = builder.create<AddIOp>(loc, val, getConstantIndex(1));
-          descr.setUpperBound(val);
+          Val = builder.create<arith::AddIOp>(loc, Val, getConstantIndex(1));
+          Descr.setUpperBound(Val);
         }
         return true;
       }
@@ -73,83 +71,82 @@ bool MLIRScanner::getLowerBound(clang::ForStmt *fors,
 
 // Make sure that the induction variable initialized in
 // the for is the same as the one used in the condition.
-bool matchIndvar(const Expr *expr, VarDecl *indVar) {
-  while (const auto *IC = dyn_cast<ImplicitCastExpr>(expr)) {
-    expr = IC->getSubExpr();
+bool matchIndvar(const clang::Expr *Expr, clang::VarDecl *IndVar) {
+  while (const auto *IC = dyn_cast<clang::ImplicitCastExpr>(Expr)) {
+    Expr = IC->getSubExpr();
   }
-  if (const auto *declRef = dyn_cast<DeclRefExpr>(expr)) {
-    const auto *declRefName = declRef->getDecl();
-    if (declRefName == indVar)
+  if (const auto *DeclRef = dyn_cast<clang::DeclRefExpr>(Expr)) {
+    const auto *DeclRefName = DeclRef->getDecl();
+    if (DeclRefName == IndVar)
       return true;
   }
   return false;
 }
 
-bool MLIRScanner::getUpperBound(clang::ForStmt *fors,
-                                mlirclang::AffineLoopDescriptor &descr) {
-  auto *cond = fors->getCond();
-  if (auto *binaryOp = dyn_cast<clang::BinaryOperator>(cond)) {
-    auto *lhs = binaryOp->getLHS();
-    if (!matchIndvar(lhs, descr.getName()))
+bool MLIRScanner::getUpperBound(clang::ForStmt *Fors,
+                                mlirclang::AffineLoopDescriptor &Descr) {
+  auto *Cond = Fors->getCond();
+  if (auto *BinaryOp = dyn_cast<clang::BinaryOperator>(Cond)) {
+    auto *Lhs = BinaryOp->getLHS();
+    if (!matchIndvar(Lhs, Descr.getName()))
       return false;
 
-    if (descr.getForwardMode()) {
-      if (binaryOp->getOpcode() != clang::BinaryOperator::Opcode::BO_LT &&
-          binaryOp->getOpcode() != clang::BinaryOperator::Opcode::BO_LE)
+    if (Descr.getForwardMode()) {
+      if (BinaryOp->getOpcode() != clang::BinaryOperator::Opcode::BO_LT &&
+          BinaryOp->getOpcode() != clang::BinaryOperator::Opcode::BO_LE)
         return false;
 
-      auto *rhs = binaryOp->getRHS();
-      mlir::Value val = Visit(rhs).getValue(builder);
-      val = builder.create<IndexCastOp>(
-          loc, mlir::IndexType::get(val.getContext()), val);
-      if (binaryOp->getOpcode() == clang::BinaryOperator::Opcode::BO_LE)
-        val = builder.create<AddIOp>(loc, val, getConstantIndex(1));
-      descr.setUpperBound(val);
-      return true;
-    } else {
-      if (binaryOp->getOpcode() != clang::BinaryOperator::Opcode::BO_GT &&
-          binaryOp->getOpcode() != clang::BinaryOperator::Opcode::BO_GE)
-        return false;
-
-      auto *rhs = binaryOp->getRHS();
-      mlir::Value val = Visit(rhs).getValue(builder);
-      val = builder.create<IndexCastOp>(
-          loc, mlir::IndexType::get(val.getContext()), val);
-      if (binaryOp->getOpcode() == clang::BinaryOperator::Opcode::BO_GT)
-        val = builder.create<AddIOp>(loc, val, getConstantIndex(1));
-      descr.setLowerBound(val);
+      auto *Rhs = BinaryOp->getRHS();
+      Value Val = Visit(Rhs).getValue(builder);
+      Val = builder.create<arith::IndexCastOp>(
+          loc, IndexType::get(Val.getContext()), Val);
+      if (BinaryOp->getOpcode() == clang::BinaryOperator::Opcode::BO_LE)
+        Val = builder.create<arith::AddIOp>(loc, Val, getConstantIndex(1));
+      Descr.setUpperBound(Val);
       return true;
     }
+    if (BinaryOp->getOpcode() != clang::BinaryOperator::Opcode::BO_GT &&
+        BinaryOp->getOpcode() != clang::BinaryOperator::Opcode::BO_GE)
+      return false;
+
+    auto *Rhs = BinaryOp->getRHS();
+    Value Val = Visit(Rhs).getValue(builder);
+    Val = builder.create<arith::IndexCastOp>(
+        loc, IndexType::get(Val.getContext()), Val);
+    if (BinaryOp->getOpcode() == clang::BinaryOperator::Opcode::BO_GT)
+      Val = builder.create<arith::AddIOp>(loc, Val, getConstantIndex(1));
+    Descr.setLowerBound(Val);
+    return true;
   }
   return false;
 }
 
-bool MLIRScanner::getConstantStep(clang::ForStmt *fors,
-                                  mlirclang::AffineLoopDescriptor &descr) {
-  auto *inc = fors->getInc();
-  if (auto *unaryOp = dyn_cast<clang::UnaryOperator>(inc))
-    if (unaryOp->isPrefix() || unaryOp->isPostfix()) {
-      bool forwardLoop =
-          unaryOp->getOpcode() == clang::UnaryOperator::Opcode::UO_PostInc ||
-          unaryOp->getOpcode() == clang::UnaryOperator::Opcode::UO_PreInc;
-      descr.setStep(1);
-      descr.setForwardMode(forwardLoop);
+bool MLIRScanner::getConstantStep(clang::ForStmt *Fors,
+                                  mlirclang::AffineLoopDescriptor &Descr) {
+  auto *Inc = Fors->getInc();
+  if (auto *UnaryOp = dyn_cast<clang::UnaryOperator>(Inc))
+    if (UnaryOp->isPrefix() || UnaryOp->isPostfix()) {
+      bool ForwardLoop =
+          UnaryOp->getOpcode() == clang::UnaryOperator::Opcode::UO_PostInc ||
+          UnaryOp->getOpcode() == clang::UnaryOperator::Opcode::UO_PreInc;
+      Descr.setStep(1);
+      Descr.setForwardMode(ForwardLoop);
       return true;
     }
   return false;
 }
 
-bool MLIRScanner::isTrivialAffineLoop(clang::ForStmt *fors,
-                                      mlirclang::AffineLoopDescriptor &descr) {
-  if (!getConstantStep(fors, descr)) {
+bool MLIRScanner::isTrivialAffineLoop(clang::ForStmt *Fors,
+                                      mlirclang::AffineLoopDescriptor &Descr) {
+  if (!getConstantStep(Fors, Descr)) {
     LLVM_DEBUG(llvm::dbgs() << "getConstantStep -> false\n");
     return false;
   }
-  if (!getLowerBound(fors, descr)) {
+  if (!getLowerBound(Fors, Descr)) {
     LLVM_DEBUG(llvm::dbgs() << "getLowerBound -> false\n");
     return false;
   }
-  if (!getUpperBound(fors, descr)) {
+  if (!getUpperBound(Fors, Descr)) {
     LLVM_DEBUG(llvm::dbgs() << "getUpperBound -> false\n");
     return false;
   }
@@ -158,1018 +155,1013 @@ bool MLIRScanner::isTrivialAffineLoop(clang::ForStmt *fors,
 }
 
 void MLIRScanner::buildAffineLoopImpl(
-    clang::ForStmt *fors, mlir::Location loc, mlir::Value lb, mlir::Value ub,
-    const mlirclang::AffineLoopDescriptor &descr) {
-  auto affineOp = builder.create<AffineForOp>(
-      loc, lb, builder.getSymbolIdentityMap(), ub,
-      builder.getSymbolIdentityMap(), descr.getStep(),
+    clang::ForStmt *Fors, Location Loc, Value Lb, Value Ub,
+    const mlirclang::AffineLoopDescriptor &Descr) {
+  auto AffineOp = builder.create<AffineForOp>(
+      Loc, Lb, builder.getSymbolIdentityMap(), Ub,
+      builder.getSymbolIdentityMap(), Descr.getStep(),
       /*iterArgs=*/llvm::None);
 
-  auto &reg = affineOp.getLoopBody();
+  auto &Reg = AffineOp.getLoopBody();
 
-  auto val = (mlir::Value)affineOp.getInductionVar();
+  auto Val = (Value)AffineOp.getInductionVar();
 
-  reg.front().clear();
+  Reg.front().clear();
 
-  auto oldpoint = builder.getInsertionPoint();
-  auto *oldblock = builder.getInsertionBlock();
+  auto Oldpoint = builder.getInsertionPoint();
+  auto *Oldblock = builder.getInsertionBlock();
 
-  builder.setInsertionPointToEnd(&reg.front());
+  builder.setInsertionPointToEnd(&Reg.front());
 
-  auto er = builder.create<scf::ExecuteRegionOp>(loc, ArrayRef<mlir::Type>());
-  er.getRegion().push_back(new Block());
-  builder.setInsertionPointToStart(&er.getRegion().back());
-  builder.create<scf::YieldOp>(loc);
-  builder.setInsertionPointToStart(&er.getRegion().back());
+  auto Er = builder.create<scf::ExecuteRegionOp>(Loc, ArrayRef<Type>());
+  Er.getRegion().push_back(new Block());
+  builder.setInsertionPointToStart(&Er.getRegion().back());
+  builder.create<scf::YieldOp>(Loc);
+  builder.setInsertionPointToStart(&Er.getRegion().back());
 
-  if (!descr.getForwardMode()) {
-    val = builder.create<SubIOp>(loc, val, lb);
-    val = builder.create<SubIOp>(
-        loc, builder.create<SubIOp>(loc, ub, getConstantIndex(1)), val);
+  if (!Descr.getForwardMode()) {
+    Val = builder.create<arith::SubIOp>(Loc, Val, Lb);
+    Val = builder.create<arith::SubIOp>(
+        Loc, builder.create<arith::SubIOp>(Loc, Ub, getConstantIndex(1)), Val);
   }
-  auto idx = builder.create<IndexCastOp>(loc, descr.getType(), val);
-  assert(params.find(descr.getName()) != params.end());
-  params[descr.getName()].store(builder, idx);
+  auto Idx = builder.create<arith::IndexCastOp>(Loc, Descr.getType(), Val);
+  assert(params.find(Descr.getName()) != params.end());
+  params[Descr.getName()].store(builder, Idx);
 
   // TODO: set loop context.
-  Visit(fors->getBody());
+  Visit(Fors->getBody());
 
-  builder.setInsertionPointToEnd(&reg.front());
-  builder.create<AffineYieldOp>(loc);
+  builder.setInsertionPointToEnd(&Reg.front());
+  builder.create<AffineYieldOp>(Loc);
 
   // TODO: set the value of the iteration value to the final bound at the
   // end of the loop.
-  builder.setInsertionPoint(oldblock, oldpoint);
+  builder.setInsertionPoint(Oldblock, Oldpoint);
 }
 
 void MLIRScanner::buildAffineLoop(
-    clang::ForStmt *fors, mlir::Location loc,
-    const mlirclang::AffineLoopDescriptor &descr) {
-  mlir::Value lb = descr.getLowerBound();
-  mlir::Value ub = descr.getUpperBound();
-  buildAffineLoopImpl(fors, loc, lb, ub, descr);
+    clang::ForStmt *Fors, Location Loc,
+    const mlirclang::AffineLoopDescriptor &Descr) {
+  Value LB = Descr.getLowerBound();
+  Value UB = Descr.getUpperBound();
+  buildAffineLoopImpl(Fors, Loc, LB, UB, Descr);
 }
 
-ValueCategory MLIRScanner::VisitForStmt(clang::ForStmt *fors) {
-  IfScope scope(*this);
+ValueCategory MLIRScanner::VisitForStmt(clang::ForStmt *Fors) {
+  IfScope Scope(*this);
 
-  auto loc = getMLIRLocation(fors->getForLoc());
+  Location Loc = getMLIRLocation(Fors->getForLoc());
 
-  mlirclang::AffineLoopDescriptor affineLoopDescr;
-  if (Glob.getScopLocList().isInScop(fors->getForLoc()) &&
-      isTrivialAffineLoop(fors, affineLoopDescr)) {
-    buildAffineLoop(fors, loc, affineLoopDescr);
+  mlirclang::AffineLoopDescriptor AffineLoopDescr;
+  if (Glob.getScopLocList().isInScop(Fors->getForLoc()) &&
+      isTrivialAffineLoop(Fors, AffineLoopDescr)) {
+    buildAffineLoop(Fors, Loc, AffineLoopDescr);
   } else {
 
-    if (auto *s = fors->getInit()) {
-      Visit(s);
-    }
+    if (auto *S = Fors->getInit())
+      Visit(S);
 
-    auto i1Ty = builder.getIntegerType(1);
-    auto type = mlir::MemRefType::get({}, i1Ty, {}, 0);
-    auto truev = builder.create<ConstantIntOp>(loc, true, 1);
+    auto I1Ty = builder.getIntegerType(1);
+    auto Type = MemRefType::get({}, I1Ty, {}, 0);
+    auto Truev = builder.create<arith::ConstantIntOp>(Loc, true, 1);
 
-    LoopContext lctx{builder.create<mlir::memref::AllocaOp>(loc, type),
-                     builder.create<mlir::memref::AllocaOp>(loc, type)};
-    builder.create<mlir::memref::StoreOp>(loc, truev, lctx.noBreak);
+    LoopContext Lctx{builder.create<memref::AllocaOp>(Loc, Type),
+                     builder.create<memref::AllocaOp>(Loc, Type)};
+    builder.create<memref::StoreOp>(Loc, Truev, Lctx.noBreak);
 
-    auto *toadd = builder.getInsertionBlock()->getParent();
-    auto &condB = *(new Block());
-    toadd->getBlocks().push_back(&condB);
-    auto &bodyB = *(new Block());
-    toadd->getBlocks().push_back(&bodyB);
-    auto &exitB = *(new Block());
-    toadd->getBlocks().push_back(&exitB);
+    auto *Toadd = builder.getInsertionBlock()->getParent();
+    auto &CondB = *(new Block());
+    Toadd->getBlocks().push_back(&CondB);
+    auto &BodyB = *(new Block());
+    Toadd->getBlocks().push_back(&BodyB);
+    auto &ExitB = *(new Block());
+    Toadd->getBlocks().push_back(&ExitB);
 
-    builder.create<mlir::cf::BranchOp>(loc, &condB);
+    builder.create<cf::BranchOp>(Loc, &CondB);
 
-    builder.setInsertionPointToStart(&condB);
+    builder.setInsertionPointToStart(&CondB);
 
-    if (auto *s = fors->getCond()) {
-      auto condRes = Visit(s);
-      auto cond = condRes.getValue(builder);
-      if (auto LT = cond.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
-        auto nullptr_llvm = builder.create<mlir::LLVM::NullOp>(loc, LT);
-        cond = builder.create<mlir::LLVM::ICmpOp>(
-            loc, mlir::LLVM::ICmpPredicate::ne, cond, nullptr_llvm);
+    if (auto *S = Fors->getCond()) {
+      auto CondRes = Visit(S);
+      auto Cond = CondRes.getValue(builder);
+      if (auto LT = Cond.getType().dyn_cast<LLVM::LLVMPointerType>()) {
+        auto NullptrLlvm = builder.create<LLVM::NullOp>(Loc, LT);
+        Cond = builder.create<LLVM::ICmpOp>(Loc, LLVM::ICmpPredicate::ne, Cond,
+                                            NullptrLlvm);
       }
-      auto ty = cond.getType().cast<mlir::IntegerType>();
-      if (ty.getWidth() != 1) {
-        cond = builder.create<arith::CmpIOp>(
-            loc, CmpIPredicate::ne, cond,
-            builder.create<ConstantIntOp>(loc, 0, ty));
+      auto Ty = Cond.getType().cast<IntegerType>();
+      if (Ty.getWidth() != 1) {
+        Cond = builder.create<arith::CmpIOp>(
+            Loc, arith::CmpIPredicate::ne, Cond,
+            builder.create<arith::ConstantIntOp>(Loc, 0, Ty));
       }
-      auto nb = builder.create<mlir::memref::LoadOp>(
-          loc, lctx.noBreak, std::vector<mlir::Value>());
-      cond = builder.create<AndIOp>(loc, cond, nb);
-      builder.create<mlir::cf::CondBranchOp>(loc, cond, &bodyB, &exitB);
+      auto Nb = builder.create<memref::LoadOp>(Loc, Lctx.noBreak,
+                                               std::vector<Value>());
+      Cond = builder.create<arith::AndIOp>(Loc, Cond, Nb);
+      builder.create<cf::CondBranchOp>(Loc, Cond, &BodyB, &ExitB);
     } else {
-      auto cond = builder.create<mlir::memref::LoadOp>(
-          loc, lctx.noBreak, std::vector<mlir::Value>());
-      builder.create<mlir::cf::CondBranchOp>(loc, cond, &bodyB, &exitB);
+      auto Cond = builder.create<memref::LoadOp>(Loc, Lctx.noBreak,
+                                                 std::vector<Value>());
+      builder.create<cf::CondBranchOp>(Loc, Cond, &BodyB, &ExitB);
     }
 
-    builder.setInsertionPointToStart(&bodyB);
-    builder.create<mlir::memref::StoreOp>(
-        loc,
-        builder.create<mlir::memref::LoadOp>(loc, lctx.noBreak,
-                                             std::vector<mlir::Value>()),
-        lctx.keepRunning, std::vector<mlir::Value>());
+    builder.setInsertionPointToStart(&BodyB);
+    builder.create<memref::StoreOp>(
+        Loc,
+        builder.create<memref::LoadOp>(Loc, Lctx.noBreak, std::vector<Value>()),
+        Lctx.keepRunning, std::vector<Value>());
 
-    loops.push_back(lctx);
-    Visit(fors->getBody());
+    loops.push_back(Lctx);
+    Visit(Fors->getBody());
 
-    builder.create<mlir::memref::StoreOp>(
-        loc,
-        builder.create<mlir::memref::LoadOp>(loc, lctx.noBreak,
-                                             std::vector<mlir::Value>()),
-        lctx.keepRunning, std::vector<mlir::Value>());
-    if (auto *s = fors->getInc()) {
-      IfScope scope(*this);
-      Visit(s);
+    builder.create<memref::StoreOp>(
+        Loc,
+        builder.create<memref::LoadOp>(Loc, Lctx.noBreak, std::vector<Value>()),
+        Lctx.keepRunning, std::vector<Value>());
+    if (auto *S = Fors->getInc()) {
+      IfScope Scope(*this);
+      Visit(S);
     }
     loops.pop_back();
     if (builder.getInsertionBlock()->empty() ||
         !isTerminator(&builder.getInsertionBlock()->back())) {
-      builder.create<mlir::cf::BranchOp>(loc, &condB);
+      builder.create<cf::BranchOp>(Loc, &CondB);
     }
 
-    builder.setInsertionPointToStart(&exitB);
+    builder.setInsertionPointToStart(&ExitB);
   }
   return nullptr;
 }
 
-ValueCategory MLIRScanner::VisitCXXForRangeStmt(clang::CXXForRangeStmt *fors) {
-  IfScope scope(*this);
+ValueCategory MLIRScanner::VisitCXXForRangeStmt(clang::CXXForRangeStmt *Fors) {
+  IfScope Scope(*this);
 
-  auto loc = getMLIRLocation(fors->getForLoc());
+  auto Loc = getMLIRLocation(Fors->getForLoc());
 
-  if (auto *s = fors->getInit()) {
-    Visit(s);
+  if (auto *S = Fors->getInit()) {
+    Visit(S);
   }
-  Visit(fors->getRangeStmt());
-  Visit(fors->getBeginStmt());
-  Visit(fors->getEndStmt());
+  Visit(Fors->getRangeStmt());
+  Visit(Fors->getBeginStmt());
+  Visit(Fors->getEndStmt());
 
-  auto i1Ty = builder.getIntegerType(1);
-  auto type = mlir::MemRefType::get({}, i1Ty, {}, 0);
-  auto truev = builder.create<ConstantIntOp>(loc, true, 1);
+  auto I1Ty = builder.getIntegerType(1);
+  auto Type = MemRefType::get({}, I1Ty, {}, 0);
+  auto Truev = builder.create<arith::ConstantIntOp>(Loc, true, 1);
 
-  LoopContext lctx{builder.create<mlir::memref::AllocaOp>(loc, type),
-                   builder.create<mlir::memref::AllocaOp>(loc, type)};
-  builder.create<mlir::memref::StoreOp>(loc, truev, lctx.noBreak);
+  LoopContext Lctx{builder.create<memref::AllocaOp>(Loc, Type),
+                   builder.create<memref::AllocaOp>(Loc, Type)};
+  builder.create<memref::StoreOp>(Loc, Truev, Lctx.noBreak);
 
-  auto *toadd = builder.getInsertionBlock()->getParent();
-  auto &condB = *(new Block());
-  toadd->getBlocks().push_back(&condB);
-  auto &bodyB = *(new Block());
-  toadd->getBlocks().push_back(&bodyB);
-  auto &exitB = *(new Block());
-  toadd->getBlocks().push_back(&exitB);
+  auto *Toadd = builder.getInsertionBlock()->getParent();
+  auto &CondB = *(new Block());
+  Toadd->getBlocks().push_back(&CondB);
+  auto &BodyB = *(new Block());
+  Toadd->getBlocks().push_back(&BodyB);
+  auto &ExitB = *(new Block());
+  Toadd->getBlocks().push_back(&ExitB);
 
-  builder.create<mlir::cf::BranchOp>(loc, &condB);
+  builder.create<cf::BranchOp>(Loc, &CondB);
 
-  builder.setInsertionPointToStart(&condB);
+  builder.setInsertionPointToStart(&CondB);
 
-  if (auto *s = fors->getCond()) {
-    auto condRes = Visit(s);
-    auto cond = condRes.getValue(builder);
-    if (auto LT = cond.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
-      auto nullptr_llvm = builder.create<mlir::LLVM::NullOp>(loc, LT);
-      cond = builder.create<mlir::LLVM::ICmpOp>(
-          loc, mlir::LLVM::ICmpPredicate::ne, cond, nullptr_llvm);
+  if (auto *S = Fors->getCond()) {
+    auto CondRes = Visit(S);
+    auto Cond = CondRes.getValue(builder);
+    if (auto LT = Cond.getType().dyn_cast<LLVM::LLVMPointerType>()) {
+      auto NullptrLlvm = builder.create<LLVM::NullOp>(Loc, LT);
+      Cond = builder.create<LLVM::ICmpOp>(Loc, LLVM::ICmpPredicate::ne, Cond,
+                                          NullptrLlvm);
     }
-    auto ty = cond.getType().cast<mlir::IntegerType>();
-    if (ty.getWidth() != 1) {
-      cond = builder.create<arith::CmpIOp>(
-          loc, CmpIPredicate::ne, cond,
-          builder.create<ConstantIntOp>(loc, 0, ty));
+    auto Ty = Cond.getType().cast<IntegerType>();
+    if (Ty.getWidth() != 1) {
+      Cond = builder.create<arith::CmpIOp>(
+          Loc, arith::CmpIPredicate::ne, Cond,
+          builder.create<arith::ConstantIntOp>(Loc, 0, Ty));
     }
-    auto nb = builder.create<mlir::memref::LoadOp>(loc, lctx.noBreak,
-                                                   std::vector<mlir::Value>());
-    cond = builder.create<AndIOp>(loc, cond, nb);
-    builder.create<mlir::cf::CondBranchOp>(loc, cond, &bodyB, &exitB);
+    auto Nb =
+        builder.create<memref::LoadOp>(Loc, Lctx.noBreak, std::vector<Value>());
+    Cond = builder.create<arith::AndIOp>(Loc, Cond, Nb);
+    builder.create<cf::CondBranchOp>(Loc, Cond, &BodyB, &ExitB);
   } else {
-    auto cond = builder.create<mlir::memref::LoadOp>(
-        loc, lctx.noBreak, std::vector<mlir::Value>());
-    builder.create<mlir::cf::CondBranchOp>(loc, cond, &bodyB, &exitB);
+    auto Cond =
+        builder.create<memref::LoadOp>(Loc, Lctx.noBreak, std::vector<Value>());
+    builder.create<cf::CondBranchOp>(Loc, Cond, &BodyB, &ExitB);
   }
 
-  builder.setInsertionPointToStart(&bodyB);
-  builder.create<mlir::memref::StoreOp>(
-      loc,
-      builder.create<mlir::memref::LoadOp>(loc, lctx.noBreak,
-                                           std::vector<mlir::Value>()),
-      lctx.keepRunning, std::vector<mlir::Value>());
+  builder.setInsertionPointToStart(&BodyB);
+  builder.create<memref::StoreOp>(
+      Loc,
+      builder.create<memref::LoadOp>(Loc, Lctx.noBreak, std::vector<Value>()),
+      Lctx.keepRunning, std::vector<Value>());
 
-  loops.push_back(lctx);
-  Visit(fors->getLoopVarStmt());
-  Visit(fors->getBody());
+  loops.push_back(Lctx);
+  Visit(Fors->getLoopVarStmt());
+  Visit(Fors->getBody());
 
-  builder.create<mlir::memref::StoreOp>(
-      loc,
-      builder.create<mlir::memref::LoadOp>(loc, lctx.noBreak,
-                                           std::vector<mlir::Value>()),
-      lctx.keepRunning, std::vector<mlir::Value>());
-  if (auto *s = fors->getInc()) {
-    IfScope scope(*this);
-    Visit(s);
+  builder.create<memref::StoreOp>(
+      Loc,
+      builder.create<memref::LoadOp>(Loc, Lctx.noBreak, std::vector<Value>()),
+      Lctx.keepRunning, std::vector<Value>());
+  if (auto *S = Fors->getInc()) {
+    IfScope Scope(*this);
+    Visit(S);
   }
   loops.pop_back();
   if (builder.getInsertionBlock()->empty() ||
       !isTerminator(&builder.getInsertionBlock()->back())) {
-    builder.create<mlir::cf::BranchOp>(loc, &condB);
+    builder.create<cf::BranchOp>(Loc, &CondB);
   }
 
-  builder.setInsertionPointToStart(&exitB);
+  builder.setInsertionPointToStart(&ExitB);
   return nullptr;
 }
 
 ValueCategory
-MLIRScanner::VisitOMPSingleDirective(clang::OMPSingleDirective *par) {
-  IfScope scope(*this);
+MLIRScanner::VisitOMPSingleDirective(clang::OMPSingleDirective *Par) {
+  IfScope Scope(*this);
 
   builder.create<omp::BarrierOp>(loc);
-  auto affineOp = builder.create<omp::MasterOp>(loc);
+  auto AffineOp = builder.create<omp::MasterOp>(loc);
   builder.create<omp::BarrierOp>(loc);
 
-  auto oldpoint = builder.getInsertionPoint();
-  auto *oldblock = builder.getInsertionBlock();
+  auto Oldpoint = builder.getInsertionPoint();
+  auto *Oldblock = builder.getInsertionBlock();
 
-  affineOp.getRegion().push_back(new Block());
-  builder.setInsertionPointToStart(&affineOp.getRegion().front());
+  AffineOp.getRegion().push_back(new Block());
+  builder.setInsertionPointToStart(&AffineOp.getRegion().front());
 
-  auto executeRegion =
-      builder.create<scf::ExecuteRegionOp>(loc, ArrayRef<mlir::Type>());
-  executeRegion.getRegion().push_back(new Block());
+  auto ExecuteRegion =
+      builder.create<scf::ExecuteRegionOp>(loc, ArrayRef<Type>());
+  ExecuteRegion.getRegion().push_back(new Block());
   builder.create<omp::TerminatorOp>(loc);
-  builder.setInsertionPointToStart(&executeRegion.getRegion().back());
+  builder.setInsertionPointToStart(&ExecuteRegion.getRegion().back());
 
-  auto *oldScope = allocationScope;
-  allocationScope = &executeRegion.getRegion().back();
+  auto *OldScope = allocationScope;
+  allocationScope = &ExecuteRegion.getRegion().back();
 
-  Visit(cast<CapturedStmt>(par->getAssociatedStmt())
+  Visit(cast<clang::CapturedStmt>(Par->getAssociatedStmt())
             ->getCapturedDecl()
             ->getBody());
 
   builder.create<scf::YieldOp>(loc);
-  allocationScope = oldScope;
-  builder.setInsertionPoint(oldblock, oldpoint);
+  allocationScope = OldScope;
+  builder.setInsertionPoint(Oldblock, Oldpoint);
   return nullptr;
 }
 
-ValueCategory MLIRScanner::VisitOMPForDirective(clang::OMPForDirective *fors) {
-  IfScope scope(*this);
+ValueCategory MLIRScanner::VisitOMPForDirective(clang::OMPForDirective *Fors) {
+  IfScope Scope(*this);
 
-  if (fors->getPreInits()) {
-    Visit(fors->getPreInits());
+  if (Fors->getPreInits()) {
+    Visit(Fors->getPreInits());
   }
 
-  SmallVector<mlir::Value> inits;
-  for (auto *f : fors->inits()) {
-    assert(f);
-    f = cast<clang::BinaryOperator>(f)->getRHS();
-    inits.push_back(builder.create<IndexCastOp>(loc, builder.getIndexType(),
-                                                Visit(f).getValue(builder)));
+  SmallVector<Value> Inits;
+  for (auto *F : Fors->inits()) {
+    assert(F);
+    F = cast<clang::BinaryOperator>(F)->getRHS();
+    Inits.push_back(builder.create<arith::IndexCastOp>(
+        loc, builder.getIndexType(), Visit(F).getValue(builder)));
   }
 
-  SmallVector<mlir::Value> finals;
-  for (auto *f : fors->finals()) {
-    f = cast<clang::BinaryOperator>(f)->getRHS();
-    finals.push_back(builder.create<IndexCastOp>(loc, builder.getIndexType(),
-                                                 Visit(f).getValue(builder)));
+  SmallVector<Value> Finals;
+  for (auto *F : Fors->finals()) {
+    F = cast<clang::BinaryOperator>(F)->getRHS();
+    Finals.push_back(builder.create<arith::IndexCastOp>(
+        loc, builder.getIndexType(), Visit(F).getValue(builder)));
   }
 
-  SmallVector<mlir::Value> incs;
-  for (auto *f : fors->updates()) {
-    f = cast<clang::BinaryOperator>(f)->getRHS();
-    while (auto *ce = dyn_cast<clang::CastExpr>(f))
-      f = ce->getSubExpr();
-    auto *bo = cast<clang::BinaryOperator>(f);
-    assert(bo->getOpcode() == clang::BinaryOperator::Opcode::BO_Add);
-    f = bo->getRHS();
-    while (auto *ce = dyn_cast<clang::CastExpr>(f))
-      f = ce->getSubExpr();
-    bo = cast<clang::BinaryOperator>(f);
-    assert(bo->getOpcode() == clang::BinaryOperator::Opcode::BO_Mul);
-    f = bo->getRHS();
-    incs.push_back(builder.create<IndexCastOp>(loc, builder.getIndexType(),
-                                               Visit(f).getValue(builder)));
+  SmallVector<Value> Incs;
+  for (auto *F : Fors->updates()) {
+    F = cast<clang::BinaryOperator>(F)->getRHS();
+    while (auto *Ce = dyn_cast<clang::CastExpr>(F))
+      F = Ce->getSubExpr();
+    auto *Bo = cast<clang::BinaryOperator>(F);
+    assert(Bo->getOpcode() == clang::BinaryOperator::Opcode::BO_Add);
+    F = Bo->getRHS();
+    while (auto *Ce = dyn_cast<clang::CastExpr>(F))
+      F = Ce->getSubExpr();
+    Bo = cast<clang::BinaryOperator>(F);
+    assert(Bo->getOpcode() == clang::BinaryOperator::Opcode::BO_Mul);
+    F = Bo->getRHS();
+    Incs.push_back(builder.create<arith::IndexCastOp>(
+        loc, builder.getIndexType(), Visit(F).getValue(builder)));
   }
 
-  auto affineOp = builder.create<omp::WsLoopOp>(loc, inits, finals, incs);
-  affineOp.getRegion().push_back(new Block());
-  for (auto init : inits)
-    affineOp.getRegion().front().addArgument(init.getType(), init.getLoc());
-  auto inds = affineOp.getRegion().front().getArguments();
+  auto AffineOp = builder.create<omp::WsLoopOp>(loc, Inits, Finals, Incs);
+  AffineOp.getRegion().push_back(new Block());
+  for (auto Init : Inits)
+    AffineOp.getRegion().front().addArgument(Init.getType(), Init.getLoc());
+  auto Inds = AffineOp.getRegion().front().getArguments();
 
-  auto oldpoint = builder.getInsertionPoint();
-  auto *oldblock = builder.getInsertionBlock();
+  auto Oldpoint = builder.getInsertionPoint();
+  auto *Oldblock = builder.getInsertionBlock();
 
-  builder.setInsertionPointToStart(&affineOp.getRegion().front());
+  builder.setInsertionPointToStart(&AffineOp.getRegion().front());
 
-  auto executeRegion =
-      builder.create<scf::ExecuteRegionOp>(loc, ArrayRef<mlir::Type>());
+  auto ExecuteRegion =
+      builder.create<scf::ExecuteRegionOp>(loc, ArrayRef<Type>());
   builder.create<omp::YieldOp>(loc, ValueRange());
-  executeRegion.getRegion().push_back(new Block());
-  builder.setInsertionPointToStart(&executeRegion.getRegion().back());
+  ExecuteRegion.getRegion().push_back(new Block());
+  builder.setInsertionPointToStart(&ExecuteRegion.getRegion().back());
 
-  auto *oldScope = allocationScope;
-  allocationScope = &executeRegion.getRegion().back();
+  auto *OldScope = allocationScope;
+  allocationScope = &ExecuteRegion.getRegion().back();
 
-  std::map<VarDecl *, ValueCategory> prevInduction;
-  for (auto zp : zip(inds, fors->counters())) {
-    auto idx = builder.create<IndexCastOp>(
+  std::map<clang::VarDecl *, ValueCategory> PrevInduction;
+  for (auto Zp : zip(Inds, Fors->counters())) {
+    auto Idx = builder.create<arith::IndexCastOp>(
         loc,
-        Glob.getTypes().getMLIRType(fors->getIterationVariable()->getType()),
-        std::get<0>(zp));
-    VarDecl *name =
-        cast<VarDecl>(cast<DeclRefExpr>(std::get<1>(zp))->getDecl());
+        Glob.getTypes().getMLIRType(Fors->getIterationVariable()->getType()),
+        std::get<0>(Zp));
+    clang::VarDecl *Name = cast<clang::VarDecl>(
+        cast<clang::DeclRefExpr>(std::get<1>(Zp))->getDecl());
 
-    if (params.find(name) != params.end()) {
-      prevInduction[name] = params[name];
-      params.erase(name);
+    if (params.find(Name) != params.end()) {
+      PrevInduction[Name] = params[Name];
+      params.erase(Name);
     }
 
     bool LLVMABI = false;
-    bool isArray = false;
+    bool IsArray = false;
     if (Glob.getTypes()
             .getMLIRType(Glob.getCGM().getContext().getLValueReferenceType(
-                name->getType()))
-            .isa<mlir::LLVM::LLVMPointerType>())
+                Name->getType()))
+            .isa<LLVM::LLVMPointerType>())
       LLVMABI = true;
     else
-      Glob.getTypes().getMLIRType(name->getType(), &isArray);
+      Glob.getTypes().getMLIRType(Name->getType(), &IsArray);
 
-    auto allocop = createAllocOp(idx.getType(), name, /*memtype*/ 0,
-                                 /*isArray*/ isArray, /*LLVMABI*/ LLVMABI);
-    params[name] = ValueCategory(allocop, true);
-    params[name].store(builder, idx);
+    auto Allocop = createAllocOp(Idx.getType(), Name, /*memtype*/ 0,
+                                 /*isArray*/ IsArray, /*LLVMABI*/ LLVMABI);
+    params[Name] = ValueCategory(Allocop, true);
+    params[Name].store(builder, Idx);
   }
 
   // TODO: set loop context.
-  Visit(fors->getBody());
+  Visit(Fors->getBody());
 
   builder.create<scf::YieldOp>(loc, ValueRange());
 
-  allocationScope = oldScope;
+  allocationScope = OldScope;
 
   // TODO: set the value of the iteration value to the final bound at the
   // end of the loop.
-  builder.setInsertionPoint(oldblock, oldpoint);
+  builder.setInsertionPoint(Oldblock, Oldpoint);
 
-  for (auto pair : prevInduction)
-    params[pair.first] = pair.second;
+  for (auto Pair : PrevInduction)
+    params[Pair.first] = Pair.second;
 
   return nullptr;
 }
 
 ValueCategory
-MLIRScanner::VisitOMPParallelDirective(clang::OMPParallelDirective *par) {
-  IfScope scope(*this);
+MLIRScanner::VisitOMPParallelDirective(clang::OMPParallelDirective *Par) {
+  IfScope Scope(*this);
 
-  auto affineOp = builder.create<omp::ParallelOp>(loc);
+  auto AffineOp = builder.create<omp::ParallelOp>(loc);
 
-  auto oldpoint = builder.getInsertionPoint();
-  auto *oldblock = builder.getInsertionBlock();
+  auto Oldpoint = builder.getInsertionPoint();
+  auto *Oldblock = builder.getInsertionBlock();
 
-  affineOp.getRegion().push_back(new Block());
-  builder.setInsertionPointToStart(&affineOp.getRegion().front());
+  AffineOp.getRegion().push_back(new Block());
+  builder.setInsertionPointToStart(&AffineOp.getRegion().front());
 
-  auto executeRegion =
-      builder.create<scf::ExecuteRegionOp>(loc, ArrayRef<mlir::Type>());
-  executeRegion.getRegion().push_back(new Block());
+  auto ExecuteRegion =
+      builder.create<scf::ExecuteRegionOp>(loc, ArrayRef<Type>());
+  ExecuteRegion.getRegion().push_back(new Block());
   builder.create<omp::TerminatorOp>(loc);
-  builder.setInsertionPointToStart(&executeRegion.getRegion().back());
+  builder.setInsertionPointToStart(&ExecuteRegion.getRegion().back());
 
-  auto *oldScope = allocationScope;
-  allocationScope = &executeRegion.getRegion().back();
+  auto *OldScope = allocationScope;
+  allocationScope = &ExecuteRegion.getRegion().back();
 
-  std::map<VarDecl *, ValueCategory> prevInduction;
-  for (auto *f : par->clauses()) {
-    switch (f->getClauseKind()) {
+  std::map<clang::VarDecl *, ValueCategory> PrevInduction;
+  for (auto *F : Par->clauses()) {
+    switch (F->getClauseKind()) {
     case llvm::omp::OMPC_private:
-      for (auto *stmt : f->children()) {
-        VarDecl *name = cast<VarDecl>(cast<DeclRefExpr>(stmt)->getDecl());
+      for (auto *Stmt : F->children()) {
+        auto *Name =
+            cast<clang::VarDecl>(cast<clang::DeclRefExpr>(Stmt)->getDecl());
 
-        prevInduction[name] = params[name];
-        params.erase(name);
+        PrevInduction[Name] = params[Name];
+        params.erase(Name);
 
         bool LLVMABI = false;
-        bool isArray = false;
-        mlir::Type ty;
+        bool IsArray = false;
+        Type Ty;
         if (Glob.getTypes()
                 .getMLIRType(Glob.getCGM().getContext().getLValueReferenceType(
-                    name->getType()))
-                .isa<mlir::LLVM::LLVMPointerType>()) {
+                    Name->getType()))
+                .isa<LLVM::LLVMPointerType>()) {
           LLVMABI = true;
-          bool undef;
-          ty = Glob.getTypes().getMLIRType(name->getType(), &undef);
+          bool Undef;
+          Ty = Glob.getTypes().getMLIRType(Name->getType(), &Undef);
         } else
-          ty = Glob.getTypes().getMLIRType(name->getType(), &isArray);
+          Ty = Glob.getTypes().getMLIRType(Name->getType(), &IsArray);
 
-        auto allocop = createAllocOp(ty, name, /*memtype*/ 0,
-                                     /*isArray*/ isArray, /*LLVMABI*/ LLVMABI);
-        params[name] = ValueCategory(allocop, true);
-        params[name].store(builder, prevInduction[name], isArray);
+        auto Allocop = createAllocOp(Ty, Name, /*memtype*/ 0,
+                                     /*isArray*/ IsArray, /*LLVMABI*/ LLVMABI);
+        params[Name] = ValueCategory(Allocop, true);
+        params[Name].store(builder, PrevInduction[Name], IsArray);
       }
       break;
     default:
-      llvm::errs() << "may not handle omp clause " << (int)f->getClauseKind()
+      llvm::errs() << "may not handle omp clause " << (int)F->getClauseKind()
                    << "\n";
     }
   }
 
-  Visit(cast<CapturedStmt>(par->getAssociatedStmt())
+  Visit(cast<clang::CapturedStmt>(Par->getAssociatedStmt())
             ->getCapturedDecl()
             ->getBody());
 
   builder.create<scf::YieldOp>(loc);
-  allocationScope = oldScope;
-  builder.setInsertionPoint(oldblock, oldpoint);
+  allocationScope = OldScope;
+  builder.setInsertionPoint(Oldblock, Oldpoint);
 
-  for (auto pair : prevInduction)
-    params[pair.first] = pair.second;
+  for (auto Pair : PrevInduction)
+    params[Pair.first] = Pair.second;
   return nullptr;
 }
 
 ValueCategory MLIRScanner::VisitOMPParallelForDirective(
-    clang::OMPParallelForDirective *fors) {
-  IfScope scope(*this);
+    clang::OMPParallelForDirective *Fors) {
+  IfScope Scope(*this);
 
-  if (fors->getPreInits()) {
-    Visit(fors->getPreInits());
+  if (Fors->getPreInits()) {
+    Visit(Fors->getPreInits());
   }
 
-  SmallVector<mlir::Value> inits;
-  for (auto *f : fors->inits()) {
-    assert(f);
-    f = cast<clang::BinaryOperator>(f)->getRHS();
-    inits.push_back(builder.create<IndexCastOp>(loc, builder.getIndexType(),
-                                                Visit(f).getValue(builder)));
+  SmallVector<Value> Inits;
+  for (auto *F : Fors->inits()) {
+    assert(F);
+    F = cast<clang::BinaryOperator>(F)->getRHS();
+    Inits.push_back(builder.create<arith::IndexCastOp>(
+        loc, builder.getIndexType(), Visit(F).getValue(builder)));
   }
 
-  SmallVector<mlir::Value> finals;
-  for (auto *f : fors->finals()) {
-    f = cast<clang::BinaryOperator>(f)->getRHS();
-    finals.push_back(builder.create<arith::IndexCastOp>(
-        loc, builder.getIndexType(), Visit(f).getValue(builder)));
+  SmallVector<Value> Finals;
+  for (auto *F : Fors->finals()) {
+    F = cast<clang::BinaryOperator>(F)->getRHS();
+    Finals.push_back(builder.create<arith::IndexCastOp>(
+        loc, builder.getIndexType(), Visit(F).getValue(builder)));
   }
 
-  SmallVector<mlir::Value> incs;
-  for (auto *f : fors->updates()) {
-    f = cast<clang::BinaryOperator>(f)->getRHS();
-    while (auto *ce = dyn_cast<clang::CastExpr>(f))
-      f = ce->getSubExpr();
-    auto *bo = cast<clang::BinaryOperator>(f);
-    assert(bo->getOpcode() == clang::BinaryOperator::Opcode::BO_Add);
-    f = bo->getRHS();
-    while (auto *ce = dyn_cast<clang::CastExpr>(f))
-      f = ce->getSubExpr();
-    bo = cast<clang::BinaryOperator>(f);
-    assert(bo->getOpcode() == clang::BinaryOperator::Opcode::BO_Mul);
-    f = bo->getRHS();
-    incs.push_back(builder.create<IndexCastOp>(loc, builder.getIndexType(),
-                                               Visit(f).getValue(builder)));
+  SmallVector<Value> Incs;
+  for (auto *F : Fors->updates()) {
+    F = cast<clang::BinaryOperator>(F)->getRHS();
+    while (auto *Ce = dyn_cast<clang::CastExpr>(F))
+      F = Ce->getSubExpr();
+    auto *Bo = cast<clang::BinaryOperator>(F);
+    assert(Bo->getOpcode() == clang::BinaryOperator::Opcode::BO_Add);
+    F = Bo->getRHS();
+    while (auto *Ce = dyn_cast<clang::CastExpr>(F))
+      F = Ce->getSubExpr();
+    Bo = cast<clang::BinaryOperator>(F);
+    assert(Bo->getOpcode() == clang::BinaryOperator::Opcode::BO_Mul);
+    F = Bo->getRHS();
+    Incs.push_back(builder.create<arith::IndexCastOp>(
+        loc, builder.getIndexType(), Visit(F).getValue(builder)));
   }
 
-  auto affineOp = builder.create<scf::ParallelOp>(loc, inits, finals, incs);
+  auto AffineOp = builder.create<scf::ParallelOp>(loc, Inits, Finals, Incs);
 
-  auto inds = affineOp.getInductionVars();
+  auto Inds = AffineOp.getInductionVars();
 
-  auto oldpoint = builder.getInsertionPoint();
-  auto *oldblock = builder.getInsertionBlock();
+  auto Oldpoint = builder.getInsertionPoint();
+  auto *Oldblock = builder.getInsertionBlock();
 
-  builder.setInsertionPointToStart(&affineOp.getRegion().front());
+  builder.setInsertionPointToStart(&AffineOp.getRegion().front());
 
-  auto executeRegion =
-      builder.create<scf::ExecuteRegionOp>(loc, ArrayRef<mlir::Type>());
-  executeRegion.getRegion().push_back(new Block());
-  builder.setInsertionPointToStart(&executeRegion.getRegion().back());
+  auto ExecuteRegion =
+      builder.create<scf::ExecuteRegionOp>(loc, ArrayRef<Type>());
+  ExecuteRegion.getRegion().push_back(new Block());
+  builder.setInsertionPointToStart(&ExecuteRegion.getRegion().back());
 
-  auto *oldScope = allocationScope;
-  allocationScope = &executeRegion.getRegion().back();
+  auto *OldScope = allocationScope;
+  allocationScope = &ExecuteRegion.getRegion().back();
 
-  std::map<VarDecl *, ValueCategory> prevInduction;
-  for (auto zp : zip(inds, fors->counters())) {
-    auto idx = builder.create<IndexCastOp>(
+  std::map<clang::VarDecl *, ValueCategory> PrevInduction;
+  for (auto Zp : zip(Inds, Fors->counters())) {
+    auto Idx = builder.create<arith::IndexCastOp>(
         loc,
-        Glob.getTypes().getMLIRType(fors->getIterationVariable()->getType()),
-        std::get<0>(zp));
-    VarDecl *name =
-        cast<VarDecl>(cast<DeclRefExpr>(std::get<1>(zp))->getDecl());
+        Glob.getTypes().getMLIRType(Fors->getIterationVariable()->getType()),
+        std::get<0>(Zp));
+    auto *Name = cast<clang::VarDecl>(
+        cast<clang::DeclRefExpr>(std::get<1>(Zp))->getDecl());
 
-    if (params.find(name) != params.end()) {
-      prevInduction[name] = params[name];
-      params.erase(name);
+    if (params.find(Name) != params.end()) {
+      PrevInduction[Name] = params[Name];
+      params.erase(Name);
     }
 
     bool LLVMABI = false;
-    bool isArray = false;
+    bool IsArray = false;
     if (Glob.getTypes()
             .getMLIRType(Glob.getCGM().getContext().getLValueReferenceType(
-                name->getType()))
-            .isa<mlir::LLVM::LLVMPointerType>())
+                Name->getType()))
+            .isa<LLVM::LLVMPointerType>())
       LLVMABI = true;
     else
-      Glob.getTypes().getMLIRType(name->getType(), &isArray);
+      Glob.getTypes().getMLIRType(Name->getType(), &IsArray);
 
-    auto allocop = createAllocOp(idx.getType(), name, /*memtype*/ 0,
-                                 /*isArray*/ isArray, /*LLVMABI*/ LLVMABI);
-    params[name] = ValueCategory(allocop, true);
-    params[name].store(builder, idx);
+    auto Allocop = createAllocOp(Idx.getType(), Name, /*memtype*/ 0,
+                                 /*isArray*/ IsArray, /*LLVMABI*/ LLVMABI);
+    params[Name] = ValueCategory(Allocop, true);
+    params[Name].store(builder, Idx);
   }
 
   // TODO: set loop context.
-  Visit(fors->getBody());
+  Visit(Fors->getBody());
 
   builder.create<scf::YieldOp>(loc);
 
-  allocationScope = oldScope;
+  allocationScope = OldScope;
 
   // TODO: set the value of the iteration value to the final bound at the
   // end of the loop.
-  builder.setInsertionPoint(oldblock, oldpoint);
+  builder.setInsertionPoint(Oldblock, Oldpoint);
 
-  for (auto pair : prevInduction)
-    params[pair.first] = pair.second;
+  for (auto Pair : PrevInduction)
+    params[Pair.first] = Pair.second;
 
   return nullptr;
 }
 
-ValueCategory MLIRScanner::VisitDoStmt(clang::DoStmt *fors) {
-  IfScope scope(*this);
+ValueCategory MLIRScanner::VisitDoStmt(clang::DoStmt *Fors) {
+  IfScope Scope(*this);
 
-  auto loc = getMLIRLocation(fors->getDoLoc());
+  Location Loc = getMLIRLocation(Fors->getDoLoc());
 
-  auto i1Ty = builder.getIntegerType(1);
-  auto type = mlir::MemRefType::get({}, i1Ty, {}, 0);
-  auto truev = builder.create<ConstantIntOp>(loc, true, 1);
-  loops.push_back({builder.create<mlir::memref::AllocaOp>(loc, type),
-                   builder.create<mlir::memref::AllocaOp>(loc, type)});
-  builder.create<mlir::memref::StoreOp>(loc, truev, loops.back().noBreak);
+  auto I1Ty = builder.getIntegerType(1);
+  auto Type = MemRefType::get({}, I1Ty, {}, 0);
+  auto Truev = builder.create<arith::ConstantIntOp>(Loc, true, 1);
+  loops.push_back({builder.create<memref::AllocaOp>(Loc, Type),
+                   builder.create<memref::AllocaOp>(Loc, Type)});
+  builder.create<memref::StoreOp>(Loc, Truev, loops.back().noBreak);
 
-  auto *toadd = builder.getInsertionBlock()->getParent();
-  auto &condB = *(new Block());
-  toadd->getBlocks().push_back(&condB);
-  auto &bodyB = *(new Block());
-  toadd->getBlocks().push_back(&bodyB);
-  auto &exitB = *(new Block());
-  toadd->getBlocks().push_back(&exitB);
+  auto *Toadd = builder.getInsertionBlock()->getParent();
+  auto &CondB = *(new Block());
+  Toadd->getBlocks().push_back(&CondB);
+  auto &BodyB = *(new Block());
+  Toadd->getBlocks().push_back(&BodyB);
+  auto &ExitB = *(new Block());
+  Toadd->getBlocks().push_back(&ExitB);
 
-  builder.create<mlir::cf::BranchOp>(loc, &bodyB);
+  builder.create<cf::BranchOp>(Loc, &BodyB);
 
-  builder.setInsertionPointToStart(&condB);
+  builder.setInsertionPointToStart(&CondB);
 
-  if (auto *s = fors->getCond()) {
-    auto condRes = Visit(s);
-    auto cond = condRes.getValue(builder);
-    if (auto LT = cond.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
-      auto nullptr_llvm = builder.create<mlir::LLVM::NullOp>(loc, LT);
-      cond = builder.create<mlir::LLVM::ICmpOp>(
-          loc, mlir::LLVM::ICmpPredicate::ne, cond, nullptr_llvm);
+  if (auto *S = Fors->getCond()) {
+    auto CondRes = Visit(S);
+    auto Cond = CondRes.getValue(builder);
+    if (auto LT = Cond.getType().dyn_cast<LLVM::LLVMPointerType>()) {
+      auto NullptrLlvm = builder.create<LLVM::NullOp>(Loc, LT);
+      Cond = builder.create<LLVM::ICmpOp>(Loc, LLVM::ICmpPredicate::ne, Cond,
+                                          NullptrLlvm);
     }
-    auto ty = cond.getType().cast<mlir::IntegerType>();
-    if (ty.getWidth() != 1) {
-      cond = builder.create<arith::CmpIOp>(
-          loc, CmpIPredicate::ne, cond,
-          builder.create<ConstantIntOp>(loc, 0, ty));
+    auto Ty = Cond.getType().cast<IntegerType>();
+    if (Ty.getWidth() != 1) {
+      Cond = builder.create<arith::CmpIOp>(
+          Loc, arith::CmpIPredicate::ne, Cond,
+          builder.create<arith::ConstantIntOp>(Loc, 0, Ty));
     }
-    auto nb = builder.create<mlir::memref::LoadOp>(loc, loops.back().noBreak,
-                                                   std::vector<mlir::Value>());
-    cond = builder.create<AndIOp>(loc, cond, nb);
-    builder.create<mlir::cf::CondBranchOp>(loc, cond, &bodyB, &exitB);
+    auto Nb = builder.create<memref::LoadOp>(Loc, loops.back().noBreak,
+                                             std::vector<Value>());
+    Cond = builder.create<arith::AndIOp>(Loc, Cond, Nb);
+    builder.create<cf::CondBranchOp>(Loc, Cond, &BodyB, &ExitB);
   }
 
-  builder.setInsertionPointToStart(&bodyB);
-  builder.create<mlir::memref::StoreOp>(
-      loc,
-      builder.create<mlir::memref::LoadOp>(loc, loops.back().noBreak,
-                                           std::vector<mlir::Value>()),
-      loops.back().keepRunning, std::vector<mlir::Value>());
+  builder.setInsertionPointToStart(&BodyB);
+  builder.create<memref::StoreOp>(
+      Loc,
+      builder.create<memref::LoadOp>(Loc, loops.back().noBreak,
+                                     std::vector<Value>()),
+      loops.back().keepRunning, std::vector<Value>());
 
-  Visit(fors->getBody());
+  Visit(Fors->getBody());
   loops.pop_back();
 
-  builder.create<mlir::cf::BranchOp>(loc, &condB);
+  builder.create<cf::BranchOp>(Loc, &CondB);
 
-  builder.setInsertionPointToStart(&exitB);
+  builder.setInsertionPointToStart(&ExitB);
 
   return nullptr;
 }
 
-ValueCategory MLIRScanner::VisitWhileStmt(clang::WhileStmt *fors) {
-  IfScope scope(*this);
+ValueCategory MLIRScanner::VisitWhileStmt(clang::WhileStmt *Fors) {
+  IfScope Scope(*this);
 
-  auto loc = getMLIRLocation(fors->getLParenLoc());
+  Location Loc = getMLIRLocation(Fors->getLParenLoc());
 
-  auto i1Ty = builder.getIntegerType(1);
-  auto type = mlir::MemRefType::get({}, i1Ty, {}, 0);
-  auto truev = builder.create<ConstantIntOp>(loc, true, 1);
-  loops.push_back({builder.create<mlir::memref::AllocaOp>(loc, type),
-                   builder.create<mlir::memref::AllocaOp>(loc, type)});
-  builder.create<mlir::memref::StoreOp>(loc, truev, loops.back().noBreak);
+  auto I1Ty = builder.getIntegerType(1);
+  auto Type = MemRefType::get({}, I1Ty, {}, 0);
+  auto Truev = builder.create<arith::ConstantIntOp>(Loc, true, 1);
+  loops.push_back({builder.create<memref::AllocaOp>(Loc, Type),
+                   builder.create<memref::AllocaOp>(Loc, Type)});
+  builder.create<memref::StoreOp>(Loc, Truev, loops.back().noBreak);
 
-  auto *toadd = builder.getInsertionBlock()->getParent();
-  auto &condB = *(new Block());
-  toadd->getBlocks().push_back(&condB);
-  auto &bodyB = *(new Block());
-  toadd->getBlocks().push_back(&bodyB);
-  auto &exitB = *(new Block());
-  toadd->getBlocks().push_back(&exitB);
+  auto *Toadd = builder.getInsertionBlock()->getParent();
+  auto &CondB = *(new Block());
+  Toadd->getBlocks().push_back(&CondB);
+  auto &BodyB = *(new Block());
+  Toadd->getBlocks().push_back(&BodyB);
+  auto &ExitB = *(new Block());
+  Toadd->getBlocks().push_back(&ExitB);
 
-  builder.create<mlir::cf::BranchOp>(loc, &condB);
+  builder.create<cf::BranchOp>(Loc, &CondB);
 
-  builder.setInsertionPointToStart(&condB);
+  builder.setInsertionPointToStart(&CondB);
 
-  if (auto *s = fors->getCond()) {
-    auto condRes = Visit(s);
-    auto cond = condRes.getValue(builder);
-    if (auto LT = cond.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
-      auto nullptr_llvm = builder.create<mlir::LLVM::NullOp>(loc, LT);
-      cond = builder.create<mlir::LLVM::ICmpOp>(
-          loc, mlir::LLVM::ICmpPredicate::ne, cond, nullptr_llvm);
+  if (auto *S = Fors->getCond()) {
+    auto CondRes = Visit(S);
+    auto Cond = CondRes.getValue(builder);
+    if (auto LT = Cond.getType().dyn_cast<LLVM::LLVMPointerType>()) {
+      auto NullptrLlvm = builder.create<LLVM::NullOp>(Loc, LT);
+      Cond = builder.create<LLVM::ICmpOp>(Loc, LLVM::ICmpPredicate::ne, Cond,
+                                          NullptrLlvm);
     }
-    auto ty = cond.getType().cast<mlir::IntegerType>();
-    if (ty.getWidth() != 1) {
-      cond = builder.create<arith::CmpIOp>(
-          loc, CmpIPredicate::ne, cond,
-          builder.create<ConstantIntOp>(loc, 0, ty));
+    auto Ty = Cond.getType().cast<IntegerType>();
+    if (Ty.getWidth() != 1) {
+      Cond = builder.create<arith::CmpIOp>(
+          Loc, arith::CmpIPredicate::ne, Cond,
+          builder.create<arith::ConstantIntOp>(Loc, 0, Ty));
     }
-    auto nb = builder.create<mlir::memref::LoadOp>(loc, loops.back().noBreak,
-                                                   std::vector<mlir::Value>());
-    cond = builder.create<AndIOp>(loc, cond, nb);
-    builder.create<mlir::cf::CondBranchOp>(loc, cond, &bodyB, &exitB);
+    auto Nb = builder.create<memref::LoadOp>(Loc, loops.back().noBreak,
+                                             std::vector<Value>());
+    Cond = builder.create<arith::AndIOp>(Loc, Cond, Nb);
+    builder.create<cf::CondBranchOp>(Loc, Cond, &BodyB, &ExitB);
   }
 
-  builder.setInsertionPointToStart(&bodyB);
-  builder.create<mlir::memref::StoreOp>(
-      loc,
-      builder.create<mlir::memref::LoadOp>(loc, loops.back().noBreak,
-                                           std::vector<mlir::Value>()),
-      loops.back().keepRunning, std::vector<mlir::Value>());
+  builder.setInsertionPointToStart(&BodyB);
+  builder.create<memref::StoreOp>(
+      Loc,
+      builder.create<memref::LoadOp>(Loc, loops.back().noBreak,
+                                     std::vector<Value>()),
+      loops.back().keepRunning, std::vector<Value>());
 
-  Visit(fors->getBody());
+  Visit(Fors->getBody());
   loops.pop_back();
 
-  builder.create<mlir::cf::BranchOp>(loc, &condB);
+  builder.create<cf::BranchOp>(Loc, &CondB);
 
-  builder.setInsertionPointToStart(&exitB);
+  builder.setInsertionPointToStart(&ExitB);
 
   return nullptr;
 }
 
-ValueCategory MLIRScanner::VisitIfStmt(clang::IfStmt *stmt) {
-  IfScope scope(*this);
-  auto loc = getMLIRLocation(stmt->getIfLoc());
-  auto cond = Visit(stmt->getCond()).getValue(builder);
-  assert(cond != nullptr && "must be a non-null");
+ValueCategory MLIRScanner::VisitIfStmt(clang::IfStmt *Stmt) {
+  IfScope Scope(*this);
+  auto Loc = getMLIRLocation(Stmt->getIfLoc());
+  auto Cond = Visit(Stmt->getCond()).getValue(builder);
+  assert(Cond != nullptr && "must be a non-null");
 
-  auto oldpoint = builder.getInsertionPoint();
-  auto *oldblock = builder.getInsertionBlock();
-  if (auto LT = cond.getType().dyn_cast<MemRefType>()) {
-    cond = builder.create<polygeist::Memref2PointerOp>(
-        loc, LLVM::LLVMPointerType::get(builder.getI8Type()), cond);
+  auto Oldpoint = builder.getInsertionPoint();
+  auto *Oldblock = builder.getInsertionBlock();
+  if (auto LT = Cond.getType().dyn_cast<MemRefType>()) {
+    Cond = builder.create<polygeist::Memref2PointerOp>(
+        Loc, LLVM::LLVMPointerType::get(builder.getI8Type()), Cond);
   }
-  if (auto LT = cond.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
-    auto nullptr_llvm = builder.create<mlir::LLVM::NullOp>(loc, LT);
-    cond = builder.create<mlir::LLVM::ICmpOp>(
-        loc, mlir::LLVM::ICmpPredicate::ne, cond, nullptr_llvm);
+  if (auto LT = Cond.getType().dyn_cast<LLVM::LLVMPointerType>()) {
+    auto NullptrLlvm = builder.create<LLVM::NullOp>(Loc, LT);
+    Cond = builder.create<LLVM::ICmpOp>(Loc, LLVM::ICmpPredicate::ne, Cond,
+                                        NullptrLlvm);
   }
-  if (!cond.getType().isa<mlir::IntegerType>()) {
-    stmt->dump();
-    llvm::errs() << " cond: " << cond << " ct: " << cond.getType() << "\n";
+  if (!Cond.getType().isa<IntegerType>()) {
+    Stmt->dump();
+    llvm::errs() << " cond: " << Cond << " ct: " << Cond.getType() << "\n";
   }
-  auto prevTy = cond.getType().cast<mlir::IntegerType>();
-  if (!prevTy.isInteger(1)) {
-    cond = builder.create<arith::CmpIOp>(
-        loc, CmpIPredicate::ne, cond,
-        builder.create<ConstantIntOp>(loc, 0, prevTy));
+  auto PrevTy = Cond.getType().cast<IntegerType>();
+  if (!PrevTy.isInteger(1)) {
+    Cond = builder.create<arith::CmpIOp>(
+        Loc, arith::CmpIPredicate::ne, Cond,
+        builder.create<arith::ConstantIntOp>(Loc, 0, PrevTy));
   }
-  bool hasElseRegion = stmt->getElse();
-  auto ifOp = builder.create<mlir::scf::IfOp>(loc, cond, hasElseRegion);
+  bool HasElseRegion = Stmt->getElse();
+  auto IfOp = builder.create<scf::IfOp>(Loc, Cond, HasElseRegion);
 
-  ifOp.getThenRegion().back().clear();
-  builder.setInsertionPointToStart(&ifOp.getThenRegion().back());
-  Visit(stmt->getThen());
-  builder.create<scf::YieldOp>(loc);
-  if (hasElseRegion) {
-    ifOp.getElseRegion().back().clear();
-    builder.setInsertionPointToStart(&ifOp.getElseRegion().back());
-    Visit(stmt->getElse());
-    builder.create<scf::YieldOp>(loc);
+  IfOp.getThenRegion().back().clear();
+  builder.setInsertionPointToStart(&IfOp.getThenRegion().back());
+  Visit(Stmt->getThen());
+  builder.create<scf::YieldOp>(Loc);
+  if (HasElseRegion) {
+    IfOp.getElseRegion().back().clear();
+    builder.setInsertionPointToStart(&IfOp.getElseRegion().back());
+    Visit(Stmt->getElse());
+    builder.create<scf::YieldOp>(Loc);
   }
 
-  builder.setInsertionPoint(oldblock, oldpoint);
+  builder.setInsertionPoint(Oldblock, Oldpoint);
   return nullptr;
 }
 
-ValueCategory MLIRScanner::VisitSwitchStmt(clang::SwitchStmt *stmt) {
-  IfScope scope(*this);
-  auto cond = Visit(stmt->getCond()).getValue(builder);
-  assert(cond != nullptr);
-  SmallVector<int64_t> caseVals;
+ValueCategory MLIRScanner::VisitSwitchStmt(clang::SwitchStmt *Stmt) {
+  IfScope Scope(*this);
+  auto Cond = Visit(Stmt->getCond()).getValue(builder);
+  assert(Cond != nullptr);
+  SmallVector<int64_t> CaseVals;
 
-  auto er = builder.create<scf::ExecuteRegionOp>(loc, ArrayRef<mlir::Type>());
-  er.getRegion().push_back(new Block());
-  auto oldpoint2 = builder.getInsertionPoint();
-  auto *oldblock2 = builder.getInsertionBlock();
+  auto Er = builder.create<scf::ExecuteRegionOp>(loc, ArrayRef<Type>());
+  Er.getRegion().push_back(new Block());
+  auto Oldpoint2 = builder.getInsertionPoint();
+  auto *Oldblock2 = builder.getInsertionBlock();
 
-  auto &exitB = *(new Block());
-  builder.setInsertionPointToStart(&exitB);
+  auto &ExitB = *(new Block());
+  builder.setInsertionPointToStart(&ExitB);
   builder.create<scf::YieldOp>(loc);
-  builder.setInsertionPointToStart(&exitB);
+  builder.setInsertionPointToStart(&ExitB);
 
-  SmallVector<Block *> blocks;
-  bool inCase = false;
+  SmallVector<Block *> Blocks;
+  bool InCase = false;
 
-  Block *defaultB = &exitB;
+  Block *DefaultB = &ExitB;
 
-  for (auto *cse : stmt->getBody()->children()) {
-    if (auto *cses = dyn_cast<CaseStmt>(cse)) {
-      auto &condB = *(new Block());
+  for (auto *Cse : Stmt->getBody()->children()) {
+    if (auto *Cses = dyn_cast<clang::CaseStmt>(Cse)) {
+      auto &CondB = *(new Block());
 
-      auto cval = Visit(cses->getLHS());
-      if (!cval.val) {
-        cses->getLHS()->dump();
+      auto Cval = Visit(Cses->getLHS());
+      if (!Cval.val) {
+        Cses->getLHS()->dump();
       }
-      assert(cval.val);
-      auto cint = cval.getValue(builder).getDefiningOp<ConstantIntOp>();
-      if (!cint) {
-        cses->getLHS()->dump();
-        llvm::errs() << "cval: " << cval.val << "\n";
+      assert(Cval.val);
+      auto Cint = Cval.getValue(builder).getDefiningOp<arith::ConstantIntOp>();
+      if (!Cint) {
+        Cses->getLHS()->dump();
+        llvm::errs() << "cval: " << Cval.val << "\n";
       }
-      assert(cint);
-      caseVals.push_back(cint.value());
+      assert(Cint);
+      CaseVals.push_back(Cint.value());
 
-      if (inCase) {
-        auto noBreak =
-            builder.create<mlir::memref::LoadOp>(loc, loops.back().noBreak);
-        builder.create<mlir::cf::CondBranchOp>(loc, noBreak, &condB, &exitB);
+      if (InCase) {
+        auto NoBreak =
+            builder.create<memref::LoadOp>(loc, loops.back().noBreak);
+        builder.create<cf::CondBranchOp>(loc, NoBreak, &CondB, &ExitB);
         loops.pop_back();
       }
 
-      inCase = true;
-      er.getRegion().getBlocks().push_back(&condB);
-      blocks.push_back(&condB);
-      builder.setInsertionPointToStart(&condB);
+      InCase = true;
+      Er.getRegion().getBlocks().push_back(&CondB);
+      Blocks.push_back(&CondB);
+      builder.setInsertionPointToStart(&CondB);
 
-      auto i1Ty = builder.getIntegerType(1);
-      auto type = mlir::MemRefType::get({}, i1Ty, {}, 0);
-      auto truev = builder.create<ConstantIntOp>(loc, true, 1);
-      loops.push_back({builder.create<mlir::memref::AllocaOp>(loc, type),
-                       builder.create<mlir::memref::AllocaOp>(loc, type)});
-      builder.create<mlir::memref::StoreOp>(loc, truev, loops.back().noBreak);
-      builder.create<mlir::memref::StoreOp>(loc, truev,
-                                            loops.back().keepRunning);
-      Visit(cses->getSubStmt());
-    } else if (auto *cses = dyn_cast<DefaultStmt>(cse)) {
-      auto &condB = *(new Block());
+      auto I1Ty = builder.getIntegerType(1);
+      auto Type = MemRefType::get({}, I1Ty, {}, 0);
+      auto Truev = builder.create<arith::ConstantIntOp>(loc, true, 1);
+      loops.push_back({builder.create<memref::AllocaOp>(loc, Type),
+                       builder.create<memref::AllocaOp>(loc, Type)});
+      builder.create<memref::StoreOp>(loc, Truev, loops.back().noBreak);
+      builder.create<memref::StoreOp>(loc, Truev, loops.back().keepRunning);
+      Visit(Cses->getSubStmt());
+    } else if (auto *Cses = dyn_cast<clang::DefaultStmt>(Cse)) {
+      auto &CondB = *(new Block());
 
-      if (inCase) {
-        auto noBreak =
-            builder.create<mlir::memref::LoadOp>(loc, loops.back().noBreak);
-        builder.create<mlir::cf::CondBranchOp>(loc, noBreak, &condB, &exitB);
+      if (InCase) {
+        auto NoBreak =
+            builder.create<memref::LoadOp>(loc, loops.back().noBreak);
+        builder.create<cf::CondBranchOp>(loc, NoBreak, &CondB, &ExitB);
         loops.pop_back();
       }
 
-      inCase = true;
-      er.getRegion().getBlocks().push_back(&condB);
-      builder.setInsertionPointToStart(&condB);
+      InCase = true;
+      Er.getRegion().getBlocks().push_back(&CondB);
+      builder.setInsertionPointToStart(&CondB);
 
-      auto i1Ty = builder.getIntegerType(1);
-      auto type = mlir::MemRefType::get({}, i1Ty, {}, 0);
-      auto truev = builder.create<ConstantIntOp>(loc, true, 1);
-      loops.push_back({builder.create<mlir::memref::AllocaOp>(loc, type),
-                       builder.create<mlir::memref::AllocaOp>(loc, type)});
-      builder.create<mlir::memref::StoreOp>(loc, truev, loops.back().noBreak);
-      builder.create<mlir::memref::StoreOp>(loc, truev,
-                                            loops.back().keepRunning);
-      defaultB = &condB;
-      Visit(cses->getSubStmt());
+      auto I1Ty = builder.getIntegerType(1);
+      auto Type = MemRefType::get({}, I1Ty, {}, 0);
+      auto Truev = builder.create<arith::ConstantIntOp>(loc, true, 1);
+      loops.push_back({builder.create<memref::AllocaOp>(loc, Type),
+                       builder.create<memref::AllocaOp>(loc, Type)});
+      builder.create<memref::StoreOp>(loc, Truev, loops.back().noBreak);
+      builder.create<memref::StoreOp>(loc, Truev, loops.back().keepRunning);
+      DefaultB = &CondB;
+      Visit(Cses->getSubStmt());
     } else {
-      Visit(cse);
+      Visit(Cse);
     }
   }
 
-  if (caseVals.size() == 0) {
-    delete &exitB;
-    er.erase();
-    builder.setInsertionPoint(oldblock2, oldpoint2);
+  if (CaseVals.size() == 0) {
+    delete &ExitB;
+    Er.erase();
+    builder.setInsertionPoint(Oldblock2, Oldpoint2);
     return nullptr;
   }
 
-  if (inCase)
+  if (InCase)
     loops.pop_back();
-  builder.create<mlir::cf::BranchOp>(loc, &exitB);
+  builder.create<cf::BranchOp>(loc, &ExitB);
 
-  er.getRegion().getBlocks().push_back(&exitB);
+  Er.getRegion().getBlocks().push_back(&ExitB);
 
-  DenseIntElementsAttr caseValuesAttr;
-  ShapedType caseValueType = mlir::VectorType::get(
-      static_cast<int64_t>(caseVals.size()), cond.getType());
-  auto ity = cond.getType().cast<mlir::IntegerType>();
-  if (ity.getWidth() == 64)
-    caseValuesAttr = DenseIntElementsAttr::get(caseValueType, caseVals);
-  else if (ity.getWidth() == 32) {
-    SmallVector<int32_t> caseVals32;
-    for (auto v : caseVals)
-      caseVals32.push_back((int32_t)v);
-    caseValuesAttr = DenseIntElementsAttr::get(caseValueType, caseVals32);
-  } else if (ity.getWidth() == 16) {
-    SmallVector<int16_t> caseVals16;
-    for (auto v : caseVals)
-      caseVals16.push_back((int16_t)v);
-    caseValuesAttr = DenseIntElementsAttr::get(caseValueType, caseVals16);
+  DenseIntElementsAttr CaseValuesAttr;
+  ShapedType CaseValueType =
+      VectorType::get(static_cast<int64_t>(CaseVals.size()), Cond.getType());
+  auto Ity = Cond.getType().cast<IntegerType>();
+  if (Ity.getWidth() == 64)
+    CaseValuesAttr = DenseIntElementsAttr::get(CaseValueType, CaseVals);
+  else if (Ity.getWidth() == 32) {
+    SmallVector<int32_t> CaseVals32;
+    for (auto V : CaseVals)
+      CaseVals32.push_back((int32_t)V);
+    CaseValuesAttr = DenseIntElementsAttr::get(CaseValueType, CaseVals32);
+  } else if (Ity.getWidth() == 16) {
+    SmallVector<int16_t> CaseVals16;
+    for (auto V : CaseVals)
+      CaseVals16.push_back((int16_t)V);
+    CaseValuesAttr = DenseIntElementsAttr::get(CaseValueType, CaseVals16);
   } else {
-    assert(ity.getWidth() == 8);
-    SmallVector<int8_t> caseVals8;
-    for (auto v : caseVals)
-      caseVals8.push_back((int8_t)v);
-    caseValuesAttr = DenseIntElementsAttr::get(caseValueType, caseVals8);
+    assert(Ity.getWidth() == 8);
+    SmallVector<int8_t> CaseVals8;
+    for (auto V : CaseVals)
+      CaseVals8.push_back((int8_t)V);
+    CaseValuesAttr = DenseIntElementsAttr::get(CaseValueType, CaseVals8);
   }
 
-  builder.setInsertionPointToStart(&er.getRegion().front());
-  builder.create<mlir::cf::SwitchOp>(
-      loc, cond, defaultB, ArrayRef<mlir::Value>(), caseValuesAttr, blocks,
-      SmallVector<mlir::ValueRange>(caseVals.size(), ArrayRef<mlir::Value>()));
-  builder.setInsertionPoint(oldblock2, oldpoint2);
+  builder.setInsertionPointToStart(&Er.getRegion().front());
+  builder.create<cf::SwitchOp>(
+      loc, Cond, DefaultB, ArrayRef<Value>(), CaseValuesAttr, Blocks,
+      SmallVector<ValueRange>(CaseVals.size(), ArrayRef<Value>()));
+  builder.setInsertionPoint(Oldblock2, Oldpoint2);
   return nullptr;
 }
 
-ValueCategory MLIRScanner::VisitDeclStmt(clang::DeclStmt *decl) {
+ValueCategory MLIRScanner::VisitDeclStmt(clang::DeclStmt *Decl) {
   LLVM_DEBUG({
     llvm::dbgs() << "VisitDeclStmt: ";
-    decl->dump();
+    Decl->dump();
     llvm::dbgs() << "\n";
   });
 
-  IfScope scope(*this);
-  for (auto *sub : decl->decls()) {
-    if (auto *vd = dyn_cast<VarDecl>(sub)) {
-      VisitVarDecl(vd);
-    } else if (isa<TypeAliasDecl, RecordDecl, StaticAssertDecl, TypedefDecl,
-                   UsingDecl, UsingDirectiveDecl>(sub)) {
+  IfScope Scope(*this);
+  for (auto *Sub : Decl->decls()) {
+    if (auto *Vd = dyn_cast<clang::VarDecl>(Sub)) {
+      VisitVarDecl(Vd);
+    } else if (isa<clang::TypeAliasDecl, clang::RecordDecl,
+                   clang::StaticAssertDecl, clang::TypedefDecl,
+                   clang::UsingDecl, clang::UsingDirectiveDecl>(Sub)) {
     } else {
-      emitError(getMLIRLocation(decl->getBeginLoc()))
+      emitError(getMLIRLocation(Decl->getBeginLoc()))
           << " + visiting unknonwn sub decl stmt\n";
-      sub->dump();
+      Sub->dump();
       assert(0 && "unknown sub decl");
     }
   }
   return nullptr;
 }
 
-ValueCategory MLIRScanner::VisitAttributedStmt(AttributedStmt *AS) {
+ValueCategory MLIRScanner::VisitAttributedStmt(clang::AttributedStmt *AS) {
   emitWarning(getMLIRLocation(AS->getAttrLoc())) << "ignoring attributes\n";
   return Visit(AS->getSubStmt());
 }
 
-ValueCategory MLIRScanner::VisitCompoundStmt(clang::CompoundStmt *stmt) {
-  for (auto *a : stmt->children()) {
-    IfScope scope(*this);
-    Visit(a);
+ValueCategory MLIRScanner::VisitCompoundStmt(clang::CompoundStmt *Stmt) {
+  for (auto *A : Stmt->children()) {
+    IfScope Scope(*this);
+    Visit(A);
   }
   return nullptr;
 }
 
-ValueCategory MLIRScanner::VisitBreakStmt(clang::BreakStmt *stmt) {
-  IfScope scope(*this);
+ValueCategory MLIRScanner::VisitBreakStmt(clang::BreakStmt *Stmt) {
+  IfScope Scope(*this);
   assert(loops.size() && "must be non-empty");
   assert(loops.back().keepRunning && "keep running false");
   assert(loops.back().noBreak && "no break false");
-  auto vfalse =
-      builder.create<ConstantIntOp>(builder.getUnknownLoc(), false, 1);
-  builder.create<mlir::memref::StoreOp>(loc, vfalse, loops.back().keepRunning);
-  builder.create<mlir::memref::StoreOp>(loc, vfalse, loops.back().noBreak);
+  auto Vfalse =
+      builder.create<arith::ConstantIntOp>(builder.getUnknownLoc(), false, 1);
+  builder.create<memref::StoreOp>(loc, Vfalse, loops.back().keepRunning);
+  builder.create<memref::StoreOp>(loc, Vfalse, loops.back().noBreak);
 
   return nullptr;
 }
 
-ValueCategory MLIRScanner::VisitContinueStmt(clang::ContinueStmt *stmt) {
-  IfScope scope(*this);
+ValueCategory MLIRScanner::VisitContinueStmt(clang::ContinueStmt *Stmt) {
+  IfScope Scope(*this);
   assert(loops.size() && "must be non-empty");
   assert(loops.back().keepRunning && "keep running false");
-  auto vfalse =
-      builder.create<ConstantIntOp>(builder.getUnknownLoc(), false, 1);
-  builder.create<mlir::memref::StoreOp>(loc, vfalse, loops.back().keepRunning);
+  auto Vfalse =
+      builder.create<arith::ConstantIntOp>(builder.getUnknownLoc(), false, 1);
+  builder.create<memref::StoreOp>(loc, Vfalse, loops.back().keepRunning);
   return nullptr;
 }
 
-ValueCategory MLIRScanner::VisitLabelStmt(clang::LabelStmt *stmt) {
-  auto *toadd = builder.getInsertionBlock()->getParent();
-  Block *labelB;
-  auto found = labels.find(stmt);
-  if (found != labels.end()) {
-    labelB = found->second;
+ValueCategory MLIRScanner::VisitLabelStmt(clang::LabelStmt *Stmt) {
+  auto *Toadd = builder.getInsertionBlock()->getParent();
+  Block *LabelB;
+  auto Found = labels.find(Stmt);
+  if (Found != labels.end()) {
+    LabelB = Found->second;
   } else {
-    labelB = new Block();
-    labels[stmt] = labelB;
+    LabelB = new Block();
+    labels[Stmt] = LabelB;
   }
-  toadd->getBlocks().push_back(labelB);
-  builder.create<mlir::cf::BranchOp>(loc, labelB);
-  builder.setInsertionPointToStart(labelB);
-  Visit(stmt->getSubStmt());
+  Toadd->getBlocks().push_back(LabelB);
+  builder.create<cf::BranchOp>(loc, LabelB);
+  builder.setInsertionPointToStart(LabelB);
+  Visit(Stmt->getSubStmt());
   return nullptr;
 }
 
-ValueCategory MLIRScanner::VisitGotoStmt(clang::GotoStmt *stmt) {
-  auto *labelstmt = stmt->getLabel()->getStmt();
-  Block *labelB;
-  auto found = labels.find(labelstmt);
-  if (found != labels.end()) {
-    labelB = found->second;
+ValueCategory MLIRScanner::VisitGotoStmt(clang::GotoStmt *Stmt) {
+  auto *Labelstmt = Stmt->getLabel()->getStmt();
+  Block *LabelB;
+  auto Found = labels.find(Labelstmt);
+  if (Found != labels.end()) {
+    LabelB = Found->second;
   } else {
-    labelB = new Block();
-    labels[labelstmt] = labelB;
+    LabelB = new Block();
+    labels[Labelstmt] = LabelB;
   }
-  builder.create<mlir::cf::BranchOp>(loc, labelB);
+  builder.create<cf::BranchOp>(loc, LabelB);
   return nullptr;
 }
 
-ValueCategory MLIRScanner::VisitCXXTryStmt(clang::CXXTryStmt *stmt) {
+ValueCategory MLIRScanner::VisitCXXTryStmt(clang::CXXTryStmt *Stmt) {
   llvm::errs() << "warning, not performing catches for try: ";
-  stmt->dump();
-  return Visit(stmt->getTryBlock());
+  Stmt->dump();
+  return Visit(Stmt->getTryBlock());
 }
 
-ValueCategory MLIRScanner::VisitReturnStmt(clang::ReturnStmt *stmt) {
-  IfScope scope(*this);
-  bool isArrayReturn = false;
+ValueCategory MLIRScanner::VisitReturnStmt(clang::ReturnStmt *Stmt) {
+  IfScope Scope(*this);
+  bool IsArrayReturn = false;
   Glob.getTypes().getMLIRType(EmittingFunctionDecl->getReturnType(),
-                              &isArrayReturn);
+                              &IsArrayReturn);
 
-  if (isArrayReturn) {
-    auto rv = Visit(stmt->getRetValue());
-    assert(rv.val && "expect right value to be valid");
-    assert(rv.isReference && "right value must be a reference");
-    auto op = function.getArgument(function.getNumArguments() - 1);
-    assert(rv.val.getType().cast<MemRefType>().getElementType() ==
-               op.getType().cast<MemRefType>().getElementType() &&
+  if (IsArrayReturn) {
+    auto Rv = Visit(Stmt->getRetValue());
+    assert(Rv.val && "expect right value to be valid");
+    assert(Rv.isReference && "right value must be a reference");
+    auto Op = function.getArgument(function.getNumArguments() - 1);
+    assert(Rv.val.getType().cast<MemRefType>().getElementType() ==
+               Op.getType().cast<MemRefType>().getElementType() &&
            "type mismatch");
-    assert(op.getType().cast<MemRefType>().getShape().size() == 2 &&
+    assert(Op.getType().cast<MemRefType>().getShape().size() == 2 &&
            "expect 2d memref");
-    assert(rv.val.getType().cast<MemRefType>().getShape().size() == 2 &&
+    assert(Rv.val.getType().cast<MemRefType>().getShape().size() == 2 &&
            "expect 2d memref");
-    assert(rv.val.getType().cast<MemRefType>().getShape()[1] ==
-           op.getType().cast<MemRefType>().getShape()[1]);
+    assert(Rv.val.getType().cast<MemRefType>().getShape()[1] ==
+           Op.getType().cast<MemRefType>().getShape()[1]);
 
-    for (int i = 0; i < op.getType().cast<MemRefType>().getShape()[1]; i++) {
-      std::vector<mlir::Value> idx = {getConstantIndex(0), getConstantIndex(i)};
-      assert(rv.val.getType().cast<MemRefType>().getShape().size() == 2);
-      builder.create<mlir::memref::StoreOp>(
-          loc, builder.create<mlir::memref::LoadOp>(loc, rv.val, idx), op, idx);
+    for (int I = 0; I < Op.getType().cast<MemRefType>().getShape()[1]; I++) {
+      std::vector<Value> Idx = {getConstantIndex(0), getConstantIndex(I)};
+      assert(Rv.val.getType().cast<MemRefType>().getShape().size() == 2);
+      builder.create<memref::StoreOp>(
+          loc, builder.create<memref::LoadOp>(loc, Rv.val, Idx), Op, Idx);
     }
-  } else if (stmt->getRetValue()) {
-    auto rv = Visit(stmt->getRetValue());
-    if (!stmt->getRetValue()->getType()->isVoidType()) {
-      if (!rv.val) {
-        stmt->dump();
+  } else if (Stmt->getRetValue()) {
+    auto Rv = Visit(Stmt->getRetValue());
+    if (!Stmt->getRetValue()->getType()->isVoidType()) {
+      if (!Rv.val) {
+        Stmt->dump();
       }
-      assert(rv.val && "expect right value to be valid");
+      assert(Rv.val && "expect right value to be valid");
 
-      mlir::Value val;
-      if (stmt->getRetValue()->isLValue() || stmt->getRetValue()->isXValue()) {
-        assert(rv.isReference);
-        val = rv.val;
+      Value Val;
+      if (Stmt->getRetValue()->isLValue() || Stmt->getRetValue()->isXValue()) {
+        assert(Rv.isReference);
+        Val = Rv.val;
       } else {
-        val = rv.getValue(builder);
+        Val = Rv.getValue(builder);
       }
 
-      auto postTy = returnVal.getType().cast<MemRefType>().getElementType();
-      if (auto prevTy = val.getType().dyn_cast<mlir::IntegerType>()) {
-        const auto SrcTy = stmt->getRetValue()->getType();
+      auto PostTy = returnVal.getType().cast<MemRefType>().getElementType();
+      if (auto PrevTy = Val.getType().dyn_cast<IntegerType>()) {
+        const auto SrcTy = Stmt->getRetValue()->getType();
         const auto IsSigned =
             SrcTy->isBooleanType() ? false : SrcTy->isSignedIntegerType();
-        val = rv.IntCast(builder, getMLIRLocation(stmt->getReturnLoc()), postTy,
+        Val = Rv.IntCast(builder, getMLIRLocation(Stmt->getReturnLoc()), PostTy,
                          IsSigned)
                   .val;
-      } else if (val.getType().isa<MemRefType>() &&
-                 postTy.isa<LLVM::LLVMPointerType>())
-        val = builder.create<polygeist::Memref2PointerOp>(loc, postTy, val);
-      else if (val.getType().isa<LLVM::LLVMPointerType>() &&
-               postTy.isa<MemRefType>())
-        val = builder.create<polygeist::Pointer2MemrefOp>(loc, postTy, val);
-      if (postTy != val.getType()) {
-        stmt->dump();
-        llvm::errs() << " val: " << val << " postTy: " << postTy
-                     << " rv.val: " << rv.val << " rv.isRef"
-                     << (int)rv.isReference << " mm: "
-                     << (int)(stmt->getRetValue()->isLValue() ||
-                              stmt->getRetValue()->isXValue())
+      } else if (Val.getType().isa<MemRefType>() &&
+                 PostTy.isa<LLVM::LLVMPointerType>())
+        Val = builder.create<polygeist::Memref2PointerOp>(loc, PostTy, Val);
+      else if (Val.getType().isa<LLVM::LLVMPointerType>() &&
+               PostTy.isa<MemRefType>())
+        Val = builder.create<polygeist::Pointer2MemrefOp>(loc, PostTy, Val);
+      if (PostTy != Val.getType()) {
+        Stmt->dump();
+        llvm::errs() << " val: " << Val << " postTy: " << PostTy
+                     << " rv.val: " << Rv.val << " rv.isRef"
+                     << (int)Rv.isReference << " mm: "
+                     << (int)(Stmt->getRetValue()->isLValue() ||
+                              Stmt->getRetValue()->isXValue())
                      << "\n";
       }
-      assert(postTy == val.getType());
-      builder.create<mlir::memref::StoreOp>(loc, val, returnVal);
+      assert(PostTy == Val.getType());
+      builder.create<memref::StoreOp>(loc, Val, returnVal);
     }
   }
 
   assert(loops.size() && "must be non-empty");
-  auto vfalse =
-      builder.create<ConstantIntOp>(builder.getUnknownLoc(), false, 1);
-  for (auto l : loops) {
-    builder.create<mlir::memref::StoreOp>(loc, vfalse, l.keepRunning);
-    builder.create<mlir::memref::StoreOp>(loc, vfalse, l.noBreak);
+  auto Vfalse =
+      builder.create<arith::ConstantIntOp>(builder.getUnknownLoc(), false, 1);
+  for (auto L : loops) {
+    builder.create<memref::StoreOp>(loc, Vfalse, L.keepRunning);
+    builder.create<memref::StoreOp>(loc, Vfalse, L.noBreak);
   }
 
   return nullptr;


### PR DESCRIPTION
Remove non-mlir `using namespace`.

This PR fixes some clang-tidy warnings:
   - change variable names to start with upper case
   - remove use of else after if branch with a return