### PR TITLE
[SYCL] Remove intel_gpu_ehl target

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -710,7 +710,6 @@ SmallString<64> SYCL::gen::getGenDeviceMacro(StringRef DeviceName) {
                       .Case("aml", "INTEL_GPU_AML")
                       .Case("cml", "INTEL_GPU_CML")
                       .Case("icllp", "INTEL_GPU_ICLLP")
-                      .Case("ehl", "INTEL_GPU_EHL")
                       .Case("tgllp", "INTEL_GPU_TGLLP")
                       .Case("rkl", "INTEL_GPU_RKL")
                       .Case("adl_s", "INTEL_GPU_ADL_S")

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -646,7 +646,6 @@ StringRef SYCL::gen::resolveGenDevice(StringRef DeviceName) {
                .Cases("intel_gpu_aml", "intel_gpu_9_6_0", "aml")
                .Cases("intel_gpu_cml", "intel_gpu_9_7_0", "cml")
                .Cases("intel_gpu_icllp", "intel_gpu_11_0_0", "icllp")
-               .Cases("intel_gpu_ehl", "intel_gpu_11_2_0", "ehl")
                .Cases("intel_gpu_tgllp", "intel_gpu_12_0_0", "tgllp")
                .Case("intel_gpu_rkl", "rkl")
                .Case("intel_gpu_adl_s", "adl_s")

--- a/clang/test/Driver/sycl-oneapi-gpu.cpp
+++ b/clang/test/Driver/sycl-oneapi-gpu.cpp
@@ -42,10 +42,6 @@
 // RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_11_0_0 -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=icllp \
 // RUN:             -DMAC_STR=ICLLP
-// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_ehl -### %s 2>&1 | \
-// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=ehl -DMAC_STR=EHL
-// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_11_2_0 -### %s 2>&1 | \
-// RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=ehl -DMAC_STR=EHL
 // RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_tgllp -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefixes=DEVICE,MACRO -DDEV_STR=tgllp \
 // RUN:             -DMAC_STR=TGLLP

--- a/sycl/doc/UsersManual.md
+++ b/sycl/doc/UsersManual.md
@@ -46,7 +46,6 @@ and not recommended to use in production environment.
     * intel_gpu_adl_s - Alder Lake S Intel graphics architecture
     * intel_gpu_rkl - Rocket Lake Intel graphics architecture
     * intel_gpu_tgllp, intel_gpu_12_0_0 - Tiger Lake Intel graphics architecture
-    * intel_gpu_ehl, intel_gpu_11_2_0 - Elkhart Lake Intel graphics architecture
     * intel_gpu_icllp, intel_gpu_11_0_0 - Ice Lake Intel graphics architecture
     * intel_gpu_cml, intel_gpu_9_7_0 - Comet Lake Intel graphics architecture
     * intel_gpu_aml, intel_gpu_9_6_0 - Amber Lake Intel graphics architecture

--- a/sycl/doc/design/DeviceIf.md
+++ b/sycl/doc/design/DeviceIf.md
@@ -48,7 +48,6 @@ recognizes:
 * `intel_gpu_aml`
 * `intel_gpu_cml`
 * `intel_gpu_icllp`
-* `intel_gpu_ehl`
 * `intel_gpu_tgllp`
 * `intel_gpu_rkl`
 * `intel_gpu_adl_s`
@@ -70,7 +69,6 @@ recognizes:
 * `intel_gpu_9_6_0` (alias for `intel_gpu_aml`)
 * `intel_gpu_9_7_0` (alias for `intel_gpu_cml`)
 * `intel_gpu_11_0_0` (alias for `intel_gpu_icllp`)
-* `intel_gpu_11_2_0` (alias for `intel_gpu_ehl`)
 * `intel_gpu_12_0_0` (alias for `intel_gpu_tgllp`)
 * `intel_gpu_12_10_0` (alias for `intel_gpu_dg1`)
 * `nvidia_gpu_sm_50`

--- a/sycl/doc/design/DeviceIf.md
+++ b/sycl/doc/design/DeviceIf.md
@@ -142,7 +142,6 @@ one of the following corresponding C++ macro names:
 * `__SYCL_TARGET_INTEL_GPU_AML__`
 * `__SYCL_TARGET_INTEL_GPU_CML__`
 * `__SYCL_TARGET_INTEL_GPU_ICLLP__`
-* `__SYCL_TARGET_INTEL_GPU_EHL__`
 * `__SYCL_TARGET_INTEL_GPU_TGLLP__`
 * `__SYCL_TARGET_INTEL_GPU_RKL__`
 * `__SYCL_TARGET_INTEL_GPU_ADL_S__`

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_architecture.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_architecture.asciidoc
@@ -109,7 +109,6 @@ enum class architecture : /* unspecified */ {
   intel_gpu_aml,
   intel_gpu_cml,
   intel_gpu_icllp,
-  intel_gpu_ehl,
   intel_gpu_tgllp,
   intel_gpu_rkl,
   intel_gpu_adl_s,
@@ -170,7 +169,6 @@ enum class architecture : /* unspecified */ {
   intel_gpu_9_6_0 = intel_gpu_aml,
   intel_gpu_9_7_0 = intel_gpu_cml,
   intel_gpu_11_0_0 = intel_gpu_icllp,
-  intel_gpu_11_2_0 = intel_gpu_ehl,
   intel_gpu_12_0_0 = intel_gpu_tgllp,
   intel_gpu_12_10_0 = intel_gpu_dg1 
 };
@@ -230,10 +228,6 @@ of these enumerators, and it provides a brief description of their meanings.
 |`intel_gpu_icllp`
 |-
 |Ice Lake Intel graphics architecture.
-
-|`intel_gpu_ehl`
-|-
-|Elkhart Lake Intel graphics architecture.
 
 |`intel_gpu_tgllp`
 |-
@@ -318,10 +312,6 @@ of these enumerators, and it provides a brief description of their meanings.
 |`intel_gpu_11_0_0`
 |-
 |Alias for `intel_gpu_icllp`.
-
-|`intel_gpu_11_2_0`
-|-
-|Alias for `intel_gpu_ehl`.
 
 |`intel_gpu_12_0_0`
 |-

--- a/sycl/include/sycl/ext/oneapi/experimental/device_architecture.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/device_architecture.hpp
@@ -122,9 +122,6 @@ static constexpr ext::oneapi::experimental::architecture max_architecture =
 #ifndef __SYCL_TARGET_INTEL_GPU_ICLLP__
 #define __SYCL_TARGET_INTEL_GPU_ICLLP__ 0
 #endif
-#ifndef __SYCL_TARGET_INTEL_GPU_EHL__
-#define __SYCL_TARGET_INTEL_GPU_EHL__ 0
-#endif
 #ifndef __SYCL_TARGET_INTEL_GPU_TGLLP__
 #define __SYCL_TARGET_INTEL_GPU_TGLLP__ 0
 #endif
@@ -284,7 +281,6 @@ static constexpr bool is_allowable_aot_mode =
     (__SYCL_TARGET_INTEL_GPU_AML__ == 1) ||
     (__SYCL_TARGET_INTEL_GPU_CML__ == 1) ||
     (__SYCL_TARGET_INTEL_GPU_ICLLP__ == 1) ||
-    (__SYCL_TARGET_INTEL_GPU_EHL__ == 1) ||
     (__SYCL_TARGET_INTEL_GPU_TGLLP__ == 1) ||
     (__SYCL_TARGET_INTEL_GPU_RKL__ == 1) ||
     (__SYCL_TARGET_INTEL_GPU_ADL_S__ == 1) ||

--- a/sycl/include/sycl/ext/oneapi/experimental/device_architecture.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/device_architecture.hpp
@@ -18,7 +18,6 @@ enum class architecture {
   intel_gpu_aml,
   intel_gpu_cml,
   intel_gpu_icllp,
-  intel_gpu_ehl,
   intel_gpu_tgllp,
   intel_gpu_rkl,
   intel_gpu_adl_s,
@@ -79,7 +78,6 @@ enum class architecture {
   intel_gpu_9_6_0 = intel_gpu_aml,
   intel_gpu_9_7_0 = intel_gpu_cml,
   intel_gpu_11_0_0 = intel_gpu_icllp,
-  intel_gpu_11_2_0 = intel_gpu_ehl,
   intel_gpu_12_0_0 = intel_gpu_tgllp,
   intel_gpu_12_10_0 = intel_gpu_dg1,
 };
@@ -364,8 +362,6 @@ struct IsAOTForArchitectureClass {
         __SYCL_TARGET_INTEL_GPU_CML__ == 1;
     arr[static_cast<int>(arch::intel_gpu_icllp)] =
         __SYCL_TARGET_INTEL_GPU_ICLLP__ == 1;
-    arr[static_cast<int>(arch::intel_gpu_ehl)] =
-        __SYCL_TARGET_INTEL_GPU_EHL__ == 1;
     arr[static_cast<int>(arch::intel_gpu_tgllp)] =
         __SYCL_TARGET_INTEL_GPU_TGLLP__ == 1;
     arr[static_cast<int>(arch::intel_gpu_rkl)] =


### PR DESCRIPTION
This commit removes the Elkhart Lake (intel_gpu_ehl) target from the valid SYCL targets.