### PR TITLE
[SYCL] Refactor program build and cache

### DIFF
--- a/sycl/source/detail/kernel_program_cache.cpp
+++ b/sycl/source/detail/kernel_program_cache.cpp
@@ -14,7 +14,7 @@ namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace detail {
 KernelProgramCache::~KernelProgramCache() {
-  for (auto &ProgIt : MCachedPrograms) {
+  for (auto &ProgIt : MCachedPrograms.Cache) {
     ProgramWithBuildStateT &ProgWithState = ProgIt.second;
     PiProgramT *ToBeDeleted = ProgWithState.Ptr.load();
 

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -39,13 +39,16 @@ public:
     bool isFilledIn() const { return !Msg.empty(); }
   };
 
+  /// Denotes the state of a build.
+  enum BuildState { BS_InProgress, BS_Done, BS_Failed };
+
   /// Denotes pointer to some entity with its general state and build error.
   /// The pointer is not null if and only if the entity is usable.
   /// State of the entity is provided by the user of cache instance.
   /// Currently there is only a single user - ProgramManager class.
   template <typename T> struct BuildResult {
     std::atomic<T *> Ptr;
-    std::atomic<int> State;
+    std::atomic<BuildState> State;
     BuildError Error;
 
     /// Condition variable to signal that build result is ready.
@@ -62,7 +65,7 @@ public:
     /// A mutex to be employed along with MBuildCV.
     std::mutex MBuildResultMutex;
 
-    BuildResult(T *P, int S) : Ptr{P}, State{S}, Error{"", 0} {}
+    BuildResult(T *P, BuildState S) : Ptr{P}, State{S}, Error{"", 0} {}
   };
 
   using PiProgramT = std::remove_pointer<RT::PiProgram>::type;
@@ -70,7 +73,15 @@ public:
   using ProgramWithBuildStateT = BuildResult<PiProgramT>;
   using ProgramCacheKeyT = std::pair<std::pair<SerializedObj, std::uintptr_t>,
                                      std::pair<RT::PiDevice, std::string>>;
-  using ProgramCacheT = std::map<ProgramCacheKeyT, ProgramWithBuildStateT>;
+  using CommonProgramKeyT = std::pair<std::uintptr_t, RT::PiDevice>;
+
+  struct ProgramCache {
+    std::map<ProgramCacheKeyT, ProgramWithBuildStateT> Cache;
+    std::multimap<CommonProgramKeyT, ProgramCacheKeyT> KeyMap;
+
+    size_t size() { return Cache.size(); }
+  };
+
   using ContextPtr = context_impl *;
 
   using PiKernelT = std::remove_pointer<RT::PiKernel>::type;
@@ -91,7 +102,7 @@ public:
 
   void setContextPtr(const ContextPtr &AContext) { MParentContext = AContext; }
 
-  Locked<ProgramCacheT> acquireCachedPrograms() {
+  Locked<ProgramCache> acquireCachedPrograms() {
     return {MCachedPrograms, MProgramCacheMutex};
   }
 
@@ -99,11 +110,56 @@ public:
     return {MKernelsPerProgramCache, MKernelsPerProgramCacheMutex};
   }
 
+  std::pair<ProgramWithBuildStateT *, bool>
+  getOrInsertProgram(const ProgramCacheKeyT &CacheKey) {
+    auto LockedCache = acquireCachedPrograms();
+    auto &ProgCache = LockedCache.get();
+    auto Inserted = ProgCache.Cache.emplace(
+        std::piecewise_construct, std::forward_as_tuple(CacheKey),
+        std::forward_as_tuple(nullptr, BS_InProgress));
+    if (Inserted.second) {
+      // Save reference between the common key and the full key.
+      CommonProgramKeyT CommonKey =
+          std::make_pair(CacheKey.first.second, CacheKey.second.first);
+      ProgCache.KeyMap.emplace(std::piecewise_construct,
+                               std::forward_as_tuple(CommonKey),
+                               std::forward_as_tuple(CacheKey));
+    }
+    return std::make_pair(&Inserted.first->second, Inserted.second);
+  }
+
+  std::pair<KernelWithBuildStateT *, bool>
+  getOrInsertKernel(RT::PiProgram Program, const std::string &KernelName) {
+    auto LockedCache = acquireKernelsPerProgramCache();
+    auto &Cache = LockedCache.get()[Program];
+    auto Inserted = Cache.emplace(
+        std::piecewise_construct, std::forward_as_tuple(KernelName),
+        std::forward_as_tuple(nullptr, BS_InProgress));
+    return std::make_pair(&Inserted.first->second, Inserted.second);
+  }
+
   template <typename T, class Predicate>
   void waitUntilBuilt(BuildResult<T> &BR, Predicate Pred) const {
     std::unique_lock<std::mutex> Lock(BR.MBuildResultMutex);
 
     BR.MBuildCV.wait(Lock, Pred);
+  }
+
+  template <typename ExceptionT, typename RetT>
+  RetT *waitUntilBuilt(BuildResult<RetT> *BuildResult) {
+    // Any thread which will find nullptr in cache will wait until the pointer
+    // is not null anymore.
+    waitUntilBuilt(*BuildResult, [BuildResult]() {
+      int State = BuildResult->State.load();
+      return State == BuildState::BS_Done || State == BuildState::BS_Failed;
+    });
+
+    if (BuildResult->Error.isFilledIn()) {
+      const BuildError &Error = BuildResult->Error;
+      throw ExceptionT(Error.Msg, Error.Code);
+    }
+
+    return BuildResult->Ptr.load();
   }
 
   template <typename T> void notifyAllBuild(BuildResult<T> &BR) const {
@@ -132,7 +188,7 @@ public:
   ///
   /// This member function should only be used in unit tests.
   void reset() {
-    MCachedPrograms = ProgramCacheT{};
+    MCachedPrograms = ProgramCache{};
     MKernelsPerProgramCache = KernelCacheT{};
     MKernelFastCache = KernelFastCacheT{};
   }
@@ -141,7 +197,7 @@ private:
   std::mutex MProgramCacheMutex;
   std::mutex MKernelsPerProgramCacheMutex;
 
-  ProgramCacheT MCachedPrograms;
+  ProgramCache MCachedPrograms;
   KernelCacheT MKernelsPerProgramCache;
   ContextPtr MParentContext;
 

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -79,7 +79,7 @@ public:
     std::map<ProgramCacheKeyT, ProgramWithBuildStateT> Cache;
     std::multimap<CommonProgramKeyT, ProgramCacheKeyT> KeyMap;
 
-    size_t size() { return Cache.size(); }
+    size_t size() const noexcept { return Cache.size(); }
   };
 
   using ContextPtr = context_impl *;

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1287,10 +1287,6 @@ void ProgramManager::addImages(pi_device_binaries DeviceBinary) {
               DeviceGlobalInfo.consume<std::uint32_t, std::uint32_t>();
           assert(DeviceGlobalInfo.empty() && "Extra data left!");
 
-          // Give the image pointer as an identifier for the image the
-          // device-global is associated with.
-          uintptr_t ImgId = reinterpret_cast<uintptr_t>(Img.get());
-
           auto ExistingDeviceGlobal = m_DeviceGlobals.find(DeviceGlobal->Name);
           if (ExistingDeviceGlobal != m_DeviceGlobals.end()) {
             // If it has already been registered we update the information.

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -10,10 +10,12 @@
 #include <detail/context_impl.hpp>
 #include <detail/device_image_impl.hpp>
 #include <detail/device_impl.hpp>
+#include <detail/event_impl.hpp>
 #include <detail/global_handler.hpp>
 #include <detail/persistent_device_code_cache.hpp>
 #include <detail/program_impl.hpp>
 #include <detail/program_manager/program_manager.hpp>
+#include <detail/queue_impl.hpp>
 #include <detail/spec_constant_impl.hpp>
 #include <sycl/aspects.hpp>
 #include <sycl/backend_types.hpp>
@@ -45,8 +47,6 @@ namespace detail {
 using ContextImplPtr = std::shared_ptr<sycl::detail::context_impl>;
 
 static constexpr int DbgProgMgr = 0;
-
-enum BuildState { BS_InProgress, BS_Done, BS_Failed };
 
 static constexpr char UseSpvEnv[]("SYCL_USE_KERNEL_SPV");
 
@@ -118,27 +118,6 @@ ProgramManager::getDeviceImage(OSModuleHandle M, const std::string &KernelName,
   return getDeviceImage(M, KSId, Context, Device, JITCompilationIsRequired);
 }
 
-template <typename ExceptionT, typename RetT>
-RetT *waitUntilBuilt(KernelProgramCache &Cache,
-                     KernelProgramCache::BuildResult<RetT> *BuildResult) {
-  // any thread which will find nullptr in cache will wait until the pointer
-  // is not null anymore
-  Cache.waitUntilBuilt(*BuildResult, [BuildResult]() {
-    int State = BuildResult->State.load();
-
-    return State == BS_Done || State == BS_Failed;
-  });
-
-  if (BuildResult->Error.isFilledIn()) {
-    const KernelProgramCache::BuildError &Error = BuildResult->Error;
-    throw ExceptionT(Error.Msg, Error.Code);
-  }
-
-  RetT *Result = BuildResult->Ptr.load();
-
-  return Result;
-}
-
 /// Try to fetch entity (kernel or program) from cache. If there is no such
 /// entity try to build it. Throw any exception build process may throw.
 /// This method eliminates unwanted builds by employing atomic variable with
@@ -158,38 +137,28 @@ RetT *waitUntilBuilt(KernelProgramCache &Cache,
 ///         cache. Accepts nothing. Return pointer to built entity.
 ///
 /// \return a pointer to cached build result, return value must not be nullptr.
-template <typename RetT, typename ExceptionT, typename KeyT, typename AcquireFT,
-          typename GetCacheFT, typename BuildFT>
+template <typename RetT, typename ExceptionT, typename GetCachedBuildFT,
+          typename BuildFT>
 KernelProgramCache::BuildResult<RetT> *
-getOrBuild(KernelProgramCache &KPCache, KeyT &&CacheKey, AcquireFT &&Acquire,
-           GetCacheFT &&GetCache, BuildFT &&Build) {
-  bool InsertionTookPlace;
-  KernelProgramCache::BuildResult<RetT> *BuildResult;
+getOrBuild(KernelProgramCache &KPCache, GetCachedBuildFT &&GetCachedBuild,
+           BuildFT &&Build) {
+  using BuildState = KernelProgramCache::BuildState;
 
-  {
-    auto LockedCache = Acquire(KPCache);
-    auto &Cache = GetCache(LockedCache);
-    auto Inserted =
-        Cache.emplace(std::piecewise_construct, std::forward_as_tuple(CacheKey),
-                      std::forward_as_tuple(nullptr, BS_InProgress));
-
-    InsertionTookPlace = Inserted.second;
-    BuildResult = &Inserted.first->second;
-  }
+  auto [BuildResult, InsertionTookPlace] = GetCachedBuild();
 
   // no insertion took place, thus some other thread has already inserted smth
   // in the cache
   if (!InsertionTookPlace) {
     for (;;) {
-      RetT *Result = waitUntilBuilt<ExceptionT>(KPCache, BuildResult);
+      RetT *Result = KPCache.waitUntilBuilt<ExceptionT>(BuildResult);
 
       if (Result)
         return BuildResult;
 
       // Previous build is failed. There was no SYCL exception though.
       // We might try to build once more.
-      int Expected = BS_Failed;
-      int Desired = BS_InProgress;
+      BuildState Expected = BuildState::BS_Failed;
+      BuildState Desired = BuildState::BS_InProgress;
 
       if (BuildResult->State.compare_exchange_strong(Expected, Desired))
         break; // this thread is the building thread now
@@ -214,7 +183,7 @@ getOrBuild(KernelProgramCache &KPCache, KeyT &&CacheKey, AcquireFT &&Acquire,
       // Even if shared variable is atomic, it must be modified under the mutex
       // in order to correctly publish the modification to the waiting thread
       std::lock_guard<std::mutex> Lock(BuildResult->MBuildResultMutex);
-      BuildResult->State.store(BS_Done);
+      BuildResult->State.store(BuildState::BS_Done);
     }
 
     KPCache.notifyAllBuild(*BuildResult);
@@ -226,7 +195,7 @@ getOrBuild(KernelProgramCache &KPCache, KeyT &&CacheKey, AcquireFT &&Acquire,
 
     {
       std::lock_guard<std::mutex> Lock(BuildResult->MBuildResultMutex);
-      BuildResult->State.store(BS_Failed);
+      BuildResult->State.store(BuildState::BS_Failed);
     }
 
     KPCache.notifyAllBuild(*BuildResult);
@@ -235,7 +204,7 @@ getOrBuild(KernelProgramCache &KPCache, KeyT &&CacheKey, AcquireFT &&Acquire,
   } catch (...) {
     {
       std::lock_guard<std::mutex> Lock(BuildResult->MBuildResultMutex);
-      BuildResult->State.store(BS_Failed);
+      BuildResult->State.store(BuildState::BS_Failed);
     }
 
     KPCache.notifyAllBuild(*BuildResult);
@@ -522,16 +491,8 @@ RT::PiProgram ProgramManager::getBuiltPIProgram(
   KernelSetId KSId = getKernelSetId(M, KernelName);
 
   using PiProgramT = KernelProgramCache::PiProgramT;
-  using ProgramCacheT = KernelProgramCache::ProgramCacheT;
 
   KernelProgramCache &Cache = ContextImpl->getKernelProgramCache();
-
-  auto AcquireF = [](KernelProgramCache &Cache) {
-    return Cache.acquireCachedPrograms();
-  };
-  auto GetF = [](const Locked<ProgramCacheT> &LockedCache) -> ProgramCacheT & {
-    return LockedCache.get();
-  };
 
   std::string CompileOpts;
   std::string LinkOpts;
@@ -662,14 +623,18 @@ RT::PiProgram ProgramManager::getBuiltPIProgram(
     return BuiltProgram.release();
   };
 
-  const RT::PiDevice PiDevice = Dev->getHandleRef();
-
   uint32_t ImgId = Img.getImageID();
-  auto BuildResult = getOrBuild<PiProgramT, compile_program_error>(
-      Cache,
+  const RT::PiDevice PiDevice = Dev->getHandleRef();
+  auto CacheKey =
       std::make_pair(std::make_pair(std::move(SpecConsts), ImgId),
-                     std::make_pair(PiDevice, CompileOpts + LinkOpts)),
-      AcquireF, GetF, BuildF);
+                     std::make_pair(PiDevice, CompileOpts + LinkOpts));
+
+  auto GetCachedBuildF = [&Cache, &CacheKey]() {
+    return Cache.getOrInsertProgram(CacheKey);
+  };
+
+  auto BuildResult = getOrBuild<PiProgramT, compile_program_error>(
+      Cache, GetCachedBuildF, BuildF);
   // getOrBuild is not supposed to return nullptr
   assert(BuildResult != nullptr && "Invalid build result");
   return BuildResult->Ptr.load();
@@ -688,8 +653,6 @@ ProgramManager::getOrCreateKernel(OSModuleHandle M,
   }
 
   using PiKernelT = KernelProgramCache::PiKernelT;
-  using KernelCacheT = KernelProgramCache::KernelCacheT;
-  using KernelByNameT = KernelProgramCache::KernelByNameT;
 
   KernelProgramCache &Cache = ContextImpl->getKernelProgramCache();
 
@@ -711,13 +674,6 @@ ProgramManager::getOrCreateKernel(OSModuleHandle M,
   RT::PiProgram Program =
       getBuiltPIProgram(M, ContextImpl, DeviceImpl, KernelName, Prg);
 
-  auto AcquireF = [](KernelProgramCache &Cache) {
-    return Cache.acquireKernelsPerProgramCache();
-  };
-  auto GetF =
-      [&Program](const Locked<KernelCacheT> &LockedCache) -> KernelByNameT & {
-    return LockedCache.get()[Program];
-  };
   auto BuildF = [&Program, &KernelName, &ContextImpl] {
     PiKernelT *Result = nullptr;
 
@@ -733,8 +689,12 @@ ProgramManager::getOrCreateKernel(OSModuleHandle M,
     return Result;
   };
 
+  auto GetCachedBuildF = [&Cache, &KernelName, Program]() {
+    return Cache.getOrInsertKernel(Program, KernelName);
+  };
+
   auto BuildResult = getOrBuild<PiKernelT, invalid_object_error>(
-      Cache, KernelName, AcquireF, GetF, BuildF);
+      Cache, GetCachedBuildF, BuildF);
   // getOrBuild is not supposed to return nullptr
   assert(BuildResult != nullptr && "Invalid build result");
   auto ret_val = std::make_tuple(BuildResult->Ptr.load(),
@@ -1326,6 +1286,10 @@ void ProgramManager::addImages(pi_device_binaries DeviceBinary) {
           auto [TypeSize, DeviceImageScopeDecorated] =
               DeviceGlobalInfo.consume<std::uint32_t, std::uint32_t>();
           assert(DeviceGlobalInfo.empty() && "Extra data left!");
+
+          // Give the image pointer as an identifier for the image the
+          // device-global is associated with.
+          uintptr_t ImgId = reinterpret_cast<uintptr_t>(Img.get());
 
           auto ExistingDeviceGlobal = m_DeviceGlobals.find(DeviceGlobal->Name);
           if (ExistingDeviceGlobal != m_DeviceGlobals.end()) {
@@ -1990,16 +1954,8 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
   const ContextImplPtr ContextImpl = getSyclObjImpl(Context);
 
   using PiProgramT = KernelProgramCache::PiProgramT;
-  using ProgramCacheT = KernelProgramCache::ProgramCacheT;
 
   KernelProgramCache &Cache = ContextImpl->getKernelProgramCache();
-
-  auto AcquireF = [](KernelProgramCache &Cache) {
-    return Cache.acquireCachedPrograms();
-  };
-  auto GetF = [](const Locked<ProgramCacheT> &LockedCache) -> ProgramCacheT & {
-    return LockedCache.get();
-  };
 
   std::string CompileOpts;
   std::string LinkOpts;
@@ -2091,9 +2047,16 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
   auto CacheKey =
       std::make_pair(std::make_pair(std::move(SpecConsts), ImgId),
                      std::make_pair(PiDevice, CompileOpts + LinkOpts));
+
+  // CacheKey is captured by reference so when we overwrite it later we can
+  // reuse this function.
+  auto GetCachedBuildF = [&Cache, &CacheKey]() {
+    return Cache.getOrInsertProgram(CacheKey);
+  };
+
   // TODO: Throw SYCL2020 style exception
   auto BuildResult = getOrBuild<PiProgramT, compile_program_error>(
-      Cache, CacheKey, AcquireF, GetF, BuildF);
+      Cache, GetCachedBuildF, BuildF);
   // getOrBuild is not supposed to return nullptr
   assert(BuildResult != nullptr && "Invalid build result");
 
@@ -2116,8 +2079,8 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
 
     // Change device in the cache key to reduce copying of spec const data.
     CacheKey.second.first = PiDeviceAdd;
-    getOrBuild<PiProgramT, compile_program_error>(Cache, CacheKey, AcquireF,
-                                                  GetF, CacheOtherDevices);
+    getOrBuild<PiProgramT, compile_program_error>(Cache, GetCachedBuildF,
+                                                  CacheOtherDevices);
     // getOrBuild is not supposed to return nullptr
     assert(BuildResult != nullptr && "Invalid build result");
   }
@@ -2145,18 +2108,9 @@ std::pair<RT::PiKernel, std::mutex *> ProgramManager::getOrCreateKernel(
   const ContextImplPtr Ctx = getSyclObjImpl(Context);
 
   using PiKernelT = KernelProgramCache::PiKernelT;
-  using KernelCacheT = KernelProgramCache::KernelCacheT;
-  using KernelByNameT = KernelProgramCache::KernelByNameT;
 
   KernelProgramCache &Cache = Ctx->getKernelProgramCache();
 
-  auto AcquireF = [](KernelProgramCache &Cache) {
-    return Cache.acquireKernelsPerProgramCache();
-  };
-  auto GetF =
-      [&Program](const Locked<KernelCacheT> &LockedCache) -> KernelByNameT & {
-    return LockedCache.get()[Program];
-  };
   auto BuildF = [&Program, &KernelName, &Ctx] {
     PiKernelT *Result = nullptr;
 
@@ -2170,8 +2124,12 @@ std::pair<RT::PiKernel, std::mutex *> ProgramManager::getOrCreateKernel(
     return Result;
   };
 
+  auto GetCachedBuildF = [&Cache, &KernelName, Program]() {
+    return Cache.getOrInsertKernel(Program, KernelName);
+  };
+
   auto BuildResult = getOrBuild<PiKernelT, invalid_object_error>(
-      Cache, KernelName, AcquireF, GetF, BuildF);
+      Cache, GetCachedBuildF, BuildF);
   // getOrBuild is not supposed to return nullptr
   assert(BuildResult != nullptr && "Invalid build result");
   return std::make_pair(BuildResult->Ptr.load(),

--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -126,7 +126,7 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_ProgramSourceNegativeBuild) {
 
   //   Prg.build_with_source("");
   auto CtxImpl = detail::getSyclObjImpl(Ctx);
-  detail::KernelProgramCache::ProgramCacheT &Cache =
+  detail::KernelProgramCache::ProgramCache &Cache =
       CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for source programs";
 }
@@ -138,7 +138,7 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_ProgramSourceNegativeBuildWithOpts) {
 
   //   Prg.build_with_source("", "-g");
   auto CtxImpl = detail::getSyclObjImpl(Ctx);
-  detail::KernelProgramCache::ProgramCacheT &Cache =
+  detail::KernelProgramCache::ProgramCache &Cache =
       CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for source programs";
 }
@@ -152,7 +152,7 @@ TEST_F(KernelAndProgramCacheTest,
   //   Prg.compile_with_source("");
   //   Prg.link();
   auto CtxImpl = detail::getSyclObjImpl(Ctx);
-  detail::KernelProgramCache::ProgramCacheT &Cache =
+  detail::KernelProgramCache::ProgramCache &Cache =
       CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for source programs";
 }
@@ -167,7 +167,7 @@ TEST_F(KernelAndProgramCacheTest,
   //   Prg.compile_with_source("");
   //   Prg.link();
   auto CtxImpl = detail::getSyclObjImpl(Ctx);
-  detail::KernelProgramCache::ProgramCacheT &Cache =
+  detail::KernelProgramCache::ProgramCache &Cache =
       CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for source programs";
 }
@@ -181,7 +181,7 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_ProgramBuildPositive) {
   //   Prg1.build_with_kernel_type<CacheTestKernel>();
   //   Prg2.build_with_kernel_type<CacheTestKernel>();
   auto CtxImpl = detail::getSyclObjImpl(Ctx);
-  detail::KernelProgramCache::ProgramCacheT &Cache =
+  detail::KernelProgramCache::ProgramCache &Cache =
       CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 1U) << "Expect non-empty cache for programs";
 }
@@ -206,7 +206,7 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_ProgramBuildPositiveBuildOpts) {
   //   Prg5.build_with_kernel_type<CacheTestKernel2>("-a");
 
   auto CtxImpl = detail::getSyclObjImpl(Ctx);
-  detail::KernelProgramCache::ProgramCacheT &Cache =
+  detail::KernelProgramCache::ProgramCache &Cache =
       CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 3U) << "Expect non-empty cache for programs";
 }
@@ -219,7 +219,7 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_ProgramBuildNegativeCompileOpts) {
   //   Prg.compile_with_kernel_type<CacheTestKernel>("-g");
   //   Prg.link();
   auto CtxImpl = detail::getSyclObjImpl(Ctx);
-  detail::KernelProgramCache::ProgramCacheT &Cache =
+  detail::KernelProgramCache::ProgramCache &Cache =
       CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for programs";
 }
@@ -232,7 +232,7 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_ProgramBuildNegativeLinkOpts) {
   //   Prg.compile_with_kernel_type<CacheTestKernel>();
   //   Prg.link("-g");
   auto CtxImpl = detail::getSyclObjImpl(Ctx);
-  detail::KernelProgramCache::ProgramCacheT &Cache =
+  detail::KernelProgramCache::ProgramCache &Cache =
       CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for programs";
 }


### PR DESCRIPTION
In order to help device_global find associated programs in the cache, the way the program manager and the cache interacts needs a refactoring. This commit makes this refactoring.

Additionally this adds the notion of a "common key" (CommonProgramKeyT) representing the common parts of the full cache key shared between builds of the same program on the same device, excluding specializations such as specialization constants and compilation options.