### PR TITLE
[SYCL][Fusion] Scheduler support for kernel fusion

### DIFF
--- a/sycl/source/detail/fusion/fusion_wrapper_impl.cpp
+++ b/sycl/source/detail/fusion/fusion_wrapper_impl.cpp
@@ -8,6 +8,8 @@
 
 #include <detail/fusion/fusion_wrapper_impl.hpp>
 
+#include <detail/scheduler/scheduler.hpp>
+
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace detail {
@@ -20,22 +22,22 @@ std::shared_ptr<detail::queue_impl> fusion_wrapper_impl::get_queue() const {
   return MQueue;
 }
 
-bool fusion_wrapper_impl::is_in_fusion_mode() const { return false; }
+bool fusion_wrapper_impl::is_in_fusion_mode() const {
+  return MQueue->is_in_fusion_mode();
+}
 
 void fusion_wrapper_impl::start_fusion() {
-  throw sycl::exception(sycl::errc::feature_not_supported,
-                        "Fusion not yet implemented");
+  detail::Scheduler::getInstance().startFusion(MQueue);
 }
 
 void fusion_wrapper_impl::cancel_fusion() {
-  throw sycl::exception(sycl::errc::feature_not_supported,
-                        "Fusion not yet implemented");
+  detail::Scheduler::getInstance().cancelFusion(MQueue);
 }
 
 event fusion_wrapper_impl::complete_fusion(const property_list &PropList) {
-  (void)PropList;
-  throw sycl::exception(sycl::errc::feature_not_supported,
-                        "Fusion not yet implemented");
+  auto EventImpl =
+      detail::Scheduler::getInstance().completeFusion(MQueue, PropList);
+  return detail::createSyclObjFromImpl<event>(EventImpl);
 }
 
 } // namespace detail

--- a/sycl/source/detail/helpers.cpp
+++ b/sycl/source/detail/helpers.cpp
@@ -32,7 +32,7 @@ std::vector<RT::PiEvent> getOrWaitEvents(std::vector<sycl::event> DepEvents,
       continue;
     }
     // The fusion command and its event are associated with a non-host context,
-    // but still does not produce a PI event,.
+    // but still does not produce a PI event.
     bool NoPiEvent =
         SyclEventImplPtr->MCommand &&
         !static_cast<Command *>(SyclEventImplPtr->MCommand)->producesPiEvent();

--- a/sycl/source/detail/helpers.cpp
+++ b/sycl/source/detail/helpers.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <detail/scheduler/commands.hpp>
 #include <sycl/detail/helpers.hpp>
 
 #include <detail/context_impl.hpp>
@@ -30,9 +31,16 @@ std::vector<RT::PiEvent> getOrWaitEvents(std::vector<sycl::event> DepEvents,
         !SyclEventImplPtr->is_host()) {
       continue;
     }
+    // The fusion command and its event are associated with a non-host context,
+    // but still does not produce a PI event,.
+    bool NoPiEvent =
+        SyclEventImplPtr->MCommand &&
+        !static_cast<Command *>(SyclEventImplPtr->MCommand)->producesPiEvent();
     if (SyclEventImplPtr->is_host() ||
-        SyclEventImplPtr->getContextImpl() != Context) {
-      SyclEventImplPtr->waitInternal();
+        SyclEventImplPtr->getContextImpl() != Context || NoPiEvent) {
+      // Call wait, because the command for the event might not have been
+      // enqueued when kernel fusion is happening.
+      SyclEventImplPtr->wait(SyclEventImplPtr);
     } else {
       Events.push_back(SyclEventImplPtr->getHandleRef());
     }

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -498,6 +498,15 @@ public:
 
   bool ext_oneapi_empty() const;
 
+  /// Check whether the queue is in fusion mode.
+  ///
+  /// \return true if the queue is in fusion mode, false otherwise.
+  bool is_in_fusion_mode() {
+    return detail::Scheduler::getInstance().isInFusionMode(
+        std::hash<typename std::shared_ptr<queue_impl>::element_type *>()(
+            this));
+  }
+
 protected:
   // template is needed for proper unit testing
   template <typename HandlerType = handler>

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -168,6 +168,8 @@ static std::string commandToNodeType(Command::CommandType Type) {
     return "host_acc_create_buffer_lock_node";
   case Command::CommandType::EMPTY_TASK:
     return "host_acc_destroy_buffer_release_node";
+  case Command::CommandType::FUSION:
+    return "kernel_fusion_placeholder_node";
   default:
     return "unknown_node";
   }
@@ -196,6 +198,8 @@ static std::string commandToName(Command::CommandType Type) {
     return "Host Accessor Creation/Buffer Lock";
   case Command::CommandType::EMPTY_TASK:
     return "Host Accessor Destruction/Buffer Lock Release";
+  case Command::CommandType::FUSION:
+    return "Kernel Fusion Placeholder";
   default:
     return "Unknown Action";
   }
@@ -2586,6 +2590,125 @@ bool ExecCGCommand::readyForCleanup() const {
     return MLeafCounter == 0 && MEvent->isCompleted();
   return Command::readyForCleanup();
 }
+
+KernelFusionCommand::KernelFusionCommand(QueueImplPtr Queue)
+    : Command(Command::CommandType::FUSION, Queue),
+      MStatus(FusionStatus::ACTIVE) {
+  emitInstrumentationDataProxy();
+}
+
+std::vector<Command *> &KernelFusionCommand::auxiliaryCommands() {
+  return MAuxiliaryCommands;
+}
+
+void KernelFusionCommand::addToFusionList(ExecCGCommand *Kernel) {
+  MFusionList.push_back(Kernel);
+}
+
+std::vector<ExecCGCommand *> &KernelFusionCommand::getFusionList() {
+  return MFusionList;
+}
+
+bool KernelFusionCommand::producesPiEvent() const { return false; }
+
+pi_int32 KernelFusionCommand::enqueueImp() {
+  waitForPreparedHostEvents();
+  waitForEvents(MQueue, MPreparedDepsEvents, MEvent->getHandleRef());
+
+  return PI_SUCCESS;
+}
+
+void KernelFusionCommand::setFusionStatus(FusionStatus Status) {
+  MStatus = Status;
+}
+
+void KernelFusionCommand::emitInstrumentationData() {
+#ifdef XPTI_ENABLE_INSTRUMENTATION
+  if (!xptiTraceEnabled()) {
+    return;
+  }
+  // Create a payload with the command name and an event using this payload to
+  // emit a node_create
+  MCommandNodeType = commandToNodeType(MType);
+  MCommandName = commandToName(MType);
+
+  static unsigned FusionNodeCount = 0;
+  std::stringstream PayloadStr;
+  PayloadStr << "Fusion command #" << FusionNodeCount++;
+  xpti::payload_t Payload = xpti::payload_t(PayloadStr.str().c_str());
+
+  uint64_t CommandInstanceNo = 0;
+  xpti_td *CmdTraceEvent =
+      xptiMakeEvent(MCommandName.c_str(), &Payload, xpti::trace_graph_event,
+                    xpti_at::active, &CommandInstanceNo);
+
+  MInstanceID = CommandInstanceNo;
+  if (CmdTraceEvent) {
+    MTraceEvent = static_cast<void *>(CmdTraceEvent);
+    // If we are seeing this event again, then the instance ID
+    // will be greater
+    // than 1; in this case, we must skip sending a
+    // notification to create a node as this node has already
+    // been created. We return this value so the epilog method
+    // can be called selectively.
+    // See makeTraceEventProlog.
+    MFirstInstance = (CommandInstanceNo == 1);
+  }
+
+  // This function is called in the constructor of the command. At this point
+  // the kernel fusion list is still empty, so we don't have a terrible lot of
+  // information we could attach to this node here.
+  if (MFirstInstance && CmdTraceEvent) {
+    xpti::addMetadata(CmdTraceEvent, "sycl_device",
+                      deviceToID(MQueue->get_device()));
+    xpti::addMetadata(CmdTraceEvent, "sycl_device_type",
+                      deviceToString(MQueue->get_device()));
+    xpti::addMetadata(CmdTraceEvent, "sycl_device_name",
+                      getSyclObjImpl(MQueue->get_device())->getDeviceName());
+  }
+
+  if (MFirstInstance) {
+    xptiNotifySubscribers(MStreamID, xpti::trace_node_create,
+                          detail::GSYCLGraphEvent,
+                          static_cast<xpti_td *>(MTraceEvent), MInstanceID,
+                          static_cast<const void *>(MCommandNodeType.c_str()));
+  }
+
+#endif
+}
+
+void KernelFusionCommand::printDot(std::ostream &Stream) const {
+  Stream << "\"" << this << "\" [style=filled, fillcolor=\"#AFFF82\", label=\"";
+
+  Stream << "ID = " << this << "\\n";
+  Stream << "KERNEL FUSION on " << deviceToString(MQueue->get_device()) << "\\n"
+         << "FUSION LIST: {";
+  bool Initial = true;
+  for (auto *Cmd : MFusionList) {
+    if (!Initial) {
+      Stream << ",\\n";
+    }
+    Initial = false;
+    auto *KernelCG = static_cast<detail::CGExecKernel *>(&Cmd->getCG());
+    if (KernelCG->MSyclKernel && KernelCG->MSyclKernel->isCreatedFromSource()) {
+      Stream << "created from source";
+    } else {
+      Stream << demangleKernelName(KernelCG->getKernelName());
+    }
+  }
+  Stream << "}\\n";
+
+  Stream << "\"];" << std::endl;
+
+  for (const auto &Dep : MDeps) {
+    Stream << "  \"" << this << "\" -> \"" << Dep.MDepCommand << "\""
+           << " [ label = \"Access mode: "
+           << accessModeToString(Dep.MDepRequirement->MAccessMode) << "\\n"
+           << "MemObj: " << Dep.MDepRequirement->MSYCLMemObj << " \" ]"
+           << std::endl;
+  }
+}
+
 } // namespace detail
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -1367,7 +1367,7 @@ void Scheduler::GraphBuilder::removeNodeFromGraph(
         auto *DepReq = PrevDep.MDepRequirement;
         auto *DepRecord = getMemObjRecord(DepReq->MSYCLMemObj);
         if (DepRecord == Record) {
-          // Need to restore this as a leave, because we pushed it from the
+          // Need to restore this as a leaf, because we pushed it from the
           // leaves when adding the placeholder command.
           assert(Dep.MDepCommand);
           addNodeToLeaves(Record, Dep.MDepCommand, DepReq->MAccessMode,

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -109,6 +109,12 @@ Scheduler::GraphBuilder::GraphBuilder() {
     if (GraphPrintOpts.find("after_addHostAcc") != std::string::npos ||
         EnableAlways)
       MPrintOptionsArray[AfterAddHostAcc] = true;
+    if (GraphPrintOpts.find("after_fusionComplete") != std::string::npos ||
+        EnableAlways)
+      MPrintOptionsArray[AfterFusionComplete] = true;
+    if (GraphPrintOpts.find("after_fusionCancel") != std::string::npos ||
+        EnableAlways)
+      MPrintOptionsArray[AfterFusionCancel] = true;
   }
 }
 
@@ -129,6 +135,14 @@ static void unmarkVisitedNodes(std::vector<Command *> &Visited) {
 static void handleVisitedNodes(std::vector<Command *> &Visited) {
   for (Command *Cmd : Visited) {
     if (Cmd->MMarks.MToBeDeleted) {
+      if (Cmd->getType() == Command::FUSION &&
+          !static_cast<KernelFusionCommand *>(Cmd)->readyForDeletion()) {
+        // Fusion commands might still be needed because fusion might be
+        // aborted, but a later call to complete_fusion still needs to be able
+        // to return a valid event. Clean-up of fusion commands is therefore
+        // explicitly handled by start fusion.
+        return;
+      }
       Cmd->getEvent()->setCommand(nullptr);
       delete Cmd;
     } else
@@ -884,7 +898,7 @@ Scheduler::GraphBuilder::addEmptyCmd(Command *Cmd, const std::vector<T *> &Reqs,
   return EmptyCmd;
 }
 
-static bool isInteropHostTask(const std::unique_ptr<ExecCGCommand> &Cmd) {
+static bool isInteropHostTask(ExecCGCommand *Cmd) {
   if (Cmd->getCG().getType() != CG::CGTYPE::CodeplayHostTask)
     return false;
 
@@ -914,7 +928,7 @@ static void combineAccessModesOfReqs(std::vector<Requirement *> &Reqs) {
   }
 }
 
-Command *
+Scheduler::GraphBuildResult
 Scheduler::GraphBuilder::addCG(std::unique_ptr<detail::CG> CommandGroup,
                                const QueueImplPtr &Queue,
                                std::vector<Command *> &ToEnqueue) {
@@ -924,6 +938,74 @@ Scheduler::GraphBuilder::addCG(std::unique_ptr<detail::CG> CommandGroup,
   auto NewCmd = std::make_unique<ExecCGCommand>(std::move(CommandGroup), Queue);
   if (!NewCmd)
     throw runtime_error("Out of host memory", PI_ERROR_OUT_OF_HOST_MEMORY);
+
+  // Host tasks cannot participate in fusion. They take the regular route. If
+  // they create any requirement or event dependency on any of the kernels in
+  // the fusion list, this will lead to cancellation of the fusion in the
+  // GraphProcessor.
+  auto QUniqueID = std::hash<QueueImplPtr>()(Queue);
+  if (isInFusionMode(QUniqueID) && !NewCmd->isHostTask()) {
+    auto *FusionCmd = findFusionList(QUniqueID)->second.get();
+    FusionCmd->addToFusionList(NewCmd.get());
+    // Add the kernel to the graph, but delay the enqueue of any auxiliary
+    // commands (e.g., allocations) resulting from that process by adding them
+    // to the list of auxiliary commands of the fusion command.
+    createGraphForCommand(NewCmd.get(), NewCmd->getCG(),
+                          isInteropHostTask(NewCmd.get()), Reqs, Events, Queue,
+                          FusionCmd->auxiliaryCommands());
+    // We need to check the commands that this kernel depends on for any other
+    // commands that have been submitted to another queue which is also in
+    // fusion mode. If we detect such another command, we cancel fusion for that
+    // other queue to avoid circular dependencies.
+    // Handle requirements on any commands part of another active fusion.
+    for (auto &Dep : NewCmd->MDeps) {
+      auto *DepCmd = Dep.MDepCommand;
+      if (!DepCmd) {
+        continue;
+      }
+      if (DepCmd->getQueue() != Queue && isPartOfActiveFusion(DepCmd)) {
+        printFusionWarning("Aborting fusion because of requirement from a "
+                           "different fusion process");
+        cancelFusion(DepCmd->getQueue(), ToEnqueue);
+      }
+    }
+    // Handle event dependencies on any commands part of another active fusion.
+    for (auto &Ev : Events) {
+      auto *EvDepCmd = static_cast<Command *>(Ev->getCommand());
+      if (!EvDepCmd) {
+        continue;
+      }
+      if (EvDepCmd->getQueue() != Queue && isPartOfActiveFusion(EvDepCmd)) {
+        printFusionWarning("Aborting fusion because of event dependency from a "
+                           "different fusion");
+        cancelFusion(EvDepCmd->getQueue(), ToEnqueue);
+      }
+    }
+
+    // Set the fusion command, so we recognize when another command depends on a
+    // kernel in the fusion list.
+    NewCmd->MFusionCmd = FusionCmd;
+    std::vector<Command *> ToCleanUp;
+    // Add an event dependency from the fusion placeholder command to the new
+    // kernel.
+    auto ConnectionCmd = FusionCmd->addDep(NewCmd->getEvent(), ToCleanUp);
+    if (ConnectionCmd) {
+      FusionCmd->auxiliaryCommands().push_back(ConnectionCmd);
+    }
+    return {NewCmd.release(), FusionCmd->getEvent(), false};
+  }
+  createGraphForCommand(NewCmd.get(), NewCmd->getCG(),
+                        isInteropHostTask(NewCmd.get()), Reqs, Events, Queue,
+                        ToEnqueue);
+  auto Event = NewCmd->getEvent();
+  return {NewCmd.release(), Event, true};
+}
+
+void Scheduler::GraphBuilder::createGraphForCommand(
+    Command *NewCmd, CG &CG, bool isInteropTask,
+    std::vector<Requirement *> &Reqs,
+    const std::vector<detail::EventImplPtr> &Events, QueueImplPtr Queue,
+    std::vector<Command *> &ToEnqueue) {
 
   if (MPrintOptionsArray[BeforeAddCG])
     printGraphAsDot("before_addCG");
@@ -941,9 +1023,7 @@ Scheduler::GraphBuilder::addCG(std::unique_ptr<detail::CG> CommandGroup,
 
     {
       const QueueImplPtr &QueueForAlloca =
-          isInteropHostTask(NewCmd)
-              ? static_cast<detail::CGHostTask &>(NewCmd->getCG()).MQueue
-              : Queue;
+          isInteropTask ? static_cast<detail::CGHostTask &>(CG).MQueue : Queue;
 
       Record = getOrInsertMemObjRecord(QueueForAlloca, Req, ToEnqueue);
       markModifiedIfWrite(Record, Req);
@@ -969,9 +1049,8 @@ Scheduler::GraphBuilder::addCG(std::unique_ptr<detail::CG> CommandGroup,
       bool NeedMemMoveToHost = false;
       auto MemMoveTargetQueue = Queue;
 
-      if (isInteropHostTask(NewCmd)) {
-        const detail::CGHostTask &HT =
-            static_cast<detail::CGHostTask &>(NewCmd->getCG());
+      if (isInteropTask) {
+        const detail::CGHostTask &HT = static_cast<detail::CGHostTask &>(CG);
 
         if (HT.MQueue->getContextImplPtr() != Record->MCurContext) {
           NeedMemMoveToHost = true;
@@ -990,10 +1069,12 @@ Scheduler::GraphBuilder::addCG(std::unique_ptr<detail::CG> CommandGroup,
         findDepsForReq(Record, Req, Queue->getContextImplPtr());
 
     for (Command *Dep : Deps) {
-      Command *ConnCmd =
-          NewCmd->addDep(DepDesc{Dep, Req, AllocaCmd}, ToCleanUp);
-      if (ConnCmd)
-        ToEnqueue.push_back(ConnCmd);
+      if (Dep != NewCmd) {
+        Command *ConnCmd =
+            NewCmd->addDep(DepDesc{Dep, Req, AllocaCmd}, ToCleanUp);
+        if (ConnCmd)
+          ToEnqueue.push_back(ConnCmd);
+      }
     }
   }
 
@@ -1006,11 +1087,14 @@ Scheduler::GraphBuilder::addCG(std::unique_ptr<detail::CG> CommandGroup,
     const Requirement *Req = Dep.MDepRequirement;
     MemObjRecord *Record = getMemObjRecord(Req->MSYCLMemObj);
     updateLeaves({Dep.MDepCommand}, Record, Req->MAccessMode, ToCleanUp);
-    addNodeToLeaves(Record, NewCmd.get(), Req->MAccessMode, ToEnqueue);
+    addNodeToLeaves(Record, NewCmd, Req->MAccessMode, ToEnqueue);
   }
 
   // Register all the events as dependencies
   for (detail::EventImplPtr e : Events) {
+    if (e->getCommand() && e->getCommand() == NewCmd) {
+      continue;
+    }
     if (Command *ConnCmd = NewCmd->addDep(e, ToCleanUp))
       ToEnqueue.push_back(ConnCmd);
   }
@@ -1018,9 +1102,9 @@ Scheduler::GraphBuilder::addCG(std::unique_ptr<detail::CG> CommandGroup,
   if (MPrintOptionsArray[AfterAddCG])
     printGraphAsDot("after_addCG");
 
-  for (Command *Cmd : ToCleanUp)
+  for (Command *Cmd : ToCleanUp) {
     cleanupCommand(Cmd);
-  return NewCmd.release();
+  }
 }
 
 void Scheduler::GraphBuilder::decrementLeafCountersForRecord(
@@ -1126,10 +1210,12 @@ void Scheduler::GraphBuilder::cleanupCommandsForRecord(MemObjRecord *Record) {
   handleVisitedNodes(MVisitedCmds);
 }
 
-void Scheduler::GraphBuilder::cleanupCommand(Command *Cmd) {
+void Scheduler::GraphBuilder::cleanupCommand(Command *Cmd,
+                                             bool AllowUnsubmitted) {
   if (SYCLConfig<SYCL_DISABLE_POST_ENQUEUE_CLEANUP>::get())
     return;
-  assert(Cmd->MLeafCounter == 0 && Cmd->isSuccessfullyEnqueued());
+  assert(Cmd->MLeafCounter == 0 &&
+         (Cmd->isSuccessfullyEnqueued() || AllowUnsubmitted));
   Command::CommandType CmdT = Cmd->getType();
 
   assert(CmdT != Command::ALLOCA && CmdT != Command::ALLOCA_SUB_BUF);
@@ -1156,6 +1242,14 @@ void Scheduler::GraphBuilder::cleanupCommand(Command *Cmd) {
     DepCmd->MUsers.erase(Cmd);
   }
 
+  if (Cmd->getType() == Command::FUSION &&
+      !static_cast<KernelFusionCommand *>(Cmd)->readyForDeletion()) {
+    // Fusion commands might still be needed because fusion might be aborted,
+    // but a later call to complete_fusion still needs to be able to return a
+    // valid event. Clean-up of fusion commands is therefore explicitly handled
+    // by start fusion.
+    return;
+  }
   Cmd->getEvent()->setCommand(nullptr);
   delete Cmd;
 }
@@ -1234,6 +1328,186 @@ Command *Scheduler::GraphBuilder::connectDepEvent(
   }
 
   return ConnectCmd;
+}
+
+void Scheduler::GraphBuilder::startFusion(QueueImplPtr Queue) {
+  auto QUniqueID = std::hash<QueueImplPtr>()(Queue);
+  if (isInFusionMode(QUniqueID)) {
+    throw sycl::exception{sycl::make_error_code(sycl::errc::invalid),
+                          "Queue already in fusion mode"};
+  }
+  auto OldFusionCmd = findFusionList(QUniqueID);
+  if (OldFusionCmd != MFusionMap.end()) {
+    // If fusion was used on this queue previously, the old fusion command might
+    // still be around to make sure that even after
+    // cancellation of the fusion due to synchronization, complete_fusion is
+    // still able to return a valid event.
+    OldFusionCmd->second->setFusionStatus(
+        KernelFusionCommand::FusionStatus::DELETED);
+    cleanupCommand(OldFusionCmd->second.release());
+    MFusionMap.erase(OldFusionCmd);
+  }
+  MFusionMap.emplace(QUniqueID, std::make_unique<KernelFusionCommand>(Queue));
+}
+
+void Scheduler::GraphBuilder::removeNodeFromGraph(
+    Command *Node, std::vector<Command *> &ToEnqueue) {
+  // Remove the placeholder command as leaf of all its requirements and from the
+  // user list of all its dependencies.
+  for (auto &Dep : Node->MDeps) {
+    auto AccessMode = Dep.MDepRequirement->MAccessMode;
+    auto *Record = getMemObjRecord(Dep.MDepRequirement->MSYCLMemObj);
+
+    Node->MLeafCounter -= Record->MReadLeaves.remove(Node);
+    Node->MLeafCounter -= Record->MWriteLeaves.remove(Node);
+    // If the placeholder had a write-requirement on this record, we need to
+    // restore the previous leaves.
+    if (AccessMode != access::mode::read) {
+      for (auto PrevDep : Dep.MDepCommand->MDeps) {
+        auto *DepReq = PrevDep.MDepRequirement;
+        auto *DepRecord = getMemObjRecord(DepReq->MSYCLMemObj);
+        if (DepRecord == Record) {
+          // Need to restore this as a leave, because we pushed it from the
+          // leaves when adding the placeholder command.
+          assert(Dep.MDepCommand);
+          addNodeToLeaves(Record, Dep.MDepCommand, DepReq->MAccessMode,
+                          ToEnqueue);
+        }
+      }
+    }
+    Dep.MDepCommand->MUsers.erase(Node);
+  }
+
+  Node->MDeps.clear();
+}
+
+void Scheduler::GraphBuilder::cancelFusion(QueueImplPtr Queue,
+                                           std::vector<Command *> &ToEnqueue) {
+  auto QUniqueID = std::hash<QueueImplPtr>()(Queue);
+  if (!isInFusionMode(QUniqueID)) {
+    return;
+  }
+  auto FusionList = findFusionList(QUniqueID);
+
+  auto *PlaceholderCmd = (*FusionList).second.get();
+
+  // Enqueue all the kernels/commands from the fusion list
+  auto FusedCmdList = PlaceholderCmd->getFusionList();
+  ToEnqueue.insert(ToEnqueue.end(), FusedCmdList.begin(), FusedCmdList.end());
+
+  // The commands establishing an event dependency between the fusion
+  // placeholder command and the individual kernels need to be enqueued.
+  ToEnqueue.insert(ToEnqueue.end(), PlaceholderCmd->auxiliaryCommands().begin(),
+                   PlaceholderCmd->auxiliaryCommands().end());
+
+  ToEnqueue.push_back(PlaceholderCmd);
+
+  if (MPrintOptionsArray[AfterFusionCancel]) {
+    printGraphAsDot("after_fusionCancel");
+  }
+
+  // Set the status for the fusion command
+  PlaceholderCmd->setFusionStatus(KernelFusionCommand::FusionStatus::CANCELLED);
+}
+
+EventImplPtr
+Scheduler::GraphBuilder::completeFusion(QueueImplPtr Queue,
+                                        std::vector<Command *> &ToEnqueue,
+                                        const property_list &PropList) {
+  auto QUniqueID = std::hash<QueueImplPtr>()(Queue);
+#if SYCL_EXT_CODEPLAY_KERNEL_FUSION
+  if (!isInFusionMode(QUniqueID)) {
+    auto InactiveFusionList = findFusionList(QUniqueID);
+    if (InactiveFusionList == MFusionMap.end()) {
+      throw sycl::exception{
+          sycl::make_error_code(sycl::errc::invalid),
+          "Calling complete_fusion on a queue not in fusion mode"};
+    }
+    return InactiveFusionList->second->getEvent();
+  }
+
+  auto FusionList = findFusionList(QUniqueID);
+  auto *PlaceholderCmd = FusionList->second.get();
+  auto &CmdList = PlaceholderCmd->getFusionList();
+
+  // TODO: The logic to invoke the JIT compiler to create a fused kernel from
+  // the list will be added in a later PR.
+  auto FusedCG = nullptr;
+
+  if (!FusedCG) {
+    // If the JIT compiler returns a nullptr, JIT compilation of the fused
+    // kernel failed. In that case, simply cancel the fusion and run each kernel
+    // on its own.
+    auto LastEvent = PlaceholderCmd->getEvent();
+    this->cancelFusion(Queue, ToEnqueue);
+    return LastEvent;
+  }
+
+  // Remove internal explicit dependencies, i.e., explicit dependencies from one
+  // kernel in the fusion list to another kernel also in the fusion list.
+  auto &FusedEventDeps = FusedCG->MEvents;
+  FusedEventDeps.erase(
+      std::remove_if(
+          FusedEventDeps.begin(), FusedEventDeps.end(),
+          [&](EventImplPtr &E) { return E->getCommand() == PlaceholderCmd; }),
+      FusedEventDeps.end());
+
+  auto FusedKernelCmd =
+      std::make_unique<ExecCGCommand>(std::move(FusedCG), Queue);
+
+  assert(PlaceholderCmd->MDeps.empty());
+  // Next, backwards iterate over all the commands in the fusion list and remove
+  // them from the graph to restore the state before starting fusion, so we can
+  // add the fused kernel to the graph in the next step.
+  // Clean up the old commands after successfully fusing them.
+  for (auto OldCmd = CmdList.rbegin(); OldCmd != CmdList.rend(); ++OldCmd) {
+    removeNodeFromGraph(*OldCmd, ToEnqueue);
+    cleanupCommand(*OldCmd, /* AllowUnsubmitted */ true);
+  }
+
+  createGraphForCommand(FusedKernelCmd.get(), FusedKernelCmd->getCG(), false,
+                        FusedKernelCmd->getCG().MRequirements,
+                        FusedKernelCmd->getCG().MEvents, Queue, ToEnqueue);
+
+  ToEnqueue.push_back(FusedKernelCmd.get());
+
+  std::vector<Command *> ToCleanUp;
+  // Make the placeholder command depend on the execution of the fused kernel
+  auto *ConnectToPlaceholder =
+      PlaceholderCmd->addDep(FusedKernelCmd->getEvent(), ToCleanUp);
+  if (ConnectToPlaceholder) {
+    ToEnqueue.push_back(ConnectToPlaceholder);
+  }
+  for (Command *Cmd : ToCleanUp) {
+    cleanupCommand(Cmd);
+  }
+  ToEnqueue.push_back(PlaceholderCmd);
+
+  if (MPrintOptionsArray[AfterFusionComplete]) {
+    printGraphAsDot("after_fusionComplete");
+  }
+
+  // Set the status for the fusion command.
+  PlaceholderCmd->setFusionStatus(KernelFusionCommand::FusionStatus::COMPLETE);
+
+  return FusedKernelCmd.release()->getEvent();
+#else  // SYCL_EXT_CODEPLAY_KERNEL_FUSION
+  printFusionWarning("Kernel fusion not supported by this build");
+  (void)PropList;
+  auto FusionList = findFusionList(QUniqueID);
+  auto *PlaceholderCmd = FusionList->second.get();
+  auto LastEvent = PlaceholderCmd->getEvent();
+  this->cancelFusion(Queue, ToEnqueue);
+  return LastEvent;
+#endif // SYCL_EXT_CODEPLAY_KERNEL_FUSION
+}
+
+bool Scheduler::GraphBuilder::isInFusionMode(QueueIdT Id) {
+  auto FusionList = findFusionList(Id);
+  if (FusionList == MFusionMap.end()) {
+    return false;
+  }
+  return FusionList->second->isActive();
 }
 
 } // namespace detail

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -46,7 +46,8 @@ void Scheduler::waitForRecordToFinish(MemObjRecord *Record,
   std::vector<Command *> ToCleanUp;
   for (Command *Cmd : Record->MReadLeaves) {
     EnqueueResultT Res;
-    bool Enqueued = GraphProcessor::enqueueCommand(Cmd, Res, ToCleanUp, Cmd);
+    bool Enqueued =
+        GraphProcessor::enqueueCommand(Cmd, GraphReadLock, Res, ToCleanUp, Cmd);
     if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
       throw runtime_error("Enqueue process failed.",
                           PI_ERROR_INVALID_OPERATION);
@@ -58,7 +59,8 @@ void Scheduler::waitForRecordToFinish(MemObjRecord *Record,
   }
   for (Command *Cmd : Record->MWriteLeaves) {
     EnqueueResultT Res;
-    bool Enqueued = GraphProcessor::enqueueCommand(Cmd, Res, ToCleanUp, Cmd);
+    bool Enqueued =
+        GraphProcessor::enqueueCommand(Cmd, GraphReadLock, Res, ToCleanUp, Cmd);
     if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
       throw runtime_error("Enqueue process failed.",
                           PI_ERROR_INVALID_OPERATION);
@@ -70,8 +72,8 @@ void Scheduler::waitForRecordToFinish(MemObjRecord *Record,
   for (AllocaCommandBase *AllocaCmd : Record->MAllocaCommands) {
     Command *ReleaseCmd = AllocaCmd->getReleaseCmd();
     EnqueueResultT Res;
-    bool Enqueued =
-        GraphProcessor::enqueueCommand(ReleaseCmd, Res, ToCleanUp, ReleaseCmd);
+    bool Enqueued = GraphProcessor::enqueueCommand(ReleaseCmd, GraphReadLock,
+                                                   Res, ToCleanUp, ReleaseCmd);
     if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
       throw runtime_error("Enqueue process failed.",
                           PI_ERROR_INVALID_OPERATION);
@@ -109,6 +111,7 @@ EventImplPtr Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup,
     }
   }
 
+  bool ShouldEnqueue = true;
   {
     WriteLockT Lock = acquireWriteLock();
 
@@ -117,36 +120,62 @@ EventImplPtr Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup,
     case CG::UpdateHost:
       NewCmd = MGraphBuilder.addCGUpdateHost(std::move(CommandGroup),
                                              DefaultHostQueue, AuxiliaryCmds);
+      NewEvent = NewCmd->getEvent();
       break;
-    case CG::CodeplayHostTask:
-      NewCmd = MGraphBuilder.addCG(std::move(CommandGroup), DefaultHostQueue,
-                                   AuxiliaryCmds);
+    case CG::CodeplayHostTask: {
+      auto Result = MGraphBuilder.addCG(std::move(CommandGroup),
+                                        DefaultHostQueue, AuxiliaryCmds);
+      NewCmd = Result.NewCmd;
+      NewEvent = Result.NewEvent;
+      ShouldEnqueue = Result.ShouldEnqueue;
       break;
-    default:
-      NewCmd = MGraphBuilder.addCG(std::move(CommandGroup), std::move(Queue),
-                                   AuxiliaryCmds);
     }
-    NewEvent = NewCmd->getEvent();
+    default:
+      auto Result = MGraphBuilder.addCG(std::move(CommandGroup),
+                                        std::move(Queue), AuxiliaryCmds);
+      NewCmd = Result.NewCmd;
+      NewEvent = Result.NewEvent;
+      ShouldEnqueue = Result.ShouldEnqueue;
+    }
   }
 
+  if (ShouldEnqueue) {
+    enqueueCommandForCG(NewEvent, AuxiliaryCmds);
+
+    for (auto StreamImplPtr : Streams) {
+      StreamImplPtr->flush(NewEvent);
+    }
+
+    if (!AuxiliaryResources.empty())
+      registerAuxiliaryResources(NewEvent, std::move(AuxiliaryResources));
+  }
+
+  return NewEvent;
+}
+
+void Scheduler::enqueueCommandForCG(EventImplPtr NewEvent,
+                                    std::vector<Command *> &AuxiliaryCmds) {
   std::vector<Command *> ToCleanUp;
   {
     ReadLockT Lock = acquireReadLock();
 
-    Command *NewCmd = static_cast<Command *>(NewEvent->getCommand());
+    Command *NewCmd =
+        (NewEvent) ? static_cast<Command *>(NewEvent->getCommand()) : nullptr;
 
     EnqueueResultT Res;
     bool Enqueued;
 
     auto CleanUp = [&]() {
       if (NewCmd && (NewCmd->MDeps.size() == 0 && NewCmd->MUsers.size() == 0)) {
-        NewEvent->setCommand(nullptr);
+        if (NewEvent) {
+          NewEvent->setCommand(nullptr);
+        }
         delete NewCmd;
       }
     };
 
     for (Command *Cmd : AuxiliaryCmds) {
-      Enqueued = GraphProcessor::enqueueCommand(Cmd, Res, ToCleanUp, Cmd);
+      Enqueued = GraphProcessor::enqueueCommand(Cmd, Lock, Res, ToCleanUp, Cmd);
       try {
         if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
           throw runtime_error("Auxiliary enqueue process failed.",
@@ -163,8 +192,8 @@ EventImplPtr Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup,
       // TODO: Check if lazy mode.
       EnqueueResultT Res;
       try {
-        bool Enqueued =
-            GraphProcessor::enqueueCommand(NewCmd, Res, ToCleanUp, NewCmd);
+        bool Enqueued = GraphProcessor::enqueueCommand(NewCmd, Lock, Res,
+                                                       ToCleanUp, NewCmd);
         if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
           throw runtime_error("Enqueue process failed.",
                               PI_ERROR_INVALID_OPERATION);
@@ -177,14 +206,6 @@ EventImplPtr Scheduler::addCG(std::unique_ptr<detail::CG> CommandGroup,
     }
   }
   cleanupCommands(ToCleanUp);
-
-  for (auto StreamImplPtr : Streams) {
-    StreamImplPtr->flush(NewEvent);
-  }
-  if (!AuxiliaryResources.empty())
-    registerAuxiliaryResources(NewEvent, std::move(AuxiliaryResources));
-
-  return NewEvent;
 }
 
 EventImplPtr Scheduler::addCopyBack(Requirement *Req) {
@@ -206,13 +227,14 @@ EventImplPtr Scheduler::addCopyBack(Requirement *Req) {
     bool Enqueued;
 
     for (Command *Cmd : AuxiliaryCmds) {
-      Enqueued = GraphProcessor::enqueueCommand(Cmd, Res, ToCleanUp, Cmd);
+      Enqueued = GraphProcessor::enqueueCommand(Cmd, Lock, Res, ToCleanUp, Cmd);
       if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
         throw runtime_error("Enqueue process failed.",
                             PI_ERROR_INVALID_OPERATION);
     }
 
-    Enqueued = GraphProcessor::enqueueCommand(NewCmd, Res, ToCleanUp, NewCmd);
+    Enqueued =
+        GraphProcessor::enqueueCommand(NewCmd, Lock, Res, ToCleanUp, NewCmd);
     if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
       throw runtime_error("Enqueue process failed.",
                           PI_ERROR_INVALID_OPERATION);
@@ -286,14 +308,15 @@ EventImplPtr Scheduler::addHostAccessor(Requirement *Req) {
     bool Enqueued;
 
     for (Command *Cmd : AuxiliaryCmds) {
-      Enqueued = GraphProcessor::enqueueCommand(Cmd, Res, ToCleanUp, Cmd);
+      Enqueued = GraphProcessor::enqueueCommand(Cmd, Lock, Res, ToCleanUp, Cmd);
       if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
         throw runtime_error("Enqueue process failed.",
                             PI_ERROR_INVALID_OPERATION);
     }
 
     if (Command *NewCmd = static_cast<Command *>(NewCmdEvent->getCommand())) {
-      Enqueued = GraphProcessor::enqueueCommand(NewCmd, Res, ToCleanUp, NewCmd);
+      Enqueued =
+          GraphProcessor::enqueueCommand(NewCmd, Lock, Res, ToCleanUp, NewCmd);
       if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
         throw runtime_error("Enqueue process failed.",
                             PI_ERROR_INVALID_OPERATION);
@@ -315,18 +338,20 @@ void Scheduler::releaseHostAccessor(Requirement *Req) {
 
     BlockedCmd->MEnqueueStatus = EnqueueResultT::SyclEnqueueReady;
 
-    enqueueLeavesOfReqUnlocked(Req, ToCleanUp);
+    enqueueLeavesOfReqUnlocked(Req, Lock, ToCleanUp);
   }
   cleanupCommands(ToCleanUp);
 }
 
 void Scheduler::enqueueLeavesOfReqUnlocked(const Requirement *const Req,
+                                           ReadLockT &GraphReadLock,
                                            std::vector<Command *> &ToCleanUp) {
   MemObjRecord *Record = Req->MSYCLMemObj->MRecord.get();
-  auto EnqueueLeaves = [&ToCleanUp](LeavesCollection &Leaves) {
+  auto EnqueueLeaves = [&ToCleanUp, &GraphReadLock](LeavesCollection &Leaves) {
     for (Command *Cmd : Leaves) {
       EnqueueResultT Res;
-      bool Enqueued = GraphProcessor::enqueueCommand(Cmd, Res, ToCleanUp, Cmd);
+      bool Enqueued = GraphProcessor::enqueueCommand(Cmd, GraphReadLock, Res,
+                                                     ToCleanUp, Cmd);
       if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
         throw runtime_error("Enqueue process failed.",
                             PI_ERROR_INVALID_OPERATION);
@@ -338,14 +363,15 @@ void Scheduler::enqueueLeavesOfReqUnlocked(const Requirement *const Req,
 }
 
 void Scheduler::enqueueUnblockedCommands(
-    const std::vector<EventImplPtr> &ToEnqueue,
+    const std::vector<EventImplPtr> &ToEnqueue, ReadLockT &GraphReadLock,
     std::vector<Command *> &ToCleanUp) {
   for (auto &Event : ToEnqueue) {
     Command *Cmd = static_cast<Command *>(Event->getCommand());
     if (!Cmd)
       continue;
     EnqueueResultT Res;
-    bool Enqueued = GraphProcessor::enqueueCommand(Cmd, Res, ToCleanUp, Cmd);
+    bool Enqueued =
+        GraphProcessor::enqueueCommand(Cmd, GraphReadLock, Res, ToCleanUp, Cmd);
     if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
       throw runtime_error("Enqueue process failed.",
                           PI_ERROR_INVALID_OPERATION);
@@ -448,7 +474,7 @@ void Scheduler::NotifyHostTaskCompletion(Command *Cmd) {
       // update self-event status
       Cmd->getEvent()->setComplete();
     }
-    Scheduler::enqueueUnblockedCommands(Cmd->MBlockedUsers, ToCleanUp);
+    Scheduler::enqueueUnblockedCommands(Cmd->MBlockedUsers, Lock, ToCleanUp);
   }
   cleanupCommands(ToCleanUp);
 }
@@ -537,6 +563,62 @@ void Scheduler::cleanupAuxiliaryResources(BlockingT Blocking) {
 }
 
 thread_local bool Scheduler::ForceDeferredMemObjRelease = false;
+
+void Scheduler::startFusion(QueueImplPtr Queue) {
+  WriteLockT Lock(MGraphLock, std::defer_lock);
+  MGraphBuilder.startFusion(Queue);
+}
+
+void Scheduler::cancelFusion(QueueImplPtr Queue) {
+  std::vector<Command *> ToEnqueue;
+  {
+    WriteLockT Lock{MGraphLock, std::defer_lock};
+    MGraphBuilder.cancelFusion(Queue, ToEnqueue);
+  }
+  enqueueCommandForCG(nullptr, ToEnqueue);
+}
+
+EventImplPtr Scheduler::completeFusion(QueueImplPtr Queue,
+                                       const property_list &PropList) {
+  std::vector<Command *> ToEnqueue;
+  EventImplPtr FusedEvent;
+  {
+    WriteLockT Lock{MGraphLock, std::defer_lock};
+    FusedEvent = MGraphBuilder.completeFusion(Queue, ToEnqueue, PropList);
+  }
+  enqueueCommandForCG(nullptr, ToEnqueue);
+
+  return FusedEvent;
+}
+
+bool Scheduler::isInFusionMode(QueueIdT queue) {
+  ReadLockT Lock{MGraphLock, std::defer_lock};
+  return MGraphBuilder.isInFusionMode(queue);
+}
+
+void Scheduler::printFusionWarning(const std::string &Message) {
+  if (detail::SYCLConfig<detail::SYCL_RT_WARNING_LEVEL>::get() > 0) {
+    std::cerr << "WARNING: " << Message << "\n";
+  }
+}
+
+KernelFusionCommand *Scheduler::isPartOfActiveFusion(Command *Cmd) {
+  auto CmdType = Cmd->getType();
+  switch (CmdType) {
+  case Command::FUSION: {
+    auto *FusionCmd = static_cast<KernelFusionCommand *>(Cmd);
+    return (FusionCmd->isActive()) ? FusionCmd : nullptr;
+  }
+  case Command::RUN_CG: {
+    auto *CGCmd = static_cast<ExecCGCommand *>(Cmd);
+    return (CGCmd->MFusionCmd && CGCmd->MFusionCmd->isActive())
+               ? CGCmd->MFusionCmd
+               : nullptr;
+  }
+  default:
+    return nullptr;
+  }
+}
 
 } // namespace detail
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -565,14 +565,14 @@ void Scheduler::cleanupAuxiliaryResources(BlockingT Blocking) {
 thread_local bool Scheduler::ForceDeferredMemObjRelease = false;
 
 void Scheduler::startFusion(QueueImplPtr Queue) {
-  WriteLockT Lock(MGraphLock, std::defer_lock);
+  WriteLockT Lock = acquireWriteLock();
   MGraphBuilder.startFusion(Queue);
 }
 
 void Scheduler::cancelFusion(QueueImplPtr Queue) {
   std::vector<Command *> ToEnqueue;
   {
-    WriteLockT Lock{MGraphLock, std::defer_lock};
+    WriteLockT Lock = acquireWriteLock();
     MGraphBuilder.cancelFusion(Queue, ToEnqueue);
   }
   enqueueCommandForCG(nullptr, ToEnqueue);
@@ -583,7 +583,7 @@ EventImplPtr Scheduler::completeFusion(QueueImplPtr Queue,
   std::vector<Command *> ToEnqueue;
   EventImplPtr FusedEvent;
   {
-    WriteLockT Lock{MGraphLock, std::defer_lock};
+    WriteLockT Lock = acquireWriteLock();
     FusedEvent = MGraphBuilder.completeFusion(Queue, ToEnqueue, PropList);
   }
   enqueueCommandForCG(nullptr, ToEnqueue);
@@ -592,7 +592,7 @@ EventImplPtr Scheduler::completeFusion(QueueImplPtr Queue,
 }
 
 bool Scheduler::isInFusionMode(QueueIdT queue) {
-  ReadLockT Lock{MGraphLock, std::defer_lock};
+  ReadLockT Lock = acquireReadLock();
   return MGraphBuilder.isInFusionMode(queue);
 }
 

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -439,7 +439,7 @@ public:
   static MemObjRecord *getMemObjRecord(const Requirement *const Req);
 
   void deferMemObjRelease(const std::shared_ptr<detail::SYCLMemObjI> &MemObj);
-  
+
   void startFusion(QueueImplPtr Queue);
 
   void cancelFusion(QueueImplPtr Queue);
@@ -499,7 +499,7 @@ protected:
 
   // May lock graph with read and write modes during execution.
   void cleanupDeferredMemObjects(BlockingT Blocking);
-  
+
   // POD struct to convey some additional information from GraphBuilder::addCG
   // to the Scheduler to support kernel fusion.
   struct GraphBuildResult {

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -147,11 +147,13 @@ event handler::finalize() {
       }
     }
 
-    if (MRequirements.size() + MEvents.size() + MStreamStorage.size() == 0) {
+    const auto &type = getType();
+    if (type == detail::CG::Kernel && !MQueue->is_in_fusion_mode() &&
+        MRequirements.size() + MEvents.size() + MStreamStorage.size() == 0) {
       // if user does not add a new dependency to the dependency graph, i.e.
-      // the graph is not changed, then this faster path is used to submit
-      // kernel bypassing scheduler and avoiding CommandGroup, Command objects
-      // creation.
+      // the graph is not changed, and the queue is not in fusion mode, then
+      // this faster path is used to submit kernel bypassing scheduler and
+      // avoiding CommandGroup, Command objects creation.
 
       std::vector<RT::PiEvent> RawEvents;
       detail::EventImplPtr NewEvent;

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -147,8 +147,7 @@ event handler::finalize() {
       }
     }
 
-    const auto &type = getType();
-    if (type == detail::CG::Kernel && !MQueue->is_in_fusion_mode() &&
+    if (!MQueue->is_in_fusion_mode() &&
         MRequirements.size() + MEvents.size() + MStreamStorage.size() == 0) {
       // if user does not add a new dependency to the dependency graph, i.e.
       // the graph is not changed, and the queue is not in fusion mode, then

--- a/sycl/unittests/scheduler/CMakeLists.txt
+++ b/sycl/unittests/scheduler/CMakeLists.txt
@@ -22,4 +22,5 @@ add_sycl_unittest(SchedulerTests OBJECT
     RunOnHostIntelCG.cpp
     EnqueueWithDependsOnDeps.cpp
     AccessorDefaultCtor.cpp
+    KernelFusion.cpp
 )

--- a/sycl/unittests/scheduler/KernelFusion.cpp
+++ b/sycl/unittests/scheduler/KernelFusion.cpp
@@ -1,0 +1,150 @@
+//==----------- KernelFusion.cpp - Kernel Fusion scheduler unit tests ------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "SchedulerTest.hpp"
+#include "SchedulerTestUtils.hpp"
+
+#include <helpers/PiMock.hpp>
+#include <helpers/ScopedEnvVar.hpp>
+#include <helpers/TestKernel.hpp>
+
+#include <vector>
+
+using namespace sycl;
+using EventImplPtr = std::shared_ptr<detail::event_impl>;
+
+template <typename T, int Dim>
+detail::Command *CreateTaskCommand(MockScheduler &MS,
+                                   detail::QueueImplPtr DevQueue,
+                                   buffer<T, Dim> &buf) {
+  MockHandlerCustomFinalize MockCGH(DevQueue, false);
+
+  auto acc = buf.get_access(static_cast<sycl::handler &>(MockCGH));
+
+  kernel_bundle KernelBundle =
+      sycl::get_kernel_bundle<sycl::bundle_state::input>(
+          DevQueue->get_context());
+  auto ExecBundle = sycl::build(KernelBundle);
+  MockCGH.use_kernel_bundle(ExecBundle);
+  MockCGH.single_task<TestKernel<>>([] {});
+
+  auto CmdGrp = MockCGH.finalize();
+
+  std::vector<detail::Command *> ToEnqueue;
+  detail::Command *NewCmd = MS.addCG(std::move(CmdGrp), DevQueue, ToEnqueue);
+  EXPECT_EQ(ToEnqueue.size(), 0u);
+  return NewCmd;
+}
+
+bool CheckTestExecRequirements(const platform &plt) {
+  if (plt.is_host()) {
+    std::cout << "Not run due to host-only environment\n";
+    return false;
+  }
+  // This test only contains device image for SPIR-V capable devices.
+  if (plt.get_backend() != sycl::backend::opencl &&
+      plt.get_backend() != sycl::backend::ext_oneapi_level_zero) {
+    std::cout << "Only OpenCL and Level Zero are supported for this test\n";
+    return false;
+  }
+  return true;
+}
+
+bool containsCommand(detail::Command *Cmd,
+                     std::vector<detail::Command *> &List) {
+  return std::find(List.begin(), List.end(), Cmd) != List.end();
+}
+
+bool dependsOnViaDep(detail::Command *Dependent, detail::Command *Dependee) {
+  return std::find_if(Dependent->MDeps.begin(), Dependent->MDeps.end(),
+                      [=](detail::DepDesc &Desc) {
+                        return Desc.MDepCommand == Dependee;
+                      }) != Dependent->MDeps.end();
+}
+
+bool dependsOnViaEvent(detail::Command *Dependent, detail::Command *Dependee) {
+  auto &DepEvents = Dependent->getPreparedDepsEvents();
+  return std::find_if(DepEvents.begin(), DepEvents.end(),
+                      [=](const EventImplPtr &Ev) {
+                        return Ev->getCommand() && Ev->getCommand() == Dependee;
+                      }) != DepEvents.end();
+}
+
+TEST_F(SchedulerTest, CancelKernelFusion) {
+  unittest::PiMock Mock;
+  platform Plt = Mock.getPlatform();
+  if (!CheckTestExecRequirements(Plt))
+    return;
+
+  queue QueueDev(context(Plt), default_selector_v);
+  MockScheduler MS;
+
+  detail::QueueImplPtr QueueDevImpl = detail::getSyclObjImpl(QueueDev);
+
+  // Test scenario: Create four memory objects (buffers) and one command for
+  // each memory object before starting fusion. Then start fusion, again adding
+  // one command with a requirement for each of the memory objects. Then cancel
+  // fusion and check for correct dependencies.
+
+  buffer<int, 1> b1{range<1>{4}};
+  buffer<int, 1> b2{range<1>{4}};
+  buffer<int, 1> b3{range<1>{4}};
+  buffer<int, 1> b4{range<1>{4}};
+
+  auto *nonFusionCmd1 = CreateTaskCommand(MS, QueueDevImpl, b1);
+  auto *nonFusionCmd2 = CreateTaskCommand(MS, QueueDevImpl, b2);
+  auto *nonFusionCmd3 = CreateTaskCommand(MS, QueueDevImpl, b3);
+  auto *nonFusionCmd4 = CreateTaskCommand(MS, QueueDevImpl, b4);
+
+  MS.startFusion(QueueDevImpl);
+
+  auto *fusionCmd1 = CreateTaskCommand(MS, QueueDevImpl, b1);
+  auto *fusionCmd2 = CreateTaskCommand(MS, QueueDevImpl, b2);
+  auto *fusionCmd3 = CreateTaskCommand(MS, QueueDevImpl, b3);
+  auto *fusionCmd4 = CreateTaskCommand(MS, QueueDevImpl, b4);
+
+  std::vector<detail::Command *> ToEnqueue;
+  MS.cancelFusion(QueueDevImpl, ToEnqueue);
+
+  // The list of commands filled by cancelFusion should contain the four
+  // commands submitted while in fusion mode, plus the placeholder command.
+  EXPECT_EQ(ToEnqueue.size(), 5u);
+  EXPECT_TRUE(containsCommand(fusionCmd1, ToEnqueue));
+  EXPECT_TRUE(containsCommand(fusionCmd2, ToEnqueue));
+  EXPECT_TRUE(containsCommand(fusionCmd3, ToEnqueue));
+  EXPECT_TRUE(containsCommand(fusionCmd4, ToEnqueue));
+
+  // Each of the commands submitted while in fusion mode should have exactly one
+  // dependency on the command not participating in fusion, but accessing the
+  // same memory object.
+  EXPECT_TRUE(dependsOnViaDep(fusionCmd1, nonFusionCmd1));
+  EXPECT_EQ(fusionCmd1->MDeps.size(), 1u);
+  EXPECT_TRUE(dependsOnViaDep(fusionCmd2, nonFusionCmd2));
+  EXPECT_EQ(fusionCmd2->MDeps.size(), 1u);
+  EXPECT_TRUE(dependsOnViaDep(fusionCmd3, nonFusionCmd3));
+  EXPECT_EQ(fusionCmd3->MDeps.size(), 1u);
+  EXPECT_TRUE(dependsOnViaDep(fusionCmd4, nonFusionCmd4));
+  EXPECT_EQ(fusionCmd4->MDeps.size(), 1u);
+
+  // There should be one placeholder command in the command list.
+  auto FusionCmdIt = std::find_if(
+      ToEnqueue.begin(), ToEnqueue.end(), [](detail::Command *Cmd) {
+        return Cmd->getType() == sycl::_V1::detail::Command::FUSION;
+      });
+  EXPECT_NE(FusionCmdIt, ToEnqueue.end());
+
+  // Check that the placeholder command has an event dependency on each of the
+  // commands submitted while in fusion mode.
+  auto *placeHolderCmd =
+      static_cast<detail::KernelFusionCommand *>(*FusionCmdIt);
+  EXPECT_EQ(placeHolderCmd->getPreparedDepsEvents().size(), 4u);
+  EXPECT_TRUE(dependsOnViaEvent(placeHolderCmd, fusionCmd2));
+  EXPECT_TRUE(dependsOnViaEvent(placeHolderCmd, fusionCmd3));
+  EXPECT_TRUE(dependsOnViaEvent(placeHolderCmd, fusionCmd4));
+  EXPECT_TRUE(dependsOnViaEvent(placeHolderCmd, fusionCmd1));
+}

--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -202,6 +202,11 @@ public:
     return MGraphBuilder.addCG(std::move(CommandGroup), Queue, ToEnqueue)
         .NewCmd;
   }
+
+  void cancelFusion(sycl::detail::QueueImplPtr Queue,
+                    std::vector<sycl::detail::Command *> &ToEnqueue) {
+    MGraphBuilder.cancelFusion(Queue, ToEnqueue);
+  }
 };
 
 void addEdge(sycl::detail::Command *User, sycl::detail::Command *Dep,

--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -7,10 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
+#include <detail/handler_impl.hpp>
 #include <detail/queue_impl.hpp>
 #include <detail/scheduler/commands.hpp>
 #include <detail/scheduler/scheduler.hpp>
-#include <detail/handler_impl.hpp>
 #include <detail/stream_impl.hpp>
 #include <sycl/detail/cl.h>
 
@@ -143,9 +143,11 @@ public:
   static bool enqueueCommand(sycl::detail::Command *Cmd,
                              sycl::detail::EnqueueResultT &EnqueueResult,
                              sycl::detail::BlockingT Blocking) {
+    RWLockT MockLock;
+    ReadLockT MockReadLock(MockLock);
     std::vector<sycl::detail::Command *> ToCleanUp;
-    return GraphProcessor::enqueueCommand(Cmd, EnqueueResult, ToCleanUp, Cmd,
-                                          Blocking);
+    return GraphProcessor::enqueueCommand(Cmd, MockReadLock, EnqueueResult,
+                                          ToCleanUp, Cmd, Blocking);
   }
 
   sycl::detail::AllocaCommandBase *
@@ -197,7 +199,8 @@ public:
   addCG(std::unique_ptr<sycl::detail::CG> CommandGroup,
         sycl::detail::QueueImplPtr Queue,
         std::vector<sycl::detail::Command *> &ToEnqueue) {
-    return MGraphBuilder.addCG(std::move(CommandGroup), Queue, ToEnqueue);
+    return MGraphBuilder.addCG(std::move(CommandGroup), Queue, ToEnqueue)
+        .NewCmd;
   }
 };
 


### PR DESCRIPTION
This is the third patch in a series of patches to add an implementation of the [kernel fusion extension](https://github.com/intel/llvm/pull/7098). We have split the implementation into multiple patches to make them more easy to review. This patch integrates the kernel fusion extension into the SYCL runtime scheduler. 

Next to collecting the kernels submitted while in fusion mode in the fusion list associated with the queue, the integration into the scheduler is also responsible for detecting the synchronization scenarios. Various scenarios, such as buffer destruction or event wait, require fusion to be aborted early. The full list of scenarios is available in the [extension proposal](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_codeplay_kernel_fusion.asciidoc#synchronization-in-the-sycl-application).

A high-level description of the integration into the scheduler can be found in the [design document](https://github.com/intel/llvm/pull/7204). 

This PR can be reviewed and merged independently of https://github.com/intel/llvm/pull/7465.

Signed-off-by: Lukas Sommer <lukas.sommer@codeplay.com>