### PR TITLE
[SYCL][NFC] Migrate clang-offload-wrapper from `makeArrayRef()` API

### DIFF
--- a/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
+++ b/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
@@ -945,7 +945,7 @@ private:
           return MnfOrErr.takeError();
         MemoryBuffer *Mnf = *MnfOrErr;
         FMnf = addArrayToModule(
-            makeArrayRef(Mnf->getBufferStart(), Mnf->getBufferSize()),
+            ArrayRef<char>(Mnf->getBufferStart(), Mnf->getBufferSize()),
             Twine(OffloadKindTag) + Twine(ImgId) + Twine(".manifest"));
       }
 
@@ -967,7 +967,7 @@ private:
         Bin = addELFNotes(Bin, Img.File);
       }
       std::pair<Constant *, Constant *> Fbin = addDeviceImageToModule(
-          makeArrayRef(Bin->getBufferStart(), Bin->getBufferSize()),
+          ArrayRef<char>(Bin->getBufferStart(), Bin->getBufferSize()),
           Twine(OffloadKindTag) + Twine(ImgId) + Twine(".data"), Kind, Img.Tgt);
 
       if (Kind == OffloadKind::SYCL) {


### PR DESCRIPTION
Use the `ArrayRef<char>` constructor directly, thus avoiding LLVM deprecation warnings.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>