### PR TITLE
[SYCL] sycl_special_class is avaialble in SYCL device compilation only

### DIFF
--- a/sycl/include/sycl/detail/defines.hpp
+++ b/sycl/include/sycl/detail/defines.hpp
@@ -21,7 +21,7 @@
 #endif
 #endif
 
-#if __has_attribute(sycl_special_class) && defined(SYCL_DEVICE_ONLY)
+#if __has_attribute(sycl_special_class) && defined(__SYCL_DEVICE_ONLY__)
 #define __SYCL_SPECIAL_CLASS __attribute__((sycl_special_class))
 #else
 #define __SYCL_SPECIAL_CLASS

--- a/sycl/include/sycl/detail/defines.hpp
+++ b/sycl/include/sycl/detail/defines.hpp
@@ -21,7 +21,7 @@
 #endif
 #endif
 
-#if __has_attribute(sycl_special_class)
+#if __has_attribute(sycl_special_class) && defined(SYCL_DEVICE_ONLY)
 #define __SYCL_SPECIAL_CLASS __attribute__((sycl_special_class))
 #else
 #define __SYCL_SPECIAL_CLASS


### PR DESCRIPTION
Fixes unrecognized attribute warning when code is compiled in C++ mode. Discovered at #7672.