### PR TITLE
[SYCL-MLIR] Avoid evaluating expressions only used on supressed warnings

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"
 #include "mlir/Target/LLVMIR/TypeFromLLVM.h"
+#include "llvm/Support/WithColor.h"
 
 #define DEBUG_TYPE "CGCall"
 
@@ -1167,8 +1168,8 @@ MLIRScanner::emitGPUCallExpr(clang::CallExpr *Expr) {
       }
       if (Sr->getDecl()->getIdentifier() &&
           Sr->getDecl()->getName() == "cudaFuncSetCacheConfig") {
-        mlirclang::warning()
-            << " Not emitting GPU option: cudaFuncSetCacheConfig\n";
+        CGEIST_WARNING(llvm::WithColor::warning()
+                       << " Not emitting GPU option: cudaFuncSetCacheConfig\n");
         return std::make_pair(ValueCategory(), true);
       }
       // TODO move free out.

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/SYCL/IR/SYCLOpsDialect.h"
 
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/WithColor.h"
 
 #define DEBUG_TYPE "CGExpr"
 
@@ -492,7 +493,7 @@ static const clang::ConstantArrayType *getCAT(const clang::Type *T) {
 
 ValueCategory MLIRScanner::VisitArrayInitLoop(clang::ArrayInitLoopExpr *Expr,
                                               ValueCategory ToStore) {
-  CGEIST_WARNING(mlirclang::warning()
+  CGEIST_WARNING(llvm::WithColor::warning()
                  << "recomputing common in arrayinitloopexpr\n");
 
   const clang::ConstantArrayType *CAT = getCAT(Expr->getType().getTypePtr());
@@ -674,7 +675,8 @@ ValueCategory MLIRScanner::VisitMaterializeTemporaryExpr(
   if (IsArray)
     return V;
 
-  CGEIST_WARNING(mlirclang::warning() << "cleanup of materialized not handled");
+  CGEIST_WARNING(llvm::WithColor::warning()
+                 << "cleanup of materialized not handled");
   auto Op =
       createAllocOp(Glob.getTypes().getMLIRType(Expr->getSubExpr()->getType()),
                     nullptr, 0, /*isArray*/ IsArray, /*LLVMABI*/ LLVMABI);
@@ -683,7 +685,8 @@ ValueCategory MLIRScanner::VisitMaterializeTemporaryExpr(
 }
 
 ValueCategory MLIRScanner::VisitCXXDeleteExpr(clang::CXXDeleteExpr *Expr) {
-  CGEIST_WARNING(mlirclang::warning() << "not calling destructor on delete\n");
+  CGEIST_WARNING(llvm::WithColor::warning()
+                 << "not calling destructor on delete\n");
 
   Location Loc = getMLIRLocation(Expr->getExprLoc());
   mlir::Value ToDelete = Visit(Expr->getArgument()).getValue(Builder);
@@ -931,7 +934,7 @@ MLIRScanner::EmitVectorSubscript(clang::ArraySubscriptExpr *Expr) {
   ValueCategory Base{Visit(Expr->getBase()).getValue(Builder), false};
   auto Idx = Visit(Expr->getIdx());
 
-  mlirclang::warning() << "Not emitting bounds check\n";
+  CGEIST_WARNING(llvm::WithColor::warning() << "Not emitting bounds check\n");
 
   return Base.ExtractElement(Builder, getMLIRLocation(Expr->getExprLoc()),
                              Idx.val);
@@ -1241,8 +1244,8 @@ ValueCategory MLIRScanner::VisitExprWithCleanups(ExprWithCleanups *E) {
   auto Ret = Visit(E->getSubExpr());
   CGEIST_WARNING({
     for (auto &Child : E->children()) {
-      mlirclang::warning() << "cleanup not handled for: ";
-      Child->dump(mlirclang::warning(), Glob.getCGM().getContext());
+      llvm::WithColor::warning() << "cleanup not handled for: ";
+      Child->dump(llvm::WithColor::warning(), Glob.getCGM().getContext());
     }
   });
   return Ret;
@@ -2288,7 +2291,8 @@ ValueCategory MLIRScanner::EmitScalarCast(mlir::Location Loc, ValueCategory Src,
     bool InputSigned = SrcQT->isSignedIntegerOrEnumerationType();
     if (SrcQT->isBooleanType()) {
       // TODO: Should check options
-      CGEIST_WARNING(mlirclang::warning() << "Treating boolean as unsigned\n");
+      CGEIST_WARNING(llvm::WithColor::warning()
+                     << "Treating boolean as unsigned\n");
       InputSigned = false;
     }
 
@@ -2306,7 +2310,7 @@ ValueCategory MLIRScanner::EmitScalarCast(mlir::Location Loc, ValueCategory Src,
     // If we can't recognize overflow as undefined behavior, assume that
     // overflow saturates. This protects against normal optimizations if we are
     // compiling with non-standard FP semantics.
-    CGEIST_WARNING(mlirclang::warning()
+    CGEIST_WARNING(llvm::WithColor::warning()
                    << "Performing strict float cast overflow\n");
 
     if (IsSigned)
@@ -2362,8 +2366,9 @@ ValueCategory MLIRScanner::EmitScalarConversion(ValueCategory Src,
     if (DstTy.isa<FloatType>()) {
       CGEIST_WARNING({
         if (CGM.getContext().getTargetInfo().useFP16ConversionIntrinsics())
-          mlirclang::warning() << "Should call convert_from_fp16 intrinsic "
-                                  "to perfom this conversion\n";
+          llvm::WithColor::warning()
+              << "Should call convert_from_fp16 intrinsic "
+                 "to perfom this conversion\n";
       });
     } else {
       // Cast to other types through float, using either the intrinsic or FPExt,
@@ -2371,8 +2376,9 @@ ValueCategory MLIRScanner::EmitScalarConversion(ValueCategory Src,
       // (as opposed to operations on half, available with NativeHalfType).
       CGEIST_WARNING({
         if (CGM.getContext().getTargetInfo().useFP16ConversionIntrinsics())
-          mlirclang::warning() << "Should call convert_from_fp16 intrinsic "
-                                  "to perfom this conversion\n";
+          llvm::WithColor::warning()
+              << "Should call convert_from_fp16 intrinsic "
+                 "to perfom this conversion\n";
       });
 
       Src = Src.FPExt(Builder, MLIRLoc, Builder.getF32Type());
@@ -2383,7 +2389,7 @@ ValueCategory MLIRScanner::EmitScalarConversion(ValueCategory Src,
 
   // Ignore conversions like int -> uint.
   if (SrcTy == DstTy) {
-    CGEIST_WARNING(mlirclang::warning()
+    CGEIST_WARNING(llvm::WithColor::warning()
                    << "Not emitting implicit integer sign change checks\n");
 
     return Src;
@@ -2407,7 +2413,7 @@ ValueCategory MLIRScanner::EmitScalarConversion(ValueCategory Src,
 
   // Finally, we have the arithmetic types: real int/float.
   mlir::Type ResTy = DstTy;
-  CGEIST_WARNING(mlirclang::warning() << "Missing overflow checks\n");
+  CGEIST_WARNING(llvm::WithColor::warning() << "Missing overflow checks\n");
 
   // Cast to half through float if half isn't a native type.
   if (DstQT->isHalfType() && !CGM.getContext().getLangOpts().NativeHalfType) {
@@ -2417,8 +2423,8 @@ ValueCategory MLIRScanner::EmitScalarConversion(ValueCategory Src,
       // (as opposed to operations on half, available with NativeHalfType).
       CGEIST_WARNING({
         if (CGM.getContext().getTargetInfo().useFP16ConversionIntrinsics())
-          mlirclang::warning() << "Should call convert_to_fp16 intrinsic "
-                                  "to perfom this conversion\n";
+          llvm::WithColor::warning() << "Should call convert_to_fp16 intrinsic "
+                                        "to perfom this conversion\n";
       });
       // If the half type is supported, just use an fptrunc.
       return Src.FPTrunc(Builder, MLIRLoc, DstTy);
@@ -2431,7 +2437,7 @@ ValueCategory MLIRScanner::EmitScalarConversion(ValueCategory Src,
   if (DstTy != ResTy) {
     if (CGM.getContext().getTargetInfo().useFP16ConversionIntrinsics()) {
       assert(ResTy.isInteger(16) && "Only half FP requires extra conversion");
-      CGEIST_WARNING(mlirclang::warning()
+      CGEIST_WARNING(llvm::WithColor::warning()
                      << "Should call convert_to_fp16 intrinsic to "
                         "perfom this conversion\n");
     }
@@ -2439,8 +2445,8 @@ ValueCategory MLIRScanner::EmitScalarConversion(ValueCategory Src,
   }
 
   CGEIST_WARNING({
-    mlirclang::warning() << "Missing truncation checks\n";
-    mlirclang::warning() << "Missing integer sign change checks\n";
+    llvm::WithColor::warning() << "Missing truncation checks\n";
+    llvm::WithColor::warning() << "Missing integer sign change checks\n";
   });
 
   return Res;
@@ -2564,7 +2570,7 @@ std::pair<ValueCategory, ValueCategory> MLIRScanner::EmitCompoundAssignLValue(
 
   CGEIST_WARNING({
     if (E->getComputationResultType()->isAnyComplexType())
-      mlirclang::warning() << "Not handling complex types yet\n";
+      llvm::WithColor::warning() << "Not handling complex types yet\n";
   });
 
   // Emit the RHS first.  __block variables need to have the rhs evaluated
@@ -2586,15 +2592,14 @@ std::pair<ValueCategory, ValueCategory> MLIRScanner::EmitCompoundAssignLValue(
   const SourceLocation Loc = E->getExprLoc();
 
   // Load/convert the LHS.
-  CGEIST_WARNING(mlirclang::warning() << "Emitting unchecked LValue\n");
+  CGEIST_WARNING(llvm::WithColor::warning() << "Emitting unchecked LValue\n");
 
   const ValueCategory LHSLV = EmitLValue(E->getLHS());
-  CGEIST_WARNING(
-      {
-        if (isa<AtomicType>(LHSTy))
-          mlirclang::warning()
-              << "Not handling atomics. Should perform RMW operation here.\n";
-      });
+  CGEIST_WARNING({
+    if (isa<AtomicType>(LHSTy))
+      llvm::WithColor::warning()
+          << "Not handling atomics. Should perform RMW operation here.\n";
+  });
 
   ValueCategory LHS{LHSLV.getValue(Builder), false};
   if (!PromotionTypeLHS.isNull())
@@ -2612,8 +2617,9 @@ std::pair<ValueCategory, ValueCategory> MLIRScanner::EmitCompoundAssignLValue(
 
   CGEIST_WARNING({
     if (Glob.getCGM().getLangOpts().OpenMP)
-      mlirclang::warning() << "Should checkAndEmitLastprivateConditional, "
-                              "but not implemented yet.\n";
+      llvm::WithColor::warning()
+          << "Should checkAndEmitLastprivateConditional, "
+             "but not implemented yet.\n";
   });
 
   return {LHSLV, Result};
@@ -2688,7 +2694,7 @@ ValueCategory MLIRScanner::EmitBinMul(const BinOpInfo &Info) {
 
 ValueCategory MLIRScanner::EmitBinDiv(const BinOpInfo &Info) {
   CGEIST_WARNING(
-      mlirclang::warning()
+      llvm::WithColor::warning()
       << "Not checking division by zero nor signed integer overflow.\n");
 
   assert(!Info.getType()->isConstantMatrixType() && "Not implemented");
@@ -2708,7 +2714,8 @@ ValueCategory MLIRScanner::EmitBinDiv(const BinOpInfo &Info) {
         // build option allows an application to specify that single precision
         // floating-point divide (x/y and 1/x) and sqrt used in the program
         // source are correctly rounded.
-        mlirclang::warning() << "Not applying OpenCL/HIP precision options.\n";
+        llvm::WithColor::warning()
+            << "Not applying OpenCL/HIP precision options.\n";
       }
     });
     return LHS.FDiv(Builder, Loc, RHS);
@@ -2720,7 +2727,7 @@ ValueCategory MLIRScanner::EmitBinDiv(const BinOpInfo &Info) {
 
 ValueCategory MLIRScanner::EmitBinRem(const BinOpInfo &Info) {
   CGEIST_WARNING(
-      mlirclang::warning()
+      llvm::WithColor::warning()
       << "Not checking division by zero nor signed integer overflow.\n");
 
   const auto Loc = getMLIRLocation(Info.getExpr()->getExprLoc());
@@ -2990,7 +2997,7 @@ ValueCategory MLIRScanner::EmitBinShl(const BinOpInfo &Info) {
     this->Loc = Loc;
     RHS = ConstrainShiftValue(LHS, RHS);
   } else {
-    CGEIST_WARNING(mlirclang::warning() << "Not performing SHL checks\n");
+    CGEIST_WARNING(llvm::WithColor::warning() << "Not performing SHL checks\n");
   }
 
   return LHS.Shl(Builder, Loc, RHS.val);
@@ -3010,7 +3017,7 @@ ValueCategory MLIRScanner::EmitBinShr(const BinOpInfo &Info) {
     this->Loc = Loc;
     RHS = ConstrainShiftValue(LHS, RHS);
   } else {
-    CGEIST_WARNING(mlirclang::warning() << "Not performing SHR checks\n");
+    CGEIST_WARNING(llvm::WithColor::warning() << "Not performing SHR checks\n");
   }
 
   if (Info.getType()->hasUnsignedIntegerRepresentation())

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -805,7 +805,8 @@ MLIRScanner::VisitCXXScalarValueInitExpr(clang::CXXScalarValueInitExpr *Expr) {
 ValueCategory MLIRScanner::VisitCXXPseudoDestructorExpr(
     clang::CXXPseudoDestructorExpr *Expr) {
   Visit(Expr->getBase());
-  mlirclang::warning() << "not running pseudo destructor\n";
+  CGEIST_WARNING(llvm::WithColor::warning()
+                 << "not running pseudo destructor\n");
   return nullptr;
 }
 
@@ -2671,7 +2672,8 @@ BinOpInfo MLIRScanner::EmitBinOps(BinaryOperator *E, QualType PromotionType) {
 static void informNoOverflowCheck(LangOptions::SignedOverflowBehaviorTy SOB,
                                   llvm::StringRef OpName) {
   if (SOB != clang::LangOptions::SOB_Defined)
-    mlirclang::warning() << "Not emitting overflow-checked " << OpName << "\n";
+    llvm::WithColor::warning()
+        << "Not emitting overflow-checked " << OpName << "\n";
 }
 
 ValueCategory MLIRScanner::EmitBinMul(const BinOpInfo &Info) {
@@ -2680,8 +2682,8 @@ ValueCategory MLIRScanner::EmitBinMul(const BinOpInfo &Info) {
   const auto RHS = Info.getRHS().val;
 
   if (Info.getType()->isSignedIntegerOrEnumerationType()) {
-    informNoOverflowCheck(
-        Glob.getCGM().getLangOpts().getSignedOverflowBehavior(), "mul");
+    CGEIST_WARNING(informNoOverflowCheck(
+        Glob.getCGM().getLangOpts().getSignedOverflowBehavior(), "mul"));
     return LHS.Mul(Builder, Loc, RHS);
   }
 
@@ -2880,8 +2882,8 @@ ValueCategory MLIRScanner::EmitBinAdd(const BinOpInfo &Info) {
     return EmitPointerArithmetic(Info);
 
   if (Info.getType()->isSignedIntegerOrEnumerationType()) {
-    informNoOverflowCheck(
-        Glob.getCGM().getLangOpts().getSignedOverflowBehavior(), "add");
+    CGEIST_WARNING(informNoOverflowCheck(
+        Glob.getCGM().getLangOpts().getSignedOverflowBehavior(), "add"));
     return LHS.Add(Builder, Loc, RHS);
   }
 
@@ -2901,8 +2903,8 @@ ValueCategory MLIRScanner::EmitBinSub(const BinOpInfo &Info) {
   // The LHS is always a pointer if either side is.
   if (!mlirclang::isPointerOrMemRefTy(LHS.val.getType())) {
     if (Info.getType()->isSignedIntegerOrEnumerationType()) {
-      informNoOverflowCheck(
-          Glob.getCGM().getLangOpts().getSignedOverflowBehavior(), "sub");
+      CGEIST_WARNING(informNoOverflowCheck(
+          Glob.getCGM().getLangOpts().getSignedOverflowBehavior(), "sub"));
       return LHS.Sub(Builder, Loc, RHS.val);
     }
     assert(!Info.getType()->isConstantMatrixType() && "Not yet implemented");

--- a/polygeist/tools/cgeist/Lib/CGStmt.cc
+++ b/polygeist/tools/cgeist/Lib/CGStmt.cc
@@ -573,8 +573,9 @@ MLIRScanner::VisitOMPParallelDirective(clang::OMPParallelDirective *Par) {
       }
       break;
     default:
-      mlirclang::warning() << "may not handle omp clause "
-                           << (int)F->getClauseKind() << "\n";
+      CGEIST_WARNING(llvm::WithColor::warning()
+                     << "may not handle omp clause " << (int)F->getClauseKind()
+                     << "\n");
     }
   }
 

--- a/polygeist/tools/cgeist/Lib/CGStmt.cc
+++ b/polygeist/tools/cgeist/Lib/CGStmt.cc
@@ -1086,7 +1086,8 @@ ValueCategory MLIRScanner::VisitGotoStmt(clang::GotoStmt *Stmt) {
 }
 
 ValueCategory MLIRScanner::VisitCXXTryStmt(clang::CXXTryStmt *Stmt) {
-  mlirclang::warning() << "not performing catches for try stmt\n";
+  CGEIST_WARNING(mlirclang::warning()
+                 << "not performing catches for try stmt\n");
   return Visit(Stmt->getTryBlock());
 }
 

--- a/polygeist/tools/cgeist/Lib/CGStmt.cc
+++ b/polygeist/tools/cgeist/Lib/CGStmt.cc
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/Diagnostics.h"
+#include "llvm/Support/WithColor.h"
 
 #define DEBUG_TYPE "CGStmt"
 
@@ -1086,7 +1087,7 @@ ValueCategory MLIRScanner::VisitGotoStmt(clang::GotoStmt *Stmt) {
 }
 
 ValueCategory MLIRScanner::VisitCXXTryStmt(clang::CXXTryStmt *Stmt) {
-  CGEIST_WARNING(mlirclang::warning()
+  CGEIST_WARNING(llvm::WithColor::warning()
                  << "not performing catches for try stmt\n");
   return Visit(Stmt->getTryBlock());
 }

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -29,6 +29,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ModRef.h"
+#include "llvm/Support/WithColor.h"
 #include "llvm/Support/raw_ostream.h"
 
 #define DEBUG_TYPE "cgeist"
@@ -341,8 +342,9 @@ void ClangToLLVMArgMapping::construct(const clang::ASTContext &Context,
 
       CGEIST_WARNING({
         if (AI.isDirect() && AI.getCanBeFlattened() && STy)
-          mlirclang::warning() << "struct should be flattened but MLIR codegen "
-                                  "cannot yet handle it. Needs to be fixed.\n";
+          llvm::WithColor::warning()
+              << "struct should be flattened but MLIR codegen "
+                 "cannot yet handle it. Needs to be fixed.\n";
       });
 
       if (AllowStructFlattening && AI.isDirect() && AI.getCanBeFlattened() &&
@@ -478,7 +480,7 @@ CodeGenTypes::getFunctionType(const clang::CodeGen::CGFunctionInfo &FI,
   case clang::CodeGen::ABIArgInfo::Indirect:
     if (!AllowSRet) {
       // HACK: remove once we can handle function returning a struct.
-      CGEIST_WARNING(mlirclang::warning()
+      CGEIST_WARNING(llvm::WithColor::warning()
                      << "function should return its value indirectly (as "
                         "an extra reference parameter). This is not yet "
                         "handled by the MLIR codegen\n");
@@ -595,8 +597,9 @@ CodeGenTypes::getFunctionType(const clang::CodeGen::CGFunctionInfo &FI,
 
       CGEIST_WARNING({
         if (ST && ArgInfo.isDirect() && ArgInfo.getCanBeFlattened())
-          mlirclang::warning() << "struct should be flattened but MLIR codegen "
-                                  "cannot yet handle it. Needs to be fixed.\n";
+          llvm::WithColor::warning()
+              << "struct should be flattened but MLIR codegen "
+                 "cannot yet handle it. Needs to be fixed.\n";
       });
 
       if (AllowStructFlattening && ST && ArgInfo.isDirect() &&
@@ -1346,8 +1349,9 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
       // name.
       CGEIST_WARNING({
         if (TypeName != "")
-          mlirclang::warning() << "SYCL type '" << ST->getName()
-                               << "' has not been converted to SYCL MLIR\n";
+          llvm::WithColor::warning()
+              << "SYCL type '" << ST->getName()
+              << "' has not been converted to SYCL MLIR\n";
       });
     }
 
@@ -1606,9 +1610,9 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
     if (Ty->is16bitFPTy()) {
       CGEIST_WARNING({
         if (CGM.getTarget().shouldEmitFloat16WithExcessPrecision()) {
-          mlirclang::warning() << "Experimental usage of _Float16. Code "
-                                  "generated will be illegal "
-                                  "for this target. Use with caution.\n";
+          llvm::WithColor::warning() << "Experimental usage of _Float16. Code "
+                                        "generated will be illegal "
+                                        "for this target. Use with caution.\n";
         }
       });
       return Builder.getF16Type();

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -23,6 +23,7 @@
 #include "mlir/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.h"
 
 #include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/WithColor.h"
 
 using namespace mlir;
 using namespace mlir::arith;
@@ -117,7 +118,7 @@ void ValueCategory::store(mlir::OpBuilder &builder, mlir::Value toStore) const {
             if (mt.getElementType() != spt.getElementType()) {
               // llvm::errs() << " func: " <<
               // val.getDefiningOp()->getParentOfType<FuncOp>() << "\n";
-              mlirclang::warning()
+              llvm::WithColor::warning()
                   << "potential store type mismatch:\n"
                   << "val: " << val << " tosval: " << toStore << "\n"
                   << "mt: " << mt << "spt: " << spt << "\n";
@@ -321,15 +322,15 @@ void ValueCategory::store(mlir::OpBuilder &builder, ValueCategory toStore,
 }
 
 template <typename OpTy> inline void warnUnconstrainedOp() {
-  mlirclang::warning() << "Creating unconstrained " << OpTy::getOperationName()
-                       << "\n";
+  llvm::WithColor::warning()
+      << "Creating unconstrained " << OpTy::getOperationName() << "\n";
 }
 
 template <typename OpTy> inline void warnNonExactOp(bool IsExact) {
   if (!IsExact)
     return;
-  mlirclang::warning() << "Creating exact " << OpTy::getOperationName()
-                       << " is not suported.\n";
+  llvm::WithColor::warning()
+      << "Creating exact " << OpTy::getOperationName() << " is not suported.\n";
 }
 
 ValueCategory ValueCategory::FPTrunc(OpBuilder &Builder, Location Loc,
@@ -573,9 +574,9 @@ static ValueCategory NUWNSWBinOp(mlir::OpBuilder &Builder, mlir::Location Loc,
   // No way of adding these flags to MLIR.
   CGEIST_WARNING({
     if (HasNUW)
-      mlirclang::warning() << "Not adding NUW flag.\n";
+      llvm::WithColor::warning() << "Not adding NUW flag.\n";
     if (HasNSW)
-      mlirclang::warning() << "Not adding NSW flag.\n";
+      llvm::WithColor::warning() << "Not adding NSW flag.\n";
   })
   return IntBinOp<OpTy>(Builder, Loc, LHS, RHS);
 }
@@ -664,7 +665,8 @@ ValueCategory ValueCategory::SubIndex(OpBuilder &Builder, Location Loc,
 
   CGEIST_WARNING({
     if (IsInBounds)
-      mlirclang::warning() << "Cannot create an inbounds SubIndex operation\n";
+      llvm::WithColor::warning()
+          << "Cannot create an inbounds SubIndex operation\n";
   });
 
   auto PtrTy = mlirclang::getPtrTyWithNewType(val.getType(), Type);
@@ -687,7 +689,7 @@ ValueCategory ValueCategory::GEP(OpBuilder &Builder, Location Loc, Type Type,
 
   CGEIST_WARNING({
     if (IsInBounds)
-      mlirclang::warning() << "Cannot create an inbounds GEP operation\n";
+      llvm::WithColor::warning() << "Cannot create an inbounds GEP operation\n";
   });
 
   auto PtrTy = mlirclang::getPtrTyWithNewType(val.getType(), Type);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -44,6 +44,7 @@
 
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/WithColor.h"
 #include "llvm/Support/raw_ostream.h"
 
 #define DEBUG_TYPE "cgeist"
@@ -295,8 +296,8 @@ void MLIRScanner::init(FunctionOpInterface func, const FunctionToEmit &FTE) {
 
   CGEIST_WARNING({
     if (auto CC = dyn_cast<clang::CXXDestructorDecl>(FD))
-      mlirclang::warning() << "destructor not fully handled yet for: " << CC
-                           << "\n";
+      llvm::WithColor::warning()
+          << "destructor not fully handled yet for: " << CC << "\n";
   });
 
   auto i1Ty = Builder.getIntegerType(1);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -239,7 +239,7 @@ void MLIRScanner::init(FunctionOpInterface func, const FunctionToEmit &FTE) {
 
           clang::Expr *init = expr->getInit();
           if (auto clean = dyn_cast<clang::ExprWithCleanups>(init)) {
-            mlirclang::warning() << "TODO: cleanup\n";
+            CGEIST_WARNING(llvm::WithColor::warning() << "TODO: cleanup\n");
             init = clean->getSubExpr();
           }
 
@@ -251,7 +251,7 @@ void MLIRScanner::init(FunctionOpInterface func, const FunctionToEmit &FTE) {
         if (expr->isDelegatingInitializer()) {
           clang::Expr *init = expr->getInit();
           if (auto clean = dyn_cast<clang::ExprWithCleanups>(init)) {
-            mlirclang::warning() << "TODO: cleanup\n";
+            CGEIST_WARNING(llvm::WithColor::warning() << "TODO: cleanup\n");
             init = clean->getSubExpr();
           }
 

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -293,9 +293,11 @@ void MLIRScanner::init(FunctionOpInterface func, const FunctionToEmit &FTE) {
     }
   }
 
-  if (auto CC = dyn_cast<clang::CXXDestructorDecl>(FD))
-    mlirclang::warning() << "destructor not fully handled yet for: " << CC
-                         << "\n";
+  CGEIST_WARNING({
+    if (auto CC = dyn_cast<clang::CXXDestructorDecl>(FD))
+      mlirclang::warning() << "destructor not fully handled yet for: " << CC
+                           << "\n";
+  });
 
   auto i1Ty = Builder.getIntegerType(1);
   auto type = MemRefType::get({}, i1Ty, {}, 0);

--- a/polygeist/tools/cgeist/Lib/utils.cc
+++ b/polygeist/tools/cgeist/Lib/utils.cc
@@ -20,8 +20,6 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/Support/WithColor.h"
-#include "llvm/Support/raw_ostream.h"
 
 using namespace mlir;
 
@@ -86,7 +84,5 @@ gpu::GPUModuleOp getDeviceModule(ModuleOp Module) {
   return cast<gpu::GPUModuleOp>(
       Module.lookupSymbol(MLIRASTConsumer::DeviceModuleName));
 }
-
-llvm::raw_ostream &warning() { return llvm::WithColor::warning(); }
 
 } // namespace mlirclang

--- a/polygeist/tools/cgeist/Lib/utils.cc
+++ b/polygeist/tools/cgeist/Lib/utils.cc
@@ -25,8 +25,6 @@
 
 using namespace mlir;
 
-extern llvm::cl::opt<bool> SuppressWarnings;
-
 namespace mlirclang {
 
 Operation *buildLinalgOp(llvm::StringRef Name, OpBuilder &B,
@@ -89,10 +87,6 @@ gpu::GPUModuleOp getDeviceModule(ModuleOp Module) {
       Module.lookupSymbol(MLIRASTConsumer::DeviceModuleName));
 }
 
-llvm::raw_ostream &warning() {
-  if (SuppressWarnings)
-    return llvm::nulls();
-  return llvm::WithColor::warning();
-}
+llvm::raw_ostream &warning() { return llvm::WithColor::warning(); }
 
 } // namespace mlirclang

--- a/polygeist/tools/cgeist/Lib/utils.h
+++ b/polygeist/tools/cgeist/Lib/utils.h
@@ -9,6 +9,15 @@
 #ifndef MLIR_TOOLS_MLIRCLANG_UTILS_H
 #define MLIR_TOOLS_MLIRCLANG_UTILS_H
 
+#include "llvm/Support/CommandLine.h"
+
+extern llvm::cl::opt<bool> SuppressWarnings;
+
+#define CGEIST_WARNING(X)                                                      \
+  if (!SuppressWarnings) {                                                     \
+    X;                                                                         \
+  }
+
 namespace clang {
 class DeclContext;
 }

--- a/polygeist/tools/cgeist/Lib/utils.h
+++ b/polygeist/tools/cgeist/Lib/utils.h
@@ -66,9 +66,6 @@ FunctionContext getInputContext(const mlir::OpBuilder &Builder);
 /// Return the device module in the input module.
 mlir::gpu::GPUModuleOp getDeviceModule(mlir::ModuleOp Module);
 
-/// Emit a warning if -w is not in effect.
-llvm::raw_ostream &warning();
-
 } // namespace mlirclang
 
 #endif // MLIR_TOOLS_MLIRCLANG_UTILS_H

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -55,6 +55,7 @@
 #include "llvm/Support/Host.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/Program.h"
+#include "llvm/Support/WithColor.h"
 
 #include "Options.h"
 #include "polygeist/Dialect.h"
@@ -858,7 +859,7 @@ getOptimizationLevel(unsigned OptimizationLevel) {
     return llvm::OptimizationLevel::O3;
   default:
     // All speed levels above 2 are equivalent to '-O3'
-    CGEIST_WARNING(mlirclang::warning()
+    CGEIST_WARNING(llvm::WithColor::warning()
                    << "optimization level '-O" << OptimizationLevel
                    << "' is not supported; using '-O3' instead\n");
   }

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -858,8 +858,9 @@ getOptimizationLevel(unsigned OptimizationLevel) {
     return llvm::OptimizationLevel::O3;
   default:
     // All speed levels above 2 are equivalent to '-O3'
-    mlirclang::warning() << "optimization level '-O" << OptimizationLevel
-                         << "' is not supported; using '-O3' instead\n";
+    CGEIST_WARNING(mlirclang::warning()
+                   << "optimization level '-O" << OptimizationLevel
+                   << "' is not supported; using '-O3' instead\n");
   }
   return llvm::OptimizationLevel::O3;
 }


### PR DESCRIPTION
Define CGEIST_WARNING macro to avoid evaluating not needed expressions if -w is passed.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>