### PR TITLE
[SYCL-MLIR] Improve warning and debug messages

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -1167,7 +1167,8 @@ MLIRScanner::emitGPUCallExpr(clang::CallExpr *Expr) {
       }
       if (Sr->getDecl()->getIdentifier() &&
           Sr->getDecl()->getName() == "cudaFuncSetCacheConfig") {
-        llvm::errs() << " Not emitting GPU option: cudaFuncSetCacheConfig\n";
+        mlirclang::warning()
+            << " Not emitting GPU option: cudaFuncSetCacheConfig\n";
         return std::make_pair(ValueCategory(), true);
       }
       // TODO move free out.

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -673,7 +673,7 @@ ValueCategory MLIRScanner::VisitMaterializeTemporaryExpr(
   if (IsArray)
     return V;
 
-  mlirclang::warning() << "cleanup of materialized not handled";
+  mlirclang::warning() << "cleanup of materialized not handled\n";
   auto Op =
       createAllocOp(Glob.getTypes().getMLIRType(Expr->getSubExpr()->getType()),
                     nullptr, 0, /*isArray*/ IsArray, /*LLVMABI*/ LLVMABI);
@@ -801,7 +801,7 @@ MLIRScanner::VisitCXXScalarValueInitExpr(clang::CXXScalarValueInitExpr *Expr) {
 ValueCategory MLIRScanner::VisitCXXPseudoDestructorExpr(
     clang::CXXPseudoDestructorExpr *Expr) {
   Visit(Expr->getBase());
-  llvm::errs() << "not running pseudo destructor\n";
+  mlirclang::warning() << "not running pseudo destructor\n";
   return nullptr;
 }
 
@@ -1383,18 +1383,20 @@ ValueCategory MLIRScanner::VisitCXXNoexceptExpr(CXXNoexceptExpr *Expr) {
 }
 
 ValueCategory MLIRScanner::VisitMemberExpr(MemberExpr *ME) {
-  if (auto *Sr2 = dyn_cast<OpaqueValueExpr>(ME->getBase())) {
-    if (auto *SR = dyn_cast<DeclRefExpr>(Sr2->getSourceExpr())) {
-      if (SR->getDecl()->getName() == "blockIdx")
-        llvm::errs() << "known block index";
-      if (SR->getDecl()->getName() == "blockDim")
-        llvm::errs() << "known block dim";
-      if (SR->getDecl()->getName() == "threadIdx")
-        llvm::errs() << "known thread index";
-      if (SR->getDecl()->getName() == "gridDim")
-        llvm::errs() << "known grid index";
+  LLVM_DEBUG({
+    if (auto *Sr2 = dyn_cast<OpaqueValueExpr>(ME->getBase())) {
+      if (auto *SR = dyn_cast<DeclRefExpr>(Sr2->getSourceExpr())) {
+        if (SR->getDecl()->getName() == "blockIdx")
+          llvm::dbgs() << "known block index";
+        else if (SR->getDecl()->getName() == "blockDim")
+          llvm::dbgs() << "known block dim";
+        else if (SR->getDecl()->getName() == "threadIdx")
+          llvm::dbgs() << "known thread index";
+        else if (SR->getDecl()->getName() == "gridDim")
+          llvm::dbgs() << "known grid index";
+      }
     }
-  }
+  });
   auto Base = Visit(ME->getBase());
   clang::QualType OT = ME->getBase()->getType();
   if (ME->isArrow()) {
@@ -1651,13 +1653,11 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
       return ValueCategory(Nval, /*isReference*/ false);
     }
 
-#ifdef DEBUG
     if (!Scalar.getType().isa<mlir::MemRefType>()) {
       E->dump();
       E->getType()->dump();
       llvm::errs() << "Scalar: " << Scalar << "\n";
     }
-#endif
 
     assert(Scalar.getType().isa<mlir::MemRefType>() &&
            "Expecting 'Scalar' to have MemRefType");
@@ -1700,11 +1700,10 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
                            /*isReference*/ false);
     }
 
-#ifdef DEBUG
     E->dump();
     E->getType()->dump();
     llvm::errs() << " Scalar: " << Scalar << " MLIRTy: " << MLIRTy << "\n";
-#endif
+
     llvm_unreachable("illegal type for cast");
   } break;
   case clang::CastKind::CK_LValueToRValue: {
@@ -1800,12 +1799,12 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
         PostTy.isa<mlir::IndexType>())
       return ValueCategory(
           Builder.create<arith::IndexCastOp>(Loc, PostTy, Scalar), false);
-#ifdef DEBUG
+
     if (!Scalar.getType().isa<mlir::IntegerType>()) {
       E->dump();
       llvm::errs() << " Scalar: " << Scalar << "\n";
     }
-#endif
+
     auto PrevTy = Scalar.getType().cast<mlir::IntegerType>();
     bool SignedType = true;
     if (const auto *Bit =
@@ -1860,12 +1859,12 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
   }
   case clang::CastKind::CK_FloatingCast: {
     auto Scalar = Visit(E->getSubExpr()).getValue(Builder);
-#ifdef DEBUG
+
     if (!Scalar.getType().isa<mlir::FloatType>()) {
       E->dump();
       llvm::errs() << "Scalar: " << Scalar << "\n";
     }
-#endif
+
     auto PrevTy = Scalar.getType().cast<mlir::FloatType>();
     auto PostTy =
         Glob.getTypes().getMLIRType(E->getType()).cast<mlir::FloatType>();
@@ -1958,11 +1957,11 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
       auto Val = Builder.create<mlir::LLVM::PtrToIntOp>(Loc, MLIRTy, Scalar);
       return ValueCategory(Val, /*isReference*/ false);
     }
-#ifdef DEBUG
-    function.dump();
+
+    Function.dump();
     llvm::errs() << "Scalar: " << Scalar << "\n";
     E->dump();
-#endif
+
     llvm_unreachable("unhandled ptrtoint cast");
   } break;
   case clang::CastKind::CK_IntegralToBoolean: {
@@ -2642,7 +2641,7 @@ BinOpInfo MLIRScanner::EmitBinOps(BinaryOperator *E, QualType PromotionType) {
 static void informNoOverflowCheck(LangOptions::SignedOverflowBehaviorTy SOB,
                                   llvm::StringRef OpName) {
   if (SOB != clang::LangOptions::SOB_Defined)
-    llvm::errs() << "Not emitting overflow-checked " << OpName << "\n";
+    mlirclang::warning() << "Not emitting overflow-checked " << OpName << "\n";
 }
 
 ValueCategory MLIRScanner::EmitBinMul(const BinOpInfo &Info) {

--- a/polygeist/tools/cgeist/Lib/CGStmt.cc
+++ b/polygeist/tools/cgeist/Lib/CGStmt.cc
@@ -572,8 +572,8 @@ MLIRScanner::VisitOMPParallelDirective(clang::OMPParallelDirective *Par) {
       }
       break;
     default:
-      llvm::errs() << "may not handle omp clause " << (int)F->getClauseKind()
-                   << "\n";
+      mlirclang::warning() << "may not handle omp clause "
+                           << (int)F->getClauseKind() << "\n";
     }
   }
 

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -341,7 +341,7 @@ void ClangToLLVMArgMapping::construct(const clang::ASTContext &Context,
 
       if (AI.isDirect() && AI.getCanBeFlattened() && STy)
         mlirclang::warning() << "struct should be flattened but MLIR codegen "
-                                "cannot yet handle it. Needs to be fixed.";
+                                "cannot yet handle it. Needs to be fixed.\n";
 
       if (AllowStructFlattening && AI.isDirect() && AI.getCanBeFlattened() &&
           STy) {
@@ -592,7 +592,7 @@ CodeGenTypes::getFunctionType(const clang::CodeGen::CGFunctionInfo &FI,
 
       if (ST && ArgInfo.isDirect() && ArgInfo.getCanBeFlattened())
         mlirclang::warning() << "struct should be flattened but MLIR codegen "
-                                "cannot yet handle it. Needs to be fixed.";
+                                "cannot yet handle it. Needs to be fixed.\n";
 
       if (AllowStructFlattening && ST && ArgInfo.isDirect() &&
           ArgInfo.getCanBeFlattened()) {

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -238,7 +238,7 @@ void MLIRScanner::init(FunctionOpInterface func, const FunctionToEmit &FTE) {
 
           clang::Expr *init = expr->getInit();
           if (auto clean = dyn_cast<clang::ExprWithCleanups>(init)) {
-            llvm::errs() << "TODO: cleanup\n";
+            mlirclang::warning() << "TODO: cleanup\n";
             init = clean->getSubExpr();
           }
 
@@ -250,7 +250,7 @@ void MLIRScanner::init(FunctionOpInterface func, const FunctionToEmit &FTE) {
         if (expr->isDelegatingInitializer()) {
           clang::Expr *init = expr->getInit();
           if (auto clean = dyn_cast<clang::ExprWithCleanups>(init)) {
-            llvm::errs() << "TODO: cleanup\n";
+            mlirclang::warning() << "TODO: cleanup\n";
             init = clean->getSubExpr();
           }
 


### PR DESCRIPTION
Use mlirclang::warning or llvm::dbgs when suitable.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>