### PR TITLE
[SYCL] Fix constexpr initialization of vec for half

### DIFF
--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -466,6 +466,56 @@ static T<NewDim> convertToArrayOfN(T<OldDim> OldObj) {
   return NewObj;
 }
 
+// Helper function for concatenating two std::array.
+template <typename T, std::size_t... Is1, std::size_t... Is2>
+constexpr std::array<T, sizeof...(Is1) + sizeof...(Is2)>
+ConcatArrays(const std::array<T, sizeof...(Is1)> &A1,
+             const std::array<T, sizeof...(Is2)> &A2,
+             std::index_sequence<Is1...>, std::index_sequence<Is2...>) {
+  return {A1[Is1]..., A2[Is2]...};
+}
+template <typename T, std::size_t N1, std::size_t N2>
+constexpr std::array<T, N1 + N2> ConcatArrays(const std::array<T, N1> &A1,
+                                              const std::array<T, N2> &A2) {
+  return ConcatArrays(A1, A2, std::make_index_sequence<N1>(),
+                      std::make_index_sequence<N2>());
+}
+
+// Utility for creating an std::array from the results of flattening the
+// arguments using a flattening functor.
+template <typename DataT, template <typename, typename> typename FlattenF,
+          typename... ArgTN>
+struct ArrayCreator;
+template <typename DataT, template <typename, typename> typename FlattenF,
+          typename ArgT, typename... ArgTN>
+struct ArrayCreator<DataT, FlattenF, ArgT, ArgTN...> {
+  static constexpr auto Create(const ArgT &Arg, const ArgTN &...Args) {
+    auto ImmArray = FlattenF<DataT, ArgT>()(Arg);
+    if constexpr (sizeof...(Args))
+      return ConcatArrays(
+          ImmArray, ArrayCreator<DataT, FlattenF, ArgTN...>::Create(Args...));
+    else
+      return ImmArray;
+  }
+};
+template <typename DataT, template <typename, typename> typename FlattenF>
+struct ArrayCreator<DataT, FlattenF> {
+  static constexpr auto Create() { return std::array<DataT, 0>{}; }
+};
+
+// Helper function for creating an arbitrary sized array with the same value
+// repeating.
+template <typename T, size_t... Is>
+static constexpr std::array<T, sizeof...(Is)>
+RepeatValueHelper(const T &Arg, std::index_sequence<Is...>) {
+  auto ReturnArg = [&](size_t) { return Arg; };
+  return {ReturnArg(Is)...};
+}
+template <size_t N, typename T>
+static constexpr std::array<T, N> RepeatValue(const T &Arg) {
+  return RepeatValueHelper(Arg, std::make_index_sequence<N>());
+}
+
 } // namespace detail
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/half_type.hpp
+++ b/sycl/include/sycl/half_type.hpp
@@ -252,6 +252,11 @@ template <int NumElements> struct half_vec {
       StorageT s[NumElements];
 
   __SYCL_CONSTEXPR_HALF half_vec() : s{0.0f} { initialize_data(); }
+  template <typename... Ts,
+            typename = std::enable_if_t<(sizeof...(Ts) == NumElements) &&
+                                        (std::is_same_v<half, Ts> && ...)>>
+  __SYCL_CONSTEXPR_HALF half_vec(const Ts &...hs) : s{hs...} {}
+
   constexpr void initialize_data() {
     for (size_t i = 0; i < NumElements; ++i) {
       s[i] = StorageT(0.0f);

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -585,6 +585,58 @@ template <typename Type, int NumElements> class vec {
                               SizeChecker<Counter + 1, MaxValue, tail...>,
                               std::false_type> {};
 
+  // Utility trait for creating an std::array from an vector argument.
+  template <typename DataT_, typename T, std::size_t... Is>
+  static constexpr std::array<DataT_, sizeof...(Is)>
+  VecToArray(const vec<T, sizeof...(Is)> &V, std::index_sequence<Is...>) {
+    return {static_cast<DataT_>(V.getValue(Is))...};
+  }
+  template <typename DataT_, typename T, int N, typename T2, typename T3,
+            template <typename> class T4, int... T5, std::size_t... Is>
+  static constexpr std::array<DataT_, sizeof...(Is)>
+  VecToArray(const detail::SwizzleOp<vec<T, N>, T2, T3, T4, T5...> &V,
+             std::index_sequence<Is...>) {
+    return {static_cast<DataT_>(V.getValue(Is))...};
+  }
+  template <typename DataT_, typename T, int N, typename T2, typename T3,
+            template <typename> class T4, int... T5, std::size_t... Is>
+  static constexpr std::array<DataT_, sizeof...(Is)>
+  VecToArray(const detail::SwizzleOp<const vec<T, N>, T2, T3, T4, T5...> &V,
+             std::index_sequence<Is...>) {
+    return {static_cast<DataT_>(V.getValue(Is))...};
+  }
+  template <typename DataT_, typename T, int N>
+  static constexpr std::array<DataT_, N>
+  FlattenVecArgHelper(const vec<T, N> &A) {
+    return VecToArray<DataT_>(A, std::make_index_sequence<N>());
+  }
+  template <typename DataT_, typename T, int N, typename T2, typename T3,
+            template <typename> class T4, int... T5>
+  static constexpr std::array<DataT_, sizeof...(T5)> FlattenVecArgHelper(
+      const detail::SwizzleOp<vec<T, N>, T2, T3, T4, T5...> &A) {
+    return VecToArray<DataT_>(A, std::make_index_sequence<sizeof...(T5)>());
+  }
+  template <typename DataT_, typename T, int N, typename T2, typename T3,
+            template <typename> class T4, int... T5>
+  static constexpr std::array<DataT_, sizeof...(T5)> FlattenVecArgHelper(
+      const detail::SwizzleOp<const vec<T, N>, T2, T3, T4, T5...> &A) {
+    return VecToArray<DataT_>(A, std::make_index_sequence<sizeof...(T5)>());
+  }
+  template <typename DataT_, typename T>
+  static constexpr auto FlattenVecArgHelper(const T &A) {
+    return std::array<DataT_, 1>{vec_data<DataT_>::get(A)};
+  }
+  template <typename DataT_, typename T> struct FlattenVecArg {
+    constexpr auto operator()(const T &A) const {
+      return FlattenVecArgHelper<DataT_>(A);
+    }
+  };
+
+  // Alias for shortening the vec arguments to array converter.
+  template <typename DataT_, typename... ArgTN>
+  using VecArgArrayCreator =
+      detail::ArrayCreator<DataT_, FlattenVecArg, ArgTN...>;
+
 #define __SYCL_ALLOW_VECTOR_SIZES(num_elements)                                \
   template <int Counter, int MaxValue, typename DataT_, class... tail>         \
   struct SizeChecker<Counter, MaxValue, vec<DataT_, num_elements>, tail...>    \
@@ -672,6 +724,14 @@ template <typename Type, int NumElements> class vec {
   using EnableIfSuitableNumElements = typename detail::enable_if_t<
       SizeChecker<0, NumElements, argTN...>::value>;
 
+  template <size_t... Is>
+  constexpr vec(const std::array<vec_data_t<DataT>, NumElements> &Arr,
+                std::index_sequence<Is...>)
+      : m_Data{Arr[Is]...} {}
+
+  constexpr vec(const std::array<vec_data_t<DataT>, NumElements> &Arr)
+      : vec{Arr, std::make_index_sequence<NumElements>()} {}
+
 public:
   using element_type = DataT;
   using rel_t = detail::rel_t<DataT>;
@@ -720,9 +780,8 @@ public:
       T>;
 
   template <typename Ty = DataT>
-  explicit constexpr vec(const EnableIfNotHostHalf<Ty> &arg) {
-    m_Data = (DataType)vec_data<Ty>::get(arg);
-  }
+  explicit constexpr vec(const EnableIfNotHostHalf<Ty> &arg)
+      : m_Data{(DataType)vec_data<Ty>::get(arg)} {}
 
   template <typename Ty = DataT>
   typename detail::enable_if_t<
@@ -735,11 +794,9 @@ public:
   }
 
   template <typename Ty = DataT>
-  explicit constexpr vec(const EnableIfHostHalf<Ty> &arg) {
-    for (int i = 0; i < NumElements; ++i) {
-      setValue(i, arg);
-    }
-  }
+  explicit constexpr vec(const EnableIfHostHalf<Ty> &arg)
+      : vec{detail::RepeatValue<NumElements>(
+            static_cast<vec_data_t<DataT>>(arg))} {}
 
   template <typename Ty = DataT>
   typename detail::enable_if_t<
@@ -753,11 +810,9 @@ public:
     return *this;
   }
 #else
-  explicit constexpr vec(const DataT &arg) {
-    for (int i = 0; i < NumElements; ++i) {
-      setValue(i, arg);
-    }
-  }
+  explicit constexpr vec(const DataT &arg)
+      : vec{detail::RepeatValue<NumElements>(
+            static_cast<vec_data_t<DataT>>(arg))} {}
 
   template <typename Ty = DataT>
   typename detail::enable_if_t<
@@ -827,9 +882,8 @@ public:
   // base types are match and that the NumElements == sum of lengths of args.
   template <typename... argTN, typename = EnableIfSuitableTypes<argTN...>,
             typename = EnableIfSuitableNumElements<argTN...>>
-  constexpr vec(const argTN &...args) {
-    vaargCtorHelper(0, args...);
-  }
+  constexpr vec(const argTN &...args)
+      : vec{VecArgArrayCreator<vec_data_t<DataT>, argTN...>::Create(args...)} {}
 
   // TODO: Remove, for debug purposes only.
   void dump() {
@@ -1268,7 +1322,7 @@ private:
 
   template <int Num = NumElements, typename Ty = int,
             typename = typename detail::enable_if_t<1 != Num>>
-  DataT getValue(EnableIfNotHostHalf<Ty> Index, int) const {
+  constexpr DataT getValue(EnableIfNotHostHalf<Ty> Index, int) const {
     return vec_data<DataT>::get(m_Data[Index]);
   }
 
@@ -1280,7 +1334,7 @@ private:
 
   template <int Num = NumElements, typename Ty = int,
             typename = typename detail::enable_if_t<1 != Num>>
-  DataT getValue(EnableIfHostHalf<Ty> Index, int) const {
+  constexpr DataT getValue(EnableIfHostHalf<Ty> Index, int) const {
     return vec_data<DataT>::get(m_Data.s[Index]);
   }
 #else  // __SYCL_USE_EXT_VECTOR_TYPE__
@@ -1292,7 +1346,7 @@ private:
 
   template <int Num = NumElements,
             typename = typename detail::enable_if_t<1 != Num>>
-  DataT getValue(int Index, int) const {
+  constexpr DataT getValue(int Index, int) const {
     return vec_data<DataT>::get(m_Data.s[Index]);
   }
 #endif // __SYCL_USE_EXT_VECTOR_TYPE__
@@ -1319,59 +1373,6 @@ private:
 
   DataT getValue(int Index) const {
     return (NumElements == 1) ? getValue(Index, 0) : getValue(Index, 0.f);
-  }
-
-  // Helpers for variadic template constructor of vec.
-  template <typename T, typename... argTN>
-  constexpr int vaargCtorHelper(int Idx, const T &arg) {
-    setValue(Idx, arg);
-    return Idx + 1;
-  }
-
-  template <typename DataT_, int NumElements_>
-  constexpr int vaargCtorHelper(int Idx, const vec<DataT_, NumElements_> &arg) {
-    for (size_t I = 0; I < NumElements_; ++I) {
-      setValue(Idx + I, arg.getValue(I));
-    }
-    return Idx + NumElements_;
-  }
-
-  template <typename DataT_, int NumElements_, typename T2, typename T3,
-            template <typename> class T4, int... T5>
-  constexpr int
-  vaargCtorHelper(int Idx, const detail::SwizzleOp<vec<DataT_, NumElements_>,
-                                                   T2, T3, T4, T5...> &arg) {
-    size_t NumElems = sizeof...(T5);
-    for (size_t I = 0; I < NumElems; ++I) {
-      setValue(Idx + I, arg.getValue(I));
-    }
-    return Idx + NumElems;
-  }
-
-  template <typename DataT_, int NumElements_, typename T2, typename T3,
-            template <typename> class T4, int... T5>
-  constexpr int
-  vaargCtorHelper(int Idx,
-                  const detail::SwizzleOp<const vec<DataT_, NumElements_>, T2,
-                                          T3, T4, T5...> &arg) {
-    size_t NumElems = sizeof...(T5);
-    for (size_t I = 0; I < NumElems; ++I) {
-      setValue(Idx + I, arg.getValue(I));
-    }
-    return Idx + NumElems;
-  }
-
-  template <typename T1, typename... argTN>
-  constexpr void vaargCtorHelper(int Idx, const T1 &arg, const argTN &...args) {
-    int NewIdx = vaargCtorHelper(Idx, arg);
-    vaargCtorHelper(NewIdx, args...);
-  }
-
-  template <typename DataT_, int NumElements_, typename... argTN>
-  constexpr void vaargCtorHelper(int Idx, const vec<DataT_, NumElements_> &arg,
-                                 const argTN &...args) {
-    int NewIdx = vaargCtorHelper(Idx, arg);
-    vaargCtorHelper(NewIdx, args...);
   }
 
   // fields

--- a/sycl/test/basic_tests/vectors/constexpr-constructor.cpp
+++ b/sycl/test/basic_tests/vectors/constexpr-constructor.cpp
@@ -1,0 +1,65 @@
+// RUN: %clangxx -fsycl -fsyntax-only -Wno-deprecated-declarations %s
+// RUN: %clangxx -fsycl -D__NO_EXT_VECTOR_TYPE_ON_HOST__ -fsyntax-only -Wno-deprecated-declarations %s
+
+#include <sycl/sycl.hpp>
+
+#include <cstdint>
+
+#define DEFINE_CONSTEXPR_VECTOR(name, type, size)                              \
+  constexpr sycl::vec<type, size> name##_##size{0};
+
+#define DEFINE_CONSTEXPR_VECTOR_INIT_NON_ZERO(name, type, size, init)          \
+  constexpr sycl::vec<type, size> name##_##size{init};
+
+#define DEFINE_CONSTEXPR_VECTOR_FOR_TYPE(type)                                 \
+  DEFINE_CONSTEXPR_VECTOR(type, type, 1)                                       \
+  DEFINE_CONSTEXPR_VECTOR(type, type, 2)                                       \
+  DEFINE_CONSTEXPR_VECTOR(type, type, 3)                                       \
+  DEFINE_CONSTEXPR_VECTOR(type, type, 4)                                       \
+  DEFINE_CONSTEXPR_VECTOR(type, type, 8)                                       \
+  DEFINE_CONSTEXPR_VECTOR(type, type, 16)
+
+#define DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(type, name)                     \
+  DEFINE_CONSTEXPR_VECTOR(name, type, 1)                                       \
+  DEFINE_CONSTEXPR_VECTOR(name, type, 2)                                       \
+  DEFINE_CONSTEXPR_VECTOR(name, type, 3)                                       \
+  DEFINE_CONSTEXPR_VECTOR(name, type, 4)                                       \
+  DEFINE_CONSTEXPR_VECTOR(name, type, 8)                                       \
+  DEFINE_CONSTEXPR_VECTOR(name, type, 16)
+
+int main() {
+
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(sycl::byte, syclbyte)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(sycl::half, half)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE(bool)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE(char)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(signed char, schar)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(unsigned char, uchar)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(short int, short)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(unsigned short int, ushort)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE(int)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(unsigned int, uint)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(long int, long)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(unsigned long int, ulong)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(long long int, longlong)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(unsigned long long int, ulonglong)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE(float)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE(double)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(std::int8_t, int8)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(std::uint8_t, uint8)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(std::int16_t, int16)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(std::uint16_t, uint16)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(std::int32_t, int32)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(std::uint32_t, uint32)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(std::int64_t, int64)
+  DEFINE_CONSTEXPR_VECTOR_FOR_TYPE_NAMED(std::uint64_t, uint64)
+
+  DEFINE_CONSTEXPR_VECTOR_INIT_NON_ZERO(stdbyte, std::byte, 1, std::byte{1});
+  DEFINE_CONSTEXPR_VECTOR_INIT_NON_ZERO(stdbyte, std::byte, 2, std::byte{1});
+  DEFINE_CONSTEXPR_VECTOR_INIT_NON_ZERO(stdbyte, std::byte, 3, std::byte{1});
+  DEFINE_CONSTEXPR_VECTOR_INIT_NON_ZERO(stdbyte, std::byte, 4, std::byte{1});
+  DEFINE_CONSTEXPR_VECTOR_INIT_NON_ZERO(stdbyte, std::byte, 8, std::byte{1});
+  DEFINE_CONSTEXPR_VECTOR_INIT_NON_ZERO(stdbyte, std::byte, 16, std::byte{1});
+
+  return 0;
+}


### PR DESCRIPTION
Vec currently requires that the underlying type has a constexpr default constructor. However, half does not have any guarantees that such a constructor exists. This commit removes this requirement by initializing the underlying data.