### PR TITLE
[SYCL] Allow const device_global

### DIFF
--- a/sycl/include/sycl/ext/oneapi/device_global/device_global.hpp
+++ b/sycl/include/sycl/ext/oneapi/device_global/device_global.hpp
@@ -44,7 +44,7 @@ template <typename T, typename PropertyListT, typename = void>
 class device_global_base {
 protected:
   using pointer_t = typename decorated_global_ptr<T>::pointer;
-  pointer_t usmptr;
+  pointer_t usmptr{};
   pointer_t get_ptr() noexcept { return usmptr; }
   const pointer_t get_ptr() const noexcept { return usmptr; }
 

--- a/sycl/test/regression/device_global_const.cpp
+++ b/sycl/test/regression/device_global_const.cpp
@@ -1,0 +1,11 @@
+// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s
+// expected-no-diagnostics
+
+#include <sycl/sycl.hpp>
+
+namespace experimental = sycl::ext::oneapi::experimental;
+
+const experimental::device_global<int> DeviceGlobal;
+const experimental::device_global<int, decltype(experimental::properties{
+                                           experimental::device_image_scope})>
+    ScopedDeviceGlobal;


### PR DESCRIPTION
This commit default constructs the USM pointer member of a device_global without the device_image_scope property. This fixes an issue where the compiler would disallow device_global from being const.