### PR TITLE
[SYCL][Docs] Move sycl_ext_oneapi_memcpy2d to supported

### DIFF
--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_memcpy2d.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_memcpy2d.asciidoc
@@ -39,11 +39,7 @@ SYCL specification refer to that revision.
 
 == Status
 
-This is a proposed extension specification, intended to gather community
-feedback.  Interfaces defined in this specification may not be implemented yet
-or may be in a preliminary state.  The specification itself may also change in
-incompatible ways before it is finalized.  *Shipping software products should
-not rely on APIs defined in this specification.*
+This extension is implemented and fully supported by {dpcpp}.
 
 == Specification
 


### PR DESCRIPTION
https://github.com/intel/llvm/pull/7370 implemented the proposed sycl_ext_oneapi_memcpy2d extension. With that PR merged we can now move the extension specification to supported.