### PR TITLE
[SYCL] Deprecate sycl::ext::oneapi::leader(group)

### DIFF
--- a/sycl/include/sycl/ext/oneapi/group_algorithm.hpp
+++ b/sycl/include/sycl/ext/oneapi/group_algorithm.hpp
@@ -531,8 +531,11 @@ detail::enable_if_t<
 }
 
 template <typename Group>
-detail::enable_if_t<detail::is_generic_group<Group>::value, bool>
-leader(Group g) {
+__SYCL2020_DEPRECATED(
+    "ext::oneapi::leader free function is deprecated. Use member function "
+    "leader of the sycl::group/sycl::sub_group instead.")
+detail::enable_if_t<detail::is_generic_group<Group>::value, bool> leader(
+    Group g) {
 #ifdef __SYCL_DEVICE_ONLY__
   typename Group::linear_id_type linear_id =
       sycl::detail::get_local_linear_id(g);

--- a/sycl/test/warnings/free_function_leader.cpp
+++ b/sycl/test/warnings/free_function_leader.cpp
@@ -1,0 +1,13 @@
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  using namespace sycl;
+  queue q;
+  q.parallel_for(nd_range<1>{range<1>{42}, range<1>{42}}, [=](nd_item<1> item) {
+     // expected-warning@+1 {{ext::oneapi::leader free function is deprecated. Use member function leader of the sycl::group/sycl::sub_group instead.}}
+     std::ignore = leader(item.get_sub_group());
+   }).wait();
+  return 0;
+}


### PR DESCRIPTION
SYCL 2020 member function leader should be used instead.