### PR TITLE
[SYCL] Return level_zero loader and header back to install

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -362,8 +362,6 @@ set( SYCL_TOOLCHAIN_DEPLOY_COMPONENTS
      clang-offload-deps
      clang-offload-extract
      file-table-tform
-     level-zero-loader
-     level-zero-headers
      llc
      llvm-ar
      llvm-foreach
@@ -381,6 +379,7 @@ set( SYCL_TOOLCHAIN_DEPLOY_COMPONENTS
      sycl-headers-extras
      sycl
      libsycldevice
+     level-zero-sycl-dev
      ${XPTIFW_LIBS}
      ${SYCL_TOOLCHAIN_DEPS}
 )

--- a/sycl/plugins/level_zero/CMakeLists.txt
+++ b/sycl/plugins/level_zero/CMakeLists.txt
@@ -105,6 +105,25 @@ add_sycl_plugin(level_zero
     ${XPTI_LIBS}
 )
 
+#FIXME: We should stop shipping level zero loader and headers as part of the
+#       toolchain installation. Instead these should be avaialble in the system.
+#       We keep shipping it until all environments are updated.
+install(TARGETS ze_loader
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        COMPONENT level-zero-sycl-dev
+        NAMELINK_SKIP
+)
+
+file(GLOB LEVEL_ZERO_API_HEADERS "${LEVEL_ZERO_INCLUDE_DIR}/*.h")
+install(FILES ${LEVEL_ZERO_API_HEADERS}
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/include/sycl/level_zero/
+    COMPONENT level-zero-sycl-dev
+)
+# end of FIXME
+
 add_dependencies(pi_level_zero ze-api)
 
 if (SYCL_ENABLE_XPTI_TRACING)


### PR DESCRIPTION
We need to update at least 2 environements before we can remove that:
* Jenkins testing on llvm-test-suite
* Windows testing on llvm-test-suite. See related #7477 that currently fails.