### PR TITLE
[SYCL] Reorder enum `read_write_mode`

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_intel_fpga_kernel_arg_properties.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_intel_fpga_kernel_arg_properties.asciidoc
@@ -172,9 +172,9 @@ struct dwidth_key {
 };
 
 enum class read_write_mode_enum {
-  read_write,
   read,
-  write
+  write,
+  read_write
 };
 
 struct read_write_mode_key {

--- a/sycl/include/sycl/ext/oneapi/annotated_arg/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/annotated_arg/properties.hpp
@@ -55,7 +55,7 @@ struct latency_key {
   using value_t = property_value<latency_key, std::integral_constant<int, K>>;
 };
 
-enum class read_write_mode_enum : std::uint16_t { read_write, read, write };
+enum class read_write_mode_enum : std::uint16_t { read, write, read_write };
 
 struct read_write_mode_key {
   template <read_write_mode_enum Mode>


### PR DESCRIPTION
Reorder `read_write_mode_enum` to be consistent with [SPIR-V Access Qualifier](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_access_qualifier)