### PR TITLE
[CI] Set one hour time limit for llvm-test-suite

### DIFF
--- a/devops/actions/llvm_test_suite/action.yml
+++ b/devops/actions/llvm_test_suite/action.yml
@@ -32,6 +32,7 @@ inputs:
 post-if: false
 runs:
   using: "composite"
+  timeout-minutes: 60
   steps:
   - run: |
       cp -r /actions .


### PR DESCRIPTION
Usual time is less than 25 minutes on slowest devices in CI. One hour should be enough to detect abnormal runs and cancel them.