### PR TITLE
[CODEOWNER] Update unified runtime plug-in code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,9 @@ sycl/doc/extensions/ @intel/dpcpp-specification-reviewers
 # Level Zero plugin
 sycl/plugins/level_zero/ @intel/dpcpp-l0-pi-reviewers
 
+# Unified Runtime plugin
+sycl/plugins/unified_runtime/ @intel/dpcpp-l0-pi-reviewers
+
 # ESIMD CPU emulator plug-in
 sycl/plugins/esimd_emulator/ @intel/dpcpp-esimd-reviewers
 


### PR DESCRIPTION
Make @intel/dpcpp-l0-pi-reviewers the owner of UR while it is not moved into a separate repo.