### PR TITLE
[NFC][SYCL] Remove __SYCL_INLINE_NAMESPACE macro

### DIFF
--- a/sycl/include/sycl/detail/defines_elementary.hpp
+++ b/sycl/include/sycl/detail/defines_elementary.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#define __SYCL_INLINE_NAMESPACE(X) inline namespace X
-
 #define __SYCL_INLINE_VER_NAMESPACE(X) inline namespace X
 
 #ifndef __has_attribute

--- a/sycl/include/sycl/detail/info_desc_helpers.hpp
+++ b/sycl/include/sycl/detail/info_desc_helpers.hpp
@@ -12,7 +12,7 @@
 #include <sycl/info/info_desc.hpp>
 
 namespace sycl {
-__SYCL_INLINE_NAMESPACE(_V1) {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace detail {
 template <typename T> struct PiInfoCode;
 template <typename T> struct is_platform_info_desc : std::false_type {};
@@ -117,5 +117,5 @@ struct IsSubGroupInfo<info::kernel_device_specific::compile_sub_group_size>
 #undef __SYCL_PARAM_TRAITS_SPEC
 
 } // namespace detail
-} // __SYCL_INLINE_NAMESPACE(_V1)
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/oneapi/experimental/uniform.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/uniform.hpp
@@ -15,7 +15,7 @@
 // 1 - Initial extension version. Base features are supported.
 #define SYCL_EXT_ONEAPI_UNIFORM 1
 
-#include <sycl/detail/defines_elementary.hpp> // for __SYCL_INLINE_NAMESPACE
+#include <sycl/detail/defines_elementary.hpp> // for __SYCL_INLINE_VER_NAMESPACE
 
 #include <type_traits>
 


### PR DESCRIPTION
Existing uses should have been __SYCL_INLINE_VER_NAMESPACE and after fixing them the macro becomes dead.