### PR TITLE
[SYCL] Include sycl/builtins.hpp in imf header

### DIFF
--- a/sycl/include/sycl/ext/intel/math.hpp
+++ b/sycl/include/sycl/ext/intel/math.hpp
@@ -9,6 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
+#include <sycl/builtins.hpp>
 #include <sycl/ext/intel/math/imf_half_trivial.hpp>
 #include <sycl/half_type.hpp>
 #include <type_traits>


### PR DESCRIPTION
sycl math functions are used in util functions in intel math headers to provide equivalent functionalities as CUDA math. We missed including sycl/builtins.hpp previously, so users must include sycl/sycl.hpp before including sycl intel math headers, this pr fixes this issue.