### PR TITLE
[SYCL] Enable scan_spirv13 after GroupNonUniformArithmetic is enabled

### DIFF
--- a/sycl/test-e2e/SubGroup/scan_spirv13.cpp
+++ b/sycl/test-e2e/SubGroup/scan_spirv13.cpp
@@ -5,9 +5,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// Missing GroupNonUniformArithmetic capability on CPU RT
-// XFAIL: cpu
-
 // This test verifies the correct work of SPIR-V 1.3 exclusive_scan() and
 // inclusive_scan() algoriths used with the operation MUL, bitwise OR, XOR, AND.
 


### PR DESCRIPTION
This commit is to enable SubGroup/scan_spirv13 on CPU after related capability is enabled