### PR TITLE
[SYCL] Move get_spec_const_vec16 E2E regression test

### DIFF
--- a/sycl/test-e2e/Regression/get_spec_const_vec16.cpp
+++ b/sycl/test-e2e/Regression/get_spec_const_vec16.cpp
@@ -1,0 +1,27 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -o %t.out %s
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+// RUN: %ACC_RUN_PLACEHOLDER %t.out
+//
+// Tests that the right value returned after setting a specialization constant
+// of sycl::vec<char, 16> type is correct.
+
+#include <sycl/sycl.hpp>
+
+#include <algorithm>
+
+constexpr sycl::specialization_id<sycl::vec<char, 16>> spec_const(20);
+
+int main() {
+  sycl::vec<char, 16> Result{0};
+  sycl::vec<char, 16> Ref{5};
+  sycl::queue Q;
+  Q.submit([&](sycl::handler &CGH) {
+    CGH.set_specialization_constant<spec_const>(Ref);
+    Result = CGH.get_specialization_constant<spec_const>();
+  });
+  auto CompRes = Ref == Result;
+  assert(std::all_of(&CompRes[0], &CompRes[0] + 16,
+                     [](const bool &A) { return A; }));
+  return 0;
+}


### PR DESCRIPTION
This commit moves the in-review get_spec_const_vec16.cpp test from the now archived intel/llvm-test-suite repo.

See https://github.com/intel/llvm-test-suite/pull/1634.