### PR TITLE
[SYCL][NFC] Use unique (or no at all) output files in LIT tests

### DIFF
--- a/sycl/test/abi/layout_accessors_host.cpp
+++ b/sycl/test/abi/layout_accessors_host.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s | FileCheck %s
+// RUN: %clangxx -fsycl -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s -o %t.out | FileCheck %s
 // REQUIRES: linux
 // UNSUPPORTED: libcxx
 

--- a/sycl/test/abi/layout_array.cpp
+++ b/sycl/test/abi/layout_array.cpp
@@ -1,5 +1,5 @@
-// RUN: %clangxx -fsycl -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s | FileCheck %s
-// RUN: %clangxx -fsycl -fsycl-device-only -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s | FileCheck %s
+// RUN: %clangxx -fsycl -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s -o %t.out | FileCheck %s
+// RUN: %clangxx -fsycl -fsycl-device-only -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s -o %t.out | FileCheck %s
 // REQUIRES: linux
 // UNSUPPORTED: libcxx
 

--- a/sycl/test/abi/layout_buffer.cpp
+++ b/sycl/test/abi/layout_buffer.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s | FileCheck %s
+// RUN: %clangxx -fsycl -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s -o %t.out | FileCheck %s
 // REQUIRES: linux
 // UNSUPPORTED: libcxx
 

--- a/sycl/test/abi/layout_handler.cpp
+++ b/sycl/test/abi/layout_handler.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s | FileCheck %s
+// RUN: %clangxx -fsycl -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s -o %t.out | FileCheck %s
 // REQUIRES: linux
 // UNSUPPORTED: libcxx
 

--- a/sycl/test/abi/layout_image.cpp
+++ b/sycl/test/abi/layout_image.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s | FileCheck %s
+// RUN: %clangxx -fsycl -fsyntax-only -fno-color-diagnostics -Xclang -fdump-record-layouts %s | FileCheck %s
 // REQUIRES: linux
 // UNSUPPORTED: libcxx
 

--- a/sycl/test/abi/layout_vec.cpp
+++ b/sycl/test/abi/layout_vec.cpp
@@ -1,5 +1,5 @@
-// RUN: %clangxx -fsycl -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s | FileCheck %s
-// RUN: %clangxx -fsycl -fsycl-device-only -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s | FileCheck %s
+// RUN: %clangxx -fsycl -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s -o %t.out | FileCheck %s
+// RUN: %clangxx -fsycl -fsycl-device-only -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s -o %t.out | FileCheck %s
 // REQUIRES: linux
 // UNSUPPORTED: libcxx
 

--- a/sycl/test/abi/vtable.cpp
+++ b/sycl/test/abi/vtable.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -c -fno-color-diagnostics -Xclang -fdump-vtable-layouts %s | FileCheck %s
+// RUN: %clangxx -fsycl -c -fno-color-diagnostics -Xclang -fdump-vtable-layouts %s -o %t.out | FileCheck %s
 // REQUIRES: linux
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/basic_tests/accessor/iterator-member-types.cpp
+++ b/sycl/test/basic_tests/accessor/iterator-member-types.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -c %s
+// RUN: %clangxx -fsycl -fsyntax-only %s
 //
 // Purpose of this test is to check that [accessor|host_accessor]::iterator and
 // ::const_iterator are aliased to the correct type.

--- a/sycl/test/basic_tests/boost_mp11_import_sanity_check.cpp
+++ b/sycl/test/basic_tests/boost_mp11_import_sanity_check.cpp
@@ -16,7 +16,7 @@
 // http://www.boost.org/LICENSE_1_0.txt
 //===----------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -c %s
+// RUN: %clangxx -fsycl -fsyntax-only -fsycl-targets=%sycl_triple %s
 
 // This is a sanity check test to verify that the automatic boost/mp11 import
 // into SYCL is not badly broken.

--- a/sycl/test/basic_tests/interop-backend-traits.cpp
+++ b/sycl/test/basic_tests/interop-backend-traits.cpp
@@ -1,8 +1,8 @@
-// RUN: %clangxx -fsycl -DUSE_OPENCL %s
-// RUN: %clangxx %fsycl-host-only -DUSE_L0 %s
-// RUN: %clangxx -fsycl -DUSE_CUDA %s
-// RUN: %clangxx -fsycl -DUSE_HIP %s
-// RUN: %clangxx -fsycl -DUSE_CUDA_EXPERIMENTAL %s
+// RUN: %clangxx -fsycl -fsyntax-only -DUSE_OPENCL %s
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -DUSE_L0 %s
+// RUN: %clangxx -fsycl -fsyntax-only -DUSE_CUDA %s
+// RUN: %clangxx -fsycl -fsyntax-only -DUSE_HIP %s
+// RUN: %clangxx -fsycl -fsyntax-only -DUSE_CUDA_EXPERIMENTAL %s
 
 #ifdef USE_OPENCL
 #include <CL/cl.h>

--- a/sycl/test/basic_tests/iostream_clean_compile_1.cpp
+++ b/sycl/test/basic_tests/iostream_clean_compile_1.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -Wno-unused-command-line-argument -Werror -fsycl %s -c
+// RUN: %clangxx -Wno-unused-command-line-argument -Werror -fsycl -fsyntax-only %s
 
 #include <iostream>
 #include <sycl/sycl.hpp>

--- a/sycl/test/basic_tests/iostream_clean_compile_2.cpp
+++ b/sycl/test/basic_tests/iostream_clean_compile_2.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -Wno-unused-command-line-argument -Werror -fsycl %s -c
+// RUN: %clangxx -Wno-unused-command-line-argument -Werror -fsycl -fsyntax-only %s
 
 // clang-format off
 #include <sycl/sycl.hpp>

--- a/sycl/test/basic_tests/relational_builtins.cpp
+++ b/sycl/test/basic_tests/relational_builtins.cpp
@@ -1,5 +1,5 @@
-// RUN: %clangxx -DSYCL2020_CONFORMANT_APIS -fsycl  %s
-// RUN: %clangxx -sycl-std=121 -fsycl %s
+// RUN: %clangxx -DSYCL2020_CONFORMANT_APIS -fsycl -fsyntax-only %s
+// RUN: %clangxx -sycl-std=121 -fsycl -fsyntax-only %s
 
 #include <CL/sycl.hpp>
 

--- a/sycl/test/basic_tests/span.cpp
+++ b/sycl/test/basic_tests/span.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -c %s
+// RUN: %clangxx -fsycl -fsyntax-only %s
 
 //==--------------- span.cpp - SYCL span test ------------------------------==//
 //

--- a/sycl/test/gdb/accessors.cpp
+++ b/sycl/test/gdb/accessors.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -c -fno-color-diagnostics -std=c++17 -I %sycl_include/sycl -I %sycl_include -Xclang -ast-dump %s | FileCheck %s
+// RUN: %clangxx -fsyntax-only -fno-color-diagnostics -std=c++17 -I %sycl_include/sycl -I %sycl_include -Xclang -ast-dump %s | FileCheck %s
 // RUN: %clangxx -c -fno-color-diagnostics -std=c++17 -I %sycl_include/sycl -I %sycl_include -Xclang -emit-llvm -g %s -o - | FileCheck %s --check-prefixes CHECK-DEBUG-INFO
 // UNSUPPORTED: windows
 #include <sycl/sycl.hpp>

--- a/sycl/test/gdb/printers.cpp
+++ b/sycl/test/gdb/printers.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -c -fno-color-diagnostics -std=c++17 -I %sycl_include/sycl -I %sycl_include -Xclang -ast-dump %s | FileCheck %s
+// RUN: %clangxx -fsyntax-only -fno-color-diagnostics -std=c++17 -I %sycl_include/sycl -I %sycl_include -Xclang -ast-dump %s | FileCheck %s
 // UNSUPPORTED: windows
 #include <sycl/buffer.hpp>
 #include <sycl/detail/array.hpp>

--- a/sycl/test/gdb/private-memory.cpp
+++ b/sycl/test/gdb/private-memory.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -c -fsycl -fno-color-diagnostics -Xclang -ast-dump %s | FileCheck %s
+// RUN: %clangxx -fsyntax-only -fsycl -fno-color-diagnostics -Xclang -ast-dump %s | FileCheck %s
 // UNSUPPORTED: windows
 #include <sycl/group.hpp>
 #include <sycl/id.hpp>

--- a/sycl/test/invoke_simd/invoke_simd.cpp
+++ b/sycl/test/invoke_simd/invoke_simd.cpp
@@ -1,4 +1,6 @@
-// RUN: %clangxx -c -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %s
+// RUN: %clangxx -fsycl -fsyntax-only -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %s
+// FIXME: check if -fno-sycl-device-code-split-esimd affects any pre-link steps
+//        and remove the flag if that is not the case
 
 // The tests checks that invoke_simd API is compileable.
 

--- a/sycl/test/regression/print_args.cpp
+++ b/sycl/test/regression/print_args.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl %s -c
+// RUN: %clangxx -fsycl -fsyntax-only %s
 
 // Regression tests for https://github.com/intel/llvm/issues/1011
 // Checks that SYCL headers call internal templated function 'printArgs'


### PR DESCRIPTION
This fixes sporadic issue with `check-sycl` on Windows. Apparently we had a number of tests, which didn't specify `-o %t.out` and it caused some tests to write to the same default `a.exe` and fail with error like:
```
LINK : fatal error LNK1104: cannot open file 'a.exe'
```

To resolve this, switch most of such tests to use `-fsyntax-only` or explicitly added `-o %t.out` to prevent possible races.

"bad" tests were discovered using `grep -rnP 'clangxx(?!.*\-o)' sycl/test/`