### PR TITLE
[SYCL-MLIR] Verify SYCLMethodOps generated in cgeist

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1100,7 +1100,7 @@ llvm::Optional<sycl::SYCLMethodOpInterface> MLIRScanner::createSYCLMethodOp(
     return std::nullopt;
   }
 
-  LLVM_DEBUG(llvm::dbgs() << "Inserting operation " << OptOpName
+  LLVM_DEBUG(llvm::dbgs() << "Attempting to insert operation " << OptOpName
                           << " to replace SYCL method call.\n");
 
   sycl::SYCLMethodOpInterface op = Builder.create(

--- a/polygeist/tools/cgeist/Test/Verification/sycl/illegal_methodop.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/illegal_methodop.cpp
@@ -1,0 +1,22 @@
+// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s
+
+#include <sycl/sycl.hpp>
+
+// We should be generating the following error, but not the `sycl.id.get`
+// operation.
+
+// CHECK-LITERAL:  error: 'sycl.id.get' op result #0 must be 64-bit signless integer or memref of 64-bit signless integer values, but got 'f32'
+// CHECK-NOT:      sycl.id.get
+
+namespace sycl {
+class tricky_class {
+ public:
+  static float get(const id<1> &, int) {
+    return 7;
+  }
+};
+}  // namespace sycl
+
+SYCL_EXTERNAL float foo(const sycl::id<1> &i, int dimension) {
+  return sycl::tricky_class::get(i, dimension);
+}


### PR DESCRIPTION
If the created operation is illegal, it will be removed from the module right away and a `sycl.call` will be generated instead.