### PR TITLE
[SYCL][NFCI] Add constexpr to SPIR-V Scope, Order and Semantics values

### DIFF
--- a/sycl/include/sycl/atomic_fence.hpp
+++ b/sycl/include/sycl/atomic_fence.hpp
@@ -21,8 +21,8 @@ __SYCL_INLINE_VER_NAMESPACE(_V1) {
 
 static inline void atomic_fence(memory_order order, memory_scope scope) {
 #ifdef __SYCL_DEVICE_ONLY__
-  auto SPIRVOrder = detail::spirv::getMemorySemanticsMask(order);
-  auto SPIRVScope = detail::spirv::getScope(scope);
+  constexpr auto SPIRVOrder = detail::spirv::getMemorySemanticsMask(order);
+  constexpr auto SPIRVScope = detail::spirv::getScope(scope);
   __spirv_MemoryBarrier(SPIRVScope, static_cast<uint32_t>(SPIRVOrder));
 #else
   (void)scope;

--- a/sycl/include/sycl/detail/spirv.hpp
+++ b/sycl/include/sycl/detail/spirv.hpp
@@ -287,9 +287,9 @@ inline typename detail::enable_if_t<std::is_integral<T>::value, T>
 AtomicCompareExchange(multi_ptr<T, AddressSpace, IsDecorated> MPtr,
                       memory_scope Scope, memory_order Success,
                       memory_order Failure, T Desired, T Expected) {
-  auto SPIRVSuccess = getMemorySemanticsMask(Success);
-  auto SPIRVFailure = getMemorySemanticsMask(Failure);
-  auto SPIRVScope = getScope(Scope);
+  constexpr auto SPIRVSuccess = getMemorySemanticsMask(Success);
+  constexpr auto SPIRVFailure = getMemorySemanticsMask(Failure);
+  constexpr auto SPIRVScope = getScope(Scope);
   auto *Ptr = GetMultiPtrDecoratedAs<T>(MPtr);
   return __spirv_AtomicCompareExchange(Ptr, SPIRVScope, SPIRVSuccess,
                                        SPIRVFailure, Desired, Expected);
@@ -302,9 +302,9 @@ AtomicCompareExchange(multi_ptr<T, AddressSpace, IsDecorated> MPtr,
                       memory_scope Scope, memory_order Success,
                       memory_order Failure, T Desired, T Expected) {
   using I = detail::make_unsinged_integer_t<T>;
-  auto SPIRVSuccess = getMemorySemanticsMask(Success);
-  auto SPIRVFailure = getMemorySemanticsMask(Failure);
-  auto SPIRVScope = getScope(Scope);
+  constexpr auto SPIRVSuccess = getMemorySemanticsMask(Success);
+  constexpr auto SPIRVFailure = getMemorySemanticsMask(Failure);
+  constexpr auto SPIRVScope = getScope(Scope);
   auto *PtrInt = GetMultiPtrDecoratedAs<I>(MPtr);
   I DesiredInt = bit_cast<I>(Desired);
   I ExpectedInt = bit_cast<I>(Expected);
@@ -319,8 +319,8 @@ inline typename detail::enable_if_t<std::is_integral<T>::value, T>
 AtomicLoad(multi_ptr<T, AddressSpace, IsDecorated> MPtr, memory_scope Scope,
            memory_order Order) {
   auto *Ptr = GetMultiPtrDecoratedAs<T>(MPtr);
-  auto SPIRVOrder = getMemorySemanticsMask(Order);
-  auto SPIRVScope = getScope(Scope);
+  constexpr auto SPIRVOrder = getMemorySemanticsMask(Order);
+  constexpr auto SPIRVScope = getScope(Scope);
   return __spirv_AtomicLoad(Ptr, SPIRVScope, SPIRVOrder);
 }
 
@@ -331,8 +331,8 @@ AtomicLoad(multi_ptr<T, AddressSpace, IsDecorated> MPtr, memory_scope Scope,
            memory_order Order) {
   using I = detail::make_unsinged_integer_t<T>;
   auto *PtrInt = GetMultiPtrDecoratedAs<I>(MPtr);
-  auto SPIRVOrder = getMemorySemanticsMask(Order);
-  auto SPIRVScope = getScope(Scope);
+  constexpr auto SPIRVOrder = getMemorySemanticsMask(Order);
+  constexpr auto SPIRVScope = getScope(Scope);
   I ResultInt = __spirv_AtomicLoad(PtrInt, SPIRVScope, SPIRVOrder);
   return bit_cast<T>(ResultInt);
 }
@@ -343,8 +343,8 @@ inline typename detail::enable_if_t<std::is_integral<T>::value>
 AtomicStore(multi_ptr<T, AddressSpace, IsDecorated> MPtr, memory_scope Scope,
             memory_order Order, T Value) {
   auto *Ptr = GetMultiPtrDecoratedAs<T>(MPtr);
-  auto SPIRVOrder = getMemorySemanticsMask(Order);
-  auto SPIRVScope = getScope(Scope);
+  constexpr auto SPIRVOrder = getMemorySemanticsMask(Order);
+  constexpr auto SPIRVScope = getScope(Scope);
   __spirv_AtomicStore(Ptr, SPIRVScope, SPIRVOrder, Value);
 }
 
@@ -355,8 +355,8 @@ AtomicStore(multi_ptr<T, AddressSpace, IsDecorated> MPtr, memory_scope Scope,
             memory_order Order, T Value) {
   using I = detail::make_unsinged_integer_t<T>;
   auto *PtrInt = GetMultiPtrDecoratedAs<I>(MPtr);
-  auto SPIRVOrder = getMemorySemanticsMask(Order);
-  auto SPIRVScope = getScope(Scope);
+  constexpr auto SPIRVOrder = getMemorySemanticsMask(Order);
+  constexpr auto SPIRVScope = getScope(Scope);
   I ValueInt = bit_cast<I>(Value);
   __spirv_AtomicStore(PtrInt, SPIRVScope, SPIRVOrder, ValueInt);
 }
@@ -367,8 +367,8 @@ inline typename detail::enable_if_t<std::is_integral<T>::value, T>
 AtomicExchange(multi_ptr<T, AddressSpace, IsDecorated> MPtr, memory_scope Scope,
                memory_order Order, T Value) {
   auto *Ptr = GetMultiPtrDecoratedAs<T>(MPtr);
-  auto SPIRVOrder = getMemorySemanticsMask(Order);
-  auto SPIRVScope = getScope(Scope);
+  constexpr auto SPIRVOrder = getMemorySemanticsMask(Order);
+  constexpr auto SPIRVScope = getScope(Scope);
   return __spirv_AtomicExchange(Ptr, SPIRVScope, SPIRVOrder, Value);
 }
 
@@ -379,8 +379,8 @@ AtomicExchange(multi_ptr<T, AddressSpace, IsDecorated> MPtr, memory_scope Scope,
                memory_order Order, T Value) {
   using I = detail::make_unsinged_integer_t<T>;
   auto *PtrInt = GetMultiPtrDecoratedAs<I>(MPtr);
-  auto SPIRVOrder = getMemorySemanticsMask(Order);
-  auto SPIRVScope = getScope(Scope);
+  constexpr auto SPIRVOrder = getMemorySemanticsMask(Order);
+  constexpr auto SPIRVScope = getScope(Scope);
   I ValueInt = bit_cast<I>(Value);
   I ResultInt =
       __spirv_AtomicExchange(PtrInt, SPIRVScope, SPIRVOrder, ValueInt);
@@ -393,8 +393,8 @@ inline typename detail::enable_if_t<std::is_integral<T>::value, T>
 AtomicIAdd(multi_ptr<T, AddressSpace, IsDecorated> MPtr, memory_scope Scope,
            memory_order Order, T Value) {
   auto *Ptr = GetMultiPtrDecoratedAs<T>(MPtr);
-  auto SPIRVOrder = getMemorySemanticsMask(Order);
-  auto SPIRVScope = getScope(Scope);
+  constexpr auto SPIRVOrder = getMemorySemanticsMask(Order);
+  constexpr auto SPIRVScope = getScope(Scope);
   return __spirv_AtomicIAdd(Ptr, SPIRVScope, SPIRVOrder, Value);
 }
 
@@ -404,8 +404,8 @@ inline typename detail::enable_if_t<std::is_integral<T>::value, T>
 AtomicISub(multi_ptr<T, AddressSpace, IsDecorated> MPtr, memory_scope Scope,
            memory_order Order, T Value) {
   auto *Ptr = GetMultiPtrDecoratedAs<T>(MPtr);
-  auto SPIRVOrder = getMemorySemanticsMask(Order);
-  auto SPIRVScope = getScope(Scope);
+  constexpr auto SPIRVOrder = getMemorySemanticsMask(Order);
+  constexpr auto SPIRVScope = getScope(Scope);
   return __spirv_AtomicISub(Ptr, SPIRVScope, SPIRVOrder, Value);
 }
 
@@ -415,8 +415,8 @@ inline typename detail::enable_if_t<std::is_floating_point<T>::value, T>
 AtomicFAdd(multi_ptr<T, AddressSpace, IsDecorated> MPtr, memory_scope Scope,
            memory_order Order, T Value) {
   auto *Ptr = GetMultiPtrDecoratedAs<T>(MPtr);
-  auto SPIRVOrder = getMemorySemanticsMask(Order);
-  auto SPIRVScope = getScope(Scope);
+  constexpr auto SPIRVOrder = getMemorySemanticsMask(Order);
+  constexpr auto SPIRVScope = getScope(Scope);
   return __spirv_AtomicFAddEXT(Ptr, SPIRVScope, SPIRVOrder, Value);
 }
 
@@ -426,8 +426,8 @@ inline typename detail::enable_if_t<std::is_integral<T>::value, T>
 AtomicAnd(multi_ptr<T, AddressSpace, IsDecorated> MPtr, memory_scope Scope,
           memory_order Order, T Value) {
   auto *Ptr = GetMultiPtrDecoratedAs<T>(MPtr);
-  auto SPIRVOrder = getMemorySemanticsMask(Order);
-  auto SPIRVScope = getScope(Scope);
+  constexpr auto SPIRVOrder = getMemorySemanticsMask(Order);
+  constexpr auto SPIRVScope = getScope(Scope);
   return __spirv_AtomicAnd(Ptr, SPIRVScope, SPIRVOrder, Value);
 }
 
@@ -437,8 +437,8 @@ inline typename detail::enable_if_t<std::is_integral<T>::value, T>
 AtomicOr(multi_ptr<T, AddressSpace, IsDecorated> MPtr, memory_scope Scope,
          memory_order Order, T Value) {
   auto *Ptr = GetMultiPtrDecoratedAs<T>(MPtr);
-  auto SPIRVOrder = getMemorySemanticsMask(Order);
-  auto SPIRVScope = getScope(Scope);
+  constexpr auto SPIRVOrder = getMemorySemanticsMask(Order);
+  constexpr auto SPIRVScope = getScope(Scope);
   return __spirv_AtomicOr(Ptr, SPIRVScope, SPIRVOrder, Value);
 }
 
@@ -448,8 +448,8 @@ inline typename detail::enable_if_t<std::is_integral<T>::value, T>
 AtomicXor(multi_ptr<T, AddressSpace, IsDecorated> MPtr, memory_scope Scope,
           memory_order Order, T Value) {
   auto *Ptr = GetMultiPtrDecoratedAs<T>(MPtr);
-  auto SPIRVOrder = getMemorySemanticsMask(Order);
-  auto SPIRVScope = getScope(Scope);
+  constexpr auto SPIRVOrder = getMemorySemanticsMask(Order);
+  constexpr auto SPIRVScope = getScope(Scope);
   return __spirv_AtomicXor(Ptr, SPIRVScope, SPIRVOrder, Value);
 }
 
@@ -459,8 +459,8 @@ inline typename detail::enable_if_t<std::is_integral<T>::value, T>
 AtomicMin(multi_ptr<T, AddressSpace, IsDecorated> MPtr, memory_scope Scope,
           memory_order Order, T Value) {
   auto *Ptr = GetMultiPtrDecoratedAs<T>(MPtr);
-  auto SPIRVOrder = getMemorySemanticsMask(Order);
-  auto SPIRVScope = getScope(Scope);
+  constexpr auto SPIRVOrder = getMemorySemanticsMask(Order);
+  constexpr auto SPIRVScope = getScope(Scope);
   return __spirv_AtomicMin(Ptr, SPIRVScope, SPIRVOrder, Value);
 }
 
@@ -470,8 +470,8 @@ inline typename detail::enable_if_t<std::is_floating_point<T>::value, T>
 AtomicMin(multi_ptr<T, AddressSpace, IsDecorated> MPtr, memory_scope Scope,
           memory_order Order, T Value) {
   auto *Ptr = GetMultiPtrDecoratedAs<T>(MPtr);
-  auto SPIRVOrder = getMemorySemanticsMask(Order);
-  auto SPIRVScope = getScope(Scope);
+  constexpr auto SPIRVOrder = getMemorySemanticsMask(Order);
+  constexpr auto SPIRVScope = getScope(Scope);
   return __spirv_AtomicMin(Ptr, SPIRVScope, SPIRVOrder, Value);
 }
 
@@ -481,8 +481,8 @@ inline typename detail::enable_if_t<std::is_integral<T>::value, T>
 AtomicMax(multi_ptr<T, AddressSpace, IsDecorated> MPtr, memory_scope Scope,
           memory_order Order, T Value) {
   auto *Ptr = GetMultiPtrDecoratedAs<T>(MPtr);
-  auto SPIRVOrder = getMemorySemanticsMask(Order);
-  auto SPIRVScope = getScope(Scope);
+  constexpr auto SPIRVOrder = getMemorySemanticsMask(Order);
+  constexpr auto SPIRVScope = getScope(Scope);
   return __spirv_AtomicMax(Ptr, SPIRVScope, SPIRVOrder, Value);
 }
 
@@ -492,8 +492,8 @@ inline typename detail::enable_if_t<std::is_floating_point<T>::value, T>
 AtomicMax(multi_ptr<T, AddressSpace, IsDecorated> MPtr, memory_scope Scope,
           memory_order Order, T Value) {
   auto *Ptr = GetMultiPtrDecoratedAs<T>(MPtr);
-  auto SPIRVOrder = getMemorySemanticsMask(Order);
-  auto SPIRVScope = getScope(Scope);
+  constexpr auto SPIRVOrder = getMemorySemanticsMask(Order);
+  constexpr auto SPIRVScope = getScope(Scope);
   return __spirv_AtomicMax(Ptr, SPIRVScope, SPIRVOrder, Value);
 }
 

--- a/sycl/include/sycl/ext/oneapi/atomic_fence.hpp
+++ b/sycl/include/sycl/ext/oneapi/atomic_fence.hpp
@@ -26,8 +26,8 @@ using namespace sycl::detail;
 __SYCL2020_DEPRECATED("use sycl::atomic_fence instead")
 static inline void atomic_fence(memory_order order, memory_scope scope) {
 #ifdef __SYCL_DEVICE_ONLY__
-  auto SPIRVOrder = detail::spirv::getMemorySemanticsMask(order);
-  auto SPIRVScope = detail::spirv::getScope(scope);
+  constexpr auto SPIRVOrder = detail::spirv::getMemorySemanticsMask(order);
+  constexpr auto SPIRVScope = detail::spirv::getScope(scope);
   __spirv_MemoryBarrier(SPIRVScope, static_cast<uint32_t>(SPIRVOrder));
 #else
   (void)scope;

--- a/sycl/include/sycl/group_barrier.hpp
+++ b/sycl/include/sycl/group_barrier.hpp
@@ -39,8 +39,8 @@ group_barrier(Group, memory_scope FenceScope = Group::fence_scope) {
   // fence operations. All work-items execute a release fence prior to
   // barrier and acquire fence afterwards. The rest of semantics flags specify
   // which type of memory this behavior is applied to.
-  __spirv_ControlBarrier(detail::group_barrier_scope<Group>::Scope,
-                         sycl::detail::spirv::getScope(FenceScope),
+  constexpr auto SPIRVScope = sycl::detail::spirv::getScope(FenceScope);
+  __spirv_ControlBarrier(detail::group_barrier_scope<Group>::Scope, SPIRVScope,
                          __spv::MemorySemanticsMask::SequentiallyConsistent |
                              __spv::MemorySemanticsMask::SubgroupMemory |
                              __spv::MemorySemanticsMask::WorkgroupMemory |


### PR DESCRIPTION
The reason is that otherwise with -O0 compilation flag these values would remain to be function calls even if these functions are marked as inline constexpr.

Signed-off-by: Sidorov, Dmitry <dmitry.sidorov@intel.com>