### PR TITLE
[SYCL-MLIR]: Add types for local_accessor, local_accessor_base, and detail::LocalAccessorBaseDevice

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -167,15 +167,15 @@ def SYCL_AccessorSubscriptType :
   let assemblyFormat = "`<` `[` $currentDimension `]` `,` `(` $body `)` `>`";
 }
 
-def SYCL_AssertHappenedType : SYCL_Type<"AssertHappened", "assert_happened"> {
-  let parameters = (ins ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<` `(` $body `)` `>`";
-}
-
 def SYCL_ArrayType : SYCL_Type<"Array", "array"> {
   let parameters = (ins "unsigned":$dimension,
                         ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dimension `]` `,` `(` $body `)` `>`";
+}
+
+def SYCL_AssertHappenedType : SYCL_Type<"AssertHappened", "assert_happened"> {
+  let parameters = (ins ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<` `(` $body `)` `>`";
 }
 
 def SYCL_AtomicType : SYCL_Type<"Atomic", "atomic"> {
@@ -190,15 +190,15 @@ def SYCL_BFloat16Type : SYCL_Type<"BFloat16", "bfloat16"> {
   let assemblyFormat = "`<` `(` $body `)` `>`";
 }
 
+def SYCL_GetOpType : SYCL_Type<"GetOp", "get_op"> {
+  let parameters = (ins "::mlir::Type":$dataType);
+  let assemblyFormat = "`<` $dataType `>`";
+}
+
 def SYCL_GetScalarOpType : SYCL_Type<"GetScalarOp", "get_scalar_op"> {
   let parameters = (ins "::mlir::Type":$dataType,
                         ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dataType `]` `,` `(` $body `)` `>`";
-}
-
-def SYCL_GetOpType : SYCL_Type<"GetOp", "get_op"> {
-  let parameters = (ins "::mlir::Type":$dataType);
-  let assemblyFormat = "`<` $dataType `>`";
 }
 
 def SYCL_GroupType : SYCL_Type<"Group", "group"> {
@@ -226,6 +226,36 @@ def SYCL_ItemType : SYCL_Type<"Item", "item"> {
                         "bool":$withOffset,
                         ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dimension `,` $withOffset `]` `,` `(` $body `)` `>`";
+}
+
+def SYCL_LocalAccessorBaseDeviceType
+    : SYCL_Type<"LocalAccessorBaseDevice", "LocalAccessorBaseDevice"> {
+  let parameters = (ins "unsigned":$dimension,
+                        ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<` `[` $dimension `]` `,` `(` $body `)` `>`";                        
+}
+
+def SYCL_LocalAccessorBaseType
+    : SYCL_Type<"LocalAccessorBase", "local_accessor_base",
+        [SYCLInheritanceTypeTrait<"AccessorCommonType">]> {
+  let parameters = (ins "::mlir::Type":$type,
+                        "unsigned":$dimension,
+                        "mlir::sycl::MemoryAccessMode":$accessMode,
+                        ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat =
+      "`<` `[` $dimension `,` $type `,` ` ` custom<MemoryAccessMode>($accessMode) `]` `,` `(` $body `)` `>`";
+}
+
+def SYCL_LocalAccessorType
+    : SYCL_Type<"LocalAccessor", "local_accessor",
+        [SYCLInheritanceTypeTrait<"LocalAccessorBaseType">]> {
+  let summary = "Local Accessor";
+  let description = [{ Accessor to a local buffer.}];
+  let parameters = (ins "::mlir::Type":$type,
+                        "unsigned":$dimension,
+                        ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat =
+      "`<` `[` $dimension `,` $type `]` `,` `(` $body `)` `>`";
 }
 
 def SYCL_MultiPtrType : SYCL_Type<"MultiPtr", "multi_ptr"> {
@@ -285,7 +315,7 @@ def SYCL_VecType : SYCL_Type<"Vec", "vec"> {
 // Define MemRef types (alphabetical order).
 def AccessorCommonMemRef : MemRefOf<[SYCL_AccessorCommonType]>;
 def AccessorImplDeviceMemRef : MemRefOf<[SYCL_AccessorImplDeviceType]>;
-def AccessorMemRef : MemRefOf<[SYCL_AccessorType]>;
+def AccessorMemRef : MemRefOf<[SYCL_AccessorType, SYCL_LocalAccessorType]>;
 def AccessorSubscriptMemRef : MemRefOf<[SYCL_AccessorSubscriptType]>;
 def ArrayMemRef : MemRefOf<[SYCL_ArrayType]>;
 def AtomicMemRef : MemRefOf<[SYCL_AtomicType]>;
@@ -293,6 +323,9 @@ def GroupMemRef : MemRefOf<[SYCL_GroupType]>;
 def IDMemRef : MemRefOf<[SYCL_IDType]>;
 def ItemBaseMemRef : MemRefOf<[SYCL_ItemBaseType]>;
 def ItemMemRef : MemRefOf<[SYCL_ItemType]>;
+def LocalAccessorBaseDeviceMemRef : MemRefOf<[SYCL_LocalAccessorBaseDeviceType]>;
+def LocalAccessorBaseMemRef : MemRefOf<[SYCL_LocalAccessorBaseType]>;
+def LocalAccessorMemRef : MemRefOf<[SYCL_LocalAccessorType]>;
 def MultiPtrMemRef : MemRefOf<[SYCL_MultiPtrType]>;
 def NDItemMemRef : MemRefOf<[SYCL_NdItemType]>;
 def NDRangeMemRef : MemRefOf<[SYCL_NdRangeType]>;
@@ -311,6 +344,9 @@ def SYCLMemref : AnyTypeOf<[
   IDMemRef,
   ItemBaseMemRef,
   ItemMemRef,
+  LocalAccessorBaseDeviceMemRef,
+  LocalAccessorBaseMemRef,
+  LocalAccessorMemRef,
   MultiPtrMemRef,
   NDItemMemRef,
   NDRangeMemRef,

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -26,7 +26,7 @@ include "mlir/Interfaces/CastInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 
 ////////////////////////////////////////////////////////////////////////////////
-// TYPE DECLARATIONS
+// DIALECT DECLARATION
 ////////////////////////////////////////////////////////////////////////////////
 
 def SYCL_Dialect : Dialect {
@@ -115,6 +115,10 @@ class SYCLMethodOpInterfaceImpl<
   }];
 }
 
+////////////////////////////////////////////////////////////////////////////////
+// TYPES DECLARATIONS
+////////////////////////////////////////////////////////////////////////////////
+
 class SYCL_Type<string name, string typeMnemonic, list<Trait> traits = []>
     : TypeDef<SYCL_Dialect, name,
               !listconcat([MemRefElementTypeInterface,
@@ -128,20 +132,25 @@ class SYCLInheritanceTypeTrait<string ParentClass>
   let cppNamespace = "::mlir::sycl";
 }
 
-def SYCL_IDType
-    : SYCL_Type<"ID", "id", [SYCLInheritanceTypeTrait<"ArrayType">]> {
-  let parameters = (ins "unsigned":$dimension,
-                        ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<`  `[` $dimension `]` `,` `(` $body `)` `>`";
-}
-
+//
+// SYCL types (alphabetical order).
+//
 def SYCL_AccessorCommonType : SYCL_Type<"AccessorCommon", "accessor_common"> {
   let assemblyFormat = "";
+}
+
+def SYCL_AccessorImplDeviceType :
+    SYCL_Type<"AccessorImplDevice", "accessor_impl_device"> {
+  let parameters = (ins "unsigned":$dimension,
+                        ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<` `[` $dimension `]` `,` `(` $body `)` `>`";
 }
 
 def SYCL_AccessorType
     : SYCL_Type<"Accessor", "accessor",
         [SYCLInheritanceTypeTrait<"AccessorCommonType">]> {
+  let summary = "Buffer Accessor";
+  let description = [{ Accessor to a buffer object.}];
   let parameters = (ins "::mlir::Type":$type,
                         "unsigned":$dimension,
                         "mlir::sycl::MemoryAccessMode":$accessMode,
@@ -151,31 +160,16 @@ def SYCL_AccessorType
       "`<` `[` $dimension `,` $type `,` ` ` custom<MemoryAccessMode>($accessMode) `,` ` ` custom<MemoryTargetMode>($targetMode) `]` `,` `(` $body `)` `>`";
 }
 
-def SYCL_RangeType
-    : SYCL_Type<"Range", "range", [SYCLInheritanceTypeTrait<"ArrayType">]> {
-  let parameters = (ins "unsigned":$dimension,
-                        ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<`  `[` $dimension `]` `,` `(` $body `)` `>`";
-}
-
-def SYCL_NdRangeType : SYCL_Type<"NdRange", "nd_range"> {
-  let parameters = (ins "unsigned":$dimension,
-                        ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<` `[` $dimension `]` `,` `(` $body `)` `>`";
-}
-
-def SYCL_AccessorImplType :
-    SYCL_Type<"AccessorImplDevice", "accessor_impl_device"> {
-  let parameters = (ins "unsigned":$dimension,
-                        ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<` `[` $dimension `]` `,` `(` $body `)` `>`";
-}
-
 def SYCL_AccessorSubscriptType :
     SYCL_Type<"AccessorSubscript", "accessor_subscript"> {
   let parameters = (ins "int":$currentDimension,
                         ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $currentDimension `]` `,` `(` $body `)` `>`";
+}
+
+def SYCL_AssertHappenedType : SYCL_Type<"AssertHappened", "assert_happened"> {
+  let parameters = (ins ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<` `(` $body `)` `>`";
 }
 
 def SYCL_ArrayType : SYCL_Type<"Array", "array"> {
@@ -184,11 +178,40 @@ def SYCL_ArrayType : SYCL_Type<"Array", "array"> {
   let assemblyFormat = "`<` `[` $dimension `]` `,` `(` $body `)` `>`";
 }
 
-def SYCL_ItemType : SYCL_Type<"Item", "item"> {
-  let parameters = (ins "unsigned":$dimension,
-                        "bool":$withOffset,
+def SYCL_AtomicType : SYCL_Type<"Atomic", "atomic"> {
+  let parameters = (ins "::mlir::Type":$dataType,
+                        "mlir::sycl::AccessAddrSpace":$addrSpace,
                         ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<` `[` $dimension `,` $withOffset `]` `,` `(` $body `)` `>`";
+  let assemblyFormat = "`<` `[` $dataType `,` custom<AccessAddrSpace>($addrSpace) `]` `,` `(` $body `)` `>`";
+}
+
+def SYCL_BFloat16Type : SYCL_Type<"BFloat16", "bfloat16"> {
+  let parameters = (ins ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<` `(` $body `)` `>`";
+}
+
+def SYCL_GetScalarOpType : SYCL_Type<"GetScalarOp", "get_scalar_op"> {
+  let parameters = (ins "::mlir::Type":$dataType,
+                        ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<` `[` $dataType `]` `,` `(` $body `)` `>`";
+}
+
+def SYCL_GetOpType : SYCL_Type<"GetOp", "get_op"> {
+  let parameters = (ins "::mlir::Type":$dataType);
+  let assemblyFormat = "`<` $dataType `>`";
+}
+
+def SYCL_GroupType : SYCL_Type<"Group", "group"> {
+  let parameters = (ins "unsigned":$dimension,
+                        ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<` `[` $dimension `]` `,` `(` $body `)` `>`";
+}
+
+def SYCL_IDType
+    : SYCL_Type<"ID", "id", [SYCLInheritanceTypeTrait<"ArrayType">]> {
+  let parameters = (ins "unsigned":$dimension,
+                        ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<`  `[` $dimension `]` `,` `(` $body `)` `>`";
 }
 
 def SYCL_ItemBaseType : SYCL_Type<"ItemBase", "item_base"> {
@@ -198,33 +221,42 @@ def SYCL_ItemBaseType : SYCL_Type<"ItemBase", "item_base"> {
   let assemblyFormat = "`<` `[` $dimension `,` $withOffset `]` `,` `(` $body `)` `>`";
 }
 
+def SYCL_ItemType : SYCL_Type<"Item", "item"> {
+  let parameters = (ins "unsigned":$dimension,
+                        "bool":$withOffset,
+                        ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<` `[` $dimension `,` $withOffset `]` `,` `(` $body `)` `>`";
+}
+
+def SYCL_MultiPtrType : SYCL_Type<"MultiPtr", "multi_ptr"> {
+  let parameters = (ins "::mlir::Type":$dataType,
+                        "mlir::sycl::AccessAddrSpace":$addrSpace,
+                        "mlir::sycl::DecoratedAccess":$decAccess,
+                        ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<` `[` $dataType `,` ` ` custom<AccessAddrSpace>($addrSpace) `,` ` ` custom<DecoratedAccess>($decAccess) `]` `,` `(` $body `)` `>`";
+}
+
 def SYCL_NdItemType : SYCL_Type<"NdItem", "nd_item"> {
   let parameters = (ins "unsigned":$dimension,
                         ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dimension `]` `,` `(` $body `)` `>`";
 }
 
-def SYCL_GroupType : SYCL_Type<"Group", "group"> {
+def SYCL_NdRangeType : SYCL_Type<"NdRange", "nd_range"> {
   let parameters = (ins "unsigned":$dimension,
                         ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dimension `]` `,` `(` $body `)` `>`";
 }
 
-def SYCL_GetOpType : SYCL_Type<"GetOp", "get_op"> {
-  let parameters = (ins "::mlir::Type":$dataType);
-  let assemblyFormat = "`<` $dataType `>`";
+def SYCL_RangeType
+    : SYCL_Type<"Range", "range", [SYCLInheritanceTypeTrait<"ArrayType">]> {
+  let parameters = (ins "unsigned":$dimension,
+                        ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<`  `[` $dimension `]` `,` `(` $body `)` `>`";
 }
 
-def SYCL_GetScalarOpType : SYCL_Type<"GetScalarOp", "get_scalar_op"> {
-  let parameters = (ins "::mlir::Type":$dataType,
-                        ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<` `[` $dataType `]` `,` `(` $body `)` `>`";
-}
-
-def SYCL_TupleValueHolderType : SYCL_Type<"TupleValueHolder", "tuple_value_holder"> {
-  let parameters = (ins "::mlir::Type":$dataType,
-                        ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<` `[` $dataType `]` `,` `(` $body `)` `>`";
+def SYCL_SubGroupType : SYCL_Type<"SubGroup", "sub_group"> {
+  let assemblyFormat = "";
 }
 
 def SYCL_TupleCopyAssignableValueHolderType
@@ -236,9 +268,11 @@ def SYCL_TupleCopyAssignableValueHolderType
   let assemblyFormat = "`<` `[` $dataType `,` $isTriviallyCopyAssignable `]` `,` `(` $body `)` `>`";
 }
 
-def VectorEltTy : AnyTypeOf<[I1, I8, I16, I32, I64, F16, F32, F64]>;
-
-def VectorSplatArg : MemRefOf<[VectorEltTy]>;
+def SYCL_TupleValueHolderType : SYCL_Type<"TupleValueHolder", "tuple_value_holder"> {
+  let parameters = (ins "::mlir::Type":$dataType,
+                        ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<` `[` $dataType `]` `,` `(` $body `)` `>`";
+}
 
 def SYCL_VecType : SYCL_Type<"Vec", "vec"> {
   let parameters = (ins "::mlir::Type":$dataType,
@@ -248,73 +282,49 @@ def SYCL_VecType : SYCL_Type<"Vec", "vec"> {
   let genVerifyDecl = 1;
 }
 
-def SYCL_AtomicType : SYCL_Type<"Atomic", "atomic"> {
-  let parameters = (ins "::mlir::Type":$dataType,
-                        "mlir::sycl::AccessAddrSpace":$addrSpace,
-                        ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<` `[` $dataType `,` custom<AccessAddrSpace>($addrSpace) `]` `,` `(` $body `)` `>`";
-}
-
-def SYCL_MultiPtrType : SYCL_Type<"MultiPtr", "multi_ptr"> {
-  let parameters = (ins "::mlir::Type":$dataType,
-                        "mlir::sycl::AccessAddrSpace":$addrSpace,
-                        "mlir::sycl::DecoratedAccess":$decAccess,
-                        ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<` `[` $dataType `,` ` ` custom<AccessAddrSpace>($addrSpace) `,` ` ` custom<DecoratedAccess>($decAccess) `]` `,` `(` $body `)` `>`";
-}
-
-def SYCL_AssertHappenedType : SYCL_Type<"AssertHappened", "assert_happened"> {
-  let parameters = (ins ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<` `(` $body `)` `>`";
-}
-
-def SYCL_BFloat16Type : SYCL_Type<"BFloat16", "bfloat16"> {
-  let parameters = (ins ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<` `(` $body `)` `>`";
-}
-
-def SYCL_SubGroupType : SYCL_Type<"SubGroup", "sub_group"> {
-  let assemblyFormat = "";
-}
-
-def IDMemRef : MemRefOf<[SYCL_IDType]>;
+// Define MemRef types (alphabetical order).
 def AccessorCommonMemRef : MemRefOf<[SYCL_AccessorCommonType]>;
+def AccessorImplDeviceMemRef : MemRefOf<[SYCL_AccessorImplDeviceType]>;
 def AccessorMemRef : MemRefOf<[SYCL_AccessorType]>;
-def AtomicMemRef : MemRefOf<[SYCL_AtomicType]>;
-def RangeMemRef : MemRefOf<[SYCL_RangeType]>;
-def NDRangeMemRef : MemRefOf<[SYCL_NdRangeType]>;
-def AccessorImplMemRef : MemRefOf<[SYCL_AccessorImplType]>;
 def AccessorSubscriptMemRef : MemRefOf<[SYCL_AccessorSubscriptType]>;
 def ArrayMemRef : MemRefOf<[SYCL_ArrayType]>;
-def ItemMemRef : MemRefOf<[SYCL_ItemType]>;
+def AtomicMemRef : MemRefOf<[SYCL_AtomicType]>;
+def GroupMemRef : MemRefOf<[SYCL_GroupType]>;
+def IDMemRef : MemRefOf<[SYCL_IDType]>;
 def ItemBaseMemRef : MemRefOf<[SYCL_ItemBaseType]>;
+def ItemMemRef : MemRefOf<[SYCL_ItemType]>;
 def MultiPtrMemRef : MemRefOf<[SYCL_MultiPtrType]>;
 def NDItemMemRef : MemRefOf<[SYCL_NdItemType]>;
-def GroupMemRef : MemRefOf<[SYCL_GroupType]>;
+def NDRangeMemRef : MemRefOf<[SYCL_NdRangeType]>;
+def RangeMemRef : MemRefOf<[SYCL_RangeType]>;
 def VecMemRef : MemRefOf<[SYCL_VecType]>;
 
 def SYCLMemref : AnyTypeOf<[
-  IDMemRef,
+  // Keep in alphabetical order.
   AccessorCommonMemRef,
+  AccessorImplDeviceMemRef,
   AccessorMemRef,
-  AtomicMemRef,
-  RangeMemRef,
-  NDRangeMemRef,
-  AccessorImplMemRef,
   AccessorSubscriptMemRef,
   ArrayMemRef,
-  ItemMemRef,
+  AtomicMemRef,
+  GroupMemRef,  
+  IDMemRef,
   ItemBaseMemRef,
+  ItemMemRef,
   MultiPtrMemRef,
   NDItemMemRef,
-  GroupMemRef,
-  VecMemRef,
-  AtomicMemRef
+  NDRangeMemRef,
+  RangeMemRef,
+  VecMemRef
 ]>;
+
+// Other types (alphabetical order).
 def IndexType : AnyTypeOf<[I32, I64, Index]>;
-def SYCLGetResult : AnyTypeOf<[I64, MemRefOf<[I64]>]>;
 def SYCLGetIDResult : AnyTypeOf<[I64, SYCL_IDType]>;
 def SYCLGetRangeResult : AnyTypeOf<[I64, SYCL_RangeType]>;
+def SYCLGetResult : AnyTypeOf<[I64, MemRefOf<[I64]>]>;
+def VectorEltTy : AnyTypeOf<[I1, I8, I16, I32, I64, F16, F32, F64]>;
+def VectorSplatArg : MemRefOf<[VectorEltTy]>;
 
 ////////////////////////////////////////////////////////////////////////////////
 // CONSTRUCTOR OPERATION

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -185,6 +185,32 @@ static Optional<Type> convertItemBaseType(sycl::ItemBaseType type,
                          type.getBody(), converter);
 }
 
+/// Converts SYCL local accessor base device type to LLVM type.
+static Optional<Type>
+convertLocalAccessorBaseDeviceType(sycl::LocalAccessorBaseDeviceType type,
+                                   LLVMTypeConverter &converter) {
+  return convertBodyType("class.sycl::_V1::details::LocalAccessorBaseDevice" +
+                             std::to_string(type.getDimension()),
+                         type.getBody(), converter);
+}
+
+/// Converts SYCL local accessor base type to LLVM type.
+static Optional<Type>
+convertLocalAccessorBaseType(sycl::LocalAccessorBaseType type,
+                             LLVMTypeConverter &converter) {
+  return convertBodyType("class.sycl::_V1::local_accessor_base" +
+                             std::to_string(type.getDimension()),
+                         type.getBody(), converter);
+}
+
+/// Converts SYCL local accessor type to LLVM type.
+static Optional<Type> convertLocalAccessorType(sycl::LocalAccessorType type,
+                                               LLVMTypeConverter &converter) {
+  return convertBodyType("class.sycl::_V1::local_accessor" +
+                             std::to_string(type.getDimension()),
+                         type.getBody(), converter);
+}
+
 /// Converts SYCL multi_ptr type to LLVM type.
 static Optional<Type> convertMultiPtrType(sycl::MultiPtrType type,
                                           LLVMTypeConverter &converter) {
@@ -435,29 +461,39 @@ private:
 
 void mlir::sycl::populateSYCLToLLVMTypeConversion(
     LLVMTypeConverter &typeConverter) {
+  // Same order as in SYCLOps.td
   typeConverter.addConversion([&](sycl::AccessorCommonType type) {
     return convertAccessorCommonType(type, typeConverter);
   });
   typeConverter.addConversion([&](sycl::AccessorImplDeviceType type) {
     return convertAccessorImplDeviceType(type, typeConverter);
   });
-  typeConverter.addConversion([&](sycl::AccessorSubscriptType type) {
-    return convertAccessorSubscriptType(type, typeConverter);
-  });
   typeConverter.addConversion([&](sycl::AccessorType type) {
     return convertAccessorType(type, typeConverter);
+  });
+  typeConverter.addConversion([&](sycl::AccessorSubscriptType type) {
+    return convertAccessorSubscriptType(type, typeConverter);
   });
   typeConverter.addConversion([&](sycl::ArrayType type) {
     return convertArrayType(type, typeConverter);
   });
-  typeConverter.addConversion([&](sycl::GroupType type) {
-    return convertGroupType(type, typeConverter);
+  typeConverter.addConversion([&](sycl::AssertHappenedType type) {
+    return convertAssertHappenedType(type, typeConverter);
+  });
+  typeConverter.addConversion([&](sycl::AtomicType type) {
+    return convertAtomicType(type, typeConverter);
+  });
+  typeConverter.addConversion([&](sycl::BFloat16Type type) {
+    return convertBFloat16Type(type, typeConverter);
   });
   typeConverter.addConversion([&](sycl::GetOpType type) {
     return convertGetOpType(type, typeConverter);
   });
   typeConverter.addConversion([&](sycl::GetScalarOpType type) {
     return convertGetScalarOpType(type, typeConverter);
+  });
+  typeConverter.addConversion([&](sycl::GroupType type) {
+    return convertGroupType(type, typeConverter);
   });
   typeConverter.addConversion(
       [&](sycl::IDType type) { return convertIDType(type, typeConverter); });
@@ -467,39 +503,39 @@ void mlir::sycl::populateSYCLToLLVMTypeConversion(
   typeConverter.addConversion([&](sycl::ItemType type) {
     return convertItemType(type, typeConverter);
   });
+  typeConverter.addConversion([&](sycl::LocalAccessorBaseDeviceType type) {
+    return convertLocalAccessorBaseDeviceType(type, typeConverter);
+  });
+  typeConverter.addConversion([&](sycl::LocalAccessorBaseType type) {
+    return convertLocalAccessorBaseType(type, typeConverter);
+  });
+  typeConverter.addConversion([&](sycl::LocalAccessorType type) {
+    return convertLocalAccessorType(type, typeConverter);
+  });
   typeConverter.addConversion([&](sycl::MultiPtrType type) {
     return convertMultiPtrType(type, typeConverter);
   });
   typeConverter.addConversion([&](sycl::NdItemType type) {
     return convertNdItemType(type, typeConverter);
   });
-  typeConverter.addConversion([&](sycl::RangeType type) {
-    return convertRangeType(type, typeConverter);
-  });
   typeConverter.addConversion([&](sycl::NdRangeType type) {
     return convertNdRangeType(type, typeConverter);
   });
-  typeConverter.addConversion([&](sycl::TupleValueHolderType type) {
-    return convertTupleValueHolderType(type, typeConverter);
+  typeConverter.addConversion([&](sycl::RangeType type) {
+    return convertRangeType(type, typeConverter);
+  });
+  typeConverter.addConversion([&](sycl::SubGroupType type) {
+    return convertSubGroupType(type, typeConverter);
   });
   typeConverter.addConversion(
       [&](sycl::TupleCopyAssignableValueHolderType type) {
         return convertTupleCopyAssignableValueHolderType(type, typeConverter);
       });
+  typeConverter.addConversion([&](sycl::TupleValueHolderType type) {
+    return convertTupleValueHolderType(type, typeConverter);
+  });
   typeConverter.addConversion(
       [&](sycl::VecType type) { return convertVecType(type, typeConverter); });
-  typeConverter.addConversion([&](sycl::AtomicType type) {
-    return convertAtomicType(type, typeConverter);
-  });
-  typeConverter.addConversion([&](sycl::AssertHappenedType type) {
-    return convertAssertHappenedType(type, typeConverter);
-  });
-  typeConverter.addConversion([&](sycl::BFloat16Type type) {
-    return convertBFloat16Type(type, typeConverter);
-  });
-  typeConverter.addConversion([&](sycl::SubGroupType type) {
-    return convertSubGroupType(type, typeConverter);
-  });
 }
 
 void mlir::sycl::populateSYCLToLLVMConversionPatterns(

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -206,6 +206,8 @@ convertLocalAccessorBaseType(sycl::LocalAccessorBaseType type,
 /// Converts SYCL local accessor type to LLVM type.
 static Optional<Type> convertLocalAccessorType(sycl::LocalAccessorType type,
                                                LLVMTypeConverter &converter) {
+  // FIXME: Make sure that we have llvm.ptr as the body, not memref, through
+  // the conversion done in ConvertTOLLVMABI pass
   return convertBodyType("class.sycl::_V1::local_accessor" +
                              std::to_string(type.getDimension()),
                          type.getBody(), converter);

--- a/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
@@ -14,15 +14,13 @@
 
 bool mlir::sycl::SYCLCastOp::areCastCompatible(::mlir::TypeRange Inputs,
                                                ::mlir::TypeRange Outputs) {
-  if (Inputs.size() != 1 || Outputs.size() != 1) {
+  if (Inputs.size() != 1 || Outputs.size() != 1)
     return false;
-  }
 
   const auto Input = Inputs.front().dyn_cast<MemRefType>();
   const auto Output = Outputs.front().dyn_cast<MemRefType>();
-  if (!Input || !Output) {
+  if (!Input || !Output)
     return false;
-  }
 
   /// This is a hack - Since the sycl's CastOp takes as input/output MemRef, we
   /// want to ensure that the cast is valid within MemRef's world.
@@ -34,9 +32,8 @@ bool mlir::sycl::SYCLCastOp::areCastCompatible(::mlir::TypeRange Inputs,
   const auto TempOutput =
       mlir::MemRefType::get(Output.getShape(), Input.getElementType(),
                             Output.getLayout(), Output.getMemorySpace());
-  if (!mlir::memref::CastOp::areCastCompatible(Input, TempOutput)) {
+  if (!mlir::memref::CastOp::areCastCompatible(Input, TempOutput))
     return false;
-  }
 
   const bool HasArrayTrait = Input.getElementType()
                                  .hasTrait<mlir::sycl::SYCLInheritanceTypeTrait<

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1343,9 +1343,11 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
           TypeName == "atomic" || TypeName == "bfloat16" ||
           TypeName == "GetOp" || TypeName == "GetScalarOp" ||
           TypeName == "group" || TypeName == "id" || TypeName == "item" ||
-          TypeName == "ItemBase" || TypeName == "multi_ptr" ||
-          TypeName == "nd_item" || TypeName == "nd_range" ||
-          TypeName == "range" || TypeName == "sub_group" ||
+          TypeName == "ItemBase" || TypeName == "LocalAccessorBaseDevice" ||
+          TypeName == "local_accessor_base" || TypeName == "local_accessor" ||
+          TypeName == "multi_ptr" || TypeName == "nd_item" ||
+          TypeName == "nd_range" || TypeName == "range" ||
+          TypeName == "sub_group" ||
           TypeName == "TupleCopyAssignableValueHolder" ||
           TypeName == "TupleValueHolder" || TypeName == "vec") {
         return getSYCLType(RT, *this);

--- a/polygeist/tools/cgeist/Lib/TypeUtils.cc
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.cc
@@ -283,6 +283,7 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
           CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
       const auto Dim =
           CTS->getTemplateArgs().get(1).getAsIntegral().getExtValue();
+      Body.push_back(CGT.getMLIRType(CTS->bases_begin()->getType()));
       return mlir::sycl::LocalAccessorType::get(CGT.getModule()->getContext(),
                                                 Type, Dim, Body);
     }

--- a/polygeist/tools/cgeist/Lib/TypeUtils.cc
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.cc
@@ -101,7 +101,60 @@ mlir::Type getPtrTyWithNewType(mlir::Type Orig, mlir::Type NewElementType) {
 
 mlir::Type getSYCLType(const clang::RecordType *RT,
                        mlirclang::CodeGen::CodeGenTypes &CGT) {
-  const auto *RD = RT->getAsRecordDecl();
+
+  enum TypeEnum {
+    // Keep in alphabetical order.
+    AccessorCommon,
+    AccessorImplDevice,
+    Accessor,
+    AccessorSubscript,
+    AssertHappened,
+    Array,
+    Atomic,
+    BFloat16,
+    GetScalarOp,
+    GetOp,
+    Group,
+    ID,
+    ItemBase,
+    Item,
+    MultiPtr,
+    NdItem,
+    NdRange,
+    Range,
+    SubGroup,
+    TupleCopyAssignableValueHolder,
+    TupleValueHolder,
+    Vec
+  };
+
+  std::map<std::string, TypeEnum> StrToTypeEnum = {
+      // Keep in alphabetical order.
+      {"accessor_common", TypeEnum::AccessorCommon},
+      {"AccessorImplDevice", TypeEnum::AccessorImplDevice},
+      {"accessor", TypeEnum::Accessor},
+      {"AccessorSubscript", TypeEnum::AccessorSubscript},
+      {"AssertHappened", AssertHappened},
+      {"array", TypeEnum::Array},
+      {"atomic", TypeEnum::Atomic},
+      {"bfloat16", BFloat16},
+      {"GetScalarOp", TypeEnum::GetScalarOp},
+      {"GetOp", TypeEnum::GetOp},
+      {"group", TypeEnum::Group},
+      {"id", TypeEnum::ID},
+      {"ItemBase", TypeEnum::ItemBase},
+      {"item", TypeEnum::Item},
+      {"multi_ptr", MultiPtr},
+      {"nd_item", TypeEnum::NdItem},
+      {"nd_range", TypeEnum::NdRange},
+      {"range", TypeEnum::Range},
+      {"sub_group", SubGroup},
+      {"TupleCopyAssignableValueHolder", TupleCopyAssignableValueHolder},
+      {"TupleValueHolder", TypeEnum::TupleValueHolder},
+      {"vec", TypeEnum::Vec},
+  };
+
+  const clang::RecordDecl *RD = RT->getAsRecordDecl();
   llvm::SmallVector<mlir::Type, 4> Body;
 
   for (const auto *Field : RD->fields())
@@ -109,34 +162,21 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
 
   if (const auto *CTS =
           llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(RD)) {
-    if (CTS->getName() == "range") {
-      const auto Dim =
-          CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
-      Body.push_back(CGT.getMLIRType(CTS->bases_begin()->getType()));
-      return mlir::sycl::RangeType::get(CGT.getModule()->getContext(), Dim,
-                                        Body);
-    }
-    if (CTS->getName() == "nd_range") {
-      const auto Dim =
-          CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
-      return mlir::sycl::NdRangeType::get(CGT.getModule()->getContext(), Dim,
-                                          Body);
-    }
-    if (CTS->getName() == "array") {
-      const auto Dim =
-          CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
-      return mlir::sycl::ArrayType::get(CGT.getModule()->getContext(), Dim,
-                                        Body);
-    }
-    if (CTS->getName() == "id") {
-      const auto Dim =
-          CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
-      Body.push_back(CGT.getMLIRType(CTS->bases_begin()->getType()));
-      return mlir::sycl::IDType::get(CGT.getModule()->getContext(), Dim, Body);
-    }
-    if (CTS->getName() == "accessor_common")
+
+    llvm::dbgs() << "at line " << __LINE__
+                 << ", CTS->getName(): " << CTS->getName() << "\n";
+
+    switch (StrToTypeEnum[CTS->getName().str()]) {
+    // Keep in alphabetical order.
+    case TypeEnum::AccessorCommon:
       return mlir::sycl::AccessorCommonType::get(CGT.getModule()->getContext());
-    if (CTS->getName() == "accessor") {
+    case TypeEnum::AccessorImplDevice: {
+      const auto Dim =
+          CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
+      return mlir::sycl::AccessorImplDeviceType::get(
+          CGT.getModule()->getContext(), Dim, Body);
+    }
+    case TypeEnum::Accessor: {
       const auto Type =
           CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
       const auto Dim =
@@ -149,73 +189,20 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
                                            Dim, MemAccessMode, MemTargetMode,
                                            Body);
     }
-    if (CTS->getName() == "AccessorImplDevice") {
-      const auto Dim =
-          CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
-      return mlir::sycl::AccessorImplDeviceType::get(
-          CGT.getModule()->getContext(), Dim, Body);
-    }
-    if (CTS->getName() == "AccessorSubscript") {
+    case TypeEnum::AccessorSubscript: {
       const auto CurDim =
           CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
       return mlir::sycl::AccessorSubscriptType::get(
           CGT.getModule()->getContext(), CurDim, Body);
     }
-    if (CTS->getName() == "item") {
+    case TypeEnum::Array: {
+      llvm::dbgs() << "at line " << __LINE__ << "\n";
       const auto Dim =
           CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
-      const auto Offset =
-          CTS->getTemplateArgs().get(1).getAsIntegral().getExtValue();
-      return mlir::sycl::ItemType::get(CGT.getModule()->getContext(), Dim,
-                                       Offset, Body);
-    }
-    if (CTS->getName() == "ItemBase") {
-      const auto Dim =
-          CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
-      const auto Offset =
-          CTS->getTemplateArgs().get(1).getAsIntegral().getExtValue();
-      return mlir::sycl::ItemBaseType::get(CGT.getModule()->getContext(), Dim,
-                                           Offset, Body);
-    }
-    if (CTS->getName() == "nd_item") {
-      const auto Dim =
-          CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
-      return mlir::sycl::NdItemType::get(CGT.getModule()->getContext(), Dim,
-                                         Body);
-    }
-    if (CTS->getName() == "group") {
-      const auto Dim =
-          CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
-      return mlir::sycl::GroupType::get(CGT.getModule()->getContext(), Dim,
+      return mlir::sycl::ArrayType::get(CGT.getModule()->getContext(), Dim,
                                         Body);
     }
-    if (CTS->getName() == "GetOp") {
-      const auto Type =
-          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
-      return mlir::sycl::GetOpType::get(CGT.getModule()->getContext(), Type);
-    }
-    if (CTS->getName() == "GetScalarOp") {
-      const auto Type =
-          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
-      return mlir::sycl::GetScalarOpType::get(CGT.getModule()->getContext(),
-                                              Type, Body);
-    }
-    if (CTS->getName() == "TupleValueHolder") {
-      const auto Type =
-          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
-      return mlir::sycl::TupleValueHolderType::get(
-          CGT.getModule()->getContext(), Type, Body);
-    }
-    if (CTS->getName() == "TupleCopyAssignableValueHolder") {
-      const auto Type =
-          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
-      const auto IsTriviallyCopyAssignable =
-          CTS->getTemplateArgs().get(1).getAsIntegral().getExtValue();
-      Body.push_back(CGT.getMLIRType(CTS->bases_begin()->getType()));
-      return mlir::sycl::TupleCopyAssignableValueHolderType::get(
-          CGT.getModule()->getContext(), Type, IsTriviallyCopyAssignable, Body);
-    }
-    if (CTS->getName() == "atomic") {
+    case TypeEnum::Atomic: {
       const auto Type =
           CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
       const int AddrSpace =
@@ -224,7 +211,46 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
           CGT.getModule()->getContext(), Type,
           static_cast<mlir::sycl::AccessAddrSpace>(AddrSpace), Body);
     }
-    if (CTS->getName() == "multi_ptr") {
+    case TypeEnum::GetScalarOp: {
+      const auto Type =
+          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
+      return mlir::sycl::GetScalarOpType::get(CGT.getModule()->getContext(),
+                                              Type, Body);
+    }
+    case TypeEnum::GetOp: {
+      const auto Type =
+          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
+      return mlir::sycl::GetOpType::get(CGT.getModule()->getContext(), Type);
+    }
+    case TypeEnum::Group: {
+      const auto Dim =
+          CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
+      return mlir::sycl::GroupType::get(CGT.getModule()->getContext(), Dim,
+                                        Body);
+    }
+    case TypeEnum::ID: {
+      const auto Dim =
+          CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
+      Body.push_back(CGT.getMLIRType(CTS->bases_begin()->getType()));
+      return mlir::sycl::IDType::get(CGT.getModule()->getContext(), Dim, Body);
+    }
+    case TypeEnum::ItemBase: {
+      const auto Dim =
+          CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
+      const auto Offset =
+          CTS->getTemplateArgs().get(1).getAsIntegral().getExtValue();
+      return mlir::sycl::ItemBaseType::get(CGT.getModule()->getContext(), Dim,
+                                           Offset, Body);
+    }
+    case TypeEnum::Item: {
+      const auto Dim =
+          CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
+      const auto Offset =
+          CTS->getTemplateArgs().get(1).getAsIntegral().getExtValue();
+      return mlir::sycl::ItemType::get(CGT.getModule()->getContext(), Dim,
+                                       Offset, Body);
+    }
+    case TypeEnum::MultiPtr: {
       const auto Type =
           CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
       const int AddrSpace =
@@ -236,7 +262,41 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
           static_cast<mlir::sycl::AccessAddrSpace>(AddrSpace),
           static_cast<mlir::sycl::DecoratedAccess>(DecAccess), Body);
     }
-    if (CTS->getName() == "vec") {
+    case TypeEnum::NdItem: {
+      const auto Dim =
+          CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
+      return mlir::sycl::NdItemType::get(CGT.getModule()->getContext(), Dim,
+                                         Body);
+    }
+    case TypeEnum::NdRange: {
+      const auto Dim =
+          CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
+      return mlir::sycl::NdRangeType::get(CGT.getModule()->getContext(), Dim,
+                                          Body);
+    }
+    case TypeEnum::Range: {
+      const auto Dim =
+          CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
+      Body.push_back(CGT.getMLIRType(CTS->bases_begin()->getType()));
+      return mlir::sycl::RangeType::get(CGT.getModule()->getContext(), Dim,
+                                        Body);
+    }
+    case TypeEnum::TupleCopyAssignableValueHolder: {
+      const auto Type =
+          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
+      const auto IsTriviallyCopyAssignable =
+          CTS->getTemplateArgs().get(1).getAsIntegral().getExtValue();
+      Body.push_back(CGT.getMLIRType(CTS->bases_begin()->getType()));
+      return mlir::sycl::TupleCopyAssignableValueHolderType::get(
+          CGT.getModule()->getContext(), Type, IsTriviallyCopyAssignable, Body);
+    }
+    case TypeEnum::TupleValueHolder: {
+      const auto Type =
+          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
+      return mlir::sycl::TupleValueHolderType::get(
+          CGT.getModule()->getContext(), Type, Body);
+    }
+    case TypeEnum::Vec: {
       const auto ElemType =
           CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
       const auto NumElems =
@@ -244,18 +304,28 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
       return mlir::sycl::VecType::get(CGT.getModule()->getContext(), ElemType,
                                       NumElems, Body);
     }
-  }
-  if (const auto *CXXRD = llvm::dyn_cast<clang::CXXRecordDecl>(RD)) {
-    if (CXXRD->getName() == "AssertHappened")
-      return mlir::sycl::AssertHappenedType::get(CGT.getModule()->getContext(),
-                                                 Body);
-    if (CXXRD->getName() == "bfloat16")
-      return mlir::sycl::BFloat16Type::get(CGT.getModule()->getContext(), Body);
-    if (CXXRD->getName() == "sub_group")
-      return mlir::sycl::SubGroupType::get(CGT.getModule()->getContext());
+    default:
+      llvm_unreachable(
+          "ClassTemplateSpecializationDecl: SYCL type not handled (yet)");
+    }
   }
 
-  llvm_unreachable("SYCL type not handle (yet)");
+  if (const auto *CXXRD = llvm::dyn_cast<clang::CXXRecordDecl>(RD)) {
+    switch (StrToTypeEnum[CXXRD->getName().str()]) {
+    // Keep in alphabetical order.
+    case TypeEnum::AssertHappened:
+      return mlir::sycl::AssertHappenedType::get(CGT.getModule()->getContext(),
+                                                 Body);
+    case TypeEnum::BFloat16:
+      return mlir::sycl::BFloat16Type::get(CGT.getModule()->getContext(), Body);
+    case TypeEnum::SubGroup:
+      return mlir::sycl::SubGroupType::get(CGT.getModule()->getContext());
+    default:
+      llvm_unreachable("CXXRecordDecl: SYCL type not handled (yet)");
+    }
+  }
+
+  llvm_unreachable("SYCL type not handled (yet)");
 }
 
 llvm::Type *getLLVMType(const clang::QualType QT,

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1441,8 +1441,10 @@ ValueCategory MLIRScanner::CommonFieldLookup(clang::QualType CT,
             .Case<sycl::AccessorType, sycl::AccessorImplDeviceType,
                   sycl::AccessorSubscriptType, sycl::AtomicType,
                   sycl::GetScalarOpType, sycl::GroupType, sycl::ItemBaseType,
-                  sycl::ItemType, sycl::MultiPtrType, sycl::NdItemType,
-                  sycl::NdRangeType, sycl::VecType>([&](auto ElemTy) {
+                  sycl::ItemType, sycl::LocalAccessorBaseDeviceType,
+                  sycl::LocalAccessorBaseType, sycl::LocalAccessorType,
+                  sycl::MultiPtrType, sycl::NdItemType, sycl::NdRangeType,
+                  sycl::VecType>([&](auto ElemTy) {
               return SYCLCommonFieldLookup<decltype(ElemTy)>(Val, FNum, Shape);
             })
             .Default([&Val](Type T) {
@@ -1473,19 +1475,19 @@ ValueCategory MLIRScanner::CommonFieldLookup(clang::QualType CT,
 
 static bool isSYCLInheritType(Type &Ty, Value &Val) {
   assert(Val.getType().isa<MemRefType>());
+  if (!Ty.isa<MemRefType>())
+    return false;
 
-  Type ElemTy = Val.getType().cast<MemRefType>().getElementType();
-  return TypeSwitch<Type, bool>(ElemTy)
-      .Case<sycl::IDType, sycl::RangeType>([&](auto) {
-        assert(Ty.isa<MemRefType>());
-        return Ty.cast<MemRefType>().getElementType().isa<sycl::ArrayType>();
-      })
-      .Case<sycl::AccessorType>([&](auto) {
-        assert(Ty.isa<MemRefType>());
-        return Ty.cast<MemRefType>()
-            .getElementType()
-            .isa<sycl::AccessorCommonType>();
-      })
+  Type ElemTy = Ty.cast<MemRefType>().getElementType();
+
+  return TypeSwitch<Type, bool>(
+             Val.getType().cast<MemRefType>().getElementType())
+      .Case<sycl::AccessorType, sycl::LocalAccessorBaseType>(
+          [&](auto) { return ElemTy.isa<sycl::AccessorCommonType>(); })
+      .Case<sycl::LocalAccessorType>(
+          [&](auto) { return ElemTy.isa<sycl::LocalAccessorBaseType>(); })
+      .Case<sycl::IDType, sycl::RangeType>(
+          [&](auto) { return ElemTy.isa<sycl::ArrayType>(); })
       .Default([](auto) { return false; });
 }
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -21,7 +21,7 @@
 // CHECK-DAG: !sycl_item_2_ = !sycl.item<[2, false], (!sycl.item_base<[2, false], (!sycl_range_2_, !sycl_id_2_)>)>
 // CHECK-DAG: !sycl_LocalAccessorBaseDevice_1_ = !sycl.LocalAccessorBaseDevice<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 // CHECK-DAG: !sycl_local_accessor_base_1_i32_rw = !sycl.local_accessor_base<[1, i32, read_write], (!sycl_LocalAccessorBaseDevice_1_, memref<?xi32, 3>)>
-// CHECK-DAG: !sycl_local_accessor_1_i32_ = !sycl.local_accessor<[1, i32], ()>
+// CHECK-DAG: !sycl_local_accessor_1_i32_ = !sycl.local_accessor<[1, i32], (!sycl_local_accessor_base_1_i32_rw)>
 // CHECK-DAG: !sycl_multi_ptr_i32_1_ = !sycl.multi_ptr<[i32, 1, 1], (memref<?xi32, 1>)>
 // CHECK-DAG: !sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>)>, !sycl_group_1_)>
 // CHECK-DAG: !sycl_nd_item_2_ = !sycl.nd_item<[2], (!sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl_range_2_, !sycl_id_2_, !sycl_id_2_)>)>, !sycl_item_2_, !sycl_group_2_)>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -1,81 +1,59 @@
 // RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir -o - %s | FileCheck %s
+// COM: Keep the tests in alphabetical order !
 
 #include <sycl/sycl.hpp>
 
-// CHECK-DAG: !sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
-// CHECK-DAG: !sycl_array_2_ = !sycl.array<[2], (memref<2xi64, 4>)>
-// CHECK-DAG: !sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
-// CHECK-DAG: !sycl_id_2_ = !sycl.id<[2], (!sycl_array_2_)>
-// CHECK-DAG: !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
-// CHECK-DAG: !sycl_range_2_ = !sycl.range<[2], (!sycl_array_2_)>
 // CHECK-DAG: !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
 // CHECK-DAG: !sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>, !llvm.struct<(ptr<i32, 1>)>)>
 // CHECK-DAG: !sycl_accessor_3_f32_rw_gb = !sycl.accessor<[3, f32, read_write, global_buffer], (!sycl.accessor_impl_device<[3], (!sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>, !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>, !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>)>, !llvm.struct<(ptr<f32, 1>)>)>
+// CHECK-DAG: !sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
+// CHECK-DAG: !sycl_array_2_ = !sycl.array<[2], (memref<2xi64, 4>)>
+// CHECK-DAG: !sycl_assert_happened_ = !sycl.assert_happened<(i32, !llvm.array<257 x i8>, !llvm.array<257 x i8>, !llvm.array<129 x i8>, i32, i64, i64, i64, i64, i64, i64)>
+// CHECK-DAG: !sycl_atomic_f32_3_ = !sycl.atomic<[f32,3], (memref<?xf32, 3>)>
+// CHECK-DAG: !sycl_atomic_i32_1_ = !sycl.atomic<[i32,1], (memref<?xi32, 1>)>
+// CHECK-DAG: !sycl_bfloat16_ = !sycl.bfloat16<(i16)>
+// CHECK-DAG: !sycl_get_scalar_op_i32_ = !sycl.get_scalar_op<[i32], (i32)>
 // CHECK-DAG: !sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 // CHECK-DAG: !sycl_group_2_ = !sycl.group<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
-// CHECK-DAG: ![[ITEM1:.*]] = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>)>
-// CHECK-DAG: ![[ITEM2:.*]] = !sycl.item<[2, false], (!sycl.item_base<[2, false], (!sycl_range_2_, !sycl_id_2_)>)>
+// CHECK-DAG: !sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
+// CHECK-DAG: !sycl_id_2_ = !sycl.id<[2], (!sycl_array_2_)>
+// CHECK-DAG: !sycl_item_1_ = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>)>
+// CHECK-DAG: !sycl_item_2_ = !sycl.item<[2, false], (!sycl.item_base<[2, false], (!sycl_range_2_, !sycl_id_2_)>)>
+// CHECK-DAG: !sycl_LocalAccessorBaseDevice_1_ = !sycl.LocalAccessorBaseDevice<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+// CHECK-DAG: !sycl_local_accessor_base_1_i32_rw = !sycl.local_accessor_base<[1, i32, read_write], (!sycl_LocalAccessorBaseDevice_1_, memref<?xi32, 3>)>
+// CHECK-DAG: !sycl_local_accessor_1_i32_ = !sycl.local_accessor<[1, i32], ()>
+// CHECK-DAG: !sycl_multi_ptr_i32_1_ = !sycl.multi_ptr<[i32, 1, 1], (memref<?xi32, 1>)>
 // CHECK-DAG: !sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>)>, !sycl_group_1_)>
 // CHECK-DAG: !sycl_nd_item_2_ = !sycl.nd_item<[2], (!sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl_range_2_, !sycl_id_2_, !sycl_id_2_)>)>, !sycl_item_2_, !sycl_group_2_)>
 // CHECK-DAG: !sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 // CHECK-DAG: !sycl_nd_range_2_ = !sycl.nd_range<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
-// CHECK-DAG: !sycl_get_scalar_op_i32_ = !sycl.get_scalar_op<[i32], (i32)>
+// CHECK-DAG: ![[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_TRUE:.*]] = !sycl.tuple_copy_assignable_value_holder<[i32, true], (!sycl_tuple_value_holder_i32_)>
+// CHECK-DAG: ![[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_FALSE:.*]] = !sycl.tuple_copy_assignable_value_holder<[i32, false], (!sycl_tuple_value_holder_i32_)>
 // CHECK-DAG: !sycl_tuple_value_holder_i32_ = !sycl.tuple_value_holder<[i32], (i32)>
-// CHECK-DAG: [[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_TRUE:!sycl_tuple_copy_assignable_value_holder_i32_.*]] = !sycl.tuple_copy_assignable_value_holder<[i32, true], (!sycl_tuple_value_holder_i32_)>
-// CHECK-DAG: [[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_FALSE:!sycl_tuple_copy_assignable_value_holder_i32_.*]] = !sycl.tuple_copy_assignable_value_holder<[i32, false], (!sycl_tuple_value_holder_i32_)>
 // CHECK-DAG: !sycl_vec_f32_8_ = !sycl.vec<[f32, 8], (vector<8xf32>)>
 // CHECK-DAG: !sycl_vec_i32_4_ = !sycl.vec<[i32, 4], (vector<4xi32>)>
-// CHECK-DAG: !sycl_atomic_f32_3_ = !sycl.atomic<[f32,3], (memref<?xf32, 3>)>
-// CHECK-DAG: !sycl_atomic_i32_1_ = !sycl.atomic<[i32,1], (memref<?xi32, 1>)>
-// CHECK-DAG: !sycl_assert_happened_ = !sycl.assert_happened<(i32, !llvm.array<257 x i8>, !llvm.array<257 x i8>, !llvm.array<129 x i8>, i32, i64, i64, i64, i64, i64, i64)>
-// CHECK-DAG: !sycl_bfloat16_ = !sycl.bfloat16<(i16)>
-// CHECK-DAG: !sycl_multi_ptr_i32_1_ = !sycl.multi_ptr<[i32, 1, 1], (memref<?xi32, 1>)>
 
-// CHECK-LABEL: func.func @_Z4id_1N4sycl3_V12idILi1EEE(
-// CHECK:          %arg0: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef})
+// CHECK-LABEL: func.func @_Z10accessor_1N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
+// CHECK:          %arg0: memref<?x!sycl_accessor_1_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_1_i32_rw_gb, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC:llvm.cconv = #llvm.cconv<spir_funccc>]], [[LINKEXT:llvm.linkage = #llvm.linkage<external>]],
 // CHECK-SAME: [[PASSTHROUGH:passthrough = \["convergent", "mustprogress", "norecurse", "nounwind", \["frame-pointer", "all"\], \["no-trapping-math", "true"\], \["stack-protector-buffer-size", "8"\], \["sycl-module-id", ".*/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp"\]\]]]} {
-SYCL_EXTERNAL void id_1(sycl::id<1> id) {}
+SYCL_EXTERNAL void accessor_1(sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write, sycl::access::target::global_buffer>) {}
 
-// CHECK-LABEL: func.func @_Z4id_2N4sycl3_V12idILi2EEE(
-// CHECK:          %arg0: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})
-// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void id_2(sycl::id<2> id) {}
-
-// CHECK-LABEL: func.func @_Z5acc_1N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
-// CHECK:          %arg0: memref<?x!sycl_accessor_1_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_1_i32_rw_gb, llvm.noundef})
-// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void acc_1(sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write>) {}
-
-// CHECK-LABEL: func.func @_Z5acc_2N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
+// CHECK-LABEL: func.func @_Z10accessor_2N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
 // CHECK:          %arg0: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void acc_2(sycl::accessor<sycl::cl_int, 2, sycl::access::mode::read_write>) {}
+SYCL_EXTERNAL void accessor_2(sycl::accessor<sycl::cl_int, 2, sycl::access::mode::read_write, sycl::access::target::global_buffer>) {}
 
-// CHECK-LABEL: func.func @_Z5acc_3N4sycl3_V18accessorIfLi3ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
+// CHECK-LABEL: func.func @_Z10accessor_3N4sycl3_V18accessorIfLi3ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
 // CHECK:          %arg0: memref<?x!sycl_accessor_3_f32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_3_f32_rw_gb, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void acc_3(sycl::accessor<sycl::cl_float, 3, sycl::access::mode::read_write>) {}
+SYCL_EXTERNAL void accessor_3(sycl::accessor<sycl::cl_float, 3, sycl::access::mode::read_write, sycl::access::target::global_buffer>) {}
 
-// CHECK-LABEL: func.func @_Z7range_1N4sycl3_V15rangeILi1EEE(
-// CHECK:          %arg0: memref<?x!sycl_range_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_1_, llvm.noundef})
+// %"struct.sycl::_V1::detail::AssertHappened" = type { i32, [257 x i8], [257 x i8], [129 x i8], i32, i64, i64, i64, i64, i64, i64 }
+// CHECK-LABEL: func.func @_Z15assert_happenedN4sycl3_V16detail14AssertHappenedE(
+// CHECK:          %arg0: memref<?x!sycl_assert_happened_> {llvm.align = 8 : i64, llvm.byval = !sycl_assert_happened_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void range_1(sycl::range<1> range) {}
-
-// CHECK-LABEL: func.func @_Z7range_2N4sycl3_V15rangeILi2EEE(
-// CHECK:          %arg0: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef})  
-// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void range_2(sycl::range<2> range) {}
-
-// CHECK-LABEL: func.func @_Z10nd_range_1N4sycl3_V18nd_rangeILi1EEE(
-// CHECK:          %arg0: memref<?x!sycl_nd_range_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_1_, llvm.noundef})
-// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void nd_range_1(sycl::nd_range<1> nd_range) {}
-
-// CHECK-LABEL: func @_Z10nd_range_2N4sycl3_V18nd_rangeILi2EEE(
-// CHECK:          %arg0: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})  
-// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void nd_range_2(sycl::nd_range<2> nd_range) {}
+SYCL_EXTERNAL void assert_happened(sycl::detail::AssertHappened assert_happened) {}
 
 // CHECK-LABEL: func.func @_Z5arr_1N4sycl3_V16detail5arrayILi1EEE(
 // CHECK:          %arg0: memref<?x!sycl_array_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_array_1_, llvm.noundef})
@@ -87,35 +65,20 @@ SYCL_EXTERNAL void arr_1(sycl::detail::array<1> arr) {}
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
 SYCL_EXTERNAL void arr_2(sycl::detail::array<2> arr) {}
 
-// CHECK-LABEL: func.func @_Z11item_1_trueN4sycl3_V14itemILi1ELb1EEE(
-// CHECK:          %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef})
+// CHECK-LABEL: func.func @_Z8atomic_1N4sycl3_V16atomicIiLNS0_6access13address_spaceE1EEE(
+// CHECK:          %arg0: memref<?x!sycl_atomic_i32_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_atomic_i32_1_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void item_1_true(sycl::item<1, true> item) {}
+SYCL_EXTERNAL void atomic_1(sycl::atomic<int> atomic_int) {}
 
-// CHECK-LABEL: func.func @_Z12item_2_falseN4sycl3_V14itemILi2ELb0EEE(
-// CHECK:          %arg0: memref<?x![[ITEM2]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM2]], llvm.noundef})
+// CHECK-LABEL: func.func @_Z8atomic_2N4sycl3_V16atomicIfLNS0_6access13address_spaceE3EEE(
+// CHECK:          %arg0: memref<?x!sycl_atomic_f32_3_> {llvm.align = 8 : i64, llvm.byval = !sycl_atomic_f32_3_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void item_2_false(sycl::item<2, false> item) {}
+SYCL_EXTERNAL void atomic_2(sycl::atomic<float, sycl::access::address_space::local_space> atomic_float) {}
 
-// CHECK-LABEL: func.func @_Z9nd_item_1N4sycl3_V17nd_itemILi1EEE(
-// CHECK:          %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
+// CHECK-LABEL: func.func @_Z8bfloat16N4sycl3_V13ext6oneapi8bfloat16E(
+// CHECK:          %arg0: memref<?x!sycl_bfloat16_> {llvm.align = 2 : i64, llvm.byval = !sycl_bfloat16_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void nd_item_1(sycl::nd_item<1> nd_item) {}
-
-// CHECK-LABEL: func.func @_Z9nd_item_2N4sycl3_V17nd_itemILi2EEE(
-// CHECK:          %arg0: memref<?x!sycl_nd_item_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_2_, llvm.noundef})
-// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void nd_item_2(sycl::nd_item<2> nd_item) {}
-
-// CHECK-LABEL: func.func @_Z7group_1N4sycl3_V15groupILi1EEE(
-// CHECK:          %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
-// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void group_1(sycl::group<1> group) {}
-
-// CHECK-LABEL: func.func @_Z7group_2N4sycl3_V15groupILi2EEE(
-// CHECK:          %arg0: memref<?x!sycl_group_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_2_, llvm.noundef})
-// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void group_2(sycl::group<2> group) {}
+SYCL_EXTERNAL void bfloat16(sycl::ext::oneapi::bfloat16 bfloat16) {}
 
 // CHECK-LABEL: func.func @_Z6get_opN4sycl3_V16detail5GetOpIiEE(
 // CHECK:          %arg0: memref<?x!sycl.get_op<i32>> {llvm.align = 1 : i64, llvm.byval = !sycl.get_op<i32>, llvm.noundef})
@@ -127,58 +90,112 @@ SYCL_EXTERNAL void get_op(sycl::detail::GetOp<int> get_op) {}
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
 SYCL_EXTERNAL void get_scalar_op(sycl::detail::GetScalarOp<int> get_scalar_op) {}
 
-// CHECK-LABEL: func.func @_Z18tuple_value_holderN4sycl3_V16detail16TupleValueHolderIiEE(
-// CHECK:          %arg0: memref<?x!sycl_tuple_value_holder_i32_> {llvm.align = 4 : i64, llvm.byval = !sycl_tuple_value_holder_i32_, llvm.noundef})
+// CHECK-LABEL: func.func @_Z7group_1N4sycl3_V15groupILi1EEE(
+// CHECK:          %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void tuple_value_holder(sycl::detail::TupleValueHolder<int> get_tuple_value_holder) {}
+SYCL_EXTERNAL void group_1(sycl::group<1> group) {}
 
-// CHECK-LABEL: func.func @_Z36tuple_copy_assignable_value_holder_1N4sycl3_V16detail30TupleCopyAssignableValueHolderIiLb1EEE(
-// CHECK:          %arg0: memref<?x[[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_TRUE]]> {llvm.align = 4 : i64, llvm.byval = [[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_TRUE]], llvm.noundef})
+// CHECK-LABEL: func.func @_Z7group_2N4sycl3_V15groupILi2EEE(
+// CHECK:          %arg0: memref<?x!sycl_group_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_2_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void tuple_copy_assignable_value_holder_1(sycl::detail::TupleCopyAssignableValueHolder<int, true> tuple_copy_assignable_value_holder_true) {}
+SYCL_EXTERNAL void group_2(sycl::group<2> group) {}
 
-// CHECK-LABEL: func.func @_Z36tuple_copy_assignable_value_holder_2N4sycl3_V16detail30TupleCopyAssignableValueHolderIiLb0EEE(
-// CHECK:          %arg0: memref<?x[[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_FALSE]]> {llvm.align = 4 : i64, llvm.byval = [[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_FALSE]], llvm.noundef})
+// CHECK-LABEL: func.func @_Z4id_1N4sycl3_V12idILi1EEE(
+// CHECK:          %arg0: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void tuple_copy_assignable_value_holder_2(sycl::detail::TupleCopyAssignableValueHolder<int, false> tuple_copy_assignable_value_holder_false) {}
+SYCL_EXTERNAL void id_1(sycl::id<1> id) {}
 
-// CHECK-LABEL: func.func @_Z5vec_3N4sycl3_V13vecIiLi4EEE(
-// CHECK-SAME:    %arg0: memref<?x!sycl_vec_i32_4_> {llvm.align = 16 : i64, llvm.byval = !sycl_vec_i32_4_, llvm.noundef})
+// CHECK-LABEL: func.func @_Z4id_2N4sycl3_V12idILi2EEE(
+// CHECK:          %arg0: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void vec_3(sycl::vec<sycl::cl_int, 4> vec) {}
+SYCL_EXTERNAL void id_2(sycl::id<2> id) {}
 
-// CHECK-LABEL: func.func @_Z5vec_4N4sycl3_V13vecIfLi8EEE(
-// CHECK-SAME:    %arg0: memref<?x!sycl_vec_f32_8_> {llvm.align = 32 : i64, llvm.byval = !sycl_vec_f32_8_, llvm.noundef})
+// CHECK-LABEL: func.func @_Z11item_1_trueN4sycl3_V14itemILi1ELb1EEE(
+// CHECK:          %arg0: memref<?x!sycl_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void vec_4(sycl::float8 vec) {}
+SYCL_EXTERNAL void item_1_true(sycl::item<1, true> item) {}
 
-// CHECK-LABEL: func.func @_Z8atomic_1N4sycl3_V16atomicIiLNS0_6access13address_spaceE1EEE(
-// CHECK:          %arg0: memref<?x!sycl_atomic_i32_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_atomic_i32_1_, llvm.noundef})
+// CHECK-LABEL: func.func @_Z12item_2_falseN4sycl3_V14itemILi2ELb0EEE(
+// CHECK:          %arg0: memref<?x!sycl_item_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_2_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void atomic_1(sycl::atomic<int> atomic_int) {}
+SYCL_EXTERNAL void item_2_false(sycl::item<2, false> item) {}
 
-// CHECK-LABEL: func.func @_Z8atomic_2N4sycl3_V16atomicIfLNS0_6access13address_spaceE3EEE(
-// CHECK:          %arg0: memref<?x!sycl_atomic_f32_3_> {llvm.align = 8 : i64, llvm.byval = !sycl_atomic_f32_3_, llvm.noundef})
+// CHECK-LABEL: func.func @_Z26local_accessor_base_deviceN4sycl3_V16detail23LocalAccessorBaseDeviceILi1EEE(
+// CHECK:          %arg0: memref<?x!sycl_LocalAccessorBaseDevice_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_LocalAccessorBaseDevice_1_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void atomic_2(sycl::atomic<float, sycl::access::address_space::local_space> atomic_float) {}
+SYCL_EXTERNAL void local_accessor_base_device(sycl::detail::LocalAccessorBaseDevice<1> acc) {}
 
-// %"struct.sycl::_V1::detail::AssertHappened" = type { i32, [257 x i8], [257 x i8], [129 x i8], i32, i64, i64, i64, i64, i64, i64 }
-// CHECK-LABEL: func.func @_Z19get_assert_happenedN4sycl3_V16detail14AssertHappenedE(
-// CHECK:          %arg0: memref<?x!sycl_assert_happened_> {llvm.align = 8 : i64, llvm.byval = !sycl_assert_happened_, llvm.noundef})
+// CHECK-LABEL:  func.func @_Z19local_accessor_baseN4sycl3_V119local_accessor_baseIiLi1ELNS0_6access4modeE1026ELNS2_11placeholderE0EEE(
+// CHECK:          %arg0: memref<?x!sycl_local_accessor_base_1_i32_rw> {llvm.align = 8 : i64, llvm.byval = !sycl_local_accessor_base_1_i32_rw, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void get_assert_happened(sycl::detail::AssertHappened get_assert_happened) {}
+SYCL_EXTERNAL void local_accessor_base(sycl::local_accessor_base<sycl::cl_int, 1, sycl::access::mode::read_write, sycl::access::placeholder::false_t> acc) {}
 
-// CHECK-LABEL: func.func @_Z12get_bfloat16N4sycl3_V13ext6oneapi8bfloat16E(
-// CHECK:          %arg0: memref<?x!sycl_bfloat16_> {llvm.align = 2 : i64, llvm.byval = !sycl_bfloat16_, llvm.noundef})
+// CHECK-LABEL: func.func @_Z14local_accessorN4sycl3_V114local_accessorIiLi1EEE(
+// CHECK:          %arg0: memref<?x!sycl_local_accessor_1_i32_> {llvm.align = 8 : i64, llvm.byval = !sycl_local_accessor_1_i32_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void get_bfloat16(sycl::ext::oneapi::bfloat16 get_bfloat16) {}
-
-// CHECL-LABEL: func.func @_Z13get_sub_groupN4sycl3_V13ext6oneapi9sub_groupE(
-// CHECK:          %arg0: memref<?x!sycl.sub_group> {llvm.align = 1 : i64, llvm.byval = !sycl.sub_group, llvm.noundef})
-// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void get_sub_group(sycl::ext::oneapi::sub_group get_sub_group) {}
+SYCL_EXTERNAL void local_accessor(sycl::local_accessor<sycl::cl_int, 1> acc) {}
 
 // CHECK-LABEL: func.func @_Z9multi_ptrN4sycl3_V19multi_ptrIiLNS0_6access13address_spaceE1ELNS2_9decoratedE1EEE(
 // CHECK:          %arg0: memref<?x!sycl_multi_ptr_i32_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_multi_ptr_i32_1_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
 SYCL_EXTERNAL void multi_ptr(sycl::multi_ptr<int, sycl::access::address_space::global_space, sycl::access::decorated::yes> multi_ptr_int) {}
+
+// CHECK-LABEL: func.func @_Z9nd_item_1N4sycl3_V17nd_itemILi1EEE(
+// CHECK:          %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void nd_item_1(sycl::nd_item<1> nd_item) {}
+
+// CHECK-LABEL: func.func @_Z9nd_item_2N4sycl3_V17nd_itemILi2EEE(
+// CHECK:          %arg0: memref<?x!sycl_nd_item_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_2_, llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void nd_item_2(sycl::nd_item<2> nd_item) {}
+
+// CHECK-LABEL: func.func @_Z10nd_range_1N4sycl3_V18nd_rangeILi1EEE(
+// CHECK:          %arg0: memref<?x!sycl_nd_range_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_1_, llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void nd_range_1(sycl::nd_range<1> nd_range) {}
+
+// CHECK-LABEL: func @_Z10nd_range_2N4sycl3_V18nd_rangeILi2EEE(
+// CHECK:          %arg0: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})  
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void nd_range_2(sycl::nd_range<2> nd_range) {}
+
+// CHECK-LABEL: func.func @_Z7range_1N4sycl3_V15rangeILi1EEE(
+// CHECK:          %arg0: memref<?x!sycl_range_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_1_, llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void range_1(sycl::range<1> range) {}
+
+// CHECK-LABEL: func.func @_Z7range_2N4sycl3_V15rangeILi2EEE(
+// CHECK:          %arg0: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef})  
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void range_2(sycl::range<2> range) {}
+
+// CHECL-LABEL: func.func @_Z13sub_groupN4sycl3_V13ext6oneapi9sub_groupE(
+// CHECK:          %arg0: memref<?x!sycl.sub_group> {llvm.align = 1 : i64, llvm.byval = !sycl.sub_group, llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void sub_group(sycl::ext::oneapi::sub_group get_sub_group) {}
+
+// CHECK-LABEL: func.func @_Z36tuple_copy_assignable_value_holder_1N4sycl3_V16detail30TupleCopyAssignableValueHolderIiLb1EEE(
+// CHECK:          %arg0: memref<?x![[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_TRUE]]> {llvm.align = 4 : i64, llvm.byval = ![[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_TRUE]], llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void tuple_copy_assignable_value_holder_1(sycl::detail::TupleCopyAssignableValueHolder<int, true> tuple_copy_assignable_value_holder_true) {}
+
+// CHECK-LABEL: func.func @_Z36tuple_copy_assignable_value_holder_2N4sycl3_V16detail30TupleCopyAssignableValueHolderIiLb0EEE(
+// CHECK:          %arg0: memref<?x![[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_FALSE]]> {llvm.align = 4 : i64, llvm.byval = ![[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_FALSE]], llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void tuple_copy_assignable_value_holder_2(sycl::detail::TupleCopyAssignableValueHolder<int, false> tuple_copy_assignable_value_holder_false) {}
+
+// CHECK-LABEL: func.func @_Z18tuple_value_holderN4sycl3_V16detail16TupleValueHolderIiEE(
+// CHECK:          %arg0: memref<?x!sycl_tuple_value_holder_i32_> {llvm.align = 4 : i64, llvm.byval = !sycl_tuple_value_holder_i32_, llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void tuple_value_holder(sycl::detail::TupleValueHolder<int> tuple_value_holder) {}
+
+// CHECK-LABEL: func.func @_Z5vec_1N4sycl3_V13vecIiLi4EEE(
+// CHECK-SAME:    %arg0: memref<?x!sycl_vec_i32_4_> {llvm.align = 16 : i64, llvm.byval = !sycl_vec_i32_4_, llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void vec_1(sycl::vec<sycl::cl_int, 4> vec) {}
+
+// CHECK-LABEL: func.func @_Z5vec_2N4sycl3_V13vecIfLi8EEE(
+// CHECK-SAME:    %arg0: memref<?x!sycl_vec_f32_8_> {llvm.align = 32 : i64, llvm.byval = !sycl_vec_f32_8_, llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void vec_2(sycl::float8 vec) {}


### PR DESCRIPTION
The clang generated LLVM IR types for the aforementioned types are:
  - %"class.sycl::_V1::detail::LocalAccessorBaseDevice" = type { %"class.sycl::_V1::range", %"class.sycl::_V1::range", %"class.sycl::_V1::id" }
  - %"class.sycl::_V1::local_accessor_base" = type { %"class.sycl::_V1::detail::LocalAccessorBaseDevice", i32 addrspace(3)* }
  - %"class.sycl::_V1::local_accessor" = type { %"class.sycl::_V1::local_accessor_base" }

 