### PR TITLE
[SYCL-MLIR] Add `sycl.accessor.size`

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -675,9 +675,10 @@ def SYCLCallOp : SYCL_Op<"call", [CallOpInterface]> {
 def SYCLAccessorSizeOp
     : SYCLMethodOpInterfaceImpl<"accessor.size", "AccessorType",
                                 ["size"]> {
-  let summary = "Call to accessor::size";
+  let summary = "Represent the accessor::size";
   let description = [{
-    This operation represents a call to the accessor::size function.
+    This operation returns the number of elements in the region of a SYCL buffer
+    that the given SYCL accessor is accessing.
   }];
 
   let arguments = (ins Arg<AccessorMemRef, "The accessor", [MemRead]>:$Acc,

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -677,8 +677,8 @@ def SYCLAccessorSizeOp
                                 ["size"]> {
   let summary = "Represent the accessor::size";
   let description = [{
-    This operation returns the number of elements in the region of a SYCL buffer
-    that the given SYCL accessor is accessing.
+    This operation returns the number of elements accessible by this SYCL
+    accessor.
   }];
 
   let arguments = (ins Arg<AccessorMemRef, "The accessor", [MemRead]>:$Acc,

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -687,7 +687,7 @@ def SYCLAccessorSizeOp
                        OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
                        FlatSymbolRefAttr:$TypeName);
 
-  let results = (outs I64:$Res);
+  let results = (outs IndexType:$Res);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -669,6 +669,27 @@ def SYCLCallOp : SYCL_Op<"call", [CallOpInterface]> {
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// accessor.size OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLAccessorSizeOp
+    : SYCLMethodOpInterfaceImpl<"accessor.size", "AccessorType",
+                                ["size"]> {
+  let summary = "Call to accessor::size";
+  let description = [{
+    This operation represents a call to the accessor::size function.
+  }];
+
+  let arguments = (ins Arg<AccessorMemRef, "The accessor", [MemRead]>:$Acc,
+                       TypeArrayAttr:$ArgumentTypes,
+                       FlatSymbolRefAttr:$FunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let results = (outs I64:$Res);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // accessor.subscript OPERATION
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -675,10 +675,10 @@ def SYCLCallOp : SYCL_Op<"call", [CallOpInterface]> {
 def SYCLAccessorSizeOp
     : SYCLMethodOpInterfaceImpl<"accessor.size", "AccessorType",
                                 ["size"]> {
-  let summary = "Represent the accessor::size";
+  let summary = "Represents the accessor size operation";
   let description = [{
-    This operation returns the number of elements accessible by this SYCL
-    accessor.
+    Returns the number of elements of the memory region this accessor may
+    access.
   }];
 
   let arguments = (ins Arg<AccessorMemRef, "The accessor", [MemRead]>:$Acc,

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -156,6 +156,30 @@ func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> memref<?xi64> {
 // -----
 
 //===-------------------------------------------------------------------------------------------------===//
+// sycl.accessor.size
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
+!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[ACCESSOR1:.*]]>) -> i64 {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %arg0[0, 0, 1, 0, 0, 0] : (!llvm.ptr<[[ACCESSOR1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mul %[[VAL_1]], %[[VAL_3]]  : i64
+// CHECK-NEXT:      llvm.return %[[VAL_4]] : i64
+// CHECK-NEXT:    }
+func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> i64 {
+  %0 = sycl.accessor.size(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>], FunctionName = @"size", MangledFunctionName = @"size", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> i64
+  return %0 : i64
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
 // sycl.accessor.subscript with scalar offset and 1D accessor
 //===-------------------------------------------------------------------------------------------------===//
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -40,6 +40,18 @@
 
 template <typename T> SYCL_EXTERNAL void keep(T);
 
+// CHECK-MLIR-LABEL: func.func @_Z13accessor_sizeN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
+// CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef})
+// CHECK-MLIR: %{{.*}} = sycl.accessor.size(%arg0) {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>], FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE4sizeEv, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> i64
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z13accessor_sizeN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
+// CHECK-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0) #[[FUNCATTRS:[0-9]+]] {
+// CHECK-LLVM:  %{{.*}} = call spir_func i64 @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE4sizeEv(%"class.sycl::_V1::accessor.2" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void accessor_size(sycl::accessor<sycl::cl_int, 2> acc) {
+  keep(acc.size());
+}
+
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_0N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEENS0_2idILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef}, 
 // CHECK_MLIR_SAME:      %{{.*}}: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})


### PR DESCRIPTION
This operation returns the number of elements accessible by this SYCL accessor.