### PR TITLE
[SYCL] Add support for templated call operator in functors

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -991,12 +991,17 @@ static QualType GetSYCLKernelObjectType(const FunctionDecl *KernelCaller) {
   return KernelParamTy.getUnqualifiedType();
 }
 
-static CXXMethodDecl *getOperatorParens(const CXXRecordDecl *RD) {
+// Get the call operator function associated with the function object
+// for both templated and non-templated operator()().
+
+static CXXMethodDecl *getFunctorCallOperator(const CXXRecordDecl *RD) {
   DeclarationName Name =
       RD->getASTContext().DeclarationNames.getCXXOperatorName(OO_Call);
   DeclContext::lookup_result Calls = RD->lookup(Name);
 
-  assert(!Calls.empty() && "Missing functor call operator!");
+  if (Calls.empty())
+    return nullptr;
+
   NamedDecl *CallOp = Calls.front();
 
   if (CallOp == nullptr)
@@ -1018,7 +1023,7 @@ GetCallOperatorOfKernelObject(const CXXRecordDecl *KernelObjType) {
   if (KernelObjType->isLambda())
     CallOperator = KernelObjType->getLambdaCallOperator();
   else
-    CallOperator = getOperatorParens(KernelObjType);
+    CallOperator = getFunctorCallOperator(KernelObjType);
   return CallOperator;
 }
 
@@ -2811,7 +2816,7 @@ public:
 };
 
 static bool isESIMDKernelType(const CXXRecordDecl *KernelObjType) {
-  const CXXMethodDecl *OpParens = getOperatorParens(KernelObjType);
+  const CXXMethodDecl *OpParens = getFunctorCallOperator(KernelObjType);
   return (OpParens != nullptr) && OpParens->hasAttr<SYCLSimdAttr>();
 }
 
@@ -4050,7 +4055,7 @@ void Sema::CheckSYCLKernelCall(FunctionDecl *KernelFunc,
 // kernel to wrapped kernel.
 void Sema::copySYCLKernelAttrs(const CXXRecordDecl *KernelObj) {
   // Get the operator() function of the wrapper.
-  CXXMethodDecl *OpParens = getOperatorParens(KernelObj);
+  CXXMethodDecl *OpParens = getFunctorCallOperator(KernelObj);
   assert(OpParens && "invalid kernel object");
 
   typedef std::pair<FunctionDecl *, FunctionDecl *> ChildParentPair;

--- a/clang/test/SemaSYCL/undefined-functor.cpp
+++ b/clang/test/SemaSYCL/undefined-functor.cpp
@@ -19,7 +19,6 @@ class FunctorWithCallOpDefined {
 };
 
 class FunctorWithCallOpTemplated {
-  int x;
   public:
   template <int x = 0>
   void operator()() const {}

--- a/clang/test/SemaSYCL/undefined-functor.cpp
+++ b/clang/test/SemaSYCL/undefined-functor.cpp
@@ -18,6 +18,13 @@ class FunctorWithCallOpDefined {
   void operator()() const {}
 };
 
+class FunctorWithCallOpTemplated {
+  int x;
+  public:
+  template <int x = 0>
+  void operator()() const {}
+};
+
 int main() {
   
   q.submit([&](sycl::handler &cgh) {
@@ -35,6 +42,10 @@ int main() {
   
   q.submit([&](sycl::handler &cgh) {
     cgh.single_task(FunctorWithCallOpDefined{});
+  });
+
+  q.submit([&](sycl::handler &cgh) {
+    cgh.single_task(FunctorWithCallOpTemplated{});
   });
 
 }


### PR DESCRIPTION
This PR enables kernels to be defined as named function object types, where the  operator() member function is templated.

Example:
```
class FunctorWithCallOpTemplated {
  int x;
  public:
  template <int x = 0>
  void operator()() const {}
};

q.submit([&](sycl::handler &cgh) {
    cgh.single_task(FunctorWithCallOpTemplated{});
  });
```