### PR TITLE
[SYCL] Add RegisterAllocMode metadata to large GRF kernels

### DIFF
--- a/llvm/test/SYCLLowerIR/lower_kernel_props.ll
+++ b/llvm/test/SYCLLowerIR/lower_kernel_props.ll
@@ -33,7 +33,8 @@ define weak_odr dso_local spir_kernel void @__large_grf_kernel1() !sycl_explicit
 
 ; -- This kernel calls the marker function directly
 define weak_odr dso_local spir_kernel void @__large_grf_kernel2() #0 !sycl_explicit_simd !0 !intel_reqd_sub_group_size !1 {
-; CHECK: {{.*}} spir_kernel void @__large_grf_kernel2() #0
+; CHECK: {{.*}} spir_kernel void @__large_grf_kernel2() #0 {{.*}} !RegisterAllocMode ![[MetadataArg:[0-9]+]]
+; CHECK: ![[MetadataArg]] = !{i32 2}
   call spir_func void @_Z28__sycl_set_kernel_propertiesi(i32 noundef 0)
   ret void
 }

--- a/llvm/test/tools/sycl-post-link/sycl-esimd-large-grf.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd-large-grf.ll
@@ -58,6 +58,8 @@ entry:
 declare dso_local spir_func void @_Z28__sycl_set_kernel_propertiesi(i32 noundef)
 
 define weak_odr dso_local spir_kernel void @__ESIMD_large_grf_kernel() #0 !sycl_explicit_simd !0 !intel_reqd_sub_group_size !1 {
+; CHECK-ESIMD-LargeGRF-IR: @__ESIMD_large_grf_kernel() {{.*}} !RegisterAllocMode ![[MetadataArg:[0-9]+]]
+; CHECK-ESIMD-LargeGRF-IR: ![[MetadataArg]] = !{i32 2}
 entry:
   call spir_func void @_Z17large_grf_markerv()
   ret void

--- a/llvm/test/tools/sycl-post-link/sycl-large-grf.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-large-grf.ll
@@ -47,6 +47,8 @@ entry:
 declare dso_local spir_func void @_Z28__sycl_set_kernel_propertiesi(i32 noundef)
 
 define weak_odr dso_local spir_kernel void @__large_grf_kernel() #0 {
+; CHECK-LARGE-GRF-IR: @__large_grf_kernel() {{.*}} !RegisterAllocMode ![[MetadataArg:[0-9]+]]
+; CHECK-LARGE-GRF-IR: ![[MetadataArg]] = !{i32 2}
 entry:
   call spir_func void @_Z17large_grf_markerv()
   ret void

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -421,8 +421,9 @@ static void appendCompileOptionsFromImage(std::string &CompileOpts,
   if (isLargeGRF) {
     if (!CompileOpts.empty())
       CompileOpts += " ";
-    // TODO: Always use -ze-opt-large-register-file once IGC VC bug ignoring it
-    // is fixed
+    // TODO: Don't check the property or pass these flags after the next ABI
+    // break. The behavior is now controlled through the RegisterAllocMode
+    // metadata.
     CompileOpts += isEsimdImage ? "-doubleGRF" : "-ze-opt-large-register-file";
   }
 }


### PR DESCRIPTION
Currently, we tell IGC to compile the kernel in large GRF mode by the -doubleGRF/-ze-opt-large-register-file flags passed in program manager. However, this doesn't work for AOT because the kernel has already been compiled and today we have no way to change AOT compiler flags based on the kernel contents. Instead, use the RegisterAllocMode metadata to get IGC to use large GRF mode, which will work for both JIT and AOT. This metadata is translated to the final metadata IGC looks for in llvm-spirv.

Signed-off-by: Sarnie, Nick <nick.sarnie@intel.com>