### PR TITLE
[SYCL][Cmake] Add SYCL_LIBDEVICE_GCC_TOOLCHAIN variable

### DIFF
--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -32,6 +32,12 @@ set(compile_opts
   -sycl-std=2020
   )
 
+set(SYCL_LIBDEVICE_GCC_TOOLCHAIN "" CACHE PATH "Path to GCC installation")
+
+if (NOT SYCL_LIBDEVICE_GCC_TOOLCHAIN STREQUAL "")
+  list(APPEND compile_opts "--gcc-toolchain=${SYCL_LIBDEVICE_GCC_TOOLCHAIN}")
+endif()
+
 if ("NVPTX" IN_LIST LLVM_TARGETS_TO_BUILD)
   string(APPEND sycl_targets_opt ",nvptx64-nvidia-cuda")
   list(APPEND compile_opts


### PR DESCRIPTION
To be used when we want libdevice built against non-system STL (e.g. if we're using non-system GCC) as clang doesn't use gcc in PATH to determine which STL to use.