### PR TITLE
[CI] Exclude image_accessor from SYCL CTS

### DIFF
--- a/devops/cts_exclude_filter
+++ b/devops/cts_exclude_filter
@@ -23,3 +23,4 @@ device_selector
 math_builtin_api
 stream
 marray
+image_accessor


### PR DESCRIPTION
This change propagates the change Khronos SYCL-CTS config file. image_accessor does not build with DPC++. See https://github.com/KhronosGroup/SYCL-CTS/pull/485 for more details.