### PR TITLE
[SYCL] Fix mock plugin creation for different backends

### DIFF
--- a/sycl/unittests/helpers/PiMock.hpp
+++ b/sycl/unittests/helpers/PiMock.hpp
@@ -204,7 +204,7 @@ public:
       // Copy the PiPlugin, thus untying our to-be mock platform from other
       // platforms within the context. Reset our platform to use the new plugin.
       NewPluginPtr = std::make_shared<detail::plugin>(
-          OriginalPiPlugin.getPiPluginPtr(), OriginalPiPlugin.getBackend(),
+          OriginalPiPlugin.getPiPluginPtr(), Backend,
           OriginalPiPlugin.getLibraryHandle());
       // Save a copy of the platform resource
       OrigFuncTable = OriginalPiPlugin.getPiPlugin().PiFunctionTable;


### PR DESCRIPTION
This PR is supposed to fix DescendentDevice unit test failure in post-commit.