### PR TITLE
[SYCL][Fusion] Make builtin remapping interprocedural

### DIFF
--- a/sycl-fusion/common/include/Kernel.h
+++ b/sycl-fusion/common/include/Kernel.h
@@ -159,7 +159,7 @@ public:
     return !(LHS == RHS);
   }
 
-  friend constexpr bool operator<(const NDRange &LHS, const NDRange &RHS) {
+  friend bool operator<(const NDRange &LHS, const NDRange &RHS) {
     if (LHS.Dimensions < RHS.Dimensions) {
       return true;
     }
@@ -192,7 +192,7 @@ public:
     return LHS.Offset < RHS.Offset;
   }
 
-  friend constexpr bool operator>(const NDRange &LHS, const NDRange &RHS) {
+  friend bool operator>(const NDRange &LHS, const NDRange &RHS) {
     return RHS < LHS;
   }
 

--- a/sycl-fusion/common/include/Kernel.h
+++ b/sycl-fusion/common/include/Kernel.h
@@ -159,6 +159,43 @@ public:
     return !(LHS == RHS);
   }
 
+  friend constexpr bool operator<(const NDRange &LHS, const NDRange &RHS) {
+    if (LHS.Dimensions < RHS.Dimensions) {
+      return true;
+    }
+    if (LHS.Dimensions > RHS.Dimensions) {
+      return false;
+    }
+
+    if (LHS.GlobalSize < RHS.GlobalSize) {
+      return true;
+    }
+    if (LHS.GlobalSize > RHS.GlobalSize) {
+      return false;
+    }
+
+    if (!LHS.hasSpecificLocalSize() && RHS.hasSpecificLocalSize()) {
+      return true;
+    }
+    if (LHS.hasSpecificLocalSize() && !RHS.hasSpecificLocalSize()) {
+      return false;
+    }
+    if (LHS.hasSpecificLocalSize() && RHS.hasSpecificLocalSize()) {
+      if (LHS.LocalSize < RHS.LocalSize) {
+        return true;
+      }
+      if (LHS.LocalSize > RHS.LocalSize) {
+        return false;
+      }
+    }
+
+    return LHS.Offset < RHS.Offset;
+  }
+
+  friend constexpr bool operator>(const NDRange &LHS, const NDRange &RHS) {
+    return RHS < LHS;
+  }
+
 private:
   /** @brief The number of dimensions. */
   int Dimensions;

--- a/sycl-fusion/jit-compiler/lib/KernelFusion.cpp
+++ b/sycl-fusion/jit-compiler/lib/KernelFusion.cpp
@@ -123,6 +123,10 @@ FusionResult KernelFusion::fuseKernels(
       fusion::FusionPipeline::runFusionPasses(*NewMod, ModuleInfo,
                                               BarriersFlags);
 
+  if (!NewMod->getFunction(FusedKernelName)) {
+    return FusionResult{"Kernel fusion failed"};
+  }
+
   // Get the updated kernel info for the fused kernel and add the information to
   // the existing KernelInfo.
   if (!NewModInfo->hasKernelFor(FusedKernelName)) {

--- a/sycl-fusion/jit-compiler/lib/translation/SPIRVLLVMTranslation.cpp
+++ b/sycl-fusion/jit-compiler/lib/translation/SPIRVLLVMTranslation.cpp
@@ -60,6 +60,9 @@ SPIRV::TranslatorOpts &SPIRVLLVMTranslator::translatorOpts() {
   static auto Opts = []() -> SPIRV::TranslatorOpts {
     // Options for translation between SPIR-V and LLVM IR.
     // Set SPIRV-V 1.4 as the maximum version number for now.
+    // Note that some parts of the code depend on the available builtins, e.g.,
+    // passes/kernel-fusion/Builtins.cpp, so updating the SPIR-V version should
+    // involve revisiting that code.
     SPIRV::TranslatorOpts TransOpt{SPIRV::VersionNumber::SPIRV_1_4};
     // Enable attachment of kernel arg names as metadata.
     TransOpt.enableGenArgNameMD();

--- a/sycl-fusion/passes/kernel-fusion/Builtins.cpp
+++ b/sycl-fusion/passes/kernel-fusion/Builtins.cpp
@@ -459,7 +459,8 @@ static bool isSafeToNotRemapBuiltin(Function *F) {
   Name = Name.drop_front(Name.find(SPIRVBuiltinPrefix) +
                          SPIRVBuiltinPrefix.size());
   // Check that Name does not start with any name in UnsafeBuiltIns
-  const auto *Iter = llvm::upper_bound(UnsafeBuiltIns, Name);
+  const auto *Iter =
+      std::upper_bound(UnsafeBuiltIns.begin(), UnsafeBuiltIns.end(), Name);
   return Iter == UnsafeBuiltIns.begin() || !Name.starts_with(*(Iter - 1));
 }
 

--- a/sycl-fusion/passes/kernel-fusion/Builtins.cpp
+++ b/sycl-fusion/passes/kernel-fusion/Builtins.cpp
@@ -470,7 +470,7 @@ static bool isSafeToNotRemapBuiltin(Function *F) {
 Expected<Function *>
 jit_compiler::Remapper::remapBuiltins(Function *F, const NDRange &SrcNDRange,
                                       const NDRange &FusedNDRange) {
-  auto &Cached = Cache[decltype(Cache)::key_type{F, SrcNDRange}];
+  auto &Cached = Cache[decltype(Cache)::key_type{F, SrcNDRange, FusedNDRange}];
   if (Cached) {
     // Cache hit. Return cached function.
     return Cached;

--- a/sycl-fusion/passes/kernel-fusion/Builtins.cpp
+++ b/sycl-fusion/passes/kernel-fusion/Builtins.cpp
@@ -8,66 +8,60 @@
 using namespace llvm;
 using namespace jit_compiler;
 
-namespace {
-/// This class implements all of the logic to remap builtins.
-///
-/// When constructed, the "remapping function" to be called instead of the
-/// builtin is initialized (if needed) and the remapping then simply involves
-/// replacing each relevant call by such function.
-class Remapper {
-public:
-  enum class Kind : uint8_t {
-    GlobalSizeRemapper,
-    LocalSizeRemapper,
-    NumWorkGroupsRemapper,
-    GlobalOffsetRemapper,
-    GlobalIDRemapper,
-    LocalIDRemapper,
-    GroupIDRemapper,
-  } K;
-
-  Remapper(Kind K, Module &M, const NDRange &SrcNDRange,
-           const NDRange &FusedNDRange)
-      : K{K}, F{initFunction(K, M, SrcNDRange, FusedNDRange)} {}
-
-  void operator()(CallBase *C) const;
-
-  static constexpr StringLiteral RemapperCommonName{"__remapper"};
-
-private:
-  static uint64_t getDefaultValue(Kind K);
-  static std::string getFunctionName(Kind K, const NDRange &SrcNDRange,
-                                     const NDRange &FusedNDRange);
-  static bool shouldRemap(Kind K, const NDRange &SrcNDRange,
-                          const NDRange &FusedNDRange);
-  static Value *generateCase(Kind K, IRBuilderBase &Builder,
-                             const NDRange &SrcNDRange,
-                             const NDRange &FusedNDRange, uint32_t Index);
-  static Function *initFunction(Kind K, Module &M, const NDRange &SrcNDRange,
-                                const NDRange &FusedNDRange);
-
-  Function *F;
+enum class BuiltinKind : uint8_t {
+  GlobalSizeRemapper,
+  LocalSizeRemapper,
+  NumWorkGroupsRemapper,
+  GlobalOffsetRemapper,
+  GlobalIDRemapper,
+  LocalIDRemapper,
+  GroupIDRemapper,
 };
-} // namespace
 
-void Remapper::operator()(CallBase *C) const {
-  if (F) {
-    C->setCalledFunction(F);
-    C->setAttributes(F->getAttributes());
-  }
+static constexpr StringLiteral RemapperCommonName{"__remapper"};
+static constexpr size_t NumBuiltins{11};
+static constexpr size_t NumBuiltinsToRemap{7};
+
+template <typename ForwardIt, typename KeyTy>
+static ForwardIt mapArrayLookup(ForwardIt Begin, ForwardIt End,
+                                const KeyTy &Key) {
+  return std::lower_bound(
+      Begin, End, Key,
+      [](const auto &Entry, const auto &Key) { return Entry.first < Key; });
+}
+
+template <typename ForwardIt, typename KeyTy>
+static auto mapArrayLookupValue(ForwardIt Begin, ForwardIt End,
+                                const KeyTy &Key) -> decltype(Begin->second) {
+  const auto Iter = mapArrayLookup(Begin, End, Key);
+  assert(Iter != End && Iter->first == Key && "Invalid key");
+  return Iter->second;
+}
+
+static BuiltinKind getBuiltinKind(Function *F) {
+  constexpr std::array<std::pair<StringLiteral, BuiltinKind>,
+                       NumBuiltinsToRemap>
+      Map{{{GetGlobalSizeName, BuiltinKind::GlobalSizeRemapper},
+           {GetGroupIDName, BuiltinKind::GroupIDRemapper},
+           {GetGlobalOffsetName, BuiltinKind::GlobalOffsetRemapper},
+           {GetNumWorkGroupsName, BuiltinKind::NumWorkGroupsRemapper},
+           {GetLocalSizeName, BuiltinKind::LocalSizeRemapper},
+           {GetLocalIDName, BuiltinKind::LocalIDRemapper},
+           {GetGlobalIDName, BuiltinKind::GlobalIDRemapper}}};
+  return mapArrayLookupValue(Map.begin(), Map.end(), F->getName());
 }
 
 /// 0 for IDs/offset and 1 for sizes.
-uint64_t Remapper::getDefaultValue(Kind K) {
+static uint64_t getDefaultValue(BuiltinKind K) {
   switch (K) {
-  case Kind::GlobalSizeRemapper:
-  case Kind::LocalSizeRemapper:
-  case Kind::NumWorkGroupsRemapper:
+  case BuiltinKind::GlobalSizeRemapper:
+  case BuiltinKind::LocalSizeRemapper:
+  case BuiltinKind::NumWorkGroupsRemapper:
     return 1;
-  case Kind::GlobalIDRemapper:
-  case Kind::LocalIDRemapper:
-  case Kind::GroupIDRemapper:
-  case Kind::GlobalOffsetRemapper:
+  case BuiltinKind::GlobalIDRemapper:
+  case BuiltinKind::LocalIDRemapper:
+  case BuiltinKind::GroupIDRemapper:
+  case BuiltinKind::GlobalOffsetRemapper:
     return 0;
   }
   llvm_unreachable("Unhandled kind");
@@ -84,26 +78,26 @@ static raw_ostream &operator<<(raw_ostream &Os, const NDRange &ND) {
 
 /// Will generate a unique function name so that it can be reused in further
 /// stages.
-std::string Remapper::getFunctionName(Kind K, const NDRange &SrcNDRange,
-                                      const NDRange &FusedNDRange) {
+static std::string getFunctionName(BuiltinKind K, const NDRange &SrcNDRange,
+                                   const NDRange &FusedNDRange) {
   std::string Res;
   raw_string_ostream S{Res};
   S << "__" <<
       [K]() {
         switch (K) {
-        case Kind::GlobalSizeRemapper:
+        case BuiltinKind::GlobalSizeRemapper:
           return "global_size";
-        case Kind::LocalSizeRemapper:
+        case BuiltinKind::LocalSizeRemapper:
           return "local_size";
-        case Kind::NumWorkGroupsRemapper:
+        case BuiltinKind::NumWorkGroupsRemapper:
           return "num_work_groups";
-        case Kind::GlobalIDRemapper:
+        case BuiltinKind::GlobalIDRemapper:
           return "global_id";
-        case Kind::LocalIDRemapper:
+        case BuiltinKind::LocalIDRemapper:
           return "local_id";
-        case Kind::GroupIDRemapper:
+        case BuiltinKind::GroupIDRemapper:
           return "group_id";
-        case Kind::GlobalOffsetRemapper:
+        case BuiltinKind::GlobalOffsetRemapper:
           return "global_offset";
         }
         llvm_unreachable("Unhandled kind");
@@ -112,19 +106,19 @@ std::string Remapper::getFunctionName(Kind K, const NDRange &SrcNDRange,
   return S.str();
 }
 
-bool Remapper::shouldRemap(Kind K, const NDRange &SrcNDRange,
-                           const NDRange &FusedNDRange) {
+static bool shouldRemap(BuiltinKind K, const NDRange &SrcNDRange,
+                        const NDRange &FusedNDRange) {
   switch (K) {
-  case Kind::GlobalSizeRemapper:
-  case Kind::GlobalOffsetRemapper:
+  case BuiltinKind::GlobalSizeRemapper:
+  case BuiltinKind::GlobalOffsetRemapper:
     return true;
-  case Kind::NumWorkGroupsRemapper:
-  case Kind::LocalSizeRemapper:
+  case BuiltinKind::NumWorkGroupsRemapper:
+  case BuiltinKind::LocalSizeRemapper:
     // Do not remap when the local size is not specified.
     return SrcNDRange.hasSpecificLocalSize();
-  case Kind::GlobalIDRemapper:
-  case Kind::LocalIDRemapper:
-  case Kind::GroupIDRemapper: {
+  case BuiltinKind::GlobalIDRemapper:
+  case BuiltinKind::LocalIDRemapper:
+  case BuiltinKind::GroupIDRemapper: {
     // No need to remap when all but the dimensions and the left-most components
     // of the global size range are equal.
     const auto &GS0 = SrcNDRange.getGlobalSize();
@@ -268,47 +262,27 @@ static Value *generateGetGroupIDCase(IRBuilderBase &Builder,
                                 SrcNDRange.getDimensions(), Index)]));
 }
 
-Value *Remapper::generateCase(Kind K, IRBuilderBase &Builder,
-                              const NDRange &SrcNDRange,
-                              const NDRange &FusedNDRange, uint32_t Index) {
+static Value *generateCase(BuiltinKind K, IRBuilderBase &Builder,
+                           const NDRange &SrcNDRange,
+                           const NDRange &FusedNDRange, uint32_t Index) {
   switch (K) {
-  case Kind::GlobalSizeRemapper:
+  case BuiltinKind::GlobalSizeRemapper:
     return generateGetGlobalSizeCase(Builder, SrcNDRange, FusedNDRange, Index);
-  case Kind::LocalSizeRemapper:
+  case BuiltinKind::LocalSizeRemapper:
     return generateGetLocalSizeCase(Builder, SrcNDRange, FusedNDRange, Index);
-  case Kind::NumWorkGroupsRemapper:
+  case BuiltinKind::NumWorkGroupsRemapper:
     return generateNumWorkGroupsCase(Builder, SrcNDRange, FusedNDRange, Index);
-  case Kind::GlobalIDRemapper:
+  case BuiltinKind::GlobalIDRemapper:
     return generateGetGlobalIDCase(Builder, SrcNDRange, FusedNDRange, Index);
-  case Kind::LocalIDRemapper:
+  case BuiltinKind::LocalIDRemapper:
     return generateGetLocalIDCase(Builder, SrcNDRange, FusedNDRange, Index);
-  case Kind::GroupIDRemapper:
+  case BuiltinKind::GroupIDRemapper:
     return generateGetGroupIDCase(Builder, SrcNDRange, FusedNDRange, Index);
-  case Kind::GlobalOffsetRemapper:
+  case BuiltinKind::GlobalOffsetRemapper:
     return generateGetGlobalOffsetCase(Builder, SrcNDRange, FusedNDRange,
                                        Index);
   }
   llvm_unreachable("Unhandled kind");
-}
-
-static constexpr size_t NumBuiltins{8};
-static constexpr size_t NumBuiltinsToRemap{7};
-
-template <typename ForwardIt>
-static ForwardIt mapArrayLookup(ForwardIt Begin, ForwardIt End,
-                                const decltype(Begin->first) &Key) {
-  return std::lower_bound(
-      Begin, End, Key,
-      [](const auto &Entry, const auto &Key) { return Entry.first < Key; });
-}
-
-template <typename ForwardIt>
-static auto mapArrayLookupValue(ForwardIt Begin, ForwardIt End,
-                                const decltype(Begin->first) &Key)
-    -> decltype(Begin->second) {
-  const auto Iter = mapArrayLookup(Begin, End, Key);
-  assert(Iter != End && Iter->first == Key && "Invalid key");
-  return Iter->second;
 }
 
 static llvm::AttributeList getAttributes(StringRef FunctionName,
@@ -337,6 +311,7 @@ static llvm::AttributeList getAttributes(StringRef FunctionName,
                   Attribute::get(Ctx, Attribute::AttrKind::AlwaysInline)}),
         {}, {});
   };
+  constexpr auto OffloaderAttrs = RemapperAttrs;
 
   // This array is sorted by key value
   const std::array<
@@ -345,12 +320,15 @@ static llvm::AttributeList getAttributes(StringRef FunctionName,
       AttrMap{{{BarrierName, GetBarrierAttrs},
                {GetGlobalSizeName, GetIndexSpaceAttrs},
                {GetGroupIDName, GetIndexSpaceAttrs},
+               {GetGlobalOffsetName, GetIndexSpaceAttrs},
                {GetNumWorkGroupsName, GetIndexSpaceAttrs},
                {GetLocalSizeName, GetIndexSpaceAttrs},
                {GetGlobalLinearIDName, GetIndexSpaceAttrs},
                {GetLocalIDName, GetIndexSpaceAttrs},
                {GetGlobalIDName, GetIndexSpaceAttrs},
-               {Remapper::RemapperCommonName, RemapperAttrs}}};
+               {RemapperCommonName, RemapperAttrs},
+               {OffloadStartWrapperName, OffloaderAttrs},
+               {OffloadFinishWrapperName, OffloaderAttrs}}};
   return mapArrayLookupValue(AttrMap.begin(), AttrMap.end(), FunctionName)(Ctx);
 }
 
@@ -375,6 +353,9 @@ static FunctionType *getFunctionType(IRBuilderBase &Builder,
         {Builder.getInt32Ty(), Builder.getInt32Ty(), Builder.getInt32Ty()},
         false /*IsVarArg*/);
   };
+  constexpr auto OffloadWrapperTy = [](IRBuilderBase &Builder) {
+    return FunctionType::get(Builder.getVoidTy(), {}, false /*IsVarArg*/);
+  };
 
   // This array is sorted by key value
   const std::array<
@@ -383,35 +364,37 @@ static FunctionType *getFunctionType(IRBuilderBase &Builder,
       TypeMap{{{BarrierName, GetBarrierTy},
                {GetGlobalSizeName, GetIndexSpaceGetTy},
                {GetGroupIDName, GetIndexSpaceGetTy},
+               {GetGlobalOffsetName, GetIndexSpaceGetTy},
                {GetNumWorkGroupsName, GetIndexSpaceGetTy},
                {GetLocalSizeName, GetIndexSpaceGetTy},
                {GetGlobalLinearIDName, GetGlobalLinearIDTy},
                {GetLocalIDName, GetIndexSpaceGetTy},
                {GetGlobalIDName, GetIndexSpaceGetTy},
-               {Remapper::RemapperCommonName, GetIndexSpaceGetTy}}};
+               {RemapperCommonName, GetIndexSpaceGetTy},
+               {OffloadFinishWrapperName, OffloadWrapperTy},
+               {OffloadStartWrapperName, OffloadWrapperTy}}};
 
   return mapArrayLookupValue(TypeMap.begin(), TypeMap.end(),
                              FunctionName)(Builder);
 }
 
-Function *Remapper::initFunction(Kind K, Module &M, const NDRange &SrcNDRange,
-                                 const NDRange &FusedNDRange) {
+static Function *initFunction(Function *OldF, const NDRange &SrcNDRange,
+                              const NDRange &FusedNDRange) {
+  const auto K = getBuiltinKind(OldF);
   if (!shouldRemap(K, SrcNDRange, FusedNDRange)) {
-    // If the builtin should not be remapped, the function won't be initialized.
-    return nullptr;
+    // If the builtin should not be remapped, return the original function.
+    return OldF;
   }
   const auto Name = getFunctionName(K, SrcNDRange, FusedNDRange);
-  auto *F = M.getFunction(Name);
-  if (F) {
-    // Remapping function already generated
-    return F;
-  }
+  auto *M = OldF->getParent();
+  auto *F = M->getFunction(Name);
+  assert(!F && "Function name should be unique");
 
-  auto &Ctx = M.getContext();
+  auto &Ctx = M->getContext();
   IRBuilder<> Builder{Ctx};
 
   F = Function::Create(getFunctionType(Builder, RemapperCommonName),
-                       Function::LinkageTypes::InternalLinkage, Name, M);
+                       Function::LinkageTypes::InternalLinkage, Name, *M);
 
   auto *EntryBlock = BasicBlock::Create(Ctx, "entry", F);
   Builder.SetInsertPoint(EntryBlock);
@@ -442,59 +425,99 @@ Value *jit_compiler::getGlobalLinearID(IRBuilderBase &Builder,
   return createSPIRVCall(Builder, GetGlobalLinearIDName, {});
 }
 
-Function *jit_compiler::remapBuiltins(Function *F, const NDRange &SrcNDRange,
-                                      const NDRange &FusedNDRange) {
-  {
-    ValueToValueMapTy Map;
-    F = CloneFunction(F, Map);
+static bool isIndexSpaceGetterBuiltin(Function *F) {
+  constexpr std::array<StringLiteral, NumBuiltinsToRemap> BuiltinNames{
+      GetGlobalSizeName,    GetGroupIDName,   GetGlobalOffsetName,
+      GetNumWorkGroupsName, GetLocalSizeName, GetLocalIDName,
+      GetGlobalIDName};
+  const auto Name = F->getName();
+  const auto *Iter = llvm::lower_bound(BuiltinNames, Name);
+  return Iter != BuiltinNames.end() && *Iter == Name;
+}
+
+static bool isSafeToNotRemapBuiltin(Function *F) {
+  constexpr std::size_t NumUnsafeBuiltins{8};
+  // SPIRV builtins with kernel capabilities in alphabetical order.
+  constexpr std::array<StringLiteral, NumUnsafeBuiltins> UnsafeBuiltIns{
+      "EnqueuedWorkgroupSize",
+      "NumEnqueuedSubgroups",
+      "NumSubgroups",
+      "SubgroupId",
+      "SubgroupLocalInvocationId",
+      "SubgroupMaxSize",
+      "SubgroupSize",
+      "WorkDim"};
+  constexpr StringLiteral SPIRVBuiltinNamespace{"spirv"};
+  constexpr StringLiteral SPIRVBuiltinPrefix{"BuiltIn"};
+
+  auto Name = F->getName();
+  if (!(Name.contains(SPIRVBuiltinNamespace) &&
+        Name.contains(SPIRVBuiltinPrefix))) {
+    return true;
   }
-  auto &M = *F->getParent();
-  // This is a sorted array which should have the same order as the one in the
-  // remap function.
-  // Values are lazy initialized.
-  std::array<std::pair<StringRef,
-                       std::pair<Remapper::Kind, std::unique_ptr<Remapper>>>,
-             NumBuiltinsToRemap>
-      Remappers{{
-          {GetGlobalSizeName,
-           std::pair<Remapper::Kind, std::unique_ptr<Remapper>>{
-               Remapper::Kind::GlobalSizeRemapper,
-               std::unique_ptr<Remapper>{}}},
-          {GetGroupIDName,
-           std::pair<Remapper::Kind, std::unique_ptr<Remapper>>{
-               Remapper::Kind::GroupIDRemapper, std::unique_ptr<Remapper>{}}},
-          {GetGlobalOffsetName,
-           std::pair<Remapper::Kind, std::unique_ptr<Remapper>>{
-               Remapper::Kind::GlobalOffsetRemapper,
-               std::unique_ptr<Remapper>{}}},
-          {GetNumWorkGroupsName,
-           std::pair<Remapper::Kind, std::unique_ptr<Remapper>>{
-               Remapper::Kind::NumWorkGroupsRemapper,
-               std::unique_ptr<Remapper>{}}},
-          {GetLocalSizeName,
-           std::pair<Remapper::Kind, std::unique_ptr<Remapper>>{
-               Remapper::Kind::LocalSizeRemapper, std::unique_ptr<Remapper>{}}},
-          {GetLocalIDName,
-           std::pair<Remapper::Kind, std::unique_ptr<Remapper>>{
-               Remapper::Kind::LocalIDRemapper, std::unique_ptr<Remapper>{}}},
-          {GetGlobalIDName,
-           std::pair<Remapper::Kind, std::unique_ptr<Remapper>>{
-               Remapper::Kind::GlobalIDRemapper, std::unique_ptr<Remapper>{}}},
-      }};
-  for (auto &I : instructions(F)) {
-    if (auto *Call = dyn_cast<CallInst>(&I)) {
-      const auto Name = Call->getCalledFunction()->getName();
-      auto *Iter = mapArrayLookup(Remappers.begin(), Remappers.end(), Name);
-      if (Iter != Remappers.end() && Iter->first == Name) {
-        if (!Iter->second.second) {
-          Iter->second.second = std::make_unique<Remapper>(
-              Iter->second.first, M, SrcNDRange, FusedNDRange);
-        }
-        (*Iter->second.second)(Call);
+  // Drop "spirv" namespace name and "BuiltIn" prefix.
+  Name = Name.drop_front(Name.find(SPIRVBuiltinPrefix) +
+                         SPIRVBuiltinPrefix.size());
+  // Check that Name does not start with any name in UnsafeBuiltIns
+  const auto *Iter = llvm::upper_bound(UnsafeBuiltIns, Name);
+  return Iter == UnsafeBuiltIns.begin() || !Name.starts_with(*(Iter - 1));
+}
+
+Expected<Function *>
+jit_compiler::Remapper::remapBuiltins(Function *F, const NDRange &SrcNDRange,
+                                      const NDRange &FusedNDRange) {
+  auto &Cached = Cache[decltype(Cache)::key_type{F, SrcNDRange}];
+  if (Cached) {
+    // Cache hit. Return cached function.
+    return Cached;
+  }
+
+  if (F->isDeclaration()) {
+    if (isIndexSpaceGetterBuiltin(F)) {
+      // Remap given builtin.
+      return Cached = initFunction(F, SrcNDRange, FusedNDRange);
+    }
+    if (isSafeToNotRemapBuiltin(F)) {
+      // No need to remap.
+      return Cached = F;
+    }
+    // Unknown builtin
+    return make_error<StringError>(Twine("Cannot remap unknown builtin: \"")
+                                       .concat(Twine{F->getName()})
+                                       .concat("\""),
+                                   inconvertibleErrorCode());
+  }
+
+  ValueToValueMapTy Map;
+  ClonedCodeInfo CodeInfo;
+  auto *Clone = CloneFunction(F, Map, &CodeInfo);
+
+  if (!CodeInfo.ContainsCalls) {
+    // No need to perform any remapping as the function has no calls.
+    // We can erase the cloned function from the parent and return the
+    // original.
+    Clone->eraseFromParent();
+    return Cached = F;
+  }
+
+  // Set Cached to support recursive functions.
+  Cached = Clone;
+  for (auto &I : instructions(Clone)) {
+    if (auto *Call = dyn_cast<CallBase>(&I)) {
+      // Recursive call
+      auto *OldF = Call->getCalledFunction();
+      auto ErrOrNewF = remapBuiltins(OldF, SrcNDRange, FusedNDRange);
+      if (auto Err = ErrOrNewF.takeError()) {
+        return Err;
       }
+      // Override called function.
+      auto *NewF = *ErrOrNewF;
+      Call->setCalledFunction(NewF);
+      Call->setCallingConv(NewF->getCallingConv());
+      Call->setAttributes(NewF->getAttributes());
     }
   }
-  return F;
+  return Clone;
 }
 
 void jit_compiler::barrierCall(IRBuilderBase &Builder, int Flags) {

--- a/sycl-fusion/passes/kernel-fusion/Builtins.cpp
+++ b/sycl-fusion/passes/kernel-fusion/Builtins.cpp
@@ -438,6 +438,9 @@ static bool isIndexSpaceGetterBuiltin(Function *F) {
 static bool isSafeToNotRemapBuiltin(Function *F) {
   constexpr std::size_t NumUnsafeBuiltins{8};
   // SPIRV builtins with kernel capabilities in alphabetical order.
+  //
+  // These builtins might need remapping, but are not supported by the remapper,
+  // so we should abort kernel fusion if we find them during remapping.
   constexpr std::array<StringLiteral, NumUnsafeBuiltins> UnsafeBuiltIns{
       "EnqueuedWorkgroupSize",
       "NumEnqueuedSubgroups",
@@ -489,6 +492,9 @@ jit_compiler::Remapper::remapBuiltins(Function *F, const NDRange &SrcNDRange,
                                    inconvertibleErrorCode());
   }
 
+  // As we clone the called function and remap the clone, we can have
+  // more than one callee to the same function being remapped and a different
+  // remapping will be performed each time.
   ValueToValueMapTy Map;
   ClonedCodeInfo CodeInfo;
   auto *Clone = CloneFunction(F, Map, &CodeInfo);

--- a/sycl-fusion/passes/kernel-fusion/Builtins.h
+++ b/sycl-fusion/passes/kernel-fusion/Builtins.h
@@ -79,9 +79,7 @@ public:
                                                  const NDRange &FusedNDRange);
 
 private:
-  std::map<std::tuple<llvm::Function *,
-                      std::add_lvalue_reference_t<std::add_const_t<NDRange>>>,
-           llvm::Function *>
+  std::map<std::tuple<llvm::Function *, const NDRange &>, llvm::Function *>
       Cache;
 };
 } // namespace jit_compiler

--- a/sycl-fusion/passes/kernel-fusion/Builtins.h
+++ b/sycl-fusion/passes/kernel-fusion/Builtins.h
@@ -4,6 +4,9 @@
 #include "Kernel.h"
 
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Error.h"
+
+#include <map>
 
 namespace llvm {
 // Forward declarations
@@ -42,6 +45,12 @@ constexpr llvm::StringLiteral GetLocalIDName{
 /// get_global_id builtin name
 constexpr llvm::StringLiteral GetGlobalIDName{
     "_Z33__spirv_BuiltInGlobalInvocationIdi"};
+/// offload_wi_finish_wrapper name
+constexpr llvm::StringLiteral OffloadFinishWrapperName{
+    "__itt_offload_wi_finish_wrapper"};
+/// offload_wi_start_wrapper name
+constexpr llvm::StringLiteral OffloadStartWrapperName{
+    "__itt_offload_wi_start_wrapper"};
 
 ///
 /// @return The result of calling get_global_linear_id
@@ -61,10 +70,20 @@ void barrierCall(llvm::IRBuilderBase &Builder, int Flags);
 llvm::Value *createSPIRVCall(llvm::IRBuilderBase &Builder, llvm::StringRef N,
                              llvm::ArrayRef<llvm::Value *> Args);
 
-///
-/// Remaps index space getters builtins.
-llvm::Function *remapBuiltins(llvm::Function *F, const NDRange &SrcNDRange,
-                              const NDRange &FusedNDRange);
+class Remapper {
+public:
+  ///
+  /// Remaps index space getters builtins.
+  llvm::Expected<llvm::Function *> remapBuiltins(llvm::Function *F,
+                                                 const NDRange &SrcNDRange,
+                                                 const NDRange &FusedNDRange);
+
+private:
+  std::map<std::tuple<llvm::Function *,
+                      std::add_lvalue_reference_t<std::add_const_t<NDRange>>>,
+           llvm::Function *>
+      Cache;
+};
 } // namespace jit_compiler
 
 #endif // KERNEL_FUSION_PASS_SYCL_BUILTINS_H

--- a/sycl-fusion/passes/kernel-fusion/Builtins.h
+++ b/sycl-fusion/passes/kernel-fusion/Builtins.h
@@ -79,7 +79,8 @@ public:
                                                  const NDRange &FusedNDRange);
 
 private:
-  std::map<std::tuple<llvm::Function *, const NDRange &>, llvm::Function *>
+  std::map<std::tuple<llvm::Function *, const NDRange &, const NDRange &>,
+           llvm::Function *>
       Cache;
 };
 } // namespace jit_compiler

--- a/sycl-fusion/passes/kernel-fusion/SYCLKernelFusion.cpp
+++ b/sycl-fusion/passes/kernel-fusion/SYCLKernelFusion.cpp
@@ -147,6 +147,7 @@ PreservedAnalyses SYCLKernelFusion::run(Module &M, ModuleAnalysisManager &AM) {
   // Iterate over the functions in the module and locate all
   // stub functions identified by metadata.
   SmallPtrSet<Function *, 8> ToCleanUp;
+  Error DeferredErrs = Error::success();
   for (Function &F : M) {
     if (F.isDeclaration() // The stub should be a declaration and not defined.
         && F.hasMetadata(
@@ -155,7 +156,9 @@ PreservedAnalyses SYCLKernelFusion::run(Module &M, ModuleAnalysisManager &AM) {
       // attached to this stub function.
       // The newly created function will carry the name also specified
       // in the metadata.
-      fuseKernel(M, F, ModuleInfo, ToCleanUp);
+      if (auto Err = fuseKernel(M, F, ModuleInfo, ToCleanUp)) {
+        DeferredErrs = joinErrors(std::move(DeferredErrs), std::move(Err));
+      }
       // Rembember the stub for deletion, as it is not required anymore after
       // inserting the actual fused function.
       ToCleanUp.insert(&F);
@@ -165,6 +168,11 @@ PreservedAnalyses SYCLKernelFusion::run(Module &M, ModuleAnalysisManager &AM) {
   for (Function *SF : ToCleanUp) {
     SF->eraseFromParent();
   }
+
+  handleAllErrors(std::move(DeferredErrs), [](const StringError &EL) {
+    FUSION_DEBUG(dbgs() << EL.message() << "\n");
+  });
+
   // Inserting a new function and deleting the stub function is a major
   // modification to the module and we did not update any analyses,
   // so return none here.
@@ -222,16 +230,19 @@ static FusionInsertPoints addGuard(IRBuilderBase &Builder,
   return {Entry, CallInsertion, Exit};
 }
 
-static CallInst *createFusionCall(IRBuilderBase &Builder, Function *F,
-                                  ArrayRef<Value *> CallArgs,
-                                  const jit_compiler::NDRange &SrcNDRange,
-                                  const jit_compiler::NDRange &FusedNDRange,
-                                  bool IsLast, int BarriersFlags,
-                                  bool ShouldRemap) {
+static Expected<CallInst *> createFusionCall(
+    IRBuilderBase &Builder, Function *F, ArrayRef<Value *> CallArgs,
+    const jit_compiler::NDRange &SrcNDRange,
+    const jit_compiler::NDRange &FusedNDRange, bool IsLast, int BarriersFlags,
+    jit_compiler::Remapper &Remapper, bool ShouldRemap) {
   const auto IPs = addGuard(Builder, SrcNDRange, FusedNDRange, IsLast);
 
   if (ShouldRemap) {
-    F = jit_compiler::remapBuiltins(F, SrcNDRange, FusedNDRange);
+    auto FOrErr = Remapper.remapBuiltins(F, SrcNDRange, FusedNDRange);
+    if (auto Err = FOrErr.takeError()) {
+      return std::move(Err);
+    }
+    F = *FOrErr;
   }
 
   // Insert call
@@ -258,7 +269,7 @@ static CallInst *createFusionCall(IRBuilderBase &Builder, Function *F,
   return Res;
 }
 
-void SYCLKernelFusion::fuseKernel(
+Error SYCLKernelFusion::fuseKernel(
     Module &M, Function &StubFunction, jit_compiler::SYCLModuleInfo *ModInfo,
     SmallPtrSetImpl<Function *> &ToCleanUp) const {
   // Retrieve the metadata from the stub function.
@@ -523,7 +534,9 @@ void SYCLKernelFusion::fuseKernel(
     const auto BarriersEnd = InputFunctions.size() - 1;
     const auto IsHeterogeneousNDRangesList =
         hasHeterogeneousNDRangesList(InputFunctions);
+    jit_compiler::Remapper Remapper;
 
+    Error DeferredErrs = Error::success();
     for (auto &KF : InputFunctions) {
       auto *IF = KF.F;
       SmallVector<Value *> CallArgs;
@@ -533,16 +546,26 @@ void SYCLKernelFusion::fuseKernel(
         unsigned ParamIdx = ParamMapping[{FuncIndex, I}];
         CallArgs.push_back(FusedFunction->getArg(ParamIdx));
       }
-      auto *Call = createFusionCall(Builder, IF, CallArgs, KF.ND, NDRange,
-                                    FuncIndex == BarriersEnd, BarriersFlags,
-                                    IsHeterogeneousNDRangesList);
-      Calls.push_back(Call);
-
-      ++FuncIndex;
+      auto CallOrErr = createFusionCall(Builder, IF, CallArgs, KF.ND, NDRange,
+                                        FuncIndex == BarriersEnd, BarriersFlags,
+                                        Remapper, IsHeterogeneousNDRangesList);
       // Add to the set of original kernel functions that can be deleted after
       // fusion is complete.
       ToCleanUp.insert(IF);
+      ++FuncIndex;
+
+      if (auto Err = CallOrErr.takeError()) {
+        DeferredErrs = joinErrors(std::move(DeferredErrs), std::move(Err));
+        continue;
+      }
+      auto *Call = *CallOrErr;
+      Calls.push_back(Call);
       ToCleanUp.insert(Call->getCalledFunction());
+    }
+    if (DeferredErrs) {
+      // If we found an error, clean and exit.
+      FusedFunction->eraseFromParent();
+      return DeferredErrs;
     }
   }
   // Create a void return at the end of the newly created kernel.
@@ -608,6 +631,7 @@ void SYCLKernelFusion::fuseKernel(
         &*FusedFunction->getEntryBlock().getFirstInsertionPt());
     WrapperCall->setCallingConv(CallingConv::SPIR_FUNC);
   }
+  return Error::success();
 }
 
 void SYCLKernelFusion::canonicalizeParameters(

--- a/sycl-fusion/passes/kernel-fusion/SYCLKernelFusion.h
+++ b/sycl-fusion/passes/kernel-fusion/SYCLKernelFusion.h
@@ -109,9 +109,10 @@ private:
     }
   };
 
-  void fuseKernel(llvm::Module &M, llvm::Function &StubFunction,
-                  jit_compiler::SYCLModuleInfo *ModInfo,
-                  llvm::SmallPtrSetImpl<llvm::Function *> &ToCleanUp) const;
+  llvm::Error
+  fuseKernel(llvm::Module &M, llvm::Function &StubFunction,
+             jit_compiler::SYCLModuleInfo *ModInfo,
+             llvm::SmallPtrSetImpl<llvm::Function *> &ToCleanUp) const;
 
   void canonicalizeParameters(
       llvm::SmallVectorImpl<ParameterIdentity> &Params) const;

--- a/sycl-fusion/test/kernel-fusion/check-failed-remapping.ll
+++ b/sycl-fusion/test/kernel-fusion/check-failed-remapping.ll
@@ -1,0 +1,40 @@
+; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext\
+; RUN: -passes=sycl-kernel-fusion\
+; RUN: --sycl-info-path %S/check-remapping.yaml -S %s\
+; RUN: | FileCheck %s
+
+; This tests checks that kernel fusion fails when an unknown builtin
+; is called inside a kernel.
+
+; CHECK-NOT: fused_0
+
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"
+target triple = "spir64-unknown-unknown"
+
+; Unsupported builtin
+declare spir_func void @spirv_BuiltInWorkDim()
+
+define spir_kernel void @KernelOne(i32 %x) #0 !kernel_arg_addr_space !0 !kernel_arg_access_qual !0 !kernel_arg_type !0 !kernel_arg_type_qual !0 !kernel_arg_base_type !0 !kernel_arg_name !0 !work_group_size_hint !1 {
+entry:
+  call spir_func void @spirv_BuiltInWorkDim()
+  ret void
+}
+
+declare !sycl.kernel.fused !2 !sycl.kernel.nd-ranges !4 !sycl.kernel.nd-range !13 void @fused_kernel()
+
+attributes #0 = { nounwind }
+
+!0 = !{}
+!1 = !{i32 64, i32 1, i32 1}
+!2 = !{!"fused_0", !3}
+!3 = !{!"KernelOne", !"KernelOne", !"KernelOne"}
+!4 = !{!5, !9, !11}
+!5 = !{i32 3, !6, !7, !8}
+!6 = !{i64 2, i64 3, i64 7}
+!7 = !{i64 2, i64 1, i64 1}
+!8 = !{i64 0, i64 0, i64 0}
+!9 = !{i32 2, !10, !7, !8}
+!10 = !{i64 2, i64 4, i64 1}
+!11 = !{i32 1, !12, !7, !8}
+!12 = !{i64 48, i64 1, i64 1}
+!13 = !{i32 3, !12, !7, !8}

--- a/sycl-fusion/test/kernel-fusion/check-remapping-interproc.ll
+++ b/sycl-fusion/test/kernel-fusion/check-remapping-interproc.ll
@@ -1,0 +1,287 @@
+; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext\
+; RUN: -passes=sycl-kernel-fusion\
+; RUN: --sycl-info-path %S/check-remapping.yaml -S %s\
+; RUN: | FileCheck %s
+
+; This tests checks that SPIR-V builtins are correctly remapped when fusing
+;  kernels with different ND-ranges.
+
+target datalayout = "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v16:16:16-v24:32:32-v32:32:32-v48:64:64-v64:64:64-v96:128:128-v128:128:128-v192:256:256-v256:256:256-v512:512:512-v1024:1024:1024"
+target triple = "spir64-unknown-unknown"
+
+
+; Function Attrs: alwaysinline nounwind
+declare spir_func void @__itt_offload_wi_start_wrapper() #3
+
+; Function Attrs: alwaysinline nounwind
+declare spir_func void @__itt_offload_wi_finish_wrapper() #3
+
+declare spir_func i64 @_Z25__spirv_BuiltInGlobalSizei(i32) #4
+declare spir_func i64 @_Z26__spirv_BuiltInWorkgroupIdi(i32) #4
+declare spir_func i64 @_Z28__spirv_BuiltInWorkgroupSizei(i32) #4
+declare spir_func i64 @_Z29__spirv_BuiltInGlobalLinearIdv() #4
+declare spir_func i64 @_Z32__spirv_BuiltInLocalInvocationIdi(i32) #4
+declare spir_func i64 @_Z33__spirv_BuiltInGlobalInvocationIdi(i32) #4
+declare spir_func i64 @_Z28__spirv_BuiltInNumWorkgroupsi(i32) #4
+declare spir_func i64 @_Z27__spirv_BuiltInGlobalOffseti(i32) #4
+
+define spir_func void @foo(i32 %x) {
+entry:
+  %0 = call spir_func i64 @_Z29__spirv_BuiltInGlobalLinearIdv() #4
+  %1 = call spir_func i64 @_Z25__spirv_BuiltInGlobalSizei(i32 %x) #4
+  %2 = call spir_func i64 @_Z26__spirv_BuiltInWorkgroupIdi(i32 %x) #4
+  %3 = call spir_func i64 @_Z28__spirv_BuiltInWorkgroupSizei(i32 %x) #4
+  %4 = call spir_func i64 @_Z32__spirv_BuiltInLocalInvocationIdi(i32 %x) #4
+  %5 = call spir_func i64 @_Z33__spirv_BuiltInGlobalInvocationIdi(i32 %x) #4
+  %6 = call spir_func i64 @_Z28__spirv_BuiltInNumWorkgroupsi(i32 %x) #4
+  %7 = call spir_func i64 @_Z27__spirv_BuiltInGlobalOffseti(i32 %x) #4
+  ret void
+}
+
+define spir_func i32 @bar(i32 %x) {
+entry:
+  %cmp = icmp ule i32 %x, 1
+  br i1 %cmp, label %return, label %if.end
+
+if.end:
+  %sub = sub i32 %x, 1
+  %call = call i32 @bar(i32 %sub)
+  %mul = mul i32 %x, %call
+  br label %return
+
+return:
+  %res = phi i32 [%x, %entry], [%sub, %if.end]
+  ret i32 %res
+}
+
+define spir_func void @baz(i32 %x) {
+entry:
+  ret void
+}
+
+; Function Attrs: nounwind
+define spir_kernel void @KernelOne(i32 %x) #2 !kernel_arg_addr_space !6 !kernel_arg_access_qual !6 !kernel_arg_type !6 !kernel_arg_type_qual !6 !kernel_arg_base_type !6 !kernel_arg_name !6 !work_group_size_hint !11 {
+entry:
+  call spir_func void @__itt_offload_wi_start_wrapper() #3
+  %0 = call spir_func i64 @_Z29__spirv_BuiltInGlobalLinearIdv() #4
+  %1 = call spir_func i64 @_Z25__spirv_BuiltInGlobalSizei(i32 %x) #4
+  %2 = call spir_func i64 @_Z26__spirv_BuiltInWorkgroupIdi(i32 %x) #4
+  %3 = call spir_func i64 @_Z28__spirv_BuiltInWorkgroupSizei(i32 %x) #4
+  %4 = call spir_func i64 @_Z32__spirv_BuiltInLocalInvocationIdi(i32 %x) #4
+  %5 = call spir_func i64 @_Z33__spirv_BuiltInGlobalInvocationIdi(i32 %x) #4
+  %6 = call spir_func i64 @_Z28__spirv_BuiltInNumWorkgroupsi(i32 %x) #4
+  %7 = call spir_func i64 @_Z27__spirv_BuiltInGlobalOffseti(i32 %x) #4
+  call spir_func void @foo(i32 %x)
+  %y = call spir_func i32 @bar(i32 %x)
+  call spir_func void @baz(i32 %y)
+  call spir_func void @__itt_offload_wi_finish_wrapper() #3
+  ret void
+}
+
+declare !sycl.kernel.fused !13 !sycl.kernel.nd-ranges !15 !sycl.kernel.nd-range !24 void @fused_kernel()
+
+; CHECK-LABEL: define spir_kernel void @fused_0(
+; CHECK-SAME:                                   i32 %[[X0:.*]], i32 %[[X1:.*]], i32 %[[X2:.*]])
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    %[[GID:.*]] = call spir_func i64 @_Z29__spirv_BuiltInGlobalLinearIdv()
+; CHECK-NEXT:    %[[CMP:.*]] = icmp ult i64 %[[GID]], 42
+; CHECK-NEXT:    br i1 %[[CMP]], label %[[CALL:.*]], label %[[EXIT:.*]]
+; CHECK-EMPTY:
+; CHECK-NEXT:  [[CALL]]:
+; CHECK-NEXT:    call spir_func i64 @_Z29__spirv_BuiltInGlobalLinearIdv()
+; CHECK-NEXT:    call spir_func i64 @__global_size_remapper_3_2_3_7_2_1_1_3_48_1_1_2_1_1(i32 %[[X0]]) #[[ATTRS:.*]]
+; CHECK-NEXT:    call spir_func i64 @__group_id_remapper_3_2_3_7_2_1_1_3_48_1_1_2_1_1(i32 %[[X0]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func i64 @__local_size_remapper_3_2_3_7_2_1_1_3_48_1_1_2_1_1(i32 %[[X0]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func i64 @__local_id_remapper_3_2_3_7_2_1_1_3_48_1_1_2_1_1(i32 %[[X0]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func i64 @__global_id_remapper_3_2_3_7_2_1_1_3_48_1_1_2_1_1(i32 %[[X0]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func i64 @__num_work_groups_remapper_3_2_3_7_2_1_1_3_48_1_1_2_1_1(i32 %[[X0]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func i64 @__global_offset_remapper_3_2_3_7_2_1_1_3_48_1_1_2_1_1(i32 %[[X0]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func void @foo.2(i32 %[[X0]])
+; CHECK-NEXT:    %[[Y0:.*]] = call spir_func i32 @bar.3(i32 %[[X0]])
+; CHECK-NEXT:    call spir_func void @baz(i32 %[[Y0]])
+; CHECK-NEXT:    br label %[[EXIT]]
+; CHECK-EMPTY:
+; CHECK-NEXT:  [[EXIT]]:
+; CHECK-NEXT:    call spir_func void @_Z22__spirv_ControlBarrierjjj
+; CHECK-NEXT:    %[[GID:.*]] = call spir_func i64 @_Z29__spirv_BuiltInGlobalLinearIdv()
+; CHECK-NEXT:    %[[CMP:.*]] = icmp ult i64 %[[GID]], 8
+; CHECK-NEXT:    br i1 %[[CMP]], label %[[CALL:.*]], label %[[EXIT:.*]]
+; CHECK-EMPTY:
+; CHECK-NEXT:  [[CALL]]:
+; CHECK-NEXT:    call spir_func i64 @_Z29__spirv_BuiltInGlobalLinearIdv()
+; CHECK-NEXT:    call spir_func i64 @__global_size_remapper_2_2_4_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X1]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func i64 @__group_id_remapper_2_2_4_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X1]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func i64 @__local_size_remapper_2_2_4_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X1]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func i64 @__local_id_remapper_2_2_4_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X1]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func i64 @__global_id_remapper_2_2_4_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X1]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func i64 @__num_work_groups_remapper_2_2_4_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X1]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func i64 @__global_offset_remapper_2_2_4_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X1]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func void @foo.6(i32 %[[X1]])
+; CHECK-NEXT:    %[[Y1:.*]] = call spir_func i32 @bar.7(i32 %[[X1]])
+; CHECK-NEXT:    call spir_func void @baz(i32 %[[Y1]])
+; CHECK-NEXT:    br label %[[EXIT]]
+; CHECK-EMPTY:
+; CHECK-NEXT:  [[EXIT]]:
+; CHECK-NEXT:    call spir_func void @_Z22__spirv_ControlBarrierjjj
+; CHECK-NEXT:    call spir_func i64 @_Z29__spirv_BuiltInGlobalLinearIdv()
+; CHECK-NEXT:    call spir_func i64 @__global_size_remapper_1_48_1_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X2]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func i64 @__group_id_remapper_1_48_1_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X2]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func i64 @__local_size_remapper_1_48_1_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X2]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func i64 @__local_id_remapper_1_48_1_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X2]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func i64 @__global_id_remapper_1_48_1_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X2]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func i64 @__num_work_groups_remapper_1_48_1_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X2]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func i64 @__global_offset_remapper_1_48_1_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X2]]) #[[ATTRS]]
+; CHECK-NEXT:    call spir_func void @foo.10(i32 %[[X2]])
+; CHECK-NEXT:    %[[Y2:.*]] = call spir_func i32 @bar.11(i32 %[[X2]])
+; CHECK-NEXT:    call spir_func void @baz(i32 %[[Y2]])
+; CHECK-NEXT:    ret void
+; CHECK-NEXT:  }
+
+; CHECK-LABEL: define spir_func void @foo.2(
+; CHECK-SAME:                               i32 %[[X:.*]]) {
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   call spir_func i64 @_Z29__spirv_BuiltInGlobalLinearIdv()
+; CHECK-NEXT:   call spir_func i64 @__global_size_remapper_3_2_3_7_2_1_1_3_48_1_1_2_1_1(i32 %[[X]]) #[[ATTRS]]
+; CHECK-NEXT:   call spir_func i64 @__group_id_remapper_3_2_3_7_2_1_1_3_48_1_1_2_1_1(i32 %[[X]]) #[[ATTRS]]
+; CHECK-NEXT:   call spir_func i64 @__local_size_remapper_3_2_3_7_2_1_1_3_48_1_1_2_1_1(i32 %[[X]]) #[[ATTRS]]
+; CHECK-NEXT:   call spir_func i64 @__local_id_remapper_3_2_3_7_2_1_1_3_48_1_1_2_1_1(i32 %[[X]]) #[[ATTRS]]
+; CHECK-NEXT:   call spir_func i64 @__global_id_remapper_3_2_3_7_2_1_1_3_48_1_1_2_1_1(i32 %[[X]]) #[[ATTRS]]
+; CHECK-NEXT:   call spir_func i64 @__num_work_groups_remapper_3_2_3_7_2_1_1_3_48_1_1_2_1_1(i32 %[[X]]) #[[ATTRS]]
+; CHECK-NEXT:   call spir_func i64 @__global_offset_remapper_3_2_3_7_2_1_1_3_48_1_1_2_1_1(i32 %[[X]]) #[[ATTRS]]
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }
+
+; CHECK-LABEL: define spir_func i32 @bar.3(
+; CHECK:        call spir_func i32 @bar.3
+
+; CHECK-LABEL: define spir_func void @foo.6(
+; CHECK-SAME:                               i32 %[[X:.*]]) {
+; CHECK-NEXT: entry:
+; CHECK-NEXT:   call spir_func i64 @_Z29__spirv_BuiltInGlobalLinearIdv()
+; CHECK-NEXT:   call spir_func i64 @__global_size_remapper_2_2_4_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X]]) #[[ATTRS]]
+; CHECK-NEXT:   call spir_func i64 @__group_id_remapper_2_2_4_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X]]) #[[ATTRS]]
+; CHECK-NEXT:   call spir_func i64 @__local_size_remapper_2_2_4_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X]]) #[[ATTRS]]
+; CHECK-NEXT:   call spir_func i64 @__local_id_remapper_2_2_4_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X]]) #[[ATTRS]]
+; CHECK-NEXT:   call spir_func i64 @__global_id_remapper_2_2_4_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X]]) #[[ATTRS]]
+; CHECK-NEXT:   call spir_func i64 @__num_work_groups_remapper_2_2_4_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X]]) #[[ATTRS]]
+; CHECK-NEXT:   call spir_func i64 @__global_offset_remapper_2_2_4_1_2_1_1_3_48_1_1_2_1_1(i32 %[[X]]) #[[ATTRS]]
+; CHECK-NEXT:   ret void
+; CHECK-NEXT: }
+
+declare !sycl.kernel.fused !31 !sycl.kernel.nd-ranges !25 !sycl.kernel.nd-range !24 void @fused_kernel_1D()
+
+; CHECK-LABEL: define spir_kernel void @fused_1(
+; CHECK-SAME:                                   i32 %[[X0:.*]], i32 %[[X1:.*]], i32 %[[X2:.*]])
+; CHECK-NEXT:   entry:
+; CHECK-NEXT:     %[[GID:.*]] = call spir_func i64 @_Z29__spirv_BuiltInGlobalLinearIdv()
+; CHECK-NEXT:     %[[CMP:.*]] = icmp ult i64 %[[GID]], 20
+; CHECK-NEXT:     br i1 %[[CMP]], label %[[CALL:.*]], label %[[EXIT:.*]]
+; CHECK-EMPTY:
+; CHECK-NEXT:   [[CALL]]
+; CHECK-NEXT:     call spir_func i64 @_Z29__spirv_BuiltInGlobalLinearIdv()
+; CHECK-NEXT:     call spir_func i64 @__global_size_remapper_1_20_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X0]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func i64 @__group_id_remapper_1_20_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X0]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func i64 @__local_size_remapper_1_20_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X0]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func i64 @__local_id_remapper_1_20_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X0]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func i64 @__global_id_remapper_1_20_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X0]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func i64 @__num_work_groups_remapper_1_20_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X0]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func i64 @__global_offset_remapper_1_20_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X0]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func void @foo.14(i32 %[[X0]])
+; CHECK-NEXT:     %[[Y0:.*]] = call spir_func i32 @bar.15(i32 %[[X0]])
+; CHECK-NEXT:     call spir_func void @baz(i32 %[[Y0]])
+; CHECK-NEXT:     br label %[[EXIT]]
+; CHECK-EMPTY:
+; CHECK-NEXT:   [[EXIT]]:
+; CHECK-NEXT:     call spir_func void @_Z22__spirv_ControlBarrierjjj
+; CHECK-NEXT:     %[[GID:.*]] = call spir_func i64 @_Z29__spirv_BuiltInGlobalLinearIdv()
+; CHECK-NEXT:     %[[CMP:.*]] = icmp ult i64 %[[GID]], 10
+; CHECK-NEXT:     br i1 %[[CMP]], label %[[CALL:.*]], label %[[EXIT:.*]]
+; CHECK-EMPTY:
+; CHECK-NEXT:   [[CALL]]:
+; CHECK-NEXT:     call spir_func i64 @_Z29__spirv_BuiltInGlobalLinearIdv()
+; CHECK-NEXT:     call spir_func i64 @__global_size_remapper_1_10_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X1]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func i64 @__group_id_remapper_1_10_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X1]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func i64 @__local_size_remapper_1_10_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X1]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func i64 @__local_id_remapper_1_10_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X1]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func i64 @__global_id_remapper_1_10_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X1]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func i64 @__num_work_groups_remapper_1_10_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X1]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func i64 @__global_offset_remapper_1_10_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X1]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func void @foo.18(i32 %[[X1]])
+; CHECK-NEXT:     %[[Y1:.*]] = call spir_func i32 @bar.19(i32 %[[X1]])
+; CHECK-NEXT:     call spir_func void @baz(i32 %[[Y1]])
+; CHECK-NEXT:     label %[[EXIT]]
+; CHECK-EMPTY:
+; CHECK-NEXT:   [[EXIT]]:
+; CHECK-NEXT:     call spir_func void @_Z22__spirv_ControlBarrierjjj
+; CHECK-NEXT:     %[[GID:.*]] = call spir_func i64 @_Z29__spirv_BuiltInGlobalLinearIdv()
+; CHECK-NEXT:     %[[CMP:.*]] = icmp ult i64 %[[GID]], 20
+; CHECK-NEXT:     br i1 %[[CMP]], label %[[CALL:.*]], label %[[EXIT:.*]]
+; CHECK-EMPTY:
+; CHECK-NEXT:   [[CALL]]:
+; CHECK-NEXT:     call spir_func i64 @_Z29__spirv_BuiltInGlobalLinearIdv()
+; CHECK-NEXT:     call spir_func i64 @__global_size_remapper_1_20_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X2]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func i64 @__group_id_remapper_1_20_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X2]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func i64 @__local_size_remapper_1_20_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X2]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func i64 @__local_id_remapper_1_20_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X2]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func i64 @__global_id_remapper_1_20_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X2]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func i64 @__num_work_groups_remapper_1_20_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X2]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func i64 @__global_offset_remapper_1_20_1_1_10_1_1_3_48_1_1_2_1_1(i32 %[[X2]]) #[[ATTRS]]
+; CHECK-NEXT:     call spir_func void @foo.14(i32 %[[X2]])
+; CHECK-NEXT:     %[[Y2:.*]] = call spir_func i32 @bar.15(i32 %[[X2]])
+; CHECK-NEXT:     call spir_func void @baz(i32 %[[Y2]])
+; CHECK-NEXT:     br label %[[EXIT]]
+; CHECK-EMPTY:
+; CHECK-NEXT:   [[EXIT]]:
+; CHECK-NEXT:     ret void
+; CHECK-NEXT:   }
+
+; This should be the last test
+
+declare !sycl.kernel.fused !41 !sycl.kernel.nd-ranges !42 !sycl.kernel.nd-range !43 void @fused_kernel_homogeneous()
+
+; CHECK-LABEL: define spir_kernel void @fused_3
+; CHECK-NOT:   remapper
+
+attributes #2 = { nounwind }
+attributes #3 = { alwaysinline nounwind }
+attributes #4 = { willreturn nounwind }
+
+; CHECK:       attributes #[[ATTRS]] = { alwaysinline nounwind }
+
+!6 = !{}
+!11 = !{i32 64, i32 1, i32 1}
+!12 = !{!"_arg_y"}
+!13 = !{!"fused_0", !14}
+!14 = !{!"KernelOne", !"KernelOne", !"KernelOne"}
+!15 = !{!16, !17, !18}
+!16 = !{i32 3, !19, !20, !21}
+!17 = !{i32 2, !22, !20, !21}
+!18 = !{i32 1, !23, !20, !21}
+!19 = !{i64 2, i64 3, i64 7}
+!20 = !{i64 2, i64 1, i64 1}
+!21 = !{i64 0, i64 0, i64 0}
+!22 = !{i64 2, i64 4, i64 1}
+!23 = !{i64 48, i64 1, i64 1}
+!24 = !{i32 3, !23, !20, !21}
+!25 = !{!26, !27, !26}
+!26 = !{i32 1, !28, !29, !21}
+!27 = !{i32 1, !30, !29, !21}
+!28 = !{i64 20, i64 1, i64 1}
+!29 = !{i64 10, i64 1, i64 1}
+!30 = !{i64 10, i64 1, i64 1}
+!31 = !{!"fused_1", !14}
+!32 = !{!"fused_2", !14}
+!33 = !{!34, !35, !36}
+!34 = !{i32 3, !37, !38, !21}
+!35 = !{i32 3, !39, !38, !21}
+!36 = !{i32 3, !40, !38, !21}
+!37 = !{i64 60, i64 60, i64 60}
+!38 = !{i64 2, i64 3, i64 20}
+!39 = !{i64 2, i64 6, i64 40}
+!40 = !{i64 6, i64 30, i64 60}
+!41 = !{!"fused_3", !14}
+!42 = !{!43, !43, !43}
+!43 = !{i32 3, !44, !45, !46}
+!44 = !{i64 100, i64 100, i64 100}
+!45 = !{i64 10, i64 10, i64 10}
+!46 = !{i64 0, i64 0, i64 0}


### PR DESCRIPTION
This involves:

- Remapping functions calling other functions;
- Using a cache to support recursive functions;
- Fail if an unsupported builtin is used.

