### PR TITLE
[SYCL] Use const qualifier in several `accessor_iterator` operators

### DIFF
--- a/sycl/include/sycl/detail/accessor_iterator.hpp
+++ b/sycl/include/sycl/detail/accessor_iterator.hpp
@@ -55,7 +55,9 @@ public:
 
   accessor_iterator() = default;
 
-  reference operator*() { return *(MDataPtr + getAbsoluteOffsetToBuffer()); }
+  reference operator*() const {
+    return *(MDataPtr + getAbsoluteOffsetToBuffer());
+  }
 
   accessor_iterator &operator++() {
     ++MLinearId;
@@ -85,9 +87,8 @@ public:
     return *this;
   }
 
-  friend accessor_iterator operator+(const accessor_iterator &Lhs,
-                                     difference_type N) {
-    auto Ret = Lhs;
+  accessor_iterator operator+(difference_type N) const {
+    auto Ret = *this;
     Ret += N;
     return Ret;
   }
@@ -105,13 +106,12 @@ public:
     return *this;
   }
 
-  friend accessor_iterator operator-(const accessor_iterator &Lhs,
-                                     difference_type N) {
-    auto Temp = Lhs;
+  accessor_iterator operator-(difference_type N) const {
+    auto Temp = *this;
     return Temp -= N;
   }
 
-  reference &operator[](difference_type N) {
+  reference &operator[](difference_type N) const {
     auto Copy = *this;
     Copy += N;
     return *Copy;
@@ -139,7 +139,7 @@ public:
     return !(*this == Other);
   }
 
-  difference_type operator-(const accessor_iterator &Rhs) {
+  difference_type operator-(const accessor_iterator &Rhs) const {
     return MLinearId - Rhs.MLinearId;
   }
 
@@ -232,7 +232,7 @@ private:
   //
   // This function performs necessary calculations to make sure that all
   // access ranges and offsets are taken into account.
-  size_t getAbsoluteOffsetToBuffer() {
+  size_t getAbsoluteOffsetToBuffer() const {
     // For 1D case, any possible offsets are already incorporated into
     // MLinearId, so 1D is always treated as a non-ranged accessor
     if (!MAccessorIsRanged || Dimensions == 1)


### PR DESCRIPTION
In order to be compliant with the `std::reverse_iterator` adaptor, different operators require const qualifier. Otherwise, it might prevent compilation depending on the implementation of `std::reverse_iterator` (e.g. MSVC).