### PR TITLE
added support to get alignment information from sycl-compile-time-properties

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/CompileTimePropertiesPass.h
+++ b/llvm/include/llvm/SYCLLowerIR/CompileTimePropertiesPass.h
@@ -40,6 +40,8 @@ private:
       Module &M, IntrinsicInst *IntrInst,
       SmallVectorImpl<IntrinsicInst *> &RemovableAnnotations);
 
+  void parseAlignmentAndApply(Module &M, IntrinsicInst *IntrInst);
+
   // Map for keeping track of global variables generated for annotation strings.
   // This allows reuse for annotations with the same generated annotation
   // strings.

--- a/llvm/lib/SYCLLowerIR/CompileTimePropertiesPass.cpp
+++ b/llvm/lib/SYCLLowerIR/CompileTimePropertiesPass.cpp
@@ -232,6 +232,40 @@ attributeToExecModeMetadata(Module &M, const Attribute &Attr) {
   return std::nullopt;
 }
 
+SmallVector<std::pair<std::optional<StringRef>, std::optional<StringRef>>, 8>
+parseSYCLPropertiesString(Module &M, IntrinsicInst *IntrInst) {
+  SmallVector<std::pair<std::optional<StringRef>, std::optional<StringRef>>, 8>
+      result;
+
+  if (const auto *Cast =
+          dyn_cast<BitCastOperator>(IntrInst->getArgOperand(4))) {
+    if (const auto *AnnotValsGV =
+            dyn_cast<GlobalVariable>(Cast->getOperand(0))) {
+      if (const auto *AnnotValsAggr =
+              dyn_cast<ConstantAggregate>(AnnotValsGV->getInitializer())) {
+        assert(
+            (AnnotValsAggr->getNumOperands() & 1) == 0 &&
+            "sycl-properties annotation must have an even number of annotation "
+            "values.");
+
+        // Iterate over the pairs of property meta-names and meta-values.
+        for (size_t I = 0; I < AnnotValsAggr->getNumOperands(); I += 2) {
+          std::optional<StringRef> PropMetaName =
+              getGlobalVariableString(AnnotValsAggr->getOperand(I));
+          std::optional<StringRef> PropMetaValue =
+              getGlobalVariableString(AnnotValsAggr->getOperand(I + 1));
+
+          assert(PropMetaName &&
+                 "Unexpected format for property name in annotation.");
+
+          result.push_back(std::make_pair(PropMetaName, PropMetaValue));
+        }
+      }
+    }
+  }
+  return result;
+}
+
 } // anonymous namespace
 
 PreservedAnalyses CompileTimePropertiesPass::run(Module &M,
@@ -382,6 +416,74 @@ PreservedAnalyses CompileTimePropertiesPass::run(Module &M,
                                   : PreservedAnalyses::all();
 }
 
+void CompileTimePropertiesPass::parseAlignmentAndApply(
+    Module &M, IntrinsicInst *IntrInst) {
+  LLVMContext &Ctx = M.getContext();
+  unsigned MDKindID = Ctx.getMDKindID(SPIRV_DECOR_MD_KIND);
+
+  // Get the global variable with the annotation string.
+  const GlobalVariable *AnnotStrArgGV = nullptr;
+  const Value *IntrAnnotStringArg = IntrInst->getArgOperand(1);
+  if (auto *GEP = dyn_cast<GEPOperator>(IntrAnnotStringArg))
+    if (auto *C = dyn_cast<Constant>(GEP->getOperand(0)))
+      AnnotStrArgGV = dyn_cast<GlobalVariable>(C);
+  if (!AnnotStrArgGV)
+    return;
+
+  std::optional<StringRef> AnnotStr = getGlobalVariableString(AnnotStrArgGV);
+  if (!AnnotStr)
+    return;
+
+  // parse properties string to decoration-value pairs
+  auto properties = parseSYCLPropertiesString(M, IntrInst);
+
+  SmallVector<Value *, 8> userList;
+  SmallVector<Instruction *, 4> instList;
+  // check if used by a load or store instructions
+  for (auto val : IntrInst->users()) {
+    // if castInst, push sussessors
+    if (auto cast = dyn_cast<CastInst>(val)) {
+      for (auto sussessor : cast->users())
+        userList.push_back(sussessor);
+    } else {
+      userList.push_back(val);
+    }
+  }
+
+  for (auto &value : userList) {
+    if (isa<LoadInst>(value) || isa<StoreInst>(value))
+      instList.push_back(cast<Instruction>(value));
+  }
+
+  for (auto property : properties) {
+    // get decorcode code
+    auto DecorIt = SpirvDecorMap.find(*property.first);
+    if (DecorIt == SpirvDecorMap.end())
+      continue;
+
+    uint32_t DecorCode = DecorIt->second.Code;
+    auto DecorStr = property.first->str();
+    auto DecorValue = property.second;
+    uint32_t attr_val;
+
+    if (DecorStr == "sycl-alignment") {
+      assert(DecorValue && !DecorValue->getAsInteger(0, attr_val) &&
+             "sycl-alignment attribute is missing or not valid");
+
+      assert(llvm::isPowerOf2_64(attr_val) &&
+             "sycl-alignment attribute is not a power of 2");
+
+      // apply alignment attributes to load/store
+      for (auto inst : instList) {
+        if (auto loadinst = dyn_cast<LoadInst>(inst))
+          loadinst->setAlignment(Align(attr_val));
+        else if (auto storeinst = dyn_cast<StoreInst>(inst))
+          storeinst->setAlignment(Align(attr_val));
+      }
+    }
+  }
+}
+
 // Returns true if the transformation changed IntrInst.
 bool CompileTimePropertiesPass::transformSYCLPropertiesAnnotation(
     Module &M, IntrinsicInst *IntrInst,
@@ -406,45 +508,26 @@ bool CompileTimePropertiesPass::transformSYCLPropertiesAnnotation(
   if (!AnnotStr || AnnotStr->str() != "sycl-properties")
     return false;
 
+  // check alignment annotation and apply it to load/store
+  parseAlignmentAndApply(M, IntrInst);
+
   // Read the annotation values and create the new annotation string.
   std::string NewAnnotString = "";
-  if (const auto *Cast =
-          dyn_cast<BitCastOperator>(IntrInst->getArgOperand(4))) {
-    if (const auto *AnnotValsGV =
-            dyn_cast<GlobalVariable>(Cast->getOperand(0))) {
-      if (const auto *AnnotValsAggr =
-              dyn_cast<ConstantAggregate>(AnnotValsGV->getInitializer())) {
-        assert(
-            (AnnotValsAggr->getNumOperands() & 1) == 0 &&
-            "sycl-properties annotation must have an even number of annotation "
-            "values.");
+  auto properties = parseSYCLPropertiesString(M, IntrInst);
+  for (auto property : properties) {
+    auto DecorIt = SpirvDecorMap.find(*property.first);
+    if (DecorIt == SpirvDecorMap.end())
+      continue;
+    uint32_t DecorCode = DecorIt->second.Code;
 
-        // Iterate over the pairs of property meta-names and meta-values.
-        for (size_t I = 0; I < AnnotValsAggr->getNumOperands(); I += 2) {
-          std::optional<StringRef> PropMetaName =
-              getGlobalVariableString(AnnotValsAggr->getOperand(I));
-          std::optional<StringRef> PropMetaValue =
-              getGlobalVariableString(AnnotValsAggr->getOperand(I + 1));
-
-          assert(PropMetaName &&
-                 "Unexpected format for property name in annotation.");
-
-          auto DecorIt = SpirvDecorMap.find(*PropMetaName);
-          if (DecorIt == SpirvDecorMap.end())
-            continue;
-          uint32_t DecorCode = DecorIt->second.Code;
-
-          // Expected format is '{X}' or '{X:Y}' where X is decoration ID and
-          // Y is the value if present. It encloses Y in " to ensure that
-          // string values are handled correctly. Note that " around values are
-          // always valid, even if the decoration parameters are not strings.
-          NewAnnotString += "{" + std::to_string(DecorCode);
-          if (PropMetaValue)
-            NewAnnotString += ":\"" + PropMetaValue->str() + "\"";
-          NewAnnotString += "}";
-        }
-      }
-    }
+    // Expected format is '{X}' or '{X:Y}' where X is decoration ID and
+    // Y is the value if present. It encloses Y in " to ensure that
+    // string values are handled correctly. Note that " around values are
+    // always valid, even if the decoration parameters are not strings.
+    NewAnnotString += "{" + std::to_string(DecorCode);
+    if (property.second)
+      NewAnnotString += ":\"" + property.second->str() + "\"";
+    NewAnnotString += "}";
   }
 
   // If the new annotation string is empty there is no reason to keep it, so

--- a/llvm/lib/SYCLLowerIR/CompileTimePropertiesPass.cpp
+++ b/llvm/lib/SYCLLowerIR/CompileTimePropertiesPass.cpp
@@ -441,10 +441,10 @@ void CompileTimePropertiesPass::parseAlignmentAndApply(
   SmallVector<Instruction *, 4> instList;
   // check if used by a load or store instructions
   for (auto val : IntrInst->users()) {
-    // if castInst, push sussessors
+    // if castInst, push successors
     if (auto cast = dyn_cast<CastInst>(val)) {
-      for (auto sussessor : cast->users())
-        userList.push_back(sussessor);
+      for (auto successor : cast->users())
+        userList.push_back(successor);
     } else {
       userList.push_back(val);
     }

--- a/llvm/test/tools/sycl-post-link/sycl-properties-alignment-loadstore.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-properties-alignment-loadstore.ll
@@ -1,0 +1,60 @@
+; RUN: opt -passes="compile-time-properties" -S %s -o %t.ll
+; RUN: FileCheck %s -input-file=%t.ll
+;
+; Tests the translation of "sycl-alignment" to alignment attributes on load/store
+
+target triple = "spir64_fpga-unknown-unknown"
+
+%struct.MyIP = type { %class.ann_ptr }
+%class.ann_ptr = type { i32 addrspace(4)* }
+
+$_ZN7ann_refIiEC2EPi = comdat any
+$_ZN7ann_refIiEcvRiEv = comdat any
+
+@.str = private unnamed_addr addrspace(1) constant [16 x i8] c"sycl-properties\00", section "llvm.metadata"
+@.str.1 = private unnamed_addr addrspace(1) constant [9 x i8] c"main.cpp\00", section "llvm.metadata"
+@.str.2 = private unnamed_addr addrspace(1) constant [15 x i8] c"sycl-alignment\00", section "llvm.metadata"
+@.str.3 = private unnamed_addr addrspace(1) constant [3 x i8] c"64\00", section "llvm.metadata"
+@.args = private unnamed_addr addrspace(1) constant { [15 x i8] addrspace(1)*, [3 x i8] addrspace(1)* } { [15 x i8] addrspace(1)* @.str.2, [3 x i8] addrspace(1)* @.str.3 }, section "llvm.met
+adata"
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare i8 addrspace(4)* @llvm.ptr.annotation.p4i8.p1i8(i8 addrspace(4)*, i8 addrspace(1)*, i8 addrspace(1)*, i32, i8 addrspace(1)*) #5
+
+; Function Attrs: convergent mustprogress norecurse nounwind
+define linkonce_odr dso_local spir_func noundef align 4 dereferenceable(4) i32 addrspace(4)* @_ZN7ann_refIiEcvRiEv(%class.ann_ptr addrspace(4)* noundef align 8 dereferenceable_or_null(8) %this) #3 comdat align 2 {
+entry:
+  %retval = alloca i32 addrspace(4)*, align 8
+  %this.addr = alloca %class.ann_ptr addrspace(4)*, align 8
+  %retval.ascast = addrspacecast i32 addrspace(4)** %retval to i32 addrspace(4)* addrspace(4)*
+  %this.addr.ascast = addrspacecast %class.ann_ptr addrspace(4)** %this.addr to %class.ann_ptr addrspace(4)* addrspace(4)*
+  store %class.ann_ptr addrspace(4)* %this, %class.ann_ptr addrspace(4)* addrspace(4)* %this.addr.ascast, align 8
+  %this1 = load %class.ann_ptr addrspace(4)*, %class.ann_ptr addrspace(4)* addrspace(4)* %this.addr.ascast, align 8
+  %p = getelementptr inbounds %class.ann_ptr, %class.ann_ptr addrspace(4)* %this1, i32 0, i32 0
+  %0 = bitcast i32 addrspace(4)* addrspace(4)* %p to i8 addrspace(4)*
+  %1 = call i8 addrspace(4)* @llvm.ptr.annotation.p4i8.p1i8(i8 addrspace(4)* %0, i8 addrspace(1)* getelementptr inbounds ([16 x i8], [16 x i8] addrspace(1)* @.str, i32 0, i32 0), i8 addrspace(1)* getelementptr inbounds ([9 x i8], [9 x i8] addrspace(1)* @.str.1, i32 0, i32 0), i32 22, i8 addrspace(1)* bitcast ({ [15 x i8] addrspace(1)*, [3 x i8] addrspace(1)* } addrspace(1)* @.args to i8 addrspace(1)*))
+  %2 = bitcast i8 addrspace(4)* %1 to i32 addrspace(4)* addrspace(4)*
+  %3 = load i32 addrspace(4)*, i32 addrspace(4)* addrspace(4)* %2, align 8
+; CHECK: load i32 addrspace(4)*, i32 addrspace(4)* addrspace(4)* %2, align 64
+  ret i32 addrspace(4)* %3
+}
+
+; Function Attrs: convergent norecurse nounwind
+define linkonce_odr dso_local spir_func void @_ZN7ann_refIiEC2EPi(%class.ann_ptr addrspace(4)* noundef align 8 dereferenceable_or_null(8) %this, i32 addrspace(4)* noundef %ptr) unnamed_addr #2 comdat align 2 {
+entry:
+  %this.addr = alloca %class.ann_ptr addrspace(4)*, align 8
+  %ptr.addr = alloca i32 addrspace(4)*, align 8
+  %this.addr.ascast = addrspacecast %class.ann_ptr addrspace(4)** %this.addr to %class.ann_ptr addrspace(4)* addrspace(4)*
+  %ptr.addr.ascast = addrspacecast i32 addrspace(4)** %ptr.addr to i32 addrspace(4)* addrspace(4)*
+  store %class.ann_ptr addrspace(4)* %this, %class.ann_ptr addrspace(4)* addrspace(4)* %this.addr.ascast, align 8
+  store i32 addrspace(4)* %ptr, i32 addrspace(4)* addrspace(4)* %ptr.addr.ascast, align 8
+  %this1 = load %class.ann_ptr addrspace(4)*, %class.ann_ptr addrspace(4)* addrspace(4)* %this.addr.ascast, align 8
+  %p = getelementptr inbounds %class.ann_ptr, %class.ann_ptr addrspace(4)* %this1, i32 0, i32 0
+  %0 = bitcast i32 addrspace(4)* addrspace(4)* %p to i8 addrspace(4)*
+  %1 = call i8 addrspace(4)* @llvm.ptr.annotation.p4i8.p1i8(i8 addrspace(4)* %0, i8 addrspace(1)* getelementptr inbounds ([16 x i8], [16 x i8] addrspace(1)* @.str, i32 0, i32 0), i8 addrspace(1)* getelementptr inbounds ([9 x i8], [9 x i8] addrspace(1)* @.str.1, i32 0, i32 0), i32 22, i8 addrspace(1)* bitcast ({ [15 x i8] addrspace(1)*, [3 x i8] addrspace(1)* } addrspace(1)* @.args to i8 addrspace(1)*))
+  %2 = bitcast i8 addrspace(4)* %1 to i32 addrspace(4)* addrspace(4)*
+  %3 = load i32 addrspace(4)*, i32 addrspace(4)* addrspace(4)* %ptr.addr.ascast, align 8
+  store i32 addrspace(4)* %3, i32 addrspace(4)* addrspace(4)* %2, align 8
+; CHECK: store i32 addrspace(4)* %3, i32 addrspace(4)* addrspace(4)* %2, align 64
+  ret void
+}


### PR DESCRIPTION
This patch did:
1. create a utility function "parseSYCLPropertiesString"
2. parse string in llvm.ptr.annotation and get the alignment information out and apply on load/store instruction

This is to read the alignment decoration applied on a pointer using`__sycl_detail__::add_ir_annotations_member("sycl-alignment", "")` and transform the information on the load/store instructions which use this pointer.