### PR TITLE
[SYCL] Uninitialized value used with IntelNamedSubGroupSize

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -4060,6 +4060,7 @@ static void handleIntelNamedSubGroupSize(Sema &S, Decl *D,
   if (!IntelNamedSubGroupSizeAttr::ConvertStrToSubGroupSizeType(SizeStr,
                                                                 SizeType)) {
     S.Diag(Loc, diag::warn_attribute_type_not_supported) << AL << SizeStr;
+    return;
   }
   D->addAttr(IntelNamedSubGroupSizeAttr::Create(S.Context, SizeType, AL));
 }


### PR DESCRIPTION
A release compiler build with the memory sanitizer discovered the use of an uninitialized value in SemaDeclAttr.cpp while running the test SemaSYCL/sub-group-size.cpp.  It was caused by not returning early after diagnosing invalid attribute values.