### PR TITLE
[SYCL-MLIR] Add calling convention to callsite

### DIFF
--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -81,9 +81,9 @@
 // CHECK-LLVM-DAG: [[RANGE:%.*]] = alloca [[RANGE_TYPE]]
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE]]
 // CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID]] to [[ID_TYPE]] addrspace(4)*
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi1EEC1ERKS2_([[ID_TYPE]] addrspace(4)* [[ID1_AS]], 
+// CHECK-LLVM: call spir_func void @_ZN4sycl3_V12idILi1EEC1ERKS2_([[ID_TYPE]] addrspace(4)* [[ID1_AS]], 
 // CHECK-LLVM: [[RANGE1_AS:%.*]] = addrspacecast [[RANGE_TYPE]]* [[RANGE]] to [[RANGE_TYPE]] addrspace(4)*
-// CHECK-LLVM: call void @_ZN4sycl3_V15rangeILi1EEC1ERKS2_([[RANGE_TYPE]] addrspace(4)* [[RANGE1_AS]],
+// CHECK-LLVM: call spir_func void @_ZN4sycl3_V15rangeILi1EEC1ERKS2_([[RANGE_TYPE]] addrspace(4)* [[RANGE1_AS]],
 
 extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
   auto id = sycl::id<1>{i};
@@ -110,7 +110,7 @@ extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
 // CHECK-LLVM: [[CAST1:%.*]] = bitcast [[ID_TYPE]]* %1 to i8*
 // CHECK-LLVM: call void @llvm.memset.p0i8.i64(i8* %2, i8 0, i64 16, i1 false)
 // CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID1]] to [[ID_TYPE]] addrspace(4)*
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1Ev([[ID_TYPE]] addrspace(4)* [[ID1_AS]])  
+// CHECK-LLVM: call spir_func void @_ZN4sycl3_V12idILi2EEC1Ev([[ID_TYPE]] addrspace(4)* [[ID1_AS]])  
 
 extern "C" SYCL_EXTERNAL void cons_1() {
   auto id = sycl::id<2>{};
@@ -128,7 +128,7 @@ extern "C" SYCL_EXTERNAL void cons_1() {
 // CHECK-LLVM-SAME:  #[[FUNCATTRS]]
 // CHECK-LLVM: [[ID1:%.*]] = alloca [[ID_TYPE:%"class.sycl::_V1::id.2"]]
 // CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID1]] to [[ID_TYPE]] addrspace(4)*
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm([[ID_TYPE]] addrspace(4)* [[ID1_AS]], i64 %0, i64 %1)
+// CHECK-LLVM: call spir_func void @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm([[ID_TYPE]] addrspace(4)* [[ID1_AS]], i64 %0, i64 %1)
 
 extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
   auto id = sycl::id<2>{a, b};
@@ -149,7 +149,7 @@ extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE:%"class.sycl::_V1::id.2"]]  
 // CHECK-LLVM: [[ID_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID]] to [[ID_TYPE]] addrspace(4)*
 // CHECK-LLVM: [[ITEM_AS:%.*]] = addrspacecast [[ITEM_TYPE]]* [[ARG0]] to [[ITEM_TYPE]] addrspace(4)*
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE([[ID_TYPE]] addrspace(4)* [[ID_AS]], [[ITEM_TYPE]] addrspace(4)* [[ITEM_AS]])
+// CHECK-LLVM: call spir_func void @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE([[ID_TYPE]] addrspace(4)* [[ID_AS]], [[ITEM_TYPE]] addrspace(4)* [[ITEM_AS]])
 
 extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
   auto id = sycl::id<2>{val};
@@ -170,7 +170,7 @@ extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE]]
 // CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID]] to [[ID_TYPE]] addrspace(4)*
 // CHECK-LLVM: [[ID2_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ARG0]] to [[ID_TYPE]] addrspace(4)*
-// CHECK-LLVM: call void @_ZN4sycl3_V12idILi2EEC1ERKS2_([[ID_TYPE]] addrspace(4)* [[ID1_AS]], [[ID_TYPE]] addrspace(4)* [[ID2_AS]])
+// CHECK-LLVM: call spir_func void @_ZN4sycl3_V12idILi2EEC1ERKS2_([[ID_TYPE]] addrspace(4)* [[ID1_AS]], [[ID_TYPE]] addrspace(4)* [[ID2_AS]])
 
 extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
   auto id = sycl::id<2>{val};
@@ -185,7 +185,7 @@ extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
 // CHECK-LLVM-SAME:  #[[FUNCATTRS]]
 // CHECK-LLVM: [[ACCESSOR:%.*]] = alloca %"class.sycl::_V1::accessor.1", align 8
 // CHECK-LLVM: [[ACAST:%.*]] = addrspacecast %"class.sycl::_V1::accessor.1"* [[ACCESSOR]] to %"class.sycl::_V1::accessor.1" addrspace(4)*
-// CHECK-LLVM: call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]])
+// CHECK-LLVM: call spir_func void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]])
 
 extern "C" SYCL_EXTERNAL void cons_5() {
   auto accessor = sycl::accessor<sycl::cl_int, 1, sycl::access::mode::write>{};

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -41,7 +41,7 @@ template <typename T> SYCL_EXTERNAL void keep(T);
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_0N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEENS0_2idILi2EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0, %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %1) #[[FUNCATTRS:[0-9]+]]
-// CHECK-LLVM:  %{{.*}} = call i32 addrspace(4)* @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE(%"class.sycl::_V1::accessor.2" addrspace(4)* %{{.*}}, %"class.sycl::_V1::id.2"* %{{.*}})
+// CHECK-LLVM:  %{{.*}} = call spir_func i32 addrspace(4)* @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE(%"class.sycl::_V1::accessor.2" addrspace(4)* %{{.*}}, %"class.sycl::_V1::id.2"* %{{.*}})
 
 SYCL_EXTERNAL void accessor_subscript_operator_0(sycl::accessor<sycl::cl_int, 2> acc, sycl::id<2> index) {
   keep(acc[index]);
@@ -53,7 +53,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_0(sycl::accessor<sycl::cl_int, 2>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_1N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0, i64 noundef %1) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::detail::accessor_common.AccessorSubscript.1" @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEEDam(%"class.sycl::_V1::accessor.2" addrspace(4)* %{{.*}}, i64 %1)
+// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::detail::accessor_common.AccessorSubscript.1" @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEEDam(%"class.sycl::_V1::accessor.2" addrspace(4)* %{{.*}}, i64 %1)
 
 SYCL_EXTERNAL void accessor_subscript_operator_1(sycl::accessor<sycl::cl_int, 2> acc, size_t index) {
   keep(acc[index]);
@@ -66,7 +66,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_1(sycl::accessor<sycl::cl_int, 2>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_2N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-LLVM:           %"class.sycl::_V1::accessor.1"* noundef byval(%"class.sycl::_V1::accessor.1") align 8 %0, i64 noundef %1) #[[FUNCATTRS]]  
-// CHECK-LLVM:  %{{.*}} = call i32 addrspace(4)* @_ZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERiNS0_2idILi1EEE(%"class.sycl::_V1::accessor.1" addrspace(4)* %{{.*}}, %"class.sycl::_V1::id.1"* %{{.*}})
+// CHECK-LLVM:  %{{.*}} = call spir_func i32 addrspace(4)* @_ZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERiNS0_2idILi1EEE(%"class.sycl::_V1::accessor.1" addrspace(4)* %{{.*}}, %"class.sycl::_V1::id.1"* %{{.*}})
 
 SYCL_EXTERNAL void accessor_subscript_operator_2(sycl::accessor<sycl::cl_int, 1> acc, size_t index) {
   keep(acc[index]);
@@ -79,7 +79,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_2(sycl::accessor<sycl::cl_int, 1>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z11range_get_0N4sycl3_V15rangeILi2EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #[[FUNCATTRS]] 
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V16detail5arrayILi2EE3getEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %{{.*}}, i32 %1)
+// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V16detail5arrayILi2EE3getEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void range_get_0(sycl::range<2> r, int dimension) {
   keep(r.get(dimension));
@@ -92,7 +92,7 @@ SYCL_EXTERNAL void range_get_0(sycl::range<2> r, int dimension) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z11range_get_1N4sycl3_V15rangeILi2EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]   
-// CHECK-LLVM: %{{.*}} = call i64 addrspace(4)* @_ZN4sycl3_V16detail5arrayILi2EEixEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %{{.*}}, i32 %1)
+// CHECK-LLVM: %{{.*}} = call spir_func i64 addrspace(4)* @_ZN4sycl3_V16detail5arrayILi2EEixEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void range_get_1(sycl::range<2> r, int dimension) {
   keep(r[dimension]);
@@ -105,7 +105,7 @@ SYCL_EXTERNAL void range_get_1(sycl::range<2> r, int dimension) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z11range_get_2N4sycl3_V15rangeILi2EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]     
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V16detail5arrayILi2EEixEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %{{.*}}, i32 %1)
+// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V16detail5arrayILi2EEixEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void range_get_2(const sycl::range<2> r, int dimension) {
   keep(r[dimension]);
@@ -117,7 +117,7 @@ SYCL_EXTERNAL void range_get_2(const sycl::range<2> r, int dimension) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z10range_sizeN4sycl3_V15rangeILi2EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0) #[[FUNCATTRS]]       
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15rangeILi2EE4sizeEv(%"class.sycl::_V1::range.2" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15rangeILi2EE4sizeEv(%"class.sycl::_V1::range.2" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void range_size(sycl::range<2> r) {
   keep(r.size());
@@ -141,13 +141,13 @@ SYCL_EXTERNAL void range_size(sycl::range<2> r) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_range_get_global_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #[[FUNCATTRS]]  
-// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* %{{.*}})
 
 // CHECK-LLVM: define linkonce_odr spir_func %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* noundef align 8 [[VAL_0:%.*]]) #1 {
 // CHECK-LLVM-NEXT:   [[VAL_2:%.*]] = alloca %"class.sycl::_V1::range.2", align 8
 // CHECK-LLVM-NEXT:   [[VAL_3:%.*]]  = addrspacecast %"class.sycl::_V1::range.2"* [[VAL_2]] to %"class.sycl::_V1::range.2" addrspace(4)*
 // CHECK-LLVM-NEXT:   [[VAL_4:%.*]]  = bitcast %"class.sycl::_V1::nd_range.2" addrspace(4)* [[VAL_0]] to %"class.sycl::_V1::range.2" addrspace(4)*
-// CHECK-LLVM-NEXT:   call void @_ZN4sycl3_V15rangeILi2EEC1ERKS2_(%"class.sycl::_V1::range.2" addrspace(4)* [[VAL_3]], %"class.sycl::_V1::range.2" addrspace(4)* [[VAL_4]])
+// CHECK-LLVM-NEXT:   call spir_func void @_ZN4sycl3_V15rangeILi2EEC1ERKS2_(%"class.sycl::_V1::range.2" addrspace(4)* [[VAL_3]], %"class.sycl::_V1::range.2" addrspace(4)* [[VAL_4]])
 // CHECK-LLVM-NEXT:   [[VAL_5:%.*]]  = load %"class.sycl::_V1::range.2", %"class.sycl::_V1::range.2"* [[VAL_2]], align 8
 // CHECK-LLVM-NEXT:   ret %"class.sycl::_V1::range.2" [[VAL_5]] 
 // CHECK-LLVM-NEXT: }
@@ -162,7 +162,7 @@ SYCL_EXTERNAL void nd_range_get_global_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z24nd_range_get_local_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE15get_local_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE15get_local_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_range_get_local_range(sycl::nd_range<2> nd_range) {
   keep(nd_range.get_local_range());
@@ -174,7 +174,7 @@ SYCL_EXTERNAL void nd_range_get_local_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z24nd_range_get_group_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #[[FUNCATTRS]]  
-// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE15get_group_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE15get_group_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_range_get_group_range(sycl::nd_range<2> nd_range) {
   keep(nd_range.get_group_range());
@@ -186,7 +186,7 @@ SYCL_EXTERNAL void nd_range_get_group_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_0N4sycl3_V12idILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V16detail5arrayILi1EE3getEi(%"class.sycl::_V1::detail::array.1" addrspace(4)* %{{.*}}, i32 %1)
+// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V16detail5arrayILi1EE3getEi(%"class.sycl::_V1::detail::array.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void id_get_0(sycl::id<1> id, int dimension) {
   keep(id.get(dimension));
@@ -198,7 +198,7 @@ SYCL_EXTERNAL void id_get_0(sycl::id<1> id, int dimension) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_1N4sycl3_V12idILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]  
-// CHECK-LLVM: %{{.*}} = call i64 addrspace(4)* @_ZN4sycl3_V16detail5arrayILi1EEixEi(%"class.sycl::_V1::detail::array.1" addrspace(4)* %{{.*}}, i32 %1)
+// CHECK-LLVM: %{{.*}} = call spir_func i64 addrspace(4)* @_ZN4sycl3_V16detail5arrayILi1EEixEi(%"class.sycl::_V1::detail::array.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void id_get_1(sycl::id<1> id, int dimension) {
   keep(id[dimension]);
@@ -210,7 +210,7 @@ SYCL_EXTERNAL void id_get_1(sycl::id<1> id, int dimension) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_2N4sycl3_V12idILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]    
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V16detail5arrayILi1EEixEi(%"class.sycl::_V1::detail::array.1" addrspace(4)* %{{.*}}, i32 %1)
+// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V16detail5arrayILi1EEixEi(%"class.sycl::_V1::detail::array.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void id_get_2(const sycl::id<1> id, int dimension) {
   keep(id[dimension]);
@@ -230,7 +230,7 @@ SYCL_EXTERNAL void id_get_3(sycl::id<1> id) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::id.1" @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::id.1" @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void item_get_id_0(sycl::item<1> item) {
   keep(item.get_id());
@@ -258,7 +258,7 @@ SYCL_EXTERNAL void item_get_id_2(sycl::item<1> item, int dimension) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_3N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]  
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V14itemILi1ELb1EEcvmEv(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V14itemILi1ELb1EEcvmEv(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void item_get_id_3(sycl::item<1> item) {
   keep(static_cast<size_t>(item));
@@ -270,7 +270,7 @@ SYCL_EXTERNAL void item_get_id_3(sycl::item<1> item) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z16item_get_range_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]    
-// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEv(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.1" @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEv(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void item_get_range_0(sycl::item<1> item) {
   keep(item.get_range());
@@ -298,7 +298,7 @@ SYCL_EXTERNAL void item_get_linear_id(sycl::item<1> item) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23nd_item_get_global_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::id.1" @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::id.1" @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_global_id_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_global_id());
@@ -326,7 +326,7 @@ SYCL_EXTERNAL void nd_item_get_global_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z22nd_item_get_local_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]  
-// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::id.1" @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::id.1" @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_local_id_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_local_id());
@@ -346,7 +346,7 @@ SYCL_EXTERNAL void nd_item_get_local_id_1(sycl::nd_item<1> nd_item, int dimensio
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z27nd_item_get_local_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]    
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE19get_local_linear_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V17nd_itemILi1EE19get_local_linear_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_local_linear_id(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_local_linear_id());
@@ -358,7 +358,7 @@ SYCL_EXTERNAL void nd_item_get_local_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z19nd_item_get_group_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]      
-// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::group.1" @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::group.1" @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_group_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_group());
@@ -386,7 +386,7 @@ SYCL_EXTERNAL void nd_item_get_group_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_group_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]        
-// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.1" @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_group_range_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_group_range());
@@ -406,7 +406,7 @@ SYCL_EXTERNAL void nd_item_get_group_range_1(sycl::nd_item<1> nd_item, int dimen
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z26nd_item_get_global_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.1" @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_global_range_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_global_range());
@@ -418,7 +418,7 @@ SYCL_EXTERNAL void nd_item_get_global_range_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z26nd_item_get_global_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]      
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
+// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void nd_item_get_global_range_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_global_range(dimension));
@@ -430,7 +430,7 @@ SYCL_EXTERNAL void nd_item_get_global_range_1(sycl::nd_item<1> nd_item, int dime
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_local_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.1" @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_local_range_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_local_range());
@@ -442,7 +442,7 @@ SYCL_EXTERNAL void nd_item_get_local_range_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_local_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]        
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
+// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void nd_item_get_local_range_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_local_range(dimension));
@@ -454,7 +454,7 @@ SYCL_EXTERNAL void nd_item_get_local_range_1(sycl::nd_item<1> nd_item, int dimen
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20nd_item_get_nd_rangeN4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]          
-// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::nd_range.1" @_ZNK4sycl3_V17nd_itemILi1EE12get_nd_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::nd_range.1" @_ZNK4sycl3_V17nd_itemILi1EE12get_nd_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_nd_range(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_nd_range());
@@ -466,7 +466,7 @@ SYCL_EXTERNAL void nd_item_get_nd_range(sycl::nd_item<1> nd_item) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_0N4sycl3_V15groupILi1EEE(
 
-// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::id.1" @_ZNK4sycl3_V15groupILi1EE12get_group_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::id.1" @_ZNK4sycl3_V15groupILi1EE12get_group_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_group_id_0(sycl::group<1> group) {
   keep(group.get_group_id());
@@ -478,7 +478,7 @@ SYCL_EXTERNAL void group_get_group_id_0(sycl::group<1> group) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_1N4sycl3_V15groupILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE12get_group_idEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
+// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15groupILi1EE12get_group_idEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void group_get_group_id_1(sycl::group<1> group, int dimension) {
   keep(group.get_group_id(dimension));
@@ -490,7 +490,7 @@ SYCL_EXTERNAL void group_get_group_id_1(sycl::group<1> group, int dimension) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_2N4sycl3_V15groupILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EEixEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
+// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15groupILi1EEixEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void group_get_group_id_2(sycl::group<1> group, int dimension) {
   keep(group[dimension]);
@@ -502,7 +502,7 @@ SYCL_EXTERNAL void group_get_group_id_2(sycl::group<1> group, int dimension) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_local_id_0N4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]   
-// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::id.1" @_ZNK4sycl3_V15groupILi1EE12get_local_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::id.1" @_ZNK4sycl3_V15groupILi1EE12get_local_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_local_id_0(sycl::group<1> group) {
   keep(group.get_local_id());
@@ -514,7 +514,7 @@ SYCL_EXTERNAL void group_get_local_id_0(sycl::group<1> group) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_local_id_1N4sycl3_V15groupILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]  
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE12get_local_idEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
+// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15groupILi1EE12get_local_idEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void group_get_local_id_1(sycl::group<1> group, int dimension) {
   keep(group.get_local_id(dimension));
@@ -526,7 +526,7 @@ SYCL_EXTERNAL void group_get_local_id_1(sycl::group<1> group, int dimension) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_local_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]     
-// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.1" @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_local_range_0(sycl::group<1> group) {
   keep(group.get_local_range());
@@ -538,7 +538,7 @@ SYCL_EXTERNAL void group_get_local_range_0(sycl::group<1> group) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_local_range_1N4sycl3_V15groupILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]    
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
+// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void group_get_local_range_1(sycl::group<1> group, int dimension) {
   keep(group.get_local_range(dimension));
@@ -550,7 +550,7 @@ SYCL_EXTERNAL void group_get_local_range_1(sycl::group<1> group, int dimension) 
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_group_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]       
-// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.1" @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_group_range_0(sycl::group<1> group) {
   keep(group.get_group_range());
@@ -562,7 +562,7 @@ SYCL_EXTERNAL void group_get_group_range_0(sycl::group<1> group) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_group_range_1N4sycl3_V15groupILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]      
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
+// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void group_get_group_range_1(sycl::group<1> group, int dimension) {
   keep(group.get_group_range(dimension));
@@ -574,7 +574,7 @@ SYCL_EXTERNAL void group_get_group_range_1(sycl::group<1> group, int dimension) 
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_max_local_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]         
-// CHECK-LLVM: %{{.*}} = call %"class.sycl::_V1::range.1" @_ZNK4sycl3_V15groupILi1EE19get_max_local_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.1" @_ZNK4sycl3_V15groupILi1EE19get_max_local_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_max_local_range(sycl::group<1> group) {
   keep(group.get_max_local_range());
@@ -586,7 +586,7 @@ SYCL_EXTERNAL void group_get_max_local_range(sycl::group<1> group) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_group_linear_idN4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]           
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE19get_group_linear_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15groupILi1EE19get_group_linear_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_group_linear_id(sycl::group<1> group) {
   keep(group.get_group_linear_id());
@@ -598,7 +598,7 @@ SYCL_EXTERNAL void group_get_group_linear_id(sycl::group<1> group) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_local_linear_idN4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]         
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE19get_local_linear_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15groupILi1EE19get_local_linear_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_local_linear_id(sycl::group<1> group) {
   keep(group.get_local_linear_id());
@@ -610,7 +610,7 @@ SYCL_EXTERNAL void group_get_local_linear_id(sycl::group<1> group) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z28group_get_group_linear_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]           
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE22get_group_linear_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15groupILi1EE22get_group_linear_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_group_linear_range(sycl::group<1> group) {
   keep(group.get_group_linear_range());
@@ -622,7 +622,7 @@ SYCL_EXTERNAL void group_get_group_linear_range(sycl::group<1> group) {
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z28group_get_local_linear_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]             
-// CHECK-LLVM: %{{.*}} = call i64 @_ZNK4sycl3_V15groupILi1EE22get_local_linear_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
+// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15groupILi1EE22get_local_linear_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_local_linear_range(sycl::group<1> group) {
   keep(group.get_local_linear_range());
@@ -640,7 +640,7 @@ SYCL_EXTERNAL void group_get_local_linear_range(sycl::group<1> group) {
 // CHECK-LLVM-LABEL: define spir_func void @_Z8method_2N4sycl3_V14itemILi2ELb1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::item.2.true"* noundef byval(%"class.sycl::_V1::item.2.true") align 8 %0) #[[FUNCATTRS]]
 // CHECK-LLVM-NEXT:  %2 = addrspacecast %"class.sycl::_V1::item.2.true"* %0 to %"class.sycl::_V1::item.2.true" addrspace(4)*
-// CHECK-LLVM-NEXT:  %3 = call i8 @_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_(%"class.sycl::_V1::item.2.true" addrspace(4)* %2, %"class.sycl::_V1::item.2.true" addrspace(4)* %2)
+// CHECK-LLVM-NEXT:  %3 = call spir_func i8 @_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_(%"class.sycl::_V1::item.2.true" addrspace(4)* %2, %"class.sycl::_V1::item.2.true" addrspace(4)* %2)
 // CHECK-LLVM-NEXT:  ret void
 // CHECK-LLVM-NEXT: }
 
@@ -664,7 +664,7 @@ SYCL_EXTERNAL void method_2(sycl::item<2, true> item) {
 // CHECK-LLVM            %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %0, %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %1) #[[FUNCATTRS]]
 // CHECK-LLVM-NEXT: %3 = addrspacecast %"class.sycl::_V1::id.2"* %0 to %"class.sycl::_V1::id.2" addrspace(4)*
 // CHECK-LLVM-NEXT: %4 = addrspacecast %"class.sycl::_V1::id.2"* %1 to %"class.sycl::_V1::id.2" addrspace(4)*
-// CHECK-LLVM-NEXT: %5 = call i8 @_ZNK4sycl3_V12idILi2EEeqERKS2_(%"class.sycl::_V1::id.2" addrspace(4)* %3, %"class.sycl::_V1::id.2" addrspace(4)* %4)
+// CHECK-LLVM-NEXT: %5 = call spir_func i8 @_ZNK4sycl3_V12idILi2EEeqERKS2_(%"class.sycl::_V1::id.2" addrspace(4)* %3, %"class.sycl::_V1::id.2" addrspace(4)* %4)
 // CHECK-LLVM-NEXT: ret void
 // CHECK-LLVM-NEXT: }
 
@@ -690,10 +690,10 @@ SYCL_EXTERNAL void op_1(sycl::id<2> a, sycl::id<2> b) {
 // CHECK-LLVM            %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %0, %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %1) #[[FUNCATTRS]]  
 // CHECK-LLVM-NEXT: %3 = addrspacecast %"class.sycl::_V1::id.2"* %0 to %"class.sycl::_V1::id.2" addrspace(4)*
 // CHECK-LLVM-NEXT: %4 = bitcast %"class.sycl::_V1::id.2" addrspace(4)* %3 to %"class.sycl::_V1::detail::array.2" addrspace(4)*
-// CHECK-LLVM-NEXT: %5 = call i64 @_ZNK4sycl3_V16detail5arrayILi2EE3getEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %4, i32 0)
-// CHECK-LLVM-NEXT: %6 = call i64 @_ZNK4sycl3_V16detail5arrayILi2EE3getEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %4, i32 1)
+// CHECK-LLVM-NEXT: %5 = call spir_func i64 @_ZNK4sycl3_V16detail5arrayILi2EE3getEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %4, i32 0)
+// CHECK-LLVM-NEXT: %6 = call spir_func i64 @_ZNK4sycl3_V16detail5arrayILi2EE3getEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %4, i32 1)
 // CHECK-LLVM-NEXT: %7 = add i64 %5, %6
-// CHECK-LLVM-NEXT: %8 = call i64 @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_(i64 %7)
+// CHECK-LLVM-NEXT: %8 = call spir_func i64 @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_(i64 %7)
 // CHECK-LLVM-NEXT: ret void
 // CHECK-LLVM-NEXT: }
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/parallel_for.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/parallel_for.cpp
@@ -1,17 +1,28 @@
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.00.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.01.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.02.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
-
+// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O0.bc
+// RUN: clang++ -fsycl -fsycl-device-only -O1 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O1.bc
+// RUN: clang++ -fsycl -fsycl-device-only -O2 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O2.bc
 
 // Test that the LLVMIR generated is verifiable.
-// RUN: opt -verify -disable-output < %t.bc
+// RUN: opt -verify -disable-output < %t.O0.bc
+// RUN: opt -verify -disable-output < %t.O1.bc
+// RUN: opt -verify -disable-output < %t.O2.bc
 
 // Verify that LLVMIR generated is translatable to SPIRV.
-// RUN: llvm-spirv %t.bc
+// RUN: llvm-spirv %t.O0.bc
+// RUN: llvm-spirv %t.O1.bc
+// RUN: llvm-spirv %t.O2.bc
 
 // Test that all referenced sycl header functions are generated.
-// RUN: llvm-dis %t.bc
-// RUN: cat %t.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
+// RUN: llvm-dis %t.O0.bc
+// RUN: llvm-dis %t.O1.bc
+// RUN: llvm-dis %t.O2.bc
+// RUN: cat %t.O0.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
+// RUN: cat %t.O1.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
+// RUN: cat %t.O2.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
 
 // Test that the kernel named `kernel_parallel_for` is generated with the correct signature.
 // LLVM: define weak_odr spir_kernel void {{.*}}kernel_parallel_for(

--- a/polygeist/tools/cgeist/Test/Verification/sycl/parallel_for.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/parallel_for.cpp
@@ -1,28 +1,20 @@
 // RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.00.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 // RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.01.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 // RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.02.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.03.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.0fast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O0.bc
-// RUN: clang++ -fsycl -fsycl-device-only -O1 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O1.bc
-// RUN: clang++ -fsycl -fsycl-device-only -O2 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O2.bc
+// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
 
 // Test that the LLVMIR generated is verifiable.
-// RUN: opt -verify -disable-output < %t.O0.bc
-// RUN: opt -verify -disable-output < %t.O1.bc
-// RUN: opt -verify -disable-output < %t.O2.bc
+// RUN: opt -verify -disable-output < %t.bc
 
 // Verify that LLVMIR generated is translatable to SPIRV.
-// RUN: llvm-spirv %t.O0.bc
-// RUN: llvm-spirv %t.O1.bc
-// RUN: llvm-spirv %t.O2.bc
+// RUN: llvm-spirv %t.bc
 
 // Test that all referenced sycl header functions are generated.
-// RUN: llvm-dis %t.O0.bc
-// RUN: llvm-dis %t.O1.bc
-// RUN: llvm-dis %t.O2.bc
-// RUN: cat %t.O0.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
-// RUN: cat %t.O1.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
-// RUN: cat %t.O2.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
+// RUN: llvm-dis %t.bc
+// RUN: cat %t.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
 
 // Test that the kernel named `kernel_parallel_for` is generated with the correct signature.
 // LLVM: define weak_odr spir_kernel void {{.*}}kernel_parallel_for(

--- a/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
@@ -1,28 +1,20 @@
 // RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 // RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 // RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.Ofast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O0.bc
-// RUN: clang++ -fsycl -fsycl-device-only -O1 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O1.bc
-// RUN: clang++ -fsycl -fsycl-device-only -O2 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O2.bc
+// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
 
 // Test that the LLVMIR generated is verifiable.
-// RUN: opt -verify -disable-output < %t.O0.bc
-// RUN: opt -verify -disable-output < %t.O1.bc
-// RUN: opt -verify -disable-output < %t.O2.bc
+// RUN: opt -verify -disable-output < %t.bc
 
 // Verify that LLVMIR generated is translatable to SPIRV.
-// RUN: llvm-spirv %t.O0.bc
-// RUN: llvm-spirv %t.O1.bc
-// RUN: llvm-spirv %t.O2.bc
+// RUN: llvm-spirv %t.bc
 
 // Test that all referenced sycl header functions are generated.
-// RUN: llvm-dis %t.O0.bc
-// RUN: llvm-dis %t.O1.bc
-// RUN: llvm-dis %t.O2.bc
-// RUN: cat %t.O0.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
-// RUN: cat %t.O1.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
-// RUN: cat %t.O2.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
+// RUN: llvm-dis %t.bc
+// RUN: cat %t.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
 
 // Test that the kernel named `kernel_single_task` is generated with the correct signature.
 // LLVM: define weak_odr spir_kernel void {{.*}}kernel_single_task(

--- a/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
@@ -1,16 +1,28 @@
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
+// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O0.bc
+// RUN: clang++ -fsycl -fsycl-device-only -O1 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O1.bc
+// RUN: clang++ -fsycl -fsycl-device-only -O2 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O2.bc
 
 // Test that the LLVMIR generated is verifiable.
-// RUN: opt -verify -disable-output < %t.bc
+// RUN: opt -verify -disable-output < %t.O0.bc
+// RUN: opt -verify -disable-output < %t.O1.bc
+// RUN: opt -verify -disable-output < %t.O2.bc
 
 // Verify that LLVMIR generated is translatable to SPIRV.
-// RUN: llvm-spirv %t.bc
+// RUN: llvm-spirv %t.O0.bc
+// RUN: llvm-spirv %t.O1.bc
+// RUN: llvm-spirv %t.O2.bc
 
 // Test that all referenced sycl header functions are generated.
-// RUN: llvm-dis %t.bc
-// RUN: cat %t.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
+// RUN: llvm-dis %t.O0.bc
+// RUN: llvm-dis %t.O1.bc
+// RUN: llvm-dis %t.O2.bc
+// RUN: cat %t.O0.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
+// RUN: cat %t.O1.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
+// RUN: cat %t.O2.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
 
 // Test that the kernel named `kernel_single_task` is generated with the correct signature.
 // LLVM: define weak_odr spir_kernel void {{.*}}kernel_single_task(

--- a/polygeist/tools/cgeist/Test/Verification/sycl/stream-copy.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/stream-copy.cpp
@@ -1,16 +1,28 @@
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
+// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O0.bc
+// RUN: clang++ -fsycl -fsycl-device-only -O1 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O1.bc
+// RUN: clang++ -fsycl -fsycl-device-only -O2 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O2.bc
 
 // Test that the LLVMIR generated is verifiable.
-// RUN: opt -verify -disable-output < %t.bc
+// RUN: opt -verify -disable-output < %t.O0.bc
+// RUN: opt -verify -disable-output < %t.O1.bc
+// RUN: opt -verify -disable-output < %t.O2.bc
 
 // Verify that LLVMIR generated is translatable to SPIRV.
-// RUN: llvm-spirv %t.bc
+// RUN: llvm-spirv %t.O0.bc
+// RUN: llvm-spirv %t.O1.bc
+// RUN: llvm-spirv %t.O2.bc
 
 // Test that all referenced sycl header functions are generated.
-// RUN: llvm-dis %t.bc
-// RUN: cat %t.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
+// RUN: llvm-dis %t.O0.bc
+// RUN: llvm-dis %t.O1.bc
+// RUN: llvm-dis %t.O2.bc
+// RUN: cat %t.O0.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
+// RUN: cat %t.O1.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
+// RUN: cat %t.O2.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
 
 // Test that the kernel named `kernel_stream_copy` is generated with the correct signature.
 // LLVM: define weak_odr spir_kernel void {{.*}}kernel_stream_copy(

--- a/polygeist/tools/cgeist/Test/Verification/sycl/stream-copy.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/stream-copy.cpp
@@ -1,28 +1,20 @@
 // RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 // RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 // RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.Ofast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O0.bc
-// RUN: clang++ -fsycl -fsycl-device-only -O1 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O1.bc
-// RUN: clang++ -fsycl -fsycl-device-only -O2 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O2.bc
+// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
 
 // Test that the LLVMIR generated is verifiable.
-// RUN: opt -verify -disable-output < %t.O0.bc
-// RUN: opt -verify -disable-output < %t.O1.bc
-// RUN: opt -verify -disable-output < %t.O2.bc
+// RUN: opt -verify -disable-output < %t.bc
 
 // Verify that LLVMIR generated is translatable to SPIRV.
-// RUN: llvm-spirv %t.O0.bc
-// RUN: llvm-spirv %t.O1.bc
-// RUN: llvm-spirv %t.O2.bc
+// RUN: llvm-spirv %t.bc
 
 // Test that all referenced sycl header functions are generated.
-// RUN: llvm-dis %t.O0.bc
-// RUN: llvm-dis %t.O1.bc
-// RUN: llvm-dis %t.O2.bc
-// RUN: cat %t.O0.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
-// RUN: cat %t.O1.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
-// RUN: cat %t.O2.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
+// RUN: llvm-dis %t.bc
+// RUN: cat %t.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
 
 // Test that the kernel named `kernel_stream_copy` is generated with the correct signature.
 // LLVM: define weak_odr spir_kernel void {{.*}}kernel_stream_copy(

--- a/polygeist/tools/cgeist/Test/Verification/sycl/stream-triad.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/stream-triad.cpp
@@ -1,16 +1,28 @@
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
+// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O0.bc
+// RUN: clang++ -fsycl -fsycl-device-only -O1 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O1.bc
+// RUN: clang++ -fsycl -fsycl-device-only -O2 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O2.bc
 
 // Test that the LLVMIR generated is verifiable.
-// RUN: opt -verify -disable-output < %t.bc
+// RUN: opt -verify -disable-output < %t.O0.bc
+// RUN: opt -verify -disable-output < %t.O1.bc
+// RUN: opt -verify -disable-output < %t.O2.bc
 
 // Verify that LLVMIR generated is translatable to SPIRV.
-// RUN: llvm-spirv %t.bc
+// RUN: llvm-spirv %t.O0.bc
+// RUN: llvm-spirv %t.O1.bc
+// RUN: llvm-spirv %t.O2.bc
 
 // Test that all referenced sycl header functions are generated.
-// RUN: llvm-dis %t.bc
-// RUN: cat %t.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
+// RUN: llvm-dis %t.O0.bc
+// RUN: llvm-dis %t.O1.bc
+// RUN: llvm-dis %t.O2.bc
+// RUN: cat %t.O0.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
+// RUN: cat %t.O1.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
+// RUN: cat %t.O2.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
 
 // Test that the kernel named `kernel_stream_triad` is generated with the correct signature.
 // LLVM: define weak_odr spir_kernel void {{.*}}kernel_stream_triad(

--- a/polygeist/tools/cgeist/Test/Verification/sycl/stream-triad.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/stream-triad.cpp
@@ -1,28 +1,20 @@
 // RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 // RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 // RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.Ofast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O0.bc
-// RUN: clang++ -fsycl -fsycl-device-only -O1 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O1.bc
-// RUN: clang++ -fsycl -fsycl-device-only -O2 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.O2.bc
+// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
 
 // Test that the LLVMIR generated is verifiable.
-// RUN: opt -verify -disable-output < %t.O0.bc
-// RUN: opt -verify -disable-output < %t.O1.bc
-// RUN: opt -verify -disable-output < %t.O2.bc
+// RUN: opt -verify -disable-output < %t.bc
 
 // Verify that LLVMIR generated is translatable to SPIRV.
-// RUN: llvm-spirv %t.O0.bc
-// RUN: llvm-spirv %t.O1.bc
-// RUN: llvm-spirv %t.O2.bc
+// RUN: llvm-spirv %t.bc
 
 // Test that all referenced sycl header functions are generated.
-// RUN: llvm-dis %t.O0.bc
-// RUN: llvm-dis %t.O1.bc
-// RUN: llvm-dis %t.O2.bc
-// RUN: cat %t.O0.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
-// RUN: cat %t.O1.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
-// RUN: cat %t.O2.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
+// RUN: llvm-dis %t.bc
+// RUN: cat %t.ll | FileCheck %s --check-prefix=LLVM --implicit-check-not="declare{{.*}}spir_func"
 
 // Test that the kernel named `kernel_stream_triad` is generated with the correct signature.
 // LLVM: define weak_odr spir_kernel void {{.*}}kernel_stream_triad(

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -19,7 +19,7 @@
 // CHECK-LLVM-SAME:  #[[FUNCATTRS1:[0-9]+]] {
 // CHECK-LLVM-NEXT:  [[ACCESSOR:%.*]] = alloca %"class.sycl::_V1::accessor.1", align 8
 // CHECK-LLVM-NEXT:  [[ACAST:%.*]] = addrspacecast %"class.sycl::_V1::accessor.1"* [[ACCESSOR]] to %"class.sycl::_V1::accessor.1" addrspace(4)*
-// CHECK-LLVM-NEXT:  call void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]])
+// CHECK-LLVM-NEXT:  call spir_func void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]])
 
 // CHECK-LLVM-LABEL: define weak_odr spir_kernel void @_ZTSZZ16host_single_taskvENKUlRN4sycl3_V17handlerEE_clES2_E18kernel_single_task
 // CHECK-LLVM-SAME: #[[FUNCATTRS1]]


### PR DESCRIPTION
Some optimizations optimize away callsite without calling convention, e.g., `spir_kernel` caller calling non-`spir_func` callee.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>