### PR TITLE
[SYCL][NFC] Fix unused StreamName argument

### DIFF
--- a/sycl/unittests/xpti_trace/xptitest_subscriber/XPTISubscriber.cpp
+++ b/sycl/unittests/xpti_trace/xptitest_subscriber/XPTISubscriber.cpp
@@ -44,12 +44,12 @@ XPTI_CALLBACK_API void testCallback(uint16_t TraceType,
 XPTI_CALLBACK_API void xptiTraceInit(unsigned int /*major_version*/,
                                      unsigned int /*minor_version*/,
                                      const char * /*version_str*/,
-                                     const char *StreamName) {
+                                     const char * /*StreamName*/) {
   uint8_t StreamID = xptiRegisterStream("sycl");
   xptiRegisterCallback(StreamID, xpti::trace_diagnostics, testCallback);
 }
 
-XPTI_CALLBACK_API void xptiTraceFinish(const char *StreamName) {}
+XPTI_CALLBACK_API void xptiTraceFinish(const char * /*StreamName*/) {}
 
 XPTI_CALLBACK_API bool queryReceivedNotifications(uint16_t &TraceType,
                                                   std::string &Message) {


### PR DESCRIPTION
Logs: https://github.com/intel/llvm/actions/runs/4382801939/jobs/7672271805

```
/home/runner/work/llvm/llvm/src/sycl/unittests/xpti_trace/xptitest_subscriber/XPTISubscriber.cpp:47:50: error: unused parameter 'StreamName' [-Werror,-Wunused-parameter]
                                     const char *StreamName) {
                                                 ^
/home/runner/work/llvm/llvm/src/sycl/unittests/xpti_trace/xptitest_subscriber/XPTISubscriber.cpp:52:52: error: unused parameter 'StreamName' [-Werror,-Wunused-parameter]
XPTI_CALLBACK_API void xptiTraceFinish(const char *StreamName) {}
                                                   ^
```