### PR TITLE
[NFC][SYCL] Switch to std::remove_* type traits

### DIFF
--- a/sycl/include/sycl/buffer.hpp
+++ b/sycl/include/sycl/buffer.hpp
@@ -344,7 +344,7 @@ public:
               using IteratorValueType =
                   detail::iterator_value_type_t<InputIterator>;
               using IteratorNonConstValueType =
-                  detail::remove_const_t<IteratorValueType>;
+                  std::remove_const_t<IteratorValueType>;
               using IteratorPointerToNonConstValueType =
                   detail::add_pointer_t<IteratorNonConstValueType>;
               std::copy(first, last,
@@ -377,7 +377,7 @@ public:
               using IteratorValueType =
                   detail::iterator_value_type_t<InputIterator>;
               using IteratorNonConstValueType =
-                  detail::remove_const_t<IteratorValueType>;
+                  std::remove_const_t<IteratorValueType>;
               using IteratorPointerToNonConstValueType =
                   detail::add_pointer_t<IteratorNonConstValueType>;
               std::copy(first, last,

--- a/sycl/include/sycl/detail/stl_type_traits.hpp
+++ b/sycl/include/sycl/detail/stl_type_traits.hpp
@@ -23,14 +23,6 @@ namespace detail {
 template <bool B, class T, class F>
 using conditional_t = typename std::conditional<B, T, F>::type;
 
-template <typename T>
-using remove_const_t = typename std::remove_const<T>::type;
-
-template <typename T> using remove_cv_t = typename std::remove_cv<T>::type;
-
-template <typename T>
-using remove_reference_t = typename std::remove_reference<T>::type;
-
 template <typename T> using add_pointer_t = typename std::add_pointer<T>::type;
 
 // C++17

--- a/sycl/include/sycl/detail/type_list.hpp
+++ b/sycl/include/sycl/detail/type_list.hpp
@@ -52,7 +52,7 @@ public:
 // is_contained
 template <typename T, typename TypeList>
 struct is_contained
-    : conditional_t<std::is_same<remove_cv_t<T>, head_t<TypeList>>::value,
+    : conditional_t<std::is_same<std::remove_cv_t<T>, head_t<TypeList>>::value,
                     std::true_type, is_contained<T, tail_t<TypeList>>> {};
 
 template <typename T>

--- a/sycl/include/sycl/detail/type_traits.hpp
+++ b/sycl/include/sycl/detail/type_traits.hpp
@@ -94,7 +94,8 @@ template <typename T> struct vector_size_impl : int_constant<1> {};
 template <typename T, int N>
 struct vector_size_impl<vec<T, N>> : int_constant<N> {};
 template <typename T>
-struct vector_size : vector_size_impl<remove_cv_t<remove_reference_t<T>>> {};
+struct vector_size
+    : vector_size_impl<std::remove_cv_t<std::remove_reference_t<T>>> {};
 
 // 4.10.2.6 Memory layout and alignment
 template <typename T, int N>
@@ -104,7 +105,7 @@ struct vector_alignment_impl
 
 template <typename T, int N>
 struct vector_alignment
-    : vector_alignment_impl<remove_cv_t<remove_reference_t<T>>, N> {};
+    : vector_alignment_impl<std::remove_cv_t<std::remove_reference_t<T>>, N> {};
 
 // vector_element
 template <typename T> struct vector_element_impl;
@@ -117,7 +118,8 @@ template <typename T, int N> struct vector_element_impl<vec<T, N>> {
   using type = T;
 };
 template <typename T> struct vector_element {
-  using type = copy_cv_qualifiers_t<T, vector_element_impl_t<remove_cv_t<T>>>;
+  using type =
+      copy_cv_qualifiers_t<T, vector_element_impl_t<std::remove_cv_t<T>>>;
 };
 template <class T> using vector_element_t = typename vector_element<T>::type;
 
@@ -153,7 +155,7 @@ struct copy_cv_qualifiers_impl<const volatile T, R> {
 };
 
 template <typename T, typename R> struct copy_cv_qualifiers {
-  using type = typename copy_cv_qualifiers_impl<T, remove_cv_t<R>>::type;
+  using type = typename copy_cv_qualifiers_impl<T, std::remove_cv_t<R>>::type;
 };
 
 // make_signed with support SYCL vec class
@@ -184,7 +186,7 @@ struct make_signed_impl<
 };
 
 template <typename T> struct make_signed {
-  using new_type_wo_cv_qualifiers = make_signed_impl_t<remove_cv_t<T>>;
+  using new_type_wo_cv_qualifiers = make_signed_impl_t<std::remove_cv_t<T>>;
   using type = copy_cv_qualifiers_t<T, new_type_wo_cv_qualifiers>;
 };
 
@@ -218,7 +220,7 @@ struct make_unsigned_impl<
 };
 
 template <typename T> struct make_unsigned {
-  using new_type_wo_cv_qualifiers = make_unsigned_impl_t<remove_cv_t<T>>;
+  using new_type_wo_cv_qualifiers = make_unsigned_impl_t<std::remove_cv_t<T>>;
   using type = copy_cv_qualifiers_t<T, new_type_wo_cv_qualifiers>;
 };
 
@@ -245,7 +247,7 @@ template <> struct is_floating_point_impl<half> : std::true_type {};
 
 template <typename T>
 struct is_floating_point
-    : is_floating_point_impl<remove_cv_t<vector_element_t<T>>> {};
+    : is_floating_point_impl<std::remove_cv_t<vector_element_t<T>>> {};
 
 // is_arithmetic
 template <typename T>
@@ -263,7 +265,7 @@ struct is_vector_arithmetic
 // is_bool
 template <typename T>
 struct is_scalar_bool
-    : bool_constant<std::is_same<remove_cv_t<T>, bool>::value> {};
+    : bool_constant<std::is_same<std::remove_cv_t<T>, bool>::value> {};
 
 template <typename T>
 struct is_vector_bool
@@ -283,7 +285,8 @@ template <typename T, access::address_space Space,
 struct is_pointer_impl<multi_ptr<T, Space, DecorateAddress>> : std::true_type {
 };
 
-template <typename T> struct is_pointer : is_pointer_impl<remove_cv_t<T>> {};
+template <typename T>
+struct is_pointer : is_pointer_impl<std::remove_cv_t<T>> {};
 
 // remove_pointer_t
 template <typename T> struct remove_pointer_impl {
@@ -301,7 +304,7 @@ struct remove_pointer_impl<multi_ptr<T, Space, DecorateAddress>> {
 };
 
 template <typename T>
-struct remove_pointer : remove_pointer_impl<remove_cv_t<T>> {};
+struct remove_pointer : remove_pointer_impl<std::remove_cv_t<T>> {};
 
 template <typename T> using remove_pointer_t = typename remove_pointer<T>::type;
 
@@ -320,7 +323,7 @@ struct is_address_space_compliant_impl<multi_ptr<T, Space, DecorateAddress>,
 
 template <typename T, typename SpaceList>
 struct is_address_space_compliant
-    : is_address_space_compliant_impl<remove_cv_t<T>, SpaceList> {};
+    : is_address_space_compliant_impl<std::remove_cv_t<T>, SpaceList> {};
 
 // make_type_t
 template <typename T, typename TL> struct make_type_impl {

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -329,8 +329,8 @@ private:
           std::shared_ptr<detail::queue_impl> SecondaryQueue, bool IsHost);
 
   /// Stores copy of Arg passed to the MArgsStorage.
-  template <typename T, typename F = typename detail::remove_const_t<
-                            typename detail::remove_reference_t<T>>>
+  template <typename T, typename F = typename std::remove_const_t<
+                            typename std::remove_reference_t<T>>>
   F *storePlainArg(T &&Arg) {
     MArgsStorage.emplace_back(sizeof(T));
     auto Storage = reinterpret_cast<F *>(MArgsStorage.back().data());
@@ -794,7 +794,7 @@ private:
         class __copyAcc2Ptr<TSrc, TDst, Dim, AccMode, AccTarget, IsPH>>(
         Range, [=](id<Dim> Index) {
           const size_t LinearIndex = detail::getLinearIndex(Index, Range);
-          using TSrcNonConst = typename detail::remove_const_t<TSrc>;
+          using TSrcNonConst = typename std::remove_const_t<TSrc>;
           (reinterpret_cast<TSrcNonConst *>(Dst))[LinearIndex] = Src[Index];
         });
   }
@@ -811,7 +811,7 @@ private:
                    TDst *Dst) {
     single_task<class __copyAcc2Ptr<TSrc, TDst, Dim, AccMode, AccTarget, IsPH>>(
         [=]() {
-          using TSrcNonConst = typename detail::remove_const_t<TSrc>;
+          using TSrcNonConst = typename std::remove_const_t<TSrc>;
           *(reinterpret_cast<TSrcNonConst *>(Dst)) = *(Src.get_pointer());
         });
   }
@@ -1410,9 +1410,9 @@ private:
       const std::shared_ptr<detail::kernel_bundle_impl> &NewKernelBundleImpPtr);
 
   template <typename FuncT>
-  std::enable_if_t<detail::check_fn_signature<detail::remove_reference_t<FuncT>,
+  std::enable_if_t<detail::check_fn_signature<std::remove_reference_t<FuncT>,
                                               void()>::value ||
-                   detail::check_fn_signature<detail::remove_reference_t<FuncT>,
+                   detail::check_fn_signature<std::remove_reference_t<FuncT>,
                                               void(interop_handle)>::value>
   host_task_impl(FuncT &&Func) {
     throwIfActionIsCreated();
@@ -1494,17 +1494,16 @@ public:
   void depends_on(const std::vector<event> &Events);
 
   template <typename T>
-  using remove_cv_ref_t =
-      typename detail::remove_cv_t<detail::remove_reference_t<T>>;
+  using remove_cv_ref_t = typename std::remove_cv_t<std::remove_reference_t<T>>;
 
   template <typename U, typename T>
   using is_same_type = std::is_same<remove_cv_ref_t<U>, remove_cv_ref_t<T>>;
 
   template <typename T> struct ShouldEnableSetArg {
     static constexpr bool value =
-        std::is_trivially_copyable<detail::remove_reference_t<T>>::value
+        std::is_trivially_copyable<std::remove_reference_t<T>>::value
 #if SYCL_LANGUAGE_VERSION && SYCL_LANGUAGE_VERSION <= 201707
-            && std::is_standard_layout<detail::remove_reference_t<T>>::value
+            && std::is_standard_layout<std::remove_reference_t<T>>::value
 #endif
         || is_same_type<sampler, T>::value // Sampler
         || (!is_same_type<cl_mem, T>::value &&
@@ -1593,9 +1592,9 @@ public:
 
   /// Enqueues a command to the SYCL runtime to invoke \p Func once.
   template <typename FuncT>
-  std::enable_if_t<detail::check_fn_signature<detail::remove_reference_t<FuncT>,
+  std::enable_if_t<detail::check_fn_signature<std::remove_reference_t<FuncT>,
                                               void()>::value ||
-                   detail::check_fn_signature<detail::remove_reference_t<FuncT>,
+                   detail::check_fn_signature<std::remove_reference_t<FuncT>,
                                               void(interop_handle)>::value>
   host_task(FuncT &&Func) {
     host_task_impl(Func);

--- a/sycl/include/sycl/multi_ptr.hpp
+++ b/sycl/include/sycl/multi_ptr.hpp
@@ -173,10 +173,9 @@ public:
            Space == access::address_space::ext_intel_global_device_space) &&
           std::is_const<RelayElementType>::value &&
           std::is_same<RelayElementType, ElementType>::value>>
-  multi_ptr(
-      accessor<typename detail::remove_const_t<RelayElementType>, Dimensions,
-               Mode, access::target::device, isPlaceholder, PropertyListT>
-          Accessor)
+  multi_ptr(accessor<typename std::remove_const_t<RelayElementType>, Dimensions,
+                     Mode, access::target::device, isPlaceholder, PropertyListT>
+                Accessor)
       : multi_ptr(Accessor.get_pointer().get()) {}
 
   // Only if Space == local_space || generic_space and element type is const
@@ -190,10 +189,9 @@ public:
                  Space == access::address_space::local_space) &&
                 std::is_const<RelayElementType>::value &&
                 std::is_same<RelayElementType, ElementType>::value>>
-  multi_ptr(
-      accessor<typename detail::remove_const_t<RelayElementType>, Dimensions,
-               Mode, access::target::local, isPlaceholder, PropertyListT>
-          Accessor)
+  multi_ptr(accessor<typename std::remove_const_t<RelayElementType>, Dimensions,
+                     Mode, access::target::local, isPlaceholder, PropertyListT>
+                Accessor)
       : multi_ptr(Accessor.get_pointer().get()) {}
 
   // Only if Space == local_space || generic_space and element type is const
@@ -205,9 +203,9 @@ public:
                  Space == access::address_space::local_space) &&
                 std::is_const<RelayElementType>::value &&
                 std::is_same<RelayElementType, ElementType>::value>>
-  multi_ptr(local_accessor<typename detail::remove_const_t<RelayElementType>,
-                           Dimensions>
-                Accessor)
+  multi_ptr(
+      local_accessor<typename std::remove_const_t<RelayElementType>, Dimensions>
+          Accessor)
       : multi_ptr(Accessor.get_pointer().get()) {}
 
   // Assignment and access operators
@@ -813,7 +811,7 @@ public:
            Space == access::address_space::global_space ||
            Space == access::address_space::ext_intel_global_device_space) &&
           std::is_const<ET>::value && std::is_same<ET, ElementType>::value>>
-  multi_ptr(accessor<typename detail::remove_const_t<ET>, dimensions, Mode,
+  multi_ptr(accessor<typename std::remove_const_t<ET>, dimensions, Mode,
                      access::target::device, isPlaceholder, PropertyListT>
                 Accessor)
       : multi_ptr(Accessor.get_pointer()) {}
@@ -828,7 +826,7 @@ public:
           (Space == access::address_space::generic_space ||
            Space == access::address_space::local_space) &&
           std::is_const<ET>::value && std::is_same<ET, ElementType>::value>>
-  multi_ptr(accessor<typename detail::remove_const_t<ET>, dimensions, Mode,
+  multi_ptr(accessor<typename std::remove_const_t<ET>, dimensions, Mode,
                      access::target::local, isPlaceholder, PropertyListT>
                 Accessor)
       : multi_ptr(Accessor.get_pointer()) {}
@@ -843,7 +841,7 @@ public:
            Space == access::address_space::local_space) &&
           std::is_const<ET>::value && std::is_same<ET, ElementType>::value>>
   multi_ptr(
-      local_accessor<typename detail::remove_const_t<ET>, dimensions> Accessor)
+      local_accessor<typename std::remove_const_t<ET>, dimensions> Accessor)
       : multi_ptr(Accessor.get_pointer()) {}
 
   // Only if Space == constant_space and element type is const
@@ -855,7 +853,7 @@ public:
           _Space == Space && Space == access::address_space::constant_space &&
           std::is_const<ET>::value && std::is_same<ET, ElementType>::value>>
   multi_ptr(
-      accessor<typename detail::remove_const_t<ET>, dimensions, Mode,
+      accessor<typename std::remove_const_t<ET>, dimensions, Mode,
                access::target::constant_buffer, isPlaceholder, PropertyListT>
           Accessor)
       : multi_ptr(Accessor.get_pointer()) {}
@@ -871,7 +869,7 @@ public:
   template <typename ET = ElementType>
   multi_ptr(typename std::enable_if_t<
             std::is_const<ET>::value && std::is_same<ET, ElementType>::value,
-            const multi_ptr<typename detail::remove_const_t<ET>, Space,
+            const multi_ptr<typename std::remove_const_t<ET>, Space,
                             access::decorated::legacy>> &ETP)
       : m_Pointer(ETP.get()) {}
 

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -740,9 +740,9 @@ public:
   single_task(PropertiesT Properties,
               _KERNELFUNCPARAM(KernelFunc) _CODELOCPARAM(&CodeLoc)) {
     static_assert(
-        (detail::check_fn_signature<detail::remove_reference_t<KernelType>,
+        (detail::check_fn_signature<std::remove_reference_t<KernelType>,
                                     void()>::value ||
-         detail::check_fn_signature<detail::remove_reference_t<KernelType>,
+         detail::check_fn_signature<std::remove_reference_t<KernelType>,
                                     void(kernel_handler)>::value),
         "sycl::queue.single_task() requires a kernel instead of command group. "
         "Use queue.submit() instead");
@@ -779,9 +779,9 @@ public:
   single_task(event DepEvent, PropertiesT Properties,
               _KERNELFUNCPARAM(KernelFunc) _CODELOCPARAM(&CodeLoc)) {
     static_assert(
-        (detail::check_fn_signature<detail::remove_reference_t<KernelType>,
+        (detail::check_fn_signature<std::remove_reference_t<KernelType>,
                                     void()>::value ||
-         detail::check_fn_signature<detail::remove_reference_t<KernelType>,
+         detail::check_fn_signature<std::remove_reference_t<KernelType>,
                                     void(kernel_handler)>::value),
         "sycl::queue.single_task() requires a kernel instead of command group. "
         "Use queue.submit() instead");
@@ -822,9 +822,9 @@ public:
   single_task(const std::vector<event> &DepEvents, PropertiesT Properties,
               _KERNELFUNCPARAM(KernelFunc) _CODELOCPARAM(&CodeLoc)) {
     static_assert(
-        (detail::check_fn_signature<detail::remove_reference_t<KernelType>,
+        (detail::check_fn_signature<std::remove_reference_t<KernelType>,
                                     void()>::value ||
-         detail::check_fn_signature<detail::remove_reference_t<KernelType>,
+         detail::check_fn_signature<std::remove_reference_t<KernelType>,
                                     void(kernel_handler)>::value),
         "sycl::queue.single_task() requires a kernel instead of command group. "
         "Use queue.submit() instead");

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -718,7 +718,7 @@ public:
   template <typename Ty = DataT>
   typename std::enable_if_t<
       std::is_fundamental<vec_data_t<Ty>>::value ||
-          std::is_same<typename detail::remove_const_t<Ty>, half>::value,
+          std::is_same<typename std::remove_const_t<Ty>, half>::value,
       vec &>
   operator=(const EnableIfNotHostHalf<Ty> &Rhs) {
     m_Data = (DataType)vec_data<Ty>::get(Rhs);
@@ -735,7 +735,7 @@ public:
   template <typename Ty = DataT>
   typename std::enable_if_t<
       std::is_fundamental<vec_data_t<Ty>>::value ||
-          std::is_same<typename detail::remove_const_t<Ty>, half>::value,
+          std::is_same<typename std::remove_const_t<Ty>, half>::value,
       vec &>
   operator=(const EnableIfHostHalf<Ty> &Rhs) {
     for (int i = 0; i < NumElements; ++i) {
@@ -753,7 +753,7 @@ public:
   template <typename Ty = DataT>
   typename std::enable_if_t<
       std::is_fundamental<vec_data_t<Ty>>::value ||
-          std::is_same<typename detail::remove_const_t<Ty>, half>::value,
+          std::is_same<typename std::remove_const_t<Ty>, half>::value,
       vec &>
   operator=(const DataT &Rhs) {
     for (int i = 0; i < NumElements; ++i) {
@@ -1002,7 +1002,7 @@ public:
   typename std::enable_if_t<                                                   \
       std::is_convertible<DataT, T>::value &&                                  \
           (std::is_fundamental<vec_data_t<T>>::value ||                        \
-           std::is_same<typename detail::remove_const_t<T>, half>::value),     \
+           std::is_same<typename std::remove_const_t<T>, half>::value),        \
       vec>                                                                     \
   operator BINOP(const T &Rhs) const {                                         \
     return *this BINOP vec(static_cast<const DataT &>(Rhs));                   \
@@ -1030,7 +1030,7 @@ public:
   typename std::enable_if_t<                                                   \
       std::is_convertible<DataT, T>::value &&                                  \
           (std::is_fundamental<vec_data_t<T>>::value ||                        \
-           std::is_same<typename detail::remove_const_t<T>, half>::value),     \
+           std::is_same<typename std::remove_const_t<T>, half>::value),        \
       vec>                                                                     \
   operator BINOP(const T &Rhs) const {                                         \
     return *this BINOP vec(static_cast<const DataT &>(Rhs));                   \
@@ -1437,13 +1437,13 @@ class SwizzleOp {
   using EnableIfScalarType = typename std::enable_if_t<
       std::is_convertible<DataT, T>::value &&
       (std::is_fundamental<vec_data_t<T>>::value ||
-       std::is_same<typename detail::remove_const_t<T>, half>::value)>;
+       std::is_same<typename std::remove_const_t<T>, half>::value)>;
 
   template <typename T>
   using EnableIfNoScalarType = typename std::enable_if_t<
       !std::is_convertible<DataT, T>::value ||
       !(std::is_fundamental<vec_data_t<T>>::value ||
-        std::is_same<typename detail::remove_const_t<T>, half>::value)>;
+        std::is_same<typename std::remove_const_t<T>, half>::value)>;
 
   template <int... Indices>
   using Swizzle =
@@ -1980,7 +1980,7 @@ private:
   template <typename T, int Num>                                               \
   typename std::enable_if_t<                                                   \
       std::is_fundamental<vec_data_t<T>>::value ||                             \
-          std::is_same<typename detail::remove_const_t<T>, half>::value,       \
+          std::is_same<typename std::remove_const_t<T>, half>::value,          \
       vec<T, Num>>                                                             \
   operator BINOP(const T &Lhs, const vec<T, Num> &Rhs) {                       \
     return vec<T, Num>(Lhs) BINOP Rhs;                                         \
@@ -1992,7 +1992,7 @@ private:
   typename std::enable_if_t<                                                   \
       std::is_convertible<T, T1>::value &&                                     \
           (std::is_fundamental<vec_data_t<T>>::value ||                        \
-           std::is_same<typename detail::remove_const_t<T>, half>::value),     \
+           std::is_same<typename std::remove_const_t<T>, half>::value),        \
       vec<T1, Num>>                                                            \
   operator BINOP(                                                              \
       const T &Lhs,                                                            \
@@ -2035,7 +2035,7 @@ __SYCL_BINOP(<<)
   typename std::enable_if_t<                                                   \
       std::is_convertible<T, DataT>::value &&                                  \
           (std::is_fundamental<vec_data_t<T>>::value ||                        \
-           std::is_same<typename detail::remove_const_t<T>, half>::value),     \
+           std::is_same<typename std::remove_const_t<T>, half>::value),        \
       vec<detail::rel_t<DataT>, Num>>                                          \
   operator RELLOGOP(const T &Lhs, const vec<DataT, Num> &Rhs) {                \
     return vec<T, Num>(static_cast<T>(Lhs)) RELLOGOP Rhs;                      \
@@ -2047,7 +2047,7 @@ __SYCL_BINOP(<<)
   typename std::enable_if_t<                                                   \
       std::is_convertible<T, T1>::value &&                                     \
           (std::is_fundamental<vec_data_t<T>>::value ||                        \
-           std::is_same<typename detail::remove_const_t<T>, half>::value),     \
+           std::is_same<typename std::remove_const_t<T>, half>::value),        \
       vec<detail::rel_t<T1>, Num>>                                             \
   operator RELLOGOP(                                                           \
       const T &Lhs,                                                            \

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -644,7 +644,7 @@ RT::PiDeviceBinaryType getBinaryImageFormat(const unsigned char *ImgData,
               {PI_DEVICE_BINARY_TYPE_NATIVE, 0x43544E49}};
 
   if (ImgSize >= sizeof(Fmts[0].Magic)) {
-    detail::remove_const_t<decltype(Fmts[0].Magic)> Hdr = 0;
+    std::remove_const_t<decltype(Fmts[0].Magic)> Hdr = 0;
     std::copy(ImgData, ImgData + sizeof(Hdr), reinterpret_cast<char *>(&Hdr));
 
     // Check headers for direct formats.


### PR DESCRIPTION
Didn't touch `detail::remove_pointer` in `syc/detail/type_traits.hpp`
(as opposite to `stl_type_traits.hpp`) as its behavior seems to differ
from that of `std::remove_pointer`. Will look into it separately in a
distinct PR.
