### PR TITLE
[compiler-rt]revert local fix for opaque pointers

### DIFF
--- a/compiler-rt/test/profile/Linux/counter_promo_for.c
+++ b/compiler-rt/test/profile/Linux/counter_promo_for.c
@@ -22,9 +22,9 @@ __attribute__((noinline)) void foo(int n, int N) {
 // PROMO: load{{.*}}@__profc_foo{{.*}} 3){{.*}}
 // PROMO-NEXT: add
 // PROMO-NEXT: store{{.*}}@__profc_foo{{.*}} 3){{.*}}
-// PROMO: load{{.*}}@__profc_foo, align
+// PROMO: load{{.*}}@__profc_foo{{.*}} 0){{.*}}
 // PROMO-NEXT: add
-// PROMO-NEXT: store{{.*}}@__profc_foo, align
+// PROMO-NEXT: store{{.*}}@__profc_foo{{.*}} 0){{.*}}
 // PROMO-NEXT: load{{.*}}@__profc_foo{{.*}} 1){{.*}}
 // PROMO-NEXT: add
 // PROMO-NEXT: store{{.*}}@__profc_foo{{.*}} 1){{.*}}
@@ -33,9 +33,9 @@ __attribute__((noinline)) void foo(int n, int N) {
 // PROMO-NEXT: store{{.*}}@__profc_foo{{.*}} 2){{.*}}
 //
 // NOPROMO-LABEL: @foo
-// NOPROMO: load{{.*}}@__profc_foo, align
+// NOPROMO: load{{.*}}@__profc_foo{{.*}} 0){{.*}}
 // NOPROMO-NEXT: add
-// NOPROMO-NEXT: store{{.*}}@__profc_foo, align
+// NOPROMO-NEXT: store{{.*}}@__profc_foo{{.*}} 0){{.*}}
 // NOPROMO: load{{.*}}@__profc_foo{{.*}} 1){{.*}}
 // NOPROMO-NEXT: add
 // NOPROMO-NEXT: store{{.*}}@__profc_foo{{.*}} 1){{.*}}

--- a/compiler-rt/test/profile/Linux/counter_promo_while.c
+++ b/compiler-rt/test/profile/Linux/counter_promo_while.c
@@ -17,9 +17,9 @@ int g;
 __attribute__((noinline)) void bar(int i) { g += i; }
 __attribute__((noinline)) void foo(int n, int N) {
 // PROMO-LABEL: @foo
-// PROMO: load{{.*}}@__profc_foo, align
+// PROMO: load{{.*}}@__profc_foo{{.*}} 0){{.*}}
 // PROMO-NEXT: add
-// PROMO-NEXT: store{{.*}}@__profc_foo, align
+// PROMO-NEXT: store{{.*}}@__profc_foo{{.*}} 0){{.*}}
 // PROMO-NEXT: load{{.*}}@__profc_foo{{.*}} 1){{.*}}
 // PROMO-NEXT: add
 // PROMO-NEXT: store{{.*}}@__profc_foo{{.*}} 1){{.*}}
@@ -28,9 +28,9 @@ __attribute__((noinline)) void foo(int n, int N) {
 // PROMO-NEXT: store{{.*}}@__profc_foo{{.*}} 2){{.*}}
 //
 // NOPROMO-LABEL: @foo
-// NOPROMO: load{{.*}}@__profc_foo, align
+// NOPROMO: load{{.*}}@__profc_foo{{.*}} 0){{.*}}
 // NOPROMO-NEXT: add
-// NOPROMO-NEXT: store{{.*}}@__profc_foo, align
+// NOPROMO-NEXT: store{{.*}}@__profc_foo{{.*}} 0){{.*}}
 // NOPROMO: load{{.*}}@__profc_foo{{.*}} 1){{.*}}
 // NOPROMO-NEXT: add
 // NOPROMO-NEXT: store{{.*}}@__profc_foo{{.*}} 1){{.*}}


### PR DESCRIPTION
This reverts

commit fe0bd3e24e9c8ed886170e242a429a49407e1a75
Author: Nikita Popov <npopov@redhat.com>
Date:   Wed Dec 14 16:45:05 2022 +0100

    [compiler-rt] Convert profile tests to opaque pointers (NFC)
