### PR TITLE
[SYCL] fix for flaky race in StreamBufferDeallocation unit test. 

### DIFF
--- a/sycl/unittests/scheduler/GraphCleanup.cpp
+++ b/sycl/unittests/scheduler/GraphCleanup.cpp
@@ -344,8 +344,6 @@ TEST_F(SchedulerTest, StreamBufferDeallocation) {
     EventImplPtr = MSPtr->addCG(std::move(CG), QueueImplPtr);
   }
 
-  // Both buffers should have been sent to the deferred release.
-  ASSERT_EQ(MSPtr->MDeferredMemObjRelease.size(), 2u);
   // The buffers should have been released with graph cleanup once the work is
   // finished.
   EventImplPtr->wait(EventImplPtr);


### PR DESCRIPTION
The Scheduler/GraphCleanup::StreamBufferDeallocation test attempts to 'precheck' that the node count is 2 before the cleanup completes (when it is once again tested and confirmed to be 0).  But this 'precheck' is racing on Windows. While it is OK about 85% of the time, in the other 15% of runs the clean-up has already begun and there is just one node, or none. This fix simply removes the 'precheck' as it is not central to the test.

Signed-off-by: Perkins, Chris <chris.perkins@intel.com>