### PR TITLE
[Driver][SYCL] Improve AOT option passing with intel_gpu targets

### DIFF
--- a/clang/test/Driver/sycl-oneapi-gpu.cpp
+++ b/clang/test/Driver/sycl-oneapi-gpu.cpp
@@ -382,3 +382,16 @@
 // CHECK_PHASES_MIX: 26: file-table-tform, {22, 25}, tempfiletable, (device-sycl)
 // CHECK_PHASES_MIX: 27: clang-offload-wrapper, {26}, object, (device-sycl)
 // CHECK_PHASES_MIX: 28: offload, "host-sycl (x86_64-unknown-linux-gnu)" {10}, "device-sycl (spir64_gen-unknown-unknown:skl)" {20}, "device-sycl (spir64_gen-unknown-unknown)" {27}, image
+
+/// Check that ocloc backend option settings only occur for the expected
+/// toolchains when mixing spir64_gen and intel_gpu
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_dg1,spir64_gen,intel_gpu_skl \
+// RUN:   -Xsycl-target-backend=spir64_gen "-device skl -DSKL" \
+// RUN:   -Xsycl-target-backend=intel_gpu_dg1 "-DDG1" \
+// RUN:   -Xsycl-target-backend=intel_gpu_skl "-DSKL2" \
+// RUN:   -fno-sycl-device-lib=all -fno-sycl-instrument-device-code \
+// RUN:   -target x86_64-unknown-linux-gnu -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefix=CHECK_TOOLS_BEOPTS
+// CHECK_TOOLS_BEOPTS: ocloc{{.*}} "-device" "dg1" "-DDG1"
+// CHECK_TOOLS_BEOPTS: ocloc{{.*}} "-device" "skl" "-DSKL"
+// CHECK_TOOLS_BEOPTS: ocloc{{.*}} "-device" "skl" "-DSKL2"


### PR DESCRIPTION
When using -fsycl-targets=intel_gpu* -Xsycl-target-backend=intel_gpu* "opts" be sure to pass "opts" to the ocloc call.  These specially handled target values imply spir64_gen but were not processed properly to be able to scrutinize various target possibilities.