### PR TITLE
[SYCL][Reduction] Fix return type of identityless reduction

### DIFF
--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -2328,9 +2328,7 @@ template <
     typename = std::enable_if_t<!has_known_identity<BinaryOperation, T>::value>>
 detail::reduction_impl<
     T, BinaryOperation, 0, 1,
-    accessor<T, 1, access::mode::read_write, access::target::device,
-             access::placeholder::true_t,
-             ext::oneapi::accessor_property_list<>>>
+    accessor<T, 1, access::mode::read_write, access::target::device>>
 reduction(buffer<T, 1, AllocatorT>, handler &, BinaryOperation,
           const property_list &PropList = {}) {
   // TODO: implement reduction that works even when identity is not known.

--- a/sycl/test/regression/identityless_reduction.cpp
+++ b/sycl/test/regression/identityless_reduction.cpp
@@ -1,0 +1,20 @@
+// RUN: %clangxx -fsycl -fsyntax-only -sycl-std=2020 %s
+
+// Regression test for ensuring that identityless reductions with accessors
+// compile without error.
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  auto IdentitylessPlus = [](int a, int b) { return a + b; };
+
+  sycl::queue Q;
+  sycl::buffer<int, 1> ReduBuff{1};
+  Q.submit([&](sycl::handler &CGH) {
+     auto Reduction = sycl::reduction(ReduBuff, CGH, IdentitylessPlus);
+     CGH.parallel_for(sycl::range<1>(10), Reduction,
+                      [=](sycl::id<1>, auto &Redu) { Redu.combine(1); });
+   }).wait();
+
+  return 0;
+}


### PR DESCRIPTION
Identityless reduction uses an unexpected value for the deprecated placeholder template parameter in accessor, so using it causes a failure during compilation. This commit fixes the compilation failures.