### PR TITLE
[SYCL][NFC] Use -fsyntax-only more extensively in LIT tests

### DIFF
--- a/sycl/test/basic_tests/accessor/accessor_property_list_ct.cpp
+++ b/sycl/test/basic_tests/accessor/accessor_property_list_ct.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/basic_tests/accessor/addrspace_exposure.cpp
+++ b/sycl/test/basic_tests/accessor/addrspace_exposure.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 //==------- addrspace_exposure.cpp - SYCL accessor AS exposure test --------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/basic_tests/accessor/atomic_zero_dimension_accessor.cpp
+++ b/sycl/test/basic_tests/accessor/atomic_zero_dimension_accessor.cpp
@@ -1,5 +1,5 @@
-// RUN: %clangxx -fsycl -fsyntax-only %s -o %t.out
-// RUN: %clangxx -fsycl -fsyntax-only -fsycl-targets=spir64_fpga %s -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
+// RUN: %clangxx -fsycl -fsyntax-only -fsycl-targets=spir64_fpga %s
 
 // When using zero dimension accessors with atomic access we
 // want to make sure they are compiling correctly on all devices,

--- a/sycl/test/basic_tests/atomic-ref-instantiation.cpp
+++ b/sycl/test/basic_tests/atomic-ref-instantiation.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s -o %t.out -Xclang -verify-ignore-unexpected=note
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s -Xclang -verify-ignore-unexpected=note
 // expected-no-diagnostics
 #include <sycl/atomic_ref.hpp>
 

--- a/sycl/test/basic_tests/cl_sycl_hpp.cpp
+++ b/sycl/test/basic_tests/cl_sycl_hpp.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -c -o %t.o
+// RUN: %clangxx -fsycl -fsyntax-only %s
 
 #include <CL/sycl.hpp>
 

--- a/sycl/test/basic_tests/define_vendors.cpp
+++ b/sycl/test/basic_tests/define_vendors.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -c -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 #include <sycl/sycl.hpp>
 
 #if !defined(SYCL_IMPLEMENTATION_ONEAPI)

--- a/sycl/test/basic_tests/generic_type_traits.cpp
+++ b/sycl/test/basic_tests/generic_type_traits.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 
 #include <cassert>
 #include <iostream>

--- a/sycl/test/basic_tests/interop-cuda.cpp
+++ b/sycl/test/basic_tests/interop-cuda.cpp
@@ -1,10 +1,10 @@
 // REQUIRES: cuda
-// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
-// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note -D__SYCL_INTERNAL_API %s -o %t.out
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note -D__SYCL_INTERNAL_API %s
 //
 /// Also test the experimental CUDA interop interface
-// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note -DSYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL %s -o %t.out
-// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note -D__SYCL_INTERNAL_API -DSYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL %s -o %t.out
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note -DSYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL %s
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note -D__SYCL_INTERNAL_API -DSYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL %s
 // expected-no-diagnostics
 
 // Test for legacy and experimental CUDA interop API

--- a/sycl/test/basic_tests/interop-hip.cpp
+++ b/sycl/test/basic_tests/interop-hip.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: hip_be
-// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
-// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note -D__SYCL_INTERNAL_API %s -o %t.out
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note -D__SYCL_INTERNAL_API %s
 // expected-no-diagnostics
 
 // Test for HIP interop API

--- a/sycl/test/basic_tests/interop-level-zero-2020.cpp
+++ b/sycl/test/basic_tests/interop-level-zero-2020.cpp
@@ -1,5 +1,5 @@
-// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
-// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note -D__SYCL_INTERNAL_API %s -o %t.out
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note -D__SYCL_INTERNAL_API %s
 
 // Test for SYCL-2020 Level Zero interop API
 

--- a/sycl/test/basic_tests/kernel_size_mismatch.cpp
+++ b/sycl/test/basic_tests/kernel_size_mismatch.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning -o - %s
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning %s
 
 // Tests for static assertion failure when kernel lambda mismatches between host
 // and device.

--- a/sycl/test/basic_tests/parallel_for_user_types.cpp
+++ b/sycl/test/basic_tests/parallel_for_user_types.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl %s -c -o %t.o
+// RUN: %clangxx -fsycl -fsyntax-only %s
 
 // This test performs basic check of supporting user defined class that are
 // implicitly converted from sycl::item/sycl::nd_item in parallel_for.

--- a/sycl/test/basic_tests/queue/queue_offset_shortcut_initlist.cpp
+++ b/sycl/test/basic_tests/queue/queue_offset_shortcut_initlist.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsyntax-only %s -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 //=---queue_offset_shortcut_initlist.cpp - SYCL queue offset shortcuts test--=//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/basic_tests/queue/queue_parallel_for_interface.cpp
+++ b/sycl/test/basic_tests/queue/queue_parallel_for_interface.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsyntax-only %s -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 
 //==- queue_parallel_for_generic.cpp - SYCL queue parallel_for interface test -=//
 //

--- a/sycl/test/basic_tests/single_task_error_message.cpp
+++ b/sycl/test/basic_tests/single_task_error_message.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note -o - %s
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
 #include <iostream>
 #include <sycl/sycl.hpp>
 int main() {

--- a/sycl/test/basic_tests/stdcpp_compat.cpp
+++ b/sycl/test/basic_tests/stdcpp_compat.cpp
@@ -1,8 +1,8 @@
-// RUN: %clangxx -std=c++14 -fsycl -Wall -pedantic -Wno-c99-extensions -Wno-deprecated -fsyntax-only -Xclang -verify-ignore-unexpected=error,note,warning -Xclang -verify=expected,cxx14 %s -c -o %t.out
-// RUN: %clangxx -std=c++14 -fsycl -Wall -pedantic -Wno-c99-extensions -Wno-deprecated -fsyntax-only -Xclang -verify-ignore-unexpected=error,note,warning -Xclang -verify=cxx14,warning_extension,expected  %s -c -o %t.out
-// RUN: %clangxx -std=c++17 -fsycl -Wall -pedantic -Wno-c99-extensions -Wno-deprecated -fsyntax-only -Xclang -verify %s -c -o %t.out
-// RUN: %clangxx -std=c++20 -fsycl -Wall -pedantic -Wno-c99-extensions -Wno-deprecated -fsyntax-only -Xclang -verify %s -c -o %t.out
-// RUN: %clangxx            -fsycl -Wall -pedantic -Wno-c99-extensions -Wno-deprecated -fsyntax-only -Xclang -verify %s -c -o %t.out
+// RUN: %clangxx -std=c++14 -fsycl -Wall -pedantic -Wno-c99-extensions -Wno-deprecated -fsyntax-only -Xclang -verify-ignore-unexpected=error,note,warning -Xclang -verify=expected,cxx14 %s
+// RUN: %clangxx -std=c++14 -fsycl -Wall -pedantic -Wno-c99-extensions -Wno-deprecated -fsyntax-only -Xclang -verify-ignore-unexpected=error,note,warning -Xclang -verify=cxx14,warning_extension,expected  %s
+// RUN: %clangxx -std=c++17 -fsycl -Wall -pedantic -Wno-c99-extensions -Wno-deprecated -fsyntax-only -Xclang -verify %s
+// RUN: %clangxx -std=c++20 -fsycl -Wall -pedantic -Wno-c99-extensions -Wno-deprecated -fsyntax-only -Xclang -verify %s
+// RUN: %clangxx            -fsycl -Wall -pedantic -Wno-c99-extensions -Wno-deprecated -fsyntax-only -Xclang -verify %s
 
 // The test checks SYCL headers C++ compiance and that a warning is emitted
 // when compiling in < C++17 mode.

--- a/sycl/test/basic_tests/stream/byte.cpp
+++ b/sycl/test/basic_tests/stream/byte.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning %s -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning %s
 // expected-error@sycl/stream.hpp:* {{Convert the byte to a numeric value using std::to_integer}}
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/basic_tests/version.cpp
+++ b/sycl/test/basic_tests/version.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/extensions/fpga.cpp
+++ b/sycl/test/extensions/fpga.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 
 #include <sycl/ext/intel/fpga_extensions.hpp>
 #include <sycl/sycl.hpp>

--- a/sycl/test/extensions/inline_asm.cpp
+++ b/sycl/test/extensions/inline_asm.cpp
@@ -1,6 +1,6 @@
 // This is a basic acceptance test for inline ASM feature. More tests can be
 // found in https://github.com/intel/llvm-test-suite/tree/intel/SYCL/InlineAsm
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 
 #include <cmath>
 #include <iostream>

--- a/sycl/test/extensions/macro.cpp
+++ b/sycl/test/extensions/macro.cpp
@@ -1,27 +1,30 @@
 // This test checks presence of macros for available extensions.
-// RUN: %clangxx -fsycl %s -o %t.out
-// RUN: %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 
-#include <iostream>
 #include <sycl/sycl.hpp>
-int main() {
+
 #if SYCL_BACKEND_OPENCL == 1
-  std::cout << "SYCL_BACKEND_OPENCL=1" << std::endl;
+constexpr bool backend_opencl_macro_defined = true;
 #else
-  std::cerr << "SYCL_BACKEND_OPENCL!=1" << std::endl;
-  exit(1);
+constexpr bool backend_opencl_macro_defined = false;
 #endif
+
 #if SYCL_EXT_ONEAPI_SUB_GROUP_MASK == 1
-  std::cout << "SYCL_EXT_ONEAPI_SUB_GROUP_MASK=1" << std::endl;
+constexpr bool sub_group_mask_macro_defined = true;
 #else
-  std::cerr << "SYCL_EXT_ONEAPI_SUB_GROUP_MASK!=1" << std::endl;
-  exit(1);
+constexpr bool sub_group_mask_macro_defined = false;
 #endif
+
 #if SYCL_EXT_ONEAPI_BACKEND_LEVEL_ZERO == 3
-  std::cout << "SYCL_EXT_ONEAPI_BACKEND_LEVEL_ZERO=3" << std::endl;
+constexpr bool backend_level_zero_macro_defined = true;
 #else
-  std::cerr << "SYCL_EXT_ONEAPI_BACKEND_LEVEL_ZERO!=3" << std::endl;
-  exit(1);
+constexpr bool backend_level_zero_macro_defined = false;
 #endif
-  exit(0);
+
+int main() {
+  static_assert(backend_opencl_macro_defined);
+  static_assert(sub_group_mask_macro_defined);
+  static_assert(backend_level_zero_macro_defined);
+
+  return 0;
 }

--- a/sycl/test/extensions/macro_cuda.cpp
+++ b/sycl/test/extensions/macro_cuda.cpp
@@ -2,13 +2,14 @@
 // RUN: %clangxx -fsycl -fsyntax-only %s
 // REQUIRES: cuda_be
 
+#include <sycl/sycl.hpp>
+
 #if SYCL_EXT_ONEAPI_BACKEND_CUDA == 1
 constexpr bool macro_defined = true;
 #else
 constexpr bool macro_defined = false;
 #endif
 
-#include <sycl/sycl.hpp>
 int main() {
   static_assert(macro_defined);
 

--- a/sycl/test/extensions/macro_cuda.cpp
+++ b/sycl/test/extensions/macro_cuda.cpp
@@ -1,15 +1,16 @@
 // This test checks presence of macros for available extensions.
-// RUN: %clangxx -fsycl %s -o %t.out
-// RUN: %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 // REQUIRES: cuda_be
-#include <iostream>
+
+#if SYCL_EXT_ONEAPI_BACKEND_CUDA == 1
+constexpr bool macro_defined = true;
+#else
+constexpr bool macro_defined = false;
+#endif
+
 #include <sycl/sycl.hpp>
 int main() {
-#if SYCL_EXT_ONEAPI_BACKEND_CUDA == 1
-  std::cout << "SYCL_EXT_ONEAPI_BACKEND_CUDA=1" << std::endl;
-#else
-  std::cerr << "SYCL_EXT_ONEAPI_BACKEND_CUDA!=1" << std::endl;
-  exit(1);
-#endif
-  exit(0);
+  static_assert(macro_defined);
+
+  return 0;
 }

--- a/sycl/test/extensions/macro_esimd_emulator.cpp
+++ b/sycl/test/extensions/macro_esimd_emulator.cpp
@@ -1,15 +1,17 @@
 // This test checks presence of macros for available extensions.
-// RUN: %clangxx -fsycl %s -o %t.out
-// RUN: %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 // REQUIRES: esimd_emulator_be
-#include <iostream>
+
 #include <sycl/sycl.hpp>
-int main() {
+
 #if SYCL_EXT_INTEL_BACKEND_ESIMD_EMULATOR == 1
-  std::cout << "SYCL_EXT_INTEL_BACKEND_ESIMD_EMULATOR=1" << std::endl;
+constexpr bool macro_deifned = true;
 #else
-  std::cerr << "SYCL_EXT_INTEL_BACKEND_ESIMD_EMULATOR!=1" << std::endl;
-  exit(1);
+constexpr bool macro_deifned = false;
 #endif
-  exit(0);
+
+int main() {
+  static_assert(macro_defined);
+
+  return 0;
 }

--- a/sycl/test/extensions/macro_esimd_emulator.cpp
+++ b/sycl/test/extensions/macro_esimd_emulator.cpp
@@ -5,9 +5,9 @@
 #include <sycl/sycl.hpp>
 
 #if SYCL_EXT_INTEL_BACKEND_ESIMD_EMULATOR == 1
-constexpr bool macro_deifned = true;
+constexpr bool macro_defined = true;
 #else
-constexpr bool macro_deifned = false;
+constexpr bool macro_defined = false;
 #endif
 
 int main() {

--- a/sycl/test/extensions/macro_hip.cpp
+++ b/sycl/test/extensions/macro_hip.cpp
@@ -1,15 +1,17 @@
 // This test checks presence of macros for available extensions.
-// RUN: %clangxx -fsycl %s -o %t.out
-// RUN: %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 // REQUIRES: hip_be
-#include <iostream>
+
 #include <sycl/sycl.hpp>
-int main() {
+
 #if SYCL_EXT_ONEAPI_BACKEND_HIP == 1
-  std::cout << "SYCL_EXT_ONEAPI_BACKEND_HIP=1" << std::endl;
+constexpr bool macro_defined = true;
 #else
-  std::cerr << "SYCL_EXT_ONEAPI_BACKEND_HIP!=1" << std::endl;
-  exit(1);
+constexpr bool macro_defined = false;
 #endif
-  exit(0);
+
+int main() {
+  static_assert(macro_defined);
+
+  return 0;
 }

--- a/sycl/test/extensions/test_complex.cpp
+++ b/sycl/test/extensions/test_complex.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 
 #define SYCL_EXT_ONEAPI_COMPLEX
 

--- a/sycl/test/regression/async_work_group_copy.cpp
+++ b/sycl/test/regression/async_work_group_copy.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o -
+// RUN: %clangxx -fsycl -fsyntax-only %s
 
 // Test checks for that no compile errors occur for
 // builtin async_work_group_copy

--- a/sycl/test/regression/buffer_from_rvalue.cpp
+++ b/sycl/test/regression/buffer_from_rvalue.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx %fsycl-host-only -fsyntax-only -sycl-std=2020 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -sycl-std=2020 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
 // expected-no-diagnostics
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/regression/copy-with-unnamed-lambda.cpp
+++ b/sycl/test/regression/copy-with-unnamed-lambda.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-unnamed-lambda %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsyntax-only %s
 // The purpose of this test is to check that the following code can be
 // successfully compiled
 #include <sycl/sycl.hpp>

--- a/sycl/test/regression/half_union.cpp
+++ b/sycl/test/regression/half_union.cpp
@@ -1,5 +1,4 @@
-// RUN: %clangxx -fsycl %s -o %t.out
-// RUN: %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/regression/headers_conflict.cpp
+++ b/sycl/test/regression/headers_conflict.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s -o %t.out -Xclang -verify-ignore-unexpected=note,warning
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s -Xclang -verify-ignore-unexpected=note,warning
 // expected-no-diagnostics
 //
 //===----------------------------------------------------------------------===//

--- a/sycl/test/regression/multi_ptr_gen_casting.cpp
+++ b/sycl/test/regression/multi_ptr_gen_casting.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 //
 // Tests that casting multi_ptr to and from generic compiles for various
 // combinations of valid qualifiers.

--- a/sycl/test/regression/operator-names.cpp
+++ b/sycl/test/regression/operator-names.cpp
@@ -3,9 +3,6 @@
 //===----------------------------------------------------------------------===//
 // This test checks if any SYCL header files use C++ operator name keywords
 // e.g. and, or, not
-//
-// This test does not use -fsyntax-only because it does not appear to respect
-// the -fno-operator-names option
 //===----------------------------------------------------------------------===//
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/regression/operator-names.cpp
+++ b/sycl/test/regression/operator-names.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -c %s -o %t.out -Wno-deprecated -fno-operator-names
+// RUN: %clangxx -fsycl -fsyntax-only %s -Wno-deprecated -fno-operator-names
 //
 //===----------------------------------------------------------------------===//
 // This test checks if any SYCL header files use C++ operator name keywords

--- a/sycl/test/regression/unnamed-lambda-split-order.cpp
+++ b/sycl/test/regression/unnamed-lambda-split-order.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-unnamed-lambda %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-unnamed-lambda -fsyntax-only %s
 #include "sycl.hpp"
 
 // This validates the case where using a lambda in a kernel in a different order

--- a/sycl/test/regression/unnamed-lambda.cpp
+++ b/sycl/test/regression/unnamed-lambda.cpp
@@ -1,5 +1,5 @@
-// RUN: %clangxx -fsycl -c %s -o %t.temp
-// RUN: %clangxx -fsycl -sycl-std=1.2.1 -c %s -o %t.temp
+// RUN: %clangxx -fsycl -fsyntax-only %s
+// RUN: %clangxx -fsycl -sycl-std=1.2.1 -fsyntax-only %s
 
 #include "sycl.hpp"
 

--- a/sycl/test/type_traits/half_operator_types.cpp
+++ b/sycl/test/type_traits/half_operator_types.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 //==-------------- type_traits.cpp - SYCL type_traits test -----------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/type_traits/integer_n_bit.cpp
+++ b/sycl/test/type_traits/integer_n_bit.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 //==---- integer_n_bit.cpp - SYCL integerNbit type traits test -------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/type_traits/type_list.cpp
+++ b/sycl/test/type_traits/type_list.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 //==---------------- type_list.cpp - SYCL type_list test -------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/type_traits/type_traits.cpp
+++ b/sycl/test/type_traits/type_traits.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %clangxx -fsycl -fsyntax-only %s
 //==-------------- type_traits.cpp - SYCL type_traits test -----------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test/warnings/free_function_leader.cpp
+++ b/sycl/test/warnings/free_function_leader.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/warnings/group_local_memory_deprecation.cpp
+++ b/sycl/test/warnings/group_local_memory_deprecation.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl-device-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
+// RUN: %clangxx -fsycl-device-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/warnings/interop_task_deprecation.cpp
+++ b/sycl/test/warnings/interop_task_deprecation.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/warnings/run_on_host_intel_deprecation.hpp
+++ b/sycl/test/warnings/run_on_host_intel_deprecation.hpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx %fsycl-host-only -fsyntax-only -ferror-limit=0 -sycl-std=2020 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -o %t.out
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -ferror-limit=0 -sycl-std=2020 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
 
 #include <CL/sycl.hpp>
 #include <sycl/ext/intel/experimental/online_compiler.hpp>


### PR DESCRIPTION
Adjusted LIT tests to use syntax-only mode for some tests which perform full compilation and linking or only compilation (`-c`) to speed up those tests.

Also removed `-o` option from some existing `-fsyntax-only` mode to shorten `RUN` lines, because it is anyway ignored by the compiler.

Refactored some tests for predefined macro to make checks at compile-time and not at runtime.