### PR TITLE
[SYCL-MLIR] Generate non-LLVM dialect types inside single-field unions

### DIFF
--- a/polygeist/tools/cgeist/Test/Verification/single_field_union.c
+++ b/polygeist/tools/cgeist/Test/Verification/single_field_union.c
@@ -1,0 +1,21 @@
+// RUN: cgeist %s -O0 --function=* -S | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: cgeist %s -O0 --function=* -S -emit-llvm | FileCheck %s --check-prefix=CHECK-LLVM
+// XFAIL: *
+
+union int_wrapper {
+  int *ptr;
+};
+
+// CHECK-MLIR-LABEL:   func.func @foo(
+// CHECK-MLIR-SAME:                   %[[VAL_0:.*]]: memref<?xi32>) -> memref<?xi32>
+// CHECK-MLIR-NEXT:      return %[[VAL_0]] : memref<?xi32>
+// CHECK-MLIR-NEXT:    }
+
+// CHECK-LLVM-LABEL:   define i32* @foo(
+// CHECK-LLVM-SAME:                     i32* %[[VAL_0:.*]]) {
+// CHECK-LLVM-NEXT:      ret i32* %[[VAL_0]]
+// CHECK-LLVM-NEXT:    }
+
+union int_wrapper foo(union int_wrapper w) {
+  return w;
+}

--- a/polygeist/tools/cgeist/Test/Verification/single_field_union.c
+++ b/polygeist/tools/cgeist/Test/Verification/single_field_union.c
@@ -2,6 +2,12 @@
 // RUN: cgeist %s -O0 --function=* -S -emit-llvm | FileCheck %s --check-prefix=CHECK-LLVM
 // XFAIL: *
 
+// Our type generation currently does not differ between scalar and memory
+// representation. Here we are generating the memory representation of union
+// int_wrapper instead of its scalar representation. This test will thus fail.
+
+// Also see issue: https://github.com/intel/llvm/issues/7994
+
 union int_wrapper {
   int *ptr;
 };

--- a/polygeist/tools/cgeist/Test/Verification/single_field_union_for_mem.c
+++ b/polygeist/tools/cgeist/Test/Verification/single_field_union_for_mem.c
@@ -1,0 +1,22 @@
+// RUN: cgeist %s -O0 --function=* -S | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: cgeist %s -O0 --function=* -S -emit-llvm | FileCheck %s --check-prefix=CHECK-LLVM
+
+struct foo {
+  union int_wrapper {
+    int *ptr;
+  } d;
+};
+
+// CHECK-MLIR-LABEL:   func.func @id(
+// CHECK-MLIR-SAME:                  %[[VAL_0:.*]]: !llvm.struct<(!llvm.struct<(memref<?xi32>)>)>) -> !llvm.struct<(!llvm.struct<(memref<?xi32>)>)>
+// CHECK-MLIR-NEXT:      return %[[VAL_0]] : !llvm.struct<(!llvm.struct<(memref<?xi32>)>)>
+// CHECK-MLIR-NEXT:    }
+
+// CHECK-LLVM-LABEL:   define { { i32* } } @id(
+// CHECK-LLVM-SAME:                                 { { i32* } } %[[VAL_0:.*]]) {
+// CHECK-LLVM-NEXT:      ret { { i32* } } %[[VAL_0]]
+// CHECK-LLVM-NEXT:    }
+
+struct foo id(struct foo f) {
+  return f;
+}

--- a/polygeist/tools/cgeist/Test/Verification/single_field_union_for_mem.c
+++ b/polygeist/tools/cgeist/Test/Verification/single_field_union_for_mem.c
@@ -13,7 +13,7 @@ struct foo {
 // CHECK-MLIR-NEXT:    }
 
 // CHECK-LLVM-LABEL:   define { { i32* } } @id(
-// CHECK-LLVM-SAME:                                 { { i32* } } %[[VAL_0:.*]]) {
+// CHECK-LLVM-SAME:                            { { i32* } } %[[VAL_0:.*]]) {
 // CHECK-LLVM-NEXT:      ret { { i32* } } %[[VAL_0]]
 // CHECK-LLVM-NEXT:    }
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -11,7 +11,7 @@
 // CHECK-DAG: !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
 // CHECK-DAG: !sycl_range_2_ = !sycl.range<[2], (!sycl_array_2_)>
 // CHECK-DAG: !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-// CHECK-DAG: !sycl_accessor_1_i32_w_gb = !sycl.accessor<[1, i32, write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+// CHECK-DAG: !sycl_accessor_1_i32_w_gb = !sycl.accessor<[1, i32, write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
 // CHECK-DAG: ![[ITEM_BASE:.*]] = !sycl.item_base<[2, true], (!sycl_range_2_, !sycl_id_2_, !sycl_id_2_)>
 // CHECK-DAG: ![[ITEM:.*]] = !sycl.item<[2, true], (![[ITEM_BASE]])>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -16,8 +16,8 @@
 // CHECK-MLIR-DAG: !sycl_range_2_ = !sycl.range<[2], (!sycl_array_2_)>
 // CHECK-MLIR-DAG: !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
 // CHECK-MLIR-DAG: !sycl_accessor_impl_device_2_ = !sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>
-// CHECK-MLIR-DAG: !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
-// CHECK-MLIR-DAG: !sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<i32, 1>)>)>
+// CHECK-MLIR-DAG: !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
+// CHECK-MLIR-DAG: !sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(memref<?xi32, 1>)>)>
 // CHECK-MLIR-DAG: ![[ACC_STRUCT:.*]] = !sycl.accessor<[1, !llvm.struct<(i32)>, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<struct<(i32)>, 1>)>)>
 // CHECK-MLIR-DAG: ![[ACC_SUBSCRIPT:.*]] = !sycl.accessor_subscript<[1], (!sycl_id_2_, !sycl_accessor_2_i32_rw_gb)>
 // CHECK-MLIR-DAG: ![[ITEM_BASE1:.*]] = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -3,10 +3,11 @@
 
 #include <sycl/sycl.hpp>
 
-// CHECK-DAG: !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+// CHECK-DAG: !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
 // CHECK-DAG: !sycl_accessor_1_i32_rw_l = !sycl.accessor<[1, i32, read_write, local], (!sycl_local_accessor_base_1_i32_rw)>
-// CHECK-DAG: !sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<i32, 1>)>)>
-// CHECK-DAG: !sycl_accessor_3_f32_rw_gb = !sycl.accessor<[3, f32, read_write, global_buffer], (!sycl_accessor_impl_device_3_, !llvm.struct<(ptr<f32, 1>)>)>
+// CHECK-DAG: !sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(memref<?xi32, 1>)>)>
+// CHECK-DAG: !sycl_accessor_3_f32_rw_gb = !sycl.accessor<[3, f32, read_write, global_buffer], (!sycl_accessor_impl_device_3_, !llvm.struct<(memref<?xf32, 1>)>)>
+// CHECK-DAG: !sycl_accessor_1_21sycl2Evec3C5Bi322C_45D2C_28vector3C4xi323E293E_rw_gb = !sycl.accessor<[1, !sycl_vec_i32_4_, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?x!sycl_vec_i32_4_, 1>)>)>
 // CHECK-DAG: !sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
 // CHECK-DAG: !sycl_array_2_ = !sycl.array<[2], (memref<2xi64, 4>)>
 // CHECK-DAG: !sycl_assert_happened_ = !sycl.assert_happened<(i32, !llvm.array<257 x i8>, !llvm.array<257 x i8>, !llvm.array<129 x i8>, i32, i64, i64, i64, i64, i64, i64)>
@@ -67,6 +68,11 @@ SYCL_EXTERNAL void accessor_3(sycl::accessor<sycl::cl_float, 3, sycl::access::mo
 // CHECK:          %arg0: memref<?x!sycl_accessor_1_i32_rw_l> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_1_i32_rw_l, llvm.noundef}) 
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
 SYCL_EXTERNAL void accessor_4(sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write, sycl::access::target::local>) {}
+
+// CHECK-LABEL: func.func @_Z10accessor_5N4sycl3_V18accessorINS0_3vecIiLi4EEELi1ELNS0_6access4modeE1026ELNS4_6targetE2014ELNS4_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
+// CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_21sycl2Evec3C5Bi322C_45D2C_28vector3C4xi323E293E_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_1_21sycl2Evec3C5Bi322C_45D2C_28vector3C4xi323E293E_rw_gb, llvm.noundef})
+// CHECK-SAME:  attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
+SYCL_EXTERNAL void accessor_5(sycl::accessor<sycl::vec<int, 4>, 1, sycl::access::mode::read_write, sycl::access::target::global_buffer>) {}
 
 // %"struct.sycl::_V1::detail::AssertHappened" = type { i32, [257 x i8], [257 x i8], [129 x i8], i32, i64, i64, i64, i64, i64, i64 }
 // CHECK-LABEL: func.func @_Z15assert_happenedN4sycl3_V16detail14AssertHappenedE(


### PR DESCRIPTION
Instead of generating a pure LLVM dialect type, allow other types inside                                                                                                                                                                                           
single-field unions.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>