### PR TITLE
[SYCL] Don't use C++17 CTAD causing post-commit failures

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -501,7 +501,7 @@ struct _pi_queue {
 
   template <typename T> bool all_of(T &&f) {
     {
-      std::lock_guard compute_guard(compute_stream_mutex_);
+      std::lock_guard<std::mutex> compute_guard(compute_stream_mutex_);
       unsigned int end =
           std::min(static_cast<unsigned int>(compute_streams_.size()),
                    num_compute_streams_);
@@ -510,7 +510,7 @@ struct _pi_queue {
         return false;
     }
     {
-      std::lock_guard transfer_guard(transfer_stream_mutex_);
+      std::lock_guard<std::mutex> transfer_guard(transfer_stream_mutex_);
       unsigned int end =
           std::min(static_cast<unsigned int>(transfer_streams_.size()),
                    num_transfer_streams_);

--- a/sycl/plugins/hip/pi_hip.hpp
+++ b/sycl/plugins/hip/pi_hip.hpp
@@ -480,7 +480,7 @@ struct _pi_queue {
 
   template <typename T> bool all_of(T &&f) {
     {
-      std::lock_guard compute_guard(compute_stream_mutex_);
+      std::lock_guard<std::mutex> compute_guard(compute_stream_mutex_);
       unsigned int end =
           std::min(static_cast<unsigned int>(compute_streams_.size()),
                    num_compute_streams_);
@@ -489,7 +489,7 @@ struct _pi_queue {
         return false;
     }
     {
-      std::lock_guard transfer_guard(transfer_stream_mutex_);
+      std::lock_guard<std::mutex> transfer_guard(transfer_stream_mutex_);
       unsigned int end =
           std::min(static_cast<unsigned int>(transfer_streams_.size()),
                    num_transfer_streams_);

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -404,7 +404,7 @@ bool queue_impl::ext_oneapi_empty() const {
   // If we have in-order queue where events are not discarded then just check
   // the status of the last event.
   if (isInOrder() && !MDiscardEvents) {
-    std::lock_guard Lock(MLastEventMtx);
+    std::lock_guard<std::mutex> Lock(MLastEventMtx);
     return MLastEvent.get_info<info::event::command_execution_status>() ==
            info::event_command_status::complete;
   }
@@ -421,7 +421,7 @@ bool queue_impl::ext_oneapi_empty() const {
 
   // We may have events like host tasks which are not submitted to the backend
   // queue so we need to get their status separately.
-  std::lock_guard Lock(MMutex);
+  std::lock_guard<std::mutex> Lock(MMutex);
   for (event Event : MEventsShared)
     if (Event.get_info<info::event::command_execution_status>() !=
         info::event_command_status::complete)


### PR DESCRIPTION
Using C++17 results in post-commit failures: https://github.com/intel/llvm/actions/runs/3617075742/jobs/6095609311
