### PR TITLE
[Driver] -save-temps issue with files in CWD

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -9015,7 +9015,7 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
   if (isSaveTempsEnabled()) {
     // If we're saving temps and the temp file conflicts with any
     // input/resulting file, then avoid overwriting.
-    if (!AtTopLevel) {
+    if (!AtTopLevel && NamedOutput == BaseName) {
       bool SameFile = false;
       SmallString<256> Result;
       llvm::sys::fs::current_path(Result);

--- a/clang/test/Driver/save-temps.c
+++ b/clang/test/Driver/save-temps.c
@@ -93,3 +93,11 @@
 // CHECK-SAVE-TEMPS-CMSE: -cc1as
 // CHECK-SAVE-TEMPS-CMSE: +8msecext
 // CHECK-SAVE-TEMPS-CMSE-NOT: '+cmse' is not a recognized feature for this target (ignoring feature)
+
+// Usage of -save-temps with a file in $CWD should create the intermediate
+// files _not_ in /tmp.
+//
+// RUN: touch dummy.c
+// RUN: %clang -save-temps dummy.c -### 2>&1  \
+// RUN:   | FileCheck %s -check-prefix=CHECK-CWD-FILE
+// CHECK-CWD-FILE: clang{{.*}} "-o" "dummy.ii"

--- a/clang/test/Driver/sycl-offload-save-temps.cpp
+++ b/clang/test/Driver/sycl-offload-save-temps.cpp
@@ -40,3 +40,10 @@
 // RUN: | FileCheck %s --check-prefix=CHK_LLVM_PASSES
 // CHK_LLVM_PASSES-NOT: clang{{.*}} "-triple" "spir64-unknown-unknown" {{.*}} "-disable-llvm-passes"
 // CHK_LLVM_PASSES: clang{{.*}} "-triple" "x86_64-unknown-linux-gnu" {{.*}} "-disable-llvm-passes"
+
+/// Usage of -save-temps with a file in $CWD should create the intermediate
+/// files _not_ in /tmp.
+// RUN: touch dummy.c
+// RUN: %clangxx -save-temps dummy.c -### 2>&1  \
+// RUN:   | FileCheck %s --check-prefix=CHK_CWD_FILE
+// CHK_CWD_FILE: clang{{.*}} "-o" "dummy.ii"

--- a/clang/test/Driver/sycl-offload-save-temps.cpp
+++ b/clang/test/Driver/sycl-offload-save-temps.cpp
@@ -40,10 +40,3 @@
 // RUN: | FileCheck %s --check-prefix=CHK_LLVM_PASSES
 // CHK_LLVM_PASSES-NOT: clang{{.*}} "-triple" "spir64-unknown-unknown" {{.*}} "-disable-llvm-passes"
 // CHK_LLVM_PASSES: clang{{.*}} "-triple" "x86_64-unknown-linux-gnu" {{.*}} "-disable-llvm-passes"
-
-/// Usage of -save-temps with a file in $CWD should create the intermediate
-/// files _not_ in /tmp.
-// RUN: touch dummy.c
-// RUN: %clangxx -save-temps dummy.c -### 2>&1  \
-// RUN:   | FileCheck %s --check-prefix=CHK_CWD_FILE
-// CHK_CWD_FILE: clang{{.*}} "-o" "dummy.ii"


### PR DESCRIPTION
When using -save-temps against fails in the $CWD, the driver was avoiding creating the intermediate files in the $CWD and creating them in /tmp. A previous modification to improve our behaviors with potential clashing intermediate files when working with llvm-foreach compilations inadvertently modified the check for the output name matching the base input name.  Put this check back in.