### PR TITLE
[SYCL] Use correct template args for host_accessor constructors

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -2962,7 +2962,7 @@ public:
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>::value>>
   host_accessor(
-      buffer<DataT, Dimensions, AllocatorT> &BufferRef, mode_tag_t<AccessMode>,
+      buffer<T, Dims, AllocatorT> &BufferRef, mode_tag_t<AccessMode>,
       const property_list &PropertyList = {},
       const detail::code_location CodeLoc = detail::code_location::current())
       : host_accessor(BufferRef, PropertyList, CodeLoc) {}
@@ -2978,35 +2978,32 @@ public:
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>::value>>
   host_accessor(
-      buffer<DataT, Dimensions, AllocatorT> &BufferRef,
-      handler &CommandGroupHandler, mode_tag_t<AccessMode>,
-      const property_list &PropertyList = {},
+      buffer<T, Dims, AllocatorT> &BufferRef, handler &CommandGroupHandler,
+      mode_tag_t<AccessMode>, const property_list &PropertyList = {},
       const detail::code_location CodeLoc = detail::code_location::current())
       : host_accessor(BufferRef, CommandGroupHandler, PropertyList, CodeLoc) {}
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>::value>>
   host_accessor(
-      buffer<DataT, Dimensions, AllocatorT> &BufferRef,
-      range<Dimensions> AccessRange, const property_list &PropertyList = {},
+      buffer<T, Dims, AllocatorT> &BufferRef, range<Dimensions> AccessRange,
+      const property_list &PropertyList = {},
       const detail::code_location CodeLoc = detail::code_location::current())
       : AccessorT(BufferRef, AccessRange, {}, PropertyList, CodeLoc) {}
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>::value>>
   host_accessor(
-      buffer<DataT, Dimensions, AllocatorT> &BufferRef,
-      range<Dimensions> AccessRange, mode_tag_t<AccessMode>,
-      const property_list &PropertyList = {},
+      buffer<T, Dims, AllocatorT> &BufferRef, range<Dimensions> AccessRange,
+      mode_tag_t<AccessMode>, const property_list &PropertyList = {},
       const detail::code_location CodeLoc = detail::code_location::current())
       : host_accessor(BufferRef, AccessRange, {}, PropertyList, CodeLoc) {}
 
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>::value>>
   host_accessor(
-      buffer<DataT, Dimensions, AllocatorT> &BufferRef,
-      handler &CommandGroupHandler, range<Dimensions> AccessRange,
-      const property_list &PropertyList = {},
+      buffer<T, Dims, AllocatorT> &BufferRef, handler &CommandGroupHandler,
+      range<Dimensions> AccessRange, const property_list &PropertyList = {},
       const detail::code_location CodeLoc = detail::code_location::current())
       : AccessorT(BufferRef, CommandGroupHandler, AccessRange, {}, PropertyList,
                   CodeLoc) {}
@@ -3014,9 +3011,9 @@ public:
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>::value>>
   host_accessor(
-      buffer<DataT, Dimensions, AllocatorT> &BufferRef,
-      handler &CommandGroupHandler, range<Dimensions> AccessRange,
-      mode_tag_t<AccessMode>, const property_list &PropertyList = {},
+      buffer<T, Dims, AllocatorT> &BufferRef, handler &CommandGroupHandler,
+      range<Dimensions> AccessRange, mode_tag_t<AccessMode>,
+      const property_list &PropertyList = {},
       const detail::code_location CodeLoc = detail::code_location::current())
       : host_accessor(BufferRef, CommandGroupHandler, AccessRange, {},
                       PropertyList, CodeLoc) {}
@@ -3024,9 +3021,8 @@ public:
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>::value>>
   host_accessor(
-      buffer<DataT, Dimensions, AllocatorT> &BufferRef,
-      range<Dimensions> AccessRange, id<Dimensions> AccessOffset,
-      const property_list &PropertyList = {},
+      buffer<T, Dims, AllocatorT> &BufferRef, range<Dimensions> AccessRange,
+      id<Dimensions> AccessOffset, const property_list &PropertyList = {},
       const detail::code_location CodeLoc = detail::code_location::current())
       : AccessorT(BufferRef, AccessRange, AccessOffset, PropertyList, CodeLoc) {
   }
@@ -3034,9 +3030,9 @@ public:
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>::value>>
   host_accessor(
-      buffer<DataT, Dimensions, AllocatorT> &BufferRef,
-      range<Dimensions> AccessRange, id<Dimensions> AccessOffset,
-      mode_tag_t<AccessMode>, const property_list &PropertyList = {},
+      buffer<T, Dims, AllocatorT> &BufferRef, range<Dimensions> AccessRange,
+      id<Dimensions> AccessOffset, mode_tag_t<AccessMode>,
+      const property_list &PropertyList = {},
       const detail::code_location CodeLoc = detail::code_location::current())
       : host_accessor(BufferRef, AccessRange, AccessOffset, PropertyList,
                       CodeLoc) {}
@@ -3044,9 +3040,9 @@ public:
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>::value>>
   host_accessor(
-      buffer<DataT, Dimensions, AllocatorT> &BufferRef,
-      handler &CommandGroupHandler, range<Dimensions> AccessRange,
-      id<Dimensions> AccessOffset, const property_list &PropertyList = {},
+      buffer<T, Dims, AllocatorT> &BufferRef, handler &CommandGroupHandler,
+      range<Dimensions> AccessRange, id<Dimensions> AccessOffset,
+      const property_list &PropertyList = {},
       const detail::code_location CodeLoc = detail::code_location::current())
       : AccessorT(BufferRef, CommandGroupHandler, AccessRange, AccessOffset,
                   PropertyList, CodeLoc) {}
@@ -3054,10 +3050,9 @@ public:
   template <typename T = DataT, int Dims = Dimensions, typename AllocatorT,
             typename = detail::enable_if_t<IsSameAsBuffer<T, Dims>::value>>
   host_accessor(
-      buffer<DataT, Dimensions, AllocatorT> &BufferRef,
-      handler &CommandGroupHandler, range<Dimensions> AccessRange,
-      id<Dimensions> AccessOffset, mode_tag_t<AccessMode>,
-      const property_list &PropertyList = {},
+      buffer<T, Dims, AllocatorT> &BufferRef, handler &CommandGroupHandler,
+      range<Dimensions> AccessRange, id<Dimensions> AccessOffset,
+      mode_tag_t<AccessMode>, const property_list &PropertyList = {},
       const detail::code_location CodeLoc = detail::code_location::current())
       : host_accessor(BufferRef, CommandGroupHandler, AccessRange, AccessOffset,
                       PropertyList, CodeLoc) {}

--- a/sycl/test/basic_tests/accessor/zero-dim-host-accessor.cpp
+++ b/sycl/test/basic_tests/accessor/zero-dim-host-accessor.cpp
@@ -1,0 +1,17 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %t.out
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  using DataT = int;
+  using AccT = sycl::host_accessor<DataT, 0>;
+  int data(5);
+  sycl::range<1> r(1);
+  sycl::buffer<DataT, 1> data_buf(&data, r);
+  AccT acc{data_buf};
+  assert(acc.get_size() == sizeof(DataT));
+  assert(acc.size() == 1);
+  auto ref = &acc;
+  assert(*ref == 5);
+}


### PR DESCRIPTION
Prior to this change using the host_accessor zero dimension constructor would result in a series of errors because some constructors were using `DataT, Dimensions` (the class template args) for `buffer`. During template exploration, the compiler would try and instantiate buffer with `Dimensions = 0`, which is not possible, and that would trigger the series of errors mentioned before. Using `T, Dims` (the function template args) the rest of constructors are not enabled because the dimensions of the host_accessor and the dimensions of the buffer don't match.