### PR TITLE
[SYCL][Fusion] Fix kernel fusion passes tests

### DIFF
--- a/sycl-fusion/passes/CMakeLists.txt
+++ b/sycl-fusion/passes/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Module library for usage as library/pass-plugin with LLVM opt.
-add_llvm_library(SYCLKernelFusion SHARED
+add_llvm_library(SYCLKernelFusion MODULE
   SYCLFusionPasses.cpp
   kernel-fusion/SYCLKernelFusion.cpp
   kernel-info/SYCLKernelInfo.cpp

--- a/sycl-fusion/passes/cleanup/Cleanup.cpp
+++ b/sycl-fusion/passes/cleanup/Cleanup.cpp
@@ -37,7 +37,7 @@ static void copyAttributesFrom(const BitVector &Mask, Function *NF,
   NF->copyAttributesFrom(F);
   // Drop masked-out attributes.
   SmallVector<AttributeSet> Attributes;
-  const llvm::AttributeList PAL = NF->getAttributes();
+  const AttributeList PAL = NF->getAttributes();
   std::transform(Mask.set_bits_begin(), Mask.set_bits_end(),
                  std::back_inserter(Attributes),
                  [&](unsigned I) { return PAL.getParamAttrs(I); });
@@ -47,11 +47,9 @@ static void copyAttributesFrom(const BitVector &Mask, Function *NF,
 
 static Function *createMaskedFunction(const BitVector &Mask, Function *F) {
   // Declare
-  llvm::FunctionType *NFTy =
-      createMaskedFunctionType(Mask, F->getFunctionType());
-  llvm::Function *NF =
-      Function::Create(NFTy, F->getLinkage(), F->getAddressSpace(),
-                       F->getName(), F->getParent());
+  FunctionType *NFTy = createMaskedFunctionType(Mask, F->getFunctionType());
+  Function *NF = Function::Create(NFTy, F->getLinkage(), F->getAddressSpace(),
+                                  F->getName(), F->getParent());
   copyAttributesFrom(Mask, NF, F);
   NF->setComdat(F->getComdat());
   NF->takeName(F);
@@ -74,7 +72,7 @@ static Function *createMaskedFunction(const BitVector &Mask, Function *F) {
     // Copy metadata.
     SmallVector<std::pair<unsigned, MDNode *>> MDs;
     F->getAllMetadata(MDs);
-    for (auto MD : MDs) {
+    for (auto &MD : MDs) {
       NF->addMetadata(MD.first, *MD.second);
     }
   }
@@ -108,7 +106,7 @@ static void applyArgMask(const jit_compiler::ArgUsageMask &NewArgInfo,
                          const BitVector &Mask, Function *F,
                          ModuleAnalysisManager &AM) {
   // Create the function without the masked-out args.
-  llvm::Function *NF = createMaskedFunction(Mask, F);
+  Function *NF = createMaskedFunction(Mask, F);
   // Update the unused args mask.
   jit_compiler::SYCLModuleInfo *ModuleInfo =
       AM.getResult<SYCLModuleInfoAnalysis>(*NF->getParent()).ModuleInfo;

--- a/sycl-fusion/passes/kernel-info/SYCLKernelInfo.cpp
+++ b/sycl-fusion/passes/kernel-info/SYCLKernelInfo.cpp
@@ -25,8 +25,8 @@ llvm::AnalysisKey SYCLModuleInfoAnalysis::Key;
 
 void SYCLModuleInfoAnalysis::loadModuleInfoFromFile() {
   DiagnosticPrinterRawOStream Printer{llvm::errs()};
-  llvm::ErrorOr<std::unique_ptr<MemoryBuffer>> FileOrError =
-      llvm::MemoryBuffer::getFile(ModuleInfoFilePath);
+  ErrorOr<std::unique_ptr<MemoryBuffer>> FileOrError =
+      MemoryBuffer::getFile(ModuleInfoFilePath);
   if (std::error_code EC = FileOrError.getError()) {
     Printer << "Could not open file " << ModuleInfoFilePath << " due to error "
             << EC.message() << "\n";
@@ -50,8 +50,8 @@ SYCLModuleInfoAnalysis::run(Module &, ModuleAnalysisManager &) {
   return {ModuleInfo.get()};
 }
 
-PreservedAnalyses SYCLModuleInfoPrinter::run(llvm::Module &Mod,
-                                             llvm::ModuleAnalysisManager &MAM) {
+PreservedAnalyses SYCLModuleInfoPrinter::run(Module &Mod,
+                                             ModuleAnalysisManager &MAM) {
   jit_compiler::SYCLModuleInfo *ModuleInfo =
       MAM.getResult<SYCLModuleInfoAnalysis>(Mod).ModuleInfo;
   if (!ModuleInfo) {

--- a/sycl-fusion/test/CMakeLists.txt
+++ b/sycl-fusion/test/CMakeLists.txt
@@ -16,7 +16,7 @@ add_lit_testsuite(check-sycl-fusion-lit-tests "Running LLVM lit test suite"
     "${CMAKE_CURRENT_BINARY_DIR}"
 
     DEPENDS
-    SYCLKernelFusionPasses
+    SYCLKernelFusion
     opt
     FileCheck
 )

--- a/sycl-fusion/test/internalization/promote-local-scalar.ll
+++ b/sycl-fusion/test/internalization/promote-local-scalar.ll
@@ -1,4 +1,4 @@
-; RUN: opt -load-pass-plugin %shlibdir/libSYCLKernelFusionPasses%shlibext\
+; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext\
 ; RUN: -passes=sycl-internalization --sycl-info-path %S/../kernel-fusion/kernel-info.yaml -S %s | FileCheck %s
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"

--- a/sycl-fusion/test/internalization/promote-local-vec.ll
+++ b/sycl-fusion/test/internalization/promote-local-vec.ll
@@ -1,4 +1,4 @@
-; RUN: opt -load-pass-plugin %shlibdir/libSYCLKernelFusionPasses%shlibext\
+; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext\
 ; RUN: -passes=sycl-internalization --sycl-info-path %S/../kernel-fusion/kernel-info.yaml -S %s | FileCheck %s
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"

--- a/sycl-fusion/test/internalization/promote-private-scalar.ll
+++ b/sycl-fusion/test/internalization/promote-private-scalar.ll
@@ -1,4 +1,4 @@
-; RUN: opt -load-pass-plugin %shlibdir/libSYCLKernelFusionPasses%shlibext\
+; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext\
 ; RUN: -passes=sycl-internalization --sycl-info-path %S/../kernel-fusion/kernel-info.yaml -S %s | FileCheck %s
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"

--- a/sycl-fusion/test/internalization/promote-private-vec.ll
+++ b/sycl-fusion/test/internalization/promote-private-vec.ll
@@ -1,4 +1,4 @@
-; RUN: opt -load-pass-plugin %shlibdir/libSYCLKernelFusionPasses%shlibext\
+; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext\
 ; RUN: -passes=sycl-internalization --sycl-info-path %S/../kernel-fusion/kernel-info.yaml -S %s | FileCheck %s
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"

--- a/sycl-fusion/test/kernel-fusion/required_work_group_size.ll
+++ b/sycl-fusion/test/kernel-fusion/required_work_group_size.ll
@@ -1,4 +1,4 @@
-; RUN: opt -load-pass-plugin %shlibdir/libSYCLKernelFusionPasses%shlibext\
+; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext\
 ; RUN: -passes=sycl-kernel-fusion\
 ; RUN: --sycl-info-path %S/required_work_group_size.yaml -S %s\
 ; RUN: | FileCheck %s

--- a/sycl-fusion/test/kernel-fusion/two-kernels-no-identities.ll
+++ b/sycl-fusion/test/kernel-fusion/two-kernels-no-identities.ll
@@ -1,15 +1,15 @@
 ; Check IR produced by fusion pass:
-; RUN: opt -load-pass-plugin %shlibdir/libSYCLKernelFusionPasses%shlibext\
+; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext\
 ; RUN: -passes="sycl-kernel-fusion" --sycl-info-path %S/kernel-info.yaml -S %s\
 ; RUN: | FileCheck %s --implicit-check-not fused_kernel --check-prefix FUSION
 
 ; Check metadata attached to kernel by fusion pass:
-; RUN: opt -load-pass-plugin %shlibdir/libSYCLKernelFusionPasses%shlibext\
+; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext\
 ; RUN: -passes=sycl-kernel-fusion --sycl-info-path %S/kernel-info.yaml -S %s\
 ; RUN: | FileCheck %s --check-prefix MD
 
 ; Check kernel information produced by fusion pass:
-; RUN: opt -load-pass-plugin %shlibdir/libSYCLKernelFusionPasses%shlibext\
+; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext\
 ; RUN: -passes=sycl-kernel-fusion,print-sycl-module-info -disable-output --sycl-info-path %S/kernel-info.yaml -S %s\
 ; RUN: | FileCheck %s --check-prefix INFO
 

--- a/sycl-fusion/test/kernel-fusion/two-kernels-out-is-in.ll
+++ b/sycl-fusion/test/kernel-fusion/two-kernels-out-is-in.ll
@@ -1,15 +1,15 @@
 ; Check IR produced by fusion pass:
-; RUN: opt -load-pass-plugin %shlibdir/libSYCLKernelFusionPasses%shlibext\
+; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext\
 ; RUN: -passes="sycl-kernel-fusion" --sycl-info-path %S/kernel-info.yaml -S %s\
 ; RUN: | FileCheck %s --implicit-check-not fused_kernel --check-prefix FUSION
 
 ; Check metadata attached to kernel by fusion pass:
-; RUN: opt -load-pass-plugin %shlibdir/libSYCLKernelFusionPasses%shlibext\
+; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext\
 ; RUN: -passes=sycl-kernel-fusion --sycl-info-path %S/kernel-info.yaml -S %s\
 ; RUN: | FileCheck %s --check-prefix MD
 
 ; Check kernel information produced by fusion pass:
-; RUN: opt -load-pass-plugin %shlibdir/libSYCLKernelFusionPasses%shlibext\
+; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext\
 ; RUN: -passes=sycl-kernel-fusion,print-sycl-module-info -disable-output --sycl-info-path %S/kernel-info.yaml -S %s\
 ; RUN: | FileCheck %s --check-prefix INFO
 

--- a/sycl-fusion/test/kernel-fusion/work_group_size_hint.ll
+++ b/sycl-fusion/test/kernel-fusion/work_group_size_hint.ll
@@ -1,4 +1,4 @@
-; RUN: opt -load-pass-plugin %shlibdir/libSYCLKernelFusionPasses%shlibext\
+; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext\
 ; RUN: -passes=sycl-kernel-fusion\
 ; RUN: --sycl-info-path %S/work_group_size_hint.yaml -S %s\
 ; RUN: | FileCheck %s

--- a/sycl-fusion/test/kernel-info/kernel-info.ll
+++ b/sycl-fusion/test/kernel-info/kernel-info.ll
@@ -1,4 +1,4 @@
-; RUN: opt -load-pass-plugin %shlibdir/libSYCLKernelFusionPasses%shlibext\
+; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext\
 ; RUN: -passes=print-sycl-module-info\
 ; RUN: --sycl-info-path %S/kernel-info.yaml -disable-output %s | FileCheck %s
 

--- a/sycl-fusion/test/syclcp/syclcp.ll
+++ b/sycl-fusion/test/syclcp/syclcp.ll
@@ -1,4 +1,4 @@
-; RUN: opt -load-pass-plugin %shlibdir/libSYCLKernelFusionPasses%shlibext\
+; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext\
 ; RUN: -passes=sycl-cp -S %s -sycl-info-path %S/../kernel-fusion/kernel-info.yaml | FileCheck %s
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"
 target triple = "spir64-unknown-unknown"


### PR DESCRIPTION
Fix tests for kernel fusion passes in static builds by using correct library, loadable by `opt`, for tests. 

Also fixes post-commit feedback from @AlexeySachkov in #7661.

Signed-off-by: Lukas Sommer <lukas.sommer@codeplay.com>