### PR TITLE
[SYCL] Don't run xpti tests on Windows

### DIFF
--- a/sycl/unittests/CMakeLists.txt
+++ b/sycl/unittests/CMakeLists.txt
@@ -50,4 +50,8 @@ add_subdirectory(context_device)
 add_subdirectory(accessor)
 add_subdirectory(handler)
 add_subdirectory(builtins)
-add_subdirectory(xpti_trace)
+# TODO Enable xpti tests for Windows
+if (NOT WIN32)
+  add_subdirectory(xpti_trace)
+endif()
+


### PR DESCRIPTION
xpti tests set environment variables pointing to .so files for xpti framework library. That's why tests fail on Windows now. For Windows paths to dll files must be set.

Disable tests on Windows for now.