### PR TITLE
[SYCL-MLIR] Change sycl.cast assembly format

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -664,7 +664,7 @@ def SYCLCastOp : SYCL_Op<"cast", [DeclareOpInterfaceMethods<CastOpInterface>,
   let results = (outs CastRes:$result);
 
   let assemblyFormat = [{
-    `(` $source `)` attr-dict `:` functional-type($source, results)
+    $source attr-dict `:` type($source) `to` type($result)
   }];
 }
 

--- a/mlir-sycl/test/Dialect/IR/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/invalid.mlir
@@ -1,5 +1,27 @@
 // RUN: sycl-mlir-opt -split-input-file %s -verify-diagnostics
 
+!sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
+
+func.func @test_cast_not_parents(%arg: memref<1x!sycl_id_1_>) -> memref<1x!sycl.accessor_common> {
+  // expected-error @+1 {{'sycl.cast' op operand type 'memref<1x!sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>>' and result type 'memref<1x!sycl.accessor_common>' are cast incompatible}}
+  %0 = sycl.cast %arg : memref<1x!sycl_id_1_> to memref<1x!sycl.accessor_common>
+  return %0 : memref<1x!sycl.accessor_common>
+}
+
+// -----
+
+!sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
+
+func.func @test_cast_bad_shape(%arg: memref<1x!sycl_id_1_>) -> memref<2x!sycl_array_1_> {
+  // expected-error @+1 {{'sycl.cast' op operand type 'memref<1x!sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>>' and result type 'memref<2x!sycl.array<[1], (memref<1xi64, 4>)>>' are cast incompatible}}
+  %0 = sycl.cast %arg : memref<1x!sycl_id_1_> to memref<2x!sycl_array_1_>
+  return %0 : memref<2x!sycl_array_1_>
+}
+
+// -----
+
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 
 func.func @test_num_work_items(%i: i32) -> !sycl_range_1_ {

--- a/mlir-sycl/test/Dialect/IR/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/invalid.mlir
@@ -1,5 +1,6 @@
 // RUN: sycl-mlir-opt -split-input-file %s -verify-diagnostics
 
+!sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
 !sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
 

--- a/mlir-sycl/test/Dialect/IR/SYCL/ops.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/ops.mlir
@@ -1,12 +1,34 @@
 // RUN: sycl-mlir-opt %s | sycl-mlir-opt | FileCheck %s
 // RUN: sycl-mlir-opt %s --mlir-print-op-generic | sycl-mlir-opt | FileCheck %s
 
-!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
-!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
-!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
-!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
-!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
-!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
+!sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
+!sycl_array_2_ = !sycl.array<[2], (memref<2xi64, 4>)>
+!sycl_array_3_ = !sycl.array<[3], (memref<3xi64, 4>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl_array_2_)>
+!sycl_id_3_ = !sycl.id<[3], (!sycl_array_3_)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl_array_2_)>
+!sycl_range_3_ = !sycl.range<[3], (!sycl_array_3_)>
+!sycl_accessor_1_i32_w_gb = !sycl.accessor<[1, i32, write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
+
+// CHECK-LABEL: test_cast_id
+func.func @test_cast_id(%arg: memref<1x!sycl_id_1_>) -> memref<1x!sycl_array_1_> {
+  %0 = sycl.cast %arg : memref<1x!sycl_id_1_> to memref<1x!sycl_array_1_>
+  return %0 : memref<1x!sycl_array_1_>
+}
+
+// CHECK-LABEL: test_cast_range
+func.func @test_cast_range(%arg: memref<1x!sycl_range_2_>) -> memref<1x!sycl_array_2_> {
+  %0 = sycl.cast %arg : memref<1x!sycl_range_2_> to memref<1x!sycl_array_2_>
+  return %0 : memref<1x!sycl_array_2_>
+}
+
+// CHECK-LABEL: test_cast_accessor
+func.func @test_cast_accessor(%arg: memref<1x!sycl_accessor_1_i32_w_gb>) -> memref<1x!sycl.accessor_common> {
+  %0 = sycl.cast %arg : memref<1x!sycl_accessor_1_i32_w_gb> to memref<1x!sycl.accessor_common>
+  return %0 : memref<1x!sycl.accessor_common>
+}
 
 // CHECK-LABEL: test_num_work_items
 func.func @test_num_work_items() -> !sycl_range_1_ {

--- a/mlir-sycl/test/Transforms/sycl-method-to-sycl-call.mlir
+++ b/mlir-sycl/test/Transforms/sycl-method-to-sycl-call.mlir
@@ -38,7 +38,7 @@ func.func @accessor_subscript_operator(%arg0: !sycl_accessor_2_i32_rw_gb, %arg1:
 // CHECK-NEXT:      %[[VAL_4:.*]] = "polygeist.memref2pointer"(%[[VAL_3]]) : (memref<1x!sycl_range_2_>) -> !llvm.ptr<!sycl_range_2_>
 // CHECK-NEXT:      %[[VAL_5:.*]] = llvm.addrspacecast %[[VAL_4]] : !llvm.ptr<!sycl_range_2_> to !llvm.ptr<!sycl_range_2_, 4>
 // CHECK-NEXT:      %[[VAL_6:.*]] = "polygeist.pointer2memref"(%[[VAL_5]]) : (!llvm.ptr<!sycl_range_2_, 4>) -> memref<?x!sycl_range_2_, 4>
-// CHECK-NEXT:      %[[VAL_7:.*]] = sycl.cast(%[[VAL_6]]) : (memref<?x!sycl_range_2_, 4>) -> memref<?x!sycl_array_2_, 4>
+// CHECK-NEXT:      %[[VAL_7:.*]] = sycl.cast %[[VAL_6]] : memref<?x!sycl_range_2_, 4> to memref<?x!sycl_array_2_, 4>
 // CHECK-NEXT:      %[[VAL_8:.*]] = sycl.call(%[[VAL_7]], %[[VAL_1]]) {FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_array_2_, 4>, i32) -> i64
 // CHECK-NEXT:      return %[[VAL_8]] : i64
 // CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -75,13 +75,13 @@
 // CHECK:          (%arg0: memref<?x!sycl_id_1_, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 8 : i64, llvm.noundef}, 
 // CHECK-SAME:      %arg1: memref<?x!sycl_id_1_, 4> {llvm.align = 8 : i64, llvm.dereferenceable = 8 : i64, llvm.noundef})
 // CHECK-SAME:      attributes {[[SPIR_FUNCCC:llvm.cconv = #llvm.cconv<spir_funccc>]], [[LINKONCE:llvm.linkage = #llvm.linkage<linkonce_odr>]] 
-// CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl_id_1_, 4>) -> memref<?x!sycl_array_1_, 4>
+// CHECK-NEXT:   %0 = sycl.cast %arg0 : memref<?x!sycl_id_1_, 4> to memref<?x!sycl_array_1_, 4>
 //
 // CHECK-LABEL: func.func @_ZN4sycl3_V15rangeILi1EEC1ERKS2_
 // CHECK:          (%arg0: memref<?x!sycl_range_1_, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 8 : i64, llvm.noundef}, 
 // CHECK-SAME:      %arg1: memref<?x!sycl_range_1_, 4> {llvm.align = 8 : i64, llvm.dereferenceable = 8 : i64, llvm.noundef})
 // CHECK-SAME:     attributes {[[SPIR_FUNCCC]], [[LINKONCE]], {{.*}}}
-// CHECK-NEXT:   %0 = sycl.cast(%arg0) : (memref<?x!sycl_range_1_, 4>) -> memref<?x!sycl_array_1_, 4>
+// CHECK-NEXT:   %0 = sycl.cast %arg0 : memref<?x!sycl_range_1_, 4> to memref<?x!sycl_array_1_, 4>
 
 // CHECK-LLVM: define spir_func void @cons_0([[ID_TYPE:%"class.sycl::_V1::id.1"]]* noundef byval(%"class.sycl::_V1::id.1") align 8 [[ARG0:%.*]], 
 // CHECK-LLVM-SAME:                          [[RANGE_TYPE:%"class.sycl::_V1::range.1"]]* noundef byval(%"class.sycl::_V1::range.1") align 8 [[ARG1:%.*]]) #[[FUNCATTRS:[0-9]+]]


### PR DESCRIPTION
Change sycl.cast assembly format to a format more similar to that of similar operations:

`$source attr-dict : type($source) to type($result)`

Signed-off-by: Victor Perez <victor.perez@codeplay.com>