### PR TITLE
[SYCL][Docs] Change ODF design document to run pass twice

### DIFF
--- a/sycl/doc/design/OptionalDeviceFeatures.md
+++ b/sycl/doc/design/OptionalDeviceFeatures.md
@@ -659,10 +659,6 @@ effect and the pass may elect to ignore these aspects. To avoid repeating
 warnings issued by the previous execution of the pass, this run will not issue
 any warning diagnostics.
 
-For users that want the strict requirements from all aspects, the driver offers
-a `--strict-aspect-requirements` option which excludes no aspects in the first
-run of the pass and skips the second run altogether. 
-
 ### Assumptions on other phases of clang
 
 The post-link tool (described below) uses the `!sycl_used_aspects` and

--- a/sycl/doc/design/OptionalDeviceFeatures.md
+++ b/sycl/doc/design/OptionalDeviceFeatures.md
@@ -524,17 +524,19 @@ We add a new IR phase to the device compiler which does the following:
   graph so that each function lists the aspects used by that function and by
   any functions it calls.
 
-* Diagnoses a warning if any function that has `!sycl_declared_aspects` uses
-  an aspect not listed in that declared set.
-
 * Creates an `!sycl_fixed_targets` metadata for each kernel function or
   `SYCL_EXTERNAL` function that is defined.  This is done regardless of whether
   the `-fsycl-fixed-targets` command line switch is specified.  If the switch
   is not specified, the metadata has an empty list of targets.
 
-* If the `-fsycl-fixed-targets` command line switch is specified, diagnoses a
-  warning if any function uses an aspect that is not compatible with all target
-  devices specified by that switch.
+Additionally, the pass will issue warning diagnostics in the following cases:
+
+* If any function that has `!sycl_declared_aspects` uses an aspect not listed in
+  that declared set.
+
+* If the `-fsycl-fixed-targets` command line switch is specified and any
+  function uses an aspect that is not compatible with all target devices
+  specified by that switch.
 
 It is important that this IR phase runs before any other optimization phase
 that might eliminate a reference to a type or inline a function call because
@@ -568,13 +570,13 @@ need only look at the `!sycl_used_aspects` metadata for each function,
 propagating the aspects used by each function up to it callers and augmenting
 the caller's `!sycl_used_aspects` set.
 
-Diagnosing warnings for the third bullet point is then straightforward.  The
+Diagnosing warnings for the fifth bullet point is then straightforward.  The
 implementation looks for functions that have `!sycl_declared_aspects` and
 compares that set with the `!sycl_used_aspects` set (if any).  If a function
 uses an aspect that is not in the declared set, the implementation issues a
 warning.
 
-Diagnosing warnings for the fifth bullet point requires the [device
+Diagnosing warnings for the sixth bullet point requires the [device
 configuration file][7] which gives the set of allowed optional features for
 each target device.  The implementation looks for functions that have either
 `!sycl_declared_aspects` or `!sycl_used_aspects`, and it compares the aspects
@@ -632,6 +634,34 @@ AST.  By contrast, we can diagnose the warning more efficiently in an IR pass
 because traversal of the IR is much more efficient than traversal of the AST.
 The downside, though, is that the warning message is less informative.
 
+#### Aspect requirement strictness control
+
+For some aspects (currently only `fp64`) we want the usage analysis to be less
+strict to avoid user confusion in cases where the aspects are used
+unintentionally and is later optimized out. An example of this is through the
+use of a literal such as `3.14` which is a double-precision floating point value
+in C++, but may be lowered to a single-precision floating point immediately,
+making it difficult to debug.
+
+To allow both strict and relaxed aspect propagation, the aspect propagation pass
+is run twice; once before optimizations and again after optimizations.
+
+The first run of the pass takes a list of aspect names to exclude when saving
+the result of the propagation. It will still propagate the excluded aspects to
+correctly issue strict warning diagnostics for the cases mentioned above, but
+after the pass finishes functions will only have the excluded aspects in their
+`!sycl_used_aspects` metadata if they had them prior to the execution of the
+pass.
+
+In the second run of the pass, all aspects are propagated and saved. For the
+aspects that were not excluded from the first run of the pass this will have no
+effect and the pass may elect to ignore these aspects. To avoid repeating
+warnings issued by the previous execution of the pass, this run will not issue
+any warning diagnostics.
+
+For users that want the strict requirements from all aspects, the driver offers
+a `--strict-aspect-requirements` option which excludes no aspects in the first
+run of the pass and skips the second run altogether. 
 
 ### Assumptions on other phases of clang
 


### PR DESCRIPTION
This commit changes the Optional Device Features design document to describe a change in approach for the aspect propagation pass to be run twice to allow some aspect uses to be optimized out.