### PR TITLE
[SYCL][HIP] Fix a Windows specific lit test failure on sycl-oneapi-gpu.

### DIFF
--- a/clang/test/Driver/sycl-oneapi-gpu.cpp
+++ b/clang/test/Driver/sycl-oneapi-gpu.cpp
@@ -168,7 +168,7 @@
 // RUN:   FileCheck %s --check-prefixes=DEVICE_AMD,MACRO_AMD -DDEV_STR=gfx1032 -DMAC_STR=GFX1032
 // MACRO_AMD: clang{{.*}} "-triple" "amdgcn-amd-amdhsa"
 // MACRO_AMD: "-D__SYCL_TARGET_AMD_GPU_[[MAC_STR]]__"
-// DEVICE_AMD: clang-offload-wrapper{{.*}} "-compile-opts=--offload-arch=[[DEV_STR]]"
+// DEVICE_AMD: clang-offload-wrapper{{.*}} "-compile-opts=--offload-arch=[[DEV_STR]]{{.*}}"
 // MACRO_AMD: clang{{.*}} "-fsycl-is-host"
 // MACRO_AMD: "-D__SYCL_TARGET_AMD_GPU_[[MAC_STR]]__"
 
@@ -381,4 +381,3 @@
 // CHECK_PHASES_MIX: 26: file-table-tform, {22, 25}, tempfiletable, (device-sycl)
 // CHECK_PHASES_MIX: 27: clang-offload-wrapper, {26}, object, (device-sycl)
 // CHECK_PHASES_MIX: 28: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64_gen-unknown-unknown:skl)" {20}, "device-sycl (spir64_gen-unknown-unknown)" {27}, image
-


### PR DESCRIPTION
Fix a Windows lit test failure. 
The issue is due to clang-offload-wrapper is slightly different on Windows compared to Linux. This is not specific to recent update.
On Windows the argument of the clang-offload-wrapper looks like  "-compile-opts=--offload-arch=gfx??? --offload-arch=gfx???", while on Linux that is  "-compile-opts=--offload-arch=gfx???"