### PR TITLE
[SYCL][PI][NFC] Fix linkage warning on helper functions in PI OpenCL

### DIFF
--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -290,8 +290,6 @@ static pi_result USMSetIndirectAccess(pi_kernel kernel) {
   return PI_SUCCESS;
 }
 
-extern "C" {
-
 // Helper functions
 
 // Returns true if the device is a cslice subdevice.
@@ -345,6 +343,8 @@ static bool isPVC(pi_device device) {
 }
 
 // End of helper functions
+
+extern "C" {
 
 pi_result piDeviceGetInfo(pi_device device, pi_device_info paramName,
                           size_t paramValueSize, void *paramValue,


### PR DESCRIPTION
Recently added helper functions in pi_opencl.cpp were placed under C-style linking. Since one of the functions return a std::vector this cases a warning. This commit moves these static helper functions out of the extern "C" scope.