### PR TITLE
[SYCL-MLIR] Use TypeSwitch to get SYCL element type

### DIFF
--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -287,6 +287,13 @@ private:
   mlir::Value SYCLCommonFieldLookup(mlir::Value V, size_t FNum,
                                     llvm::ArrayRef<int64_t> Shape);
 
+  // Return a MemRefType with the \p ElemIndex element of \p SYCLType with \p
+  // Shape shape in \p MemorySpace memory space.
+  template <typename T>
+  mlir::MemRefType SYCLGetElementType(T SYCLType, unsigned ElemIndex,
+                                      llvm::ArrayRef<int64_t> Shape,
+                                      mlir::Attribute MemorySpace);
+
   mlir::LLVM::AllocaOp allocateBuffer(size_t I, mlir::LLVM::LLVMPointerType T) {
     auto &Vec = Bufs[T.getAsOpaquePointer()];
     if (I < Vec.size())


### PR DESCRIPTION
Before this PR, `InitializeValueByInitListExpr` asserts for an explicit list of SYCL types, this is error prone, as we may forget to update the list when adding new types.
In the PR, `InitializeValueByInitListExpr` uses a `TypeSwitch` to get the SYCL element type. The default case of the `TypeSwitch` asserts, which forces types in use to explicitly define its behavior, instead of silently fail somewhere else (or luckily pass).
This PR also added a templated function `SYCLGetElementType`, which aims to reduce duplication for different SYCL types.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>