### PR TITLE
[SYCL] Add support for __arithmetic_fence builtin for SYCL targets.

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -193,6 +193,8 @@ public:
   bool hasFeature(StringRef Feature) const override {
     return Feature == "spir";
   }
+
+  bool checkArithmeticFenceSupported() const override { return true; }
 };
 
 class LLVM_LIBRARY_VISIBILITY SPIR32TargetInfo : public SPIRTargetInfo {

--- a/clang/test/CodeGen/arithmetic-fence-builtin.c
+++ b/clang/test/CodeGen/arithmetic-fence-builtin.c
@@ -1,20 +1,30 @@
 // Test with fast math
 // RUN: %clang_cc1 -triple i386-pc-linux-gnu -emit-llvm -DFAST \
 // RUN: -mreassociate \
-// RUN: -o - %s | FileCheck --check-prefixes CHECK,CHECKFAST,CHECKNP %s
+// RUN: -o - %s | FileCheck --check-prefixes CHECK,CHECKFAST,CHECKPREC,CHECKNP %s
 //
 // Test with fast math and fprotect-parens
 // RUN: %clang_cc1 -triple i386-pc-linux-gnu -emit-llvm -DFAST \
 // RUN: -mreassociate -fprotect-parens -ffp-contract=on\
-// RUN: -o - %s | FileCheck --check-prefixes CHECK,CHECKFAST,CHECKPP %s
+// RUN: -o - %s | FileCheck --check-prefixes CHECK,CHECKFAST,CHECKPREC,CHECKPP %s
 //
 // Test without fast math: llvm intrinsic not created
 // RUN: %clang_cc1 -triple i386-pc-linux-gnu -emit-llvm -fprotect-parens\
 // RUN: -o - %s | FileCheck --implicit-check-not="llvm.arithmetic.fence" %s
 //
-int v;
-int addit(float a, float b) {
-  // CHECK: define {{.*}}@addit(float noundef %a, float noundef %b) #0 {
+// RUN: %clang_cc1 -triple spir64-unknown-unknown  -emit-llvm -fsycl-is-device \
+// RUN: -disable-llvm-passes -mreassociate -opaque-pointers -DSYCLD \
+// RUN: -o - %s | FileCheck --check-prefixes CHECKS,CHECKFAST,CHECKPPS %s
+
+#ifdef SYCLD
+int __attribute__((sycl_device)) addit(float a, float b)
+#else
+int  addit(float a, float b)
+#endif
+{
+  int v;
+  // CHECKS: define dso_local spir_func i32 @addit(float noundef %a, float noundef %b) #0
+  // CHECK: define {{.*}} @addit(float noundef %a, float noundef %b) #0 {
   _Complex double cd, cd1;
   cd = __arithmetic_fence(cd1);
   // CHECKFAST: call{{.*}} double @llvm.arithmetic.fence.f64({{.*}}real)
@@ -32,7 +42,11 @@ int addit(float a, float b) {
 
   v = (a + b);
   // CHECKPP: call{{.*}} float @llvm.arithmetic.fence.f32(float %add{{.*}})
+
   v = a + (b*b);
+  // CHECKPPS: fmul
+  // CHECKPPS-NEXT: fadd
+
   // CHECKPP: fmul reassoc
   // CHECKPP-NEXT: call{{.*}} float @llvm.arithmetic.fence.f32(float %mul)
   // CHECKNP: fmul
@@ -56,16 +70,24 @@ int addit(float a, float b) {
   return 0;
   // CHECK-NEXT ret i32 0
 }
-int addit1(int a, int b) {
+
+#ifdef SYCLD
+int __attribute__((sycl_device)) addit1(int a, int b)
+#else
+int  addit1(int a, int b)
+  #endif
+{
+  int v;
   // CHECK: define {{.*}}@addit1(i32 noundef %a, i32 noundef %b{{.*}}
   v = (a + b);
   // CHECK-NOT: call{{.*}} float @llvm.arithmetic.fence.int(float noundef %add)
   return 0;
 }
+
 #ifdef FAST
 #pragma float_control(precise, on)
 int subit(float a, float b, float *fp) {
-  // CHECKFAST: define {{.*}}@subit(float noundef %a, float noundef %b{{.*}}
+  // CHECKPREC: define {{.*}}@subit(float noundef %a, float noundef %b{{.*}}
   *fp = __arithmetic_fence(a - b);
   *fp = (a + b);
   // CHECK-NOT: call{{.*}} float @llvm.arithmetic.fence.f32(float noundef %add)

--- a/clang/test/CodeGen/arithmetic-fence-builtin.c
+++ b/clang/test/CodeGen/arithmetic-fence-builtin.c
@@ -1,22 +1,22 @@
 // Test with fast math
 // RUN: %clang_cc1 -triple i386-pc-linux-gnu -emit-llvm -DFAST \
 // RUN: -mreassociate \
-// RUN: -o - %s | FileCheck --check-prefixes CHECK,CHECKFAST,CHECKPREC,CHECKNP %s
+// RUN: -o - %s | FileCheck --check-prefixes CHECK,CHECKFAST,CHECKPRECISION,CHECKNP %s
 //
 // Test with fast math and fprotect-parens
 // RUN: %clang_cc1 -triple i386-pc-linux-gnu -emit-llvm -DFAST \
 // RUN: -mreassociate -fprotect-parens -ffp-contract=on\
-// RUN: -o - %s | FileCheck --check-prefixes CHECK,CHECKFAST,CHECKPREC,CHECKPP %s
+// RUN: -o - %s | FileCheck --check-prefixes CHECK,CHECKFAST,CHECKPRECISION,CHECKPP %s
 //
 // Test without fast math: llvm intrinsic not created
 // RUN: %clang_cc1 -triple i386-pc-linux-gnu -emit-llvm -fprotect-parens\
 // RUN: -o - %s | FileCheck --implicit-check-not="llvm.arithmetic.fence" %s
 //
 // RUN: %clang_cc1 -triple spir64-unknown-unknown  -emit-llvm -fsycl-is-device \
-// RUN: -disable-llvm-passes -mreassociate -opaque-pointers -DSYCLD \
+// RUN: -mreassociate -opaque-pointers -DSYCL_DEVICE \
 // RUN: -o - %s | FileCheck --check-prefixes CHECKS,CHECKFAST,CHECKPPS %s
 
-#ifdef SYCLD
+#ifdef SYCL_DEVICE
 int __attribute__((sycl_device)) addit(float a, float b)
 #else
 int  addit(float a, float b)
@@ -71,11 +71,11 @@ int  addit(float a, float b)
   // CHECK-NEXT ret i32 0
 }
 
-#ifdef SYCLD
+#ifdef SYCL_DEVICE
 int __attribute__((sycl_device)) addit1(int a, int b)
 #else
 int  addit1(int a, int b)
-  #endif
+#endif
 {
   int v;
   // CHECK: define {{.*}}@addit1(i32 noundef %a, i32 noundef %b{{.*}}
@@ -87,7 +87,7 @@ int  addit1(int a, int b)
 #ifdef FAST
 #pragma float_control(precise, on)
 int subit(float a, float b, float *fp) {
-  // CHECKPREC: define {{.*}}@subit(float noundef %a, float noundef %b{{.*}}
+  // CHECKPRECISION: define {{.*}}@subit(float noundef %a, float noundef %b{{.*}}
   *fp = __arithmetic_fence(a - b);
   *fp = (a + b);
   // CHECK-NOT: call{{.*}} float @llvm.arithmetic.fence.f32(float noundef %add)

--- a/clang/test/Sema/arithmetic-fence-builtin.c
+++ b/clang/test/Sema/arithmetic-fence-builtin.c
@@ -3,10 +3,10 @@
 // RUN: not %clang_cc1 -triple ppc64le -DPPC     -emit-llvm -o - -x c++ %s \
 // RUN:            -fprotect-parens 2>&1 | FileCheck -check-prefix=PPC %s
 // RUN: %clang_cc1 -triple spir64-unknown-unknown  -emit-llvm -fsycl-is-device \
-// RUN: -DSYCLD -o - -verify -x c++ %s
+// RUN: -DSYCL_DEVICE -o - -verify -x c++ %s
 
 #ifndef PPC
-#ifdef SYCLD
+#ifdef SYCL_DEVICE
 template <typename T> T __attribute__((sycl_device)) addT(T a, T b)
 #else
 template <typename T> T addT(T a, T b)
@@ -18,7 +18,7 @@ template <typename T> T addT(T a, T b)
   return __arithmetic_fence(a + b);
   // expected-error@-1 {{invalid operand of type 'int' where floating, complex or a vector of such types is required}}
 }
-#ifdef SYCLD
+#ifdef SYCL_DEVICE
 int __attribute__((sycl_device)) addit(int a, int b)
 #else
 int  addit(int a, int b)


### PR DESCRIPTION
__arithmetic_fence enforces ordering on expression evaluation when fast-math is enabled.
In fast math mode some floating-point optimizations are performed such as reassociation and distribution.

For example, the compiler may transform (a+b)+c into a+(b+c). Although these two expressions are equivalent in integer arithmetic, they may not be in floating-point arithmetic. The builtin tells the compiler that the expression in parenthesis can’t be re-associated or distributed.
__arithmetic_fence(a+b)+c is not equivalent to a+(b+c).
