### PR TITLE
[SYCL] Add No RDC Windows lit tests

### DIFF
--- a/clang/test/Driver/sycl-no-rdc-fat-archive-win.cpp
+++ b/clang/test/Driver/sycl-no-rdc-fat-archive-win.cpp
@@ -1,0 +1,32 @@
+
+/// test behaviors of passing a fat static lib with -fno-sycl-rdc on Windows
+// REQUIRES: system-windows
+
+// Build a fat static lib that will be used for all tests
+// RUN: echo "void foo(void) {}" > %t1.cpp
+// RUN: %clangxx -target x86_64-pc-windows-msvc -fsycl %t1.cpp -c -o %t1_bundle.o
+// RUN: llvm-ar cr %t_lib.a %t1_bundle.o
+// RUN: %clang -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=off --sysroot=%S/Inputs/SYCL %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
+// RUN: %clang -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=auto --sysroot=%S/Inputs/SYCL %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
+// RUN: %clang -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=per_kernel --sysroot=%S/Inputs/SYCL %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
+// RUN: %clang -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=per_source --sysroot=%S/Inputs/SYCL %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
+// CHECK: 2: input, "{{.*}}_lib.a", archive
+// CHECK: 3: clang-offload-unbundler, {2}, tempfilelist
+// CHECK: 4: spirv-to-ir-wrapper, {3}, tempfilelist, (device-sycl)
+// CHECK: 5: input, "{{.*}}libsycl-crt{{.*}}", object
+// CHECK: 6: clang-offload-unbundler, {5}, object
+// CHECK: 7: offload, " (spir64-unknown-unknown)" {6}, object
+// CHECK: 68: linker, {7, {{.*}}}, ir, (device-sycl)
+// CHECK: 69: linker, {4, 68}, ir, (device-sycl)
+// CHECK: 70: foreach, {4, 69}, ir, (device-sycl)
+// CHECK: 71: file-table-tform, {4, 70}, tempfilelist, (device-sycl)
+// CHECK: 72: sycl-post-link, {71}, tempfiletable, (device-sycl)
+// CHECK: 73: foreach, {71, 72}, tempfiletable, (device-sycl)
+// CHECK: 74: file-table-tform, {73}, tempfilelist, (device-sycl)
+// CHECK: 75: file-table-tform, {73}, tempfilelist, (device-sycl)
+// CHECK: 76: foreach, {71, 75}, tempfilelist, (device-sycl)
+// CHECK: 77: file-table-tform, {76}, tempfilelist, (device-sycl)
+// CHECK: 78: llvm-spirv, {77}, tempfilelist, (device-sycl)
+// CHECK: 79: file-table-tform, {74, 78}, tempfiletable, (device-sycl)
+// CHECK: 80: clang-offload-wrapper, {79}, object, (device-sycl)
+// CHECK: 81: offload, "host-sycl (x86_64-pc-windows-msvc)" {1}, "device-sycl (spir64-unknown-unknown)" {80}, image

--- a/clang/test/Driver/sycl-no-rdc-win.cpp
+++ b/clang/test/Driver/sycl-no-rdc-win.cpp
@@ -1,0 +1,33 @@
+/// Tests for -fno-sycl-rdc on Windows
+// REQUIRES: system-windows
+
+// RUN: touch %t1.cpp
+// RUN: touch %t2.cpp
+// RUN: %clang -### -fsycl -fno-sycl-rdc --sysroot=%S/Inputs/SYCL %t1.cpp %t2.cpp 2>&1 -ccc-print-phases | FileCheck %s
+
+// CHECK: 3: input, "{{.*}}1.cpp", c++, (device-sycl)
+// CHECK: 4: preprocessor, {3}, c++-cpp-output, (device-sycl)
+// CHECK: 5: compiler, {4}, ir, (device-sycl)
+// CHECK: 13: input, "{{.*}}2.cpp", c++, (device-sycl)
+// CHECK: 14: preprocessor, {13}, c++-cpp-output, (device-sycl)
+// CHECK: 15: compiler, {14}, ir, (device-sycl)
+
+// CHECK: 21: input, {{.*}}libsycl-crt{{.*}}, object
+// CHECK: 22: clang-offload-unbundler, {21}, object
+// CHECK: 23: offload, " (spir64-unknown-unknown)" {22}, object
+// CHECK: 84: linker, {23, {{.*}}}, ir, (device-sycl)
+// CHECK: 85: linker, {5, 84}, ir, (device-sycl)
+// CHECK: 86: sycl-post-link, {85}, tempfiletable, (device-sycl)
+// CHECK: 87: file-table-tform, {86}, tempfilelist, (device-sycl)
+// CHECK: 88: llvm-spirv, {87}, tempfilelist, (device-sycl)
+// CHECK: 89: file-table-tform, {86, 88}, tempfiletable, (device-sycl)
+// CHECK: 90: clang-offload-wrapper, {89}, object, (device-sycl)
+
+// CHECK: 91: linker, {15, 84}, ir, (device-sycl)
+// CHECK: 92: sycl-post-link, {91}, tempfiletable, (device-sycl)
+// CHECK: 93: file-table-tform, {92}, tempfilelist, (device-sycl)
+// CHECK: 94: llvm-spirv, {93}, tempfilelist, (device-sycl)
+// CHECK: 95: file-table-tform, {92, 94}, tempfiletable, (device-sycl)
+// CHECK: 96: clang-offload-wrapper, {95}, object, (device-sycl)
+
+// CHECK: 97: offload, "host-sycl (x86_64-pc-windows-msvc)" {{{.*}}}, "device-sycl (spir64-unknown-unknown)" {90}, "device-sycl (spir64-unknown-unknown)" {96}, image


### PR DESCRIPTION
The cause of the windows test failures in my previous change was 
1) Expected linux host triple in a few places
2) Did not account for different number of device libraries for windows

I tested these manually on Windows

Signed-off-by: Sarnie <nick.sarnie@intel.com>