### PR TITLE
[SYCL][CUDA] Add missing include to `pi_cuda.hpp`

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.hpp
+++ b/sycl/plugins/cuda/pi_cuda.hpp
@@ -26,6 +26,7 @@
   _PI_PLUGIN_VERSION_STRING(_PI_CUDA_PLUGIN_VERSION)
 
 #include "sycl/detail/pi.h"
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <cassert>


### PR DESCRIPTION
MSVC 14.2 builds on windows with the `--cuda` flag to buildbot are failing due to a missing `algorithm` import on `llvm/sycl/plugins/cuda/pi_cuda.hpp`, due to the usage of `std::all_of`