### PR TITLE
Revert "[NFC][SYCL] Switch to std:: equivalents for utilities in stl_type_traits.hpp (#7668)"

### DIFF
--- a/sycl/include/sycl/atomic_ref.hpp
+++ b/sycl/include/sycl/atomic_ref.hpp
@@ -49,9 +49,9 @@ template <sycl::access::address_space AS> struct IsValidAtomicRefAddressSpace {
 
 // DefaultOrder parameter is limited to read-modify-write orders
 template <memory_order Order>
-using IsValidDefaultOrder = std::bool_constant<Order == memory_order::relaxed ||
-                                               Order == memory_order::acq_rel ||
-                                               Order == memory_order::seq_cst>;
+using IsValidDefaultOrder = bool_constant<Order == memory_order::relaxed ||
+                                          Order == memory_order::acq_rel ||
+                                          Order == memory_order::seq_cst>;
 
 template <memory_order ReadModifyWriteOrder> struct memory_order_traits;
 

--- a/sycl/include/sycl/buffer.hpp
+++ b/sycl/include/sycl/buffer.hpp
@@ -159,11 +159,11 @@ public:
   // using same requirement for contiguous container as std::span
   template <class Container>
   using EnableIfContiguous =
-      std::void_t<std::enable_if_t<std::is_convertible<
-                      detail::remove_pointer_t<
-                          decltype(std::declval<Container>().data())> (*)[],
-                      const T (*)[]>::value>,
-                  decltype(std::declval<Container>().size())>;
+      detail::void_t<std::enable_if_t<std::is_convertible<
+                         detail::remove_pointer_t<
+                             decltype(std::declval<Container>().data())> (*)[],
+                         const T (*)[]>::value>,
+                     decltype(std::declval<Container>().size())>;
   template <class It>
   using EnableIfItInputIterator = std::enable_if_t<
       std::is_convertible<typename std::iterator_traits<It>::iterator_category,
@@ -344,9 +344,9 @@ public:
               using IteratorValueType =
                   detail::iterator_value_type_t<InputIterator>;
               using IteratorNonConstValueType =
-                  std::remove_const_t<IteratorValueType>;
+                  detail::remove_const_t<IteratorValueType>;
               using IteratorPointerToNonConstValueType =
-                  std::add_pointer_t<IteratorNonConstValueType>;
+                  detail::add_pointer_t<IteratorNonConstValueType>;
               std::copy(first, last,
                         static_cast<IteratorPointerToNonConstValueType>(ToPtr));
             },
@@ -377,9 +377,9 @@ public:
               using IteratorValueType =
                   detail::iterator_value_type_t<InputIterator>;
               using IteratorNonConstValueType =
-                  std::remove_const_t<IteratorValueType>;
+                  detail::remove_const_t<IteratorValueType>;
               using IteratorPointerToNonConstValueType =
-                  std::add_pointer_t<IteratorNonConstValueType>;
+                  detail::add_pointer_t<IteratorNonConstValueType>;
               std::copy(first, last,
                         static_cast<IteratorPointerToNonConstValueType>(ToPtr));
             },

--- a/sycl/include/sycl/context.hpp
+++ b/sycl/include/sycl/context.hpp
@@ -236,8 +236,9 @@ private:
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 
   template <class T>
-  friend typename std::add_pointer_t<typename decltype(T::impl)::element_type>
-  detail::getRawSyclObjImpl(const T &SyclObject);
+  friend
+      typename detail::add_pointer_t<typename decltype(T::impl)::element_type>
+      detail::getRawSyclObjImpl(const T &SyclObject);
 
   template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);

--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -254,7 +254,7 @@ template <class Obj> decltype(Obj::impl) getSyclObjImpl(const Obj &SyclObject) {
 // must make sure the returned pointer is not captured in a field or otherwise
 // stored - i.e. must live only as on-stack value.
 template <class T>
-typename std::add_pointer_t<typename decltype(T::impl)::element_type>
+typename detail::add_pointer_t<typename decltype(T::impl)::element_type>
 getRawSyclObjImpl(const T &SyclObject) {
   return SyclObject.impl.get();
 }

--- a/sycl/include/sycl/detail/generic_type_lists.hpp
+++ b/sycl/include/sycl/detail/generic_type_lists.hpp
@@ -423,39 +423,36 @@ using marray_byte_list = type_list<marray<std::byte, 1>, marray<std::byte, 2>,
 #endif
 
 // integer types
-using scalar_signed_integer_list =
-    type_list<std::conditional_t<
-                  std::is_signed<char>::value,
+using scalar_signed_integer_list = type_list<
+    conditional_t<std::is_signed<char>::value,
                   type_list<scalar_default_char_list, scalar_signed_char_list>,
                   scalar_signed_char_list>,
-              scalar_signed_short_list, scalar_signed_int_list,
-              scalar_signed_long_list, scalar_signed_longlong_list>;
+    scalar_signed_short_list, scalar_signed_int_list, scalar_signed_long_list,
+    scalar_signed_longlong_list>;
 
-using vector_signed_integer_list =
-    type_list<std::conditional_t<
-                  std::is_signed<char>::value,
+using vector_signed_integer_list = type_list<
+    conditional_t<std::is_signed<char>::value,
                   type_list<vector_default_char_list, vector_signed_char_list>,
                   vector_signed_char_list>,
-              vector_signed_short_list, vector_signed_int_list,
-              vector_signed_long_list, vector_signed_longlong_list>;
+    vector_signed_short_list, vector_signed_int_list, vector_signed_long_list,
+    vector_signed_longlong_list>;
 
-using marray_signed_integer_list =
-    type_list<std::conditional_t<
-                  std::is_signed<char>::value,
+using marray_signed_integer_list = type_list<
+    conditional_t<std::is_signed<char>::value,
                   type_list<marray_default_char_list, marray_signed_char_list>,
                   marray_signed_char_list>,
-              marray_signed_short_list, marray_signed_int_list,
-              marray_signed_long_list, marray_signed_longlong_list>;
+    marray_signed_short_list, marray_signed_int_list, marray_signed_long_list,
+    marray_signed_longlong_list>;
 
 using signed_integer_list =
     type_list<scalar_signed_integer_list, vector_signed_integer_list,
               marray_signed_integer_list>;
 
 using scalar_unsigned_integer_list =
-    type_list<std::conditional_t<std::is_unsigned<char>::value,
-                                 type_list<scalar_default_char_list,
-                                           scalar_unsigned_char_list>,
-                                 scalar_unsigned_char_list>,
+    type_list<conditional_t<std::is_unsigned<char>::value,
+                            type_list<scalar_default_char_list,
+                                      scalar_unsigned_char_list>,
+                            scalar_unsigned_char_list>,
               scalar_unsigned_short_list, scalar_unsigned_int_list,
               scalar_unsigned_long_list, scalar_unsigned_longlong_list
 #if (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
@@ -465,10 +462,10 @@ using scalar_unsigned_integer_list =
               >;
 
 using vector_unsigned_integer_list =
-    type_list<std::conditional_t<std::is_unsigned<char>::value,
-                                 type_list<vector_default_char_list,
-                                           vector_unsigned_char_list>,
-                                 vector_unsigned_char_list>,
+    type_list<conditional_t<std::is_unsigned<char>::value,
+                            type_list<vector_default_char_list,
+                                      vector_unsigned_char_list>,
+                            vector_unsigned_char_list>,
               vector_unsigned_short_list, vector_unsigned_int_list,
               vector_unsigned_long_list, vector_unsigned_longlong_list
 #if (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
@@ -478,10 +475,10 @@ using vector_unsigned_integer_list =
               >;
 
 using marray_unsigned_integer_list =
-    type_list<std::conditional_t<std::is_unsigned<char>::value,
-                                 type_list<marray_default_char_list,
-                                           marray_unsigned_char_list>,
-                                 marray_unsigned_char_list>,
+    type_list<conditional_t<std::is_unsigned<char>::value,
+                            type_list<marray_default_char_list,
+                                      marray_unsigned_char_list>,
+                            marray_unsigned_char_list>,
               marray_unsigned_short_list, marray_unsigned_int_list,
               marray_unsigned_long_list, marray_unsigned_longlong_list
 #if (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)

--- a/sycl/include/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/sycl/detail/generic_type_traits.hpp
@@ -228,17 +228,17 @@ template <typename T>
 using is_geninteger64bit = is_gen_based_on_type_sizeof<T, 8, is_geninteger>;
 
 template <typename T>
-using is_genintptr = std::bool_constant<
+using is_genintptr = bool_constant<
     is_pointer<T>::value && is_genint<remove_pointer_t<T>>::value &&
     is_address_space_compliant<T, gvl::nonconst_address_space_list>::value>;
 
 template <typename T>
-using is_genfloatptr = std::bool_constant<
+using is_genfloatptr = bool_constant<
     is_pointer<T>::value && is_genfloat<remove_pointer_t<T>>::value &&
     is_address_space_compliant<T, gvl::nonconst_address_space_list>::value>;
 
 template <typename T>
-using is_genptr = std::bool_constant<
+using is_genptr = bool_constant<
     is_pointer<T>::value && is_gentype<remove_pointer_t<T>>::value &&
     is_address_space_compliant<T, gvl::nonconst_address_space_list>::value>;
 
@@ -424,10 +424,10 @@ using mptr_or_vec_elem_type_t = typename mptr_or_vec_elem_type<T>::type;
 // select_apply_cl_scalar_t selects from T8/T16/T32/T64 basing on
 // sizeof(IN).  expected to handle scalar types.
 template <typename T, typename T8, typename T16, typename T32, typename T64>
-using select_apply_cl_scalar_t = std::conditional_t<
-    sizeof(T) == 1, T8,
-    std::conditional_t<sizeof(T) == 2, T16,
-                       std::conditional_t<sizeof(T) == 4, T32, T64>>>;
+using select_apply_cl_scalar_t =
+    conditional_t<sizeof(T) == 1, T8,
+                  conditional_t<sizeof(T) == 2, T16,
+                                conditional_t<sizeof(T) == 4, T32, T64>>>;
 
 // Shortcuts for selecting scalar int/unsigned int/fp type.
 template <typename T>
@@ -447,21 +447,21 @@ using select_cl_scalar_float_t =
 
 template <typename T>
 using select_cl_scalar_integral_t =
-    std::conditional_t<std::is_signed<T>::value,
-                       select_cl_scalar_integral_signed_t<T>,
-                       select_cl_scalar_integral_unsigned_t<T>>;
+    conditional_t<std::is_signed<T>::value,
+                  select_cl_scalar_integral_signed_t<T>,
+                  select_cl_scalar_integral_unsigned_t<T>>;
 
 // select_cl_scalar_t picks corresponding cl_* type for input
 // scalar T or returns T if T is not scalar.
 template <typename T>
-using select_cl_scalar_t = std::conditional_t<
+using select_cl_scalar_t = conditional_t<
     std::is_integral<T>::value, select_cl_scalar_integral_t<T>,
-    std::conditional_t<
+    conditional_t<
         std::is_floating_point<T>::value, select_cl_scalar_float_t<T>,
         // half is a special case: it is implemented differently on host and
         // device and therefore, might lower to different types
-        std::conditional_t<std::is_same<T, half>::value,
-                           sycl::detail::half_impl::BIsRepresentationT, T>>>;
+        conditional_t<std::is_same<T, half>::value,
+                      sycl::detail::half_impl::BIsRepresentationT, T>>>;
 
 // select_cl_vector_or_scalar_or_ptr does cl_* type selection for element type
 // of a vector type T, pointer type substitution, and scalar type substitution.
@@ -476,10 +476,9 @@ struct select_cl_vector_or_scalar_or_ptr<
       // select_cl_scalar_t returns _Float16, so, we try to instantiate vec
       // class with _Float16 DataType, which is not expected there
       // So, leave vector<half, N> as-is
-      vec<std::conditional_t<
-              std::is_same<mptr_or_vec_elem_type_t<T>, half>::value,
-              mptr_or_vec_elem_type_t<T>,
-              select_cl_scalar_t<mptr_or_vec_elem_type_t<T>>>,
+      vec<conditional_t<std::is_same<mptr_or_vec_elem_type_t<T>, half>::value,
+                        mptr_or_vec_elem_type_t<T>,
+                        select_cl_scalar_t<mptr_or_vec_elem_type_t<T>>>,
           T::size()>;
 };
 
@@ -548,10 +547,10 @@ using SelectMatchingOpenCLType_t =
 // Converts T to OpenCL friendly
 //
 template <typename T>
-using ConvertToOpenCLType_t = std::conditional_t<
+using ConvertToOpenCLType_t = conditional_t<
     TryToGetVectorT<SelectMatchingOpenCLType_t<T>>::value,
     typename TryToGetVectorT<SelectMatchingOpenCLType_t<T>>::type,
-    std::conditional_t<
+    conditional_t<
         TryToGetPointerT<SelectMatchingOpenCLType_t<T>>::value,
         typename TryToGetPointerVecT<SelectMatchingOpenCLType_t<T>>::type,
         SelectMatchingOpenCLType_t<T>>>;
@@ -594,12 +593,12 @@ template <typename T> inline constexpr bool msbIsSet(const T x) {
 // TODO: marray support isn't implemented yet.
 template <typename T>
 using common_rel_ret_t =
-    std::conditional_t<is_vgentype<T>::value, make_singed_integer_t<T>, bool>;
+    conditional_t<is_vgentype<T>::value, make_singed_integer_t<T>, bool>;
 
 // TODO: Remove this when common_rel_ret_t is promoted.
 template <typename T>
 using internal_host_rel_ret_t =
-    std::conditional_t<is_vgentype<T>::value, make_singed_integer_t<T>, int>;
+    conditional_t<is_vgentype<T>::value, make_singed_integer_t<T>, int>;
 #else
 // SYCL 1.2.1 4.13.7 (Relation functions), e.g.
 //
@@ -613,7 +612,7 @@ using internal_host_rel_ret_t =
 // Fixing it would be an ABI-breaking change so isn't done.
 template <typename T>
 using common_rel_ret_t =
-    std::conditional_t<is_vgentype<T>::value, make_singed_integer_t<T>, int>;
+    conditional_t<is_vgentype<T>::value, make_singed_integer_t<T>, int>;
 template <typename T> using internal_host_rel_ret_t = common_rel_ret_t<T>;
 #endif
 

--- a/sycl/include/sycl/detail/spirv.hpp
+++ b/sycl/include/sycl/detail/spirv.hpp
@@ -105,9 +105,8 @@ template <typename Group> bool GroupAny(bool pred) {
 // Native broadcasts map directly to a SPIR-V GroupBroadcast intrinsic
 // FIXME: Do not special-case for half once all backends support all data types.
 template <typename T>
-using is_native_broadcast =
-    std::bool_constant<detail::is_arithmetic<T>::value &&
-                       !std::is_same<T, half>::value>;
+using is_native_broadcast = bool_constant<detail::is_arithmetic<T>::value &&
+                                          !std::is_same<T, half>::value>;
 
 template <typename T, typename IdT = size_t>
 using EnableIfNativeBroadcast = std::enable_if_t<
@@ -116,7 +115,7 @@ using EnableIfNativeBroadcast = std::enable_if_t<
 // Bitcast broadcasts can be implemented using a single SPIR-V GroupBroadcast
 // intrinsic, but require type-punning via an appropriate integer type
 template <typename T>
-using is_bitcast_broadcast = std::bool_constant<
+using is_bitcast_broadcast = bool_constant<
     !is_native_broadcast<T>::value && std::is_trivially_copyable<T>::value &&
     (sizeof(T) == 1 || sizeof(T) == 2 || sizeof(T) == 4 || sizeof(T) == 8)>;
 
@@ -133,9 +132,9 @@ using ConvertToNativeBroadcastType_t = select_cl_scalar_integral_unsigned_t<T>;
 // - At most one 32-bit, 16-bit and 8-bit chunk left over
 template <typename T>
 using is_generic_broadcast =
-    std::bool_constant<!is_native_broadcast<T>::value &&
-                       !is_bitcast_broadcast<T>::value &&
-                       std::is_trivially_copyable<T>::value>;
+    bool_constant<!is_native_broadcast<T>::value &&
+                  !is_bitcast_broadcast<T>::value &&
+                  std::is_trivially_copyable<T>::value>;
 
 template <typename T, typename IdT = size_t>
 using EnableIfGenericBroadcast = std::enable_if_t<
@@ -143,11 +142,10 @@ using EnableIfGenericBroadcast = std::enable_if_t<
 
 // FIXME: Disable widening once all backends support all data types.
 template <typename T>
-using WidenOpenCLTypeTo32_t = std::conditional_t<
+using WidenOpenCLTypeTo32_t = conditional_t<
     std::is_same<T, cl_char>() || std::is_same<T, cl_short>(), cl_int,
-    std::conditional_t<std::is_same<T, cl_uchar>() ||
-                           std::is_same<T, cl_ushort>(),
-                       cl_uint, T>>;
+    conditional_t<std::is_same<T, cl_uchar>() || std::is_same<T, cl_ushort>(),
+                  cl_uint, T>>;
 
 // Broadcast with scalar local index
 // Work-group supports any integral type

--- a/sycl/include/sycl/detail/stl_type_traits.hpp
+++ b/sycl/include/sycl/detail/stl_type_traits.hpp
@@ -17,9 +17,34 @@ namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace detail {
 
-// Custom type traits.
-// FIXME: Those doesn't seem to be a part of any published/future C++ standard
-// so should probably be moved to a different place.
+// Type traits identical to those in std in newer versions. Can be removed when
+// SYCL requires a newer version of the C++ standard.
+// C++14
+template <bool B, class T, class F>
+using conditional_t = typename std::conditional<B, T, F>::type;
+
+template <typename T>
+using remove_const_t = typename std::remove_const<T>::type;
+
+template <typename T> using remove_cv_t = typename std::remove_cv<T>::type;
+
+template <typename T>
+using remove_reference_t = typename std::remove_reference<T>::type;
+
+template <typename T> using add_pointer_t = typename std::add_pointer<T>::type;
+
+// C++17
+template <bool V> using bool_constant = std::integral_constant<bool, V>;
+
+template <class...> using void_t = void;
+
+// Custom type traits
+template <typename T>
+using allocator_value_type_t = typename std::allocator_traits<T>::value_type;
+
+template <typename T>
+using allocator_pointer_t = typename std::allocator_traits<T>::pointer;
+
 template <typename T>
 using iterator_category_t = typename std::iterator_traits<T>::iterator_category;
 
@@ -37,9 +62,9 @@ using iterator_to_const_type_t =
 // https://en.cppreference.com/w/cpp/named_req/OutputIterator
 template <typename T>
 using output_iterator_requirements =
-    std::void_t<iterator_category_t<T>,
-                decltype(*std::declval<T>() =
-                             std::declval<iterator_value_type_t<T>>())>;
+    void_t<iterator_category_t<T>,
+           decltype(*std::declval<T>() =
+                        std::declval<iterator_value_type_t<T>>())>;
 
 template <typename, typename = void> struct is_output_iterator {
   static constexpr bool value = false;

--- a/sycl/include/sycl/detail/type_list.hpp
+++ b/sycl/include/sycl/detail/type_list.hpp
@@ -26,8 +26,8 @@ using empty_type_list = type_list<>;
 
 template <typename T>
 struct is_empty_type_list
-    : std::conditional_t<std::is_same<T, empty_type_list>::value,
-                         std::true_type, std::false_type> {};
+    : conditional_t<std::is_same<T, empty_type_list>::value, std::true_type,
+                    std::false_type> {};
 
 template <> struct type_list<> {};
 
@@ -46,16 +46,14 @@ private:
 
 public:
   using head = head_t<type_list<Head>>;
-  using tail =
-      std::conditional_t<has_remainder, with_remainder, without_remainder>;
+  using tail = conditional_t<has_remainder, with_remainder, without_remainder>;
 };
 
 // is_contained
 template <typename T, typename TypeList>
 struct is_contained
-    : std::conditional_t<
-          std::is_same<std::remove_cv_t<T>, head_t<TypeList>>::value,
-          std::true_type, is_contained<T, tail_t<TypeList>>> {};
+    : conditional_t<std::is_same<remove_cv_t<T>, head_t<TypeList>>::value,
+                    std::true_type, is_contained<T, tail_t<TypeList>>> {};
 
 template <typename T>
 struct is_contained<T, empty_type_list> : std::false_type {};
@@ -73,8 +71,8 @@ template <typename T> struct value_list<T> {};
 // is_contained_value
 template <typename T, T Value, typename ValueList>
 struct is_contained_value
-    : std::conditional_t<Value == ValueList::head, std::true_type,
-                         is_contained_value<T, Value, tail_t<ValueList>>> {};
+    : conditional_t<Value == ValueList::head, std::true_type,
+                    is_contained_value<T, Value, tail_t<ValueList>>> {};
 
 template <typename T, T Value>
 struct is_contained_value<T, Value, value_list<T>> : std::false_type {};
@@ -89,21 +87,21 @@ using is_one_of_spaces =
 
 // size type predicates
 template <typename T1, typename T2>
-struct is_type_size_equal : std::bool_constant<(sizeof(T1) == sizeof(T2))> {};
+struct is_type_size_equal : bool_constant<(sizeof(T1) == sizeof(T2))> {};
 
 template <typename T1, typename T2>
-struct is_type_size_greater : std::bool_constant<(sizeof(T1) > sizeof(T2))> {};
+struct is_type_size_greater : bool_constant<(sizeof(T1) > sizeof(T2))> {};
 
 template <typename T1, typename T2>
 struct is_type_size_double_of
-    : std::bool_constant<(sizeof(T1) == (sizeof(T2) * 2))> {};
+    : bool_constant<(sizeof(T1) == (sizeof(T2) * 2))> {};
 
 template <typename T1, typename T2>
-struct is_type_size_less : std::bool_constant<(sizeof(T1) < sizeof(T2))> {};
+struct is_type_size_less : bool_constant<(sizeof(T1) < sizeof(T2))> {};
 
 template <typename T1, typename T2>
-struct is_type_size_half_of
-    : std::bool_constant<(sizeof(T1) == (sizeof(T2) / 2))> {};
+struct is_type_size_half_of : bool_constant<(sizeof(T1) == (sizeof(T2) / 2))> {
+};
 
 // find required type
 template <typename TypeList, template <typename, typename> class Comp,
@@ -111,7 +109,7 @@ template <typename TypeList, template <typename, typename> class Comp,
 struct find_type {
   using head = head_t<TypeList>;
   using tail = typename find_type<tail_t<TypeList>, Comp, T>::type;
-  using type = std::conditional_t<Comp<head, T>::value, head, tail>;
+  using type = conditional_t<Comp<head, T>::value, head, tail>;
 };
 
 template <template <typename, typename> class Comp, typename T>

--- a/sycl/include/sycl/detail/type_traits.hpp
+++ b/sycl/include/sycl/detail/type_traits.hpp
@@ -92,18 +92,17 @@ template <typename T> struct vector_size_impl : int_constant<1> {};
 template <typename T, int N>
 struct vector_size_impl<vec<T, N>> : int_constant<N> {};
 template <typename T>
-struct vector_size
-    : vector_size_impl<std::remove_cv_t<std::remove_reference_t<T>>> {};
+struct vector_size : vector_size_impl<remove_cv_t<remove_reference_t<T>>> {};
 
 // 4.10.2.6 Memory layout and alignment
 template <typename T, int N>
 struct vector_alignment_impl
-    : std::conditional_t<N == 3, int_constant<sizeof(T) * 4>,
-                         int_constant<sizeof(T) * N>> {};
+    : conditional_t<N == 3, int_constant<sizeof(T) * 4>,
+                    int_constant<sizeof(T) * N>> {};
 
 template <typename T, int N>
 struct vector_alignment
-    : vector_alignment_impl<std::remove_cv_t<std::remove_reference_t<T>>, N> {};
+    : vector_alignment_impl<remove_cv_t<remove_reference_t<T>>, N> {};
 
 // vector_element
 template <typename T> struct vector_element_impl;
@@ -116,8 +115,7 @@ template <typename T, int N> struct vector_element_impl<vec<T, N>> {
   using type = T;
 };
 template <typename T> struct vector_element {
-  using type =
-      copy_cv_qualifiers_t<T, vector_element_impl_t<std::remove_cv_t<T>>>;
+  using type = copy_cv_qualifiers_t<T, vector_element_impl_t<remove_cv_t<T>>>;
 };
 template <class T> using vector_element_t = typename vector_element<T>::type;
 
@@ -153,7 +151,7 @@ struct copy_cv_qualifiers_impl<const volatile T, R> {
 };
 
 template <typename T, typename R> struct copy_cv_qualifiers {
-  using type = typename copy_cv_qualifiers_impl<T, std::remove_cv_t<R>>::type;
+  using type = typename copy_cv_qualifiers_impl<T, remove_cv_t<R>>::type;
 };
 
 // make_signed with support SYCL vec class
@@ -184,7 +182,7 @@ struct make_signed_impl<
 };
 
 template <typename T> struct make_signed {
-  using new_type_wo_cv_qualifiers = make_signed_impl_t<std::remove_cv_t<T>>;
+  using new_type_wo_cv_qualifiers = make_signed_impl_t<remove_cv_t<T>>;
   using type = copy_cv_qualifiers_t<T, new_type_wo_cv_qualifiers>;
 };
 
@@ -218,7 +216,7 @@ struct make_unsigned_impl<
 };
 
 template <typename T> struct make_unsigned {
-  using new_type_wo_cv_qualifiers = make_unsigned_impl_t<std::remove_cv_t<T>>;
+  using new_type_wo_cv_qualifiers = make_unsigned_impl_t<remove_cv_t<T>>;
   using type = copy_cv_qualifiers_t<T, new_type_wo_cv_qualifiers>;
 };
 
@@ -227,7 +225,7 @@ template <typename T> using make_unsigned_t = typename make_unsigned<T>::type;
 // Checks that sizeof base type of T equal N and T satisfies S<T>::value
 template <typename T, int N, template <typename> class S>
 using is_gen_based_on_type_sizeof =
-    std::bool_constant<S<T>::value && (sizeof(vector_element_t<T>) == N)>;
+    bool_constant<S<T>::value && (sizeof(vector_element_t<T>) == N)>;
 
 template <typename> struct is_vec : std::false_type {};
 template <typename T, std::size_t N>
@@ -245,35 +243,33 @@ template <> struct is_floating_point_impl<half> : std::true_type {};
 
 template <typename T>
 struct is_floating_point
-    : is_floating_point_impl<std::remove_cv_t<vector_element_t<T>>> {};
+    : is_floating_point_impl<remove_cv_t<vector_element_t<T>>> {};
 
 // is_arithmetic
 template <typename T>
 struct is_arithmetic
-    : std::bool_constant<is_integral<T>::value || is_floating_point<T>::value> {
-};
+    : bool_constant<is_integral<T>::value || is_floating_point<T>::value> {};
 
 template <typename T>
 struct is_scalar_arithmetic
-    : std::bool_constant<!is_vec<T>::value && is_arithmetic<T>::value> {};
+    : bool_constant<!is_vec<T>::value && is_arithmetic<T>::value> {};
 
 template <typename T>
 struct is_vector_arithmetic
-    : std::bool_constant<is_vec<T>::value && is_arithmetic<T>::value> {};
+    : bool_constant<is_vec<T>::value && is_arithmetic<T>::value> {};
 
 // is_bool
 template <typename T>
 struct is_scalar_bool
-    : std::bool_constant<std::is_same<std::remove_cv_t<T>, bool>::value> {};
+    : bool_constant<std::is_same<remove_cv_t<T>, bool>::value> {};
 
 template <typename T>
 struct is_vector_bool
-    : std::bool_constant<is_vec<T>::value &&
-                         is_scalar_bool<vector_element_t<T>>::value> {};
+    : bool_constant<is_vec<T>::value &&
+                    is_scalar_bool<vector_element_t<T>>::value> {};
 
 template <typename T>
-struct is_bool
-    : std::bool_constant<is_scalar_bool<vector_element_t<T>>::value> {};
+struct is_bool : bool_constant<is_scalar_bool<vector_element_t<T>>::value> {};
 
 // is_pointer
 template <typename T> struct is_pointer_impl : std::false_type {};
@@ -285,8 +281,7 @@ template <typename T, access::address_space Space,
 struct is_pointer_impl<multi_ptr<T, Space, DecorateAddress>> : std::true_type {
 };
 
-template <typename T>
-struct is_pointer : is_pointer_impl<std::remove_cv_t<T>> {};
+template <typename T> struct is_pointer : is_pointer_impl<remove_cv_t<T>> {};
 
 // remove_pointer_t
 template <typename T> struct remove_pointer_impl {
@@ -304,7 +299,7 @@ struct remove_pointer_impl<multi_ptr<T, Space, DecorateAddress>> {
 };
 
 template <typename T>
-struct remove_pointer : remove_pointer_impl<std::remove_cv_t<T>> {};
+struct remove_pointer : remove_pointer_impl<remove_cv_t<T>> {};
 
 template <typename T> using remove_pointer_t = typename remove_pointer<T>::type;
 
@@ -319,11 +314,11 @@ template <typename T, typename SpaceList, access::address_space Space,
           access::decorated DecorateAddress>
 struct is_address_space_compliant_impl<multi_ptr<T, Space, DecorateAddress>,
                                        SpaceList>
-    : std::bool_constant<is_one_of_spaces<Space, SpaceList>::value> {};
+    : bool_constant<is_one_of_spaces<Space, SpaceList>::value> {};
 
 template <typename T, typename SpaceList>
 struct is_address_space_compliant
-    : is_address_space_compliant_impl<std::remove_cv_t<T>, SpaceList> {};
+    : is_address_space_compliant_impl<remove_cv_t<T>, SpaceList> {};
 
 // make_type_t
 template <typename T, typename TL> struct make_type_impl {
@@ -365,7 +360,7 @@ template <typename T, int N> struct make_larger_impl<vec<T, N>, vec<T, N>> {
   using upper_type = typename make_larger_impl<base_type, base_type>::type;
   using new_type = vec<upper_type, N>;
   static constexpr bool found = !std::is_same<upper_type, void>::value;
-  using type = std::conditional_t<found, new_type, void>;
+  using type = conditional_t<found, new_type, void>;
 };
 
 template <typename T> struct make_larger {

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -239,8 +239,9 @@ private:
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 
   template <class T>
-  friend typename std::add_pointer_t<typename decltype(T::impl)::element_type>
-  detail::getRawSyclObjImpl(const T &SyclObject);
+  friend
+      typename detail::add_pointer_t<typename decltype(T::impl)::element_type>
+      detail::getRawSyclObjImpl(const T &SyclObject);
 
   template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -350,8 +350,9 @@ ESIMD_INLINE
                                     detail::uint_type_t<sizeof(T)>>;
     using Treal = __raw_t<T>;
     simd<Tint, N> vals_int = bitcast<Tint, Treal, N>(std::move(vals).data());
-    using PromoT = typename std::conditional_t<std::is_signed<Tint>::value,
-                                               int32_t, uint32_t>;
+    using PromoT =
+        typename sycl::detail::conditional_t<std::is_signed<Tint>::value,
+                                             int32_t, uint32_t>;
     const simd<PromoT, N> promo_vals = convert<PromoT>(std::move(vals_int));
     __esimd_scatter_scaled<PromoT, N, decltype(si), TypeSizeLog2, scale>(
         mask.data(), si, glob_offset, offsets.data(), promo_vals.data());
@@ -387,8 +388,9 @@ gather_impl(AccessorTy acc, simd<uint32_t, N> offsets, uint32_t glob_offset,
     using Treal = __raw_t<T>;
     static_assert(std::is_integral<Tint>::value,
                   "only integral 1- & 2-byte types are supported");
-    using PromoT = typename std::conditional_t<std::is_signed<Tint>::value,
-                                               int32_t, uint32_t>;
+    using PromoT =
+        typename sycl::detail::conditional_t<std::is_signed<Tint>::value,
+                                             int32_t, uint32_t>;
     const simd<PromoT, N> promo_vals =
         __esimd_gather_masked_scaled2<PromoT, N, decltype(si), TypeSizeLog2,
                                       scale>(si, glob_offset, offsets.data(),

--- a/sycl/include/sycl/ext/intel/experimental/fpga_utils.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_utils.hpp
@@ -28,8 +28,8 @@ template <template <int32_t> class _Type, class... _T> struct _GetValue {
 template <template <int32_t> class _Type, class _T1, class... _T>
 struct _GetValue<_Type, _T1, _T...> {
   static constexpr auto value =
-      std::conditional_t<_MatchType<_Type, _T1>::value, _T1,
-                         _GetValue<_Type, _T...>>::value;
+      sycl::detail::conditional_t<_MatchType<_Type, _T1>::value, _T1,
+                                  _GetValue<_Type, _T...>>::value;
 };
 
 // Get the specified property from the given compile-time property list. If

--- a/sycl/include/sycl/ext/oneapi/accessor_property_list.hpp
+++ b/sycl/include/sycl/ext/oneapi/accessor_property_list.hpp
@@ -61,8 +61,9 @@ class __SYCL_TYPE(accessor_property_list) accessor_property_list
   template <typename PropT> struct ContainsProperty<PropT> : std::false_type {};
   template <typename PropT, typename Head, typename... Tail>
   struct ContainsProperty<PropT, Head, Tail...>
-      : std::conditional_t<AreSameTemplate<PropT, Head>::value, std::true_type,
-                           ContainsProperty<PropT, Tail...>> {};
+      : sycl::detail::conditional_t<AreSameTemplate<PropT, Head>::value,
+                                    std::true_type,
+                                    ContainsProperty<PropT, Tail...>> {};
 
   // PropertyContainer is a helper structure, that holds list of properties.
   // It is used to avoid multiple parameter packs in templates.
@@ -85,7 +86,7 @@ class __SYCL_TYPE(accessor_property_list) accessor_property_list
   template <typename ContainerT, template <auto...> typename PropT,
             auto... Args>
   struct ContainsPropertyInstance
-      : std::conditional_t<
+      : sycl::detail::conditional_t<
             !std::is_same_v<typename ContainerT::Head, void> &&
                 AreSameTemplate<PropT<Args...>,
                                 typename ContainerT::Head>::value,
@@ -101,7 +102,7 @@ class __SYCL_TYPE(accessor_property_list) accessor_property_list
   // skipped.
   template <typename ContainerT, typename... OtherProps>
   struct ContainsSameProperties
-      : std::conditional_t<
+      : sycl::detail::conditional_t<
             !sycl::detail::IsCompileTimePropertyInstance<
                 typename ContainerT::Head>::value ||
                 ContainsProperty<typename ContainerT::Head,
@@ -117,7 +118,7 @@ class __SYCL_TYPE(accessor_property_list) accessor_property_list
   // use void as return type.
   template <typename ContainerT, template <auto...> class PropT, auto... Args>
   struct GetCompileTimePropertyHelper {
-    using type = typename std::conditional_t<
+    using type = typename sycl::detail::conditional_t<
         AreSameTemplate<typename ContainerT::Head, PropT<Args...>>::value,
         typename ContainerT::Head,
         typename GetCompileTimePropertyHelper<typename ContainerT::Rest, PropT,
@@ -125,7 +126,7 @@ class __SYCL_TYPE(accessor_property_list) accessor_property_list
   };
   template <typename Head, template <auto...> class PropT, auto... Args>
   struct GetCompileTimePropertyHelper<PropertyContainer<Head>, PropT, Args...> {
-    using type = typename std::conditional_t<
+    using type = typename sycl::detail::conditional_t<
         AreSameTemplate<Head, PropT<Args...>>::value, Head, void>;
   };
 
@@ -137,7 +138,7 @@ class __SYCL_TYPE(accessor_property_list) accessor_property_list
   template <typename... Tail> struct AllProperties : std::true_type {};
   template <typename T, typename... Tail>
   struct AllProperties<T, Tail...>
-      : std::conditional_t<
+      : sycl::detail::conditional_t<
             std::is_base_of<sycl::detail::DataLessPropertyBase, T>::value ||
                 std::is_base_of<sycl::detail::PropertyWithDataBase, T>::value ||
                 sycl::detail::IsCompileTimePropertyInstance<T>::value,

--- a/sycl/include/sycl/ext/oneapi/atomic_ref.hpp
+++ b/sycl/include/sycl/ext/oneapi/atomic_ref.hpp
@@ -43,16 +43,16 @@ template <typename T> struct IsValidAtomicRefType {
 };
 
 template <sycl::access::address_space AS>
-using IsValidAtomicAddressSpace = std::bool_constant<
-    AS == access::address_space::global_space ||
-    AS == access::address_space::local_space ||
-    AS == access::address_space::ext_intel_global_device_space>;
+using IsValidAtomicAddressSpace =
+    bool_constant<AS == access::address_space::global_space ||
+                  AS == access::address_space::local_space ||
+                  AS == access::address_space::ext_intel_global_device_space>;
 
 // DefaultOrder parameter is limited to read-modify-write orders
 template <memory_order Order>
-using IsValidDefaultOrder = std::bool_constant<Order == memory_order::relaxed ||
-                                               Order == memory_order::acq_rel ||
-                                               Order == memory_order::seq_cst>;
+using IsValidDefaultOrder = bool_constant<Order == memory_order::relaxed ||
+                                          Order == memory_order::acq_rel ||
+                                          Order == memory_order::seq_cst>;
 
 template <memory_order ReadModifyWriteOrder> struct memory_order_traits;
 

--- a/sycl/include/sycl/ext/oneapi/device_global/device_global.hpp
+++ b/sycl/include/sycl/ext/oneapi/device_global/device_global.hpp
@@ -34,8 +34,8 @@ namespace detail {
 template <typename T, typename = void>
 struct HasArrowOperator : std::false_type {};
 template <typename T>
-struct HasArrowOperator<T,
-                        std::void_t<decltype(std::declval<T>().operator->())>>
+struct HasArrowOperator<
+    T, sycl::detail::void_t<decltype(std::declval<T>().operator->())>>
     : std::true_type {};
 
 // Base class for device_global.

--- a/sycl/include/sycl/ext/oneapi/device_global/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/device_global/properties.hpp
@@ -42,7 +42,7 @@ struct init_mode_key {
 struct implement_in_csr_key {
   template <bool Enable>
   using value_t =
-      property_value<implement_in_csr_key, std::bool_constant<Enable>>;
+      property_value<implement_in_csr_key, sycl::detail::bool_constant<Enable>>;
 };
 
 inline constexpr device_image_scope_key::value_t device_image_scope;

--- a/sycl/include/sycl/ext/oneapi/experimental/group_sort.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/group_sort.hpp
@@ -25,7 +25,7 @@ namespace detail {
 template <typename T, typename = void> struct has_difference_type {};
 
 template <typename T>
-struct has_difference_type<T, std::void_t<typename T::difference_type>>
+struct has_difference_type<T, sycl::detail::void_t<typename T::difference_type>>
     : std::true_type {};
 
 template <typename T> struct has_difference_type<T *> : std::true_type {};
@@ -49,8 +49,9 @@ struct is_sorter_impl {
 template <typename Sorter, typename Group,
           typename Ptr> // multi_ptr has difference_type and don't have other
                         // iterator's fields
-struct is_sorter_impl<Sorter, Group, Ptr,
-                      std::void_t<typename has_difference_type<Ptr>::type>> {
+struct is_sorter_impl<
+    Sorter, Group, Ptr,
+    sycl::detail::void_t<typename has_difference_type<Ptr>::type>> {
   template <typename G = Group>
   static decltype(std::declval<Sorter>()(std::declval<G>(), std::declval<Ptr>(),
                                          std::declval<Ptr>()),

--- a/sycl/include/sycl/ext/oneapi/functional.hpp
+++ b/sycl/include/sycl/ext/oneapi/functional.hpp
@@ -54,13 +54,13 @@ struct GroupOpTag<T, std::enable_if_t<detail::is_sgenfloat<T>::value>> {
   static T calc(GroupTag, T x, BinaryOperation) {                              \
     using ConvertedT = detail::ConvertToOpenCLType_t<T>;                       \
                                                                                \
-    using OCLT = std::conditional_t<                                           \
-        std::is_same<ConvertedT, cl_char>() ||                                 \
-            std::is_same<ConvertedT, cl_short>(),                              \
-        cl_int,                                                                \
-        std::conditional_t<std::is_same<ConvertedT, cl_uchar>() ||             \
-                               std::is_same<ConvertedT, cl_ushort>(),          \
-                           cl_uint, ConvertedT>>;                              \
+    using OCLT =                                                               \
+        conditional_t<std::is_same<ConvertedT, cl_char>() ||                   \
+                          std::is_same<ConvertedT, cl_short>(),                \
+                      cl_int,                                                  \
+                      conditional_t<std::is_same<ConvertedT, cl_uchar>() ||    \
+                                        std::is_same<ConvertedT, cl_ushort>(), \
+                                    cl_uint, ConvertedT>>;                     \
     OCLT Arg = x;                                                              \
     OCLT Ret =                                                                 \
         __spirv_Group##SPIRVOperation(S, static_cast<unsigned int>(O), Arg);   \

--- a/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
@@ -173,10 +173,9 @@ template <typename T, typename = void>
 struct HasKernelPropertiesGetMethod : std::false_type {};
 
 template <typename T>
-struct HasKernelPropertiesGetMethod<T,
-                                    std::void_t<decltype(std::declval<T>().get(
-                                        std::declval<properties_tag>()))>>
-    : std::true_type {
+struct HasKernelPropertiesGetMethod<
+    T, sycl::detail::void_t<decltype(std::declval<T>().get(
+           std::declval<properties_tag>()))>> : std::true_type {
   using properties_t =
       decltype(std::declval<T>().get(std::declval<properties_tag>()));
 };

--- a/sycl/include/sycl/ext/oneapi/properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/properties.hpp
@@ -77,10 +77,11 @@ template <typename... Ts> struct RuntimePropertyStorage<std::tuple<Ts...>> {
 };
 template <typename T, typename... Ts>
 struct RuntimePropertyStorage<std::tuple<T, Ts...>>
-    : std::conditional_t<IsRuntimeProperty<T>::value,
-                         PrependTuple<T, typename RuntimePropertyStorage<
-                                             std::tuple<Ts...>>::type>,
-                         RuntimePropertyStorage<std::tuple<Ts...>>> {};
+    : sycl::detail::conditional_t<
+          IsRuntimeProperty<T>::value,
+          PrependTuple<
+              T, typename RuntimePropertyStorage<std::tuple<Ts...>>::type>,
+          RuntimePropertyStorage<std::tuple<Ts...>>> {};
 
 // Helper class to extract a subset of elements from a tuple.
 // NOTES: This assumes no duplicate properties and that all properties in the

--- a/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
@@ -75,9 +75,9 @@ template <typename... Ts>
 struct AllPropertyValues<std::tuple<Ts...>> : std::true_type {};
 template <typename T, typename... Ts>
 struct AllPropertyValues<std::tuple<T, Ts...>>
-    : std::conditional_t<IsPropertyValue<T>::value,
-                         AllPropertyValues<std::tuple<Ts...>>,
-                         std::false_type> {};
+    : sycl::detail::conditional_t<IsPropertyValue<T>::value,
+                                  AllPropertyValues<std::tuple<Ts...>>,
+                                  std::false_type> {};
 
 //******************************************************************************
 // Property type sorting
@@ -202,8 +202,9 @@ struct IsSorted<std::tuple<Ts...>> : std::true_type {};
 template <typename T> struct IsSorted<std::tuple<T>> : std::true_type {};
 template <typename L, typename R, typename... Rest>
 struct IsSorted<std::tuple<L, R, Rest...>>
-    : std::conditional_t<PropertyID<L>::value <= PropertyID<R>::value,
-                         IsSorted<std::tuple<R, Rest...>>, std::false_type> {};
+    : sycl::detail::conditional_t<PropertyID<L>::value <= PropertyID<R>::value,
+                                  IsSorted<std::tuple<R, Rest...>>,
+                                  std::false_type> {};
 
 // Checks that all types in a sorted tuple have unique PropertyID.
 template <typename T> struct SortedAllUnique {};
@@ -212,9 +213,9 @@ struct SortedAllUnique<std::tuple<Ts...>> : std::true_type {};
 template <typename T> struct SortedAllUnique<std::tuple<T>> : std::true_type {};
 template <typename L, typename R, typename... Rest>
 struct SortedAllUnique<std::tuple<L, R, Rest...>>
-    : std::conditional_t<PropertyID<L>::value != PropertyID<R>::value,
-                         SortedAllUnique<std::tuple<R, Rest...>>,
-                         std::false_type> {};
+    : sycl::detail::conditional_t<PropertyID<L>::value != PropertyID<R>::value,
+                                  SortedAllUnique<std::tuple<R, Rest...>>,
+                                  std::false_type> {};
 
 //******************************************************************************
 // Property merging

--- a/sycl/include/sycl/ext/oneapi/properties/property_value.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_value.hpp
@@ -65,10 +65,10 @@ template <typename V, typename O, typename = void> struct is_property_value_of {
 };
 // Specialization for compile-time-constant properties
 template <typename V>
-struct is_property_value<V, std::void_t<typename V::key_t>>
+struct is_property_value<V, sycl::detail::void_t<typename V::key_t>>
     : is_property_key<typename V::key_t> {};
 template <typename V, typename O>
-struct is_property_value_of<V, O, std::void_t<typename V::key_t>>
+struct is_property_value_of<V, O, sycl::detail::void_t<typename V::key_t>>
     : is_property_key_of<typename V::key_t, O> {};
 
 namespace detail {

--- a/sycl/include/sycl/ext/oneapi/sub_group.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group.hpp
@@ -40,13 +40,13 @@ using SelectBlockT = select_cl_scalar_integral_unsigned_t<T>;
 
 template <typename T, access::address_space Space>
 using AcceptableForGlobalLoadStore =
-    std::bool_constant<!std::is_same<void, SelectBlockT<T>>::value &&
-                       Space == access::address_space::global_space>;
+    bool_constant<!std::is_same<void, SelectBlockT<T>>::value &&
+                  Space == access::address_space::global_space>;
 
 template <typename T, access::address_space Space>
 using AcceptableForLocalLoadStore =
-    std::bool_constant<!std::is_same<void, SelectBlockT<T>>::value &&
-                       Space == access::address_space::local_space>;
+    bool_constant<!std::is_same<void, SelectBlockT<T>>::value &&
+                  Space == access::address_space::local_space>;
 
 #ifdef __SYCL_DEVICE_ONLY__
 template <typename T, access::address_space Space,

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -331,8 +331,8 @@ private:
           std::shared_ptr<detail::queue_impl> SecondaryQueue, bool IsHost);
 
   /// Stores copy of Arg passed to the MArgsStorage.
-  template <typename T, typename F = typename std::remove_const_t<
-                            typename std::remove_reference_t<T>>>
+  template <typename T, typename F = typename detail::remove_const_t<
+                            typename detail::remove_reference_t<T>>>
   F *storePlainArg(T &&Arg) {
     MArgsStorage.emplace_back(sizeof(T));
     auto Storage = reinterpret_cast<F *>(MArgsStorage.back().data());
@@ -796,7 +796,7 @@ private:
         class __copyAcc2Ptr<TSrc, TDst, Dim, AccMode, AccTarget, IsPH>>(
         Range, [=](id<Dim> Index) {
           const size_t LinearIndex = detail::getLinearIndex(Index, Range);
-          using TSrcNonConst = typename std::remove_const_t<TSrc>;
+          using TSrcNonConst = typename detail::remove_const_t<TSrc>;
           (reinterpret_cast<TSrcNonConst *>(Dst))[LinearIndex] = Src[Index];
         });
   }
@@ -813,7 +813,7 @@ private:
                    TDst *Dst) {
     single_task<class __copyAcc2Ptr<TSrc, TDst, Dim, AccMode, AccTarget, IsPH>>(
         [=]() {
-          using TSrcNonConst = typename std::remove_const_t<TSrc>;
+          using TSrcNonConst = typename detail::remove_const_t<TSrc>;
           *(reinterpret_cast<TSrcNonConst *>(Dst)) = *(Src.get_pointer());
         });
   }
@@ -1412,9 +1412,9 @@ private:
       const std::shared_ptr<detail::kernel_bundle_impl> &NewKernelBundleImpPtr);
 
   template <typename FuncT>
-  std::enable_if_t<detail::check_fn_signature<std::remove_reference_t<FuncT>,
+  std::enable_if_t<detail::check_fn_signature<detail::remove_reference_t<FuncT>,
                                               void()>::value ||
-                   detail::check_fn_signature<std::remove_reference_t<FuncT>,
+                   detail::check_fn_signature<detail::remove_reference_t<FuncT>,
                                               void(interop_handle)>::value>
   host_task_impl(FuncT &&Func) {
     throwIfActionIsCreated();
@@ -1493,16 +1493,17 @@ public:
   void depends_on(const std::vector<event> &Events);
 
   template <typename T>
-  using remove_cv_ref_t = typename std::remove_cv_t<std::remove_reference_t<T>>;
+  using remove_cv_ref_t =
+      typename detail::remove_cv_t<detail::remove_reference_t<T>>;
 
   template <typename U, typename T>
   using is_same_type = std::is_same<remove_cv_ref_t<U>, remove_cv_ref_t<T>>;
 
   template <typename T> struct ShouldEnableSetArg {
     static constexpr bool value =
-        std::is_trivially_copyable<std::remove_reference_t<T>>::value
+        std::is_trivially_copyable<detail::remove_reference_t<T>>::value
 #if SYCL_LANGUAGE_VERSION && SYCL_LANGUAGE_VERSION <= 201707
-            && std::is_standard_layout<std::remove_reference_t<T>>::value
+            && std::is_standard_layout<detail::remove_reference_t<T>>::value
 #endif
         || is_same_type<sampler, T>::value // Sampler
         || (!is_same_type<cl_mem, T>::value &&
@@ -1591,9 +1592,9 @@ public:
 
   /// Enqueues a command to the SYCL runtime to invoke \p Func once.
   template <typename FuncT>
-  std::enable_if_t<detail::check_fn_signature<std::remove_reference_t<FuncT>,
+  std::enable_if_t<detail::check_fn_signature<detail::remove_reference_t<FuncT>,
                                               void()>::value ||
-                   detail::check_fn_signature<std::remove_reference_t<FuncT>,
+                   detail::check_fn_signature<detail::remove_reference_t<FuncT>,
                                               void(interop_handle)>::value>
   host_task(FuncT &&Func) {
     host_task_impl(Func);

--- a/sycl/include/sycl/id.hpp
+++ b/sycl/include/sycl/id.hpp
@@ -47,7 +47,7 @@ private:
   template <typename N, typename T>
   using EnableIfIntegral = std::enable_if_t<std::is_integral<N>::value, T>;
   template <bool B, typename T>
-  using EnableIfT = std::conditional_t<B, T, __private_class>;
+  using EnableIfT = detail::conditional_t<B, T, __private_class>;
 #endif // __SYCL_DISABLE_ID_TO_INT_CONV__
 
 public:

--- a/sycl/include/sycl/item.hpp
+++ b/sycl/include/sycl/item.hpp
@@ -45,7 +45,7 @@ template <int dimensions = 1, bool with_offset = true> class item {
   class __private_class;
 
   template <bool B, typename T>
-  using EnableIfT = std::conditional_t<B, T, __private_class>;
+  using EnableIfT = detail::conditional_t<B, T, __private_class>;
 #endif // __SYCL_DISABLE_ITEM_TO_INT_CONV__
 public:
   item() = delete;

--- a/sycl/include/sycl/known_identity.hpp
+++ b/sycl/include/sycl/known_identity.hpp
@@ -20,100 +20,98 @@ namespace detail {
 
 template <typename T, class BinaryOperation>
 using IsPlus =
-    std::bool_constant<std::is_same<BinaryOperation, sycl::plus<T>>::value ||
-                       std::is_same<BinaryOperation, sycl::plus<void>>::value>;
+    bool_constant<std::is_same<BinaryOperation, sycl::plus<T>>::value ||
+                  std::is_same<BinaryOperation, sycl::plus<void>>::value>;
 
 template <typename T, class BinaryOperation>
-using IsMultiplies = std::bool_constant<
-    std::is_same<BinaryOperation, sycl::multiplies<T>>::value ||
-    std::is_same<BinaryOperation, sycl::multiplies<void>>::value>;
+using IsMultiplies =
+    bool_constant<std::is_same<BinaryOperation, sycl::multiplies<T>>::value ||
+                  std::is_same<BinaryOperation, sycl::multiplies<void>>::value>;
 
 template <typename T, class BinaryOperation>
-using IsMinimum = std::bool_constant<
-    std::is_same<BinaryOperation, sycl::minimum<T>>::value ||
-    std::is_same<BinaryOperation, sycl::minimum<void>>::value>;
+using IsMinimum =
+    bool_constant<std::is_same<BinaryOperation, sycl::minimum<T>>::value ||
+                  std::is_same<BinaryOperation, sycl::minimum<void>>::value>;
 
 template <typename T, class BinaryOperation>
-using IsMaximum = std::bool_constant<
-    std::is_same<BinaryOperation, sycl::maximum<T>>::value ||
-    std::is_same<BinaryOperation, sycl::maximum<void>>::value>;
+using IsMaximum =
+    bool_constant<std::is_same<BinaryOperation, sycl::maximum<T>>::value ||
+                  std::is_same<BinaryOperation, sycl::maximum<void>>::value>;
 
 template <typename T, class BinaryOperation>
-using IsBitAND = std::bool_constant<
-    std::is_same<BinaryOperation, sycl::bit_and<T>>::value ||
-    std::is_same<BinaryOperation, sycl::bit_and<void>>::value>;
+using IsBitAND =
+    bool_constant<std::is_same<BinaryOperation, sycl::bit_and<T>>::value ||
+                  std::is_same<BinaryOperation, sycl::bit_and<void>>::value>;
 
 template <typename T, class BinaryOperation>
-using IsBitOR = std::bool_constant<
-    std::is_same<BinaryOperation, sycl::bit_or<T>>::value ||
-    std::is_same<BinaryOperation, sycl::bit_or<void>>::value>;
+using IsBitOR =
+    bool_constant<std::is_same<BinaryOperation, sycl::bit_or<T>>::value ||
+                  std::is_same<BinaryOperation, sycl::bit_or<void>>::value>;
 
 template <typename T, class BinaryOperation>
-using IsBitXOR = std::bool_constant<
-    std::is_same<BinaryOperation, sycl::bit_xor<T>>::value ||
-    std::is_same<BinaryOperation, sycl::bit_xor<void>>::value>;
+using IsBitXOR =
+    bool_constant<std::is_same<BinaryOperation, sycl::bit_xor<T>>::value ||
+                  std::is_same<BinaryOperation, sycl::bit_xor<void>>::value>;
 
 template <typename T, class BinaryOperation>
-using IsLogicalAND = std::bool_constant<
+using IsLogicalAND = bool_constant<
     std::is_same<BinaryOperation, sycl::logical_and<T>>::value ||
     std::is_same<BinaryOperation, sycl::logical_and<void>>::value>;
 
 template <typename T, class BinaryOperation>
-using IsLogicalOR = std::bool_constant<
-    std::is_same<BinaryOperation, sycl::logical_or<T>>::value ||
-    std::is_same<BinaryOperation, sycl::logical_or<void>>::value>;
+using IsLogicalOR =
+    bool_constant<std::is_same<BinaryOperation, sycl::logical_or<T>>::value ||
+                  std::is_same<BinaryOperation, sycl::logical_or<void>>::value>;
 
 // Identity = 0
 template <typename T, class BinaryOperation>
-using IsZeroIdentityOp = std::bool_constant<
-    (is_geninteger<T>::value &&
-     (IsPlus<T, BinaryOperation>::value || IsBitOR<T, BinaryOperation>::value ||
-      IsBitXOR<T, BinaryOperation>::value)) ||
-    (is_genfloat<T>::value && IsPlus<T, BinaryOperation>::value)>;
+using IsZeroIdentityOp =
+    bool_constant<(is_geninteger<T>::value &&
+                   (IsPlus<T, BinaryOperation>::value ||
+                    IsBitOR<T, BinaryOperation>::value ||
+                    IsBitXOR<T, BinaryOperation>::value)) ||
+                  (is_genfloat<T>::value && IsPlus<T, BinaryOperation>::value)>;
 
 // Identity = 1
 template <typename T, class BinaryOperation>
 using IsOneIdentityOp =
-    std::bool_constant<(is_geninteger<T>::value || is_genfloat<T>::value) &&
-                       IsMultiplies<T, BinaryOperation>::value>;
+    bool_constant<(is_geninteger<T>::value || is_genfloat<T>::value) &&
+                  IsMultiplies<T, BinaryOperation>::value>;
 
 // Identity = ~0
 template <typename T, class BinaryOperation>
-using IsOnesIdentityOp =
-    std::bool_constant<is_geninteger<T>::value &&
-                       IsBitAND<T, BinaryOperation>::value>;
+using IsOnesIdentityOp = bool_constant<is_geninteger<T>::value &&
+                                       IsBitAND<T, BinaryOperation>::value>;
 
 // Identity = <max possible value>
 template <typename T, class BinaryOperation>
 using IsMinimumIdentityOp =
-    std::bool_constant<(is_geninteger<T>::value || is_genfloat<T>::value) &&
-                       IsMinimum<T, BinaryOperation>::value>;
+    bool_constant<(is_geninteger<T>::value || is_genfloat<T>::value) &&
+                  IsMinimum<T, BinaryOperation>::value>;
 
 // Identity = <min possible value>
 template <typename T, class BinaryOperation>
 using IsMaximumIdentityOp =
-    std::bool_constant<(is_geninteger<T>::value || is_genfloat<T>::value) &&
-                       IsMaximum<T, BinaryOperation>::value>;
+    bool_constant<(is_geninteger<T>::value || is_genfloat<T>::value) &&
+                  IsMaximum<T, BinaryOperation>::value>;
 
 // Identity = false
 template <typename T, class BinaryOperation>
-using IsFalseIdentityOp =
-    std::bool_constant<IsLogicalOR<T, BinaryOperation>::value>;
+using IsFalseIdentityOp = bool_constant<IsLogicalOR<T, BinaryOperation>::value>;
 
 // Identity = true
 template <typename T, class BinaryOperation>
-using IsTrueIdentityOp =
-    std::bool_constant<IsLogicalAND<T, BinaryOperation>::value>;
+using IsTrueIdentityOp = bool_constant<IsLogicalAND<T, BinaryOperation>::value>;
 
 template <typename T, class BinaryOperation>
 using IsKnownIdentityOp =
-    std::bool_constant<IsZeroIdentityOp<T, BinaryOperation>::value ||
-                       IsOneIdentityOp<T, BinaryOperation>::value ||
-                       IsOnesIdentityOp<T, BinaryOperation>::value ||
-                       IsMinimumIdentityOp<T, BinaryOperation>::value ||
-                       IsMaximumIdentityOp<T, BinaryOperation>::value ||
-                       IsFalseIdentityOp<T, BinaryOperation>::value ||
-                       IsTrueIdentityOp<T, BinaryOperation>::value>;
+    bool_constant<IsZeroIdentityOp<T, BinaryOperation>::value ||
+                  IsOneIdentityOp<T, BinaryOperation>::value ||
+                  IsOnesIdentityOp<T, BinaryOperation>::value ||
+                  IsMinimumIdentityOp<T, BinaryOperation>::value ||
+                  IsMaximumIdentityOp<T, BinaryOperation>::value ||
+                  IsFalseIdentityOp<T, BinaryOperation>::value ||
+                  IsTrueIdentityOp<T, BinaryOperation>::value>;
 
 template <typename BinaryOperation, typename AccumulatorT>
 struct has_known_identity_impl

--- a/sycl/include/sycl/multi_ptr.hpp
+++ b/sycl/include/sycl/multi_ptr.hpp
@@ -174,7 +174,7 @@ public:
            Space == access::address_space::ext_intel_global_device_space) &&
           std::is_const<RelayElementType>::value &&
           std::is_same<RelayElementType, ElementType>::value>>
-  multi_ptr(accessor<typename std::remove_const_t<RelayElementType>, Dimensions,
+  multi_ptr(accessor<typename detail::remove_const_t<RelayElementType>, Dimensions,
                      Mode, access::target::device, isPlaceholder, PropertyListT>
                 Accessor)
       : multi_ptr(
@@ -191,9 +191,10 @@ public:
                  Space == access::address_space::local_space) &&
                 std::is_const<RelayElementType>::value &&
                 std::is_same<RelayElementType, ElementType>::value>>
-  multi_ptr(accessor<typename std::remove_const_t<RelayElementType>, Dimensions,
-                     Mode, access::target::local, isPlaceholder, PropertyListT>
-                Accessor)
+  multi_ptr(
+      accessor<typename detail::remove_const_t<RelayElementType>, Dimensions,
+               Mode, access::target::local, isPlaceholder, PropertyListT>
+          Accessor)
       : multi_ptr(Accessor.get_pointer().get()) {}
 
   // Only if Space == local_space || generic_space and element type is const
@@ -205,9 +206,9 @@ public:
                  Space == access::address_space::local_space) &&
                 std::is_const<RelayElementType>::value &&
                 std::is_same<RelayElementType, ElementType>::value>>
-  multi_ptr(
-      local_accessor<typename std::remove_const_t<RelayElementType>, Dimensions>
-          Accessor)
+  multi_ptr(local_accessor<typename detail::remove_const_t<RelayElementType>,
+                           Dimensions>
+                Accessor)
       : multi_ptr(Accessor.get_pointer().get()) {}
 
   // Assignment and access operators
@@ -649,9 +650,9 @@ template <typename ElementType, access::address_space Space>
 class multi_ptr<ElementType, Space, access::decorated::legacy> {
 public:
   using element_type =
-      std::conditional_t<std::is_same<ElementType, half>::value,
-                         sycl::detail::half_impl::BIsRepresentationT,
-                         ElementType>;
+      detail::conditional_t<std::is_same<ElementType, half>::value,
+                            sycl::detail::half_impl::BIsRepresentationT,
+                            ElementType>;
   using difference_type = std::ptrdiff_t;
 
   // Implementation defined pointer and reference types that correspond to
@@ -815,7 +816,7 @@ public:
            Space == access::address_space::global_space ||
            Space == access::address_space::ext_intel_global_device_space) &&
           std::is_const<ET>::value && std::is_same<ET, ElementType>::value>>
-  multi_ptr(accessor<typename std::remove_const_t<ET>, dimensions, Mode,
+  multi_ptr(accessor<typename detail::remove_const_t<ET>, dimensions, Mode,
                      access::target::device, isPlaceholder, PropertyListT>
                 Accessor)
       : multi_ptr(Accessor.get_pointer()) {}
@@ -830,7 +831,7 @@ public:
           (Space == access::address_space::generic_space ||
            Space == access::address_space::local_space) &&
           std::is_const<ET>::value && std::is_same<ET, ElementType>::value>>
-  multi_ptr(accessor<typename std::remove_const_t<ET>, dimensions, Mode,
+  multi_ptr(accessor<typename detail::remove_const_t<ET>, dimensions, Mode,
                      access::target::local, isPlaceholder, PropertyListT>
                 Accessor)
       : multi_ptr(Accessor.get_pointer()) {}
@@ -845,7 +846,7 @@ public:
            Space == access::address_space::local_space) &&
           std::is_const<ET>::value && std::is_same<ET, ElementType>::value>>
   multi_ptr(
-      local_accessor<typename std::remove_const_t<ET>, dimensions> Accessor)
+      local_accessor<typename detail::remove_const_t<ET>, dimensions> Accessor)
       : multi_ptr(Accessor.get_pointer()) {}
 
   // Only if Space == constant_space and element type is const
@@ -857,7 +858,7 @@ public:
           _Space == Space && Space == access::address_space::constant_space &&
           std::is_const<ET>::value && std::is_same<ET, ElementType>::value>>
   multi_ptr(
-      accessor<typename std::remove_const_t<ET>, dimensions, Mode,
+      accessor<typename detail::remove_const_t<ET>, dimensions, Mode,
                access::target::constant_buffer, isPlaceholder, PropertyListT>
           Accessor)
       : multi_ptr(Accessor.get_pointer()) {}
@@ -873,7 +874,7 @@ public:
   template <typename ET = ElementType>
   multi_ptr(typename std::enable_if_t<
             std::is_const<ET>::value && std::is_same<ET, ElementType>::value,
-            const multi_ptr<typename std::remove_const_t<ET>, Space,
+            const multi_ptr<typename detail::remove_const_t<ET>, Space,
                             access::decorated::legacy>> &ETP)
       : m_Pointer(ETP.get()) {}
 

--- a/sycl/include/sycl/property_list.hpp
+++ b/sycl/include/sycl/property_list.hpp
@@ -27,8 +27,8 @@ class property_list : protected detail::PropertyListBase {
   template <typename... Tail> struct AllProperties : std::true_type {};
   template <typename T, typename... Tail>
   struct AllProperties<T, Tail...>
-      : std::conditional_t<is_property<T>::value, AllProperties<Tail...>,
-                           std::false_type> {};
+      : detail::conditional_t<is_property<T>::value, AllProperties<Tail...>,
+                              std::false_type> {};
 
 public:
   template <typename... PropsT, typename = typename std::enable_if_t<

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -1059,9 +1059,9 @@ public:
   single_task(PropertiesT Properties,
               _KERNELFUNCPARAM(KernelFunc) _CODELOCPARAM(&CodeLoc)) {
     static_assert(
-        (detail::check_fn_signature<std::remove_reference_t<KernelType>,
+        (detail::check_fn_signature<detail::remove_reference_t<KernelType>,
                                     void()>::value ||
-         detail::check_fn_signature<std::remove_reference_t<KernelType>,
+         detail::check_fn_signature<detail::remove_reference_t<KernelType>,
                                     void(kernel_handler)>::value),
         "sycl::queue.single_task() requires a kernel instead of command group. "
         "Use queue.submit() instead");
@@ -1098,9 +1098,9 @@ public:
   single_task(event DepEvent, PropertiesT Properties,
               _KERNELFUNCPARAM(KernelFunc) _CODELOCPARAM(&CodeLoc)) {
     static_assert(
-        (detail::check_fn_signature<std::remove_reference_t<KernelType>,
+        (detail::check_fn_signature<detail::remove_reference_t<KernelType>,
                                     void()>::value ||
-         detail::check_fn_signature<std::remove_reference_t<KernelType>,
+         detail::check_fn_signature<detail::remove_reference_t<KernelType>,
                                     void(kernel_handler)>::value),
         "sycl::queue.single_task() requires a kernel instead of command group. "
         "Use queue.submit() instead");
@@ -1141,9 +1141,9 @@ public:
   single_task(const std::vector<event> &DepEvents, PropertiesT Properties,
               _KERNELFUNCPARAM(KernelFunc) _CODELOCPARAM(&CodeLoc)) {
     static_assert(
-        (detail::check_fn_signature<std::remove_reference_t<KernelType>,
+        (detail::check_fn_signature<detail::remove_reference_t<KernelType>,
                                     void()>::value ||
-         detail::check_fn_signature<std::remove_reference_t<KernelType>,
+         detail::check_fn_signature<detail::remove_reference_t<KernelType>,
                                     void(kernel_handler)>::value),
         "sycl::queue.single_task() requires a kernel instead of command group. "
         "Use queue.submit() instead");

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -80,17 +80,17 @@ namespace detail {
 template <typename T, class BinaryOperation>
 using IsReduOptForFastAtomicFetch =
 #ifdef SYCL_REDUCTION_DETERMINISTIC
-    std::bool_constant<false>;
+    bool_constant<false>;
 #else
-    std::bool_constant<((is_sgenfloat<T>::value && sizeof(T) == 4) ||
-                        is_sgeninteger<T>::value) &&
-                       IsValidAtomicType<T>::value &&
-                       (IsPlus<T, BinaryOperation>::value ||
-                        IsMinimum<T, BinaryOperation>::value ||
-                        IsMaximum<T, BinaryOperation>::value ||
-                        IsBitOR<T, BinaryOperation>::value ||
-                        IsBitXOR<T, BinaryOperation>::value ||
-                        IsBitAND<T, BinaryOperation>::value)>;
+    bool_constant<((is_sgenfloat<T>::value && sizeof(T) == 4) ||
+                   is_sgeninteger<T>::value) &&
+                  IsValidAtomicType<T>::value &&
+                  (IsPlus<T, BinaryOperation>::value ||
+                   IsMinimum<T, BinaryOperation>::value ||
+                   IsMaximum<T, BinaryOperation>::value ||
+                   IsBitOR<T, BinaryOperation>::value ||
+                   IsBitXOR<T, BinaryOperation>::value ||
+                   IsBitAND<T, BinaryOperation>::value)>;
 #endif
 
 // This type trait is used to detect if the atomic operation BinaryOperation
@@ -104,12 +104,12 @@ using IsReduOptForFastAtomicFetch =
 template <typename T, class BinaryOperation>
 using IsReduOptForAtomic64Op =
 #ifdef SYCL_REDUCTION_DETERMINISTIC
-    std::bool_constant<false>;
+    bool_constant<false>;
 #else
-    std::bool_constant<(IsPlus<T, BinaryOperation>::value ||
-                        IsMinimum<T, BinaryOperation>::value ||
-                        IsMaximum<T, BinaryOperation>::value) &&
-                       is_sgenfloat<T>::value && sizeof(T) == 8>;
+    bool_constant<(IsPlus<T, BinaryOperation>::value ||
+                   IsMinimum<T, BinaryOperation>::value ||
+                   IsMaximum<T, BinaryOperation>::value) &&
+                  is_sgenfloat<T>::value && sizeof(T) == 8>;
 #endif
 
 // This type trait is used to detect if the group algorithm reduce() used with
@@ -120,14 +120,14 @@ using IsReduOptForAtomic64Op =
 template <typename T, class BinaryOperation>
 using IsReduOptForFastReduce =
 #ifdef SYCL_REDUCTION_DETERMINISTIC
-    std::bool_constant<false>;
+    bool_constant<false>;
 #else
-    std::bool_constant<((is_sgeninteger<T>::value &&
-                         (sizeof(T) == 4 || sizeof(T) == 8)) ||
-                        is_sgenfloat<T>::value) &&
-                       (IsPlus<T, BinaryOperation>::value ||
-                        IsMinimum<T, BinaryOperation>::value ||
-                        IsMaximum<T, BinaryOperation>::value)>;
+    bool_constant<((is_sgeninteger<T>::value &&
+                    (sizeof(T) == 4 || sizeof(T) == 8)) ||
+                   is_sgenfloat<T>::value) &&
+                  (IsPlus<T, BinaryOperation>::value ||
+                   IsMinimum<T, BinaryOperation>::value ||
+                   IsMaximum<T, BinaryOperation>::value)>;
 #endif
 
 // std::tuple seems to be a) too heavy and b) not copyable to device now

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -121,14 +121,14 @@ template <typename T, int N> class BaseCLTypeConverter;
 
 // Element type for relational operator return value.
 template <typename DataT>
-using rel_t = typename std::conditional_t<
+using rel_t = typename detail::conditional_t<
     sizeof(DataT) == sizeof(cl_char), cl_char,
-    typename std::conditional_t<
+    typename detail::conditional_t<
         sizeof(DataT) == sizeof(cl_short), cl_short,
-        typename std::conditional_t<
+        typename detail::conditional_t<
             sizeof(DataT) == sizeof(cl_int), cl_int,
-            typename std::conditional_t<sizeof(DataT) == sizeof(cl_long),
-                                        cl_long, bool>>>>;
+            typename detail::conditional_t<sizeof(DataT) == sizeof(cl_long),
+                                           cl_long, bool>>>>;
 
 // Special type indicating that SwizzleOp should just read value from vector -
 // not trying to perform any operations. Should not be called.
@@ -317,17 +317,17 @@ std::enable_if_t<is_float_to_int<T, R>::value, R> convertImpl(T Value) {
 #else
 
 template <rounding_mode Mode>
-using RteOrAutomatic = std::bool_constant<Mode == rounding_mode::automatic ||
-                                          Mode == rounding_mode::rte>;
+using RteOrAutomatic = detail::bool_constant<Mode == rounding_mode::automatic ||
+                                             Mode == rounding_mode::rte>;
 
 template <rounding_mode Mode>
-using Rtz = std::bool_constant<Mode == rounding_mode::rtz>;
+using Rtz = detail::bool_constant<Mode == rounding_mode::rtz>;
 
 template <rounding_mode Mode>
-using Rtp = std::bool_constant<Mode == rounding_mode::rtp>;
+using Rtp = detail::bool_constant<Mode == rounding_mode::rtp>;
 
 template <rounding_mode Mode>
-using Rtn = std::bool_constant<Mode == rounding_mode::rtn>;
+using Rtn = detail::bool_constant<Mode == rounding_mode::rtn>;
 
 // convert types with an equal size and diff names
 template <typename T, typename R, rounding_mode roundingMode, typename OpenCLT,
@@ -566,19 +566,20 @@ template <typename Type, int NumElements> class vec {
 
   // SizeChecker is needed for vec(const argTN &... args) ctor to validate args.
   template <int Counter, int MaxValue, class...>
-  struct SizeChecker : std::conditional_t<Counter == MaxValue, std::true_type,
-                                          std::false_type> {};
+  struct SizeChecker : detail::conditional_t<Counter == MaxValue,
+                                             std::true_type, std::false_type> {
+  };
 
   template <int Counter, int MaxValue, typename DataT_, class... tail>
   struct SizeChecker<Counter, MaxValue, DataT_, tail...>
-      : std::conditional_t<Counter + 1 <= MaxValue,
-                           SizeChecker<Counter + 1, MaxValue, tail...>,
-                           std::false_type> {};
+      : detail::conditional_t<Counter + 1 <= MaxValue,
+                              SizeChecker<Counter + 1, MaxValue, tail...>,
+                              std::false_type> {};
 
 #define __SYCL_ALLOW_VECTOR_SIZES(num_elements)                                \
   template <int Counter, int MaxValue, typename DataT_, class... tail>         \
   struct SizeChecker<Counter, MaxValue, vec<DataT_, num_elements>, tail...>    \
-      : std::conditional_t<                                                    \
+      : detail::conditional_t<                                                 \
             Counter + (num_elements) <= MaxValue,                              \
             SizeChecker<Counter + (num_elements), MaxValue, tail...>,          \
             std::false_type> {};                                               \
@@ -589,7 +590,7 @@ template <typename Type, int NumElements> class vec {
       Counter, MaxValue,                                                       \
       detail::SwizzleOp<vec<DataT_, num_elements>, T2, T3, T4, T5...>,         \
       tail...>                                                                 \
-      : std::conditional_t<                                                    \
+      : detail::conditional_t<                                                 \
             Counter + sizeof...(T5) <= MaxValue,                               \
             SizeChecker<Counter + sizeof...(T5), MaxValue, tail...>,           \
             std::false_type> {};                                               \
@@ -600,7 +601,7 @@ template <typename Type, int NumElements> class vec {
       Counter, MaxValue,                                                       \
       detail::SwizzleOp<const vec<DataT_, num_elements>, T2, T3, T4, T5...>,   \
       tail...>                                                                 \
-      : std::conditional_t<                                                    \
+      : detail::conditional_t<                                                 \
             Counter + sizeof...(T5) <= MaxValue,                               \
             SizeChecker<Counter + sizeof...(T5), MaxValue, tail...>,           \
             std::false_type> {};
@@ -616,7 +617,7 @@ template <typename Type, int NumElements> class vec {
   template <class...> struct conjunction : std::true_type {};
   template <class B1, class... tail>
   struct conjunction<B1, tail...>
-      : std::conditional_t<bool(B1::value), conjunction<tail...>, B1> {};
+      : detail::conditional_t<bool(B1::value), conjunction<tail...>, B1> {};
 
   // TypeChecker is needed for vec(const argTN &... args) ctor to validate args.
   template <typename T, typename DataT_>
@@ -717,7 +718,7 @@ public:
   template <typename Ty = DataT>
   typename std::enable_if_t<
       std::is_fundamental<vec_data_t<Ty>>::value ||
-          std::is_same<typename std::remove_const_t<Ty>, half>::value,
+          std::is_same<typename detail::remove_const_t<Ty>, half>::value,
       vec &>
   operator=(const EnableIfNotHostHalf<Ty> &Rhs) {
     m_Data = (DataType)vec_data<Ty>::get(Rhs);
@@ -734,7 +735,7 @@ public:
   template <typename Ty = DataT>
   typename std::enable_if_t<
       std::is_fundamental<vec_data_t<Ty>>::value ||
-          std::is_same<typename std::remove_const_t<Ty>, half>::value,
+          std::is_same<typename detail::remove_const_t<Ty>, half>::value,
       vec &>
   operator=(const EnableIfHostHalf<Ty> &Rhs) {
     for (int i = 0; i < NumElements; ++i) {
@@ -752,7 +753,7 @@ public:
   template <typename Ty = DataT>
   typename std::enable_if_t<
       std::is_fundamental<vec_data_t<Ty>>::value ||
-          std::is_same<typename std::remove_const_t<Ty>, half>::value,
+          std::is_same<typename detail::remove_const_t<Ty>, half>::value,
       vec &>
   operator=(const DataT &Rhs) {
     for (int i = 0; i < NumElements; ++i) {
@@ -1001,7 +1002,7 @@ public:
   typename std::enable_if_t<                                                   \
       std::is_convertible<DataT, T>::value &&                                  \
           (std::is_fundamental<vec_data_t<T>>::value ||                        \
-           std::is_same<typename std::remove_const_t<T>, half>::value),        \
+           std::is_same<typename detail::remove_const_t<T>, half>::value),     \
       vec>                                                                     \
   operator BINOP(const T &Rhs) const {                                         \
     return *this BINOP vec(static_cast<const DataT &>(Rhs));                   \
@@ -1029,7 +1030,7 @@ public:
   typename std::enable_if_t<                                                   \
       std::is_convertible<DataT, T>::value &&                                  \
           (std::is_fundamental<vec_data_t<T>>::value ||                        \
-           std::is_same<typename std::remove_const_t<T>, half>::value),        \
+           std::is_same<typename detail::remove_const_t<T>, half>::value),     \
       vec>                                                                     \
   operator BINOP(const T &Rhs) const {                                         \
     return *this BINOP vec(static_cast<const DataT &>(Rhs));                   \
@@ -1436,13 +1437,13 @@ class SwizzleOp {
   using EnableIfScalarType = typename std::enable_if_t<
       std::is_convertible<DataT, T>::value &&
       (std::is_fundamental<vec_data_t<T>>::value ||
-       std::is_same<typename std::remove_const_t<T>, half>::value)>;
+       std::is_same<typename detail::remove_const_t<T>, half>::value)>;
 
   template <typename T>
   using EnableIfNoScalarType = typename std::enable_if_t<
       !std::is_convertible<DataT, T>::value ||
       !(std::is_fundamental<vec_data_t<T>>::value ||
-        std::is_same<typename std::remove_const_t<T>, half>::value)>;
+        std::is_same<typename detail::remove_const_t<T>, half>::value)>;
 
   template <int... Indices>
   using Swizzle =
@@ -1979,7 +1980,7 @@ private:
   template <typename T, int Num>                                               \
   typename std::enable_if_t<                                                   \
       std::is_fundamental<vec_data_t<T>>::value ||                             \
-          std::is_same<typename std::remove_const_t<T>, half>::value,          \
+          std::is_same<typename detail::remove_const_t<T>, half>::value,       \
       vec<T, Num>>                                                             \
   operator BINOP(const T &Lhs, const vec<T, Num> &Rhs) {                       \
     return vec<T, Num>(Lhs) BINOP Rhs;                                         \
@@ -1991,7 +1992,7 @@ private:
   typename std::enable_if_t<                                                   \
       std::is_convertible<T, T1>::value &&                                     \
           (std::is_fundamental<vec_data_t<T>>::value ||                        \
-           std::is_same<typename std::remove_const_t<T>, half>::value),        \
+           std::is_same<typename detail::remove_const_t<T>, half>::value),     \
       vec<T1, Num>>                                                            \
   operator BINOP(                                                              \
       const T &Lhs,                                                            \
@@ -2034,7 +2035,7 @@ __SYCL_BINOP(<<)
   typename std::enable_if_t<                                                   \
       std::is_convertible<T, DataT>::value &&                                  \
           (std::is_fundamental<vec_data_t<T>>::value ||                        \
-           std::is_same<typename std::remove_const_t<T>, half>::value),        \
+           std::is_same<typename detail::remove_const_t<T>, half>::value),     \
       vec<detail::rel_t<DataT>, Num>>                                          \
   operator RELLOGOP(const T &Lhs, const vec<DataT, Num> &Rhs) {                \
     return vec<T, Num>(static_cast<T>(Lhs)) RELLOGOP Rhs;                      \
@@ -2046,7 +2047,7 @@ __SYCL_BINOP(<<)
   typename std::enable_if_t<                                                   \
       std::is_convertible<T, T1>::value &&                                     \
           (std::is_fundamental<vec_data_t<T>>::value ||                        \
-           std::is_same<typename std::remove_const_t<T>, half>::value),        \
+           std::is_same<typename detail::remove_const_t<T>, half>::value),     \
       vec<detail::rel_t<T1>, Num>>                                             \
   operator RELLOGOP(                                                           \
       const T &Lhs,                                                            \
@@ -2143,10 +2144,10 @@ namespace detail {
 // select_apply_cl_t selects from T8/T16/T32/T64 basing on
 // sizeof(IN).  expected to handle scalar types in IN.
 template <typename T, typename T8, typename T16, typename T32, typename T64>
-using select_apply_cl_t = std::conditional_t<
-    sizeof(T) == 1, T8,
-    std::conditional_t<sizeof(T) == 2, T16,
-                       std::conditional_t<sizeof(T) == 4, T32, T64>>>;
+using select_apply_cl_t =
+    conditional_t<sizeof(T) == 1, T8,
+                  conditional_t<sizeof(T) == 2, T16,
+                                conditional_t<sizeof(T) == 4, T32, T64>>>;
 } // namespace detail
 
 #define __SYCL_DECLARE_CONVERTER(base, num)                                    \
@@ -2404,8 +2405,8 @@ template <> struct is_device_copyable<std::tuple<>> : std::true_type {};
 // is device copyable.
 template <typename T, typename... Ts>
 struct is_device_copyable<std::tuple<T, Ts...>>
-    : std::bool_constant<is_device_copyable<T>::value &&
-                         is_device_copyable<std::tuple<Ts...>>::value> {};
+    : detail::bool_constant<is_device_copyable<T>::value &&
+                            is_device_copyable<std::tuple<Ts...>>::value> {};
 
 // marray is device copyable if element type is device copyable and it is also
 // not trivially copyable (if the element type is trivially copyable, the marray

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -644,7 +644,7 @@ RT::PiDeviceBinaryType getBinaryImageFormat(const unsigned char *ImgData,
               {PI_DEVICE_BINARY_TYPE_NATIVE, 0x43544E49}};
 
   if (ImgSize >= sizeof(Fmts[0].Magic)) {
-    std::remove_const_t<decltype(Fmts[0].Magic)> Hdr = 0;
+    detail::remove_const_t<decltype(Fmts[0].Magic)> Hdr = 0;
     std::copy(ImgData, ImgData + sizeof(Hdr), reinterpret_cast<char *>(&Hdr));
 
     // Check headers for direct formats.


### PR DESCRIPTION
This reverts commit f4fc927095949ed9403b049662ec60923d56b067.

We found issues when trying to build the project on RHEL7 systems that we need in our OS support matrix.