### PR TITLE
[SYCL] Augment known_identity for std::complex and std::plus.

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_complex_algorithms.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_complex_algorithms.asciidoc
@@ -125,6 +125,10 @@ NOTE: `sycl::bit_and`, `sycl::bit_or`, `sycl::bit_xor`, `sycl::logical_and`,
 because their behaviors are defined in terms of operators that `std::complex`
 does not implement.
 
+=== Known Identities
+
+Along with the known identities listed in https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#table.identities[Table 123], `sycl::known_identity` and `sycl::has_known_identity` also support `std::complex` with floating-point types.
+
 == Issues
 
 None.

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_complex_algorithms.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_complex_algorithms.asciidoc
@@ -127,7 +127,7 @@ does not implement.
 
 === Known Identities
 
-Along with the known identities listed in https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#table.identities[Table 123], `sycl::known_identity` and `sycl::has_known_identity` also support `std::complex` with floating-point types.
+Along with the known identities listed in https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#table.identities[Table 123], `sycl::known_identity` and `sycl::has_known_identity` also support `std::complex` with the `float` and `double` floating-point types.
 
 == Issues
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_complex_algorithms.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_complex_algorithms.asciidoc
@@ -127,7 +127,15 @@ does not implement.
 
 === Known Identities
 
-Along with the known identities listed in https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#table.identities[Table 123], `sycl::known_identity` and `sycl::has_known_identity` also support `std::complex` with the `float` and `double` floating-point types.
+This extension adds the following known identities, augmenting https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#table.identities[Table 123] in the core SYCL specification:
+[cols="5,30,70"]
+[grid="rows"]
+[options="header"]
+|========================================
+|Operator|Available When|Identity
+|`sycl::plus`|`std::is_same_v<std::remove_cv_t<AccumulatorT>, std::complex<float>> \|\|
+std::is_same_v<std::remove_cv_t<AccumulatorT>, std::complex<double>>`|`AccumulatorT{}`
+|========================================
 
 == Issues
 

--- a/sycl/include/sycl/known_identity.hpp
+++ b/sycl/include/sycl/known_identity.hpp
@@ -63,6 +63,13 @@ using IsLogicalOR =
     bool_constant<std::is_same<BinaryOperation, sycl::logical_or<T>>::value ||
                   std::is_same<BinaryOperation, sycl::logical_or<void>>::value>;
 
+template <typename T>
+using isComplex =
+    bool_constant<std::is_same<T, std::complex<short>>::value ||
+                  std::is_same<T, std::complex<int>>::value ||
+                  std::is_same<T, std::complex<float>>::value ||
+                  std::is_same<T, std::complex<double>>::value>;
+
 // Identity = 0
 template <typename T, class BinaryOperation>
 using IsZeroIdentityOp =
@@ -70,7 +77,10 @@ using IsZeroIdentityOp =
                    (IsPlus<T, BinaryOperation>::value ||
                     IsBitOR<T, BinaryOperation>::value ||
                     IsBitXOR<T, BinaryOperation>::value)) ||
-                  (is_genfloat<T>::value && IsPlus<T, BinaryOperation>::value)>;
+                  (is_genfloat<T>::value &&
+                    IsPlus<T, BinaryOperation>::value) ||
+                  (isComplex<T>::value &&
+                    IsPlus<T, BinaryOperation>::value)>;
 
 // Identity = 1
 template <typename T, class BinaryOperation>

--- a/sycl/include/sycl/known_identity.hpp
+++ b/sycl/include/sycl/known_identity.hpp
@@ -65,9 +65,7 @@ using IsLogicalOR =
 
 template <typename T>
 using isComplex =
-    bool_constant<std::is_same<T, std::complex<short>>::value ||
-                  std::is_same<T, std::complex<int>>::value ||
-                  std::is_same<T, std::complex<float>>::value ||
+    bool_constant<std::is_same<T, std::complex<float>>::value ||
                   std::is_same<T, std::complex<double>>::value>;
 
 // Identity = 0


### PR DESCRIPTION
This PR proposes to augment sycl::has_known_identity to return true for std::complex and std::plus operator. This will have two benefits:

1. It enables support for complex numbers in sycl::reduction without the user having to explicitly pass identity.
2. sycl::known_identity can now be used to simplify the implementation of group algorithms (See PR #5394).

Also, this PR addresses the Github issue #5477.
Test Case PR: https://github.com/intel/llvm-test-suite/pull/1609