### PR TITLE
[SYCL-MLIR] Inline func.call operations

### DIFF
--- a/mlir-sycl/lib/Transforms/Inliner.cpp
+++ b/mlir-sycl/lib/Transforms/Inliner.cpp
@@ -742,11 +742,11 @@ void Inliner::collectCallOps(CallGraphNode &SrcNode, CallGraph &CG,
       return true;
     case sycl::InlineMode::Aggressive:
       return isa<sycl::SYCLCallOp, sycl::SYCLConstructorOp,
-                 sycl::SYCLMethodOpInterface>(Call);
+                 sycl::SYCLMethodOpInterface, func::CallOp>(Call);
     case sycl::InlineMode::Simple:
-      return isa<sycl::SYCLCallOp, sycl::SYCLConstructorOp>(Call);
+      return isa<sycl::SYCLCallOp, sycl::SYCLConstructorOp, func::CallOp>(Call);
     case sycl::InlineMode::AlwaysInline:
-      return isa<sycl::SYCLCallOp>(Call);
+      return isa<sycl::SYCLCallOp, func::CallOp>(Call);
     }
   };
 

--- a/polygeist/tools/cgeist/Test/Verification/base_with_virt.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/base_with_virt.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
+// RUN: cgeist %s -O0 --function=* -S | FileCheck %s
 
 class M {
 };

--- a/polygeist/tools/cgeist/Test/Verification/base_with_virt2.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/base_with_virt2.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
+// RUN: cgeist %s -O0 --function=* -S | FileCheck %s
 
 class M {
 };

--- a/polygeist/tools/cgeist/Test/Verification/no_inline.c
+++ b/polygeist/tools/cgeist/Test/Verification/no_inline.c
@@ -11,7 +11,7 @@ void foo(int A[10]) {
 // CHECK-LABEL: func @main()
 // CHECK: call @foo
 // OPT1-LABEL: func @main()
-// OPT1: call @foo
+// OPT1-NOT: call @foo
 int main() {
   int A[10];
   foo(A);


### PR DESCRIPTION
Also inline func.call in adition to call-like operations in the SYCL dialect.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>