### PR TITLE
[SYCL] Return true in has_kernel for sub-devices

### DIFF
--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -82,9 +82,17 @@ public:
 
   bool has_kernel(const kernel_id &KernelIDCand,
                   const device &DeviceCand) const noexcept {
+    // If the device is in the device list and the kernel ID is in the kernel
+    // bundle, return true.
     for (const device &Device : MDevices)
       if (Device == DeviceCand)
         return has_kernel(KernelIDCand);
+
+    // Otherwise, if the device candidate is a sub-device it is also valid if
+    // its parent is valid.
+    if (!getSyclObjImpl(DeviceCand)->isRootDevice())
+      return has_kernel(KernelIDCand,
+                        DeviceCand.get_info<info::device::parent_device>());
 
     return false;
   }


### PR DESCRIPTION
SYCL 2020 specifies that `kernel_bundle::has_kernel(kernel_id, device)` should return `true` if the kernel is valid for a given device. As such sub-devices where any of its parents are in the kernel bundle should be considered valid. This commit changes the implementation of `has_kernel` to recursively check the parents of a passed sub-device if it is not itself in the `kernel_bundle`'s list of devices.