### PR TITLE
[SYCL][Sema] Prevent Ctor/Dtor from being called during SYCL kernel rebuild

### DIFF
--- a/clang/lib/AST/Expr.cpp
+++ b/clang/lib/AST/Expr.cpp
@@ -270,7 +270,15 @@ bool Expr::isFlexibleArrayMemberLike(
           continue;
         }
         if (ConstantArrayTypeLoc CTL = TL.getAs<ConstantArrayTypeLoc>()) {
-          const Expr *SizeExpr = dyn_cast<IntegerLiteral>(CTL.getSizeExpr());
+          // FIXME: changed dyn_cast to dyn_cast_or_null
+          //    to work around the fact that CTL.getSizeExpr() isn't set
+          //    for a FieldDecl of a class generated from a lambda capture.
+          //    This is highlighted only by the way lambda expression used
+          //    as a SYCL kernel is being processed.
+          //    In normal situation the capture list is used.
+          //    No harm done, just a work around.
+          const Expr *SizeExpr =
+              dyn_cast_or_null<IntegerLiteral>(CTL.getSizeExpr());
           if (!SizeExpr || SizeExpr->getExprLoc().isMacroID())
             return false;
         }

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -1,5 +1,8 @@
 #pragma once
 
+void* operator new  (__SIZE_TYPE__ size, void* ptr) noexcept;
+void* operator new[](__SIZE_TYPE__ size, void* ptr) noexcept;
+
 #define ATTR_SYCL_KERNEL __attribute__((sycl_kernel))
 #define __SYCL_TYPE(x) [[__sycl_detail__::sycl_type(x)]]
 

--- a/clang/test/CodeGenSYCL/accessor-readonly-invalid-lib.cpp
+++ b/clang/test/CodeGenSYCL/accessor-readonly-invalid-lib.cpp
@@ -2,6 +2,8 @@
 //
 // Test which verifies that readonly attribute is generated for unexpected access mode value.
 
+void* operator new  (__SIZE_TYPE__ size, void* ptr) noexcept;
+
 // Dummy library with unexpected access::mode enum value.
 namespace sycl {
 inline namespace _V1 {

--- a/clang/test/CodeGenSYCL/accessor_inheritance.cpp
+++ b/clang/test/CodeGenSYCL/accessor_inheritance.cpp
@@ -42,7 +42,7 @@ int main() {
 // CHECK: [[ACC1_DATA]].addr = alloca ptr addrspace(1)
 // CHECK: [[ACC2_DATA]].addr = alloca ptr addrspace(1)
 // CHECK: [[ARG_C]].addr = alloca i32
-// CHECK: [[KERNEL:%[a-zA-Z0-9_]+]] = alloca %class{{.*}}.anon
+// CHECK: [[KERNEL:%[a-zA-Z0-9_]+]] = alloca %union{{.*}}.__wrapper_union
 // CHECK: [[ARG_A]].addr.ascast = addrspacecast ptr [[ARG_A]].addr to ptr addrspace(4)
 // CHECK: [[ARG_B]].addr.ascast = addrspacecast ptr [[ARG_B]].addr to ptr addrspace(4)
 // CHECK: [[ACC1_DATA]].addr.ascast = addrspacecast ptr [[ACC1_DATA]].addr to ptr addrspace(4)
@@ -60,33 +60,37 @@ int main() {
 // CHECK: store i32 [[ARG_C]], ptr addrspace(4) [[ARG_C]].addr.ascast
 //
 // Check A and B scalar fields initialization
+// CHECK: [[ARG_A_LOAD:%[a-zA-Z0-9_]+]] = load i32, ptr addrspace(4) [[ARG_A]].addr.ascast
 // CHECK: [[GEP:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class{{.*}}.anon, ptr addrspace(4) [[KERNEL_OBJ]], i32 0, i32 0
 // CHECK: [[FIELD_A:%[a-zA-Z0-9_]+]] = getelementptr inbounds %struct{{.*}}Base, ptr addrspace(4) [[GEP]], i32 0, i32 0
-// CHECK: [[ARG_A_LOAD:%[a-zA-Z0-9_]+]] = load i32, ptr addrspace(4) [[ARG_A]].addr.ascast
 // CHECK: store i32 [[ARG_A_LOAD]], ptr addrspace(4) [[FIELD_A]]
-// CHECK: [[FIELD_B:%[a-zA-Z0-9_]+]] = getelementptr inbounds %struct{{.*}}Base, ptr addrspace(4) [[GEP]], i32 0, i32 1
 // CHECK: [[ARG_B_LOAD:%[a-zA-Z0-9_]+]] = load i32, ptr addrspace(4) [[ARG_B]].addr.ascast
+// CHECK: [[GEP:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class{{.*}}.anon, ptr addrspace(4) [[KERNEL_OBJ]], i32 0, i32 0
+// CHECK: [[FIELD_B:%[a-zA-Z0-9_]+]] = getelementptr inbounds %struct{{.*}}Base, ptr addrspace(4) [[GEP]], i32 0, i32 1
 // CHECK: store i32 [[ARG_B_LOAD]], ptr addrspace(4) [[FIELD_B]]
 //
 // Check accessors initialization
+// CHECK: [[GEP:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class{{.*}}.anon, ptr addrspace(4) [[KERNEL_OBJ]], i32 0, i32 0
 // CHECK: [[ACC_FIELD:%[a-zA-Z0-9_]+]] = getelementptr inbounds %struct{{.*}}Base, ptr addrspace(4) [[GEP]], i32 0, i32 2
 // Default constructor call
 // CHECK: call spir_func void @_ZN4sycl3_V18accessorIcLi1ELNS0_6access4modeE1024ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(ptr addrspace(4) {{[^,]*}} [[ACC_FIELD]])
-// CHECK: [[GEP1:%[a-zA-Z0-9_]+]] = getelementptr inbounds i8, ptr addrspace(4) [[GEP]], i64 20
-// Default constructor call
-// CHECK: call spir_func void @_ZN4sycl3_V18accessorIcLi1ELNS0_6access4modeE1024ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC2Ev(ptr addrspace(4) {{[^,]*}} [[GEP1]])
-
-// CHECK C field initialization
-// CHECK: [[FIELD_C:%[a-zA-Z0-9_]+]] = getelementptr inbounds %struct{{.*}}Captured, ptr addrspace(4) [[GEP]], i32 0, i32 2
-// CHECK: [[ARG_C_LOAD:%[a-zA-Z0-9_]+]] = load i32, ptr addrspace(4) [[ARG_C]].addr.ascast
-// CHECK: store i32 [[ARG_C_LOAD]], ptr addrspace(4) [[FIELD_C]]
-//
 // Check __init method calls
 // CHECK: [[GEP2:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class{{.*}}.anon, ptr addrspace(4) [[KERNEL_OBJ]], i32 0, i32 0
 // CHECK: [[ACC1_FIELD:%[a-zA-Z0-9_]+]] = getelementptr inbounds %struct{{.*}}Base, ptr addrspace(4) [[GEP2]], i32 0, i32 2
 // CHECK: [[ACC1_DATA_LOAD:%[a-zA-Z0-9_]+]] = load ptr addrspace(1), ptr addrspace(4) [[ACC1_DATA]].addr.ascast
 // CHECK: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{[^,]*}} [[ACC1_FIELD]], ptr addrspace(1) noundef [[ACC1_DATA_LOAD]]
-//
+// CHECK: [[GEP:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class{{.*}}.anon, ptr addrspace(4) [[KERNEL_OBJ]], i32 0, i32 0
+// CHECK: [[GEP1:%[a-zA-Z0-9_.]+]] = getelementptr inbounds i8, ptr addrspace(4) [[GEP]], i64 20
+// Default constructor call
+// CHECK: call spir_func void @_ZN4sycl3_V18accessorIcLi1ELNS0_6access4modeE1024ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(ptr addrspace(4) {{[^,]*}} [[GEP1]])
+// Check __init method calls
 // CHECK: [[GEP3:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class{{.*}}.anon, ptr addrspace(4) [[KERNEL_OBJ]], i32 0, i32 0
 // CHECK: [[ACC2_DATA_LOAD:%[a-zA-Z0-9_]+]] = load ptr addrspace(1), ptr addrspace(4) [[ACC2_DATA]].addr.ascast
 // CHECK: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{[^,]*}}, ptr addrspace(1) noundef [[ACC2_DATA_LOAD]]
+
+// CHECK C field initialization
+// CHECK: [[ARG_C_LOAD:%[a-zA-Z0-9_]+]] = load i32, ptr addrspace(4) [[ARG_C]].addr.ascast
+// CHECK: [[GEP:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class{{.*}}.anon, ptr addrspace(4) [[KERNEL_OBJ]], i32 0, i32 0
+// CHECK: [[FIELD_C:%[a-zA-Z0-9_]+]] = getelementptr inbounds %struct{{.*}}Captured, ptr addrspace(4) [[GEP]], i32 0, i32 2
+// CHECK: store i32 [[ARG_C_LOAD]], ptr addrspace(4) [[FIELD_C]]
+//

--- a/clang/test/CodeGenSYCL/address-space-parameter-conversions.cpp
+++ b/clang/test/CodeGenSYCL/address-space-parameter-conversions.cpp
@@ -1,4 +1,8 @@
 // RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -disable-llvm-passes -opaque-pointers -emit-llvm %s -o - | FileCheck %s
+
+// Set the cursor so that CEHCK-DAG don't pickup wrong matches
+// CHECK: define {{.*}} @_Z6usagesv
+
 void bar(int & Data) {}
 // CHECK-DAG: define {{.*}}spir_func void @[[RAW_REF:[a-zA-Z0-9_]+]](ptr addrspace(4) noundef align 4 dereferenceable(4) %
 void bar2(int & Data) {}

--- a/clang/test/CodeGenSYCL/basic-kernel-wrapper.cpp
+++ b/clang/test/CodeGenSYCL/basic-kernel-wrapper.cpp
@@ -27,7 +27,7 @@ int main() {
 // Check alloca for pointer argument
 // CHECK: [[MEM_ARG]].addr = alloca ptr addrspace(1)
 // Check lambda object alloca
-// CHECK: [[ANONALLOCA:%[a-zA-Z0-9_]+]] = alloca %class.anon
+// CHECK: [[ANONALLOCA:%[a-zA-Z0-9_]+]] = alloca %union.__wrapper_union
 // Check allocas for ranges
 // CHECK: [[ARANGEA:%agg.tmp.*]] = alloca %"struct.sycl::_V1::range"
 // CHECK: [[MRANGEA:%agg.tmp.*]] = alloca %"struct.sycl::_V1::range"

--- a/clang/test/CodeGenSYCL/check-direct-attribute-propagation.cpp
+++ b/clang/test/CodeGenSYCL/check-direct-attribute-propagation.cpp
@@ -317,7 +317,7 @@ int main() {
 
     // Test attribute is not propagated.
     // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name32() #0{{.*}} !kernel_arg_buffer_location ![[NUM]]
-    // CHECK: define {{.*}}spir_func void @{{.*}}Functor10{{.*}}(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) #3 comdat align 2
+    // CHECK: define {{.*}}spir_func void @{{.*}}Functor10{{.*}}(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) #2 comdat align 2
     // CHECK-NOT: noalias
     // CHECK-SAME: {
     // CHECK: define dso_local spir_func void @_Z4foo8v()
@@ -325,12 +325,12 @@ int main() {
     h.single_task<class kernel_name32>(f10);
 
     // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name33() #0{{.*}} !kernel_arg_buffer_location ![[NUM]]
-    // CHECK: define {{.*}}spir_func void @{{.*}}Foo8{{.*}}(ptr addrspace(4) noalias noundef align 1 dereferenceable_or_null(1) %this) #3 comdat align 2
+    // CHECK: define {{.*}}spir_func void @{{.*}}Foo8{{.*}}(ptr addrspace(4) noalias noundef align 1 dereferenceable_or_null(1) %this) #2 comdat align 2
     Foo8 boo8;
     h.single_task<class kernel_name33>(boo8);
 
     // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name34() #0{{.*}} !kernel_arg_buffer_location ![[NUM]]
-    // CHECK: define {{.*}}spir_func void @{{.*}}(ptr addrspace(4) noalias noundef align 1 dereferenceable_or_null(1) %this) #4 align 2
+    // CHECK: define {{.*}}spir_func void @{{.*}}(ptr addrspace(4) noalias noundef align 1 dereferenceable_or_null(1) %this) #3 align 2
     h.single_task<class kernel_name34>(
         []() [[intel::kernel_args_restrict]]{});
 

--- a/clang/test/CodeGenSYCL/generated-types-initialization.cpp
+++ b/clang/test/CodeGenSYCL/generated-types-initialization.cpp
@@ -41,8 +41,10 @@ int main() {
 // CHECK: define dso_local spir_kernel void @{{.*}}basic(ptr noundef byval(%struct.__generated_B) align 8 %_arg_Obj)
 //
 // Kernel object clone.
-// CHECK: %[[K:[a-zA-Z0-9_.]+]] = alloca %class.anon
+// CHECK: %[[K:[a-zA-Z0-9_.]+]] = alloca %union.__wrapper_union
+// CHECK: %[[K_PTR_ALLOCA:[a-zA-Z0-9_.]+]] = alloca ptr addrspace(4)
 // CHECK: %[[K_as_cast:[a-zA-Z0-9_.]+]] = addrspacecast ptr %[[K]] to ptr addrspace(4)
+// CHECK: %[[K_PTR_ALLOCA_as_cast:[a-zA-Z0-9_.]+]] = addrspacecast ptr %[[K_PTR_ALLOCA]] to ptr addrspace(4)
 //
 // Argument reference.
 // CHECK: %[[Arg_ref:[a-zA-Z0-9_.]+]] = addrspacecast ptr %_arg_Obj to ptr addrspace(4)
@@ -52,20 +54,26 @@ int main() {
 // CHECK: call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) align 8 %[[GEP]], ptr addrspace(4) align 8 %[[Arg_ref]], i64 16, i1 false)
 //
 // Kernel body call.
-// CHECK: call spir_func void @_ZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEv(ptr addrspace(4) noundef align 8 dereferenceable_or_null(16) %[[K_as_cast]])
+// CHECK: store ptr addrspace(4) %[[K_as_cast]], ptr addrspace(4) %[[K_PTR_ALLOCA_as_cast]]
+// CHECK: %[[K_PTR:[a-zA-Z0-9_.]+]] = load ptr addrspace(4), ptr addrspace(4) %[[K_PTR_ALLOCA_as_cast]]
+// CHECK: call spir_func void @_ZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEv(ptr addrspace(4) noundef align 8 dereferenceable_or_null(16) %[[K_PTR]])
 
 // CHECK: define dso_local spir_kernel void @{{.*}}nns(ptr noundef byval(%struct.__generated_B.0) align 8 %_arg_NNSObj)
 //
 // Kernel object clone.
-// CHECK: %[[NNSK:[a-zA-Z0-9_.]+]] = alloca %class.anon.2
+// CHECK: %[[NNSK:[a-zA-Z0-9_.]+]] = alloca %union.__wrapper_union.2
+// CHECK: %[[NNSK_PTR_ALLOCA:[a-zA-Z0-9_.]+]] = alloca ptr addrspace(4)
 // CHECK: %[[NNSK_as_cast:[a-zA-Z0-9_.]+]] = addrspacecast ptr %[[NNSK]] to ptr addrspace(4)
+// CHECK: %[[NNSK_PTR_ALLOCA_as_cast:[a-zA-Z0-9_.]+]] = addrspacecast ptr %[[NNSK_PTR_ALLOCA]] to ptr addrspace(4)
 //
 // Argument reference.
 // CHECK: %[[NNSArg_ref:[a-zA-Z0-9_.]+]] = addrspacecast ptr %_arg_NNSObj to ptr addrspace(4)
 //
 // Initialization.
-// CHECK: %[[NNSGEP:[a-zA-Z0-9_.]+]] = getelementptr inbounds %class.anon.2, ptr addrspace(4) %[[NNSK_as_cast]], i32 0, i32 0
+// CHECK: %[[NNSGEP:[a-zA-Z0-9_.]+]] = getelementptr inbounds %class.anon.3, ptr addrspace(4) %[[NNSK_as_cast]], i32 0, i32 0
 // CHECK: call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) align 8 %[[NNSGEP]], ptr addrspace(4) align 8 %[[NNSArg_ref]], i64 16, i1 false)
 //
 // Kernel body call.
-// CHECK: call spir_func void @_ZZZ4mainENKUlRN4sycl3_V17handlerEE0_clES2_ENKUlvE_clEv(ptr addrspace(4) noundef align 8 dereferenceable_or_null(16) %[[NNSK_as_cast]])
+// CHECK: store ptr addrspace(4) %[[NNSK_as_cast]], ptr addrspace(4) %[[NNSK_PTR_ALLOCA_as_cast]]
+// CHECK: %[[NNSK_PTR:[a-zA-Z0-9_.]+]] = load ptr addrspace(4), ptr addrspace(4) %[[NNSK_PTR_ALLOCA_as_cast]]
+// CHECK: call spir_func void @_ZZZ4mainENKUlRN4sycl3_V17handlerEE0_clES2_ENKUlvE_clEv(ptr addrspace(4) noundef align 8 dereferenceable_or_null(16) %[[NNSK_PTR]])

--- a/clang/test/CodeGenSYCL/image_accessor.cpp
+++ b/clang/test/CodeGenSYCL/image_accessor.cpp
@@ -7,22 +7,22 @@
 // RUN: FileCheck < %t.ll --enable-var-scope %s --check-prefix=CHECK-3DWO
 //
 // CHECK-1DRO: define {{.*}}spir_kernel void @{{.*}}(ptr addrspace(1) [[IMAGE_ARG:%[a-zA-Z0-9_]+]])
-// CHECK-1DRO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z]+}}, ptr addrspace(1) %{{[0-9]+}})
+// CHECK-1DRO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z0-9]+}}, ptr addrspace(1) %{{[0-9]+}})
 //
 // CHECK-2DRO: define {{.*}}spir_kernel void @{{.*}}(ptr addrspace(1) [[IMAGE_ARG:%[a-zA-Z0-9_]+]])
-// CHECK-2DRO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z]+}}, ptr addrspace(1) %{{[0-9]+}})
+// CHECK-2DRO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z0-9]+}}, ptr addrspace(1) %{{[0-9]+}})
 //
 // CHECK-3DRO: define {{.*}}spir_kernel void @{{.*}}(ptr addrspace(1) [[IMAGE_ARG:%[a-zA-Z0-9_]+]])
-// CHECK-3DRO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z]+}}, ptr addrspace(1) %{{[0-9]+}})
+// CHECK-3DRO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z0-9]+}}, ptr addrspace(1) %{{[0-9]+}})
 //
 // CHECK-1DWO: define {{.*}}spir_kernel void @{{.*}}(ptr addrspace(1) [[IMAGE_ARG:%[a-zA-Z0-9_]+]])
-// CHECK-1DWO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z]+}}, ptr addrspace(1) %{{[0-9]+}})
+// CHECK-1DWO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z0-9]+}}, ptr addrspace(1) %{{[0-9]+}})
 //
 // CHECK-2DWO: define {{.*}}spir_kernel void @{{.*}}(ptr addrspace(1) [[IMAGE_ARG:%[a-zA-Z0-9_]+]])
-// CHECK-2DWO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z]+}}, ptr addrspace(1) %{{[0-9]+}})
+// CHECK-2DWO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z0-9]+}}, ptr addrspace(1) %{{[0-9]+}})
 //
 // CHECK-3DWO: define {{.*}}spir_kernel void @{{.*}}(ptr addrspace(1) [[IMAGE_ARG:%[a-zA-Z0-9_]+]])
-// CHECK-3DWO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z]+}}, ptr addrspace(1) %{{[0-9]+}})
+// CHECK-3DWO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z0-9]+}}, ptr addrspace(1) %{{[0-9]+}})
 //
 // TODO: Add tests for the image_array opencl datatype support.
 #include "Inputs/sycl.hpp"

--- a/clang/test/CodeGenSYCL/inheritance.cpp
+++ b/clang/test/CodeGenSYCL/inheritance.cpp
@@ -56,24 +56,24 @@ int main() {
 
 // Check allocas for kernel parameters and local functor object
 // CHECK: %[[ARG_A_ALLOCA:[a-zA-Z0-9_.]+]] = alloca i32, align 4
-// CHECK: %[[LOCAL_OBJECT_ALLOCA:[a-zA-Z0-9_.]+]] = alloca %struct.derived, align 8
+// CHECK: %[[UNIONALLOCA:[a-zA-Z0-9_]+]] = alloca %union.__wrapper_union
+// CHECK: %[[LOCAL_OBJECT:[a-zA-Z0-9_.]+]] = alloca ptr addrspace(4), align 8
 // CHECK: %[[ARG_A:[a-zA-Z0-9_.]+]] = addrspacecast ptr %[[ARG_A_ALLOCA]] to ptr addrspace(4)
-// CHECK: %[[LOCAL_OBJECT:[a-zA-Z0-9_.]+]] = addrspacecast ptr %[[LOCAL_OBJECT_ALLOCA]] to ptr addrspace(4)
+// CHECK: %[[UNION:[a-zA-Z0-9_.]+]] = addrspacecast ptr %[[UNIONALLOCA]] to ptr addrspace(4)
 // CHECK: %[[ARG_BASE:[a-zA-Z0-9_.]+]] = addrspacecast ptr %_arg__base to ptr addrspace(4)
 // CHECK: %[[ARG_BASE1:[a-zA-Z0-9_.]+]] = addrspacecast ptr %_arg__base1 to ptr addrspace(4)
 // CHECK: store i32 %_arg_a, ptr addrspace(4) %[[ARG_A]], align 4
 
 // Initialize 'base' subobject
-// CHECK: call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) align 8 %[[LOCAL_OBJECT]], ptr addrspace(4) align 4 %[[ARG_BASE]], i64 12, i1 false)
+// CHECK: call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) align 8 %[[UNION]], ptr addrspace(4) align 4 %[[ARG_BASE]], i64 12, i1 false)
 
 // Initialize 'second_base' subobject
 // First, derived-to-base cast with offset:
-// CHECK: %[[OFFSET_CALC:.*]] = getelementptr inbounds i8, ptr addrspace(4) %[[LOCAL_OBJECT]], i64 16
+// CHECK: %[[OFFSET_CALC:.*]] = getelementptr inbounds i8, ptr addrspace(4) %[[UNION]], i64 16
 // Initialize 'second_base'
 // CHECK: call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) align 8 %[[OFFSET_CALC]], ptr addrspace(4) align 8 %[[ARG_BASE1]], i64 24, i1 false)
 
 // Initialize field 'a'
-// CHECK: %[[GEP_A:[a-zA-Z0-9]+]] = getelementptr inbounds %struct.derived, ptr addrspace(4) %[[LOCAL_OBJECT]], i32 0, i32 3
 // CHECK: %[[LOAD_A:[0-9]+]] = load i32, ptr addrspace(4) %[[ARG_A]], align 4
+// CHECK: %[[GEP_A:[a-zA-Z0-9]+]] = getelementptr inbounds %struct.derived, ptr addrspace(4) %[[UNION]], i32 0, i32 3
 // CHECK: store i32 %[[LOAD_A]], ptr addrspace(4) %[[GEP_A]]
-

--- a/clang/test/CodeGenSYCL/kernel-param-acc-array.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-acc-array.cpp
@@ -39,7 +39,7 @@ int main() {
 // CHECK: [[MEM_ARG2:%[a-zA-Z0-9_.]+]] = alloca ptr addrspace(1), align 8
 
 // CHECK lambda object alloca
-// CHECK: [[LOCAL_OBJECTA:%__SYCLKernel]] = alloca %class.anon, align 4
+// CHECK: [[UNION_ALLOCA:%.*]] = alloca %union.__wrapper_union, align 4
 
 // CHECK allocas for ranges
 // CHECK: [[ACC_RANGE1A:%[a-zA-Z0-9_.]+]] = alloca %"struct.sycl::_V1::range"
@@ -48,9 +48,10 @@ int main() {
 // CHECK: [[ACC_RANGE2A:%[a-zA-Z0-9_.]+]] = alloca %"struct.sycl::_V1::range"
 // CHECK: [[MEM_RANGE2A:%[a-zA-Z0-9_.]+]] = alloca %"struct.sycl::_V1::range"
 // CHECK: [[OFFSET2A:%[a-zA-Z0-9_.]+]] = alloca %"struct.sycl::_V1::id"
+// CHECK: [[FUNCTOR_PTRALLOCA:%.*]] = alloca ptr addrspace(4)
 
 // CHECK lambda object addrspacecast
-// CHECK: [[LOCAL_OBJECT:%.*]] = addrspacecast ptr [[LOCAL_OBJECTA]] to ptr addrspace(4)
+// CHECK: [[LOCAL_OBJECT:%.*]] = addrspacecast ptr [[UNION_ALLOCA]] to ptr addrspace(4)
 
 // CHECK addrspacecasts for ranges
 // CHECK: [[ACC_RANGE1AS:%.*]] = addrspacecast ptr [[ACC_RANGE1A]] to ptr addrspace(4)
@@ -59,16 +60,13 @@ int main() {
 // CHECK: [[ACC_RANGE2AS:%.*]] = addrspacecast ptr [[ACC_RANGE2A]] to ptr addrspace(4)
 // CHECK: [[MEM_RANGE2AS:%.*]] = addrspacecast ptr [[MEM_RANGE2A]] to ptr addrspace(4)
 // CHECK: [[OFFSET2AS:%.*]] = addrspacecast ptr [[OFFSET2A]] to ptr addrspace(4)
+
 // CHECK accessor array default inits
 // CHECK: [[ACCESSOR_ARRAY1:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class.anon, ptr addrspace(4) [[LOCAL_OBJECT]], i32 0, i32 0
 // CHECK: [[BEGIN:%[a-zA-Z0-9._]*]] = getelementptr inbounds [2 x [[ACCESSOR:.*]]], ptr addrspace(4) [[ACCESSOR_ARRAY1]], i64 0, i64 0
 // Clang takes advantage of element 1 having the same address as the array, so it doesn't do a GEP.
 // CTOR Call #1
 // CHECK: call spir_func void @{{.+}}(ptr addrspace(4) {{[^,]*}} [[BEGIN]])
-// CHECK: [[ELEM2_GEP:%[a-zA-Z0-9_.]+]] = getelementptr inbounds [[ACCESSOR]], ptr addrspace(4) [[BEGIN]], i64 1
-// CTOR Call #2
-// CHECK: call spir_func void @{{.+}}(ptr addrspace(4) {{[^,]*}} [[ELEM2_GEP]])
-
 // CHECK acc[0] __init method call
 // CHECK: [[ACCESSOR_ARRAY1:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class.anon, ptr addrspace(4) [[LOCAL_OBJECT]], i32 0, i32 0
 // CHECK: [[INDEX1:%[a-zA-Z0-9._]*]] = getelementptr inbounds [2 x [[ACCESSOR]]], ptr addrspace(4) [[ACCESSOR_ARRAY1]], i64 0, i64 0
@@ -78,6 +76,11 @@ int main() {
 // CHECK: [[MEM_RANGE1:%.*]] = addrspacecast ptr addrspace(4) [[MEM_RANGE1AS]] to ptr
 // CHECK: [[OFFSET1:%.*]] = addrspacecast ptr addrspace(4) [[OFFSET1AS]] to ptr
 // CHECK: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{[^,]*}} [[INDEX1]], ptr addrspace(1) noundef [[MEM_LOAD1]], ptr noundef byval({{.*}}) align 4 [[ACC_RANGE1]], ptr noundef byval({{.*}}) align 4 [[MEM_RANGE1]], ptr noundef byval({{.*}}) align 4 [[OFFSET1]])
+
+// CTOR Call #2
+// CHECK: [[ACCESSOR_ARRAY2:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class.anon, ptr addrspace(4) [[LOCAL_OBJECT]], i32 0, i32 0
+// CHECK: [[ELEM2_GEP:%[a-zA-Z0-9_.]+]] = getelementptr inbounds [2 x [[ACCESSOR]]], ptr addrspace(4) [[ACCESSOR_ARRAY2]], i64 0, i64 1
+// CHECK: call spir_func void @{{.+}}(ptr addrspace(4) {{[^,]*}} [[ELEM2_GEP]])
 
 // CHECK acc[1] __init method call
 // CHECK: [[ACCESSOR_ARRAY2:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class.anon, ptr addrspace(4) [[LOCAL_OBJECT]], i32 0, i32 0

--- a/clang/test/CodeGenSYCL/kernel-param-member-acc-array.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-member-acc-array.cpp
@@ -42,7 +42,7 @@ int main() {
 // CHECK: [[MEM_ARG1]].addr{{[0-9]*}} = alloca ptr addrspace(1), align 8
 
 // Check lambda object alloca
-// CHECK: [[LOCAL_OBJECTA:%__SYCLKernel]] = alloca %class{{.*}}.anon, align 4
+// CHECK: [[LOCAL_OBJECTA:%__wrapper_union]] = alloca %union.__wrapper_union, align 4
 
 // Check allocas for ranges
 // CHECK: [[ACC_RANGE1A:%[a-zA-Z0-9_.]+]] = alloca %"struct.sycl::_V1::range"
@@ -53,7 +53,7 @@ int main() {
 // CHECK: [[OFFSET2A:%[a-zA-Z0-9_.]+]] = alloca %"struct.sycl::_V1::id"
 
 // Check lambda object addrspacecast
-// CHECK: [[LOCAL_OBJECT:%.*]] = addrspacecast ptr %__SYCLKernel to ptr addrspace(4)
+// CHECK: [[LOCAL_OBJECT:%.*]] = addrspacecast ptr [[LOCAL_OBJECTA]] to ptr addrspace(4)
 
 // Check addrspacecast for ranges
 // CHECK: [[ACC_RANGE1AS:%.*]] = addrspacecast ptr [[ACC_RANGE1A]] to ptr addrspace(4)
@@ -69,10 +69,6 @@ int main() {
 // CHECK: [[BEGIN:%[a-zA-Z0-9._]*]] = getelementptr inbounds [2 x [[ACCESSOR:.*]]], ptr addrspace(4) [[ACCESSOR_ARRAY1]], i64 0, i64 0
 // CTOR Call #1
 // CHECK: call spir_func void @{{.+}}(ptr addrspace(4) {{[^,]*}} [[BEGIN]])
-// CHECK: [[ELEM2_GEP:%[a-zA-Z0-9_.]+]] = getelementptr inbounds [[ACCESSOR]], ptr addrspace(4) [[BEGIN]], i64 1
-// CTOR Call #2
-// CHECK: call spir_func void @{{.+}}(ptr addrspace(4) {{[^,]*}} [[ELEM2_GEP]])
-
 // Check acc[0] __init method call
 // CHECK: [[GEP_LAMBDA1:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class{{.*}}.anon, ptr addrspace(4) [[LOCAL_OBJECT]], i32 0, i32 0
 // CHECK: [[GEP_MEMBER_ACC1:%[a-zA-Z0-9_]+]] = getelementptr inbounds %struct{{.*}}.struct_acc_t, ptr addrspace(4) [[GEP_LAMBDA1]], i32 0, i32 0
@@ -82,6 +78,12 @@ int main() {
 // CHECK: [[MEM_RANGE1:%.*]] = addrspacecast ptr addrspace(4) [[MEM_RANGE1AS]] to ptr
 // CHECK: [[OFFSET1:%.*]] = addrspacecast ptr addrspace(4) [[OFFSET1AS]] to ptr
 // CHECK: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{[^,]*}} [[ARRAY_IDX1]], ptr addrspace(1) noundef [[MEM_LOAD1]], ptr noundef byval({{.*}}) align 4 [[ACC_RANGE1]], ptr noundef byval({{.*}}) align 4 [[MEM_RANGE1]], ptr noundef byval({{.*}}) align 4 [[OFFSET1]])
+
+// CHECK: [[ACCESSOR_WRAPPER:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class{{.*}}.anon, ptr addrspace(4) [[LOCAL_OBJECT]], i32 0, i32 0
+// CHECK: [[ACCESSOR_ARRAY1:%[a-zA-Z0-9_.]+]] = getelementptr inbounds %struct{{.*}}.struct_acc_t, ptr addrspace(4) [[ACCESSOR_WRAPPER]], i32 0, i32 0
+// CHECK: [[ELEM2_GEP:%[a-zA-Z0-9._]*]] = getelementptr inbounds [2 x [[ACCESSOR:.*]]], ptr addrspace(4) [[ACCESSOR_ARRAY1]], i64 0, i64 1
+// CTOR Call #2
+// CHECK: call spir_func void @{{.+}}(ptr addrspace(4) {{[^,]*}} [[ELEM2_GEP]])
 
 // Check acc[1] __init method call
 // CHECK: [[GEP_LAMBDA2:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class{{.*}}.anon, ptr addrspace(4) [[LOCAL_OBJECT]], i32 0, i32 0

--- a/clang/test/CodeGenSYCL/kernel-param-pod-array.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-pod-array.cpp
@@ -49,85 +49,36 @@ int main() {
 // CHECK-SAME:(ptr noundef byval(%struct{{.*}}.__wrapper_class) align 4 %[[ARR_ARG:.*]])
 
 // Check local lambda object alloca
-// CHECK: %[[LOCAL_OBJECTA:[a-zA-Z0-9_]+]] = alloca %class{{.*}}.anon, align 4
+// CHECK: %[[LOCAL_OBJECTA:[a-zA-Z0-9_]+]] = alloca %union{{.*}}.__wrapper_union, align 4
 // CHECK: %[[LOCAL_OBJECT:[a-zA-Z0-9_.]+]] = addrspacecast ptr %[[LOCAL_OBJECTA]] to ptr addrspace(4)
 
 // Check for Array init loop
 // CHECK: %[[LAMBDA_PTR:.+]] = getelementptr inbounds %class{{.*}}.anon, ptr addrspace(4) %[[LOCAL_OBJECT]], i32 0, i32 0
 // CHECK: %[[WRAPPER_PTR:.+]] = getelementptr inbounds %struct{{.*}}.__wrapper_class, ptr addrspace(4) %[[ARR_ARG]].ascast, i32 0, i32 0
-// CHECK: %[[ARRAY_BEGIN:.+]] = getelementptr inbounds [2 x i32], ptr addrspace(4) %[[LAMBDA_PTR]], i64 0, i64 0
-// CHECK: br label %[[ARRAYINITBODY:.+]]
-
-// The loop body itself
-// CHECK: [[ARRAYINITBODY]]:
-// CHECK: %[[ARRAYINDEX:.+]] = phi i64 [ 0, %{{.*}} ], [ %[[NEXTINDEX:.+]], %[[ARRAYINITBODY]] ]
-// CHECK: %[[TARG_ARRAY_ELEM:.+]] = getelementptr inbounds i32, ptr addrspace(4) %[[ARRAY_BEGIN]], i64 %[[ARRAYINDEX]]
-// CHECK: %[[SRC_ELEM:.+]] = getelementptr inbounds [2 x i32], ptr addrspace(4) %[[WRAPPER_PTR]], i64 0, i64 %[[ARRAYINDEX]]
-// CHECK: %[[SRC_VAL:.+]] = load i32, ptr addrspace(4) %[[SRC_ELEM]]
-// CHECK: store i32 %[[SRC_VAL]], ptr addrspace(4) %[[TARG_ARRAY_ELEM]]
-// CHECK: %[[NEXTINDEX]] = add nuw i64 %[[ARRAYINDEX]], 1
-// CHECK: %[[ISDONE:.+]] = icmp eq i64 %[[NEXTINDEX]], 2
-// CHECK: br i1 %[[ISDONE]], label %{{.*}}, label %[[ARRAYINITBODY]]
+// CHECK: call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) align 4 %[[LAMBDA_PTR]], ptr addrspace(4) align 4 %[[WRAPPER_PTR]], i64 8, i1 false)
 
 // Check kernel_C parameters
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_C
 // CHECK-SAME:(ptr noundef byval(%struct{{.*}}.__wrapper_class{{.*}}) align 4 %[[ARR_ARG:.*]])
 
 // Check local lambda object alloca
-// CHECK: %[[LOCAL_OBJECTA:[a-zA-Z0-9_]+]] = alloca %class{{.*}}.anon{{.*}}, align 4
+// CHECK: %[[LOCAL_OBJECTA:[a-zA-Z0-9_]+]] = alloca %union{{.*}}.__wrapper_union{{.*}}, align 4
 // CHECK: %[[LOCAL_OBJECT:[a-zA-Z0-9_.]+]] = addrspacecast ptr %[[LOCAL_OBJECTA]] to ptr addrspace(4)
 
 // Check for Array init loop
 // CHECK: %[[LAMBDA_PTR:.+]] = getelementptr inbounds %class{{.*}}.anon{{.*}}, ptr addrspace(4) %[[LOCAL_OBJECT]], i32 0, i32 0
 // CHECK: %[[WRAPPER_PTR:.+]] = getelementptr inbounds %struct{{.*}}.__wrapper_class{{.*}}, ptr addrspace(4) %[[ARR_ARG]].ascast, i32 0, i32 0
-// CHECK: %[[ARRAY_BEGIN:.+]] = getelementptr inbounds [2 x %struct{{.*}}.foo], ptr addrspace(4) %[[LAMBDA_PTR]], i64 0, i64 0
-// CHECK: br label %[[ARRAYINITBODY:.+]]
-
-// The loop body itself
-// CHECK: [[ARRAYINITBODY]]:
-// CHECK: %[[ARRAYINDEX:.+]] = phi i64 [ 0, %{{.*}} ], [ %[[NEXTINDEX:.+]], %[[ARRAYINITBODY]] ]
-// CHECK: %[[TARG_ARRAY_ELEM:.+]] = getelementptr inbounds %struct{{.*}}.foo, ptr addrspace(4) %[[ARRAY_BEGIN]], i64 %[[ARRAYINDEX]]
-// CHECK: %[[SRC_ELEM:.+]] = getelementptr inbounds [2 x %struct{{.*}}.foo], ptr addrspace(4) %[[WRAPPER_PTR]], i64 0, i64 %[[ARRAYINDEX]]
-// call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) align 4 %[[TARG_ARRAY_ELEM]], ptr addrspace(4) align %[[SRC_ELEM]], i64 24, i1 false)
-// CHECK: %[[NEXTINDEX]] = add nuw i64 %[[ARRAYINDEX]], 1
-// CHECK: %[[ISDONE:.+]] = icmp eq i64 %[[NEXTINDEX]], 2
-// CHECK: br i1 %[[ISDONE]], label %{{.*}}, label %[[ARRAYINITBODY]]
+// CHECK: call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) align 4 %[[LAMBDA_PTR]], ptr addrspace(4) align 4 %[[WRAPPER_PTR]], i64 48, i1 false)
 
 // Check kernel_D parameters
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_D
 // CHECK-SAME:(ptr noundef byval(%struct{{.*}}.__wrapper_class{{.*}}) align 4 %[[ARR_ARG:.*]])
 
 // Check local lambda object alloca
-// CHECK: %[[LOCAL_OBJECTA:[a-zA-Z0-9_]+]] = alloca %class{{.*}}.anon{{.*}}, align 4
+// CHECK: %[[LOCAL_OBJECTA:[a-zA-Z0-9_]+]] = alloca %union{{.*}}.__wrapper_union{{.*}}, align 4
 // CHECK: %[[LOCAL_OBJECT:[a-zA-Z0-9_.]+]] = addrspacecast ptr %[[LOCAL_OBJECTA]] to ptr addrspace(4)
 
 // Check for Array init loop
 // CHECK: %[[LAMBDA_PTR:.+]] = getelementptr inbounds %class{{.*}}.anon{{.*}}, ptr addrspace(4) %[[LOCAL_OBJECT]], i32 0, i32 0
 // CHECK: %[[WRAPPER_PTR:.+]] = getelementptr inbounds %struct{{.*}}.__wrapper_class{{.*}}, ptr addrspace(4) %[[ARR_ARG]].ascast, i32 0, i32 0
-// CHECK: %[[ARRAY_BEGIN:.+]] = getelementptr inbounds [2 x [1 x i32]], ptr addrspace(4) %[[LAMBDA_PTR]], i64 0, i64 0
-// CHECK: br label %[[ARRAYINITBODY:.+]]
-
-// Check Outer loop.
-// CHECK: [[ARRAYINITBODY]]:
-// CHECK: %[[ARRAYINDEX:.+]] = phi i64 [ 0, %{{.*}} ], [ %[[NEXTINDEX:.+]], %[[ARRAYINITEND:.+]] ]
-// CHECK: %[[TARG_OUTER_ELEM:.+]] = getelementptr inbounds [1 x i32], ptr addrspace(4) %[[ARRAY_BEGIN]], i64 %[[ARRAYINDEX]]
-// CHECK: %[[SRC_OUTER_ELEM:.+]] = getelementptr inbounds [2 x [1 x i32]], ptr addrspace(4) %[[WRAPPER_PTR]], i64 0, i64 %[[ARRAYINDEX]]
-// CHECK: %[[ARRAY_BEGIN_INNER:.+]] = getelementptr inbounds [1 x i32], ptr addrspace(4) %[[TARG_OUTER_ELEM]], i64 0, i64 0
-// CHECK: br label %[[ARRAYINITBODY_INNER:.+]]
-
-// Check Inner Loop
-// CHECK: [[ARRAYINITBODY_INNER]]:
-// CHECK: %[[ARRAYINDEX_INNER:.+]] = phi i64 [ 0, %{{.*}} ], [ %[[NEXTINDEX_INNER:.+]], %[[ARRAYINITBODY_INNER:.+]] ]
-// CHECK: %[[TARG_INNER_ELEM:.+]] = getelementptr inbounds i32, ptr addrspace(4) %[[ARRAY_BEGIN_INNER]], i64 %[[ARRAYINDEX_INNER]]
-// CHECK: %[[SRC_INNER_ELEM:.+]] = getelementptr inbounds [1 x i32], ptr addrspace(4) %[[SRC_OUTER_ELEM]], i64 0, i64 %[[ARRAYINDEX_INNER]]
-// CHECK: %[[SRC_LOAD:.+]] = load i32, ptr addrspace(4) %[[SRC_INNER_ELEM]]
-// CHECK: store i32 %[[SRC_LOAD]], ptr addrspace(4) %[[TARG_INNER_ELEM]]
-// CHECK: %[[NEXTINDEX_INNER]] = add nuw i64 %[[ARRAYINDEX_INNER]], 1
-// CHECK: %[[ISDONE_INNER:.+]] = icmp eq i64 %[[NEXTINDEX_INNER]], 1
-// CHECK: br i1 %[[ISDONE_INNER]], label %[[ARRAYINITEND]], label %[[ARRAYINITBODY_INNER]]
-
-// Check Inner loop 'end'
-// CHECK: [[ARRAYINITEND]]:
-// CHECK: %[[NEXTINDEX]] = add nuw i64 %[[ARRAYINDEX]], 1
-// CHECK: %[[ISDONE:.+]] = icmp eq i64 %[[NEXTINDEX]], 2
-// CHECK: br i1 %[[ISDONE]], label %{{.*}}, label %[[ARRAYINITBODY]]
+// CHECK: call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) align 4 %[[LAMBDA_PTR]], ptr addrspace(4) align 4 %[[WRAPPER_PTR]], i64 8, i1 false)

--- a/clang/test/CodeGenSYCL/kernel_binding_decls.cpp
+++ b/clang/test/CodeGenSYCL/kernel_binding_decls.cpp
@@ -25,22 +25,24 @@ void foo() {
 // Check alloca of the captured types
 // CHECK: %_arg_x.addr = alloca i32, align 4
 // CHECK: %_arg_f2.addr = alloca float, align 4
-// CHECK: %__SYCLKernel = alloca %class.anon, align 4
+// CHECK: %__wrapper_union = alloca %union.__wrapper_union, align 4
 
 // Copy the parameters into the alloca-ed addresses
 // CHECK: store i32 %_arg_x, ptr addrspace(4) %_arg_x.addr
 // CHECK: store float %_arg_f2, ptr addrspace(4) %_arg_f2.addr
 
 // Store the int and the float into the struct created
-// CHECK: %x = getelementptr inbounds %class.anon, ptr addrspace(4) %__SYCLKernel{{.*}}, i32 0, i32 0
-// CHECK: %0 = load i32, ptr addrspace(4) %_arg_x.addr
-// CHECK: store i32 %0, ptr addrspace(4) %x
-// CHECK: %f2 = getelementptr inbounds %class.anon, ptr addrspace(4) %__SYCLKernel{{.*}}, i32 0, i32 1
-// CHECK: %1 = load float, ptr addrspace(4) %_arg_f2.addr
-// CHECK: store float %1, ptr addrspace(4) %f2
+// CHECK: %[[X_VALUE:[A-Za-z0-9]*]] = load i32, ptr addrspace(4) %_arg_x.addr
+// CHECK: %x = getelementptr inbounds %class.anon, ptr addrspace(4) %__wrapper_union{{.*}}, i32 0, i32 0
+// CHECK: store i32 %[[X_VALUE]], ptr addrspace(4) %x
+// CHECK: %[[F2_VALUE:[A-Za-z0-9]*]] = load float, ptr addrspace(4) %_arg_f2.addr
+// CHECK: %f2 = getelementptr inbounds %class.anon, ptr addrspace(4) %__wrapper_union{{.*}}, i32 0, i32 1
+// CHECK: store float %[[F2_VALUE]], ptr addrspace(4) %f2
 
 // Call the lambda
-// CHECK: call spir_func void @{{.*}}foo{{.*}}(ptr addrspace(4) {{.*}} %__SYCLKernel{{.*}})
+// CHECK: store ptr addrspace(4) %__wrapper_union{{.*}}, ptr addrspace(4) %[[KERNEL_REF_ADDR:[A-Za-z0-9]*]]
+// CHECK: %[[KERNEL_REF:[A-Za-z0-9]*]] = load ptr addrspace(4), ptr addrspace(4) %[[KERNEL_REF_ADDR]]
+// CHECK: call spir_func void @{{.*}}foo{{.*}}(ptr addrspace(4) {{.*}} %[[KERNEL_REF]])
 // CHECK:   ret void
 
 // Check the lambda call

--- a/clang/test/CodeGenSYCL/max-concurrency.cpp
+++ b/clang/test/CodeGenSYCL/max-concurrency.cpp
@@ -23,14 +23,18 @@
 // CHECK: entry:
 // CHECK: [[F1:%.*]] = alloca [[CLASS_F1:%.*]], align 1
 // CHECK: [[F1_ASCAST:%.*]] = addrspacecast ptr [[F1]] to ptr addrspace(4)
-// CHECK: call spir_func void @_ZNK8Functor1clEv(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) [[F1_ASCAST]])
+// CHECK: store ptr addrspace(4) [[F1_ASCAST]], ptr addrspace(4) [[F1_STACK:%.*]], align 8
+// CHECK: [[K:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[F1_STACK]], align 8
+// CHECK: call spir_func void @_ZNK8Functor1clEv(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) [[K]])
 // CHECK: ret void
 
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name4() [[ATTR0]] {{.*}} !max_concurrency ![[NUM1:[0-9]+]]
 // CHECK: entry
 // CHECK: [[F3:%.*]] = alloca [[CLASS_F3:%.*]], align 1
 // CHECK: [[F3_ASCAST:%.*]] = addrspacecast ptr [[F3]] to ptr addrspace(4)
-// CHECK: call spir_func void @_ZNK8Functor3ILi4EEclEv(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) [[F3_ASCAST]])
+// CHECK: store ptr addrspace(4) [[F3_ASCAST]], ptr addrspace(4) [[F3_STACK:%.*]], align 8
+// CHECK: [[K:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[F3_STACK]], align 8
+// CHECK: call spir_func void @_ZNK8Functor3ILi4EEclEv(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) [[K]])
 // CHECK: ret void
 
 // CHECK: define linkonce_odr spir_func void @_ZNK8Functor3ILi4EEclEv
@@ -45,7 +49,9 @@
 // CHECK: entry:
 // CHECK: [[H1:%.*]] = alloca [[H:%.*]], align 1
 // CHECK: [[H2:%.*]] = addrspacecast ptr [[H1]] to ptr addrspace(4)
-// CHECK: call spir_func void @_ZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEv(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) [[H2]])
+// CHECK: store ptr addrspace(4) [[H2]], ptr addrspace(4) [[H_STACK:%.*]], align 8
+// CHECK: [[K:%.*]] = load ptr addrspace(4), ptr addrspace(4) [[H_STACK]], align 8
+// CHECK: call spir_func void @_ZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEv(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) [[K]])
 // CHECK: ret void
 
 // CHECK: define {{.*}}spir_func void @_ZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEv

--- a/clang/test/CodeGenSYCL/no-opaque-generated-types-initialization.cpp
+++ b/clang/test/CodeGenSYCL/no-opaque-generated-types-initialization.cpp
@@ -41,37 +41,43 @@ int main() {
 // CHECK: define dso_local spir_kernel void @{{.*}}basic(%struct.__generated_B* noundef byval(%struct.__generated_B) align 8 %_arg_Obj)
 //
 // Kernel object clone.
-// CHECK: %[[K:[a-zA-Z0-9_.]+]] = alloca %class.anon
-// CHECK: %[[K_as_cast:[a-zA-Z0-9_.]+]] = addrspacecast %class.anon* %[[K]] to %class.anon addrspace(4)*
+// CHECK: %[[K:[a-zA-Z0-9_.]+]] = alloca %union.__wrapper_union
+// CHECK: %[[K_as_cast:[a-zA-Z0-9_.]+]] = addrspacecast %union.__wrapper_union* %[[K]] to %union.__wrapper_union addrspace(4)*
 //
 // Argument reference.
 // CHECK: %[[Arg_ref:[a-zA-Z0-9_.]+]] = addrspacecast %struct.__generated_B* %_arg_Obj to %struct.__generated_B addrspace(4)*
 
 // Initialization.
-// CHECK: %[[GEP:[a-zA-Z0-9_.]+]] = getelementptr inbounds %class.anon, %class.anon addrspace(4)* %[[K_as_cast]], i32 0, i32 0
-// CHECK: %[[ArgBC:[a-zA-Z0-9_.]+]] = bitcast %struct.__generated_B addrspace(4)* %[[Arg_ref]] to %struct.B addrspace(4)*
+// CHECK: %[[K_BC:[a-zA-Z0-9_.]+]] = bitcast %union.__wrapper_union addrspace(4)* %[[K_as_cast]] to %class.anon addrspace(4)*
+// CHECK: %[[GEP:[a-zA-Z0-9_.]+]] = getelementptr inbounds %class.anon, %class.anon addrspace(4)* %[[K_BC]], i32 0, i32 0
 // CHECK: %[[GEPBC:[a-zA-Z0-9_.]+]] = bitcast %struct.B addrspace(4)* %[[GEP]] to i8 addrspace(4)*
-// CHECK: %[[ArgBC2:[a-zA-Z0-9_.]+]] = bitcast %struct.B addrspace(4)* %[[ArgBC]] to i8 addrspace(4)*
-// CHECK: call void @llvm.memcpy.p4i8.p4i8.i64(i8 addrspace(4)* align 8 %[[GEPBC]], i8 addrspace(4)* align 8 %[[ArgBC2]], i64 16, i1 false)
+// CHECK: %[[ArgBC:[a-zA-Z0-9_.]+]] = bitcast %struct.__generated_B addrspace(4)* %[[Arg_ref]] to i8 addrspace(4)*
+// CHECK: call void @llvm.memcpy.p4i8.p4i8.i64(i8 addrspace(4)* align 8 %[[GEPBC]], i8 addrspace(4)* align 8 %[[ArgBC]], i64 16, i1 false)
 //
 // Kernel body call.
-// CHECK: call spir_func void @_ZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEv(%class.anon addrspace(4)* noundef align 8 dereferenceable_or_null(16) %[[K_as_cast]])
+// CHECK: %[[K_BC:[a-zA-Z0-9_.]+]] = bitcast %union.__wrapper_union addrspace(4)* %[[K_as_cast]] to %class.anon addrspace(4)*
+// CHECK: store %class.anon addrspace(4)* %[[K_BC]], %class.anon addrspace(4)* addrspace(4)* %[[K_STACK_PTR:[a-zA-Z0-9_.]+]]
+// CHECK: %[[K_PTR:[a-zA-Z0-9_.]+]] = load %class.anon addrspace(4)*, %class.anon addrspace(4)* addrspace(4)* %[[K_STACK_PTR]]
+// CHECK: call spir_func void @_ZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEv(%class.anon addrspace(4)* noundef align 8 dereferenceable_or_null(16) %[[K_PTR]])
 
 // CHECK: define dso_local spir_kernel void @{{.*}}nns(%struct.__generated_B.0* noundef byval(%struct.__generated_B.0) align 8 %_arg_NNSObj)
 //
 // Kernel object clone.
-// CHECK: %[[NNSK:[a-zA-Z0-9_.]+]] = alloca %class.anon.2
-// CHECK: %[[NNSK_as_cast:[a-zA-Z0-9_.]+]] = addrspacecast %class.anon.2* %[[NNSK]] to %class.anon.2 addrspace(4)*
+// CHECK: %[[NNSK:[a-zA-Z0-9_.]+]] = alloca %union.__wrapper_union.2
+// CHECK: %[[NNSK_as_cast:[a-zA-Z0-9_.]+]] = addrspacecast %union.__wrapper_union.2* %[[NNSK]] to %union.__wrapper_union.2 addrspace(4)*
 //
 // Argument reference.
 // CHECK: %[[NNSArg_ref:[a-zA-Z0-9_.]+]] = addrspacecast %struct.__generated_B.0* %_arg_NNSObj to %struct.__generated_B.0 addrspace(4)*
 //
 // Initialization.
-// CHECK: %[[NNSGEP:[a-zA-Z0-9_.]+]] = getelementptr inbounds %class.anon.2, %class.anon.2 addrspace(4)* %[[NNSK_as_cast]], i32 0, i32 0
-// CHECK: %[[NNSArgBC:[a-zA-Z0-9_.]+]] = bitcast %struct.__generated_B.0 addrspace(4)* %[[NNSArg_ref]] to %struct.B addrspace(4)*
+// CHECK: %[[NNSK_BC:[a-zA-Z0-9_.]+]] = bitcast %union.__wrapper_union.2 addrspace(4)* %[[NNSK_as_cast]] to %class.anon.3 addrspace(4)*
+// CHECK: %[[NNSGEP:[a-zA-Z0-9_.]+]] = getelementptr inbounds %class.anon.3, %class.anon.3 addrspace(4)* %[[NNSK_BC]], i32 0, i32 0
 // CHECK: %[[NNSGEPBC:[a-zA-Z0-9_.]+]] = bitcast %struct.B addrspace(4)* %[[NNSGEP]] to i8 addrspace(4)*
-// CHECK: %[[NNSArgBC2:[a-zA-Z0-9_.]+]] = bitcast %struct.B addrspace(4)* %[[NNSArgBC]] to i8 addrspace(4)*
-// CHECK: call void @llvm.memcpy.p4i8.p4i8.i64(i8 addrspace(4)* align 8 %[[NNSGEPBC]], i8 addrspace(4)* align 8 %[[NNSArgBC2]], i64 16, i1 false)
+// CHECK: %[[NNSArgBC:[a-zA-Z0-9_.]+]] = bitcast %struct.__generated_B.0 addrspace(4)* %[[NNSArg_ref]] to i8 addrspace(4)*
+// CHECK: call void @llvm.memcpy.p4i8.p4i8.i64(i8 addrspace(4)* align 8 %[[NNSGEPBC]], i8 addrspace(4)* align 8 %[[NNSArgBC]], i64 16, i1 false)
 //
 // Kernel body call.
-// CHECK: call spir_func void @_ZZZ4mainENKUlRN4sycl3_V17handlerEE0_clES2_ENKUlvE_clEv(%class.anon.2 addrspace(4)* noundef align 8 dereferenceable_or_null(16) %[[NNSK_as_cast]])
+// CHECK: %[[NNSK_BC:[a-zA-Z0-9_.]+]] = bitcast %union.__wrapper_union.2 addrspace(4)* %[[NNSK_as_cast]] to %class.anon.3 addrspace(4)*
+// CHECK: store %class.anon.3 addrspace(4)* %[[NNSK_BC]], %class.anon.3 addrspace(4)* addrspace(4)* %[[NNSK_STACK_PTR:[a-zA-Z0-9_.]+]]
+// CHECK: %[[NNSK_PTR:[a-zA-Z0-9_.]+]] = load %class.anon.3 addrspace(4)*, %class.anon.3 addrspace(4)* addrspace(4)* %[[NNSK_STACK_PTR]]
+// CHECK: call spir_func void @_ZZZ4mainENKUlRN4sycl3_V17handlerEE0_clES2_ENKUlvE_clEv(%class.anon.3 addrspace(4)* noundef align 8 dereferenceable_or_null(16) %[[NNSK_PTR]])

--- a/clang/test/CodeGenSYCL/no-opaque-ptr-kernel_binding_decls.cpp
+++ b/clang/test/CodeGenSYCL/no-opaque-ptr-kernel_binding_decls.cpp
@@ -25,22 +25,27 @@ void foo() {
 // Check alloca of the captured types
 // CHECK: %_arg_x.addr = alloca i32, align 4
 // CHECK: %_arg_f2.addr = alloca float, align 4
-// CHECK: %__SYCLKernel = alloca %class.anon, align 4
+// CHECK: [[FUNCTOR:%__wrapper_union]] = alloca %union.__wrapper_union, align 4
 
 // Copy the parameters into the alloca-ed addresses
 // CHECK: store i32 %_arg_x, i32 addrspace(4)* %_arg_x.addr
 // CHECK: store float %_arg_f2, float addrspace(4)* %_arg_f2.addr
 
 // Store the int and the float into the struct created
-// CHECK: %x = getelementptr inbounds %class.anon, %class.anon addrspace(4)* %__SYCLKernel{{.*}}, i32 0, i32 0
-// CHECK: %0 = load i32, i32 addrspace(4)* %_arg_x.addr
-// CHECK: store i32 %0, i32 addrspace(4)* %x
-// CHECK: %f2 = getelementptr inbounds %class.anon, %class.anon addrspace(4)* %__SYCLKernel{{.*}}, i32 0, i32 1
-// CHECK: %1 = load float, float addrspace(4)* %_arg_f2.addr
-// CHECK: store float %1, float addrspace(4)* %f2
+// CHECK: [[X_ARG:%[0-9a-zA-Z_.]+]] = load i32, i32 addrspace(4)* %_arg_x.addr
+// CHECK: [[FUNCTOR_BC:%[0-9a-zA-Z_.]+]] = bitcast %union.__wrapper_union addrspace(4)* [[FUNCTOR]].ascast to %class.anon addrspace(4)*
+// CHECK: %x = getelementptr inbounds %class.anon, %class.anon addrspace(4)* [[FUNCTOR_BC]], i32 0, i32 0
+// CHECK: store i32 [[X_ARG]], i32 addrspace(4)* %x
+// CHECK: [[F2_ARG:%[0-9a-zA-Z_.]+]] = load float, float addrspace(4)* %_arg_f2.addr
+// CHECK: [[FUNCTOR_BC:%[0-9a-zA-Z_.]+]] = bitcast %union.__wrapper_union addrspace(4)* [[FUNCTOR]].ascast to %class.anon addrspace(4)*
+// CHECK: %f2 = getelementptr inbounds %class.anon, %class.anon addrspace(4)* [[FUNCTOR_BC]], i32 0, i32 1
+// CHECK: store float [[F2_ARG]], float addrspace(4)* %f2
 
 // Call the lambda
-// CHECK: call spir_func void @{{.*}}foo{{.*}}(%class.anon addrspace(4)* {{.*}} %__SYCLKernel{{.*}})
+// CHECK: [[FUNCTOR_BC:%[0-9a-zA-Z_.]+]] = bitcast %union.__wrapper_union addrspace(4)* [[FUNCTOR]].ascast to %class.anon addrspace(4)*
+// CHECK: store %class.anon addrspace(4)* [[FUNCTOR_BC]], %class.anon addrspace(4)* addrspace(4)* [[K_PTR:%[0-9a-zA-Z_.]+]]
+// CHECK: [[THIS:%[0-9a-zA-Z_.]+]] = load %class.anon addrspace(4)*, %class.anon addrspace(4)* addrspace(4)* [[K_PTR]]
+// CHECK: call spir_func void @{{.*}}foo{{.*}}(%class.anon addrspace(4)* {{.*}} [[THIS]])
 // CHECK:   ret void
 
 // Check the lambda call

--- a/clang/test/CodeGenSYCL/no_opaque_basic-kernel-wrapper.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_basic-kernel-wrapper.cpp
@@ -27,12 +27,12 @@ int main() {
 // Check alloca for pointer argument
 // CHECK: [[MEM_ARG]].addr = alloca i32 addrspace(1)*
 // Check lambda object alloca
-// CHECK: [[ANONALLOCA:%[a-zA-Z0-9_]+]] = alloca %class.anon
+// CHECK: [[UNIONALLOCA:%[a-zA-Z0-9_]+]] = alloca %union.__wrapper_union
 // Check allocas for ranges
 // CHECK: [[ARANGEA:%agg.tmp.*]] = alloca %"struct.sycl::_V1::range"
 // CHECK: [[MRANGEA:%agg.tmp.*]] = alloca %"struct.sycl::_V1::range"
 // CHECK: [[OIDA:%agg.tmp.*]] = alloca %"struct.sycl::_V1::id"
-// CHECK: [[ANON:%[a-zA-Z0-9_.]+]] = addrspacecast %class.anon* [[ANONALLOCA]] to %class.anon addrspace(4)*
+// CHECK: [[UNION:%[a-zA-Z0-9_.]+]] = addrspacecast %union.__wrapper_union* [[UNIONALLOCA]] to %union.__wrapper_union addrspace(4)*
 // CHECK: [[ARANGET:%agg.tmp.*]] = addrspacecast %"struct.sycl::_V1::range"* [[ARANGEA]] to %"struct.sycl::_V1::range" addrspace(4)*
 // CHECK: [[MRANGET:%agg.tmp.*]] = addrspacecast %"struct.sycl::_V1::range"* [[MRANGEA]] to %"struct.sycl::_V1::range" addrspace(4)*
 // CHECK: [[OIDT:%agg.tmp.*]] = addrspacecast %"struct.sycl::_V1::id"* [[OIDA]] to %"struct.sycl::_V1::id" addrspace(4)*
@@ -44,6 +44,7 @@ int main() {
 // CHECK: call spir_func {{.*}}accessor
 
 // Check accessor GEP
+// CHECK: [[ANON:%[a-zA-Z0-9_]+]] = bitcast %union.__wrapper_union addrspace(4)* [[UNION]] to %class.anon addrspace(4)*
 // CHECK: [[ACCESSOR:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class.anon, %class.anon addrspace(4)* [[ANON]], i32 0, i32 0
 
 // Check load from kernel pointer argument alloca

--- a/clang/test/CodeGenSYCL/no_opaque_check-direct-attribute-propagation.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_check-direct-attribute-propagation.cpp
@@ -317,7 +317,7 @@ int main() {
 
     // Test attribute is not propagated.
     // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name32() #0{{.*}} !kernel_arg_buffer_location ![[NUM]]
-    // CHECK: define {{.*}}spir_func void @{{.*}}Functor10{{.*}}(%class.Functor10 addrspace(4)* noundef align 1 dereferenceable_or_null(1) %this) #3 comdat align 2
+    // CHECK: define {{.*}}spir_func void @{{.*}}Functor10{{.*}}(%class.Functor10 addrspace(4)* noundef align 1 dereferenceable_or_null(1) %this) #2 comdat align 2
     // CHECK-NOT: noalias
     // CHECK-SAME: {
     // CHECK: define dso_local spir_func void @_Z4foo8v()
@@ -325,12 +325,12 @@ int main() {
     h.single_task<class kernel_name32>(f10);
 
     // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name33() #0{{.*}} !kernel_arg_buffer_location ![[NUM]]
-    // CHECK: define {{.*}}spir_func void @{{.*}}Foo8{{.*}}(%class.Foo8 addrspace(4)* noalias noundef align 1 dereferenceable_or_null(1) %this) #3 comdat align 2
+    // CHECK: define {{.*}}spir_func void @{{.*}}Foo8{{.*}}(%class.Foo8 addrspace(4)* noalias noundef align 1 dereferenceable_or_null(1) %this) #2 comdat align 2
     Foo8 boo8;
     h.single_task<class kernel_name33>(boo8);
 
     // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name34() #0{{.*}} !kernel_arg_buffer_location ![[NUM]]
-    // CHECK: define {{.*}}spir_func void @{{.*}}(%class.anon{{.*}} addrspace(4)* noalias noundef align 1 dereferenceable_or_null(1) %this) #4 align 2
+    // CHECK: define {{.*}}spir_func void @{{.*}}(%class.anon{{.*}} addrspace(4)* noalias noundef align 1 dereferenceable_or_null(1) %this) #3 align 2
     h.single_task<class kernel_name34>(
         []() [[intel::kernel_args_restrict]]{});
 

--- a/clang/test/CodeGenSYCL/no_opaque_image_accessor.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_image_accessor.cpp
@@ -8,27 +8,27 @@
 //
 // CHECK-1DRO: %opencl.image1d_ro_t = type opaque
 // CHECK-1DRO: define {{.*}}spir_kernel void @{{.*}}(%opencl.image1d_ro_t addrspace(1)* [[IMAGE_ARG:%[a-zA-Z0-9_]+]])
-// CHECK-1DRO: call spir_func void @{{.*}}__init{{.*}}(%{{.*}}sycl::_V1::accessor{{.*}} %{{[a-zA-Z]+}}, %opencl.image1d_ro_t addrspace(1)* %{{[0-9]+}})
-//
+// CHECK-1DRO: call spir_func void @{{.*}}__init{{.*}}(%{{.*}}sycl::_V1::accessor{{.*}} %{{[a-zA-Z0-9]+}}, %opencl.image1d_ro_t addrspace(1)* %{{[0-9]+}})
+
 // CHECK-2DRO: %opencl.image2d_ro_t = type opaque
 // CHECK-2DRO: define {{.*}}spir_kernel void @{{.*}}(%opencl.image2d_ro_t addrspace(1)* [[IMAGE_ARG:%[a-zA-Z0-9_]+]])
-// CHECK-2DRO: call spir_func void @{{.*}}__init{{.*}}(%{{.*}}sycl::_V1::accessor{{.*}} %{{[a-zA-Z]+}}, %opencl.image2d_ro_t addrspace(1)* %{{[0-9]+}})
+// CHECK-2DRO: call spir_func void @{{.*}}__init{{.*}}(%{{.*}}sycl::_V1::accessor{{.*}} %{{[a-zA-Z0-9]+}}, %opencl.image2d_ro_t addrspace(1)* %{{[0-9]+}})
 //
 // CHECK-3DRO: %opencl.image3d_ro_t = type opaque
 // CHECK-3DRO: define {{.*}}spir_kernel void @{{.*}}(%opencl.image3d_ro_t addrspace(1)* [[IMAGE_ARG:%[a-zA-Z0-9_]+]])
-// CHECK-3DRO: call spir_func void @{{.*}}__init{{.*}}(%{{.*}}sycl::_V1::accessor{{.*}} %{{[a-zA-Z]+}}, %opencl.image3d_ro_t addrspace(1)* %{{[0-9]+}})
+// CHECK-3DRO: call spir_func void @{{.*}}__init{{.*}}(%{{.*}}sycl::_V1::accessor{{.*}} %{{[a-zA-Z0-9]+}}, %opencl.image3d_ro_t addrspace(1)* %{{[0-9]+}})
 //
 // CHECK-1DWO: %opencl.image1d_wo_t = type opaque
 // CHECK-1DWO: define {{.*}}spir_kernel void @{{.*}}(%opencl.image1d_wo_t addrspace(1)* [[IMAGE_ARG:%[a-zA-Z0-9_]+]])
-// CHECK-1DWO: call spir_func void @{{.*}}__init{{.*}}(%{{.*}}sycl::_V1::accessor{{.*}} %{{[a-zA-Z]+}}, %opencl.image1d_wo_t addrspace(1)* %{{[0-9]+}})
+// CHECK-1DWO: call spir_func void @{{.*}}__init{{.*}}(%{{.*}}sycl::_V1::accessor{{.*}} %{{[a-zA-Z0-9]+}}, %opencl.image1d_wo_t addrspace(1)* %{{[0-9]+}})
 //
 // CHECK-2DWO: %opencl.image2d_wo_t = type opaque
 // CHECK-2DWO: define {{.*}}spir_kernel void @{{.*}}(%opencl.image2d_wo_t addrspace(1)* [[IMAGE_ARG:%[a-zA-Z0-9_]+]])
-// CHECK-2DWO: call spir_func void @{{.*}}__init{{.*}}(%{{.*}}sycl::_V1::accessor{{.*}} %{{[a-zA-Z]+}}, %opencl.image2d_wo_t addrspace(1)* %{{[0-9]+}})
+// CHECK-2DWO: call spir_func void @{{.*}}__init{{.*}}(%{{.*}}sycl::_V1::accessor{{.*}} %{{[a-zA-Z0-9]+}}, %opencl.image2d_wo_t addrspace(1)* %{{[0-9]+}})
 //
 // CHECK-3DWO: %opencl.image3d_wo_t = type opaque
 // CHECK-3DWO: define {{.*}}spir_kernel void @{{.*}}(%opencl.image3d_wo_t addrspace(1)* [[IMAGE_ARG:%[a-zA-Z0-9_]+]])
-// CHECK-3DWO: call spir_func void @{{.*}}__init{{.*}}(%{{.*}}sycl::_V1::accessor{{.*}} %{{[a-zA-Z]+}}, %opencl.image3d_wo_t addrspace(1)* %{{[0-9]+}})
+// CHECK-3DWO: call spir_func void @{{.*}}__init{{.*}}(%{{.*}}sycl::_V1::accessor{{.*}} %{{[a-zA-Z0-9]+}}, %opencl.image3d_wo_t addrspace(1)* %{{[0-9]+}})
 //
 // TODO: Add tests for the image_array opencl datatype support.
 #include "Inputs/sycl.hpp"

--- a/clang/test/CodeGenSYCL/no_opaque_inheritance.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_inheritance.cpp
@@ -54,31 +54,33 @@ int main() {
 
 // Check allocas for kernel parameters and local functor object
 // CHECK: %[[ARG_A_ALLOCA:[a-zA-Z0-9_.]+]] = alloca i32, align 4
-// CHECK: %[[LOCAL_OBJECT_ALLOCA:[a-zA-Z0-9_.]+]] = alloca %struct.derived, align 8
+// CHECK: %[[LOCAL_OBJECT_ALLOCA:[a-zA-Z0-9_.]+]] = alloca %union.__wrapper_union, align 8
 // CHECK: %[[ARG_A:[a-zA-Z0-9_.]+]] = addrspacecast i32* %[[ARG_A_ALLOCA]] to i32 addrspace(4)*
-// CHECK: %[[LOCAL_OBJECT:[a-zA-Z0-9_.]+]] = addrspacecast %struct.derived* %[[LOCAL_OBJECT_ALLOCA]] to %struct.derived addrspace(4)*
+// CHECK: %[[LOCAL_OBJECT:[a-zA-Z0-9_.]+]] = addrspacecast %union.__wrapper_union* %[[LOCAL_OBJECT_ALLOCA]] to %union.__wrapper_union addrspace(4)*
 // CHECK: %[[ARG_BASE:[a-zA-Z0-9_.]+]] = addrspacecast %struct.base* %_arg__base to %struct.base addrspace(4)*
 // CHECK: %[[ARG_BASE1:[a-zA-Z0-9_.]+]] = addrspacecast %class.__generated_second_base* %_arg__base1 to %class.__generated_second_base addrspace(4)*
 // CHECK: store i32 %_arg_a, i32 addrspace(4)* %[[ARG_A]], align 4
 
 // Initialize 'base' subobject
-// CHECK: %[[DERIVED_TO_BASE:.*]] = bitcast %struct.derived addrspace(4)* %[[LOCAL_OBJECT]] to %struct.base addrspace(4)*
+// CHECK: %[[DERIVED_PTR:.*]] = bitcast %union.__wrapper_union addrspace(4)* %[[LOCAL_OBJECT]] to %struct.derived addrspace(4)*
+// CHECK: %[[DERIVED_TO_BASE:.*]] = bitcast %struct.derived addrspace(4)* %[[DERIVED_PTR]] to %struct.base addrspace(4)*
 // CHECK: %[[BASE_TO_PTR:.*]] = bitcast %struct.base addrspace(4)* %[[DERIVED_TO_BASE]] to i8 addrspace(4)*
 // CHECK: %[[PARAM_TO_PTR:.*]] = bitcast %struct.base addrspace(4)* %[[ARG_BASE]] to i8 addrspace(4)*
 // CHECK: call void @llvm.memcpy.p4i8.p4i8.i64(i8 addrspace(4)* align 8 %[[BASE_TO_PTR]], i8 addrspace(4)* align 4 %[[PARAM_TO_PTR]], i64 12, i1 false)
 
 // Initialize 'second_base' subobject
 // First, derived-to-base cast with offset:
-// CHECK: %[[DERIVED_PTR:.*]] = bitcast %struct.derived addrspace(4)* %[[LOCAL_OBJECT]] to i8 addrspace(4)*
-// CHECK: %[[OFFSET_CALC:.*]] = getelementptr inbounds i8, i8 addrspace(4)* %[[DERIVED_PTR]], i64 16
+// CHECK: %[[DERIVED_PTR:.*]] = bitcast %union.__wrapper_union addrspace(4)* %[[LOCAL_OBJECT]] to %struct.derived addrspace(4)*
+// CHECK: %[[BASE_PTR:.*]] = bitcast %struct.derived addrspace(4)* %[[DERIVED_PTR]] to i8 addrspace(4)*
+// CHECK: %[[OFFSET_CALC:.*]] = getelementptr inbounds i8, i8 addrspace(4)* %[[BASE_PTR]], i64 16
 // CHECK: %[[TO_SECOND_BASE:.*]] = bitcast i8 addrspace(4)* %[[OFFSET_CALC]] to %class.second_base addrspace(4)*
-// CHECK: %[[GEN_TO_SECOND_BASE:.*]] = bitcast %class.__generated_second_base addrspace(4)* %[[ARG_BASE1]] to %class.second_base addrspace(4)*
 // CHECK: %[[TO:.*]] = bitcast %class.second_base addrspace(4)* %[[TO_SECOND_BASE]] to i8 addrspace(4)*
-// CHECK: %[[FROM:.*]] = bitcast %class.second_base addrspace(4)* %[[GEN_TO_SECOND_BASE]] to i8 addrspace(4)*
+// CHECK: %[[FROM:.*]] = bitcast %class.__generated_second_base addrspace(4)* %[[ARG_BASE1]] to i8 addrspace(4)*
 // CHECK: call void @llvm.memcpy.p4i8.p4i8.i64(i8 addrspace(4)* align 8 %[[TO]], i8 addrspace(4)* align 8 %[[FROM]], i64 8, i1 false)
 
 
 // Initialize field 'a'
-// CHECK: %[[GEP_A:[a-zA-Z0-9]+]] = getelementptr inbounds %struct.derived, %struct.derived addrspace(4)* %[[LOCAL_OBJECT]], i32 0, i32 3
 // CHECK: %[[LOAD_A:[0-9]+]] = load i32, i32 addrspace(4)* %[[ARG_A]], align 4
+// CHECK: %[[DERIVED_PTR:.*]] = bitcast %union.__wrapper_union addrspace(4)* %[[LOCAL_OBJECT]] to %struct.derived addrspace(4)*
+// CHECK: %[[GEP_A:[a-zA-Z0-9]+]] = getelementptr inbounds %struct.derived, %struct.derived addrspace(4)* %[[DERIVED_PTR]], i32 0, i32 3
 // CHECK: store i32 %[[LOAD_A]], i32 addrspace(4)* %[[GEP_A]]

--- a/clang/test/CodeGenSYCL/no_opaque_inline_asm.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_inline_asm.cpp
@@ -9,8 +9,8 @@ __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   // CHECK: %[[ARRAY_A]].ascast = addrspacecast [100 x i32]* %[[ARRAY_A]] to [100 x i32] addrspace(4)*
   // CHECK: %[[I]].ascast = addrspacecast i32* %[[I]] to i32 addrspace(4)*
   // CHECK: store i32 0, i32 addrspace(4)* %[[I]].ascast, align 4
-  // CHECK: %0 = load i32, i32 addrspace(4)* %[[I]].ascast, align 4
-  // CHECK: %[[IDXPROM:[0-9a-z]+]] = sext i32 %0 to i64
+  // CHECK: %[[I_VAL:[0-9a-zA-Z_.]+]] = load i32, i32 addrspace(4)* %[[I]].ascast, align 4
+  // CHECK: %[[IDXPROM:[0-9a-z]+]] = sext i32 %[[I_VAL]] to i64
   // CHECK: %[[IDX:.*]] = getelementptr inbounds [100 x i32], [100 x i32] addrspace(4)* %[[ARRAY_A]].ascast, i64 0, i64 %[[IDXPROM]]
   int a[100], i = 0;
   // CHECK-NEXT: call void asm sideeffect

--- a/clang/test/CodeGenSYCL/no_opaque_kernel-arg-accessor-pointer.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_kernel-arg-accessor-pointer.cpp
@@ -137,16 +137,16 @@ int main() {
 
 // CHECK: define {{.*}}spir_kernel void @{{.*}}localAccessorDep
 // CHECK-SAME: float addrspace(1)* noundef align 4 [[MEM_ARG1:%[a-zA-Z0-9_]+]],
-// CHECK-SAME: %"struct.sycl::_V1::range.5"* noundef byval{{.*}}align 4 [[ACC_RANGE1:%[a-zA-Z0-9_]+1]],
-// CHECK-SAME: %"struct.sycl::_V1::range.5"* noundef byval{{.*}}align 4 [[MEM_RANGE1:%[a-zA-Z0-9_]+2]],
-// CHECK-SAME: %"struct.sycl::_V1::id.6"* noundef byval{{.*}}align 4 [[OFFSET1:%[a-zA-Z0-9_]+3]]
+// CHECK-SAME: %"struct.sycl::_V1::range.9"* noundef byval{{.*}}align 4 [[ACC_RANGE1:%[a-zA-Z0-9_]+1]],
+// CHECK-SAME: %"struct.sycl::_V1::range.9"* noundef byval{{.*}}align 4 [[MEM_RANGE1:%[a-zA-Z0-9_]+2]],
+// CHECK-SAME: %"struct.sycl::_V1::id.10"* noundef byval{{.*}}align 4 [[OFFSET1:%[a-zA-Z0-9_]+3]]
 // CHECK-SAME: !kernel_arg_runtime_aligned ![[#RTALIGNED2]]
 
 // CHECK: define {{.*}}spir_kernel void @{{.*}}localAccessor
 // CHECK-SAME: float addrspace(3)* noundef align 4 [[MEM_ARG1:%[a-zA-Z0-9_]+]],
-// CHECK-SAME: %"struct.sycl::_V1::range.5"* noundef byval{{.*}}align 4 [[ACC_RANGE1:%[a-zA-Z0-9_]+1]],
-// CHECK-SAME: %"struct.sycl::_V1::range.5"* noundef byval{{.*}}align 4 [[MEM_RANGE1:%[a-zA-Z0-9_]+2]],
-// CHECK-SAME: %"struct.sycl::_V1::id.6"* noundef byval{{.*}}align 4 [[OFFSET1:%[a-zA-Z0-9_]+3]]
+// CHECK-SAME: %"struct.sycl::_V1::range.9"* noundef byval{{.*}}align 4 [[ACC_RANGE1:%[a-zA-Z0-9_]+1]],
+// CHECK-SAME: %"struct.sycl::_V1::range.9"* noundef byval{{.*}}align 4 [[MEM_RANGE1:%[a-zA-Z0-9_]+2]],
+// CHECK-SAME: %"struct.sycl::_V1::id.10"* noundef byval{{.*}}align 4 [[OFFSET1:%[a-zA-Z0-9_]+3]]
 // CHECK-SAME: !kernel_arg_runtime_aligned ![[#RTALIGNED2]]
 
 // Check kernel_acc_raw_ptr parameters

--- a/clang/test/CodeGenSYCL/no_opaque_kernel-param-acc-array.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_kernel-param-acc-array.cpp
@@ -39,7 +39,7 @@ int main() {
 // CHECK: [[MEM_ARG2:%[a-zA-Z0-9_.]+]] = alloca i32 addrspace(1)*, align 8
 
 // CHECK lambda object alloca
-// CHECK: [[LOCAL_OBJECTA:%__SYCLKernel]] = alloca %class.anon, align 4
+// CHECK: [[LOCAL_OBJECTA:%__wrapper_union]] = alloca %union.__wrapper_union, align 4
 
 // CHECK allocas for ranges
 // CHECK: [[ACC_RANGE1A:%[a-zA-Z0-9_.]+]] = alloca %"struct.sycl::_V1::range"
@@ -50,7 +50,7 @@ int main() {
 // CHECK: [[OFFSET2A:%[a-zA-Z0-9_.]+]] = alloca %"struct.sycl::_V1::id"
 
 // CHECK lambda object addrspacecast
-// CHECK: [[LOCAL_OBJECT:%.*]] = addrspacecast %class.anon* [[LOCAL_OBJECTA]] to %class.anon addrspace(4)*
+// CHECK: [[LOCAL_OBJECT:%.*]] = addrspacecast %union.__wrapper_union* [[LOCAL_OBJECTA]] to %union.__wrapper_union addrspace(4)*
 
 // CHECK addrspacecasts for ranges
 // CHECK: [[ACC_RANGE1AS:%.*]] = addrspacecast %"struct.sycl::_V1::range"* [[ACC_RANGE1A]] to %"struct.sycl::_V1::range" addrspace(4)*
@@ -60,17 +60,16 @@ int main() {
 // CHECK: [[MEM_RANGE2AS:%.*]] = addrspacecast %"struct.sycl::_V1::range"* [[MEM_RANGE2A]] to %"struct.sycl::_V1::range" addrspace(4)*
 // CHECK: [[OFFSET2AS:%.*]] = addrspacecast %"struct.sycl::_V1::id"* [[OFFSET2A]] to %"struct.sycl::_V1::id" addrspace(4)*
 // CHECK accessor array default inits
-// CHECK: [[ACCESSOR_ARRAY1:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class.anon, %class.anon addrspace(4)* [[LOCAL_OBJECT]], i32 0, i32 0
+// CHECK: [[CLASS_BC:%.*]] = bitcast %union.__wrapper_union addrspace(4)* [[LOCAL_OBJECT]] to %class.anon addrspace(4)*
+// CHECK: [[ACCESSOR_ARRAY1:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class.anon, %class.anon addrspace(4)* [[CLASS_BC]], i32 0, i32 0
 // CHECK: [[BEGIN:%[a-zA-Z0-9._]*]] = getelementptr inbounds [2 x [[ACCESSOR:.*]]], [2 x [[ACCESSOR]]] addrspace(4)* [[ACCESSOR_ARRAY1]], i64 0, i64 0
-// Clang takes advantage of element 1 having the same address as the array, so it doesn't do a GEP.
+// CHECK: [[BC1:%.*]] = bitcast %"class.sycl::_V1::accessor" addrspace(4)* [[BEGIN]] to i8 addrspace(4)*
+// CHECK: [[BC2:%.*]] = bitcast i8 addrspace(4)* [[BC1]] to %"class.sycl::_V1::accessor" addrspace(4)*
 // CTOR Call #1
-// CHECK: call spir_func void @{{.+}}([[ACCESSOR]] addrspace(4)* {{[^,]*}} [[BEGIN]])
-// CHECK: [[ELEM2_GEP:%[a-zA-Z0-9_.]+]] = getelementptr inbounds [[ACCESSOR]], [[ACCESSOR]] addrspace(4)* [[BEGIN]], i64 1
-// CTOR Call #2
-// CHECK: call spir_func void @{{.+}}([[ACCESSOR]] addrspace(4)* {{[^,]*}} [[ELEM2_GEP]])
-
+// CHECK: call spir_func void @{{.+}}([[ACCESSOR]] addrspace(4)* {{[^,]*}} [[BC2]])
 // CHECK acc[0] __init method call
-// CHECK: [[ACCESSOR_ARRAY1:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class.anon, %class.anon addrspace(4)* [[LOCAL_OBJECT]], i32 0, i32 0
+// CHECK: [[CLASS_BC:%.*]] = bitcast %union.__wrapper_union addrspace(4)* [[LOCAL_OBJECT]] to %class.anon addrspace(4)*
+// CHECK: [[ACCESSOR_ARRAY1:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class.anon, %class.anon addrspace(4)* [[CLASS_BC]], i32 0, i32 0
 // CHECK: [[INDEX1:%[a-zA-Z0-9._]*]] = getelementptr inbounds [2 x [[ACCESSOR]]], [2 x [[ACCESSOR]]] addrspace(4)* [[ACCESSOR_ARRAY1]], i64 0, i64 0
 // CHECK load from kernel pointer argument alloca
 // CHECK: [[MEM_LOAD1:%[a-zA-Z0-9_]+]] = load i32 addrspace(1)*, i32 addrspace(1)* addrspace(4)* [[MEM_ARG1]]
@@ -79,8 +78,16 @@ int main() {
 // CHECK: [[OFFSET1:%.*]] = addrspacecast %"struct.sycl::_V1::id" addrspace(4)* [[OFFSET1AS]] to %"struct.sycl::_V1::id"*
 // CHECK: call spir_func void @{{.*}}__init{{.*}}(%"class.sycl::_V1::accessor" addrspace(4)* {{[^,]*}} [[INDEX1]], i32 addrspace(1)* noundef [[MEM_LOAD1]], %"struct.sycl::_V1::range"* noundef byval({{.*}}) align 4 [[ACC_RANGE1]], %"struct.sycl::_V1::range"* noundef byval({{.*}}) align 4 [[MEM_RANGE1]], %"struct.sycl::_V1::id"* noundef byval({{.*}}) align 4 [[OFFSET1]])
 
+// CTOR Call #2
+// CHECK: [[CLASS_BC:%.*]] = bitcast %union.__wrapper_union addrspace(4)* [[LOCAL_OBJECT]] to %class.anon addrspace(4)*
+// CHECK: [[ACCESSOR_ARRAY1:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class.anon, %class.anon addrspace(4)* [[CLASS_BC]], i32 0, i32 0
+// CHECK: [[BEGIN:%[a-zA-Z0-9._]*]] = getelementptr inbounds [2 x [[ACCESSOR:.*]]], [2 x [[ACCESSOR]]] addrspace(4)* [[ACCESSOR_ARRAY1]], i64 0, i64 1
+// CHECK: [[BC1:%.*]] = bitcast %"class.sycl::_V1::accessor" addrspace(4)* [[BEGIN]] to i8 addrspace(4)*
+// CHECK: [[BC2:%.*]] = bitcast i8 addrspace(4)* [[BC1]] to %"class.sycl::_V1::accessor" addrspace(4)*
+// CHECK: call spir_func void @{{.+}}([[ACCESSOR]] addrspace(4)* {{[^,]*}} [[BC2]])
 // CHECK acc[1] __init method call
-// CHECK: [[ACCESSOR_ARRAY2:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class.anon, %class.anon addrspace(4)* [[LOCAL_OBJECT]], i32 0, i32 0
+// CHECK: [[CLASS_BC:%.*]] = bitcast %union.__wrapper_union addrspace(4)* [[LOCAL_OBJECT]] to %class.anon addrspace(4)*
+// CHECK: [[ACCESSOR_ARRAY2:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class.anon, %class.anon addrspace(4)* [[CLASS_BC]], i32 0, i32 0
 // CHECK: [[INDEX2:%[a-zA-Z0-9._]*]] = getelementptr inbounds [2 x [[ACCESSOR]]], [2 x [[ACCESSOR]]] addrspace(4)* [[ACCESSOR_ARRAY2]], i64 0, i64 1
 // CHECK load from kernel pointer argument alloca
 // CHECK: [[MEM_LOAD2:%[a-zA-Z0-9_]+]] = load i32 addrspace(1)*, i32 addrspace(1)* addrspace(4)* [[MEM_ARG2]]

--- a/clang/test/CodeGenSYCL/no_opaque_kernel-param-member-acc-array.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_kernel-param-member-acc-array.cpp
@@ -42,7 +42,7 @@ int main() {
 // CHECK: [[MEM_ARG1]].addr{{[0-9]*}} = alloca i32 addrspace(1)*, align 8
 
 // Check lambda object alloca
-// CHECK: [[LOCAL_OBJECTA:%__SYCLKernel]] = alloca %class{{.*}}.anon, align 4
+// CHECK: [[LOCAL_OBJECTA:%__wrapper_union]] = alloca %union{{.*}}.__wrapper_union, align 4
 
 // Check allocas for ranges
 // CHECK: [[ACC_RANGE1A:%[a-zA-Z0-9_.]+]] = alloca %"struct.sycl::_V1::range"
@@ -53,7 +53,7 @@ int main() {
 // CHECK: [[OFFSET2A:%[a-zA-Z0-9_.]+]] = alloca %"struct.sycl::_V1::id"
 
 // Check lambda object addrspacecast
-// CHECK: [[LOCAL_OBJECT:%.*]] = addrspacecast %class{{.*}}.anon* %__SYCLKernel to %class{{.*}}.anon addrspace(4)*
+// CHECK: [[LOCAL_OBJECT:%.*]] = addrspacecast %union{{.*}}.__wrapper_union* [[LOCAL_OBJECTA]] to %union{{.*}}.__wrapper_union addrspace(4)*
 
 // Check addrspacecast for ranges
 // CHECK: [[ACC_RANGE1AS:%.*]] = addrspacecast %"struct.sycl::_V1::range"* [[ACC_RANGE1A]] to %"struct.sycl::_V1::range" addrspace(4)*
@@ -64,17 +64,17 @@ int main() {
 // CHECK: [[OFFSET2AS:%.*]] = addrspacecast %"struct.sycl::_V1::id"* [[OFFSET2A]] to %"struct.sycl::_V1::id" addrspace(4)*
 
 // CHECK accessor array default inits
-// CHECK: [[ACCESSOR_WRAPPER:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class{{.*}}.anon, %class{{.*}}.anon addrspace(4)* [[LOCAL_OBJECT]], i32 0, i32 0
+// CHECK: [[CLASS_BC:%.*]] = bitcast %union.__wrapper_union addrspace(4)* [[LOCAL_OBJECT]] to %class.anon addrspace(4)*
+// CHECK: [[ACCESSOR_WRAPPER:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class{{.*}}.anon, %class{{.*}}.anon addrspace(4)* [[CLASS_BC]], i32 0, i32 0
 // CHECK: [[ACCESSOR_ARRAY1:%[a-zA-Z0-9_.]+]] = getelementptr inbounds %struct{{.*}}.struct_acc_t, %struct{{.*}}.struct_acc_t addrspace(4)* [[ACCESSOR_WRAPPER]], i32 0, i32 0
 // CHECK: [[BEGIN:%[a-zA-Z0-9._]*]] = getelementptr inbounds [2 x [[ACCESSOR:.*]]], [2 x [[ACCESSOR]]] addrspace(4)* [[ACCESSOR_ARRAY1]], i64 0, i64 0
+// CHECK: [[BC1:%.*]] = bitcast %"class.sycl::_V1::accessor" addrspace(4)* [[BEGIN]] to i8 addrspace(4)*
+// CHECK: [[BC2:%.*]] = bitcast i8 addrspace(4)* [[BC1]] to %"class.sycl::_V1::accessor" addrspace(4)*
 // CTOR Call #1
-// CHECK: call spir_func void @{{.+}}([[ACCESSOR]] addrspace(4)* {{[^,]*}} [[BEGIN]])
-// CHECK: [[ELEM2_GEP:%[a-zA-Z0-9_.]+]] = getelementptr inbounds [[ACCESSOR]], [[ACCESSOR]] addrspace(4)* [[BEGIN]], i64 1
-// CTOR Call #2
-// CHECK: call spir_func void @{{.+}}([[ACCESSOR]] addrspace(4)* {{[^,]*}} [[ELEM2_GEP]])
-
+// CHECK: call spir_func void @{{.+}}([[ACCESSOR]] addrspace(4)* {{[^,]*}} [[BC2]])
 // Check acc[0] __init method call
-// CHECK: [[GEP_LAMBDA1:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class{{.*}}.anon, %class{{.*}}.anon addrspace(4)* [[LOCAL_OBJECT]], i32 0, i32 0
+// CHECK-NEXT: [[CLASS_BC:%.*]] = bitcast %union.__wrapper_union addrspace(4)* [[LOCAL_OBJECT]] to %class.anon addrspace(4)*
+// CHECK: [[GEP_LAMBDA1:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class{{.*}}.anon, %class{{.*}}.anon addrspace(4)* [[CLASS_BC]], i32 0, i32 0
 // CHECK: [[GEP_MEMBER_ACC1:%[a-zA-Z0-9_]+]] = getelementptr inbounds %struct{{.*}}.struct_acc_t, %struct{{.*}}.struct_acc_t addrspace(4)* [[GEP_LAMBDA1]], i32 0, i32 0
 // CHECK: [[ARRAY_IDX1:%[a-zA-Z0-9._]*]] = getelementptr inbounds [2 x [[ACCESSOR]]], [2 x [[ACCESSOR]]] addrspace(4)* [[GEP_MEMBER_ACC1]], i64 0, i64 0
 // CHECK: [[MEM_LOAD1:%[a-zA-Z0-9_]+]] = load i32 addrspace(1)*, i32 addrspace(1)* addrspace(4)* [[MEM_ARG1]].addr
@@ -83,8 +83,18 @@ int main() {
 // CHECK: [[OFFSET1:%.*]] = addrspacecast %"struct.sycl::_V1::id" addrspace(4)* [[OFFSET1AS]] to %"struct.sycl::_V1::id"*
 // CHECK: call spir_func void @{{.*}}__init{{.*}}([[ACCESSOR]] addrspace(4)* {{[^,]*}} [[ARRAY_IDX1]], i32 addrspace(1)* noundef [[MEM_LOAD1]], %"struct{{.*}}.sycl::_V1::range"* noundef byval({{.*}}) align 4 [[ACC_RANGE1]], %"struct{{.*}}.sycl::_V1::range"* noundef byval({{.*}}) align 4 [[MEM_RANGE1]], %"struct{{.*}}.sycl::_V1::id"* noundef byval({{.*}}) align 4 [[OFFSET1]])
 
+// CTOR Call #2
+// CHECK: [[CLASS_BC:%.*]] = bitcast %union.__wrapper_union addrspace(4)* [[LOCAL_OBJECT]] to %class.anon addrspace(4)*
+// CHECK: [[ACCESSOR_WRAPPER:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class{{.*}}.anon, %class{{.*}}.anon addrspace(4)* [[CLASS_BC]], i32 0, i32 0
+// CHECK: [[ACCESSOR_ARRAY1:%[a-zA-Z0-9_.]+]] = getelementptr inbounds %struct{{.*}}.struct_acc_t, %struct{{.*}}.struct_acc_t addrspace(4)* [[ACCESSOR_WRAPPER]], i32 0, i32 0
+// CHECK: [[BEGIN:%[a-zA-Z0-9._]*]] = getelementptr inbounds [2 x [[ACCESSOR:.*]]], [2 x [[ACCESSOR]]] addrspace(4)* [[ACCESSOR_ARRAY1]], i64 0, i64 1
+// CHECK: [[BC1:%.*]] = bitcast %"class.sycl::_V1::accessor" addrspace(4)* [[BEGIN]] to i8 addrspace(4)*
+// CHECK: [[BC2:%.*]] = bitcast i8 addrspace(4)* [[BC1]] to %"class.sycl::_V1::accessor" addrspace(4)*
+// CHECK: call spir_func void @{{.+}}([[ACCESSOR]] addrspace(4)* {{[^,]*}} [[BC2]])
+
 // Check acc[1] __init method call
-// CHECK: [[GEP_LAMBDA2:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class{{.*}}.anon, %class{{.*}}.anon addrspace(4)* [[LOCAL_OBJECT]], i32 0, i32 0
+// CHECK: [[CLASS_BC:%.*]] = bitcast %union.__wrapper_union addrspace(4)* [[LOCAL_OBJECT]] to %class.anon addrspace(4)*
+// CHECK: [[GEP_LAMBDA2:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class{{.*}}.anon, %class{{.*}}.anon addrspace(4)* [[CLASS_BC]], i32 0, i32 0
 // CHECK: [[GEP_MEMBER_ACC2:%[a-zA-Z0-9_]+]] = getelementptr inbounds %struct{{.*}}.struct_acc_t, %struct{{.*}}.struct_acc_t addrspace(4)* [[GEP_LAMBDA2]], i32 0, i32 0
 // CHECK: [[ARRAY_IDX2:%[a-zA-Z0-9_]*]] = getelementptr inbounds [2 x [[ACCESSOR]]], [2 x [[ACCESSOR]]] addrspace(4)* [[GEP_MEMBER_ACC2]], i64 0, i64 1
 // CHECK: [[MEM_LOAD2:%[a-zA-Z0-9_]+]] = load i32 addrspace(1)*, i32 addrspace(1)* addrspace(4)* [[MEM_ARG1]].addr

--- a/clang/test/CodeGenSYCL/no_opaque_kernel-param-pod-array.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_kernel-param-pod-array.cpp
@@ -49,87 +49,45 @@ int main() {
 // CHECK-SAME:(%struct{{.*}}.__wrapper_class* noundef byval(%struct{{.*}}.__wrapper_class) align 4 %[[ARR_ARG:.*]])
 
 // Check local lambda object alloca
-// CHECK: %[[LOCAL_OBJECTA:[a-zA-Z0-9_]+]] = alloca %class{{.*}}.anon, align 4
-// CHECK: %[[LOCAL_OBJECT:[a-zA-Z0-9_.]+]] = addrspacecast %class{{.*}}.anon* %[[LOCAL_OBJECTA]] to %class{{.*}}.anon addrspace(4)*
+// CHECK: %[[LOCAL_OBJECTA:[a-zA-Z0-9_]+]] = alloca %union{{.*}}.__wrapper_union, align 4
+// CHECK: %[[LOCAL_OBJECT:[a-zA-Z0-9_.]+]] = addrspacecast %union{{.*}}.__wrapper_union* %[[LOCAL_OBJECTA]] to %union{{.*}}.__wrapper_union addrspace(4)*
 
-// Check for Array init loop
-// CHECK: %[[LAMBDA_PTR:.+]] = getelementptr inbounds %class{{.*}}.anon, %class{{.*}}.anon addrspace(4)* %[[LOCAL_OBJECT]], i32 0, i32 0
-// CHECK: %[[WRAPPER_PTR:.+]] = getelementptr inbounds %struct{{.*}}.__wrapper_class, %struct{{.*}}.__wrapper_class addrspace(4)* %[[ARR_ARG]].ascast, i32 0, i32 0
-// CHECK: %[[ARRAY_BEGIN:.+]] = getelementptr inbounds [2 x i32], [2 x i32] addrspace(4)* %[[LAMBDA_PTR]], i64 0, i64 0
-// CHECK: br label %[[ARRAYINITBODY:.+]]
-
-// The loop body itself
-// CHECK: [[ARRAYINITBODY]]:
-// CHECK: %[[ARRAYINDEX:.+]] = phi i64 [ 0, %{{.*}} ], [ %[[NEXTINDEX:.+]], %[[ARRAYINITBODY]] ]
-// CHECK: %[[TARG_ARRAY_ELEM:.+]] = getelementptr inbounds i32, i32 addrspace(4)* %[[ARRAY_BEGIN]], i64 %[[ARRAYINDEX]]
-// CHECK: %[[SRC_ELEM:.+]] = getelementptr inbounds [2 x i32], [2 x i32] addrspace(4)* %[[WRAPPER_PTR]], i64 0, i64 %[[ARRAYINDEX]]
-// CHECK: %[[SRC_VAL:.+]] = load i32, i32 addrspace(4)* %[[SRC_ELEM]]
-// CHECK: store i32 %[[SRC_VAL]], i32 addrspace(4)* %[[TARG_ARRAY_ELEM]]
-// CHECK: %[[NEXTINDEX]] = add nuw i64 %[[ARRAYINDEX]], 1
-// CHECK: %[[ISDONE:.+]] = icmp eq i64 %[[NEXTINDEX]], 2
-// CHECK: br i1 %[[ISDONE]], label %{{.*}}, label %[[ARRAYINITBODY]]
+// Check for Array init
+// CHECK: %[[KERNEL_BC:[a-zA-Z0-9_.]+]] = bitcast %union{{.*}}.__wrapper_union addrspace(4)* %[[LOCAL_OBJECT]] to %class{{.*}}.anon addrspace(4)*
+// CHECK: %[[A_DST_PTR:[a-zA-Z0-9_.]+]] = getelementptr inbounds %class{{.*}}.anon, %class{{.*}}.anon addrspace(4)* %[[KERNEL_BC]], i32 0, i32 0
+// CHECK: %[[A_DST:[a-zA-Z0-9_.]+]] = bitcast [2 x i32] addrspace(4)* %[[A_DST_PTR]] to i8 addrspace(4)*
+// CHECK: %[[A_SRC_PTR:[a-zA-Z0-9_.]+]] = getelementptr inbounds %struct{{.*}}.__wrapper_class, %struct{{.*}}.__wrapper_class addrspace(4)* %[[ARR_ARG]].ascast, i32 0, i32 0
+// CHECK: %[[A_SRC:[a-zA-Z0-9_.]+]] = bitcast [2 x i32] addrspace(4)* %[[A_SRC_PTR]] to i8 addrspace(4)*
+// CHECK: call void @llvm.memcpy.p4i8.p4i8.i64(i8 addrspace(4)* align 4 %[[A_DST]], i8 addrspace(4)* align 4 %[[A_SRC]], i64 8, i1 false)
 
 // Check kernel_C parameters
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_C
 // CHECK-SAME:(%struct{{.*}}.__wrapper_class{{.*}}* noundef byval(%struct{{.*}}.__wrapper_class{{.*}}) align 4 %[[ARR_ARG:.*]])
 
 // Check local lambda object alloca
-// CHECK: %[[LOCAL_OBJECTA:[a-zA-Z0-9_]+]] = alloca %class{{.*}}.anon{{.*}}, align 4
-// CHECK: %[[LOCAL_OBJECT:[a-zA-Z0-9_.]+]] = addrspacecast %class{{.*}}.anon{{.*}}* %[[LOCAL_OBJECTA]] to %class{{.*}}.anon{{.*}} addrspace(4)*
+// CHECK: %[[LOCAL_OBJECTA:[a-zA-Z0-9_]+]] = alloca %union{{.*}}.__wrapper_union{{.*}}, align 4
+// CHECK: %[[LOCAL_OBJECT:[a-zA-Z0-9_.]+]] = addrspacecast %union{{.*}}.__wrapper_union{{.*}}* %[[LOCAL_OBJECTA]] to %union{{.*}}.__wrapper_union{{.*}} addrspace(4)*
 
-// Check for Array init loop
-// CHECK: %[[LAMBDA_PTR:.+]] = getelementptr inbounds %class{{.*}}.anon{{.*}}, %class{{.*}}.anon{{.*}} addrspace(4)* %[[LOCAL_OBJECT]], i32 0, i32 0
-// CHECK: %[[WRAPPER_PTR:.+]] = getelementptr inbounds %struct{{.*}}.__wrapper_class{{.*}}, %struct{{.*}}.__wrapper_class{{.*}} addrspace(4)* %[[ARR_ARG]].ascast, i32 0, i32 0
-// CHECK: %[[ARRAY_BEGIN:.+]] = getelementptr inbounds [2 x %struct{{.*}}.foo], [2 x %struct{{.*}}.foo] addrspace(4)* %[[LAMBDA_PTR]], i64 0, i64 0
-// CHECK: br label %[[ARRAYINITBODY:.+]]
-
-// The loop body itself
-// CHECK: [[ARRAYINITBODY]]:
-// CHECK: %[[ARRAYINDEX:.+]] = phi i64 [ 0, %{{.*}} ], [ %[[NEXTINDEX:.+]], %[[ARRAYINITBODY]] ]
-// CHECK: %[[TARG_ARRAY_ELEM:.+]] = getelementptr inbounds %struct{{.*}}.foo, %struct{{.*}}.foo addrspace(4)* %[[ARRAY_BEGIN]], i64 %[[ARRAYINDEX]]
-// CHECK: %[[SRC_ELEM:.+]] = getelementptr inbounds [2 x %struct{{.*}}.foo], [2 x %struct{{.*}}.foo] addrspace(4)* %[[WRAPPER_PTR]], i64 0, i64 %[[ARRAYINDEX]]
-// CHECK: %[[TARG_PTR:.+]] = bitcast %struct{{.*}}.foo addrspace(4)* %[[TARG_ARRAY_ELEM]] to i8 addrspace(4)*
-// CHECK: %[[SRC_PTR:.+]] = bitcast %struct{{.*}}.foo addrspace(4)* %[[SRC_ELEM]] to i8 addrspace(4)*
-// call void @llvm.memcpy.p4i8.p4i8.i64(i8 addrspace(4)* align 4 %[[TARG_PTR]], i8 addrspace(4)* align %[[SRC_PTR]], i64 24, i1 false)
-// CHECK: %[[NEXTINDEX]] = add nuw i64 %[[ARRAYINDEX]], 1
-// CHECK: %[[ISDONE:.+]] = icmp eq i64 %[[NEXTINDEX]], 2
-// CHECK: br i1 %[[ISDONE]], label %{{.*}}, label %[[ARRAYINITBODY]]
+// Check for Array init
+// CHECK: %[[KERNEL_BC:[a-zA-Z0-9_.]+]] = bitcast %union{{.*}}.__wrapper_union{{.*}} addrspace(4)* %[[LOCAL_OBJECT]] to %class{{.*}}.anon{{.*}} addrspace(4)*
+// CHECK: %[[DST_PTR:[a-zA-Z0-9_.]+]] = getelementptr inbounds %class{{.*}}.anon{{.*}}, %class{{.*}}.anon{{.*}} addrspace(4)* %[[KERNEL_BC]], i32 0, i32 0
+// CHECK: %[[DST:[a-zA-Z0-9_.]+]] = bitcast [2 x %struct.foo] addrspace(4)* %[[DST_PTR]] to i8 addrspace(4)*
+// CHECK: %[[SRC_PTR:[a-zA-Z0-9_.]+]] = getelementptr inbounds %struct{{.*}}.__wrapper_class{{.*}}, %struct{{.*}}.__wrapper_class{{.*}} addrspace(4)* %[[ARR_ARG]].ascast, i32 0, i32 0
+// CHECK: %[[SRC:[a-zA-Z0-9_.]+]] = bitcast [2 x %struct.foo] addrspace(4)* %[[SRC_PTR]] to i8 addrspace(4)*
+// CHECK: call void @llvm.memcpy.p4i8.p4i8.i64(i8 addrspace(4)* align 4 %[[DST]], i8 addrspace(4)* align 4 %[[SRC]], i64 48, i1 false)
 
 // Check kernel_D parameters
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_D
 // CHECK-SAME:(%struct{{.*}}.__wrapper_class{{.*}}* noundef byval(%struct{{.*}}.__wrapper_class{{.*}}) align 4 %[[ARR_ARG:.*]])
 
 // Check local lambda object alloca
-// CHECK: %[[LOCAL_OBJECTA:[a-zA-Z0-9_]+]] = alloca %class{{.*}}.anon{{.*}}, align 4
-// CHECK: %[[LOCAL_OBJECT:[a-zA-Z0-9_.]+]] = addrspacecast %class{{.*}}.anon{{.*}}* %[[LOCAL_OBJECTA]] to %class{{.*}}.anon{{.*}} addrspace(4)*
+// CHECK: %[[LOCAL_OBJECTA:[a-zA-Z0-9_]+]] = alloca %union{{.*}}.__wrapper_union{{.*}}, align 4
+// CHECK: %[[LOCAL_OBJECT:[a-zA-Z0-9_.]+]] = addrspacecast %union{{.*}}.__wrapper_union{{.*}}* %[[LOCAL_OBJECTA]] to %union{{.*}}.__wrapper_union{{.*}} addrspace(4)*
 
-// Check for Array init loop
-// CHECK: %[[LAMBDA_PTR:.+]] = getelementptr inbounds %class{{.*}}.anon{{.*}}, %class{{.*}}.anon{{.*}} addrspace(4)* %[[LOCAL_OBJECT]], i32 0, i32 0
-// CHECK: %[[WRAPPER_PTR:.+]] = getelementptr inbounds %struct{{.*}}.__wrapper_class{{.*}}, %struct{{.*}}.__wrapper_class{{.*}} addrspace(4)* %[[ARR_ARG]].ascast, i32 0, i32 0
-// CHECK: %[[ARRAY_BEGIN:.+]] = getelementptr inbounds [2 x [1 x i32]], [2 x [1 x i32]] addrspace(4)* %[[LAMBDA_PTR]], i64 0, i64 0
-// CHECK: br label %[[ARRAYINITBODY:.+]]
-
-// Check Outer loop.
-// CHECK: [[ARRAYINITBODY]]:
-// CHECK: %[[ARRAYINDEX:.+]] = phi i64 [ 0, %{{.*}} ], [ %[[NEXTINDEX:.+]], %[[ARRAYINITEND:.+]] ]
-// CHECK: %[[TARG_OUTER_ELEM:.+]] = getelementptr inbounds [1 x i32], [1 x i32] addrspace(4)* %[[ARRAY_BEGIN]], i64 %[[ARRAYINDEX]]
-// CHECK: %[[SRC_OUTER_ELEM:.+]] = getelementptr inbounds [2 x [1 x i32]], [2 x [1 x i32]] addrspace(4)* %[[WRAPPER_PTR]], i64 0, i64 %[[ARRAYINDEX]]
-// CHECK: %[[ARRAY_BEGIN_INNER:.+]] = getelementptr inbounds [1 x i32], [1 x i32] addrspace(4)* %[[TARG_OUTER_ELEM]], i64 0, i64 0
-// CHECK: br label %[[ARRAYINITBODY_INNER:.+]]
-
-// Check Inner Loop
-// CHECK: [[ARRAYINITBODY_INNER]]:
-// CHECK: %[[ARRAYINDEX_INNER:.+]] = phi i64 [ 0, %{{.*}} ], [ %[[NEXTINDEX_INNER:.+]], %[[ARRAYINITBODY_INNER:.+]] ]
-// CHECK: %[[TARG_INNER_ELEM:.+]] = getelementptr inbounds i32, i32 addrspace(4)* %[[ARRAY_BEGIN_INNER]], i64 %[[ARRAYINDEX_INNER]]
-// CHECK: %[[SRC_INNER_ELEM:.+]] = getelementptr inbounds [1 x i32], [1 x i32] addrspace(4)* %[[SRC_OUTER_ELEM]], i64 0, i64 %[[ARRAYINDEX_INNER]]
-// CHECK: %[[SRC_LOAD:.+]] = load i32, i32 addrspace(4)* %[[SRC_INNER_ELEM]]
-// CHECK: store i32 %[[SRC_LOAD]], i32 addrspace(4)* %[[TARG_INNER_ELEM]]
-// CHECK: %[[NEXTINDEX_INNER]] = add nuw i64 %[[ARRAYINDEX_INNER]], 1
-// CHECK: %[[ISDONE_INNER:.+]] = icmp eq i64 %[[NEXTINDEX_INNER]], 1
-// CHECK: br i1 %[[ISDONE_INNER]], label %[[ARRAYINITEND]], label %[[ARRAYINITBODY_INNER]]
-
-// Check Inner loop 'end'
-// CHECK: [[ARRAYINITEND]]:
-// CHECK: %[[NEXTINDEX]] = add nuw i64 %[[ARRAYINDEX]], 1
-// CHECK: %[[ISDONE:.+]] = icmp eq i64 %[[NEXTINDEX]], 2
-// CHECK: br i1 %[[ISDONE]], label %{{.*}}, label %[[ARRAYINITBODY]]
+// Check for Array init
+// CHECK: %[[KERNEL_BC:[a-zA-Z0-9_.]+]] = bitcast %union{{.*}}.__wrapper_union{{.*}} addrspace(4)* %[[LOCAL_OBJECT]] to %class{{.*}}.anon{{.*}} addrspace(4)*
+// CHECK: %[[DST_PTR:[a-zA-Z0-9_.]+]] = getelementptr inbounds %class{{.*}}.anon{{.*}}, %class{{.*}}.anon{{.*}} addrspace(4)* %[[KERNEL_BC]], i32 0, i32 0
+// CHECK: %[[DST:[a-zA-Z0-9_.]+]] = bitcast [2 x [1 x i32]] addrspace(4)* %[[DST_PTR]] to i8 addrspace(4)*
+// CHECK: %[[SRC_PTR:[a-zA-Z0-9_.]+]] = getelementptr inbounds %struct{{.*}}.__wrapper_class{{.*}}, %struct{{.*}}.__wrapper_class{{.*}} addrspace(4)* %[[ARR_ARG]].ascast, i32 0, i32 0
+// CHECK: %[[SRC:[a-zA-Z0-9_.]+]] = bitcast [2 x [1 x i32]] addrspace(4)* %[[SRC_PTR]] to i8 addrspace(4)*
+// CHECK: call void @llvm.memcpy.p4i8.p4i8.i64(i8 addrspace(4)* align 4 %[[DST]], i8 addrspace(4)* align 4 %[[SRC]], i64 8, i1 false)

--- a/clang/test/CodeGenSYCL/no_opaque_max-concurrency.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_max-concurrency.cpp
@@ -20,23 +20,33 @@
 
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name1() [[ATTR0:#[0-9]+]] {{.*}} !max_concurrency ![[NUM1:[0-9]+]]
 // CHECK: entry:
-// CHECK: [[F1:%.*]] = alloca [[CLASS_F1:%.*]], align 1
-// CHECK: [[F1_ASCAST:%.*]] = addrspacecast [[CLASS_F1]]* [[F1]] to [[CLASS_F1]] addrspace(4)*
-// CHECK: [[TMP0:%.*]] = bitcast [[CLASS_F1]]* [[F1]] to i8*
+// CHECK: [[F1:%.*]] = alloca [[UNION_F1:%.*]], align 1
+// CHECK: [[F1_PTR:%.*]] = alloca [[CLASS_F1:%.*]] addrspace(4)*, align 8
+// CHECK: [[F1_ASCAST:%.*]] = addrspacecast [[UNION_F1]]* [[F1]] to [[UNION_F1]] addrspace(4)*
+// CHECK: [[F1_PTR_ASCAST:%.*]] = addrspacecast [[CLASS_F1]] addrspace(4)** [[F1_PTR]] to [[CLASS_F1]] addrspace(4)* addrspace(4)*
+// CHECK: [[TMP0:%.*]] = bitcast [[UNION_F1]]* [[F1]] to i8*
 // CHECK: call void @llvm.lifetime.start.p0i8(i64 1, i8* [[TMP0]])
-// CHECK: call spir_func void @_ZNK8Functor1clEv([[CLASS_F1]] addrspace(4)* noundef align 1 dereferenceable_or_null(1) [[F1_ASCAST]])
-// CHECK: [[TMP1:%.*]] = bitcast [[CLASS_F1]]* [[F1]] to i8*
+// CHECK: [[F1_BC:%.*]] = bitcast [[UNION_F1]] addrspace(4)* [[F1_ASCAST]] to [[CLASS_F1]] addrspace(4)*
+// CHECK: store [[CLASS_F1]] addrspace(4)* %4, [[CLASS_F1]] addrspace(4)* addrspace(4)* [[F1_PTR_ASCAST]]
+// CHECK: [[F1_PTR:%.*]] = load [[CLASS_F1]] addrspace(4)*, [[CLASS_F1]] addrspace(4)* addrspace(4)* [[F1_PTR_ASCAST]]
+// CHECK: call spir_func void @_ZNK8Functor1clEv([[CLASS_F1]] addrspace(4)* noundef align 1 dereferenceable_or_null(1) [[F1_PTR]])
+// CHECK: [[TMP1:%.*]] = bitcast [[UNION_F1]]* [[F1]] to i8*
 // CHECK: call void @llvm.lifetime.end.p0i8(i64 1, i8* [[TMP1]])
 // CHECK: ret void
 
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name4() [[ATTR0]] {{.*}} !max_concurrency ![[NUM1:[0-9]+]]
 // CHECK: entry
-// CHECK: [[F3:%.*]] = alloca [[CLASS_F3:%.*]], align 1
-// CHECK: [[F3_ASCAST:%.*]] = addrspacecast [[CLASS_F3]]* [[F3]] to [[CLASS_F3]] addrspace(4)*
-// CHECK: [[TMP2:%.*]] = bitcast [[CLASS_F3]]* [[F3]] to i8*
+// CHECK: [[F3:%.*]] = alloca [[UNION_F3:%.*]], align 1
+// CHECK: [[F3_PTR:%.*]] = alloca [[CLASS_F3:%.*]] addrspace(4)*, align 8
+// CHECK: [[F3_ASCAST:%.*]] = addrspacecast [[UNION_F3]]* [[F3]] to [[UNION_F3]] addrspace(4)*
+// CHECK: [[F3_PTR_ASCAST:%.*]] = addrspacecast [[CLASS_F3]] addrspace(4)** [[F3_PTR]] to [[CLASS_F3]] addrspace(4)* addrspace(4)*
+// CHECK: [[TMP2:%.*]] = bitcast [[UNION_F3]]* [[F3]] to i8*
 // CHECK: call void @llvm.lifetime.start.p0i8(i64 1, i8* [[TMP2]])
-// CHECK: call spir_func void @_ZNK8Functor3ILi4EEclEv([[CLASS_F3]] addrspace(4)* noundef align 1 dereferenceable_or_null(1) [[F3_ASCAST]])
-// CHECK: [[TMP3:%.*]] = bitcast [[CLASS_F3]]* [[F3]] to i8*
+// CHECK: [[F3_BC:%.*]] = bitcast [[UNION_F3]] addrspace(4)* [[F3_ASCAST]] to [[CLASS_F3]] addrspace(4)*
+// CHECK: store [[CLASS_F3]] addrspace(4)* %4, [[CLASS_F3]] addrspace(4)* addrspace(4)* [[F3_PTR_ASCAST]]
+// CHECK: [[F3_PTR:%.*]] = load [[CLASS_F3]] addrspace(4)*, [[CLASS_F3]] addrspace(4)* addrspace(4)* [[F3_PTR_ASCAST]]
+// CHECK: call spir_func void @_ZNK8Functor3ILi4EEclEv([[CLASS_F3]] addrspace(4)* noundef align 1 dereferenceable_or_null(1) [[F3_PTR]])
+// CHECK: [[TMP3:%.*]] = bitcast [[UNION_F3]]* [[F3]] to i8*
 // CHECK: call void @llvm.lifetime.end.p0i8(i64 1, i8* [[TMP3]]
 // CHECK: ret void
 
@@ -51,10 +61,15 @@
 // CHECK: define dso_local spir_kernel void @_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_E12kernel_name5()
 // CHECK: entry:
 // CHECK: [[H1:%.*]] = alloca [[H:%.*]], align 1
+// CHECK: [[H_PTR:%.*]] = alloca [[CLASS_H:%.*]] addrspace(4)*, align 8
 // CHECK: [[H2:%.*]] = addrspacecast [[H]]* [[H1]] to [[H]] addrspace(4)*
+// CHECK: [[H_PTR_ASCAST:%.*]] = addrspacecast [[CLASS_H]] addrspace(4)** [[H_PTR]] to [[CLASS_H]] addrspace(4)* addrspace(4)*
 // CHECK: [[H3:%.*]] = bitcast [[H]]* [[H1]] to i8*
 // CHECK: call void @llvm.lifetime.start.p0i8(i64 1, i8* [[H3]])
-// CHECK: call spir_func void @_ZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEv([[H]] addrspace(4)* noundef align 1 dereferenceable_or_null(1) [[H2]])
+// CHECK: [[H_BC:%.*]] = bitcast [[H]] addrspace(4)* [[H2]] to [[CLASS_H]] addrspace(4)*
+// CHECK: store [[CLASS_H]] addrspace(4)* %4, [[CLASS_H]] addrspace(4)* addrspace(4)* [[H_PTR_ASCAST]]
+// CHECK: [[H_PTR:%.*]] = load [[CLASS_H]] addrspace(4)*, [[CLASS_H]] addrspace(4)* addrspace(4)* [[H_PTR_ASCAST]]
+// CHECK: call spir_func void @_ZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEv([[CLASS_H]] addrspace(4)* noundef align 1 dereferenceable_or_null(1) [[H_PTR]])
 // CHECK: [[TMP4:%.*]] = bitcast [[H]]* [[H1]] to i8*
 // CHECK: call void @llvm.lifetime.end.p0i8(i64 1, i8* [[TMP4]])
 // CHECK: ret void

--- a/clang/test/CodeGenSYCL/no_opaque_sampler.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_sampler.cpp
@@ -2,10 +2,12 @@
 // CHECK: define {{.*}}spir_kernel void @{{[a-zA-Z0-9_]+}}(%opencl.sampler_t addrspace(2)* [[SAMPLER_ARG:%[a-zA-Z0-9_]+]])
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[SAMPLER_ARG]].addr = alloca %opencl.sampler_t addrspace(2)*, align 8
-// CHECK: [[ANON:%[a-zA-Z0-9_]+]] = alloca %class.anon, align 8
-// CHECK: [[ANONCAST:%[a-zA-Z0-9_.]+]] = addrspacecast %class.anon* [[ANON]] to %class.anon addrspace(4)*
+// CHECK: [[ANON:%[a-zA-Z0-9_]+]] = alloca %union.__wrapper_union, align 8
+// CHECK: [[ANONCAST:%[a-zA-Z0-9_.]+]] = addrspacecast %union.__wrapper_union* [[ANON]] to %union.__wrapper_union addrspace(4)*
 // CHECK: store %opencl.sampler_t addrspace(2)* [[SAMPLER_ARG]], %opencl.sampler_t addrspace(2)* addrspace(4)* [[SAMPLER_ARG]].addr.ascast, align 8
-// CHECK-NEXT: [[GEP:%[a-zA-z0-9]+]]  = getelementptr inbounds %class.anon, %class.anon addrspace(4)* [[ANONCAST]], i32 0, i32 0
+// CHECK-NEXT: [[BITCAST:%[0-9]+]] = bitcast %union.__wrapper_union addrspace(4)* [[ANONCAST]] to %class.anon addrspace(4)*
+// CHECK: [[BITCAST:%[0-9]+]] = bitcast %union.__wrapper_union addrspace(4)* [[ANONCAST]] to %class.anon addrspace(4)*
+// CHECK-NEXT: [[GEP:%[a-zA-z0-9]+]]  = getelementptr inbounds %class.anon, %class.anon addrspace(4)* [[BITCAST]], i32 0, i32 0
 // CHECK-NEXT: [[LOAD_SAMPLER_ARG:%[0-9]+]] = load %opencl.sampler_t addrspace(2)*, %opencl.sampler_t addrspace(2)* addrspace(4)* [[SAMPLER_ARG]].addr.ascast, align 8
 // CHECK-NEXT: call spir_func void @{{[a-zA-Z0-9_]+}}(%"class.sycl::_V1::sampler" addrspace(4)* {{[^,]*}} [[GEP]], %opencl.sampler_t addrspace(2)* [[LOAD_SAMPLER_ARG]])
 //
@@ -15,25 +17,27 @@
 // Check alloca
 // CHECK: [[SAMPLER_ARG_WRAPPED]].addr = alloca %opencl.sampler_t addrspace(2)*, align 8
 // CHECK: [[ARG_A]].addr = alloca i32, align 4
-// CHECK: [[LAMBDAA:%[a-zA-Z0-9_]+]] = alloca %class.anon.0, align 8
-// CHECK: [[LAMBDA:%[a-zA-Z0-9_.]+]] = addrspacecast %class.anon.0* [[LAMBDAA]] to %class.anon.0 addrspace(4)*
+// CHECK: [[LAMBDAA:%[a-zA-Z0-9_]+]] = alloca %union.__wrapper_union.0, align 8
+// CHECK: [[LAMBDA:%[a-zA-Z0-9_.]+]] = addrspacecast %union.__wrapper_union.0* [[LAMBDAA]] to %union.__wrapper_union.0 addrspace(4)*
 
 // Check argument store
 // CHECK: store %opencl.sampler_t addrspace(2)* [[SAMPLER_ARG_WRAPPED]], %opencl.sampler_t addrspace(2)* addrspace(4)* [[SAMPLER_ARG_WRAPPED]].addr.ascast, align 8
 // CHECK: store i32 [[ARG_A]], i32 addrspace(4)* [[ARG_A]].addr.ascast, align 4
 
-// Initialize 'a'
-// CHECK: [[GEP_LAMBDA:%[a-zA-z0-9]+]] = getelementptr inbounds %class.anon.0, %class.anon.0 addrspace(4)* [[LAMBDA]], i32 0, i32 0
-// CHECK: [[GEP_A:%[a-zA-Z0-9]+]] = getelementptr inbounds %struct.sampler_wrapper, %struct.sampler_wrapper addrspace(4)* [[GEP_LAMBDA]], i32 0, i32 1
-// CHECK: [[LOAD_A:%[0-9]+]] = load i32, i32 addrspace(4)* [[ARG_A]].addr.ascast, align 4
-// CHECK: store i32 [[LOAD_A]], i32 addrspace(4)* [[GEP_A]], align 8
-
 // Initialize wrapped sampler 'smpl'
-// CHECK: [[GEP_LAMBDA_0:%[a-zA-z0-9]+]] = getelementptr inbounds %class.anon.0, %class.anon.0 addrspace(4)* [[LAMBDA]], i32 0, i32 0
+// CHECK-NEXT: [[BITCAST:%[0-9]+]] = bitcast %union.__wrapper_union.0 addrspace(4)* [[LAMBDA]] to %class.anon.1 addrspace(4)*
+// CHECK: [[GEP_LAMBDA_0:%[a-zA-z0-9]+]] = getelementptr inbounds %class.anon.1, %class.anon.1 addrspace(4)* [[BITCAST]], i32 0, i32 0
 // CHECK: [[GEP_SMPL:%[a-zA-Z0-9]+]] = getelementptr inbounds %struct.sampler_wrapper, %struct.sampler_wrapper addrspace(4)* [[GEP_LAMBDA_0]], i32 0, i32 0
 // CHECK: [[LOAD_SMPL:%[0-9]+]] = load %opencl.sampler_t addrspace(2)*, %opencl.sampler_t addrspace(2)* addrspace(4)* [[SAMPLER_ARG_WRAPPED]].addr.ascast, align 8
 // CHECK: call spir_func void @{{[a-zA-Z0-9_]+}}(%"class.sycl::_V1::sampler" addrspace(4)* {{.*}}, %opencl.sampler_t addrspace(2)* [[LOAD_SMPL]])
 //
+// Initialize 'a'
+// CHECK: [[LOAD_A:%[0-9]+]] = load i32, i32 addrspace(4)* [[ARG_A]].addr.ascast, align 4
+// CHECK: [[BITCAST:%[0-9]+]] = bitcast %union.__wrapper_union.0 addrspace(4)* [[LAMBDA]] to %class.anon.1 addrspace(4)*
+// CHECK: [[GEP_LAMBDA:%[a-zA-z0-9]+]] = getelementptr inbounds %class.anon.1, %class.anon.1 addrspace(4)* [[BITCAST]], i32 0, i32 0
+// CHECK: [[GEP_A:%[a-zA-Z0-9]+]] = getelementptr inbounds %struct.sampler_wrapper, %struct.sampler_wrapper addrspace(4)* [[GEP_LAMBDA]], i32 0, i32 1
+// CHECK: store i32 [[LOAD_A]], i32 addrspace(4)* [[GEP_A]], align 8
+
 #include "Inputs/sycl.hpp"
 
 struct sampler_wrapper {

--- a/clang/test/CodeGenSYCL/no_opaque_stall_enable_device.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_stall_enable_device.cpp
@@ -26,12 +26,12 @@ public:
 int main() {
   q.submit([&](handler &h) {
     // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel1() {{.*}} !stall_enable ![[NUM4:[0-9]+]]
-    // CHECK: define {{.*}}spir_func void @{{.*}}FuncObjclEv(%struct.{{.*}}FuncObj addrspace(4)* noundef align 1 dereferenceable_or_null(1) %this) #2 comdat align 2{{.*}} !stall_enable ![[NUM4]]
+    // CHECK: define {{.*}}spir_func void @{{.*}}FuncObjclEv(%struct.{{.*}}FuncObj addrspace(4)* noundef align 1 dereferenceable_or_null(1) %this) #1 comdat align 2{{.*}} !stall_enable ![[NUM4]]
     h.single_task<class test_kernel1>(
         FuncObj());
 
     // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel2() {{.*}} !stall_enable ![[NUM4]]
-    // CHECK define {{.*}}spir_func void @{{.*}}FooclEv(%class._ZTS3Foo.Foo addrspace(4)* noundef align 1 dereferenceable_or_null(1) %this) #2 comdat align 2{{.*}} !stall_enable ![[NUM4]]
+    // CHECK define {{.*}}spir_func void @{{.*}}FooclEv(%class._ZTS3Foo.Foo addrspace(4)* noundef align 1 dereferenceable_or_null(1) %this) #1 comdat align 2{{.*}} !stall_enable ![[NUM4]]
     Foo f;
     h.single_task<class test_kernel2>(f);
 
@@ -47,7 +47,7 @@ int main() {
     // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel4()
     // CHECK-NOT: !stall_enable
     // CHECK-SAME: {
-    // CHECK: define {{.*}}spir_func void @{{.*}}func1{{.*}}(%class.anon{{.*}} addrspace(4)* noundef align 1 dereferenceable_or_null(1) %this) #2 align 2{{.*}} !stall_enable ![[NUM4]]
+    // CHECK: define {{.*}}spir_func void @{{.*}}func1{{.*}}(%class.anon{{.*}} addrspace(4)* noundef align 1 dereferenceable_or_null(1) %this) #1 align 2{{.*}} !stall_enable ![[NUM4]]
     h.single_task<class test_kernel4>(
         []() { func1(); });
 

--- a/clang/test/CodeGenSYCL/no_opaque_union-kernel-param.cpp
+++ b/clang/test/CodeGenSYCL/no_opaque_union-kernel-param.cpp
@@ -31,12 +31,16 @@ int main() {
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_A(%union.MyUnion* noundef byval(%union.MyUnion) align 4 [[MEM_ARG:%[a-zA-Z0-9_]+]])
 
 // Check lambda object alloca
-// CHECK: [[LOCAL_OBJECT:%__SYCLKernel]] = alloca %class.anon, align 4
+// CHECK: [[LOCAL_OBJECT:%__wrapper_union]] = alloca %union.__wrapper_union, align 4
+// CHECK: [[FUNCTOR_PTR:%.*]] = alloca %class.anon addrspace(4)*
 
-// CHECK: [[LOCAL_OBJECTAS:%.*]] = addrspacecast %class.anon* [[LOCAL_OBJECT]] to %class.anon addrspace(4)*
+// CHECK: [[LOCAL_OBJECTAS:%.*]] = addrspacecast %union.__wrapper_union* [[LOCAL_OBJECT]] to %union.__wrapper_union addrspace(4)*
+// CHECK: [[FUNCTOR_PTRAS:%.*]] = addrspacecast %class.anon addrspace(4)** [[FUNCTOR_PTR]] to %class.anon addrspace(4)* addrspace(4)*
 // CHECK: [[MEM_ARGAS:%.*]] = addrspacecast %union.MyUnion* [[MEM_ARG]] to %union.MyUnion addrspace(4)*
-// CHECK: [[L_STRUCT_ADDR:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class.anon, %class.anon addrspace(4)* [[LOCAL_OBJECTAS]], i32 0, i32 0
+// CHECK: [[ANON_OBJECTAS:%.*]] = bitcast %union.__wrapper_union addrspace(4)* [[LOCAL_OBJECTAS]] to %class.anon addrspace(4)*
+// CHECK: [[L_STRUCT_ADDR:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class.anon, %class.anon addrspace(4)* [[ANON_OBJECTAS]], i32 0, i32 0
 // CHECK: [[MEMCPY_DST:%[0-9a-zA-Z_]+]] = bitcast %union.{{.*}}MyUnion addrspace(4)* [[L_STRUCT_ADDR]] to i8 addrspace(4)*
 // CHECK: [[MEMCPY_SRC:%[0-9a-zA-Z_]+]] = bitcast %union.{{.*}}MyUnion addrspace(4)* [[MEM_ARGAS]] to i8 addrspace(4)*
 // CHECK: call void @llvm.memcpy.p4i8.p4i8.i64(i8 addrspace(4)* align 4 [[MEMCPY_DST]], i8 addrspace(4)* align 4 [[MEMCPY_SRC]], i64 12, i1 false)
-// CHECK: call spir_func void @{{.*}}(%class.anon addrspace(4)* {{[^,]*}} [[LOCAL_OBJECTAS]])
+// CHECK: [[FUNCTOR:%[0-9a-zA-Z_]+]] = load %class.anon addrspace(4)*, %class.anon addrspace(4)* addrspace(4)* [[FUNCTOR_PTRAS]]
+// CHECK: call spir_func void @{{.*}}(%class.anon addrspace(4)* {{[^,]*}} [[FUNCTOR]])

--- a/clang/test/CodeGenSYCL/sampler.cpp
+++ b/clang/test/CodeGenSYCL/sampler.cpp
@@ -2,9 +2,10 @@
 // CHECK: define {{.*}}spir_kernel void @{{[a-zA-Z0-9_]+}}(ptr addrspace(2) [[SAMPLER_ARG:%[a-zA-Z0-9_]+]])
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[SAMPLER_ARG]].addr = alloca ptr addrspace(2), align 8
-// CHECK: [[ANON:%[a-zA-Z0-9_]+]] = alloca %class.anon, align 8
+// CHECK: [[ANON:%[a-zA-Z0-9_]+]] = alloca %union.__wrapper_union, align 8
 // CHECK: [[ANONCAST:%[a-zA-Z0-9_.]+]] = addrspacecast ptr [[ANON]] to ptr addrspace(4)
 // CHECK: store ptr addrspace(2) [[SAMPLER_ARG]], ptr addrspace(4) [[SAMPLER_ARG]].addr.ascast, align 8
+// CHECK-NEXT: [[GEP:%[a-zA-z0-9]+]]  = getelementptr inbounds %class.anon, ptr addrspace(4) [[ANONCAST]], i32 0, i32 0
 // CHECK-NEXT: [[GEP:%[a-zA-z0-9]+]]  = getelementptr inbounds %class.anon, ptr addrspace(4) [[ANONCAST]], i32 0, i32 0
 // CHECK-NEXT: [[LOAD_SAMPLER_ARG:%[0-9]+]] = load ptr addrspace(2), ptr addrspace(4) [[SAMPLER_ARG]].addr.ascast, align 8
 // CHECK-NEXT: call spir_func void @{{[a-zA-Z0-9_]+}}(ptr addrspace(4) {{[^,]*}} [[GEP]], ptr addrspace(2) [[LOAD_SAMPLER_ARG]])
@@ -15,24 +16,25 @@
 // Check alloca
 // CHECK: [[SAMPLER_ARG_WRAPPED]].addr = alloca ptr addrspace(2), align 8
 // CHECK: [[ARG_A]].addr = alloca i32, align 4
-// CHECK: [[LAMBDAA:%[a-zA-Z0-9_]+]] = alloca %class.anon.0, align 8
+// CHECK: [[LAMBDAA:%[a-zA-Z0-9_]+]] = alloca %union.__wrapper_union.0, align 8
 // CHECK: [[LAMBDA:%[a-zA-Z0-9_.]+]] = addrspacecast ptr [[LAMBDAA]] to ptr addrspace(4)
 
 // Check argument store
 // CHECK: store ptr addrspace(2) [[SAMPLER_ARG_WRAPPED]], ptr addrspace(4) [[SAMPLER_ARG_WRAPPED]].addr.ascast, align 8
 // CHECK: store i32 [[ARG_A]], ptr addrspace(4) [[ARG_A]].addr.ascast, align 4
 
-// Initialize 'a'
-// CHECK: [[GEP_LAMBDA:%[a-zA-z0-9]+]] = getelementptr inbounds %class.anon.0, ptr addrspace(4) [[LAMBDA]], i32 0, i32 0
-// CHECK: [[GEP_A:%[a-zA-Z0-9]+]] = getelementptr inbounds %struct.sampler_wrapper, ptr addrspace(4) [[GEP_LAMBDA]], i32 0, i32 1
-// CHECK: [[LOAD_A:%[0-9]+]] = load i32, ptr addrspace(4) [[ARG_A]].addr.ascast, align 4
-// CHECK: store i32 [[LOAD_A]], ptr addrspace(4) [[GEP_A]], align 8
-
 // Initialize wrapped sampler 'smpl'
-// CHECK: [[GEP_LAMBDA_0:%[a-zA-z0-9]+]] = getelementptr inbounds %class.anon.0, ptr addrspace(4) [[LAMBDA]], i32 0, i32 0
+// CHECK: [[GEP_LAMBDA_0:%[a-zA-z0-9]+]] = getelementptr inbounds %class.anon.1, ptr addrspace(4) [[LAMBDA]], i32 0, i32 0
 // CHECK: [[GEP_SMPL:%[a-zA-Z0-9]+]] = getelementptr inbounds %struct.sampler_wrapper, ptr addrspace(4) [[GEP_LAMBDA_0]], i32 0, i32 0
 // CHECK: [[LOAD_SMPL:%[0-9]+]] = load ptr addrspace(2), ptr addrspace(4) [[SAMPLER_ARG_WRAPPED]].addr.ascast, align 8
 // CHECK: call spir_func void @{{[a-zA-Z0-9_]+}}(ptr addrspace(4) {{.*}}, ptr addrspace(2) [[LOAD_SMPL]])
+
+// Initialize 'a'
+// CHECK: [[LOAD_A:%[0-9]+]] = load i32, ptr addrspace(4) [[ARG_A]].addr.ascast, align 4
+// CHECK: [[GEP_LAMBDA:%[a-zA-z0-9]+]] = getelementptr inbounds %class.anon.1, ptr addrspace(4) [[LAMBDA]], i32 0, i32 0
+// CHECK: [[GEP_A:%[a-zA-Z0-9]+]] = getelementptr inbounds %struct.sampler_wrapper, ptr addrspace(4) [[GEP_LAMBDA]], i32 0, i32 1
+// CHECK: store i32 [[LOAD_A]], ptr addrspace(4) [[GEP_A]], align 8
+
 //
 #include "Inputs/sycl.hpp"
 

--- a/clang/test/CodeGenSYCL/stall_enable_device.cpp
+++ b/clang/test/CodeGenSYCL/stall_enable_device.cpp
@@ -26,12 +26,12 @@ public:
 int main() {
   q.submit([&](handler &h) {
     // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel1() {{.*}} !stall_enable ![[NUM4:[0-9]+]]
-    // CHECK: define {{.*}}spir_func void @{{.*}}FuncObjclEv(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) #2 comdat align 2{{.*}} !stall_enable ![[NUM4]]
+    // CHECK: define {{.*}}spir_func void @{{.*}}FuncObjclEv(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) #1 comdat align 2{{.*}} !stall_enable ![[NUM4]]
     h.single_task<class test_kernel1>(
         FuncObj());
 
     // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel2() {{.*}} !stall_enable ![[NUM4]]
-    // CHECK define {{.*}}spir_func void @{{.*}}FooclEv(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) #2 comdat align 2{{.*}} !stall_enable ![[NUM4]]
+    // CHECK define {{.*}}spir_func void @{{.*}}FooclEv(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) #1 comdat align 2{{.*}} !stall_enable ![[NUM4]]
     Foo f;
     h.single_task<class test_kernel2>(f);
 
@@ -47,7 +47,7 @@ int main() {
     // CHECK: define {{.*}}spir_kernel void @{{.*}}test_kernel4()
     // CHECK-NOT: !stall_enable
     // CHECK-SAME: {
-    // CHECK: define {{.*}}spir_func void @{{.*}}func1{{.*}}(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) #2 align 2{{.*}} !stall_enable ![[NUM4]]
+    // CHECK: define {{.*}}spir_func void @{{.*}}func1{{.*}}(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) #1 align 2{{.*}} !stall_enable ![[NUM4]]
     h.single_task<class test_kernel4>(
         []() { func1(); });
 

--- a/clang/test/CodeGenSYCL/union-kernel-param.cpp
+++ b/clang/test/CodeGenSYCL/union-kernel-param.cpp
@@ -27,10 +27,12 @@ int main() {
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_A(ptr noundef byval(%union.MyUnion) align 4 [[MEM_ARG:%[a-zA-Z0-9_]+]])
 
 // Check lambda object alloca
-// CHECK: [[LOCAL_OBJECT:%__SYCLKernel]] = alloca %class.anon, align 4
+// CHECK: [[LOCAL_OBJECT:%__wrapper_union]] = alloca %union.__wrapper_union, align 4
 
 // CHECK: [[LOCAL_OBJECTAS:%.*]] = addrspacecast ptr [[LOCAL_OBJECT]] to ptr addrspace(4)
 // CHECK: [[MEM_ARGAS:%.*]] = addrspacecast ptr [[MEM_ARG]] to ptr addrspace(4)
 // CHECK: [[L_STRUCT_ADDR:%[a-zA-Z0-9_]+]] = getelementptr inbounds %class.anon, ptr addrspace(4) [[LOCAL_OBJECTAS]], i32 0, i32 0
 // CHECK: call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) align 4 [[L_STRUCT_ADDR]], ptr addrspace(4) align 4 [[MEM_ARGAS]], i64 12, i1 false)
-// CHECK: call spir_func void @{{.*}}(ptr addrspace(4) {{[^,]*}} [[LOCAL_OBJECTAS]])
+// CHECK: store ptr addrspace(4) [[LOCAL_OBJECTAS]], ptr addrspace(4) [[KERNEL_REF_ADDR:%[A-Za-z0-9]*]]
+// CHECK: [[KERNEL_REF:%[A-Za-z0-9]*]] = load ptr addrspace(4), ptr addrspace(4) [[KERNEL_REF_ADDR]]
+// CHECK: call spir_func void @{{.*}}(ptr addrspace(4) {{[^,]*}} [[KERNEL_REF]])

--- a/clang/test/SemaSYCL/Inputs/sycl.hpp
+++ b/clang/test/SemaSYCL/Inputs/sycl.hpp
@@ -1,6 +1,8 @@
 #ifndef SYCL_HPP
 #define SYCL_HPP
 
+void* operator new  (__SIZE_TYPE__ size, void* ptr) noexcept;
+void* operator new[](__SIZE_TYPE__ size, void* ptr) noexcept;
 #define __SYCL_TYPE(x) [[__sycl_detail__::sycl_type(x)]]
 
 // Shared code for SYCL tests

--- a/clang/test/SemaSYCL/accessor_inheritance.cpp
+++ b/clang/test/SemaSYCL/accessor_inheritance.cpp
@@ -44,32 +44,90 @@ int main() {
 // CHECK: ParmVarDecl{{.*}} used _arg_C 'int'
 
 // Check lambda initialization
-// CHECK: VarDecl {{.*}} used __SYCLKernel '(lambda at {{.*}}accessor_inheritance.cpp
-// CHECK-NEXT: InitListExpr {{.*}}
-// CHECK-NEXT: InitListExpr {{.*}} 'AccessorDerived'
-// CHECK-NEXT: InitListExpr {{.*}} 'AccessorBase'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
-// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_A' 'int'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
-// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_B' 'int'
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::accessor<char, 1, sycl::access::mode::read>':'sycl::accessor<char, 1, sycl::access::mode::read>' 'void () noexcept'
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::accessor<char, 1, sycl::access::mode::read>':'sycl::accessor<char, 1, sycl::access::mode::read>' 'void () noexcept'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
-// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_C' 'int'
+// CHECK: VarDecl {{.*}} used __wrapper_union '__wrapper_union'
 
-// Check __init calls
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
-// CHECK-NEXT: MemberExpr {{.*}} .__init
-// CHECK-NEXT: MemberExpr {{.*}} .AccField
-// CHECK-NEXT: ImplicitCastExpr {{.*}}'AccessorBase' lvalue <DerivedToBase (AccessorBase)>
-// CHECK-NEXT: MemberExpr {{.*}}'AccessorDerived' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}}'(lambda at {{.*}}accessor_inheritance.cpp
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global char *' <LValueToRValue>
-// CHECK-NEXT: DeclRefExpr {{.*}} '__global char *' lvalue ParmVar {{.*}} '_arg_AccField' '__global char *'
+// Init A
+// memcpy(lambda.A, __arg_A, 4)
+//
+// CHECK: BinaryOperator {{.*}} '='
+// CHECK:  MemberExpr {{.*}} 'int' lvalue .A
+// CHECK:   ImplicitCastExpr {{.*}} <DerivedToBase (AccessorBase)>
+// CHECK:    MemberExpr {{.*}} 'AccessorDerived':'AccessorDerived' lvalue .
+// CHECK:     MemberExpr {{.*}} '(lambda at
+// CHECK:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK:  DeclRefExpr {{.*}} '_arg_A'
 
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
-// CHECK-NEXT: MemberExpr{{.*}} lvalue .__init
-// CHECK-NEXT: MemberExpr{{.*}}'AccessorDerived' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at {{.*}}accessor_inheritance.cpp
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global char *' <LValueToRValue>
-// CHECK-NEXT: DeclRefExpr {{.*}} '__global char *' lvalue ParmVar {{.*}} '_arg__base' '__global char *'
+// Init B
+// memcpy(lambda.B, __arg_B, 4)
+//
+// CHECK: BinaryOperator {{.*}} '='
+// CHECK:  MemberExpr {{.*}} 'int' lvalue .B
+// CHECK:   ImplicitCastExpr {{.*}} <DerivedToBase (AccessorBase)>
+// CHECK:    MemberExpr {{.*}} 'AccessorDerived':'AccessorDerived' lvalue .
+// CHECK:     MemberExpr {{.*}} '(lambda at
+// CHECK:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK:  DeclRefExpr {{.*}} '_arg_B'
+
+// Init AccField
+// placement new
+//
+// CHECK: CXXNewExpr {{.*}} 'sycl::accessor<char, 1, sycl::access::mode::read> *' global Function {{.*}} 'operator new'
+// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::accessor<char, 1, sycl::access::mode::read>' 'void () noexcept'
+// CHECK: MemberExpr {{.*}}'sycl::accessor<char, 1, sycl::access::mode::read>':'sycl::accessor<char, 1, sycl::access::mode::read>' lvalue .AccField
+// CHECK-NEXT: ImplicitCastExpr {{.*}} <DerivedToBase (AccessorBase)>
+// CHECK-NEXT:  MemberExpr {{.*}} 'AccessorDerived':'AccessorDerived'
+// CHECK-NEXT:   MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:    DeclRefExpr {{.*}} '__wrapper_union'
+
+// call to __init
+//
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (PtrType, range<1>, range<1>, id<1>)' lvalue .__init
+// CHECK-NEXT:  MemberExpr {{.*}} .AccField {{.*}}
+// CHECK-NEXT:   ImplicitCastExpr {{.*}} <DerivedToBase (AccessorBase)>
+// CHECK-NEXT:    MemberExpr {{.*}} 'AccessorDerived':'AccessorDerived'
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK:       DeclRefExpr {{.*}} '_arg_AccField' '__global char *'
+// CHECK-NEXT:  CXXConstructExpr {{.*}} 'range<1>':'sycl::range<1>'
+// CHECK:        DeclRefExpr {{.*}} ParmVar {{.*}} '_arg_AccField' 'sycl::range<1>'
+// CHECK-NEXT:  CXXConstructExpr {{.*}} 'range<1>':'sycl::range<1>'
+// CHECK:        DeclRefExpr {{.*}} ParmVar {{.*}} '_arg_AccField' 'sycl::range<1>'
+// CHECK-NEXT:  CXXConstructExpr {{.*}} 'id<1>':'sycl::id<1>'
+// CHECK:        DeclRefExpr {{.*}} ParmVar {{.*}} '_arg_AccField' 'sycl::id<1>'
+
+// Init inherited accessor
+// placement new
+//
+// CHECK:      CXXNewExpr {{.*}} 'sycl::accessor<char, 1, sycl::access::mode::read> *' global Function {{.*}} 'operator new'
+// CHECK-NEXT:  CXXConstructExpr {{.*}} 'sycl::accessor<char, 1, sycl::access::mode::read>' 'void () noexcept'
+// CHECK:       ImplicitCastExpr {{.*}} <DerivedToBase (accessor)>
+// CHECK-NEXT:   MemberExpr {{.*}} 'AccessorDerived':'AccessorDerived'
+// CHECK-NEXT:    MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:     DeclRefExpr {{.*}} '__wrapper_union'
+
+// call to __init
+//
+// CHECK:      CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (PtrType, range<1>, range<1>, id<1>)' lvalue .__init
+// CHECK-NEXT:  ImplicitCastExpr {{.*}} <DerivedToBase (accessor)>
+// CHECK-NEXT:   MemberExpr {{.*}} 'AccessorDerived':'AccessorDerived'
+// CHECK-NEXT:    MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:     DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK:       DeclRefExpr {{.*}} '_arg__base' '__global char *'
+// CHECK-NEXT:  CXXConstructExpr {{.*}} 'range<1>':'sycl::range<1>'
+// CHECK:        DeclRefExpr {{.*}} ParmVar {{.*}} '_arg__base' 'sycl::range<1>'
+// CHECK-NEXT:  CXXConstructExpr {{.*}} 'range<1>':'sycl::range<1>'
+// CHECK:        DeclRefExpr {{.*}} ParmVar {{.*}} '_arg__base' 'sycl::range<1>'
+// CHECK-NEXT:  CXXConstructExpr {{.*}} 'id<1>':'sycl::id<1>'
+// CHECK:        DeclRefExpr {{.*}} ParmVar {{.*}} '_arg__base' 'sycl::id<1>'
+
+// Init C
+// memcpy(lambda.C, __arg_C, 4)
+//
+// CHECK: BinaryOperator {{.*}} '='
+// CHECK:  MemberExpr {{.*}} 'int' lvalue .C
+// CHECK:   MemberExpr {{.*}} 'AccessorDerived':'AccessorDerived' lvalue .
+// CHECK:    MemberExpr {{.*}} '(lambda at
+// CHECK:     DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK:  DeclRefExpr {{.*}} '_arg_C'

--- a/clang/test/SemaSYCL/array-kernel-param.cpp
+++ b/clang/test/SemaSYCL/array-kernel-param.cpp
@@ -135,49 +135,43 @@ int main() {
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_Array '__wrapper_class'
 // Check Kernel_Array inits
 // CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: DeclStmt
-// CHECK-NEXT: VarDecl {{.*}} cinit
-// CHECK-NEXT: InitListExpr
-// CHECK-NEXT: ArrayInitLoopExpr {{.*}} 'int[2]'
-// CHECK-NEXT: OpaqueValueExpr {{.*}} 'int[2]' lvalue
-// CHECK-NEXT: MemberExpr {{.*}} 'int[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_Array' '__wrapper_class'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'int' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <ArrayToPointerDecay>
-// CHECK-NEXT: OpaqueValueExpr {{.*}} 'int[2]' lvalue
-// CHECK-NEXT: MemberExpr {{.*}} 'int[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_Array' '__wrapper_class'
+// CHECK-NEXT:  DeclStmt
+// CHECK-NEXT:   VarDecl {{.*}} __wrapper_union
+// CHECK-NEXT: CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .Array
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT:  UnaryOperator
+// CHECK-NEXT:   MemberExpr
+// CHECK-NEXT:    DeclRefExpr {{.*}} ParmVar {{.*}} '_arg_Array'
+// CHECK-NEXT: IntegerLiteral {{.*}} 8
+
 
 // Check Kernel_Array_Ptrs parameters
 // CHECK: FunctionDecl {{.*}}Kernel_Array_Ptrs{{.*}} 'void (__wrapper_class)'
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_ArrayOfPointers '__wrapper_class'
 // Check Kernel_Array_Ptrs inits
 // CHECK-NEXT: CompoundStmt
-// CHECK-NEXT: DeclStmt
-// CHECK-NEXT: VarDecl {{.*}} cinit
-// CHECK-NEXT: InitListExpr
-// CHECK-NEXT: InitListExpr {{.*}} 'int *[2]'
-// Initializer for ArrayOfPointers[0]
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <LValueToRValue>
-// CHECK-NEXT: UnaryOperator {{.*}} 'int *' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CXXReinterpretCastExpr {{.*}} 'int **' reinterpret_cast<int **> <BitCast>
-// CHECK-NEXT: UnaryOperator {{.*}} '__global int **' prefix '&' cannot overflow
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__global int *' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int **' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} '__global int *[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ArrayOfPointers'
-// CHECK-NEXT: IntegerLiteral {{.*}} 0
-// Initializer for ArrayOfPointers[1]
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <LValueToRValue>
-// CHECK-NEXT: UnaryOperator {{.*}} 'int *' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CXXReinterpretCastExpr {{.*}} 'int **' reinterpret_cast<int **> <BitCast>
-// CHECK-NEXT: UnaryOperator {{.*}} '__global int **' prefix '&' cannot overflow
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__global int *' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int **' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} '__global int *[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ArrayOfPointers'
-// CHECK-NEXT: IntegerLiteral {{.*}} 1
+// CHECK-NEXT:  DeclStmt
+// CHECK-NEXT:   VarDecl {{.*}} __wrapper_union
+// CHECK-NEXT: CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .ArrayOfPointers
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT:  UnaryOperator
+// CHECK-NEXT:   MemberExpr
+// CHECK-NEXT:    DeclRefExpr {{.*}} ParmVar {{.*}} '_arg_ArrayOfPointers'
+// CHECK-NEXT: IntegerLiteral {{.*}} 16
 
 // Check Kernel_StructAccArray parameters
 // CHECK: FunctionDecl {{.*}}Kernel_StructAccArray{{.*}} 'void (__global int *, sycl::range<1>, sycl::range<1>, sycl::id<1>, __global int *, sycl::range<1>, sycl::range<1>, sycl::id<1>)'
@@ -193,29 +187,54 @@ int main() {
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_member_acc 'sycl::id<1>'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: DeclStmt
-// CHECK-NEXT: VarDecl {{.*}} used __SYCLKernel '(lambda at {{.*}}array-kernel-param.cpp{{.*}})' cinit
-// CHECK-NEXT: InitListExpr {{.*}} '(lambda at {{.*}}array-kernel-param.cpp{{.*}})'
-// CHECK-NEXT: InitListExpr {{.*}} 'StructWithAccessors'
-// CHECK-NEXT: InitListExpr {{.*}} 'Accessor[2]'
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'Accessor'
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'Accessor'
-
-// Check __init functions are called
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
-// CHECK-NEXT: MemberExpr {{.*}}__init
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
-// CHECK-NEXT: MemberExpr {{.*}}__init
+// CHECK-NEXT:  VarDecl {{.*}} __wrapper_union
+// Init first accessor
+// CHECK-NEXT: CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    ArraySubscriptExpr
+// CHECK-NEXT:     ImplicitCastExpr
+// CHECK-NEXT:      MemberExpr {{.*}} .member_acc
+// CHECK-NEXT:       MemberExpr {{.*}} .StructAccArrayObj
+// CHECK-NEXT:        MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:         DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:    IntegerLiteral {{.*}} 0
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT:  MemberExpr {{.*}}__init
+// Init second accessor
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:      MemberExpr {{.*}} .member_acc
+// CHECK-NEXT:       MemberExpr {{.*}} .StructAccArrayObj
+// CHECK-NEXT:        MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:         DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:     IntegerLiteral {{.*}} 1
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT:  MemberExpr {{.*}}__init
 
 // Check Kernel_TemplatedStructArray parameters
 // CHECK: FunctionDecl {{.*}}Kernel_TemplatedStructArray{{.*}} 'void (S<int>)'
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_s 'S<int>':'S<int>'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: DeclStmt
-// CHECK-NEXT: VarDecl {{.*}} used __SYCLKernel '(lambda at {{.*}}array-kernel-param.cpp{{.*}})' cinit
-// CHECK-NEXT: InitListExpr {{.*}} '(lambda at {{.*}}array-kernel-param.cpp{{.*}})'
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'S<int>':'S<int>' 'void (const S<int> &) noexcept'
+// CHECK-NEXT:  VarDecl
+// CHECK-NEXT: CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} 'S<int>':'S<int>'
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: ImplicitCastExpr
-// CHECK-NEXT: DeclRefExpr {{.*}} 'S<int>':'S<int>' lvalue ParmVar {{.*}} '_arg_s' 'S<int>':'S<int>'
+// CHECK-NEXT:  UnaryOperator
+// CHECK-NEXT:    DeclRefExpr {{.*}} ParmVar {{.*}} '_arg_s'
+// CHECK-NEXT: IntegerLiteral {{.*}} 12
 
 // Check Kernel_Array_2D parameters
 // CHECK: FunctionDecl {{.*}}Kernel_Array_2D{{.*}} 'void (__wrapper_class)'
@@ -223,31 +242,20 @@ int main() {
 // Check Kernel_Array_2D inits
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: DeclStmt
-// CHECK-NEXT: VarDecl {{.*}} cinit
-// CHECK-NEXT: InitListExpr
-// CHECK-NEXT: ArrayInitLoopExpr {{.*}} 'int[2][3]'
-// CHECK-NEXT: OpaqueValueExpr {{.*}} 'int[2][3]' lvalue
-// CHECK-NEXT: MemberExpr {{.*}} 'int[2][3]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_array_2D' '__wrapper_class'
-// CHECK-NEXT: ArrayInitLoopExpr {{.*}} 'int[3]'
-// CHECK-NEXT: OpaqueValueExpr {{.*}} 'int[3]' lvalue
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'int[3]' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int (*)[3]' <ArrayToPointerDecay>
-// CHECK-NEXT: OpaqueValueExpr {{.*}} 'int[2][3]' lvalue
-// CHECK-NEXT: MemberExpr {{.*}} 'int[2][3]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_array_2D' '__wrapper_class'
-// CHECK-NEXT: ArrayInitIndexExpr {{.*}} 'unsigned
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'int' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <ArrayToPointerDecay>
-// CHECK-NEXT: OpaqueValueExpr {{.*}} 'int[3]' lvalue
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'int[3]' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int (*)[3]' <ArrayToPointerDecay>
-// CHECK-NEXT: OpaqueValueExpr {{.*}} 'int[2][3]' lvalue
-// CHECK-NEXT: MemberExpr {{.*}} 'int[2][3]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_array_2D' '__wrapper_class'
-// CHECK-NEXT: ArrayInitIndexExpr {{.*}} 'unsigned
-// CHECK-NEXT: ArrayInitIndexExpr {{.*}} 'unsigned
+// CHECK-NEXT:  VarDecl
+// CHECK-NEXT: CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .array_2D
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT:  UnaryOperator
+// CHECK-NEXT:   MemberExpr
+// CHECK-NEXT:    DeclRefExpr {{.*}} ParmVar {{.*}} '_arg_array_2D'
+// CHECK-NEXT: IntegerLiteral {{.*}} 24
 
 // Check Kernel_NonDecomposedStruct parameters.
 // CHECK: FunctionDecl {{.*}}Kernel_NonDecomposedStruct{{.*}} 'void (__wrapper_class)'
@@ -255,20 +263,20 @@ int main() {
 // Check Kernel_NonDecomposedStruct inits
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: DeclStmt
-// CHECK-NEXT: VarDecl {{.*}} cinit
-// CHECK-NEXT: InitListExpr
-// CHECK-NEXT: ArrayInitLoopExpr {{.*}} 'NonDecomposedStruct[2]'
-// CHECK-NEXT: OpaqueValueExpr {{.*}} 'NonDecomposedStruct[2]' lvalue
-// CHECK-NEXT: MemberExpr {{.*}} 'NonDecomposedStruct[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_NonDecompStructArray' '__wrapper_class'
-// CHECK-NEXT: CXXConstructExpr {{.*}}'NonDecomposedStruct' 'void (const NonDecomposedStruct &) noexcept'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const NonDecomposedStruct':'const NonDecomposedStruct' lvalue <NoOp>
-// CHECK-NEXT: ArraySubscriptExpr {{.*}}'NonDecomposedStruct' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'NonDecomposedStruct *' <ArrayToPointerDecay>
-// CHECK-NEXT: OpaqueValueExpr {{.*}} 'NonDecomposedStruct[2]' lvalue
-// CHECK-NEXT: MemberExpr {{.*}} 'NonDecomposedStruct[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_NonDecompStructArray' '__wrapper_class'
-// CHECK-NEXT: ArrayInitIndexExpr {{.*}} 'unsigned
+// CHECK-NEXT:  VarDecl
+// CHECK-NEXT: CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .NonDecompStructArray
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT:  UnaryOperator
+// CHECK-NEXT:   MemberExpr
+// CHECK-NEXT:    DeclRefExpr {{.*}} ParmVar {{.*}} '_arg_NonDecompStructArray'
+// CHECK-NEXT: IntegerLiteral {{.*}} 32
 
 // Check Kernel_StructWithPointers parameters.
 // CHECK: FunctionDecl {{.*}}Kernel_StructWithPointers{{.*}} 'void (__wrapper_class)'
@@ -276,152 +284,51 @@ int main() {
 // Check Kernel_StructWithPointers inits
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: DeclStmt
-// CHECK-NEXT: VarDecl {{.*}} cinit
-// CHECK-NEXT: InitListExpr
-// CHECK-NEXT: InitListExpr {{.*}} 'StructWithPointers[2]'
-// Initializer for StructWithPointersArray[0]
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'StructWithPointers':'StructWithPointers' 'void (const StructWithPointers &) noexcept'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const StructWithPointers':'const StructWithPointers' lvalue <NoOp>
-// CHECK-NEXT: UnaryOperator {{.*}} 'StructWithPointers':'StructWithPointers' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CXXReinterpretCastExpr {{.*}} 'StructWithPointers *' reinterpret_cast<StructWithPointers *> <BitCast>
-// CHECK-NEXT: UnaryOperator {{.*}} '__generated_StructWithPointers *' prefix '&' cannot overflow
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__generated_StructWithPointers' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__generated_StructWithPointers *' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} '__generated_StructWithPointers[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_StructWithPointersArray'
-// CHECK-NEXT: IntegerLiteral {{.*}} 0
-// Initializer for StructWithPointersArray[1]
-// CHECK: CXXConstructExpr {{.*}} 'StructWithPointers':'StructWithPointers' 'void (const StructWithPointers &) noexcept'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const StructWithPointers':'const StructWithPointers' lvalue <NoOp>
-// CHECK-NEXT: UnaryOperator {{.*}} 'StructWithPointers':'StructWithPointers' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CXXReinterpretCastExpr {{.*}} 'StructWithPointers *' reinterpret_cast<StructWithPointers *> <BitCast>
-// CHECK-NEXT: UnaryOperator {{.*}} '__generated_StructWithPointers *' prefix '&' cannot overflow
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__generated_StructWithPointers' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__generated_StructWithPointers *' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} '__generated_StructWithPointers[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_StructWithPointersArray'
-// CHECK-NEXT: IntegerLiteral {{.*}} 1
+// CHECK-NEXT:  VarDecl
+// CHECK-NEXT: CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .StructWithPointersArray
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT:  UnaryOperator
+// CHECK-NEXT:   MemberExpr
+// CHECK-NEXT:    DeclRefExpr {{.*}} ParmVar {{.*}} '_arg_StructWithPointersArray'
+// CHECK-NEXT: IntegerLiteral {{.*}} 48
 
 // Check Kernel_Array_Ptrs_2D parameters
 // CHECK: FunctionDecl {{.*}}Kernel_Array_Ptrs_2D{{.*}} 'void (__wrapper_class, __wrapper_class)'
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_ArrayOfPointers_2D '__wrapper_class'
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_ArrayOfPointers '__wrapper_class'
-
-// Check Kernel_Array_Ptrs_2D inits
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: DeclStmt
-// CHECK-NEXT: VarDecl {{.*}} cinit
-// CHECK-NEXT: InitListExpr
-
-// Initializer for ArrayOfPointers_2D
-// CHECK-NEXT: InitListExpr {{.*}} 'int *[2][3]'
-// CHECK-NEXT: InitListExpr {{.*}} 'int *[3]'
-// Initializer for ArrayOfPointers_2D[0][0]
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <LValueToRValue>
-// CHECK-NEXT: UnaryOperator {{.*}} 'int *' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CXXReinterpretCastExpr {{.*}} 'int **' reinterpret_cast<int **> <BitCast>
-// CHECK-NEXT: UnaryOperator {{.*}} '__global int **' prefix '&' cannot overflow
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__global int *' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int **' <ArrayToPointerDecay>
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__global int *[3]' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *(*)[3]' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} '__global int *[2][3]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ArrayOfPointers_2D'
-// CHECK-NEXT: IntegerLiteral {{.*}} 0
-// CHECK-NEXT: IntegerLiteral {{.*}} 0
-
-// Initializer for ArrayOfPointers_2D[0][1]
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <LValueToRValue>
-// CHECK-NEXT: UnaryOperator {{.*}} 'int *' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CXXReinterpretCastExpr {{.*}} 'int **' reinterpret_cast<int **> <BitCast>
-// CHECK-NEXT: UnaryOperator {{.*}} '__global int **' prefix '&' cannot overflow
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__global int *' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int **' <ArrayToPointerDecay>
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__global int *[3]' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *(*)[3]' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} '__global int *[2][3]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ArrayOfPointers_2D'
-// CHECK-NEXT: IntegerLiteral {{.*}} 0
-// CHECK-NEXT: IntegerLiteral {{.*}} 1
-
-// Initializer for ArrayOfPointers_2D[0][2]
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <LValueToRValue>
-// CHECK-NEXT: UnaryOperator {{.*}} 'int *' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CXXReinterpretCastExpr {{.*}} 'int **' reinterpret_cast<int **> <BitCast>
-// CHECK-NEXT: UnaryOperator {{.*}} '__global int **' prefix '&' cannot overflow
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__global int *' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int **' <ArrayToPointerDecay>
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__global int *[3]' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *(*)[3]' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} '__global int *[2][3]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ArrayOfPointers_2D'
-// CHECK-NEXT: IntegerLiteral {{.*}} 0
-// CHECK-NEXT: IntegerLiteral {{.*}} 2
-
-// CHECK-NEXT: InitListExpr {{.*}} 'int *[3]'
-
-// Initializer for ArrayOfPointers_2D[1][0]
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <LValueToRValue>
-// CHECK-NEXT: UnaryOperator {{.*}} 'int *' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CXXReinterpretCastExpr {{.*}} 'int **' reinterpret_cast<int **> <BitCast>
-// CHECK-NEXT: UnaryOperator {{.*}} '__global int **' prefix '&' cannot overflow
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__global int *' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int **' <ArrayToPointerDecay>
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__global int *[3]' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *(*)[3]' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} '__global int *[2][3]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ArrayOfPointers_2D'
-// CHECK-NEXT: IntegerLiteral {{.*}} 1
-// CHECK-NEXT: IntegerLiteral {{.*}} 0
-
-// Initializer for ArrayOfPointers_2D[1][1]
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <LValueToRValue>
-// CHECK-NEXT: UnaryOperator {{.*}} 'int *' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CXXReinterpretCastExpr {{.*}} 'int **' reinterpret_cast<int **> <BitCast>
-// CHECK-NEXT: UnaryOperator {{.*}} '__global int **' prefix '&' cannot overflow
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__global int *' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int **' <ArrayToPointerDecay>
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__global int *[3]' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *(*)[3]' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} '__global int *[2][3]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ArrayOfPointers_2D'
-// CHECK-NEXT: IntegerLiteral {{.*}} 1
-// CHECK-NEXT: IntegerLiteral {{.*}} 1
-
-// Initializer for ArrayOfPointers_2D[1][2]
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <LValueToRValue>
-// CHECK-NEXT: UnaryOperator {{.*}} 'int *' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CXXReinterpretCastExpr {{.*}} 'int **' reinterpret_cast<int **> <BitCast>
-// CHECK-NEXT: UnaryOperator {{.*}} '__global int **' prefix '&' cannot overflow
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__global int *' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int **' <ArrayToPointerDecay>
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__global int *[3]' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *(*)[3]' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} '__global int *[2][3]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ArrayOfPointers_2D'
-// CHECK-NEXT: IntegerLiteral {{.*}} 1
-// CHECK-NEXT: IntegerLiteral {{.*}} 2
-
-// Initializer for ArrayOfPointers
-// CHECK-NEXT: InitListExpr {{.*}} 'int *[2]'
-// Initializer for ArrayOfPointers[0]
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <LValueToRValue>
-// CHECK-NEXT: UnaryOperator {{.*}} 'int *' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CXXReinterpretCastExpr {{.*}} 'int **' reinterpret_cast<int **> <BitCast>
-// CHECK-NEXT: UnaryOperator {{.*}} '__global int **' prefix '&' cannot overflow
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__global int *' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int **' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} '__global int *[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ArrayOfPointers'
-// CHECK-NEXT: IntegerLiteral {{.*}} 0
-
-// Initializer for ArrayOfPointers[1]
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <LValueToRValue>
-// CHECK-NEXT: UnaryOperator {{.*}} 'int *' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CXXReinterpretCastExpr {{.*}} 'int **' reinterpret_cast<int **> <BitCast>
-// CHECK-NEXT: UnaryOperator {{.*}} '__global int **' prefix '&' cannot overflow
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__global int *' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int **' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} '__global int *[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ArrayOfPointers'
-// CHECK-NEXT: IntegerLiteral {{.*}} 1
+// CHECK-NEXT:  VarDecl
+// CHECK-NEXT: CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .ArrayOfPointers_2D
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT:  UnaryOperator
+// CHECK-NEXT:   MemberExpr
+// CHECK-NEXT:    DeclRefExpr {{.*}} ParmVar {{.*}} '_arg_ArrayOfPointers_2D'
+// CHECK-NEXT: IntegerLiteral {{.*}} 48
+// CHECK-NEXT: CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .ArrayOfPointers
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT:  UnaryOperator
+// CHECK-NEXT:   MemberExpr
+// CHECK-NEXT:    DeclRefExpr {{.*}} ParmVar {{.*}} '_arg_ArrayOfPointers'
+// CHECK-NEXT: IntegerLiteral {{.*}} 16

--- a/clang/test/SemaSYCL/basic-kernel-wrapper.cpp
+++ b/clang/test/SemaSYCL/basic-kernel-wrapper.cpp
@@ -34,14 +34,22 @@ int main() {
 // Check lambda declaration inside the wrapper
 
 // CHECK: DeclStmt
-// CHECK-NEXT: VarDecl {{.*}} used __SYCLKernel '(lambda at {{.*}}basic-kernel-wrapper.cpp{{.*}})'
+// CHECK: VarDecl {{.*}} '__wrapper_union'
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .readWriteAccessor
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
 
 // Check accessor initialization
 
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ({{.*}}PtrType, range<1>, range<1>, id<1>)' lvalue .__init
-// CHECK-NEXT: MemberExpr {{.*}} 'sycl::accessor<int, 1, sycl::access::mode::read_write>':'sycl::accessor<int, 1, sycl::access::mode::read_write>' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at {{.*}}basic-kernel-wrapper.cpp{{.*}})' lvalue Var
+// CHECK-NEXT:  MemberExpr {{.*}} .readWriteAccessor
+// CHECK-NEXT:   MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:    DeclRefExpr {{.*}} '__wrapper_union'
 
 // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>
 // CHECK-NEXT: DeclRefExpr {{.*}} '__global int *' lvalue ParmVar {{.*}} '[[_arg_Mem]]' '__global int *'

--- a/clang/test/SemaSYCL/built-in-type-kernel-arg.cpp
+++ b/clang/test/SemaSYCL/built-in-type-kernel-arg.cpp
@@ -81,78 +81,93 @@ int main() {
 // CHECK: ParmVarDecl {{.*}} used _arg_some_const 'const int'
 
 // Check that lambda field of const built-in type is initialized
-// CHECK: VarDecl {{.*}}'(lambda at {{.*}}built-in-type-kernel-arg.cpp{{.*}})'
-// CHECK-NEXT: InitListExpr
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
-// CHECK-NEXT: DeclRefExpr {{.*}} 'const int' lvalue ParmVar {{.*}} '_arg_some_const' 'const int'
+// CHECK:      VarDecl {{.*}} '__wrapper_union'
+// CHECK:      BinaryOperator {{.*}} '='
+// CHECK-NEXT:  MemberExpr {{.*}} .some_const
+// CHECK-NEXT:   MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:    DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:  DeclRefExpr {{.*}} ParmVar {{.*}} '_arg_some_const'
 
 // Check kernel parameters
 // CHECK: {{.*}}kernel_int{{.*}} 'void (int)'
 // CHECK: ParmVarDecl {{.*}} used _arg_data 'int'
 
 // Check that lambda field of built-in type is initialized
-// CHECK: VarDecl {{.*}}'(lambda at {{.*}}built-in-type-kernel-arg.cpp{{.*}})'
-// CHECK-NEXT: InitListExpr
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
-// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_data' 'int'
+// CHECK: VarDecl {{.*}} '__wrapper_union'
+// CHECK:      BinaryOperator {{.*}} '='
+// CHECK-NEXT:  MemberExpr {{.*}} .data
+// CHECK-NEXT:   MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:    DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:  DeclRefExpr {{.*}} ParmVar {{.*}} '_arg_data'
 
 // Check kernel parameters
 // CHECK: {{.*}}kernel_struct{{.*}} 'void (__generated_test_struct)'
 // CHECK: ParmVarDecl {{.*}} used _arg_s '__generated_test_struct'
 
 // Check that lambda field of struct type is initialized
-// CHECK: VarDecl {{.*}}'(lambda at {{.*}}built-in-type-kernel-arg.cpp{{.*}})'
-// CHECK-NEXT: InitListExpr {{.*}}'(lambda at {{.*}}built-in-type-kernel-arg.cpp{{.*}})'
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'test_struct':'test_struct' 'void (const test_struct &) noexcept'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const test_struct':'const test_struct' lvalue <NoOp>
-// CHECK-NEXT: UnaryOperator {{.*}} 'test_struct':'test_struct' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CXXReinterpretCastExpr {{.*}} 'test_struct *' reinterpret_cast<test_struct *> <BitCast>
-// CHECK-NEXT: UnaryOperator {{.*}} '__generated_test_struct *' prefix '&' cannot overflow
-// CHECK-NEXT: DeclRefExpr {{.*}} '__generated_test_struct' lvalue ParmVar {{.*}} '_arg_s'
+// CHECK: VarDecl {{.*}} '__wrapper_union'
+// CHECK:      CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .s
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT: ImplicitCastExpr
+// CHECK-NEXT:  UnaryOperator
+// CHECK-NEXT:    DeclRefExpr {{.*}} ParmVar {{.*}} '_arg_s'
+// CHECK-NEXT: IntegerLiteral {{.*}} 80
 
 // Check kernel parameters
 // CHECK: {{.*}}kernel_pointer{{.*}} 'void (__global int *, __global int *, __wrapper_class)'
 // CHECK: ParmVarDecl {{.*}} used _arg_new_data_addr '__global int *'
 // CHECK: ParmVarDecl {{.*}} used _arg_data_addr '__global int *'
 // CHECK: ParmVarDecl {{.*}} used _arg_ptr_array '__wrapper_class'
-// CHECK: VarDecl {{.*}}'(lambda at {{.*}}built-in-type-kernel-arg.cpp{{.*}})'
+// CHECK: VarDecl {{.*}} '__wrapper_union'
 
 // Check that lambda fields of pointer types are initialized
-// CHECK: InitListExpr
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' <LValueToRValue>
-// CHECK-NEXT: DeclRefExpr {{.*}} '__global int *' lvalue ParmVar {{.*}} '_arg_new_data_addr' '__global int *'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' <LValueToRValue>
-// CHECK-NEXT: DeclRefExpr {{.*}} '__global int *' lvalue ParmVar {{.*}} '_arg_data_addr' '__global int *'
-// CHECK: InitListExpr {{.*}} 'int *[2]'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <LValueToRValue>
-// CHECK-NEXT: UnaryOperator {{.*}} 'int *' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CXXReinterpretCastExpr {{.*}} 'int **' reinterpret_cast<int **> <BitCast>
-// CHECK-NEXT: UnaryOperator {{.*}} '__global int **' prefix '&' cannot overflow
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__global int *' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int **' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} '__global int *[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr_array'
-// CHECK-NEXT: IntegerLiteral {{.*}} 0
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <LValueToRValue>
-// CHECK-NEXT: UnaryOperator {{.*}} 'int *' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CXXReinterpretCastExpr {{.*}} 'int **' reinterpret_cast<int **> <BitCast>
-// CHECK-NEXT: UnaryOperator {{.*}} '__global int **' prefix '&' cannot overflow
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} '__global int *' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int **' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} '__global int *[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_class' lvalue ParmVar {{.*}} '_arg_ptr_array'
-// CHECK-NEXT: IntegerLiteral {{.*}} 1
+// CHECK:      BinaryOperator {{.*}} '='
+// CHECK-NEXT:  MemberExpr {{.*}} .new_data_addr
+// CHECK-NEXT:   MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:    DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:  ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion> 
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    DeclRefExpr {{.*}} ParmVar {{.*}} '_arg_new_data_addr'
+// CHECK-NEXT:  BinaryOperator {{.*}} '='
+// CHECK-NEXT:   MemberExpr {{.*}} .data_addr
+// CHECK-NEXT:    MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:     DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:   ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion> 
+// CHECK-NEXT:    ImplicitCastExpr
+// CHECK-NEXT:      DeclRefExpr {{.*}} ParmVar {{.*}} '_arg_data_addr'
+// CHECK-NEXT: CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .ptr_array
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr
+// CHECK-NEXT:     DeclRefExpr {{.*}} ParmVar {{.*}} '_arg_ptr_array'
+// CHECK-NEXT:  IntegerLiteral {{.*}} 16
 
 // CHECK: FunctionDecl {{.*}}kernel_nns{{.*}} 'void (__generated_test_struct_simple)'
 // CHECK-NEXT: ParmVarDecl {{.*}} used _arg_tds '__generated_test_struct_simple'
 
-// CHECK: VarDecl {{.*}} used __SYCLKernel
-// CHECK: InitListExpr
-// CHECK: CXXConstructExpr {{.*}} 'Nested::TDS':'test_struct_simple' 'void (const test_struct_simple &) noexcept'
-// CHECK: ImplicitCastExpr {{.*}} 'const test_struct_simple':'const test_struct_simple' lvalue <NoOp>
-// CHECK: UnaryOperator {{.*}} 'Nested::TDS':'test_struct_simple' lvalue prefix '*' cannot overflow
-// CHECK: CXXReinterpretCastExpr {{.*}} 'Nested::TDS *' reinterpret_cast<struct Nested::TDS *> <BitCast>
-// CHECK: UnaryOperator {{.*}} '__generated_test_struct_simple *' prefix '&' cannot overflow
-// CHECK: DeclRefExpr {{.*}} '__generated_test_struct_simple' lvalue ParmVar {{.*}} '_arg_tds' '__generated_test_struct_simple'
+// CHECK: VarDecl {{.*}} __wrapper_union
+// CHECK:      CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .tds
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    DeclRefExpr {{.*}} ParmVar {{.*}} '_arg_tds'
+// CHECK-NEXT:  IntegerLiteral {{.*}} 16

--- a/clang/test/SemaSYCL/half-kernel-arg.cpp
+++ b/clang/test/SemaSYCL/half-kernel-arg.cpp
@@ -20,8 +20,16 @@ int main() {
 // CHECK: {{.*}}kernel_half{{.*}} 'void (sycl::half)'
 // CHECK: ParmVarDecl {{.*}} used _arg_HostHalf 'sycl::half':'sycl::detail::half_impl::half'
 // // Check that lambda field of half type is initialized
-// CHECK: VarDecl {{.*}}'(lambda at {{.*}}'
-// CHECK-NEXT: InitListExpr {{.*}}'(lambda at {{.*}}'
-// CHECK-NEXT: CXXConstructExpr {{.*}}'sycl::detail::half_impl::half'{{.*}}
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const half':'const sycl::detail::half_impl::half'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'sycl::half':'sycl::detail::half_impl::half' lvalue ParmVar {{.*}} '_arg_HostHalf' 'sycl::half':'sycl::detail::half_impl::half'
+// CHECK: VarDecl {{.*}} used __wrapper_union '__wrapper_union'
+// CHECK:      CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .HostHalf
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    DeclRefExpr {{.*}} '_arg_HostHalf'
+// CHECK-NEXT:  IntegerLiteral {{.*}} 2

--- a/clang/test/SemaSYCL/inheritance.cpp
+++ b/clang/test/SemaSYCL/inheritance.cpp
@@ -63,41 +63,69 @@ int main() {
 // Check initializers for derived and base classes.
 // Each class has it's own initializer list
 // Base classes should be initialized first.
-// CHECK: VarDecl {{.*}} used derived 'derived' cinit
-// CHECK-NEXT: InitListExpr {{.*}} 'derived'
+// CHECK: VarDecl {{.*}} __wrapper_union
 
 // base is a simple class with no corresponding generated type. Therefore
 // copy from ParamVar
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'base':'base' 'void (const base &) noexcept'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const base':'const base' lvalue <NoOp>
-// CHECK-NEXT: DeclRefExpr {{.*}} lvalue ParmVar {{.*}} '_arg__base' 'base'
+// CHECK:      CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    ImplicitCastExpr {{.*}} <DerivedToBase (base)>
+// CHECK-NEXT:     MemberExpr {{.*}} 'derived'
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    DeclRefExpr {{.*}} '_arg__base'
+// CHECK-NEXT:  IntegerLiteral {{.*}} 12
 
 // second_base contains pointers and therefore the ParamVar is a new generated
 // type. Perform a copy of the corresponding kernel parameter via
 // reinterpret_cast.
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'second_base':'second_base' 'void (const second_base &) noexcept'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const second_base':'const second_base' lvalue <NoOp>
-// CHECK-NEXT: UnaryOperator {{.*}} 'second_base':'second_base' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CXXReinterpretCastExpr {{.*}} 'second_base *' reinterpret_cast<second_base *> <BitCast>
-// CHECK-NEXT: UnaryOperator {{.*}} '__generated_second_base *' prefix '&' cannot overflow
-// CHECK-NEXT: DeclRefExpr {{.*}} '__generated_second_base' lvalue ParmVar {{.*}} '_arg__base' '__generated_second_base'
+// CHECK-NEXT: CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    ImplicitCastExpr {{.*}} <DerivedToBase (second_base)>
+// CHECK-NEXT:     MemberExpr {{.*}} 'derived'
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    DeclRefExpr {{.*}} '_arg__base' '__generated_second_base'
+// CHECK-NEXT:  IntegerLiteral {{.*}} 8
 
 // third_base contains special type accessor. Therefore it is decomposed and it's
 // data members are copied from corresponding ParamVar
-// CHECK-NEXT: InitListExpr {{.*}} 'third_base'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int *' <AddressSpaceConversion>
-// CHECK-NEXT: ImplicitCastExpr {{.*}} '__global int *' <LValueToRValue>
-// CHECK-NEXT: MemberExpr {{.*}} '__global int *' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} lvalue ParmVar {{.*}} '_arg_d' '__wrapper_class'
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::accessor<char, 1, sycl::access::mode::read>'
-
-// Initialize fields of 'derived'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
-// CHECK-NEXT: DeclRefExpr {{.*}} lvalue ParmVar {{.*}} '_arg_a' 'int'
-
+// CHECK-NEXT:  BinaryOperator {{.*}} '='
+// CHECK-NEXT:   MemberExpr {{.*}} .d
+// CHECK-NEXT:    ImplicitCastExpr {{.*}} <DerivedToBase (third_base)>
+// CHECK-NEXT:     MemberExpr {{.*}} 'derived'
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:   ImplicitCastExpr {{.*}} <AddressSpaceConversion>
+// CHECK-NEXT:    ImplicitCastExpr
+// CHECK-NEXT:     MemberExpr {{.*}} lvalue .
+// CHECK-NEXT:      DeclRefExpr {{.*}} '_arg_d' '__wrapper_class'
+// CHECK-NEXT: CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .AccField
+// CHECK-NEXT:     ImplicitCastExpr {{.*}} <DerivedToBase (third_base)>
+// CHECK-NEXT:      MemberExpr {{.*}} 'derived'
+// CHECK-NEXT:       DeclRefExpr {{.*}} '__wrapper_union'
 // Check kernel body for call to __init function of accessor
 // CHECK: CXXMemberCallExpr
 // CHECK-NEXT: MemberExpr {{.*}} lvalue .__init
 // CHECK-NEXT: MemberExpr {{.*}} lvalue .AccField
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'third_base':'third_base' lvalue <DerivedToBase (third_base)>
-// CHECK-NEXT: DeclRefExpr {{.*}} 'derived' lvalue Var {{.*}} 'derived' 'derived'
+// CHECK-NEXT:  MemberExpr {{.*}} 'derived'
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
+
+// Initialize fields of 'derived'
+// CHECK:      BinaryOperator {{.*}} '='
+// CHECK-NEXT:  MemberExpr {{.*}} .a
+// CHECK-NEXT:   MemberExpr {{.*}} 'derived'
+// CHECK-NEXT:    DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:  DeclRefExpr {{.*}} '_arg_a'

--- a/clang/test/SemaSYCL/kernel-handler.cpp
+++ b/clang/test/SemaSYCL/kernel-handler.cpp
@@ -35,10 +35,13 @@ int main() {
 // Check declaration and initialization of kernel object local clone
 // NONATIVESUPPORT-NEXT: CompoundStmt
 // NONATIVESUPPORT-NEXT: DeclStmt
-// NONATIVESUPPORT-NEXT: VarDecl {{.*}} cinit
-// NONATIVESUPPORT-NEXT: InitListExpr
-// NONATIVESUPPORT-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
-// NONATIVESUPPORT-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_a' 'int'
+// NONATIVESUPPORT-NEXT: VarDecl {{.*}}
+
+// NONATIVESUPPORT:      BinaryOperator {{.*}} '='
+// NONATIVESUPPORT-NEXT:  MemberExpr {{.*}} .a
+// NONATIVESUPPORT-NEXT:   MemberExpr {{.*}} '(lambda at
+// NONATIVESUPPORT-NEXT:    DeclRefExpr {{.*}} '__wrapper_union'
+// NONATIVESUPPORT-NEXT:  DeclRefExpr {{.*}} '_arg_a'
 
 // Check declaration and initialization of kernel handler local clone using default constructor
 // NONATIVESUPPORT-NEXT: DeclStmt
@@ -52,16 +55,16 @@ int main() {
 // NONATIVESUPPORT-NEXT: ImplicitCastExpr {{.*}} 'char *' <AddressSpaceConversion>
 // NONATIVESUPPORT-NEXT: ImplicitCastExpr {{.*}} '__global char *' <LValueToRValue>
 // NONATIVESUPPORT-NEXT: DeclRefExpr {{.*}} '__global char *' lvalue ParmVar {{.*}} '_arg__specialization_constants_buffer' '__global char *'
-// NONATIVESUPPORT-NEXT: CompoundStmt
+// NONATIVESUPPORT:      CompoundStmt
 // NONATIVESUPPORT-NEXT: CXXOperatorCallExpr
 // NONATIVESUPPORT-NEXT: ImplicitCastExpr {{.*}} 'void (*)(sycl::kernel_handler) const' <FunctionToPointerDecay>
 // NONATIVESUPPORT-NEXT: DeclRefExpr {{.*}} 'void (sycl::kernel_handler) const' lvalue CXXMethod {{.*}} 'operator()' 'void (sycl::kernel_handler) const'
 // Kernel body with clones
 // NONATIVESUPPORT-NEXT: ImplicitCastExpr {{.*}} 'const (lambda at {{.*}}kernel-handler.cpp{{.*}})' lvalue
-// NONATIVESUPPORT-NEXT: DeclRefExpr {{.*}} '(lambda at {{.*}}kernel-handler.cpp{{.*}})' lvalue Var {{.*}} '(lambda at {{.*}}kernel-handler.cpp{{.*}})'
+// NONATIVESUPPORT-NEXT: DeclRefExpr {{.*}} '(lambda at {{.*}}kernel-handler.cpp{{.*}})' lvalue Var {{.*}} '(lambda at {{.*}}kernel-handler.cpp{{.*}}) &'
 // NONATIVESUPPORT-NEXT: CXXConstructExpr {{.*}} 'sycl::kernel_handler':'sycl::kernel_handler' 'void (const kernel_handler &) noexcept'
-// NONATIVESUPPORT-NEXT: ImplicitCastExpr {{.*}} 'const kernel_handler':'const sycl::kernel_handler' lvalue
-// NONATIVESUPPORT-NEXT: DeclRefExpr {{.*}} 'kernel_handler':'sycl::kernel_handler' lvalue Var {{.*}} 'kh' 'kernel_handler':'sycl::kernel_handler'
+// NONATIVESUPPORT-NEXT: ImplicitCastExpr {{.*}}const sycl::kernel_handler' lvalue
+// NONATIVESUPPORT-NEXT: DeclRefExpr {{.*}}'sycl::kernel_handler' lvalue Var {{.*}} 'kh' {{.*}}'sycl::kernel_handler'
 
 // Check test_pfwg_kernel_handler parameters
 // NONATIVESUPPORT: FunctionDecl {{.*}}test_pfwg_kernel_handler{{.*}} 'void (int, __global char *)'
@@ -71,11 +74,14 @@ int main() {
 // Check declaration and initialization of kernel object local clone
 // NONATIVESUPPORT-NEXT: CompoundStmt
 // NONATIVESUPPORT-NEXT: DeclStmt
-// NONATIVESUPPORT-NEXT: VarDecl {{.*}} cinit
-// NONATIVESUPPORT-NEXT: InitListExpr
-// NONATIVESUPPORT-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
-// NONATIVESUPPORT-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_a' 'int'
+// NONATIVESUPPORT-NEXT: VarDecl {{.*}}
 // NONATIVESUPPORT-NEXT: SYCLScopeAttr {{.*}} Implicit WorkGroup
+
+// NONATIVESUPPORT:      BinaryOperator {{.*}} '='
+// NONATIVESUPPORT-NEXT:  MemberExpr {{.*}} .a
+// NONATIVESUPPORT-NEXT:   MemberExpr {{.*}} '(lambda at
+// NONATIVESUPPORT-NEXT:    DeclRefExpr {{.*}} '__wrapper_union'
+// NONATIVESUPPORT-NEXT:  DeclRefExpr {{.*}} '_arg_a'
 
 // Check declaration and initialization of kernel handler local clone using default constructor
 // NONATIVESUPPORT-NEXT: DeclStmt
@@ -89,14 +95,14 @@ int main() {
 // NONATIVESUPPORT-NEXT: ImplicitCastExpr {{.*}} 'char *' <AddressSpaceConversion>
 // NONATIVESUPPORT-NEXT: ImplicitCastExpr {{.*}} '__global char *' <LValueToRValue>
 // NONATIVESUPPORT-NEXT: DeclRefExpr {{.*}} '__global char *' lvalue ParmVar {{.*}} '_arg__specialization_constants_buffer' '__global char *'
-// NONATIVESUPPORT-NEXT: CompoundStmt
+// NONATIVESUPPORT:      CompoundStmt
 // NONATIVESUPPORT-NEXT: CXXOperatorCallExpr
 // NONATIVESUPPORT-NEXT: ImplicitCastExpr {{.*}} 'void (*)(group<1>, kernel_handler) const' <FunctionToPointerDecay>
 // NONATIVESUPPORT-NEXT: DeclRefExpr {{.*}} 'void (group<1>, kernel_handler) const' lvalue CXXMethod {{.*}} 'operator()' 'void (group<1>, kernel_handler) const'
 
 // Kernel body with clones
 // NONATIVESUPPORT-NEXT: ImplicitCastExpr {{.*}} 'const (lambda at {{.*}}kernel-handler.cpp{{.*}})' lvalue
-// NONATIVESUPPORT-NEXT: DeclRefExpr {{.*}} '(lambda at {{.*}}kernel-handler.cpp{{.*}})' lvalue Var {{.*}} '(lambda at {{.*}}kernel-handler.cpp{{.*}})'
+// NONATIVESUPPORT-NEXT: DeclRefExpr {{.*}} '(lambda at {{.*}}kernel-handler.cpp{{.*}})' lvalue Var {{.*}} '(lambda at {{.*}}kernel-handler.cpp{{.*}}) &'
 // NONATIVESUPPORT-NEXT: CXXTemporaryObjectExpr {{.*}} 'group<1>':'sycl::group<>' 'void () noexcept' zeroing
 // NONATIVESUPPORT-NEXT: CXXConstructExpr {{.*}}'kernel_handler':'sycl::kernel_handler' 'void (const kernel_handler &) noexcept'
 // NONATIVESUPPORT-NEXT: ImplicitCastExpr {{.*}}'const sycl::kernel_handler' lvalue
@@ -112,10 +118,13 @@ int main() {
 // Check declaration and initialization of kernel object local clone
 // NATIVESUPPORT-NEXT: CompoundStmt
 // NATIVESUPPORT-NEXT: DeclStmt
-// NATIVESUPPORT-NEXT: VarDecl {{.*}} cinit
-// NATIVESUPPORT-NEXT: InitListExpr
-// NATIVESUPPORT-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
-// NATIVESUPPORT-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar {{.*}} '_arg_a' 'int'
+// NATIVESUPPORT-NEXT: VarDecl {{.*}}
+
+// NATIVESUPPORT:      BinaryOperator {{.*}} '='
+// NATIVESUPPORT-NEXT:  MemberExpr {{.*}} .a
+// NATIVESUPPORT-NEXT:   MemberExpr {{.*}} '(lambda at
+// NATIVESUPPORT-NEXT:    DeclRefExpr {{.*}} '__wrapper_union'
+// NATIVESUPPORT-NEXT:  DeclRefExpr {{.*}} '_arg_a'
 
 // Check declaration and initialization of kernel handler local clone using default constructor
 // NATIVESUPPORT-NEXT: DeclStmt
@@ -127,7 +136,7 @@ int main() {
 
 // Kernel body with clones
 // NATIVESUPPORT: ImplicitCastExpr {{.*}} 'const (lambda at {{.*}}kernel-handler.cpp{{.*}})' lvalue
-// NATIVESUPPORT-NEXT: DeclRefExpr {{.*}} '(lambda at {{.*}}kernel-handler.cpp{{.*}})' lvalue Var {{.*}} '(lambda at {{.*}}kernel-handler.cpp{{.*}})'
+// NATIVESUPPORT-NEXT: DeclRefExpr {{.*}} '(lambda at {{.*}}kernel-handler.cpp{{.*}})' lvalue Var {{.*}} '(lambda at {{.*}}kernel-handler.cpp{{.*}}) &'
 // NATIVESUPPORT-NEXT: CXXConstructExpr {{.*}} 'sycl::kernel_handler':'sycl::kernel_handler' 'void (const kernel_handler &) noexcept'
-// NATIVESUPPORT-NEXT: ImplicitCastExpr {{.*}} 'const kernel_handler':'const sycl::kernel_handler' lvalue
-// NATIVESUPPORT-NEXT: DeclRefExpr {{.*}} 'kernel_handler':'sycl::kernel_handler' lvalue Var {{.*}} 'kh' 'kernel_handler':'sycl::kernel_handler'
+// NATIVESUPPORT-NEXT: ImplicitCastExpr {{.*}}'const sycl::kernel_handler' lvalue
+// NATIVESUPPORT-NEXT: DeclRefExpr {{.*}}'sycl::kernel_handler' lvalue Var {{.*}} 'kh' {{.*}}'sycl::kernel_handler'

--- a/clang/test/SemaSYCL/sampler.cpp
+++ b/clang/test/SemaSYCL/sampler.cpp
@@ -29,7 +29,8 @@ int main() {
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void (__ocl_sampler_t)' lvalue .__init
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::sampler':'sycl::sampler' lvalue
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at {{.*}}sampler.cpp{{.*}})' lvalue Var {{.*}} '(lambda at {{.*}}sampler.cpp{{.*}})'
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 //
 // Check the parameters of __init method
 // CHECK-NEXT: ImplicitCastExpr {{.*}} '__ocl_sampler_t':'sampler_t' <LValueToRValue>

--- a/clang/test/SemaSYCL/spec-const-kernel-arg.cpp
+++ b/clang/test/SemaSYCL/spec-const-kernel-arg.cpp
@@ -25,9 +25,27 @@ int main() {
 }
 
 // CHECK: FunctionDecl {{.*}}kernel_sc{{.*}} 'void ()'
-// CHECK: VarDecl {{.*}}'(lambda at {{.*}}'
-// CHECK-NEXT: InitListExpr {{.*}}'(lambda at {{.*}}'
-// CHECK-NEXT: CXXConstructExpr {{.*}}'sycl::ext::oneapi::experimental::spec_constant<char, class MyInt32Const>':'sycl::ext::oneapi::experimental::spec_constant<char, MyInt32Const>'
-// CHECK-NEXT: InitListExpr {{.*}} 'SpecConstantsWrapper'
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::ext::oneapi::experimental::spec_constant<int, class sc_name1>':'sycl::ext::oneapi::experimental::spec_constant<int, sc_name1>'
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::ext::oneapi::experimental::spec_constant<int, class sc_name2>':'sycl::ext::oneapi::experimental::spec_constant<int, sc_name2>'
+// CHECK: VarDecl {{.*}} used __wrapper_union '__wrapper_union'
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr {{.*}} 'sycl::ext::oneapi::experimental::spec_constant<char, MyInt32Const>'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .SC
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT: CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr {{.*}} 'sycl::ext::oneapi::experimental::spec_constant<int, sc_name1>'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .SC1
+// CHECK-NEXT:     MemberExpr {{.*}} .SCWrapper
+// CHECK-NEXT:      MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:       DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT: CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr {{.*}} 'sycl::ext::oneapi::experimental::spec_constant<int, sc_name2>'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .SC2
+// CHECK-NEXT:     MemberExpr {{.*}} .SCWrapper
+// CHECK-NEXT:      MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:       DeclRefExpr {{.*}} '__wrapper_union'

--- a/clang/test/SemaSYCL/spec-const-value-dependent-crash.cpp
+++ b/clang/test/SemaSYCL/spec-const-value-dependent-crash.cpp
@@ -19,6 +19,11 @@ int main() {
 }
 
 // CHECK: FunctionDecl {{.*}}kernel_sc{{.*}} 'void ()'
-// CHECK: VarDecl {{.*}}'(lambda at {{.*}}'
-// CHECK-NEXT: InitListExpr {{.*}}'(lambda at {{.*}}'
-// CHECK-NEXT: CXXConstructExpr {{.*}}'sycl::ext::oneapi::experimental::spec_constant<int, class MyInt32Const>':'sycl::ext::oneapi::experimental::spec_constant<int, MyInt32Const>' 'void ()'
+// CHECK: VarDecl {{.*}} __wrapper_union
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr {{.*}} 'sycl::ext::oneapi::experimental::spec_constant<int, MyInt32Const>' 'void ()'
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     MemberExpr {{.*}} .SC
+// CHECK-NEXT:      MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:       DeclRefExpr {{.*}} '__wrapper_union'

--- a/clang/test/SemaSYCL/stream.cpp
+++ b/clang/test/SemaSYCL/stream.cpp
@@ -50,286 +50,274 @@ int main() {
 
 // Initializers:
 
-// CHECK: InitListExpr {{.*}} '(lambda at
 // 'in_lambda'
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// 'in_lambda_array'
-// CHECK-NEXT: InitListExpr {{.*}} 'sycl::stream[2]'
-// element 0
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// element 1
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-
-// 'in_lambda_mdarray'
-// CHECK-NEXT: InitListExpr {{.*}} 'sycl::stream[2][2]'
-// sub-array 0
-// CHECK-NEXT: InitListExpr {{.*}} 'sycl::stream[2]'
-// element 0
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// element 1
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// sub-array 1
-// CHECK-NEXT: InitListExpr {{.*}} 'sycl::stream[2]'
-// element 0
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// element 1
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-
-// HasStreams struct
-// CHECK: InitListExpr {{.*}} 'HasStreams'
-// HasStreams::s1
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// HasStreams::s_array
-// CHECK-NEXT: InitListExpr {{.*}} 'sycl::stream[2]'
-// element 0
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// element 1
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-
-// HasArrayOfHasStreams
-// CHECK-NEXT: InitListExpr {{.*}} 'HasArrayOfHasStreams'
-// HasArrayOfHasStreams::i
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
-// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar
-// HasArrayOfHasStreams::hs
-// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams[2]'
-// HasStreams struct
-// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams'
-// HasStreams::s1
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// HasStreams::s_array
-// CHECK-NEXT: InitListExpr {{.*}} 'sycl::stream[2]'
-// element 0
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// element 1
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// HasStreams struct
-// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams'
-// HasStreams::s1
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// HasStreams::s_array
-// CHECK-NEXT: InitListExpr {{.*}} 'sycl::stream[2]'
-// element 0
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// element 1
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-
-// HasArrayOfHasStreams Array
-// CHECK: InitListExpr {{.*}} 'HasArrayOfHasStreams[2]'
-// // HasArrayOfHasStreams Struct
-// CHECK-NEXT: InitListExpr {{.*}} 'HasArrayOfHasStreams'
-// HasArrayOfHasStreams::i
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
-// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar
-// HasArrayOfHasStreams::hs
-// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams[2]'
-// HasStreams struct
-// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams'
-// HasStreams::s1
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// HasStreams::s_array
-// CHECK-NEXT: InitListExpr {{.*}} 'sycl::stream[2]'
-// element 0
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// element 1
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// HasStreams struct
-// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams'
-// HasStreams::s1
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// HasStreams::s_array
-// CHECK-NEXT: InitListExpr {{.*}} 'sycl::stream[2]'
-// element 0
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// element 1
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// HasArrayOfHasStreams Struct
-// CHECK-NEXT: InitListExpr {{.*}} 'HasArrayOfHasStreams'
-// HasArrayOfHasStreams::i
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'int' <LValueToRValue>
-// CHECK-NEXT: DeclRefExpr {{.*}} 'int' lvalue ParmVar
-// HasArrayOfHasStreams::hs
-// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams[2]'
-// HasStreams struct
-// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams'
-// HasStreams::s1
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// HasStreams::s_array
-// CHECK-NEXT: InitListExpr {{.*}} 'sycl::stream[2]'
-// element 0
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// element 1
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// HasStreams struct
-// CHECK-NEXT: InitListExpr {{.*}} 'HasStreams'
-// HasStreams::s1
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// HasStreams::s_array
-// CHECK-NEXT: InitListExpr {{.*}} 'sycl::stream[2]'
-// element 0
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-// element 1
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::stream':'sycl::stream' 'void () noexcept'
-
-// Calls to init
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     MemberExpr {{.*}} .in_lambda
+// CHECK-NEXT:      MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:       DeclRefExpr {{.*}} '__wrapper_union'
 // in_lambda __init
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 
-// in_lambda_array
+// 'in_lambda_array'
 // element 0
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       MemberExpr {{.*}} .in_lambda_array
+// CHECK-NEXT:        MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:         DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:     IntegerLiteral {{.*}} 0
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
-
 // element 1
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       MemberExpr {{.*}} .in_lambda_array
+// CHECK-NEXT:        MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:         DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:     IntegerLiteral {{.*}} 1
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr  {{.*}} 'sycl::stream[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 
-// _in_lambda_mdarray
+// 'in_lambda_mdarray'
 // [0][0]
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       ArraySubscriptExpr
+// CHECK-NEXT:        ImplicitCastExpr
+// CHECK-NEXT:         MemberExpr {{.*}} .in_lambda_mdarray
+// CHECK-NEXT:          MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:           DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:       IntegerLiteral {{.*}} 0
+// CHECK-NEXT:     IntegerLiteral {{.*}} 0
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream[2]' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream (*)[2]' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2][2]' lvalue
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
-// [0][1]
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// [1][0]
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       ArraySubscriptExpr
+// CHECK-NEXT:        ImplicitCastExpr
+// CHECK-NEXT:         MemberExpr {{.*}} .in_lambda_mdarray
+// CHECK-NEXT:          MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:           DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:       IntegerLiteral {{.*}} 0
+// CHECK-NEXT:     IntegerLiteral {{.*}} 1
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream[2]' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream (*)[2]' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2][2]' lvalue
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
-// [1][0]
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// [0][1]
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       ArraySubscriptExpr
+// CHECK-NEXT:        ImplicitCastExpr
+// CHECK-NEXT:         MemberExpr {{.*}} .in_lambda_mdarray
+// CHECK-NEXT:          MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:           DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:       IntegerLiteral {{.*}} 1
+// CHECK-NEXT:     IntegerLiteral {{.*}} 0
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream[2]' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream (*)[2]' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2][2]' lvalue
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // [1][1]
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       ArraySubscriptExpr
+// CHECK-NEXT:        ImplicitCastExpr
+// CHECK-NEXT:         MemberExpr {{.*}} .in_lambda_mdarray
+// CHECK-NEXT:          MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:           DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:       IntegerLiteral {{.*}} 1
+// CHECK-NEXT:     IntegerLiteral {{.*}} 1
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream[2]' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream (*)[2]' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2][2]' lvalue
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 
-// HasStreams
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// HasStreams struct
+// HasStreams::s1
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     MemberExpr {{.*}} .s1
+// CHECK-NEXT:      MemberExpr {{.*}} .Struct
+// CHECK-NEXT:       MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:        DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue .s1
 // CHECK-NEXT: MemberExpr {{.*}}'HasStreams' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
-// array:
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
+// 'HasStreams::s_array'
+// element 0
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       MemberExpr {{.*}} .s_array
+// CHECK-NEXT:        MemberExpr {{.*}} .Struct
+// CHECK-NEXT:         MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:          DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:     IntegerLiteral {{.*}} 0
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2]' lvalue .s_array
 // CHECK-NEXT: MemberExpr {{.*}}'HasStreams' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // element 1
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       MemberExpr {{.*}} .s_array
+// CHECK-NEXT:        MemberExpr {{.*}} .Struct
+// CHECK-NEXT:         MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:          DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:     IntegerLiteral {{.*}} 1
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2]' lvalue .s_array
 // CHECK-NEXT: MemberExpr {{.*}}'HasStreams' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 
 // HasArrayOfHasStreams
-// First element
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// HasArrayOfHasStreams::i
+// CHECK:      BinaryOperator {{.*}} '='
+// CHECK-NEXT:  MemberExpr {{.*}} .i
+// CHECK-NEXT:   MemberExpr {{.*}} .haohs
+// CHECK-NEXT:    MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:     DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:    DeclRefExpr {{.*}} '_arg_i'
+// HasArrayOfHasStreams::hs
+// HasStreams struct
+// HasStreams::s1
+// CHECK-NEXT: CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     MemberExpr {{.*}} .s1
+// CHECK-NEXT:      ArraySubscriptExpr
+// CHECK-NEXT:       ImplicitCastExpr
+// CHECK-NEXT:        MemberExpr {{.*}} .hs
+// CHECK-NEXT:         MemberExpr {{.*}} .haohs
+// CHECK-NEXT:          MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:           DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:      IntegerLiteral {{.*}} 0
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue .s1
 // CHECK-NEXT: ArraySubscriptExpr {{.*}}'HasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
 // CHECK-NEXT: MemberExpr {{.*}}'HasArrayOfHasStreams' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
-// array:
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
-// CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2]' lvalue .s_array
-// CHECK-NEXT: ArraySubscriptExpr {{.*}}'HasStreams' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
-// CHECK-NEXT: MemberExpr {{.*}}'HasArrayOfHasStreams' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
-// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
-// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
-// element 1
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
-// CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2]' lvalue .s_array
-// CHECK-NEXT: ArraySubscriptExpr {{.*}}'HasStreams' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
-// CHECK-NEXT: MemberExpr {{.*}}'HasArrayOfHasStreams' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
-// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
-// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
-// second element
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
-// CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
-// CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue .s1
-// CHECK-NEXT: ArraySubscriptExpr {{.*}}'HasStreams' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
-// CHECK-NEXT: MemberExpr {{.*}}'HasArrayOfHasStreams' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
-// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
-// array:
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
-// CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2]' lvalue .s_array
-// CHECK-NEXT: ArraySubscriptExpr {{.*}}'HasStreams' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
-// CHECK-NEXT: MemberExpr {{.*}}'HasArrayOfHasStreams' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
-// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
-// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
-// element 1
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// HasStreams::s_array
+// element 0
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       MemberExpr {{.*}} .s_array
+// CHECK-NEXT:        ArraySubscriptExpr
+// CHECK-NEXT:         ImplicitCastExpr
+// CHECK-NEXT:          MemberExpr {{.*}} .hs
+// CHECK-NEXT:           MemberExpr {{.*}} .haohs
+// CHECK-NEXT:            MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:             DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:        IntegerLiteral {{.*}} 0
+// CHECK-NEXT:     IntegerLiteral {{.*}} 0
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
@@ -338,12 +326,154 @@ int main() {
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
 // CHECK-NEXT: MemberExpr {{.*}}'HasArrayOfHasStreams' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       MemberExpr {{.*}} .s_array
+// CHECK-NEXT:        ArraySubscriptExpr
+// CHECK-NEXT:         ImplicitCastExpr
+// CHECK-NEXT:          MemberExpr {{.*}} .hs
+// CHECK-NEXT:           MemberExpr {{.*}} .haohs
+// CHECK-NEXT:            MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:             DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:        IntegerLiteral {{.*}} 0
+// CHECK-NEXT:     IntegerLiteral {{.*}} 1
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}}'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}}'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// HasStreams struct
+// HasStreams::s1
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     MemberExpr {{.*}} .s1
+// CHECK-NEXT:      ArraySubscriptExpr
+// CHECK-NEXT:       ImplicitCastExpr
+// CHECK-NEXT:        MemberExpr {{.*}} .hs
+// CHECK-NEXT:         MemberExpr {{.*}} .haohs
+// CHECK-NEXT:          MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:           DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:      IntegerLiteral {{.*}} 1
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}}'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}}'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// HasStreams::s_array
+// element 0
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       MemberExpr {{.*}} .s_array
+// CHECK-NEXT:        ArraySubscriptExpr
+// CHECK-NEXT:         ImplicitCastExpr
+// CHECK-NEXT:          MemberExpr {{.*}} .hs
+// CHECK-NEXT:           MemberExpr {{.*}} .haohs
+// CHECK-NEXT:            MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:             DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:        IntegerLiteral {{.*}} 1
+// CHECK-NEXT:     IntegerLiteral {{.*}} 0
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}}'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}}'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       MemberExpr {{.*}} .s_array
+// CHECK-NEXT:        ArraySubscriptExpr
+// CHECK-NEXT:         ImplicitCastExpr
+// CHECK-NEXT:          MemberExpr {{.*}} .hs
+// CHECK-NEXT:           MemberExpr {{.*}} .haohs
+// CHECK-NEXT:            MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:             DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:        IntegerLiteral {{.*}} 1
+// CHECK-NEXT:     IntegerLiteral {{.*}} 1
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}}'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
+// CHECK-NEXT: MemberExpr {{.*}}'HasArrayOfHasStreams' lvalue .
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
-// HasArrayOfHasStreams array
-// First element
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+
+// HasArrayOfHasStreams Array
+// HasArrayOfHasStreams Struct
+// HasArrayOfHasStreams::i
+// CHECK:      BinaryOperator {{.*}} '='
+// CHECK-NEXT:  MemberExpr {{.*}} .i
+// CHECK-NEXT:   ArraySubscriptExpr
+// CHECK-NEXT:    ImplicitCastExpr
+// CHECK-NEXT:     MemberExpr {{.*}} .haohs
+// CHECK-NEXT:      MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:       DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:   IntegerLiteral {{.*}} 0
+// CHECK-NEXT:  DeclRefExpr {{.*}} '_arg_i'
+// HasArrayOfHasStreams::hs
+// HasStreams struct
+// HasStreams::s1
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     MemberExpr {{.*}} .s1
+// CHECK-NEXT:      ArraySubscriptExpr
+// CHECK-NEXT:       ImplicitCastExpr
+// CHECK-NEXT:        MemberExpr {{.*}} .hs
+// CHECK-NEXT:         ArraySubscriptExpr
+// CHECK-NEXT:          ImplicitCastExpr
+// CHECK-NEXT:           MemberExpr {{.*}} .haohs_array
+// CHECK-NEXT:            MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:             DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:         IntegerLiteral {{.*}} 0
+// CHECK-NEXT:      IntegerLiteral {{.*}} 0
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue .s1
 // CHECK-NEXT: ArraySubscriptExpr {{.*}}'HasStreams' lvalue
@@ -352,11 +482,31 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
-// array:
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// HasStreams::s_array
+// element 0
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       MemberExpr {{.*}} .s_array
+// CHECK-NEXT:        ArraySubscriptExpr
+// CHECK-NEXT:         ImplicitCastExpr
+// CHECK-NEXT:          MemberExpr {{.*}} .hs
+// CHECK-NEXT:           ArraySubscriptExpr
+// CHECK-NEXT:            ImplicitCastExpr
+// CHECK-NEXT:             MemberExpr {{.*}} .haohs_array
+// CHECK-NEXT:              MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:               DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:           IntegerLiteral {{.*}} 0
+// CHECK-NEXT:        IntegerLiteral {{.*}} 0
+// CHECK-NEXT:     IntegerLiteral {{.*}} 0
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
@@ -367,12 +517,31 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // element 1
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       MemberExpr {{.*}} .s_array
+// CHECK-NEXT:        ArraySubscriptExpr
+// CHECK-NEXT:         ImplicitCastExpr
+// CHECK-NEXT:          MemberExpr {{.*}} .hs
+// CHECK-NEXT:           ArraySubscriptExpr
+// CHECK-NEXT:            ImplicitCastExpr
+// CHECK-NEXT:             MemberExpr {{.*}} .haohs_array
+// CHECK-NEXT:              MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:               DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:           IntegerLiteral {{.*}} 0
+// CHECK-NEXT:        IntegerLiteral {{.*}} 0
+// CHECK-NEXT:     IntegerLiteral {{.*}} 1
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
@@ -383,12 +552,29 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
-// second element
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// HasStreams struct
+// HasStreams::s1
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     MemberExpr {{.*}} .s1
+// CHECK-NEXT:      ArraySubscriptExpr
+// CHECK-NEXT:       ImplicitCastExpr
+// CHECK-NEXT:        MemberExpr {{.*}} .hs
+// CHECK-NEXT:         ArraySubscriptExpr
+// CHECK-NEXT:          ImplicitCastExpr
+// CHECK-NEXT:           MemberExpr {{.*}} .haohs_array
+// CHECK-NEXT:            MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:             DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:         IntegerLiteral {{.*}} 0
+// CHECK-NEXT:      IntegerLiteral {{.*}} 1
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue .s1
 // CHECK-NEXT: ArraySubscriptExpr {{.*}}'HasStreams' lvalue
@@ -397,11 +583,31 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
-// array:
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// HasStreams::s_array
+// element 0
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       MemberExpr {{.*}} .s_array
+// CHECK-NEXT:        ArraySubscriptExpr
+// CHECK-NEXT:         ImplicitCastExpr
+// CHECK-NEXT:          MemberExpr {{.*}} .hs
+// CHECK-NEXT:           ArraySubscriptExpr
+// CHECK-NEXT:            ImplicitCastExpr
+// CHECK-NEXT:             MemberExpr {{.*}} .haohs_array
+// CHECK-NEXT:              MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:               DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:           IntegerLiteral {{.*}} 0
+// CHECK-NEXT:        IntegerLiteral {{.*}} 1
+// CHECK-NEXT:     IntegerLiteral {{.*}} 0
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
@@ -412,12 +618,31 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // element 1
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       MemberExpr {{.*}} .s_array
+// CHECK-NEXT:        ArraySubscriptExpr
+// CHECK-NEXT:         ImplicitCastExpr
+// CHECK-NEXT:          MemberExpr {{.*}} .hs
+// CHECK-NEXT:           ArraySubscriptExpr
+// CHECK-NEXT:            ImplicitCastExpr
+// CHECK-NEXT:             MemberExpr {{.*}} .haohs_array
+// CHECK-NEXT:              MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:               DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:           IntegerLiteral {{.*}} 0
+// CHECK-NEXT:        IntegerLiteral {{.*}} 1
+// CHECK-NEXT:     IntegerLiteral {{.*}} 1
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}}  'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
@@ -428,11 +653,141 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
-// second element
+// HasArrayOfHasStreams Struct
+// HasArrayOfHasStreams::i
+// CHECK:      BinaryOperator {{.*}} '='
+// CHECK-NEXT:  MemberExpr {{.*}} .i
+// CHECK-NEXT:   ArraySubscriptExpr
+// CHECK-NEXT:    ImplicitCastExpr
+// CHECK-NEXT:     MemberExpr {{.*}} .haohs
+// CHECK-NEXT:      MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:       DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:   IntegerLiteral {{.*}} 1
+// CHECK-NEXT:  DeclRefExpr {{.*}} '_arg_i'
+// HasArrayOfHasStreams::hs
+// HasStreams struct
+// HasStreams::s1
+// CHECK-NEXT: CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     MemberExpr {{.*}} .s1
+// CHECK-NEXT:      ArraySubscriptExpr
+// CHECK-NEXT:       ImplicitCastExpr
+// CHECK-NEXT:        MemberExpr {{.*}} .hs
+// CHECK-NEXT:         ArraySubscriptExpr
+// CHECK-NEXT:          ImplicitCastExpr
+// CHECK-NEXT:           MemberExpr {{.*}} .haohs_array
+// CHECK-NEXT:      MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:       DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:         IntegerLiteral {{.*}} 1
+// CHECK-NEXT:      IntegerLiteral {{.*}} 0
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}}  'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
+// CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue .s1
+// CHECK-NEXT: ArraySubscriptExpr {{.*}}'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// HasStreams::s_array
+// element 0
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       MemberExpr {{.*}} .s_array
+// CHECK-NEXT:        ArraySubscriptExpr
+// CHECK-NEXT:         ImplicitCastExpr
+// CHECK-NEXT:          MemberExpr {{.*}} .hs
+// CHECK-NEXT:           ArraySubscriptExpr
+// CHECK-NEXT:            ImplicitCastExpr
+// CHECK-NEXT:             MemberExpr {{.*}} .haohs_array
+// CHECK-NEXT:              MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:               DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:           IntegerLiteral {{.*}} 1
+// CHECK-NEXT:        IntegerLiteral {{.*}} 0
+// CHECK-NEXT:     IntegerLiteral {{.*}} 0
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}}  'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}}'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// element 1
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       MemberExpr {{.*}} .s_array
+// CHECK-NEXT:        ArraySubscriptExpr
+// CHECK-NEXT:         ImplicitCastExpr
+// CHECK-NEXT:          MemberExpr {{.*}} .hs
+// CHECK-NEXT:           ArraySubscriptExpr
+// CHECK-NEXT:            ImplicitCastExpr
+// CHECK-NEXT:             MemberExpr {{.*}} .haohs_array
+// CHECK-NEXT:              MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:               DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:           IntegerLiteral {{.*}} 1
+// CHECK-NEXT:        IntegerLiteral {{.*}} 0
+// CHECK-NEXT:     IntegerLiteral {{.*}} 1
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: MemberExpr {{.*}}  'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
+// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2]' lvalue .s_array
+// CHECK-NEXT: ArraySubscriptExpr {{.*}}'HasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
+// CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
+// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
+// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// HasStreams struct
+// HasStreams::s1
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     MemberExpr {{.*}} .s1
+// CHECK-NEXT:      ArraySubscriptExpr
+// CHECK-NEXT:       ImplicitCastExpr
+// CHECK-NEXT:        MemberExpr {{.*}} .hs
+// CHECK-NEXT:         ArraySubscriptExpr
+// CHECK-NEXT:          ImplicitCastExpr
+// CHECK-NEXT:           MemberExpr {{.*}} .haohs_array
+// CHECK-NEXT:            MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:             DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:         IntegerLiteral {{.*}} 1
+// CHECK-NEXT:      IntegerLiteral {{.*}} 1
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}}  'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue .s1
@@ -442,11 +797,31 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
-// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
-// array:
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+// HasStreams::s_array
+// element 0
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       MemberExpr {{.*}} .s_array
+// CHECK-NEXT:        ArraySubscriptExpr
+// CHECK-NEXT:         ImplicitCastExpr
+// CHECK-NEXT:          MemberExpr {{.*}} .hs
+// CHECK-NEXT:           ArraySubscriptExpr
+// CHECK-NEXT:            ImplicitCastExpr
+// CHECK-NEXT:             MemberExpr {{.*}} .haohs_array
+// CHECK-NEXT:              MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:               DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:           IntegerLiteral {{.*}} 1
+// CHECK-NEXT:        IntegerLiteral {{.*}} 1
+// CHECK-NEXT:     IntegerLiteral {{.*}} 0
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}}  'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
@@ -457,57 +832,31 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
-// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
-// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
-// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
-// element 1
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
-// CHECK-NEXT: MemberExpr {{.*}}  'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2]' lvalue .s_array
-// CHECK-NEXT: ArraySubscriptExpr {{.*}}'HasStreams' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
-// CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
-// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
-// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
-// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
-// second element
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
-// CHECK-NEXT: MemberExpr {{.*}}  'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
-// CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue .s1
-// CHECK-NEXT: ArraySubscriptExpr {{.*}}'HasStreams' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
-// CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
-// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
-// CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
-// array:
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
-// CHECK-NEXT: MemberExpr {{.*}}  'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
-// CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2]' lvalue .s_array
-// CHECK-NEXT: ArraySubscriptExpr {{.*}}'HasStreams' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
-// CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
-// CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // element 1
-// CHECK: CXXMemberCallExpr {{.*}} 'void'
+// CHECK:      CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     ArraySubscriptExpr
+// CHECK-NEXT:      ImplicitCastExpr
+// CHECK-NEXT:       MemberExpr {{.*}} .s_array
+// CHECK-NEXT:        ArraySubscriptExpr
+// CHECK-NEXT:         ImplicitCastExpr
+// CHECK-NEXT:          MemberExpr {{.*}} .hs
+// CHECK-NEXT:           ArraySubscriptExpr
+// CHECK-NEXT:            ImplicitCastExpr
+// CHECK-NEXT:             MemberExpr {{.*}} .haohs_array
+// CHECK-NEXT:              MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:               DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:           IntegerLiteral {{.*}} 1
+// CHECK-NEXT:        IntegerLiteral {{.*}} 1
+// CHECK-NEXT:     IntegerLiteral {{.*}} 1
+// CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}}  'void (__global char *, range<1>, range<1>, id<1>, int)' lvalue .__init
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
@@ -518,17 +867,20 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
+
 
 // Finalize
 // in_lambda __finalize
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 
 // _in_lambda_array
 // element 0
@@ -537,7 +889,8 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2]' lvalue
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // element 1
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
@@ -545,7 +898,8 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2]' lvalue
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 
 // _in_lambda_mdarray
@@ -557,7 +911,8 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream[2]' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream (*)[2]' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2][2]' lvalue
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // [0][1]
@@ -568,7 +923,8 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream[2]' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream (*)[2]' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2][2]' lvalue
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // [1][0]
@@ -579,7 +935,8 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream[2]' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream (*)[2]' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2][2]' lvalue
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // [1][1]
@@ -590,7 +947,8 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr {{.*}} 'sycl::stream[2]' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream (*)[2]' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2][2]' lvalue
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 
@@ -599,7 +957,8 @@ int main() {
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream':'sycl::stream' lvalue .s1
 // CHECK-NEXT: MemberExpr {{.*}}'HasStreams' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // array:
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
 // CHECK-NEXT: MemberExpr {{.*}} 'void ()' lvalue .__finalize
@@ -607,7 +966,8 @@ int main() {
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2]' lvalue .s_array
 // CHECK-NEXT: MemberExpr {{.*}}'HasStreams' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // element 1
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
@@ -616,7 +976,8 @@ int main() {
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'sycl::stream *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'sycl::stream[2]' lvalue .s_array
 // CHECK-NEXT: MemberExpr {{.*}}'HasStreams' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 
 // HasArrayOfHasStreams
@@ -628,7 +989,8 @@ int main() {
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
 // CHECK-NEXT: MemberExpr {{.*}}'HasArrayOfHasStreams' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // array:
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
@@ -640,7 +1002,8 @@ int main() {
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
 // CHECK-NEXT: MemberExpr {{.*}}'HasArrayOfHasStreams' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // element 1
@@ -653,7 +1016,8 @@ int main() {
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
 // CHECK-NEXT: MemberExpr {{.*}}'HasArrayOfHasStreams' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // second element
@@ -664,7 +1028,8 @@ int main() {
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
 // CHECK-NEXT: MemberExpr {{.*}}'HasArrayOfHasStreams' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // array:
 // CHECK: CXXMemberCallExpr {{.*}} 'void'
@@ -676,7 +1041,8 @@ int main() {
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
 // CHECK-NEXT: MemberExpr {{.*}}'HasArrayOfHasStreams' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // element 1
@@ -689,7 +1055,8 @@ int main() {
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasStreams[2]' lvalue .hs
 // CHECK-NEXT: MemberExpr {{.*}}'HasArrayOfHasStreams' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 
@@ -704,7 +1071,8 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // array:
@@ -719,7 +1087,8 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
@@ -735,7 +1104,8 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
@@ -749,7 +1119,8 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // array:
@@ -764,7 +1135,8 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
@@ -780,7 +1152,8 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
@@ -794,7 +1167,8 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // array:
@@ -809,7 +1183,8 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
@@ -825,7 +1200,8 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
@@ -839,7 +1215,8 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // array:
@@ -854,7 +1231,8 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 0
@@ -870,7 +1248,8 @@ int main() {
 // CHECK-NEXT: ArraySubscriptExpr{{.*}}'HasArrayOfHasStreams' lvalue
 // CHECK-NEXT: ImplicitCastExpr {{.*}} 'HasArrayOfHasStreams *' <ArrayToPointerDecay>
 // CHECK-NEXT: MemberExpr {{.*}} 'HasArrayOfHasStreams[2]' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at
+// CHECK-NEXT:  MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__wrapper_union'
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1
 // CHECK-NEXT: IntegerLiteral {{.*}} '{{.*}}' 1

--- a/clang/test/SemaSYCL/union-kernel-param.cpp
+++ b/clang/test/SemaSYCL/union-kernel-param.cpp
@@ -30,8 +30,16 @@ int main() {
 // Check kernel inits
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: DeclStmt
-// CHECK-NEXT: VarDecl {{.*}} cinit
-// CHECK-NEXT: InitListExpr
-// CHECK-NEXT: CXXConstructExpr {{.*}}'MyUnion' 'void (const MyUnion &) noexcept'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const MyUnion'
-// CHECK-NEXT: DeclRefExpr {{.*}}'MyUnion' lvalue ParmVar {{.*}} '_arg_accel' {{.*}}'MyUnion'
+// CHECK-NEXT: VarDecl {{.*}} __wrapper_union
+// CHECK:      CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .accel
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    DeclRefExpr {{.*}} '_arg_accel'
+// CHECK-NEXT:  IntegerLiteral {{.*}} 4

--- a/clang/test/SemaSYCL/union-kernel-param1.cpp
+++ b/clang/test/SemaSYCL/union-kernel-param1.cpp
@@ -39,11 +39,19 @@ int main() {
 // Check kernel_A inits
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: DeclStmt
-// CHECK-NEXT: VarDecl {{.*}} cinit
-// CHECK-NEXT: InitListExpr
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'union union_acc_t':'union_acc_t' 'void (const union_acc_t &) noexcept'
-// CHECK: ImplicitCastExpr {{.*}} 'const union_acc_t'
-// CHECK: DeclRefExpr {{.*}} 'union union_acc_t':'union_acc_t' lvalue ParmVar {{.*}} '_arg_union_acc' 'union union_acc_t':'union_acc_t'
+// CHECK-NEXT: VarDecl {{.*}} __wrapper_union
+// CHECK:      CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .union_acc
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    DeclRefExpr {{.*}} '_arg_union_acc'
+// CHECK-NEXT:  IntegerLiteral {{.*}} 8
 
 // Check kernel_B parameters
 // CHECK: FunctionDecl {{.*}}kernel_B{{.*}} 'void (S<int>)'
@@ -52,8 +60,16 @@ int main() {
 // Check kernel_B inits
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: DeclStmt
-// CHECK-NEXT: VarDecl {{.*}} cinit
-// CHECK-NEXT: InitListExpr
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'S<int>':'S<int>' 'void (const S<int> &) noexcept'
-// CHECK-NEXT: ImplicitCastExpr {{.*}}  'const S<int>'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'S<int>':'S<int>' lvalue ParmVar {{.*}} '_arg_s' 'S<int>':'S<int>'
+// CHECK-NEXT: VarDecl {{.*}} __wrapper_union
+// CHECK:      CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .s
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    DeclRefExpr {{.*}} '_arg_s'
+// CHECK-NEXT:  IntegerLiteral {{.*}} 12

--- a/clang/test/SemaSYCL/union-kernel-param2.cpp
+++ b/clang/test/SemaSYCL/union-kernel-param2.cpp
@@ -65,11 +65,19 @@ int main() {
 // Check kernel_A inits
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: DeclStmt
-// CHECK-NEXT: VarDecl {{.*}} cinit
-// CHECK-NEXT: InitListExpr
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'union MyUnion':'MyUnion' 'void (const MyUnion &) noexcept'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const MyUnion'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'union MyUnion':'MyUnion' lvalue ParmVar {{.*}} '_arg_union_mem' 'union MyUnion':'MyUnion'
+// CHECK-NEXT: VarDecl {{.*}} __wrapper_union
+// CHECK:      CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .union_mem
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    DeclRefExpr {{.*}} '_arg_union_mem'
+// CHECK-NEXT:  IntegerLiteral {{.*}} 20
 
 // Check kernel_B parameters
 // CHECK: FunctionDecl {{.*}}kernel_B{{.*}} 'void (union MyUnion, __global char *, sycl::range<1>, sycl::range<1>, sycl::id<1>)'
@@ -82,20 +90,36 @@ int main() {
 // Check kernel_B inits
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: DeclStmt
-// CHECK-NEXT: VarDecl {{.*}} cinit
-// CHECK-NEXT: InitListExpr
-// CHECK-NEXT: InitListExpr {{.*}} 'MyStruct'
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'union MyUnion':'MyStruct::MyUnion' 'void (const MyUnion &) noexcept'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const MyUnion':'const MyStruct::MyUnion'
-// CHECK-NEXT: DeclRefExpr {{.*}} 'union MyUnion':'MyStruct::MyUnion' lvalue ParmVar {{.*}} '_arg_union_mem' 'union MyUnion':'MyStruct::MyUnion'
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'sycl::accessor<char, 1, sycl::access::mode::read>'
+// CHECK-NEXT: VarDecl {{.*}} __wrapper_union
+// CHECK:      CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .union_mem
+// CHECK-NEXT:     MemberExpr {{.*}} .struct_mem
+// CHECK-NEXT:      MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:       DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    DeclRefExpr {{.*}} '_arg_union_mem'
+// CHECK-NEXT:  IntegerLiteral {{.*}} 12
+// CHECK-NEXT: CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:   ImplicitCastExpr
+// CHECK-NEXT:    UnaryOperator
+// CHECK-NEXT:     MemberExpr {{.*}} .AccField
+// CHECK-NEXT:      MemberExpr {{.*}} .struct_mem
+// CHECK-NEXT:       MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:        DeclRefExpr {{.*}} '__wrapper_union'
 
 // Check call to __init to initialize AccField
 // CHECK-NEXT: CXXMemberCallExpr
 // CHECK-NEXT: MemberExpr {{.*}} lvalue .__init
 // CHECK-NEXT: MemberExpr {{.*}} lvalue .AccField
 // CHECK-NEXT: MemberExpr {{.*}} lvalue .struct_mem
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at {{.*}}union-kernel-param2.cpp:48:9)' lvalue Var {{.*}} '__SYCLKernel' '(lambda at {{.*}}union-kernel-param2.cpp:48:9)'
+// CHECK-NEXT: MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT: DeclRefExpr {{.*}} '__wrapper_union'
 
 // Check kernel_C parameters
 // CHECK: FunctionDecl {{.*}}kernel_C{{.*}} 'void (__generated_MyStructWithPtr)'
@@ -104,11 +128,16 @@ int main() {
 // Check kernel_C inits
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: DeclStmt
-// CHECK-NEXT: VarDecl {{.*}} cinit
-// CHECK-NEXT: InitListExpr
-// CHECK-NEXT: CXXConstructExpr {{.*}} 'struct MyStructWithPtr':'MyStructWithPtr' 'void (const MyStructWithPtr &) noexcept'
-// CHECK-NEXT: ImplicitCastExpr {{.*}} 'const MyStructWithPtr':'const MyStructWithPtr' lvalue <NoOp>
-// CHECK-NEXT: UnaryOperator {{.*}} 'struct MyStructWithPtr':'MyStructWithPtr' lvalue prefix '*' cannot overflow
-// CHECK-NEXT: CXXReinterpretCastExpr {{.*}} 'struct MyStructWithPtr *' reinterpret_cast<struct MyStructWithPtr *> <BitCast>
-// CHECK-NEXT: UnaryOperator {{.*}} '__generated_MyStructWithPtr *' prefix '&' cannot overflow
-// CHECK-NEXT: DeclRefExpr {{.*}} '__generated_MyStructWithPtr' lvalue ParmVar {{.*}} '_arg_structWithPtr_mem' '__generated_MyStructWithPtr'
+// CHECK-NEXT: VarDecl {{.*}} __wrapper_union
+// CHECK:      CallExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   DeclRefExpr {{.*}} '__builtin_memcpy'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .structWithPtr_mem
+// CHECK-NEXT:     MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:      DeclRefExpr {{.*}} '__wrapper_union'
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    DeclRefExpr {{.*}} '_arg_structWithPtr_mem'
+// CHECK-NEXT:  IntegerLiteral {{.*}} 24

--- a/clang/test/SemaSYCL/wrapped-accessor.cpp
+++ b/clang/test/SemaSYCL/wrapped-accessor.cpp
@@ -35,17 +35,25 @@ int main() {
 
 // Check that wrapper object itself is initialized with corresponding kernel
 // argument
-// CHECK: VarDecl {{.*}}'(lambda at {{.*}}wrapped-accessor.cpp{{.*}})'
-// CHECK-NEXT: InitListExpr {{.*}}'(lambda at {{.*}}wrapped-accessor.cpp{{.*}})'
-// CHECK-NEXT: InitListExpr {{.*}}'AccWrapper<sycl::accessor<int, 1, sycl::access::mode::read_write>>'
-// CHECK-NEXT: CXXConstructExpr {{.*}}'sycl::accessor<int, 1, sycl::access::mode::read_write>':'sycl::accessor<int, 1, sycl::access::mode::read_write>' 'void () noexcept'
+// CHECK: VarDecl {{.*}} '__wrapper_union'
+
+// Build accessor
+// CHECK-NEXT: CXXNewExpr
+// CHECK-NEXT:  CXXConstructExpr
+// CHECK-NEXT:  ImplicitCastExpr
+// CHECK-NEXT:   UnaryOperator
+// CHECK-NEXT:    MemberExpr {{.*}} .accessor
+// CHECK-NEXT:     MemberExpr {{.*}} .acc_wrapped
+// CHECK-NEXT:      MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:       DeclRefExpr {{.*}} '__wrapper_union'
 
 // Check that accessor field of the wrapper object is initialized using __init method
 // CHECK-NEXT: CXXMemberCallExpr {{.*}} 'void'
-// CHECK-NEXT: MemberExpr {{.*}} 'void ({{.*}}PtrType, range<1>, range<1>, id<1>)' lvalue .__init
-// CHECK-NEXT: MemberExpr {{.*}} 'sycl::accessor<int, 1, sycl::access::mode::read_write>':'sycl::accessor<int, 1, sycl::access::mode::read_write>' lvalue .accessor {{.*}}
-// CHECK-NEXT: MemberExpr {{.*}} 'AccWrapper<decltype(acc)>':'AccWrapper<sycl::accessor<int, 1, sycl::access::mode::read_write>>' lvalue .
-// CHECK-NEXT: DeclRefExpr {{.*}} '(lambda at {{.*}}wrapped-accessor.cpp{{.*}})' lvalue Var {{.*}} '(lambda at {{.*}}wrapped-accessor.cpp{{.*}})'
+// CHECK-NEXT:  MemberExpr {{.*}} 'void ({{.*}}PtrType, range<1>, range<1>, id<1>)' lvalue .__init
+// CHECK-NEXT:   MemberExpr {{.*}} 'sycl::accessor<int, 1, sycl::access::mode::read_write>':'sycl::accessor<int, 1, sycl::access::mode::read_write>' lvalue .accessor {{.*}}
+// CHECK-NEXT:    MemberExpr {{.*}} 'AccWrapper<decltype(acc)>':'AccWrapper<sycl::accessor<int, 1, sycl::access::mode::read_write>>' lvalue .
+// CHECK-NEXT:      MemberExpr {{.*}} '(lambda at
+// CHECK-NEXT:       DeclRefExpr {{.*}} '__wrapper_union'
 
 // Parameters of the _init method
 // CHECK-NEXT: ImplicitCastExpr {{.*}} <LValueToRValue>

--- a/sycl/test/basic_tests/not-strictly-device-copyable.cpp
+++ b/sycl/test/basic_tests/not-strictly-device-copyable.cpp
@@ -1,0 +1,26 @@
+// RUN: %clangxx -fsycl -fsycl-device-only -S -emit-llvm -I %sycl_include %s -o - | FileCheck %s
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+// Not device copyable because of the user defined Dtor.
+struct NonDeviceCopiable {
+  int a;
+  std::string s; // not good for device, but never used in kernel.
+};
+template <> struct is_device_copyable<NonDeviceCopiable> : std::true_type {};
+
+// Check clang is not emitting anything due to std::string
+// CHECK-NOT: _ZSt19__throw_logic_errorPKc
+// CHECK-NOT: _ZSt20__throw_length_errorPKc
+// CHECK-NOT: _ZSt17__throw_bad_allocv
+// CHECK-NOT: _Znwm
+// CHECK-NOT: _ZdlPv
+
+void test() {
+  NonDeviceCopiable k{42};
+
+  queue Q;
+  Q.single_task<class TestA>([=] { (void)k.a; });
+}


### PR DESCRIPTION
Complete implementation initially opened [here](https://github.com/intel/llvm/pull/8240) by @bader 

Wrap the SYCL kernel object in an union.
This works around the clang codegen emiting the object destructor.

User can declare their type as device copyable even if they do not meet the criterias. In some cases,
this triggers calls to undefined function.

Per SYCL rules, a SYCL kernel object must be device copiable which normally implies a trivial destructor. Plus the spec doesn't guarantee that the destructor should get called at all as it allows the functor to be reused by multiple WI.

This patch exploit that UB by preventing the destructor of being called by wrapping it into a union. This does nothing to prevent cleanup of temporaries if they happen.

Instead of using initializer list, init the SYCL kernel using memcpy for non special type and Ctor/__init for special type.

An example of what this patch enables is shown in the runtime test.