### PR TITLE
Initial version of cluster properties extension.

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_intel_cluster_properties.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_intel_cluster_properties.asciidoc
@@ -1,0 +1,101 @@
+= sycl_ext_intel_cluster_properties
+
+== Introduction
+
+On FPGA targets, regions of the circuit called clusters may be statically scheduled.
+This extension introduces two kernel properties that specify how statically-scheduled clusters should be implemented for an FPGA target.
+
+== Notice
+
+Copyright (c) 2022 Intel Corporation.  All rights reserved.
+
+== Status
+
+Working Draft
+
+This is a proposed extension specification, intended to gather community
+feedback. Interfaces defined in this specification may not be implemented yet
+or may be in a preliminary state. The specification itself may also change in
+incompatible ways before it is finalized. Shipping software products should not
+rely on APIs defined in this specification.
+
+== Version
+
+Last Modified Date: 2022-12-19 +
+Revision: 1
+
+== Contributors
+
+Jessica Davies, Intel +
+
+== Dependencies
+
+This extension is written against the SYCL 2020 specification, Revision 6 and
+the following extension:
+
+- link:sycl_ext_oneapi_kernel_properties.asciidoc[sycl_ext_oneapi_kernel_properties]
+
+== Feature Test Macro
+
+This extension provides a feature-test macro as described in the core SYCL
+specification section 6.3.3 "Feature test macros".  Therefore, an
+implementation supporting this extension must predefine the macro
+`SYCL_EXT_INTEL_CLUSTER_PROPERTIES` to one of the values defined in the table
+below.  Applications can test for the existence of this macro to determine if
+the implementation supports this feature, or applications can test the macro's
+value to determine which of the extension's APIs the implementation supports.
+
+[%header,cols="1,5"]
+|===
+|Value |Description
+|1     |Initial extension version.  Base features are supported.
+|===
+
+== Cluster Properties
+```c++
+namespace sycl {
+namespace ext {
+namespace intel {
+namespace experimental {
+
+struct stall_free_clusters_key {
+  using value_t = property_value<stall_free_clusters_key>;
+};
+
+struct stall_enable_clusters_key {
+  using value_t = property_value<stall_enable_clusters_key>;
+};
+
+inline constexpr stall_free_clusters_key::value_t stall_free_clusters;
+inline constexpr stall_enable_clusters_key::value_t stall_enable_clusters;
+
+template <> struct is_property_key<stall_free_clusters_key> : std::true_type {};
+template <> struct is_property_key<stall_enable_clusters_key> : std::true_type {};
+
+} // namespace experimental
+} // namespace intel
+} // namespace ext
+} // namespace sycl
+```
+
+|===
+|Property|Description
+
+|`stall_free_clusters`
+|Implement statically-scheduled clusters using an exit FIFO to hold output data from the cluster when the cluster is stalled.
+This property applies to kernels. If the kernel also has the stall_enable_clusters property a diagnostic error will be produced.
+|`stall_enable_clusters`
+|Implement statically-scheduled clusters using an enable signal to freeze the cluster when the cluster is stalled.
+This property applies to kernels. If the kernel also has the stall_free_clusters property a diagnostic error will be produced.
+|===
+
+== Revision History
+
+[cols="5,15,15,70"]
+[grid="rows"]
+[options="header"]
+|========================================
+|Rev|Date|Author|Changes
+|1|2022-12-19|Jessica Davies|*Initial public working draft*
+|========================================
+


### PR DESCRIPTION
This extension introduces two new kernel properties that specify how statically-scheduled clusters should be implemented on an FPGA target.