### PR TITLE
[SYCL-MLIR][NFC] Replace deprecated header with new one

### DIFF
--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -2615,7 +2615,6 @@ MLIRASTConsumer::getMLIRFunction(const std::string &MangledName,
 }
 
 #include "clang/Frontend/FrontendAction.h"
-#include "llvm/Support/Host.h"
 
 class MLIRAction : public clang::ASTFrontendAction {
 public:

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -54,12 +54,12 @@
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Passes/StandardInstrumentations.h"
 #include "llvm/Support/FileSystem.h"
-#include "llvm/Support/Host.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/LLVMDriver.h"
 #include "llvm/Support/Program.h"
 #include "llvm/Support/Regex.h"
 #include "llvm/Support/WithColor.h"
+#include "llvm/TargetParser/Host.h"
 
 #include "Options.h"
 #include "mlir/Dialect/Polygeist/IR/Polygeist.h"


### PR DESCRIPTION
Fix warning:

    This header is deprecated, please use llvm/TargetParser/Host.h