### PR TITLE
Revert "[SYCL] Refactor program build and cache"

### DIFF
--- a/sycl/source/detail/kernel_program_cache.cpp
+++ b/sycl/source/detail/kernel_program_cache.cpp
@@ -14,7 +14,7 @@ namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace detail {
 KernelProgramCache::~KernelProgramCache() {
-  for (auto &ProgIt : MCachedPrograms.Cache) {
+  for (auto &ProgIt : MCachedPrograms) {
     ProgramWithBuildStateT &ProgWithState = ProgIt.second;
     PiProgramT *ToBeDeleted = ProgWithState.Ptr.load();
 

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -39,16 +39,13 @@ public:
     bool isFilledIn() const { return !Msg.empty(); }
   };
 
-  /// Denotes the state of a build.
-  enum BuildState { BS_InProgress, BS_Done, BS_Failed };
-
   /// Denotes pointer to some entity with its general state and build error.
   /// The pointer is not null if and only if the entity is usable.
   /// State of the entity is provided by the user of cache instance.
   /// Currently there is only a single user - ProgramManager class.
   template <typename T> struct BuildResult {
     std::atomic<T *> Ptr;
-    std::atomic<BuildState> State;
+    std::atomic<int> State;
     BuildError Error;
 
     /// Condition variable to signal that build result is ready.
@@ -65,7 +62,7 @@ public:
     /// A mutex to be employed along with MBuildCV.
     std::mutex MBuildResultMutex;
 
-    BuildResult(T *P, BuildState S) : Ptr{P}, State{S}, Error{"", 0} {}
+    BuildResult(T *P, int S) : Ptr{P}, State{S}, Error{"", 0} {}
   };
 
   using PiProgramT = std::remove_pointer<RT::PiProgram>::type;
@@ -73,15 +70,7 @@ public:
   using ProgramWithBuildStateT = BuildResult<PiProgramT>;
   using ProgramCacheKeyT = std::pair<std::pair<SerializedObj, std::uintptr_t>,
                                      std::pair<RT::PiDevice, std::string>>;
-  using CommonProgramKeyT = std::pair<std::uintptr_t, RT::PiDevice>;
-
-  struct ProgramCache {
-    std::map<ProgramCacheKeyT, ProgramWithBuildStateT> Cache;
-    std::multimap<CommonProgramKeyT, ProgramCacheKeyT> KeyMap;
-
-    size_t size() const noexcept { return Cache.size(); }
-  };
-
+  using ProgramCacheT = std::map<ProgramCacheKeyT, ProgramWithBuildStateT>;
   using ContextPtr = context_impl *;
 
   using PiKernelT = std::remove_pointer<RT::PiKernel>::type;
@@ -102,7 +91,7 @@ public:
 
   void setContextPtr(const ContextPtr &AContext) { MParentContext = AContext; }
 
-  Locked<ProgramCache> acquireCachedPrograms() {
+  Locked<ProgramCacheT> acquireCachedPrograms() {
     return {MCachedPrograms, MProgramCacheMutex};
   }
 
@@ -110,56 +99,11 @@ public:
     return {MKernelsPerProgramCache, MKernelsPerProgramCacheMutex};
   }
 
-  std::pair<ProgramWithBuildStateT *, bool>
-  getOrInsertProgram(const ProgramCacheKeyT &CacheKey) {
-    auto LockedCache = acquireCachedPrograms();
-    auto &ProgCache = LockedCache.get();
-    auto Inserted = ProgCache.Cache.emplace(
-        std::piecewise_construct, std::forward_as_tuple(CacheKey),
-        std::forward_as_tuple(nullptr, BS_InProgress));
-    if (Inserted.second) {
-      // Save reference between the common key and the full key.
-      CommonProgramKeyT CommonKey =
-          std::make_pair(CacheKey.first.second, CacheKey.second.first);
-      ProgCache.KeyMap.emplace(std::piecewise_construct,
-                               std::forward_as_tuple(CommonKey),
-                               std::forward_as_tuple(CacheKey));
-    }
-    return std::make_pair(&Inserted.first->second, Inserted.second);
-  }
-
-  std::pair<KernelWithBuildStateT *, bool>
-  getOrInsertKernel(RT::PiProgram Program, const std::string &KernelName) {
-    auto LockedCache = acquireKernelsPerProgramCache();
-    auto &Cache = LockedCache.get()[Program];
-    auto Inserted = Cache.emplace(
-        std::piecewise_construct, std::forward_as_tuple(KernelName),
-        std::forward_as_tuple(nullptr, BS_InProgress));
-    return std::make_pair(&Inserted.first->second, Inserted.second);
-  }
-
   template <typename T, class Predicate>
   void waitUntilBuilt(BuildResult<T> &BR, Predicate Pred) const {
     std::unique_lock<std::mutex> Lock(BR.MBuildResultMutex);
 
     BR.MBuildCV.wait(Lock, Pred);
-  }
-
-  template <typename ExceptionT, typename RetT>
-  RetT *waitUntilBuilt(BuildResult<RetT> *BuildResult) {
-    // Any thread which will find nullptr in cache will wait until the pointer
-    // is not null anymore.
-    waitUntilBuilt(*BuildResult, [BuildResult]() {
-      int State = BuildResult->State.load();
-      return State == BuildState::BS_Done || State == BuildState::BS_Failed;
-    });
-
-    if (BuildResult->Error.isFilledIn()) {
-      const BuildError &Error = BuildResult->Error;
-      throw ExceptionT(Error.Msg, Error.Code);
-    }
-
-    return BuildResult->Ptr.load();
   }
 
   template <typename T> void notifyAllBuild(BuildResult<T> &BR) const {
@@ -188,7 +132,7 @@ public:
   ///
   /// This member function should only be used in unit tests.
   void reset() {
-    MCachedPrograms = ProgramCache{};
+    MCachedPrograms = ProgramCacheT{};
     MKernelsPerProgramCache = KernelCacheT{};
     MKernelFastCache = KernelFastCacheT{};
   }
@@ -197,7 +141,7 @@ private:
   std::mutex MProgramCacheMutex;
   std::mutex MKernelsPerProgramCacheMutex;
 
-  ProgramCache MCachedPrograms;
+  ProgramCacheT MCachedPrograms;
   KernelCacheT MKernelsPerProgramCache;
   ContextPtr MParentContext;
 

--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -130,7 +130,7 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_ProgramSourceNegativeBuild) {
 
   //   Prg.build_with_source("");
   auto CtxImpl = detail::getSyclObjImpl(Ctx);
-  detail::KernelProgramCache::ProgramCache &Cache =
+  detail::KernelProgramCache::ProgramCacheT &Cache =
       CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for source programs";
 }
@@ -142,7 +142,7 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_ProgramSourceNegativeBuildWithOpts) {
 
   //   Prg.build_with_source("", "-g");
   auto CtxImpl = detail::getSyclObjImpl(Ctx);
-  detail::KernelProgramCache::ProgramCache &Cache =
+  detail::KernelProgramCache::ProgramCacheT &Cache =
       CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for source programs";
 }
@@ -156,7 +156,7 @@ TEST_F(KernelAndProgramCacheTest,
   //   Prg.compile_with_source("");
   //   Prg.link();
   auto CtxImpl = detail::getSyclObjImpl(Ctx);
-  detail::KernelProgramCache::ProgramCache &Cache =
+  detail::KernelProgramCache::ProgramCacheT &Cache =
       CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for source programs";
 }
@@ -171,7 +171,7 @@ TEST_F(KernelAndProgramCacheTest,
   //   Prg.compile_with_source("");
   //   Prg.link();
   auto CtxImpl = detail::getSyclObjImpl(Ctx);
-  detail::KernelProgramCache::ProgramCache &Cache =
+  detail::KernelProgramCache::ProgramCacheT &Cache =
       CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for source programs";
 }
@@ -186,7 +186,7 @@ TEST_F(KernelAndProgramCacheTest, KernelBundleInputState) {
       sycl::get_kernel_bundle<sycl::bundle_state::input>(Ctx, {KernelID1});
 
   auto CtxImpl = detail::getSyclObjImpl(Ctx);
-  detail::KernelProgramCache::ProgramCache &Cache =
+  detail::KernelProgramCache::ProgramCacheT &Cache =
       CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
 
   EXPECT_EQ(Cache.size(), 0U)
@@ -303,7 +303,7 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_ProgramBuildPositiveBuildOpts) {
   //   Prg5.build_with_kernel_type<CacheTestKernel2>("-a");
 
   auto CtxImpl = detail::getSyclObjImpl(Ctx);
-  detail::KernelProgramCache::ProgramCache &Cache =
+  detail::KernelProgramCache::ProgramCacheT &Cache =
       CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 3U) << "Expect non-empty cache for programs";
 }
@@ -316,7 +316,7 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_ProgramBuildNegativeCompileOpts) {
   //   Prg.compile_with_kernel_type<CacheTestKernel>("-g");
   //   Prg.link();
   auto CtxImpl = detail::getSyclObjImpl(Ctx);
-  detail::KernelProgramCache::ProgramCache &Cache =
+  detail::KernelProgramCache::ProgramCacheT &Cache =
       CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for programs";
 }
@@ -329,7 +329,7 @@ TEST_F(KernelAndProgramCacheTest, DISABLED_ProgramBuildNegativeLinkOpts) {
   //   Prg.compile_with_kernel_type<CacheTestKernel>();
   //   Prg.link("-g");
   auto CtxImpl = detail::getSyclObjImpl(Ctx);
-  detail::KernelProgramCache::ProgramCache &Cache =
+  detail::KernelProgramCache::ProgramCacheT &Cache =
       CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
   EXPECT_EQ(Cache.size(), 0U) << "Expect empty cache for programs";
 }


### PR DESCRIPTION
Reverts intel/llvm#8104

This commit breaks the build.
See https://github.com/intel/llvm/actions/runs/4080648773 for the details.