### PR TITLE
[SYCL-MLIR] Allow nested operations to be transformed

### DIFF
--- a/mlir/lib/Pass/Pass.cpp
+++ b/mlir/lib/Pass/Pass.cpp
@@ -718,20 +718,25 @@ void OpToOpPassAdaptor::runOnOperationAsyncImpl(bool verifyPasses) {
   // operation, as well as providing a queue of operations to execute over.
   std::vector<OpPMInfo> opInfos;
   DenseMap<OperationName, std::optional<unsigned>> knownOpPMIdx;
-  for (auto &region : getOperation()->getRegions()) {
-    for (Operation &op : region.getOps()) {
-      // Get the pass manager index for this operation type.
-      auto pmIdxIt = knownOpPMIdx.try_emplace(op.getName(), std::nullopt);
-      if (pmIdxIt.second) {
-        if (auto *mgr = findPassManagerFor(mgrs, op.getName(), *context))
-          pmIdxIt.first->second = std::distance(mgrs.begin(), mgr);
-      }
+  std::function<void(Operation &)> collectOpInfos = [&](Operation &regionOp) {
+    for (auto &region : regionOp.getRegions()) {
+      for (Operation &op : region.getOps()) {
+        // Get the pass manager index for this operation type.
+        auto pmIdxIt = knownOpPMIdx.try_emplace(op.getName(), std::nullopt);
+        if (pmIdxIt.second) {
+          if (auto *mgr = findPassManagerFor(mgrs, op.getName(), *context))
+            pmIdxIt.first->second = std::distance(mgrs.begin(), mgr);
+        }
 
-      // If this operation can be scheduled, add it to the list.
-      if (pmIdxIt.first->second)
-        opInfos.emplace_back(*pmIdxIt.first->second, &op, am.nest(&op));
+        // If this operation can be scheduled, add it to the list.
+        if (pmIdxIt.first->second)
+          opInfos.emplace_back(*pmIdxIt.first->second, &op, am.nest(&op));
+        else
+          collectOpInfos(op);
+      }
     }
-  }
+  };
+  collectOpInfos(*getOperation());
 
   // Get the current thread for this adaptor.
   PassInstrumentation::PipelineParentInfo parentInfo = {llvm::get_threadid(),

--- a/mlir/test/Pass/nested-operations.mlir
+++ b/mlir/test/Pass/nested-operations.mlir
@@ -1,0 +1,24 @@
+// RUN: mlir-opt -allow-unregistered-dialect %s -affine-scalrep | FileCheck %s
+
+// Affine scalar replacement pass is a func::FuncOp pass.
+// Ensure that simple_store_load function nested in gpu.module can be transformed by -affine-scalrep.
+
+gpu.module @functions {
+  // CHECK-LABEL: func @simple_store_load() {
+  func.func @simple_store_load() {
+    %cf7 = arith.constant 7.0 : f32
+    %m = memref.alloc() : memref<10xf32>
+    affine.for %i0 = 0 to 10 {
+      affine.store %cf7, %m[%i0] : memref<10xf32>
+      %v0 = affine.load %m[%i0] : memref<10xf32>
+      %v1 = arith.addf %v0, %v0 : f32
+    }
+    memref.dealloc %m : memref<10xf32>
+    return
+  // CHECK:       %[[C7:.*]] = arith.constant 7.000000e+00 : f32
+  // CHECK-NEXT:  affine.for %{{.*}} = 0 to 10 {
+  // CHECK-NEXT:    arith.addf %[[C7]], %[[C7]] : f32
+  // CHECK-NEXT:  }
+  // CHECK-NEXT:  return
+  }
+}


### PR DESCRIPTION
Allow transformations on `func::FuncOp` to work as expected when the `func::FuncOp` is nested in another region e.g., in `gpu.module`.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>