### PR TITLE
[SYCL] Use per-kernel mutex for interop kernel enqueue

### DIFF
--- a/sycl/source/detail/kernel_impl.hpp
+++ b/sycl/source/detail/kernel_impl.hpp
@@ -173,6 +173,10 @@ public:
 
   ProgramImplPtr getProgramImpl() const { return MProgramImpl; }
 
+  std::mutex &getNoncacheableEnqueueMutex() {
+    return MNoncacheableEnqueueMutex;
+  }
+
 private:
   RT::PiKernel MKernel;
   const ContextImplPtr MContext;
@@ -181,6 +185,7 @@ private:
   const DeviceImageImplPtr MDeviceImageImpl;
   const KernelBundleImplPtr MKernelBundleImpl;
   bool MIsInterop = false;
+  std::mutex MNoncacheableEnqueueMutex;
 };
 
 template <typename Param>


### PR DESCRIPTION
Switch from using a single mutex to one per kernel when enqueueing interoperability kernels. Compared to the original solution (#8111), this allows to enqueue different interop SYCL kernels in parallel, but leaves out an edge case where two SYCL kernels were created with the same native handle.