### PR TITLE
[SYCL] platform.has(aspect) fix for empty platforms.

### DIFF
--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -575,8 +575,13 @@ typename Param::return_type platform_impl::get_info() const {
 }
 
 // All devices on the platform must have the given aspect.
+// False if there are no devices.
 bool platform_impl::has(aspect Aspect) const {
-  for (const auto &dev : get_devices()) {
+  std::vector<device> devices = get_devices();
+  if (devices.size() == 0)
+    return false;
+
+  for (const auto &dev : devices) {
     if (dev.has(Aspect) == false) {
       return false;
     }


### PR DESCRIPTION
platform::has(aspect) should be false if there are no devices at all.

This will fix the failure we are seeing in select_device.cpp allowing us to revert https://github.com/intel/llvm-test-suite/pull/1483
for which I've opened a PR here: https://github.com/intel/llvm-test-suite/pull/1488