### PR TITLE
[SYCL] Copy spec constant information to link result

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1954,12 +1954,48 @@ ProgramManager::link(const std::vector<device_image_plain> &DeviceImages,
   }
 
   std::shared_ptr<std::vector<kernel_id>> KernelIDs{new std::vector<kernel_id>};
+  std::vector<unsigned char> NewSpecConstBlob;
+  device_image_impl::SpecConstMapT NewSpecConstMap;
   for (const device_image_plain &DeviceImage : DeviceImages) {
+    std::shared_ptr<device_image_impl> DeviceImageImpl =
+        getSyclObjImpl(DeviceImage);
+
     // Duplicates are not expected here, otherwise piProgramLink should fail
-    KernelIDs->insert(
-        KernelIDs->end(),
-        getSyclObjImpl(DeviceImage)->get_kernel_ids_ptr()->begin(),
-        getSyclObjImpl(DeviceImage)->get_kernel_ids_ptr()->end());
+    KernelIDs->insert(KernelIDs->end(),
+                      DeviceImageImpl->get_kernel_ids_ptr()->begin(),
+                      DeviceImageImpl->get_kernel_ids_ptr()->end());
+
+    // To be able to answer queries about specialziation constants, the new
+    // device image should have the specialization constants from all the linked
+    // images.
+    {
+      const std::lock_guard<std::mutex> SpecConstLock(
+          DeviceImageImpl->get_spec_const_data_lock());
+
+      // Copy all map entries to the new map. Since the blob will be copied to
+      // the end of the new blob we need to move the blob offset of each entry.
+      for (const auto &SpecConstIt :
+           DeviceImageImpl->get_spec_const_data_ref()) {
+        std::vector<device_image_impl::SpecConstDescT> &NewDescEntries =
+            NewSpecConstMap[SpecConstIt.first];
+        assert(NewDescEntries.empty() &&
+               "Specialization constant already exists in the map.");
+        NewDescEntries.reserve(SpecConstIt.second.size());
+        for (const device_image_impl::SpecConstDescT &SpecConstDesc :
+             SpecConstIt.second) {
+          device_image_impl::SpecConstDescT NewSpecConstDesc = SpecConstDesc;
+          NewSpecConstDesc.BlobOffset += NewSpecConstBlob.size();
+          NewDescEntries.push_back(std::move(NewSpecConstDesc));
+        }
+      }
+
+      // Copy the blob from the device image into the new blob. This moves the
+      // offsets of the following blobs.
+      NewSpecConstBlob.insert(
+          NewSpecConstBlob.end(),
+          DeviceImageImpl->get_spec_const_blob_ref().begin(),
+          DeviceImageImpl->get_spec_const_blob_ref().end());
+    }
   }
   // device_image_impl expects kernel ids to be sorted for fast search
   std::sort(KernelIDs->begin(), KernelIDs->end(), LessByHash<kernel_id>{});
@@ -1967,7 +2003,8 @@ ProgramManager::link(const std::vector<device_image_plain> &DeviceImages,
   DeviceImageImplPtr ExecutableImpl =
       std::make_shared<detail::device_image_impl>(
           /*BinImage=*/nullptr, Context, Devs, bundle_state::executable,
-          std::move(KernelIDs), LinkedProg);
+          std::move(KernelIDs), LinkedProg, std::move(NewSpecConstMap),
+          std::move(NewSpecConstBlob));
 
   // TODO: Make multiple sets of device images organized by devices they are
   // compiled for.


### PR DESCRIPTION
The executable `kernel_bundle` resulting from calling `sycl::link` with input kernel bundles should also be able to answer kernel bundle queries like `has_specialization_constant()` and `get_specialization_constant()`. To make this possible, the link operation copies both the spec constant data and the spec-constant name-to-descriptor mappings of all input bundles.