### PR TITLE
[SYCL][Level Zero] Don't use ZE_MEMORY_ADVICE_SET_READ_MOSTLY for read-only USM

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -7942,9 +7942,12 @@ static pi_result USMSharedAllocImpl(void **ResultPtr, pi_context Context,
   // with the same command list handle.
   std::scoped_lock<pi_mutex> Lock(Context->ImmediateCommandListMutex);
 
-  ZE_CALL(zeCommandListAppendMemAdvise,
-          (Context->ZeCommandListInit, Device->ZeDevice, *ResultPtr, Size,
-           ZE_MEMORY_ADVICE_SET_READ_MOSTLY));
+  // TODO: Underlying Level Zero runtime has issues with this one.
+  // Re-enable/substitute with read_only once that is fixed/implemented.
+  //
+  // ZE_CALL(zeCommandListAppendMemAdvise,
+  //         (Context->ZeCommandListInit, Device->ZeDevice, *ResultPtr, Size,
+  //          ZE_MEMORY_ADVICE_SET_READ_MOSTLY));
 
   ZE_CALL(zeCommandListAppendMemAdvise,
           (Context->ZeCommandListInit, Device->ZeDevice, *ResultPtr, Size,

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -7942,12 +7942,8 @@ static pi_result USMSharedAllocImpl(void **ResultPtr, pi_context Context,
   // with the same command list handle.
   std::scoped_lock<pi_mutex> Lock(Context->ImmediateCommandListMutex);
 
-  // TODO: Underlying Level Zero runtime has issues with this one.
-  // Re-enable/substitute with read_only once that is fixed/implemented.
-  //
-  // ZE_CALL(zeCommandListAppendMemAdvise,
-  //         (Context->ZeCommandListInit, Device->ZeDevice, *ResultPtr, Size,
-  //          ZE_MEMORY_ADVICE_SET_READ_MOSTLY));
+  // TODO: Underlying Level Zero runtime doesn't have a way to communicate
+  // read-only property yet.
 
   ZE_CALL(zeCommandListAppendMemAdvise,
           (Context->ZeCommandListInit, Device->ZeDevice, *ResultPtr, Size,


### PR DESCRIPTION
There are issues in the underlying Level Zero RT causing stability problems. This partially reverts https://github.com/intel/llvm/pull/7496.