### PR TITLE
[SYCL-MLIR] Implement vector elementwise modification

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -944,9 +944,8 @@ MLIRScanner::EmitVectorSubscript(clang::ArraySubscriptExpr *Expr) {
 
 ValueCategory
 MLIRScanner::EmitArraySubscriptExpr(clang::ArraySubscriptExpr *E) {
-  if (!E->getBase()->getType()->isVectorType()) {
+  if (!E->getBase()->getType()->isVectorType())
     return Visit(E);
-  }
 
   auto LHS = EmitLValue(E->getBase());
   auto Idx = Visit(E->getIdx());

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -948,7 +948,7 @@ MLIRScanner::EmitArraySubscriptExpr(clang::ArraySubscriptExpr *E) {
     return Visit(E);
   }
 
-  auto LHS = Visit(E->getBase());
+  auto LHS = EmitLValue(E->getBase());
   auto Idx = Visit(E->getIdx());
   return {LHS.val, Idx.val};
 }

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -943,6 +943,17 @@ MLIRScanner::EmitVectorSubscript(clang::ArraySubscriptExpr *Expr) {
 }
 
 ValueCategory
+MLIRScanner::EmitArraySubscriptExpr(clang::ArraySubscriptExpr *E) {
+  if (!E->getBase()->getType()->isVectorType()) {
+    return Visit(E);
+  }
+
+  auto LHS = Visit(E->getBase());
+  auto Idx = Visit(E->getIdx());
+  return {LHS.val, Idx.val};
+}
+
+ValueCategory
 MLIRScanner::VisitArraySubscriptExpr(clang::ArraySubscriptExpr *Expr) {
   LLVM_DEBUG({
     llvm::dbgs() << "VisitArraySubscriptExpr: ";
@@ -2155,7 +2166,7 @@ ValueCategory MLIRScanner::VisitBinAssign(BinaryOperator *E) {
     llvm::dbgs() << "\n";
   });
   ValueCategory RHS = Visit(E->getRHS());
-  ValueCategory LHS = Visit(E->getLHS());
+  ValueCategory LHS = EmitLValue(E->getLHS());
 
   assert(LHS.isReference);
   mlir::Value ToStore = RHS.getValue(Builder);
@@ -2562,6 +2573,8 @@ ValueCategory MLIRScanner::EmitLValue(Expr *E) {
   }
   case Expr::ParenExprClass:
     return EmitLValue(cast<ParenExpr>(E)->getSubExpr());
+  case Expr::ArraySubscriptExprClass:
+    return EmitArraySubscriptExpr(cast<ArraySubscriptExpr>(E));
   }
 }
 

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -63,10 +63,9 @@ mlir::Value ValueCategory::getValue(mlir::OpBuilder &builder) const {
     auto c0 = builder.create<ConstantIndexOp>(loc, 0);
     Value Loaded = builder.create<memref::LoadOp>(
         loc, val, std::vector<mlir::Value>({c0}));
-    if (Index) {
+    if (Index)
       Loaded =
           ValueCategory{Loaded, false}.ExtractElement(builder, loc, *Index).val;
-    }
     return Loaded;
   }
   llvm_unreachable("type must be LLVMPointer or MemRef");

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -42,6 +42,14 @@ ValueCategory::ValueCategory(mlir::Value val, bool isReference)
   }
 }
 
+ValueCategory::ValueCategory(mlir::Value Val, mlir::Value Index)
+    : val{Val}, isReference{true}, Index{Index} {
+  assert(val.getType().isa<MemRefType>() &&
+         val.getType().cast<MemRefType>().getElementType().isa<VectorType>() &&
+         "Expecting memref of vector");
+  assert(Index.getType().isa<IntegerType>() && "Expecting integer index");
+}
+
 mlir::Value ValueCategory::getValue(mlir::OpBuilder &builder) const {
   assert(val && "must be not-null");
   if (!isReference)
@@ -53,8 +61,13 @@ mlir::Value ValueCategory::getValue(mlir::OpBuilder &builder) const {
   if (auto mt = val.getType().dyn_cast<mlir::MemRefType>()) {
     assert(mt.getShape().size() == 1 && "must have shape 1");
     auto c0 = builder.create<ConstantIndexOp>(loc, 0);
-    return builder.create<memref::LoadOp>(loc, val,
-                                          std::vector<mlir::Value>({c0}));
+    Value Loaded = builder.create<memref::LoadOp>(
+        loc, val, std::vector<mlir::Value>({c0}));
+    if (Index) {
+      Loaded =
+          ValueCategory{Loaded, false}.ExtractElement(builder, loc, *Index).val;
+    }
+    return Loaded;
   }
   llvm_unreachable("type must be LLVMPointer or MemRef");
 }
@@ -136,6 +149,18 @@ void ValueCategory::store(mlir::OpBuilder &builder, mlir::Value toStore) const {
   }
   if (auto mt = val.getType().dyn_cast<MemRefType>()) {
     assert(mt.getShape().size() == 1 && "must have size 1");
+
+    if (Index) {
+      auto VT = mt.getElementType().cast<mlir::VectorType>().getElementType();
+      assert(VT == toStore.getType() && "Vector insertion element mismatch");
+      const auto C0 = builder.createOrFold<arith::ConstantIntOp>(
+          loc, 0, builder.getI64Type());
+      ValueCategory Vec{builder.createOrFold<memref::LoadOp>(loc, val, C0),
+                        false};
+      Vec = Vec.InsertElement(builder, loc, toStore, *Index);
+      toStore = Vec.val;
+    }
+
     if (auto PT = toStore.getType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
       if (auto MT = val.getType()
                         .cast<MemRefType>()
@@ -779,6 +804,17 @@ ValueCategory ValueCategory::Insert(OpBuilder &Builder, Location Loc, Value V,
          "Invalid index");
 
   return {Builder.createOrFold<vector::InsertOp>(Loc, V, val, Indices), false};
+}
+
+ValueCategory ValueCategory::InsertElement(OpBuilder &Builder, Location Loc,
+                                           Value V, Value Idx) const {
+  assert(val.getType().isa<VectorType>() && "Expecting vector type");
+  assert(val.getType().cast<VectorType>().getElementType() == V.getType() &&
+         "Cannot insert value in vector of different type");
+  assert(Idx.getType().isa<IntegerType>() && "Index must be an integer");
+
+  return {Builder.createOrFold<vector::InsertElementOp>(Loc, V, val, Idx),
+          false};
 }
 
 ValueCategory ValueCategory::Extract(OpBuilder &Builder, Location Loc,

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -36,7 +36,7 @@ public:
   mlir::Value val;
   bool isReference;
   /// Holds the index the lvalue to a vector element refers to.
-  llvm::Optional<mlir::Value> Index;
+  llvm::Optional<mlir::Value> Index{llvm::None};
 
 public:
   ValueCategory() : val(nullptr), isReference(false) {}

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Value.h"
+#include "llvm/ADT/Optional.h"
 
 // Represents a rhs or lhs value.
 class ValueCategory {
@@ -34,11 +35,14 @@ private:
 public:
   mlir::Value val;
   bool isReference;
+  /// Holds the index the lvalue to a vector element refers to.
+  llvm::Optional<mlir::Value> Index;
 
 public:
   ValueCategory() : val(nullptr), isReference(false) {}
   ValueCategory(std::nullptr_t) : val(nullptr), isReference(false) {}
   ValueCategory(mlir::Value val, bool isReference);
+  ValueCategory(mlir::Value Val, mlir::Value Index);
 
   static ValueCategory getNullValue(mlir::OpBuilder &Builder,
                                     mlir::Location Loc, mlir::Type Type);
@@ -155,6 +159,8 @@ public:
 
   ValueCategory Insert(mlir::OpBuilder &Builder, mlir::Location Loc,
                        mlir::Value V, llvm::ArrayRef<int64_t> Indices) const;
+  ValueCategory InsertElement(mlir::OpBuilder &Builder, mlir::Location Loc,
+                              mlir::Value V, mlir::Value Idx) const;
   ValueCategory Extract(mlir::OpBuilder &Builder, mlir::Location Loc,
                         llvm::ArrayRef<int64_t> Indices) const;
   ValueCategory ExtractElement(mlir::OpBuilder &Builder, mlir::Location Loc,

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -74,30 +74,7 @@ MLIRScanner::MLIRScanner(MLIRASTConsumer &Glob, OwningOpRef<ModuleOp> &Module,
       CaptureKinds(), ThisCapture(nullptr), ArrayInit(), ThisVal(), ReturnVal(),
       LTInfo(LTInfo) {}
 
-void MLIRScanner::initUnsupportedFunctions() {
-  // FIXME: Implement Array subscript expression for vectors (rvalue).
-  // #3 0x000056079c19f88a MLIRScanner::CommonArrayLookup(ValueCategory,
-  // mlir::Value, bool, bool)
-  // #4 0x000056079c20e68b
-  // MLIRScanner::VisitArraySubscriptExpr(clang::ArraySubscriptExpr*)
-  UnsupportedFuncs.insert(
-      "_ZNK4sycl3_V13vecIlLi2EE8getValueILi2EivEElNSt9enable_ifILb1ET0_"
-      "E4typeEi");
-  UnsupportedFuncs.insert(
-      "_ZNK4sycl3_V13vecIlLi4EE8getValueILi4EivEElNSt9enable_ifILb1ET0_"
-      "E4typeEi");
-  UnsupportedFuncs.insert(
-      "_ZNK4sycl3_V13vecIlLi8EE8getValueILi8EivEElNSt9enable_ifILb1ET0_"
-      "E4typeEi");
-  // FIXME: Implement Array subscript expression for vectors (lvalue).
-  // #3 0x000055d43215b80a MLIRScanner::CommonArrayLookup(ValueCategory,
-  // mlir::Value, bool, bool)
-  // #4 0x000055d4321ca6bb
-  // MLIRScanner::VisitArraySubscriptExpr(clang::ArraySubscriptExpr*)
-  UnsupportedFuncs.insert(
-      "_ZN4sycl3_V13vecIlLi16EE8setValueILi16EivEEvNSt9enable_ifILb1ET0_"
-      "E4typeERKli");
-}
+void MLIRScanner::initUnsupportedFunctions() {}
 
 static void checkFunctionParent(const FunctionOpInterface F,
                                 FunctionContext Context,

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -380,6 +380,7 @@ private:
   ValueCategory EmitVectorInitList(clang::InitListExpr *Expr,
                                    mlir::VectorType VType);
   ValueCategory EmitVectorSubscript(clang::ArraySubscriptExpr *Expr);
+  ValueCategory EmitArraySubscriptExpr(clang::ArraySubscriptExpr *E);
 
 public:
   MLIRScanner(MLIRASTConsumer &Glob, mlir::OwningOpRef<mlir::ModuleOp> &Module,

--- a/polygeist/tools/cgeist/Test/Verification/vecaccess.c
+++ b/polygeist/tools/cgeist/Test/Verification/vecaccess.c
@@ -40,13 +40,13 @@ int test_store(int_vec *v, int idx, int el) {
 // CHECK-SAME:                        %[[VAL_0:.*]]: memref<?xvector<3xi32>>,
 // CHECK-SAME:                        %[[VAL_1:.*]]: i32,
 // CHECK-SAME:                        %[[VAL_2:.*]]: i32) -> i32
-// CHECK:           %[[VAL_3:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi32>>
-// CHECK:           %[[VAL_4:.*]] = vector.extractelement %[[VAL_3]]{{\[}}%[[VAL_1]] : i32] : vector<3xi32>
-// CHECK:           %[[VAL_5:.*]] = arith.addi %[[VAL_4]], %[[VAL_2]] : i32
-// CHECK:           %[[VAL_6:.*]] = vector.insertelement %[[VAL_5]], %[[VAL_3]]{{\[}}%[[VAL_1]] : i32] : vector<3xi32>
-// CHECK:           affine.store %[[VAL_6]], %[[VAL_0]][0] : memref<?xvector<3xi32>>
-// CHECK:           return %[[VAL_5]] : i32
-// CHECK:         }
+// CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi32>>
+// CHECK-NEXT:      %[[VAL_4:.*]] = vector.extractelement %[[VAL_3]]{{\[}}%[[VAL_1]] : i32] : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.addi %[[VAL_4]], %[[VAL_2]] : i32
+// CHECK-NEXT:      %[[VAL_6:.*]] = vector.insertelement %[[VAL_5]], %[[VAL_3]]{{\[}}%[[VAL_1]] : i32] : vector<3xi32>
+// CHECK-NEXT:      affine.store %[[VAL_6]], %[[VAL_0]][0] : memref<?xvector<3xi32>>
+// CHECK-NEXT:      return %[[VAL_5]] : i32
+// CHECK-NEXT:    }
 
 int test_inc(int_vec *v, int idx, int el) {
   return (*v)[idx] += el;

--- a/polygeist/tools/cgeist/Test/Verification/vecaccess.c
+++ b/polygeist/tools/cgeist/Test/Verification/vecaccess.c
@@ -54,9 +54,9 @@ int test_inc(int_vec *v, int idx, int el) {
 
 // CHECK-LABEL:   func.func @test_gen(
 // CHECK-SAME:                        %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32) -> vector<3xi32>
-// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 2 : i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:      %[[VAL_5:.*]] = arith.constant 0 : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 2 : i32
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : i32
 // CHECK-NEXT:      %[[VAL_6:.*]] = memref.alloca() : memref<1xvector<3xi32>>
 // CHECK-NEXT:      %[[VAL_7:.*]] = affine.load %[[VAL_6]][0] : memref<1xvector<3xi32>>
 // CHECK-NEXT:      %[[VAL_8:.*]] = vector.insertelement %[[VAL_0]], %[[VAL_7]]{{\[}}%[[VAL_5]] : i32] : vector<3xi32>

--- a/polygeist/tools/cgeist/Test/Verification/vecaccess.c
+++ b/polygeist/tools/cgeist/Test/Verification/vecaccess.c
@@ -21,3 +21,55 @@ int test_cons_idx(int_vec v) {
 int test_var_idx(int_vec v, unsigned i) {
   return v[i];
 }
+
+// CHECK-LABEL:   func.func @test_store(
+// CHECK-SAME:                          %[[VAL_0:.*]]: memref<?xvector<3xi32>>,
+// CHECK-SAME:                          %[[VAL_1:.*]]: i32,
+// CHECK-SAME:                          %[[VAL_2:.*]]: i32) -> i32 attributes
+// CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi32>>
+// CHECK-NEXT:      %[[VAL_4:.*]] = vector.insertelement %[[VAL_2]], %[[VAL_3]]{{\[}}%[[VAL_1]] : i32] : vector<3xi32>
+// CHECK-NEXT:      affine.store %[[VAL_4]], %[[VAL_0]][0] : memref<?xvector<3xi32>>
+// CHECK-NEXT:      return %[[VAL_2]] : i32
+// CHECK-NEXT:    }
+
+int test_store(int_vec *v, int idx, int el) {
+  return (*v)[idx] = el;
+}
+
+// CHECK-LABEL:   func.func @test_inc(
+// CHECK-SAME:                        %[[VAL_0:.*]]: memref<?xvector<3xi32>>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: i32,
+// CHECK-SAME:                        %[[VAL_2:.*]]: i32) -> i32
+// CHECK:           %[[VAL_3:.*]] = affine.load %[[VAL_0]][0] : memref<?xvector<3xi32>>
+// CHECK:           %[[VAL_4:.*]] = vector.extractelement %[[VAL_3]]{{\[}}%[[VAL_1]] : i32] : vector<3xi32>
+// CHECK:           %[[VAL_5:.*]] = arith.addi %[[VAL_4]], %[[VAL_2]] : i32
+// CHECK:           %[[VAL_6:.*]] = vector.insertelement %[[VAL_5]], %[[VAL_3]]{{\[}}%[[VAL_1]] : i32] : vector<3xi32>
+// CHECK:           affine.store %[[VAL_6]], %[[VAL_0]][0] : memref<?xvector<3xi32>>
+// CHECK:           return %[[VAL_5]] : i32
+// CHECK:         }
+
+int test_inc(int_vec *v, int idx, int el) {
+  return (*v)[idx] += el;
+}
+
+// CHECK-LABEL:   func.func @test_gen(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32) -> vector<3xi32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 2 : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[VAL_6:.*]] = memref.alloca() : memref<1xvector<3xi32>>
+// CHECK-NEXT:      %[[VAL_7:.*]] = affine.load %[[VAL_6]][0] : memref<1xvector<3xi32>>
+// CHECK-NEXT:      %[[VAL_8:.*]] = vector.insertelement %[[VAL_0]], %[[VAL_7]]{{\[}}%[[VAL_5]] : i32] : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_9:.*]] = vector.insertelement %[[VAL_1]], %[[VAL_8]]{{\[}}%[[VAL_4]] : i32] : vector<3xi32>
+// CHECK-NEXT:      %[[VAL_10:.*]] = vector.insertelement %[[VAL_2]], %[[VAL_9]]{{\[}}%[[VAL_3]] : i32] : vector<3xi32>
+// CHECK-NEXT:      affine.store %[[VAL_10]], %[[VAL_6]][0] : memref<1xvector<3xi32>>
+// CHECK-NEXT:      return %[[VAL_10]] : vector<3xi32>
+// CHECK-NEXT:    }
+
+int_vec test_gen(int a, int b, int c) {
+  int_vec v;
+  v[0] = a;
+  v[1] = b;
+  v[2] = c;
+  return v;
+}


### PR DESCRIPTION
Add an optional Index member variable to ValueCategory which will hold the index a vector element lvalue points to. If a ValueCategory holds an index, it must also hold a memref to a vector.

Loading/storing is extended with extractelement/insertelement for this kind of lvalues.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>