### PR TITLE
[ESIMD] Fix some stability and performance issues in code

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/ESIMDOptimizeVecArgCallConv.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/ESIMDOptimizeVecArgCallConv.cpp
@@ -462,9 +462,9 @@ static bool processFunction(Function *F) {
       NewParamTs.push_back(Arg.getType());
       continue;
     }
-    OptimizeableParams.emplace_back(std::move(PI));
+    OptimizeableParams.push_back(PI);
 
-    if (OptimizeableParams.back().isSret()) {
+    if (PI.isSret()) {
       continue; // optimizeable 'sret' parameter is removed in the clone
     }
     // parameter is converted from 'by pointer' to 'by value' passing, its type
@@ -510,7 +510,7 @@ ESIMDOptimizeVecArgCallConvPass::run(Module &M, ModuleAnalysisManager &MAM) {
 
   for (Function &F : M) {
     const bool FReplaced = processFunction(&F);
-    Modified &= FReplaced;
+    Modified |= FReplaced;
 
     if (FReplaced) {
       ToErase.push_back(&F);

--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMDVecArg.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMDVecArg.cpp
@@ -207,7 +207,7 @@ Function *ESIMDLowerVecArgPass::rewriteFunc(Function &F) {
     OldNewInst.push_back(std::make_pair(Call, NewCallInst));
   }
 
-  for (auto InstPair : OldNewInst) {
+  for (auto &InstPair : OldNewInst) {
     auto OldInst = InstPair.first;
     auto NewInst = InstPair.second;
     ReplaceInstWithInst(OldInst, NewInst);

--- a/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
+++ b/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
@@ -339,7 +339,7 @@ std::pair<Function *, Value *> GlobalOffsetPass::addOffsetArgumentToFunction(
     // Clone metadata of the old function, including debug info descriptor.
     SmallVector<std::pair<unsigned, MDNode *>, 1> MDs;
     Func->getAllMetadata(MDs);
-    for (auto MD : MDs)
+    for (const auto &MD : MDs)
       NewFunc->addMetadata(MD.first, *MD.second);
 
     ImplicitOffset = std::prev(NewFunc->arg_end());

--- a/llvm/lib/SYCLLowerIR/LocalAccessorToSharedMemory.cpp
+++ b/llvm/lib/SYCLLowerIR/LocalAccessorToSharedMemory.cpp
@@ -68,7 +68,7 @@ LocalAccessorToSharedMemoryPass::run(Module &M, ModuleAnalysisManager &) {
     return PreservedAnalyses::all();
 
   // Process the function and if changed, update the metadata.
-  for (auto K : Kernels) {
+  for (const auto &K : Kernels) {
     auto *NewKernel = processKernel(M, K.Kernel);
     if (NewKernel)
       NewToOldKernels.push_back(std::make_pair(NewKernel, K));
@@ -196,7 +196,7 @@ Function *LocalAccessorToSharedMemoryPass::processKernel(Module &M,
   // Clone metadata of the old function, including debug info descriptor.
   SmallVector<std::pair<unsigned, MDNode *>, 1> MDs;
   F->getAllMetadata(MDs);
-  for (auto MD : MDs)
+  for (const auto &MD : MDs)
     NF->addMetadata(MD.first, *MD.second);
 
   // Now that the old function is dead, delete it.

--- a/llvm/lib/SYCLLowerIR/LowerInvokeSimd.cpp
+++ b/llvm/lib/SYCLLowerIR/LowerInvokeSimd.cpp
@@ -364,8 +364,10 @@ bool processInvokeSimdCall(CallInst *InvokeSimd,
     Function *InvokeSimdF = InvokeSimd->getCalledFunction();
     assert(InvokeSimdF && "Unexpected IR for invoke_simd");
     // - type of the obsolete (unmodified) helper:
-    Type *HelperArgTy = InvokeSimdF->getArg(HelperArgNo)->getType();
-    unsigned AS = dyn_cast<PointerType>(HelperArgTy)->getAddressSpace();
+    PointerType *HelperArgTy =
+        dyn_cast<PointerType>(InvokeSimdF->getArg(HelperArgNo)->getType());
+    assert(HelperArgTy && "Unexpected IR for invoke_simd");
+    unsigned AS = HelperArgTy->getAddressSpace();
     FunctionType *InvokeSimdFTy = InvokeSimdF->getFunctionType();
     // - create the list of new formal parameter types (the old one, with the
     //   second element removed):

--- a/llvm/lib/SYCLLowerIR/MutatePrintfAddrspace.cpp
+++ b/llvm/lib/SYCLLowerIR/MutatePrintfAddrspace.cpp
@@ -125,7 +125,9 @@ Constant *getCASLiteral(GlobalVariable *GenericASLiteral) {
     return ExistingGlobal;
 
   StringRef LiteralValue;
-  getConstantStringInfo(GenericASLiteral, LiteralValue);
+  bool HasString = getConstantStringInfo(GenericASLiteral, LiteralValue);
+  if (!HasString)
+    llvm_unreachable("Unexpected string literal in getCASLiteral()");
   IRBuilder<> Builder(M->getContext());
   GlobalVariable *Res = Builder.CreateGlobalString(LiteralValue, CASLiteralName,
                                                    ConstantAddrspaceID, M);


### PR DESCRIPTION
Performance issues are simple (copy overhead in for loops). Stability issues are mostly usage of uninitialized variables. One of issues is usage after std::move().
One if issues is usage of "Modified &= ..." where "Modified |= ..." was supposed.

Signed-off-by: Vyacheslav N Klochkov <vyacheslav.n.klochkov@intel.com>