### PR TITLE
[SYCL] Fix Windows post commit failures

### DIFF
--- a/clang/test/Driver/sycl-no-rdc-fat-archive-win.cpp
+++ b/clang/test/Driver/sycl-no-rdc-fat-archive-win.cpp
@@ -5,14 +5,14 @@
 // RUN: echo "void foo(void) {}" > %t1.cpp
 // RUN: %clangxx -target x86_64-pc-windows-msvc -fsycl %t1.cpp -c -o %t1_bundle.o
 // RUN: llvm-ar cr %t_lib.a %t1_bundle.o
-// RUN: %clang -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=off --sysroot=%S/Inputs/SYCL %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
-// RUN: %clang -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=auto --sysroot=%S/Inputs/SYCL %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
-// RUN: %clang -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=per_kernel --sysroot=%S/Inputs/SYCL %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
-// RUN: %clang -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=per_source --sysroot=%S/Inputs/SYCL %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
-// RUN: %clang_cl -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=off --sysroot=%S/Inputs/SYCL %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
-// RUN: %clang_cl -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=auto --sysroot=%S/Inputs/SYCL %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
-// RUN: %clang_cl -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=per_kernel --sysroot=%S/Inputs/SYCL %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
-// RUN: %clang_cl -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=per_source --sysroot=%S/Inputs/SYCL %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
+// RUN: %clang -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=off --sysroot=%S/Inputs/SYCL-windows %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
+// RUN: %clang -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=auto --sysroot=%S/Inputs/SYCL-windows %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
+// RUN: %clang -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=per_kernel --sysroot=%S/Inputs/SYCL-windows %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
+// RUN: %clang -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=per_source --sysroot=%S/Inputs/SYCL-windows %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
+// RUN: %clang_cl -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=off /clang:--sysroot=%S/Inputs/SYCL-windows %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
+// RUN: %clang_cl -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=auto /clang:--sysroot=%S/Inputs/SYCL-windows %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
+// RUN: %clang_cl -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=per_kernel /clang:--sysroot=%S/Inputs/SYCL-windows %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
+// RUN: %clang_cl -### -fsycl -fno-sycl-rdc -fsycl-device-code-split=per_source /clang:--sysroot=%S/Inputs/SYCL-windows %t_lib.a 2>&1 -ccc-print-phases | FileCheck %s
 // CHECK: 2: input, "{{.*}}_lib.a", archive
 // CHECK: 3: clang-offload-unbundler, {2}, tempfilelist
 // CHECK: 4: spirv-to-ir-wrapper, {3}, tempfilelist, (device-sycl)

--- a/clang/test/Driver/sycl-no-rdc-win.cpp
+++ b/clang/test/Driver/sycl-no-rdc-win.cpp
@@ -3,8 +3,8 @@
 
 // RUN: touch %t1.cpp
 // RUN: touch %t2.cpp
-// RUN: %clang -### -fsycl -fno-sycl-rdc --sysroot=%S/Inputs/SYCL %t1.cpp %t2.cpp 2>&1 -ccc-print-phases | FileCheck %s
-// RUN: %clang_cl -### -fsycl -fno-sycl-rdc --sysroot=%S/Inputs/SYCL %t1.cpp %t2.cpp 2>&1 -ccc-print-phases | FileCheck %s
+// RUN: %clang -### -fsycl -fno-sycl-rdc --sysroot=%S/Inputs/SYCL-windows %t1.cpp %t2.cpp 2>&1 -ccc-print-phases | FileCheck %s
+// RUN: %clang_cl -### -fsycl -fno-sycl-rdc /clang:--sysroot=%S/Inputs/SYCL-windows  %t1.cpp %t2.cpp 2>&1 -ccc-print-phases | FileCheck %s
 
 // CHECK: 3: input, "{{.*}}1.cpp", c++, (device-sycl)
 // CHECK: 4: preprocessor, {3}, c++-cpp-output, (device-sycl)


### PR DESCRIPTION
Main issue was for the clang-cl call I wasn't using `/clang:` so the `--sysroot` was getting ignored, causing the failure.
Also we should probably be using the SYCL windows libraries for these windows tests, so I fixed that.

Signed-off-by: Sarnie, Nick <nick.sarnie@intel.com>