### PR TITLE
[SYCL] Implement SYCL 2020 vec aliases

### DIFF
--- a/sycl/include/sycl/aliases.hpp
+++ b/sycl/include/sycl/aliases.hpp
@@ -10,6 +10,7 @@
 
 #include <sycl/detail/cl.h>
 #include <sycl/detail/common.hpp>
+#include <sycl/detail/defines_elementary.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -62,6 +63,22 @@ class half;
   __SYCL_MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES(N)                               \
   __SYCL_MAKE_VECTOR_ALIASES_FOR_SIGNED_AND_UNSIGNED_TYPES(N)
 
+// FIXME: OpenCL vector aliases are not defined by SYCL 2020 spec and should be
+//        removed from here. See intel/llvm#7888
+#define __SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(N)                   \
+  __SYCL_MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES(N)                               \
+  __SYCL_MAKE_VECTOR_ALIAS(char, std::int8_t, N)                               \
+  __SYCL_MAKE_VECTOR_ALIAS(uchar, std::uint8_t, N)                             \
+  __SYCL_MAKE_VECTOR_ALIAS(short, std::int16_t, N)                             \
+  __SYCL_MAKE_VECTOR_ALIAS(ushort, std::uint16_t, N)                           \
+  __SYCL_MAKE_VECTOR_ALIAS(int, std::int32_t, N)                               \
+  __SYCL_MAKE_VECTOR_ALIAS(uint, std::uint32_t, N)                             \
+  __SYCL_MAKE_VECTOR_ALIAS(long, std::int64_t, N)                              \
+  __SYCL_MAKE_VECTOR_ALIAS(ulong, std::uint64_t, N)                            \
+  __SYCL_MAKE_VECTOR_ALIAS(float, float, N)                                    \
+  __SYCL_MAKE_VECTOR_ALIAS(double, double, N)                                  \
+  __SYCL_MAKE_VECTOR_ALIAS(half, half, N)
+
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 using byte __SYCL2020_DEPRECATED("use std::byte instead") = std::uint8_t;
@@ -73,6 +90,9 @@ using ulong = unsigned long;
 using longlong = long long;
 using ulonglong = unsigned long long;
 using half = sycl::detail::half_impl::half;
+
+// FIXME: SYCL 2020 spec says that cl_* aliases should reside in sycl::opencl
+// namespace.
 using cl_bool = bool;
 using cl_char = std::int8_t;
 using cl_uchar = std::uint8_t;
@@ -86,11 +106,20 @@ using cl_half = half;
 using cl_float = float;
 using cl_double = double;
 
+// Vector aliases are different between SYCL 1.2.1 and SYCL 2020
+#if SYCL_LANGUAGE_VERSION >= 202001
+__SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(2)
+__SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(3)
+__SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(4)
+__SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(8)
+__SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(16)
+#else
 __SYCL_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(2)
 __SYCL_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(3)
 __SYCL_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(4)
 __SYCL_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(8)
 __SYCL_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(16)
+#endif
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl
 
@@ -99,3 +128,4 @@ __SYCL_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(16)
 #undef __SYCL_MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES
 #undef __SYCL_MAKE_VECTOR_ALIASES_FOR_SIGNED_AND_UNSIGNED_TYPES
 #undef __SYCL_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH
+#undef __SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH

--- a/sycl/test/basic_tests/aliases.cpp
+++ b/sycl/test/basic_tests/aliases.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %clangxx -fsycl -sycl-std=1.2.1 -fsycl-targets=%sycl_triple -fsyntax-only %s
 //==------------ aliases.cpp - SYCL type aliases test ----------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/basic_tests/vectors/aliases.cpp
+++ b/sycl/test/basic_tests/vectors/aliases.cpp
@@ -18,7 +18,7 @@
   CHECK_ALIAS(uint, std::uint32_t, N)                                          \
   CHECK_ALIAS(long, std::int64_t, N)                                           \
   CHECK_ALIAS(ulong, std::uint64_t, N)                                         \
-  CHECK_ALIAS(half, sycl::half, N)                                       \
+  CHECK_ALIAS(half, sycl::half, N)                                             \
   CHECK_ALIAS(float, float, N)                                                 \
   CHECK_ALIAS(double, double, N)
 

--- a/sycl/test/basic_tests/vectors/aliases.cpp
+++ b/sycl/test/basic_tests/vectors/aliases.cpp
@@ -1,0 +1,34 @@
+// RUN: %clangxx -fsycl -fsyntax-only -fsycl-device-only %s
+
+#include <sycl/sycl.hpp>
+
+#include <cstdint>
+#include <type_traits>
+
+#define CHECK_ALIAS(type, storage_type, elems)                                 \
+  static_assert(                                                               \
+      std::is_same_v<sycl::type##elems, sycl::vec<storage_type, elems>>);
+
+#define CHECK_ALIASES_FOR_VEC_LENGTH(N)                                        \
+  CHECK_ALIAS(char, std::int8_t, N)                                            \
+  CHECK_ALIAS(uchar, std::uint8_t, N)                                          \
+  CHECK_ALIAS(short, std::int16_t, N)                                          \
+  CHECK_ALIAS(ushort, std::uint16_t, N)                                        \
+  CHECK_ALIAS(int, std::int32_t, N)                                            \
+  CHECK_ALIAS(uint, std::uint32_t, N)                                          \
+  CHECK_ALIAS(long, std::int64_t, N)                                           \
+  CHECK_ALIAS(ulong, std::uint64_t, N)                                         \
+  CHECK_ALIAS(sycl::half, sycl::half, N)                                       \
+  CHECK_ALIAS(float, float, N)                                                 \
+  CHECK_ALIAS(double, double, N)
+
+int main() {
+
+  CHECK_ALIASES_FOR_VEC_LENGTH(2)
+  CHECK_ALIASES_FOR_VEC_LENGTH(3)
+  CHECK_ALIASES_FOR_VEC_LENGTH(4)
+  CHECK_ALIASES_FOR_VEC_LENGTH(8)
+  CHECK_ALIASES_FOR_VEC_LENGTH(16)
+
+  return 0;
+}

--- a/sycl/test/basic_tests/vectors/aliases.cpp
+++ b/sycl/test/basic_tests/vectors/aliases.cpp
@@ -18,7 +18,7 @@
   CHECK_ALIAS(uint, std::uint32_t, N)                                          \
   CHECK_ALIAS(long, std::int64_t, N)                                           \
   CHECK_ALIAS(ulong, std::uint64_t, N)                                         \
-  CHECK_ALIAS(sycl::half, sycl::half, N)                                       \
+  CHECK_ALIAS(half, sycl::half, N)                                       \
   CHECK_ALIAS(float, float, N)                                                 \
   CHECK_ALIAS(double, double, N)
 

--- a/sycl/test/type_traits/type_traits.cpp
+++ b/sycl/test/type_traits/type_traits.cpp
@@ -187,7 +187,6 @@ int main() {
   test_nan_types<s::ushort2, s::ushort2>();
   test_nan_types<s::uint2, s::uint2>();
   test_nan_types<s::ulong2, s::ulong2>();
-  test_nan_types<s::ulonglong2, s::ulonglong2>();
 
   test_make_signed_t<int, int>();
   test_make_signed_t<const int, const int>();


### PR DESCRIPTION
This commit added aliases for `sycl::vec` class as described in section 4.14.2.2. Aliases of SYCL 2020 specification, revision 6.

Aliases which use OpenCL type, such as `cl_int2` are still preserved, because they are used internally, see intel/llvm#7888.