### PR TITLE
[CI] Use correct variable in windows pre-commit on comment workflow

### DIFF
--- a/.github/workflows/windows_test_comment_trigger.yml
+++ b/.github/workflows/windows_test_comment_trigger.yml
@@ -28,7 +28,7 @@ jobs:
           const pr = await github.rest.pulls.get({
             owner: context.issue.owner,
             repo: context.issue.repo,
-            pull_number: number
+            pull_number: context.issue.number
           });
           return pr.data.head.sha
     - name: update_pr_status_pending


### PR DESCRIPTION
The `number` variable doesn't exist after https://github.com/intel/llvm/pull/8297 .
The patch updates workflow to use full name `context.issue.number`.