### PR TITLE
[SYCL] Add support of sycl::marray to relational functions

### DIFF
--- a/sycl/include/sycl/builtins.hpp
+++ b/sycl/include/sycl/builtins.hpp
@@ -1382,8 +1382,8 @@ detail::common_rel_ret_t<T> signbit(T x) __NOEXC {
 #define __SYCL_MARRAY_RELATIONAL_FUNCTION_BINOP_OVERLOAD(NAME)                 \
   template <typename T,                                                        \
             typename = std::enable_if_t<detail::is_mgenfloat<T>::value>>       \
-  sycl::marray<bool, detail::marray_size<T>> NAME(T x, T y) __NOEXC {          \
-    sycl::marray<bool, detail::marray_size<T>> res;                            \
+  sycl::marray<bool, T::size()> NAME(T x, T y) __NOEXC {                       \
+    sycl::marray<bool, T::size()> res;                                         \
     for (int i = 0; i < x.size(); i++) {                                       \
       res[i] = NAME(x[i], y[i]);                                               \
     }                                                                          \
@@ -1393,8 +1393,8 @@ detail::common_rel_ret_t<T> signbit(T x) __NOEXC {
 #define __SYCL_MARRAY_RELATIONAL_FUNCTION_UNOP_OVERLOAD(NAME)                  \
   template <typename T,                                                        \
             typename = std::enable_if_t<detail::is_mgenfloat<T>::value>>       \
-  sycl::marray<bool, detail::marray_size<T>> NAME(T x) __NOEXC {               \
-    sycl::marray<bool, detail::marray_size<T>> res;                            \
+  sycl::marray<bool, T::size()> NAME(T x) __NOEXC {                            \
+    sycl::marray<bool, T::size()> res;                                         \
     for (int i = 0; i < x.size(); i++) {                                       \
       res[i] = NAME(x[i]);                                                     \
     }                                                                          \
@@ -1472,15 +1472,10 @@ detail::enable_if_t<detail::is_sgentype<T>::value, T> select(T a, T b,
 
 // mgentype select (mgentype a, mgentype b, marray<bool, { N }> c)
 template <typename T,
-          typename = detail::enable_if_t<
-              detail::is_mgenfloat<T>::value &&
-                  detail::is_sgentype<detail::marray_element_type<T>>::value,
-              T>>
-sycl::marray<detail::marray_element_type<T>, detail::marray_size<T>>
-select(T a, T b, sycl::marray<bool, detail::marray_size<T>> c) __NOEXC {
-  static_assert((a.size() == b.size()) && (b.size() == c.size()),
-                "sycl::marray sizes must be equal.");
-  sycl::marray<detail::marray_element_type<T>, detail::marray_size<T>> res;
+          typename = std::enable_if_t<detail::is_mgenfloat<T>::value>>
+sycl::marray<detail::marray_element_type<T>, T::size()>
+select(T a, T b, sycl::marray<bool, T::size()> c) __NOEXC {
+  sycl::marray<detail::marray_element_type<T>, T::size()> res;
   for (int i = 0; i < a.size(); i++) {
     res[i] = select(a[i], b[i], c[i]);
   }

--- a/sycl/include/sycl/builtins.hpp
+++ b/sycl/include/sycl/builtins.hpp
@@ -1377,6 +1377,198 @@ detail::common_rel_ret_t<T> signbit(T x) __NOEXC {
       __sycl_std::__invoke_SignBitSet<detail::internal_rel_ret_t<T>>(x));
 }
 
+// marray relational functions
+template <typename T,
+          typename = detail::enable_if_t<
+              detail::is_mgenfloat<T>::value &&
+                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
+              T>>
+sycl::marray<bool, detail::marray_size<T>> isequal(T x, T y) __NOEXC {
+  static_assert(x.size() == y.size(), "sycl::marray sizes must be equal.");
+  sycl::marray<bool, detail::marray_size<T>> res;
+  for (int i = 0; i < x.size(); i++) {
+    res[i] = isequal(x[i], y[i]);
+  }
+  return res;
+}
+
+template <typename T,
+          typename = detail::enable_if_t<
+              detail::is_mgenfloat<T>::value &&
+                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
+              T>>
+sycl::marray<bool, detail::marray_size<T>> isnotequal(T x, T y) __NOEXC {
+  static_assert(x.size() == y.size(), "sycl::marray sizes must be equal.");
+  sycl::marray<bool, detail::marray_size<T>> res;
+  for (int i = 0; i < x.size(); i++) {
+    res[i] = isnotequal(x[i], y[i]);
+  }
+  return res;
+}
+
+template <typename T,
+          typename = detail::enable_if_t<
+              detail::is_mgenfloat<T>::value &&
+                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
+              T>>
+sycl::marray<bool, detail::marray_size<T>> isgreater(T x, T y) __NOEXC {
+  static_assert(x.size() == y.size(), "sycl::marray sizes must be equal.");
+  sycl::marray<bool, detail::marray_size<T>> res;
+  for (int i = 0; i < x.size(); i++) {
+    res[i] = isgreater(x[i], y[i]);
+  }
+  return res;
+}
+
+template <typename T,
+          typename = detail::enable_if_t<
+              detail::is_mgenfloat<T>::value &&
+                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
+              T>>
+sycl::marray<bool, detail::marray_size<T>> isgreaterequal(T x, T y) __NOEXC {
+  static_assert(x.size() == y.size(), "sycl::marray sizes must be equal.");
+  sycl::marray<bool, detail::marray_size<T>> res;
+  for (int i = 0; i < x.size(); i++) {
+    res[i] = isgreaterequal(x[i], y[i]);
+  }
+  return res;
+}
+
+template <typename T,
+          typename = detail::enable_if_t<
+              detail::is_mgenfloat<T>::value &&
+                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
+              T>>
+sycl::marray<bool, detail::marray_size<T>> isless(T x, T y) __NOEXC {
+  static_assert(x.size() == y.size(), "sycl::marray sizes must be equal.");
+  sycl::marray<bool, detail::marray_size<T>> res;
+  for (int i = 0; i < x.size(); i++) {
+    res[i] = isless(x[i], y[i]);
+  }
+  return res;
+}
+
+template <typename T,
+          typename = detail::enable_if_t<
+              detail::is_mgenfloat<T>::value &&
+                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
+              T>>
+sycl::marray<bool, detail::marray_size<T>> islessequal(T x, T y) __NOEXC {
+  static_assert(x.size() == y.size(), "sycl::marray sizes must be equal.");
+  sycl::marray<bool, detail::marray_size<T>> res;
+  for (int i = 0; i < x.size(); i++) {
+    res[i] = islessequal(x[i], y[i]);
+  }
+  return res;
+}
+
+template <typename T,
+          typename = detail::enable_if_t<
+              detail::is_mgenfloat<T>::value &&
+                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
+              T>>
+sycl::marray<bool, detail::marray_size<T>> islessgreater(T x, T y) __NOEXC {
+  static_assert(x.size() == y.size(), "sycl::marray sizes must be equal.");
+  sycl::marray<bool, detail::marray_size<T>> res;
+  for (int i = 0; i < x.size(); i++) {
+    res[i] = islessgreater(x[i], y[i]);
+  }
+  return res;
+}
+
+template <typename T,
+          typename = detail::enable_if_t<
+              detail::is_mgenfloat<T>::value &&
+                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
+              T>>
+sycl::marray<bool, detail::marray_size<T>> isfinite(T x) __NOEXC {
+  sycl::marray<bool, detail::marray_size<T>> res;
+  for (int i = 0; i < x.size(); i++) {
+    res[i] = isfinite(x[i]);
+  }
+  return res;
+}
+
+template <typename T,
+          typename = detail::enable_if_t<
+              detail::is_mgenfloat<T>::value &&
+                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
+              T>>
+sycl::marray<bool, detail::marray_size<T>> isinf(T x) __NOEXC {
+  sycl::marray<bool, detail::marray_size<T>> res;
+  for (int i = 0; i < x.size(); i++) {
+    res[i] = isinf(x[i]);
+  }
+  return res;
+}
+
+template <typename T,
+          typename = detail::enable_if_t<
+              detail::is_mgenfloat<T>::value &&
+                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
+              T>>
+sycl::marray<bool, detail::marray_size<T>> isnan(T x) __NOEXC {
+  sycl::marray<bool, detail::marray_size<T>> res;
+  for (int i = 0; i < x.size(); i++) {
+    res[i] = isnan(x[i]);
+  }
+  return res;
+}
+
+template <typename T,
+          typename = detail::enable_if_t<
+              detail::is_mgenfloat<T>::value &&
+                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
+              T>>
+sycl::marray<bool, detail::marray_size<T>> isnormal(T x) __NOEXC {
+  sycl::marray<bool, detail::marray_size<T>> res;
+  for (int i = 0; i < x.size(); i++) {
+    res[i] = isnormal(x[i]);
+  }
+  return res;
+}
+
+template <typename T,
+          typename = detail::enable_if_t<
+              detail::is_mgenfloat<T>::value &&
+                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
+              T>>
+sycl::marray<bool, detail::marray_size<T>> isordered(T x, T y) __NOEXC {
+  static_assert(x.size() == y.size(), "sycl::marray sizes must be equal.");
+  sycl::marray<bool, detail::marray_size<T>> res;
+  for (int i = 0; i < x.size(); i++) {
+    res[i] = isordered(x[i], y[i]);
+  }
+  return res;
+}
+
+template <typename T,
+          typename = detail::enable_if_t<
+              detail::is_mgenfloat<T>::value &&
+                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
+              T>>
+sycl::marray<bool, detail::marray_size<T>> isunordered(T x, T y) __NOEXC {
+  static_assert(x.size() == y.size(), "sycl::marray sizes must be equal.");
+  sycl::marray<bool, detail::marray_size<T>> res;
+  for (int i = 0; i < x.size(); i++) {
+    res[i] = isunordered(x[i], y[i]);
+  }
+  return res;
+}
+
+template <typename T,
+          typename = detail::enable_if_t<
+              detail::is_mgenfloat<T>::value &&
+                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
+              T>>
+sycl::marray<bool, detail::marray_size<T>> signbit(T x) __NOEXC {
+  sycl::marray<bool, detail::marray_size<T>> res;
+  for (int i = 0; i < x.size(); i++) {
+    res[i] = signbit(x[i]);
+  }
+  return res;
+}
+
 namespace detail {
 #if defined(SYCL2020_CONFORMANT_APIS) && SYCL_LANGUAGE_VERSION >= 202001
 using anyall_ret_t = bool;
@@ -1429,6 +1621,23 @@ template <typename T>
 detail::enable_if_t<detail::is_sgentype<T>::value, T> select(T a, T b,
                                                              bool c) __NOEXC {
   return __sycl_std::__invoke_select<T>(a, b, static_cast<int>(c));
+}
+
+// mgentype select (mgentype a, mgentype b, marray<bool, { N }> c)
+template <typename T,
+          typename = detail::enable_if_t<
+              detail::is_mgenfloat<T>::value &&
+                  detail::is_sgentype<detail::marray_element_type<T>>::value,
+              T>>
+sycl::marray<detail::marray_element_type<T>, detail::marray_size<T>>
+select(T a, T b, sycl::marray<bool, detail::marray_size<T>> c) __NOEXC {
+  static_assert((a.size() == b.size()) && (b.size() == c.size()),
+                "sycl::marray sizes must be equal.");
+  sycl::marray<detail::marray_element_type<T>, detail::marray_size<T>> res;
+  for (int i = 0; i < a.size(); i++) {
+    res[i] = select(a[i], b[i], c[i]);
+  }
+  return res;
 }
 
 // geninteger select (geninteger a, geninteger b, igeninteger c)

--- a/sycl/include/sycl/builtins.hpp
+++ b/sycl/include/sycl/builtins.hpp
@@ -1378,196 +1378,43 @@ detail::common_rel_ret_t<T> signbit(T x) __NOEXC {
 }
 
 // marray relational functions
-template <typename T,
-          typename = detail::enable_if_t<
-              detail::is_mgenfloat<T>::value &&
-                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
-              T>>
-sycl::marray<bool, detail::marray_size<T>> isequal(T x, T y) __NOEXC {
-  static_assert(x.size() == y.size(), "sycl::marray sizes must be equal.");
-  sycl::marray<bool, detail::marray_size<T>> res;
-  for (int i = 0; i < x.size(); i++) {
-    res[i] = isequal(x[i], y[i]);
-  }
-  return res;
-}
 
-template <typename T,
-          typename = detail::enable_if_t<
-              detail::is_mgenfloat<T>::value &&
-                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
-              T>>
-sycl::marray<bool, detail::marray_size<T>> isnotequal(T x, T y) __NOEXC {
-  static_assert(x.size() == y.size(), "sycl::marray sizes must be equal.");
-  sycl::marray<bool, detail::marray_size<T>> res;
-  for (int i = 0; i < x.size(); i++) {
-    res[i] = isnotequal(x[i], y[i]);
+#define __SYCL_MARRAY_RELATIONAL_FUNCTION_BINOP_OVERLOAD(NAME)                 \
+  template <typename T,                                                        \
+            typename = std::enable_if_t<detail::is_mgenfloat<T>::value>>       \
+  sycl::marray<bool, detail::marray_size<T>> NAME(T x, T y) __NOEXC {          \
+    sycl::marray<bool, detail::marray_size<T>> res;                            \
+    for (int i = 0; i < x.size(); i++) {                                       \
+      res[i] = NAME(x[i], y[i]);                                               \
+    }                                                                          \
+    return res;                                                                \
   }
-  return res;
-}
 
-template <typename T,
-          typename = detail::enable_if_t<
-              detail::is_mgenfloat<T>::value &&
-                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
-              T>>
-sycl::marray<bool, detail::marray_size<T>> isgreater(T x, T y) __NOEXC {
-  static_assert(x.size() == y.size(), "sycl::marray sizes must be equal.");
-  sycl::marray<bool, detail::marray_size<T>> res;
-  for (int i = 0; i < x.size(); i++) {
-    res[i] = isgreater(x[i], y[i]);
+#define __SYCL_MARRAY_RELATIONAL_FUNCTION_UNOP_OVERLOAD(NAME)                  \
+  template <typename T,                                                        \
+            typename = std::enable_if_t<detail::is_mgenfloat<T>::value>>       \
+  sycl::marray<bool, detail::marray_size<T>> NAME(T x) __NOEXC {               \
+    sycl::marray<bool, detail::marray_size<T>> res;                            \
+    for (int i = 0; i < x.size(); i++) {                                       \
+      res[i] = NAME(x[i]);                                                     \
+    }                                                                          \
+    return res;                                                                \
   }
-  return res;
-}
 
-template <typename T,
-          typename = detail::enable_if_t<
-              detail::is_mgenfloat<T>::value &&
-                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
-              T>>
-sycl::marray<bool, detail::marray_size<T>> isgreaterequal(T x, T y) __NOEXC {
-  static_assert(x.size() == y.size(), "sycl::marray sizes must be equal.");
-  sycl::marray<bool, detail::marray_size<T>> res;
-  for (int i = 0; i < x.size(); i++) {
-    res[i] = isgreaterequal(x[i], y[i]);
-  }
-  return res;
-}
-
-template <typename T,
-          typename = detail::enable_if_t<
-              detail::is_mgenfloat<T>::value &&
-                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
-              T>>
-sycl::marray<bool, detail::marray_size<T>> isless(T x, T y) __NOEXC {
-  static_assert(x.size() == y.size(), "sycl::marray sizes must be equal.");
-  sycl::marray<bool, detail::marray_size<T>> res;
-  for (int i = 0; i < x.size(); i++) {
-    res[i] = isless(x[i], y[i]);
-  }
-  return res;
-}
-
-template <typename T,
-          typename = detail::enable_if_t<
-              detail::is_mgenfloat<T>::value &&
-                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
-              T>>
-sycl::marray<bool, detail::marray_size<T>> islessequal(T x, T y) __NOEXC {
-  static_assert(x.size() == y.size(), "sycl::marray sizes must be equal.");
-  sycl::marray<bool, detail::marray_size<T>> res;
-  for (int i = 0; i < x.size(); i++) {
-    res[i] = islessequal(x[i], y[i]);
-  }
-  return res;
-}
-
-template <typename T,
-          typename = detail::enable_if_t<
-              detail::is_mgenfloat<T>::value &&
-                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
-              T>>
-sycl::marray<bool, detail::marray_size<T>> islessgreater(T x, T y) __NOEXC {
-  static_assert(x.size() == y.size(), "sycl::marray sizes must be equal.");
-  sycl::marray<bool, detail::marray_size<T>> res;
-  for (int i = 0; i < x.size(); i++) {
-    res[i] = islessgreater(x[i], y[i]);
-  }
-  return res;
-}
-
-template <typename T,
-          typename = detail::enable_if_t<
-              detail::is_mgenfloat<T>::value &&
-                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
-              T>>
-sycl::marray<bool, detail::marray_size<T>> isfinite(T x) __NOEXC {
-  sycl::marray<bool, detail::marray_size<T>> res;
-  for (int i = 0; i < x.size(); i++) {
-    res[i] = isfinite(x[i]);
-  }
-  return res;
-}
-
-template <typename T,
-          typename = detail::enable_if_t<
-              detail::is_mgenfloat<T>::value &&
-                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
-              T>>
-sycl::marray<bool, detail::marray_size<T>> isinf(T x) __NOEXC {
-  sycl::marray<bool, detail::marray_size<T>> res;
-  for (int i = 0; i < x.size(); i++) {
-    res[i] = isinf(x[i]);
-  }
-  return res;
-}
-
-template <typename T,
-          typename = detail::enable_if_t<
-              detail::is_mgenfloat<T>::value &&
-                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
-              T>>
-sycl::marray<bool, detail::marray_size<T>> isnan(T x) __NOEXC {
-  sycl::marray<bool, detail::marray_size<T>> res;
-  for (int i = 0; i < x.size(); i++) {
-    res[i] = isnan(x[i]);
-  }
-  return res;
-}
-
-template <typename T,
-          typename = detail::enable_if_t<
-              detail::is_mgenfloat<T>::value &&
-                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
-              T>>
-sycl::marray<bool, detail::marray_size<T>> isnormal(T x) __NOEXC {
-  sycl::marray<bool, detail::marray_size<T>> res;
-  for (int i = 0; i < x.size(); i++) {
-    res[i] = isnormal(x[i]);
-  }
-  return res;
-}
-
-template <typename T,
-          typename = detail::enable_if_t<
-              detail::is_mgenfloat<T>::value &&
-                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
-              T>>
-sycl::marray<bool, detail::marray_size<T>> isordered(T x, T y) __NOEXC {
-  static_assert(x.size() == y.size(), "sycl::marray sizes must be equal.");
-  sycl::marray<bool, detail::marray_size<T>> res;
-  for (int i = 0; i < x.size(); i++) {
-    res[i] = isordered(x[i], y[i]);
-  }
-  return res;
-}
-
-template <typename T,
-          typename = detail::enable_if_t<
-              detail::is_mgenfloat<T>::value &&
-                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
-              T>>
-sycl::marray<bool, detail::marray_size<T>> isunordered(T x, T y) __NOEXC {
-  static_assert(x.size() == y.size(), "sycl::marray sizes must be equal.");
-  sycl::marray<bool, detail::marray_size<T>> res;
-  for (int i = 0; i < x.size(); i++) {
-    res[i] = isunordered(x[i], y[i]);
-  }
-  return res;
-}
-
-template <typename T,
-          typename = detail::enable_if_t<
-              detail::is_mgenfloat<T>::value &&
-                  detail::is_svgenfloat<detail::marray_element_type<T>>::value,
-              T>>
-sycl::marray<bool, detail::marray_size<T>> signbit(T x) __NOEXC {
-  sycl::marray<bool, detail::marray_size<T>> res;
-  for (int i = 0; i < x.size(); i++) {
-    res[i] = signbit(x[i]);
-  }
-  return res;
-}
+__SYCL_MARRAY_RELATIONAL_FUNCTION_BINOP_OVERLOAD(isequal)
+__SYCL_MARRAY_RELATIONAL_FUNCTION_BINOP_OVERLOAD(isnotequal)
+__SYCL_MARRAY_RELATIONAL_FUNCTION_BINOP_OVERLOAD(isgreater)
+__SYCL_MARRAY_RELATIONAL_FUNCTION_BINOP_OVERLOAD(isgreaterequal)
+__SYCL_MARRAY_RELATIONAL_FUNCTION_BINOP_OVERLOAD(isless)
+__SYCL_MARRAY_RELATIONAL_FUNCTION_BINOP_OVERLOAD(islessequal)
+__SYCL_MARRAY_RELATIONAL_FUNCTION_BINOP_OVERLOAD(islessgreater)
+__SYCL_MARRAY_RELATIONAL_FUNCTION_UNOP_OVERLOAD(isfinite)
+__SYCL_MARRAY_RELATIONAL_FUNCTION_UNOP_OVERLOAD(isinf)
+__SYCL_MARRAY_RELATIONAL_FUNCTION_UNOP_OVERLOAD(isnan)
+__SYCL_MARRAY_RELATIONAL_FUNCTION_UNOP_OVERLOAD(isnormal)
+__SYCL_MARRAY_RELATIONAL_FUNCTION_BINOP_OVERLOAD(isordered)
+__SYCL_MARRAY_RELATIONAL_FUNCTION_BINOP_OVERLOAD(isunordered)
+__SYCL_MARRAY_RELATIONAL_FUNCTION_UNOP_OVERLOAD(signbit)
 
 namespace detail {
 #if defined(SYCL2020_CONFORMANT_APIS) && SYCL_LANGUAGE_VERSION >= 202001

--- a/sycl/include/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/sycl/detail/generic_type_traits.hpp
@@ -55,6 +55,13 @@ using is_vgenfloat = is_contained<T, gtl::vector_floating_list>;
 template <typename T>
 using is_svgenfloat = is_contained<T, gtl::scalar_vector_floating_list>;
 
+template <typename T> using marray_element_type = typename T::value_type;
+template <typename T> constexpr int marray_size = T::size();
+
+template <typename T>
+using is_mgenfloat =
+    std::is_same<T, sycl::marray<marray_element_type<T>, marray_size<T>>>;
+
 template <typename T>
 using is_gengeofloat = is_contained<T, gtl::geo_float_list>;
 

--- a/sycl/include/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/sycl/detail/generic_type_traits.hpp
@@ -60,7 +60,9 @@ template <typename T> constexpr int marray_size = T::size();
 
 template <typename T>
 using is_mgenfloat =
-    std::is_same<T, sycl::marray<marray_element_type<T>, marray_size<T>>>;
+    bool_constant<std::is_same<T, sycl::marray<marray_element_type<T>,
+                                               marray_size<T>>>::value &&
+                  is_svgenfloat<marray_element_type<T>>::value>;
 
 template <typename T>
 using is_gengeofloat = is_contained<T, gtl::geo_float_list>;

--- a/sycl/include/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/sycl/detail/generic_type_traits.hpp
@@ -56,13 +56,11 @@ template <typename T>
 using is_svgenfloat = is_contained<T, gtl::scalar_vector_floating_list>;
 
 template <typename T> using marray_element_type = typename T::value_type;
-template <typename T> constexpr int marray_size = T::size();
 
 template <typename T>
-using is_mgenfloat =
-    bool_constant<std::is_same<T, sycl::marray<marray_element_type<T>,
-                                               marray_size<T>>>::value &&
-                  is_svgenfloat<marray_element_type<T>>::value>;
+using is_mgenfloat = bool_constant<
+    std::is_same<T, sycl::marray<marray_element_type<T>, T::size()>>::value &&
+    is_svgenfloat<marray_element_type<T>>::value>;
 
 template <typename T>
 using is_gengeofloat = is_contained<T, gtl::geo_float_list>;


### PR DESCRIPTION
This patch adds support of relational functions which take mgentype as an argument as it is stated in Table 182 of SYCL 2020 specification.

E2E tests: https://github.com/intel/llvm-test-suite/pull/1617