### PR TITLE
[SPIR-V] W/A for builtin vars translation

### DIFF
--- a/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
@@ -1823,8 +1823,9 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
       std::vector<Instruction *> Loads;
       auto *GVTy = GV->getType();
       auto *VecTy = GVTy->isOpaquePointerTy()
-          ? nullptr
-          : dyn_cast<FixedVectorType>(GVTy->getNonOpaquePointerElementType());
+                        ? nullptr
+                        : dyn_cast<FixedVectorType>(
+                              GVTy->getNonOpaquePointerElementType());
       auto ReplaceIfLoad = [&](User *I) -> void {
         auto *LD = dyn_cast<LoadInst>(I);
         if (!LD)

--- a/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
@@ -1817,7 +1817,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
 
     // TODO: it's W/A for intel/llvm to prevent not fixed SPIR-V consumers
     // from crashing. Need to remove, when we have the fixed drivers
-    // to remove: being
+    // to remove: begin
     {
       std::vector<Instruction *> GEPs;
       std::vector<Instruction *> Loads;
@@ -1826,15 +1826,14 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
                         ? nullptr
                         : dyn_cast<FixedVectorType>(
                               GVTy->getNonOpaquePointerElementType());
-      auto ReplaceIfLoad = [&](User *I) -> void {
+      auto ReplaceIfLoad = [&](User *I, ConstantInt *Idx) -> void {
         auto *LD = dyn_cast<LoadInst>(I);
         if (!LD)
           return;
         Loads.push_back(LD);
         const DebugLoc &DLoc = LD->getDebugLoc();
         LoadInst *Load = new LoadInst(VecTy, GV, "", LD);
-        auto *Zero = ConstantInt::get(Type::getInt32Ty(GV->getContext()), 0);
-        ExtractElementInst *Extract = ExtractElementInst::Create(Load, Zero);
+        ExtractElementInst *Extract = ExtractElementInst::Create(Load, Idx);
         if (DLoc)
           Extract->setDebugLoc(DLoc);
         Extract->insertAfter(cast<Instruction>(Load));
@@ -1845,8 +1844,12 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
           break;
         if (auto *GEP = dyn_cast<GetElementPtrInst>(UI)) {
           GEPs.push_back(GEP);
-          for (auto *GEPUser : GEP->users())
-            ReplaceIfLoad(GEPUser);
+          for (auto *GEPUser : GEP->users()) {
+            assert(GEP->getNumIndices() == 2 &&
+                   "GEP to ID vector is expected to have exactly 2 indices");
+            auto *Idx = cast<ConstantInt>(GEP->getOperand(2));
+            ReplaceIfLoad(GEPUser, Idx);
+          }
         }
       }
       auto Erase = [](std::vector<Instruction *> &ToErase) {

--- a/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
@@ -1816,6 +1816,7 @@ LLVMToSPIRVBase::transValueWithoutDecoration(Value *V, SPIRVBasicBlock *BB,
     }
 
     // TODO: it's W/A for intel/llvm to prevent not fixed SPIR-V consumers
+    // see https://github.com/intel/llvm/issues/7592
     // from crashing. Need to remove, when we have the fixed drivers
     // to remove: begin
     {

--- a/llvm-spirv/test/transcoding/builtin_vars_gep.ll
+++ b/llvm-spirv/test/transcoding/builtin_vars_gep.ll
@@ -28,7 +28,7 @@ entry:
   ; CHECK-OCL-IR: %[[#VEC2:]] = insertelement <3 x i64> %[[#VEC1]], i64 %[[#ID2]], i32 1
   ; CHECK-OCL-IR: %[[#ID3:]] = call spir_func i64 @_Z13get_global_idj(i32 2)
   ; CHECK-OCL-IR: %[[#VEC3:]] = insertelement <3 x i64> %[[#VEC2]], i64 %[[#ID3]], i32 2
-  ; CHECK-OCL-IR: %[[#]] = extractelement <3 x i64> %[[#VEC3]], i64 0
+  ; CHECK-OCL-IR: %[[#]] = extractelement <3 x i64> %[[#VEC3]], i32 0
 
   ; CHECK-SPV-IR: %[[#ID1:]] = call spir_func i64 @_Z33__spirv_BuiltInGlobalInvocationIdi(i32 0)
   ; CHECK-SPV-IR: %[[#VEC1:]] = insertelement <3 x i64> undef, i64 %[[#ID1]], i32 0
@@ -36,7 +36,7 @@ entry:
   ; CHECK-SPV-IR: %[[#VEC2:]] = insertelement <3 x i64> %[[#VEC1]], i64 %[[#ID2]], i32 1
   ; CHECK-SPV-IR: %[[#ID3:]] = call spir_func i64 @_Z33__spirv_BuiltInGlobalInvocationIdi(i32 2)
   ; CHECK-SPV-IR: %[[#VEC3:]] = insertelement <3 x i64> %[[#VEC2]], i64 %[[#ID3]], i32 2
-  ; CHECK-SPV-IR: %[[#]] = extractelement <3 x i64> %[[#VEC3]], i64 0
+  ; CHECK-SPV-IR: %[[#]] = extractelement <3 x i64> %[[#VEC3]], i32 0
 
   ret void
 }


### PR DESCRIPTION
The translator was crashing in case if builin GV was accessed via GEP without AS cast due to incorrect assumption. The W/A replaced GEP with ExtractElementInst.

This W/A is exclusive for intel/llvm . Proper fix is done in SPIR-V consumer, but it will take take time to have the drivers be updated in CI.

Signed-off-by: Sidorov, Dmitry <dmitry.sidorov@intel.com>