### PR TITLE
[SYCL][UR][L0] Correct global_mem_size reported

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero.cpp
@@ -693,9 +693,17 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(
     return ReturnValue(uint64_t{Device->ZeDeviceProperties->maxMemAllocSize});
   case UR_DEVICE_INFO_GLOBAL_MEM_SIZE: {
     uint64_t GlobalMemSize = 0;
-    for (const auto &ZeDeviceMemoryExtProperty :
-         Device->ZeDeviceMemoryProperties->second) {
-      GlobalMemSize += ZeDeviceMemoryExtProperty.physicalSize;
+    if (Device->ZeDeviceProperties->flags &
+        ZE_DEVICE_PROPERTY_FLAG_INTEGRATED) {
+      for (const auto &ZeDeviceMemoryProperty :
+           Device->ZeDeviceMemoryProperties->first) {
+        GlobalMemSize += ZeDeviceMemoryProperty.totalSize;
+      }
+    } else {
+      for (const auto &ZeDeviceMemoryExtProperty :
+           Device->ZeDeviceMemoryProperties->second) {
+        GlobalMemSize += ZeDeviceMemoryExtProperty.physicalSize;
+      }
     }
     return ReturnValue(uint64_t{GlobalMemSize});
   }


### PR DESCRIPTION
When reporting memory for integrated devices, report memory from totalSize instead of physicalSize, as L0 GPU Driver reports zero for physicalSize on integrated devices.