### PR TITLE
[SYCL][Reduction] Fix range reductions after work restrictions

### DIFF
--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -2119,7 +2119,6 @@ void reduCGFuncMulti(handler &CGH, KernelType KernelFunc,
                      std::tuple<Reductions...> &ReduTuple,
                      std::index_sequence<Is...> ReduIndices) {
   size_t WGSize = Range.get_local_range().size();
-  size_t NWorkItems = Range.get_group_range().size();
 
   // Ignore active items to avoid warnings when uncaptured.
   std::ignore = ActiveItemsPerWG;


### PR DESCRIPTION
This commit fixes an issue where range reductions would potentially supply less work than the work group size while the reduction algorithm assuming the exact same number of items as work.