### PR TITLE
[SYCL-MLIR] Fix inlining of `SYCLMethodOp` operations

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.td
@@ -32,6 +32,7 @@ def InlinePass : Pass<"inliner"> {
     Option<"MaxIterationCount", "max-num-iters", "unsigned", /*default=*/"3",
            "Maximum number of inlining iterations for each SCC">,
   ];
+  let dependentDialects = ["memref::MemRefDialect"];
 
   let statistics = [
     Statistic<"NumInlinedCalls", "num-inlined-calls", "Number of inlined calls">
@@ -44,8 +45,7 @@ def SYCLMethodToSYCLCall : Pass<"sycl-method-to-sycl-call", "ModuleOp"> {
     Replace SYCLMethodOpInterface instances by SYCLCallOps.
   }];
   let constructor = "mlir::sycl::createSYCLMethodToSYCLCallPass()";
-  let dependentDialects =
-    ["memref::MemRefDialect", "LLVM::LLVMDialect", "polygeist::PolygeistDialect"];
+  let dependentDialects = ["memref::MemRefDialect"];
 }
 
 #endif // MLIR_DIALECT_SYCL_TRANSFORMS_PASSES

--- a/mlir-sycl/lib/Transforms/CMakeLists.txt
+++ b/mlir-sycl/lib/Transforms/CMakeLists.txt
@@ -1,10 +1,10 @@
 add_mlir_library(MLIRSYCLTransforms
   Inliner.cpp
   SYCLMethodToSYCLCall.cpp
+  Utils.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Transforms
-  ${POLYGEIST_INCLUDE_DIR}
 
   DEPENDS
   MLIRSYCLTransformsIncGen
@@ -16,5 +16,4 @@ add_mlir_library(MLIRSYCLTransforms
   MLIRSYCLDialect
   MLIRFuncDialect
   MLIRGPUOps
-  MLIRPolygeist
   )

--- a/mlir-sycl/lib/Transforms/SYCLMethodToSYCLCall.cpp
+++ b/mlir-sycl/lib/Transforms/SYCLMethodToSYCLCall.cpp
@@ -11,20 +11,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
-#include "mlir/Dialect/MemRef/IR/MemRef.h"
-#include "mlir/Dialect/SYCL/IR/SYCLOpsDialect.h"
-#include "mlir/Dialect/SYCL/MethodUtils.h"
 #include "mlir/Dialect/SYCL/Transforms/Passes.h"
 
-#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "Utils.h"
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"
+#include "mlir/Dialect/SYCL/MethodUtils.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Rewrite/FrozenRewritePatternSet.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
-#include "mlir/Dialect/Polygeist/IR/Ops.h"
 #include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "sycl-method-to-sycl-call"
@@ -37,63 +33,6 @@ namespace mlir {
 
 using namespace mlir;
 using namespace sycl;
-
-static mlir::Value adaptArgumentForSYCLCall(OpBuilder &Rewriter,
-                                            mlir::Location Loc,
-                                            mlir::Value Original,
-                                            mlir::Type TargetType) {
-  if (Original.getType() == TargetType)
-    return Original;
-
-  const auto MT = TargetType.cast<MemRefType>();
-  const auto ThisType = Original.getType().cast<MemRefType>();
-  const llvm::ArrayRef<int64_t> TargetShape = MT.getShape();
-  const mlir::Type TargetElementType = MT.getElementType();
-  const unsigned TargetMemSpace = MT.getMemorySpaceAsInt();
-
-  assert(MT.getLayout() == ThisType.getLayout() && "Invalid layout mismatch");
-
-  if (TargetShape != ThisType.getShape()) {
-    Original = Rewriter.create<memref::CastOp>(
-        Loc,
-        MemRefType::get(TargetShape, ThisType.getElementType(),
-                        ThisType.getLayout(), ThisType.getMemorySpace()),
-        Original);
-    LLVM_DEBUG(llvm::dbgs() << "  MemRef cast needed: " << Original << "\n");
-  }
-
-  if (ThisType.getMemorySpaceAsInt() != TargetMemSpace) {
-    Original = Rewriter.create<memref::MemorySpaceCastOp>(
-        Loc,
-        MemRefType::get(TargetShape, ThisType.getElementType(),
-                        ThisType.getLayout().getAffineMap(), TargetMemSpace),
-        Original);
-    LLVM_DEBUG(llvm::dbgs()
-               << "  Address space cast needed: " << Original << "\n");
-  }
-
-  if (ThisType.getElementType() != TargetElementType) {
-    Original = Rewriter.create<sycl::SYCLCastOp>(Loc, TargetType, Original);
-    LLVM_DEBUG(llvm::dbgs() << "  sycl.cast inserted: " << Original << "\n");
-  }
-
-  return Original;
-}
-
-static SmallVector<Value>
-adaptArgumentsForSYCLCall(OpBuilder &Builder, SYCLMethodOpInterface Method) {
-  SmallVector<Value> Transformed;
-  Transformed.reserve(Method->getNumOperands());
-  const auto Loc = Method.getLoc();
-  const auto TargetTypes = Method.getArgumentTypes();
-  std::transform(Method->operand_begin(), Method->operand_end(),
-                 TargetTypes.begin(), std::back_inserter(Transformed),
-                 [&](auto Val, auto Ty) {
-                   return adaptArgumentForSYCLCall(Builder, Loc, Val, Ty);
-                 });
-  assert(ValueRange{Transformed}.getTypes() == TargetTypes);
-  return Transformed;
-}
 
 static LogicalResult convertMethod(SYCLMethodOpInterface method,
                                    PatternRewriter &rewriter) {

--- a/mlir-sycl/lib/Transforms/Utils.cpp
+++ b/mlir-sycl/lib/Transforms/Utils.cpp
@@ -1,0 +1,73 @@
+#include "Utils.h"
+
+#include "mlir/Dialect/SYCL/IR/SYCLOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "llvm/Support/Debug.h"
+
+#define INLINER_DEBUG_TYPE "inlining"
+#define SYCL_METHOD_TO_SYCL_CALL_DEBUG_TYPE "sycl-method-to-sycl-call"
+
+/// Custom definition to print messages coming from clients.
+#define LLVM_DEBUG(X)                                                          \
+  DEBUG_WITH_TYPE(INLINER_DEBUG_TYPE, X);                                      \
+  DEBUG_WITH_TYPE(SYCL_METHOD_TO_SYCL_CALL_DEBUG_TYPE, X)
+
+using namespace mlir;
+using namespace sycl;
+
+static Value adaptArgumentForSYCLCall(OpBuilder &rewriter, Location loc,
+                                      Value original, Type targetType) {
+  if (original.getType() == targetType)
+    return original;
+
+  const auto mt = targetType.cast<MemRefType>();
+  const auto thisType = original.getType().cast<MemRefType>();
+  const llvm::ArrayRef<int64_t> targetShape = mt.getShape();
+  const Type targetElementType = mt.getElementType();
+  const unsigned targetMemSpace = mt.getMemorySpaceAsInt();
+
+  assert(mt.getLayout() == thisType.getLayout() && "Invalid layout mismatch");
+
+  if (targetShape != thisType.getShape()) {
+    original = rewriter.create<memref::CastOp>(
+        loc,
+        MemRefType::get(targetShape, thisType.getElementType(),
+                        thisType.getLayout(), thisType.getMemorySpace()),
+        original);
+    LLVM_DEBUG(llvm::dbgs() << "  MemRef cast needed: " << original << "\n");
+  }
+
+  if (thisType.getMemorySpaceAsInt() != targetMemSpace) {
+    original = rewriter.create<memref::MemorySpaceCastOp>(
+        loc,
+        MemRefType::get(targetShape, thisType.getElementType(),
+                        thisType.getLayout().getAffineMap(), targetMemSpace),
+        original);
+    LLVM_DEBUG(llvm::dbgs()
+               << "  Address space cast needed: " << original << "\n");
+  }
+
+  if (thisType.getElementType() != targetElementType) {
+    original = rewriter.create<SYCLCastOp>(loc, targetType, original);
+    LLVM_DEBUG(llvm::dbgs() << "  sycl.cast inserted: " << original << "\n");
+  }
+
+  return original;
+}
+
+SmallVector<Value>
+mlir::sycl::adaptArgumentsForSYCLCall(OpBuilder &builder,
+                                      SYCLMethodOpInterface method) {
+  SmallVector<Value> transformed;
+  transformed.reserve(method->getNumOperands());
+  const auto loc = method.getLoc();
+  const auto targetTypes = method.getArgumentTypes();
+  std::transform(method->operand_begin(), method->operand_end(),
+                 targetTypes.begin(), std::back_inserter(transformed),
+                 [&](auto Val, auto Ty) {
+                   return adaptArgumentForSYCLCall(builder, loc, Val, Ty);
+                 });
+  assert(ValueRange{transformed}.getTypes() == targetTypes);
+  return transformed;
+}

--- a/mlir-sycl/lib/Transforms/Utils.cpp
+++ b/mlir-sycl/lib/Transforms/Utils.cpp
@@ -1,3 +1,11 @@
+//===- Utils.cpp - SYCL dialect transform utils -------------*- C++ -*-----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #include "Utils.h"
 
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"

--- a/mlir-sycl/lib/Transforms/Utils.h
+++ b/mlir-sycl/lib/Transforms/Utils.h
@@ -1,0 +1,25 @@
+//===- Utils.h - SYCL dialect transform utils ---------------*- C++ -*-----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_SYCL_LIB_TRANSFORMS_UTILS_H
+#define MLIR_SYCL_LIB_TRANSFORMS_UTILS_H
+
+#include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir {
+class OpBuilder;
+namespace sycl {
+class SYCLMethodOpInterface;
+SmallVector<Value> adaptArgumentsForSYCLCall(OpBuilder &builder,
+                                             SYCLMethodOpInterface method);
+} // namespace sycl
+} // namespace mlir
+
+#endif // MLIR_SYCL_LIB_TRANSFORMS_UTILS_H

--- a/mlir-sycl/test/Transforms/inliner.mlir
+++ b/mlir-sycl/test/Transforms/inliner.mlir
@@ -1,6 +1,6 @@
 // RUN: sycl-mlir-opt -split-input-file -inliner="mode=alwaysinline remove-dead-callees=false" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefix=ALWAYS-INLINE %s
 // RUN: sycl-mlir-opt -split-input-file -inliner="mode=simple remove-dead-callees=true" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefix=INLINE --check-prefix=CHECK-ALL %s
-// RUN: sycl-mlir-opt -split-input-file -inliner="mode=aggressive remove-dead-callees=true" -canonicalize -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefix=AGGRESSIVE --check-prefix=CHECK-ALL %s
+// RUN: sycl-mlir-opt -split-input-file -inliner="mode=aggressive remove-dead-callees=true" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefix=AGGRESSIVE --check-prefix=CHECK-ALL %s
 
 // COM: Ensure a func.func can be inlined in a func.func caller iff the callee is 'alwaysinline'.
 // COM: Ensure a gpu.func cannot be inlined in a func.func caller (even if it has the 'alwaysinline' attribute).
@@ -192,11 +192,15 @@ gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
 // AGGRESSIVE-NOT: func.func private @private_callee
 // AGGRESSIVE-NOT: func.func prive @get
 
-// AGGRESSIVE-DAG:       %[[VAL_1:.*]] = arith.constant 3 : i32
-// AGGRESSIVE-DAG:       %[[VAL_2:.*]] = arith.constant 2 : i64
-// AGGRESSIVE:           %[[VAL_3:.*]] = sycl.call @main_() {MangledFunctionName = @main, TypeName = @A} : () -> i32
-// AGGRESSIVE:           %[[VAL_4:.*]] = arith.addi %[[VAL_3]], %[[VAL_1]] : i32
-// AGGRESSIVE:           return %[[VAL_4]], %[[VAL_2]] : i32, i64
+// AGGRESSIVE-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i32
+// AGGRESSIVE-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i32
+// AGGRESSIVE-DAG:       %[[VAL_3:.*]] = arith.constant 2 : i32
+// AGGRESSIVE:           %[[VAL_4:.*]] = sycl.call @main_() {MangledFunctionName = @main, TypeName = @A} : () -> i32
+// AGGRESSIVE:           %[[VAL_5:.*]] = arith.addi %[[VAL_3]], %[[VAL_4]] : i32
+// AGGRESSIVE:           %[[VAL_6:.*]] = arith.addi %[[VAL_2]], %[[VAL_5]] : i32
+// AGGRESSIVE:           %[[VAL_7:.*]] = memref.memory_space_cast %[[VAL_0]] : memref<?x!sycl_id_1_> to memref<?x!sycl_id_1_, 4>
+// AGGRESSIVE:           %[[VAL_8:.*]] = arith.constant 2 : i64
+// AGGRESSIVE:           return %[[VAL_6]], %[[VAL_8]] : i32, i64
 // AGGRESSIVE:         }
 
 !sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>

--- a/mlir-sycl/test/Transforms/inliner.mlir
+++ b/mlir-sycl/test/Transforms/inliner.mlir
@@ -1,6 +1,6 @@
 // RUN: sycl-mlir-opt -split-input-file -inliner="mode=alwaysinline remove-dead-callees=false" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefix=ALWAYS-INLINE %s
-// RUN: sycl-mlir-opt -split-input-file -inliner="mode=simple remove-dead-callees=true" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefix=INLINE --check-prefix=CHECK-ALL %s
-// RUN: sycl-mlir-opt -split-input-file -inliner="mode=aggressive remove-dead-callees=true" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefix=AGGRESSIVE --check-prefix=CHECK-ALL %s
+// RUN: sycl-mlir-opt -split-input-file -inliner="mode=simple remove-dead-callees=true" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefixes=INLINE,CHECK-ALL %s
+// RUN: sycl-mlir-opt -split-input-file -inliner="mode=aggressive remove-dead-callees=true" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefixes=AGGRESSIVE,CHECK-ALL %s
 
 // COM: Ensure a func.func can be inlined in a func.func caller iff the callee is 'alwaysinline'.
 // COM: Ensure a gpu.func cannot be inlined in a func.func caller (even if it has the 'alwaysinline' attribute).

--- a/mlir-sycl/test/Transforms/inliner.mlir
+++ b/mlir-sycl/test/Transforms/inliner.mlir
@@ -1,5 +1,6 @@
 // RUN: sycl-mlir-opt -split-input-file -inliner="mode=alwaysinline remove-dead-callees=false" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefix=ALWAYS-INLINE %s
-// RUN: sycl-mlir-opt -split-input-file -inliner="mode=simple remove-dead-callees=true" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefix=INLINE %s
+// RUN: sycl-mlir-opt -split-input-file -inliner="mode=simple remove-dead-callees=true" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefix=INLINE --check-prefix=CHECK-ALL %s
+// RUN: sycl-mlir-opt -split-input-file -inliner="mode=aggressive remove-dead-callees=true" -canonicalize -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefix=AGGRESSIVE --check-prefix=CHECK-ALL %s
 
 // COM: Ensure a func.func can be inlined in a func.func caller iff the callee is 'alwaysinline'.
 // COM: Ensure a gpu.func cannot be inlined in a func.func caller (even if it has the 'alwaysinline' attribute).
@@ -170,22 +171,36 @@ gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
 
 // -----
 
-// COM: Ensure functions in a SCC are fully inlined (requires multiple inlining iterations). 
-// INLINE-LABEL: func.func @callee() -> i32 {
-// INLINE-DAG:     %c1_i32 = arith.constant 1 : i32
-// INLINE-DAG:     %c2_i32 = arith.constant 2 : i32
-// INLINE-DAG:     %c1_i32_0 = arith.constant 1 : i32
-// INLINE-DAG:     %c2_i32_1 = arith.constant 2 : i32
-// INLINE-DAG:     %0 = sycl.call @callee_() {MangledFunctionName = @callee, TypeName = @A} : () -> i32
-// INLINE-NEXT:    %1 = arith.addi %c2_i32_1, %0 : i32
-// INLINE-NEXT:    %2 = arith.addi %c1_i32_0, %1 : i32
-// INLINE-NEXT:    %3 = arith.addi %c1_i32, %c2_i32 : i32
-// INLINE-NEXT:    %4 = arith.addi %2, %3 : i32
-// INLINE-NEXT:    return %4 : i32
-// INLINE-NEXT:  }
+// COM: Ensure functions in a SCC are fully inlined (requires multiple inlining iterations).
+// CHECK-ALL-LABEL:   func.func @main(
+// CHECK-ALL-SAME:                      %[[VAL_0:.*]]: memref<?x!sycl_id_1_>) -> (i32, i64) {
+
+// INLINE-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i32
+// INLINE-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i32
+// INLINE-DAG:       %[[VAL_3:.*]] = arith.constant 2 : i32
+// INLINE:           %[[VAL_4:.*]] = sycl.call @main_() {MangledFunctionName = @main, TypeName = @A} : () -> i32
+// INLINE:           %[[VAL_5:.*]] = arith.addi %[[VAL_3]], %[[VAL_4]] : i32
+// INLINE:           %[[VAL_6:.*]] = arith.addi %[[VAL_2]], %[[VAL_5]] : i32
+// INLINE:           %[[VAL_7:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_1]]] {ArgumentTypes = [memref<?x!sycl_id_1_, 4>, i32], FunctionName = @get, MangledFunctionName = @get, TypeName = @id} : (memref<?x!sycl_id_1_>, i32) -> i64
+// INLINE:           return %[[VAL_6]], %[[VAL_7]] : i32, i64
+// INLINE:         }
 
 // INLINE-NOT: func.func private @inline_hint_callee
 // INLINE-NOT: func.func private @private_callee
+
+// AGGRESSIVE-NOT: func.func private @inline_hint_callee
+// AGGRESSIVE-NOT: func.func private @private_callee
+// AGGRESSIVE-NOT: func.func prive @get
+
+// AGGRESSIVE-DAG:       %[[VAL_1:.*]] = arith.constant 3 : i32
+// AGGRESSIVE-DAG:       %[[VAL_2:.*]] = arith.constant 2 : i64
+// AGGRESSIVE:           %[[VAL_3:.*]] = sycl.call @main_() {MangledFunctionName = @main, TypeName = @A} : () -> i32
+// AGGRESSIVE:           %[[VAL_4:.*]] = arith.addi %[[VAL_3]], %[[VAL_1]] : i32
+// AGGRESSIVE:           return %[[VAL_4]], %[[VAL_2]] : i32, i64
+// AGGRESSIVE:         }
+
+!sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
 
 func.func private @inline_hint_callee() -> i32 attributes {passthrough = ["inlinehint"]} {
   %c_i32 = arith.constant 1 : i32
@@ -196,16 +211,19 @@ func.func private @inline_hint_callee() -> i32 attributes {passthrough = ["inlin
 
 func.func private @private_callee() -> i32 {
   %c_i32 = arith.constant 2 : i32
-  %res1 = sycl.call @callee_() {MangledFunctionName = @callee, TypeName = @A} : () -> i32
+  %res1 = sycl.call @main_() {MangledFunctionName = @main, TypeName = @A} : () -> i32
   %res2 = arith.addi %c_i32, %res1 : i32
   return %res2 : i32
 }
 
-func.func @callee() -> i32 {
-  %c1 = arith.constant 1 : i32
-  %c2 = arith.constant 2 : i32
+func.func private @get(%id: memref<?x!sycl_id_1_, 4>, %i: i32) -> i64 {
+  %c2_i64 = arith.constant 2 : i64
+  return %c2_i64 : i64
+}
+
+func.func @main(%id: memref<?x!sycl_id_1_>) -> (i32, i64) {
+  %c1_i32 = arith.constant 1 : i32
   %res1 = sycl.call @inline_hint_callee_() {MangledFunctionName = @inline_hint_callee, TypeName = @A} : () -> i32    
-  %add1 = arith.addi %c1, %c2 : i32
-  %add2 = arith.addi %res1, %add1 : i32  
-  return %add2 : i32
+  %res2 = sycl.id.get %id[%c1_i32] {ArgumentTypes = [memref<?x!sycl_id_1_, 4>, i32], FunctionName = @get, MangledFunctionName = @get, TypeName = @id} : (memref<?x!sycl_id_1_>, i32) -> i64
+  return %res1, %res2 : i32, i64
 }

--- a/mlir-sycl/test/Transforms/inliner.mlir
+++ b/mlir-sycl/test/Transforms/inliner.mlir
@@ -190,7 +190,7 @@ gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
 
 // AGGRESSIVE-NOT: func.func private @inline_hint_callee
 // AGGRESSIVE-NOT: func.func private @private_callee
-// AGGRESSIVE-NOT: func.func prive @get
+// AGGRESSIVE-NOT: func.func private @get
 
 // AGGRESSIVE-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i32
 // AGGRESSIVE-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i32


### PR DESCRIPTION
These operations need their operands to be transformed before being inlined.