### PR TITLE
[SYCL][NFC] Avoid narrowing size_t to bool

### DIFF
--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -491,7 +491,7 @@ template <typename DataT, template <typename, typename> typename FlattenF,
 struct ArrayCreator<DataT, FlattenF, ArgT, ArgTN...> {
   static constexpr auto Create(const ArgT &Arg, const ArgTN &...Args) {
     auto ImmArray = FlattenF<DataT, ArgT>()(Arg);
-    if constexpr (sizeof...(Args))
+    if constexpr (sizeof...(Args) > 0)
       return ConcatArrays(
           ImmArray, ArrayCreator<DataT, FlattenF, ArgTN...>::Create(Args...));
     else


### PR DESCRIPTION
This commit changes a conditional statement from returning size_t to return bool. This is to avoid MSVC from warning about the narrowing.