### PR TITLE
[SYCL-MLIR] Drop CallOpInterface trait from SYCLMethodOpInterfaceImpl

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -84,7 +84,7 @@ class SYCL_Op<string mnemonic, list<Trait> traits = []>
 
 class SYCLMethodOpInterfaceImpl<
     string mnemonic, string type, list<string> methodNames, list<Trait> traits = []>
-        : SYCL_Op<mnemonic, !listconcat(traits, [SYCLMethodOpInterface, CallOpInterface])> {
+        : SYCL_Op<mnemonic, !listconcat(traits, [SYCLMethodOpInterface])> {
   string baseType = type;
   list<string> memberFunctionNames = methodNames;
   int arrSize = !size(memberFunctionNames);

--- a/mlir-sycl/lib/Transforms/Inliner.cpp
+++ b/mlir-sycl/lib/Transforms/Inliner.cpp
@@ -741,8 +741,6 @@ void Inliner::collectCallOps(CallGraphNode &SrcNode, CallGraph &CG,
     case sycl::InlineMode::Ludicrous:
       return true;
     case sycl::InlineMode::Aggressive:
-      return isa<sycl::SYCLCallOp, sycl::SYCLConstructorOp,
-                 sycl::SYCLMethodOpInterface>(Call);
     case sycl::InlineMode::Simple:
       return isa<sycl::SYCLCallOp, sycl::SYCLConstructorOp>(Call);
     case sycl::InlineMode::AlwaysInline:


### PR DESCRIPTION
We don't want these to be treated as functions anymore, e.g., no inlining. These are now independent operations.