### PR TITLE
[SYCL] Add non-standard vec aliases back to fix SYCL-CTS

### DIFF
--- a/sycl/include/sycl/aliases.hpp
+++ b/sycl/include/sycl/aliases.hpp
@@ -65,8 +65,15 @@ class half;
 
 // FIXME: OpenCL vector aliases are not defined by SYCL 2020 spec and should be
 //        removed from here. See intel/llvm#7888
+// FIXME: schar, longlong and ulonglong aliases are not defined by SYCL 2020
+//        spec, but they are preserved in SYCL 2020 mode, because SYCL-CTS is
+//        still using them.
+//        See KhronosGroup/SYCL-CTS#446 and KhronosGroup/SYCL-Docs#335
 #define __SYCL_2020_MAKE_VECTOR_ALIASES_FOR_VECTOR_LENGTH(N)                   \
   __SYCL_MAKE_VECTOR_ALIASES_FOR_OPENCL_TYPES(N)                               \
+  __SYCL_MAKE_VECTOR_ALIAS(schar, std::int8_t, N)                              \
+  __SYCL_MAKE_VECTOR_ALIAS(longlong, std::int64_t, N)                          \
+  __SYCL_MAKE_VECTOR_ALIAS(ulonglong, std::uint64_t, N)                        \
   __SYCL_MAKE_VECTOR_ALIAS(char, std::int8_t, N)                               \
   __SYCL_MAKE_VECTOR_ALIAS(uchar, std::uint8_t, N)                             \
   __SYCL_MAKE_VECTOR_ALIAS(short, std::int16_t, N)                             \

--- a/sycl/test/basic_tests/vectors/aliases.cpp
+++ b/sycl/test/basic_tests/vectors/aliases.cpp
@@ -10,6 +10,9 @@
       std::is_same_v<sycl::type##elems, sycl::vec<storage_type, elems>>);
 
 #define CHECK_ALIASES_FOR_VEC_LENGTH(N)                                        \
+  CHECK_ALIAS(schar, std::int8_t, N)                                           \
+  CHECK_ALIAS(longlong, std::int64_t, N)                                       \
+  CHECK_ALIAS(ulonglong, std::uint64_t, N)                                     \
   CHECK_ALIAS(char, std::int8_t, N)                                            \
   CHECK_ALIAS(uchar, std::uint8_t, N)                                          \
   CHECK_ALIAS(short, std::int16_t, N)                                          \


### PR DESCRIPTION
SYCL-CTS are still using some aliases which were removed from SYCL 2020 specification, see KhronosGroup/SYCL-CTS#446. Those tests are part of our post-commit and to make it green, this commit temporary adds those aliases back.

Note that it is not entierly clear if those aliases should have been removed in the first place, see KhronosGroup/SYCL-Docs#335.