### PR TITLE
[SYCL][ESIMD] Handle scalar loads of SPIRV global vector in LowerESIMD

### DIFF
--- a/llvm/lib/Passes/PassBuilderPipelines.cpp
+++ b/llvm/lib/Passes/PassBuilderPipelines.cpp
@@ -634,9 +634,7 @@ PassBuilder::buildFunctionSimplificationPipeline(OptimizationLevel Level,
 
   // Try vectorization/scalarization transforms that are both improvements
   // themselves and can allow further folds with GVN and InstCombine.
-  // Disable for SYCL until SPIR-V reader is updated for all drivers.
-  if (!SYCLOptimizationMode)
-    FPM.addPass(VectorCombinePass(/*TryEarlyFoldsOnly=*/true));
+  FPM.addPass(VectorCombinePass(/*TryEarlyFoldsOnly=*/true));
 
   // Eliminate redundancies.
   FPM.addPass(MergedLoadStoreMotionPass());

--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -1203,7 +1203,7 @@ translateSpirvGlobalUses(LoadInst *LI, StringRef SpirvGlobalName,
   if (!LI->getType()->isVectorTy()) {
     // Copy users to seperate container for safe modification
     // during iteration.
-    SmallVector<User *> Users(LI->users().begin(), LI->users().end());
+    SmallVector<User *> Users(LI->users());
     for (User *LU : Users) {
       Instruction *Inst = cast<Instruction>(LU);
       NewInst =

--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -1195,6 +1195,25 @@ translateSpirvGlobalUses(LoadInst *LI, StringRef SpirvGlobalName,
     return;
   }
 
+  // As an optimization of accesses of the first element for vector SPIRV
+  // globals sometimes the load will return a scalar and the uses can be of any
+  // pattern. In this case, generate GenX calls to access the first element and
+  // update the use to instead use the GenX call result rather than the load
+  // result.
+  if (!LI->getType()->isVectorTy()) {
+    // Copy users to seperate container for safe modification
+    // during iteration.
+    SmallVector<User *> Users(LI->users().begin(), LI->users().end());
+    for (User *LU : Users) {
+      Instruction *Inst = cast<Instruction>(LU);
+      NewInst =
+          generateSpirvGlobalGenX(Inst, SpirvGlobalName, /*IndexValue=*/0);
+      LU->replaceUsesOfWith(LI, NewInst);
+    }
+    InstsToErase.push_back(LI);
+    return;
+  }
+
   // Only loads from _vector_ SPIRV globals reach here now. Their users are
   // expected to be ExtractElementInst only, and they are
   // replaced in this loop. When loads from _scalar_ SPIRV globals are handled

--- a/llvm/test/SYCLLowerIR/ESIMD/lower_spirv_intrins_vector_treated_as_scalar.ll
+++ b/llvm/test/SYCLLowerIR/ESIMD/lower_spirv_intrins_vector_treated_as_scalar.ll
@@ -1,0 +1,32 @@
+; RUN: opt -opaque-pointers < %s -passes=LowerESIMD -S | FileCheck %s
+
+; This test checks we lower vector SPIRV globals correctly if
+; it is accessed as a scalar as an optimization to get the first element
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+@__spirv_BuiltInGlobalInvocationId = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
+
+define spir_kernel void @"__spirv_GlobalInvocationId_xyz"(i64 addrspace(1)* %_arg_) {
+; CHECK-LABEL: @__spirv_GlobalInvocationId_xyz(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[DOTESIMD6:%.*]] = call <3 x i32> @llvm.genx.local.id.v3i32()
+; CHECK-NEXT:    [[LOCAL_ID_X:%.*]] = extractelement <3 x i32> [[DOTESIMD6]], i32 0
+; CHECK-NEXT:    [[LOCAL_ID_X_CAST_TY:%.*]] = zext i32 [[LOCAL_ID_X]] to i64
+; CHECK-NEXT:    [[DOTESIMD7:%.*]] = call <3 x i32> @llvm.genx.local.size.v3i32()
+; CHECK-NEXT:    [[WGSIZE_X:%.*]] = extractelement <3 x i32> [[DOTESIMD7]], i32 0
+; CHECK-NEXT:    [[WGSIZE_X_CAST_TY:%.*]] = zext i32 [[WGSIZE_X]] to i64
+; CHECK-NEXT:    [[GROUP_ID_X:%.*]] = call i32 @llvm.genx.group.id.x()
+; CHECK-NEXT:    [[GROUP_ID_X_CAST_TY:%.*]] = zext i32 [[GROUP_ID_X]] to i64
+; CHECK-NEXT:    [[MUL8:%.*]] = mul i64 [[WGSIZE_X_CAST_TY]], [[GROUP_ID_X_CAST_TY]]
+; CHECK-NEXT:    [[ADD9:%.*]] = add i64 [[LOCAL_ID_X_CAST_TY]], [[MUL8]]
+; CHECK-NEXT:    [[MUL10:%.*]] = shl nuw nsw i64 [[ADD9]], 5
+
+; Verify that the attribute is deleted from GenX declaration
+; CHECK-NOT: readnone
+entry:
+ %0 = load i64, ptr addrspace(1) @__spirv_BuiltInGlobalInvocationId, align 32
+ %mul.i = shl nuw nsw i64 %0, 5
+ ret void
+}


### PR DESCRIPTION
 As an optimization of accesses of the first element for vector SPIRV
 globals sometimes the load will return a scalar and the uses can be of any
 pattern. In this case, generate GenX calls to access the first element and
 update the use to instead use the GenX call result rather than the load
 result.

 With this last remaining issue fixed, enable VectorCombine for SYCL.