### PR TITLE
[SYCL] Do not track allocation if we don't own the handle

### DIFF
--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -3344,6 +3344,10 @@ pi_result piextMemCreateWithNativeHandle(pi_native_handle NativeHandle,
     pi_platform Plt = Context->getPlatform();
     std::unique_lock<pi_shared_mutex> ContextsLock(Plt->ContextsMutex,
                                                    std::defer_lock);
+    // If we don't own the native handle then we can't control deallocation of
+    // that memory so there is no point of keeping track of the memory
+    // allocation for deferred memory release in the mode when indirect access
+    // tracking is enabled.
     if (IndirectAccessTrackingEnabled && ownNativeHandle) {
       // We need to keep track of all memory allocations in the context
       ContextsLock.lock();


### PR DESCRIPTION
If we don't own level zero handle of the pi_mem then we can't control deallocation of that memory so there is no point of keeping track of the memory allocation for deferred memory release. More over currently level zero context is leaked because we increase its ref count at the point where we start tracking memory but don't decrement that ref count in USMFreeHelper. This PR fixes that problem.