### PR TITLE
[SYCL-MLIR] Change body type parameters type to ArrayRef

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -221,7 +221,7 @@ def SYCL_GetScalarOpType : SYCL_Type<"GetScalarOp", "get_scalar_op"> {
 
 def SYCL_TupleValueHolderType : SYCL_Type<"TupleValueHolder", "tuple_value_holder"> {
   let parameters = (ins "::mlir::Type":$dataType,
-                        "llvm::SmallVector<mlir::Type, 4>":$body);
+                        ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dataType `]` `,` `(` $body `)` `>`";
 }
 
@@ -230,7 +230,7 @@ def SYCL_TupleCopyAssignableValueHolderType
         [SYCLInheritanceTypeTrait<"TupleValueHolderType">]> {
   let parameters = (ins "::mlir::Type":$dataType,
                         "bool":$isTriviallyCopyAssignable,
-                        "llvm::SmallVector<mlir::Type, 4>":$body);
+                        ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dataType `,` $isTriviallyCopyAssignable `]` `,` `(` $body `)` `>`";
 }
 
@@ -254,12 +254,12 @@ def SYCL_AtomicType : SYCL_Type<"Atomic", "atomic"> {
 }
 
 def SYCL_AssertHappenedType : SYCL_Type<"AssertHappened", "assert_happened"> {
-  let parameters = (ins "llvm::SmallVector<mlir::Type, 4>":$body);
+  let parameters = (ins ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `(` $body `)` `>`";
 }
 
 def SYCL_BFloat16Type : SYCL_Type<"BFloat16", "bfloat16"> {
-  let parameters = (ins "llvm::SmallVector<mlir::Type, 4>":$body);
+  let parameters = (ins ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `(` $body `)` `>`";
 }
 

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -145,7 +145,7 @@ def SYCL_AccessorType
                         "unsigned":$dimension,
                         "mlir::sycl::MemoryAccessMode":$accessMode,
                         "mlir::sycl::MemoryTargetMode":$targetMode,
-                        "llvm::SmallVector<mlir::Type, 4>":$body);
+                        ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat =
       "`<` `[` $dimension `,` $type `,` ` ` custom<MemoryAccessMode>($accessMode) `,` ` ` custom<MemoryTargetMode>($targetMode) `]` `,` `(` $body `)` `>`";
 }
@@ -158,53 +158,53 @@ def SYCL_RangeType
 
 def SYCL_NdRangeType : SYCL_Type<"NdRange", "nd_range"> {
   let parameters = (ins "unsigned":$dimension,
-                        "llvm::SmallVector<mlir::Type, 4>":$body);
+                        ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dimension `]` `,` `(` $body `)` `>`";
 }
 
 def SYCL_AccessorImplType :
     SYCL_Type<"AccessorImplDevice", "accessor_impl_device"> {
   let parameters = (ins "unsigned":$dimension,
-                        "llvm::SmallVector<mlir::Type, 4>":$body);
+                        ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dimension `]` `,` `(` $body `)` `>`";
 }
 
 def SYCL_AccessorSubscriptType :
     SYCL_Type<"AccessorSubscript", "accessor_subscript"> {
   let parameters = (ins "int":$currentDimension,
-                        "llvm::SmallVector<mlir::Type, 4>":$body);
+                        ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $currentDimension `]` `,` `(` $body `)` `>`";
 }
 
 def SYCL_ArrayType : SYCL_Type<"Array", "array"> {
   let parameters = (ins "unsigned":$dimension,
-                        "llvm::SmallVector<mlir::Type, 4>":$body);
+                        ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dimension `]` `,` `(` $body `)` `>`";
 }
 
 def SYCL_ItemType : SYCL_Type<"Item", "item"> {
   let parameters = (ins "unsigned":$dimension,
                         "bool":$withOffset,
-                        "llvm::SmallVector<mlir::Type, 4>":$body);
+                        ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dimension `,` $withOffset `]` `,` `(` $body `)` `>`";
 }
 
 def SYCL_ItemBaseType : SYCL_Type<"ItemBase", "item_base"> {
   let parameters = (ins "unsigned":$dimension,
                         "bool":$withOffset,
-                        "llvm::SmallVector<mlir::Type, 4>":$body);
+                        ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dimension `,` $withOffset `]` `,` `(` $body `)` `>`";
 }
 
 def SYCL_NdItemType : SYCL_Type<"NdItem", "nd_item"> {
   let parameters = (ins "unsigned":$dimension,
-                        "llvm::SmallVector<mlir::Type, 4>":$body);
+                        ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dimension `]` `,` `(` $body `)` `>`";
 }
 
 def SYCL_GroupType : SYCL_Type<"Group", "group"> {
   let parameters = (ins "unsigned":$dimension,
-                        "llvm::SmallVector<mlir::Type, 4>":$body);
+                        ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dimension `]` `,` `(` $body `)` `>`";
 }
 
@@ -215,7 +215,7 @@ def SYCL_GetOpType : SYCL_Type<"GetOp", "get_op"> {
 
 def SYCL_GetScalarOpType : SYCL_Type<"GetScalarOp", "get_scalar_op"> {
   let parameters = (ins "::mlir::Type":$dataType,
-                        "llvm::SmallVector<mlir::Type, 4>":$body);
+                        ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dataType `]` `,` `(` $body `)` `>`";
 }
 
@@ -241,7 +241,7 @@ def VectorSplatArg : MemRefOf<[VectorEltTy]>;
 def SYCL_VecType : SYCL_Type<"Vec", "vec"> {
   let parameters = (ins "::mlir::Type":$dataType,
                         "int":$numElements,
-                        "llvm::SmallVector<mlir::Type, 4>":$body);
+                        ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dataType `,` $numElements `]` `,` `(` $body `)` `>`";
   let genVerifyDecl = 1;
 }
@@ -249,7 +249,7 @@ def SYCL_VecType : SYCL_Type<"Vec", "vec"> {
 def SYCL_AtomicType : SYCL_Type<"Atomic", "atomic"> {
   let parameters = (ins "::mlir::Type":$dataType,
                         "mlir::sycl::AccessAddrSpace":$addrSpace,
-                        "llvm::SmallVector<mlir::Type, 4>":$body);
+                        ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dataType `,` custom<AccessAddrSpace>($addrSpace) `]` `,` `(` $body `)` `>`";
 }
 

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsTypes.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsTypes.cpp
@@ -156,7 +156,7 @@ mlir::sycl::getDerivedTypes(mlir::TypeID TypeID) {
 mlir::LogicalResult
 mlir::sycl::VecType::verify(llvm::function_ref<InFlightDiagnostic()> EmitError,
                             mlir::Type DataT, int NumElements,
-                            llvm::SmallVector<mlir::Type, 4>) {
+                            llvm::ArrayRef<mlir::Type>) {
   if (!(NumElements == 1 || NumElements == 2 || NumElements == 3 ||
         NumElements == 4 || NumElements == 8 || NumElements == 16)) {
     return EmitError() << "SYCL vector types can only hold 1, 2, 3, 4, 8 or 16 "

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -4,11 +4,12 @@
 #include <sycl/aliases.hpp>
 #include <sycl/sycl.hpp>
 
-// CHECK-DAG: !sycl_accessor_1_i32_w_gb = !sycl.accessor<[1, i32, write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>
+// CHECK-DAG: !sycl_accessor_1_i32_w_gb = !sycl.accessor<[1, i32, write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
 // CHECK-DAG: !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>
 // CHECK-DAG: !sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
 // CHECK-DAG: !sycl_array_2_ = !sycl.array<[2], (memref<2xi64, 4>)>
-// CHECK-DAG: ![[ITEM:.*]] = !sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>)>
+// CHECK-DAG: ![[ITEM_BASE:.*]] = !sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>
+// CHECK-DAG: ![[ITEM:.*]] = !sycl.item<[2, true], (![[ITEM_BASE]])>
 
 // Check globals referenced in device functions are created in the GPU module
 // CHECK: gpu.module @device_functions {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -10,13 +10,15 @@
 
 // CHECK-MLIR-DAG: !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>
 // CHECK-MLIR-DAG: !sycl_accessor_impl_device_2_ = !sycl.accessor_impl_device<[2], (!sycl.id<2>, !sycl.range<2>, !sycl.range<2>)>
-// CHECK-MLIR-DAG: !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>
-// CHECK-MLIR-DAG: !sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl.id<2>, !sycl.range<2>, !sycl.range<2>)>, !llvm.struct<(ptr<i32, 1>)>)>
+// CHECK-MLIR-DAG: !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+// CHECK-MLIR-DAG: !sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<i32, 1>)>)>
 // CHECK-MLIR-DAG: !sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
 // CHECK-MLIR-DAG: !sycl_array_2_ = !sycl.array<[2], (memref<2xi64, 4>)>
-// CHECK-MLIR-DAG: ![[ACC_SUBSCRIPT:.*]] = !sycl.accessor_subscript<[1], (!sycl.id<2>, !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl.id<2>, !sycl.range<2>, !sycl.range<2>)>, !llvm.struct<(ptr<i32, 1>)>)>)>
-// CHECK-MLIR-DAG: ![[ITEM1:.*]] = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>
-// CHECK-MLIR-DAG: ![[ITEM2:.*]] = !sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>)>
+// CHECK-MLIR-DAG: ![[ACC_SUBSCRIPT:.*]] = !sycl.accessor_subscript<[1], (!sycl.id<2>, !sycl_accessor_2_i32_rw_gb)>
+// CHECK-MLIR-DAG: ![[ITEM_BASE1:.*]] = !sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>
+// CHECK-MLIR-DAG: ![[ITEM_BASE2:.*]] = !sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>
+// CHECK-MLIR-DAG: ![[ITEM1:.*]] = !sycl.item<[1, true], (!sycl_item_base_1_)>
+// CHECK-MLIR-DAG: ![[ITEM2:.*]] = !sycl.item<[2, true], (!sycl_item_base_2_)>
 
 // CHECK-LLVM-DAG: %"class.sycl::_V1::detail::array.1" = type { [1 x i64] }
 // CHECK-LLVM-DAG: %"class.sycl::_V1::detail::array.2" = type { [2 x i64] }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -11,8 +11,8 @@
 // CHECK-DAG: !sycl_group_2_ = !sycl.group<[2], (!sycl.range<2>, !sycl.range<2>, !sycl.range<2>, !sycl.id<2>)>
 // CHECK-DAG: ![[ITEM1:.*]] = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>
 // CHECK-DAG: ![[ITEM2:.*]] = !sycl.item<[2, false], (!sycl.item_base<[2, false], (!sycl.range<2>, !sycl.id<2>)>)>
-// CHECK-DAG: !sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>, !sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl.range<1>, !sycl.id<1>)>)>, !sycl.group<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>)>
-// CHECK-DAG: !sycl_nd_item_2_ = !sycl.nd_item<[2], (!sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>)>, !sycl.item<[2, false], (!sycl.item_base<[2, false], (!sycl.range<2>, !sycl.id<2>)>)>, !sycl.group<[2], (!sycl.range<2>, !sycl.range<2>, !sycl.range<2>, !sycl.id<2>)>)>
+// CHECK-DAG: !sycl_nd_item_1_ = !sycl.nd_item<[1], (![[ITEM1]], !sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl.range<1>, !sycl.id<1>)>)>, !sycl_group_1_)>
+// CHECK-DAG: !sycl_nd_item_2_ = !sycl.nd_item<[2], (!sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>)>, ![[ITEM2]], !sycl_group_2_)>
 // CHECK-DAG: !sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>
 // CHECK-DAG: !sycl_nd_range_2_ = !sycl.nd_range<[2], (!sycl.range<2>, !sycl.range<2>, !sycl.id<2>)>
 // CHECK-DAG: !sycl_get_scalar_op_i32_ = !sycl.get_scalar_op<[i32], (i32)>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -17,8 +17,8 @@
 // CHECK-DAG: !sycl_nd_range_2_ = !sycl.nd_range<[2], (!sycl.range<2>, !sycl.range<2>, !sycl.id<2>)>
 // CHECK-DAG: !sycl_get_scalar_op_i32_ = !sycl.get_scalar_op<[i32], (i32)>
 // CHECK-DAG: !sycl_tuple_value_holder_i32_ = !sycl.tuple_value_holder<[i32], (i32)>
-// CHECK-DAG: [[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_TRUE:!sycl_tuple_copy_assignable_value_holder_i32_.*]] = !sycl.tuple_copy_assignable_value_holder<[i32, true], (!sycl.tuple_value_holder<[i32], (i32)>)>
-// CHECK-DAG: [[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_FALSE:!sycl_tuple_copy_assignable_value_holder_i32_.*]] = !sycl.tuple_copy_assignable_value_holder<[i32, false], (!sycl.tuple_value_holder<[i32], (i32)>)>
+// CHECK-DAG: [[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_TRUE:!sycl_tuple_copy_assignable_value_holder_i32_.*]] = !sycl.tuple_copy_assignable_value_holder<[i32, true], (!sycl_tuple_value_holder_i32_)>
+// CHECK-DAG: [[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_FALSE:!sycl_tuple_copy_assignable_value_holder_i32_.*]] = !sycl.tuple_copy_assignable_value_holder<[i32, false], (!sycl_tuple_value_holder_i32_)>
 // CHECK-DAG: !sycl_vec_f32_8_ = !sycl.vec<[f32, 8], (vector<8xf32>)>
 // CHECK-DAG: !sycl_vec_i32_4_ = !sycl.vec<[i32, 4], (vector<4xi32>)>
 // CHECK-DAG: !sycl_atomic_f32_3_ = !sycl.atomic<[f32,3], (memref<?xf32, 3>)>


### PR DESCRIPTION
This way, getting the body of a type will not involve memory allocation.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>