### PR TITLE
[SYCL][DOC][P2P] Remove erroneous enum entry

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_peer_access.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_peer_access.asciidoc
@@ -101,7 +101,6 @@ namespace ext    {
 namespace oneapi {
 enum class peer_access {
   access_supported,
-  access_enabled,
   atomics_supported,
 };
 } // namespace oneapi


### PR DESCRIPTION
Missed an enum entry in last commit to the extension document.