### PR TITLE
[CI] Update drivers installation process into containers

### DIFF
--- a/.github/workflows/sycl_containers.yaml
+++ b/.github/workflows/sycl_containers.yaml
@@ -94,6 +94,8 @@ jobs:
           build-args: |
             compute_runtime_tag=${{fromJson(steps.deps.outputs.deps).linux.compute_runtime.github_tag}}
             igc_tag=${{fromJson(steps.deps.outputs.deps).linux.igc.github_tag}}
+            cm_tag=${{fromJson(steps.deps.outputs.deps).linux.cm.github_tag}}
+            level_zero_tag=${{fromJson(steps.deps.outputs.deps).linux.level_zero.github_tag}}
             tbb_tag=${{fromJson(steps.deps.outputs.deps).linux.tbb.github_tag}}
             fpgaemu_tag=${{fromJson(steps.deps.outputs.deps).linux.fpgaemu.github_tag}}
             cpu_tag=${{fromJson(steps.deps.outputs.deps).linux.oclcpu.github_tag}}
@@ -128,12 +130,8 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/ubuntu2004_intel_drivers:unstable-${{ github.sha }}
             ghcr.io/${{ github.repository }}/ubuntu2004_intel_drivers:unstable
-          build-args: |
-            compute_runtime_tag=${{fromJson(steps.deps.outputs.deps).linux_staging.compute_runtime.github_tag}}
-            igc_tag=${{fromJson(steps.deps.outputs.deps).linux_staging.igc.github_tag}}
-            tbb_tag=${{fromJson(steps.deps.outputs.deps).linux_staging.tbb.github_tag}}
-            fpgaemu_tag=${{fromJson(steps.deps.outputs.deps).linux_staging.fpgaemu.github_tag}}
-            cpu_tag=${{fromJson(steps.deps.outputs.deps).linux_staging.oclcpu.github_tag}}
+          # build-args:empty , so we automatically take the "latest" tags as
+          # unstable
 
   base_image_ubuntu2204:
     if: github.repository == 'intel/llvm'
@@ -207,10 +205,11 @@ jobs:
           build-args: |
             compute_runtime_tag=${{fromJson(steps.deps.outputs.deps).linux.compute_runtime.github_tag}}
             igc_tag=${{fromJson(steps.deps.outputs.deps).linux.igc.github_tag}}
+            cm_tag=${{fromJson(steps.deps.outputs.deps).linux.cm.github_tag}}
+            level_zero_tag=${{fromJson(steps.deps.outputs.deps).linux.level_zero.github_tag}}
             tbb_tag=${{fromJson(steps.deps.outputs.deps).linux.tbb.github_tag}}
             fpgaemu_tag=${{fromJson(steps.deps.outputs.deps).linux.fpgaemu.github_tag}}
             cpu_tag=${{fromJson(steps.deps.outputs.deps).linux.oclcpu.github_tag}}
-
   # This job produces a Docker container with the latest versions of Intel
   # drivers, that can be found on GitHub.
   drivers_image_ubuntu2204_unstable:
@@ -241,10 +240,5 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/ubuntu2204_intel_drivers:unstable-${{ github.sha }}
             ghcr.io/${{ github.repository }}/ubuntu2204_intel_drivers:unstable
-          build-args: |
-            compute_runtime_tag=${{fromJson(steps.deps.outputs.deps).linux_staging.compute_runtime.github_tag}}
-            igc_tag=${{fromJson(steps.deps.outputs.deps).linux_staging.igc.github_tag}}
-            tbb_tag=${{fromJson(steps.deps.outputs.deps).linux_staging.tbb.github_tag}}
-            fpgaemu_tag=${{fromJson(steps.deps.outputs.deps).linux_staging.fpgaemu.github_tag}}
-            cpu_tag=${{fromJson(steps.deps.outputs.deps).linux_staging.oclcpu.github_tag}}
-
+          # build-args:empty, so we automatically take the "latest" tags as
+          # unstable

--- a/devops/containers/ubuntu2004_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2004_intel_drivers.Dockerfile
@@ -8,6 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ARG compute_runtime_tag=latest
 ARG igc_tag=latest
 ARG cm_tag=latest
+ARG level_zero_tag=latest
 ARG tbb_tag=latest
 ARG fpgaemu_tag=latest
 ARG cpu_tag=latest

--- a/devops/containers/ubuntu2204_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2204_intel_drivers.Dockerfile
@@ -8,6 +8,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ARG compute_runtime_tag=latest
 ARG igc_tag=latest
 ARG cm_tag=latest
+ARG level_zero_tag=latest
 ARG tbb_tag=latest
 ARG fpgaemu_tag=latest
 ARG cpu_tag=latest

--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -18,6 +18,12 @@
       "url": "https://github.com/intel/cm-compiler/releases/tag/cmclang-1.0.144",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
+    "level_zero": {
+      "github_tag": "v1.8.8",
+      "version": "v1.8.8",
+      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.8.8",
+      "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
+    },
     "tbb": {
       "github_tag": "v2021.5.0",
       "version": "2021.5.0",

--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -46,47 +46,6 @@
       "root": "{ARCHIVE_ROOT}/comp/oclfpga/linux"
     }
   },
-  "linux_staging": {
-    "compute_runtime": {
-      "github_tag": "22.31.23852",
-      "version": "22.31.23852",
-      "url": "https://github.com/intel/compute-runtime/releases/tag/22.31.23852",
-      "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
-    },
-    "igc": {
-      "github_tag": "igc-1.0.11485",
-      "version": "1.0.11485",
-      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/igc-1.0.11485",
-      "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
-    },
-    "cm": {
-      "github_tag": "cmclang-1.0.144",
-      "version": "1.0.144",
-      "url": "https://github.com/intel/cm-compiler/releases/tag/cmclang-1.0.144",
-      "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
-    },
-    "tbb": {
-      "github_tag": "v2021.5.0",
-      "version": "2021.5.0",
-      "url": "https://github.com/oneapi-src/oneTBB/releases/download/v2021.5.0/oneapi-tbb-2021.5.0-lin.tgz",
-      "root": "{DEPS_ROOT}/tbb/lin"
-    },
-    "oclcpu": {
-      "github_tag": "2021-WW50",
-      "version": "2021.13.11.0.23",
-      "url": "https://github.com/intel/llvm/releases/download/2021-WW50/oclcpuexp-2021.13.11.0.23_rel.tar.gz",
-      "root": "{DEPS_ROOT}/opencl/runtime/linux/oclcpu"
-    },
-    "fpgaemu": {
-      "github_tag": "2021-WW50",
-      "version": "2021.13.11.0.23",
-      "url": "https://github.com/intel/llvm/releases/download/2021-WW50/fpgaemu-2021.13.11.0.23_rel.tar.gz",
-      "root": "{DEPS_ROOT}/opencl/runtime/linux/oclfpgaemu"
-    },
-    "fpga": {
-      "root": "{ARCHIVE_ROOT}/comp/oclfpga/linux"
-    }
-  },
   "windows": {
     "compute_runtime": {
       "version": "101.1191",

--- a/devops/scripts/generate_test_matrix.js
+++ b/devops/scripts/generate_test_matrix.js
@@ -17,7 +17,9 @@ module.exports = ({core, process}) => {
               driverOld["linux"]["igc"]["version"] ||
           driverNew["linux"]["cm"]["version"] !==
               driverOld["linux"]["cm"]["version"] ||
-          driverNew["linux"]["tbb"]["version"] !==
+          driverNew["linux"]["level_zero"]["version"] !==
+              driverOld["linux"]["level_zero"]["version"] ||
+           driverNew["linux"]["tbb"]["version"] !==
               driverOld["linux"]["tbb"]["version"] ||
           driverNew["linux"]["oclcpu"]["version"] !==
               driverOld["linux"]["oclcpu"]["version"] ||
@@ -37,6 +39,7 @@ module.exports = ({core, process}) => {
                   driverNew["linux"]["compute_runtime"]["github_tag"],
               "igc_tag" : driverNew["linux"]["igc"]["github_tag"],
               "cm_tag" : driverNew["linux"]["cm"]["github_tag"],
+              "level_zero_tag" : driverNew["linux"]["level_zero"]["github_tag"],
               "tbb_tag" : driverNew["linux"]["tbb"]["github_tag"],
               "cpu_tag" : driverNew["linux"]["oclcpu"]["github_tag"],
               "fpgaemu_tag" : driverNew["linux"]["fpgaemu"]["github_tag"],
@@ -82,6 +85,7 @@ module.exports = ({core, process}) => {
                   driverNew["linux"]["compute_runtime"]["github_tag"],
               "igc_tag" : driverNew["linux"]["igc"]["github_tag"],
               "cm_tag" : driverNew["linux"]["cm"]["github_tag"],
+              "level_zero_tag" : driverNew["linux"]["level_zero"]["github_tag"],
               "tbb_tag" : driverNew["linux"]["tbb"]["github_tag"],
               "cpu_tag" : driverNew["linux"]["oclcpu"]["github_tag"],
               "fpgaemu_tag" : driverNew["linux"]["fpgaemu"]["github_tag"],

--- a/devops/scripts/generate_test_matrix.js
+++ b/devops/scripts/generate_test_matrix.js
@@ -19,7 +19,7 @@ module.exports = ({core, process}) => {
               driverOld["linux"]["cm"]["version"] ||
           driverNew["linux"]["level_zero"]["version"] !==
               driverOld["linux"]["level_zero"]["version"] ||
-           driverNew["linux"]["tbb"]["version"] !==
+          driverNew["linux"]["tbb"]["version"] !==
               driverOld["linux"]["tbb"]["version"] ||
           driverNew["linux"]["oclcpu"]["version"] !==
               driverOld["linux"]["oclcpu"]["version"] ||

--- a/devops/scripts/install_drivers.sh
+++ b/devops/scripts/install_drivers.sh
@@ -3,6 +3,7 @@
 CR_TAG=$compute_runtime_tag
 IGC_TAG=$igc_tag
 CM_TAG=$cm_tag
+L0_TAG=$level_zero_tag
 TBB_TAG=$tbb_tag
 FPGA_TAG=$fpgaemu_tag
 CPU_TAG=$cpu_tag
@@ -47,6 +48,9 @@ InstallIGFX () {
     | wget -qi -
   sha256sum -c *.sum && \
   python3 $LOCATION/get_release.py intel/cm-compiler $CM_TAG \
+    | grep ".*deb" \
+    | wget -qi -
+  python3 $LOCATION/get_release.py oneapi-src/level-zero $L0_TAG \
     | grep ".*deb" \
     | wget -qi -
   dpkg -i *.deb && rm *.deb *.sum

--- a/devops/scripts/install_drivers.sh
+++ b/devops/scripts/install_drivers.sh
@@ -40,6 +40,7 @@ InstallIGFX () {
   echo "Compute Runtime version $CR_TAG"
   echo "IGC version $IGC_TAG"
   echo "CM compiler version $CM_TAG"
+  echo "Level Zero version $L0_TAG"
   python3 $LOCATION/get_release.py intel/intel-graphics-compiler $IGC_TAG \
     | grep ".*deb" \
     | wget -qi -
@@ -49,6 +50,7 @@ InstallIGFX () {
   sha256sum -c *.sum && \
   python3 $LOCATION/get_release.py intel/cm-compiler $CM_TAG \
     | grep ".*deb" \
+    | grep -v "u18" \
     | wget -qi -
   python3 $LOCATION/get_release.py oneapi-src/level-zero $L0_TAG \
     | grep ".*deb" \

--- a/devops/scripts/update_drivers.py
+++ b/devops/scripts/update_drivers.py
@@ -33,6 +33,11 @@ def uplift_linux_igfx_driver(config, platform_tag):
     config[platform_tag]['cm']['version'] = cm['tag_name'].replace('cmclang-', '')
     config[platform_tag]['cm']['url'] = 'https://github.com/intel/cm-compiler/releases/tag/' + cm['tag_name']
 
+    level_zero = get_latest_release('oneapi-src/level-zero')
+    config[platform_tag]['level_zero']['github_tag'] = level_zero['tag_name']
+    config[platform_tag]['level_zero']['version'] = level_zero['tag_name']
+    config[platform_tag]['level_zero']['url'] = 'https://github.com/oneapi-src/level-zero/releases/tag/' + level_zero['tag_name']
+
     return config
 
 
@@ -52,5 +57,5 @@ def main(platform_tag):
 
 
 if __name__ == '__main__':
-    platform_tag = sys.argv[1] if len(sys.argv) > 1 else 'linux_staging'
+    platform_tag = sys.argv[1] if len(sys.argv) > 1 else "ERROR_PLATFORM"
     sys.stdout.write(main(platform_tag) + '\n')


### PR DESCRIPTION
* Install level_zero loader and headers as part of the drivers installation. Should be installed as dependency into containers, rather than built and shipped with the compiler.
* Add level_zero to update_drivers.py
* Fix CM install. Takes version from dependencies.json rather than always the latest.
* Exclude u18 CM package from consideration. Before it was installing u18 then u20 and produced a warning.
* Update "unstable" containers build by always taking the "latest" packages rather than relying on prior definition of staging versions.
* Clean up dependencies.json and erase specific staging versions. We stopped updating these earlier.