### PR TITLE
[SYCL][CI] Remove grouping around "LLVM Test Suite SYCL tests"

### DIFF
--- a/devops/actions/llvm_test_suite/action.yml
+++ b/devops/actions/llvm_test_suite/action.yml
@@ -88,9 +88,7 @@ runs:
       echo "::group::SYCL In-Tree End-to-End tests"
       ninja -C build-e2e check-sycl-e2e
       echo "::endgroup::"
-      echo "::group::LLVM Test Suite SYCL tests"
       ninja -C build check-sycl-all
-      echo "::endgroup::"
   - name: Upload test results
     uses: actions/upload-artifact@v1
     if: always()


### PR DESCRIPTION
Current In-Tree End-to-End tests (subset copy of llvm-test-suite) is still grouped. That should make the failure visible/expanded by default in most of the cases.