### PR TITLE
[SYCL][Fusion] Fix dependencies for fusion passes

### DIFF
--- a/sycl-fusion/passes/CMakeLists.txt
+++ b/sycl-fusion/passes/CMakeLists.txt
@@ -7,6 +7,9 @@ add_llvm_library(SYCLKernelFusion MODULE
   syclcp/SYCLCP.cpp
   cleanup/Cleanup.cpp
   debug/PassDebug.cpp
+
+  DEPENDS
+  intrinsics_gen
 )
 
 target_include_directories(SYCLKernelFusion
@@ -25,6 +28,9 @@ add_llvm_library(SYCLKernelFusionPasses
   syclcp/SYCLCP.cpp
   cleanup/Cleanup.cpp
   debug/PassDebug.cpp
+
+  DEPENDS
+  intrinsics_gen
 
   LINK_COMPONENTS
   Core


### PR DESCRIPTION
Fusion libraries with LLVM passes include headers, which use intrinsics tables generated by TableGen.

Following error appears when dependencies aren't satisfied:

```
In file included from llvm/include/llvm/IR/InstrTypes.h:24,
                 from llvm/include/llvm/Analysis/TargetLibraryInfo.h:14,
                 from llvm/include/llvm/Analysis/LazyCallGraph.h:45,
                 from llvm/include/llvm/Analysis/CGSCCPassManager.h:92,
                 from llvm/include/llvm/Passes/PassBuilder.h:18,
                 from /sycl-fusion/passes/SYCLFusionPasses.cpp:9:
llvm/include/llvm/IR/Attributes.h:90:14: fatal error: llvm/IR/Attributes.inc: No such file or directory
   90 |     #include "llvm/IR/Attributes.inc"
      |              ^~~~~~~~~~~~~~~~~~~~~~~~
```