### PR TITLE
Revert "[CI] Set one hour time limit for llvm-test-suite"

### DIFF
--- a/devops/actions/llvm_test_suite/action.yml
+++ b/devops/actions/llvm_test_suite/action.yml
@@ -43,7 +43,6 @@ inputs:
 post-if: false
 runs:
   using: "composite"
-  timeout-minutes: 60
   steps:
   - run: |
       cp -r /actions .


### PR DESCRIPTION
Reverts intel/llvm#8287

Apparently composite actions do not support timeout. See https://github.com/actions/runner/issues/1979.