### PR TITLE
[SYCL-MLIR][NFC] Removing SYCL RT functions filtering mechanism

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -1125,24 +1125,8 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
     return ValueCategory(Called, IsReference);
   }
 
-  /// If the callee is part of the SYCL namespace, we may not want the
-  /// GetOrCreateMLIRFunction to add this FuncOp to the functionsToEmit deque,
-  /// since we will create it's equivalent with SYCL operations. Please note
-  /// that we still generate some functions that we need for lowering some
-  /// sycl op.  Therefore, in those case, we set ShouldEmit back to "true" by
-  /// looking them up in our "registry" of supported functions.
-  const auto IsSyclFunc =
-      mlirclang::getNamespaceKind(Callee->getEnclosingNamespaceContext()) !=
-      mlirclang::NamespaceKind::Other;
-  bool ShouldEmit = !IsSyclFunc;
-
-  std::string MangledName =
-      MLIRScanner::getMangledFuncName(*Callee, Glob.getCGM());
-  if (GenerateAllSYCLFuncs || !isUnsupportedFunction(MangledName))
-    ShouldEmit = true;
-
   FunctionToEmit F(*Callee, mlirclang::getInputContext(Builder));
-  auto ToCall = cast<func::FuncOp>(Glob.getOrCreateMLIRFunction(F, ShouldEmit));
+  auto ToCall = cast<func::FuncOp>(Glob.getOrCreateMLIRFunction(F));
 
   SmallVector<std::pair<ValueCategory, clang::Expr *>> Args;
   clang::QualType ObjType;

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -940,25 +940,8 @@ ValueCategory MLIRScanner::VisitConstructCommon(clang::CXXConstructExpr *Cons,
     assert(Obj.isReference);
   }
 
-  /// If the constructor is part of the SYCL namespace, we may not want the
-  /// GetOrCreateMLIRFunction to add this FuncOp to the functionsToEmit deque,
-  /// since we will create it's equivalent with SYCL operations. Please note
-  /// that we still generate some constructors that we need for lowering some
-  /// sycl op.  Therefore, in those case, we set ShouldEmit back to "true" by
-  /// looking them up in our "registry" of supported constructors.
-  const auto IsSyclCtor =
-      mlirclang::getNamespaceKind(CtorDecl->getEnclosingNamespaceContext()) !=
-      mlirclang::NamespaceKind::Other;
-  bool ShouldEmit = !IsSyclCtor;
-
-  std::string MangledName = MLIRScanner::getMangledFuncName(
-      cast<FunctionDecl>(*CtorDecl), Glob.getCGM());
-  MangledName = (PrefixABI + MangledName);
-  if (GenerateAllSYCLFuncs || !isUnsupportedFunction(MangledName))
-    ShouldEmit = true;
-
   FunctionToEmit F(*CtorDecl, mlirclang::getInputContext(Builder));
-  auto ToCall = cast<func::FuncOp>(Glob.getOrCreateMLIRFunction(F, ShouldEmit));
+  auto ToCall = cast<func::FuncOp>(Glob.getOrCreateMLIRFunction(F));
 
   SmallVector<std::pair<ValueCategory, clang::Expr *>> Args{{Obj, nullptr}};
   Args.reserve(Cons->getNumArgs() + 1);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -177,7 +177,6 @@ public:
   ::ScopLocList &getScopLocList() { return ScopLocs; }
 
   mlir::FunctionOpInterface getOrCreateMLIRFunction(FunctionToEmit &FTE,
-                                                    const bool ShouldEmit,
                                                     bool GetDeviceStub = false);
   mlir::LLVM::LLVMFuncOp getOrCreateLLVMFunction(const clang::FunctionDecl *FD,
                                                  FunctionContext FuncContext);
@@ -215,7 +214,7 @@ public:
 private:
   /// Returns the LLVM linkage type of the given function declaration \p FD.
   llvm::GlobalValue::LinkageTypes
-  getLLVMLinkageType(const clang::FunctionDecl &FD, bool ShouldEmit);
+  getLLVMLinkageType(const clang::FunctionDecl &FD);
 
   /// Returns the MLIR LLVM dialect linkage corresponding to \p LV.
   static mlir::LLVM::Linkage getMLIRLinkage(llvm::GlobalValue::LinkageTypes LV);
@@ -234,16 +233,15 @@ private:
   /// in the host module (ModuleOp), depending on the calling context embedded
   /// in the FTE).
   mlir::FunctionOpInterface createMLIRFunction(const FunctionToEmit &FTE,
-                                               std::string MangledName,
-                                               bool ShouldEmit);
+                                               std::string MangledName);
 
   /// Set the symbol visibility on the given \p function.
   void setMLIRFunctionVisibility(mlir::FunctionOpInterface Function,
-                                 const FunctionToEmit &FTE, bool ShouldEmit);
+                                 const FunctionToEmit &FTE);
 
   /// Set the MLIR function attributes for the given \p function.
   void setMLIRFunctionAttributes(mlir::FunctionOpInterface Function,
-                                 const FunctionToEmit &FTE, bool ShouldEmit);
+                                 const FunctionToEmit &FTE);
 
   void setMLIRFunctionAttributesForDefinition(
       const clang::Decl *D, mlir::FunctionOpInterface Function) const;
@@ -261,7 +259,6 @@ private:
   mlir::Block *EntryBlock;
   std::vector<LoopContext> Loops;
   mlir::Block *AllocationScope;
-  llvm::SmallSet<std::string, 4> UnsupportedFuncs;
   std::map<const void *, std::vector<mlir::LLVM::AllocaOp>> Bufs;
   std::map<int, mlir::Value> Constants;
   std::map<clang::LabelStmt *, mlir::Block *> Labels;
@@ -275,13 +272,6 @@ private:
   ValueCategory ThisVal;
   mlir::Value ReturnVal;
   LowerToInfo &LTInfo;
-
-  // Initialize a exclude list of SYCL functions to emit instead just the
-  // declaration. Eventually, this list should be removed.
-  void initUnsupportedFunctions();
-  bool isUnsupportedFunction(std::string Name) const {
-    return UnsupportedFuncs.contains(Name);
-  }
 
   // Get the \p FNum field of MemRef Value \p V of element type T. \p Shape is
   // the shape of the result MemRef.

--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -227,10 +227,6 @@ llvm::cl::opt<bool> OmitOptionalMangledFunctionName(
     llvm::cl::desc("Whether to omit optional \"MangledFunctionName\" fields"));
 
 llvm::cl::opt<bool>
-    GenerateAllSYCLFuncs("gen-all-sycl-funcs", llvm::cl::init(false),
-                         llvm::cl::desc("Generate all SYCL functions"));
-
-llvm::cl::opt<bool>
     GenerateSYCLAddrSpaceCast("gen-sycl-addrspacecast", llvm::cl::init(false),
                               llvm::cl::desc("Generate sycl.addrspacecast"));
 


### PR DESCRIPTION
We haven't been using this for a while, so cleaning up the code.