### PR TITLE
[SYCL-MLIR] Undef-initialize stack-allocated vectors

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -451,7 +451,7 @@ ValueCategory MLIRScanner::VisitCXXStdInitializerListExpr(
 
   mlir::Type SubType = Glob.getTypes().getMLIRType(Expr->getType());
 
-  mlir::Value Res = Builder.create<LLVM::UndefOp>(Loc, SubType);
+  mlir::Value Res = ValueCategory::getUndefValue(Builder, Loc, SubType).val;
 
   ArrayPtr = CommonArrayToPointer(ArrayPtr);
 

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -96,6 +96,12 @@ ValueCategory ValueCategory::getNullValue(OpBuilder &Builder, Location Loc,
   return {ZeroVal, false};
 }
 
+ValueCategory ValueCategory::getUndefValue(OpBuilder &Builder, Location Loc,
+                                           Type Type) {
+  // TODO: Replace with higher-level undef operation when defined.
+  return {Builder.createOrFold<LLVM::UndefOp>(Loc, Type), false};
+}
+
 void ValueCategory::store(mlir::OpBuilder &builder, mlir::Value toStore) const {
   assert(isReference && "must be a reference");
   assert(val && "expect not-null");

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -46,6 +46,8 @@ public:
 
   static ValueCategory getNullValue(mlir::OpBuilder &Builder,
                                     mlir::Location Loc, mlir::Type Type);
+  static ValueCategory getUndefValue(mlir::OpBuilder &Builder,
+                                     mlir::Location Loc, mlir::Type Type);
 
   // TODO: rename to 'loadVariable'? getValue seems to generic.
   mlir::Value getValue(mlir::OpBuilder &Builder) const;

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -313,7 +313,8 @@ void MLIRScanner::init(FunctionOpInterface func, const FunctionToEmit &FTE) {
     ReturnVal = Builder.create<memref::AllocaOp>(Loc, type);
     if (type.getElementType().isa<IntegerType, FloatType>()) {
       Builder.create<memref::StoreOp>(
-          Loc, Builder.create<LLVM::UndefOp>(Loc, type.getElementType()),
+          Loc,
+          ValueCategory::getUndefValue(Builder, Loc, type.getElementType()).val,
           ReturnVal, std::vector<Value>({}));
     }
   }
@@ -408,7 +409,8 @@ Value MLIRScanner::createAllocOp(Type t, clang::VarDecl *name,
             aBuilder.create<arith::ConstantIntOp>(varLoc, 1, 64), 0);
         if (t.isa<IntegerType, FloatType>()) {
           aBuilder.create<LLVM::StoreOp>(
-              varLoc, aBuilder.create<LLVM::UndefOp>(varLoc, t), alloc);
+              varLoc, ValueCategory::getUndefValue(aBuilder, varLoc, t).val,
+              alloc);
         }
         // alloc = Builder.create<LLVM::BitcastOp>(varLoc,
         // LLVM::LLVMPointerType::get(LLVM::LLVMArrayType::get(t, 1)), alloc);
@@ -440,10 +442,11 @@ Value MLIRScanner::createAllocOp(Type t, clang::VarDecl *name,
         llvm::dbgs() << "\n";
       });
 
-      if (t.isa<IntegerType, FloatType>()) {
+      if (t.isa<IntegerType, FloatType, VectorType>()) {
         Value idxs[] = {aBuilder.create<arith::ConstantIndexOp>(Loc, 0)};
         aBuilder.create<memref::StoreOp>(
-            varLoc, aBuilder.create<LLVM::UndefOp>(varLoc, t), alloc, idxs);
+            varLoc, ValueCategory::getUndefValue(aBuilder, varLoc, t).val,
+            alloc, idxs);
       }
     }
   } else {
@@ -1810,7 +1813,7 @@ MLIRASTConsumer::getOrCreateLLVMGlobal(const clang::ValueDecl *FD,
       ms.setEntryAndAllocBlock(blk);
       res = ms.Visit(const_cast<clang::Expr *>(init)).getValue(Builder);
     } else {
-      res = Builder.create<LLVM::UndefOp>(Module->getLoc(), rt);
+      res = ValueCategory::getUndefValue(Builder, Module->getLoc(), rt).val;
     }
     bool legal = true;
     for (Operation &op : *blk) {
@@ -1827,7 +1830,8 @@ MLIRASTConsumer::getOrCreateLLVMGlobal(const clang::ValueDecl *FD,
     } else {
       Block *blk2 = new Block();
       Builder.setInsertionPointToEnd(blk2);
-      Value nres = Builder.create<LLVM::UndefOp>(Module->getLoc(), rt);
+      Value nres =
+          ValueCategory::getUndefValue(Builder, Module->getLoc(), rt).val;
       Builder.create<LLVM::ReturnOp>(Module->getLoc(),
                                      std::vector<Value>({nres}));
       glob.getInitializerRegion().push_back(blk2);

--- a/polygeist/tools/cgeist/Test/Verification/ext_vector_type.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/ext_vector_type.cpp
@@ -19,8 +19,7 @@ size_t evt2() {
 // CHECK: memref.global constant @stv : memref<vector<3xi64>> {alignment = 32 : i64}
 
 // CHECK-LABEL:   func.func @_Z3evtv() -> i64 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:    %alloca = memref.alloca() : memref<1xvector<3xi64>>
-// CHECK-NEXT:    %0 = affine.load %alloca[0] : memref<1xvector<3xi64>>
+// CHECK-NEXT:    %0 = llvm.mlir.undef : vector<3xi64>
 // CHECK-NEXT:    %1 = vector.extract %0[0] : vector<3xi64>
 // CHECK-NEXT:    return %1 : i64
 // CHECK-NEXT:    }
@@ -37,10 +36,7 @@ size_t evt2() {
 // LLVM:       @stv = external constant <3 x i64>, align 32
 
 // LLVM-LABEL: define i64 @_Z3evtv() {
-// LLVM-NEXT:   %1 = alloca <3 x i64>, align 32
-// LLVM-NEXT:   %2 = load <3 x i64>, <3 x i64>* %1, align 32
-// LLVM-NEXT:   %3 = extractelement <3 x i64> %2, i64 0
-// LLVM-NEXT:   ret i64 %3
+// LLVM-NEXT:   ret i64 undef
 
 // LLVM-LABEL: define i64 @_Z4evt2v() {
 // LLVM-NEXT:   %1 = load <3 x i64>, <3 x i64>* @stv, align 32

--- a/polygeist/tools/cgeist/Test/Verification/vecaccess.c
+++ b/polygeist/tools/cgeist/Test/Verification/vecaccess.c
@@ -57,12 +57,10 @@ int test_inc(int_vec *v, int idx, int el) {
 // CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 2 : i32
 // CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 1 : i32
 // CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:      %[[VAL_6:.*]] = memref.alloca() : memref<1xvector<3xi32>>
-// CHECK-NEXT:      %[[VAL_7:.*]] = affine.load %[[VAL_6]][0] : memref<1xvector<3xi32>>
+// CHECK-DAG:       %[[VAL_7:.*]] = llvm.mlir.undef : vector<3xi32>
 // CHECK-NEXT:      %[[VAL_8:.*]] = vector.insertelement %[[VAL_0]], %[[VAL_7]]{{\[}}%[[VAL_5]] : i32] : vector<3xi32>
 // CHECK-NEXT:      %[[VAL_9:.*]] = vector.insertelement %[[VAL_1]], %[[VAL_8]]{{\[}}%[[VAL_4]] : i32] : vector<3xi32>
 // CHECK-NEXT:      %[[VAL_10:.*]] = vector.insertelement %[[VAL_2]], %[[VAL_9]]{{\[}}%[[VAL_3]] : i32] : vector<3xi32>
-// CHECK-NEXT:      affine.store %[[VAL_10]], %[[VAL_6]][0] : memref<1xvector<3xi32>>
 // CHECK-NEXT:      return %[[VAL_10]] : vector<3xi32>
 // CHECK-NEXT:    }
 


### PR DESCRIPTION
When a vector variable is declared, but not initialized, it should be undef-initialized, as it is the case with other types.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>