### PR TITLE
[SYCL-MLIR] Use `memref.memory_space_cast`

### DIFF
--- a/mlir-sycl/lib/Dialect/IR/MethodUtils.cpp
+++ b/mlir-sycl/lib/Dialect/IR/MethodUtils.cpp
@@ -33,7 +33,7 @@ static Operation *trackCasts(Value Val) {
     return nullptr;
 
   return TypeSwitch<Operation *, Operation *>(DefiningOp)
-      .Case<mlir::sycl::SYCLCastOp, mlir::sycl::SYCLAddrSpaceCastOp>(
+      .Case<mlir::sycl::SYCLCastOp, memref::MemorySpaceCastOp>(
           [](Operation *Op) {
             if (auto *Res = trackCasts(Op->getOperand(0)))
               return Res;

--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -226,8 +226,4 @@ llvm::cl::opt<bool> OmitOptionalMangledFunctionName(
     "no-mangled-function-name", llvm::cl::init(false),
     llvm::cl::desc("Whether to omit optional \"MangledFunctionName\" fields"));
 
-llvm::cl::opt<bool>
-    GenerateSYCLAddrSpaceCast("gen-sycl-addrspacecast", llvm::cl::init(false),
-                              llvm::cl::desc("Generate sycl.addrspacecast"));
-
 #endif /* CGEIST_OPTIONS_H_ */

--- a/polygeist/tools/cgeist/Test/Verification/addressspace.c
+++ b/polygeist/tools/cgeist/Test/Verification/addressspace.c
@@ -2,10 +2,8 @@
 
 // CHECK:  func.func @test() -> memref<?xi32, 4> attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK:    [[CALL:%.*]] = call @foo() : () -> memref<?xi32, 1>
-// CHECK:    [[M2P:%.*]] = "polygeist.memref2pointer"([[CALL]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
-// CHECK:    [[ACAST:%.*]] = llvm.addrspacecast [[M2P]] : !llvm.ptr<i32, 1> to !llvm.ptr<i32, 4>
-// CHECK:    [[P2M:%.*]] = "polygeist.pointer2memref"([[ACAST]]) : (!llvm.ptr<i32, 4>) -> memref<?xi32, 4>
-// CHECK:    return [[P2M]] : memref<?xi32, 4>
+// CHECK:    [[MSC:%.*]] = memref.memory_space_cast [[CALL]] : memref<?xi32, 1> to memref<?xi32, 4>
+// CHECK:    return [[MSC]] : memref<?xi32, 4>
 // CHECK:  }
 // CHECK:  func.func private @foo() -> memref<?xi32, 1>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/assert.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/assert.cpp
@@ -7,16 +7,16 @@ using namespace sycl;
 // CHECK-LABEL:    llvm.func @__assert_fail(!llvm.ptr<i8, 4>, !llvm.ptr<i8, 4>, i32, !llvm.ptr<i8, 4>)
 // CHECK-LABEL:    func.func @_Z12check_assertN4sycl3_V12idILi1EEES2_(%arg0: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef})
 // CHECK-NEXT:        [[C22:%.*]] = arith.constant 22 : i32
-// CHECK:             %3 = llvm.mlir.addressof @str0 : !llvm.ptr<array<11 x i8>>
-// CHECK-NEXT:        %4 = llvm.getelementptr inbounds %3[0, 0] : (!llvm.ptr<array<11 x i8>>) -> !llvm.ptr<i8>
-// CHECK-NEXT:        %5 = llvm.mlir.addressof @str1 : !llvm.ptr<array<[[PATH_LENGTH:.*]] x i8>>
-// CHECK-NEXT:        %6 = llvm.getelementptr inbounds %5[0, 0] : (!llvm.ptr<array<[[PATH_LENGTH]] x i8>>) -> !llvm.ptr<i8>
-// CHECK-NEXT:        %7 = llvm.mlir.addressof @str2 : !llvm.ptr<array<32 x i8>>
-// CHECK-NEXT:        %8 = llvm.getelementptr inbounds %7[0, 0] : (!llvm.ptr<array<32 x i8>>) -> !llvm.ptr<i8>
-// CHECK-NEXT:        %9 = llvm.addrspacecast %4 : !llvm.ptr<i8> to !llvm.ptr<i8, 4>
-// CHECK-NEXT:        %10 = llvm.addrspacecast %6 : !llvm.ptr<i8> to !llvm.ptr<i8, 4>
-// CHECK-NEXT:        %11 = llvm.addrspacecast %8 : !llvm.ptr<i8> to !llvm.ptr<i8, 4>
-// CHECK-NEXT:        llvm.call @__assert_fail(%9, %10, [[C22]], %11) : (!llvm.ptr<i8, 4>, !llvm.ptr<i8, 4>, i32, !llvm.ptr<i8, 4>) -> ()
+// CHECK:             %1 = llvm.mlir.addressof @str0 : !llvm.ptr<array<11 x i8>>
+// CHECK-NEXT:        %2 = llvm.getelementptr inbounds %1[0, 0] : (!llvm.ptr<array<11 x i8>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:        %3 = llvm.mlir.addressof @str1 : !llvm.ptr<array<[[PATH_LENGTH:.*]] x i8>>
+// CHECK-NEXT:        %4 = llvm.getelementptr inbounds %3[0, 0] : (!llvm.ptr<array<[[PATH_LENGTH]] x i8>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:        %5 = llvm.mlir.addressof @str2 : !llvm.ptr<array<32 x i8>>
+// CHECK-NEXT:        %6 = llvm.getelementptr inbounds %5[0, 0] : (!llvm.ptr<array<32 x i8>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:        %7 = llvm.addrspacecast %2 : !llvm.ptr<i8> to !llvm.ptr<i8, 4>
+// CHECK-NEXT:        %8 = llvm.addrspacecast %4 : !llvm.ptr<i8> to !llvm.ptr<i8, 4>
+// CHECK-NEXT:        %9 = llvm.addrspacecast %6 : !llvm.ptr<i8> to !llvm.ptr<i8, 4>
+// CHECK-NEXT:        llvm.call @__assert_fail(%7, %8, [[C22]], %9) : (!llvm.ptr<i8, 4>, !llvm.ptr<i8, 4>, i32, !llvm.ptr<i8, 4>) -> ()
 
 SYCL_EXTERNAL void check_assert(id<1> id1, id<1> id2) {
   assert(id1 == id2);

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -107,8 +107,8 @@ extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
 // CHECK-NEXT: %1 = "polygeist.typeSize"() {source = !sycl_id_2_} : () -> index
 // CHECK-NEXT: %2 = arith.index_cast %1 : index to i64
 // CHECK-NEXT: "llvm.intr.memset"(%0, %c0_i8, %2, %false) : (!llvm.ptr<i8>, i8, i64, i1) -> ()
-// CHECK-NEXT: %3 = sycl.addrspacecast %cast : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
-// CHECK-NEXT: sycl.constructor @id(%3) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1Ev} : (memref<?x!sycl_id_2_, 4>)
+// CHECK-NEXT: %memspacecast = memref.memory_space_cast %cast : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
+// CHECK-NEXT: sycl.constructor @id(%memspacecast) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1Ev} : (memref<?x!sycl_id_2_, 4>)
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_1()
 // CHECK-LLVM-SAME:  #[[FUNCATTRS]]
@@ -126,8 +126,8 @@ extern "C" SYCL_EXTERNAL void cons_1() {
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXTERNAL]], {{.*}}}
 // CHECK-NEXT: %alloca = memref.alloca() : memref<1x!sycl_id_2_>
 // CHECK-NEXT: %cast = memref.cast %alloca : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
-// CHECK-NEXT: %0 = sycl.addrspacecast %cast : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
-// CHECK-NEXT: sycl.constructor @id(%0, %arg0, %arg1) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm} : (memref<?x!sycl_id_2_, 4>, i64, i64)
+// CHECK-NEXT: %memspacecast = memref.memory_space_cast %cast : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
+// CHECK-NEXT: sycl.constructor @id(%memspacecast, %arg0, %arg1) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm} : (memref<?x!sycl_id_2_, 4>, i64, i64)
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_2(i64 noundef %0, i64 noundef %1)
 // CHECK-LLVM-SAME:  #[[FUNCATTRS]]
@@ -144,9 +144,9 @@ extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXTERNAL]], {{.*}}}
 // CHECK-NEXT: %alloca = memref.alloca() : memref<1x!sycl_id_2_>
 // CHECK-NEXT: %cast = memref.cast %alloca : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
-// CHECK-NEXT: %0 = sycl.addrspacecast %cast : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
-// CHECK-NEXT: %1 = sycl.addrspacecast %arg0 : memref<?x![[ITEM]]> to memref<?x![[ITEM]], 4>
-// CHECK-NEXT: sycl.constructor @id(%0, %1) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE} : (memref<?x!sycl_id_2_, 4>, memref<?x![[ITEM]], 4>)
+// CHECK-NEXT: %memspacecast = memref.memory_space_cast %cast : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
+// CHECK-NEXT: %memspacecast_0 = memref.memory_space_cast %arg0 : memref<?x![[ITEM]]> to memref<?x![[ITEM]], 4>
+// CHECK-NEXT: sycl.constructor @id(%memspacecast, %memspacecast_0) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE} : (memref<?x!sycl_id_2_, 4>, memref<?x![[ITEM]], 4>)
 
 // CHECK-LLVM: define spir_func void @cons_3([[ITEM_TYPE:%"class.sycl::_V1::item.2.true"]]* noundef byval(%"class.sycl::_V1::item.2.true") align 8 [[ARG0:%.*]]) #[[FUNCATTRS]]
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE:%"class.sycl::_V1::id.2"]]  
@@ -162,9 +162,9 @@ extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXTERNAL]], {{.*}}}
 // CHECK-NEXT: %alloca = memref.alloca() : memref<1x!sycl_id_2_>
 // CHECK-NEXT: %cast = memref.cast %alloca : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
-// CHECK-NEXT: %0 = sycl.addrspacecast %cast : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
-// CHECK-NEXT: %1 = sycl.addrspacecast %arg0 : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
-// CHECK-NEXT: sycl.constructor @id(%0, %1) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ERKS2_} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>)
+// CHECK-NEXT: %memspacecast = memref.memory_space_cast %cast : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
+// CHECK-NEXT: %memspacecast_0 = memref.memory_space_cast %arg0 : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
+// CHECK-NEXT: sycl.constructor @id(%memspacecast, %memspacecast_0) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ERKS2_} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>)
 
 // CHECK-LLVM: define spir_func void @cons_4([[ID_TYPE:%"class.sycl::_V1::id.2"]]*  noundef byval(%"class.sycl::_V1::id.2") align 8 [[ARG0:%.*]]) #[[FUNCATTRS]]
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE]]
@@ -249,7 +249,7 @@ extern "C" SYCL_EXTERNAL void cons_9(const sycl::vec<sycl::cl_char, 3>::vector_t
 
 // CHECK-LABEL: func.func @cons_10(
 // CHECK-SAME:                     %[[ARG0:.*]]: memref<?x!sycl_vec_i64_8_, 4> {{{.*}}}, %[[ARG1:.*]]: memref<?x!sycl_vec_i64_4_, 4> {{{.*}}}, %[[ARG2:.*]]: memref<?x!sycl_vec_i64_2_, 4> {{{.*}}}, %{{.*}}: i64 {{{.*}}}, %{{.*}}: i64 {{{.*}}}) attributes {[[SPIR_FUNCCC]], [[LINKEXTERNAL]], {{.*}}}
-// CHECK:         sycl.constructor @vec(%1, %[[ARG0]], %[[ARG1]], %[[ARG2]], %2, %3) {MangledFunctionName = @[[VEC_INITLIST_VEC_CTR:.*]]} : (memref<?x!sycl_vec_i64_16_, 4>, memref<?x!sycl_vec_i64_8_, 4>, memref<?x!sycl_vec_i64_4_, 4>, memref<?x!sycl_vec_i64_2_, 4>, memref<?xi64, 4>, memref<?xi64, 4>)
+// CHECK:         sycl.constructor @vec(%memspacecast, %[[ARG0]], %[[ARG1]], %[[ARG2]], %memspacecast_4, %memspacecast_5) {MangledFunctionName = @[[VEC_INITLIST_VEC_CTR:.*]]} : (memref<?x!sycl_vec_i64_16_, 4>, memref<?x!sycl_vec_i64_8_, 4>, memref<?x!sycl_vec_i64_4_, 4>, memref<?x!sycl_vec_i64_2_, 4>, memref<?xi64, 4>, memref<?xi64, 4>)
 // CHECK:       func.func @[[VEC_INITLIST_VEC_CTR]](%{{.*}}: memref<?x!sycl_vec_i64_16_, 4> {{{.*}}}, %{{.*}}: memref<?x!sycl_vec_i64_8_, 4> {{{.*}}}, %{{.*}}: memref<?x!sycl_vec_i64_4_, 4> {{{.*}}}, %{{.*}}: memref<?x!sycl_vec_i64_2_, 4> {{{.*}}}, %{{.*}}: memref<?xi64, 4> {{{.*}}}, %{{.*}}: memref<?xi64, 4> {{{.*}}}) attributes {[[SPIR_FUNCCC]], [[LINKONCE]], {{.*}}}
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_10(

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -153,7 +153,7 @@ SYCL_EXTERNAL void range_size(sycl::range<2> r) {
 // CHECK-MLIR-NEXT:             %[[VAL_2:.*]] = memref.alloca() : memref<1x!sycl_range_2_>
 // CHECK-MLIR-NEXT:             %cast = memref.cast %alloca : memref<1x!sycl_range_2_> to memref<?x!sycl_range_2_>
 // CHECK-MLIR-NEXT:             %[[VAL_3:.*]] = "polygeist.subindex"(%[[VAL_0]], %[[VAL_1]]) : (memref<?x!sycl_nd_range_2_, 4>, index) -> memref<?x!sycl_range_2_, 4>
-// CHECK-MLIR-NEXT:             %[[VAL_4:.*]] = sycl.addrspacecast %cast : memref<?x!sycl_range_2_> to memref<?x!sycl_range_2_, 4>
+// CHECK-MLIR-NEXT:             %[[VAL_4:.*]] = memref.memory_space_cast %cast : memref<?x!sycl_range_2_> to memref<?x!sycl_range_2_, 4>
 // CHECK-MLIR-NEXT:             sycl.constructor @range(%[[VAL_4]], %[[VAL_3]]) {MangledFunctionName = @_ZN4sycl3_V15rangeILi2EEC1ERKS2_} : (memref<?x!sycl_range_2_, 4>, memref<?x!sycl_range_2_, 4>)
 // CHECK-MLIR-NEXT:             %[[VAL_7:.*]] = affine.load %[[VAL_2]][0] : memref<1x!sycl_range_2_>
 // CHECK-MLIR-NEXT:             return %[[VAL_7]] : !sycl_range_2_
@@ -651,8 +651,8 @@ SYCL_EXTERNAL void group_get_local_linear_range(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8method_2N4sycl3_V14itemILi2ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM2]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM2]], llvm.noundef})
-// CHECK-MLIR-NEXT: %0 = sycl.addrspacecast %arg0 : memref<?x![[ITEM2]]> to memref<?x![[ITEM2]], 4>
-// CHECK-MLIR-NEXT: %1 = sycl.call @"operator=="(%0, %0) {MangledFunctionName = @_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_, TypeName = @item} : (memref<?x![[ITEM2]], 4>, memref<?x![[ITEM2]], 4>) -> i1
+// CHECK-MLIR-NEXT: %memspacecast = memref.memory_space_cast %arg0 : memref<?x![[ITEM2]]> to memref<?x![[ITEM2]], 4>
+// CHECK-MLIR-NEXT: %0 = sycl.call @"operator=="(%memspacecast, %memspacecast) {MangledFunctionName = @_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_, TypeName = @item} : (memref<?x![[ITEM2]], 4>, memref<?x![[ITEM2]], 4>) -> i1
 // CHECK-MLIR-NEXT: return
 // CHECK-MLIR-NEXT: }
 
@@ -669,9 +669,9 @@ SYCL_EXTERNAL void method_2(sycl::item<2, true> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z4op_1N4sycl3_V12idILi2EEES2_(
 // CHECK-MLIR:         %arg0: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef}, %arg1: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})
-// CHECK-MLIR-NEXT: %0 = sycl.addrspacecast %arg0 : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
-// CHECK-MLIR-NEXT: %1 = sycl.addrspacecast %arg1 : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
-// CHECK-MLIR-NEXT: %2 = sycl.call @"operator=="(%0, %1) {MangledFunctionName = @_ZNK4sycl3_V12idILi2EEeqERKS2_, TypeName = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> i1
+// CHECK-MLIR-NEXT: %memspacecast = memref.memory_space_cast %arg0 : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
+// CHECK-MLIR-NEXT: %memspacecast_0 = memref.memory_space_cast %arg1 : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
+// CHECK-MLIR-NEXT: %0 = sycl.call @"operator=="(%memspacecast, %memspacecast_0) {MangledFunctionName = @_ZNK4sycl3_V12idILi2EEeqERKS2_, TypeName = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> i1
 // CHECK-MLIR-NEXT: return
 // CHECK-MLIR-NEXT: }
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/image.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/image.cpp
@@ -20,9 +20,9 @@ static constexpr unsigned N = 8;
 // CHECK-NEXT:    %1 = "polygeist.memref2pointer"(%arg0) : (memref<?x!llvm.struct<(!sycl_accessor_1_21sycl2Evec3C5Bf322C_45D2C_28vector3C4xf323E293E_r_i)>, 4>) -> !llvm.ptr<struct<(ptr<struct<"opencl.image1d_ro_t", opaque>, 1>, array<24 x i8>)>, 4>
 // CHECK-NEXT:    %2 = sycl.item.get_id(%arg1, %c0_i32) {ArgumentTypes = [memref<?x!sycl_item_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EEixEi, TypeName = @item} : (memref<?x!sycl_item_1_>, i32) -> i64
 // CHECK-NEXT:    %3 = arith.trunci %2 : i64 to i32
-// CHECK-NEXT:    %4 = sycl.addrspacecast %cast : memref<?xi32> to memref<?xi32, 4>
-// CHECK-NEXT:    affine.store %3, %4[0] : memref<?xi32, 4>
-// CHECK-NEXT:    %5 = sycl.call @read(%1, %4) {MangledFunctionName = @_ZNK4sycl3_V16detail14image_accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS5_6targetE2017ELNS5_11placeholderE0EE4readIiLi1EvEES4_RKT_, TypeName = @image_accessor} : (!llvm.ptr<struct<(ptr<struct<"opencl.image1d_ro_t", opaque>, 1>, array<24 x i8>)>, 4>, memref<?xi32, 4>) -> !sycl_vec_f32_4_
+// CHECK-NEXT:    %memspacecast = memref.memory_space_cast %cast : memref<?xi32> to memref<?xi32, 4>
+// CHECK-NEXT:    affine.store %3, %memspacecast[0] : memref<?xi32, 4>
+// CHECK-NEXT:    %4 = sycl.call @read(%1, %memspacecast) {MangledFunctionName = @_ZNK4sycl3_V16detail14image_accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS5_6targetE2017ELNS5_11placeholderE0EE4readIiLi1EvEES4_RKT_, TypeName = @image_accessor} : (!llvm.ptr<struct<(ptr<struct<"opencl.image1d_ro_t", opaque>, 1>, array<24 x i8>)>, 4>, memref<?xi32, 4>) -> !sycl_vec_f32_4_
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
@@ -10,21 +10,21 @@
 // CHECK-MLIR-SAME:      %arg1: !llvm.ptr<!llvm.struct<(memref<?xi32, 1>)>> {llvm.align = 8 : i64, llvm.byval = !llvm.struct<(memref<?xi32, 1>)>, llvm.noundef}) 
 // CHECK-MLIR-SAME:      kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>
 
-// CHECK-MLIR: sycl.constructor @range(%2, %3) {MangledFunctionName = @_ZN4sycl3_V15rangeILi1EEC1ERKS2_} : (memref<?x!sycl_range_1_, 4>, memref<?x!sycl_range_1_, 4>)
-// CHECK-MLIR: %4 = affine.load %alloca_0[0] : memref<1x!sycl_range_1_>
-// CHECK-MLIR: affine.store %4, %1[0] : memref<?x!sycl_range_1_>
-// CHECK-MLIR: %5 = "polygeist.subindex"(%cast_3, %c1) : (memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>>, index) -> memref<?x!llvm.struct<(memref<?xi32, 4>)>>
-// CHECK-MLIR: %6 = llvm.bitcast %arg1 : !llvm.ptr<!llvm.struct<(memref<?xi32, 1>)>> to !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>>
-// CHECK-MLIR: %7 = llvm.addrspacecast %0 : !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>> to !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>, 4>
-// CHECK-MLIR: %8 = llvm.addrspacecast %6 : !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>> to !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>, 4>
-// CHECK-MLIR: func.call @_ZZ4testRN4sycl3_V15queueEENUlNS0_2idILi1EEEE_C1ERKS5_(%7, %8) : (!llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>, 4>, !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>, 4>) -> ()
-// CHECK-MLIR: %9 = llvm.load %0 : !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>>
-// CHECK-MLIR: affine.store %9, %5[0] : memref<?x!llvm.struct<(memref<?xi32, 4>)>>
-// CHECK-MLIR: %10 = sycl.call @declptr() {MangledFunctionName = @_ZN4sycl3_V16detail7declptrINS0_4itemILi1ELb1EEEEEPT_v} : () -> memref<?x!sycl_item_1_, 4>
-// CHECK-MLIR: %11 = sycl.call @getElement(%10) {MangledFunctionName = @_ZN4sycl3_V16detail7Builder10getElementILi1ELb1EEEDTcl7getItemIXT_EXT0_EEEEPNS0_4itemIXT_EXT0_EEE, TypeName = @Builder} : (memref<?x!sycl_item_1_, 4>) -> !sycl_item_1_
-// CHECK-MLIR: %12 = sycl.addrspacecast %cast_3 : memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>> to memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>, 4>
-// CHECK-MLIR: affine.store %11, %alloca[0] : memref<1x!sycl_item_1_>
-// CHECK-MLIR: sycl.call @"operator()"(%12, %cast) {MangledFunctionName = @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_, TypeName = @RoundedRangeKernel} : (memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>, 4>, memref<?x!sycl_item_1_>) -> ()
+// CHECK-MLIR: sycl.constructor @range(%memspacecast, %memspacecast_4) {MangledFunctionName = @_ZN4sycl3_V15rangeILi1EEC1ERKS2_} : (memref<?x!sycl_range_1_, 4>, memref<?x!sycl_range_1_, 4>)
+// CHECK-MLIR: %2 = affine.load %alloca_0[0] : memref<1x!sycl_range_1_>
+// CHECK-MLIR: affine.store %2, %1[0] : memref<?x!sycl_range_1_>
+// CHECK-MLIR: %3 = "polygeist.subindex"(%cast_3, %c1) : (memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>>, index) -> memref<?x!llvm.struct<(memref<?xi32, 4>)>>
+// CHECK-MLIR: %4 = llvm.bitcast %arg1 : !llvm.ptr<!llvm.struct<(memref<?xi32, 1>)>> to !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>>
+// CHECK-MLIR: %5 = llvm.addrspacecast %0 : !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>> to !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>, 4>
+// CHECK-MLIR: %6 = llvm.addrspacecast %4 : !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>> to !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>, 4>
+// CHECK-MLIR: func.call @_ZZ4testRN4sycl3_V15queueEENUlNS0_2idILi1EEEE_C1ERKS5_(%5, %6) : (!llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>, 4>, !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>, 4>) -> ()
+// CHECK-MLIR: %7 = llvm.load %0 : !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>>
+// CHECK-MLIR: affine.store %7, %3[0] : memref<?x!llvm.struct<(memref<?xi32, 4>)>>
+// CHECK-MLIR: %8 = sycl.call @declptr() {MangledFunctionName = @_ZN4sycl3_V16detail7declptrINS0_4itemILi1ELb1EEEEEPT_v} : () -> memref<?x!sycl_item_1_, 4>
+// CHECK-MLIR: %9 = sycl.call @getElement(%8) {MangledFunctionName = @_ZN4sycl3_V16detail7Builder10getElementILi1ELb1EEEDTcl7getItemIXT_EXT0_EEEEPNS0_4itemIXT_EXT0_EEE, TypeName = @Builder} : (memref<?x!sycl_item_1_, 4>) -> !sycl_item_1_
+// CHECK-MLIR: %memspacecast_5 = memref.memory_space_cast %cast_3 : memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>> to memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>, 4>
+// CHECK-MLIR: affine.store %9, %alloca[0] : memref<1x!sycl_item_1_>
+// CHECK-MLIR: sycl.call @"operator()"(%memspacecast_5, %cast) {MangledFunctionName = @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_, TypeName = @RoundedRangeKernel} : (memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>, 4>, memref<?x!sycl_item_1_>) -> ()
 // CHECK-MLIR: gpu.return
 
 // CHECK-LLVM-LABEL: define weak_odr spir_kernel void @_ZTSN4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EE

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -237,14 +237,6 @@ static void loadDialects(MLIRContext &Ctx, const bool SYCLIsDevice) {
   if (SYCLIsDevice) {
     Ctx.getOrLoadDialect<mlir::sycl::SYCLDialect>();
     Ctx.getOrLoadDialect<mlir::spirv::SPIRVDialect>();
-    // TODO: Use memref.memory_space_cast by default.
-    if (GenerateSYCLAddrSpaceCast.getNumOccurrences() == 0)
-      GenerateSYCLAddrSpaceCast = true;
-  } else if (GenerateSYCLAddrSpaceCast) {
-    CGEIST_WARNING(
-        llvm::WithColor::warning()
-        << "Cannot use sycl.addrspacecast outside of SYCL context\n");
-    GenerateSYCLAddrSpaceCast = false;
   }
 
   LLVM::LLVMPointerType::attachInterface<MemRefInsider>(Ctx);


### PR DESCRIPTION
Generate `memref.memory_space_cast` instead of `sycl.addrspacecast` in `cgeist`.