### PR TITLE
[SYCL] Reintroduce experimental bfloat16 math functions

### DIFF
--- a/sycl/include/sycl/ext/oneapi/bfloat16.hpp
+++ b/sycl/include/sycl/ext/oneapi/bfloat16.hpp
@@ -24,7 +24,7 @@ namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace ext {
 namespace oneapi {
-  
+
 class bfloat16;
 
 namespace detail {

--- a/sycl/include/sycl/ext/oneapi/experimental/bfloat16_math.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/bfloat16_math.hpp
@@ -1,0 +1,187 @@
+//==-------- bfloat16_math.hpp - SYCL bloat16 math functions ---------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <sycl/detail/defines_elementary.hpp>
+#include <sycl/exception.hpp>
+#include <sycl/ext/oneapi/bfloat16.hpp>
+#include <sycl/marray.hpp>
+
+#include <cstring>
+#include <tuple>
+#include <type_traits>
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+namespace ext {
+namespace oneapi {
+namespace experimental {
+
+namespace detail {
+template <size_t N>
+uint32_t to_uint32_t(sycl::marray<bfloat16, N> x, size_t start) {
+  uint32_t res;
+  std::memcpy(&res, &x[start], sizeof(uint32_t));
+  return res;
+}
+} // namespace detail
+
+template <typename T>
+std::enable_if_t<std::is_same<T, bfloat16>::value, T> fabs(T x) {
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
+  return bfloat16::from_bits(__clc_fabs(x.raw()));
+#else
+  std::ignore = x;
+  throw runtime_error("bfloat16 is not currently supported on the host device.",
+                      PI_ERROR_INVALID_DEVICE);
+#endif // defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
+}
+
+template <size_t N>
+sycl::marray<bfloat16, N> fabs(sycl::marray<bfloat16, N> x) {
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
+  sycl::marray<bfloat16, N> res;
+
+  for (size_t i = 0; i < N / 2; i++) {
+    auto partial_res = __clc_fabs(detail::to_uint32_t(x, i * 2));
+    std::memcpy(&res[i * 2], &partial_res, sizeof(uint32_t));
+  }
+
+  if (N % 2) {
+    res[N - 1] = bfloat16::from_bits(__clc_fabs(x[N - 1].raw()));
+  }
+  return res;
+#else
+  std::ignore = x;
+  throw runtime_error("bfloat16 is not currently supported on the host device.",
+                      PI_ERROR_INVALID_DEVICE);
+#endif // defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
+}
+
+template <typename T>
+std::enable_if_t<std::is_same<T, bfloat16>::value, T> fmin(T x, T y) {
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
+  return bfloat16::from_bits(__clc_fmin(x.raw(), y.raw()));
+#else
+  std::ignore = x;
+  std::ignore = y;
+  throw runtime_error("bfloat16 is not currently supported on the host device.",
+                      PI_ERROR_INVALID_DEVICE);
+#endif // defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
+}
+
+template <size_t N>
+sycl::marray<bfloat16, N> fmin(sycl::marray<bfloat16, N> x,
+                               sycl::marray<bfloat16, N> y) {
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
+  sycl::marray<bfloat16, N> res;
+
+  for (size_t i = 0; i < N / 2; i++) {
+    auto partial_res = __clc_fmin(detail::to_uint32_t(x, i * 2),
+                                  detail::to_uint32_t(y, i * 2));
+    std::memcpy(&res[i * 2], &partial_res, sizeof(uint32_t));
+  }
+
+  if (N % 2) {
+    res[N - 1] =
+        bfloat16::from_bits(__clc_fmin(x[N - 1].raw(), y[N - 1].raw()));
+  }
+
+  return res;
+#else
+  std::ignore = x;
+  std::ignore = y;
+  throw runtime_error("bfloat16 is not currently supported on the host device.",
+                      PI_ERROR_INVALID_DEVICE);
+#endif // defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
+}
+
+template <typename T>
+std::enable_if_t<std::is_same<T, bfloat16>::value, T> fmax(T x, T y) {
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
+  return bfloat16::from_bits(__clc_fmax(x.raw(), y.raw()));
+#else
+  std::ignore = x;
+  std::ignore = y;
+  throw runtime_error("bfloat16 is not currently supported on the host device.",
+                      PI_ERROR_INVALID_DEVICE);
+#endif // defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
+}
+
+template <size_t N>
+sycl::marray<bfloat16, N> fmax(sycl::marray<bfloat16, N> x,
+                               sycl::marray<bfloat16, N> y) {
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
+  sycl::marray<bfloat16, N> res;
+
+  for (size_t i = 0; i < N / 2; i++) {
+    auto partial_res = __clc_fmax(detail::to_uint32_t(x, i * 2),
+                                  detail::to_uint32_t(y, i * 2));
+    std::memcpy(&res[i * 2], &partial_res, sizeof(uint32_t));
+  }
+
+  if (N % 2) {
+    res[N - 1] =
+        bfloat16::from_bits(__clc_fmax(x[N - 1].raw(), y[N - 1].raw()));
+  }
+  return res;
+#else
+  std::ignore = x;
+  std::ignore = y;
+  throw runtime_error("bfloat16 is not currently supported on the host device.",
+                      PI_ERROR_INVALID_DEVICE);
+#endif // defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
+}
+
+template <typename T>
+std::enable_if_t<std::is_same<T, bfloat16>::value, T> fma(T x, T y, T z) {
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
+  return bfloat16::from_bits(__clc_fma(x.raw(), y.raw(), z.raw()));
+#else
+  std::ignore = x;
+  std::ignore = y;
+  std::ignore = z;
+  throw runtime_error("bfloat16 is not currently supported on the host device.",
+                      PI_ERROR_INVALID_DEVICE);
+#endif // defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
+}
+
+template <size_t N>
+sycl::marray<bfloat16, N> fma(sycl::marray<bfloat16, N> x,
+                              sycl::marray<bfloat16, N> y,
+                              sycl::marray<bfloat16, N> z) {
+#if defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
+  sycl::marray<bfloat16, N> res;
+
+  for (size_t i = 0; i < N / 2; i++) {
+    auto partial_res =
+        __clc_fma(detail::to_uint32_t(x, i * 2), detail::to_uint32_t(y, i * 2),
+                  detail::to_uint32_t(z, i * 2));
+    std::memcpy(&res[i * 2], &partial_res, sizeof(uint32_t));
+  }
+
+  if (N % 2) {
+    res[N - 1] = bfloat16::from_bits(
+        __clc_fma(x[N - 1].raw(), y[N - 1].raw(), z[N - 1].raw()));
+  }
+  return res;
+#else
+  std::ignore = x;
+  std::ignore = y;
+  std::ignore = z;
+  throw runtime_error("bfloat16 is not currently supported on the host device.",
+                      PI_ERROR_INVALID_DEVICE);
+#endif // defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
+}
+
+} // namespace experimental
+} // namespace oneapi
+} // namespace ext
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
+} // namespace sycl

--- a/sycl/include/sycl/ext/oneapi/experimental/bfloat16_math.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/bfloat16_math.hpp
@@ -35,7 +35,8 @@ uint32_t to_uint32_t(sycl::marray<bfloat16, N> x, size_t start) {
 template <typename T>
 std::enable_if_t<std::is_same<T, bfloat16>::value, T> fabs(T x) {
 #if defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
-  return bfloat16::from_bits(__clc_fabs(x.raw()));
+  oneapi::detail::Bfloat16StorageT XBits = oneapi::detail::bfloat16ToBits(x);
+  return oneapi::detail::bitsToBfloat16(__clc_fabs(XBits));
 #else
   std::ignore = x;
   throw runtime_error("bfloat16 is not currently supported on the host device.",
@@ -54,7 +55,9 @@ sycl::marray<bfloat16, N> fabs(sycl::marray<bfloat16, N> x) {
   }
 
   if (N % 2) {
-    res[N - 1] = bfloat16::from_bits(__clc_fabs(x[N - 1].raw()));
+    oneapi::detail::Bfloat16StorageT XBits =
+        oneapi::detail::bfloat16ToBits(x[N - 1]);
+    res[N - 1] = oneapi::detail::bitsToBfloat16(__clc_fabs(XBits));
   }
   return res;
 #else
@@ -67,7 +70,9 @@ sycl::marray<bfloat16, N> fabs(sycl::marray<bfloat16, N> x) {
 template <typename T>
 std::enable_if_t<std::is_same<T, bfloat16>::value, T> fmin(T x, T y) {
 #if defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
-  return bfloat16::from_bits(__clc_fmin(x.raw(), y.raw()));
+  oneapi::detail::Bfloat16StorageT XBits = oneapi::detail::bfloat16ToBits(x);
+  oneapi::detail::Bfloat16StorageT YBits = oneapi::detail::bfloat16ToBits(y);
+  return oneapi::detail::bitsToBfloat16(__clc_fmin(XBits, YBits));
 #else
   std::ignore = x;
   std::ignore = y;
@@ -89,8 +94,11 @@ sycl::marray<bfloat16, N> fmin(sycl::marray<bfloat16, N> x,
   }
 
   if (N % 2) {
-    res[N - 1] =
-        bfloat16::from_bits(__clc_fmin(x[N - 1].raw(), y[N - 1].raw()));
+    oneapi::detail::Bfloat16StorageT XBits =
+        oneapi::detail::bfloat16ToBits(x[N - 1]);
+    oneapi::detail::Bfloat16StorageT YBits =
+        oneapi::detail::bfloat16ToBits(y[N - 1]);
+    res[N - 1] = oneapi::detail::bitsToBfloat16(__clc_fmin(XBits, YBits));
   }
 
   return res;
@@ -105,7 +113,9 @@ sycl::marray<bfloat16, N> fmin(sycl::marray<bfloat16, N> x,
 template <typename T>
 std::enable_if_t<std::is_same<T, bfloat16>::value, T> fmax(T x, T y) {
 #if defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
-  return bfloat16::from_bits(__clc_fmax(x.raw(), y.raw()));
+  oneapi::detail::Bfloat16StorageT XBits = oneapi::detail::bfloat16ToBits(x);
+  oneapi::detail::Bfloat16StorageT YBits = oneapi::detail::bfloat16ToBits(y);
+  return oneapi::detail::bitsToBfloat16(__clc_fmax(XBits, YBits));
 #else
   std::ignore = x;
   std::ignore = y;
@@ -127,8 +137,11 @@ sycl::marray<bfloat16, N> fmax(sycl::marray<bfloat16, N> x,
   }
 
   if (N % 2) {
-    res[N - 1] =
-        bfloat16::from_bits(__clc_fmax(x[N - 1].raw(), y[N - 1].raw()));
+    oneapi::detail::Bfloat16StorageT XBits =
+        oneapi::detail::bfloat16ToBits(x[N - 1]);
+    oneapi::detail::Bfloat16StorageT YBits =
+        oneapi::detail::bfloat16ToBits(y[N - 1]);
+    res[N - 1] = oneapi::detail::bitsToBfloat16(__clc_fmax(XBits, YBits));
   }
   return res;
 #else
@@ -142,7 +155,10 @@ sycl::marray<bfloat16, N> fmax(sycl::marray<bfloat16, N> x,
 template <typename T>
 std::enable_if_t<std::is_same<T, bfloat16>::value, T> fma(T x, T y, T z) {
 #if defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
-  return bfloat16::from_bits(__clc_fma(x.raw(), y.raw(), z.raw()));
+  oneapi::detail::Bfloat16StorageT XBits = oneapi::detail::bfloat16ToBits(x);
+  oneapi::detail::Bfloat16StorageT YBits = oneapi::detail::bfloat16ToBits(y);
+  oneapi::detail::Bfloat16StorageT ZBits = oneapi::detail::bfloat16ToBits(z);
+  return oneapi::detail::bitsToBfloat16(__clc_fma(XBits, YBits, ZBits));
 #else
   std::ignore = x;
   std::ignore = y;
@@ -167,8 +183,13 @@ sycl::marray<bfloat16, N> fma(sycl::marray<bfloat16, N> x,
   }
 
   if (N % 2) {
-    res[N - 1] = bfloat16::from_bits(
-        __clc_fma(x[N - 1].raw(), y[N - 1].raw(), z[N - 1].raw()));
+    oneapi::detail::Bfloat16StorageT XBits =
+        oneapi::detail::bfloat16ToBits(x[N - 1]);
+    oneapi::detail::Bfloat16StorageT YBits =
+        oneapi::detail::bfloat16ToBits(y[N - 1]);
+    oneapi::detail::Bfloat16StorageT ZBits =
+        oneapi::detail::bfloat16ToBits(z[N - 1]);
+    res[N - 1] = oneapi::detail::bitsToBfloat16(__clc_fma(XBits, YBits, ZBits));
   }
   return res;
 #else

--- a/sycl/include/sycl/ext/oneapi/experimental/builtins.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/builtins.hpp
@@ -32,15 +32,6 @@ namespace ext {
 namespace oneapi {
 namespace experimental {
 
-namespace detail {
-template <size_t N>
-uint32_t to_uint32_t(sycl::marray<bfloat16, N> x, size_t start) {
-  uint32_t res;
-  std::memcpy(&res, &x[start], sizeof(uint32_t));
-  return res;
-}
-} // namespace detail
-
 // Provides functionality to print data from kernels in a C way:
 // - On non-host devices this function is directly mapped to printf from
 //   OpenCL C

--- a/sycl/include/sycl/ext/oneapi/sub_group.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group.hpp
@@ -205,8 +205,7 @@ struct sub_group {
 
   template <typename T>
   using EnableIfIsScalarArithmetic =
-      std::enable_if_t<sycl::detail::is_scalar_arithmetic<T>::value,
-                                T>;
+      std::enable_if_t<sycl::detail::is_scalar_arithmetic<T>::value, T>;
 
   /* --- one-input shuffles --- */
   /* indices in [0 , sub_group size) */

--- a/sycl/include/sycl/ext/oneapi/sub_group.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group.hpp
@@ -205,7 +205,7 @@ struct sub_group {
 
   template <typename T>
   using EnableIfIsScalarArithmetic =
-      sycl::detail::enable_if_t<sycl::detail::is_scalar_arithmetic<T>::value,
+      std::enable_if_t<sycl::detail::is_scalar_arithmetic<T>::value,
                                 T>;
 
   /* --- one-input shuffles --- */
@@ -260,7 +260,7 @@ struct sub_group {
 #ifdef __SYCL_DEVICE_ONLY__
   // Method for decorated pointer
   template <typename CVT, typename T = std::remove_cv_t<CVT>>
-  detail::enable_if_t<!std::is_same<remove_decoration_t<T>, T>::value, T>
+  std::enable_if_t<!std::is_same<remove_decoration_t<T>, T>::value, T>
   load(CVT *cv_src) const {
     T *src = const_cast<T *>(cv_src);
     return load(sycl::multi_ptr<remove_decoration_t<T>,
@@ -270,7 +270,7 @@ struct sub_group {
 
   // Method for raw pointer
   template <typename CVT, typename T = std::remove_cv_t<CVT>>
-  detail::enable_if_t<std::is_same<remove_decoration_t<T>, T>::value, T>
+  std::enable_if_t<std::is_same<remove_decoration_t<T>, T>::value, T>
   load(CVT *cv_src) const {
     T *src = const_cast<T *>(cv_src);
 
@@ -300,10 +300,11 @@ struct sub_group {
 
   template <typename CVT, access::address_space Space,
             access::decorated IsDecorated, typename T = std::remove_cv_t<CVT>>
-  sycl::detail::enable_if_t<
+  std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value, T>
   load(const multi_ptr<CVT, Space, IsDecorated> cv_src) const {
-    multi_ptr<T, Space, IsDecorated> src = detail::GetUnqualMultiPtr(cv_src);
+    multi_ptr<T, Space, IsDecorated> src =
+        sycl::detail::GetUnqualMultiPtr(cv_src);
 #ifdef __SYCL_DEVICE_ONLY__
 #ifdef __NVPTX__
     return src.get()[get_local_id()[0]];
@@ -319,10 +320,11 @@ struct sub_group {
 
   template <typename CVT, access::address_space Space,
             access::decorated IsDecorated, typename T = std::remove_cv_t<CVT>>
-  sycl::detail::enable_if_t<
+  std::enable_if_t<
       sycl::detail::sub_group::AcceptableForLocalLoadStore<T, Space>::value, T>
   load(const multi_ptr<CVT, Space, IsDecorated> cv_src) const {
-    multi_ptr<T, Space, IsDecorated> src = detail::GetUnqualMultiPtr(cv_src);
+    multi_ptr<T, Space, IsDecorated> src =
+        sycl::detail::GetUnqualMultiPtr(cv_src);
 #ifdef __SYCL_DEVICE_ONLY__
     return src.get()[get_local_id()[0]];
 #else
@@ -335,11 +337,12 @@ struct sub_group {
 #ifdef __NVPTX__
   template <int N, typename CVT, access::address_space Space,
             access::decorated IsDecorated, typename T = std::remove_cv_t<CVT>>
-  sycl::detail::enable_if_t<
+  std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value,
       vec<T, N>>
   load(const multi_ptr<CVT, Space, IsDecorated> cv_src) const {
-    multi_ptr<T, Space, IsDecorated> src = detail::GetUnqualMultiPtr(cv_src);
+    multi_ptr<T, Space, IsDecorated> src =
+        sycl::detail::GetUnqualMultiPtr(cv_src);
     vec<T, N> res;
     for (int i = 0; i < N; ++i) {
       res[i] = *(src.get() + i * get_max_local_range()[0] + get_local_id()[0]);
@@ -349,23 +352,25 @@ struct sub_group {
 #else  // __NVPTX__
   template <int N, typename CVT, access::address_space Space,
             access::decorated IsDecorated, typename T = std::remove_cv_t<CVT>>
-  sycl::detail::enable_if_t<
+  std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
           N != 1 && N != 3 && N != 16,
       vec<T, N>>
   load(const multi_ptr<CVT, Space, IsDecorated> cv_src) const {
-    multi_ptr<T, Space, IsDecorated> src = detail::GetUnqualMultiPtr(cv_src);
+    multi_ptr<T, Space, IsDecorated> src =
+        sycl::detail::GetUnqualMultiPtr(cv_src);
     return sycl::detail::sub_group::load<N, T>(src);
   }
 
   template <int N, typename CVT, access::address_space Space,
             access::decorated IsDecorated, typename T = std::remove_cv_t<CVT>>
-  sycl::detail::enable_if_t<
+  std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
           N == 16,
       vec<T, 16>>
   load(const multi_ptr<CVT, Space, IsDecorated> cv_src) const {
-    multi_ptr<T, Space, IsDecorated> src = detail::GetUnqualMultiPtr(cv_src);
+    multi_ptr<T, Space, IsDecorated> src =
+        sycl::detail::GetUnqualMultiPtr(cv_src);
     return {sycl::detail::sub_group::load<8, T>(src),
             sycl::detail::sub_group::load<8, T>(src +
                                                 8 * get_max_local_range()[0])};
@@ -373,12 +378,13 @@ struct sub_group {
 
   template <int N, typename CVT, access::address_space Space,
             access::decorated IsDecorated, typename T = std::remove_cv_t<CVT>>
-  sycl::detail::enable_if_t<
+  std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
           N == 3,
       vec<T, 3>>
   load(const multi_ptr<CVT, Space, IsDecorated> cv_src) const {
-    multi_ptr<T, Space, IsDecorated> src = detail::GetUnqualMultiPtr(cv_src);
+    multi_ptr<T, Space, IsDecorated> src =
+        sycl::detail::GetUnqualMultiPtr(cv_src);
     return {
         sycl::detail::sub_group::load<1, T>(src),
         sycl::detail::sub_group::load<2, T>(src + get_max_local_range()[0])};
@@ -386,19 +392,20 @@ struct sub_group {
 
   template <int N, typename CVT, access::address_space Space,
             access::decorated IsDecorated, typename T = std::remove_cv_t<CVT>>
-  sycl::detail::enable_if_t<
+  std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
           N == 1,
       vec<T, 1>>
   load(const multi_ptr<CVT, Space, IsDecorated> cv_src) const {
-    multi_ptr<T, Space, IsDecorated> src = detail::GetUnqualMultiPtr(cv_src);
+    multi_ptr<T, Space, IsDecorated> src =
+        sycl::detail::GetUnqualMultiPtr(cv_src);
     return sycl::detail::sub_group::load(src);
   }
 #endif // ___NVPTX___
 #else  // __SYCL_DEVICE_ONLY__
   template <int N, typename CVT, access::address_space Space,
             access::decorated IsDecorated, typename T = std::remove_cv_t<CVT>>
-  sycl::detail::enable_if_t<
+  std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value,
       vec<T, N>>
   load(const multi_ptr<CVT, Space, IsDecorated> src) const {
@@ -410,11 +417,12 @@ struct sub_group {
 
   template <int N, typename CVT, access::address_space Space,
             access::decorated IsDecorated, typename T = std::remove_cv_t<CVT>>
-  sycl::detail::enable_if_t<
+  std::enable_if_t<
       sycl::detail::sub_group::AcceptableForLocalLoadStore<T, Space>::value,
       vec<T, N>>
   load(const multi_ptr<CVT, Space, IsDecorated> cv_src) const {
-    multi_ptr<T, Space, IsDecorated> src = detail::GetUnqualMultiPtr(cv_src);
+    multi_ptr<T, Space, IsDecorated> src =
+        sycl::detail::GetUnqualMultiPtr(cv_src);
 #ifdef __SYCL_DEVICE_ONLY__
     vec<T, N> res;
     for (int i = 0; i < N; ++i) {
@@ -431,7 +439,7 @@ struct sub_group {
 #ifdef __SYCL_DEVICE_ONLY__
   // Method for decorated pointer
   template <typename T>
-  detail::enable_if_t<!std::is_same<remove_decoration_t<T>, T>::value>
+  std::enable_if_t<!std::is_same<remove_decoration_t<T>, T>::value>
   store(T *dst, const remove_decoration_t<T> &x) const {
     store(sycl::multi_ptr<remove_decoration_t<T>,
                           sycl::detail::deduce_AS<T>::value,
@@ -441,7 +449,7 @@ struct sub_group {
 
   // Method for raw pointer
   template <typename T>
-  detail::enable_if_t<std::is_same<remove_decoration_t<T>, T>::value>
+  std::enable_if_t<std::is_same<remove_decoration_t<T>, T>::value>
   store(T *dst, const remove_decoration_t<T> &x) const {
 
 #ifdef __NVPTX__
@@ -475,7 +483,7 @@ struct sub_group {
 
   template <typename T, access::address_space Space,
             access::decorated DecorateAddress>
-  sycl::detail::enable_if_t<
+  std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value>
   store(multi_ptr<T, Space, DecorateAddress> dst, const T &x) const {
 #ifdef __SYCL_DEVICE_ONLY__
@@ -494,7 +502,7 @@ struct sub_group {
 
   template <typename T, access::address_space Space,
             access::decorated DecorateAddress>
-  sycl::detail::enable_if_t<
+  std::enable_if_t<
       sycl::detail::sub_group::AcceptableForLocalLoadStore<T, Space>::value>
   store(multi_ptr<T, Space, DecorateAddress> dst, const T &x) const {
 #ifdef __SYCL_DEVICE_ONLY__
@@ -511,7 +519,7 @@ struct sub_group {
 #ifdef __NVPTX__
   template <int N, typename T, access::address_space Space,
             access::decorated DecorateAddress>
-  sycl::detail::enable_if_t<
+  std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value>
   store(multi_ptr<T, Space, DecorateAddress> dst, const vec<T, N> &x) const {
     for (int i = 0; i < N; ++i) {
@@ -521,7 +529,7 @@ struct sub_group {
 #else // __NVPTX__
   template <int N, typename T, access::address_space Space,
             access::decorated DecorateAddress>
-  sycl::detail::enable_if_t<
+  std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
       N != 1 && N != 3 && N != 16>
   store(multi_ptr<T, Space, DecorateAddress> dst, const vec<T, N> &x) const {
@@ -530,7 +538,7 @@ struct sub_group {
 
   template <int N, typename T, access::address_space Space,
             access::decorated DecorateAddress>
-  sycl::detail::enable_if_t<
+  std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
       N == 1>
   store(multi_ptr<T, Space, DecorateAddress> dst, const vec<T, 1> &x) const {
@@ -539,7 +547,7 @@ struct sub_group {
 
   template <int N, typename T, access::address_space Space,
             access::decorated DecorateAddress>
-  sycl::detail::enable_if_t<
+  std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
       N == 3>
   store(multi_ptr<T, Space, DecorateAddress> dst, const vec<T, 3> &x) const {
@@ -550,7 +558,7 @@ struct sub_group {
 
   template <int N, typename T, access::address_space Space,
             access::decorated DecorateAddress>
-  sycl::detail::enable_if_t<
+  std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
       N == 16>
   store(multi_ptr<T, Space, DecorateAddress> dst, const vec<T, 16> &x) const {
@@ -563,7 +571,7 @@ struct sub_group {
 #else  // __SYCL_DEVICE_ONLY__
   template <int N, typename T, access::address_space Space,
             access::decorated DecorateAddress>
-  sycl::detail::enable_if_t<
+  std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value>
   store(multi_ptr<T, Space, DecorateAddress> dst, const vec<T, N> &x) const {
     (void)dst;
@@ -575,7 +583,7 @@ struct sub_group {
 
   template <int N, typename T, access::address_space Space,
             access::decorated DecorateAddress>
-  sycl::detail::enable_if_t<
+  std::enable_if_t<
       sycl::detail::sub_group::AcceptableForLocalLoadStore<T, Space>::value>
   store(multi_ptr<T, Space, DecorateAddress> dst, const vec<T, N> &x) const {
 #ifdef __SYCL_DEVICE_ONLY__


### PR DESCRIPTION
https://github.com/intel/llvm/pull/6524 accidentally removed the experimental bfloat16 math functions while moving bfloat16 out of the experimental namespace. This commit reintroduces these in the bfloat16_math.hpp header file.

Changes to sub_group.hpp are to resolve detail namespace ambiguities are are NFC.