### PR TITLE
[CI] Use 20.04 Ubuntu image instead of latest

### DIFF
--- a/.github/workflows/sycl_containers.yaml
+++ b/.github/workflows/sycl_containers.yaml
@@ -25,7 +25,7 @@ jobs:
   base_image_ubuntu2004:
     if: github.repository == 'intel/llvm'
     name: Base Ubuntu 20.04 Docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -44,7 +44,7 @@ jobs:
   build_image_ubuntu2004:
     if: github.repository == 'intel/llvm'
     name: Build Ubuntu Docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -66,7 +66,7 @@ jobs:
   drivers_image_ubuntu2004:
     if: github.repository == 'intel/llvm'
     name: Intel Drivers Ubuntu 20.04 Docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: base_image_ubuntu2004
     steps:
       - name: Checkout
@@ -105,7 +105,7 @@ jobs:
   drivers_image_ubuntu2004_unstable:
     if: github.repository == 'intel/llvm'
     name: Intel Drivers (unstable) Ubuntu 20.04 Docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: base_image_ubuntu2004
     steps:
       - name: Checkout
@@ -136,7 +136,7 @@ jobs:
   base_image_ubuntu2204:
     if: github.repository == 'intel/llvm'
     name: Base Ubuntu 22.04 Docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -155,7 +155,7 @@ jobs:
   build_image_ubuntu2204:
     if: github.repository == 'intel/llvm'
     name: Build Ubuntu Docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -177,7 +177,7 @@ jobs:
   drivers_image_ubuntu2204:
     if: github.repository == 'intel/llvm'
     name: Intel Drivers Ubuntu 22.04 Docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: base_image_ubuntu2204
     steps:
       - name: Checkout
@@ -215,7 +215,7 @@ jobs:
   drivers_image_ubuntu2204_unstable:
     if: github.repository == 'intel/llvm'
     name: Intel Drivers (unstable) Ubuntu 22.04 Docker image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: base_image_ubuntu2204
     steps:
       - name: Checkout

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -182,7 +182,7 @@ jobs:
     name: Start AWS
     needs: build
     if: ${{ inputs.lts_aws_matrix != '[]' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: aws
     steps:
       - name: Setup script
@@ -308,7 +308,7 @@ jobs:
     # Always attempt to shutdown AWS instance, even if AWS start was not
     # successful.
     if: ${{ always() && inputs.lts_aws_matrix != '[]' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: aws
     steps:
       - name: Setup script

--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -68,7 +68,7 @@ jobs:
 
   ubuntu2004_docker_build_push:
     if: github.repository == 'intel/llvm'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: ubuntu2004_build_test
     steps:
     - uses: actions/checkout@v3
@@ -105,7 +105,7 @@ jobs:
 
   ubuntu2204_docker_build_push:
     if: github.repository == 'intel/llvm'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: ubuntu2204_build_test
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/sycl_update_gpu_driver.yml
+++ b/.github/workflows/sycl_update_gpu_driver.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update_driver_linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository == 'intel/llvm'
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/windows_test_comment_trigger.yml
+++ b/.github/workflows/windows_test_comment_trigger.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   windows_test_preparation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: ${{ github.event.issue.pull_request && github.event.comment.body == '/testwin' }}
     steps:
     - name: react_to_comment
@@ -52,7 +52,7 @@ jobs:
       build_ref: ${{ needs.windows_test_preparation.outputs.PR_SHA }}
 
   windows_test_completion:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [windows_test_preparation, windows_default]
     if: always()
     steps:


### PR DESCRIPTION
For unknown reason, GitHub Actions seems to pick up jobs running on ubuntu-20.04 much faster than on ubuntu-latest. Ubuntu version is not relevant for our tasks, but using 20.04 should significantly improve responsivness of CI system.