### PR TITLE
[VectorUtils] Enhance VFABI demangling API

### DIFF
--- a/llvm/include/llvm/Analysis/VectorUtils.h
+++ b/llvm/include/llvm/Analysis/VectorUtils.h
@@ -166,6 +166,12 @@ static constexpr char const *_LLVM_Scalarize_ = "_LLVM_Scalarize_";
 /// respective IR declarations.
 std::optional<VFInfo> tryDemangleForVFABI(StringRef MangledName,
                                           const Module &M);
+/// \param M -> The pointer to module used to retrieve informations about the
+/// vector function. If nullptr is passed, we don't check the existence of
+/// the demangled vector function.
+std::optional<VFInfo> tryDemangleForVFABI(StringRef MangledName,
+                                          const Module *M = nullptr);
+VFInfo demangleForVFABI(StringRef MangledName);
 
 /// This routine mangles the given VectorName according to the LangRef
 /// specification for vector-function-abi-variant attribute and is specific to


### PR DESCRIPTION
This is a cherry-pick of https://reviews.llvm.org/D141650

This patch adds more flexibility to the original VFABI demangling API.

1. Allow demangling an empty parameter list, which is explicitly allowed by X86 VFABI doc ([section 2.6](https://sourceware.org/glibc/wiki/libmvec?action=AttachFile&do=view&target=VectorABI.txt)) and probably implicitly allowed by AArch64 VFABI doc ([section 4.1](https://github.com/ARM-software/abi-aa/blob/main/vfabia64/vfabia64.rst#id26)) as well.
2. Allow passing the module as a nullptr, so that we don't check the existence of the demangled vector function name. This is useful when we want to create the widened function according to the demangling result.

Signed-off-by: Yilong Guo <yilong.guo@intel.com>