### PR TITLE
[SYCL][CMake][LibDevice] Avoid gcc-toolchain fixup for /bin/g++

### DIFF
--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -37,8 +37,10 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   # freshly built clang. The system one might be very old.
   get_filename_component(gcc_bin_dir ${CMAKE_CXX_COMPILER} DIRECTORY)
   get_filename_component(gcc_install_dir ${gcc_bin_dir} DIRECTORY)
-  list(APPEND compile_opts
-    "--gcc-toolchain=${gcc_install_dir}")
+  # /bin/g++ doesn't need any fixup.
+  if (NOT gcc_install_dir STREQUAL "/")
+    list(APPEND compile_opts "--gcc-toolchain=${gcc_install_dir}")
+  endif()
 endif()
 
 if ("NVPTX" IN_LIST LLVM_TARGETS_TO_BUILD)


### PR DESCRIPTION
Should fix "/verify with" in llvm-test-suite. The issue was introduced in #7628.