### PR TITLE
[SYCL][Docs] Reintroduce device_ptr and host_ptr under namespace

### DIFF
--- a/sycl/doc/extensions/supported/sycl_ext_intel_usm_address_spaces.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_intel_usm_address_spaces.asciidoc
@@ -154,8 +154,9 @@ This constructor may only be called from within a command.
 
 === Explicit Pointer Aliases
 
-Add `device_ptr` and `host_ptr` aliases to the list of `multi_ptr` aliases as
-follows:
+Add `device_ptr`, `host_ptr`, `raw_device_ptr`, `raw_host_ptr`,
+`decorated_device_ptr`, and `decorated_host_ptr` aliases to the list of
+`multi_ptr` aliases as follows:
 ```c++
 namespace sycl {
 
@@ -175,6 +176,18 @@ using host_ptr =
 
 namespace ext {
 namespace intel {
+
+template<typename ElementType,
+         access::decorated IsDecorated = access::decorated::legacy>
+using device_ptr =
+    multi_ptr<ElementType, access::address_space::ext_intel_global_device_space,
+              IsDecorated>
+
+template<typename ElementType,
+         access::decorated IsDecorated = access::decorated::legacy>
+using host_ptr =
+    multi_ptr<ElementType, access::address_space::ext_intel_global_host_space,
+              IsDecorated>
 
 template<typename ElementType>
 using raw_device_ptr =


### PR DESCRIPTION
https://github.com/intel/llvm/pull/7680 deprecated device_ptr and host_ptr under the sycl namespace and intended to add them under the sycl::ext::intel namespace instead, but did not. This commit adds them to the namespace as originally intended. They are already implemented in the extension headers.