### PR TITLE
[SYCL-MLIR] Drop sycl.constructor variadic arguments constraint

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -523,7 +523,7 @@ def SYCLConstructorOp : SYCL_Op<"constructor", [CallOpInterface]> {
 
   let arguments = (ins
     Arg<SYCLMemref, "The SYCL object being created", [MemWrite]>:$Dst,
-    Arg<Variadic<AnyType>, "The constructor arguments", [MemRead, MemWrite]>:$Args,
+    Arg<Variadic<AnyType>, "The constructor arguments">:$Args,
     FlatSymbolRefAttr:$TypeName,
     FlatSymbolRefAttr:$MangledFunctionName
   );

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -523,7 +523,7 @@ def SYCLConstructorOp : SYCL_Op<"constructor", [CallOpInterface]> {
 
   let arguments = (ins
     Arg<SYCLMemref, "The SYCL object being created", [MemWrite]>:$Dst,
-    Arg<Variadic<AnyType>, "The constructor arguments", [MemRead]>:$Args,
+    Variadic<AnyType>:$Args,
     FlatSymbolRefAttr:$TypeName,
     FlatSymbolRefAttr:$MangledFunctionName
   );

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -515,14 +515,6 @@ def SYCLSubGroupLocalIDOp : SYCL1DGridOp<"sub_group_local_id"> {
 // CONSTRUCTOR OPERATION
 ////////////////////////////////////////////////////////////////////////////////
 
-def ConstructorArgs : AnyTypeOf<[Builtin_Vector,
-                                 IndexType,
-                                 SYCL_IDType,
-                                 SYCLMemref,
-                                 SYCL_RangeType,
-                                 VectorEltTy,
-                                 VectorSplatArg
-                               ]>;
 def SYCLConstructorOp : SYCL_Op<"constructor", [CallOpInterface]> {
   let summary = "Generic constructor operation";
   let description = [{
@@ -531,7 +523,7 @@ def SYCLConstructorOp : SYCL_Op<"constructor", [CallOpInterface]> {
 
   let arguments = (ins
     Arg<SYCLMemref, "The SYCL object being created", [MemWrite]>:$Dst,
-    Variadic<ConstructorArgs>:$Args,  
+    Arg<Variadic<AnyType>, "The constructor arguments", [MemRead]>:$Args,
     FlatSymbolRefAttr:$TypeName,
     FlatSymbolRefAttr:$MangledFunctionName
   );

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -523,7 +523,7 @@ def SYCLConstructorOp : SYCL_Op<"constructor", [CallOpInterface]> {
 
   let arguments = (ins
     Arg<SYCLMemref, "The SYCL object being created", [MemWrite]>:$Dst,
-    Variadic<AnyType>:$Args,
+    Arg<Variadic<AnyType>, "The constructor arguments", [MemRead, MemWrite]>:$Args,
     FlatSymbolRefAttr:$TypeName,
     FlatSymbolRefAttr:$MangledFunctionName
   );


### PR DESCRIPTION
Drop type constraint, allowing any type for every argument but the first one.