### PR TITLE
[SYCL-MLIR] Extend and fix SYCL inline pass options

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.h
@@ -33,8 +33,7 @@ enum InlineMode { AlwaysInline, Simple, Aggressive, Ludicrous };
 //===----------------------------------------------------------------------===//
 
 std::unique_ptr<Pass> createInlinePass();
-std::unique_ptr<Pass> createInlinePass(enum InlineMode InlineMode,
-                                       bool RemoveDeadCallees);
+std::unique_ptr<Pass> createInlinePass(const InlinePassOptions &options);
 
 std::unique_ptr<Pass> createSYCLMethodToSYCLCallPass();
 

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.td
@@ -31,6 +31,9 @@ def InlinePass : Pass<"inliner"> {
            "Remove callees that become unreachable after inlining them">,
     Option<"MaxIterationCount", "max-num-iters", "unsigned", /*default=*/"3",
            "Maximum number of inlining iterations for each SCC">,
+    Option<"InlineSYCLMethodOps", "inline-sycl-method-ops",
+           "bool", /*default=*/"true",
+           "Whether to inline SYCLMethodOp operations">,
   ];
   let dependentDialects = ["memref::MemRefDialect"];
 

--- a/mlir-sycl/test/Transforms/inliner.mlir
+++ b/mlir-sycl/test/Transforms/inliner.mlir
@@ -1,6 +1,7 @@
-// RUN: sycl-mlir-opt -split-input-file -inliner="mode=alwaysinline remove-dead-callees=false" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefixes=ALWAYS-INLINE,CHECK-ALL %s
-// RUN: sycl-mlir-opt -split-input-file -inliner="mode=simple remove-dead-callees=true" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefixes=INLINE,CHECK-ALL %s
-// RUN: sycl-mlir-opt -split-input-file -inliner="mode=aggressive remove-dead-callees=true" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefixes=AGGRESSIVE,CHECK-ALL %s
+// RUN: sycl-mlir-opt -split-input-file -inliner="mode=alwaysinline remove-dead-callees=false inline-sycl-method-ops=false" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefixes=ALWAYS-INLINE,CHECK-ALL %s
+// RUN: sycl-mlir-opt -split-input-file -inliner="mode=simple remove-dead-callees=true inline-sycl-method-ops=false" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefixes=INLINE,CHECK-ALL %s
+// RUN: sycl-mlir-opt -split-input-file -inliner="mode=aggressive remove-dead-callees=true inline-sycl-method-ops=false" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefixes=AGGRESSIVE,CHECK-ALL %s
+// RUN: sycl-mlir-opt -split-input-file -inliner="mode=aggressive remove-dead-callees=true inline-sycl-method-ops=true" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefixes=AGGRESSIVE-METHODOPS,CHECK-ALL %s
 
 // COM: Ensure a func.func can be inlined in a func.func caller iff the callee is 'alwaysinline'.
 // COM: Ensure a gpu.func cannot be inlined in a func.func caller (even if it has the 'alwaysinline' attribute).
@@ -171,6 +172,13 @@ gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
 
 // -----
 
+// AGGRESSIVE-METHODOPS-NOT: func.func private @inline_hint_callee
+// AGGRESSIVE-METHODOPS-NOT: func.func private @private_callee
+// AGGRESSIVE-METHODOPS-NOT: func.func private @get
+
+// AGGRESSIVE-NOT: func.func private @inline_hint_callee
+// AGGRESSIVE-NOT: func.func private @private_callee
+
 // COM: Ensure functions in a SCC are fully inlined (requires multiple inlining iterations).
 // CHECK-ALL-LABEL:   func.func @main(
 // CHECK-ALL-SAME:                      %[[VAL_0:.*]]: memref<?x!sycl_id_1_>) -> (i32, i64) {
@@ -196,20 +204,27 @@ gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
 // INLINE-NOT: func.func private @inline_hint_callee
 // INLINE-NOT: func.func private @private_callee
 
-// AGGRESSIVE-NOT: func.func private @inline_hint_callee
-// AGGRESSIVE-NOT: func.func private @private_callee
-// AGGRESSIVE-NOT: func.func private @get
+// AGGRESSIVE-METHODOPS-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i32
+// AGGRESSIVE-METHODOPS-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i32
+// AGGRESSIVE-METHODOPS-DAG:       %[[VAL_3:.*]] = arith.constant 2 : i32
+// AGGRESSIVE-METHODOPS:           %[[VAL_4:.*]] = sycl.call @main_() {MangledFunctionName = @main, TypeName = @A} : () -> i32
+// AGGRESSIVE-METHODOPS:           %[[VAL_5:.*]] = arith.addi %[[VAL_3]], %[[VAL_4]] : i32
+// AGGRESSIVE-METHODOPS:           %[[VAL_6:.*]] = arith.addi %[[VAL_2]], %[[VAL_5]] : i32
+// AGGRESSIVE-METHODOPS:           call @foo(%[[VAL_0]], %[[VAL_1]]) : (memref<?x!sycl_id_1_>, i32) -> ()
+// AGGRESSIVE-METHODOPS:           %[[VAL_7:.*]] = memref.memory_space_cast %[[VAL_0]] : memref<?x!sycl_id_1_> to memref<?x!sycl_id_1_, 4>
+// AGGRESSIVE-METHODOPS:           %[[VAL_8:.*]] = arith.constant 2 : i64
+// AGGRESSIVE-METHODOPS:           return %[[VAL_6]], %[[VAL_8]] : i32, i64
+// AGGRESSIVE-METHODOPS:         }
 
-// AGGRESSIVE-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i32
-// AGGRESSIVE-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i32
-// AGGRESSIVE-DAG:       %[[VAL_3:.*]] = arith.constant 2 : i32
+// AGGRESSIVE:           %[[VAL_1:.*]] = arith.constant 1 : i32
+// AGGRESSIVE:           %[[VAL_2:.*]] = arith.constant 1 : i32
+// AGGRESSIVE:           %[[VAL_3:.*]] = arith.constant 2 : i32
 // AGGRESSIVE:           %[[VAL_4:.*]] = sycl.call @main_() {MangledFunctionName = @main, TypeName = @A} : () -> i32
 // AGGRESSIVE:           %[[VAL_5:.*]] = arith.addi %[[VAL_3]], %[[VAL_4]] : i32
 // AGGRESSIVE:           %[[VAL_6:.*]] = arith.addi %[[VAL_2]], %[[VAL_5]] : i32
 // AGGRESSIVE:           call @foo(%[[VAL_0]], %[[VAL_1]]) : (memref<?x!sycl_id_1_>, i32) -> ()
-// AGGRESSIVE:           %[[VAL_7:.*]] = memref.memory_space_cast %[[VAL_0]] : memref<?x!sycl_id_1_> to memref<?x!sycl_id_1_, 4>
-// AGGRESSIVE:           %[[VAL_8:.*]] = arith.constant 2 : i64
-// AGGRESSIVE:           return %[[VAL_6]], %[[VAL_8]] : i32, i64
+// AGGRESSIVE:           %[[VAL_7:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_1]]] {ArgumentTypes = [memref<?x!sycl_id_1_, 4>, i32], FunctionName = @get, MangledFunctionName = @get, TypeName = @id} : (memref<?x!sycl_id_1_>, i32) -> i64
+// AGGRESSIVE:           return %[[VAL_6]], %[[VAL_7]] : i32, i64
 // AGGRESSIVE:         }
 
 !sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>

--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -222,6 +222,11 @@ static llvm::cl::opt<std::string> McpuOpt("mcpu", llvm::cl::init(""),
                                           llvm::cl::desc("Target CPU"),
                                           llvm::cl::cat(ToolOptions));
 
+static llvm::cl::opt<bool> InlineSYCLMethodOps(
+    "inline-sycl-method-ops", llvm::cl::init(true),
+    llvm::cl::desc("Whether to inline SYCLMethodOp operations"),
+    llvm::cl::cat(ToolOptions));
+
 llvm::cl::opt<bool> OmitOptionalMangledFunctionName(
     "no-mangled-function-name", llvm::cl::init(false),
     llvm::cl::desc("Whether to omit optional \"MangledFunctionName\" fields"));

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -370,7 +370,8 @@ static int optimize(mlir::MLIRContext &Ctx,
     if (RaiseToAffine)
       OptPM.addPass(mlir::createLowerAffinePass());
     if (OmitOptionalMangledFunctionName) {
-      // Needed as the inliner pass needs the `MangledFunctionName` attribute.
+      // Needed as the inliner pass needs the `MangledFunctionName` attribute to
+      // build the call graph.
       PM.addPass(mlir::sycl::createSYCLMethodToSYCLCallPass());
     }
     PM.addPass(sycl::createInlinePass({sycl::InlineMode::Simple,

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -369,8 +369,13 @@ static int optimize(mlir::MLIRContext &Ctx,
     // operations to be inlined.
     if (RaiseToAffine)
       OptPM.addPass(mlir::createLowerAffinePass());
-    PM.addPass(sycl::createInlinePass(sycl::InlineMode::Simple,
-                                      /* RemoveDeadCallees */ true));
+    if (OmitOptionalMangledFunctionName) {
+      // Needed as the inliner pass needs the `MangledFunctionName` attribute.
+      PM.addPass(mlir::sycl::createSYCLMethodToSYCLCallPass());
+    }
+    PM.addPass(sycl::createInlinePass({sycl::InlineMode::Simple,
+                                       /* RemoveDeadCallees */ true,
+                                       InlineSYCLMethodOps}));
 
     mlir::OpPassManager &OptPM2 = PM.nestAny();
     OptPM2.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));


### PR DESCRIPTION
We add an `-inline-sycl-method-ops` option both to the pass itself and to `cgeist` to decide whether to inline `SYCLMethodOps` (on by default).

The pipeline needs further modification as `-no-mangled-function-name` is incompatible with inlining `SYCLMethodOps`, so we have to convert to `sycl.call` beforehand.

Now the default `-remove-dead-callees` will be used if no argument is provided.