### PR TITLE
[SYCL] Fix error when size_t is used as enum base

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4776,7 +4776,7 @@ class SYCLFwdDeclEmitter
     D->print(OS, Policy);
 
     if (const auto *ED = dyn_cast<EnumDecl>(D)) {
-      QualType T = ED->getIntegerType();
+      QualType T = ED->getIntegerType().getCanonicalType();
       // Backup since getIntegerType() returns null for enum forward
       // declaration with no fixed underlying type
       if (T.isNull())

--- a/clang/test/CodeGenSYCL/kernelname-enum.cpp
+++ b/clang/test/CodeGenSYCL/kernelname-enum.cpp
@@ -5,6 +5,10 @@
 
 #include "Inputs/sycl.hpp"
 
+namespace std {
+typedef long unsigned int size_t;
+} // namespace std
+
 enum unscoped_enum : int {
   val_1,
   val_2
@@ -110,6 +114,14 @@ public:
   void operator()() const {}
 };
 
+enum class TestStdEnum : std::size_t { A, B };
+
+template <TestStdEnum value>
+class dummy_functor_9 {
+public:
+  void operator()() const {}
+};
+
 int main() {
 
   dummy_functor_1<no_namespace_int::val_1> f1;
@@ -121,6 +133,7 @@ int main() {
   dummy_functor_7<no_namespace_int> f7;
   dummy_functor_7<internal::namespace_short> f8;
   dummy_functor_8<EnumTypeOut, Baz> f9;
+  dummy_functor_9<TestStdEnum::A> f10;
 
   sycl::queue q;
 
@@ -166,6 +179,10 @@ int main() {
 
   q.submit([&](sycl::handler &cgh) {
     cgh.single_task(f9);
+  });
+
+  q.submit([&](sycl::handler &cgh) {
+    cgh.single_task(f10);
   });
 
   return 0;

--- a/clang/test/CodeGenSYCL/kernelname-enum.cpp
+++ b/clang/test/CodeGenSYCL/kernelname-enum.cpp
@@ -215,6 +215,8 @@ int main() {
 // NUL: enum class EnumValueIn : int;
 // NUL: template <EnumValueIn EnumValue, typename EnumTypeIn> class Baz;
 // NUL: template <typename EnumTypeOut, template <EnumValueIn EnumValue, typename EnumTypeIn> class T> class dummy_functor_8;
+// NUL: enum class TestStdEnum : unsigned long;
+// NUL: template <TestStdEnum value> class dummy_functor_9;
 
 // CHECK: Specializations of KernelInfo for kernel function types:
 // NUL: template <> struct KernelInfo<::dummy_functor_1<static_cast<::no_namespace_int>(0)>>
@@ -237,3 +239,5 @@ int main() {
 // CHECK: template <> struct KernelInfo<::T1<::T3<::type_argument_template_enum::E>>>
 // NUL: template <> struct KernelInfo<::dummy_functor_8<::EnumTypeOut, Baz>>
 // UL: template <> struct KernelInfoData<'_', 'Z', 'T', 'S', '1', '5', 'd', 'u', 'm', 'm', 'y', '_', 'f', 'u', 'n', 'c', 't', 'o', 'r', '_', '8', 'I', '1', '1', 'E', 'n', 'u', 'm', 'T', 'y', 'p', 'e', 'O', 'u', 't', '3', 'B', 'a', 'z', 'E'>
+// NUL: template <> struct KernelInfo<::dummy_functor_9<static_cast<::TestStdEnum>(0)>> {
+// UL: template <> struct KernelInfoData<'_', 'Z', 'T', 'S', '1', '5', 'd', 'u', 'm', 'm', 'y', '_', 'f', 'u', 'n', 'c', 't', 'o', 'r', '_', '9', 'I', 'L', '1', '1', 'T', 'e', 's', 't', 'S', 't', 'd', 'E', 'n', 'u', 'm', '0', 'E', 'E'>

--- a/clang/test/SemaSYCL/stdtypes_kernel_type.cpp
+++ b/clang/test/SemaSYCL/stdtypes_kernel_type.cpp
@@ -14,6 +14,8 @@ class U;
 class Foo;
 } // namespace std
 
+enum class test_enum : std::size_t { a, b };
+
 template <typename T>
 struct Templated_kernel_name;
 
@@ -65,6 +67,9 @@ int main() {
   });
   q.submit([&](handler &h) {
     h.single_task<std::ptrdiff_t>([=] {});
+  });
+  q.submit([&](handler &h) {
+    h.single_task<Templated_kernel_name<test_enum>>([=] {});
   });
 
   return 0;


### PR DESCRIPTION
"std::size_t" was emitted in the forward declaration of enum in integration header. 
This resulted in compilation errors about use of undeclared identifier "std". To fix this,
builtin is resolved to integral type in forward declaration.