### PR TITLE
[SYCL-MLIR] Fix `memref2pointer(subindex)` canonicalization for SYCL types

### DIFF
--- a/polygeist/lib/polygeist/Ops.cpp
+++ b/polygeist/lib/polygeist/Ops.cpp
@@ -1173,7 +1173,9 @@ public:
       return failure();
 
     auto MET = src.getSource().getType().cast<MemRefType>().getElementType();
-    if (MET.isa<LLVM::LLVMStructType>())
+    // SYCL types are lowered to LLVM struct type.
+    bool isSYCLTy = MET.getDialect().getNamespace().contains("sycl");
+    if (MET.isa<LLVM::LLVMStructType>() || isSYCLTy)
       return failure();
 
     Value idx[] = {src.getIndex()};

--- a/polygeist/test/polygeist-opt/invalid_canonicalization.mlir
+++ b/polygeist/test/polygeist-opt/invalid_canonicalization.mlir
@@ -62,3 +62,20 @@ func.func @Memref2PointerIndex(%arg0: memref<?x!llvm.struct<(i32, i32)>>) -> !ll
 }
 
 // -----
+
+// CHECK:  func.func @Memref2PointerIndexSycl([[A0:%.*]]: memref<?x!sycl_array_1_, 4>) -> !llvm.ptr<i64, 4> {
+// CHECK-NEXT:    [[C1:%.*]] = arith.constant 1 : index
+// CHECK-NEXT:    [[T0:%.*]] = "polygeist.subindex"([[A0]], [[C1]]) : (memref<?x!sycl_array_1_, 4>, index) -> memref<?xi64, 4>
+// CHECK-NEXT:    [[T1:%.*]] = "polygeist.memref2pointer"([[T0]]) : (memref<?xi64, 4>) -> !llvm.ptr<i64, 4>
+// CHECK-NEXT:    return [[T1]] : !llvm.ptr<i64, 4>
+// CHECK-NEXT:  }
+
+!sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
+func.func @Memref2PointerIndexSycl(%arg0: memref<?x!sycl_array_1_, 4>) -> !llvm.ptr<i64, 4> {
+  %c1 = arith.constant 1 : index
+  %0 = "polygeist.subindex"(%arg0, %c1) : (memref<?x!sycl.array<[1], (memref<1xi64, 4>)>, 4>, index) -> memref<?xi64, 4>
+  %1 = "polygeist.memref2pointer"(%0) : (memref<?xi64, 4>) -> !llvm.ptr<i64, 4>
+  return %1 : !llvm.ptr<i64, 4>
+}
+
+// -----


### PR DESCRIPTION
SYCL types are lowered to LLVM struct types.
`memref2pointer(subindex)` canonicalization is invalid when `subindex` element type is LLVM struct type, so it is also invalid for SYCL types.

`KernelFusion/internalize_multi_ptr.cpp` fixed by this PR.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>