### PR TITLE
[SYCL][NFC] Update uses of OpenCL aliases in LIT tests

### DIFF
--- a/sycl/test/basic_tests/types.cpp
+++ b/sycl/test/basic_tests/types.cpp
@@ -99,19 +99,20 @@ int main() {
   // Table 4.93: Additional scalar data types supported by SYCL.
   static_assert(sizeof(s::byte) == sizeof(int8_t), "");
 
-  // Table 4.94: Scalar data type aliases supported by SYCL
-  static_assert(is_same<s::cl_bool, decltype(0 != 1)>::value, "");
-  checkSizeForSignedIntegral<s::cl_char, sizeof(int8_t)>();
-  checkSizeForUnsignedIntegral<s::cl_uchar, sizeof(uint8_t)>();
-  checkSizeForSignedIntegral<s::cl_short, sizeof(int16_t)>();
-  checkSizeForUnsignedIntegral<s::cl_ushort, sizeof(uint16_t)>();
-  checkSizeForSignedIntegral<s::cl_int, sizeof(int32_t)>();
-  checkSizeForUnsignedIntegral<s::cl_uint, sizeof(uint32_t)>();
-  checkSizeForSignedIntegral<s::cl_long, sizeof(int64_t)>();
-  checkSizeForUnsignedIntegral<s::cl_ulong, sizeof(uint64_t)>();
-  checkSizeForFloatingPoint<s::cl_half, sizeof(int16_t)>();
-  checkSizeForFloatingPoint<s::cl_float, sizeof(int32_t)>();
-  checkSizeForFloatingPoint<s::cl_double, sizeof(int64_t)>();
+  // SYCL 2020: Table 193. Scalar data type aliases supported by SYCL OpenCL
+  // backend
+  static_assert(is_same<s::opencl::cl_bool, decltype(0 != 1)>::value, "");
+  checkSizeForSignedIntegral<s::opencl::cl_char, sizeof(int8_t)>();
+  checkSizeForUnsignedIntegral<s::opencl::cl_uchar, sizeof(uint8_t)>();
+  checkSizeForSignedIntegral<s::opencl::cl_short, sizeof(int16_t)>();
+  checkSizeForUnsignedIntegral<s::opencl::cl_ushort, sizeof(uint16_t)>();
+  checkSizeForSignedIntegral<s::opencl::cl_int, sizeof(int32_t)>();
+  checkSizeForUnsignedIntegral<s::opencl::cl_uint, sizeof(uint32_t)>();
+  checkSizeForSignedIntegral<s::opencl::cl_long, sizeof(int64_t)>();
+  checkSizeForUnsignedIntegral<s::opencl::cl_ulong, sizeof(uint64_t)>();
+  checkSizeForFloatingPoint<s::opencl::cl_half, sizeof(int16_t)>();
+  checkSizeForFloatingPoint<s::opencl::cl_float, sizeof(int32_t)>();
+  checkSizeForFloatingPoint<s::opencl::cl_double, sizeof(int64_t)>();
 
   return 0;
 }

--- a/sycl/test/basic_tests/valid_kernel_args.cpp
+++ b/sycl/test/basic_tests/valid_kernel_args.cpp
@@ -27,15 +27,18 @@ struct SomeMarrayStructure {
   sycl::marray<double, 5> points;
 };
 
-#define CHECK_PASSING_TO_KERNEL_BY_VALUE(Type)                                 \
-  static_assert(std::is_standard_layout<Type>::value,                          \
-                "Is not standard layouti type.");                              \
-  static_assert(std::is_trivially_copyable<Type>::value,                       \
+template <typename T> void check() {
+  static_assert(std::is_standard_layout<T>::value,
+                "Is not standard layouti type.");
+  static_assert(std::is_trivially_copyable<T>::value,
                 "Is not trivially copyable type.");
+}
 
+SYCL_EXTERNAL void foo() {
 #ifdef __SYCL_DEVICE_ONLY__
-CHECK_PASSING_TO_KERNEL_BY_VALUE(int)
-CHECK_PASSING_TO_KERNEL_BY_VALUE(sycl::cl_uchar4)
-CHECK_PASSING_TO_KERNEL_BY_VALUE(SomeStructure)
+  check<int>();
+  check<sycl::vec<sycl::opencl::cl_uchar, 4>>();
+  check<SomeStructure>();
 #endif
-CHECK_PASSING_TO_KERNEL_BY_VALUE(SomeMarrayStructure)
+  check<SomeMarrayStructure>();
+}

--- a/sycl/test/extensions/inline_asm.cpp
+++ b/sycl/test/extensions/inline_asm.cpp
@@ -9,7 +9,7 @@
 
 constexpr const size_t DEFAULT_PROBLEM_SIZE = 16;
 
-using DataType = sycl::cl_int;
+using DataType = sycl::opencl::cl_int;
 
 int main() {
   DataType DataA[DEFAULT_PROBLEM_SIZE], DataB[DEFAULT_PROBLEM_SIZE],

--- a/sycl/test/regression/async_work_group_copy.cpp
+++ b/sycl/test/regression/async_work_group_copy.cpp
@@ -56,7 +56,8 @@ int main() {
   test<int16_t>();
   test<int32_t>();
   test<int64_t>();
-  test<sycl::cl_half>();
+  test<sycl::opencl::cl_half>();
+  test<sycl::half>();
   test<float>();
   test<double>();
   return 1;

--- a/sycl/test/regression/memcpy-in-vec-as.cpp
+++ b/sycl/test/regression/memcpy-in-vec-as.cpp
@@ -3,10 +3,10 @@
 #include <sycl/sycl.hpp>
 
 int main() {
-  using res_vec_type = sycl::vec<sycl::cl_ushort, 4>;
+  using res_vec_type = sycl::vec<unsigned short, 4>;
   res_vec_type res;
 
-  sycl::vec<sycl::cl_uchar, 8> RefData(1, 2, 3, 4, 5, 6, 7, 8);
+  sycl::vec<unsigned char, 8> RefData(1, 2, 3, 4, 5, 6, 7, 8);
   {
     sycl::buffer<res_vec_type, 1> OutBuf(&res, sycl::range<1>(1));
     sycl::buffer<decltype(RefData), 1> InBuf(&RefData, sycl::range<1>(1));


### PR DESCRIPTION
`cl_*` aliases for OpenCL interoperability are defined differently in SYCL 1.2.1 and SYCL 2020.

This patch aligns our tests with SYCL 2020 by doing following changes:
- switched to use standard C++ types in some tests
- added `opencl::` namespace when `cl_*` aliases are used in some tests
- replaced `cl_*` vector aliases with `vec<opencl::cl_*>` in some tests