### PR TITLE
[SYCL-MLIR][NFC] Remove unused variable 'genericAddressSpace'

### DIFF
--- a/mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPU.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPU.cpp
@@ -31,8 +31,6 @@ using namespace mlir;
 using namespace mlir::sycl;
 
 namespace {
-constexpr unsigned genericAddressSpace{4};
-
 template <typename SYCLOpTy> struct gpu_counterpart_operation {};
 
 template <> struct gpu_counterpart_operation<SYCLWorkGroupIDOp> {


### PR DESCRIPTION
mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPU.cpp:34:20: warning: unused variable 'genericAddressSpace'