### PR TITLE
[SYCL] Fix forward declarations to SubgroupShuffleUp/Down overloads

### DIFF
--- a/sycl/include/sycl/detail/spirv.hpp
+++ b/sycl/include/sycl/detail/spirv.hpp
@@ -596,22 +596,16 @@ template <typename T>
 EnableIfBitcastShuffle<T> SubgroupShuffleXor(T x, id<1> local_id);
 
 template <typename T>
-EnableIfBitcastShuffle<T> SubgroupShuffleDown(T x, id<1> local_id);
-
-template <typename T>
-EnableIfBitcastShuffle<T> SubgroupShuffleUp(T x, id<1> local_id);
-
-template <typename T>
 EnableIfGenericShuffle<T> SubgroupShuffle(T x, id<1> local_id);
 
 template <typename T>
 EnableIfGenericShuffle<T> SubgroupShuffleXor(T x, id<1> local_id);
 
 template <typename T>
-EnableIfGenericShuffle<T> SubgroupShuffleDown(T x, id<1> local_id);
+EnableIfGenericShuffle<T> SubgroupShuffleDown(T x, uint32_t delta);
 
 template <typename T>
-EnableIfGenericShuffle<T> SubgroupShuffleUp(T x, id<1> local_id);
+EnableIfGenericShuffle<T> SubgroupShuffleUp(T x, uint32_t delta);
 
 template <typename T>
 EnableIfNativeShuffle<T> SubgroupShuffle(T x, id<1> local_id) {


### PR DESCRIPTION
This PR fixes up the template overload function forward declarations for (Generic) `SubroupShuffleDown` and `SubroupShuffleUp` to use the `uint32_t delta` parameter instead of `id<1> local_id`. Also removed two unnecessary forward declarations  `EnableIfBitcastShuffle SubroupShuffleUp/Down` with `id<1> local_id`.

These forward declarations are needed because the `EnableIfVector` imlpementations call these functions but their bodies are defined after vector versions, so the compiler can't identify them.

Without this fix users will get `SYCL kernel cannot call an undefined function without SYCL_EXTERNAL attribute ...` compile errors. That error also manifested in issue [#8516](https://github.com/intel/llvm/issues/8516), which will be fixed with the changes of the PR.

Side note: This also fixes compiling the `group_broadcast` tests for the `test_group_functions` target in the SYCL-CTS.