### PR TITLE
[SYCL][NFC] Add missing unordered_map include

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMDSlmReservation.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMDSlmReservation.cpp
@@ -68,6 +68,8 @@
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Module.h"
 
+#include <unordered_map>
+
 #define DEBUG_TYPE "LowerESIMDSlmAllocPass"
 
 namespace llvm {


### PR DESCRIPTION
This fixes build on MacOS.