### PR TITLE
[SYCL] Implement native_specialization_constant()

### DIFF
--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -110,8 +110,19 @@ public:
   }
 
   bool all_specialization_constant_native() const noexcept {
-    assert(false && "Not implemented");
-    return false;
+    // Specialization constants are natively supported in JIT mode on backends,
+    // that are using SPIR-V as IR
+    auto IsAOTBinary = [](const char *Format) {
+      return (
+          (strcmp(Format, __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64_X86_64) ==
+           0) ||
+          (strcmp(Format, __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64_GEN) == 0) ||
+          (strcmp(Format, __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64_FPGA) == 0));
+    };
+
+    return !IsAOTBinary(MBinImage->getRawData().DeviceTargetSpec) &&
+           (MContext.get_backend() == backend::opencl ||
+            MContext.get_backend() == backend::ext_oneapi_level_zero);
   }
 
   bool has_specialization_constant(const char *SpecName) const noexcept {


### PR DESCRIPTION
native_specialization_constant() returns true only in JIT mode on opencl & level-zero backends (because only SPIR-V supports them)