### PR TITLE
[SYCL][Fusion] Statically link library

### DIFF
--- a/sycl-fusion/jit-compiler/CMakeLists.txt
+++ b/sycl-fusion/jit-compiler/CMakeLists.txt
@@ -1,6 +1,5 @@
 
 add_llvm_library(sycl-fusion
-  SHARED
    lib/KernelFusion.cpp
    lib/JITContext.cpp
    lib/translation/SPIRVLLVMTranslation.cpp
@@ -9,7 +8,7 @@ add_llvm_library(sycl-fusion
    lib/fusion/ModuleHelper.cpp
    lib/helper/ConfigHelper.cpp
 
-   LINK_COMPONENTS
+  LINK_COMPONENTS
    Core
    Support
    Analysis
@@ -39,15 +38,13 @@ target_link_libraries(sycl-fusion
   ${CMAKE_THREAD_LIBS_INIT}
 )
 
-if(NOT MSVC AND NOT APPLE)
-  # Manage symbol visibility through the linker to make sure no LLVM symbols
-  # are exported and confuse the drivers.
-  set(linker_script "${CMAKE_CURRENT_SOURCE_DIR}/ld-version-script.txt")
-  target_link_libraries(
-    sycl-fusion PRIVATE "-Wl,--version-script=${linker_script}")
-  set_target_properties(sycl-fusion PROPERTIES LINK_DEPENDS ${linker_script})
+if (BUILD_SHARED_LIBS)
+  if(NOT MSVC AND NOT APPLE)
+    # Manage symbol visibility through the linker to make sure no LLVM symbols
+    # are exported and confuse the drivers.
+    set(linker_script "${CMAKE_CURRENT_SOURCE_DIR}/ld-version-script.txt")
+    target_link_libraries(
+      sycl-fusion PRIVATE "-Wl,--version-script=${linker_script}")
+    set_target_properties(sycl-fusion PROPERTIES LINK_DEPENDS ${linker_script})
+  endif()
 endif()
-
-install(TARGETS sycl-fusion
-  LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT sycl-fusion
-  RUNTIME DESTINATION "bin" COMPONENT sycl-fusion)

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -93,8 +93,10 @@ function(add_sycl_rt_library LIB_NAME LIB_OBJ_NAME)
   if(SYCL_ENABLE_KERNEL_FUSION)
     target_link_libraries(${LIB_NAME} PRIVATE sycl-fusion)
     target_link_libraries(${LIB_OBJ_NAME} PRIVATE sycl-fusion)
-    set_property(GLOBAL APPEND PROPERTY SYCL_TOOLCHAIN_INSTALL_COMPONENTS
-      sycl-fusion)
+    if (BUILD_SHARED_LIBS)
+     set_property(GLOBAL APPEND PROPERTY SYCL_TOOLCHAIN_INSTALL_COMPONENTS
+       sycl-fusion)
+    endif (BUILD_SHARED_LIBS)
   endif(SYCL_ENABLE_KERNEL_FUSION)
 
   find_package(Threads REQUIRED)


### PR DESCRIPTION
Having a dynamic companion lib creates issues for users relying on rpath.

The path makes the library statically linked to libsycl unless it is a shared build.

Signed-off-by: Victor Lomuller <victor@codeplay.com>