### PR TITLE
[SYCL-MLIR]: Add rudimentary optimization reports to LICM and AffineReduction 

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
@@ -32,6 +32,10 @@ def ParallelLower : Pass<"parallel-lower", "mlir::ModuleOp"> {
 def AffineReduction : Pass<"detect-reduction"> {
   let summary = "Detect reductions in affine.for";
   let constructor = "mlir::polygeist::detectReductionPass()";
+  let statistics = [
+    Statistic<"numReductions", "num-reductions", "Number of reductions detected">
+  ];
+
 }
 
 def SCFCPUify : Pass<"cpuify"> {

--- a/polygeist/lib/Dialect/Polygeist/Transforms/AffineReduction.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/AffineReduction.cpp
@@ -354,20 +354,13 @@ public:
 
     numReductionsDetected += ReductionOps.size();
 
-    [[maybe_unused]] auto getParentFunction = [](LoopLikeOpInterface loop) {
-      Operation *parentOp = loop;
-      do {
-        parentOp = parentOp->getParentOp();
-      } while (parentOp && !isa<func::FuncOp>(parentOp));
-      assert(parentOp && "Failed to find parent function");
-      return cast<func::FuncOp>(parentOp);
-    };
-
     DEBUG_WITH_TYPE(
         REPORT_DEBUG_TYPE, if (!ReductionOps.empty()) {
-          llvm::dbgs() << "AffineReduction: detected " << ReductionOps.size()
-                       << " reduction(s) in: "
-                       << getParentFunction(ForOp).getSymName() << "\n";
+          llvm::dbgs()
+              << "AffineReduction: detected " << ReductionOps.size()
+              << " reduction(s) in: "
+              << ForOp->getParentOfType<FunctionOpInterface>().getName()
+              << "\n";
         });
 
     Rewriter.replaceOp(ForOp, NewYieldedRes);

--- a/polygeist/lib/Dialect/Polygeist/Transforms/AffineReduction.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/AffineReduction.cpp
@@ -10,6 +10,7 @@
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -17,6 +18,7 @@
 #include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "affine-reduction"
+#define REPORT_DEBUG_TYPE DEBUG_TYPE "-report"
 
 namespace mlir {
 namespace polygeist {
@@ -26,7 +28,6 @@ namespace polygeist {
 } // namespace mlir
 
 using namespace mlir;
-using namespace polygeist;
 
 namespace {
 class AffineReductionPass
@@ -73,9 +74,14 @@ private:
 }
 
 class AffineForReductionIter : public OpRewritePattern<AffineForOp> {
-  using OpRewritePattern<AffineForOp>::OpRewritePattern;
+  Pass::Statistic &numReductionsDetected;
 
 public:
+  AffineForReductionIter(MLIRContext *context,
+                         Pass::Statistic &numReductionsDetected)
+      : OpRewritePattern<AffineForOp>(context),
+        numReductionsDetected(numReductionsDetected) {}
+
   /// Returns true if the given operation \p Op is immediately contained in the
   /// \p ForOp loop, and false otherwise.
   bool isInAffineFor(Operation *Op, const AffineForOp ForOp) const {
@@ -346,6 +352,24 @@ public:
       });
     }
 
+    numReductionsDetected += ReductionOps.size();
+
+    [[maybe_unused]] auto getParentFunction = [](LoopLikeOpInterface loop) {
+      Operation *parentOp = loop;
+      do {
+        parentOp = parentOp->getParentOp();
+      } while (parentOp && !isa<func::FuncOp>(parentOp));
+      assert(parentOp && "Failed to find parent function");
+      return cast<func::FuncOp>(parentOp);
+    };
+
+    DEBUG_WITH_TYPE(
+        REPORT_DEBUG_TYPE, if (!ReductionOps.empty()) {
+          llvm::dbgs() << "AffineReduction: detected " << ReductionOps.size()
+                       << " reduction(s) in: "
+                       << getParentFunction(ForOp).getSymName() << "\n";
+        });
+
     Rewriter.replaceOp(ForOp, NewYieldedRes);
     return success();
   }
@@ -355,7 +379,7 @@ public:
 
 void AffineReductionPass::runOnOperation() {
   RewritePatternSet RPS(getOperation()->getContext());
-  RPS.add<AffineForReductionIter>(getOperation()->getContext());
+  RPS.add<AffineForReductionIter>(getOperation()->getContext(), numReductions);
   GreedyRewriteConfig Config;
   (void)applyPatternsAndFoldGreedily(getOperation(), std::move(RPS), Config);
 }

--- a/polygeist/lib/Dialect/Polygeist/Transforms/AffineReduction.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/AffineReduction.cpp
@@ -354,14 +354,13 @@ public:
 
     numReductionsDetected += ReductionOps.size();
 
-    DEBUG_WITH_TYPE(
-        REPORT_DEBUG_TYPE, if (!ReductionOps.empty()) {
-          llvm::dbgs()
-              << "AffineReduction: detected " << ReductionOps.size()
-              << " reduction(s) in: "
-              << ForOp->getParentOfType<FunctionOpInterface>().getName()
-              << "\n";
-        });
+    DEBUG_WITH_TYPE(REPORT_DEBUG_TYPE, {
+      if (!ReductionOps.empty())
+        llvm::dbgs() << "AffineReduction: detected " << ReductionOps.size()
+                     << " reduction(s) in: "
+                     << ForOp->getParentOfType<FunctionOpInterface>().getName()
+                     << "\n";
+    });
 
     Rewriter.replaceOp(ForOp, NewYieldedRes);
     return success();

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
@@ -27,6 +27,7 @@
 #include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "licm"
+#define REPORT_DEBUG_TYPE DEBUG_TYPE "-report"
 
 namespace mlir {
 namespace polygeist {
@@ -912,7 +913,7 @@ void LICM::runOnOperation() {
       parentOp = parentOp->getParentOp();
     } while (parentOp && !isa<func::FuncOp>(parentOp));
     assert(parentOp && "Failed to find parent function");
-    return parentOp;
+    return cast<func::FuncOp>(parentOp);
   };
 
   getOperation()->walk([&](LoopLikeOpInterface loop) {
@@ -952,6 +953,13 @@ void LICM::runOnOperation() {
         }
         llvm::dbgs() << "----------------\n";
       });
+
+      DEBUG_WITH_TYPE(
+          REPORT_DEBUG_TYPE, if (OpHoisted) {
+            llvm::dbgs() << "LICM: hoisted " << OpHoisted
+                         << " operations(s) in : "
+                         << getParentFunction(loop).getSymName() << "\n";
+          });
     }
   });
 }

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
@@ -950,13 +950,13 @@ void LICM::runOnOperation() {
         llvm::dbgs() << "----------------\n";
       });
 
-      DEBUG_WITH_TYPE(
-          REPORT_DEBUG_TYPE, if (OpHoisted) {
-            llvm::dbgs()
-                << "LICM: hoisted " << OpHoisted << " operations(s) in : "
-                << loop->getParentOfType<FunctionOpInterface>().getName()
-                << "\n";
-          });
+      DEBUG_WITH_TYPE(REPORT_DEBUG_TYPE, {
+        if (OpHoisted)
+          llvm::dbgs() << "LICM: hoisted " << OpHoisted
+                       << " operations(s) in : "
+                       << loop->getParentOfType<FunctionOpInterface>().getName()
+                       << "\n";
+      });
     }
   });
 }

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
@@ -907,20 +907,12 @@ void LICM::runOnOperation() {
   AliasAnalysis &aliasAnalysis = getAnalysis<AliasAnalysis>();
   aliasAnalysis.addAnalysisImplementation(sycl::AliasAnalysis(relaxedAliasing));
 
-  [[maybe_unused]] auto getParentFunction = [](LoopLikeOpInterface loop) {
-    Operation *parentOp = loop;
-    do {
-      parentOp = parentOp->getParentOp();
-    } while (parentOp && !isa<func::FuncOp>(parentOp));
-    assert(parentOp && "Failed to find parent function");
-    return cast<func::FuncOp>(parentOp);
-  };
-
   getOperation()->walk([&](LoopLikeOpInterface loop) {
     LLVM_DEBUG({
       llvm::dbgs() << "----------------\n";
       loop.print(llvm::dbgs() << "Original loop:\n");
-      llvm::dbgs() << "\nIn:\n" << *getParentFunction(loop) << "\n";
+      llvm::dbgs() << "\nIn:\n"
+                   << *loop->getParentOfType<FunctionOpInterface>() << "\n";
     });
 
     // First use MLIR LICM to hoist simple operations.
@@ -932,8 +924,10 @@ void LICM::runOnOperation() {
                      << " operation(s).\n";
         if (OpHoisted) {
           loop.print(llvm::dbgs() << "Loop after MLIR LICM:\n");
-          llvm::dbgs() << "\nIn:\n" << *getParentFunction(loop) << "\n";
-          assert(mlir::verify(getParentFunction(loop)).succeeded());
+          llvm::dbgs() << "\nIn:\n"
+                       << *loop->getParentOfType<FunctionOpInterface>() << "\n";
+          assert(mlir::verify(loop->getParentOfType<FunctionOpInterface>())
+                     .succeeded());
         }
         llvm::dbgs() << "----------------\n";
       });
@@ -948,17 +942,20 @@ void LICM::runOnOperation() {
         llvm::dbgs() << "\nLICM hoisted " << OpHoisted << " operation(s).\n";
         if (OpHoisted) {
           loop.print(llvm::dbgs() << "Loop after LICM:\n");
-          llvm::dbgs() << "\nIn:\n" << *getParentFunction(loop) << "\n";
-          assert(mlir::verify(getParentFunction(loop)).succeeded());
+          llvm::dbgs() << "\nIn:\n"
+                       << *loop->getParentOfType<FunctionOpInterface>() << "\n";
+          assert(mlir::verify(loop->getParentOfType<FunctionOpInterface>())
+                     .succeeded());
         }
         llvm::dbgs() << "----------------\n";
       });
 
       DEBUG_WITH_TYPE(
           REPORT_DEBUG_TYPE, if (OpHoisted) {
-            llvm::dbgs() << "LICM: hoisted " << OpHoisted
-                         << " operations(s) in : "
-                         << getParentFunction(loop).getSymName() << "\n";
+            llvm::dbgs()
+                << "LICM: hoisted " << OpHoisted << " operations(s) in : "
+                << loop->getParentOfType<FunctionOpInterface>().getName()
+                << "\n";
           });
     }
   });


### PR DESCRIPTION
Introduce a simple way to report the number of operation hoisted (LICM) and reduction detected (AffineReduction). 
To enable optimization reports for:
  - LICM:  -debug-only=licm-report
  - AffineReduction: -debug-only=affine-reduction-report 

Example:
```
clang++ -fsycl ... 2mm.cpp -Xcgeist  -debug-only=licm-report  -Xcgeist -debug-only=affine-reduction-report
LICM: hoisted 4 operations(s) in : _ZZZN13Polybench_2mm3runERSt6vectorIN4sycl3_V15eventESaIS3_EEENKUlRNS2_7handlerEE_clES8_ENKUlNS2_4itemILi2ELb1EEEE_clESB_
AffineReduction: detected 1 reduction(s) in: _ZZZN13Polybench_2mm3runERSt6vectorIN4sycl3_V15eventESaIS3_EEENKUlRNS2_7handlerEE_clES8_ENKUlNS2_4itemILi2ELb1EEEE_clESB_
```