### PR TITLE
[SYCL] Fix crash in unique stable name processing

### DIFF
--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -644,7 +644,8 @@ std::string SYCLUniqueStableNameExpr::ComputeName(ASTContext &Context) const {
 static llvm::Optional<unsigned>
 UniqueStableNameDiscriminator(ASTContext &, const NamedDecl *ND) {
   if (const auto *RD = dyn_cast<CXXRecordDecl>(ND))
-    return RD->getDeviceLambdaManglingNumber();
+    if (RD->isLambda())
+      return RD->getDeviceLambdaManglingNumber();
   return llvm::None;
 }
 

--- a/clang/test/SemaSYCL/unique-stable-name-anon-struct-crash.cpp
+++ b/clang/test/SemaSYCL/unique-stable-name-anon-struct-crash.cpp
@@ -1,0 +1,16 @@
+// RUN: %clang_cc1 %s %s -std=c++17 -triple x86_64-linux-gnu -Wno-sycl-2020-compat -fsycl-is-device -verify -fsyntax-only -Wno-unused
+
+// This would crash due to UniqueStableNameDiscriminator expecting only lambdas
+// as unnamed records.
+// expected-no-diagnostics
+
+template <typename T1, typename T2>
+class TC {};
+
+template <typename T1, typename T2> void TFoo(T1 _T1, T2 _T2) {
+ __builtin_sycl_unique_stable_name(TC<T1, T2>);
+}
+void use() {
+  struct {float r1, r2, r12; } s;
+  TFoo(1, s);
+}


### PR DESCRIPTION
It seems built-in implementation expects only lambdas as unnamed structures, turns out that is not always the case.

Fixes #7360