### PR TITLE
[SYCL] Decorate part of sycl::atomic_ref that is optional kernel feature

### DIFF
--- a/sycl/include/sycl/atomic_ref.hpp
+++ b/sycl/include/sycl/atomic_ref.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <sycl/access/access.hpp>
+#include <sycl/aspects.hpp>
 #include <sycl/atomic.hpp>
 #include <sycl/detail/defines.hpp>
 #include <sycl/memory_enums.hpp>
@@ -259,8 +260,9 @@ protected:
 };
 
 // Hook allowing partial specializations to inherit atomic_ref_base
-template <typename T, memory_order DefaultOrder, memory_scope DefaultScope,
-          access::address_space AddressSpace, typename = void>
+template <typename T, bool IsAspectAtomic64AttrUsed, memory_order DefaultOrder,
+          memory_scope DefaultScope, access::address_space AddressSpace,
+          typename = void>
 class atomic_ref_impl
     : public atomic_ref_base<T, DefaultOrder, DefaultScope, AddressSpace> {
 public:
@@ -269,9 +271,10 @@ public:
 };
 
 // Partial specialization for integral types
-template <typename T, memory_order DefaultOrder, memory_scope DefaultScope,
-          access::address_space AddressSpace>
-class atomic_ref_impl<T, DefaultOrder, DefaultScope, AddressSpace,
+template <typename T, bool IsAspectAtomic64AttrUsed, memory_order DefaultOrder,
+          memory_scope DefaultScope, access::address_space AddressSpace>
+class atomic_ref_impl<T, IsAspectAtomic64AttrUsed, DefaultOrder, DefaultScope,
+                      AddressSpace,
                       typename detail::enable_if_t<std::is_integral<T>::value>>
     : public atomic_ref_base<T, DefaultOrder, DefaultScope, AddressSpace> {
 
@@ -416,10 +419,10 @@ private:
 };
 
 // Partial specialization for floating-point types
-template <typename T, memory_order DefaultOrder, memory_scope DefaultScope,
-          access::address_space AddressSpace>
+template <typename T, bool IsAspectAtomic64AttrUsed, memory_order DefaultOrder,
+          memory_scope DefaultScope, access::address_space AddressSpace>
 class atomic_ref_impl<
-    T, DefaultOrder, DefaultScope, AddressSpace,
+    T, IsAspectAtomic64AttrUsed, DefaultOrder, DefaultScope, AddressSpace,
     typename detail::enable_if_t<std::is_floating_point<T>::value>>
     : public atomic_ref_base<T, DefaultOrder, DefaultScope, AddressSpace> {
 
@@ -523,12 +526,49 @@ private:
   using atomic_ref_base<T, DefaultOrder, DefaultScope, AddressSpace>::ptr;
 };
 
+// Partial specialization for 64-bit integral types needed for optional kernel
+// features
+template <typename T, memory_order DefaultOrder, memory_scope DefaultScope,
+          access::address_space AddressSpace>
+#ifndef __SYCL_DEVICE_ONLY__
+class atomic_ref_impl<
+#else
+class [[__sycl_detail__::__uses_aspects__(aspect::atomic64)]] atomic_ref_impl<
+#endif
+    T, /*IsAspectAtomic64AttrUsed = */ true, DefaultOrder, DefaultScope,
+    AddressSpace, typename detail::enable_if_t<std::is_integral<T>::value>>
+    : public atomic_ref_impl<T, /*IsAspectAtomic64AttrUsed = */ false,
+                             DefaultOrder, DefaultScope, AddressSpace> {
+public:
+  using atomic_ref_impl<T, /*IsAspectAtomic64AttrUsed = */ false, DefaultOrder,
+                        DefaultScope, AddressSpace>::atomic_ref_impl;
+};
+
+// Partial specialization for 64-bit floating-point types needed for optional
+// kernel features
+template <typename T, memory_order DefaultOrder, memory_scope DefaultScope,
+          access::address_space AddressSpace>
+#ifndef __SYCL_DEVICE_ONLY__
+class atomic_ref_impl<
+#else
+class [[__sycl_detail__::__uses_aspects__(aspect::atomic64)]] atomic_ref_impl<
+#endif
+    T, /*IsAspectAtomic64AttrUsed = */ true, DefaultOrder, DefaultScope,
+    AddressSpace,
+    typename detail::enable_if_t<std::is_floating_point<T>::value>>
+    : public atomic_ref_impl<T, /*IsAspectAtomic64AttrUsed = */ false,
+                             DefaultOrder, DefaultScope, AddressSpace> {
+public:
+  using atomic_ref_impl<T, /*IsAspectAtomic64AttrUsed = */ false, DefaultOrder,
+                        DefaultScope, AddressSpace>::atomic_ref_impl;
+};
+
 // Partial specialization for pointer types
 // Arithmetic is emulated because target's representation of T* is unknown
 // TODO: Find a way to use intptr_t or uintptr_t atomics instead
-template <typename T, memory_order DefaultOrder, memory_scope DefaultScope,
+template <typename T, bool IsAspectAtomic64AttrUsed, memory_order DefaultOrder, memory_scope DefaultScope,
           access::address_space AddressSpace>
-class atomic_ref_impl<T *, DefaultOrder, DefaultScope, AddressSpace>
+class atomic_ref_impl<T *, IsAspectAtomic64AttrUsed, DefaultOrder, DefaultScope, AddressSpace>
     : public atomic_ref_base<uintptr_t, DefaultOrder, DefaultScope,
                              AddressSpace> {
 
@@ -664,12 +704,16 @@ private:
 template <typename T, memory_order DefaultOrder, memory_scope DefaultScope,
           access::address_space AddressSpace =
               access::address_space::generic_space>
-class atomic_ref : public detail::atomic_ref_impl<T, DefaultOrder, DefaultScope,
-                                                  AddressSpace> {
+// if sizeof(T) == 8 bytes, then the type T is optional kernel feature, so it
+// was decorated with [[__sycl_detail__::__uses_aspects__(aspect::atomic64))]]
+// attribute in detail::atomic_ref_impl partial specializations above
+class atomic_ref
+    : public detail::atomic_ref_impl<T, sizeof(T) == 8, DefaultOrder,
+                                     DefaultScope, AddressSpace> {
 public:
-  using detail::atomic_ref_impl<T, DefaultOrder, DefaultScope,
+  using detail::atomic_ref_impl<T, sizeof(T) == 8, DefaultOrder, DefaultScope,
                                 AddressSpace>::atomic_ref_impl;
-  using detail::atomic_ref_impl<T, DefaultOrder, DefaultScope,
+  using detail::atomic_ref_impl<T, sizeof(T) == 8, DefaultOrder, DefaultScope,
                                 AddressSpace>::operator=;
 };
 

--- a/sycl/include/sycl/atomic_ref.hpp
+++ b/sycl/include/sycl/atomic_ref.hpp
@@ -542,6 +542,8 @@ class [[__sycl_detail__::__uses_aspects__(aspect::atomic64)]] atomic_ref_impl<
 public:
   using atomic_ref_impl<T, /*IsAspectAtomic64AttrUsed = */ false, DefaultOrder,
                         DefaultScope, AddressSpace>::atomic_ref_impl;
+  using atomic_ref_impl<T, /*IsAspectAtomic64AttrUsed = */ false, DefaultOrder,
+                        DefaultScope, AddressSpace>::atomic_ref_impl::operator=;
 };
 
 // Partial specialization for 64-bit floating-point types needed for optional
@@ -561,6 +563,8 @@ class [[__sycl_detail__::__uses_aspects__(aspect::atomic64)]] atomic_ref_impl<
 public:
   using atomic_ref_impl<T, /*IsAspectAtomic64AttrUsed = */ false, DefaultOrder,
                         DefaultScope, AddressSpace>::atomic_ref_impl;
+  using atomic_ref_impl<T, /*IsAspectAtomic64AttrUsed = */ false, DefaultOrder,
+                        DefaultScope, AddressSpace>::atomic_ref_impl::operator=;
 };
 
 // Partial specialization for pointer types

--- a/sycl/test/optional_kernel_features/atomic_ref-atomic64-aspect.cpp
+++ b/sycl/test/optional_kernel_features/atomic_ref-atomic64-aspect.cpp
@@ -1,0 +1,53 @@
+// RUN: %clangxx %s -S -o %t.ll -fsycl-device-only
+// RUN: FileCheck %s --input-file %t.ll
+
+// CHECK: !sycl_types_that_use_aspects = !{![[#MDNUM1:]], ![[#MDNUM2:]], ![[#MDNUM3:]]}
+// CHECK: ![[#MDNUM1]] = !{!"class.sycl::_V1::detail::atomic_ref_impl", i32 [[#ASPECT_NUM:]]}
+// CHECK: ![[#MDNUM2]] = !{!"class.sycl::_V1::detail::atomic_ref_impl.2", i32 [[#ASPECT_NUM:]]}
+// CHECK: ![[#MDNUM3]] = !{!"class.sycl::_V1::detail::atomic_ref_impl.7", i32 [[#ASPECT_NUM:]]}
+// CHECK: !{{.*}} = !{!"atomic64", i32 [[#ASPECT_NUM]]}
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  double d = 10.0;
+  sycl::queue q;
+  q.submit([&](sycl::handler &h) {
+    h.single_task([=]() {
+      double val_double = 100.0;
+      // uses atomic64 aspect
+      auto ref_double =
+          sycl::atomic_ref<double, sycl::memory_order_acq_rel,
+                           sycl::memory_scope_device,
+                           sycl::access::address_space::local_space>(
+              val_double);
+      long long val_longlong = 101;
+      // uses atomic64 aspect
+      auto ref_longlong =
+          sycl::atomic_ref<long long, sycl::memory_order_acq_rel,
+                           sycl::memory_scope_device,
+                           sycl::access::address_space::local_space>(
+              val_longlong);
+      uint64_t val_uint64_t = 102;
+      // uses atomic64 aspect
+      auto ref_uint64 =
+          sycl::atomic_ref<uint64_t, sycl::memory_order_acq_rel,
+                           sycl::memory_scope_device,
+                           sycl::access::address_space::local_space>(
+              val_uint64_t);
+      float val_float = 103.0;
+      // doesn't use atomic64 aspect
+      auto ref_float =
+          sycl::atomic_ref<float, sycl::memory_order_acq_rel,
+                           sycl::memory_scope_device,
+                           sycl::access::address_space::local_space>(val_float);
+      int val_int = 104;
+      // doesn't use atomic64 aspect
+      auto ref_int =
+          sycl::atomic_ref<int, sycl::memory_order_acq_rel,
+                           sycl::memory_scope_device,
+                           sycl::access::address_space::local_space>(val_int);
+    });
+  });
+  return 0;
+}

--- a/sycl/test/optional_kernel_features/atomic_ref-atomic64-aspect.cpp
+++ b/sycl/test/optional_kernel_features/atomic_ref-atomic64-aspect.cpp
@@ -10,7 +10,6 @@
 #include <sycl/sycl.hpp>
 
 int main() {
-  double d = 10.0;
   sycl::queue q;
   q.submit([&](sycl::handler &h) {
     h.single_task([=]() {


### PR DESCRIPTION
This patch adds
`[[__sycl_detail__::__uses_aspects__(aspect::atomic64)]]` attribute to specializations of `sycl::atomic_ref` that are 64-bits wide. Such type is optional kernel feature.