### PR TITLE
[SYCL][Fusion] Initialize Constants member of FusedFunction

### DIFF
--- a/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.h
+++ b/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.h
@@ -37,8 +37,8 @@ public:
         : FusedName{FusedName}, FusedKernels{FusedKernels},
           ParameterIdentities{ParameterIdentities},
           ParameterInternalization{ParameterInternalization},
-          NDRanges{NDRanges}, FusedNDRange{
-                                  jit_compiler::combineNDRanges(NDRanges)} {}
+          Constants{Constants}, NDRanges{NDRanges},
+          FusedNDRange{jit_compiler::combineNDRanges(NDRanges)} {}
 
     std::string FusedName;
     std::vector<std::string> FusedKernels;


### PR DESCRIPTION
325bc4e206d97acb56f6800014d953de0e83a1f0 defined a constructor for this struct, but did not initialize the `Constants` member, leading to not JIT constants propagation being performed. This change fixes that bug.