### PR TITLE
[SYCL][CMake] Disable win_proxy_loader build and link on non-Windows

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -314,10 +314,13 @@ add_custom_target( sycl-toolchain
   DEPENDS sycl-runtime-libraries
           sycl-compiler
           sycl-ls
-	  win_proxy_loader
           ${XPTIFW_LIBS}
   COMMENT "Building SYCL compiler toolchain..."
 )
+
+if (WIN32)
+  add_dependencies(sycl-toolchain win_proxy_loader)
+endif()
 
 # Enable new IN_LIST operator.
 cmake_policy(SET CMP0057 NEW)
@@ -351,7 +354,9 @@ add_subdirectory( plugins )
 
 add_subdirectory(tools)
 
-add_subdirectory(win_proxy_loader)
+if (WIN32)
+  add_subdirectory(win_proxy_loader)
+endif()
 
 if(SYCL_INCLUDE_TESTS)
   if(NOT LLVM_INCLUDE_TESTS)
@@ -395,10 +400,13 @@ set( SYCL_TOOLCHAIN_DEPLOY_COMPONENTS
      sycl
      libsycldevice
      level-zero-sycl-dev
-     win_proxy_loader
      ${XPTIFW_LIBS}
      ${SYCL_TOOLCHAIN_DEPS}
 )
+
+if (WIN32)
+  list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS win_proxy_loader)
+endif()
 
 if (TARGET sycl-prof)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS sycl-prof)

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -71,11 +71,13 @@ function(add_sycl_rt_library LIB_NAME LIB_OBJ_NAME)
   endif()
 
   # win_proxy_loader
-  include_directories(${LLVM_EXTERNAL_SYCL_SOURCE_DIR}/win_proxy_loader)
-  if(WIN_DUPE)
-    target_link_libraries(${LIB_NAME} PUBLIC win_proxy_loaderd)
-  else()
-    target_link_libraries(${LIB_NAME} PUBLIC win_proxy_loader)
+  if (WIN32)
+    include_directories(${LLVM_EXTERNAL_SYCL_SOURCE_DIR}/win_proxy_loader)
+    if(WIN_DUPE)
+      target_link_libraries(${LIB_NAME} PUBLIC win_proxy_loaderd)
+    else()
+      target_link_libraries(${LIB_NAME} PUBLIC win_proxy_loader)
+    endif()
   endif()
 
   target_compile_definitions(${LIB_OBJ_NAME} PRIVATE __SYCL_INTERNAL_API )

--- a/sycl/win_proxy_loader/CMakeLists.txt
+++ b/sycl/win_proxy_loader/CMakeLists.txt
@@ -1,10 +1,8 @@
 project(win_proxy_loader)
 add_library(win_proxy_loader SHARED  win_proxy_loader.cpp)
-if (WIN32)
-  install(TARGETS win_proxy_loader
-          RUNTIME DESTINATION "bin" COMPONENT win_proxy_loader
-  )
-endif()
+install(TARGETS win_proxy_loader
+        RUNTIME DESTINATION "bin" COMPONENT win_proxy_loader
+)
 
 if (MSVC)
   # MSVC provides two incompatible build variants for its CRT: release and debug
@@ -48,10 +46,8 @@ if (MSVC)
   target_compile_options(win_proxy_loader PRIVATE ${WINUNLOAD_CXX_FLAGS_RELEASE})
   target_link_libraries(win_proxy_loaderd PRIVATE shlwapi)
   target_link_libraries(win_proxy_loader PRIVATE shlwapi)
-  if (WIN32)
-     install(TARGETS win_proxy_loaderd
-             RUNTIME DESTINATION "bin" COMPONENT win_proxy_loader)
-  endif()
+  install(TARGETS win_proxy_loaderd
+          RUNTIME DESTINATION "bin" COMPONENT win_proxy_loader)
 endif()
 
 


### PR DESCRIPTION
Currently the win_proxy_loader is built and linked to the SYCL runtime on all platforms, but only carries meaning on Windows. Currently this causes issues as the corresponding library is not installed on non-Windows targets. Instead of installing it on non-Windows targets, this commit makes it only build and link to the SYCL runtime library when building on Windows.