### PR TITLE
[SYCL-MLIR] Allow accessing vector elements using array subscripts

### DIFF
--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -781,6 +781,14 @@ ValueCategory ValueCategory::Extract(OpBuilder &Builder, Location Loc,
   return {Builder.createOrFold<vector::ExtractOp>(Loc, val, Indices), false};
 }
 
+ValueCategory ValueCategory::ExtractElement(OpBuilder &Builder, Location Loc,
+                                            Value Idx) const {
+  assert(Idx.getType().isa<IntegerType>() && "Index must be an integer");
+  assert(val.getType().isa<VectorType>() && "Expecting vector type");
+
+  return {Builder.createOrFold<vector::ExtractElementOp>(Loc, val, Idx), false};
+}
+
 ValueCategory ValueCategory::Shuffle(OpBuilder &Builder, Location Loc, Value V2,
                                      llvm::ArrayRef<int64_t> Indices) const {
   assert(val.getType().isa<VectorType>() && "Expecting vector type");

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -157,6 +157,8 @@ public:
                        mlir::Value V, llvm::ArrayRef<int64_t> Indices) const;
   ValueCategory Extract(mlir::OpBuilder &Builder, mlir::Location Loc,
                         llvm::ArrayRef<int64_t> Indices) const;
+  ValueCategory ExtractElement(mlir::OpBuilder &Builder, mlir::Location Loc,
+                               mlir::Value Idx) const;
   ValueCategory Shuffle(mlir::OpBuilder &Builder, mlir::Location Loc,
                         mlir::Value V2, llvm::ArrayRef<int64_t> Indices) const;
   ValueCategory Reshape(mlir::OpBuilder &Builder, mlir::Location Loc,

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -373,6 +373,7 @@ private:
                                      clang::QualType SrcType);
   ValueCategory EmitVectorInitList(clang::InitListExpr *Expr,
                                    mlir::VectorType VType);
+  ValueCategory EmitVectorSubscript(clang::ArraySubscriptExpr *Expr);
 
 public:
   MLIRScanner(MLIRASTConsumer &Glob, mlir::OwningOpRef<mlir::ModuleOp> &Module,

--- a/polygeist/tools/cgeist/Test/Verification/vecaccess.c
+++ b/polygeist/tools/cgeist/Test/Verification/vecaccess.c
@@ -1,0 +1,23 @@
+// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+
+typedef int int_vec __attribute__((ext_vector_type(3)));
+
+// CHECK-LABEL:   func.func @test_cons_idx(
+// CHECK-SAME:                             %[[VAL_0:.*]]: vector<3xi32>) -> i32
+// CHECK:           %[[VAL_1:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_2:.*]] = vector.extractelement %[[VAL_0]]{{\[}}%[[VAL_1]] : i32] : vector<3xi32>
+// CHECK:           return %[[VAL_2]] : i32
+// CHECK:         }
+int test_cons_idx(int_vec v) {
+  return v[0];
+}
+
+// CHECK-LABEL:   func.func @test_var_idx(
+// CHECK-SAME:                    %[[VAL_0:.*]]: vector<3xi32>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> i32
+// CHECK:           %[[VAL_2:.*]] = vector.extractelement %[[VAL_0]]{{\[}}%[[VAL_1]] : i32] : vector<3xi32>
+// CHECK:           return %[[VAL_2]] : i32
+// CHECK:         }
+int test_var_idx(int_vec v, unsigned i) {
+  return v[i];
+}


### PR DESCRIPTION
Use vector.extractelement to obtain elements of a vector.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>