### PR TITLE
[SYCL][NFC] Rename misleading queue_impl::MSupportOOO variable

### DIFF
--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -713,7 +713,8 @@ protected:
   size_t MNextQueueIdx = 0;
 
   const bool MHostQueue = false;
-  // Assume OOO support by default.
+  /// Indicates that a native out-of-order queue could not be created and we
+  /// need to emulate it with multiple native in-order queues.
   bool MEmulateOOO = false;
 
   // Buffer to store assert failure descriptor

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -449,8 +449,8 @@ public:
     // If creating out-of-order queue failed and this property is not
     // supported (for example, on FPGA), it will return
     // PI_ERROR_INVALID_QUEUE_PROPERTIES and will try to create in-order queue.
-    if (MSupportOOO && Error == PI_ERROR_INVALID_QUEUE_PROPERTIES) {
-      MSupportOOO = false;
+    if (!MEmulateOOO && Error == PI_ERROR_INVALID_QUEUE_PROPERTIES) {
+      MEmulateOOO = true;
       Queue = createQueue(QueueOrder::Ordered);
     } else {
       Plugin.checkPiResult(Error);
@@ -493,7 +493,7 @@ public:
   /// \return a raw PI queue handle. The returned handle is not retained. It
   /// is caller responsibility to make sure queue is still alive.
   RT::PiQueue &getHandleRef() {
-    if (MSupportOOO)
+    if (!MEmulateOOO)
       return MQueues[0];
 
     return getExclusiveQueueHandleRef();
@@ -714,7 +714,7 @@ protected:
 
   const bool MHostQueue = false;
   // Assume OOO support by default.
-  bool MSupportOOO = true;
+  bool MEmulateOOO = false;
 
   // Buffer to store assert failure descriptor
   buffer<AssertHappened, 1> MAssertHappenedBuffer;


### PR DESCRIPTION
The variable is supposed to indicate that we failed to create an OOO native queue and we need to emulate it if its value is false. Rename to MEmulateOOO to avoid confusion with in-order/out-of-order SYCL queues.