### PR TITLE
[SYCL] Throw exception if accessor isn't bound to handler

### DIFF
--- a/sycl/include/sycl/detail/cg_types.hpp
+++ b/sycl/include/sycl/detail/cg_types.hpp
@@ -34,11 +34,6 @@ public:
   void *MPtr;
   int MSize;
   int MIndex;
-
-  constexpr bool operator==(const ArgDesc &rhs) {
-    return MType == rhs.MType && MPtr == rhs.MPtr && MSize == rhs.MSize &&
-           MIndex == rhs.MIndex;
-  }
 };
 
 // The structure represents NDRange - global, local sizes, global offset and

--- a/sycl/include/sycl/detail/cg_types.hpp
+++ b/sycl/include/sycl/detail/cg_types.hpp
@@ -34,6 +34,11 @@ public:
   void *MPtr;
   int MSize;
   int MIndex;
+
+  constexpr bool operator==(const ArgDesc &rhs) {
+    return MType == rhs.MType && MPtr == rhs.MPtr && MSize == rhs.MSize &&
+           MIndex == rhs.MIndex;
+  }
 };
 
 // The structure represents NDRange - global, local sizes, global offset and

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -2901,7 +2901,7 @@ private:
   void checkIfPlaceholderIsBoundToHandler(
       accessor<T, Dims, AccessMode, AccessTarget, IsPlaceholder, PropertyListT>
           Acc) {
-    detail::AccessorBaseHost *AccBase = (detail::AccessorBaseHost *)&Acc;
+    auto *AccBase = reinterpret_cast<detail::AccessorBaseHost *>(&Acc);
     detail::AccessorImplPtr AccImpl = detail::getSyclObjImpl(*AccBase);
     detail::AccessorImplHost *Req = AccImpl.get();
     if (std::find_if(MAssociatedAccesors.begin(), MAssociatedAccesors.end(),

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -2904,10 +2904,13 @@ private:
     detail::AccessorBaseHost *AccBase = (detail::AccessorBaseHost *)&Acc;
     detail::AccessorImplPtr AccImpl = detail::getSyclObjImpl(*AccBase);
     detail::AccessorImplHost *Req = AccImpl.get();
-    detail::ArgDesc AD(detail::kernel_param_kind_t::kind_accessor, Req,
-                       static_cast<int>(AccessTarget), 0);
-    if (std::find(MAssociatedAccesors.begin(), MAssociatedAccesors.end(), AD) ==
-        MAssociatedAccesors.end())
+    if (std::find_if(MAssociatedAccesors.begin(), MAssociatedAccesors.end(),
+                     [&](const detail::ArgDesc &AD) {
+                       return AD.MType ==
+                                  detail::kernel_param_kind_t::kind_accessor &&
+                              AD.MPtr == Req &&
+                              AD.MSize == static_cast<int>(AccessTarget);
+                     }) == MAssociatedAccesors.end())
       throw sycl::exception(make_error_code(errc::kernel_argument),
                             "placeholder accessor must be bound by calling "
                             "handler::require() before it can be used.");

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -2107,7 +2107,7 @@ public:
   void copy(accessor<T_Src, Dims, AccessMode, AccessTarget, IsPlaceholder> Src,
             std::shared_ptr<T_Dst> Dst) {
     if (Src.is_placeholder())
-      checkIfPlaceholderIsBoundedToCG(Src);
+      checkIfPlaceholderIsBoundToHandler(Src);
 
     throwIfActionIsCreated();
     static_assert(isValidTargetForExplicitOp(AccessTarget),
@@ -2135,7 +2135,7 @@ public:
   copy(std::shared_ptr<T_Src> Src,
        accessor<T_Dst, Dims, AccessMode, AccessTarget, IsPlaceholder> Dst) {
     if (Dst.is_placeholder())
-      checkIfPlaceholderIsBoundedToCG(Dst);
+      checkIfPlaceholderIsBoundToHandler(Dst);
 
     throwIfActionIsCreated();
     static_assert(isValidTargetForExplicitOp(AccessTarget),
@@ -2162,7 +2162,7 @@ public:
   void copy(accessor<T_Src, Dims, AccessMode, AccessTarget, IsPlaceholder> Src,
             T_Dst *Dst) {
     if (Src.is_placeholder())
-      checkIfPlaceholderIsBoundedToCG(Src);
+      checkIfPlaceholderIsBoundToHandler(Src);
 
     throwIfActionIsCreated();
     static_assert(isValidTargetForExplicitOp(AccessTarget),
@@ -2204,7 +2204,7 @@ public:
   copy(const T_Src *Src,
        accessor<T_Dst, Dims, AccessMode, AccessTarget, IsPlaceholder> Dst) {
     if (Dst.is_placeholder())
-      checkIfPlaceholderIsBoundedToCG(Dst);
+      checkIfPlaceholderIsBoundToHandler(Dst);
 
     throwIfActionIsCreated();
     static_assert(isValidTargetForExplicitOp(AccessTarget),
@@ -2252,9 +2252,9 @@ public:
                      IsPlaceholder_Dst>
                 Dst) {
     if (Src.is_placeholder())
-      checkIfPlaceholderIsBoundedToCG(Src);
+      checkIfPlaceholderIsBoundToHandler(Src);
     if (Dst.is_placeholder())
-      checkIfPlaceholderIsBoundedToCG(Dst);
+      checkIfPlaceholderIsBoundToHandler(Dst);
 
     throwIfActionIsCreated();
     static_assert(isValidTargetForExplicitOp(AccessTarget_Src),
@@ -2300,7 +2300,7 @@ public:
   void
   update_host(accessor<T, Dims, AccessMode, AccessTarget, IsPlaceholder> Acc) {
     if (Acc.is_placeholder())
-      checkIfPlaceholderIsBoundedToCG(Acc);
+      checkIfPlaceholderIsBoundToHandler(Acc);
 
     throwIfActionIsCreated();
     static_assert(isValidTargetForExplicitOp(AccessTarget),
@@ -2332,7 +2332,7 @@ public:
            Dst,
        const T &Pattern) {
     if (Dst.is_placeholder())
-      checkIfPlaceholderIsBoundedToCG(Dst);
+      checkIfPlaceholderIsBoundToHandler(Dst);
 
     throwIfActionIsCreated();
     // TODO add check:T must be an integral scalar value or a SYCL vector type
@@ -2898,7 +2898,7 @@ private:
             access::target AccessTarget,
             access::placeholder IsPlaceholder = access::placeholder::false_t,
             typename PropertyListT = property_list>
-  void checkIfPlaceholderIsBoundedToCG(
+  void checkIfPlaceholderIsBoundToHandler(
       accessor<T, Dims, AccessMode, AccessTarget, IsPlaceholder, PropertyListT>
           Acc) {
     detail::AccessorBaseHost *AccBase = (detail::AccessorBaseHost *)&Acc;

--- a/sycl/unittests/handler/require.cpp
+++ b/sycl/unittests/handler/require.cpp
@@ -17,3 +17,220 @@ TEST(Require, RequireWithNonPlaceholderAccessor) {
     Q.wait();
   }
 }
+
+TEST(Require, checkIfAccBoundedToHandler) {
+  std::string msg("placeholder accessor must be bound by calling "
+                  "handler::require() before it can be used.");
+  sycl::unittest::PiMock Mock;
+  sycl::queue Q;
+  int data = 0;
+
+  // Check fill() command
+  {
+    try {
+      sycl::buffer<int, 1> buf(&data, 1);
+      sycl::accessor acc(buf);
+      Q.submit([&](sycl::handler &h) { h.fill(acc, 1); });
+      Q.wait();
+    } catch (sycl::exception const &e) {
+      EXPECT_EQ(e.what(), msg);
+    }
+
+    // Should pass without any exception throwed
+    {
+      sycl::buffer<int, 1> buf(&data, 1);
+      sycl::accessor acc(buf);
+      Q.submit([&](sycl::handler &h) {
+        h.require(acc);
+        h.fill(acc, 1);
+      });
+      Q.wait();
+    }
+  }
+
+  // Check update_host() command
+  {
+    int data = 0;
+    try {
+      sycl::buffer<int, 1> buf(&data, 1);
+      sycl::accessor acc(buf);
+      Q.submit([&](sycl::handler &h) { h.update_host(acc); });
+      Q.wait();
+    } catch (sycl::exception const &e) {
+      EXPECT_EQ(e.what(), msg);
+    }
+
+    // Should pass without any exception throwed
+    {
+      sycl::buffer<int, 1> buf(&data, 1);
+      sycl::accessor acc(buf);
+      Q.submit([&](sycl::handler &h) {
+        h.require(acc);
+        h.update_host(acc);
+      });
+      Q.wait();
+    }
+  }
+
+  // Check different copy() variants
+  {
+    // void copy(accessor<SrcT, SrcDims, SrcMode, SrcTgt, IsPlaceholder> src,
+    //           std::shared_ptr<DestT> dest)
+    {
+      std::shared_ptr<int> ptr(new int(0));
+      try {
+        sycl::buffer<int, 1> buf(&data, 1);
+        sycl::accessor acc(buf);
+        Q.submit([&](sycl::handler &h) { h.copy(acc, ptr); });
+        Q.wait();
+      } catch (sycl::exception const &e) {
+        EXPECT_EQ(e.what(), msg);
+      }
+
+      // Should pass without any exception throwed
+      {
+        sycl::buffer<int, 1> buf(&data, 1);
+        sycl::accessor acc(buf);
+        Q.submit([&](sycl::handler &h) {
+          h.require(acc);
+          h.copy(acc, ptr);
+        });
+        Q.wait();
+      }
+    }
+
+    // void copy(std::shared_ptr<SrcT> src,
+    //           accessor<DestT, DestDims, DestMode, DestTgt, IsPlaceholder>
+    //           dest)
+    {
+      std::shared_ptr<int> ptr(new int(0));
+      try {
+        sycl::buffer<int, 1> buf(&data, 1);
+        sycl::accessor acc(buf);
+        Q.submit([&](sycl::handler &h) { h.copy(ptr, acc); });
+        Q.wait();
+      } catch (sycl::exception const &e) {
+        EXPECT_EQ(e.what(), msg);
+      }
+
+      // Should pass without any exception throwed
+      {
+        sycl::buffer<int, 1> buf(&data, 1);
+        sycl::accessor acc(buf);
+        Q.submit([&](sycl::handler &h) {
+          h.require(acc);
+          h.copy(ptr, acc);
+        });
+        Q.wait();
+      }
+    }
+
+    // void copy(accessor<SrcT, SrcDims, SrcMode, SrcTgt, IsPlaceholder> src,
+    //           DestT* dest)
+    {
+      int *ptr = new int(0);
+      try {
+        sycl::buffer<int, 1> buf(&data, 1);
+        sycl::accessor acc(buf);
+        Q.submit([&](sycl::handler &h) { h.copy(acc, ptr); });
+        Q.wait();
+      } catch (sycl::exception const &e) {
+        EXPECT_EQ(e.what(), msg);
+      }
+
+      // Should pass without any exception throwed
+      {
+        sycl::buffer<int, 1> buf(&data, 1);
+        sycl::accessor acc(buf);
+        Q.submit([&](sycl::handler &h) {
+          h.require(acc);
+          h.copy(acc, ptr);
+        });
+        Q.wait();
+      }
+    }
+
+    // void copy(const SrcT* src,
+    //           accessor<DestT, DestDims, DestMode, DestTgt, IsPlaceholder>
+    //           dest)
+    {
+      int *ptr = new int(0);
+      try {
+        sycl::buffer<int, 1> buf(&data, 1);
+        sycl::accessor acc(buf);
+        Q.submit([&](sycl::handler &h) { h.copy(ptr, acc); });
+        Q.wait();
+      } catch (sycl::exception const &e) {
+        EXPECT_EQ(e.what(), msg);
+      }
+
+      // Should pass without any exception throwed
+      {
+        sycl::buffer<int, 1> buf(&data, 1);
+        sycl::accessor acc(buf);
+        Q.submit([&](sycl::handler &h) {
+          h.require(acc);
+          h.copy(ptr, acc);
+        });
+        Q.wait();
+      }
+    }
+
+    // void copy(accessor<SrcT, SrcDims, SrcMode, SrcTgt, IsSrcPlaceholder> src,
+    //           accessor<DestT, DestDims, DestMode, DestTgt, IsDestPlaceholder>
+    //           dest)
+    {
+      int data2 = 0;
+      try {
+        sycl::buffer<int, 1> buf(&data, 1);
+        sycl::buffer<int, 1> buf2(&data2, 1);
+        sycl::accessor acc(buf);
+        sycl::accessor acc2(buf2);
+        Q.submit([&](sycl::handler &h) { h.copy(acc, acc2); });
+        Q.wait();
+      } catch (sycl::exception const &e) {
+        EXPECT_EQ(e.what(), msg);
+      }
+      try {
+        sycl::buffer<int, 1> buf(&data, 1);
+        sycl::buffer<int, 1> buf2(&data2, 1);
+        sycl::accessor acc(buf);
+        sycl::accessor acc2(buf2);
+        Q.submit([&](sycl::handler &h) {
+          h.require(acc);
+          h.copy(acc, acc2);
+        });
+        Q.wait();
+      } catch (sycl::exception const &e) {
+        EXPECT_EQ(e.what(), msg);
+      }
+      try {
+        sycl::buffer<int, 1> buf(&data, 1);
+        sycl::buffer<int, 1> buf2(&data2, 1);
+        sycl::accessor acc(buf);
+        sycl::accessor acc2(buf2);
+        Q.submit([&](sycl::handler &h) {
+          h.require(acc2);
+          h.copy(acc, acc2);
+        });
+        Q.wait();
+      } catch (sycl::exception const &e) {
+        EXPECT_EQ(e.what(), msg);
+      }
+
+      // Should pass without any exception throwed
+      {
+        sycl::buffer<int, 1> buf(&data, 1);
+        sycl::buffer<int, 1> buf2(&data2, 1);
+        sycl::accessor acc(buf);
+        sycl::accessor acc2(buf2);
+        Q.submit([&](sycl::handler &h) {
+          h.require(acc);
+          h.require(acc2);
+          h.copy(acc, acc2);
+        });
+        Q.wait();
+      }
+    }
+  }
+}

--- a/sycl/unittests/handler/require.cpp
+++ b/sycl/unittests/handler/require.cpp
@@ -36,7 +36,7 @@ TEST(Require, checkIfAccBoundedToHandler) {
       EXPECT_EQ(e.what(), msg);
     }
 
-    // Should pass without any exception throwed
+    // Should pass without any exception thrown
     {
       sycl::buffer<int, 1> buf(&data, 1);
       sycl::accessor acc(buf);
@@ -60,7 +60,7 @@ TEST(Require, checkIfAccBoundedToHandler) {
       EXPECT_EQ(e.what(), msg);
     }
 
-    // Should pass without any exception throwed
+    // Should pass without any exception thrown
     {
       sycl::buffer<int, 1> buf(&data, 1);
       sycl::accessor acc(buf);
@@ -87,7 +87,7 @@ TEST(Require, checkIfAccBoundedToHandler) {
         EXPECT_EQ(e.what(), msg);
       }
 
-      // Should pass without any exception throwed
+      // Should pass without any exception thrown
       {
         sycl::buffer<int, 1> buf(&data, 1);
         sycl::accessor acc(buf);
@@ -113,7 +113,7 @@ TEST(Require, checkIfAccBoundedToHandler) {
         EXPECT_EQ(e.what(), msg);
       }
 
-      // Should pass without any exception throwed
+      // Should pass without any exception thrown
       {
         sycl::buffer<int, 1> buf(&data, 1);
         sycl::accessor acc(buf);
@@ -138,7 +138,7 @@ TEST(Require, checkIfAccBoundedToHandler) {
         EXPECT_EQ(e.what(), msg);
       }
 
-      // Should pass without any exception throwed
+      // Should pass without any exception thrown
       {
         sycl::buffer<int, 1> buf(&data, 1);
         sycl::accessor acc(buf);
@@ -164,7 +164,7 @@ TEST(Require, checkIfAccBoundedToHandler) {
         EXPECT_EQ(e.what(), msg);
       }
 
-      // Should pass without any exception throwed
+      // Should pass without any exception thrown
       {
         sycl::buffer<int, 1> buf(&data, 1);
         sycl::accessor acc(buf);
@@ -218,7 +218,7 @@ TEST(Require, checkIfAccBoundedToHandler) {
         EXPECT_EQ(e.what(), msg);
       }
 
-      // Should pass without any exception throwed
+      // Should pass without any exception thrown
       {
         sycl::buffer<int, 1> buf(&data, 1);
         sycl::buffer<int, 1> buf2(&data2, 1);


### PR DESCRIPTION
If a placeholder accessor is passed as an argument to a command without first being bound to a command group with handler::require(), the implementation should throw a synchronous exception with the errc::kernel_argument error code when the command is submitted.