### PR TITLE
[SYCL] Copy llvm-test-suite/SYCL/AOT/{gpu,cpu}.cpp tests to sycl/test-e2e

### DIFF
--- a/sycl/test-e2e/AOT/cpu.cpp
+++ b/sycl/test-e2e/AOT/cpu.cpp
@@ -1,0 +1,15 @@
+//==--- cpu.cpp - AOT compilation for cpu devices using opencl-aot --------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+// REQUIRES: opencl-aot, cpu
+
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 %S/Inputs/aot.cpp -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+
+// Test that opencl-aot can handle multiple build options.
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64  %S/Inputs/aot.cpp -Xsycl-target-backend "--bo=-g" -Xsycl-target-backend "--bo=-cl-opt-disable" -o %t2.out

--- a/sycl/test-e2e/AOT/gpu.cpp
+++ b/sycl/test-e2e/AOT/gpu.cpp
@@ -1,0 +1,14 @@
+//==--- gpu.cpp - AOT compilation for gen devices using GEN compiler ------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------------===//
+
+// REQUIRES: ocloc, gpu
+// UNSUPPORTED: cuda
+// CUDA is not compatible with SPIR.
+//
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts %S/Inputs/aot.cpp -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
sycl/test-e2e/AOT/gpu.cpp is using %gpu_aot_target_opts substitution and I need it to verify some internal infrastructure changes. The cpu.cpp is copied just in case/for "completeness".