### PR TITLE
[SYCL-MLIR] Enable raise to affine by default

### DIFF
--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -113,7 +113,7 @@ static llvm::cl::opt<bool> ShowAST("show-ast", llvm::cl::init(false),
                                    llvm::cl::desc("Show AST"));
 
 static llvm::cl::opt<bool> RaiseToAffine("raise-scf-to-affine",
-                                         llvm::cl::init(false),
+                                         llvm::cl::init(true),
                                          llvm::cl::desc("Raise SCF to Affine"));
 
 static llvm::cl::opt<bool>

--- a/polygeist/tools/cgeist/Test/Verification/arrayconsllvm.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/arrayconsllvm.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
 
 struct AIntDivider {
     AIntDivider() : divisor(3) {}

--- a/polygeist/tools/cgeist/Test/Verification/arrayconsmemref.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/arrayconsmemref.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 -w %s --function=* -S | FileCheck %s
+// RUN: cgeist -O0 -w %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
 
 struct AIntDivider {
     AIntDivider() : divisor(3) {}

--- a/polygeist/tools/cgeist/Test/Verification/arrayconsmemrefinner.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/arrayconsmemrefinner.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 -w %s --function=* -S | FileCheck %s
+// RUN: cgeist -O0 -w %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
 
 struct AIntDivider {
     AIntDivider() : divisor(3) {}

--- a/polygeist/tools/cgeist/Test/Verification/calloc.c
+++ b/polygeist/tools/cgeist/Test/Verification/calloc.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
 
 void* calloc(unsigned long a, unsigned long b);
 

--- a/polygeist/tools/cgeist/Test/Verification/canonicalization.c
+++ b/polygeist/tools/cgeist/Test/Verification/canonicalization.c
@@ -1,4 +1,4 @@
-// RUN: cgeist --S -O2 --function=* --memref-fullrank %s | FileCheck %s
+// RUN: cgeist --S -O2 --function=* --memref-fullrank %s --raise-scf-to-affine=false | FileCheck %s
 
 // The following should be able to fully lower to memref ops without memref
 // subviews.

--- a/polygeist/tools/cgeist/Test/Verification/constexpr.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/constexpr.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
 constexpr int num = 10 + 4;
 
 int sum(int*);

--- a/polygeist/tools/cgeist/Test/Verification/continue.c
+++ b/polygeist/tools/cgeist/Test/Verification/continue.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
 
 int get();
 void other();

--- a/polygeist/tools/cgeist/Test/Verification/fscanf.c
+++ b/polygeist/tools/cgeist/Test/Verification/fscanf.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O2 %stdinclude --function=alloc -S | FileCheck %s
+// RUN: cgeist %s -O2 %stdinclude --function=alloc -S --raise-scf-to-affine=false | FileCheck %s
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/polygeist/tools/cgeist/Test/Verification/hist.c
+++ b/polygeist/tools/cgeist/Test/Verification/hist.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
+// RUN: cgeist %s -O2 --function=* -S --raise-scf-to-affine=false | FileCheck %s
 
 void histo_kernel(int i);
 

--- a/polygeist/tools/cgeist/Test/Verification/label.c
+++ b/polygeist/tools/cgeist/Test/Verification/label.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
 
 int fir (int d_i[1000], int idx[1000] ) {
 	int i;

--- a/polygeist/tools/cgeist/Test/Verification/multidim_init.c
+++ b/polygeist/tools/cgeist/Test/Verification/multidim_init.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -S --function=* | FileCheck %s
+// RUN: cgeist %s -S --function=* --raise-scf-to-affine=false | FileCheck %s
 
   float glob_A[][4] = {
       {1.0f, 2.0, 3.0, 4.0}, 

--- a/polygeist/tools/cgeist/Test/Verification/nestloop.c
+++ b/polygeist/tools/cgeist/Test/Verification/nestloop.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s %stdinclude --function=init_array -S | FileCheck %s
-// RUN: cgeist %s %stdinclude --function=init_array -S -memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist %s %stdinclude --function=init_array -S --raise-scf-to-affine=false | FileCheck %s
+// RUN: cgeist %s %stdinclude --function=init_array -S -memref-fullrank --raise-scf-to-affine=false | FileCheck %s --check-prefix=FULLRANK
 
 #include <stdio.h>
 #include <unistd.h>

--- a/polygeist/tools/cgeist/Test/Verification/omp3.c
+++ b/polygeist/tools/cgeist/Test/Verification/omp3.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -fopenmp -S | FileCheck %s
+// RUN: cgeist %s --function=* -fopenmp -S --raise-scf-to-affine=false | FileCheck %s
 
 void square(double* x) {
     int i;

--- a/polygeist/tools/cgeist/Test/Verification/omp4.c
+++ b/polygeist/tools/cgeist/Test/Verification/omp4.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -fopenmp -S | FileCheck %s
+// RUN: cgeist %s --function=* -fopenmp -S --raise-scf-to-affine=false | FileCheck %s
 
 int get(int);
 void square(double* x, int ss) {

--- a/polygeist/tools/cgeist/Test/Verification/omp5.c
+++ b/polygeist/tools/cgeist/Test/Verification/omp5.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -fopenmp -S | FileCheck %s
+// RUN: cgeist %s --function=* -fopenmp -S --raise-scf-to-affine=false | FileCheck %s
 
 void square(double* x, int sstart, int send, int sinc) {
     #pragma omp parallel for

--- a/polygeist/tools/cgeist/Test/Verification/sycl/structvec.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/structvec.cpp
@@ -79,23 +79,20 @@ SYCL_EXTERNAL structvec test_store(structvec sv, int idx, char el) {
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: func.func @_ZN9structvecC1ESt16initializer_listIcE(%arg0: !llvm.ptr<struct<(vector<2xi8>)>, 4> {llvm.align = 2 : i64, llvm.dereferenceable_or_null = 2 : i64, llvm.noundef}, %arg1: !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>> {llvm.align = 8 : i64, llvm.byval = !llvm.struct<(memref<?xi8, 4>, i64)>, llvm.noundef})
-// CHECK-DAG:     %c2 = arith.constant 2 : index
-// CHECK-DAG:     %c0 = arith.constant 0 : index
-// CHECK-DAG:     %c1 = arith.constant 1 : index
-// CHECK-DAG:     %c0_i8 = arith.constant 0 : i8
-// CHECK-NEXT:    scf.for %arg2 = %c0 to %c2 step %c1 {
-// CHECK-NEXT:      %0 = arith.index_cast %arg2 : index to i32
-// CHECK-NEXT:      %1 = llvm.addrspacecast %arg1 : !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>> to !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>, 4>
-// CHECK-NEXT:      %2 = func.call @_ZNKSt16initializer_listIcE5beginEv(%1) : (!llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>, 4>) -> memref<?xi8, 4>
-// CHECK-NEXT:      %3 = arith.index_castui %0 : i32 to index
-// CHECK-NEXT:      %4 = memref.load %2[%3] : memref<?xi8, 4>
-// CHECK-NEXT:      %5 = arith.cmpi ne, %4, %c0_i8 : i8
-// CHECK-NEXT:      %6 = arith.extui %5 : i1 to i32
-// CHECK-NEXT:      %7 = arith.trunci %6 : i32 to i8
-// CHECK-NEXT:      %8 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(vector<2xi8>)>, 4>) -> !llvm.ptr<vector<2xi8>, 4>
-// CHECK-NEXT:      %9 = llvm.load %8 : !llvm.ptr<vector<2xi8>, 4>
-// CHECK-NEXT:      %10 = vector.insertelement %7, %9[%0 : i32] : vector<2xi8>
-// CHECK-NEXT:      llvm.store %10, %8 : !llvm.ptr<vector<2xi8>, 4>
+// CHECK-NEXT:    %c0_i8 = arith.constant 0 : i8
+// CHECK-NEXT:    %0 = llvm.addrspacecast %arg1 : !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>> to !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>, 4>
+// CHECK-NEXT:    %1 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(vector<2xi8>)>, 4>) -> !llvm.ptr<vector<2xi8>, 4>
+// CHECK-NEXT:    affine.for %arg2 = 0 to 2 {
+// CHECK-NEXT:      %2 = arith.index_cast %arg2 : index to i32
+// CHECK-NEXT:      %3 = func.call @_ZNKSt16initializer_listIcE5beginEv(%0) : (!llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>, 4>) -> memref<?xi8, 4>
+// CHECK-NEXT:      %4 = arith.index_castui %2 : i32 to index
+// CHECK-NEXT:      %5 = memref.load %3[%4] : memref<?xi8, 4>
+// CHECK-NEXT:      %6 = arith.cmpi ne, %5, %c0_i8 : i8
+// CHECK-NEXT:      %7 = arith.extui %6 : i1 to i32
+// CHECK-NEXT:      %8 = arith.trunci %7 : i32 to i8
+// CHECK-NEXT:      %9 = llvm.load %1 : !llvm.ptr<vector<2xi8>, 4>
+// CHECK-NEXT:      %10 = vector.insertelement %8, %9[%2 : i32] : vector<2xi8>
+// CHECK-NEXT:      llvm.store %10, %1 : !llvm.ptr<vector<2xi8>, 4>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }

--- a/polygeist/tools/cgeist/Test/Verification/whiletofor.c
+++ b/polygeist/tools/cgeist/Test/Verification/whiletofor.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s -O2 --function=whiletofor -S | FileCheck %s
-// RUN: cgeist %s -O2 --function=whiletofor -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist %s -O2 --function=whiletofor -S --raise-scf-to-affine=false | FileCheck %s
+// RUN: cgeist %s -O2 --function=whiletofor -S --memref-fullrank --raise-scf-to-affine=false | FileCheck %s --check-prefix=FULLRANK
 
 void use(int a[100][100]);
 

--- a/polygeist/tools/cgeist/Test/Verification/xor.c
+++ b/polygeist/tools/cgeist/Test/Verification/xor.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+// RUN: cgeist -O0 %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
 
 typedef char char_vec __attribute__((ext_vector_type(3)));
 typedef short short_vec __attribute__((ext_vector_type(3)));


### PR DESCRIPTION
We want to enable `-raise-scf-to-affine` by default, so we can run affine optimizations.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>