### PR TITLE
[SYCL][NFC] Add CTAD to PiArray in unittests to avoid warnings

### DIFF
--- a/sycl/unittests/helpers/PiImage.hpp
+++ b/sycl/unittests/helpers/PiImage.hpp
@@ -157,6 +157,9 @@ private:
   bool MEntriesNeedUpdate = false;
 };
 
+// PiArray CTAD to avoid warnings.
+template <typename T> PiArray(std::initializer_list<T>) -> PiArray<T>;
+
 /// Convenience wrapper for pi_device_binary_property_set.
 class PiPropertySet {
 public:


### PR DESCRIPTION
The constructor for PiArray in the unittest utilities could cause a warning due to potentially unintended deductions. This commit adds a CTAD definition to avoid this warning.