### PR TITLE
[SYCL] Use rpath on SYCL library to find plugins

### DIFF
--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -26,6 +26,11 @@ function(add_sycl_rt_library LIB_NAME LIB_OBJ_NAME)
               $<TARGET_OBJECTS:${LIB_OBJ_NAME}>
               ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
 
+  # Setup install rpath on the SYCL library, this is helpful on some platforms
+  # to find the plugin shared libraries. Using the llvm helper function will
+  # give it the same rpath setup as clang++.
+  llvm_setup_rpath(${LIB_NAME})
+
   # Unlike for sycl library, for LLVMSupport we have only one version for a given build,
   # so, we link LLVMSupport lib to matching sycl version only.
   if (SYCL_ENABLE_STACK_PRINTING)

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -420,15 +420,12 @@ static void initializePlugins(std::vector<plugin> &Plugins) {
     std::cerr << "SYCL_PI_TRACE[all]: "
               << "No Plugins Found." << std::endl;
 
-  const std::string LibSYCLDir =
-      sycl::detail::OSUtil::getCurrentDSODir() + sycl::detail::OSUtil::DirSep;
-
   for (unsigned int I = 0; I < PluginNames.size(); I++) {
     std::shared_ptr<PiPlugin> PluginInformation = std::make_shared<PiPlugin>(
         PiPlugin{_PI_H_VERSION_STRING, _PI_H_VERSION_STRING,
                  /*Targets=*/nullptr, /*FunctionPointers=*/{}});
 
-    void *Library = loadPlugin(LibSYCLDir + PluginNames[I].first);
+    void *Library = loadPlugin(PluginNames[I].first);
 
     if (!Library) {
       if (trace(PI_TRACE_ALL)) {


### PR DESCRIPTION
This patch reworks the plugin loading from looking up the plugin libraries using an absolute path, to using an `rpath` on the SYCL library, so it essentially reverts the following:

* https://github.com/intel/llvm/pull/6658

And instead sets a `rpath` on `libsycl.so` to help it find the in-tree plugin libraries, additionally with this `rpath` we could also revert https://github.com/intel/llvm/pull/8105 and go back to having the fusion library as a separate shared library.

To set  `rpath` I've used the LLVM CMake machinery `llvm_setup_rpath`, which will correctly set it for various platforms, and currently it will set it to be identical to the one that is already set on `clang++` in existing builds and packages: `$ORIGIN/../lib`, this is a little redundant for `libsycl.so` and `$ORIGIN` would suffice but it will resolve to the same directory and allows us to just re-use the LLVM setup. `$ORIGIN` resolves to the directory containing the binary.

I believe this is a more standard way of handling the issue of `libsycl.so` finding the plugin libraries, and it is also better in cases where plugins may be installed in a different directory from `libsycl.so` as it allows the regular linker rules to find these types of plugins. As mentioned in https://github.com/intel/llvm/pull/6658 it was technically possible to load plugins from other directories using `LD_PRELOAD`, but I believe this `rpath` option is preferable.