### PR TITLE
[SYCL] Refactor sub_group_mask tests

### DIFF
--- a/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
@@ -249,7 +249,8 @@ struct sub_group_mask {
   }
 
 private:
-  sub_group_mask(BitsType rhs, size_t bn) : Bits(rhs), bits_num(bn) {
+  sub_group_mask(BitsType rhs, size_t bn)
+      : Bits(rhs & valuable_bits(bn)), bits_num(bn) {
     assert(bits_num <= max_bits);
   }
   inline BitsType valuable_bits(size_t bn) const {

--- a/sycl/test/extensions/sub_group_mask.cpp
+++ b/sycl/test/extensions/sub_group_mask.cpp
@@ -1,136 +1,85 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %t.out
+// RUN: %clangxx -fsycl -fsycl-device-only -fsyntax-only %s
+//
+// This test is intended to check sycl::ext::oneapi::sub_group_mask interface.
+// There is a work in progress update to the spec: intel/llvm#8174
+// TODO: udpate this test once revision 2 of the extension is supported
 
-//==-------- sub_group_mask.cpp - SYCL sub-group mask test -----------------==//
-//
-// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
-// See https://llvm.org/LICENSE.txt for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-#include <cassert>
-#include <iostream>
 #include <sycl/sycl.hpp>
 
+#include <cstdint>
+#include <type_traits>
+
 int main() {
-  for (size_t sgsize = 32; sgsize > 4; sgsize /= 2) {
-    std::cout << "Running test for sub-group size = " << sgsize << std::endl;
-    auto g = sycl::detail::Builder::createSubGroupMask<
-        sycl::ext::oneapi::sub_group_mask>(0, sgsize);
-    assert(g.none() && !g.any() && !g.all());
-    assert(g[5] == false); // reference::operator[](id) const;
-    g[5] = true;           // reference::operator=(bool);
-    assert(g[5] == true);
-    g[6] = g[5]; // reference::operator=(reference) reference::operator[](id);
-    assert(g[5].flip() == false);   // reference::flip()
-    assert(~g[5 % sgsize] == true); // refernce::operator~()
-    assert(g[5 % sgsize] == false);
-    assert(g[6 % sgsize] == true);
-    assert(g.test(5 % sgsize) == false && g.test(6 % sgsize) == true);
-    g.set(3 % sgsize, 1);
-    g.set(6 % sgsize, 0);
-    g.set(2 % sgsize, 1);
-    assert(!g.none() && g.any() && !g.all());
+  using mask_type = sycl::ext::oneapi::sub_group_mask;
+  using mask_reference_type = sycl::ext::oneapi::sub_group_mask &;
 
-    assert(g.count() == 2);
-    assert(g.find_low() == 2 % sgsize);
-    assert(g.find_high() == 3 % sgsize);
-    assert(g.size() == sgsize);
+  auto mask = sycl::detail::Builder::createSubGroupMask<mask_type>(0, 32);
+  const auto const_mask =
+      sycl::detail::Builder::createSubGroupMask<mask_type>(0, 32);
 
-    g.reset();
-    assert(g.none() && !g.any() && !g.all());
-    assert(g.find_low() == g.size() && g.find_high() == g.size());
-    g.set();
-    assert(!g.none() && g.any() && g.all());
-    assert(g.find_low() == 0 && g.find_high() == 31 % sgsize);
-    g.flip();
-    assert(g.none() && !g.any() && !g.all());
+  static_assert(
+      std::is_same_v<decltype(mask[sycl::id(0)]), mask_type::reference>);
+  static_assert(std::is_same_v<decltype(const_mask[sycl::id(0)]), bool>);
 
-    g.flip(2);
-    g.flip(3);
-    g.flip(7);
-    auto b = g;
-    assert(b == g && !(b != g));
-    g.flip(7);
-    assert(g.find_high() == 3 % sgsize);
-    assert(b.find_high() == 7 % sgsize);
-    assert(b != g && !(b == g));
-    g.flip(7);
-    assert(b == g && !(b != g));
-    b = g >> 1;
-    assert(b[1] && b[2] && b[6]);
-    b <<= 1;
-    assert(b == g);
-    g ^= ~b;
-    assert(!g.none() && g.any() && g.all());
-    assert((g | ~g).all());
-    assert((g & ~g).none());
-    assert((g ^ ~g).all());
-    b.reset_low();
-    b.reset_high();
-    assert(!b[2] && b[3] && !b[7]);
-    b.insert_bits(0x01020408);
-    assert(((b[24] && b[17]) || sgsize < 32) && (b[10] || sgsize < 16) && b[3]);
-    b <<= 10;
-    assert(((!b[24] && !b[17] && b[27] && b[20]) || sgsize < 32) &&
-           ((!b[10] && b[13]) || sgsize < 16) && !b[3]);
-    b.insert_bits((char)0b01010101, 6);
-    assert(b[6] && ((b[8] && b[10] && b[12] && !b[13]) || sgsize < 16));
-    b[3] = true;
-    b.insert_bits(sycl::marray<char, 8>{1, 2, 4, 8, 16, 32, 64, 128}, 5);
-    assert(
-        ((!b[18] && !b[20] && !b[22] && !b[24] && !b[30] && !b[16] && b[23]) ||
-         sgsize < 32) &&
-        b[3] && b[5] && (b[14] || sgsize < 16));
-    b.flip(14);
-    b.flip(23);
-    char r, rbc;
-    const auto b_const{b};
-    b.extract_bits(r);
-    b_const.extract_bits(rbc);
-    assert(r == 0b00101000);
-    assert(rbc == 0b00101000);
-    long r2 = -1, r2bc = -1;
-    b.extract_bits(r2, 3);
-    b_const.extract_bits(r2bc, 3);
-    assert(r2 == 5);
-    assert(r2bc == 5);
+  static_assert(std::is_same_v<decltype(const_mask.test(sycl::id(0))), bool>);
 
-    b.insert_bits((uint32_t)0x08040201);
-    const auto b_const2{b};
-    sycl::marray<char, 6> r3{-1}, r3bc{-1};
-    b.extract_bits(r3);
-    b_const2.extract_bits(r3bc);
-    assert(r3[0] == 1 && r3[1] == (sgsize > 8 ? 2 : 0) &&
-           r3[2] == (sgsize > 16 ? 4 : 0) && r3[3] == (sgsize > 16 ? 8 : 0) &&
-           !r3[4] && !r3[5]);
-    assert(r3bc[0] == 1 && r3bc[1] == (sgsize > 8 ? 2 : 0) &&
-           r3bc[2] == (sgsize > 16 ? 4 : 0) &&
-           r3bc[3] == (sgsize > 16 ? 8 : 0) && !r3bc[4] && !r3bc[5]);
-    int ibits = 0b1010101010101010101010101010101;
-    b.insert_bits(ibits);
-    for (size_t i = 0; i < sgsize; i++) {
-      assert(b[i] != (bool)(i % 2));
-    }
-    short sbits = 0b0111011101110111;
-    b.insert_bits(sbits, 7);
-    b.extract_bits(ibits);
-    assert(ibits ==
-           (0b1010101001110111011101111010101 & ((1ULL << sgsize) - 1ULL)));
-    sbits = 0b1100001111000011;
-    b.insert_bits(sbits, 23);
-    b.extract_bits(ibits);
-    if (sgsize >= 32) {
-      int64_t lbits = -1;
-      b.extract_bits(lbits, 33);
-      assert(lbits == 0);
-      lbits = -1;
-      b.extract_bits(lbits, 5);
-      assert(lbits ==
-             (0b111000011011101110111011110 & ((1ULL << sgsize) - 1ULL)));
-      lbits = -1;
-      b.insert_bits(lbits);
-      assert(b.all());
-    }
-  }
+  static_assert(std::is_same_v<decltype(const_mask.any()), bool>);
+  static_assert(std::is_same_v<decltype(const_mask.all()), bool>);
+  static_assert(std::is_same_v<decltype(const_mask.none()), bool>);
+
+  static_assert(std::is_same_v<decltype(const_mask.count()), std::uint32_t>);
+  static_assert(std::is_same_v<decltype(const_mask.size()), std::uint32_t>);
+
+  static_assert(std::is_same_v<decltype(const_mask.find_low()), sycl::id<1>>);
+  static_assert(std::is_same_v<decltype(const_mask.find_high()), sycl::id<1>>);
+
+  int bits_i = 0;
+  unsigned long long bits_ull = 0;
+  sycl::marray<char, 3> bits_mc(0);
+  sycl::marray<unsigned short, 12> bits_ms(0);
+
+  mask.insert_bits(bits_i);
+  mask.insert_bits(bits_ull, sycl::id(0));
+  mask.insert_bits(bits_mc);
+  mask.insert_bits(bits_ms, sycl::id(0));
+
+  const_mask.extract_bits(bits_i);
+  const_mask.extract_bits(bits_ull, sycl::id(0));
+  const_mask.extract_bits(bits_mc);
+  const_mask.extract_bits(bits_ms, sycl::id(0));
+
+  mask.set();
+  mask.set(sycl::id(0));
+  mask.set(sycl::id(0), false);
+
+  mask.reset();
+  mask.reset(sycl::id(0));
+
+  mask.reset_low();
+  mask.reset_high();
+
+  mask.flip();
+  mask.flip(sycl::id(0));
+
+  static_assert(std::is_same_v<decltype(const_mask == mask), bool>);
+  static_assert(std::is_same_v<decltype(const_mask != mask), bool>);
+
+  static_assert(
+      std::is_same_v<decltype(mask &= const_mask), mask_reference_type>);
+  static_assert(
+      std::is_same_v<decltype(mask |= const_mask), mask_reference_type>);
+  static_assert(
+      std::is_same_v<decltype(mask ^= const_mask), mask_reference_type>);
+  static_assert(std::is_same_v<decltype(mask <<= 3u), mask_reference_type>);
+  static_assert(std::is_same_v<decltype(mask >>= 3u), mask_reference_type>);
+
+  static_assert(std::is_same_v<decltype(~const_mask), mask_type>);
+  static_assert(std::is_same_v<decltype(const_mask << 3u), mask_type>);
+  static_assert(std::is_same_v<decltype(const_mask >> 3u), mask_type>);
+
+  static_assert(std::is_same_v<decltype(const_mask & mask), mask_type>);
+  static_assert(std::is_same_v<decltype(const_mask | mask), mask_type>);
+  static_assert(std::is_same_v<decltype(const_mask ^ mask), mask_type>);
+
+  return 0;
 }

--- a/sycl/unittests/Extensions/CMakeLists.txt
+++ b/sycl/unittests/Extensions/CMakeLists.txt
@@ -7,5 +7,6 @@ add_sycl_unittest(ExtensionsTests OBJECT
   WeakObject.cpp
   USMMemcpy2D.cpp
   DeviceGlobal.cpp
+  OneAPISubGroupMask.cpp
 )
 

--- a/sycl/unittests/Extensions/OneAPISubGroupMask.cpp
+++ b/sycl/unittests/Extensions/OneAPISubGroupMask.cpp
@@ -1,0 +1,355 @@
+#include <gtest/gtest.h>
+
+#include <sycl/sycl.hpp>
+
+#include <algorithm>
+
+class SubGroupMask : public testing::TestWithParam<size_t> {
+protected:
+  void SetUp() override {
+    MaskZero = sycl::detail::Builder::createSubGroupMask<
+        sycl::ext::oneapi::sub_group_mask>(0, GetParam());
+    MaskAllOnes = sycl::detail::Builder::createSubGroupMask<
+        sycl::ext::oneapi::sub_group_mask>(
+        static_cast<sycl::ext::oneapi::sub_group_mask::BitsType>(-1),
+        GetParam());
+    MaskOne = sycl::detail::Builder::createSubGroupMask<
+        sycl::ext::oneapi::sub_group_mask>(1, GetParam());
+  }
+
+  sycl::ext::oneapi::sub_group_mask MaskZero =
+      sycl::detail::Builder::createSubGroupMask<
+          sycl::ext::oneapi::sub_group_mask>(0, 1);
+  sycl::ext::oneapi::sub_group_mask MaskOne =
+      sycl::detail::Builder::createSubGroupMask<
+          sycl::ext::oneapi::sub_group_mask>(0, 1);
+  sycl::ext::oneapi::sub_group_mask MaskAllOnes =
+      sycl::detail::Builder::createSubGroupMask<
+          sycl::ext::oneapi::sub_group_mask>(0, 1);
+};
+
+TEST_P(SubGroupMask, SubscriptOperatorBool) {
+  const auto MZ = MaskZero;
+  const auto MO = MaskOne;
+  const auto MAO = MaskAllOnes;
+  ASSERT_FALSE(MZ[0]);
+  ASSERT_TRUE(MO[0]);
+  ASSERT_TRUE(MAO[0]);
+
+  for (size_t I = 1; I < GetParam(); ++I) {
+    ASSERT_FALSE(MZ[I]);
+    ASSERT_FALSE(MO[I]);
+    ASSERT_TRUE(MAO[I]);
+  }
+}
+
+TEST_P(SubGroupMask, SubscriptOperator) {
+  ASSERT_FALSE(MaskZero[0]);
+  ASSERT_TRUE(MaskOne[0]);
+  ASSERT_TRUE(MaskAllOnes[0]);
+
+  for (size_t I = 1; I < GetParam(); ++I) {
+    ASSERT_FALSE(MaskZero[I]);
+    ASSERT_FALSE(MaskOne[I]);
+    ASSERT_TRUE(MaskAllOnes[I]);
+  }
+}
+
+TEST_P(SubGroupMask, Test) {
+  ASSERT_FALSE(MaskZero.test(0));
+  ASSERT_TRUE(MaskOne.test(0));
+  ASSERT_TRUE(MaskAllOnes.test(0));
+
+  for (size_t I = 1; I < GetParam(); ++I) {
+    ASSERT_FALSE(MaskZero.test(I));
+    ASSERT_FALSE(MaskOne.test(I));
+    ASSERT_TRUE(MaskAllOnes.test(I));
+  }
+}
+
+TEST_P(SubGroupMask, All) {
+  ASSERT_FALSE(MaskZero.all());
+  ASSERT_FALSE(MaskOne.all());
+  ASSERT_TRUE(MaskAllOnes.all());
+}
+
+TEST_P(SubGroupMask, Any) {
+  ASSERT_FALSE(MaskZero.any());
+  ASSERT_TRUE(MaskOne.any());
+  ASSERT_TRUE(MaskAllOnes.any());
+}
+
+TEST_P(SubGroupMask, None) {
+  ASSERT_TRUE(MaskZero.none());
+  ASSERT_FALSE(MaskOne.none());
+  ASSERT_FALSE(MaskAllOnes.none());
+}
+
+TEST_P(SubGroupMask, Count) {
+  ASSERT_EQ(MaskZero.count(), 0u);
+  ASSERT_EQ(MaskOne.count(), 1u);
+  ASSERT_EQ(MaskAllOnes.count(), GetParam());
+}
+
+TEST_P(SubGroupMask, Size) {
+  ASSERT_EQ(MaskZero.size(), GetParam());
+  ASSERT_EQ(MaskOne.size(), GetParam());
+  ASSERT_EQ(MaskAllOnes.size(), GetParam());
+}
+
+TEST_P(SubGroupMask, SetAll) {
+  MaskZero.set();
+  ASSERT_TRUE(MaskZero.all());
+  MaskOne.set();
+  ASSERT_TRUE(MaskOne.all());
+}
+
+TEST_P(SubGroupMask, Set) {
+  MaskZero.set(GetParam() / 2);
+  ASSERT_TRUE(MaskZero[GetParam() / 2]);
+  MaskOne.set(0, false);
+  ASSERT_FALSE(MaskOne[0]);
+}
+
+TEST_P(SubGroupMask, ResetAll) {
+  MaskOne.reset();
+  ASSERT_TRUE(MaskOne.none());
+  MaskAllOnes.reset();
+  ASSERT_TRUE(MaskAllOnes.none());
+}
+
+TEST_P(SubGroupMask, Reset) {
+  MaskOne.reset(0);
+  ASSERT_FALSE(MaskOne[0]);
+  MaskAllOnes.reset(GetParam() / 2);
+  ASSERT_FALSE(MaskAllOnes[GetParam() / 2]);
+}
+
+TEST_P(SubGroupMask, FlipAll) {
+  MaskZero.flip();
+  ASSERT_TRUE(MaskZero.all());
+  MaskAllOnes.flip();
+  ASSERT_TRUE(MaskAllOnes.none());
+  MaskOne.flip();
+  ASSERT_FALSE(MaskOne[0]);
+  for (size_t I = 1; I < GetParam(); ++I) {
+    ASSERT_TRUE(MaskOne[I]);
+  }
+}
+
+TEST_P(SubGroupMask, Flip) {
+  MaskZero.flip(GetParam() / 2);
+  ASSERT_TRUE(MaskZero[GetParam() / 2]);
+  MaskOne.flip(0);
+  ASSERT_FALSE(MaskOne[0]);
+}
+
+TEST_P(SubGroupMask, FindLow) {
+  ASSERT_EQ(MaskZero.find_low(), GetParam());
+  ASSERT_EQ(MaskOne.find_low(), 0u);
+  ASSERT_EQ(MaskAllOnes.find_low(), 0u);
+}
+
+TEST_P(SubGroupMask, FindHigh) {
+  ASSERT_EQ(MaskZero.find_high(), GetParam());
+  ASSERT_EQ(MaskOne.find_high(), 0u);
+  ASSERT_EQ(MaskAllOnes.find_high(), GetParam() - 1u);
+}
+
+TEST_P(SubGroupMask, ResetLow) {
+  MaskAllOnes.reset_low();
+  ASSERT_FALSE(MaskAllOnes[0]);
+
+  MaskOne.flip();
+  MaskOne.reset_low();
+  ASSERT_FALSE(MaskOne[1]);
+}
+
+TEST_P(SubGroupMask, ResetHigh) {
+  MaskOne.reset_high();
+  ASSERT_FALSE(MaskOne[0]);
+  MaskAllOnes.reset_high();
+  ASSERT_FALSE(MaskAllOnes[GetParam() - 1u]);
+}
+
+TEST_P(SubGroupMask, OperatorEq) {
+  ASSERT_FALSE(MaskZero == MaskAllOnes);
+  MaskZero.flip();
+  ASSERT_TRUE(MaskZero == MaskAllOnes);
+}
+
+TEST_P(SubGroupMask, OperatorNeq) {
+  ASSERT_TRUE(MaskZero != MaskAllOnes);
+  MaskZero.flip();
+  ASSERT_FALSE(MaskZero != MaskAllOnes);
+}
+
+TEST_P(SubGroupMask, OperatorAndEq) {
+  MaskZero &= MaskOne;
+  ASSERT_TRUE(MaskZero.none());
+  MaskAllOnes &= MaskOne;
+  ASSERT_EQ(MaskAllOnes, MaskOne);
+}
+
+TEST_P(SubGroupMask, OperatorOrEq) {
+  MaskZero |= MaskOne;
+  ASSERT_EQ(MaskZero, MaskOne);
+  MaskAllOnes |= MaskOne;
+  ASSERT_TRUE(MaskAllOnes.all());
+}
+
+TEST_P(SubGroupMask, OperatorXorEq) {
+  MaskZero ^= MaskOne;
+  ASSERT_EQ(MaskZero, MaskOne);
+  MaskOne ^= MaskAllOnes;
+  ASSERT_FALSE(MaskOne[0]);
+  for (size_t I = 1; I < GetParam(); ++I) {
+    ASSERT_TRUE(MaskOne[I]);
+  }
+}
+
+TEST_P(SubGroupMask, OperatorShiftLeftEq) {
+  size_t Shift = GetParam() / 2;
+  MaskAllOnes <<= Shift;
+  ASSERT_EQ(MaskAllOnes.find_low(), Shift);
+  MaskAllOnes.flip();
+  ASSERT_EQ(MaskAllOnes.find_high(), Shift - 1);
+
+  MaskOne <<= Shift;
+  ASSERT_EQ(MaskOne.find_high(), MaskOne.find_low());
+  ASSERT_TRUE(MaskOne[Shift]);
+}
+
+TEST_P(SubGroupMask, OperationShiftRightEq) {
+  size_t Shift = GetParam() / 2;
+  MaskAllOnes >>= Shift;
+  ASSERT_EQ(MaskAllOnes.find_high(), Shift - 1);
+  MaskAllOnes.flip();
+  ASSERT_EQ(MaskAllOnes.find_low(), Shift);
+
+  MaskOne >>= Shift;
+  ASSERT_TRUE(MaskOne.none());
+}
+
+TEST_P(SubGroupMask, OperatorShiftLeft) {
+  size_t Shift = GetParam() / 2;
+  auto Mask = MaskAllOnes << Shift;
+  ASSERT_EQ(Mask.find_low(), Shift);
+  Mask.flip();
+  ASSERT_EQ(Mask.find_high(), Shift - 1);
+
+  Mask = MaskOne <<= Shift;
+  ASSERT_EQ(Mask.find_high(), Mask.find_low());
+  ASSERT_TRUE(Mask[Shift]);
+}
+
+TEST_P(SubGroupMask, OperatorShiftRight) {
+  size_t Shift = GetParam() / 2;
+  auto Mask = MaskAllOnes >> Shift;
+  ASSERT_EQ(Mask.find_high(), Shift - 1);
+  Mask.flip();
+  ASSERT_EQ(Mask.find_low(), Shift);
+
+  Mask = MaskOne >> Shift;
+  ASSERT_TRUE(Mask.none());
+}
+
+TEST_P(SubGroupMask, OperatorBitwiseNot) {
+  ASSERT_EQ(~MaskZero, MaskAllOnes);
+  ASSERT_EQ(MaskZero, ~MaskAllOnes);
+}
+
+TEST_P(SubGroupMask, OperatorAnd) {
+  auto Mask = MaskOne & MaskAllOnes;
+  ASSERT_EQ(Mask, MaskOne);
+  Mask = MaskZero & MaskAllOnes;
+  ASSERT_EQ(Mask, MaskZero);
+}
+
+TEST_P(SubGroupMask, OperatorOr) {
+  auto Mask = MaskZero | MaskOne;
+  ASSERT_EQ(Mask, MaskOne);
+  Mask = MaskOne | MaskAllOnes;
+  ASSERT_EQ(Mask, MaskAllOnes);
+}
+
+TEST_P(SubGroupMask, OperatorXor) {
+  auto Mask = MaskZero ^ MaskOne;
+  ASSERT_EQ(Mask, MaskOne);
+  Mask = MaskOne ^ MaskAllOnes;
+  ASSERT_FALSE(Mask[0]);
+  for (size_t I = 1; I < GetParam(); ++I) {
+    ASSERT_TRUE(Mask[I]);
+  }
+}
+
+TEST_P(SubGroupMask, InsertBitsIntegral) {
+  uint8_t Bits = -1;
+  size_t Pos = GetParam() / 2u;
+  MaskZero.insert_bits(Bits, Pos);
+  for (size_t I = 0; I < Pos; ++I) {
+    ASSERT_FALSE(MaskZero[I]);
+  }
+  size_t End = std::min(static_cast<size_t>(MaskZero.size()),
+                        Pos + sizeof(Bits) * CHAR_BIT);
+  for (size_t I = Pos; I < End; ++I) {
+    ASSERT_TRUE(MaskZero[I]);
+  }
+  for (size_t I = End; I < MaskZero.size(); ++I) {
+    ASSERT_FALSE(MaskZero[I]);
+  }
+}
+
+TEST_P(SubGroupMask, ExtractBitsIntegral) {
+  uint8_t Bits = 0;
+  size_t Pos = GetParam() / 2u;
+  MaskAllOnes.extract_bits(Bits, Pos);
+  size_t Mid = std::min(sizeof(Bits) * CHAR_BIT,
+                        static_cast<size_t>(MaskAllOnes.size()) - Pos);
+
+  for (size_t I = 0; I < Mid; ++I) {
+    ASSERT_TRUE((Bits >> I) & 1u);
+  }
+  for (size_t I = Mid; I < sizeof(Bits) * CHAR_BIT; ++I) {
+    ASSERT_FALSE((Bits >> I) & 1u);
+  }
+}
+
+TEST_P(SubGroupMask, InsertBitsMarray) {
+  sycl::marray<uint8_t, 2> Bits(-1);
+  size_t Pos = GetParam() / 2u;
+  MaskZero.insert_bits(Bits, Pos);
+  for (size_t I = 0; I < Pos; ++I) {
+    ASSERT_FALSE(MaskZero[I]);
+  }
+  size_t End = std::min(static_cast<size_t>(MaskZero.size()),
+                        Pos + Bits.size() * CHAR_BIT);
+  for (size_t I = Pos; I < End; ++I) {
+    ASSERT_TRUE(MaskZero[I]);
+  }
+  for (size_t I = End; I < MaskZero.size(); ++I) {
+    ASSERT_FALSE(MaskZero[I]);
+  }
+}
+
+TEST_P(SubGroupMask, ExtractBitsMarray) {
+  sycl::marray<uint8_t, 2> Bits(0);
+  size_t Pos = GetParam() / 2u;
+  MaskAllOnes.extract_bits(Bits, Pos);
+  size_t Mid = std::min(Bits.size() * CHAR_BIT,
+                        static_cast<size_t>(MaskAllOnes.size()) - Pos);
+
+  auto BitsToCheck = *reinterpret_cast<uint16_t *>(Bits.begin());
+  for (size_t I = 0; I < Mid; ++I) {
+    ASSERT_TRUE((BitsToCheck >> I) & 1u);
+  }
+  for (size_t I = Mid; I < sizeof(Bits) * CHAR_BIT; ++I) {
+    ASSERT_FALSE((BitsToCheck >> I) & 1u);
+  }
+}
+
+// TODO: sub_group_mask::reference tests
+// There is an extension spec update happening in intel/llvm#8174
+// TODO: update tests for revision 2 of the extension spec once it is supported
+
+INSTANTIATE_TEST_SUITE_P(OneAPI, SubGroupMask, testing::Values(32, 16, 8));


### PR DESCRIPTION
Existing LIT test turned into compile-only test which checks interface of `sub_group_mask` class.
New unit-test added to test behavior of `sub_group_mask` class.