### PR TITLE
[SYCL][XPTI] Make code location stable for prefetch and fill methods

### DIFF
--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -481,7 +481,10 @@ public:
   /// \param Count is the number of times to fill Pattern into Ptr.
   /// \return an event representing fill operation.
   template <typename T> event fill(void *Ptr, const T &Pattern, size_t Count) {
-    return submit([&](handler &CGH) { CGH.fill<T>(Ptr, Pattern, Count); });
+    // TODO: to add code location as parameter when ABI break is permitted
+    const detail::code_location CodeLoc("sycl/queue.hpp", "fill", 0, 0);
+    return submit([&](handler &CGH) { CGH.fill<T>(Ptr, Pattern, Count); },
+                  CodeLoc);
   }
 
   /// Fills the specified memory with the specified pattern.
@@ -708,7 +711,9 @@ public:
   /// \param Count is a number of bytes to be prefetched.
   /// \return an event representing prefetch operation.
   event prefetch(const void *Ptr, size_t Count) {
-    return submit([=](handler &CGH) { CGH.prefetch(Ptr, Count); });
+    // TODO: to add code location as parameter when ABI break is permitted
+    const detail::code_location CodeLoc("sycl/queue.hpp", "prefetch", 0, 0);
+    return submit([=](handler &CGH) { CGH.prefetch(Ptr, Count); }, CodeLoc);
   }
 
   /// Provides hints to the runtime library that data should be made available

--- a/sycl/unittests/xpti_trace/QueueApiFailures.cpp
+++ b/sycl/unittests/xpti_trace/QueueApiFailures.cpp
@@ -268,7 +268,7 @@ TEST_F(QueueApiFailures, QueueFill) {
   std::string Message;
   ASSERT_TRUE(queryReceivedNotifications(TraceType, Message));
   EXPECT_EQ(TraceType, xpti::trace_diagnostics);
-  EXPECT_THAT(Message, HasSubstr(UnknownCodeLocation));
+  EXPECT_THAT(Message, HasSubstr("fill;sycl/queue.hpp"));
   EXPECT_FALSE(queryReceivedNotifications(TraceType, Message));
 }
 
@@ -302,7 +302,7 @@ TEST_F(QueueApiFailures, QueuePrefetch) {
   std::string Message;
   ASSERT_TRUE(queryReceivedNotifications(TraceType, Message));
   EXPECT_EQ(TraceType, xpti::trace_diagnostics);
-  EXPECT_THAT(Message, HasSubstr(UnknownCodeLocation));
+  EXPECT_THAT(Message, HasSubstr("prefetch;sycl/queue.hpp"));
   EXPECT_FALSE(queryReceivedNotifications(TraceType, Message));
 }
 


### PR DESCRIPTION
clang has functionality to provide valid code location while gcc - not.
fill and prefetch methods has no API to set code location directly but call submit that has such parameter that causes difference in behavior with gcc and clang compilation.
This commit has an intention to make this code location to have stable value. 