### PR TITLE
[SYCL-MLIR][NFC]: Code cleanup

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -29,11 +29,10 @@ extern llvm::cl::opt<bool> GenerateAllSYCLFuncs;
 /// callee arg type. We only deal with the cast where src and dst have the same
 /// shape size and elem type, and just the first shape differs: src has -1 and
 /// dst has a constant integer.
-static mlir::Value castCallerMemRefArg(mlir::Value CallerArg,
-                                       mlir::Type CalleeArgType,
-                                       mlir::OpBuilder &B) {
-  mlir::OpBuilder::InsertionGuard Guard(B);
-  mlir::Type CallerArgType = CallerArg.getType();
+static Value castCallerMemRefArg(Value CallerArg, Type CalleeArgType,
+                                 OpBuilder &B) {
+  OpBuilder::InsertionGuard Guard(B);
+  Type CallerArgType = CallerArg.getType();
 
   if (MemRefType DstTy = CalleeArgType.dyn_cast_or_null<MemRefType>()) {
     MemRefType SrcTy = CallerArgType.dyn_cast<MemRefType>();
@@ -48,8 +47,8 @@ static mlir::Value castCallerMemRefArg(mlir::Value CallerArg,
                      std::next(DstShape.begin()))) {
         B.setInsertionPointAfterValue(CallerArg);
 
-        return B.create<mlir::memref::CastOp>(CallerArg.getLoc(), CalleeArgType,
-                                              CallerArg);
+        return B.create<memref::CastOp>(CallerArg.getLoc(), CalleeArgType,
+                                        CallerArg);
       }
     }
   }
@@ -63,10 +62,9 @@ static mlir::Value castCallerMemRefArg(mlir::Value CallerArg,
 /// expected type for an arg is memref<10xi8> while the provided is
 /// memref<20xf32>, we will simply ignore the case in this function and wait for
 /// the rest of the pipeline to detect it.
-static void castCallerArgs(mlir::func::FuncOp Callee,
-                           llvm::SmallVectorImpl<mlir::Value> &Args,
-                           mlir::OpBuilder &B) {
-  mlir::FunctionType FuncTy = Callee.getFunctionType();
+static void castCallerArgs(func::FuncOp Callee,
+                           llvm::SmallVectorImpl<Value> &Args, OpBuilder &B) {
+  FunctionType FuncTy = Callee.getFunctionType();
   assert(Args.size() == FuncTy.getNumInputs() &&
          "The caller arguments should have the same size as the number of "
          "callee arguments as the interface.");
@@ -74,13 +72,13 @@ static void castCallerArgs(mlir::func::FuncOp Callee,
   LLVM_DEBUG({
     llvm::dbgs() << "FuncTy: " << FuncTy << "\n";
     llvm::dbgs() << "Args: \n";
-    for (const mlir::Value &arg : Args)
+    for (const Value &arg : Args)
       llvm::dbgs().indent(2) << arg << "\n";
   });
 
   for (unsigned I = 0; I < Args.size(); ++I) {
-    mlir::Type CalleeArgType = FuncTy.getInput(I);
-    mlir::Type CallerArgType = Args[I].getType();
+    Type CalleeArgType = FuncTy.getInput(I);
+    Type CallerArgType = Args[I].getType();
 
     if (CalleeArgType == CallerArgType)
       continue;
@@ -100,15 +98,15 @@ ValueCategory MLIRScanner::callHelper(
     ArrayRef<std::pair<ValueCategory, clang::Expr *>> Arguments,
     clang::QualType RetType, bool RetReference, clang::Expr *Expr,
     const clang::FunctionDecl &Callee) {
-  SmallVector<mlir::Value, 4> Args;
-  mlir::FunctionType FnType = ToCall.getFunctionType();
+  SmallVector<Value, 4> Args;
+  FunctionType FnType = ToCall.getFunctionType();
   const clang::CodeGen::CGFunctionInfo &CalleeInfo =
       Glob.getOrCreateCGFunctionInfo(&Callee);
   auto CalleeArgs = CalleeInfo.arguments();
 
   size_t I = 0;
-  // map from declaration name to mlir::value
-  std::map<std::string, mlir::Value> MapFuncOperands;
+  // map from declaration name to value
+  std::map<std::string, Value> MapFuncOperands;
 
   for (const std::pair<ValueCategory, clang::Expr *> &Pair : Arguments) {
     ValueCategory Arg = std::get<0>(Pair);
@@ -143,7 +141,7 @@ ValueCategory MLIRScanner::callHelper(
 
     bool IsArray = false;
     clang::QualType AType = (I == 0 && A == nullptr) ? ObjType : A->getType();
-    mlir::Type ExpectedType = Glob.getTypes().getMLIRType(AType, &IsArray);
+    Type ExpectedType = Glob.getTypes().getMLIRType(AType, &IsArray);
 
     LLVM_DEBUG({
       llvm::dbgs() << "AType: " << AType << "\n";
@@ -159,7 +157,7 @@ ValueCategory MLIRScanner::callHelper(
             Loc, LLVM::LLVMPointerType::get(PT.getElementType(), 0), Arg.val);
     }
 
-    mlir::Value Val = nullptr;
+    Value Val = nullptr;
     if (!IsReference) {
       if (IsArray) {
         LLVM_DEBUG({
@@ -194,18 +192,17 @@ ValueCategory MLIRScanner::callHelper(
 
         OpBuilder ABuilder(Builder.getContext());
         ABuilder.setInsertionPointToStart(AllocationScope);
-        auto Alloc = ABuilder.create<mlir::memref::AllocaOp>(
-            Loc, mlir::MemRefType::get(Shape, MT.getElementType(),
-                                       MemRefLayoutAttrInterface(),
-                                       MT.getMemorySpace()));
+        auto Alloc = ABuilder.create<memref::AllocaOp>(
+            Loc,
+            MemRefType::get(Shape, MT.getElementType(),
+                            MemRefLayoutAttrInterface(), MT.getMemorySpace()));
         ValueCategory(Alloc, /*isRef*/ true)
             .store(Builder, Arg, /*isArray*/ IsArray);
         Shape[0] = Pshape;
-        Val = Builder.create<mlir::memref::CastOp>(
+        Val = Builder.create<memref::CastOp>(
             Loc,
-            mlir::MemRefType::get(Shape, MT.getElementType(),
-                                  MemRefLayoutAttrInterface(),
-                                  MT.getMemorySpace()),
+            MemRefType::get(Shape, MT.getElementType(),
+                            MemRefLayoutAttrInterface(), MT.getMemorySpace()),
             Alloc);
       } else {
         if (CalleeArgs[I].info.getKind() ==
@@ -218,13 +215,12 @@ ValueCategory MLIRScanner::callHelper(
               Arg.getValue(Builder).getType(),
               Glob.getCGM().getDataLayout().getAllocaAddrSpace(),
               /*IsAlloc*/ true);
-          if (auto MemRefTy = Ty.dyn_cast<mlir::MemRefType>()) {
-            Val = ABuilder.create<mlir::memref::AllocaOp>(Loc, MemRefTy);
-            Val = ABuilder.create<mlir::memref::CastOp>(
-                Loc, mlir::MemRefType::get(-1, Arg.getValue(Builder).getType()),
-                Val);
+          if (auto MemRefTy = Ty.dyn_cast<MemRefType>()) {
+            Val = ABuilder.create<memref::AllocaOp>(Loc, MemRefTy);
+            Val = ABuilder.create<memref::CastOp>(
+                Loc, MemRefType::get(-1, Arg.getValue(Builder).getType()), Val);
           } else
-            Val = ABuilder.create<mlir::LLVM::AllocaOp>(
+            Val = ABuilder.create<LLVM::AllocaOp>(
                 Loc, Ty, ABuilder.create<arith::ConstantIntOp>(Loc, 1, 64), 0);
 
           ValueCategory(Val, /*isRef*/ true)
@@ -237,8 +233,8 @@ ValueCategory MLIRScanner::callHelper(
           Val = Builder.create<polygeist::Pointer2MemrefOp>(Loc, ExpectedType,
                                                             Val);
 
-        if (auto PrevTy = Val.getType().dyn_cast<mlir::IntegerType>()) {
-          auto IPostTy = ExpectedType.cast<mlir::IntegerType>();
+        if (auto PrevTy = Val.getType().dyn_cast<IntegerType>()) {
+          auto IPostTy = ExpectedType.cast<IntegerType>();
           if (PrevTy != IPostTy)
             Val = Builder.create<arith::TruncIOp>(Loc, IPostTy, Val);
         }
@@ -264,8 +260,8 @@ ValueCategory MLIRScanner::callHelper(
 
   // handle lowerto pragma.
   if (LTInfo.SymbolTable.count(ToCall.getName())) {
-    SmallVector<mlir::Value> InputOperands;
-    SmallVector<mlir::Value> OutputOperands;
+    SmallVector<Value> InputOperands;
+    SmallVector<Value> OutputOperands;
     for (StringRef Input : LTInfo.InputSymbol)
       if (MapFuncOperands.find(Input.str()) != MapFuncOperands.end())
         InputOperands.push_back(MapFuncOperands[Input.str()]);
@@ -287,7 +283,7 @@ ValueCategory MLIRScanner::callHelper(
   if (!RetReference)
     Glob.getTypes().getMLIRType(RetType, &IsArrayReturn);
 
-  mlir::Value Alloc;
+  Value Alloc;
   if (IsArrayReturn) {
     auto MT =
         Glob.getTypes()
@@ -304,15 +300,14 @@ ValueCategory MLIRScanner::callHelper(
 
     OpBuilder ABuilder(Builder.getContext());
     ABuilder.setInsertionPointToStart(AllocationScope);
-    Alloc = ABuilder.create<mlir::memref::AllocaOp>(
-        Loc, mlir::MemRefType::get(Shape, MT.getElementType(),
-                                   MemRefLayoutAttrInterface(),
-                                   MT.getMemorySpace()));
+    Alloc = ABuilder.create<memref::AllocaOp>(
+        Loc, MemRefType::get(Shape, MT.getElementType(),
+                             MemRefLayoutAttrInterface(), MT.getMemorySpace()));
     Shape[0] = Pshape;
-    Alloc = Builder.create<mlir::memref::CastOp>(
+    Alloc = Builder.create<memref::CastOp>(
         Loc,
-        mlir::MemRefType::get(Shape, MT.getElementType(),
-                              MemRefLayoutAttrInterface(), MT.getMemorySpace()),
+        MemRefType::get(Shape, MT.getElementType(), MemRefLayoutAttrInterface(),
+                        MT.getMemorySpace()),
         Alloc);
     Args.push_back(Alloc);
   }
@@ -320,22 +315,22 @@ ValueCategory MLIRScanner::callHelper(
   if (auto *CU = dyn_cast<clang::CUDAKernelCallExpr>(Expr)) {
     auto L0 = Visit(CU->getConfig()->getArg(0));
     assert(L0.isReference);
-    mlir::Value Blocks[3];
+    Value Blocks[3];
     for (int I = 0; I < 3; I++) {
-      mlir::Value Val = L0.val;
+      Value Val = L0.val;
       if (auto MT = Val.getType().dyn_cast<MemRefType>()) {
-        mlir::Value Idx[] = {getConstantIndex(0), getConstantIndex(I)};
+        Value Idx[] = {getConstantIndex(0), getConstantIndex(I)};
         assert(MT.getShape().size() == 2);
         Blocks[I] = Builder.create<arith::IndexCastOp>(
-            Loc, mlir::IndexType::get(Builder.getContext()),
-            Builder.create<mlir::memref::LoadOp>(Loc, Val, Idx));
+            Loc, IndexType::get(Builder.getContext()),
+            Builder.create<memref::LoadOp>(Loc, Val, Idx));
       } else {
-        mlir::Value Idx[] = {Builder.create<arith::ConstantIntOp>(Loc, 0, 32),
-                             Builder.create<arith::ConstantIntOp>(Loc, I, 32)};
+        Value Idx[] = {Builder.create<arith::ConstantIntOp>(Loc, 0, 32),
+                       Builder.create<arith::ConstantIntOp>(Loc, I, 32)};
         auto PT = Val.getType().cast<LLVM::LLVMPointerType>();
         auto ET = PT.getElementType().cast<LLVM::LLVMStructType>().getBody()[I];
         Blocks[I] = Builder.create<arith::IndexCastOp>(
-            Loc, mlir::IndexType::get(Builder.getContext()),
+            Loc, IndexType::get(Builder.getContext()),
             Builder.create<LLVM::LoadOp>(
                 Loc,
                 Builder.create<LLVM::GEPOp>(
@@ -346,22 +341,22 @@ ValueCategory MLIRScanner::callHelper(
 
     auto T0 = Visit(CU->getConfig()->getArg(1));
     assert(T0.isReference);
-    mlir::Value Threads[3];
+    Value Threads[3];
     for (int I = 0; I < 3; I++) {
-      mlir::Value Val = T0.val;
+      Value Val = T0.val;
       if (auto MT = Val.getType().dyn_cast<MemRefType>()) {
-        mlir::Value Idx[] = {getConstantIndex(0), getConstantIndex(I)};
+        Value Idx[] = {getConstantIndex(0), getConstantIndex(I)};
         assert(MT.getShape().size() == 2);
         Threads[I] = Builder.create<arith::IndexCastOp>(
-            Loc, mlir::IndexType::get(Builder.getContext()),
-            Builder.create<mlir::memref::LoadOp>(Loc, Val, Idx));
+            Loc, IndexType::get(Builder.getContext()),
+            Builder.create<memref::LoadOp>(Loc, Val, Idx));
       } else {
-        mlir::Value Idx[] = {Builder.create<arith::ConstantIntOp>(Loc, 0, 32),
-                             Builder.create<arith::ConstantIntOp>(Loc, I, 32)};
+        Value Idx[] = {Builder.create<arith::ConstantIntOp>(Loc, 0, 32),
+                       Builder.create<arith::ConstantIntOp>(Loc, I, 32)};
         auto PT = Val.getType().cast<LLVM::LLVMPointerType>();
         auto ET = PT.getElementType().cast<LLVM::LLVMStructType>().getBody()[I];
         Threads[I] = Builder.create<arith::IndexCastOp>(
-            Loc, mlir::IndexType::get(Builder.getContext()),
+            Loc, IndexType::get(Builder.getContext()),
             Builder.create<LLVM::LoadOp>(
                 Loc,
                 Builder.create<LLVM::GEPOp>(
@@ -369,8 +364,8 @@ ValueCategory MLIRScanner::callHelper(
                     Val, Idx)));
       }
     }
-    mlir::Value Stream = nullptr;
-    SmallVector<mlir::Value, 1> AsyncDependencies;
+    Value Stream = nullptr;
+    SmallVector<Value, 1> AsyncDependencies;
     if (3 < CU->getConfig()->getNumArgs() &&
         !isa<clang::CXXDefaultArgExpr>(CU->getConfig()->getArg(3))) {
       Stream = Visit(CU->getConfig()->getArg(3)).getValue(Builder);
@@ -379,7 +374,7 @@ ValueCategory MLIRScanner::callHelper(
       assert(Stream);
       AsyncDependencies.push_back(Stream);
     }
-    auto Op = Builder.create<mlir::gpu::LaunchOp>(
+    auto Op = Builder.create<gpu::LaunchOp>(
         Loc, Blocks[0], Blocks[1], Blocks[2], Threads[0], Threads[1],
         Threads[2],
         /*dynamic shmem size*/ nullptr,
@@ -398,7 +393,7 @@ ValueCategory MLIRScanner::callHelper(
   castCallerArgs(ToCall, Args, Builder);
 
   /// Try to emit SYCL operations before creating a CallOp
-  mlir::Operation *Op = emitSYCLOps(Expr, Args);
+  Operation *Op = emitSYCLOps(Expr, Args);
   if (!Op)
     Op = Builder.create<func::CallOp>(Loc, ToCall, Args);
 
@@ -468,9 +463,8 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
                   : RHS->getExprOperand()->getType();
           llvm::Constant *LC = Glob.getCGM().GetAddrOfRTTIDescriptor(LT);
           llvm::Constant *RC = Glob.getCGM().GetAddrOfRTTIDescriptor(RT);
-          auto PostTy = Glob.getTypes()
-                            .getMLIRType(Expr->getType())
-                            .cast<mlir::IntegerType>();
+          auto PostTy =
+              Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
           return ValueCategory(
               Builder.create<arith::ConstantIntOp>(Loc, LC == RC, PostTy),
               false);
@@ -519,7 +513,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
         arith::AtomicRMWKind Op;
         LLVM::AtomicBinOp Lop;
         if (Sr->getDecl()->getName() == "atomicAdd") {
-          if (A1.getType().isa<mlir::IntegerType>()) {
+          if (A1.getType().isa<IntegerType>()) {
             Op = arith::AtomicRMWKind::addi;
             Lop = LLVM::AtomicBinOp::add;
           } else {
@@ -536,11 +530,10 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
           assert(0);
 
         if (A0.getType().isa<MemRefType>())
-          return ValueCategory(
-              Builder.create<memref::AtomicRMWOp>(
-                  Loc, A1.getType(), Op, A1, A0,
-                  std::vector<mlir::Value>({getConstantIndex(0)})),
-              /*isReference*/ false);
+          return ValueCategory(Builder.create<memref::AtomicRMWOp>(
+                                   Loc, A1.getType(), Op, A1, A0,
+                                   std::vector<Value>({getConstantIndex(0)})),
+                               /*isReference*/ false);
         return ValueCategory(
             Builder.create<LLVM::AtomicRMWOp>(Loc, A1.getType(), Lop, A0, A1,
                                               LLVM::AtomicOrdering::acq_rel),
@@ -548,9 +541,9 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
       }
     }
 
-  mlir::LLVM::TypeFromLLVMIRTranslator TypeTranslator(*Module->getContext());
+  LLVM::TypeFromLLVMIRTranslator TypeTranslator(*Module->getContext());
 
-  auto GetLLVM = [&](clang::Expr *E) -> mlir::Value {
+  auto GetLLVM = [&](clang::Expr *E) -> Value {
     auto Sub = Visit(E);
     if (!Sub.val) {
       Expr->dump();
@@ -561,7 +554,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
     bool IsReference = E->isLValue() || E->isXValue();
     if (IsReference) {
       assert(Sub.isReference);
-      mlir::Value Val = Sub.val;
+      Value Val = Sub.val;
       if (auto MT = Val.getType().dyn_cast<MemRefType>()) {
         Val = Builder.create<polygeist::Memref2PointerOp>(
             Loc,
@@ -588,7 +581,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
       OpBuilder ABuilder(Builder.getContext());
       ABuilder.setInsertionPointToStart(AllocationScope);
       auto One = ABuilder.create<arith::ConstantIntOp>(Loc, 1, 64);
-      auto Alloc = ABuilder.create<mlir::LLVM::AllocaOp>(
+      auto Alloc = ABuilder.create<LLVM::AllocaOp>(
           Loc,
           LLVM::LLVMPointerType::get(
               TypeTranslator.translateType(mlirclang::anonymize(
@@ -615,70 +608,70 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
   switch (Expr->getBuiltinCallee()) {
   case clang::Builtin::BI__builtin_strlen:
   case clang::Builtin::BIstrlen: {
-    mlir::Value V0 = GetLLVM(Expr->getArg(0));
+    Value V0 = GetLLVM(Expr->getArg(0));
 
     const std::string Name("strlen");
 
     if (Glob.getFunctions().find(Name) == Glob.getFunctions().end()) {
-      std::vector<mlir::Type> Types{V0.getType()};
+      std::vector<Type> Types{V0.getType()};
 
-      mlir::Type RT = Glob.getTypes().getMLIRType(Expr->getType());
-      std::vector<mlir::Type> RetTypes{RT};
-      mlir::OpBuilder Builder(Module->getContext());
+      Type RT = Glob.getTypes().getMLIRType(Expr->getType());
+      std::vector<Type> RetTypes{RT};
+      OpBuilder Builder(Module->getContext());
       auto FuncType = Builder.getFunctionType(Types, RetTypes);
-      Glob.getFunctions()[Name] = mlir::func::FuncOp(
-          mlir::func::FuncOp::create(Builder.getUnknownLoc(), Name, FuncType));
+      Glob.getFunctions()[Name] = func::FuncOp(
+          func::FuncOp::create(Builder.getUnknownLoc(), Name, FuncType));
       SymbolTable::setSymbolVisibility(Glob.getFunctions()[Name],
                                        SymbolTable::Visibility::Private);
       Module->push_back(Glob.getFunctions()[Name]);
     }
 
-    mlir::Value Vals[] = {V0};
+    Value Vals[] = {V0};
     return ValueCategory(
         Builder.create<func::CallOp>(Loc, Glob.getFunctions()[Name], Vals)
             .getResult(0),
         false);
   }
   case clang::Builtin::BI__builtin_isnormal: {
-    mlir::Value V = GetLLVM(Expr->getArg(0));
-    auto Ty = V.getType().cast<mlir::FloatType>();
-    mlir::Value Eq =
+    Value V = GetLLVM(Expr->getArg(0));
+    auto Ty = V.getType().cast<FloatType>();
+    Value Eq =
         Builder.create<arith::CmpFOp>(Loc, arith::CmpFPredicate::OEQ, V, V);
 
-    mlir::Value Abs = Builder.create<math::AbsFOp>(Loc, V);
+    Value Abs = Builder.create<math::AbsFOp>(Loc, V);
     auto Infinity = Builder.create<arith::ConstantFloatOp>(
         Loc, APFloat::getInf(Ty.getFloatSemantics()), Ty);
-    mlir::Value IsLessThanInf = Builder.create<arith::CmpFOp>(
+    Value IsLessThanInf = Builder.create<arith::CmpFOp>(
         Loc, arith::CmpFPredicate::ULT, Abs, Infinity);
     APFloat Smallest = APFloat::getSmallestNormalized(Ty.getFloatSemantics());
     auto SmallestV = Builder.create<arith::ConstantFloatOp>(Loc, Smallest, Ty);
-    mlir::Value IsNormal = Builder.create<arith::CmpFOp>(
+    Value IsNormal = Builder.create<arith::CmpFOp>(
         Loc, arith::CmpFPredicate::UGE, Abs, SmallestV);
     V = Builder.create<arith::AndIOp>(Loc, Eq, IsLessThanInf);
     V = Builder.create<arith::AndIOp>(Loc, V, IsNormal);
     auto PostTy =
-        Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
-    mlir::Value Res = Builder.create<arith::ExtUIOp>(Loc, PostTy, V);
+        Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
+    Value Res = Builder.create<arith::ExtUIOp>(Loc, PostTy, V);
     return ValueCategory(Res, /*isRef*/ false);
   }
   case clang::Builtin::BI__builtin_signbit: {
-    mlir::Value V = GetLLVM(Expr->getArg(0));
-    auto Ty = V.getType().cast<mlir::FloatType>();
+    Value V = GetLLVM(Expr->getArg(0));
+    auto Ty = V.getType().cast<FloatType>();
     auto ITy = Builder.getIntegerType(Ty.getWidth());
-    mlir::Value BC = Builder.create<arith::BitcastOp>(Loc, ITy, V);
+    Value BC = Builder.create<arith::BitcastOp>(Loc, ITy, V);
     auto ZeroV = Builder.create<arith::ConstantIntOp>(Loc, 0, ITy);
     V = Builder.create<arith::CmpIOp>(Loc, arith::CmpIPredicate::slt, BC,
                                       ZeroV);
     auto PostTy =
-        Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
-    mlir::Value Res = Builder.create<arith::ExtUIOp>(Loc, PostTy, V);
+        Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
+    Value Res = Builder.create<arith::ExtUIOp>(Loc, PostTy, V);
     return ValueCategory(Res, /*isRef*/ false);
   }
   case clang::Builtin::BI__builtin_addressof: {
     auto V = Visit(Expr->getArg(0));
     assert(V.isReference);
-    mlir::Value Val = V.val;
-    mlir::Type T = Glob.getTypes().getMLIRType(Expr->getType());
+    Value Val = V.val;
+    Type T = Glob.getTypes().getMLIRType(Expr->getType());
     if (T == Val.getType())
       return ValueCategory(Val, /*isRef*/ false);
     if (T.isa<LLVM::LLVMPointerType>()) {
@@ -724,12 +717,12 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
            Sr->getDecl()->getName() == "__nv_powi" ||
            Sr->getDecl()->getName() == "__nv_powi" ||
            BuiltinCallee == clang::Builtin::BIpowf)) {
-        mlir::Type MLIRType = Glob.getTypes().getMLIRType(Expr->getType());
-        std::vector<mlir::Value> Args;
+        Type MLIRType = Glob.getTypes().getMLIRType(Expr->getType());
+        std::vector<Value> Args;
         for (auto *A : Expr->arguments()) {
           Args.push_back(Visit(A).getValue(Builder));
         }
-        if (Args[1].getType().isa<mlir::IntegerType>())
+        if (Args[1].getType().isa<IntegerType>())
           return ValueCategory(
               Builder.create<LLVM::PowIOp>(Loc, MLIRType, Args[0], Args[1]),
               /*isReference*/ false);
@@ -752,13 +745,13 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
         // isinf(x)    --> fabs(x) == infinity
         // isfinite(x) --> fabs(x) != infinity
         // x != NaN via the ordered compare in either case.
-        mlir::Value V = GetLLVM(Expr->getArg(0));
-        mlir::Value Fabs;
-        if (V.getType().isa<mlir::FloatType>())
+        Value V = GetLLVM(Expr->getArg(0));
+        Value Fabs;
+        if (V.getType().isa<FloatType>())
           Fabs = Builder.create<math::AbsFOp>(Loc, V);
         else {
           auto Zero = Builder.create<arith::ConstantIntOp>(
-              Loc, 0, V.getType().cast<mlir::IntegerType>().getWidth());
+              Loc, 0, V.getType().cast<IntegerType>().getWidth());
           Fabs = Builder.create<arith::SelectOp>(
               Loc,
               Builder.create<arith::CmpIOp>(Loc, arith::CmpIPredicate::sge, V,
@@ -769,8 +762,8 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
       }
       if (Sr->getDecl()->getIdentifier() &&
           Sr->getDecl()->getName() == "__nv_mul24") {
-        mlir::Value V0 = GetLLVM(Expr->getArg(0));
-        mlir::Value V1 = GetLLVM(Expr->getArg(1));
+        Value V0 = GetLLVM(Expr->getArg(0));
+        Value V1 = GetLLVM(Expr->getArg(1));
         auto C8 = Builder.create<arith::ConstantIntOp>(Loc, 8, 32);
         V0 = Builder.create<arith::ShLIOp>(Loc, V0, C8);
         V0 = Builder.create<arith::ShRUIOp>(Loc, V0, C8);
@@ -782,8 +775,8 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
           BuiltinCallee == clang::Builtin::BI__builtin_frexpf ||
           BuiltinCallee == clang::Builtin::BI__builtin_frexpl ||
           BuiltinCallee == clang::Builtin::BI__builtin_frexpf128) {
-        mlir::Value V0 = GetLLVM(Expr->getArg(0));
-        mlir::Value V1 = GetLLVM(Expr->getArg(1));
+        Value V0 = GetLLVM(Expr->getArg(0));
+        Value V1 = GetLLVM(Expr->getArg(1));
 
         auto Name = Sr->getDecl()
                         ->getName()
@@ -791,21 +784,20 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
                         .str();
 
         if (Glob.getFunctions().find(Name) == Glob.getFunctions().end()) {
-          std::vector<mlir::Type> Types{V0.getType(), V1.getType()};
+          std::vector<Type> Types{V0.getType(), V1.getType()};
 
-          mlir::Type RT = Glob.getTypes().getMLIRType(Expr->getType());
-          std::vector<mlir::Type> Rettype{RT};
-          mlir::OpBuilder MBuilder(Module->getContext());
+          Type RT = Glob.getTypes().getMLIRType(Expr->getType());
+          std::vector<Type> Rettype{RT};
+          OpBuilder MBuilder(Module->getContext());
           auto FuncType = MBuilder.getFunctionType(Types, Rettype);
-          Glob.getFunctions()[Name] =
-              mlir::func::FuncOp(mlir::func::FuncOp::create(
-                  Builder.getUnknownLoc(), Name, FuncType));
+          Glob.getFunctions()[Name] = func::FuncOp(
+              func::FuncOp::create(Builder.getUnknownLoc(), Name, FuncType));
           SymbolTable::setSymbolVisibility(Glob.getFunctions()[Name],
                                            SymbolTable::Visibility::Private);
           Module->push_back(Glob.getFunctions()[Name]);
         }
 
-        mlir::Value Vals[] = {V0, V1};
+        Value Vals[] = {V0, V1};
         return ValueCategory(
             Builder.create<func::CallOp>(Loc, Glob.getFunctions()[Name], Vals)
                 .getResult(0),
@@ -818,86 +810,82 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
         // isinf(x)    --> fabs(x) == infinity
         // isfinite(x) --> fabs(x) != infinity
         // x != NaN via the ordered compare in either case.
-        mlir::Value V = GetLLVM(Expr->getArg(0));
-        auto Ty = V.getType().cast<mlir::FloatType>();
-        mlir::Value Fabs = Builder.create<math::AbsFOp>(Loc, V);
+        Value V = GetLLVM(Expr->getArg(0));
+        auto Ty = V.getType().cast<FloatType>();
+        Value Fabs = Builder.create<math::AbsFOp>(Loc, V);
         auto Infinity = Builder.create<arith::ConstantFloatOp>(
             Loc, APFloat::getInf(Ty.getFloatSemantics()), Ty);
         auto Pred = (BuiltinCallee == clang::Builtin::BI__builtin_isinf ||
                      Sr->getDecl()->getName() == "__nv_isinff")
                         ? arith::CmpFPredicate::OEQ
                         : arith::CmpFPredicate::ONE;
-        mlir::Value FCmp =
-            Builder.create<arith::CmpFOp>(Loc, Pred, Fabs, Infinity);
-        auto PostTy = Glob.getTypes()
-                          .getMLIRType(Expr->getType())
-                          .cast<mlir::IntegerType>();
-        mlir::Value Res = Builder.create<arith::ExtUIOp>(Loc, PostTy, FCmp);
+        Value FCmp = Builder.create<arith::CmpFOp>(Loc, Pred, Fabs, Infinity);
+        auto PostTy =
+            Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
+        Value Res = Builder.create<arith::ExtUIOp>(Loc, PostTy, FCmp);
         return ValueCategory(Res, /*isRef*/ false);
       }
       if (Sr->getDecl()->getIdentifier() &&
           (BuiltinCallee == clang::Builtin::BI__builtin_isnan ||
            Sr->getDecl()->getName() == "__nv_isnanf")) {
-        mlir::Value V = GetLLVM(Expr->getArg(0));
-        mlir::Value Eq =
+        Value V = GetLLVM(Expr->getArg(0));
+        Value Eq =
             Builder.create<arith::CmpFOp>(Loc, arith::CmpFPredicate::UNO, V, V);
-        auto PostTy = Glob.getTypes()
-                          .getMLIRType(Expr->getType())
-                          .cast<mlir::IntegerType>();
-        mlir::Value Res = Builder.create<arith::ExtUIOp>(Loc, PostTy, Eq);
+        auto PostTy =
+            Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
+        Value Res = Builder.create<arith::ExtUIOp>(Loc, PostTy, Eq);
         return ValueCategory(Res, /*isRef*/ false);
       }
       if (Sr->getDecl()->getIdentifier() &&
           (Sr->getDecl()->getName() == "__nv_fmodf")) {
-        mlir::Value V = GetLLVM(Expr->getArg(0));
-        mlir::Value V2 = GetLLVM(Expr->getArg(1));
-        V = Builder.create<mlir::LLVM::FRemOp>(Loc, V.getType(), V, V2);
+        Value V = GetLLVM(Expr->getArg(0));
+        Value V2 = GetLLVM(Expr->getArg(1));
+        V = Builder.create<LLVM::FRemOp>(Loc, V.getType(), V, V2);
         return ValueCategory(V, /*isRef*/ false);
       }
       if (Sr->getDecl()->getIdentifier() &&
           (Sr->getDecl()->getName() == "__nv_scalbn" ||
            Sr->getDecl()->getName() == "__nv_scalbnf" ||
            Sr->getDecl()->getName() == "__nv_scalbnl")) {
-        mlir::Value V = GetLLVM(Expr->getArg(0));
-        mlir::Value V2 = GetLLVM(Expr->getArg(1));
+        Value V = GetLLVM(Expr->getArg(0));
+        Value V2 = GetLLVM(Expr->getArg(1));
         auto Name = Sr->getDecl()->getName().substr(5).str();
-        std::vector<mlir::Type> Types{V.getType(), V2.getType()};
-        mlir::Type RT = Glob.getTypes().getMLIRType(Expr->getType());
+        std::vector<Type> Types{V.getType(), V2.getType()};
+        Type RT = Glob.getTypes().getMLIRType(Expr->getType());
 
-        std::vector<mlir::Type> Rettypes{RT};
+        std::vector<Type> Rettypes{RT};
 
-        mlir::OpBuilder Builder(Module->getContext());
+        OpBuilder Builder(Module->getContext());
         auto FuncType = Builder.getFunctionType(Types, Rettypes);
-        mlir::func::FuncOp Function =
-            mlir::func::FuncOp(mlir::func::FuncOp::create(
-                Builder.getUnknownLoc(), Name, FuncType));
+        func::FuncOp Function = func::FuncOp(
+            func::FuncOp::create(Builder.getUnknownLoc(), Name, FuncType));
         SymbolTable::setSymbolVisibility(Function,
                                          SymbolTable::Visibility::Private);
 
         Glob.getFunctions()[Name] = Function;
         Module->push_back(Function);
-        mlir::Value Vals[] = {V, V2};
+        Value Vals[] = {V, V2};
         V = Builder.create<func::CallOp>(Loc, Function, Vals).getResult(0);
         return ValueCategory(V, /*isRef*/ false);
       }
       if (Sr->getDecl()->getIdentifier() &&
           (Sr->getDecl()->getName() == "__nv_dmul_rn")) {
-        mlir::Value V = GetLLVM(Expr->getArg(0));
-        mlir::Value V2 = GetLLVM(Expr->getArg(1));
+        Value V = GetLLVM(Expr->getArg(0));
+        Value V2 = GetLLVM(Expr->getArg(1));
         V = Builder.create<arith::MulFOp>(Loc, V, V2);
         return ValueCategory(V, /*isRef*/ false);
       }
       if (Sr->getDecl()->getIdentifier() &&
           (Sr->getDecl()->getName() == "__nv_dadd_rn")) {
-        mlir::Value V = GetLLVM(Expr->getArg(0));
-        mlir::Value V2 = GetLLVM(Expr->getArg(1));
+        Value V = GetLLVM(Expr->getArg(0));
+        Value V2 = GetLLVM(Expr->getArg(1));
         V = Builder.create<arith::AddFOp>(Loc, V, V2);
         return ValueCategory(V, /*isRef*/ false);
       }
       if (Sr->getDecl()->getIdentifier() &&
           (Sr->getDecl()->getName() == "__nv_dsub_rn")) {
-        mlir::Value V = GetLLVM(Expr->getArg(0));
-        mlir::Value V2 = GetLLVM(Expr->getArg(1));
+        Value V = GetLLVM(Expr->getArg(0));
+        Value V2 = GetLLVM(Expr->getArg(1));
         V = Builder.create<arith::SubFOp>(Loc, V, V2);
         return ValueCategory(V, /*isRef*/ false);
       }
@@ -908,7 +896,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
            Sr->getDecl()->getName() == "__nv_log2" ||
            Sr->getDecl()->getName() == "__nv_log2f" ||
            Sr->getDecl()->getName() == "__nv_log2l")) {
-        mlir::Value V = GetLLVM(Expr->getArg(0));
+        Value V = GetLLVM(Expr->getArg(0));
         V = Builder.create<math::Log2Op>(Loc, V);
         return ValueCategory(V, /*isRef*/ false);
       }
@@ -919,7 +907,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
            Sr->getDecl()->getName() == "__nv_log10" ||
            Sr->getDecl()->getName() == "__nv_log10f" ||
            Sr->getDecl()->getName() == "__nv_log10l")) {
-        mlir::Value V = GetLLVM(Expr->getArg(0));
+        Value V = GetLLVM(Expr->getArg(0));
         V = Builder.create<math::Log10Op>(Loc, V);
         return ValueCategory(V, /*isRef*/ false);
       }
@@ -938,8 +926,8 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
         const auto *ToCall = EmitCallee(Expr->getCallee());
         auto StrcmpF = Glob.getOrCreateLLVMFunction(ToCall);
 
-        std::vector<mlir::Value> Args;
-        std::vector<std::pair<mlir::Value, mlir::Value>> Ops;
+        std::vector<Value> Args;
+        std::vector<std::pair<Value, Value>> Ops;
         std::map<const void *, size_t> Counts;
         for (auto *A : Expr->arguments()) {
           auto V = GetLLVM(A);
@@ -952,12 +940,11 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
           } else
             Args.push_back(V);
         }
-        auto Called = Builder.create<mlir::LLVM::CallOp>(Loc, StrcmpF, Args);
+        auto Called = Builder.create<LLVM::CallOp>(Loc, StrcmpF, Args);
         for (auto Pair : Ops) {
-          auto Lop = Builder.create<mlir::LLVM::LoadOp>(Loc, Pair.first);
-          Builder.create<mlir::memref::StoreOp>(
-              Loc, Lop, Pair.second,
-              std::vector<mlir::Value>({getConstantIndex(0)}));
+          auto Lop = Builder.create<LLVM::LoadOp>(Loc, Pair.first);
+          Builder.create<memref::StoreOp>(
+              Loc, Lop, Pair.second, std::vector<Value>({getConstantIndex(0)}));
         }
         return ValueCategory(Called.getResult(), /*isReference*/ false);
       }
@@ -1049,25 +1036,23 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
           Name.startswith("MKL_") || Name.startswith("cublas") ||
           Name.startswith("cblas_")) {
 
-        std::vector<mlir::Value> Args;
+        std::vector<Value> Args;
         for (auto *A : Expr->arguments())
           Args.push_back(GetLLVM(A));
 
-        mlir::Value Called;
+        Value Called;
 
         if (Callee) {
           auto StrcmpF = Glob.getOrCreateLLVMFunction(Callee);
-          Called = Builder.create<mlir::LLVM::CallOp>(Loc, StrcmpF, Args)
-                       .getResult();
+          Called = Builder.create<LLVM::CallOp>(Loc, StrcmpF, Args).getResult();
         } else {
           Args.insert(Args.begin(), GetLLVM(Expr->getCallee()));
-          SmallVector<mlir::Type> RTs = {
+          SmallVector<Type> RTs = {
               TypeTranslator.translateType(mlirclang::anonymize(
                   mlirclang::getLLVMType(Expr->getType(), Glob.getCGM())))};
           if (RTs[0].isa<LLVM::LLVMVoidType>())
             RTs.clear();
-          Called =
-              Builder.create<mlir::LLVM::CallOp>(Loc, RTs, Args).getResult();
+          Called = Builder.create<LLVM::CallOp>(Loc, RTs, Args).getResult();
         }
         return ValueCategory(Called, /*isReference*/ Expr->isLValue() ||
                                          Expr->isXValue());
@@ -1076,21 +1061,20 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
 
   if (!Callee || Callee->isVariadic()) {
     bool IsReference = Expr->isLValue() || Expr->isXValue();
-    std::vector<mlir::Value> Args;
+    std::vector<Value> Args;
     for (auto *A : Expr->arguments())
       Args.push_back(GetLLVM(A));
 
-    mlir::Value Called;
+    Value Called;
     if (Callee) {
       auto StrcmpF = Glob.getOrCreateLLVMFunction(Callee);
-      Called =
-          Builder.create<mlir::LLVM::CallOp>(Loc, StrcmpF, Args).getResult();
+      Called = Builder.create<LLVM::CallOp>(Loc, StrcmpF, Args).getResult();
     } else {
       Args.insert(Args.begin(), GetLLVM(Expr->getCallee()));
       auto CT = Expr->getType();
       if (IsReference)
         CT = Glob.getCGM().getContext().getLValueReferenceType(CT);
-      SmallVector<mlir::Type> RTs = {TypeTranslator.translateType(
+      SmallVector<Type> RTs = {TypeTranslator.translateType(
           mlirclang::anonymize(mlirclang::getLLVMType(CT, Glob.getCGM())))};
 
       auto Ft = Args[0]
@@ -1101,7 +1085,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
       assert(RTs[0] == Ft.getReturnType());
       if (RTs[0].isa<LLVM::LLVMVoidType>())
         RTs.clear();
-      Called = Builder.create<mlir::LLVM::CallOp>(Loc, RTs, Args).getResult();
+      Called = Builder.create<LLVM::CallOp>(Loc, RTs, Args).getResult();
     }
     if (IsReference) {
       if (!(Called.getType().isa<LLVM::LLVMPointerType>() ||
@@ -1171,7 +1155,7 @@ MLIRScanner::emitGPUCallExpr(clang::CallExpr *Expr) {
     if (auto *Sr = dyn_cast<clang::DeclRefExpr>(Ic->getSubExpr())) {
       if (Sr->getDecl()->getIdentifier() &&
           Sr->getDecl()->getName() == "__syncthreads") {
-        Builder.create<mlir::NVVM::Barrier0Op>(Loc);
+        Builder.create<NVVM::Barrier0Op>(Loc);
         return std::make_pair(ValueCategory(), true);
       }
       if (Sr->getDecl()->getIdentifier() &&
@@ -1188,16 +1172,16 @@ MLIRScanner::emitGPUCallExpr(clang::CallExpr *Expr) {
         auto *Sub = Expr->getArg(0);
         while (auto *BC = dyn_cast<clang::CastExpr>(Sub))
           Sub = BC->getSubExpr();
-        mlir::Value Arg = Visit(Sub).getValue(Builder);
+        Value Arg = Visit(Sub).getValue(Builder);
 
-        if (Arg.getType().isa<mlir::LLVM::LLVMPointerType>()) {
+        if (Arg.getType().isa<LLVM::LLVMPointerType>()) {
           const auto *Callee = EmitCallee(Expr->getCallee());
           auto StrcmpF = Glob.getOrCreateLLVMFunction(Callee);
-          mlir::Value Args[] = {Builder.create<LLVM::BitcastOp>(
+          Value Args[] = {Builder.create<LLVM::BitcastOp>(
               Loc, LLVM::LLVMPointerType::get(Builder.getIntegerType(8)), Arg)};
-          Builder.create<mlir::LLVM::CallOp>(Loc, StrcmpF, Args);
+          Builder.create<LLVM::CallOp>(Loc, StrcmpF, Args);
         } else {
-          Builder.create<mlir::memref::DeallocOp>(Loc, Arg);
+          Builder.create<memref::DeallocOp>(Loc, Arg);
         }
         if (Sr->getDecl()->getName() == "cudaFree" ||
             Sr->getDecl()->getName() == "cudaFreeHost") {
@@ -1227,10 +1211,10 @@ MLIRScanner::emitGPUCallExpr(clang::CallExpr *Expr) {
                           Sub->getType()->getUnqualifiedDesugaredType())
                           ->getPointeeType())
                       ->getPointeeType());
-              mlir::Value AllocSize;
+              Value AllocSize;
               if (Sr->getDecl()->getName() == "cudaMallocPitch") {
-                mlir::Value Width = Visit(Expr->getArg(2)).getValue(Builder);
-                mlir::Value Height = Visit(Expr->getArg(3)).getValue(Builder);
+                Value Width = Visit(Expr->getArg(2)).getValue(Builder);
+                Value Height = Visit(Expr->getArg(3)).getValue(Builder);
                 // Not changing pitch from provided width here
                 // TODO can consider addition alignment considerations
                 Visit(Expr->getArg(1))
@@ -1239,23 +1223,23 @@ MLIRScanner::emitGPUCallExpr(clang::CallExpr *Expr) {
                 AllocSize = Builder.create<arith::MulIOp>(Loc, Width, Height);
               } else
                 AllocSize = Visit(Expr->getArg(1)).getValue(Builder);
-              auto IdxType = mlir::IndexType::get(Builder.getContext());
-              mlir::Value Args[1] = {Builder.create<arith::DivUIOp>(
+              auto IdxType = IndexType::get(Builder.getContext());
+              Value Args[1] = {Builder.create<arith::DivUIOp>(
                   Loc,
                   Builder.create<arith::IndexCastOp>(Loc, IdxType, AllocSize),
                   ElemSize)};
-              auto Alloc = Builder.create<mlir::memref::AllocOp>(
+              auto Alloc = Builder.create<memref::AllocOp>(
                   Loc,
                   (Sr->getDecl()->getName() != "cudaMallocHost" && !CudaLower)
-                      ? mlir::MemRefType::get(Shape, MT.getElementType(),
-                                              MemRefLayoutAttrInterface(),
-                                              mlirclang::wrapIntegerMemorySpace(
-                                                  1, MT.getContext()))
+                      ? MemRefType::get(Shape, MT.getElementType(),
+                                        MemRefLayoutAttrInterface(),
+                                        mlirclang::wrapIntegerMemorySpace(
+                                            1, MT.getContext()))
                       : MT,
                   Args);
               ValueCategory(Dst, /*isReference*/ true)
                   .store(Builder,
-                         Builder.create<mlir::memref::CastOp>(Loc, MT, Alloc));
+                         Builder.create<memref::CastOp>(Loc, MT, Alloc));
               auto RetTy = Glob.getTypes().getMLIRType(Expr->getType());
               return std::make_pair(
                   ValueCategory(
@@ -1268,36 +1252,32 @@ MLIRScanner::emitGPUCallExpr(clang::CallExpr *Expr) {
       }
     }
 
-    auto CreateBlockIdOp = [&](gpu::Dimension Str,
-                               mlir::Type MLIRType) -> mlir::Value {
+    auto CreateBlockIdOp = [&](gpu::Dimension Str, Type MLIRType) -> Value {
       return Builder.create<arith::IndexCastOp>(
           Loc, MLIRType,
-          Builder.create<mlir::gpu::BlockIdOp>(
-              Loc, mlir::IndexType::get(Builder.getContext()), Str));
+          Builder.create<gpu::BlockIdOp>(
+              Loc, IndexType::get(Builder.getContext()), Str));
     };
 
-    auto CreateBlockDimOp = [&](gpu::Dimension Str,
-                                mlir::Type MLIRType) -> mlir::Value {
+    auto CreateBlockDimOp = [&](gpu::Dimension Str, Type MLIRType) -> Value {
       return Builder.create<arith::IndexCastOp>(
           Loc, MLIRType,
-          Builder.create<mlir::gpu::BlockDimOp>(
-              Loc, mlir::IndexType::get(Builder.getContext()), Str));
+          Builder.create<gpu::BlockDimOp>(
+              Loc, IndexType::get(Builder.getContext()), Str));
     };
 
-    auto CreateThreadIdOp = [&](gpu::Dimension Str,
-                                mlir::Type MLIRType) -> mlir::Value {
+    auto CreateThreadIdOp = [&](gpu::Dimension Str, Type MLIRType) -> Value {
       return Builder.create<arith::IndexCastOp>(
           Loc, MLIRType,
-          Builder.create<mlir::gpu::ThreadIdOp>(
-              Loc, mlir::IndexType::get(Builder.getContext()), Str));
+          Builder.create<gpu::ThreadIdOp>(
+              Loc, IndexType::get(Builder.getContext()), Str));
     };
 
-    auto CreateGridDimOp = [&](gpu::Dimension Str,
-                               mlir::Type MLIRType) -> mlir::Value {
+    auto CreateGridDimOp = [&](gpu::Dimension Str, Type MLIRType) -> Value {
       return Builder.create<arith::IndexCastOp>(
           Loc, MLIRType,
-          Builder.create<mlir::gpu::GridDimOp>(
-              Loc, mlir::IndexType::get(Builder.getContext()), Str));
+          Builder.create<gpu::GridDimOp>(
+              Loc, IndexType::get(Builder.getContext()), Str));
     };
 
     if (auto *ME = dyn_cast<clang::MemberExpr>(Ic->getSubExpr())) {
@@ -1402,17 +1382,17 @@ MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
     if (auto *Sr = dyn_cast<clang::DeclRefExpr>(Ic->getSubExpr()))
       if (Sr->getDecl()->getIdentifier() &&
           Sr->getDecl()->getName() == "__log2f") {
-        std::vector<mlir::Value> Args;
+        std::vector<Value> Args;
         for (auto *A : Expr->arguments())
           Args.push_back(Visit(A).getValue(Builder));
 
         return std::make_pair(
-            ValueCategory(Builder.create<mlir::math::Log2Op>(Loc, Args[0]),
+            ValueCategory(Builder.create<math::Log2Op>(Loc, Args[0]),
                           /*isReference*/ false),
             true);
       }
 
-  std::vector<mlir::Value> Args;
+  std::vector<Value> Args;
   auto VisitArgs = [&]() {
     assert(Args.empty() && "Expecting empty args");
     for (auto *A : Expr->arguments())
@@ -1426,25 +1406,25 @@ MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
   } break;
   case clang::Builtin::BIcos: {
     VisitArgs();
-    V = Builder.create<mlir::math::CosOp>(Loc, Args[0]);
+    V = Builder.create<math::CosOp>(Loc, Args[0]);
   } break;
   case clang::Builtin::BIexp:
   case clang::Builtin::BIexpf: {
     VisitArgs();
-    V = Builder.create<mlir::math::ExpOp>(Loc, Args[0]);
+    V = Builder.create<math::ExpOp>(Loc, Args[0]);
   } break;
   case clang::Builtin::BIlog: {
     VisitArgs();
-    V = Builder.create<mlir::math::LogOp>(Loc, Args[0]);
+    V = Builder.create<math::LogOp>(Loc, Args[0]);
   } break;
   case clang::Builtin::BIsin: {
     VisitArgs();
-    V = Builder.create<mlir::math::SinOp>(Loc, Args[0]);
+    V = Builder.create<math::SinOp>(Loc, Args[0]);
   } break;
   case clang::Builtin::BIsqrt:
   case clang::Builtin::BIsqrtf: {
     VisitArgs();
-    V = Builder.create<mlir::math::SqrtOp>(Loc, Args[0]);
+    V = Builder.create<math::SqrtOp>(Loc, Args[0]);
   } break;
   case clang::Builtin::BI__builtin_atanh:
   case clang::Builtin::BI__builtin_atanhf:
@@ -1507,7 +1487,7 @@ MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
   case clang::Builtin::BI__builtin_isgreater: {
     VisitArgs();
     auto PostTy =
-        Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
+        Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
     V = Builder.create<arith::ExtUIOp>(
         Loc, PostTy,
         Builder.create<arith::CmpFOp>(Loc, arith::CmpFPredicate::OGT, Args[0],
@@ -1516,7 +1496,7 @@ MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
   case clang::Builtin::BI__builtin_isgreaterequal: {
     VisitArgs();
     auto PostTy =
-        Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
+        Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
     V = Builder.create<arith::ExtUIOp>(
         Loc, PostTy,
         Builder.create<arith::CmpFOp>(Loc, arith::CmpFPredicate::OGE, Args[0],
@@ -1525,7 +1505,7 @@ MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
   case clang::Builtin::BI__builtin_isless: {
     VisitArgs();
     auto PostTy =
-        Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
+        Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
     V = Builder.create<arith::ExtUIOp>(
         Loc, PostTy,
         Builder.create<arith::CmpFOp>(Loc, arith::CmpFPredicate::OLT, Args[0],
@@ -1534,7 +1514,7 @@ MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
   case clang::Builtin::BI__builtin_islessequal: {
     VisitArgs();
     auto PostTy =
-        Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
+        Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
     V = Builder.create<arith::ExtUIOp>(
         Loc, PostTy,
         Builder.create<arith::CmpFOp>(Loc, arith::CmpFPredicate::OLE, Args[0],
@@ -1543,7 +1523,7 @@ MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
   case clang::Builtin::BI__builtin_islessgreater: {
     VisitArgs();
     auto PostTy =
-        Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
+        Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
     V = Builder.create<arith::ExtUIOp>(
         Loc, PostTy,
         Builder.create<arith::CmpFOp>(Loc, arith::CmpFPredicate::ONE, Args[0],
@@ -1552,7 +1532,7 @@ MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
   case clang::Builtin::BI__builtin_isunordered: {
     VisitArgs();
     auto PostTy =
-        Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
+        Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
     V = Builder.create<arith::ExtUIOp>(
         Loc, PostTy,
         Builder.create<arith::CmpFOp>(Loc, arith::CmpFPredicate::UNO, Args[0],

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -6,14 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "Lib/TypeUtils.h"
+#include "TypeUtils.h"
 #include "clang-mlir.h"
 #include "utils.h"
-#include "llvm/ADT/TypeSwitch.h"
-#include "llvm/Support/WithColor.h"
 
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"
 #include "mlir/Dialect/SYCL/IR/SYCLOpsDialect.h"
+
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/WithColor.h"
 
 #define DEBUG_TYPE "CGExpr"
 
@@ -25,234 +26,232 @@ extern llvm::cl::opt<bool> GenerateAllSYCLFuncs;
 extern llvm::cl::opt<bool> OmitOptionalMangledFunctionName;
 
 ValueCategory
-MLIRScanner::VisitExtVectorElementExpr(clang::ExtVectorElementExpr *expr) {
-  auto base = Visit(expr->getBase());
-  SmallVector<uint32_t, 4> indices;
-  expr->getEncodedElementAccess(indices);
-  assert(indices.size() == 1 &&
+MLIRScanner::VisitExtVectorElementExpr(clang::ExtVectorElementExpr *Expr) {
+  auto Base = Visit(Expr->getBase());
+  SmallVector<uint32_t, 4> Indices;
+  Expr->getEncodedElementAccess(Indices);
+  assert(Indices.size() == 1 &&
          "The support for higher dimensions to be implemented.");
-  assert(base.isReference);
-  assert(base.val.getType().isa<MemRefType>() &&
+  assert(Base.isReference);
+  assert(Base.val.getType().isa<MemRefType>() &&
          "Expecting ExtVectorElementExpr to have memref type");
-  auto MT = base.val.getType().cast<MemRefType>();
+  auto MT = Base.val.getType().cast<MemRefType>();
   assert(MT.getElementType().isa<mlir::VectorType>() &&
          "Expecting ExtVectorElementExpr to have memref of vector elements");
-  auto Idx = builder.create<ConstantIntOp>(loc, indices[0], 64);
-  mlir::Value Val = base.getValue(builder);
-  return ValueCategory(builder.create<LLVM::ExtractElementOp>(loc, Val, Idx),
+  auto Idx = Builder.create<ConstantIntOp>(Loc, Indices[0], 64);
+  mlir::Value Val = Base.getValue(Builder);
+  return ValueCategory(Builder.create<LLVM::ExtractElementOp>(Loc, Val, Idx),
                        /*IsReference*/ false);
 }
 
-ValueCategory MLIRScanner::VisitConstantExpr(clang::ConstantExpr *expr) {
-  auto sv = Visit(expr->getSubExpr());
-  if (auto ty = Glob.getTypes()
-                    .getMLIRType(expr->getType())
+ValueCategory MLIRScanner::VisitConstantExpr(clang::ConstantExpr *Expr) {
+  auto Sv = Visit(Expr->getSubExpr());
+  if (auto Ty = Glob.getTypes()
+                    .getMLIRType(Expr->getType())
                     .dyn_cast<mlir::IntegerType>()) {
-    if (expr->hasAPValueResult()) {
-      return ValueCategory(builder.create<arith::ConstantIntOp>(
-                               getMLIRLocation(expr->getExprLoc()),
-                               expr->getResultAsAPSInt().getExtValue(), ty),
+    if (Expr->hasAPValueResult())
+      return ValueCategory(Builder.create<arith::ConstantIntOp>(
+                               getMLIRLocation(Expr->getExprLoc()),
+                               Expr->getResultAsAPSInt().getExtValue(), Ty),
                            /*isReference*/ false);
-    }
   }
-  assert(sv.val);
-  return sv;
+  assert(Sv.val);
+  return Sv;
 }
 
-ValueCategory MLIRScanner::VisitTypeTraitExpr(clang::TypeTraitExpr *expr) {
-  auto ty =
-      Glob.getTypes().getMLIRType(expr->getType()).cast<mlir::IntegerType>();
+ValueCategory MLIRScanner::VisitTypeTraitExpr(clang::TypeTraitExpr *Expr) {
+  auto Ty =
+      Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
   return ValueCategory(
-      builder.create<arith::ConstantIntOp>(getMLIRLocation(expr->getExprLoc()),
-                                           expr->getValue(), ty),
+      Builder.create<arith::ConstantIntOp>(getMLIRLocation(Expr->getExprLoc()),
+                                           Expr->getValue(), Ty),
       /*isReference*/ false);
 }
 
-ValueCategory MLIRScanner::VisitGNUNullExpr(clang::GNUNullExpr *expr) {
-  auto ty =
-      Glob.getTypes().getMLIRType(expr->getType()).cast<mlir::IntegerType>();
-  return ValueCategory(builder.create<arith::ConstantIntOp>(
-                           getMLIRLocation(expr->getExprLoc()), 0, ty),
+ValueCategory MLIRScanner::VisitGNUNullExpr(clang::GNUNullExpr *Expr) {
+  auto Ty =
+      Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
+  return ValueCategory(Builder.create<arith::ConstantIntOp>(
+                           getMLIRLocation(Expr->getExprLoc()), 0, Ty),
                        /*isReference*/ false);
 }
 
-ValueCategory MLIRScanner::VisitIntegerLiteral(clang::IntegerLiteral *expr) {
-  auto ty =
-      Glob.getTypes().getMLIRType(expr->getType()).cast<mlir::IntegerType>();
+ValueCategory MLIRScanner::VisitIntegerLiteral(clang::IntegerLiteral *Expr) {
+  auto Ty =
+      Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
   return ValueCategory(
-      builder.create<arith::ConstantIntOp>(getMLIRLocation(expr->getExprLoc()),
-                                           expr->getValue().getSExtValue(), ty),
+      Builder.create<arith::ConstantIntOp>(getMLIRLocation(Expr->getExprLoc()),
+                                           Expr->getValue().getSExtValue(), Ty),
       /*isReference*/ false);
 }
 
 ValueCategory
-MLIRScanner::VisitCharacterLiteral(clang::CharacterLiteral *expr) {
-  auto ty =
-      Glob.getTypes().getMLIRType(expr->getType()).cast<mlir::IntegerType>();
+MLIRScanner::VisitCharacterLiteral(clang::CharacterLiteral *Expr) {
+  auto Ty =
+      Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
   return ValueCategory(
-      builder.create<arith::ConstantIntOp>(getMLIRLocation(expr->getExprLoc()),
-                                           expr->getValue(), ty),
+      Builder.create<arith::ConstantIntOp>(getMLIRLocation(Expr->getExprLoc()),
+                                           Expr->getValue(), Ty),
       /*isReference*/ false);
 }
 
-ValueCategory MLIRScanner::VisitFloatingLiteral(clang::FloatingLiteral *expr) {
-  auto ty =
-      Glob.getTypes().getMLIRType(expr->getType()).cast<mlir::FloatType>();
+ValueCategory MLIRScanner::VisitFloatingLiteral(clang::FloatingLiteral *Expr) {
+  auto Ty =
+      Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::FloatType>();
   return ValueCategory(
-      builder.create<ConstantFloatOp>(getMLIRLocation(expr->getExprLoc()),
-                                      expr->getValue(), ty),
+      Builder.create<ConstantFloatOp>(getMLIRLocation(Expr->getExprLoc()),
+                                      Expr->getValue(), Ty),
       /*isReference*/ false);
 }
 
 ValueCategory
-MLIRScanner::VisitImaginaryLiteral(clang::ImaginaryLiteral *expr) {
-  auto mt = Glob.getTypes().getMLIRType(expr->getType()).cast<MemRefType>();
-  auto ty = mt.getElementType().cast<FloatType>();
+MLIRScanner::VisitImaginaryLiteral(clang::ImaginaryLiteral *Expr) {
+  auto Mt = Glob.getTypes().getMLIRType(Expr->getType()).cast<MemRefType>();
+  auto Ty = Mt.getElementType().cast<FloatType>();
 
-  OpBuilder abuilder(builder.getContext());
-  abuilder.setInsertionPointToStart(allocationScope);
-  auto iloc = getMLIRLocation(expr->getExprLoc());
-  auto alloc = abuilder.create<mlir::memref::AllocaOp>(iloc, mt);
-  builder.create<mlir::memref::StoreOp>(
-      iloc,
-      builder.create<ConstantFloatOp>(iloc,
-                                      APFloat(ty.getFloatSemantics(), "0"), ty),
-      alloc, getConstantIndex(0));
-  builder.create<mlir::memref::StoreOp>(
-      iloc, Visit(expr->getSubExpr()).getValue(builder), alloc,
+  OpBuilder Abuilder(Builder.getContext());
+  Abuilder.setInsertionPointToStart(AllocationScope);
+  auto Iloc = getMLIRLocation(Expr->getExprLoc());
+  auto Alloc = Abuilder.create<mlir::memref::AllocaOp>(Iloc, Mt);
+  Builder.create<mlir::memref::StoreOp>(
+      Iloc,
+      Builder.create<ConstantFloatOp>(Iloc,
+                                      APFloat(Ty.getFloatSemantics(), "0"), Ty),
+      Alloc, getConstantIndex(0));
+  Builder.create<mlir::memref::StoreOp>(
+      Iloc, Visit(Expr->getSubExpr()).getValue(Builder), Alloc,
       getConstantIndex(1));
-  return ValueCategory(alloc,
+  return ValueCategory(Alloc,
                        /*isReference*/ true);
 }
 
 ValueCategory
-MLIRScanner::VisitCXXBoolLiteralExpr(clang::CXXBoolLiteralExpr *expr) {
-  auto ty =
-      Glob.getTypes().getMLIRType(expr->getType()).cast<mlir::IntegerType>();
+MLIRScanner::VisitCXXBoolLiteralExpr(clang::CXXBoolLiteralExpr *Expr) {
+  auto Ty =
+      Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
   return ValueCategory(
-      builder.create<ConstantIntOp>(getMLIRLocation(expr->getExprLoc()),
-                                    expr->getValue(), ty),
+      Builder.create<ConstantIntOp>(getMLIRLocation(Expr->getExprLoc()),
+                                    Expr->getValue(), Ty),
       /*isReference*/ false);
 }
 
-ValueCategory MLIRScanner::VisitStringLiteral(clang::StringLiteral *expr) {
-  auto loc = getMLIRLocation(expr->getExprLoc());
+ValueCategory MLIRScanner::VisitStringLiteral(clang::StringLiteral *Expr) {
+  auto Loc = getMLIRLocation(Expr->getExprLoc());
   return ValueCategory(
-      Glob.GetOrCreateGlobalLLVMString(loc, builder, expr->getString()),
+      Glob.getOrCreateGlobalLLVMString(Loc, Builder, Expr->getString()),
       /*isReference*/ true);
 }
 
-ValueCategory MLIRScanner::VisitParenExpr(clang::ParenExpr *expr) {
-  return Visit(expr->getSubExpr());
+ValueCategory MLIRScanner::VisitParenExpr(clang::ParenExpr *Expr) {
+  return Visit(Expr->getSubExpr());
 }
 
 ValueCategory
-MLIRScanner::VisitImplicitValueInitExpr(clang::ImplicitValueInitExpr *decl) {
-  mlir::Type Mty = Glob.getTypes().getMLIRType(decl->getType());
+MLIRScanner::VisitImplicitValueInitExpr(clang::ImplicitValueInitExpr *Decl) {
+  mlir::Type Mty = Glob.getTypes().getMLIRType(Decl->getType());
 
   if (auto FT = Mty.dyn_cast<mlir::FloatType>())
-    return ValueCategory(builder.create<ConstantFloatOp>(
-                             loc, APFloat(FT.getFloatSemantics(), "0"), FT),
+    return ValueCategory(Builder.create<ConstantFloatOp>(
+                             Loc, APFloat(FT.getFloatSemantics(), "0"), FT),
                          /*isReference*/ false);
   if (auto IT = Mty.dyn_cast<mlir::IntegerType>())
-    return ValueCategory(builder.create<ConstantIntOp>(loc, 0, IT),
+    return ValueCategory(Builder.create<ConstantIntOp>(Loc, 0, IT),
                          /*isReference*/ false);
   if (auto MT = Mty.dyn_cast<mlir::MemRefType>())
     return ValueCategory(
-        builder.create<polygeist::Pointer2MemrefOp>(
-            loc, MT,
-            builder.create<mlir::LLVM::NullOp>(
-                loc, LLVM::LLVMPointerType::get(builder.getI8Type(),
+        Builder.create<polygeist::Pointer2MemrefOp>(
+            Loc, MT,
+            Builder.create<mlir::LLVM::NullOp>(
+                Loc, LLVM::LLVMPointerType::get(Builder.getI8Type(),
                                                 MT.getMemorySpaceAsInt()))),
         false);
   if (auto PT = Mty.dyn_cast<mlir::LLVM::LLVMPointerType>())
-    return ValueCategory(builder.create<mlir::LLVM::NullOp>(loc, PT), false);
-  for (auto child : decl->children()) {
-    child->dump();
+    return ValueCategory(Builder.create<mlir::LLVM::NullOp>(Loc, PT), false);
+  for (auto *Child : Decl->children()) {
+    Child->dump();
   }
-  decl->dump();
+  Decl->dump();
   llvm::errs() << " mty: " << Mty << "\n";
   assert(0 && "bad");
 }
 
 /// Construct corresponding MLIR operations to initialize the given value by a
 /// provided InitListExpr.
-mlir::Attribute MLIRScanner::InitializeValueByInitListExpr(mlir::Value toInit,
-                                                           clang::Expr *expr) {
+mlir::Attribute MLIRScanner::InitializeValueByInitListExpr(mlir::Value ToInit,
+                                                           clang::Expr *Expr) {
   // Struct initializan requires an extra 0, since the first index
   // is the pointer index, and then the struct index.
-  auto PTT = expr->getType()->getUnqualifiedDesugaredType();
+  const auto *PTT = Expr->getType()->getUnqualifiedDesugaredType();
 
-  bool inner = false;
+  bool Inner = false;
   if (isa<RecordType>(PTT) || isa<clang::ComplexType>(PTT)) {
-    if (auto mt = toInit.getType().dyn_cast<MemRefType>()) {
-      inner = true;
-    }
+    if (auto Mt = ToInit.getType().dyn_cast<MemRefType>())
+      Inner = true;
   }
 
-  while (auto CO = toInit.getDefiningOp<memref::CastOp>())
-    toInit = CO.getSource();
+  while (auto CO = ToInit.getDefiningOp<memref::CastOp>())
+    ToInit = CO.getSource();
 
   // Recursively visit the initialization expression following the linear
   // increment of the memory address.
-  std::function<mlir::DenseElementsAttr(Expr *, mlir::Value, bool)> helper =
-      [&](Expr *expr, mlir::Value toInit,
-          bool inner) -> mlir::DenseElementsAttr {
-    Location loc = toInit.getLoc();
-    if (InitListExpr *initListExpr = dyn_cast<InitListExpr>(expr)) {
-      if (inner) {
-        if (auto mt = toInit.getType().dyn_cast<MemRefType>()) {
-          auto shape = std::vector<int64_t>(mt.getShape());
-          assert(!shape.empty());
-          if (shape.size() > 1)
-            shape.erase(shape.begin());
+  std::function<mlir::DenseElementsAttr(clang::Expr *, mlir::Value, bool)>
+      Helper = [&](class Expr *Expr, mlir::Value ToInit,
+                   bool Inner) -> mlir::DenseElementsAttr {
+    Location Loc = ToInit.getLoc();
+    if (auto *InitListExpr = dyn_cast<clang::InitListExpr>(Expr)) {
+      if (Inner) {
+        if (auto Mt = ToInit.getType().dyn_cast<MemRefType>()) {
+          auto Shape = std::vector<int64_t>(Mt.getShape());
+          assert(!Shape.empty());
+          if (Shape.size() > 1)
+            Shape.erase(Shape.begin());
           else
-            shape[0] = -1;
-          auto mt0 = mlir::MemRefType::get(shape, mt.getElementType(),
+            Shape[0] = -1;
+          auto Mt0 = mlir::MemRefType::get(Shape, Mt.getElementType(),
                                            MemRefLayoutAttrInterface(),
-                                           mt.getMemorySpace());
-          toInit = builder.create<polygeist::SubIndexOp>(loc, mt0, toInit,
+                                           Mt.getMemorySpace());
+          ToInit = Builder.create<polygeist::SubIndexOp>(Loc, Mt0, ToInit,
                                                          getConstantIndex(0));
         }
       }
 
-      unsigned num = 0;
-      if (initListExpr->hasArrayFiller()) {
-        if (auto MT = toInit.getType().dyn_cast<MemRefType>()) {
-          auto shape = MT.getShape();
-          assert(shape.size() > 0);
-          assert(shape[0] != -1);
-          num = shape[0];
+      unsigned Num = 0;
+      if (InitListExpr->hasArrayFiller()) {
+        if (auto MT = ToInit.getType().dyn_cast<MemRefType>()) {
+          auto Shape = MT.getShape();
+          assert(Shape.size() > 0);
+          assert(Shape[0] != -1);
+          Num = Shape[0];
         } else if (auto PT =
-                       toInit.getType().dyn_cast<LLVM::LLVMPointerType>()) {
+                       ToInit.getType().dyn_cast<LLVM::LLVMPointerType>()) {
           if (auto AT = PT.getElementType().dyn_cast<LLVM::LLVMArrayType>()) {
-            num = AT.getNumElements();
+            Num = AT.getNumElements();
           } else if (auto AT =
                          PT.getElementType().dyn_cast<LLVM::LLVMStructType>()) {
-            num = AT.getBody().size();
+            Num = AT.getBody().size();
           } else {
-            toInit.getType().dump();
+            ToInit.getType().dump();
             assert(0 && "TODO get number of values in array filler expression");
           }
         } else {
-          toInit.getType().dump();
+          ToInit.getType().dump();
           assert(0 && "TODO get number of values in array filler expression");
         }
       } else {
-        num = initListExpr->getNumInits();
+        Num = InitListExpr->getNumInits();
       }
 
-      SmallVector<char> attrs;
-      bool allSub = true;
-      for (unsigned i = 0, e = num; i < e; ++i) {
+      SmallVector<char> Attrs;
+      bool AllSub = true;
+      for (unsigned I = 0, E = Num; I < E; ++I) {
 
-        mlir::Value next;
-        if (auto mt = toInit.getType().dyn_cast<MemRefType>()) {
-          auto shape = std::vector<int64_t>(mt.getShape());
-          assert(!shape.empty());
-          shape[0] = -1;
+        mlir::Value Next;
+        if (auto Mt = ToInit.getType().dyn_cast<MemRefType>()) {
+          auto Shape = std::vector<int64_t>(Mt.getShape());
+          assert(!Shape.empty());
+          Shape[0] = -1;
 
-          if (mt.getElementType()
+          if (Mt.getElementType()
                   .isa<mlir::sycl::AccessorType,
                        mlir::sycl::AccessorImplDeviceType,
                        mlir::sycl::ArrayType, mlir::sycl::ItemType,
@@ -262,240 +261,241 @@ mlir::Attribute MLIRScanner::InitializeValueByInitListExpr(mlir::Value toInit,
 
           mlir::Type ET;
           if (auto ST =
-                  mt.getElementType().dyn_cast<mlir::LLVM::LLVMStructType>()) {
-            ET = mlir::MemRefType::get(shape, ST.getBody()[i],
+                  Mt.getElementType().dyn_cast<mlir::LLVM::LLVMStructType>()) {
+            ET = mlir::MemRefType::get(Shape, ST.getBody()[I],
                                        MemRefLayoutAttrInterface(),
-                                       mt.getMemorySpace());
-          } else if (auto ST = mt.getElementType()
+                                       Mt.getMemorySpace());
+          } else if (auto ST = Mt.getElementType()
                                    .dyn_cast<mlir::sycl::ItemBaseType>()) {
-            ET = mlir::MemRefType::get(shape, ST.getBody()[i],
+            ET = mlir::MemRefType::get(Shape, ST.getBody()[I],
                                        MemRefLayoutAttrInterface(),
-                                       mt.getMemorySpace());
+                                       Mt.getMemorySpace());
           } else {
-            ET = mlir::MemRefType::get(shape, mt.getElementType(),
+            ET = mlir::MemRefType::get(Shape, Mt.getElementType(),
                                        MemRefLayoutAttrInterface(),
-                                       mt.getMemorySpace());
+                                       Mt.getMemorySpace());
           }
-          next = builder.create<polygeist::SubIndexOp>(loc, ET, toInit,
-                                                       getConstantIndex(i));
+          Next = Builder.create<polygeist::SubIndexOp>(Loc, ET, ToInit,
+                                                       getConstantIndex(I));
         } else {
-          auto PT = toInit.getType().cast<LLVM::LLVMPointerType>();
+          auto PT = ToInit.getType().cast<LLVM::LLVMPointerType>();
           auto ET = PT.getElementType();
-          mlir::Type nextType;
+          mlir::Type NextType;
           if (auto ST = ET.dyn_cast<LLVM::LLVMStructType>())
-            nextType = ST.getBody()[i];
+            NextType = ST.getBody()[I];
           else if (auto AT = ET.dyn_cast<LLVM::LLVMArrayType>())
-            nextType = AT.getElementType();
+            NextType = AT.getElementType();
           else
             assert(0 && "unknown inner type");
 
-          mlir::Value idxs[] = {
-              builder.create<ConstantIntOp>(loc, 0, 32),
-              builder.create<ConstantIntOp>(loc, i, 32),
+          mlir::Value Idxs[] = {
+              Builder.create<ConstantIntOp>(Loc, 0, 32),
+              Builder.create<ConstantIntOp>(Loc, I, 32),
           };
-          next = builder.create<LLVM::GEPOp>(
-              loc, LLVM::LLVMPointerType::get(nextType, PT.getAddressSpace()),
-              toInit, idxs);
+          Next = Builder.create<LLVM::GEPOp>(
+              Loc, LLVM::LLVMPointerType::get(NextType, PT.getAddressSpace()),
+              ToInit, Idxs);
         }
 
-        auto sub =
-            helper(initListExpr->hasArrayFiller() ? initListExpr->getInit(0)
-                                                  : initListExpr->getInit(i),
-                   next, true);
-        if (sub) {
-          size_t n = 1;
-          if (sub.isSplat())
-            n = sub.size();
-          for (size_t i = 0; i < n; i++)
-            for (auto ea : sub.getRawData())
-              attrs.push_back(ea);
+        auto Sub =
+            Helper(InitListExpr->hasArrayFiller() ? InitListExpr->getInit(0)
+                                                  : InitListExpr->getInit(I),
+                   Next, true);
+        if (Sub) {
+          size_t N = 1;
+          if (Sub.isSplat())
+            N = Sub.size();
+          for (size_t I = 0; I < N; I++)
+            for (auto Ea : Sub.getRawData())
+              Attrs.push_back(Ea);
         } else {
-          allSub = false;
+          AllSub = false;
         }
       }
-      if (!allSub)
+      if (!AllSub)
         return mlir::DenseElementsAttr();
-      if (auto mt = toInit.getType().dyn_cast<MemRefType>()) {
+      if (auto Mt = ToInit.getType().dyn_cast<MemRefType>()) {
         return DenseElementsAttr::getFromRawBuffer(
-            RankedTensorType::get(mt.getShape(), mt.getElementType()), attrs);
+            RankedTensorType::get(Mt.getShape(), Mt.getElementType()), Attrs);
       }
-      return mlir::DenseElementsAttr();
-    } else {
-      bool isArray = false;
-      Glob.getTypes().getMLIRType(expr->getType(), &isArray);
-      ValueCategory sub = Visit(expr);
-      ValueCategory(toInit, /*isReference*/ true).store(builder, sub, isArray);
-      if (!sub.isReference)
-        if (auto mt = toInit.getType().dyn_cast<MemRefType>()) {
-          if (auto cop = sub.val.getDefiningOp<ConstantIntOp>())
-            return DenseElementsAttr::get(
-                RankedTensorType::get(std::vector<int64_t>({1}),
-                                      mt.getElementType()),
-                cop.getValue());
-          if (auto cop = sub.val.getDefiningOp<ConstantFloatOp>())
-            return DenseElementsAttr::get(
-                RankedTensorType::get(std::vector<int64_t>({1}),
-                                      mt.getElementType()),
-                cop.getValue());
-        }
       return mlir::DenseElementsAttr();
     }
+
+    bool IsArray = false;
+    Glob.getTypes().getMLIRType(Expr->getType(), &IsArray);
+    ValueCategory Sub = Visit(Expr);
+    ValueCategory(ToInit, /*isReference*/ true).store(Builder, Sub, IsArray);
+    if (!Sub.isReference)
+      if (auto Mt = ToInit.getType().dyn_cast<MemRefType>()) {
+        if (auto Cop = Sub.val.getDefiningOp<ConstantIntOp>())
+          return DenseElementsAttr::get(
+              RankedTensorType::get(std::vector<int64_t>({1}),
+                                    Mt.getElementType()),
+              Cop.getValue());
+        if (auto Cop = Sub.val.getDefiningOp<ConstantFloatOp>())
+          return DenseElementsAttr::get(
+              RankedTensorType::get(std::vector<int64_t>({1}),
+                                    Mt.getElementType()),
+              Cop.getValue());
+      }
+    return mlir::DenseElementsAttr();
   };
 
-  return helper(expr, toInit, inner);
+  return Helper(Expr, ToInit, Inner);
 }
 
 ValueCategory
-MLIRScanner::VisitCXXDefaultArgExpr(clang::CXXDefaultArgExpr *expr) {
-  return Visit(expr->getExpr());
+MLIRScanner::VisitCXXDefaultArgExpr(clang::CXXDefaultArgExpr *Expr) {
+  return Visit(Expr->getExpr());
 }
 
-ValueCategory MLIRScanner::VisitCXXThisExpr(clang::CXXThisExpr *expr) {
+ValueCategory MLIRScanner::VisitCXXThisExpr(clang::CXXThisExpr *Expr) {
   return ThisVal;
 }
 
-ValueCategory MLIRScanner::VisitPredefinedExpr(clang::PredefinedExpr *expr) {
-  return VisitStringLiteral(expr->getFunctionName());
+ValueCategory MLIRScanner::VisitPredefinedExpr(clang::PredefinedExpr *Expr) {
+  return VisitStringLiteral(Expr->getFunctionName());
 }
 
-ValueCategory MLIRScanner::VisitInitListExpr(clang::InitListExpr *expr) {
-  mlir::Type subType = Glob.getTypes().getMLIRType(expr->getType());
-  bool isArray = false;
+ValueCategory MLIRScanner::VisitInitListExpr(clang::InitListExpr *Expr) {
+  mlir::Type SubType = Glob.getTypes().getMLIRType(Expr->getType());
+  bool IsArray = false;
   bool LLVMABI = false;
 
   if (Glob.getTypes()
           .getMLIRType(Glob.getCGM().getContext().getLValueReferenceType(
-              expr->getType()))
+              Expr->getType()))
           .isa<mlir::LLVM::LLVMPointerType>())
     LLVMABI = true;
   else {
-    Glob.getTypes().getMLIRType(expr->getType(), &isArray);
-    if (isArray)
-      subType = Glob.getTypes().getMLIRType(
-          Glob.getCGM().getContext().getLValueReferenceType(expr->getType()));
+    Glob.getTypes().getMLIRType(Expr->getType(), &IsArray);
+    if (IsArray)
+      SubType = Glob.getTypes().getMLIRType(
+          Glob.getCGM().getContext().getLValueReferenceType(Expr->getType()));
   }
-  auto op = createAllocOp(subType, nullptr, /*memtype*/ 0, isArray, LLVMABI);
-  InitializeValueByInitListExpr(op, expr);
-  return ValueCategory(op, true);
+  auto Op = createAllocOp(SubType, nullptr, /*memtype*/ 0, IsArray, LLVMABI);
+  InitializeValueByInitListExpr(Op, Expr);
+  return ValueCategory(Op, true);
 }
 
 ValueCategory MLIRScanner::VisitCXXStdInitializerListExpr(
-    clang::CXXStdInitializerListExpr *expr) {
+    clang::CXXStdInitializerListExpr *Expr) {
 
-  auto ArrayPtr = Visit(expr->getSubExpr());
+  auto ArrayPtr = Visit(Expr->getSubExpr());
 
   const ConstantArrayType *ArrayType =
       Glob.getCGM().getContext().getAsConstantArrayType(
-          expr->getSubExpr()->getType());
+          Expr->getSubExpr()->getType());
   assert(ArrayType && "std::initializer_list constructed from non-array");
 
   // FIXME: Perform the checks on the field types in SemaInit.
-  RecordDecl *Record = expr->getType()->castAs<RecordType>()->getDecl();
+  RecordDecl *Record = Expr->getType()->castAs<RecordType>()->getDecl();
   auto Field = Record->field_begin();
 
-  mlir::Type subType = Glob.getTypes().getMLIRType(expr->getType());
+  mlir::Type SubType = Glob.getTypes().getMLIRType(Expr->getType());
 
-  mlir::Value res = builder.create<LLVM::UndefOp>(loc, subType);
+  mlir::Value Res = Builder.create<LLVM::UndefOp>(Loc, SubType);
 
   ArrayPtr = CommonArrayToPointer(ArrayPtr);
 
-  res = builder.create<LLVM::InsertValueOp>(loc, res,
-                                            ArrayPtr.getValue(builder), 0);
+  Res = Builder.create<LLVM::InsertValueOp>(Loc, Res,
+                                            ArrayPtr.getValue(Builder), 0);
   Field++;
-  auto iTy =
+  auto ITy =
       Glob.getTypes().getMLIRType(Field->getType()).cast<mlir::IntegerType>();
-  res = builder.create<LLVM::InsertValueOp>(
-      loc, res,
-      builder.create<arith::ConstantIntOp>(
-          loc, ArrayType->getSize().getZExtValue(), iTy.getWidth()),
+  Res = Builder.create<LLVM::InsertValueOp>(
+      Loc, Res,
+      Builder.create<arith::ConstantIntOp>(
+          Loc, ArrayType->getSize().getZExtValue(), ITy.getWidth()),
       1);
-  return ValueCategory(res, /*isRef*/ false);
+  return ValueCategory(Res, /*isRef*/ false);
 }
 
 ValueCategory
-MLIRScanner::VisitArrayInitIndexExpr(clang::ArrayInitIndexExpr *expr) {
-  assert(arrayinit.size());
+MLIRScanner::VisitArrayInitIndexExpr(clang::ArrayInitIndexExpr *Expr) {
+  assert(ArrayInit.size());
   return ValueCategory(
-      builder.create<IndexCastOp>(
-          loc, Glob.getTypes().getMLIRType(expr->getType()), arrayinit.back()),
+      Builder.create<IndexCastOp>(
+          Loc, Glob.getTypes().getMLIRType(Expr->getType()), ArrayInit.back()),
       /*isReference*/ false);
 }
 
 static const clang::ConstantArrayType *getCAT(const clang::Type *T) {
   const clang::Type *Child;
-  if (auto CAT = dyn_cast<clang::ConstantArrayType>(T)) {
+  if (const auto *CAT = dyn_cast<clang::ConstantArrayType>(T))
     return CAT;
-  } else if (auto ET = dyn_cast<clang::ElaboratedType>(T)) {
+
+  if (const auto *ET = dyn_cast<clang::ElaboratedType>(T))
     Child = ET->getNamedType().getTypePtr();
-  } else if (auto TypeDefT = dyn_cast<clang::TypedefType>(T)) {
+  else if (const auto *TypeDefT = dyn_cast<clang::TypedefType>(T))
     Child = TypeDefT->getUnqualifiedDesugaredType();
-  } else {
+  else
     llvm_unreachable("Unhandled case\n");
-  }
+
   return getCAT(Child);
 }
 
-ValueCategory MLIRScanner::VisitArrayInitLoop(clang::ArrayInitLoopExpr *expr,
-                                              ValueCategory tostore) {
-  const clang::ConstantArrayType *CAT = getCAT(expr->getType().getTypePtr());
-  llvm::errs() << "warning recomputing common in arrayinitloopexpr\n";
-  std::vector<mlir::Value> start = {getConstantIndex(0)};
-  std::vector<mlir::Value> sizes = {
+ValueCategory MLIRScanner::VisitArrayInitLoop(clang::ArrayInitLoopExpr *Expr,
+                                              ValueCategory Tostore) {
+  const clang::ConstantArrayType *CAT = getCAT(Expr->getType().getTypePtr());
+  llvm::errs() << "warning recomputing common in  ArrayInitloopexpr\n";
+  std::vector<mlir::Value> Start = {getConstantIndex(0)};
+  std::vector<mlir::Value> Sizes = {
       getConstantIndex(CAT->getSize().getLimitedValue())};
-  AffineMap map = builder.getSymbolIdentityMap();
-  auto affineOp = builder.create<AffineForOp>(loc, start, map, sizes, map);
+  AffineMap Map = Builder.getSymbolIdentityMap();
+  auto AffineOp = Builder.create<AffineForOp>(Loc, Start, Map, Sizes, Map);
 
-  auto oldpoint = builder.getInsertionPoint();
-  auto oldblock = builder.getInsertionBlock();
+  auto Oldpoint = Builder.getInsertionPoint();
+  auto *Oldblock = Builder.getInsertionBlock();
 
-  builder.setInsertionPointToStart(&affineOp.getLoopBody().front());
+  Builder.setInsertionPointToStart(&AffineOp.getLoopBody().front());
 
-  arrayinit.push_back(affineOp.getInductionVar());
+  ArrayInit.push_back(AffineOp.getInductionVar());
 
-  auto alu =
-      CommonArrayLookup(CommonArrayToPointer(tostore),
-                        affineOp.getInductionVar(), /*isImplicitRef*/ false);
+  auto Alu =
+      CommonArrayLookup(CommonArrayToPointer(Tostore),
+                        AffineOp.getInductionVar(), /*isImplicitRef*/ false);
 
-  if (auto AILE = dyn_cast<ArrayInitLoopExpr>(expr->getSubExpr())) {
-    VisitArrayInitLoop(AILE, alu);
+  if (auto *AILE = dyn_cast<ArrayInitLoopExpr>(Expr->getSubExpr())) {
+    VisitArrayInitLoop(AILE, Alu);
   } else {
-    auto val = Visit(expr->getSubExpr());
-    if (!val.val) {
-      expr->dump();
-      expr->getSubExpr()->dump();
+    auto Val = Visit(Expr->getSubExpr());
+    if (!Val.val) {
+      Expr->dump();
+      Expr->getSubExpr()->dump();
     }
-    assert(val.val);
-    assert(tostore.isReference);
-    bool isArray = false;
-    Glob.getTypes().getMLIRType(expr->getSubExpr()->getType(), &isArray);
-    alu.store(builder, val, isArray);
+    assert(Val.val);
+    assert(Tostore.isReference);
+    bool IsArray = false;
+    Glob.getTypes().getMLIRType(Expr->getSubExpr()->getType(), &IsArray);
+    Alu.store(Builder, Val, IsArray);
   }
 
-  arrayinit.pop_back();
+  ArrayInit.pop_back();
 
-  builder.setInsertionPoint(oldblock, oldpoint);
+  Builder.setInsertionPoint(Oldblock, Oldpoint);
   return nullptr;
 }
 
 ValueCategory
-MLIRScanner::VisitCXXFunctionalCastExpr(clang::CXXFunctionalCastExpr *expr) {
-  if (expr->getType()->isVoidType()) {
-    Visit(expr->getSubExpr());
+MLIRScanner::VisitCXXFunctionalCastExpr(clang::CXXFunctionalCastExpr *Expr) {
+  if (Expr->getType()->isVoidType()) {
+    Visit(Expr->getSubExpr());
     return nullptr;
   }
-  if (expr->getCastKind() == clang::CastKind::CK_NoOp)
-    return Visit(expr->getSubExpr());
-  if (expr->getCastKind() == clang::CastKind::CK_ConstructorConversion)
-    return Visit(expr->getSubExpr());
-  return VisitCastExpr(expr);
+  if (Expr->getCastKind() == clang::CastKind::CK_NoOp)
+    return Visit(Expr->getSubExpr());
+  if (Expr->getCastKind() == clang::CastKind::CK_ConstructorConversion)
+    return Visit(Expr->getSubExpr());
+  return VisitCastExpr(Expr);
 }
 
 ValueCategory
-MLIRScanner::VisitCXXBindTemporaryExpr(clang::CXXBindTemporaryExpr *expr) {
-  return Visit(expr->getSubExpr());
+MLIRScanner::VisitCXXBindTemporaryExpr(clang::CXXBindTemporaryExpr *Expr) {
+  return Visit(Expr->getSubExpr());
 }
 
-ValueCategory MLIRScanner::VisitLambdaExpr(clang::LambdaExpr *expr) {
+ValueCategory MLIRScanner::VisitLambdaExpr(clang::LambdaExpr *Expr) {
 
   // llvm::DenseMap<const VarDecl *, FieldDecl *> InnerCaptures;
   // FieldDecl *ThisCapture = nullptr;
@@ -503,339 +503,337 @@ ValueCategory MLIRScanner::VisitLambdaExpr(clang::LambdaExpr *expr) {
   // expr->getLambdaClass()->getCaptureFields(InnerCaptures, ThisCapture);
 
   bool LLVMABI = false;
-  mlir::Type t =
-      Glob.getTypes().getMLIRType(expr->getCallOperator()->getThisType());
+  mlir::Type T =
+      Glob.getTypes().getMLIRType(Expr->getCallOperator()->getThisType());
 
-  bool isArray =
+  bool IsArray =
       false; // isa<clang::ArrayType>(expr->getCallOperator()->getThisType());
-  Glob.getTypes().getMLIRType(expr->getCallOperator()->getThisObjectType(),
-                              &isArray);
+  Glob.getTypes().getMLIRType(Expr->getCallOperator()->getThisObjectType(),
+                              &IsArray);
 
-  if (auto PT = t.dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+  if (auto PT = T.dyn_cast<mlir::LLVM::LLVMPointerType>()) {
     LLVMABI = true;
-    t = PT.getElementType();
+    T = PT.getElementType();
   }
-  if (auto mt = t.dyn_cast<MemRefType>()) {
-    auto shape = std::vector<int64_t>(mt.getShape());
-    if (!isArray)
-      shape[0] = 1;
-    t = mlir::MemRefType::get(shape, mt.getElementType(),
-                              MemRefLayoutAttrInterface(), mt.getMemorySpace());
+  if (auto Mt = T.dyn_cast<MemRefType>()) {
+    auto Shape = std::vector<int64_t>(Mt.getShape());
+    if (!IsArray)
+      Shape[0] = 1;
+    T = mlir::MemRefType::get(Shape, Mt.getElementType(),
+                              MemRefLayoutAttrInterface(), Mt.getMemorySpace());
   }
-  auto op = createAllocOp(t, nullptr, /*memtype*/ 0, isArray, LLVMABI);
+  auto Op = createAllocOp(T, nullptr, /*memtype*/ 0, IsArray, LLVMABI);
 
-  for (auto tup : llvm::zip(expr->getLambdaClass()->captures(),
-                            expr->getLambdaClass()->fields())) {
-    auto C = std::get<0>(tup);
-    auto field = std::get<1>(tup);
+  for (auto Tup : llvm::zip(Expr->getLambdaClass()->captures(),
+                            Expr->getLambdaClass()->fields())) {
+    auto C = std::get<0>(Tup);
+    auto *Field = std::get<1>(Tup);
     if (C.capturesThis())
       continue;
-    else if (!C.capturesVariable())
+    if (!C.capturesVariable())
       continue;
 
     auto CK = C.getCaptureKind();
-    auto var = C.getCapturedVar();
+    auto *Var = C.getCapturedVar();
 
-    ValueCategory result;
+    ValueCategory Result;
 
-    if (params.find(var) != params.end()) {
-      result = params[var];
-    } else {
-      if (auto VD = dyn_cast<VarDecl>(var)) {
+    if (Params.find(Var) != Params.end())
+      Result = Params[Var];
+    else {
+      if (auto *VD = dyn_cast<VarDecl>(Var)) {
         if (Captures.find(VD) != Captures.end()) {
-          FieldDecl *field = Captures[VD];
-          result = CommonFieldLookup(
+          FieldDecl *Field = Captures[VD];
+          Result = CommonFieldLookup(
               cast<CXXMethodDecl>(EmittingFunctionDecl)->getThisObjectType(),
-              field, ThisVal.val, /*isLValue*/ false);
+              Field, ThisVal.val, /*isLValue*/ false);
           assert(CaptureKinds.find(VD) != CaptureKinds.end());
           if (CaptureKinds[VD] == LambdaCaptureKind::LCK_ByRef)
-            result = result.dereference(builder);
+            Result = Result.dereference(Builder);
           goto endp;
         }
       }
       EmittingFunctionDecl->dump();
-      expr->dump();
-      function.dump();
+      Expr->dump();
+      Function.dump();
       llvm::errs() << "<pairs>\n";
-      for (auto p : params)
-        p.first->dump();
+      for (auto P : Params)
+        P.first->dump();
       llvm::errs() << "</pairs>";
-      var->dump();
+      Var->dump();
     }
   endp:
 
-    bool isArray = false;
-    Glob.getTypes().getMLIRType(field->getType(), &isArray);
+    bool IsArray = false;
+    Glob.getTypes().getMLIRType(Field->getType(), &IsArray);
 
     if (CK == LambdaCaptureKind::LCK_ByCopy)
-      CommonFieldLookup(expr->getCallOperator()->getThisObjectType(), field, op,
+      CommonFieldLookup(Expr->getCallOperator()->getThisObjectType(), Field, Op,
                         /*isLValue*/ false)
-          .store(builder, result, isArray);
+          .store(Builder, Result, IsArray);
     else {
       assert(CK == LambdaCaptureKind::LCK_ByRef);
-      assert(result.isReference);
+      assert(Result.isReference);
 
-      auto val = result.val;
+      auto Val = Result.val;
 
-      if (auto mt = val.getType().dyn_cast<MemRefType>()) {
-        auto shape = std::vector<int64_t>(mt.getShape());
-        shape[0] = -1;
-        val = builder.create<memref::CastOp>(
-            loc,
-            MemRefType::get(shape, mt.getElementType(),
-                            MemRefLayoutAttrInterface(), mt.getMemorySpace()),
-            val);
+      if (auto Mt = Val.getType().dyn_cast<MemRefType>()) {
+        auto Shape = std::vector<int64_t>(Mt.getShape());
+        Shape[0] = -1;
+        Val = Builder.create<memref::CastOp>(
+            Loc,
+            MemRefType::get(Shape, Mt.getElementType(),
+                            MemRefLayoutAttrInterface(), Mt.getMemorySpace()),
+            Val);
       }
 
-      CommonFieldLookup(expr->getCallOperator()->getThisObjectType(), field, op,
+      CommonFieldLookup(Expr->getCallOperator()->getThisObjectType(), Field, Op,
                         /*isLValue*/ false)
-          .store(builder, val);
+          .store(Builder, Val);
     }
   }
-  return ValueCategory(op, /*isReference*/ true);
+  return ValueCategory(Op, /*isReference*/ true);
 }
 
 // TODO actually deallocate
 ValueCategory MLIRScanner::VisitMaterializeTemporaryExpr(
-    clang::MaterializeTemporaryExpr *expr) {
-  auto v = Visit(expr->getSubExpr());
-  if (!v.val) {
-    expr->dump();
+    clang::MaterializeTemporaryExpr *Expr) {
+  auto V = Visit(Expr->getSubExpr());
+  if (!V.val) {
+    Expr->dump();
   }
-  assert(v.val);
+  assert(V.val);
 
-  bool isArray = false;
+  bool IsArray = false;
   bool LLVMABI = false;
   if (Glob.getTypes()
           .getMLIRType(Glob.getCGM().getContext().getLValueReferenceType(
-              expr->getSubExpr()->getType()))
+              Expr->getSubExpr()->getType()))
           .isa<mlir::LLVM::LLVMPointerType>())
     LLVMABI = true;
   else {
-    Glob.getTypes().getMLIRType(expr->getSubExpr()->getType(), &isArray);
+    Glob.getTypes().getMLIRType(Expr->getSubExpr()->getType(), &IsArray);
   }
-  if (isArray)
-    return v;
+  if (IsArray)
+    return V;
 
   llvm::errs() << "cleanup of materialized not handled";
-  auto op =
-      createAllocOp(Glob.getTypes().getMLIRType(expr->getSubExpr()->getType()),
-                    nullptr, 0, /*isArray*/ isArray, /*LLVMABI*/ LLVMABI);
+  auto Op =
+      createAllocOp(Glob.getTypes().getMLIRType(Expr->getSubExpr()->getType()),
+                    nullptr, 0, /*isArray*/ IsArray, /*LLVMABI*/ LLVMABI);
 
-  ValueCategory(op, /*isRefererence*/ true).store(builder, v, isArray);
-  return ValueCategory(op, /*isRefererence*/ true);
+  ValueCategory(Op, /*isRefererence*/ true).store(Builder, V, IsArray);
+  return ValueCategory(Op, /*isRefererence*/ true);
 }
 
-ValueCategory MLIRScanner::VisitCXXDeleteExpr(clang::CXXDeleteExpr *expr) {
-  auto loc = getMLIRLocation(expr->getExprLoc());
-  expr->dump();
+ValueCategory MLIRScanner::VisitCXXDeleteExpr(clang::CXXDeleteExpr *Expr) {
+  Location Loc = getMLIRLocation(Expr->getExprLoc());
+  Expr->dump();
   llvm::errs() << "warning not calling destructor on delete\n";
 
-  mlir::Value toDelete = Visit(expr->getArgument()).getValue(builder);
+  mlir::Value ToDelete = Visit(Expr->getArgument()).getValue(Builder);
 
-  if (toDelete.getType().isa<mlir::MemRefType>()) {
-    builder.create<mlir::memref::DeallocOp>(loc, toDelete);
+  if (ToDelete.getType().isa<mlir::MemRefType>()) {
+    Builder.create<mlir::memref::DeallocOp>(Loc, ToDelete);
   } else {
-    mlir::Value args[1] = {builder.create<LLVM::BitcastOp>(
-        loc, LLVM::LLVMPointerType::get(builder.getI8Type()), toDelete)};
-    builder.create<mlir::LLVM::CallOp>(loc, Glob.GetOrCreateFreeFunction(),
-                                       args);
+    mlir::Value Args[1] = {Builder.create<LLVM::BitcastOp>(
+        Loc, LLVM::LLVMPointerType::get(Builder.getI8Type()), ToDelete)};
+    Builder.create<mlir::LLVM::CallOp>(Loc, Glob.getOrCreateFreeFunction(),
+                                       Args);
   }
 
   return nullptr;
 }
-ValueCategory MLIRScanner::VisitCXXNewExpr(clang::CXXNewExpr *expr) {
-  auto loc = getMLIRLocation(expr->getExprLoc());
+ValueCategory MLIRScanner::VisitCXXNewExpr(clang::CXXNewExpr *Expr) {
+  Location Loc = getMLIRLocation(Expr->getExprLoc());
 
-  mlir::Value count;
+  mlir::Value Count;
 
-  if (expr->isArray()) {
-    count = Visit(*expr->raw_arg_begin()).getValue(builder);
-    count = builder.create<IndexCastOp>(
-        loc, mlir::IndexType::get(builder.getContext()), count);
+  if (Expr->isArray()) {
+    Count = Visit(*Expr->raw_arg_begin()).getValue(Builder);
+    Count = Builder.create<IndexCastOp>(
+        Loc, mlir::IndexType::get(Builder.getContext()), Count);
   } else {
-    count = getConstantIndex(1);
+    Count = getConstantIndex(1);
   }
-  assert(count);
+  assert(Count);
 
-  mlir::Type ty = Glob.getTypes().getMLIRType(expr->getType());
+  mlir::Type Ty = Glob.getTypes().getMLIRType(Expr->getType());
 
-  mlir::Value alloc;
-  mlir::Value arrayCons;
-  if (!expr->placement_arguments().empty()) {
-    mlir::Value val = Visit(*expr->placement_arg_begin()).getValue(builder);
-    if (auto mt = ty.dyn_cast<mlir::MemRefType>()) {
-      arrayCons = alloc =
-          builder.create<polygeist::Pointer2MemrefOp>(loc, mt, val);
+  mlir::Value Alloc;
+  mlir::Value ArrayCons;
+  if (!Expr->placement_arguments().empty()) {
+    mlir::Value Val = Visit(*Expr->placement_arg_begin()).getValue(Builder);
+    if (auto Mt = Ty.dyn_cast<mlir::MemRefType>()) {
+      ArrayCons = Alloc =
+          Builder.create<polygeist::Pointer2MemrefOp>(Loc, Mt, Val);
     } else {
-      arrayCons = alloc = builder.create<mlir::LLVM::BitcastOp>(loc, ty, val);
-      auto PT = ty.cast<LLVM::LLVMPointerType>();
-      if (expr->isArray())
-        arrayCons = builder.create<mlir::LLVM::BitcastOp>(
-            loc,
+      ArrayCons = Alloc = Builder.create<mlir::LLVM::BitcastOp>(Loc, Ty, Val);
+      auto PT = Ty.cast<LLVM::LLVMPointerType>();
+      if (Expr->isArray())
+        ArrayCons = Builder.create<mlir::LLVM::BitcastOp>(
+            Loc,
             LLVM::LLVMPointerType::get(
                 LLVM::LLVMArrayType::get(PT.getElementType(), 0),
                 PT.getAddressSpace()),
-            alloc);
+            Alloc);
     }
-  } else if (auto mt = ty.dyn_cast<mlir::MemRefType>()) {
-    auto shape = std::vector<int64_t>(mt.getShape());
-    mlir::Value args[1] = {count};
-    arrayCons = alloc = builder.create<mlir::memref::AllocOp>(loc, mt, args);
-    if (expr->hasInitializer() && isa<InitListExpr>(expr->getInitializer()))
-      (void)InitializeValueByInitListExpr(alloc, expr->getInitializer());
+  } else if (auto Mt = Ty.dyn_cast<mlir::MemRefType>()) {
+    auto Shape = std::vector<int64_t>(Mt.getShape());
+    mlir::Value Args[1] = {Count};
+    ArrayCons = Alloc = Builder.create<mlir::memref::AllocOp>(Loc, Mt, Args);
+    if (Expr->hasInitializer() && isa<InitListExpr>(Expr->getInitializer()))
+      (void)InitializeValueByInitListExpr(Alloc, Expr->getInitializer());
 
   } else {
-    auto i64 = mlir::IntegerType::get(count.getContext(), 64);
-    auto typeSize = getTypeSize(expr->getAllocatedType());
-    mlir::Value args[1] = {builder.create<arith::MulIOp>(loc, typeSize, count)};
-    args[0] = builder.create<IndexCastOp>(loc, i64, args[0]);
-    arrayCons = alloc = builder.create<mlir::LLVM::BitcastOp>(
-        loc, ty,
-        builder
-            .create<mlir::LLVM::CallOp>(loc, Glob.GetOrCreateMallocFunction(),
-                                        args)
+    auto I64 = mlir::IntegerType::get(Count.getContext(), 64);
+    auto TypeSize = getTypeSize(Expr->getAllocatedType());
+    mlir::Value Args[1] = {Builder.create<arith::MulIOp>(Loc, TypeSize, Count)};
+    Args[0] = Builder.create<IndexCastOp>(Loc, I64, Args[0]);
+    ArrayCons = Alloc = Builder.create<mlir::LLVM::BitcastOp>(
+        Loc, Ty,
+        Builder
+            .create<mlir::LLVM::CallOp>(Loc, Glob.getOrCreateMallocFunction(),
+                                        Args)
             ->getResult(0));
-    auto PT = ty.cast<LLVM::LLVMPointerType>();
-    if (expr->isArray())
-      arrayCons = builder.create<mlir::LLVM::BitcastOp>(
-          loc,
+    auto PT = Ty.cast<LLVM::LLVMPointerType>();
+    if (Expr->isArray())
+      ArrayCons = Builder.create<mlir::LLVM::BitcastOp>(
+          Loc,
           LLVM::LLVMPointerType::get(
               LLVM::LLVMArrayType::get(PT.getElementType(), 0),
               PT.getAddressSpace()),
-          alloc);
+          Alloc);
   }
-  assert(alloc);
+  assert(Alloc);
 
-  if (expr->getConstructExpr()) {
+  if (Expr->getConstructExpr()) {
     VisitConstructCommon(
-        const_cast<CXXConstructExpr *>(expr->getConstructExpr()),
-        /*name*/ nullptr, /*memtype*/ 0, arrayCons, count);
+        const_cast<CXXConstructExpr *>(Expr->getConstructExpr()),
+        /*name*/ nullptr, /*memtype*/ 0, ArrayCons, Count);
   }
-  return ValueCategory(alloc, /*isRefererence*/ false);
+  return ValueCategory(Alloc, /*isRefererence*/ false);
 }
 
 ValueCategory
-MLIRScanner::VisitCXXScalarValueInitExpr(clang::CXXScalarValueInitExpr *expr) {
-  auto loc = getMLIRLocation(expr->getExprLoc());
+MLIRScanner::VisitCXXScalarValueInitExpr(clang::CXXScalarValueInitExpr *Expr) {
+  Location Loc = getMLIRLocation(Expr->getExprLoc());
 
-  bool isArray = false;
-  mlir::Type melem = Glob.getTypes().getMLIRType(expr->getType(), &isArray);
-  assert(!isArray);
+  bool IsArray = false;
+  mlir::Type Melem = Glob.getTypes().getMLIRType(Expr->getType(), &IsArray);
+  assert(!IsArray);
 
-  if (melem.isa<mlir::IntegerType>())
-    return ValueCategory(builder.create<ConstantIntOp>(loc, 0, melem), false);
-  else if (auto MT = melem.dyn_cast<mlir::MemRefType>())
+  if (Melem.isa<mlir::IntegerType>())
+    return ValueCategory(Builder.create<ConstantIntOp>(Loc, 0, Melem), false);
+  if (auto MT = Melem.dyn_cast<mlir::MemRefType>())
     return ValueCategory(
-        builder.create<polygeist::Pointer2MemrefOp>(
-            loc, MT,
-            builder.create<mlir::LLVM::NullOp>(
-                loc, LLVM::LLVMPointerType::get(builder.getI8Type(),
+        Builder.create<polygeist::Pointer2MemrefOp>(
+            Loc, MT,
+            Builder.create<mlir::LLVM::NullOp>(
+                Loc, LLVM::LLVMPointerType::get(Builder.getI8Type(),
                                                 MT.getMemorySpaceAsInt()))),
         false);
-  else if (auto PT = melem.dyn_cast<mlir::LLVM::LLVMPointerType>())
-    return ValueCategory(builder.create<mlir::LLVM::NullOp>(loc, PT), false);
-  else {
-    if (!melem.isa<FloatType>())
-      expr->dump();
-    auto ft = melem.cast<FloatType>();
-    return ValueCategory(builder.create<ConstantFloatOp>(
-                             loc, APFloat(ft.getFloatSemantics(), "0"), ft),
-                         false);
-  }
+  if (auto PT = Melem.dyn_cast<mlir::LLVM::LLVMPointerType>())
+    return ValueCategory(Builder.create<mlir::LLVM::NullOp>(Loc, PT), false);
+  if (!Melem.isa<FloatType>())
+    Expr->dump();
+  auto Ft = Melem.cast<FloatType>();
+  return ValueCategory(Builder.create<ConstantFloatOp>(
+                           Loc, APFloat(Ft.getFloatSemantics(), "0"), Ft),
+                       false);
 }
 
 ValueCategory MLIRScanner::VisitCXXPseudoDestructorExpr(
-    clang::CXXPseudoDestructorExpr *expr) {
-  Visit(expr->getBase());
+    clang::CXXPseudoDestructorExpr *Expr) {
+  Visit(Expr->getBase());
   llvm::errs() << "not running pseudo destructor\n";
   return nullptr;
 }
 
 ValueCategory
-MLIRScanner::VisitCXXConstructExpr(clang::CXXConstructExpr *cons) {
-  return VisitConstructCommon(cons, /*name*/ nullptr, /*space*/ 0);
+MLIRScanner::VisitCXXConstructExpr(clang::CXXConstructExpr *Cons) {
+  return VisitConstructCommon(Cons, /*name*/ nullptr, /*space*/ 0);
 }
 
-ValueCategory MLIRScanner::VisitConstructCommon(clang::CXXConstructExpr *cons,
-                                                VarDecl *name, unsigned memtype,
-                                                mlir::Value op,
-                                                mlir::Value count) {
-  auto loc = getMLIRLocation(cons->getExprLoc());
+ValueCategory MLIRScanner::VisitConstructCommon(clang::CXXConstructExpr *Cons,
+                                                VarDecl *Name, unsigned Memtype,
+                                                mlir::Value Op,
+                                                mlir::Value Count) {
+  Location Loc = getMLIRLocation(Cons->getExprLoc());
 
-  bool isArray = false;
-  mlir::Type subType = Glob.getTypes().getMLIRType(cons->getType(), &isArray);
+  bool IsArray = false;
+  mlir::Type SubType = Glob.getTypes().getMLIRType(Cons->getType(), &IsArray);
 
   bool LLVMABI = false;
-  mlir::Type ptrty = Glob.getTypes().getMLIRType(
-      Glob.getCGM().getContext().getLValueReferenceType(cons->getType()));
-  if (ptrty.isa<mlir::LLVM::LLVMPointerType>())
+  mlir::Type Ptrty = Glob.getTypes().getMLIRType(
+      Glob.getCGM().getContext().getLValueReferenceType(Cons->getType()));
+  if (Ptrty.isa<mlir::LLVM::LLVMPointerType>())
     LLVMABI = true;
-  else if (isArray) {
-    subType = ptrty;
-    isArray = true;
+  else if (IsArray) {
+    SubType = Ptrty;
+    IsArray = true;
   }
-  if (op == nullptr)
-    op = createAllocOp(subType, name, memtype, isArray, LLVMABI);
+  if (Op == nullptr)
+    Op = createAllocOp(SubType, Name, Memtype, IsArray, LLVMABI);
 
-  if (cons->requiresZeroInitialization()) {
-    mlir::Value val = op;
-    if (val.getType().isa<MemRefType>()) {
-      val = builder.create<polygeist::Memref2PointerOp>(
-          loc,
+  if (Cons->requiresZeroInitialization()) {
+    mlir::Value Val = Op;
+    if (Val.getType().isa<MemRefType>()) {
+      Val = Builder.create<polygeist::Memref2PointerOp>(
+          Loc,
           LLVM::LLVMPointerType::get(
-              builder.getI8Type(),
-              val.getType().cast<MemRefType>().getMemorySpaceAsInt()),
-          val);
+              Builder.getI8Type(),
+              Val.getType().cast<MemRefType>().getMemorySpaceAsInt()),
+          Val);
     } else {
-      val = builder.create<LLVM::BitcastOp>(
-          loc,
+      Val = Builder.create<LLVM::BitcastOp>(
+          Loc,
           LLVM::LLVMPointerType::get(
-              builder.getI8Type(),
-              val.getType().cast<LLVM::LLVMPointerType>().getAddressSpace()),
-          val);
+              Builder.getI8Type(),
+              Val.getType().cast<LLVM::LLVMPointerType>().getAddressSpace()),
+          Val);
     }
-    mlir::Value size = getTypeSize(cons->getType());
+    mlir::Value Size = getTypeSize(Cons->getType());
 
-    auto i8_0 = builder.create<ConstantIntOp>(loc, 0, 8);
-    auto sizev =
-        builder.create<arith::IndexCastOp>(loc, builder.getI64Type(), size);
+    auto I80 = Builder.create<ConstantIntOp>(Loc, 0, 8);
+    auto Sizev =
+        Builder.create<arith::IndexCastOp>(Loc, Builder.getI64Type(), Size);
 
-    auto falsev = builder.create<ConstantIntOp>(loc, false, 1);
-    builder.create<LLVM::MemsetOp>(loc, val, i8_0, sizev, falsev);
+    auto Falsev = Builder.create<ConstantIntOp>(Loc, false, 1);
+    Builder.create<LLVM::MemsetOp>(Loc, Val, I80, Sizev, Falsev);
   }
 
-  CXXConstructorDecl *ctorDecl = cons->getConstructor();
-  if (ctorDecl->isTrivial() && ctorDecl->isDefaultConstructor())
-    return ValueCategory(op, /*isReference*/ true);
+  CXXConstructorDecl *CtorDecl = Cons->getConstructor();
+  if (CtorDecl->isTrivial() && CtorDecl->isDefaultConstructor())
+    return ValueCategory(Op, /*isReference*/ true);
 
-  mlir::Block::iterator oldpoint;
-  mlir::Block *oldblock;
-  ValueCategory endobj(op, /*isReference*/ true);
+  mlir::Block::iterator Oldpoint;
+  mlir::Block *Oldblock;
+  ValueCategory Endobj(Op, /*isReference*/ true);
 
-  ValueCategory obj(op, /*isReference*/ true);
-  QualType innerType = cons->getType();
-  if (auto arrayType =
-          Glob.getCGM().getContext().getAsArrayType(cons->getType())) {
-    innerType = arrayType->getElementType();
-    mlir::Value size;
-    if (count)
-      size = count;
+  ValueCategory Obj(Op, /*isReference*/ true);
+  QualType InnerType = Cons->getType();
+  if (const auto *ArrayType =
+          Glob.getCGM().getContext().getAsArrayType(Cons->getType())) {
+    InnerType = ArrayType->getElementType();
+    mlir::Value Size;
+    if (Count)
+      Size = Count;
     else {
-      auto CAT = cast<clang::ConstantArrayType>(arrayType);
-      size = getConstantIndex(CAT->getSize().getLimitedValue());
+      const auto *CAT = cast<clang::ConstantArrayType>(ArrayType);
+      Size = getConstantIndex(CAT->getSize().getLimitedValue());
     }
-    auto forOp = builder.create<scf::ForOp>(loc, getConstantIndex(0), size,
+    auto ForOp = Builder.create<scf::ForOp>(Loc, getConstantIndex(0), Size,
                                             getConstantIndex(1));
-    oldpoint = builder.getInsertionPoint();
-    oldblock = builder.getInsertionBlock();
+    Oldpoint = Builder.getInsertionPoint();
+    Oldblock = Builder.getInsertionBlock();
 
-    builder.setInsertionPointToStart(&forOp.getLoopBody().front());
-    assert(obj.isReference);
-    obj = CommonArrayToPointer(obj);
-    obj = CommonArrayLookup(obj, forOp.getInductionVar(),
+    Builder.setInsertionPointToStart(&ForOp.getLoopBody().front());
+    assert(Obj.isReference);
+    Obj = CommonArrayToPointer(Obj);
+    Obj = CommonArrayLookup(Obj, ForOp.getInductionVar(),
                             /*isImplicitRef*/ false, /*removeIndex*/ false);
-    assert(obj.isReference);
+    assert(Obj.isReference);
   }
 
   /// If the constructor is part of the SYCL namespace, we may not want the
@@ -844,113 +842,109 @@ ValueCategory MLIRScanner::VisitConstructCommon(clang::CXXConstructExpr *cons,
   /// that we still generate some constructors that we need for lowering some
   /// sycl op.  Therefore, in those case, we set ShouldEmit back to "true" by
   /// looking them up in our "registry" of supported constructors.
-  bool isSyclCtor =
-      mlirclang::isNamespaceSYCL(ctorDecl->getEnclosingNamespaceContext());
-  bool ShouldEmit = !isSyclCtor;
+  bool IsSyclCtor =
+      mlirclang::isNamespaceSYCL(CtorDecl->getEnclosingNamespaceContext());
+  bool ShouldEmit = !IsSyclCtor;
 
-  std::string mangledName = MLIRScanner::getMangledFuncName(
-      cast<FunctionDecl>(*ctorDecl), Glob.getCGM());
-  mangledName = (PrefixABI + mangledName);
-  if (GenerateAllSYCLFuncs || !isUnsupportedFunction(mangledName))
+  std::string MangledName = MLIRScanner::getMangledFuncName(
+      cast<FunctionDecl>(*CtorDecl), Glob.getCGM());
+  MangledName = (PrefixABI + MangledName);
+  if (GenerateAllSYCLFuncs || !isUnsupportedFunction(MangledName))
     ShouldEmit = true;
 
-  FunctionToEmit F(*ctorDecl, mlirclang::getInputContext(builder));
-  auto ToCall = cast<func::FuncOp>(Glob.GetOrCreateMLIRFunction(F, ShouldEmit));
+  FunctionToEmit F(*CtorDecl, mlirclang::getInputContext(Builder));
+  auto ToCall = cast<func::FuncOp>(Glob.getOrCreateMLIRFunction(F, ShouldEmit));
 
-  SmallVector<std::pair<ValueCategory, clang::Expr *>> Args{{obj, nullptr}};
-  Args.reserve(cons->getNumArgs() + 1);
-  for (auto A : cons->arguments())
+  SmallVector<std::pair<ValueCategory, clang::Expr *>> Args{{Obj, nullptr}};
+  Args.reserve(Cons->getNumArgs() + 1);
+  for (auto *A : Cons->arguments())
     Args.emplace_back(Visit(A), A);
 
-  callHelper(ToCall, innerType, Args,
-             /*retType*/ Glob.getCGM().getContext().VoidTy, false, cons,
-             *ctorDecl);
+  callHelper(ToCall, InnerType, Args,
+             /*retType*/ Glob.getCGM().getContext().VoidTy, false, Cons,
+             *CtorDecl);
 
-  if (Glob.getCGM().getContext().getAsArrayType(cons->getType()))
-    builder.setInsertionPoint(oldblock, oldpoint);
+  if (Glob.getCGM().getContext().getAsArrayType(Cons->getType()))
+    Builder.setInsertionPoint(Oldblock, Oldpoint);
 
-  return endobj;
+  return Endobj;
 }
 
 ValueCategory
-MLIRScanner::VisitArraySubscriptExpr(clang::ArraySubscriptExpr *expr) {
-  auto moo = Visit(expr->getLHS());
+MLIRScanner::VisitArraySubscriptExpr(clang::ArraySubscriptExpr *Expr) {
+  auto Moo = Visit(Expr->getLHS());
 
-  auto rhs = Visit(expr->getRHS()).getValue(builder);
+  auto Rhs = Visit(Expr->getRHS()).getValue(Builder);
   // Check the RHS has been successfully emitted
-  assert(rhs);
-  auto idx = castToIndex(getMLIRLocation(expr->getRBracketLoc()), rhs);
+  assert(Rhs);
+  auto Idx = castToIndex(getMLIRLocation(Expr->getRBracketLoc()), Rhs);
   if (isa<clang::VectorType>(
-          expr->getLHS()->getType()->getUnqualifiedDesugaredType())) {
-    assert(moo.isReference);
-    moo.isReference = false;
-    auto mt = moo.val.getType().cast<MemRefType>();
+          Expr->getLHS()->getType()->getUnqualifiedDesugaredType())) {
+    assert(Moo.isReference);
+    Moo.isReference = false;
+    auto Mt = Moo.val.getType().cast<MemRefType>();
 
-    auto shape = std::vector<int64_t>(mt.getShape());
-    shape.erase(shape.begin());
-    auto mt0 =
-        mlir::MemRefType::get(shape, mt.getElementType(),
-                              MemRefLayoutAttrInterface(), mt.getMemorySpace());
-    moo.val = builder.create<polygeist::SubIndexOp>(loc, mt0, moo.val,
+    auto Shape = std::vector<int64_t>(Mt.getShape());
+    Shape.erase(Shape.begin());
+    auto Mt0 =
+        mlir::MemRefType::get(Shape, Mt.getElementType(),
+                              MemRefLayoutAttrInterface(), Mt.getMemorySpace());
+    Moo.val = Builder.create<polygeist::SubIndexOp>(Loc, Mt0, Moo.val,
                                                     getConstantIndex(0));
   }
-  bool isArray = false;
-  if (!Glob.getCGM().getContext().getAsArrayType(expr->getType()))
-    Glob.getTypes().getMLIRType(expr->getType(), &isArray);
-  return CommonArrayLookup(moo, idx, isArray);
+  bool IsArray = false;
+  if (!Glob.getCGM().getContext().getAsArrayType(Expr->getType()))
+    Glob.getTypes().getMLIRType(Expr->getType(), &IsArray);
+  return CommonArrayLookup(Moo, Idx, IsArray);
 }
 
 const clang::FunctionDecl *MLIRScanner::EmitCallee(const Expr *E) {
   E = E->IgnoreParens();
   // Look through function-to-pointer decay.
-  if (auto ICE = dyn_cast<ImplicitCastExpr>(E)) {
+  if (const auto *ICE = dyn_cast<ImplicitCastExpr>(E)) {
     if (ICE->getCastKind() == CK_FunctionToPointerDecay ||
         ICE->getCastKind() == CK_BuiltinFnToFnPtr) {
       return EmitCallee(ICE->getSubExpr());
     }
-
     // Resolve direct calls.
-  } else if (auto DRE = dyn_cast<DeclRefExpr>(E)) {
-    if (auto FD = dyn_cast<FunctionDecl>(DRE->getDecl())) {
+  } else if (const auto *DRE = dyn_cast<DeclRefExpr>(E)) {
+    if (const auto *FD = dyn_cast<FunctionDecl>(DRE->getDecl()))
       return FD;
-    }
-
-  } else if (auto ME = dyn_cast<MemberExpr>(E)) {
-    if (auto FD = dyn_cast<FunctionDecl>(ME->getMemberDecl())) {
+  } else if (const auto *ME = dyn_cast<MemberExpr>(E)) {
+    if (auto *FD = dyn_cast<FunctionDecl>(ME->getMemberDecl())) {
       // TODO EmitIgnoredExpr(ME->getBase());
       return FD;
     }
 
     // Look through template substitutions.
-  } else if (auto NTTP = dyn_cast<SubstNonTypeTemplateParmExpr>(E)) {
+  } else if (const auto *NTTP = dyn_cast<SubstNonTypeTemplateParmExpr>(E)) {
     return EmitCallee(NTTP->getReplacement());
-  } else if (auto UOp = dyn_cast<clang::UnaryOperator>(E)) {
-    if (UOp->getOpcode() == UnaryOperatorKind::UO_AddrOf) {
+  } else if (const auto *UOp = dyn_cast<clang::UnaryOperator>(E)) {
+    if (UOp->getOpcode() == UnaryOperatorKind::UO_AddrOf)
       return EmitCallee(UOp->getSubExpr());
-    }
   }
 
   return nullptr;
 }
 
-static NamedAttrList getSYCLMethodOpAttrs(OpBuilder &builder,
-                                          mlir::Type baseType,
-                                          llvm::StringRef typeName,
-                                          llvm::StringRef functionName,
-                                          llvm::StringRef mangledFunctionName) {
-  NamedAttrList attrs;
-  attrs.set(mlir::sycl::SYCLDialect::getBaseTypeAttrName(),
-            mlir::TypeAttr::get(baseType));
-  attrs.set(mlir::sycl::SYCLDialect::getFunctionNameAttrName(),
-            FlatSymbolRefAttr::get(builder.getStringAttr(functionName)));
+static NamedAttrList getSYCLMethodOpAttrs(OpBuilder &Builder,
+                                          mlir::Type BaseType,
+                                          llvm::StringRef TypeName,
+                                          llvm::StringRef FunctionName,
+                                          llvm::StringRef MangledFunctionName) {
+  NamedAttrList Attrs;
+  Attrs.set(mlir::sycl::SYCLDialect::getBaseTypeAttrName(),
+            mlir::TypeAttr::get(BaseType));
+  Attrs.set(mlir::sycl::SYCLDialect::getFunctionNameAttrName(),
+            FlatSymbolRefAttr::get(Builder.getStringAttr(FunctionName)));
   if (!OmitOptionalMangledFunctionName) {
-    attrs.set(
+    Attrs.set(
         mlir::sycl::SYCLDialect::getMangledFunctionNameAttrName(),
-        FlatSymbolRefAttr::get(builder.getStringAttr(mangledFunctionName)));
+        FlatSymbolRefAttr::get(Builder.getStringAttr(MangledFunctionName)));
   }
-  attrs.set(mlir::sycl::SYCLDialect::getTypeNameAttrName(),
-            FlatSymbolRefAttr::get(builder.getStringAttr(typeName)));
-  return attrs;
+  Attrs.set(mlir::sycl::SYCLDialect::getTypeNameAttrName(),
+            FlatSymbolRefAttr::get(Builder.getStringAttr(TypeName)));
+  return Attrs;
 }
 
 /// Returns the SYCL cast originating this value if such operation exists; None
@@ -958,80 +952,79 @@ static NamedAttrList getSYCLMethodOpAttrs(OpBuilder &builder,
 ///
 /// This function relies on how arguments are casted to perform a function call.
 /// Should be updated if this changes.
-static llvm::Optional<mlir::sycl::SYCLCastOp> trackSYCLCast(Value val) {
-  const auto trackWithOperand =
+static llvm::Optional<mlir::sycl::SYCLCastOp> trackSYCLCast(Value Val) {
+  const auto TrackWithOperand =
       [](Operation *Op) -> llvm::Optional<mlir::sycl::SYCLCastOp> {
     return trackSYCLCast(Op->getOperand(0));
   };
-  const auto DefiningOp = val.getDefiningOp();
-  if (!DefiningOp) {
+  auto *const DefiningOp = Val.getDefiningOp();
+  if (!DefiningOp)
     return llvm::None;
-  }
+
   return TypeSwitch<mlir::Operation *, llvm::Optional<mlir::sycl::SYCLCastOp>>(
              DefiningOp)
       .Case<mlir::sycl::SYCLCastOp>(
           [](auto Cast) -> llvm::Optional<mlir::sycl::SYCLCastOp> {
             return Cast;
           })
-      .Case<mlir::LLVM::AddrSpaceCastOp>(trackWithOperand)
-      .Case<mlir::polygeist::Memref2PointerOp>(trackWithOperand)
-      .Case<mlir::polygeist::Pointer2MemrefOp>(trackWithOperand)
+      .Case<mlir::LLVM::AddrSpaceCastOp>(TrackWithOperand)
+      .Case<mlir::polygeist::Memref2PointerOp>(TrackWithOperand)
+      .Case<mlir::polygeist::Pointer2MemrefOp>(TrackWithOperand)
       .Default([](auto) -> llvm::Optional<mlir::sycl::SYCLCastOp> {
         return llvm::None;
       });
 }
 
 llvm::Optional<sycl::SYCLMethodOpInterface> MLIRScanner::createSYCLMethodOp(
-    llvm::StringRef typeName, llvm::StringRef functionName,
-    mlir::ValueRange operands, llvm::Optional<mlir::Type> returnType,
-    llvm::StringRef mangledFunctionName) {
+    llvm::StringRef TypeName, llvm::StringRef FunctionName,
+    mlir::ValueRange Operands, llvm::Optional<mlir::Type> ReturnType,
+    llvm::StringRef MangledFunctionName) {
   // Expecting a MemRef as the first argument, as the first operand to a method
   // call should be a pointer to `this`.
-  if (operands.empty() || !operands[0].getType().isa<MemRefType>()) {
+  if (Operands.empty() || !Operands[0].getType().isa<MemRefType>())
     return llvm::None;
-  }
 
   auto *SYCLDialect =
-      operands[0].getContext()->getLoadedDialect<mlir::sycl::SYCLDialect>();
+      Operands[0].getContext()->getLoadedDialect<mlir::sycl::SYCLDialect>();
   assert(SYCLDialect && "MLIR-SYCL dialect not loaded.");
 
   // Need to copy to avoid overriding elements in the input argument.
-  SmallVector<mlir::Value> operandsCpy(operands);
+  SmallVector<mlir::Value> OperandsCpy(Operands);
 
   // SYCLCastOps are abstracted to avoid missing method calls due to
   // implementation details.
   if (const llvm::Optional<sycl::SYCLCastOp> Cast =
-          trackSYCLCast(operandsCpy[0])) {
+          trackSYCLCast(OperandsCpy[0])) {
     auto NewArg = (*Cast)->getOperand(0);
     // Make sure the memory space is not changed:
     const auto MemSpace =
-        operandsCpy[0].getType().cast<MemRefType>().getMemorySpaceAsInt();
+        OperandsCpy[0].getType().cast<MemRefType>().getMemorySpaceAsInt();
     if (NewArg.getType().cast<MemRefType>().getMemorySpaceAsInt() != MemSpace) {
       NewArg = castToMemSpace(NewArg, MemSpace);
     }
-    operandsCpy[0] = NewArg;
+    OperandsCpy[0] = NewArg;
     LLVM_DEBUG(llvm::dbgs() << "Abstracting cast to " << NewArg.getType()
                             << " to insert a SYCL method\n");
   }
 
-  auto BaseType = operandsCpy[0].getType().cast<MemRefType>();
+  auto BaseType = OperandsCpy[0].getType().cast<MemRefType>();
   const llvm::Optional<llvm::StringRef> OptOpName = SYCLDialect->findMethod(
-      BaseType.getElementType().getTypeID(), functionName);
+      BaseType.getElementType().getTypeID(), FunctionName);
 
   if (!OptOpName) {
     LLVM_DEBUG(llvm::dbgs() << "SYCL method not inserted. Type: " << BaseType
-                            << " Name: " << functionName << "\n");
+                            << " Name: " << FunctionName << "\n");
     return llvm::None;
   }
 
   LLVM_DEBUG(llvm::dbgs() << "Inserting operation " << OptOpName
                           << " to replace SYCL method call.\n");
 
-  return static_cast<sycl::SYCLMethodOpInterface>(builder.create(
-      loc, builder.getStringAttr(*OptOpName), operandsCpy,
-      returnType ? mlir::TypeRange{*returnType} : mlir::TypeRange{},
-      getSYCLMethodOpAttrs(builder, operands[0].getType(), typeName,
-                           functionName, mangledFunctionName)));
+  return static_cast<sycl::SYCLMethodOpInterface>(Builder.create(
+      Loc, Builder.getStringAttr(*OptOpName), OperandsCpy,
+      ReturnType ? mlir::TypeRange{*ReturnType} : mlir::TypeRange{},
+      getSYCLMethodOpAttrs(Builder, Operands[0].getType(), TypeName,
+                           FunctionName, MangledFunctionName)));
 }
 
 mlir::Operation *
@@ -1044,10 +1037,10 @@ MLIRScanner::emitSYCLOps(const clang::Expr *Expr,
 
     if (mlirclang::isNamespaceSYCL(Func->getEnclosingNamespaceContext())) {
       if (const auto *RD = dyn_cast<clang::CXXRecordDecl>(Func->getParent())) {
-        std::string name =
+        std::string Name =
             MLIRScanner::getMangledFuncName(*Func, Glob.getCGM());
-        Op = builder.create<mlir::sycl::SYCLConstructorOp>(loc, RD->getName(),
-                                                           name, Args);
+        Op = Builder.create<mlir::sycl::SYCLConstructorOp>(Loc, RD->getName(),
+                                                           Name, Args);
       }
     }
   } else if (const auto *CallExpr = dyn_cast<clang::CallExpr>(Expr)) {
@@ -1066,55 +1059,55 @@ MLIRScanner::emitSYCLOps(const clang::Expr *Expr,
         OptRetType = RetType;
       }
 
-      std::string name = MLIRScanner::getMangledFuncName(*Func, Glob.getCGM());
+      std::string Name = MLIRScanner::getMangledFuncName(*Func, Glob.getCGM());
       if (OptFuncType) {
         // Attempt to create a SYCL method call first, if that fails create a
         // generic SYCLCallOp.
         Op = createSYCLMethodOp(*OptFuncType, Func->getNameAsString(), Args,
-                                OptRetType, name)
+                                OptRetType, Name)
                  .value_or(nullptr);
       }
-      if (!Op) {
-        Op = builder.create<mlir::sycl::SYCLCallOp>(
-            loc, OptRetType, OptFuncType, Func->getNameAsString(), name, Args);
-      }
+
+      if (!Op)
+        Op = Builder.create<mlir::sycl::SYCLCallOp>(
+            Loc, OptRetType, OptFuncType, Func->getNameAsString(), Name, Args);
     }
   }
 
   return Op;
 }
 
-ValueCategory MLIRScanner::VisitMSPropertyRefExpr(MSPropertyRefExpr *expr) {
+ValueCategory MLIRScanner::VisitMSPropertyRefExpr(MSPropertyRefExpr *Expr) {
   assert(0 && "unhandled ms propertyref");
   // TODO obviously fake
   return nullptr;
 }
 
 ValueCategory
-MLIRScanner::VisitPseudoObjectExpr(clang::PseudoObjectExpr *expr) {
-  return Visit(expr->getResultExpr());
+MLIRScanner::VisitPseudoObjectExpr(clang::PseudoObjectExpr *Expr) {
+  return Visit(Expr->getResultExpr());
 }
 
 ValueCategory MLIRScanner::VisitSubstNonTypeTemplateParmExpr(
-    SubstNonTypeTemplateParmExpr *expr) {
-  return Visit(expr->getReplacement());
+    SubstNonTypeTemplateParmExpr *Expr) {
+  return Visit(Expr->getReplacement());
 }
 
 ValueCategory
 MLIRScanner::VisitUnaryExprOrTypeTraitExpr(UnaryExprOrTypeTraitExpr *Uop) {
   switch (Uop->getKind()) {
   case UETT_SizeOf: {
-    auto value = getTypeSize(Uop->getTypeOfArgument());
-    auto retTy =
+    auto Value = getTypeSize(Uop->getTypeOfArgument());
+    auto RetTy =
         Glob.getTypes().getMLIRType(Uop->getType()).cast<mlir::IntegerType>();
-    return ValueCategory(builder.create<arith::IndexCastOp>(loc, retTy, value),
+    return ValueCategory(Builder.create<arith::IndexCastOp>(Loc, RetTy, Value),
                          /*isReference*/ false);
   }
   case UETT_AlignOf: {
-    auto value = getTypeAlign(Uop->getTypeOfArgument());
-    auto retTy =
+    auto Value = getTypeAlign(Uop->getTypeOfArgument());
+    auto RetTy =
         Glob.getTypes().getMLIRType(Uop->getType()).cast<mlir::IntegerType>();
-    return ValueCategory(builder.create<arith::IndexCastOp>(loc, retTy, value),
+    return ValueCategory(Builder.create<arith::IndexCastOp>(Loc, RetTy, Value),
                          /*isReference*/ false);
   }
   default:
@@ -1124,38 +1117,38 @@ MLIRScanner::VisitUnaryExprOrTypeTraitExpr(UnaryExprOrTypeTraitExpr *Uop) {
 }
 
 ValueCategory MLIRScanner::VisitAtomicExpr(clang::AtomicExpr *BO) {
-  auto loc = getMLIRLocation(BO->getExprLoc());
+  Location Loc = getMLIRLocation(BO->getExprLoc());
 
   switch (BO->getOp()) {
   case AtomicExpr::AtomicOp::AO__atomic_add_fetch: {
-    auto a0 = Visit(BO->getPtr()).getValue(builder);
-    auto a1 = Visit(BO->getVal1()).getValue(builder);
-    auto ty = a1.getType();
-    AtomicRMWKind op;
-    LLVM::AtomicBinOp lop;
-    if (ty.isa<mlir::IntegerType>()) {
-      op = AtomicRMWKind::addi;
-      lop = LLVM::AtomicBinOp::add;
+    auto A0 = Visit(BO->getPtr()).getValue(Builder);
+    auto A1 = Visit(BO->getVal1()).getValue(Builder);
+    auto Ty = A1.getType();
+    AtomicRMWKind Op;
+    LLVM::AtomicBinOp Lop;
+    if (Ty.isa<mlir::IntegerType>()) {
+      Op = AtomicRMWKind::addi;
+      Lop = LLVM::AtomicBinOp::add;
     } else {
-      op = AtomicRMWKind::addf;
-      lop = LLVM::AtomicBinOp::fadd;
+      Op = AtomicRMWKind::addf;
+      Lop = LLVM::AtomicBinOp::fadd;
     }
     // TODO add atomic ordering
-    mlir::Value v;
-    if (a0.getType().isa<MemRefType>())
-      v = builder.create<memref::AtomicRMWOp>(
-          loc, a1.getType(), op, a1, a0,
+    mlir::Value V;
+    if (A0.getType().isa<MemRefType>())
+      V = Builder.create<memref::AtomicRMWOp>(
+          Loc, A1.getType(), Op, A1, A0,
           std::vector<mlir::Value>({getConstantIndex(0)}));
     else
-      v = builder.create<LLVM::AtomicRMWOp>(loc, a1.getType(), lop, a0, a1,
+      V = Builder.create<LLVM::AtomicRMWOp>(Loc, A1.getType(), Lop, A0, A1,
                                             LLVM::AtomicOrdering::acq_rel);
 
-    if (ty.isa<mlir::IntegerType>())
-      v = builder.create<arith::AddIOp>(loc, v, a1);
+    if (Ty.isa<mlir::IntegerType>())
+      V = Builder.create<arith::AddIOp>(Loc, V, A1);
     else
-      v = builder.create<arith::AddFOp>(loc, v, a1);
+      V = Builder.create<arith::AddFOp>(Loc, V, A1);
 
-    return ValueCategory(v, false);
+    return ValueCategory(V, false);
   }
   default:
     llvm::errs() << "unhandled atomic:";
@@ -1165,12 +1158,12 @@ ValueCategory MLIRScanner::VisitAtomicExpr(clang::AtomicExpr *BO) {
 }
 
 ValueCategory MLIRScanner::VisitExprWithCleanups(ExprWithCleanups *E) {
-  auto ret = Visit(E->getSubExpr());
-  for (auto &child : E->children()) {
-    child->dump();
+  auto Ret = Visit(E->getSubExpr());
+  for (auto &Child : E->children()) {
+    Child->dump();
     llvm::errs() << "cleanup not handled\n";
   }
-  return ret;
+  return Ret;
 }
 
 ValueCategory MLIRScanner::VisitDeclRefExpr(DeclRefExpr *E) {
@@ -1180,70 +1173,70 @@ ValueCategory MLIRScanner::VisitDeclRefExpr(DeclRefExpr *E) {
     llvm::dbgs() << "\n";
   });
 
-  auto name = E->getDecl()->getName().str();
+  auto Name = E->getDecl()->getName().str();
 
-  if (auto tocall = dyn_cast<FunctionDecl>(E->getDecl()))
-    return ValueCategory(builder.create<LLVM::AddressOfOp>(
-                             loc, Glob.GetOrCreateLLVMFunction(tocall)),
+  if (auto *Tocall = dyn_cast<FunctionDecl>(E->getDecl()))
+    return ValueCategory(Builder.create<LLVM::AddressOfOp>(
+                             Loc, Glob.getOrCreateLLVMFunction(Tocall)),
                          /*isReference*/ true);
 
-  if (auto VD = dyn_cast<VarDecl>(E->getDecl())) {
+  if (auto *VD = dyn_cast<VarDecl>(E->getDecl())) {
     if (Captures.find(VD) != Captures.end()) {
-      FieldDecl *field = Captures[VD];
-      auto res = CommonFieldLookup(
-          cast<CXXMethodDecl>(EmittingFunctionDecl)->getThisObjectType(), field,
+      FieldDecl *Field = Captures[VD];
+      auto Res = CommonFieldLookup(
+          cast<CXXMethodDecl>(EmittingFunctionDecl)->getThisObjectType(), Field,
           ThisVal.val,
           isa<clang::ReferenceType>(
-              field->getType()->getUnqualifiedDesugaredType()));
+              Field->getType()->getUnqualifiedDesugaredType()));
       assert(CaptureKinds.find(VD) != CaptureKinds.end());
-      return res;
+      return Res;
     }
   }
 
-  if (auto PD = dyn_cast<VarDecl>(E->getDecl())) {
-    auto found = params.find(PD);
-    if (found != params.end()) {
-      auto res = found->second;
-      assert(res.val);
-      return res;
+  if (auto *PD = dyn_cast<VarDecl>(E->getDecl())) {
+    auto Found = Params.find(PD);
+    if (Found != Params.end()) {
+      auto Res = Found->second;
+      assert(Res.val);
+      return Res;
     }
   }
-  if (auto ED = dyn_cast<EnumConstantDecl>(E->getDecl())) {
-    auto ty =
+  if (auto *ED = dyn_cast<EnumConstantDecl>(E->getDecl())) {
+    auto Ty =
         Glob.getTypes().getMLIRType(E->getType()).cast<mlir::IntegerType>();
     return ValueCategory(
-        builder.create<ConstantIntOp>(loc, ED->getInitVal().getExtValue(), ty),
+        Builder.create<ConstantIntOp>(Loc, ED->getInitVal().getExtValue(), Ty),
         /*isReference*/ false);
 
     if (!ED->getInitExpr())
       ED->dump();
     return Visit(ED->getInitExpr());
   }
-  if (auto VD = dyn_cast<ValueDecl>(E->getDecl())) {
+  if (auto *VD = dyn_cast<ValueDecl>(E->getDecl())) {
     if (Glob.getTypes()
             .getMLIRType(
                 Glob.getCGM().getContext().getPointerType(E->getType()))
             .isa<mlir::LLVM::LLVMPointerType>() ||
-        name == "stderr" || name == "stdout" || name == "stdin" ||
+        Name == "stderr" || Name == "stdout" || Name == "stdin" ||
         (E->hasQualifier())) {
-      return ValueCategory(builder.create<mlir::LLVM::AddressOfOp>(
-                               loc, Glob.GetOrCreateLLVMGlobal(VD)),
+      return ValueCategory(Builder.create<mlir::LLVM::AddressOfOp>(
+                               Loc, Glob.getOrCreateLLVMGlobal(VD)),
                            /*isReference*/ true);
     }
 
     // We need to decide where to put the Global.  If we are in a device
     // module, the global should be in the gpu module (which is nested inside
     // another main module).
-    std::pair<mlir::memref::GlobalOp, bool> gv = Glob.getOrCreateGlobal(
+    std::pair<mlir::memref::GlobalOp, bool> Gv = Glob.getOrCreateGlobal(
         *VD, /*prefix=*/"",
-        isa<mlir::gpu::GPUModuleOp>(function->getParentOp())
+        isa<mlir::gpu::GPUModuleOp>(Function->getParentOp())
             ? FunctionContext::SYCLDevice
             : FunctionContext::Host);
 
-    auto gv2 = builder.create<memref::GetGlobalOp>(loc, gv.first.getType(),
-                                                   gv.first.getName());
+    auto Gv2 = Builder.create<memref::GetGlobalOp>(Loc, Gv.first.getType(),
+                                                   Gv.first.getName());
     Value V = castToMemSpace(
-        reshapeRanklessGlobal(gv2),
+        reshapeRanklessGlobal(Gv2),
         Glob.getCGM().getContext().getTargetAddressSpace(VD->getType()));
 
     // TODO check reference
@@ -1251,7 +1244,7 @@ ValueCategory MLIRScanner::VisitDeclRefExpr(DeclRefExpr *E) {
   }
   E->dump();
   E->getDecl()->dump();
-  llvm::errs() << "couldn't find " << name << "\n";
+  llvm::errs() << "couldn't find " << Name << "\n";
   assert(0 && "couldnt find value");
   return nullptr;
 }
@@ -1261,13 +1254,13 @@ ValueCategory MLIRScanner::VisitOpaqueValueExpr(OpaqueValueExpr *E) {
     E->dump();
     assert(E->getSourceExpr());
   }
-  auto res = Visit(E->getSourceExpr());
-  if (!res.val) {
+  auto Res = Visit(E->getSourceExpr());
+  if (!Res.val) {
     E->dump();
     E->getSourceExpr()->dump();
-    assert(res.val);
+    assert(Res.val);
   }
-  return res;
+  return Res;
 }
 
 ValueCategory MLIRScanner::VisitCXXTypeidExpr(clang::CXXTypeidExpr *E) {
@@ -1278,111 +1271,104 @@ ValueCategory MLIRScanner::VisitCXXTypeidExpr(clang::CXXTypeidExpr *E) {
     T = E->getExprOperand()->getType();
   llvm::Constant *C = Glob.getCGM().GetAddrOfRTTIDescriptor(T);
   llvm::errs() << *C << "\n";
-  mlir::Type ty = Glob.getTypes().getMLIRType(E->getType());
-  llvm::errs() << ty << "\n";
+  mlir::Type Ty = Glob.getTypes().getMLIRType(E->getType());
+  llvm::errs() << Ty << "\n";
   assert(0 && "unhandled typeid");
 }
 
 ValueCategory
-MLIRScanner::VisitCXXDefaultInitExpr(clang::CXXDefaultInitExpr *expr) {
+MLIRScanner::VisitCXXDefaultInitExpr(clang::CXXDefaultInitExpr *Expr) {
   assert(ThisVal.val);
-  auto toset = Visit(expr->getExpr());
+  auto Toset = Visit(Expr->getExpr());
   assert(!ThisVal.isReference);
-  assert(toset.val);
+  assert(Toset.val);
 
-  bool isArray = false;
-  Glob.getTypes().getMLIRType(expr->getExpr()->getType(), &isArray);
+  bool IsArray = false;
+  Glob.getTypes().getMLIRType(Expr->getExpr()->getType(), &IsArray);
 
-  auto cfl = CommonFieldLookup(
+  auto Cfl = CommonFieldLookup(
       cast<CXXMethodDecl>(EmittingFunctionDecl)->getThisObjectType(),
-      expr->getField(), ThisVal.val, /*isLValue*/ false);
-  assert(cfl.val);
-  cfl.store(builder, toset, isArray);
-  return cfl;
+      Expr->getField(), ThisVal.val, /*isLValue*/ false);
+  assert(Cfl.val);
+  Cfl.store(Builder, Toset, IsArray);
+  return Cfl;
 }
 
-ValueCategory MLIRScanner::VisitCXXNoexceptExpr(CXXNoexceptExpr *expr) {
-  auto ty =
-      Glob.getTypes().getMLIRType(expr->getType()).cast<mlir::IntegerType>();
+ValueCategory MLIRScanner::VisitCXXNoexceptExpr(CXXNoexceptExpr *Expr) {
+  auto Ty =
+      Glob.getTypes().getMLIRType(Expr->getType()).cast<mlir::IntegerType>();
   return ValueCategory(
-      builder.create<ConstantIntOp>(getMLIRLocation(expr->getExprLoc()),
-                                    expr->getValue(), ty),
+      Builder.create<ConstantIntOp>(getMLIRLocation(Expr->getExprLoc()),
+                                    Expr->getValue(), Ty),
       /*isReference*/ false);
 }
 
 ValueCategory MLIRScanner::VisitMemberExpr(MemberExpr *ME) {
-  auto memberName = ME->getMemberDecl()->getName();
-  if (auto sr2 = dyn_cast<OpaqueValueExpr>(ME->getBase())) {
-    if (auto sr = dyn_cast<DeclRefExpr>(sr2->getSourceExpr())) {
-      if (sr->getDecl()->getName() == "blockIdx") {
-        if (memberName == "__fetch_builtin_x") {
-        }
+  if (auto *Sr2 = dyn_cast<OpaqueValueExpr>(ME->getBase())) {
+    if (auto *Sr = dyn_cast<DeclRefExpr>(Sr2->getSourceExpr())) {
+      if (Sr->getDecl()->getName() == "blockIdx")
         llvm::errs() << "known block index";
-      }
-      if (sr->getDecl()->getName() == "blockDim") {
+      if (Sr->getDecl()->getName() == "blockDim")
         llvm::errs() << "known block dim";
-      }
-      if (sr->getDecl()->getName() == "threadIdx") {
+      if (Sr->getDecl()->getName() == "threadIdx")
         llvm::errs() << "known thread index";
-      }
-      if (sr->getDecl()->getName() == "gridDim") {
+      if (Sr->getDecl()->getName() == "gridDim")
         llvm::errs() << "known grid index";
-      }
     }
   }
-  auto base = Visit(ME->getBase());
+  auto Base = Visit(ME->getBase());
   clang::QualType OT = ME->getBase()->getType();
   if (ME->isArrow()) {
-    if (!base.val) {
+    if (!Base.val)
       ME->dump();
-    }
-    base = base.dereference(builder);
+
+    Base = Base.dereference(Builder);
     OT = cast<clang::PointerType>(OT->getUnqualifiedDesugaredType())
              ->getPointeeType();
   }
-  if (!base.isReference) {
+  if (!Base.isReference) {
     EmittingFunctionDecl->dump();
-    function.dump();
+    Function.dump();
     ME->dump();
-    llvm::errs() << "base value: " << base.val << "\n";
+    llvm::errs() << "base value: " << Base.val << "\n";
   }
-  assert(base.isReference);
-  const FieldDecl *field = cast<FieldDecl>(ME->getMemberDecl());
+  assert(Base.isReference);
+  const FieldDecl *Field = cast<clang::FieldDecl>(ME->getMemberDecl());
   return CommonFieldLookup(
-      OT, field, base.val,
+      OT, Field, Base.val,
       isa<clang::ReferenceType>(
-          field->getType()->getUnqualifiedDesugaredType()));
+          Field->getType()->getUnqualifiedDesugaredType()));
 }
 
 ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
-  auto loc = getMLIRLocation(E->getExprLoc());
+  Location Loc = getMLIRLocation(E->getExprLoc());
   switch (E->getCastKind()) {
 
   case clang::CastKind::CK_NullToPointer: {
-    mlir::Type llvmType = Glob.getTypes().getMLIRType(E->getType());
-    if (llvmType.isa<LLVM::LLVMPointerType>())
-      return ValueCategory(builder.create<mlir::LLVM::NullOp>(loc, llvmType),
+    mlir::Type LlvmType = Glob.getTypes().getMLIRType(E->getType());
+    if (LlvmType.isa<LLVM::LLVMPointerType>())
+      return ValueCategory(Builder.create<mlir::LLVM::NullOp>(Loc, LlvmType),
                            /*isReference*/ false);
-    else if (auto MT = llvmType.dyn_cast<MemRefType>())
+    if (auto MT = LlvmType.dyn_cast<MemRefType>())
       return ValueCategory(
-          builder.create<polygeist::Pointer2MemrefOp>(
-              loc, MT,
-              builder.create<mlir::LLVM::NullOp>(
-                  loc, LLVM::LLVMPointerType::get(builder.getI8Type(),
+          Builder.create<polygeist::Pointer2MemrefOp>(
+              Loc, MT,
+              Builder.create<mlir::LLVM::NullOp>(
+                  Loc, LLVM::LLVMPointerType::get(Builder.getI8Type(),
                                                   MT.getMemorySpaceAsInt()))),
           false);
     llvm_unreachable("illegal type for cast");
   }
-  case clang::CastKind::CK_UserDefinedConversion: {
+  case clang::CastKind::CK_UserDefinedConversion:
     return Visit(E->getSubExpr());
-  }
+
   case clang::CastKind::CK_AddressSpaceConversion: {
-    auto scalar = Visit(E->getSubExpr());
+    auto Scalar = Visit(E->getSubExpr());
     // JLE_QUEL::TODO (II-201)
     // assert(scalar.isReference);
-    auto postTy = returnVal.getType().cast<MemRefType>().getElementType();
-    return ValueCategory(castToMemSpaceOfType(scalar.val, postTy),
-                         scalar.isReference);
+    auto PostTy = ReturnVal.getType().cast<MemRefType>().getElementType();
+    return ValueCategory(castToMemSpaceOfType(Scalar.val, PostTy),
+                         Scalar.isReference);
   }
   case clang::CastKind::CK_Dynamic: {
     E->dump();
@@ -1390,25 +1376,25 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
   }
   case clang::CastKind::CK_UncheckedDerivedToBase:
   case clang::CastKind::CK_DerivedToBase: {
-    auto se = Visit(E->getSubExpr());
-    if (!se.val) {
+    auto Se = Visit(E->getSubExpr());
+    if (!Se.val)
       E->dump();
-    }
-    assert(se.val);
-    auto Derived =
+
+    assert(Se.val);
+    const auto *Derived =
         (E->isLValue() || E->isXValue())
             ? cast<CXXRecordDecl>(
                   E->getSubExpr()->getType()->castAs<RecordType>()->getDecl())
             : E->getSubExpr()->getType()->getPointeeCXXRecordDecl();
     SmallVector<const clang::Type *> BaseTypes;
     SmallVector<bool> BaseVirtual;
-    for (auto B : E->path()) {
+    for (auto *B : E->path()) {
       BaseTypes.push_back(B->getType().getTypePtr());
       BaseVirtual.push_back(B->isVirtual());
     }
 
-    if (auto ut = se.val.getType().dyn_cast<mlir::MemRefType>()) {
-      auto mt = Glob.getTypes()
+    if (auto Ut = Se.val.getType().dyn_cast<mlir::MemRefType>()) {
+      auto Mt = Glob.getTypes()
                     .getMLIRType(
                         (E->isLValue() || E->isXValue())
                             ? Glob.getCGM().getContext().getLValueReferenceType(
@@ -1416,176 +1402,174 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
                             : E->getType())
                     .dyn_cast<mlir::MemRefType>();
 
-      if (ut.getShape().size() != mt.getShape().size()) {
+      if (Ut.getShape().size() != Mt.getShape().size()) {
         E->dump();
-        llvm::errs() << " se.val: " << se.val << " ut: " << ut << " mt: " << mt
+        llvm::errs() << " se.val: " << Se.val << " ut: " << Ut << " mt: " << Mt
                      << "\n";
       }
-      assert(ut.getShape().size() == mt.getShape().size());
-      auto ty = mlir::MemRefType::get(mt.getShape(), mt.getElementType(),
+      assert(Ut.getShape().size() == Mt.getShape().size());
+      auto Ty = mlir::MemRefType::get(Mt.getShape(), Mt.getElementType(),
                                       MemRefLayoutAttrInterface(),
-                                      ut.getMemorySpace());
-      if (ty.getElementType().getDialect().getNamespace() ==
+                                      Ut.getMemorySpace());
+      if (Ty.getElementType().getDialect().getNamespace() ==
               mlir::sycl::SYCLDialect::getDialectNamespace() &&
-          ut.getElementType().getDialect().getNamespace() ==
+          Ut.getElementType().getDialect().getNamespace() ==
               mlir::sycl::SYCLDialect::getDialectNamespace() &&
-          ty.getElementType() != ut.getElementType()) {
+          Ty.getElementType() != Ut.getElementType()) {
         return ValueCategory(
-            builder.create<mlir::sycl::SYCLCastOp>(loc, ty, se.val),
-            /*isReference*/ se.isReference);
+            Builder.create<mlir::sycl::SYCLCastOp>(Loc, Ty, Se.val),
+            /*isReference*/ Se.isReference);
       }
     }
 
-    mlir::Value val =
-        GetAddressOfBaseClass(se.val, Derived, BaseTypes, BaseVirtual);
+    mlir::Value Val =
+        GetAddressOfBaseClass(Se.val, Derived, BaseTypes, BaseVirtual);
     if (E->getCastKind() != clang::CastKind::CK_UncheckedDerivedToBase &&
         !isa<CXXThisExpr>(E->IgnoreParens())) {
-      mlir::Value ptr = val;
-      if (auto MT = ptr.getType().dyn_cast<MemRefType>())
-        ptr = builder.create<polygeist::Memref2PointerOp>(
-            loc,
+      mlir::Value Ptr = Val;
+      if (auto MT = Ptr.getType().dyn_cast<MemRefType>())
+        Ptr = Builder.create<polygeist::Memref2PointerOp>(
+            Loc,
             LLVM::LLVMPointerType::get(MT.getElementType(),
                                        MT.getMemorySpaceAsInt()),
-            ptr);
-      mlir::Value nullptr_llvm =
-          builder.create<mlir::LLVM::NullOp>(loc, ptr.getType());
-      auto ne = builder.create<mlir::LLVM::ICmpOp>(
-          loc, mlir::LLVM::ICmpPredicate::ne, ptr, nullptr_llvm);
-      if (auto MT = ptr.getType().dyn_cast<MemRefType>())
-        nullptr_llvm =
-            builder.create<polygeist::Pointer2MemrefOp>(loc, MT, nullptr_llvm);
-      val = builder.create<arith::SelectOp>(loc, ne, val, nullptr_llvm);
+            Ptr);
+      mlir::Value NullptrLlvm =
+          Builder.create<mlir::LLVM::NullOp>(Loc, Ptr.getType());
+      auto Ne = Builder.create<mlir::LLVM::ICmpOp>(
+          Loc, mlir::LLVM::ICmpPredicate::ne, Ptr, NullptrLlvm);
+      if (auto MT = Ptr.getType().dyn_cast<MemRefType>())
+        NullptrLlvm =
+            Builder.create<polygeist::Pointer2MemrefOp>(Loc, MT, NullptrLlvm);
+      Val = Builder.create<arith::SelectOp>(Loc, Ne, Val, NullptrLlvm);
     }
 
-    return ValueCategory(val, se.isReference);
+    return ValueCategory(Val, Se.isReference);
   }
   case clang::CastKind::CK_BaseToDerived: {
-    auto se = Visit(E->getSubExpr());
-    if (!se.val) {
+    auto Se = Visit(E->getSubExpr());
+    if (!Se.val)
       E->dump();
-    }
-    assert(se.val);
-    auto Derived =
+
+    assert(Se.val);
+    const auto *Derived =
         (E->isLValue() || E->isXValue())
             ? cast<CXXRecordDecl>(E->getType()->castAs<RecordType>()->getDecl())
             : E->getType()->getPointeeCXXRecordDecl();
-    mlir::Value val = GetAddressOfDerivedClass(se.val, Derived, E->path_begin(),
+    mlir::Value Val = GetAddressOfDerivedClass(Se.val, Derived, E->path_begin(),
                                                E->path_end());
     /*
     if (ShouldNullCheckClassCastValue(E)) {
         mlir::Value ptr = val;
         if (auto MT = ptr.getType().dyn_cast<MemRefType>())
-            ptr = builder.create<polygeist::Memref2PointerOp>(loc,
+            ptr = Builder.create<polygeist::Memref2PointerOp>(Loc,
     LLVM::LLVMPointerType::get(MT.getElementType()), ptr); auto nullptr_llvm =
-    builder.create<mlir::LLVM::NullOp>(loc, ptr.getType()); auto ne =
-    builder.create<mlir::LLVM::ICmpOp>( loc, mlir::LLVM::ICmpPredicate::ne, ptr,
+    Builder.create<mlir::LLVM::NullOp>(Loc, ptr.getType()); auto ne =
+    Builder.create<mlir::LLVM::ICmpOp>( Loc, mlir::LLVM::ICmpPredicate::ne, ptr,
     nullptr_llvm); if (auto MT = ptr.getType().dyn_cast<MemRefType>())
-           nullptr_llvm = builder.create<polygeist::Pointer2MemrefOp>(loc, MT,
-    nullptr_llvm); val = builder.create<arith::SelectOp>(loc, ne, val,
+           nullptr_llvm = Builder.create<polygeist::Pointer2MemrefOp>(Loc, MT,
+    nullptr_llvm); val = Builder.create<arith::SelectOp>(Loc, ne, val,
     nullptr_llvm);
     }
     */
-    return ValueCategory(val, se.isReference);
+    return ValueCategory(Val, Se.isReference);
   }
   case clang::CastKind::CK_BitCast: {
-
-    if (auto CI = dyn_cast<clang::CallExpr>(E->getSubExpr()))
-      if (auto ic = dyn_cast<ImplicitCastExpr>(CI->getCallee()))
-        if (auto sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
-          if (sr->getDecl()->getIdentifier() &&
-              sr->getDecl()->getName() == "polybench_alloc_data") {
-            if (auto mt = Glob.getTypes()
+    if (auto *CI = dyn_cast<clang::CallExpr>(E->getSubExpr()))
+      if (auto *Ic = dyn_cast<ImplicitCastExpr>(CI->getCallee()))
+        if (auto *Sr = dyn_cast<DeclRefExpr>(Ic->getSubExpr())) {
+          if (Sr->getDecl()->getIdentifier() &&
+              Sr->getDecl()->getName() == "polybench_alloc_data") {
+            if (auto Mt = Glob.getTypes()
                               .getMLIRType(E->getType())
                               .dyn_cast<mlir::MemRefType>()) {
-              auto shape = std::vector<int64_t>(mt.getShape());
+              auto Shape = std::vector<int64_t>(Mt.getShape());
               // shape.erase(shape.begin());
-              auto mt0 = mlir::MemRefType::get(shape, mt.getElementType(),
+              auto Mt0 = mlir::MemRefType::get(Shape, Mt.getElementType(),
                                                MemRefLayoutAttrInterface(),
-                                               mt.getMemorySpace());
+                                               Mt.getMemorySpace());
 
-              auto alloc = builder.create<mlir::memref::AllocOp>(loc, mt0);
-              return ValueCategory(alloc, /*isReference*/ false);
+              auto Alloc = Builder.create<mlir::memref::AllocOp>(Loc, Mt0);
+              return ValueCategory(Alloc, /*isReference*/ false);
             }
           }
         }
 
-    if (auto CI = dyn_cast<clang::CallExpr>(E->getSubExpr()))
-      if (auto ic = dyn_cast<ImplicitCastExpr>(CI->getCallee()))
-        if (auto sr = dyn_cast<DeclRefExpr>(ic->getSubExpr())) {
-          if (sr->getDecl()->getIdentifier() &&
-              (sr->getDecl()->getName() == "malloc" ||
-               sr->getDecl()->getName() == "calloc"))
-            if (auto mt = Glob.getTypes()
+    if (auto *CI = dyn_cast<clang::CallExpr>(E->getSubExpr()))
+      if (auto *Ic = dyn_cast<ImplicitCastExpr>(CI->getCallee()))
+        if (auto *Sr = dyn_cast<DeclRefExpr>(Ic->getSubExpr())) {
+          if (Sr->getDecl()->getIdentifier() &&
+              (Sr->getDecl()->getName() == "malloc" ||
+               Sr->getDecl()->getName() == "calloc"))
+            if (auto Mt = Glob.getTypes()
                               .getMLIRType(E->getType())
                               .dyn_cast<mlir::MemRefType>()) {
-              auto shape = std::vector<int64_t>(mt.getShape());
+              auto Shape = std::vector<int64_t>(Mt.getShape());
 
-              auto elemSize =
+              auto ElemSize =
                   getTypeSize(cast<clang::PointerType>(
                                   E->getType()->getUnqualifiedDesugaredType())
                                   ->getPointeeType());
-              mlir::Value allocSize = builder.create<IndexCastOp>(
-                  loc, mlir::IndexType::get(builder.getContext()),
-                  Visit(CI->getArg(0)).getValue(builder));
-              if (sr->getDecl()->getName() == "calloc") {
-                allocSize = builder.create<MulIOp>(
-                    loc, allocSize,
-                    builder.create<arith::IndexCastOp>(
-                        loc, mlir::IndexType::get(builder.getContext()),
-                        Visit(CI->getArg(1)).getValue(builder)));
+              mlir::Value AllocSize = Builder.create<IndexCastOp>(
+                  Loc, mlir::IndexType::get(Builder.getContext()),
+                  Visit(CI->getArg(0)).getValue(Builder));
+              if (Sr->getDecl()->getName() == "calloc") {
+                AllocSize = Builder.create<MulIOp>(
+                    Loc, AllocSize,
+                    Builder.create<arith::IndexCastOp>(
+                        Loc, mlir::IndexType::get(Builder.getContext()),
+                        Visit(CI->getArg(1)).getValue(Builder)));
               }
-              mlir::Value args[1] = {
-                  builder.create<DivUIOp>(loc, allocSize, elemSize)};
-              auto alloc = builder.create<mlir::memref::AllocOp>(loc, mt, args);
-              if (sr->getDecl()->getName() == "calloc") {
-                mlir::Value val = alloc;
-                if (val.getType().isa<MemRefType>()) {
-                  val = builder.create<polygeist::Memref2PointerOp>(
-                      loc,
-                      LLVM::LLVMPointerType::get(builder.getI8Type(),
-                                                 val.getType()
+              mlir::Value Args[1] = {
+                  Builder.create<DivUIOp>(Loc, AllocSize, ElemSize)};
+              auto Alloc = Builder.create<mlir::memref::AllocOp>(Loc, Mt, Args);
+              if (Sr->getDecl()->getName() == "calloc") {
+                mlir::Value Val = Alloc;
+                if (Val.getType().isa<MemRefType>()) {
+                  Val = Builder.create<polygeist::Memref2PointerOp>(
+                      Loc,
+                      LLVM::LLVMPointerType::get(Builder.getI8Type(),
+                                                 Val.getType()
                                                      .cast<MemRefType>()
                                                      .getMemorySpaceAsInt()),
-                      val);
+                      Val);
                 } else {
-                  val = builder.create<LLVM::BitcastOp>(
-                      loc,
+                  Val = Builder.create<LLVM::BitcastOp>(
+                      Loc,
                       LLVM::LLVMPointerType::get(
-                          builder.getI8Type(),
-                          val.getType()
+                          Builder.getI8Type(),
+                          Val.getType()
                               .cast<LLVM::LLVMPointerType>()
                               .getAddressSpace()),
-                      val);
+                      Val);
                 }
-                auto i8_0 = builder.create<arith::ConstantIntOp>(loc, 0, 8);
-                auto sizev = builder.create<arith::IndexCastOp>(
-                    loc, builder.getI64Type(), allocSize);
-                auto falsev =
-                    builder.create<arith::ConstantIntOp>(loc, false, 1);
-                builder.create<LLVM::MemsetOp>(loc, val, i8_0, sizev, falsev);
+                auto I80 = Builder.create<arith::ConstantIntOp>(Loc, 0, 8);
+                auto Sizev = Builder.create<arith::IndexCastOp>(
+                    Loc, Builder.getI64Type(), AllocSize);
+                auto Falsev =
+                    Builder.create<arith::ConstantIntOp>(Loc, false, 1);
+                Builder.create<LLVM::MemsetOp>(Loc, Val, I80, Sizev, Falsev);
               }
-              return ValueCategory(alloc, /*isReference*/ false);
+              return ValueCategory(Alloc, /*isReference*/ false);
             }
         }
-    auto se = Visit(E->getSubExpr());
+    auto Se = Visit(E->getSubExpr());
 #ifdef DEBUG
-    if (!se.val) {
+    if (!se.val)
       E->dump();
-    }
 #endif
-    auto scalar = se.getValue(builder);
-    if (auto spt = scalar.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
-      mlir::Type nt = Glob.getTypes().getMLIRType(E->getType());
-      LLVM::LLVMPointerType pt = nt.dyn_cast<LLVM::LLVMPointerType>();
-      if (!pt) {
+    auto Scalar = Se.getValue(Builder);
+    if (auto Spt = Scalar.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+      mlir::Type Nt = Glob.getTypes().getMLIRType(E->getType());
+      LLVM::LLVMPointerType Pt = Nt.dyn_cast<LLVM::LLVMPointerType>();
+      if (!Pt) {
         return ValueCategory(
-            builder.create<polygeist::Pointer2MemrefOp>(loc, nt, scalar),
+            Builder.create<polygeist::Pointer2MemrefOp>(Loc, Nt, Scalar),
             false);
       }
-      pt = LLVM::LLVMPointerType::get(pt.getElementType(),
-                                      spt.getAddressSpace());
-      auto nval = builder.create<mlir::LLVM::BitcastOp>(loc, pt, scalar);
-      return ValueCategory(nval, /*isReference*/ false);
+      Pt = LLVM::LLVMPointerType::get(Pt.getElementType(),
+                                      Spt.getAddressSpace());
+      auto Nval = Builder.create<mlir::LLVM::BitcastOp>(Loc, Pt, Scalar);
+      return ValueCategory(Nval, /*isReference*/ false);
     }
 
 #ifdef DEBUG
@@ -1596,44 +1580,44 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
     }
 #endif
 
-    assert(scalar.getType().isa<mlir::MemRefType>() &&
+    assert(Scalar.getType().isa<mlir::MemRefType>() &&
            "Expecting 'scalar' to have MemRefType");
 
-    auto scalarTy = scalar.getType().cast<mlir::MemRefType>();
-    mlir::Type mlirty = Glob.getTypes().getMLIRType(E->getType());
+    auto ScalarTy = Scalar.getType().cast<mlir::MemRefType>();
+    mlir::Type Mlirty = Glob.getTypes().getMLIRType(E->getType());
 
-    if (auto PT = mlirty.dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+    if (auto PT = Mlirty.dyn_cast<mlir::LLVM::LLVMPointerType>()) {
       assert(
-          scalarTy.getMemorySpaceAsInt() == PT.getAddressSpace() &&
+          ScalarTy.getMemorySpaceAsInt() == PT.getAddressSpace() &&
           "The type of 'scalar' does not have the same memory space as 'PT'");
-      auto val =
-          builder.create<mlir::polygeist::Memref2PointerOp>(loc, PT, scalar);
-      return ValueCategory(val, /*isReference*/ false);
+      auto Val =
+          Builder.create<mlir::polygeist::Memref2PointerOp>(Loc, PT, Scalar);
+      return ValueCategory(Val, /*isReference*/ false);
     }
 
-    if (auto mt = mlirty.dyn_cast<mlir::MemRefType>()) {
-      auto ty = mlir::MemRefType::get(mt.getShape(), mt.getElementType(),
+    if (auto Mt = Mlirty.dyn_cast<mlir::MemRefType>()) {
+      auto Ty = mlir::MemRefType::get(Mt.getShape(), Mt.getElementType(),
                                       MemRefLayoutAttrInterface(),
-                                      scalarTy.getMemorySpace());
-      if (scalarTy.getShape().size() == mt.getShape().size() + 1)
-        return ValueCategory(builder.create<mlir::polygeist::SubIndexOp>(
-                                 loc, ty, scalar, getConstantIndex(0)),
+                                      ScalarTy.getMemorySpace());
+      if (ScalarTy.getShape().size() == Mt.getShape().size() + 1)
+        return ValueCategory(Builder.create<mlir::polygeist::SubIndexOp>(
+                                 Loc, Ty, Scalar, getConstantIndex(0)),
                              /*isReference*/ false);
 
-      if (scalarTy.getShape().size() != mt.getShape().size()) {
-        auto memRefToPtr = builder.create<polygeist::Memref2PointerOp>(
-            loc,
-            LLVM::LLVMPointerType::get(builder.getI8Type(),
-                                       scalarTy.getMemorySpaceAsInt()),
-            scalar);
-        assert(ty.getMemorySpaceAsInt() == scalarTy.getMemorySpaceAsInt() &&
+      if (ScalarTy.getShape().size() != Mt.getShape().size()) {
+        auto MemRefToPtr = Builder.create<polygeist::Memref2PointerOp>(
+            Loc,
+            LLVM::LLVMPointerType::get(Builder.getI8Type(),
+                                       ScalarTy.getMemorySpaceAsInt()),
+            Scalar);
+        assert(Ty.getMemorySpaceAsInt() == ScalarTy.getMemorySpaceAsInt() &&
                "Expecting 'ty' and 'scalarTy' to have the same memory space");
-        auto ptrToMemRef =
-            builder.create<polygeist::Pointer2MemrefOp>(loc, ty, memRefToPtr);
-        return ValueCategory(ptrToMemRef, /*isReference*/ false);
+        auto PtrToMemRef =
+            Builder.create<polygeist::Pointer2MemrefOp>(Loc, Ty, MemRefToPtr);
+        return ValueCategory(PtrToMemRef, /*isReference*/ false);
       }
 
-      return ValueCategory(builder.create<memref::CastOp>(loc, ty, scalar),
+      return ValueCategory(Builder.create<memref::CastOp>(Loc, Ty, Scalar),
                            /*isReference*/ false);
     }
 
@@ -1645,10 +1629,10 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
     llvm_unreachable("illegal type for cast");
   } break;
   case clang::CastKind::CK_LValueToRValue: {
-    if (auto dr = dyn_cast<DeclRefExpr>(E->getSubExpr())) {
-      if (auto VD = dyn_cast<VarDecl>(dr->getDecl()->getCanonicalDecl())) {
-        if (NOUR_Constant == dr->isNonOdrUse()) {
-          auto VarD = cast<VarDecl>(VD);
+    if (auto *Dr = dyn_cast<DeclRefExpr>(E->getSubExpr())) {
+      if (auto *VD = dyn_cast<VarDecl>(Dr->getDecl()->getCanonicalDecl())) {
+        if (NOUR_Constant == Dr->isNonOdrUse()) {
+          auto *VarD = cast<VarDecl>(VD);
           if (!VarD->getInit()) {
             E->dump();
             VarD->dump();
@@ -1657,11 +1641,11 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
           return Visit(VarD->getInit());
         }
       }
-      if (dr->getDecl()->getIdentifier() &&
-          dr->getDecl()->getName() == "warpSize") {
-        mlir::Type mlirType = Glob.getTypes().getMLIRType(E->getType());
+      if (Dr->getDecl()->getIdentifier() &&
+          Dr->getDecl()->getName() == "warpSize") {
+        mlir::Type MlirType = Glob.getTypes().getMLIRType(E->getType());
         return ValueCategory(
-            builder.create<mlir::NVVM::WarpSizeOp>(loc, mlirType),
+            Builder.create<mlir::NVVM::WarpSizeOp>(Loc, MlirType),
             /*isReference*/ false);
       }
       /*
@@ -1672,70 +1656,71 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
       }
       */
     }
-    auto prev = EmitLValue(E->getSubExpr());
+    auto Prev = EmitLValue(E->getSubExpr());
 
-    bool isArray = false;
-    Glob.getTypes().getMLIRType(E->getType(), &isArray);
-    if (isArray)
-      return prev;
+    bool IsArray = false;
+    Glob.getTypes().getMLIRType(E->getType(), &IsArray);
+    if (IsArray)
+      return Prev;
 
-    auto lres = prev.getValue(builder);
+    auto Lres = Prev.getValue(Builder);
 #ifdef DEBUG
     if (!prev.isReference) {
       E->dump();
       lres.dump();
     }
 #endif
-    return ValueCategory(lres, /*isReference*/ false);
+    return ValueCategory(Lres, /*isReference*/ false);
   }
   case clang::CastKind::CK_IntegralToFloating: {
-    auto scalar = Visit(E->getSubExpr()).getValue(builder);
-    auto ty = Glob.getTypes().getMLIRType(E->getType()).cast<mlir::FloatType>();
-    bool signedType = true;
-    if (auto bit = dyn_cast<clang::BuiltinType>(&*E->getSubExpr()->getType())) {
-      if (bit->isUnsignedInteger())
-        signedType = false;
-      if (bit->isSignedInteger())
-        signedType = true;
+    auto Scalar = Visit(E->getSubExpr()).getValue(Builder);
+    auto Ty = Glob.getTypes().getMLIRType(E->getType()).cast<mlir::FloatType>();
+    bool SignedType = true;
+    if (const auto *Bit =
+            dyn_cast<clang::BuiltinType>(&*E->getSubExpr()->getType())) {
+      if (Bit->isUnsignedInteger())
+        SignedType = false;
+      if (Bit->isSignedInteger())
+        SignedType = true;
     }
-    if (signedType)
+    if (SignedType)
       return ValueCategory(
-          builder.create<mlir::arith::SIToFPOp>(loc, ty, scalar),
+          Builder.create<mlir::arith::SIToFPOp>(Loc, Ty, Scalar),
           /*isReference*/ false);
 
-    return ValueCategory(builder.create<mlir::arith::UIToFPOp>(loc, ty, scalar),
+    return ValueCategory(Builder.create<mlir::arith::UIToFPOp>(Loc, Ty, Scalar),
                          /*isReference*/ false);
   }
   case clang::CastKind::CK_FloatingToIntegral: {
-    auto scalar = Visit(E->getSubExpr()).getValue(builder);
-    auto ty =
+    auto Scalar = Visit(E->getSubExpr()).getValue(Builder);
+    auto Ty =
         Glob.getTypes().getMLIRType(E->getType()).cast<mlir::IntegerType>();
-    bool signedType = true;
-    if (auto bit = dyn_cast<clang::BuiltinType>(&*E->getType())) {
-      if (bit->isUnsignedInteger())
-        signedType = false;
-      if (bit->isSignedInteger())
-        signedType = true;
+    bool SignedType = true;
+    if (const auto *Bit = dyn_cast<clang::BuiltinType>(&*E->getType())) {
+      if (Bit->isUnsignedInteger())
+        SignedType = false;
+      if (Bit->isSignedInteger())
+        SignedType = true;
     }
-    if (signedType)
+    if (SignedType)
       return ValueCategory(
-          builder.create<mlir::arith::FPToSIOp>(loc, ty, scalar),
+          Builder.create<mlir::arith::FPToSIOp>(Loc, Ty, Scalar),
           /*isReference*/ false);
-    return ValueCategory(builder.create<mlir::arith::FPToUIOp>(loc, ty, scalar),
+    return ValueCategory(Builder.create<mlir::arith::FPToUIOp>(Loc, Ty, Scalar),
                          /*isReference*/ false);
   }
   case clang::CastKind::CK_IntegralCast: {
-    auto scalar = Visit(E->getSubExpr()).getValue(builder);
-    assert(scalar);
-    auto postTy =
+    auto Scalar = Visit(E->getSubExpr()).getValue(Builder);
+    assert(Scalar);
+    auto PostTy =
         Glob.getTypes().getMLIRType(E->getType()).cast<mlir::IntegerType>();
-    if (scalar.getType().isa<mlir::LLVM::LLVMPointerType>())
+    if (Scalar.getType().isa<mlir::LLVM::LLVMPointerType>())
       return ValueCategory(
-          builder.create<mlir::LLVM::PtrToIntOp>(loc, postTy, scalar),
+          Builder.create<mlir::LLVM::PtrToIntOp>(Loc, PostTy, Scalar),
           /*isReference*/ false);
-    if (scalar.getType().isa<mlir::IndexType>() ||
-        postTy.isa<mlir::IndexType>())
-      return ValueCategory(builder.create<IndexCastOp>(loc, postTy, scalar),
+    if (Scalar.getType().isa<mlir::IndexType>() ||
+        PostTy.isa<mlir::IndexType>())
+      return ValueCategory(Builder.create<IndexCastOp>(Loc, PostTy, Scalar),
                            false);
 #ifdef DEBUG
     if (!scalar.getType().isa<mlir::IntegerType>()) {
@@ -1743,85 +1728,86 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
       llvm::errs() << " scalar: " << scalar << "\n";
     }
 #endif
-    auto prevTy = scalar.getType().cast<mlir::IntegerType>();
-    bool signedType = true;
-    if (auto bit = dyn_cast<clang::BuiltinType>(&*E->getSubExpr()->getType())) {
-      if (bit->isUnsignedInteger())
-        signedType = false;
-      if (bit->isSignedInteger())
-        signedType = true;
+    auto PrevTy = Scalar.getType().cast<mlir::IntegerType>();
+    bool SignedType = true;
+    if (const auto *Bit =
+            dyn_cast<clang::BuiltinType>(&*E->getSubExpr()->getType())) {
+      if (Bit->isUnsignedInteger())
+        SignedType = false;
+      if (Bit->isSignedInteger())
+        SignedType = true;
     }
 
-    if (prevTy == postTy)
-      return ValueCategory(scalar, /*isReference*/ false);
-    if (prevTy.getWidth() < postTy.getWidth()) {
-      if (signedType) {
-        if (auto CI = scalar.getDefiningOp<arith::ConstantIntOp>()) {
+    if (PrevTy == PostTy)
+      return ValueCategory(Scalar, /*isReference*/ false);
+    if (PrevTy.getWidth() < PostTy.getWidth()) {
+      if (SignedType) {
+        if (auto CI = Scalar.getDefiningOp<arith::ConstantIntOp>()) {
           return ValueCategory(
-              builder.create<arith::ConstantOp>(
-                  loc, postTy,
+              Builder.create<arith::ConstantOp>(
+                  Loc, PostTy,
                   mlir::IntegerAttr::get(
-                      postTy, CI.getValue().cast<IntegerAttr>().getValue().sext(
-                                  postTy.getWidth()))),
+                      PostTy, CI.getValue().cast<IntegerAttr>().getValue().sext(
+                                  PostTy.getWidth()))),
               /*isReference*/ false);
         }
         return ValueCategory(
-            builder.create<arith::ExtSIOp>(loc, postTy, scalar),
+            Builder.create<arith::ExtSIOp>(Loc, PostTy, Scalar),
             /*isReference*/ false);
       }
-      if (auto CI = scalar.getDefiningOp<arith::ConstantIntOp>()) {
+      if (auto CI = Scalar.getDefiningOp<arith::ConstantIntOp>()) {
         return ValueCategory(
-            builder.create<arith::ConstantOp>(
-                loc, postTy,
+            Builder.create<arith::ConstantOp>(
+                Loc, PostTy,
                 mlir::IntegerAttr::get(
-                    postTy, CI.getValue().cast<IntegerAttr>().getValue().zext(
-                                postTy.getWidth()))),
+                    PostTy, CI.getValue().cast<IntegerAttr>().getValue().zext(
+                                PostTy.getWidth()))),
             /*isReference*/ false);
       }
-      return ValueCategory(builder.create<arith::ExtUIOp>(loc, postTy, scalar),
+      return ValueCategory(Builder.create<arith::ExtUIOp>(Loc, PostTy, Scalar),
                            /*isReference*/ false);
     }
 
-    if (auto CI = scalar.getDefiningOp<ConstantIntOp>()) {
+    if (auto CI = Scalar.getDefiningOp<ConstantIntOp>()) {
       return ValueCategory(
-          builder.create<arith::ConstantOp>(
-              loc, postTy,
+          Builder.create<arith::ConstantOp>(
+              Loc, PostTy,
               mlir::IntegerAttr::get(
-                  postTy, CI.getValue().cast<IntegerAttr>().getValue().trunc(
-                              postTy.getWidth()))),
+                  PostTy, CI.getValue().cast<IntegerAttr>().getValue().trunc(
+                              PostTy.getWidth()))),
           /*isReference*/ false);
     }
-    return ValueCategory(builder.create<arith::TruncIOp>(loc, postTy, scalar),
+    return ValueCategory(Builder.create<arith::TruncIOp>(Loc, PostTy, Scalar),
                          /*isReference*/ false);
   }
   case clang::CastKind::CK_FloatingCast: {
-    auto scalar = Visit(E->getSubExpr()).getValue(builder);
+    auto Scalar = Visit(E->getSubExpr()).getValue(Builder);
 #ifdef DEBUG
     if (!scalar.getType().isa<mlir::FloatType>()) {
       E->dump();
       llvm::errs() << "scalar: " << scalar << "\n";
     }
 #endif
-    auto prevTy = scalar.getType().cast<mlir::FloatType>();
-    auto postTy =
+    auto PrevTy = Scalar.getType().cast<mlir::FloatType>();
+    auto PostTy =
         Glob.getTypes().getMLIRType(E->getType()).cast<mlir::FloatType>();
 
-    if (prevTy == postTy)
-      return ValueCategory(scalar, /*isReference*/ false);
-    if (auto c = scalar.getDefiningOp<ConstantFloatOp>()) {
-      APFloat Val = c.getValue().cast<FloatAttr>().getValue();
-      bool ignored;
-      Val.convert(postTy.getFloatSemantics(), APFloat::rmNearestTiesToEven,
-                  &ignored);
-      return ValueCategory(builder.create<arith::ConstantOp>(
-                               loc, postTy, mlir::FloatAttr::get(postTy, Val)),
+    if (PrevTy == PostTy)
+      return ValueCategory(Scalar, /*isReference*/ false);
+    if (auto C = Scalar.getDefiningOp<ConstantFloatOp>()) {
+      APFloat Val = C.getValue().cast<FloatAttr>().getValue();
+      bool Ignored;
+      Val.convert(PostTy.getFloatSemantics(), APFloat::rmNearestTiesToEven,
+                  &Ignored);
+      return ValueCategory(Builder.create<arith::ConstantOp>(
+                               Loc, PostTy, mlir::FloatAttr::get(PostTy, Val)),
                            false);
     }
-    if (prevTy.getWidth() < postTy.getWidth()) {
-      return ValueCategory(builder.create<arith::ExtFOp>(loc, postTy, scalar),
+    if (PrevTy.getWidth() < PostTy.getWidth())
+      return ValueCategory(Builder.create<arith::ExtFOp>(Loc, PostTy, Scalar),
                            /*isReference*/ false);
-    }
-    return ValueCategory(builder.create<arith::TruncFOp>(loc, postTy, scalar),
+
+    return ValueCategory(Builder.create<arith::TruncFOp>(Loc, PostTy, Scalar),
                          /*isReference*/ false);
   }
   case clang::CastKind::CK_ArrayToPointerDecay: {
@@ -1838,7 +1824,7 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
     shape2[0] = -1;
     auto nex = mlir::MemRefType::get(shape2, mt.getElementType(),
                                      mt.getLayout(), mt.getMemorySpace());
-    auto cst = builder.create<mlir::MemRefCastOp>(loc, scalar.val, nex);
+    auto cst = Builder.create<mlir::MemRefCastOp>(Loc, scalar.val, nex);
     //llvm::errs() << "<ArrayToPtrDecay>\n";
     //E->dump();
     //llvm::errs() << cst << " - " << scalar.val << "\n";
@@ -1848,9 +1834,9 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
 #endif
   }
   case clang::CastKind::CK_FunctionToPointerDecay: {
-    auto scalar = Visit(E->getSubExpr());
-    assert(scalar.isReference);
-    return ValueCategory(scalar.val, /*isReference*/ false);
+    auto Scalar = Visit(E->getSubExpr());
+    assert(Scalar.isReference);
+    return ValueCategory(Scalar.val, /*isReference*/ false);
   }
   case clang::CastKind::CK_ConstructorConversion:
   case clang::CastKind::CK_NoOp: {
@@ -1861,38 +1847,38 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
     return nullptr;
   }
   case clang::CastKind::CK_PointerToBoolean: {
-    auto scalar = Visit(E->getSubExpr()).getValue(builder);
-    if (auto mt = scalar.getType().dyn_cast<mlir::MemRefType>()) {
-      scalar = builder.create<polygeist::Memref2PointerOp>(
-          loc,
-          LLVM::LLVMPointerType::get(mt.getElementType(),
-                                     mt.getMemorySpaceAsInt()),
-          scalar);
+    auto Scalar = Visit(E->getSubExpr()).getValue(Builder);
+    if (auto Mt = Scalar.getType().dyn_cast<mlir::MemRefType>()) {
+      Scalar = Builder.create<polygeist::Memref2PointerOp>(
+          Loc,
+          LLVM::LLVMPointerType::get(Mt.getElementType(),
+                                     Mt.getMemorySpaceAsInt()),
+          Scalar);
     }
-    if (auto LT = scalar.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
-      auto nullptr_llvm = builder.create<mlir::LLVM::NullOp>(loc, LT);
-      auto ne = builder.create<mlir::LLVM::ICmpOp>(
-          loc, mlir::LLVM::ICmpPredicate::ne, scalar, nullptr_llvm);
-      return ValueCategory(ne, /*isReference*/ false);
+    if (auto LT = Scalar.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+      auto NullptrLlvm = Builder.create<mlir::LLVM::NullOp>(Loc, LT);
+      auto Ne = Builder.create<mlir::LLVM::ICmpOp>(
+          Loc, mlir::LLVM::ICmpPredicate::ne, Scalar, NullptrLlvm);
+      return ValueCategory(Ne, /*isReference*/ false);
     }
-    function.dump();
-    llvm::errs() << "scalar: " << scalar << "\n";
+    Function.dump();
+    llvm::errs() << "scalar: " << Scalar << "\n";
     E->dump();
     assert(0 && "unhandled ptrtobool cast");
   }
   case clang::CastKind::CK_PointerToIntegral: {
-    auto scalar = Visit(E->getSubExpr()).getValue(builder);
-    if (auto mt = scalar.getType().dyn_cast<mlir::MemRefType>()) {
-      scalar = builder.create<polygeist::Memref2PointerOp>(
-          loc,
-          LLVM::LLVMPointerType::get(mt.getElementType(),
-                                     mt.getMemorySpaceAsInt()),
-          scalar);
+    auto Scalar = Visit(E->getSubExpr()).getValue(Builder);
+    if (auto Mt = Scalar.getType().dyn_cast<mlir::MemRefType>()) {
+      Scalar = Builder.create<polygeist::Memref2PointerOp>(
+          Loc,
+          LLVM::LLVMPointerType::get(Mt.getElementType(),
+                                     Mt.getMemorySpaceAsInt()),
+          Scalar);
     }
-    if (auto LT = scalar.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
-      mlir::Type mlirType = Glob.getTypes().getMLIRType(E->getType());
-      auto val = builder.create<mlir::LLVM::PtrToIntOp>(loc, mlirType, scalar);
-      return ValueCategory(val, /*isReference*/ false);
+    if (auto LT = Scalar.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+      mlir::Type MlirType = Glob.getTypes().getMLIRType(E->getType());
+      auto Val = Builder.create<mlir::LLVM::PtrToIntOp>(Loc, MlirType, Scalar);
+      return ValueCategory(Val, /*isReference*/ false);
     }
 #ifdef DEBUG
     function.dump();
@@ -1902,72 +1888,69 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
     llvm_unreachable("unhandled ptrtoint cast");
   } break;
   case clang::CastKind::CK_IntegralToBoolean: {
-    auto res = Visit(E->getSubExpr()).getValue(builder);
-    auto prevTy = res.getType().cast<mlir::IntegerType>();
-    res = builder.create<arith::CmpIOp>(
-        loc, CmpIPredicate::ne, res,
-        builder.create<ConstantIntOp>(loc, 0, prevTy));
-    auto postTy =
+    auto Res = Visit(E->getSubExpr()).getValue(Builder);
+    auto PrevTy = Res.getType().cast<mlir::IntegerType>();
+    Res = Builder.create<arith::CmpIOp>(
+        Loc, CmpIPredicate::ne, Res,
+        Builder.create<ConstantIntOp>(Loc, 0, PrevTy));
+    auto PostTy =
         Glob.getTypes().getMLIRType(E->getType()).cast<mlir::IntegerType>();
-    bool signedType = true;
-    if (auto bit = dyn_cast<clang::BuiltinType>(&*E->getType())) {
-      if (bit->isUnsignedInteger())
-        signedType = false;
-      if (bit->isSignedInteger())
-        signedType = true;
+    bool SignedType = true;
+    if (const auto *Bit = dyn_cast<clang::BuiltinType>(&*E->getType())) {
+      if (Bit->isUnsignedInteger())
+        SignedType = false;
+      if (Bit->isSignedInteger())
+        SignedType = true;
     }
-    if (postTy.getWidth() > 1) {
-      if (signedType) {
-        res = builder.create<arith::ExtSIOp>(loc, postTy, res);
-      } else {
-        res = builder.create<arith::ExtUIOp>(loc, postTy, res);
-      }
+    if (PostTy.getWidth() > 1) {
+      if (SignedType)
+        Res = Builder.create<arith::ExtSIOp>(Loc, PostTy, Res);
+      else
+        Res = Builder.create<arith::ExtUIOp>(Loc, PostTy, Res);
     }
-    return ValueCategory(res, /*isReference*/ false);
+    return ValueCategory(Res, /*isReference*/ false);
   }
   case clang::CastKind::CK_FloatingToBoolean: {
-    auto res = Visit(E->getSubExpr()).getValue(builder);
-    auto prevTy = res.getType().cast<mlir::FloatType>();
-    auto postTy =
+    auto Res = Visit(E->getSubExpr()).getValue(Builder);
+    auto PrevTy = Res.getType().cast<mlir::FloatType>();
+    auto PostTy =
         Glob.getTypes().getMLIRType(E->getType()).cast<mlir::IntegerType>();
-    bool signedType = true;
-    if (auto bit = dyn_cast<clang::BuiltinType>(&*E->getType())) {
-      if (bit->isUnsignedInteger())
-        signedType = false;
-      if (bit->isSignedInteger())
-        signedType = true;
+    bool SignedType = true;
+    if (const auto *Bit = dyn_cast<clang::BuiltinType>(&*E->getType())) {
+      if (Bit->isUnsignedInteger())
+        SignedType = false;
+      if (Bit->isSignedInteger())
+        SignedType = true;
     }
-    auto Zero = builder.create<ConstantFloatOp>(
-        loc, APFloat::getZero(prevTy.getFloatSemantics()), prevTy);
-    res = builder.create<arith::CmpFOp>(loc, CmpFPredicate::UNE, res, Zero);
-    if (1 < postTy.getWidth()) {
-      if (signedType) {
-        res = builder.create<arith::ExtSIOp>(loc, postTy, res);
-      } else {
-        res = builder.create<arith::ExtUIOp>(loc, postTy, res);
-      }
+    auto Zero = Builder.create<ConstantFloatOp>(
+        Loc, APFloat::getZero(PrevTy.getFloatSemantics()), PrevTy);
+    Res = Builder.create<arith::CmpFOp>(Loc, CmpFPredicate::UNE, Res, Zero);
+    if (1 < PostTy.getWidth()) {
+      if (SignedType)
+        Res = Builder.create<arith::ExtSIOp>(Loc, PostTy, Res);
+      else
+        Res = Builder.create<arith::ExtUIOp>(Loc, PostTy, Res);
     }
-    return ValueCategory(res, /*isReference*/ false);
+    return ValueCategory(Res, /*isReference*/ false);
   }
   case clang::CastKind::CK_IntegralToPointer: {
-    auto vc = Visit(E->getSubExpr());
+    auto Vc = Visit(E->getSubExpr());
 #ifdef DEBUG
-    if (!vc.val) {
+    if (!vc.val)
       E->dump();
-    }
 #endif
-    assert(vc.val);
-    auto res = vc.getValue(builder);
-    mlir::Type postTy = Glob.getTypes().getMLIRType(E->getType());
-    if (postTy.isa<LLVM::LLVMPointerType>())
-      res = builder.create<LLVM::IntToPtrOp>(loc, postTy, res);
+    assert(Vc.val);
+    auto Res = Vc.getValue(Builder);
+    mlir::Type PostTy = Glob.getTypes().getMLIRType(E->getType());
+    if (PostTy.isa<LLVM::LLVMPointerType>())
+      Res = Builder.create<LLVM::IntToPtrOp>(Loc, PostTy, Res);
     else {
-      assert(postTy.isa<MemRefType>());
-      res = builder.create<LLVM::IntToPtrOp>(
-          loc, LLVM::LLVMPointerType::get(builder.getI8Type()), res);
-      res = builder.create<polygeist::Pointer2MemrefOp>(loc, postTy, res);
+      assert(PostTy.isa<MemRefType>());
+      Res = Builder.create<LLVM::IntToPtrOp>(
+          Loc, LLVM::LLVMPointerType::get(Builder.getI8Type()), Res);
+      Res = Builder.create<polygeist::Pointer2MemrefOp>(Loc, PostTy, Res);
     }
-    return ValueCategory(res, /*isReference*/ false);
+    return ValueCategory(Res, /*isReference*/ false);
   }
 
   default:
@@ -1981,149 +1964,147 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
 
 ValueCategory
 MLIRScanner::VisitConditionalOperator(clang::ConditionalOperator *E) {
-  auto cond = Visit(E->getCond()).getValue(builder);
-  assert(cond != nullptr);
-  if (auto LT = cond.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
-    auto nullptr_llvm = builder.create<mlir::LLVM::NullOp>(loc, LT);
-    cond = builder.create<mlir::LLVM::ICmpOp>(
-        loc, mlir::LLVM::ICmpPredicate::ne, cond, nullptr_llvm);
+  auto Cond = Visit(E->getCond()).getValue(Builder);
+  assert(Cond != nullptr);
+  if (auto LT = Cond.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+    auto NullptrLlvm = Builder.create<mlir::LLVM::NullOp>(Loc, LT);
+    Cond = Builder.create<mlir::LLVM::ICmpOp>(
+        Loc, mlir::LLVM::ICmpPredicate::ne, Cond, NullptrLlvm);
   }
-  auto prevTy = cond.getType().cast<mlir::IntegerType>();
-  if (!prevTy.isInteger(1)) {
-    cond = builder.create<arith::CmpIOp>(
-        loc, CmpIPredicate::ne, cond,
-        builder.create<ConstantIntOp>(loc, 0, prevTy));
+  auto PrevTy = Cond.getType().cast<mlir::IntegerType>();
+  if (!PrevTy.isInteger(1)) {
+    Cond = Builder.create<arith::CmpIOp>(
+        Loc, CmpIPredicate::ne, Cond,
+        Builder.create<ConstantIntOp>(Loc, 0, PrevTy));
   }
-  std::vector<mlir::Type> types;
+  std::vector<mlir::Type> Types;
   if (!E->getType()->isVoidType())
-    types.push_back(Glob.getTypes().getMLIRType(E->getType()));
-  auto ifOp = builder.create<mlir::scf::IfOp>(loc, types, cond,
+    Types.push_back(Glob.getTypes().getMLIRType(E->getType()));
+  auto IfOp = Builder.create<mlir::scf::IfOp>(Loc, Types, Cond,
                                               /*hasElseRegion*/ true);
 
-  auto oldpoint = builder.getInsertionPoint();
-  auto oldblock = builder.getInsertionBlock();
-  builder.setInsertionPointToStart(&ifOp.getThenRegion().back());
+  auto Oldpoint = Builder.getInsertionPoint();
+  auto *Oldblock = Builder.getInsertionBlock();
+  Builder.setInsertionPointToStart(&IfOp.getThenRegion().back());
 
-  auto trueExpr = Visit(E->getTrueExpr());
+  auto TrueExpr = Visit(E->getTrueExpr());
 
-  bool isReference = E->isLValue() || E->isXValue();
+  bool IsReference = E->isLValue() || E->isXValue();
 
-  std::vector<mlir::Value> truearray;
+  std::vector<mlir::Value> Truearray;
   if (!E->getType()->isVoidType()) {
-    if (!trueExpr.val) {
+    if (!TrueExpr.val)
       E->dump();
-    }
-    assert(trueExpr.val);
-    mlir::Value truev;
-    if (isReference) {
-      assert(trueExpr.isReference);
-      truev = trueExpr.val;
+
+    assert(TrueExpr.val);
+    mlir::Value Truev;
+    if (IsReference) {
+      assert(TrueExpr.isReference);
+      Truev = TrueExpr.val;
     } else {
-      if (trueExpr.isReference)
-        if (auto mt = trueExpr.val.getType().dyn_cast<MemRefType>())
-          if (mt.getShape().size() != 1) {
+      if (TrueExpr.isReference)
+        if (auto Mt = TrueExpr.val.getType().dyn_cast<MemRefType>())
+          if (Mt.getShape().size() != 1) {
             E->dump();
             E->getTrueExpr()->dump();
-            llvm::errs() << " trueExpr: " << trueExpr.val << "\n";
+            llvm::errs() << " trueExpr: " << TrueExpr.val << "\n";
             assert(0);
           }
-      truev = trueExpr.getValue(builder);
+      Truev = TrueExpr.getValue(Builder);
     }
-    assert(truev != nullptr);
-    truearray.push_back(truev);
-    builder.create<mlir::scf::YieldOp>(loc, truearray);
+    assert(Truev != nullptr);
+    Truearray.push_back(Truev);
+    Builder.create<mlir::scf::YieldOp>(Loc, Truearray);
   }
 
-  builder.setInsertionPointToStart(&ifOp.getElseRegion().back());
+  Builder.setInsertionPointToStart(&IfOp.getElseRegion().back());
 
-  auto falseExpr = Visit(E->getFalseExpr());
-  std::vector<mlir::Value> falsearray;
+  auto FalseExpr = Visit(E->getFalseExpr());
+  std::vector<mlir::Value> Falsearray;
   if (!E->getType()->isVoidType()) {
-    mlir::Value falsev;
-    if (isReference) {
-      assert(falseExpr.isReference);
-      falsev = falseExpr.val;
+    mlir::Value Falsev;
+    if (IsReference) {
+      assert(FalseExpr.isReference);
+      Falsev = FalseExpr.val;
     } else
-      falsev = falseExpr.getValue(builder);
-    assert(falsev != nullptr);
-    falsearray.push_back(falsev);
-    builder.create<mlir::scf::YieldOp>(loc, falsearray);
+      Falsev = FalseExpr.getValue(Builder);
+    assert(Falsev != nullptr);
+    Falsearray.push_back(Falsev);
+    Builder.create<mlir::scf::YieldOp>(Loc, Falsearray);
   }
 
-  builder.setInsertionPoint(oldblock, oldpoint);
+  Builder.setInsertionPoint(Oldblock, Oldpoint);
 
-  for (size_t i = 0; i < truearray.size(); i++)
-    types[i] = truearray[i].getType();
-  auto newIfOp = builder.create<mlir::scf::IfOp>(loc, types, cond,
+  for (size_t I = 0; I < Truearray.size(); I++)
+    Types[I] = Truearray[I].getType();
+  auto NewIfOp = Builder.create<mlir::scf::IfOp>(Loc, Types, Cond,
                                                  /*hasElseRegion*/ true);
-  newIfOp.getThenRegion().takeBody(ifOp.getThenRegion());
-  newIfOp.getElseRegion().takeBody(ifOp.getElseRegion());
-  ifOp.erase();
-  return ValueCategory(newIfOp.getResult(0), /*isReference*/ isReference);
+  NewIfOp.getThenRegion().takeBody(IfOp.getThenRegion());
+  NewIfOp.getElseRegion().takeBody(IfOp.getElseRegion());
+  IfOp.erase();
+  return ValueCategory(NewIfOp.getResult(0), /*isReference*/ IsReference);
 }
 
-ValueCategory MLIRScanner::VisitStmtExpr(clang::StmtExpr *stmt) {
-  ValueCategory off = nullptr;
-  for (auto a : stmt->getSubStmt()->children()) {
-    off = Visit(a);
-  }
-  return off;
+ValueCategory MLIRScanner::VisitStmtExpr(clang::StmtExpr *Stmt) {
+  ValueCategory Off = nullptr;
+  for (auto *A : Stmt->getSubStmt()->children())
+    Off = Visit(A);
+
+  return Off;
 }
 
-ValueCategory MLIRScanner::VisitBinAssign(BinaryOperator *e) {
+ValueCategory MLIRScanner::VisitBinAssign(BinaryOperator *E) {
   LLVM_DEBUG({
     llvm::dbgs() << "VisitBinAssign: ";
-    e->dump();
+    E->dump();
     llvm::dbgs() << "\n";
   });
-  ValueCategory rhs = Visit(e->getRHS());
-  ValueCategory lhs = Visit(e->getLHS());
+  ValueCategory Rhs = Visit(E->getRHS());
+  ValueCategory Lhs = Visit(E->getLHS());
 
-  assert(lhs.isReference);
-  mlir::Value tostore = rhs.getValue(builder);
-  mlir::Type subType;
-  if (auto PT = lhs.val.getType().dyn_cast<mlir::LLVM::LLVMPointerType>())
-    subType = PT.getElementType();
+  assert(Lhs.isReference);
+  mlir::Value Tostore = Rhs.getValue(Builder);
+  mlir::Type SubType;
+  if (auto PT = Lhs.val.getType().dyn_cast<mlir::LLVM::LLVMPointerType>())
+    SubType = PT.getElementType();
   else
-    subType = lhs.val.getType().cast<MemRefType>().getElementType();
+    SubType = Lhs.val.getType().cast<MemRefType>().getElementType();
 
-  if (tostore.getType() != subType) {
-    if (auto prevTy = tostore.getType().dyn_cast<mlir::IntegerType>()) {
-      if (auto postTy = subType.dyn_cast<mlir::IntegerType>()) {
-        bool signedType = true;
-        if (auto bit = dyn_cast<BuiltinType>(&*e->getType())) {
-          if (bit->isUnsignedInteger())
-            signedType = false;
-          if (bit->isSignedInteger())
-            signedType = true;
+  if (Tostore.getType() != SubType) {
+    if (auto PrevTy = Tostore.getType().dyn_cast<mlir::IntegerType>()) {
+      if (auto PostTy = SubType.dyn_cast<mlir::IntegerType>()) {
+        bool SignedType = true;
+        if (const auto *Bit = dyn_cast<BuiltinType>(&*E->getType())) {
+          if (Bit->isUnsignedInteger())
+            SignedType = false;
+          if (Bit->isSignedInteger())
+            SignedType = true;
         }
 
-        if (prevTy.getWidth() < postTy.getWidth()) {
-          if (signedType) {
-            tostore = builder.create<arith::ExtSIOp>(loc, postTy, tostore);
-          } else {
-            tostore = builder.create<arith::ExtUIOp>(loc, postTy, tostore);
-          }
-        } else if (prevTy.getWidth() > postTy.getWidth()) {
-          tostore = builder.create<arith::TruncIOp>(loc, postTy, tostore);
-        }
+        if (PrevTy.getWidth() < PostTy.getWidth()) {
+          if (SignedType)
+            Tostore = Builder.create<arith::ExtSIOp>(Loc, PostTy, Tostore);
+          else
+            Tostore = Builder.create<arith::ExtUIOp>(Loc, PostTy, Tostore);
+        } else if (PrevTy.getWidth() > PostTy.getWidth())
+          Tostore = Builder.create<arith::TruncIOp>(Loc, PostTy, Tostore);
       }
     }
   }
-  lhs.store(builder, tostore);
-  return rhs;
+  Lhs.store(Builder, Tostore);
+  return Rhs;
 }
 
 static bool isSigned(QualType Ty) {
   // TODO note assumptions made here about unsigned / unordered
-  bool signedType = true;
-  if (auto bit = dyn_cast<clang::BuiltinType>(Ty)) {
-    if (bit->isUnsignedInteger())
-      signedType = false;
-    if (bit->isSignedInteger())
-      signedType = true;
+  bool SignedType = true;
+  if (const auto *Bit = dyn_cast<clang::BuiltinType>(Ty)) {
+    if (Bit->isUnsignedInteger())
+      SignedType = false;
+    if (Bit->isSignedInteger())
+      SignedType = true;
   }
-  return signedType;
+  return SignedType;
 }
 
 class BinOpInfo {
@@ -2191,20 +2172,20 @@ ValueCategory MLIRScanner::CastToVoidPtr(ValueCategory Ptr) {
          "Expecting pointer or memref");
 
   const auto DestType =
-      mlirclang::getPtrTyWithNewType(Ptr.val.getType(), builder.getI8Type());
+      mlirclang::getPtrTyWithNewType(Ptr.val.getType(), Builder.getI8Type());
 
-  return Ptr.BitCast(builder, loc, DestType);
+  return Ptr.BitCast(Builder, Loc, DestType);
 }
 
 ValueCategory MLIRScanner::EmitPromotedValue(Location Loc, ValueCategory Result,
                                              QualType PromotionType) {
-  return Result.FPExt(builder, Loc, Glob.getTypes().getMLIRType(PromotionType));
+  return Result.FPExt(Builder, Loc, Glob.getTypes().getMLIRType(PromotionType));
 }
 
 ValueCategory MLIRScanner::EmitUnPromotedValue(Location Loc,
                                                ValueCategory Result,
                                                QualType PromotionType) {
-  return Result.FPTrunc(builder, Loc,
+  return Result.FPTrunc(Builder, Loc,
                         Glob.getTypes().getMLIRType(PromotionType));
 }
 
@@ -2233,10 +2214,10 @@ ValueCategory MLIRScanner::EmitScalarCast(mlir::Location Loc, ValueCategory Src,
     }
 
     if (DstTy.isIntOrIndex())
-      return Src.IntCast(builder, Loc, DstTy, InputSigned);
+      return Src.IntCast(Builder, Loc, DstTy, InputSigned);
     if (InputSigned)
-      return Src.SIToFP(builder, Loc, DstTy);
-    return Src.UIToFP(builder, Loc, DstTy);
+      return Src.SIToFP(Builder, Loc, DstTy);
+    return Src.UIToFP(Builder, Loc, DstTy);
   }
 
   if (DstTy.isIntOrIndex()) {
@@ -2249,13 +2230,13 @@ ValueCategory MLIRScanner::EmitScalarCast(mlir::Location Loc, ValueCategory Src,
     llvm::WithColor::warning() << "Performing strict float cast overflow\n";
 
     if (IsSigned)
-      return Src.FPToSI(builder, Loc, DstTy);
-    return Src.FPToUI(builder, Loc, DstTy);
+      return Src.FPToSI(Builder, Loc, DstTy);
+    return Src.FPToUI(Builder, Loc, DstTy);
   }
 
   if (DstTy.cast<FloatType>().getWidth() < SrcTy.cast<FloatType>().getWidth())
-    return Src.FPTrunc(builder, Loc, DstTy);
-  return Src.FPExt(builder, Loc, DstTy);
+    return Src.FPTrunc(Builder, Loc, DstTy);
+  return Src.FPExt(Builder, Loc, DstTy);
 }
 
 ValueCategory MLIRScanner::EmitScalarConversion(ValueCategory Src,
@@ -2310,9 +2291,9 @@ ValueCategory MLIRScanner::EmitScalarConversion(ValueCategory Src,
       if (CGM.getContext().getTargetInfo().useFP16ConversionIntrinsics())
         llvm::WithColor::warning() << "Should call convert_from_fp16 intrinsic "
                                       "to perfom this conversion\n";
-      Src = Src.FPExt(builder, MLIRLoc, builder.getF32Type());
+      Src = Src.FPExt(Builder, MLIRLoc, Builder.getF32Type());
       SrcType = CGM.getContext().FloatTy;
-      SrcTy = builder.getF32Type();
+      SrcTy = Builder.getF32Type();
     }
   }
 
@@ -2354,9 +2335,9 @@ ValueCategory MLIRScanner::EmitScalarConversion(ValueCategory Src,
         llvm::WithColor::warning() << "Should call convert_to_fp16 intrinsic "
                                       "to perfom this conversion\n";
       // If the half type is supported, just use an fptrunc.
-      return Src.FPTrunc(builder, MLIRLoc, DstTy);
+      return Src.FPTrunc(Builder, MLIRLoc, DstTy);
     }
-    DstTy = builder.getF32Type();
+    DstTy = Builder.getF32Type();
   }
 
   ValueCategory Res =
@@ -2368,7 +2349,7 @@ ValueCategory MLIRScanner::EmitScalarConversion(ValueCategory Src,
       llvm::WithColor::warning() << "Should call convert_to_fp16 intrinsic to "
                                     "perfom this conversion\n";
     }
-    Res = Res.FPTrunc(builder, MLIRLoc, ResTy);
+    Res = Res.FPTrunc(Builder, MLIRLoc, ResTy);
   }
 
   llvm::WithColor::warning() << "Missing truncation checks\n";
@@ -2380,12 +2361,12 @@ ValueCategory MLIRScanner::EmitScalarConversion(ValueCategory Src,
 ValueCategory MLIRScanner::EmitFloatToBoolConversion(Location Loc,
                                                      ValueCategory Src) {
   assert(Src.val.getType().isa<FloatType>() && "Expecting a float value");
-  mlir::OpBuilder SubBuilder(builder.getContext());
-  SubBuilder.setInsertionPointToStart(entryBlock);
+  mlir::OpBuilder SubBuilder(Builder.getContext());
+  SubBuilder.setInsertionPointToStart(EntryBlock);
   auto FloatTy = cast<FloatType>(Src.val.getType());
   auto Zero = SubBuilder.create<ConstantFloatOp>(
       Loc, mlir::APFloat::getZero(FloatTy.getFloatSemantics()), FloatTy);
-  return Src.FCmpUNE(builder, Loc, Zero);
+  return Src.FCmpUNE(Builder, Loc, Zero);
 }
 
 ValueCategory MLIRScanner::EmitPointerToBoolConversion(Location Loc,
@@ -2394,16 +2375,16 @@ ValueCategory MLIRScanner::EmitPointerToBoolConversion(Location Loc,
     auto ElementTy = MemRefTy.getElementType();
     auto AddressSpace = MemRefTy.getMemorySpaceAsInt();
     Src = {
-        builder.create<polygeist::Memref2PointerOp>(
+        Builder.create<polygeist::Memref2PointerOp>(
             Loc, LLVM::LLVMPointerType::get(ElementTy, AddressSpace), Src.val),
         Src.isReference};
   }
   assert(Src.val.getType().isa<LLVM::LLVMPointerType>() &&
          "Expecting a pointer");
-  mlir::OpBuilder SubBuilder(builder.getContext());
-  SubBuilder.setInsertionPointToStart(entryBlock);
+  mlir::OpBuilder SubBuilder(Builder.getContext());
+  SubBuilder.setInsertionPointToStart(EntryBlock);
   auto Zero = SubBuilder.create<LLVM::NullOp>(Loc, Src.val.getType());
-  return {builder.createOrFold<LLVM::ICmpOp>(Loc, LLVM::ICmpPredicate::ne,
+  return {Builder.createOrFold<LLVM::ICmpOp>(Loc, LLVM::ICmpPredicate::ne,
                                              Src.val, Zero),
           false};
 }
@@ -2411,11 +2392,11 @@ ValueCategory MLIRScanner::EmitPointerToBoolConversion(Location Loc,
 ValueCategory MLIRScanner::EmitIntToBoolConversion(Location Loc,
                                                    ValueCategory Src) {
   assert(Src.val.getType().isa<IntegerType>() && "Expecting an integer value");
-  mlir::OpBuilder SubBuilder(builder.getContext());
-  SubBuilder.setInsertionPointToStart(entryBlock);
+  mlir::OpBuilder SubBuilder(Builder.getContext());
+  SubBuilder.setInsertionPointToStart(EntryBlock);
   auto Zero = SubBuilder.create<ConstantIntOp>(
       Loc, 0, Src.val.getType().cast<IntegerType>().getWidth());
-  return Src.ICmpNE(builder, Loc, Zero);
+  return Src.ICmpNE(Builder, Loc, Zero);
 }
 
 ValueCategory MLIRScanner::EmitConversionToBool(Location Loc, ValueCategory Src,
@@ -2522,7 +2503,7 @@ std::pair<ValueCategory, ValueCategory> MLIRScanner::EmitCompoundAssignLValue(
     llvm::WithColor::warning()
         << "Not handling atomics. Should perform RMW operation here.\n";
 
-  ValueCategory LHS{LHSLV.getValue(builder), false};
+  ValueCategory LHS{LHSLV.getValue(Builder), false};
   if (!PromotionTypeLHS.isNull())
     LHS = EmitScalarConversion(LHS, LHSTy, PromotionTypeLHS, E->getExprLoc());
   else
@@ -2534,7 +2515,7 @@ std::pair<ValueCategory, ValueCategory> MLIRScanner::EmitCompoundAssignLValue(
   // potentially with Implicit Conversion sanitizer check.
   Result = EmitScalarConversion(Result, PromotionTypeCR, LHSTy, Loc);
 
-  LHSLV.store(builder, Result.val);
+  LHSLV.store(Builder, Result.val);
 
   if (Glob.getCGM().getLangOpts().OpenMP) {
     llvm::WithColor::warning() << "Should checkAndEmitLastprivateConditional, "
@@ -2594,47 +2575,42 @@ static void informNoOverflowCheck(LangOptions::SignedOverflowBehaviorTy SOB,
 }
 
 ValueCategory MLIRScanner::EmitBinMul(const BinOpInfo &Info) {
-  auto lhs_v = Info.getLHS().getValue(builder);
-  auto rhs_v = Info.getRHS().getValue(builder);
-  if (lhs_v.getType().isa<mlir::FloatType>()) {
-    return ValueCategory(builder.create<arith::MulFOp>(loc, lhs_v, rhs_v),
-                         /*isReference*/ false);
-  } else {
-    return ValueCategory(builder.create<arith::MulIOp>(loc, lhs_v, rhs_v),
+  auto LhsV = Info.getLHS().getValue(Builder);
+  auto RhsV = Info.getRHS().getValue(Builder);
+  if (LhsV.getType().isa<mlir::FloatType>()) {
+    return ValueCategory(Builder.create<arith::MulFOp>(Loc, LhsV, RhsV),
                          /*isReference*/ false);
   }
+  return ValueCategory(Builder.create<arith::MulIOp>(Loc, LhsV, RhsV),
+                       /*isReference*/ false);
 }
 
 ValueCategory MLIRScanner::EmitBinDiv(const BinOpInfo &Info) {
-  auto lhs_v = Info.getLHS().getValue(builder);
-  auto rhs_v = Info.getRHS().getValue(builder);
-  if (lhs_v.getType().isa<mlir::FloatType>()) {
-    return ValueCategory(builder.create<arith::DivFOp>(loc, lhs_v, rhs_v),
+  auto LhsV = Info.getLHS().getValue(Builder);
+  auto RhsV = Info.getRHS().getValue(Builder);
+  if (LhsV.getType().isa<mlir::FloatType>()) {
+    return ValueCategory(Builder.create<arith::DivFOp>(Loc, LhsV, RhsV),
                          /*isReference*/ false);
-  } else {
-    if (isSigned(Info.getType()))
-      return ValueCategory(builder.create<arith::DivSIOp>(loc, lhs_v, rhs_v),
-                           /*isReference*/ false);
-    else
-      return ValueCategory(builder.create<arith::DivUIOp>(loc, lhs_v, rhs_v),
-                           /*isReference*/ false);
   }
+  if (isSigned(Info.getType()))
+    return ValueCategory(Builder.create<arith::DivSIOp>(Loc, LhsV, RhsV),
+                         /*isReference*/ false);
+  return ValueCategory(Builder.create<arith::DivUIOp>(Loc, LhsV, RhsV),
+                       /*isReference*/ false);
 }
 
 ValueCategory MLIRScanner::EmitBinRem(const BinOpInfo &Info) {
-  auto lhs_v = Info.getLHS().getValue(builder);
-  auto rhs_v = Info.getRHS().getValue(builder);
-  if (lhs_v.getType().isa<mlir::FloatType>()) {
-    return ValueCategory(builder.create<arith::RemFOp>(loc, lhs_v, rhs_v),
+  auto LhsV = Info.getLHS().getValue(Builder);
+  auto RhsV = Info.getRHS().getValue(Builder);
+  if (LhsV.getType().isa<mlir::FloatType>()) {
+    return ValueCategory(Builder.create<arith::RemFOp>(Loc, LhsV, RhsV),
                          /*isReference*/ false);
-  } else {
-    if (isSigned(Info.getType()))
-      return ValueCategory(builder.create<arith::RemSIOp>(loc, lhs_v, rhs_v),
-                           /*isReference*/ false);
-    else
-      return ValueCategory(builder.create<arith::RemUIOp>(loc, lhs_v, rhs_v),
-                           /*isReference*/ false);
   }
+  if (isSigned(Info.getType()))
+    return ValueCategory(Builder.create<arith::RemSIOp>(Loc, LhsV, RhsV),
+                         /*isReference*/ false);
+  return ValueCategory(Builder.create<arith::RemUIOp>(Loc, LhsV, RhsV),
+                       /*isReference*/ false);
 }
 
 /// Casts index of subindex operation conditionally.
@@ -2663,10 +2639,10 @@ ValueCategory MLIRScanner::EmitCheckedInBoundsPtrOffsetOp(mlir::Type ElemTy,
          "Expecting indices list");
 
   if (Optional<Value> NewValue =
-          castSubIndexOpIndex(builder, loc, Pointer, IdxList, IsSigned))
+          castSubIndexOpIndex(Builder, Loc, Pointer, IdxList, IsSigned))
     IdxList = *NewValue;
 
-  return Pointer.InBoundsGEPOrSubIndex(builder, loc, ElemTy, IdxList);
+  return Pointer.InBoundsGEPOrSubIndex(Builder, Loc, ElemTy, IdxList);
 }
 
 ValueCategory MLIRScanner::EmitPointerArithmetic(const BinOpInfo &Info) {
@@ -2717,9 +2693,8 @@ ValueCategory MLIRScanner::EmitPointerArithmetic(const BinOpInfo &Info) {
   //   The pointer type is not byte-sized.
   //
   if (BinaryOperator::isNullPointerArithmeticExtension(
-          CGM.getContext(), Opcode, PointerOperand, IndexOperand)) {
-    return Index.IntToPtr(builder, loc, PtrTy);
-  }
+          CGM.getContext(), Opcode, PointerOperand, IndexOperand))
+    return Index.IntToPtr(Builder, Loc, PtrTy);
 
   auto &DL = CGM.getDataLayout();
   const unsigned IndexTypeSize = DL.getIndexTypeSizeInBits(
@@ -2730,13 +2705,13 @@ ValueCategory MLIRScanner::EmitPointerArithmetic(const BinOpInfo &Info) {
   if (Width != IndexTypeSize) {
     // Zero-extend or sign-extend the pointer value according to
     // whether the index is signed or not.
-    Index = Index.IntCast(builder, loc, builder.getIntegerType(IndexTypeSize),
+    Index = Index.IntCast(Builder, Loc, Builder.getIntegerType(IndexTypeSize),
                           IsSigned);
   }
 
   // If this is subtraction, negate the index.
   if (IsSubtraction)
-    Index = Index.Neg(builder, loc);
+    Index = Index.Neg(Builder, Loc);
 
   const auto *PointerType =
       PointerOperand->getType()->getAs<clang::PointerType>();
@@ -2753,16 +2728,16 @@ ValueCategory MLIRScanner::EmitPointerArithmetic(const BinOpInfo &Info) {
   if (ElementType->isVoidType() || ElementType->isFunctionType()) {
     assert(PtrTy.isa<LLVM::LLVMPointerType>() && "Expecting pointer type");
     auto Result = CastToVoidPtr(Pointer);
-    Result = Result.GEP(builder, loc, builder.getI8Type(), Index.val);
-    return Result.BitCast(builder, loc, Pointer.val.getType());
+    Result = Result.GEP(Builder, Loc, Builder.getI8Type(), Index.val);
+    return Result.BitCast(Builder, Loc, Pointer.val.getType());
   }
 
   auto ElemTy = Glob.getTypes().getMLIRType(ElementType);
   if (CGM.getLangOpts().isSignedOverflowDefined()) {
     if (Optional<Value> NewIndex =
-            castSubIndexOpIndex(builder, loc, Pointer, Index.val, IsSigned))
+            castSubIndexOpIndex(Builder, Loc, Pointer, Index.val, IsSigned))
       Index.val = *NewIndex;
-    return Pointer.GEPOrSubIndex(builder, loc, ElemTy, Index.val);
+    return Pointer.GEPOrSubIndex(Builder, Loc, ElemTy, Index.val);
   }
 
   return EmitCheckedInBoundsPtrOffsetOp(ElemTy, Pointer, Index.val, IsSigned,
@@ -2775,22 +2750,21 @@ ValueCategory MLIRScanner::EmitBinAdd(const BinOpInfo &Info) {
   const auto RHS = Info.getRHS().val;
 
   if (mlirclang::isPointerOrMemRefTy(LHS.val.getType()) ||
-      mlirclang::isPointerOrMemRefTy(RHS.getType())) {
-    loc = Loc;
+      mlirclang::isPointerOrMemRefTy(RHS.getType()))
     return EmitPointerArithmetic(Info);
-  }
 
   if (Info.getType()->isSignedIntegerOrEnumerationType()) {
     informNoOverflowCheck(
         Glob.getCGM().getLangOpts().getSignedOverflowBehavior(), "add");
-    return LHS.Add(builder, Loc, RHS);
+    return LHS.Add(Builder, Loc, RHS);
   }
 
   assert(!Info.getType()->isConstantMatrixType() && "Not yet implemented");
 
   if (mlirclang::isFPOrFPVectorTy(LHS.val.getType()))
-    return LHS.FAdd(builder, Loc, RHS);
-  return LHS.Add(builder, Loc, RHS);
+    return LHS.FAdd(Builder, Loc, RHS);
+
+  return LHS.Add(Builder, Loc, RHS);
 }
 
 ValueCategory MLIRScanner::EmitBinSub(const BinOpInfo &Info) {
@@ -2803,29 +2777,27 @@ ValueCategory MLIRScanner::EmitBinSub(const BinOpInfo &Info) {
     if (Info.getType()->isSignedIntegerOrEnumerationType()) {
       informNoOverflowCheck(
           Glob.getCGM().getLangOpts().getSignedOverflowBehavior(), "sub");
-      return LHS.Sub(builder, Loc, RHS.val);
+      return LHS.Sub(Builder, Loc, RHS.val);
     }
     assert(!Info.getType()->isConstantMatrixType() && "Not yet implemented");
     if (mlirclang::isFPOrFPVectorTy(LHS.val.getType()))
-      return LHS.FSub(builder, Loc, RHS.val);
-    return LHS.Sub(builder, Loc, RHS.val);
+      return LHS.FSub(Builder, Loc, RHS.val);
+    return LHS.Sub(Builder, Loc, RHS.val);
   }
 
   // If the RHS is not a pointer, then we have normal pointer
   // arithmetic.
-  if (!mlirclang::isPointerOrMemRefTy(RHS.val.getType())) {
-    loc = Loc;
+  if (!mlirclang::isPointerOrMemRefTy(RHS.val.getType()))
     return EmitPointerArithmetic(Info);
-  }
 
   // Otherwise, this is a pointer subtraction.
 
   // Do the raw subtraction part.
-  const auto PtrDiffTy = builder.getIntegerType(
+  const auto PtrDiffTy = Builder.getIntegerType(
       Glob.getCGM().getDataLayout().getPointerSizeInBits());
-  LHS = LHS.MemRef2Ptr(builder, Loc).PtrToInt(builder, Loc, PtrDiffTy);
-  RHS = RHS.MemRef2Ptr(builder, Loc).PtrToInt(builder, Loc, PtrDiffTy);
-  const auto DiffInChars = LHS.Sub(builder, Loc, RHS.val);
+  LHS = LHS.MemRef2Ptr(Builder, Loc).PtrToInt(Builder, Loc, PtrDiffTy);
+  RHS = RHS.MemRef2Ptr(Builder, Loc).PtrToInt(Builder, Loc, PtrDiffTy);
+  const auto DiffInChars = LHS.Sub(Builder, Loc, RHS.val);
 
   // Okay, figure out the element size.
   const QualType ElementType =
@@ -2842,62 +2814,61 @@ ValueCategory MLIRScanner::EmitBinSub(const BinOpInfo &Info) {
   if (ElementSize.isOne())
     return DiffInChars;
 
-  const auto Divisor = builder.createOrFold<arith::ConstantIntOp>(
+  const auto Divisor = Builder.createOrFold<arith::ConstantIntOp>(
       Loc, ElementSize.getQuantity(), PtrDiffTy);
 
-  return DiffInChars.ExactSDiv(builder, Loc, Divisor);
+  return DiffInChars.ExactSDiv(Builder, Loc, Divisor);
 }
 
 ValueCategory MLIRScanner::EmitBinShl(const BinOpInfo &Info) {
-  auto lhsv = Info.getLHS().getValue(builder);
-  auto rhsv = Info.getRHS().getValue(builder);
-  auto prevTy = rhsv.getType().cast<mlir::IntegerType>();
-  auto postTy = lhsv.getType().cast<mlir::IntegerType>();
-  if (prevTy.getWidth() < postTy.getWidth())
-    rhsv = builder.create<arith::ExtUIOp>(loc, postTy, rhsv);
-  if (prevTy.getWidth() > postTy.getWidth())
-    rhsv = builder.create<arith::TruncIOp>(loc, postTy, rhsv);
-  assert(lhsv.getType() == rhsv.getType());
-  return ValueCategory(builder.create<ShLIOp>(loc, lhsv, rhsv),
+  auto Lhsv = Info.getLHS().getValue(Builder);
+  auto Rhsv = Info.getRHS().getValue(Builder);
+  auto PrevTy = Rhsv.getType().cast<mlir::IntegerType>();
+  auto PostTy = Lhsv.getType().cast<mlir::IntegerType>();
+  if (PrevTy.getWidth() < PostTy.getWidth())
+    Rhsv = Builder.create<arith::ExtUIOp>(Loc, PostTy, Rhsv);
+  if (PrevTy.getWidth() > PostTy.getWidth())
+    Rhsv = Builder.create<arith::TruncIOp>(Loc, PostTy, Rhsv);
+  assert(Lhsv.getType() == Rhsv.getType());
+  return ValueCategory(Builder.create<ShLIOp>(Loc, Lhsv, Rhsv),
                        /*isReference*/ false);
 }
 
 ValueCategory MLIRScanner::EmitBinShr(const BinOpInfo &Info) {
-  auto lhsv = Info.getLHS().getValue(builder);
-  auto rhsv = Info.getRHS().getValue(builder);
-  auto prevTy = rhsv.getType().cast<mlir::IntegerType>();
-  auto postTy = lhsv.getType().cast<mlir::IntegerType>();
-  if (prevTy.getWidth() < postTy.getWidth())
-    rhsv = builder.create<mlir::arith::ExtUIOp>(loc, postTy, rhsv);
-  if (prevTy.getWidth() > postTy.getWidth())
-    rhsv = builder.create<mlir::arith::TruncIOp>(loc, postTy, rhsv);
-  assert(lhsv.getType() == rhsv.getType());
+  auto Lhsv = Info.getLHS().getValue(Builder);
+  auto Rhsv = Info.getRHS().getValue(Builder);
+  auto PrevTy = Rhsv.getType().cast<mlir::IntegerType>();
+  auto PostTy = Lhsv.getType().cast<mlir::IntegerType>();
+  if (PrevTy.getWidth() < PostTy.getWidth())
+    Rhsv = Builder.create<mlir::arith::ExtUIOp>(Loc, PostTy, Rhsv);
+  if (PrevTy.getWidth() > PostTy.getWidth())
+    Rhsv = Builder.create<mlir::arith::TruncIOp>(Loc, PostTy, Rhsv);
+  assert(Lhsv.getType() == Rhsv.getType());
   if (isSigned(Info.getExpr()->getType()))
-    return ValueCategory(builder.create<ShRSIOp>(loc, lhsv, rhsv),
+    return ValueCategory(Builder.create<ShRSIOp>(Loc, Lhsv, Rhsv),
                          /*isReference*/ false);
-  else
-    return ValueCategory(builder.create<ShRUIOp>(loc, lhsv, rhsv),
-                         /*isReference*/ false);
+  return ValueCategory(Builder.create<ShRUIOp>(Loc, Lhsv, Rhsv),
+                       /*isReference*/ false);
 }
 
 ValueCategory MLIRScanner::EmitBinAnd(const BinOpInfo &Info) {
-  return ValueCategory(builder.create<AndIOp>(loc,
-                                              Info.getLHS().getValue(builder),
-                                              Info.getRHS().getValue(builder)),
+  return ValueCategory(Builder.create<AndIOp>(Loc,
+                                              Info.getLHS().getValue(Builder),
+                                              Info.getRHS().getValue(Builder)),
                        /*isReference*/ false);
 }
 
 ValueCategory MLIRScanner::EmitBinXor(const BinOpInfo &Info) {
-  return ValueCategory(builder.create<XOrIOp>(loc,
-                                              Info.getLHS().getValue(builder),
-                                              Info.getRHS().getValue(builder)),
+  return ValueCategory(Builder.create<XOrIOp>(Loc,
+                                              Info.getLHS().getValue(Builder),
+                                              Info.getRHS().getValue(Builder)),
                        /*isReference*/ false);
 }
 
 ValueCategory MLIRScanner::EmitBinOr(const BinOpInfo &Info) {
   // TODO short circuit
-  return ValueCategory(builder.create<OrIOp>(loc,
-                                             Info.getLHS().getValue(builder),
-                                             Info.getRHS().getValue(builder)),
+  return ValueCategory(Builder.create<OrIOp>(Loc,
+                                             Info.getLHS().getValue(Builder),
+                                             Info.getRHS().getValue(Builder)),
                        /*isReference*/ false);
 }

--- a/polygeist/tools/cgeist/Lib/IfScope.cc
+++ b/polygeist/tools/cgeist/Lib/IfScope.cc
@@ -15,26 +15,26 @@
 using namespace mlir;
 
 IfScope::IfScope(MLIRScanner &Scanner) : Scanner(Scanner), PrevBlock(nullptr) {
-  if (Scanner.loops.size() && Scanner.loops.back().keepRunning) {
-    auto Lop = Scanner.builder.create<memref::LoadOp>(
-        Scanner.loc, Scanner.loops.back().keepRunning);
-    auto IfOp = Scanner.builder.create<scf::IfOp>(Scanner.loc, Lop,
+  if (Scanner.Loops.size() && Scanner.Loops.back().KeepRunning) {
+    auto Lop = Scanner.Builder.create<memref::LoadOp>(
+        Scanner.Loc, Scanner.Loops.back().KeepRunning);
+    auto IfOp = Scanner.Builder.create<scf::IfOp>(Scanner.Loc, Lop,
                                                   /*hasElse*/ false);
-    PrevBlock = Scanner.builder.getInsertionBlock();
-    PrevIterator = Scanner.builder.getInsertionPoint();
+    PrevBlock = Scanner.Builder.getInsertionBlock();
+    PrevIterator = Scanner.Builder.getInsertionPoint();
     IfOp.getThenRegion().back().clear();
-    Scanner.builder.setInsertionPointToStart(&IfOp.getThenRegion().back());
-    auto Er = Scanner.builder.create<scf::ExecuteRegionOp>(
-        Scanner.loc, ArrayRef<mlir::Type>());
-    Scanner.builder.create<scf::YieldOp>(Scanner.loc);
+    Scanner.Builder.setInsertionPointToStart(&IfOp.getThenRegion().back());
+    auto Er = Scanner.Builder.create<scf::ExecuteRegionOp>(
+        Scanner.Loc, ArrayRef<mlir::Type>());
+    Scanner.Builder.create<scf::YieldOp>(Scanner.Loc);
     Er.getRegion().push_back(new Block());
-    Scanner.builder.setInsertionPointToStart(&Er.getRegion().back());
+    Scanner.Builder.setInsertionPointToStart(&Er.getRegion().back());
   }
 }
 
 IfScope::~IfScope() {
-  if (Scanner.loops.size() && Scanner.loops.back().keepRunning) {
-    Scanner.builder.create<scf::YieldOp>(Scanner.loc);
-    Scanner.builder.setInsertionPoint(PrevBlock, PrevIterator);
+  if (Scanner.Loops.size() && Scanner.Loops.back().KeepRunning) {
+    Scanner.Builder.create<scf::YieldOp>(Scanner.Loc);
+    Scanner.Builder.setInsertionPoint(PrevBlock, PrevIterator);
   }
 }

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -134,7 +134,7 @@ private:
   clang::CodeGen::CodeGenModule CGM;
   mlirclang::CodeGen::CodeGenTypes CGTypes;
   bool Error;
-  ScopLocList ScopLocList;
+  ScopLocList ScopLocs;
   LowerToInfo LTInfo;
   std::map<const clang::FunctionDecl *, const clang::CodeGen::CGFunctionInfo *>
       CGFunctionInfos;
@@ -163,9 +163,9 @@ public:
         CGM(AstContext, &SM.getFileManager().getVirtualFileSystem(),
             PP.getHeaderSearchInfo().getHeaderSearchOpts(),
             PP.getPreprocessorOpts(), Codegenops, LLVMMod, PP.getDiagnostics()),
-        CGTypes(CGM, Module), Error(false), ScopLocList(), LTInfo() {
-    addPragmaScopHandlers(PP, ScopLocList);
-    addPragmaEndScopHandlers(PP, ScopLocList);
+        CGTypes(CGM, Module), Error(false), ScopLocs(), LTInfo() {
+    addPragmaScopHandlers(PP, ScopLocs);
+    addPragmaEndScopHandlers(PP, ScopLocs);
     addPragmaLowerToHandlers(PP, LTInfo);
   }
 
@@ -174,7 +174,7 @@ public:
   std::map<std::string, mlir::func::FuncOp> &getFunctions() {
     return Functions;
   }
-  ::ScopLocList &getScopLocList() { return ScopLocList; }
+  ::ScopLocList &getScopLocList() { return ScopLocs; }
 
   mlir::FunctionOpInterface getOrCreateMLIRFunction(FunctionToEmit &FTE,
                                                     const bool ShouldEmit,

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -56,8 +56,8 @@ class CodeGenTypes;
 } // namespace mlirclang
 
 struct LoopContext {
-  mlir::Value keepRunning;
-  mlir::Value noBreak;
+  mlir::Value KeepRunning;
+  mlir::Value NoBreak;
 };
 
 class BinOpInfo;
@@ -118,23 +118,23 @@ private:
 
 class MLIRASTConsumer : public clang::ASTConsumer {
 private:
-  std::set<std::string> &emitIfFound;
-  std::set<std::pair<FunctionContext, std::string>> &done;
-  std::map<std::string, mlir::LLVM::GlobalOp> &llvmStringGlobals;
-  std::map<std::string, std::pair<mlir::memref::GlobalOp, bool>> &globals;
-  std::map<std::string, mlir::func::FuncOp> &functions;
-  std::map<std::string, mlir::FunctionOpInterface> &deviceFunctions;
-  std::map<std::string, mlir::LLVM::GlobalOp> &llvmGlobals;
-  std::map<std::string, mlir::LLVM::LLVMFuncOp> &llvmFunctions;
-  std::deque<FunctionToEmit> functionsToEmit;
-  mlir::OwningOpRef<mlir::ModuleOp> &module;
+  std::set<std::string> &EmitIfFound;
+  std::set<std::pair<FunctionContext, std::string>> &Done;
+  std::map<std::string, mlir::LLVM::GlobalOp> &LLVMStringGlobals;
+  std::map<std::string, std::pair<mlir::memref::GlobalOp, bool>> &Globals;
+  std::map<std::string, mlir::func::FuncOp> &Functions;
+  std::map<std::string, mlir::FunctionOpInterface> &DeviceFunctions;
+  std::map<std::string, mlir::LLVM::GlobalOp> &LLVMGlobals;
+  std::map<std::string, mlir::LLVM::LLVMFuncOp> &LLVMFunctions;
+  std::deque<FunctionToEmit> FunctionsToEmit;
+  mlir::OwningOpRef<mlir::ModuleOp> &Module;
   clang::SourceManager &SM;
-  llvm::LLVMContext lcontext;
-  llvm::Module llvmMod;
+  llvm::LLVMContext Lcontext;
+  llvm::Module LLVMMod;
   clang::CodeGen::CodeGenModule CGM;
   mlirclang::CodeGen::CodeGenTypes CGTypes;
-  bool error;
-  ScopLocList scopLocList;
+  bool Error;
+  ScopLocList ScopLocList;
   LowerToInfo LTInfo;
   std::map<const clang::FunctionDecl *, const clang::CodeGen::CGFunctionInfo *>
       CGFunctionInfos;
@@ -145,50 +145,50 @@ public:
   MLIRASTConsumer(
       std::set<std::string> &EmitIfFound,
       std::set<std::pair<FunctionContext, std::string>> &Done,
-      std::map<std::string, mlir::LLVM::GlobalOp> &LlvmStringGlobals,
+      std::map<std::string, mlir::LLVM::GlobalOp> &LLVMStringGlobals,
       std::map<std::string, std::pair<mlir::memref::GlobalOp, bool>> &Globals,
       std::map<std::string, mlir::func::FuncOp> &Functions,
       std::map<std::string, mlir::FunctionOpInterface> &DeviceFunctions,
-      std::map<std::string, mlir::LLVM::GlobalOp> &LlvmGlobals,
-      std::map<std::string, mlir::LLVM::LLVMFuncOp> &LlvmFunctions,
+      std::map<std::string, mlir::LLVM::GlobalOp> &LLVMGlobals,
+      std::map<std::string, mlir::LLVM::LLVMFuncOp> &LLVMFunctions,
       clang::Preprocessor &PP, clang::ASTContext &AstContext,
       mlir::OwningOpRef<mlir::ModuleOp> &Module, clang::SourceManager &SM,
       clang::CodeGenOptions &Codegenops, std::string ModuleId)
-      : emitIfFound(EmitIfFound), done(Done),
-        llvmStringGlobals(LlvmStringGlobals), globals(Globals),
-        functions(Functions), deviceFunctions(DeviceFunctions),
-        llvmGlobals(LlvmGlobals), llvmFunctions(LlvmFunctions),
-        functionsToEmit(), module(Module), SM(SM), lcontext(),
-        llvmMod(ModuleId, lcontext),
+      : EmitIfFound(EmitIfFound), Done(Done),
+        LLVMStringGlobals(LLVMStringGlobals), Globals(Globals),
+        Functions(Functions), DeviceFunctions(DeviceFunctions),
+        LLVMGlobals(LLVMGlobals), LLVMFunctions(LLVMFunctions),
+        FunctionsToEmit(), Module(Module), SM(SM), Lcontext(),
+        LLVMMod(ModuleId, Lcontext),
         CGM(AstContext, &SM.getFileManager().getVirtualFileSystem(),
             PP.getHeaderSearchInfo().getHeaderSearchOpts(),
-            PP.getPreprocessorOpts(), Codegenops, llvmMod, PP.getDiagnostics()),
-        CGTypes(CGM, Module), error(false), scopLocList(), LTInfo() {
-    addPragmaScopHandlers(PP, scopLocList);
-    addPragmaEndScopHandlers(PP, scopLocList);
+            PP.getPreprocessorOpts(), Codegenops, LLVMMod, PP.getDiagnostics()),
+        CGTypes(CGM, Module), Error(false), ScopLocList(), LTInfo() {
+    addPragmaScopHandlers(PP, ScopLocList);
+    addPragmaEndScopHandlers(PP, ScopLocList);
     addPragmaLowerToHandlers(PP, LTInfo);
   }
 
   clang::CodeGen::CodeGenModule &getCGM() { return CGM; }
   mlirclang::CodeGen::CodeGenTypes &getTypes() { return CGTypes; }
   std::map<std::string, mlir::func::FuncOp> &getFunctions() {
-    return functions;
+    return Functions;
   }
-  ScopLocList &getScopLocList() { return scopLocList; }
+  ::ScopLocList &getScopLocList() { return ScopLocList; }
 
-  mlir::FunctionOpInterface GetOrCreateMLIRFunction(FunctionToEmit &FTE,
+  mlir::FunctionOpInterface getOrCreateMLIRFunction(FunctionToEmit &FTE,
                                                     const bool ShouldEmit,
                                                     bool GetDeviceStub = false);
-  mlir::LLVM::LLVMFuncOp GetOrCreateLLVMFunction(const clang::FunctionDecl *FD);
-  mlir::LLVM::LLVMFuncOp GetOrCreateMallocFunction();
-  mlir::LLVM::LLVMFuncOp GetOrCreateFreeFunction();
+  mlir::LLVM::LLVMFuncOp getOrCreateLLVMFunction(const clang::FunctionDecl *FD);
+  mlir::LLVM::LLVMFuncOp getOrCreateMallocFunction();
+  mlir::LLVM::LLVMFuncOp getOrCreateFreeFunction();
 
-  mlir::LLVM::GlobalOp GetOrCreateLLVMGlobal(const clang::ValueDecl *VD,
+  mlir::LLVM::GlobalOp getOrCreateLLVMGlobal(const clang::ValueDecl *VD,
                                              std::string Prefix = "");
 
   /// Return a value representing an access into a global string with the
   /// given name, creating the string if necessary.
-  mlir::Value GetOrCreateGlobalLLVMString(mlir::Location Loc,
+  mlir::Value getOrCreateGlobalLLVMString(mlir::Location Loc,
                                           mlir::OpBuilder &Builder,
                                           clang::StringRef Value);
 
@@ -198,7 +198,7 @@ public:
                     FunctionContext FuncContext);
 
   const clang::CodeGen::CGFunctionInfo &
-  GetOrCreateCGFunctionInfo(const clang::FunctionDecl *FD);
+  getOrCreateCGFunctionInfo(const clang::FunctionDecl *FD);
 
   void run();
 
@@ -252,45 +252,45 @@ class MLIRScanner : public clang::StmtVisitor<MLIRScanner, ValueCategory> {
 
 private:
   MLIRASTConsumer &Glob;
-  mlir::FunctionOpInterface function;
-  mlir::OwningOpRef<mlir::ModuleOp> &module;
-  mlir::OpBuilder builder;
-  mlir::Location loc;
-  mlir::Block *entryBlock;
-  std::vector<LoopContext> loops;
-  mlir::Block *allocationScope;
-  llvm::SmallSet<std::string, 4> unsupportedFuncs;
-  std::map<const void *, std::vector<mlir::LLVM::AllocaOp>> bufs;
-  std::map<int, mlir::Value> constants;
-  std::map<clang::LabelStmt *, mlir::Block *> labels;
+  mlir::FunctionOpInterface Function;
+  mlir::OwningOpRef<mlir::ModuleOp> &Module;
+  mlir::OpBuilder Builder;
+  mlir::Location Loc;
+  mlir::Block *EntryBlock;
+  std::vector<LoopContext> Loops;
+  mlir::Block *AllocationScope;
+  llvm::SmallSet<std::string, 4> UnsupportedFuncs;
+  std::map<const void *, std::vector<mlir::LLVM::AllocaOp>> Bufs;
+  std::map<int, mlir::Value> Constants;
+  std::map<clang::LabelStmt *, mlir::Block *> Labels;
   const clang::FunctionDecl *EmittingFunctionDecl;
-  std::map<const clang::ValueDecl *, ValueCategory> params;
+  std::map<const clang::ValueDecl *, ValueCategory> Params;
   llvm::DenseMap<const clang::ValueDecl *, clang::FieldDecl *> Captures;
   llvm::DenseMap<const clang::ValueDecl *, clang::LambdaCaptureKind>
       CaptureKinds;
   clang::FieldDecl *ThisCapture;
-  std::vector<mlir::Value> arrayinit;
+  std::vector<mlir::Value> ArrayInit;
   ValueCategory ThisVal;
-  mlir::Value returnVal;
+  mlir::Value ReturnVal;
   LowerToInfo &LTInfo;
 
   // Initialize a exclude list of SYCL functions to emit instead just the
   // declaration. Eventually, this list should be removed.
   void initUnsupportedFunctions();
   bool isUnsupportedFunction(std::string Name) const {
-    return unsupportedFuncs.contains(Name);
+    return UnsupportedFuncs.contains(Name);
   }
 
-  mlir::LLVM::AllocaOp allocateBuffer(size_t i, mlir::LLVM::LLVMPointerType t) {
-    auto &Vec = bufs[t.getAsOpaquePointer()];
-    if (i < Vec.size())
-      return Vec[i];
+  mlir::LLVM::AllocaOp allocateBuffer(size_t I, mlir::LLVM::LLVMPointerType T) {
+    auto &Vec = Bufs[T.getAsOpaquePointer()];
+    if (I < Vec.size())
+      return Vec[I];
 
-    mlir::OpBuilder Subbuilder(builder.getContext());
-    Subbuilder.setInsertionPointToStart(allocationScope);
+    mlir::OpBuilder Subbuilder(Builder.getContext());
+    Subbuilder.setInsertionPointToStart(AllocationScope);
 
-    auto One = Subbuilder.create<mlir::arith::ConstantIntOp>(loc, 1, 64);
-    auto Rs = Subbuilder.create<mlir::LLVM::AllocaOp>(loc, t, One, 0);
+    auto One = Subbuilder.create<mlir::arith::ConstantIntOp>(Loc, 1, 64);
+    auto Rs = Subbuilder.create<mlir::LLVM::AllocaOp>(Loc, T, One, 0);
     Vec.push_back(Rs);
     return Rs;
   }
@@ -379,13 +379,13 @@ public:
   void init(mlir::FunctionOpInterface Function, const FunctionToEmit &FTE);
 
   void setEntryAndAllocBlock(mlir::Block *B) {
-    allocationScope = entryBlock = B;
-    builder.setInsertionPointToStart(B);
+    AllocationScope = EntryBlock = B;
+    Builder.setInsertionPointToStart(B);
   }
 
-  mlir::OpBuilder &getBuilder() { return builder; };
-  std::vector<LoopContext> &getLoops() { return loops; }
-  mlir::Location getLoc() const { return loc; }
+  mlir::OpBuilder &getBuilder() { return Builder; };
+  std::vector<LoopContext> &getLoops() { return Loops; }
+  mlir::Location getLoc() const { return Loc; }
 
   mlir::Value getConstantIndex(int X);
 

--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -109,8 +109,8 @@ static llvm::cl::opt<bool>
     InnerSerialize("inner-serialize", llvm::cl::init(false),
                    llvm::cl::desc("Turn on parallel licm"));
 
-llvm::cl::opt<bool> ShowAST("show-ast", llvm::cl::init(false),
-                            llvm::cl::desc("Show AST"));
+static llvm::cl::opt<bool> ShowAST("show-ast", llvm::cl::init(false),
+                                   llvm::cl::desc("Show AST"));
 
 static llvm::cl::opt<bool> RaiseToAffine("raise-scf-to-affine",
                                          llvm::cl::init(false),

--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -109,8 +109,8 @@ static llvm::cl::opt<bool>
     InnerSerialize("inner-serialize", llvm::cl::init(false),
                    llvm::cl::desc("Turn on parallel licm"));
 
-static llvm::cl::opt<bool> ShowAST("show-ast", llvm::cl::init(false),
-                                   llvm::cl::desc("Show AST"));
+llvm::cl::opt<bool> ShowAST("show-ast", llvm::cl::init(false),
+                            llvm::cl::desc("Show AST"));
 
 static llvm::cl::opt<bool> RaiseToAffine("raise-scf-to-affine",
                                          llvm::cl::init(false),

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -1070,15 +1070,15 @@ int main(int argc, char **argv) {
       Args.push_back(argv[i]);
 
     ArrayRef<const char *> Argv = makeArrayRef(Args);
-    const OptTable &OptTbl = getDriverOptTable();
-    const unsigned IncludedFlagsBitmask = options::CC1AsOption;
+    const llvm::opt::OptTable &OptTbl = clang::driver::getDriverOptTable();
+    const unsigned IncludedFlagsBitmask = clang::driver::options::CC1AsOption;
     unsigned MissingArgIndex, MissingArgCount;
-    InputArgList InputArgs = OptTbl.ParseArgs(
+    opt::InputArgList InputArgs = OptTbl.ParseArgs(
         Argv, MissingArgIndex, MissingArgCount, IncludedFlagsBitmask);
 
     SmallVector<const char *> NewArgv = {Argv[0]};
     for (const opt::Arg *InputArg :
-         InputArgs.filtered(driver::options::OPT_mllvm))
+         InputArgs.filtered(clang::driver::options::OPT_mllvm))
       NewArgv.push_back(InputArg->getValue());
     llvm::cl::ParseCommandLineOptions(NewArgv.size(), &NewArgv[0]);
   }

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -64,8 +64,6 @@
 
 #define DEBUG_TYPE "cgeist"
 
-using namespace llvm;
-
 class MemRefInsider
     : public mlir::MemRefElementTypeInterface::FallbackModel<MemRefInsider> {};
 
@@ -74,18 +72,18 @@ struct PtrElementModel
     : public mlir::LLVM::PointerElementTypeInterface::ExternalModel<
           PtrElementModel<T>, T> {};
 
-extern int cc1_main(ArrayRef<const char *> Argv, const char *Argv0,
+extern int cc1_main(llvm::ArrayRef<const char *> Argv, const char *Argv0,
                     void *MainAddr);
-extern int cc1as_main(ArrayRef<const char *> Argv, const char *Argv0,
+extern int cc1as_main(llvm::ArrayRef<const char *> Argv, const char *Argv0,
                       void *MainAddr);
-extern int cc1gen_reproducer_main(ArrayRef<const char *> Argv,
+extern int cc1gen_reproducer_main(llvm::ArrayRef<const char *> Argv,
                                   const char *Argv0, void *MainAddr);
 
 static llvm::ExitOnError ExitOnErr;
 
 std::string GetExecutablePath(const char *Argv0, bool CanonicalPrefixes) {
   if (!CanonicalPrefixes) {
-    SmallString<128> ExecutablePath(Argv0);
+    llvm::SmallString<128> ExecutablePath(Argv0);
     // Do a PATH lookup if Argv0 isn't a valid path.
     if (!llvm::sys::fs::exists(ExecutablePath))
       if (llvm::ErrorOr<std::string> P =
@@ -100,7 +98,7 @@ std::string GetExecutablePath(const char *Argv0, bool CanonicalPrefixes) {
   return llvm::sys::fs::getMainExecutable(Argv0, P);
 }
 
-static int ExecuteCC1Tool(SmallVectorImpl<const char *> &ArgV) {
+static int ExecuteCC1Tool(llvm::SmallVectorImpl<const char *> &ArgV) {
   // If we call the cc1 tool from the clangDriver library (through
   // Driver::CC1Main), we need to clean up the options usage count. The options
   // are currently global, and they might have been used previously by the
@@ -110,7 +108,7 @@ static int ExecuteCC1Tool(SmallVectorImpl<const char *> &ArgV) {
   llvm::BumpPtrAllocator A;
   llvm::StringSaver Saver(A);
   llvm::cl::ExpandResponseFiles(Saver, &llvm::cl::TokenizeGNUCommandLine, ArgV);
-  StringRef Tool = ArgV[1];
+  llvm::StringRef Tool = ArgV[1];
   void *GetExecutablePathVP = (void *)(intptr_t)GetExecutablePath;
   if (Tool == "-cc1")
     return cc1_main(makeArrayRef(ArgV).slice(1), ArgV[0], GetExecutablePathVP);
@@ -127,7 +125,7 @@ static int ExecuteCC1Tool(SmallVectorImpl<const char *> &ArgV) {
 }
 
 static int emitBinary(const char *Argv0, const char *Filename,
-                      const SmallVectorImpl<const char *> &LinkArgs,
+                      const llvm::SmallVectorImpl<const char *> &LinkArgs,
                       bool LinkOMP) {
   using namespace clang;
 
@@ -341,7 +339,7 @@ static int optimize(mlir::MLIRContext &context,
   if (DetectReduction)
     optPM.addPass(polygeist::detectReductionPass());
 
-  if (OptimizationLevel != OptimizationLevel::O0) {
+  if (OptimizationLevel != llvm::OptimizationLevel::O0) {
     optPM.addPass(mlir::createCanonicalizerPass(canonicalizerConfig, {}, {}));
     optPM.addPass(mlir::createCSEPass());
     // Affine must be lowered to enable inlining
@@ -703,7 +701,7 @@ runOptimizationPipeline(llvm::Module &Module,
                                     PrintPassOpts);
   SI.registerCallbacks(PIC, &FAM);
 
-  TargetMachine *TM = nullptr;
+  llvm::TargetMachine *TM = nullptr;
   llvm::Optional<llvm::PGOOptions> P = llvm::None;
   llvm::PipelineTuningOptions PTO;
 
@@ -722,14 +720,14 @@ runOptimizationPipeline(llvm::Module &Module,
           : PB.buildPerModuleDefaultPipeline(OptimizationLevel);
 
   // Before executing passes, print the final values of the LLVM options.
-  cl::PrintOptionValues();
+  llvm::cl::PrintOptionValues();
 
   // Print a textual representation of the LLVM pipeline.
   LLVM_DEBUG({
     llvm::dbgs() << "*** Run LLVM Optimization pipeline: ***\n";
 
     std::string Pipeline;
-    raw_string_ostream OS(Pipeline);
+    llvm::raw_string_ostream OS(Pipeline);
 
     MPM.printPipeline(OS, [&PIC](StringRef ClassName) {
       auto PassName = PIC.getPassNameForClassName(ClassName);
@@ -740,7 +738,7 @@ runOptimizationPipeline(llvm::Module &Module,
 
   // Now that we have all of the passes ready, run them.
   {
-    PrettyStackTraceString CrashInfo("Optimizer");
+    llvm::PrettyStackTraceString CrashInfo("Optimizer");
     llvm::TimeTraceScope TimeScope("Optimizer");
     MPM.run(Module, MAM);
   }
@@ -751,7 +749,7 @@ static int compileModule(mlir::OwningOpRef<mlir::ModuleOp> &module,
                          StringRef moduleId, mlir::MLIRContext &context,
                          llvm::DataLayout &DL, llvm::Triple &triple,
                          const llvm::OptimizationLevel &OptimizationLevel,
-                         const SmallVectorImpl<const char *> &LinkArgs,
+                         const llvm::SmallVectorImpl<const char *> &LinkArgs,
                          const char *Argv0) {
   bool LinkOMP = FOpenMP;
   int rc = createAndExecutePassPipeline(context, module, DL, triple,
@@ -767,14 +765,15 @@ static int compileModule(mlir::OwningOpRef<mlir::ModuleOp> &module,
   if (emitMLIR) {
     if (Output == "-") {
       // Write the MLIR to stdout.
-      LLVM_DEBUG(dbgs() << "*** MLIR Produced ***\n");
-      module->print(outs());
+      LLVM_DEBUG(llvm::dbgs() << "*** MLIR Produced ***\n");
+      module->print(llvm::outs());
     } else {
       // Write the MLIR to a file.
       std::error_code EC;
       llvm::raw_fd_ostream out(Output, EC);
       module->print(out);
-      LLVM_DEBUG(dbgs() << "*** Dumped MLIR in file '" << Output << "' ***\n");
+      LLVM_DEBUG(llvm::dbgs()
+                 << "*** Dumped MLIR in file '" << Output << "' ***\n");
     }
   } else {
     // Generate LLVM IR.
@@ -789,7 +788,8 @@ static int compileModule(mlir::OwningOpRef<mlir::ModuleOp> &module,
 
     llvmModule->setDataLayout(DL);
     llvmModule->setTargetTriple(triple.getTriple());
-    LLVM_DEBUG(dbgs() << "*** Translated MLIR to LLVM IR successfully ***\n");
+    LLVM_DEBUG(llvm::dbgs()
+               << "*** Translated MLIR to LLVM IR successfully ***\n");
 
     if (emitBC || EmitLLVM) {
       // Not needed when emitting binary for now; will be handled by the driver.
@@ -802,20 +802,20 @@ static int compileModule(mlir::OwningOpRef<mlir::ModuleOp> &module,
       std::error_code EC;
       llvm::raw_fd_ostream out(Output, EC);
       WriteBitcodeToFile(*llvmModule, out);
-      LLVM_DEBUG(dbgs() << "*** Dumped LLVM BC in file '" << Output
-                        << "' ***\n");
+      LLVM_DEBUG(llvm::dbgs()
+                 << "*** Dumped LLVM BC in file '" << Output << "' ***\n");
     } else if (EmitLLVM) {
       if (Output == "-") {
         // Write the LLVM IR to stdout.
-        LLVM_DEBUG(dbgs() << "*** LLVM IR Produced ***\n");
+        LLVM_DEBUG(llvm::dbgs() << "*** LLVM IR Produced ***\n");
         llvm::outs() << *llvmModule << "\n";
       } else {
         // Write the LLVM IR to a file.
         std::error_code EC;
         llvm::raw_fd_ostream out(Output, EC);
         out << *llvmModule << "\n";
-        LLVM_DEBUG(dbgs() << "*** Dumped LLVM IR in file '" << Output
-                          << "' ***\n");
+        LLVM_DEBUG(llvm::dbgs()
+                   << "*** Dumped LLVM IR in file '" << Output << "' ***\n");
       }
     } else {
       // Compile the LLVM IR.
@@ -991,12 +991,12 @@ static void loadMLIR(const std::string &inputFile,
 }
 
 // Generate MLIR for the input files.
-static void processInputFiles(const cl::list<std::string> &inputFiles,
-                              const cl::list<std::string> &inputCommandArgs,
-                              mlir::MLIRContext &context,
-                              mlir::OwningOpRef<ModuleOp> &module,
-                              llvm::DataLayout &DL, llvm::Triple &triple,
-                              const char *Argv0, bool syclIsDevice) {
+static void
+processInputFiles(const llvm::cl::list<std::string> &inputFiles,
+                  const llvm::cl::list<std::string> &inputCommandArgs,
+                  mlir::MLIRContext &context,
+                  mlir::OwningOpRef<ModuleOp> &module, llvm::DataLayout &DL,
+                  llvm::Triple &triple, const char *Argv0, bool syclIsDevice) {
   assert(!inputFiles.empty() && "inputFiles should not be empty");
 
   // Ensure all input files can be opened.
@@ -1069,15 +1069,15 @@ int main(int argc, char **argv) {
     for (int i = 0; i < argc; i++)
       Args.push_back(argv[i]);
 
-    ArrayRef<const char *> Argv = makeArrayRef(Args);
+    llvm::ArrayRef<const char *> Argv = makeArrayRef(Args);
     const llvm::opt::OptTable &OptTbl = clang::driver::getDriverOptTable();
     const unsigned IncludedFlagsBitmask = clang::driver::options::CC1AsOption;
     unsigned MissingArgIndex, MissingArgCount;
-    opt::InputArgList InputArgs = OptTbl.ParseArgs(
+    llvm::opt::InputArgList InputArgs = OptTbl.ParseArgs(
         Argv, MissingArgIndex, MissingArgCount, IncludedFlagsBitmask);
 
     SmallVector<const char *> NewArgv = {Argv[0]};
-    for (const opt::Arg *InputArg :
+    for (const llvm::opt::Arg *InputArg :
          InputArgs.filtered(clang::driver::options::OPT_mllvm))
       NewArgv.push_back(InputArg->getValue());
     llvm::cl::ParseCommandLineOptions(NewArgv.size(), &NewArgv[0]);
@@ -1107,7 +1107,7 @@ int main(int argc, char **argv) {
   // Register command line options specific to cgeist.
   int Size = MLIRArgs.size();
   const char **Data = MLIRArgs.data();
-  InitLLVM Y(Size, Data);
+  llvm::InitLLVM Y(Size, Data);
   llvm::cl::ParseCommandLineOptions(Size, Data);
 
   // Register MLIR dialects.


### PR DESCRIPTION
This PR fixes some clang-tidy warnings:
- change variable names to start with upper case
- remove use of else after if branch with a return

Signed-off-by: Tiotto, Ettore <ettore.tiotto@intel.com>