### PR TITLE
[SYCL] Merge USMAllocContext for Sub-Devices and Sub-Sub-Devices

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -8229,7 +8229,7 @@ pi_result piextUSMDeviceAlloc(void **ResultPtr, pi_context Context,
     if (It == Context->DeviceMemAllocContexts.end())
       return PI_ERROR_INVALID_VALUE;
 
-    *ResultPtr = It->second.get()->allocate(Size, Alignment);
+    *ResultPtr = It->second->allocate(Size, Alignment);
     if (IndirectAccessTrackingEnabled) {
       // Keep track of all memory allocations in the context
       Context->MemAllocs.emplace(std::piecewise_construct,
@@ -8307,7 +8307,7 @@ pi_result piextUSMSharedAlloc(void **ResultPtr, pi_context Context,
     if (It == Allocator.end())
       return PI_ERROR_INVALID_VALUE;
 
-    *ResultPtr = It->second.get()->allocate(Size, Alignment);
+    *ResultPtr = It->second->allocate(Size, Alignment);
     if (DeviceReadOnly) {
       Context->SharedReadOnlyAllocs.insert(*ResultPtr);
     }
@@ -8475,7 +8475,7 @@ static pi_result USMFreeHelper(pi_context Context, void *Ptr,
               return PI_ERROR_INVALID_VALUE;
 
             // The right context is found, deallocate the pointer
-            It->second.get()->deallocate(Ptr, OwnZeMemHandle);
+            It->second->deallocate(Ptr, OwnZeMemHandle);
           } catch (const UsmAllocationException &Ex) {
             return Ex.getError();
           }

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -794,9 +794,10 @@ pi_result _pi_context::initialize() {
        &createUSMAllocatorsRecursive](pi_device Device) -> void {
     createUSMAllocators(Device);
     for (auto &SubDevice : Device->SubDevices)
-      // Share USMAllocCOntext of CCS and sub-device.
-      if (!SubDevice->isCCS())
-        createUSMAllocatorsRecursive(SubDevice);
+      if (SubDevice->isCCS())
+      	// CCS share USMAllocContext with its root device.
+	continue;
+      createUSMAllocatorsRecursive(SubDevice);
   };
 
   // Create USM allocator context for each pair (device, context).

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -772,27 +772,27 @@ pi_result _pi_context::initialize() {
   // Helper lambda to create various USM allocators for a device.
   // For SubDevices, create a shared pointer.
   auto createUSMAllocators = [this](pi_device Device) {
-
     SharedMemAllocContexts.emplace(
         std::piecewise_construct, std::make_tuple(Device),
-        std::make_tuple(std::make_shared<USMAllocContext>(
-        std::unique_ptr<SystemMemory>(new USMSharedMemoryAlloc(this, Device)))));
+        std::make_tuple(
+            std::make_shared<USMAllocContext>(std::unique_ptr<SystemMemory>(
+                new USMSharedMemoryAlloc(this, Device)))));
 
     SharedReadOnlyMemAllocContexts.emplace(
         std::piecewise_construct, std::make_tuple(Device),
-        std::make_tuple(std::make_shared<USMAllocContext>(
-        std::unique_ptr<SystemMemory>(new USMSharedReadOnlyMemoryAlloc(this, Device)))));
+        std::make_tuple(
+            std::make_shared<USMAllocContext>(std::unique_ptr<SystemMemory>(
+                new USMSharedReadOnlyMemoryAlloc(this, Device)))));
 
     DeviceMemAllocContexts.emplace(
         std::piecewise_construct, std::make_tuple(Device),
         std::make_tuple(std::make_shared<USMAllocContext>(
-        std::unique_ptr<USMDeviceMemoryAlloc>(new USMDeviceMemoryAlloc(
-            this, Device)))));
+            std::unique_ptr<USMDeviceMemoryAlloc>(
+                new USMDeviceMemoryAlloc(this, Device)))));
   };
 
-  auto copyUSMAllocatorOfSubDeviceToCCS =
-       [this](pi_device CCS, pi_device SubDevice) {
-
+  auto copyUSMAllocatorOfSubDeviceToCCS = [this](pi_device CCS,
+                                                 pi_device SubDevice) {
     if (SharedMemAllocContexts.find(SubDevice) !=
         SharedMemAllocContexts.end()) {
       SharedMemAllocContexts.emplace(
@@ -8467,7 +8467,8 @@ static pi_result USMFreeHelper(pi_context Context, void *Ptr,
 
     auto DeallocationHelper =
         [Context, Device, Ptr, OwnZeMemHandle](
-            std::unordered_map<pi_device, std::shared_ptr<USMAllocContext>> &AllocContextMap) {
+            std::unordered_map<pi_device, std::shared_ptr<USMAllocContext>>
+                &AllocContextMap) {
           try {
             auto It = AllocContextMap.find(Device);
             if (It == AllocContextMap.end())

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -793,11 +793,12 @@ pi_result _pi_context::initialize() {
       [createUSMAllocators,
        &createUSMAllocatorsRecursive](pi_device Device) -> void {
     createUSMAllocators(Device);
-    for (auto &SubDevice : Device->SubDevices)
+    for (auto &SubDevice : Device->SubDevices) {
       if (SubDevice->isCCS())
       	// CCS share USMAllocContext with its root device.
 	continue;
       createUSMAllocatorsRecursive(SubDevice);
+    }
   };
 
   // Create USM allocator context for each pair (device, context).

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -462,9 +462,9 @@ struct _pi_context : _pi_object {
   // Store USM allocator context(internal allocator structures)
   // for USM shared and device allocations. There is 1 allocator context
   // per each pair of (context, device) per each memory type.
-  std::unordered_map<pi_device, USMAllocContext> DeviceMemAllocContexts;
-  std::unordered_map<pi_device, USMAllocContext> SharedMemAllocContexts;
-  std::unordered_map<pi_device, USMAllocContext> SharedReadOnlyMemAllocContexts;
+  std::unordered_map<pi_device, std::shared_ptr<USMAllocContext>> DeviceMemAllocContexts;
+  std::unordered_map<pi_device, std::shared_ptr<USMAllocContext>> SharedMemAllocContexts;
+  std::unordered_map<pi_device, std::shared_ptr<USMAllocContext>> SharedReadOnlyMemAllocContexts;
 
   // Since L0 native runtime does not distinguisg "shared device_read_only"
   // vs regular "shared" allocations, we have keep track of it to use

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -462,11 +462,11 @@ struct _pi_context : _pi_object {
   // Store USM allocator context(internal allocator structures)
   // for USM shared and device allocations. There is 1 allocator context
   // per each pair of (context, device) per each memory type.
-  std::unordered_map<pi_device, std::shared_ptr<USMAllocContext>>
+  std::unordered_map<ze_device_handle_t, USMAllocContext>
       DeviceMemAllocContexts;
-  std::unordered_map<pi_device, std::shared_ptr<USMAllocContext>>
+  std::unordered_map<ze_device_handle_t, USMAllocContext>
       SharedMemAllocContexts;
-  std::unordered_map<pi_device, std::shared_ptr<USMAllocContext>>
+  std::unordered_map<ze_device_handle_t, USMAllocContext>
       SharedReadOnlyMemAllocContexts;
 
   // Since L0 native runtime does not distinguisg "shared device_read_only"

--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -462,9 +462,12 @@ struct _pi_context : _pi_object {
   // Store USM allocator context(internal allocator structures)
   // for USM shared and device allocations. There is 1 allocator context
   // per each pair of (context, device) per each memory type.
-  std::unordered_map<pi_device, std::shared_ptr<USMAllocContext>> DeviceMemAllocContexts;
-  std::unordered_map<pi_device, std::shared_ptr<USMAllocContext>> SharedMemAllocContexts;
-  std::unordered_map<pi_device, std::shared_ptr<USMAllocContext>> SharedReadOnlyMemAllocContexts;
+  std::unordered_map<pi_device, std::shared_ptr<USMAllocContext>>
+      DeviceMemAllocContexts;
+  std::unordered_map<pi_device, std::shared_ptr<USMAllocContext>>
+      SharedMemAllocContexts;
+  std::unordered_map<pi_device, std::shared_ptr<USMAllocContext>>
+      SharedReadOnlyMemAllocContexts;
 
   // Since L0 native runtime does not distinguisg "shared device_read_only"
   // vs regular "shared" allocations, we have keep track of it to use


### PR DESCRIPTION
**Problem:**
Currently, sub-devices and sub-sub-devices have different USM allocation contexts (USMAllocContext) but they share the same ze_device_handle. This causes issues with USM memory allocation, for instance, double-free.

**Proposed Fix:**
I have merged the USMAllocContext of the sub-device and sub-sub-device.