### PR TITLE
[SYCL][Fusion] Suppress build error message for gcc 11.3.0

### DIFF
--- a/sycl-fusion/jit-compiler/include/JITContext.h
+++ b/sycl-fusion/jit-compiler/include/JITContext.h
@@ -9,6 +9,7 @@
 #ifndef SYCL_FUSION_JIT_COMPILER_JITCONTEXT_H
 #define SYCL_FUSION_JIT_COMPILER_JITCONTEXT_H
 
+#include <memory>
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>


### PR DESCRIPTION
The error is:
```
/repo/sycl-fusion/jit-compiler/include/JITContext.h:61:8: error: ‘unique_ptr’ in namespace ‘std’ does not name a template type
   61 |   std::unique_ptr<llvm::LLVMContext> LLVMCtx;
      |        ^~~~~~~~~~
/repo/sycl-fusion/jit-compiler/include/JITContext.h:18:1: note: ‘std::unique_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?
   17 | #include "Parameter.h"
  +++ |+#include <memory>
   18 |
```