### PR TITLE
[SYCL][Level Zero] Use MemAdvise for read-only shared allocs

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -8077,7 +8077,6 @@ static pi_result USMSharedAllocImpl(void **ResultPtr, pi_context Context,
                                     pi_device Device,
                                     pi_usm_mem_properties *Properties,
                                     size_t Size, pi_uint32 Alignment) {
-  (void)Properties;
   PI_ASSERT(Context, PI_ERROR_INVALID_CONTEXT);
   PI_ASSERT(Device, PI_ERROR_INVALID_DEVICE);
 
@@ -8101,6 +8100,31 @@ static pi_result USMSharedAllocImpl(void **ResultPtr, pi_context Context,
   PI_ASSERT(Alignment == 0 ||
                 reinterpret_cast<std::uintptr_t>(*ResultPtr) % Alignment == 0,
             PI_ERROR_INVALID_VALUE);
+
+  // See if the memory is going to be read-only on the device.
+  bool DeviceReadOnly = false;
+  // Check that incorrect bits are not set in the properties.
+  if (Properties && *Properties != 0) {
+    PI_ASSERT(*(Properties) == PI_MEM_ALLOC_FLAGS && *(Properties + 2) == 0,
+              PI_ERROR_INVALID_VALUE);
+    DeviceReadOnly = *(Properties + 1) & PI_MEM_ALLOC_DEVICE_READ_ONLY;
+  }
+  if (!DeviceReadOnly)
+    return PI_SUCCESS;
+
+  // For read-only memory, let L0 know about that by using advises.
+
+  // zeCommandListAppendMemAdvise must not be called from simultaneous threads
+  // with the same command list handle.
+  std::scoped_lock<pi_mutex> Lock(Context->ImmediateCommandListMutex);
+
+  ZE_CALL(zeCommandListAppendMemAdvise,
+          (Context->ZeCommandListInit, Device->ZeDevice, *ResultPtr, Size,
+           ZE_MEMORY_ADVICE_SET_READ_MOSTLY));
+
+  ZE_CALL(zeCommandListAppendMemAdvise,
+          (Context->ZeCommandListInit, Device->ZeDevice, *ResultPtr, Size,
+           ZE_MEMORY_ADVICE_SET_PREFERRED_LOCATION));
 
   return PI_SUCCESS;
 }
@@ -8153,7 +8177,9 @@ pi_result USMSharedMemoryAlloc::allocateImpl(void **ResultPtr, size_t Size,
 pi_result USMSharedReadOnlyMemoryAlloc::allocateImpl(void **ResultPtr,
                                                      size_t Size,
                                                      pi_uint32 Alignment) {
-  return USMSharedAllocImpl(ResultPtr, Context, Device, nullptr, Size,
+  pi_usm_mem_properties Props[] = {PI_MEM_ALLOC_FLAGS,
+                                   PI_MEM_ALLOC_DEVICE_READ_ONLY, 0};
+  return USMSharedAllocImpl(ResultPtr, Context, Device, Props, Size,
                             Alignment);
 }
 


### PR DESCRIPTION
Those don't affect stability:

 > Memory advice is a performance hint only and is not required for
 > functional correctness.