### PR TITLE
[CI] Exclude stream test from SYCL-CTS runs

### DIFF
--- a/devops/cts_exclude_filter
+++ b/devops/cts_exclude_filter
@@ -21,3 +21,4 @@ kernel_bundle
 specialization_constants
 device_selector
 math_builtin_api
+stream


### PR DESCRIPTION
stream test is failing in post-commit with the following error:

> tests/stream/stream_constructors.cpp:44: FAILED:
> explicitly with message:
>   This test case has been compile-time disabled.

Temprorary disable the test to avoid false alarms in CI system.