### PR TITLE
[SYCL] Fix default host_accessor iteration methods

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -1141,20 +1141,6 @@ public:
   accessor(const detail::AccessorImplPtr &Impl)
       : detail::AccessorBaseHost{Impl} {}
 
-  id<3> getOffset() {
-    if constexpr (IsHostBuf)
-      return MAccData ? MAccData->MOffset : id<3>();
-    else
-      return AccessorBaseHost::getOffset();
-  }
-
-  range<3> &getAccessRange() { return AccessorBaseHost::getAccessRange(); }
-  range<3> getMemoryRange() {
-    if constexpr (IsHostBuf)
-      return MAccData ? MAccData->MMemoryRange : range(0, 0, 0);
-    else
-      return AccessorBaseHost::getMemoryRange();
-  }
   void *getPtr() { return AccessorBaseHost::getPtr(); }
 
   const id<3> getOffset() const {

--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -1141,34 +1141,34 @@ public:
   accessor(const detail::AccessorImplPtr &Impl)
       : detail::AccessorBaseHost{Impl} {}
 
-  id<3> &getOffset() {
+  id<3> getOffset() {
     if constexpr (IsHostBuf)
-      return MAccData->MOffset;
+      return MAccData ? MAccData->MOffset : id<3>();
     else
       return AccessorBaseHost::getOffset();
   }
 
   range<3> &getAccessRange() { return AccessorBaseHost::getAccessRange(); }
-  range<3> &getMemoryRange() {
+  range<3> getMemoryRange() {
     if constexpr (IsHostBuf)
-      return MAccData->MMemoryRange;
+      return MAccData ? MAccData->MMemoryRange : range(0, 0, 0);
     else
       return AccessorBaseHost::getMemoryRange();
   }
   void *getPtr() { return AccessorBaseHost::getPtr(); }
 
-  const id<3> &getOffset() const {
+  const id<3> getOffset() const {
     if constexpr (IsHostBuf)
-      return MAccData->MOffset;
+      return MAccData ? MAccData->MOffset : id<3>();
     else
       return AccessorBaseHost::getOffset();
   }
   const range<3> &getAccessRange() const {
     return AccessorBaseHost::getAccessRange();
   }
-  const range<3> &getMemoryRange() const {
+  const range<3> getMemoryRange() const {
     if constexpr (IsHostBuf)
-      return MAccData->MMemoryRange;
+      return MAccData ? MAccData->MMemoryRange : range(0, 0, 0);
     else
       return AccessorBaseHost::getMemoryRange();
   }
@@ -1200,7 +1200,7 @@ public:
 
   PtrType getQualifiedPtr() const noexcept {
     if constexpr (IsHostBuf)
-      return reinterpret_cast<PtrType>(MAccData->MData);
+      return MAccData ? reinterpret_cast<PtrType>(MAccData->MData) : nullptr;
     else
       return reinterpret_cast<PtrType>(AccessorBaseHost::getPtr());
   }

--- a/sycl/unittests/accessor/AccessorIterator.cpp
+++ b/sycl/unittests/accessor/AccessorIterator.cpp
@@ -571,3 +571,16 @@ TEST_F(AccessorIteratorTest, IteratorInequalitiesOperators) {
   ASSERT_TRUE(a <= b);
   ASSERT_TRUE(a >= b);
 }
+
+TEST_F(AccessorIteratorTest, DefaultHostAccessorIterationMethonds) {
+  // Should not fail with segmentation fault
+  sycl::host_accessor<int, 1> acc;
+  acc.begin();
+  acc.end();
+  acc.cbegin();
+  acc.cend();
+  acc.rbegin();
+  acc.rend();
+  acc.crbegin();
+  acc.crend();
+}


### PR DESCRIPTION
Iteration methods for default host_accessor constructor were causing
segmentation fault because we don't check if MAccData is nullptr.