### PR TITLE
[SYCL] Do not use sycl::cl_* types in vec class

### DIFF
--- a/sycl/include/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/sycl/detail/generic_type_traits.hpp
@@ -41,6 +41,8 @@ template <typename T> using is_halfn = is_contained<T, gtl::vector_half_list>;
 
 template <typename T> using is_genfloath = is_contained<T, gtl::half_list>;
 
+template <typename T> using is_half = is_contained<T, gtl::scalar_half_list>;
+
 template <typename T>
 using is_svgenfloath = is_contained<T, gtl::scalar_vector_half_list>;
 

--- a/sycl/test/basic_tests/generic_type_traits.cpp
+++ b/sycl/test/basic_tests/generic_type_traits.cpp
@@ -55,6 +55,8 @@ int main() {
 
   static_assert(d::is_ugenint<s::cl_uint3>::value == true, "");
 
+  static_assert(d::is_half<s::half>::value);
+
   // TODO add checks for the following type traits
   /*
   is_doublen

--- a/sycl/test/basic_tests/types.cpp
+++ b/sycl/test/basic_tests/types.cpp
@@ -33,6 +33,7 @@ template <typename T> inline void checkVectorsWithN() {
 }
 
 inline void checkVectors() {
+  checkVectorsWithN<bool>();
   checkVectorsWithN<s::half>();
   checkVectorsWithN<float>();
   checkVectorsWithN<double>();

--- a/sycl/test/basic_tests/vectors/negative.cpp
+++ b/sycl/test/basic_tests/vectors/negative.cpp
@@ -1,0 +1,27 @@
+// This test is intended to check that creating vec<DataT, N> with unsupported
+// DataT or N produces a verbose error message.
+//
+// RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note,error %s
+//
+// Note: there is one more error being emitted: "requested alignemnt is not a power of 2"
+// It happens because in all cases above we weren't able to select underlying
+// data type for vec and therefore it screwed up other code realying on it.
+// This error message is not they key thing we want to test here and that's why
+// it is ok to ignore it.
+
+#include <sycl/sycl.hpp>
+
+struct CustomT {
+  int a;
+  float b;
+};
+
+void unsupported_data_type() {
+  // expected-error@sycl/types.hpp:* {{Incorrect data type for sycl::vec}}
+  sycl::vec<CustomT, 4> v;
+}
+
+void unsupported_size() {
+  // expected-error@sycl/types.hpp:* {{Incorrect number of elements for sycl::vec}}
+  sycl::vec<int, 15> v;
+}


### PR DESCRIPTION
Refactored `vec`'s underlying storage type selection so it doesn't reference `sycl::cl_*` types which do not exists in SYCL 2020 spec anymore.

New approach takes less lines of code and it also provides better error messages for wrong data type or number of elements passed by user.

The change is mostly non-functional, except for the new error messages.