### PR TITLE
[SYCL-MLIR]: Fix warnings

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -33,6 +33,7 @@ def SYCL_Dialect : Dialect {
   let name = "sycl";
   let cppNamespace = "::mlir::sycl";
   let useDefaultTypePrinterParser = 1;
+  let useFoldAPI = kEmitFoldAdaptorFolder;
   let extraClassDeclaration = [{
     MethodRegistry methods;
 

--- a/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistBase.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistBase.td
@@ -15,6 +15,7 @@ def Polygeist_Dialect : Dialect {
   let name = "polygeist";
   let cppNamespace = "::mlir::polygeist";
   let description = [{}];
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 #endif // POLYGEIST_BASE

--- a/polygeist/lib/Dialect/Polygeist/Transforms/Utils.h
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/Utils.h
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 namespace llvm {
-template <typename T> struct SmallVectorImpl;
+template <typename T> class SmallVectorImpl;
 } // namespace llvm
 
 namespace mlir {

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -111,15 +111,16 @@ static int executeCC1Tool(llvm::SmallVectorImpl<const char *> &ArgV) {
   llvm::StringSaver Saver(A);
   llvm::cl::ExpandResponseFiles(Saver, &llvm::cl::TokenizeGNUCommandLine, ArgV);
   llvm::StringRef Tool = ArgV[1];
-  void *GetExecutablePathVP = (void *)(intptr_t)GetExecutablePath;
+  void *GetExecutablePathVP =
+      reinterpret_cast<void *>(reinterpret_cast<intptr_t>(GetExecutablePath));
+  auto argv{llvm::ArrayRef(ArgV)};
+
   if (Tool == "-cc1")
-    return cc1_main(makeArrayRef(ArgV).slice(1), ArgV[0], GetExecutablePathVP);
+    return cc1_main(argv.slice(1), ArgV[0], GetExecutablePathVP);
   if (Tool == "-cc1as")
-    return cc1as_main(makeArrayRef(ArgV).slice(2), ArgV[0],
-                      GetExecutablePathVP);
+    return cc1as_main(argv.slice(2), ArgV[0], GetExecutablePathVP);
   if (Tool == "-cc1gen-reproducer")
-    return cc1gen_reproducer_main(makeArrayRef(ArgV).slice(2), ArgV[0],
-                                  GetExecutablePathVP);
+    return cc1gen_reproducer_main(argv.slice(2), ArgV[0], GetExecutablePathVP);
   // Reject unknown tools.
   llvm::errs() << "error: unknown integrated tool '" << Tool << "'. "
                << "Valid tools include '-cc1' and '-cc1as'.\n";
@@ -1076,7 +1077,7 @@ int main(int argc, char **argv) {
     for (int I = 0; I < argc; I++)
       Args.push_back(argv[I]);
 
-    llvm::ArrayRef<const char *> Argv = makeArrayRef(Args);
+    llvm::ArrayRef<const char *> Argv{llvm::ArrayRef(Args)};
     const llvm::opt::OptTable &OptTbl = clang::driver::getDriverOptTable();
     const unsigned IncludedFlagsBitmask = clang::driver::options::CC1AsOption;
     unsigned MissingArgIndex, MissingArgCount;


### PR DESCRIPTION
Fix the following issues in the SYCL-MLIR codebase:
  - adapt SYCL-MLIR and Polygeist dialects to MLIR improved `fold` method signature (https://discourse.llvm.org/t/psa-new-improved-fold-method-signature-has-landed-please-update-your-downstream-projects/67618)
  - warning: 'makeArrayRef<const char *, 6>' is deprecated: Use deduction guide instead (https://reviews.llvm.org/D140896)
  - fix some clang-tidy warnings
  