### PR TITLE
[SYCL][Doc] Fix typo in SPV_INTEL_function_pointers

### DIFF
--- a/sycl/doc/design/spirv-extensions/SPV_INTEL_function_pointers.asciidoc
+++ b/sycl/doc/design/spirv-extensions/SPV_INTEL_function_pointers.asciidoc
@@ -97,7 +97,7 @@ OpFunctionPointerCallINTEL
 
 == New Decorations
 
-Decorations added under the *IndirectlyReferencableINTEL* capability:
+Decorations added under the *IndirectReferencesINTEL* capability:
 
 ----
 ReferencedIndirectlyINTEL


### PR DESCRIPTION
This resolves #7548