### PR TITLE
[SYCL] Win: do not cleanup scheduler resources due to unpredictable s…

### DIFF
--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -443,6 +443,7 @@ Scheduler::~Scheduler() {
 }
 
 void Scheduler::releaseResources() {
+#ifndef _WIN32
   if (DefaultHostQueue) {
     DefaultHostQueue->wait();
   }
@@ -462,6 +463,7 @@ void Scheduler::releaseResources() {
   // added to deferred mem obj storage. So we may end up with leak.
   while (!isDeferredMemObjectsEmpty())
     cleanupDeferredMemObjects(BlockingT::BLOCKING);
+#endif
 }
 
 MemObjRecord *Scheduler::getMemObjRecord(const Requirement *const Req) {


### PR DESCRIPTION
Windows specific.
Do not try to release any resources during program exit. It may cause unpredictable results.
The main root cause is threads. Per my observations and according to windows ExitProcess docs threads are killed before libraries unload. So at the time when we call shutdown - thread pool threads and any other user threads will already be killed. What it means to us: we could not know exactly the state of jobs and objects they was working with. For example graph mutex could be locked by thread executing by host task, or container state could be undefined if killed thread was working with it, or additional user thread could call sycl API and some resources of sycl dependencies could be also affected. 

Signed-off-by: Tikhomirova, Kseniya <kseniya.tikhomirova@intel.com>