### PR TITLE
[SYCL][Doc] Graph fusion extension proposal

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_codeplay_kernel_fusion.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_codeplay_kernel_fusion.asciidoc
@@ -49,6 +49,16 @@ incompatible ways before it is finalized.  *Shipping software products should
 not rely on APIs defined in this specification.*
 
 [NOTE]
+====
+There is a link:../proposed/sycl_ext_oneapi_graph_fusion.asciidoc[follow-up
+proposal] for fusion based on the SYCL graph API. That proposal continues some
+of the ideas presented in this proposal, but uses the more versatile SYCL graphs
+API to define the sequence of kernels to execute. 
+
+Once accepted and implemented, the new proposal will supersede this proposal.
+====
+
+[NOTE]
 ==== 
 This is an experimental extension for the SYCL specification.
 Exceptions while in fusion mode can leave a `queue` in an unknown fusion state,

--- a/sycl/doc/extensions/experimental/sycl_ext_codeplay_kernel_fusion.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_codeplay_kernel_fusion.asciidoc
@@ -51,9 +51,10 @@ not rely on APIs defined in this specification.*
 [NOTE]
 ====
 There is a link:../proposed/sycl_ext_oneapi_graph_fusion.asciidoc[follow-up
-proposal] for fusion based on the SYCL graph API. That proposal continues some
-of the ideas presented in this proposal, but uses the more versatile SYCL graphs
-API to define the sequence of kernels to execute. 
+proposal] for fusion based on the https://github.com/intel/llvm/pull/5626[SYCL
+graph API]. That proposal continues some of the ideas presented in this
+proposal, but uses the more versatile SYCL graphs API to define the sequence of
+kernels to execute.
 
 Once accepted and implemented, the new proposal will supersede this proposal.
 ====

--- a/sycl/doc/extensions/experimental/sycl_ext_codeplay_kernel_fusion.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_codeplay_kernel_fusion.asciidoc
@@ -51,10 +51,11 @@ not rely on APIs defined in this specification.*
 [NOTE]
 ====
 There is a link:../proposed/sycl_ext_oneapi_graph_fusion.asciidoc[follow-up
-proposal] for fusion based on the https://github.com/intel/llvm/pull/5626[SYCL
-graph API]. That proposal continues some of the ideas presented in this
-proposal, but uses the more versatile SYCL graphs API to define the sequence of
-kernels to execute.
+proposal] for fusion based on the 
+https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc[SYCL graph API].
+That proposal continues some of the ideas presented in this proposal, but uses
+the more versatile SYCL graphs API to define the sequence of kernels to
+execute.
 
 Once accepted and implemented, the new proposal will supersede this proposal.
 ====

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -1207,7 +1207,7 @@ The `sycl::ext::codeplay::experimental::property::queue::enable_fusion` property
 defined by the extension is ignored by queue recording.
 
 To enable kernel fusion in a `command_graph` see the
-https://github.com/sommerlukas/llvm/blob/proposal/graph-fusion/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc[sycl_ext_oneapi_graph_fusion extension proposal]
+link:../proposed/sycl_ext_oneapi_graph_fusion.asciidoc[sycl_ext_oneapi_graph_fusion extension proposal]
 which is layered ontop of `sycl_ext_oneapi_graph`.
 
 ==== sycl_ext_oneapi_kernel_properties

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph_fusion.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph_fusion.asciidoc
@@ -1,0 +1,634 @@
+= sycl_ext_oneapi_graph_fusion
+
+:source-highlighter: coderay
+:coderay-linenums-mode: table
+
+// This section needs to be after the document title.
+:doctype: book
+:toc2:
+:toc: left
+:encoding: utf-8
+:lang: en
+:dpcpp: pass:[DPC++]
+:stem: asciimath
+
+// Set the default source code type in this document to C++,
+// for syntax highlighting purposes.  This is needed because
+// docbook uses c++ and html5 uses cpp.
+:language: {basebackend@docbook:c++:cpp}
+
+
+== 1. Notice
+
+[%hardbreaks]
+Copyright (C) Codeplay Software Limited.  All rights reserved.
+
+Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
+of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by
+permission by Khronos.
+
+
+== 2. Contact
+
+To report problems with this extension, please open a new issue at:
+
+https://github.com/intel/llvm/issues
+
+
+== 3. Dependencies
+
+This extension is written against the SYCL 2020 revision 6 specification.  All
+references below to the "core SYCL specification" or to section numbers in the
+SYCL specification refer to that revision.
+
+This extension builds on top of the proposed SYCL graphs
+https://github.com/reble/llvm/blob/sycl-graph-update/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc[extension
+proposal]. All references to the "graphs proposal" refer to this proposal.
+
+== 4. Status
+
+This is a proposed extension specification, intended to gather community
+feedback.  Interfaces defined in this specification may not be implemented yet
+or may be in a preliminary state.  The specification itself may also change in
+incompatible ways before it is finalized.  *Shipping software products should
+not rely on APIs defined in this specification.*
+
+== 5. Overview
+
+The SYCL graph
+https://github.com/reble/llvm/blob/sycl-graph-update/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc[extension
+proposal] seeks to reduce the runtime overhead linked to SYCL kernel submission
+and expose additional optimization opportunities. 
+
+One of those further optimizations enabled by the graphs proposal is _kernel
+fusion_. Fusing two or more kernels executing on the same device into a single
+kernel launch can further reduce runtime overhead and enable futher kernel
+optimizations such as dataflow internalization discussed below.
+
+This proposal is a continuation of many of the ideas of the initial
+https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_codeplay_kernel_fusion.asciidoc[experimental
+kernel fusion proposal] for SYCL. However, instead of defining its own
+SYCL-based API to record a sequence of kernels to fuse, this proposal builds on
+top of the graphs proposal to allow the fusion of graphs. This not only unifies
+the APIs, making sure users only need to familiarize themselves with a single
+API, but also provides additional advantages. 
+
+The graph proposal defines two APIs to create graphs: a proposal using a
+recording mechanism, similar to the initial kernel fusion proposal; and another
+one using explicit graph building. Thus, future users will be able to choose
+from two different mechanisms to construct the sequence of kernels to fuse. As
+there is an explicit step for finalization of graphs before being submitted for
+execution, the fusion step can happen asynchronously and also eliminates many of
+the synchronization concerns that needed to be covered in the experimental
+kernel fusion proposal.
+
+The aim of this document is to propose a mechanism for users to request the
+fusion of two or more kernels in a SYCL graph into a single kernel **at
+runtime**. This requires the extension of the runtime with some sort of JIT
+compiler to allow for the fusion of kernel functions at runtime.
+
+== 6. Specification
+
+=== 6.1. Feature test macro
+
+This extension provides a feature-test macro as described in the core SYCL
+specification.  An implementation supporting this extension must predefine the
+macro `SYCL_EXT_ONEAPI_GRAPH_FUSION` to one of the values defined in the
+table below.  Applications can test for the existence of this macro to determine
+if the implementation supports this feature, or applications can test the
+macro's value to determine which of the extension's features the implementation
+supports.
+
+[%header,cols="1,5"]
+|===
+|Value
+|Description
+
+|1
+|Initial version of this extension.
+|===
+
+=== 6.2. API modifications
+
+==== 6.2.1. Properties
+
+===== 6.2.1.1. Graph Fusion Property
+
+The API for `command_graph<graph_state::modifiable>::finalize()` includes a
+`property_list` parameter. The following property, defined by this extension,
+can be added to the property list to indicate that the kernels in the
+command-graph should be fused. 
+
+```c++
+sycl::ext::oneapi::experimental::property::command_graph::perform_fusion 
+```
+
+The property is not prescriptive. Implementations are free to not perform fusion
+if it is not possible (see below section <<_6_5_limitations>>), fusion is not
+supported by the implementation, or the implementation decides not to perform
+fusion for other reasons. It is not an error if an implementation does not
+perform fusion even though the property is passed. 
+
+Implementations can provide a diagnostic message in case fusion was not
+performed through an implementation-specified mechanism, but are not required to
+do so.
+
+===== 6.2.1.2. Barrier property
+
+The following property can be added to the `property_list` of the
+`command_graph<graph_state::modifiable>::finalize()` API.
+
+```c++
+sycl::ext::oneapi::experimental::property::command_graph::no_barriers
+```
+
+If the property list contains this property, no barriers are introduced between
+kernels in the fused kernel (see below section on synchronization on kernels). 
+
+The property only takes effect if the
+`sycl::ext::oneapi::experimental::property::command_graph::perform_fusion`
+property is also part of the `property_list` of the same invocation of
+`command_graph<...>::finalize()`. 
+
+===== 6.2.1.3. Local internalization property
+
+The following property can be passed to three different APIs, namely:
+
+* The `accessor` constructor, giving a more granular control
+* The `buffer` constructor, in which case all the `accessors` derived from 
+this buffer will inherit this property (unless overridden).
+* The `property_list` parameter of 
+`command_graph<graph_state::modifiable>::add_malloc_device()` to apply the 
+property to an USM pointer.
+
+```c++ 
+sycl::ext::oneapi::experimental::property::promote_local 
+```
+
+This property is an assertion by the application that each element in the buffer
+or allocated device memory is accessed by no more than one work-group in the
+kernel submitted by this command-group (in case the property is specified on an
+accessor) or in any kernel in the graph (in case the property is specified on a
+buffer or an USM pointer). Implementations may treat this as a hint to promote
+the elements of the buffer or allocated device memory to local memory (see below
+section on local and private internalization).
+
+The application also asserts that the updates made to the buffer or allocated
+device memory by the kernel submitted by this command-group (in case the
+property is specified on an accessor) or in any kernel in the graph (in case the
+property is specified on a buffer or an USM pointer) may not be available for
+use after the fused kernel completes execution. Implementations may treat this
+as a hint to not initialize or write back the final result to global memory.
+
+If different properties (local or private) are applied to accessors to the same
+buffer, the resolution rules specified below apply. The property is not
+prescriptive, implementations are free to not perform internalization and it is
+no error if they do not perform internalization. Implementations can provide a
+diagnostic message in case internalization was not performed through an
+implementation-specified mechanism, but are not required to do so.
+
+===== 6.2.1.4. Private internalization property
+
+The following property can be passed to three different APIs, namely:
+
+* The `accessor` constructor, giving a more granular control
+* The `buffer` constructor, in which case all the `accessors` derived from 
+this buffer will inherit this property (unless overridden).
+* The `property_list` parameter of 
+`command_graph<graph_state::modifiable>::add_malloc_device()` to apply the 
+property to an USM pointer.
+
+```c++ 
+sycl::ext::oneapi::experimental::property::promote_private 
+```
+
+This property is an assertion by the application that each element in the buffer
+or allocated device memory is accessed by no more than one work-item in the
+kernel submitted by this command-group (in case the property is specified on an
+accessor) or in any kernel in the graph (in case the property is specified on a
+buffer or an USM pointer). Implementations may treat this as a hint to promote
+the elements of the buffer or allocated device memory to private memory (see below
+section on local and private internalization).
+
+The application also asserts that the updates made to the buffer or allocated
+device memory by the kernel submitted by this command-group (in case the
+property is specified on an accessor) or in any kernel in the graph (in case the
+property is specified on a buffer or an USM pointer) may not be available for
+use after the fused kernel completes execution. Implementations may treat this
+as a hint to not initialize or write back the final result to global memory.
+
+If different properties (local or private) are applied to accessors to the same
+buffer, the resolution rules specified below apply. The property is not
+prescriptive, implementations are free to not perform internalization and it is
+no error if they do not perform internalization. Implementations can provide a
+diagnostic message in case internalization was not performed through an
+implementation-specified mechanism, but are not required to do so.
+
+==== 6.2.2. Device information descriptors
+
+To support querying whether a SYCL device and the underlying platform support
+kernel fusion for graphs, the following device information descriptor is added
+as part of this extension proposal. 
+
+```c++
+sycl::ext::oneapi::experimental::info::device::supports_fusion
+```
+
+When passed to `device::get_info<...>()`, the function returns `true` if the
+SYCL `device` and the underlying `platform` support kernel fusion for graphs.
+
+
+=== 6.3. Linearization
+
+In order to be able to perform kernel fusion, the commands in a graph must be
+arranged in a valid sequential order. 
+
+A valid _linearization_ of the graph is an order of the commands in the graph
+such that each command in the linearization depends only on commands that appear
+in the sequence before the command itself. 
+
+The exact linearization of the dependency DAG (which generally only implies a
+partial order) is implementation defined. The linearization should be
+deterministic, i.e. it should yield the same sequence when presented with the
+same DAG.
+
+=== 6.4. Synchronization in kernels
+
+Group barriers semantics do not change in the fused kernel and barriers already
+in the unfused kernels are preserved in the fused kernel. Despite this, it is
+worth noting that, in order to introduce synchronization between work items in a
+same work-group executing a fused kernel, a barrier is added between each of the
+kernels being fused. This automatic insertion of additional barriers can be
+deactivated through the property defined above.
+
+=== 6.5. Limitations
+
+Some scenarios might require fusion to be cancelled if some undesired scenarios
+arise.
+
+As the fusion property is not prescriptive, it is not an error for an
+implementation to cancel fusion in those scenarios. A valid recovery from such a
+scenario is to not perform fusion and rather maintain the original graph,
+executing the kernels individually rather than in a single fused kernel. 
+
+Implementations can provide a diagnostic message in case fusion was cancelled
+through an implementation-specified mechanism, but are not required to do so.
+
+The following sections describe a number of scenarios that might require to
+cancel fusion. Note that some implementations might be more capable/permissive
+and might not abort fusion in all of these cases.
+
+==== 6.5.1. Hierarchical Parallelism
+
+The extension does not support kernels using hierarchical parallelism. Although
+some implementations might want to add support for this kind of kernels.
+
+==== 6.5.2. Incompatible ND-ranges of the kernels to fuse
+
+Incompatibility of ND-ranges will be determined by the kernel fusion
+implementation. All implementations should support fusing kernels with the exact
+same ND-ranges, but implementations might cancel fusion as soon as a kernel with
+a different ND-range is submitted.
+
+==== 6.5.3. Kernels with different dimensions
+
+Similar to the previous one, it is implementation-defined whether or not to
+support fusing kernels with different dimensionality.
+
+==== 6.5.4. No intermediate representation
+
+In case any of the kernels to be fused does not come with an accessible
+suitable intermediate representation, kernel fusion is canceled.
+
+==== 6.5.5. Explicit memory operations and host tasks
+
+The graph proposal allows graphs to contain, next to device kernels, explicit
+memory operations and host tasks. As both of these types of commands cannot be
+integrated into a fused kernel, fusion must be cancelled, unless there is a
+valid linearization (see above section on linearization) that allows all memory
+operations and host tasks to execute either before or after all device kernels.
+It is valid to execute some memory operations and host tasks before all device
+kernels and some after all device kernels, as long as that sequence is a valid
+linearization.
+
+==== 6.5.6. Multi-device graph
+
+Attempting to fuse a graph containing device kernels for more than one device
+may lead to fusion being cancelled, as kernel fusion across multiple devices
+and/or backends is generally not possible. 
+
+=== 6.6. Internalization
+
+While avoiding repeated kernel launch overheads will most likely already improve
+application performance, kernel fusion can deliver even higher performance gains
+when internalizing dataflows.
+
+In a situation where data produced by one kernel is consumed by another kernel
+and the two kernels are fused, the dataflow from the first kernel to the second
+kernel can be made internal to the fused kernel. Instead of using time-consuming
+reads and writes to/from global memory, the fused kernel can use much faster
+mechanisms, e.g., registers or private memory to "communicate" the result.
+
+To achieve this result during fusion, a fusion compiler must be aware of some
+additional information and context:
+
+* The compiler must know that two arguments refer to the same underlying memory.
+* As internalized buffers or memories are not initialized, elements of the internalized
+  buffer or memory being read by a kernel must have been written before (either in the
+  same kernel or in a previous one in the same graph).
+* Values stored to an internalized buffer/memory must not be used by any other kernel
+  not part of the graph, as the data becomes unavailable to consumers through
+  internalization. This is knowledge that the compiler cannot deduce. Instead,
+  the fact that the values stored to an internalized buffer/memory are not used
+  outside the fused kernel must be provided by the user.
+* If these conditions hold, depending on the memory access pattern of the fused
+  kernel, we can say that a buffer is:
+** _Privately internalizable_: If not a single element of the buffer/memory is to be
+   accessed by more than one work-item;
+** _Locally internalizable_: If not a single element of the buffer/memory is to be
+   accessed by work items of different work groups.
+
+As the compiler can reason about the access behavior of the different kernels
+only in a very limited fashion, **it's the user's responsibility to make sure no
+data races occur in the fused kernel**. Data races could in particular be
+introduced because the implicit inter-work-group synchronization between the
+execution of two separate kernels is eliminated by fusion. The user must ensure
+that the kernels combined during fusion do not rely on this synchronization.
+
+The properties `sycl::ext::oneapi::experimental::property::promote_local` and
+`sycl::ext::oneapi::experimental::property::promote_local` defined by this
+proposal serve a dual purpose. For one, by adding the properties to an accessor,
+buffer or USM pointer, the user asserts that internalization of the underlying
+memory to private or local memory, respectively, will not cause a data race. 
+
+Additionally, the user asserts that no command executing after the fused graph
+requires access to the data that would be stored into the internalized memory if
+no internalization were to happen.
+
+In sum this allows users to trigger internalization of a buffer or allocated
+device memory by just specifying a single property.
+
+==== 6.6.1. Buffer internalization
+
+In some cases, the user will specify different internalization targets for a
+buffer and accessors to such buffer. When incompatible combinations are used, an
+`exception` with `errc::invalid` error code is thrown. Otherwise, these
+properties must be combined as follows:
+
+[options="header"]
+|===
+|Accessor Internalization Target|Buffer Internalization Target|Resulting Internalization Target
+
+.3+.^|None
+|None
+|None
+
+|Local
+|Local
+
+|Private
+|Private
+
+.3+.^|Local
+|None
+|Local
+
+|Local
+|Local
+
+|Private
+|*Error*
+
+.3+.^|Private
+|None
+|Private
+
+|Local
+|*Error*
+
+|Private
+|Private
+|===
+
+In case different internalization targets are used for accessors to the same
+buffer, the following (commutative and associative) rules are followed:
+
+[options="header"]
+|===
+|Accessor~1~ Internalization Target|Accessor~2~ Internalization Target|Resulting Internalization Target
+
+|None
+|_Any_
+|None
+
+.2+.^|Local
+|Local
+|Local
+
+|Private
+|None
+
+|Private
+|Private
+|Private
+|===
+
+If no work-group size is specified or two accessors specify different
+work-group sizes when using local internalization for any of the
+kernels involved in the fusion, no internalization will be
+performed. If there is a mismatch between the two accessors (access
+range, access offset, number of dimensions, data type), no
+internalization is performed.
+
+== 7. Examples
+
+=== 7.1. Buffer-based example
+
+```c++
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+struct AddKernel {
+  accessor<int, 1> accIn1;
+  accessor<int, 1> accIn2;
+  accessor<int, 1> accOut;
+
+  void operator()(id<1> i) const { accOut[i] = accIn1[i] + accIn2[i]; }
+};
+
+int main() {
+  constexpr size_t dataSize = 512;
+  int in1[dataSize], in2[dataSize], in3[dataSize], tmp1[dataSize],
+      tmp2[dataSize], tmp3[dataSize], out[dataSize];
+
+  queue q{default_selector_v};
+
+  ext::oneapi::experimental::command_graph graph;
+  {
+    buffer<int> bIn1{in1, range{dataSize}};
+    buffer<int> bIn2{in2, range{dataSize}};
+    buffer<int> bIn3{in3, range{dataSize}};
+    buffer<int> bTmp1{tmp1, range{dataSize}};
+    // Internalization specified on the buffer
+    buffer<int> bTmp2{tmp2, range{dataSize}, 
+      {sycl::ext::oneapi::experimental::property::promote_private{}}};
+    // Internalization specified on the buffer
+    buffer<int> bTmp3{tmp3, range{dataSize}, 
+      {sycl::ext::oneapi::experimental::property::promote_private{}}};
+    buffer<int> bOut{out, range{dataSize}};
+
+    graph.begin_recording(q);
+
+    q.submit([&](handler &cgh) {
+      auto accIn1 = bIn1.get_access(cgh);
+      auto accIn2 = bIn2.get_access(cgh);
+      // Internalization specified on each accessor. 
+      auto accTmp1 = bTmp1.get_access(
+          cgh, sycl::ext::oneapi::experimental::property::promote_private{});
+      cgh.parallel_for<AddKernel>(dataSize, AddKernel{accIn1, accIn2, accTmp1});
+    });
+
+    q.submit([&](handler &cgh) {
+      // Internalization specified on each accessor. 
+      auto accTmp1 = bTmp1.get_access(
+          cgh, sycl::ext::oneapi::experimental::property::promote_private{});
+      auto accIn3 = bIn3.get_access(cgh);
+      auto accTmp2 = bTmp2.get_access(cgh);
+      cgh.parallel_for<class KernelOne>(
+          dataSize, [=](id<1> i) { accTmp2[i] = accTmp1[i] * accIn3[i]; });
+    });
+
+    q.submit([&](handler &cgh) {
+      // Internalization specified on each accessor. 
+      auto accTmp1 = bTmp1.get_access(
+          cgh, sycl::ext::oneapi::experimental::property::promote_private{});
+      auto accTmp3 = bTmp3.get_access(cgh);
+      cgh.parallel_for<class KernelTwo>(
+          dataSize, [=](id<1> i) { accTmp3[i] = accTmp1[i] * 5; });
+    });
+
+    q.submit([&](handler &cgh) {
+      auto accTmp2 = bTmp2.get_access(cgh);
+      auto accTmp3 = bTmp3.get_access(cgh);
+      auto accOut = bOut.get_access(cgh);
+      cgh.parallel_for<AddKernel>(dataSize,
+                                  AddKernel{accTmp2, accTmp3, accOut});
+    });
+
+    graph.end_recording();
+
+    // Trigger fusion during finalization.
+    auto exec_graph = graph.finalize(q.get_context(), 
+      {sycl::ext::oneapi::experimental::property::command_graph::perform_fusion});
+
+    q.submit([&](handler& cgh) {
+      cgh.ext_oneapi_graph(exec_graph);
+    });
+  }
+  return 0;
+}
+```
+
+=== 7.2. USM-based example
+
+```c++
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+namespace sycl_ext = sycl::ext::oneapi::experimental;
+
+int main() {
+  constexpr size_t dataSize = 512;
+  constexpr size_t numBytes = dataSize * sizeof(int);
+
+  int in1[dataSize], in2[dataSize], in3[dataSize], out[dataSize];
+
+  queue q{default_selector_v};
+
+  sycl_ext::command_graph graph;
+
+  int *dIn1, dIn2, dIn3, dTmp, dOut;
+
+  auto node_in1 = graph.add_malloc_device(dIn1, numBytes);
+  auto node_in2 = graph.add_malloc_device(dIn2, numBytes);
+  auto node_in3 = graph.add_malloc_device(dIn3, numBytes);
+  auto node_out = graph.add_malloc_device(dOut, numBytes);
+
+  // Specify internalization for an USM pointer
+  auto node_tmp = graph.add_malloc_device(
+      dTmp, numBytes,
+      {sycl::ext::oneapi::experimental::property::promote_private});
+
+  // This explicit memory operation is compatible with fusion, as it can be
+  // linearized before any device kernel in the graph.
+  auto copy_in1 =
+      graph.add([&](handler &cgh) { cgh.memcpy(dIn1, in1, numBytes); },
+                {sycl_ext::property::node::depends_on(node_in1)});
+
+  // This explicit memory operation is compatible with fusion, as it can be
+  // linearized before any device kernel in the graph.
+  auto copy_in2 =
+      graph.add([&](handler &cgh) { cgh.memcpy(dIn2, in2, numBytes); },
+                {sycl_ext::property::node::depends_on(node_in2)});
+
+  auto kernel1 = graph.add(
+      [&](handler &cgh) {
+        cgh.parallel_for<class KernelOne>(
+            dataSize, [=](id<1> i) { tmp[i] = in1[i] + in2[i]; });
+      },
+      {sycl_ext::property::node::depends_on(copy_in1, copy_in2, node_tmp)});
+
+  // This explicit memory operation is compatible with fusion, as it can be
+  // linearized before any device kernel in the graph.
+  auto copy_in3 =
+      graph.add([&](handler &cgh) { cgh.memcpy(dIn3, in3, numBytes); },
+                {sycl_ext::property::node::depends_on(node_in3)});
+
+  auto kernel2 = graph.add(
+      [&](handler &cgh) {
+        cgh.parallel_for<class KernelTwo>(
+            dataSize, [=](id<1> i) { out[i] = tmp[i] * in3[i]; });
+      },
+      {sycl_ext::property::node::depends_on(copy_in3, kernel1)});
+
+  // This explicit memory operation is compatible with fusion, as it can be
+  // linearized after any device kernel in the graph.
+  auto copy_out =
+      graph.add([&](handler &cgh) { cgh.memcpy(out, dOut, numBytes); },
+                {sycl_ext::property::node::depends_on(kernel2)});
+
+  graph.add_free(dIn1, {sycl_ext::property::node::depends_on(copy_out)});
+  graph.add_free(dIn2, {sycl_ext::property::node::depends_on(copy_out)});
+  graph.add_free(dIn3, {sycl_ext::property::node::depends_on(copy_out)});
+  graph.add_free(dTmp, {sycl_ext::property::node::depends_on(copy_out)});
+  graph.add_free(dOut, {sycl_ext::property::node::depends_on(copy_out)});
+
+  // Trigger fusion during finalization.
+  auto exec = graph.finalize(q.get_context(),
+                             {sycl::ext::oneapi::experimental::property::
+                                  command_graph::perform_fusion});
+
+  // use queue shortcut for graph submission
+  q.ext_oneapi_graph(exec).wait();
+
+  return 0;
+}
+```
+
+== 8. Contributors
+
+Lukas Sommer, Codeplay +
+Victor Lomüller, Codeplay +
+Victor Perez, Codeplay +
+
+== Revision History
+
+[cols="5,15,15,70"]
+[grid="rows"]
+[options="header"]
+|========================================
+|Rev|Date|Authors|Changes
+|1|2023-02-16|Lukas Sommer|*Initial draft*
+|========================================

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph_fusion.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph_fusion.asciidoc
@@ -10,7 +10,8 @@
 :encoding: utf-8
 :lang: en
 :dpcpp: pass:[DPC++]
-:stem: asciimath
+:sectnums:
+:sectnumlevels: 4
 
 // Set the default source code type in this document to C++,
 // for syntax highlighting purposes.  This is needed because
@@ -18,7 +19,7 @@
 :language: {basebackend@docbook:c++:cpp}
 
 
-== 1. Notice
+== Notice
 
 [%hardbreaks]
 Copyright (C) Codeplay Software Limited.  All rights reserved.
@@ -28,14 +29,14 @@ of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by
 permission by Khronos.
 
 
-== 2. Contact
+== Contact
 
 To report problems with this extension, please open a new issue at:
 
 https://github.com/intel/llvm/issues
 
 
-== 3. Dependencies
+== Dependencies
 
 This extension is written against the SYCL 2020 revision 6 specification.  All
 references below to the "core SYCL specification" or to section numbers in the
@@ -45,7 +46,7 @@ This extension builds on top of the proposed SYCL graphs
 https://github.com/reble/llvm/blob/sycl-graph-update/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc[extension
 proposal]. All references to the "graphs proposal" refer to this proposal.
 
-== 4. Status
+== Status
 
 This is a proposed extension specification, intended to gather community
 feedback.  Interfaces defined in this specification may not be implemented yet
@@ -53,7 +54,7 @@ or may be in a preliminary state.  The specification itself may also change in
 incompatible ways before it is finalized.  *Shipping software products should
 not rely on APIs defined in this specification.*
 
-== 5. Overview
+== Overview
 
 The SYCL graph
 https://github.com/reble/llvm/blob/sycl-graph-update/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc[extension
@@ -87,9 +88,9 @@ fusion of two or more kernels in a SYCL graph into a single kernel **at
 runtime**. This requires the extension of the runtime with some sort of JIT
 compiler to allow for the fusion of kernel functions at runtime.
 
-== 6. Specification
+== Specification
 
-=== 6.1. Feature test macro
+=== Feature test macro
 
 This extension provides a feature-test macro as described in the core SYCL
 specification.  An implementation supporting this extension must predefine the
@@ -108,11 +109,11 @@ supports.
 |Initial version of this extension.
 |===
 
-=== 6.2. API modifications
+=== API modifications
 
-==== 6.2.1. Properties
+==== Properties
 
-===== 6.2.1.1. Graph Fusion Property
+===== Graph Fusion Property
 
 The API for `command_graph<graph_state::modifiable>::finalize()` includes a
 `property_list` parameter. The following property, defined by this extension,
@@ -124,7 +125,7 @@ sycl::ext::oneapi::experimental::property::command_graph::perform_fusion
 ```
 
 The property is not prescriptive. Implementations are free to not perform fusion
-if it is not possible (see below section <<_6_5_limitations>>), fusion is not
+if it is not possible (see below section <<_limitations>>), fusion is not
 supported by the implementation, or the implementation decides not to perform
 fusion for other reasons. It is not an error if an implementation does not
 perform fusion even though the property is passed. 
@@ -133,7 +134,7 @@ Implementations can provide a diagnostic message in case fusion was not
 performed through an implementation-specified mechanism, but are not required to
 do so.
 
-===== 6.2.1.2. Barrier property
+===== Barrier property
 
 The following property can be added to the `property_list` of the
 `command_graph<graph_state::modifiable>::finalize()` API.
@@ -150,7 +151,7 @@ The property only takes effect if the
 property is also part of the `property_list` of the same invocation of
 `command_graph<...>::finalize()`. 
 
-===== 6.2.1.3. Local internalization property
+===== Local internalization property
 
 The following property can be passed to three different APIs, namely:
 
@@ -187,7 +188,7 @@ no error if they do not perform internalization. Implementations can provide a
 diagnostic message in case internalization was not performed through an
 implementation-specified mechanism, but are not required to do so.
 
-===== 6.2.1.4. Private internalization property
+===== Private internalization property
 
 The following property can be passed to three different APIs, namely:
 
@@ -224,7 +225,7 @@ no error if they do not perform internalization. Implementations can provide a
 diagnostic message in case internalization was not performed through an
 implementation-specified mechanism, but are not required to do so.
 
-==== 6.2.2. Device information descriptors
+==== Device information descriptors
 
 To support querying whether a SYCL device and the underlying platform support
 kernel fusion for graphs, the following device information descriptor is added
@@ -238,7 +239,7 @@ When passed to `device::get_info<...>()`, the function returns `true` if the
 SYCL `device` and the underlying `platform` support kernel fusion for graphs.
 
 
-=== 6.3. Linearization
+=== Linearization
 
 In order to be able to perform kernel fusion, the commands in a graph must be
 arranged in a valid sequential order. 
@@ -252,7 +253,7 @@ partial order) is implementation defined. The linearization should be
 deterministic, i.e. it should yield the same sequence when presented with the
 same DAG.
 
-=== 6.4. Synchronization in kernels
+=== Synchronization in kernels
 
 Group barriers semantics do not change in the fused kernel and barriers already
 in the unfused kernels are preserved in the fused kernel. Despite this, it is
@@ -261,7 +262,7 @@ same work-group executing a fused kernel, a barrier is added between each of the
 kernels being fused. This automatic insertion of additional barriers can be
 deactivated through the property defined above.
 
-=== 6.5. Limitations
+=== Limitations
 
 Some scenarios might require fusion to be cancelled if some undesired scenarios
 arise.
@@ -278,29 +279,29 @@ The following sections describe a number of scenarios that might require to
 cancel fusion. Note that some implementations might be more capable/permissive
 and might not abort fusion in all of these cases.
 
-==== 6.5.1. Hierarchical Parallelism
+==== Hierarchical Parallelism
 
 The extension does not support kernels using hierarchical parallelism. Although
 some implementations might want to add support for this kind of kernels.
 
-==== 6.5.2. Incompatible ND-ranges of the kernels to fuse
+==== Incompatible ND-ranges of the kernels to fuse
 
 Incompatibility of ND-ranges will be determined by the kernel fusion
 implementation. All implementations should support fusing kernels with the exact
 same ND-ranges, but implementations might cancel fusion as soon as a kernel with
 a different ND-range is submitted.
 
-==== 6.5.3. Kernels with different dimensions
+==== Kernels with different dimensions
 
 Similar to the previous one, it is implementation-defined whether or not to
 support fusing kernels with different dimensionality.
 
-==== 6.5.4. No intermediate representation
+==== No intermediate representation
 
 In case any of the kernels to be fused does not come with an accessible
 suitable intermediate representation, kernel fusion is canceled.
 
-==== 6.5.5. Explicit memory operations and host tasks
+==== Explicit memory operations and host tasks
 
 The graph proposal allows graphs to contain, next to device kernels, explicit
 memory operations and host tasks. As both of these types of commands cannot be
@@ -311,13 +312,13 @@ It is valid to execute some memory operations and host tasks before all device
 kernels and some after all device kernels, as long as that sequence is a valid
 linearization.
 
-==== 6.5.6. Multi-device graph
+==== Multi-device graph
 
 Attempting to fuse a graph containing device kernels for more than one device
 may lead to fusion being cancelled, as kernel fusion across multiple devices
 and/or backends is generally not possible. 
 
-=== 6.6. Internalization
+=== Internalization
 
 While avoiding repeated kernel launch overheads will most likely already improve
 application performance, kernel fusion can deliver even higher performance gains
@@ -368,7 +369,7 @@ no internalization were to happen.
 In sum this allows users to trigger internalization of a buffer or allocated
 device memory by just specifying a single property.
 
-==== 6.6.1. Buffer internalization
+==== Buffer internalization
 
 In some cases, the user will specify different internalization targets for a
 buffer and accessors to such buffer. When incompatible combinations are used, an
@@ -440,9 +441,9 @@ performed. If there is a mismatch between the two accessors (access
 range, access offset, number of dimensions, data type), no
 internalization is performed.
 
-== 7. Examples
+== Examples
 
-=== 7.1. Buffer-based example
+=== Buffer-based example
 
 ```c++
 #include <sycl/sycl.hpp>
@@ -530,7 +531,7 @@ int main() {
 }
 ```
 
-=== 7.2. USM-based example
+=== USM-based example
 
 ```c++
 #include <sycl/sycl.hpp>
@@ -617,11 +618,12 @@ int main() {
 }
 ```
 
-== 8. Contributors
+== Contributors
 
 Lukas Sommer, Codeplay +
 Victor Lomüller, Codeplay +
 Victor Perez, Codeplay +
+Ewan Crawford, Codeplay +
 
 == Revision History
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
@@ -38,7 +38,7 @@ https://github.com/intel/llvm/issues
 
 == Dependencies
 
-This extension is written against the SYCL 2020 revision 6 specification.  All
+This extension is written against the SYCL 2020 revision 7 specification.  All
 references below to the "core SYCL specification" or to section numbers in the
 SYCL specification refer to that revision.
 
@@ -79,9 +79,9 @@ recording mechanism, similar to the initial kernel fusion proposal; and another
 one using explicit graph building. Thus, future users will be able to choose
 from two different mechanisms to construct the sequence of kernels to fuse. As
 there is an explicit step for finalization of graphs before being submitted for
-execution, the fusion step can happen asynchronously and also eliminates many of
-the synchronization concerns that needed to be covered in the experimental
-kernel fusion proposal.
+execution, fusion can happen in this step, which also eliminates many of the
+synchronization concerns that needed to be covered in the experimental kernel
+fusion proposal.
 
 The aim of this document is to propose a mechanism for users to request the
 fusion of two or more kernels in a SYCL graph into a single kernel **at
@@ -460,29 +460,32 @@ struct AddKernel {
 
 int main() {
   constexpr size_t dataSize = 512;
-  int in1[dataSize], in2[dataSize], in3[dataSize], tmp1[dataSize],
-      tmp2[dataSize], tmp3[dataSize], out[dataSize];
+  int in1[dataSize], in2[dataSize], in3[dataSize], out[dataSize];
 
   queue q{default_selector_v};
 
-  ext::oneapi::experimental::command_graph graph{q.get_context(),
-                                                 q.get_device()};
   {
     buffer<int> bIn1{in1, range{dataSize}};
+    bIn1.set_write_back(false);
     buffer<int> bIn2{in2, range{dataSize}};
+    bIn2.set_write_back(false);
     buffer<int> bIn3{in3, range{dataSize}};
-    buffer<int> bTmp1{tmp1, range{dataSize}};
+    bIn3.set_write_back(false);
+    buffer<int> bTmp1{range{dataSize}};
     // Internalization specified on the buffer
     buffer<int> bTmp2{
-        tmp2,
         range{dataSize},
         {sycl::ext::oneapi::experimental::property::promote_private{}}};
     // Internalization specified on the buffer
     buffer<int> bTmp3{
-        tmp3,
         range{dataSize},
         {sycl::ext::oneapi::experimental::property::promote_private{}}};
     buffer<int> bOut{out, range{dataSize}};
+    bOut.set_write_back(false);
+
+    ext::oneapi::experimental::command_graph graph{
+        q.get_context(), q.get_device(),
+        sycl::ext::oneapi::experimental::property::graph::no_host_copy{}};
 
     graph.begin_recording(q);
 
@@ -530,6 +533,8 @@ int main() {
                             command_graph::perform_fusion});
 
     q.ext_oneapi_graph(exec_graph);
+
+    q.wait();
   }
   return 0;
 }
@@ -635,4 +640,5 @@ Ewan Crawford, Codeplay +
 |1|2023-02-16|Lukas Sommer|*Initial draft*
 |2|2023-03-16|Lukas Sommer|*Remove reference to outdated `add_malloc_device` API*
 |3|2023-04-11|Lukas Sommer|*Update usage examples for graph API changes*
+|4|2023-08-17|Lukas Sommer|*Update after graph extension has been merged*
 |========================================

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
@@ -158,9 +158,9 @@ The following property can be passed to three different APIs, namely:
 * The `accessor` constructor, giving a more granular control
 * The `buffer` constructor, in which case all the `accessors` derived from 
 this buffer will inherit this property (unless overridden).
-* The `property_list` parameter of 
-`command_graph<graph_state::modifiable>::add_malloc_device()` to apply the 
-property to an USM pointer.
+* The `property_list` parameter of `sycl::malloc_device()`,
+`sycl::aligned_alloc_device()`, `sycl::malloc_shared()`, or
+`sycl::aligned_alloc_shared()` to apply the property to an USM pointer.
 
 ```c++ 
 sycl::ext::oneapi::experimental::property::promote_local 
@@ -195,9 +195,9 @@ The following property can be passed to three different APIs, namely:
 * The `accessor` constructor, giving a more granular control
 * The `buffer` constructor, in which case all the `accessors` derived from 
 this buffer will inherit this property (unless overridden).
-* The `property_list` parameter of 
-`command_graph<graph_state::modifiable>::add_malloc_device()` to apply the 
-property to an USM pointer.
+* The `property_list` parameter of `sycl::malloc_device()`,
+`sycl::aligned_alloc_device()`, `sycl::malloc_shared()`, or
+`sycl::aligned_alloc_shared()` to apply the property to an USM pointer.
 
 ```c++ 
 sycl::ext::oneapi::experimental::property::promote_private 
@@ -552,40 +552,36 @@ int main() {
 
   int *dIn1, dIn2, dIn3, dTmp, dOut;
 
-  auto node_in1 = graph.add_malloc_device(dIn1, numBytes);
-  auto node_in2 = graph.add_malloc_device(dIn2, numBytes);
-  auto node_in3 = graph.add_malloc_device(dIn3, numBytes);
-  auto node_out = graph.add_malloc_device(dOut, numBytes);
+  dIn1 = malloc_device<int>(q, dataSize);
+  dIn2 = malloc_device<int>(q, dataSize);
+  dIn3 = malloc_device<int>(q, dataSize);
+  dOut = malloc_device<int>(q, dataSize);
 
   // Specify internalization for an USM pointer
-  auto node_tmp = graph.add_malloc_device(
-      dTmp, numBytes,
+  dTmp = malloc_device<int>(q, dataSize,
       {sycl::ext::oneapi::experimental::property::promote_private});
 
   // This explicit memory operation is compatible with fusion, as it can be
   // linearized before any device kernel in the graph.
   auto copy_in1 =
-      graph.add([&](handler &cgh) { cgh.memcpy(dIn1, in1, numBytes); },
-                {sycl_ext::property::node::depends_on(node_in1)});
+      graph.add([&](handler &cgh) { cgh.memcpy(dIn1, in1, numBytes); });
 
   // This explicit memory operation is compatible with fusion, as it can be
   // linearized before any device kernel in the graph.
   auto copy_in2 =
-      graph.add([&](handler &cgh) { cgh.memcpy(dIn2, in2, numBytes); },
-                {sycl_ext::property::node::depends_on(node_in2)});
+      graph.add([&](handler &cgh) { cgh.memcpy(dIn2, in2, numBytes); });
 
   auto kernel1 = graph.add(
       [&](handler &cgh) {
         cgh.parallel_for<class KernelOne>(
             dataSize, [=](id<1> i) { tmp[i] = in1[i] + in2[i]; });
       },
-      {sycl_ext::property::node::depends_on(copy_in1, copy_in2, node_tmp)});
+      {sycl_ext::property::node::depends_on(copy_in1, copy_in2)});
 
   // This explicit memory operation is compatible with fusion, as it can be
   // linearized before any device kernel in the graph.
   auto copy_in3 =
-      graph.add([&](handler &cgh) { cgh.memcpy(dIn3, in3, numBytes); },
-                {sycl_ext::property::node::depends_on(node_in3)});
+      graph.add([&](handler &cgh) { cgh.memcpy(dIn3, in3, numBytes); });
 
   auto kernel2 = graph.add(
       [&](handler &cgh) {
@@ -600,12 +596,6 @@ int main() {
       graph.add([&](handler &cgh) { cgh.memcpy(out, dOut, numBytes); },
                 {sycl_ext::property::node::depends_on(kernel2)});
 
-  graph.add_free(dIn1, {sycl_ext::property::node::depends_on(copy_out)});
-  graph.add_free(dIn2, {sycl_ext::property::node::depends_on(copy_out)});
-  graph.add_free(dIn3, {sycl_ext::property::node::depends_on(copy_out)});
-  graph.add_free(dTmp, {sycl_ext::property::node::depends_on(copy_out)});
-  graph.add_free(dOut, {sycl_ext::property::node::depends_on(copy_out)});
-
   // Trigger fusion during finalization.
   auto exec = graph.finalize(q.get_context(),
                              {sycl::ext::oneapi::experimental::property::
@@ -613,6 +603,12 @@ int main() {
 
   // use queue shortcut for graph submission
   q.ext_oneapi_graph(exec).wait();
+
+  free(dIn1, q);
+  free(dIn2, q);
+  free(dIn3, q);
+  free(dOut, q);
+  free(dTmp, q);
 
   return 0;
 }
@@ -633,4 +629,5 @@ Ewan Crawford, Codeplay +
 |========================================
 |Rev|Date|Authors|Changes
 |1|2023-02-16|Lukas Sommer|*Initial draft*
+|2|2023-03-16|Lukas Sommer|*Remove reference to outdated `add_malloc_device` API*
 |========================================

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
@@ -35,6 +35,15 @@ To report problems with this extension, please open a new issue at:
 
 https://github.com/intel/llvm/issues
 
+== Contributors
+
+Lukas Sommer, Codeplay +
+Victor Lomüller, Codeplay +
+Victor Perez, Codeplay +
+Julian Oppermann, Codeplay +
+Ewan Crawford, Codeplay +
+Ben Tracy, Codeplay +
+John Pennycook, Intel +
 
 == Dependencies
 
@@ -42,8 +51,8 @@ This extension is written against the SYCL 2020 revision 7 specification.  All
 references below to the "core SYCL specification" or to section numbers in the
 SYCL specification refer to that revision.
 
-This extension builds on top of the proposed SYCL graphs
-https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc[extension
+This extension builds on top of the experimental SYCL graphs
+https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc[extension
 proposal]. All references to the "graphs proposal" refer to this proposal.
 
 == Status
@@ -57,7 +66,7 @@ not rely on APIs defined in this specification.*
 == Overview
 
 The SYCL graph
-https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc[extension
+https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc[extension
 proposal] seeks to reduce the runtime overhead linked to SYCL kernel submission
 and expose additional optimization opportunities.
 
@@ -113,19 +122,20 @@ supports.
 
 ==== Properties
 
-===== Graph Fusion Property
+===== Graph Fusion Properties
 
 The API for `command_graph<graph_state::modifiable>::finalize()` includes a
-`property_list` parameter. The following property, defined by this extension,
+`property_list` parameter. The following properties, defined by this extension,
 can be added to the property list to indicate that the kernels in the
-command-graph should be fused. 
+command-graph can or should be fused. 
 
 ```c++
-sycl::ext::oneapi::experimental::property::graph::perform_fusion 
+sycl::ext::oneapi::experimental::property::graph::enable_fusion 
 ```
 
-The property is not prescriptive. Implementations are free to not perform fusion
-if it is not possible (see below section <<limitations, Limitations>>), fusion is not
+This property is only descriptive, not prescriptive. Implementations are free to
+not perform fusion if it is not possible 
+(see below section <<limitations, Limitations>>), fusion is not
 supported by the implementation, or the implementation decides not to perform
 fusion for other reasons. It is not an error if an implementation does not
 perform fusion even though the property is passed. 
@@ -134,63 +144,56 @@ Implementations can provide a diagnostic message in case fusion was not
 performed through an implementation-specified mechanism, but are not required to
 do so.
 
+```c++
+sycl::ext::oneapi::experimental::property::graph::require_fusion
+```
+
+This property is prescriptive, i.e., in contrast to the property above,
+implementations _must_ perform fusion. If fusion is not supported by the
+implementation at all, the implementation must raise an error with error code
+`errc::feature_not_supported`. If the implementation is unable to perform fusion
+for this graph (see below section <<limitations, Limitations>>), the
+implementation must raise an error with error code `errc::kernel_not_supported`.
+
 ===== Barrier property
 
 The following property can be added to the `property_list` of the
 `command_graph<graph_state::modifiable>::finalize()` API.
 
 ```c++
-sycl::ext::oneapi::experimental::property::graph::no_barriers
+sycl::ext::oneapi::experimental::property::graph::insert_barriers
 ```
 
-If the property list contains this property, no barriers are introduced between
-kernels in the fused kernel (see below section on synchronization on kernels). 
+By default, graph fusion will not introduce any additional barriers to the
+fused kernel. Existing group barriers inside the code will be retained (see
+below). 
 
-The property only takes effect if the
-`sycl::ext::oneapi::experimental::property::graph::perform_fusion`
-property is also part of the `property_list` of the same invocation of
+If the property list contains this property, additional work-group barriers are 
+introduced between kernels in the fused kernel (see below section on 
+synchronization in kernels). 
+
+The property only takes effect if either the
+`sycl::ext::oneapi::experimental::property::graph::enable_fusion`
+property or the
+`sycl::ext::oneapi::experimental::property::graph::require_fusion` property is 
+also part of the `property_list` of the same invocation of
 `command_graph<...>::finalize()`. 
 
-===== Local internalization property
+[NOTE]
+====
+By adding the `insert_barriers` property, a _work-group barrier_ will be
+inserted between the kernels. To achieve a device-wide synchronization, i.e.,
+a synchronization between different work-groups that is implicit between two
+kernels when executed separately, users should leverage the subgraph feature of
+the SYCL graph proposal. By creating two subgraphs, fusing each and adding both
+to the same graph, a device-wide synchronization between two fused parts can be
+achieved if necessary.
+====
 
-The following property can be passed to three different APIs, namely:
+===== Access scope property
 
-* The `accessor` constructor, giving a more granular control.
-* The `buffer` constructor, in which case all the `accessors` derived from 
-this buffer will inherit this property (unless overridden).
-* The `property_list` parameter of `sycl::malloc_device()`,
-`sycl::aligned_alloc_device()`, `sycl::malloc_shared()`, or
-`sycl::aligned_alloc_shared()` to apply the property to an USM pointer.
-
-```c++ 
-sycl::ext::oneapi::experimental::property::promote_local 
-```
-
-This property is an assertion by the application that each element in the buffer
-or allocated device memory is accessed by no more than one work-group in the
-kernel submitted by this command-group (in case the property is specified on an
-accessor) or in any kernel in the graph (in case the property is specified on a
-buffer or an USM pointer). Implementations may treat this as a hint to promote
-the elements of the buffer or allocated device memory to local memory (see below
-section on local and private internalization).
-
-The application also asserts that the updates made to the buffer or allocated
-device memory by the kernel submitted by this command-group (in case the
-property is specified on an accessor) or in any kernel in the graph (in case the
-property is specified on a buffer or an USM pointer) may not be available for
-use after the fused kernel completes execution. Implementations may treat this
-as a hint to not initialize or write back the final result to global memory.
-
-If different properties (local or private) are applied to accessors to the same
-buffer, the resolution rules specified below apply. The property is not
-prescriptive, implementations are free to not perform internalization and it is
-no error if they do not perform internalization. Implementations can provide a
-diagnostic message in case internalization was not performed through an
-implementation-specified mechanism, but are not required to do so.
-
-===== Private internalization property
-
-The following property can be passed to three different APIs, namely:
+Specializations of the following property template can be passed to three
+different APIs, namely:
 
 * The `accessor` constructor, giving a more granular control.
 * The `buffer` constructor, in which case all the `accessors` derived from 
@@ -198,46 +201,93 @@ this buffer will inherit this property (unless overridden).
 * The `property_list` parameter of `sycl::malloc_device()`,
 `sycl::aligned_alloc_device()`, `sycl::malloc_shared()`, or
 `sycl::aligned_alloc_shared()` to apply the property to an USM pointer.
-
-```c++ 
-sycl::ext::oneapi::experimental::property::promote_private 
-```
-
-This property is an assertion by the application that each element in the buffer
-or allocated device memory is accessed by no more than one work-item in the
-kernel submitted by this command-group (in case the property is specified on an
-accessor) or in any kernel in the graph (in case the property is specified on a
-buffer or an USM pointer). Implementations may treat this as a hint to promote
-the elements of the buffer or allocated device memory to private memory (see below
-section on local and private internalization).
-
-The application also asserts that the updates made to the buffer or allocated
-device memory by the kernel submitted by this command-group (in case the
-property is specified on an accessor) or in any kernel in the graph (in case the
-property is specified on a buffer or an USM pointer) may not be available for
-use after the fused kernel completes execution. Implementations may treat this
-as a hint to not initialize or write back the final result to global memory.
-
-If different properties (local or private) are applied to accessors to the same
-buffer, the resolution rules specified below apply. The property is not
-prescriptive, implementations are free to not perform internalization and it is
-no error if they do not perform internalization. Implementations can provide a
-diagnostic message in case internalization was not performed through an
-implementation-specified mechanism, but are not required to do so.
-
-==== Device information descriptors
-
-To support querying whether a SYCL device and the underlying platform support
-kernel fusion for graphs, the following device information descriptor is added
-as part of this extension proposal. 
 
 ```c++
-sycl::ext::oneapi::experimental::info::device::supports_fusion
+namespace sycl::ext::oneapi::experimental::property{
+
+  template<sycl::memory_scope Scope>
+  struct access_scope {};
+
+  inline constexpr auto access_scope_local = 
+                                    access_scope<memory_scope_work_group>;
+
+  inlint constexpr auto access_scope_private = 
+                                    access_scope<memory_scope_work_item>;
+
+} // namespace sycl::ext::oneapi::experimental::property
 ```
 
-When passed to `device::get_info<...>()`, the function returns `true` if the
-SYCL `device` and the underlying `platform` support kernel fusion for graphs.
+Specializations of the `access_scope` property template can be used to express
+the access pattern of kernels to a buffer or USM allocation.
 
+The specializations of the property are an assertion by the application that
+each element in the buffer or allocated device memory is at most accessed in
+the given memory scope in the kernel submitted by this command-group (in case
+the property is specified on an accessor) or in any kernel in the graph (in case
+the property is specified on a buffer or an USM pointer).
+
+More concretely, the two shortcuts express the following semantics:
+* `access_scope_local`: Applying this specialization asserts that each element 
+in the buffer or allocated device memory is accessed by no more than one
+work-group.
+* `access_scope_private`: Applying this specialization asserts that each element 
+in the buffer or allocated device memory is accessed by no more than one
+work-item.
+
+Implementations may treat specializations of the access scope property as a
+hint to promote the elements of the buffer or allocated device memory to a
+different type of memory (see below section on local and private
+internalization).
+
+If different specializations are applied to accessors to the same buffer or
+device memory allocation, the resolution rules specified below apply.
+
+The property is not prescriptive, implementations are free to not perform
+internalization and it is no error if they do not perform internalization.
+Implementations can provide a diagnostic message in case internalization was
+not performed through an implementation-specified mechanism, but are not
+required to do so.
+
+===== Internal memory property
+
+The following property can be passed to three different APIs, namely:
+
+* The `accessor` constructor, giving a more granular control.
+* The `buffer` constructor, in which case all the `accessors` derived from 
+this buffer will inherit this property (unless overridden).
+* The `property_list` parameter of `sycl::malloc_device()`,
+`sycl::aligned_alloc_device()`, `sycl::malloc_shared()`, or
+`sycl::aligned_alloc_shared()` to apply the property to an USM pointer.
+
+```c++ 
+sycl::ext::oneapi::experimental::property::fusion_internal_memory 
+```
+
+By applying this property, the application asserts that the updates made to the
+buffer or allocated device memory by the kernel submitted by this command-group
+(in case the property is specified on an accessor) or in any kernel in the
+graph (in case the property is specified on a buffer or an USM pointer) may not
+be available for use after the fused kernel completes execution.
+Implementations may treat this as a hint to not write back the final result to
+global memory.
+
+The property is not prescriptive, implementations are free to not perform
+internalization and it is no error if they do not perform internalization.
+Implementations can provide a diagnostic message in case internalization was
+not performed through an implementation-specified mechanism, but are not
+required to do so.
+
+==== Device aspect 
+
+To support querying whether a SYCL device and the underlying platform support
+kernel fusion for graphs, the following device aspect is added as part of this
+extension proposal. 
+
+```c++
+sycl::aspect::ext_oneapi_graph_fusion
+```
+
+Devices with `aspect::ext_oneapi_graph_fusion` support kernel fusion for graphs.
 
 === Linearization
 
@@ -256,24 +306,41 @@ same DAG.
 === Synchronization in kernels
 
 Group barriers semantics do not change in the fused kernel and barriers already
-in the unfused kernels are preserved in the fused kernel. Despite this, it is
-worth noting that, in order to introduce synchronization between work items in a
-same work-group executing a fused kernel, a barrier is added between each of the
-kernels being fused. This automatic insertion of additional barriers can be
-deactivated through the property defined above.
+in the unfused kernels are preserved in the fused kernel. 
+
+Despite this, it is worth noting that, in order to introduce synchronization
+between work items in a same work-group executing a fused kernel, a work-group
+barrier can added between each of the kernels being fused by applying the
+`insert_barriers` property.
+
+As the fusion compiler can reason about the access behavior of the different
+kernels only in a very limited fashion, **it's the user's responsibility to
+make sure no data races occur in the fused kernel**. Data races could in
+particular be introduced because the implicit inter-work-group synchronization
+between the execution of two separate kernels is eliminated by fusion. The user
+must ensure that the kernels combined during fusion do not rely on this
+synchronization or introduce appropriate synchronization.
+
+Device-wide synchronization can be achieved by splitting the graph into multiple
+subgraphs and fusing each separately, as decribed above.
 
 === Limitations
 
 Some scenarios might require fusion to be cancelled if some undesired scenarios
-arise.
+arise. The required implementation behavior in this case depends on the
+property that was used to initiate fusion.
 
-As the fusion property is not prescriptive, it is not an error for an
-implementation to cancel fusion in those scenarios. A valid recovery from such a
-scenario is to not perform fusion and rather maintain the original graph,
-executing the kernels individually rather than in a single fused kernel. 
+If the _descriptive_ `enable_fusion` property was used to initiate fusion, it
+is not an error for an implementation to cancel fusion in those scenarios. A
+valid recovery from such a scenario is to not perform fusion and rather
+maintain the original graph, executing the kernels individually rather than in
+a single fused kernel. Implementations can provide a diagnostic message in case
+fusion was cancelled through an implementation-specified mechanism, but are not
+required to do so.
 
-Implementations can provide a diagnostic message in case fusion was cancelled
-through an implementation-specified mechanism, but are not required to do so.
+If, on the other hand, the _prescriptive_ `require_fusion` property was used to
+initiate fusion, implementations must raise an error if they need to cancel
+fusion in those scenarios.
 
 The following sections describe a number of scenarios that might require to
 cancel fusion. Note that some implementations might be more capable/permissive
@@ -330,55 +397,82 @@ kernel can be made internal to the fused kernel. Instead of using time-consuming
 reads and writes to/from global memory, the fused kernel can use much faster
 mechanisms, e.g., registers or private memory to "communicate" the result.
 
-To achieve this result during fusion, a fusion compiler must be aware of some
-additional information and context:
+To achieve this result during fusion, a fusion compiler must establish some
+additional context and information. 
 
-* The compiler must know that two arguments refer to the same underlying memory.
-* As internalized buffers or memories are not initialized, elements of the internalized
-  buffer or memory being read by a kernel must have been written before (either in the
-  same kernel or in a previous one in the same graph).
-* Values stored to an internalized buffer/memory must not be used by any other kernel
-  not part of the graph, as the data becomes unavailable to consumers through
-  internalization. This is knowledge that the compiler cannot deduce. Instead,
-  the fact that the values stored to an internalized buffer/memory are not used
-  outside the fused kernel must be provided by the user.
-* If these conditions hold, depending on the memory access pattern of the fused
-  kernel, we can say that a buffer is:
-** _Privately internalizable_: If not a single element of the buffer/memory is to be
-   accessed by more than one work-item;
-** _Locally internalizable_: If not a single element of the buffer/memory is to be
-   accessed by work items of different work groups.
+First, the compiler must know that two arguments refer to the same underlying
+memory. This is possible during runtime, so no additional user input is
+required.
 
-As the compiler can reason about the access behavior of the different kernels
-only in a very limited fashion, **it's the user's responsibility to make sure no
-data races occur in the fused kernel**. Data races could in particular be
-introduced because the implicit inter-work-group synchronization between the
-execution of two separate kernels is eliminated by fusion. The user must ensure
-that the kernels combined during fusion do not rely on this synchronization.
+For the remaining information that needs to be established, the necessity of
+user-provided input depends on the individual capabilities of the
+implementation. 
 
-The properties `sycl::ext::oneapi::experimental::property::promote_local` and
-`sycl::ext::oneapi::experimental::property::promote_local` defined by this
-proposal serve a dual purpose. For one, by adding the properties to an accessor,
-buffer or USM pointer, the user asserts that internalization of the underlying
-memory to private or local memory, respectively, will not cause a data race. 
+If the implementation's fusion compiler is not able to initialize the
+internalized buffers or memories, elements of the internalized buffer or memory
+being read by a kernel must have been written before (either in the same kernel
+or in a previous one in the same graph). This behavior can be asserted by the
+application by applying the `no_init` property (see
+https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_properties_2[section
+4.7.6.4] of the SYCL specification) to the buffer or allocated device memory.
 
-Additionally, the user asserts that no command executing after the fused graph
-requires access to the data that would be stored into the internalized memory if
-no internalization were to happen.
+To this end, this extension allows the use of the property in more places than
+defined in Table 52 in the SYCL specification. More concretely, this extension
+allows to use the property in the buffer constructor or the `property_list`
+parameter of `sycl::malloc_device()`, `sycl::aligned_alloc_device()`,
+`sycl::malloc_shared()` and `sycl::aligned_alloc_shared()`.
 
-In sum this allows users to trigger internalization of a buffer or allocated
-device memory by just specifying a single property.
+If the implementation's fusion compiler is not able to guarantee write-back of
+the final result after internalization, values stored to an internalized
+buffer/memory must not be used by any other kernel not part of the graph, as
+the data becomes unavailable to consumers through internalization. This is
+knowledge that the compiler cannot deduce. Instead, the fact that the values
+stored to an internalized buffer/memory are not used outside the fused kernel
+must be provided by the user by applying the `fusion_internal_memory` property
+to the buffer or allocated device memory as described above.
+
+The type of memory that can be used for internalization depends on the memory
+access pattern of the fuses kernel. Depending on the access pattern, the buffer
+or allocated device memory can be classified as:
+* _Privately internalizable_: If not a single element of the buffer/memory is to
+  be accessed by more than one work-item;
+* _Locally internalizable_: If not a single element of the buffer/memory is to
+  be accessed by work items of different work groups.
+
+If the implementation's fusion compiler is not able to deduce the access
+pattern, suitable information must be provided by the user. To this end,
+specializations of the `access_scope` property template defined in this
+proposal can be used to inform the fusion compiler about the access pattern of
+the kernels involved in fusion.
+
+As already stated above, it depends on the implementation's capabilities which
+properties need to be applied to a buffer or allocated device memory to enable
+dataflow internalization. Implementations should document the necessary
+properties required to enable internalization in implementation documentation.
+
+All internalization-related properties are only _descriptive_, so it is not an
+error if an implementation is unable to perform internalization based on the
+specified properties. Implementations can provide a diagnostic message in case
+the set of specified properties are not sufficient to perform internalization,
+but are not required to do so.
+
+[NOTE]
+====
+The current implementation in DPC++ requires the addition of the `no_init`,
+`fusion_internal_memory` and one specialization of the `access_scope` property
+to buffers or allocated device memory to enable internalization.
+====
 
 ==== Buffer internalization
 
-In some cases, the user will specify different internalization targets for a
+In some cases, the user will specify different access scopes for a
 buffer and accessors to such buffer. When incompatible combinations are used, an
 `exception` with `errc::invalid` error code is thrown. Otherwise, these
 properties must be combined as follows:
 
 [options="header"]
 |===
-|Accessor Internalization Target|Buffer Internalization Target|Resulting Internalization Target
+|Accessor Access Scope|Buffer Access Scope|Resulting Access Scope 
 
 .3+.^|None
 |None
@@ -416,7 +510,7 @@ buffer, the following (commutative and associative) rules are followed:
 
 [options="header"]
 |===
-|Accessor~1~ Internalization Target|Accessor~2~ Internalization Target|Resulting Internalization Target
+|Accessor~1~ Access Scope|Accessor~2~ Access Scope|Resulting Access Scope 
 
 |None
 |_Any_
@@ -435,7 +529,7 @@ buffer, the following (commutative and associative) rules are followed:
 |===
 
 If no work-group size is specified or two accessors specify different
-work-group sizes when using local internalization for any of the
+work-group sizes when attempting local internalization for any of the
 kernels involved in the fusion, no internalization will be
 performed. If there is a mismatch between the two accessors (access
 range, access offset, number of dimensions, data type), no
@@ -475,17 +569,22 @@ int main() {
     // Internalization specified on the buffer
     buffer<int> bTmp2{
         range{dataSize},
-        {sycl::ext::oneapi::experimental::property::promote_private{}}};
+        {sycl::ext::oneapi::experimental::property::access_scope_private{},
+          sycl::ext::oneapi::experimental::property::fusion_internal_memory{},
+          no_init}};
     // Internalization specified on the buffer
     buffer<int> bTmp3{
         range{dataSize},
-        {sycl::ext::oneapi::experimental::property::promote_private{}}};
+        {sycl::ext::oneapi::experimental::property::access_scope_private{},
+          sycl::ext::oneapi::experimental::property::fusion_internal_memory{},
+          no_init}};
     buffer<int> bOut{out, range{dataSize}};
     bOut.set_write_back(false);
 
     ext::oneapi::experimental::command_graph graph{
         q.get_context(), q.get_device(),
-        sycl::ext::oneapi::experimental::property::graph::no_host_copy{}};
+        sycl::ext::oneapi::experimental::property::graph::
+                                                assume_buffer_outlives_graph{}};
 
     graph.begin_recording(q);
 
@@ -494,14 +593,18 @@ int main() {
       auto accIn2 = bIn2.get_access(cgh);
       // Internalization specified on each accessor.
       auto accTmp1 = bTmp1.get_access(
-          cgh, sycl::ext::oneapi::experimental::property::promote_private{});
+          cgh, sycl::ext::oneapi::experimental::property::access_scope_private{}
+            sycl::ext::oneapi::experimental::property::fusion_internal_memory{},
+            no_init);
       cgh.parallel_for<AddKernel>(dataSize, AddKernel{accIn1, accIn2, accTmp1});
     });
 
     q.submit([&](handler &cgh) {
       // Internalization specified on each accessor.
       auto accTmp1 = bTmp1.get_access(
-          cgh, sycl::ext::oneapi::experimental::property::promote_private{});
+          cgh, sycl::ext::oneapi::experimental::property::access_scope_private{}
+            sycl::ext::oneapi::experimental::property::fusion_internal_memory{},
+            no_init);
       auto accIn3 = bIn3.get_access(cgh);
       auto accTmp2 = bTmp2.get_access(cgh);
       cgh.parallel_for<class KernelOne>(
@@ -511,7 +614,9 @@ int main() {
     q.submit([&](handler &cgh) {
       // Internalization specified on each accessor.
       auto accTmp1 = bTmp1.get_access(
-          cgh, sycl::ext::oneapi::experimental::property::promote_private{});
+          cgh, sycl::ext::oneapi::experimental::property::access_scope_private{}
+            sycl::ext::oneapi::experimental::property::fusion_internal_memory{},
+            no_init);
       auto accTmp3 = bTmp3.get_access(cgh);
       cgh.parallel_for<class KernelTwo>(
           dataSize, [=](id<1> i) { accTmp3[i] = accTmp1[i] * 5; });
@@ -530,7 +635,7 @@ int main() {
     // Trigger fusion during finalization.
     auto exec_graph =
         graph.finalize({sycl::ext::oneapi::experimental::property::
-                            graph::perform_fusion});
+                            graph::require_fusion{}});
 
     q.ext_oneapi_graph(exec_graph);
 
@@ -569,7 +674,8 @@ int main() {
   // Specify internalization for an USM pointer
   dTmp = malloc_device<int>(
       q, dataSize,
-      {sycl::ext::oneapi::experimental::property::promote_private});
+      {sycl_ext::property::access_scope_private{},
+        sycl_ext::property::fusion_internal_memory{}, no_init});
 
   // This explicit memory operation is compatible with fusion, as it can be
   // linearized before any device kernel in the graph.
@@ -607,8 +713,7 @@ int main() {
                 {sycl_ext::property::node::depends_on(kernel2)});
 
   // Trigger fusion during finalization.
-  auto exec = graph.finalize({sycl::ext::oneapi::experimental::property::
-                                  graph::perform_fusion});
+  auto exec = graph.finalize({sycl_ext::property::graph::require_fusion{}});
 
   // use queue shortcut for graph submission
   q.ext_oneapi_graph(exec).wait();
@@ -623,13 +728,6 @@ int main() {
 }
 ```
 
-== Contributors
-
-Lukas Sommer, Codeplay +
-Victor Lomüller, Codeplay +
-Victor Perez, Codeplay +
-Ewan Crawford, Codeplay +
-
 == Revision History
 
 [cols="5,15,15,70"]
@@ -641,4 +739,5 @@ Ewan Crawford, Codeplay +
 |2|2023-03-16|Lukas Sommer|*Remove reference to outdated `add_malloc_device` API*
 |3|2023-04-11|Lukas Sommer|*Update usage examples for graph API changes*
 |4|2023-08-17|Lukas Sommer|*Update after graph extension has been merged*
+|5|2023-09-01|Lukas Sommer|*Split internalization properties and change barrier*
 |========================================

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
@@ -44,6 +44,7 @@ Julian Oppermann, Codeplay +
 Ewan Crawford, Codeplay +
 Ben Tracy, Codeplay +
 John Pennycook, Intel +
+Greg Lueck, Intel +
 
 == Dependencies
 
@@ -192,8 +193,9 @@ By adding the `insert_barriers` property, a _work-group barrier_ will be
 inserted between the kernels. To achieve a device-wide synchronization, i.e.,
 a synchronization between different work-groups that is implicit between two
 kernels when executed separately, users should leverage the subgraph feature of
-the SYCL graph proposal. By creating two subgraphs, fusing each and adding both
-to the same graph, a device-wide synchronization between two fused parts can be
+the SYCL graph proposal, as device-wide synchronization inside the fused kernel
+is not achievable. By creating two subgraphs, fusing each and adding both to
+the same graph, a device-wide synchronization between two fused parts can be
 achieved if necessary.
 ====
 
@@ -233,9 +235,11 @@ the property is specified on an accessor) or in any kernel in the graph (in case
 the property is specified on a buffer or an USM pointer).
 
 More concretely, the two shortcuts express the following semantics:
+
 * `access_scope_work_group`: Applying this specialization asserts that each
 element in the buffer or allocated device memory is accessed by no more than one
 work-group.
+
 * `access_scope_work_item`: Applying this specialization asserts that each
 element in the buffer or allocated device memory is accessed by no more than one
 work-item.
@@ -320,7 +324,7 @@ in the sequence before the command itself.
 
 The exact linearization of the dependency DAG (which generally only implies a
 partial order) is implementation defined. The linearization should be
-deterministic, i.e. it should yield the same sequence when presented with the
+deterministic, i.e., it should yield the same sequence when presented with the
 same DAG.
 
 === Synchronization in kernels
@@ -336,13 +340,13 @@ barrier can added between each of the kernels being fused by applying the
 As the fusion compiler can reason about the access behavior of the different
 kernels only in a very limited fashion, **it's the user's responsibility to
 make sure no data races occur in the fused kernel**. Data races could in
-particular be introduced because the implicit inter-work-group synchronization
+particular be introduced because the implicit device-wide synchronization
 between the execution of two separate kernels is eliminated by fusion. The user
 must ensure that the kernels combined during fusion do not rely on this
 synchronization or introduce appropriate synchronization.
 
 Device-wide synchronization can be achieved by splitting the graph into multiple
-subgraphs and fusing each separately, as decribed above.
+subgraphs and fusing each separately, as described above.
 
 === Limitations
 
@@ -421,7 +425,7 @@ To achieve this result during fusion, a fusion compiler must establish some
 additional context and information. 
 
 First, the compiler must know that two arguments refer to the same underlying
-memory. This is possible during runtime, so no additional user input is
+memory. This can be inferred during runtime, so no additional user input is
 required.
 
 For the remaining information that needs to be established, the necessity of
@@ -456,10 +460,12 @@ must be provided by the user by applying the `fusion_internal_memory` property
 to the buffer or allocated device memory as described above.
 
 The type of memory that can be used for internalization depends on the memory
-access pattern of the fuses kernel. Depending on the access pattern, the buffer
+access pattern of the fused kernel. Depending on the access pattern, the buffer
 or allocated device memory can be classified as:
+
 * _Privately internalizable_: If not a single element of the buffer/memory is to
   be accessed by more than one work-item;
+
 * _Locally internalizable_: If not a single element of the buffer/memory is to
   be accessed by work items of different work groups.
 
@@ -483,10 +489,10 @@ dataflow internalization. Implementations should document the necessary
 properties required to enable internalization in implementation documentation.
 
 All internalization-related properties are only _descriptive_, so it is not an
-error if an implementation is unable to perform internalization based on the
-specified properties. Implementations can provide a diagnostic message in case
-the set of specified properties are not sufficient to perform internalization,
-but are not required to do so.
+error if an implementation is unable to or for other reasons decides not to
+perform internalization based on the specified properties. Implementations can
+provide a diagnostic message in case the set of specified properties are not
+sufficient to perform internalization, but are not required to do so.
 
 [NOTE]
 ====
@@ -575,87 +581,86 @@ internalization is performed.
 ```c++
 #include <sycl/sycl.hpp>
 
-using namespace sycl;
+namespace sycl_ext = sycl::ext::oneapi::experimental;
 
 struct AddKernel {
-  accessor<int, 1> accIn1;
-  accessor<int, 1> accIn2;
-  accessor<int, 1> accOut;
+  sycl::accessor<int, 1> accIn1;
+  sycl::accessor<int, 1> accIn2;
+  sycl::accessor<int, 1> accOut;
 
-  void operator()(id<1> i) const { accOut[i] = accIn1[i] + accIn2[i]; }
+  void operator()(sycl::id<1> i) const { accOut[i] = accIn1[i] + accIn2[i]; }
 };
 
 int main() {
   constexpr size_t dataSize = 512;
   int in1[dataSize], in2[dataSize], in3[dataSize], out[dataSize];
 
-  queue q{default_selector_v};
+  sycl::queue q{default_selector_v};
 
   {
-    buffer<int> bIn1{in1, range{dataSize}};
+    sycl::buffer<int> bIn1{in1, sycl::range{dataSize}};
     bIn1.set_write_back(false);
-    buffer<int> bIn2{in2, range{dataSize}};
+    sycl::buffer<int> bIn2{in2, sycl::range{dataSize}};
     bIn2.set_write_back(false);
-    buffer<int> bIn3{in3, range{dataSize}};
+    sycl::buffer<int> bIn3{in3, sycl::range{dataSize}};
     bIn3.set_write_back(false);
     buffer<int> bTmp1{range{dataSize}};
     // Internalization specified on the buffer
-    buffer<int> bTmp2{
-        range{dataSize},
-        {sycl::ext::oneapi::experimental::property::access_scope_work_item{},
-          sycl::ext::oneapi::experimental::property::fusion_internal_memory{},
-          no_init}};
+    sycl::buffer<int> bTmp2{
+        sycl::range{dataSize},
+        {sycl_ext::property::access_scope_work_item{},
+          sycl_ext::property::fusion_internal_memory{},
+          sycl::no_init}};
     // Internalization specified on the buffer
-    buffer<int> bTmp3{
-        range{dataSize},
-        {sycl::ext::oneapi::experimental::property::access_scope_work_item{},
-          sycl::ext::oneapi::experimental::property::fusion_internal_memory{},
-          no_init}};
-    buffer<int> bOut{out, range{dataSize}};
+    sycl::buffer<int> bTmp3{
+        sycl::range{dataSize},
+        {sycl_ext::property::access_scope_work_item{},
+          sycl_ext::property::fusion_internal_memory{},
+          sycl::no_init}};
+    sycl::buffer<int> bOut{out, sycl::range{dataSize}};
     bOut.set_write_back(false);
 
-    ext::oneapi::experimental::command_graph graph{
+    sycl_ext::command_graph graph{
         q.get_context(), q.get_device(),
-        sycl::ext::oneapi::experimental::property::graph::
-                                                assume_buffer_outlives_graph{}};
+        sycl_ext::property::graph::assume_buffer_outlives_graph{}};
 
     graph.begin_recording(q);
 
-    q.submit([&](handler &cgh) {
+    q.submit([&](sycl::handler &cgh) {
       auto accIn1 = bIn1.get_access(cgh);
       auto accIn2 = bIn2.get_access(cgh);
       // Internalization specified on each accessor.
       auto accTmp1 = bTmp1.get_access(cgh,
-            sycl::ext::oneapi::experimental::property::access_scope_work_item{}
-            sycl::ext::oneapi::experimental::property::fusion_internal_memory{},
-            no_init);
+            sycl_ext::property::access_scope_work_item{}
+            sycl_ext::property::fusion_internal_memory{},
+            sycl::no_init);
       cgh.parallel_for<AddKernel>(dataSize, AddKernel{accIn1, accIn2, accTmp1});
     });
 
-    q.submit([&](handler &cgh) {
+    q.submit([&](sycl::handler &cgh) {
       // Internalization specified on each accessor.
       auto accTmp1 = bTmp1.get_access(cgh,
-            sycl::ext::oneapi::experimental::property::access_scope_work_item{}
-            sycl::ext::oneapi::experimental::property::fusion_internal_memory{},
-            no_init);
+            sycl_ext::property::access_scope_work_item{}
+            sycl_ext::property::fusion_internal_memory{},
+            sycl::no_init);
       auto accIn3 = bIn3.get_access(cgh);
       auto accTmp2 = bTmp2.get_access(cgh);
       cgh.parallel_for<class KernelOne>(
-          dataSize, [=](id<1> i) { accTmp2[i] = accTmp1[i] * accIn3[i]; });
+          dataSize, [=](sycl::id<1> i) { accTmp2[i] = accTmp1[i] * accIn3[i]; });
     });
 
-    q.submit([&](handler &cgh) {
+    q.submit([&](sycl::handler &cgh) {
       // Internalization specified on each accessor.
       auto accTmp1 = bTmp1.get_access(cgh,
-            sycl::ext::oneapi::experimental::property::access_scope_work_item{}
-            sycl::ext::oneapi::experimental::property::fusion_internal_memory{},
-            no_init);
+            sycl_ext::property::access_scope_work_item{}
+            sycl_ext::property::fusion_internal_memory{},
+            sycl::no_init);
       auto accTmp3 = bTmp3.get_access(cgh);
       cgh.parallel_for<class KernelTwo>(
-          dataSize, [=](id<1> i) { accTmp3[i] = accTmp1[i] * 5; });
+          dataSize, [=](sycl::id<1> i) { accTmp3[i] = accTmp1[i] * 5; });
     });
 
-    q.submit([&](handler &cgh) {
+    q.submit([&](sycl::handler &cgh) {
       auto accTmp2 = bTmp2.get_access(cgh);
       auto accTmp3 = bTmp3.get_access(cgh);
       auto accOut = bOut.get_access(cgh);
@@ -667,8 +672,7 @@ int main() {
 
     // Trigger fusion during finalization.
     auto exec_graph =
-        graph.finalize({sycl::ext::oneapi::experimental::property::
-                            graph::require_fusion{}});
+        graph.finalize({sycl_ext::property::graph::require_fusion{}});
 
     q.ext_oneapi_graph(exec_graph);
 
@@ -683,8 +687,6 @@ int main() {
 ```c++
 #include <sycl/sycl.hpp>
 
-using namespace sycl;
-
 namespace sycl_ext = sycl::ext::oneapi::experimental;
 
 int main() {
@@ -693,56 +695,56 @@ int main() {
 
   int in1[dataSize], in2[dataSize], in3[dataSize], out[dataSize];
 
-  queue q{default_selector_v};
+  sycl::queue q{default_selector_v};
 
   sycl_ext::command_graph graph{q.get_context(), q.get_device()};
 
   int *dIn1, dIn2, dIn3, dTmp, dOut;
 
-  dIn1 = malloc_device<int>(q, dataSize);
-  dIn2 = malloc_device<int>(q, dataSize);
-  dIn3 = malloc_device<int>(q, dataSize);
-  dOut = malloc_device<int>(q, dataSize);
+  dIn1 = sycl::malloc_device<int>(q, dataSize);
+  dIn2 = sycl::malloc_device<int>(q, dataSize);
+  dIn3 = sycl::malloc_device<int>(q, dataSize);
+  dOut = sycl::malloc_device<int>(q, dataSize);
 
-  // Specify internalization for an USM pointer
-  dTmp = malloc_device<int>(q, dataSize)
+  // Specify internalization to local memory for an USM pointer
+  dTmp = sycl::malloc_device<int>(q, dataSize)
   auto annotatedTmp = sycl_ext::annotated_ptr(
-      dTmp, sycl_ext::property::access_scope_work_item{},
+      dTmp, sycl_ext::property::access_scope_work_group{},
              sycl_ext::property::fusion_internal_memory{}, no_init);
 
   // This explicit memory operation is compatible with fusion, as it can be
   // linearized before any device kernel in the graph.
   auto copy_in1 =
-      graph.add([&](handler &cgh) { cgh.memcpy(dIn1, in1, numBytes); });
+      graph.add([&](sycl::handler &cgh) { cgh.memcpy(dIn1, in1, numBytes); });
 
   // This explicit memory operation is compatible with fusion, as it can be
   // linearized before any device kernel in the graph.
   auto copy_in2 =
-      graph.add([&](handler &cgh) { cgh.memcpy(dIn2, in2, numBytes); });
+      graph.add([&](sycl::handler &cgh) { cgh.memcpy(dIn2, in2, numBytes); });
 
   auto kernel1 = graph.add(
-      [&](handler &cgh) {
+      [&](sycl::handler &cgh) {
         cgh.parallel_for<class KernelOne>(
-            dataSize, [=](id<1> i) { annotatedTmp[i] = in1[i] + in2[i]; });
+            dataSize, [=](sycl::id<1> i) { annotatedTmp[i] = in1[i] + in2[i]; });
       },
       {sycl_ext::property::node::depends_on(copy_in1, copy_in2)});
 
   // This explicit memory operation is compatible with fusion, as it can be
   // linearized before any device kernel in the graph.
   auto copy_in3 =
-      graph.add([&](handler &cgh) { cgh.memcpy(dIn3, in3, numBytes); });
+      graph.add([&](sycl::handler &cgh) { cgh.memcpy(dIn3, in3, numBytes); });
 
   auto kernel2 = graph.add(
-      [&](handler &cgh) {
+      [&](sycl::handler &cgh) {
         cgh.parallel_for<class KernelTwo>(
-            dataSize, [=](id<1> i) { out[i] = annotatedTmp[i] * in3[i]; });
+            dataSize, [=](sycl::id<1> i) { out[i] = annotatedTmp[i] * in3[i]; });
       },
       {sycl_ext::property::node::depends_on(copy_in3, kernel1)});
 
   // This explicit memory operation is compatible with fusion, as it can be
   // linearized after any device kernel in the graph.
   auto copy_out =
-      graph.add([&](handler &cgh) { cgh.memcpy(out, dOut, numBytes); },
+      graph.add([&](sycl::handler &cgh) { cgh.memcpy(out, dOut, numBytes); },
                 {sycl_ext::property::node::depends_on(kernel2)});
 
   // Trigger fusion during finalization.
@@ -751,11 +753,11 @@ int main() {
   // use queue shortcut for graph submission
   q.ext_oneapi_graph(exec).wait();
 
-  free(dIn1, q);
-  free(dIn2, q);
-  free(dIn3, q);
-  free(dOut, q);
-  free(dTmp, q);
+  sycl::free(dIn1, q);
+  sycl::free(dIn2, q);
+  sycl::free(dIn3, q);
+  sycl::free(dOut, q);
+  sycl::free(dTmp, q);
 
   return 0;
 }

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
@@ -125,7 +125,7 @@ sycl::ext::oneapi::experimental::property::command_graph::perform_fusion
 ```
 
 The property is not prescriptive. Implementations are free to not perform fusion
-if it is not possible (see below section <<_limitations>>), fusion is not
+if it is not possible (see below section <<limitations, Limitations>>), fusion is not
 supported by the implementation, or the implementation decides not to perform
 fusion for other reasons. It is not an error if an implementation does not
 perform fusion even though the property is passed. 
@@ -155,7 +155,7 @@ property is also part of the `property_list` of the same invocation of
 
 The following property can be passed to three different APIs, namely:
 
-* The `accessor` constructor, giving a more granular control
+* The `accessor` constructor, giving a more granular control.
 * The `buffer` constructor, in which case all the `accessors` derived from 
 this buffer will inherit this property (unless overridden).
 * The `property_list` parameter of `sycl::malloc_device()`,
@@ -192,7 +192,7 @@ implementation-specified mechanism, but are not required to do so.
 
 The following property can be passed to three different APIs, namely:
 
-* The `accessor` constructor, giving a more granular control
+* The `accessor` constructor, giving a more granular control.
 * The `buffer` constructor, in which case all the `accessors` derived from 
 this buffer will inherit this property (unless overridden).
 * The `property_list` parameter of `sycl::malloc_device()`,

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
@@ -63,7 +63,7 @@ and expose additional optimization opportunities.
 
 One of those further optimizations enabled by the graphs proposal is _kernel
 fusion_. Fusing two or more kernels executing on the same device into a single
-kernel launch can further reduce runtime overhead and enable futher kernel
+kernel launch can further reduce runtime overhead and enable further kernel
 optimizations such as dataflow internalization discussed below.
 
 This proposal is a continuation of many of the ideas of the initial

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
@@ -43,7 +43,7 @@ references below to the "core SYCL specification" or to section numbers in the
 SYCL specification refer to that revision.
 
 This extension builds on top of the proposed SYCL graphs
-https://github.com/reble/llvm/blob/sycl-graph-update/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc[extension
+https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc[extension
 proposal]. All references to the "graphs proposal" refer to this proposal.
 
 == Status
@@ -57,9 +57,9 @@ not rely on APIs defined in this specification.*
 == Overview
 
 The SYCL graph
-https://github.com/reble/llvm/blob/sycl-graph-update/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc[extension
+https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc[extension
 proposal] seeks to reduce the runtime overhead linked to SYCL kernel submission
-and expose additional optimization opportunities. 
+and expose additional optimization opportunities.
 
 One of those further optimizations enabled by the graphs proposal is _kernel
 fusion_. Fusing two or more kernels executing on the same device into a single
@@ -121,7 +121,7 @@ can be added to the property list to indicate that the kernels in the
 command-graph should be fused. 
 
 ```c++
-sycl::ext::oneapi::experimental::property::command_graph::perform_fusion 
+sycl::ext::oneapi::experimental::property::graph::perform_fusion 
 ```
 
 The property is not prescriptive. Implementations are free to not perform fusion
@@ -140,14 +140,14 @@ The following property can be added to the `property_list` of the
 `command_graph<graph_state::modifiable>::finalize()` API.
 
 ```c++
-sycl::ext::oneapi::experimental::property::command_graph::no_barriers
+sycl::ext::oneapi::experimental::property::graph::no_barriers
 ```
 
 If the property list contains this property, no barriers are introduced between
 kernels in the fused kernel (see below section on synchronization on kernels). 
 
 The property only takes effect if the
-`sycl::ext::oneapi::experimental::property::command_graph::perform_fusion`
+`sycl::ext::oneapi::experimental::property::graph::perform_fusion`
 property is also part of the `property_list` of the same invocation of
 `command_graph<...>::finalize()`. 
 
@@ -530,7 +530,7 @@ int main() {
     // Trigger fusion during finalization.
     auto exec_graph =
         graph.finalize({sycl::ext::oneapi::experimental::property::
-                            command_graph::perform_fusion});
+                            graph::perform_fusion});
 
     q.ext_oneapi_graph(exec_graph);
 
@@ -608,7 +608,7 @@ int main() {
 
   // Trigger fusion during finalization.
   auto exec = graph.finalize({sycl::ext::oneapi::experimental::property::
-                                  command_graph::perform_fusion});
+                                  graph::perform_fusion});
 
   // use queue shortcut for graph submission
   q.ext_oneapi_graph(exec).wait();

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
@@ -465,18 +465,23 @@ int main() {
 
   queue q{default_selector_v};
 
-  ext::oneapi::experimental::command_graph graph;
+  ext::oneapi::experimental::command_graph graph{q.get_context(),
+                                                 q.get_device()};
   {
     buffer<int> bIn1{in1, range{dataSize}};
     buffer<int> bIn2{in2, range{dataSize}};
     buffer<int> bIn3{in3, range{dataSize}};
     buffer<int> bTmp1{tmp1, range{dataSize}};
     // Internalization specified on the buffer
-    buffer<int> bTmp2{tmp2, range{dataSize}, 
-      {sycl::ext::oneapi::experimental::property::promote_private{}}};
+    buffer<int> bTmp2{
+        tmp2,
+        range{dataSize},
+        {sycl::ext::oneapi::experimental::property::promote_private{}}};
     // Internalization specified on the buffer
-    buffer<int> bTmp3{tmp3, range{dataSize}, 
-      {sycl::ext::oneapi::experimental::property::promote_private{}}};
+    buffer<int> bTmp3{
+        tmp3,
+        range{dataSize},
+        {sycl::ext::oneapi::experimental::property::promote_private{}}};
     buffer<int> bOut{out, range{dataSize}};
 
     graph.begin_recording(q);
@@ -484,14 +489,14 @@ int main() {
     q.submit([&](handler &cgh) {
       auto accIn1 = bIn1.get_access(cgh);
       auto accIn2 = bIn2.get_access(cgh);
-      // Internalization specified on each accessor. 
+      // Internalization specified on each accessor.
       auto accTmp1 = bTmp1.get_access(
           cgh, sycl::ext::oneapi::experimental::property::promote_private{});
       cgh.parallel_for<AddKernel>(dataSize, AddKernel{accIn1, accIn2, accTmp1});
     });
 
     q.submit([&](handler &cgh) {
-      // Internalization specified on each accessor. 
+      // Internalization specified on each accessor.
       auto accTmp1 = bTmp1.get_access(
           cgh, sycl::ext::oneapi::experimental::property::promote_private{});
       auto accIn3 = bIn3.get_access(cgh);
@@ -501,7 +506,7 @@ int main() {
     });
 
     q.submit([&](handler &cgh) {
-      // Internalization specified on each accessor. 
+      // Internalization specified on each accessor.
       auto accTmp1 = bTmp1.get_access(
           cgh, sycl::ext::oneapi::experimental::property::promote_private{});
       auto accTmp3 = bTmp3.get_access(cgh);
@@ -520,12 +525,11 @@ int main() {
     graph.end_recording();
 
     // Trigger fusion during finalization.
-    auto exec_graph = graph.finalize(q.get_context(), 
-      {sycl::ext::oneapi::experimental::property::command_graph::perform_fusion});
+    auto exec_graph =
+        graph.finalize({sycl::ext::oneapi::experimental::property::
+                            command_graph::perform_fusion});
 
-    q.submit([&](handler& cgh) {
-      cgh.ext_oneapi_graph(exec_graph);
-    });
+    q.ext_oneapi_graph(exec_graph);
   }
   return 0;
 }
@@ -548,7 +552,7 @@ int main() {
 
   queue q{default_selector_v};
 
-  sycl_ext::command_graph graph;
+  sycl_ext::command_graph graph{q.get_context(), q.get_device()};
 
   int *dIn1, dIn2, dIn3, dTmp, dOut;
 
@@ -558,7 +562,8 @@ int main() {
   dOut = malloc_device<int>(q, dataSize);
 
   // Specify internalization for an USM pointer
-  dTmp = malloc_device<int>(q, dataSize,
+  dTmp = malloc_device<int>(
+      q, dataSize,
       {sycl::ext::oneapi::experimental::property::promote_private});
 
   // This explicit memory operation is compatible with fusion, as it can be
@@ -597,8 +602,7 @@ int main() {
                 {sycl_ext::property::node::depends_on(kernel2)});
 
   // Trigger fusion during finalization.
-  auto exec = graph.finalize(q.get_context(),
-                             {sycl::ext::oneapi::experimental::property::
+  auto exec = graph.finalize({sycl::ext::oneapi::experimental::property::
                                   command_graph::perform_fusion});
 
   // use queue shortcut for graph submission
@@ -630,4 +634,5 @@ Ewan Crawford, Codeplay +
 |Rev|Date|Authors|Changes
 |1|2023-02-16|Lukas Sommer|*Initial draft*
 |2|2023-03-16|Lukas Sommer|*Remove reference to outdated `add_malloc_device` API*
+|3|2023-04-11|Lukas Sommer|*Update usage examples for graph API changes*
 |========================================

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
@@ -211,7 +211,7 @@ namespace sycl::ext::oneapi::experimental::property{
   inline constexpr auto access_scope_local = 
                                     access_scope<memory_scope_work_group>;
 
-  inlint constexpr auto access_scope_private = 
+  inline constexpr auto access_scope_private = 
                                     access_scope<memory_scope_work_item>;
 
 } // namespace sycl::ext::oneapi::experimental::property

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
@@ -55,6 +55,13 @@ This extension builds on top of the experimental SYCL graphs
 https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc[extension
 proposal]. All references to the "graphs proposal" refer to this proposal.
 
+In addition, this extension also depends on the following other SYCL extensions:
+
+* link:../experimental/sycl_ext_oneapi_properties.asciidoc[sycl_ext_oneapi_properties]
+extension.
+* link:../experimental/sycl_ext_oneapi_annotated_ptr.asciidoc[sycl_ext_oneapi_annotated_ptr]
+extension.
+
 == Status
 
 This is a proposed extension specification, intended to gather community
@@ -198,9 +205,8 @@ different APIs, namely:
 * The `accessor` constructor, giving a more granular control.
 * The `buffer` constructor, in which case all the `accessors` derived from 
 this buffer will inherit this property (unless overridden).
-* The `property_list` parameter of `sycl::malloc_device()`,
-`sycl::aligned_alloc_device()`, `sycl::malloc_shared()`, or
-`sycl::aligned_alloc_shared()` to apply the property to an USM pointer.
+* The property list parameter of `annotated_ptr`, to apply the property to a
+USM pointer.
 
 ```c++
 namespace sycl::ext::oneapi::experimental::property{
@@ -248,6 +254,13 @@ Implementations can provide a diagnostic message in case internalization was
 not performed through an implementation-specified mechanism, but are not
 required to do so.
 
+In case the `access_scope` property is attached to `annotated_ptr`, the
+properties should be inspected by an implementation when the `annotated_ptr` is
+captured by a kernel lambda or otherwise passed as an argument to a kernel
+function. Implementations are not required to track internalization-related
+information from other USM pointers that may be used by a kernel, such as those
+stored inside of structs or other data structures.
+
 ===== Internal memory property
 
 The following property can be passed to three different APIs, namely:
@@ -255,9 +268,8 @@ The following property can be passed to three different APIs, namely:
 * The `accessor` constructor, giving a more granular control.
 * The `buffer` constructor, in which case all the `accessors` derived from 
 this buffer will inherit this property (unless overridden).
-* The `property_list` parameter of `sycl::malloc_device()`,
-`sycl::aligned_alloc_device()`, `sycl::malloc_shared()`, or
-`sycl::aligned_alloc_shared()` to apply the property to an USM pointer.
+* The property list parameter of `annotated_ptr`, to apply the property to a
+USM pointer.
 
 ```c++ 
 sycl::ext::oneapi::experimental::property::fusion_internal_memory 
@@ -276,6 +288,14 @@ internalization and it is no error if they do not perform internalization.
 Implementations can provide a diagnostic message in case internalization was
 not performed through an implementation-specified mechanism, but are not
 required to do so.
+
+In case the `fusion_internal_memory` property is attached to `annotated_ptr`,
+the properties should be inspected by an implementation when the
+`annotated_ptr` is captured by a kernel lambda or otherwise passed as an
+argument to a kernel function. Implementations are not required to track
+internalization-related information from other USM pointers that may be used by
+a kernel, such as those stored inside of structs or other data structures.
+
 
 ==== Device aspect 
 
@@ -418,9 +438,13 @@ https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_propertie
 
 To this end, this extension allows the use of the property in more places than
 defined in Table 52 in the SYCL specification. More concretely, this extension
-allows to use the property in the buffer constructor or the `property_list`
-parameter of `sycl::malloc_device()`, `sycl::aligned_alloc_device()`,
-`sycl::malloc_shared()` and `sycl::aligned_alloc_shared()`.
+allows to use the property in the buffer constructor or the property list
+parameter of `annotated_ptr<...>`. In case the `no_init` property is attached to 
+`annotated_ptr`, the properties should be inspected by an implementation when
+the `annotated_ptr` is captured by a kernel lambda or otherwise passed as an
+argument to a kernel function. Implementations are not required to track
+internalization-related information from other USM pointers that may be used by
+a kernel, such as those stored inside of structs or other data structures.
 
 If the implementation's fusion compiler is not able to guarantee write-back of
 the final result after internalization, values stored to an internalized
@@ -444,6 +468,14 @@ pattern, suitable information must be provided by the user. To this end,
 specializations of the `access_scope` property template defined in this
 proposal can be used to inform the fusion compiler about the access pattern of
 the kernels involved in fusion.
+
+If an `annotated_ptr` is created with any of the properties relating to
+internalization and captured by a kernel lambda or otherwise passed as an
+argument to a kernel function participating in fusion, the underlying memory
+must only be accessed via pointers that are also captured or passed as kernel
+argument. Access to the underlying memory via a different pointer, such as
+pointers stored inside of structs or other data structures results in undefined
+behavior.
 
 As already stated above, it depends on the implementation's capabilities which
 properties need to be applied to a buffer or allocated device memory to enable
@@ -506,11 +538,12 @@ properties must be combined as follows:
 |===
 
 In case different internalization targets are used for accessors to the same
-buffer, the following (commutative and associative) rules are followed:
+buffer or for `annotated_ptr` pointing to the same underlying memory, the
+following (commutative and associative) rules are followed:
 
 [options="header"]
 |===
-|Accessor~1~ Access Scope|Accessor~2~ Access Scope|Resulting Access Scope 
+|Accessor/Ptr~1~ Access Scope|Accessor/Ptr~2~ Access Scope|Resulting Access Scope 
 
 |None
 |_Any_
@@ -528,7 +561,7 @@ buffer, the following (commutative and associative) rules are followed:
 |Work Item
 |===
 
-If no work-group size is specified or two accessors specify different
+If no work-group size is specified or two kernels specify different
 work-group sizes when attempting local internalization for any of the
 kernels involved in the fusion, no internalization will be
 performed. If there is a mismatch between the two accessors (access
@@ -672,10 +705,10 @@ int main() {
   dOut = malloc_device<int>(q, dataSize);
 
   // Specify internalization for an USM pointer
-  dTmp = malloc_device<int>(
-      q, dataSize,
-      {sycl_ext::property::access_scope_work_item{},
-        sycl_ext::property::fusion_internal_memory{}, no_init});
+  dTmp = malloc_device<int>(q, dataSize)
+  auto annotatedTmp = sycl_ext::annotated_ptr(
+      dTmp, sycl_ext::property::access_scope_work_item{},
+             sycl_ext::property::fusion_internal_memory{}, no_init);
 
   // This explicit memory operation is compatible with fusion, as it can be
   // linearized before any device kernel in the graph.
@@ -690,7 +723,7 @@ int main() {
   auto kernel1 = graph.add(
       [&](handler &cgh) {
         cgh.parallel_for<class KernelOne>(
-            dataSize, [=](id<1> i) { tmp[i] = in1[i] + in2[i]; });
+            dataSize, [=](id<1> i) { annotatedTmp[i] = in1[i] + in2[i]; });
       },
       {sycl_ext::property::node::depends_on(copy_in1, copy_in2)});
 
@@ -702,7 +735,7 @@ int main() {
   auto kernel2 = graph.add(
       [&](handler &cgh) {
         cgh.parallel_for<class KernelTwo>(
-            dataSize, [=](id<1> i) { out[i] = tmp[i] * in3[i]; });
+            dataSize, [=](id<1> i) { out[i] = annotatedTmp[i] * in3[i]; });
       },
       {sycl_ext::property::node::depends_on(copy_in3, kernel1)});
 
@@ -740,4 +773,5 @@ int main() {
 |3|2023-04-11|Lukas Sommer|*Update usage examples for graph API changes*
 |4|2023-08-17|Lukas Sommer|*Update after graph extension has been merged*
 |5|2023-09-01|Lukas Sommer|*Split internalization properties and change barrier*
+|6|2023-09-13|Lukas Sommer|*Use annotated_ptr for USM internalization*
 |========================================

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph_fusion.asciidoc
@@ -208,10 +208,10 @@ namespace sycl::ext::oneapi::experimental::property{
   template<sycl::memory_scope Scope>
   struct access_scope {};
 
-  inline constexpr auto access_scope_local = 
+  inline constexpr auto access_scope_work_group = 
                                     access_scope<memory_scope_work_group>;
 
-  inline constexpr auto access_scope_private = 
+  inline constexpr auto access_scope_work_item = 
                                     access_scope<memory_scope_work_item>;
 
 } // namespace sycl::ext::oneapi::experimental::property
@@ -227,11 +227,11 @@ the property is specified on an accessor) or in any kernel in the graph (in case
 the property is specified on a buffer or an USM pointer).
 
 More concretely, the two shortcuts express the following semantics:
-* `access_scope_local`: Applying this specialization asserts that each element 
-in the buffer or allocated device memory is accessed by no more than one
+* `access_scope_work_group`: Applying this specialization asserts that each
+element in the buffer or allocated device memory is accessed by no more than one
 work-group.
-* `access_scope_private`: Applying this specialization asserts that each element 
-in the buffer or allocated device memory is accessed by no more than one
+* `access_scope_work_item`: Applying this specialization asserts that each
+element in the buffer or allocated device memory is accessed by no more than one
 work-item.
 
 Implementations may treat specializations of the access scope property as a
@@ -478,31 +478,31 @@ properties must be combined as follows:
 |None
 |None
 
-|Local
-|Local
+|Work Group
+|Work Group
 
-|Private
-|Private
+|Work Item
+|Work Item
 
-.3+.^|Local
+.3+.^|Work Group
 |None
-|Local
+|Work Group
 
-|Local
-|Local
+|Work Group
+|Work Group
 
-|Private
+|Work Item
 |*Error*
 
-.3+.^|Private
+.3+.^|Work Item
 |None
-|Private
+|Work Item
 
-|Local
+|Work Group
 |*Error*
 
-|Private
-|Private
+|Work Item
+|Work Item
 |===
 
 In case different internalization targets are used for accessors to the same
@@ -516,16 +516,16 @@ buffer, the following (commutative and associative) rules are followed:
 |_Any_
 |None
 
-.2+.^|Local
-|Local
-|Local
+.2+.^|Work Group
+|Work Group
+|Work Group
 
-|Private
+|Work Item
 |None
 
-|Private
-|Private
-|Private
+|Work Item
+|Work Item
+|Work Item
 |===
 
 If no work-group size is specified or two accessors specify different
@@ -569,13 +569,13 @@ int main() {
     // Internalization specified on the buffer
     buffer<int> bTmp2{
         range{dataSize},
-        {sycl::ext::oneapi::experimental::property::access_scope_private{},
+        {sycl::ext::oneapi::experimental::property::access_scope_work_item{},
           sycl::ext::oneapi::experimental::property::fusion_internal_memory{},
           no_init}};
     // Internalization specified on the buffer
     buffer<int> bTmp3{
         range{dataSize},
-        {sycl::ext::oneapi::experimental::property::access_scope_private{},
+        {sycl::ext::oneapi::experimental::property::access_scope_work_item{},
           sycl::ext::oneapi::experimental::property::fusion_internal_memory{},
           no_init}};
     buffer<int> bOut{out, range{dataSize}};
@@ -592,8 +592,8 @@ int main() {
       auto accIn1 = bIn1.get_access(cgh);
       auto accIn2 = bIn2.get_access(cgh);
       // Internalization specified on each accessor.
-      auto accTmp1 = bTmp1.get_access(
-          cgh, sycl::ext::oneapi::experimental::property::access_scope_private{}
+      auto accTmp1 = bTmp1.get_access(cgh,
+            sycl::ext::oneapi::experimental::property::access_scope_work_item{}
             sycl::ext::oneapi::experimental::property::fusion_internal_memory{},
             no_init);
       cgh.parallel_for<AddKernel>(dataSize, AddKernel{accIn1, accIn2, accTmp1});
@@ -601,8 +601,8 @@ int main() {
 
     q.submit([&](handler &cgh) {
       // Internalization specified on each accessor.
-      auto accTmp1 = bTmp1.get_access(
-          cgh, sycl::ext::oneapi::experimental::property::access_scope_private{}
+      auto accTmp1 = bTmp1.get_access(cgh,
+            sycl::ext::oneapi::experimental::property::access_scope_work_item{}
             sycl::ext::oneapi::experimental::property::fusion_internal_memory{},
             no_init);
       auto accIn3 = bIn3.get_access(cgh);
@@ -613,8 +613,8 @@ int main() {
 
     q.submit([&](handler &cgh) {
       // Internalization specified on each accessor.
-      auto accTmp1 = bTmp1.get_access(
-          cgh, sycl::ext::oneapi::experimental::property::access_scope_private{}
+      auto accTmp1 = bTmp1.get_access(cgh,
+            sycl::ext::oneapi::experimental::property::access_scope_work_item{}
             sycl::ext::oneapi::experimental::property::fusion_internal_memory{},
             no_init);
       auto accTmp3 = bTmp3.get_access(cgh);
@@ -674,7 +674,7 @@ int main() {
   // Specify internalization for an USM pointer
   dTmp = malloc_device<int>(
       q, dataSize,
-      {sycl_ext::property::access_scope_private{},
+      {sycl_ext::property::access_scope_work_item{},
         sycl_ext::property::fusion_internal_memory{}, no_init});
 
   // This explicit memory operation is compatible with fusion, as it can be


### PR DESCRIPTION
Experimental SYCL extension proposal for kernel fusion on top of the [SYCL graphs API](https://github.com/reble/llvm/blob/sycl-graph-update/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc).

Constructing the sequence of kernels to fuse is completely left to the graphs proposal, which provides two APIs to this end. One recording API similar to the fusion mode for queues in the initial kernel fusion proposal, and an explicit graph construction APIs. Both APIs are supported for kernel fusion.

This proposal mainly introduces a number of properties to trigger fusion of the graph and internalization of dataflow in the fused kernel.

This proposal continues some of the ideas of the [experimental SYCL extension for kernel fusion](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_codeplay_kernel_fusion.asciidoc). In contrast to the original kernel fusion proposal, this proposal now also allows internalization of USM pointers.