### PR TITLE
[SYCL] Fix and re-enable some kernel-and-program/Cache.cpp unit tests.

### DIFF
--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -60,7 +60,7 @@ template <> struct KernelInfo<CacheTestKernel2> : public MockKernelInfo {
 };
 template <> const char *get_spec_constant_symbolic_ID<SpecConst1>() {
   return "SC1";
-};
+}
 } // namespace detail
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -178,8 +178,8 @@ TEST_F(KernelAndProgramCacheTest,
 
 // Check that kernel_bundles with input_state are not cached.
 TEST_F(KernelAndProgramCacheTest, KernelBundleInputState) {
-  std::vector<sycl::device> Devices = Plt.get_devices(info::device_type::gpu);
-  sycl::context Ctx(Devices);
+  std::vector<sycl::device> Devices = Plt.get_devices();
+  sycl::context Ctx(Devices[0]);
 
   auto KernelID1 = sycl::get_kernel_id<CacheTestKernel>();
   sycl::kernel_bundle KernelBundle1 =

--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -195,8 +195,8 @@ TEST_F(KernelAndProgramCacheTest, KernelBundleInputState) {
 
 // Check that kernel_bundles with object_state are not cached.
 TEST_F(KernelAndProgramCacheTest, KernelBundleObjectState) {
-  std::vector<sycl::device> Devices = Plt.get_devices(info::device_type::gpu);
-  sycl::context Ctx(Devices);
+  std::vector<sycl::device> Devices = Plt.get_devices();
+  sycl::context Ctx(Devices[0]);
 
   auto KernelID1 = sycl::get_kernel_id<CacheTestKernel>();
   sycl::kernel_bundle KernelBundle1 =
@@ -212,8 +212,8 @@ TEST_F(KernelAndProgramCacheTest, KernelBundleObjectState) {
 
 // Check that kernel_bundles with executable_state are cached.
 TEST_F(KernelAndProgramCacheTest, KernelBundleExecutableState) {
-  std::vector<sycl::device> Devices = Plt.get_devices(info::device_type::gpu);
-  sycl::context Ctx(Devices);
+  std::vector<sycl::device> Devices = Plt.get_devices();
+  sycl::context Ctx(Devices[0]);
 
   auto KernelID1 = sycl::get_kernel_id<CacheTestKernel>();
   auto KernelID2 = sycl::get_kernel_id<CacheTestKernel2>();
@@ -232,8 +232,8 @@ TEST_F(KernelAndProgramCacheTest, KernelBundleExecutableState) {
 
 // Check that kernel_bundle built with specialization constants are cached.
 TEST_F(KernelAndProgramCacheTest, SpecConstantCacheNegative) {
-  std::vector<sycl::device> Devices = Plt.get_devices(info::device_type::gpu);
-  sycl::context Ctx(Devices);
+  std::vector<sycl::device> Devices = Plt.get_devices();
+  sycl::context Ctx(Devices[0]);
 
   auto KernelID1 = sycl::get_kernel_id<CacheTestKernel>();
   auto KernelID2 = sycl::get_kernel_id<CacheTestKernel2>();
@@ -261,8 +261,8 @@ TEST_F(KernelAndProgramCacheTest, SpecConstantCacheNegative) {
 
 // Check that kernel_bundle created through join() is not cached.
 TEST_F(KernelAndProgramCacheTest, KernelBundleJoin) {
-  std::vector<sycl::device> Devices = Plt.get_devices(info::device_type::gpu);
-  sycl::context Ctx(Devices);
+  std::vector<sycl::device> Devices = Plt.get_devices();
+  sycl::context Ctx(Devices[0]);
 
   auto KernelID1 = sycl::get_kernel_id<CacheTestKernel>();
   auto KernelID2 = sycl::get_kernel_id<CacheTestKernel2>();


### PR DESCRIPTION
These unit tests were disabled when the sycl::program class was removed in [#6666](https://github.com/intel/llvm/pull/6666.)
I have modified some of these unit tests to use kernel_bundles instead of sycl::program.

I was not able to modify and re-enable all the unit tests in Cache.cpp file because some of the older test cases were using APIs like sycl::program.build_with_source (or compile_with_source) and, as far as I am aware of it, there is no kernel_bundle API(s) equivalent  to sycl::program.build_with_source.