### PR TITLE
[SYCL-MLIR][INLINE]: Add aggressive & ludicrous heuristics

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -286,7 +286,7 @@ def ConstructorArgs : AnyTypeOf<[SYCLMemref,
                                  SYCL_RangeType,
                                  Builtin_Vector,
                                ]>;
-def SYCLConstructorOp : SYCL_Op<"constructor", []> {
+def SYCLConstructorOp : SYCL_Op<"constructor", [CallOpInterface]> {
   let summary = "Generic constructor operation";
   let description = [{
     This operation represent the call to the constructor of a SYCL type.
@@ -300,6 +300,23 @@ def SYCLConstructorOp : SYCL_Op<"constructor", []> {
   let results = (outs);
 
   let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    operand_iterator arg_operand_begin() { return operand_begin(); }
+    operand_iterator arg_operand_end() { return operand_end(); }
+
+    /// Return the callee of the generic SYCL call operation, this is required by
+    /// the call interface.
+    CallInterfaceCallable getCallableForCallee() {
+      return (*this)->getAttrOfType<FlatSymbolRefAttr>(getMangledFunctionNameAttrName());
+    }
+
+    /// Get the argument operands to the called function, this is required by the
+    /// call interface.
+    operand_range getArgOperands() {
+      return {arg_operand_begin(), arg_operand_end()};
+    }
+  }];      
 
   let assemblyFormat = [{
     `(` $Args `)` attr-dict `:` functional-type($Args, results)

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.h
@@ -21,7 +21,7 @@ namespace mlir {
 namespace sycl {
 
 /// Inline mode to attempt.
-enum InlineMode { AlwaysInline, Simple, Aggressive };
+enum InlineMode { AlwaysInline, Simple, Aggressive, Ludicrous };
 
 #define GEN_PASS_DECL
 #include "mlir/Dialect/SYCL/Transforms/Passes.h.inc"

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
@@ -38,11 +38,10 @@ public:
   //===--------------------------------------------------------------------===//
 
   /// This hook checks whether is legal to inline the \p Callable operation and
-  /// replace the \p Call operation with it. For the SYCL dialect we want to
-  /// allow inlining only SYCLCallOp operations.
+  /// replace the \p Call operation with it.
   bool isLegalToInline(mlir::Operation *Call, mlir::Operation *Callable,
                        bool WouldBeCloned) const final {
-    return mlir::isa<mlir::sycl::SYCLCallOp>(Call);
+    return true;
   }
 
   /// This hook checks whether is legal to inline the \p Op operation into the

--- a/mlir-sycl/test/Transforms/inliner.mlir
+++ b/mlir-sycl/test/Transforms/inliner.mlir
@@ -11,18 +11,21 @@
 // ALWAYS-INLINE-NEXT:    %c1_i32 = arith.constant 1 : i32
 // ALWAYS-INLINE-NEXT:    %0 = sycl.call() {FunctionName = @inline_hint_callee_, MangledFunctionName = @inline_hint_callee, TypeName = @A} : () -> i32
 // ALWAYS-INLINE-NEXT:    %1 = sycl.call() {FunctionName = @private_callee_, MangledFunctionName = @private_callee, TypeName = @A} : () -> i32
-// ALWAYS-INLINE-NEXT:    %2 = sycl.call() {FunctionName = @callee_, MangledFunctionName = @callee, TypeName = @A} : () -> i32
-// ALWAYS-INLINE-NEXT:    %3 = sycl.call() {FunctionName = @gpu_func_callee_, MangledFunctionName = @gpu_func_callee, TypeName = @A} : () -> i32
-// ALWAYS-INLINE-NEXT:    %4 = arith.addi %c1_i32, %0 : i32
-// ALWAYS-INLINE-NEXT:    %5 = arith.addi %1, %2 : i32
-// ALWAYS-INLINE-NEXT:    %6 = arith.addi %3, %4 : i32
-// ALWAYS-INLINE-NEXT:    %7 = arith.addi %5, %6 : i32
-// ALWAYS-INLINE-NEXT:    return %7 : i32
+// ALWAYS-INLINE-NEXT:    %2 = sycl.call() {FunctionName = @small_callee_, MangledFunctionName = @small_callee, TypeName = @A} : () -> i32
+// ALWAYS-INLINE-NEXT:    %3 = sycl.call() {FunctionName = @callee_, MangledFunctionName = @callee, TypeName = @A} : () -> i32
+// ALWAYS-INLINE-NEXT:    %4 = sycl.call() {FunctionName = @gpu_func_callee_, MangledFunctionName = @gpu_func_callee, TypeName = @A} : () -> i32
+// ALWAYS-INLINE-NEXT:    %5 = arith.addi %c1_i32, %0 : i32
+// ALWAYS-INLINE-NEXT:    %6 = arith.addi %1, %2 : i32
+// ALWAYS-INLINE-NEXT:    %7 = arith.addi %3, %4 : i32
+// ALWAYS-INLINE-NEXT:    %8 = arith.addi %5, %6 : i32
+// ALWAYS-INLINE-NEXT:    %9 = arith.addi %7, %8 : i32
+// ALWAYS-INLINE-NEXT:    return %9 : i32
 // ALWAYS-INLINE-NEXT:  }
 
 // ALWAYS-INLINE-LABEL: func.func @always_inline_callee
 // ALWAYS-INLINE-LABEL: func.func @inline_hint_callee
 // ALWAYS-INLINE-LABEL: func.func private @private_callee
+// ALWAYS-INLINE-LABEL: func.func @small_callee
 // ALWAYS-INLINE-LABEL: func.func @callee
 // ALWAYS-INLINE-LABEL: gpu.func @gpu_func_callee
 
@@ -30,24 +33,27 @@
 // COM: Ensure a gpu.func cannot be inlined in a func.func caller (even if it has the 'alwaysinline' attribute).
 
 // INLINE-LABEL: InlinePass
-// INLINE-LABEL:  (S) 3 num-inlined-calls - Number of inlined calls
+// INLINE-LABEL:  (S) 4 num-inlined-calls - Number of inlined calls
 
 // INLINE-LABEL: func.func @caller() -> i32 {
-// INLINE-NEXT:    %c1_i32 = arith.constant 1 : i32
-// INLINE-NEXT:    %c2_i32 = arith.constant 2 : i32
-// INLINE-NEXT:    %c3_i32 = arith.constant 3 : i32
+// INLINE-DAG:     %c1_i32 = arith.constant 1 : i32
+// INLINE-DAG:     %c2_i32 = arith.constant 2 : i32
+// INLINE-DAG:     %c3_i32 = arith.constant 3 : i32
+// INLINE-DAG:     %c4_i32 = arith.constant 4 : i32
 // INLINE-NEXT:    %0 = sycl.call() {FunctionName = @callee_, MangledFunctionName = @callee, TypeName = @A} : () -> i32
 // INLINE-NEXT:    %1 = sycl.call() {FunctionName = @gpu_func_callee_, MangledFunctionName = @gpu_func_callee, TypeName = @A} : () -> i32
 // INLINE-NEXT:    %2 = arith.addi %c1_i32, %c2_i32 : i32
-// INLINE-NEXT:    %3 = arith.addi %c3_i32, %0 : i32
-// INLINE-NEXT:    %4 = arith.addi %1, %2 : i32
-// INLINE-NEXT:    %5 = arith.addi %3, %4 : i32
-// INLINE-NEXT:    return %5 : i32
+// INLINE-NEXT:    %3 = arith.addi %c3_i32, %c4_i32 : i32
+// INLINE-NEXT:    %4 = arith.addi %0, %1 : i32
+// INLINE-NEXT:    %5 = arith.addi %2, %3 : i32
+// INLINE-NEXT:    %6 = arith.addi %4, %5 : i32
+// INLINE-NEXT:    return %6 : i32
 // INLINE-NEXT:  }
 
 // INLINE-LABEL: func.func @always_inline_callee
 // INLINE-LABEL: func.func @inline_hint_callee
 // INLINE-NOT: func.func private @private_callee
+// INLINE-LABEL: func.func @small_callee
 // INLINE-LABEL: func.func @callee
 // INLINE-LABEL: gpu.func @gpu_func_callee
 
@@ -57,13 +63,15 @@ func.func @caller() -> i32 {
   %res1 = sycl.call() {FunctionName = @"always_inline_callee_", MangledFunctionName = @always_inline_callee, TypeName = @A} : () -> i32
   %res2 = sycl.call() {FunctionName = @"inline_hint_callee_", MangledFunctionName = @inline_hint_callee, TypeName = @A} : () -> i32
   %res3 = sycl.call() {FunctionName = @"private_callee_", MangledFunctionName = @private_callee, TypeName = @A} : () -> i32
-  %res4 = sycl.call() {FunctionName = @"callee_", MangledFunctionName = @callee, TypeName = @A} : () -> i32
-  %res5 = sycl.call() {FunctionName = @"gpu_func_callee_", MangledFunctionName = @gpu_func_callee, TypeName = @A} : () -> i32
-  %res6 = arith.addi %res1, %res2 : i32
-  %res7 = arith.addi %res3, %res4 : i32  
-  %res8 = arith.addi %res5, %res6 : i32  
-  %res9 = arith.addi %res7, %res8 : i32    
-  return %res9 : i32
+  %res4 = sycl.call() {FunctionName = @"small_callee_", MangledFunctionName = @small_callee, TypeName = @A} : () -> i32
+  %res5 = sycl.call() {FunctionName = @"callee_", MangledFunctionName = @callee, TypeName = @A} : () -> i32  
+  %res6 = sycl.call() {FunctionName = @"gpu_func_callee_", MangledFunctionName = @gpu_func_callee, TypeName = @A} : () -> i32
+  %add1 = arith.addi %res1, %res2 : i32
+  %add2 = arith.addi %res3, %res4 : i32  
+  %add3 = arith.addi %res5, %res6 : i32  
+  %add4 = arith.addi %add1, %add2 : i32    
+  %add5 = arith.addi %add3, %add4 : i32      
+  return %add5 : i32
 }
 
 func.func @always_inline_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
@@ -81,9 +89,20 @@ func.func private @private_callee() -> i32 {
   return %c3_i32 : i32
 }
 
-func.func @callee() -> i32 {
+func.func @small_callee() -> i32 {
   %c4_i32 = arith.constant 4 : i32
   return %c4_i32 : i32
+}
+
+func.func @callee() -> i32 {
+  %c1 = arith.constant 1 : i32
+  %c2 = arith.constant 2 : i32
+  %c3 = arith.constant 3 : i32
+  %c4 = arith.constant 4 : i32  
+  %add1 = arith.addi %c1, %c2 : i32
+  %add2 = arith.addi %c3, %c4 : i32  
+  %add3 = arith.addi %add1, %add2 : i32  
+  return %add3 : i32
 }
 
 gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
@@ -132,8 +151,14 @@ func.func @inlinable_callee() -> i32 attributes {passthrough = ["alwaysinline"]}
 }
 
 func.func @callee() -> i32 {
-  %c2_i32 = arith.constant 2 : i32
-  return %c2_i32 : i32
+  %c1 = arith.constant 1 : i32
+  %c2 = arith.constant 2 : i32
+  %c3 = arith.constant 3 : i32
+  %c4 = arith.constant 4 : i32  
+  %add1 = arith.addi %c1, %c2 : i32
+  %add2 = arith.addi %c3, %c4 : i32  
+  %add3 = arith.addi %add1, %add2 : i32  
+  return %add3 : i32
 }
 
 gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
@@ -150,10 +175,10 @@ gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
 // INLINE-DAG:     %c1_i32 = arith.constant 1 : i32
 // INLINE-DAG:     %c2_i32 = arith.constant 2 : i32
 // INLINE-DAG:     %c3_i32 = arith.constant 3 : i32
-// INLINE-DAG:     %0 = sycl.call() {FunctionName = @callee_, MangledFunctionName = @callee, TypeName = @A} : () -> i32
-// INLINE-NEXT:    %1 = arith.addi %c2_i32, %0 : i32
-// INLINE-NEXT:    %2 = arith.addi %c1_i32, %1 : i32
-// INLINE-NEXT:    %3 = arith.addi %c3_i32, %2 : i32
+// INLINE-DAG:     %0 = sycl.call() {FunctionName = @private_callee_, MangledFunctionName = @private_callee, TypeName = @A} : () -> i32
+// INLINE-NEXT:    %1 = arith.addi %c1_i32, %0 : i32
+// INLINE-NEXT:    %2 = arith.addi %c3_i32, %1 : i32
+// INLINE-NEXT:    %3 = arith.addi %c2_i32, %2 : i32
 // INLINE-NEXT:    return %3 : i32
 // INLINE-NEXT:  }
 

--- a/mlir-sycl/test/Transforms/inliner.mlir
+++ b/mlir-sycl/test/Transforms/inliner.mlir
@@ -174,12 +174,14 @@ gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
 // INLINE-LABEL: func.func @callee() -> i32 {
 // INLINE-DAG:     %c1_i32 = arith.constant 1 : i32
 // INLINE-DAG:     %c2_i32 = arith.constant 2 : i32
-// INLINE-DAG:     %c3_i32 = arith.constant 3 : i32
-// INLINE-DAG:     %0 = sycl.call() {FunctionName = @private_callee_, MangledFunctionName = @private_callee, TypeName = @A} : () -> i32
-// INLINE-NEXT:    %1 = arith.addi %c1_i32, %0 : i32
-// INLINE-NEXT:    %2 = arith.addi %c3_i32, %1 : i32
-// INLINE-NEXT:    %3 = arith.addi %c2_i32, %2 : i32
-// INLINE-NEXT:    return %3 : i32
+// INLINE-DAG:     %c1_i32_0 = arith.constant 1 : i32
+// INLINE-DAG:     %c2_i32_1 = arith.constant 2 : i32
+// INLINE-DAG:     %0 = sycl.call() {FunctionName = @callee_, MangledFunctionName = @callee, TypeName = @A} : () -> i32
+// INLINE-NEXT:    %1 = arith.addi %c2_i32_1, %0 : i32
+// INLINE-NEXT:    %2 = arith.addi %c1_i32_0, %1 : i32
+// INLINE-NEXT:    %3 = arith.addi %c1_i32, %c2_i32 : i32
+// INLINE-NEXT:    %4 = arith.addi %2, %3 : i32
+// INLINE-NEXT:    return %4 : i32
 // INLINE-NEXT:  }
 
 // INLINE-NOT: func.func private @inline_hint_callee
@@ -200,9 +202,10 @@ func.func private @private_callee() -> i32 {
 }
 
 func.func @callee() -> i32 {
-  %c_i32 = arith.constant 3 : i32
-  %res1 = sycl.call() {FunctionName = @"inline_hint_callee_", MangledFunctionName = @inline_hint_callee, TypeName = @A} : () -> i32  
-  %res2 = arith.addi %c_i32, %res1 : i32  
-  return %res2 : i32
+  %c1 = arith.constant 1 : i32
+  %c2 = arith.constant 2 : i32
+  %res1 = sycl.call() {FunctionName = @"inline_hint_callee_", MangledFunctionName = @inline_hint_callee, TypeName = @A} : () -> i32    
+  %add1 = arith.addi %c1, %c2 : i32
+  %add2 = arith.addi %res1, %add1 : i32  
+  return %add2 : i32
 }
-

--- a/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
+++ b/mlir/lib/Dialect/Vector/IR/VectorOps.cpp
@@ -30,6 +30,7 @@
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/IR/TypeUtilities.h"
 #include "mlir/Support/LLVM.h"
+#include "mlir/Transforms/InliningUtils.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/ADT/bit.h"
@@ -234,6 +235,24 @@ struct BitmaskEnumStorage : public AttributeStorage {
 } // namespace mlir
 
 //===----------------------------------------------------------------------===//
+// VectorDialect Interfaces
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+struct VectorInlinerInterface : public DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+
+  /// All operations can be inlined.
+  bool isLegalToInline(Operation *, Region *, bool wouldBeCloned,
+                       BlockAndValueMapping &) const final {
+    return true;
+  }
+};
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
 // VectorDialect
 //===----------------------------------------------------------------------===//
 
@@ -247,6 +266,8 @@ void VectorDialect::initialize() {
 #define GET_OP_LIST
 #include "mlir/Dialect/Vector/IR/VectorOps.cpp.inc"
       >();
+
+  addInterfaces<VectorInlinerInterface>();
 }
 
 /// Materialize a single constant operation from a given attribute value with

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -348,7 +348,7 @@ static int optimize(mlir::MLIRContext &Ctx,
     if (RaiseToAffine)
       OptPM.addPass(mlir::createLowerAffinePass());
     PM.addPass(sycl::createInlinePass(sycl::InlineMode::Simple,
-                                      /* RemoveDeadCallees */ false));
+                                      /* RemoveDeadCallees */ true));
 
     mlir::OpPassManager &OptPM2 = PM.nestAny();
     OptPM2.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));


### PR DESCRIPTION
This PR expands upon PR https://github.com/intel/llvm/pull/7576 by adding the "aggressive" and "ludicrous" heuristics. It also modifies the "simple" heuristic. The inline heuristics 'mode' is as follows:
  - alwaysinline: collect 'sycl.call' edges
     + inline callees that have the 'alwaysinline' attribute
  - simple: collect 'sycl.call' and 'sycl.constructor' edges
     + inline callees that have either the 'inlinehint' or the 'alwaysinline' attribute, and 
     + inline callees that are dead after inlining the last call, and
     + inline small callees (num instructions < small threshold)
  - aggressive: collect 'sycl.call', 'sycl.constructor', and 'sycl.method' call instructions
     + inline callees that have either the 'inlinehint' or the 'alwaysinline' attribute, and 
     + inline callees that are dead after inlining the last call, and
     + inline medium size callees (num instructions < medium threshold)
  - ludicrous:  collect all call instructions
     + inline callees that have either the 'inlinehint' or the 'alwaysinline' attribute, and 
     + inline callees that are dead after inlining the last call, and
     + inline large size callees (num instructions < large threshold)
     
Finally, the PR allows callees containing instructions from the vector dialect to be inlined.

Signed-off-by: Tiotto, Ettore <ettore.tiotto@intel.com>