### PR TITLE
[SYCL-MLIR] Use the vector dialect to lower sycl grid operations

### DIFF
--- a/mlir-sycl/include/mlir/Conversion/SYCLPasses.td
+++ b/mlir-sycl/include/mlir/Conversion/SYCLPasses.td
@@ -53,10 +53,10 @@ def ConvertSYCLToGPU : Pass<"convert-sycl-to-gpu", "ModuleOp"> {
   }];
   let constructor = "mlir::sycl::createConvertSYCLToGPUPass()";
   let dependentDialects = [
-      "AffineDialect",
       "arith::ArithDialect",
       "gpu::GPUDialect",
       "memref::MemRefDialect",
+      "vector::VectorDialect"
   ];
 }
 
@@ -81,10 +81,10 @@ def ConvertSYCLToSPIRV : Pass<"convert-sycl-to-spirv", "ModuleOp"> {
   }];
   let constructor = "mlir::sycl::createConvertSYCLToSPIRVPass()";
   let dependentDialects = [
-      "AffineDialect",
       "arith::ArithDialect",
       "spirv::SPIRVDialect",
       "memref::MemRefDialect",
+      "vector::VectorDialect"
   ];
 }
 

--- a/mlir-sycl/lib/Conversion/SYCLToGPU/CMakeLists.txt
+++ b/mlir-sycl/lib/Conversion/SYCLToGPU/CMakeLists.txt
@@ -13,4 +13,5 @@ add_mlir_conversion_library(MLIRSYCLToGPU
   MLIRIR
   MLIRSYCLDialect
   MLIRTransforms
+  MLIRVectorDialect
   )

--- a/mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPUPass.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPUPass.cpp
@@ -13,11 +13,11 @@
 #include "mlir/Conversion/SYCLToGPU/SYCLToGPUPass.h"
 
 #include "mlir/Conversion/SYCLToGPU/SYCLToGPU.h"
-#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 
 using namespace mlir;
 using namespace mlir::sycl;
@@ -44,8 +44,9 @@ void ConvertSYCLToGPUPass::runOnOperation() {
 
   populateSYCLToGPUConversionPatterns(patterns);
 
-  target.addLegalDialect<AffineDialect, arith::ArithDialect, gpu::GPUDialect,
-                         memref::MemRefDialect, SYCLDialect>();
+  target.addLegalDialect<arith::ArithDialect, gpu::GPUDialect,
+                         memref::MemRefDialect, SYCLDialect,
+                         vector::VectorDialect>();
 
   target
       .addIllegalOp<SYCLWorkGroupIDOp, SYCLNumWorkItemsOp, SYCLWorkGroupSizeOp,

--- a/mlir-sycl/lib/Conversion/SYCLToSPIRV/CMakeLists.txt
+++ b/mlir-sycl/lib/Conversion/SYCLToSPIRV/CMakeLists.txt
@@ -15,4 +15,5 @@ add_mlir_conversion_library(MLIRSYCLToSPIRV
   MLIRSPIRVDialect
   MLIRSYCLDialect
   MLIRTransforms
+  MLIRVectorDialect
   )

--- a/mlir-sycl/lib/Conversion/SYCLToSPIRV/SYCLToSPIRVPass.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToSPIRV/SYCLToSPIRVPass.cpp
@@ -13,7 +13,6 @@
 #include "mlir/Conversion/SYCLToSPIRV/SYCLToSPIRVPass.h"
 
 #include "mlir/Conversion/SYCLToSPIRV/SYCLToSPIRV.h"
-#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -22,6 +21,7 @@
 #include "mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h"
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"
 #include "mlir/Dialect/SYCL/IR/SYCLOpsDialect.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
 
 using namespace mlir;
 using namespace mlir::sycl;
@@ -58,8 +58,8 @@ void ConvertSYCLToSPIRVPass::runOnOperation() {
     target.addLegalDialect<arith::ArithDialect>();
     target.addLegalDialect<spirv::SPIRVDialect>();
     target.addLegalDialect<memref::MemRefDialect>();
-    target.addLegalDialect<AffineDialect>();
     target.addLegalDialect<SYCLDialect>();
+    target.addLegalDialect<vector::VectorDialect>();
 
     target.addIllegalOp<SYCLGlobalOffsetOp, SYCLNumWorkGroupsOp,
                         SYCLSubGroupLocalIDOp, SYCLSubGroupMaxSizeOp>();

--- a/mlir-sycl/test/Conversion/SYCLToGPU/grid-ops.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToGPU/grid-ops.mlir
@@ -14,8 +14,8 @@
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.grid_dim  x
 // CHECK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : index to i64
 // CHECK-NEXT:      %[[VAL_5:.*]] = sycl.range.get %[[VAL_0]]{{\[}}%[[VAL_2]]] {ArgumentTypes = [memref<1x!sycl_range_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_1_>, i32) -> memref<1xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<1xi64, 4>
-// CHECK-NEXT:      %[[VAL_6:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_range_1_>
+// CHECK-NEXT:      memref.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<1xi64, 4>
+// CHECK-NEXT:      %[[VAL_6:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_range_1_>
 // CHECK-NEXT:      return %[[VAL_6]] : !sycl_range_1_
 // CHECK-NEXT:    }
 func.func @test_num_work_items() -> !sycl_range_1_ {
@@ -25,18 +25,14 @@ func.func @test_num_work_items() -> !sycl_range_1_ {
 
 // CHECK-LABEL:   func.func @test_num_work_items_dim(
 // CHECK-SAME:                                       %[[VAL_0:.*]]: i32) -> index {
-// CHECK-NEXT:      %[[VAL_1:.*]] = memref.alloca() : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant dense<0> : vector<3xindex>
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.grid_dim  x
-// CHECK-NEXT:      affine.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_4:.*]] = vector.insert %[[VAL_3]], %[[VAL_1]] [0] : index into vector<3xindex>
 // CHECK-NEXT:      %[[VAL_5:.*]] = gpu.grid_dim  y
-// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[VAL_6:.*]] = vector.insert %[[VAL_5]], %[[VAL_4]] [1] : index into vector<3xindex>
 // CHECK-NEXT:      %[[VAL_7:.*]] = gpu.grid_dim  z
-// CHECK-NEXT:      affine.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_0]] : i32 to index
-// CHECK-NEXT:      %[[VAL_9:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_8:.*]] = vector.insert %[[VAL_7]], %[[VAL_6]] [2] : index into vector<3xindex>
+// CHECK-NEXT:      %[[VAL_9:.*]] = vector.extractelement %[[VAL_8]]{{\[}}%[[VAL_0]] : i32] : vector<3xindex>
 // CHECK-NEXT:      return %[[VAL_9]] : index
 // CHECK-NEXT:    }
 func.func @test_num_work_items_dim(%i: i32) -> index {
@@ -51,13 +47,13 @@ func.func @test_num_work_items_dim(%i: i32) -> index {
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.global_id  x
 // CHECK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : index to i64
 // CHECK-NEXT:      %[[VAL_5:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_2]]] {ArgumentTypes = [memref<1x!sycl_id_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_2_>, i32) -> memref<2xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<2xi64, 4>
+// CHECK-NEXT:      memref.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<2xi64, 4>
 // CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 1 : i32
 // CHECK-NEXT:      %[[VAL_7:.*]] = gpu.global_id  y
 // CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_7]] : index to i64
 // CHECK-NEXT:      %[[VAL_9:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_6]]] {ArgumentTypes = [memref<1x!sycl_id_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_2_>, i32) -> memref<2xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_8]], %[[VAL_9]]{{\[}}%[[VAL_1]]] : memref<2xi64, 4>
-// CHECK-NEXT:      %[[VAL_10:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_2_>
+// CHECK-NEXT:      memref.store %[[VAL_8]], %[[VAL_9]]{{\[}}%[[VAL_1]]] : memref<2xi64, 4>
+// CHECK-NEXT:      %[[VAL_10:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_2_>
 // CHECK-NEXT:      return %[[VAL_10]] : !sycl_id_2_
 // CHECK-NEXT:    }
 func.func @test_global_id() -> !sycl_id_2_ {
@@ -67,18 +63,14 @@ func.func @test_global_id() -> !sycl_id_2_ {
 
 // CHECK-LABEL:   func.func @test_global_id_dim(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: i32) -> index {
-// CHECK-NEXT:      %[[VAL_1:.*]] = memref.alloca() : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant dense<0> : vector<3xindex>
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.global_id  x
-// CHECK-NEXT:      affine.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_4:.*]] = vector.insert %[[VAL_3]], %[[VAL_1]] [0] : index into vector<3xindex>
 // CHECK-NEXT:      %[[VAL_5:.*]] = gpu.global_id  y
-// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[VAL_6:.*]] = vector.insert %[[VAL_5]], %[[VAL_4]] [1] : index into vector<3xindex>
 // CHECK-NEXT:      %[[VAL_7:.*]] = gpu.global_id  z
-// CHECK-NEXT:      affine.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_0]] : i32 to index
-// CHECK-NEXT:      %[[VAL_9:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_8:.*]] = vector.insert %[[VAL_7]], %[[VAL_6]] [2] : index into vector<3xindex>
+// CHECK-NEXT:      %[[VAL_9:.*]] = vector.extractelement %[[VAL_8]]{{\[}}%[[VAL_0]] : i32] : vector<3xindex>
 // CHECK-NEXT:      return %[[VAL_9]] : index
 // CHECK-NEXT:    }
 func.func @test_global_id_dim(%i: i32) -> index {
@@ -93,18 +85,18 @@ func.func @test_global_id_dim(%i: i32) -> index {
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.thread_id  x
 // CHECK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : index to i64
 // CHECK-NEXT:      %[[VAL_5:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_2]]] {ArgumentTypes = [memref<1x!sycl_id_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_3_>, i32) -> memref<3xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      memref.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
 // CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 1 : i32
 // CHECK-NEXT:      %[[VAL_7:.*]] = gpu.thread_id  y
 // CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_7]] : index to i64
 // CHECK-NEXT:      %[[VAL_9:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_6]]] {ArgumentTypes = [memref<1x!sycl_id_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_3_>, i32) -> memref<3xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_8]], %[[VAL_9]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      memref.store %[[VAL_8]], %[[VAL_9]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
 // CHECK-NEXT:      %[[VAL_10:.*]] = arith.constant 2 : i32
 // CHECK-NEXT:      %[[VAL_11:.*]] = gpu.thread_id  z
 // CHECK-NEXT:      %[[VAL_12:.*]] = arith.index_cast %[[VAL_11]] : index to i64
 // CHECK-NEXT:      %[[VAL_13:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_10]]] {ArgumentTypes = [memref<1x!sycl_id_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_3_>, i32) -> memref<3xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_12]], %[[VAL_13]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
-// CHECK-NEXT:      %[[VAL_14:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_3_>
+// CHECK-NEXT:      memref.store %[[VAL_12]], %[[VAL_13]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      %[[VAL_14:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_3_>
 // CHECK-NEXT:      return %[[VAL_14]] : !sycl_id_3_
 // CHECK-NEXT:    }
 func.func @test_local_id() -> !sycl_id_3_ {
@@ -114,18 +106,14 @@ func.func @test_local_id() -> !sycl_id_3_ {
 
 // CHECK-LABEL:   func.func @test_local_id_dim(
 // CHECK-SAME:                                 %[[VAL_0:.*]]: i32) -> index {
-// CHECK-NEXT:      %[[VAL_1:.*]] = memref.alloca() : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant dense<0> : vector<3xindex>
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.thread_id  x
-// CHECK-NEXT:      affine.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_4:.*]] = vector.insert %[[VAL_3]], %[[VAL_1]] [0] : index into vector<3xindex>
 // CHECK-NEXT:      %[[VAL_5:.*]] = gpu.thread_id  y
-// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[VAL_6:.*]] = vector.insert %[[VAL_5]], %[[VAL_4]] [1] : index into vector<3xindex>
 // CHECK-NEXT:      %[[VAL_7:.*]] = gpu.thread_id  z
-// CHECK-NEXT:      affine.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_0]] : i32 to index
-// CHECK-NEXT:      %[[VAL_9:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_8:.*]] = vector.insert %[[VAL_7]], %[[VAL_6]] [2] : index into vector<3xindex>
+// CHECK-NEXT:      %[[VAL_9:.*]] = vector.extractelement %[[VAL_8]]{{\[}}%[[VAL_0]] : i32] : vector<3xindex>
 // CHECK-NEXT:      return %[[VAL_9]] : index
 // CHECK-NEXT:    }
 func.func @test_local_id_dim(%i: i32) -> index {
@@ -140,18 +128,18 @@ func.func @test_local_id_dim(%i: i32) -> index {
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.block_dim  x
 // CHECK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : index to i64
 // CHECK-NEXT:      %[[VAL_5:.*]] = sycl.range.get %[[VAL_0]]{{\[}}%[[VAL_2]]] {ArgumentTypes = [memref<1x!sycl_range_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      memref.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
 // CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 1 : i32
 // CHECK-NEXT:      %[[VAL_7:.*]] = gpu.block_dim  y
 // CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_7]] : index to i64
 // CHECK-NEXT:      %[[VAL_9:.*]] = sycl.range.get %[[VAL_0]]{{\[}}%[[VAL_6]]] {ArgumentTypes = [memref<1x!sycl_range_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_8]], %[[VAL_9]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      memref.store %[[VAL_8]], %[[VAL_9]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
 // CHECK-NEXT:      %[[VAL_10:.*]] = arith.constant 2 : i32
 // CHECK-NEXT:      %[[VAL_11:.*]] = gpu.block_dim  z
 // CHECK-NEXT:      %[[VAL_12:.*]] = arith.index_cast %[[VAL_11]] : index to i64
 // CHECK-NEXT:      %[[VAL_13:.*]] = sycl.range.get %[[VAL_0]]{{\[}}%[[VAL_10]]] {ArgumentTypes = [memref<1x!sycl_range_3_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_12]], %[[VAL_13]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
-// CHECK-NEXT:      %[[VAL_14:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_range_3_>
+// CHECK-NEXT:      memref.store %[[VAL_12]], %[[VAL_13]]{{\[}}%[[VAL_1]]] : memref<3xi64, 4>
+// CHECK-NEXT:      %[[VAL_14:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_range_3_>
 // CHECK-NEXT:      return %[[VAL_14]] : !sycl_range_3_
 // CHECK-NEXT:    }
 func.func @test_work_group_size() -> !sycl_range_3_ {
@@ -161,18 +149,14 @@ func.func @test_work_group_size() -> !sycl_range_3_ {
 
 // CHECK-LABEL:   func.func @test_work_group_size_dim(
 // CHECK-SAME:                                        %[[VAL_0:.*]]: i32) -> index {
-// CHECK-NEXT:      %[[VAL_1:.*]] = memref.alloca() : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant dense<0> : vector<3xindex>
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.block_dim  x
-// CHECK-NEXT:      affine.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_4:.*]] = vector.insert %[[VAL_3]], %[[VAL_1]] [0] : index into vector<3xindex>
 // CHECK-NEXT:      %[[VAL_5:.*]] = gpu.block_dim  y
-// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[VAL_6:.*]] = vector.insert %[[VAL_5]], %[[VAL_4]] [1] : index into vector<3xindex>
 // CHECK-NEXT:      %[[VAL_7:.*]] = gpu.block_dim  z
-// CHECK-NEXT:      affine.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_0]] : i32 to index
-// CHECK-NEXT:      %[[VAL_9:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_8:.*]] = vector.insert %[[VAL_7]], %[[VAL_6]] [2] : index into vector<3xindex>
+// CHECK-NEXT:      %[[VAL_9:.*]] = vector.extractelement %[[VAL_8]]{{\[}}%[[VAL_0]] : i32] : vector<3xindex>
 // CHECK-NEXT:      return %[[VAL_9]] : index
 // CHECK-NEXT:    }
 func.func @test_work_group_size_dim(%i: i32) -> index {
@@ -187,8 +171,8 @@ func.func @test_work_group_size_dim(%i: i32) -> index {
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.block_id  x
 // CHECK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : index to i64
 // CHECK-NEXT:      %[[VAL_5:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_2]]] {ArgumentTypes = [memref<1x!sycl_id_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_1_>, i32) -> memref<1xi64, 4>
-// CHECK-NEXT:      affine.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<1xi64, 4>
-// CHECK-NEXT:      %[[VAL_6:.*]] = affine.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_1_>
+// CHECK-NEXT:      memref.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<1xi64, 4>
+// CHECK-NEXT:      %[[VAL_6:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_1_>
 // CHECK-NEXT:      return %[[VAL_6]] : !sycl_id_1_
 // CHECK-NEXT:    }
 func.func @test_work_group_id() -> !sycl_id_1_ {
@@ -198,18 +182,14 @@ func.func @test_work_group_id() -> !sycl_id_1_ {
 
 // CHECK-LABEL:   func.func @test_work_group_id_dim(
 // CHECK-SAME:                                      %[[VAL_0:.*]]: i32) -> index {
-// CHECK-NEXT:      %[[VAL_1:.*]] = memref.alloca() : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant dense<0> : vector<3xindex>
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.block_id  x
-// CHECK-NEXT:      affine.store %[[VAL_3]], %[[VAL_1]]{{\[}}%[[VAL_2]]] : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_4:.*]] = vector.insert %[[VAL_3]], %[[VAL_1]] [0] : index into vector<3xindex>
 // CHECK-NEXT:      %[[VAL_5:.*]] = gpu.block_id  y
-// CHECK-NEXT:      affine.store %[[VAL_5]], %[[VAL_1]]{{\[}}%[[VAL_4]]] : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 2 : index
+// CHECK-NEXT:      %[[VAL_6:.*]] = vector.insert %[[VAL_5]], %[[VAL_4]] [1] : index into vector<3xindex>
 // CHECK-NEXT:      %[[VAL_7:.*]] = gpu.block_id  z
-// CHECK-NEXT:      affine.store %[[VAL_7]], %[[VAL_1]]{{\[}}%[[VAL_6]]] : memref<3xindex>
-// CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_0]] : i32 to index
-// CHECK-NEXT:      %[[VAL_9:.*]] = affine.load %[[VAL_1]]{{\[}}%[[VAL_8]]] : memref<3xindex>
+// CHECK-NEXT:      %[[VAL_8:.*]] = vector.insert %[[VAL_7]], %[[VAL_6]] [2] : index into vector<3xindex>
+// CHECK-NEXT:      %[[VAL_9:.*]] = vector.extractelement %[[VAL_8]]{{\[}}%[[VAL_0]] : i32] : vector<3xindex>
 // CHECK-NEXT:      return %[[VAL_9]] : index
 // CHECK-NEXT:    }
 func.func @test_work_group_id_dim(%i: i32) -> index {

--- a/mlir-sycl/test/Conversion/SYCLToSPIRV/grid-ops.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToSPIRV/grid-ops.mlir
@@ -13,17 +13,17 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:         gpu.func @test_global_offset() kernel
     // CHECK-NEXT:            %[[VAL_0:.*]] = spirv.mlir.addressof @[[GO]] : !spirv.ptr<vector<3xi32>, Input>
-    // CHECK-NEXT             %[[VAL_1:.*]] = spirv.Load "Input" %[[VAL_0]] : vector<3xi32>
-    // CHECK-NEXT             %[[VAL_2:.*]] = memref.alloca() : memref<1x!sycl_id_1_>
-    // CHECK-NEXT             %[[VAL_3:.*]] = arith.constant 0 : index
-    // CHECK-NEXT             %[[VAL_5:.*]] = arith.constant 0 : i32
-    // CHECK-NEXT             %[[VAL_6:.*]] = spirv.CompositeExtract %[[VAL_1]][0 : i32] : vector<3xi32>
-    // CHECK-NEXT             %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-    // CHECK-NEXT             %[[VAL_8:.*]] = "sycl.id.get"(%[[VAL_2]], %[[VAL_5]]) {ArgumentTypes = [memref<1x!sycl_id_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (!sycl_id_1_, i32) -> memref<1xi64, 4>
-    // CHECK-NEXT             affine.store %[[VAL_7]], %[[VAL_8]]{{\[}}%[[VAL_3]]] : memref<1xi64, 4>
-    // CHECK-NEXT             %[[VAL_4:.*]] = affine.load %[[VAL_2]]{{\[}}%[[VAL_3]]] : memref<1x!sycl_id_1_>
-    // CHECK-NEXT             gpu.return
-    // CHECK-NEXT           }
+    // CHECK-NEXT:            %[[VAL_1:.*]] = spirv.Load "Input" %[[VAL_0]] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_2:.*]] = memref.alloca() : memref<1x!sycl_id_1_>
+    // CHECK-NEXT:            %[[VAL_3:.*]] = arith.constant 0 : index
+    // CHECK-NEXT:            %[[VAL_5:.*]] = arith.constant 0 : i32
+    // CHECK-NEXT:            %[[VAL_6:.*]] = spirv.CompositeExtract %[[VAL_1]][0 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
+    // CHECK-NEXT:            %[[VAL_8:.*]] = sycl.id.get %[[VAL_2]][%[[VAL_5]]] {ArgumentTypes = [memref<1x!sycl_id_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_1_>, i32) -> memref<1xi64, 4>
+    // CHECK-NEXT:            memref.store %[[VAL_7]], %[[VAL_8]]{{\[}}%[[VAL_3]]] : memref<1xi64, 4>
+    // CHECK-NEXT:            %[[VAL_4:.*]] = memref.load %[[VAL_2]]{{\[}}%[[VAL_3]]] : memref<1x!sycl_id_1_>
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
     gpu.func @test_global_offset() kernel
       attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       %0 = sycl.global_offset : !sycl_id_1_
@@ -32,25 +32,21 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:         gpu.func @test_global_offset_dim(
     // CHECK-SAME:                                           %[[VAL_9:.*]]: i32) kernel
-    // CHECK-NEXT             %[[VAL_10:.*]] = spirv.mlir.addressof @[[GO]] : !spirv.ptr<vector<3xi32>, Input>
-    // CHECK-NEXT             %[[VAL_11:.*]] = spirv.Load "Input" %[[VAL_10]] : vector<3xi32>
-    // CHECK-NEXT             %[[VAL_12:.*]] = memref.alloca() : memref<3xindex>
-    // CHECK-NEXT             %[[VAL_13:.*]] = arith.constant 0 : index
-    // CHECK-NEXT             %[[VAL_14:.*]] = spirv.CompositeExtract %[[VAL_11]][0 : i32] : vector<3xi32>
-    // CHECK-NEXT             %[[VAL_15:.*]] = arith.index_cast %[[VAL_14]] : i32 to index
-    // CHECK-NEXT             affine.store %[[VAL_15]], %[[VAL_12]]{{\[}}%[[VAL_13]]] : memref<3xindex>
-    // CHECK-NEXT             %[[VAL_16:.*]] = arith.constant 1 : index
-    // CHECK-NEXT             %[[VAL_17:.*]] = spirv.CompositeExtract %[[VAL_11]][1 : i32] : vector<3xi32>
-    // CHECK-NEXT             %[[VAL_18:.*]] = arith.index_cast %[[VAL_17]] : i32 to index
-    // CHECK-NEXT             affine.store %[[VAL_18]], %[[VAL_12]]{{\[}}%[[VAL_16]]] : memref<3xindex>
-    // CHECK-NEXT             %[[VAL_19:.*]] = arith.constant 2 : index
-    // CHECK-NEXT             %[[VAL_20:.*]] = spirv.CompositeExtract %[[VAL_11]][2 : i32] : vector<3xi32>
-    // CHECK-NEXT             %[[VAL_21:.*]] = arith.index_cast %[[VAL_20]] : i32 to index
-    // CHECK-NEXT             affine.store %[[VAL_21]], %[[VAL_12]]{{\[}}%[[VAL_19]]] : memref<3xindex>
-    // CHECK-NEXT             %[[VAL_22:.*]] = arith.index_cast %[[VAL_9]] : i32 to index
-    // CHECK-NEXT             %[[VAL_23:.*]] = affine.load %[[VAL_12]]{{\[}}%[[VAL_22]]] : memref<3xindex>
-    // CHECK-NEXT             gpu.return
-    // CHECK-NEXT           }
+    // CHECK-NEXT:            %[[VAL_10:.*]] = spirv.mlir.addressof @[[GO]] : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-NEXT:            %[[VAL_11:.*]] = spirv.Load "Input" %[[VAL_10]] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_12:.*]] = arith.constant dense<0> : vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_14:.*]] = spirv.CompositeExtract %[[VAL_11]][0 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_15:.*]] = arith.index_cast %[[VAL_14]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_16:.*]] = vector.insert %[[VAL_15]], %[[VAL_12]] [0] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_17:.*]] = spirv.CompositeExtract %[[VAL_11]][1 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_18:.*]] = arith.index_cast %[[VAL_17]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_19:.*]] = vector.insert %[[VAL_18]], %[[VAL_16]] [1] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_20:.*]] = spirv.CompositeExtract %[[VAL_11]][2 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_21:.*]] = arith.index_cast %[[VAL_20]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_22:.*]] = vector.insert %[[VAL_21]], %[[VAL_19]] [2] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_23:.*]] = vector.extractelement %[[VAL_22]]{{\[}}%[[VAL_9]] : i32] : vector<3xindex>
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
     gpu.func @test_global_offset_dim(%i: i32) kernel
       attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       %0 = sycl.global_offset %i : index
@@ -58,23 +54,23 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:         gpu.func @test_num_work_groups() kernel
-    // CHECK-NEXT             %[[VAL_24:.*]] = spirv.mlir.addressof @[[NW]] : !spirv.ptr<vector<3xi32>, Input>
-    // CHECK-NEXT             %[[VAL_25:.*]] = spirv.Load "Input" %[[VAL_24]] : vector<3xi32>
-    // CHECK-NEXT             %[[VAL_26:.*]] = memref.alloca() : memref<1x!sycl_range_2_>
-    // CHECK-NEXT             %[[VAL_27:.*]] = arith.constant 0 : index
-    // CHECK-NEXT             %[[VAL_29:.*]] = arith.constant 0 : i32
-    // CHECK-NEXT             %[[VAL_30:.*]] = spirv.CompositeExtract %[[VAL_25]][0 : i32] : vector<3xi32>
-    // CHECK-NEXT             %[[VAL_31:.*]] = arith.extsi %[[VAL_30]] : i32 to i64
-    // CHECK-NEXT             %[[VAL_32:.*]] = "sycl.range.get"(%[[VAL_26]], %[[VAL_29]]) {ArgumentTypes = [memref<1x!sycl_range_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (!sycl_range_2_, i32) -> memref<2xi64, 4>
-    // CHECK-NEXT             affine.store %[[VAL_31]], %[[VAL_32]]{{\[}}%[[VAL_27]]] : memref<2xi64, 4>
-    // CHECK-NEXT             %[[VAL_33:.*]] = arith.constant 1 : i32
-    // CHECK-NEXT             %[[VAL_34:.*]] = spirv.CompositeExtract %[[VAL_25]][1 : i32] : vector<3xi32>
-    // CHECK-NEXT             %[[VAL_35:.*]] = arith.extsi %[[VAL_34]] : i32 to i64
-    // CHECK-NEXT             %[[VAL_36:.*]] = "sycl.range.get"(%[[VAL_26]], %[[VAL_33]]) {ArgumentTypes = [memref<1x!sycl_range_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (!sycl_range_2_, i32) -> memref<2xi64, 4>
-    // CHECK-NEXT             affine.store %[[VAL_35]], %[[VAL_36]]{{\[}}%[[VAL_27]]] : memref<2xi64, 4>
-    // CHECK-NEXT             %[[VAL_28:.*]] = affine.load %[[VAL_26]]{{\[}}%[[VAL_27]]] : memref<1x!sycl_range_2_>
-    // CHECK-NEXT             gpu.return
-    // CHECK-NEXT           }
+    // CHECK-NEXT:            %[[VAL_24:.*]] = spirv.mlir.addressof @[[NW]] : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-NEXT:            %[[VAL_25:.*]] = spirv.Load "Input" %[[VAL_24]] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_26:.*]] = memref.alloca() : memref<1x!sycl_range_2_>
+    // CHECK-NEXT:            %[[VAL_27:.*]] = arith.constant 0 : index
+    // CHECK-NEXT:            %[[VAL_29:.*]] = arith.constant 0 : i32
+    // CHECK-NEXT:            %[[VAL_30:.*]] = spirv.CompositeExtract %[[VAL_25]][0 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_31:.*]] = arith.extsi %[[VAL_30]] : i32 to i64
+    // CHECK-NEXT:            %[[VAL_32:.*]] = sycl.range.get %[[VAL_26]][%[[VAL_29]]] {ArgumentTypes = [memref<1x!sycl_range_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_2_>, i32) -> memref<2xi64, 4>
+    // CHECK-NEXT:            memref.store %[[VAL_31]], %[[VAL_32]]{{\[}}%[[VAL_27]]] : memref<2xi64, 4>
+    // CHECK-NEXT:            %[[VAL_33:.*]] = arith.constant 1 : i32
+    // CHECK-NEXT:            %[[VAL_34:.*]] = spirv.CompositeExtract %[[VAL_25]][1 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_35:.*]] = arith.extsi %[[VAL_34]] : i32 to i64
+    // CHECK-NEXT:            %[[VAL_36:.*]] = sycl.range.get %[[VAL_26]][%[[VAL_33]]] {ArgumentTypes = [memref<1x!sycl_range_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_2_>, i32) -> memref<2xi64, 4>
+    // CHECK-NEXT:            memref.store %[[VAL_35]], %[[VAL_36]]{{\[}}%[[VAL_27]]] : memref<2xi64, 4>
+    // CHECK-NEXT:            %[[VAL_28:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_27]]] : memref<1x!sycl_range_2_>
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
     gpu.func @test_num_work_groups() kernel
       attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       %0 = sycl.num_work_groups : !sycl_range_2_
@@ -83,25 +79,21 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:         gpu.func @test_num_work_groups_dim(
     // CHECK-SAME:                                             %[[VAL_37:.*]]: i32) kernel
-    // CHECK-NEXT             %[[VAL_38:.*]] = spirv.mlir.addressof @[[NW]] : !spirv.ptr<vector<3xi32>, Input>
-    // CHECK-NEXT             %[[VAL_39:.*]] = spirv.Load "Input" %[[VAL_38]] : vector<3xi32>
-    // CHECK-NEXT             %[[VAL_40:.*]] = memref.alloca() : memref<3xindex>
-    // CHECK-NEXT             %[[VAL_41:.*]] = arith.constant 0 : index
-    // CHECK-NEXT             %[[VAL_42:.*]] = spirv.CompositeExtract %[[VAL_39]][0 : i32] : vector<3xi32>
-    // CHECK-NEXT             %[[VAL_43:.*]] = arith.index_cast %[[VAL_42]] : i32 to index
-    // CHECK-NEXT             affine.store %[[VAL_43]], %[[VAL_40]]{{\[}}%[[VAL_41]]] : memref<3xindex>
-    // CHECK-NEXT             %[[VAL_44:.*]] = arith.constant 1 : index
-    // CHECK-NEXT             %[[VAL_45:.*]] = spirv.CompositeExtract %[[VAL_39]][1 : i32] : vector<3xi32>
-    // CHECK-NEXT             %[[VAL_46:.*]] = arith.index_cast %[[VAL_45]] : i32 to index
-    // CHECK-NEXT             affine.store %[[VAL_46]], %[[VAL_40]]{{\[}}%[[VAL_44]]] : memref<3xindex>
-    // CHECK-NEXT             %[[VAL_47:.*]] = arith.constant 2 : index
-    // CHECK-NEXT             %[[VAL_48:.*]] = spirv.CompositeExtract %[[VAL_39]][2 : i32] : vector<3xi32>
-    // CHECK-NEXT             %[[VAL_49:.*]] = arith.index_cast %[[VAL_48]] : i32 to index
-    // CHECK-NEXT             affine.store %[[VAL_49]], %[[VAL_40]]{{\[}}%[[VAL_47]]] : memref<3xindex>
-    // CHECK-NEXT             %[[VAL_50:.*]] = arith.index_cast %[[VAL_37]] : i32 to index
-    // CHECK-NEXT             %[[VAL_51:.*]] = affine.load %[[VAL_40]]{{\[}}%[[VAL_50]]] : memref<3xindex>
-    // CHECK-NEXT             gpu.return
-    // CHECK-NEXT           }
+    // CHECK-NEXT:            %[[VAL_38:.*]] = spirv.mlir.addressof @[[NW]] : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-NEXT:            %[[VAL_39:.*]] = spirv.Load "Input" %[[VAL_38]] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_40:.*]] = arith.constant dense<0> : vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_42:.*]] = spirv.CompositeExtract %[[VAL_39]][0 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_43:.*]] = arith.index_cast %[[VAL_42]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_44:.*]] = vector.insert %[[VAL_43]], %[[VAL_40]] [0] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_45:.*]] = spirv.CompositeExtract %[[VAL_39]][1 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_46:.*]] = arith.index_cast %[[VAL_45]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_47:.*]] = vector.insert %[[VAL_46]], %[[VAL_44]] [1] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_48:.*]] = spirv.CompositeExtract %[[VAL_39]][2 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_49:.*]] = arith.index_cast %[[VAL_48]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_50:.*]] = vector.insert %[[VAL_49]], %[[VAL_47]] [2] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_51:.*]] = vector.extractelement %[[VAL_50]]{{\[}}%[[VAL_37]] : i32] : vector<3xindex>
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
     gpu.func @test_num_work_groups_dim(%i: i32) kernel
       attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       %0 = sycl.num_work_groups %i : index
@@ -109,10 +101,10 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:         gpu.func @test_sub_group_max_size() kernel
-    // CHECK-NEXT             %[[VAL_52:.*]] = spirv.mlir.addressof @[[SMS]] : !spirv.ptr<i32, Input>
-    // CHECK-NEXT             %[[VAL_53:.*]] = spirv.Load "Input" %[[VAL_52]] : i32
-    // CHECK-NEXT             gpu.return
-    // CHECK-NEXT           }
+    // CHECK-NEXT:            %[[VAL_52:.*]] = spirv.mlir.addressof @[[SMS]] : !spirv.ptr<i32, Input>
+    // CHECK-NEXT:            %[[VAL_53:.*]] = spirv.Load "Input" %[[VAL_52]] : i32
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
     gpu.func @test_sub_group_max_size() kernel
       attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       %0 = sycl.sub_group_max_size : i32
@@ -120,10 +112,10 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:         gpu.func @test_sub_group_local_id() kernel
-    // CHECK-NEXT             %[[VAL_54:.*]] = spirv.mlir.addressof @[[SLIID]] : !spirv.ptr<i32, Input>
-    // CHECK-NEXT             %[[VAL_55:.*]] = spirv.Load "Input" %[[VAL_54]] : i32
-    // CHECK-NEXT             gpu.return
-    // CHECK-NEXT           }
+    // CHECK-NEXT:            %[[VAL_54:.*]] = spirv.mlir.addressof @[[SLIID]] : !spirv.ptr<i32, Input>
+    // CHECK-NEXT:            %[[VAL_55:.*]] = spirv.Load "Input" %[[VAL_54]] : i32
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
     gpu.func @test_sub_group_local_id() kernel
       attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       %0 = sycl.sub_group_local_id : i32


### PR DESCRIPTION
Use this dialect instead of `memref` + `affine`, easing canonicalization. Also replace `affine.x` operations with `memref.x` operations when suitable.