### PR TITLE
[CI] Run CPU device tests on labeled nodes

### DIFF
--- a/devops/test_configs.json
+++ b/devops/test_configs.json
@@ -79,7 +79,10 @@
       "name": "[AWS] CUDA LLVM Test Suite",
       "runs-on": "aws-cuda_${{ inputs.uniq }}",
       "aws-ami": "ami-01cb0573cb039ab24",
-      "aws-type": [ "g5.2xlarge", "g5.4xlarge" ],
+      "aws-type": [
+        "g5.2xlarge",
+        "g5.4xlarge"
+      ],
       "aws-disk": "/dev/sda1:64",
       "aws-spot": "false",
       "image": "${{ inputs.cuda_image }}",

--- a/devops/test_configs.json
+++ b/devops/test_configs.json
@@ -29,7 +29,8 @@
       "name": "OCL x64 LLVM Test Suite",
       "runs-on": [
         "Linux",
-        "x64"
+        "x64",
+        "x86-cpu"
       ],
       "image": "${{ inputs.intel_drivers_image }}",
       "container_options": "-u 1001",
@@ -41,7 +42,8 @@
       "name": "ESIMD Emu LLVM Test Suite",
       "runs-on": [
         "Linux",
-        "x64"
+        "x64",
+        "x86-cpu"
       ],
       "image": "${{ inputs.intel_drivers_image }}",
       "container_options": "-u 1001",


### PR DESCRIPTION
Right now llvm-test-suite jobs testing OpenCL CPU device or ESIMD Emulator are executed on machines with "Linux" and "x64" tags, which are assigned by GitHub automatically even for AWS nodes with CUDA GPUs. AWS nodes are currently configured to execute only one job and this must be llvm-test-suite testing NVIDIA GPU (as we don't have active self-hosted runners with NVIDIA GPU).
I labeled all self-hosted runners capable of running tests on CPU with 'x86-cpu' label and limit execution of llvm-test-suite tests to these machines only.