### PR TITLE
[SYCL] Fix method definition of sub_group_mask::group_ballot

### DIFF
--- a/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
@@ -29,6 +29,11 @@ namespace ext::oneapi {
 #define BITS_TYPE uint32_t
 #endif
 
+// defining `group_ballot` here to make predicate default `true`
+template <typename Group>
+detail::enable_if_t<std::is_same<std::decay_t<Group>, sub_group>::value, sub_group_mask>
+group_ballot(Group g, bool predicate = true);
+
 struct sub_group_mask {
   friend class detail::Builder;
   using BitsType = BITS_TYPE;
@@ -267,7 +272,7 @@ private:
 template <typename Group>
 detail::enable_if_t<std::is_same<std::decay_t<Group>, sub_group>::value,
                     sub_group_mask>
-group_ballot(Group g, bool predicate = true) {
+group_ballot(Group g, bool predicate) {
   (void)g;
 #ifdef __SYCL_DEVICE_ONLY__
   auto res = __spirv_GroupNonUniformBallot(

--- a/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
@@ -31,7 +31,8 @@ namespace ext::oneapi {
 
 // defining `group_ballot` here to make predicate default `true`
 template <typename Group>
-detail::enable_if_t<std::is_same<std::decay_t<Group>, sub_group>::value, sub_group_mask>
+detail::enable_if_t<std::is_same<std::decay_t<Group>, sub_group>::value,
+                    sub_group_mask>
 group_ballot(Group g, bool predicate = true);
 
 struct sub_group_mask {

--- a/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
@@ -30,6 +30,8 @@ namespace ext::oneapi {
 #endif
 
 // defining `group_ballot` here to make predicate default `true`
+// need to forward declare sub_group_mask first
+struct sub_group_mask;
 template <typename Group>
 detail::enable_if_t<std::is_same<std::decay_t<Group>, sub_group>::value,
                     sub_group_mask>

--- a/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
@@ -267,7 +267,7 @@ private:
 template <typename Group>
 detail::enable_if_t<std::is_same<std::decay_t<Group>, sub_group>::value,
                     sub_group_mask>
-group_ballot(Group g, bool predicate) {
+group_ballot(Group g, bool predicate = true) {
   (void)g;
 #ifdef __SYCL_DEVICE_ONLY__
   auto res = __spirv_GroupNonUniformBallot(

--- a/sycl/test/check_device_code/group_ballot.cpp
+++ b/sycl/test/check_device_code/group_ballot.cpp
@@ -1,4 +1,5 @@
-// RUN: %clangxx -fsycl -fsycl-device-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning %s
+// RUN: %clangxx -fsycl -fsycl-device-only -fsyntax-only -Xclang -verify %s
+// expected-no-diagnostics
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/check_device_code/group_ballot.cpp
+++ b/sycl/test/check_device_code/group_ballot.cpp
@@ -1,0 +1,10 @@
+// RUN: %clangxx -fsycl -fsycl-device-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning %s
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  sycl::queue Q;
+  Q.parallel_for(sycl::nd_range<1>{32, 32}, [=](sycl::nd_item<1> item) {
+    auto Mask = sycl::ext::oneapi::group_ballot(item.get_sub_group());
+  });
+}


### PR DESCRIPTION
Closes #8201
provided default value for `predicate` argument in `sub_group_mask::group_ballot` definition