### PR TITLE
[CI] Disable math_builtin_api CTS test in post-commit

### DIFF
--- a/devops/cts_exclude_filter
+++ b/devops/cts_exclude_filter
@@ -20,3 +20,4 @@ vector_swizzles
 kernel_bundle
 specialization_constants
 device_selector
+math_builtin_api


### PR DESCRIPTION
Disable the test to fix post-commit status, while we are working on a fix.

Opened https://github.com/intel/llvm/issues/7950 to track the status of this issue.