### PR TITLE
[SYCL] Make device_has test correctly handle changed metadata

### DIFF
--- a/sycl/test/check_device_code/device_has.cpp
+++ b/sycl/test/check_device_code/device_has.cpp
@@ -56,16 +56,16 @@ void foo() {
   });
 }
 
-// CHECK: [[ASPECTS1]] = !{i32 1}
-// CHECK: [[SRCLOC1]] = !{i32 {{[0-9]+}}}
-// CHECK: [[EMPTYASPECTS]] = !{}
-// CHECK: [[SRCLOC2]] = !{i32 {{[0-9]+}}}
-// CHECK: [[ASPECTS2]] = !{i32 5, i32 2}
-// CHECK: [[SRCLOC3]] = !{i32 {{[0-9]+}}}
-// CHECK: [[SRCLOC4]] = !{i32 {{[0-9]+}}}
-// CHECK: [[ASPECTS3]] = !{i32 0}
-// CHECK: [[SRCLOC5]] = !{i32 {{[0-9]+}}}
-// CHECK: [[SRCLOC6]] = !{i32 {{[0-9]+}}}
-// CHECK: [[SRCLOC7]] = !{i32 {{[0-9]+}}}
-// CHECK: [[ASPECTS4]] = !{i32 2}
-// CHECK: [[SRCLOC8]] = !{i32 {{[0-9]+}}}
+// CHECK-DAG: [[ASPECTS1]] = !{i32 1}
+// CHECK-DAG: [[SRCLOC1]] = !{i32 {{[0-9]+}}}
+// CHECK-DAG: [[EMPTYASPECTS]] = !{}
+// CHECK-DAG: [[SRCLOC2]] = !{i32 {{[0-9]+}}}
+// CHECK-DAG: [[ASPECTS2]] = !{i32 5, i32 2}
+// CHECK-DAG: [[SRCLOC3]] = !{i32 {{[0-9]+}}}
+// CHECK-DAG: [[SRCLOC4]] = !{i32 {{[0-9]+}}}
+// CHECK-DAG: [[ASPECTS3]] = !{i32 0}
+// CHECK-DAG: [[SRCLOC5]] = !{i32 {{[0-9]+}}}
+// CHECK-DAG: [[SRCLOC6]] = !{i32 {{[0-9]+}}}
+// CHECK-DAG: [[SRCLOC7]] = !{i32 {{[0-9]+}}}
+// CHECK-DAG: [[ASPECTS4]] = !{i32 2}
+// CHECK-DAG: [[SRCLOC8]] = !{i32 {{[0-9]+}}}


### PR DESCRIPTION
The sycl/test/check_device_code/device_has.cpp test currently enforces strict ordering of the expected metadata in the resulting IR, but there is no guarantee about this ordering and future changes could make some of the metadata appear earlier, e.g. through consolidation with other metadata nodes. This test should not care about the order however, so this commit removes the ordering requirements.