### PR TITLE
[SYCL][NFC] Recover community code formatting.

### DIFF
--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -7452,6 +7452,7 @@ NamedDecl *Sema::ActOnVariableDeclarator(
     return nullptr;
   }
 
+
   DeclSpec::SCS SCSpec = D.getDeclSpec().getStorageClassSpec();
   StorageClass SC = StorageClassSpecToVarDeclStorageClass(D.getDeclSpec());
 

--- a/clang/test/Sema/conversion.c
+++ b/clang/test/Sema/conversion.c
@@ -288,7 +288,7 @@ void test13(long double v) {
   takes_int(v); // expected-warning {{implicit conversion turns floating-point number into integer}}
   takes_long(v); // expected-warning {{implicit conversion turns floating-point number into integer}}
   takes_longlong(v); // expected-warning {{implicit conversion turns floating-point number into integer}}
-  takes_float(v);    // expected-warning {{implicit conversion loses floating-point precision}}
+  takes_float(v); // expected-warning {{implicit conversion loses floating-point precision}}
   takes_double(v); // expected-warning {{implicit conversion loses floating-point precision}}
   takes_longdouble(v);
 }
@@ -429,6 +429,7 @@ void test27(ushort16 constants) {
     ushort16 crCbScale = pairedConstants.s4; // expected-warning {{implicit conversion loses integer precision: 'uint32_t' (aka 'unsigned int') to 'ushort16'}}
     ushort16 brBias = pairedConstants.s6; // expected-warning {{implicit conversion loses integer precision: 'uint32_t' (aka 'unsigned int') to 'ushort16'}}
 }
+
 
 float double2float_test1(double a) {
     return a; // expected-warning {{implicit conversion loses floating-point precision: 'double' to 'float'}}


### PR DESCRIPTION
There are a few places where sycl branch diverges from the main llvm community branch for no reason other than code formatting. I'm recovering original formatting to avoid merge conflicts due to this difference.