### PR TITLE
[SYCL] Add imf simd emulation APIs to sycl_ext_intel_math

### DIFF
--- a/sycl/include/sycl/ext/intel/math.hpp
+++ b/sycl/include/sycl/ext/intel/math.hpp
@@ -46,6 +46,8 @@ _iml_half_internal __imf_rsqrtf16(_iml_half_internal);
 float __imf_truncf(float);
 double __imf_trunc(double);
 _iml_half_internal __imf_truncf16(_iml_half_internal);
+unsigned int __imf_vabs2(unsigned int);
+unsigned int __imf_vabs4(unsigned int);
 };
 
 namespace sycl {
@@ -197,6 +199,14 @@ std::enable_if_t<std::is_same_v<Tp, sycl::half>, sycl::half> trunc(Tp x) {
 sycl::half2 trunc(sycl::half2 x) {
   return sycl::half2{trunc(x.s0()), trunc(x.s1())};
 }
+
+// functions for SIMD emulation
+template <typename Tp>
+Tp vabs2(Tp x) = delete;
+template <> unsigned int vabs2(unsigned int x) { return __imf_vabs2(x); }
+template <typename Tp>
+Tp vabs4(Tp x) = delete;
+template <> unsigned int vabs4(unsigned int x) { return __imf_vabs4(x); }
 } // namespace ext::intel::math
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/math.hpp
+++ b/sycl/include/sycl/ext/intel/math.hpp
@@ -11,6 +11,7 @@
 #pragma once
 #include <sycl/builtins.hpp>
 #include <sycl/ext/intel/math/imf_half_trivial.hpp>
+#include <sycl/ext/intel/math/imf_simd.hpp>
 #include <sycl/half_type.hpp>
 #include <type_traits>
 
@@ -49,8 +50,6 @@ _iml_half_internal __imf_rsqrtf16(_iml_half_internal);
 float __imf_truncf(float);
 double __imf_trunc(double);
 _iml_half_internal __imf_truncf16(_iml_half_internal);
-unsigned int __imf_vabs2(unsigned int);
-unsigned int __imf_vabs4(unsigned int);
 };
 
 namespace sycl {
@@ -99,7 +98,8 @@ std::enable_if_t<std::is_same_v<Tp, sycl::half>, sycl::half> ceil(Tp x) {
   return __builtin_bit_cast(sycl::half, __imf_ceilf16(xi));
 }
 
-sycl::half2 ceil(sycl::half2 x) {
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, sycl::half2>, sycl::half2> ceil(Tp x) {
   return sycl::half2{ceil(x.s0()), ceil(x.s1())};
 }
 
@@ -119,7 +119,8 @@ std::enable_if_t<std::is_same_v<Tp, sycl::half>, sycl::half> floor(Tp x) {
   return __builtin_bit_cast(sycl::half, __imf_floorf16(xi));
 }
 
-sycl::half2 floor(sycl::half2 x) {
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, sycl::half2>, sycl::half2> floor(Tp x) {
   return sycl::half2{floor(x.s0()), floor(x.s1())};
 }
 
@@ -139,7 +140,10 @@ std::enable_if_t<std::is_same_v<Tp, sycl::half>, sycl::half> inv(Tp x) {
   return __builtin_bit_cast(sycl::half, __imf_invf16(xi));
 }
 
-sycl::half2 inv(sycl::half2 x) { return sycl::half2{inv(x.s0()), inv(x.s1())}; }
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, sycl::half2>, sycl::half2> inv(Tp x) {
+  return sycl::half2{inv(x.s0()), inv(x.s1())};
+}
 
 template <typename Tp>
 std::enable_if_t<std::is_same_v<Tp, float>, float> rint(Tp x) {
@@ -157,7 +161,8 @@ std::enable_if_t<std::is_same_v<Tp, sycl::half>, sycl::half> rint(Tp x) {
   return __builtin_bit_cast(sycl::half, __imf_rintf16(xi));
 }
 
-sycl::half2 rint(sycl::half2 x) {
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, sycl::half2>, sycl::half2> rint(Tp x) {
   return sycl::half2{rint(x.s0()), rint(x.s1())};
 }
 
@@ -177,7 +182,8 @@ std::enable_if_t<std::is_same_v<Tp, sycl::half>, sycl::half> sqrt(Tp x) {
   return __builtin_bit_cast(sycl::half, __imf_sqrtf16(xi));
 }
 
-sycl::half2 sqrt(sycl::half2 x) {
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, sycl::half2>, sycl::half2> sqrt(Tp x) {
   return sycl::half2{sqrt(x.s0()), sqrt(x.s1())};
 }
 
@@ -197,7 +203,8 @@ std::enable_if_t<std::is_same_v<Tp, sycl::half>, sycl::half> rsqrt(Tp x) {
   return __builtin_bit_cast(sycl::half, __imf_rsqrtf16(xi));
 }
 
-sycl::half2 rsqrt(sycl::half2 x) {
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, sycl::half2>, sycl::half2> rsqrt(Tp x) {
   return sycl::half2{rsqrt(x.s0()), rsqrt(x.s1())};
 }
 
@@ -217,17 +224,11 @@ std::enable_if_t<std::is_same_v<Tp, sycl::half>, sycl::half> trunc(Tp x) {
   return __builtin_bit_cast(sycl::half, __imf_truncf16(xi));
 }
 
-sycl::half2 trunc(sycl::half2 x) {
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, sycl::half2>, sycl::half2> trunc(Tp x) {
   return sycl::half2{trunc(x.s0()), trunc(x.s1())};
 }
 
-// functions for SIMD emulation
-template <typename Tp>
-Tp vabs2(Tp x) = delete;
-template <> unsigned int vabs2(unsigned int x) { return __imf_vabs2(x); }
-template <typename Tp>
-Tp vabs4(Tp x) = delete;
-template <> unsigned int vabs4(unsigned int x) { return __imf_vabs4(x); }
 } // namespace ext::intel::math
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/ext/intel/math/imf_simd.hpp
+++ b/sycl/include/sycl/ext/intel/math/imf_simd.hpp
@@ -1,0 +1,340 @@
+//==-------------- imf_simd.hpp - APIS for simd emulation ------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// APIs for simd emulation
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+extern "C" {
+unsigned int __imf_vabs2(unsigned int);
+unsigned int __imf_vabs4(unsigned int);
+unsigned int __imf_vabsdiffs2(unsigned int, unsigned int);
+unsigned int __imf_vabsdiffs4(unsigned int, unsigned int);
+unsigned int __imf_vabsdiffu2(unsigned int, unsigned int);
+unsigned int __imf_vabsdiffu4(unsigned int, unsigned int);
+unsigned int __imf_vabsss2(unsigned int);
+unsigned int __imf_vabsss4(unsigned int);
+unsigned int __imf_vadd2(unsigned int, unsigned int);
+unsigned int __imf_vadd4(unsigned int, unsigned int);
+unsigned int __imf_vaddss2(unsigned int, unsigned int);
+unsigned int __imf_vaddss4(unsigned int, unsigned int);
+unsigned int __imf_vaddus2(unsigned int, unsigned int);
+unsigned int __imf_vaddus4(unsigned int, unsigned int);
+unsigned int __imf_vavgs2(unsigned int, unsigned int);
+unsigned int __imf_vavgs4(unsigned int, unsigned int);
+unsigned int __imf_vavgu2(unsigned int, unsigned int);
+unsigned int __imf_vavgu4(unsigned int, unsigned int);
+unsigned int __imf_vcmpeq2(unsigned int, unsigned int);
+unsigned int __imf_vcmpeq4(unsigned int, unsigned int);
+unsigned int __imf_vcmpges2(unsigned int, unsigned int);
+unsigned int __imf_vcmpges4(unsigned int, unsigned int);
+unsigned int __imf_vcmpgeu2(unsigned int, unsigned int);
+unsigned int __imf_vcmpgeu4(unsigned int, unsigned int);
+unsigned int __imf_vcmpgts2(unsigned int, unsigned int);
+unsigned int __imf_vcmpgts4(unsigned int, unsigned int);
+unsigned int __imf_vcmpgtu2(unsigned int, unsigned int);
+unsigned int __imf_vcmpgtu4(unsigned int, unsigned int);
+unsigned int __imf_vcmples2(unsigned int, unsigned int);
+unsigned int __imf_vcmples4(unsigned int, unsigned int);
+unsigned int __imf_vcmpleu2(unsigned int, unsigned int);
+unsigned int __imf_vcmpleu4(unsigned int, unsigned int);
+unsigned int __imf_vcmplts2(unsigned int, unsigned int);
+unsigned int __imf_vcmplts4(unsigned int, unsigned int);
+unsigned int __imf_vcmpltu2(unsigned int, unsigned int);
+unsigned int __imf_vcmpltu4(unsigned int, unsigned int);
+unsigned int __imf_vcmpne2(unsigned int, unsigned int);
+unsigned int __imf_vcmpne4(unsigned int, unsigned int);
+unsigned int __imf_vmaxs2(unsigned int, unsigned int);
+unsigned int __imf_vmaxs4(unsigned int, unsigned int);
+unsigned int __imf_vmaxu2(unsigned int, unsigned int);
+unsigned int __imf_vmaxu4(unsigned int, unsigned int);
+unsigned int __imf_vmins2(unsigned int, unsigned int);
+unsigned int __imf_vmins4(unsigned int, unsigned int);
+unsigned int __imf_vminu2(unsigned int, unsigned int);
+unsigned int __imf_vminu4(unsigned int, unsigned int);
+};
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+namespace ext::intel::math {
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vabs2(Tp x) {
+  return __imf_vabs2(x);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vabs4(Tp x) {
+  return __imf_vabs4(x);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vabsdiffs2(Tp x, Tp y) {
+  return __imf_vabsdiffs2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vabsdiffs4(Tp x, Tp y) {
+  return __imf_vabsdiffs4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vabsdiffu2(Tp x, Tp y) {
+  return __imf_vabsdiffu2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vabsdiffu4(Tp x, Tp y) {
+  return __imf_vabsdiffu4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vabsss2(Tp x) {
+  return __imf_vabsss2(x);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vabsss4(Tp x) {
+  return __imf_vabsss4(x);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vadd2(Tp x,
+                                                                       Tp y) {
+  return __imf_vadd2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vadd4(Tp x,
+                                                                       Tp y) {
+  return __imf_vadd4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vaddss2(Tp x,
+                                                                         Tp y) {
+  return __imf_vaddss2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vaddss4(Tp x,
+                                                                         Tp y) {
+  return __imf_vaddss4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vaddus2(Tp x,
+                                                                         Tp y) {
+  return __imf_vaddus2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vaddus4(Tp x,
+                                                                         Tp y) {
+  return __imf_vaddus4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vavgs2(Tp x,
+                                                                        Tp y) {
+  return __imf_vavgs2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vavgs4(Tp x,
+                                                                        Tp y) {
+  return __imf_vavgs4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vavgu2(Tp x,
+                                                                        Tp y) {
+  return __imf_vavgu2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vavgu4(Tp x,
+                                                                        Tp y) {
+  return __imf_vavgu4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vcmpeq2(Tp x,
+                                                                         Tp y) {
+  return __imf_vcmpeq2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vcmpeq4(Tp x,
+                                                                         Tp y) {
+  return __imf_vcmpeq4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vcmpges2(Tp x, Tp y) {
+  return __imf_vcmpges2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vcmpges4(Tp x, Tp y) {
+  return __imf_vcmpges4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vcmpgeu2(Tp x, Tp y) {
+  return __imf_vcmpgeu2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vcmpgeu4(Tp x, Tp y) {
+  return __imf_vcmpgeu4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vcmpgts2(Tp x, Tp y) {
+  return __imf_vcmpgts2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vcmpgts4(Tp x, Tp y) {
+  return __imf_vcmpgts4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vcmpgtu2(Tp x, Tp y) {
+  return __imf_vcmpgtu2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vcmpgtu4(Tp x, Tp y) {
+  return __imf_vcmpgtu4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vcmples2(Tp x, Tp y) {
+  return __imf_vcmples2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vcmples4(Tp x, Tp y) {
+  return __imf_vcmples4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vcmpleu2(Tp x, Tp y) {
+  return __imf_vcmpleu2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vcmpleu4(Tp x, Tp y) {
+  return __imf_vcmpleu4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vcmplts2(Tp x, Tp y) {
+  return __imf_vcmplts2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vcmplts4(Tp x, Tp y) {
+  return __imf_vcmplts4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vcmpltu2(Tp x, Tp y) {
+  return __imf_vcmpltu2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vcmpltu4(Tp x, Tp y) {
+  return __imf_vcmpltu4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vcmpne2(Tp x,
+                                                                         Tp y) {
+  return __imf_vcmpne2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vcmpne4(Tp x,
+                                                                         Tp y) {
+  return __imf_vcmpne4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vmaxs2(Tp x,
+                                                                        Tp y) {
+  return __imf_vmaxs2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vmaxs4(Tp x,
+                                                                        Tp y) {
+  return __imf_vmaxs4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vmaxu2(Tp x,
+                                                                        Tp y) {
+  return __imf_vmaxu2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vmaxu4(Tp x,
+                                                                        Tp y) {
+  return __imf_vmaxu4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vmins2(Tp x,
+                                                                        Tp y) {
+  return __imf_vmins2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vmins4(Tp x,
+                                                                        Tp y) {
+  return __imf_vmins4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vminu2(Tp x,
+                                                                        Tp y) {
+  return __imf_vminu2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vminu4(Tp x,
+                                                                        Tp y) {
+  return __imf_vminu4(x, y);
+}
+
+} // namespace ext::intel::math
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
+} // namespace sycl

--- a/sycl/include/sycl/ext/intel/math/imf_simd.hpp
+++ b/sycl/include/sycl/ext/intel/math/imf_simd.hpp
@@ -13,6 +13,10 @@
 extern "C" {
 unsigned int __imf_vabs2(unsigned int);
 unsigned int __imf_vabs4(unsigned int);
+unsigned int __imf_vneg2(unsigned int);
+unsigned int __imf_vneg4(unsigned int);
+unsigned int __imf_vnegss2(unsigned int);
+unsigned int __imf_vnegss4(unsigned int);
 unsigned int __imf_vabsdiffs2(unsigned int, unsigned int);
 unsigned int __imf_vabsdiffs4(unsigned int, unsigned int);
 unsigned int __imf_vabsdiffu2(unsigned int, unsigned int);
@@ -25,6 +29,14 @@ unsigned int __imf_vaddss2(unsigned int, unsigned int);
 unsigned int __imf_vaddss4(unsigned int, unsigned int);
 unsigned int __imf_vaddus2(unsigned int, unsigned int);
 unsigned int __imf_vaddus4(unsigned int, unsigned int);
+unsigned int __imf_vsub2(unsigned int, unsigned int);
+unsigned int __imf_vsub4(unsigned int, unsigned int);
+unsigned int __imf_vsubss2(unsigned int, unsigned int);
+unsigned int __imf_vsubss4(unsigned int, unsigned int);
+unsigned int __imf_vsubus2(unsigned int, unsigned int);
+unsigned int __imf_vsubus4(unsigned int, unsigned int);
+unsigned int __imf_vhaddu2(unsigned int, unsigned int);
+unsigned int __imf_vhaddu4(unsigned int, unsigned int);
 unsigned int __imf_vavgs2(unsigned int, unsigned int);
 unsigned int __imf_vavgs4(unsigned int, unsigned int);
 unsigned int __imf_vavgu2(unsigned int, unsigned int);
@@ -57,6 +69,30 @@ unsigned int __imf_vmins2(unsigned int, unsigned int);
 unsigned int __imf_vmins4(unsigned int, unsigned int);
 unsigned int __imf_vminu2(unsigned int, unsigned int);
 unsigned int __imf_vminu4(unsigned int, unsigned int);
+unsigned int __imf_vseteq2(unsigned int, unsigned int);
+unsigned int __imf_vseteq4(unsigned int, unsigned int);
+unsigned int __imf_vsetne2(unsigned int, unsigned int);
+unsigned int __imf_vsetne4(unsigned int, unsigned int);
+unsigned int __imf_vsetges2(unsigned int, unsigned int);
+unsigned int __imf_vsetges4(unsigned int, unsigned int);
+unsigned int __imf_vsetgeu2(unsigned int, unsigned int);
+unsigned int __imf_vsetgeu4(unsigned int, unsigned int);
+unsigned int __imf_vsetgts2(unsigned int, unsigned int);
+unsigned int __imf_vsetgts4(unsigned int, unsigned int);
+unsigned int __imf_vsetgtu2(unsigned int, unsigned int);
+unsigned int __imf_vsetgtu4(unsigned int, unsigned int);
+unsigned int __imf_vsetles2(unsigned int, unsigned int);
+unsigned int __imf_vsetles4(unsigned int, unsigned int);
+unsigned int __imf_vsetleu2(unsigned int, unsigned int);
+unsigned int __imf_vsetleu4(unsigned int, unsigned int);
+unsigned int __imf_vsetlts2(unsigned int, unsigned int);
+unsigned int __imf_vsetlts4(unsigned int, unsigned int);
+unsigned int __imf_vsetltu2(unsigned int, unsigned int);
+unsigned int __imf_vsetltu4(unsigned int, unsigned int);
+unsigned int __imf_vsads2(unsigned int, unsigned int);
+unsigned int __imf_vsads4(unsigned int, unsigned int);
+unsigned int __imf_vsadu2(unsigned int, unsigned int);
+unsigned int __imf_vsadu4(unsigned int, unsigned int);
 };
 
 namespace sycl {
@@ -71,6 +107,26 @@ std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vabs2(Tp x) {
 template <typename Tp>
 std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vabs4(Tp x) {
   return __imf_vabs4(x);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vneg2(Tp x) {
+  return __imf_vneg2(x);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vneg4(Tp x) {
+  return __imf_vneg4(x);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vnegss2(Tp x) {
+  return __imf_vnegss2(x);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vnegss4(Tp x) {
+  return __imf_vnegss4(x);
 }
 
 template <typename Tp>
@@ -141,6 +197,54 @@ template <typename Tp>
 std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vaddus4(Tp x,
                                                                          Tp y) {
   return __imf_vaddus4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vsub2(Tp x,
+                                                                       Tp y) {
+  return __imf_vsub2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vsub4(Tp x,
+                                                                       Tp y) {
+  return __imf_vsub4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vsubss2(Tp x,
+                                                                         Tp y) {
+  return __imf_vsubss2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vsubss4(Tp x,
+                                                                         Tp y) {
+  return __imf_vsubss4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vsubus2(Tp x,
+                                                                         Tp y) {
+  return __imf_vsubus2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vsubus4(Tp x,
+                                                                         Tp y) {
+  return __imf_vsubus4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vhaddu2(Tp x,
+                                                                         Tp y) {
+  return __imf_vhaddu2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vhaddu4(Tp x,
+                                                                         Tp y) {
+  return __imf_vhaddu4(x, y);
 }
 
 template <typename Tp>
@@ -335,6 +439,149 @@ std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vminu4(Tp x,
   return __imf_vminu4(x, y);
 }
 
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vseteq2(Tp x,
+                                                                         Tp y) {
+  return __imf_vseteq2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vseteq4(Tp x,
+                                                                         Tp y) {
+  return __imf_vseteq4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vsetne2(Tp x,
+                                                                         Tp y) {
+  return __imf_vsetne2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vsetne4(Tp x,
+                                                                         Tp y) {
+  return __imf_vsetne4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vsetges2(Tp x, Tp y) {
+  return __imf_vsetges2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vsetges4(Tp x, Tp y) {
+  return __imf_vsetges4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vsetgeu2(Tp x, Tp y) {
+  return __imf_vsetgeu2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vsetgeu4(Tp x, Tp y) {
+  return __imf_vsetgeu4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vsetgts2(Tp x, Tp y) {
+  return __imf_vsetgts2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vsetgts4(Tp x, Tp y) {
+  return __imf_vsetgts4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vsetgtu2(Tp x, Tp y) {
+  return __imf_vsetgtu2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vsetgtu4(Tp x, Tp y) {
+  return __imf_vsetgtu4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vsetles2(Tp x, Tp y) {
+  return __imf_vsetles2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vsetles4(Tp x, Tp y) {
+  return __imf_vsetles4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vsetleu2(Tp x, Tp y) {
+  return __imf_vsetleu2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vsetleu4(Tp x, Tp y) {
+  return __imf_vsetleu4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vsetlts2(Tp x, Tp y) {
+  return __imf_vsetlts2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vsetlts4(Tp x, Tp y) {
+  return __imf_vsetlts4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vsetltu2(Tp x, Tp y) {
+  return __imf_vsetltu2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int>
+vsetltu4(Tp x, Tp y) {
+  return __imf_vsetltu4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vsads2(Tp x,
+                                                                        Tp y) {
+  return __imf_vsads2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vsads4(Tp x,
+                                                                        Tp y) {
+  return __imf_vsads4(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vsadu2(Tp x,
+                                                                        Tp y) {
+  return __imf_vsadu2(x, y);
+}
+
+template <typename Tp>
+std::enable_if_t<std::is_same_v<Tp, unsigned int>, unsigned int> vsadu4(Tp x,
+                                                                        Tp y) {
+  return __imf_vsadu4(x, y);
+}
 } // namespace ext::intel::math
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl


### PR DESCRIPTION
CUDA math provides a series of simd intrinsic: https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__INTRINSIC__SIMD.html#group__CUDA__MATH__INTRINSIC__SIMD
We provided corresponding APIs in SYCL libdevice which emulates the behaviors of these CUDA simd intrinsic.
The PR  adds these APIs to sycl_ext_intel_math header file, so users can invoke them when porting CUDA code to SYCL.