### PR TITLE
[SYCL-MLIR] Represent `sycl.id` and `sycl.range` with body `sycl.array`

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -130,8 +130,9 @@ class SYCLInheritanceTypeTrait<string ParentClass>
 
 def SYCL_IDType
     : SYCL_Type<"ID", "id", [SYCLInheritanceTypeTrait<"ArrayType">]> {
-  let parameters = (ins "unsigned":$dimension);
-  let assemblyFormat = "`<` $dimension `>`";
+  let parameters = (ins "unsigned":$dimension,
+                        ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<`  `[` $dimension `]` `,` `(` $body `)` `>`";
 }
 
 def SYCL_AccessorCommonType : SYCL_Type<"AccessorCommon", "accessor_common"> {
@@ -152,8 +153,9 @@ def SYCL_AccessorType
 
 def SYCL_RangeType
     : SYCL_Type<"Range", "range", [SYCLInheritanceTypeTrait<"ArrayType">]> {
-  let parameters = (ins "unsigned":$dimension);
-  let assemblyFormat = "`<` $dimension `>`";
+  let parameters = (ins "unsigned":$dimension,
+                        ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<`  `[` $dimension `]` `,` `(` $body `)` `>`";
 }
 
 def SYCL_NdRangeType : SYCL_Type<"NdRange", "nd_range"> {

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -266,13 +266,7 @@ static Optional<Type> convertBFloat16Type(sycl::BFloat16Type type,
 /// Converts SYCL sub_group type to LLVM type.
 static Optional<Type> convertSubGroupType(sycl::SubGroupType type,
                                           LLVMTypeConverter &converter) {
-  auto convertedTy = LLVM::LLVMStructType::getIdentified(
-      &converter.getContext(), "struct.sycl::_V1::ext::oneapi::sub_group");
-  if (!convertedTy.isInitialized())
-    if (failed(convertedTy.setBody(IntegerType::get(&converter.getContext(), 8),
-                                   /*isPacked=*/false)))
-      return llvm::None;
-  return convertedTy;
+  return getI8Struct("struct.sycl::_V1::ext::oneapi::sub_group", converter);
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
@@ -128,9 +128,9 @@ SYCLOpAsmInterface::getAlias(mlir::Type Type, llvm::raw_ostream &OS) const {
             OS << "sycl_" << decltype(Ty)::getMnemonic() << "_";
             return AliasResult::FinalAlias;
           })
-      .Case<mlir::sycl::NdRangeType, mlir::sycl::AccessorImplDeviceType,
-            mlir::sycl::ArrayType, mlir::sycl::NdItemType,
-            mlir::sycl::GroupType>([&](auto Ty) {
+      .Case<mlir::sycl::IDType, mlir::sycl::RangeType, mlir::sycl::NdRangeType,
+            mlir::sycl::AccessorImplDeviceType, mlir::sycl::ArrayType,
+            mlir::sycl::NdItemType, mlir::sycl::GroupType>([&](auto Ty) {
         OS << "sycl_" << decltype(Ty)::getMnemonic() << "_" << Ty.getDimension()
            << "_";
         return AliasResult::FinalAlias;

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-call-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-call-to-llvm.mlir
@@ -22,14 +22,16 @@ func.func @test() -> (i32) {
 // Member functions for sycl::accessor
 //===-------------------------------------------------------------------------------------------------===//
 
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
 
 // CHECK: llvm.func @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE([[ARG_TYPES:!llvm.ptr<struct<"class.sycl::_V1::accessor.1",.*]])
-func.func private @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE(memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?xi32>, !sycl.range<1>, !sycl.range<1>, !sycl.id<1>)
+func.func private @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE(memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?xi32>, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)
 
-func.func @accessorInit1(%arg0: memref<?x!sycl_accessor_1_i32_rw_gb>, %arg1: memref<?xi32>, %arg2: !sycl.range<1>, %arg3: !sycl.range<1>, %arg4: !sycl.id<1>) {
+func.func @accessorInit1(%arg0: memref<?x!sycl_accessor_1_i32_rw_gb>, %arg1: memref<?xi32>, %arg2: !sycl_range_1_, %arg3: !sycl_range_1_, %arg4: !sycl_id_1_) {
   // CHECK: llvm.call @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE({{.*}}) : ([[ARG_TYPES]]) -> ()
-  sycl.call(%arg0, %arg1, %arg2, %arg3, %arg4) {FunctionName = @__init, MangledFunctionName = @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?xi32>, !sycl.range<1>, !sycl.range<1>, !sycl.id<1>) -> ()
+  sycl.call(%arg0, %arg1, %arg2, %arg3, %arg4) {FunctionName = @__init, MangledFunctionName = @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?xi32>, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_) -> ()
   return
 }
 

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-cast-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-cast-to-llvm.mlir
@@ -1,7 +1,8 @@
 // RUN: sycl-mlir-opt -split-input-file -convert-sycl-to-llvm -verify-diagnostics %s | FileCheck %s
 
 !sycl_array_1_ = !sycl.array<[1], (memref<1xi64>)>
-func.func @test1(%arg0: memref<?x!sycl.range<1>>) -> memref<?x!sycl_array_1_> {
+!sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
+func.func @test1(%arg0: memref<?x!sycl_range_1_>) -> memref<?x!sycl_array_1_> {
   // CHECK: llvm.func @test1
   // CHECK: [[SRC:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.sycl::_V1::range.1"
   // CHECK-DAG: [[SRC_IV0:%.*]] = llvm.insertvalue %arg0, [[SRC]][0]
@@ -27,14 +28,15 @@ func.func @test1(%arg0: memref<?x!sycl.range<1>>) -> memref<?x!sycl_array_1_> {
 
   // CHECK: llvm.return [[RES_IV2]] : !llvm.struct<(ptr<struct<"class.sycl::_V1::detail::array.1"  
 
-  %0 = "sycl.cast"(%arg0) : (memref<?x!sycl.range<1>>) -> memref<?x!sycl_array_1_>
+  %0 = "sycl.cast"(%arg0) : (memref<?x!sycl_range_1_>) -> memref<?x!sycl_array_1_>
   func.return %0 : memref<?x!sycl_array_1_>
 }
 
 // -----
 
 !sycl_array_1_ = !sycl.array<[1], (memref<1xi64>)>
-func.func @test2(%arg0: memref<?x!sycl.id<1>>) -> memref<?x!sycl_array_1_> {
+!sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
+func.func @test2(%arg0: memref<?x!sycl_id_1_>) -> memref<?x!sycl_array_1_> {
   // CHECK: llvm.func @test2
   // CHECK: [[SRC:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.sycl::_V1::id.1"
   // CHECK-DAG: [[SRC_IV0:%.*]] = llvm.insertvalue %arg0, [[SRC]][0]
@@ -60,13 +62,15 @@ func.func @test2(%arg0: memref<?x!sycl.id<1>>) -> memref<?x!sycl_array_1_> {
 
   // CHECK: llvm.return [[RES_IV2]] : !llvm.struct<(ptr<struct<"class.sycl::_V1::detail::array.1"  
 
-  %0 = "sycl.cast"(%arg0) : (memref<?x!sycl.id<1>>) -> memref<?x!sycl_array_1_>
+  %0 = "sycl.cast"(%arg0) : (memref<?x!sycl_id_1_>) -> memref<?x!sycl_array_1_>
   func.return %0: memref<?x!sycl_array_1_>
 }
 
 // -----
 
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
 func.func @test3(%arg0: memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?x!sycl.accessor_common> {
   // CHECK-LABEL: llvm.func @test3
   // CHECK: [[SRC:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<struct<"class.sycl::_V1::accessor.1"

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-constructor-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-constructor-to-llvm.mlir
@@ -4,7 +4,9 @@
 // Constructors for sycl::accessor<t, d, m, t, p>::accessor()
 //===-------------------------------------------------------------------------------------------------===//
 
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
 
 // CHECK: llvm.func @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::accessor.1",.*]])
 func.func private @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC2Ev(memref<?x!sycl_accessor_1_i32_rw_gb>)
@@ -21,34 +23,37 @@ func.func @accessorInt1ReadWriteGlobalBufferFalseCtor(%arg0: memref<?x!sycl_acce
 // Constructors for sycl::id<n>::id()
 //===-------------------------------------------------------------------------------------------------===//
 
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl2idILi1EEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.1",.*]])
-func.func private @_ZN2cl4sycl2idILi1EEC2Ev(memref<?x!sycl.id<1>>)
+func.func private @_ZN2cl4sycl2idILi1EEC2Ev(memref<?x!sycl_id_1_>)
 
-func.func @id1Ctor(%arg0: memref<?x!sycl.id<1>>) {
+func.func @id1Ctor(%arg0: memref<?x!sycl_id_1_>) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi1EEC2Ev({{.*}}) : ([[THIS_PTR_TYPE]]) -> ()
-  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl2idILi1EEC2Ev, TypeName = @id} : (memref<?x!sycl.id<1>>) -> ()
+  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl2idILi1EEC2Ev, TypeName = @id} : (memref<?x!sycl_id_1_>) -> ()
   return
 }
 
 // -----
 
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl2idILi2EEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.2",.*]])
-func.func private @_ZN2cl4sycl2idILi2EEC2Ev(memref<?x!sycl.id<2>>)
+func.func private @_ZN2cl4sycl2idILi2EEC2Ev(memref<?x!sycl_id_2_>)
 
-func.func @id2Ctor(%arg0: memref<?x!sycl.id<2>>) {
+func.func @id2Ctor(%arg0: memref<?x!sycl_id_2_>) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi2EEC2Ev({{.*}}) : ([[THIS_PTR_TYPE]]) -> ()
-  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl2idILi2EEC2Ev, TypeName = @id} : (memref<?x!sycl.id<2>>) -> ()
+  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl2idILi2EEC2Ev, TypeName = @id} : (memref<?x!sycl_id_2_>) -> ()
   return
 }
 
 // -----
 
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl2idILi3EEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.3",.*]])
-func.func private @_ZN2cl4sycl2idILi3EEC2Ev(memref<?x!sycl.id<3>>)
+func.func private @_ZN2cl4sycl2idILi3EEC2Ev(memref<?x!sycl_id_3_>)
 
-func.func @id3Ctor(%arg0: memref<?x!sycl.id<3>>) {
+func.func @id3Ctor(%arg0: memref<?x!sycl_id_3_>) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi3EEC2Ev({{.*}}) : ([[THIS_PTR_TYPE]]) -> ()
-  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl2idILi3EEC2Ev, TypeName = @id} : (memref<?x!sycl.id<3>>) -> ()
+  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl2idILi3EEC2Ev, TypeName = @id} : (memref<?x!sycl_id_3_>) -> ()
   return
 }
 
@@ -58,34 +63,37 @@ func.func @id3Ctor(%arg0: memref<?x!sycl.id<3>>) {
 // Constructors for cl::sycl::id<n>::id<n>(std::enable_if<(n)==(n), unsigned long>::type)
 //===-------------------------------------------------------------------------------------------------===//
 
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.1",.*]], i64)
-func.func private @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE(memref<?x!sycl.id<1>>, i64)
+func.func private @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE(memref<?x!sycl_id_1_>, i64)
 
-func.func @id1CtorSizeT(%arg0: memref<?x!sycl.id<1>>, %arg1: i64) {
+func.func @id1CtorSizeT(%arg0: memref<?x!sycl_id_1_>, %arg1: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE({{.*}}, %arg5) : ([[THIS_PTR_TYPE]], i64) -> ()
-  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE, TypeName = @id} : (memref<?x!sycl.id<1>>, i64) -> ()
+  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE, TypeName = @id} : (memref<?x!sycl_id_1_>, i64) -> ()
   return
 }
 
 // -----
 
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.2",.*]], i64)
-func.func private @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE(memref<?x!sycl.id<2>>, i64)
+func.func private @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE(memref<?x!sycl_id_2_>, i64)
 
-func.func @id2CtorSizeT(%arg0: memref<?x!sycl.id<2>>, %arg1: i64) {
+func.func @id2CtorSizeT(%arg0: memref<?x!sycl_id_2_>, %arg1: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE({{.*}}, %arg5) : ([[THIS_PTR_TYPE]], i64) -> ()
-  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE, TypeName = @id} : (memref<?x!sycl.id<2>>, i64) -> ()
+  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE, TypeName = @id} : (memref<?x!sycl_id_2_>, i64) -> ()
   return
 }
 
 // -----
 
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.3",.*]], i64)
-func.func private @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE(memref<?x!sycl.id<3>>, i64)
+func.func private @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE(memref<?x!sycl_id_3_>, i64)
 
-func.func @id3CtorSizeT(%arg0: memref<?x!sycl.id<3>>, %arg1: i64) {
+func.func @id3CtorSizeT(%arg0: memref<?x!sycl_id_3_>, %arg1: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE({{.*}}, %arg5) : ([[THIS_PTR_TYPE]], i64) -> ()
-  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE, TypeName = @id} : (memref<?x!sycl.id<3>>, i64) -> ()
+  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE, TypeName = @id} : (memref<?x!sycl_id_3_>, i64) -> ()
   return
 }
 
@@ -95,34 +103,37 @@ func.func @id3CtorSizeT(%arg0: memref<?x!sycl.id<3>>, %arg1: i64) {
 // Constructors for cl::sycl::id<n>::id<n>(std::enable_if<(n)==(n), unsigned long>::type, unsigned long)
 //===-------------------------------------------------------------------------------------------------===//
 
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.1",.*]], i64, i64)
-func.func private @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm(memref<?x!sycl.id<1>>, i64, i64)
+func.func private @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm(memref<?x!sycl_id_1_>, i64, i64)
 
-func.func @id1CtorRange(%arg0: memref<?x!sycl.id<1>>, %arg1: i64, %arg2: i64) {
+func.func @id1CtorRange(%arg0: memref<?x!sycl_id_1_>, %arg1: i64, %arg2: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm({{.*}}, %arg5, %arg6) : ([[THIS_PTR_TYPE]], i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2) {MangledFunctionName = @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm, TypeName = @id} : (memref<?x!sycl.id<1>>, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2) {MangledFunctionName = @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm, TypeName = @id} : (memref<?x!sycl_id_1_>, i64, i64) -> ()
   return
 }
 
 // -----
 
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.2",.*]], i64, i64)
-func.func private @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm(memref<?x!sycl.id<2>>, i64, i64)
+func.func private @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm(memref<?x!sycl_id_2_>, i64, i64)
 
-func.func @id2CtorRange(%arg0: memref<?x!sycl.id<2>>, %arg1: i64, %arg2: i64) {
+func.func @id2CtorRange(%arg0: memref<?x!sycl_id_2_>, %arg1: i64, %arg2: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm({{.*}}, %arg5, %arg6) : ([[THIS_PTR_TYPE]], i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2) {MangledFunctionName = @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, TypeName = @id} : (memref<?x!sycl.id<2>>, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2) {MangledFunctionName = @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, TypeName = @id} : (memref<?x!sycl_id_2_>, i64, i64) -> ()
   return
 }
 
 // -----
 
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.3",.*]], i64, i64)
-func.func private @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm(memref<?x!sycl.id<3>>, i64, i64)
+func.func private @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm(memref<?x!sycl_id_3_>, i64, i64)
 
-func.func @id3CtorRange(%arg0: memref<?x!sycl.id<3>>, %arg1: i64, %arg2: i64) {
+func.func @id3CtorRange(%arg0: memref<?x!sycl_id_3_>, %arg1: i64, %arg2: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm({{.*}}, %arg5, %arg6) : ([[THIS_PTR_TYPE]], i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2) {MangledFunctionName = @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm, TypeName = @id} : (memref<?x!sycl.id<3>>, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2) {MangledFunctionName = @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm, TypeName = @id} : (memref<?x!sycl_id_3_>, i64, i64) -> ()
   return
 }
 
@@ -132,34 +143,37 @@ func.func @id3CtorRange(%arg0: memref<?x!sycl.id<3>>, %arg1: i64, %arg2: i64) {
 // Constructors for cl::sycl::id<n>::id<n>(std::enable_if<(n)==(n), unsigned long>::type, unsigned long, unsigned long)
 //===-------------------------------------------------------------------------------------------------===//
 
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.1",.*]], i64, i64, i64)
-func.func private @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm(memref<?x!sycl.id<1>>, i64, i64, i64)
+func.func private @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm(memref<?x!sycl_id_1_>, i64, i64, i64)
 
-func.func @id1CtorItem(%arg0: memref<?x!sycl.id<1>>, %arg1: i64, %arg2: i64, %arg3: i64) {
+func.func @id1CtorItem(%arg0: memref<?x!sycl_id_1_>, %arg1: i64, %arg2: i64, %arg3: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm({{.*}}, %arg5, %arg6, %arg7) : ([[THIS_PTR_TYPE]], i64, i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledFunctionName = @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm, TypeName = @id} : (memref<?x!sycl.id<1>>, i64, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledFunctionName = @_ZN2cl4sycl2idILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm, TypeName = @id} : (memref<?x!sycl_id_1_>, i64, i64, i64) -> ()
   return
 }
 
 // -----
 
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.2",.*]], i64, i64, i64)
-func.func private @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm(memref<?x!sycl.id<2>>, i64, i64, i64)
+func.func private @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm(memref<?x!sycl_id_2_>, i64, i64, i64)
 
-func.func @id2CtorItem(%arg0: memref<?x!sycl.id<2>>, %arg1: i64, %arg2: i64, %arg3: i64) {
+func.func @id2CtorItem(%arg0: memref<?x!sycl_id_2_>, %arg1: i64, %arg2: i64, %arg3: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm({{.*}}, %arg5, %arg6, %arg7) : ([[THIS_PTR_TYPE]], i64, i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledFunctionName = @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm, TypeName = @id} : (memref<?x!sycl.id<2>>, i64, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledFunctionName = @_ZN2cl4sycl2idILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm, TypeName = @id} : (memref<?x!sycl_id_2_>, i64, i64, i64) -> ()
   return
 }
 
 // -----
 
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.3",.*]], i64, i64, i64)
-func.func private @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm(memref<?x!sycl.id<3>>, i64, i64, i64)
+func.func private @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm(memref<?x!sycl_id_3_>, i64, i64, i64)
 
-func.func @id3CtorItem(%arg0: memref<?x!sycl.id<3>>, %arg1: i64, %arg2: i64, %arg3: i64) {
+func.func @id3CtorItem(%arg0: memref<?x!sycl_id_3_>, %arg1: i64, %arg2: i64, %arg3: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm({{.*}}, %arg5, %arg6, %arg7) : ([[THIS_PTR_TYPE]], i64, i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledFunctionName = @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm, TypeName = @id} : (memref<?x!sycl.id<3>>, i64, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledFunctionName = @_ZN2cl4sycl2idILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm, TypeName = @id} : (memref<?x!sycl_id_3_>, i64, i64, i64) -> ()
   return
 }
 
@@ -169,34 +183,37 @@ func.func @id3CtorItem(%arg0: memref<?x!sycl.id<3>>, %arg1: i64, %arg2: i64, %ar
 // Constructors sycl::id<n>::id(sycl::id<n> const&, sycl::id<n> const&)
 //===-------------------------------------------------------------------------------------------------===//
 
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl2idILi1EEC1ERKS2_([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.1",.*]], [[THIS_PTR_TYPE]])
-func.func private @_ZN2cl4sycl2idILi1EEC1ERKS2_(memref<?x!sycl.id<1>>, memref<?x!sycl.id<1>>)
+func.func private @_ZN2cl4sycl2idILi1EEC1ERKS2_(memref<?x!sycl_id_1_>, memref<?x!sycl_id_1_>)
 
-func.func @id1CopyCtor(%arg0: memref<?x!sycl.id<1>>, %arg1: memref<?x!sycl.id<1>>) {
+func.func @id1CopyCtor(%arg0: memref<?x!sycl_id_1_>, %arg1: memref<?x!sycl_id_1_>) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi1EEC1ERKS2_({{.*}}, {{.*}}) : ([[THIS_PTR_TYPE]], [[THIS_PTR_TYPE]]) -> ()  
- "sycl.constructor"(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl2idILi1EEC1ERKS2_, TypeName = @id} : (memref<?x!sycl.id<1>>, memref<?x!sycl.id<1>>) -> ()
+ "sycl.constructor"(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl2idILi1EEC1ERKS2_, TypeName = @id} : (memref<?x!sycl_id_1_>, memref<?x!sycl_id_1_>) -> ()
   return
 }
 
 // -----
 
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl2idILi2EEC1ERKS2_([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.2",.*]], [[THIS_PTR_TYPE]])
-func.func private @_ZN2cl4sycl2idILi2EEC1ERKS2_(memref<?x!sycl.id<2>>, memref<?x!sycl.id<2>>)
+func.func private @_ZN2cl4sycl2idILi2EEC1ERKS2_(memref<?x!sycl_id_2_>, memref<?x!sycl_id_2_>)
 
-func.func @id2CopyCtor(%arg0: memref<?x!sycl.id<2>>, %arg1: memref<?x!sycl.id<2>>) {
+func.func @id2CopyCtor(%arg0: memref<?x!sycl_id_2_>, %arg1: memref<?x!sycl_id_2_>) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi2EEC1ERKS2_({{.*}}, {{.*}}) : ([[THIS_PTR_TYPE]], [[THIS_PTR_TYPE]]) -> ()
- "sycl.constructor"(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl2idILi2EEC1ERKS2_, TypeName = @id} : (memref<?x!sycl.id<2>>, memref<?x!sycl.id<2>>) -> ()  
+ "sycl.constructor"(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl2idILi2EEC1ERKS2_, TypeName = @id} : (memref<?x!sycl_id_2_>, memref<?x!sycl_id_2_>) -> ()  
   return
 }
 
 // -----
 
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl2idILi3EEC1ERKS2_([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::id.3",.*]], [[THIS_PTR_TYPE]])
-func.func private @_ZN2cl4sycl2idILi3EEC1ERKS2_(memref<?x!sycl.id<3>>, memref<?x!sycl.id<3>>)
+func.func private @_ZN2cl4sycl2idILi3EEC1ERKS2_(memref<?x!sycl_id_3_>, memref<?x!sycl_id_3_>)
 
-func.func @id3CopyCtor(%arg0: memref<?x!sycl.id<3>>, %arg1: memref<?x!sycl.id<3>>) {
+func.func @id3CopyCtor(%arg0: memref<?x!sycl_id_3_>, %arg1: memref<?x!sycl_id_3_>) {
   // CHECK: llvm.call @_ZN2cl4sycl2idILi3EEC1ERKS2_({{.*}}, {{.*}}) : ([[THIS_PTR_TYPE]], [[THIS_PTR_TYPE]]) -> ()
- "sycl.constructor"(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl2idILi3EEC1ERKS2_, TypeName = @id} : (memref<?x!sycl.id<3>>, memref<?x!sycl.id<3>>) -> ()
+ "sycl.constructor"(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl2idILi3EEC1ERKS2_, TypeName = @id} : (memref<?x!sycl_id_3_>, memref<?x!sycl_id_3_>) -> ()
   return
 }
 
@@ -206,34 +223,37 @@ func.func @id3CopyCtor(%arg0: memref<?x!sycl.id<3>>, %arg1: memref<?x!sycl.id<3>
 // Constructors for sycl::range<n>::range()
 //===-------------------------------------------------------------------------------------------------===//
 
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl5rangeILi1EEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.1",.*]])
-func.func private @_ZN2cl4sycl5rangeILi1EEC2Ev(memref<?x!sycl.range<1>>)
+func.func private @_ZN2cl4sycl5rangeILi1EEC2Ev(memref<?x!sycl_range_1_>)
 
-func.func @range1Ctor(%arg0: memref<?x!sycl.range<1>>) {
+func.func @range1Ctor(%arg0: memref<?x!sycl_range_1_>) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi1EEC2Ev({{.*}}) : ([[THIS_PTR_TYPE]]) -> ()
-  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl5rangeILi1EEC2Ev, TypeName = @range} : (memref<?x!sycl.range<1>>) -> ()
+  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl5rangeILi1EEC2Ev, TypeName = @range} : (memref<?x!sycl_range_1_>) -> ()
   return
 }
 
 // -----
 
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl5rangeILi2EEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.2",.*]])
-func.func private @_ZN2cl4sycl5rangeILi2EEC2Ev(memref<?x!sycl.range<2>>)
+func.func private @_ZN2cl4sycl5rangeILi2EEC2Ev(memref<?x!sycl_range_2_>)
 
-func.func @range2Ctor(%arg0: memref<?x!sycl.range<2>>) {
+func.func @range2Ctor(%arg0: memref<?x!sycl_range_2_>) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi2EEC2Ev({{.*}}) : ([[THIS_PTR_TYPE]]) -> ()
-  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl5rangeILi2EEC2Ev, TypeName = @range} : (memref<?x!sycl.range<2>>) -> ()
+  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl5rangeILi2EEC2Ev, TypeName = @range} : (memref<?x!sycl_range_2_>) -> ()
   return
 }
 
 // -----
 
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<2xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl5rangeILi3EEC2Ev([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.3",.*]])
-func.func private @_ZN2cl4sycl5rangeILi3EEC2Ev(memref<?x!sycl.range<3>>)
+func.func private @_ZN2cl4sycl5rangeILi3EEC2Ev(memref<?x!sycl_range_3_>)
 
-func.func @range3Ctor(%arg0: memref<?x!sycl.range<3>>) {
+func.func @range3Ctor(%arg0: memref<?x!sycl_range_3_>) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi3EEC2Ev({{.*}}) : ([[THIS_PTR_TYPE]]) -> ()
-  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl5rangeILi3EEC2Ev, TypeName = @range} : (memref<?x!sycl.range<3>>) -> ()
+  sycl.constructor(%arg0) {MangledFunctionName = @_ZN2cl4sycl5rangeILi3EEC2Ev, TypeName = @range} : (memref<?x!sycl_range_3_>) -> ()
   return
 }
 
@@ -243,34 +263,37 @@ func.func @range3Ctor(%arg0: memref<?x!sycl.range<3>>) {
 // Constructors for cl::sycl::range<n>::range<n>(std::enable_if<(n)==(n), unsigned long>::type)
 //===-------------------------------------------------------------------------------------------------===//
 
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.1",.*]], i64)
-func.func private @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE(memref<?x!sycl.range<1>>, i64)
+func.func private @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE(memref<?x!sycl_range_1_>, i64)
 
-func.func @range1CtorSizeT(%arg0: memref<?x!sycl.range<1>>, %arg1: i64) {
+func.func @range1CtorSizeT(%arg0: memref<?x!sycl_range_1_>, %arg1: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE({{.*}}, %arg5) : ([[THIS_PTR_TYPE]], i64) -> ()
-  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE, TypeName = @range} : (memref<?x!sycl.range<1>>, i64) -> ()
+  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE, TypeName = @range} : (memref<?x!sycl_range_1_>, i64) -> ()
   return
 }
 
 // -----
 
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.2",.*]], i64)
-func.func private @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE( memref<?x!sycl.range<2>>, i64)
+func.func private @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE( memref<?x!sycl_range_2_>, i64)
 
-func.func @range2CtorSizeT(%arg0: memref<?x!sycl.range<2>>, %arg1: i64) {
+func.func @range2CtorSizeT(%arg0: memref<?x!sycl_range_2_>, %arg1: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE({{.*}}, %arg5) : ([[THIS_PTR_TYPE]], i64) -> ()
-  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE, TypeName = @range} : (memref<?x!sycl.range<2>>, i64) -> ()
+  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeE, TypeName = @range} : (memref<?x!sycl_range_2_>, i64) -> ()
   return
 }
 
 // -----
 
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<2xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.3",.*]], i64)
-func.func private @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE(memref<?x!sycl.range<3>>, i64)
+func.func private @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE(memref<?x!sycl_range_3_>, i64)
 
-func.func @range3CtorSizeT(%arg0: memref<?x!sycl.range<3>>, %arg1: i64) {
+func.func @range3CtorSizeT(%arg0: memref<?x!sycl_range_3_>, %arg1: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE({{.*}}, %arg5) : ([[THIS_PTR_TYPE]], i64) -> ()
-  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE, TypeName = @range} : (memref<?x!sycl.range<3>>, i64) -> ()
+  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeE, TypeName = @range} : (memref<?x!sycl_range_3_>, i64) -> ()
   return
 }
 
@@ -280,34 +303,37 @@ func.func @range3CtorSizeT(%arg0: memref<?x!sycl.range<3>>, %arg1: i64) {
 // Constructors for cl::sycl::range<n>::range<n>(std::enable_if<(n)==(n), unsigned long>::type, unsigned long)
 //===-------------------------------------------------------------------------------------------------===//
 
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.1",.*]], i64, i64)
-func.func private @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm(memref<?x!sycl.range<1>>, i64, i64)
+func.func private @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm(memref<?x!sycl_range_1_>, i64, i64)
 
-func.func @range1Ctor2SizeT(%arg0: memref<?x!sycl.range<1>>, %arg1: i64, %arg2: i64) {
+func.func @range1Ctor2SizeT(%arg0: memref<?x!sycl_range_1_>, %arg1: i64, %arg2: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm({{.*}}, %arg5, %arg6) : ([[THIS_PTR_TYPE]], i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2) {MangledFunctionName = @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm, TypeName = @range} : (memref<?x!sycl.range<1>>, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2) {MangledFunctionName = @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEm, TypeName = @range} : (memref<?x!sycl_range_1_>, i64, i64) -> ()
   return
 }
 
 // -----
 
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.2",.*]], i64, i64)
-func.func private @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm(memref<?x!sycl.range<2>>, i64, i64)
+func.func private @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm(memref<?x!sycl_range_2_>, i64, i64)
 
-func.func @range2Ctor2SizeT(%arg0: memref<?x!sycl.range<2>>, %arg1: i64, %arg2: i64) {
+func.func @range2Ctor2SizeT(%arg0: memref<?x!sycl_range_2_>, %arg1: i64, %arg2: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm({{.*}}, %arg5, %arg6) : ([[THIS_PTR_TYPE]], i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2) {MangledFunctionName = @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, TypeName = @range} : (memref<?x!sycl.range<2>>, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2) {MangledFunctionName = @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, TypeName = @range} : (memref<?x!sycl_range_2_>, i64, i64) -> ()
   return
 }
 
 // -----
 
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<2xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.3",.*]], i64, i64)
-func.func private @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm(memref<?x!sycl.range<3>>, i64, i64)
+func.func private @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm(memref<?x!sycl_range_3_>, i64, i64)
 
-func.func @range3Ctor2SizeT(%arg0: memref<?x!sycl.range<3>>, %arg1: i64, %arg2: i64) {
+func.func @range3Ctor2SizeT(%arg0: memref<?x!sycl_range_3_>, %arg1: i64, %arg2: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm({{.*}}, %arg5, %arg6) : ([[THIS_PTR_TYPE]], i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2) {MangledFunctionName = @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm, TypeName = @range} : (memref<?x!sycl.range<3>>, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2) {MangledFunctionName = @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEm, TypeName = @range} : (memref<?x!sycl_range_3_>, i64, i64) -> ()
   return
 }
 
@@ -317,34 +343,37 @@ func.func @range3Ctor2SizeT(%arg0: memref<?x!sycl.range<3>>, %arg1: i64, %arg2: 
 // Constructors for cl::sycl::range<n>::range<n>(std::enable_if<(n)==(n), unsigned long>::type, unsigned long, unsigned long)
 //===-------------------------------------------------------------------------------------------------===//
 
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.1",.*]], i64, i64, i64)
-func.func private @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm(memref<?x!sycl.range<1>>, i64, i64, i64)
+func.func private @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm(memref<?x!sycl_range_1_>, i64, i64, i64)
 
-func.func @range1Ctor3SizeT(%arg0: memref<?x!sycl.range<1>>, %arg1: i64, %arg2: i64, %arg3: i64) {
+func.func @range1Ctor3SizeT(%arg0: memref<?x!sycl_range_1_>, %arg1: i64, %arg2: i64, %arg3: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm({{.*}}, %arg5, %arg6, %arg7) : ([[THIS_PTR_TYPE]], i64, i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledFunctionName = @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm, TypeName = @range} : (memref<?x!sycl.range<1>>, i64, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledFunctionName = @_ZN2cl4sycl5rangeILi1EEC2ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeEmm, TypeName = @range} : (memref<?x!sycl_range_1_>, i64, i64, i64) -> ()
   return
 }
 
 // -----
 
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.2",.*]], i64, i64, i64)
-func.func private @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm(memref<?x!sycl.range<2>>, i64, i64, i64)
+func.func private @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm(memref<?x!sycl_range_2_>, i64, i64, i64)
 
-func.func @range2Ctor3SizeT(%arg0: memref<?x!sycl.range<2>>, %arg1: i64, %arg2: i64, %arg3: i64) {
+func.func @range2Ctor3SizeT(%arg0: memref<?x!sycl_range_2_>, %arg1: i64, %arg2: i64, %arg3: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm({{.*}}, %arg5, %arg6, %arg7) : ([[THIS_PTR_TYPE]], i64, i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledFunctionName = @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm, TypeName = @range} : (memref<?x!sycl.range<2>>, i64, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledFunctionName = @_ZN2cl4sycl5rangeILi2EEC2ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEmm, TypeName = @range} : (memref<?x!sycl_range_2_>, i64, i64, i64) -> ()
   return
 }
 
 // -----
 
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<2xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.3",.*]], i64, i64, i64)
-func.func private @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm(memref<?x!sycl.range<3>>, i64, i64, i64)
+func.func private @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm(memref<?x!sycl_range_3_>, i64, i64, i64)
 
-func.func @range3Ctor3SizeT(%arg0: memref<?x!sycl.range<3>>, %arg1: i64, %arg2: i64, %arg3: i64) {
+func.func @range3Ctor3SizeT(%arg0: memref<?x!sycl_range_3_>, %arg1: i64, %arg2: i64, %arg3: i64) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm({{.*}}, %arg5, %arg6, %arg7) : ([[THIS_PTR_TYPE]], i64, i64, i64) -> ()
-  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledFunctionName = @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm, TypeName = @range} : (memref<?x!sycl.range<3>>, i64, i64, i64) -> ()
+  sycl.constructor(%arg0, %arg1, %arg2, %arg3) {MangledFunctionName = @_ZN2cl4sycl5rangeILi3EEC2ILi3EEENSt9enable_ifIXeqT_Li3EEmE4typeEmm, TypeName = @range} : (memref<?x!sycl_range_3_>, i64, i64, i64) -> ()
   return
 }
 
@@ -354,33 +383,36 @@ func.func @range3Ctor3SizeT(%arg0: memref<?x!sycl.range<3>>, %arg1: i64, %arg2: 
 // Constructors sycl::range<n>::id(sycl::range<n> const&, sycl::range<n> const&)
 //===-------------------------------------------------------------------------------------------------===//
 
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl5rangeILi1EEC1ERKS2_([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.1",.*]], [[THIS_PTR_TYPE]])
-func.func private @_ZN2cl4sycl5rangeILi1EEC1ERKS2_(memref<?x!sycl.range<1>>, memref<?x!sycl.range<1>>)
+func.func private @_ZN2cl4sycl5rangeILi1EEC1ERKS2_(memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>)
 
-func.func @range1CopyCtor(%arg0: memref<?x!sycl.range<1>>, %arg1: memref<?x!sycl.range<1>>) {
+func.func @range1CopyCtor(%arg0: memref<?x!sycl_range_1_>, %arg1: memref<?x!sycl_range_1_>) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi1EEC1ERKS2_({{.*}}, {{.*}}) : ([[THIS_PTR_TYPE]], [[THIS_PTR_TYPE]]) -> ()
- "sycl.constructor"(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl5rangeILi1EEC1ERKS2_, TypeName = @range} : (memref<?x!sycl.range<1>>, memref<?x!sycl.range<1>>) -> ()
+ "sycl.constructor"(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl5rangeILi1EEC1ERKS2_, TypeName = @range} : (memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>) -> ()
   return
 }
 
 // -----
 
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl5rangeILi2EEC1ERKS2_([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.2",.*]], [[THIS_PTR_TYPE]])
-func.func private @_ZN2cl4sycl5rangeILi2EEC1ERKS2_(memref<?x!sycl.range<2>>, memref<?x!sycl.range<2>>)
+func.func private @_ZN2cl4sycl5rangeILi2EEC1ERKS2_(memref<?x!sycl_range_2_>, memref<?x!sycl_range_2_>)
 
-func.func @range2CopyCtor(%arg0: memref<?x!sycl.range<2>>, %arg1: memref<?x!sycl.range<2>>) {
+func.func @range2CopyCtor(%arg0: memref<?x!sycl_range_2_>, %arg1: memref<?x!sycl_range_2_>) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi2EEC1ERKS2_({{.*}}, {{.*}}) : ([[THIS_PTR_TYPE]], [[THIS_PTR_TYPE]]) -> ()
- "sycl.constructor"(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl5rangeILi2EEC1ERKS2_, TypeName = @range} : (memref<?x!sycl.range<2>>, memref<?x!sycl.range<2>>) -> ()
+ "sycl.constructor"(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl5rangeILi2EEC1ERKS2_, TypeName = @range} : (memref<?x!sycl_range_2_>, memref<?x!sycl_range_2_>) -> ()
   return
 }
 
 // -----
 
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<2xi64, 4>)>)>
 // CHECK: llvm.func @_ZN2cl4sycl5rangeILi3EEC1ERKS2_([[THIS_PTR_TYPE:!llvm.ptr<struct<"class.sycl::_V1::range.3",.*]], [[THIS_PTR_TYPE]])
-func.func private @_ZN2cl4sycl5rangeILi3EEC1ERKS2_(memref<?x!sycl.range<3>>, memref<?x!sycl.range<3>>)
+func.func private @_ZN2cl4sycl5rangeILi3EEC1ERKS2_(memref<?x!sycl_range_3_>, memref<?x!sycl_range_3_>)
 
-func.func @range3CopyCtor(%arg0: memref<?x!sycl.range<3>>, %arg1: memref<?x!sycl.range<3>>) {
+func.func @range3CopyCtor(%arg0: memref<?x!sycl_range_3_>, %arg1: memref<?x!sycl_range_3_>) {
   // CHECK: llvm.call @_ZN2cl4sycl5rangeILi3EEC1ERKS2_({{.*}}, {{.*}}) : ([[THIS_PTR_TYPE]], [[THIS_PTR_TYPE]]) -> ()
- "sycl.constructor"(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl5rangeILi3EEC1ERKS2_, TypeName = @range} : (memref<?x!sycl.range<3>>, memref<?x!sycl.range<3>>) -> ()
+ "sycl.constructor"(%arg0, %arg1) {MangledFunctionName = @_ZN2cl4sycl5rangeILi3EEC1ERKS2_, TypeName = @range} : (memref<?x!sycl_range_3_>, memref<?x!sycl_range_3_>) -> ()
   return
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
@@ -13,26 +13,33 @@ func.func @test_array.2(%arg0: !sycl_array_2_) {
 
 // -----
 
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 // CHECK: llvm.func @test_id(%arg0: !llvm.[[ID_1:struct<"class.sycl::_V1::id.*", \(]][[ARRAY_1]][[SUFFIX:\)>]], %arg1: !llvm.[[ID_1]][[ARRAY_1]][[SUFFIX]])
-func.func @test_id(%arg0: !sycl.id<1>, %arg1: !sycl.id<1>) {
+func.func @test_id(%arg0: !sycl_id_1_, %arg1: !sycl_id_1_) {
   return
 }
 
 // -----
 
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 // CHECK: llvm.func @test_range.1(%arg0: !llvm.[[RANGE_1:struct<"class.sycl::_V1::range.*", \(]][[ARRAY_1]][[SUFFIX]])
-func.func @test_range.1(%arg0: !sycl.range<1>) {
+func.func @test_range.1(%arg0: !sycl_range_1_) {
   return
 }
 // CHECK: llvm.func @test_range.2(%arg0: !llvm.[[RANGE_2:struct<"class.sycl::_V1::range.*", \(]][[ARRAY_2]][[SUFFIX]])
-func.func @test_range.2(%arg0: !sycl.range<2>) {
+func.func @test_range.2(%arg0: !sycl_range_2_) {
   return
 }
 
 // -----
 
-!sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>
-!sycl_nd_range_2_ = !sycl.nd_range<[2], (!sycl.range<2>, !sycl.range<2>, !sycl.id<2>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_nd_range_2_ = !sycl.nd_range<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
 // CHECK: llvm.func @test_nd_range.1(%arg0: !llvm.[[ND_RANGE_1:struct<"class.sycl::_V1::nd_range.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]]) {
 func.func @test_nd_range.1(%arg0: !sycl_nd_range_1_) {
   return
@@ -44,13 +51,17 @@ func.func @test_nd_range.2(%arg0: !sycl_nd_range_2_) {
 
 // -----
 
-!sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>
-!sycl_accessor_impl_device_2_ = !sycl.accessor_impl_device<[2], (!sycl.id<2>, !sycl.range<2>, !sycl.range<2>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
+!sycl_accessor_impl_device_2_ = !sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>
 !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
 !sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<i32, 1>)>)>
 !sycl_accessor_1_f32_rw_gb = !sycl.accessor<[1, f32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<f32, 1>)>)>
 !sycl_accessor_2_f32_rw_gb = !sycl.accessor<[2, f32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<f32, 1>)>)>
-!sycl_accessor_subscript_1_ = !sycl.accessor_subscript<[1], (!sycl.id<2>, !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<i32, 1>)>)>)>
+!sycl_accessor_subscript_1_ = !sycl.accessor_subscript<[1], (!sycl_id_2_, !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<i32, 1>)>)>)>
 // CHECK: llvm.func @test_accessorImplDevice(%arg0: !llvm.[[ACCESSORIMPLDEVICE_1:struct<"class.sycl::_V1::detail::AccessorImplDevice.*", \(]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
 func.func @test_accessorImplDevice(%arg0: !sycl_accessor_impl_device_1_) {
   return
@@ -82,11 +93,13 @@ func.func @test_accessorSubscript(%arg0: !sycl_accessor_subscript_1_) {
 
 // -----
 
-!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>
-!sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl.range<1>, !sycl.id<1>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
+!sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
 !sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
 !sycl_item_1_1 = !sycl.item<[1, false], (!sycl_item_base_1_1)>
-!sycl_group_1_ = !sycl.group<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 !sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1, !sycl_group_1_)>
 // CHECK: llvm.func @test_itemBase.true(%arg0: !llvm.[[ITEM_BASE_1_TRUE:struct<"struct.sycl::_V1::detail::ItemBase.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
 func.func @test_itemBase.true(%arg0: !sycl_item_base_1_) {

--- a/mlir-sycl/test/Dialect/IR/SYCL/constructor.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/constructor.mlir
@@ -2,14 +2,16 @@
 
 // Ensure sycl.id and sycl.range types can be arguments of sycl.constructor.
 // CHECK-LABEL: func.func @AccessorImplDevice
-func.func @AccessorImplDevice(%arg0: memref<?x!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>>, %arg1: !sycl.id<1>, %arg2: !sycl.range<1>) {
-  sycl.constructor(%arg0, %arg1, %arg2, %arg2) {MangledFunctionName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_, TypeName = @AccessorImplDevice} : (memref<?x!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>>, !sycl.id<1>, !sycl.range<1>, !sycl.range<1>) -> ()
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+func.func @AccessorImplDevice(%arg0: memref<?x!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>>, %arg1: !sycl_id_1_, %arg2: !sycl_range_1_) {
+  sycl.constructor(%arg0, %arg1, %arg2, %arg2) {MangledFunctionName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_, TypeName = @AccessorImplDevice} : (memref<?x!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>>, !sycl_id_1_, !sycl_range_1_, !sycl_range_1_) -> ()
   return
 }
 
 // Ensure integer pointer can be arguments of sycl.constructor.
 // CHECK-LABEL: func.func @TestConstructorII32Ptr
-func.func @TestConstructorII32Ptr(%arg0: memref<?x!sycl.id<1>, 4>, %arg1: memref<?xi32, 1>) {
-  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN4sycl3_V19multi_ptrIjLNS0_6access13address_spaceE1ELNS2_9decoratedE1EEC1EPU3AS1j, TypeName = @multi_ptr} : (memref<?x!sycl.id<1>, 4>, memref<?xi32, 1>) -> ()
+func.func @TestConstructorII32Ptr(%arg0: memref<?x!sycl_id_1_, 4>, %arg1: memref<?xi32, 1>) {
+  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN4sycl3_V19multi_ptrIjLNS0_6access13address_spaceE1ELNS2_9decoratedE1EEC1EPU3AS1j, TypeName = @multi_ptr} : (memref<?x!sycl_id_1_, 4>, memref<?xi32, 1>) -> ()
   return
 }

--- a/mlir-sycl/test/Dialect/IR/SYCL/types.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/types.mlir
@@ -8,12 +8,14 @@
 // ID
 ////////////////////////////////////////////////////////////////////////////////
 
-// CHECK: func @_Z4id_1N2cl4sycl2idILi1EEE(%arg0: !sycl.id<1>)
-func.func @_Z4id_1N2cl4sycl2idILi1EEE(%arg0: !sycl.id<1>) attributes {llvm.linkage = #llvm.linkage<external>} {
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+// CHECK: func @_Z4id_1N2cl4sycl2idILi1EEE(%arg0: !sycl_id_1_)
+func.func @_Z4id_1N2cl4sycl2idILi1EEE(%arg0: !sycl_id_1_) attributes {llvm.linkage = #llvm.linkage<external>} {
   return
 }
-// CHECK: func @_Z4id_2N2cl4sycl2idILi2EEE(%arg0: !sycl.id<2>)
-func.func @_Z4id_2N2cl4sycl2idILi2EEE(%arg0: !sycl.id<2>) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK: func @_Z4id_2N2cl4sycl2idILi2EEE(%arg0: !sycl_id_2_)
+func.func @_Z4id_2N2cl4sycl2idILi2EEE(%arg0: !sycl_id_2_) attributes {llvm.linkage = #llvm.linkage<external>} {
   return
 }
 
@@ -23,8 +25,12 @@ func.func @_Z4id_2N2cl4sycl2idILi2EEE(%arg0: !sycl.id<2>) attributes {llvm.linka
 // ACCESSOR
 ////////////////////////////////////////////////////////////////////////////////
 
-!sycl_accessor_1_i32_w_gb = !sycl.accessor<[1, i32, write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>
-!sycl_accessor_2_i32_r_gb = !sycl.accessor<[2, i32, read, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl.id<2>, !sycl.range<2>, !sycl.range<2>)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_accessor_1_i32_w_gb = !sycl.accessor<[1, i32, write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_2_i32_r_gb = !sycl.accessor<[2, i32, read, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>, !llvm.struct<(ptr<i32, 1>)>)>
 
 // CHECK: func @_Z5acc_1N2cl4sycl8accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl_accessor_1_i32_w_gb)
 func.func @_Z5acc_1N2cl4sycl8accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl_accessor_1_i32_w_gb) attributes {llvm.linkage = #llvm.linkage<external>} {
@@ -41,12 +47,14 @@ func.func @_Z5acc_2N2cl4sycl8accessorIiLi2ELNS0_6access4modeE1024ELNS2_6targetE2
 // RANGE
 ////////////////////////////////////////////////////////////////////////////////
 
-// CHECK: func @_Z7range_1N2cl4sycl5rangeILi1EEE(%arg0: !sycl.range<1>)
-func.func @_Z7range_1N2cl4sycl5rangeILi1EEE(%arg0: !sycl.range<1>) attributes {llvm.linkage = #llvm.linkage<external>} {
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+// CHECK: func @_Z7range_1N2cl4sycl5rangeILi1EEE(%arg0: !sycl_range_1_)
+func.func @_Z7range_1N2cl4sycl5rangeILi1EEE(%arg0: !sycl_range_1_) attributes {llvm.linkage = #llvm.linkage<external>} {
   return
 }
-// CHECK: func @_Z7range_2N2cl4sycl5rangeILi2EEE(%arg0: !sycl.range<2>)
-func.func @_Z7range_2N2cl4sycl5rangeILi2EEE(%arg0: !sycl.range<2>) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK: func @_Z7range_2N2cl4sycl5rangeILi2EEE(%arg0: !sycl_range_2_)
+func.func @_Z7range_2N2cl4sycl5rangeILi2EEE(%arg0: !sycl_range_2_) attributes {llvm.linkage = #llvm.linkage<external>} {
   return
 }
 
@@ -56,15 +64,19 @@ func.func @_Z7range_2N2cl4sycl5rangeILi2EEE(%arg0: !sycl.range<2>) attributes {l
 // ND_RANGE
 ////////////////////////////////////////////////////////////////////////////////
 
-!sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>
-!sycl_nd_range_2_ = !sycl.nd_range<[2], (!sycl.range<2>, !sycl.range<2>, !sycl.id<2>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_nd_range_2_ = !sycl.nd_range<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
 
 // CHECK: func @_Z10nd_range_1N4sycl3_V18nd_rangeILi1EEE(%arg0: !sycl_nd_range_1_)
-func.func @_Z10nd_range_1N4sycl3_V18nd_rangeILi1EEE(%arg0: !sycl.nd_range<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>) attributes {llvm.linkage = #llvm.linkage<external>} {
+func.func @_Z10nd_range_1N4sycl3_V18nd_rangeILi1EEE(%arg0: !sycl.nd_range<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>) attributes {llvm.linkage = #llvm.linkage<external>} {
   return
 }
 // CHECK: func @_Z10nd_range_2N4sycl3_V18nd_rangeILi2EEE(%arg0: !sycl_nd_range_2_)
-func.func @_Z10nd_range_2N4sycl3_V18nd_rangeILi2EEE(%arg0: !sycl.nd_range<[2], (!sycl.range<2>, !sycl.range<2>, !sycl.id<2>)>) attributes {llvm.linkage = #llvm.linkage<external>} {
+func.func @_Z10nd_range_2N4sycl3_V18nd_rangeILi2EEE(%arg0: !sycl.nd_range<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>) attributes {llvm.linkage = #llvm.linkage<external>} {
   return
 }
 
@@ -92,8 +104,12 @@ func.func @_Z5arr_2N2cl4sycl6detail5arrayILi2EEE(%arg0: !sycl.array<[2], (memref
 // ITEM
 ////////////////////////////////////////////////////////////////////////////////
 
-!sycl_item_1_ = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>
-!sycl_item_2_ = !sycl.item<[2, false], (!sycl.item_base<[2, false], (!sycl.range<2>, !sycl.id<2>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>)>
+!sycl_item_2_ = !sycl.item<[2, false], (!sycl.item_base<[2, false], (!sycl_range_2_, !sycl_id_2_)>)>
 
 // CHECK: func @_Z11item_1_trueN2cl4sycl4itemILi1ELb1EEE(%arg0: !sycl_item_1_)
 func.func @_Z11item_1_trueN2cl4sycl4itemILi1ELb1EEE(%arg0: !sycl_item_1_) attributes {llvm.linkage = #llvm.linkage<external>} {
@@ -110,8 +126,12 @@ func.func @_Z12item_2_falseN2cl4sycl4itemILi2ELb0EEE(%arg0: !sycl_item_2_) attri
 // ND_ITEM 
 ////////////////////////////////////////////////////////////////////////////////
 
-!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>, !sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl.range<1>, !sycl.id<1>)>)>, !sycl.group<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>)>
-!sycl_nd_item_2_ = !sycl.nd_item<[2], (!sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>)>, !sycl.item<[2, false], (!sycl.item_base<[2, false], (!sycl.range<2>, !sycl.id<2>)>)>, !sycl.group<[2], (!sycl.range<2>, !sycl.range<2>, !sycl.range<2>, !sycl.id<2>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>)>, !sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>)>, !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>)>
+!sycl_nd_item_2_ = !sycl.nd_item<[2], (!sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl_range_2_, !sycl_id_2_, !sycl_id_2_)>)>, !sycl.item<[2, false], (!sycl.item_base<[2, false], (!sycl_range_2_, !sycl_id_2_)>)>, !sycl.group<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>)>
 
 // CHECK: func @_Z9nd_item_1N2cl4sycl7nd_itemILi1EEE(%arg0: !sycl_nd_item_1_)
 func.func @_Z9nd_item_1N2cl4sycl7nd_itemILi1EEE(%arg0: !sycl_nd_item_1_) attributes {llvm.linkage = #llvm.linkage<external>} {
@@ -128,8 +148,12 @@ func.func @_Z9nd_item_2N2cl4sycl7nd_itemILi2EEE(%arg0: !sycl_nd_item_2_) attribu
 // GROUP
 ////////////////////////////////////////////////////////////////////////////////
 
-!sycl_group_1_ = !sycl.group<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>
-!sycl_group_2_ = !sycl.group<[2], (!sycl.range<2>, !sycl.range<2>, !sycl.range<2>, !sycl.id<2>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_group_2_ = !sycl.group<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
 
 // CHECK: func @_Z7group_1N2cl4sycl5groupILi1EEE(%arg0: !sycl_group_1_)
 func.func @_Z7group_1N2cl4sycl5groupILi1EEE(%arg0: !sycl_group_1_) attributes {llvm.linkage = #llvm.linkage<external>} {

--- a/mlir-sycl/test/Transforms/sycl-method-to-sycl-call.mlir
+++ b/mlir-sycl/test/Transforms/sycl-method-to-sycl-call.mlir
@@ -1,38 +1,42 @@
 // RUN: sycl-mlir-opt -sycl-method-to-sycl-call -split-input-file -verify-diagnostics %s | FileCheck %s
 
-!sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl.id<2>, !sycl.range<2>, !sycl.range<2>)>, !llvm.struct<(ptr<i32, 1>)>)>
 !sycl_array_2_ = !sycl.array<[2], (memref<2xi64, 4>)>
-!sycl_item_1_ = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl_array_2_)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl_array_2_)>
+!sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>)>
 
-// CHECK-LABEL: func.func @accessor_subscript_operator(%arg0: memref<?x!sycl_accessor_2_i32_rw_gb, 4>, %arg1: memref<?x!sycl.id<2>>) -> memref<?xi32, 4> {
-// CHECK-NEXT: %0 = sycl.call(%arg0, %arg1) {FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl.id<2>>) -> memref<?xi32, 4>
+// CHECK-LABEL: func.func @accessor_subscript_operator(%arg0: memref<?x!sycl_accessor_2_i32_rw_gb, 4>, %arg1: memref<?x!sycl_id_2_>) -> memref<?xi32, 4> {
+// CHECK-NEXT: %0 = sycl.call(%arg0, %arg1) {FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
 
-func.func @accessor_subscript_operator(%arg0: memref<?x!sycl_accessor_2_i32_rw_gb, 4>, %arg1: memref<?x!sycl.id<2>>) -> memref<?xi32, 4> {
-  %0 = sycl.accessor.subscript %arg0[%arg1] {BaseType = memref<?x!sycl_accessor_2_i32_rw_gb, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl.id<2>>) -> memref<?xi32, 4>
+func.func @accessor_subscript_operator(%arg0: memref<?x!sycl_accessor_2_i32_rw_gb, 4>, %arg1: memref<?x!sycl_id_2_>) -> memref<?xi32, 4> {
+  %0 = sycl.accessor.subscript %arg0[%arg1] {BaseType = memref<?x!sycl_accessor_2_i32_rw_gb, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
   return %0 : memref<?xi32, 4>
 }
 
-// CHECK-LABEL: func.func @range_get(%arg0: memref<?x!sycl.range<2>, 4>, %arg1: i32) -> i64 {
-// CHECK-NEXT: %0 = sycl.cast(%arg0) : (memref<?x!sycl.range<2>, 4>) -> memref<?x!sycl_array_2_, 4>
+// CHECK-LABEL: func.func @range_get(%arg0: memref<?x!sycl_range_2_, 4>, %arg1: i32) -> i64 {
+// CHECK-NEXT: %0 = sycl.cast(%arg0) : (memref<?x!sycl_range_2_, 4>) -> memref<?x!sycl_array_2_, 4>
 // CHECK-NEXT: %1 = sycl.call(%0, %arg1) {FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_array_2_, 4>, i32) -> i64
 
-func.func @range_get(%arg0: memref<?x!sycl.range<2>, 4>, %arg1: i32) -> i64 {
-  %0 = "sycl.range.get"(%arg0, %arg1) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl.range<2>, 4>, i32) -> i64
+func.func @range_get(%arg0: memref<?x!sycl_range_2_, 4>, %arg1: i32) -> i64 {
+  %0 = "sycl.range.get"(%arg0, %arg1) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> i64
   return %0 : i64
 }
 
-// CHECK-LABEL: func.func @range_size(%arg0: memref<?x!sycl.range<2>, 4>) -> i64 {
-// CHECK-NEXT: %0 = sycl.call(%arg0) {FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl.range<2>, 4>) -> i64
+// CHECK-LABEL: func.func @range_size(%arg0: memref<?x!sycl_range_2_, 4>) -> i64 {
+// CHECK-NEXT: %0 = sycl.call(%arg0) {FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl_range_2_, 4>) -> i64
 
-func.func @range_size(%arg0: memref<?x!sycl.range<2>, 4>) -> i64 {
-  %0 = "sycl.range.size"(%arg0) {BaseType = memref<?x!sycl.range<2>, 4>, FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl.range<2>, 4>) -> i64
+func.func @range_size(%arg0: memref<?x!sycl_range_2_, 4>) -> i64 {
+  %0 = "sycl.range.size"(%arg0) {BaseType = memref<?x!sycl_range_2_, 4>, FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl_range_2_, 4>) -> i64
   return %0 : i64
 }
 
-// CHECK-LABEL: func.func @sycl_item_get_id(%arg0: memref<?x!sycl_item_1_, 4>) -> !sycl.id<1> {
-// CHECK-NEXT: %0 = sycl.call(%arg0) {FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x!sycl_item_1_, 4>) -> !sycl.id<1>
+// CHECK-LABEL: func.func @sycl_item_get_id(%arg0: memref<?x!sycl_item_1_, 4>) -> !sycl_id_1_ {
+// CHECK-NEXT: %0 = sycl.call(%arg0) {FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x!sycl_item_1_, 4>) -> !sycl_id_1_
 
-func.func @sycl_item_get_id(%arg0: memref<?x!sycl_item_1_, 4>) -> !sycl.id<1> {
-  %0 = "sycl.item.get_id"(%arg0) {BaseType = memref<?x!sycl_item_1_, 4>, FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x!sycl_item_1_, 4>) -> !sycl.id<1>
-  return %0 : !sycl.id<1>
+func.func @sycl_item_get_id(%arg0: memref<?x!sycl_item_1_, 4>) -> !sycl_id_1_ {
+  %0 = "sycl.item.get_id"(%arg0) {BaseType = memref<?x!sycl_item_1_, 4>, FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x!sycl_item_1_, 4>) -> !sycl_id_1_
+  return %0 : !sycl_id_1_
 }

--- a/polygeist/test/polygeist-opt/sycl/convertToLLVMABI.mlir
+++ b/polygeist/test/polygeist-opt/sycl/convertToLLVMABI.mlir
@@ -1,13 +1,15 @@
 // RUN: polygeist-opt --convert-to-llvm-abi --split-input-file %s | FileCheck %s
 
-// CHECK: gpu.func @kernel([[A0:%.*]]: !llvm.ptr<i32, 1>, %arg1: !sycl.range<1>, %arg2: !sycl.range<1>, %arg3: !sycl.id<1>)
+// CHECK: gpu.func @kernel([[A0:%.*]]: !llvm.ptr<i32, 1>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_)
 // CHECK-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
 // CHECK-NEXT:      [[P2M:%.*]] = "polygeist.pointer2memref"([[A0]]) : (!llvm.ptr<i32, 1>) -> memref<?xi32, 1>
 // CHECK-NEXT:      [[M2P:%.*]] = "polygeist.memref2pointer"([[P2M]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
 // CHECK-NEXT:      sycl.call([[M2P]]) {FunctionName = @foo, MangledFunctionName = @foo} : (!llvm.ptr<i32, 1>) -> ()
 
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 gpu.module @module {
-gpu.func @kernel(%arg0: memref<?xi32, 1>, %arg1: !sycl.range<1>, %arg2: !sycl.range<1>, %arg3: !sycl.id<1>) kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
+gpu.func @kernel(%arg0: memref<?xi32, 1>, %arg1: !sycl_range_1_, %arg2: !sycl_range_1_, %arg3: !sycl_id_1_) kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, passthrough = ["norecurse", "nounwind", "convergent", "mustprogress"]} {
   sycl.call(%arg0) {FunctionName = @foo, MangledFunctionName = @foo} : (memref<?xi32, 1>) -> ()
   gpu.return
 }
@@ -53,15 +55,16 @@ func.func private @callee(%arg0: memref<?xi32, 1>) -> memref<?xi32, 1>
 
 // -----
 
-// CHECK: func.func @constructor_caller([[A0:%.*]]: !llvm.ptr<!sycl.id<1>, 1>) {
-// CHECK-NEXT:    [[P2M:%.*]] = "polygeist.pointer2memref"([[A0]]) : (!llvm.ptr<!sycl.id<1>, 1>) -> memref<?x!sycl.id<1>, 1>
-// CHECK-NEXT:    [[M2P:%.*]] = "polygeist.memref2pointer"([[P2M]]) : (memref<?x!sycl.id<1>, 1>) -> !llvm.ptr<!sycl.id<1>, 1>
-// CHECK-NEXT:    call @constructor([[M2P]]) : (!llvm.ptr<!sycl.id<1>, 1>) -> ()
+// CHECK: func.func @constructor_caller([[A0:%.*]]: !llvm.ptr<!sycl_id_1_, 1>) {
+// CHECK-NEXT:    [[P2M:%.*]] = "polygeist.pointer2memref"([[A0]]) : (!llvm.ptr<!sycl_id_1_, 1>) -> memref<?x!sycl_id_1_, 1>
+// CHECK-NEXT:    [[M2P:%.*]] = "polygeist.memref2pointer"([[P2M]]) : (memref<?x!sycl_id_1_, 1>) -> !llvm.ptr<!sycl_id_1_, 1>
+// CHECK-NEXT:    call @constructor([[M2P]]) : (!llvm.ptr<!sycl_id_1_, 1>) -> ()
 
-func.func @constructor_caller(%arg0: memref<?x!sycl.id<1>, 1>) {
-  sycl.constructor(%arg0) {MangledFunctionName = @constructor, TypeName = @foo} : (memref<?x!sycl.id<1>, 1>) -> ()
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+func.func @constructor_caller(%arg0: memref<?x!sycl_id_1_, 1>) {
+  sycl.constructor(%arg0) {MangledFunctionName = @constructor, TypeName = @foo} : (memref<?x!sycl_id_1_, 1>) -> ()
   func.return
 }
 
-// CHECK: func.func private @constructor(!llvm.ptr<!sycl.id<1>, 1>)
-func.func private @constructor(%arg0: memref<?x!sycl.id<1>, 1>)
+// CHECK: func.func private @constructor(!llvm.ptr<!sycl_id_1_, 1>)
+func.func private @constructor(%arg0: memref<?x!sycl_id_1_, 1>)

--- a/polygeist/test/polygeist-opt/sycl/subindex.mlir
+++ b/polygeist/test/polygeist-opt/sycl/subindex.mlir
@@ -6,10 +6,11 @@
 // CHECK: [[MEMREF:%.*]] = llvm.mlir.undef : !llvm.struct<(ptr<[[SYCLIDSTRUCT]], {{.*}}
 // CHECK: %{{.*}} = llvm.insertvalue [[GEP]], [[MEMREF]][0] : !llvm.struct<(ptr<[[SYCLIDSTRUCT]], {{.*}}
 
-func.func @test_1(%arg0: memref<?x!llvm.struct<(!sycl.id<1>)>>) -> memref<?x!sycl.id<1>> {
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+func.func @test_1(%arg0: memref<?x!llvm.struct<(!sycl_id_1_)>>) -> memref<?x!sycl_id_1_> {
   %c0 = arith.constant 0 : index
-  %0 = "polygeist.subindex"(%arg0, %c0) : (memref<?x!llvm.struct<(!sycl.id<1>)>>, index) -> memref<?x!sycl.id<1>>
-  return %0 : memref<?x!sycl.id<1>>
+  %0 = "polygeist.subindex"(%arg0, %c0) : (memref<?x!llvm.struct<(!sycl_id_1_)>>, index) -> memref<?x!sycl_id_1_>
+  return %0 : memref<?x!sycl_id_1_>
 }
 
 // -----
@@ -17,8 +18,10 @@ func.func @test_1(%arg0: memref<?x!llvm.struct<(!sycl.id<1>)>>) -> memref<?x!syc
 // CHECK-LABEL: @test_2
 // CHECK: llvm.return %{{.*}} : !llvm.struct<(ptr<struct<"class.sycl::_V1::detail::AccessorImplDevice 
 
-!sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>
-!sycl_accessor_1_ = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
+!sycl_accessor_1_ = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
 
 func.func @test_2(%arg0: memref<?x!sycl_accessor_1_>) -> memref<?x!sycl_accessor_impl_device_1_> {
   %c0 = arith.constant 0 : index
@@ -62,9 +65,10 @@ func.func @test_3(%arg0: memref<?x!llvm.struct<(i32)>>) -> memref<?xi32> {
 // CHECK: [[MEMREF1:%.*]] = llvm.insertvalue {{.*}}, [[MEMREF]][0] : !llvm.struct<(ptr<struct<([[IDTYPE]])>>, ptr<struct<([[IDTYPE]])>>, i64, array<1 x i64>, array<1 x i64>)>
 // CHECK: %{{.*}} = llvm.insertvalue [[GEP]], [[MEMREF1]][1] : !llvm.struct<(ptr<struct<([[IDTYPE]])>>, ptr<struct<([[IDTYPE]])>>, i64, array<1 x i64>, array<1 x i64>)>
 
-func.func @test_4(%arg0: memref<1x!llvm.struct<(!sycl.id<1>)>>, %arg1: index) -> memref<?x!llvm.struct<(!sycl.id<1>)>> {
-  %0 = "polygeist.subindex"(%arg0, %arg1) : (memref<1x!llvm.struct<(!sycl.id<1>)>>, index) -> memref<?x!llvm.struct<(!sycl.id<1>)>>
-  return %0 : memref<?x!llvm.struct<(!sycl.id<1>)>>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+func.func @test_4(%arg0: memref<1x!llvm.struct<(!sycl_id_1_)>>, %arg1: index) -> memref<?x!llvm.struct<(!sycl_id_1_)>> {
+  %0 = "polygeist.subindex"(%arg0, %arg1) : (memref<1x!llvm.struct<(!sycl_id_1_)>>, index) -> memref<?x!llvm.struct<(!sycl_id_1_)>>
+  return %0 : memref<?x!llvm.struct<(!sycl_id_1_)>>
 }
 
 // -----
@@ -80,6 +84,8 @@ func.func @test_4(%arg0: memref<1x!llvm.struct<(!sycl.id<1>)>>, %arg1: index) ->
 // CHECK-DAG: [[ZERO2:%.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-DAG: [[AlignedPtr:%.*]] = llvm.extractvalue %5[1] : !llvm.struct<(ptr<[[ARRTYPE]], 4>, ptr<[[ARRTYPE]], 4>, i64, array<1 x i64>, array<1 x i64>)>
 // CHECK: [[GEP:%.*]] = llvm.getelementptr [[AlignedPtr]][[[ZERO2]], 0, [[ZERO1]]] : (!llvm.ptr<[[ARRTYPE]], 4>, i64, i64) -> !llvm.ptr<i64, 4>
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 func.func @test_5(%arg0: memref<?x!sycl.array<[1], (memref<1xi64, 4>)>, 4>) -> memref<1xi64, 4> {
   %c0 = arith.constant 0 : index
   %0 = "polygeist.subindex"(%arg0, %c0) : (memref<?x!sycl.array<[1], (memref<1xi64, 4>)>, 4>, index) -> memref<1xi64, 4>

--- a/polygeist/tools/cgeist/Lib/TypeUtils.cc
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.cc
@@ -112,7 +112,9 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
     if (CTS->getName() == "range") {
       const auto Dim =
           CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
-      return mlir::sycl::RangeType::get(CGT.getModule()->getContext(), Dim);
+      Body.push_back(CGT.getMLIRType(CTS->bases_begin()->getType()));
+      return mlir::sycl::RangeType::get(CGT.getModule()->getContext(), Dim,
+                                        Body);
     }
     if (CTS->getName() == "nd_range") {
       const auto Dim =
@@ -129,7 +131,8 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
     if (CTS->getName() == "id") {
       const auto Dim =
           CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
-      return mlir::sycl::IDType::get(CGT.getModule()->getContext(), Dim);
+      Body.push_back(CGT.getMLIRType(CTS->bases_begin()->getType()));
+      return mlir::sycl::IDType::get(CGT.getModule()->getContext(), Dim, Body);
     }
     if (CTS->getName() == "accessor_common")
       return mlir::sycl::AccessorCommonType::get(CGT.getModule()->getContext());

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -4,11 +4,14 @@
 #include <sycl/aliases.hpp>
 #include <sycl/sycl.hpp>
 
-// CHECK-DAG: !sycl_accessor_1_i32_w_gb = !sycl.accessor<[1, i32, write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
-// CHECK-DAG: !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>
 // CHECK-DAG: !sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
 // CHECK-DAG: !sycl_array_2_ = !sycl.array<[2], (memref<2xi64, 4>)>
-// CHECK-DAG: ![[ITEM_BASE:.*]] = !sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>
+// CHECK-DAG: !sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
+// CHECK-DAG: !sycl_id_2_ = !sycl.id<[2], (!sycl_array_2_)>
+// CHECK-DAG: !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
+// CHECK-DAG: !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
+// CHECK-DAG: !sycl_accessor_1_i32_w_gb = !sycl.accessor<[1, i32, write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+// CHECK-DAG: ![[ITEM_BASE:.*]] = !sycl.item_base<[2, true], (!sycl.range<[2], (!sycl_array_2_)>, !sycl_id_2_, !sycl_id_2_)>
 // CHECK-DAG: ![[ITEM:.*]] = !sycl.item<[2, true], (![[ITEM_BASE]])>
 
 // Check globals referenced in device functions are created in the GPU module
@@ -68,16 +71,16 @@
 
 // Ensure the constructors are NOT filtered out, and sycl.cast is generated for cast from sycl.id or sycl.range to sycl.array.
 // CHECK-LABEL: func.func @_ZN4sycl3_V12idILi1EEC1ERKS2_
-// CHECK:          (%arg0: memref<?x!sycl.id<1>, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 8 : i64, llvm.noundef}, 
-// CHECK-SAME:      %arg1: memref<?x!sycl.id<1>, 4> {llvm.align = 8 : i64, llvm.dereferenceable = 8 : i64, llvm.noundef})
+// CHECK:          (%arg0: memref<?x!sycl_id_1_, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 8 : i64, llvm.noundef}, 
+// CHECK-SAME:      %arg1: memref<?x!sycl_id_1_, 4> {llvm.align = 8 : i64, llvm.dereferenceable = 8 : i64, llvm.noundef})
 // CHECK-SAME:      attributes {[[SPIR_FUNCCC:llvm.cconv = #llvm.cconv<spir_funccc>]], [[LINKONCE:llvm.linkage = #llvm.linkage<linkonce_odr>]] 
-// CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl.id<1>, 4>) -> memref<?x!sycl_array_1_, 4>
+// CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl_id_1_, 4>) -> memref<?x!sycl_array_1_, 4>
 //
 // CHECK-LABEL: func.func @_ZN4sycl3_V15rangeILi1EEC1ERKS2_
-// CHECK:          (%arg0: memref<?x!sycl.range<1>, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 8 : i64, llvm.noundef}, 
-// CHECK-SAME:      %arg1: memref<?x!sycl.range<1>, 4> {llvm.align = 8 : i64, llvm.dereferenceable = 8 : i64, llvm.noundef})
+// CHECK:          (%arg0: memref<?x!sycl_range_1_, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 8 : i64, llvm.noundef}, 
+// CHECK-SAME:      %arg1: memref<?x!sycl_range_1_, 4> {llvm.align = 8 : i64, llvm.dereferenceable = 8 : i64, llvm.noundef})
 // CHECK-SAME:     attributes {[[SPIR_FUNCCC]], [[LINKONCE]], {{.*}}}
-// CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl.range<1>, 4>) -> memref<?x!sycl_array_1_, 4>
+// CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl_range_1_, 4>) -> memref<?x!sycl_array_1_, 4>
 
 // CHECK-LLVM: define spir_func void @cons_0([[ID_TYPE:%"class.sycl::_V1::id.1"]]* noundef byval(%"class.sycl::_V1::id.1") align 8 [[ARG0:%.*]], 
 // CHECK-LLVM-SAME:                          [[RANGE_TYPE:%"class.sycl::_V1::range.1"]]* noundef byval(%"class.sycl::_V1::range.1") align 8 [[ARG1:%.*]]) #[[FUNCATTRS:[0-9]+]]
@@ -97,15 +100,15 @@ extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXTERNAL:llvm.linkage = #llvm.linkage<external>]], {{.*}}} {
 // CHECK-NEXT: %false = arith.constant false
 // CHECK-NEXT: %c0_i8 = arith.constant 0 : i8
-// CHECK-NEXT: %alloca = memref.alloca() : memref<1x!sycl.id<2>>
-// CHECK-NEXT: %0 = "polygeist.memref2pointer"(%alloca) : (memref<1x!sycl.id<2>>) -> !llvm.ptr<i8>
-// CHECK-NEXT: %1 = "polygeist.typeSize"() {source = !sycl.id<2>} : () -> index
+// CHECK-NEXT: %alloca = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %0 = "polygeist.memref2pointer"(%alloca) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<i8>
+// CHECK-NEXT: %1 = "polygeist.typeSize"() {source = !sycl_id_2_} : () -> index
 // CHECK-NEXT: %2 = arith.index_cast %1 : index to i64
 // CHECK-NEXT: "llvm.intr.memset"(%0, %c0_i8, %2, %false) : (!llvm.ptr<i8>, i8, i64, i1) -> ()
-// CHECK-NEXT: %3 = "polygeist.memref2pointer"(%alloca) : (memref<1x!sycl.id<2>>) -> !llvm.ptr<!sycl.id<2>>
-// CHECK-NEXT: %4 = llvm.addrspacecast %3 : !llvm.ptr<!sycl.id<2>> to !llvm.ptr<!sycl.id<2>, 4>
-// CHECK-NEXT: %5 = "polygeist.pointer2memref"(%4) : (!llvm.ptr<!sycl.id<2>, 4>) -> memref<?x!sycl.id<2>, 4>
-// CHECK-NEXT: sycl.constructor(%5) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1Ev, TypeName = @id} : (memref<?x!sycl.id<2>, 4>) -> ()
+// CHECK-NEXT: %3 = "polygeist.memref2pointer"(%alloca) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
+// CHECK-NEXT: %4 = llvm.addrspacecast %3 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
+// CHECK-NEXT: %5 = "polygeist.pointer2memref"(%4) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
+// CHECK-NEXT: sycl.constructor(%5) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1Ev, TypeName = @id} : (memref<?x!sycl_id_2_, 4>) -> ()
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_1()
 // CHECK-LLVM-SAME:  #[[FUNCATTRS]]
@@ -121,11 +124,11 @@ extern "C" SYCL_EXTERNAL void cons_1() {
 
 // CHECK-LABEL: func.func @cons_2(%arg0: i64 {llvm.noundef}, %arg1: i64 {llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXTERNAL]], {{.*}}}
-// CHECK-NEXT: %alloca = memref.alloca() : memref<1x!sycl.id<2>>
-// CHECK-NEXT: %0 = "polygeist.memref2pointer"(%alloca) : (memref<1x!sycl.id<2>>) -> !llvm.ptr<!sycl.id<2>>
-// CHECK-NEXT: %1 = llvm.addrspacecast %0 : !llvm.ptr<!sycl.id<2>> to !llvm.ptr<!sycl.id<2>, 4>
-// CHECK-NEXT: %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<!sycl.id<2>, 4>) -> memref<?x!sycl.id<2>, 4>
-// CHECK-NEXT: sycl.constructor(%2, %arg0, %arg1) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, TypeName = @id} : (memref<?x!sycl.id<2>, 4>, i64, i64) -> ()
+// CHECK-NEXT: %alloca = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %0 = "polygeist.memref2pointer"(%alloca) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
+// CHECK-NEXT: %1 = llvm.addrspacecast %0 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
+// CHECK-NEXT: %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
+// CHECK-NEXT: sycl.constructor(%2, %arg0, %arg1) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm, TypeName = @id} : (memref<?x!sycl_id_2_, 4>, i64, i64) -> ()
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_2(i64 noundef %0, i64 noundef %1)
 // CHECK-LLVM-SAME:  #[[FUNCATTRS]]
@@ -140,14 +143,14 @@ extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
 // CHECK-LABEL: func.func @cons_3(
 // CHECK-SAME:                    %arg0: memref<?x![[ITEM]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM]], llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXTERNAL]], {{.*}}}
-// CHECK-NEXT: %alloca = memref.alloca() : memref<1x!sycl.id<2>>
-// CHECK-NEXT: %0 = "polygeist.memref2pointer"(%alloca) : (memref<1x!sycl.id<2>>) -> !llvm.ptr<!sycl.id<2>>
-// CHECK-NEXT: %1 = llvm.addrspacecast %0 : !llvm.ptr<!sycl.id<2>> to !llvm.ptr<!sycl.id<2>, 4>
-// CHECK-NEXT: %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<!sycl.id<2>, 4>) -> memref<?x!sycl.id<2>, 4>
+// CHECK-NEXT: %alloca = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %0 = "polygeist.memref2pointer"(%alloca) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
+// CHECK-NEXT: %1 = llvm.addrspacecast %0 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
+// CHECK-NEXT: %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
 // CHECK-NEXT: %3 = "polygeist.memref2pointer"(%arg0) : (memref<?x![[ITEM]]>) -> !llvm.ptr<![[ITEM]]>
 // CHECK-NEXT: %4 = llvm.addrspacecast %3 : !llvm.ptr<![[ITEM]]> to !llvm.ptr<![[ITEM]], 4>
 // CHECK-NEXT: %5 = "polygeist.pointer2memref"(%4) : (!llvm.ptr<![[ITEM]], 4>) -> memref<?x![[ITEM]], 4>
-// CHECK-NEXT: sycl.constructor(%2, %5) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE, TypeName = @id} : (memref<?x!sycl.id<2>, 4>, memref<?x![[ITEM]], 4>) -> ()
+// CHECK-NEXT: sycl.constructor(%2, %5) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE, TypeName = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x![[ITEM]], 4>) -> ()
 
 // CHECK-LLVM: define spir_func void @cons_3([[ITEM_TYPE:%"class.sycl::_V1::item.2.true"]]* noundef byval(%"class.sycl::_V1::item.2.true") align 8 [[ARG0:%.*]]) #[[FUNCATTRS]]
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE:%"class.sycl::_V1::id.2"]]  
@@ -159,16 +162,16 @@ extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
   auto id = sycl::id<2>{val};
 }
 
-// CHECK-LABEL: func.func @cons_4(%arg0: memref<?x!sycl.id<2>> {llvm.align = 8 : i64, llvm.byval = !sycl.id<2>, llvm.noundef})
+// CHECK-LABEL: func.func @cons_4(%arg0: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXTERNAL]], {{.*}}}
-// CHECK-NEXT: %alloca = memref.alloca() : memref<1x!sycl.id<2>>
-// CHECK-NEXT: %0 = "polygeist.memref2pointer"(%alloca) : (memref<1x!sycl.id<2>>) -> !llvm.ptr<!sycl.id<2>>
-// CHECK-NEXT: %1 = llvm.addrspacecast %0 : !llvm.ptr<!sycl.id<2>> to !llvm.ptr<!sycl.id<2>, 4>
-// CHECK-NEXT: %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<!sycl.id<2>, 4>) -> memref<?x!sycl.id<2>, 4>
-// CHECK-NEXT: %3 = "polygeist.memref2pointer"(%arg0) : (memref<?x!sycl.id<2>>) -> !llvm.ptr<!sycl.id<2>>
-// CHECK-NEXT: %4 = llvm.addrspacecast %3 : !llvm.ptr<!sycl.id<2>> to !llvm.ptr<!sycl.id<2>, 4>
-// CHECK-NEXT: %5 = "polygeist.pointer2memref"(%4) : (!llvm.ptr<!sycl.id<2>, 4>) -> memref<?x!sycl.id<2>, 4>
-// CHECK-NEXT: sycl.constructor(%2, %5) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ERKS2_, TypeName = @id} : (memref<?x!sycl.id<2>, 4>, memref<?x!sycl.id<2>, 4>) -> ()
+// CHECK-NEXT: %alloca = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT: %0 = "polygeist.memref2pointer"(%alloca) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
+// CHECK-NEXT: %1 = llvm.addrspacecast %0 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
+// CHECK-NEXT: %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
+// CHECK-NEXT: %3 = "polygeist.memref2pointer"(%arg0) : (memref<?x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
+// CHECK-NEXT: %4 = llvm.addrspacecast %3 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
+// CHECK-NEXT: %5 = "polygeist.pointer2memref"(%4) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
+// CHECK-NEXT: sycl.constructor(%2, %5) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ERKS2_, TypeName = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> ()
 
 // CHECK-LLVM: define spir_func void @cons_4([[ID_TYPE:%"class.sycl::_V1::id.2"]]*  noundef byval(%"class.sycl::_V1::id.2") align 8 [[ARG0:%.*]]) #[[FUNCATTRS]]
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE]]
@@ -183,7 +186,7 @@ extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
 // CHECK-LABEL: func.func @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(
 // CHECK-SAME: {{.*}}) attributes {[[SPIR_FUNCCC]], [[LINKONCE]], {{.*}}}
 // CHECK: [[I:%.*]] = "polygeist.subindex"(%arg0, %c0) : (memref<?x!sycl_accessor_1_i32_w_gb, 4>, index) -> memref<?x!sycl_accessor_impl_device_1_, 4>
-// CHECK: sycl.constructor([[I]], {{%.*}}, {{%.*}}, {{%.*}}) {MangledFunctionName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_, TypeName = @AccessorImplDevice} : (memref<?x!sycl_accessor_impl_device_1_, 4>, memref<?x!sycl.id<1>>, memref<?x!sycl.range<1>>, memref<?x!sycl.range<1>>) -> ()
+// CHECK: sycl.constructor([[I]], {{%.*}}, {{%.*}}, {{%.*}}) {MangledFunctionName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_, TypeName = @AccessorImplDevice} : (memref<?x!sycl_accessor_impl_device_1_, 4>, memref<?x!sycl_id_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>) -> ()
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_5()
 // CHECK-LLVM-SAME:  #[[FUNCATTRS]]

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -8,17 +8,21 @@
 
 // CHECK-MLIR-NO-MANGLED-FUNCTION-NAME-NOT: {{^(sycl\.constructor|sycl\.call){,0}.*}} MangledFunctionName
 
-// CHECK-MLIR-DAG: !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>
-// CHECK-MLIR-DAG: !sycl_accessor_impl_device_2_ = !sycl.accessor_impl_device<[2], (!sycl.id<2>, !sycl.range<2>, !sycl.range<2>)>
-// CHECK-MLIR-DAG: !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
-// CHECK-MLIR-DAG: !sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<i32, 1>)>)>
 // CHECK-MLIR-DAG: !sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
 // CHECK-MLIR-DAG: !sycl_array_2_ = !sycl.array<[2], (memref<2xi64, 4>)>
-// CHECK-MLIR-DAG: ![[ACC_SUBSCRIPT:.*]] = !sycl.accessor_subscript<[1], (!sycl.id<2>, !sycl_accessor_2_i32_rw_gb)>
-// CHECK-MLIR-DAG: ![[ITEM_BASE1:.*]] = !sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>
-// CHECK-MLIR-DAG: ![[ITEM_BASE2:.*]] = !sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>
-// CHECK-MLIR-DAG: ![[ITEM1:.*]] = !sycl.item<[1, true], (!sycl_item_base_1_)>
-// CHECK-MLIR-DAG: ![[ITEM2:.*]] = !sycl.item<[2, true], (!sycl_item_base_2_)>
+// CHECK-MLIR-DAG: !sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
+// CHECK-MLIR-DAG: !sycl_id_2_ = !sycl.id<[2], (!sycl_array_2_)>
+// CHECK-MLIR-DAG: !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
+// CHECK-MLIR-DAG: !sycl_range_2_ = !sycl.range<[2], (!sycl_array_2_)>
+// CHECK-MLIR-DAG: !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
+// CHECK-MLIR-DAG: !sycl_accessor_impl_device_2_ = !sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>
+// CHECK-MLIR-DAG: !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+// CHECK-MLIR-DAG: !sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<i32, 1>)>)>
+// CHECK-MLIR-DAG: ![[ACC_SUBSCRIPT:.*]] = !sycl.accessor_subscript<[1], (!sycl_id_2_, !sycl_accessor_2_i32_rw_gb)>
+// CHECK-MLIR-DAG: ![[ITEM_BASE1:.*]] = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)
+// CHECK-MLIR-DAG: ![[ITEM_BASE2:.*]] = !sycl.item_base<[2, true], (!sycl_range_2_, !sycl_id_2_, !sycl_id_2_)>
+// CHECK-MLIR-DAG: ![[ITEM1:.*]] = !sycl.item<[1, true], (![[ITEM_BASE1]])>
+// CHECK-MLIR-DAG: ![[ITEM2:.*]] = !sycl.item<[2, true], (![[ITEM_BASE2]])>
 
 // CHECK-LLVM-DAG: %"class.sycl::_V1::detail::array.1" = type { [1 x i64] }
 // CHECK-LLVM-DAG: %"class.sycl::_V1::detail::array.2" = type { [2 x i64] }
@@ -36,8 +40,8 @@ template <typename T> SYCL_EXTERNAL void keep(T);
 
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_0N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEENS0_2idILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef}, 
-// CHECK_MLIR_SAME:      %{{.*}}: memref<?x!sycl.id<2>> {llvm.align = 8 : i64, llvm.byval = !sycl.id<2>, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {BaseType = memref<?x!sycl_accessor_2_i32_rw_gb, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl.id<2>>) -> memref<?xi32, 4>
+// CHECK_MLIR_SAME:      %{{.*}}: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {BaseType = memref<?x!sycl_accessor_2_i32_rw_gb, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_0N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEENS0_2idILi2EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0, %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %1) #[[FUNCATTRS:[0-9]+]]
@@ -62,7 +66,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_1(sycl::accessor<sycl::cl_int, 2>
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_2N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_1_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_1_i32_rw_gb, llvm.noundef}, 
 // CHECK-MLIR-SAME:      %{{.*}}: i64 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {BaseType = memref<?x!sycl_accessor_1_i32_rw_gb, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERiNS0_2idILi1EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl.id<1>>) -> memref<?xi32, 4>
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {BaseType = memref<?x!sycl_accessor_1_i32_rw_gb, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERiNS0_2idILi1EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_2N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-LLVM:           %"class.sycl::_V1::accessor.1"* noundef byval(%"class.sycl::_V1::accessor.1") align 8 %0, i64 noundef %1) #[[FUNCATTRS]]  
@@ -73,9 +77,9 @@ SYCL_EXTERNAL void accessor_subscript_operator_2(sycl::accessor<sycl::cl_int, 1>
 }
 
 // CHECK-MLIR-LABEL: func.func @_Z11range_get_0N4sycl3_V15rangeILi2EEEi(
-// CHECK-MLIR:           %{{.*}}: memref<?x!sycl.range<2>> {llvm.align = 8 : i64, llvm.byval = !sycl.range<2>, llvm.noundef}, 
+// CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef}, 
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.range.get"(%{{.*}}, %{{.*}}) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl.range<2>, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.range.get"(%{{.*}}, %{{.*}}) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z11range_get_0N4sycl3_V15rangeILi2EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #[[FUNCATTRS]] 
@@ -86,9 +90,9 @@ SYCL_EXTERNAL void range_get_0(sycl::range<2> r, int dimension) {
 }
 
 // CHECK-MLIR-LABEL: func.func @_Z11range_get_1N4sycl3_V15rangeILi2EEEi(
-// CHECK-MLIR:           %{{.*}}: memref<?x!sycl.range<2>> {llvm.align = 8 : i64, llvm.byval = !sycl.range<2>, llvm.noundef}
+// CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef}
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.range.get"(%{{.*}}, %{{.*}}) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZN4sycl3_V16detail5arrayILi2EEixEi, TypeName = @array} : (memref<?x!sycl.range<2>, 4>, i32) -> memref<?xi64, 4>
+// CHECK-MLIR: %{{.*}} = "sycl.range.get"(%{{.*}}, %{{.*}}) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZN4sycl3_V16detail5arrayILi2EEixEi, TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> memref<?xi64, 4>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z11range_get_1N4sycl3_V15rangeILi2EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]   
@@ -99,9 +103,9 @@ SYCL_EXTERNAL void range_get_1(sycl::range<2> r, int dimension) {
 }
 
 // CHECK-MLIR-LABEL: func.func @_Z11range_get_2N4sycl3_V15rangeILi2EEEi(
-// CHECK-MLIR:           %{{.*}}: memref<?x!sycl.range<2>> {llvm.align = 8 : i64, llvm.byval = !sycl.range<2>, llvm.noundef}
+// CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef}
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.range.get"(%{{.*}}, %{{.*}}) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EEixEi, TypeName = @array} : (memref<?x!sycl.range<2>, 4>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = "sycl.range.get"(%{{.*}}, %{{.*}}) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EEixEi, TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z11range_get_2N4sycl3_V15rangeILi2EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]     
@@ -112,8 +116,8 @@ SYCL_EXTERNAL void range_get_2(const sycl::range<2> r, int dimension) {
 }
 
 // CHECK-MLIR-LABEL: func.func @_Z10range_sizeN4sycl3_V15rangeILi2EEE(
-// CHECK-MLIR:           %{{.*}}: memref<?x!sycl.range<2>> {llvm.align = 8 : i64, llvm.byval = !sycl.range<2>, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.range.size"(%{{.*}}) {BaseType = memref<?x!sycl.range<2>, 4>, FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl.range<2>, 4>) -> i64
+// CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef})
+// CHECK-MLIR: %{{.*}} = "sycl.range.size"(%{{.*}}) {BaseType = memref<?x!sycl_range_2_, 4>, FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl_range_2_, 4>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z10range_sizeN4sycl3_V15rangeILi2EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0) #[[FUNCATTRS]]       
@@ -125,18 +129,18 @@ SYCL_EXTERNAL void range_size(sycl::range<2> r) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_range_get_global_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_range.get_global_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_range_2_, 4>, FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_, 4>) -> !sycl.range<2>
+// CHECK-MLIR: %{{.*}} = "sycl.nd_range.get_global_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_range_2_, 4>, FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_, 4>) -> !sycl_range_2_
 
-// CHECK-MLIR:           func.func @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv(%[[VAL_0:.*]]: memref<?x!sycl_nd_range_2_, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 48 : i64, llvm.noundef}) -> !sycl.range<2>
+// CHECK-MLIR:           func.func @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv(%[[VAL_0:.*]]: memref<?x!sycl_nd_range_2_, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 48 : i64, llvm.noundef}) -> !sycl_range_2_
 // CHECK-MLIR-NEXT:             %[[VAL_1:.*]] = arith.constant 0 : index
-// CHECK-MLIR-NEXT:             %[[VAL_2:.*]] = memref.alloca() : memref<1x!sycl.range<2>>
-// CHECK-MLIR-NEXT:             %[[VAL_3:.*]] = "polygeist.subindex"(%[[VAL_0]], %[[VAL_1]]) : (memref<?x!sycl_nd_range_2_, 4>, index) -> memref<?x!sycl.range<2>, 4>
-// CHECK-MLIR-NEXT:             %[[VAL_4:.*]] = "polygeist.memref2pointer"(%[[VAL_2]]) : (memref<1x!sycl.range<2>>) -> !llvm.ptr<!sycl.range<2>>
-// CHECK-MLIR-NEXT:             %[[VAL_5:.*]] = llvm.addrspacecast %[[VAL_4]] : !llvm.ptr<!sycl.range<2>> to !llvm.ptr<!sycl.range<2>, 4>
-// CHECK-MLIR-NEXT:             %[[VAL_6:.*]] = "polygeist.pointer2memref"(%[[VAL_5]]) : (!llvm.ptr<!sycl.range<2>, 4>) -> memref<?x!sycl.range<2>, 4>
-// CHECK-MLIR-NEXT:             sycl.constructor(%[[VAL_6]], %[[VAL_3]]) {MangledFunctionName = @_ZN4sycl3_V15rangeILi2EEC1ERKS2_, TypeName = @range} : (memref<?x!sycl.range<2>, 4>, memref<?x!sycl.range<2>, 4>) -> ()
-// CHECK-MLIR-NEXT:             %[[VAL_7:.*]] = affine.load %[[VAL_2]][0] : memref<1x!sycl.range<2>>
-// CHECK-MLIR-NEXT:             return %[[VAL_7]] : !sycl.range<2>
+// CHECK-MLIR-NEXT:             %[[VAL_2:.*]] = memref.alloca() : memref<1x!sycl_range_2_>
+// CHECK-MLIR-NEXT:             %[[VAL_3:.*]] = "polygeist.subindex"(%[[VAL_0]], %[[VAL_1]]) : (memref<?x!sycl_nd_range_2_, 4>, index) -> memref<?x!sycl_range_2_, 4>
+// CHECK-MLIR-NEXT:             %[[VAL_4:.*]] = "polygeist.memref2pointer"(%[[VAL_2]]) : (memref<1x!sycl_range_2_>) -> !llvm.ptr<!sycl_range_2_>
+// CHECK-MLIR-NEXT:             %[[VAL_5:.*]] = llvm.addrspacecast %[[VAL_4]] : !llvm.ptr<!sycl_range_2_> to !llvm.ptr<!sycl_range_2_, 4>
+// CHECK-MLIR-NEXT:             %[[VAL_6:.*]] = "polygeist.pointer2memref"(%[[VAL_5]]) : (!llvm.ptr<!sycl_range_2_, 4>) -> memref<?x!sycl_range_2_, 4>
+// CHECK-MLIR-NEXT:             sycl.constructor(%[[VAL_6]], %[[VAL_3]]) {MangledFunctionName = @_ZN4sycl3_V15rangeILi2EEC1ERKS2_, TypeName = @range} : (memref<?x!sycl_range_2_, 4>, memref<?x!sycl_range_2_, 4>) -> ()
+// CHECK-MLIR-NEXT:             %[[VAL_7:.*]] = affine.load %[[VAL_2]][0] : memref<1x!sycl_range_2_>
+// CHECK-MLIR-NEXT:             return %[[VAL_7]] : !sycl_range_2_
 // CHECK-MLIR-NEXT:           }
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_range_get_global_rangeN4sycl3_V18nd_rangeILi2EEE(
@@ -158,7 +162,7 @@ SYCL_EXTERNAL void nd_range_get_global_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-MLIR-LABEL: func.func @_Z24nd_range_get_local_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_range.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_range_2_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE15get_local_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_, 4>) -> !sycl.range<2>
+// CHECK-MLIR: %{{.*}} = "sycl.nd_range.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_range_2_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE15get_local_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_, 4>) -> !sycl_range_2_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z24nd_range_get_local_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #[[FUNCATTRS]]
@@ -170,7 +174,7 @@ SYCL_EXTERNAL void nd_range_get_local_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-MLIR-LABEL: func.func @_Z24nd_range_get_group_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_range.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_range_2_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE15get_group_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_, 4>) -> !sycl.range<2>
+// CHECK-MLIR: %{{.*}} = "sycl.nd_range.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_range_2_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE15get_group_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_, 4>) -> !sycl_range_2_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z24nd_range_get_group_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #[[FUNCATTRS]]  
@@ -181,8 +185,8 @@ SYCL_EXTERNAL void nd_range_get_group_range(sycl::nd_range<2> nd_range) {
 }
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_0N4sycl3_V12idILi1EEEi(
-// CHECK-MLIR:           %arg0: memref<?x!sycl.id<1>>  {llvm.align = 8 : i64, llvm.byval = !sycl.id<1>, llvm.noundef}, %arg1: i32  {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi1EE3getEi, TypeName = @array} : (memref<?x!sycl.id<1>, 4>, i32) -> i64
+// CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})
+// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi1EE3getEi, TypeName = @array} : (memref<?x!sycl_id_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_0N4sycl3_V12idILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
@@ -193,8 +197,8 @@ SYCL_EXTERNAL void id_get_0(sycl::id<1> id, int dimension) {
 }
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_1N4sycl3_V12idILi1EEEi(
-// CHECK-MLIR:           %arg0: memref<?x!sycl.id<1>>  {llvm.align = 8 : i64, llvm.byval = !sycl.id<1>, llvm.noundef}, %arg1: i32  {llvm.noundef})  
-// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZN4sycl3_V16detail5arrayILi1EEixEi, TypeName = @array} : (memref<?x!sycl.id<1>, 4>, i32) -> memref<?xi64, 4>
+// CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})  
+// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZN4sycl3_V16detail5arrayILi1EEixEi, TypeName = @array} : (memref<?x!sycl_id_1_, 4>, i32) -> memref<?xi64, 4>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_1N4sycl3_V12idILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]  
@@ -205,8 +209,8 @@ SYCL_EXTERNAL void id_get_1(sycl::id<1> id, int dimension) {
 }
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_2N4sycl3_V12idILi1EEEi(
-// CHECK-MLIR:           %arg0: memref<?x!sycl.id<1>>  {llvm.align = 8 : i64, llvm.byval = !sycl.id<1>, llvm.noundef}, %arg1: i32  {llvm.noundef})    
-// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi1EEixEi, TypeName = @array} : (memref<?x!sycl.id<1>, 4>, i32) -> i64
+// CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})    
+// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}, %arg1) {BaseType = memref<?x!sycl_array_1_, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi1EEixEi, TypeName = @array} : (memref<?x!sycl_id_1_, 4>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_2N4sycl3_V12idILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]    
@@ -217,8 +221,8 @@ SYCL_EXTERNAL void id_get_2(const sycl::id<1> id, int dimension) {
 }
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_3N4sycl3_V12idILi1EEE(
-// CHECK-MLIR:           %arg0: memref<?x!sycl.id<1>> {llvm.align = 8 : i64, llvm.byval = !sycl.id<1>, llvm.noundef}
-// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}) {BaseType = memref<?x!sycl.id<1>, 4>, FunctionName = @"operator unsigned long", MangledFunctionName = @_ZNK4sycl3_V12idILi1EEcvmEv, TypeName = @id} : (memref<?x!sycl.id<1>, 4>) -> i64
+// CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}
+// CHECK-MLIR: %{{.*}} = "sycl.id.get"(%{{.*}}) {BaseType = memref<?x!sycl_id_1_, 4>, FunctionName = @"operator unsigned long", MangledFunctionName = @_ZNK4sycl3_V12idILi1EEcvmEv, TypeName = @id} : (memref<?x!sycl_id_1_, 4>) -> i64
 
 SYCL_EXTERNAL void id_get_3(sycl::id<1> id) {
   keep(static_cast<size_t>(id));
@@ -226,7 +230,7 @@ SYCL_EXTERNAL void id_get_3(sycl::id<1> id) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}) {BaseType = memref<?x![[ITEM1]], 4>, FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x![[ITEM1]], 4>) -> !sycl.id<1>
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_id"(%{{.*}}) {BaseType = memref<?x![[ITEM1]], 4>, FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x![[ITEM1]], 4>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]
@@ -266,7 +270,7 @@ SYCL_EXTERNAL void item_get_id_3(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z16item_get_range_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.item.get_range"(%{{.*}}) {BaseType = memref<?x![[ITEM1]], 4>, FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEv, TypeName = @item} : (memref<?x![[ITEM1]], 4>) -> !sycl.range<1>
+// CHECK-MLIR: %{{.*}} = "sycl.item.get_range"(%{{.*}}) {BaseType = memref<?x![[ITEM1]], 4>, FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEv, TypeName = @item} : (memref<?x![[ITEM1]], 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z16item_get_range_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]    
@@ -294,7 +298,7 @@ SYCL_EXTERNAL void item_get_linear_id(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23nd_item_get_global_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl.id<1>
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23nd_item_get_global_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]
@@ -322,7 +326,7 @@ SYCL_EXTERNAL void nd_item_get_global_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z22nd_item_get_local_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl.id<1>
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_id"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z22nd_item_get_local_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]  
@@ -382,7 +386,7 @@ SYCL_EXTERNAL void nd_item_get_group_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_group_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl.range<1>
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_group_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]        
@@ -402,7 +406,7 @@ SYCL_EXTERNAL void nd_item_get_group_range_1(sycl::nd_item<1> nd_item, int dimen
 
 // CHECK-MLIR-LABEL: func.func @_Z26nd_item_get_global_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl.range<1>
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_global_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z26nd_item_get_global_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]
@@ -426,7 +430,7 @@ SYCL_EXTERNAL void nd_item_get_global_range_1(sycl::nd_item<1> nd_item, int dime
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_local_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl.range<1>
+// CHECK-MLIR: %{{.*}} = "sycl.nd_item.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_nd_item_1_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_local_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]
@@ -462,7 +466,7 @@ SYCL_EXTERNAL void nd_item_get_nd_range(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_group_idEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl.id<1>
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_group_idEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_0N4sycl3_V15groupILi1EEE(
 
@@ -498,7 +502,7 @@ SYCL_EXTERNAL void group_get_group_id_2(sycl::group<1> group, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_local_id_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_local_idEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl.id<1>
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_id"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_local_idEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_local_id_0N4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]   
@@ -522,7 +526,7 @@ SYCL_EXTERNAL void group_get_local_id_1(sycl::group<1> group, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_local_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl.range<1>
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_local_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]     
@@ -546,7 +550,7 @@ SYCL_EXTERNAL void group_get_local_range_1(sycl::group<1> group, int dimension) 
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_group_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}  
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl.range<1>
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_group_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_group_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]       
@@ -570,7 +574,7 @@ SYCL_EXTERNAL void group_get_group_range_1(sycl::group<1> group, int dimension) 
 
 // CHECK-MLIR-LABEL: func.func @_Z25group_get_max_local_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}      
-// CHECK-MLIR: %{{.*}} = "sycl.group.get_max_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_max_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_max_local_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl.range<1>
+// CHECK-MLIR: %{{.*}} = "sycl.group.get_max_local_range"(%{{.*}}) {BaseType = memref<?x!sycl_group_1_, 4>, FunctionName = @get_max_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_max_local_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_, 4>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_max_local_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]         
@@ -649,14 +653,14 @@ SYCL_EXTERNAL void method_2(sycl::item<2, true> item) {
 }
 
 // CHECK-MLIR-LABEL: func.func @_Z4op_1N4sycl3_V12idILi2EEES2_(
-// CHECK-MLIR:         %arg0: memref<?x!sycl.id<2>> {llvm.align = 8 : i64, llvm.byval = !sycl.id<2>, llvm.noundef}, %arg1: memref<?x!sycl.id<2>> {llvm.align = 8 : i64, llvm.byval = !sycl.id<2>, llvm.noundef})
-// CHECK-MLIR-NEXT: %0 = "polygeist.memref2pointer"(%arg0) : (memref<?x!sycl.id<2>>) -> !llvm.ptr<!sycl.id<2>>
-// CHECK-MLIR-NEXT: %1 = llvm.addrspacecast %0 : !llvm.ptr<!sycl.id<2>> to !llvm.ptr<!sycl.id<2>, 4>
-// CHECK-MLIR-NEXT: %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<!sycl.id<2>, 4>) -> memref<?x!sycl.id<2>, 4>
-// CHECK-MLIR-NEXT: %3 = "polygeist.memref2pointer"(%arg1) : (memref<?x!sycl.id<2>>) -> !llvm.ptr<!sycl.id<2>>
-// CHECK-MLIR-NEXT: %4 = llvm.addrspacecast %3 : !llvm.ptr<!sycl.id<2>> to !llvm.ptr<!sycl.id<2>, 4>
-// CHECK-MLIR-NEXT: %5 = "polygeist.pointer2memref"(%4) : (!llvm.ptr<!sycl.id<2>, 4>) -> memref<?x!sycl.id<2>, 4>
-// CHECK-MLIR-NEXT: %6 = sycl.call(%2, %5) {FunctionName = @"operator==", MangledFunctionName = @_ZNK4sycl3_V12idILi2EEeqERKS2_, TypeName = @id} : (memref<?x!sycl.id<2>, 4>, memref<?x!sycl.id<2>, 4>) -> i8
+// CHECK-MLIR:         %arg0: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef}, %arg1: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})
+// CHECK-MLIR-NEXT: %0 = "polygeist.memref2pointer"(%arg0) : (memref<?x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
+// CHECK-MLIR-NEXT: %1 = llvm.addrspacecast %0 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
+// CHECK-MLIR-NEXT: %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
+// CHECK-MLIR-NEXT: %3 = "polygeist.memref2pointer"(%arg1) : (memref<?x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
+// CHECK-MLIR-NEXT: %4 = llvm.addrspacecast %3 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
+// CHECK-MLIR-NEXT: %5 = "polygeist.pointer2memref"(%4) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
+// CHECK-MLIR-NEXT: %6 = sycl.call(%2, %5) {FunctionName = @"operator==", MangledFunctionName = @_ZNK4sycl3_V12idILi2EEeqERKS2_, TypeName = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> i8
 // CHECK-MLIR-NEXT: return
 // CHECK-MLIR-NEXT: }
 
@@ -673,14 +677,14 @@ SYCL_EXTERNAL void op_1(sycl::id<2> a, sycl::id<2> b) {
 }
 
 // CHECK-MLIR-LABEL: func.func @_Z8static_1N4sycl3_V12idILi2EEES2_(
-// CHECK-MLIR:         %arg0: memref<?x!sycl.id<2>> {llvm.align = 8 : i64, llvm.byval = !sycl.id<2>, llvm.noundef}, %arg1: memref<?x!sycl.id<2>> {llvm.align = 8 : i64, llvm.byval = !sycl.id<2>, llvm.noundef})
+// CHECK-MLIR:         %arg0: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef}, %arg1: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})
 // CHECK-MLIR-NEXT: %c1_i32 = arith.constant 1 : i32
 // CHECK-MLIR-NEXT: %c0_i32 = arith.constant 0 : i32
-// CHECK-MLIR-NEXT: %0 = "polygeist.memref2pointer"(%arg0) : (memref<?x!sycl.id<2>>) -> !llvm.ptr<!sycl.id<2>>
-// CHECK-MLIR-NEXT: %1 = llvm.addrspacecast %0 : !llvm.ptr<!sycl.id<2>> to !llvm.ptr<!sycl.id<2>, 4>
-// CHECK-MLIR-NEXT: %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<!sycl.id<2>, 4>) -> memref<?x!sycl.id<2>, 4>
-// CHECK-MLIR-NEXT: %3 = "sycl.id.get"(%2, %c0_i32) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl.id<2>, 4>, i32) -> i64
-// CHECK-MLIR-NEXT: %4 = "sycl.id.get"(%2, %c1_i32) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl.id<2>, 4>, i32) -> i64
+// CHECK-MLIR-NEXT: %0 = "polygeist.memref2pointer"(%arg0) : (memref<?x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
+// CHECK-MLIR-NEXT: %1 = llvm.addrspacecast %0 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
+// CHECK-MLIR-NEXT: %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
+// CHECK-MLIR-NEXT: %3 = "sycl.id.get"(%2, %c0_i32) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_id_2_, 4>, i32) -> i64
+// CHECK-MLIR-NEXT: %4 = "sycl.id.get"(%2, %c1_i32) {BaseType = memref<?x!sycl_array_2_, 4>, FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_id_2_, 4>, i32) -> i64
 // CHECK-MLIR-NEXT: %5 = arith.addi %3, %4 : i64
 // CHECK-MLIR-NEXT: %6 = sycl.call(%5) {FunctionName = @abs, MangledFunctionName = @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_} : (i64) -> i64
 // CHECK-MLIR-NEXT: return

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -3,6 +3,10 @@
 
 #include <sycl/sycl.hpp>
 
+// CHECK-MLIR-DAG: !sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
+// CHECK-MLIR-DAG: !sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
+// CHECK-MLIR-DAG: !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
+
 // CHECK-LLVM-DAG: %"class.sycl::_V1::accessor.1" = type { %"class.sycl::_V1::detail::AccessorImplDevice.1", { i32 addrspace(1)* } }
 // CHECK-LLVM-DAG: %"class.sycl::_V1::detail::AccessorImplDevice.1" = type { %"class.sycl::_V1::id.1", %"class.sycl::_V1::range.1", %"class.sycl::_V1::range.1" }
 // CHECK-LLVM-DAG: %"class.sycl::_V1::id.1" = type { %"class.sycl::_V1::detail::array.1" }
@@ -14,9 +18,9 @@
 // CHECK-MLIR: gpu.module @device_functions
 // CHECK-MLIR-LABEL: gpu.func @_ZTS8kernel_1(
 // CHECK-MLIR:         %arg0: memref<?xi32, 1> {llvm.noundef},
-// CHECK-MLIR-SAME:    %arg1: memref<?x!sycl.range<1>> {llvm.align = 8 : i64, llvm.byval = !sycl.range<1>, llvm.noundef},
-// CHECK-MLIR-SAME:    %arg2: memref<?x!sycl.range<1>> {llvm.align = 8 : i64, llvm.byval = !sycl.range<1>, llvm.noundef},
-// CHECK-MLIR-SAME:    %arg3: memref<?x!sycl.id<1>> {llvm.align = 8 : i64, llvm.byval = !sycl.id<1>, llvm.noundef})
+// CHECK-MLIR-SAME:    %arg1: memref<?x!sycl_range_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_1_, llvm.noundef},
+// CHECK-MLIR-SAME:    %arg2: memref<?x!sycl_range_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_1_, llvm.noundef},
+// CHECK-MLIR-SAME:    %arg3: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef})
 // CHECK-MLIR-SAME:  kernel attributes {[[CCONV:llvm.cconv = #llvm.cconv<spir_kernelcc>]], [[LINKAGE:llvm.linkage = #llvm.linkage<weak_odr>]],
 // CHECK-MLIR-NOT: gpu.func kernel
 
@@ -49,9 +53,9 @@ void host_1() {
 
 // CHECK-MLIR: gpu.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2(
 // CHECK-MLIR:          %arg0: memref<?xi32, 1> {llvm.noundef},
-// CHECK-MLIR-SAME:     %arg1: memref<?x!sycl.range<1>> {llvm.align = 8 : i64, llvm.byval = !sycl.range<1>, llvm.noundef},
-// CHECK-MLIR-SAME:     %arg2: memref<?x!sycl.range<1>> {llvm.align = 8 : i64, llvm.byval = !sycl.range<1>, llvm.noundef},
-// CHECK-MLIR-SAME:     %arg3: memref<?x!sycl.id<1>> {llvm.align = 8 : i64, llvm.byval = !sycl.id<1>, llvm.noundef}
+// CHECK-MLIR-SAME:     %arg1: memref<?x!sycl_range_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_1_, llvm.noundef},
+// CHECK-MLIR-SAME:     %arg2: memref<?x!sycl_range_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_1_, llvm.noundef},
+// CHECK-MLIR-SAME:     %arg3: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}
 // CHECK-MLIR-SAME:     kernel attributes {[[CCONV]], [[LINKAGE]], {{.*}}}
 // CHECK-MLIR-NOT: gpu.func kernel
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -2,19 +2,23 @@
 
 #include <sycl/sycl.hpp>
 
-// CHECK-DAG: !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl.id<1>, !sycl.range<1>, !sycl.range<1>)>, !llvm.struct<(ptr<i32, 1>)>)>
-// CHECK-DAG: !sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl.id<2>, !sycl.range<2>, !sycl.range<2>)>, !llvm.struct<(ptr<i32, 1>)>)>
-// CHECK-DAG: !sycl_accessor_3_f32_rw_gb = !sycl.accessor<[3, f32, read_write, global_buffer], (!sycl.accessor_impl_device<[3], (!sycl.id<3>, !sycl.range<3>, !sycl.range<3>)>, !llvm.struct<(ptr<f32, 1>)>)>
 // CHECK-DAG: !sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
 // CHECK-DAG: !sycl_array_2_ = !sycl.array<[2], (memref<2xi64, 4>)>
-// CHECK-DAG: !sycl_group_1_ = !sycl.group<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>
-// CHECK-DAG: !sycl_group_2_ = !sycl.group<[2], (!sycl.range<2>, !sycl.range<2>, !sycl.range<2>, !sycl.id<2>)>
-// CHECK-DAG: ![[ITEM1:.*]] = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl.range<1>, !sycl.id<1>, !sycl.id<1>)>)>
-// CHECK-DAG: ![[ITEM2:.*]] = !sycl.item<[2, false], (!sycl.item_base<[2, false], (!sycl.range<2>, !sycl.id<2>)>)>
-// CHECK-DAG: !sycl_nd_item_1_ = !sycl.nd_item<[1], (![[ITEM1]], !sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl.range<1>, !sycl.id<1>)>)>, !sycl_group_1_)>
-// CHECK-DAG: !sycl_nd_item_2_ = !sycl.nd_item<[2], (!sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl.range<2>, !sycl.id<2>, !sycl.id<2>)>)>, ![[ITEM2]], !sycl_group_2_)>
-// CHECK-DAG: !sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl.range<1>, !sycl.range<1>, !sycl.id<1>)>
-// CHECK-DAG: !sycl_nd_range_2_ = !sycl.nd_range<[2], (!sycl.range<2>, !sycl.range<2>, !sycl.id<2>)>
+// CHECK-DAG: !sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
+// CHECK-DAG: !sycl_id_2_ = !sycl.id<[2], (!sycl_array_2_)>
+// CHECK-DAG: !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
+// CHECK-DAG: !sycl_range_2_ = !sycl.range<[2], (!sycl_array_2_)>
+// CHECK-DAG: !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
+// CHECK-DAG: !sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>, !llvm.struct<(ptr<i32, 1>)>)>
+// CHECK-DAG: !sycl_accessor_3_f32_rw_gb = !sycl.accessor<[3, f32, read_write, global_buffer], (!sycl.accessor_impl_device<[3], (!sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>, !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>, !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>)>, !llvm.struct<(ptr<f32, 1>)>)>
+// CHECK-DAG: !sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+// CHECK-DAG: !sycl_group_2_ = !sycl.group<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
+// CHECK-DAG: ![[ITEM1:.*]] = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>)>
+// CHECK-DAG: ![[ITEM2:.*]] = !sycl.item<[2, false], (!sycl.item_base<[2, false], (!sycl_range_2_, !sycl_id_2_)>)>
+// CHECK-DAG: !sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>)>, !sycl_group_1_)>
+// CHECK-DAG: !sycl_nd_item_2_ = !sycl.nd_item<[2], (!sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl_range_2_, !sycl_id_2_, !sycl_id_2_)>)>, !sycl_item_2_, !sycl_group_2_)>
+// CHECK-DAG: !sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+// CHECK-DAG: !sycl_nd_range_2_ = !sycl.nd_range<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
 // CHECK-DAG: !sycl_get_scalar_op_i32_ = !sycl.get_scalar_op<[i32], (i32)>
 // CHECK-DAG: !sycl_tuple_value_holder_i32_ = !sycl.tuple_value_holder<[i32], (i32)>
 // CHECK-DAG: [[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_TRUE:!sycl_tuple_copy_assignable_value_holder_i32_.*]] = !sycl.tuple_copy_assignable_value_holder<[i32, true], (!sycl_tuple_value_holder_i32_)>
@@ -27,13 +31,13 @@
 // CHECK-DAG: !sycl_bfloat16_ = !sycl.bfloat16<(i16)>
 
 // CHECK-LABEL: func.func @_Z4id_1N4sycl3_V12idILi1EEE(
-// CHECK:          %arg0: memref<?x!sycl.id<1>> {llvm.align = 8 : i64, llvm.byval = !sycl.id<1>, llvm.noundef})
+// CHECK:          %arg0: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC:llvm.cconv = #llvm.cconv<spir_funccc>]], [[LINKEXT:llvm.linkage = #llvm.linkage<external>]],
 // CHECK-SAME: [[PASSTHROUGH:passthrough = \["convergent", "mustprogress", "norecurse", "nounwind", \["frame-pointer", "all"\], \["no-trapping-math", "true"\], \["stack-protector-buffer-size", "8"\], \["sycl-module-id", ".*/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp"\]\]]]} {
 SYCL_EXTERNAL void id_1(sycl::id<1> id) {}
 
 // CHECK-LABEL: func.func @_Z4id_2N4sycl3_V12idILi2EEE(
-// CHECK:          %arg0: memref<?x!sycl.id<2>> {llvm.align = 8 : i64, llvm.byval = !sycl.id<2>, llvm.noundef})
+// CHECK:          %arg0: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
 SYCL_EXTERNAL void id_2(sycl::id<2> id) {}
 
@@ -53,12 +57,12 @@ SYCL_EXTERNAL void acc_2(sycl::accessor<sycl::cl_int, 2, sycl::access::mode::rea
 SYCL_EXTERNAL void acc_3(sycl::accessor<sycl::cl_float, 3, sycl::access::mode::read_write>) {}
 
 // CHECK-LABEL: func.func @_Z7range_1N4sycl3_V15rangeILi1EEE(
-// CHECK:          %arg0: memref<?x!sycl.range<1>> {llvm.align = 8 : i64, llvm.byval = !sycl.range<1>, llvm.noundef})
+// CHECK:          %arg0: memref<?x!sycl_range_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_1_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
 SYCL_EXTERNAL void range_1(sycl::range<1> range) {}
 
 // CHECK-LABEL: func.func @_Z7range_2N4sycl3_V15rangeILi2EEE(
-// CHECK:          %arg0: memref<?x!sycl.range<2>> {llvm.align = 8 : i64, llvm.byval = !sycl.range<2>, llvm.noundef})  
+// CHECK:          %arg0: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef})  
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
 SYCL_EXTERNAL void range_2(sycl::range<2> range) {}
 


### PR DESCRIPTION
`sycl::id<1>` is lowered to `!llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>` in LLVM.
`sycl::range<1>` is lowered to `!llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>` in LLVM.

In MLIR, `sycl::id<1>` was represented as `!sycl.id<1>`,
`sycl::id<1>` is now represented as `!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>` in this PR.
In MLIR, `sycl::range<1>` was represented as `!sycl.range<1>`,
`sycl::id<1>` is now represented as `!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>` in this PR.
The benefit is we can have a more consistent implementation in `SYCLToLLVM` conversion, and before converting to LLVM, pass is aware that `sycl.id` and `sycl.range` contain `sycl.array`.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>