### PR TITLE
[SYCL-MLIR] Add "use-bare-ptr-call-conv" to -convert-sycl-to-mlir pass

### DIFF
--- a/mlir-sycl/include/mlir/Conversion/SYCLPasses.td
+++ b/mlir-sycl/include/mlir/Conversion/SYCLPasses.td
@@ -23,6 +23,10 @@ def ConvertSYCLToLLVM : Pass<"convert-sycl-to-llvm", "ModuleOp"> {
   }];
   let constructor = "mlir::sycl::createConvertSYCLToLLVMPass()";
   let dependentDialects = ["LLVM::LLVMDialect"];
+  let options = [Option<"useBarePtrCallConv", "use-bare-ptr-call-conv", "bool",
+                        /*default=*/"false",
+			"Replace MemRef values with bare pointers to the MemRef "
+			"element types">];
 }
 
 #endif // MLIR_CONVERSION_SYCLPASSES

--- a/mlir-sycl/include/mlir/Conversion/SYCLToLLVM/SYCLToLLVMPass.h
+++ b/mlir-sycl/include/mlir/Conversion/SYCLToLLVM/SYCLToLLVMPass.h
@@ -17,6 +17,7 @@
 #include <memory>
 
 namespace mlir {
+class LowerToLLVMOptions;
 class ModuleOp;
 template <typename T> class OperationPass;
 
@@ -28,6 +29,8 @@ namespace sycl {
 
 /// Creates a pass to convert SYCL operations to the LLVMIR dialect.
 std::unique_ptr<OperationPass<ModuleOp>> createConvertSYCLToLLVMPass();
+std::unique_ptr<OperationPass<ModuleOp>>
+createConvertSYCLToLLVMPass(const LowerToLLVMOptions &options);
 
 } // namespace sycl
 } // namespace mlir


### PR DESCRIPTION
Add this option to enable/disable conversion patterns relying on bare pointer representation.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>