### PR TITLE
[SYCL-MLIR] Change sycl.call assembly format

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -724,7 +724,7 @@ def SYCLCallOp : SYCL_Op<"call", [CallOpInterface]> {
   }];    
 
   let assemblyFormat = [{
-    `(` $Args `)` attr-dict `:` functional-type($Args, results)
+    $FunctionName `(` $Args `)` attr-dict `:` functional-type($Args, results)
   }];
 }
 

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-call-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-call-to-llvm.mlir
@@ -12,7 +12,7 @@
 func.func private @foo() -> (i32)
 
 func.func @test() -> (i32) {
-  %0 = sycl.call() {FunctionName = @foo, MangledFunctionName = @foo, TypeName = @accessor} : () -> i32
+  %0 = sycl.call @foo() {MangledFunctionName = @foo, TypeName = @accessor} : () -> i32
   return %0 : i32
 }
 
@@ -31,7 +31,7 @@ func.func private @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6target
 
 func.func @accessorInit1(%arg0: memref<?x!sycl_accessor_1_i32_rw_gb>, %arg1: memref<?xi32>, %arg2: !sycl_range_1_, %arg3: !sycl_range_1_, %arg4: !sycl_id_1_) {
   // CHECK: llvm.call @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE({{.*}}) : ([[ARG_TYPES]]) -> ()
-  sycl.call(%arg0, %arg1, %arg2, %arg3, %arg4) {FunctionName = @__init, MangledFunctionName = @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?xi32>, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_) -> ()
+  sycl.call @__init(%arg0, %arg1, %arg2, %arg3, %arg4) {MangledFunctionName = @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?xi32>, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_) -> ()
   return
 }
 

--- a/mlir-sycl/test/Dialect/IR/SYCL/ops.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/ops.mlir
@@ -8,6 +8,36 @@
 !sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 !sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
 
+// CHECK-LABEL: test_void_call
+func.func @test_void_call() {
+  sycl.call @foo() {MangledFunctionName = @foov, TypeName = @A} : () -> ()
+  return
+}
+
+// CHECK-LABEL: test_void_call_with_arg
+func.func @test_void_call_with_arg(%arg_0: i32) {
+  sycl.call @foo(%arg_0) {MangledFunctionName = @fooi, TypeName = @A} : (i32) -> ()
+  return
+}
+
+// CHECK-LABEL: test_i32_call
+func.func @test_i32_call() {
+  %0 = sycl.call @bar() {MangledFunctionName = @barv, TypeName = @A} : () -> (i32)
+  return
+}
+
+// CHECK-LABEL: test_i32_call_with_arg
+func.func @test_i32_call_with_arg(%arg_0: i32) {
+  %0 = sycl.call @bar(%arg_0) {MangledFunctionName = @bari, TypeName = @A} : (i32) -> (i32)
+  return
+}
+
+// CHECK-LABEL: test_i32_call_with_two_args
+func.func @test_i32_call_with_two_args(%arg_0: i32, %arg_1: i64) {
+  %0 = sycl.call @bar(%arg_0, %arg_1) {MangledFunctionName = @baril, TypeName = @A} : (i32, i64) -> (i32)
+  return
+}
+
 // CHECK-LABEL: test_num_work_items
 func.func @test_num_work_items() -> !sycl_range_1_ {
   %0 = sycl.num_work_items() : () -> !sycl_range_1_

--- a/mlir-sycl/test/Transforms/inliner.mlir
+++ b/mlir-sycl/test/Transforms/inliner.mlir
@@ -9,11 +9,11 @@
 
 // ALWAYS-INLINE-LABEL: func.func @caller() -> i32 {
 // ALWAYS-INLINE-NEXT:    %c1_i32 = arith.constant 1 : i32
-// ALWAYS-INLINE-NEXT:    %0 = sycl.call() {FunctionName = @inline_hint_callee_, MangledFunctionName = @inline_hint_callee, TypeName = @A} : () -> i32
-// ALWAYS-INLINE-NEXT:    %1 = sycl.call() {FunctionName = @private_callee_, MangledFunctionName = @private_callee, TypeName = @A} : () -> i32
-// ALWAYS-INLINE-NEXT:    %2 = sycl.call() {FunctionName = @small_callee_, MangledFunctionName = @small_callee, TypeName = @A} : () -> i32
-// ALWAYS-INLINE-NEXT:    %3 = sycl.call() {FunctionName = @callee_, MangledFunctionName = @callee, TypeName = @A} : () -> i32
-// ALWAYS-INLINE-NEXT:    %4 = sycl.call() {FunctionName = @gpu_func_callee_, MangledFunctionName = @gpu_func_callee, TypeName = @A} : () -> i32
+// ALWAYS-INLINE-NEXT:    %0 = sycl.call @inline_hint_callee_() {MangledFunctionName = @inline_hint_callee, TypeName = @A} : () -> i32
+// ALWAYS-INLINE-NEXT:    %1 = sycl.call @private_callee_() {MangledFunctionName = @private_callee, TypeName = @A} : () -> i32
+// ALWAYS-INLINE-NEXT:    %2 = sycl.call @small_callee_() {MangledFunctionName = @small_callee, TypeName = @A} : () -> i32
+// ALWAYS-INLINE-NEXT:    %3 = sycl.call @callee_() {MangledFunctionName = @callee, TypeName = @A} : () -> i32
+// ALWAYS-INLINE-NEXT:    %4 = sycl.call @gpu_func_callee_() {MangledFunctionName = @gpu_func_callee, TypeName = @A} : () -> i32
 // ALWAYS-INLINE-NEXT:    %5 = arith.addi %c1_i32, %0 : i32
 // ALWAYS-INLINE-NEXT:    %6 = arith.addi %1, %2 : i32
 // ALWAYS-INLINE-NEXT:    %7 = arith.addi %3, %4 : i32
@@ -40,8 +40,8 @@
 // INLINE-DAG:     %c2_i32 = arith.constant 2 : i32
 // INLINE-DAG:     %c3_i32 = arith.constant 3 : i32
 // INLINE-DAG:     %c4_i32 = arith.constant 4 : i32
-// INLINE-NEXT:    %0 = sycl.call() {FunctionName = @callee_, MangledFunctionName = @callee, TypeName = @A} : () -> i32
-// INLINE-NEXT:    %1 = sycl.call() {FunctionName = @gpu_func_callee_, MangledFunctionName = @gpu_func_callee, TypeName = @A} : () -> i32
+// INLINE-NEXT:    %0 = sycl.call @callee_() {MangledFunctionName = @callee, TypeName = @A} : () -> i32
+// INLINE-NEXT:    %1 = sycl.call @gpu_func_callee_() {MangledFunctionName = @gpu_func_callee, TypeName = @A} : () -> i32
 // INLINE-NEXT:    %2 = arith.addi %c1_i32, %c2_i32 : i32
 // INLINE-NEXT:    %3 = arith.addi %c3_i32, %c4_i32 : i32
 // INLINE-NEXT:    %4 = arith.addi %0, %1 : i32
@@ -60,12 +60,12 @@
 gpu.module @module {
 
 func.func @caller() -> i32 {
-  %res1 = sycl.call() {FunctionName = @"always_inline_callee_", MangledFunctionName = @always_inline_callee, TypeName = @A} : () -> i32
-  %res2 = sycl.call() {FunctionName = @"inline_hint_callee_", MangledFunctionName = @inline_hint_callee, TypeName = @A} : () -> i32
-  %res3 = sycl.call() {FunctionName = @"private_callee_", MangledFunctionName = @private_callee, TypeName = @A} : () -> i32
-  %res4 = sycl.call() {FunctionName = @"small_callee_", MangledFunctionName = @small_callee, TypeName = @A} : () -> i32
-  %res5 = sycl.call() {FunctionName = @"callee_", MangledFunctionName = @callee, TypeName = @A} : () -> i32  
-  %res6 = sycl.call() {FunctionName = @"gpu_func_callee_", MangledFunctionName = @gpu_func_callee, TypeName = @A} : () -> i32
+  %res1 = sycl.call @always_inline_callee_() {MangledFunctionName = @always_inline_callee, TypeName = @A} : () -> i32
+  %res2 = sycl.call @inline_hint_callee_() {MangledFunctionName = @inline_hint_callee, TypeName = @A} : () -> i32
+  %res3 = sycl.call @private_callee_() {MangledFunctionName = @private_callee, TypeName = @A} : () -> i32
+  %res4 = sycl.call @small_callee_() {MangledFunctionName = @small_callee, TypeName = @A} : () -> i32
+  %res5 = sycl.call @callee_() {MangledFunctionName = @callee, TypeName = @A} : () -> i32  
+  %res6 = sycl.call @gpu_func_callee_() {MangledFunctionName = @gpu_func_callee, TypeName = @A} : () -> i32
   %add1 = arith.addi %res1, %res2 : i32
   %add2 = arith.addi %res3, %res4 : i32  
   %add3 = arith.addi %res5, %res6 : i32  
@@ -117,8 +117,8 @@ gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
 // COM: Ensure a func.func can be inlined in a gpu.func caller iff the callee is 'alwaysinline'. 
 // ALWAYS-INLINE-LABEL: gpu.func @caller() -> i32 {
 // ALWAYS-INLINE-NEXT:    %c1_i32 = arith.constant 1 : i32  
-// ALWAYS-INLINE-NEXT:    %0 = sycl.call() {FunctionName = @callee_, MangledFunctionName = @callee, TypeName = @A} : () -> i32
-// ALWAYS-INLINE-NEXT:    %1 = sycl.call() {FunctionName = @gpu_callee_, MangledFunctionName = @gpu_func_callee, TypeName = @A} : () -> i32
+// ALWAYS-INLINE-NEXT:    %0 = sycl.call @callee_() {MangledFunctionName = @callee, TypeName = @A} : () -> i32
+// ALWAYS-INLINE-NEXT:    %1 = sycl.call @gpu_callee_() {MangledFunctionName = @gpu_func_callee, TypeName = @A} : () -> i32
 // ALWAYS-INLINE-NEXT:    %2 = arith.addi %c1_i32, %0 : i32
 // ALWAYS-INLINE-NEXT:    %3 = arith.addi %2, %1 : i32
 // ALWAYS-INLINE-NEXT:    gpu.return %3 : i32
@@ -127,8 +127,8 @@ gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
 // COM: Ensure a func.func can be inlined in a gpu.func caller. 
 // INLINE-LABEL: gpu.func @caller() -> i32 {
 // INLINE-NEXT:    %c1_i32 = arith.constant 1 : i32  
-// INLINE-NEXT:    %0 = sycl.call() {FunctionName = @callee_, MangledFunctionName = @callee, TypeName = @A} : () -> i32
-// INLINE-NEXT:    %1 = sycl.call() {FunctionName = @gpu_callee_, MangledFunctionName = @gpu_func_callee, TypeName = @A} : () -> i32
+// INLINE-NEXT:    %0 = sycl.call @callee_() {MangledFunctionName = @callee, TypeName = @A} : () -> i32
+// INLINE-NEXT:    %1 = sycl.call @gpu_callee_() {MangledFunctionName = @gpu_func_callee, TypeName = @A} : () -> i32
 // INLINE-NEXT:    %2 = arith.addi %c1_i32, %0 : i32
 // INLINE-NEXT:    %3 = arith.addi %2, %1 : i32
 // INLINE-NEXT:    gpu.return %3 : i32
@@ -137,9 +137,9 @@ gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
 gpu.module @module {
 
 gpu.func @caller() -> i32 {
-  %res1 = sycl.call() {FunctionName = @"inlinable_callee_", MangledFunctionName = @inlinable_callee, TypeName = @A} : () -> i32
-  %res2 = sycl.call() {FunctionName = @"callee_", MangledFunctionName = @callee, TypeName = @A} : () -> i32  
-  %res3 = sycl.call() {FunctionName = @"gpu_callee_", MangledFunctionName = @gpu_func_callee, TypeName = @A} : () -> i32
+  %res1 = sycl.call @inlinable_callee_() {MangledFunctionName = @inlinable_callee, TypeName = @A} : () -> i32
+  %res2 = sycl.call @callee_() {MangledFunctionName = @callee, TypeName = @A} : () -> i32  
+  %res3 = sycl.call @gpu_callee_() {MangledFunctionName = @gpu_func_callee, TypeName = @A} : () -> i32
   %res4 = arith.addi %res1, %res2 : i32
   %res5 = arith.addi %res4, %res3 : i32  
   gpu.return %res5 : i32
@@ -176,7 +176,7 @@ gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
 // INLINE-DAG:     %c2_i32 = arith.constant 2 : i32
 // INLINE-DAG:     %c1_i32_0 = arith.constant 1 : i32
 // INLINE-DAG:     %c2_i32_1 = arith.constant 2 : i32
-// INLINE-DAG:     %0 = sycl.call() {FunctionName = @callee_, MangledFunctionName = @callee, TypeName = @A} : () -> i32
+// INLINE-DAG:     %0 = sycl.call @callee_() {MangledFunctionName = @callee, TypeName = @A} : () -> i32
 // INLINE-NEXT:    %1 = arith.addi %c2_i32_1, %0 : i32
 // INLINE-NEXT:    %2 = arith.addi %c1_i32_0, %1 : i32
 // INLINE-NEXT:    %3 = arith.addi %c1_i32, %c2_i32 : i32
@@ -189,14 +189,14 @@ gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
 
 func.func private @inline_hint_callee() -> i32 attributes {passthrough = ["inlinehint"]} {
   %c_i32 = arith.constant 1 : i32
-  %res1 = sycl.call() {FunctionName = @"private_callee_", MangledFunctionName = @private_callee, TypeName = @A} : () -> i32
+  %res1 = sycl.call @private_callee_() {MangledFunctionName = @private_callee, TypeName = @A} : () -> i32
   %res2 = arith.addi %c_i32, %res1 : i32
   return %res2 : i32
 }
 
 func.func private @private_callee() -> i32 {
   %c_i32 = arith.constant 2 : i32
-  %res1 = sycl.call() {FunctionName = @"callee_", MangledFunctionName = @callee, TypeName = @A} : () -> i32
+  %res1 = sycl.call @callee_() {MangledFunctionName = @callee, TypeName = @A} : () -> i32
   %res2 = arith.addi %c_i32, %res1 : i32
   return %res2 : i32
 }
@@ -204,7 +204,7 @@ func.func private @private_callee() -> i32 {
 func.func @callee() -> i32 {
   %c1 = arith.constant 1 : i32
   %c2 = arith.constant 2 : i32
-  %res1 = sycl.call() {FunctionName = @"inline_hint_callee_", MangledFunctionName = @inline_hint_callee, TypeName = @A} : () -> i32    
+  %res1 = sycl.call @inline_hint_callee_() {MangledFunctionName = @inline_hint_callee, TypeName = @A} : () -> i32    
   %add1 = arith.addi %c1, %c2 : i32
   %add2 = arith.addi %res1, %add1 : i32  
   return %add2 : i32

--- a/mlir-sycl/test/Transforms/sycl-method-to-sycl-call.mlir
+++ b/mlir-sycl/test/Transforms/sycl-method-to-sycl-call.mlir
@@ -20,7 +20,7 @@
 // CHECK-NEXT:      %[[VAL_6:.*]] = "polygeist.pointer2memref"(%[[VAL_5]]) : (!llvm.ptr<!sycl_accessor_2_i32_rw_gb, 4>) -> memref<?x!sycl_accessor_2_i32_rw_gb, 4>
 // CHECK-NEXT:      memref.store %[[VAL_1]], %[[ID_ALLOCA]]{{\[}}%[[VAL_2]]] : memref<1x!sycl_id_2_>
 // CHECK-NEXT:      %[[ID_CAST:.*]] = memref.cast %[[ID_ALLOCA]] : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
-// CHECK-NEXT:      %[[VAL_7:.*]] = sycl.call(%[[VAL_6]], %[[ID_CAST]]) {FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
+// CHECK-NEXT:      %[[VAL_7:.*]] = sycl.call @"operator[]"(%[[VAL_6]], %[[ID_CAST]]) {MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
 // CHECK-NEXT:      return %[[VAL_7]] : memref<?xi32, 4>
 // CHECK-NEXT:    }
 
@@ -39,7 +39,7 @@ func.func @accessor_subscript_operator(%arg0: !sycl_accessor_2_i32_rw_gb, %arg1:
 // CHECK-NEXT:      %[[VAL_5:.*]] = llvm.addrspacecast %[[VAL_4]] : !llvm.ptr<!sycl_range_2_> to !llvm.ptr<!sycl_range_2_, 4>
 // CHECK-NEXT:      %[[VAL_6:.*]] = "polygeist.pointer2memref"(%[[VAL_5]]) : (!llvm.ptr<!sycl_range_2_, 4>) -> memref<?x!sycl_range_2_, 4>
 // CHECK-NEXT:      %[[VAL_7:.*]] = sycl.cast(%[[VAL_6]]) : (memref<?x!sycl_range_2_, 4>) -> memref<?x!sycl_array_2_, 4>
-// CHECK-NEXT:      %[[VAL_8:.*]] = sycl.call(%[[VAL_7]], %[[VAL_1]]) {FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_array_2_, 4>, i32) -> i64
+// CHECK-NEXT:      %[[VAL_8:.*]] = sycl.call @get(%[[VAL_7]], %[[VAL_1]]) {MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_array_2_, 4>, i32) -> i64
 // CHECK-NEXT:      return %[[VAL_8]] : i64
 // CHECK-NEXT:    }
 
@@ -56,7 +56,7 @@ func.func @range_get(%arg0: !sycl_range_2_, %arg1: i32) -> i64 {
 // CHECK-NEXT:      %[[VAL_3:.*]] = "polygeist.memref2pointer"(%[[VAL_2]]) : (memref<1x!sycl_range_2_>) -> !llvm.ptr<!sycl_range_2_>
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.addrspacecast %[[VAL_3]] : !llvm.ptr<!sycl_range_2_> to !llvm.ptr<!sycl_range_2_, 4>
 // CHECK-NEXT:      %[[VAL_5:.*]] = "polygeist.pointer2memref"(%[[VAL_4]]) : (!llvm.ptr<!sycl_range_2_, 4>) -> memref<?x!sycl_range_2_, 4>
-// CHECK-NEXT:      %[[VAL_6:.*]] = sycl.call(%[[VAL_5]]) {FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl_range_2_, 4>) -> i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = sycl.call @size(%[[VAL_5]]) {MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl_range_2_, 4>) -> i64
 // CHECK-NEXT:      return %[[VAL_6]] : i64
 // CHECK-NEXT:    }
 
@@ -73,7 +73,7 @@ func.func @range_size(%arg0: !sycl_range_2_) -> i64 {
 // CHECK-NEXT:      %[[VAL_3:.*]] = "polygeist.memref2pointer"(%[[VAL_2]]) : (memref<1x!sycl_item_1_>) -> !llvm.ptr<!sycl_item_1_>
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.addrspacecast %[[VAL_3]] : !llvm.ptr<!sycl_item_1_> to !llvm.ptr<!sycl_item_1_, 4>
 // CHECK-NEXT:      %[[VAL_5:.*]] = "polygeist.pointer2memref"(%[[VAL_4]]) : (!llvm.ptr<!sycl_item_1_, 4>) -> memref<?x!sycl_item_1_, 4>
-// CHECK-NEXT:      %[[VAL_6:.*]] = sycl.call(%[[VAL_5]]) {FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x!sycl_item_1_, 4>) -> !sycl_id_1_
+// CHECK-NEXT:      %[[VAL_6:.*]] = sycl.call @get_id(%[[VAL_5]]) {MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x!sycl_item_1_, 4>) -> !sycl_id_1_
 // CHECK-NEXT:      return %[[VAL_6]] : !sycl_id_1_
 // CHECK-NEXT:    }
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -655,7 +655,7 @@ SYCL_EXTERNAL void group_get_local_linear_range(sycl::group<1> group) {
 // CHECK-MLIR-NEXT: %0 = "polygeist.memref2pointer"(%arg0) : (memref<?x![[ITEM2]]>) -> !llvm.ptr<![[ITEM2]]>
 // CHECK-MLIR-NEXT: %1 = llvm.addrspacecast %0 : !llvm.ptr<![[ITEM2]]> to !llvm.ptr<![[ITEM2]], 4>
 // CHECK-MLIR-NEXT: %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<![[ITEM2]], 4>) -> memref<?x![[ITEM2]], 4>
-// CHECK-MLIR-NEXT: %3 = sycl.call(%2, %2) {FunctionName = @"operator==", MangledFunctionName = @_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_, TypeName = @item} : (memref<?x![[ITEM2]], 4>, memref<?x![[ITEM2]], 4>) -> i1
+// CHECK-MLIR-NEXT: %3 = sycl.call @"operator=="(%2, %2) {MangledFunctionName = @_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_, TypeName = @item} : (memref<?x![[ITEM2]], 4>, memref<?x![[ITEM2]], 4>) -> i1
 // CHECK-MLIR-NEXT: return
 // CHECK-MLIR-NEXT: }
 
@@ -678,7 +678,7 @@ SYCL_EXTERNAL void method_2(sycl::item<2, true> item) {
 // CHECK-MLIR-NEXT: %3 = "polygeist.memref2pointer"(%arg1) : (memref<?x!sycl_id_2_>) -> !llvm.ptr<!sycl_id_2_>
 // CHECK-MLIR-NEXT: %4 = llvm.addrspacecast %3 : !llvm.ptr<!sycl_id_2_> to !llvm.ptr<!sycl_id_2_, 4>
 // CHECK-MLIR-NEXT: %5 = "polygeist.pointer2memref"(%4) : (!llvm.ptr<!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
-// CHECK-MLIR-NEXT: %6 = sycl.call(%2, %5) {FunctionName = @"operator==", MangledFunctionName = @_ZNK4sycl3_V12idILi2EEeqERKS2_, TypeName = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> i1
+// CHECK-MLIR-NEXT: %6 = sycl.call @"operator=="(%2, %5) {MangledFunctionName = @_ZNK4sycl3_V12idILi2EEeqERKS2_, TypeName = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> i1
 // CHECK-MLIR-NEXT: return
 // CHECK-MLIR-NEXT: }
 
@@ -702,7 +702,7 @@ SYCL_EXTERNAL void op_1(sycl::id<2> a, sycl::id<2> b) {
 // CHECK-MLIR-NEXT: %1 = "sycl.id.get"(%0, %c0_i32) {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (!sycl_id_2_, i32) -> i64
 // CHECK-MLIR-NEXT: %2 = "sycl.id.get"(%0, %c1_i32) {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (!sycl_id_2_, i32) -> i64
 // CHECK-MLIR-NEXT: %3 = arith.addi %1, %2 : i64
-// CHECK-MLIR-NEXT: %4 = sycl.call(%3) {FunctionName = @abs, MangledFunctionName = @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_} : (i64) -> i64
+// CHECK-MLIR-NEXT: %4 = sycl.call @abs(%3) {MangledFunctionName = @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_} : (i64) -> i64
 // CHECK-MLIR-NEXT: return
 // CHECK-MLIR-NEXT: }
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/image.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/image.cpp
@@ -8,7 +8,7 @@ static constexpr unsigned N = 8;
 
 // CHECK-LABEL:  func.func @_ZN4sycl3_V18accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS4_6targetE2017ELNS4_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initE14ocl_image1d_ro(%arg0: memref<?x!sycl_accessor_1_21sycl2Evec3C5Bf322C_45D2C_28vector3C4xf323E293E_r_i, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 32 : i64, llvm.noundef}, %arg1: !llvm.ptr<struct<"opencl.image1d_ro_t", opaque>, 1>)
 // CHECK-NEXT:    %0 = "polygeist.memref2pointer"(%arg0) : (memref<?x!sycl_accessor_1_21sycl2Evec3C5Bf322C_45D2C_28vector3C4xf323E293E_r_i, 4>) -> !llvm.ptr<struct<(ptr<struct<"opencl.image1d_ro_t", opaque>, 1>, array<24 x i8>)>, 4>
-// CHECK-NEXT:    sycl.call(%0, %arg1) {FunctionName = @imageAccessorInit, MangledFunctionName = @_ZN4sycl3_V16detail14image_accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS5_6targetE2017ELNS5_11placeholderE0EE17imageAccessorInitE14ocl_image1d_ro, TypeName = @image_accessor} : (!llvm.ptr<struct<(ptr<struct<"opencl.image1d_ro_t", opaque>, 1>, array<24 x i8>)>, 4>, !llvm.ptr<struct<"opencl.image1d_ro_t", opaque>, 1>) -> ()
+// CHECK-NEXT:    sycl.call @imageAccessorInit(%0, %arg1) {MangledFunctionName = @_ZN4sycl3_V16detail14image_accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS5_6targetE2017ELNS5_11placeholderE0EE17imageAccessorInitE14ocl_image1d_ro, TypeName = @image_accessor} : (!llvm.ptr<struct<(ptr<struct<"opencl.image1d_ro_t", opaque>, 1>, array<24 x i8>)>, 4>, !llvm.ptr<struct<"opencl.image1d_ro_t", opaque>, 1>) -> ()
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 
@@ -25,7 +25,7 @@ static constexpr unsigned N = 8;
 // CHECK-NEXT:    %6 = llvm.addrspacecast %5 : !llvm.ptr<i32> to !llvm.ptr<i32, 4>
 // CHECK-NEXT:    %7 = "polygeist.pointer2memref"(%6) : (!llvm.ptr<i32, 4>) -> memref<?xi32, 4>
 // CHECK-NEXT:    llvm.store %4, %6 : !llvm.ptr<i32, 4>
-// CHECK-NEXT:    %8 = sycl.call(%1, %7) {FunctionName = @read, MangledFunctionName = @_ZNK4sycl3_V16detail14image_accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS5_6targetE2017ELNS5_11placeholderE0EE4readIiLi1EvEES4_RKT_, TypeName = @image_accessor} : (!llvm.ptr<struct<(ptr<struct<"opencl.image1d_ro_t", opaque>, 1>, array<24 x i8>)>, 4>, memref<?xi32, 4>) -> !sycl_vec_f32_4_
+// CHECK-NEXT:    %8 = sycl.call @read(%1, %7) {MangledFunctionName = @_ZNK4sycl3_V16detail14image_accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS5_6targetE2017ELNS5_11placeholderE0EE4readIiLi1EvEES4_RKT_, TypeName = @image_accessor} : (!llvm.ptr<struct<(ptr<struct<"opencl.image1d_ro_t", opaque>, 1>, array<24 x i8>)>, 4>, memref<?xi32, 4>) -> !sycl_vec_f32_4_
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
@@ -20,13 +20,13 @@
 // CHECK-MLIR: func.call @_ZZ4testRN4sycl3_V15queueEENUlNS0_2idILi1EEEE_C1ERKS5_(%11, %12) : (!llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>, 4>, !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>, 4>) -> ()
 // CHECK-MLIR: %13 = llvm.load %0 : !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>>
 // CHECK-MLIR: affine.store %13, %9[0] : memref<?x!llvm.struct<(memref<?xi32, 4>)>>
-// CHECK-MLIR: %14 = sycl.call() {FunctionName = @declptr, MangledFunctionName = @_ZN4sycl3_V16detail7declptrINS0_4itemILi1ELb1EEEEEPT_v} : () -> memref<?x!sycl_item_1_, 4>
-// CHECK-MLIR: %15 = sycl.call(%14) {FunctionName = @getElement, MangledFunctionName = @_ZN4sycl3_V16detail7Builder10getElementILi1ELb1EEEDTcl7getItemIXT_EXT0_EEEEPNS0_4itemIXT_EXT0_EEE, TypeName = @Builder} : (memref<?x!sycl_item_1_, 4>) -> !sycl_item_1_
+// CHECK-MLIR: %14 = sycl.call @declptr() {MangledFunctionName = @_ZN4sycl3_V16detail7declptrINS0_4itemILi1ELb1EEEEEPT_v} : () -> memref<?x!sycl_item_1_, 4>
+// CHECK-MLIR: %15 = sycl.call @getElement(%14) {MangledFunctionName = @_ZN4sycl3_V16detail7Builder10getElementILi1ELb1EEEDTcl7getItemIXT_EXT0_EEEEPNS0_4itemIXT_EXT0_EEE, TypeName = @Builder} : (memref<?x!sycl_item_1_, 4>) -> !sycl_item_1_
 // CHECK-MLIR: %16 = "polygeist.memref2pointer"(%alloca_1) : (memref<1x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>>) -> !llvm.ptr<!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>>
 // CHECK-MLIR: %17 = llvm.addrspacecast %16 : !llvm.ptr<!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>> to !llvm.ptr<!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>, 4>
 // CHECK-MLIR: %18 = "polygeist.pointer2memref"(%17) : (!llvm.ptr<!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>, 4>) -> memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>, 4>
 // CHECK-MLIR: affine.store %15, %alloca[0] : memref<1x!sycl_item_1_>
-// CHECK-MLIR: sycl.call(%18, %cast) {FunctionName = @"operator()", MangledFunctionName = @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_, TypeName = @RoundedRangeKernel} : (memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>, 4>, memref<?x!sycl_item_1_>) -> ()
+// CHECK-MLIR: sycl.call @"operator()"(%18, %cast) {MangledFunctionName = @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_, TypeName = @RoundedRangeKernel} : (memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>, 4>, memref<?x!sycl_item_1_>) -> ()
 // CHECK-MLIR: gpu.return
 
 // CHECK-LLVM-LABEL: define weak_odr spir_kernel void @_ZTSN4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EE

--- a/polygeist/tools/cgeist/Test/Verification/sycl/undeftypes.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/undeftypes.cpp
@@ -30,8 +30,8 @@ using namespace sycl::detail;
 // CHECK-LABEL:  func.func @_Z16vec_wrapper_testfm(
 // CHECK-SAME:     %[[SPAN:.*]]: f32
 // CHECK-SAME:     %[[INDEX:.*]]: i64
-// CHECK:          sycl.call(%{{.*}}, %[[SPAN]]) {FunctionName = @VecWrapper, MangledFunctionName = @{{.*}}, TypeName = @VecWrapper} : (memref<?x!llvm.struct<(!sycl_vec_f32_4_)>, 4>, f32) -> ()
-// CHECK:          %{{.*}} = sycl.call(%{{.*}}, %[[INDEX]]) {FunctionName = @"operator[]", MangledFunctionName = @{{.*}}, TypeName = @VecWrapper} : (memref<?x!llvm.struct<(!sycl_vec_f32_4_)>, 4>, i64) -> f32
+// CHECK:          sycl.call @VecWrapper(%{{.*}}, %[[SPAN]]) {MangledFunctionName = @{{.*}}, TypeName = @VecWrapper} : (memref<?x!llvm.struct<(!sycl_vec_f32_4_)>, 4>, f32) -> ()
+// CHECK:          %{{.*}} = sycl.call @"operator[]"(%{{.*}}, %[[INDEX]]) {MangledFunctionName = @{{.*}}, TypeName = @VecWrapper} : (memref<?x!llvm.struct<(!sycl_vec_f32_4_)>, 4>, i64) -> f32
 
 // CHECK-ERROR:  Found type in the sycl namespace, but not in the SYCL dialect
 


### PR DESCRIPTION
Make format more similar to the func.call format:

`$FunctionName ( $Args ) attr-dict : functional-type($Args, results)`

Signed-off-by: Victor Perez <victor.perez@codeplay.com>