### PR TITLE
[SYCL][Docs] Bump CI Sphinx version to 4.2.0

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install deps
       run: |
         sudo apt-get install -y doxygen graphviz ssh ninja-build
-        sudo pip3 install 'sphinx==4.1.2' 'myst-parser==0.15.1' 'recommonmark==0.7.1'
+        sudo pip3 install 'sphinx==4.2.0' 'myst-parser==0.15.1' 'recommonmark==0.7.1'
     - name: Build Docs
       run: |
         mkdir -p $GITHUB_WORKSPACE/build


### PR DESCRIPTION
Docs CI is currently failing due to an interaction between Python 3.10 and Sphinx 4.1.2. This commit bumps the Sphinx version used by docs CI to 4.2.0.