### PR TITLE
[SYCL-MLIR] Fix build warnings

### DIFF
--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsTypes.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsTypes.cpp
@@ -25,8 +25,6 @@ llvm::StringRef mlir::sycl::memoryAccessModeAsString(
     return "discard_read_write";
   case MemoryAccessMode::Atomic:
     return "atomic";
-  default:
-    llvm_unreachable("Invalid memory access mode");
   }
 }
 
@@ -80,8 +78,6 @@ llvm::StringRef mlir::sycl::memoryTargetModeAsString(
     return "host_image";
   case MemoryTargetMode::ImageArray:
     return "image_array";
-  default:
-    llvm_unreachable("Invalid memory target mode");
   }
 }
 


### PR DESCRIPTION
```
llvm/mlir-sycl/lib/Dialect/IR/SYCLOpsTypes.cpp:28:3: warning: default label in switch which covers all enumeration values [-Wcovered-switch-default]
  default:
  ^
llvm/mlir-sycl/lib/Dialect/IR/SYCLOpsTypes.cpp:83:3: warning: default label in switch which covers all enumeration values [-Wcovered-switch-default]
  default:
  ^
```

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>