### PR TITLE
[SYCL][ESIMD] Force std::tuple to be passed by value with __regcall CC

### DIFF
--- a/clang/test/CodeGenSYCL/regcall-cc-tuple-test.cpp
+++ b/clang/test/CodeGenSYCL/regcall-cc-tuple-test.cpp
@@ -1,0 +1,32 @@
+// RUN:  %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -disable-llvm-passes -O0 -opaque-pointers -emit-llvm %s -o - | FileCheck %s
+//
+// Check that we use vector ABI in the arguments and return type for a __regcall esimd function with std::tuple
+template <class T, int N> using raw_vector = T[N];
+
+template <class T, int N>
+struct simd {
+  raw_vector<T, N> val;
+};
+
+using T1 = simd<double, 5>;
+using T2 = simd<int, 20>;
+
+namespace std {
+template< class... Types >
+class tuple {
+  // Hardcode this as to not actually implement std::tuple
+  T1 one;
+  T2 two;
+};
+}
+using MyTuple = std::tuple<T1, T2>;
+// CHECK: define dso_local x86_regcallcc <30 x i32> @_Z16__regcall3__funcSt5tupleIJ4simdIdLi5EES0_IiLi20EEEE(<30 x i32> 
+__attribute__((sycl_device))
+__regcall MyTuple func(MyTuple a) __attribute__((sycl_explicit_simd)) {
+   return a;
+}
+
+__attribute__((sycl_device)) int caller() {
+  MyTuple val;
+  func(val);
+}


### PR DESCRIPTION
For std::tuple arguments/return in a regcall function, use vector ABI with bytes calculated based on the tuple element types.

This PR is me finalizing a PR from Konst which was a draft here: https://github.com/intel/llvm/pull/7836

Konst mentioned he discussed this solution with @erichkeane and they determined this was the best approach.

There is one lit test here, and multiple system tests in an associated llvm-test-suite commit.

Signed-off-by: Sarnie, Nick <nick.sarnie@intel.com>