### PR TITLE
[NFC][SYCL][Fusion] Drop debug messages check in internalization test

### DIFF
--- a/sycl-fusion/test/internalization/abort-promote-stored-ptr.ll
+++ b/sycl-fusion/test/internalization/abort-promote-stored-ptr.ll
@@ -1,11 +1,8 @@
 ; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext\
-; RUN: -passes=sycl-internalization --sycl-info-path %S/abort-kernel-info.yaml -S %s -debug 2>&1 | FileCheck %s
+; RUN: -passes=sycl-internalization --sycl-info-path %S/abort-kernel-info.yaml -S %s | FileCheck %s
 
 target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"
 target triple = "spir64-unknown-unknown"
-
-; CHECK: Unable to perform all promotions for function fused_0. Detailed information:
-; CHECK: Failed to promote argument 0 of function fused_0: It is not safe to promote values being stored to another pointer
 
 ; CHECK-LABEL: define {{[^@]+}}@fused_0
 ; CHECK-SAME: (float addrspace(1)* align 4 %[[ACC:.*]])


### PR DESCRIPTION
The test was failing for builds with no assertions. Dropping the `-debug` option and the lines checking for the warning messages due to aborted internalization fixes the test.