### PR TITLE
[SYCL][L0] Fix L0 library linking for remote paths on Windows

### DIFF
--- a/sycl/plugins/level_zero/CMakeLists.txt
+++ b/sycl/plugins/level_zero/CMakeLists.txt
@@ -46,8 +46,16 @@ if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
 endif()
 
 add_library (LevelZeroLoader INTERFACE)
+# The MSVC linker does not like / at the start of a path, so to work around this
+# we split it into a link library and a library path, where the path is allowed
+# to have leading /.
+get_filename_component(LEVEL_ZERO_LIBRARY_SRC "${LEVEL_ZERO_LIBRARY}" DIRECTORY)
+get_filename_component(LEVEL_ZERO_LIB_NAME "${LEVEL_ZERO_LIBRARY}" NAME)
+target_link_directories(LevelZeroLoader
+  INTERFACE "${LEVEL_ZERO_LIBRARY_SRC}"
+)
 target_link_libraries(LevelZeroLoader
-  INTERFACE "${LEVEL_ZERO_LIBRARY}"
+  INTERFACE "${LEVEL_ZERO_LIB_NAME}"
 )
 
 add_library (LevelZeroLoader-Headers INTERFACE)


### PR DESCRIPTION
This commit fixes a bug in the L0 plugin CMake with MSVC when the path to the L0 library starts with /.