### PR TITLE
[SYCL-MLIR] Implement 5 SYCL types

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -219,6 +219,21 @@ def SYCL_GetScalarOpType : SYCL_Type<"GetScalarOp", "get_scalar_op"> {
   let assemblyFormat = "`<` `[` $dataType `]` `,` `(` $body `)` `>`";
 }
 
+def SYCL_TupleValueHolderType : SYCL_Type<"TupleValueHolder", "tuple_value_holder"> {
+  let parameters = (ins "::mlir::Type":$dataType,
+                        "llvm::SmallVector<mlir::Type, 4>":$body);
+  let assemblyFormat = "`<` `[` $dataType `]` `,` `(` $body `)` `>`";
+}
+
+def SYCL_TupleCopyAssignableValueHolderType
+    : SYCL_Type<"TupleCopyAssignableValueHolder", "tuple_copy_assignable_value_holder",
+        [SYCLInheritanceTypeTrait<"TupleValueHolderType">]> {
+  let parameters = (ins "::mlir::Type":$dataType,
+                        "bool":$isTriviallyCopyAssignable,
+                        "llvm::SmallVector<mlir::Type, 4>":$body);
+  let assemblyFormat = "`<` `[` $dataType `,` $isTriviallyCopyAssignable `]` `,` `(` $body `)` `>`";
+}
+
 def VectorEltTy : AnyTypeOf<[I1, I8, I16, I32, I64, F16, F32, F64]>;
 
 def VectorSplatArg : MemRefOf<[VectorEltTy]>;
@@ -236,6 +251,20 @@ def SYCL_AtomicType : SYCL_Type<"Atomic", "atomic"> {
                         "mlir::sycl::AccessAddrSpace":$addrSpace,
                         "llvm::SmallVector<mlir::Type, 4>":$body);
   let assemblyFormat = "`<` `[` $dataType `,` custom<AccessAddrSpace>($addrSpace) `]` `,` `(` $body `)` `>`";
+}
+
+def SYCL_AssertHappenedType : SYCL_Type<"AssertHappened", "assert_happened"> {
+  let parameters = (ins "llvm::SmallVector<mlir::Type, 4>":$body);
+  let assemblyFormat = "`<` `(` $body `)` `>`";
+}
+
+def SYCL_BFloat16Type : SYCL_Type<"BFloat16", "bfloat16"> {
+  let parameters = (ins "llvm::SmallVector<mlir::Type, 4>":$body);
+  let assemblyFormat = "`<` `(` $body `)` `>`";
+}
+
+def SYCL_SubGroupType : SYCL_Type<"SubGroup", "sub_group"> {
+  let assemblyFormat = "";
 }
 
 def IDMemRef : MemRefOf<[SYCL_IDType]>;

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
@@ -93,6 +93,8 @@ private:
       return "drw";
     case mlir::sycl::MemoryAccessMode::Atomic:
       return "ato";
+    default:
+      llvm_unreachable("Unhandled kind");
     }
   }
 
@@ -113,6 +115,8 @@ private:
       return "hi";
     case mlir::sycl::MemoryTargetMode::ImageArray:
       return "ia";
+    default:
+      llvm_unreachable("Unhandled kind");
     }
   }
 };

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
@@ -93,8 +93,6 @@ private:
       return "drw";
     case mlir::sycl::MemoryAccessMode::Atomic:
       return "ato";
-    default:
-      llvm_unreachable("Unhandled kind");
     }
   }
 
@@ -115,8 +113,6 @@ private:
       return "hi";
     case mlir::sycl::MemoryTargetMode::ImageArray:
       return "ia";
-    default:
-      llvm_unreachable("Unhandled kind");
     }
   }
 };
@@ -124,17 +120,11 @@ private:
 mlir::OpAsmDialectInterface::AliasResult
 SYCLOpAsmInterface::getAlias(mlir::Type Type, llvm::raw_ostream &OS) const {
   return llvm::TypeSwitch<mlir::Type, AliasResult>(Type)
-      .Case<mlir::sycl::AccessorType>([&](auto Ty) {
-        OS << "sycl_" << decltype(Ty)::getMnemonic() << "_" << Ty.getDimension()
-           << "_" << Ty.getType() << "_" << getAlias(Ty.getAccessMode()) << "_"
-           << getAlias(Ty.getTargetMode());
-        return AliasResult::FinalAlias;
-      })
-      .Case<mlir::sycl::ItemType, mlir::sycl::ItemBaseType>([&](auto Ty) {
-        OS << "sycl_" << decltype(Ty)::getMnemonic() << "_" << Ty.getDimension()
-           << "_";
-        return AliasResult::OverridableAlias;
-      })
+      .Case<mlir::sycl::AssertHappenedType, mlir::sycl::BFloat16Type>(
+          [&](auto Ty) {
+            OS << "sycl_" << decltype(Ty)::getMnemonic() << "_";
+            return AliasResult::FinalAlias;
+          })
       .Case<mlir::sycl::NdRangeType, mlir::sycl::AccessorImplDeviceType,
             mlir::sycl::ArrayType, mlir::sycl::NdItemType,
             mlir::sycl::GroupType>([&](auto Ty) {
@@ -142,16 +132,21 @@ SYCLOpAsmInterface::getAlias(mlir::Type Type, llvm::raw_ostream &OS) const {
            << "_";
         return AliasResult::FinalAlias;
       })
-      .Case<mlir::sycl::GetScalarOpType>([&](auto Ty) {
-        OS << "sycl_" << decltype(Ty)::getMnemonic() << "_" << Ty.getDataType()
+      .Case<mlir::sycl::ItemType, mlir::sycl::ItemBaseType>([&](auto Ty) {
+        OS << "sycl_" << decltype(Ty)::getMnemonic() << "_" << Ty.getDimension()
            << "_";
-        return AliasResult::FinalAlias;
+        return AliasResult::OverridableAlias;
       })
-      .Case<mlir::sycl::AtomicType>([&](auto Ty) {
+      .Case<mlir::sycl::GetScalarOpType, mlir::sycl::TupleValueHolderType>(
+          [&](auto Ty) {
+            OS << "sycl_" << decltype(Ty)::getMnemonic() << "_"
+               << Ty.getDataType() << "_";
+            return AliasResult::FinalAlias;
+          })
+      .Case<mlir::sycl::TupleCopyAssignableValueHolderType>([&](auto Ty) {
         OS << "sycl_" << decltype(Ty)::getMnemonic() << "_" << Ty.getDataType()
-           << "_" << mlir::sycl::accessAddressSpaceAsString(Ty.getAddrSpace())
            << "_";
-        return AliasResult::FinalAlias;
+        return AliasResult::OverridableAlias;
       })
       .Case<mlir::sycl::VecType>([&](auto Ty) {
         OS << "sycl_" << decltype(Ty)::getMnemonic() << "_" << Ty.getDataType()
@@ -162,6 +157,18 @@ SYCLOpAsmInterface::getAlias(mlir::Type Type, llvm::raw_ostream &OS) const {
         OS << "sycl_" << decltype(Ty)::getMnemonic() << "_"
            << Ty.getCurrentDimension() << "_";
         return AliasResult::OverridableAlias;
+      })
+      .Case<mlir::sycl::AccessorType>([&](auto Ty) {
+        OS << "sycl_" << decltype(Ty)::getMnemonic() << "_" << Ty.getDimension()
+           << "_" << Ty.getType() << "_" << getAlias(Ty.getAccessMode()) << "_"
+           << getAlias(Ty.getTargetMode());
+        return AliasResult::FinalAlias;
+      })
+      .Case<mlir::sycl::AtomicType>([&](auto Ty) {
+        OS << "sycl_" << decltype(Ty)::getMnemonic() << "_" << Ty.getDataType()
+           << "_" << mlir::sycl::accessAddressSpaceAsString(Ty.getAddrSpace())
+           << "_";
+        return AliasResult::FinalAlias;
       })
       .Default([](auto) { return AliasResult::NoAlias; });
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
@@ -18,12 +18,17 @@
 // CHECK: llvm.func @test_itemBase.false(%arg0: !llvm.[[ITEM_BASE_1_FALSE:struct<"struct.sycl::_V1::detail::ItemBase.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
 // CHECK: llvm.func @test_item.true(%arg0: !llvm.[[ITEM_1_TRUE:struct<"class.sycl::_V1::item.*", \(]][[ITEM_BASE_1_TRUE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
 // CHECK: llvm.func @test_item.false(%arg0: !llvm.[[ITEM_1_FALSE:struct<"class.sycl::_V1::item.*", \(]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
-// CHECK: llvm.func @test_group(%arg0: !llvm.[[GROUP_1:struct<"class.sycl::_V1::group.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
-// CHECK: llvm.func @test_get_op(%arg0: !llvm.[[GETOP:struct<"class.sycl::_V1::detail::GetOp", \(i8\)>]])
-// CHECK: llvm.func @test_get_scalar_op(%arg0: !llvm.[[GETSCALAROP:struct<"class.sycl::_V1::detail::GetScalarOp.*", \(i32\)>]])
-// CHECK: llvm.func @test_nd_item(%arg0: !llvm.[[ND_ITEM_1:struct<"class.sycl::_V1::nd_item.*", \(]][[ITEM_1_TRUE]][[ITEM_BASE_1_TRUE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[ITEM_1_FALSE]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[GROUP_1]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
+// CHECK: llvm.func @test_group(%arg0: !llvm.[[GROUP:struct<"class.sycl::_V1::group.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
+// CHECK: llvm.func @test_get_op(%arg0: !llvm.[[GET_OP:struct<"class.sycl::_V1::detail::GetOp", \(i8\)>]])
+// CHECK: llvm.func @test_get_scalar_op(%arg0: !llvm.[[GET_SCALAR_OP:struct<"class.sycl::_V1::detail::GetScalarOp.*", \(i32\)>]])
+// CHECK: llvm.func @test_nd_item(%arg0: !llvm.[[ND_ITEM_1:struct<"class.sycl::_V1::nd_item.*", \(]][[ITEM_1_TRUE]][[ITEM_BASE_1_TRUE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[ITEM_1_FALSE]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[GROUP]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
+// CHECK: llvm.func @test_tuple_value_holder(%arg0: !llvm.[[TUPLE_VALUE_HOLDER:struct<"struct.sycl::_V1::detail::TupleValueHolder", \(i32\)>]]) {
+// CHECK: llvm.func @test_tuple_copy_assignable_value_holder(%arg0: !llvm.[[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER:struct<"struct.sycl::_V1::detail::TupleCopyAssignableValueHolder", \(]][[TUPLE_VALUE_HOLDER]][[SUFFIX]]) {
 // CHECK: llvm.func @test_vec(%arg0: !llvm.[[VEC:struct<"class.sycl::_V1::vec", \(vector<4xf32>\)>]])
 // CHECK: llvm.func @test_atomic(%arg0: !llvm.[[ATOMIC1:struct<"class.sycl::_V1::atomic", \(struct<\(ptr<f32, 3>, ptr<f32, 3>, i64, array<1 x i64>, array<1 x i64>\)>\)>]], %arg1: !llvm.[[ATOMIC1:struct<"class.sycl::_V1::atomic.1", \(struct<\(ptr<i32, 1>, ptr<i32, 1>, i64, array<1 x i64>, array<1 x i64>\)>\)>]]) {
+// CHECK: llvm.func @test_assert_happened(%arg0: !llvm.[[ASSERT_HAPPENED:struct<"struct.sycl::_V1::detail::AssertHappened", \(i32, array<257 x i8>, array<257 x i8>, array<129 x i8>, i32, i64, i64, i64, i64, i64, i64\)>]]) {
+// CHECK: llvm.func @test_bfloat16(%arg0: !llvm.[[BFLOAT16:struct<"class.sycl::_V1::ext::oneapi::bfloat16", \(i16\)>]]) {
+// CHECK: llvm.func @test_sub_group(%arg0: !llvm.[[SUB_GROUP:struct<"struct.sycl::_V1::ext::oneapi::sub_group", \(i8\)>]]) {
 
 !sycl_array_1_ = !sycl.array<[1], (memref<1xi64>)>
 !sycl_array_2_ = !sycl.array<[2], (memref<2xi64>)>
@@ -43,9 +48,13 @@
 !sycl_group_1_ = !sycl.group<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>
 !sycl_get_scalar_op_i32_ = !sycl.get_scalar_op<[i32], (i32)>
 !sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1, !sycl_group_1_)>
+!sycl_tuple_value_holder_i32_ = !sycl.tuple_value_holder<[i32], (i32)>
+!sycl_tuple_copy_assignable_value_holder_i32_ = !sycl.tuple_copy_assignable_value_holder<[i32, true], (!sycl.tuple_value_holder<[i32], (i32)>)>
 !sycl_vec_f32_4_ = !sycl.vec<[f32, 4], (vector<4xf32>)>
 !sycl_atomic_f32_3_ = !sycl.atomic<[f32,3], (memref<?xf32, 3>)>
 !sycl_atomic_i32_1_ = !sycl.atomic<[i32,1], (memref<?xi32, 1>)>
+!sycl_assert_happened_ = !sycl.assert_happened<(i32, !llvm.array<257 x i8>, !llvm.array<257 x i8>, !llvm.array<129 x i8>, i32, i64, i64, i64, i64, i64, i64)>
+!sycl_bfloat16_ = !sycl.bfloat16<(i16)>
 
 module {
   func.func @test_array.1(%arg0: !sycl_array_1_) {
@@ -114,10 +123,25 @@ module {
   func.func @test_nd_item(%arg0: !sycl_nd_item_1_) {
     return
   }
+  func.func @test_tuple_value_holder(%arg0: !sycl_tuple_value_holder_i32_) {
+    return
+  }
+  func.func @test_tuple_copy_assignable_value_holder(%arg0: !sycl_tuple_copy_assignable_value_holder_i32_) {
+    return
+  }
   func.func @test_vec(%arg0: !sycl_vec_f32_4_) {
     return
   }
   func.func @test_atomic(%arg0: !sycl_atomic_f32_3_, %arg1: !sycl_atomic_i32_1_) {
+    return
+  }
+  func.func @test_assert_happened(%arg0: !sycl_assert_happened_) {
+    return
+  }
+  func.func @test_bfloat16(%arg0: !sycl_bfloat16_) {
+    return
+  }
+  func.func @test_sub_group(%arg0: !sycl.sub_group) {
     return
   }
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
@@ -1,39 +1,49 @@
 // RUN: sycl-mlir-opt -split-input-file -convert-sycl-to-llvm -verify-diagnostics %s | FileCheck %s
 
-// CHECK: llvm.func @test_array.1(%arg0: !llvm.[[ARRAY_1:struct<"class.sycl::_V1::detail::array.*", \(array<1 x i64>\)>]])
-// CHECK: llvm.func @test_array.2(%arg0: !llvm.[[ARRAY_2:struct<"class.sycl::_V1::detail::array.*", \(array<2 x i64>\)>]])
-// CHECK: llvm.func @test_id(%arg0: !llvm.[[ID_1:struct<"class.sycl::_V1::id.*", \(]][[ARRAY_1]][[SUFFIX:\)>]], %arg1: !llvm.[[ID_1]][[ARRAY_1]][[SUFFIX]])
-// CHECK: llvm.func @test_range.1(%arg0: !llvm.[[RANGE_1:struct<"class.sycl::_V1::range.*", \(]][[ARRAY_1]][[SUFFIX]])
-// CHECK: llvm.func @test_range.2(%arg0: !llvm.[[RANGE_2:struct<"class.sycl::_V1::range.*", \(]][[ARRAY_2]][[SUFFIX]])
-// CHECK: llvm.func @test_nd_range.1(%arg0: !llvm.[[ND_RANGE_1:struct<"class.sycl::_V1::nd_range.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]]) {
-// CHECK: llvm.func @test_nd_range.2(%arg0: !llvm.[[ND_RANGE_2:struct<"class.sycl::_V1::nd_range.*", \(]][[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[ID_2:struct<"class.sycl::_V1::id.*", \(]][[ARRAY_2]][[SUFFIX]][[SUFFIX]]) {
-// CHECK: llvm.func @test_accessorImplDevice(%arg0: !llvm.[[ACCESSORIMPLDEVICE_1:struct<"class.sycl::_V1::detail::AccessorImplDevice.*", \(]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
-// CHECK: llvm.func @test_accessor_common(%arg0: !llvm.[[ACCESSOR_COMMON:struct<"class.sycl::_V1::detail::accessor_common", \(i8\)>]])
-// CHECK: llvm.func @test_accessor.1(%arg0: !llvm.[[ACCESSOR_1:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_1]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>[[SUFFIX]])
-// CHECK: llvm.func @test_accessor.2(%arg0: !llvm.[[ACCESSOR_2:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_2:struct<"class.sycl::_V1::detail::AccessorImplDevice.*", \(]][[ID_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>[[SUFFIX]])
-// CHECK: llvm.func @test_accessor.3(%arg0: !llvm.[[ACCESSOR_3:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_1]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]], struct<(ptr<f32, 1>)>[[SUFFIX]])
-// CHECK: llvm.func @test_accessor.4(%arg0: !llvm.[[ACCESSOR_4:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_2]][[ID_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]][[SUFFIX]], struct<(ptr<f32, 1>)>[[SUFFIX]])
-// CHECK: llvm.func @test_accessorSubscript(%arg0: !llvm.[[ACCESSORSUBSCRIPT_1:struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.*", \(]][[ID_2]][[ARRAY_2]][[SUFFIX]], [[ACCESSOR_2]][[ACCESSORIMPLDEVICE_2]][[ID_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>[[SUFFIX]]) 
-// CHECK: llvm.func @test_itemBase.true(%arg0: !llvm.[[ITEM_BASE_1_TRUE:struct<"struct.sycl::_V1::detail::ItemBase.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
-// CHECK: llvm.func @test_itemBase.false(%arg0: !llvm.[[ITEM_BASE_1_FALSE:struct<"struct.sycl::_V1::detail::ItemBase.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
-// CHECK: llvm.func @test_item.true(%arg0: !llvm.[[ITEM_1_TRUE:struct<"class.sycl::_V1::item.*", \(]][[ITEM_BASE_1_TRUE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
-// CHECK: llvm.func @test_item.false(%arg0: !llvm.[[ITEM_1_FALSE:struct<"class.sycl::_V1::item.*", \(]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
-// CHECK: llvm.func @test_group(%arg0: !llvm.[[GROUP:struct<"class.sycl::_V1::group.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
-// CHECK: llvm.func @test_get_op(%arg0: !llvm.[[GET_OP:struct<"class.sycl::_V1::detail::GetOp", \(i8\)>]])
-// CHECK: llvm.func @test_get_scalar_op(%arg0: !llvm.[[GET_SCALAR_OP:struct<"class.sycl::_V1::detail::GetScalarOp.*", \(i32\)>]])
-// CHECK: llvm.func @test_nd_item(%arg0: !llvm.[[ND_ITEM_1:struct<"class.sycl::_V1::nd_item.*", \(]][[ITEM_1_TRUE]][[ITEM_BASE_1_TRUE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[ITEM_1_FALSE]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[GROUP]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
-// CHECK: llvm.func @test_tuple_value_holder(%arg0: !llvm.[[TUPLE_VALUE_HOLDER:struct<"struct.sycl::_V1::detail::TupleValueHolder", \(i32\)>]]) {
-// CHECK: llvm.func @test_tuple_copy_assignable_value_holder(%arg0: !llvm.[[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER:struct<"struct.sycl::_V1::detail::TupleCopyAssignableValueHolder", \(]][[TUPLE_VALUE_HOLDER]][[SUFFIX]]) {
-// CHECK: llvm.func @test_vec(%arg0: !llvm.[[VEC:struct<"class.sycl::_V1::vec", \(vector<4xf32>\)>]])
-// CHECK: llvm.func @test_atomic(%arg0: !llvm.[[ATOMIC1:struct<"class.sycl::_V1::atomic", \(struct<\(ptr<f32, 3>, ptr<f32, 3>, i64, array<1 x i64>, array<1 x i64>\)>\)>]], %arg1: !llvm.[[ATOMIC1:struct<"class.sycl::_V1::atomic.1", \(struct<\(ptr<i32, 1>, ptr<i32, 1>, i64, array<1 x i64>, array<1 x i64>\)>\)>]]) {
-// CHECK: llvm.func @test_assert_happened(%arg0: !llvm.[[ASSERT_HAPPENED:struct<"struct.sycl::_V1::detail::AssertHappened", \(i32, array<257 x i8>, array<257 x i8>, array<129 x i8>, i32, i64, i64, i64, i64, i64, i64\)>]]) {
-// CHECK: llvm.func @test_bfloat16(%arg0: !llvm.[[BFLOAT16:struct<"class.sycl::_V1::ext::oneapi::bfloat16", \(i16\)>]]) {
-// CHECK: llvm.func @test_sub_group(%arg0: !llvm.[[SUB_GROUP:struct<"struct.sycl::_V1::ext::oneapi::sub_group", \(i8\)>]]) {
-
 !sycl_array_1_ = !sycl.array<[1], (memref<1xi64>)>
 !sycl_array_2_ = !sycl.array<[2], (memref<2xi64>)>
+// CHECK: llvm.func @test_array.1(%arg0: !llvm.[[ARRAY_1:struct<"class.sycl::_V1::detail::array.*", \(array<1 x i64>\)>]])
+func.func @test_array.1(%arg0: !sycl_array_1_) {
+  return
+}
+// CHECK: llvm.func @test_array.2(%arg0: !llvm.[[ARRAY_2:struct<"class.sycl::_V1::detail::array.*", \(array<2 x i64>\)>]])
+func.func @test_array.2(%arg0: !sycl_array_2_) {
+  return
+}
+
+// -----
+
+// CHECK: llvm.func @test_id(%arg0: !llvm.[[ID_1:struct<"class.sycl::_V1::id.*", \(]][[ARRAY_1]][[SUFFIX:\)>]], %arg1: !llvm.[[ID_1]][[ARRAY_1]][[SUFFIX]])
+func.func @test_id(%arg0: !sycl.id<1>, %arg1: !sycl.id<1>) {
+  return
+}
+
+// -----
+
+// CHECK: llvm.func @test_range.1(%arg0: !llvm.[[RANGE_1:struct<"class.sycl::_V1::range.*", \(]][[ARRAY_1]][[SUFFIX]])
+func.func @test_range.1(%arg0: !sycl.range<1>) {
+  return
+}
+// CHECK: llvm.func @test_range.2(%arg0: !llvm.[[RANGE_2:struct<"class.sycl::_V1::range.*", \(]][[ARRAY_2]][[SUFFIX]])
+func.func @test_range.2(%arg0: !sycl.range<2>) {
+  return
+}
+
+// -----
+
 !sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>
 !sycl_nd_range_2_ = !sycl.nd_range<[2], (!sycl.range<2>, !sycl.range<2>, !sycl.id<2>)>
+// CHECK: llvm.func @test_nd_range.1(%arg0: !llvm.[[ND_RANGE_1:struct<"class.sycl::_V1::nd_range.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]]) {
+func.func @test_nd_range.1(%arg0: !sycl_nd_range_1_) {
+  return
+}
+// CHECK: llvm.func @test_nd_range.2(%arg0: !llvm.[[ND_RANGE_2:struct<"class.sycl::_V1::nd_range.*", \(]][[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[ID_2:struct<"class.sycl::_V1::id.*", \(]][[ARRAY_2]][[SUFFIX]][[SUFFIX]]) {
+func.func @test_nd_range.2(%arg0: !sycl_nd_range_2_) {
+  return
+}
+
+// -----
+
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>
 !sycl_accessor_impl_device_2_ = !sycl.accessor_impl_device<[2], (!sycl.id<2>, !sycl.range<2>, !sycl.range<2>)>
 !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
@@ -41,107 +51,132 @@
 !sycl_accessor_1_f32_rw_gb = !sycl.accessor<[1, f32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<f32, 1>)>)>
 !sycl_accessor_2_f32_rw_gb = !sycl.accessor<[2, f32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<f32, 1>)>)>
 !sycl_accessor_subscript_1_ = !sycl.accessor_subscript<[1], (!sycl.id<2>, !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<i32, 1>)>)>)>
+// CHECK: llvm.func @test_accessorImplDevice(%arg0: !llvm.[[ACCESSORIMPLDEVICE_1:struct<"class.sycl::_V1::detail::AccessorImplDevice.*", \(]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
+func.func @test_accessorImplDevice(%arg0: !sycl_accessor_impl_device_1_) {
+  return
+}
+// CHECK: llvm.func @test_accessor_common(%arg0: !llvm.[[ACCESSOR_COMMON:struct<"class.sycl::_V1::detail::accessor_common", \(i8\)>]])
+func.func @test_accessor_common(%arg0: !sycl.accessor_common) {
+  return
+}
+// CHECK: llvm.func @test_accessor.1(%arg0: !llvm.[[ACCESSOR_1:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_1]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>[[SUFFIX]])
+func.func @test_accessor.1(%arg0: !sycl_accessor_1_i32_rw_gb) {
+  return
+}
+// CHECK: llvm.func @test_accessor.2(%arg0: !llvm.[[ACCESSOR_2:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_2:struct<"class.sycl::_V1::detail::AccessorImplDevice.*", \(]][[ID_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>[[SUFFIX]])
+func.func @test_accessor.2(%arg0: !sycl_accessor_2_i32_rw_gb) {
+  return
+}
+// CHECK: llvm.func @test_accessor.3(%arg0: !llvm.[[ACCESSOR_3:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_1]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]], struct<(ptr<f32, 1>)>[[SUFFIX]])
+func.func @test_accessor.3(%arg0: !sycl_accessor_1_f32_rw_gb) {
+  return
+}
+// CHECK: llvm.func @test_accessor.4(%arg0: !llvm.[[ACCESSOR_4:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_2]][[ID_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]][[SUFFIX]], struct<(ptr<f32, 1>)>[[SUFFIX]])
+func.func @test_accessor.4(%arg0: !sycl_accessor_2_f32_rw_gb) {
+  return
+}
+// CHECK: llvm.func @test_accessorSubscript(%arg0: !llvm.[[ACCESSORSUBSCRIPT_1:struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.*", \(]][[ID_2]][[ARRAY_2]][[SUFFIX]], [[ACCESSOR_2]][[ACCESSORIMPLDEVICE_2]][[ID_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>[[SUFFIX]]) 
+func.func @test_accessorSubscript(%arg0: !sycl_accessor_subscript_1_) {
+  return
+}
+
+// -----
+
 !sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>
 !sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl.range<1>, !sycl.id<1>)>
 !sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
 !sycl_item_1_1 = !sycl.item<[1, false], (!sycl_item_base_1_1)>
 !sycl_group_1_ = !sycl.group<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>
-!sycl_get_scalar_op_i32_ = !sycl.get_scalar_op<[i32], (i32)>
 !sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1, !sycl_group_1_)>
+// CHECK: llvm.func @test_itemBase.true(%arg0: !llvm.[[ITEM_BASE_1_TRUE:struct<"struct.sycl::_V1::detail::ItemBase.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
+func.func @test_itemBase.true(%arg0: !sycl_item_base_1_) {
+  return
+}
+// CHECK: llvm.func @test_itemBase.false(%arg0: !llvm.[[ITEM_BASE_1_FALSE:struct<"struct.sycl::_V1::detail::ItemBase.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
+func.func @test_itemBase.false(%arg0: !sycl_item_base_1_1) {
+  return
+}
+// CHECK: llvm.func @test_item.true(%arg0: !llvm.[[ITEM_1_TRUE:struct<"class.sycl::_V1::item.*", \(]][[ITEM_BASE_1_TRUE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
+func.func @test_item.true(%arg0: !sycl_item_1_) {
+  return
+}
+// CHECK: llvm.func @test_item.false(%arg0: !llvm.[[ITEM_1_FALSE:struct<"class.sycl::_V1::item.*", \(]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
+func.func @test_item.false(%arg0: !sycl_item_1_1) {
+  return
+}
+// CHECK: llvm.func @test_group(%arg0: !llvm.[[GROUP:struct<"class.sycl::_V1::group.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
+func.func @test_group(%arg0: !sycl_group_1_) {
+  return
+}
+// CHECK: llvm.func @test_nd_item(%arg0: !llvm.[[ND_ITEM_1:struct<"class.sycl::_V1::nd_item.*", \(]][[ITEM_1_TRUE]][[ITEM_BASE_1_TRUE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[ITEM_1_FALSE]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[GROUP]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
+func.func @test_nd_item(%arg0: !sycl_nd_item_1_) {
+  return
+}
+
+// -----
+
+// CHECK: llvm.func @test_get_op(%arg0: !llvm.[[GET_OP:struct<"class.sycl::_V1::detail::GetOp", \(i8\)>]])
+func.func @test_get_op(%arg0: !sycl.get_op<i32>) {
+  return
+}
+
+// -----
+
+!sycl_get_scalar_op_i32_ = !sycl.get_scalar_op<[i32], (i32)>
+// CHECK: llvm.func @test_get_scalar_op(%arg0: !llvm.[[GET_SCALAR_OP:struct<"class.sycl::_V1::detail::GetScalarOp.*", \(i32\)>]])
+func.func @test_get_scalar_op(%arg0: !sycl_get_scalar_op_i32_) {
+  return
+}
+
+// -----
+
 !sycl_tuple_value_holder_i32_ = !sycl.tuple_value_holder<[i32], (i32)>
 !sycl_tuple_copy_assignable_value_holder_i32_ = !sycl.tuple_copy_assignable_value_holder<[i32, true], (!sycl.tuple_value_holder<[i32], (i32)>)>
+// CHECK: llvm.func @test_tuple_value_holder(%arg0: !llvm.[[TUPLE_VALUE_HOLDER:struct<"struct.sycl::_V1::detail::TupleValueHolder", \(i32\)>]]) {
+func.func @test_tuple_value_holder(%arg0: !sycl_tuple_value_holder_i32_) {
+  return
+}
+// CHECK: llvm.func @test_tuple_copy_assignable_value_holder(%arg0: !llvm.[[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER:struct<"struct.sycl::_V1::detail::TupleCopyAssignableValueHolder", \(]][[TUPLE_VALUE_HOLDER]][[SUFFIX]]) {
+func.func @test_tuple_copy_assignable_value_holder(%arg0: !sycl_tuple_copy_assignable_value_holder_i32_) {
+  return
+}
+
+// -----
+
 !sycl_vec_f32_4_ = !sycl.vec<[f32, 4], (vector<4xf32>)>
+// CHECK: llvm.func @test_vec(%arg0: !llvm.[[VEC:struct<"class.sycl::_V1::vec", \(vector<4xf32>\)>]])
+func.func @test_vec(%arg0: !sycl_vec_f32_4_) {
+  return
+}
+
+// -----
+
 !sycl_atomic_f32_3_ = !sycl.atomic<[f32,3], (memref<?xf32, 3>)>
 !sycl_atomic_i32_1_ = !sycl.atomic<[i32,1], (memref<?xi32, 1>)>
-!sycl_assert_happened_ = !sycl.assert_happened<(i32, !llvm.array<257 x i8>, !llvm.array<257 x i8>, !llvm.array<129 x i8>, i32, i64, i64, i64, i64, i64, i64)>
-!sycl_bfloat16_ = !sycl.bfloat16<(i16)>
+// CHECK: llvm.func @test_atomic(%arg0: !llvm.[[ATOMIC1:struct<"class.sycl::_V1::atomic", \(struct<\(ptr<f32, 3>, ptr<f32, 3>, i64, array<1 x i64>, array<1 x i64>\)>\)>]], %arg1: !llvm.[[ATOMIC1:struct<"class.sycl::_V1::atomic.1", \(struct<\(ptr<i32, 1>, ptr<i32, 1>, i64, array<1 x i64>, array<1 x i64>\)>\)>]]) {
+func.func @test_atomic(%arg0: !sycl_atomic_f32_3_, %arg1: !sycl_atomic_i32_1_) {
+  return
+}
 
-module {
-  func.func @test_array.1(%arg0: !sycl_array_1_) {
-    return
-  }
-  func.func @test_array.2(%arg0: !sycl_array_2_) {
-    return
-  }
-  func.func @test_id(%arg0: !sycl.id<1>, %arg1: !sycl.id<1>) {
-    return
-  }
-  func.func @test_range.1(%arg0: !sycl.range<1>) {
-    return
-  }
-  func.func @test_range.2(%arg0: !sycl.range<2>) {
-    return
-  }
-  func.func @test_nd_range.1(%arg0: !sycl_nd_range_1_) {
-    return
-  }
-  func.func @test_nd_range.2(%arg0: !sycl_nd_range_2_) {
-    return
-  }
-  func.func @test_accessorImplDevice(%arg0: !sycl_accessor_impl_device_1_) {
-    return
-  }
-  func.func @test_accessor_common(%arg0: !sycl.accessor_common) {
-    return
-  }
-  func.func @test_accessor.1(%arg0: !sycl_accessor_1_i32_rw_gb) {
-    return
-  }
-  func.func @test_accessor.2(%arg0: !sycl_accessor_2_i32_rw_gb) {
-    return
-  }
-  func.func @test_accessor.3(%arg0: !sycl_accessor_1_f32_rw_gb) {
-    return
-  }
-  func.func @test_accessor.4(%arg0: !sycl_accessor_2_f32_rw_gb) {
-    return
-  }
-  func.func @test_accessorSubscript(%arg0: !sycl_accessor_subscript_1_) {
-    return
-  }
-  func.func @test_itemBase.true(%arg0: !sycl_item_base_1_) {
-    return
-  }
-  func.func @test_itemBase.false(%arg0: !sycl_item_base_1_1) {
-    return
-  }
-  func.func @test_item.true(%arg0: !sycl_item_1_) {
-    return
-  }
-  func.func @test_item.false(%arg0: !sycl_item_1_1) {
-    return
-  }
-  func.func @test_group(%arg0: !sycl_group_1_) {
-    return
-  }
-  func.func @test_get_op(%arg0: !sycl.get_op<i32>) {
-    return
-  }
-  func.func @test_get_scalar_op(%arg0: !sycl_get_scalar_op_i32_) {
-    return
-  }
-  func.func @test_nd_item(%arg0: !sycl_nd_item_1_) {
-    return
-  }
-  func.func @test_tuple_value_holder(%arg0: !sycl_tuple_value_holder_i32_) {
-    return
-  }
-  func.func @test_tuple_copy_assignable_value_holder(%arg0: !sycl_tuple_copy_assignable_value_holder_i32_) {
-    return
-  }
-  func.func @test_vec(%arg0: !sycl_vec_f32_4_) {
-    return
-  }
-  func.func @test_atomic(%arg0: !sycl_atomic_f32_3_, %arg1: !sycl_atomic_i32_1_) {
-    return
-  }
-  func.func @test_assert_happened(%arg0: !sycl_assert_happened_) {
-    return
-  }
-  func.func @test_bfloat16(%arg0: !sycl_bfloat16_) {
-    return
-  }
-  func.func @test_sub_group(%arg0: !sycl.sub_group) {
-    return
-  }
+// -----
+
+!sycl_assert_happened_ = !sycl.assert_happened<(i32, !llvm.array<257 x i8>, !llvm.array<257 x i8>, !llvm.array<129 x i8>, i32, i64, i64, i64, i64, i64, i64)>
+// CHECK: llvm.func @test_assert_happened(%arg0: !llvm.[[ASSERT_HAPPENED:struct<"struct.sycl::_V1::detail::AssertHappened", \(i32, array<257 x i8>, array<257 x i8>, array<129 x i8>, i32, i64, i64, i64, i64, i64, i64\)>]]) {
+func.func @test_assert_happened(%arg0: !sycl_assert_happened_) {
+  return
+}
+
+// -----
+
+!sycl_bfloat16_ = !sycl.bfloat16<(i16)>
+// CHECK: llvm.func @test_bfloat16(%arg0: !llvm.[[BFLOAT16:struct<"class.sycl::_V1::ext::oneapi::bfloat16", \(i16\)>]]) {
+func.func @test_bfloat16(%arg0: !sycl_bfloat16_) {
+  return
+}
+
+// -----
+
+// CHECK: llvm.func @test_sub_group(%arg0: !llvm.[[SUB_GROUP:struct<"struct.sycl::_V1::ext::oneapi::sub_group", \(i8\)>]]) {
+func.func @test_sub_group(%arg0: !sycl.sub_group) {
+  return
 }

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1337,14 +1337,17 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
     const auto *RD = RT->getAsRecordDecl();
     if (mlirclang::isNamespaceSYCL(RD->getEnclosingNamespaceContext())) {
       const auto TypeName = RD->getName();
-      if (TypeName == "range" || TypeName == "nd_range" ||
-          TypeName == "array" || TypeName == "id" ||
-          TypeName == "accessor_common" || TypeName == "accessor" ||
+      if (TypeName == "accessor" || TypeName == "accessor_common" ||
           TypeName == "AccessorImplDevice" || TypeName == "AccessorSubscript" ||
-          TypeName == "item" || TypeName == "ItemBase" ||
-          TypeName == "nd_item" || TypeName == "group" || TypeName == "GetOp" ||
-          TypeName == "GetScalarOp" || TypeName == "atomic" ||
-          TypeName == "vec") {
+          TypeName == "array" || TypeName == "AssertHappened" ||
+          TypeName == "atomic" || TypeName == "bfloat16" ||
+          TypeName == "GetOp" || TypeName == "GetScalarOp" ||
+          TypeName == "group" || TypeName == "id" || TypeName == "item" ||
+          TypeName == "ItemBase" || TypeName == "nd_item" ||
+          TypeName == "nd_range" || TypeName == "range" ||
+          TypeName == "sub_group" ||
+          TypeName == "TupleCopyAssignableValueHolder" ||
+          TypeName == "TupleValueHolder" || TypeName == "vec") {
         return getSYCLType(RT, *this);
       }
       // No need special handling for types that don't have record declaration

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -16,10 +16,15 @@
 // CHECK-DAG: !sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>
 // CHECK-DAG: !sycl_nd_range_2_ = !sycl.nd_range<[2], (!sycl.range<2>, !sycl.range<2>, !sycl.id<2>)>
 // CHECK-DAG: !sycl_get_scalar_op_i32_ = !sycl.get_scalar_op<[i32], (i32)>
-// CHECK-DAG: !sycl_atomic_f32_3_ = !sycl.atomic<[f32,3], (memref<?xf32, 3>)>
-// CHECK-DAG: !sycl_atomic_i32_1_ = !sycl.atomic<[i32,1], (memref<?xi32, 1>)>
+// CHECK-DAG: !sycl_tuple_value_holder_i32_ = !sycl.tuple_value_holder<[i32], (i32)>
+// CHECK-DAG: [[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_TRUE:!sycl_tuple_copy_assignable_value_holder_i32_.*]] = !sycl.tuple_copy_assignable_value_holder<[i32, true], (!sycl.tuple_value_holder<[i32], (i32)>)>
+// CHECK-DAG: [[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_FALSE:!sycl_tuple_copy_assignable_value_holder_i32_.*]] = !sycl.tuple_copy_assignable_value_holder<[i32, false], (!sycl.tuple_value_holder<[i32], (i32)>)>
 // CHECK-DAG: !sycl_vec_f32_8_ = !sycl.vec<[f32, 8], (vector<8xf32>)>
 // CHECK-DAG: !sycl_vec_i32_4_ = !sycl.vec<[i32, 4], (vector<4xi32>)>
+// CHECK-DAG: !sycl_atomic_f32_3_ = !sycl.atomic<[f32,3], (memref<?xf32, 3>)>
+// CHECK-DAG: !sycl_atomic_i32_1_ = !sycl.atomic<[i32,1], (memref<?xi32, 1>)>
+// CHECK-DAG: !sycl_assert_happened_ = !sycl.assert_happened<(i32, !llvm.array<257 x i8>, !llvm.array<257 x i8>, !llvm.array<129 x i8>, i32, i64, i64, i64, i64, i64, i64)>
+// CHECK-DAG: !sycl_bfloat16_ = !sycl.bfloat16<(i16)>
 
 // CHECK-LABEL: func.func @_Z4id_1N4sycl3_V12idILi1EEE(
 // CHECK:          %arg0: memref<?x!sycl.id<1>> {llvm.align = 8 : i64, llvm.byval = !sycl.id<1>, llvm.noundef})
@@ -117,15 +122,20 @@ SYCL_EXTERNAL void get_op(sycl::detail::GetOp<int> get_op) {}
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
 SYCL_EXTERNAL void get_scalar_op(sycl::detail::GetScalarOp<int> get_scalar_op) {}
 
-// CHECK-LABEL: func.func @_Z8atomic_1N4sycl3_V16atomicIiLNS0_6access13address_spaceE1EEE(
-// CHECK:          %arg0: memref<?x!sycl_atomic_i32_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_atomic_i32_1_, llvm.noundef})
+// CHECK-LABEL: func.func @_Z18tuple_value_holderN4sycl3_V16detail16TupleValueHolderIiEE(
+// CHECK:          %arg0: memref<?x!sycl_tuple_value_holder_i32_> {llvm.align = 4 : i64, llvm.byval = !sycl_tuple_value_holder_i32_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void atomic_1(sycl::atomic<int> atomic_int) {}
+SYCL_EXTERNAL void tuple_value_holder(sycl::detail::TupleValueHolder<int> get_tuple_value_holder) {}
 
-// CHECK-LABEL: func.func @_Z8atomic_2N4sycl3_V16atomicIfLNS0_6access13address_spaceE3EEE(
-// CHECK:          %arg0: memref<?x!sycl_atomic_f32_3_> {llvm.align = 8 : i64, llvm.byval = !sycl_atomic_f32_3_, llvm.noundef})
+// CHECK-LABEL: func.func @_Z36tuple_copy_assignable_value_holder_1N4sycl3_V16detail30TupleCopyAssignableValueHolderIiLb1EEE(
+// CHECK:          %arg0: memref<?x[[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_TRUE]]> {llvm.align = 4 : i64, llvm.byval = [[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_TRUE]], llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void atomic_2(sycl::atomic<float, sycl::access::address_space::local_space> atomic_float) {}
+SYCL_EXTERNAL void tuple_copy_assignable_value_holder_1(sycl::detail::TupleCopyAssignableValueHolder<int, true> tuple_copy_assignable_value_holder_true) {}
+
+// CHECK-LABEL: func.func @_Z36tuple_copy_assignable_value_holder_2N4sycl3_V16detail30TupleCopyAssignableValueHolderIiLb0EEE(
+// CHECK:          %arg0: memref<?x[[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_FALSE]]> {llvm.align = 4 : i64, llvm.byval = [[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_FALSE]], llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void tuple_copy_assignable_value_holder_2(sycl::detail::TupleCopyAssignableValueHolder<int, false> tuple_copy_assignable_value_holder_false) {}
 
 // CHECK-LABEL: func.func @_Z5vec_3N4sycl3_V13vecIiLi4EEE(
 // CHECK-SAME:    %arg0: memref<?x!sycl_vec_i32_4_> {llvm.align = 16 : i64, llvm.byval = !sycl_vec_i32_4_, llvm.noundef})
@@ -136,3 +146,29 @@ SYCL_EXTERNAL void vec_3(sycl::vec<sycl::cl_int, 4> vec) {}
 // CHECK-SAME:    %arg0: memref<?x!sycl_vec_f32_8_> {llvm.align = 32 : i64, llvm.byval = !sycl_vec_f32_8_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
 SYCL_EXTERNAL void vec_4(sycl::float8 vec) {}
+
+// CHECK-LABEL: func.func @_Z8atomic_1N4sycl3_V16atomicIiLNS0_6access13address_spaceE1EEE(
+// CHECK:          %arg0: memref<?x!sycl_atomic_i32_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_atomic_i32_1_, llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void atomic_1(sycl::atomic<int> atomic_int) {}
+
+// CHECK-LABEL: func.func @_Z8atomic_2N4sycl3_V16atomicIfLNS0_6access13address_spaceE3EEE(
+// CHECK:          %arg0: memref<?x!sycl_atomic_f32_3_> {llvm.align = 8 : i64, llvm.byval = !sycl_atomic_f32_3_, llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void atomic_2(sycl::atomic<float, sycl::access::address_space::local_space> atomic_float) {}
+
+// %"struct.sycl::_V1::detail::AssertHappened" = type { i32, [257 x i8], [257 x i8], [129 x i8], i32, i64, i64, i64, i64, i64, i64 }
+// CHECK-LABEL: func.func @_Z19get_assert_happenedN4sycl3_V16detail14AssertHappenedE(
+// CHECK:          %arg0: memref<?x!sycl_assert_happened_> {llvm.align = 8 : i64, llvm.byval = !sycl_assert_happened_, llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void get_assert_happened(sycl::detail::AssertHappened get_assert_happened) {}
+
+// CHECK-LABEL: func.func @_Z12get_bfloat16N4sycl3_V13ext6oneapi8bfloat16E(
+// CHECK:          %arg0: memref<?x!sycl_bfloat16_> {llvm.align = 2 : i64, llvm.byval = !sycl_bfloat16_, llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void get_bfloat16(sycl::ext::oneapi::bfloat16 get_bfloat16) {}
+
+// CHECL-LABEL: func.func @_Z13get_sub_groupN4sycl3_V13ext6oneapi9sub_groupE(
+// CHECK:          %arg0: memref<?x!sycl.sub_group> {llvm.align = 1 : i64, llvm.byval = !sycl.sub_group, llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void get_sub_group(sycl::ext::oneapi::sub_group get_sub_group) {}


### PR DESCRIPTION
Implemented SYCL `TupleValueHolder`, `TupleCopyAssignableValueHolder`, `AssertHappened`, `bfloat16` and `sub_group` types.

clang generated example:
```
%"struct.sycl::_V1::detail::TupleValueHolder" = type { i32 }
%"struct.sycl::_V1::detail::TupleCopyAssignableValueHolder" = type { %"struct.sycl::_V1::detail::TupleValueHolder" }
%"struct.sycl::_V1::detail::AssertHappened" = type { i32, [257 x i8], [257 x i8], [129 x i8], i32, i64, i64, i64, i64, i64, i64 }
%"class.sycl::_V1::ext::oneapi::bfloat16" = type { i16 }
%"struct.sycl::_V1::ext::oneapi::sub_group" = type { i8 }
```

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>