### PR TITLE
[SYCL-MLIR] Revamp SYCL conversion passes

### DIFF
--- a/mlir-sycl/include/mlir/Conversion/SYCLPasses.td
+++ b/mlir-sycl/include/mlir/Conversion/SYCLPasses.td
@@ -24,7 +24,6 @@ def ConvertSYCLToLLVM : Pass<"convert-sycl-to-llvm", "ModuleOp"> {
   let dependentDialects = [
       "LLVM::LLVMDialect",
       "arith::ArithDialect",
-      "gpu::GPUDialect",
       "memref::MemRefDialect",
       "spirv::SPIRVDialect",
       "vector::VectorDialect"

--- a/mlir-sycl/include/mlir/Conversion/SYCLToSPIRV/SYCLToSPIRV.h
+++ b/mlir-sycl/include/mlir/Conversion/SYCLToSPIRV/SYCLToSPIRV.h
@@ -18,14 +18,14 @@
 namespace mlir {
 class Pass;
 class RewritePatternSet;
-class SPIRVTypeConverter;
+class TypeConverter;
 
 #define GEN_PASS_DECL_CONVERTSYCLTOSPIRV
 #include "mlir/Conversion/SYCLPasses.h.inc"
 #undef GEN_PASS_DECL_CONVERTSYCLTOSPIRV
 
 /// Populates the given list with patterns that convert from SYCL to SPIRV.
-void populateSYCLToSPIRVConversionPatterns(SPIRVTypeConverter &typeConverter,
+void populateSYCLToSPIRVConversionPatterns(TypeConverter &typeConverter,
                                            RewritePatternSet &patterns);
 
 } // namespace mlir

--- a/mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPU.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToGPU/SYCLToGPU.cpp
@@ -37,10 +37,6 @@ template <> struct gpu_counterpart_operation<SYCLWorkGroupIDOp> {
   using type = gpu::BlockIdOp;
 };
 
-template <> struct gpu_counterpart_operation<SYCLNumWorkItemsOp> {
-  using type = gpu::GridDimOp;
-};
-
 template <> struct gpu_counterpart_operation<SYCLWorkGroupSizeOp> {
   using type = gpu::BlockDimOp;
 };
@@ -255,8 +251,8 @@ void addGridOpPatterns(RewritePatternSet &patterns, MLIRContext *context) {
 
 void mlir::populateSYCLToGPUConversionPatterns(RewritePatternSet &patterns) {
   auto *context = patterns.getContext();
-  addGridOpPatterns<SYCLWorkGroupIDOp, SYCLNumWorkItemsOp, SYCLWorkGroupSizeOp,
-                    SYCLLocalIDOp, SYCLGlobalIDOp>(patterns, context);
+  addGridOpPatterns<SYCLWorkGroupIDOp, SYCLWorkGroupSizeOp, SYCLLocalIDOp,
+                    SYCLGlobalIDOp>(patterns, context);
   patterns.add<SingleDimGridOpPattern<SYCLSubGroupIDOp>,
                SingleDimGridOpPattern<SYCLNumSubGroupsOp>,
                SingleDimGridOpPattern<SYCLSubGroupSizeOp>>(context);
@@ -282,10 +278,9 @@ void ConvertSYCLToGPUPass::runOnOperation() {
                          memref::MemRefDialect, SYCLDialect,
                          vector::VectorDialect>();
 
-  target
-      .addIllegalOp<SYCLWorkGroupIDOp, SYCLNumWorkItemsOp, SYCLWorkGroupSizeOp,
-                    SYCLLocalIDOp, SYCLGlobalIDOp, SYCLSubGroupIDOp,
-                    SYCLNumSubGroupsOp, SYCLSubGroupSizeOp>();
+  target.addIllegalOp<SYCLWorkGroupIDOp, SYCLWorkGroupSizeOp, SYCLLocalIDOp,
+                      SYCLGlobalIDOp, SYCLSubGroupIDOp, SYCLNumSubGroupsOp,
+                      SYCLSubGroupSizeOp>();
 
   if (failed(
           applyPartialConversion(getOperation(), target, std::move(patterns))))

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/CMakeLists.txt
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/CMakeLists.txt
@@ -22,7 +22,6 @@ add_mlir_conversion_library(MLIRSYCLToLLVM
   MLIRReconcileUnrealizedCasts
   MLIRSPIRVToLLVM
   MLIRSYCLDialect  
-  MLIRSYCLToGPU
   MLIRSYCLToSPIRV
   MLIRTransforms
   MLIRVectorToLLVM

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/CMakeLists.txt
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/CMakeLists.txt
@@ -19,7 +19,6 @@ add_mlir_conversion_library(MLIRSYCLToLLVM
   MLIRLLVMDialect
   MLIRMemRefToLLVM
   MLIRPolygeistTransforms
-  MLIRReconcileUnrealizedCasts
   MLIRSPIRVToLLVM
   MLIRSYCLDialect  
   MLIRSYCLToSPIRV

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -19,7 +19,6 @@
 #include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
-#include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
 #include "mlir/Conversion/SPIRVToLLVM/SPIRVToLLVM.h"
 #include "mlir/Conversion/SYCLToLLVM/DialectBuilder.h"
 #include "mlir/Conversion/SYCLToSPIRV/SYCLToSPIRV.h"

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -16,20 +16,17 @@
 
 #include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
-#include "mlir/Conversion/GPUToSPIRV/GPUToSPIRV.h"
 #include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
 #include "mlir/Conversion/LLVMCommon/Pattern.h"
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Conversion/ReconcileUnrealizedCasts/ReconcileUnrealizedCasts.h"
 #include "mlir/Conversion/SPIRVToLLVM/SPIRVToLLVM.h"
-#include "mlir/Conversion/SYCLToGPU/SYCLToGPU.h"
 #include "mlir/Conversion/SYCLToLLVM/DialectBuilder.h"
 #include "mlir/Conversion/SYCLToSPIRV/SYCLToSPIRV.h"
 #include "mlir/Conversion/VectorToLLVM/ConvertVectorToLLVM.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Func/Transforms/FuncConversions.h"
-#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Polygeist/Transforms/Passes.h"
 #include "mlir/Dialect/Polygeist/Utils/Utils.h"
@@ -2177,17 +2174,6 @@ void mlir::populateSYCLToLLVMConversionPatterns(
 }
 
 namespace {
-/// A pass converting MLIR SYCL operations into LLVM dialect.
-///
-/// This pass relies on SYCL to GPU and target dialects, e.g., SPIRV, conversion
-/// patterns. This pass is executed in 4 steps:
-/// 1. Lower all of the operations to LLVM. As some of the operations will yield
-///    SYCL grid ops, we need to run this step first;
-/// 2. Convert grid ops to a target dialect, e.g., SPIRV;
-/// 3. Lower remaining operations to LLVM. Same as 1, but no operation will
-///    yield SYCL grid ops, so we can mark these as illegal;
-/// 4. Resolve UnrealizedConversionCastOps appearing due to the fact that this
-///    pass is performed in several steps.
 class ConvertSYCLToLLVMPass
     : public impl::ConvertSYCLToLLVMBase<ConvertSYCLToLLVMPass> {
 public:

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -30,6 +30,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Polygeist/Transforms/Passes.h"
 #include "mlir/Dialect/Polygeist/Utils/Utils.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
 #include "mlir/Dialect/SPIRV/IR/TargetAndABI.h"
 #include "mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h"
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"

--- a/mlir-sycl/test/Conversion/SYCLToGPU/grid-ops.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToGPU/grid-ops.mlir
@@ -7,39 +7,6 @@
 !sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
 !sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64>)>)>
 
-// CHECK-LABEL:   func.func @test_num_work_items() -> !sycl_range_1_ {
-// CHECK-NEXT:      %[[VAL_0:.*]] = memref.alloca() : memref<1x!sycl_range_1_>
-// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:      %[[VAL_3:.*]] = gpu.grid_dim  x
-// CHECK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : index to i64
-// CHECK-NEXT:      %[[VAL_5:.*]] = sycl.range.get %[[VAL_0]]{{\[}}%[[VAL_2]]] {ArgumentTypes = [memref<1x!sycl_range_1_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_1_>, i32) -> memref<1xi64>
-// CHECK-NEXT:      memref.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<1xi64>
-// CHECK-NEXT:      %[[VAL_6:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_range_1_>
-// CHECK-NEXT:      return %[[VAL_6]] : !sycl_range_1_
-// CHECK-NEXT:    }
-func.func @test_num_work_items() -> !sycl_range_1_ {
-  %0 = sycl.num_work_items : !sycl_range_1_
-  return %0 : !sycl_range_1_
-}
-
-// CHECK-LABEL:   func.func @test_num_work_items_dim(
-// CHECK-SAME:                                       %[[VAL_0:.*]]: i32) -> index {
-// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant dense<0> : vector<3xindex>
-// CHECK-NEXT:      %[[VAL_3:.*]] = gpu.grid_dim  x
-// CHECK-NEXT:      %[[VAL_4:.*]] = vector.insert %[[VAL_3]], %[[VAL_1]] [0] : index into vector<3xindex>
-// CHECK-NEXT:      %[[VAL_5:.*]] = gpu.grid_dim  y
-// CHECK-NEXT:      %[[VAL_6:.*]] = vector.insert %[[VAL_5]], %[[VAL_4]] [1] : index into vector<3xindex>
-// CHECK-NEXT:      %[[VAL_7:.*]] = gpu.grid_dim  z
-// CHECK-NEXT:      %[[VAL_8:.*]] = vector.insert %[[VAL_7]], %[[VAL_6]] [2] : index into vector<3xindex>
-// CHECK-NEXT:      %[[VAL_9:.*]] = vector.extractelement %[[VAL_8]]{{\[}}%[[VAL_0]] : i32] : vector<3xindex>
-// CHECK-NEXT:      return %[[VAL_9]] : index
-// CHECK-NEXT:    }
-func.func @test_num_work_items_dim(%i: i32) -> index {
-  %0 = sycl.num_work_items %i : index
-  return %0 : index
-}
-
 // CHECK-LABEL:   func.func @test_global_id() -> !sycl_id_2_ {
 // CHECK-NEXT:      %[[VAL_0:.*]] = memref.alloca() : memref<1x!sycl_id_2_>
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm.mlir
@@ -30,9 +30,9 @@ module attributes {gpu.container_module} {
     // CHECK:             %[[VAL_4:.*]] = llvm.getelementptr %[[VAL_2]]{{\[}}%[[VAL_3]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
     // CHECK:             %[[VAL_5:.*]] = llvm.ptrtoint %[[VAL_4]] : !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
     // CHECK:             %[[VAL_6:.*]] = llvm.alloca %[[VAL_5]] x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK:             %[[VAL_7:.*]] = llvm.mlir.constant(0 : index) : i64
-    // CHECK:             %[[VAL_8:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_7:.*]] = llvm.mlir.constant(0 : index) : i64
+    // CHECK-DAG:         %[[VAL_8:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK:             %[[VAL_10:.*]] = llvm.extractelement %[[VAL_1]]{{\[}}%[[VAL_9]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_6]][0, 0, 0, %[[VAL_8]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK:             %[[VAL_12:.*]] = llvm.getelementptr %[[VAL_11]]{{\[}}%[[VAL_7]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
@@ -50,8 +50,8 @@ module attributes {gpu.container_module} {
     // CHECK-SAME:                                         %[[VAL_15:.*]]: i32) -> i64 {
     // CHECK:             %[[VAL_16:.*]] = llvm.mlir.addressof @__builtin_var_GlobalSize__ : !llvm.ptr<vector<3xi64>>
     // CHECK:             %[[VAL_17:.*]] = llvm.load %[[VAL_16]] : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_18:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-    // CHECK:             %[[VAL_19:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_18:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+    // CHECK-DAG:         %[[VAL_19:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK:             %[[VAL_20:.*]] = llvm.extractelement %[[VAL_17]]{{\[}}%[[VAL_19]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_21:.*]] = llvm.mlir.constant(0 : i64) : i64
     // CHECK:             %[[VAL_22:.*]] = llvm.insertelement %[[VAL_20]], %[[VAL_18]]{{\[}}%[[VAL_21]] : i64] : vector<3xi64>
@@ -79,15 +79,15 @@ module attributes {gpu.container_module} {
     // CHECK:             %[[VAL_36:.*]] = llvm.getelementptr %[[VAL_34]]{{\[}}%[[VAL_35]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
     // CHECK:             %[[VAL_37:.*]] = llvm.ptrtoint %[[VAL_36]] : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>> to i64
     // CHECK:             %[[VAL_38:.*]] = llvm.alloca %[[VAL_37]] x !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
-    // CHECK:             %[[VAL_39:.*]] = llvm.mlir.constant(0 : index) : i64
-    // CHECK:             %[[VAL_40:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_41:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_39:.*]] = llvm.mlir.constant(0 : index) : i64
+    // CHECK-DAG:         %[[VAL_40:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_41:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK:             %[[VAL_42:.*]] = llvm.extractelement %[[VAL_33]]{{\[}}%[[VAL_41]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_43:.*]] = llvm.getelementptr inbounds %[[VAL_38]][0, 0, 0, %[[VAL_40]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK:             %[[VAL_44:.*]] = llvm.getelementptr %[[VAL_43]]{{\[}}%[[VAL_39]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
     // CHECK:             llvm.store %[[VAL_42]], %[[VAL_44]] : !llvm.ptr<i64>
-    // CHECK:             %[[VAL_45:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK:             %[[VAL_46:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-DAG:         %[[VAL_45:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-DAG:         %[[VAL_46:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK:             %[[VAL_47:.*]] = llvm.extractelement %[[VAL_33]]{{\[}}%[[VAL_46]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_48:.*]] = llvm.getelementptr inbounds %[[VAL_38]][0, 0, 0, %[[VAL_45]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK:             %[[VAL_49:.*]] = llvm.getelementptr %[[VAL_48]]{{\[}}%[[VAL_39]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
@@ -105,8 +105,8 @@ module attributes {gpu.container_module} {
     // CHECK-SAME:                                    %[[VAL_52:.*]]: i32) -> i64 {
     // CHECK:             %[[VAL_53:.*]] = llvm.mlir.addressof @__builtin_var_GlobalInvocationId__ : !llvm.ptr<vector<3xi64>>
     // CHECK:             %[[VAL_54:.*]] = llvm.load %[[VAL_53]] : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_55:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-    // CHECK:             %[[VAL_56:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_55:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+    // CHECK-DAG:         %[[VAL_56:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK:             %[[VAL_57:.*]] = llvm.extractelement %[[VAL_54]]{{\[}}%[[VAL_56]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_58:.*]] = llvm.mlir.constant(0 : i64) : i64
     // CHECK:             %[[VAL_59:.*]] = llvm.insertelement %[[VAL_57]], %[[VAL_55]]{{\[}}%[[VAL_58]] : i64] : vector<3xi64>
@@ -134,21 +134,21 @@ module attributes {gpu.container_module} {
     // CHECK:             %[[VAL_73:.*]] = llvm.getelementptr %[[VAL_71]]{{\[}}%[[VAL_72]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
     // CHECK:             %[[VAL_74:.*]] = llvm.ptrtoint %[[VAL_73]] : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>> to i64
     // CHECK:             %[[VAL_75:.*]] = llvm.alloca %[[VAL_74]] x !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-    // CHECK:             %[[VAL_76:.*]] = llvm.mlir.constant(0 : index) : i64
-    // CHECK:             %[[VAL_77:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_78:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_76:.*]] = llvm.mlir.constant(0 : index) : i64
+    // CHECK-DAG:         %[[VAL_77:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_78:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK:             %[[VAL_79:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_78]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_80:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_77]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK:             %[[VAL_81:.*]] = llvm.getelementptr %[[VAL_80]]{{\[}}%[[VAL_76]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
     // CHECK:             llvm.store %[[VAL_79]], %[[VAL_81]] : !llvm.ptr<i64>
-    // CHECK:             %[[VAL_82:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK:             %[[VAL_83:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-DAG:         %[[VAL_82:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-DAG:         %[[VAL_83:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK:             %[[VAL_84:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_83]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_85:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_82]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK:             %[[VAL_86:.*]] = llvm.getelementptr %[[VAL_85]]{{\[}}%[[VAL_76]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
     // CHECK:             llvm.store %[[VAL_84]], %[[VAL_86]] : !llvm.ptr<i64>
-    // CHECK:             %[[VAL_87:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK:             %[[VAL_88:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK-DAG:         %[[VAL_87:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK-DAG:         %[[VAL_88:.*]] = llvm.mlir.constant(2 : i32) : i32
     // CHECK:             %[[VAL_89:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_88]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_90:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_87]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK:             %[[VAL_91:.*]] = llvm.getelementptr %[[VAL_90]]{{\[}}%[[VAL_76]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
@@ -166,8 +166,8 @@ module attributes {gpu.container_module} {
     // CHECK-SAME:                                   %[[VAL_94:.*]]: i32) -> i64 {
     // CHECK:             %[[VAL_95:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
     // CHECK:             %[[VAL_96:.*]] = llvm.load %[[VAL_95]] : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_97:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-    // CHECK:             %[[VAL_98:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_97:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+    // CHECK-DAG:         %[[VAL_98:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK:             %[[VAL_99:.*]] = llvm.extractelement %[[VAL_96]]{{\[}}%[[VAL_98]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_100:.*]] = llvm.mlir.constant(0 : i64) : i64
     // CHECK:             %[[VAL_101:.*]] = llvm.insertelement %[[VAL_99]], %[[VAL_97]]{{\[}}%[[VAL_100]] : i64] : vector<3xi64>
@@ -195,21 +195,21 @@ module attributes {gpu.container_module} {
     // CHECK:             %[[VAL_115:.*]] = llvm.getelementptr %[[VAL_113]]{{\[}}%[[VAL_114]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
     // CHECK:             %[[VAL_116:.*]] = llvm.ptrtoint %[[VAL_115]] : !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>> to i64
     // CHECK:             %[[VAL_117:.*]] = llvm.alloca %[[VAL_116]] x !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-    // CHECK:             %[[VAL_118:.*]] = llvm.mlir.constant(0 : index) : i64
-    // CHECK:             %[[VAL_119:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_120:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_118:.*]] = llvm.mlir.constant(0 : index) : i64
+    // CHECK-DAG:         %[[VAL_119:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_120:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK:             %[[VAL_121:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_120]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_122:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_119]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK:             %[[VAL_123:.*]] = llvm.getelementptr %[[VAL_122]]{{\[}}%[[VAL_118]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
     // CHECK:             llvm.store %[[VAL_121]], %[[VAL_123]] : !llvm.ptr<i64>
-    // CHECK:             %[[VAL_124:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK:             %[[VAL_125:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-DAG:         %[[VAL_124:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-DAG:         %[[VAL_125:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK:             %[[VAL_126:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_125]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_127:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_124]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK:             %[[VAL_128:.*]] = llvm.getelementptr %[[VAL_127]]{{\[}}%[[VAL_118]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
     // CHECK:             llvm.store %[[VAL_126]], %[[VAL_128]] : !llvm.ptr<i64>
-    // CHECK:             %[[VAL_129:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK:             %[[VAL_130:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK-DAG:         %[[VAL_129:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK-DAG:         %[[VAL_130:.*]] = llvm.mlir.constant(2 : i32) : i32
     // CHECK:             %[[VAL_131:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_130]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_132:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_129]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK:             %[[VAL_133:.*]] = llvm.getelementptr %[[VAL_132]]{{\[}}%[[VAL_118]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
@@ -227,8 +227,8 @@ module attributes {gpu.container_module} {
     // CHECK-SAME:                                          %[[VAL_136:.*]]: i32) -> i64 {
     // CHECK:             %[[VAL_137:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupSize__ : !llvm.ptr<vector<3xi64>>
     // CHECK:             %[[VAL_138:.*]] = llvm.load %[[VAL_137]] : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_139:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-    // CHECK:             %[[VAL_140:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_139:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+    // CHECK-DAG:         %[[VAL_140:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK:             %[[VAL_141:.*]] = llvm.extractelement %[[VAL_138]]{{\[}}%[[VAL_140]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_142:.*]] = llvm.mlir.constant(0 : i64) : i64
     // CHECK:             %[[VAL_143:.*]] = llvm.insertelement %[[VAL_141]], %[[VAL_139]]{{\[}}%[[VAL_142]] : i64] : vector<3xi64>
@@ -256,9 +256,9 @@ module attributes {gpu.container_module} {
     // CHECK:             %[[VAL_157:.*]] = llvm.getelementptr %[[VAL_155]]{{\[}}%[[VAL_156]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
     // CHECK:             %[[VAL_158:.*]] = llvm.ptrtoint %[[VAL_157]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
     // CHECK:             %[[VAL_159:.*]] = llvm.alloca %[[VAL_158]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK:             %[[VAL_160:.*]] = llvm.mlir.constant(0 : index) : i64
-    // CHECK:             %[[VAL_161:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_162:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_160:.*]] = llvm.mlir.constant(0 : index) : i64
+    // CHECK-DAG:         %[[VAL_161:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_162:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK:             %[[VAL_163:.*]] = llvm.extractelement %[[VAL_154]]{{\[}}%[[VAL_162]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_164:.*]] = llvm.getelementptr inbounds %[[VAL_159]][0, 0, 0, %[[VAL_161]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK:             %[[VAL_165:.*]] = llvm.getelementptr %[[VAL_164]]{{\[}}%[[VAL_160]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
@@ -276,8 +276,8 @@ module attributes {gpu.container_module} {
     // CHECK-SAME:                                        %[[VAL_168:.*]]: i32) -> i64 {
     // CHECK:             %[[VAL_169:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupId__ : !llvm.ptr<vector<3xi64>>
     // CHECK:             %[[VAL_170:.*]] = llvm.load %[[VAL_169]] : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_171:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-    // CHECK:             %[[VAL_172:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_171:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+    // CHECK-DAG:         %[[VAL_172:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK:             %[[VAL_173:.*]] = llvm.extractelement %[[VAL_170]]{{\[}}%[[VAL_172]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_174:.*]] = llvm.mlir.constant(0 : i64) : i64
     // CHECK:             %[[VAL_175:.*]] = llvm.insertelement %[[VAL_173]], %[[VAL_171]]{{\[}}%[[VAL_174]] : i64] : vector<3xi64>
@@ -338,9 +338,9 @@ module attributes {gpu.container_module} {
     // CHECK:             %[[VAL_198:.*]] = llvm.getelementptr %[[VAL_196]]{{\[}}%[[VAL_197]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
     // CHECK:             %[[VAL_199:.*]] = llvm.ptrtoint %[[VAL_198]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
     // CHECK:             %[[VAL_200:.*]] = llvm.alloca %[[VAL_199]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK:             %[[VAL_201:.*]] = llvm.mlir.constant(0 : index) : i64
-    // CHECK:             %[[VAL_202:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_203:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_201:.*]] = llvm.mlir.constant(0 : index) : i64
+    // CHECK-DAG:         %[[VAL_202:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_203:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK:             %[[VAL_204:.*]] = llvm.extractelement %[[VAL_195]]{{\[}}%[[VAL_203]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_205:.*]] = llvm.getelementptr inbounds %[[VAL_200]][0, 0, 0, %[[VAL_202]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK:             %[[VAL_206:.*]] = llvm.getelementptr %[[VAL_205]]{{\[}}%[[VAL_201]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
@@ -358,8 +358,8 @@ module attributes {gpu.container_module} {
     // CHECK-SAME:                                        %[[VAL_222:.*]]: i32) -> i64 {
     // CHECK-NEXT:        %[[VAL_223:.*]] = llvm.mlir.addressof @__builtin_var_GlobalOffset__ : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_224:.*]] = llvm.load %[[VAL_223]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_225:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_226:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG-         %[[VAL_225:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+    // CHECK-DAG-         %[[VAL_226:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT:        %[[VAL_227:.*]] = llvm.extractelement %[[VAL_224]]{{\[}}%[[VAL_226]] : i32] : vector<3xi64>
     // CHECK-DAG:         %[[VAL_228:.*]] = llvm.mlir.constant(0 : i64) : i64
     // CHECK-NEXT:        %[[VAL_229:.*]] = llvm.insertelement %[[VAL_227]], %[[VAL_225]]{{\[}}%[[VAL_228]] : i64] : vector<3xi64>
@@ -387,15 +387,15 @@ module attributes {gpu.container_module} {
     // CHECK:             %[[VAL_230:.*]] = llvm.getelementptr %[[VAL_228]]{{\[}}%[[VAL_229]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
     // CHECK:             %[[VAL_231:.*]] = llvm.ptrtoint %[[VAL_230]] : !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>> to i64
     // CHECK:             %[[VAL_232:.*]] = llvm.alloca %[[VAL_231]] x !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
-    // CHECK:             %[[VAL_233:.*]] = llvm.mlir.constant(0 : index) : i64
-    // CHECK:             %[[VAL_234:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_235:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_233:.*]] = llvm.mlir.constant(0 : index) : i64
+    // CHECK-DAG:         %[[VAL_234:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_235:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK:             %[[VAL_236:.*]] = llvm.extractelement %[[VAL_227]]{{\[}}%[[VAL_235]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_237:.*]] = llvm.getelementptr inbounds %[[VAL_232]][0, 0, 0, %[[VAL_234]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK:             %[[VAL_238:.*]] = llvm.getelementptr %[[VAL_237]]{{\[}}%[[VAL_233]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
     // CHECK:             llvm.store %[[VAL_236]], %[[VAL_238]] : !llvm.ptr<i64>
-    // CHECK:             %[[VAL_239:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK:             %[[VAL_240:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-DAG:         %[[VAL_239:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-DAG:         %[[VAL_240:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK:             %[[VAL_241:.*]] = llvm.extractelement %[[VAL_227]]{{\[}}%[[VAL_240]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_242:.*]] = llvm.getelementptr inbounds %[[VAL_232]][0, 0, 0, %[[VAL_239]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK:             %[[VAL_243:.*]] = llvm.getelementptr %[[VAL_242]]{{\[}}%[[VAL_233]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
@@ -413,8 +413,8 @@ module attributes {gpu.container_module} {
     // CHECK-SAME:                                          %[[VAL_246:.*]]: i32) -> i64 {
     // CHECK:             %[[VAL_247:.*]] = llvm.mlir.addressof @__builtin_var_NumWorkgroups__ : !llvm.ptr<vector<3xi64>>
     // CHECK:             %[[VAL_248:.*]] = llvm.load %[[VAL_247]] : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_249:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-    // CHECK:             %[[VAL_250:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_249:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+    // CHECK-DAG:         %[[VAL_250:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK:             %[[VAL_251:.*]] = llvm.extractelement %[[VAL_248]]{{\[}}%[[VAL_250]] : i32] : vector<3xi64>
     // CHECK:             %[[VAL_252:.*]] = llvm.mlir.constant(0 : i64) : i64
     // CHECK:             %[[VAL_253:.*]] = llvm.insertelement %[[VAL_251]], %[[VAL_249]]{{\[}}%[[VAL_252]] : i64] : vector<3xi64>

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm.mlir
@@ -358,8 +358,8 @@ module attributes {gpu.container_module} {
     // CHECK-SAME:                                        %[[VAL_222:.*]]: i32) -> i64 {
     // CHECK-NEXT:        %[[VAL_223:.*]] = llvm.mlir.addressof @__builtin_var_GlobalOffset__ : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_224:.*]] = llvm.load %[[VAL_223]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG-         %[[VAL_225:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-    // CHECK-DAG-         %[[VAL_226:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_225:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+    // CHECK-DAG:         %[[VAL_226:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT:        %[[VAL_227:.*]] = llvm.extractelement %[[VAL_224]]{{\[}}%[[VAL_226]] : i32] : vector<3xi64>
     // CHECK-DAG:         %[[VAL_228:.*]] = llvm.mlir.constant(0 : i64) : i64
     // CHECK-NEXT:        %[[VAL_229:.*]] = llvm.insertelement %[[VAL_227]], %[[VAL_225]]{{\[}}%[[VAL_228]] : i64] : vector<3xi64>

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm.mlir
@@ -20,23 +20,26 @@ module attributes {gpu.container_module} {
     //CHECK-DAG:      llvm.mlir.global external constant @__builtin_var_LocalInvocationId__() {addr_space = 0 : i32} : vector<3xi64>
     //CHECK-DAG:      llvm.mlir.global external constant @__builtin_var_GlobalInvocationId__() {addr_space = 0 : i32} : vector<3xi64>
     //CHECK-DAG:      llvm.mlir.global external constant @__builtin_var_NumWorkgroups__() {addr_space = 0 : i32} : vector<3xi64>
+    //CHECK-DAG:      llvm.mlir.global external constant @__builtin_var_GlobalSize__() {addr_space = 0 : i32} : vector<3xi64>
   gpu.module @kernels {
     // CHECK-LABEL:   llvm.func @test_num_work_items() -> !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> {
-    // CHECK-DAG:         %[[VAL_0:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK-DAG:         %[[VAL_1:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK-NEXT:        %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_0]][1] : (!llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>) -> !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK-NEXT:        %[[VAL_3:.*]] = llvm.ptrtoint %[[VAL_2]] : !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
-    // CHECK-NEXT:        %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK-DAG:         %[[VAL_5:.*]] = llvm.mlir.constant(0 : index) : i64
-    // CHECK-DAG:         %[[VAL_6:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_7:.*]] = llvm.mlir.addressof @__builtin_var_NumWorkgroups__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_8:.*]] = llvm.load %[[VAL_7]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_10:.*]] = llvm.extractelement %[[VAL_8]]{{\[}}%[[VAL_9]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0, 0, 0] : (!llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>) -> !llvm.ptr<i64>
-    // CHECK-NEXT:        llvm.store %[[VAL_10]], %[[VAL_11]] : !llvm.ptr<i64>
-    // CHECK-NEXT:        %[[VAL_12:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK-NEXT:        llvm.return %[[VAL_12]] : !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+    // CHECK:             %[[VAL_0:.*]] = llvm.mlir.addressof @__builtin_var_GlobalSize__ : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_1:.*]] = llvm.load %[[VAL_0]] : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_2:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK:             %[[VAL_3:.*]] = llvm.mlir.constant(1 : index) : i64
+    // CHECK:             %[[VAL_4:.*]] = llvm.getelementptr %[[VAL_2]]{{\[}}%[[VAL_3]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK:             %[[VAL_5:.*]] = llvm.ptrtoint %[[VAL_4]] : !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
+    // CHECK:             %[[VAL_6:.*]] = llvm.alloca %[[VAL_5]] x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK:             %[[VAL_7:.*]] = llvm.mlir.constant(0 : index) : i64
+    // CHECK:             %[[VAL_8:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_10:.*]] = llvm.extractelement %[[VAL_1]]{{\[}}%[[VAL_9]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_6]][0, 0, 0, %[[VAL_8]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK:             %[[VAL_12:.*]] = llvm.getelementptr %[[VAL_11]]{{\[}}%[[VAL_7]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK:             llvm.store %[[VAL_10]], %[[VAL_12]] : !llvm.ptr<i64>
+    // CHECK:             %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_6]]{{\[}}%[[VAL_7]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK:             %[[VAL_14:.*]] = llvm.load %[[VAL_13]] : !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK:             llvm.return %[[VAL_14]] : !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
     // CHECK-NEXT:      }
     func.func @test_num_work_items() -> !sycl_range_1_ {
       %0 = sycl.num_work_items : !sycl_range_1_
@@ -44,268 +47,251 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_num_work_items_dim(
-    // CHECK-SAME:                                         %[[VAL_13:.*]]: i32) -> i64 {
-    // CHECK-DAG:         %[[VAL_14:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_15:.*]] = llvm.mlir.addressof @__builtin_var_NumWorkgroups__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_16:.*]] = llvm.load %[[VAL_15]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_17:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_18:.*]] = llvm.extractelement %[[VAL_16]]{{\[}}%[[VAL_17]] : i32] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_19:.*]] = llvm.mlir.constant(0 : i64) : i64
-    // CHECK-NEXT:        %[[VAL_20:.*]] = llvm.insertelement %[[VAL_18]], %[[VAL_14]]{{\[}}%[[VAL_19]] : i64] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_21:.*]] = llvm.mlir.addressof @__builtin_var_NumWorkgroups__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_22:.*]] = llvm.load %[[VAL_21]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_23:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_24:.*]] = llvm.extractelement %[[VAL_22]]{{\[}}%[[VAL_23]] : i32] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_25:.*]] = llvm.mlir.constant(1 : i64) : i64
-    // CHECK-NEXT:        %[[VAL_26:.*]] = llvm.insertelement %[[VAL_24]], %[[VAL_20]]{{\[}}%[[VAL_25]] : i64] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_27:.*]] = llvm.mlir.addressof @__builtin_var_NumWorkgroups__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_28:.*]] = llvm.load %[[VAL_27]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_29:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_30:.*]] = llvm.extractelement %[[VAL_28]]{{\[}}%[[VAL_29]] : i32] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_31:.*]] = llvm.mlir.constant(2 : i64) : i64
-    // CHECK-NEXT:        %[[VAL_32:.*]] = llvm.insertelement %[[VAL_30]], %[[VAL_26]]{{\[}}%[[VAL_31]] : i64] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_33:.*]] = llvm.extractelement %[[VAL_32]]{{\[}}%[[VAL_13]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        llvm.return %[[VAL_33]] : i64
-    // CHECK-NEXT:      }
+    // CHECK-SAME:                                         %[[VAL_15:.*]]: i32) -> i64 {
+    // CHECK:             %[[VAL_16:.*]] = llvm.mlir.addressof @__builtin_var_GlobalSize__ : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_17:.*]] = llvm.load %[[VAL_16]] : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_18:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+    // CHECK:             %[[VAL_19:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_20:.*]] = llvm.extractelement %[[VAL_17]]{{\[}}%[[VAL_19]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_21:.*]] = llvm.mlir.constant(0 : i64) : i64
+    // CHECK:             %[[VAL_22:.*]] = llvm.insertelement %[[VAL_20]], %[[VAL_18]]{{\[}}%[[VAL_21]] : i64] : vector<3xi64>
+    // CHECK:             %[[VAL_23:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK:             %[[VAL_24:.*]] = llvm.extractelement %[[VAL_17]]{{\[}}%[[VAL_23]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_25:.*]] = llvm.mlir.constant(1 : i64) : i64
+    // CHECK:             %[[VAL_26:.*]] = llvm.insertelement %[[VAL_24]], %[[VAL_22]]{{\[}}%[[VAL_25]] : i64] : vector<3xi64>
+    // CHECK:             %[[VAL_27:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK:             %[[VAL_28:.*]] = llvm.extractelement %[[VAL_17]]{{\[}}%[[VAL_27]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_29:.*]] = llvm.mlir.constant(2 : i64) : i64
+    // CHECK:             %[[VAL_30:.*]] = llvm.insertelement %[[VAL_28]], %[[VAL_26]]{{\[}}%[[VAL_29]] : i64] : vector<3xi64>
+    // CHECK:             %[[VAL_31:.*]] = llvm.extractelement %[[VAL_30]]{{\[}}%[[VAL_15]] : i32] : vector<3xi64>
+    // CHECK:             llvm.return %[[VAL_31]] : i64
+    // CHECK:           }
     func.func @test_num_work_items_dim(%i: i32) -> index {
       %0 = sycl.num_work_items %i : index
       return %0 : index
     }
 
     // CHECK-LABEL:     llvm.func @test_global_id() -> !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> {
-    // CHECK-DAG:         %[[VAL_34:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
-    // CHECK-DAG:         %[[VAL_35:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK-NEXT:        %[[VAL_36:.*]] = llvm.getelementptr %[[VAL_34]][1] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
-    // CHECK-NEXT:        %[[VAL_37:.*]] = llvm.ptrtoint %[[VAL_36]] : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>> to i64
-    // CHECK-NEXT:        %[[VAL_38:.*]] = llvm.alloca %[[VAL_37]] x !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
-    // CHECK-DAG:         %[[VAL_39:.*]] = llvm.mlir.constant(0 : index) : i64
-    // CHECK-DAG:         %[[VAL_40:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_41:.*]] = llvm.mlir.addressof @__builtin_var_GlobalInvocationId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_42:.*]] = llvm.load %[[VAL_41]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_43:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_44:.*]] = llvm.extractelement %[[VAL_42]]{{\[}}%[[VAL_43]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_45:.*]] = llvm.getelementptr inbounds %[[VAL_38]][0, 0, 0, 0] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>) -> !llvm.ptr<i64>
-    // CHECK-NEXT:        llvm.store %[[VAL_44]], %[[VAL_45]] : !llvm.ptr<i64>
-    // CHECK-DAG:         %[[VAL_46:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_47:.*]] = llvm.mlir.addressof @__builtin_var_GlobalInvocationId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_48:.*]] = llvm.load %[[VAL_47]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_49:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_50:.*]] = llvm.extractelement %[[VAL_48]]{{\[}}%[[VAL_49]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_51:.*]] = llvm.getelementptr inbounds %[[VAL_38]][0, 0, 0, 1] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>) -> !llvm.ptr<i64>
-    // CHECK-NEXT:        llvm.store %[[VAL_50]], %[[VAL_51]] : !llvm.ptr<i64>
-    // CHECK-NEXT:        %[[VAL_52:.*]] = llvm.load %[[VAL_38]] : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
-    // CHECK-NEXT:        llvm.return %[[VAL_52]] : !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
-    // CHECK-NEXT:      }
+    // CHECK:             %[[VAL_32:.*]] = llvm.mlir.addressof @__builtin_var_GlobalInvocationId__ : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_33:.*]] = llvm.load %[[VAL_32]] : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_34:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK:             %[[VAL_35:.*]] = llvm.mlir.constant(1 : index) : i64
+    // CHECK:             %[[VAL_36:.*]] = llvm.getelementptr %[[VAL_34]]{{\[}}%[[VAL_35]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK:             %[[VAL_37:.*]] = llvm.ptrtoint %[[VAL_36]] : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>> to i64
+    // CHECK:             %[[VAL_38:.*]] = llvm.alloca %[[VAL_37]] x !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK:             %[[VAL_39:.*]] = llvm.mlir.constant(0 : index) : i64
+    // CHECK:             %[[VAL_40:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_41:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_42:.*]] = llvm.extractelement %[[VAL_33]]{{\[}}%[[VAL_41]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_43:.*]] = llvm.getelementptr inbounds %[[VAL_38]][0, 0, 0, %[[VAL_40]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK:             %[[VAL_44:.*]] = llvm.getelementptr %[[VAL_43]]{{\[}}%[[VAL_39]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK:             llvm.store %[[VAL_42]], %[[VAL_44]] : !llvm.ptr<i64>
+    // CHECK:             %[[VAL_45:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK:             %[[VAL_46:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK:             %[[VAL_47:.*]] = llvm.extractelement %[[VAL_33]]{{\[}}%[[VAL_46]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_48:.*]] = llvm.getelementptr inbounds %[[VAL_38]][0, 0, 0, %[[VAL_45]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK:             %[[VAL_49:.*]] = llvm.getelementptr %[[VAL_48]]{{\[}}%[[VAL_39]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK:             llvm.store %[[VAL_47]], %[[VAL_49]] : !llvm.ptr<i64>
+    // CHECK:             %[[VAL_50:.*]] = llvm.getelementptr %[[VAL_38]]{{\[}}%[[VAL_39]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK:             %[[VAL_51:.*]] = llvm.load %[[VAL_50]] : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK:             llvm.return %[[VAL_51]] : !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+    // CHECK:           }
     func.func @test_global_id() -> !sycl_id_2_ {
       %0 = sycl.global_id : !sycl_id_2_
       return %0 : !sycl_id_2_
     }
 
     // CHECK-LABEL:     llvm.func @test_global_id_dim(
-    // CHECK-SAME:                                    %[[VAL_53:.*]]: i32) -> i64 {
-    // CHECK-DAG:         %[[VAL_54:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_55:.*]] = llvm.mlir.addressof @__builtin_var_GlobalInvocationId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_56:.*]] = llvm.load %[[VAL_55]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_57:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_58:.*]] = llvm.extractelement %[[VAL_56]]{{\[}}%[[VAL_57]] : i32] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_59:.*]] = llvm.mlir.constant(0 : i64) : i64
-    // CHECK-NEXT:        %[[VAL_60:.*]] = llvm.insertelement %[[VAL_58]], %[[VAL_54]]{{\[}}%[[VAL_59]] : i64] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_61:.*]] = llvm.mlir.addressof @__builtin_var_GlobalInvocationId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_62:.*]] = llvm.load %[[VAL_61]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_63:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_64:.*]] = llvm.extractelement %[[VAL_62]]{{\[}}%[[VAL_63]] : i32] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_65:.*]] = llvm.mlir.constant(1 : i64) : i64
-    // CHECK-NEXT:        %[[VAL_66:.*]] = llvm.insertelement %[[VAL_64]], %[[VAL_60]]{{\[}}%[[VAL_65]] : i64] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_67:.*]] = llvm.mlir.addressof @__builtin_var_GlobalInvocationId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_68:.*]] = llvm.load %[[VAL_67]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_69:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_70:.*]] = llvm.extractelement %[[VAL_68]]{{\[}}%[[VAL_69]] : i32] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_71:.*]] = llvm.mlir.constant(2 : i64) : i64
-    // CHECK-NEXT:        %[[VAL_72:.*]] = llvm.insertelement %[[VAL_70]], %[[VAL_66]]{{\[}}%[[VAL_71]] : i64] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_73:.*]] = llvm.extractelement %[[VAL_72]]{{\[}}%[[VAL_53]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        llvm.return %[[VAL_73]] : i64
-    // CHECK-NEXT:      }
+    // CHECK-SAME:                                    %[[VAL_52:.*]]: i32) -> i64 {
+    // CHECK:             %[[VAL_53:.*]] = llvm.mlir.addressof @__builtin_var_GlobalInvocationId__ : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_54:.*]] = llvm.load %[[VAL_53]] : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_55:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+    // CHECK:             %[[VAL_56:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_57:.*]] = llvm.extractelement %[[VAL_54]]{{\[}}%[[VAL_56]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_58:.*]] = llvm.mlir.constant(0 : i64) : i64
+    // CHECK:             %[[VAL_59:.*]] = llvm.insertelement %[[VAL_57]], %[[VAL_55]]{{\[}}%[[VAL_58]] : i64] : vector<3xi64>
+    // CHECK:             %[[VAL_60:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK:             %[[VAL_61:.*]] = llvm.extractelement %[[VAL_54]]{{\[}}%[[VAL_60]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_62:.*]] = llvm.mlir.constant(1 : i64) : i64
+    // CHECK:             %[[VAL_63:.*]] = llvm.insertelement %[[VAL_61]], %[[VAL_59]]{{\[}}%[[VAL_62]] : i64] : vector<3xi64>
+    // CHECK:             %[[VAL_64:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK:             %[[VAL_65:.*]] = llvm.extractelement %[[VAL_54]]{{\[}}%[[VAL_64]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_66:.*]] = llvm.mlir.constant(2 : i64) : i64
+    // CHECK:             %[[VAL_67:.*]] = llvm.insertelement %[[VAL_65]], %[[VAL_63]]{{\[}}%[[VAL_66]] : i64] : vector<3xi64>
+    // CHECK:             %[[VAL_68:.*]] = llvm.extractelement %[[VAL_67]]{{\[}}%[[VAL_52]] : i32] : vector<3xi64>
+    // CHECK:             llvm.return %[[VAL_68]] : i64
+    // CHECK:           }
     func.func @test_global_id_dim(%i: i32) -> index {
       %0 = sycl.global_id %i : index
       return %0 : index
     }
 
     // CHECK-LABEL:     llvm.func @test_local_id() -> !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> {
-    // CHECK-DAG:         %[[VAL_74:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-    // CHECK-DAG:         %[[VAL_75:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK-NEXT:        %[[VAL_76:.*]] = llvm.getelementptr %[[VAL_74]][1] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-    // CHECK-NEXT:        %[[VAL_77:.*]] = llvm.ptrtoint %[[VAL_76]] : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>> to i64
-    // CHECK-NEXT:        %[[VAL_78:.*]] = llvm.alloca %[[VAL_77]] x !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-    // CHECK-DAG:         %[[VAL_79:.*]] = llvm.mlir.constant(0 : index) : i64
-    // CHECK-DAG:         %[[VAL_80:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_81:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_82:.*]] = llvm.load %[[VAL_81]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_83:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_84:.*]] = llvm.extractelement %[[VAL_82]]{{\[}}%[[VAL_83]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_85:.*]] = llvm.getelementptr inbounds %[[VAL_78]][0, 0, 0, 0] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>) -> !llvm.ptr<i64>
-    // CHECK-NEXT:        llvm.store %[[VAL_84]], %[[VAL_85]] : !llvm.ptr<i64>
-    // CHECK-DAG:         %[[VAL_86:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_87:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_88:.*]] = llvm.load %[[VAL_87]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_89:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_90:.*]] = llvm.extractelement %[[VAL_88]]{{\[}}%[[VAL_89]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_91:.*]] = llvm.getelementptr inbounds %[[VAL_78]][0, 0, 0, 1] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>) -> !llvm.ptr<i64>
-    // CHECK-NEXT:        llvm.store %[[VAL_90]], %[[VAL_91]] : !llvm.ptr<i64>
-    // CHECK-DAG:         %[[VAL_92:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_93:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_94:.*]] = llvm.load %[[VAL_93]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_95:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_96:.*]] = llvm.extractelement %[[VAL_94]]{{\[}}%[[VAL_95]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_97:.*]] = llvm.getelementptr inbounds %[[VAL_78]][0, 0, 0, 2] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>) -> !llvm.ptr<i64>
-    // CHECK-NEXT:        llvm.store %[[VAL_96]], %[[VAL_97]] : !llvm.ptr<i64>
-    // CHECK-NEXT:        %[[VAL_98:.*]] = llvm.load %[[VAL_78]] : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-    // CHECK-NEXT:        llvm.return %[[VAL_98]] : !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-    // CHECK-NEXT:      }
+    // CHECK:             %[[VAL_69:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_70:.*]] = llvm.load %[[VAL_69]] : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_71:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK:             %[[VAL_72:.*]] = llvm.mlir.constant(1 : index) : i64
+    // CHECK:             %[[VAL_73:.*]] = llvm.getelementptr %[[VAL_71]]{{\[}}%[[VAL_72]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK:             %[[VAL_74:.*]] = llvm.ptrtoint %[[VAL_73]] : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>> to i64
+    // CHECK:             %[[VAL_75:.*]] = llvm.alloca %[[VAL_74]] x !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK:             %[[VAL_76:.*]] = llvm.mlir.constant(0 : index) : i64
+    // CHECK:             %[[VAL_77:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_78:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_79:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_78]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_80:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_77]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK:             %[[VAL_81:.*]] = llvm.getelementptr %[[VAL_80]]{{\[}}%[[VAL_76]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK:             llvm.store %[[VAL_79]], %[[VAL_81]] : !llvm.ptr<i64>
+    // CHECK:             %[[VAL_82:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK:             %[[VAL_83:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK:             %[[VAL_84:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_83]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_85:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_82]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK:             %[[VAL_86:.*]] = llvm.getelementptr %[[VAL_85]]{{\[}}%[[VAL_76]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK:             llvm.store %[[VAL_84]], %[[VAL_86]] : !llvm.ptr<i64>
+    // CHECK:             %[[VAL_87:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK:             %[[VAL_88:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK:             %[[VAL_89:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_88]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_90:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_87]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK:             %[[VAL_91:.*]] = llvm.getelementptr %[[VAL_90]]{{\[}}%[[VAL_76]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK:             llvm.store %[[VAL_89]], %[[VAL_91]] : !llvm.ptr<i64>
+    // CHECK:             %[[VAL_92:.*]] = llvm.getelementptr %[[VAL_75]]{{\[}}%[[VAL_76]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK:             %[[VAL_93:.*]] = llvm.load %[[VAL_92]] : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK:             llvm.return %[[VAL_93]] : !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+    // CHECK:           }
     func.func @test_local_id() -> !sycl_id_3_ {
       %0 = sycl.local_id : !sycl_id_3_
       return %0 : !sycl_id_3_
     }
 
     // CHECK-LABEL:     llvm.func @test_local_id_dim(
-    // CHECK-SAME:                                   %[[VAL_99:.*]]: i32) -> i64 {
-    // CHECK-DAG:         %[[VAL_100:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_101:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_102:.*]] = llvm.load %[[VAL_101]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_103:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_104:.*]] = llvm.extractelement %[[VAL_102]]{{\[}}%[[VAL_103]] : i32] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_105:.*]] = llvm.mlir.constant(0 : i64) : i64
-    // CHECK-NEXT:        %[[VAL_106:.*]] = llvm.insertelement %[[VAL_104]], %[[VAL_100]]{{\[}}%[[VAL_105]] : i64] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_107:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_108:.*]] = llvm.load %[[VAL_107]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_109:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_110:.*]] = llvm.extractelement %[[VAL_108]]{{\[}}%[[VAL_109]] : i32] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_111:.*]] = llvm.mlir.constant(1 : i64) : i64
-    // CHECK-NEXT:        %[[VAL_112:.*]] = llvm.insertelement %[[VAL_110]], %[[VAL_106]]{{\[}}%[[VAL_111]] : i64] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_113:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_114:.*]] = llvm.load %[[VAL_113]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_115:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_116:.*]] = llvm.extractelement %[[VAL_114]]{{\[}}%[[VAL_115]] : i32] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_117:.*]] = llvm.mlir.constant(2 : i64) : i64
-    // CHECK-NEXT:        %[[VAL_118:.*]] = llvm.insertelement %[[VAL_116]], %[[VAL_112]]{{\[}}%[[VAL_117]] : i64] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_119:.*]] = llvm.extractelement %[[VAL_118]]{{\[}}%[[VAL_99]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        llvm.return %[[VAL_119]] : i64
-    // CHECK-NEXT:      }
+    // CHECK-SAME:                                   %[[VAL_94:.*]]: i32) -> i64 {
+    // CHECK:             %[[VAL_95:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_96:.*]] = llvm.load %[[VAL_95]] : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_97:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+    // CHECK:             %[[VAL_98:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_99:.*]] = llvm.extractelement %[[VAL_96]]{{\[}}%[[VAL_98]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_100:.*]] = llvm.mlir.constant(0 : i64) : i64
+    // CHECK:             %[[VAL_101:.*]] = llvm.insertelement %[[VAL_99]], %[[VAL_97]]{{\[}}%[[VAL_100]] : i64] : vector<3xi64>
+    // CHECK:             %[[VAL_102:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK:             %[[VAL_103:.*]] = llvm.extractelement %[[VAL_96]]{{\[}}%[[VAL_102]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_104:.*]] = llvm.mlir.constant(1 : i64) : i64
+    // CHECK:             %[[VAL_105:.*]] = llvm.insertelement %[[VAL_103]], %[[VAL_101]]{{\[}}%[[VAL_104]] : i64] : vector<3xi64>
+    // CHECK:             %[[VAL_106:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK:             %[[VAL_107:.*]] = llvm.extractelement %[[VAL_96]]{{\[}}%[[VAL_106]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_108:.*]] = llvm.mlir.constant(2 : i64) : i64
+    // CHECK:             %[[VAL_109:.*]] = llvm.insertelement %[[VAL_107]], %[[VAL_105]]{{\[}}%[[VAL_108]] : i64] : vector<3xi64>
+    // CHECK:             %[[VAL_110:.*]] = llvm.extractelement %[[VAL_109]]{{\[}}%[[VAL_94]] : i32] : vector<3xi64>
+    // CHECK:             llvm.return %[[VAL_110]] : i64
+    // CHECK:           }
     func.func @test_local_id_dim(%i: i32) -> index {
       %0 = sycl.local_id %i : index
       return %0 : index
     }
 
     // CHECK-LABEL:     llvm.func @test_work_group_size() -> !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> {
-    // CHECK-DAG:         %[[VAL_120:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-    // CHECK-DAG:         %[[VAL_121:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK-NEXT:        %[[VAL_122:.*]] = llvm.getelementptr %[[VAL_120]][1] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>) -> !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-    // CHECK-NEXT:        %[[VAL_123:.*]] = llvm.ptrtoint %[[VAL_122]] : !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>> to i64
-    // CHECK-NEXT:        %[[VAL_124:.*]] = llvm.alloca %[[VAL_123]] x !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-    // CHECK-DAG:         %[[VAL_125:.*]] = llvm.mlir.constant(0 : index) : i64
-    // CHECK-DAG:         %[[VAL_126:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_127:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupSize__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_128:.*]] = llvm.load %[[VAL_127]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_129:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_130:.*]] = llvm.extractelement %[[VAL_128]]{{\[}}%[[VAL_129]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_131:.*]] = llvm.getelementptr inbounds %[[VAL_124]][0, 0, 0, 0] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>) -> !llvm.ptr<i64>
-    // CHECK-NEXT:        llvm.store %[[VAL_130]], %[[VAL_131]] : !llvm.ptr<i64>
-    // CHECK-DAG:         %[[VAL_132:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_133:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupSize__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_134:.*]] = llvm.load %[[VAL_133]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_135:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_136:.*]] = llvm.extractelement %[[VAL_134]]{{\[}}%[[VAL_135]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_137:.*]] = llvm.getelementptr inbounds %[[VAL_124]][0, 0, 0, 1] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>) -> !llvm.ptr<i64>
-    // CHECK-NEXT:        llvm.store %[[VAL_136]], %[[VAL_137]] : !llvm.ptr<i64>
-    // CHECK-DAG:         %[[VAL_138:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_139:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupSize__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_140:.*]] = llvm.load %[[VAL_139]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_141:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_142:.*]] = llvm.extractelement %[[VAL_140]]{{\[}}%[[VAL_141]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_143:.*]] = llvm.getelementptr inbounds %[[VAL_124]][0, 0, 0, 2] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>) -> !llvm.ptr<i64>
-    // CHECK-NEXT:        llvm.store %[[VAL_142]], %[[VAL_143]] : !llvm.ptr<i64>
-    // CHECK-NEXT:        %[[VAL_144:.*]] = llvm.load %[[VAL_124]] : !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-    // CHECK-NEXT:        llvm.return %[[VAL_144]] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-    // CHECK-NEXT:      }
+    // CHECK:             %[[VAL_111:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupSize__ : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_112:.*]] = llvm.load %[[VAL_111]] : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_113:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK:             %[[VAL_114:.*]] = llvm.mlir.constant(1 : index) : i64
+    // CHECK:             %[[VAL_115:.*]] = llvm.getelementptr %[[VAL_113]]{{\[}}%[[VAL_114]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK:             %[[VAL_116:.*]] = llvm.ptrtoint %[[VAL_115]] : !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>> to i64
+    // CHECK:             %[[VAL_117:.*]] = llvm.alloca %[[VAL_116]] x !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK:             %[[VAL_118:.*]] = llvm.mlir.constant(0 : index) : i64
+    // CHECK:             %[[VAL_119:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_120:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_121:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_120]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_122:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_119]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK:             %[[VAL_123:.*]] = llvm.getelementptr %[[VAL_122]]{{\[}}%[[VAL_118]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK:             llvm.store %[[VAL_121]], %[[VAL_123]] : !llvm.ptr<i64>
+    // CHECK:             %[[VAL_124:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK:             %[[VAL_125:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK:             %[[VAL_126:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_125]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_127:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_124]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK:             %[[VAL_128:.*]] = llvm.getelementptr %[[VAL_127]]{{\[}}%[[VAL_118]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK:             llvm.store %[[VAL_126]], %[[VAL_128]] : !llvm.ptr<i64>
+    // CHECK:             %[[VAL_129:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK:             %[[VAL_130:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK:             %[[VAL_131:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_130]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_132:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_129]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK:             %[[VAL_133:.*]] = llvm.getelementptr %[[VAL_132]]{{\[}}%[[VAL_118]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK:             llvm.store %[[VAL_131]], %[[VAL_133]] : !llvm.ptr<i64>
+    // CHECK:             %[[VAL_134:.*]] = llvm.getelementptr %[[VAL_117]]{{\[}}%[[VAL_118]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK:             %[[VAL_135:.*]] = llvm.load %[[VAL_134]] : !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK:             llvm.return %[[VAL_135]] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+    // CHECK:           }
     func.func @test_work_group_size() -> !sycl_range_3_ {
       %0 = sycl.work_group_size : !sycl_range_3_
       return %0 : !sycl_range_3_
     }
 
     // CHECK-LABEL:     llvm.func @test_work_group_size_dim(
-    // CHECK-SAME:                                          %[[VAL_145:.*]]: i32) -> i64 {
-    // CHECK-DAG:         %[[VAL_146:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_147:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupSize__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_148:.*]] = llvm.load %[[VAL_147]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_149:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_150:.*]] = llvm.extractelement %[[VAL_148]]{{\[}}%[[VAL_149]] : i32] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_151:.*]] = llvm.mlir.constant(0 : i64) : i64
-    // CHECK-NEXT:        %[[VAL_152:.*]] = llvm.insertelement %[[VAL_150]], %[[VAL_146]]{{\[}}%[[VAL_151]] : i64] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_153:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupSize__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_154:.*]] = llvm.load %[[VAL_153]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_155:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_156:.*]] = llvm.extractelement %[[VAL_154]]{{\[}}%[[VAL_155]] : i32] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_157:.*]] = llvm.mlir.constant(1 : i64) : i64
-    // CHECK-NEXT:        %[[VAL_158:.*]] = llvm.insertelement %[[VAL_156]], %[[VAL_152]]{{\[}}%[[VAL_157]] : i64] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_159:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupSize__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_160:.*]] = llvm.load %[[VAL_159]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_161:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_162:.*]] = llvm.extractelement %[[VAL_160]]{{\[}}%[[VAL_161]] : i32] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_163:.*]] = llvm.mlir.constant(2 : i64) : i64
-    // CHECK-NEXT:        %[[VAL_164:.*]] = llvm.insertelement %[[VAL_162]], %[[VAL_158]]{{\[}}%[[VAL_163]] : i64] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_165:.*]] = llvm.extractelement %[[VAL_164]]{{\[}}%[[VAL_145]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        llvm.return %[[VAL_165]] : i64
-    // CHECK-NEXT:      }
+    // CHECK-SAME:                                          %[[VAL_136:.*]]: i32) -> i64 {
+    // CHECK:             %[[VAL_137:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupSize__ : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_138:.*]] = llvm.load %[[VAL_137]] : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_139:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+    // CHECK:             %[[VAL_140:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_141:.*]] = llvm.extractelement %[[VAL_138]]{{\[}}%[[VAL_140]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_142:.*]] = llvm.mlir.constant(0 : i64) : i64
+    // CHECK:             %[[VAL_143:.*]] = llvm.insertelement %[[VAL_141]], %[[VAL_139]]{{\[}}%[[VAL_142]] : i64] : vector<3xi64>
+    // CHECK:             %[[VAL_144:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK:             %[[VAL_145:.*]] = llvm.extractelement %[[VAL_138]]{{\[}}%[[VAL_144]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_146:.*]] = llvm.mlir.constant(1 : i64) : i64
+    // CHECK:             %[[VAL_147:.*]] = llvm.insertelement %[[VAL_145]], %[[VAL_143]]{{\[}}%[[VAL_146]] : i64] : vector<3xi64>
+    // CHECK:             %[[VAL_148:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK:             %[[VAL_149:.*]] = llvm.extractelement %[[VAL_138]]{{\[}}%[[VAL_148]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_150:.*]] = llvm.mlir.constant(2 : i64) : i64
+    // CHECK:             %[[VAL_151:.*]] = llvm.insertelement %[[VAL_149]], %[[VAL_147]]{{\[}}%[[VAL_150]] : i64] : vector<3xi64>
+    // CHECK:             %[[VAL_152:.*]] = llvm.extractelement %[[VAL_151]]{{\[}}%[[VAL_136]] : i32] : vector<3xi64>
+    // CHECK:             llvm.return %[[VAL_152]] : i64
+    // CHECK:           }
     func.func @test_work_group_size_dim(%i: i32) -> index {
       %0 = sycl.work_group_size %i : index
       return %0 : index
     }
 
     // CHECK-LABEL:     llvm.func @test_work_group_id() -> !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> {
-    // CHECK-DAG:         %[[VAL_166:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK-DAG:         %[[VAL_167:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK-NEXT:        %[[VAL_168:.*]] = llvm.getelementptr %[[VAL_166]][1] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK-NEXT:        %[[VAL_169:.*]] = llvm.ptrtoint %[[VAL_168]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
-    // CHECK-NEXT:        %[[VAL_170:.*]] = llvm.alloca %[[VAL_169]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK-DAG:         %[[VAL_171:.*]] = llvm.mlir.constant(0 : index) : i64
-    // CHECK-DAG:         %[[VAL_172:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_173:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_174:.*]] = llvm.load %[[VAL_173]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_175:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_176:.*]] = llvm.extractelement %[[VAL_174]]{{\[}}%[[VAL_175]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_177:.*]] = llvm.getelementptr inbounds %[[VAL_170]][0, 0, 0, 0] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>) -> !llvm.ptr<i64>
-    // CHECK-NEXT:        llvm.store %[[VAL_176]], %[[VAL_177]] : !llvm.ptr<i64>
-    // CHECK-NEXT:        %[[VAL_178:.*]] = llvm.load %[[VAL_170]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK-NEXT:        llvm.return %[[VAL_178]] : !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
-    // CHECK-NEXT:      }
+    // CHECK:             %[[VAL_153:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupId__ : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_154:.*]] = llvm.load %[[VAL_153]] : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_155:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK:             %[[VAL_156:.*]] = llvm.mlir.constant(1 : index) : i64
+    // CHECK:             %[[VAL_157:.*]] = llvm.getelementptr %[[VAL_155]]{{\[}}%[[VAL_156]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK:             %[[VAL_158:.*]] = llvm.ptrtoint %[[VAL_157]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
+    // CHECK:             %[[VAL_159:.*]] = llvm.alloca %[[VAL_158]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK:             %[[VAL_160:.*]] = llvm.mlir.constant(0 : index) : i64
+    // CHECK:             %[[VAL_161:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_162:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_163:.*]] = llvm.extractelement %[[VAL_154]]{{\[}}%[[VAL_162]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_164:.*]] = llvm.getelementptr inbounds %[[VAL_159]][0, 0, 0, %[[VAL_161]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK:             %[[VAL_165:.*]] = llvm.getelementptr %[[VAL_164]]{{\[}}%[[VAL_160]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK:             llvm.store %[[VAL_163]], %[[VAL_165]] : !llvm.ptr<i64>
+    // CHECK:             %[[VAL_166:.*]] = llvm.getelementptr %[[VAL_159]]{{\[}}%[[VAL_160]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK:             %[[VAL_167:.*]] = llvm.load %[[VAL_166]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK:             llvm.return %[[VAL_167]] : !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+    // CHECK:           }
     func.func @test_work_group_id() -> !sycl_id_1_ {
       %0 = sycl.work_group_id : !sycl_id_1_
       return %0 : !sycl_id_1_
     }
 
     // CHECK-LABEL:     llvm.func @test_work_group_id_dim(
-    // CHECK-SAME:                                        %[[VAL_179:.*]]: i32) -> i64 {
-    // CHECK-DAG:         %[[VAL_180:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_181:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_182:.*]] = llvm.load %[[VAL_181]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_183:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_184:.*]] = llvm.extractelement %[[VAL_182]]{{\[}}%[[VAL_183]] : i32] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_185:.*]] = llvm.mlir.constant(0 : i64) : i64
-    // CHECK-NEXT:        %[[VAL_186:.*]] = llvm.insertelement %[[VAL_184]], %[[VAL_180]]{{\[}}%[[VAL_185]] : i64] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_187:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_188:.*]] = llvm.load %[[VAL_187]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_189:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_190:.*]] = llvm.extractelement %[[VAL_188]]{{\[}}%[[VAL_189]] : i32] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_191:.*]] = llvm.mlir.constant(1 : i64) : i64
-    // CHECK-NEXT:        %[[VAL_192:.*]] = llvm.insertelement %[[VAL_190]], %[[VAL_186]]{{\[}}%[[VAL_191]] : i64] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_193:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_194:.*]] = llvm.load %[[VAL_193]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_195:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_196:.*]] = llvm.extractelement %[[VAL_194]]{{\[}}%[[VAL_195]] : i32] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_197:.*]] = llvm.mlir.constant(2 : i64) : i64
-    // CHECK-NEXT:        %[[VAL_198:.*]] = llvm.insertelement %[[VAL_196]], %[[VAL_192]]{{\[}}%[[VAL_197]] : i64] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_199:.*]] = llvm.extractelement %[[VAL_198]]{{\[}}%[[VAL_179]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        llvm.return %[[VAL_199]] : i64
-    // CHECK-NEXT:      }
+    // CHECK-SAME:                                        %[[VAL_168:.*]]: i32) -> i64 {
+    // CHECK:             %[[VAL_169:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupId__ : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_170:.*]] = llvm.load %[[VAL_169]] : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_171:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+    // CHECK:             %[[VAL_172:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_173:.*]] = llvm.extractelement %[[VAL_170]]{{\[}}%[[VAL_172]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_174:.*]] = llvm.mlir.constant(0 : i64) : i64
+    // CHECK:             %[[VAL_175:.*]] = llvm.insertelement %[[VAL_173]], %[[VAL_171]]{{\[}}%[[VAL_174]] : i64] : vector<3xi64>
+    // CHECK:             %[[VAL_176:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK:             %[[VAL_177:.*]] = llvm.extractelement %[[VAL_170]]{{\[}}%[[VAL_176]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_178:.*]] = llvm.mlir.constant(1 : i64) : i64
+    // CHECK:             %[[VAL_179:.*]] = llvm.insertelement %[[VAL_177]], %[[VAL_175]]{{\[}}%[[VAL_178]] : i64] : vector<3xi64>
+    // CHECK:             %[[VAL_180:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK:             %[[VAL_181:.*]] = llvm.extractelement %[[VAL_170]]{{\[}}%[[VAL_180]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_182:.*]] = llvm.mlir.constant(2 : i64) : i64
+    // CHECK:             %[[VAL_183:.*]] = llvm.insertelement %[[VAL_181]], %[[VAL_179]]{{\[}}%[[VAL_182]] : i64] : vector<3xi64>
+    // CHECK:             %[[VAL_184:.*]] = llvm.extractelement %[[VAL_183]]{{\[}}%[[VAL_168]] : i32] : vector<3xi64>
+    // CHECK:             llvm.return %[[VAL_184]] : i64
+    // CHECK:           }
     func.func @test_work_group_id_dim(%i: i32) -> index {
       %0 = sycl.work_group_id %i : index
       return %0 : index
@@ -345,22 +331,24 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_global_offset() -> !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> {
-    // CHECK-NEXT:        %[[VAL_209:.*]] = llvm.mlir.addressof @__builtin_var_GlobalOffset__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_210:.*]] = llvm.load %[[VAL_209]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_211:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK-DAG:         %[[VAL_212:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK-NEXT:        %[[VAL_213:.*]] = llvm.getelementptr %[[VAL_211]][1] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK-NEXT:        %[[VAL_214:.*]] = llvm.ptrtoint %[[VAL_213]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
-    // CHECK-NEXT:        %[[VAL_215:.*]] = llvm.alloca %[[VAL_214]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK-DAG:         %[[VAL_216:.*]] = llvm.mlir.constant(0 : index) : i64
-    // CHECK-DAG:         %[[VAL_217:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-DAG:         %[[VAL_218:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_219:.*]] = llvm.extractelement %[[VAL_210]]{{\[}}%[[VAL_218]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_220:.*]] = llvm.getelementptr inbounds %[[VAL_215]][0, 0, 0, 0] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>) -> !llvm.ptr<i64>
-    // CHECK-NEXT:        llvm.store %[[VAL_219]], %[[VAL_220]] : !llvm.ptr<i64>
-    // CHECK-NEXT:        %[[VAL_221:.*]] = llvm.load %[[VAL_215]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK-NEXT:        llvm.return %[[VAL_221]] : !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
-    // CHECK-NEXT:      }
+    // CHECK:             %[[VAL_194:.*]] = llvm.mlir.addressof @__builtin_var_GlobalOffset__ : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_195:.*]] = llvm.load %[[VAL_194]] : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_196:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK:             %[[VAL_197:.*]] = llvm.mlir.constant(1 : index) : i64
+    // CHECK:             %[[VAL_198:.*]] = llvm.getelementptr %[[VAL_196]]{{\[}}%[[VAL_197]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK:             %[[VAL_199:.*]] = llvm.ptrtoint %[[VAL_198]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
+    // CHECK:             %[[VAL_200:.*]] = llvm.alloca %[[VAL_199]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK:             %[[VAL_201:.*]] = llvm.mlir.constant(0 : index) : i64
+    // CHECK:             %[[VAL_202:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_203:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_204:.*]] = llvm.extractelement %[[VAL_195]]{{\[}}%[[VAL_203]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_205:.*]] = llvm.getelementptr inbounds %[[VAL_200]][0, 0, 0, %[[VAL_202]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK:             %[[VAL_206:.*]] = llvm.getelementptr %[[VAL_205]]{{\[}}%[[VAL_201]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK:             llvm.store %[[VAL_204]], %[[VAL_206]] : !llvm.ptr<i64>
+    // CHECK:             %[[VAL_207:.*]] = llvm.getelementptr %[[VAL_200]]{{\[}}%[[VAL_201]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK:             %[[VAL_208:.*]] = llvm.load %[[VAL_207]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK:             llvm.return %[[VAL_208]] : !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+    // CHECK:           }
     func.func @test_global_offset() -> !sycl_id_1_ {
       %0 = sycl.global_offset : !sycl_id_1_
       return %0 : !sycl_id_1_
@@ -392,52 +380,55 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_num_work_groups() -> !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> {
-    // CHECK-NEXT:        %[[VAL_239:.*]] = llvm.mlir.addressof @__builtin_var_NumWorkgroups__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_240:.*]] = llvm.load %[[VAL_239]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_241:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
-    // CHECK-DAG:         %[[VAL_242:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK-NEXT:        %[[VAL_243:.*]] = llvm.getelementptr %[[VAL_241]][1] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>) -> !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
-    // CHECK-NEXT:        %[[VAL_244:.*]] = llvm.ptrtoint %[[VAL_243]] : !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>> to i64
-    // CHECK-NEXT:        %[[VAL_245:.*]] = llvm.alloca %[[VAL_244]] x !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
-    // CHECK-DAG:         %[[VAL_246:.*]] = llvm.mlir.constant(0 : index) : i64
-    // CHECK-DAG:         %[[VAL_247:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-DAG:         %[[VAL_248:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_249:.*]] = llvm.extractelement %[[VAL_240]]{{\[}}%[[VAL_248]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_250:.*]] = llvm.getelementptr inbounds %[[VAL_245]][0, 0, 0, 0] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>) -> !llvm.ptr<i64>
-    // CHECK-NEXT:        llvm.store %[[VAL_249]], %[[VAL_250]] : !llvm.ptr<i64>
-    // CHECK-DAG:         %[[VAL_251:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK-DAG:         %[[VAL_252:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_253:.*]] = llvm.extractelement %[[VAL_240]]{{\[}}%[[VAL_252]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_254:.*]] = llvm.getelementptr inbounds %[[VAL_245]][0, 0, 0, 1] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>) -> !llvm.ptr<i64>
-    // CHECK-NEXT:        llvm.store %[[VAL_253]], %[[VAL_254]] : !llvm.ptr<i64>
-    // CHECK-NEXT:        %[[VAL_255:.*]] = llvm.load %[[VAL_245]] : !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
-    // CHECK-NEXT:        llvm.return %[[VAL_255]] : !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
-    // CHECK-NEXT:      }
+    // CHECK:             %[[VAL_226:.*]] = llvm.mlir.addressof @__builtin_var_NumWorkgroups__ : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_227:.*]] = llvm.load %[[VAL_226]] : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_228:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK:             %[[VAL_229:.*]] = llvm.mlir.constant(1 : index) : i64
+    // CHECK:             %[[VAL_230:.*]] = llvm.getelementptr %[[VAL_228]]{{\[}}%[[VAL_229]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK:             %[[VAL_231:.*]] = llvm.ptrtoint %[[VAL_230]] : !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>> to i64
+    // CHECK:             %[[VAL_232:.*]] = llvm.alloca %[[VAL_231]] x !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK:             %[[VAL_233:.*]] = llvm.mlir.constant(0 : index) : i64
+    // CHECK:             %[[VAL_234:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_235:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_236:.*]] = llvm.extractelement %[[VAL_227]]{{\[}}%[[VAL_235]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_237:.*]] = llvm.getelementptr inbounds %[[VAL_232]][0, 0, 0, %[[VAL_234]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK:             %[[VAL_238:.*]] = llvm.getelementptr %[[VAL_237]]{{\[}}%[[VAL_233]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK:             llvm.store %[[VAL_236]], %[[VAL_238]] : !llvm.ptr<i64>
+    // CHECK:             %[[VAL_239:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK:             %[[VAL_240:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK:             %[[VAL_241:.*]] = llvm.extractelement %[[VAL_227]]{{\[}}%[[VAL_240]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_242:.*]] = llvm.getelementptr inbounds %[[VAL_232]][0, 0, 0, %[[VAL_239]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK:             %[[VAL_243:.*]] = llvm.getelementptr %[[VAL_242]]{{\[}}%[[VAL_233]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK:             llvm.store %[[VAL_241]], %[[VAL_243]] : !llvm.ptr<i64>
+    // CHECK:             %[[VAL_244:.*]] = llvm.getelementptr %[[VAL_232]]{{\[}}%[[VAL_233]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK:             %[[VAL_245:.*]] = llvm.load %[[VAL_244]] : !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK:             llvm.return %[[VAL_245]] : !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+    // CHECK:           }
     func.func @test_num_work_groups() -> !sycl_range_2_ {
       %0 = sycl.num_work_groups : !sycl_range_2_
       return %0 : !sycl_range_2_
     }
 
     // CHECK-LABEL:     llvm.func @test_num_work_groups_dim(
-    // CHECK-SAME:                                          %[[VAL_256:.*]]: i32) -> i64 {
-    // CHECK-NEXT:        %[[VAL_257:.*]] = llvm.mlir.addressof @__builtin_var_NumWorkgroups__ : !llvm.ptr<vector<3xi64>>
-    // CHECK-NEXT:        %[[VAL_258:.*]] = llvm.load %[[VAL_257]] : !llvm.ptr<vector<3xi64>>
-    // CHECK-DAG:         %[[VAL_259:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_260:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_261:.*]] = llvm.extractelement %[[VAL_258]]{{\[}}%[[VAL_260]] : i32] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_262:.*]] = llvm.mlir.constant(0 : i64) : i64
-    // CHECK-NEXT:        %[[VAL_263:.*]] = llvm.insertelement %[[VAL_261]], %[[VAL_259]]{{\[}}%[[VAL_262]] : i64] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_264:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_265:.*]] = llvm.extractelement %[[VAL_258]]{{\[}}%[[VAL_264]] : i32] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_266:.*]] = llvm.mlir.constant(1 : i64) : i64
-    // CHECK-NEXT:        %[[VAL_267:.*]] = llvm.insertelement %[[VAL_265]], %[[VAL_263]]{{\[}}%[[VAL_266]] : i64] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_268:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK-NEXT:        %[[VAL_269:.*]] = llvm.extractelement %[[VAL_258]]{{\[}}%[[VAL_268]] : i32] : vector<3xi64>
-    // CHECK-DAG:         %[[VAL_270:.*]] = llvm.mlir.constant(2 : i64) : i64
-    // CHECK-NEXT:        %[[VAL_271:.*]] = llvm.insertelement %[[VAL_269]], %[[VAL_267]]{{\[}}%[[VAL_270]] : i64] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_272:.*]] = llvm.extractelement %[[VAL_271]]{{\[}}%[[VAL_256]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        llvm.return %[[VAL_272]] : i64
-    // CHECK-NEXT:      }
+    // CHECK-SAME:                                          %[[VAL_246:.*]]: i32) -> i64 {
+    // CHECK:             %[[VAL_247:.*]] = llvm.mlir.addressof @__builtin_var_NumWorkgroups__ : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_248:.*]] = llvm.load %[[VAL_247]] : !llvm.ptr<vector<3xi64>>
+    // CHECK:             %[[VAL_249:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+    // CHECK:             %[[VAL_250:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK:             %[[VAL_251:.*]] = llvm.extractelement %[[VAL_248]]{{\[}}%[[VAL_250]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_252:.*]] = llvm.mlir.constant(0 : i64) : i64
+    // CHECK:             %[[VAL_253:.*]] = llvm.insertelement %[[VAL_251]], %[[VAL_249]]{{\[}}%[[VAL_252]] : i64] : vector<3xi64>
+    // CHECK:             %[[VAL_254:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK:             %[[VAL_255:.*]] = llvm.extractelement %[[VAL_248]]{{\[}}%[[VAL_254]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_256:.*]] = llvm.mlir.constant(1 : i64) : i64
+    // CHECK:             %[[VAL_257:.*]] = llvm.insertelement %[[VAL_255]], %[[VAL_253]]{{\[}}%[[VAL_256]] : i64] : vector<3xi64>
+    // CHECK:             %[[VAL_258:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK:             %[[VAL_259:.*]] = llvm.extractelement %[[VAL_248]]{{\[}}%[[VAL_258]] : i32] : vector<3xi64>
+    // CHECK:             %[[VAL_260:.*]] = llvm.mlir.constant(2 : i64) : i64
+    // CHECK:             %[[VAL_261:.*]] = llvm.insertelement %[[VAL_259]], %[[VAL_257]]{{\[}}%[[VAL_260]] : i64] : vector<3xi64>
+    // CHECK:             %[[VAL_262:.*]] = llvm.extractelement %[[VAL_261]]{{\[}}%[[VAL_246]] : i32] : vector<3xi64>
+    // CHECK:             llvm.return %[[VAL_262]] : i64
+    // CHECK:           }
     func.func @test_num_work_groups_dim(%i: i32) -> index {
       %0 = sycl.num_work_groups %i : index
       return %0 : index

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm.mlir
@@ -23,23 +23,23 @@ module attributes {gpu.container_module} {
     //CHECK-DAG:      llvm.mlir.global external constant @__builtin_var_GlobalSize__() {addr_space = 0 : i32} : vector<3xi64>
   gpu.module @kernels {
     // CHECK-LABEL:   llvm.func @test_num_work_items() -> !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> {
-    // CHECK:             %[[VAL_0:.*]] = llvm.mlir.addressof @__builtin_var_GlobalSize__ : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_1:.*]] = llvm.load %[[VAL_0]] : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_2:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK:             %[[VAL_3:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK:             %[[VAL_4:.*]] = llvm.getelementptr %[[VAL_2]]{{\[}}%[[VAL_3]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK:             %[[VAL_5:.*]] = llvm.ptrtoint %[[VAL_4]] : !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
-    // CHECK:             %[[VAL_6:.*]] = llvm.alloca %[[VAL_5]] x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_0:.*]] = llvm.mlir.addressof @__builtin_var_GlobalSize__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_1:.*]] = llvm.load %[[VAL_0]] : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_2:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_3:.*]] = llvm.mlir.constant(1 : index) : i64
+    // CHECK-NEXT:        %[[VAL_4:.*]] = llvm.getelementptr %[[VAL_2]]{{\[}}%[[VAL_3]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_5:.*]] = llvm.ptrtoint %[[VAL_4]] : !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
+    // CHECK-NEXT:        %[[VAL_6:.*]] = llvm.alloca %[[VAL_5]] x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
     // CHECK-DAG:         %[[VAL_7:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_8:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_10:.*]] = llvm.extractelement %[[VAL_1]]{{\[}}%[[VAL_9]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_6]][0, 0, 0, %[[VAL_8]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i32) -> !llvm.ptr<i64>
-    // CHECK:             %[[VAL_12:.*]] = llvm.getelementptr %[[VAL_11]]{{\[}}%[[VAL_7]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
-    // CHECK:             llvm.store %[[VAL_10]], %[[VAL_12]] : !llvm.ptr<i64>
-    // CHECK:             %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_6]]{{\[}}%[[VAL_7]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK:             %[[VAL_14:.*]] = llvm.load %[[VAL_13]] : !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK:             llvm.return %[[VAL_14]] : !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+    // CHECK-NEXT:        %[[VAL_10:.*]] = llvm.extractelement %[[VAL_1]]{{\[}}%[[VAL_9]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_6]][0, 0, 0, %[[VAL_8]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_12:.*]] = llvm.getelementptr %[[VAL_11]]{{\[}}%[[VAL_7]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        llvm.store %[[VAL_10]], %[[VAL_12]] : !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_6]]{{\[}}%[[VAL_7]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_14:.*]] = llvm.load %[[VAL_13]] : !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK-NEXT:        llvm.return %[[VAL_14]] : !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
     // CHECK-NEXT:      }
     func.func @test_num_work_items() -> !sycl_range_1_ {
       %0 = sycl.num_work_items : !sycl_range_1_
@@ -48,54 +48,54 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:     llvm.func @test_num_work_items_dim(
     // CHECK-SAME:                                         %[[VAL_15:.*]]: i32) -> i64 {
-    // CHECK:             %[[VAL_16:.*]] = llvm.mlir.addressof @__builtin_var_GlobalSize__ : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_17:.*]] = llvm.load %[[VAL_16]] : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_16:.*]] = llvm.mlir.addressof @__builtin_var_GlobalSize__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_17:.*]] = llvm.load %[[VAL_16]] : !llvm.ptr<vector<3xi64>>
     // CHECK-DAG:         %[[VAL_18:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
     // CHECK-DAG:         %[[VAL_19:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_20:.*]] = llvm.extractelement %[[VAL_17]]{{\[}}%[[VAL_19]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_21:.*]] = llvm.mlir.constant(0 : i64) : i64
-    // CHECK:             %[[VAL_22:.*]] = llvm.insertelement %[[VAL_20]], %[[VAL_18]]{{\[}}%[[VAL_21]] : i64] : vector<3xi64>
-    // CHECK:             %[[VAL_23:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK:             %[[VAL_24:.*]] = llvm.extractelement %[[VAL_17]]{{\[}}%[[VAL_23]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_25:.*]] = llvm.mlir.constant(1 : i64) : i64
-    // CHECK:             %[[VAL_26:.*]] = llvm.insertelement %[[VAL_24]], %[[VAL_22]]{{\[}}%[[VAL_25]] : i64] : vector<3xi64>
-    // CHECK:             %[[VAL_27:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK:             %[[VAL_28:.*]] = llvm.extractelement %[[VAL_17]]{{\[}}%[[VAL_27]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_29:.*]] = llvm.mlir.constant(2 : i64) : i64
-    // CHECK:             %[[VAL_30:.*]] = llvm.insertelement %[[VAL_28]], %[[VAL_26]]{{\[}}%[[VAL_29]] : i64] : vector<3xi64>
-    // CHECK:             %[[VAL_31:.*]] = llvm.extractelement %[[VAL_30]]{{\[}}%[[VAL_15]] : i32] : vector<3xi64>
-    // CHECK:             llvm.return %[[VAL_31]] : i64
-    // CHECK:           }
+    // CHECK-NEXT:        %[[VAL_20:.*]] = llvm.extractelement %[[VAL_17]]{{\[}}%[[VAL_19]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_21:.*]] = llvm.mlir.constant(0 : i64) : i64
+    // CHECK-NEXT:        %[[VAL_22:.*]] = llvm.insertelement %[[VAL_20]], %[[VAL_18]]{{\[}}%[[VAL_21]] : i64] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_23:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-NEXT:        %[[VAL_24:.*]] = llvm.extractelement %[[VAL_17]]{{\[}}%[[VAL_23]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_25:.*]] = llvm.mlir.constant(1 : i64) : i64
+    // CHECK-NEXT:        %[[VAL_26:.*]] = llvm.insertelement %[[VAL_24]], %[[VAL_22]]{{\[}}%[[VAL_25]] : i64] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_27:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK-NEXT:        %[[VAL_28:.*]] = llvm.extractelement %[[VAL_17]]{{\[}}%[[VAL_27]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_29:.*]] = llvm.mlir.constant(2 : i64) : i64
+    // CHECK-NEXT:        %[[VAL_30:.*]] = llvm.insertelement %[[VAL_28]], %[[VAL_26]]{{\[}}%[[VAL_29]] : i64] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_31:.*]] = llvm.extractelement %[[VAL_30]]{{\[}}%[[VAL_15]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        llvm.return %[[VAL_31]] : i64
+    // CHECK-NEXT:      }
     func.func @test_num_work_items_dim(%i: i32) -> index {
       %0 = sycl.num_work_items %i : index
       return %0 : index
     }
 
     // CHECK-LABEL:     llvm.func @test_global_id() -> !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> {
-    // CHECK:             %[[VAL_32:.*]] = llvm.mlir.addressof @__builtin_var_GlobalInvocationId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_33:.*]] = llvm.load %[[VAL_32]] : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_34:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
-    // CHECK:             %[[VAL_35:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK:             %[[VAL_36:.*]] = llvm.getelementptr %[[VAL_34]]{{\[}}%[[VAL_35]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
-    // CHECK:             %[[VAL_37:.*]] = llvm.ptrtoint %[[VAL_36]] : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>> to i64
-    // CHECK:             %[[VAL_38:.*]] = llvm.alloca %[[VAL_37]] x !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_32:.*]] = llvm.mlir.addressof @__builtin_var_GlobalInvocationId__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_33:.*]] = llvm.load %[[VAL_32]] : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_34:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_35:.*]] = llvm.mlir.constant(1 : index) : i64
+    // CHECK-NEXT:        %[[VAL_36:.*]] = llvm.getelementptr %[[VAL_34]]{{\[}}%[[VAL_35]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_37:.*]] = llvm.ptrtoint %[[VAL_36]] : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>> to i64
+    // CHECK-NEXT:        %[[VAL_38:.*]] = llvm.alloca %[[VAL_37]] x !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
     // CHECK-DAG:         %[[VAL_39:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_40:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_41:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_42:.*]] = llvm.extractelement %[[VAL_33]]{{\[}}%[[VAL_41]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_43:.*]] = llvm.getelementptr inbounds %[[VAL_38]][0, 0, 0, %[[VAL_40]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
-    // CHECK:             %[[VAL_44:.*]] = llvm.getelementptr %[[VAL_43]]{{\[}}%[[VAL_39]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
-    // CHECK:             llvm.store %[[VAL_42]], %[[VAL_44]] : !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_42:.*]] = llvm.extractelement %[[VAL_33]]{{\[}}%[[VAL_41]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_43:.*]] = llvm.getelementptr inbounds %[[VAL_38]][0, 0, 0, %[[VAL_40]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_44:.*]] = llvm.getelementptr %[[VAL_43]]{{\[}}%[[VAL_39]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        llvm.store %[[VAL_42]], %[[VAL_44]] : !llvm.ptr<i64>
     // CHECK-DAG:         %[[VAL_45:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-DAG:         %[[VAL_46:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK:             %[[VAL_47:.*]] = llvm.extractelement %[[VAL_33]]{{\[}}%[[VAL_46]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_48:.*]] = llvm.getelementptr inbounds %[[VAL_38]][0, 0, 0, %[[VAL_45]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
-    // CHECK:             %[[VAL_49:.*]] = llvm.getelementptr %[[VAL_48]]{{\[}}%[[VAL_39]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
-    // CHECK:             llvm.store %[[VAL_47]], %[[VAL_49]] : !llvm.ptr<i64>
-    // CHECK:             %[[VAL_50:.*]] = llvm.getelementptr %[[VAL_38]]{{\[}}%[[VAL_39]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
-    // CHECK:             %[[VAL_51:.*]] = llvm.load %[[VAL_50]] : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
-    // CHECK:             llvm.return %[[VAL_51]] : !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
-    // CHECK:           }
+    // CHECK-NEXT:        %[[VAL_47:.*]] = llvm.extractelement %[[VAL_33]]{{\[}}%[[VAL_46]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_48:.*]] = llvm.getelementptr inbounds %[[VAL_38]][0, 0, 0, %[[VAL_45]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_49:.*]] = llvm.getelementptr %[[VAL_48]]{{\[}}%[[VAL_39]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        llvm.store %[[VAL_47]], %[[VAL_49]] : !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_50:.*]] = llvm.getelementptr %[[VAL_38]]{{\[}}%[[VAL_39]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_51:.*]] = llvm.load %[[VAL_50]] : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK-NEXT:        llvm.return %[[VAL_51]] : !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+    // CHECK-NEXT:      }
     func.func @test_global_id() -> !sycl_id_2_ {
       %0 = sycl.global_id : !sycl_id_2_
       return %0 : !sycl_id_2_
@@ -103,60 +103,60 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:     llvm.func @test_global_id_dim(
     // CHECK-SAME:                                    %[[VAL_52:.*]]: i32) -> i64 {
-    // CHECK:             %[[VAL_53:.*]] = llvm.mlir.addressof @__builtin_var_GlobalInvocationId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_54:.*]] = llvm.load %[[VAL_53]] : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_53:.*]] = llvm.mlir.addressof @__builtin_var_GlobalInvocationId__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_54:.*]] = llvm.load %[[VAL_53]] : !llvm.ptr<vector<3xi64>>
     // CHECK-DAG:         %[[VAL_55:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
     // CHECK-DAG:         %[[VAL_56:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_57:.*]] = llvm.extractelement %[[VAL_54]]{{\[}}%[[VAL_56]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_58:.*]] = llvm.mlir.constant(0 : i64) : i64
-    // CHECK:             %[[VAL_59:.*]] = llvm.insertelement %[[VAL_57]], %[[VAL_55]]{{\[}}%[[VAL_58]] : i64] : vector<3xi64>
-    // CHECK:             %[[VAL_60:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK:             %[[VAL_61:.*]] = llvm.extractelement %[[VAL_54]]{{\[}}%[[VAL_60]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_62:.*]] = llvm.mlir.constant(1 : i64) : i64
-    // CHECK:             %[[VAL_63:.*]] = llvm.insertelement %[[VAL_61]], %[[VAL_59]]{{\[}}%[[VAL_62]] : i64] : vector<3xi64>
-    // CHECK:             %[[VAL_64:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK:             %[[VAL_65:.*]] = llvm.extractelement %[[VAL_54]]{{\[}}%[[VAL_64]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_66:.*]] = llvm.mlir.constant(2 : i64) : i64
-    // CHECK:             %[[VAL_67:.*]] = llvm.insertelement %[[VAL_65]], %[[VAL_63]]{{\[}}%[[VAL_66]] : i64] : vector<3xi64>
-    // CHECK:             %[[VAL_68:.*]] = llvm.extractelement %[[VAL_67]]{{\[}}%[[VAL_52]] : i32] : vector<3xi64>
-    // CHECK:             llvm.return %[[VAL_68]] : i64
-    // CHECK:           }
+    // CHECK-NEXT:        %[[VAL_57:.*]] = llvm.extractelement %[[VAL_54]]{{\[}}%[[VAL_56]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_58:.*]] = llvm.mlir.constant(0 : i64) : i64
+    // CHECK-NEXT:        %[[VAL_59:.*]] = llvm.insertelement %[[VAL_57]], %[[VAL_55]]{{\[}}%[[VAL_58]] : i64] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_60:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-NEXT:        %[[VAL_61:.*]] = llvm.extractelement %[[VAL_54]]{{\[}}%[[VAL_60]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_62:.*]] = llvm.mlir.constant(1 : i64) : i64
+    // CHECK-NEXT:        %[[VAL_63:.*]] = llvm.insertelement %[[VAL_61]], %[[VAL_59]]{{\[}}%[[VAL_62]] : i64] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_64:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK-NEXT:        %[[VAL_65:.*]] = llvm.extractelement %[[VAL_54]]{{\[}}%[[VAL_64]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_66:.*]] = llvm.mlir.constant(2 : i64) : i64
+    // CHECK-NEXT:        %[[VAL_67:.*]] = llvm.insertelement %[[VAL_65]], %[[VAL_63]]{{\[}}%[[VAL_66]] : i64] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_68:.*]] = llvm.extractelement %[[VAL_67]]{{\[}}%[[VAL_52]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        llvm.return %[[VAL_68]] : i64
+    // CHECK-NEXT:      }
     func.func @test_global_id_dim(%i: i32) -> index {
       %0 = sycl.global_id %i : index
       return %0 : index
     }
 
     // CHECK-LABEL:     llvm.func @test_local_id() -> !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> {
-    // CHECK:             %[[VAL_69:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_70:.*]] = llvm.load %[[VAL_69]] : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_71:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-    // CHECK:             %[[VAL_72:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK:             %[[VAL_73:.*]] = llvm.getelementptr %[[VAL_71]]{{\[}}%[[VAL_72]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-    // CHECK:             %[[VAL_74:.*]] = llvm.ptrtoint %[[VAL_73]] : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>> to i64
-    // CHECK:             %[[VAL_75:.*]] = llvm.alloca %[[VAL_74]] x !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_69:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_70:.*]] = llvm.load %[[VAL_69]] : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_71:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_72:.*]] = llvm.mlir.constant(1 : index) : i64
+    // CHECK-NEXT:        %[[VAL_73:.*]] = llvm.getelementptr %[[VAL_71]]{{\[}}%[[VAL_72]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_74:.*]] = llvm.ptrtoint %[[VAL_73]] : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>> to i64
+    // CHECK-NEXT:        %[[VAL_75:.*]] = llvm.alloca %[[VAL_74]] x !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
     // CHECK-DAG:         %[[VAL_76:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_77:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_78:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_79:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_78]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_80:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_77]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
-    // CHECK:             %[[VAL_81:.*]] = llvm.getelementptr %[[VAL_80]]{{\[}}%[[VAL_76]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
-    // CHECK:             llvm.store %[[VAL_79]], %[[VAL_81]] : !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_79:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_78]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_80:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_77]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_81:.*]] = llvm.getelementptr %[[VAL_80]]{{\[}}%[[VAL_76]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        llvm.store %[[VAL_79]], %[[VAL_81]] : !llvm.ptr<i64>
     // CHECK-DAG:         %[[VAL_82:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-DAG:         %[[VAL_83:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK:             %[[VAL_84:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_83]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_85:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_82]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
-    // CHECK:             %[[VAL_86:.*]] = llvm.getelementptr %[[VAL_85]]{{\[}}%[[VAL_76]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
-    // CHECK:             llvm.store %[[VAL_84]], %[[VAL_86]] : !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_84:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_83]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_85:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_82]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_86:.*]] = llvm.getelementptr %[[VAL_85]]{{\[}}%[[VAL_76]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        llvm.store %[[VAL_84]], %[[VAL_86]] : !llvm.ptr<i64>
     // CHECK-DAG:         %[[VAL_87:.*]] = llvm.mlir.constant(2 : i32) : i32
     // CHECK-DAG:         %[[VAL_88:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK:             %[[VAL_89:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_88]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_90:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_87]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
-    // CHECK:             %[[VAL_91:.*]] = llvm.getelementptr %[[VAL_90]]{{\[}}%[[VAL_76]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
-    // CHECK:             llvm.store %[[VAL_89]], %[[VAL_91]] : !llvm.ptr<i64>
-    // CHECK:             %[[VAL_92:.*]] = llvm.getelementptr %[[VAL_75]]{{\[}}%[[VAL_76]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-    // CHECK:             %[[VAL_93:.*]] = llvm.load %[[VAL_92]] : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-    // CHECK:             llvm.return %[[VAL_93]] : !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-    // CHECK:           }
+    // CHECK-NEXT:        %[[VAL_89:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_88]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_90:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_87]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_91:.*]] = llvm.getelementptr %[[VAL_90]]{{\[}}%[[VAL_76]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        llvm.store %[[VAL_89]], %[[VAL_91]] : !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_92:.*]] = llvm.getelementptr %[[VAL_75]]{{\[}}%[[VAL_76]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_93:.*]] = llvm.load %[[VAL_92]] : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK-NEXT:        llvm.return %[[VAL_93]] : !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+    // CHECK-NEXT:      }
     func.func @test_local_id() -> !sycl_id_3_ {
       %0 = sycl.local_id : !sycl_id_3_
       return %0 : !sycl_id_3_
@@ -164,60 +164,60 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:     llvm.func @test_local_id_dim(
     // CHECK-SAME:                                   %[[VAL_94:.*]]: i32) -> i64 {
-    // CHECK:             %[[VAL_95:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_96:.*]] = llvm.load %[[VAL_95]] : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_95:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_96:.*]] = llvm.load %[[VAL_95]] : !llvm.ptr<vector<3xi64>>
     // CHECK-DAG:         %[[VAL_97:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
     // CHECK-DAG:         %[[VAL_98:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_99:.*]] = llvm.extractelement %[[VAL_96]]{{\[}}%[[VAL_98]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_100:.*]] = llvm.mlir.constant(0 : i64) : i64
-    // CHECK:             %[[VAL_101:.*]] = llvm.insertelement %[[VAL_99]], %[[VAL_97]]{{\[}}%[[VAL_100]] : i64] : vector<3xi64>
-    // CHECK:             %[[VAL_102:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK:             %[[VAL_103:.*]] = llvm.extractelement %[[VAL_96]]{{\[}}%[[VAL_102]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_104:.*]] = llvm.mlir.constant(1 : i64) : i64
-    // CHECK:             %[[VAL_105:.*]] = llvm.insertelement %[[VAL_103]], %[[VAL_101]]{{\[}}%[[VAL_104]] : i64] : vector<3xi64>
-    // CHECK:             %[[VAL_106:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK:             %[[VAL_107:.*]] = llvm.extractelement %[[VAL_96]]{{\[}}%[[VAL_106]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_108:.*]] = llvm.mlir.constant(2 : i64) : i64
-    // CHECK:             %[[VAL_109:.*]] = llvm.insertelement %[[VAL_107]], %[[VAL_105]]{{\[}}%[[VAL_108]] : i64] : vector<3xi64>
-    // CHECK:             %[[VAL_110:.*]] = llvm.extractelement %[[VAL_109]]{{\[}}%[[VAL_94]] : i32] : vector<3xi64>
-    // CHECK:             llvm.return %[[VAL_110]] : i64
-    // CHECK:           }
+    // CHECK-NEXT:        %[[VAL_99:.*]] = llvm.extractelement %[[VAL_96]]{{\[}}%[[VAL_98]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_100:.*]] = llvm.mlir.constant(0 : i64) : i64
+    // CHECK-NEXT:        %[[VAL_101:.*]] = llvm.insertelement %[[VAL_99]], %[[VAL_97]]{{\[}}%[[VAL_100]] : i64] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_102:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-NEXT:        %[[VAL_103:.*]] = llvm.extractelement %[[VAL_96]]{{\[}}%[[VAL_102]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_104:.*]] = llvm.mlir.constant(1 : i64) : i64
+    // CHECK-NEXT:        %[[VAL_105:.*]] = llvm.insertelement %[[VAL_103]], %[[VAL_101]]{{\[}}%[[VAL_104]] : i64] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_106:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK-NEXT:        %[[VAL_107:.*]] = llvm.extractelement %[[VAL_96]]{{\[}}%[[VAL_106]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_108:.*]] = llvm.mlir.constant(2 : i64) : i64
+    // CHECK-NEXT:        %[[VAL_109:.*]] = llvm.insertelement %[[VAL_107]], %[[VAL_105]]{{\[}}%[[VAL_108]] : i64] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_110:.*]] = llvm.extractelement %[[VAL_109]]{{\[}}%[[VAL_94]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        llvm.return %[[VAL_110]] : i64
+    // CHECK-NEXT:      }
     func.func @test_local_id_dim(%i: i32) -> index {
       %0 = sycl.local_id %i : index
       return %0 : index
     }
 
     // CHECK-LABEL:     llvm.func @test_work_group_size() -> !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> {
-    // CHECK:             %[[VAL_111:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupSize__ : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_112:.*]] = llvm.load %[[VAL_111]] : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_113:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-    // CHECK:             %[[VAL_114:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK:             %[[VAL_115:.*]] = llvm.getelementptr %[[VAL_113]]{{\[}}%[[VAL_114]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-    // CHECK:             %[[VAL_116:.*]] = llvm.ptrtoint %[[VAL_115]] : !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>> to i64
-    // CHECK:             %[[VAL_117:.*]] = llvm.alloca %[[VAL_116]] x !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_111:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupSize__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_112:.*]] = llvm.load %[[VAL_111]] : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_113:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_114:.*]] = llvm.mlir.constant(1 : index) : i64
+    // CHECK-NEXT:        %[[VAL_115:.*]] = llvm.getelementptr %[[VAL_113]]{{\[}}%[[VAL_114]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_116:.*]] = llvm.ptrtoint %[[VAL_115]] : !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>> to i64
+    // CHECK-NEXT:        %[[VAL_117:.*]] = llvm.alloca %[[VAL_116]] x !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
     // CHECK-DAG:         %[[VAL_118:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_119:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_120:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_121:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_120]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_122:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_119]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
-    // CHECK:             %[[VAL_123:.*]] = llvm.getelementptr %[[VAL_122]]{{\[}}%[[VAL_118]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
-    // CHECK:             llvm.store %[[VAL_121]], %[[VAL_123]] : !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_121:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_120]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_122:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_119]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_123:.*]] = llvm.getelementptr %[[VAL_122]]{{\[}}%[[VAL_118]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        llvm.store %[[VAL_121]], %[[VAL_123]] : !llvm.ptr<i64>
     // CHECK-DAG:         %[[VAL_124:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-DAG:         %[[VAL_125:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK:             %[[VAL_126:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_125]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_127:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_124]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
-    // CHECK:             %[[VAL_128:.*]] = llvm.getelementptr %[[VAL_127]]{{\[}}%[[VAL_118]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
-    // CHECK:             llvm.store %[[VAL_126]], %[[VAL_128]] : !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_126:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_125]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_127:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_124]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_128:.*]] = llvm.getelementptr %[[VAL_127]]{{\[}}%[[VAL_118]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        llvm.store %[[VAL_126]], %[[VAL_128]] : !llvm.ptr<i64>
     // CHECK-DAG:         %[[VAL_129:.*]] = llvm.mlir.constant(2 : i32) : i32
     // CHECK-DAG:         %[[VAL_130:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK:             %[[VAL_131:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_130]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_132:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_129]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
-    // CHECK:             %[[VAL_133:.*]] = llvm.getelementptr %[[VAL_132]]{{\[}}%[[VAL_118]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
-    // CHECK:             llvm.store %[[VAL_131]], %[[VAL_133]] : !llvm.ptr<i64>
-    // CHECK:             %[[VAL_134:.*]] = llvm.getelementptr %[[VAL_117]]{{\[}}%[[VAL_118]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-    // CHECK:             %[[VAL_135:.*]] = llvm.load %[[VAL_134]] : !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
-    // CHECK:             llvm.return %[[VAL_135]] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
-    // CHECK:           }
+    // CHECK-NEXT:        %[[VAL_131:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_130]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_132:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_129]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_133:.*]] = llvm.getelementptr %[[VAL_132]]{{\[}}%[[VAL_118]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        llvm.store %[[VAL_131]], %[[VAL_133]] : !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_134:.*]] = llvm.getelementptr %[[VAL_117]]{{\[}}%[[VAL_118]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_135:.*]] = llvm.load %[[VAL_134]] : !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+    // CHECK-NEXT:        llvm.return %[[VAL_135]] : !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+    // CHECK-NEXT:      }
     func.func @test_work_group_size() -> !sycl_range_3_ {
       %0 = sycl.work_group_size : !sycl_range_3_
       return %0 : !sycl_range_3_
@@ -225,48 +225,48 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:     llvm.func @test_work_group_size_dim(
     // CHECK-SAME:                                          %[[VAL_136:.*]]: i32) -> i64 {
-    // CHECK:             %[[VAL_137:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupSize__ : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_138:.*]] = llvm.load %[[VAL_137]] : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_137:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupSize__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_138:.*]] = llvm.load %[[VAL_137]] : !llvm.ptr<vector<3xi64>>
     // CHECK-DAG:         %[[VAL_139:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
     // CHECK-DAG:         %[[VAL_140:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_141:.*]] = llvm.extractelement %[[VAL_138]]{{\[}}%[[VAL_140]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_142:.*]] = llvm.mlir.constant(0 : i64) : i64
-    // CHECK:             %[[VAL_143:.*]] = llvm.insertelement %[[VAL_141]], %[[VAL_139]]{{\[}}%[[VAL_142]] : i64] : vector<3xi64>
-    // CHECK:             %[[VAL_144:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK:             %[[VAL_145:.*]] = llvm.extractelement %[[VAL_138]]{{\[}}%[[VAL_144]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_146:.*]] = llvm.mlir.constant(1 : i64) : i64
-    // CHECK:             %[[VAL_147:.*]] = llvm.insertelement %[[VAL_145]], %[[VAL_143]]{{\[}}%[[VAL_146]] : i64] : vector<3xi64>
-    // CHECK:             %[[VAL_148:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK:             %[[VAL_149:.*]] = llvm.extractelement %[[VAL_138]]{{\[}}%[[VAL_148]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_150:.*]] = llvm.mlir.constant(2 : i64) : i64
-    // CHECK:             %[[VAL_151:.*]] = llvm.insertelement %[[VAL_149]], %[[VAL_147]]{{\[}}%[[VAL_150]] : i64] : vector<3xi64>
-    // CHECK:             %[[VAL_152:.*]] = llvm.extractelement %[[VAL_151]]{{\[}}%[[VAL_136]] : i32] : vector<3xi64>
-    // CHECK:             llvm.return %[[VAL_152]] : i64
-    // CHECK:           }
+    // CHECK-NEXT:        %[[VAL_141:.*]] = llvm.extractelement %[[VAL_138]]{{\[}}%[[VAL_140]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_142:.*]] = llvm.mlir.constant(0 : i64) : i64
+    // CHECK-NEXT:        %[[VAL_143:.*]] = llvm.insertelement %[[VAL_141]], %[[VAL_139]]{{\[}}%[[VAL_142]] : i64] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_144:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-NEXT:        %[[VAL_145:.*]] = llvm.extractelement %[[VAL_138]]{{\[}}%[[VAL_144]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_146:.*]] = llvm.mlir.constant(1 : i64) : i64
+    // CHECK-NEXT:        %[[VAL_147:.*]] = llvm.insertelement %[[VAL_145]], %[[VAL_143]]{{\[}}%[[VAL_146]] : i64] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_148:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK-NEXT:        %[[VAL_149:.*]] = llvm.extractelement %[[VAL_138]]{{\[}}%[[VAL_148]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_150:.*]] = llvm.mlir.constant(2 : i64) : i64
+    // CHECK-NEXT:        %[[VAL_151:.*]] = llvm.insertelement %[[VAL_149]], %[[VAL_147]]{{\[}}%[[VAL_150]] : i64] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_152:.*]] = llvm.extractelement %[[VAL_151]]{{\[}}%[[VAL_136]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        llvm.return %[[VAL_152]] : i64
+    // CHECK-NEXT:      }
     func.func @test_work_group_size_dim(%i: i32) -> index {
       %0 = sycl.work_group_size %i : index
       return %0 : index
     }
 
     // CHECK-LABEL:     llvm.func @test_work_group_id() -> !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> {
-    // CHECK:             %[[VAL_153:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_154:.*]] = llvm.load %[[VAL_153]] : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_155:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK:             %[[VAL_156:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK:             %[[VAL_157:.*]] = llvm.getelementptr %[[VAL_155]]{{\[}}%[[VAL_156]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK:             %[[VAL_158:.*]] = llvm.ptrtoint %[[VAL_157]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
-    // CHECK:             %[[VAL_159:.*]] = llvm.alloca %[[VAL_158]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_153:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupId__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_154:.*]] = llvm.load %[[VAL_153]] : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_155:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_156:.*]] = llvm.mlir.constant(1 : index) : i64
+    // CHECK-NEXT:        %[[VAL_157:.*]] = llvm.getelementptr %[[VAL_155]]{{\[}}%[[VAL_156]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_158:.*]] = llvm.ptrtoint %[[VAL_157]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
+    // CHECK-NEXT:        %[[VAL_159:.*]] = llvm.alloca %[[VAL_158]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
     // CHECK-DAG:         %[[VAL_160:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_161:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_162:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_163:.*]] = llvm.extractelement %[[VAL_154]]{{\[}}%[[VAL_162]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_164:.*]] = llvm.getelementptr inbounds %[[VAL_159]][0, 0, 0, %[[VAL_161]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i32) -> !llvm.ptr<i64>
-    // CHECK:             %[[VAL_165:.*]] = llvm.getelementptr %[[VAL_164]]{{\[}}%[[VAL_160]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
-    // CHECK:             llvm.store %[[VAL_163]], %[[VAL_165]] : !llvm.ptr<i64>
-    // CHECK:             %[[VAL_166:.*]] = llvm.getelementptr %[[VAL_159]]{{\[}}%[[VAL_160]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK:             %[[VAL_167:.*]] = llvm.load %[[VAL_166]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK:             llvm.return %[[VAL_167]] : !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
-    // CHECK:           }
+    // CHECK-NEXT:        %[[VAL_163:.*]] = llvm.extractelement %[[VAL_154]]{{\[}}%[[VAL_162]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_164:.*]] = llvm.getelementptr inbounds %[[VAL_159]][0, 0, 0, %[[VAL_161]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_165:.*]] = llvm.getelementptr %[[VAL_164]]{{\[}}%[[VAL_160]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        llvm.store %[[VAL_163]], %[[VAL_165]] : !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_166:.*]] = llvm.getelementptr %[[VAL_159]]{{\[}}%[[VAL_160]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_167:.*]] = llvm.load %[[VAL_166]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK-NEXT:        llvm.return %[[VAL_167]] : !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+    // CHECK-NEXT:      }
     func.func @test_work_group_id() -> !sycl_id_1_ {
       %0 = sycl.work_group_id : !sycl_id_1_
       return %0 : !sycl_id_1_
@@ -274,24 +274,24 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:     llvm.func @test_work_group_id_dim(
     // CHECK-SAME:                                        %[[VAL_168:.*]]: i32) -> i64 {
-    // CHECK:             %[[VAL_169:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupId__ : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_170:.*]] = llvm.load %[[VAL_169]] : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_169:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupId__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_170:.*]] = llvm.load %[[VAL_169]] : !llvm.ptr<vector<3xi64>>
     // CHECK-DAG:         %[[VAL_171:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
     // CHECK-DAG:         %[[VAL_172:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_173:.*]] = llvm.extractelement %[[VAL_170]]{{\[}}%[[VAL_172]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_174:.*]] = llvm.mlir.constant(0 : i64) : i64
-    // CHECK:             %[[VAL_175:.*]] = llvm.insertelement %[[VAL_173]], %[[VAL_171]]{{\[}}%[[VAL_174]] : i64] : vector<3xi64>
-    // CHECK:             %[[VAL_176:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK:             %[[VAL_177:.*]] = llvm.extractelement %[[VAL_170]]{{\[}}%[[VAL_176]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_178:.*]] = llvm.mlir.constant(1 : i64) : i64
-    // CHECK:             %[[VAL_179:.*]] = llvm.insertelement %[[VAL_177]], %[[VAL_175]]{{\[}}%[[VAL_178]] : i64] : vector<3xi64>
-    // CHECK:             %[[VAL_180:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK:             %[[VAL_181:.*]] = llvm.extractelement %[[VAL_170]]{{\[}}%[[VAL_180]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_182:.*]] = llvm.mlir.constant(2 : i64) : i64
-    // CHECK:             %[[VAL_183:.*]] = llvm.insertelement %[[VAL_181]], %[[VAL_179]]{{\[}}%[[VAL_182]] : i64] : vector<3xi64>
-    // CHECK:             %[[VAL_184:.*]] = llvm.extractelement %[[VAL_183]]{{\[}}%[[VAL_168]] : i32] : vector<3xi64>
-    // CHECK:             llvm.return %[[VAL_184]] : i64
-    // CHECK:           }
+    // CHECK-NEXT:        %[[VAL_173:.*]] = llvm.extractelement %[[VAL_170]]{{\[}}%[[VAL_172]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_174:.*]] = llvm.mlir.constant(0 : i64) : i64
+    // CHECK-NEXT:        %[[VAL_175:.*]] = llvm.insertelement %[[VAL_173]], %[[VAL_171]]{{\[}}%[[VAL_174]] : i64] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_176:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-NEXT:        %[[VAL_177:.*]] = llvm.extractelement %[[VAL_170]]{{\[}}%[[VAL_176]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_178:.*]] = llvm.mlir.constant(1 : i64) : i64
+    // CHECK-NEXT:        %[[VAL_179:.*]] = llvm.insertelement %[[VAL_177]], %[[VAL_175]]{{\[}}%[[VAL_178]] : i64] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_180:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK-NEXT:        %[[VAL_181:.*]] = llvm.extractelement %[[VAL_170]]{{\[}}%[[VAL_180]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_182:.*]] = llvm.mlir.constant(2 : i64) : i64
+    // CHECK-NEXT:        %[[VAL_183:.*]] = llvm.insertelement %[[VAL_181]], %[[VAL_179]]{{\[}}%[[VAL_182]] : i64] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_184:.*]] = llvm.extractelement %[[VAL_183]]{{\[}}%[[VAL_168]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        llvm.return %[[VAL_184]] : i64
+    // CHECK-NEXT:      }
     func.func @test_work_group_id_dim(%i: i32) -> index {
       %0 = sycl.work_group_id %i : index
       return %0 : index
@@ -331,24 +331,24 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_global_offset() -> !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> {
-    // CHECK:             %[[VAL_194:.*]] = llvm.mlir.addressof @__builtin_var_GlobalOffset__ : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_195:.*]] = llvm.load %[[VAL_194]] : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_196:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK:             %[[VAL_197:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK:             %[[VAL_198:.*]] = llvm.getelementptr %[[VAL_196]]{{\[}}%[[VAL_197]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK:             %[[VAL_199:.*]] = llvm.ptrtoint %[[VAL_198]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
-    // CHECK:             %[[VAL_200:.*]] = llvm.alloca %[[VAL_199]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_194:.*]] = llvm.mlir.addressof @__builtin_var_GlobalOffset__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_195:.*]] = llvm.load %[[VAL_194]] : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_196:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_197:.*]] = llvm.mlir.constant(1 : index) : i64
+    // CHECK-NEXT:        %[[VAL_198:.*]] = llvm.getelementptr %[[VAL_196]]{{\[}}%[[VAL_197]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_199:.*]] = llvm.ptrtoint %[[VAL_198]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
+    // CHECK-NEXT:        %[[VAL_200:.*]] = llvm.alloca %[[VAL_199]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
     // CHECK-DAG:         %[[VAL_201:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_202:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_203:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_204:.*]] = llvm.extractelement %[[VAL_195]]{{\[}}%[[VAL_203]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_205:.*]] = llvm.getelementptr inbounds %[[VAL_200]][0, 0, 0, %[[VAL_202]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i32) -> !llvm.ptr<i64>
-    // CHECK:             %[[VAL_206:.*]] = llvm.getelementptr %[[VAL_205]]{{\[}}%[[VAL_201]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
-    // CHECK:             llvm.store %[[VAL_204]], %[[VAL_206]] : !llvm.ptr<i64>
-    // CHECK:             %[[VAL_207:.*]] = llvm.getelementptr %[[VAL_200]]{{\[}}%[[VAL_201]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK:             %[[VAL_208:.*]] = llvm.load %[[VAL_207]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
-    // CHECK:             llvm.return %[[VAL_208]] : !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
-    // CHECK:           }
+    // CHECK-NEXT:        %[[VAL_204:.*]] = llvm.extractelement %[[VAL_195]]{{\[}}%[[VAL_203]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_205:.*]] = llvm.getelementptr inbounds %[[VAL_200]][0, 0, 0, %[[VAL_202]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_206:.*]] = llvm.getelementptr %[[VAL_205]]{{\[}}%[[VAL_201]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        llvm.store %[[VAL_204]], %[[VAL_206]] : !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_207:.*]] = llvm.getelementptr %[[VAL_200]]{{\[}}%[[VAL_201]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_208:.*]] = llvm.load %[[VAL_207]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+    // CHECK-NEXT:        llvm.return %[[VAL_208]] : !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+    // CHECK-NEXT:      }
     func.func @test_global_offset() -> !sycl_id_1_ {
       %0 = sycl.global_offset : !sycl_id_1_
       return %0 : !sycl_id_1_
@@ -380,30 +380,30 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_num_work_groups() -> !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> {
-    // CHECK:             %[[VAL_226:.*]] = llvm.mlir.addressof @__builtin_var_NumWorkgroups__ : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_227:.*]] = llvm.load %[[VAL_226]] : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_228:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
-    // CHECK:             %[[VAL_229:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK:             %[[VAL_230:.*]] = llvm.getelementptr %[[VAL_228]]{{\[}}%[[VAL_229]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
-    // CHECK:             %[[VAL_231:.*]] = llvm.ptrtoint %[[VAL_230]] : !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>> to i64
-    // CHECK:             %[[VAL_232:.*]] = llvm.alloca %[[VAL_231]] x !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_226:.*]] = llvm.mlir.addressof @__builtin_var_NumWorkgroups__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_227:.*]] = llvm.load %[[VAL_226]] : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_228:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_229:.*]] = llvm.mlir.constant(1 : index) : i64
+    // CHECK-NEXT:        %[[VAL_230:.*]] = llvm.getelementptr %[[VAL_228]]{{\[}}%[[VAL_229]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_231:.*]] = llvm.ptrtoint %[[VAL_230]] : !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>> to i64
+    // CHECK-NEXT:        %[[VAL_232:.*]] = llvm.alloca %[[VAL_231]] x !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
     // CHECK-DAG:         %[[VAL_233:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_234:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_235:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_236:.*]] = llvm.extractelement %[[VAL_227]]{{\[}}%[[VAL_235]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_237:.*]] = llvm.getelementptr inbounds %[[VAL_232]][0, 0, 0, %[[VAL_234]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
-    // CHECK:             %[[VAL_238:.*]] = llvm.getelementptr %[[VAL_237]]{{\[}}%[[VAL_233]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
-    // CHECK:             llvm.store %[[VAL_236]], %[[VAL_238]] : !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_236:.*]] = llvm.extractelement %[[VAL_227]]{{\[}}%[[VAL_235]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_237:.*]] = llvm.getelementptr inbounds %[[VAL_232]][0, 0, 0, %[[VAL_234]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_238:.*]] = llvm.getelementptr %[[VAL_237]]{{\[}}%[[VAL_233]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        llvm.store %[[VAL_236]], %[[VAL_238]] : !llvm.ptr<i64>
     // CHECK-DAG:         %[[VAL_239:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-DAG:         %[[VAL_240:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK:             %[[VAL_241:.*]] = llvm.extractelement %[[VAL_227]]{{\[}}%[[VAL_240]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_242:.*]] = llvm.getelementptr inbounds %[[VAL_232]][0, 0, 0, %[[VAL_239]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
-    // CHECK:             %[[VAL_243:.*]] = llvm.getelementptr %[[VAL_242]]{{\[}}%[[VAL_233]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
-    // CHECK:             llvm.store %[[VAL_241]], %[[VAL_243]] : !llvm.ptr<i64>
-    // CHECK:             %[[VAL_244:.*]] = llvm.getelementptr %[[VAL_232]]{{\[}}%[[VAL_233]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
-    // CHECK:             %[[VAL_245:.*]] = llvm.load %[[VAL_244]] : !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
-    // CHECK:             llvm.return %[[VAL_245]] : !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
-    // CHECK:           }
+    // CHECK-NEXT:        %[[VAL_241:.*]] = llvm.extractelement %[[VAL_227]]{{\[}}%[[VAL_240]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_242:.*]] = llvm.getelementptr inbounds %[[VAL_232]][0, 0, 0, %[[VAL_239]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_243:.*]] = llvm.getelementptr %[[VAL_242]]{{\[}}%[[VAL_233]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+    // CHECK-NEXT:        llvm.store %[[VAL_241]], %[[VAL_243]] : !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_244:.*]] = llvm.getelementptr %[[VAL_232]]{{\[}}%[[VAL_233]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK-NEXT:        %[[VAL_245:.*]] = llvm.load %[[VAL_244]] : !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+    // CHECK-NEXT:        llvm.return %[[VAL_245]] : !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+    // CHECK-NEXT:      }
     func.func @test_num_work_groups() -> !sycl_range_2_ {
       %0 = sycl.num_work_groups : !sycl_range_2_
       return %0 : !sycl_range_2_
@@ -411,24 +411,24 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:     llvm.func @test_num_work_groups_dim(
     // CHECK-SAME:                                          %[[VAL_246:.*]]: i32) -> i64 {
-    // CHECK:             %[[VAL_247:.*]] = llvm.mlir.addressof @__builtin_var_NumWorkgroups__ : !llvm.ptr<vector<3xi64>>
-    // CHECK:             %[[VAL_248:.*]] = llvm.load %[[VAL_247]] : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_247:.*]] = llvm.mlir.addressof @__builtin_var_NumWorkgroups__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_248:.*]] = llvm.load %[[VAL_247]] : !llvm.ptr<vector<3xi64>>
     // CHECK-DAG:         %[[VAL_249:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
     // CHECK-DAG:         %[[VAL_250:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK:             %[[VAL_251:.*]] = llvm.extractelement %[[VAL_248]]{{\[}}%[[VAL_250]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_252:.*]] = llvm.mlir.constant(0 : i64) : i64
-    // CHECK:             %[[VAL_253:.*]] = llvm.insertelement %[[VAL_251]], %[[VAL_249]]{{\[}}%[[VAL_252]] : i64] : vector<3xi64>
-    // CHECK:             %[[VAL_254:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK:             %[[VAL_255:.*]] = llvm.extractelement %[[VAL_248]]{{\[}}%[[VAL_254]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_256:.*]] = llvm.mlir.constant(1 : i64) : i64
-    // CHECK:             %[[VAL_257:.*]] = llvm.insertelement %[[VAL_255]], %[[VAL_253]]{{\[}}%[[VAL_256]] : i64] : vector<3xi64>
-    // CHECK:             %[[VAL_258:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK:             %[[VAL_259:.*]] = llvm.extractelement %[[VAL_248]]{{\[}}%[[VAL_258]] : i32] : vector<3xi64>
-    // CHECK:             %[[VAL_260:.*]] = llvm.mlir.constant(2 : i64) : i64
-    // CHECK:             %[[VAL_261:.*]] = llvm.insertelement %[[VAL_259]], %[[VAL_257]]{{\[}}%[[VAL_260]] : i64] : vector<3xi64>
-    // CHECK:             %[[VAL_262:.*]] = llvm.extractelement %[[VAL_261]]{{\[}}%[[VAL_246]] : i32] : vector<3xi64>
-    // CHECK:             llvm.return %[[VAL_262]] : i64
-    // CHECK:           }
+    // CHECK-NEXT:        %[[VAL_251:.*]] = llvm.extractelement %[[VAL_248]]{{\[}}%[[VAL_250]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_252:.*]] = llvm.mlir.constant(0 : i64) : i64
+    // CHECK-NEXT:        %[[VAL_253:.*]] = llvm.insertelement %[[VAL_251]], %[[VAL_249]]{{\[}}%[[VAL_252]] : i64] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_254:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-NEXT:        %[[VAL_255:.*]] = llvm.extractelement %[[VAL_248]]{{\[}}%[[VAL_254]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_256:.*]] = llvm.mlir.constant(1 : i64) : i64
+    // CHECK-NEXT:        %[[VAL_257:.*]] = llvm.insertelement %[[VAL_255]], %[[VAL_253]]{{\[}}%[[VAL_256]] : i64] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_258:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK-NEXT:        %[[VAL_259:.*]] = llvm.extractelement %[[VAL_248]]{{\[}}%[[VAL_258]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_260:.*]] = llvm.mlir.constant(2 : i64) : i64
+    // CHECK-NEXT:        %[[VAL_261:.*]] = llvm.insertelement %[[VAL_259]], %[[VAL_257]]{{\[}}%[[VAL_260]] : i64] : vector<3xi64>
+    // CHECK-NEXT:        %[[VAL_262:.*]] = llvm.extractelement %[[VAL_261]]{{\[}}%[[VAL_246]] : i32] : vector<3xi64>
+    // CHECK-NEXT:        llvm.return %[[VAL_262]] : i64
+    // CHECK-NEXT:       }
     func.func @test_num_work_groups_dim(%i: i32) -> index {
       %0 = sycl.num_work_groups %i : index
       return %0 : index

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -415,8 +415,8 @@ func.func @test_struct(%acc: memref<?x!sycl_accessor_1_struct_rw_gb>, %idx: memr
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[ACCESSOR1:.*]]>,
 // CHECK-SAME:                    %[[VAL_1:.*]]: !llvm.ptr<[[ID1:.*]]>) -> !llvm.[[ATOM1:.*]] {
-// CHECK:           %[[VAL_2:.*]] = llvm.mlir.undef : !llvm.[[ATOM1]]
-// CHECK:           %[[VAL_3:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = llvm.mlir.undef : !llvm.[[ATOM1]]
+// CHECK-DAG:           %[[VAL_3:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK:           %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr<[[ACCESSOR1]]>) -> !llvm.ptr<i64>
 // CHECK:           %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<i64>
 // CHECK:           %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 0] : (!llvm.ptr<[[ID1]]>) -> !llvm.ptr<i64>
@@ -1222,21 +1222,21 @@ module attributes {gpu.container} {
 // CHECK:             %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_3]]{{\[}}%[[VAL_4]]] : (!llvm.ptr<[[ID3]]>, i64) -> !llvm.ptr<[[ID3]]>
 // CHECK:             %[[VAL_6:.*]] = llvm.ptrtoint %[[VAL_5]] : !llvm.ptr<[[ID3]]> to i64
 // CHECK:             %[[VAL_7:.*]] = llvm.alloca %[[VAL_6]] x !llvm.[[ID3]] : (i64) -> !llvm.ptr<[[ID3]]>
-// CHECK:             %[[VAL_8:.*]] = llvm.mlir.constant(0 : index) : i64
-// CHECK:             %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_10:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_8:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-DAG:         %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_10:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_11:.*]] = llvm.extractelement %[[VAL_2]]{{\[}}%[[VAL_10]] : i32] : vector<3xi64>
 // CHECK:             %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_9]]] : (!llvm.ptr<[[ID3]]>, i32) -> !llvm.ptr<i64>
 // CHECK:             %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_12]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
 // CHECK:             llvm.store %[[VAL_11]], %[[VAL_13]] : !llvm.ptr<i64>
-// CHECK:             %[[VAL_14:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK:             %[[VAL_15:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-DAG:         %[[VAL_14:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-DAG:         %[[VAL_15:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK:             %[[VAL_16:.*]] = llvm.extractelement %[[VAL_2]]{{\[}}%[[VAL_15]] : i32] : vector<3xi64>
 // CHECK:             %[[VAL_17:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_14]]] : (!llvm.ptr<[[ID3]]>, i32) -> !llvm.ptr<i64>
 // CHECK:             %[[VAL_18:.*]] = llvm.getelementptr %[[VAL_17]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
 // CHECK:             llvm.store %[[VAL_16]], %[[VAL_18]] : !llvm.ptr<i64>
-// CHECK:             %[[VAL_19:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK:             %[[VAL_20:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-DAG:         %[[VAL_19:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-DAG:         %[[VAL_20:.*]] = llvm.mlir.constant(2 : i32) : i32
 // CHECK:             %[[VAL_21:.*]] = llvm.extractelement %[[VAL_2]]{{\[}}%[[VAL_20]] : i32] : vector<3xi64>
 // CHECK:             %[[VAL_22:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_19]]] : (!llvm.ptr<[[ID3]]>, i32) -> !llvm.ptr<i64>
 // CHECK:             %[[VAL_23:.*]] = llvm.getelementptr %[[VAL_22]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
@@ -1266,8 +1266,8 @@ module attributes {gpu.container} {
 // CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> i64 {
 // CHECK:             %[[VAL_2:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
 // CHECK:             %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<vector<3xi64>>
-// CHECK:             %[[VAL_4:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK:             %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_4:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+// CHECK-DAG:         %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_6:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_5]] : i32] : vector<3xi64>
 // CHECK:             %[[VAL_7:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK:             %[[VAL_8:.*]] = llvm.insertelement %[[VAL_6]], %[[VAL_4]]{{\[}}%[[VAL_7]] : i64] : vector<3xi64>
@@ -1424,8 +1424,8 @@ module attributes {gpu.container} {
 // CHECK:             %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_2:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
 // CHECK:             %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<vector<3xi64>>
-// CHECK:             %[[VAL_4:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK:             %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_4:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+// CHECK-DAG:         %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_6:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_5]] : i32] : vector<3xi64>
 // CHECK:             %[[VAL_7:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK:             %[[VAL_8:.*]] = llvm.insertelement %[[VAL_6]], %[[VAL_4]]{{\[}}%[[VAL_7]] : i64] : vector<3xi64>
@@ -1450,8 +1450,8 @@ module attributes {gpu.container} {
 // CHECK:             %[[VAL_19:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_20:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
 // CHECK:             %[[VAL_21:.*]] = llvm.load %[[VAL_20]] : !llvm.ptr<vector<3xi64>>
-// CHECK:             %[[VAL_22:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK:             %[[VAL_23:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_22:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+// CHECK-DAG:         %[[VAL_23:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_24:.*]] = llvm.extractelement %[[VAL_21]]{{\[}}%[[VAL_23]] : i32] : vector<3xi64>
 // CHECK:             %[[VAL_25:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK:             %[[VAL_26:.*]] = llvm.insertelement %[[VAL_24]], %[[VAL_22]]{{\[}}%[[VAL_25]] : i64] : vector<3xi64>
@@ -1470,8 +1470,8 @@ module attributes {gpu.container} {
 // CHECK:             %[[VAL_39:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK:             %[[VAL_40:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
 // CHECK:             %[[VAL_41:.*]] = llvm.load %[[VAL_40]] : !llvm.ptr<vector<3xi64>>
-// CHECK:             %[[VAL_42:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK:             %[[VAL_43:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_42:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+// CHECK-DAG:         %[[VAL_43:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_44:.*]] = llvm.extractelement %[[VAL_41]]{{\[}}%[[VAL_43]] : i32] : vector<3xi64>
 // CHECK:             %[[VAL_45:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK:             %[[VAL_46:.*]] = llvm.insertelement %[[VAL_44]], %[[VAL_42]]{{\[}}%[[VAL_45]] : i64] : vector<3xi64>
@@ -1497,8 +1497,8 @@ module attributes {gpu.container} {
 // CHECK:             %[[VAL_58:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_59:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
 // CHECK:             %[[VAL_60:.*]] = llvm.load %[[VAL_59]] : !llvm.ptr<vector<3xi64>>
-// CHECK:             %[[VAL_61:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK:             %[[VAL_62:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_61:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+// CHECK-DAG:         %[[VAL_62:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_63:.*]] = llvm.extractelement %[[VAL_60]]{{\[}}%[[VAL_62]] : i32] : vector<3xi64>
 // CHECK:             %[[VAL_64:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK:             %[[VAL_65:.*]] = llvm.insertelement %[[VAL_63]], %[[VAL_61]]{{\[}}%[[VAL_64]] : i64] : vector<3xi64>
@@ -1520,8 +1520,8 @@ module attributes {gpu.container} {
 // CHECK:             %[[VAL_81:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK:             %[[VAL_82:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
 // CHECK:             %[[VAL_83:.*]] = llvm.load %[[VAL_82]] : !llvm.ptr<vector<3xi64>>
-// CHECK:             %[[VAL_84:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK:             %[[VAL_85:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_84:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+// CHECK-DAG:         %[[VAL_85:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_86:.*]] = llvm.extractelement %[[VAL_83]]{{\[}}%[[VAL_85]] : i32] : vector<3xi64>
 // CHECK:             %[[VAL_87:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK:             %[[VAL_88:.*]] = llvm.insertelement %[[VAL_86]], %[[VAL_84]]{{\[}}%[[VAL_87]] : i64] : vector<3xi64>
@@ -1539,8 +1539,8 @@ module attributes {gpu.container} {
 // CHECK:             %[[VAL_100:.*]] = llvm.mlir.constant(2 : i32) : i32
 // CHECK:             %[[VAL_101:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
 // CHECK:             %[[VAL_102:.*]] = llvm.load %[[VAL_101]] : !llvm.ptr<vector<3xi64>>
-// CHECK:             %[[VAL_103:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK:             %[[VAL_104:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_103:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+// CHECK-DAG:         %[[VAL_104:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_105:.*]] = llvm.extractelement %[[VAL_102]]{{\[}}%[[VAL_104]] : i32] : vector<3xi64>
 // CHECK:             %[[VAL_106:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK:             %[[VAL_107:.*]] = llvm.insertelement %[[VAL_105]], %[[VAL_103]]{{\[}}%[[VAL_106]] : i64] : vector<3xi64>

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -125,7 +125,8 @@ func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> i64 {
 
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[ID1:.*]]>) -> i64 {
-// CHECK:           %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 0] : (!llvm.ptr<[[ID1]]>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:           %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, %[[VAL_1]]] : (!llvm.ptr<[[ID1]]>, i32) -> !llvm.ptr<i64>
 // CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i64>
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:    }
@@ -408,7 +409,7 @@ func.func @test_struct(%acc: memref<?x!sycl_accessor_1_struct_rw_gb>, %idx: memr
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_ato_gb = !sycl.accessor<[1, i32, atomic, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 3>)>)>
+!sycl_accessor_1_i32_ato_gb = !sycl.accessor<[1, i32, atomic, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
 !sycl_atomic_i32_1_ = !sycl.atomic<[i32, 1], (memref<?xi32, 1>)>
 
 // CHECK-LABEL:   llvm.func @test(
@@ -551,7 +552,8 @@ func.func @test(%item: memref<?x!sycl_item_1_>, %i: i32) -> i64 {
 
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[ITEM1]]>) -> i64 {
-// CHECK:            %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 1, 0, 0, 0] : (!llvm.ptr<[[ITEM1]]>) -> !llvm.ptr<i64>
+// CHECK:            %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:            %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 1, 0, 0, %[[VAL_1]]] : (!llvm.ptr<[[ITEM1]]>, i32) -> !llvm.ptr<i64>
 // CHECK-NEXT:       %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i64>
 // CHECK-NEXT:       llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:     }
@@ -1213,79 +1215,35 @@ module attributes {gpu.container} {
   gpu.module @kernels {
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[GROUP3:.*]]>) -> !llvm.[[ID3:.*]] {
-// CHECK-NEXT:       %[[VAL_1:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:       %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.[[ID3]] : (i32) -> !llvm.ptr<[[ID3]]>
-// CHECK-NEXT:       %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, 0] : (!llvm.ptr<[[ID3]]>) -> !llvm.ptr<i64>
-// CHECK-NEXT:       %[[VAL_4:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:       %[[TMP_0:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_1:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_2:.*]] = llvm.load %[[TMP_1]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_3:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:       %[[TMP_4:.*]] = llvm.extractelement %[[TMP_2]][%[[TMP_3]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_5:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:       %[[TMP_6:.*]] = llvm.insertelement %[[TMP_4]], %[[TMP_0]][%[[TMP_5]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_7:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_8:.*]] = llvm.load %[[TMP_7]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_9:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:       %[[TMP_10:.*]] = llvm.extractelement %[[TMP_8]][%[[TMP_9]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_11:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:       %[[TMP_12:.*]] = llvm.insertelement %[[TMP_10]], %[[TMP_6]][%[[TMP_11]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_13:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_14:.*]] = llvm.load %[[TMP_13]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_15:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:       %[[TMP_16:.*]] = llvm.extractelement %[[TMP_14]][%[[TMP_15]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_17:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:       %[[TMP_18:.*]] = llvm.insertelement %[[TMP_16]], %[[TMP_12]][%[[TMP_17]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_6:.*]]  = llvm.extractelement %[[TMP_18]][%[[VAL_4]] : i32] : vector<3xi64>
-// CHECK-NEXT:       llvm.store %[[VAL_6]], %[[VAL_3]] : !llvm.ptr<i64>
-// CHECK-NEXT:       %[[VAL_7:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, 1] : (!llvm.ptr<[[ID3]]>) -> !llvm.ptr<i64>
-// CHECK-NEXT:       %[[VAL_8:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:       %[[TMP_0:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_1:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_2:.*]] = llvm.load %[[TMP_1]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_3:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:       %[[TMP_4:.*]] = llvm.extractelement %[[TMP_2]][%[[TMP_3]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_5:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:       %[[TMP_6:.*]] = llvm.insertelement %[[TMP_4]], %[[TMP_0]][%[[TMP_5]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_7:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_8:.*]] = llvm.load %[[TMP_7]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_9:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:       %[[TMP_10:.*]] = llvm.extractelement %[[TMP_8]][%[[TMP_9]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_11:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:       %[[TMP_12:.*]] = llvm.insertelement %[[TMP_10]], %[[TMP_6]][%[[TMP_11]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_13:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_14:.*]] = llvm.load %[[TMP_13]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_15:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:       %[[TMP_16:.*]] = llvm.extractelement %[[TMP_14]][%[[TMP_15]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_17:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:       %[[TMP_18:.*]] = llvm.insertelement %[[TMP_16]], %[[TMP_12]][%[[TMP_17]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_10:.*]]  = llvm.extractelement %[[TMP_18]][%[[VAL_8]] : i32] : vector<3xi64>
-// CHECK-NEXT:       llvm.store %[[VAL_10]], %[[VAL_7]] : !llvm.ptr<i64>
-// CHECK-NEXT:       %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, 2] : (!llvm.ptr<[[ID3]]>) -> !llvm.ptr<i64>
-// CHECK-NEXT:       %[[VAL_12:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:       %[[TMP_0:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_1:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_2:.*]] = llvm.load %[[TMP_1]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_3:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:       %[[TMP_4:.*]] = llvm.extractelement %[[TMP_2]][%[[TMP_3]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_5:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:       %[[TMP_6:.*]] = llvm.insertelement %[[TMP_4]], %[[TMP_0]][%[[TMP_5]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_7:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_8:.*]] = llvm.load %[[TMP_7]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_9:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:       %[[TMP_10:.*]] = llvm.extractelement %[[TMP_8]][%[[TMP_9]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_11:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:       %[[TMP_12:.*]] = llvm.insertelement %[[TMP_10]], %[[TMP_6]][%[[TMP_11]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_13:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_14:.*]] = llvm.load %[[TMP_13]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_15:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:       %[[TMP_16:.*]] = llvm.extractelement %[[TMP_14]][%[[TMP_15]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_17:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:       %[[TMP_18:.*]] = llvm.insertelement %[[TMP_16]], %[[TMP_12]][%[[TMP_17]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_14:.*]] = llvm.extractelement %[[TMP_18]][%[[VAL_12]] : i32] : vector<3xi64>
-// CHECK-NEXT:       llvm.store %[[VAL_14]], %[[VAL_11]] : !llvm.ptr<i64>
-// CHECK-NEXT:       %[[VAL_15:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<[[ID3]]>
-// CHECK-NEXT:       llvm.return %[[VAL_15]] : !llvm.[[ID3]]
+// CHECK:             %[[VAL_1:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_3:.*]] = llvm.mlir.null : !llvm.ptr<[[ID3]]>
+// CHECK:             %[[VAL_4:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:             %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_3]]{{\[}}%[[VAL_4]]] : (!llvm.ptr<[[ID3]]>, i64) -> !llvm.ptr<[[ID3]]>
+// CHECK:             %[[VAL_6:.*]] = llvm.ptrtoint %[[VAL_5]] : !llvm.ptr<[[ID3]]> to i64
+// CHECK:             %[[VAL_7:.*]] = llvm.alloca %[[VAL_6]] x !llvm.[[ID3]] : (i64) -> !llvm.ptr<[[ID3]]>
+// CHECK:             %[[VAL_8:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK:             %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_10:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_11:.*]] = llvm.extractelement %[[VAL_2]]{{\[}}%[[VAL_10]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_9]]] : (!llvm.ptr<[[ID3]]>, i32) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_12]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+// CHECK:             llvm.store %[[VAL_11]], %[[VAL_13]] : !llvm.ptr<i64>
+// CHECK:             %[[VAL_14:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_15:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_16:.*]] = llvm.extractelement %[[VAL_2]]{{\[}}%[[VAL_15]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_17:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_14]]] : (!llvm.ptr<[[ID3]]>, i32) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_18:.*]] = llvm.getelementptr %[[VAL_17]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+// CHECK:             llvm.store %[[VAL_16]], %[[VAL_18]] : !llvm.ptr<i64>
+// CHECK:             %[[VAL_19:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:             %[[VAL_20:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:             %[[VAL_21:.*]] = llvm.extractelement %[[VAL_2]]{{\[}}%[[VAL_20]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_22:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_19]]] : (!llvm.ptr<[[ID3]]>, i32) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_23:.*]] = llvm.getelementptr %[[VAL_22]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+// CHECK:             llvm.store %[[VAL_21]], %[[VAL_23]] : !llvm.ptr<i64>
+// CHECK:             %[[VAL_24:.*]] = llvm.getelementptr %[[VAL_7]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<[[ID3]]>, i64) -> !llvm.ptr<[[ID3]]>
+// CHECK:             %[[VAL_25:.*]] = llvm.load %[[VAL_24]] : !llvm.ptr<[[ID3]]>
+// CHECK:             llvm.return %[[VAL_25]] : !llvm.[[ID3]]
 // CHECK-NEXT:     }
     func.func @test(%group: memref<?x!sycl_group_3_>) -> !sycl_id_3_ {
       %0 = sycl.group.get_local_id(%group) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_local_id", MangledFunctionName = @"get_local_id", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> !sycl_id_3_
@@ -1306,27 +1264,23 @@ module attributes {gpu.container} {
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[GROUP1]]>,
 // CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> i64 {
-// CHECK-NEXT:       %[[VAL_2:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_3:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:       %[[VAL_6:.*]] = llvm.extractelement %[[VAL_4]][%[[VAL_5]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_7:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:       %[[VAL_8:.*]] = llvm.insertelement %[[VAL_6]], %[[VAL_2]][%[[VAL_7]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_9:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[VAL_11:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:       %[[VAL_12:.*]] = llvm.extractelement %[[VAL_10]][%[[VAL_11]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_13:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:       %[[VAL_14:.*]] = llvm.insertelement %[[VAL_12]], %[[VAL_8]][%[[VAL_13]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_15:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[VAL_16:.*]] = llvm.load %[[VAL_15]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[VAL_17:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:       %[[VAL_18:.*]] = llvm.extractelement %[[VAL_16]][%[[VAL_17]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_19:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:       %[[VAL_20:.*]] = llvm.insertelement %[[VAL_18]], %[[VAL_14]][%[[VAL_19]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_21:.*]] = llvm.extractelement %[[VAL_20]][%arg1 : i32] : vector<3xi64>
-// CHECK-NEXT:       llvm.return %[[VAL_21]] : i64
+// CHECK:             %[[VAL_2:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_4:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+// CHECK:             %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_6:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_5]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_7:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK:             %[[VAL_8:.*]] = llvm.insertelement %[[VAL_6]], %[[VAL_4]]{{\[}}%[[VAL_7]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_9:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_10:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_9]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_11:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:             %[[VAL_12:.*]] = llvm.insertelement %[[VAL_10]], %[[VAL_8]]{{\[}}%[[VAL_11]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_13:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:             %[[VAL_14:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_13]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_15:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK:             %[[VAL_16:.*]] = llvm.insertelement %[[VAL_14]], %[[VAL_12]]{{\[}}%[[VAL_15]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_17:.*]] = llvm.extractelement %[[VAL_16]]{{\[}}%[[VAL_1]] : i32] : vector<3xi64>
+// CHECK:             llvm.return %[[VAL_17]] : i64
 // CHECK-NEXT:     }
     func.func @test(%group: memref<?x!sycl_group_1_>, %i: i32) -> i64 {
       %0 = sycl.group.get_local_id(%group, %i) { ArgumentTypes = [memref<?x!sycl_group_1_>, i32], FunctionName = @"get_local_id", MangledFunctionName = @"get_local_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>, i32) -> i64
@@ -1467,28 +1421,24 @@ module attributes {gpu.container} {
   gpu.module @kernels {
 // CHECK-LABEL:   llvm.func @test_1(
 // CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr<[[GROUP1]]>) -> i64 {
-// CHECK-NEXT:       %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:       %[[VAL_2:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_3:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:       %[[VAL_6:.*]] = llvm.extractelement %[[VAL_4]][%[[VAL_5]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_7:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:       %[[VAL_8:.*]] = llvm.insertelement %[[VAL_6]], %[[VAL_2]][%[[VAL_7]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_9:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[VAL_11:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:       %[[VAL_12:.*]] = llvm.extractelement %[[VAL_10]][%[[VAL_11]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_13:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:       %[[VAL_14:.*]] = llvm.insertelement %[[VAL_12]], %[[VAL_8]][%[[VAL_13]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_15:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[VAL_16:.*]] = llvm.load %[[VAL_15]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[VAL_17:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:       %[[VAL_18:.*]] = llvm.extractelement %[[VAL_16]][%[[VAL_17]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_19:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:       %[[VAL_20:.*]] = llvm.insertelement %[[VAL_18]], %[[VAL_14]][%[[VAL_19]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_21:.*]] = llvm.extractelement %[[VAL_20]][%[[VAL_1]] : i32] : vector<3xi64>
-// CHECK-NEXT:       llvm.return %[[VAL_21]] : i64
+// CHECK:             %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_2:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_4:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+// CHECK:             %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_6:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_5]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_7:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK:             %[[VAL_8:.*]] = llvm.insertelement %[[VAL_6]], %[[VAL_4]]{{\[}}%[[VAL_7]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_9:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_10:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_9]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_11:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:             %[[VAL_12:.*]] = llvm.insertelement %[[VAL_10]], %[[VAL_8]]{{\[}}%[[VAL_11]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_13:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:             %[[VAL_14:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_13]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_15:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK:             %[[VAL_16:.*]] = llvm.insertelement %[[VAL_14]], %[[VAL_12]]{{\[}}%[[VAL_15]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_17:.*]] = llvm.extractelement %[[VAL_16]]{{\[}}%[[VAL_1]] : i32] : vector<3xi64>
+// CHECK:             llvm.return %[[VAL_17]] : i64
 // CHECK-NEXT:     }
     func.func @test_1(%group: memref<?x!sycl_group_1_>) -> i64 {
       %0 = sycl.group.get_local_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> i64
@@ -1496,54 +1446,46 @@ module attributes {gpu.container} {
     }
 
 // CHECK-LABEL:   llvm.func @test_2(
-// CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr<[[GROUP2]]>) -> i64 {
-// CHECK-NEXT:       %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:       %[[TMP_0:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_1:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_2:.*]] = llvm.load %[[TMP_1]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_3:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:       %[[TMP_4:.*]] = llvm.extractelement %[[TMP_2]][%[[TMP_3]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_5:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:       %[[TMP_6:.*]] = llvm.insertelement %[[TMP_4]], %[[TMP_0]][%[[TMP_5]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_7:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_8:.*]] = llvm.load %[[TMP_7]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_9:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:       %[[TMP_10:.*]] = llvm.extractelement %[[TMP_8]][%[[TMP_9]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_11:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:       %[[TMP_12:.*]] = llvm.insertelement %[[TMP_10]], %[[TMP_6]][%[[TMP_11]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_13:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_14:.*]] = llvm.load %[[TMP_13]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_15:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:       %[[TMP_16:.*]] = llvm.extractelement %[[TMP_14]][%[[TMP_15]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_17:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:       %[[TMP_18:.*]] = llvm.insertelement %[[TMP_16]], %[[TMP_12]][%[[TMP_17]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_2:.*]]  = llvm.extractelement %[[TMP_18]][%[[VAL_1]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2, 0, 0, 1] : (!llvm.ptr<[[GROUP2]]>) -> !llvm.ptr<i64>
-// CHECK-NEXT:       %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<i64>
-// CHECK-NEXT:       %[[VAL_6:.*]] = llvm.mul %[[VAL_21]], %[[VAL_5]] : i64
-// CHECK-NEXT:       %[[VAL_7:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:       %[[TMP_0:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_1:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_2:.*]] = llvm.load %[[TMP_1]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_3:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:       %[[TMP_4:.*]] = llvm.extractelement %[[TMP_2]][%[[TMP_3]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_5:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:       %[[TMP_6:.*]] = llvm.insertelement %[[TMP_4]], %[[TMP_0]][%[[TMP_5]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_7:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_8:.*]] = llvm.load %[[TMP_7]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_9:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:       %[[TMP_10:.*]] = llvm.extractelement %[[TMP_8]][%[[TMP_9]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_11:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:       %[[TMP_12:.*]] = llvm.insertelement %[[TMP_10]], %[[TMP_6]][%[[TMP_11]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_13:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_14:.*]] = llvm.load %[[TMP_13]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_15:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:       %[[TMP_16:.*]] = llvm.extractelement %[[TMP_14]][%[[TMP_15]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_17:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:       %[[TMP_18:.*]] = llvm.insertelement %[[TMP_16]], %[[TMP_12]][%[[TMP_17]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_8:.*]]  = llvm.extractelement %[[TMP_18]][%[[VAL_7]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_10:.*]] = llvm.add %[[VAL_6]], %[[VAL_8]] : i64
-// CHECK-NEXT:       llvm.return %[[VAL_10]] : i64
+// CHECK-SAME:                      %[[VAL_18:.*]]: !llvm.ptr<[[GROUP2]]>) -> i64 {
+// CHECK:             %[[VAL_19:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_20:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_21:.*]] = llvm.load %[[VAL_20]] : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_22:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+// CHECK:             %[[VAL_23:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_24:.*]] = llvm.extractelement %[[VAL_21]]{{\[}}%[[VAL_23]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_25:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK:             %[[VAL_26:.*]] = llvm.insertelement %[[VAL_24]], %[[VAL_22]]{{\[}}%[[VAL_25]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_27:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_28:.*]] = llvm.extractelement %[[VAL_21]]{{\[}}%[[VAL_27]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_29:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:             %[[VAL_30:.*]] = llvm.insertelement %[[VAL_28]], %[[VAL_26]]{{\[}}%[[VAL_29]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_31:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:             %[[VAL_32:.*]] = llvm.extractelement %[[VAL_21]]{{\[}}%[[VAL_31]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_33:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK:             %[[VAL_34:.*]] = llvm.insertelement %[[VAL_32]], %[[VAL_30]]{{\[}}%[[VAL_33]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_35:.*]] = llvm.extractelement %[[VAL_34]]{{\[}}%[[VAL_19]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_36:.*]] = llvm.getelementptr inbounds %[[VAL_18]][0, 2, 0, 0, 1] : (!llvm.ptr<[[GROUP2]]>) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_37:.*]] = llvm.load %[[VAL_36]] : !llvm.ptr<i64>
+// CHECK:             %[[VAL_38:.*]] = llvm.mul %[[VAL_35]], %[[VAL_37]]  : i64
+// CHECK:             %[[VAL_39:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_40:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_41:.*]] = llvm.load %[[VAL_40]] : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_42:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+// CHECK:             %[[VAL_43:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_44:.*]] = llvm.extractelement %[[VAL_41]]{{\[}}%[[VAL_43]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_45:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK:             %[[VAL_46:.*]] = llvm.insertelement %[[VAL_44]], %[[VAL_42]]{{\[}}%[[VAL_45]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_47:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_48:.*]] = llvm.extractelement %[[VAL_41]]{{\[}}%[[VAL_47]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_49:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:             %[[VAL_50:.*]] = llvm.insertelement %[[VAL_48]], %[[VAL_46]]{{\[}}%[[VAL_49]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_51:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:             %[[VAL_52:.*]] = llvm.extractelement %[[VAL_41]]{{\[}}%[[VAL_51]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_53:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK:             %[[VAL_54:.*]] = llvm.insertelement %[[VAL_52]], %[[VAL_50]]{{\[}}%[[VAL_53]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_55:.*]] = llvm.extractelement %[[VAL_54]]{{\[}}%[[VAL_39]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_56:.*]] = llvm.add %[[VAL_38]], %[[VAL_55]]  : i64
+// CHECK:             llvm.return %[[VAL_56]] : i64
 // CHECK-NEXT:     }
     func.func @test_2(%group: memref<?x!sycl_group_2_>) -> i64 {
       %0 = sycl.group.get_local_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_2_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_2_>) -> i64
@@ -1551,80 +1493,68 @@ module attributes {gpu.container} {
     }
 
 // CHECK-LABEL:   llvm.func @test_3(
-// CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr<[[GROUP3]]>) -> i64 {
-// CHECK-NEXT:       %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:       %[[TMP_0:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_1:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_2:.*]] = llvm.load %[[TMP_1]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_3:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:       %[[TMP_4:.*]] = llvm.extractelement %[[TMP_2]][%[[TMP_3]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_5:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:       %[[TMP_6:.*]] = llvm.insertelement %[[TMP_4]], %[[TMP_0]][%[[TMP_5]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_7:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_8:.*]] = llvm.load %[[TMP_7]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_9:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:       %[[TMP_10:.*]] = llvm.extractelement %[[TMP_8]][%[[TMP_9]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_11:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:       %[[TMP_12:.*]] = llvm.insertelement %[[TMP_10]], %[[TMP_6]][%[[TMP_11]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_13:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_14:.*]] = llvm.load %[[TMP_13]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_15:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:       %[[TMP_16:.*]] = llvm.extractelement %[[TMP_14]][%[[TMP_15]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_17:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:       %[[TMP_18:.*]] = llvm.insertelement %[[TMP_16]], %[[TMP_12]][%[[TMP_17]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_2:.*]]  = llvm.extractelement %[[TMP_18]][%[[VAL_1]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2, 0, 0, 1] : (!llvm.ptr<[[GROUP3]]>) -> !llvm.ptr<i64>
-// CHECK-NEXT:       %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<i64>
-// CHECK-NEXT:       %[[VAL_6:.*]] = llvm.mul %[[VAL_2]], %[[VAL_5]] : i64
-// CHECK-NEXT:       %[[VAL_7:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2, 0, 0, 2] : (!llvm.ptr<[[GROUP3]]>) -> !llvm.ptr<i64>
-// CHECK-NEXT:       %[[VAL_8:.*]] = llvm.load %[[VAL_7]] : !llvm.ptr<i64>
-// CHECK-NEXT:       %[[VAL_9:.*]] = llvm.mul %[[VAL_6]], %[[VAL_8]] : i64
-// CHECK-NEXT:       %[[VAL_10:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:       %[[TMP_0:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_1:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_2:.*]] = llvm.load %[[TMP_1]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_3:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:       %[[TMP_4:.*]] = llvm.extractelement %[[TMP_2]][%[[TMP_3]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_5:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:       %[[TMP_6:.*]] = llvm.insertelement %[[TMP_4]], %[[TMP_0]][%[[TMP_5]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_7:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_8:.*]] = llvm.load %[[TMP_7]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_9:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:       %[[TMP_10:.*]] = llvm.extractelement %[[TMP_8]][%[[TMP_9]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_11:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:       %[[TMP_12:.*]] = llvm.insertelement %[[TMP_10]], %[[TMP_6]][%[[TMP_11]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_13:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_14:.*]] = llvm.load %[[TMP_13]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_15:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:       %[[TMP_16:.*]] = llvm.extractelement %[[TMP_14]][%[[TMP_15]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_17:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:       %[[TMP_18:.*]] = llvm.insertelement %[[TMP_16]], %[[TMP_12]][%[[TMP_17]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_12:.*]]  = llvm.extractelement %[[TMP_18]][%[[VAL_10]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_13:.*]] = llvm.mul %[[VAL_12]], %[[VAL_8]] : i64
-// CHECK-NEXT:       %[[VAL_14:.*]] = llvm.add %[[VAL_9]], %[[VAL_13]] : i64
-// CHECK-NEXT:       %[[VAL_15:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:       %[[TMP_0:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_1:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_2:.*]] = llvm.load %[[TMP_1]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_3:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:       %[[TMP_4:.*]] = llvm.extractelement %[[TMP_2]][%[[TMP_3]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_5:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:       %[[TMP_6:.*]] = llvm.insertelement %[[TMP_4]], %[[TMP_0]][%[[TMP_5]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_7:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_8:.*]] = llvm.load %[[TMP_7]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_9:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:       %[[TMP_10:.*]] = llvm.extractelement %[[TMP_8]][%[[TMP_9]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_11:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:       %[[TMP_12:.*]] = llvm.insertelement %[[TMP_10]], %[[TMP_6]][%[[TMP_11]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_13:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_14:.*]] = llvm.load %[[TMP_13]] : !llvm.ptr<vector<3xi64>>
-// CHECK-NEXT:       %[[TMP_15:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:       %[[TMP_16:.*]] = llvm.extractelement %[[TMP_14]][%[[TMP_15]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[TMP_17:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:       %[[TMP_18:.*]] = llvm.insertelement %[[TMP_16]], %[[TMP_12]][%[[TMP_17]] : i64] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_16:.*]]  = llvm.extractelement %[[TMP_18]][%[[VAL_15]] : i32] : vector<3xi64>
-// CHECK-NEXT:       %[[VAL_18:.*]] = llvm.add %[[VAL_14]], %[[VAL_16]] : i64
-// CHECK-NEXT:       llvm.return %[[VAL_18]] : i64
+// CHECK-SAME:                      %[[VAL_57:.*]]: !llvm.ptr<[[GROUP3]]>) -> i64 {
+// CHECK:             %[[VAL_58:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_59:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_60:.*]] = llvm.load %[[VAL_59]] : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_61:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+// CHECK:             %[[VAL_62:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_63:.*]] = llvm.extractelement %[[VAL_60]]{{\[}}%[[VAL_62]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_64:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK:             %[[VAL_65:.*]] = llvm.insertelement %[[VAL_63]], %[[VAL_61]]{{\[}}%[[VAL_64]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_66:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_67:.*]] = llvm.extractelement %[[VAL_60]]{{\[}}%[[VAL_66]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_68:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:             %[[VAL_69:.*]] = llvm.insertelement %[[VAL_67]], %[[VAL_65]]{{\[}}%[[VAL_68]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_70:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:             %[[VAL_71:.*]] = llvm.extractelement %[[VAL_60]]{{\[}}%[[VAL_70]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_72:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK:             %[[VAL_73:.*]] = llvm.insertelement %[[VAL_71]], %[[VAL_69]]{{\[}}%[[VAL_72]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_74:.*]] = llvm.extractelement %[[VAL_73]]{{\[}}%[[VAL_58]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_75:.*]] = llvm.getelementptr inbounds %[[VAL_57]][0, 2, 0, 0, 1] : (!llvm.ptr<[[GROUP3]]>) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_76:.*]] = llvm.load %[[VAL_75]] : !llvm.ptr<i64>
+// CHECK:             %[[VAL_77:.*]] = llvm.mul %[[VAL_74]], %[[VAL_76]]  : i64
+// CHECK:             %[[VAL_78:.*]] = llvm.getelementptr inbounds %[[VAL_57]][0, 2, 0, 0, 2] : (!llvm.ptr<[[GROUP3]]>) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_79:.*]] = llvm.load %[[VAL_78]] : !llvm.ptr<i64>
+// CHECK:             %[[VAL_80:.*]] = llvm.mul %[[VAL_77]], %[[VAL_79]]  : i64
+// CHECK:             %[[VAL_81:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_82:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_83:.*]] = llvm.load %[[VAL_82]] : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_84:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+// CHECK:             %[[VAL_85:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_86:.*]] = llvm.extractelement %[[VAL_83]]{{\[}}%[[VAL_85]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_87:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK:             %[[VAL_88:.*]] = llvm.insertelement %[[VAL_86]], %[[VAL_84]]{{\[}}%[[VAL_87]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_89:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_90:.*]] = llvm.extractelement %[[VAL_83]]{{\[}}%[[VAL_89]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_91:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:             %[[VAL_92:.*]] = llvm.insertelement %[[VAL_90]], %[[VAL_88]]{{\[}}%[[VAL_91]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_93:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:             %[[VAL_94:.*]] = llvm.extractelement %[[VAL_83]]{{\[}}%[[VAL_93]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_95:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK:             %[[VAL_96:.*]] = llvm.insertelement %[[VAL_94]], %[[VAL_92]]{{\[}}%[[VAL_95]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_97:.*]] = llvm.extractelement %[[VAL_96]]{{\[}}%[[VAL_81]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_98:.*]] = llvm.mul %[[VAL_97]], %[[VAL_79]]  : i64
+// CHECK:             %[[VAL_99:.*]] = llvm.add %[[VAL_80]], %[[VAL_98]]  : i64
+// CHECK:             %[[VAL_100:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:             %[[VAL_101:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_102:.*]] = llvm.load %[[VAL_101]] : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_103:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
+// CHECK:             %[[VAL_104:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_105:.*]] = llvm.extractelement %[[VAL_102]]{{\[}}%[[VAL_104]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_106:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK:             %[[VAL_107:.*]] = llvm.insertelement %[[VAL_105]], %[[VAL_103]]{{\[}}%[[VAL_106]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_108:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_109:.*]] = llvm.extractelement %[[VAL_102]]{{\[}}%[[VAL_108]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_110:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK:             %[[VAL_111:.*]] = llvm.insertelement %[[VAL_109]], %[[VAL_107]]{{\[}}%[[VAL_110]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_112:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:             %[[VAL_113:.*]] = llvm.extractelement %[[VAL_102]]{{\[}}%[[VAL_112]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_114:.*]] = llvm.mlir.constant(2 : i64) : i64
+// CHECK:             %[[VAL_115:.*]] = llvm.insertelement %[[VAL_113]], %[[VAL_111]]{{\[}}%[[VAL_114]] : i64] : vector<3xi64>
+// CHECK:             %[[VAL_116:.*]] = llvm.extractelement %[[VAL_115]]{{\[}}%[[VAL_100]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_117:.*]] = llvm.add %[[VAL_99]], %[[VAL_116]]  : i64
+// CHECK:             llvm.return %[[VAL_117]] : i64
 // CHECK-NEXT:     }
     func.func @test_3(%group: memref<?x!sycl_group_3_>) -> i64 {
       %0 = sycl.group.get_local_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64

--- a/mlir-sycl/test/Conversion/SYCLToSPIRV/grid-ops.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToSPIRV/grid-ops.mlir
@@ -1,15 +1,24 @@
 // RUN: sycl-mlir-opt -convert-sycl-to-spirv %s | FileCheck %s
 
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
 
 module attributes {gpu.container_module} {
   // CHECK:   gpu.module @kernels {
   gpu.module @kernels {
-    // CHECK-DAG:           spirv.GlobalVariable @[[SLIID:.*]] built_in("SubgroupLocalInvocationId") : !spirv.ptr<i32, Input>
-    // CHECK-DAG:           spirv.GlobalVariable @[[SMS:.*]] built_in("SubgroupMaxSize") : !spirv.ptr<i32, Input>
     // CHECK-DAG:           spirv.GlobalVariable @[[NW:.*]] built_in("NumWorkgroups") : !spirv.ptr<vector<3xi32>, Input>
     // CHECK-DAG:           spirv.GlobalVariable @[[GO:.*]] built_in("GlobalOffset") : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-DAG:           spirv.GlobalVariable @[[WI:.*]] built_in("WorkgroupId") : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-DAG:           spirv.GlobalVariable @[[NWI:.*]] built_in("GlobalSize") : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-DAG:           spirv.GlobalVariable @[[WGS:.*]] built_in("WorkgroupSize") : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-DAG:           spirv.GlobalVariable @[[LII:.*]] built_in("LocalInvocationId") : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-DAG:           spirv.GlobalVariable @[[GII:.*]] built_in("GlobalInvocationId") : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-DAG:           spirv.GlobalVariable @[[SLIID:.*]] built_in("SubgroupLocalInvocationId") : !spirv.ptr<i32, Input>
+    // CHECK-DAG:           spirv.GlobalVariable @[[SMS:.*]] built_in("SubgroupMaxSize") : !spirv.ptr<i32, Input>
+    // CHECK-DAG:           spirv.GlobalVariable @[[SI:.*]] built_in("SubgroupId") : !spirv.ptr<i32, Input>
+    // CHECK-DAG:           spirv.GlobalVariable @[[NS:.*]] built_in("NumSubgroups") : !spirv.ptr<i32, Input>
+    // CHECK-DAG:           spirv.GlobalVariable @[[SS:.*]] built_in("SubgroupSize") : !spirv.ptr<i32, Input>
 
     // CHECK-LABEL:         gpu.func @test_global_offset() kernel
     // CHECK-NEXT:            %[[VAL_0:.*]] = spirv.mlir.addressof @[[GO]] : !spirv.ptr<vector<3xi32>, Input>
@@ -100,6 +109,216 @@ module attributes {gpu.container_module} {
       gpu.return
     }
 
+    // CHECK-LABEL:         gpu.func @test_work_group_id() kernel
+    // CHECK-NEXT:            %[[VAL_0:.*]] = spirv.mlir.addressof @[[WI]] : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-NEXT:            %[[VAL_1:.*]] = spirv.Load "Input" %[[VAL_0]] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_2:.*]] = memref.alloca() : memref<1x!sycl_id_1_>
+    // CHECK-NEXT:            %[[VAL_3:.*]] = arith.constant 0 : index
+    // CHECK-NEXT:            %[[VAL_5:.*]] = arith.constant 0 : i32
+    // CHECK-NEXT:            %[[VAL_6:.*]] = spirv.CompositeExtract %[[VAL_1]][0 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
+    // CHECK-NEXT:            %[[VAL_8:.*]] = sycl.id.get %[[VAL_2]][%[[VAL_5]]] {ArgumentTypes = [memref<1x!sycl_id_1_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_1_>, i32) -> memref<1xi64>
+    // CHECK-NEXT:            memref.store %[[VAL_7]], %[[VAL_8]]{{\[}}%[[VAL_3]]] : memref<1xi64>
+    // CHECK-NEXT:            %[[VAL_4:.*]] = memref.load %[[VAL_2]]{{\[}}%[[VAL_3]]] : memref<1x!sycl_id_1_>
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
+    gpu.func @test_work_group_id() kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %0 = sycl.work_group_id : !sycl_id_1_
+      gpu.return
+    }
+
+    // CHECK-LABEL:         gpu.func @test_work_group_id_dim(
+    // CHECK-SAME:                                           %[[VAL_9:.*]]: i32) kernel
+    // CHECK-NEXT:            %[[VAL_10:.*]] = spirv.mlir.addressof @[[WI]] : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-NEXT:            %[[VAL_11:.*]] = spirv.Load "Input" %[[VAL_10]] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_12:.*]] = arith.constant dense<0> : vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_14:.*]] = spirv.CompositeExtract %[[VAL_11]][0 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_15:.*]] = arith.index_cast %[[VAL_14]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_16:.*]] = vector.insert %[[VAL_15]], %[[VAL_12]] [0] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_17:.*]] = spirv.CompositeExtract %[[VAL_11]][1 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_18:.*]] = arith.index_cast %[[VAL_17]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_19:.*]] = vector.insert %[[VAL_18]], %[[VAL_16]] [1] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_20:.*]] = spirv.CompositeExtract %[[VAL_11]][2 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_21:.*]] = arith.index_cast %[[VAL_20]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_22:.*]] = vector.insert %[[VAL_21]], %[[VAL_19]] [2] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_23:.*]] = vector.extractelement %[[VAL_22]]{{\[}}%[[VAL_9]] : i32] : vector<3xindex>
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
+    gpu.func @test_work_group_id_dim(%i: i32) kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %0 = sycl.work_group_id %i : index
+      gpu.return
+    }
+
+    // CHECK-LABEL:         gpu.func @test_num_work_items() kernel
+    // CHECK-NEXT:            %[[VAL_0:.*]] = spirv.mlir.addressof @[[NWI]] : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-NEXT:            %[[VAL_1:.*]] = spirv.Load "Input" %[[VAL_0]] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_2:.*]] = memref.alloca() : memref<1x!sycl_range_1_>
+    // CHECK-NEXT:            %[[VAL_3:.*]] = arith.constant 0 : index
+    // CHECK-NEXT:            %[[VAL_5:.*]] = arith.constant 0 : i32
+    // CHECK-NEXT:            %[[VAL_6:.*]] = spirv.CompositeExtract %[[VAL_1]][0 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
+    // CHECK-NEXT:            %[[VAL_8:.*]] = sycl.range.get %[[VAL_2]][%[[VAL_5]]] {ArgumentTypes = [memref<1x!sycl_range_1_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_1_>, i32) -> memref<1xi64>
+    // CHECK-NEXT:            memref.store %[[VAL_7]], %[[VAL_8]]{{\[}}%[[VAL_3]]] : memref<1xi64>
+    // CHECK-NEXT:            %[[VAL_4:.*]] = memref.load %[[VAL_2]]{{\[}}%[[VAL_3]]] : memref<1x!sycl_range_1_>
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
+    gpu.func @test_num_work_items() kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %0 = sycl.num_work_items : !sycl_range_1_
+      gpu.return
+    }
+
+    // CHECK-LABEL:         gpu.func @test_num_work_items_dim(
+    // CHECK-SAME:                                           %[[VAL_9:.*]]: i32) kernel
+    // CHECK-NEXT:            %[[VAL_10:.*]] = spirv.mlir.addressof @[[NWI]] : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-NEXT:            %[[VAL_11:.*]] = spirv.Load "Input" %[[VAL_10]] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_12:.*]] = arith.constant dense<0> : vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_14:.*]] = spirv.CompositeExtract %[[VAL_11]][0 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_15:.*]] = arith.index_cast %[[VAL_14]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_16:.*]] = vector.insert %[[VAL_15]], %[[VAL_12]] [0] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_17:.*]] = spirv.CompositeExtract %[[VAL_11]][1 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_18:.*]] = arith.index_cast %[[VAL_17]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_19:.*]] = vector.insert %[[VAL_18]], %[[VAL_16]] [1] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_20:.*]] = spirv.CompositeExtract %[[VAL_11]][2 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_21:.*]] = arith.index_cast %[[VAL_20]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_22:.*]] = vector.insert %[[VAL_21]], %[[VAL_19]] [2] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_23:.*]] = vector.extractelement %[[VAL_22]]{{\[}}%[[VAL_9]] : i32] : vector<3xindex>
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
+    gpu.func @test_num_work_items_dim(%i: i32) kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %0 = sycl.num_work_items %i : index
+      gpu.return
+    }
+
+    // CHECK-LABEL:         gpu.func @test_work_group_size() kernel
+    // CHECK-NEXT:            %[[VAL_0:.*]] = spirv.mlir.addressof @[[WGS]] : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-NEXT:            %[[VAL_1:.*]] = spirv.Load "Input" %[[VAL_0]] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_2:.*]] = memref.alloca() : memref<1x!sycl_range_1_>
+    // CHECK-NEXT:            %[[VAL_3:.*]] = arith.constant 0 : index
+    // CHECK-NEXT:            %[[VAL_5:.*]] = arith.constant 0 : i32
+    // CHECK-NEXT:            %[[VAL_6:.*]] = spirv.CompositeExtract %[[VAL_1]][0 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
+    // CHECK-NEXT:            %[[VAL_8:.*]] = sycl.range.get %[[VAL_2]][%[[VAL_5]]] {ArgumentTypes = [memref<1x!sycl_range_1_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_1_>, i32) -> memref<1xi64>
+    // CHECK-NEXT:            memref.store %[[VAL_7]], %[[VAL_8]]{{\[}}%[[VAL_3]]] : memref<1xi64>
+    // CHECK-NEXT:            %[[VAL_4:.*]] = memref.load %[[VAL_2]]{{\[}}%[[VAL_3]]] : memref<1x!sycl_range_1_>
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
+    gpu.func @test_work_group_size() kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %0 = sycl.work_group_size : !sycl_range_1_
+      gpu.return
+    }
+
+    // CHECK-LABEL:         gpu.func @test_work_group_size_dim(
+    // CHECK-SAME:                                           %[[VAL_9:.*]]: i32) kernel
+    // CHECK-NEXT:            %[[VAL_10:.*]] = spirv.mlir.addressof @[[WGS]] : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-NEXT:            %[[VAL_11:.*]] = spirv.Load "Input" %[[VAL_10]] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_12:.*]] = arith.constant dense<0> : vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_14:.*]] = spirv.CompositeExtract %[[VAL_11]][0 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_15:.*]] = arith.index_cast %[[VAL_14]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_16:.*]] = vector.insert %[[VAL_15]], %[[VAL_12]] [0] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_17:.*]] = spirv.CompositeExtract %[[VAL_11]][1 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_18:.*]] = arith.index_cast %[[VAL_17]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_19:.*]] = vector.insert %[[VAL_18]], %[[VAL_16]] [1] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_20:.*]] = spirv.CompositeExtract %[[VAL_11]][2 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_21:.*]] = arith.index_cast %[[VAL_20]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_22:.*]] = vector.insert %[[VAL_21]], %[[VAL_19]] [2] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_23:.*]] = vector.extractelement %[[VAL_22]]{{\[}}%[[VAL_9]] : i32] : vector<3xindex>
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
+    gpu.func @test_work_group_size_dim(%i: i32) kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %0 = sycl.work_group_size %i : index
+      gpu.return
+    }
+
+    // CHECK-LABEL:         gpu.func @test_local_id() kernel
+    // CHECK-NEXT:            %[[VAL_0:.*]] = spirv.mlir.addressof @[[LII]] : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-NEXT:            %[[VAL_1:.*]] = spirv.Load "Input" %[[VAL_0]] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_2:.*]] = memref.alloca() : memref<1x!sycl_id_1_>
+    // CHECK-NEXT:            %[[VAL_3:.*]] = arith.constant 0 : index
+    // CHECK-NEXT:            %[[VAL_5:.*]] = arith.constant 0 : i32
+    // CHECK-NEXT:            %[[VAL_6:.*]] = spirv.CompositeExtract %[[VAL_1]][0 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
+    // CHECK-NEXT:            %[[VAL_8:.*]] = sycl.id.get %[[VAL_2]][%[[VAL_5]]] {ArgumentTypes = [memref<1x!sycl_id_1_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_1_>, i32) -> memref<1xi64>
+    // CHECK-NEXT:            memref.store %[[VAL_7]], %[[VAL_8]]{{\[}}%[[VAL_3]]] : memref<1xi64>
+    // CHECK-NEXT:            %[[VAL_4:.*]] = memref.load %[[VAL_2]]{{\[}}%[[VAL_3]]] : memref<1x!sycl_id_1_>
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
+    gpu.func @test_local_id() kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %0 = sycl.local_id : !sycl_id_1_
+      gpu.return
+    }
+
+    // CHECK-LABEL:         gpu.func @test_local_id_dim(
+    // CHECK-SAME:                                           %[[VAL_9:.*]]: i32) kernel
+    // CHECK-NEXT:            %[[VAL_10:.*]] = spirv.mlir.addressof @[[LII]] : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-NEXT:            %[[VAL_11:.*]] = spirv.Load "Input" %[[VAL_10]] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_12:.*]] = arith.constant dense<0> : vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_14:.*]] = spirv.CompositeExtract %[[VAL_11]][0 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_15:.*]] = arith.index_cast %[[VAL_14]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_16:.*]] = vector.insert %[[VAL_15]], %[[VAL_12]] [0] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_17:.*]] = spirv.CompositeExtract %[[VAL_11]][1 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_18:.*]] = arith.index_cast %[[VAL_17]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_19:.*]] = vector.insert %[[VAL_18]], %[[VAL_16]] [1] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_20:.*]] = spirv.CompositeExtract %[[VAL_11]][2 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_21:.*]] = arith.index_cast %[[VAL_20]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_22:.*]] = vector.insert %[[VAL_21]], %[[VAL_19]] [2] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_23:.*]] = vector.extractelement %[[VAL_22]]{{\[}}%[[VAL_9]] : i32] : vector<3xindex>
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
+    gpu.func @test_local_id_dim(%i: i32) kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %0 = sycl.local_id %i : index
+      gpu.return
+    }
+
+    // CHECK-LABEL:         gpu.func @test_global_id() kernel
+    // CHECK-NEXT:            %[[VAL_0:.*]] = spirv.mlir.addressof @[[GII]] : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-NEXT:            %[[VAL_1:.*]] = spirv.Load "Input" %[[VAL_0]] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_2:.*]] = memref.alloca() : memref<1x!sycl_id_1_>
+    // CHECK-NEXT:            %[[VAL_3:.*]] = arith.constant 0 : index
+    // CHECK-NEXT:            %[[VAL_5:.*]] = arith.constant 0 : i32
+    // CHECK-NEXT:            %[[VAL_6:.*]] = spirv.CompositeExtract %[[VAL_1]][0 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
+    // CHECK-NEXT:            %[[VAL_8:.*]] = sycl.id.get %[[VAL_2]][%[[VAL_5]]] {ArgumentTypes = [memref<1x!sycl_id_1_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_1_>, i32) -> memref<1xi64>
+    // CHECK-NEXT:            memref.store %[[VAL_7]], %[[VAL_8]]{{\[}}%[[VAL_3]]] : memref<1xi64>
+    // CHECK-NEXT:            %[[VAL_4:.*]] = memref.load %[[VAL_2]]{{\[}}%[[VAL_3]]] : memref<1x!sycl_id_1_>
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
+    gpu.func @test_global_id() kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %0 = sycl.global_id : !sycl_id_1_
+      gpu.return
+    }
+
+    // CHECK-LABEL:         gpu.func @test_global_id_dim(
+    // CHECK-SAME:                                           %[[VAL_9:.*]]: i32) kernel
+    // CHECK-NEXT:            %[[VAL_10:.*]] = spirv.mlir.addressof @[[GII]] : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-NEXT:            %[[VAL_11:.*]] = spirv.Load "Input" %[[VAL_10]] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_12:.*]] = arith.constant dense<0> : vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_14:.*]] = spirv.CompositeExtract %[[VAL_11]][0 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_15:.*]] = arith.index_cast %[[VAL_14]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_16:.*]] = vector.insert %[[VAL_15]], %[[VAL_12]] [0] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_17:.*]] = spirv.CompositeExtract %[[VAL_11]][1 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_18:.*]] = arith.index_cast %[[VAL_17]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_19:.*]] = vector.insert %[[VAL_18]], %[[VAL_16]] [1] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_20:.*]] = spirv.CompositeExtract %[[VAL_11]][2 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_21:.*]] = arith.index_cast %[[VAL_20]] : i32 to index
+    // CHECK-NEXT:            %[[VAL_22:.*]] = vector.insert %[[VAL_21]], %[[VAL_19]] [2] : index into vector<3xindex>
+    // CHECK-NEXT:            %[[VAL_23:.*]] = vector.extractelement %[[VAL_22]]{{\[}}%[[VAL_9]] : i32] : vector<3xindex>
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
+    gpu.func @test_global_id_dim(%i: i32) kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %0 = sycl.global_id %i : index
+      gpu.return
+    }
+
     // CHECK-LABEL:         gpu.func @test_sub_group_max_size() kernel
     // CHECK-NEXT:            %[[VAL_52:.*]] = spirv.mlir.addressof @[[SMS]] : !spirv.ptr<i32, Input>
     // CHECK-NEXT:            %[[VAL_53:.*]] = spirv.Load "Input" %[[VAL_52]] : i32
@@ -119,6 +338,39 @@ module attributes {gpu.container_module} {
     gpu.func @test_sub_group_local_id() kernel
       attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       %0 = sycl.sub_group_local_id : i32
+      gpu.return
+    }
+
+    // CHECK-LABEL:         gpu.func @test_sub_group_id() kernel
+    // CHECK-NEXT:            %[[VAL_54:.*]] = spirv.mlir.addressof @[[SI]] : !spirv.ptr<i32, Input>
+    // CHECK-NEXT:            %[[VAL_55:.*]] = spirv.Load "Input" %[[VAL_54]] : i32
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
+    gpu.func @test_sub_group_id() kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %0 = sycl.sub_group_id : i32
+      gpu.return
+    }
+
+    // CHECK-LABEL:         gpu.func @test_num_sub_groups() kernel
+    // CHECK-NEXT:            %[[VAL_54:.*]] = spirv.mlir.addressof @[[NS]] : !spirv.ptr<i32, Input>
+    // CHECK-NEXT:            %[[VAL_55:.*]] = spirv.Load "Input" %[[VAL_54]] : i32
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
+    gpu.func @test_num_sub_groups() kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %0 = sycl.num_sub_groups : i32
+      gpu.return
+    }
+
+    // CHECK-LABEL:         gpu.func @test_sub_group_size() kernel
+    // CHECK-NEXT:            %[[VAL_54:.*]] = spirv.mlir.addressof @[[SS]] : !spirv.ptr<i32, Input>
+    // CHECK-NEXT:            %[[VAL_55:.*]] = spirv.Load "Input" %[[VAL_54]] : i32
+    // CHECK-NEXT:            gpu.return
+    // CHECK-NEXT:          }
+    gpu.func @test_sub_group_size() kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %0 = sycl.sub_group_size : i32
       gpu.return
     }
   }

--- a/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
@@ -346,6 +346,7 @@ static Type convertBoolMemrefType(const spirv::TargetEnv &targetEnv,
     return nullptr;
   }
 
+
   if (!type.hasStaticShape()) {
     // For OpenCL Kernel, dynamic shaped memrefs convert into a pointer pointing
     // to the element.
@@ -412,6 +413,7 @@ static Type convertMemrefType(const spirv::TargetEnv &targetEnv,
                << type << " illegal: cannot deduce converted element size\n");
     return nullptr;
   }
+
 
   if (!type.hasStaticShape()) {
     // For OpenCL Kernel, dynamic shaped memrefs convert into a pointer pointing

--- a/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
@@ -346,7 +346,6 @@ static Type convertBoolMemrefType(const spirv::TargetEnv &targetEnv,
     return nullptr;
   }
 
-
   if (!type.hasStaticShape()) {
     // For OpenCL Kernel, dynamic shaped memrefs convert into a pointer pointing
     // to the element.
@@ -413,7 +412,6 @@ static Type convertMemrefType(const spirv::TargetEnv &targetEnv,
                << type << " illegal: cannot deduce converted element size\n");
     return nullptr;
   }
-
 
   if (!type.hasStaticShape()) {
     // For OpenCL Kernel, dynamic shaped memrefs convert into a pointer pointing
@@ -594,7 +592,8 @@ getOrInsertBuiltinVariable(Block &body, Location loc, spirv::BuiltIn builtin,
   case spirv::BuiltIn::WorkgroupId:
   case spirv::BuiltIn::LocalInvocationId:
   case spirv::BuiltIn::GlobalInvocationId:
-  case spirv::BuiltIn::GlobalOffset: {
+  case spirv::BuiltIn::GlobalOffset:
+  case spirv::BuiltIn::GlobalSize: {
     auto ptrType = spirv::PointerType::get(VectorType::get({3}, integerType),
                                            spirv::StorageClass::Input);
     std::string name = getBuiltinVarName(builtin);


### PR DESCRIPTION
- `-convert-sycl-to-llvm`: Do not use `SYCLToGPU` to run the pass in a single take. Our conversion to LLVM patterns are not idempotent, so this was causing issues.
- `-convert-sycl-to-spirv`: Add missing patterns to make it complete.
- `-convert-sycl-to-gpu`: Conversion of `sycl.num_work_items` to GPU dropped, as it was incorrect and there's no counterpart operation in the `gpu` dialect.