### PR TITLE
[SYCL-MLIR] Add `sycl.accessor.get_range`

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -692,6 +692,30 @@ def SYCLAccessorGetPointerOp
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// accessor.range OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLAccessorGetRangeOp
+    : SYCLMethodOpInterfaceImpl<"accessor.get_range", "AccessorType",
+                                ["get_range"]> {
+  let summary = "Represents the accessor get_range operation";
+  let description = [{
+    Returns a range object which represents the number of elements per dimension
+    that this accessor may access.
+  }];
+
+  let arguments = (ins Arg<AccessorMemRef, "The accessor", [MemRead]>:$Acc,
+                       TypeArrayAttr:$ArgumentTypes,
+                       FlatSymbolRefAttr:$FunctionName,
+                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
+                       FlatSymbolRefAttr:$TypeName);
+
+  let hasVerifier = 1;
+
+  let results = (outs SYCL_RangeType:$result);
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // accessor.size OPERATION
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -1105,6 +1105,18 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
+// AccessorSizePattern - Convert `sycl.accessor.get_range` to LLVM.
+//===----------------------------------------------------------------------===//
+
+class AccessorGetRangePattern
+    : public LoadMemberPattern<SYCLAccessorGetRangeOp,
+                               AccessorGetMAccessRange> {
+public:
+  using LoadMemberPattern<SYCLAccessorGetRangeOp,
+                          AccessorGetMAccessRange>::LoadMemberPattern;
+};
+
+//===----------------------------------------------------------------------===//
 // AccessorSizePattern - Convert `sycl.accessor.size` to LLVM.
 //===----------------------------------------------------------------------===//
 
@@ -2148,14 +2160,14 @@ void mlir::populateSYCLToLLVMConversionPatterns(
   patterns.add<CastPattern>(typeConverter);
   patterns.add<BarePtrCastPattern>(typeConverter, /*benefit*/ 2);
   patterns
-      .add<AccessorGetPointerPattern, AccessorSizePattern,
-           AddZeroArgPattern<SYCLIDGetOp>, AddZeroArgPattern<SYCLItemGetIDOp>,
-           AtomicSubscriptIDOffset, BarePtrAddrSpaceCastPattern,
-           GroupGetGroupIDPattern, GroupGetGroupLinearRangePattern,
-           GroupGetGroupRangeDimPattern, GroupGetLocalIDPattern,
-           GroupGetLocalLinearRangePattern, GroupGetLocalRangeDimPattern,
-           IDGetPattern, IDGetRefPattern, ItemGetIDDimPattern,
-           ItemGetRangeDimPattern, ItemGetRangePattern,
+      .add<AccessorGetPointerPattern, AccessorGetRangePattern,
+           AccessorSizePattern, AddZeroArgPattern<SYCLIDGetOp>,
+           AddZeroArgPattern<SYCLItemGetIDOp>, AtomicSubscriptIDOffset,
+           BarePtrAddrSpaceCastPattern, GroupGetGroupIDPattern,
+           GroupGetGroupLinearRangePattern, GroupGetGroupRangeDimPattern,
+           GroupGetLocalIDPattern, GroupGetLocalLinearRangePattern,
+           GroupGetLocalRangeDimPattern, IDGetPattern, IDGetRefPattern,
+           ItemGetIDDimPattern, ItemGetRangeDimPattern, ItemGetRangePattern,
            NDItemGetGlobalIDDimPattern, NDItemGetGlobalIDPattern,
            NDItemGetGroupPattern, NDItemGetGroupRangeDimPattern,
            NDItemGetLocalIDDimPattern, NDItemGetLocalLinearIDPattern,

--- a/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
@@ -92,12 +92,25 @@ bool SYCLAddrSpaceCastOp::areCastCompatible(TypeRange inputs,
 LogicalResult SYCLAccessorGetPointerOp::verify() {
   const auto accTy = cast<AccessorType>(
       cast<MemRefType>(getOperand().getType()).getElementType());
-  const Type resTy = getResult().getType();
-  const Type resElemTy = cast<MemRefType>(resTy).getElementType();
+  const MemRefType resTy = getResult().getType();
+  const Type resElemTy = resTy.getElementType();
   return (resElemTy != accTy.getType())
              ? emitOpError(
                    "Expecting a reference to this accessor's value type (")
                    << accTy.getType() << "). Got " << resTy
+             : success();
+}
+
+LogicalResult SYCLAccessorGetRangeOp::verify() {
+  const auto accTy = cast<AccessorType>(
+      cast<MemRefType>(getOperand().getType()).getElementType());
+  const auto accRangeTy = cast<RangeType>(
+      cast<AccessorImplDeviceType>(accTy.getBody()[0]).getBody()[1]);
+  const RangeType resTy = getResult().getType();
+  return (accRangeTy != resTy)
+             ? emitOpError(
+                   "Expecting a reference to this accessor's range type (")
+                   << accRangeTy << "). Got " << resTy
              : success();
 }
 

--- a/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
@@ -109,8 +109,9 @@ LogicalResult SYCLAccessorGetRangeOp::verify() {
              ? emitOpError(
                    "Both the result and the accessor must have the same "
                    "number of dimensions, but the accessor has ")
-                   << accTy.getDimension() << " dimensions and the result, "
-                   << resTy.getDimension()
+                   << accTy.getDimension()
+                   << " dimension(s) and the result has "
+                   << resTy.getDimension() << " dimension(s)"
              : success();
 }
 
@@ -167,8 +168,8 @@ LogicalResult SYCLAccessorSubscriptOp::verify() {
                    ? emitOpError(
                          "Both the index and the accessor must have the same "
                          "number of dimensions, but the accessor has ")
-                         << Dimensions << "dimensions and the index, "
-                         << IDTy.getDimension()
+                         << Dimensions << " dimension(s) and the index has "
+                         << IDTy.getDimension() << " dimension(s)"
                    : VerifyResultType();
       })
       .Case<IntegerType>([&](auto) {

--- a/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLOps.cpp
@@ -104,13 +104,13 @@ LogicalResult SYCLAccessorGetPointerOp::verify() {
 LogicalResult SYCLAccessorGetRangeOp::verify() {
   const auto accTy = cast<AccessorType>(
       cast<MemRefType>(getOperand().getType()).getElementType());
-  const auto accRangeTy = cast<RangeType>(
-      cast<AccessorImplDeviceType>(accTy.getBody()[0]).getBody()[1]);
   const RangeType resTy = getResult().getType();
-  return (accRangeTy != resTy)
+  return (accTy.getDimension() != resTy.getDimension())
              ? emitOpError(
-                   "Expecting a reference to this accessor's range type (")
-                   << accRangeTy << "). Got " << resTy
+                   "Both the result and the accessor must have the same "
+                   "number of dimensions, but the accessor has ")
+                   << accTy.getDimension() << " dimensions and the result, "
+                   << resTy.getDimension()
              : success();
 }
 

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -167,23 +167,45 @@ func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> memref<?xi64> {
 
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[ACCESSOR1:.*]]>) -> !llvm.ptr<i32, 1> {
-// CHECK-NEXT:      %0 = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %1 = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %2 = llvm.getelementptr inbounds %arg0[0, 0, 2, 0, 0, 0] : (!llvm.ptr<[[ACCESSOR1]]>) -> !llvm.ptr<i64>
-// CHECK-NEXT:      %3 = llvm.load %2 : !llvm.ptr<i64>
-// CHECK-NEXT:      %4 = llvm.getelementptr inbounds %arg0[0, 0, 0, 0, 0, 0] : (!llvm.ptr<[[ACCESSOR1]]>) -> !llvm.ptr<i64>
-// CHECK-NEXT:      %5 = llvm.load %4 : !llvm.ptr<i64>
-// CHECK-NEXT:      %6 = llvm.mul %1, %3  : i64
-// CHECK-NEXT:      %7 = llvm.add %6, %5  : i64
-// CHECK-NEXT:      %8 = llvm.sub %0, %7  : i64
-// CHECK-NEXT:      %9 = llvm.getelementptr inbounds %arg0[0, 1, 0] : (!llvm.ptr<[[ACCESSOR1]]>) -> !llvm.ptr<ptr<i32, 1>>
-// CHECK-NEXT:      %10 = llvm.load %9 : !llvm.ptr<ptr<i32, 1>>
-// CHECK-NEXT:      %11 = llvm.getelementptr inbounds %10[%8] : (!llvm.ptr<i32, 1>, i64) -> !llvm.ptr<i32, 1>
-// CHECK-NEXT:      llvm.return %11 : !llvm.ptr<i32, 1>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr<[[ACCESSOR1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 0, 0, 0] : (!llvm.ptr<[[ACCESSOR1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]]  : i64
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.add %[[VAL_7]], %[[VAL_6]]  : i64
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.sub %[[VAL_1]], %[[VAL_8]] : i64
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr<[[ACCESSOR1]]>) -> !llvm.ptr<ptr<i32, 1>>
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.load %[[VAL_10]] : !llvm.ptr<ptr<i32, 1>>
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_11]][%[[VAL_9]]] : (!llvm.ptr<i32, 1>, i64) -> !llvm.ptr<i32, 1>
+// CHECK-NEXT:      llvm.return %[[VAL_12]] : !llvm.ptr<i32, 1>
 // CHECK-NEXT:    }
 func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1> {
   %0 = sycl.accessor.get_pointer(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>], FunctionName = @"get_pointer", MangledFunctionName = @"get_pointer", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
+}
+
+// -----
+
+//===-------------------------------------------------------------------------------------------------===//
+// sycl.accessor.get_range
+//===-------------------------------------------------------------------------------------------------===//
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
+!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+
+// CHECK-LABEL:   llvm.func @test(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[ACCESSOR1:.*]]>) -> !llvm.[[RANGE1:.*]] {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 1] : (!llvm.ptr<[[ACCESSOR1]]>) -> !llvm.ptr<[[RANGE1]]>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<[[RANGE1]]>
+// CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.[[RANGE1]]
+// CHECK-NEXT:    }
+func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_1_ {
+  %0 = sycl.accessor.get_range(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>], FunctionName = @"get_range", MangledFunctionName = @"get_range", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_1_
+  return %0 : !sycl_range_1_
 }
 
 // -----
@@ -200,7 +222,7 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1> 
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[ACCESSOR1:.*]]>) -> i64 {
 // CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %arg0[0, 0, 1, 0, 0, 0] : (!llvm.ptr<[[ACCESSOR1]]>) -> !llvm.ptr<i64>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 1, 0, 0, 0] : (!llvm.ptr<[[ACCESSOR1]]>) -> !llvm.ptr<i64>
 // CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<i64>
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mul %[[VAL_1]], %[[VAL_3]]  : i64
 // CHECK-NEXT:      llvm.return %[[VAL_4]] : i64

--- a/mlir-sycl/test/Dialect/IR/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/invalid.mlir
@@ -280,7 +280,7 @@ func.func @test_accessor_get_pointer(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>)
 !sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
 
 func.func @test_accessor_get_range(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_2_ {
-  // expected-error @+1 {{'sycl.accessor.get_range' op Expecting a reference to this accessor's range type}}
+  // expected-error @+1 {{'sycl.accessor.get_range' op Both the result and the accessor must have the same number of dimensions, but the accessor has 1 dimensions and the result, 2}}
   %0 = sycl.accessor.get_range(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>], FunctionName = @"get_range", MangledFunctionName = @"get_range", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_2_
   return %0 : !sycl_range_2_
 }

--- a/mlir-sycl/test/Dialect/IR/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/invalid.mlir
@@ -273,6 +273,20 @@ func.func @test_accessor_get_pointer(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>)
 
 // -----
 
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
+!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+
+func.func @test_accessor_get_range(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_2_ {
+  // expected-error @+1 {{'sycl.accessor.get_range' op Expecting a reference to this accessor's range type}}
+  %0 = sycl.accessor.get_range(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>], FunctionName = @"get_range", MangledFunctionName = @"get_range", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_2_
+  return %0 : !sycl_range_2_
+}
+
+// -----
+
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>

--- a/mlir-sycl/test/Dialect/IR/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/invalid.mlir
@@ -280,7 +280,7 @@ func.func @test_accessor_get_pointer(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>)
 !sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
 
 func.func @test_accessor_get_range(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_2_ {
-  // expected-error @+1 {{'sycl.accessor.get_range' op Both the result and the accessor must have the same number of dimensions, but the accessor has 1 dimensions and the result, 2}}
+  // expected-error @+1 {{'sycl.accessor.get_range' op Both the result and the accessor must have the same number of dimensions, but the accessor has 1 dimension(s) and the result has 2 dimension(s)}}
   %0 = sycl.accessor.get_range(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>], FunctionName = @"get_range", MangledFunctionName = @"get_range", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_2_
   return %0 : !sycl_range_2_
 }

--- a/mlir-sycl/test/Dialect/IR/SYCL/ops.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/ops.mlir
@@ -266,6 +266,12 @@ func.func @test_accessor_get_pointer(%acc: memref<?x!sycl_accessor_1_i32_w_gb>) 
   return %0 : memref<?xi32, 1>
 }
 
+// CHECL-LABEL: test_accessor_get_range
+func.func @test_accessor_get_range(%acc: memref<?x!sycl_accessor_1_i32_w_gb>) -> !sycl_range_1_ {
+  %0 = sycl.accessor.get_range(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_w_gb>], FunctionName = @"get_range", MangledFunctionName = @"get_range", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_w_gb>) -> !sycl_range_1_
+  return %0 : !sycl_range_1_
+}
+
 // CHECK-LABEL: test_accessor_subscript_atomic
 func.func @test_accessor_subscript_atomic(
   %acc: memref<?x!sycl_accessor_1_i32_ato_gb>, 

--- a/mlir-sycl/test/Dialect/IR/SYCL/ops.mlir
+++ b/mlir-sycl/test/Dialect/IR/SYCL/ops.mlir
@@ -260,13 +260,13 @@ func.func @test_work_group_id_const() -> index {
   return %0 : index
 }
 
-// CHECL-LABEL: test_accessor_get_pointer
+// CHECK-LABEL: test_accessor_get_pointer
 func.func @test_accessor_get_pointer(%acc: memref<?x!sycl_accessor_1_i32_w_gb>) -> memref<?xi32, 1> {
   %0 = sycl.accessor.get_pointer(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_w_gb>], FunctionName = @"get_pointer", MangledFunctionName = @"get_pointer", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_w_gb>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
-// CHECL-LABEL: test_accessor_get_range
+// CHECK-LABEL: test_accessor_get_range
 func.func @test_accessor_get_range(%acc: memref<?x!sycl_accessor_1_i32_w_gb>) -> !sycl_range_1_ {
   %0 = sycl.accessor.get_range(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_w_gb>], FunctionName = @"get_range", MangledFunctionName = @"get_range", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_w_gb>) -> !sycl_range_1_
   return %0 : !sycl_range_1_

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -57,6 +57,18 @@ SYCL_EXTERNAL void accessor_get_pointer(sycl::accessor<sycl::cl_int, 2> acc) {
   keep(acc.get_pointer());
 }
 
+// CHECK-MLIR-LABEL: func.func @_Z18accessor_get_rangeN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
+// CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef})
+// CHECK-MLIR: %{{.*}} = sycl.accessor.get_range(%arg0) {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>], FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE9get_rangeILi2EvEENS0_5rangeILi2EEEv, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> !sycl_range_2_
+
+// CHECK-LLVM-LABEL: define spir_func void @_Z18accessor_get_rangeN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
+// CHECK-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0) #[[FUNCATTRS:[0-9]+]] {
+// CHECK-LLVM:  %{{.*}} = call spir_func %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE9get_rangeILi2EvEENS0_5rangeILi2EEEv(%"class.sycl::_V1::accessor.2" addrspace(4)* %{{.*}})
+
+SYCL_EXTERNAL void accessor_get_range(sycl::accessor<sycl::cl_int, 2> acc) {
+  keep(acc.get_range());
+}
+
 // CHECK-MLIR-LABEL: func.func @_Z13accessor_sizeN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.accessor.size(%arg0) {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>], FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE4sizeEv, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> i64


### PR DESCRIPTION
Returns a range object which represents the number of elements per dimension that this accessor may access.