### PR TITLE
[lldb] Fix build warnings of unhandled SPIRV builtin types

### DIFF
--- a/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
+++ b/lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp
@@ -4966,6 +4966,21 @@ lldb::Encoding TypeSystemClang::GetEncoding(lldb::opaque_compiler_type_t type,
     case clang::BuiltinType::OCLIntelSubgroupAVCImeDualRefStreamin:
       break;
 
+    // SPIRV builtin types.
+    case clang::BuiltinType::SampledOCLImage1dRO:
+    case clang::BuiltinType::SampledOCLImage1dArrayRO:
+    case clang::BuiltinType::SampledOCLImage1dBufferRO:
+    case clang::BuiltinType::SampledOCLImage2dRO:
+    case clang::BuiltinType::SampledOCLImage2dArrayRO:
+    case clang::BuiltinType::SampledOCLImage2dDepthRO:
+    case clang::BuiltinType::SampledOCLImage2dArrayDepthRO:
+    case clang::BuiltinType::SampledOCLImage2dMSAARO:
+    case clang::BuiltinType::SampledOCLImage2dArrayMSAARO:
+    case clang::BuiltinType::SampledOCLImage2dMSAADepthRO:
+    case clang::BuiltinType::SampledOCLImage2dArrayMSAADepthRO:
+    case clang::BuiltinType::SampledOCLImage3dRO:
+      break;
+
     // PowerPC -- Matrix Multiply Assist
     case clang::BuiltinType::VectorPair:
     case clang::BuiltinType::VectorQuad:


### PR DESCRIPTION
These types are introduced in #1945

This PR fix following build warnings:
```
[3204/3298] Building CXX object tools/lldb/source/Plugins/TypeSystem/Clang/CMakeFiles/lldbPluginTypeSystemClang.dir/TypeSystemClang.cpp.o
lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp: In member function ‘virtual lldb::Encoding lldb_private::TypeSystemClang::GetEncoding(lldb::opaque_compiler_type_t, uint64_t&)’:
lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp:4829:12: warning: enumeration value ‘SampledOCLImage1dRO’ not handled in switch [-Wswitch]
     switch (llvm::cast<clang::BuiltinType>(qual_type)->getKind()) {
            ^
lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp:4829:12: warning: enumeration value ‘SampledOCLImage1dArrayRO’ not handled in switch [-Wswitch]
lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp:4829:12: warning: enumeration value ‘SampledOCLImage1dBufferRO’ not handled in switch [-Wswitch]
lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp:4829:12: warning: enumeration value ‘SampledOCLImage2dRO’ not handled in switch [-Wswitch]
lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp:4829:12: warning: enumeration value ‘SampledOCLImage2dArrayRO’ not handled in switch [-Wswitch]
lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp:4829:12: warning: enumeration value ‘SampledOCLImage2dDepthRO’ not handled in switch [-Wswitch]
lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp:4829:12: warning: enumeration value ‘SampledOCLImage2dArrayDepthRO’ not handled in switch [-Wswitch]
lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp:4829:12: warning: enumeration value ‘SampledOCLImage2dMSAARO’ not handled in switch [-Wswitch]
lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp:4829:12: warning: enumeration value ‘SampledOCLImage2dArrayMSAARO’ not handled in switch [-Wswitch]
lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp:4829:12: warning: enumeration value ‘SampledOCLImage2dMSAADepthRO’ not handled in switch [-Wswitch]
lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp:4829:12: warning: enumeration value ‘SampledOCLImage2dArrayMSAADepthRO’ not handled in switch [-Wswitch]
lldb/source/Plugins/TypeSystem/Clang/TypeSystemClang.cpp:4829:12: warning: enumeration value ‘SampledOCLImage3dRO’ not handled in switch [-Wswitch]
```