### PR TITLE
[SYCL-MLIR] Allow atomic access mode when return type os sycl.atomic for sycl.accessor.subscript operation.

### DIFF
--- a/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
@@ -101,14 +101,18 @@ mlir::LogicalResult mlir::sycl::SYCLAccessorSubscriptOp::verify() {
     return emitOpError("Dimensions cannot be zero");
 
   const auto verifyResultType = [&]() -> mlir::LogicalResult {
-    const auto resultMemrefType = getResult().getType().dyn_cast<mlir::MemRefType>();
-    const auto resultAtomicType = getResult().getType().dyn_cast<mlir::sycl::AtomicType>();
+    const auto resultMemrefType =
+        getResult().getType().dyn_cast<mlir::MemRefType>();
+    const auto resultAtomicType =
+        getResult().getType().dyn_cast<mlir::sycl::AtomicType>();
 
     if (!resultMemrefType && !resultAtomicType) {
-      return emitOpError("Expecting memref or sycl.atomic return type. Got ") << getResult().getType();
+      return emitOpError("Expecting memref or sycl.atomic return type. Got ")
+             << getResult().getType();
     }
 
-    if (resultMemrefType && resultMemrefType.getElementType() != AccessorTy.getType()) {
+    if (resultMemrefType &&
+        resultMemrefType.getElementType() != AccessorTy.getType()) {
       return emitOpError(
                  "Expecting a reference to this accessor's value type (")
              << AccessorTy.getType() << "). Got " << getResult().getType();
@@ -139,11 +143,12 @@ mlir::LogicalResult mlir::sycl::SYCLAccessorSubscriptOp::verify() {
         }
         if (AccessorTy.getAccessMode() ==
             mlir::sycl::MemoryAccessMode::Atomic) {
-              const auto resultType = getResult().getType().dyn_cast<mlir::sycl::AtomicType>();
+          const auto resultType =
+              getResult().getType().dyn_cast<mlir::sycl::AtomicType>();
           if (!resultType) {
             // For atomic return type, allow atomic access mode.
-            return emitOpError(
-              "Cannot use this signature when the atomic access mode is used");
+            return emitOpError("Cannot use this signature when the atomic "
+                               "access mode is used");
           }
         }
         return verifyResultType();

--- a/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
@@ -99,12 +99,12 @@ mlir::LogicalResult mlir::sycl::SYCLAccessorSubscriptOp::verify() {
   const unsigned Dimensions = AccessorTy.getDimension();
   if (Dimensions == 0)
     return emitOpError("Dimensions cannot be zero");
-  
+
   const auto resultMemrefType =
-        getResult().getType().dyn_cast<mlir::MemRefType>();
+      getResult().getType().dyn_cast<mlir::MemRefType>();
   const auto resultAtomicType =
-        getResult().getType().dyn_cast<mlir::sycl::AtomicType>();
-  
+      getResult().getType().dyn_cast<mlir::sycl::AtomicType>();
+
   const auto verifyResultType = [&]() -> mlir::LogicalResult {
     if (!resultMemrefType && !resultAtomicType) {
       return emitOpError("Expecting memref or sycl.atomic return type. Got ")
@@ -140,13 +140,14 @@ mlir::LogicalResult mlir::sycl::SYCLAccessorSubscriptOp::verify() {
         if (Dimensions != 1) {
           // Implementation defined result type.
           return success();
-        }            
-        
+        }
+
         // Allow atomic access mode only for atomic return type.
         if (AccessorTy.getAccessMode() ==
-            mlir::sycl::MemoryAccessMode::Atomic && !resultAtomicType) {
-            return emitOpError("Cannot use this signature when the atomic "
-                               "access mode is used");
+                mlir::sycl::MemoryAccessMode::Atomic &&
+            !resultAtomicType) {
+          return emitOpError("Cannot use this signature when the atomic "
+                             "access mode is used");
         }
         return verifyResultType();
       })

--- a/mlir-sycl/test/Dialect/IR/SYCL/acc_subscript.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/acc_subscript.mlir
@@ -1,0 +1,12 @@
+// RUN: sycl-mlir-opt -allow-unregistered-dialect %s -split-input-file | FileCheck %s
+
+// Ensure atomic access mode is OK when we have atomic return type for sycl.accessor.subscript.
+// CHECK-LABEL: func.func @AccessorSubscript
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_accessor_1_i32_ato_gb = !sycl.accessor<[1, i32, atomic, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_atomic_i32_1_ = !sycl.atomic<[i32,1], (memref<?xi32, 1>)>
+func.func @AccessorSubscript(%arg0: memref<?x!sycl_accessor_1_i32_ato_gb, 4>, %arg1: i64) {
+  %0 = "sycl.accessor.subscript"(%arg0, %arg1) {BaseType = memref<?x!sycl_accessor_1_i32_ato_gb, 4>, FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIjLi1ELNS0_6access4modeE1029ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EEENSt9enable_ifIXaaeqT_Li1EeqcvS3_Li1029ELS3_1029EENS0_6atomicIjLNS2_13address_spaceE1EEEE4typeEm, TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_ato_gb, 4>, i64) -> !sycl_atomic_i32_1_
+  return
+}


### PR DESCRIPTION
There are signatures for accessor which returns atomic return type and for those cases, it is acceptable to have access mode as atomic.  This PR allows these conditions.