### PR TITLE
[CI] Replace scheduled main branch sync with manual.

### DIFF
--- a/.github/workflows/sync-main.yml
+++ b/.github/workflows/sync-main.yml
@@ -1,8 +1,8 @@
-name: automatic sync main branch from llvm-project to llvm
+name: main branch sync
 
 on:
-  schedule:
-  - cron: '0 */1 * * *'
+  workflow_dispatch:
+
 jobs:
   sync:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Automatic synchronization will be performed by Intel internal automation without using this action at all. Keep it for a manual trigger possibility for now though.