### PR TITLE
[SYCL] Avoid passing pointer to temporary in device_global initialization

### DIFF
--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -339,7 +339,7 @@ std::vector<RT::PiEvent> context_impl::initializeDeviceGlobals(
       // Write the pointer to the device global and store the event in the
       // initialize events list.
       RT::PiEvent InitEvent;
-      void *USMPtr = DeviceGlobalUSM.getPtr();
+      void *const &USMPtr = DeviceGlobalUSM.getPtr();
       Plugin.call<PiApiKind::piextEnqueueDeviceGlobalVariableWrite>(
           QueueImpl->getHandleRef(), NativePrg,
           DeviceGlobalEntry->MUniqueId.c_str(), false, sizeof(void *), 0,

--- a/sycl/source/detail/device_global_map_entry.hpp
+++ b/sycl/source/detail/device_global_map_entry.hpp
@@ -64,7 +64,7 @@ struct DeviceGlobalUSMMem {
   DeviceGlobalUSMMem(void *Ptr) : MPtr(Ptr) {}
   ~DeviceGlobalUSMMem();
 
-  void *getPtr() const noexcept { return MPtr; }
+  void *const &getPtr() const noexcept { return MPtr; }
 
   // Gets the zero-initialization event if it exists. If not the OwnedPiEvent
   // will contain no event.


### PR DESCRIPTION
This commit fixes a bug where the backend would be passed a pointer to a temporary value holding the pointer to the address of the USM memory for the device_global when initializing it, potentially causing wrong values to be copied.