### PR TITLE
[SYCL][NFC] Fix warnings in OffloadBundler upon conflict resolution

### DIFF
--- a/clang/lib/Driver/OffloadBundler.cpp
+++ b/clang/lib/Driver/OffloadBundler.cpp
@@ -827,7 +827,7 @@ public:
       if (!SymbolsOrErr->empty()) {
         // Add section with symbols names to fat object.
         Expected<StringRef> SymbolsFileOrErr =
-            TempFiles.Create(makeArrayRef(*SymbolsOrErr));
+            TempFiles.Create(ArrayRef<char>(*SymbolsOrErr));
         if (!SymbolsFileOrErr)
           return SymbolsFileOrErr.takeError();
 
@@ -1071,7 +1071,7 @@ public:
   Expected<std::optional<StringRef>>
   ReadBundleStart(MemoryBuffer &Input) override {
     if (NextBundle == Bundles.end())
-      return None;
+      return std::nullopt;
     CurrBundle = NextBundle++;
     return CurrBundle->first();
   }


### PR DESCRIPTION
Avoid using deprecated APIs in downstream-specific parts of the offload bundler library implementation. The warnings could be due to inaccurate conflict resolution (e.g. upon LLORG commit 0c2f6e36f9b2d).

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>