### PR TITLE
[SYCL] Use decorated pointer in device_global

### DIFF
--- a/sycl/include/sycl/ext/oneapi/device_global/device_global.hpp
+++ b/sycl/include/sycl/ext/oneapi/device_global/device_global.hpp
@@ -15,6 +15,7 @@
 #include <sycl/exception.hpp>
 #include <sycl/ext/oneapi/device_global/properties.hpp>
 #include <sycl/ext/oneapi/properties/properties.hpp>
+#include <sycl/pointers.hpp>
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define __SYCL_HOST_NOT_SUPPORTED(Op)
@@ -42,8 +43,7 @@ struct HasArrowOperator<
 template <typename T, typename PropertyListT, typename = void>
 class device_global_base {
 protected:
-  using pointer_t = typename multi_ptr<T, access::address_space::global_space,
-                                       access::decorated::yes>::pointer;
+  using pointer_t = typename decorated_global_ptr<T>::pointer;
   pointer_t usmptr;
   pointer_t get_ptr() noexcept { return usmptr; }
   const pointer_t get_ptr() const noexcept { return usmptr; }

--- a/sycl/include/sycl/ext/oneapi/device_global/device_global.hpp
+++ b/sycl/include/sycl/ext/oneapi/device_global/device_global.hpp
@@ -42,9 +42,28 @@ struct HasArrowOperator<
 template <typename T, typename PropertyListT, typename = void>
 class device_global_base {
 protected:
-  T *usmptr;
-  T *get_ptr() noexcept { return usmptr; }
-  const T *get_ptr() const noexcept { return usmptr; }
+  using pointer_t = typename multi_ptr<T, access::address_space::global_space,
+                                       access::decorated::yes>::pointer;
+  pointer_t usmptr;
+  pointer_t get_ptr() noexcept { return usmptr; }
+  const pointer_t get_ptr() const noexcept { return usmptr; }
+
+public:
+  template <access::decorated IsDecorated>
+  multi_ptr<T, access::address_space::global_space, IsDecorated>
+  get_multi_ptr() noexcept {
+    __SYCL_HOST_NOT_SUPPORTED("get_multi_ptr()")
+    return multi_ptr<T, access::address_space::global_space, IsDecorated>{
+        get_ptr()};
+  }
+
+  template <access::decorated IsDecorated>
+  multi_ptr<const T, access::address_space::global_space, IsDecorated>
+  get_multi_ptr() const noexcept {
+    __SYCL_HOST_NOT_SUPPORTED("get_multi_ptr()")
+    return multi_ptr<const T, access::address_space::global_space, IsDecorated>{
+        get_ptr()};
+  }
 };
 
 // Specialization of device_global base class for when device_image_scope is in
@@ -58,6 +77,23 @@ protected:
   T val{};
   T *get_ptr() noexcept { return &val; }
   const T *get_ptr() const noexcept { return &val; }
+
+public:
+  template <access::decorated IsDecorated>
+  multi_ptr<T, access::address_space::global_space, IsDecorated>
+  get_multi_ptr() noexcept {
+    __SYCL_HOST_NOT_SUPPORTED("get_multi_ptr()")
+    return address_space_cast<access::address_space::global_space, IsDecorated,
+                              T>(this->get_ptr());
+  }
+
+  template <access::decorated IsDecorated>
+  multi_ptr<const T, access::address_space::global_space, IsDecorated>
+  get_multi_ptr() const noexcept {
+    __SYCL_HOST_NOT_SUPPORTED("get_multi_ptr()")
+    return address_space_cast<access::address_space::global_space, IsDecorated,
+                              const T>(this->get_ptr());
+  }
 };
 } // namespace detail
 
@@ -112,22 +148,6 @@ public:
   device_global(const device_global &&) = delete;
   device_global &operator=(const device_global &) = delete;
   device_global &operator=(const device_global &&) = delete;
-
-  template <access::decorated IsDecorated>
-  multi_ptr<T, access::address_space::global_space, IsDecorated>
-  get_multi_ptr() noexcept {
-    __SYCL_HOST_NOT_SUPPORTED("get_multi_ptr()")
-    return address_space_cast<access::address_space::global_space, IsDecorated>(
-        this->get_ptr());
-  }
-
-  template <access::decorated IsDecorated>
-  multi_ptr<const T, access::address_space::global_space, IsDecorated>
-  get_multi_ptr() const noexcept {
-    __SYCL_HOST_NOT_SUPPORTED("get_multi_ptr()")
-    return address_space_cast<access::address_space::global_space, IsDecorated,
-                              const T>(this->get_ptr());
-  }
 
   T &get() noexcept {
     __SYCL_HOST_NOT_SUPPORTED("get()")


### PR DESCRIPTION
device_global without device_image_scope currently use an undecorated pointer for its underlying type, but we know that the pointer will be to the global memory space. This commit changes the underlying member for device_global with device_image_scope to be a decorated pointer and changes the get_multi_ptr member function to create the multi_ptr directly from the decorated pointer instead of performing unnecessary address space casts.