### PR TITLE
[SYCL-MLIR] Fix build due to bad rebase

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1934,7 +1934,7 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
   case clang::CastKind::CK_VectorSplat: {
     const auto DstTy = Glob.getTypes().getMLIRType(E->getType());
     const auto Elt = Visit(E->getSubExpr());
-    return Elt.Splat(builder, loc, DstTy);
+    return Elt.Splat(Builder, Loc, DstTy);
   }
   case clang::CastKind::CK_IntegralToPointer: {
     auto Vc = Visit(E->getSubExpr());


### PR DESCRIPTION
00fb523053de was not rebased properly and a renamed variable broke build.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>