### PR TITLE
[SYCL] Fix sycl::vec constructor ambiguity

### DIFF
--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -729,9 +729,6 @@ template <typename Type, int NumElements> class vec {
                 std::index_sequence<Is...>)
       : m_Data{Arr[Is]...} {}
 
-  constexpr vec(const std::array<vec_data_t<DataT>, NumElements> &Arr)
-      : vec{Arr, std::make_index_sequence<NumElements>()} {}
-
 public:
   using element_type = DataT;
   using rel_t = detail::rel_t<DataT>;
@@ -796,7 +793,8 @@ public:
   template <typename Ty = DataT>
   explicit constexpr vec(const EnableIfHostHalf<Ty> &arg)
       : vec{detail::RepeatValue<NumElements>(
-            static_cast<vec_data_t<DataT>>(arg))} {}
+                static_cast<vec_data_t<DataT>>(arg)),
+            std::make_index_sequence<NumElements>()} {}
 
   template <typename Ty = DataT>
   typename detail::enable_if_t<
@@ -812,7 +810,8 @@ public:
 #else
   explicit constexpr vec(const DataT &arg)
       : vec{detail::RepeatValue<NumElements>(
-            static_cast<vec_data_t<DataT>>(arg))} {}
+                static_cast<vec_data_t<DataT>>(arg)),
+            std::make_index_sequence<NumElements>()} {}
 
   template <typename Ty = DataT>
   typename detail::enable_if_t<
@@ -883,7 +882,8 @@ public:
   template <typename... argTN, typename = EnableIfSuitableTypes<argTN...>,
             typename = EnableIfSuitableNumElements<argTN...>>
   constexpr vec(const argTN &...args)
-      : vec{VecArgArrayCreator<vec_data_t<DataT>, argTN...>::Create(args...)} {}
+      : vec{VecArgArrayCreator<vec_data_t<DataT>, argTN...>::Create(args...),
+            std::make_index_sequence<NumElements>()} {}
 
   // TODO: Remove, for debug purposes only.
   void dump() {

--- a/sycl/test/regression/vec_init_list_ctor.cpp
+++ b/sycl/test/regression/vec_init_list_ctor.cpp
@@ -1,0 +1,12 @@
+// RUN: %clang -fsycl -O0 -fsyntax-only -Xclang -verify %s
+// expected-no-diagnostics
+
+// Regression test checking that the vector ctor taking an initializer list
+// doesn't cause warnings or errors.
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  sycl::vec<int, 2> V({1, 2});
+  return 0;
+}


### PR DESCRIPTION
Recent changes to the sycl::vec class added a private constructor taking and array. This resulted in constructor ambiguity when passing an initializer list, despite the constructor being private. This commit removes the constructor, making the implementation use the constructor taking both an array and an index sequence directly.