### PR TITLE
[NFC][SYCL] Use [[fallthrough]] unconditionally

### DIFF
--- a/sycl/include/sycl/detail/defines_elementary.hpp
+++ b/sycl/include/sycl/detail/defines_elementary.hpp
@@ -72,21 +72,6 @@
 #endif
 #endif
 
-#ifndef __SYCL_FALLTHROUGH
-#if defined(__cplusplus) && __cplusplus >= 201703L &&                          \
-    __SYCL_HAS_CPP_ATTRIBUTE(fallthrough)
-#define __SYCL_FALLTHROUGH [[fallthrough]]
-#elif __SYCL_HAS_CPP_ATTRIBUTE(gnu::fallthrough)
-#define __SYCL_FALLTHROUGH [[gnu::fallthrough]]
-#elif __has_attribute(fallthrough)
-#define __SYCL_FALLTHROUGH __attribute__((fallthrough))
-#elif __SYCL_HAS_CPP_ATTRIBUTE(clang::fallthrough)
-#define __SYCL_FALLTHROUGH [[clang::fallthrough]]
-#else
-#define __SYCL_FALLTHROUGH
-#endif
-#endif // __SYCL_FALLTHROUGH
-
 // Stringify an argument to pass it in _Pragma directive below.
 #ifndef __SYCL_STRINGIFY
 #define __SYCL_STRINGIFY(x) #x

--- a/sycl/source/detail/image_impl.cpp
+++ b/sycl/source/detail/image_impl.cpp
@@ -288,10 +288,10 @@ image_impl::image_impl(cl_mem MemObject, const context &SyclContext,
   switch (MDimensions) {
   case 3:
     getImageInfo(Context, PI_IMAGE_INFO_DEPTH, MRange[2], Mem);
-    __SYCL_FALLTHROUGH;
+    [[fallthrough]];
   case 2:
     getImageInfo(Context, PI_IMAGE_INFO_HEIGHT, MRange[1], Mem);
-    __SYCL_FALLTHROUGH;
+    [[fallthrough]];
   case 1:
     getImageInfo(Context, PI_IMAGE_INFO_WIDTH, MRange[0], Mem);
   }


### PR DESCRIPTION
C++17 guarantees its existence.