### PR TITLE
[NFC][SYCL] Use "inline constexpr" unconditionally

### DIFF
--- a/sycl/include/sycl/detail/defines_elementary.hpp
+++ b/sycl/include/sycl/detail/defines_elementary.hpp
@@ -55,15 +55,6 @@
 #endif
 #endif // __SYCL2020_DEPRECATED
 
-#ifndef __SYCL_INLINE_CONSTEXPR
-// inline constexpr is a C++17 feature
-#if __cplusplus >= 201703L
-#define __SYCL_INLINE_CONSTEXPR inline constexpr
-#else
-#define __SYCL_INLINE_CONSTEXPR static constexpr
-#endif
-#endif // __SYCL_INLINE_CONSTEXPR
-
 #ifndef __SYCL_HAS_CPP_ATTRIBUTE
 #if defined(__cplusplus) && defined(__has_cpp_attribute)
 #define __SYCL_HAS_CPP_ATTRIBUTE(x) __has_cpp_attribute(x)

--- a/sycl/include/sycl/detail/type_traits.hpp
+++ b/sycl/include/sycl/detail/type_traits.hpp
@@ -66,12 +66,12 @@ template <typename ElementType, access::address_space Space,
 class multi_ptr;
 
 template <class T>
-__SYCL_INLINE_CONSTEXPR bool is_group_v =
+inline constexpr bool is_group_v =
     detail::is_group<T>::value || detail::is_sub_group<T>::value;
 
 namespace ext::oneapi::experimental {
 template <class T>
-__SYCL_INLINE_CONSTEXPR bool is_group_helper_v =
+inline constexpr bool is_group_helper_v =
     detail::is_group_helper<std::decay_t<T>>::value;
 } // namespace ext::oneapi::experimental
 

--- a/sycl/include/sycl/ext/oneapi/atomic_enums.hpp
+++ b/sycl/include/sycl/ext/oneapi/atomic_enums.hpp
@@ -26,31 +26,28 @@ namespace oneapi {
 
 using memory_order __SYCL2020_DEPRECATED("use 'sycl::memory_order' instead") =
     sycl::memory_order;
-__SYCL_INLINE_CONSTEXPR memory_order memory_order_relaxed __SYCL2020_DEPRECATED(
+inline constexpr memory_order memory_order_relaxed __SYCL2020_DEPRECATED(
     "use 'sycl::memory_order_relaxed' instead") = memory_order::relaxed;
-__SYCL_INLINE_CONSTEXPR memory_order memory_order_acquire __SYCL2020_DEPRECATED(
+inline constexpr memory_order memory_order_acquire __SYCL2020_DEPRECATED(
     "use 'sycl::memory_order_acquire' instead") = memory_order::acquire;
-__SYCL_INLINE_CONSTEXPR memory_order memory_order_release __SYCL2020_DEPRECATED(
+inline constexpr memory_order memory_order_release __SYCL2020_DEPRECATED(
     "use 'sycl::memory_order_release' instead") = memory_order::release;
-__SYCL_INLINE_CONSTEXPR memory_order memory_order_acq_rel __SYCL2020_DEPRECATED(
+inline constexpr memory_order memory_order_acq_rel __SYCL2020_DEPRECATED(
     "use 'sycl::memory_order_acq_rel' instead") = memory_order::acq_rel;
-__SYCL_INLINE_CONSTEXPR memory_order memory_order_seq_cst __SYCL2020_DEPRECATED(
+inline constexpr memory_order memory_order_seq_cst __SYCL2020_DEPRECATED(
     "use 'sycl::memory_order_seq_cst' instead") = memory_order::seq_cst;
 
 using memory_scope __SYCL2020_DEPRECATED("use 'sycl::memory_scope' instead") =
     sycl::memory_scope;
-__SYCL_INLINE_CONSTEXPR
-memory_scope memory_scope_work_item __SYCL2020_DEPRECATED(
+inline constexpr memory_scope memory_scope_work_item __SYCL2020_DEPRECATED(
     "use 'sycl::memory_scope_work_item' instead") = memory_scope::work_item;
-__SYCL_INLINE_CONSTEXPR
-memory_scope memory_scope_sub_group __SYCL2020_DEPRECATED(
+inline constexpr memory_scope memory_scope_sub_group __SYCL2020_DEPRECATED(
     "use 'sycl::memory_scope_sub_group' instead") = memory_scope::sub_group;
-__SYCL_INLINE_CONSTEXPR memory_scope memory_scope_work_group
-    __SYCL2020_DEPRECATED("use 'sycl::memory_scope_work_group' instead") =
-        memory_scope::work_group;
-__SYCL_INLINE_CONSTEXPR memory_scope memory_scope_device __SYCL2020_DEPRECATED(
+inline constexpr memory_scope memory_scope_work_group __SYCL2020_DEPRECATED(
+    "use 'sycl::memory_scope_work_group' instead") = memory_scope::work_group;
+inline constexpr memory_scope memory_scope_device __SYCL2020_DEPRECATED(
     "use 'sycl::memory_scope_device' instead") = memory_scope::device;
-__SYCL_INLINE_CONSTEXPR memory_scope memory_scope_system __SYCL2020_DEPRECATED(
+inline constexpr memory_scope memory_scope_system __SYCL2020_DEPRECATED(
     "use 'sycl::memory_scope_system' instead") = memory_scope::system;
 
 #ifndef __SYCL_DEVICE_ONLY__

--- a/sycl/include/sycl/known_identity.hpp
+++ b/sycl/include/sycl/known_identity.hpp
@@ -381,7 +381,7 @@ struct has_known_identity
                                       std::decay_t<AccumulatorT>> {};
 
 template <typename BinaryOperation, typename AccumulatorT>
-__SYCL_INLINE_CONSTEXPR bool has_known_identity_v =
+inline constexpr bool has_known_identity_v =
     sycl::has_known_identity<BinaryOperation, AccumulatorT>::value;
 
 // ---- known_identity
@@ -391,7 +391,7 @@ struct known_identity
                                   std::decay_t<AccumulatorT>> {};
 
 template <typename BinaryOperation, typename AccumulatorT>
-__SYCL_INLINE_CONSTEXPR AccumulatorT known_identity_v =
+inline constexpr AccumulatorT known_identity_v =
     sycl::known_identity<BinaryOperation, AccumulatorT>::value;
 
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)

--- a/sycl/include/sycl/properties/accessor_properties.hpp
+++ b/sycl/include/sycl/properties/accessor_properties.hpp
@@ -25,10 +25,10 @@ class __SYCL2020_DEPRECATED("spelling is now: no_init") noinit
 
 } // namespace property
 
-__SYCL_INLINE_CONSTEXPR property::no_init no_init;
+inline constexpr property::no_init no_init;
 
 __SYCL2020_DEPRECATED("spelling is now: no_init")
-__SYCL_INLINE_CONSTEXPR property::noinit noinit;
+inline constexpr property::noinit noinit;
 
 namespace ext {
 namespace intel {

--- a/sycl/include/sycl/properties/property_traits.hpp
+++ b/sycl/include/sycl/properties/property_traits.hpp
@@ -24,10 +24,10 @@ template <typename propertyT, typename syclObjectT>
 struct is_property_of : public std::false_type {};
 
 template <typename propertyT>
-__SYCL_INLINE_CONSTEXPR bool is_property_v = is_property<propertyT>::value;
+inline constexpr bool is_property_v = is_property<propertyT>::value;
 
 template <typename propertyT, typename syclObjectT>
-__SYCL_INLINE_CONSTEXPR bool is_property_of_v =
+inline constexpr bool is_property_of_v =
     is_property_of<propertyT, syclObjectT>::value;
 
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)


### PR DESCRIPTION
C++17 is minimally supported standard, so it is always available to us.