### PR TITLE
[NFC][SYCL] Convert test-suite/.../in_order_property_trace.cpp to unittest

### DIFF
--- a/sycl/unittests/queue/CMakeLists.txt
+++ b/sycl/unittests/queue/CMakeLists.txt
@@ -5,4 +5,5 @@ add_sycl_unittest(QueueTests OBJECT
   Wait.cpp
   GetProfilingInfo.cpp
   ShortcutFunctions.cpp
+  InOrderQueue.cpp
 )

--- a/sycl/unittests/queue/InOrderQueue.cpp
+++ b/sycl/unittests/queue/InOrderQueue.cpp
@@ -1,0 +1,28 @@
+#include <gtest/gtest.h>
+#include <helpers/PiMock.hpp>
+#include <sycl/properties/queue_properties.hpp>
+#include <sycl/queue.hpp>
+
+using namespace sycl;
+
+static bool InOrderFlagSeen = false;
+pi_result piQueueCreateRedefineBefore(pi_context context, pi_device device,
+                                      pi_queue_properties properties,
+                                      pi_queue *queue) {
+  InOrderFlagSeen = !(properties & PI_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE);
+  return PI_SUCCESS;
+}
+
+TEST(InOrderQueue, CheckFlagIsPassed) {
+  unittest::PiMock Mock;
+  platform Plt = Mock.getPlatform();
+
+  Mock.redefineBefore<detail::PiApiKind::piQueueCreate>(
+      piQueueCreateRedefineBefore);
+
+  EXPECT_FALSE(InOrderFlagSeen);
+  queue q1{};
+  EXPECT_FALSE(InOrderFlagSeen);
+  queue q2{property::queue::in_order{}};
+  EXPECT_TRUE(InOrderFlagSeen);
+}


### PR DESCRIPTION
Needed for https://github.com/intel/llvm/pull/7599 as the LIT trace using SYCL_PI_TRACE wouldn't be possible after it due to extra indirection level when passing PI_QUEUE_* flags.