### PR TITLE
[SYCL] Change trivially_copyable to device_copyable

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -2345,12 +2345,12 @@ public:
   ///
   /// \param Ptr is the pointer to the memory to fill
   /// \param Pattern is the pattern to fill into the memory.  T should be
-  /// trivially copyable.
+  /// device copyable.
   /// \param Count is the number of times to fill Pattern into Ptr.
   template <typename T> void fill(void *Ptr, const T &Pattern, size_t Count) {
     throwIfActionIsCreated();
-    static_assert(std::is_trivially_copyable<T>::value,
-                  "Pattern must be trivially copyable");
+    static_assert(is_device_copyable<T>::value,
+                  "Pattern must be device copyable");
     parallel_for<class __usmfill<T>>(range<1>(Count), [=](id<1> Index) {
       T *CastedPtr = static_cast<T *>(Ptr);
       CastedPtr[Index] = Pattern;
@@ -2597,15 +2597,15 @@ public:
   /// \param Dest is a USM pointer to the destination memory.
   /// \param DestPitch is the pitch of the rows in \param Dest.
   /// \param Pattern is the pattern to fill into the memory.  T should be
-  /// trivially copyable.
+  /// device copyable.
   /// \param Width is the width in number of elements of the 2D region to fill.
   /// \param Height is the height in number of rows of the 2D region to fill.
   template <typename T>
   void ext_oneapi_fill2d(void *Dest, size_t DestPitch, const T &Pattern,
                          size_t Width, size_t Height) {
     throwIfActionIsCreated();
-    static_assert(std::is_trivially_copyable<T>::value,
-                  "Pattern must be trivially copyable");
+    static_assert(is_device_copyable<T>::value,
+                  "Pattern must be device copyable");
     if (Width > DestPitch)
       throw sycl::exception(sycl::make_error_code(errc::invalid),
                             "Destination pitch must be greater than or equal "

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -2137,6 +2137,8 @@ public:
                   "Invalid accessor target for the copy method.");
     static_assert(isValidModeForDestinationAccessor(AccessMode),
                   "Invalid accessor mode for the copy method.");
+    static_assert(is_device_copyable<T_Src>::value,
+                  "Pattern must be device copyable");
     // Make sure data shared_ptr points to is not released until we finish
     // work with it.
     MSharedPtrStorage.push_back(Src);
@@ -2200,6 +2202,8 @@ public:
                   "Invalid accessor target for the copy method.");
     static_assert(isValidModeForDestinationAccessor(AccessMode),
                   "Invalid accessor mode for the copy method.");
+    static_assert(is_device_copyable<T_Src>::value,
+                  "Pattern must be device copyable");
 #ifndef __SYCL_DEVICE_ONLY__
     if (MIsHost) {
       // TODO: Temporary implementation for host. Should be handled by memory


### PR DESCRIPTION
`cgh.fill(...)` was failing when `T` is a `sycl::vec` type, since `sycl::vec` types have no specialization for `std::is_trivially_copyable`. Since `device_copyable` is a sycl superset of trivially copyable we should use this instead in sycl headers.

I can add a test to check that `cgh.fill` works for vec types if necessary. Let me know if I should do this.

There are some other occurrences of `std::is_trivially_copyable` in the sycl headers. Let me know if I should replace more incidences.