### PR TITLE
[SYCL-MLIR] Add inbounds attribute to LLVM::GEPOp

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Transforms/BareMemRefToLLVM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/BareMemRefToLLVM.cpp
@@ -48,7 +48,8 @@ struct GetGlobalMemrefOpLowering
     // the address of the GV as the base, and (rank + 1) number of 0 indices.
     rewriter.replaceOpWithNewOp<LLVM::GEPOp>(
         getGlobalOp, typeConverter->convertType(memrefTy), addressOf,
-        SmallVector<LLVM::GEPArg>(memrefTy.getRank() + 1, 0));
+        SmallVector<LLVM::GEPArg>(memrefTy.getRank() + 1, 0),
+        /* inbounds */ true);
 
     return success();
   }

--- a/polygeist/test/polygeist-opt/bareptrlowering.mlir
+++ b/polygeist/test/polygeist-opt/bareptrlowering.mlir
@@ -59,7 +59,7 @@ memref.global @global : memref<3xi64>
 
 // CHECK-LABEL:   llvm.func @get_global() -> !llvm.ptr<i64>
 // CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.addressof @global : !llvm.ptr<array<3 x i64>>
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr %[[VAL_0]][0, 0] : (!llvm.ptr<array<3 x i64>>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr<array<3 x i64>>) -> !llvm.ptr<i64>
 // CHECK-NEXT:      llvm.return %[[VAL_1]] : !llvm.ptr<i64>
 // CHECK-NEXT:    }
 
@@ -76,7 +76,7 @@ memref.global @global_addrspace : memref<3xi64, 4>
 
 // CHECK-LABEL:   llvm.func @get_global_addrspace() -> !llvm.ptr<i64, 4>
 // CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.addressof @global_addrspace : !llvm.ptr<array<3 x i64>, 4>
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr %[[VAL_0]][0, 0] : (!llvm.ptr<array<3 x i64>, 4>) -> !llvm.ptr<i64, 4>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr<array<3 x i64>, 4>) -> !llvm.ptr<i64, 4>
 // CHECK-NEXT:      llvm.return %[[VAL_1]] : !llvm.ptr<i64, 4>
 // CHECK-NEXT:    }
 
@@ -91,7 +91,7 @@ memref.global "private" constant @shape : memref<2xi64> = dense<[2, 2]>
 
 // CHECK-LABEL:   llvm.func @reshape(
 // CHECK-SAME:                       %[[VAL_0:.*]]: !llvm.ptr<i32>) -> !llvm.ptr<i32>
-// CHECK:           %[[VAL_2:.*]] = llvm.getelementptr %{{.*}}[0, 0] : (!llvm.ptr<array<2 x i64>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_2:.*]] = llvm.getelementptr inbounds %{{.*}}[0, 0] : (!llvm.ptr<array<2 x i64>>) -> !llvm.ptr<i64>
 // CHECK-NEXT:      llvm.return %[[VAL_0]] : !llvm.ptr<i32>
 // CHECK-NEXT:    }
 
@@ -107,7 +107,7 @@ memref.global "private" constant @shape : memref<1xindex>
 
 // CHECK-LABEL:   llvm.func @reshape_dyn(
 // CHECK-SAME:                           %[[VAL_0:.*]]: !llvm.ptr<i32>) -> !llvm.ptr<i32>
-// CHECK:           %[[VAL_2:.*]] = llvm.getelementptr %{{.*}}[0, 0] : (!llvm.ptr<array<1 x i64>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_2:.*]] = llvm.getelementptr inbounds %{{.*}}[0, 0] : (!llvm.ptr<array<1 x i64>>) -> !llvm.ptr<i64>
 // CHECK-NEXT:      llvm.return %[[VAL_0]] : !llvm.ptr<i32>
 // CHECK-NEXT:    }
 

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -298,22 +298,23 @@ mlir::Attribute MLIRScanner::InitializeValueByInitListExpr(mlir::Value ToInit,
                         Loc,
                         LLVM::LLVMPointerType::get(ST.getBody()[I],
                                                    PT.getAddressSpace()),
-                        ToInit,
-                        llvm::ArrayRef<mlir::LLVM::GEPArg>{0, GEPIndex});
+                        ToInit, llvm::ArrayRef<mlir::LLVM::GEPArg>{0, GEPIndex},
+                        /* inbounds */ true);
                   })
                   .Case<LLVM::LLVMArrayType>([=](auto AT) {
                     return Builder.create<LLVM::GEPOp>(
                         Loc,
                         LLVM::LLVMPointerType::get(AT.getElementType(),
                                                    PT.getAddressSpace()),
-                        ToInit,
-                        llvm::ArrayRef<mlir::LLVM::GEPArg>{0, GEPIndex});
+                        ToInit, llvm::ArrayRef<mlir::LLVM::GEPArg>{0, GEPIndex},
+                        /* inbounds */ true);
                   })
                   .Case<IntegerType>([=](auto IT) {
                     return Builder.create<LLVM::GEPOp>(
                         Loc,
                         LLVM::LLVMPointerType::get(IT, PT.getAddressSpace()),
-                        ToInit, llvm::ArrayRef<mlir::LLVM::GEPArg>{GEPIndex});
+                        ToInit, llvm::ArrayRef<mlir::LLVM::GEPArg>{GEPIndex},
+                        /* inbounds */ true);
                   });
         }
 
@@ -483,11 +484,12 @@ ValueCategory MLIRScanner::VisitCXXStdInitializerListExpr(
   auto Zero = Builder.create<arith::ConstantIntOp>(Loc, 0, 32);
   auto GEP0 = Builder.create<LLVM::GEPOp>(
       Loc, LLVM::LLVMPointerType::get(SubType.getBody()[0], 0), Alloca,
-      ValueRange({Zero, Zero}));
+      ValueRange({Zero, Zero}), /* inbounds */ true);
   Builder.create<LLVM::StoreOp>(Loc, ArrayPtr.getValue(Builder), GEP0);
   auto GEP1 = Builder.create<LLVM::GEPOp>(
       Loc, LLVM::LLVMPointerType::get(SubType.getBody()[1], 0), Alloca,
-      ValueRange({Zero, Builder.create<arith::ConstantIntOp>(Loc, 1, 32)}));
+      ValueRange({Zero, Builder.create<arith::ConstantIntOp>(Loc, 1, 32)}),
+      /* inbounds */ true);
   ++Field;
   auto ITy =
       Glob.getTypes().getMLIRType(Field->getType()).cast<mlir::IntegerType>();

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -322,7 +322,8 @@ void ValueCategory::store(mlir::OpBuilder &builder, ValueCategory toStore,
                                 builder.create<ConstantIntOp>(loc, i, 32)};
           builder.create<mlir::LLVM::StoreOp>(
               loc, builder.create<mlir::memref::LoadOp>(loc, toStore.val, idx),
-              builder.create<mlir::LLVM::GEPOp>(loc, elty, val, lidx));
+              builder.create<mlir::LLVM::GEPOp>(loc, elty, val, lidx,
+                                                /* inbounds */ true));
         }
       }
     } else if (auto smt = val.getType().dyn_cast<mlir::MemRefType>()) {
@@ -352,8 +353,8 @@ void ValueCategory::store(mlir::OpBuilder &builder, ValueCategory toStore,
         builder.create<mlir::memref::StoreOp>(
             loc,
             builder.create<mlir::LLVM::LoadOp>(
-                loc, builder.create<mlir::LLVM::GEPOp>(loc, elty, toStore.val,
-                                                       lidx)),
+                loc, builder.create<mlir::LLVM::GEPOp>(
+                         loc, elty, toStore.val, lidx, /* inbounds */ true)),
             val, idx);
       }
     } else
@@ -752,8 +753,9 @@ ValueCategory ValueCategory::GEP(OpBuilder &Builder, Location Loc, Type Type,
   });
 
   auto PtrTy = mlirclang::getPtrTyWithNewType(val.getType(), Type);
-  return {Builder.createOrFold<LLVM::GEPOp>(Loc, PtrTy, val, IdxList),
-          isReference};
+  return {
+      Builder.createOrFold<LLVM::GEPOp>(Loc, PtrTy, val, IdxList, IsInBounds),
+      isReference};
 }
 
 ValueCategory ValueCategory::InBoundsGEP(OpBuilder &Builder, Location Loc,

--- a/polygeist/tools/cgeist/Test/Verification/arrayconsllvm.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/arrayconsllvm.cpp
@@ -16,7 +16,7 @@ void kern() {
 // CHECK-DAG:     %c1 = arith.constant 1 : index
 // CHECK-DAG:     %c0 = arith.constant 0 : index
 // CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.array<25 x struct<(i32, f64)>> : (i64) -> !llvm.ptr<array<25 x struct<(i32, f64)>>>
-// CHECK-NEXT:     %1 = llvm.getelementptr %0[0, 0] : (!llvm.ptr<array<25 x struct<(i32, f64)>>>) -> !llvm.ptr<struct<(i32, f64)>>
+// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<array<25 x struct<(i32, f64)>>>) -> !llvm.ptr<struct<(i32, f64)>>
 // CHECK-NEXT:     scf.for %arg0 = %c0 to %c25 step %c1 {
 // CHECK-NEXT:       %2 = arith.index_cast %arg0 : index to i64
 // CHECK-NEXT:       %3 = llvm.getelementptr %1[%2] : (!llvm.ptr<struct<(i32, f64)>>, i64) -> !llvm.ptr<struct<(i32, f64)>>
@@ -26,7 +26,7 @@ void kern() {
 // CHECK-NEXT:   }
 // CHECK:   func @_ZN11AIntDividerC1Ev(%arg0: !llvm.ptr<struct<(i32, f64)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
 // CHECK-DAG:     %c3_i32 = arith.constant 3 : i32
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:     llvm.store %c3_i32, %0 : !llvm.ptr<i32>
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }

--- a/polygeist/tools/cgeist/Test/Verification/arrayconsmemref.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/arrayconsmemref.cpp
@@ -15,7 +15,7 @@ void kern() {
 // CHECK-DAG:     %c0 = arith.constant 0 : index
 // CHECK-DAG:      %c1_i64 = arith.constant 1 : i64
 // CHECK-NEXT:     llvm.alloca %c1_i64 x !llvm.array<25 x struct<(i32)>> : (i64) -> !llvm.ptr<array<25 x struct<(i32)>>>
-// CHECK-NEXT:     %1 = llvm.getelementptr %0[0, 0] : (!llvm.ptr<array<25 x struct<(i32)>>>) -> !llvm.ptr<struct<(i32)>>
+// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<array<25 x struct<(i32)>>>) -> !llvm.ptr<struct<(i32)>>
 // CHECK-NEXT:     scf.for %arg0 = %c0 to %c25 s
 // CHECK-NEXT:      %2 = arith.index_cast %arg0 : index to i64
 // CHECK-NEXT:      %3 = llvm.getelementptr %1[%2] : (!llvm.ptr<struct<(i32)>>, i64) -> !llvm.ptr<struct<(i32)>>
@@ -25,7 +25,7 @@ void kern() {
 // CHECK-NEXT:   }
 // CHECK:   func @_ZN11AIntDividerC1Ev(%arg0: !llvm.ptr<struct<(i32)>>)
 // CHECK-NEXT:     %c3_i32 = arith.constant 3 : i32
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:     llvm.store %c3_i32, %0 : !llvm.ptr<i32>
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }

--- a/polygeist/tools/cgeist/Test/Verification/arrayconsmemrefinner.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/arrayconsmemrefinner.cpp
@@ -24,8 +24,8 @@ void kern() {
 // CHECK-DAG:     %c25 = arith.constant 25 : index
 // CHECK-DAG:     %c1 = arith.constant 1 : index
 // CHECK-DAG:     %c0 = arith.constant 0 : index
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(array<25 x struct<(i32)>>, f64)>>) -> !llvm.ptr<array<25 x struct<(i32)>>>
-// CHECK-NEXT:     %1 = llvm.getelementptr %0[0, 0] : (!llvm.ptr<array<25 x struct<(i32)>>>) -> !llvm.ptr<struct<(i32)>>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(array<25 x struct<(i32)>>, f64)>>) -> !llvm.ptr<array<25 x struct<(i32)>>>
+// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<array<25 x struct<(i32)>>>) -> !llvm.ptr<struct<(i32)>>
 // CHECK-NEXT:     scf.for %arg1 = %c0 to %c25 step %c1 {
 // CHECK-NEXT:       %2 = arith.index_cast %arg1 : index to i64
 // CHECK-NEXT:       %3 = llvm.getelementptr %1[%2] : (!llvm.ptr<struct<(i32)>>, i64) -> !llvm.ptr<struct<(i32)>>
@@ -35,7 +35,7 @@ void kern() {
 // CHECK-NEXT:   }
 // CHECK:   func.func @_ZN11AIntDividerC1Ev(%arg0: !llvm.ptr<struct<(i32)>>)  attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
 // CHECK-NEXT:     %c3_i32 = arith.constant 3 : i32
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:     llvm.store %c3_i32, %0 : !llvm.ptr<i32>
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }

--- a/polygeist/tools/cgeist/Test/Verification/base_nostructabi.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/base_nostructabi.cpp
@@ -34,7 +34,7 @@ void a() {
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK:   func @_ZN19basic_ostringstreamC1Ev(%arg0: !llvm.ptr<struct<(struct<(i8)>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(struct<(i8)>)>>) -> !llvm.ptr<struct<(i8)>>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(i8)>)>>) -> !llvm.ptr<struct<(i8)>>
 // CHECK-NEXT:     call @_ZN12_Alloc_hiderC1Ev(%0) : (!llvm.ptr<struct<(i8)>>) -> ()
 // CHECK-NEXT:     %1 = llvm.bitcast %arg0 : !llvm.ptr<struct<(struct<(i8)>)>> to !llvm.ptr<i8>
 // CHECK-NEXT:     call @_Z4run2Pv(%1) : (!llvm.ptr<i8>) -> ()

--- a/polygeist/tools/cgeist/Test/Verification/base_with_virt.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/base_with_virt.cpp
@@ -41,14 +41,14 @@ void a() {
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK:   func @_ZN16mbasic_stringbufC1Ev(%arg0: !llvm.ptr<struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)>>) -> !llvm.ptr<struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)>>) -> !llvm.ptr<struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>>
 // CHECK-NEXT:     call @_ZN1AC1Ev(%0) : (!llvm.ptr<struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>>) -> ()
 // CHECK:          call @_ZN12_Alloc_hiderC1Ev
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK:   func @_ZN1AC1Ev(%arg0: !llvm.ptr<struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
 // CHECK-DAG:     %c3_i32 = arith.constant 3 : i32
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 1] : (!llvm.ptr<struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:     llvm.store %c3_i32, %0 : !llvm.ptr<i32>
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }

--- a/polygeist/tools/cgeist/Test/Verification/booleanmem.c
+++ b/polygeist/tools/cgeist/Test/Verification/booleanmem.c
@@ -83,7 +83,7 @@ struct foo {
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : i64
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(i32, i8)> : (i64) -> !llvm.ptr<struct<(i32, i8)>>
 // CHECK-NEXT:      llvm.store %[[VAL_0]], %[[VAL_2]] : !llvm.ptr<struct<(i32, i8)>>
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_2]][0, 1] : (!llvm.ptr<struct<(i32, i8)>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 1] : (!llvm.ptr<struct<(i32, i8)>>) -> !llvm.ptr<i8>
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i8>
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i8 to i1
 // CHECK-NEXT:      return %[[VAL_5]] : i1
@@ -94,7 +94,7 @@ bool struct_get(struct foo s) {
 
 // CHECK-LABEL:   func.func @struct_ptr_get(
 // CHECK-SAME:                              %[[VAL_0:.*]]: !llvm.ptr<struct<(i32, i8)>>) -> i1
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr %[[VAL_0]][0, 1] : (!llvm.ptr<struct<(i32, i8)>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr<struct<(i32, i8)>>) -> !llvm.ptr<i8>
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<i8>
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i8 to i1
 // CHECK-NEXT:      return %[[VAL_3]] : i1

--- a/polygeist/tools/cgeist/Test/Verification/booleanmem.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/booleanmem.cpp
@@ -6,14 +6,14 @@
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(i8, memref<?xi8>)> : (i64) -> !llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(i8, memref<?xi8>)> : (i64) -> !llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_4]][0, 0] : (!llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0] : (!llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>) -> !llvm.ptr<i8>
 // CHECK-NEXT:      %[[VAL_6:.*]] = arith.extui %[[VAL_0]] : i1 to i8
 // CHECK-NEXT:      llvm.store %[[VAL_6]], %[[VAL_5]] : !llvm.ptr<i8>
 // CHECK-NEXT:      %[[VAL_7:.*]] = arith.extui %[[VAL_1]] : i1 to i8
 // CHECK-NEXT:      %[[VAL_8:.*]] = memref.alloca() : memref<1xi8>
 // CHECK-NEXT:      affine.store %[[VAL_7]], %[[VAL_8]][0] : memref<1xi8>
 // CHECK-NEXT:      %[[VAL_9:.*]] = memref.cast %[[VAL_8]] : memref<1xi8> to memref<?xi8>
-// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr %[[VAL_4]][0, 1] : (!llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>) -> !llvm.ptr<memref<?xi8>>
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 1] : (!llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>) -> !llvm.ptr<memref<?xi8>>
 // CHECK-NEXT:      llvm.store %[[VAL_9]], %[[VAL_10]] : !llvm.ptr<memref<?xi8>>
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>
 // CHECK-NEXT:      llvm.store %[[VAL_11]], %[[VAL_3]] : !llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>

--- a/polygeist/tools/cgeist/Test/Verification/caff.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/caff.cpp
@@ -32,7 +32,7 @@ unsigned long long int div_kernel_cuda(ASmallVectorTemplateCommon<AOperandInfo> 
 
 // CHECK:   func @_Z15div_kernel_cudaR26ASmallVectorTemplateCommonI12AOperandInfoE(%arg0: !llvm.ptr<struct<(ptr<i8>, ptr<i8>)>>) -> i64 attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-DAG:     %c16_i64 = arith.constant 16 : i64
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 1] : (!llvm.ptr<struct<(ptr<i8>, ptr<i8>)>>) -> !llvm.ptr<ptr<i8>>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<struct<(ptr<i8>, ptr<i8>)>>) -> !llvm.ptr<ptr<i8>>
 // CHECK-NEXT:     %1 = llvm.load %0 : !llvm.ptr<ptr<i8>>
 // CHECK-NEXT:     %2 = llvm.bitcast %1 : !llvm.ptr<i8> to !llvm.ptr<struct<(ptr<i8>, i8, i8)>>
 // CHECK-NEXT:     %3 = call @_ZNK26ASmallVectorTemplateCommonI12AOperandInfoE5beginEv(%arg0) : (!llvm.ptr<struct<(ptr<i8>, ptr<i8>)>>) -> !llvm.ptr<struct<(ptr<i8>, i8, i8)>>
@@ -43,7 +43,7 @@ unsigned long long int div_kernel_cuda(ASmallVectorTemplateCommon<AOperandInfo> 
 // CHECK-NEXT:     return %[[i7]] : i64
 // CHECK-NEXT:   }
 // CHECK:   func @_ZNK26ASmallVectorTemplateCommonI12AOperandInfoE5beginEv(%arg0: !llvm.ptr<struct<(ptr<i8>, ptr<i8>)>>) -> !llvm.ptr<struct<(ptr<i8>, i8, i8)>> attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(ptr<i8>, ptr<i8>)>>) -> !llvm.ptr<ptr<i8>>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(ptr<i8>, ptr<i8>)>>) -> !llvm.ptr<ptr<i8>>
 // CHECK-NEXT:     %1 = llvm.load %0 : !llvm.ptr<ptr<i8>>
 // CHECK-NEXT:     %2 = llvm.bitcast %1 : !llvm.ptr<i8> to !llvm.ptr<struct<(ptr<i8>, i8, i8)>>
 // CHECK-NEXT:     return %2 : !llvm.ptr<struct<(ptr<i8>, i8, i8)>>

--- a/polygeist/tools/cgeist/Test/Verification/capture.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/capture.cpp
@@ -19,9 +19,9 @@ double kernel_deriche(int x, float y) {
 // CHECK-NEXT:     %2 = llvm.mlir.undef : f32
 // CHECK-NEXT:     affine.store %arg1, %alloca[0] : memref<1xf32>
 // CHECK-NEXT:     %cast = memref.cast %alloca : memref<1xf32> to memref<?xf32>
-// CHECK-NEXT:     [[GEP1:%.*]] = llvm.getelementptr %1[0, 0] : (!llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>) -> !llvm.ptr<memref<?xf32>>
+// CHECK-NEXT:     [[GEP1:%.*]] = llvm.getelementptr inbounds %1[0, 0] : (!llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>) -> !llvm.ptr<memref<?xf32>>
 // CHECK-NEXT:     llvm.store %cast, [[GEP1]] : !llvm.ptr<memref<?xf32>>
-// CHECK-NEXT:     [[GEP2:%.*]] = llvm.getelementptr %1[0, 1] : (!llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:     [[GEP2:%.*]] = llvm.getelementptr inbounds %1[0, 1] : (!llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:     llvm.store %arg0, [[GEP2]] : !llvm.ptr<i32>
 // CHECK-NEXT:     [[LOAD1:%.*]] = llvm.load %1 : !llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>
 // CHECK-NEXT:     llvm.store [[LOAD1]], %0 : !llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>
@@ -31,10 +31,10 @@ double kernel_deriche(int x, float y) {
 // CHECK-NEXT:     return [[RES]] : f64
 // CHECK-NEXT:   }
 // CHECK:   func private @_ZZ14kernel_dericheENK3$_0clEv(%arg0: !llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>) attributes {llvm.linkage = #llvm.linkage<internal>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 1] : (!llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:     %1 = llvm.load %0 : !llvm.ptr<i32>
 // CHECK-NEXT:     %2 = arith.sitofp %1 : i32 to f32
-// CHECK-NEXT:     %3 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>) -> !llvm.ptr<memref<?xf32>>
+// CHECK-NEXT:     %3 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>) -> !llvm.ptr<memref<?xf32>>
 // CHECK-NEXT:     %4 = llvm.load %3 : !llvm.ptr<memref<?xf32>>
 // CHECK-NEXT:     %5 = affine.load %4[0] : memref<?xf32>
 // CHECK-NEXT:     %6 = arith.mulf %5, %2 : f32

--- a/polygeist/tools/cgeist/Test/Verification/classrefmem.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/classrefmem.cpp
@@ -28,7 +28,7 @@ void Q(A& a) {
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK:   func @_ZN1A3addEv(%arg0: !llvm.ptr<!llvm.struct<(memref<?xi32>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<!llvm.struct<(memref<?xi32>)>>) -> !llvm.ptr<memref<?xi32>>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<!llvm.struct<(memref<?xi32>)>>) -> !llvm.ptr<memref<?xi32>>
 // CHECK-NEXT:     %1 = llvm.load %0 : !llvm.ptr<memref<?xi32>>
 // CHECK-NEXT:     call @_Z4oaddRi(%1) : (memref<?xi32>) -> ()
 // CHECK-NEXT:     return

--- a/polygeist/tools/cgeist/Test/Verification/consabi.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/consabi.cpp
@@ -22,23 +22,23 @@ QStream ilaunch_kernel(QStream x) {
 // CHECK-NEXT:     return %1 : !llvm.struct<(struct<(f64, f64)>, i32)>
 // CHECK-NEXT:   }
 // CHECK-NEXT:   func @_ZN7QStreamC1EOS_(%arg0: !llvm.ptr<struct<(struct<(f64, f64)>, i32)>>, %arg1: !llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> !llvm.ptr<struct<(f64, f64)>>
-// CHECK-NEXT:     %1 = llvm.getelementptr %arg1[0, 0] : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> !llvm.ptr<struct<(f64, f64)>>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> !llvm.ptr<struct<(f64, f64)>>
+// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %arg1[0, 0] : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> !llvm.ptr<struct<(f64, f64)>>
 // CHECK-NEXT:     call @_ZN1DC1EOS_(%0, %1) : (!llvm.ptr<struct<(f64, f64)>>, !llvm.ptr<struct<(f64, f64)>>) -> ()
-// CHECK-NEXT:     %2 = llvm.getelementptr %arg1[0, 1] : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:     %2 = llvm.getelementptr inbounds %arg1[0, 1] : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:     %3 = llvm.load %2 : !llvm.ptr<i32>
-// CHECK-NEXT:     %4 = llvm.getelementptr %arg0[0, 1] : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:     %4 = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:     llvm.store %3, %4 : !llvm.ptr<i32>
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK-NEXT:   func @_ZN1DC1EOS_(%arg0: !llvm.ptr<struct<(f64, f64)>>, %arg1: !llvm.ptr<struct<(f64, f64)>>)
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg1[0, 0] : (!llvm.ptr<struct<(f64, f64)>>) -> !llvm.ptr<f64>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg1[0, 0] : (!llvm.ptr<struct<(f64, f64)>>) -> !llvm.ptr<f64>
 // CHECK-NEXT:     %1 = llvm.load %0 : !llvm.ptr<f64>
-// CHECK-NEXT:     %2 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(f64, f64)>>) -> !llvm.ptr<f64>
+// CHECK-NEXT:     %2 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(f64, f64)>>) -> !llvm.ptr<f64>
 // CHECK-NEXT:     llvm.store %1, %2 : !llvm.ptr<f64>
-// CHECK-NEXT:     %3 = llvm.getelementptr %arg1[0, 1] : (!llvm.ptr<struct<(f64, f64)>>) -> !llvm.ptr<f64>
+// CHECK-NEXT:     %3 = llvm.getelementptr inbounds %arg1[0, 1] : (!llvm.ptr<struct<(f64, f64)>>) -> !llvm.ptr<f64>
 // CHECK-NEXT:     %4 = llvm.load %3 : !llvm.ptr<f64>
-// CHECK-NEXT:     %5 = llvm.getelementptr %arg0[0, 1] : (!llvm.ptr<struct<(f64, f64)>>) -> !llvm.ptr<f64>
+// CHECK-NEXT:     %5 = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<struct<(f64, f64)>>) -> !llvm.ptr<f64>
 // CHECK-NEXT:     llvm.store %4, %5 : !llvm.ptr<f64>
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }

--- a/polygeist/tools/cgeist/Test/Verification/derived.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/derived.cpp
@@ -18,14 +18,14 @@ int ptr(struct B* v) {
 }
 
 // CHECK:   func @_Z3refR1B(%arg0: !llvm.ptr<struct<(struct<(i32, f64)>, ptr<i8>)>>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(struct<(i32, f64)>, ptr<i8>)>>) -> !llvm.ptr<struct<(i32, f64)>>
-// CHECK-NEXT:     %1 = llvm.getelementptr %0[0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(i32, f64)>, ptr<i8>)>>) -> !llvm.ptr<struct<(i32, f64)>>
+// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:     %2 = llvm.load %1 : !llvm.ptr<i32>
 // CHECK-NEXT:     return %2 : i32
 // CHECK-NEXT:   }
 // CHECK:   func @_Z3ptrP1B(%arg0: !llvm.ptr<struct<(struct<(i32, f64)>, ptr<i8>)>>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(struct<(i32, f64)>, ptr<i8>)>>) -> !llvm.ptr<struct<(i32, f64)>>
-// CHECK-NEXT:     %1 = llvm.getelementptr %0[0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(i32, f64)>, ptr<i8>)>>) -> !llvm.ptr<struct<(i32, f64)>>
+// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:     %2 = llvm.load %1 : !llvm.ptr<i32>
 // CHECK-NEXT:     return %2 : i32
 // CHECK-NEXT:   }

--- a/polygeist/tools/cgeist/Test/Verification/fscanf.c
+++ b/polygeist/tools/cgeist/Test/Verification/fscanf.c
@@ -30,7 +30,7 @@ int* alloc() {
 // CHECK-DAG:    %c1_i64 = arith.constant 1 : i64
 // CHECK-NEXT:    %0 = llvm.alloca %c1_i64 x i32 : (i64) -> !llvm.ptr<i32>
 // CHECK-NEXT:    %1 = llvm.mlir.addressof @str0 : !llvm.ptr<array<3 x i8>>
-// CHECK-NEXT:    %2 = llvm.getelementptr %1[0, 0] : (!llvm.ptr<array<3 x i8>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:    %2 = llvm.getelementptr inbounds %1[0, 0] : (!llvm.ptr<array<3 x i8>>) -> !llvm.ptr<i8>
 // CHECK-NEXT:    %3 = llvm.call @__isoc99_scanf(%2, %0) : (!llvm.ptr<i8>, !llvm.ptr<i32>) -> i32
 // CHECK-NEXT:    %4 = llvm.load %0 : !llvm.ptr<i32>
 // CHECK-NEXT:    %5 = arith.extsi %4 : i32 to i64
@@ -40,7 +40,7 @@ int* alloc() {
 // CHECK-NEXT:    %[[i8:.+]] = memref.alloc(%8) : memref<?xi32>
 // CHECK-NEXT:    %[[n:.+]] = arith.index_cast %4 : i32 to index
 // CHECK-NEXT:      %[[i9:.+]] = llvm.mlir.addressof @str1 : !llvm.ptr<array<4 x i8>>
-// CHECK-NEXT:      %[[i10:.+]] = llvm.getelementptr %[[i9]][0, 0] : (!llvm.ptr<array<4 x i8>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:      %[[i10:.+]] = llvm.getelementptr inbounds %[[i9]][0, 0] : (!llvm.ptr<array<4 x i8>>) -> !llvm.ptr<i8>
 // CHECK-NEXT:    scf.for %arg0 = %c0 to %[[n]] step %c1 {
 // CHECK-NEXT:      %[[i13:.+]] = llvm.call @__isoc99_scanf(%[[i10]], %0) : (!llvm.ptr<i8>, !llvm.ptr<i32>) -> i32
 // CHECK-NEXT:      %[[i12:.+]] = llvm.load %0 : !llvm.ptr<i32>

--- a/polygeist/tools/cgeist/Test/Verification/gettimeofday.c
+++ b/polygeist/tools/cgeist/Test/Verification/gettimeofday.c
@@ -14,10 +14,10 @@ double alloc() {
 // CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(i64, i64)> : (i64) -> !llvm.ptr<struct<(i64, i64)>>
 // CHECK-NEXT:     %1 = llvm.mlir.null : !llvm.ptr<{{.*}}>
 // CHECK:          %{{.*}} = llvm.call @gettimeofday(%0, %{{.*}}) : (!llvm.ptr<struct<(i64, i64)>>, {{.*}}) -> i32
-// CHECK-NEXT:     [[T3:%.*]] = llvm.getelementptr %0[0, 0] : (!llvm.ptr<struct<(i64, i64)>>) -> !llvm.ptr<i64>
+// CHECK-NEXT:     [[T3:%.*]] = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<struct<(i64, i64)>>) -> !llvm.ptr<i64>
 // CHECK-NEXT:     [[T4:%.*]] = llvm.load [[T3]] : !llvm.ptr<i64>
 // CHECK-NEXT:     [[T5:%.*]] = arith.sitofp [[T4]] : i64 to f64
-// CHECK-NEXT:     [[T6:%.*]] = llvm.getelementptr %0[0, 1] : (!llvm.ptr<struct<(i64, i64)>>) -> !llvm.ptr<i64>
+// CHECK-NEXT:     [[T6:%.*]] = llvm.getelementptr inbounds %0[0, 1] : (!llvm.ptr<struct<(i64, i64)>>) -> !llvm.ptr<i64>
 // CHECK-NEXT:     [[T7:%.*]] = llvm.load [[T6]] : !llvm.ptr<i64>
 // CHECK-NEXT:     [[T8:%.*]] = arith.sitofp [[T7]] : i64 to f64
 // CHECK-NEXT:     [[T9:%.*]] = arith.mulf [[T8]], %cst : f64

--- a/polygeist/tools/cgeist/Test/Verification/ident.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/ident.cpp
@@ -49,7 +49,7 @@ void lt_kernel_cuda(MTensorIterator& iter) {
 // CHECK-NEXT:     %2 = call @_ZNK15MTensorIterator11input_dtypeEv(%arg0) : (!llvm.ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>) -> i8
 // CHECK-NEXT:     %3 = arith.cmpi ne, %2, %c0_i8 : i8
 // CHECK-NEXT:     scf.if %3 {
-// CHECK-NEXT:       %4 = llvm.getelementptr %1[0, 0] : (!llvm.ptr<struct<(ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>)>>) -> !llvm.ptr<ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>>
+// CHECK-NEXT:       %4 = llvm.getelementptr inbounds %1[0, 0] : (!llvm.ptr<struct<(ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>)>>) -> !llvm.ptr<ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>>
 // CHECK-NEXT:       llvm.store %arg0, %4 : !llvm.ptr<ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>>
 // CHECK-NEXT:       %5 = llvm.load %1 : !llvm.ptr<struct<(ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>)>>
 // CHECK-NEXT:       llvm.store %5, %0 : !llvm.ptr<struct<(ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>)>>
@@ -59,9 +59,9 @@ void lt_kernel_cuda(MTensorIterator& iter) {
 // CHECK-NEXT:   }
 // CHECK:   func.func @_ZNK15MTensorIterator11input_dtypeEv(%arg0: !llvm.ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>) -> i8 attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
 // CHECK-NEXT:     %c0_i32 = arith.constant 0 : i32
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>) -> !llvm.ptr<struct<(ptr<struct<(i8, i8)>>)>>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>) -> !llvm.ptr<struct<(ptr<struct<(i8, i8)>>)>>
 // CHECK-NEXT:     %1 = call @_ZNK12MSmallVectorI12MOperandInfoEixEi(%0, %c0_i32) : (!llvm.ptr<struct<(ptr<struct<(i8, i8)>>)>>, i32) -> !llvm.ptr<struct<(i8, i8)>>
-// CHECK-NEXT:     %2 = llvm.getelementptr %1[0, 1] : (!llvm.ptr<struct<(i8, i8)>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:     %2 = llvm.getelementptr inbounds %1[0, 1] : (!llvm.ptr<struct<(i8, i8)>>) -> !llvm.ptr<i8>
 // CHECK-NEXT:     %3 = llvm.load %2 : !llvm.ptr<i8>
 // CHECK-NEXT:     return %3 : i8
 // CHECK-NEXT:   }
@@ -69,7 +69,7 @@ void lt_kernel_cuda(MTensorIterator& iter) {
 // CHECK-NEXT:     %c1_i64 = arith.constant 1 : i64
 // CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(i8)> : (i64) -> !llvm.ptr<struct<(i8)>>
 // CHECK-NEXT:     %1 = llvm.alloca %c1_i64 x !llvm.struct<(i8)> : (i64) -> !llvm.ptr<struct<(i8)>>
-// CHECK-NEXT:     %2 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>)>>) -> !llvm.ptr<ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>>
+// CHECK-NEXT:     %2 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>)>>) -> !llvm.ptr<ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>>
 // CHECK-NEXT:     %3 = llvm.load %2 : !llvm.ptr<ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>>
 // CHECK-NEXT:     %4 = llvm.load %1 : !llvm.ptr<struct<(i8)>>
 // CHECK-NEXT:     llvm.store %4, %0 : !llvm.ptr<struct<(i8)>>
@@ -77,7 +77,7 @@ void lt_kernel_cuda(MTensorIterator& iter) {
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK:   func.func @_ZNK12MSmallVectorI12MOperandInfoEixEi(%arg0: !llvm.ptr<struct<(ptr<struct<(i8, i8)>>)>>, %arg1: i32) -> !llvm.ptr<struct<(i8, i8)>> attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:    %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(ptr<struct<(i8, i8)>>)>>) -> !llvm.ptr<ptr<struct<(i8, i8)>>>
+// CHECK-NEXT:    %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(ptr<struct<(i8, i8)>>)>>) -> !llvm.ptr<ptr<struct<(i8, i8)>>>
 // CHECK-NEXT:    %1 = llvm.load %0 : !llvm.ptr<ptr<struct<(i8, i8)>>>
 // CHECK-NEXT:    %2 = arith.index_cast %arg1 : i32 to index
 // CHECK-NEXT:    %3 = arith.index_cast %2 : index to i64
@@ -90,9 +90,9 @@ void lt_kernel_cuda(MTensorIterator& iter) {
 // CHECK-NEXT:  }
 // CHECK:      func.func @_ZNK15MTensorIterator6deviceEv(%arg0: !llvm.ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>) -> i8 attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
 // CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
-// CHECK-NEXT:    %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>) -> !llvm.ptr<struct<(ptr<struct<(i8, i8)>>)>>
+// CHECK-NEXT:    %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>) -> !llvm.ptr<struct<(ptr<struct<(i8, i8)>>)>>
 // CHECK-NEXT:    %1 = call @_ZNK12MSmallVectorI12MOperandInfoEixEi(%0, %c0_i32) : (!llvm.ptr<struct<(ptr<struct<(i8, i8)>>)>>, i32) -> !llvm.ptr<struct<(i8, i8)>>
-// CHECK-NEXT:    %2 = llvm.getelementptr %1[0, 0] : (!llvm.ptr<struct<(i8, i8)>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:    %2 = llvm.getelementptr inbounds %1[0, 0] : (!llvm.ptr<struct<(i8, i8)>>) -> !llvm.ptr<i8>
 // CHECK-NEXT:    %3 = llvm.load %2 : !llvm.ptr<i8>
 // CHECK-NEXT:    return %3 : i8
 // CHECK-NEXT:  }

--- a/polygeist/tools/cgeist/Test/Verification/loop.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/loop.cpp
@@ -30,7 +30,7 @@ void div_(int* sizes, short k) {
 // CHECK-NEXT:       %reshape = memref.reshape %[[VAL_K]](%alloca) : (memref<i16>, memref<1xindex>) -> memref<1xi16>
 // CHECK-NEXT:       affine.store %[[ARG_K]], %reshape[0] : memref<1xi16>
 // CHECK-NEXT:       %[[VAL_5:.*]] = memref.get_global @MAX_DIMS : memref<i32>
-// CHECK-NEXT:       %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_4]][0, 0] : (!llvm.ptr<array<25 x struct<(i32, f64)>>>) -> !llvm.ptr<struct<(i32, f64)>>
+// CHECK-NEXT:       %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0] : (!llvm.ptr<array<25 x struct<(i32, f64)>>>) -> !llvm.ptr<struct<(i32, f64)>>
 // CHECK-NEXT:       %[[VAL_7:.*]] = scf.while (%[[VAL_8:.*]] = %[[VAL_2]]) : (i32) -> i32 {
 // CHECK-NEXT:         %[[VAL_9:.*]] = memref.alloca() : memref<1xindex>
 // CHECK-NEXT:         %[[VAL_10:.*]] = memref.reshape %[[VAL_5]](%[[VAL_9]]) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
@@ -48,7 +48,7 @@ void div_(int* sizes, short k) {
 // CHECK-NEXT:         %[[ADDI:.*]] = arith.addi %[[VAL_15]], %[[EXTSI]] : i32
 // CHECK-NEXT:         %[[VAL_16:.*]] = arith.index_cast %[[VAL_14]] : index to i64
 // CHECK-NEXT:         %[[VAL_17:.*]] = llvm.getelementptr %[[VAL_6]]{{\[}}%[[VAL_16]]] : (!llvm.ptr<struct<(i32, f64)>>, i64) -> !llvm.ptr<struct<(i32, f64)>>
-// CHECK-NEXT:         %[[VAL_18:.*]] = llvm.getelementptr %[[VAL_17]][0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:         %[[VAL_18:.*]] = llvm.getelementptr inbounds %[[VAL_17]][0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:         llvm.store %[[ADDI]], %[[VAL_18]] : !llvm.ptr<i32>
 // CHECK-NEXT:         %[[VAL_19:.*]] = arith.addi %[[VAL_13]], %[[VAL_1]] : i32
 // CHECK-NEXT:         scf.yield %[[VAL_19]] : i32

--- a/polygeist/tools/cgeist/Test/Verification/new.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/new.cpp
@@ -15,9 +15,9 @@ int main(int argc, char const *argv[]) {
   // CHECK-DAG:    %c0_i32 = arith.constant 0 : i32
   // CHECK:        %0 = llvm.call @malloc(%c8_i64) : (i64) -> !llvm.ptr<i8>
   // CHECK-NEXT:   %1 = llvm.bitcast %0 : !llvm.ptr<i8> to !llvm.ptr<struct<(f32, f32)>>
-  // CHECK-NEXT:   %2 = llvm.getelementptr %1[0, 0] : (!llvm.ptr<struct<(f32, f32)>>) -> !llvm.ptr<f32>
+  // CHECK-NEXT:   %2 = llvm.getelementptr inbounds %1[0, 0] : (!llvm.ptr<struct<(f32, f32)>>) -> !llvm.ptr<f32>
   // CHECK-NEXT:   llvm.store %cst_0, %2 : !llvm.ptr<f32>
-  // CHECK-NEXT:   %3 = llvm.getelementptr %1[0, 1] : (!llvm.ptr<struct<(f32, f32)>>) -> !llvm.ptr<f32>
+  // CHECK-NEXT:   %3 = llvm.getelementptr inbounds %1[0, 1] : (!llvm.ptr<struct<(f32, f32)>>) -> !llvm.ptr<f32>
   // CHECK-NEXT:   llvm.store %cst, %3 : !llvm.ptr<f32>
   // CHECK-NEXT:   call @_Z1fP1A(%1) : (!llvm.ptr<struct<(f32, f32)>>) -> ()
   // CHECK-NEXT:   return %c0_i32 : i32

--- a/polygeist/tools/cgeist/Test/Verification/packedstruct.c
+++ b/polygeist/tools/cgeist/Test/Verification/packedstruct.c
@@ -17,9 +17,9 @@ void compute(struct fin f) {
 }
 
 // CHECK:   func @compute(%arg0: !llvm.ptr<struct<(struct<(i64, i8)>, i8)>>) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(struct<(i64, i8)>, i8)>>) -> !llvm.ptr<struct<(i64, i8)>>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(i64, i8)>, i8)>>) -> !llvm.ptr<struct<(i64, i8)>>
 // CHECK-NEXT:     %1 = llvm.load %0 : !llvm.ptr<struct<(i64, i8)>>
-// CHECK-NEXT:     %2 = llvm.getelementptr %arg0[0, 1] : (!llvm.ptr<struct<(struct<(i64, i8)>, i8)>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:     %2 = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<struct<(struct<(i64, i8)>, i8)>>) -> !llvm.ptr<i8>
 // CHECK-NEXT:     %3 = llvm.load %2 : !llvm.ptr<i8>
 // CHECK-NEXT:     %4 = call @run(%1, %3) : (!llvm.struct<(i64, i8)>, i8) -> i64
 // CHECK-NEXT:     return

--- a/polygeist/tools/cgeist/Test/Verification/pair.c
+++ b/polygeist/tools/cgeist/Test/Verification/pair.c
@@ -22,7 +22,7 @@ int create() {
 // CHECK-NEXT:    %c1_i64 = arith.constant 1 : i64
 // CHECK-NEXT:    %0 = llvm.alloca %c1_i64 x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr<struct<(i32, i32)>>
 // CHECK-NEXT:    llvm.store %arg0, %0 : !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    %1 = llvm.getelementptr %0[0, 1] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:    %1 = llvm.getelementptr inbounds %0[0, 1] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:    llvm.store %arg1, %1 : !llvm.ptr<i32>
 // CHECK-NEXT:    %2 = llvm.load %0 : !llvm.ptr<struct<(i32, i32)>>
 // CHECK-NEXT:    return %2 : !llvm.struct<(i32, i32)>
@@ -34,14 +34,14 @@ int create() {
 // CHECK-DAG:     %c1_i64 = arith.constant 1 : i64
 // CHECK-NEXT:    %0 = llvm.alloca %c1_i64 x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr<struct<(i32, i32)>>
 // CHECK-NEXT:    %1 = llvm.alloca %c1_i64 x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    %2 = llvm.getelementptr %1[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:    %2 = llvm.getelementptr inbounds %1[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:    llvm.store %c0_i32, %2 : !llvm.ptr<i32>
-// CHECK-NEXT:    %3 = llvm.getelementptr %1[0, 1] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:    %3 = llvm.getelementptr inbounds %1[0, 1] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:    llvm.store %c1_i32, %3 : !llvm.ptr<i32>
 // CHECK-NEXT:    %4 = llvm.load %1 : !llvm.ptr<struct<(i32, i32)>>
 // CHECK-NEXT:    %5 = call @byval0(%4, %c2_i32) : (!llvm.struct<(i32, i32)>, i32) -> !llvm.struct<(i32, i32)>
 // CHECK-NEXT:    llvm.store %5, %0 : !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    %6 = llvm.getelementptr %0[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:    %6 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:    %7 = llvm.load %6 : !llvm.ptr<i32>
 // CHECK-NEXT:    return %7 : i32
 // CHECK-NEXT:   }

--- a/polygeist/tools/cgeist/Test/Verification/pairinit.c
+++ b/polygeist/tools/cgeist/Test/Verification/pairinit.c
@@ -14,9 +14,9 @@ struct pair func() {
 // CHECK-DAG:     %c2_i32 = arith.constant 2 : i32
 // CHECK-DAG:     %c1_i64 = arith.constant 1 : i64
 // CHECK-NEXT:    %0 = llvm.alloca %c1_i64 x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    %1 = llvm.getelementptr %0[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:    %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:    llvm.store %c2_i32, %1 : !llvm.ptr<i32>
-// CHECK-NEXT:    %2 = llvm.getelementptr %0[0, 1] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:    %2 = llvm.getelementptr inbounds %0[0, 1] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:    llvm.store %c3_i32, %2 : !llvm.ptr<i32>
 // CHECK-NEXT:    %3 = llvm.load %0 : !llvm.ptr<struct<(i32, i32)>>
 // CHECK-NEXT:    return %3 : !llvm.struct<(i32, i32)>

--- a/polygeist/tools/cgeist/Test/Verification/pairptr.c
+++ b/polygeist/tools/cgeist/Test/Verification/pairptr.c
@@ -28,13 +28,13 @@ int create() {
 // CHECK-DAG:     %c1_i64 = arith.constant 1 : i64
 // CHECK-NEXT:    %0 = llvm.alloca %c1_i64 x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr<struct<(i32, i32)>>
 // CHECK-NEXT:    %1 = llvm.alloca %c1_i64 x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    %2 = llvm.getelementptr %1[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:    %2 = llvm.getelementptr inbounds %1[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:    llvm.store %c0_i32, %2 : !llvm.ptr<i32>
-// CHECK-NEXT:    %3 = llvm.getelementptr %1[0, 1] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:    %3 = llvm.getelementptr inbounds %1[0, 1] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:    llvm.store %c1_i32, %3 : !llvm.ptr<i32>
 // CHECK-NEXT:    %4 = call @byval0(%1, %c2_i32) : (!llvm.ptr<struct<(i32, i32)>>, i32) -> !llvm.struct<(i32, i32)>
 // CHECK-NEXT:    llvm.store %4, %0 : !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    %5 = llvm.getelementptr %0[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:    %5 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:    %6 = llvm.load %5 : !llvm.ptr<i32>
 // CHECK-NEXT:    return %6 : i32
 // CHECK-NEXT:   }

--- a/polygeist/tools/cgeist/Test/Verification/recurstruct.c
+++ b/polygeist/tools/cgeist/Test/Verification/recurstruct.c
@@ -17,9 +17,9 @@ double sum(struct Node* n) {
 // CHECK-NEXT:     %2 = scf.if %1 -> (f64) {
 // CHECK-NEXT:       scf.yield %cst : f64
 // CHECK-NEXT:     } else {
-// CHECK-NEXT:       %3 = llvm.getelementptr %arg0[0, 1] : (!llvm.ptr<struct<"polygeist@mlir@struct.Node", (ptr<struct<"polygeist@mlir@struct.Node">>, f64)>>) -> !llvm.ptr<f64>
+// CHECK-NEXT:       %3 = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<struct<"polygeist@mlir@struct.Node", (ptr<struct<"polygeist@mlir@struct.Node">>, f64)>>) -> !llvm.ptr<f64>
 // CHECK-NEXT:       %4 = llvm.load %3 : !llvm.ptr<f64>
-// CHECK-NEXT:       %5 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<"polygeist@mlir@struct.Node", (ptr<struct<"polygeist@mlir@struct.Node">>, f64)>>) -> !llvm.ptr<ptr<struct<"polygeist@mlir@struct.Node", (ptr<struct<"polygeist@mlir@struct.Node">>, f64)>>>
+// CHECK-NEXT:       %5 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<"polygeist@mlir@struct.Node", (ptr<struct<"polygeist@mlir@struct.Node">>, f64)>>) -> !llvm.ptr<ptr<struct<"polygeist@mlir@struct.Node", (ptr<struct<"polygeist@mlir@struct.Node">>, f64)>>>
 // CHECK-NEXT:       %6 = llvm.load %5 : !llvm.ptr<ptr<struct<"polygeist@mlir@struct.Node", (ptr<struct<"polygeist@mlir@struct.Node">>, f64)>>>
 // CHECK-NEXT:       %7 = func.call @sum(%6) : (!llvm.ptr<struct<"polygeist@mlir@struct.Node", (ptr<struct<"polygeist@mlir@struct.Node">>, f64)>>) -> f64
 // CHECK-NEXT:       %8 = arith.addf %4, %7 : f64

--- a/polygeist/tools/cgeist/Test/Verification/refpair.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/refpair.cpp
@@ -21,7 +21,7 @@ void kernel_deriche() {
 
 // CHECK:   func @sub(%arg0: !llvm.ptr<struct<(i32, i32)>>)
 // CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:     %1 = llvm.load %0 : !llvm.ptr<i32>
 // CHECK-NEXT:     %2 = arith.addi %1, %c1_i32 : i32
 // CHECK-NEXT:     llvm.store %2, %0 : !llvm.ptr<i32>
@@ -32,7 +32,7 @@ void kernel_deriche() {
 // CHECK-DAG:      %c32_i32 = arith.constant 32 : i32
 // CHECK-DAG:      %c1_i64 = arith.constant 1 : i64
 // CHECK:          %0 = llvm.alloca %c1_i64 x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:     %1 = llvm.getelementptr %0[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:     llvm.store %c32_i32, %1 : !llvm.ptr<i32>
 // CHECK-NEXT:     call @sub0(%0) : (!llvm.ptr<struct<(i32, i32)>>) -> ()
 // CHECK-NEXT:     return

--- a/polygeist/tools/cgeist/Test/Verification/struct.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/struct.cpp
@@ -17,7 +17,7 @@ float func(struct OperandInfo* op) {
 }
 
 // CHECK:   func @func(%arg0: !llvm.ptr<struct<(i8, ptr<i8>, i8)>>) -> f32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %[[i2:.+]] = llvm.getelementptr %arg0[0, 1] : (!llvm.ptr<struct<(i8, ptr<i8>, i8)>>) -> !llvm.ptr<ptr<i8>>
+// CHECK-NEXT:     %[[i2:.+]] = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<struct<(i8, ptr<i8>, i8)>>) -> !llvm.ptr<ptr<i8>>
 // CHECK-NEXT:     %[[i3:.+]] = llvm.load %[[i2]] : !llvm.ptr<ptr<i8>>
 // CHECK-NEXT:     %[[i4:.+]] = call @_Z5hloadPKv(%[[i3]]) : (!llvm.ptr<i8>) -> f32
 // CHECK-NEXT:     return %[[i4]] : f32

--- a/polygeist/tools/cgeist/Test/Verification/sycl/assert.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/assert.cpp
@@ -8,11 +8,11 @@ using namespace sycl;
 // CHECK-LABEL:    func.func @_Z12check_assertN4sycl3_V12idILi1EEES2_(%arg0: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef})
 // CHECK-NEXT:        [[C22:%.*]] = arith.constant 22 : i32
 // CHECK:             %3 = llvm.mlir.addressof @str0 : !llvm.ptr<array<11 x i8>>
-// CHECK-NEXT:        %4 = llvm.getelementptr %3[0, 0] : (!llvm.ptr<array<11 x i8>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:        %4 = llvm.getelementptr inbounds %3[0, 0] : (!llvm.ptr<array<11 x i8>>) -> !llvm.ptr<i8>
 // CHECK-NEXT:        %5 = llvm.mlir.addressof @str1 : !llvm.ptr<array<[[PATH_LENGTH:.*]] x i8>>
-// CHECK-NEXT:        %6 = llvm.getelementptr %5[0, 0] : (!llvm.ptr<array<[[PATH_LENGTH]] x i8>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:        %6 = llvm.getelementptr inbounds %5[0, 0] : (!llvm.ptr<array<[[PATH_LENGTH]] x i8>>) -> !llvm.ptr<i8>
 // CHECK-NEXT:        %7 = llvm.mlir.addressof @str2 : !llvm.ptr<array<32 x i8>>
-// CHECK-NEXT:        %8 = llvm.getelementptr %7[0, 0] : (!llvm.ptr<array<32 x i8>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:        %8 = llvm.getelementptr inbounds %7[0, 0] : (!llvm.ptr<array<32 x i8>>) -> !llvm.ptr<i8>
 // CHECK-NEXT:        %9 = llvm.addrspacecast %4 : !llvm.ptr<i8> to !llvm.ptr<i8, 4>
 // CHECK-NEXT:        %10 = llvm.addrspacecast %6 : !llvm.ptr<i8> to !llvm.ptr<i8, 4>
 // CHECK-NEXT:        %11 = llvm.addrspacecast %8 : !llvm.ptr<i8> to !llvm.ptr<i8, 4>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/structvec.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/structvec.cpp
@@ -17,7 +17,7 @@ struct structvec {
 // CHECK-LABEL: func.func @_Z10test_store9structvecic(%arg0: !llvm.ptr<struct<(vector<2xi8>)>> {llvm.align = 2 : i64, llvm.byval = !llvm.struct<(vector<2xi8>)>, llvm.noundef}, %arg1: i32 {llvm.noundef}, %arg2: i8 {llvm.noundef, llvm.signext}) -> !llvm.struct<(vector<2xi8>)>
 // CHECK-NEXT:    %c1_i64 = arith.constant 1 : i64
 // CHECK-NEXT:    %0 = llvm.alloca %c1_i64 x !llvm.struct<(vector<2xi8>)> : (i64) -> !llvm.ptr<struct<(vector<2xi8>)>>
-// CHECK-NEXT:    %1 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(vector<2xi8>)>>) -> !llvm.ptr<vector<2xi8>>
+// CHECK-NEXT:    %1 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(vector<2xi8>)>>) -> !llvm.ptr<vector<2xi8>>
 // CHECK-NEXT:    %2 = llvm.load %1 : !llvm.ptr<vector<2xi8>>
 // CHECK-NEXT:    %3 = vector.insertelement %arg2, %2[%arg1 : i32] : vector<2xi8>
 // CHECK-NEXT:    llvm.store %3, %1 : !llvm.ptr<vector<2xi8>>
@@ -29,9 +29,9 @@ struct structvec {
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: func.func @_ZN9structvecC1EOS_(%arg0: !llvm.ptr<struct<(vector<2xi8>)>, 4> {llvm.align = 2 : i64, llvm.dereferenceable_or_null = 2 : i64, llvm.noundef}, %arg1: !llvm.ptr<struct<(vector<2xi8>)>, 4> {llvm.align = 2 : i64, llvm.dereferenceable = 2 : i64, llvm.noundef})
-// CHECK-NEXT:    %0 = llvm.getelementptr %arg1[0, 0] : (!llvm.ptr<struct<(vector<2xi8>)>, 4>) -> !llvm.ptr<vector<2xi8>, 4>
+// CHECK-NEXT:    %0 = llvm.getelementptr inbounds %arg1[0, 0] : (!llvm.ptr<struct<(vector<2xi8>)>, 4>) -> !llvm.ptr<vector<2xi8>, 4>
 // CHECK-NEXT:    %1 = llvm.load %0 : !llvm.ptr<vector<2xi8>, 4>
-// CHECK-NEXT:    %2 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(vector<2xi8>)>, 4>) -> !llvm.ptr<vector<2xi8>, 4>
+// CHECK-NEXT:    %2 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(vector<2xi8>)>, 4>) -> !llvm.ptr<vector<2xi8>, 4>
 // CHECK-NEXT:    llvm.store %1, %2 : !llvm.ptr<vector<2xi8>, 4>
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
@@ -53,17 +53,17 @@ SYCL_EXTERNAL structvec test_store(structvec sv, int idx, char el) {
 // CHECK-DAG:     %4 = llvm.alloca %c1_i64 x !llvm.array<2 x i8> : (i64) -> !llvm.ptr<array<2 x i8>>
 // CHECK-DAG:     %5 = llvm.alloca %c1_i64 x !llvm.array<2 x i8> : (i64) -> !llvm.ptr<array<2 x i8>>
 // CHECK-DAG:     %6 = llvm.alloca %c1_i64 x !llvm.struct<(vector<2xi8>)> : (i64) -> !llvm.ptr<struct<(vector<2xi8>)>>
-// CHECK-NEXT:    %7 = llvm.getelementptr %5[0, 0] : (!llvm.ptr<array<2 x i8>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:    %7 = llvm.getelementptr inbounds %5[0, 0] : (!llvm.ptr<array<2 x i8>>) -> !llvm.ptr<i8>
 // CHECK-NEXT:    llvm.store %c0_i8, %7 : !llvm.ptr<i8>
-// CHECK-NEXT:    %8 = llvm.getelementptr %5[0, 1] : (!llvm.ptr<array<2 x i8>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:    %8 = llvm.getelementptr inbounds %5[0, 1] : (!llvm.ptr<array<2 x i8>>) -> !llvm.ptr<i8>
 // CHECK-NEXT:    llvm.store %c1_i8, %8 : !llvm.ptr<i8>
 // CHECK-NEXT:    %9 = llvm.addrspacecast %4 : !llvm.ptr<array<2 x i8>> to !llvm.ptr<array<2 x i8>, 4>
 // CHECK-NEXT:    %10 = llvm.load %5 : !llvm.ptr<array<2 x i8>>
 // CHECK-NEXT:    llvm.store %10, %9 : !llvm.ptr<array<2 x i8>, 4>
 // CHECK-NEXT:    %11 = "polygeist.pointer2memref"(%9) : (!llvm.ptr<array<2 x i8>, 4>) -> memref<?xi8, 4 : i32>
-// CHECK-NEXT:    %12 = llvm.getelementptr %3[0, 0] : (!llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>>) -> !llvm.ptr<memref<?xi8, 4>>
+// CHECK-NEXT:    %12 = llvm.getelementptr inbounds %3[0, 0] : (!llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>>) -> !llvm.ptr<memref<?xi8, 4>>
 // CHECK-NEXT:    llvm.store %11, %12 : !llvm.ptr<memref<?xi8, 4>>
-// CHECK-NEXT:    %13 = llvm.getelementptr %3[0, 1] : (!llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>>) -> !llvm.ptr<i64>
+// CHECK-NEXT:    %13 = llvm.getelementptr inbounds %3[0, 1] : (!llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>>) -> !llvm.ptr<i64>
 // CHECK-NEXT:    llvm.store %c2_i64, %13 : !llvm.ptr<i64>
 // CHECK-NEXT:    %14 = llvm.load %3 : !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>>
 // CHECK-NEXT:    %15 = llvm.addrspacecast %6 : !llvm.ptr<struct<(vector<2xi8>)>> to !llvm.ptr<struct<(vector<2xi8>)>, 4>
@@ -83,7 +83,7 @@ SYCL_EXTERNAL structvec test_store(structvec sv, int idx, char el) {
 // CHECK-DAG:     %c0_i32 = arith.constant 0 : i32
 // CHECK-DAG:     %c0_i8 = arith.constant 0 : i8
 // CHECK-NEXT:    %0 = llvm.addrspacecast %arg1 : !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>> to !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>, 4>
-// CHECK-NEXT:    %1 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(vector<2xi8>)>, 4>) -> !llvm.ptr<vector<2xi8>, 4>
+// CHECK-NEXT:    %1 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(vector<2xi8>)>, 4>) -> !llvm.ptr<vector<2xi8>, 4>
 // CHECK-NEXT:    affine.for %arg2 = 0 to 2 {
 // CHECK-NEXT:      %2 = arith.index_cast %arg2 : index to i32
 // CHECK-NEXT:      %3 = func.call @_ZNKSt16initializer_listIcE5beginEv(%0) : (!llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>, 4>) -> memref<?xi8, 4>

--- a/polygeist/tools/cgeist/Test/Verification/threeInt.c
+++ b/polygeist/tools/cgeist/Test/Verification/threeInt.c
@@ -9,7 +9,7 @@ int struct_pass_all_same(threeInt* a) {
 }
 
 // CHECK:  func @struct_pass_all_same(%arg0: !llvm.ptr<struct<(i32, i32, i32)>>) -> i32
-// CHECK-NEXT:    %0 = llvm.getelementptr %arg0[0, 1] : (!llvm.ptr<struct<(i32, i32, i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:    %0 = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<struct<(i32, i32, i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:    %1 = llvm.load %0 : !llvm.ptr<i32>
 // CHECK-NEXT:    return %1 : i32
 // CHECK-NEXT:  }

--- a/polygeist/tools/cgeist/Test/Verification/tobits.c
+++ b/polygeist/tools/cgeist/Test/Verification/tobits.c
@@ -12,7 +12,7 @@ float fp32_from_bits(uint32_t w) {
 // CHECK:   func @fp32_from_bits(%arg0: i32) -> f32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-DAG:     %c1_i64 = arith.constant 1 : i64
 // CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(i32)> : (i64) -> !llvm.ptr<struct<(i32)>>
-// CHECK-NEXT:     %1 = llvm.getelementptr %0[0, 0] : (!llvm.ptr<struct<(i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<struct<(i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:     llvm.store %arg0, %1 : !llvm.ptr<i32>
 // CHECK-NEXT:     %2 = llvm.bitcast %1 : !llvm.ptr<i32> to !llvm.ptr<f32>
 // CHECK-NEXT:     %3 = llvm.load %2 : !llvm.ptr<f32>

--- a/polygeist/tools/cgeist/Test/Verification/unioncopy.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/unioncopy.cpp
@@ -31,21 +31,21 @@ void meta() {
 // CHECK-NEXT:     %3 = llvm.load %1 : !llvm.ptr<struct<(struct<(f64)>)>>
 // CHECK-NEXT:     llvm.store %3, %0 : !llvm.ptr<struct<(struct<(f64)>)>>
 // CHECK-NEXT:     %4 = call @_ZN8MyScalaraSEOS_(%2, %0) : (!llvm.ptr<struct<(struct<(f64)>)>>, !llvm.ptr<struct<(struct<(f64)>)>>) -> !llvm.ptr<struct<(struct<(f64)>)>>
-// CHECK-NEXT:     %5 = llvm.getelementptr %2[0, 0] : (!llvm.ptr<struct<(struct<(f64)>)>>) -> !llvm.ptr<struct<(f64)>>
-// CHECK-NEXT:     %6 = llvm.getelementptr %5[0, 0] : (!llvm.ptr<struct<(f64)>>) -> !llvm.ptr<f64>
+// CHECK-NEXT:     %5 = llvm.getelementptr inbounds %2[0, 0] : (!llvm.ptr<struct<(struct<(f64)>)>>) -> !llvm.ptr<struct<(f64)>>
+// CHECK-NEXT:     %6 = llvm.getelementptr inbounds %5[0, 0] : (!llvm.ptr<struct<(f64)>>) -> !llvm.ptr<f64>
 // CHECK-NEXT:     %7 = llvm.load %6 : !llvm.ptr<f64>
 // CHECK-NEXT:     call @_Z3used(%7) : (f64) -> ()
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK:   func @_ZN8MyScalarC1Ed(%arg0: !llvm.ptr<struct<(struct<(f64)>)>>, %arg1: f64) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(struct<(f64)>)>>) -> !llvm.ptr<struct<(f64)>>
-// CHECK-NEXT:     %1 = llvm.getelementptr %0[0, 0] : (!llvm.ptr<struct<(f64)>>) -> !llvm.ptr<f64>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(f64)>)>>) -> !llvm.ptr<struct<(f64)>>
+// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<struct<(f64)>>) -> !llvm.ptr<f64>
 // CHECK-NEXT:     llvm.store %arg1, %1 : !llvm.ptr<f64>
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK:   func @_ZN8MyScalaraSEOS_(%arg0: !llvm.ptr<struct<(struct<(f64)>)>>, %arg1: !llvm.ptr<struct<(struct<(f64)>)>>) -> !llvm.ptr<struct<(struct<(f64)>)>> attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(struct<(f64)>)>>) -> !llvm.ptr<struct<(f64)>>
-// CHECK-NEXT:     %1 = llvm.getelementptr %arg1[0, 0] : (!llvm.ptr<struct<(struct<(f64)>)>>) -> !llvm.ptr<struct<(f64)>>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(f64)>)>>) -> !llvm.ptr<struct<(f64)>>
+// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %arg1[0, 0] : (!llvm.ptr<struct<(struct<(f64)>)>>) -> !llvm.ptr<struct<(f64)>>
 // CHECK-NEXT:     %2 = call @_ZN1SaSEOS_(%0, %1) : (!llvm.ptr<struct<(f64)>>, !llvm.ptr<struct<(f64)>>) -> !llvm.ptr<struct<(f64)>>
 // CHECK-NEXT:     return %arg0 : !llvm.ptr<struct<(struct<(f64)>)>>
 // CHECK-NEXT:   }

--- a/polygeist/tools/cgeist/Test/Verification/virt.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/virt.cpp
@@ -39,11 +39,11 @@ void make() {
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK:   func @_ZN3SubC1Eid(%arg0: !llvm.ptr<struct<(struct<(i32)>, struct<(f32)>, f64)>>, %arg1: i32, %arg2: f64) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(struct<(i32)>, struct<(f32)>, f64)>>) -> !llvm.ptr<struct<(i32)>>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(i32)>, struct<(f32)>, f64)>>) -> !llvm.ptr<struct<(i32)>>
 // CHECK-NEXT:     call @_ZN4RootC1Ei(%0, %arg1) : (!llvm.ptr<struct<(i32)>>, i32) -> ()
-// CHECK-NEXT:     %1 = llvm.getelementptr %arg0[0, 1] : (!llvm.ptr<struct<(struct<(i32)>, struct<(f32)>, f64)>>) -> !llvm.ptr<struct<(f32)>>
+// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<struct<(struct<(i32)>, struct<(f32)>, f64)>>) -> !llvm.ptr<struct<(f32)>>
 // CHECK-NEXT:     call @_ZN5FRootC1Ev(%1) : (!llvm.ptr<struct<(f32)>>) -> ()
-// CHECK-NEXT:     %2 = llvm.getelementptr %arg0[0, 2] : (!llvm.ptr<struct<(struct<(i32)>, struct<(f32)>, f64)>>) -> !llvm.ptr<f64>
+// CHECK-NEXT:     %2 = llvm.getelementptr inbounds %arg0[0, 2] : (!llvm.ptr<struct<(struct<(i32)>, struct<(f32)>, f64)>>) -> !llvm.ptr<f64>
 // CHECK-NEXT:     llvm.store %arg2, %2 : !llvm.ptr<f64>
 // CHECK-NEXT:     %3 = llvm.mlir.addressof @str0 : !llvm.ptr<array<12 x i8>>
 // CHECK-NEXT:     %4 = "polygeist.pointer2memref"(%3) : (!llvm.ptr<array<12 x i8>>) -> memref<?xi8>
@@ -51,7 +51,7 @@ void make() {
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
 // CHECK:   func @_ZN4RootC1Ei(%arg0: !llvm.ptr<struct<(i32)>>, %arg1: i32) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(i32)>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(i32)>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:     llvm.store %arg1, %0 : !llvm.ptr<i32>
 // CHECK-NEXT:     %1 = llvm.mlir.addressof @str1 : !llvm.ptr<array<13 x i8>>
 // CHECK-NEXT:     %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<array<13 x i8>>) -> memref<?xi8>
@@ -60,7 +60,7 @@ void make() {
 // CHECK-NEXT:   }
 // CHECK:   func.func @_ZN5FRootC1Ev(%arg0: !llvm.ptr<struct<(f32)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
 // CHECK-DAG:      %cst = arith.constant 2.180000e+00 : f32
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(f32)>>) -> !llvm.ptr<f32>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(f32)>>) -> !llvm.ptr<f32>
 // CHECK-NEXT:     llvm.store %cst, %0 : !llvm.ptr<f32>
 // CHECK-NEXT:     %[[i1:.+]] = llvm.mlir.addressof @str2 : !llvm.ptr<array<14 x i8>>
 // CHECK-NEXT:     %[[i2:.+]] = "polygeist.pointer2memref"(%1) : (!llvm.ptr<array<14 x i8>>) -> memref<?xi8>

--- a/polygeist/tools/cgeist/Test/elaborated-init.cpp
+++ b/polygeist/tools/cgeist/Test/elaborated-init.cpp
@@ -11,10 +11,10 @@ void testArrayInitExpr()
 }
 
 // CHECK: func.func private @_ZZ17testArrayInitExprvEN3$_0C1EOS_(%arg0: !llvm.ptr<struct<(array<4 x i32>)>>, %arg1: !llvm.ptr<struct<(array<4 x i32>)>>) attributes {llvm.linkage = #llvm.linkage<internal>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 0] : (!llvm.ptr<struct<(array<4 x i32>)>>) -> !llvm.ptr<array<4 x i32>>
-// CHECK-NEXT:     %1 = llvm.getelementptr %0[0, 0] : (!llvm.ptr<array<4 x i32>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     %2 = llvm.getelementptr %arg1[0, 0] : (!llvm.ptr<struct<(array<4 x i32>)>>) -> !llvm.ptr<array<4 x i32>>
-// CHECK-NEXT:     %3 = llvm.getelementptr %2[0, 0] : (!llvm.ptr<array<4 x i32>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(array<4 x i32>)>>) -> !llvm.ptr<array<4 x i32>>
+// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<array<4 x i32>>) -> !llvm.ptr<i32>
+// CHECK-NEXT:     %2 = llvm.getelementptr inbounds %arg1[0, 0] : (!llvm.ptr<struct<(array<4 x i32>)>>) -> !llvm.ptr<array<4 x i32>>
+// CHECK-NEXT:     %3 = llvm.getelementptr inbounds %2[0, 0] : (!llvm.ptr<array<4 x i32>>) -> !llvm.ptr<i32>
 // CHECK-NEXT:     affine.for %arg2 = 0 to 4 {
 // CHECK-NEXT:       %4 = arith.index_cast %arg2 : index to i64
 // CHECK-NEXT:       %5 = llvm.getelementptr %1[%4] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>


### PR DESCRIPTION
Add the `inbounds` attribute to some of the `LLVM::GEPOp` generated by Polygeist during codegen, lowering or transformations. 

Signed-off-by: Lukas Sommer <lukas.sommer@codeplay.com>