### PR TITLE
[SYCL-MLIR] Generate i1 for scalar Boolean values

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -2645,7 +2645,7 @@ ValueCategory MLIRScanner::EmitPointerArithmetic(const BinOpInfo &Info) {
     return Result.BitCast(Builder, Loc, Pointer.val.getType());
   }
 
-  auto ElemTy = Glob.getTypes().getMLIRType(ElementType);
+  auto ElemTy = Glob.getTypes().getMLIRTypeForMem(ElementType);
   if (CGM.getLangOpts().isSignedOverflowDefined()) {
     if (Optional<Value> NewIndex =
             castSubIndexOpIndex(Builder, Loc, Pointer, Index.val, IsSigned))

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1305,8 +1305,7 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
         SmallVector<int64_t, 4> Shape;
         clang::QualType ElemTy;
         getConstantArrayShapeAndElemType(OrigTy, Shape, ElemTy);
-        return mlir::MemRefType::get(
-            Shape, getMLIRTypeForMem(ElemTy, ImplicitRef, AllowMerge));
+        return mlir::MemRefType::get(Shape, getMLIRTypeForMem(ElemTy));
       }
 
       // If -memref-fullrank is unset or it cannot be fulfilled.

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1255,7 +1255,7 @@ mlir::Type CodeGenTypes::getMLIRTypeForMem(clang::QualType QT,
   // TODO: Check for the boolean vector case.
 
   // If this is a bool type map this integer to the target-specified size.
-  if (R.isInteger(1))
+  if (!QT->isBitIntType() && R.isInteger(1))
     return mlir::IntegerType::get(TheModule->getContext(),
                                   Context.getTypeSize(QT));
 

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1614,8 +1614,8 @@ mlir::Type CodeGenTypes::getMLIRType(const clang::BuiltinType *BT) const {
     return Builder.getIntegerType(8);
 
   case BuiltinType::Bool:
-    // TODO: boolean types should be represented as i1 rather than i8.
-    return Builder.getIntegerType(8);
+    // Note that we always return bool as i1 for use as a scalar type.
+    return Builder.getIntegerType(1);
 
   case BuiltinType::Char_S:
   case BuiltinType::Char_U:

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.h
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.h
@@ -83,6 +83,14 @@ public:
                               unsigned &CallingConv, bool AttrOnCallSite,
                               bool IsThunk);
 
+  /// Convert type T into an mlir::Type.
+  ///
+  /// This differs from getMLIRType in that it is used to convert to the memory
+  /// representation for a type.  For example, the scalar representation for
+  /// _Bool is i1, but the memory representation is usually i8 or i32, depending
+  /// on the target.
+  mlir::Type getMLIRTypeForMem(clang::QualType QT, bool *ImplicitRef = nullptr,
+                               bool AllowMerge = true);
   // TODO: Possibly create a SYCLTypeCache
   mlir::Type getMLIRType(clang::QualType QT, bool *ImplicitRef = nullptr,
                          bool AllowMerge = true);

--- a/polygeist/tools/cgeist/Lib/TypeUtils.cc
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.cc
@@ -176,7 +176,7 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
   llvm::SmallVector<mlir::Type, 4> Body;
 
   for (const auto *Field : RD->fields())
-    Body.push_back(CGT.getMLIRType(Field->getType()));
+    Body.push_back(CGT.getMLIRTypeForMem(Field->getType()));
 
   if (const auto *CTS =
           llvm::dyn_cast<clang::ClassTemplateSpecializationDecl>(RD)) {
@@ -193,7 +193,7 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
     }
     case TypeEnum::Accessor: {
       const auto Type =
-          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
+          CGT.getMLIRTypeForMem(CTS->getTemplateArgs().get(0).getAsType());
       const auto Dim =
           CTS->getTemplateArgs().get(1).getAsIntegral().getExtValue();
       const auto MemAccessMode = static_cast<mlir::sycl::MemoryAccessMode>(
@@ -206,7 +206,7 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
       // TODO: we should push the non-empty base classes in a more general way.
       if (MemTargetMode == mlir::sycl::MemoryTargetMode::Local) {
         assert(Body.empty());
-        Body.push_back(CGT.getMLIRType(CTS->bases_begin()->getType()));
+        Body.push_back(CGT.getMLIRTypeForMem(CTS->bases_begin()->getType()));
       }
 
       return mlir::sycl::AccessorType::get(CGT.getModule()->getContext(), Type,
@@ -227,7 +227,7 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
     }
     case TypeEnum::Atomic: {
       const auto Type =
-          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
+          CGT.getMLIRTypeForMem(CTS->getTemplateArgs().get(0).getAsType());
       const int AddrSpace =
           CTS->getTemplateArgs().get(1).getAsIntegral().getExtValue();
       return mlir::sycl::AtomicType::get(
@@ -236,12 +236,12 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
     }
     case TypeEnum::GetOp: {
       const auto Type =
-          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
+          CGT.getMLIRTypeForMem(CTS->getTemplateArgs().get(0).getAsType());
       return mlir::sycl::GetOpType::get(CGT.getModule()->getContext(), Type);
     }
     case TypeEnum::GetScalarOp: {
       const auto Type =
-          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
+          CGT.getMLIRTypeForMem(CTS->getTemplateArgs().get(0).getAsType());
       return mlir::sycl::GetScalarOpType::get(CGT.getModule()->getContext(),
                                               Type, Body);
     }
@@ -260,7 +260,7 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
     case TypeEnum::ID: {
       const auto Dim =
           CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
-      Body.push_back(CGT.getMLIRType(CTS->bases_begin()->getType()));
+      Body.push_back(CGT.getMLIRTypeForMem(CTS->bases_begin()->getType()));
       return mlir::sycl::IDType::get(CGT.getModule()->getContext(), Dim, Body);
     }
     case TypeEnum::ItemBase: {
@@ -287,7 +287,7 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
     }
     case TypeEnum::LocalAccessorBase: {
       const auto Type =
-          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
+          CGT.getMLIRTypeForMem(CTS->getTemplateArgs().get(0).getAsType());
       const auto Dim =
           CTS->getTemplateArgs().get(1).getAsIntegral().getExtValue();
       const auto MemAccessMode = static_cast<mlir::sycl::MemoryAccessMode>(
@@ -297,10 +297,10 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
     }
     case TypeEnum::LocalAccessor: {
       const auto Type =
-          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
+          CGT.getMLIRTypeForMem(CTS->getTemplateArgs().get(0).getAsType());
       const auto Dim =
           CTS->getTemplateArgs().get(1).getAsIntegral().getExtValue();
-      Body.push_back(CGT.getMLIRType(CTS->bases_begin()->getType()));
+      Body.push_back(CGT.getMLIRTypeForMem(CTS->bases_begin()->getType()));
       return mlir::sycl::LocalAccessorType::get(CGT.getModule()->getContext(),
                                                 Type, Dim, Body);
     }
@@ -316,7 +316,7 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
     }
     case TypeEnum::MultiPtr: {
       const auto Type =
-          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
+          CGT.getMLIRTypeForMem(CTS->getTemplateArgs().get(0).getAsType());
       const int AddrSpace =
           CTS->getTemplateArgs().get(1).getAsIntegral().getExtValue();
       const int DecAccess =
@@ -343,28 +343,28 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
     case TypeEnum::Range: {
       const auto Dim =
           CTS->getTemplateArgs().get(0).getAsIntegral().getExtValue();
-      Body.push_back(CGT.getMLIRType(CTS->bases_begin()->getType()));
+      Body.push_back(CGT.getMLIRTypeForMem(CTS->bases_begin()->getType()));
       return mlir::sycl::RangeType::get(CGT.getModule()->getContext(), Dim,
                                         Body);
     }
     case TypeEnum::TupleCopyAssignableValueHolder: {
       const auto Type =
-          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
+          CGT.getMLIRTypeForMem(CTS->getTemplateArgs().get(0).getAsType());
       const auto IsTriviallyCopyAssignable =
           CTS->getTemplateArgs().get(1).getAsIntegral().getExtValue();
-      Body.push_back(CGT.getMLIRType(CTS->bases_begin()->getType()));
+      Body.push_back(CGT.getMLIRTypeForMem(CTS->bases_begin()->getType()));
       return mlir::sycl::TupleCopyAssignableValueHolderType::get(
           CGT.getModule()->getContext(), Type, IsTriviallyCopyAssignable, Body);
     }
     case TypeEnum::TupleValueHolder: {
       const auto Type =
-          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
+          CGT.getMLIRTypeForMem(CTS->getTemplateArgs().get(0).getAsType());
       return mlir::sycl::TupleValueHolderType::get(
           CGT.getModule()->getContext(), Type, Body);
     }
     case TypeEnum::Vec: {
       const auto ElemType =
-          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType());
+          CGT.getMLIRTypeForMem(CTS->getTemplateArgs().get(0).getAsType());
       const auto NumElems =
           CTS->getTemplateArgs().get(1).getAsIntegral().getExtValue();
       return mlir::sycl::VecType::get(CGT.getModule()->getContext(), ElemType,
@@ -372,7 +372,7 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
     }
     case TypeEnum::SwizzleOp: {
       const auto VecType =
-          CGT.getMLIRType(CTS->getTemplateArgs().get(0).getAsType())
+          CGT.getMLIRTypeForMem(CTS->getTemplateArgs().get(0).getAsType())
               .cast<mlir::sycl::VecType>();
       const auto IndexesArgs = CTS->getTemplateArgs().get(4).getPackAsArray();
       SmallVector<int> Indexes;

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -142,21 +142,19 @@ void ValueCategory::store(mlir::OpBuilder &builder, mlir::Value toStore) const {
 
     if (toStore.getType() != pt.getElementType()) {
       if (auto mt = toStore.getType().dyn_cast<MemRefType>()) {
-        if (auto spt =
-                pt.getElementType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
-          CGEIST_WARNING({
-            if (mt.getElementType() != spt.getElementType()) {
-              // llvm::errs() << " func: " <<
-              // val.getDefiningOp()->getParentOfType<FuncOp>() << "\n";
-              llvm::WithColor::warning()
-                  << "potential store type mismatch:\n"
-                  << "val: " << val << " tosval: " << toStore << "\n"
-                  << "mt: " << mt << "spt: " << spt << "\n";
-            }
-          });
-          toStore =
-              builder.create<polygeist::Memref2PointerOp>(loc, spt, toStore);
-        }
+        auto spt = pt.getElementType().cast<mlir::LLVM::LLVMPointerType>();
+        CGEIST_WARNING({
+          if (mt.getElementType() != spt.getElementType()) {
+            // llvm::errs() << " func: " <<
+            // val.getDefiningOp()->getParentOfType<FuncOp>() << "\n";
+            llvm::WithColor::warning()
+                << "potential store type mismatch:\n"
+                << "val: " << val << " tosval: " << toStore << "\n"
+                << "mt: " << mt << "spt: " << spt << "\n";
+          }
+        });
+        toStore =
+            builder.create<polygeist::Memref2PointerOp>(loc, spt, toStore);
       }
     } else { // toStore.getType() == pt.getElementType()
       assert(toStore.getType() == pt.getElementType() && "expect same type");

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -142,19 +142,21 @@ void ValueCategory::store(mlir::OpBuilder &builder, mlir::Value toStore) const {
 
     if (toStore.getType() != pt.getElementType()) {
       if (auto mt = toStore.getType().dyn_cast<MemRefType>()) {
-        auto spt = pt.getElementType().cast<mlir::LLVM::LLVMPointerType>();
-        CGEIST_WARNING({
-          if (mt.getElementType() != spt.getElementType()) {
-            // llvm::errs() << " func: " <<
-            // val.getDefiningOp()->getParentOfType<FuncOp>() << "\n";
-            llvm::WithColor::warning()
-                << "potential store type mismatch:\n"
-                << "val: " << val << " tosval: " << toStore << "\n"
-                << "mt: " << mt << "spt: " << spt << "\n";
-          }
-        });
-        toStore =
-            builder.create<polygeist::Memref2PointerOp>(loc, spt, toStore);
+        if (auto spt =
+                pt.getElementType().dyn_cast<mlir::LLVM::LLVMPointerType>()) {
+          CGEIST_WARNING({
+            if (mt.getElementType() != spt.getElementType()) {
+              // llvm::errs() << " func: " <<
+              // val.getDefiningOp()->getParentOfType<FuncOp>() << "\n";
+              llvm::WithColor::warning()
+                  << "potential store type mismatch:\n"
+                  << "val: " << val << " tosval: " << toStore << "\n"
+                  << "mt: " << mt << "spt: " << spt << "\n";
+            }
+          });
+          toStore =
+              builder.create<polygeist::Memref2PointerOp>(loc, spt, toStore);
+        }
       }
     } else { // toStore.getType() == pt.getElementType()
       assert(toStore.getType() == pt.getElementType() && "expect same type");

--- a/polygeist/tools/cgeist/Test/Verification/booleanconversion.c
+++ b/polygeist/tools/cgeist/Test/Verification/booleanconversion.c
@@ -3,70 +3,64 @@
 #include <stdbool.h>
 
 // CHECK-LABEL:   func.func @int_conversion(
-// CHECK-SAME:                              %[[VAL_0:.*]]: i32) -> i8
+// CHECK-SAME:                              %[[VAL_0:.*]]: i32) -> i1
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : i32
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.cmpi ne, %[[VAL_0]], %[[VAL_1]] : i32
-// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_2]] : i1 to i8
-// CHECK-NEXT:      return %[[VAL_3]] : i8
+// CHECK-NEXT:      return %[[VAL_2]] : i1
 // CHECK-NEXT:    }
 bool int_conversion(int i) { return (bool)i; }
 
 // CHECK-LABEL:   func.func @long_conversion(
-// CHECK-SAME:                               %[[VAL_0:.*]]: i64) -> i8
+// CHECK-SAME:                               %[[VAL_0:.*]]: i64) -> i1
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : i64
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.cmpi ne, %[[VAL_0]], %[[VAL_1]] : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_2]] : i1 to i8
-// CHECK-NEXT:      return %[[VAL_3]] : i8
+// CHECK-NEXT:      return %[[VAL_2]] : i1
 // CHECK-NEXT:    }
 bool long_conversion(long i) { return (bool)i; }
 
 // CHECK-LABEL:   func.func @float_conversion(
-// CHECK-SAME:                                %[[VAL_0:.*]]: f32) -> i8
+// CHECK-SAME:                                %[[VAL_0:.*]]: f32) -> i1
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.cmpf une, %[[VAL_0]], %[[VAL_1]] : f32
-// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_2]] : i1 to i8
-// CHECK-NEXT:      return %[[VAL_3]] : i8
+// CHECK-NEXT:      return %[[VAL_2]] : i1
 // CHECK-NEXT:    }
 bool float_conversion(float i) { return (bool)i; }
 
 // CHECK-LABEL:   func.func @double_conversion(
-// CHECK-SAME:                                 %[[VAL_0:.*]]: f64) -> i8
+// CHECK-SAME:                                 %[[VAL_0:.*]]: f64) -> i1
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.cmpf une, %[[VAL_0]], %[[VAL_1]] : f64
-// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_2]] : i1 to i8
-// CHECK-NEXT:      return %[[VAL_3]] : i8
+// CHECK-NEXT:      return %[[VAL_2]] : i1
 // CHECK-NEXT:    }
 bool double_conversion(double i) { return (bool)i; }
 
 // CHECK-LABEL:   func.func @ptr_conversion(
-// CHECK-SAME:                              %[[VAL_0:.*]]: !llvm.ptr<i8>) -> i8
+// CHECK-SAME:                              %[[VAL_0:.*]]: !llvm.ptr<i8>) -> i1
 // CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.null : !llvm.ptr<i8>
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.icmp "ne" %[[VAL_0]], %[[VAL_1]] : !llvm.ptr<i8>
-// CHECK-NEXT:      %[[VAL_3:.*]] = arith.extui %[[VAL_2]] : i1 to i8
-// CHECK-NEXT:      return %[[VAL_3]] : i8
+// CHECK-NEXT:      return %[[VAL_2]] : i1
 // CHECK-NEXT:    }
 bool ptr_conversion(void *i) { return (bool)i; }
 
 // CHECK-LABEL:   func.func @memref_conversion(
-// CHECK-SAME:                                 %[[VAL_0:.*]]: memref<?xi32>) -> i8
+// CHECK-SAME:                                 %[[VAL_0:.*]]: memref<?xi32>) -> i1
 // CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.null : !llvm.ptr<i32>
 // CHECK-NEXT:      %[[VAL_2:.*]] = "polygeist.memref2pointer"(%[[VAL_0]]) : (memref<?xi32>) -> !llvm.ptr<i32>
 // CHECK-NEXT:      %[[VAL_3:.*]] = llvm.icmp "ne" %[[VAL_2]], %[[VAL_1]] : !llvm.ptr<i32>
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.extui %[[VAL_3]] : i1 to i8
-// CHECK-NEXT:      return %[[VAL_4]] : i8
+// CHECK-NEXT:      return %[[VAL_3]] : i1
 // CHECK-NEXT:    }
 bool memref_conversion(int *i) { return (bool)i; }
 
 // CHECK-LABEL:   func.func @bool2unsigned_conversion(
-// CHECK-SAME:                                        %[[VAL_0:.*]]: i8) -> i32
-// CHECK-NEXT:      %[[VAL_1:.*]] = arith.extui %[[VAL_0]] : i8 to i32
+// CHECK-SAME:                                        %[[VAL_0:.*]]: i1) -> i32
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.extui %[[VAL_0]] : i1 to i32
 // CHECK-NEXT:      return %[[VAL_1]] : i32
 // CHECK-NEXT:    }
 unsigned bool2unsigned_conversion(bool i) { return (unsigned)i; }
 
 // CHECK-LABEL:   func.func @bool2long_conversion(
-// CHECK-SAME:                                    %[[VAL_0:.*]]: i8) -> i64
-// CHECK-NEXT:      %[[VAL_1:.*]] = arith.extui %[[VAL_0]] : i8 to i64
+// CHECK-SAME:                                    %[[VAL_0:.*]]: i1) -> i64
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.extui %[[VAL_0]] : i1 to i64
 // CHECK-NEXT:      return %[[VAL_1]] : i64
 // CHECK-NEXT:    }
 long bool2long_conversion(bool i) { return (long)i; }

--- a/polygeist/tools/cgeist/Test/Verification/booleanmem.c
+++ b/polygeist/tools/cgeist/Test/Verification/booleanmem.c
@@ -69,14 +69,6 @@ bool array_2d_get(bool arr[100][100], size_t i, size_t j) {
 // CHECK-NEXT:      return %[[VAL_4]] : i1
 // CHECK-NEXT:    }
 
-// CHECK-FULLRANK-LABEL:   func.func @ptr_get(
-// CHECK-FULLRANK-SAME:                       %[[VAL_0:.*]]: memref<?xi8>,
-// CHECK-FULLRANK-SAME:                       %[[VAL_1:.*]]: i64) -> i1
-// CHECK-FULLRANK-NEXT:      %[[VAL_2:.*]] = arith.index_cast %[[VAL_1]] : i64 to index
-// CHECK-FULLRANK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_0]][symbol(%[[VAL_2]])] : memref<?xi8>
-// CHECK-FULLRANK-NEXT:      %[[VAL_4:.*]] = arith.trunci %[[VAL_3]] : i8 to i1
-// CHECK-FULLRANK-NEXT:      return %[[VAL_4]] : i1
-// CHECK-FULLRANK-NEXT:    }
 bool ptr_get(bool *arr, size_t i) {
   return arr[i];
 }
@@ -96,17 +88,6 @@ struct foo {
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i8 to i1
 // CHECK-NEXT:      return %[[VAL_5]] : i1
 // CHECK-NEXT:    }
-
-// CHECK-FULLRANK-LABEL:   func.func @struct_get(
-// CHECK-FULLRANK-SAME:                          %[[VAL_0:.*]]: !llvm.struct<(i32, i8)>) -> i1
-// CHECK-FULLRANK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : i64
-// CHECK-FULLRANK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(i32, i8)> : (i64) -> !llvm.ptr<struct<(i32, i8)>>
-// CHECK-FULLRANK-NEXT:      llvm.store %[[VAL_0]], %[[VAL_2]] : !llvm.ptr<struct<(i32, i8)>>
-// CHECK-FULLRANK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_2]][0, 1] : (!llvm.ptr<struct<(i32, i8)>>) -> !llvm.ptr<i8>
-// CHECK-FULLRANK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i8>
-// CHECK-FULLRANK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i8 to i1
-// CHECK-FULLRANK-NEXT:      return %[[VAL_5]] : i1
-// CHECK-FULLRANK-NEXT:    }
 bool struct_get(struct foo s) {
   return s.x;
 }
@@ -118,14 +99,6 @@ bool struct_get(struct foo s) {
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i8 to i1
 // CHECK-NEXT:      return %[[VAL_3]] : i1
 // CHECK-NEXT:    }
-
-// CHECK-FULLRANK-LABEL:   func.func @struct_ptr_get(
-// CHECK-FULLRANK-SAME:                              %[[VAL_0:.*]]: !llvm.ptr<struct<(i32, i8)>>) -> i1
-// CHECK-FULLRANK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr %[[VAL_0]][0, 1] : (!llvm.ptr<struct<(i32, i8)>>) -> !llvm.ptr<i8>
-// CHECK-FULLRANK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<i8>
-// CHECK-FULLRANK-NEXT:      %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i8 to i1
-// CHECK-FULLRANK-NEXT:      return %[[VAL_3]] : i1
-// CHECK-FULLRANK-NEXT:    }
 bool struct_ptr_get(struct foo *s) {
   return s->x;
 }

--- a/polygeist/tools/cgeist/Test/Verification/booleanmem.c
+++ b/polygeist/tools/cgeist/Test/Verification/booleanmem.c
@@ -4,6 +4,16 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+// CHECK-LABEL:    memref.global "private" @arr_no_init : memref<2xi8> = dense<0> {alignment = 1 : i64}
+// CHECK-LABEL:    memref.global "private" @arr : memref<2xi8> = dense<[-1, 0]> {alignment = 1 : i64}
+// CHECK-LABEL:    memref.global "private" @"static_arr_local_no_init@static@arr" : memref<10xi8> = dense<0> {alignment = 1 : i64}
+// CHECK-LABEL:    memref.global "private" @"static_arr_local@static@arr@init" : memref<i1> = dense<true>
+// CHECK-LABEL:    memref.global "private" @"static_arr_local@static@arr" : memref<2xi8> = dense<[-1, 0]> {alignment = 1 : i64}
+// CHECK-LABEL:    memref.global "private" @x_no_init : memref<i8> = dense<0> {alignment = 1 : i64}
+// CHECK-LABEL:    memref.global "private" @x : memref<i8> = dense<0> {alignment = 1 : i64}
+// CHECK-LABEL:    memref.global "private" @"get_local_static@static@x@init" : memref<i1> = dense<true>
+// CHECK-LABEL:    memref.global "private" @"get_local_static@static@x" : memref<i8> = dense<1> {alignment = 1 : i64}
+
 // CHECK-LABEL:   func.func @array_get(
 // CHECK-SAME:                         %[[VAL_0:.*]]: memref<?xi8>,
 // CHECK-SAME:                         %[[VAL_1:.*]]: i64) -> i1
@@ -220,7 +230,6 @@ bool get_global_static_no_init() {
 // CHECK-NEXT:      call @keep(%[[VAL_8]]) : (memref<?xi8>) -> ()
 // CHECK-NEXT:      return
 // CHECK-NEXT:    }
-
 void static_arr_local() {
   static bool arr[2] = {true, false};
   keep(arr);
@@ -232,7 +241,6 @@ void static_arr_local() {
 // CHECK-NEXT:      call @keep(%[[VAL_1]]) : (memref<?xi8>) -> ()
 // CHECK-NEXT:      return
 // CHECK-NEXT:    }
-
 void static_arr_local_no_init() {
   static bool arr[10];
   keep(arr);
@@ -246,7 +254,6 @@ static bool arr[2] = {true, false};
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.trunci %[[VAL_1]] : i8 to i1
 // CHECK-NEXT:      return %[[VAL_2]] : i1
 // CHECK-NEXT:    }
-
 bool static_arr_global() {
   return arr[0];
 }
@@ -259,7 +266,6 @@ static bool arr_no_init[2];
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.trunci %[[VAL_1]] : i8 to i1
 // CHECK-NEXT:      return %[[VAL_2]] : i1
 // CHECK-NEXT:    }
-
 bool static_arr_global_no_init() {
   return arr_no_init[0];
 }

--- a/polygeist/tools/cgeist/Test/Verification/booleanmem.c
+++ b/polygeist/tools/cgeist/Test/Verification/booleanmem.c
@@ -1,0 +1,121 @@
+// RUN: cgeist %s -w -O0 --function=* -S | FileCheck %s
+// RUN: cgeist %s -w -O0 --memref-fullrank --function=* -S | FileCheck %s --check-prefix=CHECK-FULLRANK
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+struct foo {
+  int dummy;
+  bool x;
+};
+
+// CHECK-LABEL:   func.func @array_get(
+// CHECK-SAME:                         %[[VAL_0:.*]]: memref<?xi8>,
+// CHECK-SAME:                         %[[VAL_1:.*]]: i64) -> i1
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.index_cast %[[VAL_1]] : i64 to index
+// CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_0]][symbol(%[[VAL_2]])] : memref<?xi8>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.trunci %[[VAL_3]] : i8 to i1
+// CHECK-NEXT:      return %[[VAL_4]] : i1
+// CHECK-NEXT:    }
+
+// CHECK-FULLRANK-LABEL:   func.func @array_get(
+// CHECK-FULLRANK-SAME:                         %[[VAL_0:.*]]: memref<100xi8>,
+// CHECK-FULLRANK-SAME:                         %[[VAL_1:.*]]: i64) -> i1
+// CHECK-FULLRANK-NEXT:      %[[VAL_2:.*]] = arith.index_cast %[[VAL_1]] : i64 to index
+// CHECK-FULLRANK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_0]][symbol(%[[VAL_2]])] : memref<100xi8>
+// CHECK-FULLRANK-NEXT:      %[[VAL_4:.*]] = arith.trunci %[[VAL_3]] : i8 to i1
+// CHECK-FULLRANK-NEXT:      return %[[VAL_4]] : i1
+// CHECK-FULLRANK-NEXT:    }
+bool array_get(bool arr[100], size_t i) {
+  return arr[i];
+}
+
+// CHECK-LABEL:   func.func @array_2d_get(
+// CHECK-SAME:                            %[[VAL_0:.*]]: memref<?x100xi8>,
+// CHECK-SAME:                            %[[VAL_1:.*]]: i64,
+// CHECK-SAME:                            %[[VAL_2:.*]]: i64) -> i1
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.index_cast %[[VAL_1]] : i64 to index
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_2]] : i64 to index
+// CHECK-NEXT:      %[[VAL_5:.*]] = affine.load %[[VAL_0]][symbol(%[[VAL_3]]), symbol(%[[VAL_4]])] : memref<?x100xi8>
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.trunci %[[VAL_5]] : i8 to i1
+// CHECK-NEXT:      return %[[VAL_6]] : i1
+// CHECK-NEXT:    }
+
+// CHECK-FULLRANK-LABEL:   func.func @array_2d_get(
+// CHECK-FULLRANK-SAME:                            %[[VAL_0:.*]]: memref<100x100xi8>,
+// CHECK-FULLRANK-SAME:                            %[[VAL_1:.*]]: i64,
+// CHECK-FULLRANK-SAME:                            %[[VAL_2:.*]]: i64) -> i1
+// CHECK-FULLRANK-NEXT:      %[[VAL_3:.*]] = arith.index_cast %[[VAL_1]] : i64 to index
+// CHECK-FULLRANK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_2]] : i64 to index
+// CHECK-FULLRANK-NEXT:      %[[VAL_5:.*]] = affine.load %[[VAL_0]][symbol(%[[VAL_3]]), symbol(%[[VAL_4]])] : memref<100x100xi8>
+// CHECK-FULLRANK-NEXT:      %[[VAL_6:.*]] = arith.trunci %[[VAL_5]] : i8 to i1
+// CHECK-FULLRANK-NEXT:      return %[[VAL_6]] : i1
+// CHECK-FULLRANK-NEXT:    }
+bool array_2d_get(bool arr[100][100], size_t i, size_t j) {
+  return arr[i][j];
+}
+
+// CHECK-LABEL:   func.func @ptr_get(
+// CHECK-SAME:                       %[[VAL_0:.*]]: memref<?xi8>,
+// CHECK-SAME:                       %[[VAL_1:.*]]: i64) -> i1
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.index_cast %[[VAL_1]] : i64 to index
+// CHECK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_0]][symbol(%[[VAL_2]])] : memref<?xi8>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.trunci %[[VAL_3]] : i8 to i1
+// CHECK-NEXT:      return %[[VAL_4]] : i1
+// CHECK-NEXT:    }
+
+// CHECK-FULLRANK-LABEL:   func.func @ptr_get(
+// CHECK-FULLRANK-SAME:                       %[[VAL_0:.*]]: memref<?xi8>,
+// CHECK-FULLRANK-SAME:                       %[[VAL_1:.*]]: i64) -> i1
+// CHECK-FULLRANK-NEXT:      %[[VAL_2:.*]] = arith.index_cast %[[VAL_1]] : i64 to index
+// CHECK-FULLRANK-NEXT:      %[[VAL_3:.*]] = affine.load %[[VAL_0]][symbol(%[[VAL_2]])] : memref<?xi8>
+// CHECK-FULLRANK-NEXT:      %[[VAL_4:.*]] = arith.trunci %[[VAL_3]] : i8 to i1
+// CHECK-FULLRANK-NEXT:      return %[[VAL_4]] : i1
+// CHECK-FULLRANK-NEXT:    }
+bool ptr_get(bool *arr, size_t i) {
+  return arr[i];
+}
+
+// CHECK-LABEL:   func.func @struct_get(
+// CHECK-SAME:                          %[[VAL_0:.*]]: !llvm.struct<(i32, i8)>) -> i1
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(i32, i8)> : (i64) -> !llvm.ptr<struct<(i32, i8)>>
+// CHECK-NEXT:      llvm.store %[[VAL_0]], %[[VAL_2]] : !llvm.ptr<struct<(i32, i8)>>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_2]][0, 1] : (!llvm.ptr<struct<(i32, i8)>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i8 to i1
+// CHECK-NEXT:      return %[[VAL_5]] : i1
+// CHECK-NEXT:    }
+
+// CHECK-FULLRANK-LABEL:   func.func @struct_get(
+// CHECK-FULLRANK-SAME:                          %[[VAL_0:.*]]: !llvm.struct<(i32, i8)>) -> i1
+// CHECK-FULLRANK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-FULLRANK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(i32, i8)> : (i64) -> !llvm.ptr<struct<(i32, i8)>>
+// CHECK-FULLRANK-NEXT:      llvm.store %[[VAL_0]], %[[VAL_2]] : !llvm.ptr<struct<(i32, i8)>>
+// CHECK-FULLRANK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_2]][0, 1] : (!llvm.ptr<struct<(i32, i8)>>) -> !llvm.ptr<i8>
+// CHECK-FULLRANK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i8>
+// CHECK-FULLRANK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i8 to i1
+// CHECK-FULLRANK-NEXT:      return %[[VAL_5]] : i1
+// CHECK-FULLRANK-NEXT:    }
+bool struct_get(struct foo s) {
+  return s.x;
+}
+
+// CHECK-LABEL:   func.func @struct_ptr_get(
+// CHECK-SAME:                              %[[VAL_0:.*]]: !llvm.ptr<struct<(i32, i8)>>) -> i1
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr %[[VAL_0]][0, 1] : (!llvm.ptr<struct<(i32, i8)>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i8 to i1
+// CHECK-NEXT:      return %[[VAL_3]] : i1
+// CHECK-NEXT:    }
+
+// CHECK-FULLRANK-LABEL:   func.func @struct_ptr_get(
+// CHECK-FULLRANK-SAME:                              %[[VAL_0:.*]]: !llvm.ptr<struct<(i32, i8)>>) -> i1
+// CHECK-FULLRANK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr %[[VAL_0]][0, 1] : (!llvm.ptr<struct<(i32, i8)>>) -> !llvm.ptr<i8>
+// CHECK-FULLRANK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<i8>
+// CHECK-FULLRANK-NEXT:      %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i8 to i1
+// CHECK-FULLRANK-NEXT:      return %[[VAL_3]] : i1
+// CHECK-FULLRANK-NEXT:    }
+bool struct_ptr_get(struct foo *s) {
+  return s->x;
+}

--- a/polygeist/tools/cgeist/Test/Verification/booleanmem.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/booleanmem.cpp
@@ -1,20 +1,7 @@
 // RUN: cgeist %s -w -O0 --function=* -S | FileCheck %s
 // XFAIL: *
 
-// CHECK-LABEL:   func.func @_Z14lambda_capturebb(
-// CHECK-SAME:                                     %[[VAL_0:.*]]: i1,
-// CHECK-SAME:                                     %[[VAL_1:.*]]: i1)
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 1 : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(i8, memref<?xi8>)> : (i64) -> !llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr %[[VAL_3]][0, 0] : (!llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>) -> !llvm.ptr<i8>
-// CHECK-NEXT:      %[[VAL_5:.*]] = arith.extui %[[VAL_0]] : i1 to i8
-// CHECK-NEXT:      llvm.store %[[VAL_5]], %[[VAL_4]] : !llvm.ptr<i8>
-// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_3]][0, 1] : (!llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>) -> !llvm.ptr<i8>
-// CHECK-NEXT:      %[[VAL_7:.*]] = arith.extui %[[VAL_1]] : i1 to i8
-// CHECK-NEXT:      llvm.store %[[VAL_7]], %[[VAL_6]] : !llvm.ptr<i8>
-// CHECK-NEXT:      %[[VAL_8]] = llvm.load %[[VAL_3]] : !llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>
-// CHECK-NEXT:      return %[[VAL_8]] : !llvm.struct<(i8, memref<?xi8>)>
-// CHECK-NEXT:    }
-auto lambda_capture(bool x, bool y) {
-  return [x, &y]() { y = !x; };
+void lambda_capture(bool x, bool &y) {
+  const auto f = [x, &y]() { y = !x; };
+  f();
 }

--- a/polygeist/tools/cgeist/Test/Verification/booleanmem.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/booleanmem.cpp
@@ -1,4 +1,5 @@
 // RUN: cgeist %s -w -O0 --function=* -S | FileCheck %s
+// XFAIL: *
 
 // CHECK-LABEL:   func.func @_Z14lambda_capturebb(
 // CHECK-SAME:                                     %[[VAL_0:.*]]: i1,
@@ -8,8 +9,12 @@
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr %[[VAL_3]][0, 0] : (!llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>) -> !llvm.ptr<i8>
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.extui %[[VAL_0]] : i1 to i8
 // CHECK-NEXT:      llvm.store %[[VAL_5]], %[[VAL_4]] : !llvm.ptr<i8>
-// CHECK-NEXT:      return
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_3]][0, 1] : (!llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_7:.*]] = arith.extui %[[VAL_1]] : i1 to i8
+// CHECK-NEXT:      llvm.store %[[VAL_7]], %[[VAL_6]] : !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_8]] = llvm.load %[[VAL_3]] : !llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>
+// CHECK-NEXT:      return %[[VAL_8]] : !llvm.struct<(i8, memref<?xi8>)>
 // CHECK-NEXT:    }
-void lambda_capture(bool x, bool y) {
-  const auto f = [x, &y]() { y = !x; };
+auto lambda_capture(bool x, bool y) {
+  return [x, &y]() { y = !x; };
 }

--- a/polygeist/tools/cgeist/Test/Verification/booleanmem.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/booleanmem.cpp
@@ -1,0 +1,20 @@
+// RUN: cgeist %s -w -O0 --function=* -S | FileCheck %s
+
+#include <functional>
+
+// CHECK-LABEL:   func.func @_Z14lambda_capturebRb(
+// CHECK-SAME:                                     %[[VAL_0:.*]]: i1,
+// CHECK-SAME:                                     %[[VAL_1:.*]]: memref<?xi8>)
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(i8, memref<?xi8>)> : (i64) -> !llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr %[[VAL_3]][0, 0] : (!llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.extui %[[VAL_0]] : i1 to i8
+// CHECK-NEXT:      llvm.store %[[VAL_5]], %[[VAL_4]] : !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_3]][0, 1] : (!llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>) -> !llvm.ptr<memref<?xi8>>
+// CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_6]] : !llvm.ptr<memref<?xi8>>
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+void lambda_capture(bool x, bool &y) {
+  const auto f = [x, &y]() { y = !x; };
+}

--- a/polygeist/tools/cgeist/Test/Verification/booleanmem.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/booleanmem.cpp
@@ -1,7 +1,5 @@
 // RUN: cgeist %s -w -O0 --function=* -S | FileCheck %s
 
-#include <functional>
-
 // CHECK-LABEL:   func.func @_Z14lambda_capturebb(
 // CHECK-SAME:                                     %[[VAL_0:.*]]: i1,
 // CHECK-SAME:                                     %[[VAL_1:.*]]: i1)

--- a/polygeist/tools/cgeist/Test/Verification/booleanmem.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/booleanmem.cpp
@@ -2,18 +2,16 @@
 
 #include <functional>
 
-// CHECK-LABEL:   func.func @_Z14lambda_capturebRb(
+// CHECK-LABEL:   func.func @_Z14lambda_capturebb(
 // CHECK-SAME:                                     %[[VAL_0:.*]]: i1,
-// CHECK-SAME:                                     %[[VAL_1:.*]]: memref<?xi8>)
+// CHECK-SAME:                                     %[[VAL_1:.*]]: i1)
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(i8, memref<?xi8>)> : (i64) -> !llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr %[[VAL_3]][0, 0] : (!llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>) -> !llvm.ptr<i8>
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.extui %[[VAL_0]] : i1 to i8
 // CHECK-NEXT:      llvm.store %[[VAL_5]], %[[VAL_4]] : !llvm.ptr<i8>
-// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_3]][0, 1] : (!llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>) -> !llvm.ptr<memref<?xi8>>
-// CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_6]] : !llvm.ptr<memref<?xi8>>
 // CHECK-NEXT:      return
 // CHECK-NEXT:    }
-void lambda_capture(bool x, bool &y) {
+void lambda_capture(bool x, bool y) {
   const auto f = [x, &y]() { y = !x; };
 }

--- a/polygeist/tools/cgeist/Test/Verification/booleanmem.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/booleanmem.cpp
@@ -1,7 +1,27 @@
 // RUN: cgeist %s -w -O0 --function=* -S | FileCheck %s
-// XFAIL: *
 
-void lambda_capture(bool x, bool &y) {
-  const auto f = [x, &y]() { y = !x; };
+// CHECK-LABEL:   func.func @_Z14lambda_capturebb(
+// CHECK-SAME:                                    %[[VAL_0:.*]]: i1,
+// CHECK-SAME:                                    %[[VAL_1:.*]]: i1)
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(i8, memref<?xi8>)> : (i64) -> !llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(i8, memref<?xi8>)> : (i64) -> !llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_4]][0, 0] : (!llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.extui %[[VAL_0]] : i1 to i8
+// CHECK-NEXT:      llvm.store %[[VAL_6]], %[[VAL_5]] : !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_7:.*]] = arith.extui %[[VAL_1]] : i1 to i8
+// CHECK-NEXT:      %[[VAL_8:.*]] = memref.alloca() : memref<1xi8>
+// CHECK-NEXT:      affine.store %[[VAL_7]], %[[VAL_8]][0] : memref<1xi8>
+// CHECK-NEXT:      %[[VAL_9:.*]] = memref.cast %[[VAL_8]] : memref<1xi8> to memref<?xi8>
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr %[[VAL_4]][0, 1] : (!llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>) -> !llvm.ptr<memref<?xi8>>
+// CHECK-NEXT:      llvm.store %[[VAL_9]], %[[VAL_10]] : !llvm.ptr<memref<?xi8>>
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>
+// CHECK-NEXT:      llvm.store %[[VAL_11]], %[[VAL_3]] : !llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>
+// CHECK-NEXT:      call @_ZZ14lambda_capturebbENK3$_0clEv(%[[VAL_3]]) : (!llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+void lambda_capture(bool x, bool y) {
+  const auto f = [x, &y]() { y = y ^ x; };
   f();
 }

--- a/polygeist/tools/cgeist/Test/Verification/booleanmem.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/booleanmem.cpp
@@ -14,7 +14,6 @@
 // CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_6]] : !llvm.ptr<memref<?xi8>>
 // CHECK-NEXT:      return
 // CHECK-NEXT:    }
-
 void lambda_capture(bool x, bool &y) {
   const auto f = [x, &y]() { y = !x; };
 }

--- a/polygeist/tools/cgeist/Test/Verification/compoundassign.c
+++ b/polygeist/tools/cgeist/Test/Verification/compoundassign.c
@@ -176,7 +176,7 @@ unsigned f12(unsigned *a, unsigned b) {
 
 // CHECK-LABEL:   func.func @f13(
 // CHECK-SAME:                   %[[VAL_0:.*]]: memref<?xi8>,
-// CHECK-SAME:                   %[[VAL_1:.*]]: i32) -> i8
+// CHECK-SAME:                   %[[VAL_1:.*]]: i32) -> i1
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0 : i32
 // CHECK:           %[[VAL_3:.*]] = affine.load %[[VAL_0]][0] : memref<?xi8>
 // CHECK:           %[[VAL_4:.*]] = arith.extui %[[VAL_3]] : i8 to i32
@@ -184,7 +184,7 @@ unsigned f12(unsigned *a, unsigned b) {
 // CHECK:           %[[VAL_6:.*]] = arith.cmpi ne, %[[VAL_5]], %[[VAL_2]] : i32
 // CHECK:           %[[VAL_7:.*]] = arith.extui %[[VAL_6]] : i1 to i8
 // CHECK:           affine.store %[[VAL_7]], %[[VAL_0]][0] : memref<?xi8>
-// CHECK:           return %[[VAL_7]] : i8
+// CHECK:           return %[[VAL_6]] : i1
 // CHECK:         }
 
 bool f13(bool *a, unsigned b) {
@@ -193,7 +193,7 @@ bool f13(bool *a, unsigned b) {
 
 // CHECK-LABEL:   func.func @f14(
 // CHECK-SAME:                   %[[VAL_0:.*]]: memref<?xi8>,
-// CHECK-SAME:                   %[[VAL_1:.*]]: f32) -> i8
+// CHECK-SAME:                   %[[VAL_1:.*]]: f32) -> i1
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK:           %[[VAL_3:.*]] = affine.load %[[VAL_0]][0] : memref<?xi8>
 // CHECK:           %[[VAL_4:.*]] = arith.uitofp %[[VAL_3]] : i8 to f32
@@ -201,7 +201,7 @@ bool f13(bool *a, unsigned b) {
 // CHECK:           %[[VAL_6:.*]] = arith.cmpf une, %[[VAL_5]], %[[VAL_2]] : f32
 // CHECK:           %[[VAL_7:.*]] = arith.extui %[[VAL_6]] : i1 to i8
 // CHECK:           affine.store %[[VAL_7]], %[[VAL_0]][0] : memref<?xi8>
-// CHECK:           return %[[VAL_7]] : i8
+// CHECK:           return %[[VAL_6]] : i1
 // CHECK:         }
 
 bool f14(bool *a, float b) {
@@ -210,7 +210,7 @@ bool f14(bool *a, float b) {
 
 // CHECK-LABEL:   func.func @f15(
 // CHECK-SAME:                   %[[VAL_0:.*]]: memref<?xi8>,
-// CHECK-SAME:                   %[[VAL_1:.*]]: f64) -> i8
+// CHECK-SAME:                   %[[VAL_1:.*]]: f64) -> i1
 // CHECK:           %[[VAL_2:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:           %[[VAL_3:.*]] = affine.load %[[VAL_0]][0] : memref<?xi8>
 // CHECK:           %[[VAL_4:.*]] = arith.uitofp %[[VAL_3]] : i8 to f64
@@ -218,7 +218,7 @@ bool f14(bool *a, float b) {
 // CHECK:           %[[VAL_6:.*]] = arith.cmpf une, %[[VAL_5]], %[[VAL_2]] : f64
 // CHECK:           %[[VAL_7:.*]] = arith.extui %[[VAL_6]] : i1 to i8
 // CHECK:           affine.store %[[VAL_7]], %[[VAL_0]][0] : memref<?xi8>
-// CHECK:           return %[[VAL_7]] : i8
+// CHECK:           return %[[VAL_6]] : i1
 // CHECK:         }
 
 bool f15(bool *a, double b) {

--- a/polygeist/tools/cgeist/Test/Verification/scor.c
+++ b/polygeist/tools/cgeist/Test/Verification/scor.c
@@ -29,10 +29,10 @@ void kernel_correlation(double out[28], double stddev[28], _Bool cmp)
 
 }
 
-// CHECK:   func @kernel_correlation(%arg0: memref<?xf64>, %arg1: memref<?xf64>, %arg2: i8)
+// CHECK:   func @kernel_correlation(%arg0: memref<?xf64>, %arg1: memref<?xf64>, %arg2: i1)
 // CHECK-DAG:     %[[cst:.+]] = arith.constant 1.000000e+00 : f64
 // CHECK-DAG:     %[[cst_0:.+]] = arith.constant 3.140000e+00 : f64
-// CHECK:     %[[sel:.+]] = arith.select %{{.*}}, %[[cst]], %[[cst_0]] : f64
+// CHECK-NEXT:    %[[sel:.+]] = arith.select %arg2, %[[cst]], %[[cst_0]] : f64
 // CHECK-NEXT:     affine.for %arg3 = 0 to 28 {
 // CHECK-NEXT:       affine.store %[[cst_0]], %arg1[%arg3] : memref<?xf64>
 // CHECK-NEXT:       affine.store %[[sel]], %arg0[%arg3] : memref<?xf64>
@@ -40,4 +40,4 @@ void kernel_correlation(double out[28], double stddev[28], _Bool cmp)
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 
-// FULLRANK: func @kernel_correlation(%{{.*}}: memref<28xf64>, %{{.*}}: memref<28xf64>, %{{.*}}: i8)
+// FULLRANK: func @kernel_correlation(%{{.*}}: memref<28xf64>, %{{.*}}: memref<28xf64>, %{{.*}}: i1)

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -655,14 +655,14 @@ SYCL_EXTERNAL void group_get_local_linear_range(sycl::group<1> group) {
 // CHECK-MLIR-NEXT: %0 = "polygeist.memref2pointer"(%arg0) : (memref<?x![[ITEM2]]>) -> !llvm.ptr<![[ITEM2]]>
 // CHECK-MLIR-NEXT: %1 = llvm.addrspacecast %0 : !llvm.ptr<![[ITEM2]]> to !llvm.ptr<![[ITEM2]], 4>
 // CHECK-MLIR-NEXT: %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<![[ITEM2]], 4>) -> memref<?x![[ITEM2]], 4>
-// CHECK-MLIR-NEXT: %3 = sycl.call(%2, %2) {FunctionName = @"operator==", MangledFunctionName = @_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_, TypeName = @item} : (memref<?x![[ITEM2]], 4>, memref<?x![[ITEM2]], 4>) -> i8
+// CHECK-MLIR-NEXT: %3 = sycl.call(%2, %2) {FunctionName = @"operator==", MangledFunctionName = @_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_, TypeName = @item} : (memref<?x![[ITEM2]], 4>, memref<?x![[ITEM2]], 4>) -> i1
 // CHECK-MLIR-NEXT: return
 // CHECK-MLIR-NEXT: }
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8method_2N4sycl3_V14itemILi2ELb1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::item.2.true"* noundef byval(%"class.sycl::_V1::item.2.true") align 8 %0) #[[FUNCATTRS]]
 // CHECK-LLVM-NEXT:  %2 = addrspacecast %"class.sycl::_V1::item.2.true"* %0 to %"class.sycl::_V1::item.2.true" addrspace(4)*
-// CHECK-LLVM-NEXT:  %3 = call spir_func i8 @_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_(%"class.sycl::_V1::item.2.true" addrspace(4)* %2, %"class.sycl::_V1::item.2.true" addrspace(4)* %2)
+// CHECK-LLVM-NEXT:  %3 = call spir_func i1 @_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_(%"class.sycl::_V1::item.2.true" addrspace(4)* %2, %"class.sycl::_V1::item.2.true" addrspace(4)* %2)
 // CHECK-LLVM-NEXT:  ret void
 // CHECK-LLVM-NEXT: }
 
@@ -678,7 +678,7 @@ SYCL_EXTERNAL void method_2(sycl::item<2, true> item) {
 // CHECK-MLIR-NEXT: %3 = "polygeist.memref2pointer"(%arg1) : (memref<?x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
 // CHECK-MLIR-NEXT: %4 = llvm.addrspacecast %3 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
 // CHECK-MLIR-NEXT: %5 = "polygeist.pointer2memref"(%4) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
-// CHECK-MLIR-NEXT: %6 = sycl.call(%2, %5) {FunctionName = @"operator==", MangledFunctionName = @_ZNK4sycl3_V12idILi2EEeqERKS2_, TypeName = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> i8
+// CHECK-MLIR-NEXT: %6 = sycl.call(%2, %5) {FunctionName = @"operator==", MangledFunctionName = @_ZNK4sycl3_V12idILi2EEeqERKS2_, TypeName = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> i1
 // CHECK-MLIR-NEXT: return
 // CHECK-MLIR-NEXT: }
 
@@ -686,7 +686,7 @@ SYCL_EXTERNAL void method_2(sycl::item<2, true> item) {
 // CHECK-LLVM            %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %0, %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %1) #[[FUNCATTRS]]
 // CHECK-LLVM-NEXT: %3 = addrspacecast %"class.sycl::_V1::id.2"* %0 to %"class.sycl::_V1::id.2" addrspace(4)*
 // CHECK-LLVM-NEXT: %4 = addrspacecast %"class.sycl::_V1::id.2"* %1 to %"class.sycl::_V1::id.2" addrspace(4)*
-// CHECK-LLVM-NEXT: %5 = call spir_func i8 @_ZNK4sycl3_V12idILi2EEeqERKS2_(%"class.sycl::_V1::id.2" addrspace(4)* %3, %"class.sycl::_V1::id.2" addrspace(4)* %4)
+// CHECK-LLVM-NEXT: %5 = call spir_func i1 @_ZNK4sycl3_V12idILi2EEeqERKS2_(%"class.sycl::_V1::id.2" addrspace(4)* %3, %"class.sycl::_V1::id.2" addrspace(4)* %4)
 // CHECK-LLVM-NEXT: ret void
 // CHECK-LLVM-NEXT: }
 

--- a/polygeist/tools/cgeist/Test/Verification/templatemember.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/templatemember.cpp
@@ -15,7 +15,7 @@ bool add_kernel_cuda() {
   return Info<House>::has_infinity;
 }
 
-//  CHECK:   func @_Z15add_kernel_cudav() -> i8 attributes {llvm.linkage = #llvm.linkage<external>} {
-//  CHECK-NEXT:     %c1_i8 = arith.constant 1 : i8
-//  CHECK-NEXT:     return %c1_i8 : i8
+//  CHECK:   func @_Z15add_kernel_cudav() -> i1 attributes {llvm.linkage = #llvm.linkage<external>} {
+//  CHECK-NEXT:     %true = arith.constant true
+//  CHECK-NEXT:     return %true : i1
 //  CHECK-NEXT:   }

--- a/polygeist/tools/cgeist/Test/Verification/twotemplatevardecls.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/twotemplatevardecls.cpp
@@ -18,9 +18,9 @@ unsigned char conv() {
 }
 
 
-// CHECK:   func @_Z7failurev() -> i8 
-// CHECK-NEXT:     %c1_i8 = arith.constant 1 : i8
-// CHECK-NEXT:     return %c1_i8 : i8
+// CHECK:   func @_Z7failurev() -> i1
+// CHECK-NEXT:     %true = arith.constant true
+// CHECK-NEXT:     return %true : i1
 // CHECK-NEXT:   }
 // CHECK:   func @_Z4convv() -> i8 
 // CHECK-NEXT:     %c1_i8 = arith.constant 1 : i8


### PR DESCRIPTION
Keep using i8 for memory Boolean values.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>