### PR TITLE
[SYCL][CUDA] Remove obsolete ScopedContext workaround

### DIFF
--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -188,7 +188,7 @@ pi_result check_error(CUresult result, const char *function, int line,
 /// contexts to be restored by SYCL.
 class ScopedContext {
 public:
-  ScopedContext(pi_context ctxt) : device(nullptr) {
+  ScopedContext(pi_context ctxt) {
     if (!ctxt) {
       throw PI_ERROR_INVALID_CONTEXT;
     }
@@ -196,22 +196,9 @@ public:
     set_context(ctxt->get());
   }
 
-  ScopedContext(CUcontext ctxt) : device(nullptr) { set_context(ctxt); }
+  ScopedContext(CUcontext ctxt) { set_context(ctxt); }
 
-  // Creating a scoped context from a device will simply use the primary
-  // context, this should be used when there is no other appropriate context,
-  // such as for the device infos.
-  ScopedContext(pi_device device) : device(device) {
-    CUcontext ctxt;
-    cuDevicePrimaryCtxRetain(&ctxt, device->get());
-
-    set_context(ctxt);
-  }
-
-  ~ScopedContext() {
-    if (device)
-      cuDevicePrimaryCtxRelease(device->get());
-  }
+  ~ScopedContext() {}
 
 private:
   void set_context(CUcontext desired) {
@@ -225,8 +212,6 @@ private:
       PI_CHECK_ERROR(cuCtxSetCurrent(desired));
     }
   }
-
-  pi_device device;
 };
 
 /// \cond NODOXY


### PR DESCRIPTION
This is no longer needed with intel/llvm#8197