### PR TITLE
[SYCL][NFC] Do not use outdated cl_* aliases

### DIFF
--- a/sycl/include/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/sycl/detail/generic_type_traits.hpp
@@ -420,18 +420,18 @@ using select_apply_cl_scalar_t =
 // Shortcuts for selecting scalar int/unsigned int/fp type.
 template <typename T>
 using select_cl_scalar_integral_signed_t =
-    select_apply_cl_scalar_t<T, sycl::cl_char, sycl::cl_short, sycl::cl_int,
-                             sycl::cl_long>;
+    select_apply_cl_scalar_t<T, sycl::opencl::cl_char, sycl::opencl::cl_short,
+                             sycl::opencl::cl_int, sycl::opencl::cl_long>;
 
 template <typename T>
 using select_cl_scalar_integral_unsigned_t =
-    select_apply_cl_scalar_t<T, sycl::cl_uchar, sycl::cl_ushort, sycl::cl_uint,
-                             sycl::cl_ulong>;
+    select_apply_cl_scalar_t<T, sycl::opencl::cl_uchar, sycl::opencl::cl_ushort,
+                             sycl::opencl::cl_uint, sycl::opencl::cl_ulong>;
 
 template <typename T>
 using select_cl_scalar_float_t =
-    select_apply_cl_scalar_t<T, std::false_type, sycl::cl_half, sycl::cl_float,
-                             sycl::cl_double>;
+    select_apply_cl_scalar_t<T, std::false_type, sycl::opencl::cl_half,
+                             sycl::opencl::cl_float, sycl::opencl::cl_double>;
 
 template <typename T>
 using select_cl_scalar_integral_t =

--- a/sycl/test/basic_tests/generic_type_traits.cpp
+++ b/sycl/test/basic_tests/generic_type_traits.cpp
@@ -21,23 +21,27 @@ struct v {};
 
 int main() {
   // is_floatn
-  static_assert(d::is_floatn<s::cl_float4>::value == true, "");
-  static_assert(d::is_floatn<s::cl_float16>::value == true, "");
+  static_assert(d::is_floatn<s::vec<s::opencl::cl_float, 4>>::value == true);
+  static_assert(d::is_floatn<s::vec<s::opencl::cl_float, 16>>::value == true);
+  static_assert(d::is_floatn<s::float4>::value == true, "");
+  static_assert(d::is_floatn<s::float16>::value == true, "");
 
-  static_assert(d::is_floatn<s::cl_float>::value == false, "");
-  static_assert(d::is_floatn<s::cl_int>::value == false, "");
+  static_assert(d::is_floatn<s::opencl::cl_float>::value == false);
+  static_assert(d::is_floatn<s::opencl::cl_int>::value == false);
   static_assert(d::is_floatn<i_t>::value == false, "");
   static_assert(d::is_floatn<f_t>::value == false, "");
   static_assert(d::is_floatn<t::c_t>::value == false, "");
   static_assert(d::is_floatn<t::d_t>::value == false, "");
   static_assert(d::is_floatn<v>::value == false, "");
   // is_genfloatf
-  static_assert(d::is_genfloatf<s::cl_float4>::value == true, "");
-  static_assert(d::is_genfloatf<s::cl_float16>::value == true, "");
-  static_assert(d::is_genfloatf<s::cl_float>::value == true, "");
+  static_assert(d::is_genfloatf<s::vec<s::opencl::cl_float, 4>>::value == true);
+  static_assert(d::is_genfloatf<s::vec<s::opencl::cl_float, 16>>::value == true);
+  static_assert(d::is_genfloatf<s::opencl::cl_float>::value == true);
+  static_assert(d::is_genfloatf<s::float4>::value == true);
+  static_assert(d::is_genfloatf<s::float16>::value == true);
   static_assert(d::is_genfloatf<f_t>::value == true, "");
 
-  static_assert(d::is_genfloatf<s::cl_int>::value == false, "");
+  static_assert(d::is_genfloatf<s::opencl::cl_int>::value == false);
   static_assert(d::is_genfloatf<i_t>::value == false, "");
   static_assert(d::is_genfloatf<t::c_t>::value == false, "");
   static_assert(d::is_genfloatf<t::d_t>::value == false, "");
@@ -45,15 +49,17 @@ int main() {
 
   //
 
-  static_assert(d::is_genfloat<s::cl_float>::value == true, "");
-  static_assert(d::is_genfloat<s::cl_float4>::value == true, "");
-  static_assert(d::is_genfloat<s::cl_float4>::value == true, "");
+  static_assert(d::is_genfloat<s::opencl::cl_float>::value == true);
+  static_assert(d::is_genfloat<s::vec<s::opencl::cl_float, 4>>::value == true);
 
-  static_assert(d::is_ugenint<s::cl_float4>::value == false, "");
+  static_assert(d::is_ugenint<s::vec<s::opencl::cl_float, 4>>::value == false);
+  static_assert(d::is_ugenint<s::float4>::value == false);
 
-  static_assert(d::is_ugenint<s::cl_uint>::value == true, "");
+  static_assert(d::is_ugenint<s::opencl::cl_uint>::value == true);
+  static_assert(d::is_ugenint<unsigned int>::value == true);
 
-  static_assert(d::is_ugenint<s::cl_uint3>::value == true, "");
+  static_assert(d::is_ugenint<s::vec<s::opencl::cl_uint, 3>>::value == true);
+  static_assert(d::is_ugenint<s::uint3>::value == true);
 
   // TODO add checks for the following type traits
   /*
@@ -139,11 +145,11 @@ int main() {
   */
   // is_nan_type
   static_assert(d::is_nan_type<unsigned long long int>::value == true, "");
-  static_assert(d::is_nan_type<s::longlong>::value == false, "");
-  static_assert(d::is_nan_type<s::ulonglong>::value == true, "");
+  static_assert(d::is_nan_type<long long>::value == false, "");
+  static_assert(d::is_nan_type<unsigned long long>::value == true, "");
   static_assert(d::is_nan_type<unsigned long>::value == true, "");
   static_assert(d::is_nan_type<long>::value == false, "");
-  static_assert(d::is_nan_type<s::ulong>::value == true, "");
+  static_assert(d::is_nan_type<unsigned long>::value == true, "");
   /*
   float_point_to_sign_integeral
 
@@ -152,88 +158,75 @@ int main() {
   */
 
   // checks for some type conversions.
-  static_assert(
-      std::is_same<d::SelectMatchingOpenCLType_t<s::cl_int>, s::cl_int>::value,
-      "");
+  static_assert(std::is_same<d::SelectMatchingOpenCLType_t<s::opencl::cl_int>,
+                             s::opencl::cl_int>::value);
 
   static_assert(
-      std::is_same<d::SelectMatchingOpenCLType_t<s::vec<s::cl_int, 2>>,
-                   s::vec<s::cl_int, 2>>::value,
-      "");
+      std::is_same<d::SelectMatchingOpenCLType_t<s::vec<s::opencl::cl_int, 2>>,
+                   s::vec<s::opencl::cl_int, 2>>::value);
+
+  static_assert(std::is_same<
+                d::SelectMatchingOpenCLType_t<s::multi_ptr<
+                    s::opencl::cl_int, s::access::address_space::global_space,
+                    s::access::decorated::yes>>,
+                s::multi_ptr<s::opencl::cl_int,
+                             s::access::address_space::global_space,
+                             s::access::decorated::yes>>::value);
 
   static_assert(
-      std::is_same<
-          d::SelectMatchingOpenCLType_t<
-              s::multi_ptr<s::cl_int, s::access::address_space::global_space,
-                           s::access::decorated::yes>>,
-          s::multi_ptr<s::cl_int, s::access::address_space::global_space,
-                       s::access::decorated::yes>>::value,
-      "");
+      std::is_same<d::SelectMatchingOpenCLType_t<
+                       s::multi_ptr<s::vec<s::opencl::cl_int, 2>,
+                                    s::access::address_space::global_space,
+                                    s::access::decorated::yes>>,
+                   s::multi_ptr<s::vec<s::opencl::cl_int, 2>,
+                                s::access::address_space::global_space,
+                                s::access::decorated::yes>>::value);
+
+  static_assert(std::is_same<d::SelectMatchingOpenCLType_t<long long>,
+                             s::opencl::cl_long>::value);
 
   static_assert(
-      std::is_same<
-          d::SelectMatchingOpenCLType_t<s::multi_ptr<
-              s::vec<s::cl_int, 2>, s::access::address_space::global_space,
-              s::access::decorated::yes>>,
-          s::multi_ptr<s::vec<s::cl_int, 2>,
-                       s::access::address_space::global_space,
-                       s::access::decorated::yes>>::value,
-      "");
-
-  static_assert(std::is_same<d::SelectMatchingOpenCLType_t<s::longlong>,
-                             s::cl_long>::value,
-                "");
+      std::is_same<d::SelectMatchingOpenCLType_t<s::vec<long long, 2>>,
+                   s::vec<s::opencl::cl_long, 2>>::value);
 
   static_assert(
-      std::is_same<d::SelectMatchingOpenCLType_t<s::vec<s::longlong, 2>>,
-                   s::vec<s::cl_long, 2>>::value,
-      "");
-
-  static_assert(
-      std::is_same<
-          d::SelectMatchingOpenCLType_t<
-              s::multi_ptr<s::longlong, s::access::address_space::global_space,
-                           s::access::decorated::yes>>,
-          s::multi_ptr<s::cl_long, s::access::address_space::global_space,
-                       s::access::decorated::yes>>::value,
-      "");
+      std::is_same<d::SelectMatchingOpenCLType_t<s::multi_ptr<
+                       long long, s::access::address_space::global_space,
+                       s::access::decorated::yes>>,
+                   s::multi_ptr<s::opencl::cl_long,
+                                s::access::address_space::global_space,
+                                s::access::decorated::yes>>::value);
 
   static_assert(
       std::is_same<
           d::SelectMatchingOpenCLType_t<s::multi_ptr<
-              s::vec<s::longlong, 2>, s::access::address_space::global_space,
+              s::vec<long long, 2>, s::access::address_space::global_space,
               s::access::decorated::yes>>,
-          s::multi_ptr<s::vec<s::cl_long, 2>,
+          s::multi_ptr<s::vec<s::opencl::cl_long, 2>,
                        s::access::address_space::global_space,
-                       s::access::decorated::yes>>::value,
-      "");
+                       s::access::decorated::yes>>::value);
 
 #ifdef __SYCL_DEVICE_ONLY__
   static_assert(
-      std::is_same<d::ConvertToOpenCLType_t<s::vec<s::cl_int, 2>>,
-                   s::vec<s::cl_int, 2>::vector_t>::value,
-      "");
+      std::is_same<d::ConvertToOpenCLType_t<s::vec<s::opencl::cl_int, 2>>,
+                   s::vec<s::opencl::cl_int, 2>::vector_t>::value);
+  static_assert(std::is_same<d::ConvertToOpenCLType_t<s::vec<long long, 2>>,
+                             s::vec<s::opencl::cl_long, 2>::vector_t>::value);
+  static_assert(std::is_same<
+                d::ConvertToOpenCLType_t<s::multi_ptr<
+                    s::opencl::cl_int, s::access::address_space::global_space,
+                    s::access::decorated::yes>>,
+                s::multi_ptr<s::opencl::cl_int,
+                             s::access::address_space::global_space,
+                             s::access::decorated::yes>::pointer>::value);
   static_assert(
-      std::is_same<d::ConvertToOpenCLType_t<s::vec<s::longlong, 2>>,
-                   s::vec<s::cl_long, 2>::vector_t>::value,
-      "");
-  static_assert(
-      std::is_same<
-          d::ConvertToOpenCLType_t<
-              s::multi_ptr<s::cl_int, s::access::address_space::global_space,
-                           s::access::decorated::yes>>,
-          s::multi_ptr<s::cl_int, s::access::address_space::global_space,
-                       s::access::decorated::yes>::pointer>::value,
-      "");
-  static_assert(
-      std::is_same<
-          d::ConvertToOpenCLType_t<s::multi_ptr<
-              s::vec<s::cl_int, 4>, s::access::address_space::global_space,
-              s::access::decorated::yes>>,
-          s::multi_ptr<s::vec<s::cl_int, 4>::vector_t,
-                       s::access::address_space::global_space,
-                       s::access::decorated::yes>::pointer>::value,
-      "");
+      std::is_same<d::ConvertToOpenCLType_t<
+                       s::multi_ptr<s::vec<s::opencl::cl_int, 4>,
+                                    s::access::address_space::global_space,
+                                    s::access::decorated::yes>>,
+                   s::multi_ptr<s::vec<s::opencl::cl_int, 4>::vector_t,
+                                s::access::address_space::global_space,
+                                s::access::decorated::yes>::pointer>::value);
 #endif
   static_assert(std::is_same<d::ConvertToOpenCLType_t<s::half>,
                              d::half_impl::BIsRepresentationT>::value,

--- a/sycl/test/type_traits/type_list.cpp
+++ b/sycl/test/type_traits/type_list.cpp
@@ -153,37 +153,42 @@ int main() {
   static_assert(d::is_contained_value<bool, false, my_bool_list>::value, "");
   static_assert(d::is_contained_value<bool, true, my_bool_list>::value, "");
 
-  test_predicate<d::is_type_size_equal, int8_t, s::cl_char>();
-  test_predicate<d::is_type_size_equal, int16_t, s::cl_char, false>();
-  test_predicate<d::is_type_size_greater, int8_t, s::cl_char, false>();
-  test_predicate<d::is_type_size_greater, int32_t, s::cl_char>();
-  test_predicate<d::is_type_size_double_of, int8_t, s::cl_char, false>();
-  test_predicate<d::is_type_size_double_of, int16_t, s::cl_char>();
-  test_predicate<d::is_type_size_double_of, int32_t, s::cl_char, false>();
-  test_predicate<d::is_type_size_less, int8_t, s::cl_int>();
-  test_predicate<d::is_type_size_less, int32_t, s::cl_int, false>();
-  test_predicate<d::is_type_size_half_of, int8_t, s::cl_int, false>();
-  test_predicate<d::is_type_size_half_of, int16_t, s::cl_int>();
-  test_predicate<d::is_type_size_half_of, int32_t, s::cl_int, false>();
+  test_predicate<d::is_type_size_equal, int8_t, s::opencl::cl_char>();
+  test_predicate<d::is_type_size_equal, int16_t, s::opencl::cl_char, false>();
+  test_predicate<d::is_type_size_greater, int8_t, s::opencl::cl_char, false>();
+  test_predicate<d::is_type_size_greater, int32_t, s::opencl::cl_char>();
+  test_predicate<d::is_type_size_double_of, int8_t, s::opencl::cl_char,
+                 false>();
+  test_predicate<d::is_type_size_double_of, int16_t, s::opencl::cl_char>();
+  test_predicate<d::is_type_size_double_of, int32_t, s::opencl::cl_char,
+                 false>();
+  test_predicate<d::is_type_size_less, int8_t, s::opencl::cl_int>();
+  test_predicate<d::is_type_size_less, int32_t, s::opencl::cl_int, false>();
+  test_predicate<d::is_type_size_half_of, int8_t, s::opencl::cl_int, false>();
+  test_predicate<d::is_type_size_half_of, int16_t, s::opencl::cl_int>();
+  test_predicate<d::is_type_size_half_of, int32_t, s::opencl::cl_int, false>();
 
   // if void is found, the required type is not found
-  test_trait<d::find_same_size_type_t, d::type_list<int8_t>, s::cl_char,
+  test_trait<d::find_same_size_type_t, d::type_list<int8_t>, s::opencl::cl_char,
              int8_t>();
-  test_trait<d::find_same_size_type_t, d::type_list<int16_t>, s::cl_char,
+  test_trait<d::find_same_size_type_t, d::type_list<int16_t>,
+             s::opencl::cl_char, void>();
+  test_trait<d::find_larger_type_t, d::type_list<int8_t, int16_t>,
+             s::opencl::cl_char, int16_t>();
+  test_trait<d::find_larger_type_t, d::type_list<int8_t>, s::opencl::cl_char,
              void>();
-  test_trait<d::find_larger_type_t, d::type_list<int8_t, int16_t>, s::cl_char,
-             int16_t>();
-  test_trait<d::find_larger_type_t, d::type_list<int8_t>, s::cl_char, void>();
   test_trait<d::find_twice_as_large_type_t, d::type_list<int8_t, int16_t>,
-             s::cl_char, int16_t>();
+             s::opencl::cl_char, int16_t>();
   test_trait<d::find_twice_as_large_type_t, d::type_list<int8_t, int32_t>,
-             s::cl_char, void>();
-  test_trait<d::find_smaller_type_t, d::type_list<int8_t>, s::cl_int, int8_t>();
-  test_trait<d::find_smaller_type_t, d::type_list<int32_t>, s::cl_int, void>();
+             s::opencl::cl_char, void>();
+  test_trait<d::find_smaller_type_t, d::type_list<int8_t>, s::opencl::cl_int,
+             int8_t>();
+  test_trait<d::find_smaller_type_t, d::type_list<int32_t>, s::opencl::cl_int,
+             void>();
   test_trait<d::find_twice_as_small_type_t, d::type_list<int8_t, int16_t>,
-             s::cl_int, int16_t>();
+             s::opencl::cl_int, int16_t>();
   test_trait<d::find_twice_as_small_type_t, d::type_list<int8_t, int32_t>,
-             s::cl_int, void>();
+             s::opencl::cl_int, void>();
 
   return 0;
 }

--- a/sycl/test/type_traits/type_traits.cpp
+++ b/sycl/test/type_traits/type_traits.cpp
@@ -51,11 +51,9 @@ void test_vector_element_t() {
                 "");
 }
 
-template <typename T, typename CheckedT, bool Expected = true>
-void test_nan_types() {
-  static_assert((sizeof(d::vector_element_t<d::nan_return_t<T>>) ==
-                 sizeof(d::nan_argument_base_t<T>)) == Expected,
-                "");
+template <typename T> void test_nan_types() {
+  static_assert(sizeof(d::vector_element_t<d::nan_return_t<T>>) ==
+                sizeof(d::nan_argument_base_t<T>));
 }
 
 template <typename T, typename CheckedT, bool Expected = true>
@@ -151,9 +149,13 @@ int main() {
   test_is_arithmetic<s::half2>();
 
   test_make_type_t<int, d::gtl::scalar_unsigned_int_list, unsigned int>();
-  test_make_type_t<s::cl_int, d::gtl::scalar_float_list, s::cl_float>();
-  test_make_type_t<s::cl_int3, d::gtl::scalar_unsigned_int_list, s::cl_uint3>();
-  test_make_type_t<s::cl_int3, d::gtl::scalar_float_list, s::cl_float3>();
+  test_make_type_t<s::opencl::cl_int, d::gtl::scalar_float_list,
+                   s::opencl::cl_float>();
+  test_make_type_t<s::vec<s::opencl::cl_int, 3>,
+                   d::gtl::scalar_unsigned_int_list,
+                   s::vec<s::opencl::cl_uint, 3>>();
+  test_make_type_t<s::vec<s::opencl::cl_int, 3>, d::gtl::scalar_float_list,
+                   s::vec<s::opencl::cl_float, 3>>();
 
   test_make_larger_t<s::half, float>();
   test_make_larger_t<s::half3, s::float3>();
@@ -180,13 +182,13 @@ int main() {
   test_vector_element_t<volatile s::int2, volatile int>();
   test_vector_element_t<const volatile s::int2, const volatile int>();
 
-  test_nan_types<s::ushort, s::ushort>();
-  test_nan_types<s::uint, s::uint>();
-  test_nan_types<s::ulong, s::ulong>();
-  test_nan_types<s::ulonglong, s::ulonglong>();
-  test_nan_types<s::ushort2, s::ushort2>();
-  test_nan_types<s::uint2, s::uint2>();
-  test_nan_types<s::ulong2, s::ulong2>();
+  test_nan_types<unsigned short>();
+  test_nan_types<unsigned int>();
+  test_nan_types<unsigned long>();
+  test_nan_types<unsigned long long>();
+  test_nan_types<s::ushort2>();
+  test_nan_types<s::uint2>();
+  test_nan_types<s::ulong2>();
 
   test_make_signed_t<int, int>();
   test_make_signed_t<const int, const int>();


### PR DESCRIPTION
Updated type traits/type list-related files and tests to use proper namespaces for `cl_*` types (or alternative spellings for them like for `cl_*` vector aliases).