### PR TITLE
[SYCL-MLIR] Override `SYCLConstructorOp::getEffects()`

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -515,14 +515,15 @@ def SYCLSubGroupLocalIDOp : SYCL1DGridOp<"sub_group_local_id"> {
 // CONSTRUCTOR OPERATION
 ////////////////////////////////////////////////////////////////////////////////
 
-def SYCLConstructorOp : SYCL_Op<"constructor", [CallOpInterface]> {
+def SYCLConstructorOp : SYCL_Op<"constructor",
+    [CallOpInterface, MemoryEffectsOpInterface]> {
   let summary = "Generic constructor operation";
   let description = [{
     This operation represent the call to the constructor of a SYCL type.
   }];
 
   let arguments = (ins
-    Arg<SYCLMemref, "The SYCL object being created", [MemWrite]>:$Dst,
+    Arg<SYCLMemref, "The SYCL object being created">:$Dst,
     Arg<Variadic<AnyType>, "The constructor arguments">:$Args,
     FlatSymbolRefAttr:$TypeName,
     FlatSymbolRefAttr:$MangledFunctionName
@@ -544,6 +545,15 @@ def SYCLConstructorOp : SYCL_Op<"constructor", [CallOpInterface]> {
     operand_range getArgOperands() {
       return {arg_operand_begin(), arg_operand_end()};
     }
+
+    /// Return the memory effects associated to each argument.
+    ///
+    /// The first argument, `this` will have `MemoryEffects::Write` memory
+    /// effect associated and the rest of argument will have
+    /// `MemoryEffects::Read` if they're a pointer/memref and no memory effect
+    /// otherwise.
+    void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<
+                        ::mlir::MemoryEffects::Effect>> &effects);
   }];      
 
   let assemblyFormat = [{

--- a/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
@@ -161,6 +161,23 @@ LogicalResult SYCLAccessorSubscriptOp::verify() {
       });
 }
 
+void SYCLConstructorOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  // NOTE: This definition assumes only the first (`this`) argument is written
+  // to. This is true for constructors run in the device, but not necessarily
+  // true for constructors run in host code.
+  auto *defaultResource = SideEffects::DefaultResource::get();
+  // The `this` argument will always be written to
+  effects.emplace_back(MemoryEffects::Write::get(), getDst(), defaultResource);
+  // The rest of the arguments will be scalar or read from
+  for (auto value : getArgs()) {
+    if (isa<MemRefType, LLVM::LLVMPointerType>(value.getType())) {
+      effects.emplace_back(MemoryEffects::Read::get(), value, defaultResource);
+    }
+  }
+}
+
 #include "mlir/Dialect/SYCL/IR/SYCLOpInterfaces.cpp.inc"
 
 #define GET_OP_CLASSES

--- a/polygeist/test/polygeist-opt/sycl/licm-constructor.mlir
+++ b/polygeist/test/polygeist-opt/sycl/licm-constructor.mlir
@@ -1,0 +1,42 @@
+// RUN: polygeist-opt -licm %s | FileCheck %s
+
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+
+// CHECK-LABEL:   func.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: memref<?x!sycl_nd_range_1_>) {
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = memref.alloca() : memref<1x!sycl_nd_range_1_>
+// CHECK-DAG:       %[[VAL_4:.*]] = memref.alloca() : memref<1x!sycl_range_1_>
+// CHECK-DAG:       %[[VAL_5:.*]] = memref.alloca() : memref<1x!sycl_range_1_>
+// CHECK:           %[[VAL_6:.*]] = memref.dim %[[VAL_0]], %[[VAL_1]] : memref<?x!sycl_nd_range_1_>
+// CHECK:           %[[VAL_7:.*]] = arith.cmpi slt, %[[VAL_1]], %[[VAL_6]] : index
+// CHECK:           scf.if %[[VAL_7]] {
+// CHECK:             sycl.constructor @range(%[[VAL_4]], %[[VAL_1]]) {MangledFunctionName = @range} : (memref<1x!sycl_range_1_>, index)
+// CHECK:             sycl.constructor @range(%[[VAL_5]], %[[VAL_1]]) {MangledFunctionName = @range} : (memref<1x!sycl_range_1_>, index)
+// CHECK:             sycl.constructor @nd_range(%[[VAL_3]], %[[VAL_4]], %[[VAL_5]]) {MangledFunctionName = @nd_range} : (memref<1x!sycl_nd_range_1_>, memref<1x!sycl_range_1_>, memref<1x!sycl_range_1_>)
+// CHECK:             %[[VAL_8:.*]] = memref.load %[[VAL_3]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_nd_range_1_>
+// CHECK:             scf.for %[[VAL_9:.*]] = %[[VAL_1]] to %[[VAL_6]] step %[[VAL_2]] {
+// CHECK:               memref.store %[[VAL_8]], %[[VAL_0]]{{\[}}%[[VAL_9]]] : memref<?x!sycl_nd_range_1_>
+// CHECK:             }
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+func.func @test(%out: memref<?x!sycl_nd_range_1_>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %nd = memref.alloca() : memref<1x!sycl_nd_range_1_>
+  %gs = memref.alloca() : memref<1x!sycl_range_1_>
+  %ls = memref.alloca() : memref<1x!sycl_range_1_>
+  %size = memref.dim %out, %c0 : memref<?x!sycl_nd_range_1_>
+  scf.for %i = %c0 to %size step %c1 {
+    sycl.constructor @range(%gs, %c0) {MangledFunctionName = @range} : (memref<1x!sycl_range_1_>, index)
+    sycl.constructor @range(%ls, %c0) {MangledFunctionName = @range} : (memref<1x!sycl_range_1_>, index)
+    sycl.constructor @nd_range(%nd, %gs, %ls) {MangledFunctionName = @nd_range} : (memref<1x!sycl_nd_range_1_>, memref<1x!sycl_range_1_>, memref<1x!sycl_range_1_>)
+    %val = memref.load %nd[%c0] : memref<1x!sycl_nd_range_1_>
+    memref.store %val, %out[%i] : memref<?x!sycl_nd_range_1_>
+  }
+  return
+}


### PR DESCRIPTION
Custom definition so that the first argument is marked as write only and the rest is read only for pointers/memrefs or no effect for other types.