### PR TITLE
[SYCL] Fix weak_object move and copy assignment

### DIFF
--- a/sycl/include/sycl/ext/oneapi/weak_object_base.hpp
+++ b/sycl/include/sycl/ext/oneapi/weak_object_base.hpp
@@ -33,6 +33,9 @@ public:
   weak_object_base(const weak_object_base &Other) noexcept = default;
   weak_object_base(weak_object_base &&Other) noexcept = default;
 
+  weak_object_base &operator=(const weak_object_base &Other) noexcept = default;
+  weak_object_base &operator=(weak_object_base &&Other) noexcept = default;
+
   void reset() noexcept { MObjWeakPtr.reset(); }
   void swap(weak_object_base &Other) noexcept {
     MObjWeakPtr.swap(Other.MObjWeakPtr);


### PR DESCRIPTION
This commit fixes an issue where the copy and move assignment operators of the weak_object class would be implicitly deleted due to them being missing from the base class.