### PR TITLE
[CI][CTS] Temporary disable atomic_ref tests

### DIFF
--- a/devops/cts_exclude_filter
+++ b/devops/cts_exclude_filter
@@ -28,3 +28,4 @@ atomic_fence
 function_objects
 group_functions
 image
+atomic_ref


### PR DESCRIPTION
atomic_ref tests started to fail on CUDA in post-commit after https://github.com/KhronosGroup/SYCL-CTS/commit/df2259b2bc17cc724920d97e19beeb09bd86aed0, temporary disable them.