### PR TITLE
[SYCL][Fusion] Fix build `error: call to deleted constructor`

### DIFF
--- a/sycl-fusion/passes/kernel-fusion/Builtins.cpp
+++ b/sycl-fusion/passes/kernel-fusion/Builtins.cpp
@@ -580,7 +580,7 @@ jit_compiler::Remapper::remapBuiltins(Function *F, const NDRange &SrcNDRange,
       auto *OldF = Call->getCalledFunction();
       auto ErrOrNewF = remapBuiltins(OldF, SrcNDRange, FusedNDRange);
       if (auto Err = ErrOrNewF.takeError()) {
-        return Err;
+        return std::move(Err);
       }
       // Override called function.
       auto *NewF = *ErrOrNewF;


### PR DESCRIPTION
```
sycl-fusion/passes/kernel-fusion/Builtins.cpp:583:16: error: call to deleted constructor of 'llvm::Error'
        return Err;
               ^~~
```