### PR TITLE
[SYCL][L0] Return maximum group size in L0 for info::kernel_device_specific::work_group_size

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -5321,6 +5321,7 @@ pi_result piKernelGetGroupInfo(pi_kernel Kernel, pi_device Device,
     return ReturnValue(WorkSize);
   }
   case PI_KERNEL_GROUP_INFO_WORK_GROUP_SIZE: {
+    // As of right now, L0 is missing API to query kernel and device specific max work group size. 
     return ReturnValue(
         pi_uint64{Device->ZeDeviceComputeProperties->maxTotalGroupSize});
   }

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -5321,10 +5321,8 @@ pi_result piKernelGetGroupInfo(pi_kernel Kernel, pi_device Device,
     return ReturnValue(WorkSize);
   }
   case PI_KERNEL_GROUP_INFO_WORK_GROUP_SIZE: {
-    uint32_t X, Y, Z;
-    ZE_CALL(zeKernelSuggestGroupSize,
-            (Kernel->ZeKernel, 10000, 10000, 10000, &X, &Y, &Z));
-    return ReturnValue(size_t{X * Y * Z});
+    return ReturnValue(
+        pi_uint64{Device->ZeDeviceComputeProperties->maxTotalGroupSize});
   }
   case PI_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE: {
     struct {


### PR DESCRIPTION
Level-zero currently implements kernel.get_info<info::kernel_device_specific::work_group_size> by calling zeKernelSuggestGroupSize which gives a group size suggestion based on a global size. This seems to be against specification where the descriptor requires the maximum work items available for execution in a group
Signed-off-by: Rauf, Rana <rana.rauf@intel.com>