### PR TITLE
[SYCL-MLIR] Move alloca to the beginning of function

### DIFF
--- a/mlir-sycl/lib/Transforms/Inliner.cpp
+++ b/mlir-sycl/lib/Transforms/Inliner.cpp
@@ -701,14 +701,6 @@ bool Inliner::inlineCallsInSCC(Inliner &Inliner, CGUseList &UseList,
     DidSomething = true;
     ++NumInlinedCalls;
 
-    // Move all AllocaOp to the beginning of the caller function.
-    Operation *nextOp = ResolvedCall.Call->getNextNode();
-    Operation *firstOp = &getFunction(*ResolvedCall.SrcNode).front().front();
-    while (auto alloca = dyn_cast<memref::AllocaOp>(nextOp)) {
-      nextOp = alloca->getNextNode();
-      alloca->moveBefore(firstOp);
-    }
-
     // Merge the new uses into the source node.
     UseList.dropCallUses(ResolvedCall.SrcNode, ResolvedCall.Call.getOperation(),
                          Inliner.getCG());

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -830,9 +830,9 @@ forwardPassthroughAttributes(Location loc, std::optional<ArrayAttr> attributes,
 
 // This function moves all AllocaOp (and its operands) to the beginning of the
 // function.
-static bool moveAllocaToTop(LLVMFuncOp func) {
+static void moveAllocaToTop(LLVMFuncOp func) {
   if (func.getBody().empty())
-    return false;
+    return;
 
   llvm::SetVector<Operation *> ops;
   func.walk([&ops](LLVM::AllocaOp allocaOp) {
@@ -854,8 +854,6 @@ static bool moveAllocaToTop(LLVMFuncOp func) {
       op->moveAfter(prevOp);
     prevOp = op;
   }
-
-  return !ops.empty();
 }
 
 LogicalResult ModuleTranslation::convertOneFunction(LLVMFuncOp func) {

--- a/polygeist/tools/cgeist/Test/CMakeLists.txt
+++ b/polygeist/tools/cgeist/Test/CMakeLists.txt
@@ -9,13 +9,14 @@ configure_lit_site_cfg(
 )
 
 list(APPEND MLIR_CLANG_TEST_DEPS
+  cgeist
+  clang
+  FileCheck count not
   llvm-config 
   llvm-dis
-  FileCheck count not
-  cgeist
-  split-file
-  clang
+  mlir-translate
   opt
+  split-file
   sycl-toolchain
   )
 

--- a/polygeist/tools/cgeist/Test/Verification/move_alloca_to_top.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/move_alloca_to_top.cpp
@@ -1,0 +1,16 @@
+// RUN: mlir-translate -mlir-to-llvmir -split-input-file -verify-diagnostics %s | FileCheck %s
+
+// CHECK-LABEL: define void @move_alloca(float* %0) {
+// CHECK-DAG:     %{{.*}} = alloca float, i8 1, align 4
+// CHECK-DAG:     %{{.*}} = alloca float, i8 1, align 4
+// CHECK-NEXT:    %4 = load float, float* %0, align 4
+// CHECK-NEXT:    ret void
+// CHECK-NEXT:  }
+
+llvm.func @move_alloca(%arg0: !llvm.ptr<f32>) {
+    %0 = llvm.load %arg0 : !llvm.ptr<f32>
+    %1 = llvm.mlir.constant(1 : i8) : i8
+    %2 = llvm.alloca %1 x f32 : (i8) -> !llvm.ptr<f32>
+    %3 = llvm.alloca %1 x f32 : (i8) -> !llvm.ptr<f32>
+    llvm.return
+}


### PR DESCRIPTION
`Basic/linear-sub_group.cpp` fails when not all `AllocaOp`s are in the beginning of functions.
We moved `memref::AllocaOp`s to the beginning of caller functions in Inliner pass, but it only works for `AllocaOp` in `memref` dialect and only when the problem is exposed from Inliner pass.

This PR removed the inliner code that moves alloca operations, and adds a new utility function to move `LLVM::AllocaOp` right before emitting LLVM IR. AFAIK there are no limitations in LLVM IR that require alloca operation to be at the top of a function. This is just a limitation of the LLVM to SPIRV translator. 

This is therefore a workaround that should be removed once the translator is able to tollerate alloca operation in the middle of a function. 