### PR TITLE
[ESIMD][NFC] Fix warning: unused variable StoreInstValueOperandIndex

### DIFF
--- a/llvm/lib/SYCLLowerIR/SYCLUtils.cpp
+++ b/llvm/lib/SYCLLowerIR/SYCLUtils.cpp
@@ -181,10 +181,7 @@ bool collectPossibleStoredVals(
     Value *V = U->getUser();
 
     if (auto *StI = dyn_cast<StoreInst>(V)) {
-      constexpr int StoreInstValueOperandIndex = 0;
-
       if (U != &StI->getOperandUse(StoreInst::getPointerOperandIndex())) {
-        assert(U == &StI->getOperandUse(StoreInstValueOperandIndex));
         // this is double indirection - not supported
         return false;
       }


### PR DESCRIPTION
The variable was used only in 1 assert statement and caused a warning with build modes where assert is mapped to NO-OP.

The assert is also removed because it verifies something that should always be true. In particular, the StoreInst instructions have 2 operands: Value and DestPtr. If 'StI' is user of 'U' and 'U' is not DstPtr, then 'U' simply must be the 'Value' operand.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>