### PR TITLE
[SYCL][Docs] Clarify that weak_object is only available on host

### DIFF
--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_weak_object.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_weak_object.asciidoc
@@ -330,5 +330,5 @@ they are both empty `weak_object` instances.
 
 |===
 
-The `weak_object` class, the `ext_oneapi_owner_before` methods and the
-`owner_less` function object type can only be used on the host application.
+The `weak_object` class, the `ext_oneapi_owner_before` member functions and the
+`owner_less` function object type must not be used in device code.

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_weak_object.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_weak_object.asciidoc
@@ -330,3 +330,5 @@ they are both empty `weak_object` instances.
 
 |===
 
+The `weak_object` class, the `ext_oneapi_owner_before` methods and the
+`owner_less` function object type can only be used on the host application.


### PR DESCRIPTION
This commit makes a clarification to sycl_ext_oneapi_weak_object that the new interfaces are only available on the host application.