### PR TITLE
[SYCL] Add assert for LangOpts and ParseKind in LanguageOptionsSpecificAttr

### DIFF
--- a/clang/utils/TableGen/ClangAttrEmitter.cpp
+++ b/clang/utils/TableGen/ClangAttrEmitter.cpp
@@ -4066,11 +4066,19 @@ static void GenerateLangOptRequirements(const Record &R,
   // ParseKind name with other attributes. Attributes like these are considered
   // valid for a given language option if any of the attributes they share
   // ParseKind with accepts it.
-  if (R.isSubClassOf("LanguageOptionsSpecificAttr") &&
-      !R.isValueUnset("ParseKind")) {
+  if (R.isSubClassOf("LanguageOptionsSpecificAttr")) {
+    assert(!R.isValueUnset("ParseKind") &&
+           "Attributes deriving from LanguageOptionsSpecificAttr must all "
+           "define a ParseKind string value.");
+    assert(!R.isValueUnset("LangOpts") &&
+           "Attributes deriving from LanguageOptionsSpecificAttr must all "
+           "define a LangOpts list.");
     const StringRef APK = R.getValueAsString("ParseKind");
     for (const auto &I : Dupes) {
       if (I.first == APK) {
+        assert(!I.second->isValueUnset("LangOpts") &&
+               "Attributes deriving from LanguageOptionsSpecificAttr must all "
+               "define a LangOpts list.");
         std::vector<Record *> LO = I.second->getValueAsListOfDefs("LangOpts");
         LangOpts.insert(LangOpts.end(), LO.begin(), LO.end());
       }


### PR DESCRIPTION
This commit adds asserts that all attributes deriving from LanguageOptionsSpecificAttr define both a ParseKind and a LangOpts value.

Based on https://github.com/intel/llvm/pull/7450#discussion_r1060656853