### PR TITLE
[SYCL][CTS] Ignore image_accessor for DPCPP

### DIFF
--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -1,7 +1,7 @@
 name: SYCL Post Commit
 
 on:
-  push:
+  pull_request_target:
     branches:
     - sycl
   pull_request:

--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -1,5 +1,6 @@
 name: SYCL Post Commit
 
+
 on:
   pull_request_target:
     branches:

--- a/devops/cts_exclude_filter
+++ b/devops/cts_exclude_filter
@@ -23,3 +23,4 @@ device_selector
 math_builtin_api
 stream
 marray
+image_accessor


### PR DESCRIPTION
Currently we observe failure in post-commit on CUDA in CTS: https://github.com/intel/llvm/actions/runs/4129760637/jobs/7136039243,
and image_accessor is not yet supported by DPCPP