### PR TITLE
[Driver][SYCL] Deprecate usage of -sycl-std=1.2.1

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -470,6 +470,9 @@ def warn_drv_deprecated_option : Warning<
 def warn_drv_deprecated_option_release : Warning<
   "option '%0' is deprecated and will be removed in a future release">,
   InGroup<Deprecated>;
+def warn_drv_deprecated_argument_option_release : Warning<
+  "argument '%0' for option '%1' is deprecated and will be removed in a "
+  "future release">, InGroup<Deprecated>;
 def warn_ignoring_verify_debuginfo_preserve_export : Warning<
   "ignoring -fverify-debuginfo-preserve-export=%0 because "
   "-fverify-debuginfo-preserve wasn't enabled">,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5032,6 +5032,13 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       A->render(Args, CmdArgs);
 
     if (SYCLStdArg) {
+      // Use of -sycl-std=1.2.1 is deprecated. Emit a diagnostic stating so.
+      // TODO: remove support at next approprate major release.
+      StringRef StdValue(SYCLStdArg->getValue());
+      if (StdValue == "1.2.1" || StdValue == "121" ||
+          StdValue == "sycl-1.2.1" || StdValue == "2017")
+        D.Diag(diag::warn_drv_deprecated_argument_option_release)
+            << StdValue << SYCLStdArg->getSpelling();
       SYCLStdArg->render(Args, CmdArgs);
       CmdArgs.push_back("-fsycl-std-layout-kernel-params");
     } else {

--- a/clang/test/Driver/sycl-deprecated.cpp
+++ b/clang/test/Driver/sycl-deprecated.cpp
@@ -2,3 +2,17 @@
 // RUN: %clangxx -fsycl-explicit-simd %s -### 2>&1 | FileCheck %s -DOPTION=-fsycl-explicit-simd
 // RUN: %clangxx -fno-sycl-explicit-simd %s -### 2>&1 | FileCheck %s -DOPTION=-fno-sycl-explicit-simd
 // CHECK: option '[[OPTION]]' is deprecated and will be removed in a future release
+
+// RUN: %clangxx -fsycl -sycl-std=1.2.1 %s -### 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=CHECK-ARG -DOPTION=-sycl-std= \
+// RUN:    -DARGUMENT=1.2.1
+// RUN: %clangxx -fsycl -sycl-std=121 %s -### 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=CHECK-ARG -DOPTION=-sycl-std= \
+// RUN:     -DARGUMENT=121
+// RUN: %clangxx -fsycl -sycl-std=sycl-1.2.1 %s -### 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=CHECK-ARG -DOPTION=-sycl-std= \
+// RUN:     -DARGUMENT=sycl-1.2.1
+// RUN: %clangxx -fsycl -sycl-std=2017 %s -### 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=CHECK-ARG -DOPTION=-sycl-std= \
+// RUN:     -DARGUMENT=2017
+// CHECK-ARG: argument '[[ARGUMENT]]' for option '[[OPTION]]' is deprecated and will be removed in a future release

--- a/sycl/doc/UsersManual.md
+++ b/sycl/doc/UsersManual.md
@@ -98,7 +98,7 @@ and not recommended to use in production environment.
 **`-sycl-std=<value>`** [EXPERIMENTAL]
 
     SYCL language standard to compile for. Possible values:
-    * 121 - SYCL 1.2.1
+    * 121 - SYCL 1.2.1 [DEPRECATED]
     * 2020 - SYCL 2020
     It doesn't guarantee specific standard compliance, but some selected
     compiler features change behavior.


### PR DESCRIPTION
Use of -sycl-std=1.2.1 is deprecated.  Emit a diagnostic stating so. We will remove support in a future major compiler release.