### PR TITLE
[CI] Exclude marray test from SYCL-CTS runs

### DIFF
--- a/devops/cts_exclude_filter
+++ b/devops/cts_exclude_filter
@@ -22,3 +22,4 @@ specialization_constants
 device_selector
 math_builtin_api
 stream
+marray


### PR DESCRIPTION
Similar to #8057 new marray test is failing in post-commit with the following error:

> tests/marray/marray_alias.cpp:47: FAILED:
> explicitly with message:
>   This test case has been compile-time disabled.

Temprorary disable the test to avoid false alarms in CI system.