### PR TITLE
[CI] Don't upload SYCL End-to-End tests results' json

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -228,7 +228,6 @@ jobs:
         sycl_artifact: sycl_linux_${{ inputs.build_artifact_suffix }}
         sycl_archive: llvm_sycl.tar.xz
         check_sycl_all: ${{ matrix.check_sycl_all }}
-        results_name_suffix: ${{ matrix.config }}_${{ inputs.build_artifact_suffix }}
         cmake_args: '${{ matrix.cmake_args }} ${{ inputs.lts_cmake_extra_args }}'
 
   khronos_sycl_cts:

--- a/devops/actions/llvm_test_suite/action.yml
+++ b/devops/actions/llvm_test_suite/action.yml
@@ -12,9 +12,6 @@ inputs:
     description: 'Name of SYCL toolchain archive file'
     required: false
     default: 'llvm_sycl.tar.xz'
-  results_name_suffix:
-    description: 'Name suffix of the results artifact'
-    required: true
   check_sycl_all:
     description: 'List of SYCL backends with set of target devices per each to be tested iteratively'
     required: true
@@ -54,7 +51,7 @@ runs:
       export PATH=$PWD/toolchain/bin/:$PATH
       # TODO make this part of container build
       export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/rocm/hip/lib/:/opt/rocm/lib
-      export LIT_OPTS="-v --no-progress-bar --show-unsupported --max-time 3600 --time-tests -o $PWD/build/results_${{ inputs.results_name_suffix }}.json"
+      export LIT_OPTS="-v --no-progress-bar --show-unsupported --max-time 3600 --time-tests"
       if [ -e /runtimes/oneapi-tbb/env/vars.sh ]; then
         source /runtimes/oneapi-tbb/env/vars.sh;
       elif [ -e /opt/runtimes/oneapi-tbb/env/vars.sh ]; then
@@ -76,12 +73,6 @@ runs:
       SYCL_PI_TRACE=-1 sycl-ls
       echo "::endgroup::"
       ninja -C build-e2e check-sycl-e2e
-  - name: Upload test results
-    uses: actions/upload-artifact@v1
-    if: always()
-    with:
-      name: lit_results
-      path: build/results_${{ inputs.results_name_suffix }}.json
   - name: Cleanup
     shell: bash
     if: always()


### PR DESCRIPTION
Nobody uses it anyway. Should fix pre-commit issue looking like

```
Traceback (most recent call last):
  File "/__w/llvm/llvm/llvm/llvm/utils/lit/lit.py", line 6, in <module>
    main()
  File "/__w/llvm/llvm/llvm/llvm/utils/lit/lit/main.py", line 121, in main
    report.write_results(tests_for_report, elapsed)
  File "/__w/llvm/llvm/llvm/llvm/utils/lit/lit/reports.py", line 68, in write_results
    with open(self.output_file, 'w') as file:
FileNotFoundError: [Errno 2] No such file or directory: '/__w/llvm/llvm/build/results_hip_amdgpu_default.json'
```