### PR TITLE
[SYCL-MLIR] Attach spirv.entry_point_abi to SPIR(-V) kernels

### DIFF
--- a/polygeist/tools/cgeist/CMakeLists.txt
+++ b/polygeist/tools/cgeist/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(cgeist PRIVATE
   MLIRSupport
   MLIRIR
   MLIRAnalysis
+  MLIRSPIRVDialect
   MLIRSYCLDialect
   MLIROpenMPDialect
   MLIRGPUOps

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
@@ -7,7 +7,7 @@
 //
 // CHECK-MLIR-DAG:  gpu.func @_ZTS8kernel_1
 // CHECK-MLIR-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>,
-// CHECK-MLIR-SAME: [[PASSTHROUGH:passthrough = \["convergent", "mustprogress", "noinline", "norecurse", "nounwind", "optnone", \["frame-pointer", "all"\], \["no-trapping-math", "true"\], \["stack-protector-buffer-size", "8"\], \["sycl-module-id", ".*/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp"\], \["uniform-work-group-size", "true"\]\]]]} {
+// CHECK-MLIR-SAME: [[PASSTHROUGH:passthrough = \["convergent", "mustprogress", "noinline", "norecurse", "nounwind", "optnone", \["frame-pointer", "all"\], \["no-trapping-math", "true"\], \["stack-protector-buffer-size", "8"\], \["sycl-module-id", ".*/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp"\], \["uniform-work-group-size", "true"\]\], spirv.entry_point_abi = #spirv.entry_point_abi<>]]} {
 // CHECK-MLIR-DAG:  gpu.func @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2
 // CHECK-MLIR-SAME: kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>, [[PASSTHROUGH]]} {
 // CHECK-MLIR-DAG:  func.func @_ZN12StoreWrapperIiLi1ELN4sycl3_V16access4modeE1026EEC1ENS1_8accessorIiLi1ELS3_1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS1_3ext6oneapi22accessor_property_listIJEEEEENS1_2idILi1EEERKi

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -35,6 +35,7 @@
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/Passes.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
 #include "mlir/Dialect/SYCL/IR/SYCLOpsDialect.h"
 #include "mlir/Dialect/SYCL/Transforms/Passes.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
@@ -230,6 +231,7 @@ static void loadDialects(MLIRContext &Ctx, const bool SYCLIsDevice) {
 
   if (SYCLIsDevice) {
     Ctx.getOrLoadDialect<mlir::sycl::SYCLDialect>();
+    Ctx.getOrLoadDialect<mlir::spirv::SPIRVDialect>();
     // TODO: Use memref.memory_space_cast by default.
     if (GenerateSYCLAddrSpaceCast.getNumOccurrences() == 0)
       GenerateSYCLAddrSpaceCast = true;


### PR DESCRIPTION
This attribute marks functions as SPIR-V dialect kernels. This attribute also accepts two optional arguments specifying work-group and sub-group sizes. We are not providing these yet due to lack of info.