### PR TITLE
[SYCL] Fix handling of max_num_sub_groups query

### DIFF
--- a/sycl/plugins/esimd_emulator/pi_esimd_emulator.cpp
+++ b/sycl/plugins/esimd_emulator/pi_esimd_emulator.cpp
@@ -787,8 +787,9 @@ pi_result piDeviceGetInfo(pi_device Device, pi_device_info ParamName,
     return ReturnValue(size_t{1});
   case PI_EXT_INTEL_DEVICE_INFO_MAX_COMPUTE_QUEUE_INDICES:
     return ReturnValue(pi_int32{1});
+  case PI_DEVICE_INFO_MAX_NUM_SUB_GROUPS:
+    return ReturnValue(pi_uint32{1}); // Minimum required by SYCL 2020 spec
 
-    CASE_PI_UNSUPPORTED(PI_DEVICE_INFO_MAX_NUM_SUB_GROUPS)
     CASE_PI_UNSUPPORTED(PI_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS)
     CASE_PI_UNSUPPORTED(PI_DEVICE_INFO_IL_VERSION)
 

--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -366,20 +366,24 @@ pi_result piDeviceGetInfo(pi_device device, pi_device_info paramName,
         cl_uint value = 1u;
         std::memcpy(paramValue, &value, sizeof(cl_uint));
       }
-    } else {
-      // Otherwise, we can't query anything, because even cl_khr_subgroups does
-      // not provide similar query. Therefore, simply return minimum possible
-      // value 1 here.
-      if (paramValue && paramValueSize < sizeof(cl_uint))
-        return static_cast<pi_result>(CL_INVALID_VALUE);
-      if (paramValueSizeRet)
-        *paramValueSizeRet = sizeof(cl_uint);
 
-      if (paramValue) {
-        cl_uint value = 1u;
-        std::memcpy(paramValue, &value, sizeof(cl_uint));
-      }
+      return static_cast<pi_result>(err);
     }
+
+    // Otherwise, we can't query anything, because even cl_khr_subgroups does
+    // not provide similar query. Therefore, simply return minimum possible
+    // value 1 here.
+    if (paramValue && paramValueSize < sizeof(cl_uint))
+      return static_cast<pi_result>(CL_INVALID_VALUE);
+    if (paramValueSizeRet)
+      *paramValueSizeRet = sizeof(cl_uint);
+
+    if (paramValue) {
+      cl_uint value = 1u;
+      std::memcpy(paramValue, &value, sizeof(cl_uint));
+    }
+
+    return static_cast<pi_result>(CL_SUCCESS);
   }
   default:
     cl_int result = clGetDeviceInfo(

--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -345,7 +345,42 @@ pi_result piDeviceGetInfo(pi_device device, pi_device_info paramName,
     std::memcpy(paramValue, &result, sizeof(pi_int32));
     return PI_SUCCESS;
   }
+  case PI_DEVICE_INFO_MAX_NUM_SUB_GROUPS: {
+    // Corresponding OpenCL query is only available starting with OpenCL 2.1 and
+    // we have to emulate it on older OpenCL runtimes.
+    OCLV::OpenCLVersion version;
+    cl_int err = getDeviceVersion(cast<cl_device_id>(device), version);
+    if (err != CL_SUCCESS)
+      return static_cast<pi_result>(err);
 
+    if (version >= OCLV::V2_1) {
+      err = clGetDeviceInfo(cast<cl_device_id>(device),
+                            cast<cl_device_info>(paramName), paramValueSize,
+                            paramValue, paramValueSizeRet);
+      if (err != CL_SUCCESS)
+        return static_cast<pi_result>(err);
+
+      if (paramValue && *static_cast<cl_uint *>(paramValue) == 0u) {
+        // OpenCL returns 0 if sub-groups are not supported, but SYCL 2020 spec
+        // says that minimum possible value is 1.
+        cl_uint value = 1u;
+        std::memcpy(paramValue, &value, sizeof(cl_uint));
+      }
+    } else {
+      // Otherwise, we can't query anything, because even cl_khr_subgroups does
+      // not provide similar query. Therefore, simply return minimum possible
+      // value 1 here.
+      if (paramValue && paramValueSize < sizeof(cl_uint))
+        return static_cast<pi_result>(CL_INVALID_VALUE);
+      if (paramValueSizeRet)
+        *paramValueSizeRet = sizeof(cl_uint);
+
+      if (paramValue) {
+        cl_uint value = 1u;
+        std::memcpy(paramValue, &value, sizeof(cl_uint));
+      }
+    }
+  }
   default:
     cl_int result = clGetDeviceInfo(
         cast<cl_device_id>(device), cast<cl_device_info>(paramName),


### PR DESCRIPTION
Updated `esimd_emulator` PI plugin to return minimum possible value 1.
Updated `opencl` PI plugin to perform conditional query (based on OpenCL
version supported by a device) to prevent crashes on OpenCL < 2.1