### PR TITLE
[SYCL-MLIR] Handle vector splat casts

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1951,6 +1951,11 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
     }
     return ValueCategory(res, /*isReference*/ false);
   }
+  case clang::CastKind::CK_VectorSplat: {
+    const auto DstTy = Glob.getTypes().getMLIRType(E->getType());
+    const auto Elt = Visit(E->getSubExpr());
+    return Elt.Splat(builder, loc, DstTy);
+  }
   case clang::CastKind::CK_IntegralToPointer: {
     auto vc = Visit(E->getSubExpr());
 #ifdef DEBUG

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -10,6 +10,7 @@
 
 #include "ValueCategory.h"
 #include "Lib/TypeUtils.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "polygeist/Ops.h"
 #include "utils.h"
 
@@ -469,6 +470,14 @@ ValueCategory ValueCategory::MemRef2Ptr(OpBuilder &Builder,
       LLVM::LLVMPointerType::get(Ty.getElementType(), Ty.getMemorySpaceAsInt());
   return {Builder.createOrFold<polygeist::Memref2PointerOp>(Loc, DestTy, val),
           isReference};
+}
+
+ValueCategory ValueCategory::Splat(OpBuilder &Builder, Location Loc,
+                                   mlir::Type VecTy) const {
+  assert(VecTy.isa<mlir::VectorType>() && "Expecting vector type for cast");
+  assert(VecTy.cast<mlir::VectorType>().getElementType() == val.getType() &&
+         "Cannot splat to a vector of different element type");
+  return {Builder.createOrFold<vector::SplatOp>(Loc, val, VecTy), false};
 }
 
 ValueCategory ValueCategory::ICmpNE(mlir::OpBuilder &builder, Location Loc,

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -90,6 +90,9 @@ public:
                         mlir::Type DestTy) const;
   ValueCategory MemRef2Ptr(mlir::OpBuilder &Builder, mlir::Location Loc) const;
 
+  ValueCategory Splat(mlir::OpBuilder &Builder, mlir::Location Loc,
+                      mlir::Type VecTy) const;
+
   ValueCategory ICmpNE(mlir::OpBuilder &builder, mlir::Location Loc,
                        mlir::Value RHS) const;
   ValueCategory FCmpUNE(mlir::OpBuilder &builder, mlir::Location Loc,

--- a/polygeist/tools/cgeist/Test/Verification/vecsplat.c
+++ b/polygeist/tools/cgeist/Test/Verification/vecsplat.c
@@ -1,0 +1,39 @@
+// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist %s --function=* -S -emit-llvm | FileCheck %s --check-prefix=CHECK-LLVM
+
+typedef int int_t_vec __attribute__((ext_vector_type(3)));
+typedef float float_t_vec __attribute__((ext_vector_type(4)));
+
+// CHECK-LABEL:   func.func @splat_int(
+// CHECK-SAME:                         %[[VAL_0:.*]]: i32) -> vector<3xi32>
+// CHECK-NEXT:      %[[VAL_1:.*]] = vector.splat %[[VAL_0]] : vector<3xi32>
+// CHECK-NEXT:      return %[[VAL_1]] : vector<3xi32>
+// CHECK-NEXT:    }
+
+// CHECK-LLVM-LABEL:    define <3 x i32> @splat_int(
+// CHECK-LLVM-SAME:                                 i32 %[[VAL_0:.*]]) {
+// CHECK-LLVM-NEXT:       %[[VAL_1:.*]] = insertelement <3 x i32> undef, i32 %[[VAL_0]], i32 0
+// CHECK-LLVM-NEXT:       %[[VAL_2:.*]] = shufflevector <3 x i32> %[[VAL_1]], <3 x i32> undef, <3 x i32> zeroinitializer
+// CHECK-LLVM-NEXT:       ret <3 x i32> %[[VAL_2]]
+// CHECK-LLVM-NEXT:     }
+
+int_t_vec splat_int(int el) {
+  return el;
+}
+
+// CHECK-LABEL:   func.func @splat_float(
+// CHECK-SAME:                           %[[VAL_0:.*]]: f32) -> vector<4xf32>
+// CHECK-NEXT:           %[[VAL_1:.*]] = vector.splat %[[VAL_0]] : vector<4xf32>
+// CHECK-NEXT:           return %[[VAL_1]] : vector<4xf32>
+// CHECK-NEXT:         }
+
+// CHECK-LLVM-LABEL:    define <4 x float> @splat_float(
+// CHECK-LLVM-SAME:                                     float %[[VAL_0:.*]]) {
+// CHECK-LLVM-NEXT:       %[[VAL_1:.*]] = insertelement <4 x float> undef, float %[[VAL_0]], i32 0
+// CHECK-LLVM-NEXT:       %[[VAL_2:.*]] = shufflevector <4 x float> %[[VAL_1]], <4 x float> undef, <4 x i32> zeroinitializer
+// CHECK-LLVM-NEXT:       ret <4 x float> %[[VAL_2]]
+// CHECK-LLVM-NEXT:     }
+
+float_t_vec splat_float(float el) {
+  return el;
+}


### PR DESCRIPTION
Use vector.splat to handle vector splat casts.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>