### PR TITLE
[CI] Add CUDA on AWS run in pre-commit

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -48,7 +48,7 @@ jobs:
     uses: ./.github/workflows/sycl_gen_test_matrix.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
-      lts_config: "hip_amdgpu;ocl_x64;ocl_gen9;l0_gen9;esimd_emu;cuda"
+      lts_config: "hip_amdgpu;ocl_x64;ocl_gen9;l0_gen9;esimd_emu;cuda;cuda_aws"
 
   linux_default:
     name: Linux

--- a/devops/test_configs.json
+++ b/devops/test_configs.json
@@ -71,6 +71,18 @@
       "container_options": "--gpus all",
       "check_sycl_all": "cuda:gpu",
       "cmake_args": ""
+    },
+    {
+      "config": "cuda_aws",
+      "name": "CUDA LLVM Test Suite",
+      "runs-on": "aws-cuda_${{ inputs.uniq }}",
+      "aws-ami": "ami-02ec0f344128253f9",
+      "aws-type": [ "g4dn.2xlarge", "g4dn.4xlarge" ],
+      "aws-disk": "/dev/xvda:64",
+      "image": "${{ inputs.cuda_image }}",
+      "container_options": "--gpus all",
+      "check_sycl_all": "cuda:gpu",
+      "cmake_args": ""
     }
   ],
   "cts": [


### PR DESCRIPTION
Add CUDA on AWS in addition to CUDA on self-hosted runner. Self-hosted runner will be turned off for OS upgrade.
Note that pre-commit testing on this PR will test nothing due to pull_request_target trigger.
This change has to be merged first and we'll see effect on the other pre-commit PRs where we expect both self-hosted and AWS run done in parallel.