### PR TITLE
[SYCL][sycl-post-link][LIT] Use redirection instead of direct filenames

### DIFF
--- a/llvm/test/tools/sycl-post-link/assert/indirect-with-split-2.ll
+++ b/llvm/test/tools/sycl-post-link/assert/indirect-with-split-2.ll
@@ -8,7 +8,7 @@
 ; __devicelib_assert_fail, then all kernels in the module are conservatively
 ; marked as using asserts.
 
-; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=auto -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.prop -check-prefix=PRESENCE-CHECK
 ; RUN: FileCheck %s -input-file=%t_0.prop -check-prefix=ABSENCE-CHECK
 

--- a/llvm/test/tools/sycl-post-link/assert/indirect-with-split.ll
+++ b/llvm/test/tools/sycl-post-link/assert/indirect-with-split.ll
@@ -6,7 +6,7 @@
 ; __devicelib_assert_fail, then all kernels in the module are conservatively
 ; marked as using asserts.
 
-; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=auto -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.prop
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/llvm/test/tools/sycl-post-link/assert/property-1.ll
+++ b/llvm/test/tools/sycl-post-link/assert/property-1.ll
@@ -2,16 +2,16 @@
 ; property - it should include only kernels that call assertions in their call
 ; graph.
 
-; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=auto -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.prop --implicit-check-not TheKernel2
 ;
-; RUN: sycl-post-link -split=source -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=source -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.prop --implicit-check-not TheKernel2
 ;
-; RUN: sycl-post-link -symbols -S %s -o %t.table
+; RUN: sycl-post-link -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.prop --implicit-check-not TheKernel2
 ;
-; RUN: sycl-post-link -split=kernel -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=kernel -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.prop --check-prefixes=CHECK-K1
 ; RUN: FileCheck %s -input-file=%t_1.prop --check-prefixes=CHECK-K2
 ; RUN: FileCheck %s -input-file=%t_2.prop --check-prefixes=CHECK-K3

--- a/llvm/test/tools/sycl-post-link/assert/property-2.ll
+++ b/llvm/test/tools/sycl-post-link/assert/property-2.ll
@@ -2,7 +2,7 @@
 ; property - it should include only kernels that call assertions in their call
 ; graph.
 
-; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=auto -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.prop -check-prefix=PRESENCE-CHECK
 ; RUN: FileCheck %s -input-file=%t_0.prop -check-prefix=ABSENCE-CHECK
 

--- a/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-1.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-1.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=auto -symbols -S < %s -o %t.table
 ; By default auto mode is equal to source mode
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-TU0,CHECK
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefixes CHECK-TU1,CHECK

--- a/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-2.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-2.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=auto -symbols -S < %s -o %t.table
 ; In precense of indirectly callable function auto mode is equal to no split,
 ; which means that separate LLVM IR file for device is not generated and we only
 ; need to check generated symbol table

--- a/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-3.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-3.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=auto -symbols -S < %s -o %t.table
 ; In precense of indirect calls auto mode is equal to no split,
 ; which means that separate LLVM IR file for device is not generated and we only
 ; need to check generated symbol table

--- a/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-func-ptr.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-func-ptr.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=auto -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.sym
 
 ; This test checkes that module is not split if function pointer's user is not

--- a/llvm/test/tools/sycl-post-link/device-code-split/basic-module-split.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/basic-module-split.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -split=source -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=source -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-TU0,CHECK
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefixes CHECK-TU1,CHECK
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefixes CHECK-TU0-TXT

--- a/llvm/test/tools/sycl-post-link/device-code-split/one-kernel-per-module.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/one-kernel-per-module.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -split=kernel -symbols -S %s -o %t.files.table
+; RUN: sycl-post-link -split=kernel -symbols -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll --check-prefixes CHECK-MODULE0,CHECK
 ; RUN: FileCheck %s -input-file=%t.files_0.sym --check-prefixes CHECK-MODULE0-TXT
 ; RUN: FileCheck %s -input-file=%t.files_1.ll --check-prefixes CHECK-MODULE1,CHECK

--- a/llvm/test/tools/sycl-post-link/device-code-split/per-aspect-split-1.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/per-aspect-split-1.ll
@@ -7,7 +7,7 @@
 ; that use aspects from kernels which doesn't use aspects regardless of device
 ; code split mode
 
-; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=auto -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-M0-IR \
 ; RUN: --implicit-check-not kernel0 --implicit-check-not kernel1
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefixes CHECK-M1-IR \
@@ -21,7 +21,7 @@
 ; RUN: FileCheck %s -input-file=%t_2.sym --check-prefixes CHECK-M2-SYMS \
 ; RUN: --implicit-check-not kernel0 --implicit-check-not kernel1
 
-; RUN: sycl-post-link -split=source -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=source -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-M0-IR \
 ; RUN: --implicit-check-not kernel0 --implicit-check-not kernel1
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefixes CHECK-M1-IR \
@@ -35,7 +35,7 @@
 ; RUN: FileCheck %s -input-file=%t_2.sym --check-prefixes CHECK-M2-SYMS \
 ; RUN: --implicit-check-not kernel0 --implicit-check-not kernel1
 
-; RUN: sycl-post-link -split=kernel -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=kernel -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-M0-IR \
 ; RUN: --implicit-check-not kernel0 --implicit-check-not kernel1
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefixes CHECK-M1-IR \

--- a/llvm/test/tools/sycl-post-link/device-code-split/per-aspect-split-2.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/per-aspect-split-2.ll
@@ -1,7 +1,7 @@
 ; The test is intended to check that sycl-post-link correctly groups kernels
 ; by unique sets of aspects used in them
 
-; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=auto -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t.table --check-prefix CHECK-TABLE
 ;
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefix CHECK-M0-SYMS \

--- a/llvm/test/tools/sycl-post-link/device-code-split/per-aspect-split-3.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/per-aspect-split-3.ll
@@ -1,7 +1,7 @@
 ; This test is intended to check that per-aspect device code split works as
 ; expected with SYCL_EXTERNAL functions
 
-; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=auto -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t.table --check-prefix CHECK-TABLE
 ;
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefix CHECK-M0-SYMS \

--- a/llvm/test/tools/sycl-post-link/device-code-split/per-aspect-split-4.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/per-aspect-split-4.ll
@@ -1,13 +1,13 @@
 ; This test is intended to check that we do not perform per-aspect split if
 ; it was disabled through one or another sycl-post-link option
 
-; RUN: sycl-post-link -symbols -S %s -o %t.table
+; RUN: sycl-post-link -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t.table --check-prefix CHECK-TABLE
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefix CHECK-IR
 ;
 ; -lower-esimd is needed so sycl-post-link does not complain about no actions
 ; specified
-; RUN: sycl-post-link -lower-esimd -ir-output-only -S %s -o %t.ll
+; RUN: sycl-post-link -lower-esimd -ir-output-only -S < %s -o %t.ll
 ; RUN: FileCheck %s -input-file=%t.ll --check-prefix CHECK-IR
 
 ; We expect to see only one module generated:

--- a/llvm/test/tools/sycl-post-link/device-code-split/per-reqd-wg-size-split-1.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/per-reqd-wg-size-split-1.ll
@@ -7,7 +7,7 @@
 ; that use reqd_work_group_size attributes from kernels which doesn't use them
 ; regardless of device code split mode
 
-; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=auto -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-M0-IR \
 ; RUN: --implicit-check-not kernel0 --implicit-check-not kernel1
 ; RUN: FileCheck %s -input-file=%t_2.ll --check-prefixes CHECK-M1-IR \
@@ -21,7 +21,7 @@
 ; RUN: FileCheck %s -input-file=%t_1.sym --check-prefixes CHECK-M2-SYMS \
 ; RUN: --implicit-check-not kernel1 --implicit-check-not kernel2
 
-; RUN: sycl-post-link -split=source -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=source -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-M0-IR \
 ; RUN: --implicit-check-not kernel0 --implicit-check-not kernel1
 ; RUN: FileCheck %s -input-file=%t_2.ll --check-prefixes CHECK-M1-IR \
@@ -35,7 +35,7 @@
 ; RUN: FileCheck %s -input-file=%t_1.sym --check-prefixes CHECK-M2-SYMS \
 ; RUN: --implicit-check-not kernel1 --implicit-check-not kernel2
 
-; RUN: sycl-post-link -split=kernel -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=kernel -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-M0-IR \
 ; RUN: --implicit-check-not kernel0 --implicit-check-not kernel1
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefixes CHECK-M1-IR \

--- a/llvm/test/tools/sycl-post-link/device-code-split/per-reqd-wg-size-split-2.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/per-reqd-wg-size-split-2.ll
@@ -1,7 +1,7 @@
 ; The test is intended to check that sycl-post-link correctly groups kernels
 ; by unique reqd_work_group_size values used in them
 
-; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=auto -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t.table --check-prefix CHECK-TABLE
 ;
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefix CHECK-M0-SYMS \

--- a/llvm/test/tools/sycl-post-link/device-code-split/per-reqd-wg-size-split-3.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/per-reqd-wg-size-split-3.ll
@@ -1,13 +1,13 @@
 ; This test is intended to check that we do not perform per-reqd_work_group_size
 ; split if it was disabled through one or another sycl-post-link option
 
-; RUN: sycl-post-link -symbols -S %s -o %t.table
+; RUN: sycl-post-link -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t.table --check-prefix CHECK-TABLE
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefix CHECK-IR
 ;
 ; -lower-esimd is needed so sycl-post-link does not complain about no actions
 ; specified
-; RUN: sycl-post-link -lower-esimd -ir-output-only -S %s -o %t.ll
+; RUN: sycl-post-link -lower-esimd -ir-output-only -S < %s -o %t.ll
 ; RUN: FileCheck %s -input-file=%t.ll --check-prefix CHECK-IR
 
 ; We expect to see only one module generated:

--- a/llvm/test/tools/sycl-post-link/device-code-split/split-with-func-ptrs.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/split-with-func-ptrs.ll
@@ -3,14 +3,14 @@
 ; modules.
 
 ; -- Per-source split
-; RUN: sycl-post-link -split=source -emit-param-info -symbols -emit-exported-symbols -split-esimd -lower-esimd -O2 -spec-const=rt -S %s -o %tA.table
+; RUN: sycl-post-link -split=source -emit-param-info -symbols -emit-exported-symbols -split-esimd -lower-esimd -O2 -spec-const=rt -S < %s -o %tA.table
 ; RUN: FileCheck %s -input-file=%tA_0.ll --check-prefixes CHECK-A0
 ; RUN: FileCheck %s -input-file=%tA_1.ll --check-prefixes CHECK-A1
 ; -- No split
-; RUN: sycl-post-link -emit-param-info -symbols -emit-exported-symbols -split-esimd -lower-esimd -O2 -spec-const=rt -S %s -o %tB.table
+; RUN: sycl-post-link -emit-param-info -symbols -emit-exported-symbols -split-esimd -lower-esimd -O2 -spec-const=rt -S < %s -o %tB.table
 ; RUN: FileCheck %s -input-file=%tB_0.ll --check-prefixes CHECK-B0
 ; -- Per-kernel split
-; RUN: sycl-post-link -split=kernel -emit-param-info -symbols -emit-exported-symbols -split-esimd -lower-esimd -O2 -spec-const=rt -S %s -o %tC.table
+; RUN: sycl-post-link -split=kernel -emit-param-info -symbols -emit-exported-symbols -split-esimd -lower-esimd -O2 -spec-const=rt -S < %s -o %tC.table
 ; RUN: FileCheck %s -input-file=%tC_0.ll --check-prefixes CHECK-C0
 ; RUN: FileCheck %s -input-file=%tC_1.ll --check-prefixes CHECK-C1
 

--- a/llvm/test/tools/sycl-post-link/device-code-split/split-with-kernel-declarations.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/split-with-kernel-declarations.ll
@@ -1,12 +1,12 @@
 ; Purpose of this test is to check that sycl-post-link does not treat
 ; declarations as entry points.
 
-; RUN: sycl-post-link -split=source -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=source -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t.table --check-prefix CHECK-PER-SOURCE-TABLE
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefix CHECK-PER-SOURCE-SYM0
 ; RUN: FileCheck %s -input-file=%t_1.sym --check-prefix CHECK-PER-SOURCE-SYM1
 ;
-; RUN: sycl-post-link -split=kernel -symbols -S %s -o %t1.table
+; RUN: sycl-post-link -split=kernel -symbols -S < %s -o %t1.table
 ; RUN: FileCheck %s -input-file=%t1.table --check-prefix CHECK-PER-KERNEL-TABLE
 ; RUN: FileCheck %s -input-file=%t1_0.sym --check-prefix CHECK-PER-KERNEL-SYM0
 ; RUN: FileCheck %s -input-file=%t1_1.sym --check-prefix CHECK-PER-KERNEL-SYM1

--- a/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_global_variable.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link --device-globals -S %s -o %t.files.table
+; RUN: sycl-post-link --device-globals -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefix CHECK-PROP
 source_filename = "test_global_variable.cpp"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"

--- a/llvm/test/tools/sycl-post-link/device-globals/test_global_variable_many_kernels_in_one_module.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_global_variable_many_kernels_in_one_module.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link --device-globals --split=source -S %s -o %t.files.table
+; RUN: sycl-post-link --device-globals --split=source -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll --check-prefix CHECK-MOD0
 ; RUN: FileCheck %s -input-file=%t.files_1.ll --check-prefix CHECK-MOD1
 

--- a/llvm/test/tools/sycl-post-link/device-globals/test_global_variable_many_modules_no_dev_global.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_global_variable_many_modules_no_dev_global.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link --device-globals --split=source -S %s -o %t.files.table
+; RUN: sycl-post-link --device-globals --split=source -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll --check-prefix CHECK-MOD0
 ; RUN: FileCheck %s -input-file=%t.files_1.ll --check-prefix CHECK-MOD1
 ; RUN: FileCheck %s -input-file=%t.files_2.ll --check-prefix CHECK-MOD2

--- a/llvm/test/tools/sycl-post-link/device-globals/test_global_variable_many_modules_no_dev_img_scope.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_global_variable_many_modules_no_dev_img_scope.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link --device-globals --split=source -S %s -o %t.files.table
+; RUN: sycl-post-link --device-globals --split=source -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll --check-prefix CHECK-MOD0
 ; RUN: FileCheck %s -input-file=%t.files_1.ll --check-prefix CHECK-MOD1
 ; RUN: FileCheck %s -input-file=%t.files_2.ll --check-prefix CHECK-MOD2

--- a/llvm/test/tools/sycl-post-link/device-globals/test_global_variable_many_modules_two_vars_ok.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_global_variable_many_modules_two_vars_ok.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link --device-globals --split=source -S %s -o %t.files.table
+; RUN: sycl-post-link --device-globals --split=source -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll --check-prefix CHECK-MOD0
 ; RUN: FileCheck %s -input-file=%t.files_1.ll --check-prefix CHECK-MOD1
 

--- a/llvm/test/tools/sycl-post-link/device-globals/test_global_variable_name_mapping_metadata.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_global_variable_name_mapping_metadata.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link --device-globals --emit-program-metadata -S %s -o %t.files.table
+; RUN: sycl-post-link --device-globals --emit-program-metadata -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefix CHECK-PROP
 
 ; This test is intended to check that the global_id_mapping program metadata properties are

--- a/llvm/test/tools/sycl-post-link/device-globals/test_no_property_set_header_for_an_empty_set.ll
+++ b/llvm/test/tools/sycl-post-link/device-globals/test_no_property_set_header_for_an_empty_set.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link --device-globals -S %s -o %t.files.table
+; RUN: sycl-post-link --device-globals -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefix CHECK-PROP
 
 ; This test is intended to check that sycl-post-link doesn't add the header for

--- a/llvm/test/tools/sycl-post-link/device-requirements/aspects.ll
+++ b/llvm/test/tools/sycl-post-link/device-requirements/aspects.ll
@@ -13,10 +13,10 @@
 ;   });
 ; }
 
-; RUN: sycl-post-link -split=auto %s -o %t.files.table
+; RUN: sycl-post-link -split=auto < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefix CHECK-PROP-AUTO-SPLIT
 
-; RUN: sycl-post-link -split=kernel %s -o %t.files.table
+; RUN: sycl-post-link -split=kernel < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefix CHECK-PROP-KERNEL-SPLIT-0
 ; RUN: FileCheck %s -input-file=%t.files_1.prop --check-prefix CHECK-PROP-KERNEL-SPLIT-1
 

--- a/llvm/test/tools/sycl-post-link/device-requirements/fixed-target.ll
+++ b/llvm/test/tools/sycl-post-link/device-requirements/fixed-target.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -split=auto %s -o %t.files.table
+; RUN: sycl-post-link -split=auto < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.prop
 
 ; CHECK: [SYCL/device requirements]

--- a/llvm/test/tools/sycl-post-link/device-requirements/reqd-work-group-size.ll
+++ b/llvm/test/tools/sycl-post-link/device-requirements/reqd-work-group-size.ll
@@ -21,7 +21,7 @@
 ;   return 0;
 ; }
 
-; RUN: sycl-post-link -split=auto %s -o %t.table
+; RUN: sycl-post-link -split=auto < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.prop --check-prefix CHECK-PROP-AUTO-SPLIT-0
 ; RUN: FileCheck %s -input-file=%t_1.prop --check-prefix CHECK-PROP-AUTO-SPLIT-1
 

--- a/llvm/test/tools/sycl-post-link/emit_exported_symbols.ll
+++ b/llvm/test/tools/sycl-post-link/emit_exported_symbols.ll
@@ -1,17 +1,17 @@
 ; This test checks that the post-link tool generates list of exported symbols.
 ;
 ; Global scope
-; RUN: sycl-post-link -symbols -emit-exported-symbols -S %s -o %t.global.files.table
+; RUN: sycl-post-link -symbols -emit-exported-symbols -S < %s -o %t.global.files.table
 ; RUN: FileCheck %s -input-file=%t.global.files_0.prop --implicit-check-not="NotExported" --check-prefix=CHECK-GLOBAL-PROP
 ;
 ; Per-module split
-; RUN: sycl-post-link -symbols -split=source -emit-exported-symbols -S %s -o %t.per_module.files.table
+; RUN: sycl-post-link -symbols -split=source -emit-exported-symbols -S < %s -o %t.per_module.files.table
 ; RUN: FileCheck %s -input-file=%t.per_module.files_0.prop -implicit-check-not="NotExported" --check-prefix=CHECK-PERMODULE-0-PROP
 ; RUN: FileCheck %s -input-file=%t.per_module.files_1.prop -implicit-check-not="NotExported" --check-prefix=CHECK-KERNELONLY-PROP
 ; RUN: FileCheck %s -input-file=%t.per_module.files_2.prop -implicit-check-not="NotExported" --check-prefix=CHECK-PERMODULE-2-PROP
 ;
 ; Per-kernel split
-; RUN: sycl-post-link -symbols -split=kernel -emit-exported-symbols -S %s -o %t.per_kernel.files.table
+; RUN: sycl-post-link -symbols -split=kernel -emit-exported-symbols -S < %s -o %t.per_kernel.files.table
 ; RUN: FileCheck %s -input-file=%t.per_kernel.files_0.prop --implicit-check-not="NotExported" --check-prefix=CHECK-PERKERNEL-0-PROP
 ; RUN: FileCheck %s -input-file=%t.per_kernel.files_1.prop --implicit-check-not="NotExported" --check-prefix=CHECK-PERKERNEL-1-PROP
 ; RUN: FileCheck %s -input-file=%t.per_kernel.files_2.prop --implicit-check-not="NotExported" --check-prefix=CHECK-PERKERNEL-2-PROP

--- a/llvm/test/tools/sycl-post-link/emit_program_metadata.ll
+++ b/llvm/test/tools/sycl-post-link/emit_program_metadata.ll
@@ -1,6 +1,6 @@
 ; This test checks that the post-link tool generates SYCL program metadata.
 ;
-; RUN: sycl-post-link -emit-program-metadata -device-globals -S %s -o %t.files.table
+; RUN: sycl-post-link -emit-program-metadata -device-globals -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files.table --check-prefixes CHECK-TABLE
 ; RUN: FileCheck %s -input-file=%t.files_0.prop --match-full-lines --check-prefixes CHECK-PROP
 

--- a/llvm/test/tools/sycl-post-link/erase_used.ll
+++ b/llvm/test/tools/sycl-post-link/erase_used.ll
@@ -2,14 +2,14 @@
 ; the output modules when splitting modules, creating a single row table,
 ; and outputing IR only
 ;
-; RUN: sycl-post-link -split=kernel -S %s -o %t.files.table
+; RUN: sycl-post-link -split=kernel -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll
 ; RUN: FileCheck %s -input-file=%t.files_1.ll
 ;
-; RUN: sycl-post-link -S -split=auto -symbols -split-esimd -lower-esimd -O2 -spec-const=default %s -o %t.out.table
+; RUN: sycl-post-link -S -split=auto -symbols -split-esimd -lower-esimd -O2 -spec-const=default < %s -o %t.out.table
 ; RUN: FileCheck %s --input-file=%t.out_0.ll
 ;
-; RUN: sycl-post-link -S -split=auto -ir-output-only %s -o %t.out_ir_only.ll
+; RUN: sycl-post-link -S -split=auto -ir-output-only < %s -o %t.out_ir_only.ll
 ; RUN: FileCheck %s --input-file %t.out_ir_only.ll
 
 target triple = "spir64-unknown-unknown"

--- a/llvm/test/tools/sycl-post-link/erase_used_decl.ll
+++ b/llvm/test/tools/sycl-post-link/erase_used_decl.ll
@@ -1,7 +1,7 @@
 ; This test checks that the post-link tool doesn't incorrectly remove function
 ; declarations which are still in use while erasing the "llvm.used" global.
 ;
-; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.files.table
+; RUN: sycl-post-link -split=auto -symbols -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll
 ;
 target triple = "spir64-unknown-unknown"

--- a/llvm/test/tools/sycl-post-link/erase_used_decl_opaque.ll
+++ b/llvm/test/tools/sycl-post-link/erase_used_decl_opaque.ll
@@ -1,7 +1,7 @@
 ; This test checks that the post-link tool doesn't incorrectly remove function
 ; declarations which are still in use while erasing the "llvm.used" global.
 ;
-; RUN: sycl-post-link -split=auto -symbols -S %s -o %t.files.table
+; RUN: sycl-post-link -split=auto -symbols -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll
 ;
 target triple = "spir64-unknown-unknown"

--- a/llvm/test/tools/sycl-post-link/erase_used_opaque.ll
+++ b/llvm/test/tools/sycl-post-link/erase_used_opaque.ll
@@ -2,14 +2,14 @@
 ; the output modules when splitting modules, creating a single row table,
 ; and outputing IR only
 ;
-; RUN: sycl-post-link -split=kernel -S %s -o %t.files.table
+; RUN: sycl-post-link -split=kernel -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll
 ; RUN: FileCheck %s -input-file=%t.files_1.ll
 ;
-; RUN: sycl-post-link -S -split=auto -symbols -split-esimd -lower-esimd -O2 -spec-const=default %s -o %t.out.table
+; RUN: sycl-post-link -S -split=auto -symbols -split-esimd -lower-esimd -O2 -spec-const=default < %s -o %t.out.table
 ; RUN: FileCheck %s --input-file=%t.out_0.ll
 ;
-; RUN: sycl-post-link -S -split=auto -ir-output-only %s -o %t.out_ir_only.ll
+; RUN: sycl-post-link -S -split=auto -ir-output-only < %s -o %t.out_ir_only.ll
 ; RUN: FileCheck %s --input-file %t.out_ir_only.ll
 
 target triple = "spir64-unknown-unknown"

--- a/llvm/test/tools/sycl-post-link/ir-output-only.ll
+++ b/llvm/test/tools/sycl-post-link/ir-output-only.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link --ir-output-only -split=auto -S %s -o %t.ll
+; RUN: sycl-post-link --ir-output-only -split=auto -S < %s -o %t.ll
 ; RUN: FileCheck %s -input-file=%t.ll
 
 ; This test checks that the --ir-output-only option writes a LLVM IR

--- a/llvm/test/tools/sycl-post-link/no-args-to-eliminate.ll
+++ b/llvm/test/tools/sycl-post-link/no-args-to-eliminate.ll
@@ -1,7 +1,7 @@
 ; This test ensures that sycl-post-link doesn't crash when kernel parameter
 ; optimization info metadata is empty
 ;
-; RUN: sycl-post-link -emit-param-info -S %s -o %t.files.table
+; RUN: sycl-post-link -emit-param-info -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.prop
 ;
 ; CHECK: [SYCL/kernel param opt]

--- a/llvm/test/tools/sycl-post-link/omit_kernel_args.ll
+++ b/llvm/test/tools/sycl-post-link/omit_kernel_args.ll
@@ -2,7 +2,7 @@
 ; optimization info into a property file if the source IR contained
 ; corresponding metadata.
 ;
-; RUN: sycl-post-link -emit-param-info -S %s -o %t.files.table
+; RUN: sycl-post-link -emit-param-info -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files.table --check-prefixes CHECK-TABLE
 ; RUN: FileCheck %s -input-file=%t.files_0.prop --match-full-lines --check-prefixes CHECK-PROP
 

--- a/llvm/test/tools/sycl-post-link/spec-constants/DeprecatedFeautres/composite-O0.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/DeprecatedFeautres/composite-O0.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -spec-const=rt --ir-output-only %s -S -o - \
+; RUN: sycl-post-link -spec-const=rt --ir-output-only < %s -S -o - \
 ; RUN: | FileCheck %s --implicit-check-not "call {{.*}} __sycl_getCompositeSpecConstantValue"
 ;
 ; This test is intended to check that sycl-post-link tool is capable of handling

--- a/llvm/test/tools/sycl-post-link/spec-constants/DeprecatedFeautres/multiple-composite-usages-2.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/DeprecatedFeautres/multiple-composite-usages-2.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -spec-const=rt --ir-output-only %s -S -o - \
+; RUN: sycl-post-link -spec-const=rt --ir-output-only < %s -S -o - \
 ; RUN: | FileCheck %s --implicit-check-not "call {{.*}} __sycl_getCompositeSpecConstantValue"
 ;
 ; This test is intended to check that sycl-post-link tool is capable of handling

--- a/llvm/test/tools/sycl-post-link/spec-constants/DeprecatedFeautres/multiple-composite-usages.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/DeprecatedFeautres/multiple-composite-usages.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -spec-const=rt --ir-output-only %s -S -o - \
+; RUN: sycl-post-link -spec-const=rt --ir-output-only < %s -S -o - \
 ; RUN: | FileCheck %s --implicit-check-not "call {{.*}} __sycl_getCompositeSpecConstantValue"
 ;
 ; This test is intended to check that sycl-post-link tool is capable of handling

--- a/llvm/test/tools/sycl-post-link/spec-constants/DeprecatedFeautres/multiple-scalar-usages.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/DeprecatedFeautres/multiple-scalar-usages.ll
@@ -2,7 +2,7 @@
 ; spec constant is accessed twice, then metadata for both accesses should point
 ; to the same ID
 
-; RUN: sycl-post-link -spec-const=rt --ir-output-only %s -S -o - \
+; RUN: sycl-post-link -spec-const=rt --ir-output-only < %s -S -o - \
 ; RUN: | FileCheck %s
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/llvm/test/tools/sycl-post-link/spec-constants/DeprecatedFeautres/multiple-sym-id-usages.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/DeprecatedFeautres/multiple-sym-id-usages.ll
@@ -1,7 +1,7 @@
 ; This test checks that the tool does not crash and removes the unused spec
 ; constant global symbol when it is referenced more than once.
 
-; RUN: sycl-post-link -spec-const=rt --ir-output-only %s -S -o %t.ll
+; RUN: sycl-post-link -spec-const=rt --ir-output-only < %s -S -o %t.ll
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-unknown"

--- a/llvm/test/tools/sycl-post-link/spec-constants/DeprecatedFeautres/scalar-O0.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/DeprecatedFeautres/scalar-O0.ll
@@ -1,6 +1,6 @@
-; RUN: sycl-post-link --ir-output-only -spec-const=default %s -S -o - | \
+; RUN: sycl-post-link --ir-output-only -spec-const=default < %s -S -o - | \
 ; RUN:   FileCheck %s -check-prefixes=CHECK,CHECK-DEF
-; RUN: sycl-post-link --ir-output-only -spec-const=rt %s -S -o - | \
+; RUN: sycl-post-link --ir-output-only -spec-const=rt < %s -S -o - | \
 ; RUN:   FileCheck %s -check-prefixes=CHECK,CHECK-RT
 
 ; This test checks that the post link tool is able to correctly transform

--- a/llvm/test/tools/sycl-post-link/spec-constants/DeprecatedFeautres/scalar-O2.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/DeprecatedFeautres/scalar-O2.ll
@@ -1,6 +1,6 @@
-; RUN: sycl-post-link --ir-output-only -spec-const=default %s -S -o - | \
+; RUN: sycl-post-link --ir-output-only -spec-const=default < %s -S -o - | \
 ; RUN:   FileCheck %s -check-prefixes=CHECK,CHECK-DEF
-; RUN: sycl-post-link --ir-output-only -spec-const=rt %s -S -o - | \
+; RUN: sycl-post-link --ir-output-only -spec-const=rt < %s -S -o - | \
 ; RUN:   FileCheck %s -check-prefixes=CHECK,CHECK-RT
 
 ; This test checks that the post link tool is able to correctly transform

--- a/llvm/test/tools/sycl-post-link/spec-constants/DeprecatedFeautres/spec_const_and_split.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/DeprecatedFeautres/spec_const_and_split.ll
@@ -6,7 +6,7 @@
 ; constant property correctly: i.e. it doesn't put all specialization constants
 ; into properties of each device image
 
-; RUN: sycl-post-link -split=kernel -spec-const=rt -S %s -o %t.files.table
+; RUN: sycl-post-link -split=kernel -spec-const=rt -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll --check-prefixes CHECK-IR0
 ; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefixes CHECK-PROP0
 ; RUN: FileCheck %s -input-file=%t.files_1.ll --check-prefixes CHECK-IR1

--- a/llvm/test/tools/sycl-post-link/spec-constants/SYCL-2020-zeroinitializer-array-of-arrays.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/SYCL-2020-zeroinitializer-array-of-arrays.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link --spec-const=rt -S %s -o %t.files.table
+; RUN: sycl-post-link --spec-const=rt -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll --check-prefix CHECK-IR
 ; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefix CHECK-PROP
 ;

--- a/llvm/test/tools/sycl-post-link/spec-constants/SYCL-2020.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/SYCL-2020.ll
@@ -1,7 +1,7 @@
-; RUN: sycl-post-link -spec-const=default %s -S -o %t.table
+; RUN: sycl-post-link -spec-const=default < %s -S -o %t.table
 ; RUN: FileCheck %s -check-prefixes=CHECK,CHECK-DEF < %t_0.ll
 ; RUN: FileCheck %s --check-prefixes=CHECK-PROPS,CHECK-PROPS-DEF < %t_0.prop
-; RUN: sycl-post-link -spec-const=rt %s -S -o %t.table
+; RUN: sycl-post-link -spec-const=rt < %s -S -o %t.table
 ; RUN: FileCheck %s -check-prefixes=CHECK,CHECK-RT < %t_0.ll
 ; RUN: FileCheck %s --check-prefixes=CHECK-PROPS < %t_0.prop
 

--- a/llvm/test/tools/sycl-post-link/spec-constants/SYCL2020-struct-with-undef-padding.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/SYCL2020-struct-with-undef-padding.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link --spec-const=rt -S %s -o %t.files.table
+; RUN: sycl-post-link --spec-const=rt -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll --check-prefix CHECK-IR
 ; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefix CHECK-PROP
 ;

--- a/llvm/test/tools/sycl-post-link/spec-constants/bool.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/bool.ll
@@ -1,6 +1,6 @@
-; RUN: sycl-post-link -spec-const=rt -S %s --ir-output-only -o %t.ll
+; RUN: sycl-post-link -spec-const=rt -S < %s --ir-output-only -o %t.ll
 ; RUN: FileCheck %s --input-file=%t.ll --implicit-check-not "call i8 bitcast" --check-prefixes=CHECK,CHECK-RT
-; RUN: sycl-post-link -spec-const=default -S %s --ir-output-only -o %t.ll
+; RUN: sycl-post-link -spec-const=default -S < %s --ir-output-only -o %t.ll
 ; RUN: FileCheck %s --input-file=%t.ll --check-prefixes=CHECK,CHECK-DEF
 
 ; CHECK-LABEL: void @kernel_A

--- a/llvm/test/tools/sycl-post-link/spec-constants/composite-O2.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/composite-O2.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -spec-const=rt --ir-output-only %s -S -o - \
+; RUN: sycl-post-link -spec-const=rt --ir-output-only < %s -S -o - \
 ; RUN: | FileCheck %s --implicit-check-not "call {{.*}} __sycl_getCompositeSpecConstantValue" --implicit-check-not "call {{.*}} __sycl_getComposite2020SpecConstantValue"
 ;
 ; This test is intended to check that sycl-post-link tool is capable of handling

--- a/llvm/test/tools/sycl-post-link/spec-constants/composite-default-value-padding.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/composite-default-value-padding.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -spec-const=default %s -o %t.files.table
+; RUN: sycl-post-link -spec-const=default < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.prop
 ;
 ; This test checks that composite specialization constants with padding gets the

--- a/llvm/test/tools/sycl-post-link/spec-constants/composite-default-value.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/composite-default-value.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -spec-const=default --ir-output-only %s -S -o - \
+; RUN: sycl-post-link -spec-const=default --ir-output-only < %s -S -o - \
 ; RUN: | FileCheck %s --implicit-check-not "call {{.*}} __sycl_getCompositeSpecConstantValue" --implicit-check-not "call {{.*}} __sycl_getComposite2020SpecConstantValue"
 ;
 ; This test checks that composite specialization constants can be correctly

--- a/llvm/test/tools/sycl-post-link/spec-constants/composite-no-sret.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/composite-no-sret.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -spec-const=rt --ir-output-only %s -S -o - \
+; RUN: sycl-post-link -spec-const=rt --ir-output-only < %s -S -o - \
 ; RUN: | FileCheck %s --implicit-check-not "call {{.*}} __sycl_getCompositeSpecConstantValue" --implicit-check-not "call {{.*}} __sycl_getComposite2020SpecConstantValue"
 
 ; CHECK: %[[#NS0:]] = call i32 @_Z20__spirv_SpecConstantii(i32 [[#ID:]], i32

--- a/llvm/test/tools/sycl-post-link/spec-constants/composite-padding-desc.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/composite-padding-desc.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -spec-const=rt %s -o %t.files.table
+; RUN: sycl-post-link -spec-const=rt < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.prop
 ;
 ; This test checks that composite specialization constants with implicit padding

--- a/llvm/test/tools/sycl-post-link/sycl-esimd-large-grf.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd-large-grf.ll
@@ -7,7 +7,7 @@
 ; - Compiler adds 'isLargeGRF' property to the ESIMD device binary
 ;   images requesting "large GRF" 
 
-; RUN: sycl-post-link -split=source -symbols -split-esimd -lower-esimd -S %s -o %t.table
+; RUN: sycl-post-link -split=source -symbols -split-esimd -lower-esimd -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t.table
 ; RUN: FileCheck %s -input-file=%t_esimd_large_grf_0.ll --check-prefixes CHECK-ESIMD-LargeGRF-IR
 ; RUN: FileCheck %s -input-file=%t_esimd_large_grf_0.prop --check-prefixes CHECK-ESIMD-LargeGRF-PROP

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/basic-esimd-lower.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/basic-esimd-lower.ll
@@ -3,19 +3,19 @@
 ; for ESIMD kernels in any case.
 
 ; No lowering
-; RUN: sycl-post-link -split-esimd -S %s -o %t.table
+; RUN: sycl-post-link -split-esimd -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes CHECK-NO-LOWERING
 
 ; Default lowering
-; RUN: sycl-post-link -split-esimd -lower-esimd -S %s -o %t.table
+; RUN: sycl-post-link -split-esimd -lower-esimd -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes CHECK-O2
 
 ; -O2 lowering
-; RUN: sycl-post-link -split-esimd -lower-esimd -O2 -S %s -o %t.table
+; RUN: sycl-post-link -split-esimd -lower-esimd -O2 -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes CHECK-O2
 
 ; -O0 lowering
-; RUN: sycl-post-link -split-esimd -lower-esimd -O0 -S %s -o %t.table
+; RUN: sycl-post-link -split-esimd -lower-esimd -O0 -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes CHECK-O0
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/basic-sycl-esimd-split.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/basic-sycl-esimd-split.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -split-esimd -S %s -o %t.table
+; RUN: sycl-post-link -split-esimd -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-SYCL-IR
 ; RUN: FileCheck %s -input-file=%t_esimd_0.ll --check-prefixes CHECK-ESIMD-IR

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/nbarriers-metadata.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/nbarriers-metadata.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -split-esimd -lower-esimd -S %s -o %t.table
+; RUN: sycl-post-link -split-esimd -lower-esimd -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_esimd_0.ll
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/no-sycl-esimd-split-shared-func.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/no-sycl-esimd-split-shared-func.ll
@@ -5,7 +5,7 @@
 ;   making sure no functions are shared by the callgraphs (currently required by
 ;   IGC)
 
-; RUN: sycl-post-link -lower-esimd -symbols -split=auto -S %s -o %t.table
+; RUN: sycl-post-link -lower-esimd -symbols -split=auto -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t.table --check-prefixes CHECK-TABLE
 ; RUN: FileCheck %s -input-file=%t_0.ll
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefixes CHECK-SYM

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/no-sycl-esimd-split.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/no-sycl-esimd-split.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -split=source -S %s -o %t.table
+; RUN: sycl-post-link -split=source -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-IR-0
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefixes CHECK-IR-1

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/sycl-esimd-split-per-kernel.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/sycl-esimd-split-per-kernel.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -split-esimd -split=kernel -S %s -o %t.table
+; RUN: sycl-post-link -split-esimd -split=kernel -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-SYCL-IR-0
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefixes CHECK-SYCL-IR-1

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/sycl-esimd-split-per-source.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/sycl-esimd-split-per-source.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -split-esimd -split=source -S %s -o %t.table
+; RUN: sycl-post-link -split-esimd -split=source -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-SYCL-IR-0
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefixes CHECK-SYCL-IR-1

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/sycl-esimd-split-symbols.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/sycl-esimd-split-symbols.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -split-esimd -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split-esimd -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t.table
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefixes CHECK-SYCL-SYM
 ; RUN: FileCheck %s -input-file=%t_esimd_0.sym --check-prefixes CHECK-ESIMD-SYM

--- a/llvm/test/tools/sycl-post-link/sycl-external-funcs/drop-known-builtins.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-external-funcs/drop-known-builtins.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -ir-output-only -split=auto -S %s -o %t.ll
+; RUN: sycl-post-link -ir-output-only -split=auto -S < %s -o %t.ll
 ; RUN: FileCheck %s -input-file=%t.ll
 
 ; This test checks that known SPIRV and SYCL builtin functions

--- a/llvm/test/tools/sycl-post-link/sycl-external-funcs/drop-unref-funcs.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-external-funcs/drop-unref-funcs.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -ir-output-only -split=auto -S %s -o %t.ll
+; RUN: sycl-post-link -ir-output-only -split=auto -S < %s -o %t.ll
 ; RUN: FileCheck %s -input-file=%t.ll
 
 ; This test checks that unreferenced functions without sycl-module-id

--- a/llvm/test/tools/sycl-post-link/sycl-external-funcs/keep-indirectly-ref-funcs.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-external-funcs/keep-indirectly-ref-funcs.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -ir-output-only -split=auto -S %s -o %t.ll
+; RUN: sycl-post-link -ir-output-only -split=auto -S < %s -o %t.ll
 ; RUN: FileCheck %s -input-file=%t.ll
 
 ; This test checks that indirectly referenced functions (with sycl-module-id

--- a/llvm/test/tools/sycl-post-link/sycl-external-funcs/split-and-lower-esimd.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-external-funcs/split-and-lower-esimd.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -split=auto -split-esimd -lower-esimd -O0 -S %s -o %t.table
+; RUN: sycl-post-link -split=auto -split-esimd -lower-esimd -O0 -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_esimd_0.ll
 
 ; This test checks that unreferenced functions with sycl-module-id

--- a/llvm/test/tools/sycl-post-link/sycl-external-funcs/split-global.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-external-funcs/split-global.ll
@@ -1,10 +1,10 @@
 ; This test checks handling of unreferenced functions with sycl-module-id
 ; attribute with splitting in global mode.
 
-; RUN: sycl-post-link -ir-output-only -split=auto -S %s -o %t.ll
+; RUN: sycl-post-link -ir-output-only -split=auto -S < %s -o %t.ll
 ; RUN: FileCheck %s -input-file=%t.ll --check-prefix=CHECK-ALL
 
-; RUN: sycl-post-link -ir-output-only -emit-only-kernels-as-entry-points -split=auto -S %s -o %t.ll
+; RUN: sycl-post-link -ir-output-only -emit-only-kernels-as-entry-points -split=auto -S < %s -o %t.ll
 ; RUN: FileCheck %s -input-file=%t.ll --check-prefix=CHECK-KERNEL-ONLY --implicit-check-not @externalDeviceFunc
 
 

--- a/llvm/test/tools/sycl-post-link/sycl-external-funcs/split-per-kernel.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-external-funcs/split-per-kernel.ll
@@ -1,7 +1,7 @@
 ; This test checks handling of unreferenced functions with sycl-module-id
 ; attribute with splitting in per-kernel mode.
 
-; RUN: sycl-post-link -split=kernel -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=kernel -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-IR0
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefixes CHECK-SYM0
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefixes CHECK-IR1
@@ -9,7 +9,7 @@
 ; RUN: FileCheck %s -input-file=%t_2.ll --check-prefixes CHECK-IR2
 ; RUN: FileCheck %s -input-file=%t_2.sym --check-prefixes CHECK-SYM2
 
-; RUN: sycl-post-link -split=kernel -emit-only-kernels-as-entry-points -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=kernel -emit-only-kernels-as-entry-points -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefixes CHECK-IR1
 ; RUN: FileCheck %s -input-file=%t_1.sym --check-prefixes CHECK-SYM1
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-IR0

--- a/llvm/test/tools/sycl-post-link/sycl-external-funcs/split-per-source1.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-external-funcs/split-per-source1.ll
@@ -1,13 +1,13 @@
 ; This test checks handling of unreferenced functions with sycl-module-id
 ; attribute with splitting in per-source mode.
 
-; RUN: sycl-post-link -split=source -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=source -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-IR2
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefixes CHECK-SYM2
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefixes CHECK-IR1
 ; RUN: FileCheck %s -input-file=%t_1.sym --check-prefixes CHECK-SYM1
 
-; RUN: sycl-post-link -split=source -emit-only-kernels-as-entry-points -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=source -emit-only-kernels-as-entry-points -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefixes CHECK-SYM2
 ; RUN: FileCheck %s -input-file=%t.table --check-prefixes CHECK-TABLE
 ; CHECK-TABLE: [Code|Properties|Symbols]

--- a/llvm/test/tools/sycl-post-link/sycl-external-funcs/split-per-source2.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-external-funcs/split-per-source2.ll
@@ -1,13 +1,13 @@
 ; This test checks handling of referenced SYCL_EXTERNAL functions with
 ; sycl-module-id attribute with splitting in per-source mode.
 
-; RUN: sycl-post-link -split=source -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=source -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefixes CHECK-IR0
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefixes CHECK-SYM0
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefixes CHECK-IR1
 ; RUN: FileCheck %s -input-file=%t_1.sym --check-prefixes CHECK-SYM1
 
-; RUN: sycl-post-link -split=source -emit-only-kernels-as-entry-points -symbols -S %s -o %t.table
+; RUN: sycl-post-link -split=source -emit-only-kernels-as-entry-points -symbols -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefixes CHECK-SYM0
 ; RUN: FileCheck %s -input-file=%t.table --check-prefixes CHECK-TABLE
 ; CHECK-TABLE: [Code|Properties|Symbols]

--- a/llvm/test/tools/sycl-post-link/sycl-large-grf.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-large-grf.ll
@@ -7,7 +7,7 @@
 ; - Compiler adds 'isLargeGRF' property to the device binary
 ;   images requesting "large GRF" 
 
-; RUN: sycl-post-link -split=source -symbols -split-esimd -lower-esimd -S %s -o %t.table
+; RUN: sycl-post-link -split=source -symbols -split-esimd -lower-esimd -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t.table
 ; RUN: FileCheck %s -input-file=%t_large_grf_0.ll --check-prefixes CHECK-LARGE-GRF-IR
 ; RUN: FileCheck %s -input-file=%t_large_grf_0.prop --check-prefixes CHECK-LARGE-GRF-PROP

--- a/llvm/test/tools/sycl-post-link/sycl-post-link-test.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-post-link-test.ll
@@ -1,4 +1,4 @@
-; RUN: sycl-post-link -split-esimd -lower-esimd -O0 -S %s -o %t.table
+; RUN: sycl-post-link -split-esimd -lower-esimd -O0 -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_esimd_0.ll
 ; This test checks that IR code below can be successfully processed by
 ; sycl-post-link. In this IR no extractelement instruction and no casting are used

--- a/llvm/test/tools/sycl-post-link/sym_but_no_split.ll
+++ b/llvm/test/tools/sycl-post-link/sym_but_no_split.ll
@@ -2,7 +2,7 @@
 ; table and a symbol file for an input module with two kernels when no code
 ; splitting is requested.
 ;
-; RUN: sycl-post-link -symbols -spec-const=rt -S %s -o %t.files.table
+; RUN: sycl-post-link -symbols -spec-const=rt -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files.table --check-prefixes CHECK-TABLE
 ; RUN: FileCheck %s -input-file=%t.files_0.sym --match-full-lines --check-prefixes CHECK-SYM
 


### PR DESCRIPTION
Best practice in lit tests is to redirect the test file to tools operating on it via stdin instead of passing the file name directly to the tool. This is because LLVM tools often print the name of the input file in their output, and if the person running the tests is unlucky enough that the path to where they checked out the tests has the wrong substrings in it, they can see spurious lit test failures like these:

```
command line:1:22: error: CHECK-M1-IR-NOT: excluded string found in input
-implicit-check-not='bar'
                     ^
/localdisk2/dwoodwor/intel-llvm-kernel1-bar-@GV/build/test/tools/sycl-post-link/device-code-split/Output/per-aspect-split-3.ll.tmp_1.ll:1:55: note: found here
; ModuleID = '/localdisk2/dwoodwor/intel-llvm-kernel1-bar-@GV/llvm/test/tools/sycl-post-link/device-code-split/per-aspect-split-3.ll'
                                                      ^~~
```

```
command line:1:22: error: CHECK-M0-IR-NOT: excluded string found in input
-implicit-check-not='kernel1'
                     ^
/localdisk2/dwoodwor/intel-llvm-kernel1-bar-@GV/build/test/tools/sycl-post-link/device-code-split/Output/per-aspect-split-1.ll.tmp_0.ll:1:47: note: found here
; ModuleID = '/localdisk2/dwoodwor/intel-llvm-kernel1-bar-@GV/llvm/test/tools/sycl-post-link/device-code-split/per-aspect-split-1.ll'
                                              ^~~~~~~
```

```
/localdisk2/dwoodwor/intel-llvm-kernel1-bar-@GV/llvm/test/tools/sycl-post-link/device-code-split/basic-module-split.ll:13:17: error: CHECK-TU1-NOT: excluded string found i
n input
;CHECK-TU1-NOT: @{{.*}}GV{{.*}}
                ^
/localdisk2/dwoodwor/intel-llvm-kernel1-bar-@GV/build/test/tools/sycl-post-link/device-code-split/Output/basic-module-split.ll.tmp_1.ll:1:59: note: found here
; ModuleID = '/localdisk2/dwoodwor/intel-llvm-kernel1-bar-@GV/llvm/test/tools/sycl-post-link/device-code-split/basic-module-split.ll'
                                                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```