### PR TITLE
[SYCL] Fix refcounting for kernel_bundle interop with OpenCL

### DIFF
--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -141,6 +141,8 @@ make_kernel_bundle(pi_native_handle NativeHandle, const context &TargetContext,
   pi::PiProgram PiProgram = nullptr;
   Plugin.call<PiApiKind::piextProgramCreateWithNativeHandle>(
       NativeHandle, ContextImpl->getHandleRef(), !KeepOwnership, &PiProgram);
+  if (Plugin.getBackend() == backend::opencl)
+    Plugin.call<PiApiKind::piProgramRetain>(PiProgram);
 
   std::vector<pi::PiDevice> ProgramDevices;
   size_t NumDevices = 0;

--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -230,6 +230,8 @@ public:
     const auto &ContextImplPtr = detail::getSyclObjImpl(MContext);
     const plugin &Plugin = ContextImplPtr->getPlugin();
 
+    if (Plugin.getBackend() == backend::opencl)
+      Plugin.call<PiApiKind::piProgramRetain>(MProgram);
     pi_native_handle NativeProgram = 0;
     Plugin.call<PiApiKind::piextProgramGetNativeHandle>(MProgram,
                                                         &NativeProgram);


### PR DESCRIPTION
OpenCL interop spec basically says that each "conversion" must adjust reference counter of the underlying object. Many of the interop interfaces had been fixed in https://github.com/intel/llvm/pull/3236 but the majority of the kernel_bundle feature was implemented after that and made the same omission.

I'm not sure if that is the best way to fix it though. Another alternative would be to move all these retains into the OpenCL PI plugin.