### PR TITLE
[SYCL] fix comparator to be strictly less-than. 

### DIFF
--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -180,10 +180,7 @@ static std::vector<int> filterDeviceFilter(std::vector<RT::PiDevice> &PiDevices,
     // not add it to the list of available devices.
     std::sort(FilterList->get().begin(), FilterList->get().end(),
               [](const ods_target &filter1, const ods_target &filter2) {
-                std::ignore = filter1;
-                if (filter2.IsNegativeTarget)
-                  return false;
-                return true;
+                return filter1.IsNegativeTarget && !filter2.IsNegativeTarget;
               });
   }
 


### PR DESCRIPTION
the comparator to sort should be strictly less than, rather than lazy boolean check.
On Windows, a debug build may insert a check to make sure that comparator(a,b) != comparator(b,a) and this check results in an assert when tested on the current boolean check 