### PR TITLE
[SYCL][InvokeSIMD] Improve error messages

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
@@ -363,7 +363,12 @@ using strip_regcall_from_function_ptr_t =
 
 template <typename Ret, typename... Args>
 constexpr bool has_ref_arg(Ret (*)(Args...)) {
-  return std::is_reference_v<Ret> || (... || std::is_reference_v<Args>);
+  return (... || std::is_reference_v<Args>);
+}
+
+template <typename Ret, typename... Args>
+constexpr bool has_ref_ret(Ret (*)(Args...)) {
+  return std::is_reference_v<Ret>;
 }
 
 template <class Callable> constexpr void verify_no_ref() {
@@ -375,9 +380,14 @@ template <class Callable> constexpr void verify_no_ref() {
                            std::add_pointer_t<RemoveRef>>;
     using FuncPtrNoCC = strip_regcall_from_function_ptr_t<FuncPtrType>;
     constexpr FuncPtrNoCC obj = {};
-    constexpr bool callable_has_ref_arg_or_ret = has_ref_arg(obj);
-    static_assert(!callable_has_ref_arg_or_ret,
-                  "invoke_simd does not support references");
+    constexpr bool callable_has_ref_ret = has_ref_ret(obj);
+    static_assert(
+        !callable_has_ref_ret,
+        "invoke_simd does not support callables returning references");
+    constexpr bool callable_has_ref_arg = has_ref_arg(obj);
+    static_assert(
+        !callable_has_ref_arg,
+        "invoke_simd does not support callables with reference arguments");
   }
 }
 

--- a/sycl/test/invoke_simd/no_callee_found.cpp
+++ b/sycl/test/invoke_simd/no_callee_found.cpp
@@ -1,0 +1,30 @@
+// RUN: not %clangxx -fsycl -fsycl-device-only -Xclang -fsycl-allow-func-ptr -S %s -o /dev/null 2>&1 | FileCheck %s
+#include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+using namespace sycl;
+namespace esimd = sycl::ext::intel::esimd;
+struct S1 {};
+struct S2 {};
+[[intel::device_indirectly_callable]] void callee(S2 *, simd<float, 16>) {}
+
+void foo() {
+  constexpr unsigned Size = 1024;
+  constexpr unsigned GroupSize = 64;
+  sycl::range<1> GlobalRange{Size};
+  sycl::range<1> LocalRange{GroupSize};
+  sycl::nd_range<1> Range(GlobalRange, LocalRange);
+  queue q;
+  auto e = q.submit([&](handler &cgh) {
+    cgh.parallel_for(Range, [=](nd_item<1> ndi) {
+      S1 s1;
+      invoke_simd(ndi.get_sub_group(), callee, uniform{&s1}, 5);
+    });
+  });
+}
+
+int main() {
+  foo();
+  // CHECK: {{.*}}error:{{.*}}static assertion failed due to requirement 'found_invoke_simd_target': No callable invoke_simd target found. Confirm the invoke_simd invocation argument types are convertible to the invoke_simd target argument types{{.*}}
+}

--- a/sycl/test/invoke_simd/reference_types.cpp
+++ b/sycl/test/invoke_simd/reference_types.cpp
@@ -1,5 +1,5 @@
-// RUN: not %clangxx -fsycl -fsycl-device-only -Xclang -fsycl-allow-func-ptr -S %s -o /dev/null 2>&1 -DRET_REF | FileCheck %s
-// RUN: not %clangxx -fsycl -fsycl-device-only -Xclang -fsycl-allow-func-ptr -S %s -o /dev/null 2>&1 | FileCheck %s
+// RUN: not %clangxx -fsycl -fsycl-device-only -Xclang -fsycl-allow-func-ptr -S %s -o /dev/null 2>&1 -DRET_REF | FileCheck -check-prefix CHECK-RET %s
+// RUN: not %clangxx -fsycl -fsycl-device-only -Xclang -fsycl-allow-func-ptr -S %s -o /dev/null 2>&1 | FileCheck -check-prefix CHECK-ARG %s
 #include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
 #include <sycl/sycl.hpp>
 
@@ -34,5 +34,6 @@ void foo() {
 
 int main() {
   foo();
-  // CHECK: {{.*}}error:{{.*}}static assertion failed due to requirement '!callable_has_ref_arg_or_ret': invoke_simd does not support references
+  // CHECK-ARG: {{.*}}error:{{.*}}static assertion failed due to requirement '!callable_has_ref_arg': invoke_simd does not support callables with reference arguments
+  // CHECK-RET: {{.*}}error:{{.*}}static assertion failed due to requirement '!callable_has_ref_ret': invoke_simd does not support callables returning references
 }

--- a/sycl/test/invoke_simd/reference_types.cpp
+++ b/sycl/test/invoke_simd/reference_types.cpp
@@ -1,0 +1,38 @@
+// RUN: not %clangxx -fsycl -fsycl-device-only -Xclang -fsycl-allow-func-ptr -S %s -o /dev/null 2>&1 -DRET_REF | FileCheck %s
+// RUN: not %clangxx -fsycl -fsycl-device-only -Xclang -fsycl-allow-func-ptr -S %s -o /dev/null 2>&1 | FileCheck %s
+#include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+using namespace sycl;
+namespace esimd = sycl::ext::intel::esimd;
+#ifdef RET_REF
+const int a = 0;
+[[intel::device_indirectly_callable]] const int &callee() { return a; }
+#else
+[[intel::device_indirectly_callable]] void callee(double, float, short &) {}
+#endif
+
+void foo() {
+  constexpr unsigned Size = 1024;
+  constexpr unsigned GroupSize = 64;
+  sycl::range<1> GlobalRange{Size};
+  sycl::range<1> LocalRange{GroupSize};
+  sycl::nd_range<1> Range(GlobalRange, LocalRange);
+  queue q;
+  auto e = q.submit([&](handler &cgh) {
+    cgh.parallel_for(Range, [=](nd_item<1> ndi) {
+#ifdef RET_REF
+      invoke_simd(ndi.get_sub_group(), callee);
+#else
+       short s;
+       invoke_simd(ndi.get_sub_group(), callee, 0, 0, s);
+#endif
+    });
+  });
+}
+
+int main() {
+  foo();
+  // CHECK: {{.*}}error:{{.*}}static assertion failed due to requirement '!callable_has_ref_arg_or_ret': invoke_simd does not support references
+}


### PR DESCRIPTION
1) If we could not find an invoke_simd function to call, suggest the user check argument types

2) Check that no references are used for the invoke_simd callee. The current implementation only supports function pointers. It does not support lambdas or functors. We only support function pointers by default unless the user passes an undocumented define.