### PR TITLE
[CI] Disable failing CTS tests

### DIFF
--- a/devops/cts_exclude_filter
+++ b/devops/cts_exclude_filter
@@ -24,3 +24,7 @@ math_builtin_api
 stream
 marray
 image_accessor
+atomic_fence
+function_objects
+group_functions
+image


### PR DESCRIPTION
There are quite a few new tests added to SYCL-CTS and some of them fail on CUDA back-end. Termporay disable them to keep CI status clean.