### PR TITLE
[SYCL] Deallocate PiModule when program build failed

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -4957,6 +4957,8 @@ pi_result piProgramBuild(pi_program Program, pi_uint32 NumDevices,
     ZeModule = nullptr;
     Program->State = _pi_program::Invalid;
     Result = mapError(ZeResult);
+    ZE_CALL_NOCHECK(zeModuleDestroy, (ZeModule));
+    ZeModule = nullptr;
   } else {
     // The call to zeModuleCreate does not report an error if there are
     // unresolved symbols because it thinks these could be resolved later via a
@@ -4969,6 +4971,8 @@ pi_result piProgramBuild(pi_program Program, pi_uint32 NumDevices,
       Result = (ZeResult == ZE_RESULT_ERROR_MODULE_LINK_FAILURE)
                    ? PI_ERROR_BUILD_PROGRAM_FAILURE
                    : mapError(ZeResult);
+      ZE_CALL_NOCHECK(zeModuleDestroy, (ZeModule));
+      ZeModule = nullptr;
     }
   }
 


### PR DESCRIPTION
Currently, ZE_DEBG=4 test shows memory leak.
The reason is that we missed the zeModuleDestroy() call when a program build failed.

Signed-off-by: Byoungro So <byoungro.so@intel.com>