### PR TITLE
[SYCL] Implement is_group trait

### DIFF
--- a/sycl/include/sycl/detail/type_traits.hpp
+++ b/sycl/include/sycl/detail/type_traits.hpp
@@ -65,8 +65,10 @@ template <typename ElementType, access::address_space Space,
 class multi_ptr;
 
 template <class T>
-inline constexpr bool is_group_v =
-    detail::is_group<T>::value || detail::is_sub_group<T>::value;
+struct is_group : std::bool_constant<detail::is_group<T>::value ||
+                                     detail::is_sub_group<T>::value> {};
+
+template <class T> inline constexpr bool is_group_v = is_group<T>::value;
 
 namespace ext::oneapi::experimental {
 template <class T>

--- a/sycl/test/basic_tests/is_group_trait.cpp
+++ b/sycl/test/basic_tests/is_group_trait.cpp
@@ -1,0 +1,22 @@
+// RUN: %clangxx -fsycl %s
+
+#include <sycl/sycl.hpp>
+
+template <typename T, typename ExpectedBaseType> void Check() {
+  static_assert(std::is_base_of_v<ExpectedBaseType, sycl::is_group<T>>);
+  static_assert(sycl::is_group<T>::value == ExpectedBaseType::value);
+  static_assert(sycl::is_group_v<T> == ExpectedBaseType::value);
+}
+
+int main() {
+  Check<sycl::group<1>, std::true_type>();
+  Check<sycl::group<2>, std::true_type>();
+  Check<sycl::group<3>, std::true_type>();
+  Check<sycl::sub_group, std::true_type>();
+
+  Check<int, std::false_type>();
+  Check<sycl::queue, std::false_type>();
+  Check<sycl::device, std::false_type>();
+
+  return 0;
+}


### PR DESCRIPTION
This commit adds the missing SYCL 2020 is_group trait and changes the definition of is_group_v to be in line with SYCL 2020.

Fixes https://github.com/intel/llvm/issues/8704.