### PR TITLE
[CI] Switch execution of some jobs to self-hosted runners

### DIFF
--- a/.github/workflows/sycl_cleanup.yml
+++ b/.github/workflows/sycl_cleanup.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   cleanup:
-    runs-on: ubuntu-latest
+    runs-on: Linux
     steps:
     - uses: actions/github-script@v6
       with:

--- a/.github/workflows/sycl_gen_test_matrix.yml
+++ b/.github/workflows/sycl_gen_test_matrix.yml
@@ -46,7 +46,7 @@ on:
 jobs:
   test_matrix:
     name: Generate Test Matrix
-    runs-on: ubuntu-latest
+    runs-on: Linux
     outputs:
       lts_matrix: ${{ steps.work.outputs.lts_matrix }}
       cts_matrix: ${{ steps.work.outputs.cts_matrix }}

--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: Linux
     container:
       image: ghcr.io/intel/llvm/sycl_ubuntu2004_nightly:no-drivers
     steps:


### PR DESCRIPTION
GitHub-hosted runners are not available for hours. To unblock most critical pre-commit jobs we will run them on self-hosted runners.