### PR TITLE
[SYCL-MLIR] Add support for sycl::detail::SwizzleOp

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -308,6 +308,13 @@ def SYCL_VecType : SYCL_Type<"Vec", "vec"> {
   let genVerifyDecl = 1;
 }
 
+def SYCL_SwizzledVecType : SYCL_Type<"SwizzledVec", "swizzled_vec"> {
+  let parameters = (ins "::mlir::sycl::VecType":$vecType,
+                        ArrayRefParameter<"int">:$indexes,
+                        ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<` `[` $vecType `,` $indexes `]` `,` `(` $body `)` `>`";
+}
+
 // Define MemRef types (alphabetical order).
 def AccessorCommonMemRef : MemRefOf<[SYCL_AccessorCommonType]>;
 def AccessorImplDeviceMemRef : MemRefOf<[SYCL_AccessorImplDeviceType]>;
@@ -315,16 +322,16 @@ def AccessorMemRef : MemRefOf<[SYCL_AccessorType]>;
 def AccessorSubscriptMemRef : MemRefOf<[SYCL_AccessorSubscriptType]>;
 def ArrayMemRef : MemRefOf<[SYCL_ArrayType]>;
 def AtomicMemRef : MemRefOf<[SYCL_AtomicType]>;
+def GetOpMemRef : MemRefOf<[SYCL_GetOpType]>;
+def GetScalarOpMemRef : MemRefOf<[SYCL_GetScalarOpType]>;
 def GroupMemRef : MemRefOf<[SYCL_GroupType]>;
 def IDMemRef : MemRefOf<[SYCL_IDType]>;
 def ItemBaseMemRef : MemRefOf<[SYCL_ItemBaseType]>;
 def ItemMemRef : MemRefOf<[SYCL_ItemType]>;
 def MultiPtrMemRef : MemRefOf<[SYCL_MultiPtrType]>;
 def NDItemMemRef : MemRefOf<[SYCL_NdItemType]>;
-def NDRangeMemRef : MemRefOf<[SYCL_NdRangeType]>;
-def OwnerLessBaseMemRef : MemRefOf<[SYCL_OwnerLessBaseType]>;
-def RangeMemRef : MemRefOf<[SYCL_RangeType]>;
 def VecMemRef : MemRefOf<[SYCL_VecType]>;
+def SwizzledVecMemRef : MemRefOf<[SYCL_SwizzledVecType]>;
 
 def SYCLMemref : AnyTypeOf<[
   // Keep in alphabetical order.
@@ -334,6 +341,8 @@ def SYCLMemref : AnyTypeOf<[
   AccessorSubscriptMemRef,
   ArrayMemRef,
   AtomicMemRef,
+  GetOpMemRef,
+  GetScalarOpMemRef,
   GroupMemRef,  
   IDMemRef,
   ItemBaseMemRef,
@@ -343,6 +352,7 @@ def SYCLMemref : AnyTypeOf<[
   NDRangeMemRef,
   OwnerLessBaseMemRef,
   RangeMemRef,
+  SwizzledVecMemRef,
   VecMemRef
 ]>;
 

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -285,6 +285,13 @@ def SYCL_SubGroupType : SYCL_Type<"SubGroup", "sub_group"> {
   let assemblyFormat = "";
 }
 
+def SYCL_SwizzledVecType : SYCL_Type<"SwizzledVec", "swizzled_vec"> {
+  let parameters = (ins "::mlir::sycl::VecType":$vecType,
+                        ArrayRefParameter<"int">:$indexes,
+                        ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<` `[` $vecType `,` $indexes `]` `,` `(` $body `)` `>`";
+}
+
 def SYCL_TupleCopyAssignableValueHolderType
     : SYCL_Type<"TupleCopyAssignableValueHolder", "tuple_copy_assignable_value_holder",
         [SYCLInheritanceTypeTrait<"TupleValueHolderType">]> {
@@ -306,13 +313,6 @@ def SYCL_VecType : SYCL_Type<"Vec", "vec"> {
                         ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dataType `,` $numElements `]` `,` `(` $body `)` `>`";
   let genVerifyDecl = 1;
-}
-
-def SYCL_SwizzledVecType : SYCL_Type<"SwizzledVec", "swizzled_vec"> {
-  let parameters = (ins "::mlir::sycl::VecType":$vecType,
-                        ArrayRefParameter<"int">:$indexes,
-                        ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<` `[` $vecType `,` $indexes `]` `,` `(` $body `)` `>`";
 }
 
 // Define MemRef types (alphabetical order).

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -330,8 +330,11 @@ def ItemBaseMemRef : MemRefOf<[SYCL_ItemBaseType]>;
 def ItemMemRef : MemRefOf<[SYCL_ItemType]>;
 def MultiPtrMemRef : MemRefOf<[SYCL_MultiPtrType]>;
 def NDItemMemRef : MemRefOf<[SYCL_NdItemType]>;
-def VecMemRef : MemRefOf<[SYCL_VecType]>;
+def NDRangeMemRef : MemRefOf<[SYCL_NdRangeType]>;
+def OwnerLessBaseMemRef : MemRefOf<[SYCL_OwnerLessBaseType]>;
+def RangeMemRef : MemRefOf<[SYCL_RangeType]>;
 def SwizzledVecMemRef : MemRefOf<[SYCL_SwizzledVecType]>;
+def VecMemRef : MemRefOf<[SYCL_VecType]>;
 
 def SYCLMemref : AnyTypeOf<[
   // Keep in alphabetical order.

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -274,6 +274,13 @@ static Optional<Type> convertVecType(sycl::VecType type,
   return convertBodyType("class.sycl::_V1::vec", type.getBody(), converter);
 }
 
+/// Converts SYCL vec type to LLVM type.
+static Optional<Type> convertSwizzledVecType(sycl::SwizzledVecType type,
+                                             LLVMTypeConverter &converter) {
+  return convertBodyType("class.sycl::_V1::detail::SwizzleOp", type.getBody(),
+                         converter);
+}
+
 /// Converts SYCL atomic type to LLVM type.
 static Optional<Type> convertAtomicType(sycl::AtomicType type,
                                         LLVMTypeConverter &converter) {
@@ -531,6 +538,9 @@ void mlir::sycl::populateSYCLToLLVMTypeConversion(
       });
   typeConverter.addConversion(
       [&](sycl::VecType type) { return convertVecType(type, typeConverter); });
+  typeConverter.addConversion([&](sycl::SwizzledVecType type) {
+    return convertSwizzledVecType(type, typeConverter);
+  });
   typeConverter.addConversion([&](sycl::AtomicType type) {
     return convertAtomicType(type, typeConverter);
   });

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
@@ -181,6 +181,12 @@ SYCLOpAsmInterface::getAlias(mlir::Type Type, llvm::raw_ostream &OS) const {
            << "_";
         return AliasResult::OverridableAlias;
       })
+      .Case<mlir::sycl::SwizzledVecType>([&](auto Ty) {
+        const auto VecTy = Ty.getVecType();
+        OS << "sycl_" << decltype(Ty)::getMnemonic() << "_"
+           << VecTy.getDataType() << "_" << VecTy.getNumElements() << "_";
+        return AliasResult::OverridableAlias;
+      })
       .Default([](auto) { return AliasResult::NoAlias; });
 }
 } // namespace

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
@@ -188,12 +188,6 @@ func.func @test_multi_ptr(%arg0: !sycl_multi_ptr_i32_1_) {
     return
 }
 
-!sycl_swizzled_vec_f32_4_ = !sycl.swizzled_vec<[!sycl_vec_f32_4_, 0, 2], (memref<?x!sycl_vec_f32_4_, 4>, !sycl.get_op<i8>, !sycl.get_op<i8>)>
-// CHECK: llvm.func @test_swizzled_vec(%arg0: !llvm.[[SWIZZLED_VEC:struct<"class.sycl::_V1::detail::SwizzleOp"]], (struct<(ptr<[[VEC]], 4>, ptr<[[VEC]], 4>, i64, array<1 x i64>, array<1 x i64>)>, [[GET_OP]], [[GET_OP]][[SUFFIX]]) {
-func.func @test_swizzled_vec(%arg0: !sycl_swizzled_vec_f32_4_) {
-  return
-}
-
 // -----
 
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
@@ -236,6 +230,11 @@ func.func @test_tuple_copy_assignable_value_holder(%arg0: !sycl_tuple_copy_assig
 !sycl_vec_f32_4_ = !sycl.vec<[f32, 4], (vector<4xf32>)>
 // CHECK: llvm.func @test_vec(%arg0: !llvm.[[VEC:struct<"class.sycl::_V1::vec", \(vector<4xf32>\)>]])
 func.func @test_vec(%arg0: !sycl_vec_f32_4_) {
+  return
+}
+!sycl_swizzled_vec_f32_4_ = !sycl.swizzled_vec<[!sycl_vec_f32_4_, 0, 2], (memref<?x!sycl_vec_f32_4_, 4>, !sycl.get_op<i8>, !sycl.get_op<i8>)>
+// CHECK: llvm.func @test_swizzled_vec(%arg0: !llvm.[[SWIZZLED_VEC:struct<"class.sycl::_V1::detail::SwizzleOp"]], (struct<(ptr<[[VEC]], 4>, ptr<[[VEC]], 4>, i64, array<1 x i64>, array<1 x i64>)>, [[GET_OP]], [[GET_OP]][[SUFFIX]]) {
+func.func @test_swizzled_vec(%arg0: !sycl_swizzled_vec_f32_4_) {
   return
 }
 

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
@@ -188,6 +188,12 @@ func.func @test_multi_ptr(%arg0: !sycl_multi_ptr_i32_1_) {
     return
 }
 
+!sycl_swizzled_vec_f32_4_ = !sycl.swizzled_vec<[!sycl_vec_f32_4_, 0, 2], (memref<?x!sycl_vec_f32_4_, 4>, !sycl.get_op<i8>, !sycl.get_op<i8>)>
+// CHECK: llvm.func @test_swizzled_vec(%arg0: !llvm.[[SWIZZLED_VEC:struct<"class.sycl::_V1::detail::SwizzleOp"]], (struct<(ptr<[[VEC]], 4>, ptr<[[VEC]], 4>, i64, array<1 x i64>, array<1 x i64>)>, [[GET_OP]], [[GET_OP]][[SUFFIX]]) {
+func.func @test_swizzled_vec(%arg0: !sycl_swizzled_vec_f32_4_) {
+  return
+}
+
 // -----
 
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>

--- a/mlir-sycl/test/Dialect/IR/SYCL/types.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/types.mlir
@@ -175,8 +175,6 @@ func.func @get_op(%arg0: !sycl.get_op<i32>) attributes {llvm.linkage = #llvm.lin
   return
 }
 
-// -----
-
 ////////////////////////////////////////////////////////////////////////////////
 // GET_SCALAR_OP
 ////////////////////////////////////////////////////////////////////////////////
@@ -187,8 +185,6 @@ func.func @get_op(%arg0: !sycl.get_op<i32>) attributes {llvm.linkage = #llvm.lin
 func.func @get_scalar_op(%arg0: !sycl_get_scalar_op_i32_) attributes {llvm.linkage = #llvm.linkage<external>} {
   return
 }
-
-// -----
 
 ////////////////////////////////////////////////////////////////////////////////
 // VEC
@@ -205,6 +201,24 @@ func.func @vec_0(%arg0: !sycl_vec_i32_2_) attributes {llvm.linkage = #llvm.linka
 func.func @vec_1(%arg0: !sycl_vec_f32_4_) attributes {llvm.linkage = #llvm.linkage<external>} {
   return
 }
+
+////////////////////////////////////////////////////////////////////////////////
+// SWIZZLED_VEC
+////////////////////////////////////////////////////////////////////////////////
+
+!sycl_swizzled_vec_i32_2_ = !sycl.swizzled_vec<[!sycl_vec_i32_2_, 0, 1], (memref<?x!sycl_vec_i32_2_, 4>, !sycl.get_op<i8>, !sycl.get_op<i8>)>
+!sycl_swizzled_vec_i32_2_1 = !sycl.swizzled_vec<[!sycl_vec_i32_2_, 0, 1], (memref<?x!sycl_vec_i32_2_, 4>, !sycl_swizzled_vec_i32_2_, !sycl_get_scalar_op_i32_)>
+
+// CHECK: func @swizzled_vec_0(%arg0: !sycl_swizzled_vec_i32_2_)
+func.func @swizzled_vec_0(%arg0: !sycl_swizzled_vec_i32_2_) attributes {llvm.linkage = #llvm.linkage<external>} {
+  return
+}
+// CHECK: func @swizzled_vec_1(%arg0: !sycl_swizzled_vec_i32_2_1)
+func.func @swizzled_vec_1(%arg0: !sycl_swizzled_vec_i32_2_1) attributes {llvm.linkage = #llvm.linkage<external>} {
+  return
+}
+
+// -----
 
 ////////////////////////////////////////////////////////////////////////////////
 // ATOMIC

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1351,7 +1351,7 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
           TypeName == "minimum" || TypeName == "multi_ptr" ||
           TypeName == "nd_item" || TypeName == "nd_range" ||
           TypeName == "OwnerLessBase" || TypeName == "range" ||
-          TypeName == "sub_group" ||
+          TypeName == "sub_group" || TypeName == "SwizzleOp" ||
           TypeName == "TupleCopyAssignableValueHolder" ||
           TypeName == "TupleValueHolder" || TypeName == "vec") {
         return getSYCLType(RT, *this);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1445,9 +1445,11 @@ ValueCategory MLIRScanner::CommonFieldLookup(clang::QualType CT,
                   sycl::AccessorSubscriptType, sycl::AtomicType,
                   sycl::GetScalarOpType, sycl::GroupType, sycl::ItemBaseType,
                   sycl::ItemType, sycl::MultiPtrType, sycl::NdItemType,
-                  sycl::NdRangeType, sycl::VecType>([&](auto ElemTy) {
-              return SYCLCommonFieldLookup<decltype(ElemTy)>(Val, FNum, Shape);
-            })
+                  sycl::NdRangeType, sycl::SwizzledVecType, sycl::VecType>(
+                [&](auto ElemTy) {
+                  return SYCLCommonFieldLookup<decltype(ElemTy)>(Val, FNum,
+                                                                 Shape);
+                })
             .Default([&Val](Type T) {
               llvm_unreachable("not implemented");
               return Val;

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -31,6 +31,7 @@
 // CHECK-DAG: [[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_FALSE:!sycl_tuple_copy_assignable_value_holder_i32_.*]] = !sycl.tuple_copy_assignable_value_holder<[i32, false], (!sycl_tuple_value_holder_i32_)>
 // CHECK-DAG: !sycl_vec_f32_8_ = !sycl.vec<[f32, 8], (vector<8xf32>)>
 // CHECK-DAG: !sycl_vec_i32_4_ = !sycl.vec<[i32, 4], (vector<4xi32>)>
+// CHECK-DAG: !sycl_swizzled_vec_f32_8_ = !sycl.swizzled_vec<[!sycl_vec_f32_8_, 0, 1, 2], (memref<?x!sycl_vec_f32_8_, 4>, !sycl.get_op<f32>, !sycl.get_op<f32>)>
 // CHECK-DAG: !sycl_atomic_f32_3_ = !sycl.atomic<[f32,3], (memref<?xf32, 3>)>
 // CHECK-DAG: !sycl_atomic_i32_1_ = !sycl.atomic<[i32,1], (memref<?xi32, 1>)>
 // CHECK-DAG: !sycl_assert_happened_ = !sycl.assert_happened<(i32, !llvm.array<257 x i8>, !llvm.array<257 x i8>, !llvm.array<129 x i8>, i32, i64, i64, i64, i64, i64, i64)>
@@ -170,6 +171,15 @@ SYCL_EXTERNAL void vec_3(sycl::vec<sycl::cl_int, 4> vec) {}
 // CHECK-SAME:    %arg0: memref<?x!sycl_vec_f32_8_> {llvm.align = 32 : i64, llvm.byval = !sycl_vec_f32_8_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
 SYCL_EXTERNAL void vec_4(sycl::float8 vec) {}
+
+//#define SYCL_SIMPLE_SWIZZLES
+
+// CHECK-LABEL: func.func @_Z12swizzled_vecN4sycl3_V16detail9SwizzleOpINS0_3vecIfLi8EEENS1_5GetOpIfEES6_S5_JLi0ELi1ELi2EEEE(
+// CHECK-SAME:    %arg0: memref<?x!sycl_swizzled_vec_f32_8_> {llvm.noundef})
+// CHECK-SAME:  attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void swizzled_vec(sycl::detail::SwizzleOp<sycl::float8, sycl::detail::GetOp<float>, sycl::detail::GetOp<float>, sycl::detail::GetOp, 0, 1, 2> swizzle) {}
+
+//#undef SYCL_SIMPLE_SWIZZLES
 
 // CHECK-LABEL: func.func @_Z8atomic_1N4sycl3_V16atomicIiLNS0_6access13address_spaceE1EEE(
 // CHECK:          %arg0: memref<?x!sycl_atomic_i32_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_atomic_i32_1_, llvm.noundef})

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -25,7 +25,7 @@
 // CHECK-DAG: !sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 // CHECK-DAG: !sycl_nd_range_2_ = !sycl.nd_range<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
 // CHECK-DAG: !sycl_get_scalar_op_i32_ = !sycl.get_scalar_op<[i32], (i32)>
-// CHECK-DAG: !sycl_h_item_1_ = !sycl.h_item<[1], (!sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>)>, !sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>)>, !sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>)>)>
+// CHECK-DAG: !sycl_h_item_1_ = !sycl.h_item<[1], (!sycl_item_1_1, !sycl_item_1_1, !sycl_item_1_1)>
 // CHECK-DAG: !sycl_tuple_value_holder_i32_ = !sycl.tuple_value_holder<[i32], (i32)>
 // CHECK-DAG: [[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_TRUE:!sycl_tuple_copy_assignable_value_holder_i32_.*]] = !sycl.tuple_copy_assignable_value_holder<[i32, true], (!sycl_tuple_value_holder_i32_)>
 // CHECK-DAG: [[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_FALSE:!sycl_tuple_copy_assignable_value_holder_i32_.*]] = !sycl.tuple_copy_assignable_value_holder<[i32, false], (!sycl_tuple_value_holder_i32_)>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -172,14 +172,10 @@ SYCL_EXTERNAL void vec_3(sycl::vec<sycl::cl_int, 4> vec) {}
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
 SYCL_EXTERNAL void vec_4(sycl::float8 vec) {}
 
-//#define SYCL_SIMPLE_SWIZZLES
-
 // CHECK-LABEL: func.func @_Z12swizzled_vecN4sycl3_V16detail9SwizzleOpINS0_3vecIfLi8EEENS1_5GetOpIfEES6_S5_JLi0ELi1ELi2EEEE(
 // CHECK-SAME:    %arg0: memref<?x!sycl_swizzled_vec_f32_8_> {llvm.noundef})
 // CHECK-SAME:  attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
 SYCL_EXTERNAL void swizzled_vec(sycl::detail::SwizzleOp<sycl::float8, sycl::detail::GetOp<float>, sycl::detail::GetOp<float>, sycl::detail::GetOp, 0, 1, 2> swizzle) {}
-
-//#undef SYCL_SIMPLE_SWIZZLES
 
 // CHECK-LABEL: func.func @_Z8atomic_1N4sycl3_V16atomicIiLNS0_6access13address_spaceE1EEE(
 // CHECK:          %arg0: memref<?x!sycl_atomic_i32_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_atomic_i32_1_, llvm.noundef})


### PR DESCRIPTION
Define this type as swizzled_vec in the dialect, as this is the name it receives in the standard.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>