### PR TITLE
[SYCL] Restore original CXX flags after unified runtime is built

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -12,7 +12,9 @@ if (NOT DEFINED UNIFIED_RUNTIME_LIBRARY OR NOT DEFINED UNIFIED_RUNTIME_INCLUDE_D
     GIT_TAG           ${UNIFIED_RUNTIME_TAG}
   )
 
-  # Disable some compilation options to avoid errors while building the UR
+  # Disable some compilation options to avoid errors while building the UR.
+  # And remember origin flags before doing that.
+  set(CMAKE_CXX_FLAGS_BAK "${CMAKE_CXX_FLAGS}")
   if (UNIX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-variable")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-pedantic")
@@ -23,6 +25,9 @@ if (NOT DEFINED UNIFIED_RUNTIME_LIBRARY OR NOT DEFINED UNIFIED_RUNTIME_INCLUDE_D
 
   FetchContent_GetProperties(unified-runtime)
   FetchContent_MakeAvailable(unified-runtime)
+
+  # Restore original flags
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_BAK}")
 
   add_library(${PROJECT_NAME}::ur_loader ALIAS loader)
 


### PR DESCRIPTION
We have to override CXX flags to build unified runtime because that build generates warnings and they turn into errors with werror.

But we have to restore original CXX flags after doing so. This is expected to build post-commit: it looks like currently we use gcc to build external projects like unified runtime and l0 loader. At the same time clang is used to build sycl runtime. Clang doesn't understand -Wno-stringop-truncation option which leads to an error in post commit.

Please notice that same approach is used in the L0 plugin: https://github.com/intel/llvm/blob/sycl/sycl/plugins/level_zero/CMakeLists.txt#L22-L41