### PR TITLE
[SYCL-MLIR] Create -convert-sycl-to-gpu pass

### DIFF
--- a/mlir-sycl/include/mlir/Conversion/SYCLPasses.h
+++ b/mlir-sycl/include/mlir/Conversion/SYCLPasses.h
@@ -9,6 +9,7 @@
 #ifndef MLIR_CONVERSION_SYCLPASSES_H
 #define MLIR_CONVERSION_SYCLPASSES_H
 
+#include "mlir/Conversion/SYCLToGPU/SYCLToGPUPass.h"
 #include "mlir/Conversion/SYCLToLLVM/SYCLToLLVMPass.h"
 
 namespace mlir {

--- a/mlir-sycl/include/mlir/Conversion/SYCLPasses.td
+++ b/mlir-sycl/include/mlir/Conversion/SYCLPasses.td
@@ -36,6 +36,7 @@ def ConvertSYCLToGPU : Pass<"convert-sycl-to-gpu", "ModuleOp"> {
   }];
   let constructor = "mlir::sycl::createConvertSYCLToGPUPass()";
   let dependentDialects = [
+      "AffineDialect",
       "arith::ArithDialect",
       "gpu::GPUDialect",
       "memref::MemRefDialect",

--- a/mlir-sycl/include/mlir/Conversion/SYCLPasses.td
+++ b/mlir-sycl/include/mlir/Conversion/SYCLPasses.td
@@ -25,4 +25,21 @@ def ConvertSYCLToLLVM : Pass<"convert-sycl-to-llvm", "ModuleOp"> {
   let dependentDialects = ["LLVM::LLVMDialect"];
 }
 
+//===----------------------------------------------------------------------===//
+// SYCLToGPU
+//===----------------------------------------------------------------------===//
+
+def ConvertSYCLToGPU : Pass<"convert-sycl-to-gpu", "ModuleOp"> {
+  let summary = "Convert SYCL dialect to GPU dialect";
+  let description = [{
+    Pass to convert supported operations to the GPU dialect.
+  }];
+  let constructor = "mlir::sycl::createConvertSYCLToGPUPass()";
+  let dependentDialects = [
+      "arith::ArithDialect",
+      "gpu::GPUDialect",
+      "memref::MemRefDialect",
+  ];
+}
+
 #endif // MLIR_CONVERSION_SYCLPASSES

--- a/mlir-sycl/include/mlir/Conversion/SYCLPasses.td
+++ b/mlir-sycl/include/mlir/Conversion/SYCLPasses.td
@@ -33,6 +33,19 @@ def ConvertSYCLToGPU : Pass<"convert-sycl-to-gpu", "ModuleOp"> {
   let summary = "Convert SYCL dialect to GPU dialect";
   let description = [{
     Pass to convert supported operations to the GPU dialect.
+
+    This pass converts `sycl.work_group_id`, `sycl.num_work_items`,
+    `sycl.work_group_size`, `sycl.local_id`, `sycl.global_id`,
+    `sycl.sub_group_id` `sycl.num_sub_groups`, and `sycl.sub_group_size`
+    operations to `gpu.block_id` `gpu.grid_dim` `gpu.block_dim` `gpu.thread_id`
+    `gpu.global_id` `gpu.sub_group_id` `gpu.num_sub_groups`
+    `gpu.sub_group_size`, respectively.
+
+    While operations querying subgroup information are lowered to their
+    counterpart `gpu` dialect operations, the rest of the operations require a
+    different treatment, as the operation might or might not be passed an
+    argument querying for a specific dimension.
+};
   }];
   let constructor = "mlir::sycl::createConvertSYCLToGPUPass()";
   let dependentDialects = [

--- a/mlir-sycl/include/mlir/Conversion/SYCLToGPU/SYCLToGPU.h
+++ b/mlir-sycl/include/mlir/Conversion/SYCLToGPU/SYCLToGPU.h
@@ -1,0 +1,28 @@
+//===- SYCLToGPU.h - SYCL to GPU Patterns -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Provides patterns to convert SYCL dialect to GPU dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_CONVERSION_SYCLTOGPU_SYCLTOGPU_H
+#define MLIR_CONVERSION_SYCLTOGPU_SYCLTOGPU_H
+
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+class TypeConverter;
+namespace sycl {
+
+/// Populates the given list with patterns that convert from SYCL to GPU.
+void populateSYCLToGPUConversionPatterns(RewritePatternSet &patterns);
+
+} // namespace sycl
+} // namespace mlir
+
+#endif // MLIR_CONVERSION_SYCLTOGPU_SYCLTOGPU_H

--- a/mlir-sycl/include/mlir/Conversion/SYCLToGPU/SYCLToGPU.h
+++ b/mlir-sycl/include/mlir/Conversion/SYCLToGPU/SYCLToGPU.h
@@ -16,7 +16,6 @@
 #include "mlir/Transforms/DialectConversion.h"
 
 namespace mlir {
-class TypeConverter;
 namespace sycl {
 
 /// Populates the given list with patterns that convert from SYCL to GPU.

--- a/mlir-sycl/include/mlir/Conversion/SYCLToGPU/SYCLToGPUPass.h
+++ b/mlir-sycl/include/mlir/Conversion/SYCLToGPU/SYCLToGPUPass.h
@@ -1,0 +1,36 @@
+//===- SYCLToGPUPass.h - SYCL to GPU Passes ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Provides passes to convert SYCL dialect to GPU dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_CONVERSION_SYCLTOGPU_SYCLTOGPUPASS_H
+#define MLIR_CONVERSION_SYCLTOGPU_SYCLTOGPUPASS_H
+
+#include "mlir/Pass/Pass.h"
+
+#include <memory>
+
+namespace mlir {
+class ModuleOp;
+template <typename T> class OperationPass;
+
+#define GEN_PASS_DECL_CONVERTSYCLTOGPU
+#include "mlir/Conversion/SYCLPasses.h.inc"
+#undef GEN_PASS_DECL_CONVERTSYCLTOGPU
+
+namespace sycl {
+
+/// Creates a pass to convert SYCL operations to the GPU dialect.
+std::unique_ptr<OperationPass<ModuleOp>> createConvertSYCLToGPUPass();
+
+} // namespace sycl
+} // namespace mlir
+
+#endif // MLIR_CONVERSION_SYCLTOGPU_SYCLTOGPUPASS_H

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOpsTypes.h
@@ -86,6 +86,9 @@ public:
 /// Return true if the given \p Ty is a SYCL type.
 inline bool isSYCLType(Type Ty) { return isa<SYCLDialect>(Ty.getDialect()); }
 
+/// Return the number of dimensions of type \p Ty.
+unsigned getDimensions(Type Ty);
+
 llvm::SmallVector<mlir::TypeID> getDerivedTypes(mlir::TypeID TypeID);
 } // namespace sycl
 } // namespace mlir

--- a/mlir-sycl/lib/Conversion/CMakeLists.txt
+++ b/mlir-sycl/lib/Conversion/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(SYCLToLLVM)
+add_subdirectory(SYCLToGPU)

--- a/mlir-sycl/lib/Conversion/CMakeLists.txt
+++ b/mlir-sycl/lib/Conversion/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_subdirectory(SYCLToLLVM)
 add_subdirectory(SYCLToGPU)
+add_subdirectory(SYCLToLLVM)

--- a/mlir-sycl/lib/Conversion/SYCLToGPU/CMakeLists.txt
+++ b/mlir-sycl/lib/Conversion/SYCLToGPU/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_mlir_conversion_library(MLIRSYCLToGPU
+  SYCLToGPU.cpp
+  SYCLToGPUPass.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_SYCL_SOURCE_DIR}/mlir/Conversion/SYCLToGPU
+
+  DEPENDS
+  MLIRSYCLConversionPassIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRGPUOps
+  MLIRTransforms
+  MLIRSYCLDialect
+  )

--- a/mlir-sycl/lib/Conversion/SYCLToGPU/CMakeLists.txt
+++ b/mlir-sycl/lib/Conversion/SYCLToGPU/CMakeLists.txt
@@ -9,8 +9,8 @@ add_mlir_conversion_library(MLIRSYCLToGPU
   MLIRSYCLConversionPassIncGen
 
   LINK_LIBS PUBLIC
-  MLIRIR
   MLIRGPUOps
-  MLIRTransforms
+  MLIRIR
   MLIRSYCLDialect
+  MLIRTransforms
   )

--- a/mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPU.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPU.cpp
@@ -18,8 +18,6 @@
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/TypeSwitch.h"
 
-#define DEBUG_TYPE "sycl-to-gpu"
-
 using namespace mlir;
 using namespace mlir::sycl;
 

--- a/mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPU.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPU.cpp
@@ -179,7 +179,7 @@ public:
   LogicalResult
   matchAndRewrite(OpTy op, typename OpTy::Adaptor opAdaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    const auto opName = GPUOpTy::getOperationName();
+    constexpr auto opName = GPUOpTy::getOperationName();
     ::rewrite(opName,
               GPUOpTy::getDimensionAttrName({opName, rewriter.getContext()}),
               op, opAdaptor.getOperands(), rewriter);

--- a/mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPU.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPU.cpp
@@ -1,0 +1,225 @@
+//===- SYCLToGPU.cpp - SYCL to GPU Patterns -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements patterns to convert SYCL dialect to GPU dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Conversion/SYCLToGPU/SYCLToGPU.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/SYCL/IR/SYCLOps.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+#define DEBUG_TYPE "sycl-to-gpu"
+
+using namespace mlir;
+using namespace mlir::sycl;
+
+namespace {
+/// Returns the result of creating an operation to get a reference to an element
+/// of a sycl::id or sycl::range.
+Value createGetOp(OpBuilder &builder, Location loc, Type dimMtTy, Value res,
+                  Value index, ArrayAttr argumentTypes,
+                  FlatSymbolRefAttr functionName) {
+  return TypeSwitch<Type, Value>(res.getType())
+      .Case<IDType, RangeType>([&](auto arg) {
+        // `this` type
+        using ArgTy = decltype(arg);
+        // Operation type depending on ArgTy
+        using OpTy = std::conditional_t<std::is_same_v<ArgTy, IDType>,
+                                        SYCLIDGetOp, SYCLRangeGetOp>;
+        return builder.create<OpTy>(
+            loc, dimMtTy, res, index, argumentTypes, functionName, functionName,
+            builder.getAttr<FlatSymbolRefAttr>(ArgTy::getMnemonic()));
+      });
+}
+
+/// Creates an operation of with name \p opName from the GPU dialect using the
+/// dimension \p i as an attribute.
+///
+/// \return The result of such operation.
+Value getDimension(OpBuilder &builder, Location loc, StringRef opName,
+                   StringRef dimensionAttrName, int64_t i) {
+  assert(0 <= i && i < gpu::GPUDialect::getNumWorkgroupDimensions() &&
+         "Invalid index value");
+  // The GPU dialect lacks a proper way to obtain this name.
+  auto *op = builder.create(
+      loc, builder.getStringAttr(opName), ValueRange{}, builder.getIndexType(),
+      builder.getNamedAttr(
+          dimensionAttrName,
+          builder.getAttr<gpu::DimensionAttr>(static_cast<gpu::Dimension>(i))));
+  assert(op->getNumResults() == 1 && "Invalid number of results");
+  return op->getResult(0);
+}
+
+/// Replace \p op with a single operation with name \p opName from the GPU
+/// dialect thanks to the known constant index \p index.
+void convertWithConstIndex(ConversionPatternRewriter &rewriter,
+                           StringRef opName, StringRef dimensionAttrname,
+                           Operation *op, arith::ConstantOp index) {
+  const auto i = static_cast<arith::ConstantIntOp>(index).value();
+  rewriter.replaceOp(
+      op, getDimension(rewriter, op->getLoc(), opName, dimensionAttrname, i));
+}
+
+/// Replace \p op with a sequence of operations that:
+/// 1. Allocate a new array of the result type in the stack
+/// 2. Initialize the dimensions of the array with the expected results using
+/// the operation with name \p opName from the GPU dialect
+/// 3. Load the value in position \p index (assumed to be inbounds)
+void convertWithVarIndex(ConversionPatternRewriter &rewriter, StringRef opName,
+                         StringRef dimensionAttrname, Operation *op,
+                         int64_t dimensions, Value index) {
+  assert(dimensions <= gpu::GPUDialect::getNumWorkgroupDimensions() &&
+         "Invalid number of dimensions");
+  const auto loc = op->getLoc();
+  const auto indexTy = rewriter.getIndexType();
+  const auto alloca = static_cast<Value>(rewriter.create<memref::AllocaOp>(
+      loc, MemRefType::get({dimensions}, indexTy)));
+  for (int64_t i = 0; i < dimensions; ++i) {
+    const auto c =
+        static_cast<Value>(rewriter.create<arith::ConstantIndexOp>(loc, i));
+    const auto val = getDimension(rewriter, loc, opName, dimensionAttrname, i);
+    rewriter.create<memref::StoreOp>(loc, val, alloca, c);
+  }
+  index = rewriter.create<arith::IndexCastOp>(loc, indexTy, index);
+  rewriter.replaceOpWithNewOp<memref::LoadOp>(op, alloca, index);
+}
+
+/// Replace \p op with a sequence of operations that:
+/// 1. Allocate a new object of the result type in the stack
+/// 2. Load the object
+/// 3. Initialize the dimensions of the object with the expected results using
+/// the operation with name \p opName from the GPU dialect
+void convertToFullObject(ConversionPatternRewriter &rewriter, StringRef opName,
+                         StringRef dimensionAttrname, Operation *op,
+                         int64_t dimensions) {
+  // This conversion is platform dependent
+  assert(dimensions <= gpu::GPUDialect::getNumWorkgroupDimensions() &&
+         "Invalid number of dimensions");
+  const auto loc = op->getLoc();
+  const auto targetIndexTy = rewriter.getIntegerType(64);
+  const auto getIndexTy = rewriter.getIntegerType(32);
+  const auto dimMtTy = MemRefType::get(dimensions, targetIndexTy, {}, 4);
+  // Allocate
+  const auto resTy = op->getResultTypes()[0];
+  const auto alloca = static_cast<Value>(
+      rewriter.create<memref::AllocaOp>(loc, MemRefType::get(1, resTy)));
+  // Load
+  const auto zero =
+      static_cast<Value>(rewriter.create<arith::ConstantIndexOp>(loc, 0));
+  const auto res = static_cast<Value>(
+      rewriter.replaceOpWithNewOp<memref::LoadOp>(op, alloca, zero));
+  const auto argumentTypes =
+      rewriter.getTypeArrayAttr({MemRefType::get(1, resTy, {}, 4), getIndexTy});
+  const auto functionName = rewriter.getAttr<FlatSymbolRefAttr>("operator[]");
+  // Initialize
+  for (int64_t i = 0; i < dimensions; ++i) {
+    const auto index = static_cast<Value>(
+        rewriter.create<arith::ConstantIntOp>(loc, i, getIndexTy));
+    const auto val = static_cast<Value>(rewriter.create<arith::IndexCastOp>(
+        loc, targetIndexTy,
+        getDimension(rewriter, loc, opName, dimensionAttrname, i)));
+    const auto ptr = createGetOp(rewriter, loc, dimMtTy, res, index,
+                                 argumentTypes, functionName);
+    rewriter.create<memref::StoreOp>(loc, val, ptr, zero);
+  }
+}
+
+/// Converts n-dimensional operations to operations of name \p opName, from the
+/// GPU dialect.
+///
+/// There are three possible cases here:
+/// 1. No argument is passed (see convertToFullObject())
+/// 2. A constant argument is passed (see converWithConstIndex())
+/// 3. A non-constant argument is passed (see convertWithVarIndex())
+void rewrite(StringRef opName, StringRef dimensionAttrName, Operation *op,
+             ValueRange operands, ConversionPatternRewriter &rewriter) {
+  switch (op->getNumOperands()) {
+  case 0: {
+    const auto dimensions = getDimensions(op->getResultTypes()[0]);
+    convertToFullObject(rewriter, opName, dimensionAttrName, op, dimensions);
+    break;
+  }
+  case 1: {
+    const auto dimension = operands[0];
+    if (const auto definingOp = dimension.getDefiningOp<arith::ConstantOp>()) {
+      convertWithConstIndex(rewriter, opName, dimensionAttrName, op,
+                            definingOp);
+    } else {
+      // TODO: Do not rely in a default number of dimensions; take into
+      // account kernel dimensionality. This should be available in the parent
+      // function.
+      constexpr int64_t defaultDimensions{3};
+      convertWithVarIndex(rewriter, opName, dimensionAttrName, op,
+                          defaultDimensions, dimension);
+    }
+    break;
+  }
+  default:
+    llvm_unreachable("Invalid cardinality");
+  }
+}
+
+/// Converts n-dimensional operations of type \tparam OpTy to operations of type
+/// \tparam GPUOpTy.
+///
+/// Work is offloaded to the rewrite function above.
+template <typename OpTy, typename GPUOpTy>
+class GridOpPattern final : public OpConversionPattern<OpTy> {
+public:
+  using OpConversionPattern<OpTy>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(OpTy op, typename OpTy::Adaptor opAdaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    const auto opName = GPUOpTy::getOperationName();
+    ::rewrite(opName,
+              GPUOpTy::getDimensionAttrName({opName, rewriter.getContext()}),
+              op, opAdaptor.getOperands(), rewriter);
+    return success();
+  }
+};
+
+/// Converts one-dimensional operations of type \tparam OpTy to operations of
+/// type \tparam GPUOpTy.
+///
+/// Due to the different output type, as casting is needed before returning.
+template <typename OpTy, typename GPUOpTy>
+class SingleDimGridOpPattern final : public OpConversionPattern<OpTy> {
+public:
+  using OpConversionPattern<OpTy>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(OpTy op, typename OpTy::Adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Create the new operation
+    const auto res = static_cast<Value>(rewriter.create<GPUOpTy>(op->getLoc()));
+    // And cast
+    rewriter.replaceOpWithNewOp<arith::IndexCastOp>(op, op->getResultTypes()[0],
+                                                    res);
+    return success();
+  }
+};
+} // namespace
+
+void mlir::sycl::populateSYCLToGPUConversionPatterns(
+    RewritePatternSet &patterns) {
+  patterns.add<GridOpPattern<SYCLWorkGroupIDOp, gpu::BlockIdOp>,
+               GridOpPattern<SYCLNumWorkItemsOp, gpu::GridDimOp>,
+               GridOpPattern<SYCLWorkGroupSizeOp, gpu::BlockDimOp>,
+               GridOpPattern<SYCLLocalIDOp, gpu::ThreadIdOp>,
+               GridOpPattern<SYCLGlobalIDOp, gpu::GlobalIdOp>,
+               SingleDimGridOpPattern<SYCLSubGroupIDOp, gpu::SubgroupIdOp>,
+               SingleDimGridOpPattern<SYCLNumSubGroupsOp, gpu::NumSubgroupsOp>,
+               SingleDimGridOpPattern<SYCLSubGroupSizeOp, gpu::SubgroupSizeOp>>(
+      patterns.getContext());
+}

--- a/mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPUPass.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPUPass.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Conversion/SYCLToGPU/SYCLToGPUPass.h"
 
 #include "mlir/Conversion/SYCLToGPU/SYCLToGPU.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -43,7 +44,7 @@ void ConvertSYCLToGPUPass::runOnOperation() {
 
   populateSYCLToGPUConversionPatterns(patterns);
 
-  target.addLegalDialect<arith::ArithDialect, gpu::GPUDialect,
+  target.addLegalDialect<AffineDialect, arith::ArithDialect, gpu::GPUDialect,
                          memref::MemRefDialect, SYCLDialect>();
 
   target

--- a/mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPUPass.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPUPass.cpp
@@ -36,17 +36,15 @@ class ConvertSYCLToGPUPass
 } // namespace
 
 void ConvertSYCLToGPUPass::runOnOperation() {
-  auto *context = &getContext();
+  auto &context = getContext();
 
-  RewritePatternSet patterns(context);
-  ConversionTarget target(*context);
+  RewritePatternSet patterns(&context);
+  ConversionTarget target(context);
 
   populateSYCLToGPUConversionPatterns(patterns);
 
-  target.addLegalDialect<arith::ArithDialect>();
-  target.addLegalDialect<gpu::GPUDialect>();
-  target.addLegalDialect<memref::MemRefDialect>();
-  target.addLegalDialect<SYCLDialect>();
+  target.addLegalDialect<arith::ArithDialect, gpu::GPUDialect,
+                         memref::MemRefDialect, SYCLDialect>();
 
   target
       .addIllegalOp<SYCLWorkGroupIDOp, SYCLNumWorkItemsOp, SYCLWorkGroupSizeOp,

--- a/mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPUPass.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPUPass.cpp
@@ -1,0 +1,64 @@
+//===- SYCLToGPUPass.cpp - SYCL to GPU Passes -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements a pass to convert MLIR SYCL ops into GPU ops
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Conversion/SYCLToGPU/SYCLToGPUPass.h"
+
+#include "mlir/Conversion/SYCLToGPU/SYCLToGPU.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SYCL/IR/SYCLOps.h"
+
+using namespace mlir;
+using namespace mlir::sycl;
+
+namespace mlir {
+#define GEN_PASS_DEF_CONVERTSYCLTOGPU
+#include "mlir/Conversion/SYCLPasses.h.inc"
+#undef GEN_PASS_DEF_CONVERTSYCLTOGPU
+} // namespace mlir
+
+namespace {
+/// A pass converting MLIR SYCL operations into LLVM dialect.
+class ConvertSYCLToGPUPass
+    : public impl::ConvertSYCLToGPUBase<ConvertSYCLToGPUPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void ConvertSYCLToGPUPass::runOnOperation() {
+  auto *context = &getContext();
+
+  RewritePatternSet patterns(context);
+  ConversionTarget target(*context);
+
+  populateSYCLToGPUConversionPatterns(patterns);
+
+  target.addLegalDialect<arith::ArithDialect>();
+  target.addLegalDialect<gpu::GPUDialect>();
+  target.addLegalDialect<memref::MemRefDialect>();
+  target.addLegalDialect<SYCLDialect>();
+
+  target
+      .addIllegalOp<SYCLWorkGroupIDOp, SYCLNumWorkItemsOp, SYCLWorkGroupSizeOp,
+                    SYCLLocalIDOp, SYCLGlobalIDOp, SYCLSubGroupIDOp,
+                    SYCLNumSubGroupsOp, SYCLSubGroupSizeOp>();
+
+  if (failed(
+          applyPartialConversion(getOperation(), target, std::move(patterns))))
+    signalPassFailure();
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::sycl::createConvertSYCLToGPUPass() {
+  return std::make_unique<ConvertSYCLToGPUPass>();
+}

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsTypes.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsTypes.cpp
@@ -9,6 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/SYCL/IR/SYCLOpsTypes.h"
+#include "llvm/ADT/TypeSwitch.h"
 
 llvm::StringRef mlir::sycl::memoryAccessModeAsString(
     mlir::sycl::MemoryAccessMode MemAccessMode) {
@@ -214,4 +215,13 @@ mlir::sycl::VecType::verify(llvm::function_ref<InFlightDiagnostic()> EmitError,
   }
 
   return success();
+}
+
+unsigned mlir::sycl::getDimensions(mlir::Type Type) {
+  if (auto MemRefTy = Type.dyn_cast<mlir::MemRefType>()) {
+    Type = MemRefTy.getElementType();
+  }
+  return TypeSwitch<mlir::Type, unsigned>(Type)
+      .Case<AccessorType, ItemType, NdRangeType, GroupType, IDType, NdItemType,
+            RangeType>([](auto Ty) { return Ty.getDimension(); });
 }

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsTypes.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsTypes.cpp
@@ -218,10 +218,9 @@ mlir::sycl::VecType::verify(llvm::function_ref<InFlightDiagnostic()> EmitError,
 }
 
 unsigned mlir::sycl::getDimensions(mlir::Type Type) {
-  if (auto MemRefTy = Type.dyn_cast<mlir::MemRefType>()) {
+  if (auto MemRefTy = Type.dyn_cast<mlir::MemRefType>())
     Type = MemRefTy.getElementType();
-  }
   return TypeSwitch<mlir::Type, unsigned>(Type)
-      .Case<AccessorType, ItemType, NdRangeType, GroupType, IDType, NdItemType,
+      .Case<AccessorType, GroupType, IDType, ItemType, NdItemType, NdRangeType,
             RangeType>([](auto Ty) { return Ty.getDimension(); });
 }

--- a/mlir-sycl/lib/Dialect/IR/SYCLTraits.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLTraits.cpp
@@ -18,17 +18,6 @@
 using namespace mlir;
 using namespace mlir::sycl;
 
-static unsigned getDimensions(mlir::Type Type) {
-  if (auto MemRefTy = Type.dyn_cast<mlir::MemRefType>()) {
-    Type = MemRefTy.getElementType();
-  }
-  return llvm::TypeSwitch<mlir::Type, unsigned>(Type)
-      .Case<mlir::sycl::AccessorType, mlir::sycl::ItemType,
-            mlir::sycl::NdRangeType, mlir::sycl::GroupType, mlir::sycl::IDType,
-            mlir::sycl::NdItemType, mlir::sycl::RangeType>(
-          [](auto Ty) { return Ty.getDimension(); });
-}
-
 static mlir::LogicalResult
 verifyEqualDimensions(mlir::sycl::SYCLMethodOpInterface Op) {
   const auto RetTy = Op->getResult(0).getType();

--- a/mlir-sycl/test/Conversion/SYCLToGPU/grid-ops.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToGPU/grid-ops.mlir
@@ -10,12 +10,12 @@
 // CHECK-LABEL:   func.func @test_num_work_items() -> !sycl_range_1_ {
 // CHECK-NEXT:      %[[VAL_0:.*]] = memref.alloca() : memref<1x!sycl_range_1_>
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_2:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_range_1_>
+// CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_range_1_>
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 0 : i32
 // CHECK-NEXT:      %[[VAL_4:.*]] = gpu.grid_dim  x
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : index to i64
 // CHECK-NEXT:      %[[VAL_6:.*]] = "sycl.range.get"(%[[VAL_2]], %[[VAL_3]]) {ArgumentTypes = [memref<1x!sycl_range_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (!sycl_range_1_, i32) -> memref<1xi64, 4>
-// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<1xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<1xi64, 4>
 // CHECK-NEXT:      return %[[VAL_2]] : !sycl_range_1_
 // CHECK-NEXT:    }
 func.func @test_num_work_items() -> !sycl_range_1_ {
@@ -28,15 +28,15 @@ func.func @test_num_work_items() -> !sycl_range_1_ {
 // CHECK-NEXT:      %[[VAL_1:.*]] = memref.alloca() : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.grid_dim  x
-// CHECK-NEXT:      memref.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
+// CHECK-NEXT:      affine.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 1 : index
 // CHECK-NEXT:      %[[VAL_5:.*]] = gpu.grid_dim  y
-// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
+// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 2 : index
 // CHECK-NEXT:      %[[VAL_7:.*]] = gpu.grid_dim  z
-// CHECK-NEXT:      memref.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
+// CHECK-NEXT:      affine.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_0]] : i32 to index
-// CHECK-NEXT:      %[[VAL_9:.*]] = memref.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_9:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
 // CHECK-NEXT:      return %[[VAL_9]] : index
 // CHECK-NEXT:    }
 func.func @test_num_work_items_dim(%i: i32) -> index {
@@ -47,17 +47,17 @@ func.func @test_num_work_items_dim(%i: i32) -> index {
 // CHECK-LABEL:   func.func @test_global_id() -> !sycl_id_2_ {
 // CHECK-NEXT:      %[[VAL_0:.*]] = memref.alloca() : memref<1x!sycl_id_2_>
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_2:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_2_>
+// CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_2_>
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 0 : i32
 // CHECK-NEXT:      %[[VAL_4:.*]] = gpu.global_id  x
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : index to i64
 // CHECK-NEXT:      %[[VAL_6:.*]] = "sycl.id.get"(%[[VAL_2]], %[[VAL_3]]) {ArgumentTypes = [memref<1x!sycl_id_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_2_, i32) -> memref<2xi64, 4>
-// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<2xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<2xi64, 4>
 // CHECK-NEXT:      %[[VAL_7:.*]] = arith.constant 1 : i32
 // CHECK-NEXT:      %[[VAL_8:.*]] = gpu.global_id  y
 // CHECK-NEXT:      %[[VAL_9:.*]] = arith.index_cast %[[VAL_8]] : index to i64
 // CHECK-NEXT:      %[[VAL_10:.*]] = "sycl.id.get"(%[[VAL_2]], %[[VAL_7]]) {ArgumentTypes = [memref<1x!sycl_id_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_2_, i32) -> memref<2xi64, 4>
-// CHECK-NEXT:      memref.store %[[VAL_9]], %[[VAL_10]]{{\[}}%[[VAL_1]]] : memref<2xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_9]], %[[VAL_10]]{{\[}}%[[VAL_1]]] : memref<2xi64, 4>
 // CHECK-NEXT:      return %[[VAL_2]] : !sycl_id_2_
 // CHECK-NEXT:    }
 func.func @test_global_id() -> !sycl_id_2_ {
@@ -70,15 +70,15 @@ func.func @test_global_id() -> !sycl_id_2_ {
 // CHECK-NEXT:      %[[VAL_1:.*]] = memref.alloca() : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.global_id  x
-// CHECK-NEXT:      memref.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
+// CHECK-NEXT:      affine.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 1 : index
 // CHECK-NEXT:      %[[VAL_5:.*]] = gpu.global_id  y
-// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
+// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 2 : index
 // CHECK-NEXT:      %[[VAL_7:.*]] = gpu.global_id  z
-// CHECK-NEXT:      memref.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
+// CHECK-NEXT:      affine.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_0]] : i32 to index
-// CHECK-NEXT:      %[[VAL_9:.*]] = memref.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_9:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
 // CHECK-NEXT:      return %[[VAL_9]] : index
 // CHECK-NEXT:    }
 func.func @test_global_id_dim(%i: i32) -> index {
@@ -89,22 +89,22 @@ func.func @test_global_id_dim(%i: i32) -> index {
 // CHECK-LABEL:   func.func @test_local_id() -> !sycl_id_3_ {
 // CHECK-NEXT:      %[[VAL_0:.*]] = memref.alloca() : memref<1x!sycl_id_3_>
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_2:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_3_>
+// CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_3_>
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 0 : i32
 // CHECK-NEXT:      %[[VAL_4:.*]] = gpu.thread_id  x
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : index to i64
 // CHECK-NEXT:      %[[VAL_6:.*]] = "sycl.id.get"(%[[VAL_2]], %[[VAL_3]]) {ArgumentTypes = [memref<1x!sycl_id_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_3_, i32) -> memref<3xi64, 4>
-// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
 // CHECK-NEXT:      %[[VAL_7:.*]] = arith.constant 1 : i32
 // CHECK-NEXT:      %[[VAL_8:.*]] = gpu.thread_id  y
 // CHECK-NEXT:      %[[VAL_9:.*]] = arith.index_cast %[[VAL_8]] : index to i64
 // CHECK-NEXT:      %[[VAL_10:.*]] = "sycl.id.get"(%[[VAL_2]], %[[VAL_7]]) {ArgumentTypes = [memref<1x!sycl_id_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_3_, i32) -> memref<3xi64, 4>
-// CHECK-NEXT:      memref.store %[[VAL_9]], %[[VAL_10]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_9]], %[[VAL_10]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
 // CHECK-NEXT:      %[[VAL_11:.*]] = arith.constant 2 : i32
 // CHECK-NEXT:      %[[VAL_12:.*]] = gpu.thread_id  z
 // CHECK-NEXT:      %[[VAL_13:.*]] = arith.index_cast %[[VAL_12]] : index to i64
 // CHECK-NEXT:      %[[VAL_14:.*]] = "sycl.id.get"(%[[VAL_2]], %[[VAL_11]]) {ArgumentTypes = [memref<1x!sycl_id_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_3_, i32) -> memref<3xi64, 4>
-// CHECK-NEXT:      memref.store %[[VAL_13]], %[[VAL_14]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_13]], %[[VAL_14]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
 // CHECK-NEXT:      return %[[VAL_2]] : !sycl_id_3_
 // CHECK-NEXT:    }
 func.func @test_local_id() -> !sycl_id_3_ {
@@ -117,15 +117,15 @@ func.func @test_local_id() -> !sycl_id_3_ {
 // CHECK-NEXT:      %[[VAL_1:.*]] = memref.alloca() : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.thread_id  x
-// CHECK-NEXT:      memref.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
+// CHECK-NEXT:      affine.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 1 : index
 // CHECK-NEXT:      %[[VAL_5:.*]] = gpu.thread_id  y
-// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
+// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 2 : index
 // CHECK-NEXT:      %[[VAL_7:.*]] = gpu.thread_id  z
-// CHECK-NEXT:      memref.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
+// CHECK-NEXT:      affine.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_0]] : i32 to index
-// CHECK-NEXT:      %[[VAL_9:.*]] = memref.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_9:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
 // CHECK-NEXT:      return %[[VAL_9]] : index
 // CHECK-NEXT:    }
 func.func @test_local_id_dim(%i: i32) -> index {
@@ -136,22 +136,22 @@ func.func @test_local_id_dim(%i: i32) -> index {
 // CHECK-LABEL:   func.func @test_work_group_size() -> !sycl_range_3_ {
 // CHECK-NEXT:      %[[VAL_0:.*]] = memref.alloca() : memref<1x!sycl_range_3_>
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_2:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_range_3_>
+// CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_range_3_>
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 0 : i32
 // CHECK-NEXT:      %[[VAL_4:.*]] = gpu.block_dim  x
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : index to i64
 // CHECK-NEXT:      %[[VAL_6:.*]] = "sycl.range.get"(%[[VAL_2]], %[[VAL_3]]) {ArgumentTypes = [memref<1x!sycl_range_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (!sycl_range_3_, i32) -> memref<3xi64, 4>
-// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
 // CHECK-NEXT:      %[[VAL_7:.*]] = arith.constant 1 : i32
 // CHECK-NEXT:      %[[VAL_8:.*]] = gpu.block_dim  y
 // CHECK-NEXT:      %[[VAL_9:.*]] = arith.index_cast %[[VAL_8]] : index to i64
 // CHECK-NEXT:      %[[VAL_10:.*]] = "sycl.range.get"(%[[VAL_2]], %[[VAL_7]]) {ArgumentTypes = [memref<1x!sycl_range_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (!sycl_range_3_, i32) -> memref<3xi64, 4>
-// CHECK-NEXT:      memref.store %[[VAL_9]], %[[VAL_10]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_9]], %[[VAL_10]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
 // CHECK-NEXT:      %[[VAL_11:.*]] = arith.constant 2 : i32
 // CHECK-NEXT:      %[[VAL_12:.*]] = gpu.block_dim  z
 // CHECK-NEXT:      %[[VAL_13:.*]] = arith.index_cast %[[VAL_12]] : index to i64
 // CHECK-NEXT:      %[[VAL_14:.*]] = "sycl.range.get"(%[[VAL_2]], %[[VAL_11]]) {ArgumentTypes = [memref<1x!sycl_range_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (!sycl_range_3_, i32) -> memref<3xi64, 4>
-// CHECK-NEXT:      memref.store %[[VAL_13]], %[[VAL_14]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_13]], %[[VAL_14]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
 // CHECK-NEXT:      return %[[VAL_2]] : !sycl_range_3_
 // CHECK-NEXT:    }
 func.func @test_work_group_size() -> !sycl_range_3_ {
@@ -164,15 +164,15 @@ func.func @test_work_group_size() -> !sycl_range_3_ {
 // CHECK-NEXT:      %[[VAL_1:.*]] = memref.alloca() : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.block_dim  x
-// CHECK-NEXT:      memref.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
+// CHECK-NEXT:      affine.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 1 : index
 // CHECK-NEXT:      %[[VAL_5:.*]] = gpu.block_dim  y
-// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
+// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 2 : index
 // CHECK-NEXT:      %[[VAL_7:.*]] = gpu.block_dim  z
-// CHECK-NEXT:      memref.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
+// CHECK-NEXT:      affine.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_0]] : i32 to index
-// CHECK-NEXT:      %[[VAL_9:.*]] = memref.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_9:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
 // CHECK-NEXT:      return %[[VAL_9]] : index
 // CHECK-NEXT:    }
 func.func @test_work_group_size_dim(%i: i32) -> index {
@@ -183,12 +183,12 @@ func.func @test_work_group_size_dim(%i: i32) -> index {
 // CHECK-LABEL:   func.func @test_work_group_id() -> !sycl_id_1_ {
 // CHECK-NEXT:      %[[VAL_0:.*]] = memref.alloca() : memref<1x!sycl_id_1_>
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_2:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_1_>
+// CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_1_>
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 0 : i32
 // CHECK-NEXT:      %[[VAL_4:.*]] = gpu.block_id  x
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : index to i64
 // CHECK-NEXT:      %[[VAL_6:.*]] = "sycl.id.get"(%[[VAL_2]], %[[VAL_3]]) {ArgumentTypes = [memref<1x!sycl_id_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_1_, i32) -> memref<1xi64, 4>
-// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<1xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<1xi64, 4>
 // CHECK-NEXT:      return %[[VAL_2]] : !sycl_id_1_
 // CHECK-NEXT:    }
 func.func @test_work_group_id() -> !sycl_id_1_ {
@@ -201,74 +201,19 @@ func.func @test_work_group_id() -> !sycl_id_1_ {
 // CHECK-NEXT:      %[[VAL_1:.*]] = memref.alloca() : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.block_id  x
-// CHECK-NEXT:      memref.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
+// CHECK-NEXT:      affine.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 1 : index
 // CHECK-NEXT:      %[[VAL_5:.*]] = gpu.block_id  y
-// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
+// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 2 : index
 // CHECK-NEXT:      %[[VAL_7:.*]] = gpu.block_id  z
-// CHECK-NEXT:      memref.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
+// CHECK-NEXT:      affine.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
 // CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_0]] : i32 to index
-// CHECK-NEXT:      %[[VAL_9:.*]] = memref.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_9:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
 // CHECK-NEXT:      return %[[VAL_9]] : index
 // CHECK-NEXT:    }
 func.func @test_work_group_id_dim(%i: i32) -> index {
   %0 = sycl.work_group_id(%i) : (i32) -> index
-  return %0 : index
-}
-
-// CHECK-LABEL:   func.func @test_num_work_items_const() -> index {
-// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:      %[[VAL_1:.*]] = gpu.grid_dim  x
-// CHECK-NEXT:      return %[[VAL_1]] : index
-// CHECK-NEXT:    }
-func.func @test_num_work_items_const() -> index {
-  %c0_i32 = arith.constant 0 : i32
-  %0 = sycl.num_work_items(%c0_i32) : (i32) -> index
-  return %0 : index
-}
-
-// CHECK-LABEL:   func.func @test_global_id_const() -> index {
-// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:      %[[VAL_1:.*]] = gpu.global_id  y
-// CHECK-NEXT:      return %[[VAL_1]] : index
-// CHECK-NEXT:    }
-func.func @test_global_id_const() -> index {
-  %c1_i32 = arith.constant 1 : i32
-  %0 = sycl.global_id(%c1_i32) : (i32) -> index
-  return %0 : index
-}
-
-// CHECK-LABEL:   func.func @test_local_id_const() -> index {
-// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 2 : i32
-// CHECK-NEXT:      %[[VAL_1:.*]] = gpu.thread_id  z
-// CHECK-NEXT:      return %[[VAL_1]] : index
-// CHECK-NEXT:    }
-func.func @test_local_id_const() -> index {
-  %c2_i32 = arith.constant 2 : i32
-  %0 = sycl.local_id(%c2_i32) : (i32) -> index
-  return %0 : index
-}
-
-// CHECK-LABEL:   func.func @test_work_group_size_const() -> index {
-// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 2 : i32
-// CHECK-NEXT:      %[[VAL_1:.*]] = gpu.block_dim  z
-// CHECK-NEXT:      return %[[VAL_1]] : index
-// CHECK-NEXT:    }
-func.func @test_work_group_size_const() -> index {
-  %c2_i32 = arith.constant 2 : i32
-  %0 = sycl.work_group_size(%c2_i32) : (i32) -> index
-  return %0 : index
-}
-
-// CHECK-LABEL:   func.func @test_work_group_id_const() -> index {
-// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:      %[[VAL_1:.*]] = gpu.block_id  x
-// CHECK-NEXT:      return %[[VAL_1]] : index
-// CHECK-NEXT:    }
-func.func @test_work_group_id_const() -> index {
-  %c0_i32 = arith.constant 0 : i32
-  %0 = sycl.work_group_id(%c0_i32) : (i32) -> index
   return %0 : index
 }
 

--- a/mlir-sycl/test/Conversion/SYCLToGPU/grid-ops.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToGPU/grid-ops.mlir
@@ -1,0 +1,303 @@
+// RUN: sycl-mlir-opt -convert-sycl-to-gpu %s -o - | FileCheck %s
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
+
+// CHECK-LABEL:   func.func @test_num_work_items() -> !sycl_range_1_ {
+// CHECK-NEXT:      %[[VAL_0:.*]] = memref.alloca() : memref<1x!sycl_range_1_>
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_2:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_range_1_>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = gpu.grid_dim  x
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : index to i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = "sycl.range.get"(%[[VAL_2]], %[[VAL_3]]) {ArgumentTypes = [memref<1x!sycl_range_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (!sycl_range_1_, i32) -> memref<1xi64, 4>
+// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<1xi64, 4>
+// CHECK-NEXT:      return %[[VAL_2]] : !sycl_range_1_
+// CHECK-NEXT:    }
+func.func @test_num_work_items() -> !sycl_range_1_ {
+  %0 = sycl.num_work_items() : () -> !sycl_range_1_
+  return %0 : !sycl_range_1_
+}
+
+// CHECK-LABEL:   func.func @test_num_work_items_dim(
+// CHECK-SAME:                                       %[[VAL_0:.*]]: i32) -> index {
+// CHECK-NEXT:      %[[VAL_1:.*]] = memref.alloca() : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_3:.*]] = gpu.grid_dim  x
+// CHECK-NEXT:      memref.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_5:.*]] = gpu.grid_dim  y
+// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[VAL_7:.*]] = gpu.grid_dim  z
+// CHECK-NEXT:      memref.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_0]] : i32 to index
+// CHECK-NEXT:      %[[VAL_9:.*]] = memref.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
+// CHECK-NEXT:      return %[[VAL_9]] : index
+// CHECK-NEXT:    }
+func.func @test_num_work_items_dim(%i: i32) -> index {
+  %0 = sycl.num_work_items(%i) : (i32) -> index
+  return %0 : index
+}
+
+// CHECK-LABEL:   func.func @test_global_id() -> !sycl_id_2_ {
+// CHECK-NEXT:      %[[VAL_0:.*]] = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_2:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_2_>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = gpu.global_id  x
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : index to i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = "sycl.id.get"(%[[VAL_2]], %[[VAL_3]]) {ArgumentTypes = [memref<1x!sycl_id_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_2_, i32) -> memref<2xi64, 4>
+// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<2xi64, 4>
+// CHECK-NEXT:      %[[VAL_7:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:      %[[VAL_8:.*]] = gpu.global_id  y
+// CHECK-NEXT:      %[[VAL_9:.*]] = arith.index_cast %[[VAL_8]] : index to i64
+// CHECK-NEXT:      %[[VAL_10:.*]] = "sycl.id.get"(%[[VAL_2]], %[[VAL_7]]) {ArgumentTypes = [memref<1x!sycl_id_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_2_, i32) -> memref<2xi64, 4>
+// CHECK-NEXT:      memref.store %[[VAL_9]], %[[VAL_10]]{{\[}}%[[VAL_1]]] : memref<2xi64, 4>
+// CHECK-NEXT:      return %[[VAL_2]] : !sycl_id_2_
+// CHECK-NEXT:    }
+func.func @test_global_id() -> !sycl_id_2_ {
+  %0 = sycl.global_id() : () -> !sycl_id_2_
+  return %0 : !sycl_id_2_
+}
+
+// CHECK-LABEL:   func.func @test_global_id_dim(
+// CHECK-SAME:                                  %[[VAL_0:.*]]: i32) -> index {
+// CHECK-NEXT:      %[[VAL_1:.*]] = memref.alloca() : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_3:.*]] = gpu.global_id  x
+// CHECK-NEXT:      memref.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_5:.*]] = gpu.global_id  y
+// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[VAL_7:.*]] = gpu.global_id  z
+// CHECK-NEXT:      memref.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_0]] : i32 to index
+// CHECK-NEXT:      %[[VAL_9:.*]] = memref.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
+// CHECK-NEXT:      return %[[VAL_9]] : index
+// CHECK-NEXT:    }
+func.func @test_global_id_dim(%i: i32) -> index {
+  %0 = sycl.global_id(%i) : (i32) -> index
+  return %0 : index
+}
+
+// CHECK-LABEL:   func.func @test_local_id() -> !sycl_id_3_ {
+// CHECK-NEXT:      %[[VAL_0:.*]] = memref.alloca() : memref<1x!sycl_id_3_>
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_2:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_3_>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = gpu.thread_id  x
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : index to i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = "sycl.id.get"(%[[VAL_2]], %[[VAL_3]]) {ArgumentTypes = [memref<1x!sycl_id_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_3_, i32) -> memref<3xi64, 4>
+// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      %[[VAL_7:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:      %[[VAL_8:.*]] = gpu.thread_id  y
+// CHECK-NEXT:      %[[VAL_9:.*]] = arith.index_cast %[[VAL_8]] : index to i64
+// CHECK-NEXT:      %[[VAL_10:.*]] = "sycl.id.get"(%[[VAL_2]], %[[VAL_7]]) {ArgumentTypes = [memref<1x!sycl_id_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_3_, i32) -> memref<3xi64, 4>
+// CHECK-NEXT:      memref.store %[[VAL_9]], %[[VAL_10]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      %[[VAL_11:.*]] = arith.constant 2 : i32
+// CHECK-NEXT:      %[[VAL_12:.*]] = gpu.thread_id  z
+// CHECK-NEXT:      %[[VAL_13:.*]] = arith.index_cast %[[VAL_12]] : index to i64
+// CHECK-NEXT:      %[[VAL_14:.*]] = "sycl.id.get"(%[[VAL_2]], %[[VAL_11]]) {ArgumentTypes = [memref<1x!sycl_id_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_3_, i32) -> memref<3xi64, 4>
+// CHECK-NEXT:      memref.store %[[VAL_13]], %[[VAL_14]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      return %[[VAL_2]] : !sycl_id_3_
+// CHECK-NEXT:    }
+func.func @test_local_id() -> !sycl_id_3_ {
+  %0 = sycl.local_id() : () -> !sycl_id_3_
+  return %0 : !sycl_id_3_
+}
+
+// CHECK-LABEL:   func.func @test_local_id_dim(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: i32) -> index {
+// CHECK-NEXT:      %[[VAL_1:.*]] = memref.alloca() : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_3:.*]] = gpu.thread_id  x
+// CHECK-NEXT:      memref.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_5:.*]] = gpu.thread_id  y
+// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[VAL_7:.*]] = gpu.thread_id  z
+// CHECK-NEXT:      memref.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_0]] : i32 to index
+// CHECK-NEXT:      %[[VAL_9:.*]] = memref.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
+// CHECK-NEXT:      return %[[VAL_9]] : index
+// CHECK-NEXT:    }
+func.func @test_local_id_dim(%i: i32) -> index {
+  %0 = sycl.local_id(%i) : (i32) -> index
+  return %0 : index
+}
+
+// CHECK-LABEL:   func.func @test_work_group_size() -> !sycl_range_3_ {
+// CHECK-NEXT:      %[[VAL_0:.*]] = memref.alloca() : memref<1x!sycl_range_3_>
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_2:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_range_3_>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = gpu.block_dim  x
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : index to i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = "sycl.range.get"(%[[VAL_2]], %[[VAL_3]]) {ArgumentTypes = [memref<1x!sycl_range_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (!sycl_range_3_, i32) -> memref<3xi64, 4>
+// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      %[[VAL_7:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:      %[[VAL_8:.*]] = gpu.block_dim  y
+// CHECK-NEXT:      %[[VAL_9:.*]] = arith.index_cast %[[VAL_8]] : index to i64
+// CHECK-NEXT:      %[[VAL_10:.*]] = "sycl.range.get"(%[[VAL_2]], %[[VAL_7]]) {ArgumentTypes = [memref<1x!sycl_range_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (!sycl_range_3_, i32) -> memref<3xi64, 4>
+// CHECK-NEXT:      memref.store %[[VAL_9]], %[[VAL_10]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      %[[VAL_11:.*]] = arith.constant 2 : i32
+// CHECK-NEXT:      %[[VAL_12:.*]] = gpu.block_dim  z
+// CHECK-NEXT:      %[[VAL_13:.*]] = arith.index_cast %[[VAL_12]] : index to i64
+// CHECK-NEXT:      %[[VAL_14:.*]] = "sycl.range.get"(%[[VAL_2]], %[[VAL_11]]) {ArgumentTypes = [memref<1x!sycl_range_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (!sycl_range_3_, i32) -> memref<3xi64, 4>
+// CHECK-NEXT:      memref.store %[[VAL_13]], %[[VAL_14]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      return %[[VAL_2]] : !sycl_range_3_
+// CHECK-NEXT:    }
+func.func @test_work_group_size() -> !sycl_range_3_ {
+  %0 = sycl.work_group_size() : () -> !sycl_range_3_
+  return %0 : !sycl_range_3_
+}
+
+// CHECK-LABEL:   func.func @test_work_group_size_dim(
+// CHECK-SAME:                                        %[[VAL_0:.*]]: i32) -> index {
+// CHECK-NEXT:      %[[VAL_1:.*]] = memref.alloca() : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_3:.*]] = gpu.block_dim  x
+// CHECK-NEXT:      memref.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_5:.*]] = gpu.block_dim  y
+// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[VAL_7:.*]] = gpu.block_dim  z
+// CHECK-NEXT:      memref.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_0]] : i32 to index
+// CHECK-NEXT:      %[[VAL_9:.*]] = memref.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
+// CHECK-NEXT:      return %[[VAL_9]] : index
+// CHECK-NEXT:    }
+func.func @test_work_group_size_dim(%i: i32) -> index {
+  %0 = sycl.work_group_size(%i) : (i32) -> index
+  return %0 : index
+}
+
+// CHECK-LABEL:   func.func @test_work_group_id() -> !sycl_id_1_ {
+// CHECK-NEXT:      %[[VAL_0:.*]] = memref.alloca() : memref<1x!sycl_id_1_>
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_2:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_1_>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = gpu.block_id  x
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : index to i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = "sycl.id.get"(%[[VAL_2]], %[[VAL_3]]) {ArgumentTypes = [memref<1x!sycl_id_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_1_, i32) -> memref<1xi64, 4>
+// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<1xi64, 4>
+// CHECK-NEXT:      return %[[VAL_2]] : !sycl_id_1_
+// CHECK-NEXT:    }
+func.func @test_work_group_id() -> !sycl_id_1_ {
+  %0 = sycl.work_group_id() : () -> !sycl_id_1_
+  return %0 : !sycl_id_1_
+}
+
+// CHECK-LABEL:   func.func @test_work_group_id_dim(
+// CHECK-SAME:                                      %[[VAL_0:.*]]: i32) -> index {
+// CHECK-NEXT:      %[[VAL_1:.*]] = memref.alloca() : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_3:.*]] = gpu.block_id  x
+// CHECK-NEXT:      memref.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_5:.*]] = gpu.block_id  y
+// CHECK-NEXT:      memref.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[VAL_7:.*]] = gpu.block_id  z
+// CHECK-NEXT:      memref.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_0]] : i32 to index
+// CHECK-NEXT:      %[[VAL_9:.*]] = memref.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
+// CHECK-NEXT:      return %[[VAL_9]] : index
+// CHECK-NEXT:    }
+func.func @test_work_group_id_dim(%i: i32) -> index {
+  %0 = sycl.work_group_id(%i) : (i32) -> index
+  return %0 : index
+}
+
+// CHECK-LABEL:   func.func @test_num_work_items_const() -> index {
+// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[VAL_1:.*]] = gpu.grid_dim  x
+// CHECK-NEXT:      return %[[VAL_1]] : index
+// CHECK-NEXT:    }
+func.func @test_num_work_items_const() -> index {
+  %c0_i32 = arith.constant 0 : i32
+  %0 = sycl.num_work_items(%c0_i32) : (i32) -> index
+  return %0 : index
+}
+
+// CHECK-LABEL:   func.func @test_global_id_const() -> index {
+// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:      %[[VAL_1:.*]] = gpu.global_id  y
+// CHECK-NEXT:      return %[[VAL_1]] : index
+// CHECK-NEXT:    }
+func.func @test_global_id_const() -> index {
+  %c1_i32 = arith.constant 1 : i32
+  %0 = sycl.global_id(%c1_i32) : (i32) -> index
+  return %0 : index
+}
+
+// CHECK-LABEL:   func.func @test_local_id_const() -> index {
+// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 2 : i32
+// CHECK-NEXT:      %[[VAL_1:.*]] = gpu.thread_id  z
+// CHECK-NEXT:      return %[[VAL_1]] : index
+// CHECK-NEXT:    }
+func.func @test_local_id_const() -> index {
+  %c2_i32 = arith.constant 2 : i32
+  %0 = sycl.local_id(%c2_i32) : (i32) -> index
+  return %0 : index
+}
+
+// CHECK-LABEL:   func.func @test_work_group_size_const() -> index {
+// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 2 : i32
+// CHECK-NEXT:      %[[VAL_1:.*]] = gpu.block_dim  z
+// CHECK-NEXT:      return %[[VAL_1]] : index
+// CHECK-NEXT:    }
+func.func @test_work_group_size_const() -> index {
+  %c2_i32 = arith.constant 2 : i32
+  %0 = sycl.work_group_size(%c2_i32) : (i32) -> index
+  return %0 : index
+}
+
+// CHECK-LABEL:   func.func @test_work_group_id_const() -> index {
+// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[VAL_1:.*]] = gpu.block_id  x
+// CHECK-NEXT:      return %[[VAL_1]] : index
+// CHECK-NEXT:    }
+func.func @test_work_group_id_const() -> index {
+  %c0_i32 = arith.constant 0 : i32
+  %0 = sycl.work_group_id(%c0_i32) : (i32) -> index
+  return %0 : index
+}
+
+// CHECK-LABEL:   func.func @test_num_sub_groups() -> i32 {
+// CHECK-NEXT:      %[[VAL_0:.*]] = gpu.num_subgroups : index
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.index_cast %[[VAL_0]] : index to i32
+// CHECK-NEXT:      return %[[VAL_1]] : i32
+// CHECK-NEXT:    }
+func.func @test_num_sub_groups() -> i32 {
+  %0 = sycl.num_sub_groups : () -> i32
+  return %0 : i32
+}
+
+// CHECK-LABEL:   func.func @test_sub_group_size() -> i32 {
+// CHECK-NEXT:      %[[VAL_0:.*]] = gpu.subgroup_size : index
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.index_cast %[[VAL_0]] : index to i32
+// CHECK-NEXT:      return %[[VAL_1]] : i32
+// CHECK-NEXT:    }
+func.func @test_sub_group_size() -> i32 {
+  %0 = sycl.sub_group_size : () -> i32
+  return %0 : i32
+}
+
+// CHECK-LABEL:   func.func @test_sub_group_id() -> i32 {
+// CHECK-NEXT:      %[[VAL_0:.*]] = gpu.subgroup_id : index
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.index_cast %[[VAL_0]] : index to i32
+// CHECK-NEXT:      return %[[VAL_1]] : i32
+// CHECK-NEXT:    }
+func.func @test_sub_group_id() -> i32 {
+  %0 = sycl.sub_group_id : () -> i32
+  return %0 : i32
+}

--- a/mlir-sycl/tools/sycl-mlir-opt/CMakeLists.txt
+++ b/mlir-sycl/tools/sycl-mlir-opt/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LIBS
   MLIRMlirOptMain
   MLIRSYCLDialect
+  MLIRSYCLToGPU
   MLIRSYCLToLLVM
   MLIRSYCLTransforms
 )

--- a/mlir-sycl/tools/sycl-mlir-opt/sycl-mlir-opt.cpp
+++ b/mlir-sycl/tools/sycl-mlir-opt/sycl-mlir-opt.cpp
@@ -38,6 +38,7 @@ int main(int argc, char **argv) {
   registerAllPasses();
   sycl::registerSYCLPasses();
   sycl::registerConvertSYCLToLLVMPass();
+  sycl::registerConvertSYCLToGPUPass();
 
   return mlir::asMainReturnCode(
       mlir::MlirOptMain(argc, argv, "SYCL MLIR optimizer driver\n", registry,


### PR DESCRIPTION
Create pass converting operations from the SYCL dialect to the GPU
dialect.

The operations supporting this conversion are:

- `sycl.work_group_id`
- `sycl.num_work_items`
- `sycl.work_group_size`
- `sycl.local_id`
- `sycl.global_id`
- `sycl.sub_group_id`
- `sycl.num_sub_groups`
- `sycl.sub_group_size`

Signed-off-by: Victor Perez <victor.perez@codeplay.com>