### PR TITLE
[SYCL-MLIR] Allow usage of init lists for vectors

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -391,7 +391,7 @@ ValueCategory MLIRScanner::VisitInitListExpr(clang::InitListExpr *E) {
   int64_t ResElts = VType.getNumElements();
 
   int64_t CurIdx = 0;
-  ValueCategory V{Builder.createOrFold<LLVM::UndefOp>(Loc, VType), false};
+  auto V = ValueCategory::getNullValue(Builder, Loc, VType);
   for (auto *IE : E->children()) {
     ValueCategory Init = Visit(IE);
     SmallVector<int64_t> Args;
@@ -433,14 +433,6 @@ ValueCategory MLIRScanner::VisitInitListExpr(clang::InitListExpr *E) {
       std::swap(V, Init);
     V = V.Shuffle(Builder, Loc, Init.val, Args);
     CurIdx += InitElts;
-  }
-
-  // Emit remaining default initializers
-  mlir::Type EltTy = VType.getElementType();
-  mlir::Value Init;
-  for (; CurIdx < ResElts; ++CurIdx) {
-    Init = Init ? Init : ValueCategory::getNullValue(Builder, Loc, EltTy).val;
-    V = V.Insert(Builder, Loc, Init, CurIdx);
   }
 
   return V;

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -36,10 +36,8 @@ MLIRScanner::VisitExtVectorElementExpr(clang::ExtVectorElementExpr *Expr) {
   auto MT = Base.val.getType().cast<MemRefType>();
   assert(MT.getElementType().isa<mlir::VectorType>() &&
          "Expecting ExtVectorElementExpr to have memref of vector elements");
-  auto Idx = Builder.create<arith::ConstantIntOp>(Loc, Indices[0], 64);
-  mlir::Value Val = Base.getValue(Builder);
-  return ValueCategory(Builder.create<LLVM::ExtractElementOp>(Loc, Val, Idx),
-                       /*IsReference*/ false);
+  ValueCategory Val{Base.getValue(Builder), false};
+  return Val.Extract(Builder, Loc, Indices[0]);
 }
 
 ValueCategory MLIRScanner::VisitConstantExpr(clang::ConstantExpr *Expr) {
@@ -355,25 +353,97 @@ ValueCategory MLIRScanner::VisitPredefinedExpr(clang::PredefinedExpr *Expr) {
   return VisitStringLiteral(Expr->getFunctionName());
 }
 
-ValueCategory MLIRScanner::VisitInitListExpr(clang::InitListExpr *Expr) {
-  mlir::Type SubType = Glob.getTypes().getMLIRType(Expr->getType());
-  bool IsArray = false;
-  bool LLVMABI = false;
+ValueCategory MLIRScanner::VisitInitListExpr(clang::InitListExpr *E) {
+  LLVM_DEBUG({
+    llvm::dbgs() << "VisitInitListExpr: ";
+    E->dump();
+    llvm::dbgs() << "\n";
+  });
 
-  if (Glob.getTypes()
-          .getMLIRType(Glob.getCGM().getContext().getLValueReferenceType(
-              Expr->getType()))
-          .isa<mlir::LLVM::LLVMPointerType>())
-    LLVMABI = true;
-  else {
-    Glob.getTypes().getMLIRType(Expr->getType(), &IsArray);
-    if (IsArray)
-      SubType = Glob.getTypes().getMLIRType(
-          Glob.getCGM().getContext().getLValueReferenceType(Expr->getType()));
+  assert(!E->hadArrayRangeDesignator() && "Unsupported");
+
+  const auto Loc = getMLIRLocation(E->getExprLoc());
+
+  auto VType =
+      Glob.getTypes().getMLIRType(E->getType()).dyn_cast<mlir::VectorType>();
+  if (!VType) {
+    mlir::Type SubType = Glob.getTypes().getMLIRType(E->getType());
+    bool IsArray = false;
+    bool LLVMABI = false;
+
+    if (Glob.getTypes()
+            .getMLIRType(
+                Glob.getCGM().getContext().getLValueReferenceType(E->getType()))
+            .isa<mlir::LLVM::LLVMPointerType>()) {
+      LLVMABI = true;
+    } else {
+      Glob.getTypes().getMLIRType(E->getType(), &IsArray);
+      if (IsArray)
+        SubType = Glob.getTypes().getMLIRType(
+            Glob.getCGM().getContext().getLValueReferenceType(E->getType()));
+    }
+
+    auto Op = createAllocOp(SubType, nullptr, /*memtype*/ 0, IsArray, LLVMABI);
+    InitializeValueByInitListExpr(Op, E);
+    return ValueCategory(Op, true);
   }
-  auto Op = createAllocOp(SubType, nullptr, /*memtype*/ 0, IsArray, LLVMABI);
-  InitializeValueByInitListExpr(Op, Expr);
-  return ValueCategory(Op, true);
+
+  int64_t ResElts = VType.getNumElements();
+
+  int64_t CurIdx = 0;
+  ValueCategory V{Builder.createOrFold<LLVM::UndefOp>(Loc, VType), false};
+  for (auto *IE : E->children()) {
+    ValueCategory Init = Visit(IE);
+    SmallVector<int64_t> Args;
+
+    auto VVT = Init.val.getType().dyn_cast<mlir::VectorType>();
+
+    // Handle scalar elements.
+    if (!VVT) {
+      V = V.Insert(Builder, Loc, Init.val, CurIdx);
+      ++CurIdx;
+      continue;
+    }
+
+    int64_t InitElts = VVT.getNumElements();
+
+    int64_t Offset = (CurIdx == 0) ? 0 : ResElts;
+
+    // Extend init to result vector length, and then shuffle its contribution
+    // to the vector initializer into V.
+    if (Args.empty()) {
+      for (int64_t J = 0; J != InitElts; ++J)
+        Args.push_back(J);
+      Args.resize(ResElts, -1);
+      Init = Init.Shuffle(
+          Builder, Loc,
+          Builder.createOrFold<LLVM::UndefOp>(Loc, Init.val.getType()), Args);
+
+      Args.clear();
+      for (int64_t J = 0; J != CurIdx; ++J)
+        Args.push_back(J);
+      for (int64_t J = 0; J != InitElts; ++J)
+        Args.push_back(J + Offset);
+      Args.resize(ResElts, -1);
+    }
+
+    // If V is undef, make sure it ends up on the RHS of the shuffle to aid
+    // merging subsequent shuffles into this one.
+    if (CurIdx == 0)
+      std::swap(V, Init);
+    V = V.Shuffle(Builder, Loc, Init.val, Args);
+    CurIdx += InitElts;
+  }
+
+  // Emit remaining default initializers
+  mlir::Type EltTy = VType.getElementType();
+  mlir::Value Init;
+  for (; CurIdx < ResElts; ++CurIdx) {
+    Init = Init ? Init : ValueCategory::getNullValue(Builder, Loc, EltTy).val;
+    V = V.Insert(Builder, Loc, Init, CurIdx);
+  }
+
+  return V;
 }
 
 ValueCategory MLIRScanner::VisitCXXStdInitializerListExpr(

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -758,3 +758,35 @@ ValueCategory ValueCategory::Xor(mlir::OpBuilder &Builder, mlir::Location Loc,
                                  mlir::Value RHS) const {
   return IntBinOp<arith::XOrIOp>(Builder, Loc, val, RHS);
 }
+
+ValueCategory ValueCategory::Insert(OpBuilder &Builder, Location Loc, Value V,
+                                    llvm::ArrayRef<int64_t> Indices) const {
+  assert(Indices.size() == 1 && "Only supporting 1-D vectors for now");
+  assert(val.getType().isa<VectorType>() && "Expecting vector type");
+  assert(val.getType().cast<VectorType>().getElementType() == V.getType() &&
+         "Cannot insert value in vector of different type");
+  assert(val.getType().cast<VectorType>().getNumElements() > Indices[0] &&
+         "Invalid index");
+
+  return {Builder.createOrFold<vector::InsertOp>(Loc, V, val, Indices), false};
+}
+
+ValueCategory ValueCategory::Extract(OpBuilder &Builder, Location Loc,
+                                     llvm::ArrayRef<int64_t> Indices) const {
+  assert(Indices.size() == 1 && "Only supporting 1-D vectors for now");
+  assert(val.getType().isa<VectorType>() && "Expecting vector type");
+  assert(val.getType().cast<VectorType>().getNumElements() > Indices[0] &&
+         "Invalid index");
+
+  return {Builder.createOrFold<vector::ExtractOp>(Loc, val, Indices), false};
+}
+
+ValueCategory ValueCategory::Shuffle(OpBuilder &Builder, Location Loc, Value V2,
+                                     llvm::ArrayRef<int64_t> Indices) const {
+  assert(val.getType().isa<VectorType>() && "Expecting vector type");
+  assert(V2.getType().isa<VectorType>() && "Expecting vector type");
+  assert(val.getType() == V2.getType() && "Expecting vectors of equal types");
+
+  return {Builder.createOrFold<vector::ShuffleOp>(Loc, val, V2, Indices),
+          false};
+}

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -159,6 +159,8 @@ public:
                         llvm::ArrayRef<int64_t> Indices) const;
   ValueCategory Shuffle(mlir::OpBuilder &Builder, mlir::Location Loc,
                         mlir::Value V2, llvm::ArrayRef<int64_t> Indices) const;
+  ValueCategory Reshape(mlir::OpBuilder &Builder, mlir::Location Loc,
+                        llvm::ArrayRef<int64_t> Shape) const;
 };
 
 #endif /* CLANG_MLIR_VALUE_CATEGORY */

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -152,6 +152,13 @@ public:
                    mlir::Value RHS) const;
   ValueCategory Xor(mlir::OpBuilder &Builder, mlir::Location Loc,
                     mlir::Value RHS) const;
+
+  ValueCategory Insert(mlir::OpBuilder &Builder, mlir::Location Loc,
+                       mlir::Value V, llvm::ArrayRef<int64_t> Indices) const;
+  ValueCategory Extract(mlir::OpBuilder &Builder, mlir::Location Loc,
+                        llvm::ArrayRef<int64_t> Indices) const;
+  ValueCategory Shuffle(mlir::OpBuilder &Builder, mlir::Location Loc,
+                        mlir::Value V2, llvm::ArrayRef<int64_t> Indices) const;
 };
 
 #endif /* CLANG_MLIR_VALUE_CATEGORY */

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -371,6 +371,8 @@ private:
                                           ValueCategory Src);
   ValueCategory EmitConversionToBool(mlir::Location Loc, ValueCategory Src,
                                      clang::QualType SrcType);
+  ValueCategory EmitVectorInitList(clang::InitListExpr *Expr,
+                                   mlir::VectorType VType);
 
 public:
   MLIRScanner(MLIRASTConsumer &Glob, mlir::OwningOpRef<mlir::ModuleOp> &Module,

--- a/polygeist/tools/cgeist/Test/Verification/ext_vector_type.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/ext_vector_type.cpp
@@ -19,20 +19,18 @@ size_t evt2() {
 // CHECK: memref.global constant @stv : memref<vector<3xi64>> {alignment = 32 : i64}
 
 // CHECK-LABEL:   func.func @_Z3evtv() -> i64 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:    %c0_i64 = arith.constant 0 : i64
 // CHECK-NEXT:    %alloca = memref.alloca() : memref<1xvector<3xi64>>
 // CHECK-NEXT:    %0 = affine.load %alloca[0] : memref<1xvector<3xi64>>
-// CHECK-NEXT:    %1 = llvm.extractelement %0[%c0_i64 : i64] : vector<3xi64>
+// CHECK-NEXT:    %1 = vector.extract %0[0] : vector<3xi64>
 // CHECK-NEXT:    return %1 : i64
 // CHECK-NEXT:    }
 
 // CHECK-LABEL:   func.func @_Z4evt2v() -> i64 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %c0_i64 = arith.constant 0 : i64
 // CHECK-NEXT:     %0 = memref.get_global @stv : memref<vector<3xi64>>
 // CHECK-NEXT:     %alloca = memref.alloca() : memref<1xindex>
 // CHECK-NEXT:     %reshape = memref.reshape %0(%alloca) : (memref<vector<3xi64>>, memref<1xindex>) -> memref<1xvector<3xi64>>
 // CHECK-NEXT:     %1 = affine.load %reshape[0] : memref<1xvector<3xi64>>
-// CHECK-NEXT:     %2 = llvm.extractelement %1[%c0_i64 : i64] : vector<3xi64>
+// CHECK-NEXT:     %2 = vector.extract %1[0] : vector<3xi64>
 // CHECK-NEXT:     return %2 : i64
 // CHECK-NEXT:     }
 

--- a/polygeist/tools/cgeist/Test/Verification/vecinit.cl
+++ b/polygeist/tools/cgeist/Test/Verification/vecinit.cl
@@ -1,0 +1,27 @@
+// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+// XFAIL: *
+
+float8 test0(float A, float B, float C, float D,
+             float E, float F, float G, float H) {
+  return (float8)(A, B, C, D, E, F, G, H);
+}
+
+float8 test1(float8 Arg0) {
+  return (float8)(Arg0);
+}
+
+float8 test4(float4 A, float4 B) {
+  return (float8)(A, B);
+}
+
+float8 test5(float4 A, float B, float C, float D, float E) {
+  return (float8)(A, B, C, D, E);
+}
+
+float8 test6(float2 A, float B, float C, float D, float E, float F, float G) {
+  return (float8)(A, B, C, D, E, F, G);
+}
+
+float8 test7(float A, float2 B, float C, float D, float E, float F, float G) {
+  return (float8)(A, B, C, D, E, F, G);
+}

--- a/polygeist/tools/cgeist/Test/Verification/vecinit.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/vecinit.cpp
@@ -56,17 +56,12 @@ float8 test_copy(float8 Arg0) {
 
 // CHECK-LABEL:   func.func @_Z9test_fillffff(
 // CHECK-SAME:                                %[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32, %[[VAL_2:.*]]: f32, %[[VAL_3:.*]]: f32) -> vector<8xf32>
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 0.000000e+00 : f32
-// CHECK-NEXT:      %[[VAL_5:.*]] = arith.constant dense<0.000000e+00> : vector<8xf32>
-// CHECK-NEXT:      %[[VAL_6:.*]] = vector.insert %[[VAL_0]], %[[VAL_5]] [0] : f32 into vector<8xf32>
-// CHECK-NEXT:      %[[VAL_7:.*]] = vector.insert %[[VAL_1]], %[[VAL_6]] [1] : f32 into vector<8xf32>
-// CHECK-NEXT:      %[[VAL_8:.*]] = vector.insert %[[VAL_2]], %[[VAL_7]] [2] : f32 into vector<8xf32>
-// CHECK-NEXT:      %[[VAL_9:.*]] = vector.insert %[[VAL_3]], %[[VAL_8]] [3] : f32 into vector<8xf32>
-// CHECK-NEXT:      %[[VAL_10:.*]] = vector.insert %[[VAL_4]], %[[VAL_9]] [4] : f32 into vector<8xf32>
-// CHECK-NEXT:      %[[VAL_11:.*]] = vector.insert %[[VAL_4]], %[[VAL_10]] [5] : f32 into vector<8xf32>
-// CHECK-NEXT:      %[[VAL_12:.*]] = vector.insert %[[VAL_4]], %[[VAL_11]] [6] : f32 into vector<8xf32>
-// CHECK-NEXT:      %[[VAL_13:.*]] = vector.insert %[[VAL_4]], %[[VAL_12]] [7] : f32 into vector<8xf32>
-// CHECK-NEXT:      return %[[VAL_13]] : vector<8xf32>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant dense<0.000000e+00> : vector<8xf32>
+// CHECK-NEXT:      %[[VAL_5:.*]] = vector.insert %[[VAL_0]], %[[VAL_4]] [0] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_6:.*]] = vector.insert %[[VAL_1]], %[[VAL_5]] [1] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_7:.*]] = vector.insert %[[VAL_2]], %[[VAL_6]] [2] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_8:.*]] = vector.insert %[[VAL_3]], %[[VAL_7]] [3] : f32 into vector<8xf32>
+// CHECK-NEXT:      return %[[VAL_8]] : vector<8xf32>
 // CHECK-NEXT:    }
 float8 test_fill(float A, float B, float C, float D) {
   return {A, B, C, D};
@@ -99,21 +94,16 @@ float8 test_concat(float4 A, float4 B) {
 
 // CHECK-LABEL:   func.func @_Z11test_expandDv4_f(
 // CHECK-SAME:                                    %[[VAL_0:.*]]: vector<4xf32>) -> vector<8xf32>
-// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f32
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<0.000000e+00> : vector<8xf32>
-// CHECK-NEXT:      %[[VAL_3:.*]] = vector.extract %[[VAL_0]][0] : vector<4xf32>
-// CHECK-NEXT:      %[[VAL_4:.*]] = vector.insert %[[VAL_3]], %[[VAL_2]] [0] : f32 into vector<8xf32>
-// CHECK-NEXT:      %[[VAL_5:.*]] = vector.extract %[[VAL_0]][1] : vector<4xf32>
-// CHECK-NEXT:      %[[VAL_6:.*]] = vector.insert %[[VAL_5]], %[[VAL_4]] [1] : f32 into vector<8xf32>
-// CHECK-NEXT:      %[[VAL_7:.*]] = vector.extract %[[VAL_0]][2] : vector<4xf32>
-// CHECK-NEXT:      %[[VAL_8:.*]] = vector.insert %[[VAL_7]], %[[VAL_6]] [2] : f32 into vector<8xf32>
-// CHECK-NEXT:      %[[VAL_9:.*]] = vector.extract %[[VAL_0]][3] : vector<4xf32>
-// CHECK-NEXT:      %[[VAL_10:.*]] = vector.insert %[[VAL_9]], %[[VAL_8]] [3] : f32 into vector<8xf32>
-// CHECK-NEXT:      %[[VAL_11:.*]] = vector.insert %[[VAL_1]], %[[VAL_10]] [4] : f32 into vector<8xf32>
-// CHECK-NEXT:      %[[VAL_12:.*]] = vector.insert %[[VAL_1]], %[[VAL_11]] [5] : f32 into vector<8xf32>
-// CHECK-NEXT:      %[[VAL_13:.*]] = vector.insert %[[VAL_1]], %[[VAL_12]] [6] : f32 into vector<8xf32>
-// CHECK-NEXT:      %[[VAL_14:.*]] = vector.insert %[[VAL_1]], %[[VAL_13]] [7] : f32 into vector<8xf32>
-// CHECK-NEXT:      return %[[VAL_14]] : vector<8xf32>
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant dense<0.000000e+00> : vector<8xf32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = vector.extract %[[VAL_0]][0] : vector<4xf32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = vector.insert %[[VAL_2]], %[[VAL_1]] [0] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_4:.*]] = vector.extract %[[VAL_0]][1] : vector<4xf32>
+// CHECK-NEXT:      %[[VAL_5:.*]] = vector.insert %[[VAL_4]], %[[VAL_3]] [1] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_6:.*]] = vector.extract %[[VAL_0]][2] : vector<4xf32>
+// CHECK-NEXT:      %[[VAL_7:.*]] = vector.insert %[[VAL_6]], %[[VAL_5]] [2] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_8:.*]] = vector.extract %[[VAL_0]][3] : vector<4xf32>
+// CHECK-NEXT:      %[[VAL_9:.*]] = vector.insert %[[VAL_8]], %[[VAL_7]] [3] : f32 into vector<8xf32>
+// CHECK-NEXT:      return %[[VAL_9]] : vector<8xf32>
 // CHECK-NEXT:    }
 float8 test_expand(float4 A) {
   return {A.x, A.y, A.z, A.w};

--- a/polygeist/tools/cgeist/Test/Verification/vecinit.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/vecinit.cpp
@@ -12,7 +12,7 @@ typedef float float8 __attribute__((ext_vector_type(8)));
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.constant 5.000000e+00 : f32
 // CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 6.000000e+00 : f32
 // CHECK-NEXT:      %[[VAL_7:.*]] = arith.constant 7.000000e+00 : f32
-// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.mlir.undef : vector<8xf32>
+// CHECK-NEXT:      %[[VAL_8:.*]] = arith.constant dense<0.000000e+00> : vector<8xf32>
 // CHECK-NEXT:      %[[VAL_9:.*]] = vector.insert %[[VAL_0]], %[[VAL_8]] [0] : f32 into vector<8xf32>
 // CHECK-NEXT:      %[[VAL_10:.*]] = vector.insert %[[VAL_1]], %[[VAL_9]] [1] : f32 into vector<8xf32>
 // CHECK-NEXT:      %[[VAL_11:.*]] = vector.insert %[[VAL_2]], %[[VAL_10]] [2] : f32 into vector<8xf32>
@@ -29,7 +29,7 @@ float8 test_constant() {
 
 // CHECK-LABEL:   func.func @_Z9test_eachffffffff(
 // CHECK-SAME:                                    %[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32, %[[VAL_2:.*]]: f32, %[[VAL_3:.*]]: f32, %[[VAL_4:.*]]: f32, %[[VAL_5:.*]]: f32, %[[VAL_6:.*]]: f32, %[[VAL_7:.*]]: f32) -> vector<8xf32>
-// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.mlir.undef : vector<8xf32>
+// CHECK-NEXT:      %[[VAL_8:.*]] = arith.constant dense<0.000000e+00> : vector<8xf32>
 // CHECK-NEXT:      %[[VAL_9:.*]] = vector.insert %[[VAL_0]], %[[VAL_8]] [0] : f32 into vector<8xf32>
 // CHECK-NEXT:      %[[VAL_10:.*]] = vector.insert %[[VAL_1]], %[[VAL_9]] [1] : f32 into vector<8xf32>
 // CHECK-NEXT:      %[[VAL_11:.*]] = vector.insert %[[VAL_2]], %[[VAL_10]] [2] : f32 into vector<8xf32>
@@ -57,7 +57,7 @@ float8 test_copy(float8 Arg0) {
 // CHECK-LABEL:   func.func @_Z9test_fillffff(
 // CHECK-SAME:                                %[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32, %[[VAL_2:.*]]: f32, %[[VAL_3:.*]]: f32) -> vector<8xf32>
 // CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 0.000000e+00 : f32
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.undef : vector<8xf32>
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.constant dense<0.000000e+00> : vector<8xf32>
 // CHECK-NEXT:      %[[VAL_6:.*]] = vector.insert %[[VAL_0]], %[[VAL_5]] [0] : f32 into vector<8xf32>
 // CHECK-NEXT:      %[[VAL_7:.*]] = vector.insert %[[VAL_1]], %[[VAL_6]] [1] : f32 into vector<8xf32>
 // CHECK-NEXT:      %[[VAL_8:.*]] = vector.insert %[[VAL_2]], %[[VAL_7]] [2] : f32 into vector<8xf32>
@@ -74,7 +74,7 @@ float8 test_fill(float A, float B, float C, float D) {
 
 // CHECK-LABEL:   func.func @_Z11test_concatDv4_fS_(
 // CHECK-SAME:                                      %[[VAL_0:.*]]: vector<4xf32>, %[[VAL_1:.*]]: vector<4xf32>) -> vector<8xf32>
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.undef : vector<8xf32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<0.000000e+00> : vector<8xf32>
 // CHECK-NEXT:      %[[VAL_3:.*]] = vector.extract %[[VAL_0]][0] : vector<4xf32>
 // CHECK-NEXT:      %[[VAL_4:.*]] = vector.insert %[[VAL_3]], %[[VAL_2]] [0] : f32 into vector<8xf32>
 // CHECK-NEXT:      %[[VAL_5:.*]] = vector.extract %[[VAL_0]][1] : vector<4xf32>
@@ -100,7 +100,7 @@ float8 test_concat(float4 A, float4 B) {
 // CHECK-LABEL:   func.func @_Z11test_expandDv4_f(
 // CHECK-SAME:                                    %[[VAL_0:.*]]: vector<4xf32>) -> vector<8xf32>
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f32
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.undef : vector<8xf32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant dense<0.000000e+00> : vector<8xf32>
 // CHECK-NEXT:      %[[VAL_3:.*]] = vector.extract %[[VAL_0]][0] : vector<4xf32>
 // CHECK-NEXT:      %[[VAL_4:.*]] = vector.insert %[[VAL_3]], %[[VAL_2]] [0] : f32 into vector<8xf32>
 // CHECK-NEXT:      %[[VAL_5:.*]] = vector.extract %[[VAL_0]][1] : vector<4xf32>

--- a/polygeist/tools/cgeist/Test/Verification/vecinit.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/vecinit.cpp
@@ -1,0 +1,120 @@
+// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+
+typedef float float4 __attribute__((ext_vector_type(4)));
+typedef float float8 __attribute__((ext_vector_type(8)));
+
+// CHECK-LABEL:   func.func @_Z13test_constantv() -> vector<8xf32>
+// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 1.000000e+00 : f32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 2.000000e+00 : f32
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 3.000000e+00 : f32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 4.000000e+00 : f32
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.constant 5.000000e+00 : f32
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 6.000000e+00 : f32
+// CHECK-NEXT:      %[[VAL_7:.*]] = arith.constant 7.000000e+00 : f32
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.mlir.undef : vector<8xf32>
+// CHECK-NEXT:      %[[VAL_9:.*]] = vector.insert %[[VAL_0]], %[[VAL_8]] [0] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_10:.*]] = vector.insert %[[VAL_1]], %[[VAL_9]] [1] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_11:.*]] = vector.insert %[[VAL_2]], %[[VAL_10]] [2] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_12:.*]] = vector.insert %[[VAL_3]], %[[VAL_11]] [3] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_13:.*]] = vector.insert %[[VAL_4]], %[[VAL_12]] [4] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_14:.*]] = vector.insert %[[VAL_5]], %[[VAL_13]] [5] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_15:.*]] = vector.insert %[[VAL_6]], %[[VAL_14]] [6] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_16:.*]] = vector.insert %[[VAL_7]], %[[VAL_15]] [7] : f32 into vector<8xf32>
+// CHECK-NEXT:      return %[[VAL_16]] : vector<8xf32>
+// CHECK-NEXT:    }
+float8 test_constant() {
+  return {0, 1, 2, 3, 4, 5, 6, 7};
+}
+
+// CHECK-LABEL:   func.func @_Z9test_eachffffffff(
+// CHECK-SAME:                                    %[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32, %[[VAL_2:.*]]: f32, %[[VAL_3:.*]]: f32, %[[VAL_4:.*]]: f32, %[[VAL_5:.*]]: f32, %[[VAL_6:.*]]: f32, %[[VAL_7:.*]]: f32) -> vector<8xf32>
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.mlir.undef : vector<8xf32>
+// CHECK-NEXT:      %[[VAL_9:.*]] = vector.insert %[[VAL_0]], %[[VAL_8]] [0] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_10:.*]] = vector.insert %[[VAL_1]], %[[VAL_9]] [1] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_11:.*]] = vector.insert %[[VAL_2]], %[[VAL_10]] [2] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_12:.*]] = vector.insert %[[VAL_3]], %[[VAL_11]] [3] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_13:.*]] = vector.insert %[[VAL_4]], %[[VAL_12]] [4] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_14:.*]] = vector.insert %[[VAL_5]], %[[VAL_13]] [5] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_15:.*]] = vector.insert %[[VAL_6]], %[[VAL_14]] [6] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_16:.*]] = vector.insert %[[VAL_7]], %[[VAL_15]] [7] : f32 into vector<8xf32>
+// CHECK-NEXT:      return %[[VAL_16]] : vector<8xf32>
+// CHECK-NEXT:    }
+float8 test_each(float A, float B, float C, float D,
+		 float E, float F, float G, float H) {
+  return {A, B, C, D, E, F, G, H};
+}
+
+// CHECK-LABEL:   func.func @_Z9test_copyDv8_f(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: memref<?xvector<8xf32>>) -> vector<8xf32>
+// CHECK-NEXT:      %[[VAL_1:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<8xf32>>
+// CHECK-NEXT:      return %[[VAL_1]] : vector<8xf32>
+// CHECK-NEXT:    }
+float8 test_copy(float8 Arg0) {
+  return {Arg0};
+}
+
+// CHECK-LABEL:   func.func @_Z9test_fillffff(
+// CHECK-SAME:                                %[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32, %[[VAL_2:.*]]: f32, %[[VAL_3:.*]]: f32) -> vector<8xf32>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.undef : vector<8xf32>
+// CHECK-NEXT:      %[[VAL_6:.*]] = vector.insert %[[VAL_0]], %[[VAL_5]] [0] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_7:.*]] = vector.insert %[[VAL_1]], %[[VAL_6]] [1] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_8:.*]] = vector.insert %[[VAL_2]], %[[VAL_7]] [2] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_9:.*]] = vector.insert %[[VAL_3]], %[[VAL_8]] [3] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_10:.*]] = vector.insert %[[VAL_4]], %[[VAL_9]] [4] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_11:.*]] = vector.insert %[[VAL_4]], %[[VAL_10]] [5] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_12:.*]] = vector.insert %[[VAL_4]], %[[VAL_11]] [6] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_13:.*]] = vector.insert %[[VAL_4]], %[[VAL_12]] [7] : f32 into vector<8xf32>
+// CHECK-NEXT:      return %[[VAL_13]] : vector<8xf32>
+// CHECK-NEXT:    }
+float8 test_fill(float A, float B, float C, float D) {
+  return {A, B, C, D};
+}
+
+// CHECK-LABEL:   func.func @_Z11test_concatDv4_fS_(
+// CHECK-SAME:                                      %[[VAL_0:.*]]: vector<4xf32>, %[[VAL_1:.*]]: vector<4xf32>) -> vector<8xf32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.undef : vector<8xf32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = vector.extract %[[VAL_0]][0] : vector<4xf32>
+// CHECK-NEXT:      %[[VAL_4:.*]] = vector.insert %[[VAL_3]], %[[VAL_2]] [0] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_5:.*]] = vector.extract %[[VAL_0]][1] : vector<4xf32>
+// CHECK-NEXT:      %[[VAL_6:.*]] = vector.insert %[[VAL_5]], %[[VAL_4]] [1] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_7:.*]] = vector.extract %[[VAL_0]][2] : vector<4xf32>
+// CHECK-NEXT:      %[[VAL_8:.*]] = vector.insert %[[VAL_7]], %[[VAL_6]] [2] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_9:.*]] = vector.extract %[[VAL_0]][3] : vector<4xf32>
+// CHECK-NEXT:      %[[VAL_10:.*]] = vector.insert %[[VAL_9]], %[[VAL_8]] [3] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_11:.*]] = vector.extract %[[VAL_1]][0] : vector<4xf32>
+// CHECK-NEXT:      %[[VAL_12:.*]] = vector.insert %[[VAL_11]], %[[VAL_10]] [4] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_13:.*]] = vector.extract %[[VAL_1]][1] : vector<4xf32>
+// CHECK-NEXT:      %[[VAL_14:.*]] = vector.insert %[[VAL_13]], %[[VAL_12]] [5] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_15:.*]] = vector.extract %[[VAL_1]][2] : vector<4xf32>
+// CHECK-NEXT:      %[[VAL_16:.*]] = vector.insert %[[VAL_15]], %[[VAL_14]] [6] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_17:.*]] = vector.extract %[[VAL_1]][3] : vector<4xf32>
+// CHECK-NEXT:      %[[VAL_18:.*]] = vector.insert %[[VAL_17]], %[[VAL_16]] [7] : f32 into vector<8xf32>
+// CHECK-NEXT:      return %[[VAL_18]] : vector<8xf32>
+// CHECK-NEXT:    }
+float8 test_concat(float4 A, float4 B) {
+  return {A.x, A.y, A.z, A.w, B.x, B.y, B.z, B.w};
+}
+
+// CHECK-LABEL:   func.func @_Z11test_expandDv4_f(
+// CHECK-SAME:                                    %[[VAL_0:.*]]: vector<4xf32>) -> vector<8xf32>
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.undef : vector<8xf32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = vector.extract %[[VAL_0]][0] : vector<4xf32>
+// CHECK-NEXT:      %[[VAL_4:.*]] = vector.insert %[[VAL_3]], %[[VAL_2]] [0] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_5:.*]] = vector.extract %[[VAL_0]][1] : vector<4xf32>
+// CHECK-NEXT:      %[[VAL_6:.*]] = vector.insert %[[VAL_5]], %[[VAL_4]] [1] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_7:.*]] = vector.extract %[[VAL_0]][2] : vector<4xf32>
+// CHECK-NEXT:      %[[VAL_8:.*]] = vector.insert %[[VAL_7]], %[[VAL_6]] [2] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_9:.*]] = vector.extract %[[VAL_0]][3] : vector<4xf32>
+// CHECK-NEXT:      %[[VAL_10:.*]] = vector.insert %[[VAL_9]], %[[VAL_8]] [3] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_11:.*]] = vector.insert %[[VAL_1]], %[[VAL_10]] [4] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_12:.*]] = vector.insert %[[VAL_1]], %[[VAL_11]] [5] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_13:.*]] = vector.insert %[[VAL_1]], %[[VAL_12]] [6] : f32 into vector<8xf32>
+// CHECK-NEXT:      %[[VAL_14:.*]] = vector.insert %[[VAL_1]], %[[VAL_13]] [7] : f32 into vector<8xf32>
+// CHECK-NEXT:      return %[[VAL_14]] : vector<8xf32>
+// CHECK-NEXT:    }
+float8 test_expand(float4 A) {
+  return {A.x, A.y, A.z, A.w};
+}


### PR DESCRIPTION
Use operations from the vector dialect to initialize vector variables.

Replace `LLVM::ExtractElementOp` usages with `vector::ExtractOp`.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>