### PR TITLE
[SYCL-MLIR][FIX] Make sure that the global strings goes to the proper module.

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -497,7 +497,9 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
               LC = CE->getOperand(0);
             std::string Val = cast<llvm::GlobalVariable>(LC)->getName().str();
             return CommonArrayToPointer(ValueCategory(
-                Glob.getOrCreateGlobalLLVMString(Loc, Builder, Val),
+                Glob.getOrCreateGlobalLLVMString(Loc, Builder, Val, isa<mlir::gpu::GPUModuleOp>(Function->getParentOp())
+                        ? FunctionContext::SYCLDevice
+                        : FunctionContext::Host),
                 /*isReference*/ true));
           }
         }

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -497,7 +497,9 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
               LC = CE->getOperand(0);
             std::string Val = cast<llvm::GlobalVariable>(LC)->getName().str();
             return CommonArrayToPointer(ValueCategory(
-                Glob.getOrCreateGlobalLLVMString(Loc, Builder, Val, isa<mlir::gpu::GPUModuleOp>(Function->getParentOp())
+                Glob.getOrCreateGlobalLLVMString(
+                    Loc, Builder, Val,
+                    isa<mlir::gpu::GPUModuleOp>(Function->getParentOp())
                         ? FunctionContext::SYCLDevice
                         : FunctionContext::Host),
                 /*isReference*/ true));

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -498,8 +498,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
             std::string Val = cast<llvm::GlobalVariable>(LC)->getName().str();
             return CommonArrayToPointer(ValueCategory(
                 Glob.getOrCreateGlobalLLVMString(
-                    Loc, Builder, Val,
-                    mlirclang::getFuncContext(Function)),
+                    Loc, Builder, Val, mlirclang::getFuncContext(Function)),
                 /*isReference*/ true));
           }
         }

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -499,9 +499,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
             return CommonArrayToPointer(ValueCategory(
                 Glob.getOrCreateGlobalLLVMString(
                     Loc, Builder, Val,
-                    isa<mlir::gpu::GPUModuleOp>(Function->getParentOp())
-                        ? FunctionContext::SYCLDevice
-                        : FunctionContext::Host),
+                    mlirclang::getFuncContext(Function)),
                 /*isReference*/ true));
           }
         }

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -138,7 +138,9 @@ MLIRScanner::VisitCXXBoolLiteralExpr(clang::CXXBoolLiteralExpr *Expr) {
 ValueCategory MLIRScanner::VisitStringLiteral(clang::StringLiteral *Expr) {
   auto Loc = getMLIRLocation(Expr->getExprLoc());
   return ValueCategory(
-      Glob.getOrCreateGlobalLLVMString(Loc, Builder, Expr->getString()),
+      Glob.getOrCreateGlobalLLVMString(Loc, Builder, Expr->getString(), isa<mlir::gpu::GPUModuleOp>(Function->getParentOp())
+                               ? FunctionContext::SYCLDevice
+                               : FunctionContext::Host),
       /*isReference*/ true);
 }
 

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -139,9 +139,7 @@ ValueCategory MLIRScanner::VisitStringLiteral(clang::StringLiteral *Expr) {
   auto Loc = getMLIRLocation(Expr->getExprLoc());
   return ValueCategory(Glob.getOrCreateGlobalLLVMString(
                            Loc, Builder, Expr->getString(),
-                           isa<mlir::gpu::GPUModuleOp>(Function->getParentOp())
-                               ? FunctionContext::SYCLDevice
-                               : FunctionContext::Host),
+                           mlirclang::getFuncContext(Function)),
                        /*isReference*/ true);
 }
 

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -137,11 +137,12 @@ MLIRScanner::VisitCXXBoolLiteralExpr(clang::CXXBoolLiteralExpr *Expr) {
 
 ValueCategory MLIRScanner::VisitStringLiteral(clang::StringLiteral *Expr) {
   auto Loc = getMLIRLocation(Expr->getExprLoc());
-  return ValueCategory(
-      Glob.getOrCreateGlobalLLVMString(Loc, Builder, Expr->getString(), isa<mlir::gpu::GPUModuleOp>(Function->getParentOp())
+  return ValueCategory(Glob.getOrCreateGlobalLLVMString(
+                           Loc, Builder, Expr->getString(),
+                           isa<mlir::gpu::GPUModuleOp>(Function->getParentOp())
                                ? FunctionContext::SYCLDevice
                                : FunctionContext::Host),
-      /*isReference*/ true);
+                       /*isReference*/ true);
 }
 
 ValueCategory MLIRScanner::VisitParenExpr(clang::ParenExpr *Expr) {

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -137,10 +137,10 @@ MLIRScanner::VisitCXXBoolLiteralExpr(clang::CXXBoolLiteralExpr *Expr) {
 
 ValueCategory MLIRScanner::VisitStringLiteral(clang::StringLiteral *Expr) {
   auto Loc = getMLIRLocation(Expr->getExprLoc());
-  return ValueCategory(Glob.getOrCreateGlobalLLVMString(
-                           Loc, Builder, Expr->getString(),
-                           mlirclang::getFuncContext(Function)),
-                       /*isReference*/ true);
+  return ValueCategory(
+      Glob.getOrCreateGlobalLLVMString(Loc, Builder, Expr->getString(),
+                                       mlirclang::getFuncContext(Function)),
+      /*isReference*/ true);
 }
 
 ValueCategory MLIRScanner::VisitParenExpr(clang::ParenExpr *Expr) {

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -2016,22 +2016,23 @@ MLIRASTConsumer::getOrCreateGlobal(const clang::ValueDecl &VD,
   return Globals[Name];
 }
 
-Value MLIRASTConsumer::getOrCreateGlobalLLVMString(Location Loc,
-                                                   OpBuilder &Builder,
-                                                   StringRef value, FunctionContext FuncContext) {
+Value MLIRASTConsumer::getOrCreateGlobalLLVMString(
+    Location Loc, OpBuilder &Builder, StringRef value,
+    FunctionContext FuncContext) {
   using namespace mlir;
   // Create the global at the entry of the module.
   if (LLVMStringGlobals.find(value.str()) == LLVMStringGlobals.end()) {
     OpBuilder::InsertionGuard insertGuard(Builder);
-    switch(FuncContext) {
-      case FunctionContext::SYCLDevice:
-        Builder.setInsertionPointToStart(mlirclang::getDeviceModule(*Module).getBody());
-        break;
-      case FunctionContext::Host:
-        Builder.setInsertionPointToStart(Module->getBody());
-        break;
-      default:
-        llvm_unreachable("Unknown Functin Context while creating global string");  
+    switch (FuncContext) {
+    case FunctionContext::SYCLDevice:
+      Builder.setInsertionPointToStart(
+          mlirclang::getDeviceModule(*Module).getBody());
+      break;
+    case FunctionContext::Host:
+      Builder.setInsertionPointToStart(Module->getBody());
+      break;
+    default:
+      llvm_unreachable("Unknown Functin Context while creating global string");
     }
 
     auto type = LLVM::LLVMArrayType::get(

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -2018,12 +2018,22 @@ MLIRASTConsumer::getOrCreateGlobal(const clang::ValueDecl &VD,
 
 Value MLIRASTConsumer::getOrCreateGlobalLLVMString(Location Loc,
                                                    OpBuilder &Builder,
-                                                   StringRef value) {
+                                                   StringRef value, FunctionContext FuncContext) {
   using namespace mlir;
   // Create the global at the entry of the module.
   if (LLVMStringGlobals.find(value.str()) == LLVMStringGlobals.end()) {
     OpBuilder::InsertionGuard insertGuard(Builder);
-    Builder.setInsertionPointToStart(Module->getBody());
+    switch(FuncContext) {
+      case FunctionContext::SYCLDevice:
+        Builder.setInsertionPointToStart(mlirclang::getDeviceModule(*Module).getBody());
+        break;
+      case FunctionContext::Host:
+        Builder.setInsertionPointToStart(Module->getBody());
+        break;
+      default:
+        llvm_unreachable("Unknown Functin Context while creating global string");  
+    }
+
     auto type = LLVM::LLVMArrayType::get(
         IntegerType::get(Builder.getContext(), 8), value.size() + 1);
     LLVMStringGlobals[value.str()] = Builder.create<LLVM::GlobalOp>(

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -190,7 +190,7 @@ public:
   /// given name, creating the string if necessary.
   mlir::Value getOrCreateGlobalLLVMString(mlir::Location Loc,
                                           mlir::OpBuilder &Builder,
-                                          clang::StringRef Value);
+                                          clang::StringRef Value, FunctionContext FuncContext);
 
   /// Create global variable and initialize it.
   std::pair<mlir::memref::GlobalOp, bool>

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -190,7 +190,8 @@ public:
   /// given name, creating the string if necessary.
   mlir::Value getOrCreateGlobalLLVMString(mlir::Location Loc,
                                           mlir::OpBuilder &Builder,
-                                          clang::StringRef Value, FunctionContext FuncContext);
+                                          clang::StringRef Value,
+                                          FunctionContext FuncContext);
 
   /// Create global variable and initialize it.
   std::pair<mlir::memref::GlobalOp, bool>

--- a/polygeist/tools/cgeist/Lib/utils.cc
+++ b/polygeist/tools/cgeist/Lib/utils.cc
@@ -85,4 +85,10 @@ gpu::GPUModuleOp getDeviceModule(ModuleOp Module) {
       Module.lookupSymbol(MLIRASTConsumer::DeviceModuleName));
 }
 
+FunctionContext getFuncContext(FunctionOpInterface Function) {
+  return isa<mlir::gpu::GPUModuleOp>(Function->getParentOp())
+                        ? FunctionContext::SYCLDevice
+                        : FunctionContext::Host;
+}
+
 } // namespace mlirclang

--- a/polygeist/tools/cgeist/Lib/utils.cc
+++ b/polygeist/tools/cgeist/Lib/utils.cc
@@ -87,8 +87,8 @@ gpu::GPUModuleOp getDeviceModule(ModuleOp Module) {
 
 FunctionContext getFuncContext(FunctionOpInterface Function) {
   return isa<mlir::gpu::GPUModuleOp>(Function->getParentOp())
-                        ? FunctionContext::SYCLDevice
-                        : FunctionContext::Host;
+             ? FunctionContext::SYCLDevice
+             : FunctionContext::Host;
 }
 
 } // namespace mlirclang

--- a/polygeist/tools/cgeist/Lib/utils.h
+++ b/polygeist/tools/cgeist/Lib/utils.h
@@ -27,6 +27,7 @@ class OpBuilder;
 class Operation;
 class ModuleOp;
 class Value;
+class FunctionOpInterface;
 
 namespace func {
 class FuncOp;
@@ -65,6 +66,9 @@ FunctionContext getInputContext(const mlir::OpBuilder &Builder);
 
 /// Return the device module in the input module.
 mlir::gpu::GPUModuleOp getDeviceModule(mlir::ModuleOp Module);
+
+///Return the function context
+FunctionContext getFuncContext(mlir::FunctionOpInterface Function);
 
 } // namespace mlirclang
 

--- a/polygeist/tools/cgeist/Lib/utils.h
+++ b/polygeist/tools/cgeist/Lib/utils.h
@@ -67,7 +67,7 @@ FunctionContext getInputContext(const mlir::OpBuilder &Builder);
 /// Return the device module in the input module.
 mlir::gpu::GPUModuleOp getDeviceModule(mlir::ModuleOp Module);
 
-///Return the function context
+/// Return the function context
 FunctionContext getFuncContext(mlir::FunctionOpInterface Function);
 
 } // namespace mlirclang

--- a/polygeist/tools/cgeist/Test/Verification/sycl/lobal_string.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/lobal_string.cpp
@@ -1,0 +1,17 @@
+// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=MLIR
+#include <sycl/sycl.hpp>
+
+void test_global_string(sycl::device d) {
+  auto q = sycl::queue(d); 
+  {
+    q.submit([&] (sycl::handler& cgh) {
+       cgh.single_task<class printkernel>([=] {
+          // Test that the string is generated in the gpu module
+          // MLIR: gpu.module @device_functions {
+          // MLIR-NEXT: llvm.mlir.global internal constant @str0("Hello\00") {addr_space = 0 : i32}
+          char str1[10] = "Hello";
+       });
+    });
+  }
+}
+


### PR DESCRIPTION
Before this patch, global string variables that will be used by device functions would go to the main module (not the gpu module).  This patch fixes so that global strings used in device go to the `gpu` module.

PS:  There were some conversations on a old PR #7460 on the main repo, this PR is on the forked repo.