### PR TITLE
[SYCL][Doc] Fix compiler define name in sycl/test-e2e/README.md

### DIFF
--- a/sycl/test-e2e/README.md
+++ b/sycl/test-e2e/README.md
@@ -38,7 +38,7 @@ With compiler tools available in the PATH:
 ```
 # Configure
 cmake \
- -DSYCL_CXX_COMPILER=clang++ \
+ -DCMAKE_CXX_COMPILER=clang++ \
  -DSYCL_TEST_E2E_TARGETS="opencl:cpu" \
  ..
 
@@ -71,7 +71,7 @@ CC=<> CXX=<> python llvm/buildbot/configure.py -o build ... \
 
 These parameters can be used to configure tests:
 
-***SYCL_CXX_COMPILER*** - path to DPCPP compiler
+***CMAKE_CXX_COMPILER*** - path to DPCPP compiler
 
 ***TEST_SUITE_LLVM_SIZE*** - path to llvm-size tool, required for code size
 collection


### PR DESCRIPTION
SYCL_CXX_COMPILER -> CMAKE_CXX_COMPILER. The former was an internal (not user visible) variable used in lit.site.cfg.py.in.

Fixes https://github.com/intel/llvm/issues/8824