### PR TITLE
[SYCL-MLIR] Provide a way to filter functions by name

### DIFF
--- a/polygeist/tools/cgeist/Test/Verification/sycl/function_filter.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/function_filter.cpp
@@ -1,26 +1,31 @@
 // RUN: clang++ -fsycl -fsycl-device-only -emit-mlir -Xcgeist -function=match %s -o - | FileCheck %s
+// RUN: clang++ -fsycl -fsycl-device-only -emit-mlir -Xcgeist -function=match$ %s -o - | FileCheck %s --check-prefix=CHECK-END
 
 // COM: No GPU functions.
 // CHECK-NOT: gpu.func
 
 // COM: No definitions with name contain func.
-// CHCEK-NOT: func.func {{.*}}func{{.*}} {
+// CHECK-NOT: func.func {{.*}}func{{.*}} {
 
 // COM: func1 is a declaration.
 // CHECK: func.func private @func1()
 
-// COM: match1 and match2 are kept as definitions.
+// COM: match and match1 are kept as definitions.
+// CHECK: func.func @match() {{.*}} {
 // CHECK: func.func @match1() {{.*}} {
-// CHECK: func.func @match2() {{.*}} {
+
+// COM: Only match is kept as definitions.
+// CHECK-END: func.func @match() {{.*}} {
+// CHECK-END-NOT: func.func @match1() {{.*}} {
 
 #include <sycl/sycl.hpp>
 using namespace sycl;
 
 extern "C" SYCL_EXTERNAL void func1() {}
-extern "C" SYCL_EXTERNAL void match1() {
+extern "C" SYCL_EXTERNAL void match() {
   func1();
 }
-extern "C" SYCL_EXTERNAL void match2() {}
+extern "C" SYCL_EXTERNAL void match1() {}
 extern "C" SYCL_EXTERNAL void func2() {}
 
 void single_task(std::array<int, 1> &A) {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/function_filter.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/function_filter.cpp
@@ -1,0 +1,37 @@
+// RUN: clang++ -fsycl -fsycl-device-only -emit-mlir -Xcgeist -function=match %s -o - | FileCheck %s
+
+// COM: No GPU functions.
+// CHECK-NOT: gpu.func
+
+// COM: No definitions with name contain func.
+// CHCEK-NOT: func.func {{.*}}func{{.*}} {
+
+// COM: func1 is a declaration.
+// CHECK: func.func private @func1()
+
+// COM: match1 and match2 are kept as definitions.
+// CHECK: func.func @match1() {{.*}} {
+// CHECK: func.func @match2() {{.*}} {
+
+#include <sycl/sycl.hpp>
+using namespace sycl;
+
+extern "C" SYCL_EXTERNAL void func1() {}
+extern "C" SYCL_EXTERNAL void match1() {
+  func1();
+}
+extern "C" SYCL_EXTERNAL void match2() {}
+extern "C" SYCL_EXTERNAL void func2() {}
+
+void single_task(std::array<int, 1> &A) {
+  auto q = queue{};
+  {
+    auto buf = buffer<int, 1>{A.data(), 1};
+    q.submit([&](handler &cgh) {
+      auto A = buf.get_access<access::mode::write>(cgh);
+      cgh.single_task<class kernel_single_task>([=]() {
+        A[0] = 1;
+      });
+    });
+  }
+}

--- a/polygeist/tools/cgeist/Test/addressoff_call.cpp
+++ b/polygeist/tools/cgeist/Test/addressoff_call.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=_Z1fv -S | FileCheck %s
+// RUN: cgeist %s --function=* -S | FileCheck %s
 unsigned long foo(unsigned);
 inline unsigned long inlineFunc(unsigned i) noexcept {
   return foo(i);

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -57,6 +57,7 @@
 #include "llvm/Support/Host.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/Program.h"
+#include "llvm/Support/Regex.h"
 #include "llvm/Support/WithColor.h"
 
 #include "Options.h"
@@ -1119,6 +1120,33 @@ static void eraseHostCode(mlir::ModuleOp Module) {
     Op.get().erase();
 }
 
+static void filterDeviceFunctions(mlir::gpu::GPUModuleOp Module) {
+  if (Cfunction.getNumOccurrences() == 0 || Cfunction == "*")
+    return;
+
+  llvm::Regex MatchName(Cfunction);
+  LLVM_DEBUG(llvm::dbgs() << "Filtering device functions\n");
+  SmallVector<gpu::GPUFuncOp> ToRemove;
+  for (Operation &Op : Module) {
+    if (auto Func = dyn_cast<FunctionOpInterface>(Op))
+      if (!MatchName.match(Func.getName())) {
+        if (auto GPUFunc = dyn_cast<gpu::GPUFuncOp>(Op)) {
+          // 'gpu.func' op expected body with at least one block.
+          ToRemove.push_back(GPUFunc);
+          continue;
+        }
+
+        // Change to declaration.
+        Func.eraseBody();
+        // Declaration cannot have public visibility.
+        SymbolTable::setSymbolVisibility(Func,
+                                         SymbolTable::Visibility::Private);
+      }
+  }
+  for (gpu::GPUFuncOp Func : ToRemove)
+    Func.erase();
+}
+
 int main(int argc, char **argv) {
   if (argc >= 1 && std::string(argv[1]) == "-cc1") {
     SmallVector<const char *> Argv;
@@ -1180,6 +1208,7 @@ int main(int argc, char **argv) {
   // on the host code otherwise.
   if (containsFunctions(DeviceModule)) {
     eraseHostCode(*Module);
+    filterDeviceFunctions(DeviceModule);
     Module.get()->setAttr(mlir::gpu::GPUDialect::getContainerModuleAttrName(),
                           Builder.getUnitAttr());
   } else


### PR DESCRIPTION
This should help speedup investigation. For example, it can be used to focus on a function, optimizations only performs on it, so less debug output.

`-Xcgeist -function=foo` will only keep the function definitions with name containing `foo`. 
If you only want function definition that named exactly `foo`, you can use `-Xcgeist -function=^foo$`.