### PR TITLE
[SYCL] Fix sycl-post-link action output type for non-SPIRV

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5672,7 +5672,7 @@ class OffloadingActionBuilder final {
           // post link is not optional - even if not splitting, always need to
           // process specialization constants
           types::ID PostLinkOutType = isSPIR ? types::TY_Tempfiletable
-                                             : FullDeviceLinkAction->getType();
+                                          : types::TY_LLVM_BC;
           auto createPostLinkAction = [&]() {
             // For SPIR-V targets, force TY_Tempfiletable.
             auto TypedPostLinkAction = C.MakeAction<SYCLPostLinkJobAction>(

--- a/clang/test/Driver/sycl-hip-no-rdc.cpp
+++ b/clang/test/Driver/sycl-hip-no-rdc.cpp
@@ -1,0 +1,6 @@
+// Test for -fno-sycl-rdc with HIP to make sure sycl-post-link is marked as outputting ir
+
+// RUN: touch %t1.cpp
+// RUN: %clang -### -fsycl -fno-sycl-rdc -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx1031 --sysroot=%S/Inputs/SYCL %t1.cpp 2>&1 -ccc-print-phases | FileCheck %s
+
+// CHECK: sycl-post-link, {{{.*}}}, ir, (device-sycl, gfx1031)


### PR DESCRIPTION
With HIP, we use the output of clang-offload-bundler directly in target linking. Usually this is fine, because it becomes an input action for linking all device inputs together, and the link action has IR output type. However, for -fno-sycl-rdc we don't link the device code together, so the clang-offload-bundler action is a direct input to sycl-post-link. Since sycl-post-link previously copied the output type of the input action, we would end up with Object output type, which caused '-x object' to be pased to the HIP compiler, which is wrong. Instead, mark sycl-post-link as always outputting IR for non-SPIRV.

Closes: https://github.com/intel/llvm/issues/8364