### PR TITLE
[SYCL-MLIR] Use LoadOp operand instead of creating an alloca

### DIFF
--- a/mlir-sycl/test/Transforms/sycl-method-to-sycl-call.mlir
+++ b/mlir-sycl/test/Transforms/sycl-method-to-sycl-call.mlir
@@ -1,4 +1,5 @@
 // RUN: sycl-mlir-opt -sycl-method-to-sycl-call -split-input-file -verify-diagnostics %s | FileCheck %s
+// XFAIL: *
 
 !sycl_array_2_ = !sycl.array<[2], (memref<2xi64, 4>)>
 !sycl_id_2_ = !sycl.id<[2], (!sycl_array_2_)>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -4,6 +4,8 @@
 // RUN: clang++ -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 // RUN: clang++ -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - -Xcgeist -no-mangled-function-name | FileCheck %s --check-prefix=CHECK-LLVM
 
+// XFAIL: *
+
 #include <sycl/sycl.hpp>
 
 // CHECK-MLIR-NO-MANGLED-FUNCTION-NAME-NOT: {{^(sycl\.constructor|sycl\.call){,0}.*}} MangledFunctionName


### PR DESCRIPTION
Please do not review. Creating this draft PR to measure success rate on other platforms.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>