### PR TITLE
[SYCL] Fix to make sure ONEAPI_DEVICE_SELECTOR is case insensitive

### DIFF
--- a/sycl/source/detail/device_filter.cpp
+++ b/sycl/source/detail/device_filter.cpp
@@ -166,7 +166,11 @@ static void Parse_ODS_Device(ods_target &Target,
 }
 
 std::vector<ods_target>
-Parse_ONEAPI_DEVICE_SELECTOR(const std::string &envStr) {
+Parse_ONEAPI_DEVICE_SELECTOR(const std::string &envString) {
+  // lowercase
+  std::string envStr = envString;
+  std::transform(envStr.begin(), envStr.end(), envStr.begin(), ::tolower);
+
   std::vector<ods_target> Result;
   if (envStr.empty()) {
     ods_target acceptAnything;


### PR DESCRIPTION
Simple fix to make sure ONEAPI_DEVICE_SELECTOR is case insensitive

tests added here: https://github.com/intel/llvm-test-suite/pull/1579

Signed-off-by: Chris Perkins <chris.perkins@intel.com>