### PR TITLE
[SYCL] Don't return empty platforms

### DIFF
--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -127,6 +127,9 @@ std::vector<platform> platform_impl::get_platforms() {
           Plugin.getPlatformId(PiPlatform);
         }
 
+        // The SYCL spec says that a platform has one or more devices. ( SYCL
+        // 2020 4.6.2 ) If we have an empty platform, we don't report it back
+        // from platform::get_platforms().
         if (!Platform.get_devices(info::device_type::all).empty()) {
           Platforms.push_back(Platform);
         }

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -126,10 +126,8 @@ std::vector<platform> platform_impl::get_platforms() {
           // insert PiPlatform into the Plugin
           Plugin.getPlatformId(PiPlatform);
         }
-        // The users of (deprecated) SYCL_DEVICE_ALLOWLIST expect that
-        // platforms with no devices will not be reported.
-        if (!SYCLConfig<SYCL_DEVICE_ALLOWLIST>::get() ||
-            !Platform.get_devices(info::device_type::all).empty()) {
+        
+        if (!Platform.get_devices(info::device_type::all).empty()) {
           Platforms.push_back(Platform);
         }
       }

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -126,7 +126,7 @@ std::vector<platform> platform_impl::get_platforms() {
           // insert PiPlatform into the Plugin
           Plugin.getPlatformId(PiPlatform);
         }
-        
+
         if (!Platform.get_devices(info::device_type::all).empty()) {
           Platforms.push_back(Platform);
         }


### PR DESCRIPTION
collecting empty platforms leads to confusion for things like `platform.has(aspect)`  