### PR TITLE
[SYCL][E2E] Use configure_lit_site_cfg in in-tree builds

### DIFF
--- a/sycl/test-e2e/CMakeLists.txt
+++ b/sycl/test-e2e/CMakeLists.txt
@@ -33,8 +33,17 @@ set(SYCL_E2E_TESTS_LIT_FLAGS "-sv" CACHE STRING "Flags used when running lit")
 
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
 
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in"
-               "${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg")
+if(SYCL_TEST_E2E_STANDALONE)
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in"
+                 "${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py")
+else()
+  configure_lit_site_cfg(
+    ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
+    ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
+    MAIN_CONFIG
+    ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py
+    )
+endif() # Standalone.
 
 if(NOT SYCL_TEST_E2E_STANDALONE)
   list(APPEND SYCL_E2E_TEST_DEPS

--- a/sycl/test-e2e/README.md
+++ b/sycl/test-e2e/README.md
@@ -56,8 +56,8 @@ cmake -G Ninja ...
 ninja check-sycl-e2e
 ```
 
-In addition to this standalone configuration one can enable `check-sycl-e2e`
-target for the sycl-toolchain workspace/build by specifying
+In addition to this, in an in-tree configuration one can enable
+`check-sycl-e2e` target for the sycl-toolchain workspace/build by specifying
 `SYCL_TEST_E2E_TARGETS` as part of its cmake configuration. For example, like
 this:
 
@@ -65,6 +65,19 @@ this:
 CC=<> CXX=<> python llvm/buildbot/configure.py -o build ... \
   --cmake-opt=-DSYCL_TEST_E2E_TARGETS="level_zero:gpu;opencl:gpu"
   --cmake-opt=-DSYCL_E2E_TESTS_LIT_FLAGS="--param;dump_ir=True"``
+```
+
+In an in-tree build, individual tests or groups of tests can be conveniently
+run directly from their source paths, using the configured `llvm-lit` script:
+
+```
+# Implicitly uses cmake parameters SYCL_BE and SYCL_TARGET_DEVICES, detailed
+# below
+build/bin/llvm-lit -sv sycl/test-e2e/Basic/aspects.cpp
+
+# Explicitly sets SYCL backend and target device(s), overriding SYCL_BE and
+# SYCL_TARGET_DEVICES
+build/bin/llvm-lit -sv --param sycl_be=level_zero --param target_devices=cpu,gpu sycl/test-e2e/Basic/aspects.cpp
 ```
 
 # Cmake parameters


### PR DESCRIPTION
This provides the added benefit that it will automatically map the config paths from the build directories to the corresponding source ones in `llvm-lit`. With this, one should be able to run lit tests directly from source paths.

Note also that this changes the configured cfg file's name from `lit.site.cfg` to `lit.site.cfg.py`, but this aligns us with the predominant style across the llvm project.