### PR TITLE
[SYCL-MLIR] Change casting from/to scalar types

### DIFF
--- a/polygeist/tools/cgeist/CMakeLists.txt
+++ b/polygeist/tools/cgeist/CMakeLists.txt
@@ -27,6 +27,7 @@ add_clang_executable(cgeist
 
   Lib/AffineUtils.cc
   Lib/Attributes.cc
+  Lib/ConstantFolder.cc
   Lib/CGCall.cc
   Lib/CGExpr.cc
   Lib/CGStmt.cc

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -2306,7 +2306,7 @@ ValueCategory MLIRScanner::EmitPointerToIntegralConversion(Location Loc,
                                                            mlir::Type DestTy,
                                                            ValueCategory Src) {
   assert(DestTy.isa<IntegerType>() && "Expecting integer type");
-  assert((Src.val.getType().isa<MemRefType, LLVM::LLVMPointerType>()) &&
+  assert(mlirclang::isPointerOrMemRefTy(Src.val.getType()) &&
          "Expecting pointer input");
 
   return Src.MemRef2Ptr(Builder, Loc).PtrToInt(Builder, Loc, DestTy);
@@ -2315,8 +2315,7 @@ ValueCategory MLIRScanner::EmitPointerToIntegralConversion(Location Loc,
 ValueCategory MLIRScanner::EmitIntegralToPointerConversion(Location Loc,
                                                            mlir::Type DestTy,
                                                            ValueCategory Src) {
-  assert((DestTy.isa<MemRefType, LLVM::LLVMPointerType>()) &&
-         "Expecting pointer type");
+  assert(mlirclang::isPointerOrMemRefTy(DestTy) && "Expecting pointer type");
   assert(Src.val.getType().isa<IntegerType>() &&
          Src.val.getType().cast<IntegerType>().getWidth() ==
              Glob.getCGM().getDataLayout().getPointerSizeInBits() &&

--- a/polygeist/tools/cgeist/Lib/ConstantFolder.cc
+++ b/polygeist/tools/cgeist/Lib/ConstantFolder.cc
@@ -11,8 +11,8 @@
 using namespace mlir;
 using namespace mlirclang;
 
-Value mlirclang::ConstantFolder::foldFPCast(Location Loc, Type PromotionType,
-                                            arith::ConstantOp C) {
+Value ConstantFolder::foldFPCast(Location Loc, Type PromotionType,
+                                 arith::ConstantOp C) {
   assert(PromotionType.isa<FloatType>() && "Expecting FP type");
   const auto Attr = C.getValueAttr().cast<FloatAttr>();
   const auto NewAttr =

--- a/polygeist/tools/cgeist/Lib/ConstantFolder.cc
+++ b/polygeist/tools/cgeist/Lib/ConstantFolder.cc
@@ -1,0 +1,21 @@
+//===- ConstantFolder.cc -----------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ConstantFolder.h"
+
+using namespace mlir;
+using namespace mlirclang;
+
+Value mlirclang::ConstantFolder::foldFPCast(Location Loc, Type PromotionType,
+                                            arith::ConstantOp C) {
+  assert(PromotionType.isa<FloatType>() && "Expecting FP type");
+  const auto Attr = C.getValueAttr().cast<FloatAttr>();
+  const auto NewAttr =
+      FloatAttr::get(PromotionType, Attr.getValue().convertToDouble());
+  return Builder.createOrFold<arith::ConstantOp>(Loc, NewAttr, PromotionType);
+}

--- a/polygeist/tools/cgeist/Lib/ConstantFolder.h
+++ b/polygeist/tools/cgeist/Lib/ConstantFolder.h
@@ -1,0 +1,48 @@
+//===- ConstantFolder.h ------------------------------------------*- C++-*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CLANG_MLIR_CONSTANT_FOLDER
+#define CLANG_MLIR_CONSTANT_FOLDER
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/IR/Builders.h"
+
+namespace mlirclang {
+
+// Builder that folds constant expressions.
+class ConstantFolder {
+public:
+  explicit ConstantFolder(mlir::OpBuilder &Builder) : Builder{Builder} {}
+
+  /// Folds a given operation if possible or returns an empty value.
+  template <typename OpTy, typename... ArgTys>
+  inline mlir::Value fold(mlir::Location Loc, ArgTys... Args) {
+    // Return an empty value if folding is not implemented for a given
+    // operation.
+    return {};
+  }
+
+private:
+  mlir::OpBuilder &Builder;
+
+  /// Folds a FP cast operation not checking precision loss.
+  mlir::Value foldFPCast(mlir::Location Loc, mlir::Type PromotionType,
+                         mlir::arith::ConstantOp C);
+};
+
+} // namespace mlirclang
+
+template <>
+inline mlir::Value
+mlirclang::ConstantFolder::fold<mlir::arith::TruncFOp, mlir::Type,
+                                mlir::arith::ConstantOp>(
+    mlir::Location Loc, mlir::Type PromotionType, mlir::arith::ConstantOp C) {
+  return foldFPCast(Loc, PromotionType, C);
+}
+
+#endif /* CLANG_MLIR_CONSTANT_FOLDER */

--- a/polygeist/tools/cgeist/Lib/ConstantFolder.h
+++ b/polygeist/tools/cgeist/Lib/ConstantFolder.h
@@ -9,6 +9,8 @@
 #ifndef CLANG_MLIR_CONSTANT_FOLDER
 #define CLANG_MLIR_CONSTANT_FOLDER
 
+#include <type_traits>
+
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Builders.h"
 
@@ -21,7 +23,9 @@ public:
 
   /// Folds a given operation if possible or returns an empty value.
   template <typename OpTy, typename... ArgTys>
-  inline mlir::Value fold(mlir::Location Loc, ArgTys... Args) {
+  inline std::enable_if_t<OpTy::template hasTrait<mlir::OpTrait::OneResult>(),
+                          mlir::Value>
+  fold(mlir::Location Loc, ArgTys... Args) {
     // Return an empty value if folding is not implemented for a given
     // operation.
     return {};

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -533,6 +533,23 @@ ValueCategory ValueCategory::MemRef2Ptr(OpBuilder &Builder,
           isReference};
 }
 
+ValueCategory
+ValueCategory::Ptr2MemRef(OpBuilder &Builder, Location Loc,
+                          llvm::ArrayRef<int64_t> Shape,
+                          MemRefLayoutAttrInterface Layout) const {
+  const auto Ty = val.getType().dyn_cast<LLVM::LLVMPointerType>();
+  if (!Ty) {
+    assert(val.getType().isa<MemRefType>() && "Expecting MemRef type");
+    return *this;
+  }
+
+  auto DestTy =
+      MemRefType::get(Shape, Ty.getElementType(), Layout,
+                      Builder.getI32IntegerAttr(Ty.getAddressSpace()));
+  return {Builder.createOrFold<polygeist::Pointer2MemrefOp>(Loc, DestTy, val),
+          isReference};
+}
+
 ValueCategory ValueCategory::Splat(OpBuilder &Builder, Location Loc,
                                    mlir::Type VecTy) const {
   assert(VecTy.isa<mlir::VectorType>() && "Expecting vector type for cast");

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -9,6 +9,7 @@
 #ifndef CLANG_MLIR_VALUE_CATEGORY
 #define CLANG_MLIR_VALUE_CATEGORY
 
+#include "Lib/ConstantFolder.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Value.h"
@@ -22,6 +23,11 @@ private:
                      mlir::Type PromotionType) const {
     if (val.getType() == PromotionType)
       return *this;
+    if (const auto C = val.getDefiningOp<mlir::arith::ConstantOp>()) {
+      mlirclang::ConstantFolder Folder{Builder};
+      if (const auto FoldedRes = Folder.fold<OpTy>(Loc, PromotionType, C))
+        return {FoldedRes, false};
+    }
     return {Builder.createOrFold<OpTy>(Loc, PromotionType, val), false};
   }
 
@@ -98,6 +104,10 @@ public:
   ValueCategory BitCast(mlir::OpBuilder &Builder, mlir::Location Loc,
                         mlir::Type DestTy) const;
   ValueCategory MemRef2Ptr(mlir::OpBuilder &Builder, mlir::Location Loc) const;
+  ValueCategory
+  Ptr2MemRef(mlir::OpBuilder &Builder, mlir::Location Loc,
+             llvm::ArrayRef<int64_t> Shape = mlir::ShapedType::kDynamic,
+             mlir::MemRefLayoutAttrInterface Layout = {}) const;
 
   ValueCategory Splat(mlir::OpBuilder &Builder, mlir::Location Loc,
                       mlir::Type VecTy) const;

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -25,7 +25,8 @@ private:
       return *this;
     if (const auto C = val.getDefiningOp<mlir::arith::ConstantOp>()) {
       mlirclang::ConstantFolder Folder{Builder};
-      if (const auto FoldedRes = Folder.fold<OpTy>(Loc, PromotionType, C))
+      if (const mlir::Value FoldedRes =
+              Folder.fold<OpTy>(Loc, PromotionType, C))
         return {FoldedRes, false};
     }
     return {Builder.createOrFold<OpTy>(Loc, PromotionType, val), false};

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -378,6 +378,9 @@ private:
                                           ValueCategory Src);
   ValueCategory EmitConversionToBool(mlir::Location Loc, ValueCategory Src,
                                      clang::QualType SrcType);
+  ValueCategory EmitPointerToIntegralConversion(mlir::Location Loc,
+                                                mlir::Type DestTy,
+                                                ValueCategory Src);
   ValueCategory EmitVectorInitList(clang::InitListExpr *Expr,
                                    mlir::VectorType VType);
   ValueCategory EmitVectorSubscript(clang::ArraySubscriptExpr *Expr);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -381,6 +381,9 @@ private:
   ValueCategory EmitPointerToIntegralConversion(mlir::Location Loc,
                                                 mlir::Type DestTy,
                                                 ValueCategory Src);
+  ValueCategory EmitIntegralToPointerConversion(mlir::Location Loc,
+                                                mlir::Type DestTy,
+                                                ValueCategory Src);
   ValueCategory EmitVectorInitList(clang::InitListExpr *Expr,
                                    mlir::VectorType VType);
   ValueCategory EmitVectorSubscript(clang::ArraySubscriptExpr *Expr);

--- a/polygeist/tools/cgeist/Test/Verification/booleanconversion.c
+++ b/polygeist/tools/cgeist/Test/Verification/booleanconversion.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S -O0 | FileCheck %s
+// RUN: cgeist %s --function=* -S -O0 -w | FileCheck %s
 
 #include <stdbool.h>
 

--- a/polygeist/tools/cgeist/Test/Verification/booleanconversion.c
+++ b/polygeist/tools/cgeist/Test/Verification/booleanconversion.c
@@ -1,0 +1,72 @@
+// RUN: cgeist %s --function=* -S -O0 | FileCheck %s
+
+#include <stdbool.h>
+
+// CHECK-LABEL:   func.func @int_conversion(
+// CHECK-SAME:                              %[[VAL_0:.*]]: i32) -> i8
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.cmpi ne, %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_2]] : i1 to i8
+// CHECK-NEXT:      return %[[VAL_3]] : i8
+// CHECK-NEXT:    }
+bool int_conversion(int i) { return (bool)i; }
+
+// CHECK-LABEL:   func.func @long_conversion(
+// CHECK-SAME:                               %[[VAL_0:.*]]: i64) -> i8
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.cmpi ne, %[[VAL_0]], %[[VAL_1]] : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_2]] : i1 to i8
+// CHECK-NEXT:      return %[[VAL_3]] : i8
+// CHECK-NEXT:    }
+bool long_conversion(long i) { return (bool)i; }
+
+// CHECK-LABEL:   func.func @float_conversion(
+// CHECK-SAME:                                %[[VAL_0:.*]]: f32) -> i8
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.cmpf une, %[[VAL_0]], %[[VAL_1]] : f32
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_2]] : i1 to i8
+// CHECK-NEXT:      return %[[VAL_3]] : i8
+// CHECK-NEXT:    }
+bool float_conversion(float i) { return (bool)i; }
+
+// CHECK-LABEL:   func.func @double_conversion(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: f64) -> i8
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.cmpf une, %[[VAL_0]], %[[VAL_1]] : f64
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_2]] : i1 to i8
+// CHECK-NEXT:      return %[[VAL_3]] : i8
+// CHECK-NEXT:    }
+bool double_conversion(double i) { return (bool)i; }
+
+// CHECK-LABEL:   func.func @ptr_conversion(
+// CHECK-SAME:                              %[[VAL_0:.*]]: !llvm.ptr<i8>) -> i8
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.null : !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.icmp "ne" %[[VAL_0]], %[[VAL_1]] : !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_2]] : i1 to i8
+// CHECK-NEXT:      return %[[VAL_3]] : i8
+// CHECK-NEXT:    }
+bool ptr_conversion(void *i) { return (bool)i; }
+
+// CHECK-LABEL:   func.func @memref_conversion(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: memref<?xi32>) -> i8
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.null : !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = "polygeist.memref2pointer"(%[[VAL_0]]) : (memref<?xi32>) -> !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.icmp "ne" %[[VAL_2]], %[[VAL_1]] : !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.extui %[[VAL_3]] : i1 to i8
+// CHECK-NEXT:      return %[[VAL_4]] : i8
+// CHECK-NEXT:    }
+bool memref_conversion(int *i) { return (bool)i; }
+
+// CHECK-LABEL:   func.func @bool2unsigned_conversion(
+// CHECK-SAME:                                        %[[VAL_0:.*]]: i8) -> i32
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.extui %[[VAL_0]] : i8 to i32
+// CHECK-NEXT:      return %[[VAL_1]] : i32
+// CHECK-NEXT:    }
+unsigned bool2unsigned_conversion(bool i) { return (unsigned)i; }
+
+// CHECK-LABEL:   func.func @bool2long_conversion(
+// CHECK-SAME:                                    %[[VAL_0:.*]]: i8) -> i64
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.extui %[[VAL_0]] : i8 to i64
+// CHECK-NEXT:      return %[[VAL_1]] : i64
+// CHECK-NEXT:    }
+long bool2long_conversion(bool i) { return (long)i; }

--- a/polygeist/tools/cgeist/Test/Verification/constfolding.c
+++ b/polygeist/tools/cgeist/Test/Verification/constfolding.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S -O0 | FileCheck %s
+// RUN: cgeist %s --function=* -S -O0 -w | FileCheck %s
 
 // CHECK-LABEL:   func.func @foldTrunc() -> f32
 // CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 1.000000e+01 : f32

--- a/polygeist/tools/cgeist/Test/Verification/constfolding.c
+++ b/polygeist/tools/cgeist/Test/Verification/constfolding.c
@@ -1,0 +1,10 @@
+// RUN: cgeist %s --function=* -S -O0 | FileCheck %s
+
+// CHECK-LABEL:   func.func @foldTrunc() -> f32
+// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 1.000000e+01 : f32
+// CHECK-NEXT:      return %[[VAL_0]] : f32
+// CHECK-NEXT:    }
+float foldTrunc() {
+  double d = 10;
+  return d;
+}

--- a/polygeist/tools/cgeist/Test/Verification/integral2ptr.c
+++ b/polygeist/tools/cgeist/Test/Verification/integral2ptr.c
@@ -1,0 +1,36 @@
+// RUN: cgeist %s --function=* -S -O0 | FileCheck %s
+
+#include <stdint.h>
+#include <stdlib.h>
+
+// CHECK-LABEL:   func.func @size_t2ptr(
+// CHECK-SAME:                          %[[VAL_0:.*]]: i64) -> !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.inttoptr %[[VAL_0]] : i64 to !llvm.ptr<i8>
+// CHECK-NEXT:      return %[[VAL_1]] : !llvm.ptr<i8>
+// CHECK-NEXT:    }
+void *size_t2ptr(size_t i) { return (void *)i; }
+
+// CHECK-LABEL:   func.func @int8_t2ptr(
+// CHECK-SAME:                          %[[VAL_0:.*]]: i8) -> !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.extsi %[[VAL_0]] : i8 to i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.inttoptr %[[VAL_1]] : i64 to !llvm.ptr<i8>
+// CHECK-NEXT:      return %[[VAL_2]] : !llvm.ptr<i8>
+// CHECK-NEXT:    }
+void *int8_t2ptr(int8_t i) { return (void *)i; }
+
+// CHECK-LABEL:   func.func @size_t2memref(
+// CHECK-SAME:                             %[[VAL_0:.*]]: i64) -> memref<?xi32>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.inttoptr %[[VAL_0]] : i64 to !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = "polygeist.pointer2memref"(%[[VAL_1]]) : (!llvm.ptr<i32>) -> memref<?xi32>
+// CHECK-NEXT:      return %[[VAL_2]] : memref<?xi32>
+// CHECK-NEXT:    }
+int *size_t2memref(size_t i) { return (int *)i; }
+
+// CHECK-LABEL:   func.func @int8_t2memref(
+// CHECK-SAME:                             %[[VAL_0:.*]]: i8) -> memref<?xi32>
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.extui %[[VAL_0]] : i8 to i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.inttoptr %[[VAL_1]] : i64 to !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = "polygeist.pointer2memref"(%[[VAL_2]]) : (!llvm.ptr<i32>) -> memref<?xi32>
+// CHECK-NEXT:      return %[[VAL_3]] : memref<?xi32>
+// CHECK-NEXT:    }
+int *int8_t2memref(uint8_t i) { return (int *)i; }

--- a/polygeist/tools/cgeist/Test/Verification/integral2ptr.c
+++ b/polygeist/tools/cgeist/Test/Verification/integral2ptr.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S -O0 | FileCheck %s
+// RUN: cgeist %s --function=* -S -O0 -w | FileCheck %s
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/polygeist/tools/cgeist/Test/Verification/ptr2integral.c
+++ b/polygeist/tools/cgeist/Test/Verification/ptr2integral.c
@@ -1,0 +1,34 @@
+// RUN: cgeist %s --function=* -S -O0 | FileCheck %s
+
+#include <stdint.h>
+#include <stdlib.h>
+
+// CHECK-LABEL:   func.func @ptr2size_t(
+// CHECK-SAME:                          %[[VAL_0:.*]]: !llvm.ptr<i8>) -> i64
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.ptrtoint %[[VAL_0]] : !llvm.ptr<i8> to i64
+// CHECK-NEXT:      return %[[VAL_1]] : i64
+// CHECK-NEXT:    }
+size_t ptr2size_t(void * i) { return (size_t)i; }
+
+// CHECK-LABEL:   func.func @ptr2int8_t(
+// CHECK-SAME:                          %[[VAL_0:.*]]: !llvm.ptr<i8>) -> i8
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.ptrtoint %[[VAL_0]] : !llvm.ptr<i8> to i8
+// CHECK-NEXT:      return %[[VAL_1]] : i8
+// CHECK-NEXT:    }
+int8_t ptr2int8_t(void * i) { return (int8_t)i; }
+
+// CHECK-LABEL:   func.func @memref2size_t(
+// CHECK-SAME:                             %[[VAL_0:.*]]: memref<?xi32>) -> i64
+// CHECK-NEXT:      %[[VAL_1:.*]] = "polygeist.memref2pointer"(%[[VAL_0]]) : (memref<?xi32>) -> !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.ptrtoint %[[VAL_1]] : !llvm.ptr<i32> to i64
+// CHECK-NEXT:      return %[[VAL_2]] : i64
+// CHECK-NEXT:    }
+size_t memref2size_t(int * i) { return (size_t)i; }
+
+// CHECK-LABEL:   func.func @memref2int8_t(
+// CHECK-SAME:                             %[[VAL_0:.*]]: memref<?xi32>) -> i8
+// CHECK-NEXT:      %[[VAL_1:.*]] = "polygeist.memref2pointer"(%[[VAL_0]]) : (memref<?xi32>) -> !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.ptrtoint %[[VAL_1]] : !llvm.ptr<i32> to i8
+// CHECK-NEXT:      return %[[VAL_2]] : i8
+// CHECK-NEXT:    }
+uint8_t memref2int8_t(int * i) { return (uint8_t)i; }

--- a/polygeist/tools/cgeist/Test/Verification/ptr2integral.c
+++ b/polygeist/tools/cgeist/Test/Verification/ptr2integral.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S -O0 | FileCheck %s
+// RUN: cgeist %s --function=* -S -O0 -w | FileCheck %s
 
 #include <stdint.h>
 #include <stdlib.h>

--- a/polygeist/tools/cgeist/Test/Verification/scalarconversion.c
+++ b/polygeist/tools/cgeist/Test/Verification/scalarconversion.c
@@ -1,0 +1,70 @@
+// RUN: cgeist %s --function=* -S -O0 | FileCheck %s
+
+// CHECK-LABEL:   func.func @unsigned2float(
+// CHECK-SAME:                              %[[VAL_0:.*]]: i32) -> f32
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.uitofp %[[VAL_0]] : i32 to f32
+// CHECK-NEXT:      return %[[VAL_1]] : f32
+// CHECK-NEXT:    }
+float unsigned2float(unsigned i) { return (float)i; }
+
+// CHECK-LABEL:   func.func @char2double(
+// CHECK-SAME:                           %[[VAL_0:.*]]: i8) -> f64
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.sitofp %[[VAL_0]] : i8 to f64
+// CHECK-NEXT:      return %[[VAL_1]] : f64
+// CHECK-NEXT:    }
+double char2double(char i) { return (double)i; }
+
+// CHECK-LABEL:   func.func @float2unsigned(
+// CHECK-SAME:                              %[[VAL_0:.*]]: f32) -> i32
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.fptoui %[[VAL_0]] : f32 to i32
+// CHECK-NEXT:      return %[[VAL_1]] : i32
+// CHECK-NEXT:    }
+unsigned float2unsigned(float i) { return (unsigned)i; }
+
+// CHECK-LABEL:   func.func @double2longlong(
+// CHECK-SAME:                               %[[VAL_0:.*]]: f64) -> i64
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.fptosi %[[VAL_0]] : f64 to i64
+// CHECK-NEXT:      return %[[VAL_1]] : i64
+// CHECK-NEXT:    }
+long long double2longlong(double i) { return (long long)i; }
+
+// CHECK-LABEL:   func.func @float2double(
+// CHECK-SAME:                            %[[VAL_0:.*]]: f32) -> f64
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.extf %[[VAL_0]] : f32 to f64
+// CHECK-NEXT:      return %[[VAL_1]] : f64
+// CHECK-NEXT:    }
+double float2double(float i) { return (double)i; }
+
+// CHECK-LABEL:   func.func @double2float(
+// CHECK-SAME:                            %[[VAL_0:.*]]: f64) -> f32
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.truncf %[[VAL_0]] : f64 to f32
+// CHECK-NEXT:      return %[[VAL_1]] : f32
+// CHECK-NEXT:    }
+float double2float(double i) { return (float)i; }
+
+// CHECK-LABEL:   func.func @unsigned2int(
+// CHECK-SAME:                            %[[VAL_0:.*]]: i32) -> i32
+// CHECK-NEXT:      return %[[VAL_0]] : i32
+// CHECK-NEXT:    }
+int unsigned2int(unsigned i) { return (int)i; }
+
+// CHECK-LABEL:   func.func @long2int(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i64) -> i32
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.trunci %[[VAL_0]] : i64 to i32
+// CHECK-NEXT:      return %[[VAL_1]] : i32
+// CHECK-NEXT:    }
+int long2int(long i) { return (int)i; }
+
+// CHECK-LABEL:   func.func @int2long(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i32) -> i64
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.extsi %[[VAL_0]] : i32 to i64
+// CHECK-NEXT:      return %[[VAL_1]] : i64
+// CHECK-NEXT:    }
+long int2long(int i) { return (long)i; }
+
+// CHECK-LABEL:   func.func @unsigned2long(
+// CHECK-SAME:                             %[[VAL_0:.*]]: i32) -> i64
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.extui %[[VAL_0]] : i32 to i64
+// CHECK-NEXT:      return %[[VAL_1]] : i64
+// CHECK-NEXT:    }
+long unsigned2long(unsigned i) { return (long)i; }

--- a/polygeist/tools/cgeist/Test/Verification/scalarconversion.c
+++ b/polygeist/tools/cgeist/Test/Verification/scalarconversion.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S -O0 | FileCheck %s
+// RUN: cgeist %s --function=* -S -O0 -w | FileCheck %s
 
 // CHECK-LABEL:   func.func @unsigned2float(
 // CHECK-SAME:                              %[[VAL_0:.*]]: i32) -> f32


### PR DESCRIPTION
Add `ConstantFolder` class analogous to `llvm`'s that extends `mlir` folding capabilities.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>