### PR TITLE
[SYCL] [L0] Fix breakage after making them imm cmdlists thread-specific.

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -1175,9 +1175,9 @@ _pi_queue::_pi_queue(std::vector<ze_command_queue_handle_t> &ComputeQueues,
         CopyQueueGroup.ImmCmdLists = std::vector<pi_command_list_ptr_t>(
             CopyQueueGroup.ZeQueues.size(), CommandListMap.end());
       }
-      CopyQueueGroupsByTID.insert({TID, CopyQueueGroup});
     }
   }
+  CopyQueueGroupsByTID.insert({TID, CopyQueueGroup});
 
   // Initialize compute/copy command batches.
   ComputeCommandBatch.OpenCommandList = CommandListMap.end();


### PR DESCRIPTION
This change fixes an error that was introduced when immediate commandlists were made thread-specific. On a machine with copy engines, if the copy engines are not actually used by the plugin, there is a reference to an uninitialized variable.