### PR TITLE
[SYCL] Fix include loop and use-before-def

### DIFF
--- a/sycl/include/sycl/bit_cast.hpp
+++ b/sycl/include/sycl/bit_cast.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <sycl/detail/memcpy.hpp>
+
 #include <type_traits>
 
 #if __cpp_lib_bit_cast
@@ -16,11 +18,6 @@
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
-
-// forward decl
-namespace detail {
-inline void memcpy(void *Dst, const void *Src, std::size_t Size);
-}
 
 template <typename To, typename From>
 #if __cpp_lib_bit_cast || __has_builtin(__builtin_bit_cast)

--- a/sycl/include/sycl/detail/generic_type_lists.hpp
+++ b/sycl/include/sycl/detail/generic_type_lists.hpp
@@ -11,6 +11,7 @@
 #include <sycl/access/access.hpp>
 #include <sycl/detail/stl_type_traits.hpp>
 #include <sycl/detail/type_list.hpp>
+#include <sycl/half_type.hpp>
 
 #include <cstddef>
 
@@ -22,10 +23,6 @@ namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 template <typename T, int N> class vec;
 template <typename Type, std::size_t NumElements> class marray;
-namespace detail::half_impl {
-class half;
-} // namespace detail::half_impl
-using half = detail::half_impl::half;
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl
 

--- a/sycl/include/sycl/detail/helpers.hpp
+++ b/sycl/include/sycl/detail/helpers.hpp
@@ -13,6 +13,7 @@
 #include <sycl/access/access.hpp>
 #include <sycl/detail/common.hpp>
 #include <sycl/detail/export.hpp>
+#include <sycl/detail/memcpy.hpp>
 #include <sycl/detail/pi.hpp>
 #include <sycl/detail/type_traits.hpp>
 
@@ -35,13 +36,6 @@ template <typename Type, std::size_t NumElements> class marray;
 enum class memory_order;
 
 namespace detail {
-inline void memcpy(void *Dst, const void *Src, size_t Size) {
-  char *Destination = reinterpret_cast<char *>(Dst);
-  const char *Source = reinterpret_cast<const char *>(Src);
-  for (size_t I = 0; I < Size; ++I) {
-    Destination[I] = Source[I];
-  }
-}
 
 class context_impl;
 // The function returns list of events that can be passed to OpenCL API as

--- a/sycl/include/sycl/detail/memcpy.hpp
+++ b/sycl/include/sycl/detail/memcpy.hpp
@@ -1,0 +1,25 @@
+//==---------------- memcpy.hpp - SYCL memcpy --------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <cstddef>
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+namespace detail {
+inline void memcpy(void *Dst, const void *Src, size_t Size) {
+  char *Destination = reinterpret_cast<char *>(Dst);
+  const char *Source = reinterpret_cast<const char *>(Src);
+  for (size_t I = 0; I < Size; ++I) {
+    Destination[I] = Source[I];
+  }
+}
+} // namespace detail
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
+} // namespace sycl

--- a/sycl/include/sycl/detail/type_traits.hpp
+++ b/sycl/include/sycl/detail/type_traits.hpp
@@ -12,6 +12,7 @@
 #include <sycl/detail/generic_type_lists.hpp>
 #include <sycl/detail/stl_type_traits.hpp>
 #include <sycl/detail/type_list.hpp>
+#include <sycl/detail/vector_traits.hpp>
 
 #include <array>
 #include <tuple>
@@ -85,7 +86,6 @@ template <typename T, typename R>
 using copy_cv_qualifiers_t = typename copy_cv_qualifiers<T, R>::type;
 
 template <int V> using int_constant = std::integral_constant<int, V>;
-
 // vector_size
 // scalars are interpreted as a vector of 1 length.
 template <typename T> struct vector_size_impl : int_constant<1> {};
@@ -93,16 +93,6 @@ template <typename T, int N>
 struct vector_size_impl<vec<T, N>> : int_constant<N> {};
 template <typename T>
 struct vector_size : vector_size_impl<remove_cv_t<remove_reference_t<T>>> {};
-
-// 4.10.2.6 Memory layout and alignment
-template <typename T, int N>
-struct vector_alignment_impl
-    : conditional_t<N == 3, int_constant<sizeof(T) * 4>,
-                    int_constant<sizeof(T) * N>> {};
-
-template <typename T, int N>
-struct vector_alignment
-    : vector_alignment_impl<remove_cv_t<remove_reference_t<T>>, N> {};
 
 // vector_element
 template <typename T> struct vector_element_impl;

--- a/sycl/include/sycl/detail/vector_traits.hpp
+++ b/sycl/include/sycl/detail/vector_traits.hpp
@@ -1,0 +1,30 @@
+//==----------- vector_traits.hpp - SYCL vector size queries --------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <sycl/detail/stl_type_traits.hpp>
+
+#include <type_traits>
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+namespace detail {
+
+// 4.10.2.6 Memory layout and alignment
+template <typename T, int N>
+struct vector_alignment_impl
+    : conditional_t<N == 3, std::integral_constant<int, sizeof(T) * 4>,
+                    std::integral_constant<int, sizeof(T) * N>> {};
+
+template <typename T, int N>
+struct vector_alignment
+    : vector_alignment_impl<remove_cv_t<remove_reference_t<T>>, N> {};
+} // namespace detail
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
+} // namespace sycl

--- a/sycl/include/sycl/ext/intel/esimd.hpp
+++ b/sycl/include/sycl/ext/intel/esimd.hpp
@@ -79,6 +79,7 @@
 #pragma clang diagnostic ignored "-Wpsabi"
 #endif // !defined(__SYCL_DEVICE_ONLY__) && defined(__clang__)
 
+#include <sycl/detail/type_traits.hpp>
 #include <sycl/ext/intel/esimd/alt_ui.hpp>
 #include <sycl/ext/intel/esimd/common.hpp>
 #include <sycl/ext/intel/esimd/detail/bfloat16_type_traits.hpp>

--- a/sycl/include/sycl/half_type.hpp
+++ b/sycl/include/sycl/half_type.hpp
@@ -13,6 +13,7 @@
 #include <sycl/detail/defines.hpp>
 #include <sycl/detail/export.hpp>
 #include <sycl/detail/iostream_proxy.hpp>
+#include <sycl/detail/vector_traits.hpp>
 
 #include <functional>
 #include <limits>
@@ -253,19 +254,7 @@ using BIsRepresentationT = half;
 // as a kernel argument which is expected to be floating point number.
 template <int NumElements> struct half_vec {
   alignas(
-      // TODO This is copied verbatim from detail/type_traits.h to avoid a
-      // circular dependency because detail/type_traits.h includes
-      // sycl/half_type.h as it templates on sycl::half
-      std::conditional<
-          NumElements == 3,
-          std::integral_constant<
-              int, sizeof(std::remove_cv<
-                          std::remove_reference<StorageT>::type>::type) *
-                       4>,
-          std::integral_constant<
-              int, sizeof(std::remove_cv<
-                          std::remove_reference<StorageT>::type>::type) *
-                       NumElements>>::type::value) StorageT s[NumElements];
+      vector_alignment<StorageT, NumElements>::value) StorageT s[NumElements];
 
   __SYCL_CONSTEXPR_HALF half_vec() : s{0.0f} { initialize_data(); }
   constexpr void initialize_data() {

--- a/sycl/include/sycl/half_type.hpp
+++ b/sycl/include/sycl/half_type.hpp
@@ -9,10 +9,10 @@
 #pragma once
 
 #include <sycl/aspects.hpp>
+#include <sycl/bit_cast.hpp>
 #include <sycl/detail/defines.hpp>
 #include <sycl/detail/export.hpp>
 #include <sycl/detail/iostream_proxy.hpp>
-#include <sycl/detail/type_traits.hpp>
 
 #include <functional>
 #include <limits>
@@ -33,6 +33,10 @@
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
+namespace detail::half_impl {
+class half;
+}
+using half = detail::half_impl::half;
 
 namespace ext::intel::esimd::detail {
 class WrapperElementTypeProxy;
@@ -248,8 +252,20 @@ using BIsRepresentationT = half;
 // hood. As a result half values will be converted to the integer and passed
 // as a kernel argument which is expected to be floating point number.
 template <int NumElements> struct half_vec {
-  alignas(detail::vector_alignment<StorageT, NumElements>::value)
-      StorageT s[NumElements];
+  alignas(
+      // TODO This is copied verbatim from detail/type_traits.h to avoid a
+      // circular dependency because detail/type_traits.h includes
+      // sycl/half_type.h as it templates on sycl::half
+      std::conditional<
+          NumElements == 3,
+          std::integral_constant<
+              int, sizeof(std::remove_cv<
+                          std::remove_reference<StorageT>::type>::type) *
+                       4>,
+          std::integral_constant<
+              int, sizeof(std::remove_cv<
+                          std::remove_reference<StorageT>::type>::type) *
+                       NumElements>>::type::value) StorageT s[NumElements];
 
   __SYCL_CONSTEXPR_HALF half_vec() : s{0.0f} { initialize_data(); }
   constexpr void initialize_data() {


### PR DESCRIPTION
There are two issues present here that aren't obviously visible:
  1. The `sycl::half_type` alias isn't defined in sycl/half_type.hpp; it actually comes from detail/generic_type_lists.hpp seemingly accidentally.
  2. detail/type_traits.hpp transitively includes sycl/half_type.hpp as it has templates that use sycl::half. However, the half implementation itself needs type_traits.hpp for computing alignment. Depending on the order of headers included, this causes an unfulfillable declaration-before-use issue in client code. In doing so ESIMD was found to be guilty of not including all the correct headers.

There are many such transitive header issues lurking which keep the headers tightly coupled and the final preprocess very large. Until they are solved in a more general way I've had to introduce some copy-paste for the `vector_alignment` helper to avoid including type_traits.hpp inside half_type.hpp.

This patch is a prerequisite of the future complex_half group algorithms work ending up in a working order