### PR TITLE
[ESIMD][NFC] Fix 2 compilation warnings in SLM allocation

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMDSlmReservation.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMDSlmReservation.cpp
@@ -135,7 +135,6 @@ CallInst *isSlmFreeCall(const CallInst *CI) {
 // -1 is returned.
 int getSLMUsage(const CallInst *SLMReserveCall) {
   assert(isSlmInitCall(SLMReserveCall) || isSlmAllocCall(SLMReserveCall));
-  StringRef Name = SLMReserveCall->getCalledFunction()->getName();
   auto *ArgV = SLMReserveCall->getArgOperand(0);
 
   if (!isa<ConstantInt>(ArgV)) {
@@ -208,6 +207,7 @@ public:
       llvm::errs() << "}\n";
     }
 #endif
+    virtual ~Node() {}
   };
 
   // A function node of the scoped callgraph.


### PR DESCRIPTION
1st warning: 'Name' is unused.
2nd warning: class Node has virtual methods, but not virtual destructor.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>