### PR TITLE
[SYCL][Fusion] Remove LLVM include from header

### DIFF
--- a/sycl-fusion/jit-compiler/include/JITContext.h
+++ b/sycl-fusion/jit-compiler/include/JITContext.h
@@ -9,13 +9,16 @@
 #ifndef SYCL_FUSION_JIT_COMPILER_JITCONTEXT_H
 #define SYCL_FUSION_JIT_COMPILER_JITCONTEXT_H
 
-#include "llvm/IR/LLVMContext.h"
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
 
 #include "Kernel.h"
 #include "Parameter.h"
+
+namespace llvm {
+class LLVMContext;
+} // namespace llvm
 
 namespace jit_compiler {
 

--- a/sycl-fusion/jit-compiler/include/KernelFusion.h
+++ b/sycl-fusion/jit-compiler/include/KernelFusion.h
@@ -13,7 +13,9 @@
 #include "Kernel.h"
 #include "Options.h"
 #include "Parameter.h"
+#include <cassert>
 #include <string>
+#include <variant>
 #include <vector>
 
 namespace jit_compiler {

--- a/sycl-fusion/jit-compiler/lib/JITContext.cpp
+++ b/sycl-fusion/jit-compiler/lib/JITContext.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "JITContext.h"
+#include "llvm/IR/LLVMContext.h"
 
 using namespace jit_compiler;
 


### PR DESCRIPTION
Remove includes of LLVM headers from the public surface of the JIT compiler (i.e., public headers). 

This avoids inheriting warnings from the LLVM codebase, which turn into compilation errors when compiling the SYCL runtime with `SYCL_ENABLE_WERROR=ON`.

Signed-off-by: Lukas Sommer <lukas.sommer@codeplay.com>