### PR TITLE
Revert "[Clang] Update compiler-rt sanitizer test to use opaque pointers (NFC)"

### DIFF
--- a/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_allowlist_ignorelist.cpp
+++ b/compiler-rt/test/sanitizer_common/TestCases/sanitizer_coverage_allowlist_ignorelist.cpp
@@ -25,10 +25,8 @@
 
 // Check inline-8bit-counters
 // RUN: echo 'section "__sancov_cntrs"'                                                                             >  patterns.txt
-// RUN: echo '%[0-9]\+ = load i8, ptr @__sancov_gen_' >> patterns.txt
-// RUN: echo 'store i8 %[0-9]\+, ptr @__sancov_gen_'  >> patterns.txt
-// RUN: echo '%[0-9]\+ = load i8, ptr getelementptr inbounds (\[[0-9]\+ x i8\], ptr @__sancov_gen_' >> patterns.txt
-// RUN: echo 'store i8 %[0-9]\+, ptr getelementptr inbounds (\[[0-9]\+ x i8\], ptr @__sancov_gen_'  >> patterns.txt
+// RUN: echo '%[0-9]\+ = load i8, i8\* getelementptr inbounds (\[[0-9]\+ x i8\], \[[0-9]\+ x i8\]\* @__sancov_gen_' >> patterns.txt
+// RUN: echo 'store i8 %[0-9]\+, i8\* getelementptr inbounds (\[[0-9]\+ x i8\], \[[0-9]\+ x i8\]\* @__sancov_gen_'  >> patterns.txt
 
 // Check indirect-calls
 // RUN: echo 'call void @__sanitizer_cov_trace_pc_indir'                                                            >> patterns.txt
@@ -39,47 +37,47 @@
 // Check pc-table
 // RUN: echo 'section "__sancov_pcs"'                                                                               >> patterns.txt
 
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table                                                                                      2>&1 |     grep -f patterns.txt | count 14
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_all.txt                                             2>&1 |     grep -f patterns.txt | count 14
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_none.txt                                            2>&1 | not grep -f patterns.txt
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_file.txt                                            2>&1 |     grep -f patterns.txt | count 14
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_foo.txt                                             2>&1 |     grep -f patterns.txt | count 9
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_bar.txt                                             2>&1 |     grep -f patterns.txt | count 5
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table                                                                                      2>&1 |     grep -f patterns.txt | count 14
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_all.txt                                             2>&1 |     grep -f patterns.txt | count 14
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_none.txt                                            2>&1 | not grep -f patterns.txt
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_file.txt                                            2>&1 |     grep -f patterns.txt | count 14
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_foo.txt                                             2>&1 |     grep -f patterns.txt | count 9
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_bar.txt                                             2>&1 |     grep -f patterns.txt | count 5
 
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table                                           -fsanitize-coverage-ignorelist=bl_all.txt   2>&1 | not grep -f patterns.txt
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_all.txt  -fsanitize-coverage-ignorelist=bl_all.txt   2>&1 | not grep -f patterns.txt
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_none.txt -fsanitize-coverage-ignorelist=bl_all.txt   2>&1 | not grep -f patterns.txt
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_file.txt -fsanitize-coverage-ignorelist=bl_all.txt   2>&1 | not grep -f patterns.txt
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_foo.txt  -fsanitize-coverage-ignorelist=bl_all.txt   2>&1 | not grep -f patterns.txt
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_bar.txt  -fsanitize-coverage-ignorelist=bl_all.txt   2>&1 | not grep -f patterns.txt
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table                                           -fsanitize-coverage-ignorelist=bl_all.txt   2>&1 | not grep -f patterns.txt
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_all.txt  -fsanitize-coverage-ignorelist=bl_all.txt   2>&1 | not grep -f patterns.txt
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_none.txt -fsanitize-coverage-ignorelist=bl_all.txt   2>&1 | not grep -f patterns.txt
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_file.txt -fsanitize-coverage-ignorelist=bl_all.txt   2>&1 | not grep -f patterns.txt
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_foo.txt  -fsanitize-coverage-ignorelist=bl_all.txt   2>&1 | not grep -f patterns.txt
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_bar.txt  -fsanitize-coverage-ignorelist=bl_all.txt   2>&1 | not grep -f patterns.txt
 
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table                                           -fsanitize-coverage-ignorelist=bl_none.txt  2>&1 |     grep -f patterns.txt | count 14
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_all.txt  -fsanitize-coverage-ignorelist=bl_none.txt  2>&1 |     grep -f patterns.txt | count 14
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_none.txt -fsanitize-coverage-ignorelist=bl_none.txt  2>&1 | not grep -f patterns.txt
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_file.txt -fsanitize-coverage-ignorelist=bl_none.txt  2>&1 |     grep -f patterns.txt | count 14
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_foo.txt  -fsanitize-coverage-ignorelist=bl_none.txt  2>&1 |     grep -f patterns.txt | count 9
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_bar.txt  -fsanitize-coverage-ignorelist=bl_none.txt  2>&1 |     grep -f patterns.txt | count 5
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table                                           -fsanitize-coverage-ignorelist=bl_none.txt  2>&1 |     grep -f patterns.txt | count 14
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_all.txt  -fsanitize-coverage-ignorelist=bl_none.txt  2>&1 |     grep -f patterns.txt | count 14
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_none.txt -fsanitize-coverage-ignorelist=bl_none.txt  2>&1 | not grep -f patterns.txt
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_file.txt -fsanitize-coverage-ignorelist=bl_none.txt  2>&1 |     grep -f patterns.txt | count 14
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_foo.txt  -fsanitize-coverage-ignorelist=bl_none.txt  2>&1 |     grep -f patterns.txt | count 9
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_bar.txt  -fsanitize-coverage-ignorelist=bl_none.txt  2>&1 |     grep -f patterns.txt | count 5
 
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table                                           -fsanitize-coverage-ignorelist=bl_file.txt  2>&1 | not grep -f patterns.txt
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_all.txt  -fsanitize-coverage-ignorelist=bl_file.txt  2>&1 | not grep -f patterns.txt
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_none.txt -fsanitize-coverage-ignorelist=bl_file.txt  2>&1 | not grep -f patterns.txt
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_file.txt -fsanitize-coverage-ignorelist=bl_file.txt  2>&1 | not grep -f patterns.txt
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_foo.txt  -fsanitize-coverage-ignorelist=bl_file.txt  2>&1 | not grep -f patterns.txt
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_bar.txt  -fsanitize-coverage-ignorelist=bl_file.txt  2>&1 | not grep -f patterns.txt
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table                                           -fsanitize-coverage-ignorelist=bl_file.txt  2>&1 | not grep -f patterns.txt
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_all.txt  -fsanitize-coverage-ignorelist=bl_file.txt  2>&1 | not grep -f patterns.txt
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_none.txt -fsanitize-coverage-ignorelist=bl_file.txt  2>&1 | not grep -f patterns.txt
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_file.txt -fsanitize-coverage-ignorelist=bl_file.txt  2>&1 | not grep -f patterns.txt
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_foo.txt  -fsanitize-coverage-ignorelist=bl_file.txt  2>&1 | not grep -f patterns.txt
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_bar.txt  -fsanitize-coverage-ignorelist=bl_file.txt  2>&1 | not grep -f patterns.txt
 
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table                                           -fsanitize-coverage-ignorelist=bl_foo.txt   2>&1 |     grep -f patterns.txt | count 5
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_all.txt  -fsanitize-coverage-ignorelist=bl_foo.txt   2>&1 |     grep -f patterns.txt | count 5
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_none.txt -fsanitize-coverage-ignorelist=bl_foo.txt   2>&1 | not grep -f patterns.txt
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_file.txt -fsanitize-coverage-ignorelist=bl_foo.txt   2>&1 |     grep -f patterns.txt | count 5
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_foo.txt  -fsanitize-coverage-ignorelist=bl_foo.txt   2>&1 | not grep -f patterns.txt
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_bar.txt  -fsanitize-coverage-ignorelist=bl_foo.txt   2>&1 |     grep -f patterns.txt | count 5
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table                                           -fsanitize-coverage-ignorelist=bl_foo.txt   2>&1 |     grep -f patterns.txt | count 5
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_all.txt  -fsanitize-coverage-ignorelist=bl_foo.txt   2>&1 |     grep -f patterns.txt | count 5
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_none.txt -fsanitize-coverage-ignorelist=bl_foo.txt   2>&1 | not grep -f patterns.txt
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_file.txt -fsanitize-coverage-ignorelist=bl_foo.txt   2>&1 |     grep -f patterns.txt | count 5
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_foo.txt  -fsanitize-coverage-ignorelist=bl_foo.txt   2>&1 | not grep -f patterns.txt
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_bar.txt  -fsanitize-coverage-ignorelist=bl_foo.txt   2>&1 |     grep -f patterns.txt | count 5
 
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table                                           -fsanitize-coverage-ignorelist=bl_bar.txt   2>&1 |     grep -f patterns.txt | count 9
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_all.txt  -fsanitize-coverage-ignorelist=bl_bar.txt   2>&1 |     grep -f patterns.txt | count 9
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_none.txt -fsanitize-coverage-ignorelist=bl_bar.txt   2>&1 | not grep -f patterns.txt
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_file.txt -fsanitize-coverage-ignorelist=bl_bar.txt   2>&1 |     grep -f patterns.txt | count 9
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_foo.txt  -fsanitize-coverage-ignorelist=bl_bar.txt   2>&1 |     grep -f patterns.txt | count 9
-// RUN: %clangxx -O0 %s -S -o - -emit-llvm -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_bar.txt  -fsanitize-coverage-ignorelist=bl_bar.txt   2>&1 | not grep -f patterns.txt
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table                                           -fsanitize-coverage-ignorelist=bl_bar.txt   2>&1 |     grep -f patterns.txt | count 9
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_all.txt  -fsanitize-coverage-ignorelist=bl_bar.txt   2>&1 |     grep -f patterns.txt | count 9
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_none.txt -fsanitize-coverage-ignorelist=bl_bar.txt   2>&1 | not grep -f patterns.txt
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_file.txt -fsanitize-coverage-ignorelist=bl_bar.txt   2>&1 |     grep -f patterns.txt | count 9
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_foo.txt  -fsanitize-coverage-ignorelist=bl_bar.txt   2>&1 |     grep -f patterns.txt | count 9
+// RUN: %clangxx -O0 %s -S -o - -emit-llvm -Xclang -no-opaque-pointers -fsanitize-coverage=inline-8bit-counters,indirect-calls,trace-cmp,pc-table -fsanitize-coverage-allowlist=al_bar.txt  -fsanitize-coverage-ignorelist=bl_bar.txt   2>&1 | not grep -f patterns.txt
 
 // RUN: cd -
 // RUN: rm -rf $DIR
@@ -90,16 +88,16 @@
 // libFuzzer-like coverage options: 9 lines
 //   inline-8bit-counters ->
 //     @__sancov_gen_XX = private global [3 x i8] zeroinitializer, section "__sancov_cntrs"...
-//     %XX = load i8, ptr @__sancov_gen_...
-//     %XX = load i8, ptr getelementptr inbounds ([3 x i8], ptr @__sancov_gen_, i64 0, i64 1)...
-//     %XX = load i8, ptr getelementptr inbounds ([3 x i8], ptr @__sancov_gen_, i64 0, i64 2)...
-//     store i8 %XX, ptr @__sancov_gen_...
-//     store i8 %XX, ptr getelementptr inbounds ([3 x i8], ptr @__sancov_gen_, i64 0, i64 1)...
-//     store i8 %XX, ptr getelementptr inbounds ([3 x i8], ptr @__sancov_gen_, i64 0, i64 2)...
+//     %XX = load i8, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @__sancov_gen_, i64 0, i64 0)...
+//     %XX = load i8, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @__sancov_gen_, i64 0, i64 1)...
+//     %XX = load i8, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @__sancov_gen_, i64 0, i64 2)...
+//     store i8 %XX, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @__sancov_gen_, i64 0, i64 0)...
+//     store i8 %XX, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @__sancov_gen_, i64 0, i64 1)...
+//     store i8 %XX, i8* getelementptr inbounds ([3 x i8], [3 x i8]* @__sancov_gen_, i64 0, i64 2)...
 //   trace-cmp ->
 //     call void @__sanitizer_cov_trace_cmp4(i32 %XX, i32 %XX)
 //   pc-table ->
-//     @__sancov_gen_XX = private constant [6 x ptr] ..., section "__sancov_pcs"...
+//     @__sancov_gen_XX = private constant [6 x i64*] ..., section "__sancov_pcs"...
 
 bool foo(int *a, int *b) {
   if (*a == *b) {
@@ -114,11 +112,11 @@ bool foo(int *a, int *b) {
 // libFuzzer-like coverage options: 5 lines
 //   inline-8bit-counters ->
 //     @__sancov_gen_XX = private global [1 x i8] zeroinitializer, section "__sancov_cntrs"...
-//     %XX = load i8, ptr @__sancov_gen_.2, ...
-//     store i8 %XX, ptr @__sancov_gen_.2, ...
+//     %XX = load i8, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @__sancov_gen_.2, i64 0, i64 0), ...
+//     store i8 %XX, i8* getelementptr inbounds ([1 x i8], [1 x i8]* @__sancov_gen_.2, i64 0, i64 0), ...
 //   indirect-calls ->
 //     call void @__sanitizer_cov_trace_pc_indir(i64 %XX)
 //   pc-table ->
-//     @__sancov_gen_XX = private constant [2 x ptr] ..., section "__sancov_pcs"...
+//     @__sancov_gen_XX = private constant [2 x i64*] ..., section "__sancov_pcs"...
 
 void bar(void (*f)()) { f(); }


### PR DESCRIPTION
This reverts commit fe516316e53837bfb26979af32bb1591df424ad4.
