### PR TITLE
[SYCL] Fix atomic_ref ctor to fix operator ambiguity

### DIFF
--- a/sycl/include/sycl/atomic_ref.hpp
+++ b/sycl/include/sycl/atomic_ref.hpp
@@ -595,7 +595,8 @@ public:
 
   using base_type::is_lock_free;
 
-  atomic_ref_impl(T *&ref) : base_type(reinterpret_cast<uintptr_t &>(ref)) {}
+  explicit atomic_ref_impl(T *&ref)
+      : base_type(reinterpret_cast<uintptr_t &>(ref)) {}
 
   void store(T *operand, memory_order order = default_write_order,
              memory_scope scope = default_scope) const noexcept {

--- a/sycl/test/regression/atomic_ref_assignment_ambiguity.cpp
+++ b/sycl/test/regression/atomic_ref_assignment_ambiguity.cpp
@@ -1,0 +1,23 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+
+// Tests that the assignment operator on atomic_ref for pointers do not cause
+// overload resolution ambiguities.
+
+#include <sycl/sycl.hpp>
+
+#include <type_traits>
+
+using AtomicRT = sycl::atomic_ref<int *, sycl::memory_order::relaxed,
+                                  sycl::memory_scope::system,
+                                  sycl::access::address_space::global_space>;
+
+int main() {
+  int OriginalVal = 2023;
+  int NewVal = 1;
+  int *OriginalValPtr = &OriginalVal;
+
+  AtomicRT AtomicRef(OriginalValPtr);
+  int *Desired = (AtomicRef = &NewVal);
+
+  return 0;
+}


### PR DESCRIPTION
The `atomic_ref` constructor taking a reference to its datatype should be explicit, but currently the implementation of `atomic_ref` for pointer types is not. This causes ambiguity in the overloaded assignment operator as the non-explicit constructor makes overload resolution find the deleted assignment operator. To fix this, this commit makes the `atomic_ref` constructor explicit as intended.