### PR TITLE
[SYCL] Fix std::variant is_device_copyable specialization

### DIFF
--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -2285,7 +2285,7 @@ template <typename... Ts>
 struct is_device_copyable<
     std::variant<Ts...>,
     std::enable_if_t<!std::is_trivially_copyable<std::variant<Ts...>>::value>>
-    : is_device_copyable<Ts...> {};
+    : std::bool_constant<(is_device_copyable<Ts>::value && ...)> {};
 
 // marray is device copyable if element type is device copyable and it is also
 // not trivially copyable (if the element type is trivially copyable, the marray


### PR DESCRIPTION
On some systems std::variant is not trivially copyable by default, but we still consider it device-copyable as long as its constituents are. This commit fixes a bug where the pack expansion when checking the consistuent types was incorrect.