### PR TITLE
[SYCL][ESIMD] Support bool conversion to simd_mask in invoke_simd

### DIFF
--- a/sycl/include/std/experimental/simd.hpp
+++ b/sycl/include/std/experimental/simd.hpp
@@ -1682,12 +1682,14 @@ public:
 
   // implicit type conversion constructor
 #ifdef ENABLE_SYCL_EXT_ONEAPI_INVOKE_SIMD
-  // TODO inefficient, use this's and __v's storage directly
+  template <class _Up>
+  simd_mask(const simd_mask<_Up, simd_abi::fixed_size<size()>>& __v) noexcept {
+    copyElements(__v);
+  }
+
   template <class _Up>
   simd_mask(const simd_mask<_Up, abi_type>& __v) noexcept {
-    for (size_t __i = 0; __i < size(); __i++) {
-      (*this)[__i] = static_cast<element_type>(__v[__i]);
-    }
+    copyElements(__v);
   }
 #else
   template <class _Up>
@@ -1735,6 +1737,14 @@ public:
 #ifdef ENABLE_SYCL_EXT_ONEAPI_INVOKE_SIMD
 private:
   __simd_storage<element_type, _Abi> __s_;
+
+  // TODO inefficient, use this's and __v's storage directly
+  template <class _Up, class _UAbi>
+  inline void copyElements(const simd_mask<_Up, _UAbi> & __v) noexcept {
+    for (size_t __i = 0; __i < size(); __i++) {
+      (*this)[__i] = static_cast<element_type>(__v[__i]);
+    }
+  }
 #endif // ENABLE_SYCL_EXT_ONEAPI_INVOKE_SIMD
 };
 

--- a/sycl/include/std/experimental/simd.hpp
+++ b/sycl/include/std/experimental/simd.hpp
@@ -1652,7 +1652,7 @@ class simd_mask {
 public:
   using value_type = bool;
 #ifdef ENABLE_SYCL_EXT_ONEAPI_INVOKE_SIMD
-  using reference = __simd_mask_reference<_Tp, _Abi>;
+  using reference = __simd_mask_reference<element_type, _Abi>;
 #else
   // TODO: this is strawman implementation. Turn it into a proxy type.
   using reference = bool&;
@@ -1684,7 +1684,7 @@ public:
 #ifdef ENABLE_SYCL_EXT_ONEAPI_INVOKE_SIMD
   // TODO inefficient, use this's and __v's storage directly
   template <class _Up>
-  simd_mask(const simd_mask<_Up, simd_abi::fixed_size<size()>>& __v) noexcept {
+  simd_mask(const simd_mask<_Up, abi_type>& __v) noexcept {
     for (size_t __i = 0; __i < size(); __i++) {
       (*this)[__i] = static_cast<element_type>(__v[__i]);
     }

--- a/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
@@ -24,9 +24,8 @@
 #include <functional>
 
 // TODOs:
-// * (a) TODO bool translation in spmd2simd.
-// * (b) TODO enforce constness of a functor/lambda's () operator
-// * (c) TODO support lambdas and functors in BE
+// * (a) TODO enforce constness of a functor/lambda's () operator
+// * (b) TODO support lambdas and functors in BE
 
 /// Middle End - to - Back End interface to invoke explicit SIMD functions from
 /// SPMD SYCL context. Must not be used by user code. BEs are expected to

--- a/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
@@ -116,6 +116,14 @@ struct spmd2simd<T, N, std::enable_if_t<std::is_arithmetic_v<T>>> {
   using type = simd<T, N>;
 };
 
+// * bool converts to `simd_mask` with a user specified element type.
+// Arbitrarily use unsigned char for the element type for subgroup size
+// deduction and rely on the implicit conversion operator for the the actual
+// user type.
+template <int N> struct spmd2simd<bool, N> {
+  using type = simd_mask<unsigned char, N>;
+};
+
 // This structure performs the SIMD-to-SPMD return type conversion as defined
 // by the spec.
 template <class, class = void> struct simd2spmd;
@@ -135,6 +143,11 @@ template <class... T> struct simd2spmd<std::tuple<T...>> {
 template <class T>
 struct simd2spmd<T, std::enable_if_t<std::is_arithmetic_v<T>>> {
   using type = uniform<T>;
+};
+
+// * `simd_mask` converts to bool
+template <class T, int N> struct simd2spmd<simd_mask<T, N>> {
+  using type = bool;
 };
 
 template <> struct simd2spmd<void> { using type = void; };


### PR DESCRIPTION
As per our recent discussions, bool passed into invoke_simd should convert to simd_mask with a user-defined type. Conversely, simd_mask will convert back to bool from inside the invoked function.

I also had to fix a couple of minor bugs in the implementation of the DPCPP-specific changes in std::experimental::simd.

I will make a follow-up PR to update the invoke_simd spec with the results of our recent discussion.

Test PR: https://github.com/intel/llvm-test-suite/pull/1630