### PR TITLE
[SYCL-MLIR] Add back reverted upstream commit

### DIFF
--- a/llvm/lib/IR/Function.cpp
+++ b/llvm/lib/IR/Function.cpp
@@ -1944,6 +1944,7 @@ bool Function::hasAddressTaken(const User **PutOffender,
           })) {
         continue;
       }
+
       if (IgnoreLLVMUsed && !FU->user_empty()) {
         const User *FUU = FU;
         if (isa<BitCastOperator, AddrSpaceCastOperator>(FU) &&
@@ -1962,6 +1963,13 @@ bool Function::hasAddressTaken(const User **PutOffender,
         *PutOffender = FU;
       return true;
     }
+
+    if (IgnoreAssumeLikeCalls) {
+      if (const auto *I = dyn_cast<IntrinsicInst>(Call))
+        if (I->isAssumeLikeIntrinsic())
+          continue;
+    }
+
     if (!Call->isCallee(&U) || Call->getFunctionType() != getFunctionType()) {
       if (IgnoreARCAttachedCall &&
           Call->isOperandBundleOfType(LLVMContext::OB_clang_arc_attachedcall,

--- a/llvm/test/Analysis/CallGraph/ignore-assumelike-calls.ll
+++ b/llvm/test/Analysis/CallGraph/ignore-assumelike-calls.ll
@@ -1,26 +1,63 @@
 ; RUN: opt < %s -passes=print-callgraph -disable-output 2>&1 | FileCheck %s
 ; CHECK: Call graph node <<null function>><<{{.*}}>>  #uses=0
-; CHECK-NEXT:   CS<None> calls function 'cast_only'
-; CHECK-NEXT:   CS<None> calls function 'llvm.lifetime.start.p0i8'
+; CHECK-NEXT:   CS<None> calls function 'other_intrinsic_use'
+; CHECK-NEXT:   CS<None> calls function 'other_cast_intrinsic_use'
+; CHECK-NEXT:   CS<None> calls function 'llvm.lifetime.start.p0'
+; CHECK-NEXT:   CS<None> calls function 'llvm.memset.p0.i64'
+; CHECK-NEXT:   CS<None> calls function 'llvm.memset.p1.i64'
 ; CHECK-EMPTY:
-; CHECK-NEXT:   Call graph node for function: 'cast_only'<<{{.*}}>>  #uses=1
+; CHECK-NEXT:   Call graph node for function: 'addrspacecast_only'<<{{.*}}>>  #uses=0
 ; CHECK-EMPTY:
-; CHECK-NEXT:   Call graph node for function: 'llvm.lifetime.start.p0i8'<<{{.*}}>>  #uses=1
+; CHECK-NEXT:   Call graph node for function: 'bitcast_only'<<{{.*}}>>  #uses=0
+; CHECK-EMPTY:
+; CHECK-NEXT:   Call graph node for function: 'llvm.lifetime.start.p0'<<{{.*}}>>  #uses=1
+; CHECK-EMPTY:
+; CHECK-NEXT:   Call graph node for function: 'llvm.memset.p0.i64'<<{{.*}}>>  #uses=1
+; CHECK-EMPTY:
+; CHECK-NEXT:   Call graph node for function: 'llvm.memset.p1.i64'<<{{.*}}>>  #uses=1
+; CHECK-EMPTY:
+; CHECK-NEXT:   Call graph node for function: 'other_cast_intrinsic_use'<<{{.*}}>>  #uses=1
+; CHECK-EMPTY:
+; CHECK-NEXT:   Call graph node for function: 'other_intrinsic_use'<<{{.*}}>>  #uses=1
 ; CHECK-EMPTY:
 ; CHECK-NEXT:   Call graph node for function: 'used_by_lifetime'<<{{.*}}>>  #uses=0
+; CHECK-EMPTY:
+; CHECK-NEXT:   Call graph node for function: 'used_by_lifetime_cast'<<{{.*}}>>  #uses=0
 ; CHECK-EMPTY:
 
 define internal void @used_by_lifetime() {
 entry:
-  %c = bitcast void()* @used_by_lifetime to i8*
-  call void @llvm.lifetime.start.p0i8(i64 4, i8* %c)
+  call void @llvm.lifetime.start.p0(i64 4, ptr @used_by_lifetime)
   ret void
 }
 
-define internal void @cast_only() {
+define internal void @used_by_lifetime_cast() addrspace(1) {
+  call void @llvm.lifetime.start.p0(i64 4, ptr addrspacecast (ptr addrspace(1) @used_by_lifetime_cast to ptr))
+  ret void
+}
+
+define internal void @bitcast_only() {
 entry:
-  %c = bitcast void()* @cast_only to i8*
+  %c = bitcast ptr @bitcast_only to ptr
   ret void
 }
 
-declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture)
+define internal void @addrspacecast_only() addrspace(1) {
+entry:
+  %c = addrspacecast ptr addrspace(1) @addrspacecast_only to ptr
+  ret void
+}
+
+define internal void @other_intrinsic_use() {
+  call void @llvm.memset.p0.i64(ptr @other_intrinsic_use, i8 0, i64 1024, i1 false)
+  ret void
+}
+
+define internal void @other_cast_intrinsic_use() {
+  call void @llvm.memset.p1.i64(ptr addrspace(1) addrspacecast (ptr @other_cast_intrinsic_use to ptr addrspace(1)), i8 0, i64 1024, i1 false)
+  ret void
+}
+
+declare void @llvm.lifetime.start.p0(i64, ptr nocapture)
+declare void @llvm.memset.p0.i64(ptr, i8, i64, i1 immarg)
+declare void @llvm.memset.p1.i64(ptr addrspace(1), i8, i64, i1 immarg)

--- a/llvm/test/Transforms/OpenMP/parallel_deletion_cg_update.ll
+++ b/llvm/test/Transforms/OpenMP/parallel_deletion_cg_update.ll
@@ -1,15 +1,14 @@
 ; RUN: opt < %s -passes='function(instcombine),cgscc(attributor-cgscc),print-callgraph' -disable-output 2>&1 | FileCheck %s
 
 ; CHECK: Call graph node <<null function>><<{{.*}}>>  #uses=0
-; CHECK:   CS<None> calls function 'dead_fork_call'
-; CHECK:   CS<None> calls function '.omp_outlined..0'
-; CHECK:   CS<None> calls function '__kmpc_fork_call'
-; CHECK:   CS<None> calls function 'live_fork_call'
-; CHECK:   CS<None> calls function '.omp_outlined..1'
-; CHECK:   CS<None> calls function 'd'
+; CHECK-NEXT:   CS<None> calls function 'dead_fork_call'
+; CHECK-NEXT:   CS<None> calls function '__kmpc_fork_call'
+; CHECK-NEXT:   CS<None> calls function 'live_fork_call'
+; CHECK-NEXT:   CS<None> calls function '.omp_outlined..1'
+; CHECK-NEXT:   CS<None> calls function 'd'
 ;
-; CHECK: Call graph node for function: '.omp_outlined..0'<<{{.*}}>>  #uses=1
-; 
+; CHECK: Call graph node for function: '.omp_outlined..0'<<{{.*}}>>  #uses=0
+;
 ; CHECK: Call graph node for function: '.omp_outlined..1'<<{{.*}}>>  #uses=3
 ; CHECK:   CS<{{.*}}> calls function 'd'
 ;


### PR DESCRIPTION
https://github.com/intel/llvm/pull/7843 merged `sycl` branch to `sycl-mlir` branch.
On of the upstream commit https://github.com/intel/llvm/commit/0a67e771f6d21b1232c40f226c4eee48c3527210 causes lit failures, so it was temporarily reverted in `sycl-mlir` branch.  
This PR reverts the reverted commit, as the failures are resolved by https://github.com/intel/llvm/commit/bf67186bd2a1dcd042219dca408a56ddd06ee16d.

This reverts commit 61b99a2c2b371f369a68789bef20fad5c77b2cd5.

Please do not squash and merge this PR.