### PR TITLE
[SPIR-V] Reorder invocations of fixType, ReplaceTypeInOperands and mergeType

### DIFF
--- a/llvm-spirv/lib/SPIRV/SPIRVTypeScavenger.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVTypeScavenger.cpp
@@ -504,19 +504,19 @@ void SPIRVTypeScavenger::correctUseTypes(Instruction &I) {
       } else if (auto *DeferredUseTy = dyn_cast<DeferredType *>(UsedTy)) {
         // Source type is fixed, use type is deferred: set the deferred type to
         // the fixed type.
-        fixType(*DeferredUseTy, FixedTy);
         ReplaceTypeInOperands(DeferredUseTy, FixedTy);
+        fixType(*DeferredUseTy, FixedTy);
       }
     } else if (auto *DeferredTy = dyn_cast<DeferredType *>(SourceTy)) {
       if (auto *FixedUseTy = dyn_cast<Type *>(UsedTy)) {
         // Source type is fixed, use type is deferred: set the deferred type to
         // the fixed type.
-        fixType(*DeferredTy, FixedUseTy);
         ReplaceTypeInOperands(DeferredTy, FixedUseTy);
+        fixType(*DeferredTy, FixedUseTy);
       } else if (auto *DeferredUseTy = dyn_cast<DeferredType *>(UsedTy)) {
         // If they're both deferred, merge the two types together.
-        mergeType(DeferredTy, DeferredUseTy);
         ReplaceTypeInOperands(DeferredUseTy, DeferredTy);
+        mergeType(DeferredTy, DeferredUseTy);
       }
     }
   }


### PR DESCRIPTION
The reason of change is to mitigate Coverity warnings from CMPLRLLVM-42088. The issue is that SPIRVTypeScavenger::fixType method performs `delete &Ty` at the end. Then this freed
pointer is used later just as value (not dereferenced). Nevertheles, Coverity claims use-after-free warning. This commit reorders function's invocations to mitigate this issue.

Probably, a better approach could be a move to "C++ style" memory management.