### PR TITLE
[SYCL][NFC] Improve typed pointer code in `LowerESIMDVecArg`

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMDVecArg.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMDVecArg.cpp
@@ -113,11 +113,12 @@ Type *ESIMDLowerVecArgPass::getSimdArgPtrTyOrNull(Value *arg) {
   auto ArgType = dyn_cast<PointerType>(arg->getType());
   if (!ArgType)
     return nullptr;
-  Type *Res = nullptr;
+  if (!ArgType->isOpaque())
+    return nullptr;
   StructType *ST =
-      dyn_cast_or_null<StructType>(ArgType->getPointerElementType());
+      dyn_cast_or_null<StructType>(ArgType->getNonOpaquePointerElementType());
 
-  Res = esimd::getVectorTyOrNull(ST);
+  Type *Res = esimd::getVectorTyOrNull(ST);
   if (!Res)
     return nullptr;
 


### PR DESCRIPTION
As a follow-up to commit e3a1541, avoid using the deprecated `Type::getPointerElementType()` API. Explicitly disable the code path for opaque pointers until these are fully supported in ESIMD passes.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>