### PR TITLE
[SYCL] Fix directory field of DIFile.

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -667,12 +667,15 @@ void CGDebugInfo::CreateCompileUnit() {
   if (CSKind)
     CSInfo.emplace(*CSKind, Checksum);
 
-  if (!CGM.getCodeGenOpts().SYCLUseMainFileName)
-    MainFileDir = getCurrentDirname();
-
-  llvm::DIFile *CUFile =
-      DBuilder.createFile(remapDIPath(MainFileName), remapDIPath(MainFileDir),
-                          CSInfo, getSource(SM, SM.getMainFileID()));
+  llvm::DIFile *CUFile;
+  if (CGM.getCodeGenOpts().SYCLUseMainFileName)
+    CUFile =
+        DBuilder.createFile(remapDIPath(MainFileName), remapDIPath(MainFileDir),
+                            CSInfo, getSource(SM, SM.getMainFileID()));
+  else
+    CUFile = DBuilder.createFile(remapDIPath(MainFileName),
+                                 remapDIPath(getCurrentDirname()), CSInfo,
+                                 getSource(SM, SM.getMainFileID()));
 
   StringRef Sysroot, SDK;
   if (CGM.getCodeGenOpts().getDebuggerTuning() == llvm::DebuggerKind::LLDB) {

--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -667,15 +667,9 @@ void CGDebugInfo::CreateCompileUnit() {
   if (CSKind)
     CSInfo.emplace(*CSKind, Checksum);
 
-  llvm::DIFile *CUFile;
-  if (CGM.getCodeGenOpts().SYCLUseMainFileName)
-    CUFile =
-        DBuilder.createFile(remapDIPath(MainFileName), remapDIPath(MainFileDir),
-                            CSInfo, getSource(SM, SM.getMainFileID()));
-  else
-    CUFile = DBuilder.createFile(remapDIPath(MainFileName),
-                                 remapDIPath(getCurrentDirname()), CSInfo,
-                                 getSource(SM, SM.getMainFileID()));
+  llvm::DIFile *CUFile =
+      DBuilder.createFile(remapDIPath(MainFileName), remapDIPath(getCurrentDirname()),
+                          CSInfo, getSource(SM, SM.getMainFileID()));
 
   StringRef Sysroot, SDK;
   if (CGM.getCodeGenOpts().getDebuggerTuning() == llvm::DebuggerKind::LLDB) {

--- a/clang/test/CodeGenSYCL/debug-info-checksum-temp-name.cpp
+++ b/clang/test/CodeGenSYCL/debug-info-checksum-temp-name.cpp
@@ -24,7 +24,6 @@
 //
 // CHECK: !DICompileUnit({{.*}} file: ![[#FILE:]]
 // CHECK: ![[#FILE]] = !DIFile(filename: "{{.*}}clang{{.+}}test{{.+}}CodeGenSYCL{{.+}}Inputs{{.+}}debug-info-checksum.cpp"
-// CHECK-SAME: directory: "{{.*}}clang{{.+}}test{{.+}}CodeGenSYCL{{.+}}Inputs"
 // CHECK-SAME: checksumkind: CSK_MD5, checksum: "f1fb5d68350b47d90a53968ac8c40529"
 
 #include "Inputs/debug-info-checksum.cpp"

--- a/clang/test/CodeGenSYCL/debug-info-file-checksum.cpp
+++ b/clang/test/CodeGenSYCL/debug-info-file-checksum.cpp
@@ -26,12 +26,10 @@
 
 // COMP1: !DICompileUnit({{.*}} file: ![[#FILE1:]]
 // COMP1: ![[#FILE1]] = !DIFile(filename: "{{.*}}clang{{.+}}test{{.+}}CodeGenSYCL{{.+}}Inputs{{.+}}checksum.cpp"
-// COMP1-SAME: directory: "{{.*}}clang{{.+}}test{{.+}}CodeGenSYCL/Inputs"
 // COMP1-SAME: checksumkind: CSK_MD5, checksum: "259269f735d83ec32c46a11352458493")
 
 // COMP2: !DICompileUnit({{.*}} file: ![[#FILE2:]]
 // COMP2: ![[#FILE2]] = !DIFile(filename: "{{.*}}clang{{.+}}test{{.+}}CodeGenSYCL{{.+}}Inputs{{.+}}checksum.cpp"
-// COMP2: directory: "{{.*}}clang{{.+}}test{{.+}}CodeGenSYCL/Output"
 // COMP2-SAME: checksumkind: CSK_MD5, checksum: "259269f735d83ec32c46a11352458493")
 
 // TODO: Fails on windows because of the use of append-file command that returns

--- a/clang/test/CodeGenSYCL/debug-info-file-prefix-map.cpp
+++ b/clang/test/CodeGenSYCL/debug-info-file-prefix-map.cpp
@@ -14,8 +14,7 @@
 
 // CHECK: distinct !DICompileUnit(language: DW_LANG_C_plus_plus_14, file: ![[#FILE1:]]
 // CHECK-NEXT: ![[#FILE1]] = !DIFile(filename: "debug-info-file-prefix-map.cpp"
-// CHECK-SAME: directory: "{{.*}}clang{{.+}}test{{.+}}CodeGenSYCL"
-// CHECK: ![[#FILE2:]] = !DIFile(filename: "debug-info-file-prefix-map.cpp", directory: "")
+// CHECK: ![[#FILE2:]] = !DIFile(filename: "debug-info-file-prefix-map.cpp"
 // CHECK: !DIDerivedType(tag: DW_TAG_typedef, name: "__builtin_va_list", file: ![[#FILE2]]
 
 void a(__builtin_va_list);


### PR DESCRIPTION
The directory should be the current working directory of the compilation command that produced the DICompileUnit.
In other words, it should be the directory where the app is running and not the directory where the source app resides.