### PR TITLE
[SYCL] Deprecate `get_access` for `host_accessor` in SYCL2020

### DIFF
--- a/sycl/include/sycl/buffer.hpp
+++ b/sycl/include/sycl/buffer.hpp
@@ -503,6 +503,8 @@ public:
         *this, CommandGroupHandler, {}, CodeLoc);
   }
 
+  __SYCL2020_DEPRECATED("get_access() for host_accessor is deprecated, please "
+                        "use get_host_access() instead")
   template <access::mode mode>
   accessor<T, dimensions, mode, access::target::host_buffer,
            access::placeholder::false_t, ext::oneapi::accessor_property_list<>>
@@ -530,6 +532,9 @@ public:
         *this, commandGroupHandler, accessRange, accessOffset, {}, CodeLoc);
   }
 
+  __SYCL2020_DEPRECATED(
+      "get_access(range<Dimensions>, id<Dimensions>) for host_accessor is "
+      "deprecated, please use get_host_access() instead")
   template <access::mode mode>
   accessor<T, dimensions, mode, access::target::host_buffer,
            access::placeholder::false_t, ext::oneapi::accessor_property_list<>>

--- a/sycl/include/sycl/buffer.hpp
+++ b/sycl/include/sycl/buffer.hpp
@@ -503,9 +503,9 @@ public:
         *this, CommandGroupHandler, {}, CodeLoc);
   }
 
-  __SYCL2020_DEPRECATED("get_access() for host_accessor is deprecated, please "
-                        "use get_host_access() instead")
   template <access::mode mode>
+  __SYCL2020_DEPRECATED("get_access for host_accessor is deprecated, please "
+                        "use get_host_access instead")
   accessor<T, dimensions, mode, access::target::host_buffer,
            access::placeholder::false_t, ext::oneapi::accessor_property_list<>>
   get_access(
@@ -532,10 +532,9 @@ public:
         *this, commandGroupHandler, accessRange, accessOffset, {}, CodeLoc);
   }
 
-  __SYCL2020_DEPRECATED(
-      "get_access(range<Dimensions>, id<Dimensions>) for host_accessor is "
-      "deprecated, please use get_host_access() instead")
   template <access::mode mode>
+  __SYCL2020_DEPRECATED("get_access for host_accessor is deprecated, please "
+                        "use get_host_access instead")
   accessor<T, dimensions, mode, access::target::host_buffer,
            access::placeholder::false_t, ext::oneapi::accessor_property_list<>>
   get_access(

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -64,6 +64,17 @@ int main() {
   size_t BufferSize = Buffer.size();
   // expected-warning@+1 {{'get_size' is deprecated: get_size() is deprecated, please use byte_size() instead}}
   size_t BufferGetSize = Buffer.get_size();
+  {
+    // expected-warning@+2 {{'get_access' is deprecated: get_access for host_accessor is deprecated, please use get_host_access instead}}
+    // expected-warning@+1 {{'get_access<sycl::access::mode::read_write>' is deprecated: get_access for host_accessor is deprecated, please use get_host_access instead}}
+    auto acc = Buffer.get_access<sycl::access_mode::read_write>();
+  }
+  {
+    // expected-warning@+3 {{'get_access' is deprecated: get_access for host_accessor is deprecated, please use get_host_access instead}}
+    // expected-warning@+2 {{'get_access<sycl::access::mode::read_write>' is deprecated: get_access for host_accessor is deprecated, please use get_host_access instead}}
+    auto acc =
+        Buffer.get_access<sycl::access_mode::read_write>(sycl::range<1>(0));
+  }
 
   sycl::vec<int, 2> Vec(1, 2);
   // expected-warning@+1{{'get_count' is deprecated: get_count() is deprecated, please use size() instead}}


### PR DESCRIPTION
Deprecate `buffer::get_access` methods for `host_accessor` in SYCL2020. 