### PR TITLE
[SYCL] Move common reqd_work_group_size checks to a common function

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -11197,6 +11197,10 @@ public:
                                          MutableArrayRef<Expr *> Args);
   void AddSYCLReqdWorkGroupSizeAttr(Decl *D, const AttributeCommonInfo &CI,
                                     Expr *XDim, Expr *YDim, Expr *ZDim);
+  bool CheckReqdWorkGroupSizeCommonConflict(const Decl *D,
+                                            const AttributeCommonInfo &CI,
+                                            const Expr *XDim, const Expr *YDim,
+                                            const Expr *ZDim);
   SYCLReqdWorkGroupSizeAttr *
   MergeSYCLReqdWorkGroupSizeAttr(Decl *D, const SYCLReqdWorkGroupSizeAttr &A);
 


### PR DESCRIPTION
The recent rework of SYCL and non-SYCL paths for reqd_work_group_size made conflict checking with other intel-specific attributes unique to the SYCL path. In some cases OpenCL may use these too, so this commit moves these checks into a common method to be used by both paths.