### PR TITLE
[SYCL][NFC] Do not use non-existing vec aliases

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -554,18 +554,18 @@ protected:
 
 template <int Dim, typename T> struct IsValidCoordDataT;
 template <typename T> struct IsValidCoordDataT<1, T> {
-  constexpr static bool value =
-      detail::is_contained<T, detail::type_list<cl_int, cl_float>>::type::value;
+  constexpr static bool value = detail::is_contained<
+      T, detail::type_list<opencl::cl_int, opencl::cl_float>>::type::value;
 };
 template <typename T> struct IsValidCoordDataT<2, T> {
-  constexpr static bool value =
-      detail::is_contained<T,
-                           detail::type_list<cl_int2, cl_float2>>::type::value;
+  constexpr static bool value = detail::is_contained<
+      T, detail::type_list<vec<opencl::cl_int, 2>,
+                           vec<opencl::cl_float, 2>>>::type::value;
 };
 template <typename T> struct IsValidCoordDataT<3, T> {
-  constexpr static bool value =
-      detail::is_contained<T,
-                           detail::type_list<cl_int4, cl_float4>>::type::value;
+  constexpr static bool value = detail::is_contained<
+      T, detail::type_list<vec<opencl::cl_int, 4>,
+                           vec<opencl::cl_float, 4>>>::type::value;
 };
 
 template <typename DataT, int Dimensions, access::mode AccessMode,
@@ -620,10 +620,10 @@ private:
   constexpr static bool IsImageAccessAnyRead =
       (IsImageAccessReadOnly || AccessMode == access::mode::read_write);
 
-  static_assert(std::is_same<DataT, cl_int4>::value ||
-                    std::is_same<DataT, cl_uint4>::value ||
-                    std::is_same<DataT, cl_float4>::value ||
-                    std::is_same<DataT, cl_half4>::value,
+  static_assert(std::is_same<DataT, vec<opencl::cl_int, 4>>::value ||
+                    std::is_same<DataT, vec<opencl::cl_uint, 4>>::value ||
+                    std::is_same<DataT, vec<opencl::cl_float, 4>>::value ||
+                    std::is_same<DataT, vec<opencl::cl_half, 4>>::value,
                 "The data type of an image accessor must be only cl_int4, "
                 "cl_uint4, cl_float4 or cl_half4 from SYCL namespace");
 

--- a/sycl/test/basic_tests/host_image_accessor_read.cpp
+++ b/sycl/test/basic_tests/host_image_accessor_read.cpp
@@ -26,7 +26,7 @@ int foo(float *image_data) {
 
     sycl::range<2> pitch = Image.get_pitch();
 
-    sycl::cl_int4 Coords{0, 1, 2, 0};
+    sycl::vec<sycl::opencl::cl_int, 4> Coords{0, 1, 2, 0};
     {
       auto host_image_acc =
           Image.template get_access<sycl::float4, sycl::access::mode::read>();
@@ -35,14 +35,16 @@ int foo(float *image_data) {
           sycl::coordinate_normalization_mode::unnormalized,
           sycl::addressing_mode::none, sycl::filtering_mode::nearest);
       // Test image read function.
-      sycl::cl_float4 Ret_data = host_image_acc.read(Coords);
+      sycl::vec<sycl::opencl::cl_float, 4> Ret_data =
+          host_image_acc.read(Coords);
       assert((float)Ret_data.x() == 85);
       assert((float)Ret_data.y() == 86);
       assert((float)Ret_data.z() == 87);
       assert((float)Ret_data.w() == 88);
 
       // Test image read with sampler.
-      sycl::cl_float4 Ret_data2 = host_image_acc.read(Coords, Sampler);
+      sycl::vec<sycl::opencl::cl_float, 4> Ret_data2 =
+          host_image_acc.read(Coords, Sampler);
       assert((float)Ret_data2.x() == 85);
       assert((float)Ret_data2.y() == 86);
       assert((float)Ret_data2.z() == 87);
@@ -54,13 +56,15 @@ int foo(float *image_data) {
           Image.template get_access<sycl::float4, sycl::access::mode::write>();
 
       // Test image write function.
-      host_image_acc.write(Coords, sycl::cl_float4{120, 121, 122, 123});
+      host_image_acc.write(
+          Coords, sycl::vec<sycl::opencl::cl_float, 4>{120, 121, 122, 123});
     }
 
     {
       auto host_image_acc =
           Image.template get_access<sycl::float4, sycl::access::mode::read>();
-      sycl::cl_float4 Ret_data = host_image_acc.read(Coords);
+      sycl::vec<sycl::opencl::cl_float, 4> Ret_data =
+          host_image_acc.read(Coords);
       assert((float)Ret_data.x() == 120);
       assert((float)Ret_data.y() == 121);
       assert((float)Ret_data.z() == 122);
@@ -70,15 +74,14 @@ int foo(float *image_data) {
       auto Sampler = sycl::sampler(
           sycl::coordinate_normalization_mode::unnormalized,
           sycl::addressing_mode::clamp_to_edge, sycl::filtering_mode::nearest);
-      sycl::cl_int4 OutBnds_Coords{2, 2, 3, 0};
-      sycl::cl_float4 OutBnds_RetData =
+      sycl::vec<sycl::opencl::cl_int, 4> OutBnds_Coords{2, 2, 3, 0};
+      sycl::vec<sycl::opencl::cl_float, 4> OutBnds_RetData =
           host_image_acc.read(OutBnds_Coords, Sampler);
       assert((float)OutBnds_RetData.x() == 105);
       assert((float)OutBnds_RetData.y() == 106);
       assert((float)OutBnds_RetData.z() == 107);
       assert((float)OutBnds_RetData.w() == 108);
     }
-
   }
   return 0;
 }


### PR DESCRIPTION
`cl_*` vec aliases were removed in SYCL 2020. Replaced their usages with `vec<opencl::cl_*, N>`.

Note: SYCL 2020 aliases were not used here on purpose, because existing images implementation still follows SYCL 1.2.1 standard.