### PR TITLE
[SYCL] Change signature of host_accessor::get_pointer for SYCL 2020

### DIFF
--- a/sycl/test/basic_tests/accessor/host_accessor_get_pointer_type.cpp
+++ b/sycl/test/basic_tests/accessor/host_accessor_get_pointer_type.cpp
@@ -1,0 +1,35 @@
+// RUN: %clangxx -fsycl -fsyntax-only -sycl-std=2020 %s
+
+// Tests the type of the get_pointer method of host_accessor.
+
+#include <sycl/sycl.hpp>
+
+#include <type_traits>
+
+template <typename DataT, int Dims, sycl::access::mode Mode>
+void CheckHostAccessor() {
+  using HostAccessorT = sycl::host_accessor<DataT, Dims, Mode>;
+  using HostAccessorGetPointerT =
+      decltype(std::declval<HostAccessorT>().get_pointer());
+  static_assert(
+      std::is_same_v<HostAccessorGetPointerT,
+                     std::add_pointer_t<typename HostAccessorT::value_type>>);
+}
+
+template <typename DataT, int Dims> void CheckHostAccessorForModes() {
+  CheckHostAccessor<DataT, Dims, sycl::access::mode::read>();
+  CheckHostAccessor<DataT, Dims, sycl::access::mode::read_write>();
+  CheckHostAccessor<DataT, Dims, sycl::access::mode::write>();
+}
+
+template <typename DataT> void CheckHostAccessorForAllDimsAndModes() {
+  CheckHostAccessorForModes<DataT, 1>();
+  CheckHostAccessorForModes<DataT, 2>();
+  CheckHostAccessorForModes<DataT, 3>();
+}
+
+int main() {
+  CheckHostAccessorForAllDimsAndModes<int>();
+  CheckHostAccessorForAllDimsAndModes<const int>();
+  return 0;
+}


### PR DESCRIPTION
SYCL 2020 specifies that the `get_pointer` member should now return a raw pointer for based on `value_type` and should be `noexcept`. This commit changes the signature of `get_pointer` for host accessors.

Note that `AccessorBaseHost::getPtr` cannot be made `noexcept` currently as it would be an ABI break. This does not limit the functionality of these changes, but should be changed during next ABI break.