### PR TITLE
Revert "Suppress some clang-tidy errors"

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,4 @@
-Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,-misc-no-recursion,readability-identifier-naming'
-WarningsAsErrors: 'llvm-*,misc-*,-misc-no-recursion,-misc-unused-parameters,readability-identifier-naming,-llvm-header-guard'
+Checks: '-*,clang-diagnostic-*,llvm-*,misc-*,-misc-const-correctness,-misc-unused-parameters,-misc-non-private-member-variables-in-classes,-misc-no-recursion,readability-identifier-naming'
 CheckOptions:
   - key:             readability-identifier-naming.ClassCase
     value:           CamelCase


### PR DESCRIPTION

This reverts commit 0fe88e826cb42fd6bd2c540eb284f1d413e6216a.

This was a wrong merge. Original PR was for SPIRV-LLVM-Translator,
the change should be in llvm-spirv/.clang-tidy, not in this file.
