### PR TITLE
[SYCL][Doc] Correct the specified return type for the UUID query

### DIFF
--- a/sycl/doc/extensions/supported/sycl_ext_intel_device_info.md
+++ b/sycl/doc/extensions/supported/sycl_ext_intel_device_info.md
@@ -74,7 +74,7 @@ The extension supports this query in version 2 and later.
 
 | Device Descriptors | Return Type | Description |
 | ------------------ | ----------- | ----------- |
-| ext\:\:intel\:\:info\:\:device\:\:uuid | unsigned char | Returns the device UUID|
+| ext\:\:intel\:\:info\:\:device\:\:uuid | std::array<unsigned char, 16> | Returns the device UUID|
 
 
 ## Aspects ##


### PR DESCRIPTION
Align the specified return type with the current implementation and ze_device_uuid_t, which the query is supposed to map to.