### PR TITLE
[SYCL] Throw right errc for work_group_size query

### DIFF
--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -168,7 +168,7 @@ set(SYCL_SOURCES
     "detail/device_global_map.cpp"
     "detail/device_global_map_entry.cpp"
     "detail/device_impl.cpp"
-    "detail/error_handling/enqueue_kernel.cpp"
+    "detail/error_handling/error_handling.cpp"
     "detail/event_impl.cpp"
     "detail/filter_selector_impl.cpp"
     "detail/fusion/fusion_wrapper.cpp"

--- a/sycl/source/detail/error_handling/error_handling.cpp
+++ b/sycl/source/detail/error_handling/error_handling.cpp
@@ -362,7 +362,8 @@ void handleErrorOrWarning(pi_result Error, const device_impl &DeviceImpl,
 } // namespace detail::enqueue_kernel_launch
 
 namespace detail::kernel_get_group_info {
-void handleErrorOrWarning(pi_result Error, pi_kernel_group_info Descriptor) {
+void handleErrorOrWarning(pi_result Error, pi_kernel_group_info Descriptor,
+                          const plugin &Plugin) {
   assert(Error != PI_SUCCESS &&
          "Success is expected to be handled on caller side");
   switch (Error) {

--- a/sycl/source/detail/error_handling/error_handling.cpp
+++ b/sycl/source/detail/error_handling/error_handling.cpp
@@ -376,8 +376,8 @@ void handleErrorOrWarning(pi_result Error, pi_kernel_group_info Descriptor) {
     break;
   // TODO: Handle other error codes
   default:
-    throw runtime_error(
-        "Native API failed. Native API returns: " + codeToString(Error), Error);
+    Plugin.checkPiResult(Error);
+    break;
   }
 }
 } // namespace detail::kernel_get_group_info

--- a/sycl/source/detail/error_handling/error_handling.cpp
+++ b/sycl/source/detail/error_handling/error_handling.cpp
@@ -358,27 +358,29 @@ void handleErrorOrWarning(pi_result Error, const device_impl &DeviceImpl,
         "Native API failed. Native API returns: " + codeToString(Error), Error);
   }
 }
+
 } // namespace detail::enqueue_kernel_launch
 
 namespace detail::kernel_get_group_info {
-  void handleErrorOrWarning(pi_result Error, pi_kernel_group_info Descriptor) {
-    assert(Error != PI_SUCCESS && "Success is expected to be handled on caller side");
-    switch (Error) {
-    case PI_ERROR_INVALID_VALUE:
-      if (Descriptor == CL_KERNEL_GLOBAL_WORK_SIZE)
-        throw sycl::exception(
+void handleErrorOrWarning(pi_result Error, pi_kernel_group_info Descriptor) {
+  assert(Error != PI_SUCCESS &&
+         "Success is expected to be handled on caller side");
+  switch (Error) {
+  case PI_ERROR_INVALID_VALUE:
+    if (Descriptor == CL_KERNEL_GLOBAL_WORK_SIZE)
+      throw sycl::exception(
           sycl::make_error_code(errc::invalid),
           "info::kernel_device_specific::global_work_size descriptor may only "
           "be used if the device type is device_type::custom or if the kernel "
           "is a built-in kernel.");
-      break;
-    // TODO: Handle other error codes
-    default:
-      throw runtime_error(
-          "Native API failed. Native API returns: " + codeToString(Error), Error);
-    }
+    break;
+  // TODO: Handle other error codes
+  default:
+    throw runtime_error(
+        "Native API failed. Native API returns: " + codeToString(Error), Error);
   }
-} // namespace kernel_get_group_info
+}
+} // namespace detail::kernel_get_group_info
 
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/source/detail/error_handling/error_handling.cpp
+++ b/sycl/source/detail/error_handling/error_handling.cpp
@@ -358,7 +358,27 @@ void handleErrorOrWarning(pi_result Error, const device_impl &DeviceImpl,
         "Native API failed. Native API returns: " + codeToString(Error), Error);
   }
 }
-
 } // namespace detail::enqueue_kernel_launch
+
+namespace detail::kernel_get_group_info {
+  void handleErrorOrWarning(pi_result Error, pi_kernel_group_info Descriptor) {
+    assert(Error != PI_SUCCESS && "Success is expected to be handled on caller side");
+    switch (Error) {
+    case PI_ERROR_INVALID_VALUE:
+      if (Descriptor == CL_KERNEL_GLOBAL_WORK_SIZE)
+        throw sycl::exception(
+          sycl::make_error_code(errc::invalid),
+          "info::kernel_device_specific::global_work_size descriptor may only "
+          "be used if the device type is device_type::custom or if the kernel "
+          "is a built-in kernel.");
+      break;
+    // TODO: Handle other error codes
+    default:
+      throw runtime_error(
+          "Native API failed. Native API returns: " + codeToString(Error), Error);
+    }
+  }
+} // namespace kernel_get_group_info
+
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/source/detail/error_handling/error_handling.hpp
+++ b/sycl/source/detail/error_handling/error_handling.hpp
@@ -29,6 +29,11 @@ void handleErrorOrWarning(pi_result, const device_impl &, pi_kernel,
                           const NDRDescT &);
 } // namespace enqueue_kernel_launch
 
+namespace kernel_get_group_info {
+/// Analyzes error code of piKernelGetGroupInfo.
+void handleErrorOrWarning(pi_result, pi_kernel_group_info);
+} // namespace kernel_get_group_info
+
 } // namespace detail
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/source/detail/error_handling/error_handling.hpp
+++ b/sycl/source/detail/error_handling/error_handling.hpp
@@ -31,7 +31,7 @@ void handleErrorOrWarning(pi_result, const device_impl &, pi_kernel,
 
 namespace kernel_get_group_info {
 /// Analyzes error code of piKernelGetGroupInfo.
-void handleErrorOrWarning(pi_result, pi_kernel_group_info);
+void handleErrorOrWarning(pi_result, pi_kernel_group_info, const plugin &);
 } // namespace kernel_get_group_info
 
 } // namespace detail

--- a/sycl/source/detail/kernel_info.hpp
+++ b/sycl/source/detail/kernel_info.hpp
@@ -75,8 +75,8 @@ get_kernel_device_specific_info_helper(RT::PiKernel Kernel, RT::PiDevice Device,
   RT::PiResult Error = Plugin.call_nocheck<PiApiKind::piKernelGetGroupInfo>(
       Kernel, Device, PiInfoCode<Param>::value, Size, Result, nullptr);
   if (Error != PI_SUCCESS)
-    kernel_get_group_info::handleErrorOrWarning(Error,
-                                                PiInfoCode<Param>::value);
+    kernel_get_group_info::handleErrorOrWarning(Error, PiInfoCode<Param>::value,
+                                                Plugin);
 }
 
 template <typename Param>

--- a/sycl/source/detail/kernel_info.hpp
+++ b/sycl/source/detail/kernel_info.hpp
@@ -79,7 +79,8 @@ get_kernel_device_specific_info_helper(RT::PiKernel Kernel, RT::PiDevice Device,
     // CL_KERNEL_GLOBAL_WORK_SIZE and device is not a custom device and kernel
     // is not a built-in kernel. According to SYCL2020 an exception with the
     // errc::invalid error code should be thrown.
-    if (e.get_cl_code() == PI_ERROR_INVALID_VALUE)
+    std::string msg = e.what();
+    if (msg.find("PI_ERROR_INVALID_VALUE") != std::string::npos)
       throw sycl::exception(
           sycl::make_error_code(errc::invalid),
           "info::kernel_device_specific::global_work_size descriptor may only "

--- a/sycl/source/detail/kernel_info.hpp
+++ b/sycl/source/detail/kernel_info.hpp
@@ -71,22 +71,19 @@ typename std::enable_if<!IsSubGroupInfo<Param>::value>::type
 get_kernel_device_specific_info_helper(RT::PiKernel Kernel, RT::PiDevice Device,
                                        const plugin &Plugin, void *Result,
                                        size_t Size) {
-  try {
-    Plugin.call<PiApiKind::piKernelGetGroupInfo>(
-        Kernel, Device, PiInfoCode<Param>::value, Size, Result, nullptr);
-  } catch (sycl::exception &e) {
-    // clGetKernelWorkGroupInfo returns CL_INVALID_VALUE if param_name is
-    // CL_KERNEL_GLOBAL_WORK_SIZE and device is not a custom device and kernel
-    // is not a built-in kernel. According to SYCL2020 an exception with the
-    // errc::invalid error code should be thrown.
-    std::string msg = e.what();
-    if (msg.find("PI_ERROR_INVALID_VALUE") != std::string::npos)
-      throw sycl::exception(
-          sycl::make_error_code(errc::invalid),
-          "info::kernel_device_specific::global_work_size descriptor may only "
-          "be used if the device type is device_type::custom or if the kernel "
-          "is a built-in kernel.");
-  }
+  RT::PiResult Err = Plugin.call_nocheck<PiApiKind::piKernelGetGroupInfo>(
+      Kernel, Device, PiInfoCode<Param>::value, Size, Result, nullptr);
+  // clGetKernelWorkGroupInfo returns CL_INVALID_VALUE if param_name is
+  // CL_KERNEL_GLOBAL_WORK_SIZE and device is not a custom device and kernel
+  // is not a built-in kernel. According to SYCL2020 an exception with the
+  // errc::invalid error code should be thrown.
+  if (Err == PI_ERROR_INVALID_VALUE)
+    throw sycl::exception(
+        sycl::make_error_code(errc::invalid),
+        "info::kernel_device_specific::global_work_size descriptor may only "
+        "be used if the device type is device_type::custom or if the kernel "
+        "is a built-in kernel.");
+  Plugin.checkPiResult(Err);
 }
 
 template <typename Param>


### PR DESCRIPTION
clGetKernelWorkGroupInfo returns CL_INVALID_VALUE if param_name is CL_KERNEL_GLOBAL_WORK_SIZE and device is not a custom device and kernel is not a built-in kernel. According to SYCL2020 an exception with the errc::invalid error code should be thrown.