### PR TITLE
[SYCL] Fix a missing include

### DIFF
--- a/sycl-fusion/jit-compiler/include/JITContext.h
+++ b/sycl-fusion/jit-compiler/include/JITContext.h
@@ -9,6 +9,7 @@
 #ifndef SYCL_FUSION_JIT_COMPILER_JITCONTEXT_H
 #define SYCL_FUSION_JIT_COMPILER_JITCONTEXT_H
 
+#include <memory>
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>


### PR DESCRIPTION
std::unique_ptr is in <memory> and without it we get a compilation error with gcc-12