### PR TITLE
[ESIMD] Fix usage of uninitialized field ESIMDVerifier::ForceStateles…

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/ESIMD/ESIMDVerifier.h
+++ b/llvm/include/llvm/SYCLLowerIR/ESIMD/ESIMDVerifier.h
@@ -20,18 +20,18 @@ namespace llvm {
 class ModulePass;
 
 struct ESIMDVerifierPass : public PassInfoMixin<ESIMDVerifierPass> {
-  ESIMDVerifierPass() : ForceStatelessMem(false) {}
-  ESIMDVerifierPass(bool ForceStatelessMem)
-      : ForceStatelessMem(ForceStatelessMem) {}
+  ESIMDVerifierPass(bool MayNeedForceStatelessMemModeAPI = true)
+      : MayNeedForceStatelessMemModeAPI(MayNeedForceStatelessMemModeAPI) {}
   PreservedAnalyses run(Module &M, ModuleAnalysisManager &);
   static bool isRequired() { return true; }
 
-  // The verifier pass allows more SYCL classes/methods when
-  // stateless memory accesses are enforced.
-  bool ForceStatelessMem;
+  // The verifier pass allows more SYCL classes/methods when stateless
+  // memory accesses are not explicitly disabled by compilation switches.
+  bool MayNeedForceStatelessMemModeAPI;
 };
 
-ModulePass *createESIMDVerifierPass();
+ModulePass *
+createESIMDVerifierPass(bool MayNeedForceStatelessMemModeAPI = true);
 
 } // namespace llvm
 

--- a/llvm/lib/SYCLLowerIR/ESIMD/ESIMDVerifier.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/ESIMDVerifier.cpp
@@ -69,11 +69,12 @@ namespace {
 
 class ESIMDVerifierImpl {
   const Module &M;
-  bool ForceStatelessMem;
+  bool MayNeedForceStatelessMemModeAPI;
 
 public:
-  ESIMDVerifierImpl(const Module &M, bool ForceStatelessMem)
-      : M(M), ForceStatelessMem(ForceStatelessMem) {}
+  ESIMDVerifierImpl(const Module &M, bool MayNeedForceStatelessMemModeAPI)
+      : M(M), MayNeedForceStatelessMemModeAPI(MayNeedForceStatelessMemModeAPI) {
+  }
 
   void verify() {
     SmallPtrSet<const Function *, 8u> Visited;
@@ -136,7 +137,13 @@ public:
             return LegalNameRE.match(Name);
           };
           if (any_of(LegalSYCLFunctions, checkLegalFunc) ||
-              (ForceStatelessMem &&
+              // TODO: Methods listed in LegalSYCLFunctionsInStatelessMode are
+              // indeed required to support ESIMD APIs accepting accessors in
+              // stateless-only mode. This unintentionally opens that API for
+              // unintended usage in user's programs. Can those APIs be
+              // allowed for ESIMD implementation only and not for general
+              // usage?
+              (MayNeedForceStatelessMemModeAPI &&
                any_of(LegalSYCLFunctionsInStatelessMode, checkLegalFunc)))
             continue;
 
@@ -154,7 +161,7 @@ public:
 } // end anonymous namespace
 
 PreservedAnalyses ESIMDVerifierPass::run(Module &M, ModuleAnalysisManager &AM) {
-  ESIMDVerifierImpl(M, ForceStatelessMem).verify();
+  ESIMDVerifierImpl(M, MayNeedForceStatelessMemModeAPI).verify();
   return PreservedAnalyses::all();
 }
 
@@ -162,9 +169,11 @@ namespace {
 
 struct ESIMDVerifier : public ModulePass {
   static char ID;
-  bool ForceStatelessMem;
+  bool MayNeedForceStatelessMemModeAPI;
 
-  ESIMDVerifier() : ModulePass(ID) {
+  ESIMDVerifier(bool MayNeedForceStatelessMemModeAPI = true)
+      : ModulePass(ID),
+        MayNeedForceStatelessMemModeAPI(MayNeedForceStatelessMemModeAPI) {
     initializeESIMDVerifierPass(*PassRegistry::getPassRegistry());
   }
 
@@ -173,7 +182,7 @@ struct ESIMDVerifier : public ModulePass {
   }
 
   bool runOnModule(Module &M) override {
-    ESIMDVerifierImpl(M, ForceStatelessMem).verify();
+    ESIMDVerifierImpl(M, MayNeedForceStatelessMemModeAPI).verify();
     return false;
   }
 };
@@ -187,4 +196,7 @@ INITIALIZE_PASS_BEGIN(ESIMDVerifier, DEBUG_TYPE, "ESIMD-specific IR verifier",
 INITIALIZE_PASS_END(ESIMDVerifier, DEBUG_TYPE, "ESIMD-specific IR verifier",
                     false, false)
 
-ModulePass *llvm::createESIMDVerifierPass() { return new ESIMDVerifier(); }
+ModulePass *
+llvm::createESIMDVerifierPass(bool MayNeedForceStatelessMemModeAPI) {
+  return new ESIMDVerifier(MayNeedForceStatelessMemModeAPI);
+}


### PR DESCRIPTION
…sMem

The field was properly initialized in 'ESIMDVerifierPass` struct, but not in `ESIMDVerifier`.
The first one gets the proper/guarantted value from LangOpts.SYCLESIMDForceStatelessMem, while the second(i.e. ESIMDVerifier) could not do the same as it is initialized from
llvm::createESIMDVerifierPass()

Fixing this issue showed that those SYCL methods that are allowed with -fsycl-esimd-force-stateless-mem, can potentially and legally be used in some other modes, for example, when used in LLVM IR consumed by 'opt' component. Thus the meaning and name of the corresponding fields in ESIMDVerifier and ESIMDVerifierPass structs were renamed from ForceStatelessMem to MayNeedForceStatelessMemModeAPI.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>