### PR TITLE
[SYCL] Remove experimental from bfloat16 in Windows test

### DIFF
--- a/sycl/test/esimd/regression/windows_build_test.cpp
+++ b/sycl/test/esimd/regression/windows_build_test.cpp
@@ -31,8 +31,8 @@ int main() {
     using namespace sycl::ext::intel::experimental::esimd;
 
     simd<int, 32> blk;
-    simd<sycl::ext::oneapi::experimental::bfloat16, 16> A;
-    simd<sycl::ext::oneapi::experimental::bfloat16, 256> B;
+    simd<sycl::ext::oneapi::bfloat16, 16> A;
+    simd<sycl::ext::oneapi::bfloat16, 256> B;
     simd<float, 16> C;
     lzd<uint>(blk);
     lzd<uint>(35);


### PR DESCRIPTION
bfloat16 was recently moved out of the experimental namespace but windows_build_test.cpp did not reflect this. This commit removes the use of the experimental namespace.