### PR TITLE
[SYCL-MLIR] Fix build with clang

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -2636,9 +2636,10 @@ ValueCategory MLIRScanner::EmitCheckedInBoundsPtrOffsetOp(mlir::Type ElemTy,
                      }) &&
          "Expecting indices list");
 
-  if (Optional<Value> NewValue =
-          castSubIndexOpIndex(Builder, Loc, Pointer, IdxList, IsSigned))
-    IdxList = *NewValue;
+  Optional<Value> NewValue =
+      castSubIndexOpIndex(Builder, Loc, Pointer, IdxList, IsSigned);
+  if (NewValue.has_value())
+    IdxList = NewValue.value();
 
   return Pointer.InBoundsGEPOrSubIndex(Builder, Loc, ElemTy, IdxList);
 }


### PR DESCRIPTION
This PR fixes lit failures when building with `clang`.

Since https://github.com/intel/llvm/commit/9ac759f12e5564e23f2720c705ef5e947925997f, when building with `clang`, there are two lit failures:
```
Failed Tests (2):
  cgeist :: Verification/memrefaddassign.cpp
  cgeist :: Verification/ptrarith.c
```
They crash with traceback:
```
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
Stack dump:
0.      Program arguments: /localdisk2/waihungt/llvm/build/bin/cgeist /localdisk2/waihungt/llvm/polygeist/tools/cgeist/Test/Verification/ptrarith.c --function=* -S
1.      <eof> parser at end of file
 #0 0x00007f1836120043 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (/localdisk2/waihungt/llvm/build/bin/../lib/libLLVMSupport.so.16git+0x1e8043)
 #1 0x00007f183611de5e llvm::sys::RunSignalHandlers() (/localdisk2/waihungt/llvm/build/bin/../lib/libLLVMSupport.so.16git+0x1e5e5e)
 #2 0x00007f183612052f SignalHandler(int) Signals.cpp:0:0
 #3 0x00007f1849701b20 __restore_rt sigaction.c:0:0
 #4 0x00000000004d9a6e ValueCategory::SubIndex(mlir::OpBuilder&, mlir::Location, mlir::Type, mlir::Value, bool) const (/localdisk2/waihungt/llvm/build/bin/cgeist+0x4d9a6e)
 #5 0x00000000004da11f ValueCategory::GEPOrSubIndex(mlir::OpBuilder&, mlir::Location, mlir::Type, mlir::ValueRange, bool) const (/localdisk2/waihungt/llvm/build/bin/cgeist+0x4da11f)
 #6 0x00000000004da1bd ValueCategory::InBoundsGEPOrSubIndex(mlir::OpBuilder&, mlir::Location, mlir::Type, mlir::ValueRange) const (/localdisk2/waihungt/llvm/build/bin/cgeist+0x4da1bd)
 #7 0x00000000004b0394 MLIRScanner::EmitCheckedInBoundsPtrOffsetOp(mlir::Type, ValueCategory, mlir::ValueRange, bool, bool) (/localdisk2/waihungt/llvm/build/bin/cgeist+0x4b0394)
```

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>