### PR TITLE
[SYCL-MLIR] Drop some non-standard types from the SYCL dialect

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -179,32 +179,11 @@ def SYCL_ArrayType : SYCL_Type<"Array", "array"> {
   let assemblyFormat = "`<` `[` $dimension `]` `,` `(` $body `)` `>`";
 }
 
-def SYCL_AssertHappenedType : SYCL_Type<"AssertHappened", "assert_happened"> {
-  let parameters = (ins ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<` `(` $body `)` `>`";
-}
-
 def SYCL_AtomicType : SYCL_Type<"Atomic", "atomic"> {
   let parameters = (ins "::mlir::Type":$dataType,
                         "mlir::sycl::AccessAddrSpace":$addrSpace,
                         ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $dataType `,` custom<AccessAddrSpace>($addrSpace) `]` `,` `(` $body `)` `>`";
-}
-
-def SYCL_BFloat16Type : SYCL_Type<"BFloat16", "bfloat16"> {
-  let parameters = (ins ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<` `(` $body `)` `>`";
-}
-
-def SYCL_GetOpType : SYCL_Type<"GetOp", "get_op"> {
-  let parameters = (ins "::mlir::Type":$dataType);
-  let assemblyFormat = "`<` $dataType `>`";
-}
-
-def SYCL_GetScalarOpType : SYCL_Type<"GetScalarOp", "get_scalar_op"> {
-  let parameters = (ins "::mlir::Type":$dataType,
-                        ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<` `[` $dataType `]` `,` `(` $body `)` `>`";
 }
 
 def SYCL_GroupType : SYCL_Type<"Group", "group"> {
@@ -331,22 +310,6 @@ def SYCL_SwizzledVecType : SYCL_Type<"SwizzledVec", "swizzled_vec"> {
                         ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `[` $vecType `,` $indexes `]` `,` `(` $body `)` `>`";
 }
-
-def SYCL_TupleCopyAssignableValueHolderType
-    : SYCL_Type<"TupleCopyAssignableValueHolder", "tuple_copy_assignable_value_holder",
-        [SYCLInheritanceTypeTrait<"TupleValueHolderType">]> {
-  let parameters = (ins "::mlir::Type":$dataType,
-                        "bool":$isTriviallyCopyAssignable,
-                        ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<` `[` $dataType `,` $isTriviallyCopyAssignable `]` `,` `(` $body `)` `>`";
-}
-
-def SYCL_TupleValueHolderType : SYCL_Type<"TupleValueHolder", "tuple_value_holder"> {
-  let parameters = (ins "::mlir::Type":$dataType,
-                        ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<` `[` $dataType `]` `,` `(` $body `)` `>`";
-}
-
 def SYCL_VecType : SYCL_Type<"Vec", "vec"> {
   let parameters = (ins "::mlir::Type":$dataType,
                         "int":$numElements,
@@ -362,8 +325,6 @@ def AccessorMemRef : MemRefOf<[SYCL_AccessorType]>;
 def AccessorSubscriptMemRef : MemRefOf<[SYCL_AccessorSubscriptType]>;
 def ArrayMemRef : MemRefOf<[SYCL_ArrayType]>;
 def AtomicMemRef : MemRefOf<[SYCL_AtomicType]>;
-def GetOpMemRef : MemRefOf<[SYCL_GetOpType]>;
-def GetScalarOpMemRef : MemRefOf<[SYCL_GetScalarOpType]>;
 def GroupMemRef : MemRefOf<[SYCL_GroupType]>;
 def IDMemRef : MemRefOf<[SYCL_IDType]>;
 def ItemBaseMemRef : MemRefOf<[SYCL_ItemBaseType]>;
@@ -391,8 +352,6 @@ def SYCLMemref : AnyTypeOf<[
   AccessorSubscriptMemRef,
   ArrayMemRef,
   AtomicMemRef,
-  GetOpMemRef,
-  GetScalarOpMemRef,
   GroupMemRef,  
   IDMemRef,
   ItemBaseMemRef,

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -148,39 +148,12 @@ static Optional<Type> convertArrayType(sycl::ArrayType type,
   return structTy;
 }
 
-/// Converts SYCL AssertHappened type to LLVM type.
-static Optional<Type> convertAssertHappenedType(sycl::AssertHappenedType type,
-                                                LLVMTypeConverter &converter) {
-  return convertBodyType("struct.sycl::_V1::detail::AssertHappened",
-                         type.getBody(), converter);
-}
-
 /// Converts SYCL atomic type to LLVM type.
 static Optional<Type> convertAtomicType(sycl::AtomicType type,
                                         LLVMTypeConverter &converter) {
   // FIXME: Make sure that we have llvm.ptr as the body, not memref, through
   // the conversion done in ConvertTOLLVMABI pass
   return convertBodyType("class.sycl::_V1::atomic", type.getBody(), converter);
-}
-
-/// Converts SYCL bfloat16 type to LLVM type.
-static Optional<Type> convertBFloat16Type(sycl::BFloat16Type type,
-                                          LLVMTypeConverter &converter) {
-  return convertBodyType("class.sycl::_V1::ext::oneapi::bfloat16",
-                         type.getBody(), converter);
-}
-
-/// Converts SYCL GetOp type to LLVM type.
-static Optional<Type> convertGetOpType(sycl::GetOpType type,
-                                       LLVMTypeConverter &converter) {
-  return getI8Struct("class.sycl::_V1::detail::GetOp", converter);
-}
-
-/// Converts SYCL GetScalarOp type to LLVM type.
-static Optional<Type> convertGetScalarOpType(sycl::GetScalarOpType type,
-                                             LLVMTypeConverter &converter) {
-  return convertBodyType("class.sycl::_V1::detail::GetScalarOp", type.getBody(),
-                         converter);
 }
 
 /// Converts SYCL group type to LLVM type.
@@ -327,24 +300,6 @@ static Optional<Type> convertSwizzledVecType(sycl::SwizzledVecType type,
   return convertBodyType("class.sycl::_V1::detail::SwizzleOp", type.getBody(),
                          converter);
 }
-
-/// Converts SYCL TupleCopyAssignableValueHolder type to LLVM type.
-static Optional<Type> convertTupleCopyAssignableValueHolderType(
-    sycl::TupleCopyAssignableValueHolderType type,
-    LLVMTypeConverter &converter) {
-  return convertBodyType(
-      "struct.sycl::_V1::detail::TupleCopyAssignableValueHolder",
-      type.getBody(), converter);
-}
-
-/// Converts SYCL TupleValueHolder type to LLVM type.
-static Optional<Type>
-convertTupleValueHolderType(sycl::TupleValueHolderType type,
-                            LLVMTypeConverter &converter) {
-  return convertBodyType("struct.sycl::_V1::detail::TupleValueHolder",
-                         type.getBody(), converter);
-}
-
 /// Converts SYCL vec type to LLVM type.
 static Optional<Type> convertVecType(sycl::VecType type,
                                      LLVMTypeConverter &converter) {
@@ -550,20 +505,8 @@ void mlir::sycl::populateSYCLToLLVMTypeConversion(
   typeConverter.addConversion([&](sycl::ArrayType type) {
     return convertArrayType(type, typeConverter);
   });
-  typeConverter.addConversion([&](sycl::AssertHappenedType type) {
-    return convertAssertHappenedType(type, typeConverter);
-  });
   typeConverter.addConversion([&](sycl::AtomicType type) {
     return convertAtomicType(type, typeConverter);
-  });
-  typeConverter.addConversion([&](sycl::BFloat16Type type) {
-    return convertBFloat16Type(type, typeConverter);
-  });
-  typeConverter.addConversion([&](sycl::GetOpType type) {
-    return convertGetOpType(type, typeConverter);
-  });
-  typeConverter.addConversion([&](sycl::GetScalarOpType type) {
-    return convertGetScalarOpType(type, typeConverter);
   });
   typeConverter.addConversion([&](sycl::GroupType type) {
     return convertGroupType(type, typeConverter);
@@ -620,13 +563,6 @@ void mlir::sycl::populateSYCLToLLVMTypeConversion(
   });
   typeConverter.addConversion([&](sycl::SwizzledVecType type) {
     return convertSwizzledVecType(type, typeConverter);
-  });
-  typeConverter.addConversion(
-      [&](sycl::TupleCopyAssignableValueHolderType type) {
-        return convertTupleCopyAssignableValueHolderType(type, typeConverter);
-      });
-  typeConverter.addConversion([&](sycl::TupleValueHolderType type) {
-    return convertTupleValueHolderType(type, typeConverter);
   });
   typeConverter.addConversion(
       [&](sycl::VecType type) { return convertVecType(type, typeConverter); });

--- a/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
@@ -60,10 +60,6 @@ bool SYCLCastOp::areCastCompatible(TypeRange Inputs, TypeRange Outputs) {
         return InputElemType
             .hasTrait<SYCLInheritanceTypeTrait<OwnerLessBaseType>::Trait>();
       })
-      .template Case<TupleValueHolderType>([&](auto) {
-        return InputElemType
-            .hasTrait<SYCLInheritanceTypeTrait<TupleValueHolderType>::Trait>();
-      })
       .Default(false);
 }
 

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
@@ -169,6 +169,11 @@ SYCLOpAsmInterface::getAlias(mlir::Type Type, llvm::raw_ostream &OS) const {
            << "_" << Ty.getType();
         return AliasResult::FinalAlias;
       })
+      .Case<mlir::sycl::MaximumType, mlir::sycl::MinimumType>([&](auto Ty) {
+        OS << "sycl_" << decltype(Ty)::getMnemonic() << "_" << Ty.getDataType()
+           << "_";
+        return AliasResult::FinalAlias;
+      })
       .Case<mlir::sycl::MultiPtrType>([&](auto Ty) {
         OS << "sycl_" << decltype(Ty)::getMnemonic() << "_" << Ty.getDataType()
            << "_" << mlir::sycl::accessAddressSpaceAsString(Ty.getAddrSpace())
@@ -180,11 +185,6 @@ SYCLOpAsmInterface::getAlias(mlir::Type Type, llvm::raw_ostream &OS) const {
         OS << "sycl_" << decltype(Ty)::getMnemonic() << "_"
            << VecTy.getDataType() << "_" << VecTy.getNumElements() << "_";
         return AliasResult::OverridableAlias;
-      })
-      .Case<mlir::sycl::MinimumType, mlir::sycl::MaximumType>([&](auto Ty) {
-        OS << "sycl_" << decltype(Ty)::getMnemonic() << "_" << Ty.getDataType()
-           << "_";
-        return AliasResult::FinalAlias;
       })
       .Case<mlir::sycl::VecType>([&](auto Ty) {
         OS << "sycl_" << decltype(Ty)::getMnemonic() << "_" << Ty.getDataType()

--- a/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOpsDialect.cpp
@@ -135,8 +135,7 @@ SYCLOpAsmInterface::getAlias(mlir::Type Type, llvm::raw_ostream &OS) const {
            << Ty.getCurrentDimension() << "_";
         return AliasResult::OverridableAlias;
       })
-      .Case<mlir::sycl::AssertHappenedType, mlir::sycl::BFloat16Type,
-            mlir::sycl::KernelHandlerType, mlir::sycl::StreamType>(
+      .Case<mlir::sycl::KernelHandlerType, mlir::sycl::StreamType>(
           [&](auto Ty) {
             OS << "sycl_" << decltype(Ty)::getMnemonic() << "_";
             return AliasResult::FinalAlias;
@@ -176,23 +175,16 @@ SYCLOpAsmInterface::getAlias(mlir::Type Type, llvm::raw_ostream &OS) const {
            << "_";
         return AliasResult::OverridableAlias;
       })
-      .Case<mlir::sycl::GetScalarOpType, mlir::sycl::MinimumType,
-            mlir::sycl::MaximumType, mlir::sycl::TupleValueHolderType>(
-          [&](auto Ty) {
-            OS << "sycl_" << decltype(Ty)::getMnemonic() << "_"
-               << Ty.getDataType() << "_";
-            return AliasResult::FinalAlias;
-          })
       .Case<mlir::sycl::SwizzledVecType>([&](auto Ty) {
         const auto VecTy = Ty.getVecType();
         OS << "sycl_" << decltype(Ty)::getMnemonic() << "_"
            << VecTy.getDataType() << "_" << VecTy.getNumElements() << "_";
         return AliasResult::OverridableAlias;
       })
-      .Case<mlir::sycl::TupleCopyAssignableValueHolderType>([&](auto Ty) {
+      .Case<mlir::sycl::MinimumType, mlir::sycl::MaximumType>([&](auto Ty) {
         OS << "sycl_" << decltype(Ty)::getMnemonic() << "_" << Ty.getDataType()
            << "_";
-        return AliasResult::OverridableAlias;
+        return AliasResult::FinalAlias;
       })
       .Case<mlir::sycl::VecType>([&](auto Ty) {
         OS << "sycl_" << decltype(Ty)::getMnemonic() << "_" << Ty.getDataType()

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
@@ -87,41 +87,10 @@ func.func @test_OwnerLessBase(%arg0: !sycl.owner_less_base) {
 
 // -----
 
-!sycl_assert_happened_ = !sycl.assert_happened<(i32, !llvm.array<257 x i8>, !llvm.array<257 x i8>, !llvm.array<129 x i8>, i32, i64, i64, i64, i64, i64, i64)>
-// CHECK: llvm.func @test_assert_happened(%arg0: !llvm.[[ASSERT_HAPPENED:struct<"struct.sycl::_V1::detail::AssertHappened", \(i32, array<257 x i8>, array<257 x i8>, array<129 x i8>, i32, i64, i64, i64, i64, i64, i64\)>]]) {
-func.func @test_assert_happened(%arg0: !sycl_assert_happened_) {
-  return
-}
-
-// -----
-
 !sycl_atomic_i32_1_ = !sycl.atomic<[i32,1], (memref<?xi32, 1>)>
 !sycl_atomic_f32_3_ = !sycl.atomic<[f32,3], (memref<?xf32, 3>)>
 // CHECK: llvm.func @test_atomic(%arg0: !llvm.[[ATOMIC1:struct<"class.sycl::_V1::atomic", \(struct<\(ptr<f32, 3>, ptr<f32, 3>, i64, array<1 x i64>, array<1 x i64>\)>\)>]], %arg1: !llvm.[[ATOMIC1:struct<"class.sycl::_V1::atomic.1", \(struct<\(ptr<i32, 1>, ptr<i32, 1>, i64, array<1 x i64>, array<1 x i64>\)>\)>]]) {
 func.func @test_atomic(%arg0: !sycl_atomic_f32_3_, %arg1: !sycl_atomic_i32_1_) {
-  return
-}
-
-// -----
-
-!sycl_bfloat16_ = !sycl.bfloat16<(i16)>
-// CHECK: llvm.func @test_bfloat16(%arg0: !llvm.[[BFLOAT16:struct<"class.sycl::_V1::ext::oneapi::bfloat16", \(i16\)>]]) {
-func.func @test_bfloat16(%arg0: !sycl_bfloat16_) {
-  return
-}
-
-// -----
-
-!sycl_get_scalar_op_i32_ = !sycl.get_scalar_op<[i32], (i32)>
-// CHECK: llvm.func @test_get_scalar_op(%arg0: !llvm.[[GET_SCALAR_OP:struct<"class.sycl::_V1::detail::GetScalarOp.*", \(i32\)>]])
-func.func @test_get_scalar_op(%arg0: !sycl_get_scalar_op_i32_) {
-  return
-}
-
-// -----
-
-// CHECK: llvm.func @test_get_op(%arg0: !llvm.[[GET_OP:struct<"class.sycl::_V1::detail::GetOp", \(i8\)>]])
-func.func @test_get_op(%arg0: !sycl.get_op<i32>) {
   return
 }
 
@@ -252,20 +221,6 @@ func.func @test_sub_group(%arg0: !sycl.sub_group) {
 func.func @test_stream(%arg0: !sycl_stream_) {
     return
 }
-
-// -----
-
-!sycl_tuple_value_holder_i32_ = !sycl.tuple_value_holder<[i32], (i32)>
-!sycl_tuple_copy_assignable_value_holder_i32_ = !sycl.tuple_copy_assignable_value_holder<[i32, true], (!sycl.tuple_value_holder<[i32], (i32)>)>
-// CHECK: llvm.func @test_tuple_value_holder(%arg0: !llvm.[[TUPLE_VALUE_HOLDER:struct<"struct.sycl::_V1::detail::TupleValueHolder", \(i32\)>]]) {
-func.func @test_tuple_value_holder(%arg0: !sycl_tuple_value_holder_i32_) {
-  return
-}
-// CHECK: llvm.func @test_tuple_copy_assignable_value_holder(%arg0: !llvm.[[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER:struct<"struct.sycl::_V1::detail::TupleCopyAssignableValueHolder", \(]][[TUPLE_VALUE_HOLDER]][[SUFFIX]]) {
-func.func @test_tuple_copy_assignable_value_holder(%arg0: !sycl_tuple_copy_assignable_value_holder_i32_) {
-  return
-}
-
 // -----
 
 !sycl_vec_f32_4_ = !sycl.vec<[f32, 4], (vector<4xf32>)>
@@ -273,8 +228,8 @@ func.func @test_tuple_copy_assignable_value_holder(%arg0: !sycl_tuple_copy_assig
 func.func @test_vec(%arg0: !sycl_vec_f32_4_) {
   return
 }
-!sycl_swizzled_vec_f32_4_ = !sycl.swizzled_vec<[!sycl_vec_f32_4_, 0, 2], (memref<?x!sycl_vec_f32_4_, 4>, !sycl.get_op<i8>, !sycl.get_op<i8>)>
-// CHECK: llvm.func @test_swizzled_vec(%arg0: !llvm.[[SWIZZLED_VEC:struct<"class.sycl::_V1::detail::SwizzleOp"]], (struct<(ptr<[[VEC]], 4>, ptr<[[VEC]], 4>, i64, array<1 x i64>, array<1 x i64>)>, [[GET_OP]], [[GET_OP]][[SUFFIX]]) {
+!sycl_swizzled_vec_f32_4_ = !sycl.swizzled_vec<[!sycl_vec_f32_4_, 0, 2], (memref<?x!sycl_vec_f32_4_, 4>, !llvm.struct<(i8)>, !llvm.struct<(i8)>)>
+// CHECK: llvm.func @test_swizzled_vec(%arg0: !llvm.[[SWIZZLED_VEC:struct<"class.sycl::_V1::detail::SwizzleOp"]], (struct<(ptr<[[VEC]], 4>, ptr<[[VEC]], 4>, i64, array<1 x i64>, array<1 x i64>)>, [[GET_OP:struct<\(i8\)>]], [[GET_OP]][[SUFFIX]]) {
 func.func @test_swizzled_vec(%arg0: !sycl_swizzled_vec_f32_4_) {
   return
 }

--- a/mlir-sycl/test/Dialect/IR/SYCL/types.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/types.mlir
@@ -167,26 +167,6 @@ func.func @_Z7group_2N2cl4sycl5groupILi2EEE(%arg0: !sycl_group_2_) attributes {l
 // -----
 
 ////////////////////////////////////////////////////////////////////////////////
-// GET_OP
-////////////////////////////////////////////////////////////////////////////////
-
-// CHECK: func @get_op(%arg0: !sycl.get_op<i32>)
-func.func @get_op(%arg0: !sycl.get_op<i32>) attributes {llvm.linkage = #llvm.linkage<external>} {
-  return
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// GET_SCALAR_OP
-////////////////////////////////////////////////////////////////////////////////
-
-!sycl_get_scalar_op_i32_ = !sycl.get_scalar_op<[i32], (i32)>
-
-// CHECK: func @get_scalar_op(%arg0: !sycl_get_scalar_op_i32_)
-func.func @get_scalar_op(%arg0: !sycl_get_scalar_op_i32_) attributes {llvm.linkage = #llvm.linkage<external>} {
-  return
-}
-
-////////////////////////////////////////////////////////////////////////////////
 // VEC
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -206,8 +186,8 @@ func.func @vec_1(%arg0: !sycl_vec_f32_4_) attributes {llvm.linkage = #llvm.linka
 // SWIZZLED_VEC
 ////////////////////////////////////////////////////////////////////////////////
 
-!sycl_swizzled_vec_i32_2_ = !sycl.swizzled_vec<[!sycl_vec_i32_2_, 0, 1], (memref<?x!sycl_vec_i32_2_, 4>, !sycl.get_op<i8>, !sycl.get_op<i8>)>
-!sycl_swizzled_vec_i32_2_1 = !sycl.swizzled_vec<[!sycl_vec_i32_2_, 0, 1], (memref<?x!sycl_vec_i32_2_, 4>, !sycl_swizzled_vec_i32_2_, !sycl_get_scalar_op_i32_)>
+!sycl_swizzled_vec_i32_2_ = !sycl.swizzled_vec<[!sycl_vec_i32_2_, 0, 1], (memref<?x!sycl_vec_i32_2_, 4>, !llvm.struct<(i8)>, !llvm.struct<(i8)>)>
+!sycl_swizzled_vec_i32_2_1 = !sycl.swizzled_vec<[!sycl_vec_i32_2_, 0, 1], (memref<?x!sycl_vec_i32_2_, 4>, !sycl_swizzled_vec_i32_2_, !llvm.struct<(i32)>)>
 
 // CHECK: func @swizzled_vec_0(%arg0: !sycl_swizzled_vec_i32_2_)
 func.func @swizzled_vec_0(%arg0: !sycl_swizzled_vec_i32_2_) attributes {llvm.linkage = #llvm.linkage<external>} {

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1371,21 +1371,16 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
       const auto TypeName = RD->getName();
       if (TypeName == "accessor" || TypeName == "accessor_common" ||
           TypeName == "AccessorImplDevice" || TypeName == "AccessorSubscript" ||
-          TypeName == "array" || TypeName == "AssertHappened" ||
-          TypeName == "atomic" || TypeName == "bfloat16" ||
-          TypeName == "GetOp" || TypeName == "GetScalarOp" ||
-          TypeName == "group" || TypeName == "h_item" || TypeName == "id" ||
-          TypeName == "item" || TypeName == "ItemBase" ||
-          TypeName == "kernel_handler" ||
+          TypeName == "array" || TypeName == "atomic" || TypeName == "group" ||
+          TypeName == "h_item" || TypeName == "id" || TypeName == "item" ||
+          TypeName == "ItemBase" || TypeName == "kernel_handler" ||
           TypeName == "LocalAccessorBaseDevice" ||
           TypeName == "local_accessor_base" || TypeName == "local_accessor" ||
           TypeName == "maximum" || TypeName == "minimum" ||
           TypeName == "multi_ptr" || TypeName == "nd_item" ||
           TypeName == "nd_range" || TypeName == "OwnerLessBase" ||
-          TypeName == "range" || TypeName == "stream" ||
-          TypeName == "sub_group" || TypeName == "SwizzleOp" ||
-          TypeName == "TupleCopyAssignableValueHolder" ||
-          TypeName == "TupleValueHolder" || TypeName == "vec")
+          TypeName == "range" || TypeName == "SwizzleOp" ||
+          TypeName == "stream" || TypeName == "sub_group" || TypeName == "vec")
         return getSYCLType(RT, *this);
 
       assert((AllowUndefinedSYCLTypes ||

--- a/polygeist/tools/cgeist/Lib/TypeUtils.cc
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.cc
@@ -106,12 +106,8 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
     AccessorImplDevice,
     Accessor,
     AccessorSubscript,
-    AssertHappened,
     Array,
     Atomic,
-    BFloat16,
-    GetScalarOp,
-    GetOp,
     Group,
     HItem,
     ID,
@@ -131,8 +127,6 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
     Stream,
     SubGroup,
     SwizzleOp,
-    TupleCopyAssignableValueHolder,
-    TupleValueHolder,
     Vec
   };
 
@@ -142,12 +136,8 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
       {"AccessorImplDevice", TypeEnum::AccessorImplDevice},
       {"accessor", TypeEnum::Accessor},
       {"AccessorSubscript", TypeEnum::AccessorSubscript},
-      {"AssertHappened", AssertHappened},
       {"array", TypeEnum::Array},
       {"atomic", TypeEnum::Atomic},
-      {"bfloat16", BFloat16},
-      {"GetScalarOp", TypeEnum::GetScalarOp},
-      {"GetOp", TypeEnum::GetOp},
       {"group", TypeEnum::Group},
       {"h_item", TypeEnum::HItem},
       {"id", TypeEnum::ID},
@@ -167,8 +157,6 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
       {"stream", TypeEnum::Stream},
       {"sub_group", SubGroup},
       {"SwizzleOp", SwizzleOp},
-      {"TupleCopyAssignableValueHolder", TupleCopyAssignableValueHolder},
-      {"TupleValueHolder", TypeEnum::TupleValueHolder},
       {"vec", TypeEnum::Vec},
   };
 
@@ -233,17 +221,6 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
       return mlir::sycl::AtomicType::get(
           CGT.getModule()->getContext(), Type,
           static_cast<mlir::sycl::AccessAddrSpace>(AddrSpace), Body);
-    }
-    case TypeEnum::GetOp: {
-      const auto Type =
-          CGT.getMLIRTypeForMem(CTS->getTemplateArgs().get(0).getAsType());
-      return mlir::sycl::GetOpType::get(CGT.getModule()->getContext(), Type);
-    }
-    case TypeEnum::GetScalarOp: {
-      const auto Type =
-          CGT.getMLIRTypeForMem(CTS->getTemplateArgs().get(0).getAsType());
-      return mlir::sycl::GetScalarOpType::get(CGT.getModule()->getContext(),
-                                              Type, Body);
     }
     case TypeEnum::Group: {
       const auto Dim =
@@ -347,21 +324,6 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
       return mlir::sycl::RangeType::get(CGT.getModule()->getContext(), Dim,
                                         Body);
     }
-    case TypeEnum::TupleCopyAssignableValueHolder: {
-      const auto Type =
-          CGT.getMLIRTypeForMem(CTS->getTemplateArgs().get(0).getAsType());
-      const auto IsTriviallyCopyAssignable =
-          CTS->getTemplateArgs().get(1).getAsIntegral().getExtValue();
-      Body.push_back(CGT.getMLIRTypeForMem(CTS->bases_begin()->getType()));
-      return mlir::sycl::TupleCopyAssignableValueHolderType::get(
-          CGT.getModule()->getContext(), Type, IsTriviallyCopyAssignable, Body);
-    }
-    case TypeEnum::TupleValueHolder: {
-      const auto Type =
-          CGT.getMLIRTypeForMem(CTS->getTemplateArgs().get(0).getAsType());
-      return mlir::sycl::TupleValueHolderType::get(
-          CGT.getModule()->getContext(), Type, Body);
-    }
     case TypeEnum::Vec: {
       const auto ElemType =
           CGT.getMLIRTypeForMem(CTS->getTemplateArgs().get(0).getAsType());
@@ -392,11 +354,6 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
   if (const auto *CXXRD = llvm::dyn_cast<clang::CXXRecordDecl>(RD)) {
     switch (StrToTypeEnum[CXXRD->getName().str()]) {
     // Keep in alphabetical order.
-    case TypeEnum::AssertHappened:
-      return mlir::sycl::AssertHappenedType::get(CGT.getModule()->getContext(),
-                                                 Body);
-    case TypeEnum::BFloat16:
-      return mlir::sycl::BFloat16Type::get(CGT.getModule()->getContext(), Body);
     case TypeEnum::KernelHandler:
       return mlir::sycl::KernelHandlerType::get(CGT.getModule()->getContext(),
                                                 Body);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1282,28 +1282,27 @@ ValueCategory MLIRScanner::CommonFieldLookup(clang::QualType CT,
                                                    getConstantIndex(FNum));
   } else if (sycl::isSYCLType(MT.getElementType())) {
     Type ElemTy = MT.getElementType();
-    Result =
-        TypeSwitch<Type, Value>(ElemTy)
-            .Case<sycl::ArrayType>([&](sycl::ArrayType AT) {
-              assert(FNum < AT.getBody().size() && "ERROR");
-              const auto ElemType = AT.getBody()[FNum].cast<MemRefType>();
-              const auto ResultType = MemRefType::get(
-                  ElemType.getShape(), ElemType.getElementType(),
-                  MemRefLayoutAttrInterface(), MT.getMemorySpace());
-              return Builder.create<polygeist::SubIndexOp>(
-                  Loc, ResultType, Val, getConstantIndex(FNum));
-            })
-            .Case<sycl::AccessorType, sycl::AccessorImplDeviceType,
-                  sycl::AccessorSubscriptType, sycl::AtomicType,
-                  sycl::GetScalarOpType, sycl::GroupType, sycl::ItemBaseType,
-                  sycl::ItemType, sycl::LocalAccessorBaseDeviceType,
-                  sycl::LocalAccessorBaseType, sycl::LocalAccessorType,
-                  sycl::MultiPtrType, sycl::NdItemType, sycl::NdRangeType,
-                  sycl::StreamType, sycl::SwizzledVecType, sycl::VecType>(
-                [&](auto ElemTy) {
-                  return SYCLCommonFieldLookup<decltype(ElemTy)>(Val, FNum,
-                                                                 Shape);
-                });
+    Result = TypeSwitch<Type, Value>(ElemTy)
+                 .Case<sycl::ArrayType>([&](sycl::ArrayType AT) {
+                   assert(FNum < AT.getBody().size() && "ERROR");
+                   const auto ElemType = AT.getBody()[FNum].cast<MemRefType>();
+                   const auto ResultType = MemRefType::get(
+                       ElemType.getShape(), ElemType.getElementType(),
+                       MemRefLayoutAttrInterface(), MT.getMemorySpace());
+                   return Builder.create<polygeist::SubIndexOp>(
+                       Loc, ResultType, Val, getConstantIndex(FNum));
+                 })
+                 .Case<sycl::AccessorType, sycl::AccessorImplDeviceType,
+                       sycl::AccessorSubscriptType, sycl::AtomicType,
+                       sycl::GroupType, sycl::ItemBaseType, sycl::ItemType,
+                       sycl::LocalAccessorBaseDeviceType,
+                       sycl::LocalAccessorBaseType, sycl::LocalAccessorType,
+                       sycl::MultiPtrType, sycl::NdItemType, sycl::NdRangeType,
+                       sycl::StreamType, sycl::SwizzledVecType, sycl::VecType>(
+                     [&](auto ElemTy) {
+                       return SYCLCommonFieldLookup<decltype(ElemTy)>(Val, FNum,
+                                                                      Shape);
+                     });
   } else {
     auto MT0 =
         MemRefType::get(Shape, MT.getElementType(), MemRefLayoutAttrInterface(),

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -10,11 +10,8 @@
 // CHECK-DAG: !sycl_accessor_1_21sycl2Evec3C5Bi322C_45D2C_28vector3C4xi323E293E_rw_gb = !sycl.accessor<[1, !sycl_vec_i32_4_, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?x!sycl_vec_i32_4_, 1>)>)>
 // CHECK-DAG: !sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
 // CHECK-DAG: !sycl_array_2_ = !sycl.array<[2], (memref<2xi64, 4>)>
-// CHECK-DAG: !sycl_assert_happened_ = !sycl.assert_happened<(i32, !llvm.array<257 x i8>, !llvm.array<257 x i8>, !llvm.array<129 x i8>, i32, i64, i64, i64, i64, i64, i64)>
 // CHECK-DAG: !sycl_atomic_f32_3_ = !sycl.atomic<[f32, 3], (memref<?xf32, 3>)>
 // CHECK-DAG: !sycl_atomic_i32_1_ = !sycl.atomic<[i32, 1], (memref<?xi32, 1>)>
-// CHECK-DAG: !sycl_bfloat16_ = !sycl.bfloat16<(i16)>
-// CHECK-DAG: !sycl_get_scalar_op_i32_ = !sycl.get_scalar_op<[i32], (i32)>
 // CHECK-DAG: !sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 // CHECK-DAG: !sycl_group_2_ = !sycl.group<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
 // CHECK-DAG: !sycl_h_item_1_ = !sycl.h_item<[1], (![[ITEM_1_F:.*]], ![[ITEM_1_F]], ![[ITEM_1_F]])>
@@ -40,10 +37,7 @@
 // CHECK-DAG: !sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 // CHECK-DAG: !sycl_nd_range_2_ = !sycl.nd_range<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
 // CHECK-DAG: !sycl_stream_ = !sycl.stream<(!llvm.array<16 x i8>, !sycl_accessor_1_i8_rw_gb, !sycl_accessor_1_i32_ato_gb, !sycl_accessor_1_i8_rw_gb, i32, i64, i32, i32, i32, i32)>
-// CHECK-DAG: !sycl_swizzled_vec_f32_8_ = !sycl.swizzled_vec<[!sycl_vec_f32_8_, 0, 1, 2], (memref<?x!sycl_vec_f32_8_, 4>, !sycl.get_op<f32>, !sycl.get_op<f32>)>
-// CHECK-DAG: ![[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_TRUE:.*]] = !sycl.tuple_copy_assignable_value_holder<[i32, true], (!sycl_tuple_value_holder_i32_)>
-// CHECK-DAG: ![[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_FALSE:.*]] = !sycl.tuple_copy_assignable_value_holder<[i32, false], (!sycl_tuple_value_holder_i32_)>
-// CHECK-DAG: !sycl_tuple_value_holder_i32_ = !sycl.tuple_value_holder<[i32], (i32)>
+// CHECK-DAG: !sycl_swizzled_vec_f32_8_ = !sycl.swizzled_vec<[!sycl_vec_f32_8_, 0, 1, 2], (memref<?x!sycl_vec_f32_8_, 4>, !llvm.struct<(i8)>, !llvm.struct<(i8)>)>
 // CHECK-DAG: !sycl_vec_f32_8_ = !sycl.vec<[f32, 8], (vector<8xf32>)>
 // CHECK-DAG: !sycl_vec_i32_4_ = !sycl.vec<[i32, 4], (vector<4xi32>)>
 
@@ -74,12 +68,6 @@ SYCL_EXTERNAL void accessor_4(sycl::accessor<sycl::cl_int, 1, sycl::access::mode
 // CHECK-SAME:  attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
 SYCL_EXTERNAL void accessor_5(sycl::accessor<sycl::vec<int, 4>, 1, sycl::access::mode::read_write, sycl::access::target::global_buffer>) {}
 
-// %"struct.sycl::_V1::detail::AssertHappened" = type { i32, [257 x i8], [257 x i8], [129 x i8], i32, i64, i64, i64, i64, i64, i64 }
-// CHECK-LABEL: func.func @_Z15assert_happenedN4sycl3_V16detail14AssertHappenedE(
-// CHECK:          %arg0: memref<?x!sycl_assert_happened_> {llvm.align = 8 : i64, llvm.byval = !sycl_assert_happened_, llvm.noundef})
-// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void assert_happened(sycl::detail::AssertHappened assert_happened) {}
-
 // CHECK-LABEL: func.func @_Z5arr_1N4sycl3_V16detail5arrayILi1EEE(
 // CHECK:          %arg0: memref<?x!sycl_array_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_array_1_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
@@ -99,21 +87,6 @@ SYCL_EXTERNAL void atomic_1(sycl::atomic<int> atomic_int) {}
 // CHECK:          %arg0: memref<?x!sycl_atomic_f32_3_> {llvm.align = 8 : i64, llvm.byval = !sycl_atomic_f32_3_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
 SYCL_EXTERNAL void atomic_2(sycl::atomic<float, sycl::access::address_space::local_space> atomic_float) {}
-
-// CHECK-LABEL: func.func @_Z8bfloat16N4sycl3_V13ext6oneapi8bfloat16E(
-// CHECK:          %arg0: memref<?x!sycl_bfloat16_> {llvm.align = 2 : i64, llvm.byval = !sycl_bfloat16_, llvm.noundef})
-// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void bfloat16(sycl::ext::oneapi::bfloat16 bfloat16) {}
-
-// CHECK-LABEL: func.func @_Z6get_opN4sycl3_V16detail5GetOpIiEE(
-// CHECK:          %arg0: memref<?x!sycl.get_op<i32>> {llvm.align = 1 : i64, llvm.byval = !sycl.get_op<i32>, llvm.noundef})
-// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void get_op(sycl::detail::GetOp<int> get_op) {}
-
-// CHECK-LABEL: func.func @_Z13get_scalar_opN4sycl3_V16detail11GetScalarOpIiEE(
-// CHECK:          %arg0: memref<?x!sycl_get_scalar_op_i32_> {llvm.align = 4 : i64, llvm.byval = !sycl_get_scalar_op_i32_, llvm.noundef})
-// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void get_scalar_op(sycl::detail::GetScalarOp<int> get_scalar_op) {}
 
 // CHECK-LABEL: func.func @_Z15owner_less_baseN4sycl3_V16detail13OwnerLessBaseINS0_8accessorIiLi1ELNS0_6access4modeE1026ELNS4_6targetE2014ELNS4_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEEE(
 // CHECK:          %arg0: memref<?x!sycl.owner_less_base> {llvm.align = 1 : i64, llvm.byval = !sycl.owner_less_base, llvm.noundef})
@@ -234,22 +207,6 @@ SYCL_EXTERNAL void sub_group(sycl::ext::oneapi::sub_group sub_group) {}
 // CHECK-SAME:    %arg0: memref<?x!sycl_swizzled_vec_f32_8_> {llvm.noundef})
 // CHECK-SAME:  attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
 SYCL_EXTERNAL void swizzled_vec(sycl::detail::SwizzleOp<sycl::float8, sycl::detail::GetOp<float>, sycl::detail::GetOp<float>, sycl::detail::GetOp, 0, 1, 2> swizzle) {}
-
-// CHECK-LABEL: func.func @_Z36tuple_copy_assignable_value_holder_1N4sycl3_V16detail30TupleCopyAssignableValueHolderIiLb1EEE(
-// CHECK:          %arg0: memref<?x![[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_TRUE]]> {llvm.align = 4 : i64, llvm.byval = ![[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_TRUE]], llvm.noundef})
-// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void tuple_copy_assignable_value_holder_1(sycl::detail::TupleCopyAssignableValueHolder<int, true> tuple_copy_assignable_value_holder_true) {}
-
-// CHECK-LABEL: func.func @_Z36tuple_copy_assignable_value_holder_2N4sycl3_V16detail30TupleCopyAssignableValueHolderIiLb0EEE(
-// CHECK:          %arg0: memref<?x![[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_FALSE]]> {llvm.align = 4 : i64, llvm.byval = ![[TUPLE_COPY_ASSIGNABLE_VALUE_HOLDER_FALSE]], llvm.noundef})
-// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void tuple_copy_assignable_value_holder_2(sycl::detail::TupleCopyAssignableValueHolder<int, false> tuple_copy_assignable_value_holder_false) {}
-
-// CHECK-LABEL: func.func @_Z18tuple_value_holderN4sycl3_V16detail16TupleValueHolderIiEE(
-// CHECK:          %arg0: memref<?x!sycl_tuple_value_holder_i32_> {llvm.align = 4 : i64, llvm.byval = !sycl_tuple_value_holder_i32_, llvm.noundef})
-// CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void tuple_value_holder(sycl::detail::TupleValueHolder<int> tuple_value_holder) {}
-
 // CHECK-LABEL: func.func @_Z5vec_1N4sycl3_V13vecIiLi4EEE(
 // CHECK-SAME:    %arg0: memref<?x!sycl_vec_i32_4_> {llvm.align = 16 : i64, llvm.byval = !sycl_vec_i32_4_, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]


### PR DESCRIPTION
Drop types that:

1. Are not defined in the SYCL spec;
2. Are not bases of other types.

Dropped types are:

- AssertHappened;
- BFloat16;
- GetOp;
- GetScalarOp;
- TupleCopyAssignableValueHolder;
- TupleValueHolder.