### PR TITLE
[SYCL] Fix linking error in with shared llvm

### DIFF
--- a/libclc/utils/libclc-remangler/CMakeLists.txt
+++ b/libclc/utils/libclc-remangler/CMakeLists.txt
@@ -6,6 +6,7 @@ set(LLVM_LINK_COMPONENTS
   Demangle
   Support
   TransformUtils
+  IRReader
   )
 
 add_clang_tool(libclc-remangler LibclcRemangler.cpp)


### PR DESCRIPTION
After 3e4717afa78 linking `libclc-remangler` against llvm DSOs was broken. This patch adds the missing library