### PR TITLE
[SYCL-MLIR] Add back the sycl commit that changes the default optimization level

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4999,6 +4999,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-Wno-sycl-strict");
     }
 
+    // Set O2 optimization level by default
+    if (!Args.getLastArg(options::OPT_O_Group))
+      CmdArgs.push_back("-O2");
+
     // Add the integration header option to generate the header.
     StringRef Header(D.getIntegrationHeader(Input.getBaseInput()));
     if (!Header.empty()) {

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -579,10 +579,9 @@ static bool FixupInvocation(CompilerInvocation &Invocation,
 static unsigned getOptimizationLevel(ArgList &Args, InputKind IK,
                                      DiagnosticsEngine &Diags) {
   unsigned DefaultOpt = llvm::CodeGenOpt::None;
-  if (((IK.getLanguage() == Language::OpenCL ||
-        IK.getLanguage() == Language::OpenCLCXX) &&
-       !Args.hasArg(OPT_cl_opt_disable)) ||
-      Args.hasArg(OPT_fsycl_is_device))
+  if ((IK.getLanguage() == Language::OpenCL ||
+       IK.getLanguage() == Language::OpenCLCXX) &&
+      !Args.hasArg(OPT_cl_opt_disable))
     DefaultOpt = llvm::CodeGenOpt::Default;
 
   if (Arg *A = Args.getLastArg(options::OPT_O_Group)) {

--- a/clang/test/CodeGenSYCL/address-space-cond-op.cpp
+++ b/clang/test/CodeGenSYCL/address-space-cond-op.cpp
@@ -5,27 +5,27 @@ struct S {
   unsigned short x;
 };
 
-// CHECK-LABEL: @_Z3foobR1SS_(
+// CHECK-LABEL: define {{[^@]+}}@_Z3foobR1SS_(
 // CHECK:  entry:
 // CHECK-NEXT:    [[COND_ADDR:%.*]] = alloca i8, align 1
 // CHECK-NEXT:    [[LHS_ADDR:%.*]] = alloca ptr addrspace(4), align 8
 // CHECK-NEXT:    [[COND_ADDR_ASCAST:%.*]] = addrspacecast ptr [[COND_ADDR]] to ptr addrspace(4)
 // CHECK-NEXT:    [[LHS_ADDR_ASCAST:%.*]] = addrspacecast ptr [[LHS_ADDR]] to ptr addrspace(4)
 // CHECK-NEXT:    [[FROMBOOL:%.*]] = zext i1 [[COND:%.*]] to i8
-// CHECK-NEXT:    store i8 [[FROMBOOL]], ptr addrspace(4) [[COND_ADDR_ASCAST]], align 1, [[TBAA12:!tbaa !.*]]
-// CHECK-NEXT:    store ptr addrspace(4) [[LHS:%.*]], ptr addrspace(4) [[LHS_ADDR_ASCAST]], align 8, [[TBAA5:!tbaa !.*]]
+// CHECK-NEXT:    store i8 [[FROMBOOL]], ptr addrspace(4) [[COND_ADDR_ASCAST]], align 1
+// CHECK-NEXT:    store ptr addrspace(4) [[LHS:%.*]], ptr addrspace(4) [[LHS_ADDR_ASCAST]], align 8
 // CHECK-NEXT:    [[RHS_ASCAST:%.*]] = addrspacecast ptr [[RHS:%.*]] to ptr addrspace(4)
-// CHECK-NEXT:    [[TMP0:%.*]] = load i8, ptr addrspace(4) [[COND_ADDR_ASCAST]], align 1, [[TBAA12]], [[RNG14:!range !.*]]
+// CHECK-NEXT:    [[TMP0:%.*]] = load i8, ptr addrspace(4) [[COND_ADDR_ASCAST]], align 1
 // CHECK-NEXT:    [[TOBOOL:%.*]] = trunc i8 [[TMP0]] to i1
 // CHECK-NEXT:    br i1 [[TOBOOL]], label [[COND_TRUE:%.*]], label [[COND_FALSE:%.*]]
 // CHECK:       cond.true:
-// CHECK-NEXT:    [[TMP1:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[LHS_ADDR_ASCAST]], align 8, [[TBAA5]]
+// CHECK-NEXT:    [[TMP1:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[LHS_ADDR_ASCAST]], align 8
 // CHECK-NEXT:    br label [[COND_END:%.*]]
 // CHECK:       cond.false:
 // CHECK-NEXT:    br label [[COND_END]]
 // CHECK:       cond.end:
 // CHECK-NEXT:    [[COND_LVALUE:%.*]] = phi ptr addrspace(4) [ [[TMP1]], [[COND_TRUE]] ], [ [[RHS_ASCAST]], [[COND_FALSE]] ]
-// CHECK-NEXT:    call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) align 2 %agg.result, ptr addrspace(4) align 2 [[COND_LVALUE]], i64 2, i1 false), !tbaa.struct !{{[0-9]+}}
+// CHECK-NEXT:    call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) align 2 [[AGG_RESULT:%.*]], ptr addrspace(4) align 2 [[COND_LVALUE]], i64 2, i1 false)
 // CHECK-NEXT:    ret void
 //
 S foo(bool cond, S &lhs, S rhs) {

--- a/clang/test/CodeGenSYCL/check-direct-attribute-propagation.cpp
+++ b/clang/test/CodeGenSYCL/check-direct-attribute-propagation.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fno-sycl-force-inline-kernel-lambda -fsycl-is-device -internal-isystem %S/Inputs -triple spir64-unknown-unknown -disable-llvm-passes -sycl-std=2020 -opaque-pointers -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -O2 -fno-sycl-force-inline-kernel-lambda -fsycl-is-device -internal-isystem %S/Inputs -triple spir64-unknown-unknown -disable-llvm-passes -sycl-std=2020 -opaque-pointers -emit-llvm -o - %s | FileCheck %s
 
 // Tests for IR of [[intel::scheduler_target_fmax_mhz()]], [[intel::num_simd_work_items()]],
 // [[intel::no_global_work_offset()]], [[intel::max_global_work_dim()]], [[sycl::reqd_sub_group_size()]],

--- a/clang/test/CodeGenSYCL/const-wg-init.cpp
+++ b/clang/test/CodeGenSYCL/const-wg-init.cpp
@@ -15,6 +15,5 @@ int main() {
     const int WG_CONST = 10;
   });
   // CHECK:  store i32 10, ptr addrspace(4) addrspacecast (ptr addrspace(3) @{{.*}}WG_CONST{{.*}} to ptr addrspace(4))
-  // CHECK:  %{{[0-9]+}} = call ptr @llvm.invariant.start.p4(i64 4, ptr addrspace(4) addrspacecast (ptr addrspace(3) @{{.*}}WG_CONST{{.*}} to ptr addrspace(4)))
   return 0;
 }

--- a/clang/test/CodeGenSYCL/functionptr-addrspace.cpp
+++ b/clang/test/CodeGenSYCL/functionptr-addrspace.cpp
@@ -7,7 +7,7 @@ __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 
-// CHECK: define dso_local spir_func{{.*}}invoke_function{{.*}}(ptr nocapture noundef %fptr, ptr addrspace(4) nocapture noundef %ptr)
+// CHECK: define dso_local spir_func{{.*}}invoke_function{{.*}}(ptr noundef %fptr, ptr addrspace(4) noundef %ptr)
 void invoke_function(int (*fptr)(), int *ptr) {}
 
 int f() { return 0; }

--- a/clang/test/CodeGenSYCL/group-local-memory.cpp
+++ b/clang/test/CodeGenSYCL/group-local-memory.cpp
@@ -1,7 +1,7 @@
 // Check that SYCLLowerWGLocalMemory pass is added to the SYCL device
 // compilation pipeline with the inliner pass (new Pass Manager).
 
-// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -emit-llvm \
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -emit-llvm -O2 \
 // RUN:   -mdebug-pass Structure %s -o /dev/null 2>&1 \
 // RUN:   | FileCheck %s -check-prefixes=CHECK-INL,CHECK
 

--- a/clang/test/CodeGenSYCL/inline_asm.cpp
+++ b/clang/test/CodeGenSYCL/inline_asm.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -opaque-pointers -emit-llvm -x c++ %s -o - | FileCheck %s
+// RUN: %clang_cc1 -O1 -fsycl-is-device -triple spir64-unknown-unknown -opaque-pointers -emit-llvm -x c++ %s -o - | FileCheck %s
 
 class kernel;
 

--- a/clang/test/CodeGenSYCL/inlining.cpp
+++ b/clang/test/CodeGenSYCL/inlining.cpp
@@ -1,4 +1,5 @@
-// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown %s -S -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -O1 -fsycl-is-device -triple spir64-unknown-unknown %s -S -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -O0 -fsycl-is-device -triple spir64-unknown-unknown %s -S -emit-llvm -o - | FileCheck %s --check-prefix=CHECK-O0
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
@@ -6,6 +7,7 @@ __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
 }
 
 int main() {
+  // CHECK-O0: noinline
   // CHECK-NOT: noinline
   kernel_single_task<class kernel_function>([]() {});
   return 0;

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -triple spir64-unknown-unknown -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
+// RUN: %clang_cc1 -O2 -triple spir64-unknown-unknown -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 // CHECK: br label %for.cond,   !llvm.loop ![[MD_DLP:[0-9]+]]
 // CHECK: br label %for.cond,   !llvm.loop ![[MD_II:[0-9]+]]

--- a/clang/test/CodeGenSYCL/max-concurrency.cpp
+++ b/clang/test/CodeGenSYCL/max-concurrency.cpp
@@ -15,7 +15,7 @@
 // CHECK: %inc = add nsw i32 [[TMP2]], 1
 // CHECK: store i32 %inc, ptr addrspace(4) %i.ascast, align 4
 // CHECK: br label %for.cond,   !llvm.loop ![[MD_MC:[0-9]+]]
-// CHECK: store i32 %inc10, ptr addrspace(4) %i1.ascast, align 4
+// CHECK: store i32 %inc8, ptr addrspace(4) %i1.ascast, align 4
 // CHECK: br label %for.cond2,  !llvm.loop ![[MD_MC_1:[0-9]+]]
 // CHECK: ret void
 
@@ -23,18 +23,14 @@
 // CHECK: entry:
 // CHECK: [[F1:%.*]] = alloca [[CLASS_F1:%.*]], align 1
 // CHECK: [[F1_ASCAST:%.*]] = addrspacecast ptr [[F1]] to ptr addrspace(4)
-// CHECK: call void @llvm.lifetime.start.p0(i64 1, ptr [[F1]])
 // CHECK: call spir_func void @_ZNK8Functor1clEv(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) [[F1_ASCAST]])
-// CHECK: call void @llvm.lifetime.end.p0(i64 1, ptr [[F1]])
 // CHECK: ret void
 
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name4() [[ATTR0]] {{.*}} !max_concurrency ![[NUM1:[0-9]+]]
 // CHECK: entry
 // CHECK: [[F3:%.*]] = alloca [[CLASS_F3:%.*]], align 1
 // CHECK: [[F3_ASCAST:%.*]] = addrspacecast ptr [[F3]] to ptr addrspace(4)
-// CHECK: call void @llvm.lifetime.start.p0(i64 1, ptr [[F3]])
 // CHECK: call spir_func void @_ZNK8Functor3ILi4EEclEv(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) [[F3_ASCAST]])
-// CHECK: call void @llvm.lifetime.end.p0(i64 1, ptr [[F3]]
 // CHECK: ret void
 
 // CHECK: define linkonce_odr spir_func void @_ZNK8Functor3ILi4EEclEv
@@ -49,9 +45,7 @@
 // CHECK: entry:
 // CHECK: [[H1:%.*]] = alloca [[H:%.*]], align 1
 // CHECK: [[H2:%.*]] = addrspacecast ptr [[H1]] to ptr addrspace(4)
-// CHECK: call void @llvm.lifetime.start.p0(i64 1, ptr [[H1]])
 // CHECK: call spir_func void @_ZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEv(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) [[H2]])
-// CHECK: call void @llvm.lifetime.end.p0(i64 1, ptr [[H1]])
 // CHECK: ret void
 
 // CHECK: define {{.*}}spir_func void @_ZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEv

--- a/clang/test/CodeGenSYCL/no-opaque-ptr-kernel_binding_decls.cpp
+++ b/clang/test/CodeGenSYCL/no-opaque-ptr-kernel_binding_decls.cpp
@@ -33,11 +33,11 @@ void foo() {
 
 // Store the int and the float into the struct created
 // CHECK: %x = getelementptr inbounds %class.anon, %class.anon addrspace(4)* %__SYCLKernel{{.*}}, i32 0, i32 0
-// CHECK: %1 = load i32, i32 addrspace(4)* %_arg_x.addr
-// CHECK: store i32 %1, i32 addrspace(4)* %x
+// CHECK: %0 = load i32, i32 addrspace(4)* %_arg_x.addr
+// CHECK: store i32 %0, i32 addrspace(4)* %x
 // CHECK: %f2 = getelementptr inbounds %class.anon, %class.anon addrspace(4)* %__SYCLKernel{{.*}}, i32 0, i32 1
-// CHECK: %2 = load float, float addrspace(4)* %_arg_f2.addr
-// CHECK: store float %2, float addrspace(4)* %f2
+// CHECK: %1 = load float, float addrspace(4)* %_arg_f2.addr
+// CHECK: store float %1, float addrspace(4)* %f2
 
 // Call the lambda
 // CHECK: call spir_func void @{{.*}}foo{{.*}}(%class.anon addrspace(4)* {{.*}} %__SYCLKernel{{.*}})

--- a/clang/test/CodeGenSYCL/no-opaque-ptrs-sycl-intelfpga-bitint.cpp
+++ b/clang/test/CodeGenSYCL/no-opaque-ptrs-sycl-intelfpga-bitint.cpp
@@ -9,10 +9,16 @@
 
 // CHECK: define{{.*}} void @_Z3fooDB4096_S_(i4096 addrspace(4)* {{.*}} sret(i4096) align 8 %agg.result, i4096* {{.*}} byval(i4096) align 8 %[[ARG1:[0-9]+]], i4096* {{.*}} byval(i4096) align 8 %[[ARG2:[0-9]+]])
 signed _BitInt(4096) foo(signed _BitInt(4096) a, signed _BitInt(4096) b) {
-  // CHECK: %[[VAR_A:a]] = load i4096, i4096* %[[ARG1]], align 8
-  // CHECK: %[[VAR_B:b]] = load i4096, i4096* %[[ARG2]], align 8
-  // CHECK: %[[RES:div]] = sdiv i4096 %[[VAR_A]], %[[VAR_B]]
-  // CHECK: store i4096 %[[RES]], i4096 addrspace(4)* %agg.result, align 8
+  // CHECK: %a.addr.ascast = addrspacecast i4096* %a.addr to i4096 addrspace(4)*
+  // CHECK: %b.addr.ascast = addrspacecast i4096* %b.addr to i4096 addrspace(4)*
+  // CHECK: %a = load i4096, i4096* %[[ARG1]], align 8
+  // CHECK: %b = load i4096, i4096* %[[ARG2]], align 8
+  // CHECK: store i4096 %a, i4096 addrspace(4)* %a.addr.ascast, align 8
+  // CHECK: store i4096 %b, i4096 addrspace(4)* %b.addr.ascast, align 8
+  // CHECK: %2 = load i4096, i4096 addrspace(4)* %a.addr.ascast, align 8
+  // CHECK: %3 = load i4096, i4096 addrspace(4)* %b.addr.ascast, align 8
+  // CHECK: %div = sdiv i4096 %2, %3
+  // CHECK: store i4096 %div, i4096 addrspace(4)* %agg.result, align 8
   // CHECK: ret void
   return a / b;
 }

--- a/clang/test/CodeGenSYCL/no_opaque_address-space-cond-op.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_address-space-cond-op.cpp
@@ -5,29 +5,29 @@ struct S {
   unsigned short x;
 };
 
-// CHECK-LABEL: @_Z3foobR1SS_(
+// CHECK-LABEL: define {{[^@]+}}@_Z3foobR1SS_(
 // CHECK:  entry:
 // CHECK-NEXT:    [[COND_ADDR:%.*]] = alloca i8, align 1
-// CHECK-NEXT:    [[LHS_ADDR:%.*]] = alloca [[STRUCT__ZTS1S_S:%.*]] addrspace(4)*, align 8
+// CHECK-NEXT:    [[LHS_ADDR:%.*]] = alloca [[STRUCT_S:%.*]] addrspace(4)*, align 8
 // CHECK-NEXT:    [[COND_ADDR_ASCAST:%.*]] = addrspacecast i8* [[COND_ADDR]] to i8 addrspace(4)*
-// CHECK-NEXT:    [[LHS_ADDR_ASCAST:%.*]] = addrspacecast [[STRUCT__ZTS1S_S]] addrspace(4)** [[LHS_ADDR]] to [[STRUCT__ZTS1S_S]] addrspace(4)* addrspace(4)*
+// CHECK-NEXT:    [[LHS_ADDR_ASCAST:%.*]] = addrspacecast [[STRUCT_S]] addrspace(4)** [[LHS_ADDR]] to [[STRUCT_S]] addrspace(4)* addrspace(4)*
 // CHECK-NEXT:    [[FROMBOOL:%.*]] = zext i1 [[COND:%.*]] to i8
-// CHECK-NEXT:    store i8 [[FROMBOOL]], i8 addrspace(4)* [[COND_ADDR_ASCAST]], align 1, [[TBAA12:!tbaa !.*]]
-// CHECK-NEXT:    store [[STRUCT__ZTS1S_S]] addrspace(4)* [[LHS:%.*]], [[STRUCT__ZTS1S_S]] addrspace(4)* addrspace(4)* [[LHS_ADDR_ASCAST]], align 8, [[TBAA5:!tbaa !.*]]
-// CHECK-NEXT:    [[RHS_ASCAST:%.*]] = addrspacecast %struct.S* [[RHS:%.*]] to [[STRUCT__ZTS1S_S]] addrspace(4)*
-// CHECK-NEXT:    [[TMP0:%.*]] = load i8, i8 addrspace(4)* [[COND_ADDR_ASCAST]], align 1, [[TBAA12]], [[RNG14:!range !.*]]
+// CHECK-NEXT:    store i8 [[FROMBOOL]], i8 addrspace(4)* [[COND_ADDR_ASCAST]], align 1
+// CHECK-NEXT:    store [[STRUCT_S]] addrspace(4)* [[LHS:%.*]], [[STRUCT_S]] addrspace(4)* addrspace(4)* [[LHS_ADDR_ASCAST]], align 8
+// CHECK-NEXT:    [[RHS_ASCAST:%.*]] = addrspacecast %struct.S* [[RHS:%.*]] to [[STRUCT_S]] addrspace(4)*
+// CHECK-NEXT:    [[TMP0:%.*]] = load i8, i8 addrspace(4)* [[COND_ADDR_ASCAST]], align 1
 // CHECK-NEXT:    [[TOBOOL:%.*]] = trunc i8 [[TMP0]] to i1
 // CHECK-NEXT:    br i1 [[TOBOOL]], label [[COND_TRUE:%.*]], label [[COND_FALSE:%.*]]
 // CHECK:       cond.true:
-// CHECK-NEXT:    [[TMP1:%.*]] = load [[STRUCT__ZTS1S_S]] addrspace(4)*, [[STRUCT__ZTS1S_S]] addrspace(4)* addrspace(4)* [[LHS_ADDR_ASCAST]], align 8, [[TBAA5]]
+// CHECK-NEXT:    [[TMP1:%.*]] = load [[STRUCT_S]] addrspace(4)*, [[STRUCT_S]] addrspace(4)* addrspace(4)* [[LHS_ADDR_ASCAST]], align 8
 // CHECK-NEXT:    br label [[COND_END:%.*]]
 // CHECK:       cond.false:
 // CHECK-NEXT:    br label [[COND_END]]
 // CHECK:       cond.end:
-// CHECK-NEXT:    [[COND_LVALUE:%.*]] = phi [[STRUCT__ZTS1S_S]] addrspace(4)* [ [[TMP1]], [[COND_TRUE]] ], [ [[RHS_ASCAST]], [[COND_FALSE]] ]
-// CHECK-NEXT:    [[TMP2:%.*]] = bitcast [[STRUCT__ZTS1S_S]] addrspace(4)* [[AGG_RESULT:%.*]] to i8 addrspace(4)*
-// CHECK-NEXT:    [[TMP3:%.*]] = bitcast [[STRUCT__ZTS1S_S]] addrspace(4)* [[COND_LVALUE]] to i8 addrspace(4)*
-// CHECK-NEXT:    call void @llvm.memcpy.p4i8.p4i8.i64(i8 addrspace(4)* align 2 [[TMP2]], i8 addrspace(4)* align 2 [[TMP3]], i64 2, i1 false), !tbaa.struct !{{[0-9]+}}
+// CHECK-NEXT:    [[COND_LVALUE:%.*]] = phi [[STRUCT_S]] addrspace(4)* [ [[TMP1]], [[COND_TRUE]] ], [ [[RHS_ASCAST]], [[COND_FALSE]] ]
+// CHECK-NEXT:    [[TMP2:%.*]] = bitcast [[STRUCT_S]] addrspace(4)* [[AGG_RESULT:%.*]] to i8 addrspace(4)*
+// CHECK-NEXT:    [[TMP3:%.*]] = bitcast [[STRUCT_S]] addrspace(4)* [[COND_LVALUE]] to i8 addrspace(4)*
+// CHECK-NEXT:    call void @llvm.memcpy.p4i8.p4i8.i64(i8 addrspace(4)* align 2 [[TMP2]], i8 addrspace(4)* align 2 [[TMP3]], i64 2, i1 false)
 // CHECK-NEXT:    ret void
 //
 S foo(bool cond, S &lhs, S rhs) {

--- a/clang/test/CodeGenSYCL/no_opaque_check-direct-attribute-propagation.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_check-direct-attribute-propagation.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fno-sycl-force-inline-kernel-lambda -fsycl-is-device -internal-isystem %S/Inputs -triple spir64-unknown-unknown -disable-llvm-passes -sycl-std=2020 -no-opaque-pointers -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -fno-sycl-force-inline-kernel-lambda -O2 -fsycl-is-device -internal-isystem %S/Inputs -triple spir64-unknown-unknown -disable-llvm-passes -sycl-std=2020 -no-opaque-pointers -emit-llvm -o - %s | FileCheck %s
 
 // Tests for IR of [[intel::scheduler_target_fmax_mhz()]], [[intel::num_simd_work_items()]],
 // [[intel::no_global_work_offset()]], [[intel::max_global_work_dim()]], [[sycl::reqd_sub_group_size()]],

--- a/clang/test/CodeGenSYCL/no_opaque_const-wg-init.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_const-wg-init.cpp
@@ -15,7 +15,6 @@ int main() {
     const int WG_CONST = 10;
   });
 // CHECK:  store i32 10, i32 addrspace(4)* addrspacecast (i32 addrspace(3)* @{{.*}}WG_CONST{{.*}} to i32 addrspace(4)*)
-// CHECK:  %{{[0-9]+}} = call {}* @llvm.invariant.start.p4i8(i64 4, i8 addrspace(4)* addrspacecast (i8 addrspace(3)* bitcast (i32 addrspace(3)* @{{.*}}WG_CONST{{.*}} to i8 addrspace(3)*) to i8 addrspace(4)*))
 
   return 0;
 }

--- a/clang/test/CodeGenSYCL/no_opaque_inline_asm.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_inline_asm.cpp
@@ -5,15 +5,20 @@ class kernel;
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [100 x i32], align 4
-  // CHECK: %[[IDX:.*]] = getelementptr inbounds [100 x i32], [100 x i32]* %[[ARRAY_A]], i64 0, i64 0
-  // CHECK: %[[IDX4:.*]] = addrspacecast i32* %[[IDX]] to i32 addrspace(4)*
+  // CHECK: %[[I:[0-9a-z]+]] = alloca i32, align 4
+  // CHECK: %[[ARRAY_A]].ascast = addrspacecast [100 x i32]* %[[ARRAY_A]] to [100 x i32] addrspace(4)*
+  // CHECK: %[[I]].ascast = addrspacecast i32* %[[I]] to i32 addrspace(4)*
+  // CHECK: store i32 0, i32 addrspace(4)* %[[I]].ascast, align 4
+  // CHECK: %0 = load i32, i32 addrspace(4)* %[[I]].ascast, align 4
+  // CHECK: %[[IDXPROM:[0-9a-z]+]] = sext i32 %0 to i64
+  // CHECK: %[[IDX:.*]] = getelementptr inbounds [100 x i32], [100 x i32] addrspace(4)* %[[ARRAY_A]].ascast, i64 0, i64 %[[IDXPROM]]
   int a[100], i = 0;
   // CHECK-NEXT: call void asm sideeffect
   // CHECK: ".decl V52 v_type=G type=d num_elts=16 align=GRF
   // CHECK: svm_gather.4.1 (M1, 16) $0.0 V52.0
   // CHECK: add(M1, 16) V52(0, 0)<1> V52(0, 0)<1; 1, 0> 0x1
   // CHECK: svm_scatter.4.1 (M1, 16) $0.0 V52.0",
-  // CHECK: "rw"(i32 addrspace(4)* %[[IDX4]])
+  // CHECK: "rw"(i32 addrspace(4)* %[[IDX]])
   // TODO: nonnull attribute missing?
   asm volatile(".decl V52 v_type=G type=d num_elts=16 align=GRF\n"
                "svm_gather.4.1 (M1, 16) %0.0 V52.0\n"

--- a/clang/test/CodeGenSYCL/no_opaque_max-concurrency.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_max-concurrency.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fno-sycl-force-inline-kernel-lambda -fsycl-is-device -internal-isystem %S/Inputs -disable-llvm-passes -triple spir64-unknown-unknown -sycl-std=2020 -no-opaque-pointers -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -O2 -fno-sycl-force-inline-kernel-lambda -fsycl-is-device -internal-isystem %S/Inputs -disable-llvm-passes -triple spir64-unknown-unknown -sycl-std=2020 -no-opaque-pointers -emit-llvm -o - %s | FileCheck %s
 
 #include "sycl.hpp"
 

--- a/clang/test/CodeGenSYCL/no_opaque_sampler.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_sampler.cpp
@@ -5,8 +5,6 @@
 // CHECK: [[ANON:%[a-zA-Z0-9_]+]] = alloca %class.anon, align 8
 // CHECK: [[ANONCAST:%[a-zA-Z0-9_.]+]] = addrspacecast %class.anon* [[ANON]] to %class.anon addrspace(4)*
 // CHECK: store %opencl.sampler_t addrspace(2)* [[SAMPLER_ARG]], %opencl.sampler_t addrspace(2)* addrspace(4)* [[SAMPLER_ARG]].addr.ascast, align 8
-// CHECK-NEXT: [[BITCAST:%[0-9]+]] = bitcast %class.anon* [[ANON]] to i8*
-// CHECK-NEXT: call void @llvm.lifetime.start.p0i8(i64 8, i8* [[BITCAST]]) #4
 // CHECK-NEXT: [[GEP:%[a-zA-z0-9]+]]  = getelementptr inbounds %class.anon, %class.anon addrspace(4)* [[ANONCAST]], i32 0, i32 0
 // CHECK-NEXT: [[LOAD_SAMPLER_ARG:%[0-9]+]] = load %opencl.sampler_t addrspace(2)*, %opencl.sampler_t addrspace(2)* addrspace(4)* [[SAMPLER_ARG]].addr.ascast, align 8
 // CHECK-NEXT: call spir_func void @{{[a-zA-Z0-9_]+}}(%"class.sycl::_V1::sampler" addrspace(4)* {{[^,]*}} [[GEP]], %opencl.sampler_t addrspace(2)* [[LOAD_SAMPLER_ARG]])

--- a/clang/test/CodeGenSYCL/no_opaque_stall_enable_device.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_stall_enable_device.cpp
@@ -26,12 +26,12 @@ public:
 int main() {
   q.submit([&](handler &h) {
     // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel1() {{.*}} !stall_enable ![[NUM4:[0-9]+]]
-    // CHECK: define {{.*}}spir_func void @{{.*}}FuncObjclEv(%struct.{{.*}}FuncObj addrspace(4)* noundef align 1 dereferenceable_or_null(1) %this) #3 comdat align 2{{.*}} !stall_enable ![[NUM4]]
+    // CHECK: define {{.*}}spir_func void @{{.*}}FuncObjclEv(%struct.{{.*}}FuncObj addrspace(4)* noundef align 1 dereferenceable_or_null(1) %this) #2 comdat align 2{{.*}} !stall_enable ![[NUM4]]
     h.single_task<class test_kernel1>(
         FuncObj());
 
     // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel2() {{.*}} !stall_enable ![[NUM4]]
-    // CHECK define {{.*}}spir_func void @{{.*}}FooclEv(%class._ZTS3Foo.Foo addrspace(4)* noundef align 1 dereferenceable_or_null(1) %this) #3 comdat align 2{{.*}} !stall_enable ![[NUM4]]
+    // CHECK define {{.*}}spir_func void @{{.*}}FooclEv(%class._ZTS3Foo.Foo addrspace(4)* noundef align 1 dereferenceable_or_null(1) %this) #2 comdat align 2{{.*}} !stall_enable ![[NUM4]]
     Foo f;
     h.single_task<class test_kernel2>(f);
 
@@ -47,7 +47,7 @@ int main() {
     // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel4()
     // CHECK-NOT: !stall_enable
     // CHECK-SAME: {
-    // CHECK: define {{.*}}spir_func void @{{.*}}func1{{.*}}(%class.anon{{.*}} addrspace(4)* noundef align 1 dereferenceable_or_null(1) %this) #4 align 2{{.*}} !stall_enable ![[NUM4]]
+    // CHECK: define {{.*}}spir_func void @{{.*}}func1{{.*}}(%class.anon{{.*}} addrspace(4)* noundef align 1 dereferenceable_or_null(1) %this) #2 align 2{{.*}} !stall_enable ![[NUM4]]
     h.single_task<class test_kernel4>(
         []() { func1(); });
 

--- a/clang/test/CodeGenSYCL/no_opaque_stream.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_stream.cpp
@@ -13,8 +13,9 @@
 
 // Alloca and addrspace casts for kernel parameters
 // CHECK: [[ARG:%[a-zA-Z0-9_]+]].addr = alloca i8 addrspace(1)*, align 8
-// CHECK: [[ARG:%[a-zA-Z0-9_]+]].addr.ascast = addrspacecast i8 addrspace(1)** [[ARG]].addr to i8 addrspace(1)* addrspace(4)*
-// CHECK: [[ARG_LOAD:%[a-zA-Z0-9_]+]] = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(4)* [[ARG]].addr.ascast, align 8,
+// CHECK: [[ARG]].addr.ascast = addrspacecast i8 addrspace(1)** [[ARG]].addr to i8 addrspace(1)* addrspace(4)*
+// CHECK: store i8 addrspace(1)* [[ARG]], i8 addrspace(1)* addrspace(4)* [[ARG]].addr.ascast, align 8
+// CHECK: [[ARG_LOAD:%[a-zA-Z0-9_]+]] = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(4)* [[ARG]].addr.ascast, align 8
 
 // Check __init and __finalize method calls
 // CHECK:  call spir_func void @{{.*}}__init{{.*}}(%{{.*}}sycl::_V1::stream" addrspace(4)* noundef align 4 dereferenceable_or_null(16) %{{[a-zA-Z0-9_]+}}, i8 addrspace(1)* noundef [[ARG_LOAD]], %[[RANGE_TYPE]]* noundef byval(%[[RANGE_TYPE]]) {{.*}}%{{.*}}

--- a/clang/test/CodeGenSYCL/remove-restriction-builtin-printf.cpp
+++ b/clang/test/CodeGenSYCL/remove-restriction-builtin-printf.cpp
@@ -10,7 +10,7 @@ int main() {
   q.submit([&](handler &h) {
     // CHECK: define {{.*}}spir_kernel {{.*}}
     h.single_task<class kernelA>([=]() {
-      // CHECK: call {{.*}}printf(ptr noundef nonnull dereferenceable(1) @{{.*}}, i32 noundef 24)
+      // CHECK: call {{.*}}printf(ptr noundef @{{.*}}, i32 noundef 24)
         __builtin_printf("hello, %d\n", 24);
     });
   });

--- a/clang/test/CodeGenSYCL/reqd-sub-group-size-spirv-intrin.cpp
+++ b/clang/test/CodeGenSYCL/reqd-sub-group-size-spirv-intrin.cpp
@@ -21,7 +21,7 @@ int main() {
 }
 
 // CHECK: define dso_local spir_kernel void @{{.*}}main{{.*}}kernel_class() {{.*}} !intel_reqd_sub_group_size ![[SUBGROUPSIZE:[0-9]+]]
-// CHECK: tail call spir_func void @{{.*}}__spirv_ControlBarrier{{.*}}({{.*}})
+// CHECK: call spir_func void @{{.*}}__spirv_ControlBarrier{{.*}}({{.*}})
 
 // CHECK: declare spir_func void @{{.*}}__spirv_ControlBarrier{{.*}}({{.*}})
 

--- a/clang/test/CodeGenSYCL/sampler.cpp
+++ b/clang/test/CodeGenSYCL/sampler.cpp
@@ -5,7 +5,6 @@
 // CHECK: [[ANON:%[a-zA-Z0-9_]+]] = alloca %class.anon, align 8
 // CHECK: [[ANONCAST:%[a-zA-Z0-9_.]+]] = addrspacecast ptr [[ANON]] to ptr addrspace(4)
 // CHECK: store ptr addrspace(2) [[SAMPLER_ARG]], ptr addrspace(4) [[SAMPLER_ARG]].addr.ascast, align 8
-// CHECK-NEXT: call void @llvm.lifetime.start.p0(i64 8, ptr [[ANON]]) #4
 // CHECK-NEXT: [[GEP:%[a-zA-z0-9]+]]  = getelementptr inbounds %class.anon, ptr addrspace(4) [[ANONCAST]], i32 0, i32 0
 // CHECK-NEXT: [[LOAD_SAMPLER_ARG:%[0-9]+]] = load ptr addrspace(2), ptr addrspace(4) [[SAMPLER_ARG]].addr.ascast, align 8
 // CHECK-NEXT: call spir_func void @{{[a-zA-Z0-9_]+}}(ptr addrspace(4) {{[^,]*}} [[GEP]], ptr addrspace(2) [[LOAD_SAMPLER_ARG]])

--- a/clang/test/CodeGenSYCL/simplifycfg.cpp
+++ b/clang/test/CodeGenSYCL/simplifycfg.cpp
@@ -1,5 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -mllvm -sycl-opt %s -emit-llvm  -o - | FileCheck %s
-// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -mllvm -sycl-opt %s -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -mllvm -sycl-opt %s -emit-llvm -O3 -o - | FileCheck %s
 //
 // This test checks that foo (which is @_Z3foov) is called twice after O3 optimizations.
 //
@@ -15,8 +14,8 @@
 // There is a relevant discussion about introducing
 // a reliable tool for such cases: https://reviews.llvm.org/D85603
 
-// CHECK: tail call spir_func void @_Z3foov()
-// CHECK: tail call spir_func void @_Z3foov()
+// CHECK: call spir_func void @_Z3foov()
+// CHECK: call spir_func void @_Z3foov()
 
 SYCL_EXTERNAL void foo();
 

--- a/clang/test/CodeGenSYCL/stall_enable_device.cpp
+++ b/clang/test/CodeGenSYCL/stall_enable_device.cpp
@@ -26,12 +26,12 @@ public:
 int main() {
   q.submit([&](handler &h) {
     // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel1() {{.*}} !stall_enable ![[NUM4:[0-9]+]]
-    // CHECK: define {{.*}}spir_func void @{{.*}}FuncObjclEv(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) #3 comdat align 2{{.*}} !stall_enable ![[NUM4]]
+    // CHECK: define {{.*}}spir_func void @{{.*}}FuncObjclEv(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) #2 comdat align 2{{.*}} !stall_enable ![[NUM4]]
     h.single_task<class test_kernel1>(
         FuncObj());
 
     // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel2() {{.*}} !stall_enable ![[NUM4]]
-    // CHECK define {{.*}}spir_func void @{{.*}}FooclEv(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) #3 comdat align 2{{.*}} !stall_enable ![[NUM4]]
+    // CHECK define {{.*}}spir_func void @{{.*}}FooclEv(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) #2 comdat align 2{{.*}} !stall_enable ![[NUM4]]
     Foo f;
     h.single_task<class test_kernel2>(f);
 
@@ -47,7 +47,7 @@ int main() {
     // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel4()
     // CHECK-NOT: !stall_enable
     // CHECK-SAME: {
-    // CHECK: define {{.*}}spir_func void @{{.*}}func1{{.*}}(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) #4 align 2{{.*}} !stall_enable ![[NUM4]]
+    // CHECK: define {{.*}}spir_func void @{{.*}}func1{{.*}}(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) #2 align 2{{.*}} !stall_enable ![[NUM4]]
     h.single_task<class test_kernel4>(
         []() { func1(); });
 

--- a/clang/test/CodeGenSYCL/stream.cpp
+++ b/clang/test/CodeGenSYCL/stream.cpp
@@ -13,8 +13,9 @@
 
 // Alloca and addrspace casts for kernel parameters
 // CHECK: [[ARG:%[a-zA-Z0-9_]+]].addr = alloca ptr addrspace(1), align 8
-// CHECK: [[ARG:%[a-zA-Z0-9_]+]].addr.ascast = addrspacecast ptr [[ARG]].addr to ptr addrspace(4)
-// CHECK: [[ARG_LOAD:%[a-zA-Z0-9_]+]] = load ptr addrspace(1), ptr addrspace(4) [[ARG]].addr.ascast, align 8,
+// CHECK: [[ARG]].addr.ascast = addrspacecast ptr [[ARG]].addr to ptr addrspace(4)
+// CHECK: store ptr addrspace(1) [[ARG]], ptr addrspace(4) [[ARG]].addr.ascast, align 8
+// CHECK: [[ARG_LOAD:%[a-zA-Z0-9_]+]] = load ptr addrspace(1), ptr addrspace(4) [[ARG]].addr.ascast, align 8
 
 // Check __init and __finalize method calls
 // CHECK:  call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) noundef align 4 dereferenceable_or_null(16) %{{[a-zA-Z0-9_]+}}, ptr addrspace(1) noundef [[ARG_LOAD]], ptr noundef byval(%[[RANGE_TYPE]]) {{.*}}%{{.*}}

--- a/clang/test/CodeGenSYCL/sycl-intelfpga-bitint.cpp
+++ b/clang/test/CodeGenSYCL/sycl-intelfpga-bitint.cpp
@@ -9,11 +9,15 @@
 
 // CHECK: define{{.*}} void @_Z3fooDB4096_S_(ptr addrspace(4) {{.*}} sret(i4096) align 8 %agg.result, ptr {{.*}} byval(i4096) align 8 %[[ARG1:[0-9]+]], ptr {{.*}} byval(i4096) align 8 %[[ARG2:[0-9]+]])
 signed _BitInt(4096) foo(signed _BitInt(4096) a, signed _BitInt(4096) b) {
-  // CHECK: %[[VAR_A:a]] = load i4096, ptr %[[ARG1]], align 8
-  // CHECK: %[[VAR_B:b]] = load i4096, ptr %[[ARG2]], align 8
-  // CHECK: %[[RES:div]] = sdiv i4096 %[[VAR_A]], %[[VAR_B]]
-  // CHECK: store i4096 %[[RES]], ptr addrspace(4) %agg.result, align 8
-  // CHECK: ret void
+  // CHECK: %a.addr.ascast = addrspacecast ptr %a.addr to ptr addrspace(4)
+  // CHECK: %b.addr.ascast = addrspacecast ptr %b.addr to ptr addrspace(4)
+  // CHECK: %a = load i4096, ptr %[[ARG1]], align 8
+  // CHECK: %b = load i4096, ptr %[[ARG2]], align 8
+  // CHECK: store i4096 %a, ptr addrspace(4) %a.addr.ascast, align 8
+  // CHECK: store i4096 %b, ptr addrspace(4) %b.addr.ascast, align 8
+  // CHECK: %2 = load i4096, ptr addrspace(4) %a.addr.ascast, align 8
+  // CHECK: %3 = load i4096, ptr addrspace(4) %b.addr.ascast, align 8
+  // CHECK: %div = sdiv i4096 %2, %3
   return a / b;
 }
 

--- a/clang/test/Driver/sycl-device-optimizations.cpp
+++ b/clang/test/Driver/sycl-device-optimizations.cpp
@@ -13,6 +13,8 @@
 // RUN:   | FileCheck -check-prefix=CHECK-DEFAULT %s
 // CHECK-DEFAULT-NOT: "-fno-sycl-early-optimizations"
 // CHECK-DEFAULT-NOT: "-disable-llvm-passes"
+// CHECK-DEFAULT: "-fsycl-is-device"
+// CHECK-DEFAULT-SAME: "-O2"
 
 /// Check "-fno-sycl-early-optimizations" is passed to the front-end:
 // RUN:   %clang -### -fsycl -fno-sycl-early-optimizations %s 2>&1 \

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -261,7 +261,7 @@ extern "C" SYCL_EXTERNAL void cons_9(const sycl::vec<sycl::cl_char, 3>::vector_t
 // CHECK:       func.func @[[VEC_INITLIST_VEC_CTR]](%{{.*}}: memref<?x!sycl_vec_i64_16_, 4> {{{.*}}}, %{{.*}}: memref<?x!sycl_vec_i64_8_, 4> {{{.*}}}, %{{.*}}: memref<?x!sycl_vec_i64_4_, 4> {{{.*}}}, %{{.*}}: memref<?x!sycl_vec_i64_2_, 4> {{{.*}}}, %{{.*}}: memref<?xi64, 4> {{{.*}}}, %{{.*}}: memref<?xi64, 4> {{{.*}}}) attributes {[[SPIR_FUNCCC]], [[LINKONCE]], {{.*}}}
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_10(
-// CHECK-LLVM-SAME:                                 %"class.sycl::_V1::vec.5" addrspace(4)* noundef align 64 %[[ARG0:.*]], %"class.sycl::_V1::vec.6" addrspace(4)* noundef align 32 %[[ARG1:.*]], %"class.sycl::_V1::vec.7" addrspace(4)* noundef align 16 %[[ARG2:.*]], i64 noundef %{{.*}}, i64 noundef %{{.*}}) #1 {
+// CHECK-LLVM-SAME:                                 %"class.sycl::_V1::vec.5" addrspace(4)* noundef align 64 %[[ARG0:.*]], %"class.sycl::_V1::vec.6" addrspace(4)* noundef align 32 %[[ARG1:.*]], %"class.sycl::_V1::vec.7" addrspace(4)* noundef align 16 %[[ARG2:.*]], i64 noundef %{{.*}}, i64 noundef %{{.*}}) #[[FUNCATTRS]] {
 // CHECK-LLVM:         call spir_func void @[[VEC_INITLIST_VEC_CTR:.*]](%"class.sycl::_V1::vec.4" addrspace(4)* %{{.*}}, %"class.sycl::_V1::vec.5" addrspace(4)* %[[ARG0]], %"class.sycl::_V1::vec.6" addrspace(4)* %[[ARG1]], %"class.sycl::_V1::vec.7" addrspace(4)* %[[ARG2]], i64 addrspace(4)* %{{.*}}, i64 addrspace(4)* %{{.*}})
 // CHECK-LLVM:       define linkonce_odr spir_func void @[[VEC_INITLIST_VEC_CTR]](%"class.sycl::_V1::vec.4" addrspace(4)* noundef align 128 %{{.*}}, %"class.sycl::_V1::vec.5" addrspace(4)* noundef align 64 %{{.*}}, %"class.sycl::_V1::vec.6" addrspace(4)* noundef align 32 %{{.*}}, %"class.sycl::_V1::vec.7" addrspace(4)* noundef align 16 %{{.*}}, i64 addrspace(4)* noundef align 8 %{{.*}}, i64 addrspace(4)* noundef align 8 %{{.*}}) #[[FUNCATTRS]] {
 
@@ -294,4 +294,4 @@ extern "C" SYCL_EXTERNAL void cons_11() {
 }
 
 // Keep at the end.
-// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/Test/Verification/sycl/constructors.cpp" }
+// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/Test/Verification/sycl/constructors.cpp" }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -165,7 +165,7 @@ SYCL_EXTERNAL void range_size(sycl::range<2> r) {
 // CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* %{{.*}})
 
 // VAL_3 has incorrect type. Issue 7972 open in GitHub to address this.
-// CHECK-LLVM: define linkonce_odr spir_func %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* noundef align 8 [[VAL_0:%.*]]) #1 {
+// CHECK-LLVM: define linkonce_odr spir_func %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* noundef align 8 [[VAL_0:%.*]]) #[[FUNCATTRS]] {
 // CHECK-LLVM-NEXT:   [[VAL_2:%.*]] = alloca %"class.sycl::_V1::range.2", align 8
 // CHECK-LLVM-NEXT:   [[VAL_3:%.*]] = getelementptr %"class.sycl::_V1::nd_range.2", %"class.sycl::_V1::nd_range.2" addrspace(4)* [[VAL_0]], i32 0, i32 0
 // CHECK-LLVM-NEXT:   [[VAL_4:%.*]] = addrspacecast %"class.sycl::_V1::range.2"* [[VAL_2]] to %"class.sycl::_V1::range.2" addrspace(4)*
@@ -728,4 +728,4 @@ SYCL_EXTERNAL void static_1(sycl::id<2> a, sycl::id<2> b) {
   auto abs = sycl::abs(a.get(0) + a.get(1));
 }
 
-// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp" }
+// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp" }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
@@ -1,5 +1,5 @@
 // RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -fsycl -fsycl-device-only -O3 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 
@@ -31,26 +31,30 @@
 
 // CHECK-LLVM-LABEL: define weak_odr spir_kernel void @_ZTSN4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EE
 // CHECK-LLVM-SAME:     (%"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %0, 
-// CHECK-LLVM-SAME:     { i32 addrspace(1)* }* noundef byval({ i32 addrspace(1)* }) align 8 %1) local_unnamed_addr #0 {
-// CHECK-LLVM-NEXT:  %3 = addrspacecast %"class.sycl::_V1::range.1"* %0 to %"class.sycl::_V1::range.1" addrspace(4)*
-// CHECK-LLVM-NEXT:  %4 = getelementptr %"class.sycl::_V1::range.1", %"class.sycl::_V1::range.1" addrspace(4)* %3, i64 0, i32 0, i32 0, i64 0
-// CHECK-LLVM-NEXT:  %5 = load i64, i64 addrspace(4)* %4, align 8
-// CHECK-LLVM-NEXT:  %6 = bitcast { i32 addrspace(1)* }* %1 to i32 addrspace(4)**
-// CHECK-LLVM-NEXT:  %7 = addrspacecast i32 addrspace(4)** %6 to i32 addrspace(4)* addrspace(4)*
-// CHECK-LLVM-NEXT:  %.val = load i32 addrspace(4)*, i32 addrspace(4)* addrspace(4)* %7, align 8
-// CHECK-LLVM-NEXT:  %8 = load <3 x i64>, <3 x i64> addrspace(4)* addrspacecast (<3 x i64> addrspace(1)* @__spirv_BuiltInGlobalInvocationId to <3 x i64> addrspace(4)*), align 32
-// CHECK-LLVM-NEXT:  %9 = extractelement <3 x i64> %8, i64 0
-// CHECK-LLVM-NEXT:  %10 = icmp slt i64 %9, 2147483648
-// CHECK-LLVM-NEXT:  tail call void @llvm.assume(i1 %10)
-// CHECK-LLVM-NEXT:  %.not = icmp slt i64 %9, %5
-// CHECK-LLVM-NEXT:  br i1 %.not, label %11, label %14
-// CHECK-LLVM:       11: 
-// CHECK-LLVM-NEXT:    %12 = trunc i64 %9 to i32
-// CHECK-LLVM-NEXT:    %13 = getelementptr i32, i32 addrspace(4)* %.val, i64 %9
-// CHECK-LLVM-NEXT:    store i32 %12, i32 addrspace(4)* %13, align 4
-// CHECK-LLVM-NEXT:    br label %14
-// CHECK-LLVM:       14:
-// CHECK-LLVM-NEXT:    ret void
+// CHECK-LLVM-SAME:     { i32 addrspace(1)* }* noundef byval({ i32 addrspace(1)* }) align 8 %1) #0 {
+// CHECK-LLVM-NEXT:  %3 = alloca %"class.sycl::_V1::item.1.true", align 8
+// CHECK-LLVM-NEXT:  %4 = alloca { i32 addrspace(4)* }, i64 1, align 8
+// CHECK-LLVM-NEXT:  %5 = alloca %"class.sycl::_V1::range.1", align 8
+// CHECK-LLVM-NEXT:  %6 = alloca { %"class.sycl::_V1::range.1", { i32 addrspace(4)* } }, align 8
+// CHECK-LLVM-NEXT:  %7 = getelementptr { %"class.sycl::_V1::range.1", { i32 addrspace(4)* } }, { %"class.sycl::_V1::range.1", { i32 addrspace(4)* } }* %6, i32 0, i32 0
+// CHECK-LLVM-NEXT:  %8 = addrspacecast %"class.sycl::_V1::range.1"* %5 to %"class.sycl::_V1::range.1" addrspace(4)*
+// CHECK-LLVM-NEXT:  %9 = addrspacecast %"class.sycl::_V1::range.1"* %0 to %"class.sycl::_V1::range.1" addrspace(4)*
+// CHECK-LLVM-NEXT:  call spir_func void @_ZN4sycl3_V15rangeILi1EEC1ERKS2_(%"class.sycl::_V1::range.1" addrspace(4)* %8, %"class.sycl::_V1::range.1" addrspace(4)* %9)
+// CHECK-LLVM-NEXT:  %10 = load %"class.sycl::_V1::range.1", %"class.sycl::_V1::range.1"* %5, align 8
+// CHECK-LLVM-NEXT:  store %"class.sycl::_V1::range.1" %10, %"class.sycl::_V1::range.1"* %7, align 8
+// CHECK-LLVM-NEXT:  %11 = getelementptr { %"class.sycl::_V1::range.1", { i32 addrspace(4)* } }, { %"class.sycl::_V1::range.1", { i32 addrspace(4)* } }* %6, i32 0, i32 1
+// CHECK-LLVM-NEXT:  %12 = bitcast { i32 addrspace(1)* }* %1 to { i32 addrspace(4)* }*
+// CHECK-LLVM-NEXT:  %13 = addrspacecast { i32 addrspace(4)* }* %4 to { i32 addrspace(4)* } addrspace(4)*
+// CHECK-LLVM-NEXT:  %14 = addrspacecast { i32 addrspace(4)* }* %12 to { i32 addrspace(4)* } addrspace(4)*
+// CHECK-LLVM-NEXT:  call spir_func void @_ZZ4testRN4sycl3_V15queueEENUlNS0_2idILi1EEEE_C1ERKS5_({ i32 addrspace(4)* } addrspace(4)* %13, { i32 addrspace(4)* } addrspace(4)* %14)
+// CHECK-LLVM-NEXT:  %15 = load { i32 addrspace(4)* }, { i32 addrspace(4)* }* %4, align 8
+// CHECK-LLVM-NEXT:  store { i32 addrspace(4)* } %15, { i32 addrspace(4)* }* %11, align 8
+// CHECK-LLVM-NEXT:  %16 = call spir_func %"class.sycl::_V1::item.1.true" addrspace(4)* @_ZN4sycl3_V16detail7declptrINS0_4itemILi1ELb1EEEEEPT_v()
+// CHECK-LLVM-NEXT:  %17 = call spir_func %"class.sycl::_V1::item.1.true" @_ZN4sycl3_V16detail7Builder10getElementILi1ELb1EEEDTcl7getItemIXT_EXT0_EEEEPNS0_4itemIXT_EXT0_EEE(%"class.sycl::_V1::item.1.true" addrspace(4)* %16)
+// CHECK-LLVM-NEXT:  %18 = addrspacecast { %"class.sycl::_V1::range.1", { i32 addrspace(4)* } }* %6 to { %"class.sycl::_V1::range.1", { i32 addrspace(4)* } } addrspace(4)*
+// CHECK-LLVM-NEXT:  store %"class.sycl::_V1::item.1.true" %17, %"class.sycl::_V1::item.1.true"* %3, align 8
+// CHECK-LLVM-NEXT:  call spir_func void @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_({ %"class.sycl::_V1::range.1", { i32 addrspace(4)* } } addrspace(4)* %18, %"class.sycl::_V1::item.1.true"* %3)
+// CHECK-LLVM-NEXT:  ret void
 
 int test(sycl::queue &q) {
   int *x = sycl::malloc_device<int>(10, q);

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -82,4 +82,4 @@ SYCL_EXTERNAL void function_1(sycl::item<2, true> item) {
 }
 
 // Keep at the end of the file.
-// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp" }
+// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp" }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
@@ -7,7 +7,7 @@
 //
 // CHECK-MLIR-DAG:  gpu.func @_ZTS8kernel_1
 // CHECK-MLIR-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>,
-// CHECK-MLIR-SAME: [[PASSTHROUGH:passthrough = \["convergent", "mustprogress", "norecurse", "nounwind", \["frame-pointer", "all"\], \["no-trapping-math", "true"\], \["stack-protector-buffer-size", "8"\], \["sycl-module-id", ".*/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp"\]\]]]} {
+// CHECK-MLIR-SAME: [[PASSTHROUGH:passthrough = \["convergent", "mustprogress", "noinline", "norecurse", "nounwind", "optnone", \["frame-pointer", "all"\], \["no-trapping-math", "true"\], \["stack-protector-buffer-size", "8"\], \["sycl-module-id", ".*/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp"\]\]]]} {
 // CHECK-MLIR-DAG:  gpu.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2
 // CHECK-MLIR-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, [[PASSTHROUGH]]} {
 // CHECK-MLIR-DAG:  func.func @_ZN12StoreWrapperIiLi1ELN4sycl3_V16access4modeE1026EEC1ENS1_8accessorIiLi1ELS3_1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS1_3ext6oneapi22accessor_property_listIJEEEEENS1_2idILi1EEERKi
@@ -20,7 +20,7 @@
 // CHECK-LLVM-DAG:      define weak_odr spir_kernel void @_ZTS8kernel_1({{.*}}) #[[FUNCATTRS1:[0-9]+]]
 // CHECK-LLVM-DAG:      define weak_odr spir_kernel void @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2({{.*}}) #[[FUNCATTRS1]]
 
-// CHECK-LLVM-DAG: attributes #[[FUNCATTRS1]] = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp" }
+// CHECK-LLVM-DAG: attributes #[[FUNCATTRS1]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp" }
 
 template <typename DataT,
           int Dimensions = 1,

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -43,4 +43,4 @@ void host_single_task() {
 }
 
 // Keep at the end of the file.
-// CHECK-LLVM: attributes #[[FUNCATTRS1]] = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp" }
+// CHECK-LLVM: attributes #[[FUNCATTRS1]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp" }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -49,7 +49,7 @@
 // CHECK-LABEL: func.func @_Z10accessor_1N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
 // CHECK:          %arg0: memref<?x!sycl_accessor_1_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_1_i32_rw_gb, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC:llvm.cconv = #llvm.cconv<spir_funccc>]], [[LINKEXT:llvm.linkage = #llvm.linkage<external>]],
-// CHECK-SAME: [[PASSTHROUGH:passthrough = \["convergent", "mustprogress", "norecurse", "nounwind", \["frame-pointer", "all"\], \["no-trapping-math", "true"\], \["stack-protector-buffer-size", "8"\], \["sycl-module-id", ".*/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp"\]\]]]} {
+// CHECK-SAME: [[PASSTHROUGH:passthrough = \["convergent", "mustprogress", "noinline", "norecurse", "nounwind", "optnone", \["frame-pointer", "all"\], \["no-trapping-math", "true"\], \["stack-protector-buffer-size", "8"\], \["sycl-module-id", ".*/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp"\]\]]]} {
 SYCL_EXTERNAL void accessor_1(sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write, sycl::access::target::global_buffer>) {}
 
 // CHECK-LABEL: func.func @_Z10accessor_2N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(

--- a/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
@@ -16,13 +16,13 @@
 // CHECK-MLIR-NEXT: [[RESULT:%.*]] = arith.addf [[V1]], [[V2]] : f32
 // CHECK-MLIR:      affine.store [[RESULT]], {{.*}}[0] : memref<?xf32, 4>
 
-// CHECK-LLVM:       define internal spir_func void [[FUNC:@_ZZZ21vec_add_device_simpleRSt5arrayIfLm32EES1_S1_ENKUlRN4sycl3_V17handlerEE_clES5_ENKUlNS3_2idILi1EEEE_clES8_]]({{.*}}) #[[FUNCATTRS2:[0-9]+]]
+// CHECK-LLVM:       define internal spir_func void [[FUNC:@_ZZZ21vec_add_device_simpleRSt5arrayIfLm32EES1_S1_ENKUlRN4sycl3_V17handlerEE_clES5_ENKUlNS3_2idILi1EEEE_clES8_]]({{.*}}) #[[FUNCATTRS:[0-9]+]]
 // CHECK-LLVM-DAG:   [[V1:%.*]] = load float, float addrspace(4)* {{.*}}, align 4
 // CHECK-LLVM-DAG:   [[V2:%.*]] = load float, float addrspace(4)* {{.*}}, align 4
 // CHECK-LLVM:       [[RESULT:%.*]] = fadd float [[V1]], [[V2]]
 // CHECK-LLVM:       store float [[RESULT]], float addrspace(4)* {{.*}}, align 4
 
-// CHECK-LLVM:       define weak_odr spir_kernel void @{{.*}}vec_add_simple({{.*}}) #[[FUNCATTRS1:[0-9]+]]
+// CHECK-LLVM:       define weak_odr spir_kernel void @{{.*}}vec_add_simple({{.*}}) #[[FUNCATTRS]]
 // CHECK-LLVM:       call spir_func void [[FUNC]]
 
 void vec_add_device_simple(std::array<float, N> &VA, std::array<float, N> &VB,
@@ -95,5 +95,4 @@ int main() {
 }
 
 // Keep at the end of the file.
-// CHECK-LLVM-DAG: attributes #[[FUNCATTRS1]] = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp" }
-// CHECK-LLVM-DAG: attributes #[[FUNCATTRS2]] = { convergent inlinehint mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp" }
+// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp" }

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -916,6 +916,7 @@ splitCommandLineOptions(int argc, char **argv,
                         SmallVector<const char *> &MLIRArgs) {
   bool SYCLIsDevice = false;
   bool LinkOnly = false;
+  bool ClangOption = false;
   llvm::OptimizationLevel OptimizationLevel =
       CgeistOptions::getDefaultOptimizationLevel();
 
@@ -946,9 +947,14 @@ splitCommandLineOptions(int argc, char **argv,
       } else if (Ref == "-fsycl-is-device") {
         SYCLIsDevice = true;
         MLIRArgs.push_back(argv[I]);
+      } else if (Ref == "--args") {
+        ClangOption = true;
+        MLIRArgs.push_back(argv[I]);
       } else if (Ref.consume_front("-O") || Ref.consume_front("--optimize")) {
         // If several flags are passed, we keep the last one.
         OptimizationLevel = ExitOnErr(parseOptimizationLevel(Ref));
+        if (ClangOption)
+          MLIRArgs.push_back(argv[I]);
         LinkageArgs.push_back(argv[I]);
       } else if (Ref == "-g")
         LinkageArgs.push_back(argv[I]);


### PR DESCRIPTION
Please only review https://github.com/intel/llvm/pull/8007/commits/9899121120ddcb9a0ef70bc152e4cb12927cfaa3.

https://github.com/intel/llvm/pull/7957 merged `sycl` branch to `sycl-mlir` branch.
On of the upstream commit https://github.com/intel/llvm/commit/102e154349e169c7d5ad27c434e22f9630d300ca causes lit failures, so it was temporarily reverted in `sycl-mlir` branch.  
This PR adds back the reverted commit in `sycl-mlir` branch, and fix the failures.

Please do not squash and merge this PR.