### PR TITLE
[SYCL][NFC] Use std::nullopt instead of llvm::None

### DIFF
--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -645,7 +645,7 @@ static llvm::Optional<unsigned>
 UniqueStableNameDiscriminator(ASTContext &, const NamedDecl *ND) {
   if (const auto *RD = dyn_cast<CXXRecordDecl>(ND))
     return RD->getDeviceLambdaManglingNumber();
-  return llvm::None;
+  return std::nullopt;
 }
 
 std::string SYCLUniqueStableNameExpr::ComputeName(ASTContext &Context,

--- a/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
+++ b/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
@@ -1374,7 +1374,7 @@ public:
     bool ExecutionFailed = false;
     std::string ErrMsg;
     (void)sys::ExecuteAndWait(ObjcopyPath, Args,
-                              /*Env=*/llvm::None, /*Redirects=*/{},
+                              /*Env=*/std::nullopt, /*Redirects=*/{},
                               /*SecondsToWait=*/0,
                               /*MemoryLimit=*/0, &ErrMsg, &ExecutionFailed);
 


### PR DESCRIPTION
llvm::None is deprecated and causes warnings and can cause build fails in the future.