### PR TITLE
[SYCL] Add missing include to JITContext.h

### DIFF
--- a/sycl-fusion/jit-compiler/include/JITContext.h
+++ b/sycl-fusion/jit-compiler/include/JITContext.h
@@ -10,6 +10,7 @@
 #define SYCL_FUSION_JIT_COMPILER_JITCONTEXT_H
 
 #include "llvm/IR/LLVMContext.h"
+#include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
 


### PR DESCRIPTION
Fix unique_lock not being found during compilation.