### PR TITLE
[SYCL-MLIR] Support sizeof... expressions

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -18,6 +18,7 @@ include "mlir/IR/AttrTypeBase.td"
 
 include "mlir/Dialect/SYCL/IR/SYCLOpInterfaces.td"
 include "mlir/Dialect/LLVMIR/LLVMOpsInterfaces.td"
+include "mlir/Dialect/LLVMIR/LLVMOpBase.td"
 include "mlir/Dialect/MemRef/IR/MemRefBase.td"
 include "mlir/IR/BuiltinTypes.td"
 include "mlir/IR/BuiltinTypeInterfaces.td"
@@ -521,7 +522,8 @@ def ConstructorArgs : AnyTypeOf<[Builtin_Vector,
                                  SYCLMemref,
                                  SYCL_RangeType,
                                  VectorEltTy,
-                                 VectorSplatArg
+                                 VectorSplatArg,
+				 LLVM_PointerTo<LLVM_AnyStruct>
                                ]>;
 def SYCLConstructorOp : SYCL_Op<"constructor", [CallOpInterface]> {
   let summary = "Generic constructor operation";

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -2906,3 +2906,12 @@ ValueCategory MLIRScanner::VisitReal(UnaryOperator *E, QualType PromotionType) {
     return EmitPromotedScalarExpr(Op, PromotionType);
   return Visit(Op);
 }
+
+ValueCategory MLIRScanner::VisitSizeOfPackExpr(SizeOfPackExpr *E) {
+  const auto Loc = getMLIRLocation(E->getExprLoc());
+  const auto Val = E->getPackLength();
+  const auto Ty =
+      Glob.getTypes().getMLIRType(E->getType()).cast<mlir::IntegerType>();
+  return ValueCategory{Builder.create<arith::ConstantIntOp>(Loc, Val, Ty),
+                       /*isReference*/ false};
+}

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -621,6 +621,8 @@ public:
 
   ValueCategory VisitArrayInitIndexExpr(clang::ArrayInitIndexExpr *Expr);
 
+  ValueCategory VisitSizeOfPackExpr(clang::SizeOfPackExpr *E);
+
   ValueCategory CommonFieldLookup(clang::QualType OT,
                                   const clang::FieldDecl *FD, mlir::Value Val,
                                   bool IsLValue);

--- a/polygeist/tools/cgeist/Test/Verification/sizeofpack.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sizeofpack.cpp
@@ -1,0 +1,40 @@
+// RUN: cgeist %s --function=* -S -O0 | FileCheck %s
+
+#include <cstddef>
+
+template <typename... Ts>
+constexpr std::size_t sizeofpack(Ts&&... ts) {
+  return sizeof...(ts);
+}
+
+// CHECK-LABEL:   func.func @_Z10sizeofpackIJEEmDpOT_() -> i64
+// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 0 : i64
+// CHECK-NEXT:      return %[[VAL_0]] : i64
+// CHECK-NEXT:    }
+template std::size_t sizeofpack();
+// CHECK-LABEL:   func.func @_Z10sizeofpackIJiEEmDpOT_(
+// CHECK-SAME:                                         %[[VAL_0:.*]]: memref<?xi32>) -> i64
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      return %[[VAL_1]] : i64
+// CHECK-NEXT:    }
+template std::size_t sizeofpack(int&&);
+// CHECK-LABEL:   func.func @_Z10sizeofpackIJiDnEEmDpOT_(
+// CHECK-SAME:                                           %[[VAL_0:.*]]: memref<?xi32>,
+// CHECK-SAME:                                           %[[VAL_1:.*]]: memref<?xmemref<?xi8>>) -> i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 2 : i64
+// CHECK-NEXT:      return %[[VAL_2]] : i64
+// CHECK-NEXT:    }
+template std::size_t sizeofpack(int&&, std::nullptr_t&&);
+// CHECK-LABEL:   func.func @_Z10sizeofpackIJiiEEmDpOT_(
+// CHECK-SAME:                                          %[[VAL_0:.*]]: memref<?xi32>,
+// CHECK-SAME:                                          %[[VAL_1:.*]]: memref<?xi32>) -> i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 2 : i64
+// CHECK-NEXT:      return %[[VAL_2]] : i64
+// CHECK-NEXT:    }
+template std::size_t sizeofpack(int&&, int&&);
+// CHECK-LABEL:   func.func @_Z10sizeofpackIJiifEEmDpOT_(
+// CHECK-SAME:                                           %[[VAL_0:.*]]: memref<?xi32>, %[[VAL_1:.*]]: memref<?xi32>, %[[VAL_2:.*]]: memref<?xf32>) -> i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 3 : i64
+// CHECK-NEXT:      return %[[VAL_3]] : i64
+// CHECK-NEXT:    }
+template std::size_t sizeofpack(int&&, int&&, float&&);


### PR DESCRIPTION
Generate an arith.constant with the pack length as a value.