### PR TITLE
[SYCL-MLIR] Add memref of sub_group and minimum to list of SYCL memrefs

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -367,12 +367,14 @@ def ItemMemRef : MemRefOf<[SYCL_ItemType]>;
 def LocalAccessorBaseDeviceMemRef : MemRefOf<[SYCL_LocalAccessorBaseDeviceType]>;
 def LocalAccessorBaseMemRef : MemRefOf<[SYCL_LocalAccessorBaseType]>;
 def LocalAccessorMemRef : MemRefOf<[SYCL_LocalAccessorType]>;
+def MinimumMemRef : MemRefOf<[SYCL_MinimumType]>;
 def MultiPtrMemRef : MemRefOf<[SYCL_MultiPtrType]>;
 def NDItemMemRef : MemRefOf<[SYCL_NdItemType]>;
 def NDRangeMemRef : MemRefOf<[SYCL_NdRangeType]>;
 def OwnerLessBaseMemRef : MemRefOf<[SYCL_OwnerLessBaseType]>;
 def RangeMemRef : MemRefOf<[SYCL_RangeType]>;
 def StreamMemRef : MemRefOf<[SYCL_StreamType]>;
+def SubGroupMemRef : MemRefOf<[SYCL_SubGroupType]>;
 def SwizzledVecMemRef : MemRefOf<[SYCL_SwizzledVecType]>;
 def VecMemRef : MemRefOf<[SYCL_VecType]>;
 
@@ -393,13 +395,15 @@ def SYCLMemref : AnyTypeOf<[
   LocalAccessorBaseDeviceMemRef,
   LocalAccessorBaseMemRef,
   LocalAccessorMemRef,
+  MinimumMemRef,
   MultiPtrMemRef,
   NDItemMemRef,
   NDRangeMemRef,
   OwnerLessBaseMemRef,
   RangeMemRef,
-  SwizzledVecMemRef,
   StreamMemRef,
+  SubGroupMemRef,
+  SwizzledVecMemRef,
   VecMemRef
 ]>;
 

--- a/mlir-sycl/test/Dialect/IR/SYCL/constructor.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/constructor.mlir
@@ -15,3 +15,15 @@ func.func @TestConstructorII32Ptr(%arg0: memref<?x!sycl_id_1_, 4>, %arg1: memref
   sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN4sycl3_V19multi_ptrIjLNS0_6access13address_spaceE1ELNS2_9decoratedE1EEC1EPU3AS1j, TypeName = @multi_ptr} : (memref<?x!sycl_id_1_, 4>, memref<?xi32, 1>) -> ()
   return
 }
+
+// CHECK-LABEL: func.func @SubGroupConstructor
+func.func @SubGroupConstructor(%arg0: memref<?x!sycl.sub_group, 4>, %arg1: memref<?x!sycl.sub_group, 4>) {
+  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN4sycl3_V13ext6oneapi9sub_groupC1ERKS3_, TypeName = @sub_group} : (memref<?x!sycl.sub_group, 4>, memref<?x!sycl.sub_group, 4>) -> ()
+  return
+}
+
+// CHECK-LABEL: func.func @MinimumConstructor
+func.func @MinimumConstructor(%arg0: memref<?x!sycl.minimum<i32>, 4>, %arg1: memref<?x!sycl.minimum<i32>, 4>) {
+  sycl.constructor(%arg0, %arg1) {MangledFunctionName = @_ZN4sycl3_V17minimumIiEC1ERKS2_, TypeName = @minimum} : (memref<?x!sycl.minimum<i32>, 4>, memref<?x!sycl.minimum<i32>, 4>) -> ()
+  return
+}


### PR DESCRIPTION
This PR makes the following tests pass:
```
SYCL :: SubGroup/broadcast_fp64.cpp   
SYCL :: SubGroup/reduce_spirv13_fp16.cpp
SYCL :: SubGroup/reduce_spirv13_fp64.cpp 
SYCL :: SubGroup/scan_spirv13_fp16.cpp 
```

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>