### PR TITLE
Undo a bit of fcf4e360ba6b that confuses MSVC

### DIFF
--- a/clang/lib/Serialization/GlobalModuleIndex.cpp
+++ b/clang/lib/Serialization/GlobalModuleIndex.cpp
@@ -815,8 +815,10 @@ bool GlobalModuleIndexBuilder::writeIndex(llvm::BitstreamWriter &Stream) {
     IdentifierIndexWriterTrait Trait;
 
     // Populate the hash table.
-    for (auto &[Identifier, IDs] : InterestingIdentifiers) {
-      Generator.insert(Identifier, IDs, Trait);
+    for (InterestingIdentifierMap::iterator I = InterestingIdentifiers.begin(),
+                                            IEnd = InterestingIdentifiers.end();
+         I != IEnd; ++I) {
+      Generator.insert(I->first(), I->second, Trait);
     }
 
     // Create the on-disk hash table in a buffer.


### PR DESCRIPTION
clang\lib\Serialization\GlobalModuleIndex.cpp(818): error C2440: 'initializing': cannot convert from 'const ValueTy' to '_Ty2 &&'
        with
        [
            ValueTy=llvm::SmallVector<unsigned int,2>
        ]
        and
        [
            _Ty2=llvm::SmallVector<unsigned int,2>
        ]