### PR TITLE
[CI] Disable post-commit jobs in forks

### DIFF
--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -19,12 +19,14 @@ jobs:
   # This job generates matrix of tests for LLVM Test Suite
   test_matrix:
     name: Generate Test Matrix
+    if: github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl_gen_test_matrix.yml
     with:
       lts_config: "l0_gen9"
       cts_config: "cuda"
   linux_default:
     name: Linux Default
+    if: github.repository == 'intel/llvm'
     needs: test_matrix
     uses: ./.github/workflows/sycl_linux_build_and_test.yml
     secrets: inherit
@@ -36,6 +38,7 @@ jobs:
       lts_aws_matrix: ${{ needs.test_matrix.outputs.lts_aws_matrix }}
   linux_no_assert:
     name: Linux (no assert)
+    if: github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl_linux_build_and_test.yml
     secrets: inherit
     with:


### PR DESCRIPTION
These jobs are failing as they are relying on self-hosted runners available only for 'intel/llvm' repository.