### PR TITLE
[clang][SYCL] Fix LIT test for Windows

### DIFF
--- a/clang/test/CodeGenSYCL/fpga-attr-do-while-loops.cpp
+++ b/clang/test/CodeGenSYCL/fpga-attr-do-while-loops.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang++ -fsycl-device-only -fintelfpga -S %s -o - | FileCheck %s
+// RUN: %clang -fsycl-device-only -fintelfpga -S %s -o - | FileCheck %s
 
 #include "Inputs/sycl.hpp"
 


### PR DESCRIPTION
Due to incorrect substitution wrong command line was formed on Windows.