### PR TITLE
[SYCL-MLIR] Implement 4 SYCL types

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -208,6 +208,12 @@ def SYCL_GroupType : SYCL_Type<"Group", "group"> {
   let assemblyFormat = "`<` `[` $dimension `]` `,` `(` $body `)` `>`";
 }
 
+def SYCL_HItemType : SYCL_Type<"HItem", "h_item"> {
+  let parameters = (ins "unsigned":$dimension,
+                        ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<` `[` $dimension `]` `,` `(` $body `)` `>`";
+}
+
 def SYCL_IDType
     : SYCL_Type<"ID", "id", [SYCLInheritanceTypeTrait<"ArrayType">]> {
   let parameters = (ins "unsigned":$dimension,
@@ -227,6 +233,21 @@ def SYCL_ItemType : SYCL_Type<"Item", "item"> {
                         "bool":$withOffset,
                         ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dimension `,` $withOffset `]` `,` `(` $body `)` `>`";
+}
+
+def SYCL_KernelHandlerType : SYCL_Type<"KernelHandler", "kernel_handler"> {
+  let parameters = (ins ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<` `(` $body `)` `>`";
+}
+
+def SYCL_MaximumType : SYCL_Type<"Maximum", "maximum"> {
+  let parameters = (ins "::mlir::Type":$dataType);
+  let assemblyFormat = "`<` $dataType `>`";
+}
+
+def SYCL_MinimumType : SYCL_Type<"Minimum", "minimum"> {
+  let parameters = (ins "::mlir::Type":$dataType);
+  let assemblyFormat = "`<` $dataType `>`";
 }
 
 def SYCL_MultiPtrType : SYCL_Type<"MultiPtr", "multi_ptr"> {

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -168,6 +168,12 @@ static Optional<Type> convertGetScalarOpType(sycl::GetScalarOpType type,
                          converter);
 }
 
+/// Converts SYCL h_item type to LLVM type.
+static Optional<Type> convertHItemType(sycl::HItemType type,
+                                       LLVMTypeConverter &converter) {
+  return convertBodyType("class.sycl::_V1::h_item", type.getBody(), converter);
+}
+
 /// Converts SYCL id type to LLVM type.
 static Optional<Type> convertIDType(sycl::IDType type,
                                     LLVMTypeConverter &converter) {
@@ -183,6 +189,18 @@ static Optional<Type> convertItemBaseType(sycl::ItemBaseType type,
                              std::to_string(type.getDimension()) +
                              (type.getWithOffset() ? ".true" : ".false"),
                          type.getBody(), converter);
+}
+
+/// Converts SYCL maximum type to LLVM type.
+static Optional<Type> convertMaximumType(sycl::MaximumType type,
+                                         LLVMTypeConverter &converter) {
+  return getI8Struct("struct.sycl::_V1::maximum", converter);
+}
+
+/// Converts SYCL minimum type to LLVM type.
+static Optional<Type> convertMinimumType(sycl::MinimumType type,
+                                         LLVMTypeConverter &converter) {
+  return getI8Struct("struct.sycl::_V1::minimum", converter);
 }
 
 /// Converts SYCL multi_ptr type to LLVM type.
@@ -276,6 +294,13 @@ static Optional<Type> convertBFloat16Type(sycl::BFloat16Type type,
                                           LLVMTypeConverter &converter) {
   return convertBodyType("class.sycl::_V1::ext::oneapi::bfloat16",
                          type.getBody(), converter);
+}
+
+/// Converts SYCL kernel_handler type to LLVM type.
+static Optional<Type> convertKernelHandlerType(sycl::KernelHandlerType type,
+                                               LLVMTypeConverter &converter) {
+  return convertBodyType("class.sycl::_V1::kernel_handler", type.getBody(),
+                         converter);
 }
 
 /// Converts SYCL sub_group type to LLVM type.
@@ -465,6 +490,9 @@ void mlir::sycl::populateSYCLToLLVMTypeConversion(
   typeConverter.addConversion([&](sycl::GetScalarOpType type) {
     return convertGetScalarOpType(type, typeConverter);
   });
+  typeConverter.addConversion([&](sycl::HItemType type) {
+    return convertHItemType(type, typeConverter);
+  });
   typeConverter.addConversion(
       [&](sycl::IDType type) { return convertIDType(type, typeConverter); });
   typeConverter.addConversion([&](sycl::ItemBaseType type) {
@@ -472,6 +500,12 @@ void mlir::sycl::populateSYCLToLLVMTypeConversion(
   });
   typeConverter.addConversion([&](sycl::ItemType type) {
     return convertItemType(type, typeConverter);
+  });
+  typeConverter.addConversion([&](sycl::MaximumType type) {
+    return convertMaximumType(type, typeConverter);
+  });
+  typeConverter.addConversion([&](sycl::MinimumType type) {
+    return convertMinimumType(type, typeConverter);
   });
   typeConverter.addConversion([&](sycl::MultiPtrType type) {
     return convertMultiPtrType(type, typeConverter);
@@ -505,6 +539,9 @@ void mlir::sycl::populateSYCLToLLVMTypeConversion(
   });
   typeConverter.addConversion([&](sycl::BFloat16Type type) {
     return convertBFloat16Type(type, typeConverter);
+  });
+  typeConverter.addConversion([&](sycl::KernelHandlerType type) {
+    return convertKernelHandlerType(type, typeConverter);
   });
   typeConverter.addConversion([&](sycl::SubGroupType type) {
     return convertSubGroupType(type, typeConverter);

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
@@ -123,14 +123,15 @@ private:
 mlir::OpAsmDialectInterface::AliasResult
 SYCLOpAsmInterface::getAlias(mlir::Type Type, llvm::raw_ostream &OS) const {
   return llvm::TypeSwitch<mlir::Type, AliasResult>(Type)
-      .Case<mlir::sycl::AssertHappenedType, mlir::sycl::BFloat16Type>(
-          [&](auto Ty) {
-            OS << "sycl_" << decltype(Ty)::getMnemonic() << "_";
-            return AliasResult::FinalAlias;
-          })
+      .Case<mlir::sycl::AssertHappenedType, mlir::sycl::BFloat16Type,
+            mlir::sycl::KernelHandlerType>([&](auto Ty) {
+        OS << "sycl_" << decltype(Ty)::getMnemonic() << "_";
+        return AliasResult::FinalAlias;
+      })
       .Case<mlir::sycl::IDType, mlir::sycl::RangeType, mlir::sycl::NdRangeType,
             mlir::sycl::AccessorImplDeviceType, mlir::sycl::ArrayType,
-            mlir::sycl::NdItemType, mlir::sycl::GroupType>([&](auto Ty) {
+            mlir::sycl::NdItemType, mlir::sycl::GroupType,
+            mlir::sycl::HItemType>([&](auto Ty) {
         OS << "sycl_" << decltype(Ty)::getMnemonic() << "_" << Ty.getDimension()
            << "_";
         return AliasResult::FinalAlias;
@@ -140,7 +141,8 @@ SYCLOpAsmInterface::getAlias(mlir::Type Type, llvm::raw_ostream &OS) const {
            << "_";
         return AliasResult::OverridableAlias;
       })
-      .Case<mlir::sycl::GetScalarOpType, mlir::sycl::TupleValueHolderType>(
+      .Case<mlir::sycl::GetScalarOpType, mlir::sycl::MinimumType,
+            mlir::sycl::MaximumType, mlir::sycl::TupleValueHolderType>(
           [&](auto Ty) {
             OS << "sycl_" << decltype(Ty)::getMnemonic() << "_"
                << Ty.getDataType() << "_";

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
@@ -103,9 +103,10 @@ func.func @test_OwnerLessBase(%arg0: !sycl.owner_less_base) {
 !sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
 !sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
 !sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
-!sycl_item_1_1 = !sycl.item<[1, false], (!sycl_item_base_1_1)>
+!sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1)>
 !sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
-!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1, !sycl_group_1_)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
+!sycl_h_item_1_ = !sycl.h_item<[1], (!sycl_item_1_1_, !sycl_item_1_1_, !sycl_item_1_1_)>
 // CHECK: llvm.func @test_itemBase.true(%arg0: !llvm.[[ITEM_BASE_1_TRUE:struct<"struct.sycl::_V1::detail::ItemBase.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
 func.func @test_itemBase.true(%arg0: !sycl_item_base_1_) {
   return
@@ -119,7 +120,7 @@ func.func @test_item.true(%arg0: !sycl_item_1_) {
   return
 }
 // CHECK: llvm.func @test_item.false(%arg0: !llvm.[[ITEM_1_FALSE:struct<"class.sycl::_V1::item.*", \(]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
-func.func @test_item.false(%arg0: !sycl_item_1_1) {
+func.func @test_item.false(%arg0: !sycl_item_1_1_) {
   return
 }
 // CHECK: llvm.func @test_group(%arg0: !llvm.[[GROUP:struct<"class.sycl::_V1::group.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
@@ -128,6 +129,10 @@ func.func @test_group(%arg0: !sycl_group_1_) {
 }
 // CHECK: llvm.func @test_nd_item(%arg0: !llvm.[[ND_ITEM_1:struct<"class.sycl::_V1::nd_item.*", \(]][[ITEM_1_TRUE]][[ITEM_BASE_1_TRUE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[ITEM_1_FALSE]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[GROUP]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
 func.func @test_nd_item(%arg0: !sycl_nd_item_1_) {
+  return
+}
+// CHECK: llvm.func @test_h_item(%arg0: !llvm.[[H_ITEM:struct<"class.sycl::_V1::h_item", \(]][[ITEM_1_FALSE]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[ITEM_1_FALSE]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[ITEM_1_FALSE]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]][[SUFFIX]]) {
+func.func @test_h_item(%arg0: !sycl_h_item_1_) {
   return
 }
 
@@ -143,6 +148,19 @@ func.func @test_get_op(%arg0: !sycl.get_op<i32>) {
 !sycl_get_scalar_op_i32_ = !sycl.get_scalar_op<[i32], (i32)>
 // CHECK: llvm.func @test_get_scalar_op(%arg0: !llvm.[[GET_SCALAR_OP:struct<"class.sycl::_V1::detail::GetScalarOp.*", \(i32\)>]])
 func.func @test_get_scalar_op(%arg0: !sycl_get_scalar_op_i32_) {
+  return
+}
+
+// -----
+
+!sycl_maximum_i32_ = !sycl.maximum<i32>
+!sycl_minimum_i32_ = !sycl.minimum<i32>
+// CHECK: llvm.func @test_maximum(%arg0: !llvm.[[MAXIMUM:struct<"struct.sycl::_V1::maximum", \(i8\)>]]) {
+func.func @test_maximum(%arg0: !sycl_maximum_i32_) {
+  return
+}
+// CHECK: llvm.func @test_minimum(%arg0: !llvm.[[MINIMUM:struct<"struct.sycl::_V1::minimum", \(i8\)>]]) {
+func.func @test_minimum(%arg0: !sycl_minimum_i32_) {
   return
 }
 
@@ -191,6 +209,14 @@ func.func @test_assert_happened(%arg0: !sycl_assert_happened_) {
 func.func @test_bfloat16(%arg0: !sycl_bfloat16_) {
   return
 }
+
+// -----
+
+!sycl_kernel_handler_ = !sycl.kernel_handler<(!llvm.ptr<i8, 4>)>
+// CHECK: llvm.func @test_kernel_handler(%arg0: !llvm.[[KERNEL_HANDLER:struct<"class.sycl::_V1::kernel_handler", \(ptr<i8, 4>\)>]]) {
+func.func @test_kernel_handler(%arg0: !sycl_kernel_handler_) {
+  return
+} 
 
 // -----
 

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
@@ -38,23 +38,6 @@ func.func @test_range.2(%arg0: !sycl_range_2_) {
 !sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
-!sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
-!sycl_nd_range_2_ = !sycl.nd_range<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
-// CHECK: llvm.func @test_nd_range.1(%arg0: !llvm.[[ND_RANGE_1:struct<"class.sycl::_V1::nd_range.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]]) {
-func.func @test_nd_range.1(%arg0: !sycl_nd_range_1_) {
-  return
-}
-// CHECK: llvm.func @test_nd_range.2(%arg0: !llvm.[[ND_RANGE_2:struct<"class.sycl::_V1::nd_range.*", \(]][[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[ID_2:struct<"class.sycl::_V1::id.*", \(]][[ARRAY_2]][[SUFFIX]][[SUFFIX]]) {
-func.func @test_nd_range.2(%arg0: !sycl_nd_range_2_) {
-  return
-}
-
-// -----
-
-!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
-!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
-!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
-!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
 !sycl_accessor_impl_device_2_ = !sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>
 !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
@@ -62,19 +45,19 @@ func.func @test_nd_range.2(%arg0: !sycl_nd_range_2_) {
 !sycl_accessor_1_f32_rw_gb = !sycl.accessor<[1, f32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<f32, 1>)>)>
 !sycl_accessor_2_f32_rw_gb = !sycl.accessor<[2, f32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<f32, 1>)>)>
 !sycl_accessor_subscript_1_ = !sycl.accessor_subscript<[1], (!sycl_id_2_, !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<i32, 1>)>)>)>
-// CHECK: llvm.func @test_accessorImplDevice(%arg0: !llvm.[[ACCESSORIMPLDEVICE_1:struct<"class.sycl::_V1::detail::AccessorImplDevice.*", \(]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
-func.func @test_accessorImplDevice(%arg0: !sycl_accessor_impl_device_1_) {
-  return
-}
 // CHECK: llvm.func @test_accessor_common(%arg0: !llvm.struct<"class.sycl::_V1::detail::accessor_common", (i8)>)
 func.func @test_accessor_common(%arg0: !sycl.accessor_common) {
+  return
+}
+// CHECK: llvm.func @test_accessorImplDevice(%arg0: !llvm.[[ACCESSORIMPLDEVICE_1:struct<"class.sycl::_V1::detail::AccessorImplDevice.*", \(]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
+func.func @test_accessorImplDevice(%arg0: !sycl_accessor_impl_device_1_) {
   return
 }
 // CHECK: llvm.func @test_accessor.1(%arg0: !llvm.struct<"class.sycl::_V1::accessor{{.*}}", ([[ACCESSORIMPLDEVICE_1]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>[[SUFFIX]])
 func.func @test_accessor.1(%arg0: !sycl_accessor_1_i32_rw_gb) {
   return
 }
-// CHECK: llvm.func @test_accessor.2(%arg0: !llvm.[[ACCESSOR_2:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_2:struct<"class.sycl::_V1::detail::AccessorImplDevice.*", \(]][[ID_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>[[SUFFIX]])
+// CHECK: llvm.func @test_accessor.2(%arg0: !llvm.[[ACCESSOR_2:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_2:struct<"class.sycl::_V1::detail::AccessorImplDevice.*", \(]][[ID_2:struct<"class.sycl::_V1::id.*", \(]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>[[SUFFIX]])
 func.func @test_accessor.2(%arg0: !sycl_accessor_2_i32_rw_gb) {
   return
 }
@@ -98,6 +81,46 @@ func.func @test_OwnerLessBase(%arg0: !sycl.owner_less_base) {
 
 // -----
 
+!sycl_assert_happened_ = !sycl.assert_happened<(i32, !llvm.array<257 x i8>, !llvm.array<257 x i8>, !llvm.array<129 x i8>, i32, i64, i64, i64, i64, i64, i64)>
+// CHECK: llvm.func @test_assert_happened(%arg0: !llvm.[[ASSERT_HAPPENED:struct<"struct.sycl::_V1::detail::AssertHappened", \(i32, array<257 x i8>, array<257 x i8>, array<129 x i8>, i32, i64, i64, i64, i64, i64, i64\)>]]) {
+func.func @test_assert_happened(%arg0: !sycl_assert_happened_) {
+  return
+}
+
+// -----
+
+!sycl_atomic_i32_1_ = !sycl.atomic<[i32,1], (memref<?xi32, 1>)>
+!sycl_atomic_f32_3_ = !sycl.atomic<[f32,3], (memref<?xf32, 3>)>
+// CHECK: llvm.func @test_atomic(%arg0: !llvm.[[ATOMIC1:struct<"class.sycl::_V1::atomic", \(struct<\(ptr<f32, 3>, ptr<f32, 3>, i64, array<1 x i64>, array<1 x i64>\)>\)>]], %arg1: !llvm.[[ATOMIC1:struct<"class.sycl::_V1::atomic.1", \(struct<\(ptr<i32, 1>, ptr<i32, 1>, i64, array<1 x i64>, array<1 x i64>\)>\)>]]) {
+func.func @test_atomic(%arg0: !sycl_atomic_f32_3_, %arg1: !sycl_atomic_i32_1_) {
+  return
+}
+
+// -----
+
+!sycl_bfloat16_ = !sycl.bfloat16<(i16)>
+// CHECK: llvm.func @test_bfloat16(%arg0: !llvm.[[BFLOAT16:struct<"class.sycl::_V1::ext::oneapi::bfloat16", \(i16\)>]]) {
+func.func @test_bfloat16(%arg0: !sycl_bfloat16_) {
+  return
+}
+
+// -----
+
+!sycl_get_scalar_op_i32_ = !sycl.get_scalar_op<[i32], (i32)>
+// CHECK: llvm.func @test_get_scalar_op(%arg0: !llvm.[[GET_SCALAR_OP:struct<"class.sycl::_V1::detail::GetScalarOp.*", \(i32\)>]])
+func.func @test_get_scalar_op(%arg0: !sycl_get_scalar_op_i32_) {
+  return
+}
+
+// -----
+
+// CHECK: llvm.func @test_get_op(%arg0: !llvm.[[GET_OP:struct<"class.sycl::_V1::detail::GetOp", \(i8\)>]])
+func.func @test_get_op(%arg0: !sycl.get_op<i32>) {
+  return
+}
+
+// -----
+
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
@@ -105,8 +128,8 @@ func.func @test_OwnerLessBase(%arg0: !sycl.owner_less_base) {
 !sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
 !sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1)>
 !sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
-!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
 !sycl_h_item_1_ = !sycl.h_item<[1], (!sycl_item_1_1_, !sycl_item_1_1_, !sycl_item_1_1_)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
 // CHECK: llvm.func @test_itemBase.true(%arg0: !llvm.[[ITEM_BASE_1_TRUE:struct<"struct.sycl::_V1::detail::ItemBase.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]])
 func.func @test_itemBase.true(%arg0: !sycl_item_base_1_) {
   return
@@ -127,27 +150,20 @@ func.func @test_item.false(%arg0: !sycl_item_1_1_) {
 func.func @test_group(%arg0: !sycl_group_1_) {
   return
 }
-// CHECK: llvm.func @test_nd_item(%arg0: !llvm.[[ND_ITEM_1:struct<"class.sycl::_V1::nd_item.*", \(]][[ITEM_1_TRUE]][[ITEM_BASE_1_TRUE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[ITEM_1_FALSE]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[GROUP]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
-func.func @test_nd_item(%arg0: !sycl_nd_item_1_) {
-  return
-}
 // CHECK: llvm.func @test_h_item(%arg0: !llvm.[[H_ITEM:struct<"class.sycl::_V1::h_item", \(]][[ITEM_1_FALSE]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[ITEM_1_FALSE]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[ITEM_1_FALSE]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]][[SUFFIX]]) {
 func.func @test_h_item(%arg0: !sycl_h_item_1_) {
   return
 }
-
-// -----
-
-// CHECK: llvm.func @test_get_op(%arg0: !llvm.[[GET_OP:struct<"class.sycl::_V1::detail::GetOp", \(i8\)>]])
-func.func @test_get_op(%arg0: !sycl.get_op<i32>) {
+// CHECK: llvm.func @test_nd_item(%arg0: !llvm.[[ND_ITEM_1:struct<"class.sycl::_V1::nd_item.*", \(]][[ITEM_1_TRUE]][[ITEM_BASE_1_TRUE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[ITEM_1_FALSE]][[ITEM_BASE_1_FALSE]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]], [[GROUP]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]][[SUFFIX]])
+func.func @test_nd_item(%arg0: !sycl_nd_item_1_) {
   return
 }
 
 // -----
 
-!sycl_get_scalar_op_i32_ = !sycl.get_scalar_op<[i32], (i32)>
-// CHECK: llvm.func @test_get_scalar_op(%arg0: !llvm.[[GET_SCALAR_OP:struct<"class.sycl::_V1::detail::GetScalarOp.*", \(i32\)>]])
-func.func @test_get_scalar_op(%arg0: !sycl_get_scalar_op_i32_) {
+!sycl_kernel_handler_ = !sycl.kernel_handler<(!llvm.ptr<i8, 4>)>
+// CHECK: llvm.func @test_kernel_handler(%arg0: !llvm.[[KERNEL_HANDLER:struct<"class.sycl::_V1::kernel_handler", \(ptr<i8, 4>\)>]]) {
+func.func @test_kernel_handler(%arg0: !sycl_kernel_handler_) {
   return
 }
 
@@ -161,6 +177,38 @@ func.func @test_maximum(%arg0: !sycl_maximum_i32_) {
 }
 // CHECK: llvm.func @test_minimum(%arg0: !llvm.[[MINIMUM:struct<"struct.sycl::_V1::minimum", \(i8\)>]]) {
 func.func @test_minimum(%arg0: !sycl_minimum_i32_) {
+  return
+}
+
+// -----
+
+!sycl_multi_ptr_i32_1_ = !sycl.multi_ptr<[i32, 1, 1], (memref<?xi32, 1>)>
+// CHECK: llvm.func @test_multi_ptr(%arg0: !llvm.[[ATOMIC1:struct<"class.sycl::_V1::multi_ptr", \(struct<\(ptr<i32, 1>, ptr<i32, 1>, i64, array<1 x i64>, array<1 x i64>\)>\)>]]) {
+func.func @test_multi_ptr(%arg0: !sycl_multi_ptr_i32_1_) {
+    return
+}
+
+// -----
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_nd_range_2_ = !sycl.nd_range<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
+// CHECK: llvm.func @test_nd_range.1(%arg0: !llvm.[[ND_RANGE_1:struct<"class.sycl::_V1::nd_range.*", \(]][[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]]) {
+func.func @test_nd_range.1(%arg0: !sycl_nd_range_1_) {
+  return
+}
+// CHECK: llvm.func @test_nd_range.2(%arg0: !llvm.[[ND_RANGE_2:struct<"class.sycl::_V1::nd_range.*", \(]][[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[ID_2]][[ARRAY_2]][[SUFFIX]][[SUFFIX]]) {
+func.func @test_nd_range.2(%arg0: !sycl_nd_range_2_) {
+  return
+}
+
+// -----
+
+// CHECK: llvm.func @test_sub_group(%arg0: !llvm.[[SUB_GROUP:struct<"struct.sycl::_V1::ext::oneapi::sub_group", \(i8\)>]]) {
+func.func @test_sub_group(%arg0: !sycl.sub_group) {
   return
 }
 
@@ -183,54 +231,6 @@ func.func @test_tuple_copy_assignable_value_holder(%arg0: !sycl_tuple_copy_assig
 // CHECK: llvm.func @test_vec(%arg0: !llvm.[[VEC:struct<"class.sycl::_V1::vec", \(vector<4xf32>\)>]])
 func.func @test_vec(%arg0: !sycl_vec_f32_4_) {
   return
-}
-
-// -----
-
-!sycl_atomic_f32_3_ = !sycl.atomic<[f32,3], (memref<?xf32, 3>)>
-!sycl_atomic_i32_1_ = !sycl.atomic<[i32,1], (memref<?xi32, 1>)>
-// CHECK: llvm.func @test_atomic(%arg0: !llvm.[[ATOMIC1:struct<"class.sycl::_V1::atomic", \(struct<\(ptr<f32, 3>, ptr<f32, 3>, i64, array<1 x i64>, array<1 x i64>\)>\)>]], %arg1: !llvm.[[ATOMIC1:struct<"class.sycl::_V1::atomic.1", \(struct<\(ptr<i32, 1>, ptr<i32, 1>, i64, array<1 x i64>, array<1 x i64>\)>\)>]]) {
-func.func @test_atomic(%arg0: !sycl_atomic_f32_3_, %arg1: !sycl_atomic_i32_1_) {
-  return
-}
-
-// -----
-
-!sycl_assert_happened_ = !sycl.assert_happened<(i32, !llvm.array<257 x i8>, !llvm.array<257 x i8>, !llvm.array<129 x i8>, i32, i64, i64, i64, i64, i64, i64)>
-// CHECK: llvm.func @test_assert_happened(%arg0: !llvm.[[ASSERT_HAPPENED:struct<"struct.sycl::_V1::detail::AssertHappened", \(i32, array<257 x i8>, array<257 x i8>, array<129 x i8>, i32, i64, i64, i64, i64, i64, i64\)>]]) {
-func.func @test_assert_happened(%arg0: !sycl_assert_happened_) {
-  return
-}
-
-// -----
-
-!sycl_bfloat16_ = !sycl.bfloat16<(i16)>
-// CHECK: llvm.func @test_bfloat16(%arg0: !llvm.[[BFLOAT16:struct<"class.sycl::_V1::ext::oneapi::bfloat16", \(i16\)>]]) {
-func.func @test_bfloat16(%arg0: !sycl_bfloat16_) {
-  return
-}
-
-// -----
-
-!sycl_kernel_handler_ = !sycl.kernel_handler<(!llvm.ptr<i8, 4>)>
-// CHECK: llvm.func @test_kernel_handler(%arg0: !llvm.[[KERNEL_HANDLER:struct<"class.sycl::_V1::kernel_handler", \(ptr<i8, 4>\)>]]) {
-func.func @test_kernel_handler(%arg0: !sycl_kernel_handler_) {
-  return
-} 
-
-// -----
-
-// CHECK: llvm.func @test_sub_group(%arg0: !llvm.[[SUB_GROUP:struct<"struct.sycl::_V1::ext::oneapi::sub_group", \(i8\)>]]) {
-func.func @test_sub_group(%arg0: !sycl.sub_group) {
-  return
-}
-
-// -----
-
-!sycl_multi_ptr_i32_1_ = !sycl.multi_ptr<[i32, 1, 1], (memref<?xi32, 1>)>
-// CHECK: llvm.func @test_multi_ptr(%arg0: !llvm.[[ATOMIC1:struct<"class.sycl::_V1::multi_ptr", \(struct<\(ptr<i32, 1>, ptr<i32, 1>, i64, array<1 x i64>, array<1 x i64>\)>\)>]]) {
-func.func @test_multi_ptr(%arg0: !sycl_multi_ptr_i32_1_) {
-    return
 }
 
 // -----

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1342,8 +1342,10 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
           TypeName == "array" || TypeName == "AssertHappened" ||
           TypeName == "atomic" || TypeName == "bfloat16" ||
           TypeName == "GetOp" || TypeName == "GetScalarOp" ||
-          TypeName == "group" || TypeName == "id" || TypeName == "item" ||
-          TypeName == "ItemBase" || TypeName == "multi_ptr" ||
+          TypeName == "group" || TypeName == "h_item" || TypeName == "id" ||
+          TypeName == "item" || TypeName == "ItemBase" ||
+          TypeName == "kernel_handler" || TypeName == "maximum" ||
+          TypeName == "minimum" || TypeName == "multi_ptr" ||
           TypeName == "nd_item" || TypeName == "nd_range" ||
           TypeName == "OwnerLessBase" || TypeName == "range" ||
           TypeName == "sub_group" ||

--- a/polygeist/tools/cgeist/Lib/TypeUtils.cc
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.cc
@@ -115,9 +115,13 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
     GetScalarOp,
     GetOp,
     Group,
+    HItem,
     ID,
     ItemBase,
     Item,
+    KernelHandler,
+    Maximum,
+    Minimum,
     MultiPtr,
     NdItem,
     NdRange,
@@ -142,9 +146,13 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
       {"GetScalarOp", TypeEnum::GetScalarOp},
       {"GetOp", TypeEnum::GetOp},
       {"group", TypeEnum::Group},
+      {"h_item", TypeEnum::HItem},
       {"id", TypeEnum::ID},
       {"ItemBase", TypeEnum::ItemBase},
       {"item", TypeEnum::Item},
+      {"kernel_handler", TypeEnum::KernelHandler},
+      {"maximum", TypeEnum::Maximum},
+      {"minimum", TypeEnum::Minimum},
       {"multi_ptr", MultiPtr},
       {"nd_item", TypeEnum::NdItem},
       {"nd_range", TypeEnum::NdRange},
@@ -226,6 +234,12 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
       return mlir::sycl::GroupType::get(CGT.getModule()->getContext(), Dim,
                                         Body);
     }
+    case TypeEnum::HItem: {
+      const auto Dim =
+          CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
+      return mlir::sycl::HItemType::get(CGT.getModule()->getContext(), Dim,
+                                        Body);
+    }
     case TypeEnum::ID: {
       const auto Dim =
           CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
@@ -247,6 +261,16 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
           CTS->getTemplateArgs().get(1).getAsIntegral().getExtValue();
       return mlir::sycl::ItemType::get(CGT.getModule()->getContext(), Dim,
                                        Offset, Body);
+    }
+    case TypeEnum::Maximum: {
+      const auto Type =
+          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
+      return mlir::sycl::MaximumType::get(CGT.getModule()->getContext(), Type);
+    }
+    case TypeEnum::Minimum: {
+      const auto Type =
+          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
+      return mlir::sycl::MinimumType::get(CGT.getModule()->getContext(), Type);
     }
     case TypeEnum::MultiPtr: {
       const auto Type =
@@ -318,6 +342,9 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
                                                  Body);
     case TypeEnum::BFloat16:
       return mlir::sycl::BFloat16Type::get(CGT.getModule()->getContext(), Body);
+    case TypeEnum::KernelHandler:
+      return mlir::sycl::KernelHandlerType::get(CGT.getModule()->getContext(),
+                                                Body);
     case TypeEnum::SubGroup:
       return mlir::sycl::SubGroupType::get(CGT.getModule()->getContext());
     default:

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -20,6 +20,7 @@
 // CHECK-DAG: !sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 // CHECK-DAG: !sycl_nd_range_2_ = !sycl.nd_range<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
 // CHECK-DAG: !sycl_get_scalar_op_i32_ = !sycl.get_scalar_op<[i32], (i32)>
+// CHECK-DAG: !sycl_h_item_1_ = !sycl.h_item<[1], (!sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>)>, !sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>)>, !sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>)>)>
 // CHECK-DAG: !sycl_tuple_value_holder_i32_ = !sycl.tuple_value_holder<[i32], (i32)>
 // CHECK-DAG: [[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_TRUE:!sycl_tuple_copy_assignable_value_holder_i32_.*]] = !sycl.tuple_copy_assignable_value_holder<[i32, true], (!sycl_tuple_value_holder_i32_)>
 // CHECK-DAG: [[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_FALSE:!sycl_tuple_copy_assignable_value_holder_i32_.*]] = !sycl.tuple_copy_assignable_value_holder<[i32, false], (!sycl_tuple_value_holder_i32_)>
@@ -29,6 +30,9 @@
 // CHECK-DAG: !sycl_atomic_i32_1_ = !sycl.atomic<[i32,1], (memref<?xi32, 1>)>
 // CHECK-DAG: !sycl_assert_happened_ = !sycl.assert_happened<(i32, !llvm.array<257 x i8>, !llvm.array<257 x i8>, !llvm.array<129 x i8>, i32, i64, i64, i64, i64, i64, i64)>
 // CHECK-DAG: !sycl_bfloat16_ = !sycl.bfloat16<(i16)>
+// CHECK-DAG: !sycl_kernel_handler_ = !sycl.kernel_handler<(!llvm.ptr<i8, 4>)>
+// CHECK-DAG: !sycl_maximum_i32_ = !sycl.maximum<i32>
+// CHECK-DAG: !sycl_minimum_i32_ = !sycl.minimum<i32>
 // CHECK-DAG: !sycl_multi_ptr_i32_1_ = !sycl.multi_ptr<[i32, 1, 1], (memref<?xi32, 1>)>
 
 // CHECK-LABEL: func.func @_Z4id_1N4sycl3_V12idILi1EEE(
@@ -132,6 +136,11 @@ SYCL_EXTERNAL void get_op(sycl::detail::GetOp<int> get_op) {}
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
 SYCL_EXTERNAL void get_scalar_op(sycl::detail::GetScalarOp<int> get_scalar_op) {}
 
+// CHECK-LABEL: func.func @_Z6h_itemN4sycl3_V16h_itemILi1EEE(
+// CHECK:          %arg0: memref<?x!sycl_h_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_h_item_1_, llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void h_item(sycl::h_item<1> h_item) {}
+
 // CHECK-LABEL: func.func @_Z18tuple_value_holderN4sycl3_V16detail16TupleValueHolderIiEE(
 // CHECK:          %arg0: memref<?x!sycl_tuple_value_holder_i32_> {llvm.align = 4 : i64, llvm.byval = !sycl_tuple_value_holder_i32_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
@@ -168,20 +177,35 @@ SYCL_EXTERNAL void atomic_1(sycl::atomic<int> atomic_int) {}
 SYCL_EXTERNAL void atomic_2(sycl::atomic<float, sycl::access::address_space::local_space> atomic_float) {}
 
 // %"struct.sycl::_V1::detail::AssertHappened" = type { i32, [257 x i8], [257 x i8], [129 x i8], i32, i64, i64, i64, i64, i64, i64 }
-// CHECK-LABEL: func.func @_Z19get_assert_happenedN4sycl3_V16detail14AssertHappenedE(
+// CHECK-LABEL: func.func @_Z15assert_happenedN4sycl3_V16detail14AssertHappenedE(
 // CHECK:          %arg0: memref<?x!sycl_assert_happened_> {llvm.align = 8 : i64, llvm.byval = !sycl_assert_happened_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void get_assert_happened(sycl::detail::AssertHappened get_assert_happened) {}
+SYCL_EXTERNAL void assert_happened(sycl::detail::AssertHappened get_assert_happened) {}
 
-// CHECK-LABEL: func.func @_Z12get_bfloat16N4sycl3_V13ext6oneapi8bfloat16E(
+// CHECK-LABEL: func.func @_Z8bfloat16N4sycl3_V13ext6oneapi8bfloat16E(
 // CHECK:          %arg0: memref<?x!sycl_bfloat16_> {llvm.align = 2 : i64, llvm.byval = !sycl_bfloat16_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void get_bfloat16(sycl::ext::oneapi::bfloat16 get_bfloat16) {}
+SYCL_EXTERNAL void bfloat16(sycl::ext::oneapi::bfloat16 get_bfloat16) {}
 
-// CHECL-LABEL: func.func @_Z13get_sub_groupN4sycl3_V13ext6oneapi9sub_groupE(
+// CHECK-LABEL: func.func @_Z14kernel_handlerN4sycl3_V114kernel_handlerE(
+// CHECK:          %arg0: memref<?x!sycl_kernel_handler_> {llvm.align = 8 : i64, llvm.byval = !sycl_kernel_handler_, llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void kernel_handler(sycl::kernel_handler kernel_handler) {}
+
+// CHECL-LABEL: func.func @_Z7sub_groupN4sycl3_V13ext6oneapi9sub_groupE(
 // CHECK:          %arg0: memref<?x!sycl.sub_group> {llvm.align = 1 : i64, llvm.byval = !sycl.sub_group, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void get_sub_group(sycl::ext::oneapi::sub_group get_sub_group) {}
+SYCL_EXTERNAL void sub_group(sycl::ext::oneapi::sub_group get_sub_group) {}
+
+// CHECK-LABEL: func.func @_Z7maximumN4sycl3_V17maximumIiEE(
+// CHECK:          %arg0: memref<?x!sycl_maximum_i32_> {llvm.align = 1 : i64, llvm.byval = !sycl_maximum_i32_, llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void maximum(sycl::maximum<int> max) {}
+
+// CHECK-LABEL: func.func @_Z7minimumN4sycl3_V17minimumIiEE(
+// CHECK:          %arg0: memref<?x!sycl_minimum_i32_> {llvm.align = 1 : i64, llvm.byval = !sycl_minimum_i32_, llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void minimum(sycl::minimum<int> min) {}
 
 // CHECK-LABEL: func.func @_Z9multi_ptrN4sycl3_V19multi_ptrIiLNS0_6access13address_spaceE1ELNS2_9decoratedE1EEE(
 // CHECK:          %arg0: memref<?x!sycl_multi_ptr_i32_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_multi_ptr_i32_1_, llvm.noundef})


### PR DESCRIPTION
Implemented SYCL `h_item`, `maximum`, `minimum` and `kernel_handler` types.

clang generated example:
```
%"class.sycl::_V1::h_item" = type { %"class.sycl::_V1::item.19", %"class.sycl::_V1::item.19", %"class.sycl::_V1::item.19" }
%"struct.sycl::_V1::maximum" = type { i8 }
%"struct.sycl::_V1::minimum" = type { i8 }
%"class.sycl::_V1::kernel_handler" = type { i8 addrspace(4)* }
```

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>