### PR TITLE
[SYCL] More adjustments for SYCL 2020 vec aliases

### DIFF
--- a/sycl/include/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/sycl/detail/generic_type_traits.hpp
@@ -129,17 +129,6 @@ using is_intn = is_contained<T, gtl::vector_signed_int_list>;
 template <typename T> using is_genint = is_contained<T, gtl::signed_int_list>;
 
 template <typename T>
-using is_ulongn = is_contained<T, gtl::vector_unsigned_long_list>;
-
-template <typename T>
-using is_ugenlong = is_contained<T, gtl::unsigned_long_list>;
-
-template <typename T>
-using is_longn = is_contained<T, gtl::vector_signed_long_list>;
-
-template <typename T> using is_genlong = is_contained<T, gtl::signed_long_list>;
-
-template <typename T>
 using is_ulonglongn = is_contained<T, gtl::vector_unsigned_longlong_list>;
 
 template <typename T>

--- a/sycl/test/basic_tests/generic_type_traits.cpp
+++ b/sycl/test/basic_tests/generic_type_traits.cpp
@@ -99,41 +99,48 @@ int main() {
   is_genint
   */
 
+  // According to SYCL 2020 specification, revision 6 section 4.14.2.2. Aliases:
+  // long{n} alias corresponds to vec<int64_t, n>
+  //
+  // Therefore, generic "type" longn/ulongn may not be the same as long{n},
+  // because 'long' is only guaranteed to be 32 bits long by C++ spec.
+
   // is_ulongn
+  constexpr bool long_is_64_bits = sizeof(long) == 8;
   static_assert(d::is_ulongn<s::uchar>::value == false, "");
   static_assert(d::is_ulongn<s::ulong>::value == false, "");
-  static_assert(d::is_ulongn<s::ulong2>::value == true, "");
-  static_assert(d::is_ulongn<s::ulong3>::value == true, "");
-  static_assert(d::is_ulongn<s::ulong4>::value == true, "");
-  static_assert(d::is_ulongn<s::ulong8>::value == true, "");
-  static_assert(d::is_ulongn<s::ulong16>::value == true, "");
+  static_assert(d::is_ulongn<s::ulong2>::value == long_is_64_bits, "");
+  static_assert(d::is_ulongn<s::ulong3>::value == long_is_64_bits, "");
+  static_assert(d::is_ulongn<s::ulong4>::value == long_is_64_bits, "");
+  static_assert(d::is_ulongn<s::ulong8>::value == long_is_64_bits, "");
+  static_assert(d::is_ulongn<s::ulong16>::value == long_is_64_bits, "");
 
   // is_ugenlong
   static_assert(d::is_ugenlong<s::uchar>::value == false, "");
   static_assert(d::is_ugenlong<s::ulong>::value == true, "");
-  static_assert(d::is_ugenlong<s::ulong2>::value == true, "");
-  static_assert(d::is_ugenlong<s::ulong3>::value == true, "");
-  static_assert(d::is_ugenlong<s::ulong4>::value == true, "");
-  static_assert(d::is_ugenlong<s::ulong8>::value == true, "");
-  static_assert(d::is_ugenlong<s::ulong16>::value == true, "");
+  static_assert(d::is_ugenlong<s::ulong2>::value == long_is_64_bits, "");
+  static_assert(d::is_ugenlong<s::ulong3>::value == long_is_64_bits, "");
+  static_assert(d::is_ugenlong<s::ulong4>::value == long_is_64_bits, "");
+  static_assert(d::is_ugenlong<s::ulong8>::value == long_is_64_bits, "");
+  static_assert(d::is_ugenlong<s::ulong16>::value == long_is_64_bits, "");
 
   // is_longn
   static_assert(d::is_longn<char>::value == false, "");
   static_assert(d::is_longn<long>::value == false, "");
-  static_assert(d::is_longn<s::long2>::value == true, "");
-  static_assert(d::is_longn<s::long3>::value == true, "");
-  static_assert(d::is_longn<s::long4>::value == true, "");
-  static_assert(d::is_longn<s::long8>::value == true, "");
-  static_assert(d::is_longn<s::long16>::value == true, "");
+  static_assert(d::is_longn<s::long2>::value == long_is_64_bits, "");
+  static_assert(d::is_longn<s::long3>::value == long_is_64_bits, "");
+  static_assert(d::is_longn<s::long4>::value == long_is_64_bits, "");
+  static_assert(d::is_longn<s::long8>::value == long_is_64_bits, "");
+  static_assert(d::is_longn<s::long16>::value == long_is_64_bits, "");
 
   // is_genlong
   static_assert(d::is_genlong<char>::value == false, "");
   static_assert(d::is_genlong<long>::value == true, "");
-  static_assert(d::is_genlong<s::long2>::value == true, "");
-  static_assert(d::is_genlong<s::long3>::value == true, "");
-  static_assert(d::is_genlong<s::long4>::value == true, "");
-  static_assert(d::is_genlong<s::long8>::value == true, "");
-  static_assert(d::is_genlong<s::long16>::value == true, "");
+  static_assert(d::is_genlong<s::long2>::value == long_is_64_bits, "");
+  static_assert(d::is_genlong<s::long3>::value == long_is_64_bits, "");
+  static_assert(d::is_genlong<s::long4>::value == long_is_64_bits, "");
+  static_assert(d::is_genlong<s::long8>::value == long_is_64_bits, "");
+  static_assert(d::is_genlong<s::long16>::value == long_is_64_bits, "");
 
   /*
   is_ulonglongn

--- a/sycl/test/basic_tests/generic_type_traits.cpp
+++ b/sycl/test/basic_tests/generic_type_traits.cpp
@@ -99,49 +99,6 @@ int main() {
   is_genint
   */
 
-  // According to SYCL 2020 specification, revision 6 section 4.14.2.2. Aliases:
-  // long{n} alias corresponds to vec<int64_t, n>
-  //
-  // Therefore, generic "type" longn/ulongn may not be the same as long{n},
-  // because 'long' is only guaranteed to be 32 bits long by C++ spec.
-
-  // is_ulongn
-  constexpr bool long_is_64_bits = sizeof(long) == 8;
-  static_assert(d::is_ulongn<s::uchar>::value == false, "");
-  static_assert(d::is_ulongn<s::ulong>::value == false, "");
-  static_assert(d::is_ulongn<s::ulong2>::value == long_is_64_bits, "");
-  static_assert(d::is_ulongn<s::ulong3>::value == long_is_64_bits, "");
-  static_assert(d::is_ulongn<s::ulong4>::value == long_is_64_bits, "");
-  static_assert(d::is_ulongn<s::ulong8>::value == long_is_64_bits, "");
-  static_assert(d::is_ulongn<s::ulong16>::value == long_is_64_bits, "");
-
-  // is_ugenlong
-  static_assert(d::is_ugenlong<s::uchar>::value == false, "");
-  static_assert(d::is_ugenlong<s::ulong>::value == true, "");
-  static_assert(d::is_ugenlong<s::ulong2>::value == long_is_64_bits, "");
-  static_assert(d::is_ugenlong<s::ulong3>::value == long_is_64_bits, "");
-  static_assert(d::is_ugenlong<s::ulong4>::value == long_is_64_bits, "");
-  static_assert(d::is_ugenlong<s::ulong8>::value == long_is_64_bits, "");
-  static_assert(d::is_ugenlong<s::ulong16>::value == long_is_64_bits, "");
-
-  // is_longn
-  static_assert(d::is_longn<char>::value == false, "");
-  static_assert(d::is_longn<long>::value == false, "");
-  static_assert(d::is_longn<s::long2>::value == long_is_64_bits, "");
-  static_assert(d::is_longn<s::long3>::value == long_is_64_bits, "");
-  static_assert(d::is_longn<s::long4>::value == long_is_64_bits, "");
-  static_assert(d::is_longn<s::long8>::value == long_is_64_bits, "");
-  static_assert(d::is_longn<s::long16>::value == long_is_64_bits, "");
-
-  // is_genlong
-  static_assert(d::is_genlong<char>::value == false, "");
-  static_assert(d::is_genlong<long>::value == true, "");
-  static_assert(d::is_genlong<s::long2>::value == long_is_64_bits, "");
-  static_assert(d::is_genlong<s::long3>::value == long_is_64_bits, "");
-  static_assert(d::is_genlong<s::long4>::value == long_is_64_bits, "");
-  static_assert(d::is_genlong<s::long8>::value == long_is_64_bits, "");
-  static_assert(d::is_genlong<s::long16>::value == long_is_64_bits, "");
-
   /*
   is_ulonglongn
   is_ugenlonglong

--- a/sycl/test/basic_tests/vectors/vectors.cpp
+++ b/sycl/test/basic_tests/vectors/vectors.cpp
@@ -11,6 +11,8 @@
 #define SYCL_SIMPLE_SWIZZLES
 #include <sycl/sycl.hpp>
 
+#include <cstddef>
+
 void check_vectors(sycl::int4 a, sycl::int4 b, sycl::int4 c, sycl::int4 gold) {
   sycl::int4 result = a * (sycl::int4)b.y() + c;
   assert((int)result.x() == (int)gold.x());
@@ -100,17 +102,17 @@ int main() {
   auto asVec = inputVec.template swizzle<sycl::elem::s0, sycl::elem::s1>()
                    .template as<sycl::vec<int16_t, 1>>();
 
-  // Check that [u]long[n] type aliases match vec<[unsigned] long, n> types.
-  assert((std::is_same<sycl::vec<long, 2>, sycl::long2>::value));
-  assert((std::is_same<sycl::vec<long, 3>, sycl::long3>::value));
-  assert((std::is_same<sycl::vec<long, 4>, sycl::long4>::value));
-  assert((std::is_same<sycl::vec<long, 8>, sycl::long8>::value));
-  assert((std::is_same<sycl::vec<long, 16>, sycl::long16>::value));
-  assert((std::is_same<sycl::vec<unsigned long, 2>, sycl::ulong2>::value));
-  assert((std::is_same<sycl::vec<unsigned long, 3>, sycl::ulong3>::value));
-  assert((std::is_same<sycl::vec<unsigned long, 4>, sycl::ulong4>::value));
-  assert((std::is_same<sycl::vec<unsigned long, 8>, sycl::ulong8>::value));
-  assert((std::is_same<sycl::vec<unsigned long, 16>, sycl::ulong16>::value));
+  // Check that [u]long[n] type aliases match vec<[u]int64_t, n> types.
+  assert((std::is_same<sycl::vec<std::int64_t, 2>, sycl::long2>::value));
+  assert((std::is_same<sycl::vec<std::int64_t, 3>, sycl::long3>::value));
+  assert((std::is_same<sycl::vec<std::int64_t, 4>, sycl::long4>::value));
+  assert((std::is_same<sycl::vec<std::int64_t, 8>, sycl::long8>::value));
+  assert((std::is_same<sycl::vec<std::int64_t, 16>, sycl::long16>::value));
+  assert((std::is_same<sycl::vec<std::uint64_t, 2>, sycl::ulong2>::value));
+  assert((std::is_same<sycl::vec<std::uint64_t, 3>, sycl::ulong3>::value));
+  assert((std::is_same<sycl::vec<std::uint64_t, 4>, sycl::ulong4>::value));
+  assert((std::is_same<sycl::vec<std::uint64_t, 8>, sycl::ulong8>::value));
+  assert((std::is_same<sycl::vec<std::uint64_t, 16>, sycl::ulong16>::value));
 
   // Check convert() from and to various types.
   check_convert_from<int8_t>();


### PR DESCRIPTION
This is a follow-up from intel/llvm#7889. Adjusted LIT tests to acount for the new definition of long{n} alias, which may not always be equal to sycl::vec<long, n> now. Removed some dead code (type traits) from the runtime.