### PR TITLE
[SYCL] Preserve dependency chain for host tasks in the in-order queue with discard_events mode

### DIFF
--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -501,8 +501,16 @@ protected:
       bool NeedSeparateDependencyMgmt =
           IsExpDepManaged(Type) || IsExpDepManaged(MLastCGType);
 
-      if (NeedSeparateDependencyMgmt)
-        Handler.depends_on(MLastEvent);
+      if (NeedSeparateDependencyMgmt) {
+        auto EventImpl = detail::getSyclObjImpl(MLastEvent);
+        if (EventImpl->isDiscarded()) {
+          // If last event is discarded and we need explicit dependency
+          // management then we can only wait for the whole queue.
+          wait();
+        } else {
+          Handler.depends_on(MLastEvent);
+        }
+      }
 
       EventRet = Handler.finalize();
 


### PR DESCRIPTION
Currently if we submit host tasks in the in-order queue with discard_events property then dependency chain is not preserved.

This PR fixes this issue.

E2E test: https://github.com/intel/llvm-test-suite/pull/1448