### PR TITLE
[SYCL] Fix dumping of images for multiple targets

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1257,6 +1257,12 @@ void ProgramManager::addImages(pi_device_binaries DeviceBinary) {
       if (KSIdIt != KSIdMap.end()) {
         auto &Imgs = m_DeviceImages[KSIdIt->second];
         assert(Imgs && "Device image vector should have been already created");
+        // If the images differ in target format, the dumping is necessary.
+        if (DumpImages &&
+            !std::all_of(Imgs->begin(), Imgs->end(), [&](auto &I) {
+              return I->getFormat() == Img->getFormat();
+            }))
+          dumpImage(*Img, KSIdIt->second);
 
         cacheKernelUsesAssertInfo(M, *Img);
 

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1258,8 +1258,13 @@ void ProgramManager::addImages(pi_device_binaries DeviceBinary) {
       if (KSIdIt != KSIdMap.end()) {
         auto &Imgs = m_DeviceImages[KSIdIt->second];
         assert(Imgs && "Device image vector should have been already created");
-        if (DumpImages)
-          dumpImage(*Img, KSIdIt->second, ++SequenceID);
+        if (DumpImages) {
+          const bool NeedsSequenceID =
+              std::any_of(Imgs->begin(), Imgs->end(), [&](auto &I) {
+                return I->getFormat() == Img->getFormat();
+              });
+          dumpImage(*Img, KSIdIt->second, NeedsSequenceID ? ++SequenceID : 0);
+        }
 
         cacheKernelUsesAssertInfo(M, *Img);
 

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1258,7 +1258,6 @@ void ProgramManager::addImages(pi_device_binaries DeviceBinary) {
       if (KSIdIt != KSIdMap.end()) {
         auto &Imgs = m_DeviceImages[KSIdIt->second];
         assert(Imgs && "Device image vector should have been already created");
-        // If the images differ in target format, the dumping is necessary.
         if (DumpImages)
           dumpImage(*Img, KSIdIt->second, ++SequenceID);
 

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -299,7 +299,8 @@ private:
   KernelSetId getKernelSetId(OSModuleHandle M,
                              const std::string &KernelName) const;
   /// Dumps image to current directory
-  void dumpImage(const RTDeviceBinaryImage &Img, KernelSetId KSId) const;
+  void dumpImage(const RTDeviceBinaryImage &Img, KernelSetId KSId,
+                 uint32_t SequenceID = 0) const;
 
   /// Add info on kernels using assert into cache
   void cacheKernelUsesAssertInfo(OSModuleHandle M, RTDeviceBinaryImage &Img);


### PR DESCRIPTION
This was identified by the Unified Runtime team, depending on the target order in `-fsycl-targets` certain binaries are not dumped.
```
-fsycl-targets=nvptx64-nvidia-cuda,spir64

├── sycl_nvptx641.bin
├── sycl_spir642.spv
└── sycl_spir643.spv
```
```
-fsycl-targets=spir64,nvptx64-nvidia-cuda

├── sycl_spir641.spv
├── sycl_spir642.spv
└── sycl_spir643.spv
```
This patch makes sure that if a kernel is compiled for multiple targets, images belonging to different targets will be dumped.