### PR TITLE
[SYCL-MLIR] Always lower memrefs to llvm pointers

### DIFF
--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -462,10 +462,9 @@ private:
   }
 };
 
-class BarePtrCastPattern final
-    : public ConvertOpToLLVMPattern<sycl::SYCLCastOp> {
+class BarePtrCastPattern final : public ConvertOpToLLVMPattern<SYCLCastOp> {
 public:
-  using ConvertOpToLLVMPattern<sycl::SYCLCastOp>::ConvertOpToLLVMPattern;
+  using ConvertOpToLLVMPattern<SYCLCastOp>::ConvertOpToLLVMPattern;
 
   LogicalResult
   matchAndRewrite(SYCLCastOp op, OpAdaptor opAdaptor,

--- a/polygeist/include/polygeist/Passes/Utils.h
+++ b/polygeist/include/polygeist/Passes/Utils.h
@@ -107,3 +107,15 @@ static inline bool hasElse(mlir::scf::IfOp op) {
 static inline bool hasElse(mlir::AffineIfOp op) {
   return op.getElseRegion().getBlocks().size() > 0;
 }
+
+/// States whether a MemRefType can be lowered to a bare pointer
+///
+/// Only ranked MemRefTypes with identity map and non-dynamic dimensions in the
+/// range [1, rank) can be lowered to a bare pointer.
+inline bool canBeLoweredToBarePtr(mlir::MemRefType memRefType) {
+  if (!memRefType.getLayout().isIdentity() || !memRefType.hasRank())
+    return false;
+  const auto shape = memRefType.getShape();
+  return std::none_of(shape.begin() + 1, shape.end(),
+                      mlir::ShapedType::isDynamic);
+}

--- a/polygeist/lib/polygeist/Passes/ConvertPolygeistToLLVM.cpp
+++ b/polygeist/lib/polygeist/Passes/ConvertPolygeistToLLVM.cpp
@@ -11,6 +11,8 @@
 //===----------------------------------------------------------------------===//
 #include "PassDetails.h"
 
+#include <numeric>
+
 #include "mlir/Analysis/DataLayoutAnalysis.h"
 #include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
 #include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
@@ -27,6 +29,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Func/Transforms/Passes.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/FunctionCallUtils.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
@@ -37,6 +40,7 @@
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Transforms/RegionUtils.h"
 #include "polygeist/Ops.h"
+#include "polygeist/Passes/Utils.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
 
@@ -45,16 +49,513 @@
 using namespace mlir;
 using namespace polygeist;
 
-mlir::LLVM::LLVMFuncOp GetOrCreateMallocFunction(ModuleOp module);
-mlir::LLVM::LLVMFuncOp GetOrCreateFreeFunction(ModuleOp module);
+/// Conversion similar to the canonical one, but not inserting the obtained
+/// pointer in a struct.
+struct GetGlobalMemrefOpLowering
+    : public ConvertOpToLLVMPattern<memref::GetGlobalOp> {
+  using ConvertOpToLLVMPattern<memref::GetGlobalOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(memref::GetGlobalOp getGlobalOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    const auto memrefTy = getGlobalOp.getType();
+    if (!canBeLoweredToBarePtr(memrefTy))
+      return failure();
+
+    const auto loc = getGlobalOp.getLoc();
+    const auto arrayTy =
+        convertGlobalMemrefTypeToLLVM(memrefTy, *typeConverter);
+    if (!arrayTy)
+      return failure();
+    const auto memSpace = memrefTy.getMemorySpaceAsInt();
+    const auto addressOf =
+        static_cast<Value>(rewriter.create<LLVM::AddressOfOp>(
+            loc, LLVM::LLVMPointerType::get(arrayTy, memSpace),
+            adaptor.getName()));
+
+    // Get the address of the first element in the array by creating a GEP with
+    // the address of the GV as the base, and (rank + 1) number of 0 indices.
+    rewriter.replaceOpWithNewOp<LLVM::GEPOp>(
+        getGlobalOp, typeConverter->convertType(memrefTy), addressOf,
+        SmallVector<LLVM::GEPArg>(memrefTy.getRank() + 1, 0));
+
+    return success();
+  }
+
+private:
+  /// Returns the LLVM type of the global variable given the memref type `type`.
+  static Type convertGlobalMemrefTypeToLLVM(MemRefType type,
+                                            TypeConverter &typeConverter) {
+    // LLVM type for a global memref will be a multi-dimension array. For
+    // declarations or uninitialized global memrefs, we can potentially flatten
+    // this to a 1D array. However, for memref.global's with an initial value,
+    // we do not intend to flatten the ElementsAttribute when going from std ->
+    // LLVM dialect, so the LLVM type needs to me a multi-dimension array.
+    const auto shape = type.getShape();
+    const auto convElemTy = typeConverter.convertType(type.getElementType());
+    if (!convElemTy)
+      return {};
+    // Shape has the outermost dim at index 0, so need to walk it backwards
+    return std::accumulate(
+        shape.rbegin(), shape.rend(), convElemTy,
+        [](auto ty, auto dim) { return LLVM::LLVMArrayType::get(ty, dim); });
+  }
+};
+
+/// Simply replace by the source, as we don't care about the shape.
+struct ReshapeMemrefOpLowering
+    : public ConvertOpToLLVMPattern<memref::ReshapeOp> {
+  using ConvertOpToLLVMPattern<memref::ReshapeOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(memref::ReshapeOp reshape, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!canBeLoweredToBarePtr(reshape.getType()) ||
+        !canBeLoweredToBarePtr(
+            reshape.getSource().getType().cast<MemRefType>()))
+      return failure();
+
+    rewriter.replaceOp(reshape, adaptor.getSource());
+    return success();
+  }
+};
+
+/// Conversion similar to the canonical one, but not inserting the obtained
+/// pointer in a struct.
+struct AllocaMemrefOpLowering
+    : public ConvertOpToLLVMPattern<memref::AllocaOp> {
+  using ConvertOpToLLVMPattern<memref::AllocaOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(memref::AllocaOp allocaOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    const auto memrefType = allocaOp.getType();
+    if (!memrefType.hasStaticShape() || !memrefType.getLayout().isIdentity())
+      return failure();
+
+    const auto loc = allocaOp.getLoc();
+    const auto ptrType = typeConverter->convertType(allocaOp.getType());
+    if (!ptrType)
+      return failure();
+    auto nullPtr = rewriter.create<LLVM::NullOp>(loc, ptrType);
+    auto gepPtr = rewriter.create<LLVM::GEPOp>(
+        loc, ptrType, nullPtr,
+        createIndexConstant(rewriter, loc,
+                            allocaOp.getType().getNumElements()));
+    auto sizeBytes =
+        rewriter.create<LLVM::PtrToIntOp>(loc, getIndexType(), gepPtr);
+
+    rewriter.replaceOpWithNewOp<LLVM::AllocaOp>(
+        allocaOp, ptrType, sizeBytes, allocaOp.getAlignment().value_or(0));
+    return success();
+  }
+};
+
+static Value createAligned(ConversionPatternRewriter &rewriter, Location loc,
+                           Value input, Value alignment) {
+  auto one = rewriter.create<LLVM::ConstantOp>(loc, alignment.getType(), 1);
+  auto bump = rewriter.create<LLVM::SubOp>(loc, alignment, one);
+  auto bumped = rewriter.create<LLVM::AddOp>(loc, input, bump);
+  auto mod = rewriter.create<LLVM::URemOp>(loc, bumped, alignment);
+  return rewriter.create<LLVM::SubOp>(loc, bumped, mod);
+}
+
+static LLVM::LLVMFuncOp getFreeFn(LLVMTypeConverter &typeConverter,
+                                  ModuleOp module) {
+  return typeConverter.getOptions().useGenericFunctions
+             ? LLVM::lookupOrCreateGenericFreeFn(module)
+             : LLVM::lookupOrCreateFreeFn(module);
+}
+
+static LLVM::LLVMFuncOp getAllocFn(LLVMTypeConverter &typeConverter,
+                                   ModuleOp module, Type indexType) {
+  return typeConverter.getOptions().useGenericFunctions
+             ? LLVM::lookupOrCreateGenericAllocFn(module, indexType)
+             : LLVM::lookupOrCreateMallocFn(module, indexType);
+}
+
+/// Conversion similar to the canonical one, but not inserting the obtained
+/// pointer in a struct.
+struct AllocMemrefOpLowering : public ConvertOpToLLVMPattern<memref::AllocOp> {
+  using ConvertOpToLLVMPattern<memref::AllocOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(memref::AllocOp allocOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    const auto memrefType = allocOp.getType();
+    const auto elementPtrType = typeConverter->convertType(memrefType);
+    if (!elementPtrType || !memrefType.hasStaticShape() ||
+        !memrefType.getLayout().isIdentity())
+      return failure();
+
+    const auto loc = allocOp.getLoc();
+    SmallVector<Value, 4> sizes;
+    SmallVector<Value, 4> strides;
+    Value sizeBytes;
+    getMemRefDescriptorSizes(loc, memrefType, adaptor.getOperands(), rewriter,
+                             sizes, strides, sizeBytes);
+
+    const auto alignment = allocOp.getAlignment().transform(
+        [&](auto val) { return createIndexConstant(rewriter, loc, val); });
+    if (alignment) {
+      // Adjust the allocation size to consider alignment.
+      sizeBytes = rewriter.create<LLVM::AddOp>(loc, sizeBytes, *alignment);
+    }
+
+    auto module = allocOp->getParentOfType<ModuleOp>();
+    const auto allocFuncOp =
+        getAllocFn(*getTypeConverter(), module, getIndexType());
+
+    const auto results =
+        rewriter.create<LLVM::CallOp>(loc, allocFuncOp, sizeBytes).getResults();
+    auto alignedPtr = static_cast<Value>(
+        rewriter.create<LLVM::BitcastOp>(loc, elementPtrType, results));
+    if (alignment) {
+      // Compute the aligned pointer.
+      const auto allocatedInt = static_cast<Value>(
+          rewriter.create<LLVM::PtrToIntOp>(loc, getIndexType(), alignedPtr));
+      const auto alignmentInt =
+          createAligned(rewriter, loc, allocatedInt, *alignment);
+      alignedPtr =
+          rewriter.create<LLVM::IntToPtrOp>(loc, elementPtrType, alignmentInt);
+    }
+    rewriter.replaceOp(allocOp, {alignedPtr});
+    return success();
+  }
+};
+
+/// Conversion similar to the canonical one, but not extracting the allocated
+/// pointer from a struct.
+struct DeallocOpLowering : public ConvertOpToLLVMPattern<memref::DeallocOp> {
+  using ConvertOpToLLVMPattern<memref::DeallocOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(memref::DeallocOp deallocOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!canBeLoweredToBarePtr(
+            deallocOp.getMemref().getType().cast<MemRefType>()))
+      return failure();
+    // Insert the `free` declaration if it is not already present.
+    const auto freeFunc =
+        getFreeFn(*getTypeConverter(), deallocOp->getParentOfType<ModuleOp>());
+    const auto casted =
+        rewriter
+            .create<LLVM::BitcastOp>(deallocOp.getLoc(), getVoidPtrType(),
+                                     adaptor.getMemref())
+            .getRes();
+    rewriter.replaceOpWithNewOp<LLVM::CallOp>(deallocOp, freeFunc, casted);
+    return success();
+  }
+};
+
+/// Lowers to an identity operation.
+struct CastMemrefOpLowering : public ConvertOpToLLVMPattern<memref::CastOp> {
+  using ConvertOpToLLVMPattern<memref::CastOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult match(memref::CastOp castOp) const override {
+    const auto srcType = castOp.getOperand().getType().cast<MemRefType>();
+    const auto dstType = castOp.getType().cast<MemRefType>();
+
+    // This will be replaced by an identity function, so we need input and
+    // output types to match.
+    return success(canBeLoweredToBarePtr(dstType) &&
+                   canBeLoweredToBarePtr(srcType) &&
+                   typeConverter->convertType(srcType) ==
+                       typeConverter->convertType(dstType));
+  }
+
+  void rewrite(memref::CastOp castOp, OpAdaptor adaptor,
+               ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOp(castOp, adaptor.getSource());
+  }
+};
+
+/// Base class for lowering operations implementing memory accesses.
+struct MemAccessLowering : public ConvertToLLVMPattern {
+  using ConvertToLLVMPattern::ConvertToLLVMPattern;
+
+  /// Obtains offset from a memory access indices
+  Value getStridedElementBarePtr(Location loc, MemRefType type, Value base,
+                                 ValueRange indices,
+                                 ConversionPatternRewriter &rewriter) const {
+    int64_t offset;
+    SmallVector<int64_t, 4> strides;
+    auto successStrides = getStridesAndOffset(type, strides, offset);
+    assert(succeeded(successStrides) && "unexpected non-strided memref");
+    (void)successStrides;
+
+    auto index =
+        offset == 0 ? Value{} : createIndexConstant(rewriter, loc, offset);
+
+    for (const auto &iter : llvm::enumerate(llvm::zip(indices, strides))) {
+      auto increment = std::get<0>(iter.value());
+      const auto stride = std::get<1>(iter.value());
+      if (stride != 1) { // Skip if stride is 1.
+        increment = rewriter.create<LLVM::MulOp>(
+            loc, increment, createIndexConstant(rewriter, loc, stride));
+      }
+      index = index ? rewriter.create<LLVM::AddOp>(loc, index, increment)
+                    : increment;
+    }
+    const auto elementPtrType = getTypeConverter()->convertType(type);
+    if (!elementPtrType)
+      return {};
+    return index
+               ? rewriter.create<LLVM::GEPOp>(loc, elementPtrType, base, index)
+               : base;
+  }
+};
+
+struct LoadMemRefOpLowering : public MemAccessLowering {
+  LoadMemRefOpLowering(LLVMTypeConverter &typeConverter,
+                       PatternBenefit benefit = 1)
+      : MemAccessLowering{memref::LoadOp::getOperationName(),
+                          &typeConverter.getContext(), typeConverter, benefit} {
+  }
+
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> args,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto loadOp = cast<memref::LoadOp>(op);
+    if (!canBeLoweredToBarePtr(loadOp.getMemRefType()))
+      return failure();
+    memref::LoadOp::Adaptor adaptor{args};
+    const auto DataPtr = getStridedElementBarePtr(
+        loadOp.getLoc(), loadOp.getMemRefType(), adaptor.getMemref(),
+        adaptor.getIndices(), rewriter);
+    if (!DataPtr)
+      return failure();
+    rewriter.replaceOpWithNewOp<LLVM::LoadOp>(op, DataPtr);
+    return success();
+  }
+};
+
+struct StoreMemRefOpLowering : public MemAccessLowering {
+  StoreMemRefOpLowering(LLVMTypeConverter &typeConverter,
+                        PatternBenefit benefit = 1)
+      : MemAccessLowering{memref::StoreOp::getOperationName(),
+                          &typeConverter.getContext(), typeConverter, benefit} {
+  }
+
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> args,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto storeOp = cast<memref::StoreOp>(op);
+    if (!canBeLoweredToBarePtr(storeOp.getMemRefType()))
+      return failure();
+    memref::StoreOp::Adaptor adaptor{args};
+    const auto DataPtr = getStridedElementBarePtr(
+        storeOp.getLoc(), storeOp.getMemRefType(), adaptor.getMemref(),
+        adaptor.getIndices(), rewriter);
+    if (!DataPtr)
+      return failure();
+    rewriter.replaceOpWithNewOp<LLVM::StoreOp>(op, adaptor.getValue(), DataPtr);
+    return success();
+  }
+};
+
+struct SignatureConversionPattern : public ConversionPattern {
+  using ConversionPattern::ConversionPattern;
+
+protected:
+  /// States whether a signature should be converted
+  ///
+  /// A signature should be converted if it contains at least a memref type and
+  /// all of the memref types in it can be lowered to a bare ptr.
+  static bool shouldConvertSignature(TypeRange types) {
+    bool hasMT{false};
+    for (auto type : types) {
+      if (auto mt = type.dyn_cast<MemRefType>()) {
+        if (!canBeLoweredToBarePtr(mt))
+          return false;
+        hasMT = true;
+      }
+    }
+    return hasMT;
+  }
+};
+
+/// See mlir/lib/Dialect/Func/Transforms/FuncConversions.cpp
+///
+/// Copied here to be able to pass custom benefit.
+struct ReturnOpTypeConversionPattern : public SignatureConversionPattern {
+  ReturnOpTypeConversionPattern(MLIRContext *context,
+                                PatternBenefit benefit = 1)
+      : SignatureConversionPattern(func::ReturnOp::getOperationName(), benefit,
+                                   context) {}
+  ReturnOpTypeConversionPattern(TypeConverter &typeConverter,
+                                MLIRContext *context,
+                                PatternBenefit benefit = 1)
+      : SignatureConversionPattern(typeConverter,
+                                   func::ReturnOp::getOperationName(), benefit,
+                                   context) {}
+
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> args,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto returnOp = cast<func::ReturnOp>(op);
+    if (!shouldConvertSignature(returnOp.getOperandTypes()))
+      return failure();
+    func::ReturnOp::Adaptor adaptor{args};
+
+    rewriter.updateRootInPlace(
+        returnOp, [&] { returnOp->setOperands(adaptor.getOperands()); });
+    return success();
+  }
+};
+
+/// See mlir/lib/Dialect/Func/Transforms/FuncConversions.cpp
+///
+/// Copied here to be able to pass custom benefit.
+struct CallOpSignatureConversion : public SignatureConversionPattern {
+  CallOpSignatureConversion(MLIRContext *context, PatternBenefit benefit = 1)
+      : SignatureConversionPattern(func::CallOp::getOperationName(), benefit,
+                                   context) {}
+  CallOpSignatureConversion(TypeConverter &typeConverter, MLIRContext *context,
+                            PatternBenefit benefit = 1)
+      : SignatureConversionPattern(
+            typeConverter, func::CallOp::getOperationName(), benefit, context) {
+  }
+
+  /// Hook for derived classes to implement combined matching and rewriting.
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> args,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto callOp = cast<func::CallOp>(op);
+    if (!shouldConvertSignature(callOp.getOperandTypes()))
+      return failure();
+    func::CallOp::Adaptor adaptor{args};
+    // Convert the original function results.
+    SmallVector<Type, 1> convertedResults;
+    if (failed(typeConverter->convertTypes(callOp.getResultTypes(),
+                                           convertedResults)))
+      return failure();
+
+    // Substitute with the new result types from the corresponding FuncType
+    // conversion.
+    rewriter.replaceOpWithNewOp<func::CallOp>(
+        callOp, callOp.getCallee(), convertedResults, adaptor.getOperands());
+    return success();
+  }
+};
+
+/// See mlir/lib/Dialect/Func/Transforms/FuncConversions.cpp
+///
+/// Copied here to be able to pass custom benefit.
+struct AnyFunctionOpInterfaceSignatureConversion
+    : public SignatureConversionPattern {
+  AnyFunctionOpInterfaceSignatureConversion(MLIRContext *context,
+                                            PatternBenefit benefit = 1)
+      : SignatureConversionPattern(Pattern::MatchInterfaceOpTypeTag(),
+                                   FunctionOpInterface::getInterfaceID(),
+                                   benefit, context) {}
+  AnyFunctionOpInterfaceSignatureConversion(TypeConverter &typeConverter,
+                                            MLIRContext *context,
+                                            PatternBenefit benefit = 1)
+      : SignatureConversionPattern(
+            typeConverter, Pattern::MatchInterfaceOpTypeTag(),
+            FunctionOpInterface::getInterfaceID(), benefit, context) {}
+
+  LogicalResult
+  matchAndRewrite(Operation *op, ArrayRef<Value> /*operands*/,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto funcOp = cast<FunctionOpInterface>(op);
+    const auto type = funcOp.getFunctionType().cast<FunctionType>();
+    const auto operandTypes = type.getInputs();
+    const auto resultTypes = type.getResults();
+    if (!shouldConvertSignature(operandTypes) &&
+        !shouldConvertSignature(resultTypes))
+      return failure();
+
+    // Convert the original function types.
+    TypeConverter::SignatureConversion result(type.getNumInputs());
+    SmallVector<Type, 1> newResults;
+    if (failed(typeConverter->convertSignatureArgs(operandTypes, result)) ||
+        failed(typeConverter->convertTypes(resultTypes, newResults)) ||
+        failed(rewriter.convertRegionTypes(&funcOp.getFunctionBody(),
+                                           *typeConverter, &result)))
+      return failure();
+
+    // Update the function signature in-place.
+    auto newType = FunctionType::get(rewriter.getContext(),
+                                     result.getConvertedTypes(), newResults);
+
+    rewriter.updateRootInPlace(funcOp, [&] { funcOp.setType(newType); });
+
+    return success();
+  }
+};
+
+struct BaseSubIndexOpLowering : public ConvertOpToLLVMPattern<SubIndexOp> {
+  using ConvertOpToLLVMPattern<SubIndexOp>::ConvertOpToLLVMPattern;
+
+protected:
+  // Compute the indices of the GEP operation we lower the SubIndexOp to.
+  // The indices are computed based on:
+  //   a) the (converted) source element type, and
+  //   b) the (converted) result element type that is requested
+  // Examples:
+  //  - src ty: ptr<struct<array<1xi64>>>, res ty: ptr<i64>
+  //      -> idxs = [0, 0, SubIndexOp's index]
+  //  - src ty: ptr<struct<array<1xi64>>>, res ty: ptr<array<1xi64>>
+  //      -> idxs = [0, SubIndexOp's index]
+  //
+  // Note: when the source element type is a struct with more than one member
+  // type, the result type that is requested is deemed illegal unless it is one
+  // of the source member types. For example assume:
+  //   - src ty: ptr<struct<array<1xi64>,i32>>
+  //   - res ty: ptr<i64>
+  // This is illegal because res ty can only be either ptr<i32> or
+  // ptr<array<1xi64>>
+  static void computeIndices(const LLVM::LLVMStructType &srcElemType,
+                             const Type &resElemType,
+                             SmallVectorImpl<Value> &indices, SubIndexOp op,
+                             OpAdaptor transformed,
+                             ConversionPatternRewriter &rewriter) {
+    assert(indices.empty() && "Expecting an empty vector");
+
+    ArrayRef<Type> memTypes = srcElemType.getBody();
+    unsigned numMembers = memTypes.size();
+    assert((numMembers == 1 ||
+            any_of(memTypes, [=](Type t) { return resElemType == t; })) &&
+           "The requested result memref element type is illegal");
+
+    Type indexType = transformed.getIndex().getType();
+    Value zero = rewriter.create<LLVM::ConstantOp>(
+        op.getLoc(), indexType, rewriter.getIntegerAttr(indexType, 0));
+    indices.push_back(zero);
+
+    if (numMembers == 1) {
+      Type currType = srcElemType.getBody()[0];
+      while (currType != resElemType) {
+        indices.push_back(zero);
+
+        TypeSwitch<Type>(currType)
+            .Case<LLVM::LLVMStructType>([&](LLVM::LLVMStructType t) {
+              assert(t.getBody().size() == 1 && "Expecting single member type");
+              currType = t.getBody()[0];
+            })
+            .Case<LLVM::LLVMArrayType, LLVM::LLVMPointerType>(
+                [&](auto t) { currType = t.getElementType(); })
+            .Default([&](Type t) {
+              currType = t;
+              assert(currType == resElemType &&
+                     "requested result type is illegal");
+            });
+      }
+    }
+
+    indices.push_back(transformed.getIndex());
+  }
+};
 
 /// Conversion pattern that transforms a subview op into:
 ///   1. An `llvm.mlir.undef` operation to create a memref descriptor
 ///   2. Updates to the descriptor to introduce the data ptr, offset, size
 ///      and stride.
 /// The subview op is replaced by the descriptor.
-struct SubIndexOpLowering : public ConvertOpToLLVMPattern<SubIndexOp> {
-  using ConvertOpToLLVMPattern<SubIndexOp>::ConvertOpToLLVMPattern;
+struct SubIndexOpLowering : public BaseSubIndexOpLowering {
+  using BaseSubIndexOpLowering::BaseSubIndexOpLowering;
 
   LogicalResult
   matchAndRewrite(SubIndexOp subViewOp, OpAdaptor transformed,
@@ -140,65 +641,79 @@ struct SubIndexOpLowering : public ConvertOpToLLVMPattern<SubIndexOp> {
     rewriter.replaceOp(subViewOp, {memRefDesc});
     return success();
   }
+};
 
-private:
-  // Compute the indices of the GEP operation we lower the SubIndexOp to.
-  // The indices are computed based on:
-  //   a) the (converted) source element type, and
-  //   b) the (converted) result element type that is requested
-  // Examples:
-  //  - src ty: ptr<struct<array<1xi64>>>, res ty: ptr<i64>
-  //      -> idxs = [0, 0, SubIndexOp's index]
-  //  - src ty: ptr<struct<array<1xi64>>>, res ty: ptr<array<1xi64>>
-  //      -> idxs = [0, SubIndexOp's index]
-  //
-  // Note: when the source element type is a struct with more than one member
-  // type, the result type that is requested is deemed illegal unless it is one
-  // of the source member types. For example assume:
-  //   - src ty: ptr<struct<array<1xi64>,i32>>
-  //   - res ty: ptr<i64>
-  // This is illegal because res ty can only be either ptr<i32> or
-  // ptr<array<1xi64>>
-  void computeIndices(const LLVM::LLVMStructType &srcElemType,
-                      const Type &resElemType, SmallVectorImpl<Value> &indices,
-                      SubIndexOp op, OpAdaptor transformed,
-                      ConversionPatternRewriter &rewriter) const {
-    assert(indices.empty() && "Expecting an empty vector");
+struct SubIndexBarePtrOpLowering : public BaseSubIndexOpLowering {
+  using BaseSubIndexOpLowering::BaseSubIndexOpLowering;
 
-    ArrayRef<Type> memTypes = srcElemType.getBody();
-    unsigned numMembers = memTypes.size();
-    assert((numMembers == 1 ||
-            any_of(memTypes, [=](Type t) { return resElemType == t; })) &&
-           "The requested result memref element type is illegal");
+  LogicalResult
+  matchAndRewrite(SubIndexOp subViewOp, OpAdaptor transformed,
+                  ConversionPatternRewriter &rewriter) const override {
+    assert(subViewOp.getSource().getType().isa<MemRefType>() &&
+           "Source operand should be a memref type");
+    assert(subViewOp.getType().isa<MemRefType>() &&
+           "Result should be a memref type");
 
-    Type indexType = transformed.getIndex().getType();
-    Value zero = rewriter.create<LLVM::ConstantOp>(
-        op.getLoc(), indexType, rewriter.getIntegerAttr(indexType, 0));
-    indices.push_back(zero);
+    auto sourceMemRefType = subViewOp.getSource().getType().cast<MemRefType>();
+    auto viewMemRefType = subViewOp.getType().cast<MemRefType>();
+    if (!canBeLoweredToBarePtr(sourceMemRefType) ||
+        !canBeLoweredToBarePtr(viewMemRefType))
+      return failure();
 
-    if (numMembers == 1) {
-      Type currType = srcElemType.getBody()[0];
-      while (currType != resElemType) {
-        indices.push_back(zero);
+    const auto loc = subViewOp.getLoc();
+    const auto target = transformed.getSource();
+    auto idx = transformed.getIndex();
 
-        TypeSwitch<Type>(currType)
-            .Case<LLVM::LLVMStructType>([&](LLVM::LLVMStructType t) {
-              assert(t.getBody().size() == 1 && "Expecting single member type");
-              currType = t.getBody()[0];
-            })
-            .Case<LLVM::LLVMArrayType>(
-                [&](LLVM::LLVMArrayType t) { currType = t.getElementType(); })
-            .Case<LLVM::LLVMPointerType>(
-                [&](LLVM::LLVMPointerType t) { currType = t.getElementType(); })
-            .Default([&](Type t) {
-              currType = t;
-              assert(currType == resElemType &&
-                     "requested result type is illegal");
-            });
+    if (sourceMemRefType.getRank() != viewMemRefType.getRank()) {
+      if (sourceMemRefType.getRank() != viewMemRefType.getRank() + 1)
+        return failure();
+
+      size_t sz = 1;
+      for (int64_t i = 1; i < sourceMemRefType.getRank(); i++) {
+        if (sourceMemRefType.getShape()[i] == ShapedType::kDynamic)
+          return failure();
+        sz *= sourceMemRefType.getShape()[i];
       }
+      Value cop = rewriter.create<LLVM::ConstantOp>(
+          loc, idx.getType(), rewriter.getIntegerAttr(idx.getType(), sz));
+      idx = rewriter.create<LLVM::MulOp>(loc, idx, cop);
     }
 
-    indices.push_back(transformed.getIndex());
+    Type sourceElemType = sourceMemRefType.getElementType();
+    Type convSourceElemType = getTypeConverter()->convertType(sourceElemType);
+    if (!convSourceElemType)
+      return failure();
+    Type viewElemType = viewMemRefType.getElementType();
+    Type convViewElemType = getTypeConverter()->convertType(viewElemType);
+    Type resType = getTypeConverter()->convertType(subViewOp.getType());
+
+    // Handle the general (non-SYCL) case first.
+    if (convViewElemType ==
+        target.getType().cast<LLVM::LLVMPointerType>().getElementType()) {
+      rewriter.replaceOpWithNewOp<LLVM::GEPOp>(subViewOp, resType, target, idx);
+      return success();
+    }
+    assert(convSourceElemType.isa<LLVM::LLVMStructType>() &&
+           "Expecting struct type");
+
+    // SYCL case
+    assert(sourceMemRefType.getRank() == viewMemRefType.getRank() &&
+           "Expecting the input and output MemRef ranks to be the same");
+
+    SmallVector<Value> indices;
+    computeIndices(convSourceElemType.cast<LLVM::LLVMStructType>(),
+                   convViewElemType, indices, subViewOp, transformed, rewriter);
+    assert(!indices.empty() && "Expecting a least one index");
+
+    // Note: MLIRScanner::InitializeValueByInitListExpr() in clang-mlir.cc, when
+    // a memref element type is a struct type, the return type of a
+    // polygeist.subindex operation should be a memref of the element type of
+    // the struct.
+
+    rewriter.replaceOpWithNewOp<LLVM::GEPOp>(subViewOp, resType, target,
+                                             indices);
+
+    return success();
   }
 };
 
@@ -301,6 +816,44 @@ struct StreamToTokenOpLowering
   }
 };
 
+/// Lowers to a bitcast operation
+struct BareMemref2PointerOpLowering
+    : public ConvertOpToLLVMPattern<Memref2PointerOp> {
+  using ConvertOpToLLVMPattern<Memref2PointerOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Memref2PointerOp op, OpAdaptor transformed,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!canBeLoweredToBarePtr(op.getSource().getType()))
+      return failure();
+
+    const auto target = transformed.getSource();
+    rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, op.getType(), target);
+
+    return success();
+  }
+};
+
+/// Lowers to a bitcast operation
+struct BarePointer2MemrefOpLowering
+    : public ConvertOpToLLVMPattern<Pointer2MemrefOp> {
+  using ConvertOpToLLVMPattern<Pointer2MemrefOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Pointer2MemrefOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!canBeLoweredToBarePtr(op.getType()))
+      return failure();
+
+    const auto convertedType = getTypeConverter()->convertType(op.getType());
+    if (!convertedType)
+      return failure();
+    rewriter.replaceOpWithNewOp<LLVM::BitcastOp>(op, convertedType,
+                                                 adaptor.getSource());
+    return success();
+  }
+};
+
 struct TypeSizeOpLowering : public ConvertOpToLLVMPattern<TypeSizeOp> {
   using ConvertOpToLLVMPattern<TypeSizeOp>::ConvertOpToLLVMPattern;
 
@@ -363,13 +916,12 @@ struct TypeAlignOpLowering : public ConvertOpToLLVMPattern<TypeAlignOp> {
 
 void populatePolygeistToLLVMConversionPatterns(LLVMTypeConverter &converter,
                                                RewritePatternSet &patterns) {
-  // clang-format off
-  patterns.add<TypeSizeOpLowering>(converter);
-  patterns.add<TypeAlignOpLowering>(converter);
-  patterns.add<SubIndexOpLowering>(converter);
-  patterns.add<Memref2PointerOpLowering>(converter);
-  patterns.add<Pointer2MemrefOpLowering>(converter);
-  // clang-format on
+  patterns.add<TypeSizeOpLowering, TypeAlignOpLowering, SubIndexOpLowering,
+               Memref2PointerOpLowering, Pointer2MemrefOpLowering>(converter);
+  if (converter.getOptions().useBarePtrCallConv)
+    patterns.add<SubIndexBarePtrOpLowering, BareMemref2PointerOpLowering,
+                 BarePointer2MemrefOpLowering>(converter,
+                                               /*benefit*/ 2);
 }
 
 namespace {
@@ -573,7 +1125,7 @@ struct AsyncOpLowering : public ConvertOpToLLVMPattern<async::ExecuteOp> {
           valueMapping.map(idx.value(),
                            rewriter.create<LLVM::LoadOp>(loc, next));
         }
-        auto freef = GetOrCreateFreeFunction(module);
+        auto freef = getFreeFn(*getTypeConverter(), module);
         Value args[] = {arg};
         rewriter.create<LLVM::CallOp>(loc, freef, args);
       }
@@ -615,7 +1167,7 @@ struct AsyncOpLowering : public ConvertOpToLLVMPattern<async::ExecuteOp> {
           types.push_back(v.getType());
         auto ST = LLVM::LLVMStructType::getLiteral(ctx, types);
 
-        auto mallocf = GetOrCreateMallocFunction(module);
+        auto mallocf = getAllocFn(*getTypeConverter(), module, getIndexType());
 
         Value args[] = {rewriter.create<arith::IndexCastOp>(
             loc, rewriter.getI64Type(),
@@ -823,6 +1375,17 @@ struct ConvertPolygeistToLLVMPass
       populateVectorToLLVMConversionPatterns(converter, patterns);
 
       converter.addConversion([&](async::TokenType type) { return type; });
+      // This overrides the default
+      if (useBarePtrCallConv)
+        converter.addConversion([&](MemRefType type) -> Optional<Type> {
+          if (!canBeLoweredToBarePtr(type))
+            return std::nullopt;
+          const auto elemType = converter.convertType(type.getElementType());
+          if (!elemType)
+            return Type{};
+          return LLVM::LLVMPointerType::get(elemType,
+                                            type.getMemorySpaceAsInt());
+        });
 
       patterns
           .add<LLVMOpLowering, GlobalOpTypeConversion, ReturnOpTypeConversion>(
@@ -834,6 +1397,21 @@ struct ConvertPolygeistToLLVMPass
                    GPUReturnOpLowering, GPUModuleEndOpLowering>(converter);
 
       patterns.add<URLLVMOpLowering>(converter);
+
+      // Run these instead of the ones provided by the dialect to avoid lowering
+      // memrefs to a struct.
+      if (useBarePtrCallConv) {
+        patterns.add<GetGlobalMemrefOpLowering, ReshapeMemrefOpLowering,
+                     AllocMemrefOpLowering, AllocaMemrefOpLowering,
+                     CastMemrefOpLowering, DeallocOpLowering,
+                     LoadMemRefOpLowering, StoreMemRefOpLowering>(converter, 2);
+
+        // These should be run before lowering to the LLVM dialect to avoid
+        // lowering memrefs to a struct.
+        patterns.add<AnyFunctionOpInterfaceSignatureConversion,
+                     CallOpSignatureConversion, ReturnOpTypeConversionPattern>(
+            converter, &getContext(), /*benefit*/ 2);
+      }
 
       // Legality callback for operations that checks whether their operand and
       // results types are converted.

--- a/polygeist/test/polygeist-opt/bareptrlowering.mlir
+++ b/polygeist/test/polygeist-opt/bareptrlowering.mlir
@@ -551,3 +551,32 @@ func.func private @ptr2memref(%arg0: !llvm.ptr<f32>) -> memref<?xf32> {
   %res = "polygeist.pointer2memref"(%arg0) : (!llvm.ptr<f32>) -> memref<?xf32>
   return %res : memref<?xf32>
 }
+
+// -----
+
+#layout = affine_map<(s0) -> (s0 - 1)>
+
+// CHECK-LABEL:   llvm.func @non_bare_due_to_layout(
+// CHECK-SAME:                                      %[[VAL_0:.*]]: !llvm.ptr<i64>,
+// CHECK-SAME:                                      %[[VAL_1:.*]]: i64) -> i64
+// CHECK:           %[[VAL_2:.*]] = llvm.mlir.undef : !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:           %[[VAL_3:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_2]][0] : !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:           %[[VAL_4:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_3]][1] : !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:           %[[VAL_5:.*]] = llvm.mlir.constant(-1 : index) : i64
+// CHECK:           %[[VAL_6:.*]] = llvm.insertvalue %[[VAL_5]], %[[VAL_4]][2] : !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:           %[[VAL_7:.*]] = llvm.mlir.constant(100 : index) : i64
+// CHECK:           %[[VAL_8:.*]] = llvm.insertvalue %[[VAL_7]], %[[VAL_6]][3, 0] : !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:           %[[VAL_9:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:           %[[VAL_10:.*]] = llvm.insertvalue %[[VAL_9]], %[[VAL_8]][4, 0] : !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:           %[[VAL_11:.*]] = llvm.extractvalue %[[VAL_10]][1] : !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<1 x i64>, array<1 x i64>)>
+// CHECK:           %[[VAL_12:.*]] = llvm.mlir.constant(-1 : index) : i64
+// CHECK:           %[[VAL_13:.*]] = llvm.add %[[VAL_12]], %[[VAL_1]]  : i64
+// CHECK:           %[[VAL_14:.*]] = llvm.getelementptr %[[VAL_11]]{{\[}}%[[VAL_13]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_15:.*]] = llvm.load %[[VAL_14]] : !llvm.ptr<i64>
+// CHECK:           llvm.return %[[VAL_15]] : i64
+// CHECK:         }
+
+func.func private @non_bare_due_to_layout(%arg0: memref<100xi64, #layout>, %arg1: index) -> i64 {
+ %res = memref.load %arg0[%arg1] : memref<100xi64, #layout>
+ return %res : i64
+}

--- a/polygeist/test/polygeist-opt/bareptrlowering.mlir
+++ b/polygeist/test/polygeist-opt/bareptrlowering.mlir
@@ -1,0 +1,553 @@
+// RUN: polygeist-opt %s --convert-polygeist-to-llvm="use-bare-ptr-memref-call-conv" --split-input-file | FileCheck %s
+
+// CHECK-LABEL:   llvm.func @ptr_ret_static(i64) -> !llvm.ptr<i64>
+
+func.func private @ptr_ret_static(%arg0: i64) -> memref<4xi64>
+
+// -----
+
+// CHECK-LABEL:   llvm.func @ptr_ret_dynamic(i64) -> !llvm.ptr<i64>
+
+func.func private @ptr_ret_dynamic(%arg0: i64) -> memref<?xi64>
+
+// -----
+
+// CHECK-LABEL:   llvm.func @ptr_ret_nd_static(i64) -> !llvm.ptr<i64>
+
+func.func private @ptr_ret_nd_static(%arg0: i64) -> memref<4x4xi64>
+
+// -----
+
+// CHECK-LABEL:   llvm.func @ptr_ret_nd_dynamic(i64) -> !llvm.ptr<i64>
+
+func.func private @ptr_ret_nd_dynamic(%arg0: i64) -> memref<?x4x4xi64>
+
+// -----
+
+// CHECK-LABEL:   llvm.func @ptr_args_and_ret(!llvm.ptr<i64>, !llvm.ptr<i64>) -> !llvm.ptr<i64>
+
+func.func private @ptr_args_and_ret(%arg0: memref<1xi64>, %arg1: memref<?xi64>) -> memref<?x4x4xi64>
+
+// -----
+
+// CHECK-LABEL:   llvm.func @ptr_args_and_ret_with_attrs(!llvm.ptr<i64> {llvm.byval = !llvm.ptr<i64>}, !llvm.ptr<i64> {llvm.byval = !llvm.ptr<i64>}) -> !llvm.ptr<i64>
+
+func.func private @ptr_args_and_ret_with_attrs(%arg0: memref<1xi64> {llvm.byval = memref<1xi64>},
+                                               %arg1: memref<?xi64> {llvm.byval = memref<?xi64>}) -> memref<?x4x4xi64>
+
+// -----
+
+gpu.module @kernels {
+
+// CHECK-LABEL:   llvm.func @kernel(
+// CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr<i64> {llvm.byval = !llvm.ptr<i64>},
+// CHECK-SAME:                      %[[VAL_1:.*]]: !llvm.ptr<i64> {llvm.byval = !llvm.ptr<i64>}) attributes {gpu.kernel, workgroup_attributions = 0 : i64} {
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:         }
+
+  gpu.func @kernel(%arg0: memref<1xi64> {llvm.byval = memref<1xi64>},
+                   %arg1: memref<?xi64> {llvm.byval = memref<?xi64>}) kernel {
+    gpu.return
+  }
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.mlir.global external @global() {addr_space = 0 : i32} : !llvm.array<3 x i64>
+
+memref.global @global : memref<3xi64>
+
+// CHECK-LABEL:   llvm.func @get_global() -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.addressof @global : !llvm.ptr<array<3 x i64>>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr %[[VAL_0]][0, 0] : (!llvm.ptr<array<3 x i64>>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      llvm.return %[[VAL_1]] : !llvm.ptr<i64>
+// CHECK-NEXT:    }
+
+func.func private @get_global() -> memref<3xi64> {
+  %0 = memref.get_global @global : memref<3xi64>
+  return %0 : memref<3xi64>
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.mlir.global external @global_addrspace() {addr_space = 4 : i32} : !llvm.array<3 x i64>
+
+memref.global @global_addrspace : memref<3xi64, 4>
+
+// CHECK-LABEL:   llvm.func @get_global_addrspace() -> !llvm.ptr<i64, 4>
+// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.addressof @global_addrspace : !llvm.ptr<array<3 x i64>, 4>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr %[[VAL_0]][0, 0] : (!llvm.ptr<array<3 x i64>, 4>) -> !llvm.ptr<i64, 4>
+// CHECK-NEXT:      llvm.return %[[VAL_1]] : !llvm.ptr<i64, 4>
+// CHECK-NEXT:    }
+
+func.func private @get_global_addrspace() -> memref<3xi64, 4> {
+  %0 = memref.get_global @global_addrspace : memref<3xi64, 4>
+  return %0 : memref<3xi64, 4>
+}
+
+// -----
+
+memref.global "private" constant @shape : memref<2xi64> = dense<[2, 2]>
+
+// CHECK-LABEL:   llvm.func @reshape(
+// CHECK-SAME:                       %[[VAL_0:.*]]: !llvm.ptr<i32>) -> !llvm.ptr<i32>
+// CHECK:           %[[VAL_2:.*]] = llvm.getelementptr %{{.*}}[0, 0] : (!llvm.ptr<array<2 x i64>>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      llvm.return %[[VAL_0]] : !llvm.ptr<i32>
+// CHECK-NEXT:    }
+
+func.func private @reshape(%arg0: memref<4xi32>) -> memref<2x2xi32> {
+  %shape = memref.get_global @shape : memref<2xi64>
+  %0 = memref.reshape %arg0(%shape) : (memref<4xi32>, memref<2xi64>) -> memref<2x2xi32>
+  return %0 : memref<2x2xi32>
+}
+
+// -----
+
+memref.global "private" constant @shape : memref<1xindex>
+
+// CHECK-LABEL:   llvm.func @reshape_dyn(
+// CHECK-SAME:                           %[[VAL_0:.*]]: !llvm.ptr<i32>) -> !llvm.ptr<i32>
+// CHECK:           %[[VAL_2:.*]] = llvm.getelementptr %{{.*}}[0, 0] : (!llvm.ptr<array<1 x i64>>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      llvm.return %[[VAL_0]] : !llvm.ptr<i32>
+// CHECK-NEXT:    }
+
+func.func private @reshape_dyn(%arg0: memref<4xi32>) -> memref<?xi32> {
+  %shape = memref.get_global @shape : memref<1xindex>
+  %0 = memref.reshape %arg0(%shape) : (memref<4xi32>, memref<1xindex>) -> memref<?xi32>
+  return %0 : memref<?xi32>
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @alloca()
+// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.null : !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(2 : index) : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.ptrtoint %[[VAL_2]] : !llvm.ptr<i32> to i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x i32 : (i64) -> !llvm.ptr<i32>
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+
+func.func private @alloca() {
+  %0 = memref.alloca() : memref<2xi32>
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @alloca_nd()
+// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.null : !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(60 : index) : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.ptrtoint %[[VAL_2]] : !llvm.ptr<i32> to i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x i32 : (i64) -> !llvm.ptr<i32>
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+
+func.func private @alloca_nd() {
+  %0 = memref.alloca() : memref<3x10x2xi32>
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @alloca_aligned()
+// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.null : !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(2 : index) : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.ptrtoint %[[VAL_2]] : !llvm.ptr<i32> to i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x i32 {alignment = 8 : i64} : (i64) -> !llvm.ptr<i32>
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+
+func.func private @alloca_aligned() {
+  %0 = memref.alloca() {alignment = 8} : memref<2xi32>
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @alloca_nd_aligned()
+// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.null : !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(60 : index) : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.ptrtoint %[[VAL_2]] : !llvm.ptr<i32> to i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x i32 {alignment = 8 : i64} : (i64) -> !llvm.ptr<i32>
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+
+func.func private @alloca_nd_aligned() {
+  %0 = memref.alloca() {alignment = 8} : memref<3x10x2xi32>
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @malloc(i64) -> !llvm.ptr<i8>
+
+// CHECK-LABEL:   llvm.func @alloc()
+// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.constant(2 : index) : i64
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.null : !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_2]]{{\[}}%[[VAL_0]]] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.ptrtoint %[[VAL_3]] : !llvm.ptr<i32> to i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.call @malloc(%[[VAL_4]]) : (i64) -> !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.bitcast %[[VAL_5]] : !llvm.ptr<i8> to !llvm.ptr<i32>
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+
+func.func private @alloc() {
+  %0 = memref.alloc() : memref<2xi32>
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @alloc_nd()
+// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.constant(3 : index) : i64
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(10 : index) : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(2 : index) : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mlir.constant(20 : index) : i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.constant(60 : index) : i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.mlir.null : !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.getelementptr %[[VAL_6]]{{\[}}%[[VAL_5]]] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.ptrtoint %[[VAL_7]] : !llvm.ptr<i32> to i64
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.call @malloc(%[[VAL_8]]) : (i64) -> !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.bitcast %[[VAL_9]] : !llvm.ptr<i8> to !llvm.ptr<i32>
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+
+func.func private @alloc_nd() {
+  %0 = memref.alloc() : memref<3x10x2xi32>
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @alloc_aligned()
+// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.constant(2 : index) : i64
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.null : !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_2]]{{\[}}%[[VAL_0]]] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.ptrtoint %[[VAL_3]] : !llvm.ptr<i32> to i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.constant(8 : index) : i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.add %[[VAL_4]], %[[VAL_5]]  : i64
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.call @malloc(%[[VAL_6]]) : (i64) -> !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.bitcast %[[VAL_7]] : !llvm.ptr<i8> to !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.ptrtoint %[[VAL_8]] : !llvm.ptr<i32> to i64
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.sub %[[VAL_5]], %[[VAL_10]]  : i64
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.add %[[VAL_9]], %[[VAL_11]]  : i64
+// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.urem %[[VAL_12]], %[[VAL_5]]  : i64
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.sub %[[VAL_12]], %[[VAL_13]]  : i64
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.inttoptr %[[VAL_14]] : i64 to !llvm.ptr<i32>
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+
+func.func private @alloc_aligned() {
+  %0 = memref.alloc() {alignment = 8} : memref<2xi32>
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @alloc_nd_aligned()
+// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.constant(3 : index) : i64
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(10 : index) : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(2 : index) : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mlir.constant(20 : index) : i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.constant(60 : index) : i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.mlir.null : !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.getelementptr %[[VAL_6]]{{\[}}%[[VAL_5]]] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.ptrtoint %[[VAL_7]] : !llvm.ptr<i32> to i64
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.mlir.constant(8 : index) : i64
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.add %[[VAL_8]], %[[VAL_9]]  : i64
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.call @malloc(%[[VAL_10]]) : (i64) -> !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.bitcast %[[VAL_11]] : !llvm.ptr<i8> to !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.ptrtoint %[[VAL_12]] : !llvm.ptr<i32> to i64
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.sub %[[VAL_9]], %[[VAL_14]]  : i64
+// CHECK-NEXT:      %[[VAL_16:.*]] = llvm.add %[[VAL_13]], %[[VAL_15]]  : i64
+// CHECK-NEXT:      %[[VAL_17:.*]] = llvm.urem %[[VAL_16]], %[[VAL_9]]  : i64
+// CHECK-NEXT:      %[[VAL_18:.*]] = llvm.sub %[[VAL_16]], %[[VAL_17]]  : i64
+// CHECK-NEXT:      %[[VAL_19:.*]] = llvm.inttoptr %[[VAL_18]] : i64 to !llvm.ptr<i32>
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+
+func.func private @alloc_nd_aligned() {
+  %0 = memref.alloc() {alignment = 8} : memref<3x10x2xi32>
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @dealloc(
+// CHECK-SAME:                       %[[VAL_0:.*]]: !llvm.ptr<i32>)
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.bitcast %[[VAL_0]] : !llvm.ptr<i32> to !llvm.ptr<i8>
+// CHECK-NEXT:      llvm.call @free(%[[VAL_1]]) : (!llvm.ptr<i8>) -> ()
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+
+func.func private @dealloc(%arg0: memref<?xi32>) {
+  memref.dealloc %arg0 : memref<?xi32>
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @cast(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<i32>) -> !llvm.ptr<i32>
+// CHECK-NEXT:      llvm.return %[[VAL_0]] : !llvm.ptr<i32>
+// CHECK-NEXT:    }
+
+func.func private @cast(%arg0: memref<2xi32>) -> memref<?xi32> {
+  %0 = memref.cast %arg0 : memref<2xi32> to memref<?xi32>
+  return %0 : memref<?xi32>
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @load(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<f32>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: i64) -> f32
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<f32>
+// CHECK-NEXT:      llvm.return %[[VAL_3]] : f32
+// CHECK-NEXT:    }
+
+func.func private @load(%arg0: memref<100xf32>, %index: index) -> f32 {
+  %0 = memref.load %arg0[%index] : memref<100xf32>
+  return %0 : f32
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @load_nd(
+// CHECK-SAME:                       %[[VAL_0:.*]]: !llvm.ptr<f32>,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i64,
+// CHECK-SAME:                       %[[VAL_2:.*]]: i64) -> f32
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.constant(100 : index) : i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mul %[[VAL_1]], %[[VAL_3]]  : i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.add %[[VAL_4]], %[[VAL_2]]  : i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_5]]] : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.load %[[VAL_6]] : !llvm.ptr<f32>
+// CHECK-NEXT:      llvm.return %[[VAL_7]] : f32
+// CHECK-NEXT:    }
+
+func.func private @load_nd(%arg0: memref<100x100xf32>, %index0: index, %index1: index) -> f32 {
+  %0 = memref.load %arg0[%index0, %index1] : memref<100x100xf32>
+  return %0 : f32
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @load_nd_dyn(
+// CHECK-SAME:                           %[[VAL_0:.*]]: !llvm.ptr<f32>,
+// CHECK-SAME:                           %[[VAL_1:.*]]: i64,
+// CHECK-SAME:                           %[[VAL_2:.*]]: i64) -> f32
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.constant(100 : index) : i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mul %[[VAL_1]], %[[VAL_3]]  : i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.add %[[VAL_4]], %[[VAL_2]]  : i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_5]]] : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.load %[[VAL_6]] : !llvm.ptr<f32>
+// CHECK-NEXT:      llvm.return %[[VAL_7]] : f32
+// CHECK-NEXT:    }
+
+func.func private @load_nd_dyn(%arg0: memref<?x100xf32>, %index0: index, %index1: index) -> f32 {
+  %0 = memref.load %arg0[%index0, %index1] : memref<?x100xf32>
+  return %0 : f32
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @store(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<f32>,
+// CHECK-SAME:                     %[[VAL_1:.*]]: i64,
+// CHECK-SAME:                     %[[VAL_2:.*]]: f32)
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
+// CHECK-NEXT:      llvm.store %[[VAL_2]], %[[VAL_3]] : !llvm.ptr<f32>
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+
+func.func private @store(%arg0: memref<100xf32>, %index: index, %val: f32) {
+  memref.store %val, %arg0[%index] : memref<100xf32>
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @store_nd(
+// CHECK-SAME:                        %[[VAL_0:.*]]: !llvm.ptr<f32>,
+// CHECK-SAME:                        %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64,
+// CHECK-SAME:                        %[[VAL_3:.*]]: f32)
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mlir.constant(100 : index) : i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mul %[[VAL_1]], %[[VAL_4]]  : i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.add %[[VAL_5]], %[[VAL_2]]  : i64
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_6]]] : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
+// CHECK-NEXT:      llvm.store %[[VAL_3]], %[[VAL_7]] : !llvm.ptr<f32>
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+
+func.func private @store_nd(%arg0: memref<100x100xf32>, %index0: index, %index1: index, %val: f32) {
+  memref.store %val, %arg0[%index0, %index1] : memref<100x100xf32>
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @store_nd_dyn(
+// CHECK-SAME:                            %[[VAL_0:.*]]: !llvm.ptr<f32>,
+// CHECK-SAME:                            %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64,
+// CHECK-SAME:                            %[[VAL_3:.*]]: f32)
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mlir.constant(100 : index) : i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mul %[[VAL_1]], %[[VAL_4]]  : i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.add %[[VAL_5]], %[[VAL_2]]  : i64
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_6]]] : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
+// CHECK-NEXT:      llvm.store %[[VAL_3]], %[[VAL_7]] : !llvm.ptr<f32>
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+
+func.func private @store_nd_dyn(%arg0: memref<?x100xf32>, %index0: index, %index1: index, %val: f32) {
+  memref.store %val, %arg0[%index0, %index1] : memref<?x100xf32>
+  return
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @impl(!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
+
+func.func private @impl(%arg0: memref<?xf32>, %arg1: index) -> memref<?xf32>
+
+// CHECK-LABEL:   llvm.func @call(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<f32>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: i64) -> !llvm.ptr<f32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.call @impl(%[[VAL_0]], %[[VAL_1]]) : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
+// CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.ptr<f32>
+// CHECK-NEXT:    }
+
+func.func private @call(%arg0: memref<?xf32>, %arg1: index) -> memref<?xf32> {
+  %res = func.call @impl(%arg0, %arg1) : (memref<?xf32>, index) -> memref<?xf32>
+  return %res : memref<?xf32>
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @subindexop_memref(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: !llvm.ptr<f32>,
+// CHECK-SAME:                                 %[[VAL_1:.*]]: i64) -> !llvm.ptr<f32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(4 : i64) : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mul %[[VAL_1]], %[[VAL_2]]  : i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_3]]] : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
+// CHECK-NEXT:      llvm.return %[[VAL_4]] : !llvm.ptr<f32>
+// CHECK-NEXT:    }
+
+func.func private @subindexop_memref(%arg0: memref<4x4xf32>, %arg1: index) -> memref<4xf32> {
+  %res = "polygeist.subindex"(%arg0 , %arg1) : (memref<4x4xf32>, index) -> memref<4xf32>
+  return %res : memref<4xf32>
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @subindexop_memref_same_dim(
+// CHECK-SAME:                                          %[[VAL_0:.*]]: !llvm.ptr<f32>,
+// CHECK-SAME:                                          %[[VAL_1:.*]]: i64) -> !llvm.ptr<f32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<f32>, i64) -> !llvm.ptr<f32>
+// CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.ptr<f32>
+// CHECK-NEXT:    }
+
+func.func private @subindexop_memref_same_dim(%arg0: memref<4x4xf32>, %arg1: index) -> memref<4x4xf32> {
+  %res = "polygeist.subindex"(%arg0 , %arg1) : (memref<4x4xf32>, index) -> memref<4x4xf32>
+  return %res : memref<4x4xf32>
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @subindexop_memref_struct(
+// CHECK-SAME:                                        %[[VAL_0:.*]]: !llvm.ptr<struct<(f32)>>) -> !llvm.ptr<f32>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]], 0] : (!llvm.ptr<struct<(f32)>>, i64) -> !llvm.ptr<f32>
+// CHECK-NEXT:      llvm.return %[[VAL_3]] : !llvm.ptr<f32>
+// CHECK-NEXT:    }
+
+func.func private @subindexop_memref_struct(%arg0: memref<4x!llvm.struct<(f32)>>) -> memref<?xf32> {
+  %c_0 = arith.constant 0 : index
+  %res = "polygeist.subindex"(%arg0, %c_0) : (memref<4x!llvm.struct<(f32)>>, index) -> memref<?xf32>
+  return %res : memref<?xf32>
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @subindexop_memref_nested_struct(
+// CHECK-SAME:                                               %[[VAL_0:.*]]: !llvm.ptr<struct<(struct<(f32)>)>>) -> !llvm.ptr<f32>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]], 0, 0] : (!llvm.ptr<struct<(struct<(f32)>)>>, i64) -> !llvm.ptr<f32>
+// CHECK-NEXT:      llvm.return %[[VAL_3]] : !llvm.ptr<f32>
+// CHECK-NEXT:    }
+
+func.func private @subindexop_memref_nested_struct(%arg0: memref<4x!llvm.struct<(struct<(f32)>)>>) -> memref<?xf32> {
+  %c_0 = arith.constant 0 : index
+  %res = "polygeist.subindex"(%arg0, %c_0) : (memref<4x!llvm.struct<(struct<(f32)>)>>, index) -> memref<?xf32>
+  return %res : memref<?xf32>
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @subindexop_memref_nested_struct_ptr(
+// CHECK-SAME:                                                   %[[VAL_0:.*]]: !llvm.ptr<struct<(ptr<struct<(f32)>>)>>) -> !llvm.ptr<f32>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]], 0, %[[VAL_2]], %[[VAL_1]]] : (!llvm.ptr<struct<(ptr<struct<(f32)>>)>>, i64, i64, i64) -> !llvm.ptr<f32>
+// CHECK-NEXT:      llvm.return %[[VAL_3]] : !llvm.ptr<f32>
+// CHECK-NEXT:    }
+
+func.func private @subindexop_memref_nested_struct_ptr(%arg0: memref<4x!llvm.struct<(ptr<struct<(f32)>>)>>) -> memref<?xf32> {
+  %c_0 = arith.constant 0 : index
+  %res = "polygeist.subindex"(%arg0, %c_0) : (memref<4x!llvm.struct<(ptr<struct<(f32)>>)>>, index) -> memref<?xf32>
+  return %res : memref<?xf32>
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @subindexop_memref_nested_struct_array(
+// CHECK-SAME:                                                     %[[VAL_0:.*]]: !llvm.ptr<struct<(array<4 x struct<(f32)>>)>>) -> !llvm.ptr<f32>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]], 0, %[[VAL_2]], 0] : (!llvm.ptr<struct<(array<4 x struct<(f32)>>)>>, i64, i64) -> !llvm.ptr<f32>
+// CHECK-NEXT:      llvm.return %[[VAL_3]] : !llvm.ptr<f32>
+// CHECK-NEXT:    }
+
+func.func private @subindexop_memref_nested_struct_array(%arg0: memref<4x!llvm.struct<(array<4x!llvm.struct<(f32)>>)>>) -> memref<?xf32> {
+  %c_0 = arith.constant 0 : index
+  %res = "polygeist.subindex"(%arg0, %c_0) : (memref<4x!llvm.struct<(array<4x!llvm.struct<(f32)>>)>>, index) -> memref<?xf32>
+  return %res : memref<?xf32>
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @memref2ptr(
+// CHECK-SAME:                          %[[VAL_0:.*]]: !llvm.ptr<f32>) -> !llvm.ptr<f32>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.bitcast %[[VAL_0]] : !llvm.ptr<f32> to !llvm.ptr<f32>
+// CHECK-NEXT:      llvm.return %[[VAL_1]] : !llvm.ptr<f32>
+// CHECK-NEXT:    }
+
+func.func private @memref2ptr(%arg0: memref<4xf32>) -> !llvm.ptr<f32> {
+  %res = "polygeist.memref2pointer"(%arg0) : (memref<4xf32>) -> !llvm.ptr<f32>
+  return %res : !llvm.ptr<f32>
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @ptr2memref(
+// CHECK-SAME:                          %[[VAL_0:.*]]: !llvm.ptr<f32>) -> !llvm.ptr<f32>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.bitcast %[[VAL_0]] : !llvm.ptr<f32> to !llvm.ptr<f32>
+// CHECK-NEXT:      llvm.return %[[VAL_1]] : !llvm.ptr<f32>
+// CHECK-NEXT:    }
+
+func.func private @ptr2memref(%arg0: !llvm.ptr<f32>) -> memref<?xf32> {
+  %res = "polygeist.pointer2memref"(%arg0) : (!llvm.ptr<f32>) -> memref<?xf32>
+  return %res : memref<?xf32>
+}

--- a/polygeist/test/polygeist-opt/sycl/cast.mlir
+++ b/polygeist/test/polygeist-opt/sycl/cast.mlir
@@ -1,0 +1,30 @@
+// RUN: polygeist-opt --convert-polygeist-to-llvm="use-bare-ptr-memref-call-conv" --split-input-file %s | FileCheck %s
+
+!sycl_array_1_ = !sycl.array<[1], (memref<1xi64>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
+
+// CHECK-LABEL:   llvm.func @test1(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>) -> !llvm.ptr<struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>> {
+// CHECK:           %[[VAL_1:.*]] = llvm.bitcast %[[VAL_0]] : !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to !llvm.ptr<struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>>
+// CHECK:           llvm.return %[[VAL_1]] : !llvm.ptr<struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>>
+// CHECK:         }
+
+func.func @test1(%arg0: memref<?x!sycl_range_1_>) -> memref<?x!sycl_array_1_> {
+  %0 = "sycl.cast"(%arg0) : (memref<?x!sycl_range_1_>) -> memref<?x!sycl_array_1_>
+  func.return %0 : memref<?x!sycl_array_1_>
+}
+
+// -----
+
+// CHECK-LABEL:   llvm.func @test2(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>) -> !llvm.ptr<struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>> {
+// CHECK:           %[[VAL_1:.*]] = llvm.bitcast %[[VAL_0]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to !llvm.ptr<struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>>
+// CHECK:           llvm.return %[[VAL_1]] : !llvm.ptr<struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>>
+// CHECK:         }
+
+!sycl_array_1_ = !sycl.array<[1], (memref<1xi64>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
+func.func @test2(%arg0: memref<?x!sycl_id_1_>) -> memref<?x!sycl_array_1_> {
+  %0 = "sycl.cast"(%arg0) : (memref<?x!sycl_id_1_>) -> memref<?x!sycl_array_1_>
+  func.return %0: memref<?x!sycl_array_1_>
+}

--- a/polygeist/test/polygeist-opt/sycl/cast.mlir
+++ b/polygeist/test/polygeist-opt/sycl/cast.mlir
@@ -28,3 +28,18 @@ func.func @test2(%arg0: memref<?x!sycl_id_1_>) -> memref<?x!sycl_array_1_> {
   %0 = "sycl.cast"(%arg0) : (memref<?x!sycl_id_1_>) -> memref<?x!sycl_array_1_>
   func.return %0: memref<?x!sycl_array_1_>
 }
+
+// -----
+
+// CHECK-LABEL:   llvm.func @test_addrspaces(
+// CHECK-SAME:                               %[[VAL_0:.*]]: !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, 4>) -> !llvm.ptr<struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>, 4> {
+// CHECK:           %[[VAL_1:.*]] = llvm.bitcast %[[VAL_0]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, 4> to !llvm.ptr<struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>, 4>
+// CHECK:           llvm.return %[[VAL_1]] : !llvm.ptr<struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>, 4>
+// CHECK:         }
+
+!sycl_array_1_ = !sycl.array<[1], (memref<1xi64>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
+func.func @test_addrspaces(%arg0: memref<?x!sycl_id_1_, 4>) -> memref<?x!sycl_array_1_, 4> {
+  %0 = "sycl.cast"(%arg0) : (memref<?x!sycl_id_1_, 4>) -> memref<?x!sycl_array_1_, 4>
+  func.return %0: memref<?x!sycl_array_1_, 4>
+}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -166,9 +166,9 @@ SYCL_EXTERNAL void range_size(sycl::range<2> r) {
 
 // CHECK-LLVM: define linkonce_odr spir_func %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* noundef align 8 [[VAL_0:%.*]]) #1 {
 // CHECK-LLVM-NEXT:   [[VAL_2:%.*]] = alloca %"class.sycl::_V1::range.2", align 8
-// CHECK-LLVM-NEXT:   [[VAL_3:%.*]]  = addrspacecast %"class.sycl::_V1::range.2"* [[VAL_2]] to %"class.sycl::_V1::range.2" addrspace(4)*
-// CHECK-LLVM-NEXT:   [[VAL_4:%.*]]  = bitcast %"class.sycl::_V1::nd_range.2" addrspace(4)* [[VAL_0]] to %"class.sycl::_V1::range.2" addrspace(4)*
-// CHECK-LLVM-NEXT:   call spir_func void @_ZN4sycl3_V15rangeILi2EEC1ERKS2_(%"class.sycl::_V1::range.2" addrspace(4)* [[VAL_3]], %"class.sycl::_V1::range.2" addrspace(4)* [[VAL_4]])
+// CHECK-LLVM-NEXT:   [[VAL_3:%.*]] = getelementptr %"class.sycl::_V1::nd_range.2", %"class.sycl::_V1::nd_range.2" addrspace(4)* [[VAL_0]], i32 0, i32 0
+// CHECK-LLVM-NEXT:   [[VAL_4:%.*]] = addrspacecast %"class.sycl::_V1::range.2"* [[VAL_2]] to %"class.sycl::_V1::range.2" addrspace(4)*
+// CHECK-LLVM-NEXT:   call spir_func void @_ZN4sycl3_V15rangeILi2EEC1ERKS2_(%"class.sycl::_V1::range.2" addrspace(4)* [[VAL_4]], %"class.sycl::_V1::range.2" addrspace(4)* [[VAL_3]])
 // CHECK-LLVM-NEXT:   [[VAL_5:%.*]]  = load %"class.sycl::_V1::range.2", %"class.sycl::_V1::range.2"* [[VAL_2]], align 8
 // CHECK-LLVM-NEXT:   ret %"class.sycl::_V1::range.2" [[VAL_5]] 
 // CHECK-LLVM-NEXT: }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -164,6 +164,7 @@ SYCL_EXTERNAL void range_size(sycl::range<2> r) {
 // CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #[[FUNCATTRS]]  
 // CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* %{{.*}})
 
+// VAL_3 has incorrect type. Issue 7972 open in GitHub to address this.
 // CHECK-LLVM: define linkonce_odr spir_func %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* noundef align 8 [[VAL_0:%.*]]) #1 {
 // CHECK-LLVM-NEXT:   [[VAL_2:%.*]] = alloca %"class.sycl::_V1::range.2", align 8
 // CHECK-LLVM-NEXT:   [[VAL_3:%.*]] = getelementptr %"class.sycl::_V1::nd_range.2", %"class.sycl::_V1::nd_range.2" addrspace(4)* [[VAL_0]], i32 0, i32 0

--- a/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
@@ -31,14 +31,13 @@
 
 // CHECK-LLVM-LABEL: define weak_odr spir_kernel void @_ZTSN4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EE
 // CHECK-LLVM-SAME:     (%"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %0, 
-// CHECK-LLVM-SAME:     { { i32 addrspace(1)*, i32 addrspace(1)*, i64, [1 x i64], [1 x i64] } }* noundef byval({ { i32 addrspace(1)*, i32 addrspace(1)*, i64, [1 x i64], [1 x i64] } }) align 8 %1) local_unnamed_addr #0 {
+// CHECK-LLVM-SAME:     { i32 addrspace(1)* }* noundef byval({ i32 addrspace(1)* }) align 8 %1) local_unnamed_addr #0 {
 // CHECK-LLVM-NEXT:  %3 = addrspacecast %"class.sycl::_V1::range.1"* %0 to %"class.sycl::_V1::range.1" addrspace(4)*
 // CHECK-LLVM-NEXT:  %4 = getelementptr %"class.sycl::_V1::range.1", %"class.sycl::_V1::range.1" addrspace(4)* %3, i64 0, i32 0, i32 0, i64 0
 // CHECK-LLVM-NEXT:  %5 = load i64, i64 addrspace(4)* %4, align 8
-// CHECK-LLVM-NEXT:  %.elt1.i = getelementptr inbounds { { i32 addrspace(1)*, i32 addrspace(1)*, i64, [1 x i64], [1 x i64] } }, { { i32 addrspace(1)*, i32 addrspace(1)*, i64, [1 x i64], [1 x i64] } }* %1, i64 0, i32 0, i32 1
-// CHECK-LLVM-NEXT:  %6 = bitcast i32 addrspace(1)** %.elt1.i to i32 addrspace(4)**
+// CHECK-LLVM-NEXT:  %6 = bitcast { i32 addrspace(1)* }* %1 to i32 addrspace(4)**
 // CHECK-LLVM-NEXT:  %7 = addrspacecast i32 addrspace(4)** %6 to i32 addrspace(4)* addrspace(4)*
-// CHECK-LLVM-NEXT:  %.unpack2.i = load i32 addrspace(4)*, i32 addrspace(4)* addrspace(4)* %7, align 8
+// CHECK-LLVM-NEXT:  %.val = load i32 addrspace(4)*, i32 addrspace(4)* addrspace(4)* %7, align 8
 // CHECK-LLVM-NEXT:  %8 = load <3 x i64>, <3 x i64> addrspace(4)* addrspacecast (<3 x i64> addrspace(1)* @__spirv_BuiltInGlobalInvocationId to <3 x i64> addrspace(4)*), align 32
 // CHECK-LLVM-NEXT:  %9 = extractelement <3 x i64> %8, i64 0
 // CHECK-LLVM-NEXT:  %10 = icmp slt i64 %9, 2147483648
@@ -47,7 +46,7 @@
 // CHECK-LLVM-NEXT:  br i1 %.not, label %11, label %14
 // CHECK-LLVM:       11: 
 // CHECK-LLVM-NEXT:    %12 = trunc i64 %9 to i32
-// CHECK-LLVM-NEXT:    %13 = getelementptr i32, i32 addrspace(4)* %.unpack2.i, i64 %9
+// CHECK-LLVM-NEXT:    %13 = getelementptr i32, i32 addrspace(4)* %.val, i64 %9
 // CHECK-LLVM-NEXT:    store i32 %12, i32 addrspace(4)* %13, align 4
 // CHECK-LLVM-NEXT:    br label %14
 // CHECK-LLVM:       14:

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -611,7 +611,6 @@ static int finalize(mlir::MLIRContext &Ctx,
       PM3.addPass(mlir::sycl::createSYCLMethodToSYCLCallPass());
       LowerToLLVMOptions Options(&Ctx);
       Options.dataLayout = DL;
-      // invalid for gemm.c init array
       Options.useBarePtrCallConv = true;
       PM3.addPass(polygeist::createConvertPolygeistToLLVMPass(Options));
       // PM3.addPass(mlir::createLowerFuncToLLVMPass(options));

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -609,11 +609,10 @@ static int finalize(mlir::MLIRContext &Ctx,
       Module->walk([&](mlir::omp::ParallelOp) { LinkOMP = true; });
       mlir::PassManager PM3(&Ctx);
       PM3.addPass(mlir::sycl::createSYCLMethodToSYCLCallPass());
-      PM3.addPass(polygeist::createConvertToLLVMABIPass());
       LowerToLLVMOptions Options(&Ctx);
       Options.dataLayout = DL;
       // invalid for gemm.c init array
-      // options.useBarePtrCallConv = true;
+      Options.useBarePtrCallConv = true;
       PM3.addPass(polygeist::createConvertPolygeistToLLVMPass(Options));
       // PM3.addPass(mlir::createLowerFuncToLLVMPass(options));
       PM3.addPass(polygeist::createLegalizeForSPIRVPass());


### PR DESCRIPTION
Drop `-convert-polygeist-to-llvm-abi` pass and implement its functionality in the regular `-convert-polygeist-to-llvm` pass.

The new pass is implemented in a recursive way and it needs to provide patterns for most operations receiving/returning a memref simply to avoid having it inserted in a struct.

Some memrefs cannot be lowered this way preserving the program semantics. For a memref to be convertible to a pointer, it must:

1. Be ranked;
2. Present identity mapping;
3. Have no dynamic dimensions in the range `[1, n)`.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>