### PR TITLE
Fix a static analyzer issue

### DIFF
--- a/llvm/tools/opt/NewPMDriver.cpp
+++ b/llvm/tools/opt/NewPMDriver.cpp
@@ -368,7 +368,8 @@ bool llvm::runPassPipeline(StringRef Arg0, Module &M, TargetMachine *TM,
     } else /* CSPGOKindFlag == CSInstrUse */ {
       if (!P)
         errs() << "CSInstrUse needs to be together with InstrUse";
-      P->CSAction = PGOOptions::CSIRUse;
+      else
+        P->CSAction = PGOOptions::CSIRUse;
     }
   }
   if (TM)


### PR DESCRIPTION
Static analyzer reported that Null pointer 'P' may be dereferenced at line 394. This change guards this use.
Signed-off-by: Arvind Sudarsanam <arvind.sudarsanam@intel.com>