### PR TITLE
[SYCL][DOC] Add device_arch experimental language

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_architecture.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_architecture.asciidoc
@@ -43,22 +43,18 @@ SYCL specification refer to that revision.
 
 == Status
 
-This is a proposed extension specification, intended to gather community
-feedback.  Interfaces defined in this specification may not be implemented yet
-or may be in a preliminary state.  The specification itself may also change in
-incompatible ways before it is finalized.  *Shipping software products should
-not rely on APIs defined in this specification.*
+This is an experimental extension specification, intended to provide early
+access to features and gather community feedback.  Interfaces defined in this
+specification are implemented in {dpcpp}, but they are not finalized and may
+change incompatibly in future versions of {dpcpp} without prior notice.
+*Shipping software products should not rely on APIs defined in this
+specification.*
 
-[comment]
---
-_Add the following paragraph when this specification becomes "experimental"._
-
-There are important limitations with the DPC++ implementation of this
+There are important limitations with the {dpcpp} implementation of this
 experimental extension.  In particular, this extension may only be used when
 the application is compiled in AOT mode.  See the section below titled
 "Limitations with the experimental version" for a full description of the
 limitations.
---
 
 
 == Overview
@@ -532,6 +528,16 @@ pack.  This condition is `true` only if the object _F_ comes from a previous
 call to `if_architecture_is` or `else_if_architecture_is` whose condition is
 `false` *and* if the device calling `else_if_architecture_is` has one of the
 architectures in the `Archs` parameter pack.
+
+
+== Limitations with the experimental version
+
+The {dpcpp} implementation of this extension currently has some important
+limitations.  The application must be compiled in ahead-of-time (AOT) mode
+using `-fsycl-targets=<special-target>` where `<special-target>` is one of the
+"special target values" listed in the link:../../UsersManual.md[users manual]
+description of the `-fsycl-targets` option.  These are the target names of the
+form "intel_gpu_*", "nvidia_gpu_*", or "amd_gpu_*".
 
 
 == Future direction


### PR DESCRIPTION
The sycl_ext_oneapi_device_architecture extension got moved from "proposed" to "experimental", but we forgot to change the Status section to reflect this.  Do that now, and also list the limitations with our current implementation.