### PR TITLE
[SYCL] Teach libclc-remangler to accept .bc and .ll

### DIFF
--- a/libclc/utils/libclc-remangler/LibclcRemangler.cpp
+++ b/libclc/utils/libclc-remangler/LibclcRemangler.cpp
@@ -45,6 +45,7 @@
 #include "llvm/Demangle/ItaniumDemangle.h"
 #include "llvm/IR/DiagnosticInfo.h"
 #include "llvm/IR/DiagnosticPrinter.h"
+#include "llvm/IRReader/IRReader.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/ValueMapper.h"
@@ -781,11 +782,12 @@ public:
 
   void Initialize(ASTContext &C) override {
     ContextAST = &C;
-
+    SMDiagnostic Err;
     std::unique_ptr<MemoryBuffer> const Buff = ExitOnErr(
         errorOrToExpected(MemoryBuffer::getFileOrSTDIN(InputIRFilename)));
     std::unique_ptr<llvm::Module> const M =
-        ExitOnErr(parseBitcodeFile(Buff.get()->getMemBufferRef(), ContextLLVM));
+        ExitOnErr(Expected<std::unique_ptr<llvm::Module>>(
+            parseIR(Buff.get()->getMemBufferRef(), Err, ContextLLVM)));
 
     handleModule(M.get());
   }


### PR DESCRIPTION
I was trying to reduce a crash using `llvm-reduce`, and it took me while to realise why my interestingness test was failing: `llvm-reduce` passes llvm assembly - rather than bitcode files - to the interestingness test. This caused `libclc-remangler to exit with an error.