### PR TITLE
[SYCL] Assume that xpti is in-tree if XPTI_SOURCE_DIR is not defined

### DIFF
--- a/xptifw/CMakeLists.txt
+++ b/xptifw/CMakeLists.txt
@@ -11,7 +11,7 @@ set(XPTIFW_DIR ${CMAKE_CURRENT_LIST_DIR})
 # the proxy implementation of XPTI
 if (NOT DEFINED XPTI_DIR) # don't overwrite if already set
   if (NOT DEFINED XPTI_SOURCE_DIR)
-    # If XPTI_SOURCE_DIR is no provided then assume that xpti is in-tree and not external.
+    # If XPTI_SOURCE_DIR is not provided then assume that xpti is in-tree and not external.
     set(XPTI_DIR ${CMAKE_CURRENT_LIST_DIR}/../xpti)
   else()
     set(XPTI_DIR ${XPTI_SOURCE_DIR}/../xpti)

--- a/xptifw/CMakeLists.txt
+++ b/xptifw/CMakeLists.txt
@@ -10,7 +10,12 @@ set(XPTIFW_DIR ${CMAKE_CURRENT_LIST_DIR})
 # The XPTI framework requires the includes from
 # the proxy implementation of XPTI
 if (NOT DEFINED XPTI_DIR) # don't overwrite if already set
-  set(XPTI_DIR ${XPTI_SOURCE_DIR}/../xpti)
+  if (NOT DEFINED XPTI_SOURCE_DIR)
+    # If XPTI_SOURCE_DIR is no provided then assume that xpti is in-tree and not external.
+    set(XPTI_DIR ${CMAKE_CURRENT_LIST_DIR}/../xpti)
+  else()
+    set(XPTI_DIR ${XPTI_SOURCE_DIR}/../xpti)
+  endif()
 endif()
 
 # Create a soft option for enabling the use of TBB


### PR DESCRIPTION
https://github.com/intel/llvm/pull/8436 allowed using external xpti to build xptiw by using defined XPTI_SOURCE_DIR.
This change breaks builds if xpti is in-tree and XPTI_SOURCE_DIR is not provided.
Use old behaviour (assume that xpti is in-tree) if XPTI_SOURCE_DIR is not defined.
