### PR TITLE
[SYCL] Revert any and all return types to int for vectors

### DIFF
--- a/sycl/include/sycl/builtins.hpp
+++ b/sycl/include/sycl/builtins.hpp
@@ -1433,8 +1433,7 @@ any(T x) __NOEXC {
 
 // int any (vigeninteger x)
 template <typename T>
-detail::enable_if_t<detail::is_vigeninteger<T>::value, detail::anyall_ret_t>
-any(T x) __NOEXC {
+detail::enable_if_t<detail::is_vigeninteger<T>::value, int> any(T x) __NOEXC {
   return detail::rel_sign_bit_test_ret_t<T>(
       __sycl_std::__invoke_Any<detail::rel_sign_bit_test_ret_t<T>>(
           detail::rel_sign_bit_test_arg_t<T>(x)));
@@ -1449,8 +1448,7 @@ all(T x) __NOEXC {
 
 // int all (vigeninteger x)
 template <typename T>
-detail::enable_if_t<detail::is_vigeninteger<T>::value, detail::anyall_ret_t>
-all(T x) __NOEXC {
+detail::enable_if_t<detail::is_vigeninteger<T>::value, int> all(T x) __NOEXC {
   return detail::rel_sign_bit_test_ret_t<T>(
       __sycl_std::__invoke_All<detail::rel_sign_bit_test_ret_t<T>>(
           detail::rel_sign_bit_test_arg_t<T>(x)));

--- a/sycl/test/basic_tests/relational_builtins.cpp
+++ b/sycl/test/basic_tests/relational_builtins.cpp
@@ -280,28 +280,28 @@ void foo() {
 
   // any
   CHECK(int, bool, any, int16_t)
-  CHECK(int, bool, any, int16v)
+  CHECK(int, int, any, int16v)
   CHECK2020(_, bool, any, int16m)
 
   CHECK(int, bool, any, int32_t)
-  CHECK(int, bool, any, int32v)
+  CHECK(int, int, any, int32v)
   CHECK2020(_, bool, any, int32m)
 
   CHECK(int, bool, any, int64_t)
-  CHECK(int, bool, any, int64v)
+  CHECK(int, int, any, int64v)
   CHECK2020(_, bool, any, int64m)
 
   // all
   CHECK(int, bool, all, int16_t)
-  CHECK(int, bool, all, int16v)
+  CHECK(int, int, all, int16v)
   CHECK2020(_, bool, all, int16m)
 
   CHECK(int, bool, all, int32_t)
-  CHECK(int, bool, all, int32v)
+  CHECK(int, int, all, int32v)
   CHECK2020(_, bool, all, int32m)
 
   CHECK(int, bool, all, int64_t)
-  CHECK(int, bool, all, int64v)
+  CHECK(int, int, all, int64v)
   CHECK2020(_, bool, all, int64m)
 
   // bitselect


### PR DESCRIPTION
SYCL 2020 has any and all return bool for scalar and marray arguments, but int for vector arguments. Currently enabling
SYCL2020_CONFORMANT_APIS switches all versions of any and all to return bool. This commit changes it so that the variants taking vector arguments are unaffected by SYCL2020_CONFORMANT_APIS and language version.