### PR TITLE
[SYCL-MLIR]: Remove mlir inlining pass

### DIFF
--- a/polygeist/tools/cgeist/Test/Verification/base_with_virt.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/base_with_virt.cpp
@@ -43,6 +43,7 @@ void a() {
 // CHECK:   func @_ZN16mbasic_stringbufC1Ev(%arg0: !llvm.ptr<struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
 // CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)>>) -> !llvm.ptr<struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>>
 // CHECK-NEXT:     call @_ZN1AC1Ev(%0) : (!llvm.ptr<struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>>) -> ()
+// CHECK:          call @_ZN12_Alloc_hiderC1Ev
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK:   func @_ZN1AC1Ev(%arg0: !llvm.ptr<struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {

--- a/polygeist/tools/cgeist/Test/Verification/base_with_virt2.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/base_with_virt2.cpp
@@ -36,9 +36,12 @@ void a() {
 
 // clang-format off
 // CHECK:   func @_Z1av() attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK:          call @_ZN16mbasic_stringbufC1Ev
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK:   func @_ZN16mbasic_stringbufC1Ev(%arg0: !llvm.ptr<struct<(struct<(ptr<ptr<func<i32 (...)>>>)>, struct<(ptr<i8>)>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK:          call @_ZN15basic_streambufC1Ev
+// CHECK:          call @_ZN12_Alloc_hiderC1Ev
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK:   func @_ZN15basic_streambufC1Ev(%arg0: !llvm.ptr<struct<(ptr<ptr<func<i32 (...)>>>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {

--- a/polygeist/tools/cgeist/Test/Verification/classrefmem.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/classrefmem.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
+// RUN: cgeist %s -O0 --function=* -S | FileCheck %s
 
 extern int& moo;
 void oadd(int& x) {
@@ -24,18 +24,11 @@ void Q(A& a) {
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK:   func @_Z1QR1A(%arg0: memref<?x1xmemref<?xi32>>) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:     %0 = affine.load %arg0[0, 0] : memref<?x1xmemref<?xi32>>
-// CHECK-NEXT:     %1 = affine.load %0[0] : memref<?xi32>
-// CHECK-NEXT:     %2 = arith.addi %1, %c1_i32 : i32
-// CHECK-NEXT:     affine.store %2, %0[0] : memref<?xi32>
+// CHECK-NEXT:     call @_ZN1A3addEv(%arg0) : (memref<?x1xmemref<?xi32>>) -> ()
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK:   func @_ZN1A3addEv(%arg0: memref<?x1xmemref<?xi32>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
 // CHECK-NEXT:     %0 = affine.load %arg0[0, 0] : memref<?x1xmemref<?xi32>>
-// CHECK-NEXT:     %1 = affine.load %0[0] : memref<?xi32>
-// CHECK-NEXT:     %2 = arith.addi %1, %c1_i32 : i32
-// CHECK-NEXT:     affine.store %2, %0[0] : memref<?xi32>
+// CHECK-NEXT:     call @_Z4oaddRi(%0) : (memref<?xi32>) -> ()
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }

--- a/polygeist/tools/cgeist/Test/Verification/consabi.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/consabi.cpp
@@ -22,18 +22,13 @@ QStream ilaunch_kernel(QStream x) {
 // CHECK-NEXT:     return %1 : !llvm.struct<(struct<(f64, f64)>, i32)>
 // CHECK-NEXT:   }
 // CHECK-NEXT:   func @_ZN7QStreamC1EOS_(%arg0: !llvm.ptr<struct<(struct<(f64, f64)>, i32)>>, %arg1: !llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.bitcast %arg1 : !llvm.ptr<struct<(struct<(f64, f64)>, i32)>> to !llvm.ptr<f64>
-// CHECK-NEXT:     %1 = llvm.load %0 : !llvm.ptr<f64>
-// CHECK-NEXT:     %2 = llvm.bitcast %arg0 : !llvm.ptr<struct<(struct<(f64, f64)>, i32)>> to !llvm.ptr<f64>
-// CHECK-NEXT:     llvm.store %1, %2 : !llvm.ptr<f64>
-// CHECK-NEXT:     %[[a4:.+]] = llvm.getelementptr %0[1] : (!llvm.ptr<f64>) -> !llvm.ptr<f64>
-// CHECK-NEXT:     %[[a5:.+]] = llvm.load %[[a4]] : !llvm.ptr<f64>
-// CHECK-NEXT:     %[[a7:.+]] = llvm.getelementptr %2[1] : (!llvm.ptr<f64>) -> !llvm.ptr<f64>
-// CHECK-NEXT:     llvm.store %[[a5]], %[[a7]] : !llvm.ptr<f64>
-// CHECK-NEXT:     %[[a8:.+]] = llvm.getelementptr %arg1[0, 1] : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     %[[a9:.+]] = llvm.load %[[a8]] : !llvm.ptr<i32>
-// CHECK-NEXT:     %[[a10:.+]] = llvm.getelementptr %arg0[0, 1] : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     llvm.store %[[a9]], %[[a10]] : !llvm.ptr<i32>
+// CHECK-NEXT:     %0 = "polygeist.pointer2memref"(%arg0) : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> memref<?x2xf64>
+// CHECK-NEXT:     %1 = "polygeist.pointer2memref"(%arg1) : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> memref<?x2xf64>
+// CHECK-NEXT:     call @_ZN1DC1EOS_(%0, %1) : (memref<?x2xf64>, memref<?x2xf64>) -> ()
+// CHECK-NEXT:     %2 = llvm.getelementptr %arg1[0, 1] : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:     %3 = llvm.load %2 : !llvm.ptr<i32>
+// CHECK-NEXT:     %4 = llvm.getelementptr %arg0[0, 1] : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:     llvm.store %3, %4 : !llvm.ptr<i32>
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK-NEXT:   func @_ZN1DC1EOS_(%arg0: memref<?x2xf64>, %arg1: memref<?x2xf64>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {

--- a/polygeist/tools/cgeist/Test/Verification/cudaglobalcodegen.cu
+++ b/polygeist/tools/cgeist/Test/Verification/cudaglobalcodegen.cu
@@ -14,14 +14,19 @@ __global__ void bar(int * a)
 void baz(int * a){
     bar<<<dim3(1,1,1), dim3(1,1,1)>>>(a);
 }
+
 // CHECK:  func private @_Z18__device_stub__barPi(%arg0: memref<?xi32>)
+// CHECK-NEXT:    call @_Z3barPi(%arg0) : (memref<?xi32>) -> ()
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+
+// CHECK:  func.func private @_Z3barPi(%arg0: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT:    %c1_i32 = arith.constant 1 : i32
 // CHECK-NEXT:    affine.store %c1_i32, %arg0[0] : memref<?xi32>
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 // CHECK:  func @_Z3bazPi(%arg0: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:    %c1 = arith.constant 1 : index
-// CHECK-NEXT:    gpu.launch blocks(%arg1, %arg2, %arg3) in (%arg7 = %c1, %arg8 = %c1, %arg9 = %c1) threads(%arg4, %arg5, %arg6) in (%arg10 = %c1, %arg11 = %c1, %arg12 = %c1) {
+// CHECK:         gpu.launch blocks(%arg1, %arg2, %arg3) in (%arg7 = %1, %arg8 = %3, %arg9 = %5) threads(%arg4, %arg5, %arg6) in (%arg10 = %7, %arg11 = %9, %arg12 = %11) {
 // CHECK-NEXT:      call @_Z18__device_stub__barPi(%arg0) : (memref<?xi32>) -> ()
 // CHECK-NEXT:      gpu.terminator
 // CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/ident.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/ident.cpp
@@ -65,9 +65,14 @@ void lt_kernel_cuda(MTensorIterator& iter) {
 // CHECK-NEXT:     return %2 : i8
 // CHECK-NEXT:   }
 // CHECK:   func private @_ZZ14lt_kernel_cudaENK3$_0clEv(%arg0: !llvm.ptr<!llvm.struct<(!llvm.ptr<!llvm.struct<(!llvm.struct<(memref<?x2xi8>)>)>>)>>) attributes {llvm.linkage = #llvm.linkage<internal>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<!llvm.struct<(!llvm.ptr<!llvm.struct<(!llvm.struct<(memref<?x2xi8>)>)>>)>>) -> !llvm.ptr<!llvm.ptr<!llvm.struct<(!llvm.struct<(memref<?x2xi8>)>)>>>
-// CHECK-NEXT:     %1 = llvm.load %0 : !llvm.ptr<!llvm.ptr<!llvm.struct<(!llvm.struct<(memref<?x2xi8>)>)>>>
-// CHECK-NEXT:     %2 = call @_ZNK15MTensorIterator6deviceEv(%1) : (!llvm.ptr<!llvm.struct<(!llvm.struct<(memref<?x2xi8>)>)>>) -> i8
+// CHECK-NEXT:     %c1_i64 = arith.constant 1 : i64
+// CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(i8)> : (i64) -> !llvm.ptr<struct<(i8)>>
+// CHECK-NEXT:     %1 = llvm.alloca %c1_i64 x !llvm.struct<(i8)> : (i64) -> !llvm.ptr<struct<(i8)>>
+// CHECK-NEXT:     %2 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<!llvm.struct<(!llvm.ptr<!llvm.struct<(!llvm.struct<(memref<?x2xi8>)>)>>)>>) -> !llvm.ptr<!llvm.ptr<!llvm.struct<(!llvm.struct<(memref<?x2xi8>)>)>>>
+// CHECK-NEXT:     %3 = llvm.load %2 : !llvm.ptr<!llvm.ptr<!llvm.struct<(!llvm.struct<(memref<?x2xi8>)>)>>>
+// CHECK-NEXT:     %4 = llvm.load %1 : !llvm.ptr<struct<(i8)>>
+// CHECK-NEXT:     llvm.store %4, %0 : !llvm.ptr<struct<(i8)>>
+// CHECK-NEXT:     call @_Z11igpu_kernelIZZ14lt_kernel_cudaENK3$_0clEvEUlvE_EvR15MTensorIteratorRKT_(%3, %0) : (!llvm.ptr<!llvm.struct<(!llvm.struct<(memref<?x2xi8>)>)>>, !llvm.ptr<struct<(i8)>>) -> ()
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK:   func @_ZNK12MSmallVectorI12MOperandInfoEixEi(%arg0: memref<?x1xmemref<?x2xi8>>, %arg1: i32) -> memref<?x2xi8> attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
@@ -76,6 +81,10 @@ void lt_kernel_cuda(MTensorIterator& iter) {
 // CHECK-NEXT:     %2 = "polygeist.subindex"(%0, %1) : (memref<?x2xi8>, index) -> memref<?x2xi8>
 // CHECK-NEXT:     return %2 : memref<?x2xi8>
 // CHECK-NEXT:   }
+// CHECK:  func.func private @_Z11igpu_kernelIZZ14lt_kernel_cudaENK3$_0clEvEUlvE_EvR15MTensorIteratorRKT_(%arg0: !llvm.ptr<!llvm.struct<(!llvm.struct<(memref<?x2xi8>)>)>>, %arg1: !llvm.ptr<struct<(i8)>>) attributes {llvm.linkage = #llvm.linkage<internal>} {
+// CHECK-NEXT:    %0 = call @_ZNK15MTensorIterator6deviceEv(%arg0) : (!llvm.ptr<!llvm.struct<(!llvm.struct<(memref<?x2xi8>)>)>>) -> i8
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
 // CHECK-NEXT:   func @_ZNK15MTensorIterator6deviceEv(%arg0: !llvm.ptr<!llvm.struct<(!llvm.struct<(memref<?x2xi8>)>)>>) -> i8 attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
 // CHECK-NEXT:     %c0_i32 = arith.constant 0 : i32
 // CHECK-NEXT:     %0 = "polygeist.pointer2memref"(%arg0) : (!llvm.ptr<!llvm.struct<(!llvm.struct<(memref<?x2xi8>)>)>>) -> memref<?x1xmemref<?x2xi8>>
@@ -83,4 +92,3 @@ void lt_kernel_cuda(MTensorIterator& iter) {
 // CHECK-NEXT:     %2 = affine.load %1[0, 0] : memref<?x2xi8>
 // CHECK-NEXT:     return %2 : i8
 // CHECK-NEXT:   }
-

--- a/polygeist/tools/cgeist/Test/Verification/no_inline.c
+++ b/polygeist/tools/cgeist/Test/Verification/no_inline.c
@@ -11,7 +11,7 @@ void foo(int A[10]) {
 // CHECK-LABEL: func @main()
 // CHECK: call @foo
 // OPT1-LABEL: func @main()
-// OPT1-NOT: call @foo
+// OPT1-CHECK: call @foo
 int main() {
   int A[10];
   foo(A);

--- a/polygeist/tools/cgeist/Test/Verification/no_inline.c
+++ b/polygeist/tools/cgeist/Test/Verification/no_inline.c
@@ -11,7 +11,7 @@ void foo(int A[10]) {
 // CHECK-LABEL: func @main()
 // CHECK: call @foo
 // OPT1-LABEL: func @main()
-// OPT1-CHECK: call @foo
+// OPT1: call @foo
 int main() {
   int A[10];
   foo(A);

--- a/polygeist/tools/cgeist/Test/Verification/refptrabi.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/refptrabi.cpp
@@ -18,10 +18,13 @@ float ll(void* data) {
 
 // CHECK:   func @ll(%arg0: !llvm.ptr<i8>) -> f32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT:     %alloca = memref.alloca() : memref<1x1xi16>
-// CHECK-NEXT:     %0 = llvm.bitcast %arg0 : !llvm.ptr<i8> to !llvm.ptr<i16>
-// CHECK-NEXT:     %1 = llvm.load %0 : !llvm.ptr<i16>
+// CHECK-NEXT:     %alloca_0 = memref.alloca() : memref<1x1xi16>
+// CHECK-NEXT:     %cast = memref.cast %alloca_0 : memref<1x1xi16> to memref<?x1xi16>
+// CHECK-NEXT:     %0 = "polygeist.pointer2memref"(%arg0) : (!llvm.ptr<i8>) -> memref<?x1xi16>
+// CHECK-NEXT:     call @_ZN4HalfC1ERKS_(%cast, %0) : (memref<?x1xi16>, memref<?x1xi16>) -> ()
+// CHECK-NEXT:     %1 = affine.load %alloca_0[0, 0] : memref<1x1xi16>
 // CHECK-NEXT:     affine.store %1, %alloca[0, 0] : memref<1x1xi16>
-// CHECK-NEXT:     %cast = memref.cast %alloca : memref<1x1xi16> to memref<?x1xi16>
-// CHECK-NEXT:     %2 = call @thing(%cast) : (memref<?x1xi16>) -> f32
+// CHECK-NEXT:     %cast_1 = memref.cast %alloca : memref<1x1xi16> to memref<?x1xi16>
+// CHECK-NEXT:     %2 = call @thing(%cast_1) : (memref<?x1xi16>) -> f32
 // CHECK-NEXT:     return %2 : f32
 // CHECK-NEXT:   }

--- a/polygeist/tools/cgeist/Test/Verification/stream.cu
+++ b/polygeist/tools/cgeist/Test/Verification/stream.cu
@@ -14,11 +14,7 @@ void run(cudaStream_t stream1, int *array, int n) {
 }
 
 // CHECK:   func.func @_Z3runP10cudaStreamPii(%arg0: !llvm.ptr<struct<()>>, %arg1: memref<?xi32>, %arg2: i32) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %c10 = arith.constant 10 : index
-// CHECK-NEXT:     %c1 = arith.constant 1 : index
-// CHECK-NEXT:     %c20 = arith.constant 20 : index
-// CHECK-NEXT:     %0 = "polygeist.stream2token"(%arg0) : (!llvm.ptr<struct<()>>) -> !gpu.async.token
-// CHECK-NEXT:     %1 = gpu.launch async [%0] blocks(%arg3, %arg4, %arg5) in (%arg9 = %c10, %arg10 = %c1, %arg11 = %c1) threads(%arg6, %arg7, %arg8) in (%arg12 = %c20, %arg13 = %c1, %arg14 = %c1) {
+// CHECK:          %13 = gpu.launch async [%12] blocks(%arg3, %arg4, %arg5) in (%arg9 = %1, %arg10 = %3, %arg11 = %5) threads(%arg6, %arg7, %arg8) in (%arg12 = %7, %arg13 = %9, %arg14 = %11) {
 // CHECK-NEXT:       func.call @_Z21__device_stub__squarePii(%arg1, %arg2) : (memref<?xi32>, i32) -> ()
 // CHECK-NEXT:       gpu.terminator
 // CHECK-NEXT:     }

--- a/polygeist/tools/cgeist/Test/Verification/stream.cu
+++ b/polygeist/tools/cgeist/Test/Verification/stream.cu
@@ -14,8 +14,8 @@ void run(cudaStream_t stream1, int *array, int n) {
 }
 
 // CHECK:   func.func @_Z3runP10cudaStreamPii(%arg0: !llvm.ptr<struct<()>>, %arg1: memref<?xi32>, %arg2: i32) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK:          %12 = "polygeist.stream2token"(%arg0) : (!llvm.ptr<struct<()>>) -> !gpu.async.token
-// CHECK-NEXT:          %13 = gpu.launch async [%12] blocks(%arg3, %arg4, %arg5) in (%arg9 = %1, %arg10 = %3, %arg11 = %5) threads(%arg6, %arg7, %arg8) in (%arg12 = %7, %arg13 = %9, %arg14 = %11) {
+// CHECK:       %12 = "polygeist.stream2token"(%arg0) : (!llvm.ptr<struct<()>>) -> !gpu.async.token
+// CHECK-NEXT:       %13 = gpu.launch async [%12] blocks(%arg3, %arg4, %arg5) in (%arg9 = %1, %arg10 = %3, %arg11 = %5) threads(%arg6, %arg7, %arg8) in (%arg12 = %7, %arg13 = %9, %arg14 = %11) {
 // CHECK-NEXT:       func.call @_Z21__device_stub__squarePii(%arg1, %arg2) : (memref<?xi32>, i32) -> ()
 // CHECK-NEXT:       gpu.terminator
 // CHECK-NEXT:     }

--- a/polygeist/tools/cgeist/Test/Verification/stream.cu
+++ b/polygeist/tools/cgeist/Test/Verification/stream.cu
@@ -14,8 +14,8 @@ void run(cudaStream_t stream1, int *array, int n) {
 }
 
 // CHECK:   func.func @_Z3runP10cudaStreamPii(%arg0: !llvm.ptr<struct<()>>, %arg1: memref<?xi32>, %arg2: i32) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK:       %12 = "polygeist.stream2token"(%arg0) : (!llvm.ptr<struct<()>>) -> !gpu.async.token
-// CHECK-NEXT:       %13 = gpu.launch async [%12] blocks(%arg3, %arg4, %arg5) in (%arg9 = %1, %arg10 = %3, %arg11 = %5) threads(%arg6, %arg7, %arg8) in (%arg12 = %7, %arg13 = %9, %arg14 = %11) {
+// CHECK:          %12 = "polygeist.stream2token"(%arg0) : (!llvm.ptr<struct<()>>) -> !gpu.async.token
+// CHECK-NEXT:     %13 = gpu.launch async [%12] blocks(%arg3, %arg4, %arg5) in (%arg9 = %1, %arg10 = %3, %arg11 = %5) threads(%arg6, %arg7, %arg8) in (%arg12 = %7, %arg13 = %9, %arg14 = %11) {
 // CHECK-NEXT:       func.call @_Z21__device_stub__squarePii(%arg1, %arg2) : (memref<?xi32>, i32) -> ()
 // CHECK-NEXT:       gpu.terminator
 // CHECK-NEXT:     }

--- a/polygeist/tools/cgeist/Test/Verification/stream.cu
+++ b/polygeist/tools/cgeist/Test/Verification/stream.cu
@@ -14,7 +14,8 @@ void run(cudaStream_t stream1, int *array, int n) {
 }
 
 // CHECK:   func.func @_Z3runP10cudaStreamPii(%arg0: !llvm.ptr<struct<()>>, %arg1: memref<?xi32>, %arg2: i32) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK:          %13 = gpu.launch async [%12] blocks(%arg3, %arg4, %arg5) in (%arg9 = %1, %arg10 = %3, %arg11 = %5) threads(%arg6, %arg7, %arg8) in (%arg12 = %7, %arg13 = %9, %arg14 = %11) {
+// CHECK:          %12 = "polygeist.stream2token"(%arg0) : (!llvm.ptr<struct<()>>) -> !gpu.async.token
+// CHECK-NEXT:          %13 = gpu.launch async [%12] blocks(%arg3, %arg4, %arg5) in (%arg9 = %1, %arg10 = %3, %arg11 = %5) threads(%arg6, %arg7, %arg8) in (%arg12 = %7, %arg13 = %9, %arg14 = %11) {
 // CHECK-NEXT:       func.call @_Z21__device_stub__squarePii(%arg1, %arg2) : (memref<?xi32>, i32) -> ()
 // CHECK-NEXT:       gpu.terminator
 // CHECK-NEXT:     }

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -346,7 +346,7 @@ static int optimize(mlir::MLIRContext &context,
     if (RaiseToAffine)
       optPM.addPass(mlir::createLowerAffinePass());
     optPM.addPass(mlir::createCanonicalizerPass(canonicalizerConfig, {}, {}));
-    pm.addPass(mlir::createInlinerPass());
+
     mlir::OpPassManager &optPM2 = pm.nestAny();
     optPM2.addPass(mlir::createCanonicalizerPass(canonicalizerConfig, {}, {}));
     optPM2.addPass(mlir::createCSEPass());
@@ -407,7 +407,7 @@ static int optimizeCUDA(mlir::MLIRContext &context,
   noptPM.addPass(mlir::createCanonicalizerPass(canonicalizerConfig, {}, {}));
   noptPM.addPass(polygeist::createMem2RegPass());
   noptPM.addPass(mlir::createCanonicalizerPass(canonicalizerConfig, {}, {}));
-  pm.addPass(mlir::createInlinerPass());
+
   mlir::OpPassManager &noptPM2 = pm.nestAny();
   noptPM.addPass(mlir::createCanonicalizerPass(canonicalizerConfig, {}, {}));
   noptPM2.addPass(polygeist::createMem2RegPass());


### PR DESCRIPTION
`cgeist` uses the stock MLIR inlining pass in its pass pipeline. The MLIR inlining pass has no heuristic and is essentially a greedy inliner, that is, as long as callees do not contain any operation deemed illegal for inlining by their dialects, it inlines all callees irrespective of any cost considerations (size, hotness, etc...).

Without a proper cost model, the MLIR inlining pass is not useful to our use case. This PR removes the inlining pass from the cgeist mlir pass pipeline and adjust test cases accordingly. 