### PR TITLE
[SYCL][CUDA] Add missing macro to interop-backend-traits.cpp

### DIFF
--- a/sycl/test/basic_tests/interop-backend-traits.cpp
+++ b/sycl/test/basic_tests/interop-backend-traits.cpp
@@ -33,6 +33,7 @@ constexpr auto Backend = sycl::backend::ext_oneapi_hip;
 #endif
 
 #ifdef USE_CUDA_EXPERIMENTAL
+#define SYCL_EXT_ONEAPI_BACKEND_CUDA 1
 #define SYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL 1
 #include <sycl/ext/oneapi/experimental/backend/backend_traits_cuda.hpp>
 #include <sycl/ext/oneapi/experimental/backend/cuda.hpp>


### PR DESCRIPTION
This test generally uses traits of different backends when compiling using the default spirv triple. It seems this means that the test manually defines some macros that are usually defined by the backend. For the ext_oneapi_cuda case a macro was missing leading to the test failure. I have added this missing required macro.

Fixes this post-commit windows failure: https://github.com/intel/llvm/actions/runs/3585225542/jobs/6032932018

Signed-off-by: JackAKirk <jack.kirk@codeplay.com>