### PR TITLE
[SYCL-MLIR] Lower some nd_item operations to LLVM

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -736,7 +736,7 @@ def SYCLCallOp : SYCL_Op<"call", [CallOpInterface]> {
 // accessor.subscript OPERATION
 ////////////////////////////////////////////////////////////////////////////////
 
-def SYCLAccessorSubscriptIndex : AnyTypeOf<[IndexType, SYCL_IDType]>;
+def SYCLAccessorSubscriptIndex : AnyTypeOf<[IndexType, IDMemRef]>;
 
 def SYCLAccessorSubscriptOp
     : SYCLMethodOpInterfaceImpl<"accessor.subscript", "AccessorType",
@@ -746,7 +746,7 @@ def SYCLAccessorSubscriptOp
     This operation represents a call to the accessor::operator[] function.
   }];
 
-  let arguments = (ins SYCL_AccessorType:$Acc,
+  let arguments = (ins AccessorMemRef:$Acc,
                        SYCLAccessorSubscriptIndex:$Index,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
@@ -775,7 +775,7 @@ def SYCLRangeGetOp
     This operation represents a call to the range::get/operator[] functions.
   }];
 
-  let arguments = (ins SYCL_RangeType:$Range,
+  let arguments = (ins RangeMemRef:$Range,
                        I32:$Index,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
@@ -801,7 +801,7 @@ def SYCLRangeSizeOp
     This operation represents a call to the range::size[] function.
   }];
 
-  let arguments = (ins SYCL_RangeType:$Range,
+  let arguments = (ins RangeMemRef:$Range,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
                        OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
@@ -822,7 +822,7 @@ def SYCLNdRangeGetGlobalRange
     This operation represents a call to the nd_range::get_global_range function.
   }];
 
-  let arguments = (ins SYCL_NdRangeType:$ND,
+  let arguments = (ins NDRangeMemRef:$ND,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
                        OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
@@ -843,7 +843,7 @@ def SYCLNdRangeGetLocalRange
     This operation represents a call to the nd_range::get_local_range function.
   }];
 
-  let arguments = (ins SYCL_NdRangeType:$ND,
+  let arguments = (ins NDRangeMemRef:$ND,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
                        OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
@@ -864,7 +864,7 @@ def SYCLNdRangeGetGroupRange
     This operation represents a call to the nd_range::get_group_range function.
   }];
 
-  let arguments = (ins SYCL_NdRangeType:$ND,
+  let arguments = (ins NDRangeMemRef:$ND,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
                        OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
@@ -886,7 +886,7 @@ def SYCLIDGetOp
     This operation represents a call to the id::get/operator[]/operator size_t functions.
   }];
 
-  let arguments = (ins SYCL_IDType:$ID,
+  let arguments = (ins IDMemRef:$ID,
                        Optional<I32>:$Index,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
@@ -913,7 +913,7 @@ def SYCLItemGetIDOp
     This operation represents a call to the item::get_id/operator[]/operator size_t functions.
   }];
 
-  let arguments = (ins SYCL_ItemType:$Item,
+  let arguments = (ins ItemMemRef:$Item,
                        Optional<I32>:$Index,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
@@ -935,7 +935,7 @@ def SYCLItemGetRangeOp
     This operation represents a call to the item::get_range function.
   }];
 
-  let arguments = (ins SYCL_ItemType:$Item,
+  let arguments = (ins ItemMemRef:$Item,
                        Optional<I32>:$Index,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
@@ -957,7 +957,7 @@ def SYCLItemGetLinearIDOp
     This operation represents a call to the item::get_linear_id function.
   }];
 
-  let arguments = (ins SYCL_ItemType:$Item,
+  let arguments = (ins ItemMemRef:$Item,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
                        OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
@@ -978,7 +978,7 @@ def SYCLNDItemGetGlobalIDOp
     This operation represents a call to the nd_item::get_global_id function.
   }];
 
-  let arguments = (ins SYCL_NdItemType:$NDItem,
+  let arguments = (ins NDItemMemRef:$NDItem,
                        Optional<I32>:$Index,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
@@ -1000,7 +1000,7 @@ def SYCLNDItemGetGlobalLinearIDOp
     This operation represents a call to the nd_item::get_global_linear_id function.
   }];
 
-  let arguments = (ins SYCL_NdItemType:$NDItem,
+  let arguments = (ins NDItemMemRef:$NDItem,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
                        OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
@@ -1021,7 +1021,7 @@ def SYCLNDItemGetLocalIDOp
     This operation represents a call to the nd_item::get_local_id function.
   }];
 
-  let arguments = (ins SYCL_NdItemType:$NDItem,
+  let arguments = (ins NDItemMemRef:$NDItem,
                        Optional<I32>:$Index,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
@@ -1043,7 +1043,7 @@ def SYCLNDItemGetLocalLinearIDOp
     This operation represents a call to the nd_item::get_local_linear_id function.
   }];
 
-  let arguments = (ins SYCL_NdItemType:$NDItem,
+  let arguments = (ins NDItemMemRef:$NDItem,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
                        OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
@@ -1064,7 +1064,7 @@ def SYCLNDItemGetGroupOp
     This operation represents a call to the nd_item::get_group function.
   }];
 
-  let arguments = (ins SYCL_NdItemType:$NDItem,
+  let arguments = (ins NDItemMemRef:$NDItem,
                        Optional<I32>:$Index,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
@@ -1086,7 +1086,7 @@ def SYCLNDItemGetGroupLinearIDOp
     This operation represents a call to the nd_item::get_group_linear_id function.
   }];
 
-  let arguments = (ins SYCL_NdItemType:$NDItem,
+  let arguments = (ins NDItemMemRef:$NDItem,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
                        OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
@@ -1108,7 +1108,7 @@ def SYCLNDItemGetGroupRangeOp
     This operation represents a call to the nd_item::get_group_range function.
   }];
 
-  let arguments = (ins SYCL_NdItemType:$NDItem,
+  let arguments = (ins NDItemMemRef:$NDItem,
                        Optional<I32>:$Index,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
@@ -1131,7 +1131,7 @@ def SYCLNDItemGetGlobalRangeOp
     This operation represents a call to the nd_item::get_global_range function.
   }];
 
-  let arguments = (ins SYCL_NdItemType:$NDItem,
+  let arguments = (ins NDItemMemRef:$NDItem,
                        Optional<I32>:$Index,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
@@ -1154,7 +1154,7 @@ def SYCLNDItemGetLocalRangeOp
     This operation represents a call to the nd_item::get_local_range function.
   }];
 
-  let arguments = (ins SYCL_NdItemType:$NDItem,
+  let arguments = (ins NDItemMemRef:$NDItem,
                        Optional<I32>:$Index,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
@@ -1176,7 +1176,7 @@ def SYCLNDItemGetNdRangeOp
     This operation represents a call to the nd_item::get_nd_range function.
   }];
 
-  let arguments = (ins SYCL_NdItemType:$NDItem,
+  let arguments = (ins NDItemMemRef:$NDItem,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
                        OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
@@ -1198,7 +1198,7 @@ def SYCLGroupGetGroupIDOp
     This operation represents a call to the group::get_group_id/operator[] functions.
   }];
 
-  let arguments = (ins SYCL_GroupType:$Group,
+  let arguments = (ins GroupMemRef:$Group,
                        Optional<I32>:$Index,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
@@ -1221,7 +1221,7 @@ def SYCLGroupGetLocalIDOp
     This operation represents a call to the group::get_local_id function.
   }];
 
-  let arguments = (ins SYCL_GroupType:$Group,
+  let arguments = (ins GroupMemRef:$Group,
                        Optional<I32>:$Index,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
@@ -1244,7 +1244,7 @@ def SYCLGroupGetLocalRangeOp
     This operation represents a call to the group::get_local_range function.
   }];
 
-  let arguments = (ins SYCL_GroupType:$Group,
+  let arguments = (ins GroupMemRef:$Group,
                        Optional<I32>:$Index,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
@@ -1267,7 +1267,7 @@ def SYCLGroupGetGroupRangeOp
     This operation represents a call to the group::get_group_range function.
   }];
 
-  let arguments = (ins SYCL_GroupType:$Group,
+  let arguments = (ins GroupMemRef:$Group,
                        Optional<I32>:$Index,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
@@ -1289,7 +1289,7 @@ def SYCLGroupGetMaxLocalRangeOp
     This operation represents a call to the group::get_max_local_range function.
   }];
 
-  let arguments = (ins SYCL_GroupType:$Group,
+  let arguments = (ins GroupMemRef:$Group,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
                        OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
@@ -1310,7 +1310,7 @@ def SYCLGroupGetGroupLinearIDOp
     This operation represents a call to the group::get_group_linear_id function.
   }];
 
-  let arguments = (ins SYCL_GroupType:$Group,
+  let arguments = (ins GroupMemRef:$Group,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
                        OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
@@ -1331,7 +1331,7 @@ def SYCLGroupGetLocalLinearIDOp
     This operation represents a call to the group::get_local_linear_id function.
   }];
 
-  let arguments = (ins SYCL_GroupType:$Group,
+  let arguments = (ins GroupMemRef:$Group,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
                        OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
@@ -1352,7 +1352,7 @@ def SYCLGroupGetLocalLinearIDOp
     This operation represents a call to the group::get_group_linear_range function.
   }];
 
-  let arguments = (ins SYCL_GroupType:$Group,
+  let arguments = (ins GroupMemRef:$Group,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
                        OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
@@ -1373,7 +1373,7 @@ def SYCLGroupGetLocalLinearRangeOp
     This operation represents a call to the group::get_local_linear_range function.
   }];
 
-  let arguments = (ins SYCL_GroupType:$Group,
+  let arguments = (ins GroupMemRef:$Group,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
                        OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -427,52 +427,57 @@ def VectorSplatArg : MemRefOf<[VectorEltTy]>;
 // SYCL GRID OPERATIONS
 ////////////////////////////////////////////////////////////////////////////////
 
-def SYCLNumWorkItemsOp : SYCL_Op<"num_work_items", [SYCLIndexSpaceGetRange]> {
+class SYCL1DGridOp<string mnemonic, list<Trait> traits = []>
+    : SYCL_Op<mnemonic, traits> {
+  let arguments = (ins);
+  let results = (outs I32:$result);
+  let assemblyFormat = "attr-dict `:` type($result)";
+}
+
+class SYCL3DGridOp<string mnemonic, list<Trait> traits = []>
+    : SYCL_Op<mnemonic, traits> {
+  let arguments = (ins Optional<I32>:$dimension);
+  let assemblyFormat = "$dimension attr-dict `:` type($result)";
+}
+
+class SYCL3DIDGridOp<string mnemonic>
+    : SYCL3DGridOp<mnemonic, [SYCLIndexSpaceGetID]> {
+  let results = (outs SYCLIndexSpaceGetIDResult:$result);
+}
+
+class SYCL3DRangeGridOp<string mnemonic>
+    : SYCL3DGridOp<mnemonic, [SYCLIndexSpaceGetRange]> {
+  let results = (outs SYCLIndexSpaceGetRangeResult:$result);
+}
+
+def SYCLNumWorkItemsOp : SYCL3DRangeGridOp<"num_work_items"> {
   let summary = "Retrieve the number of work-items.";
   let description = [{
     This operation returns the number of work-items in the index space. If the
     optional argument is passed, the number of work-items in the given dimension
     is returned.
   }];
-
-  let arguments = (ins Optional<I32>:$dimension);
-  let results = (outs SYCLIndexSpaceGetRangeResult:$result);
-  let assemblyFormat = [{
-    `(` operands `)` attr-dict `:` functional-type(operands, results)
-  }];
 }
 
-def SYCLGlobalIDOp : SYCL_Op<"global_id", [SYCLIndexSpaceGetID]> {
+def SYCLGlobalIDOp : SYCL3DIDGridOp<"global_id"> {
   let summary = "Retrieve the global ID of the item.";
   let description = [{
     This operation returns the global ID of the item in the index space. If the
     optional argument is passed, the global ID of the item in the given
     dimension is returned.
   }];
-
-  let arguments = (ins Optional<I32>:$dimension);
-  let results = (outs SYCLIndexSpaceGetIDResult:$result);
-  let assemblyFormat = [{
-    `(` operands `)` attr-dict `:` functional-type(operands, results)
-  }];
 }
 
-def SYCLLocalIDOp : SYCL_Op<"local_id", [SYCLIndexSpaceGetID]> {
+def SYCLLocalIDOp : SYCL3DIDGridOp<"local_id"> {
   let summary = "Retrieve the local ID of the item.";
   let description = [{
     This operation returns the local ID of the item within the work-group. If
     the optional argument is passed, the local ID of the item in the given
     dimension is returned.
   }];
-
-  let arguments = (ins Optional<I32>:$dimension);
-  let results = (outs SYCLIndexSpaceGetIDResult:$result);
-  let assemblyFormat = [{
-    `(` operands `)` attr-dict `:` functional-type(operands, results)
-  }];
 }
 
-def SYCLGlobalOffsetOp : SYCL_Op<"global_offset", [SYCLIndexSpaceGetID]>,
+def SYCLGlobalOffsetOp : SYCL3DIDGridOp<"global_offset">,
                        Deprecated<"deprecated in SYCL 2020"> {
   let summary = "Retrieve the global offset of the item.";
   let description = [{
@@ -482,120 +487,66 @@ def SYCLGlobalOffsetOp : SYCL_Op<"global_offset", [SYCLIndexSpaceGetID]>,
 
     Note that this is deprecated in SYCL 2020.
   }];
-
-  let arguments = (ins Optional<I32>:$dimension);
-  let results = (outs SYCLIndexSpaceGetIDResult:$result);
-  let assemblyFormat = [{
-    `(` operands `)` attr-dict `:` functional-type(operands, results)
-  }];
 }
 
-def SYCLNumWorkGroupsOp : SYCL_Op<"num_work_groups", [SYCLIndexSpaceGetRange]> {
+def SYCLNumWorkGroupsOp : SYCL3DRangeGridOp<"num_work_groups"> {
   let summary = "Retrieve the number of work-groups.";
   let description = [{
     This operation returns the number of work-groups in the index space. If the
     optional argument is passed, the number of work-groups in the given
     dimension is returned.
   }];
-
-  let arguments = (ins Optional<I32>:$dimension);
-  let results = (outs SYCLIndexSpaceGetRangeResult:$result);
-  let assemblyFormat = [{
-    `(` operands `)` attr-dict `:` functional-type(operands, results)
-  }];
 }
 
-def SYCLWorkGroupSizeOp : SYCL_Op<"work_group_size", [SYCLIndexSpaceGetRange]> {
+def SYCLWorkGroupSizeOp : SYCL3DRangeGridOp<"work_group_size"> {
   let summary = "Retrieve the number of work-items in a work-group.";
   let description = [{
     This operation returns the number of work-items per work-group. If the
     optional argument is passed, the number of work-items per work-group in the
     given dimension is returned.
   }];
-
-  let arguments = (ins Optional<I32>:$dimension);
-  let results = (outs SYCLIndexSpaceGetRangeResult:$result);
-  let assemblyFormat = [{
-    `(` operands `)` attr-dict `:` functional-type(operands, results)
-  }];
 }
 
-def SYCLWorkGroupIDOp : SYCL_Op<"work_group_id", [SYCLIndexSpaceGetID]> {
+def SYCLWorkGroupIDOp : SYCL3DIDGridOp<"work_group_id"> {
   let summary = "Retrieve the ID of the work-group.";
   let description = [{
     This operation returns the ID of the work-group. If the optional argument is
     passed, the ID of the work-group in the given dimension is returned.
   }];
-
-  let arguments = (ins Optional<I32>:$dimension);
-  let results = (outs SYCLIndexSpaceGetIDResult:$result);
-  let assemblyFormat = [{
-    `(` operands `)` attr-dict `:` functional-type(operands, results)
-  }];
 }
 
-def SYCLNumSubGroupsOp : SYCL_Op<"num_sub_groups"> {
+def SYCLNumSubGroupsOp : SYCL1DGridOp<"num_sub_groups"> {
   let summary = "Retrieve the number of sub-groups.";
   let description = [{
     This operation returns the number of sub-groups.
   }];
-
-  let arguments = (ins);
-  let results = (outs I32:$result);
-  let assemblyFormat = [{
-    attr-dict `:` functional-type(operands, results)
-  }];
 }
 
-def SYCLSubGroupMaxSizeOp : SYCL_Op<"sub_group_max_size"> {
+def SYCLSubGroupMaxSizeOp : SYCL1DGridOp<"sub_group_max_size"> {
   let summary = "Retrieve the maximum size of a sub-group.";
   let description = [{
     This operation returns the maximum size of a sub-group.
   }];
-
-  let arguments = (ins);
-  let results = (outs I32:$result);
-  let assemblyFormat = [{
-    attr-dict `:` functional-type(operands, results)
-  }];
 }
 
-def SYCLSubGroupSizeOp : SYCL_Op<"sub_group_size"> {
+def SYCLSubGroupSizeOp : SYCL1DGridOp<"sub_group_size"> {
   let summary = "Retrieve the sub-group size.";
   let description = [{
     This operation returns the sub-group size.
   }];
-
-  let arguments = (ins);
-  let results = (outs I32:$result);
-  let assemblyFormat = [{
-    attr-dict `:` functional-type(operands, results)
-  }];
 }
 
-def SYCLSubGroupIDOp : SYCL_Op<"sub_group_id"> {
+def SYCLSubGroupIDOp : SYCL1DGridOp<"sub_group_id"> {
   let summary = "Retrieve the ID of the sub-group.";
   let description = [{
     This operation returns the ID of the sub-group.
   }];
-
-  let arguments = (ins);
-  let results = (outs I32:$result);
-  let assemblyFormat = [{
-    attr-dict `:` functional-type(operands, results)
-  }];
 }
 
-def SYCLSubGroupLocalIDOp : SYCL_Op<"sub_group_local_id"> {
+def SYCLSubGroupLocalIDOp : SYCL1DGridOp<"sub_group_local_id"> {
   let summary = "Retrieve the local ID of the sub-group.";
   let description = [{
     This operation returns the local ID of the sub-group.
-  }];
-
-  let arguments = (ins);
-  let results = (outs I32:$result);
-  let assemblyFormat = [{
-    attr-dict `:` functional-type(operands, results)
   }];
 }
 

--- a/mlir-sycl/include/mlir/Dialect/SYCL/MethodUtils.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/MethodUtils.h
@@ -23,10 +23,6 @@ class OpBuilder;
 class ValueRange;
 namespace sycl {
 class SYCLMethodOpInterface;
-/// Generates a list of values to be used as arguments to a
-/// SYCLMethodOpInterface instance from \p Original.
-SmallVector<Value> adaptSYCLMethodOpArguments(OpBuilder &Builder, Location Loc,
-                                              ValueRange Original);
 /// Abstracts different cast operations from which \p Original may have
 /// originated.
 Value abstractCasts(Value Original);

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.h
@@ -18,8 +18,6 @@
 #include "mlir/Pass/Pass.h"
 
 #include "polygeist/Dialect.h"
-#include "polygeist/Passes/Passes.h"
-
 namespace mlir {
 namespace sycl {
 

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.td
@@ -45,7 +45,7 @@ def SYCLMethodToSYCLCall : Pass<"sycl-method-to-sycl-call", "ModuleOp"> {
   }];
   let constructor = "mlir::sycl::createSYCLMethodToSYCLCallPass()";
   let dependentDialects =
-    ["memref::MemRefDialect", "LLVM::LLVMDialect", "polygeist::PolygeistDialect"];
+    ["LLVM::LLVMDialect", "polygeist::PolygeistDialect"];
 }
 
 #endif // MLIR_DIALECT_SYCL_TRANSFORMS_PASSES

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -774,7 +774,11 @@ protected:
 
   /// Whether the input accessor is 1-dimensional.
   static bool has1DAccessor(SYCLAccessorSubscriptOp op) {
-    return op.getAcc().getType().cast<AccessorType>().getDimension() == 1;
+    return op.getAcc()
+               .getType()
+               .getElementType()
+               .cast<AccessorType>()
+               .getDimension() == 1;
   }
 
   /// Whether the input offset is an id.
@@ -901,8 +905,9 @@ public:
           loc, subscript, zero, ArrayRef<int64_t>{0, 0, 0, i});
     }
     // Insert original accessor
-    rewriter.replaceOpWithNewOp<LLVM::InsertValueOp>(op, subscript,
-                                                     opAdaptor.getAcc(), 1);
+    rewriter.replaceOpWithNewOp<LLVM::InsertValueOp>(
+        op, subscript, rewriter.create<LLVM::LoadOp>(loc, opAdaptor.getAcc()),
+        1);
   }
 };
 

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -528,6 +528,8 @@ private:
   }
 };
 
+// TODO: Push fix when testing is possible.
+#if 0
 //===----------------------------------------------------------------------===//
 // SYCLRangeGetPattern - Convert `sycl.range.get` to LLVM.
 //===----------------------------------------------------------------------===//
@@ -545,7 +547,7 @@ public:
     const auto loc = op.getLoc();
     const auto range = opAdaptor.getRange();
     auto *typeConverter = getTypeConverter();
-    const auto alignment = op.getRange().getType().getDimension() * 8;
+    const auto alignment = op.getRange().getDimension() * 8;
     const auto alloca = static_cast<Value>(rewriter.create<LLVM::AllocaOp>(
         loc,
         LLVM::LLVMPointerType::get(typeConverter->convertType(range.getType())),
@@ -684,6 +686,7 @@ public:
     return success();
   }
 };
+#endif // 0
 
 //===----------------------------------------------------------------------===//
 // Pattern population
@@ -798,9 +801,11 @@ void mlir::sycl::populateSYCLToLLVMConversionPatterns(
   if (typeConverter.getOptions().useBarePtrCallConv)
     patterns.add<BarePtrCastPattern>(typeConverter, /*benefit*/ 2);
   patterns.add<ConstructorPattern>(typeConverter);
+#if 0
   if (typeConverter.getOptions().useBarePtrCallConv)
     patterns
         .add<NDRangeGetGlobalRangePattern, NDRangeGetLocalRangePattern,
              NDRangeGetGroupRangePattern, RangeGetPattern, RangeSizePattern>(
             typeConverter);
+#endif // 0
 }

--- a/mlir-sycl/lib/Dialect/IR/CMakeLists.txt
+++ b/mlir-sycl/lib/Dialect/IR/CMakeLists.txt
@@ -9,7 +9,6 @@ if (TARGET MLIRArithmetic)
     MLIRVectorInterfaces
     MLIRStandard
     MLIRMemRef
-    MLIRPolygeist
     MLIRSCF
     )
 else()
@@ -23,7 +22,6 @@ else()
     MLIRVectorInterfaces
     MLIRLLVMDialect
     MLIRMemRefDialect
-    MLIRPolygeist
     MLIRSCFDialect
     )
 endif()

--- a/mlir-sycl/lib/Dialect/IR/MethodUtils.cpp
+++ b/mlir-sycl/lib/Dialect/IR/MethodUtils.cpp
@@ -46,25 +46,6 @@ Operation *trackCasts(Value Val) {
 }
 } // namespace
 
-SmallVector<Value> mlir::sycl::adaptSYCLMethodOpArguments(OpBuilder &Builder,
-                                                          Location Loc,
-                                                          ValueRange Original) {
-  SmallVector<Value> Transformed;
-  Transformed.reserve(Original.size());
-  std::transform(
-      Original.begin(), Original.end(), std::back_inserter(Transformed),
-      [&](auto Val) {
-        return TypeSwitch<Type, Value>(Val.getType())
-            .Case<MemRefType>([&](auto MT) -> Value {
-              return Builder.createOrFold<memref::LoadOp>(
-                  Loc, Val,
-                  Builder.createOrFold<arith::ConstantIndexOp>(Loc, 0));
-            })
-            .Default([Val](Type) { return Val; });
-      });
-  return Transformed;
-}
-
 Value mlir::sycl::abstractCasts(Value Original) {
   Operation *Cast = trackCasts(Original);
   return Cast ? Cast->getOperand(0) : Original;

--- a/mlir-sycl/test/Conversion/SYCLToGPU/grid-ops.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToGPU/grid-ops.mlir
@@ -10,13 +10,13 @@
 // CHECK-LABEL:   func.func @test_num_work_items() -> !sycl_range_1_ {
 // CHECK-NEXT:      %[[VAL_0:.*]] = memref.alloca() : memref<1x!sycl_range_1_>
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_range_1_>
-// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = gpu.grid_dim  x
-// CHECK-NEXT:      %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : index to i64
-// CHECK-NEXT:      %[[VAL_6:.*]] = sycl.range.get %[[VAL_2]][%[[VAL_3]]] {ArgumentTypes = [memref<1x!sycl_range_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (!sycl_range_1_, i32) -> memref<1xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<1xi64, 4>
-// CHECK-NEXT:      return %[[VAL_2]] : !sycl_range_1_
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = gpu.grid_dim  x
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : index to i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = sycl.range.get %[[VAL_0]]{{\[}}%[[VAL_2]]] {ArgumentTypes = [memref<1x!sycl_range_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_1_>, i32) -> memref<1xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<1xi64, 4>
+// CHECK-NEXT:      %[[VAL_6:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_range_1_>
+// CHECK-NEXT:      return %[[VAL_6]] : !sycl_range_1_
 // CHECK-NEXT:    }
 func.func @test_num_work_items() -> !sycl_range_1_ {
   %0 = sycl.num_work_items() : () -> !sycl_range_1_
@@ -47,18 +47,18 @@ func.func @test_num_work_items_dim(%i: i32) -> index {
 // CHECK-LABEL:   func.func @test_global_id() -> !sycl_id_2_ {
 // CHECK-NEXT:      %[[VAL_0:.*]] = memref.alloca() : memref<1x!sycl_id_2_>
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_2_>
-// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = gpu.global_id  x
-// CHECK-NEXT:      %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : index to i64
-// CHECK-NEXT:      %[[VAL_6:.*]] = sycl.id.get %[[VAL_2]][%[[VAL_3]]] {ArgumentTypes = [memref<1x!sycl_id_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_2_, i32) -> memref<2xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<2xi64, 4>
-// CHECK-NEXT:      %[[VAL_7:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:      %[[VAL_8:.*]] = gpu.global_id  y
-// CHECK-NEXT:      %[[VAL_9:.*]] = arith.index_cast %[[VAL_8]] : index to i64
-// CHECK-NEXT:      %[[VAL_10:.*]] = sycl.id.get %[[VAL_2]][%[[VAL_7]]] {ArgumentTypes = [memref<1x!sycl_id_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_2_, i32) -> memref<2xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_9]], %[[VAL_10]]{{\[}}%[[VAL_1]]] : memref<2xi64, 4>
-// CHECK-NEXT:      return %[[VAL_2]] : !sycl_id_2_
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = gpu.global_id  x
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : index to i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_2]]] {ArgumentTypes = [memref<1x!sycl_id_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_2_>, i32) -> memref<2xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<2xi64, 4>
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:      %[[VAL_7:.*]] = gpu.global_id  y
+// CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_7]] : index to i64
+// CHECK-NEXT:      %[[VAL_9:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_6]]] {ArgumentTypes = [memref<1x!sycl_id_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_2_>, i32) -> memref<2xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_8]], %[[VAL_9]]{{\[}}%[[VAL_1]]] : memref<2xi64, 4>
+// CHECK-NEXT:      %[[VAL_10:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_2_>
+// CHECK-NEXT:      return %[[VAL_10]] : !sycl_id_2_
 // CHECK-NEXT:    }
 func.func @test_global_id() -> !sycl_id_2_ {
   %0 = sycl.global_id() : () -> !sycl_id_2_
@@ -89,23 +89,23 @@ func.func @test_global_id_dim(%i: i32) -> index {
 // CHECK-LABEL:   func.func @test_local_id() -> !sycl_id_3_ {
 // CHECK-NEXT:      %[[VAL_0:.*]] = memref.alloca() : memref<1x!sycl_id_3_>
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_3_>
-// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = gpu.thread_id  x
-// CHECK-NEXT:      %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : index to i64
-// CHECK-NEXT:      %[[VAL_6:.*]] = sycl.id.get %[[VAL_2]][%[[VAL_3]]] {ArgumentTypes = [memref<1x!sycl_id_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_3_, i32) -> memref<3xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
-// CHECK-NEXT:      %[[VAL_7:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:      %[[VAL_8:.*]] = gpu.thread_id  y
-// CHECK-NEXT:      %[[VAL_9:.*]] = arith.index_cast %[[VAL_8]] : index to i64
-// CHECK-NEXT:      %[[VAL_10:.*]] = sycl.id.get %[[VAL_2]][%[[VAL_7]]] {ArgumentTypes = [memref<1x!sycl_id_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_3_, i32) -> memref<3xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_9]], %[[VAL_10]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
-// CHECK-NEXT:      %[[VAL_11:.*]] = arith.constant 2 : i32
-// CHECK-NEXT:      %[[VAL_12:.*]] = gpu.thread_id  z
-// CHECK-NEXT:      %[[VAL_13:.*]] = arith.index_cast %[[VAL_12]] : index to i64
-// CHECK-NEXT:      %[[VAL_14:.*]] = sycl.id.get %[[VAL_2]][%[[VAL_11]]] {ArgumentTypes = [memref<1x!sycl_id_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_3_, i32) -> memref<3xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_13]], %[[VAL_14]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
-// CHECK-NEXT:      return %[[VAL_2]] : !sycl_id_3_
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = gpu.thread_id  x
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : index to i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_2]]] {ArgumentTypes = [memref<1x!sycl_id_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_3_>, i32) -> memref<3xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:      %[[VAL_7:.*]] = gpu.thread_id  y
+// CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_7]] : index to i64
+// CHECK-NEXT:      %[[VAL_9:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_6]]] {ArgumentTypes = [memref<1x!sycl_id_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_3_>, i32) -> memref<3xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_8]], %[[VAL_9]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      %[[VAL_10:.*]] = arith.constant 2 : i32
+// CHECK-NEXT:      %[[VAL_11:.*]] = gpu.thread_id  z
+// CHECK-NEXT:      %[[VAL_12:.*]] = arith.index_cast %[[VAL_11]] : index to i64
+// CHECK-NEXT:      %[[VAL_13:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_10]]] {ArgumentTypes = [memref<1x!sycl_id_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_3_>, i32) -> memref<3xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_12]], %[[VAL_13]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      %[[VAL_14:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_3_>
+// CHECK-NEXT:      return %[[VAL_14]] : !sycl_id_3_
 // CHECK-NEXT:    }
 func.func @test_local_id() -> !sycl_id_3_ {
   %0 = sycl.local_id() : () -> !sycl_id_3_
@@ -136,23 +136,23 @@ func.func @test_local_id_dim(%i: i32) -> index {
 // CHECK-LABEL:   func.func @test_work_group_size() -> !sycl_range_3_ {
 // CHECK-NEXT:      %[[VAL_0:.*]] = memref.alloca() : memref<1x!sycl_range_3_>
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_range_3_>
-// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = gpu.block_dim  x
-// CHECK-NEXT:      %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : index to i64
-// CHECK-NEXT:      %[[VAL_6:.*]] = sycl.range.get %[[VAL_2]][%[[VAL_3]]] {ArgumentTypes = [memref<1x!sycl_range_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (!sycl_range_3_, i32) -> memref<3xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
-// CHECK-NEXT:      %[[VAL_7:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:      %[[VAL_8:.*]] = gpu.block_dim  y
-// CHECK-NEXT:      %[[VAL_9:.*]] = arith.index_cast %[[VAL_8]] : index to i64
-// CHECK-NEXT:      %[[VAL_10:.*]] = sycl.range.get %[[VAL_2]][%[[VAL_7]]] {ArgumentTypes = [memref<1x!sycl_range_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (!sycl_range_3_, i32) -> memref<3xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_9]], %[[VAL_10]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
-// CHECK-NEXT:      %[[VAL_11:.*]] = arith.constant 2 : i32
-// CHECK-NEXT:      %[[VAL_12:.*]] = gpu.block_dim  z
-// CHECK-NEXT:      %[[VAL_13:.*]] = arith.index_cast %[[VAL_12]] : index to i64
-// CHECK-NEXT:      %[[VAL_14:.*]] = sycl.range.get %[[VAL_2]][%[[VAL_11]]] {ArgumentTypes = [memref<1x!sycl_range_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (!sycl_range_3_, i32) -> memref<3xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_13]], %[[VAL_14]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
-// CHECK-NEXT:      return %[[VAL_2]] : !sycl_range_3_
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = gpu.block_dim  x
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : index to i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = sycl.range.get %[[VAL_0]]{{\[}}%[[VAL_2]]] {ArgumentTypes = [memref<1x!sycl_range_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:      %[[VAL_7:.*]] = gpu.block_dim  y
+// CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_7]] : index to i64
+// CHECK-NEXT:      %[[VAL_9:.*]] = sycl.range.get %[[VAL_0]]{{\[}}%[[VAL_6]]] {ArgumentTypes = [memref<1x!sycl_range_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_8]], %[[VAL_9]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      %[[VAL_10:.*]] = arith.constant 2 : i32
+// CHECK-NEXT:      %[[VAL_11:.*]] = gpu.block_dim  z
+// CHECK-NEXT:      %[[VAL_12:.*]] = arith.index_cast %[[VAL_11]] : index to i64
+// CHECK-NEXT:      %[[VAL_13:.*]] = sycl.range.get %[[VAL_0]]{{\[}}%[[VAL_10]]] {ArgumentTypes = [memref<1x!sycl_range_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_12]], %[[VAL_13]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      %[[VAL_14:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_range_3_>
+// CHECK-NEXT:      return %[[VAL_14]] : !sycl_range_3_
 // CHECK-NEXT:    }
 func.func @test_work_group_size() -> !sycl_range_3_ {
   %0 = sycl.work_group_size() : () -> !sycl_range_3_
@@ -183,13 +183,13 @@ func.func @test_work_group_size_dim(%i: i32) -> index {
 // CHECK-LABEL:   func.func @test_work_group_id() -> !sycl_id_1_ {
 // CHECK-NEXT:      %[[VAL_0:.*]] = memref.alloca() : memref<1x!sycl_id_1_>
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_1_>
-// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = gpu.block_id  x
-// CHECK-NEXT:      %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : index to i64
-// CHECK-NEXT:      %[[VAL_6:.*]] = sycl.id.get %[[VAL_2]][%[[VAL_3]]] {ArgumentTypes = [memref<1x!sycl_id_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_1_, i32) -> memref<1xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_6]]{{\[}}%[[VAL_1]]] : memref<1xi64, 4>
-// CHECK-NEXT:      return %[[VAL_2]] : !sycl_id_1_
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = gpu.block_id  x
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : index to i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_2]]] {ArgumentTypes = [memref<1x!sycl_id_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_1_>, i32) -> memref<1xi64, 4>
+// CHECK-NEXT:      affine.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<1xi64, 4>
+// CHECK-NEXT:      %[[VAL_6:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_1_>
+// CHECK-NEXT:      return %[[VAL_6]] : !sycl_id_1_
 // CHECK-NEXT:    }
 func.func @test_work_group_id() -> !sycl_id_1_ {
   %0 = sycl.work_group_id() : () -> !sycl_id_1_

--- a/mlir-sycl/test/Conversion/SYCLToGPU/grid-ops.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToGPU/grid-ops.mlir
@@ -19,7 +19,7 @@
 // CHECK-NEXT:      return %[[VAL_6]] : !sycl_range_1_
 // CHECK-NEXT:    }
 func.func @test_num_work_items() -> !sycl_range_1_ {
-  %0 = sycl.num_work_items() : () -> !sycl_range_1_
+  %0 = sycl.num_work_items : !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
@@ -40,7 +40,7 @@ func.func @test_num_work_items() -> !sycl_range_1_ {
 // CHECK-NEXT:      return %[[VAL_9]] : index
 // CHECK-NEXT:    }
 func.func @test_num_work_items_dim(%i: i32) -> index {
-  %0 = sycl.num_work_items(%i) : (i32) -> index
+  %0 = sycl.num_work_items %i : index
   return %0 : index
 }
 
@@ -61,7 +61,7 @@ func.func @test_num_work_items_dim(%i: i32) -> index {
 // CHECK-NEXT:      return %[[VAL_10]] : !sycl_id_2_
 // CHECK-NEXT:    }
 func.func @test_global_id() -> !sycl_id_2_ {
-  %0 = sycl.global_id() : () -> !sycl_id_2_
+  %0 = sycl.global_id : !sycl_id_2_
   return %0 : !sycl_id_2_
 }
 
@@ -82,7 +82,7 @@ func.func @test_global_id() -> !sycl_id_2_ {
 // CHECK-NEXT:      return %[[VAL_9]] : index
 // CHECK-NEXT:    }
 func.func @test_global_id_dim(%i: i32) -> index {
-  %0 = sycl.global_id(%i) : (i32) -> index
+  %0 = sycl.global_id %i : index
   return %0 : index
 }
 
@@ -108,7 +108,7 @@ func.func @test_global_id_dim(%i: i32) -> index {
 // CHECK-NEXT:      return %[[VAL_14]] : !sycl_id_3_
 // CHECK-NEXT:    }
 func.func @test_local_id() -> !sycl_id_3_ {
-  %0 = sycl.local_id() : () -> !sycl_id_3_
+  %0 = sycl.local_id : !sycl_id_3_
   return %0 : !sycl_id_3_
 }
 
@@ -129,7 +129,7 @@ func.func @test_local_id() -> !sycl_id_3_ {
 // CHECK-NEXT:      return %[[VAL_9]] : index
 // CHECK-NEXT:    }
 func.func @test_local_id_dim(%i: i32) -> index {
-  %0 = sycl.local_id(%i) : (i32) -> index
+  %0 = sycl.local_id %i : index
   return %0 : index
 }
 
@@ -155,7 +155,7 @@ func.func @test_local_id_dim(%i: i32) -> index {
 // CHECK-NEXT:      return %[[VAL_14]] : !sycl_range_3_
 // CHECK-NEXT:    }
 func.func @test_work_group_size() -> !sycl_range_3_ {
-  %0 = sycl.work_group_size() : () -> !sycl_range_3_
+  %0 = sycl.work_group_size : !sycl_range_3_
   return %0 : !sycl_range_3_
 }
 
@@ -176,7 +176,7 @@ func.func @test_work_group_size() -> !sycl_range_3_ {
 // CHECK-NEXT:      return %[[VAL_9]] : index
 // CHECK-NEXT:    }
 func.func @test_work_group_size_dim(%i: i32) -> index {
-  %0 = sycl.work_group_size(%i) : (i32) -> index
+  %0 = sycl.work_group_size %i : index
   return %0 : index
 }
 
@@ -192,7 +192,7 @@ func.func @test_work_group_size_dim(%i: i32) -> index {
 // CHECK-NEXT:      return %[[VAL_6]] : !sycl_id_1_
 // CHECK-NEXT:    }
 func.func @test_work_group_id() -> !sycl_id_1_ {
-  %0 = sycl.work_group_id() : () -> !sycl_id_1_
+  %0 = sycl.work_group_id : !sycl_id_1_
   return %0 : !sycl_id_1_
 }
 
@@ -213,7 +213,7 @@ func.func @test_work_group_id() -> !sycl_id_1_ {
 // CHECK-NEXT:      return %[[VAL_9]] : index
 // CHECK-NEXT:    }
 func.func @test_work_group_id_dim(%i: i32) -> index {
-  %0 = sycl.work_group_id(%i) : (i32) -> index
+  %0 = sycl.work_group_id %i : index
   return %0 : index
 }
 
@@ -223,7 +223,7 @@ func.func @test_work_group_id_dim(%i: i32) -> index {
 // CHECK-NEXT:      return %[[VAL_1]] : i32
 // CHECK-NEXT:    }
 func.func @test_num_sub_groups() -> i32 {
-  %0 = sycl.num_sub_groups : () -> i32
+  %0 = sycl.num_sub_groups : i32
   return %0 : i32
 }
 
@@ -233,7 +233,7 @@ func.func @test_num_sub_groups() -> i32 {
 // CHECK-NEXT:      return %[[VAL_1]] : i32
 // CHECK-NEXT:    }
 func.func @test_sub_group_size() -> i32 {
-  %0 = sycl.sub_group_size : () -> i32
+  %0 = sycl.sub_group_size : i32
   return %0 : i32
 }
 
@@ -243,6 +243,6 @@ func.func @test_sub_group_size() -> i32 {
 // CHECK-NEXT:      return %[[VAL_1]] : i32
 // CHECK-NEXT:    }
 func.func @test_sub_group_id() -> i32 {
-  %0 = sycl.sub_group_id : () -> i32
+  %0 = sycl.sub_group_id : i32
   return %0 : i32
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/failing-sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/failing-sycl-methods-to-llvm.mlir
@@ -31,3 +31,64 @@ func.func @test(%acc: !sycl_accessor_1_i32_rw_gb, %off: i64) -> !sycl_atomic_i32
   %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_1_i32_rw_gb, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_1_i32_rw_gb, i64) -> !sycl_atomic_i32_1_
   return %0 : !sycl_atomic_i32_1_
 }
+
+// -----
+
+// Failing because index space getters cannot be legalized.
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.group.get_local_id with id output
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+
+func.func @test(%mr: memref<?x!sycl_group_1_>) -> !sycl_id_1_ {
+  %0 = "sycl.group.get_local_id"(%mr) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_local_id", MangledFunctionName = @"get_local_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
+  return %0 : !sycl_id_1_
+}
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.group.get_local_id with scalar output
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+
+func.func @test(%mr: memref<?x!sycl_group_1_>, %off: i32) -> i64 {
+  %0 = "sycl.group.get_local_id"(%mr, %off) { ArgumentTypes = [memref<?x!sycl_group_1_>, i32], FunctionName = @"get_local_id", MangledFunctionName = @"get_local_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>, i32) -> i64
+  return %0 : i64
+}
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.group.get_local_linear_id
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+
+func.func @test1(%mr: memref<?x!sycl_group_1_>) -> i64 {
+  %0 = "sycl.group.get_local_linear_id"(%mr) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> i64
+  return %0 : i64
+}
+
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_group_2_ = !sycl.group<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
+
+func.func @test2(%mr: memref<?x!sycl_group_2_>) -> i64 {
+  %0 = "sycl.group.get_local_linear_id"(%mr) { ArgumentTypes = [memref<?x!sycl_group_2_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_2_>) -> i64
+  return %0 : i64
+}
+
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
+!sycl_group_3_ = !sycl.group<[3], (!sycl_range_3_, !sycl_range_3_, !sycl_range_3_, !sycl_id_3_)>
+
+func.func @test3(%mr: memref<?x!sycl_group_3_>) -> i64 {
+  %0 = "sycl.group.get_local_linear_id"(%mr) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64
+  return %0 : i64
+}

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/failing-sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/failing-sycl-methods-to-llvm.mlir
@@ -13,3 +13,21 @@ func.func @test(%range: !sycl_range_3_, %idx: i32) -> memref<?xi64> {
   %0 = "sycl.range.get"(%range, %idx) { ArgumentTypes = [!sycl_range_3_, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"range" }  : (!sycl_range_3_, i32) -> memref<?xi64>
   return %0 : memref<?xi64>
 }
+
+// -----
+
+// Failing because this signature is not recognized as legal.
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.accessor.subscript with atomic access mode and sycl.id offset
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_atomic_i32_1_ = !sycl.atomic<[i32, 1], (memref<?xi32, 1>)>
+
+func.func @test(%acc: !sycl_accessor_1_i32_rw_gb, %off: i64) -> !sycl_atomic_i32_1_ {
+  %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_1_i32_rw_gb, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_1_i32_rw_gb, i64) -> !sycl_atomic_i32_1_
+  return %0 : !sycl_atomic_i32_1_
+}

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -1,5 +1,4 @@
 // RUN: sycl-mlir-opt -split-input-file -convert-sycl-to-llvm="use-bare-ptr-call-conv" %s | FileCheck %s
-// XFAIL: *
 
 //===-------------------------------------------------------------------------------------------------===//
 // sycl.nd_range.get_global_range
@@ -10,12 +9,13 @@
 !sycl_nd_range_3_ = !sycl.nd_range<[3], (!sycl_range_3_, !sycl_range_3_, !sycl_id_3_)>
 
 // CHECK-LABEL:   llvm.func @test(
-// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.struct<"class.sycl::_V1::nd_range.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>) -> !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> {
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.extractvalue %[[VAL_0]][0] : !llvm.struct<"class.sycl::_V1::nd_range.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>
-// CHECK-NEXT:      llvm.return %[[VAL_1]] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:    }
-func.func @test(%nd_range: !sycl_nd_range_3_) -> !sycl_range_3_ {
-  %0 = "sycl.nd_range.get_global_range"(%nd_range) { ArgumentTypes = [!sycl_nd_range_3_], FunctionName = @"get_global_range", MangledFunctionName = @"get_global_range", TypeName = @"nd_range" }  : (!sycl_nd_range_3_) -> !sycl_range_3_
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<struct<"class.sycl::_V1::nd_range.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>>) -> !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> {
+// CHECK:           %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr<struct<"class.sycl::_V1::nd_range.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>>) -> !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+// CHECK:           %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+// CHECK:           llvm.return %[[VAL_2]] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK:         }
+func.func @test(%mr: memref<?x!sycl_nd_range_3_>) -> !sycl_range_3_ {
+  %0 = "sycl.nd_range.get_global_range"(%mr) { ArgumentTypes = [memref<?x!sycl_nd_range_3_>], FunctionName = @"get_global_range", MangledFunctionName = @"get_global_range", TypeName = @"nd_range" }  : (memref<?x!sycl_nd_range_3_>) -> !sycl_range_3_
   return %0 : !sycl_range_3_
 }
 
@@ -30,12 +30,13 @@ func.func @test(%nd_range: !sycl_nd_range_3_) -> !sycl_range_3_ {
 !sycl_nd_range_3_ = !sycl.nd_range<[3], (!sycl_range_3_, !sycl_range_3_, !sycl_id_3_)>
 
 // CHECK-LABEL:   llvm.func @test(
-// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.struct<"class.sycl::_V1::nd_range.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>) -> !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> {
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.extractvalue %[[VAL_0]][1] : !llvm.struct<"class.sycl::_V1::nd_range.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>
-// CHECK-NEXT:      llvm.return %[[VAL_1]] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:    }
-func.func @test(%nd_range: !sycl_nd_range_3_) -> !sycl_range_3_ {
-  %0 = "sycl.nd_range.get_local_range"(%nd_range) { ArgumentTypes = [!sycl_nd_range_3_], FunctionName = @"get_local_range", MangledFunctionName = @"get_local_range", TypeName = @"nd_range" }  : (!sycl_nd_range_3_) -> !sycl_range_3_
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<struct<"class.sycl::_V1::nd_range.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>>) -> !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> {
+// CHECK:           %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr<struct<"class.sycl::_V1::nd_range.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>>) -> !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+// CHECK:           %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+// CHECK:           llvm.return %[[VAL_2]] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK:         }
+func.func @test(%mr: memref<?x!sycl_nd_range_3_>) -> !sycl_range_3_ {
+  %0 = "sycl.nd_range.get_local_range"(%mr) { ArgumentTypes = [memref<?x!sycl_nd_range_3_>], FunctionName = @"get_local_range", MangledFunctionName = @"get_local_range", TypeName = @"nd_range" }  : (memref<?x!sycl_nd_range_3_>) -> !sycl_range_3_
   return %0 : !sycl_range_3_
 }
 
@@ -50,26 +51,35 @@ func.func @test(%nd_range: !sycl_nd_range_3_) -> !sycl_range_3_ {
 !sycl_nd_range_3_ = !sycl.nd_range<[3], (!sycl_range_3_, !sycl_range_3_, !sycl_id_3_)>
 
 // CHECK-LABEL:   llvm.func @test(
-// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.struct<"class.sycl::_V1::nd_range.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>) -> !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> {
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.extractvalue %[[VAL_0]][0] : !llvm.struct<"class.sycl::_V1::nd_range.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.extractvalue %[[VAL_0]][1] : !llvm.struct<"class.sycl::_V1::nd_range.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.undef : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.extractvalue %[[VAL_1]][0, 0, 0] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.extractvalue %[[VAL_2]][0, 0, 0] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.udiv %[[VAL_4]], %[[VAL_5]]  : i64
-// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.insertvalue %[[VAL_6]], %[[VAL_3]][0, 0, 0] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.extractvalue %[[VAL_1]][0, 0, 1] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.extractvalue %[[VAL_2]][0, 0, 1] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.udiv %[[VAL_8]], %[[VAL_9]]  : i64
-// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.insertvalue %[[VAL_10]], %[[VAL_7]][0, 0, 1] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.extractvalue %[[VAL_1]][0, 0, 2] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.extractvalue %[[VAL_2]][0, 0, 2] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.udiv %[[VAL_12]], %[[VAL_13]]  : i64
-// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.insertvalue %[[VAL_14]], %[[VAL_11]][0, 0, 2] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:      llvm.return %[[VAL_15]] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:    }
-func.func @test(%nd_range: !sycl_nd_range_3_) -> !sycl_range_3_ {
-  %0 = "sycl.nd_range.get_group_range"(%nd_range) { ArgumentTypes = [!sycl_nd_range_3_], FunctionName = @"get_group_range", MangledFunctionName = @"get_group_range", TypeName = @"nd_range" }  : (!sycl_nd_range_3_) -> !sycl_range_3_
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<struct<"class.sycl::_V1::nd_range.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>>) -> !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> {
+// CHECK:           %[[VAL_1:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:           %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 0, 0] : (!llvm.ptr<struct<"class.sycl::_V1::nd_range.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, 0, 0] : (!llvm.ptr<struct<"class.sycl::_V1::nd_range.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_7:.*]] = llvm.udiv %[[VAL_4]], %[[VAL_6]]  : i64
+// CHECK:           %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, 0] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>) -> !llvm.ptr<i64>
+// CHECK:           llvm.store %[[VAL_7]], %[[VAL_8]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 0, 1] : (!llvm.ptr<struct<"class.sycl::_V1::nd_range.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, 0, 1] : (!llvm.ptr<struct<"class.sycl::_V1::nd_range.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_12:.*]] = llvm.load %[[VAL_11]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_13:.*]] = llvm.udiv %[[VAL_10]], %[[VAL_12]]  : i64
+// CHECK:           %[[VAL_14:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, 1] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>) -> !llvm.ptr<i64>
+// CHECK:           llvm.store %[[VAL_13]], %[[VAL_14]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_15:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 0, 2] : (!llvm.ptr<struct<"class.sycl::_V1::nd_range.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_16:.*]] = llvm.load %[[VAL_15]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_17:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, 0, 2] : (!llvm.ptr<struct<"class.sycl::_V1::nd_range.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_18:.*]] = llvm.load %[[VAL_17]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_19:.*]] = llvm.udiv %[[VAL_16]], %[[VAL_18]]  : i64
+// CHECK:           %[[VAL_20:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, 2] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>) -> !llvm.ptr<i64>
+// CHECK:           llvm.store %[[VAL_19]], %[[VAL_20]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_21:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+// CHECK:           llvm.return %[[VAL_21]] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK:         }
+func.func @test(%mr: memref<?x!sycl_nd_range_3_>) -> !sycl_range_3_ {
+  %0 = "sycl.nd_range.get_group_range"(%mr) { ArgumentTypes = [memref<?x!sycl_nd_range_3_>], FunctionName = @"get_group_range", MangledFunctionName = @"get_group_range", TypeName = @"nd_range" }  : (memref<?x!sycl_nd_range_3_>) -> !sycl_range_3_
   return %0 : !sycl_range_3_
 }
 
@@ -82,17 +92,14 @@ func.func @test(%nd_range: !sycl_nd_range_3_) -> !sycl_range_3_ {
 !sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
 
 // CHECK-LABEL:   llvm.func @test(
-// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>,
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>,
 // CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> i64 {
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> {alignment = 24 : i64} : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-// CHECK-NEXT:      llvm.store %[[VAL_0]], %[[VAL_3]] : !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 0, 0, %[[VAL_1]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.load %[[VAL_4]] {alignment = 24 : i64} : !llvm.ptr<i64>
-// CHECK-NEXT:      llvm.return %[[VAL_5]] : i64
-// CHECK-NEXT:    }
-func.func @test(%range: !sycl_range_3_, %idx: i32) -> i64 {
-  %0 = "sycl.range.get"(%range, %idx) { ArgumentTypes = [!sycl_range_3_, i32], FunctionName = @"get", MangledFunctionName = @"get", TypeName = @"range" }  : (!sycl_range_3_, i32) -> i64
+// CHECK:           %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, %[[VAL_1]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i64>
+// CHECK:           llvm.return %[[VAL_3]] : i64
+// CHECK:         }
+func.func @test(%mr: memref<?x!sycl_range_3_>, %idx: i32) -> i64 {
+  %0 = "sycl.range.get"(%mr, %idx) { ArgumentTypes = [memref<?x!sycl_range_3_>, i32], FunctionName = @"get", MangledFunctionName = @"get", TypeName = @"range" }  : (memref<?x!sycl_range_3_>, i32) -> i64
   return %0 : i64
 }
 
@@ -102,20 +109,57 @@ func.func @test(%range: !sycl_range_3_, %idx: i32) -> i64 {
 // sycl.range.size
 //===-------------------------------------------------------------------------------------------------===//
 
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<3xi64, 4>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<3xi64, 4>)>)>
 !sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
 
-// CHECK-LABEL:   llvm.func @test(
-// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>) -> i64 {
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.extractvalue %[[VAL_0]][0, 0, 0] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mul %[[VAL_1]], %[[VAL_2]]  : i64
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.extractvalue %[[VAL_0]][0, 0, 1] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mul %[[VAL_3]], %[[VAL_4]]  : i64
-// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.extractvalue %[[VAL_0]][0, 0, 2] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_5]], %[[VAL_6]]  : i64
-// CHECK-NEXT:      llvm.return %[[VAL_7]] : i64
-// CHECK-NEXT:    }
-func.func @test(%range: !sycl_range_3_) -> i64 {
-  %0 = "sycl.range.size"(%range) { ArgumentTypes = [!sycl_range_3_], FunctionName = @"size", MangledFunctionName = @"size", TypeName = @"range" }  : (!sycl_range_3_) -> i64
+// CHECK-LABEL:   llvm.func @test1(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>,
+// CHECK-SAME:                     %[[VAL_1:.*]]: i32) -> i64 {
+// CHECK:           %[[VAL_2:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 0] : (!llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_5:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]]  : i64
+// CHECK:           llvm.return %[[VAL_5]] : i64
+// CHECK:         }
+func.func @test1(%mr: memref<?x!sycl_range_1_>, %idx: i32) -> i64 {
+  %0 = "sycl.range.size"(%mr) { ArgumentTypes = [memref<?x!sycl_range_1_>], FunctionName = @"size", MangledFunctionName = @"size", TypeName = @"range" }  : (memref<?x!sycl_range_1_>) -> i64
+  return %0 : i64
+}
+
+// CHECK-LABEL:   llvm.func @test2(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>,
+// CHECK-SAME:                     %[[VAL_1:.*]]: i32) -> i64 {
+// CHECK:           %[[VAL_2:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 0] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_5:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]]  : i64
+// CHECK:           %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 1] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_7:.*]] = llvm.load %[[VAL_6]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_8:.*]] = llvm.mul %[[VAL_5]], %[[VAL_7]]  : i64
+// CHECK:           llvm.return %[[VAL_8]] : i64
+// CHECK:         }
+func.func @test2(%mr: memref<?x!sycl_range_2_>, %idx: i32) -> i64 {
+  %0 = "sycl.range.size"(%mr) { ArgumentTypes = [memref<?x!sycl_range_2_>], FunctionName = @"size", MangledFunctionName = @"size", TypeName = @"range" }  : (memref<?x!sycl_range_2_>) -> i64
+  return %0 : i64
+}
+
+// CHECK-LABEL:   llvm.func @test3(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>,
+// CHECK-SAME:                     %[[VAL_1:.*]]: i32) -> i64 {
+// CHECK:           %[[VAL_2:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 0] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_5:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]]  : i64
+// CHECK:           %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 1] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_7:.*]] = llvm.load %[[VAL_6]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_8:.*]] = llvm.mul %[[VAL_5]], %[[VAL_7]]  : i64
+// CHECK:           %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 2] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_11:.*]] = llvm.mul %[[VAL_8]], %[[VAL_10]]  : i64
+// CHECK:           llvm.return %[[VAL_11]] : i64
+// CHECK:         }
+func.func @test3(%mr: memref<?x!sycl_range_3_>, %idx: i32) -> i64 {
+  %0 = "sycl.range.size"(%mr) { ArgumentTypes = [memref<?x!sycl_range_3_>], FunctionName = @"size", MangledFunctionName = @"size", TypeName = @"range" }  : (memref<?x!sycl_range_3_>) -> i64
   return %0 : i64
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -193,15 +193,18 @@ func.func @test3(%mr: memref<?x!sycl_range_3_>, %idx: i32) -> i64 {
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
 
-// CHECK-LABEL:   func.func @test(
-// CHECK-SAME:                    %[[VAL_0:.*]]: !sycl_accessor_1_i32_rw_gb,
-// CHECK-SAME:                    %[[VAL_1:.*]]: i64) -> memref<?xi32, 1> {
-// CHECK-NEXT:      %[[VAL_2:.*]] = builtin.unrealized_conversion_cast %[[VAL_0]] : !sycl_accessor_1_i32_rw_gb to !llvm.struct<"class.sycl::_V1::accessor.1", (struct<"class.sycl::_V1::detail::AccessorImplDevice.1", (struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.extractvalue %[[VAL_2]][1, 0] : !llvm.struct<"class.sycl::_V1::accessor.1", (struct<"class.sycl::_V1::detail::AccessorImplDevice.1", (struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<i32, 1>, i64) -> !llvm.ptr<i32, 1>
-// CHECK-NEXT:      llvm.return %[[VAL_4]] : !llvm.ptr<i32, 1>
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[ACCESSOR1:.*]]>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: i64) -> !llvm.ptr<i32, 1> {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<[[ACCESSOR1]]>, i64) -> !llvm.ptr<[[ACCESSOR1]]>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<[[ACCESSOR1]]>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 1, 0, %[[VAL_1]]] : (!llvm.ptr<[[ACCESSOR1]]>, i64) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:      llvm.return %[[VAL_5]] : !llvm.ptr<i32, 1>
 // CHECK-NEXT:    }
-func.func @test(%acc: !sycl_accessor_1_i32_rw_gb, %off: i64) -> (memref<?xi32, 1>) {
+func.func @test(%mr: memref<?x!sycl_accessor_1_i32_rw_gb>, %off: i64) -> (memref<?xi32, 1>) {
+  %c_0 = arith.constant 0 : index
+  %acc = memref.load %mr[%c_0] : memref<?x!sycl_accessor_1_i32_rw_gb>
   %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_1_i32_rw_gb, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_1_i32_rw_gb, i64) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
@@ -222,71 +225,98 @@ func.func @test(%acc: !sycl_accessor_1_i32_rw_gb, %off: i64) -> (memref<?xi32, 1
 !sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
 !sycl_accessor_3_i32_rw_gb = !sycl.accessor<[3, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[3], (!sycl_id_3_, !sycl_range_3_, !sycl_range_3_)>, !llvm.struct<(ptr<i32, 1>)>)>
 
-// CHECK-LABEL:   func.func @test0(
-// CHECK-SAME:                     %[[VAL_0:.*]]: !sycl_accessor_1_i32_rw_gb,
-// CHECK-SAME:                     %[[VAL_1:.*]]: !sycl_id_1_) -> memref<?xi32, 1> {
-// CHECK-NEXT:      %[[VAL_2:.*]] = builtin.unrealized_conversion_cast %[[VAL_0]] : !sycl_accessor_1_i32_rw_gb to !llvm.struct<"class.sycl::_V1::accessor.1", (struct<"class.sycl::_V1::detail::AccessorImplDevice.1", (struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
-// CHECK-NEXT:      %[[VAL_3:.*]] = builtin.unrealized_conversion_cast %[[VAL_1]] : !sycl_id_1_ to !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.extractvalue %[[VAL_2]][0, 1, 0, 0, 0] : !llvm.struct<"class.sycl::_V1::accessor.1", (struct<"class.sycl::_V1::detail::AccessorImplDevice.1", (struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
-// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.extractvalue %[[VAL_3]][0, 0, 0] : !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_4]], %[[VAL_5]]  : i64
-// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.add %[[VAL_7]], %[[VAL_6]]  : i64
-// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.extractvalue %[[VAL_2]][1, 0] : !llvm.struct<"class.sycl::_V1::accessor.1", (struct<"class.sycl::_V1::detail::AccessorImplDevice.1", (struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
-// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_9]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<i32, 1>, i64) -> !llvm.ptr<i32, 1>
-// CHECK-NEXT:      llvm.return %[[VAL_10]] : !llvm.ptr<i32, 1>
+// CHECK-LABEL:   llvm.func @test0(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<[[ACCESSOR1]]>,
+// CHECK-SAME:                     %[[VAL_1:.*]]: !llvm.ptr<[[ID1:.*]]>) -> !llvm.ptr<i32, 1> {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<[[ACCESSOR1]]>, i64) -> !llvm.ptr<[[ACCESSOR1]]>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<[[ACCESSOR1]]>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_1]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<[[ID1]]>, i64) -> !llvm.ptr<[[ID1]]>
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr<[[ID1]]>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 0, 1, 0, 0, 0] : (!llvm.ptr<[[ACCESSOR1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.load %[[VAL_8]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_5]][0, 0, 0, 0] : (!llvm.ptr<[[ID1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.load %[[VAL_10]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.mul %[[VAL_7]], %[[VAL_9]]  : i64
+// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.add %[[VAL_12]], %[[VAL_11]]  : i64
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 1, 0, %[[VAL_13]]] : (!llvm.ptr<[[ACCESSOR1]]>, i64) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:      llvm.return %[[VAL_14]] : !llvm.ptr<i32, 1>
 // CHECK-NEXT:    }
-func.func @test0(%acc: !sycl_accessor_1_i32_rw_gb, %off: !sycl_id_1_) -> (memref<?xi32, 1>) {
+func.func @test0(%mr: memref<?x!sycl_accessor_1_i32_rw_gb>, %off_mr: memref<?x!sycl_id_1_>) -> (memref<?xi32, 1>) {
+  %c_0 = arith.constant 0 : index
+  %acc = memref.load %mr[%c_0] : memref<?x!sycl_accessor_1_i32_rw_gb>
+  %off = memref.load %off_mr[%c_0] : memref<?x!sycl_id_1_>
   %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_1_i32_rw_gb, !sycl_id_1_], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_1_i32_rw_gb, !sycl_id_1_) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
-// CHECK-LABEL:   func.func @test1(
-// CHECK-SAME:                     %[[VAL_0:.*]]: !sycl_accessor_2_i32_rw_gb,
-// CHECK-SAME:                     %[[VAL_1:.*]]: !sycl_id_2_) -> memref<?xi32, 1> {
-// CHECK-NEXT:      %[[VAL_2:.*]] = builtin.unrealized_conversion_cast %[[VAL_0]] : !sycl_accessor_2_i32_rw_gb to !llvm.struct<"class.sycl::_V1::accessor.2", (struct<"class.sycl::_V1::detail::AccessorImplDevice.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
-// CHECK-NEXT:      %[[VAL_3:.*]] = builtin.unrealized_conversion_cast %[[VAL_1]] : !sycl_id_2_ to !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.extractvalue %[[VAL_2]][0, 1, 0, 0, 0] : !llvm.struct<"class.sycl::_V1::accessor.2", (struct<"class.sycl::_V1::detail::AccessorImplDevice.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
-// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.extractvalue %[[VAL_3]][0, 0, 0] : !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_4]], %[[VAL_5]]  : i64
-// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.add %[[VAL_7]], %[[VAL_6]]  : i64
-// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.extractvalue %[[VAL_2]][0, 1, 0, 0, 1] : !llvm.struct<"class.sycl::_V1::accessor.2", (struct<"class.sycl::_V1::detail::AccessorImplDevice.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
-// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.extractvalue %[[VAL_3]][0, 0, 1] : !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.mul %[[VAL_8]], %[[VAL_9]]  : i64
-// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.add %[[VAL_11]], %[[VAL_10]]  : i64
-// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.extractvalue %[[VAL_2]][1, 0] : !llvm.struct<"class.sycl::_V1::accessor.2", (struct<"class.sycl::_V1::detail::AccessorImplDevice.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
-// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.getelementptr inbounds %[[VAL_13]]{{\[}}%[[VAL_12]]] : (!llvm.ptr<i32, 1>, i64) -> !llvm.ptr<i32, 1>
-// CHECK-NEXT:      llvm.return %[[VAL_14]] : !llvm.ptr<i32, 1>
+// CHECK-LABEL:   llvm.func @test1(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<[[ACCESSOR2:.*]]>,
+// CHECK-SAME:                     %[[VAL_1:.*]]: !llvm.ptr<[[ID2:.*]]>) -> !llvm.ptr<i32, 1> {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<[[ACCESSOR2]]>, i64) -> !llvm.ptr<[[ACCESSOR2]]>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<[[ACCESSOR2]]>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_1]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<[[ID2]]>, i64) -> !llvm.ptr<[[ID2]]>
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr<[[ID2]]>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 0, 1, 0, 0, 0] : (!llvm.ptr<[[ACCESSOR2]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.load %[[VAL_8]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_5]][0, 0, 0, 0] : (!llvm.ptr<[[ID2]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.load %[[VAL_10]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.mul %[[VAL_7]], %[[VAL_9]]  : i64
+// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.add %[[VAL_12]], %[[VAL_11]]  : i64
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 0, 1, 0, 0, 1] : (!llvm.ptr<[[ACCESSOR2]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.load %[[VAL_14]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_16:.*]] = llvm.getelementptr inbounds %[[VAL_5]][0, 0, 0, 1] : (!llvm.ptr<[[ID2]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_17:.*]] = llvm.load %[[VAL_16]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_18:.*]] = llvm.mul %[[VAL_13]], %[[VAL_15]]  : i64
+// CHECK-NEXT:      %[[VAL_19:.*]] = llvm.add %[[VAL_18]], %[[VAL_17]]  : i64
+// CHECK-NEXT:      %[[VAL_20:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 1, 0, %[[VAL_19]]] : (!llvm.ptr<[[ACCESSOR2]]>, i64) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:      llvm.return %[[VAL_20]] : !llvm.ptr<i32, 1>
 // CHECK-NEXT:    }
-func.func @test1(%acc: !sycl_accessor_2_i32_rw_gb, %off: !sycl_id_2_) -> (memref<?xi32, 1>) {
+func.func @test1(%mr: memref<?x!sycl_accessor_2_i32_rw_gb>, %off_mr: memref<?x!sycl_id_2_>) -> (memref<?xi32, 1>) {
+  %c_0 = arith.constant 0 : index
+  %acc = memref.load %mr[%c_0] : memref<?x!sycl_accessor_2_i32_rw_gb>
+  %off = memref.load %off_mr[%c_0] : memref<?x!sycl_id_2_>
   %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_2_i32_rw_gb, !sycl_id_2_], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_2_i32_rw_gb, !sycl_id_2_) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
-// CHECK-LABEL:   func.func @test2(
-// CHECK-SAME:                     %[[VAL_0:.*]]: !sycl_accessor_3_i32_rw_gb,
-// CHECK-SAME:                     %[[VAL_1:.*]]: !sycl_id_3_) -> memref<?xi32, 1> {
-// CHECK-NEXT:      %[[VAL_2:.*]] = builtin.unrealized_conversion_cast %[[VAL_0]] : !sycl_accessor_3_i32_rw_gb to !llvm.struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
-// CHECK-NEXT:      %[[VAL_3:.*]] = builtin.unrealized_conversion_cast %[[VAL_1]] : !sycl_id_3_ to !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.extractvalue %[[VAL_2]][0, 1, 0, 0, 0] : !llvm.struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
-// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.extractvalue %[[VAL_3]][0, 0, 0] : !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_4]], %[[VAL_5]]  : i64
-// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.add %[[VAL_7]], %[[VAL_6]]  : i64
-// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.extractvalue %[[VAL_2]][0, 1, 0, 0, 1] : !llvm.struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
-// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.extractvalue %[[VAL_3]][0, 0, 1] : !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.mul %[[VAL_8]], %[[VAL_9]]  : i64
-// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.add %[[VAL_11]], %[[VAL_10]]  : i64
-// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.extractvalue %[[VAL_2]][0, 1, 0, 0, 2] : !llvm.struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
-// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.extractvalue %[[VAL_3]][0, 0, 2] : !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.mul %[[VAL_12]], %[[VAL_13]]  : i64
-// CHECK-NEXT:      %[[VAL_16:.*]] = llvm.add %[[VAL_15]], %[[VAL_14]]  : i64
-// CHECK-NEXT:      %[[VAL_17:.*]] = llvm.extractvalue %[[VAL_2]][1, 0] : !llvm.struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
-// CHECK-NEXT:      %[[VAL_18:.*]] = llvm.getelementptr inbounds %[[VAL_17]]{{\[}}%[[VAL_16]]] : (!llvm.ptr<i32, 1>, i64) -> !llvm.ptr<i32, 1>
-// CHECK-NEXT:      llvm.return %[[VAL_18]] : !llvm.ptr<i32, 1>
+// CHECK-LABEL:   llvm.func @test2(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<[[ACCESSOR3:.*]]>,
+// CHECK-SAME:                     %[[VAL_1:.*]]: !llvm.ptr<[[ID3:.*]]>) -> !llvm.ptr<i32, 1> {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<[[ACCESSOR3]]>, i64) -> !llvm.ptr<[[ACCESSOR3]]>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<[[ACCESSOR3]]>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_1]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<[[ID3]]>, i64) -> !llvm.ptr<[[ID3]]>
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr<[[ID3]]>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 0, 1, 0, 0, 0] : (!llvm.ptr<[[ACCESSOR3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.load %[[VAL_8]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_5]][0, 0, 0, 0] : (!llvm.ptr<[[ID3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.load %[[VAL_10]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.mul %[[VAL_7]], %[[VAL_9]]  : i64
+// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.add %[[VAL_12]], %[[VAL_11]]  : i64
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 0, 1, 0, 0, 1] : (!llvm.ptr<[[ACCESSOR3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.load %[[VAL_14]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_16:.*]] = llvm.getelementptr inbounds %[[VAL_5]][0, 0, 0, 1] : (!llvm.ptr<[[ID3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_17:.*]] = llvm.load %[[VAL_16]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_18:.*]] = llvm.mul %[[VAL_13]], %[[VAL_15]]  : i64
+// CHECK-NEXT:      %[[VAL_19:.*]] = llvm.add %[[VAL_18]], %[[VAL_17]]  : i64
+// CHECK-NEXT:      %[[VAL_20:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 0, 1, 0, 0, 2] : (!llvm.ptr<[[ACCESSOR3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_21:.*]] = llvm.load %[[VAL_20]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_22:.*]] = llvm.getelementptr inbounds %[[VAL_5]][0, 0, 0, 2] : (!llvm.ptr<[[ID3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_23:.*]] = llvm.load %[[VAL_22]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_24:.*]] = llvm.mul %[[VAL_19]], %[[VAL_21]]  : i64
+// CHECK-NEXT:      %[[VAL_25:.*]] = llvm.add %[[VAL_24]], %[[VAL_23]]  : i64
+// CHECK-NEXT:      %[[VAL_26:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 1, 0, %[[VAL_25]]] : (!llvm.ptr<[[ACCESSOR3]]>, i64) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:      llvm.return %[[VAL_26]] : !llvm.ptr<i32, 1>
 // CHECK-NEXT:    }
-func.func @test2(%acc: !sycl_accessor_3_i32_rw_gb, %off: !sycl_id_3_) -> (memref<?xi32, 1>) {
+func.func @test2(%mr: memref<?x!sycl_accessor_3_i32_rw_gb>, %off_mr: memref<?x!sycl_id_3_>) -> (memref<?xi32, 1>) {
+  %c_0 = arith.constant 0 : index
+  %acc = memref.load %mr[%c_0] : memref<?x!sycl_accessor_3_i32_rw_gb>
+  %off = memref.load %off_mr[%c_0] : memref<?x!sycl_id_3_>
   %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_3_i32_rw_gb, !sycl_id_3_], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_3_i32_rw_gb, !sycl_id_3_) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
@@ -305,16 +335,21 @@ func.func @test2(%acc: !sycl_accessor_3_i32_rw_gb, %off: !sycl_id_3_) -> (memref
 !sycl_accessor_subscript_2_ = !sycl.accessor_subscript<[2], (!sycl_id_2_, !sycl.accessor<[3, i32, read_write, global_buffer], (!sycl_accessor_impl_device_3_, !llvm.struct<(ptr<i32, 1>)>)>)>
 
 // CHECK-LABEL:   llvm.func @test(
-// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>,
-// CHECK-SAME:                    %[[VAL_1:.*]]: i64) -> !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>)> {
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.undef : !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>)>
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_2]][0, 0, 0, 0] : !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>)>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_3]][0, 0, 0, 1] : !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>)>
-// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_5]][1] : !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>)>
-// CHECK-NEXT:      llvm.return %[[VAL_6]] : !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>)>
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[ACCESSOR3]]>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: i64) -> !llvm.[[SUBSCRIPT2:.*]] {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<[[ACCESSOR3]]>, i64) -> !llvm.ptr<[[ACCESSOR3]]>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<[[ACCESSOR3]]>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.undef : !llvm.[[SUBSCRIPT2]]
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_5]][0, 0, 0, 0] : !llvm.[[SUBSCRIPT2]]
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.insertvalue %[[VAL_7]], %[[VAL_6]][0, 0, 0, 1] : !llvm.[[SUBSCRIPT2]]
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_8]][1] : !llvm.[[SUBSCRIPT2]]
+// CHECK-NEXT:      llvm.return %[[VAL_9]] : !llvm.[[SUBSCRIPT2]]
 // CHECK-NEXT:    }
-func.func @test(%acc: !sycl_accessor_3_i32_rw_gb, %off: i64) -> !sycl_accessor_subscript_2_ {
+func.func @test(%mr: memref<?x!sycl_accessor_3_i32_rw_gb>, %off: i64) -> !sycl_accessor_subscript_2_ {
+  %c_0 = arith.constant 0 : index
+  %acc = memref.load %mr[%c_0] : memref<?x!sycl_accessor_3_i32_rw_gb>
   %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_3_i32_rw_gb, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_3_i32_rw_gb, i64) -> !sycl_accessor_subscript_2_
   return %0 : !sycl_accessor_subscript_2_
 }
@@ -334,15 +369,19 @@ func.func @test(%acc: !sycl_accessor_3_i32_rw_gb, %off: i64) -> !sycl_accessor_s
 !sycl_atomic_i32_3_ = !sycl.atomic<[i32, 1], (memref<?xi32, 1>)>
 
 // CHECK-LABEL:   llvm.func @test(
-// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>,
-// CHECK-SAME:                    %[[VAL_1:.*]]: i64) -> !llvm.struct<"class.sycl::_V1::atomic", (ptr<i32, 1>)> {
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.undef : !llvm.struct<"class.sycl::_V1::atomic", (ptr<i32, 1>)>
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.extractvalue %[[VAL_0]][1, 0] : !llvm.struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<i32, 1>, i64) -> !llvm.ptr<i32, 1>
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_2]][0] : !llvm.struct<"class.sycl::_V1::atomic", (ptr<i32, 1>)>
-// CHECK-NEXT:      llvm.return %[[VAL_5]] : !llvm.struct<"class.sycl::_V1::atomic", (ptr<i32, 1>)>
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[ACCESSOR3]]>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: i64) -> !llvm.[[ATO:.*]] {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<[[ACCESSOR3]]>, i64) -> !llvm.ptr<[[ACCESSOR3]]>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<[[ACCESSOR3]]>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.undef : !llvm.[[ATO]]
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 1, 0, %[[VAL_1]]] : (!llvm.ptr<[[ACCESSOR3]]>, i64) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.insertvalue %[[VAL_6]], %[[VAL_5]][0] : !llvm.[[ATO]]
+// CHECK-NEXT:      llvm.return %[[VAL_7]] : !llvm.[[ATO]]
 // CHECK-NEXT:    }
-func.func @test(%acc: !sycl_accessor_3_i32_ato_gb, %off: i64) -> !sycl_atomic_i32_3_ {
+func.func @test(%mr: memref<?x!sycl_accessor_3_i32_ato_gb>, %off: i64) -> !sycl_atomic_i32_3_ {
+  %c_0 = arith.constant 0 : index
+  %acc = memref.load %mr[%c_0] : memref<?x!sycl_accessor_3_i32_ato_gb>
   %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_3_i32_ato_gb, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_3_i32_ato_gb, i64) -> !sycl_atomic_i32_3_
   return %0 : !sycl_atomic_i32_3_
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -587,3 +587,207 @@ func.func @test3(%mr: memref<?x!sycl_item_3_>) -> i64 {
   %0 = "sycl.item.get_linear_id"(%mr) { ArgumentTypes = [memref<?x!sycl_item_3_>], FunctionName = @"get_linear_id", MangledFunctionName = @"get_linear_id", TypeName = @"item" }  : (memref<?x!sycl_item_3_>) -> i64
   return %0 : i64
 }
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.group.get_group_id with id output
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+
+func.func @test(%mr: memref<?x!sycl_group_1_>) -> !sycl_id_1_ {
+  %0 = "sycl.group.get_group_id"(%mr) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_group_id", MangledFunctionName = @"get_group_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
+  return %0 : !sycl_id_1_
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.group.get_group_id with scalar output
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+
+func.func @test(%mr: memref<?x!sycl_group_1_>, %off: i32) -> i64 {
+  %0 = "sycl.group.get_group_id"(%mr, %off) { ArgumentTypes = [memref<?x!sycl_group_1_>, i32], FunctionName = @"get_group_id", MangledFunctionName = @"get_group_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>, i32) -> i64
+  return %0 : i64
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.group.get_local_range with range output
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+
+func.func @test(%mr: memref<?x!sycl_group_1_>) -> !sycl_range_1_ {
+  %0 = "sycl.group.get_local_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_local_range", MangledFunctionName = @"get_local_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
+  return %0 : !sycl_range_1_
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.group.get_local_range with scalar output
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+
+func.func @test(%mr: memref<?x!sycl_group_1_>, %off: i32) -> i64 {
+  %0 = "sycl.group.get_local_range"(%mr, %off) { ArgumentTypes = [memref<?x!sycl_group_1_>, i32], FunctionName = @"get_local_range", MangledFunctionName = @"get_local_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>, i32) -> i64
+  return %0 : i64
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.group.get_group_range with range output
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+
+func.func @test(%mr: memref<?x!sycl_group_1_>) -> !sycl_range_1_ {
+  %0 = "sycl.group.get_group_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_group_range", MangledFunctionName = @"get_group_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
+  return %0 : !sycl_range_1_
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.group.get_group_range with scalar output
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+
+func.func @test(%mr: memref<?x!sycl_group_1_>, %off: i32) -> i64 {
+  %0 = "sycl.group.get_group_range"(%mr, %off) { ArgumentTypes = [memref<?x!sycl_group_1_>, i32], FunctionName = @"get_group_range", MangledFunctionName = @"get_group_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>, i32) -> i64
+  return %0 : i64
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.group.get_max_local_range
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+
+func.func @test(%mr: memref<?x!sycl_group_1_>) -> !sycl_range_1_ {
+  %0 = "sycl.group.get_max_local_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_max_local_range", MangledFunctionName = @"get_max_local_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
+  return %0 : !sycl_range_1_
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.group.get_group_linear_id
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+
+func.func @test1(%mr: memref<?x!sycl_group_1_>) -> i64 {
+  %0 = "sycl.group.get_group_linear_id"(%mr) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> i64
+  return %0 : i64
+}
+
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_group_2_ = !sycl.group<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
+
+func.func @test2(%mr: memref<?x!sycl_group_2_>) -> i64 {
+  %0 = "sycl.group.get_group_linear_id"(%mr) { ArgumentTypes = [memref<?x!sycl_group_2_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_2_>) -> i64
+  return %0 : i64
+}
+
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
+!sycl_group_3_ = !sycl.group<[3], (!sycl_range_3_, !sycl_range_3_, !sycl_range_3_, !sycl_id_3_)>
+
+func.func @test3(%mr: memref<?x!sycl_group_3_>) -> i64 {
+  %0 = "sycl.group.get_group_linear_id"(%mr) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64
+  return %0 : i64
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.group.get_group_linear_range
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+
+func.func @test1(%mr: memref<?x!sycl_group_1_>) -> i64 {
+  %0 = "sycl.group.get_group_linear_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_group_linear_range", MangledFunctionName = @"get_group_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> i64
+  return %0 : i64
+}
+
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_group_2_ = !sycl.group<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
+
+func.func @test2(%mr: memref<?x!sycl_group_2_>) -> i64 {
+  %0 = "sycl.group.get_group_linear_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_2_>], FunctionName = @"get_group_linear_range", MangledFunctionName = @"get_group_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_2_>) -> i64
+  return %0 : i64
+}
+
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
+!sycl_group_3_ = !sycl.group<[3], (!sycl_range_3_, !sycl_range_3_, !sycl_range_3_, !sycl_id_3_)>
+
+func.func @test3(%mr: memref<?x!sycl_group_3_>) -> i64 {
+  %0 = "sycl.group.get_group_linear_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_group_linear_range", MangledFunctionName = @"get_group_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64
+  return %0 : i64
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.group.get_local_linear_range
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+
+func.func @test1(%mr: memref<?x!sycl_group_1_>) -> i64 {
+  %0 = "sycl.group.get_local_linear_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_local_linear_range", MangledFunctionName = @"get_local_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> i64
+  return %0 : i64
+}
+
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_group_2_ = !sycl.group<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
+
+func.func @test2(%mr: memref<?x!sycl_group_2_>) -> i64 {
+  %0 = "sycl.group.get_local_linear_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_2_>], FunctionName = @"get_local_linear_range", MangledFunctionName = @"get_local_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_2_>) -> i64
+  return %0 : i64
+}
+
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
+!sycl_group_3_ = !sycl.group<[3], (!sycl_range_3_, !sycl_range_3_, !sycl_range_3_, !sycl_id_3_)>
+
+func.func @test3(%mr: memref<?x!sycl_group_3_>) -> i64 {
+  %0 = "sycl.group.get_local_linear_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_local_linear_range", MangledFunctionName = @"get_local_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64
+  return %0 : i64
+}

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -196,16 +196,11 @@ func.func @test3(%mr: memref<?x!sycl_range_3_>, %idx: i32) -> i64 {
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[ACCESSOR1:.*]]>,
 // CHECK-SAME:                    %[[VAL_1:.*]]: i64) -> !llvm.ptr<i32, 1> {
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : index) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<[[ACCESSOR1]]>, i64) -> !llvm.ptr<[[ACCESSOR1]]>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<[[ACCESSOR1]]>
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 1, 0, %[[VAL_1]]] : (!llvm.ptr<[[ACCESSOR1]]>, i64) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, %[[VAL_1]]] : (!llvm.ptr<[[ACCESSOR1]]>, i64) -> !llvm.ptr<i32, 1>
 // CHECK-NEXT:      llvm.return %[[VAL_5]] : !llvm.ptr<i32, 1>
 // CHECK-NEXT:    }
 func.func @test(%mr: memref<?x!sycl_accessor_1_i32_rw_gb>, %off: i64) -> (memref<?xi32, 1>) {
-  %c_0 = arith.constant 0 : index
-  %acc = memref.load %mr[%c_0] : memref<?x!sycl_accessor_1_i32_rw_gb>
-  %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_1_i32_rw_gb, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_1_i32_rw_gb, i64) -> memref<?xi32, 1>
+  %0 = sycl.accessor.subscript %mr[%off] { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>, i64) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
@@ -228,96 +223,68 @@ func.func @test(%mr: memref<?x!sycl_accessor_1_i32_rw_gb>, %off: i64) -> (memref
 // CHECK-LABEL:   llvm.func @test0(
 // CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<[[ACCESSOR1]]>,
 // CHECK-SAME:                     %[[VAL_1:.*]]: !llvm.ptr<[[ID1:.*]]>) -> !llvm.ptr<i32, 1> {
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : index) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<[[ACCESSOR1]]>, i64) -> !llvm.ptr<[[ACCESSOR1]]>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<[[ACCESSOR1]]>
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_1]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<[[ID1]]>, i64) -> !llvm.ptr<[[ID1]]>
-// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr<[[ID1]]>
-// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 0, 1, 0, 0, 0] : (!llvm.ptr<[[ACCESSOR1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 1, 0, 0, 0] : (!llvm.ptr<[[ACCESSOR1]]>) -> !llvm.ptr<i64>
 // CHECK-NEXT:      %[[VAL_9:.*]] = llvm.load %[[VAL_8]] : !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_5]][0, 0, 0, 0] : (!llvm.ptr<[[ID1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 0] : (!llvm.ptr<[[ID1]]>) -> !llvm.ptr<i64>
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.load %[[VAL_10]] : !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.mul %[[VAL_7]], %[[VAL_9]]  : i64
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.mul %[[VAL_2]], %[[VAL_9]]  : i64
 // CHECK-NEXT:      %[[VAL_13:.*]] = llvm.add %[[VAL_12]], %[[VAL_11]]  : i64
-// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 1, 0, %[[VAL_13]]] : (!llvm.ptr<[[ACCESSOR1]]>, i64) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, %[[VAL_13]]] : (!llvm.ptr<[[ACCESSOR1]]>, i64) -> !llvm.ptr<i32, 1>
 // CHECK-NEXT:      llvm.return %[[VAL_14]] : !llvm.ptr<i32, 1>
 // CHECK-NEXT:    }
 func.func @test0(%mr: memref<?x!sycl_accessor_1_i32_rw_gb>, %off_mr: memref<?x!sycl_id_1_>) -> (memref<?xi32, 1>) {
-  %c_0 = arith.constant 0 : index
-  %acc = memref.load %mr[%c_0] : memref<?x!sycl_accessor_1_i32_rw_gb>
-  %off = memref.load %off_mr[%c_0] : memref<?x!sycl_id_1_>
-  %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_1_i32_rw_gb, !sycl_id_1_], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_1_i32_rw_gb, !sycl_id_1_) -> memref<?xi32, 1>
+  %0 = sycl.accessor.subscript %mr[%off_mr] { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
 // CHECK-LABEL:   llvm.func @test1(
 // CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<[[ACCESSOR2:.*]]>,
 // CHECK-SAME:                     %[[VAL_1:.*]]: !llvm.ptr<[[ID2:.*]]>) -> !llvm.ptr<i32, 1> {
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : index) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<[[ACCESSOR2]]>, i64) -> !llvm.ptr<[[ACCESSOR2]]>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<[[ACCESSOR2]]>
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_1]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<[[ID2]]>, i64) -> !llvm.ptr<[[ID2]]>
-// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr<[[ID2]]>
-// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 0, 1, 0, 0, 0] : (!llvm.ptr<[[ACCESSOR2]]>) -> !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.load %[[VAL_8]] : !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_5]][0, 0, 0, 0] : (!llvm.ptr<[[ID2]]>) -> !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.load %[[VAL_10]] : !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.mul %[[VAL_7]], %[[VAL_9]]  : i64
-// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.add %[[VAL_12]], %[[VAL_11]]  : i64
-// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 0, 1, 0, 0, 1] : (!llvm.ptr<[[ACCESSOR2]]>) -> !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.load %[[VAL_14]] : !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_16:.*]] = llvm.getelementptr inbounds %[[VAL_5]][0, 0, 0, 1] : (!llvm.ptr<[[ID2]]>) -> !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_17:.*]] = llvm.load %[[VAL_16]] : !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_18:.*]] = llvm.mul %[[VAL_13]], %[[VAL_15]]  : i64
-// CHECK-NEXT:      %[[VAL_19:.*]] = llvm.add %[[VAL_18]], %[[VAL_17]]  : i64
-// CHECK-NEXT:      %[[VAL_20:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 1, 0, %[[VAL_19]]] : (!llvm.ptr<[[ACCESSOR2]]>, i64) -> !llvm.ptr<i32, 1>
-// CHECK-NEXT:      llvm.return %[[VAL_20]] : !llvm.ptr<i32, 1>
-// CHECK-NEXT:    }
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 1, 0, 0, 0] : (!llvm.ptr<[[ACCESSOR2]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 0] : (!llvm.ptr<[[ID2]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]]  : i64
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.add %[[VAL_7]], %[[VAL_6]]  : i64
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 1, 0, 0, 1] : (!llvm.ptr<[[ACCESSOR2]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 1] : (!llvm.ptr<[[ID2]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.load %[[VAL_11]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.mul %[[VAL_8]], %[[VAL_10]]  : i64
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.add %[[VAL_13]], %[[VAL_12]]  : i64
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, %[[VAL_14]]] : (!llvm.ptr<[[ACCESSOR2]]>, i64) -> !llvm.ptr<i32, 1>
 func.func @test1(%mr: memref<?x!sycl_accessor_2_i32_rw_gb>, %off_mr: memref<?x!sycl_id_2_>) -> (memref<?xi32, 1>) {
-  %c_0 = arith.constant 0 : index
-  %acc = memref.load %mr[%c_0] : memref<?x!sycl_accessor_2_i32_rw_gb>
-  %off = memref.load %off_mr[%c_0] : memref<?x!sycl_id_2_>
-  %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_2_i32_rw_gb, !sycl_id_2_], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_2_i32_rw_gb, !sycl_id_2_) -> memref<?xi32, 1>
+  %0 = sycl.accessor.subscript %mr[%off_mr] { ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
 // CHECK-LABEL:   llvm.func @test2(
 // CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<[[ACCESSOR3:.*]]>,
 // CHECK-SAME:                     %[[VAL_1:.*]]: !llvm.ptr<[[ID3:.*]]>) -> !llvm.ptr<i32, 1> {
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : index) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<[[ACCESSOR3]]>, i64) -> !llvm.ptr<[[ACCESSOR3]]>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<[[ACCESSOR3]]>
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_1]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<[[ID3]]>, i64) -> !llvm.ptr<[[ID3]]>
-// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr<[[ID3]]>
-// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 0, 1, 0, 0, 0] : (!llvm.ptr<[[ACCESSOR3]]>) -> !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.load %[[VAL_8]] : !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_5]][0, 0, 0, 0] : (!llvm.ptr<[[ID3]]>) -> !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.load %[[VAL_10]] : !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.mul %[[VAL_7]], %[[VAL_9]]  : i64
-// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.add %[[VAL_12]], %[[VAL_11]]  : i64
-// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 0, 1, 0, 0, 1] : (!llvm.ptr<[[ACCESSOR3]]>) -> !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.load %[[VAL_14]] : !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_16:.*]] = llvm.getelementptr inbounds %[[VAL_5]][0, 0, 0, 1] : (!llvm.ptr<[[ID3]]>) -> !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_17:.*]] = llvm.load %[[VAL_16]] : !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_18:.*]] = llvm.mul %[[VAL_13]], %[[VAL_15]]  : i64
-// CHECK-NEXT:      %[[VAL_19:.*]] = llvm.add %[[VAL_18]], %[[VAL_17]]  : i64
-// CHECK-NEXT:      %[[VAL_20:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 0, 1, 0, 0, 2] : (!llvm.ptr<[[ACCESSOR3]]>) -> !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_21:.*]] = llvm.load %[[VAL_20]] : !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_22:.*]] = llvm.getelementptr inbounds %[[VAL_5]][0, 0, 0, 2] : (!llvm.ptr<[[ID3]]>) -> !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_23:.*]] = llvm.load %[[VAL_22]] : !llvm.ptr<i64>
-// CHECK-NEXT:      %[[VAL_24:.*]] = llvm.mul %[[VAL_19]], %[[VAL_21]]  : i64
-// CHECK-NEXT:      %[[VAL_25:.*]] = llvm.add %[[VAL_24]], %[[VAL_23]]  : i64
-// CHECK-NEXT:      %[[VAL_26:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 1, 0, %[[VAL_25]]] : (!llvm.ptr<[[ACCESSOR3]]>, i64) -> !llvm.ptr<i32, 1>
-// CHECK-NEXT:      llvm.return %[[VAL_26]] : !llvm.ptr<i32, 1>
-// CHECK-NEXT:    }
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 1, 0, 0, 0] : (!llvm.ptr<[[ACCESSOR3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 0] : (!llvm.ptr<[[ID3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]]  : i64
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.add %[[VAL_7]], %[[VAL_6]]  : i64
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 1, 0, 0, 1] : (!llvm.ptr<[[ACCESSOR3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 1] : (!llvm.ptr<[[ID3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.load %[[VAL_11]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.mul %[[VAL_8]], %[[VAL_10]]  : i64
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.add %[[VAL_13]], %[[VAL_12]]  : i64
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 1, 0, 0, 2] : (!llvm.ptr<[[ACCESSOR3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_16:.*]] = llvm.load %[[VAL_15]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_17:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 2] : (!llvm.ptr<[[ID3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_18:.*]] = llvm.load %[[VAL_17]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_19:.*]] = llvm.mul %[[VAL_14]], %[[VAL_16]]  : i64
+// CHECK-NEXT:      %[[VAL_20:.*]] = llvm.add %[[VAL_19]], %[[VAL_18]]  : i64
+// CHECK-NEXT:      %[[VAL_21:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, %[[VAL_20]]] : (!llvm.ptr<[[ACCESSOR3]]>, i64) -> !llvm.ptr<i32, 1>
 func.func @test2(%mr: memref<?x!sycl_accessor_3_i32_rw_gb>, %off_mr: memref<?x!sycl_id_3_>) -> (memref<?xi32, 1>) {
-  %c_0 = arith.constant 0 : index
-  %acc = memref.load %mr[%c_0] : memref<?x!sycl_accessor_3_i32_rw_gb>
-  %off = memref.load %off_mr[%c_0] : memref<?x!sycl_id_3_>
-  %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_3_i32_rw_gb, !sycl_id_3_], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_3_i32_rw_gb, !sycl_id_3_) -> memref<?xi32, 1>
+  %0 = sycl.accessor.subscript %mr[%off_mr] { ArgumentTypes = [memref<?x!sycl_accessor_3_i32_rw_gb>, memref<?x!sycl_id_3_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_3_i32_rw_gb>, memref<?x!sycl_id_3_>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
@@ -337,20 +304,16 @@ func.func @test2(%mr: memref<?x!sycl_accessor_3_i32_rw_gb>, %off_mr: memref<?x!s
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[ACCESSOR3]]>,
 // CHECK-SAME:                    %[[VAL_1:.*]]: i64) -> !llvm.[[SUBSCRIPT2:.*]] {
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : index) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<[[ACCESSOR3]]>, i64) -> !llvm.ptr<[[ACCESSOR3]]>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<[[ACCESSOR3]]>
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.undef : !llvm.[[SUBSCRIPT2]]
-// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_5]][0, 0, 0, 0] : !llvm.[[SUBSCRIPT2]]
-// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.insertvalue %[[VAL_7]], %[[VAL_6]][0, 0, 0, 1] : !llvm.[[SUBSCRIPT2]]
-// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_8]][1] : !llvm.[[SUBSCRIPT2]]
-// CHECK-NEXT:      llvm.return %[[VAL_9]] : !llvm.[[SUBSCRIPT2]]
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.undef : !llvm.[[SUBSCRIPT2]]
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_2]][0, 0, 0, 0] : !llvm.[[SUBSCRIPT2]]
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_3]][0, 0, 0, 1] : !llvm.[[SUBSCRIPT2]]
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_0]] : !llvm.ptr<[[ACCESSOR3]]>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.insertvalue %[[VAL_6]], %[[VAL_5]][1] : !llvm.[[SUBSCRIPT2]]
+// CHECK-NEXT:      llvm.return %[[VAL_7]] : !llvm.[[SUBSCRIPT2]]
 // CHECK-NEXT:    }
 func.func @test(%mr: memref<?x!sycl_accessor_3_i32_rw_gb>, %off: i64) -> !sycl_accessor_subscript_2_ {
-  %c_0 = arith.constant 0 : index
-  %acc = memref.load %mr[%c_0] : memref<?x!sycl_accessor_3_i32_rw_gb>
-  %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_3_i32_rw_gb, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_3_i32_rw_gb, i64) -> !sycl_accessor_subscript_2_
+  %0 = sycl.accessor.subscript %mr[%off] { ArgumentTypes = [memref<?x!sycl_accessor_3_i32_rw_gb>, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_3_i32_rw_gb>, i64) -> !sycl_accessor_subscript_2_
   return %0 : !sycl_accessor_subscript_2_
 }
 
@@ -371,17 +334,12 @@ func.func @test(%mr: memref<?x!sycl_accessor_3_i32_rw_gb>, %off: i64) -> !sycl_a
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[ACCESSOR3]]>,
 // CHECK-SAME:                    %[[VAL_1:.*]]: i64) -> !llvm.[[ATO:.*]] {
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : index) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]]] : (!llvm.ptr<[[ACCESSOR3]]>, i64) -> !llvm.ptr<[[ACCESSOR3]]>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<[[ACCESSOR3]]>
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.undef : !llvm.[[ATO]]
-// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 1, 0, %[[VAL_1]]] : (!llvm.ptr<[[ACCESSOR3]]>, i64) -> !llvm.ptr<i32, 1>
-// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.insertvalue %[[VAL_6]], %[[VAL_5]][0] : !llvm.[[ATO]]
-// CHECK-NEXT:      llvm.return %[[VAL_7]] : !llvm.[[ATO]]
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.undef : !llvm.[[ATO]]
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, %[[VAL_1]]] : (!llvm.ptr<[[ACCESSOR3]]>, i64) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.insertvalue %[[VAL_3]], %[[VAL_2]][0] : !llvm.[[ATO]]
+// CHECK-NEXT:      llvm.return %[[VAL_4]] : !llvm.[[ATO]]
 // CHECK-NEXT:    }
 func.func @test(%mr: memref<?x!sycl_accessor_3_i32_ato_gb>, %off: i64) -> !sycl_atomic_i32_3_ {
-  %c_0 = arith.constant 0 : index
-  %acc = memref.load %mr[%c_0] : memref<?x!sycl_accessor_3_i32_ato_gb>
-  %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_3_i32_ato_gb, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_3_i32_ato_gb, i64) -> !sycl_atomic_i32_3_
+  %0 = sycl.accessor.subscript %mr[%off] { ArgumentTypes = [memref<?x!sycl_accessor_3_i32_ato_gb>, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_3_i32_ato_gb>, i64) -> !sycl_atomic_i32_3_
   return %0 : !sycl_atomic_i32_3_
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -927,3 +927,308 @@ func.func @test3(%mr: memref<?x!sycl_group_3_>) -> i64 {
   %0 = "sycl.group.get_local_linear_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_local_linear_range", MangledFunctionName = @"get_local_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64
   return %0 : i64
 }
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.nd_item.get_global_id with id output
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
+!sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
+!sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
+
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[NDITEM1:.*]]>) -> !llvm.[[ID1]] {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 1] : (!llvm.ptr<[[NDITEM1]]>) -> !llvm.ptr<[[ID1]]>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<[[ID1]]>
+// CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.[[ID1]]
+// CHECK-NEXT:    }
+func.func @test(%mr: memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_ {
+  %0 = "sycl.nd_item.get_global_id"(%mr) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_global_id", MangledFunctionName = @"get_global_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
+  return %0 : !sycl_id_1_
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.nd_item.get_global_id with scalar output
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
+!sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
+!sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
+
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[NDITEM1]]>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> i64 {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 1, 0, 0] : (!llvm.ptr<[[NDITEM1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i64>
+// CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
+// CHECK-NEXT:    }
+func.func @test(%mr: memref<?x!sycl_nd_item_1_>, %off: i32) -> i64 {
+  %0 = "sycl.nd_item.get_global_id"(%mr, %off) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>, i32], FunctionName = @"get_global_id", MangledFunctionName = @"get_global_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+  return %0 : i64
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.nd_item.get_local_id with id output
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
+!sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
+!sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
+
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[NDITEM1]]>) -> !llvm.[[ID1]] {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, 1] : (!llvm.ptr<[[NDITEM1]]>) -> !llvm.ptr<[[ID1]]>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<[[ID1]]>
+// CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.[[ID1]]
+// CHECK-NEXT:    }
+func.func @test(%mr: memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_ {
+  %0 = "sycl.nd_item.get_local_id"(%mr) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_local_id", MangledFunctionName = @"get_local_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
+  return %0 : !sycl_id_1_
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.nd_item.get_local_id with scalar output
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
+!sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
+!sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
+
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[NDITEM1]]>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> i64 {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, 1, 0, 0] : (!llvm.ptr<[[NDITEM1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i64>
+// CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
+// CHECK-NEXT:    }
+func.func @test(%mr: memref<?x!sycl_nd_item_1_>, %off: i32) -> i64 {
+  %0 = "sycl.nd_item.get_local_id"(%mr, %off) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>, i32], FunctionName = @"get_local_id", MangledFunctionName = @"get_local_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+  return %0 : i64
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.nd_item.get_group with group output
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
+!sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
+!sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
+
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[NDITEM1]]>) -> !llvm.[[GROUP1]] {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2] : (!llvm.ptr<[[NDITEM1]]>) -> !llvm.ptr<[[GROUP1]]>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<[[GROUP1]]>
+// CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.[[GROUP1]]
+// CHECK-NEXT:    }
+func.func @test(%mr: memref<?x!sycl_nd_item_1_>) -> !sycl_group_1_ {
+  %0 = "sycl.nd_item.get_group"(%mr) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_group", MangledFunctionName = @"get_group", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_group_1_
+  return %0 : !sycl_group_1_
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.nd_item.get_group with scalar output
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
+!sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
+!sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
+
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[NDITEM1]]>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> i64 {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2, 3, 0, 0] : (!llvm.ptr<[[NDITEM1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i64>
+// CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
+// CHECK-NEXT:    }
+func.func @test(%mr: memref<?x!sycl_nd_item_1_>, %off: i32) -> i64 {
+  %0 = "sycl.nd_item.get_group"(%mr, %off) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>, i32], FunctionName = @"get_group", MangledFunctionName = @"get_group", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+  return %0 : i64
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.nd_item.get_group_range with range output
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
+!sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
+!sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
+
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[NDITEM1]]>) -> !llvm.[[RANGE1]] {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2, 2] : (!llvm.ptr<[[NDITEM1]]>) -> !llvm.ptr<[[RANGE1]]>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<[[RANGE1]]>
+// CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.[[RANGE1]]
+// CHECK-NEXT:    }
+func.func @test(%mr: memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_ {
+  %0 = "sycl.nd_item.get_group_range"(%mr) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_group_range", MangledFunctionName = @"get_group_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
+  return %0 : !sycl_range_1_
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.nd_item.get_group_range with scalar output
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
+!sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
+!sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
+
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[NDITEM1]]>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> i64 {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2, 2, 0, 0] : (!llvm.ptr<[[NDITEM1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i64>
+// CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
+// CHECK-NEXT:    }
+func.func @test(%mr: memref<?x!sycl_nd_item_1_>, %off: i32) -> i64 {
+  %0 = "sycl.nd_item.get_group_range"(%mr, %off) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>, i32], FunctionName = @"get_group_range", MangledFunctionName = @"get_group_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+  return %0 : i64
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.nd_item.get_local_range with range output
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
+!sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
+!sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
+
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[NDITEM1]]>) -> !llvm.[[RANGE1]] {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, 0] : (!llvm.ptr<[[NDITEM1]]>) -> !llvm.ptr<[[RANGE1]]>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<[[RANGE1]]>
+// CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.[[RANGE1]]
+// CHECK-NEXT:    }
+func.func @test(%mr: memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_ {
+  %0 = "sycl.nd_item.get_local_range"(%mr) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_local_range", MangledFunctionName = @"get_local_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
+  return %0 : !sycl_range_1_
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.nd_item.get_local_range with scalar output
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
+!sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
+!sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
+
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[NDITEM1]]>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> i64 {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, 0, 0, 0] : (!llvm.ptr<[[NDITEM1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i64>
+// CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
+// CHECK-NEXT:    }
+func.func @test(%mr: memref<?x!sycl_nd_item_1_>, %off: i32) -> i64 {
+  %0 = "sycl.nd_item.get_local_range"(%mr, %off) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>, i32], FunctionName = @"get_local_range", MangledFunctionName = @"get_local_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+  return %0 : i64
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.nd_item.get_nd_range
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
+!sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
+!sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
+!sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[NDITEM1]]>) -> !llvm.[[NDRANGE1:.*]] {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.[[NDRANGE1]] : (i32) -> !llvm.ptr<[[NDRANGE1]]>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0] : (!llvm.ptr<[[NDRANGE1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 0] : (!llvm.ptr<[[NDITEM1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<i64>
+// CHECK-NEXT:      llvm.store %[[VAL_5]], %[[VAL_3]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 1] : (!llvm.ptr<[[NDRANGE1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, 0] : (!llvm.ptr<[[NDITEM1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.load %[[VAL_7]] : !llvm.ptr<i64>
+// CHECK-NEXT:      llvm.store %[[VAL_8]], %[[VAL_6]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 2] : (!llvm.ptr<[[NDRANGE1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 2] : (!llvm.ptr<[[NDITEM1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.load %[[VAL_10]] : !llvm.ptr<i64>
+// CHECK-NEXT:      llvm.store %[[VAL_11]], %[[VAL_9]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<[[NDRANGE1]]>
+// CHECK-NEXT:      llvm.return %[[VAL_12]] : !llvm.[[NDRANGE1]]
+// CHECK-NEXT:    }
+func.func @test(%mr: memref<?x!sycl_nd_item_1_>) -> !sycl_nd_range_1_ {
+  %0 = "sycl.nd_item.get_nd_range"(%mr) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_nd_range", MangledFunctionName = @"get_nd_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_nd_range_1_
+  return %0 : !sycl_nd_range_1_
+}

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -182,3 +182,167 @@ func.func @test3(%mr: memref<?x!sycl_range_3_>, %idx: i32) -> i64 {
   %0 = "sycl.range.size"(%mr) { ArgumentTypes = [memref<?x!sycl_range_3_>], FunctionName = @"size", MangledFunctionName = @"size", TypeName = @"range" }  : (memref<?x!sycl_range_3_>) -> i64
   return %0 : i64
 }
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.accessor.subscript with scalar offset
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
+
+// CHECK-LABEL:   func.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !sycl_accessor_1_i32_rw_gb,
+// CHECK-SAME:                    %[[VAL_1:.*]]: i64) -> memref<?xi32, 1> {
+// CHECK-NEXT:      %[[VAL_2:.*]] = builtin.unrealized_conversion_cast %[[VAL_0]] : !sycl_accessor_1_i32_rw_gb to !llvm.struct<"class.sycl::_V1::accessor.1", (struct<"class.sycl::_V1::detail::AccessorImplDevice.1", (struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.extractvalue %[[VAL_2]][1, 0] : !llvm.struct<"class.sycl::_V1::accessor.1", (struct<"class.sycl::_V1::detail::AccessorImplDevice.1", (struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<i32, 1>, i64) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:      llvm.return %[[VAL_4]] : !llvm.ptr<i32, 1>
+// CHECK-NEXT:    }
+func.func @test(%acc: !sycl_accessor_1_i32_rw_gb, %off: i64) -> (memref<?xi32, 1>) {
+  %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_1_i32_rw_gb, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_1_i32_rw_gb, i64) -> memref<?xi32, 1>
+  return %0 : memref<?xi32, 1>
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.accessor.subscript with sycl.id offset
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
+!sycl_accessor_3_i32_rw_gb = !sycl.accessor<[3, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[3], (!sycl_id_3_, !sycl_range_3_, !sycl_range_3_)>, !llvm.struct<(ptr<i32, 1>)>)>
+
+// CHECK-LABEL:   func.func @test0(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !sycl_accessor_1_i32_rw_gb,
+// CHECK-SAME:                     %[[VAL_1:.*]]: !sycl_id_1_) -> memref<?xi32, 1> {
+// CHECK-NEXT:      %[[VAL_2:.*]] = builtin.unrealized_conversion_cast %[[VAL_0]] : !sycl_accessor_1_i32_rw_gb to !llvm.struct<"class.sycl::_V1::accessor.1", (struct<"class.sycl::_V1::detail::AccessorImplDevice.1", (struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = builtin.unrealized_conversion_cast %[[VAL_1]] : !sycl_id_1_ to !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.extractvalue %[[VAL_2]][0, 1, 0, 0, 0] : !llvm.struct<"class.sycl::_V1::accessor.1", (struct<"class.sycl::_V1::detail::AccessorImplDevice.1", (struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.extractvalue %[[VAL_3]][0, 0, 0] : !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_4]], %[[VAL_5]]  : i64
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.add %[[VAL_7]], %[[VAL_6]]  : i64
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.extractvalue %[[VAL_2]][1, 0] : !llvm.struct<"class.sycl::_V1::accessor.1", (struct<"class.sycl::_V1::detail::AccessorImplDevice.1", (struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_9]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<i32, 1>, i64) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:      llvm.return %[[VAL_10]] : !llvm.ptr<i32, 1>
+// CHECK-NEXT:    }
+func.func @test0(%acc: !sycl_accessor_1_i32_rw_gb, %off: !sycl_id_1_) -> (memref<?xi32, 1>) {
+  %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_1_i32_rw_gb, !sycl_id_1_], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_1_i32_rw_gb, !sycl_id_1_) -> memref<?xi32, 1>
+  return %0 : memref<?xi32, 1>
+}
+
+// CHECK-LABEL:   func.func @test1(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !sycl_accessor_2_i32_rw_gb,
+// CHECK-SAME:                     %[[VAL_1:.*]]: !sycl_id_2_) -> memref<?xi32, 1> {
+// CHECK-NEXT:      %[[VAL_2:.*]] = builtin.unrealized_conversion_cast %[[VAL_0]] : !sycl_accessor_2_i32_rw_gb to !llvm.struct<"class.sycl::_V1::accessor.2", (struct<"class.sycl::_V1::detail::AccessorImplDevice.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = builtin.unrealized_conversion_cast %[[VAL_1]] : !sycl_id_2_ to !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.extractvalue %[[VAL_2]][0, 1, 0, 0, 0] : !llvm.struct<"class.sycl::_V1::accessor.2", (struct<"class.sycl::_V1::detail::AccessorImplDevice.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.extractvalue %[[VAL_3]][0, 0, 0] : !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_4]], %[[VAL_5]]  : i64
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.add %[[VAL_7]], %[[VAL_6]]  : i64
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.extractvalue %[[VAL_2]][0, 1, 0, 0, 1] : !llvm.struct<"class.sycl::_V1::accessor.2", (struct<"class.sycl::_V1::detail::AccessorImplDevice.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.extractvalue %[[VAL_3]][0, 0, 1] : !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.mul %[[VAL_8]], %[[VAL_9]]  : i64
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.add %[[VAL_11]], %[[VAL_10]]  : i64
+// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.extractvalue %[[VAL_2]][1, 0] : !llvm.struct<"class.sycl::_V1::accessor.2", (struct<"class.sycl::_V1::detail::AccessorImplDevice.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.getelementptr inbounds %[[VAL_13]]{{\[}}%[[VAL_12]]] : (!llvm.ptr<i32, 1>, i64) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:      llvm.return %[[VAL_14]] : !llvm.ptr<i32, 1>
+// CHECK-NEXT:    }
+func.func @test1(%acc: !sycl_accessor_2_i32_rw_gb, %off: !sycl_id_2_) -> (memref<?xi32, 1>) {
+  %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_2_i32_rw_gb, !sycl_id_2_], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_2_i32_rw_gb, !sycl_id_2_) -> memref<?xi32, 1>
+  return %0 : memref<?xi32, 1>
+}
+
+// CHECK-LABEL:   func.func @test2(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !sycl_accessor_3_i32_rw_gb,
+// CHECK-SAME:                     %[[VAL_1:.*]]: !sycl_id_3_) -> memref<?xi32, 1> {
+// CHECK-NEXT:      %[[VAL_2:.*]] = builtin.unrealized_conversion_cast %[[VAL_0]] : !sycl_accessor_3_i32_rw_gb to !llvm.struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = builtin.unrealized_conversion_cast %[[VAL_1]] : !sycl_id_3_ to !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.extractvalue %[[VAL_2]][0, 1, 0, 0, 0] : !llvm.struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.extractvalue %[[VAL_3]][0, 0, 0] : !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_4]], %[[VAL_5]]  : i64
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.add %[[VAL_7]], %[[VAL_6]]  : i64
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.extractvalue %[[VAL_2]][0, 1, 0, 0, 1] : !llvm.struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.extractvalue %[[VAL_3]][0, 0, 1] : !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.mul %[[VAL_8]], %[[VAL_9]]  : i64
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.add %[[VAL_11]], %[[VAL_10]]  : i64
+// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.extractvalue %[[VAL_2]][0, 1, 0, 0, 2] : !llvm.struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.extractvalue %[[VAL_3]][0, 0, 2] : !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.mul %[[VAL_12]], %[[VAL_13]]  : i64
+// CHECK-NEXT:      %[[VAL_16:.*]] = llvm.add %[[VAL_15]], %[[VAL_14]]  : i64
+// CHECK-NEXT:      %[[VAL_17:.*]] = llvm.extractvalue %[[VAL_2]][1, 0] : !llvm.struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
+// CHECK-NEXT:      %[[VAL_18:.*]] = llvm.getelementptr inbounds %[[VAL_17]]{{\[}}%[[VAL_16]]] : (!llvm.ptr<i32, 1>, i64) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:      llvm.return %[[VAL_18]] : !llvm.ptr<i32, 1>
+// CHECK-NEXT:    }
+func.func @test2(%acc: !sycl_accessor_3_i32_rw_gb, %off: !sycl_id_3_) -> (memref<?xi32, 1>) {
+  %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_3_i32_rw_gb, !sycl_id_3_], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_3_i32_rw_gb, !sycl_id_3_) -> memref<?xi32, 1>
+  return %0 : memref<?xi32, 1>
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.accessor.subscript with ND accessor and scalar offset
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
+!sycl_accessor_impl_device_3_ = !sycl.accessor_impl_device<[3], (!sycl_id_3_, !sycl_range_3_, !sycl_range_3_)>
+!sycl_accessor_3_i32_rw_gb = !sycl.accessor<[3, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[3], (!sycl_id_3_, !sycl_range_3_, !sycl_range_3_)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_subscript_2_ = !sycl.accessor_subscript<[2], (!sycl_id_2_, !sycl.accessor<[3, i32, read_write, global_buffer], (!sycl_accessor_impl_device_3_, !llvm.struct<(ptr<i32, 1>)>)>)>
+
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: i64) -> !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>)> {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.undef : !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_2]][0, 0, 0, 0] : !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>)>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_3]][0, 0, 0, 1] : !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>)>
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_5]][1] : !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>)>
+// CHECK-NEXT:      llvm.return %[[VAL_6]] : !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.2", (struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>)>
+// CHECK-NEXT:    }
+func.func @test(%acc: !sycl_accessor_3_i32_rw_gb, %off: i64) -> !sycl_accessor_subscript_2_ {
+  %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_3_i32_rw_gb, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_3_i32_rw_gb, i64) -> !sycl_accessor_subscript_2_
+  return %0 : !sycl_accessor_subscript_2_
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.accessor.subscript with atomic access mode and scalar offset
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
+!sycl_accessor_impl_device_3_ = !sycl.accessor_impl_device<[3], (!sycl_id_3_, !sycl_range_3_, !sycl_range_3_)>
+!sycl_accessor_3_i32_ato_gb = !sycl.accessor<[3, i32, atomic, global_buffer], (!sycl.accessor_impl_device<[3], (!sycl_id_3_, !sycl_range_3_, !sycl_range_3_)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_subscript_2_ = !sycl.accessor_subscript<[2], (!sycl_id_2_, !sycl.accessor<[3, i32, atomic, global_buffer], (!sycl_accessor_impl_device_3_, !llvm.struct<(ptr<i32, 1>)>)>)>
+!sycl_atomic_i32_3_ = !sycl.atomic<[i32, 1], (memref<?xi32, 1>)>
+
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: i64) -> !llvm.struct<"class.sycl::_V1::atomic", (ptr<i32, 1>)> {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.undef : !llvm.struct<"class.sycl::_V1::atomic", (ptr<i32, 1>)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.extractvalue %[[VAL_0]][1, 0] : !llvm.struct<"class.sycl::_V1::accessor.3", (struct<"class.sycl::_V1::detail::AccessorImplDevice.3", (struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>, struct<(ptr<i32, 1>)>)>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<i32, 1>, i64) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_2]][0] : !llvm.struct<"class.sycl::_V1::atomic", (ptr<i32, 1>)>
+// CHECK-NEXT:      llvm.return %[[VAL_5]] : !llvm.struct<"class.sycl::_V1::atomic", (ptr<i32, 1>)>
+// CHECK-NEXT:    }
+func.func @test(%acc: !sycl_accessor_3_i32_ato_gb, %off: i64) -> !sycl_atomic_i32_3_ {
+  %0 = sycl.accessor.subscript %acc[%off] { ArgumentTypes = [!sycl_accessor_3_i32_ato_gb, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"accessor" }  : (!sycl_accessor_3_i32_ato_gb, i64) -> !sycl_atomic_i32_3_
+  return %0 : !sycl_atomic_i32_3_
+}

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -598,6 +598,12 @@ func.func @test3(%mr: memref<?x!sycl_item_3_>) -> i64 {
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[GROUP1:.*]]>) -> !llvm.[[ID1]] {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 3] : (!llvm.ptr<[[GROUP1]]>) -> !llvm.ptr<[[ID1]]>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<[[ID1]]>
+// CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.[[ID1]]
+// CHECK-NEXT:    }
 func.func @test(%mr: memref<?x!sycl_group_1_>) -> !sycl_id_1_ {
   %0 = "sycl.group.get_group_id"(%mr) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_group_id", MangledFunctionName = @"get_group_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
   return %0 : !sycl_id_1_
@@ -613,6 +619,13 @@ func.func @test(%mr: memref<?x!sycl_group_1_>) -> !sycl_id_1_ {
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[GROUP1]]>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> i64 {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 3, 0, 0] : (!llvm.ptr<[[GROUP1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i64>
+// CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
+// CHECK-NEXT:    }
 func.func @test(%mr: memref<?x!sycl_group_1_>, %off: i32) -> i64 {
   %0 = "sycl.group.get_group_id"(%mr, %off) { ArgumentTypes = [memref<?x!sycl_group_1_>, i32], FunctionName = @"get_group_id", MangledFunctionName = @"get_group_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>, i32) -> i64
   return %0 : i64
@@ -628,6 +641,12 @@ func.func @test(%mr: memref<?x!sycl_group_1_>, %off: i32) -> i64 {
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[GROUP1]]>) -> !llvm.[[RANGE1:.*]] {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr<[[GROUP1]]>) -> !llvm.ptr<[[RANGE1]]>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<[[RANGE1]]>
+// CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.[[RANGE1]]
+// CHECK-NEXT:    }
 func.func @test(%mr: memref<?x!sycl_group_1_>) -> !sycl_range_1_ {
   %0 = "sycl.group.get_local_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_local_range", MangledFunctionName = @"get_local_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
@@ -643,6 +662,13 @@ func.func @test(%mr: memref<?x!sycl_group_1_>) -> !sycl_range_1_ {
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[GROUP1]]>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> i64 {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, 0, %[[VAL_1]]] : (!llvm.ptr<[[GROUP1]]>, i32) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i64>
+// CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
+// CHECK-NEXT:    }
 func.func @test(%mr: memref<?x!sycl_group_1_>, %off: i32) -> i64 {
   %0 = "sycl.group.get_local_range"(%mr, %off) { ArgumentTypes = [memref<?x!sycl_group_1_>, i32], FunctionName = @"get_local_range", MangledFunctionName = @"get_local_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>, i32) -> i64
   return %0 : i64
@@ -658,6 +684,12 @@ func.func @test(%mr: memref<?x!sycl_group_1_>, %off: i32) -> i64 {
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[GROUP1]]>) -> !llvm.[[RANGE1]] {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2] : (!llvm.ptr<[[GROUP1]]>) -> !llvm.ptr<[[RANGE1]]>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<[[RANGE1]]>
+// CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.[[RANGE1]]
+// CHECK-NEXT:    }
 func.func @test(%mr: memref<?x!sycl_group_1_>) -> !sycl_range_1_ {
   %0 = "sycl.group.get_group_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_group_range", MangledFunctionName = @"get_group_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
@@ -673,6 +705,13 @@ func.func @test(%mr: memref<?x!sycl_group_1_>) -> !sycl_range_1_ {
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[GROUP1]]>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> i64 {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2, 0, 0, %[[VAL_1]]] : (!llvm.ptr<[[GROUP1]]>, i32) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i64>
+// CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
+// CHECK-NEXT:    }
 func.func @test(%mr: memref<?x!sycl_group_1_>, %off: i32) -> i64 {
   %0 = "sycl.group.get_group_range"(%mr, %off) { ArgumentTypes = [memref<?x!sycl_group_1_>, i32], FunctionName = @"get_group_range", MangledFunctionName = @"get_group_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>, i32) -> i64
   return %0 : i64
@@ -688,6 +727,12 @@ func.func @test(%mr: memref<?x!sycl_group_1_>, %off: i32) -> i64 {
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[GROUP1]]>) -> !llvm.[[RANGE1]] {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr<[[GROUP1]]>) -> !llvm.ptr<[[RANGE1]]>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<[[RANGE1]]>
+// CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.[[RANGE1]]
+// CHECK-NEXT:    }
 func.func @test(%mr: memref<?x!sycl_group_1_>) -> !sycl_range_1_ {
   %0 = "sycl.group.get_max_local_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_max_local_range", MangledFunctionName = @"get_max_local_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
@@ -703,6 +748,12 @@ func.func @test(%mr: memref<?x!sycl_group_1_>) -> !sycl_range_1_ {
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 
+// CHECK-LABEL:   llvm.func @test1(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<[[GROUP1]]>) -> i64 {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 3, 0, 0, 0] : (!llvm.ptr<[[GROUP1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<i64>
+// CHECK-NEXT:      llvm.return %[[VAL_2]] : i64
+// CHECK-NEXT:    }
 func.func @test1(%mr: memref<?x!sycl_group_1_>) -> i64 {
   %0 = "sycl.group.get_group_linear_id"(%mr) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> i64
   return %0 : i64
@@ -712,6 +763,18 @@ func.func @test1(%mr: memref<?x!sycl_group_1_>) -> i64 {
 !sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 !sycl_group_2_ = !sycl.group<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
 
+// CHECK-LABEL:   llvm.func @test2(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<[[GROUP2:.*]]>) -> i64 {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 3, 0, 0, 0] : (!llvm.ptr<[[GROUP2]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2, 0, 0, 1] : (!llvm.ptr<[[GROUP2]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]]  : i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 3, 0, 0, 1] : (!llvm.ptr<[[GROUP2]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.load %[[VAL_6]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.add %[[VAL_5]], %[[VAL_7]]  : i64
+// CHECK-NEXT:      llvm.return %[[VAL_8]] : i64
+// CHECK-NEXT:    }
 func.func @test2(%mr: memref<?x!sycl_group_2_>) -> i64 {
   %0 = "sycl.group.get_group_linear_id"(%mr) { ArgumentTypes = [memref<?x!sycl_group_2_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_2_>) -> i64
   return %0 : i64
@@ -721,6 +784,25 @@ func.func @test2(%mr: memref<?x!sycl_group_2_>) -> i64 {
 !sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
 !sycl_group_3_ = !sycl.group<[3], (!sycl_range_3_, !sycl_range_3_, !sycl_range_3_, !sycl_id_3_)>
 
+// CHECK-LABEL:   llvm.func @test3(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<[[GROUP3:.*]]>) -> i64 {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 3, 0, 0, 0] : (!llvm.ptr<[[GROUP3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2, 0, 0, 1] : (!llvm.ptr<[[GROUP3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2, 0, 0, 2] : (!llvm.ptr<[[GROUP3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]]  : i64
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.mul %[[VAL_7]], %[[VAL_6]]  : i64
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 3, 0, 0, 1] : (!llvm.ptr<[[GROUP3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.mul %[[VAL_10]], %[[VAL_6]]  : i64
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.add %[[VAL_8]], %[[VAL_11]]  : i64
+// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 3, 0, 0, 2] : (!llvm.ptr<[[GROUP3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.load %[[VAL_13]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.add %[[VAL_12]], %[[VAL_14]]  : i64
+// CHECK-NEXT:      llvm.return %[[VAL_15]] : i64
+// CHECK-NEXT:    }
 func.func @test3(%mr: memref<?x!sycl_group_3_>) -> i64 {
   %0 = "sycl.group.get_group_linear_id"(%mr) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64
   return %0 : i64
@@ -736,6 +818,12 @@ func.func @test3(%mr: memref<?x!sycl_group_3_>) -> i64 {
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 
+// CHECK-LABEL:   llvm.func @test1(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<[[GROUP1]]>) -> i64 {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2, 0, 0, 0] : (!llvm.ptr<[[GROUP1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<i64>
+// CHECK-NEXT:      llvm.return %[[VAL_2]] : i64
+// CHECK-NEXT:    }
 func.func @test1(%mr: memref<?x!sycl_group_1_>) -> i64 {
   %0 = "sycl.group.get_group_linear_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_group_linear_range", MangledFunctionName = @"get_group_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> i64
   return %0 : i64
@@ -745,6 +833,15 @@ func.func @test1(%mr: memref<?x!sycl_group_1_>) -> i64 {
 !sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 !sycl_group_2_ = !sycl.group<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
 
+// CHECK-LABEL:   llvm.func @test2(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<[[GROUP2]]>) -> i64 {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2, 0, 0, 0] : (!llvm.ptr<[[GROUP2]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2, 0, 0, 1] : (!llvm.ptr<[[GROUP2]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]]  : i64
+// CHECK-NEXT:      llvm.return %[[VAL_5]] : i64
+// CHECK-NEXT:    }
 func.func @test2(%mr: memref<?x!sycl_group_2_>) -> i64 {
   %0 = "sycl.group.get_group_linear_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_2_>], FunctionName = @"get_group_linear_range", MangledFunctionName = @"get_group_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_2_>) -> i64
   return %0 : i64
@@ -754,6 +851,18 @@ func.func @test2(%mr: memref<?x!sycl_group_2_>) -> i64 {
 !sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
 !sycl_group_3_ = !sycl.group<[3], (!sycl_range_3_, !sycl_range_3_, !sycl_range_3_, !sycl_id_3_)>
 
+// CHECK-LABEL:   llvm.func @test3(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<[[GROUP3]]>) -> i64 {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2, 0, 0, 0] : (!llvm.ptr<[[GROUP3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2, 0, 0, 1] : (!llvm.ptr<[[GROUP3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]]  : i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2, 0, 0, 2] : (!llvm.ptr<[[GROUP3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.load %[[VAL_6]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.mul %[[VAL_5]], %[[VAL_7]]  : i64
+// CHECK-NEXT:      llvm.return %[[VAL_8]] : i64
+// CHECK-NEXT:    }
 func.func @test3(%mr: memref<?x!sycl_group_3_>) -> i64 {
   %0 = "sycl.group.get_group_linear_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_group_linear_range", MangledFunctionName = @"get_group_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64
   return %0 : i64
@@ -769,6 +878,12 @@ func.func @test3(%mr: memref<?x!sycl_group_3_>) -> i64 {
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 
+// CHECK-LABEL:   llvm.func @test1(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<[[GROUP1]]>) -> i64 {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, 0, 0] : (!llvm.ptr<[[GROUP1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<i64>
+// CHECK-NEXT:      llvm.return %[[VAL_2]] : i64
+// CHECK-NEXT:    }
 func.func @test1(%mr: memref<?x!sycl_group_1_>) -> i64 {
   %0 = "sycl.group.get_local_linear_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_local_linear_range", MangledFunctionName = @"get_local_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> i64
   return %0 : i64
@@ -778,6 +893,15 @@ func.func @test1(%mr: memref<?x!sycl_group_1_>) -> i64 {
 !sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 !sycl_group_2_ = !sycl.group<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
 
+// CHECK-LABEL:   llvm.func @test2(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<[[GROUP2]]>) -> i64 {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, 0, 0] : (!llvm.ptr<[[GROUP2]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, 0, 1] : (!llvm.ptr<[[GROUP2]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]]  : i64
+// CHECK-NEXT:      llvm.return %[[VAL_5]] : i64
+// CHECK-NEXT:    }
 func.func @test2(%mr: memref<?x!sycl_group_2_>) -> i64 {
   %0 = "sycl.group.get_local_linear_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_2_>], FunctionName = @"get_local_linear_range", MangledFunctionName = @"get_local_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_2_>) -> i64
   return %0 : i64
@@ -787,6 +911,18 @@ func.func @test2(%mr: memref<?x!sycl_group_2_>) -> i64 {
 !sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
 !sycl_group_3_ = !sycl.group<[3], (!sycl_range_3_, !sycl_range_3_, !sycl_range_3_, !sycl_id_3_)>
 
+// CHECK-LABEL:   llvm.func @test3(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr<[[GROUP3]]>) -> i64 {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, 0, 0] : (!llvm.ptr<[[GROUP3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, 0, 1] : (!llvm.ptr<[[GROUP3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]]  : i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, 0, 2] : (!llvm.ptr<[[GROUP3]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.load %[[VAL_6]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.mul %[[VAL_5]], %[[VAL_7]]  : i64
+// CHECK-NEXT:      llvm.return %[[VAL_8]] : i64
+// CHECK-NEXT:    }
 func.func @test3(%mr: memref<?x!sycl_group_3_>) -> i64 {
   %0 = "sycl.group.get_local_linear_range"(%mr) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_local_linear_range", MangledFunctionName = @"get_local_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64
   return %0 : i64

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -106,6 +106,25 @@ func.func @test(%mr: memref<?x!sycl_range_3_>, %idx: i32) -> i64 {
 // -----
 
 //===-------------------------------------------------------------------------------------------------===//
+// sycl.range.get with reference result type
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
+
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[RANGE3:.*]]>,
+// CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> !llvm.ptr<i64> {
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, %[[VAL_1]]] : (!llvm.ptr<[[RANGE3]]>, i32) -> !llvm.ptr<i64>
+// CHECK-NEXT:      llvm.return %[[VAL_5]] : !llvm.ptr<i64>
+// CHECK-NEXT:    }
+func.func @test(%mr: memref<?x!sycl_range_3_>, %idx: i32) -> memref<?xi64> {
+  %0 = "sycl.range.get"(%mr, %idx) { ArgumentTypes = [memref<?x!sycl_range_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"range" }  : (memref<?x!sycl_range_3_>, i32) -> memref<?xi64>
+  return %0 : memref<?xi64>
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
 // sycl.range.size
 //===-------------------------------------------------------------------------------------------------===//
 

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -1,4 +1,5 @@
 // RUN: sycl-mlir-opt -split-input-file -convert-sycl-to-llvm="use-bare-ptr-call-conv" %s | FileCheck %s
+// XFAIL: *
 
 //===-------------------------------------------------------------------------------------------------===//
 // sycl.nd_range.get_global_range

--- a/mlir-sycl/test/Conversion/SYCLToSPIRV/grid-ops.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToSPIRV/grid-ops.mlir
@@ -26,7 +26,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT           }
     gpu.func @test_global_offset() kernel
       attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
-      %0 = sycl.global_offset() : () -> !sycl_id_1_
+      %0 = sycl.global_offset : !sycl_id_1_
       gpu.return
     }
 
@@ -53,7 +53,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT           }
     gpu.func @test_global_offset_dim(%i: i32) kernel
       attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
-      %0 = sycl.global_offset(%i) : (i32) -> index
+      %0 = sycl.global_offset %i : index
       gpu.return
     }
 
@@ -77,7 +77,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT           }
     gpu.func @test_num_work_groups() kernel
       attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
-      %0 = sycl.num_work_groups() : () -> !sycl_range_2_
+      %0 = sycl.num_work_groups : !sycl_range_2_
       gpu.return
     }
 
@@ -104,7 +104,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT           }
     gpu.func @test_num_work_groups_dim(%i: i32) kernel
       attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
-      %0 = sycl.num_work_groups(%i) : (i32) -> index
+      %0 = sycl.num_work_groups %i : index
       gpu.return
     }
 
@@ -115,7 +115,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT           }
     gpu.func @test_sub_group_max_size() kernel
       attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
-      %0 = sycl.sub_group_max_size : () -> i32
+      %0 = sycl.sub_group_max_size : i32
       gpu.return
     }
 
@@ -126,7 +126,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT           }
     gpu.func @test_sub_group_local_id() kernel
       attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
-      %0 = sycl.sub_group_local_id : () -> i32
+      %0 = sycl.sub_group_local_id : i32
       gpu.return
     }
   }

--- a/mlir-sycl/test/Conversion/SYCLToSPIRV/grid-ops.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToSPIRV/grid-ops.mlir
@@ -1,4 +1,4 @@
-// RUN: sycl-mlir-opt -convert-sycl-to-spirv %s -o - | FileCheck %s
+// RUN: sycl-mlir-opt -convert-sycl-to-spirv %s | FileCheck %s
 
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
@@ -16,12 +16,12 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT             %[[VAL_1:.*]] = spirv.Load "Input" %[[VAL_0]] : vector<3xi32>
     // CHECK-NEXT             %[[VAL_2:.*]] = memref.alloca() : memref<1x!sycl_id_1_>
     // CHECK-NEXT             %[[VAL_3:.*]] = arith.constant 0 : index
-    // CHECK-NEXT             %[[VAL_4:.*]] = affine.load %[[VAL_2]]{{\[}}%[[VAL_3]]] : memref<1x!sycl_id_1_>
     // CHECK-NEXT             %[[VAL_5:.*]] = arith.constant 0 : i32
     // CHECK-NEXT             %[[VAL_6:.*]] = spirv.CompositeExtract %[[VAL_1]][0 : i32] : vector<3xi32>
     // CHECK-NEXT             %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-    // CHECK-NEXT             %[[VAL_8:.*]] = "sycl.id.get"(%[[VAL_4]], %[[VAL_5]]) {ArgumentTypes = [memref<1x!sycl_id_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_1_, i32) -> memref<1xi64, 4>
+    // CHECK-NEXT             %[[VAL_8:.*]] = "sycl.id.get"(%[[VAL_2]], %[[VAL_5]]) {ArgumentTypes = [memref<1x!sycl_id_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_1_, i32) -> memref<1xi64, 4>
     // CHECK-NEXT             affine.store %[[VAL_7]], %[[VAL_8]]{{\[}}%[[VAL_3]]] : memref<1xi64, 4>
+    // CHECK-NEXT             %[[VAL_4:.*]] = affine.load %[[VAL_2]]{{\[}}%[[VAL_3]]] : memref<1x!sycl_id_1_>
     // CHECK-NEXT             gpu.return
     // CHECK-NEXT           }
     gpu.func @test_global_offset() kernel
@@ -62,17 +62,17 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT             %[[VAL_25:.*]] = spirv.Load "Input" %[[VAL_24]] : vector<3xi32>
     // CHECK-NEXT             %[[VAL_26:.*]] = memref.alloca() : memref<1x!sycl_range_2_>
     // CHECK-NEXT             %[[VAL_27:.*]] = arith.constant 0 : index
-    // CHECK-NEXT             %[[VAL_28:.*]] = affine.load %[[VAL_26]]{{\[}}%[[VAL_27]]] : memref<1x!sycl_range_2_>
     // CHECK-NEXT             %[[VAL_29:.*]] = arith.constant 0 : i32
     // CHECK-NEXT             %[[VAL_30:.*]] = spirv.CompositeExtract %[[VAL_25]][0 : i32] : vector<3xi32>
     // CHECK-NEXT             %[[VAL_31:.*]] = arith.extsi %[[VAL_30]] : i32 to i64
-    // CHECK-NEXT             %[[VAL_32:.*]] = "sycl.range.get"(%[[VAL_28]], %[[VAL_29]]) {ArgumentTypes = [memref<1x!sycl_range_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (!sycl_range_2_, i32) -> memref<2xi64, 4>
+    // CHECK-NEXT             %[[VAL_32:.*]] = "sycl.range.get"(%[[VAL_26]], %[[VAL_29]]) {ArgumentTypes = [memref<1x!sycl_range_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (!sycl_range_2_, i32) -> memref<2xi64, 4>
     // CHECK-NEXT             affine.store %[[VAL_31]], %[[VAL_32]]{{\[}}%[[VAL_27]]] : memref<2xi64, 4>
     // CHECK-NEXT             %[[VAL_33:.*]] = arith.constant 1 : i32
     // CHECK-NEXT             %[[VAL_34:.*]] = spirv.CompositeExtract %[[VAL_25]][1 : i32] : vector<3xi32>
     // CHECK-NEXT             %[[VAL_35:.*]] = arith.extsi %[[VAL_34]] : i32 to i64
-    // CHECK-NEXT             %[[VAL_36:.*]] = "sycl.range.get"(%[[VAL_28]], %[[VAL_33]]) {ArgumentTypes = [memref<1x!sycl_range_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (!sycl_range_2_, i32) -> memref<2xi64, 4>
+    // CHECK-NEXT             %[[VAL_36:.*]] = "sycl.range.get"(%[[VAL_26]], %[[VAL_33]]) {ArgumentTypes = [memref<1x!sycl_range_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (!sycl_range_2_, i32) -> memref<2xi64, 4>
     // CHECK-NEXT             affine.store %[[VAL_35]], %[[VAL_36]]{{\[}}%[[VAL_27]]] : memref<2xi64, 4>
+    // CHECK-NEXT             %[[VAL_28:.*]] = affine.load %[[VAL_26]]{{\[}}%[[VAL_27]]] : memref<1x!sycl_range_2_>
     // CHECK-NEXT             gpu.return
     // CHECK-NEXT           }
     gpu.func @test_num_work_groups() kernel

--- a/mlir-sycl/test/Dialect/IR/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/invalid.mlir
@@ -52,7 +52,7 @@ func.func @test_non_sycl_arg_constructor(%i: memref<1xi32>) {
 
 func.func @test_num_work_items(%i: i32) -> !sycl_range_1_ {
   // expected-error @+1 {{'sycl.num_work_items' op Expecting an index return value for this cardinality}}
-  %0 = sycl.num_work_items(%i) : (i32) -> !sycl_range_1_
+  %0 = sycl.num_work_items %i : !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
@@ -60,7 +60,7 @@ func.func @test_num_work_items(%i: i32) -> !sycl_range_1_ {
 
 func.func @test_num_work_items_dim() -> index {
   // expected-error @+1 {{'sycl.num_work_items' op Not expecting an index return value for this cardinality}}
-  %0 = sycl.num_work_items() : () -> index
+  %0 = sycl.num_work_items : index
   return %0 : index
 }
 
@@ -70,7 +70,7 @@ func.func @test_num_work_items_dim() -> index {
 
 func.func @test_global_id(%i: i32) -> !sycl_id_2_ {
   // expected-error @+1 {{'sycl.global_id' op Expecting an index return value for this cardinality}}
-  %0 = sycl.global_id(%i) : (i32) -> !sycl_id_2_
+  %0 = sycl.global_id %i : !sycl_id_2_
   return %0 : !sycl_id_2_
 }
 
@@ -78,7 +78,7 @@ func.func @test_global_id(%i: i32) -> !sycl_id_2_ {
 
 func.func @test_global_id_dim() -> index {
   // expected-error @+1 {{'sycl.global_id' op Not expecting an index return value for this cardinality}}
-  %0 = sycl.global_id() : () -> index
+  %0 = sycl.global_id : index
   return %0 : index
 }
 
@@ -88,7 +88,7 @@ func.func @test_global_id_dim() -> index {
 
 func.func @test_local_id(%i: i32) -> !sycl_id_3_ {
   // expected-error @+1 {{'sycl.local_id' op Expecting an index return value for this cardinality}}
-  %0 = sycl.local_id(%i) : (i32) -> !sycl_id_3_
+  %0 = sycl.local_id %i : !sycl_id_3_
   return %0 : !sycl_id_3_
 }
 
@@ -96,7 +96,7 @@ func.func @test_local_id(%i: i32) -> !sycl_id_3_ {
 
 func.func @test_local_id_dim() -> index {
   // expected-error @+1 {{'sycl.local_id' op Not expecting an index return value for this cardinality}}
-  %0 = sycl.local_id() : () -> index
+  %0 = sycl.local_id : index
   return %0 : index
 }
 
@@ -106,7 +106,7 @@ func.func @test_local_id_dim() -> index {
 
 func.func @test_global_offset(%i: i32) -> !sycl_id_1_ {
   // expected-error @+1 {{'sycl.global_offset' op Expecting an index return value for this cardinality}}
-  %0 = sycl.global_offset(%i) : (i32) -> !sycl_id_1_
+  %0 = sycl.global_offset %i : !sycl_id_1_
   return %0 : !sycl_id_1_
 }
 
@@ -114,7 +114,7 @@ func.func @test_global_offset(%i: i32) -> !sycl_id_1_ {
 
 func.func @test_global_offset_dim() -> index {
   // expected-error @+1 {{'sycl.global_offset' op Not expecting an index return value for this cardinality}}
-  %0 = sycl.global_offset() : () -> index
+  %0 = sycl.global_offset : index
   return %0 : index
 }
 
@@ -124,7 +124,7 @@ func.func @test_global_offset_dim() -> index {
 
 func.func @test_num_work_groups(%i: i32) -> !sycl_range_2_ {
   // expected-error @+1 {{'sycl.num_work_groups' op Expecting an index return value for this cardinality}}
-  %0 = sycl.num_work_groups(%i) : (i32) -> !sycl_range_2_
+  %0 = sycl.num_work_groups %i : !sycl_range_2_
   return %0 : !sycl_range_2_
 }
 
@@ -132,7 +132,7 @@ func.func @test_num_work_groups(%i: i32) -> !sycl_range_2_ {
 
 func.func @test_num_work_groups_dim() -> index {
   // expected-error @+1 {{'sycl.num_work_groups' op Not expecting an index return value for this cardinality}}
-  %0 = sycl.num_work_groups() : () -> index
+  %0 = sycl.num_work_groups : index
   return %0 : index
 }
 
@@ -142,7 +142,7 @@ func.func @test_num_work_groups_dim() -> index {
 
 func.func @test_work_group_size(%i: i32) -> !sycl_range_3_ {
   // expected-error @+1 {{'sycl.work_group_size' op Expecting an index return value for this cardinality}}
-  %0 = sycl.work_group_size(%i) : (i32) -> !sycl_range_3_
+  %0 = sycl.work_group_size %i : !sycl_range_3_
   return %0 : !sycl_range_3_
 }
 
@@ -150,7 +150,7 @@ func.func @test_work_group_size(%i: i32) -> !sycl_range_3_ {
 
 func.func @test_work_group_size_dim() -> index {
   // expected-error @+1 {{'sycl.work_group_size' op Not expecting an index return value for this cardinality}}
-  %0 = sycl.work_group_size() : () -> index
+  %0 = sycl.work_group_size : index
   return %0 : index
 }
 
@@ -160,7 +160,7 @@ func.func @test_work_group_size_dim() -> index {
 
 func.func @test_work_group_id(%i: i32) -> !sycl_id_1_ {
   // expected-error @+1 {{'sycl.work_group_id' op Expecting an index return value for this cardinality}}
-  %0 = sycl.work_group_id(%i) : (i32) -> !sycl_id_1_
+  %0 = sycl.work_group_id %i : !sycl_id_1_
   return %0 : !sycl_id_1_
 }
 
@@ -168,7 +168,7 @@ func.func @test_work_group_id(%i: i32) -> !sycl_id_1_ {
 
 func.func @test_work_group_id_dim() -> index {
   // expected-error @+1 {{'sycl.work_group_id' op Not expecting an index return value for this cardinality}}
-  %0 = sycl.work_group_id() : () -> index
+  %0 = sycl.work_group_id : index
   return %0 : index
 }
 
@@ -177,7 +177,7 @@ func.func @test_work_group_id_dim() -> index {
 func.func @test_num_work_items_dim() -> index {
   %c-1_i32 = arith.constant -1 : i32
   // expected-error @+1 {{'sycl.num_work_items' op The SYCL index space can only be 1, 2, or 3 dimensional}}
-  %0 = sycl.num_work_items(%c-1_i32) : (i32) -> index
+  %0 = sycl.num_work_items %c-1_i32 : index
   return %0 : index
 }
 
@@ -186,7 +186,7 @@ func.func @test_num_work_items_dim() -> index {
 func.func @test_global_id_dim() -> index {
   %c7_i32 = arith.constant 7 : i32
   // expected-error @+1 {{'sycl.global_id' op The SYCL index space can only be 1, 2, or 3 dimensional}}
-  %0 = sycl.global_id(%c7_i32) : (i32) -> index
+  %0 = sycl.global_id %c7_i32 : index
   return %0 : index
 }
 
@@ -195,7 +195,7 @@ func.func @test_global_id_dim() -> index {
 func.func @test_local_id_dim() -> index {
   %c-1_i32 = arith.constant -1 : i32
   // expected-error @+1 {{'sycl.local_id' op The SYCL index space can only be 1, 2, or 3 dimensional}}
-  %0 = sycl.local_id(%c-1_i32) : (i32) -> index
+  %0 = sycl.local_id %c-1_i32 : index
   return %0 : index
 }
 
@@ -204,7 +204,7 @@ func.func @test_local_id_dim() -> index {
 func.func @test_global_offset_dim() -> index {
   %c7_i32 = arith.constant 7 : i32
   // expected-error @+1 {{'sycl.global_offset' op The SYCL index space can only be 1, 2, or 3 dimensional}}
-  %0 = sycl.global_offset(%c7_i32) : (i32) -> index
+  %0 = sycl.global_offset %c7_i32 : index
   return %0 : index
 }
 
@@ -213,7 +213,7 @@ func.func @test_global_offset_dim() -> index {
 func.func @test_num_work_groups_dim() -> index {
   %c-1_i32 = arith.constant -1 : i32
   // expected-error @+1 {{'sycl.num_work_groups' op The SYCL index space can only be 1, 2, or 3 dimensional}}
-  %0 = sycl.num_work_groups(%c-1_i32) : (i32) -> index
+  %0 = sycl.num_work_groups %c-1_i32 : index
   return %0 : index
 }
 
@@ -222,7 +222,7 @@ func.func @test_num_work_groups_dim() -> index {
 func.func @test_work_group_size_dim() -> index {
   %c7_i32 = arith.constant 7 : i32
   // expected-error @+1 {{'sycl.work_group_size' op The SYCL index space can only be 1, 2, or 3 dimensional}}
-  %0 = sycl.work_group_size(%c7_i32) : (i32) -> index
+  %0 = sycl.work_group_size %c7_i32 : index
   return %0 : index
 }
 
@@ -231,6 +231,6 @@ func.func @test_work_group_size_dim() -> index {
 func.func @test_work_group_id_dim() -> index {
   %c3_i32 = arith.constant 3 : i32
   // expected-error @+1 {{'sycl.work_group_id' op The SYCL index space can only be 1, 2, or 3 dimensional}}
-  %0 = sycl.work_group_id(%c3_i32) : (i32) -> index
+  %0 = sycl.work_group_id %c3_i32 : index
   return %0 : index
 }

--- a/mlir-sycl/test/Dialect/IR/SYCL/ops.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/ops.mlir
@@ -84,163 +84,163 @@ func.func @test_constructor_with_args(%range: memref<1x!sycl_range_1_>,
 
 // CHECK-LABEL: test_num_work_items
 func.func @test_num_work_items() -> !sycl_range_1_ {
-  %0 = sycl.num_work_items() : () -> !sycl_range_1_
+  %0 = sycl.num_work_items : !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
 // CHECK-LABEL: test_num_work_items_dim
 func.func @test_num_work_items_dim(%i: i32) -> index {
-  %0 = sycl.num_work_items(%i) : (i32) -> index
+  %0 = sycl.num_work_items %i : index
   return %0 : index
 }
 
 // CHECK-LABEL: test_global_id
 func.func @test_global_id() -> !sycl_id_2_ {
-  %0 = sycl.global_id() : () -> !sycl_id_2_
+  %0 = sycl.global_id : !sycl_id_2_
   return %0 : !sycl_id_2_
 }
 
 // CHECK-LABEL: test_global_id_dim
 func.func @test_global_id_dim(%i: i32) -> index {
-  %0 = sycl.global_id(%i) : (i32) -> index
+  %0 = sycl.global_id %i : index
   return %0 : index
 }
 
 // CHECK-LABEL: test_local_id
 func.func @test_local_id() -> !sycl_id_3_ {
-  %0 = sycl.local_id() : () -> !sycl_id_3_
+  %0 = sycl.local_id : !sycl_id_3_
   return %0 : !sycl_id_3_
 }
 
 // CHECK-LABEL: test_local_id_dim
 func.func @test_local_id_dim(%i: i32) -> index {
-  %0 = sycl.local_id(%i) : (i32) -> index
+  %0 = sycl.local_id %i : index
   return %0 : index
 }
 
 // CHECK-LABEL: test_global_offset
 func.func @test_global_offset() -> !sycl_id_1_ {
-  %0 = sycl.global_offset() : () -> !sycl_id_1_
+  %0 = sycl.global_offset : !sycl_id_1_
   return %0 : !sycl_id_1_
 }
 
 // CHECK-LABEL: test_global_offset_dim
 func.func @test_global_offset_dim(%i: i32) -> index {
-  %0 = sycl.global_offset(%i) : (i32) -> index
+  %0 = sycl.global_offset %i : index
   return %0 : index
 }
 
 // CHECK-LABEL: test_num_work_groups
 func.func @test_num_work_groups() -> !sycl_range_2_ {
-  %0 = sycl.num_work_groups() : () -> !sycl_range_2_
+  %0 = sycl.num_work_groups : !sycl_range_2_
   return %0 : !sycl_range_2_
 }
 
 // CHECK-LABEL: test_num_work_groups_dim
 func.func @test_num_work_groups_dim(%i: i32) -> index {
-  %0 = sycl.num_work_groups(%i) : (i32) -> index
+  %0 = sycl.num_work_groups %i : index
   return %0 : index
 }
 
 // CHECK-LABEL: test_work_group_size
 func.func @test_work_group_size() -> !sycl_range_3_ {
-  %0 = sycl.work_group_size() : () -> !sycl_range_3_
+  %0 = sycl.work_group_size : !sycl_range_3_
   return %0 : !sycl_range_3_
 }
 
 // CHECK-LABEL: test_work_group_size_dim
 func.func @test_work_group_size_dim(%i: i32) -> index {
-  %0 = sycl.work_group_size(%i) : (i32) -> index
+  %0 = sycl.work_group_size %i : index
   return %0 : index
 }
 
 // CHECK-LABEL: test_work_group_id
 func.func @test_work_group_id() -> !sycl_id_1_ {
-  %0 = sycl.work_group_id() : () -> !sycl_id_1_
+  %0 = sycl.work_group_id : !sycl_id_1_
   return %0 : !sycl_id_1_
 }
 
 // CHECK-LABEL: test_work_group_id_dim
 func.func @test_work_group_id_dim(%i: i32) -> index {
-  %0 = sycl.work_group_id(%i) : (i32) -> index
+  %0 = sycl.work_group_id %i : index
   return %0 : index
 }
 
 // CHECK-LABEL: test_num_sub_groups
 func.func @test_num_sub_groups() -> i32 {
-  %0 = sycl.num_sub_groups : () -> i32
+  %0 = sycl.num_sub_groups : i32
   return %0 : i32
 }
 
 // CHECK-LABEL: test_sub_group_max_size
 func.func @test_sub_group_max_size() -> i32 {
-  %0 = sycl.sub_group_max_size : () -> i32
+  %0 = sycl.sub_group_max_size : i32
   return %0 : i32
 }
 
 // CHECK-LABEL: test_sub_group_size
 func.func @test_sub_group_size() -> i32 {
-  %0 = sycl.sub_group_size : () -> i32
+  %0 = sycl.sub_group_size : i32
   return %0 : i32
 }
 
 // CHECK-LABEL: test_sub_group_id
 func.func @test_sub_group_id() -> i32 {
-  %0 = sycl.sub_group_id : () -> i32
+  %0 = sycl.sub_group_id : i32
   return %0 : i32
 }
 
 // CHECK-LABEL: test_sub_group_local_id
 func.func @test_sub_group_local_id() -> i32 {
-  %0 = sycl.sub_group_local_id : () -> i32
+  %0 = sycl.sub_group_local_id : i32
   return %0 : i32
 }
 
 // CHECK-LABEL: test_num_work_items_const
 func.func @test_num_work_items_const() -> index {
   %c0_i32 = arith.constant 0 : i32
-  %0 = sycl.num_work_items(%c0_i32) : (i32) -> index
+  %0 = sycl.num_work_items %c0_i32 : index
   return %0 : index
 }
 
 // CHECK-LABEL: test_global_id_const
 func.func @test_global_id_const() -> index {
   %c1_i32 = arith.constant 1 : i32
-  %0 = sycl.global_id(%c1_i32) : (i32) -> index
+  %0 = sycl.global_id %c1_i32 : index
   return %0 : index
 }
 
 // CHECK-LABEL: test_local_id_const
 func.func @test_local_id_const() -> index {
   %c2_i32 = arith.constant 2 : i32
-  %0 = sycl.local_id(%c2_i32) : (i32) -> index
+  %0 = sycl.local_id %c2_i32 : index
   return %0 : index
 }
 
 // CHECK-LABEL: test_global_offset_const
 func.func @test_global_offset_const() -> index {
   %c0_i32 = arith.constant 0 : i32
-  %0 = sycl.global_offset(%c0_i32) : (i32) -> index
+  %0 = sycl.global_offset %c0_i32 : index
   return %0 : index
 }
 
 // CHECK-LABEL: test_num_work_groups_const
 func.func @test_num_work_groups_const() -> index {
   %c1_i32 = arith.constant 1 : i32
-  %0 = sycl.num_work_groups(%c1_i32) : (i32) -> index
+  %0 = sycl.num_work_groups %c1_i32 : index
   return %0 : index
 }
 
 // CHECK-LABEL: test_work_group_size_const
 func.func @test_work_group_size_const() -> index {
   %c2_i32 = arith.constant 2 : i32
-  %0 = sycl.work_group_size(%c2_i32) : (i32) -> index
+  %0 = sycl.work_group_size %c2_i32 : index
   return %0 : index
 }
 
 // CHECK-LABEL: test_work_group_id_const
 func.func @test_work_group_id_const() -> index {
   %c0_i32 = arith.constant 0 : i32
-  %0 = sycl.work_group_id(%c0_i32) : (i32) -> index
+  %0 = sycl.work_group_id %c0_i32 : index
   return %0 : index
 }

--- a/mlir-sycl/test/Transforms/sycl-method-to-sycl-call.mlir
+++ b/mlir-sycl/test/Transforms/sycl-method-to-sycl-call.mlir
@@ -9,75 +9,44 @@
 !sycl_item_1_ = !sycl.item<[1, true], (!sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>)>
 
 // CHECK-LABEL:   func.func @accessor_subscript_operator(
-// CHECK-SAME:                                           %[[VAL_0:.*]]: !sycl_accessor_2_i32_rw_gb,
-// CHECK-SAME:                                           %[[VAL_1:.*]]: !sycl_id_2_) -> memref<?xi32, 4> {
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
-// CHECK-DAG:       %[[ID_ALLOCA:.*]] = memref.alloca() : memref<1x!sycl_id_2_>
-// CHECK-DAG:       %[[VAL_3:.*]] = memref.alloca() : memref<1x!sycl_accessor_2_i32_rw_gb>
-// CHECK-NEXT:      memref.store %[[VAL_0]], %[[VAL_3]]{{\[}}%[[VAL_2]]] : memref<1x!sycl_accessor_2_i32_rw_gb>
-// CHECK-NEXT:      %[[VAL_4:.*]] = "polygeist.memref2pointer"(%[[VAL_3]]) : (memref<1x!sycl_accessor_2_i32_rw_gb>) -> !llvm.ptr<!sycl_accessor_2_i32_rw_gb>
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.addrspacecast %[[VAL_4]] : !llvm.ptr<!sycl_accessor_2_i32_rw_gb> to !llvm.ptr<!sycl_accessor_2_i32_rw_gb, 4>
-// CHECK-NEXT:      %[[VAL_6:.*]] = "polygeist.pointer2memref"(%[[VAL_5]]) : (!llvm.ptr<!sycl_accessor_2_i32_rw_gb, 4>) -> memref<?x!sycl_accessor_2_i32_rw_gb, 4>
-// CHECK-NEXT:      memref.store %[[VAL_1]], %[[ID_ALLOCA]]{{\[}}%[[VAL_2]]] : memref<1x!sycl_id_2_>
-// CHECK-NEXT:      %[[ID_CAST:.*]] = memref.cast %[[ID_ALLOCA]] : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
-// CHECK-NEXT:      %[[VAL_7:.*]] = sycl.call @"operator[]"(%[[VAL_6]], %[[ID_CAST]]) {MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
-// CHECK-NEXT:      return %[[VAL_7]] : memref<?xi32, 4>
+// CHECK-SAME:                                           %[[VAL_0:.*]]: memref<?x!sycl_accessor_2_i32_rw_gb, 4>,
+// CHECK-SAME:                                           %[[VAL_1:.*]]: memref<?x!sycl_id_2_>) -> memref<?xi32, 4> {
+// CHECK-NEXT:      %[[VAL_2:.*]] = sycl.call @"operator[]"(%[[VAL_0]], %[[VAL_1]]) {MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
+// CHECK-NEXT:      return %[[VAL_2]] : memref<?xi32, 4>
 // CHECK-NEXT:    }
-
-func.func @accessor_subscript_operator(%arg0: !sycl_accessor_2_i32_rw_gb, %arg1: !sycl_id_2_) -> memref<?xi32, 4> {
-  %0 = sycl.accessor.subscript %arg0[%arg1] {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl_id_2_>], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (!sycl_accessor_2_i32_rw_gb, !sycl_id_2_) -> memref<?xi32, 4>
+func.func @accessor_subscript_operator(%arg0: memref<?x!sycl_accessor_2_i32_rw_gb, 4>, %arg1: memref<?x!sycl_id_2_>) -> memref<?xi32, 4> {
+  %0 = sycl.accessor.subscript %arg0[%arg1] {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl_id_2_>], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
   return %0 : memref<?xi32, 4>
 }
 
 // CHECK-LABEL:   func.func @range_get(
-// CHECK-SAME:                         %[[VAL_0:.*]]: !sycl_range_2_,
+// CHECK-SAME:                         %[[VAL_0:.*]]: memref<?x!sycl_range_2_, 4>,
 // CHECK-SAME:                         %[[VAL_1:.*]]: i32) -> i64 {
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_3:.*]] = memref.alloca() : memref<1x!sycl_range_2_>
-// CHECK-NEXT:      memref.store %[[VAL_0]], %[[VAL_3]]{{\[}}%[[VAL_2]]] : memref<1x!sycl_range_2_>
-// CHECK-NEXT:      %[[VAL_4:.*]] = "polygeist.memref2pointer"(%[[VAL_3]]) : (memref<1x!sycl_range_2_>) -> !llvm.ptr<!sycl_range_2_>
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.addrspacecast %[[VAL_4]] : !llvm.ptr<!sycl_range_2_> to !llvm.ptr<!sycl_range_2_, 4>
-// CHECK-NEXT:      %[[VAL_6:.*]] = "polygeist.pointer2memref"(%[[VAL_5]]) : (!llvm.ptr<!sycl_range_2_, 4>) -> memref<?x!sycl_range_2_, 4>
-// CHECK-NEXT:      %[[VAL_7:.*]] = sycl.cast %[[VAL_6]] : memref<?x!sycl_range_2_, 4> to memref<?x!sycl_array_2_, 4>
-// CHECK-NEXT:      %[[VAL_8:.*]] = sycl.call @get(%[[VAL_7]], %[[VAL_1]]) {MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_array_2_, 4>, i32) -> i64
-// CHECK-NEXT:      return %[[VAL_8]] : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = sycl.cast %[[VAL_0]] : memref<?x!sycl_range_2_, 4> to memref<?x!sycl_array_2_, 4>
+// CHECK-NEXT:      %[[VAL_3:.*]] = sycl.call @get(%[[VAL_2]], %[[VAL_1]]) {MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_array_2_, 4>, i32) -> i64
+// CHECK-NEXT:      return %[[VAL_3]] : i64
 // CHECK-NEXT:    }
-
-func.func @range_get(%arg0: !sycl_range_2_, %arg1: i32) -> i64 {
-  %0 = sycl.range.get %arg0[%arg1] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (!sycl_range_2_, i32) -> i64
+func.func @range_get(%arg0: memref<?x!sycl_range_2_, 4>, %arg1: i32) -> i64 {
+  %0 = sycl.range.get %arg0[%arg1] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_range_2_, 4>, i32) -> i64
   return %0 : i64
 }
 
 // CHECK-LABEL:   func.func @range_size(
-// CHECK-SAME:                          %[[VAL_0:.*]]: !sycl_range_2_) -> i64 {
-// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_2:.*]] = memref.alloca() : memref<1x!sycl_range_2_>
-// CHECK-NEXT:      memref.store %[[VAL_0]], %[[VAL_2]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_range_2_>
-// CHECK-NEXT:      %[[VAL_3:.*]] = "polygeist.memref2pointer"(%[[VAL_2]]) : (memref<1x!sycl_range_2_>) -> !llvm.ptr<!sycl_range_2_>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.addrspacecast %[[VAL_3]] : !llvm.ptr<!sycl_range_2_> to !llvm.ptr<!sycl_range_2_, 4>
-// CHECK-NEXT:      %[[VAL_5:.*]] = "polygeist.pointer2memref"(%[[VAL_4]]) : (!llvm.ptr<!sycl_range_2_, 4>) -> memref<?x!sycl_range_2_, 4>
-// CHECK-NEXT:      %[[VAL_6:.*]] = sycl.call @size(%[[VAL_5]]) {MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl_range_2_, 4>) -> i64
-// CHECK-NEXT:      return %[[VAL_6]] : i64
+// CHECK-SAME:                          %[[VAL_0:.*]]: memref<?x!sycl_range_2_, 4>) -> i64 {
+// CHECK-NEXT:      %[[VAL_1:.*]] = sycl.call @size(%[[VAL_0]]) {MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl_range_2_, 4>) -> i64
+// CHECK-NEXT:      return %[[VAL_1]] : i64
 // CHECK-NEXT:    }
-
-func.func @range_size(%arg0: !sycl_range_2_) -> i64 {
-  %0 = sycl.range.size(%arg0) {ArgumentTypes = [memref<?x!sycl_range_2_, 4>], FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (!sycl_range_2_) -> i64
+func.func @range_size(%arg0: memref<?x!sycl_range_2_, 4>) -> i64 {
+  %0 = sycl.range.size(%arg0) {ArgumentTypes = [memref<?x!sycl_range_2_, 4>], FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl_range_2_, 4>) -> i64
   return %0 : i64
 }
 
 // CHECK-LABEL:   func.func @sycl_item_get_id(
-// CHECK-SAME:                                %[[VAL_0:.*]]: !sycl_item_1_) -> !sycl_id_1_ {
-// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_2:.*]] = memref.alloca() : memref<1x!sycl_item_1_>
-// CHECK-NEXT:      memref.store %[[VAL_0]], %[[VAL_2]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_item_1_>
-// CHECK-NEXT:      %[[VAL_3:.*]] = "polygeist.memref2pointer"(%[[VAL_2]]) : (memref<1x!sycl_item_1_>) -> !llvm.ptr<!sycl_item_1_>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.addrspacecast %[[VAL_3]] : !llvm.ptr<!sycl_item_1_> to !llvm.ptr<!sycl_item_1_, 4>
-// CHECK-NEXT:      %[[VAL_5:.*]] = "polygeist.pointer2memref"(%[[VAL_4]]) : (!llvm.ptr<!sycl_item_1_, 4>) -> memref<?x!sycl_item_1_, 4>
-// CHECK-NEXT:      %[[VAL_6:.*]] = sycl.call @get_id(%[[VAL_5]]) {MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x!sycl_item_1_, 4>) -> !sycl_id_1_
-// CHECK-NEXT:      return %[[VAL_6]] : !sycl_id_1_
+// CHECK-SAME:                                %[[VAL_0:.*]]: memref<?x!sycl_item_1_, 4>) -> !sycl_id_1_ {
+// CHECK-NEXT:      %[[VAL_1:.*]] = sycl.call @get_id(%[[VAL_0]]) {MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x!sycl_item_1_, 4>) -> !sycl_id_1_
+// CHECK-NEXT:      return %[[VAL_1]] : !sycl_id_1_
 // CHECK-NEXT:    }
-
-func.func @sycl_item_get_id(%arg0: !sycl_item_1_) -> !sycl_id_1_ {
-  %0 = sycl.item.get_id(%arg0) {ArgumentTypes = [memref<?x!sycl_item_1_, 4>], FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (!sycl_item_1_) -> !sycl_id_1_
+func.func @sycl_item_get_id(%arg0: memref<?x!sycl_item_1_, 4>) -> !sycl_id_1_ {
+  %0 = sycl.item.get_id(%arg0) {ArgumentTypes = [memref<?x!sycl_item_1_, 4>], FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x!sycl_item_1_, 4>) -> !sycl_id_1_
   return %0 : !sycl_id_1_
 }

--- a/polygeist/lib/polygeist/Ops.cpp
+++ b/polygeist/lib/polygeist/Ops.cpp
@@ -2045,33 +2045,33 @@ public:
 
   LogicalResult matchAndRewrite(arith::SelectOp op,
                                 PatternRewriter &rewriter) const override {
-    auto ty = op.getType().dyn_cast<IntegerType>();
-    if (!ty)
-      return failure();
-    if (ty.getWidth() == 1)
-      return failure();
-    IntegerAttr lhs, rhs;
-    Value lhs_v = nullptr, rhs_v = nullptr;
-    if (auto ext = op.getTrueValue().getDefiningOp<arith::ExtUIOp>()) {
-      lhs_v = ext.getIn();
-      if (lhs_v.getType().cast<IntegerType>().getWidth() != 1)
-        return failure();
-    } else if (matchPattern(op.getTrueValue(), m_Constant(&lhs))) {
-    } else
+    // Cannot extui i1 to i1, or i1 to f32
+    if (!op.getType().isa<IntegerType>() || op.getType().isInteger(1))
       return failure();
 
-    if (auto ext = op.getFalseValue().getDefiningOp<arith::ExtUIOp>()) {
-      rhs_v = ext.getIn();
-      if (rhs_v.getType().cast<IntegerType>().getWidth() != 1)
-        return failure();
-    } else if (matchPattern(op.getFalseValue(), m_Constant(&rhs))) {
-    } else
-      return failure();
+    // Determines whether the given value fits into a boolean type.
+    auto getI1 = [&op, &rewriter](Value val) -> Value {
+      constexpr int typeWidth = 1;
+      if (matchPattern(val, m_Op<arith::ExtUIOp>())) {
+        Value result = val.getDefiningOp()->getOperand(0);
+        if (result.getType().cast<IntegerType>().isInteger(typeWidth))
+          return result;
+      }
 
-    if (!lhs_v)
-      lhs_v = rewriter.create<ConstantIntOp>(op.getLoc(), lhs.getInt(), 1);
-    if (!rhs_v)
-      rhs_v = rewriter.create<ConstantIntOp>(op.getLoc(), rhs.getInt(), 1);
+      IntegerAttr intAttr;
+      if (matchPattern(val, m_Constant(&intAttr))) {
+        if (intAttr.getInt() == 0 || intAttr.getInt() == 1)
+          return rewriter.create<ConstantIntOp>(op.getLoc(), intAttr.getInt(),
+                                                typeWidth);
+      }
+
+      return nullptr;
+    };
+
+    Value lhs_v = getI1(op.getTrueValue());
+    Value rhs_v = getI1(op.getFalseValue());
+    if (!lhs_v || !rhs_v)
+      return failure();
 
     rewriter.replaceOpWithNewOp<ExtUIOp>(
         op, op.getType(),

--- a/polygeist/lib/polygeist/Ops.cpp
+++ b/polygeist/lib/polygeist/Ops.cpp
@@ -1173,7 +1173,9 @@ public:
       return failure();
 
     auto MET = src.getSource().getType().cast<MemRefType>().getElementType();
-    if (MET.isa<LLVM::LLVMStructType>())
+    // SYCL types are lowered to LLVM struct type.
+    bool isSYCLTy = MET.getDialect().getNamespace().contains("sycl");
+    if (MET.isa<LLVM::LLVMStructType>() || isSYCLTy)
       return failure();
 
     Value idx[] = {src.getIndex()};

--- a/polygeist/test/polygeist-opt/invalid_canonicalization.mlir
+++ b/polygeist/test/polygeist-opt/invalid_canonicalization.mlir
@@ -62,3 +62,20 @@ func.func @Memref2PointerIndex(%arg0: memref<?x!llvm.struct<(i32, i32)>>) -> !ll
 }
 
 // -----
+
+// CHECK:  func.func @Memref2PointerIndexSycl([[A0:%.*]]: memref<?x!sycl_array_1_, 4>) -> !llvm.ptr<i64, 4> {
+// CHECK-NEXT:    [[C1:%.*]] = arith.constant 1 : index
+// CHECK-NEXT:    [[T0:%.*]] = "polygeist.subindex"([[A0]], [[C1]]) : (memref<?x!sycl_array_1_, 4>, index) -> memref<?xi64, 4>
+// CHECK-NEXT:    [[T1:%.*]] = "polygeist.memref2pointer"([[T0]]) : (memref<?xi64, 4>) -> !llvm.ptr<i64, 4>
+// CHECK-NEXT:    return [[T1]] : !llvm.ptr<i64, 4>
+// CHECK-NEXT:  }
+
+!sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
+func.func @Memref2PointerIndexSycl(%arg0: memref<?x!sycl_array_1_, 4>) -> !llvm.ptr<i64, 4> {
+  %c1 = arith.constant 1 : index
+  %0 = "polygeist.subindex"(%arg0, %c1) : (memref<?x!sycl.array<[1], (memref<1xi64, 4>)>, 4>, index) -> memref<?xi64, 4>
+  %1 = "polygeist.memref2pointer"(%0) : (memref<?xi64, 4>) -> !llvm.ptr<i64, 4>
+  return %1 : !llvm.ptr<i64, 4>
+}
+
+// -----

--- a/polygeist/test/polygeist-opt/selecti1ext.mlir
+++ b/polygeist/test/polygeist-opt/selecti1ext.mlir
@@ -1,0 +1,28 @@
+// RUN: polygeist-opt --canonicalize %s | FileCheck %s 
+  
+// CHECK-LABEL: func.func @test1(%arg0: i1) -> i32 {
+// CHECK:         %0 = arith.select %arg0, %c1_i32, %c2_i32 : i32
+// CHECK-NEXT:    return %0 : i32
+// CHECK-NEXT:  }
+
+func.func @test1(%arg0: i1) -> i32 {
+  %c1_i32 = arith.constant 1 : i32
+  %c2_i32 = arith.constant 2 : i32
+  %0 = arith.select %arg0, %c1_i32, %c2_i32 : i32
+  return %0 : i32
+}
+
+// CHECK-LABEL: func.func @test2(%arg0: i1) -> i32 {
+// CHECK:         %0 = arith.xori %arg0, %true : i1
+// CHECK-NEXT:    %1 = arith.extui %0 : i1 to i32
+// CHECK-NEXT:    return %1 : i32
+// CHECK-NEXT:  }
+
+func.func @test2(%arg0: i1) -> i32 {
+  %true = arith.constant true
+  %false = arith.constant false
+  %0 = arith.extui %true : i1 to i32
+  %1 = arith.extui %false : i1 to i32
+  %2 = arith.select %arg0, %1, %0 : i32
+  return %2 : i32
+}

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1118,8 +1118,7 @@ llvm::Optional<sycl::SYCLMethodOpInterface> MLIRScanner::createSYCLMethodOp(
                           << " to replace SYCL method call.\n");
 
   return static_cast<sycl::SYCLMethodOpInterface>(Builder.create(
-      Loc, Builder.getStringAttr(*OptOpName),
-      sycl::adaptSYCLMethodOpArguments(Builder, Loc, OperandsCpy),
+      Loc, Builder.getStringAttr(*OptOpName), OperandsCpy,
       ReturnType ? mlir::TypeRange{*ReturnType} : mlir::TypeRange{},
       getSYCLMethodOpAttrs(Builder, Operands.getTypes(), TypeName, FunctionName,
                            MangledFunctionName)));

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -43,7 +43,7 @@ template <typename T> SYCL_EXTERNAL void keep(T);
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_0N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEENS0_2idILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef}, 
 // CHECK_MLIR_SAME:      %{{.*}}: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl_id_2_>], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (!sycl_accessor_2_i32_rw_gb, !sycl_id_2_) -> memref<?xi32, 4>
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl_id_2_>], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_0N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEENS0_2idILi2EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0, %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %1) #[[FUNCATTRS:[0-9]+]]
@@ -55,7 +55,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_0(sycl::accessor<sycl::cl_int, 2>
 
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_1N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK_MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb>, %{{.*}}: i64)
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>, i64], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEEDam, TypeName = @accessor} : (!sycl_accessor_2_i32_rw_gb, i64) -> ![[ACC_SUBSCRIPT]]
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>, i64], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEEDam, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>, i64) -> ![[ACC_SUBSCRIPT]]
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_1N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0, i64 noundef %1) #[[FUNCATTRS]]
@@ -68,7 +68,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_1(sycl::accessor<sycl::cl_int, 2>
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_2N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_1_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_1_i32_rw_gb, llvm.noundef}, 
 // CHECK-MLIR-SAME:      %{{.*}}: i64 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERiNS0_2idILi1EEE, TypeName = @accessor} : (!sycl_accessor_1_i32_rw_gb, !sycl_id_1_) -> memref<?xi32, 4>
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERiNS0_2idILi1EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_2N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-LLVM:           %"class.sycl::_V1::accessor.1"* noundef byval(%"class.sycl::_V1::accessor.1") align 8 %0, i64 noundef %1) #[[FUNCATTRS]]  
@@ -81,7 +81,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_2(sycl::accessor<sycl::cl_int, 1>
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_3N4sycl3_V18accessorI6StructLi1ELNS0_6access4modeE1026ELNS3_6targetE2014ELNS3_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-MLIR:          %{{.*}}: memref<?x![[ACC_STRUCT]]> {llvm.align = 8 : i64, llvm.byval = ![[ACC_STRUCT]], llvm.noundef}, 
 // CHECK-MLIR-SAME:     %{{.*}}: i64 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x![[ACC_STRUCT]], 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorI6StructLi1ELNS0_6access4modeE1026ELNS3_6targetE2014ELNS3_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERS2_NS0_2idILi1EEE, TypeName = @accessor} : (![[ACC_STRUCT]], !sycl_id_1_) -> !llvm.ptr<struct<(i32)>, 4> 
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x![[ACC_STRUCT]], 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorI6StructLi1ELNS0_6access4modeE1026ELNS3_6targetE2014ELNS3_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERS2_NS0_2idILi1EEE, TypeName = @accessor} : (memref<?x![[ACC_STRUCT]]>, memref<?x!sycl_id_1_>) -> !llvm.ptr<struct<(i32)>, 4> 
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_3N4sycl3_V18accessorI6StructLi1ELNS0_6access4modeE1026ELNS3_6targetE2014ELNS3_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-LLVM:           %"class.sycl::_V1::accessor.1.1"* noundef byval(%"class.sycl::_V1::accessor.1.1") align 8 %0, i64 noundef %1) #[[FUNCATTRS]] 
@@ -96,7 +96,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_3(sycl::accessor<Struct, 1> acc, 
 // CHECK-MLIR-LABEL: func.func @_Z11range_get_0N4sycl3_V15rangeILi2EEEi(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef}, 
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (!sycl_range_2_, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_range_2_>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z11range_get_0N4sycl3_V15rangeILi2EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #[[FUNCATTRS]] 
@@ -109,7 +109,7 @@ SYCL_EXTERNAL void range_get_0(sycl::range<2> r, int dimension) {
 // CHECK-MLIR-LABEL: func.func @_Z11range_get_1N4sycl3_V15rangeILi2EEEi(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef}
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZN4sycl3_V16detail5arrayILi2EEixEi, TypeName = @array} : (!sycl_range_2_, i32) -> memref<?xi64, 4>
+// CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZN4sycl3_V16detail5arrayILi2EEixEi, TypeName = @array} : (memref<?x!sycl_range_2_>, i32) -> memref<?xi64, 4>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z11range_get_1N4sycl3_V15rangeILi2EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]   
@@ -122,7 +122,7 @@ SYCL_EXTERNAL void range_get_1(sycl::range<2> r, int dimension) {
 // CHECK-MLIR-LABEL: func.func @_Z11range_get_2N4sycl3_V15rangeILi2EEEi(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef}
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EEixEi, TypeName = @array} : (!sycl_range_2_, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EEixEi, TypeName = @array} : (memref<?x!sycl_range_2_>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z11range_get_2N4sycl3_V15rangeILi2EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]     
@@ -134,7 +134,7 @@ SYCL_EXTERNAL void range_get_2(const sycl::range<2> r, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z10range_sizeN4sycl3_V15rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.range.size(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_range_2_, 4>], FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (!sycl_range_2_) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.range.size(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_range_2_, 4>], FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl_range_2_>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z10range_sizeN4sycl3_V15rangeILi2EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0) #[[FUNCATTRS]]       
@@ -146,7 +146,7 @@ SYCL_EXTERNAL void range_size(sycl::range<2> r) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_range_get_global_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_range.get_global_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_range_2_, 4>], FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv, TypeName = @nd_range} : (!sycl_nd_range_2_) -> !sycl_range_2_
+// CHECK-MLIR: %{{.*}} = sycl.nd_range.get_global_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_range_2_, 4>], FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_>) -> !sycl_range_2_
 
 // CHECK-MLIR:           func.func @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv(%[[VAL_0:.*]]: memref<?x!sycl_nd_range_2_, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 48 : i64, llvm.noundef}) -> !sycl_range_2_
 // CHECK-MLIR-NEXT:             %[[VAL_1:.*]] = arith.constant 0 : index
@@ -180,7 +180,7 @@ SYCL_EXTERNAL void nd_range_get_global_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-MLIR-LABEL: func.func @_Z24nd_range_get_local_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_range.get_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_range_2_, 4>], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE15get_local_rangeEv, TypeName = @nd_range} : (!sycl_nd_range_2_) -> !sycl_range_2_
+// CHECK-MLIR: %{{.*}} = sycl.nd_range.get_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_range_2_, 4>], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE15get_local_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_>) -> !sycl_range_2_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z24nd_range_get_local_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #[[FUNCATTRS]]
@@ -192,7 +192,7 @@ SYCL_EXTERNAL void nd_range_get_local_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-MLIR-LABEL: func.func @_Z24nd_range_get_group_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_range.get_group_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_range_2_, 4>], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE15get_group_rangeEv, TypeName = @nd_range} : (!sycl_nd_range_2_) -> !sycl_range_2_
+// CHECK-MLIR: %{{.*}} = sycl.nd_range.get_group_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_range_2_, 4>], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE15get_group_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_>) -> !sycl_range_2_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z24nd_range_get_group_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #[[FUNCATTRS]]  
@@ -204,7 +204,7 @@ SYCL_EXTERNAL void nd_range_get_group_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_0N4sycl3_V12idILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] {ArgumentTypes = [memref<?x!sycl_array_1_, 4>, i32], FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi1EE3getEi, TypeName = @array} : (!sycl_id_1_, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] {ArgumentTypes = [memref<?x!sycl_array_1_, 4>, i32], FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi1EE3getEi, TypeName = @array} : (memref<?x!sycl_id_1_>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_0N4sycl3_V12idILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
@@ -216,7 +216,7 @@ SYCL_EXTERNAL void id_get_0(sycl::id<1> id, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_1N4sycl3_V12idILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})  
-// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] {ArgumentTypes = [memref<?x!sycl_array_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZN4sycl3_V16detail5arrayILi1EEixEi, TypeName = @array} : (!sycl_id_1_, i32) -> memref<?xi64, 4>
+// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] {ArgumentTypes = [memref<?x!sycl_array_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZN4sycl3_V16detail5arrayILi1EEixEi, TypeName = @array} : (memref<?x!sycl_id_1_>, i32) -> memref<?xi64, 4>
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_1N4sycl3_V12idILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]  
@@ -228,7 +228,7 @@ SYCL_EXTERNAL void id_get_1(sycl::id<1> id, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_2N4sycl3_V12idILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})    
-// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] {ArgumentTypes = [memref<?x!sycl_array_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi1EEixEi, TypeName = @array} : (!sycl_id_1_, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] {ArgumentTypes = [memref<?x!sycl_array_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi1EEixEi, TypeName = @array} : (memref<?x!sycl_id_1_>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_2N4sycl3_V12idILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]    
@@ -240,7 +240,7 @@ SYCL_EXTERNAL void id_get_2(const sycl::id<1> id, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_3N4sycl3_V12idILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}
-// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[] {ArgumentTypes = [memref<?x!sycl_id_1_, 4>], FunctionName = @"operator unsigned long", MangledFunctionName = @_ZNK4sycl3_V12idILi1EEcvmEv, TypeName = @id} : (!sycl_id_1_) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[] {ArgumentTypes = [memref<?x!sycl_id_1_, 4>], FunctionName = @"operator unsigned long", MangledFunctionName = @_ZNK4sycl3_V12idILi1EEcvmEv, TypeName = @id} : (memref<?x!sycl_id_1_>) -> i64
 
 SYCL_EXTERNAL void id_get_3(sycl::id<1> id) {
   keep(static_cast<size_t>(id));
@@ -248,7 +248,7 @@ SYCL_EXTERNAL void id_get_3(sycl::id<1> id) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (![[ITEM1]]) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x![[ITEM1]]>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]
@@ -260,7 +260,7 @@ SYCL_EXTERNAL void item_get_id_0(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_1N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x![[ITEM1]], 4>, i32], FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEi, TypeName = @item} : (![[ITEM1]], i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x![[ITEM1]], 4>, i32], FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEi, TypeName = @item} : (memref<?x![[ITEM1]]>, i32) -> i64
 
 SYCL_EXTERNAL void item_get_id_1(sycl::item<1> item, int dimension) {
   keep(item.get_id(dimension));
@@ -268,7 +268,7 @@ SYCL_EXTERNAL void item_get_id_1(sycl::item<1> item, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_2N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x![[ITEM1]], 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EEixEi, TypeName = @item} : (![[ITEM1]], i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x![[ITEM1]], 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EEixEi, TypeName = @item} : (memref<?x![[ITEM1]]>, i32) -> i64
 
 SYCL_EXTERNAL void item_get_id_2(sycl::item<1> item, int dimension) {
   keep(item[dimension]);
@@ -276,7 +276,7 @@ SYCL_EXTERNAL void item_get_id_2(sycl::item<1> item, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_3N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @"operator unsigned long", MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EEcvmEv, TypeName = @item} : (![[ITEM1]]) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @"operator unsigned long", MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EEcvmEv, TypeName = @item} : (memref<?x![[ITEM1]]>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_3N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]  
@@ -288,7 +288,7 @@ SYCL_EXTERNAL void item_get_id_3(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z16item_get_range_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_range(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEv, TypeName = @item} : (![[ITEM1]]) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.item.get_range(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEv, TypeName = @item} : (memref<?x![[ITEM1]]>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z16item_get_range_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]    
@@ -300,7 +300,7 @@ SYCL_EXTERNAL void item_get_range_0(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z16item_get_range_1N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x![[ITEM1]], 4>, i32], FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEi, TypeName = @item} : (![[ITEM1]], i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.item.get_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x![[ITEM1]], 4>, i32], FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEi, TypeName = @item} : (memref<?x![[ITEM1]]>, i32) -> i64
 
 SYCL_EXTERNAL void item_get_range_1(sycl::item<1> item, int dimension) {
   keep(item.get_range(dimension));
@@ -308,7 +308,7 @@ SYCL_EXTERNAL void item_get_range_1(sycl::item<1> item, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z18item_get_linear_idN4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @get_linear_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE13get_linear_idEv, TypeName = @item} : (![[ITEM1]]) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.item.get_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @get_linear_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE13get_linear_idEv, TypeName = @item} : (memref<?x![[ITEM1]]>) -> i64
 
 SYCL_EXTERNAL void item_get_linear_id(sycl::item<1> item) {
   keep(item.get_linear_id());
@@ -316,7 +316,7 @@ SYCL_EXTERNAL void item_get_linear_id(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23nd_item_get_global_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_global_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEv, TypeName = @nd_item} : (!sycl_nd_item_1_) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_global_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23nd_item_get_global_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]
@@ -328,7 +328,7 @@ SYCL_EXTERNAL void nd_item_get_global_id_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23nd_item_get_global_id_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_global_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEi, TypeName = @nd_item} : (!sycl_nd_item_1_, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_global_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
 
 SYCL_EXTERNAL void nd_item_get_global_id_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_global_id(dimension));
@@ -336,7 +336,7 @@ SYCL_EXTERNAL void nd_item_get_global_id_1(sycl::nd_item<1> nd_item, int dimensi
 
 // CHECK-MLIR-LABEL: func.func @_Z28nd_item_get_global_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_global_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE20get_global_linear_idEv, TypeName = @nd_item} : (!sycl_nd_item_1_) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_global_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE20get_global_linear_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> i64
 
 SYCL_EXTERNAL void nd_item_get_global_linear_id(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_global_linear_id());
@@ -344,7 +344,7 @@ SYCL_EXTERNAL void nd_item_get_global_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z22nd_item_get_local_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEv, TypeName = @nd_item} : (!sycl_nd_item_1_) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z22nd_item_get_local_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]  
@@ -356,7 +356,7 @@ SYCL_EXTERNAL void nd_item_get_local_id_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z22nd_item_get_local_id_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEi, TypeName = @nd_item} : (!sycl_nd_item_1_, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
 
 SYCL_EXTERNAL void nd_item_get_local_id_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_local_id(dimension));
@@ -364,7 +364,7 @@ SYCL_EXTERNAL void nd_item_get_local_id_1(sycl::nd_item<1> nd_item, int dimensio
 
 // CHECK-MLIR-LABEL: func.func @_Z27nd_item_get_local_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_local_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE19get_local_linear_idEv, TypeName = @nd_item} : (!sycl_nd_item_1_) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_local_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE19get_local_linear_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z27nd_item_get_local_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]    
@@ -376,7 +376,7 @@ SYCL_EXTERNAL void nd_item_get_local_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z19nd_item_get_group_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})  
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_group, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEv, TypeName = @nd_item} : (!sycl_nd_item_1_) -> !sycl_group_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_group, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_group_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z19nd_item_get_group_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]      
@@ -388,7 +388,7 @@ SYCL_EXTERNAL void nd_item_get_group_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z19nd_item_get_group_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_group, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEi, TypeName = @nd_item} : (!sycl_nd_item_1_, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_group, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
 
 SYCL_EXTERNAL void nd_item_get_group_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_group(dimension));
@@ -396,7 +396,7 @@ SYCL_EXTERNAL void nd_item_get_group_1(sycl::nd_item<1> nd_item, int dimension) 
 
 // CHECK-MLIR-LABEL: func.func @_Z27nd_item_get_group_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_group_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE19get_group_linear_idEv, TypeName = @nd_item} : (!sycl_nd_item_1_) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_group_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE19get_group_linear_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> i64
 
 SYCL_EXTERNAL void nd_item_get_group_linear_id(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_group_linear_id());
@@ -404,7 +404,7 @@ SYCL_EXTERNAL void nd_item_get_group_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_group_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEv, TypeName = @nd_item} : (!sycl_nd_item_1_) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_group_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]        
@@ -416,7 +416,7 @@ SYCL_EXTERNAL void nd_item_get_group_range_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_group_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEi, TypeName = @nd_item} : (!sycl_nd_item_1_, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
 
 SYCL_EXTERNAL void nd_item_get_group_range_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_group_range(dimension));
@@ -424,7 +424,7 @@ SYCL_EXTERNAL void nd_item_get_group_range_1(sycl::nd_item<1> nd_item, int dimen
 
 // CHECK-MLIR-LABEL: func.func @_Z26nd_item_get_global_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEv, TypeName = @nd_item} : (!sycl_nd_item_1_) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z26nd_item_get_global_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]
@@ -436,7 +436,7 @@ SYCL_EXTERNAL void nd_item_get_global_range_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z26nd_item_get_global_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEi, TypeName = @nd_item} : (!sycl_nd_item_1_, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z26nd_item_get_global_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]      
@@ -448,7 +448,7 @@ SYCL_EXTERNAL void nd_item_get_global_range_1(sycl::nd_item<1> nd_item, int dime
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_local_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEv, TypeName = @nd_item} : (!sycl_nd_item_1_) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_local_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]
@@ -460,7 +460,7 @@ SYCL_EXTERNAL void nd_item_get_local_range_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_local_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEi, TypeName = @nd_item} : (!sycl_nd_item_1_, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_local_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]        
@@ -472,7 +472,7 @@ SYCL_EXTERNAL void nd_item_get_local_range_1(sycl::nd_item<1> nd_item, int dimen
 
 // CHECK-MLIR-LABEL: func.func @_Z20nd_item_get_nd_rangeN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_nd_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_nd_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_nd_rangeEv, TypeName = @nd_item} : (!sycl_nd_item_1_) -> !sycl_nd_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_nd_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_nd_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_nd_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_nd_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20nd_item_get_nd_rangeN4sycl3_V17nd_itemILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]          
@@ -484,7 +484,7 @@ SYCL_EXTERNAL void nd_item_get_nd_range(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_group_idEv, TypeName = @group} : (!sycl_group_1_) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_group_idEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_0N4sycl3_V15groupILi1EEE(
 
@@ -496,7 +496,7 @@ SYCL_EXTERNAL void group_get_group_id_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_group_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_group_idEi, TypeName = @group} : (!sycl_group_1_, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_group_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_group_idEi, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_1N4sycl3_V15groupILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
@@ -508,7 +508,7 @@ SYCL_EXTERNAL void group_get_group_id_1(sycl::group<1> group, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_2N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V15groupILi1EEixEi, TypeName = @group} : (!sycl_group_1_, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V15groupILi1EEixEi, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_2N4sycl3_V15groupILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
@@ -520,7 +520,7 @@ SYCL_EXTERNAL void group_get_group_id_2(sycl::group<1> group, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_local_id_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_local_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_local_idEv, TypeName = @group} : (!sycl_group_1_) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = sycl.group.get_local_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_local_idEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_local_id_0N4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]   
@@ -532,7 +532,7 @@ SYCL_EXTERNAL void group_get_local_id_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_local_id_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_local_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_local_idEi, TypeName = @group} : (!sycl_group_1_, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_local_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_local_idEi, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_local_id_1N4sycl3_V15groupILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]  
@@ -544,7 +544,7 @@ SYCL_EXTERNAL void group_get_local_id_1(sycl::group<1> group, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_local_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}
-// CHECK-MLIR: %{{.*}} = sycl.group.get_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEv, TypeName = @group} : (!sycl_group_1_) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.group.get_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_local_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]     
@@ -556,7 +556,7 @@ SYCL_EXTERNAL void group_get_local_range_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_local_range_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_local_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEi, TypeName = @group} : (!sycl_group_1_, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_local_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEi, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_local_range_1N4sycl3_V15groupILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]    
@@ -568,7 +568,7 @@ SYCL_EXTERNAL void group_get_local_range_1(sycl::group<1> group, int dimension) 
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_group_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}  
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEv, TypeName = @group} : (!sycl_group_1_) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_group_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]       
@@ -580,7 +580,7 @@ SYCL_EXTERNAL void group_get_group_range_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_group_range_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}    
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEi, TypeName = @group} : (!sycl_group_1_, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEi, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_group_range_1N4sycl3_V15groupILi1EEEi(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]      
@@ -592,7 +592,7 @@ SYCL_EXTERNAL void group_get_group_range_1(sycl::group<1> group, int dimension) 
 
 // CHECK-MLIR-LABEL: func.func @_Z25group_get_max_local_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}      
-// CHECK-MLIR: %{{.*}} = sycl.group.get_max_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_max_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_max_local_rangeEv, TypeName = @group} : (!sycl_group_1_) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.group.get_max_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_max_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_max_local_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_max_local_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]         
@@ -604,7 +604,7 @@ SYCL_EXTERNAL void group_get_max_local_range(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25group_get_group_linear_idN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}        
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_linear_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_group_linear_idEv, TypeName = @group} : (!sycl_group_1_) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_linear_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_group_linear_idEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_group_linear_idN4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]           
@@ -616,7 +616,7 @@ SYCL_EXTERNAL void group_get_group_linear_id(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25group_get_local_linear_idN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}          
-// CHECK-MLIR: %{{.*}} = sycl.group.get_local_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_linear_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_local_linear_idEv, TypeName = @group} : (!sycl_group_1_) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_local_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_linear_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_local_linear_idEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_local_linear_idN4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]         
@@ -628,7 +628,7 @@ SYCL_EXTERNAL void group_get_local_linear_id(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z28group_get_group_linear_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}            
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_linear_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_linear_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE22get_group_linear_rangeEv, TypeName = @group} : (!sycl_group_1_) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_linear_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_linear_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE22get_group_linear_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z28group_get_group_linear_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]           
@@ -640,7 +640,7 @@ SYCL_EXTERNAL void group_get_group_linear_range(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z28group_get_local_linear_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_local_linear_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_linear_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE22get_local_linear_rangeEv, TypeName = @group} : (!sycl_group_1_) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_local_linear_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_linear_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE22get_local_linear_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z28group_get_local_linear_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]             
@@ -698,30 +698,22 @@ SYCL_EXTERNAL void op_1(sycl::id<2> a, sycl::id<2> b) {
 // CHECK-MLIR:         %arg0: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef}, %arg1: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})
 // CHECK-MLIR-NEXT: %c1_i32 = arith.constant 1 : i32
 // CHECK-MLIR-NEXT: %c0_i32 = arith.constant 0 : i32
-// CHECK-MLIR-NEXT: %0 = affine.load %arg0[0] : memref<?x!sycl_id_2_>
-// CHECK-MLIR-NEXT: %1 = sycl.id.get %0[%c0_i32] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (!sycl_id_2_, i32) -> i64
-// CHECK-MLIR-NEXT: %2 = sycl.id.get %0[%c1_i32] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (!sycl_id_2_, i32) -> i64
-// CHECK-MLIR-NEXT: %3 = arith.addi %1, %2 : i64
-// CHECK-MLIR-NEXT: %4 = sycl.call @abs(%3) {MangledFunctionName = @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_} : (i64) -> i64
+// CHECK-MLIR-NEXT: %0 = sycl.id.get %arg0[%c0_i32] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_id_2_>, i32) -> i64
+// CHECK-MLIR-NEXT: %1 = sycl.id.get %arg0[%c1_i32] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_id_2_>, i32) -> i64
+// CHECK-MLIR-NEXT: %2 = arith.addi %0, %1 : i64
+// CHECK-MLIR-NEXT: %3 = sycl.call @abs(%2) {MangledFunctionName = @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_} : (i64) -> i64
 // CHECK-MLIR-NEXT: return
 // CHECK-MLIR-NEXT: }
 
 // CHECK-LLVM-LABEL: define spir_func void @_Z8static_1N4sycl3_V12idILi2EEES2_(
 // CHECK-LLVM-SAME:      %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %0, %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %1) #[[FUNCATTRS]]  
-// CHECK-LLVM-NEXT: %3 = alloca %"class.sycl::_V1::id.2", align 8
-// CHECK-LLVM-NEXT: %4 = alloca %"class.sycl::_V1::id.2", align 8
-// CHECK-LLVM-NEXT: %5 = load %"class.sycl::_V1::id.2", %"class.sycl::_V1::id.2"* %0, align 8
-// CHECK-LLVM-NEXT: store %"class.sycl::_V1::id.2" %5, %"class.sycl::_V1::id.2"* %3, align 8
-// CHECK-LLVM-NEXT: %6 = addrspacecast %"class.sycl::_V1::id.2"* %3 to %"class.sycl::_V1::id.2" addrspace(4)*
-// CHECK-LLVM-NEXT: %7 = bitcast %"class.sycl::_V1::id.2" addrspace(4)* %6 to %"class.sycl::_V1::detail::array.2" addrspace(4)*
-// CHECK-LLVM-NEXT: %8 = call spir_func i64 @_ZNK4sycl3_V16detail5arrayILi2EE3getEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %7, i32 0)
-// CHECK-LLVM-NEXT: store %"class.sycl::_V1::id.2" %5, %"class.sycl::_V1::id.2"* %4, align 8
-// CHECK-LLVM-NEXT: %9 = addrspacecast %"class.sycl::_V1::id.2"* %4 to %"class.sycl::_V1::id.2" addrspace(4)*
-// CHECK-LLVM-NEXT: %10 = bitcast %"class.sycl::_V1::id.2" addrspace(4)* %9 to %"class.sycl::_V1::detail::array.2" addrspace(4)*
-// CHECK-LLVM-NEXT: %11 = call spir_func i64 @_ZNK4sycl3_V16detail5arrayILi2EE3getEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %10, i32 1)
-// CHECK-LLVM-NEXT: %12 = add i64 %8, %11
-// CHECK-LLVM-NEXT: %13 = call spir_func i64 @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_(i64 %12)
-// CHECK-LLVM-NEXT: ret void
+// CHECK-LLVM-NEXT:    %3 = addrspacecast %"class.sycl::_V1::id.2"* %0 to %"class.sycl::_V1::id.2" addrspace(4)*
+// CHECK-LLVM-NEXT:    %4 = bitcast %"class.sycl::_V1::id.2" addrspace(4)* %3 to %"class.sycl::_V1::detail::array.2" addrspace(4)*
+// CHECK-LLVM-NEXT:    %5 = call spir_func i64 @_ZNK4sycl3_V16detail5arrayILi2EE3getEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %4, i32 0)
+// CHECK-LLVM-NEXT:    %6 = call spir_func i64 @_ZNK4sycl3_V16detail5arrayILi2EE3getEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %4, i32 1)
+// CHECK-LLVM-NEXT:    %7 = add i64 %5, %6
+// CHECK-LLVM-NEXT:    %8 = call spir_func i64 @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_(i64 %7)
+// CHECK-LLVM-NEXT:    ret void
 // CHECK-LLVM-NEXT: }
 
 SYCL_EXTERNAL void static_1(sycl::id<2> a, sycl::id<2> b) {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/image.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/image.cpp
@@ -18,14 +18,13 @@ static constexpr unsigned N = 8;
 // CHECK-DAG:     %0 = llvm.mlir.undef : i32
 // CHECK-NEXT:    affine.store %0, %alloca[0] : memref<1xi32>
 // CHECK-NEXT:    %1 = "polygeist.memref2pointer"(%arg0) : (memref<?x!llvm.struct<(!sycl_accessor_1_21sycl2Evec3C5Bf322C_45D2C_28vector3C4xf323E293E_r_i)>, 4>) -> !llvm.ptr<struct<(ptr<struct<"opencl.image1d_ro_t", opaque>, 1>, array<24 x i8>)>, 4>
-// CHECK-NEXT:    %2 = affine.load %arg1[0] : memref<?x!sycl_item_1_>
-// CHECK-NEXT:    %3 = sycl.item.get_id(%2, %c0_i32) {ArgumentTypes = [memref<?x!sycl_item_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EEixEi, TypeName = @item} : (!sycl_item_1_, i32) -> i64
-// CHECK-NEXT:    %4 = arith.trunci %3 : i64 to i32
-// CHECK-NEXT:    %5 = "polygeist.memref2pointer"(%alloca) : (memref<1xi32>) -> !llvm.ptr<i32>
-// CHECK-NEXT:    %6 = llvm.addrspacecast %5 : !llvm.ptr<i32> to !llvm.ptr<i32, 4>
-// CHECK-NEXT:    %7 = "polygeist.pointer2memref"(%6) : (!llvm.ptr<i32, 4>) -> memref<?xi32, 4>
-// CHECK-NEXT:    llvm.store %4, %6 : !llvm.ptr<i32, 4>
-// CHECK-NEXT:    %8 = sycl.call @read(%1, %7) {MangledFunctionName = @_ZNK4sycl3_V16detail14image_accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS5_6targetE2017ELNS5_11placeholderE0EE4readIiLi1EvEES4_RKT_, TypeName = @image_accessor} : (!llvm.ptr<struct<(ptr<struct<"opencl.image1d_ro_t", opaque>, 1>, array<24 x i8>)>, 4>, memref<?xi32, 4>) -> !sycl_vec_f32_4_
+// CHECK-NEXT:    %2 = sycl.item.get_id(%arg1, %c0_i32) {ArgumentTypes = [memref<?x!sycl_item_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EEixEi, TypeName = @item} : (memref<?x!sycl_item_1_>, i32) -> i64
+// CHECK-NEXT:    %3 = arith.trunci %2 : i64 to i32
+// CHECK-NEXT:    %4 = "polygeist.memref2pointer"(%alloca) : (memref<1xi32>) -> !llvm.ptr<i32>
+// CHECK-NEXT:    %5 = llvm.addrspacecast %4 : !llvm.ptr<i32> to !llvm.ptr<i32, 4>
+// CHECK-NEXT:    %6 = "polygeist.pointer2memref"(%5) : (!llvm.ptr<i32, 4>) -> memref<?xi32, 4>
+// CHECK-NEXT:    llvm.store %3, %5 : !llvm.ptr<i32, 4>
+// CHECK-NEXT:    %7 = sycl.call @read(%1, %6) {MangledFunctionName = @_ZNK4sycl3_V16detail14image_accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS5_6targetE2017ELNS5_11placeholderE0EE4readIiLi1EvEES4_RKT_, TypeName = @image_accessor} : (!llvm.ptr<struct<(ptr<struct<"opencl.image1d_ro_t", opaque>, 1>, array<24 x i8>)>, 4>, memref<?xi32, 4>) -> !sycl_vec_f32_4_
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/structvec.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/structvec.cpp
@@ -79,7 +79,9 @@ SYCL_EXTERNAL structvec test_store(structvec sv, int idx, char el) {
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: func.func @_ZN9structvecC1ESt16initializer_listIcE(%arg0: !llvm.ptr<struct<(vector<2xi8>)>, 4> {llvm.align = 2 : i64, llvm.dereferenceable_or_null = 2 : i64, llvm.noundef}, %arg1: !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>> {llvm.align = 8 : i64, llvm.byval = !llvm.struct<(memref<?xi8, 4>, i64)>, llvm.noundef})
-// CHECK-NEXT:    %c0_i8 = arith.constant 0 : i8
+// CHECK-DAG:     %c-1_i32 = arith.constant -1 : i32
+// CHECK-DAG:     %c0_i32 = arith.constant 0 : i32
+// CHECK-DAG:     %c0_i8 = arith.constant 0 : i8
 // CHECK-NEXT:    %0 = llvm.addrspacecast %arg1 : !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>> to !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>, 4>
 // CHECK-NEXT:    %1 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(vector<2xi8>)>, 4>) -> !llvm.ptr<vector<2xi8>, 4>
 // CHECK-NEXT:    affine.for %arg2 = 0 to 2 {
@@ -88,7 +90,7 @@ SYCL_EXTERNAL structvec test_store(structvec sv, int idx, char el) {
 // CHECK-NEXT:      %4 = arith.index_castui %2 : i32 to index
 // CHECK-NEXT:      %5 = memref.load %3[%4] : memref<?xi8, 4>
 // CHECK-NEXT:      %6 = arith.cmpi ne, %5, %c0_i8 : i8
-// CHECK-NEXT:      %7 = arith.extui %6 : i1 to i32
+// CHECK-NEXT:      %7 = arith.select %6, %c-1_i32, %c0_i32 : i32
 // CHECK-NEXT:      %8 = arith.trunci %7 : i32 to i8
 // CHECK-NEXT:      %9 = llvm.load %1 : !llvm.ptr<vector<2xi8>, 4>
 // CHECK-NEXT:      %10 = vector.insertelement %8, %9[%2 : i32] : vector<2xi8>


### PR DESCRIPTION
Lower the following operations to LLVM:

- sycl.nd_item.get_global_id                                                                                                                                                                                                                                   
- sycl.nd_item.get_local_id                                                                                                                                                                                                                                    
- sycl.nd_item.get_group                                                                                                                                                                                                                                       
- sycl.nd_item.get_group_range                                                                                                                                                                                                                                 
- sycl.nd_item.get_local_range                                                                                                                                                                                                                                 
- sycl.nd_item.get_nd_range