### PR TITLE
[SYCL] Initialize members of device_global map entries

### DIFF
--- a/sycl/source/detail/device_global_map_entry.hpp
+++ b/sycl/source/detail/device_global_map_entry.hpp
@@ -82,16 +82,16 @@ struct DeviceGlobalMapEntry {
   // The unique identifier of the device_global.
   std::string MUniqueId;
   // Pointer to the device_global on host.
-  const void *MDeviceGlobalPtr;
+  const void *MDeviceGlobalPtr = nullptr;
   // The image identifiers for the images using the device_global used by in the
   // cache.
   std::set<std::uintptr_t> MImageIdentifiers;
   // The kernel-set IDs for the images using the device_global.
   std::set<KernelSetId> MKSIds;
   // Size of the underlying type in the device_global.
-  std::uint32_t MDeviceGlobalTSize;
+  std::uint32_t MDeviceGlobalTSize = 0;
   // True if the device_global has been decorated with device_image_scope.
-  bool MIsDeviceImageScopeDecorated;
+  bool MIsDeviceImageScopeDecorated = false;
 
   // Constructor for only initializing ID and pointer. The other members will
   // be initialized later.
@@ -103,8 +103,7 @@ struct DeviceGlobalMapEntry {
   DeviceGlobalMapEntry(std::string UniqueId, std::uintptr_t ImgId,
                        KernelSetId KSId, std::uint32_t DeviceGlobalTSize,
                        bool IsDeviceImageScopeDecorated)
-      : MUniqueId(UniqueId), MDeviceGlobalPtr(nullptr),
-        MImageIdentifiers{ImgId}, MKSIds{KSId},
+      : MUniqueId(UniqueId), MImageIdentifiers{ImgId}, MKSIds{KSId},
         MDeviceGlobalTSize(DeviceGlobalTSize),
         MIsDeviceImageScopeDecorated(IsDeviceImageScopeDecorated) {}
 


### PR DESCRIPTION
This commit adds default initializers to select members of DeviceGlobalMapEntry to avoid cases where bogus values would confuse late initialization of the entries.