### PR TITLE
[SYCL][XPTI] Fix building with XPTI disabled

### DIFF
--- a/sycl/plugins/level_zero/tracing.cpp
+++ b/sycl/plugins/level_zero/tracing.cpp
@@ -6,10 +6,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "xpti/xpti_data_types.h"
+#ifdef XPTI_ENABLE_INSTRUMENTATION
+#include <xpti/xpti_data_types.h>
+#include <xpti/xpti_trace_framework.h>
+#endif
+
 #include <exception>
 #include <layers/zel_tracing_api.h>
-#include <xpti/xpti_trace_framework.h>
 #include <ze_api.h>
 
 #include <sycl/detail/iostream_proxy.hpp>


### PR DESCRIPTION
The `XPTIScope` class uses some XPTI types, but the XPTI header is only included if the XPTI tracing is enabled, so when the XPTI tracing is disabled it fails to build.

So this patch simply macros out the whole `XPTIScope` class rather than specific member functions.

All the uses of `XPTIScope` in the codebase are already guarded by the macro.