### PR TITLE
[SYCL] Throw exception when selected device is not in context

### DIFF
--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -143,9 +143,16 @@ select_device(const DSelectorInvocableType &DeviceSelectorInvocable) {
 __SYCL_EXPORT device
 select_device(const DSelectorInvocableType &DeviceSelectorInvocable,
               const context &SyclContext) {
-  std::vector<device> devices = SyclContext.get_devices();
+  device SelectedDevice = select_device(DeviceSelectorInvocable);
 
-  return select_device(DeviceSelectorInvocable, devices);
+  // Throw exception if selected device is not in context.
+  std::vector<device> Devices = SyclContext.get_devices();
+  if (std::find(Devices.begin(), Devices.end(), SelectedDevice) ==
+      Devices.end())
+    throw sycl::exception(sycl::make_error_code(errc::invalid),
+                          "Selected device is not in the given context.");
+
+  return SelectedDevice;
 }
 
 } // namespace detail


### PR DESCRIPTION
In accordance with the SYCL 2020 specification a device selector should always pick from all available devices. Likewise, the queue constructor should throw an exception if the selected device is not in the given context. This commit fixes the device selection behavior when a context is specified, throwing the corresponding exception. Note that this only affects SYCL 2020 style device selectors.