### PR TITLE
[SYCL][CUDA] Build with cupti only when needed

### DIFF
--- a/sycl/plugins/cuda/CMakeLists.txt
+++ b/sycl/plugins/cuda/CMakeLists.txt
@@ -23,19 +23,27 @@ else()
   )
 endif()
 
-if (SYCL_ENABLE_XPTI_TRACING)
-  set(XPTI_PROXY_SRC "${CMAKE_SOURCE_DIR}/../xpti/src/xpti_proxy.cpp")
-endif()
+if (SYCL_ENABLE_XPTI_TRACING)                                                   
+  # The following two if's can be removed when FindCUDA -> FindCUDAToolkit.
+  # CUDA_CUPTI_INCLUDE_DIR -> CUDAToolkit_CUPTI_INCLUDE_DIR
+  include(FindCUDACupti)
+  if(NOT CUDA_CUPTI_INCLUDE_DIR)
+    find_cuda_cupti_include_dir()
+  endif()
+  # CUDA_cupti_LIBRARY -> CUDAToolkit_cupti_LIBRARY
+  if(NOT CUDA_cupti_LIBRARY)
+    find_cuda_cupti_library()
+  endif()
 
-# The following two if's can be removed when FindCUDA -> FindCUDAToolkit.
-# CUDA_CUPTI_INCLUDE_DIR -> CUDAToolkit_CUPTI_INCLUDE_DIR
-include(FindCUDACupti)
-if(NOT CUDA_CUPTI_INCLUDE_DIR)
-   find_cuda_cupti_include_dir()
-endif()
-# CUDA_cupti_LIBRARY -> CUDAToolkit_cupti_LIBRARY
-if(NOT CUDA_cupti_LIBRARY)
-   find_cuda_cupti_library()
+  set(XPTI_PROXY_SRC "${CMAKE_SOURCE_DIR}/../xpti/src/xpti_proxy.cpp")          
+  set(XPTI_INCLUDE
+    "${CMAKE_SOURCE_DIR}/../xpti/include"
+    "${CUDA_CUPTI_INCLUDE_DIR}"
+  )
+  set(XPTI_LIBS
+    "${CMAKE_DL_LIBS}"
+    "${CUDA_cupti_LIBRARY}"
+  )
 endif()
 
 add_sycl_plugin(cuda
@@ -46,9 +54,12 @@ add_sycl_plugin(cuda
     "pi_cuda.cpp"
     "tracing.cpp"
     ${XPTI_PROXY_SRC}
+  INCLUDE_DIRS
+    ${sycl_inc_dir}
+    ${XPTI_INCLUDE}
   LIBRARIES
     cudadrv
-    ${CUDA_cupti_LIBRARY}
+    ${XPTI_LIBS}
 )
 
 if (SYCL_ENABLE_XPTI_TRACING)
@@ -56,16 +67,7 @@ if (SYCL_ENABLE_XPTI_TRACING)
     XPTI_ENABLE_INSTRUMENTATION
     XPTI_STATIC_LIBRARY
   )
-  target_include_directories(pi_cuda PRIVATE "${CMAKE_SOURCE_DIR}/../xpti/include")
-  target_link_libraries(pi_cuda PRIVATE ${CMAKE_DL_LIBS})
 endif()
-
-
-target_include_directories(pi_cuda
-  PRIVATE
-    ${sycl_inc_dir}
-    ${CUDA_CUPTI_INCLUDE_DIR}
-)
 
 set_target_properties(pi_cuda PROPERTIES LINKER_LANGUAGE CXX)
 

--- a/sycl/plugins/cuda/tracing.cpp
+++ b/sycl/plugins/cuda/tracing.cpp
@@ -12,7 +12,9 @@
 #endif
 
 #include <cuda.h>
+#ifdef XPTI_ENABLE_INSTRUMENTATION
 #include <cupti.h>
+#endif // XPTI_ENABLE_INSTRUMENTATION
 
 #include <exception>
 #include <iostream>


### PR DESCRIPTION
* Fix an issue where libpi_cuda is linked against libcupti even when XPTI is disabled.
* Simplify pi_cuda CMake configuration.