### PR TITLE
[SYCL] Unroll local accessor index calculation

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -2522,8 +2522,8 @@ protected:
   // Method which calculates linear offset for the ID using Range and Offset.
   template <int Dims = AdjustedDim> size_t getLinearIndex(id<Dims> Id) const {
     size_t Result = 0;
-    for (int I = 0; I < Dims; ++I)
-      Result = Result * getSize()[I] + Id[I];
+    detail::dim_loop<Dims>(
+        [&, this](size_t I) { Result = Result * getSize()[I] + Id[I]; });
     return Result;
   }
 

--- a/sycl/test/check_device_code/accessor_index.cpp
+++ b/sycl/test/check_device_code/accessor_index.cpp
@@ -1,0 +1,16 @@
+// RUN: %clangxx -fsycl-device-only -fno-sycl-early-optimizations -S -emit-llvm -o - %s | FileCheck %s
+#include <sycl/sycl.hpp>
+
+// Check that accessor index calculation is unrolled in headers.
+// CHECK-NOT: llvm.loop
+using namespace sycl;
+int main() {
+  queue Q;
+  range<3> Range{8, 8, 8};
+  buffer<int, 3> Buf(Range);
+  Q.submit([&](handler &Cgh) {
+    auto Acc = Buf.get_access<access::mode::write>(Cgh);
+    local_accessor<int, 3> locAcc(Range, Cgh);
+    Cgh.parallel_for(Range, [=](item<3> it) { locAcc[it] = Acc[it]; });
+  });
+}

--- a/sycl/test/check_device_code/accessor_index.cpp
+++ b/sycl/test/check_device_code/accessor_index.cpp
@@ -12,6 +12,6 @@ int main() {
   Q.submit([&](handler &Cgh) {
     auto Acc = Buf.get_access<access::mode::write>(Cgh);
     local_accessor<int, 3> LocAcc(Range, Cgh);
-    Cgh.parallel_for(Range, [=](item<3> it) { LocAcc[it] = Acc[it]; });
+    Cgh.parallel_for(Range, [=](item<3> It) { LocAcc[It] = Acc[It]; });
   });
 }

--- a/sycl/test/check_device_code/accessor_index.cpp
+++ b/sycl/test/check_device_code/accessor_index.cpp
@@ -11,7 +11,7 @@ int main() {
   buffer<int, 3> Buf(Range);
   Q.submit([&](handler &Cgh) {
     auto Acc = Buf.get_access<access::mode::write>(Cgh);
-    local_accessor<int, 3> locAcc(Range, Cgh);
-    Cgh.parallel_for(Range, [=](item<3> it) { locAcc[it] = Acc[it]; });
+    local_accessor<int, 3> LocAcc(Range, Cgh);
+    Cgh.parallel_for(Range, [=](item<3> it) { LocAcc[it] = Acc[it]; });
   });
 }

--- a/sycl/test/check_device_code/accessor_index.cpp
+++ b/sycl/test/check_device_code/accessor_index.cpp
@@ -1,8 +1,9 @@
-// RUN: %clangxx -fsycl-device-only -fno-sycl-early-optimizations -S -emit-llvm -o - %s | FileCheck %s
+// RUN: %clangxx -fsycl-device-only -fno-sycl-early-optimizations -S -emit-llvm -D__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__ -o - %s | FileCheck %s
 #include <sycl/sycl.hpp>
 
 // Check that accessor index calculation is unrolled in headers.
 // CHECK-NOT: llvm.loop
+// CHECK-NOT: br i1
 using namespace sycl;
 int main() {
   queue Q;


### PR DESCRIPTION
Aligns local accessor index calculation with the other accessors.