### PR TITLE
[SYCL] Add support for the in-tree end-to-end tests

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -160,6 +160,8 @@ jobs:
       run: tar -cJf llvm_sycl.tar.xz -C $GITHUB_WORKSPACE/build/install .
     - name: Pack LIT
       run: tar -cJf lit.tar.xz -C $GITHUB_WORKSPACE/src/llvm/utils/lit .
+    - name: Pack End-to-End LIT tests
+      run: tar -cJf e2e_tests.tar.xz -C $GITHUB_WORKSPACE/src/sycl/test-e2e .
     - name: Upload toolchain
       uses: actions/upload-artifact@v3
       with:
@@ -170,6 +172,11 @@ jobs:
       with:
         name: sycl_lit_${{ inputs.build_artifact_suffix }}
         path: lit.tar.xz
+    - name: Upload End-to-End LIT tests
+      uses: actions/upload-artifact@v3
+      with:
+        name: sycl_e2e_tests_${{ inputs.build_artifact_suffix }}
+        path: e2e_tests.tar.xz
 
   aws-start:
     name: Start AWS
@@ -241,9 +248,12 @@ jobs:
         sycl_archive: llvm_sycl.tar.xz
         lit_artifact: sycl_lit_${{ inputs.build_artifact_suffix }}
         lit_archive: lit.tar.xz
+        e2e_tests_artifact: sycl_e2e_tests_${{ inputs.build_artifact_suffix }}
+        e2e_tests_archive: e2e_tests.tar.xz
         check_sycl_all: ${{ matrix.check_sycl_all }}
         results_name_suffix: ${{ matrix.config }}_${{ inputs.build_artifact_suffix }}
         cmake_args: '${{ matrix.cmake_args }} ${{ inputs.lts_cmake_extra_args }}'
+        in_tree_e2e: ${{ matrix.in_tree_e2e }}
 
   khronos_sycl_cts:
     needs: build

--- a/devops/actions/llvm_test_suite/action.yml
+++ b/devops/actions/llvm_test_suite/action.yml
@@ -19,6 +19,13 @@ inputs:
     description: 'Name of LIT archive file'
     required: false
     default: 'lit.tar.xz'
+  e2e_tests_artifact:
+    description: 'Name of the artifact, that contains End-to-End LIT Tests'
+    required: true
+  e2e_tests_archive:
+    description: 'Name of End-to-End LIT Tests archive file'
+    required: false
+    default: 'e2e_tests.tar.xz'
   results_name_suffix:
     description: 'Name suffix of the results artifact'
     required: true
@@ -28,6 +35,10 @@ inputs:
   cmake_args:
     description: 'Extra arguments to cmake command'
     required: false
+  in_tree_e2e:
+    description: "Flag directing to use in-tree End-to-End LIT tests"
+    required: false
+    default: false
 
 post-if: false
 runs:
@@ -66,13 +77,33 @@ runs:
       ls -la
       tar -xf ${{ inputs.lit_archive }} -C lit
       rm -f ${{ inputs.lit_archive }}
+  - name: Download End-to-End LIT Tests
+    if: inputs.in_tree_e2e
+    uses: actions/download-artifact@v3
+    with:
+      name: ${{ inputs.e2e_tests_artifact }}
+  - name: Extract End-to-End LIT Tests
+    if: inputs.in_tree_e2e
+    shell: bash
+    run: |
+      mkdir test_e2e
+      ls -la
+      tar -xf ${{ inputs.e2e_tests_archive }} -C test_e2e
+      ls -R test_e2e
+      rm -f ${{ inputs.e2e_tests_archive }}
   - name: Configure
     shell: bash
     run: |
       echo "::group::CMake configuration"
       mkdir build
       export PATH=$PWD/toolchain/bin/:$PATH
-      cmake -GNinja -B./build -S./llvm_test_suite -DTEST_SUITE_SUBDIRS=SYCL -DCHECK_SYCL_ALL="${{ inputs.check_sycl_all }}" -DCMAKE_CXX_COMPILER="$PWD/toolchain/bin/clang++" -DTEST_SUITE_LIT="$PWD/lit/lit.py" ${{ inputs.cmake_args }}
+      if ${{ inputs.in_tree_e2e }}
+      then
+        # TODO: Rename check_sycl_all input
+        cmake  -GNinja -B./build -S./test_e2e -DSYCL_TEST_E2E_TARGETS="${{ inputs.check_sycl_all }}" -DCMAKE_CXX_COMPILER="$PWD/toolchain/bin/clang++" -DLLVM_LIT="$PWD/lit/lit.py" ${{ inputs.cmake_args }}
+      else
+        cmake -GNinja -B./build -S./llvm_test_suite -DTEST_SUITE_SUBDIRS=SYCL -DCHECK_SYCL_ALL="${{ inputs.check_sycl_all }}" -DCMAKE_CXX_COMPILER="$PWD/toolchain/bin/clang++" -DTEST_SUITE_LIT="$PWD/lit/lit.py" ${{ inputs.cmake_args }}
+      fi
       echo "::endgroup::"
   - name: Run testing
     shell: bash
@@ -81,7 +112,10 @@ runs:
       export PATH=$PWD/toolchain/bin/:$PATH
       # TODO make this part of container build
       export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/hip/lib/:/opt/rocm/lib
-      export LIT_OPTS="-v --no-progress-bar --show-unsupported --max-time 3600 --time-tests -o $PWD/build/results_${{ inputs.results_name_suffix }}.json"
+      # For standalone llvm-test-suite
+      export LIT_OPTS="-v --no-progress-bar --show-unsupported --max-time 3600 --time-tests -o $PWD/build/results_${{ inputs.results_name_suffix }}_${{ inputs.in_tree_e2e }}.json"
+      # For in-tree End-to-End tests
+      export SYCL_TEST_E2E_TARGETS="-v --no-progress-bar --show-unsupported --max-time 3600 --time-tests -o $PWD/build/results_${{ inputs.results_name_suffix }}_${{ inputs.in_tree_e2e }}.json"
       if [ -e /runtimes/oneapi-tbb/env/vars.sh ]; then
         source /runtimes/oneapi-tbb/env/vars.sh;
       elif [ -e /opt/runtimes/oneapi-tbb/env/vars.sh ]; then
@@ -103,13 +137,18 @@ runs:
       SYCL_PI_TRACE=-1 sycl-ls
       echo "::endgroup::"
       cd build
-      ninja check-sycl-all
+      if ${{ inputs.in_tree_e2e }}
+      then
+        ninja check-sycl-e2e
+      else
+        ninja check-sycl-all
+      fi
   - name: Upload test results
     uses: actions/upload-artifact@v1
     if: always()
     with:
       name: lit_results
-      path: build/results_${{ inputs.results_name_suffix }}.json
+      path: build/results_${{ inputs.results_name_suffix }}_${{ inputs.in_tree_e2e}}.json
   - name: Cleanup
     shell: bash
     if: always()
@@ -118,3 +157,4 @@ runs:
       rm -rf lit
       rm -rf build
       rm -rf llvm_test_suite
+      rm -rf test-e2e

--- a/devops/actions/llvm_test_suite/action.yml
+++ b/devops/actions/llvm_test_suite/action.yml
@@ -112,10 +112,7 @@ runs:
       export PATH=$PWD/toolchain/bin/:$PATH
       # TODO make this part of container build
       export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/hip/lib/:/opt/rocm/lib
-      # For standalone llvm-test-suite
       export LIT_OPTS="-v --no-progress-bar --show-unsupported --max-time 3600 --time-tests -o $PWD/build/results_${{ inputs.results_name_suffix }}_${{ inputs.in_tree_e2e }}.json"
-      # For in-tree End-to-End tests
-      export SYCL_TEST_E2E_TARGETS="-v --no-progress-bar --show-unsupported --max-time 3600 --time-tests -o $PWD/build/results_${{ inputs.results_name_suffix }}_${{ inputs.in_tree_e2e }}.json"
       if [ -e /runtimes/oneapi-tbb/env/vars.sh ]; then
         source /runtimes/oneapi-tbb/env/vars.sh;
       elif [ -e /opt/runtimes/oneapi-tbb/env/vars.sh ]; then

--- a/devops/scripts/generate_test_matrix.js
+++ b/devops/scripts/generate_test_matrix.js
@@ -47,8 +47,16 @@ module.exports = ({core, process}) => {
           } else {
             v["env"] = {};
           }
+          // Temporary support for both in-tree/out-of-tree (llvm-test-suite)
+          // end-to-end tests.
+          v["in_tree_e2e"] = false;
           enabledLTSConfigs.push(v);
           if (v["aws-type"]) enabledLTSAWSConfigs.push(v);
+
+          var inTreeV = Object.assign({}, v);
+          inTreeV["in_tree_e2e"] = true;
+          inTreeV["name"] = inTreeV["name"] + " In-Tree"
+          enabledLTSConfigs.push(inTreeV);
         }
       });
 

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -486,3 +486,6 @@ add_custom_target(deploy-sycl-toolchain
 
 # SYCL Runtime documentation
 add_subdirectory(doc)
+
+# SYCL End-to-End tests (former intel/llvm-test-suite).
+add_subdirectory(test-e2e)

--- a/sycl/test-e2e/CMakeLists.txt
+++ b/sycl/test-e2e/CMakeLists.txt
@@ -1,0 +1,72 @@
+cmake_minimum_required(VERSION 3.15)
+
+message("Configuring SYCL End-to-End Tests")
+
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  project(sycl-e2e-test-suite C CXX)
+  set(SYCL_TEST_E2E_STANDALONE TRUE)
+endif()
+
+if(SYCL_TEST_E2E_STANDALONE)
+  if( NOT OpenCL_LIBRARY )
+    find_package(OpenCL)
+  endif()
+endif() # Standalone.
+
+if(SYCL_TEST_E2E_STANDALONE)
+  set(SYCL_CXX_COMPILER ${CMAKE_CXX_COMPILER})
+else()
+  set(SYCL_CXX_COMPILER "${LLVM_BINARY_DIR}/bin/clang++")
+endif() # Standalone.
+
+find_package(Threads REQUIRED)
+set(SYCL_THREADS_LIB ${CMAKE_THREAD_LIBS_INIT})
+
+if(NOT LLVM_LIT)
+  find_program(LLVM_LIT
+               NAMES llvm-lit lit.py lit
+               PATHS "${LLVM_MAIN_SRC_DIR}/utils/lit"
+               DOC "Path to lit.py")
+endif()
+
+set(SYCL_E2E_TESTS_LIT_FLAGS "-sv" CACHE STRING "Flags used when running lit")
+
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg")
+
+if(SYCL_TEST_E2E_TARGETS)
+  message("Configure iterative execution on multiple backends")
+  add_custom_target(check-sycl-e2e)
+  foreach(TARGET_STR ${SYCL_TEST_E2E_TARGETS})
+    string(REPLACE ":" ";" TARGET_LIST ${TARGET_STR})
+    list (GET TARGET_LIST 0 TARGET_BE)
+    list (GET TARGET_LIST 1 TARGET_DEVICES)
+
+    if ("${TARGET_BE}" STREQUAL "")
+      message(FATAL_ERROR
+        "invalid empty target backend specification in SYCL_TEST_E2E_TARGETS")
+    elseif("${TARGET_DEVICES}" STREQUAL "")
+      message(FATAL_ERROR
+        "invalid empty target device specification in SYCL_TEST_E2E_TARGETS")
+    endif()
+    message("Run on ${TARGET_DEVICES} for ${TARGET_BE}")
+
+    string(REPLACE "," "_" TARGET check-sycl-e2e-${TARGET_BE}-${TARGET_DEVICES})
+
+    add_custom_target(${TARGET}
+      COMMAND ${Python3_EXECUTABLE} ${LLVM_LIT} ${SYCL_E2E_TESTS_LIT_FLAGS} --param sycl_be=${TARGET_BE} --param target_devices=${TARGET_DEVICES} .
+      COMMENT "Running the SYCL tests for ${TARGET} backend"
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      USES_TERMINAL
+    )
+    set_target_properties(${TARGET} PROPERTIES FOLDER "SYCL Level Zero tests")
+    add_dependencies(check-sycl-e2e ${TARGET})
+
+  endforeach()
+endif(SYCL_TEST_E2E_TARGETS)
+
+# TODO: Re-enable when moving the entire intel/llvm-test-suite back in-tree.
+# add_subdirectory(External)
+# add_subdirectory(ExtraTests)

--- a/sycl/test-e2e/TestSuiteMove/hello.cpp
+++ b/sycl/test-e2e/TestSuiteMove/hello.cpp
@@ -1,0 +1,14 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+
+// XFAIL: cpu
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  sycl::queue q;
+  return q.get_device().get_info<sycl::info::device::device_type>() ==
+         sycl::info::device_type::cpu;
+}

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -1,0 +1,435 @@
+# -*- Python -*-
+
+import os
+import platform
+import re
+import subprocess
+import tempfile
+from distutils.spawn import find_executable
+
+import lit.formats
+import lit.util
+
+from lit.llvm import llvm_config
+
+# Configuration file for the 'lit' test runner.
+
+# name: The name of this test suite.
+config.name = 'SYCL'
+
+# testFormat: The test format to use to interpret tests.
+#
+# For now we require '&&' between commands, until they get globally killed and
+# the test runner updated.
+config.test_format = lit.formats.ShTest()
+
+# suffixes: A list of file extensions to treat as test files.
+config.suffixes = ['.c', '.cpp']
+
+config.excludes = ['Inputs']
+
+# test_source_root: The root path where tests are located.
+config.test_source_root = os.path.dirname(__file__)
+
+# test_exec_root: The root path where tests should be run.
+config.test_exec_root = config.sycl_obj_root
+
+# Cleanup environment variables which may affect tests
+possibly_dangerous_env_vars = ['COMPILER_PATH', 'RC_DEBUG_OPTIONS',
+                               'CINDEXTEST_PREAMBLE_FILE', 'LIBRARY_PATH',
+                               'CPATH', 'C_INCLUDE_PATH', 'CPLUS_INCLUDE_PATH',
+                               'OBJC_INCLUDE_PATH', 'OBJCPLUS_INCLUDE_PATH',
+                               'LIBCLANG_TIMING', 'LIBCLANG_OBJTRACKING',
+                               'LIBCLANG_LOGGING', 'LIBCLANG_BGPRIO_INDEX',
+                               'LIBCLANG_BGPRIO_EDIT', 'LIBCLANG_NOTHREADS',
+                               'LIBCLANG_RESOURCE_USAGE',
+                               'LIBCLANG_CODE_COMPLETION_LOGGING']
+# Clang/Win32 may refer to %INCLUDE%. vsvarsall.bat sets it.
+if platform.system() != 'Windows':
+    possibly_dangerous_env_vars.append('INCLUDE')
+
+for name in possibly_dangerous_env_vars:
+    if name in llvm_config.config.environment:
+        del llvm_config.config.environment[name]
+
+# Propagate some variables from the host environment.
+llvm_config.with_system_environment(['PATH', 'OCL_ICD_FILENAMES',
+    'CL_CONFIG_DEVICES', 'SYCL_DEVICE_ALLOWLIST', 'SYCL_CONFIG_FILE_NAME'])
+
+llvm_config.with_environment('PATH', config.lit_tools_dir, append_path=True)
+
+# Configure LD_LIBRARY_PATH or corresponding os-specific alternatives
+if platform.system() == "Linux":
+    config.available_features.add('linux')
+    llvm_config.with_system_environment(['LD_LIBRARY_PATH','LIBRARY_PATH','CPATH'])
+    llvm_config.with_environment('LD_LIBRARY_PATH', config.sycl_libs_dir, append_path=True)
+
+elif platform.system() == "Windows":
+    config.available_features.add('windows')
+    llvm_config.with_system_environment(['LIB','CPATH','INCLUDE'])
+    llvm_config.with_environment('LIB', config.sycl_libs_dir, append_path=True)
+    llvm_config.with_environment('PATH', config.sycl_libs_dir, append_path=True)
+    llvm_config.with_environment('LIB', os.path.join(config.dpcpp_root_dir, 'lib'), append_path=True)
+
+elif platform.system() == "Darwin":
+    # FIXME: surely there is a more elegant way to instantiate the Xcode directories.
+    llvm_config.with_system_environment('CPATH')
+    llvm_config.with_environment('CPATH', "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1", append_path=True)
+    llvm_config.with_environment('CPATH', "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/", append_path=True)
+    llvm_config.with_environment('DYLD_LIBRARY_PATH', config.sycl_libs_dir)
+
+llvm_config.with_environment('PATH', config.sycl_tools_dir, append_path=True)
+
+if config.extra_environment:
+    lit_config.note("Extra environment variables")
+    for env_pair in config.extra_environment.split(','):
+        [var,val]=env_pair.split("=")
+        if val:
+           llvm_config.with_environment(var,val,append_path=True)
+           lit_config.note("\t"+var+"="+val)
+        else:
+           lit_config.note("\tUnset "+var)
+           llvm_config.with_environment(var,"")
+
+config.substitutions.append( ('%sycl_libs_dir',  config.sycl_libs_dir ) )
+if platform.system() == "Windows":
+    config.substitutions.append( ('%sycl_static_libs_dir',  config.sycl_libs_dir + '/../lib' ) )
+    config.substitutions.append( ('%obj_ext', '.obj') )
+elif platform.system() == "Linux":
+    config.substitutions.append( ('%sycl_static_libs_dir',  config.sycl_libs_dir ) )
+    config.substitutions.append( ('%obj_ext', '.o') )
+config.substitutions.append( ('%sycl_include',  config.sycl_include ) )
+
+# Intel GPU FAMILY availability
+if lit_config.params.get('gpu-intel-gen9', False):
+    config.available_features.add('gpu-intel-gen9')
+if lit_config.params.get('gpu-intel-gen11', False):
+    config.available_features.add('gpu-intel-gen11')
+if lit_config.params.get('gpu-intel-gen12', False):
+    config.available_features.add('gpu-intel-gen12')
+
+# Intel GPU DEVICE availability
+if lit_config.params.get('gpu-intel-dg1', False):
+    config.available_features.add('gpu-intel-dg1')
+if lit_config.params.get('gpu-intel-dg2', False):
+    config.available_features.add('gpu-intel-dg2')
+if lit_config.params.get('gpu-intel-pvc', False):
+    config.available_features.add('gpu-intel-pvc')
+
+if lit_config.params.get('matrix', False):
+    config.available_features.add('matrix')
+
+if lit_config.params.get('matrix-xmx8', False):
+    config.available_features.add('matrix-xmx8')
+
+#support for LIT parameter ze_debug<num>
+if lit_config.params.get('ze_debug'):
+    config.ze_debug = lit_config.params.get('ze_debug')
+    lit_config.note("ZE_DEBUG: "+config.ze_debug)
+
+# check if compiler supports CL command line options
+cl_options=False
+sp = subprocess.getstatusoutput(config.dpcpp_compiler+' /help')
+if sp[0] == 0:
+    cl_options=True
+    config.available_features.add('cl_options')
+
+# Check for Level Zero SDK
+check_l0_file='l0_include.cpp'
+with open(check_l0_file, 'w') as fp:
+    fp.write('#include<level_zero/ze_api.h>\n')
+    fp.write('int main() { uint32_t t; zeDriverGet(&t,nullptr); return t; }')
+
+config.level_zero_libs_dir=lit_config.params.get("level_zero_libs_dir", config.level_zero_libs_dir)
+config.level_zero_include=lit_config.params.get("level_zero_include", (config.level_zero_include if config.level_zero_include else config.sycl_include))
+
+level_zero_options=level_zero_options = (' -L'+config.level_zero_libs_dir if config.level_zero_libs_dir else '')+' -lze_loader '+' -I'+config.level_zero_include
+if cl_options:
+    level_zero_options = ' '+( config.level_zero_libs_dir+'/ze_loader.lib ' if config.level_zero_libs_dir else 'ze_loader.lib')+' /I'+config.level_zero_include
+
+config.substitutions.append( ('%level_zero_options', level_zero_options) )
+
+sp = subprocess.getstatusoutput(config.dpcpp_compiler+' -fsycl  ' + check_l0_file + level_zero_options)
+if sp[0] == 0:
+    config.available_features.add('level_zero_dev_kit')
+    config.substitutions.append( ('%level_zero_options', level_zero_options) )
+else:
+    config.substitutions.append( ('%level_zero_options', '') )
+
+# Check for CUDA SDK
+check_cuda_file='cuda_include.cpp'
+with open(check_cuda_file, 'w') as fp:
+    fp.write('#include <cuda.h>\n')
+    fp.write('int main() { CUresult r = cuInit(0); return r; }')
+
+config.cuda_libs_dir=lit_config.params.get("cuda_libs_dir", config.cuda_libs_dir)
+config.cuda_include=lit_config.params.get("cuda_include", (config.cuda_include if config.cuda_include else config.sycl_include))
+
+cuda_options=cuda_options = (' -L'+config.cuda_libs_dir if config.cuda_libs_dir else '')+' -lcuda '+' -I'+config.cuda_include
+if cl_options:
+    cuda_options = ' '+( config.cuda_libs_dir+'/cuda.lib ' if config.cuda_libs_dir else 'cuda.lib')+' /I'+config.cuda_include
+
+config.substitutions.append( ('%cuda_options', cuda_options) )
+
+sp = subprocess.getstatusoutput(config.dpcpp_compiler+' -fsycl  ' + check_cuda_file + cuda_options)
+if sp[0] == 0:
+    config.available_features.add('cuda_dev_kit')
+    config.substitutions.append( ('%cuda_options', cuda_options) )
+else:
+    config.substitutions.append( ('%cuda_options', '') )
+
+# Check for OpenCL ICD
+if config.opencl_libs_dir:
+    if cl_options:
+        config.substitutions.append( ('%opencl_lib',  ' '+config.opencl_libs_dir+'/OpenCL.lib') )
+    else:
+        config.substitutions.append( ('%opencl_lib',  '-L'+config.opencl_libs_dir+' -lOpenCL') )
+    config.available_features.add('opencl_icd')
+config.substitutions.append( ('%opencl_include_dir',  config.opencl_include_dir) )
+
+if cl_options:
+    config.substitutions.append( ('%sycl_options',  ' ' + config.sycl_libs_dir + '/../lib/sycl6.lib /I' +
+                                config.sycl_include + ' /I' + os.path.join(config.sycl_include, 'sycl')) )
+    config.substitutions.append( ('%include_option',  '/FI' ) )
+    config.substitutions.append( ('%debug_option',  '/DEBUG' ) )
+    config.substitutions.append( ('%cxx_std_option',  '/std:' ) )
+    config.substitutions.append( ('%fPIC', '') )
+    config.substitutions.append( ('%shared_lib', '/LD') )
+else:
+    config.substitutions.append( ('%sycl_options',
+                                  (' -lsycl6' if platform.system() == "Windows" else " -lsycl") + ' -I' +
+                                  config.sycl_include + ' -I' + os.path.join(config.sycl_include, 'sycl') +
+                                  ' -L' + config.sycl_libs_dir) )
+    config.substitutions.append( ('%include_option',  '-include' ) )
+    config.substitutions.append( ('%debug_option',  '-g' ) )
+    config.substitutions.append( ('%cxx_std_option',  '-std=' ) )
+    # Position-independent code does not make sence on Windows. At the same
+    # time providing this option for compilation targeting 
+    # x86_64-pc-windows-msvc will cause compile time error on some
+    # configurations
+    config.substitutions.append( ('%fPIC', ('' if platform.system() == 'Windows' else '-fPIC')) )
+    config.substitutions.append( ('%shared_lib', '-shared') )
+
+if not config.gpu_aot_target_opts:
+    config.gpu_aot_target_opts = '"-device *"'
+
+config.substitutions.append( ('%gpu_aot_target_opts',  config.gpu_aot_target_opts ) )
+
+if not config.sycl_be:
+     lit_config.error("SYCL backend is not specified")
+
+# Transforming from SYCL_BE backend definition style to SYCL_DEVICE_FILTER used
+# for backward compatibility : e.g. 'PI_ABC_XYZ' -> 'abc_xyz'
+if config.sycl_be.startswith("PI_"):
+    config.sycl_be = config.sycl_be[3:]
+config.sycl_be = config.sycl_be.lower()
+
+# Replace deprecated backend names
+deprecated_names_mapping = {'cuda'       : 'ext_oneapi_cuda',
+                            'hip'        : 'ext_oneapi_hip',
+                            'level_zero' : 'ext_oneapi_level_zero',
+                            'esimd_cpu'  : 'ext_intel_esimd_emulator'}
+if config.sycl_be in deprecated_names_mapping.keys():
+    config.sycl_be = deprecated_names_mapping[config.sycl_be]
+
+lit_config.note("Backend: {BACKEND}".format(BACKEND=config.sycl_be))
+
+config.substitutions.append( ('%sycl_be', config.sycl_be) )
+# Use short names for LIT rules
+config.available_features.add(config.sycl_be.replace('ext_intel_', '').replace('ext_oneapi_', ''))
+config.substitutions.append( ('%BE_RUN_PLACEHOLDER', "env ONEAPI_DEVICE_SELECTOR='{SYCL_PLUGIN}:* '".format(SYCL_PLUGIN=config.sycl_be)) )
+
+if config.dump_ir_supported:
+   config.available_features.add('dump_ir')
+
+supported_sycl_be = ['opencl',
+                     'ext_oneapi_cuda',
+                     'ext_oneapi_hip',
+                     'ext_oneapi_level_zero',
+                     'ext_intel_esimd_emulator']
+
+if config.sycl_be not in supported_sycl_be:
+   lit_config.error("Unknown SYCL BE specified '" +
+                    config.sycl_be +
+                    "'. Supported values are {}".format(', '.join(supported_sycl_be)))
+
+# Run only tests in ESIMD subforlder for the ext_intel_esimd_emulator
+if config.sycl_be == 'ext_intel_esimd_emulator':
+   config.test_source_root += "/ESIMD"
+   config.test_exec_root += "/ESIMD"
+
+# If HIP_PLATFORM flag is not set, default to AMD, and check if HIP platform is supported
+supported_hip_platforms=["AMD", "NVIDIA"]
+if config.hip_platform == "":
+    config.hip_platform = "AMD"
+if config.hip_platform not in supported_hip_platforms:
+    lit_config.error("Unknown HIP platform '" + config.hip_platform + "' supported platforms are " + ', '.join(supported_hip_platforms))
+
+if config.sycl_be == "ext_oneapi_hip" and config.hip_platform == "AMD":
+    config.available_features.add('hip_amd')
+    arch_flag = '-Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=' + config.amd_arch
+elif config.sycl_be == "ext_oneapi_hip" and config.hip_platform == "NVIDIA":
+    config.available_features.add('hip_nvidia')
+    arch_flag = ""
+else:
+    arch_flag = ""
+
+if lit_config.params.get('compatibility_testing', False):
+    config.substitutions.append( ('%clangxx', ' true ') )
+    config.substitutions.append( ('%clang', ' true ') )
+else:
+    config.substitutions.append( ('%clangxx', ' '+ config.dpcpp_compiler + ' ' + config.cxx_flags + ' ' + arch_flag) )
+    config.substitutions.append( ('%clang', ' ' + config.dpcpp_compiler + ' ' + config.c_flags) )
+
+config.substitutions.append( ('%threads_lib', config.sycl_threads_lib) )
+
+# Configure device-specific substitutions based on availability of corresponding
+# devices/runtimes
+
+found_at_least_one_device = False
+
+supported_device_types=['cpu', 'gpu', 'acc']
+
+for target_device in config.target_devices.split(','):
+    if target_device == 'host':
+        lit_config.warning("Host device type is no longer supported.")
+    elif ( target_device not in supported_device_types ):
+        lit_config.error("Unknown SYCL target device type specified '" +
+                         target_device +
+                         "' supported devices are " + ', '.join(supported_device_types))
+
+cpu_run_substitute = "true"
+cpu_run_on_linux_substitute = "true "
+cpu_check_substitute = ""
+cpu_check_on_linux_substitute = ""
+
+if 'cpu' in config.target_devices.split(','):
+    found_at_least_one_device = True
+    lit_config.note("Test CPU device")
+    cpu_run_substitute = "env ONEAPI_DEVICE_SELECTOR={SYCL_PLUGIN}:cpu ".format(SYCL_PLUGIN=config.sycl_be)
+    cpu_check_substitute = "| FileCheck %s"
+    config.available_features.add('cpu')
+    if platform.system() == "Linux":
+        cpu_run_on_linux_substitute = cpu_run_substitute
+        cpu_check_on_linux_substitute = "| FileCheck %s"
+else:
+    lit_config.warning("CPU device not used")
+
+config.substitutions.append( ('%CPU_RUN_PLACEHOLDER',  cpu_run_substitute) )
+config.substitutions.append( ('%CPU_RUN_ON_LINUX_PLACEHOLDER',  cpu_run_on_linux_substitute) )
+config.substitutions.append( ('%CPU_CHECK_PLACEHOLDER',  cpu_check_substitute) )
+config.substitutions.append( ('%CPU_CHECK_ON_LINUX_PLACEHOLDER',  cpu_check_on_linux_substitute) )
+
+gpu_run_substitute = "true"
+gpu_run_on_linux_substitute = "true "
+gpu_check_substitute = ""
+gpu_l0_check_substitute = ""
+gpu_check_on_linux_substitute = ""
+
+if 'gpu' in config.target_devices.split(','):
+    found_at_least_one_device = True
+    lit_config.note("Test GPU device")
+    gpu_run_substitute = " env ONEAPI_DEVICE_SELECTOR={SYCL_PLUGIN}:gpu ".format(SYCL_PLUGIN=config.sycl_be)
+    gpu_check_substitute = "| FileCheck %s"
+    config.available_features.add('gpu')
+
+    if config.sycl_be == "ext_oneapi_level_zero":
+        gpu_l0_check_substitute = "| FileCheck %s"
+        if lit_config.params.get('ze_debug'):
+            gpu_run_substitute = " env ZE_DEBUG={ZE_DEBUG} ONEAPI_DEVICE_SELECTOR=level_zero:gpu ".format(ZE_DEBUG=config.ze_debug)
+            config.available_features.add('ze_debug'+config.ze_debug)
+    elif config.sycl_be == "ext_intel_esimd_emulator":
+        # ESIMD_EMULATOR backend uses CM_EMU library package for
+        # multi-threaded execution on CPU, and the package emulates
+        # multiple target platforms. In case user does not specify
+        # what target platform to emulate, 'skl' is chosen by default.
+        if not "CM_RT_PLATFORM" in os.environ:
+            gpu_run_substitute += "CM_RT_PLATFORM=skl "
+
+    if platform.system() == "Linux":
+        gpu_run_on_linux_substitute = "env ONEAPI_DEVICE_SELECTOR={SYCL_PLUGIN}:gpu ".format(SYCL_PLUGIN=config.sycl_be)
+        gpu_check_on_linux_substitute = "| FileCheck %s"
+
+    if config.sycl_be == "ext_oneapi_cuda":
+        gpu_run_substitute += "SYCL_PI_CUDA_ENABLE_IMAGE_SUPPORT=1 "
+
+else:
+    lit_config.warning("GPU device not used")
+
+config.substitutions.append( ('%GPU_RUN_PLACEHOLDER',  gpu_run_substitute) )
+config.substitutions.append( ('%GPU_RUN_ON_LINUX_PLACEHOLDER',  gpu_run_on_linux_substitute) )
+config.substitutions.append( ('%GPU_CHECK_PLACEHOLDER',  gpu_check_substitute) )
+config.substitutions.append( ('%GPU_L0_CHECK_PLACEHOLDER',  gpu_l0_check_substitute) )
+config.substitutions.append( ('%GPU_CHECK_ON_LINUX_PLACEHOLDER',  gpu_check_on_linux_substitute) )
+
+acc_run_substitute = "true"
+acc_check_substitute = ""
+if 'acc' in config.target_devices.split(','):
+    found_at_least_one_device = True
+    lit_config.note("Tests accelerator device")
+    acc_run_substitute = " env ONEAPI_DEVICE_SELECTOR='*:acc' "
+    acc_check_substitute = "| FileCheck %s"
+    config.available_features.add('accelerator')
+else:
+    lit_config.warning("Accelerator device not used")
+config.substitutions.append( ('%ACC_RUN_PLACEHOLDER',  acc_run_substitute) )
+config.substitutions.append( ('%ACC_CHECK_PLACEHOLDER',  acc_check_substitute) )
+
+if config.sycl_be == 'ext_oneapi_cuda' or (config.sycl_be == 'ext_oneapi_hip' and config.hip_platform == 'NVIDIA'):
+    config.substitutions.append( ('%sycl_triple',  "nvptx64-nvidia-cuda" ) )
+elif config.sycl_be == 'ext_oneapi_hip' and config.hip_platform == 'AMD':
+    config.substitutions.append( ('%sycl_triple',  "amdgcn-amd-amdhsa" ) )
+else:
+    config.substitutions.append( ('%sycl_triple',  "spir64" ) )
+
+if find_executable('sycl-ls'):
+    config.available_features.add('sycl-ls')
+
+# TODO properly set XPTIFW include and runtime dirs
+xptifw_lib_dir = os.path.join(config.dpcpp_root_dir, 'lib')
+xptifw_dispatcher = ""
+if platform.system() == "Linux":
+    xptifw_dispatcher = os.path.join(xptifw_lib_dir, 'libxptifw.so')
+elif platform.system() == "Windows":
+    xptifw_dispatcher = os.path.join(config.dpcpp_root_dir, 'bin', 'xptifw.dll')
+xptifw_includes = os.path.join(config.dpcpp_root_dir, 'include')
+if os.path.exists(xptifw_lib_dir) and os.path.exists(os.path.join(xptifw_includes, 'xpti', 'xpti_trace_framework.h')):
+    config.available_features.add('xptifw')
+    config.substitutions.append(('%xptifw_dispatcher', xptifw_dispatcher))
+    if cl_options:
+        config.substitutions.append(('%xptifw_lib', " {}/xptifw.lib /I{} ".format(xptifw_lib_dir, xptifw_includes)))
+    else:
+        config.substitutions.append(('%xptifw_lib', " -L{} -lxptifw -I{} ".format(xptifw_lib_dir, xptifw_includes)))
+
+
+llvm_tools = ["llvm-spirv", "llvm-link"]
+for llvm_tool in llvm_tools:
+  llvm_tool_path = find_executable(llvm_tool)
+  if llvm_tool_path:
+    lit_config.note("Found " + llvm_tool)
+    config.available_features.add(llvm_tool)
+    config.substitutions.append( ('%' + llvm_tool.replace('-', '_'),
+                                  os.path.realpath(llvm_tool_path)) )
+  else:
+    lit_config.warning("Can't find " + llvm_tool)
+
+if find_executable('cmc'):
+    config.available_features.add('cm-compiler')
+
+# Device AOT compilation tools aren't part of the SYCL project,
+# so they need to be pre-installed on the machine
+aot_tools = ["ocloc", "opencl-aot"]
+
+for aot_tool in aot_tools:
+    if find_executable(aot_tool) is not None:
+        lit_config.note("Found pre-installed AOT device compiler " + aot_tool)
+        config.available_features.add(aot_tool)
+    else:
+        lit_config.warning("Couldn't find pre-installed AOT device compiler " + aot_tool)
+
+# Set timeout for a single test
+try:
+    import psutil
+    lit_config.maxIndividualTestTime = 600
+except ImportError:
+    pass

--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -1,0 +1,40 @@
+@LIT_SITE_CFG_IN_HEADER@
+
+import sys
+import platform
+
+
+config.dpcpp_compiler = lit_config.params.get("dpcpp_compiler", "@SYCL_CXX_COMPILER@")
+config.dpcpp_root_dir= os.path.dirname(os.path.dirname(config.dpcpp_compiler))
+
+config.llvm_tools_dir = os.path.join(config.dpcpp_root_dir, 'bin')
+config.lit_tools_dir = os.path.dirname("@TEST_SUITE_LIT@")
+config.dump_ir_supported = lit_config.params.get("dump_ir", ("@DUMP_IR_SUPPORTED@" if "@DUMP_IR_SUPPORTED@" else False))
+config.sycl_tools_dir = config.llvm_tools_dir
+config.sycl_include = os.path.join(config.dpcpp_root_dir, 'include')
+config.sycl_obj_root = "@CMAKE_CURRENT_BINARY_DIR@"
+config.sycl_libs_dir =  os.path.join(config.dpcpp_root_dir, ('bin' if platform.system() == "Windows" else 'lib'))
+
+config.opencl_libs_dir = (os.path.dirname("@OpenCL_LIBRARY@") if "@OpenCL_LIBRARY@" else "")
+config.level_zero_libs_dir = "@LEVEL_ZERO_LIBS_DIR@"
+config.level_zero_include = "@LEVEL_ZERO_INCLUDE@"
+config.cuda_libs_dir = "@CUDA_LIBS_DIR@"
+config.cuda_include = "@CUDA_INCLUDE@"
+
+config.opencl_include_dir = os.path.join(config.sycl_include, 'sycl')
+config.target_devices = lit_config.params.get("target_devices", "@SYCL_TARGET_DEVICES@")
+config.sycl_be = lit_config.params.get("sycl_be", "@SYCL_BE@")
+config.hip_platform = "@HIP_PLATFORM@"
+config.amd_arch = "@AMD_ARCH@"
+config.sycl_threads_lib = '@SYCL_THREADS_LIB@'
+config.extra_environment = lit_config.params.get("extra_environment", "@LIT_EXTRA_ENVIRONMENT@")
+config.cxx_flags = "@CMAKE_CXX_FLAGS@"
+config.c_flags = "@CMAKE_C_FLAGS@"
+config.external_tests = "@SYCL_EXTERNAL_TESTS@"
+config.extra_include = "@CMAKE_CURRENT_SOURCE_DIR@/include"
+config.gpu_aot_target_opts = lit_config.params.get("gpu_aot_target_opts", "@GPU_AOT_TARGET_OPTS@")
+
+import lit.llvm
+lit.llvm.initialize(lit_config, config)
+
+lit_config.load_config(config, "@CMAKE_CURRENT_SOURCE_DIR@/lit.cfg.py")


### PR DESCRIPTION
We plan to move the intel/llvm-test-suite back in-tree. In order to do that, we need to update the infrastructure first, both in this repository and internally. Start by adding a single trivial test and enabling cmake/Linux CI support.

We plan to run the tests in a "standalone" mode, similarly how current intel/llvm-test-suite is used. As such, CMake target is decoupled from general check-* processing and is not include into check-all automatically.

CI support is extended via an additional parameter in test matrix generator, `in_tree_e2e` boolean flag.