### PR TITLE
[DOC] Fix MD so it works in fork; Solve MD lint issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ Project documentation is available at:
 #### Docker containers
 
 See available containers with pre-built/pre-installed DPC++ compiler at:
-[Containers](/../sycl/sycl/doc/developer/DockerBKMs.md#sycl-containers-overview)
+[Containers](./sycl/doc/developer/DockerBKMs.md#sycl-containers-overview)
 
 #### Releases
 
 Daily builds of the sycl branch on Linux are available at
-[releases](/../../releases).
-A few times a year, we publish [Release Notes](/../sycl/sycl/ReleaseNotes.md) to
+[releases](https://github.com/intel/llvm//releases).
+A few times a year, we publish [Release Notes](./sycl/ReleaseNotes.md) to
 highlight all important changes made in the project: features implemented and
 issues addressed. The corresponding builds can be found using
 [search](https://github.com/intel/llvm/releases?q=oneAPI+DPC%2B%2B+Compiler&expanded=true)
@@ -65,22 +65,22 @@ expected to be similar to the daily releases.
 
 #### Build from sources
 
-See [Get Started Guide](/../sycl/sycl/doc/GetStartedGuide.md).
+See [Get Started Guide](./sycl/doc/GetStartedGuide.md).
 
 ### Report a problem
 
-Submit an [issue](/../../issues) or initiate a [discussion](/../../discussions).
+Submit an [issue](https://github.com/intel/llvm/issues) or initiate a [discussion](https://github.com/intel/llvm/discussions).
 
 ### How to contribute to DPC++
 
-See [ContributeToDPCPP](/../sycl/sycl/doc/developer/ContributeToDPCPP.md).
+See [ContributeToDPCPP](./sycl/doc/developer/ContributeToDPCPP.md).
 
 ## Late-outline OpenMP\* and OpenMP\* Offload
 
-See [openmp](/../../tree/openmp) branch.
+See [openmp](/tree/openmp) branch.
 
 # License
 
-See [LICENSE](/../sycl/sycl/LICENSE.TXT) for details.
+See [LICENSE](./sycl/sycl/LICENSE.TXT) for details.
 
 <sub>\*Other names and brands may be claimed as the property of others.</sub>

--- a/README.md
+++ b/README.md
@@ -81,6 +81,6 @@ See [openmp](/tree/openmp) branch.
 
 # License
 
-See [LICENSE](./sycl/sycl/LICENSE.TXT) for details.
+See [LICENSE](./sycl/LICENSE.TXT) for details.
 
 <sub>\*Other names and brands may be claimed as the property of others.</sub>

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ For general contribution process see [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 The DPC++ is a LLVM-based compiler project that implements compiler and runtime
 support for the SYCL\* language. The project is hosted in the
-[sycl](https://github.com/intel/llvm/tree/sycl) branch and is synced with the tip of the LLVM upstream
-main branch on a regular basis (revisions delay is usually not more than 1-2
-weeks). DPC++ compiler takes everything from LLVM upstream as is, however some
-modules of LLVM might be not included in the default project build
-configuration. Additional modules can be enabled by modifying build framework
-settings.
+[sycl](https://github.com/intel/llvm/tree/sycl) branch and is synced with the
+tip of the LLVM upstream main branch on a regular basis (revisions delay is
+usually not more than 1-2 weeks). DPC++ compiler takes everything from LLVM
+upstream as is, however some modules of LLVM might be not included in the
+default project build configuration. Additional modules can be enabled by
+modifying build framework settings.
 
 The DPC++ goal is to support the latest SYCL\* standard and work on that is in
 progress. DPC++ also implements a number of extensions to the SYCL\* standard,
@@ -54,7 +54,7 @@ See available containers with pre-built/pre-installed DPC++ compiler at:
 #### Releases
 
 Daily builds of the sycl branch on Linux are available at
-[releases](https://github.com/intel/llvm//releases).
+[releases](https://github.com/intel/llvm/releases).
 A few times a year, we publish [Release Notes](./sycl/ReleaseNotes.md) to
 highlight all important changes made in the project: features implemented and
 issues addressed. The corresponding builds can be found using

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ See [Get Started Guide](./sycl/doc/GetStartedGuide.md).
 
 ### Report a problem
 
-Submit an [issue](https://github.com/intel/llvm/issues) or initiate a [discussion](https://github.com/intel/llvm/discussions).
+Submit an [issue](https://github.com/intel/llvm/issues) or initiate a 
+[discussion](https://github.com/intel/llvm/discussions).
 
 ### How to contribute to DPC++
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ For general contribution process see [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ## oneAPI DPC++ compiler
 
-[![](https://spec.oneapi.io/oneapi-logo-white-scaled.jpg)](https://www.oneapi.io/)
+[![oneAPI logo](https://spec.oneapi.io/oneapi-logo-white-scaled.jpg)](https://www.oneapi.io/)
 
 [![SYCL Post Commit](https://github.com/intel/llvm/actions/workflows/sycl_post_commit.yml/badge.svg?branch=sycl)](https://github.com/intel/llvm/actions/workflows/sycl_post_commit.yml)
 [![Generate Doxygen documentation](https://github.com/intel/llvm/actions/workflows/gh_pages.yml/badge.svg?branch=sycl)](https://github.com/intel/llvm/actions/workflows/gh_pages.yml)
 
 The DPC++ is a LLVM-based compiler project that implements compiler and runtime
 support for the SYCL\* language. The project is hosted in the
-[sycl](/../../tree/sycl) branch and is synced with the tip of the LLVM upstream
+[sycl](https://github.com/intel/llvm/tree/sycl) branch and is synced with the tip of the LLVM upstream
 main branch on a regular basis (revisions delay is usually not more than 1-2
 weeks). DPC++ compiler takes everything from LLVM upstream as is, however some
 modules of LLVM might be not included in the default project build
@@ -24,7 +24,7 @@ settings.
 
 The DPC++ goal is to support the latest SYCL\* standard and work on that is in
 progress. DPC++ also implements a number of extensions to the SYCL\* standard,
-which can be found in the [sycl/doc/extensions](/../sycl/sycl/doc/extensions)
+which can be found in the [sycl/doc/extensions](./sycl/doc/extensions)
 directory.
 
 The main purpose of this project is open source collaboration on the DPC++
@@ -32,7 +32,7 @@ compiler implementation in LLVM across a variety of architectures, prototyping
 compiler and runtime library solutions, designing future extensions, and
 conducting experiments. As the implementation becomes more mature, we try to
 upstream as much DPC++ support to LLVM main branch as possible. See
-[SYCL upstreaming working group notes](/../../wiki/SYCL-upstreaming-working-group-meeting-notes)
+[SYCL upstreaming working group notes](https://github.com/intel/llvm/wiki/SYCL-upstreaming-working-group-meeting-notes)
 for more details.
 
 Note that this project can be used as a technical foundation for some


### PR DESCRIPTION
* The original relative links were incorrect:
  * The **project** is hosted in the `intel/llvm` repo, but the link could be activated in a fork, which is NOT where the project is hosted.
  * The **wiki** is available in the `intel/llvm` repo, but the link could be clicked in a fork, where the wiki is NOT available.
  * The SYCL **standard extensions** documentation is available in the relative directory `./sycl/doc/extensions`, the original syntax does not follow the GitHub guidelines for relative links.

* The MarkDown linter insists on alternative text for embedded pictures, which was not provided for the oneAPI logo.