### PR TITLE
[SYCL-MLIR] Cache builtin types

### DIFF
--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1596,9 +1596,7 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
         Iter != BuiltinTypeCache.end())
       return Iter->second;
 
-    mlir::Type Ty = getMLIRType(cast<clang::BuiltinType>(T));
-    BuiltinTypeCache[T] = Ty;
-    return Ty;
+    return BuiltinTypeCache[T] = getMLIRType(cast<clang::BuiltinType>(T));
   }
 
   LLVM_DEBUG(llvm::dbgs() << "QT: "; QT->dump(); llvm::dbgs() << "\n");

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1591,8 +1591,14 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
     return Builder.getIntegerType(cast<llvm::IntegerType>(Ty)->getBitWidth());
   }
 
-  if (T->isBuiltinType())
-    return getMLIRType(cast<clang::BuiltinType>(T));
+  if (T->isBuiltinType()) {
+    if (BuiltinTypeCache.find(T) != BuiltinTypeCache.end())
+      return BuiltinTypeCache[T];
+
+    mlir::Type Ty = getMLIRType(cast<clang::BuiltinType>(T));
+    BuiltinTypeCache[T] = Ty;
+    return Ty;
+  }
 
   LLVM_DEBUG(llvm::dbgs() << "QT: "; QT->dump(); llvm::dbgs() << "\n");
   llvm_unreachable("unhandled type");

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1592,8 +1592,9 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
   }
 
   if (T->isBuiltinType()) {
-    if (BuiltinTypeCache.find(T) != BuiltinTypeCache.end())
-      return BuiltinTypeCache[T];
+    if (const auto Iter = BuiltinTypeCache.find(T);
+        Iter != BuiltinTypeCache.end())
+      return Iter->second;
 
     mlir::Type Ty = getMLIRType(cast<clang::BuiltinType>(T));
     BuiltinTypeCache[T] = Ty;

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.h
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.h
@@ -60,6 +60,7 @@ class CodeGenTypes {
   clang::CodeGen::CGCXXABI &TheCXXABI;
 
   std::map<const clang::RecordType *, mlir::LLVM::LLVMStructType> TypeCache;
+  std::map<const clang::Type *, mlir::Type> BuiltinTypeCache;
 
 public:
   CodeGenTypes(clang::CodeGen::CodeGenModule &CGM,

--- a/polygeist/tools/cgeist/Test/Verification/sycl/builtin_cache.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/builtin_cache.cpp
@@ -1,0 +1,17 @@
+// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir -o - %s | FileCheck %s
+
+#include <sycl/sycl.hpp>
+using namespace sycl;
+
+// CHECK-LABEL: func.func @_Z6callee38__spirv_SampledImage__image1d_array_ro(%arg0: !llvm.ptr<struct<"spirv.SampledImage.image1d_array_ro_t.0", opaque>, 1>)
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+// CHECK-LABEL: func.func @_Z6caller38__spirv_SampledImage__image1d_array_ro(%arg0: !llvm.ptr<struct<"spirv.SampledImage.image1d_array_ro_t.0", opaque>, 1>)
+// CHECK-NEXT:    call @_Z6callee38__spirv_SampledImage__image1d_array_ro(%arg0) : (!llvm.ptr<struct<"spirv.SampledImage.image1d_array_ro_t.0", opaque>, 1>) -> ()
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+
+SYCL_EXTERNAL void callee(__ocl_sampled_image1d_array_ro_t var) {}
+SYCL_EXTERNAL void caller(__ocl_sampled_image1d_array_ro_t var) {
+  callee(var);
+}


### PR DESCRIPTION
This PR ensures that the same MLIR type is generated for a given AST type.
Before this PR, the added test case would fail with the error below:
```
cgeist: /iusers/waihungt/llvm/polygeist/tools/cgeist/Lib/CGCall.cc:89: void castCallerArgs(func::FuncOp, llvm::SmallVectorImpl<Value> &, mlir::OpBuilder &): Assertion `CalleeArgType == Args[I].getType() && "Callsite argument mismatch"' failed.
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
```
because the callee function type is `(!llvm.ptr<struct<"spirv.SampledImage.image1d_array_ro_t.0", opaque>, 1>) -> ()`, but the call site argument has type `!llvm.ptr<struct<"spirv.SampledImage.image1d_array_ro_t.2", opaque>, 1>`.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>