### PR TITLE
[SYCL] Make half default constructor constexpr

### DIFF
--- a/sycl/include/sycl/bit_cast.hpp
+++ b/sycl/include/sycl/bit_cast.hpp
@@ -41,8 +41,8 @@ constexpr
 #if __has_builtin(__builtin_bit_cast)
   return __builtin_bit_cast(To, from);
 #else  // __has_builtin(__builtin_bit_cast)
-  static_assert(std::is_trivially_default_constructible<To>::value,
-                "To must be trivially default constructible");
+  static_assert(std::is_default_constructible<To>::value,
+                "To must be default constructible");
   To to;
   sycl::detail::memcpy(&to, &from, sizeof(To));
   return to;

--- a/sycl/include/sycl/half_type.hpp
+++ b/sycl/include/sycl/half_type.hpp
@@ -137,7 +137,8 @@ namespace host_half_impl {
 // The main host half class
 class __SYCL_EXPORT half {
 public:
-  half() = default;
+  constexpr half() {}
+
   constexpr half(const half &) = default;
   constexpr half(half &&) = default;
 
@@ -206,7 +207,7 @@ public:
   friend class sycl::ext::intel::esimd::detail::WrapperElementTypeProxy;
 
 private:
-  uint16_t Buf;
+  uint16_t Buf = {};
 };
 
 } // namespace host_half_impl
@@ -272,7 +273,7 @@ class half {
 class [[__sycl_detail__::__uses_aspects__(aspect::fp16)]] half {
 #endif
 public:
-  half() = default;
+  constexpr half() {}
   constexpr half(const half &) = default;
   constexpr half(half &&) = default;
 
@@ -548,7 +549,7 @@ public:
   friend class sycl::ext::intel::esimd::detail::WrapperElementTypeProxy;
 
 private:
-  StorageT Data;
+  StorageT Data = {};
 };
 } // namespace half_impl
 

--- a/sycl/source/detail/builtins_relational.cpp
+++ b/sycl/source/detail/builtins_relational.cpp
@@ -116,6 +116,7 @@ template <> union databitset<s::cl_double> {
 template <> union databitset<s::cl_half> {
   static_assert(sizeof(s::cl_short) == sizeof(s::cl_half),
                 "size of cl_half is not equal to 16 bits(cl_short).");
+  databitset(): i(0) {}
   s::cl_half f;
   s::cl_short i;
 };

--- a/sycl/test/basic_tests/half-constexpr-constructor.cpp
+++ b/sycl/test/basic_tests/half-constexpr-constructor.cpp
@@ -1,0 +1,9 @@
+// RUN: %clangxx -fsycl -fsyntax-only %s
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  constexpr sycl::half h;
+
+  return 0;
+}

--- a/sycl/test/regression/half_union.cpp
+++ b/sycl/test/regression/half_union.cpp
@@ -5,7 +5,7 @@
 
 typedef union _u16_to_half {
   unsigned short u;
-  sycl::half h;
+  sycl::half h = 0.0;
 } u16_to_sycl_half;
 
 int main() {


### PR DESCRIPTION
Unfortunately, it seem to be impossible to have a trivial default constexpr constructor until we enable C++23 mode. Therefore, this patch made a few other adjustments to account for non-trivial default constructor of `half` class.