### PR TITLE
[SYCL-MLIR] Implement sycl::detail::RoundedRangeKernel SYCL type

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -311,6 +311,13 @@ def SYCL_RangeType
   let assemblyFormat = "`<`  `[` $dimension `]` `,` `(` $body `)` `>`";
 }
 
+def SYCL_RoundedRangeKernelType : SYCL_Type<"RoundedRangeKernel", "rounded_range_kernel"> {
+  let parameters = (ins "::mlir::Type":$dataType,
+                        "unsigned":$dimension,
+                        ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<` `[` $dataType `,` $dimension `]` `,` `(` $body `)` `>`";
+}
+
 def SYCL_SubGroupType : SYCL_Type<"SubGroup", "sub_group"> {
   let assemblyFormat = "";
 }

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -271,6 +271,15 @@ static Optional<Type> convertRangeType(sycl::RangeType type,
                          type.getBody(), converter);
 }
 
+/// Converts SYCL RoundedRangeKernel type to LLVM type.
+static Optional<Type>
+convertRoundedRangeKernelType(sycl::RoundedRangeKernelType type,
+                              LLVMTypeConverter &converter) {
+  return convertBodyType("class.sycl::_V1::detail::RoundedRangeKernel." +
+                             std::to_string(type.getDimension()),
+                         type.getBody(), converter);
+}
+
 /// Converts SYCL nd_range type to LLVM type.
 static Optional<Type> convertNdRangeType(sycl::NdRangeType type,
                                          LLVMTypeConverter &converter) {
@@ -578,6 +587,9 @@ void mlir::sycl::populateSYCLToLLVMTypeConversion(
   });
   typeConverter.addConversion([&](sycl::RangeType type) {
     return convertRangeType(type, typeConverter);
+  });
+  typeConverter.addConversion([&](sycl::RoundedRangeKernelType type) {
+    return convertRoundedRangeKernelType(type, typeConverter);
   });
   typeConverter.addConversion([&](sycl::SubGroupType type) {
     return convertSubGroupType(type, typeConverter);

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
@@ -154,7 +154,8 @@ SYCLOpAsmInterface::getAlias(mlir::Type Type, llvm::raw_ostream &OS) const {
            << "_";
         return AliasResult::FinalAlias;
       })
-      .Case<mlir::sycl::ItemType, mlir::sycl::ItemBaseType>([&](auto Ty) {
+      .Case<mlir::sycl::ItemType, mlir::sycl::ItemBaseType,
+            mlir::sycl::RoundedRangeKernelType>([&](auto Ty) {
         OS << "sycl_" << decltype(Ty)::getMnemonic() << "_" << Ty.getDimension()
            << "_";
         return AliasResult::OverridableAlias;

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
@@ -56,7 +56,7 @@ func.func @test_accessor_common(%arg0: !sycl.accessor_common) {
 func.func @test_accessorImplDevice(%arg0: !sycl_accessor_impl_device_1_) {
   return
 }
-// CHECK: llvm.func @test_accessor.1(%arg0: !llvm.struct<"class.sycl::_V1::accessor{{.*}}", ([[ACCESSORIMPLDEVICE_1]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>[[SUFFIX]])
+// CHECK: llvm.func @test_accessor.1(%arg0: !llvm.[[ACCESSOR_1:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_1]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>[[SUFFIX]])
 func.func @test_accessor.1(%arg0: !sycl_accessor_1_i32_rw_gb) {
   return
 }
@@ -208,6 +208,21 @@ func.func @test_nd_range.1(%arg0: !sycl_nd_range_1_) {
 }
 // CHECK: llvm.func @test_nd_range.2(%arg0: !llvm.[[ND_RANGE_2:struct<"class.sycl::_V1::nd_range.*", \(]][[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[ID_2]][[ARRAY_2]][[SUFFIX]][[SUFFIX]]) {
 func.func @test_nd_range.2(%arg0: !sycl_nd_range_2_) {
+  return
+}
+
+// -----
+
+!sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
+!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
+!sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
+!sycl_accessor_1_i32_w_gb = !sycl.accessor<[1, i32, write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_rounded_range_kernel_1_ = !sycl.rounded_range_kernel<[!sycl_item_1_, 1], (!sycl_range_1_, !llvm.struct<(!sycl_accessor_1_i32_w_gb)>)>
+// CHECK: llvm.func @test_rounded_range_kernel(%arg0: !llvm.struct<"class.sycl::_V1::detail::RoundedRangeKernel.1{{.*}}", ([[RANGE_1]][[ARRAY_1]][[SUFFIX]], struct<([[ACCESSOR_1]][[ACCESSORIMPLDEVICE_1]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]], struct<(ptr<i32, 1>)>[[SUFFIX]][[SUFFIX]][[SUFFIX]]) {
+func.func @test_rounded_range_kernel(%arg0: !sycl_rounded_range_kernel_1_) {
   return
 }
 

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -266,7 +266,8 @@ mlir::Attribute MLIRScanner::InitializeValueByInitListExpr(mlir::Value ToInit,
                                                    MemRefLayoutAttrInterface(),
                                                    MT.getMemorySpace());
                     })
-                    .Case<mlir::sycl::ItemBaseType>([&](auto Ty) {
+                    .Case<mlir::sycl::ItemBaseType,
+                          mlir::sycl::RoundedRangeKernelType>([&](auto Ty) {
                       return mlir::MemRefType::get(Shape, Ty.getBody()[I],
                                                    MemRefLayoutAttrInterface(),
                                                    MT.getMemorySpace());
@@ -680,7 +681,7 @@ ValueCategory MLIRScanner::VisitMaterializeTemporaryExpr(
     return V;
 
   CGEIST_WARNING(llvm::WithColor::warning()
-                 << "cleanup of materialized not handled");
+                 << "cleanup of materialized not handled\n");
   auto Op =
       createAllocOp(Glob.getTypes().getMLIRType(Expr->getSubExpr()->getType()),
                     nullptr, 0, /*isArray*/ IsArray, /*LLVMABI*/ LLVMABI);

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1353,8 +1353,8 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
           TypeName == "maximum" || TypeName == "minimum" ||
           TypeName == "multi_ptr" || TypeName == "nd_item" ||
           TypeName == "nd_range" || TypeName == "OwnerLessBase" ||
-          TypeName == "range" || TypeName == "sub_group" ||
-          TypeName == "SwizzleOp" ||
+          TypeName == "range" || TypeName == "RoundedRangeKernel" ||
+          TypeName == "sub_group" || TypeName == "SwizzleOp" ||
           TypeName == "TupleCopyAssignableValueHolder" ||
           TypeName == "TupleValueHolder" || TypeName == "vec") {
         return getSYCLType(RT, *this);

--- a/polygeist/tools/cgeist/Lib/TypeUtils.cc
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.cc
@@ -130,6 +130,7 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
     NdRange,
     OwnerLessBase,
     Range,
+    RoundedRangeKernel,
     SubGroup,
     SwizzleOp,
     TupleCopyAssignableValueHolder,
@@ -165,6 +166,7 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
       {"nd_range", TypeEnum::NdRange},
       {"OwnerLessBase", TypeEnum::OwnerLessBase},
       {"range", TypeEnum::Range},
+      {"RoundedRangeKernel", TypeEnum::RoundedRangeKernel},
       {"sub_group", SubGroup},
       {"SwizzleOp", SwizzleOp},
       {"TupleCopyAssignableValueHolder", TupleCopyAssignableValueHolder},
@@ -346,6 +348,14 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
       Body.push_back(CGT.getMLIRType(CTS->bases_begin()->getType()));
       return mlir::sycl::RangeType::get(CGT.getModule()->getContext(), Dim,
                                         Body);
+    }
+    case TypeEnum::RoundedRangeKernel: {
+      const auto Type =
+          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
+      const auto Dim =
+          CTS->getTemplateArgs().get(1).getAsIntegral().getExtValue();
+      return mlir::sycl::RoundedRangeKernelType::get(
+          CGT.getModule()->getContext(), Type, Dim, Body);
     }
     case TypeEnum::TupleCopyAssignableValueHolder: {
       const auto Type =

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1447,7 +1447,8 @@ ValueCategory MLIRScanner::CommonFieldLookup(clang::QualType CT,
                   sycl::ItemType, sycl::LocalAccessorBaseDeviceType,
                   sycl::LocalAccessorBaseType, sycl::LocalAccessorType,
                   sycl::MultiPtrType, sycl::NdItemType, sycl::NdRangeType,
-                  sycl::SwizzledVecType, sycl::VecType>([&](auto ElemTy) {
+                  sycl::RoundedRangeKernelType, sycl::SwizzledVecType,
+                  sycl::VecType>([&](auto ElemTy) {
               return SYCLCommonFieldLookup<decltype(ElemTy)>(Val, FNum, Shape);
             })
             .Default([&Val](Type T) {


### PR DESCRIPTION
clang generated example:
```
%"class.sycl::_V1::detail::RoundedRangeKernel" = type { %"class.sycl::_V1::range", %class.anon }
%class.anon = type { %"class.sycl::_V1::accessor" }
```

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>