### PR TITLE
[SYCL][Matrix] Make sure joint matrix API is only used by CUDA and SPIR backends

### DIFF
--- a/sycl/include/sycl/detail/defines.hpp
+++ b/sycl/include/sycl/detail/defines.hpp
@@ -40,6 +40,9 @@
 #define __SYCL_TYPE(x)
 #endif
 
+// joint matrix should only be included by default for SPIR or NVPTX backends
+#if defined __SPIR__ || defined __NVPTX__ || !defined __SYCL_DEVICE_ONLY
 #ifndef SYCL_EXT_ONEAPI_MATRIX_VERSION
 #define SYCL_EXT_ONEAPI_MATRIX_VERSION 4
 #endif // SYCL_EXT_ONEAPI_MATRIX_VERSION
+#endif // __SPIR__ || __NVPTX__ || !__SYCL_DEVICE_ONLY

--- a/sycl/include/sycl/detail/defines.hpp
+++ b/sycl/include/sycl/detail/defines.hpp
@@ -41,7 +41,7 @@
 #endif
 
 // joint matrix should only be included by default for SPIR or NVPTX backends
-#if defined __SPIR__ || defined __NVPTX__ || !defined __SYCL_DEVICE_ONLY
+#if defined __SPIR__ || defined __NVPTX__ || !defined __SYCL_DEVICE_ONLY__
 #ifndef SYCL_EXT_ONEAPI_MATRIX_VERSION
 #define SYCL_EXT_ONEAPI_MATRIX_VERSION 4
 #endif // SYCL_EXT_ONEAPI_MATRIX_VERSION

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-unified.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-unified.hpp
@@ -24,10 +24,14 @@ struct joint_matrix {
 #if defined(__NVPTX__)
   sycl::ext::oneapi::detail::joint_matrix_cuda<T, Use, Rows, Cols, Layout>
       cuda_impl;
-#else
+#elif defined(__SPIR__)
   __spv::__spirv_JointMatrixINTEL<
       T, Rows, Cols, spv_matrix_layout_traits<Layout>::value,
       spv_scope_traits<Group>::value, spv_matrix_use_traits<Use>::value> *spvm;
+#else
+  static_assert(
+      false,
+      "The joint_matrix API is only supported by the Intel and CUDA backends");
 #endif // defined(__NVPTX__)
 #endif // defined(__SYCL_DEVICE_ONLY__)
 


### PR DESCRIPTION
Adding static assert to make sure joint matrix API is only used by CUDA, SPIR backends