### PR TITLE
[SYCL] Move backend macro definition to plugin headers

### DIFF
--- a/sycl/cmake/modules/AddSYCL.cmake
+++ b/sycl/cmake/modules/AddSYCL.cmake
@@ -32,7 +32,7 @@ function(add_sycl_plugin PLUGIN_NAME)
   cmake_parse_arguments("ARG"
     ""
     ""
-    "SOURCES;INCLUDE_DIRS;LIBRARIES"
+    "SOURCES;INCLUDE_DIRS;LIBRARIES;HEADER"
     ${ARGN}
   )
 
@@ -46,6 +46,19 @@ function(add_sycl_plugin PLUGIN_NAME)
       ${ARG_LIBRARIES}
       OpenCL-Headers
   )
+
+  # Install feature test header
+  if (NOT "${ARG_HEADER}" STREQUAL "")
+    get_filename_component(HEADER_NAME ${ARG_HEADER} NAME)
+    configure_file(
+      ${ARG_HEADER}
+      ${SYCL_INCLUDE_BUILD_DIR}/sycl/detail/plugins/${PLUGIN_NAME}/${HEADER_NAME}
+      COPYONLY)
+
+    install(FILES ${ARG_HEADER}
+            DESTINATION ${SYCL_INCLUDE_DIR}/sycl/detail/plugins/${PLUGIN_NAME}
+            COMPONENT pi_${PLUGIN_NAME})
+  endif()
 
   install(TARGETS pi_${PLUGIN_NAME}
     LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT pi_${PLUGIN_NAME}

--- a/sycl/include/sycl/feature_test.hpp.in
+++ b/sycl/include/sycl/feature_test.hpp.in
@@ -73,21 +73,25 @@ __SYCL_INLINE_VER_NAMESPACE(_V1) {
 #define SYCL_EXT_ONEAPI_USER_DEFINED_REDUCTIONS 1
 #define SYCL_EXT_ONEAPI_WEAK_OBJECT 1
 #define SYCL_EXT_ONEAPI_MEMCPY2D 1
-#cmakedefine01 SYCL_BUILD_PI_CUDA
-#if SYCL_BUILD_PI_CUDA
-#define SYCL_EXT_ONEAPI_BACKEND_CUDA 1
-#endif
-#cmakedefine01 SYCL_BUILD_PI_ESIMD_EMULATOR
-#if SYCL_BUILD_PI_ESIMD_EMULATOR
-#define SYCL_EXT_INTEL_BACKEND_ESIMD_EMULATOR 1
-#endif
-#cmakedefine01 SYCL_BUILD_PI_HIP
-#if SYCL_BUILD_PI_HIP
-#define SYCL_EXT_ONEAPI_BACKEND_HIP 1
-#endif
 #cmakedefine01 SYCL_ENABLE_KERNEL_FUSION
 #if SYCL_ENABLE_KERNEL_FUSION
 #define SYCL_EXT_CODEPLAY_KERNEL_FUSION 1
+#endif
+
+#ifndef __has_include
+#define __has_include(x) 0
+#endif
+
+#if __has_include("detail/plugins/cuda/features.hpp")
+#include "detail/plugins/cuda/features.hpp"
+#endif
+
+#if __has_include("detail/plugins/hip/features.hpp")
+#include "detail/plugins/hip/features.hpp"
+#endif
+
+#if __has_include("detail/plugins/esimd_emulator/features.hpp")
+#include "detail/plugins/esimd_emulator/features.hpp"
 #endif
 
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)

--- a/sycl/plugins/cuda/CMakeLists.txt
+++ b/sycl/plugins/cuda/CMakeLists.txt
@@ -60,6 +60,7 @@ add_sycl_plugin(cuda
   LIBRARIES
     cudadrv
     ${XPTI_LIBS}
+  HEADER "${CMAKE_CURRENT_SOURCE_DIR}/include/features.hpp"
 )
 
 if (SYCL_ENABLE_XPTI_TRACING)

--- a/sycl/plugins/cuda/include/features.hpp
+++ b/sycl/plugins/cuda/include/features.hpp
@@ -1,0 +1,11 @@
+//===-- features.hpp - CUDA Plugin feature macros -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#define SYCL_EXT_ONEAPI_BACKEND_CUDA 1

--- a/sycl/plugins/esimd_emulator/CMakeLists.txt
+++ b/sycl/plugins/esimd_emulator/CMakeLists.txt
@@ -113,6 +113,8 @@ add_sycl_plugin(esimd_emulator
     ${LIBIGFXCMRT_EMU}
     #TODO remove cyclic dependency
     sycl
+  HEADER
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/features.hpp
 )
 
 add_dependencies(pi_esimd_emulator cm-emu)

--- a/sycl/plugins/esimd_emulator/include/features.hpp
+++ b/sycl/plugins/esimd_emulator/include/features.hpp
@@ -1,0 +1,11 @@
+//===-- features.hpp - ESIMD emulator Plugin feature macros ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#define SYCL_EXT_INTEL_BACKEND_ESIMD_EMULATOR 1

--- a/sycl/plugins/hip/CMakeLists.txt
+++ b/sycl/plugins/hip/CMakeLists.txt
@@ -24,6 +24,8 @@ add_sycl_plugin(hip
     "pi_hip.cpp"
   INCLUDE_DIRS
     ${sycl_plugin_dir}
+  HEADER
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/features.hpp
 )
 set_target_properties(pi_hip PROPERTIES LINKER_LANGUAGE CXX)
 

--- a/sycl/plugins/hip/include/features.hpp
+++ b/sycl/plugins/hip/include/features.hpp
@@ -1,0 +1,11 @@
+//===-- features.hpp - HIP Plugin feature macros --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#define SYCL_EXT_ONEAPI_BACKEND_HIP 1


### PR DESCRIPTION
This patch introduces feature headers provided by the plugins to define the backend macros. The main feature test header can then use `__has_include` to conditionally include the plugin headers.

This is better than the current system because it allows to install a plugin build in an existing DPC++ installation by just adding the plugin feature header and the plugin shared library without having to touch the existing feature test header.

It may also be good as a follow up to move backend interop and traits headers into the plugins and use a similar system to install and distribute them.

As a side note, what we're doing with the backend traits and backend macros is technically incorrect with the way the SYCL spec is currently written, as it would mandate that if a backend is listed in the backend enum class, it must have defined backend traits and a backend macros, but in DPC++ the values are still in the enum when the plugins are not built. I've suggested a change to the SYCL spec to relax this: https://github.com/KhronosGroup/SYCL-Docs/pull/343