### PR TITLE
[CI] Don't limit runners working in parallel

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -52,10 +52,6 @@ on:
         type: string
         required: false
         default: 'intel'
-      max_parallel:
-        type: number
-        required: false
-        default: 4
       cts_matrix:
         type: string
         required: false
@@ -193,7 +189,6 @@ jobs:
     if: ${{ always() && needs.build.result == 'success' && inputs.lts_matrix != '[]' }}
     strategy:
       fail-fast: false
-      max-parallel: ${{ inputs.max_parallel }}
       matrix:
         include: ${{ fromJSON(inputs.lts_matrix) }}
     name: ${{ matrix.name }}
@@ -241,7 +236,6 @@ jobs:
     if: ${{ inputs.cts_matrix != '' }}
     strategy:
       fail-fast: false
-      max-parallel: ${{ inputs.max_parallel }}
       matrix:
         include: ${{ fromJSON(inputs.cts_matrix) }}
     name: ${{ matrix.name }}


### PR DESCRIPTION
Currently we see a problem with llvm-test-suite checks on CUDA in AWS cloud, which looks like AWS was never allocated to execute the job. Current hypothesis is that we have a matrix job spawning 6 jobs, but we limit number of runners working in parallel to 4. This means that llvm-test-suite check on CUDA might wait for 1 or 2 llvm-test-suite checks on other machines to complete before we can run llvm-test-suite on CUDA machine.
This strategy conflicts with the rules established for AWS machines, which waits for 1 hour after machine is allocated to start the job. If job has not arrived, machine returns to AWS. Since AWS allocation is speicific to each workflow run, once machine is returned to the AWS, GitHub is not able to use it anymore. GitHub waits for 24 hours and kills the workflow due to missing runner.

This change removes the limitation for the number of runners we can use in parallel to run llvm-test-suite. This should fix the problem with missing results on CUDA machines.