### PR TITLE
[SYCL][XPTI] Fix using xptifw in external projects

### DIFF
--- a/xptifw/CMakeLists.txt
+++ b/xptifw/CMakeLists.txt
@@ -6,9 +6,12 @@ project (xptifw VERSION "${XPTI_VERSION}" LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 17)
 
 set(XPTIFW_DIR ${CMAKE_CURRENT_LIST_DIR})
+
 # The XPTI framework requires the includes from
 # the proxy implementation of XPTI
-set(XPTI_DIR ${CMAKE_CURRENT_LIST_DIR}/../xpti)
+if (NOT DEFINED XPTI_DIR) # don't overwrite if already set
+  set(XPTI_DIR ${XPTI_SOURCE_DIR}/../xpti)
+endif()
 
 # Create a soft option for enabling the use of TBB
 option(XPTI_ENABLE_TBB "Enable TBB in the framework" OFF)

--- a/xptifw/CMakeLists.txt
+++ b/xptifw/CMakeLists.txt
@@ -17,6 +17,7 @@ option(XPTI_ENABLE_WERROR OFF)
 option(XPTI_BUILD_SAMPLES OFF)
 option(XPTI_BUILD_BENCHMARK OFF)
 option(XPTI_ENABLE_STATISTICS OFF)
+option(XPTI_ENABLE_TESTS ON)
 
 if (XPTI_ENABLE_WERROR)
   if(MSVC)
@@ -55,7 +56,10 @@ add_subdirectory(src)
 
 add_custom_target(check-xptifw)
 
-add_subdirectory(unit_test)
+if (XPTI_ENABLE_TESTS)
+  add_subdirectory(unit_test)
+endif()
+
 if (XPTI_BUILD_SAMPLES)
   add_subdirectory(samples/basic_collector)
   add_subdirectory(samples/syclpi_collector)


### PR DESCRIPTION
Currently, xptifw, when built outside of SYCL, downloads its own copy
of the googletest framework. This leads to target name collisions
when xptifw is included in other CMake projects (e.g., unified runtime), so add an option to disable tests in xptifw.

This project also hardcodes the location for the XPTI proxy implementation. This prevents its use outside of SYCL, so allow setting external xpti dir in xptifw.