### PR TITLE
[SYCL][CUDA] Support device ID and UUID in the CUDA Plugin

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -1997,8 +1997,7 @@ pi_result cuda_piDeviceGetInfo(pi_device device, pi_device_info param_name,
   case PI_DEVICE_INFO_DEVICE_ID: {
     int value = 0;
     sycl::detail::pi::assertion(
-        cuDeviceGetAttribute(&value,
-                             CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID,
+        cuDeviceGetAttribute(&value, CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID,
                              device->get()) == CUDA_SUCCESS);
     sycl::detail::pi::assertion(value >= 0);
     return getInfo(param_value_size, param_value, param_value_size_ret, value);
@@ -2011,16 +2010,16 @@ pi_result cuda_piDeviceGetInfo(pi_device device, pi_device_info param_name,
     int minor = driver_version % 1000 / 10;
     CUuuid uuid;
     if ((major > 11) || (major == 11 && minor >= 4)) {
-      sycl::detail::pi::assertion(
-          cuDeviceGetUuid_v2(&uuid, device->get()) == CUDA_SUCCESS);
+      sycl::detail::pi::assertion(cuDeviceGetUuid_v2(&uuid, device->get()) ==
+                                  CUDA_SUCCESS);
     } else {
-      sycl::detail::pi::assertion(
-          cuDeviceGetUuid(&uuid, device->get()) == CUDA_SUCCESS);
+      sycl::detail::pi::assertion(cuDeviceGetUuid(&uuid, device->get()) ==
+                                  CUDA_SUCCESS);
     }
     std::array<unsigned char, 16> name;
     std::copy(uuid.bytes, uuid.bytes + 16, name.begin());
-    return getInfoArray(16, param_value_size, param_value,
-                        param_value_size_ret, name.data());
+    return getInfoArray(16, param_value_size, param_value, param_value_size_ret,
+                        name.data());
   }
 
     // TODO: Investigate if this information is available on CUDA.

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -1994,8 +1994,36 @@ pi_result cuda_piDeviceGetInfo(pi_device device, pi_device_info param_name,
                    pi_int32{1});
   }
 
+  case PI_DEVICE_INFO_DEVICE_ID: {
+    int value = 0;
+    sycl::detail::pi::assertion(
+        cuDeviceGetAttribute(&value,
+                             CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID,
+                             device->get()) == CUDA_SUCCESS);
+    sycl::detail::pi::assertion(value >= 0);
+    return getInfo(param_value_size, param_value, param_value_size_ret, value);
+  }
+
+  case PI_DEVICE_INFO_UUID: {
+    int driver_version = 0;
+    cuDriverGetVersion(&driver_version);
+    int major = driver_version / 1000;
+    int minor = driver_version % 1000 / 10;
+    CUuuid uuid;
+    if ((major > 11) || (major == 11 && minor >= 4)) {
+      sycl::detail::pi::assertion(
+          cuDeviceGetUuid_v2(&uuid, device->get()) == CUDA_SUCCESS);
+    } else {
+      sycl::detail::pi::assertion(
+          cuDeviceGetUuid(&uuid, device->get()) == CUDA_SUCCESS);
+    }
+    std::array<unsigned char, 16> name;
+    std::copy(uuid.bytes, uuid.bytes + 16, name.begin());
+    return getInfoArray(16, param_value_size, param_value,
+                        param_value_size_ret, name.data());
+  }
+
     // TODO: Investigate if this information is available on CUDA.
-  case PI_DEVICE_INFO_DEVICE_ID:
   case PI_DEVICE_INFO_PCI_ADDRESS:
   case PI_DEVICE_INFO_GPU_EU_COUNT:
   case PI_DEVICE_INFO_GPU_EU_SIMD_WIDTH:
@@ -2004,10 +2032,6 @@ pi_result cuda_piDeviceGetInfo(pi_device device, pi_device_info param_name,
   case PI_DEVICE_INFO_GPU_EU_COUNT_PER_SUBSLICE:
   case PI_DEVICE_INFO_GPU_HW_THREADS_PER_EU:
   case PI_DEVICE_INFO_MAX_MEM_BANDWIDTH:
-    // TODO: Check if Intel device UUID extension is utilized for CUDA.
-    // For details about this extension, see
-    // sycl/doc/extensions/supported/sycl_ext_intel_device_info.md
-  case PI_DEVICE_INFO_UUID:
     return PI_ERROR_INVALID_VALUE;
 
   default:


### PR DESCRIPTION
This PR tries to enable the accesses to device ID and UUID with the CUDA driver APIs.  Thank you for your review.

Reference
https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_intel_device_info.md
