### PR TITLE
[SYCL-MLIR]: Relaxed aliasing support

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/AliasAnalysis.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/AliasAnalysis.h
@@ -21,6 +21,10 @@ namespace sycl {
 
 /// Specialized alias analysis for SYCL dialect operations.
 class AliasAnalysis : public LocalAliasAnalysis {
+public:
+  AliasAnalysis(bool relaxedAliasing)
+      : LocalAliasAnalysis(), relaxedAliasing(relaxedAliasing) {}
+
 protected:
   AliasResult aliasImpl(Value lhs, Value rhs) override;
 
@@ -38,6 +42,10 @@ private:
   /// 'accessor.subscript' operations. It returns 'NoAlias' if it can prove that
   /// values do not alias and 'MayAlias' otherwise.
   AliasResult handleAccessorSubscriptAlias(Value lhs, Value rhs);
+
+  /// Whether to assume the program abides to strict aliasing rules (i.e type
+  /// based aliasing) or not.
+  const bool relaxedAliasing = false;
 };
 
 } // namespace sycl

--- a/mlir-sycl/lib/Dialect/Analysis/AliasAnalysis.cpp
+++ b/mlir-sycl/lib/Dialect/Analysis/AliasAnalysis.cpp
@@ -15,9 +15,6 @@
 
 using namespace mlir;
 
-// TODO: PAss -fstrict-aliasing down from clang through cgeist.
-constexpr bool StrictAliasing = true;
-
 //===----------------------------------------------------------------------===//
 // Helper Functions
 //===----------------------------------------------------------------------===//
@@ -111,7 +108,7 @@ AliasResult sycl::AliasAnalysis::handleAccessorSubscriptAlias(Value lhs,
   //   - %2 is the result of an accessor.subscript operation, and
   //   - %alloca type (memref<1x!sycl_id_1>) is a MemRef of a SYCL type
 
-  if (StrictAliasing) {
+  if (!relaxedAliasing) {
     Type lhsTy = lhs.getType(), rhsTy = rhs.getType();
     if ((lhsSubOp && typesDoNotAlias(lhsTy, rhsTy)) ||
         (rhsSubOp && typesDoNotAlias(rhsTy, lhsTy)))

--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.h
@@ -31,9 +31,9 @@ void populateBareMemRefToLLVMConversionPatterns(LLVMTypeConverter &converter,
 #define GEN_PASS_DECL
 #include "mlir/Dialect/Polygeist/Transforms/Passes.h.inc"
 
-std::unique_ptr<Pass> createParallelLICMPass();
 std::unique_ptr<Pass> createMem2RegPass();
 std::unique_ptr<Pass> createLICMPass();
+std::unique_ptr<Pass> createLICMPass(const LICMOptions &options);
 std::unique_ptr<Pass> createLoopRestructurePass();
 std::unique_ptr<Pass> createInnerSerializationPass();
 std::unique_ptr<Pass> replaceAffineCFGPass();

--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
@@ -77,7 +77,11 @@ def SCFCanonicalizeFor : Pass<"canonicalize-scf-for"> {
 def LICM : Pass<"licm"> {
   let summary = "Perform LICM on known parallel (and serial) loops";
   let constructor = "mlir::polygeist::createLICMPass()";
-
+  let options = [
+    Option<"relaxedAliasing", "relaxed-aliasing", "bool", 
+           /*default=*/"false", 
+           "Whether to use strict aliasing (i.e. type-based aliasing) rules or not">
+  ];
   let statistics = [
     Statistic<"numOpHoisted", "num-operations-hoisted", "Number of operations hoisted">
   ];

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
@@ -43,11 +43,6 @@ struct LICM : public mlir::polygeist::impl::LICMBase<LICM> {
   using LICMBase<LICM>::LICMBase;
 
   void runOnOperation() override;
-
-private:
-  /// Whether to assume the program abides to strict aliasing rules (i.e type
-  /// based aliasing) or not.
-  const bool relaxedAliasing = false;
 };
 
 /// Represents the side effects associated with an operation.

--- a/polygeist/test/polygeist-opt/licm.mlir
+++ b/polygeist/test/polygeist-opt/licm.mlir
@@ -1,4 +1,4 @@
-// RUN: polygeist-opt --licm --split-input-file %s 2>&1 | FileCheck %s
+// RUN: polygeist-opt --licm="relaxed-aliasing=false" --split-input-file %s 2>&1 | FileCheck %s
 
 // COM: Test LICM on scf.for loops.
 module {

--- a/polygeist/test/polygeist-opt/licm.mlir
+++ b/polygeist/test/polygeist-opt/licm.mlir
@@ -1,4 +1,5 @@
 // RUN: polygeist-opt --licm="relaxed-aliasing=false" --split-input-file %s 2>&1 | FileCheck %s
+// RUN: polygeist-opt --licm="relaxed-aliasing=true" --split-input-file %s 2>&1 | FileCheck --check-prefix=CHECK-RELAXED-ALIASING %s
 
 // COM: Test LICM on scf.for loops.
 module {
@@ -308,6 +309,19 @@ func.func @affine_for_hoist5(%arg0: memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
   // CHECK-NEXT:         affine.store %6, %4[0] : memref<?xf32, 4>
   // CHECK-NEXT:       }
   // CHECK-NEXT:     }    
+
+  // CHECK-RELAXED-ALIASING:         func.func @affine_for_hoist5(%arg0: memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
+  // CHECK-RELAXED-ALIASING-DAG:      %alloca = memref.alloca() : memref<1x!sycl_id_1_>
+  // CHECK-RELAXED-ALIASING-DAG:      %alloca_0 = memref.alloca() : memref<1x!sycl_id_1_>  
+  // CHECK-RELAXED-ALIASING:          sycl.constructor @id(%2, %c64_i64) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
+  // CHECK-RELAXED-ALIASING-NEXT:     affine.for %arg1 = 0 to 10 {
+  // CHECK-RELAXED-ALIASING-NEXT:      %3 = affine.load %alloca[0] : memref<1x!sycl_id_1_>
+  // CHECK-RELAXED-ALIASING-NEXT:    affine.store %3, %alloca_0[0] : memref<1x!sycl_id_1_>
+  // CHECK-RELAXED-ALIASING-NEXT:      %4 = sycl.accessor.subscript %arg0[%alloca_0] {ArgumentTypes = [memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<1x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIfLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERfNS0_2idILi1EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<1x!sycl_id_1_>) -> memref<?xf32, 4>
+  // CHECK-RELAXED-ALIASING-NEXT:      %5 = affine.load %4[0] : memref<?xf32, 4>
+  // CHECK-RELAXED-ALIASING-NEXT:      %6 = arith.addf %5, %cst : f32
+  // CHECK-RELAXED-ALIASING-NEXT:      affine.store %6, %4[0] : memref<?xf32, 4>
+  // CHECK-RELAXED-ALIASING-NEXT:    }
 
   %alloca = memref.alloca() : memref<1x!sycl_id_1>  
   %alloca_0 = memref.alloca() : memref<1x!sycl_id_1>


### PR DESCRIPTION
This PR adds support for the FE option -relaxed-aliasing to cgeist. The option is used to instruct SYCL-MLIR aliasing analysis whether the input program respect the strict aliasing rules (i.e. type-based aliasing rules).

Options processing in the cgeist driver is streamlined to allow passing options to various parts of the optimization pipeline.