### PR TITLE
[SYCL] Disable errors from warnings while building the Unified Runtime

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -12,15 +12,11 @@ if (NOT DEFINED UNIFIED_RUNTIME_LIBRARY OR NOT DEFINED UNIFIED_RUNTIME_INCLUDE_D
     GIT_TAG           ${UNIFIED_RUNTIME_TAG}
   )
 
-  # Disable some compilation options to avoid errors while building the UR.
+  # Disable errors from warnings while building the UR.
   # And remember origin flags before doing that.
   set(CMAKE_CXX_FLAGS_BAK "${CMAKE_CXX_FLAGS}")
   if (UNIX)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-variable")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-pedantic")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-stringop-truncation")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-suggest-override")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error")
   endif()
 
   FetchContent_GetProperties(unified-runtime)


### PR DESCRIPTION
Currently we disable warnings using specific set of options, some of them are supported by GCC only. Also new warnings may appear in the future and they will cause build failures and require another specific options.

So just use more generic  -Wno-error option instead to ignore all warnings because unified runtime is external project.