### PR TITLE
[SYCL-MLIR] Add attributes for pure functions

### DIFF
--- a/polygeist/tools/cgeist/Lib/Attributes.cc
+++ b/polygeist/tools/cgeist/Lib/Attributes.cc
@@ -322,6 +322,9 @@ AttrBuilder::addAttributeImpl(llvm::Attribute::AttrKind Kind, uint64_t Val,
   };
 
   switch (Kind) {
+  case llvm::Attribute::AttrKind::Memory:
+    // Val can be zero for memory(none).
+    return Invoke(AddRawIntAttrPtr, Kind, Val);
   case llvm::Attribute::AttrKind::Alignment:
     assert(Val <= llvm::Value::MaximumAlignment && "Alignment too large");
     LLVM_FALLTHROUGH;
@@ -382,7 +385,7 @@ AttrBuilder::addPassThroughRawIntAttr(llvm::Attribute::AttrKind Kind,
   OpBuilder Builder(&Ctx);
   NamedAttribute NamedAttr(
       StringAttr::get(&Ctx, llvm::Attribute::getNameFromAttrKind(Kind)),
-      Builder.getIntegerAttr(Builder.getIntegerType(64), Value));
+      StringAttr::get(&Ctx, Twine(Value)));
   return addPassThroughAttributeImpl(NamedAttr);
 }
 

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -152,8 +152,9 @@ static void addAttributesFromAssumes(mlirclang::AttrBuilder &FuncAttrs,
   for (StringRef AttrName : Attrs)
     StrAttrs.push_back(StringAttr::get(Ctx, AttrName));
 
-  FuncAttrs.addPassThroughAttribute(llvm::AssumptionAttrKey,
-                                    mlir::ArrayAttr::get(Ctx, StrAttrs));
+  if (!StrAttrs.empty())
+    FuncAttrs.addPassThroughAttribute(llvm::AssumptionAttrKey,
+                                      mlir::ArrayAttr::get(Ctx, StrAttrs));
 }
 
 static void addNoBuiltinAttributes(mlirclang::AttrBuilder &FuncAttrs,

--- a/polygeist/tools/cgeist/Test/Verification/sycl/ex_particle_reduced.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/ex_particle_reduced.cpp
@@ -3,11 +3,11 @@
 
 // Test that the kernel named `kernel_likelihood` is generated with the correct signature.
 // LLVM: define weak_odr spir_kernel void {{.*}}kernel_likelihood(
-// LLVM-SAME: float addrspace(1)* noundef %0, %"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %1, 
+// LLVM-SAME: float addrspace(1)* noundef align 4 %0, %"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %1, 
 // LLVM-SAME: %"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %2, %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %3,
-// LLVM-SAME: float addrspace(1)* noundef %4, %"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %5, 
+// LLVM-SAME: float addrspace(1)* noundef align 4 %4, %"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %5, 
 // LLVM-SAME: %"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %6, %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %7, 
-// LLVM-SAME: i8 addrspace(1)* noundef %8, %"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %9, 
+// LLVM-SAME: i8 addrspace(1)* noundef align 1 %8, %"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %9, 
 // LLVM-SAME: %"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %10, %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %11)
 
 #include <sycl/sycl.hpp>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
@@ -31,7 +31,7 @@
 
 // CHECK-LLVM-LABEL: define weak_odr spir_kernel void @_ZTSN4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EE
 // CHECK-LLVM-SAME:     (%"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %0, 
-// CHECK-LLVM-SAME:     { i32 addrspace(1)* }* noundef byval({ i32 addrspace(1)* }) align 8 %1) #0 {
+// CHECK-LLVM-SAME:     { i32 addrspace(1)* }* noundef byval({ i32 addrspace(1)* }) align 8 %1) #1 {
 // CHECK-LLVM-NEXT:  %3 = alloca %"class.sycl::_V1::item.1.true", align 8
 // CHECK-LLVM-NEXT:  %4 = alloca { i32 addrspace(4)* }, i64 1, align 8
 // CHECK-LLVM-NEXT:  %5 = alloca %"class.sycl::_V1::range.1", align 8

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -17,7 +17,7 @@
 
 // CHECK-MLIR: gpu.module @device_functions
 // CHECK-MLIR-LABEL: gpu.func @_ZTS8kernel_1(
-// CHECK-MLIR:         %arg0: memref<?xi32, 1> {llvm.noundef},
+// CHECK-MLIR:         %arg0: memref<?xi32, 1> {llvm.align = 4 : i64, llvm.noundef},
 // CHECK-MLIR-SAME:    %arg1: memref<?x!sycl_range_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_1_, llvm.noundef},
 // CHECK-MLIR-SAME:    %arg2: memref<?x!sycl_range_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_1_, llvm.noundef},
 // CHECK-MLIR-SAME:    %arg3: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef})
@@ -52,7 +52,7 @@ void host_1() {
 }
 
 // CHECK-MLIR: gpu.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2(
-// CHECK-MLIR:          %arg0: memref<?xi32, 1> {llvm.noundef},
+// CHECK-MLIR:          %arg0: memref<?xi32, 1> {llvm.align = 4 : i64, llvm.noundef},
 // CHECK-MLIR-SAME:     %arg1: memref<?x!sycl_range_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_1_, llvm.noundef},
 // CHECK-MLIR-SAME:     %arg2: memref<?x!sycl_range_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_1_, llvm.noundef},
 // CHECK-MLIR-SAME:     %arg3: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}
@@ -82,4 +82,4 @@ SYCL_EXTERNAL void function_1(sycl::item<2, true> item) {
 }
 
 // Keep at the end of the file.
-// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp" }
+// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp" "uniform-work-group-size"="true" }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
@@ -7,7 +7,7 @@
 //
 // CHECK-MLIR-DAG:  gpu.func @_ZTS8kernel_1
 // CHECK-MLIR-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>,
-// CHECK-MLIR-SAME: [[PASSTHROUGH:passthrough = \["convergent", "mustprogress", "noinline", "norecurse", "nounwind", "optnone", \["frame-pointer", "all"\], \["no-trapping-math", "true"\], \["stack-protector-buffer-size", "8"\], \["sycl-module-id", ".*/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp"\]\]]]} {
+// CHECK-MLIR-SAME: [[PASSTHROUGH:passthrough = \["convergent", "mustprogress", "noinline", "norecurse", "nounwind", "optnone", \["frame-pointer", "all"\], \["no-trapping-math", "true"\], \["stack-protector-buffer-size", "8"\], \["sycl-module-id", ".*/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp"\], \["uniform-work-group-size", "true"\]\]]]} {
 // CHECK-MLIR-DAG:  gpu.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2
 // CHECK-MLIR-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, [[PASSTHROUGH]]} {
 // CHECK-MLIR-DAG:  func.func @_ZN12StoreWrapperIiLi1ELN4sycl3_V16access4modeE1026EEC1ENS1_8accessorIiLi1ELS3_1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS1_3ext6oneapi22accessor_property_listIJEEEEENS1_2idILi1EEERKi
@@ -20,7 +20,7 @@
 // CHECK-LLVM-DAG:      define weak_odr spir_kernel void @_ZTS8kernel_1({{.*}}) #[[FUNCATTRS1:[0-9]+]]
 // CHECK-LLVM-DAG:      define weak_odr spir_kernel void @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2({{.*}}) #[[FUNCATTRS1]]
 
-// CHECK-LLVM-DAG: attributes #[[FUNCATTRS1]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp" }
+// CHECK-LLVM: attributes #[[FUNCATTRS1]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp" "uniform-work-group-size"="true" }
 
 template <typename DataT,
           int Dimensions = 1,

--- a/polygeist/tools/cgeist/Test/Verification/sycl/pure.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/pure.cpp
@@ -1,0 +1,20 @@
+// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+
+// CHECK-MLIR-DAG: func.func private @func_const() {{.*}} attributes {{{.*}}passthrough = [{{.*}}"nounwind", {{.*}}"willreturn", {{.*}}["memory", "0"]{{.*}}]}
+// CHECK-MLIR-DAG: func.func private @func_pure() {{.*}} attributes {{{.*}}passthrough = [{{.*}}"nounwind", {{.*}}"willreturn", {{.*}}["memory", "21"]{{.*}}]}
+
+// CHECK-LLVM-DAG: declare spir_func i32 @func_const() #[[FUNCATTRS1:[0-9]+]]
+// CHECK-LLVM-DAG: declare spir_func i32 @func_pure() #[[FUNCATTRS2:[0-9]+]]
+
+// CHECK-LLVM-DAG: attributes #[[FUNCATTRS1]] = { {{.*}}nounwind {{.*}}willreturn memory(none){{.*}} }
+// CHECK-LLVM-DAG: attributes #[[FUNCATTRS2]] = { {{.*}}nounwind {{.*}}willreturn memory(read){{.*}} }
+
+#include <sycl/sycl.hpp>
+
+extern "C" SYCL_EXTERNAL int func_const() __attribute__((const));
+extern "C" SYCL_EXTERNAL int func_pure() __attribute__((pure));
+
+extern "C" SYCL_EXTERNAL int foo() {
+  return func_const() + func_pure();
+}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/pure_const_attrs.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/pure_const_attrs.cpp
@@ -12,8 +12,8 @@
 
 #include <sycl/sycl.hpp>
 
-extern "C" SYCL_EXTERNAL int func_const() __attribute__((const));
-extern "C" SYCL_EXTERNAL int func_pure() __attribute__((pure));
+extern "C" SYCL_EXTERNAL [[gnu::const]] int func_const();
+extern "C" SYCL_EXTERNAL [[gnu::pure]] int func_pure();
 
 extern "C" SYCL_EXTERNAL int foo() {
   return func_const() + func_pure();

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -16,13 +16,13 @@
 // CHECK-MLIR-NEXT:      return
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_5()
-// CHECK-LLVM-SAME:  #[[FUNCATTRS1:[0-9]+]] {
+// CHECK-LLVM-SAME:  #[[FUNCATTRS0:[0-9]+]] {
 // CHECK-LLVM-NEXT:  [[ACCESSOR:%.*]] = alloca %"class.sycl::_V1::accessor.1", align 8
 // CHECK-LLVM-NEXT:  [[ACAST:%.*]] = addrspacecast %"class.sycl::_V1::accessor.1"* [[ACCESSOR]] to %"class.sycl::_V1::accessor.1" addrspace(4)*
 // CHECK-LLVM-NEXT:  call spir_func void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]])
 
 // CHECK-LLVM-LABEL: define weak_odr spir_kernel void @_ZTSZZ16host_single_taskvENKUlRN4sycl3_V17handlerEE_clES2_E18kernel_single_task
-// CHECK-LLVM-SAME: #[[FUNCATTRS1]]
+// CHECK-LLVM-SAME: #[[FUNCATTRS1:[0-9]+]]
 // CHECK: call void @cons_5()
 
 extern "C" SYCL_EXTERNAL void cons_5() {
@@ -43,4 +43,5 @@ void host_single_task() {
 }
 
 // Keep at the end of the file.
-// CHECK-LLVM: attributes #[[FUNCATTRS1]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp" }
+// CHECK-LLVM: attributes #[[FUNCATTRS0]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp" }
+// CHECK-LLVM: attributes #[[FUNCATTRS1]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp" "uniform-work-group-size"="true" }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
@@ -22,7 +22,7 @@
 // CHECK-LLVM:       [[RESULT:%.*]] = fadd float [[V1]], [[V2]]
 // CHECK-LLVM:       store float [[RESULT]], float addrspace(4)* {{.*}}, align 4
 
-// CHECK-LLVM:       define weak_odr spir_kernel void @{{.*}}vec_add_simple({{.*}}) #[[FUNCATTRS]]
+// CHECK-LLVM:       define weak_odr spir_kernel void @{{.*}}vec_add_simple({{.*}}) #[[FUNCATTRS1:[0-9]+]]
 // CHECK-LLVM:       call spir_func void [[FUNC]]
 
 void vec_add_device_simple(std::array<float, N> &VA, std::array<float, N> &VB,
@@ -96,3 +96,4 @@ int main() {
 
 // Keep at the end of the file.
 // CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp" }
+// CHECK-LLVM: attributes #[[FUNCATTRS1]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp" "uniform-work-group-size"="true" }


### PR DESCRIPTION
Add `nounwind willreturn memory(none)` attributes to functions that marked with `__attribute__((const))`.
Add `nounwind willreturn memory(read)` attributes to functions that marked with `__attribute__((pure))`.

Signed-off-by: Tsang, Whitney <whitney.tsang@intel.com>