### PR TITLE
[SYCL-MLIR] Fix unsupported functions

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
@@ -411,7 +411,8 @@ public:
 class AccessorCommonType
     : public Type::TypeBase<AccessorCommonType, Type,
                             detail::AccessorCommonTypeStorage,
-                            mlir::MemRefElementTypeInterface::Trait> {
+                            mlir::MemRefElementTypeInterface::Trait,
+                            mlir::LLVM::PointerElementTypeInterface::Trait> {
 public:
   using Base::Base;
 

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -250,6 +250,10 @@ ValueCategory MLIRScanner::callHelper(
           ExpectedType.isa<MemRefType>())
         Val =
             Builder.create<polygeist::Pointer2MemrefOp>(Loc, ExpectedType, Val);
+      else if (Val.getType().isa<MemRefType>() &&
+               ExpectedType.isa<LLVM::LLVMPointerType>())
+        Val =
+            Builder.create<polygeist::Memref2PointerOp>(Loc, ExpectedType, Val);
 
       Val = castToMemSpaceOfType(Val, ExpectedType);
     }

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1028,8 +1028,6 @@ llvm::Optional<sycl::SYCLMethodOpInterface> MLIRScanner::createSYCLMethodOp(
 mlir::Operation *
 MLIRScanner::emitSYCLOps(const clang::Expr *Expr,
                          const llvm::SmallVectorImpl<mlir::Value> &Args) {
-  mlir::Operation *Op = nullptr;
-
   const FunctionDecl *Func = nullptr;
   if (const auto *ConsExpr = dyn_cast<clang::CXXConstructExpr>(Expr)) {
     Func = ConsExpr->getConstructor()->getAsFunction();
@@ -1038,41 +1036,41 @@ MLIRScanner::emitSYCLOps(const clang::Expr *Expr,
       if (const auto *RD = dyn_cast<clang::CXXRecordDecl>(Func->getParent())) {
         std::string Name =
             MLIRScanner::getMangledFuncName(*Func, Glob.getCGM());
-        if (!RD->getName().empty()) {
-          Op = Builder.create<mlir::sycl::SYCLConstructorOp>(Loc, RD->getName(),
-                                                             Name, Args);
-          return Op;
-        }
+        if (!RD->getName().empty())
+          return Builder.create<mlir::sycl::SYCLConstructorOp>(
+              Loc, RD->getName(), Name, Args);
       }
   }
 
+  mlir::Operation *Op = nullptr;
   if (const auto *CallExpr = dyn_cast<clang::CallExpr>(Expr))
     Func = CallExpr->getCalleeDecl()->getAsFunction();
 
-  if (mlirclang::isNamespaceSYCL(Func->getEnclosingNamespaceContext())) {
-    auto OptFuncType = llvm::Optional<llvm::StringRef>{llvm::None};
-    if (const auto *RD = dyn_cast<clang::CXXRecordDecl>(Func->getParent()))
-      if (!RD->getName().empty())
-        OptFuncType = RD->getName();
+  if (Func)
+    if (mlirclang::isNamespaceSYCL(Func->getEnclosingNamespaceContext())) {
+      auto OptFuncType = llvm::Optional<llvm::StringRef>{llvm::None};
+      if (const auto *RD = dyn_cast<clang::CXXRecordDecl>(Func->getParent()))
+        if (!RD->getName().empty())
+          OptFuncType = RD->getName();
 
-    auto OptRetType = llvm::Optional<mlir::Type>{llvm::None};
-    const mlir::Type RetType =
-        Glob.getTypes().getMLIRType(Func->getReturnType());
-    if (!RetType.isa<mlir::NoneType>())
-      OptRetType = RetType;
+      auto OptRetType = llvm::Optional<mlir::Type>{llvm::None};
+      const mlir::Type RetType =
+          Glob.getTypes().getMLIRType(Func->getReturnType());
+      if (!RetType.isa<mlir::NoneType>())
+        OptRetType = RetType;
 
-    std::string Name = MLIRScanner::getMangledFuncName(*Func, Glob.getCGM());
-    if (OptFuncType) {
-      // Attempt to create a SYCL method call first, if that fails create a
-      // generic SYCLCallOp.
-      Op = createSYCLMethodOp(*OptFuncType, Func->getNameAsString(), Args,
-                              OptRetType, Name)
-               .value_or(nullptr);
+      std::string Name = MLIRScanner::getMangledFuncName(*Func, Glob.getCGM());
+      if (OptFuncType) {
+        // Attempt to create a SYCL method call first, if that fails create a
+        // generic SYCLCallOp.
+        Op = createSYCLMethodOp(*OptFuncType, Func->getNameAsString(), Args,
+                                OptRetType, Name)
+                 .value_or(nullptr);
+      }
+      if (!Op)
+        Op = Builder.create<mlir::sycl::SYCLCallOp>(
+            Loc, OptRetType, OptFuncType, Func->getNameAsString(), Name, Args);
     }
-    if (!Op)
-      Op = Builder.create<mlir::sycl::SYCLCallOp>(
-          Loc, OptRetType, OptFuncType, Func->getNameAsString(), Name, Args);
-  }
 
   return Op;
 }

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -73,21 +73,7 @@ MLIRScanner::MLIRScanner(MLIRASTConsumer &Glob, OwningOpRef<ModuleOp> &Module,
       CaptureKinds(), ThisCapture(nullptr), ArrayInit(), ThisVal(), ReturnVal(),
       LTInfo(LTInfo) {}
 
-void MLIRScanner::initUnsupportedFunctions() {
-  // FIXME: cgeist: llvm/polygeist/tools/cgeist/Lib/clang-mlir.cc:95: void
-  // checkFunctionParent(mlir::FunctionOpInterface, FunctionContext, const
-  // mlir::OwningOpRef<mlir::ModuleOp>&): Assertion `(Context !=
-  // FunctionContext::Host || F->getParentOp() == module.get()) && "New function
-  // must be inserted into global module"' failed.
-  unsupportedFuncs.insert(
-      "_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_"
-      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
-      "listIJEEEEC1ERKSA_");
-  unsupportedFuncs.insert(
-      "_ZN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_"
-      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
-      "listIJEEEEC1ERKSA_");
-}
+void MLIRScanner::initUnsupportedFunctions() {}
 
 static void checkFunctionParent(const FunctionOpInterface F,
                                 FunctionContext Context,
@@ -2216,7 +2202,7 @@ MLIRASTConsumer::getOrCreateCGFunctionInfo(const clang::FunctionDecl *FD) {
 
 void MLIRASTConsumer::run() {
   while (FunctionsToEmit.size()) {
-    FunctionToEmit &FTE = FunctionsToEmit.front();
+    FunctionToEmit FTE = FunctionsToEmit.front();
     FunctionsToEmit.pop_front();
 
     const clang::FunctionDecl &FD = FTE.getDecl();

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -74,13 +74,17 @@ MLIRScanner::MLIRScanner(MLIRASTConsumer &Glob, OwningOpRef<ModuleOp> &Module,
       LTInfo(LTInfo) {}
 
 void MLIRScanner::initUnsupportedFunctions() {
-  // FIXME: cgeist: llvm/polygeist/tools/cgeist/Lib/clang-mlir.cc:119: void
+  // FIXME: cgeist: llvm/polygeist/tools/cgeist/Lib/clang-mlir.cc:95: void
   // checkFunctionParent(mlir::FunctionOpInterface, FunctionContext, const
   // mlir::OwningOpRef<mlir::ModuleOp>&): Assertion `(Context !=
   // FunctionContext::Host || F->getParentOp() == module.get()) && "New function
   // must be inserted into global module"' failed.
   unsupportedFuncs.insert(
       "_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_"
+      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
+      "listIJEEEEC1ERKSA_");
+  unsupportedFuncs.insert(
+      "_ZN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_"
       "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
       "listIJEEEEC1ERKSA_");
 }

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -74,16 +74,13 @@ MLIRScanner::MLIRScanner(MLIRASTConsumer &Glob, OwningOpRef<ModuleOp> &Module,
       LTInfo(LTInfo) {}
 
 void MLIRScanner::initUnsupportedFunctions() {
-  // FIXME: cgeist: llvm/polygeist/tools/cgeist/Lib/CGCall.cc:94: void
-  // castCallerArgs(func::FuncOp, llvm::SmallVectorImpl<Value>&,
-  // OpBuilder&): Assertion `CalleeArgType == Args[I].getType() &&
-  // "Callsite argument mismatch"' failed.
-  UnsupportedFuncs.insert(
+  // FIXME: cgeist: llvm/polygeist/tools/cgeist/Lib/clang-mlir.cc:119: void
+  // checkFunctionParent(mlir::FunctionOpInterface, FunctionContext, const
+  // mlir::OwningOpRef<mlir::ModuleOp>&): Assertion `(Context !=
+  // FunctionContext::Host || F->getParentOp() == module.get()) && "New function
+  // must be inserted into global module"' failed.
+  unsupportedFuncs.insert(
       "_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_"
-      "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
-      "listIJEEEEC1ERKSA_");
-  UnsupportedFuncs.insert(
-      "_ZN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_"
       "6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_"
       "listIJEEEEC1ERKSA_");
 }


### PR DESCRIPTION
To fix failures with unsupported functions: 

1. Add `PointerElementTypeInterface::Trait` to `AccessorCommonType`.

2. Fix callsite argument mismatch.

3. Constructor `_ZN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEUt_C1ERKSB_` has the anonymous union as parent `CXXRecordDecl`. `sycl.constructor` requires the first operand to be a sycl type, but it is not. In this PR, instead of creating a `sycl.constructor`, we create `sycl.call` for this kind of constructor.
```
class accessor {
  union {
    ConcreteASPtrType MData;
  };
};
```

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>