### PR TITLE
[SYCL-MLIR]: Create SYCL AliasAnalysis and use it in polygeist LICM pass

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/AliasAnalysis.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/AliasAnalysis.h
@@ -1,0 +1,47 @@
+//===- AliasAnalysis.h - SYCL Alias Analysis -------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains the implementation of a alias analysis for the SYCL
+// dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_SYCL_ANALYSIS_ALIASANALYSIS_H
+#define MLIR_DIALECT_SYCL_ANALYSIS_ALIASANALYSIS_H
+
+#include "mlir/Analysis/AliasAnalysis/LocalAliasAnalysis.h"
+
+namespace mlir {
+namespace sycl {
+
+/// Specialized alias analysis for SYCL dialect operations.
+class AliasAnalysis : public LocalAliasAnalysis {
+protected:
+  AliasResult aliasImpl(Value lhs, Value rhs) override;
+
+private:
+  /// Return 'NoAlias' if both values are function arguments and any of them
+  /// have attribute 'local_alias_analysis.restrict', and an empty optional
+  /// otherwise.
+  Optional<AliasResult> handleRestrictAlias(Value lhs, Value rhs);
+
+  /// This function attempts to refine aliasing for values produced by SYCL
+  /// operations. It returns 'NoAlias' if it can prove that values do not alias
+  /// and an empty optional otherwise.
+  Optional<AliasResult> handleSYCLAlias(Value lhs, Value rhs);
+
+  /// This function attempts to refine aliasing for values produced by SYCL
+  /// 'accessor.subscript' operations. It returns 'NoAlias' if it can prove that
+  /// values do not alias and an empty optional otherwise.
+  Optional<AliasResult> handleAccessorSubscriptAlias(Value lhs, Value rhs);
+};
+
+} // namespace sycl
+} // namespace mlir
+
+#endif // MLIR_DIALECT_SYCL_ANALYSIS_ALIASANALYSIS_H

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/AliasAnalysis.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/AliasAnalysis.h
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file contains the implementation of a alias analysis for the SYCL
+// This file contains the implementation of an alias analysis for the SYCL
 // dialect.
 //
 //===----------------------------------------------------------------------===//
@@ -26,19 +26,18 @@ protected:
 
 private:
   /// Return 'NoAlias' if both values are function arguments and any of them
-  /// have attribute 'local_alias_analysis.restrict', and an empty optional
-  /// otherwise.
-  Optional<AliasResult> handleRestrictAlias(Value lhs, Value rhs);
+  /// have attribute 'local_alias_analysis.restrict', and 'MayAlias' otherwise.
+  AliasResult handleRestrictAlias(Value lhs, Value rhs);
 
   /// This function attempts to refine aliasing for values produced by SYCL
   /// operations. It returns 'NoAlias' if it can prove that values do not alias
-  /// and an empty optional otherwise.
-  Optional<AliasResult> handleSYCLAlias(Value lhs, Value rhs);
+  /// and 'MayAlias' otherwise.
+  AliasResult handleSYCLAlias(Value lhs, Value rhs);
 
   /// This function attempts to refine aliasing for values produced by SYCL
   /// 'accessor.subscript' operations. It returns 'NoAlias' if it can prove that
-  /// values do not alias and an empty optional otherwise.
-  Optional<AliasResult> handleAccessorSubscriptAlias(Value lhs, Value rhs);
+  /// values do not alias and 'MayAlias' otherwise.
+  AliasResult handleAccessorSubscriptAlias(Value lhs, Value rhs);
 };
 
 } // namespace sycl

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.h
@@ -20,8 +20,17 @@
 
 namespace mlir {
 namespace sycl {
+
+// Return true if the operation \p op belongs to the SYCL MLIR dialect.
+inline bool isSYCLOperation(Operation *op) {
+  if (!op || !op->getDialect())
+    return false;
+  return isa<sycl::SYCLDialect>(op->getDialect());
+}
+
 template <typename T>
 using isSYCLMethod = std::is_base_of<SYCLMethodOpInterface::Trait<T>, T>;
+
 } // namespace sycl
 } // namespace mlir
 

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -656,10 +656,8 @@ def SYCLAccessorSubscriptOp
     This operation represents a call to the accessor::operator[] function.
   }];
 
-  let arguments = (ins Arg<AccessorMemRef, "The offsetted accessor",
-                           [MemRead]>:$Acc,
-                       Arg<SYCLAccessorSubscriptIndex, "The offset",
-		           [MemRead]>:$Index,
+  let arguments = (ins Arg<AccessorMemRef, "The accessor", [MemRead]>:$Acc,
+                       Arg<SYCLAccessorSubscriptIndex, "The offset", [MemRead]>:$Index,
                        TypeArrayAttr:$ArgumentTypes,
                        FlatSymbolRefAttr:$FunctionName,
                        OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,

--- a/mlir-sycl/lib/Dialect/Analysis/AliasAnalysis.cpp
+++ b/mlir-sycl/lib/Dialect/Analysis/AliasAnalysis.cpp
@@ -1,0 +1,125 @@
+//===- AliasAnalysis.cpp - Alias Analysis for the SYCL MLIR dialect -------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/SYCL/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/SYCL/IR/SYCLOps.h"
+#include "mlir/Dialect/SYCL/IR/SYCLOpsDialect.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "alias-analysis"
+
+using namespace mlir;
+
+//===----------------------------------------------------------------------===//
+// Helper Functions
+//===----------------------------------------------------------------------===//
+
+// Return true if the value \p val is a function argument, and false otherwise.
+static bool isFuncArg(Value val) {
+  auto blockArg = val.dyn_cast<BlockArgument>();
+  if (!blockArg)
+    return false;
+
+  return isa_and_nonnull<FunctionOpInterface>(
+      blockArg.getOwner()->getParentOp());
+}
+
+// Return true if the value \p val is a function argument that has the
+// 'local_alias_analysis.restrict' attribute, and false otherwise.
+static bool isRestrict(Value val) {
+  if (!isFuncArg(val))
+    return false;
+
+  auto blockArg = val.cast<BlockArgument>();
+  auto func = cast<FunctionOpInterface>(blockArg.getOwner()->getParentOp());
+  return !!func.getArgAttr(blockArg.getArgNumber(),
+                           "local_alias_analysis.restrict");
+}
+
+// Return true if the operation \p op belongs to the SYCL MLIR dialect.
+static bool isSYCLOperation(Operation *op) {
+  if (!op || !op->getDialect())
+    return false;
+  return op->getDialect()->getNamespace() ==
+         sycl::SYCLDialect::getDialectNamespace();
+}
+
+// Return true is the given type \p ty is a MemRef type with a SYCL element
+// type.
+static bool isMemRefOfSYCLType(Type ty) {
+  if (auto mt = dyn_cast<MemRefType>(ty))
+    return sycl::isSYCLType(mt.getElementType());
+  return false;
+}
+
+//===----------------------------------------------------------------------===//
+// AliasAnalysis
+//===----------------------------------------------------------------------===//
+
+AliasResult sycl::AliasAnalysis::aliasImpl(Value lhs, Value rhs) {
+  if (lhs == rhs)
+    return AliasResult::MustAlias;
+  if (Optional<AliasResult> aliasResult = handleRestrictAlias(lhs, rhs))
+    return *aliasResult;
+  if (Optional<AliasResult> aliasResult = handleSYCLAlias(lhs, rhs))
+    return *aliasResult;
+
+  return LocalAliasAnalysis::aliasImpl(lhs, rhs);
+}
+
+Optional<AliasResult> sycl::AliasAnalysis::handleRestrictAlias(Value lhs,
+                                                               Value rhs) {
+  // Function arguments do not alias if any of them are 'restrict' qualified.
+  if (isFuncArg(lhs) && isFuncArg(rhs))
+    if (isRestrict(lhs) || isRestrict(rhs))
+      return AliasResult::NoAlias;
+
+  return std::nullopt;
+}
+
+Optional<AliasResult> sycl::AliasAnalysis::handleSYCLAlias(Value lhs,
+                                                           Value rhs) {
+  Operation *lhsOp = lhs.getDefiningOp(), *rhsOp = rhs.getDefiningOp();
+  if (!isSYCLOperation(lhsOp) && !isSYCLOperation(rhsOp))
+    return std::nullopt;
+
+  // Handle accessor.subscript operations.
+  if (auto aliasResult = handleAccessorSubscriptAlias(lhs, rhs))
+    return *aliasResult;
+
+  // TODO: handle the other SYCL operations.
+
+  return std::nullopt;
+}
+
+Optional<AliasResult>
+sycl::AliasAnalysis::handleAccessorSubscriptAlias(Value lhs, Value rhs) {
+  Operation *lhsOp = lhs.getDefiningOp(), *rhsOp = rhs.getDefiningOp();
+  auto lhsSubOp = dyn_cast_or_null<sycl::SYCLAccessorSubscriptOp>(lhsOp);
+  auto rhsSubOp = dyn_cast_or_null<sycl::SYCLAccessorSubscriptOp>(rhsOp);
+
+  auto typesDoNotAlias = [](Type lhsTy, Type rhsTy) {
+    return (lhsTy != rhsTy && isMemRefOfSYCLType(rhsTy));
+  };
+
+  // The value produced by an accessor subscript operation does not alias
+  // with values that have a different SYCL type.
+  // Example:
+  //   %1 = affine.load %alloca[0] : memref<1x!sycl_id_1>
+  //   %2 = sycl.accessor.subscript %arg0[%alloca_0] : memref<?xf32, 4>
+  // here 'alias(%2, %alloca) = NoAlias' because:
+  //   - the types of the value '%alloca' and '%2' types are different, and
+  //   - %2 is the result of an accessor.subscript operation, and
+  //   - %alloca type (memref<1x!sycl_id_1>) is a MemRef of a SYCL type
+  Type lhsTy = lhs.getType(), rhsTy = rhs.getType();
+  if ((lhsSubOp && typesDoNotAlias(lhsTy, rhsTy)) ||
+      (rhsSubOp && typesDoNotAlias(rhsTy, lhsTy)))
+    return AliasResult::NoAlias;
+
+  return std::nullopt;
+}

--- a/mlir-sycl/lib/Dialect/Analysis/AliasAnalysis.cpp
+++ b/mlir-sycl/lib/Dialect/Analysis/AliasAnalysis.cpp
@@ -41,14 +41,6 @@ static bool isRestrict(Value val) {
                            "local_alias_analysis.restrict");
 }
 
-// Return true if the operation \p op belongs to the SYCL MLIR dialect.
-static bool isSYCLOperation(Operation *op) {
-  if (!op || !op->getDialect())
-    return false;
-  return op->getDialect()->getNamespace() ==
-         sycl::SYCLDialect::getDialectNamespace();
-}
-
 // Return true is the given type \p ty is a MemRef type with a SYCL element
 // type.
 static bool isMemRefOfSYCLType(Type ty) {
@@ -64,41 +56,40 @@ static bool isMemRefOfSYCLType(Type ty) {
 AliasResult sycl::AliasAnalysis::aliasImpl(Value lhs, Value rhs) {
   if (lhs == rhs)
     return AliasResult::MustAlias;
-  if (Optional<AliasResult> aliasResult = handleRestrictAlias(lhs, rhs))
-    return *aliasResult;
-  if (Optional<AliasResult> aliasResult = handleSYCLAlias(lhs, rhs))
-    return *aliasResult;
 
-  return LocalAliasAnalysis::aliasImpl(lhs, rhs);
+  if (AliasResult aliasResult = handleRestrictAlias(lhs, rhs);
+      !aliasResult.isMay())
+    return aliasResult;
+
+  return handleSYCLAlias(lhs, rhs);
 }
 
-Optional<AliasResult> sycl::AliasAnalysis::handleRestrictAlias(Value lhs,
-                                                               Value rhs) {
+AliasResult sycl::AliasAnalysis::handleRestrictAlias(Value lhs, Value rhs) {
   // Function arguments do not alias if any of them are 'restrict' qualified.
   if (isFuncArg(lhs) && isFuncArg(rhs))
     if (isRestrict(lhs) || isRestrict(rhs))
       return AliasResult::NoAlias;
 
-  return std::nullopt;
+  return AliasResult::MayAlias;
 }
 
-Optional<AliasResult> sycl::AliasAnalysis::handleSYCLAlias(Value lhs,
-                                                           Value rhs) {
+AliasResult sycl::AliasAnalysis::handleSYCLAlias(Value lhs, Value rhs) {
   Operation *lhsOp = lhs.getDefiningOp(), *rhsOp = rhs.getDefiningOp();
   if (!isSYCLOperation(lhsOp) && !isSYCLOperation(rhsOp))
-    return std::nullopt;
+    return AliasResult::MayAlias;
 
   // Handle accessor.subscript operations.
-  if (auto aliasResult = handleAccessorSubscriptAlias(lhs, rhs))
-    return *aliasResult;
+  if (AliasResult aliasResult = handleAccessorSubscriptAlias(lhs, rhs);
+      !aliasResult.isMay())
+    return aliasResult;
 
   // TODO: handle the other SYCL operations.
 
-  return std::nullopt;
+  return AliasResult::MayAlias;
 }
 
-Optional<AliasResult>
-sycl::AliasAnalysis::handleAccessorSubscriptAlias(Value lhs, Value rhs) {
+AliasResult sycl::AliasAnalysis::handleAccessorSubscriptAlias(Value lhs,
+                                                              Value rhs) {
   Operation *lhsOp = lhs.getDefiningOp(), *rhsOp = rhs.getDefiningOp();
   auto lhsSubOp = dyn_cast_or_null<sycl::SYCLAccessorSubscriptOp>(lhsOp);
   auto rhsSubOp = dyn_cast_or_null<sycl::SYCLAccessorSubscriptOp>(rhsOp);
@@ -121,5 +112,5 @@ sycl::AliasAnalysis::handleAccessorSubscriptAlias(Value lhs, Value rhs) {
       (rhsSubOp && typesDoNotAlias(rhsTy, lhsTy)))
     return AliasResult::NoAlias;
 
-  return std::nullopt;
+  return AliasResult::MayAlias;
 }

--- a/mlir-sycl/lib/Dialect/Analysis/AliasAnalysis.cpp
+++ b/mlir-sycl/lib/Dialect/Analysis/AliasAnalysis.cpp
@@ -15,6 +15,9 @@
 
 using namespace mlir;
 
+// TODO: PAss -fstrict-aliasing down from clang through cgeist.
+constexpr bool StrictAliasing = true;
+
 //===----------------------------------------------------------------------===//
 // Helper Functions
 //===----------------------------------------------------------------------===//
@@ -107,10 +110,13 @@ AliasResult sycl::AliasAnalysis::handleAccessorSubscriptAlias(Value lhs,
   //   - the types of the value '%alloca' and '%2' types are different, and
   //   - %2 is the result of an accessor.subscript operation, and
   //   - %alloca type (memref<1x!sycl_id_1>) is a MemRef of a SYCL type
-  Type lhsTy = lhs.getType(), rhsTy = rhs.getType();
-  if ((lhsSubOp && typesDoNotAlias(lhsTy, rhsTy)) ||
-      (rhsSubOp && typesDoNotAlias(rhsTy, lhsTy)))
-    return AliasResult::NoAlias;
+
+  if (StrictAliasing) {
+    Type lhsTy = lhs.getType(), rhsTy = rhs.getType();
+    if ((lhsSubOp && typesDoNotAlias(lhsTy, rhsTy)) ||
+        (rhsSubOp && typesDoNotAlias(rhsTy, lhsTy)))
+      return AliasResult::NoAlias;
+  }
 
   return AliasResult::MayAlias;
 }

--- a/mlir-sycl/lib/Dialect/Analysis/CMakeLists.txt
+++ b/mlir-sycl/lib/Dialect/Analysis/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_mlir_dialect_library(MLIRSYCLAnalysis
+  AliasAnalysis.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_SYCL_INCLUDE_DIR}/mlir/Analysis
+
+  LINK_LIBS PUBLIC
+  MLIRSYCLDialect
+  MLIRAnalysis
+  )

--- a/mlir-sycl/lib/Dialect/CMakeLists.txt
+++ b/mlir-sycl/lib/Dialect/CMakeLists.txt
@@ -1,1 +1,3 @@
+add_subdirectory(Analysis)
 add_subdirectory(IR)
+

--- a/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
@@ -35,6 +35,7 @@ add_mlir_dialect_library(MLIRPolygeistTransforms
   MLIRNVVMDialect
   MLIRPass
   MLIRPolygeist
+  MLIRSYCLAnalysis  
   MLIRSideEffectInterfaces
   MLIRSCFToControlFlow
   MLIRTransformUtils

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SYCL/Analysis/AliasAnalysis.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/IntegerSet.h"
@@ -141,16 +142,16 @@ operator<<(llvm::raw_ostream &OS, const OperationSideEffects &ME) {
 
   OS << "Operation: " << ME.getOperation() << "\n";
   if (isSideEffectFree)
-    OS.indent(2) << "is side effects free.\n";
+    OS.indent(2) << "=> is side effects free.\n";
   else {
     if (ME.readsFromResource())
-      printResources("read resources", ME.readResources);
+      printResources("=> read resources", ME.readResources);
     if (ME.writesToResource())
-      printResources("write resources", ME.writeResources);
+      printResources("=> write resources", ME.writeResources);
     if (ME.freesResource())
-      printResources("free resources", ME.freeResources);
+      printResources("=> free resources", ME.freeResources);
     if (ME.allocatesResource())
-      printResources("allocate resources", ME.allocateResources);
+      printResources("=> allocate resources", ME.allocateResources);
   }
 
   return OS;
@@ -275,7 +276,7 @@ bool OperationSideEffects::conflictsWith(const Operation &other) const {
            .hasTrait<OpTrait::HasRecursiveMemoryEffects>()) {
     LLVM_DEBUG({
       llvm::dbgs()
-          << "Found conflict due to operation with unknown side effects:\n";
+          << "=> found conflict due to operation with unknown side effects:\n";
       llvm::dbgs().indent(2) << other << "\n";
     });
     return true;
@@ -317,10 +318,8 @@ bool OperationSideEffects::conflictsWith(const Operation &other) const {
         [](const MemoryEffects::EffectInstance &EI, AliasResult aliasRes,
            const Operation &other) {
           llvm::dbgs().indent(2)
-              << "found conflicting side effect: {"
-              << EI.getResource()->getName() << ", " << EI.getValue() << "}\n";
-          llvm::dbgs().indent(4) << "with: " << other << "\n";
-          llvm::dbgs().indent(4) << "aliasResult: " << aliasRes << "\n";
+              << "=> found conflicting side effect with: " << other << "\n";
+          llvm::dbgs().indent(2) << "=> aliasResult: " << aliasRes << "\n";
         };
 
     // Check whether the given operation 'other' allocates, writes, or frees a
@@ -349,35 +348,35 @@ bool OperationSideEffects::conflictsWith(const Operation &other) const {
     // Check whether the given operation 'other' allocates, reads, writes or
     // frees a resource that is written by the operation associated with this
     // class.
-    if (llvm::any_of(writeResources, [&](const MemoryEffects::EffectInstance
-                                             &writeRes) {
-          auto hasConflict = [&](const MemoryEffects::EffectInstance &EI) {
-            AliasResult aliasRes =
-                const_cast<AliasAnalysis &>(aliasAnalysis)
-                    .alias(EI.getValue(), writeRes.getValue());
-            if (aliasRes.isNo())
-              return false;
+    if (llvm::any_of(
+            writeResources, [&](const MemoryEffects::EffectInstance &writeRes) {
+              auto hasConflict = [&](const MemoryEffects::EffectInstance &EI) {
+                AliasResult aliasRes =
+                    const_cast<AliasAnalysis &>(aliasAnalysis)
+                        .alias(EI.getValue(), writeRes.getValue());
+                if (aliasRes.isNo())
+                  return false;
 
-            // An aliased read operation doesn't prevent hoisting if it is
-            // dominated by the write operation.
-            if (isa<MemoryEffects::Read>(EI.getEffect()) &&
-                domInfo.dominates(const_cast<Operation *>(&op),
-                                  const_cast<Operation *>(&other))) {
-              LLVM_DEBUG({
-                printConflictingSideEffects(EI, aliasRes, other);
-                llvm::dbgs().indent(2)
-                    << "can be hoisted: aliased write operation dominates the "
-                       "read operation\n";
-              });
-              return false;
-            }
+                // An aliased read operation doesn't prevent hoisting if it is
+                // dominated by the write operation.
+                if (isa<MemoryEffects::Read>(EI.getEffect()) &&
+                    domInfo.dominates(const_cast<Operation *>(&op),
+                                      const_cast<Operation *>(&other))) {
+                  LLVM_DEBUG({
+                    printConflictingSideEffects(EI, aliasRes, other);
+                    llvm::dbgs().indent(2)
+                        << "=> aliased write operation dominates the "
+                           "read operation\n";
+                  });
+                  return false;
+                }
 
-            LLVM_DEBUG(printConflictingSideEffects(EI, aliasRes, other));
-            return true;
-          };
+                LLVM_DEBUG(printConflictingSideEffects(EI, aliasRes, other));
+                return true;
+              };
 
-          return checkForConflict(writeRes.getResource(), hasConflict);
-        })) {
+              return checkForConflict(writeRes.getResource(), hasConflict);
+            })) {
       return true;
     }
 
@@ -778,7 +777,8 @@ static bool canBeHoisted(Operation &op, LoopLikeOpInterface loop,
       !op.hasTrait<OpTrait::HasRecursiveMemoryEffects>()) {
     LLVM_DEBUG({
       llvm::dbgs() << "Operation: " << op << "\n";
-      llvm::dbgs().indent(2) << "cannot be hoisted: unknown side effects\n";
+      llvm::dbgs().indent(2)
+          << "**** cannot be hoisted: unknown side effects\n\n";
     });
     return false;
   }
@@ -789,7 +789,7 @@ static bool canBeHoisted(Operation &op, LoopLikeOpInterface loop,
     LLVM_DEBUG({
       llvm::dbgs() << "Operation: " << op << "\n";
       llvm::dbgs().indent(2)
-          << "cannot be hoisted: operand(s) can't be hoisted\n";
+          << "**** cannot be hoisted: operand(s) can't be hoisted\n\n";
     });
     return false;
   }
@@ -798,7 +798,7 @@ static bool canBeHoisted(Operation &op, LoopLikeOpInterface loop,
   if (isMemoryEffectFree(&op)) {
     LLVM_DEBUG({
       llvm::dbgs() << "Operation: " << op << "\n";
-      llvm::dbgs().indent(2) << "can be hoisted: has no side effects\n";
+      llvm::dbgs().indent(2) << "**** can be hoisted: has no side effects\n\n";
     });
     return true;
   }
@@ -809,7 +809,7 @@ static bool canBeHoisted(Operation &op, LoopLikeOpInterface loop,
     LLVM_DEBUG({
       llvm::dbgs() << "Operation: " << op << "\n";
       llvm::dbgs().indent(2)
-          << "cannot be hoisted: operation allocates a resource\n";
+          << "**** cannot be hoisted: operation allocates a resource\n\n";
     });
     return false;
   }
@@ -822,7 +822,7 @@ static bool canBeHoisted(Operation &op, LoopLikeOpInterface loop,
        sideEffects.freesResource()) &&
       hasConflictsInLoop(op, loop, willBeMoved, aliasAnalysis, domInfo)) {
     LLVM_DEBUG(llvm::dbgs().indent(2)
-               << "cannot be hoisted: found conflicting operation\n");
+               << "**** cannot be hoisted: found conflicting operation\n\n");
     return false;
   }
 
@@ -841,7 +841,8 @@ static bool canBeHoisted(Operation &op, LoopLikeOpInterface loop,
     }
   }
 
-  LLVM_DEBUG(llvm::dbgs().indent(2) << "can be hoisted: no conflicts found\n");
+  LLVM_DEBUG(llvm::dbgs().indent(2)
+             << "**** can be hoisted: no conflicts found\n\n");
 
   return true;
 }
@@ -890,8 +891,9 @@ static size_t moveLoopInvariantCode(LoopLikeOpInterface loop,
 }
 
 void LICM::runOnOperation() {
-  AliasAnalysis &aliasAnalysis = getAnalysis<AliasAnalysis>();
   DominanceInfo &domInfo = getAnalysis<DominanceInfo>();
+  AliasAnalysis &aliasAnalysis = getAnalysis<AliasAnalysis>();
+  aliasAnalysis.addAnalysisImplementation(sycl::AliasAnalysis());
 
   [[maybe_unused]] auto getParentFunction = [](LoopLikeOpInterface loop) {
     Operation *parentOp = loop;

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
@@ -30,6 +30,7 @@ using namespace mlir;
 using namespace polygeist;
 
 namespace {
+
 struct LICM : public LICMBase<LICM> {
   void runOnOperation() override;
 };

--- a/polygeist/test/polygeist-opt/licm.mlir
+++ b/polygeist/test/polygeist-opt/licm.mlir
@@ -182,11 +182,10 @@ func.func @scf_parallel_nohoist1(%arg0: memref<?xf32>, %arg1: index, %arg2: inde
 
 module {
 
-
 // CHECK: #set = affine_set<()[s0, s1] : (s1 - s0 - 1 >= 0)>
 // CHECK: #set1 = affine_set<() : (9 >= 0)>
 
-// COM: Ensure loop invariant unaliased load + store are hoisted.
+// COM: Ensure loop invariant load and store are hoisted.
 func.func @affine_for_hoist1(%arg0: memref<?xf32>, %arg1: index, %arg2: index) {
   // CHECK:       func.func @affine_for_hoist1(%arg0: memref<?xf32>, %arg1: index, %arg2: index) {
   // CHECK-DAG      %cst = arith.constant 2.000000e+00 : f32    
@@ -293,8 +292,8 @@ func.func @affine_for_hoist4(%arg0: memref<?xi32>) {
   return
 }  
 
-// COM: Ensure accessor.subscript operation is hoisted and the load + store instructions before the accessor.subscript
-// COM: operation are also hoisted (because the store referencing %4 is not aliased with %alloca used by the first load).
+// COM: Ensure accessor.subscript operation is hoisted and the load + store instructions before the 
+// COM: accessor.subscript operation are also hoisted (because %4 is not aliased with %alloca).
 func.func @affine_for_hoist5(%arg0: memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
   // CHECK:        func.func @affine_for_hoist5(%arg0: memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
   // CHECK-DAG:      %alloca = memref.alloca() : memref<1x!sycl_id_1_>
@@ -303,12 +302,12 @@ func.func @affine_for_hoist5(%arg0: memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
   // CHECK-NEXT:       %3 = affine.load %alloca[0] : memref<1x!sycl_id_1_>
   // CHECK-NEXT:       affine.store %3, %alloca_0[0] : memref<1x!sycl_id_1_>
   // CHECK-NEXT:       %4 = sycl.accessor.subscript %arg0[%alloca_0] {{.*}} : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<1x!sycl_id_1_>) -> memref<?xf32, 4>
-  // CHECK-NEXT:      affine.for %arg1 = 0 to 10 {
-  // CHECK-NEXT:        %5 = affine.load %4[0] : memref<?xf32, 4>
-  // CHECK-NEXT:        %6 = arith.addf %5, {{.*}} : f32
-  // CHECK-NEXT:        affine.store %6, %4[0] : memref<?xf32, 4>
-  // CHECK-NEXT:      }
-  // CHECK-NEXT:    }    
+  // CHECK-NEXT:       affine.for %arg1 = 0 to 10 {
+  // CHECK-NEXT:         %5 = affine.load %4[0] : memref<?xf32, 4>
+  // CHECK-NEXT:         %6 = arith.addf %5, {{.*}} : f32
+  // CHECK-NEXT:         affine.store %6, %4[0] : memref<?xf32, 4>
+  // CHECK-NEXT:       }
+  // CHECK-NEXT:     }    
 
   %alloca = memref.alloca() : memref<1x!sycl_id_1>  
   %alloca_0 = memref.alloca() : memref<1x!sycl_id_1>


### PR DESCRIPTION
The MLIR local alias analysis is very conservative. This PR introduces an AliasAnalysis focused on SYCL dialect operation. The intent is to augment the basic MLIR `LocalAliasAnalysis` with the new analysis.

This PR introduces the new `sycl::AliasAnalysis` class, with initial support for `sycl.accessor.subscript` operations. 
The new analysis is used in the polygeist LICM pass to allow that pass to hoist loop invariant `sycl.accessor.subscript` operations.
 