### PR TITLE
[SYCL-MLIR]: Make the first operand of SYCLConstructorOp [MemWrite]

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -514,13 +514,13 @@ def SYCLSubGroupLocalIDOp : SYCL1DGridOp<"sub_group_local_id"> {
 // CONSTRUCTOR OPERATION
 ////////////////////////////////////////////////////////////////////////////////
 
-def ConstructorArgs : AnyTypeOf<[SYCLMemref,
-                                 VectorEltTy,
+def ConstructorArgs : AnyTypeOf<[Builtin_Vector,
                                  IndexType,
-                                 VectorSplatArg,
                                  SYCL_IDType,
+                                 SYCLMemref,
                                  SYCL_RangeType,
-                                 Builtin_Vector,
+                                 VectorEltTy,
+                                 VectorSplatArg
                                ]>;
 def SYCLConstructorOp : SYCL_Op<"constructor", [CallOpInterface]> {
   let summary = "Generic constructor operation";
@@ -529,9 +529,10 @@ def SYCLConstructorOp : SYCL_Op<"constructor", [CallOpInterface]> {
   }];
 
   let arguments = (ins
+    Arg<SYCLMemref, "The SYCL object being created", [MemWrite]>:$Dst,
+    Variadic<ConstructorArgs>:$Args,  
     FlatSymbolRefAttr:$TypeName,
-    FlatSymbolRefAttr:$MangledFunctionName,
-    Variadic<ConstructorArgs>:$Args
+    FlatSymbolRefAttr:$MangledFunctionName
   );
   let results = (outs);
 
@@ -555,7 +556,7 @@ def SYCLConstructorOp : SYCL_Op<"constructor", [CallOpInterface]> {
   }];      
 
   let assemblyFormat = [{
-    $TypeName `(` $Args `)` attr-dict `:` `(` type($Args) `)`
+    $TypeName `(` $Dst (`,` $Args^)?`)` attr-dict `:` `(` type($Dst) (`,` type($Args)^)? `)`
   }];
 }
 

--- a/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
@@ -64,11 +64,8 @@ bool SYCLCastOp::areCastCompatible(TypeRange Inputs, TypeRange Outputs) {
 }
 
 LogicalResult SYCLConstructorOp::verify() {
-  if (getNumOperands() == 0)
-    return emitOpError("A sycl::constructor must be passed the object to build "
-                       "as the first argument");
-  auto MT = getOperand(0).getType().dyn_cast<MemRefType>();
-  if (MT && isSYCLType(MT.getElementType()))
+  auto mt = getOperand(0).getType().dyn_cast<MemRefType>();
+  if (mt && isSYCLType(mt.getElementType()))
     return success();
 
   return emitOpError("The first argument of a sycl::constructor op has to be a "

--- a/mlir-sycl/test/Dialect/IR/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/invalid.mlir
@@ -25,24 +25,6 @@ func.func @test_cast_bad_shape(%arg: memref<1x!sycl_id_1_>) -> memref<2x!sycl_ar
 
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 
-func.func @test_non_memref_arg_constructor(%range: !sycl_range_1_) {
-  // expected-error @+1 {{'sycl.constructor' op The first argument of a sycl::constructor op has to be a MemRef to a SYCL type}}
-  sycl.constructor @range(%range) {MangledFunctionName = @rangev} : (!sycl_range_1_)
-}
-
-// -----
-
-!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
-
-func.func @test_non_sycl_arg_constructor(%i: memref<1xi32>) {
-  // expected-error @+1 {{'sycl.constructor' op The first argument of a sycl::constructor op has to be a MemRef to a SYCL type}}
-  sycl.constructor @range(%i) {MangledFunctionName = @rangev} : (memref<1xi32>)
-}
-
-// -----
-
-!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
-
 func.func @test_num_work_items(%i: i32) -> !sycl_range_1_ {
   // expected-error @+1 {{'sycl.num_work_items' op Expecting an index return value for this cardinality}}
   %0 = sycl.num_work_items %i : !sycl_range_1_

--- a/mlir-sycl/test/Dialect/IR/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/invalid.mlir
@@ -23,13 +23,6 @@ func.func @test_cast_bad_shape(%arg: memref<1x!sycl_id_1_>) -> memref<2x!sycl_ar
 
 // -----
 
-func.func @test_not_arg_constructor() {
-  // expected-error @+1 {{'sycl.constructor' op A sycl::constructor must be passed the object to build as the first argument}}
-  "sycl.constructor"() {TypeName = @range, MangledFunctionName = @rangev} : () -> ()
-}
-
-// -----
-
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 
 func.func @test_non_memref_arg_constructor(%range: !sycl_range_1_) {

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1140,7 +1140,7 @@ MLIRScanner::emitSYCLOps(const clang::Expr *Expr,
           !RD->getName().empty()) {
         std::string Name =
             MLIRScanner::getMangledFuncName(*Func, Glob.getCGM());
-        SmallVector<Value> RemainderArgs(Args.begin() + 1, Args.end());
+        ArrayRef<Value> RemainderArgs(Args.begin() + 1, Args.end());
         return Builder.create<mlir::sycl::SYCLConstructorOp>(
             Loc, Args[0], RemainderArgs, RD->getName(), Name);
       }

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1140,8 +1140,9 @@ MLIRScanner::emitSYCLOps(const clang::Expr *Expr,
           !RD->getName().empty()) {
         std::string Name =
             MLIRScanner::getMangledFuncName(*Func, Glob.getCGM());
-        return Builder.create<mlir::sycl::SYCLConstructorOp>(Loc, RD->getName(),
-                                                             Name, Args);
+        SmallVector<Value> RemainderArgs(Args.begin() + 1, Args.end());
+        return Builder.create<mlir::sycl::SYCLConstructorOp>(
+            Loc, Args[0], RemainderArgs, RD->getName(), Name);
       }
     }
   }


### PR DESCRIPTION
The first operand of the SYCLConstructorOp operation is always a memref representing the SYCL object being constructed. Make it use the MemWrite memory effect interface.