### PR TITLE
[SYCL][Clang] Fix annotations applied to integer fields

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -2789,18 +2789,20 @@ Address CodeGenFunction::EmitFieldAnnotations(const FieldDecl *D,
   llvm::PointerType *IntrinTy =
       llvm::PointerType::getWithSamePointeeType(CGM.Int8PtrTy, AS);
 
-  llvm::Function *F = CGM.getIntrinsic(llvm::Intrinsic::ptr_annotation,
-                                       {IntrinTy, CGM.ConstGlobalsPtrTy});
-
   // llvm.ptr.annotation intrinsic accepts a pointer to integer of any width -
   // don't perform bitcasts if value is integer
   if (Addr.getElementType()->isIntegerTy()) {
+    llvm::Function *F = CGM.getIntrinsic(llvm::Intrinsic::ptr_annotation,
+                                         {VTy, CGM.ConstGlobalsPtrTy});
 
     for (const auto *I : D->specific_attrs<AnnotateAttr>())
       V = EmitAnnotationCall(F, V, I->getAnnotation(), D->getLocation(), I);
 
     return Address(V, Addr.getElementType(), Addr.getAlignment());
   }
+
+  llvm::Function *F = CGM.getIntrinsic(llvm::Intrinsic::ptr_annotation,
+                                       {IntrinTy, CGM.ConstGlobalsPtrTy});
 
   for (const auto *I : D->specific_attrs<AnnotateAttr>()) {
     V = Builder.CreateBitCast(V, IntrinTy);

--- a/clang/test/CodeGenSYCL/annotations-field-no-opaque.cpp
+++ b/clang/test/CodeGenSYCL/annotations-field-no-opaque.cpp
@@ -1,0 +1,34 @@
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -emit-llvm -no-opaque-pointers -o - %s | FileCheck %s
+
+// CHECK: private unnamed_addr addrspace(1) constant [8 x i8] c"v_ann_{{.}}\00", section "llvm.metadata"
+// CHECK: private unnamed_addr addrspace(1) constant [8 x i8] c"v_ann_{{.}}\00", section "llvm.metadata"
+// CHECK: private unnamed_addr addrspace(1) constant [8 x i8] c"w_ann_{{.}}\00", section "llvm.metadata"
+// CHECK: private unnamed_addr addrspace(1) constant [8 x i8] c"w_ann_{{.}}\00", section "llvm.metadata"
+// CHECK: private unnamed_addr addrspace(1) constant [8 x i8] c"f_ann_{{.}}\00", section "llvm.metadata"
+// CHECK: private unnamed_addr addrspace(1) constant [8 x i8] c"f_ann_{{.}}\00", section "llvm.metadata"
+
+struct foo {
+    int v __attribute__((annotate("v_ann_0"))) __attribute__((annotate("v_ann_1")));
+    char w __attribute__((annotate("w_ann_0"))) __attribute__((annotate("w_ann_1")));
+    float f __attribute__((annotate("f_ann_0"))) __attribute__((annotate("f_ann_1")));
+};
+
+int __attribute__((sycl_device)) foo() {
+    struct foo f;
+    f.v = 1;
+// CHECK: getelementptr inbounds %struct.foo, %struct.foo addrspace(4)* %{{.*}}, i32 0, i32 0
+// CHECK-NEXT: call i32 addrspace(4)* @llvm.ptr.annotation.p4i32.p1i8({{.*}}str{{.*}}str{{.*}}i32 11, i8 addrspace(1)* null)
+// CHECK-NEXT: call i32 addrspace(4)* @llvm.ptr.annotation.p4i32.p1i8({{.*}}str{{.*}}str{{.*}}i32 11, i8 addrspace(1)* null)
+    f.w = 42;
+// CHECK: getelementptr inbounds %struct.foo, %struct.foo addrspace(4)* %{{.*}}, i32 0, i32 1
+// CHECK-NEXT: call i8 addrspace(4)* @llvm.ptr.annotation.p4i8.p1i8({{.*}}str{{.*}}str{{.*}}i32 12, i8 addrspace(1)* null)
+// CHECK-NEXT: call i8 addrspace(4)* @llvm.ptr.annotation.p4i8.p1i8({{.*}}str{{.*}}str{{.*}}i32 12, i8 addrspace(1)* null)
+    f.f = 0;
+// CHECK: getelementptr inbounds %struct.foo, %struct.foo addrspace(4)* %{{.*}}, i32 0, i32 2
+// CHECK-NEXT: bitcast float addrspace(4)* %{{.*}} to i8 addrspace(4)*
+// CHECK-NEXT: call i8 addrspace(4)* @llvm.ptr.annotation.p4i8.p1i8({{.*}}str{{.*}}str{{.*}}i32 13, i8 addrspace(1)* null)
+// CHECK-NEXT: bitcast i8 addrspace(4)* %{{.*}} to float addrspace(4)*
+// CHECK-NEXT: bitcast float addrspace(4)* %{{.*}} to i8 addrspace(4)*
+// CHECK-NEXT: call i8 addrspace(4)* @llvm.ptr.annotation.p4i8.p1i8({{.*}}str{{.*}}str{{.*}}i32 13, i8 addrspace(1)* null)
+    return 0;
+}

--- a/clang/test/CodeGenSYCL/annotations-field-no-opaque.cpp
+++ b/clang/test/CodeGenSYCL/annotations-field-no-opaque.cpp
@@ -20,18 +20,18 @@ int __attribute__((sycl_device)) foo() {
     struct foo f;
     f.v = 1;
 // CHECK: getelementptr inbounds %struct.foo, %struct.foo addrspace(4)* %{{.*}}, i32 0, i32 0
-// CHECK-NEXT: call i32 addrspace(4)* @llvm.ptr.annotation.p4i32.p1i8({{.*}}str{{.*}}str{{.*}}i32 11, i8 addrspace(1)* null)
-// CHECK-NEXT: call i32 addrspace(4)* @llvm.ptr.annotation.p4i32.p1i8({{.*}}str{{.*}}str{{.*}}i32 11, i8 addrspace(1)* null)
+// CHECK-NEXT: call i32 addrspace(4)* @llvm.ptr.annotation.p4i32.p1i8({{.*}}str{{.*}}str{{.*}}i32 14, i8 addrspace(1)* null)
+// CHECK-NEXT: call i32 addrspace(4)* @llvm.ptr.annotation.p4i32.p1i8({{.*}}str{{.*}}str{{.*}}i32 14, i8 addrspace(1)* null)
     f.w = 42;
 // CHECK: getelementptr inbounds %struct.foo, %struct.foo addrspace(4)* %{{.*}}, i32 0, i32 1
-// CHECK-NEXT: call i8 addrspace(4)* @llvm.ptr.annotation.p4i8.p1i8({{.*}}str{{.*}}str{{.*}}i32 12, i8 addrspace(1)* null)
-// CHECK-NEXT: call i8 addrspace(4)* @llvm.ptr.annotation.p4i8.p1i8({{.*}}str{{.*}}str{{.*}}i32 12, i8 addrspace(1)* null)
+// CHECK-NEXT: call i8 addrspace(4)* @llvm.ptr.annotation.p4i8.p1i8({{.*}}str{{.*}}str{{.*}}i32 15, i8 addrspace(1)* null)
+// CHECK-NEXT: call i8 addrspace(4)* @llvm.ptr.annotation.p4i8.p1i8({{.*}}str{{.*}}str{{.*}}i32 15, i8 addrspace(1)* null)
     f.f = 0;
 // CHECK: getelementptr inbounds %struct.foo, %struct.foo addrspace(4)* %{{.*}}, i32 0, i32 2
 // CHECK-NEXT: bitcast float addrspace(4)* %{{.*}} to i8 addrspace(4)*
-// CHECK-NEXT: call i8 addrspace(4)* @llvm.ptr.annotation.p4i8.p1i8({{.*}}str{{.*}}str{{.*}}i32 13, i8 addrspace(1)* null)
+// CHECK-NEXT: call i8 addrspace(4)* @llvm.ptr.annotation.p4i8.p1i8({{.*}}str{{.*}}str{{.*}}i32 16, i8 addrspace(1)* null)
 // CHECK-NEXT: bitcast i8 addrspace(4)* %{{.*}} to float addrspace(4)*
 // CHECK-NEXT: bitcast float addrspace(4)* %{{.*}} to i8 addrspace(4)*
-// CHECK-NEXT: call i8 addrspace(4)* @llvm.ptr.annotation.p4i8.p1i8({{.*}}str{{.*}}str{{.*}}i32 13, i8 addrspace(1)* null)
+// CHECK-NEXT: call i8 addrspace(4)* @llvm.ptr.annotation.p4i8.p1i8({{.*}}str{{.*}}str{{.*}}i32 16, i8 addrspace(1)* null)
     return 0;
 }

--- a/clang/test/CodeGenSYCL/annotations-field-no-opaque.cpp
+++ b/clang/test/CodeGenSYCL/annotations-field-no-opaque.cpp
@@ -1,5 +1,8 @@
 // RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -emit-llvm -no-opaque-pointers -o - %s | FileCheck %s
 
+// This test checks that clang emits @llvm.ptr.annotation intrinsic correctly
+// when attribute annotate is applied to a struct field of integer type.
+
 // CHECK: private unnamed_addr addrspace(1) constant [8 x i8] c"v_ann_{{.}}\00", section "llvm.metadata"
 // CHECK: private unnamed_addr addrspace(1) constant [8 x i8] c"v_ann_{{.}}\00", section "llvm.metadata"
 // CHECK: private unnamed_addr addrspace(1) constant [8 x i8] c"w_ann_{{.}}\00", section "llvm.metadata"


### PR DESCRIPTION
Due to incorrect conflict resolution between 8e13852c (intel/llvm customization) and https://reviews.llvm.org/D138722 clang started emitting annotations applied to integer class/struct fields incorrectly. Incorrect overload of llvm.ptr.annotation intrinsic was picked up and this resulted in invalid IR emission. This patch restores behavior introduced by 8e13852c.
The existing test added for 8e13852c didn't catch the problem since it is modified upstream test `CodeGen/annotations-field.c` which doesn't test typed pointers.