### PR TITLE
[ESIMD] Add ext::intel::experimental::esimd::wait()

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -505,6 +505,7 @@ public:
         {"raw_send2_noresult",
          {"raw.send2.noresult",
           {a(0), a(1), ai1(2), a(3), a(4), a(5), a(6), a(7)}}},
+        {"wait", {"dummy.mov", {a(0)}}},
         {"dpas2",
          {"dpas2", {a(0), a(1), a(2), t(0), t(1), t(2), t(3), t(11), t(12)}}},
         {"dpas_nosrc0", {"dpas.nosrc0", {a(0), a(1), t(0)}}},

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
@@ -26,6 +26,11 @@ __ESIMD_INTRIN void __esimd_sbarrier(__ESIMD_ENS::split_barrier_action flag)
 }
 #endif // __SYCL_DEVICE_ONLY__
 
+#ifdef __SYCL_DEVICE_ONLY__
+// Create an explicit data and GPU scoreboard dependency.
+__ESIMD_INTRIN void __esimd_wait(uint16_t value);
+#endif // __SYCL_DEVICE_ONLY__
+
 // \brief Raw sends load.
 //
 // @param modifier	the send message flags (Bit-0: isSendc, Bit-1: isEOT).

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -253,6 +253,31 @@ __ESIMD_API void named_barrier_signal(uint8_t barrier_id,
       0 /*sendc*/, gateway, descriptor, payload, 1 /*pred*/);
 }
 
+/// Create explicit scoreboard dependency to avoid device code motion
+/// across this call and preserve the \p value computation even
+/// if it is unused.
+template <typename T, int N>
+__ESIMD_API std::enable_if_t<(sizeof(T) * N >= 2)>
+wait(__ESIMD_NS::simd<T, N> value) {
+#ifdef __SYCL_DEVICE_ONLY__
+  uint16_t Word = value.template bit_cast_view<uint16_t>()[0];
+  __esimd_wait(Word);
+#endif // __SYCL_DEVICE_ONLY__
+}
+
+/// Create explicit scoreboard dependency to avoid device code motion
+/// across this call and preserve the \p value computation even
+/// if it is unused.
+template <typename T, typename RegionT>
+__ESIMD_API std::enable_if_t<
+    (RegionT::length * sizeof(typename RegionT::element_type) >= 2)>
+wait(__ESIMD_NS::simd_view<T, RegionT> value) {
+#ifdef __SYCL_DEVICE_ONLY__
+  uint16_t Word = value.template bit_cast_view<uint16_t>()[0];
+  __esimd_wait(Word);
+#endif // __SYCL_DEVICE_ONLY__
+}
+
 /// @} sycl_esimd_memory_nbarrier
 
 /// @defgroup sycl_esimd_memory_lsc LSC memory access APIs.


### PR DESCRIPTION
The function is a very specific tool to set up a scoreboard dependency, add a use for the given value. It also prevents dead/unused value from optimizing away.