### PR TITLE
[SYCL][Reduction] Fix reduction kernel conflict

### DIFF
--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -531,7 +531,7 @@ namespace reduction {
 // Kernel name wrapper for initializing reduction-related memory through
 // reduction_impl_algo::withInitializedMem.
 template <typename KernelName> struct InitMemKrn;
-}
+} // namespace reduction
 
 /// A helper to pass undefined (sycl::detail::auto_name) names unmodified. We
 /// must do that to avoid name collisions.

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -531,6 +531,13 @@ struct get_red_t<
 // reduction_impl_algo::withInitializedMem.
 template <typename KernelName> struct __sycl_init_mem_for;
 
+/// A helper to pass undefined (sycl::detail::auto_name) names unmodified. We
+/// must do that to avoid name collisions.
+template <class KernelName>
+using __sycl_init_mem_for_wrapper =
+    std::conditional_t<std::is_same<KernelName, auto_name>::value, auto_name,
+                       __sycl_init_mem_for<KernelName>>;
+
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
           typename RedOutVar>
 class reduction_impl_algo : public reduction_impl_common<T, BinaryOperation> {
@@ -646,7 +653,7 @@ public:
           // between host/device in lambda captures.
           size_t NElements = num_elements;
 
-          CopyHandler.single_task<__sycl_init_mem_for<KernelName>>([=] {
+          CopyHandler.single_task<__sycl_init_mem_for_wrapper<KernelName>>([=] {
             for (int i = 0; i < NElements; ++i) {
               if (IsUpdateOfUserVar)
                 Out[i] = BOp(Out[i], Mem[i]);

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -527,16 +527,18 @@ struct get_red_t<
   using type = T;
 };
 
+namespace reduction {
 // Kernel name wrapper for initializing reduction-related memory through
 // reduction_impl_algo::withInitializedMem.
-template <typename KernelName> struct __sycl_init_mem_for;
+template <typename KernelName> struct InitMemKrn;
+}
 
 /// A helper to pass undefined (sycl::detail::auto_name) names unmodified. We
 /// must do that to avoid name collisions.
 template <class KernelName>
-using __sycl_init_mem_for_wrapper =
+using __sycl_init_mem_for =
     std::conditional_t<std::is_same<KernelName, auto_name>::value, auto_name,
-                       __sycl_init_mem_for<KernelName>>;
+                       reduction::InitMemKrn<KernelName>>;
 
 template <typename T, class BinaryOperation, int Dims, size_t Extent,
           typename RedOutVar>
@@ -653,7 +655,7 @@ public:
           // between host/device in lambda captures.
           size_t NElements = num_elements;
 
-          CopyHandler.single_task<__sycl_init_mem_for_wrapper<KernelName>>([=] {
+          CopyHandler.single_task<__sycl_init_mem_for<KernelName>>([=] {
             for (int i = 0; i < NElements; ++i) {
               if (IsUpdateOfUserVar)
                 Out[i] = BOp(Out[i], Mem[i]);

--- a/sycl/test/regression/reduction_kernel_conflict.cpp
+++ b/sycl/test/regression/reduction_kernel_conflict.cpp
@@ -1,0 +1,18 @@
+// RUN: %clangxx -fsycl -fsyntax-only -sycl-std=2020 %s
+
+// Regression test to make sure a certain configuration of reductions do not
+// cause conflicting kernels to be generated.
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  sycl::queue Q;
+  double *SumVar = sycl::malloc_shared<double>(1, Q);
+  Q.submit([&](sycl::handler &CGH) {
+     auto SumReduction = sycl::reduction(SumVar, sycl::plus<>());
+     CGH.parallel_for<class kernel>(
+         sycl::nd_range<1>{10, 10}, SumReduction,
+         [=](sycl::nd_item<1>, auto &Sum) { Sum += 1; });
+   }).wait();
+  return 0;
+}


### PR DESCRIPTION
Certain reductions generate kernels for multiple strategies and select the suitable one at runtime. This currently fails in select scenarios because the initialization kernel created by `reduction_impl_algo::withInitializedMem` uses the name of the kernel directly instead of generating a unique name. This commit fixes this by adding a wrapper class for these kernels.