### PR TITLE
[SYCL] Updated atomic_memory_order_capabilities query tests for OpenCL and Level Zero backends

### DIFF
--- a/sycl/test-e2e/AtomicRef/atomic_memory_order.cpp
+++ b/sycl/test-e2e/AtomicRef/atomic_memory_order.cpp
@@ -2,11 +2,10 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// L0, OpenCL backends don't currently support
-// info::device::atomic_memory_order_capabilities
-// UNSUPPORTED: level_zero || opencl
 
-// NOTE: General tests for atomic memory order capabilities.
+// This test checks whether the minimum required memory order capabilities are
+// supported in both context and device queries. Specifically the "relaxed"
+// memory order capability, which is used in other tests.
 
 #include "atomic_memory_order.h"
 #include <cassert>
@@ -16,12 +15,18 @@ using namespace sycl;
 int main() {
   queue q;
 
-  std::vector<memory_order> supported_memory_orders =
+  // Context
+  std::vector<memory_order> supported_context_memory_orders =
+      q.get_context()
+          .get_info<info::context::atomic_memory_order_capabilities>();
+
+  assert(is_supported(supported_context_memory_orders, memory_order::relaxed));
+
+  // Device
+  std::vector<memory_order> supported_device_memory_orders =
       q.get_device().get_info<info::device::atomic_memory_order_capabilities>();
 
-  // Relaxed memory order must be supported. This ordering is used in other
-  // tests.
-  assert(is_supported(supported_memory_orders, memory_order::relaxed));
+  assert(is_supported(supported_device_memory_orders, memory_order::relaxed));
 
   std::cout << "Test passed." << std::endl;
 }

--- a/sycl/test-e2e/AtomicRef/atomic_memory_order_acq_rel.cpp
+++ b/sycl/test-e2e/AtomicRef/atomic_memory_order_acq_rel.cpp
@@ -2,9 +2,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// L0, OpenCL, and HIP backends don't currently support
-// info::device::atomic_memory_order_capabilities
-// UNSUPPORTED: level_zero, opencl
 
 // NOTE: Tests fetch_add for acquire and release memory ordering.
 
@@ -14,7 +11,7 @@
 using namespace sycl;
 
 template <memory_order order> void test_acquire_global() {
-  const size_t N_items = 1024;
+  const size_t N_items = 256;
   const size_t N_iters = 1000;
 
   int error = 0;
@@ -56,7 +53,7 @@ template <memory_order order> void test_acquire_global() {
 }
 
 template <memory_order order> void test_acquire_local() {
-  const size_t local_size = 1024;
+  const size_t local_size = 256;
   const size_t N_wgs = 16;
   const size_t global_size = local_size * N_wgs;
   const size_t N_iters = 1000;
@@ -105,7 +102,7 @@ template <memory_order order> void test_acquire_local() {
 }
 
 template <memory_order order> void test_release_global() {
-  const size_t N_items = 1024;
+  const size_t N_items = 256;
   const size_t N_iters = 1000;
 
   int error = 0;
@@ -147,7 +144,7 @@ template <memory_order order> void test_release_global() {
 }
 
 template <memory_order order> void test_release_local() {
-  const size_t local_size = 1024;
+  const size_t local_size = 256;
   const size_t N_wgs = 16;
   const size_t global_size = local_size * N_wgs;
   const size_t N_iters = 1000;

--- a/sycl/test-e2e/AtomicRef/atomic_memory_order_seq_cst.cpp
+++ b/sycl/test-e2e/AtomicRef/atomic_memory_order_seq_cst.cpp
@@ -2,9 +2,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// L0, OpenCL, and HIP backends don't currently support
-// info::device::atomic_memory_order_capabilities
-// UNSUPPORTED: level_zero, opencl
 
 #include "atomic_memory_order.h"
 #include <iostream>


### PR DESCRIPTION
This patch updates the `atomic_memory_order*` E2E tests to include the `level_zero` and `opencl` backends, as these should now return the required memory order capability sets tested in and required by these tests.