### PR TITLE
[Dont Merge] Expose hash of last clang commit used in build during cmake run

### DIFF
--- a/clang/CMakeLists.txt
+++ b/clang/CMakeLists.txt
@@ -1013,6 +1013,13 @@ endif()
 
 set(CLANG_INSTALL_LIBDIR_BASENAME "lib${CLANG_LIBDIR_SUFFIX}")
 
+#set the variable for the last clang hash used in build
+execute_process(COMMAND git merge-base origin/xmain origin/main
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                OUTPUT_VARIABLE LLVM_MAIN_HASH
+                ERROR_VARIABLE LLVM_MAIN_HASH_ERROR
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+
 configure_file(
   ${CLANG_SOURCE_DIR}/include/clang/Config/config.h.cmake
   ${CLANG_BINARY_DIR}/include/clang/Config/config.h)

--- a/clang/include/clang/Config/config.h.cmake
+++ b/clang/include/clang/Config/config.h.cmake
@@ -83,4 +83,7 @@
 /* Whether to enable opaque pointers by default */
 #cmakedefine01 CLANG_ENABLE_OPAQUE_POINTERS_INTERNAL
 
+/* Store the hash of the last clang commit used in build */
+#define LLVM_MAIN_HASH "${LLVM_MAIN_HASH}"
+
 #endif


### PR DESCRIPTION
Export the hash of the last clang commit used in the build to LLVM_MAIN_HASH

the has is found by running git merge-base origin/xmain origin/main

This is part of larger request to expose out which version of clang is being used in the build so its easier for users to tell



