### PR TITLE
[MLIR] Allow llvm.resume with non-landingpad input

### DIFF
--- a/mlir/test/Dialect/LLVMIR/invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/invalid.mlir
@@ -754,7 +754,7 @@ llvm.func @caller(%arg0: i32) -> i32 attributes { personality = @__gxx_personali
   llvm.return %0 : i32
 ^bb2: // pred: ^bb0
   %2 = llvm.landingpad cleanup : !llvm.struct<(ptr<i8>, i32)>
-  // expected-error@+1 {{'llvm.resume' op expects landingpad value as operand}}
+  // expected-error@+1 {{'llvm.resume' op expects landingpad operation with the same type in the same function as this operation's operand}}
   llvm.resume %0 : i32
 }
 


### PR DESCRIPTION
This changes verification of llvm.resume to just fail if there is no llvm.landingpad instruction in the same function with the same type as this instruction's input, more in line with LLVM's verificatino. From LLVM documentation (https://llvm.org/docs/LangRef.html#i-resume):

The ‘resume’ instruction requires one argument, which must have the same type as the result of any ‘landingpad’ instruction in the same function.