### PR TITLE
[SYCL] Fix undefined behaviour in vector printf specifier

### DIFF
--- a/sycl/test-e2e/DeviceLib/built-ins/printf.cpp
+++ b/sycl/test-e2e/DeviceLib/built-ins/printf.cpp
@@ -64,7 +64,7 @@ int main() {
         // On SPIRV devices, vectors can be printed via native OpenCL types:
         using ocl_int4 = sycl::vec<int, 4>::vector_t;
         {
-          static const CONSTANT char format[] = "%v4d\n";
+          static const CONSTANT char format[] = "%v4hld\n";
           ext::oneapi::experimental::printf(format, (ocl_int4)v4);
         }
 


### PR DESCRIPTION
The use of `%v` vector specifiers requires a length modifier as per OpenCL specification.