### PR TITLE
[SYCL][CUDA] ext_oneapi_cuda make_device no longer duplicates sycl::device

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/backend/cuda.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/backend/cuda.hpp
@@ -69,6 +69,13 @@ interop_handle::get_native_context<backend::ext_oneapi_cuda>() const {
 template <>
 inline device make_device<backend::ext_oneapi_cuda>(
     const backend_input_t<backend::ext_oneapi_cuda, device> &BackendObject) {
+  auto devs = device::get_devices(info::device_type::gpu);
+  for (auto &dev : devs) {
+    if (dev.get_backend() == backend::ext_oneapi_cuda &&
+        BackendObject == get_native<backend::ext_oneapi_cuda>(dev)) {
+      return dev;
+    }
+  }
   pi_native_handle NativeHandle = static_cast<pi_native_handle>(BackendObject);
   return ext::oneapi::cuda::make_device(NativeHandle);
 }


### PR DESCRIPTION
Fixes https://github.com/intel/llvm/issues/6055 for ext_oneapi_cuda backend.

Tested with https://github.com/intel/llvm-test-suite/pull/1419.

Signed-off-by: JackAKirk <jack.kirk@codeplay.com>