### PR TITLE
[SYCL][Doc][HIP] Update the samples and the warp size choice

### DIFF
--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -782,9 +782,7 @@ queue objects bound to Intel GPU device:
 int main() {
 
   auto NEOGPUDeviceSelector = [](const sycl::device &Device){
-    using namespace sycl::info;
-
-    const std::string DeviceName = Device.get_info<device::name>();
+    const std::string DeviceName = Device.get_info<sycl::info::device::name>();
     bool match = Device.is_gpu() && (DeviceName.find("HD Graphics NEO") != std::string::npos);
     return match ? 1 : -1;
   };
@@ -805,9 +803,7 @@ there is none.
 ```c++
 
 int CUDASelector(const sycl::device &Device) {
-  using namespace sycl::info;
-  const std::string DriverVersion = Device.get_info<device::driver_version>();
-
+  const std::string DriverVersion = Device.get_info<sycl::info::device::driver_version>();
   if (Device.is_gpu() && (DriverVersion.find("CUDA") != std::string::npos)) {
     std::cout << " CUDA device found " << std::endl;
     return 1;

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -2845,7 +2845,12 @@ pi_result hip_piEnqueueKernelLaunch(
 
   // Set the number of threads per block to the number of threads per warp
   // by default unless user has provided a better number
-  size_t threadsPerBlock[3] = {32u, 1u, 1u};
+  int warpSize = 32;
+  sycl::detail::pi::assertion(
+      hipDeviceGetAttribute(&warpSize, hipDeviceAttributeWarpSize,
+                            command_queue->device_->get()) == hipSuccess);
+  const uint32_t subGroupSize = static_cast<uint32_t>(warpSize);
+  size_t threadsPerBlock[3] = {subGroupSize, 1u, 1u};
   size_t maxWorkGroupSize = 0u;
   size_t maxThreadsPerBlock[3] = {};
   bool providedLocalWorkGroupSize = (local_work_size != nullptr);


### PR DESCRIPTION
The PR tries to 1) update the samples in the getting started guide  2) choose a device-specific warp size as the default number of threads per block in the HIP plugin