### PR TITLE
[SYCL] Add accessor_ptr alias to accessor and local_accessor

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -1210,6 +1210,11 @@ public:
   using reference = value_type &;
   using const_reference = const DataT &;
 
+  template <access::decorated IsDecorated>
+  using accessor_ptr =
+      std::conditional_t<AccessTarget == access::target::device,
+                         global_ptr<value_type, IsDecorated>, value_type *>;
+
   using iterator = typename detail::accessor_iterator<value_type, Dimensions>;
   using const_iterator =
       typename detail::accessor_iterator<const value_type, Dimensions>;
@@ -2674,6 +2679,9 @@ public:
   using const_reverse_iterator = std::reverse_iterator<const_iterator>;
   using difference_type =
       typename std::iterator_traits<iterator>::difference_type;
+
+  template <access::decorated IsDecorated>
+  using accessor_ptr = local_ptr<value_type, IsDecorated>;
 
   void swap(local_accessor &other) { std::swap(this->impl, other.impl); }
 

--- a/sycl/test/basic_tests/accessor/accessor_ptr_alias.cpp
+++ b/sycl/test/basic_tests/accessor/accessor_ptr_alias.cpp
@@ -1,0 +1,58 @@
+// RUN: %clangxx -fsycl -fsyntax-only %s
+
+// Tests the type of the accessor_ptr member alias of sycl::accessor and
+// sycl::local_accessor.
+
+#include <sycl/sycl.hpp>
+
+#include <type_traits>
+
+template <typename AccessorT, sycl::access::address_space ExpectedSpace>
+void CheckAccessor() {
+  static_assert(std::is_same_v<
+                typename AccessorT::template accessor_ptr<
+                    sycl::access::decorated::legacy>,
+                sycl::multi_ptr<typename AccessorT::value_type, ExpectedSpace,
+                                sycl::access::decorated::legacy>>);
+  static_assert(std::is_same_v<
+                typename AccessorT::template accessor_ptr<
+                    sycl::access::decorated::yes>,
+                sycl::multi_ptr<typename AccessorT::value_type, ExpectedSpace,
+                                sycl::access::decorated::yes>>);
+  static_assert(std::is_same_v<
+                typename AccessorT::template accessor_ptr<
+                    sycl::access::decorated::no>,
+                sycl::multi_ptr<typename AccessorT::value_type, ExpectedSpace,
+                                sycl::access::decorated::no>>);
+}
+
+template <typename DataT, int Dims, sycl::access::mode Mode>
+void CheckDeviceAccessor() {
+  using DeviceAccessorT =
+      sycl::accessor<DataT, Dims, Mode, sycl::access::target::device>;
+  CheckAccessor<DeviceAccessorT, sycl::access::address_space::global_space>();
+}
+
+template <typename DataT, int Dims> void CheckLocalAccessor() {
+  using DeviceAccessorT = sycl::local_accessor<DataT, Dims>;
+  CheckAccessor<DeviceAccessorT, sycl::access::address_space::local_space>();
+}
+
+template <typename DataT, int Dims> void CheckAccessorForModes() {
+  CheckDeviceAccessor<DataT, Dims, sycl::access::mode::read>();
+  CheckDeviceAccessor<DataT, Dims, sycl::access::mode::read_write>();
+  CheckDeviceAccessor<DataT, Dims, sycl::access::mode::write>();
+  CheckLocalAccessor<DataT, Dims>();
+}
+
+template <typename DataT> void CheckAccessorForAllDimsAndModes() {
+  CheckAccessorForModes<DataT, 1>();
+  CheckAccessorForModes<DataT, 2>();
+  CheckAccessorForModes<DataT, 3>();
+}
+
+int main() {
+  CheckAccessorForAllDimsAndModes<int>();
+  CheckAccessorForAllDimsAndModes<const int>();
+  return 0;
+}


### PR DESCRIPTION
As per the SYCL 2020 specification, `sycl::accessor` and `sycl::local_accessor` must define a member alias `accessor_ptr` denoting the `multi_ptr` type associated with the accessor. This commit adds this alias.