### PR TITLE
[SYCL] Add check-sycl-dumps target for dumps-only testing

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -298,8 +298,12 @@ add_custom_target(sycl-compiler
           opencl-aot
 )
 
-add_custom_target( sycl-toolchain
+add_custom_target( sycl-runtime-libraries
   DEPENDS ${SYCL_RT_LIBS}
+)
+
+add_custom_target( sycl-toolchain
+  DEPENDS sycl-runtime-libraries
           sycl-compiler
           sycl-ls
           ${XPTIFW_LIBS}

--- a/sycl/cmake/modules/AddSYCL.cmake
+++ b/sycl/cmake/modules/AddSYCL.cmake
@@ -1,6 +1,6 @@
 function(add_sycl_library LIB_NAME TYPE)
   cmake_parse_arguments("ARG"
-    "TOOLCHAIN"
+    ""
     "LINKER_SCRIPT"
     "SOURCES;INCLUDE_DIRS;LIBRARIES"
     ${ARGN}
@@ -9,9 +9,7 @@ function(add_sycl_library LIB_NAME TYPE)
   target_include_directories(${LIB_NAME} PRIVATE ${ARG_INCLUDE_DIRS})
   target_link_libraries(${LIB_NAME} PRIVATE ${ARG_LIBRARIES})
 
-  if (ARG_TOOLCHAIN)
-    add_dependencies(sycl-runtime-libraries ${LIB_NAME})
-  endif()
+  add_dependencies(sycl-runtime-libraries ${LIB_NAME})
 
   if (ARG_LINKER_SCRIPT AND UNIX AND NOT APPLE)
     target_link_libraries(${LIB_NAME} PRIVATE
@@ -39,7 +37,6 @@ function(add_sycl_plugin PLUGIN_NAME)
   )
 
   add_sycl_library("pi_${PLUGIN_NAME}" SHARED
-    TOOLCHAIN
     LINKER_SCRIPT "${PROJECT_SOURCE_DIR}/plugins/ld-version-script.txt"
     SOURCES ${ARG_SOURCES}
     INCLUDE_DIRS

--- a/sycl/cmake/modules/AddSYCL.cmake
+++ b/sycl/cmake/modules/AddSYCL.cmake
@@ -10,7 +10,7 @@ function(add_sycl_library LIB_NAME TYPE)
   target_link_libraries(${LIB_NAME} PRIVATE ${ARG_LIBRARIES})
 
   if (ARG_TOOLCHAIN)
-    add_dependencies(sycl-toolchain ${LIB_NAME})
+    add_dependencies(sycl-runtime-libraries ${LIB_NAME})
   endif()
 
   if (ARG_LINKER_SCRIPT AND UNIX AND NOT APPLE)

--- a/sycl/test/CMakeLists.txt
+++ b/sycl/test/CMakeLists.txt
@@ -66,6 +66,14 @@ add_lit_testsuite(check-sycl-spirv "Running device-agnostic SYCL regression test
   ${SYCL_TEST_EXCLUDE}
   )
 
+add_lit_testsuite(check-sycl-dumps "Running ABI dump tests only"
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ARGS ${RT_TEST_ARGS}
+  PARAMS "SYCL_LIB_DUMPS_ONLY=True"
+  DEPENDS sycl-runtime-libraries llvm-readobj
+  EXCLUDE_FROM_CHECK_ALL
+  )
+
 add_custom_target(check-sycl)
 add_dependencies(check-sycl check-sycl-spirv)
 set_target_properties(check-sycl PROPERTIES FOLDER "SYCL tests")

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -24,7 +24,11 @@ config.name = 'SYCL'
 config.test_format = lit.formats.ShTest()
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = ['.c', '.cpp', '.dump', '.test'] #add .spv. Currently not clear what to do with those
+dump_only_tests = bool(lit_config.params.get('SYCL_LIB_DUMPS_ONLY', False))
+if dump_only_tests:
+    config.suffixes = ['.dump'] # Only run dump testing
+else:
+    config.suffixes = ['.c', '.cpp', '.dump', '.test'] #add .spv. Currently not clear what to do with those
 
 # feature tests are considered not so lightweight, so, they are excluded by default
 config.excludes = ['Inputs', 'feature-tests']
@@ -118,7 +122,9 @@ if triple == 'amdgcn-amd-amdhsa':
         additional_flags += ['-Xsycl-target-backend=amdgcn-amd-amdhsa',
                             '--offload-arch=gfx906']
 
-llvm_config.use_clang(additional_flags=additional_flags)
+# Dump-only tests do not have clang available
+if not dump_only_tests:
+    llvm_config.use_clang(additional_flags=additional_flags)
 
 # Set timeout for test = 10 mins
 try:


### PR DESCRIPTION
This commit adds a new check-sycl-dumps target. This intends to only run SYCL runtime library related dump tests and will therefore only build llvm-readobj, the SYCL libraries (including the enabled plugins), and any dependencies required by LIT. Purpose of this is to allow for faster ABI dump checks on multiple systems.