### PR TITLE
[SYCL] Improve spirv-to-ir-wrapper build/test dependencies

### DIFF
--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -143,7 +143,6 @@ set(LLVM_TEST_DEPENDS
           opt
           sancov
           sanstats
-          spirv-to-ir-wrapper
           sycl-post-link
           split-file
           verify-uselistorder
@@ -173,7 +172,7 @@ if(TARGET LTO)
 endif()
 
 if(TARGET spirv-to-ir-wrapper)
-  set(LLVM_TEST_DEPENDS ${LLVM_TEST_DEPENDS} llvm-spirv)
+  set(LLVM_TEST_DEPENDS ${LLVM_TEST_DEPENDS} spirv-to-ir-wrapper llvm-spirv)
 endif()
 
 if(LLVM_BUILD_EXAMPLES)

--- a/llvm/test/CMakeLists.txt
+++ b/llvm/test/CMakeLists.txt
@@ -143,6 +143,7 @@ set(LLVM_TEST_DEPENDS
           opt
           sancov
           sanstats
+          spirv-to-ir-wrapper
           sycl-post-link
           split-file
           verify-uselistorder
@@ -171,8 +172,8 @@ if(TARGET LTO)
   set(LLVM_TEST_DEPENDS ${LLVM_TEST_DEPENDS} LTO)
 endif()
 
-if(TARGET spirv-to-ir-wrapper)
-  set(LLVM_TEST_DEPENDS ${LLVM_TEST_DEPENDS} spirv-to-ir-wrapper llvm-spirv)
+if(TARGET llvm-spirv)
+  set(LLVM_TEST_DEPENDS ${LLVM_TEST_DEPENDS} llvm-spirv)
 endif()
 
 if(LLVM_BUILD_EXAMPLES)

--- a/llvm/tools/spirv-to-ir-wrapper/CMakeLists.txt
+++ b/llvm/tools/spirv-to-ir-wrapper/CMakeLists.txt
@@ -1,9 +1,3 @@
-
-if (NOT LLVM_TOOL_LLVM_SPIRV_BUILD OR
-    NOT IS_DIRECTORY "${LLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR}")
-  return()
-endif()
-
 set(LLVM_LINK_COMPONENTS
   BinaryFormat
   Core

--- a/llvm/tools/spirv-to-ir-wrapper/CMakeLists.txt
+++ b/llvm/tools/spirv-to-ir-wrapper/CMakeLists.txt
@@ -1,3 +1,9 @@
+
+if (NOT LLVM_TOOL_LLVM_SPIRV_BUILD OR
+    NOT IS_DIRECTORY "${LLVM_EXTERNAL_LLVM_SPIRV_SOURCE_DIR}")
+  return()
+endif()
+
 set(LLVM_LINK_COMPONENTS
   BinaryFormat
   Core


### PR DESCRIPTION
If LLVM is configured without llvm-spirv we should avoid making testing dependent upon it.
