### PR TITLE
[SYCL][Reduction] Limit reduction work non-uniform case

### DIFF
--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -1160,9 +1160,10 @@ void doTreeReduction(size_t WorkSize, nd_item<Dim> NDIt, LocalRedsTy &LocalReds,
                         });
 }
 
+// Tree-reduction over tuples of accessors. This assumes that WorkSize is
+// less than or equal to the work-group size.
 // TODO: For variadics/tuples we don't provide such a high-level abstraction as
 // for the scalar case above. Is there some C++ magic to level them?
-// TODO2: Document differences in APIs.
 template <typename... LocalAccT, typename... BOPsT, size_t... Is,
           typename BarrierTy>
 void doTreeReductionOnTuple(size_t WorkSize, size_t LID,

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -1125,7 +1125,7 @@ void doTreeReductionHelper(size_t WorkSize, size_t LID, BarrierTy Barrier,
 }
 
 // Enum for specifying work size guarantees in tree-reduction.
-enum WorkSizeGuarantees { None, Equal, LessOrEqual };
+enum class WorkSizeGuarantees { None, Equal, LessOrEqual };
 
 template <WorkSizeGuarantees WSGuarantee, int Dim, typename LocalRedsTy,
           typename BinOpTy, typename BarrierTy, typename AccessFuncTy>

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -1574,6 +1574,7 @@ template <> struct NDRangeReduction<reduction::strategy::basic> {
           size_t WGSize = NDIt.get_local_range().size();
           size_t LID = NDIt.get_local_linear_id();
           size_t GID = NDIt.get_global_linear_id();
+          size_t GrID = NDIt.get_group_linear_id();
 
           for (int E = 0; E < NElements; ++E) {
             // The last work-group may not have enough work for all its items.
@@ -1590,7 +1591,6 @@ template <> struct NDRangeReduction<reduction::strategy::basic> {
 
             // Compute the partial sum/reduction for the work-group.
             if (LID == 0) {
-              size_t GrID = NDIt.get_group_linear_id();
               typename Reduction::result_type PSum = LocalReds[0];
               if (IsUpdateOfUserVar)
                 PSum = BOp(Out[0], PSum);


### PR DESCRIPTION
In certain cases non-uniform reductions will not have enough work to fill the partial reduction in the last work-group. Previously we would pad with the identity to work around this, but to avoid needing to do this we can now instead reduce the size of the partial reduction to the actual amount of work.