### PR TITLE
[SYCL] Usm allocator refactor

### DIFF
--- a/sycl/plugins/level_zero/CMakeLists.txt
+++ b/sycl/plugins/level_zero/CMakeLists.txt
@@ -90,6 +90,8 @@ add_sycl_plugin(level_zero
     "../unified_runtime/ur/ur.cpp"
     "../unified_runtime/ur/usm_allocator.cpp"
     "../unified_runtime/ur/usm_allocator.hpp"
+    "../unified_runtime/ur/usm_allocator_config.cpp"
+    "../unified_runtime/ur/usm_allocator_config.hpp"
     "../unified_runtime/ur/adapters/level_zero/ur_level_zero.hpp"
     "../unified_runtime/ur/adapters/level_zero/ur_level_zero.cpp"
     # Following are the PI Level-Zero Plugin only codes.

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -118,7 +118,6 @@ protected:
   // type
   virtual pi_result allocateImpl(void **ResultPtr, size_t Size,
                                  pi_uint32 Alignment) = 0;
-  virtual MemType getMemTypeImpl() = 0;
 
 public:
   USMMemoryAllocBase(pi_context Ctx, pi_device Dev)
@@ -126,7 +125,6 @@ public:
   void *allocate(size_t Size) override final;
   void *allocate(size_t Size, size_t Alignment) override final;
   void deallocate(void *Ptr, bool OwnZeMemHandle) override final;
-  MemType getMemType() override final;
 };
 
 // Allocation routines for shared memory type
@@ -134,7 +132,6 @@ class USMSharedMemoryAlloc : public USMMemoryAllocBase {
 protected:
   pi_result allocateImpl(void **ResultPtr, size_t Size,
                          pi_uint32 Alignment) override;
-  MemType getMemTypeImpl() override;
 
 public:
   USMSharedMemoryAlloc(pi_context Ctx, pi_device Dev)
@@ -146,7 +143,6 @@ class USMSharedReadOnlyMemoryAlloc : public USMMemoryAllocBase {
 protected:
   pi_result allocateImpl(void **ResultPtr, size_t Size,
                          pi_uint32 Alignment) override;
-  MemType getMemTypeImpl() override { return MemType::SharedReadOnly; }
 
 public:
   USMSharedReadOnlyMemoryAlloc(pi_context Ctx, pi_device Dev)
@@ -158,7 +154,6 @@ class USMDeviceMemoryAlloc : public USMMemoryAllocBase {
 protected:
   pi_result allocateImpl(void **ResultPtr, size_t Size,
                          pi_uint32 Alignment) override;
-  MemType getMemTypeImpl() override;
 
 public:
   USMDeviceMemoryAlloc(pi_context Ctx, pi_device Dev)
@@ -170,7 +165,6 @@ class USMHostMemoryAlloc : public USMMemoryAllocBase {
 protected:
   pi_result allocateImpl(void **ResultPtr, size_t Size,
                          pi_uint32 Alignment) override;
-  MemType getMemTypeImpl() override;
 
 public:
   USMHostMemoryAlloc(pi_context Ctx) : USMMemoryAllocBase(Ctx, nullptr) {}

--- a/sycl/plugins/unified_runtime/ur/usm_allocator.cpp
+++ b/sycl/plugins/unified_runtime/ur/usm_allocator.cpp
@@ -272,9 +272,6 @@ class USMAllocContext::USMAllocImpl {
   // Configuration for this instance
   USMAllocatorParameters params;
 
-  // Protects the capacity checking of the pool.
-  SpinLock PoolLock;
-
 public:
   USMAllocImpl(std::unique_ptr<SystemMemory> SystemMemHandle,
                USMAllocatorParameters params)
@@ -308,8 +305,6 @@ public:
 
   void printStats(bool &TitlePrinted, size_t &HighBucketSize,
                   size_t &HighPeakSlabsInUse, const std::string &Label);
-
-  SpinLock &getLock() { return PoolLock; }
 
 private:
   Bucket &findBucket(size_t Size);
@@ -582,7 +577,6 @@ void Bucket::onFreeChunk(Slab &Slab, bool &ToPool) {
 }
 
 bool Bucket::CanPool(bool &ToPool) {
-  std::lock_guard<SpinLock> Lock{OwnAllocCtx.getLock()};
   size_t NewFreeSlabsInBucket;
   // Check if this bucket is used in chunked form or as full slabs.
   bool chunkedBucket = getSize() <= ChunkCutOff();

--- a/sycl/plugins/unified_runtime/ur/usm_allocator.hpp
+++ b/sycl/plugins/unified_runtime/ur/usm_allocator.hpp
@@ -9,9 +9,8 @@
 #ifndef USM_ALLOCATOR
 #define USM_ALLOCATOR
 
+#include <atomic>
 #include <memory>
-
-enum MemType { Host, Device, Shared, SharedReadOnly, All };
 
 // USM system memory allocation/deallocation interface.
 class SystemMemory {
@@ -19,8 +18,43 @@ public:
   virtual void *allocate(size_t size) = 0;
   virtual void *allocate(size_t size, size_t aligned) = 0;
   virtual void deallocate(void *ptr, bool OwnZeMemHandle) = 0;
-  virtual MemType getMemType() = 0;
   virtual ~SystemMemory() = default;
+};
+
+class USMLimits {
+public:
+  // Maximum memory left unfreed
+  size_t MaxSize = 16 * 1024 * 1024;
+
+  // Total size of pooled memory
+  std::atomic<size_t> TotalSize = 0;
+};
+
+// Configuration for specific USM allocator instance
+class USMAllocatorParameters {
+public:
+  const char *memoryTypeName = "";
+
+  // Minimum allocation size that will be requested from the system.
+  // By default this is the minimum allocation size of each memory type.
+  size_t SlabMinSize = 0;
+
+  // Allocations up to this limit will be subject to chunking/pooling
+  size_t MaxPoolableSize = 0;
+
+  // When pooling, each bucket will hold a max of 4 unfreed slabs
+  size_t Capacity = 0;
+
+  // Holds the minimum bucket size valid for allocation of a memory type.
+  size_t MinBucketSize = 0;
+
+  // Holds size of the pool managed by the allocator.
+  size_t CurPoolSize = 0;
+
+  // Whether to print pool usage statistics
+  int PoolTrace = 0;
+
+  std::shared_ptr<USMLimits> limits;
 };
 
 class USMAllocContext {
@@ -28,7 +62,8 @@ public:
   // Keep it public since it needs to be accessed by the lower layer(Buckets)
   class USMAllocImpl;
 
-  USMAllocContext(std::unique_ptr<SystemMemory> memHandle);
+  USMAllocContext(std::unique_ptr<SystemMemory> memHandle,
+                  USMAllocatorParameters params);
   ~USMAllocContext();
 
   void *allocate(size_t size);
@@ -38,8 +73,5 @@ public:
 private:
   std::unique_ptr<USMAllocImpl> pImpl;
 };
-
-// Temporary interface to allow pooling to be reverted, i.e., no buffer support
-bool enableBufferPooling();
 
 #endif

--- a/sycl/plugins/unified_runtime/ur/usm_allocator_config.cpp
+++ b/sycl/plugins/unified_runtime/ur/usm_allocator_config.cpp
@@ -135,23 +135,24 @@ USMAllocatorConfig::USMAllocatorConfig() {
 
     bool More = ParamParser(Params, Configs[LM].MaxPoolableSize, ParamWasSet);
     if (ParamWasSet && M == MemType::All) {
-      Configs[MemType::Shared].MaxPoolableSize =
-          Configs[MemType::Device].MaxPoolableSize =
-              Configs[MemType::Host].MaxPoolableSize;
+      for (auto &Config : Configs) {
+        Config.MaxPoolableSize = Configs[LM].MaxPoolableSize;
+      }
     }
     if (More) {
       More = ParamParser(Params, Configs[LM].Capacity, ParamWasSet);
       if (ParamWasSet && M == MemType::All) {
-        Configs[MemType::Shared].Capacity = Configs[MemType::Device].Capacity =
-            Configs[MemType::Host].Capacity;
+        for (auto &Config : Configs) {
+          Config.Capacity = Configs[LM].Capacity;
+        }
       }
     }
     if (More) {
       ParamParser(Params, Configs[LM].SlabMinSize, ParamWasSet);
       if (ParamWasSet && M == MemType::All) {
-        Configs[MemType::Shared].SlabMinSize =
-            Configs[MemType::Device].SlabMinSize =
-                Configs[MemType::Host].SlabMinSize;
+        for (auto &Config : Configs) {
+          Config.SlabMinSize = Configs[LM].SlabMinSize;
+        }
       }
     }
   };
@@ -225,14 +226,10 @@ USMAllocatorConfig::USMAllocatorConfig() {
     PoolTrace = std::atoi(PoolTraceVal);
   }
 
-  Configs[MemType::SharedReadOnly].limits = limits;
-  Configs[MemType::Shared].limits = limits;
-  Configs[MemType::Device].limits = limits;
-  Configs[MemType::Host].limits = limits;
-
-  Configs[MemType::Shared].PoolTrace = Configs[MemType::Device].PoolTrace =
-      Configs[MemType::Host].PoolTrace =
-          Configs[MemType::SharedReadOnly].PoolTrace = PoolTrace;
+  for (auto &Config : Configs) {
+    Config.limits = limits;
+    Config.PoolTrace = PoolTrace;
+  }
 
   if (PoolTrace < 1)
     return;

--- a/sycl/plugins/unified_runtime/ur/usm_allocator_config.cpp
+++ b/sycl/plugins/unified_runtime/ur/usm_allocator_config.cpp
@@ -1,0 +1,268 @@
+//===--- usm_allocator_config.cpp -configuration for USM memory allocator---==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "usm_allocator_config.hpp"
+
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+namespace usm_settings {
+
+constexpr auto operator""_B(unsigned long long x) -> size_t { return x; }
+constexpr auto operator""_KB(unsigned long long x) -> size_t {
+  return x * 1024;
+}
+constexpr auto operator""_MB(unsigned long long x) -> size_t {
+  return x * 1024 * 1024;
+}
+constexpr auto operator""_GB(unsigned long long x) -> size_t {
+  return x * 1024 * 1024 * 1024;
+}
+
+USMAllocatorConfig::USMAllocatorConfig() {
+  size_t i = 0;
+  for (auto &memoryTypeName : MemTypeNames) {
+    Configs[i++].memoryTypeName = memoryTypeName;
+  }
+
+  // Buckets for Host use a minimum of the cache line size of 64 bytes.
+  // This prevents two separate allocations residing in the same cache line.
+  // Buckets for Device and Shared allocations will use starting size of 512.
+  // This is because memory compression on newer GPUs makes the
+  // minimum granularity 512 bytes instead of 64.
+  Configs[MemType::Host].MinBucketSize = 64;
+  Configs[MemType::Device].MinBucketSize = 512;
+  Configs[MemType::Shared].MinBucketSize = 512;
+  Configs[MemType::SharedReadOnly].MinBucketSize = 512;
+
+  // Initialize default pool settings.
+  Configs[MemType::Host].MaxPoolableSize = 2_MB;
+  Configs[MemType::Host].Capacity = 4;
+  Configs[MemType::Host].SlabMinSize = 64_KB;
+
+  Configs[MemType::Device].MaxPoolableSize = 4_MB;
+  Configs[MemType::Device].Capacity = 4;
+  Configs[MemType::Device].SlabMinSize = 64_KB;
+
+  // Disable pooling of shared USM allocations.
+  Configs[MemType::Shared].MaxPoolableSize = 0;
+  Configs[MemType::Shared].Capacity = 0;
+  Configs[MemType::Shared].SlabMinSize = 2_MB;
+
+  // Allow pooling of shared allocations that are only modified on host.
+  Configs[MemType::SharedReadOnly].MaxPoolableSize = 4_MB;
+  Configs[MemType::SharedReadOnly].Capacity = 4;
+  Configs[MemType::SharedReadOnly].SlabMinSize = 2_MB;
+
+  // Parse optional parameters of this form:
+  // SYCL_PI_LEVEL_ZERO_USM_ALLOCATOR=[EnableBuffers][;[MaxPoolSize][;memtypelimits]...]
+  //  memtypelimits: [<memtype>:]<limits>
+  //  memtype: host|device|shared
+  //  limits:  [MaxPoolableSize][,[Capacity][,SlabMinSize]]
+  //
+  // Without a memory type, the limits are applied to each memory type.
+  // Parameters are for each context, except MaxPoolSize, which is overall
+  // pool size for all contexts.
+  // Duplicate specifications will result in the right-most taking effect.
+  //
+  // EnableBuffers:   Apply chunking/pooling to SYCL buffers.
+  //                  Default 1.
+  // MaxPoolSize:     Limit on overall unfreed memory.
+  //                  Default 16MB.
+  // MaxPoolableSize: Maximum allocation size subject to chunking/pooling.
+  //                  Default 2MB host, 4MB device and 0 shared.
+  // Capacity:        Maximum number of unfreed allocations in each bucket.
+  //                  Default 4.
+  // SlabMinSize:     Minimum allocation size requested from USM.
+  //                  Default 64KB host and device, 2MB shared.
+  //
+  // Example of usage:
+  // SYCL_PI_LEVEL_ZERO_USM_ALLOCATOR=1;32M;host:1M,4,64K;device:1M,4,64K;shared:0,0,2M
+
+  auto GetValue = [=](std::string &Param, size_t Length, size_t &Setting) {
+    size_t Multiplier = 1;
+    if (tolower(Param[Length - 1]) == 'k') {
+      Length--;
+      Multiplier = 1_KB;
+    }
+    if (tolower(Param[Length - 1]) == 'm') {
+      Length--;
+      Multiplier = 1_MB;
+    }
+    if (tolower(Param[Length - 1]) == 'g') {
+      Length--;
+      Multiplier = 1_GB;
+    }
+    std::string TheNumber = Param.substr(0, Length);
+    if (TheNumber.find_first_not_of("0123456789") == std::string::npos)
+      Setting = std::stoi(TheNumber) * Multiplier;
+  };
+
+  auto ParamParser = [=](std::string &Params, size_t &Setting,
+                         bool &ParamWasSet) {
+    bool More;
+    if (Params.size() == 0) {
+      ParamWasSet = false;
+      return false;
+    }
+    size_t Pos = Params.find(',');
+    if (Pos != std::string::npos) {
+      if (Pos > 0) {
+        GetValue(Params, Pos, Setting);
+        ParamWasSet = true;
+      }
+      Params.erase(0, Pos + 1);
+      More = true;
+    } else {
+      GetValue(Params, Params.size(), Setting);
+      ParamWasSet = true;
+      More = false;
+    }
+    return More;
+  };
+
+  auto MemParser = [=](std::string &Params, MemType M) {
+    bool ParamWasSet;
+    MemType LM = M;
+    if (M == MemType::All)
+      LM = MemType::Host;
+
+    bool More = ParamParser(Params, Configs[LM].MaxPoolableSize, ParamWasSet);
+    if (ParamWasSet && M == MemType::All) {
+      Configs[MemType::Shared].MaxPoolableSize =
+          Configs[MemType::Device].MaxPoolableSize =
+              Configs[MemType::Host].MaxPoolableSize;
+    }
+    if (More) {
+      More = ParamParser(Params, Configs[LM].Capacity, ParamWasSet);
+      if (ParamWasSet && M == MemType::All) {
+        Configs[MemType::Shared].Capacity = Configs[MemType::Device].Capacity =
+            Configs[MemType::Host].Capacity;
+      }
+    }
+    if (More) {
+      ParamParser(Params, Configs[LM].SlabMinSize, ParamWasSet);
+      if (ParamWasSet && M == MemType::All) {
+        Configs[MemType::Shared].SlabMinSize =
+            Configs[MemType::Device].SlabMinSize =
+                Configs[MemType::Host].SlabMinSize;
+      }
+    }
+  };
+
+  auto MemTypeParser = [=](std::string &Params) {
+    int Pos = 0;
+    MemType M = MemType::All;
+    if (Params.compare(0, 5, "host:") == 0) {
+      Pos = 5;
+      M = MemType::Host;
+    } else if (Params.compare(0, 7, "device:") == 0) {
+      Pos = 7;
+      M = MemType::Device;
+    } else if (Params.compare(0, 7, "shared:") == 0) {
+      Pos = 7;
+      M = MemType::Shared;
+    } else if (Params.compare(0, 17, "read_only_shared:") == 0) {
+      Pos = 17;
+      M = MemType::SharedReadOnly;
+    }
+    if (Pos > 0)
+      Params.erase(0, Pos);
+    MemParser(Params, M);
+  };
+
+  auto limits = std::make_shared<USMLimits>();
+
+  // Update pool settings if specified in environment.
+  char *PoolParams = getenv("SYCL_PI_LEVEL_ZERO_USM_ALLOCATOR");
+  if (PoolParams != nullptr) {
+    std::string Params(PoolParams);
+    size_t Pos = Params.find(';');
+    if (Pos != std::string::npos) {
+      if (Pos > 0) {
+        GetValue(Params, Pos, EnableBuffers);
+      }
+      Params.erase(0, Pos + 1);
+      size_t Pos = Params.find(';');
+      if (Pos != std::string::npos) {
+        if (Pos > 0) {
+          GetValue(Params, Pos, limits->MaxSize);
+        }
+        Params.erase(0, Pos + 1);
+        do {
+          size_t Pos = Params.find(';');
+          if (Pos != std::string::npos) {
+            if (Pos > 0) {
+              std::string MemParams = Params.substr(0, Pos);
+              MemTypeParser(MemParams);
+            }
+            Params.erase(0, Pos + 1);
+            if (Params.size() == 0)
+              break;
+          } else {
+            MemTypeParser(Params);
+            break;
+          }
+        } while (true);
+      } else {
+        // set MaxPoolSize for all configs
+        GetValue(Params, Params.size(), limits->MaxSize);
+      }
+    } else {
+      GetValue(Params, Params.size(), EnableBuffers);
+    }
+  }
+
+  char *PoolTraceVal = getenv("SYCL_PI_LEVEL_ZERO_USM_ALLOCATOR_TRACE");
+  int PoolTrace = 0;
+  if (PoolTraceVal != nullptr) {
+    PoolTrace = std::atoi(PoolTraceVal);
+  }
+
+  Configs[MemType::SharedReadOnly].limits = limits;
+  Configs[MemType::Shared].limits = limits;
+  Configs[MemType::Device].limits = limits;
+  Configs[MemType::Host].limits = limits;
+
+  Configs[MemType::Shared].PoolTrace = Configs[MemType::Device].PoolTrace =
+      Configs[MemType::Host].PoolTrace =
+          Configs[MemType::SharedReadOnly].PoolTrace = PoolTrace;
+
+  if (PoolTrace < 1)
+    return;
+
+  std::cout << "USM Pool Settings (Built-in or Adjusted by Environment "
+               "Variable)"
+            << std::endl;
+
+  std::cout << std::setw(15) << "Parameter" << std::setw(12) << "Host"
+            << std::setw(12) << "Device" << std::setw(12) << "Shared RW"
+            << std::setw(12) << "Shared RO" << std::endl;
+  std::cout << std::setw(15) << "SlabMinSize" << std::setw(12)
+            << Configs[MemType::Host].SlabMinSize << std::setw(12)
+            << Configs[MemType::Device].SlabMinSize << std::setw(12)
+            << Configs[MemType::Shared].SlabMinSize << std::setw(12)
+            << Configs[MemType::SharedReadOnly].SlabMinSize << std::endl;
+  std::cout << std::setw(15) << "MaxPoolableSize" << std::setw(12)
+            << Configs[MemType::Host].MaxPoolableSize << std::setw(12)
+            << Configs[MemType::Device].MaxPoolableSize << std::setw(12)
+            << Configs[MemType::Shared].MaxPoolableSize << std::setw(12)
+            << Configs[MemType::SharedReadOnly].MaxPoolableSize << std::endl;
+  std::cout << std::setw(15) << "Capacity" << std::setw(12)
+            << Configs[MemType::Host].Capacity << std::setw(12)
+            << Configs[MemType::Device].Capacity << std::setw(12)
+            << Configs[MemType::Shared].Capacity << std::setw(12)
+            << Configs[MemType::SharedReadOnly].Capacity << std::endl;
+  std::cout << std::setw(15) << "MaxPoolSize" << std::setw(12)
+            << limits->MaxSize << std::endl;
+  std::cout << std::setw(15) << "EnableBuffers" << std::setw(12)
+            << EnableBuffers << std::endl
+            << std::endl;
+}
+} // namespace usm_settings

--- a/sycl/plugins/unified_runtime/ur/usm_allocator_config.hpp
+++ b/sycl/plugins/unified_runtime/ur/usm_allocator_config.hpp
@@ -1,0 +1,35 @@
+//===--- usm_allocator_config.hpp -configuration for USM memory allocator---==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef USM_ALLOCATOR_CONFIG
+#define USM_ALLOCATOR_CONFIG
+
+#include "usm_allocator.hpp"
+
+#include <string>
+
+namespace usm_settings {
+
+enum MemType { Host, Device, Shared, SharedReadOnly, All };
+
+// Reads and stores configuration for all instances of USM allocator
+class USMAllocatorConfig {
+public:
+  size_t EnableBuffers = 1;
+
+  USMAllocatorParameters Configs[MemType::All];
+
+  // String names of memory types for printing in limits traces.
+  static constexpr const char *MemTypeNames[MemType::All] = {
+      "Host", "Device", "Shared", "SharedReadOnly"};
+
+  USMAllocatorConfig();
+};
+} // namespace usm_settings
+
+#endif


### PR DESCRIPTION
This commit makes USMAllocator unaware of the memory type on which it is operating. The user of USMAllocator is responsible
for setting appropriate options for each instance of USMAllocator.

This is the first step to making USMAllocator generic.  In the next step, I'd like to start integration with Unified Memory Allocation (oneMemory). USMAllocator would be used as a heap manager by UMA.