### PR TITLE
[SYCL-Fusion] Fix shared lib build

### DIFF
--- a/sycl-fusion/common/CMakeLists.txt
+++ b/sycl-fusion/common/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_llvm_library(sycl-fusion-common
   lib/NDRangesHelper.cpp
+
+  LINK_COMPONENTS
+   Support
 )
 
 target_include_directories(sycl-fusion-common


### PR DESCRIPTION
Shared lib build fails due to a missing dep.