### PR TITLE
[SYCL][HIP] Support the SYCL_PI_HIP_MAX_LOCAL_MEM_SIZE environment variable

### DIFF
--- a/sycl/doc/EnvironmentVariables.md
+++ b/sycl/doc/EnvironmentVariables.md
@@ -163,6 +163,12 @@ Note that conflicting configuration tuples in the same list will favor the last 
 | -------------------- | ------ | ----------- |
 | `SYCL_PI_CUDA_MAX_LOCAL_MEM_SIZE` | Integer | Specifies the maximum size of a local memory allocation in bytes. If the value exceeds the device's capabilities then a `sycl::runtime_error` is thrown. In order for the full error message to be printed, `SYCL_RT_WARNING_LEVEL=2` must be set. The default value for `SYCL_PI_CUDA_MAX_LOCAL_MEM_SIZE` is determined by the hardware. |
 
+## Controlling DPC++ HIP Plugin
+
+| Environment variable | Values | Description |
+| -------------------- | ------ | ----------- |
+| `SYCL_PI_HIP_MAX_LOCAL_MEM_SIZE` | Integer | Specifies the maximum size of a local memory allocation in bytes. If the value exceeds the device's capabilities then a `sycl::runtime_error` is thrown. In order for the full error message to be printed, `SYCL_RT_WARNING_LEVEL=2` must be set. The default value for `SYCL_PI_HIP_MAX_LOCAL_MEM_SIZE` is determined by the hardware. |
+
 ## Tools variables
 
 | Environment variable | Values | Description |

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -2929,6 +2929,28 @@ pi_result hip_piEnqueueKernelLaunch(
       retImplEv->start();
     }
 
+    // Set local mem max size if env var is present
+    static const char *local_mem_sz_ptr =
+        std::getenv("SYCL_PI_HIP_MAX_LOCAL_MEM_SIZE");
+
+    if (local_mem_sz_ptr) {
+      int device_max_local_mem = 0;
+      hipDeviceGetAttribute(
+          &device_max_local_mem,
+          hipDeviceAttributeMaxSharedMemoryPerBlock,
+          command_queue->get_device()->get());
+
+      static const int env_val = std::atoi(local_mem_sz_ptr);
+      if (env_val <= 0 || env_val > device_max_local_mem) {
+        setErrorMessage("Invalid value specified for "
+                        "SYCL_PI_HIP_MAX_LOCAL_MEM_SIZE",
+                        PI_ERROR_PLUGIN_SPECIFIC_ERROR);
+        return PI_ERROR_PLUGIN_SPECIFIC_ERROR;
+      }
+      PI_CHECK_ERROR(hipFuncSetAttribute(
+          hipFunc, hipFuncAttributeMaxDynamicSharedMemorySize, env_val));
+    }
+
     retError = PI_CHECK_ERROR(hipModuleLaunchKernel(
         hipFunc, blocksPerGrid[0], blocksPerGrid[1], blocksPerGrid[2],
         threadsPerBlock[0], threadsPerBlock[1], threadsPerBlock[2],

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -2935,10 +2935,9 @@ pi_result hip_piEnqueueKernelLaunch(
 
     if (local_mem_sz_ptr) {
       int device_max_local_mem = 0;
-      hipDeviceGetAttribute(
-          &device_max_local_mem,
-          hipDeviceAttributeMaxSharedMemoryPerBlock,
-          command_queue->get_device()->get());
+      hipDeviceGetAttribute(&device_max_local_mem,
+                            hipDeviceAttributeMaxSharedMemoryPerBlock,
+                            command_queue->get_device()->get());
 
       static const int env_val = std::atoi(local_mem_sz_ptr);
       if (env_val <= 0 || env_val > device_max_local_mem) {
@@ -2948,7 +2947,7 @@ pi_result hip_piEnqueueKernelLaunch(
         return PI_ERROR_PLUGIN_SPECIFIC_ERROR;
       }
       PI_CHECK_ERROR(hipFuncSetAttribute(
-          hipFunc, hipFuncAttributeMaxDynamicSharedMemorySize, env_val));
+        hipFunc, hipFuncAttributeMaxDynamicSharedMemorySize, env_val));
     }
 
     retError = PI_CHECK_ERROR(hipModuleLaunchKernel(

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -2947,7 +2947,7 @@ pi_result hip_piEnqueueKernelLaunch(
         return PI_ERROR_PLUGIN_SPECIFIC_ERROR;
       }
       PI_CHECK_ERROR(hipFuncSetAttribute(
-        hipFunc, hipFuncAttributeMaxDynamicSharedMemorySize, env_val));
+          hipFunc, hipFuncAttributeMaxDynamicSharedMemorySize, env_val));
     }
 
     retError = PI_CHECK_ERROR(hipModuleLaunchKernel(

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -2936,8 +2936,7 @@ pi_result hip_piEnqueueKernelLaunch(
     if (local_mem_sz_ptr) {
       int device_max_local_mem = 0;
       retError = PI_CHECK_ERROR(hipDeviceGetAttribute(
-          &device_max_local_mem,
-          hipDeviceAttributeMaxSharedMemoryPerBlock,
+          &device_max_local_mem, hipDeviceAttributeMaxSharedMemoryPerBlock,
           command_queue->get_device()->get()));
 
       static const int env_val = std::atoi(local_mem_sz_ptr);

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -2938,7 +2938,7 @@ pi_result hip_piEnqueueKernelLaunch(
       retError = PI_CHECK_ERROR(hipDeviceGetAttribute(
           &device_max_local_mem,
           hipDeviceAttributeMaxSharedMemoryPerBlock,
-          command_queue->get_device()->get());
+          command_queue->get_device()->get()));
 
       static const int env_val = std::atoi(local_mem_sz_ptr);
       if (env_val <= 0 || env_val > device_max_local_mem) {

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -2935,9 +2935,10 @@ pi_result hip_piEnqueueKernelLaunch(
 
     if (local_mem_sz_ptr) {
       int device_max_local_mem = 0;
-      hipDeviceGetAttribute(&device_max_local_mem,
-                            hipDeviceAttributeMaxSharedMemoryPerBlock,
-                            command_queue->get_device()->get());
+      retError = PI_CHECK_ERROR(hipDeviceGetAttribute(
+          &device_max_local_mem,
+          hipDeviceAttributeMaxSharedMemoryPerBlock,
+          command_queue->get_device()->get());
 
       static const int env_val = std::atoi(local_mem_sz_ptr);
       if (env_val <= 0 || env_val > device_max_local_mem) {
@@ -2946,7 +2947,7 @@ pi_result hip_piEnqueueKernelLaunch(
                         PI_ERROR_PLUGIN_SPECIFIC_ERROR);
         return PI_ERROR_PLUGIN_SPECIFIC_ERROR;
       }
-      PI_CHECK_ERROR(hipFuncSetAttribute(
+      retError = PI_CHECK_ERROR(hipFuncSetAttribute(
           hipFunc, hipFuncAttributeMaxDynamicSharedMemorySize, env_val));
     }
 


### PR DESCRIPTION
This PR tries to support the SYCL_PI_HIP_MAX_LOCAL_MEM_SIZE environment variable with the HIP runtime APIs. Thank you for your review.