### PR TITLE
[SYCL] Drain thread pool should not be called on Win

### DIFF
--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -202,8 +202,10 @@ void GlobalHandler::unloadPlugins() {
 }
 
 void GlobalHandler::drainThreadPool() {
+#ifndef _WIN32
   if (MHostTaskThreadPool.Inst)
     MHostTaskThreadPool.Inst->drain();
+#endif
 }
 
 void shutdown() {


### PR DESCRIPTION
Signed-off-by: Tikhomirova, Kseniya <kseniya.tikhomirova@intel.com>

PR #7908 accidentally introduced a behavior that causes lots of timeouts on the CI system on Windows.  
