### PR TITLE
[SYCL] Assignment operators for 0-dim accessors

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -2755,15 +2755,15 @@ public:
 #endif
   }
 
-  template <int Dims = Dimensions,
-            typename = detail::enable_if_t<!std::is_const_v<DataT> && Dims == 0>>
+  template <int Dims = Dimensions, typename = detail::enable_if_t<
+                                       !std::is_const_v<DataT> && Dims == 0>>
   const local_accessor &operator=(const value_type &Other) const {
     *local_acc::getQualifiedPtr() = Other;
     return *this;
   }
 
-  template <int Dims = Dimensions,
-            typename = detail::enable_if_t<!std::is_const_v<DataT> && Dims == 0>>
+  template <int Dims = Dimensions, typename = detail::enable_if_t<
+                                       !std::is_const_v<DataT> && Dims == 0>>
   const local_accessor &operator=(value_type &&Other) const {
     *local_acc::getQualifiedPtr() = std::move(Other);
     return *this;

--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -2963,6 +2963,12 @@ protected:
 public:
   using value_type = DataT;
 
+  using iterator = typename detail::accessor_iterator<value_type, Dimensions>;
+  using const_iterator =
+      typename detail::accessor_iterator<const value_type, Dimensions>;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
   host_accessor() : AccessorT() {}
 
   // The list of host_accessor constructors with their arguments
@@ -3103,21 +3109,21 @@ public:
       : host_accessor(BufferRef, CommandGroupHandler, AccessRange, AccessOffset,
                       PropertyList, CodeLoc) {}
 
-  // template <int Dims = Dimensions,
-  //           typename = detail::enable_if_t<AccessMode != access_mode::atomic &&
-  //                                          !IsAccessReadOnly && Dims == 0>>
-  // const host_accessor &operator=(const value_type &Other) const {
-  //   *AccessorT::getQualifiedPtr() = Other;
-  //   return *this;
-  // }
+  template <int Dims = Dimensions,
+            typename = detail::enable_if_t<AccessMode != access_mode::atomic &&
+                                           !IsAccessReadOnly && Dims == 0>>
+  const host_accessor &operator=(const value_type &Other) const {
+    *AccessorT::getQualifiedPtr() = Other;
+    return *this;
+  }
 
-  // template <int Dims = Dimensions,
-  //           typename = detail::enable_if_t<AccessMode != access_mode::atomic &&
-  //                                          !IsAccessReadOnly && Dims == 0>>
-  // const host_accessor &operator=(value_type &&Other) const {
-  //   *AccessorT::getQualifiedPtr() = std::move(Other);
-  //   return *this;
-  // }
+  template <int Dims = Dimensions,
+            typename = detail::enable_if_t<AccessMode != access_mode::atomic &&
+                                           !IsAccessReadOnly && Dims == 0>>
+  const host_accessor &operator=(value_type &&Other) const {
+    *AccessorT::getQualifiedPtr() = std::move(Other);
+    return *this;
+  }
 };
 
 template <typename DataT, int Dimensions, typename AllocatorT>

--- a/sycl/test/basic_tests/accessor/accessor_assignment_operator.cpp
+++ b/sycl/test/basic_tests/accessor/accessor_assignment_operator.cpp
@@ -6,46 +6,56 @@
 #include <sycl/sycl.hpp>
 
 int main() {
-  sycl::queue q;
+  sycl::queue Q;
 
   {
-    int data = 16;
+    int Data = 0;
 
-    sycl::buffer<int, 1> Buf(&data, sycl::range<1>(1));
+    using AccT = sycl::accessor<int, 0, sycl::access::mode::read_write>;
+    sycl::buffer<int, 1> Buf(&Data, sycl::range<1>(1));
 
-    q.submit([&](sycl::handler &CGH) {
+    Q.submit([&](sycl::handler &CGH) {
       sycl::accessor<int, 0> A(Buf, CGH);
-      CGH.single_task<class KernelAccessor>([A] { A = 1; });
+      CGH.single_task<class KernelAccessor>([A] {
+        typename AccT::value_type DataToWrite = 1;
+        A = DataToWrite;
+      });
 
       assert(A == 1);
-    })
-    .wait_and_throw();
+    });
+    Q.wait();
   }
 
-  q.submit([&](sycl::handler &CGH) {
-    sycl::local_accessor<int, 0> LA{CGH};
-    CGH.single_task<class KernelLocalAccessor>([LA] { LA = 2; });
+  {
+    using AccT = sycl::local_accessor<int, 0>;
+    Q.submit([&](sycl::handler &CGH) {
+      AccT LA{CGH};
+      CGH.single_task<class KernelLocalAccessor>([LA] {
+        typename AccT::value_type DataToWrite = 2;
+        LA = DataToWrite;
+      });
 
-    assert(LA == 2);
-  })
-  .wait_and_throw();
+      assert(LA == 2);
+    });
+    Q.wait();
+  }
 
   {
-    using AccT = sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::host_buffer>;
-    int data = 16;
+    int Data = 0;
 
-    sycl::buffer<int> Buf(&data, sycl::range<1>(1));
+    using AccT = sycl::host_accessor<int, 0, sycl::access::mode::read_write>;
+    sycl::buffer<int> Buf(&Data, sycl::range<1>(1));
 
-    q.submit([&](sycl::handler &CGH) {
-      AccT HA(Buf, CGH);
+    Q.submit([&](sycl::handler &CGH) {
+      AccT HA(Buf);
       CGH.single_task<class KernelHostAccessor>([=] {
-        typename AccT::value_type Data = 3;
-        HA = Data;
+        typename AccT::value_type DataToWrite = 3;
+        HA = DataToWrite;
       });
 
       assert(HA == 3);
-    })
-    .wait_and_throw();
+    });
+    Q.wait();
   }
 
   return 0;

--- a/sycl/test/basic_tests/accessor/accessor_assignment_operator.cpp
+++ b/sycl/test/basic_tests/accessor/accessor_assignment_operator.cpp
@@ -1,0 +1,52 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+
+// Testing each of the specialised assignment operators of 0 dimensional
+// buffer accessors, local accessors, and host accessors.
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  sycl::queue q;
+
+  {
+    int data = 16;
+
+    sycl::buffer<int, 1> Buf(&data, sycl::range<1>(1));
+
+    q.submit([&](sycl::handler &CGH) {
+      sycl::accessor<int, 0> A(Buf, CGH);
+      CGH.single_task<class KernelAccessor>([A] { A = 1; });
+
+      assert(A == 1);
+    })
+    .wait_and_throw();
+  }
+
+  q.submit([&](sycl::handler &CGH) {
+    sycl::local_accessor<int, 0> LA{CGH};
+    CGH.single_task<class KernelLocalAccessor>([LA] { LA = 2; });
+
+    assert(LA == 2);
+  })
+  .wait_and_throw();
+
+  {
+    using AccT = sycl::accessor<int, 0, sycl::access::mode::read_write, sycl::access::target::host_buffer>;
+    int data = 16;
+
+    sycl::buffer<int> Buf(&data, sycl::range<1>(1));
+
+    q.submit([&](sycl::handler &CGH) {
+      AccT HA(Buf, CGH);
+      CGH.single_task<class KernelHostAccessor>([=] {
+        typename AccT::value_type Data = 3;
+        HA = Data;
+      });
+
+      assert(HA == 3);
+    })
+    .wait_and_throw();
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This patch implements and provides tests for assignment operators for the read-only, 0-dimensional variants of the buffer accessor, local accessor, and host accessor classes.

Implemented according to [Table 72 of the SYCL 2020 specification](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_interface_for_buffer_host_accessors) and the following PRs: https://github.com/KhronosGroup/SYCL-Docs/pull/278, https://github.com/KhronosGroup/SYCL-Docs/pull/334