### PR TITLE
Fix fp-accuracy build problems and minor cosmetic issues

### DIFF
--- a/llvm/docs/LangRef.rst
+++ b/llvm/docs/LangRef.rst
@@ -23134,7 +23134,7 @@ intrinsic has any callsite attributes begining with "fpbuiltin-" that the code
 performing the transformation does not recognize.
 
 Unless otherwise specified using callsite attributes, the fpbuiltin intrinsics
-do not set ``errno`` or and are not guaranteed to maintain correct
+do not set ``errno`` and are not guaranteed to maintain correct
 floating-point exception state.
 
 All fpbuiltin intrinsics are overloaded intrinsics which may operate on any

--- a/llvm/include/llvm/Analysis/TargetLibraryInfo.h
+++ b/llvm/include/llvm/Analysis/TargetLibraryInfo.h
@@ -24,7 +24,7 @@ class Function;
 class Module;
 class Triple;
 
-/// Describes a possible implementation of a floating point builtin operation
+/// Describes a possible implementation of a floating point builtin operation.
 struct AltMathDesc {
   Intrinsic::ID IntrinID;
   Type::TypeID BaseFPType;
@@ -79,7 +79,7 @@ class TargetLibraryInfoImpl {
   }
 
   /// Alternate math library functions - sorted by intrinsic ID, then type,
-  ///   then vector size, then accuracy
+  /// then vector size, then accuracy
   std::vector<AltMathDesc> AltMathFuncDescs;
 
   /// Vectorization descriptors - sorted by ScalarFnName.

--- a/llvm/lib/CodeGen/FPBuiltinFnSelection.cpp
+++ b/llvm/lib/CodeGen/FPBuiltinFnSelection.cpp
@@ -74,7 +74,7 @@ static bool selectFnForFPBuiltinCalls(const TargetLibraryInfo &TLI,
       dbgs() << BuiltinCall.getRequiredAccuracy().value() << "\n";
   });
 
-  StringSet RecognizedAttrs = {FPBuiltinIntrinsic::FPBUILTIN_MAX_ERROR};
+  StringSet<> RecognizedAttrs = {FPBuiltinIntrinsic::FPBUILTIN_MAX_ERROR};
   if (BuiltinCall.hasUnrecognizedFPAttrs(RecognizedAttrs)) {
     report_fatal_error(
         Twine(BuiltinCall.getCalledFunction()->getName()) +
@@ -142,7 +142,7 @@ public:
     return runImpl(*TLI, F);
   }
 
-  void getAnalysisUsage(AnalysisUsage &AU) const {
+  void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.setPreservesCFG();
     AU.addRequired<TargetLibraryInfoWrapperPass>();
     AU.addPreserved<TargetLibraryInfoWrapperPass>();


### PR DESCRIPTION
This change fixes a clang-specific build problem and a few minor cosmetic issues with the fp-accuracy intrinsic patch.