### PR TITLE
[SYCL][Fusion][NFC] Fix warning in `FusionHelper.cpp`

### DIFF
--- a/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.cpp
+++ b/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.cpp
@@ -125,6 +125,7 @@ Expected<std::unique_ptr<Module>> helper::FusionHelper::addFusedKernel(
 
           const auto S = [&]() -> StringRef {
             switch (Info.Intern) {
+            default:
             case jit_compiler::Internalization::None:
               llvm_unreachable(
                   "Only a valid internalization kind should be used");


### PR DESCRIPTION
Warning log:
```
/path/to/llvm/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.cpp: In lambda function:
/path/to/llvm/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.cpp:136:11: warning: control reaches end of non-void function [-Wreturn-type]
  136 |           }();
      |
```

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>