### PR TITLE
[SYCL][L0] Don't append commands to the closed cmd list

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.hpp
+++ b/sycl/plugins/level_zero/pi_level_zero.hpp
@@ -192,6 +192,10 @@ struct pi_command_list_info_t {
   // may be still "in-use" due to sporadic delay in HW.
   bool ZeFenceInUse{false};
 
+  // Indicates if command list is in closed state. This is needed to avoid
+  // appending commands to the closed command list.
+  bool IsClosed{false};
+
   // Record the queue to which the command list will be submitted.
   ze_command_queue_handle_t ZeQueue{nullptr};
   // Keeps the ordinal of the ZeQueue queue group. Invalid if ZeQueue==nullptr


### PR DESCRIPTION
Shortly, problem is that currently we can't call executeCommandList for the closed command list. If we do this then it is marked as "open" again and new commands are appended there which leads to a hang.

Details:
To insert a queue-wide barrier in the piEnqueueEventsWaitWithBarrier we:
1. get a command list for each level zero queue in the pi_queue. We insert barrier into each command list and each inserted barrier signals its own event.

2. We create an event list using createAndRetainPiZeEventList based on events from all barriers -> At this point some of the open command lists may get closed and executed.

3. We insert convergence barrier into the first cmd list.

4. We call executeCommandList for each command list and that will lead to the fail if command list was closed at step 2. Because that command list will be marked as "open" again.