### PR TITLE
[SYCL-MLIR][NFC] Replace deprecated cast function

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistOps.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistOps.td
@@ -27,7 +27,7 @@ def CacheLoad
   let results = (outs AnyType:$result);
   let builders = [
     OpBuilder<(ins "Value":$memref, CArg<"ValueRange", "{}">:$indices), [{
-      auto memrefType = memref.getType().cast<MemRefType>();
+      auto memrefType = cast<MemRefType>(memref.getType());
       $_state.addOperands(memref);
       $_state.addOperands(indices);
       $_state.types.push_back(memrefType.getElementType());

--- a/polygeist/lib/Dialect/Polygeist/Transforms/BareMemRefToLLVM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/BareMemRefToLLVM.cpp
@@ -70,8 +70,7 @@ struct ReshapeMemrefOpLowering
   matchAndRewrite(memref::ReshapeOp reshape, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (!canBeLoweredToBarePtr(reshape.getType()) ||
-        !canBeLoweredToBarePtr(
-            reshape.getSource().getType().cast<MemRefType>()))
+        !canBeLoweredToBarePtr(cast<MemRefType>(reshape.getSource().getType())))
       return failure();
 
     rewriter.replaceOp(reshape, adaptor.getSource());
@@ -182,7 +181,7 @@ struct DeallocOpLowering : public ConvertOpToLLVMPattern<memref::DeallocOp> {
   matchAndRewrite(memref::DeallocOp deallocOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (!canBeLoweredToBarePtr(
-            deallocOp.getMemref().getType().cast<MemRefType>()))
+            cast<MemRefType>(deallocOp.getMemref().getType())))
       return failure();
     // Insert the `free` declaration if it is not already present.
     const auto freeFunc =
@@ -198,8 +197,8 @@ struct CastMemrefOpLowering : public ConvertOpToLLVMPattern<memref::CastOp> {
   using ConvertOpToLLVMPattern<memref::CastOp>::ConvertOpToLLVMPattern;
 
   LogicalResult match(memref::CastOp castOp) const override {
-    const auto srcType = castOp.getOperand().getType().cast<MemRefType>();
-    const auto dstType = castOp.getType().cast<MemRefType>();
+    const auto srcType = cast<MemRefType>(castOp.getOperand().getType());
+    const auto dstType = cast<MemRefType>(castOp.getType());
 
     // This will be replaced by an identity function, so we need input and
     // output types to match.
@@ -383,8 +382,7 @@ struct ReshapeMemrefOpLoweringOld
   matchAndRewrite(memref::ReshapeOp reshape, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (!canBeLoweredToBarePtr(reshape.getType()) ||
-        !canBeLoweredToBarePtr(
-            reshape.getSource().getType().cast<MemRefType>()))
+        !canBeLoweredToBarePtr(cast<MemRefType>(reshape.getSource().getType())))
       return failure();
 
     rewriter.replaceOp(reshape, adaptor.getSource());
@@ -494,7 +492,7 @@ struct DeallocOpLoweringOld : public ConvertOpToLLVMPattern<memref::DeallocOp> {
   matchAndRewrite(memref::DeallocOp deallocOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
     if (!canBeLoweredToBarePtr(
-            deallocOp.getMemref().getType().cast<MemRefType>()))
+            cast<MemRefType>(deallocOp.getMemref().getType())))
       return failure();
     // Insert the `free` declaration if it is not already present.
     const auto freeFunc =
@@ -514,8 +512,8 @@ struct CastMemrefOpLoweringOld : public ConvertOpToLLVMPattern<memref::CastOp> {
   using ConvertOpToLLVMPattern<memref::CastOp>::ConvertOpToLLVMPattern;
 
   LogicalResult match(memref::CastOp castOp) const override {
-    const auto srcType = castOp.getOperand().getType().cast<MemRefType>();
-    const auto dstType = castOp.getType().cast<MemRefType>();
+    const auto srcType = cast<MemRefType>(castOp.getOperand().getType());
+    const auto dstType = cast<MemRefType>(castOp.getType());
 
     // This will be replaced by an identity function, so we need input and
     // output types to match.

--- a/polygeist/lib/Dialect/Polygeist/Transforms/BarrierRemovalContinuation.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/BarrierRemovalContinuation.cpp
@@ -318,7 +318,7 @@ static std::pair<Block *, Block::iterator> getInsertionPointAfterDef(Value v) {
   if (Operation *op = v.getDefiningOp())
     return {op->getBlock(), std::next(Block::iterator(op))};
 
-  BlockArgument blockArg = v.cast<BlockArgument>();
+  BlockArgument blockArg = cast<BlockArgument>(v);
   return {blockArg.getParentBlock(), blockArg.getParentBlock()->begin()};
 }
 
@@ -436,7 +436,7 @@ static void reg2mem(ArrayRef<llvm::SetVector<Block *>> subgraphs,
         allocaBuilder, value, iterationCounts, /*alloca*/ true);
     /*
     if
-    (allocation.getType().cast<MemRefType>().getElementType().isa<MemRefType>())
+    (isa<MemRefType>(cast<MemRefType>(allocation.getType()).getElementType()))
     { llvm::errs() << " value: " << value << " alloc: " << allocation << "\n";
         llvm_unreachable("bad allocation\n");
     }
@@ -464,7 +464,7 @@ static void reg2mem(ArrayRef<llvm::SetVector<Block *>> subgraphs,
         accessBuilder.setInsertionPoint(use.getOwner());
         auto buf = allocation;
         for (auto idx : parallel.getInductionVars()) {
-          auto mt0 = buf.getType().cast<MemRefType>();
+          auto mt0 = cast<MemRefType>(buf.getType());
           std::vector<int64_t> shape(mt0.getShape());
           shape.erase(shape.begin());
           auto mt = MemRefType::get(shape, mt0.getElementType(),

--- a/polygeist/lib/Dialect/Polygeist/Transforms/CanonicalizeFor.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/CanonicalizeFor.cpp
@@ -120,7 +120,7 @@ struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
         if (!sameValue) {
           Value step = addOp.getOperand(1);
 
-          if (!step.getType().isa<IndexType>()) {
+          if (!isa<IndexType>(step.getType())) {
             step = rewriter.create<IndexCastOp>(forOp.getLoc(),
                                                 replacement.getType(), step);
           }
@@ -129,7 +129,7 @@ struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
               rewriter.create<MulIOp>(forOp.getLoc(), replacement, step);
         }
 
-        if (!init.getType().isa<IndexType>()) {
+        if (!isa<IndexType>(init.getType())) {
           init = rewriter.create<IndexCastOp>(forOp.getLoc(),
                                               replacement.getType(), init);
         }
@@ -137,7 +137,7 @@ struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
         replacement =
             rewriter.create<AddIOp>(forOp.getLoc(), init, replacement);
 
-        if (!std::get<1>(it).getType().isa<IndexType>()) {
+        if (!isa<IndexType>(std::get<1>(it).getType())) {
           replacement = rewriter.create<IndexCastOp>(
               forOp.getLoc(), std::get<1>(it).getType(), replacement);
         }
@@ -160,7 +160,7 @@ struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
         if (!sameValue) {
           Value step = addOp.getOperand(1);
 
-          if (!step.getType().isa<IndexType>()) {
+          if (!isa<IndexType>(step.getType())) {
             step = rewriter.create<IndexCastOp>(forOp.getLoc(),
                                                 replacement.getType(), step);
           }
@@ -169,7 +169,7 @@ struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
               rewriter.create<MulIOp>(forOp.getLoc(), replacement, step);
         }
 
-        if (!init.getType().isa<IndexType>()) {
+        if (!isa<IndexType>(init.getType())) {
           init = rewriter.create<IndexCastOp>(forOp.getLoc(),
                                               replacement.getType(), init);
         }
@@ -177,7 +177,7 @@ struct ForOpInductionReplacement : public OpRewritePattern<scf::ForOp> {
         replacement =
             rewriter.create<AddIOp>(forOp.getLoc(), init, replacement);
 
-        if (!std::get<1>(it).getType().isa<IndexType>()) {
+        if (!isa<IndexType>(std::get<1>(it).getType())) {
           replacement = rewriter.create<IndexCastOp>(
               forOp.getLoc(), std::get<1>(it).getType(), replacement);
         }
@@ -251,7 +251,7 @@ struct RemoveUnusedArgs : public OpRewritePattern<ForOp> {
     // Replace the operation's results with the new ones.
     SmallVector<Value, 4> repResults(op.getNumResults());
     for (auto en : llvm::enumerate(usedResults))
-      repResults[en.value().cast<OpResult>().getResultNumber()] =
+      repResults[cast<OpResult>(en.value()).getResultNumber()] =
           newForOp.getResult(en.index());
 
     rewriter.replaceOp(op, repResults);
@@ -313,8 +313,8 @@ cast<scf::YieldOp>(op.thenRegion().back().getTerminator());
 +        continue;
 +      if (auto top = std::get<0>(tup).getDefiningOp<ConstantOp>()) {
 +        if (auto fop = std::get<1>(tup).getDefiningOp<ConstantOp>()) {
-+          if (top.getValue().cast<IntegerAttr>().getValue() == 0 &&
-+              fop.getValue().cast<IntegerAttr>().getValue() == 1) {
++          if (cast<IntegerAttr>(top.getValue()).getValue() == 0 &&
++              cast<IntegerAttr>(fop.getValue()).getValue() == 1) {
 +
 +            for (OpOperand &use :
 +                 llvm::make_early_inc_range(std::get<2>(tup).getUses())) {
@@ -324,8 +324,8 @@ cast<scf::YieldOp>(op.thenRegion().back().getTerminator());
 +              });
 +            }
 +          }
-+          if (top.getValue().cast<IntegerAttr>().getValue() == 1 &&
-+              fop.getValue().cast<IntegerAttr>().getValue() == 0) {
++          if (cast<IntegerAttr>(top.getValue()).getValue() == 1 &&
++              cast<IntegerAttr>(fop.getValue()).getValue() == 0) {
 +            for (OpOperand &use :
 +                 llvm::make_early_inc_range(std::get<2>(tup).getUses())) {
 +              changed = true;
@@ -347,8 +347,8 @@ cast<scf::YieldOp>(op.thenRegion().back().getTerminator());
 +    bool changed = false;
 +
 +    if (llvm::all_of(op.results(), [](Value v) {
-+          return v.getType().isa<IntegerType>() &&
-+                 v.getType().cast<IntegerType>().getWidth() == 1;
++          return isa<IntegerType>(v.getType()) &&
++                 cast<IntegerType>(v.getType()).getWidth() == 1;
 +        })) {
 +      if (op.thenRegion().getBlocks().size() == 1 &&
 +          op.elseRegion().getBlocks().size() == 1) {
@@ -418,13 +418,13 @@ yop2.results()[idx]);
 */
 
 bool isTopLevelArgValue(Value value, Region *region) {
-  if (auto arg = value.dyn_cast<BlockArgument>())
+  if (auto arg = dyn_cast<BlockArgument>(value))
     return arg.getParentRegion() == region;
   return false;
 }
 
 bool isBlockArg(Value value) {
-  if (auto arg = value.dyn_cast<BlockArgument>())
+  if (auto arg = dyn_cast<BlockArgument>(value))
     return true;
   return false;
 }
@@ -468,11 +468,11 @@ struct WhileToForHelper {
     negativeStep = false;
 
     auto condOp = loop.getConditionOp();
-    indVar = cmpIOp.getLhs().dyn_cast<BlockArgument>();
+    indVar = dyn_cast<BlockArgument>(cmpIOp.getLhs());
     Type extType = nullptr;
     // todo handle ext
     if (auto ext = cmpIOp.getLhs().getDefiningOp<ExtSIOp>()) {
-      indVar = ext.getIn().dyn_cast<BlockArgument>();
+      indVar = dyn_cast<BlockArgument>(ext.getIn());
       extType = ext.getType();
     }
     // Condition is not the same as an induction variable
@@ -683,7 +683,7 @@ struct MoveWhileToFor : public OpRewritePattern<WhileOp> {
       }
       Value res;
       if (isTopLevelArgValue(arg, &loop.getBefore())) {
-        auto blockArg = arg.cast<BlockArgument>();
+        auto blockArg = cast<BlockArgument>(arg);
         auto pos = blockArg.getArgNumber();
         res = loop.getInits()[pos];
       } else
@@ -766,7 +766,7 @@ struct MoveWhileAndDown : public OpRewritePattern<WhileOp> {
 
       Value extraCmp = andIOp->getOperand(1 - i);
       Value lookThrough = nullptr;
-      if (auto BA = extraCmp.dyn_cast<BlockArgument>()) {
+      if (auto BA = dyn_cast<BlockArgument>(extraCmp)) {
         lookThrough = oldYield.getOperand(BA.getArgNumber());
       }
       if (!helper.computeLegality(/*sizeCheck*/ false, lookThrough))
@@ -1102,7 +1102,7 @@ struct MoveWhileDown2 : public OpRewritePattern<WhileOp> {
           //    yield   i:pair<2>
           // }
           if (!std::get<0>(pair).use_empty()) {
-            if (auto blockArg = elseYielded.dyn_cast<BlockArgument>())
+            if (auto blockArg = dyn_cast<BlockArgument>(elseYielded))
               if (blockArg.getOwner() == &op.getBefore().front()) {
                 if (afterYield.getResults()[blockArg.getArgNumber()] ==
                         std::get<2>(pair) &&
@@ -1222,7 +1222,7 @@ struct MoveWhileInvariantIfResult : public OpRewritePattern<WhileOp> {
       if (!std::get<0>(pair).use_empty()) {
         if (auto ifOp = std::get<1>(pair).getDefiningOp<scf::IfOp>()) {
           if (ifOp.getCondition() == term.getCondition()) {
-            auto idx = std::get<1>(pair).cast<OpResult>().getResultNumber();
+            auto idx = cast<OpResult>(std::get<1>(pair)).getResultNumber();
             Value returnWith = ifOp.elseYield().getResults()[idx];
             if (!op.getBefore().isAncestor(returnWith.getParentRegion())) {
               rewriter.updateRootInPlace(op, [&] {
@@ -1341,7 +1341,7 @@ struct WhileCmpOffset : public OpRewritePattern<WhileOp> {
         if (addI.getOperand(1).getDefiningOp() &&
             !op.getBefore().isAncestor(
                 addI.getOperand(1).getDefiningOp()->getParentRegion()))
-          if (auto blockArg = addI.getOperand(0).dyn_cast<BlockArgument>()) {
+          if (auto blockArg = dyn_cast<BlockArgument>(addI.getOperand(0))) {
             if (blockArg.getOwner() == &op.getBefore().front()) {
               auto rng = llvm::make_early_inc_range(blockArg.getUses());
 
@@ -1620,7 +1620,7 @@ struct WhileLICM : public OpRewritePattern<WhileOp> {
     auto isDefinedOutsideOfBody = [&](Value value) {
       auto *definingOp = value.getDefiningOp();
       if (!definingOp) {
-        if (auto ba = value.dyn_cast<BlockArgument>())
+        if (auto ba = dyn_cast<BlockArgument>(value))
           definingOp = ba.getOwner()->getParentOp();
         assert(definingOp);
       }

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
@@ -819,7 +819,7 @@ static bool canBeHoisted(Operation &op, LoopLikeOpInterface loop,
   // operands are not defined outside of the loop and cannot themselves be
   // moved.
   auto canBeMoved = [&](Value value) {
-    if (auto BA = value.dyn_cast<BlockArgument>())
+    if (auto BA = dyn_cast<BlockArgument>(value))
       if (willBeMoved.count(BA.getOwner()->getParentOp()))
         return true;
     Operation *definingOp = value.getDefiningOp();

--- a/polygeist/lib/Dialect/Polygeist/Transforms/Mem2Reg.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/Mem2Reg.cpp
@@ -53,8 +53,8 @@ using namespace polygeist;
 enum class Match { Exact, Maybe, None };
 
 bool operator<(Value lhs, Value rhs) {
-  if (auto lhsBA = lhs.dyn_cast<BlockArgument>()) {
-    if (auto rhsBA = rhs.dyn_cast<BlockArgument>()) {
+  if (auto lhsBA = dyn_cast<BlockArgument>(lhs)) {
+    if (auto rhsBA = dyn_cast<BlockArgument>(rhs)) {
       if (lhsBA.getOwner() != rhsBA.getOwner())
         return lhsBA.getOwner() < rhsBA.getOwner();
       else
@@ -63,11 +63,11 @@ bool operator<(Value lhs, Value rhs) {
       return true;
     }
   }
-  auto lhsOR = lhs.cast<OpResult>();
-  if (auto rhsBA = rhs.dyn_cast<BlockArgument>()) {
+  auto lhsOR = cast<OpResult>(lhs);
+  if (auto rhsBA = dyn_cast<BlockArgument>(rhs)) {
     return false;
   } else {
-    auto rhsOR = rhs.cast<OpResult>();
+    auto rhsOR = cast<OpResult>(lhs);
     if (lhsOR.getOwner() != rhsOR.getOwner())
       return lhsOR.getOwner() < rhsOR.getOwner();
     else
@@ -513,7 +513,7 @@ public:
           !exOp->isAncestor(values[0].getDefiningOp())) {
         return values[0];
       }
-      if (auto ba = values[0].dyn_cast<BlockArgument>())
+      if (auto ba = dyn_cast<BlockArgument>(values[0]))
         if (!exOp->isAncestor(ba.getOwner()->getParentOp())) {
           return values[0];
         }
@@ -1421,10 +1421,10 @@ bool Mem2Reg::forwardStoreToLoad(
   }
 
   Type elType;
-  if (auto MT = AI.getType().dyn_cast<MemRefType>())
+  if (auto MT = dyn_cast<MemRefType>(AI.getType()))
     elType = MT.getElementType();
   else
-    elType = AI.getType().cast<LLVM::LLVMPointerType>().getElementType();
+    elType = cast<LLVM::LLVMPointerType>(AI.getType()).getElementType();
 
   ReplacementHandler metaMap(elType);
 
@@ -1742,7 +1742,7 @@ bool Mem2Reg::forwardStoreToLoad(
 
     Value maybeblockArg =
         valueAtStartOfBlock.find(block)->second->materialize(false);
-    auto blockArg = maybeblockArg.dyn_cast<BlockArgument>();
+    auto blockArg = dyn_cast<BlockArgument>(maybeblockArg);
     assert(blockArg && blockArg.getOwner() == block);
 
     SetVector<Block *> prepred(block->getPredecessors().begin(),

--- a/polygeist/lib/Dialect/Polygeist/Transforms/ParallelLoopDistribute.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/ParallelLoopDistribute.cpp
@@ -276,7 +276,7 @@ static void minCutCache(polygeist::BarrierOp barrier,
       for (auto N : pair.second) {
         if (parent.find(N) == parent.end()) {
           assert(pair.first.type == Node::OP && N.type == Node::VAL);
-          assert(pair.first.O == N.V.dyn_cast<OpResult>().getOwner());
+          assert(pair.first.O == dyn_cast<OpResult>(N.V).getOwner());
           Cache.insert(N.V);
         }
       }
@@ -380,7 +380,7 @@ static bool hasNestedBarrier(Operation *op, SmallVector<BlockArgument> &vals) {
     // the `parallel` op is not an ancestor of `op` or `op` itself), the
     // barrier is considered nested in that `parallel` op and _not_ in `op`.
     for (auto arg : barrier->getOperands()) {
-      if (auto ba = arg.dyn_cast<BlockArgument>()) {
+      if (auto ba = dyn_cast<BlockArgument>(arg)) {
         if (auto parallel =
                 dyn_cast<scf::ParallelOp>(ba.getOwner()->getParentOp())) {
           if (parallel->isAncestor(op))
@@ -830,7 +830,7 @@ static LogicalResult distributeAroundBarrier(T op, BarrierOp barrier,
         rewriter.setInsertionPoint(u.getOwner());
         auto buf = alloc;
         for (auto idx : preLoop.getBody()->getArguments()) {
-          auto mt0 = buf.getType().cast<MemRefType>();
+          auto mt0 = cast<MemRefType>(buf.getType());
           std::vector<int64_t> shape(mt0.getShape());
           assert(shape.size() > 0);
           shape.erase(shape.begin());
@@ -1738,7 +1738,7 @@ struct Reg2MemIf : public OpRewritePattern<T> {
           while (!todo.empty()) {
             auto cur = todo.pop_back_val();
 
-            if (auto BA = cur.dyn_cast<BlockArgument>())
+            if (auto BA = dyn_cast<BlockArgument>(cur))
               if (BA.getOwner() == op->getBlock())
                 continue;
 
@@ -1838,7 +1838,7 @@ struct Reg2MemIf : public OpRewritePattern<T> {
           while (!todo.empty()) {
             auto cur = todo.pop_back_val();
 
-            if (auto BA = cur.dyn_cast<BlockArgument>())
+            if (auto BA = dyn_cast<BlockArgument>(cur))
               if (BA.getOwner() == op->getBlock())
                 continue;
             if (cur.getParentRegion()->isProperAncestor(
@@ -1897,7 +1897,7 @@ struct Reg2MemIf : public OpRewritePattern<T> {
           while (!todo.empty()) {
             auto cur = todo.pop_back_val();
 
-            if (auto BA = cur.dyn_cast<BlockArgument>())
+            if (auto BA = dyn_cast<BlockArgument>(cur))
               if (BA.getOwner() == op->getBlock())
                 continue;
 

--- a/polygeist/lib/Dialect/Polygeist/Transforms/ParallelLower.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/ParallelLower.cpp
@@ -348,7 +348,7 @@ void ParallelLower::runOnOperation() {
 
     container.walk([&](mlir::memref::AllocaOp alop) {
       if (auto ia =
-              alop.getType().getMemorySpace().dyn_cast_or_null<IntegerAttr>())
+              dyn_cast_or_null<IntegerAttr>(alop.getType().getMemorySpace()))
         if (ia.getValue() == 5) {
           builder.setInsertionPointToStart(blockB);
           auto newAlloca = builder.create<memref::AllocaOp>(

--- a/polygeist/lib/Dialect/Polygeist/Transforms/ParallelLower.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/ParallelLower.cpp
@@ -213,8 +213,8 @@ void ParallelLower::runOnOperation() {
 
     auto callable = caller.getCallableForCallee();
     CallableOpInterface callableOp;
-    if (SymbolRefAttr symRef = callable.dyn_cast<SymbolRefAttr>()) {
-      if (!symRef.isa<FlatSymbolRefAttr>())
+    if (SymbolRefAttr symRef = dyn_cast<SymbolRefAttr>(callable)) {
+      if (!isa<FlatSymbolRefAttr>(symRef))
         return;
       auto *symbolOp =
           symbolTable.lookupNearestSymbolFrom(getOperation(), symRef);
@@ -362,7 +362,7 @@ void ParallelLower::runOnOperation() {
     });
 
     container.walk([&](mlir::LLVM::AllocaOp alop) {
-      auto PT = alop.getType().cast<LLVM::LLVMPointerType>();
+      auto PT = cast<LLVM::LLVMPointerType>(alop.getType());
       if (PT.getAddressSpace() == 5) {
         builder.setInsertionPointToStart(blockB);
         auto newAlloca = builder.create<LLVM::AllocaOp>(
@@ -488,7 +488,7 @@ void ParallelLower::runOnOperation() {
       auto mf = GetOrCreateMallocFunction(getOperation());
       OpBuilder bz(call);
       Value args[] = {call.getOperand(1)};
-      if (args[0].getType().cast<IntegerType>().getWidth() < 64)
+      if (cast<IntegerType>(args[0].getType()).getWidth() < 64)
         args[0] =
             bz.create<arith::ExtUIOp>(call.getLoc(), bz.getI64Type(), args[0]);
       mlir::Value alloc =
@@ -497,7 +497,7 @@ void ParallelLower::runOnOperation() {
       {
         auto retv = bz.create<ConstantIntOp>(
             call.getLoc(), 0,
-            call.getResult().getType().cast<IntegerType>().getWidth());
+            cast<IntegerType>(call.getResult().getType()).getWidth());
         Value vals[] = {retv};
         call.replaceAllUsesWith(ArrayRef<Value>(vals));
         call.erase();
@@ -511,7 +511,7 @@ void ParallelLower::runOnOperation() {
       {
         auto retv = bz.create<ConstantIntOp>(
             call.getLoc(), 0,
-            call.getResult().getType().cast<IntegerType>().getWidth());
+            cast<IntegerType>(call.getResult().getType()).getWidth());
         Value vals[] = {retv};
         call.replaceAllUsesWith(ArrayRef<Value>(vals));
         call.erase();
@@ -520,7 +520,7 @@ void ParallelLower::runOnOperation() {
       OpBuilder bz(call);
       auto retv = bz.create<ConstantIntOp>(
           call.getLoc(), 0,
-          call.getResult().getType().cast<IntegerType>().getWidth());
+          cast<IntegerType>(call.getResult().getType()).getWidth());
       Value vals[] = {retv};
       call.replaceAllUsesWith(ArrayRef<Value>(vals));
       call.erase();
@@ -528,7 +528,7 @@ void ParallelLower::runOnOperation() {
       OpBuilder bz(call);
       auto retv = bz.create<ConstantIntOp>(
           call.getLoc(), 0,
-          call.getResult().getType().cast<IntegerType>().getWidth());
+          cast<IntegerType>(call.getResult().getType()).getWidth());
       Value vals[] = {retv};
       call.replaceAllUsesWith(ArrayRef<Value>(vals));
       call.erase();
@@ -539,7 +539,7 @@ void ParallelLower::runOnOperation() {
       OpBuilder bz(call);
       auto retv = bz.create<ConstantIntOp>(
           call.getLoc(), 0,
-          call.getResult(0).getType().cast<IntegerType>().getWidth());
+          cast<IntegerType>(call.getResult(0).getType()).getWidth());
       Value vals[] = {retv};
       call.replaceAllUsesWith(ArrayRef<Value>(vals));
       call.erase();
@@ -560,7 +560,7 @@ void ParallelLower::runOnOperation() {
       OpBuilder bz(call);
       auto retv = bz.create<ConstantIntOp>(
           call.getLoc(), 0,
-          call.getResult(0).getType().cast<IntegerType>().getWidth());
+          cast<IntegerType>(call.getResult(0).getType()).getWidth());
       Value vals[] = {retv};
       call.replaceAllUsesWith(ArrayRef<Value>(vals));
       call.erase();

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -36,7 +36,7 @@ static Value castCallerMemRefArg(Value CallerArg, Type CalleeArgType,
   Type CallerArgType = CallerArg.getType();
 
   if (MemRefType DstTy = CalleeArgType.dyn_cast_or_null<MemRefType>()) {
-    MemRefType SrcTy = CallerArgType.dyn_cast<MemRefType>();
+    MemRefType SrcTy = dyn_cast<MemRefType>(CallerArgType);
     if (SrcTy && DstTy.getElementType() == SrcTy.getElementType() &&
         DstTy.getMemorySpace() == SrcTy.getMemorySpace()) {
       auto SrcShape = SrcTy.getShape();
@@ -84,7 +84,7 @@ static void castCallerArgs(func::FuncOp Callee,
     if (CalleeArgType == CallerArgType)
       continue;
 
-    if (CalleeArgType.isa<MemRefType>())
+    if (isa<MemRefType>(CalleeArgType))
       Args[I] = castCallerMemRefArg(Args[I], CalleeArgType, B);
     assert(CalleeArgType == Args[I].getType() && "Callsite argument mismatch");
   }
@@ -153,7 +153,7 @@ ValueCategory MLIRScanner::callHelper(
       llvm::dbgs() << "ExpectedType: " << ExpectedType << "\n";
     });
 
-    if (auto PT = Arg.val.getType().dyn_cast<LLVM::LLVMPointerType>()) {
+    if (auto PT = dyn_cast<LLVM::LLVMPointerType>(Arg.val.getType())) {
       if (PT.getAddressSpace() == 5)
         Arg.val = Builder.create<LLVM::AddrSpaceCastOp>(
             Loc, LLVM::LLVMPointerType::get(PT.getElementType(), 0), Arg.val);
@@ -171,11 +171,8 @@ ValueCategory MLIRScanner::callHelper(
         });
         assert(Arg.isReference);
 
-        auto MT =
-            Glob.getTypes()
-                .getMLIRType(
-                    Glob.getCGM().getContext().getLValueReferenceType(AType))
-                .cast<MemRefType>();
+        auto MT = cast<MemRefType>(Glob.getTypes().getMLIRType(
+            Glob.getCGM().getContext().getLValueReferenceType(AType)));
 
         LLVM_DEBUG({
           llvm::dbgs() << "MT: " << MT << "\n";
@@ -217,7 +214,7 @@ ValueCategory MLIRScanner::callHelper(
               Arg.getValue(Builder).getType(),
               Glob.getCGM().getDataLayout().getAllocaAddrSpace(),
               /*IsAlloc*/ true);
-          if (auto MemRefTy = Ty.dyn_cast<MemRefType>()) {
+          if (auto MemRefTy = dyn_cast<MemRefType>(Ty)) {
             Val = ABuilder.create<memref::AllocaOp>(Loc, MemRefTy);
             Val = ABuilder.create<memref::CastOp>(
                 Loc,
@@ -233,13 +230,13 @@ ValueCategory MLIRScanner::callHelper(
         } else
           Val = Arg.getValue(Builder);
 
-        if (Val.getType().isa<LLVM::LLVMPointerType>() &&
-            ExpectedType.isa<MemRefType>())
+        if (isa<LLVM::LLVMPointerType>(Val.getType()) &&
+            isa<MemRefType>(ExpectedType))
           Val = Builder.create<polygeist::Pointer2MemrefOp>(Loc, ExpectedType,
                                                             Val);
 
-        if (auto PrevTy = Val.getType().dyn_cast<IntegerType>()) {
-          auto IPostTy = ExpectedType.cast<IntegerType>();
+        if (auto PrevTy = dyn_cast<IntegerType>(Val.getType())) {
+          auto IPostTy = cast<IntegerType>(ExpectedType);
           if (PrevTy != IPostTy)
             Val = Builder.create<arith::TruncIOp>(Loc, IPostTy, Val);
         }
@@ -251,12 +248,12 @@ ValueCategory MLIRScanner::callHelper(
           Glob.getCGM().getContext().getLValueReferenceType(AType));
 
       Val = Arg.val;
-      if (Val.getType().isa<LLVM::LLVMPointerType>() &&
-          ExpectedType.isa<MemRefType>())
+      if (isa<LLVM::LLVMPointerType>(Val.getType()) &&
+          isa<MemRefType>(ExpectedType))
         Val =
             Builder.create<polygeist::Pointer2MemrefOp>(Loc, ExpectedType, Val);
-      else if (Val.getType().isa<MemRefType>() &&
-               ExpectedType.isa<LLVM::LLVMPointerType>())
+      else if (isa<MemRefType>(Val.getType()) &&
+               isa<LLVM::LLVMPointerType>(ExpectedType))
         Val =
             Builder.create<polygeist::Memref2PointerOp>(Loc, ExpectedType, Val);
 
@@ -294,11 +291,8 @@ ValueCategory MLIRScanner::callHelper(
 
   Value Alloc;
   if (IsArrayReturn) {
-    auto MT =
-        Glob.getTypes()
-            .getMLIRType(
-                Glob.getCGM().getContext().getLValueReferenceType(RetType))
-            .cast<MemRefType>();
+    auto MT = cast<MemRefType>(Glob.getTypes().getMLIRType(
+        Glob.getCGM().getContext().getLValueReferenceType(RetType)));
 
     auto Shape = std::vector<int64_t>(MT.getShape());
     assert(Shape.size() == 2);
@@ -327,7 +321,7 @@ ValueCategory MLIRScanner::callHelper(
     Value Blocks[3];
     for (int I = 0; I < 3; I++) {
       Value Val = L0.val;
-      if (auto MT = Val.getType().dyn_cast<MemRefType>()) {
+      if (auto MT = dyn_cast<MemRefType>(Val.getType())) {
         assert(MT.getShape().size() == 2);
         Blocks[I] = Builder.create<arith::IndexCastOp>(
             Loc, IndexType::get(Builder.getContext()),
@@ -335,8 +329,8 @@ ValueCategory MLIRScanner::callHelper(
                 Loc, Val,
                 ValueRange({getConstantIndex(0), getConstantIndex(I)})));
       } else {
-        auto PT = Val.getType().cast<LLVM::LLVMPointerType>();
-        auto ET = PT.getElementType().cast<LLVM::LLVMStructType>().getBody()[I];
+        auto PT = cast<LLVM::LLVMPointerType>(Val.getType());
+        auto ET = cast<LLVM::LLVMStructType>(PT.getElementType()).getBody()[I];
         Blocks[I] = Builder.create<arith::IndexCastOp>(
             Loc, IndexType::get(Builder.getContext()),
             Builder.create<LLVM::LoadOp>(
@@ -355,7 +349,7 @@ ValueCategory MLIRScanner::callHelper(
     Value Threads[3];
     for (int I = 0; I < 3; I++) {
       Value Val = T0.val;
-      if (auto MT = Val.getType().dyn_cast<MemRefType>()) {
+      if (auto MT = dyn_cast<MemRefType>(Val.getType())) {
         assert(MT.getShape().size() == 2);
         Threads[I] = Builder.create<arith::IndexCastOp>(
             Loc, IndexType::get(Builder.getContext()),
@@ -363,8 +357,8 @@ ValueCategory MLIRScanner::callHelper(
                 Loc, Val,
                 ValueRange({getConstantIndex(0), getConstantIndex(I)})));
       } else {
-        auto PT = Val.getType().cast<LLVM::LLVMPointerType>();
-        auto ET = PT.getElementType().cast<LLVM::LLVMStructType>().getBody()[I];
+        auto PT = cast<LLVM::LLVMPointerType>(Val.getType());
+        auto ET = cast<LLVM::LLVMStructType>(PT.getElementType()).getBody()[I];
         Threads[I] = Builder.create<arith::IndexCastOp>(
             Loc, IndexType::get(Builder.getContext()),
             Builder.create<LLVM::LoadOp>(
@@ -477,7 +471,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
           llvm::Constant *LC = Glob.getCGM().GetAddrOfRTTIDescriptor(LT);
           llvm::Constant *RC = Glob.getCGM().GetAddrOfRTTIDescriptor(RT);
           auto PostTy =
-              Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
+              cast<IntegerType>(Glob.getTypes().getMLIRType(Expr->getType()));
           return ValueCategory(
               Builder.create<arith::ConstantIntOp>(Loc, LC == RC, PostTy),
               false);
@@ -527,7 +521,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
         arith::AtomicRMWKind Op;
         LLVM::AtomicBinOp Lop;
         if (Sr->getDecl()->getName() == "atomicAdd") {
-          if (A1.getType().isa<IntegerType>()) {
+          if (isa<IntegerType>(A1.getType())) {
             Op = arith::AtomicRMWKind::addi;
             Lop = LLVM::AtomicBinOp::add;
           } else {
@@ -543,7 +537,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
         } else
           assert(0);
 
-        if (A0.getType().isa<MemRefType>())
+        if (isa<MemRefType>(A0.getType()))
           return ValueCategory(
               Builder.create<memref::AtomicRMWOp>(
                   Loc, Op, A1, A0, std::vector<Value>({getConstantIndex(0)})),
@@ -569,7 +563,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
     if (IsReference) {
       assert(Sub.isReference);
       Value Val = Sub.val;
-      if (auto MT = Val.getType().dyn_cast<MemRefType>()) {
+      if (auto MT = dyn_cast<MemRefType>(Val.getType())) {
         Val = Builder.create<polygeist::Memref2PointerOp>(
             Loc,
             LLVM::LLVMPointerType::get(MT.getElementType(),
@@ -584,11 +578,8 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
 
     if (IsArray) {
       assert(Sub.isReference);
-      auto MT =
-          Glob.getTypes()
-              .getMLIRType(Glob.getCGM().getContext().getLValueReferenceType(
-                  E->getType()))
-              .cast<MemRefType>();
+      auto MT = cast<MemRefType>(Glob.getTypes().getMLIRType(
+          Glob.getCGM().getContext().getLValueReferenceType(E->getType())));
       auto Shape = std::vector<int64_t>(MT.getShape());
       assert(Shape.size() == 2);
 
@@ -607,11 +598,10 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
       Sub = ValueCategory(Alloc, /*isRef*/ true);
     }
     auto Val = Sub.getValue(Builder);
-    if (auto MT = Val.getType().dyn_cast<MemRefType>()) {
-      auto Nt = TypeTranslator
-                    .translateType(mlirclang::anonymize(
-                        mlirclang::getLLVMType(E->getType(), Glob.getCGM())))
-                    .cast<LLVM::LLVMPointerType>();
+    if (auto MT = dyn_cast<MemRefType>(Val.getType())) {
+      auto Nt = cast<LLVM::LLVMPointerType>(
+          TypeTranslator.translateType(mlirclang::anonymize(
+              mlirclang::getLLVMType(E->getType(), Glob.getCGM()))));
       assert(Nt.getAddressSpace() == MT.getMemorySpaceAsInt() &&
              "val does not have the same memory space as nt");
       Val = Builder.create<polygeist::Memref2PointerOp>(Loc, Nt, Val);
@@ -647,7 +637,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
   }
   case clang::Builtin::BI__builtin_isnormal: {
     Value V = GetLLVM(Expr->getArg(0));
-    auto Ty = V.getType().cast<FloatType>();
+    auto Ty = cast<FloatType>(V.getType());
     Value Eq =
         Builder.create<arith::CmpFOp>(Loc, arith::CmpFPredicate::OEQ, V, V);
 
@@ -663,20 +653,20 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
     V = Builder.create<arith::AndIOp>(Loc, Eq, IsLessThanInf);
     V = Builder.create<arith::AndIOp>(Loc, V, IsNormal);
     auto PostTy =
-        Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
+        cast<IntegerType>(Glob.getTypes().getMLIRType(Expr->getType()));
     Value Res = Builder.create<arith::ExtUIOp>(Loc, PostTy, V);
     return ValueCategory(Res, /*isRef*/ false);
   }
   case clang::Builtin::BI__builtin_signbit: {
     Value V = GetLLVM(Expr->getArg(0));
-    auto Ty = V.getType().cast<FloatType>();
+    auto Ty = cast<FloatType>(V.getType());
     auto ITy = Builder.getIntegerType(Ty.getWidth());
     Value BC = Builder.create<arith::BitcastOp>(Loc, ITy, V);
     auto ZeroV = Builder.create<arith::ConstantIntOp>(Loc, 0, ITy);
     V = Builder.create<arith::CmpIOp>(Loc, arith::CmpIPredicate::slt, BC,
                                       ZeroV);
     auto PostTy =
-        Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
+        cast<IntegerType>(Glob.getTypes().getMLIRType(Expr->getType()));
     Value Res = Builder.create<arith::ExtUIOp>(Loc, PostTy, V);
     return ValueCategory(Res, /*isRef*/ false);
   }
@@ -687,26 +677,26 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
     Type T = Glob.getTypes().getMLIRType(Expr->getType());
     if (T == Val.getType())
       return ValueCategory(Val, /*isRef*/ false);
-    if (T.isa<LLVM::LLVMPointerType>()) {
-      if (Val.getType().isa<MemRefType>()) {
-        assert(Val.getType().cast<MemRefType>().getMemorySpaceAsInt() ==
-                   T.cast<LLVM::LLVMPointerType>().getAddressSpace() &&
+    if (isa<LLVM::LLVMPointerType>(T)) {
+      if (isa<MemRefType>(Val.getType())) {
+        assert(cast<MemRefType>(Val.getType()).getMemorySpaceAsInt() ==
+                   cast<LLVM::LLVMPointerType>(T).getAddressSpace() &&
                "val does not have the same memory space as T");
         Val = Builder.create<polygeist::Memref2PointerOp>(Loc, T, Val);
       } else if (T != Val.getType())
         Val = Builder.create<LLVM::BitcastOp>(Loc, T, Val);
       return ValueCategory(Val, /*isRef*/ false);
     }
-    assert(T.isa<MemRefType>());
+    assert(isa<MemRefType>(T));
 
-    if (Val.getType().isa<MemRefType>())
+    if (isa<MemRefType>(Val.getType()))
       Val = Builder.create<polygeist::Memref2PointerOp>(
           Loc,
           LLVM::LLVMPointerType::get(
               Builder.getI8Type(),
-              Val.getType().cast<MemRefType>().getMemorySpaceAsInt()),
+              cast<MemRefType>(Val.getType()).getMemorySpaceAsInt()),
           Val);
-    if (Val.getType().isa<LLVM::LLVMPointerType>())
+    if (isa<LLVM::LLVMPointerType>(Val.getType()))
       Val = Builder.create<polygeist::Pointer2MemrefOp>(Loc, T, Val);
     return ValueCategory(Val, /*isRef*/ false);
 
@@ -735,7 +725,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
         for (auto *A : Expr->arguments()) {
           Args.push_back(Visit(A).getValue(Builder));
         }
-        if (Args[1].getType().isa<IntegerType>())
+        if (isa<IntegerType>(Args[1].getType()))
           return ValueCategory(
               Builder.create<LLVM::PowIOp>(Loc, MLIRType, Args[0], Args[1]),
               /*isReference*/ false);
@@ -760,11 +750,11 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
         // x != NaN via the ordered compare in either case.
         Value V = GetLLVM(Expr->getArg(0));
         Value Fabs;
-        if (V.getType().isa<FloatType>())
+        if (isa<FloatType>(V.getType()))
           Fabs = Builder.create<math::AbsFOp>(Loc, V);
         else {
           auto Zero = Builder.create<arith::ConstantIntOp>(
-              Loc, 0, V.getType().cast<IntegerType>().getWidth());
+              Loc, 0, cast<IntegerType>(V.getType()).getWidth());
           Fabs = Builder.create<arith::SelectOp>(
               Loc,
               Builder.create<arith::CmpIOp>(Loc, arith::CmpIPredicate::sge, V,
@@ -825,7 +815,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
         // isfinite(x) --> fabs(x) != infinity
         // x != NaN via the ordered compare in either case.
         Value V = GetLLVM(Expr->getArg(0));
-        auto Ty = V.getType().cast<FloatType>();
+        auto Ty = cast<FloatType>(V.getType());
         Value Fabs = Builder.create<math::AbsFOp>(Loc, V);
         auto Infinity = Builder.create<arith::ConstantFloatOp>(
             Loc, APFloat::getInf(Ty.getFloatSemantics()), Ty);
@@ -835,7 +825,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
                         : arith::CmpFPredicate::ONE;
         Value FCmp = Builder.create<arith::CmpFOp>(Loc, Pred, Fabs, Infinity);
         auto PostTy =
-            Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
+            cast<IntegerType>(Glob.getTypes().getMLIRType(Expr->getType()));
         Value Res = Builder.create<arith::ExtUIOp>(Loc, PostTy, FCmp);
         return ValueCategory(Res, /*isRef*/ false);
       }
@@ -846,7 +836,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
         Value Eq =
             Builder.create<arith::CmpFOp>(Loc, arith::CmpFPredicate::UNO, V, V);
         auto PostTy =
-            Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
+            cast<IntegerType>(Glob.getTypes().getMLIRType(Expr->getType()));
         Value Res = Builder.create<arith::ExtUIOp>(Loc, PostTy, Eq);
         return ValueCategory(Res, /*isRef*/ false);
       }
@@ -947,7 +937,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
         for (auto *A : Expr->arguments()) {
           auto V = GetLLVM(A);
           if (auto Toper = V.getDefiningOp<polygeist::Memref2PointerOp>()) {
-            auto T = Toper.getType().cast<LLVM::LLVMPointerType>();
+            auto T = cast<LLVM::LLVMPointerType>(Toper.getType());
             auto Idx = Counts[T.getAsOpaquePointer()]++;
             auto Aop = allocateBuffer(Idx, T);
             Args.push_back(Aop.getResult());
@@ -1062,7 +1052,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
           LLVM::LLVMFunctionType FuncTy = StrcmpF.getFunctionType();
           for (unsigned I = 0; I < FuncTy.getNumParams(); ++I) {
             Type CallerArgType = Args[I].getType();
-            if (CallerArgType.isa<LLVM::LLVMPointerType>()) {
+            if (isa<LLVM::LLVMPointerType>(CallerArgType)) {
               Type CalleeArgType = FuncTy.getParamType(I);
               Args[I] = castToMemSpaceOfType(Args[I], CalleeArgType);
             }
@@ -1073,7 +1063,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
           SmallVector<Type> RTs = {
               TypeTranslator.translateType(mlirclang::anonymize(
                   mlirclang::getLLVMType(Expr->getType(), Glob.getCGM())))};
-          if (RTs[0].isa<LLVM::LLVMVoidType>())
+          if (isa<LLVM::LLVMVoidType>(RTs[0]))
             RTs.clear();
           Called = Builder.create<LLVM::CallOp>(Loc, RTs, Args).getResult();
         }
@@ -1102,19 +1092,16 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
       SmallVector<Type> RTs = {TypeTranslator.translateType(
           mlirclang::anonymize(mlirclang::getLLVMType(CT, Glob.getCGM())))};
 
-      auto Ft = Args[0]
-                    .getType()
-                    .cast<LLVM::LLVMPointerType>()
-                    .getElementType()
-                    .cast<LLVM::LLVMFunctionType>();
+      auto Ft = cast<LLVM::LLVMFunctionType>(
+          cast<LLVM::LLVMPointerType>(Args[0].getType()).getElementType());
       assert(RTs[0] == Ft.getReturnType());
-      if (RTs[0].isa<LLVM::LLVMVoidType>())
+      if (isa<LLVM::LLVMVoidType>(RTs[0]))
         RTs.clear();
       Called = Builder.create<LLVM::CallOp>(Loc, RTs, Args).getResult();
     }
     if (IsReference) {
-      if (!(Called.getType().isa<LLVM::LLVMPointerType>() ||
-            Called.getType().isa<MemRefType>())) {
+      if (!(isa<LLVM::LLVMPointerType>(Called.getType()) ||
+            isa<MemRefType>(Called.getType()))) {
         Expr->dump();
         Expr->getType()->dump();
         llvm::errs() << " call: " << Called << "\n";
@@ -1185,7 +1172,7 @@ MLIRScanner::emitGPUCallExpr(clang::CallExpr *Expr) {
           Sub = BC->getSubExpr();
         Value Arg = Visit(Sub).getValue(Builder);
 
-        if (Arg.getType().isa<LLVM::LLVMPointerType>()) {
+        if (isa<LLVM::LLVMPointerType>(Arg.getType())) {
           const clang::FunctionDecl *Callee = EmitCallee(Expr->getCallee());
           LLVM::LLVMFuncOp StrcmpF = Glob.getOrCreateLLVMFunction(
               Callee, mlirclang::getFuncContext(Function));
@@ -1215,8 +1202,8 @@ MLIRScanner::emitGPUCallExpr(clang::CallExpr *Expr) {
           Sub = BC->getSubExpr();
         {
           auto Dst = Visit(Sub).getValue(Builder);
-          if (auto Omt = Dst.getType().dyn_cast<MemRefType>()) {
-            if (auto MT = Omt.getElementType().dyn_cast<MemRefType>()) {
+          if (auto Omt = dyn_cast<MemRefType>(Dst.getType())) {
+            if (auto MT = dyn_cast<MemRefType>(Omt.getElementType())) {
               auto Shape = std::vector<int64_t>(MT.getShape());
 
               auto ElemSize = getTypeSize(
@@ -1501,7 +1488,7 @@ MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
   case clang::Builtin::BI__builtin_isgreater: {
     VisitArgs();
     auto PostTy =
-        Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
+        cast<IntegerType>(Glob.getTypes().getMLIRType(Expr->getType()));
     V = Builder.create<arith::ExtUIOp>(
         Loc, PostTy,
         Builder.create<arith::CmpFOp>(Loc, arith::CmpFPredicate::OGT, Args[0],
@@ -1510,7 +1497,7 @@ MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
   case clang::Builtin::BI__builtin_isgreaterequal: {
     VisitArgs();
     auto PostTy =
-        Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
+        cast<IntegerType>(Glob.getTypes().getMLIRType(Expr->getType()));
     V = Builder.create<arith::ExtUIOp>(
         Loc, PostTy,
         Builder.create<arith::CmpFOp>(Loc, arith::CmpFPredicate::OGE, Args[0],
@@ -1519,7 +1506,7 @@ MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
   case clang::Builtin::BI__builtin_isless: {
     VisitArgs();
     auto PostTy =
-        Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
+        cast<IntegerType>(Glob.getTypes().getMLIRType(Expr->getType()));
     V = Builder.create<arith::ExtUIOp>(
         Loc, PostTy,
         Builder.create<arith::CmpFOp>(Loc, arith::CmpFPredicate::OLT, Args[0],
@@ -1528,7 +1515,7 @@ MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
   case clang::Builtin::BI__builtin_islessequal: {
     VisitArgs();
     auto PostTy =
-        Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
+        cast<IntegerType>(Glob.getTypes().getMLIRType(Expr->getType()));
     V = Builder.create<arith::ExtUIOp>(
         Loc, PostTy,
         Builder.create<arith::CmpFOp>(Loc, arith::CmpFPredicate::OLE, Args[0],
@@ -1537,7 +1524,7 @@ MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
   case clang::Builtin::BI__builtin_islessgreater: {
     VisitArgs();
     auto PostTy =
-        Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
+        cast<IntegerType>(Glob.getTypes().getMLIRType(Expr->getType()));
     V = Builder.create<arith::ExtUIOp>(
         Loc, PostTy,
         Builder.create<arith::CmpFOp>(Loc, arith::CmpFPredicate::ONE, Args[0],
@@ -1546,7 +1533,7 @@ MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
   case clang::Builtin::BI__builtin_isunordered: {
     VisitArgs();
     auto PostTy =
-        Glob.getTypes().getMLIRType(Expr->getType()).cast<IntegerType>();
+        cast<IntegerType>(Glob.getTypes().getMLIRType(Expr->getType()));
     V = Builder.create<arith::ExtUIOp>(
         Loc, PostTy,
         Builder.create<arith::CmpFOp>(Loc, arith::CmpFPredicate::UNO, Args[0],

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -35,7 +35,7 @@ static Value castCallerMemRefArg(Value CallerArg, Type CalleeArgType,
   OpBuilder::InsertionGuard Guard(B);
   Type CallerArgType = CallerArg.getType();
 
-  if (MemRefType DstTy = CalleeArgType.dyn_cast_or_null<MemRefType>()) {
+  if (MemRefType DstTy = dyn_cast_or_null<MemRefType>(CalleeArgType)) {
     MemRefType SrcTy = dyn_cast<MemRefType>(CallerArgType);
     if (SrcTy && DstTy.getElementType() == SrcTy.getElementType() &&
         DstTy.getMemorySpace() == SrcTy.getMemorySpace()) {

--- a/polygeist/tools/cgeist/Lib/CGDecl.cc
+++ b/polygeist/tools/cgeist/Lib/CGDecl.cc
@@ -30,10 +30,8 @@ ValueCategory MLIRScanner::VisitVarDecl(clang::VarDecl *Decl) {
   const unsigned MemType = Decl->hasAttr<clang::CUDASharedAttr>() ? 5 : 0;
   bool LLVMABI = false, IsArray = false;
 
-  if (Glob.getTypes()
-          .getMLIRType(Glob.getCGM().getContext().getLValueReferenceType(
-              Decl->getType()))
-          .isa<LLVM::LLVMPointerType>())
+  if (isa<LLVM::LLVMPointerType>(Glob.getTypes().getMLIRType(
+          Glob.getCGM().getContext().getLValueReferenceType(Decl->getType()))))
     LLVMABI = true;
   else
     Glob.getTypes().getMLIRType(Decl->getType(), &IsArray);
@@ -47,7 +45,7 @@ ValueCategory MLIRScanner::VisitVarDecl(clang::VarDecl *Decl) {
 
   if (Expr *Init = Decl->getInit()) {
     bool IsVectorType =
-        Glob.getTypes().getMLIRType(Init->getType()).isa<mlir::VectorType>();
+        isa<mlir::VectorType>(Glob.getTypes().getMLIRType(Init->getType()));
     if ((!isa<clang::InitListExpr>(Init) || IsVectorType) &&
         !isa<clang::CXXConstructExpr>(Init)) {
       auto Res = Visit(Init);
@@ -111,10 +109,8 @@ ValueCategory MLIRScanner::VisitVarDecl(clang::VarDecl *Decl) {
     ABuilder.setInsertionPointToStart(AllocationScope);
     Location VarLoc = getMLIRLocation(Decl->getBeginLoc());
 
-    if (Glob.getTypes()
-            .getMLIRType(
-                Glob.getCGM().getContext().getPointerType(Decl->getType()))
-            .isa<LLVM::LLVMPointerType>())
+    if (isa<LLVM::LLVMPointerType>(Glob.getTypes().getMLIRType(
+            Glob.getCGM().getContext().getPointerType(Decl->getType()))))
       Op = ABuilder.create<LLVM::AddressOfOp>(
           VarLoc, Glob.getOrCreateLLVMGlobal(
                       Decl, (Function.getName() + "@static@").str()));

--- a/polygeist/tools/cgeist/Lib/CGStmt.cc
+++ b/polygeist/tools/cgeist/Lib/CGStmt.cc
@@ -249,12 +249,12 @@ ValueCategory MLIRScanner::VisitForStmt(clang::ForStmt *Fors) {
     if (auto *S = Fors->getCond()) {
       auto CondRes = Visit(S);
       auto Cond = CondRes.getValue(Builder);
-      if (auto LT = Cond.getType().dyn_cast<LLVM::LLVMPointerType>()) {
+      if (auto LT = dyn_cast<LLVM::LLVMPointerType>(Cond.getType())) {
         auto NullptrLlvm = Builder.create<LLVM::NullOp>(Loc, LT);
         Cond = Builder.create<LLVM::ICmpOp>(Loc, LLVM::ICmpPredicate::ne, Cond,
                                             NullptrLlvm);
       }
-      auto Ty = Cond.getType().cast<IntegerType>();
+      auto Ty = cast<IntegerType>(Cond.getType());
       if (Ty.getWidth() != 1) {
         Cond = Builder.create<arith::CmpIOp>(
             Loc, arith::CmpIPredicate::ne, Cond,
@@ -333,12 +333,12 @@ ValueCategory MLIRScanner::VisitCXXForRangeStmt(clang::CXXForRangeStmt *Fors) {
   if (auto *S = Fors->getCond()) {
     auto CondRes = Visit(S);
     auto Cond = CondRes.getValue(Builder);
-    if (auto LT = Cond.getType().dyn_cast<LLVM::LLVMPointerType>()) {
+    if (auto LT = dyn_cast<LLVM::LLVMPointerType>(Cond.getType())) {
       auto NullptrLlvm = Builder.create<LLVM::NullOp>(Loc, LT);
       Cond = Builder.create<LLVM::ICmpOp>(Loc, LLVM::ICmpPredicate::ne, Cond,
                                           NullptrLlvm);
     }
-    auto Ty = Cond.getType().cast<IntegerType>();
+    auto Ty = cast<IntegerType>(Cond.getType());
     if (Ty.getWidth() != 1) {
       Cond = Builder.create<arith::CmpIOp>(
           Loc, arith::CmpIPredicate::ne, Cond,
@@ -490,10 +490,9 @@ ValueCategory MLIRScanner::VisitOMPForDirective(clang::OMPForDirective *Fors) {
 
     bool LLVMABI = false;
     bool IsArray = false;
-    if (Glob.getTypes()
-            .getMLIRType(Glob.getCGM().getContext().getLValueReferenceType(
-                Name->getType()))
-            .isa<LLVM::LLVMPointerType>())
+    if (isa<LLVM::LLVMPointerType>(Glob.getTypes().getMLIRType(
+            Glob.getCGM().getContext().getLValueReferenceType(
+                Name->getType()))))
       LLVMABI = true;
     else
       Glob.getTypes().getMLIRType(Name->getType(), &IsArray);
@@ -556,10 +555,9 @@ MLIRScanner::VisitOMPParallelDirective(clang::OMPParallelDirective *Par) {
         bool LLVMABI = false;
         bool IsArray = false;
         Type Ty;
-        if (Glob.getTypes()
-                .getMLIRType(Glob.getCGM().getContext().getLValueReferenceType(
-                    Name->getType()))
-                .isa<LLVM::LLVMPointerType>()) {
+        if (isa<LLVM::LLVMPointerType>(Glob.getTypes().getMLIRType(
+                Glob.getCGM().getContext().getLValueReferenceType(
+                    Name->getType())))) {
           LLVMABI = true;
           bool Undef;
           Ty = Glob.getTypes().getMLIRType(Name->getType(), &Undef);
@@ -665,10 +663,9 @@ ValueCategory MLIRScanner::VisitOMPParallelForDirective(
 
     bool LLVMABI = false;
     bool IsArray = false;
-    if (Glob.getTypes()
-            .getMLIRType(Glob.getCGM().getContext().getLValueReferenceType(
-                Name->getType()))
-            .isa<LLVM::LLVMPointerType>())
+    if (isa<LLVM::LLVMPointerType>(Glob.getTypes().getMLIRType(
+            Glob.getCGM().getContext().getLValueReferenceType(
+                Name->getType()))))
       LLVMABI = true;
     else
       Glob.getTypes().getMLIRType(Name->getType(), &IsArray);
@@ -723,12 +720,12 @@ ValueCategory MLIRScanner::VisitDoStmt(clang::DoStmt *Fors) {
   if (auto *S = Fors->getCond()) {
     auto CondRes = Visit(S);
     auto Cond = CondRes.getValue(Builder);
-    if (auto LT = Cond.getType().dyn_cast<LLVM::LLVMPointerType>()) {
+    if (auto LT = dyn_cast<LLVM::LLVMPointerType>(Cond.getType())) {
       auto NullptrLlvm = Builder.create<LLVM::NullOp>(Loc, LT);
       Cond = Builder.create<LLVM::ICmpOp>(Loc, LLVM::ICmpPredicate::ne, Cond,
                                           NullptrLlvm);
     }
-    auto Ty = Cond.getType().cast<IntegerType>();
+    auto Ty = cast<IntegerType>(Cond.getType());
     if (Ty.getWidth() != 1) {
       Cond = Builder.create<arith::CmpIOp>(
           Loc, arith::CmpIPredicate::ne, Cond,
@@ -784,12 +781,12 @@ ValueCategory MLIRScanner::VisitWhileStmt(clang::WhileStmt *Fors) {
   if (auto *S = Fors->getCond()) {
     auto CondRes = Visit(S);
     auto Cond = CondRes.getValue(Builder);
-    if (auto LT = Cond.getType().dyn_cast<LLVM::LLVMPointerType>()) {
+    if (auto LT = dyn_cast<LLVM::LLVMPointerType>(Cond.getType())) {
       auto NullptrLlvm = Builder.create<LLVM::NullOp>(Loc, LT);
       Cond = Builder.create<LLVM::ICmpOp>(Loc, LLVM::ICmpPredicate::ne, Cond,
                                           NullptrLlvm);
     }
-    auto Ty = Cond.getType().cast<IntegerType>();
+    auto Ty = cast<IntegerType>(Cond.getType());
     if (Ty.getWidth() != 1) {
       Cond = Builder.create<arith::CmpIOp>(
           Loc, arith::CmpIPredicate::ne, Cond,
@@ -826,20 +823,20 @@ ValueCategory MLIRScanner::VisitIfStmt(clang::IfStmt *Stmt) {
 
   auto OldPoint = Builder.getInsertionPoint();
   auto *OldBlock = Builder.getInsertionBlock();
-  if (auto LT = Cond.getType().dyn_cast<MemRefType>()) {
+  if (auto LT = dyn_cast<MemRefType>(Cond.getType())) {
     Cond = Builder.create<polygeist::Memref2PointerOp>(
         Loc, LLVM::LLVMPointerType::get(Builder.getI8Type()), Cond);
   }
-  if (auto LT = Cond.getType().dyn_cast<LLVM::LLVMPointerType>()) {
+  if (auto LT = dyn_cast<LLVM::LLVMPointerType>(Cond.getType())) {
     auto NullptrLlvm = Builder.create<LLVM::NullOp>(Loc, LT);
     Cond = Builder.create<LLVM::ICmpOp>(Loc, LLVM::ICmpPredicate::ne, Cond,
                                         NullptrLlvm);
   }
-  if (!Cond.getType().isa<IntegerType>()) {
+  if (!isa<IntegerType>(Cond.getType())) {
     Stmt->dump();
     llvm::errs() << " cond: " << Cond << " ct: " << Cond.getType() << "\n";
   }
-  auto PrevTy = Cond.getType().cast<IntegerType>();
+  auto PrevTy = cast<IntegerType>(Cond.getType());
   if (!PrevTy.isInteger(1)) {
     Cond = Builder.create<arith::CmpIOp>(
         Loc, arith::CmpIPredicate::ne, Cond,
@@ -965,7 +962,7 @@ ValueCategory MLIRScanner::VisitSwitchStmt(clang::SwitchStmt *Stmt) {
   DenseIntElementsAttr CaseValuesAttr;
   ShapedType CaseValueType =
       VectorType::get(static_cast<int64_t>(CaseVals.size()), Cond.getType());
-  auto Ity = Cond.getType().cast<IntegerType>();
+  auto Ity = cast<IntegerType>(Cond.getType());
   if (Ity.getWidth() == 64)
     CaseValuesAttr = DenseIntElementsAttr::get(CaseValueType, CaseVals);
   else if (Ity.getWidth() == 32) {
@@ -1104,19 +1101,19 @@ ValueCategory MLIRScanner::VisitReturnStmt(clang::ReturnStmt *Stmt) {
     assert(Rv.val && "expect right value to be valid");
     assert(Rv.isReference && "right value must be a reference");
     auto Op = Function.getArgument(Function.getNumArguments() - 1);
-    assert(Rv.val.getType().cast<MemRefType>().getElementType() ==
-               Op.getType().cast<MemRefType>().getElementType() &&
+    assert(cast<MemRefType>(Rv.val.getType()).getElementType() ==
+               cast<MemRefType>(Op.getType()).getElementType() &&
            "type mismatch");
-    assert(Op.getType().cast<MemRefType>().getShape().size() == 2 &&
+    assert(cast<MemRefType>(Op.getType()).getShape().size() == 2 &&
            "expect 2d memref");
-    assert(Rv.val.getType().cast<MemRefType>().getShape().size() == 2 &&
+    assert(cast<MemRefType>(Rv.val.getType()).getShape().size() == 2 &&
            "expect 2d memref");
-    assert(Rv.val.getType().cast<MemRefType>().getShape()[1] ==
-           Op.getType().cast<MemRefType>().getShape()[1]);
+    assert(cast<MemRefType>(Rv.val.getType()).getShape()[1] ==
+           cast<MemRefType>(Op.getType()).getShape()[1]);
 
-    for (int I = 0; I < Op.getType().cast<MemRefType>().getShape()[1]; I++) {
+    for (int I = 0; I < cast<MemRefType>(Op.getType()).getShape()[1]; I++) {
       std::vector<Value> Idx = {getConstantIndex(0), getConstantIndex(I)};
-      assert(Rv.val.getType().cast<MemRefType>().getShape().size() == 2);
+      assert(cast<MemRefType>(Rv.val.getType()).getShape().size() == 2);
       Builder.create<memref::StoreOp>(
           Loc, Builder.create<memref::LoadOp>(Loc, Rv.val, Idx), Op, Idx);
     }
@@ -1136,19 +1133,19 @@ ValueCategory MLIRScanner::VisitReturnStmt(clang::ReturnStmt *Stmt) {
         Val = Rv.getValue(Builder);
       }
 
-      auto PostTy = ReturnVal.getType().cast<MemRefType>().getElementType();
-      if (auto PrevTy = Val.getType().dyn_cast<IntegerType>()) {
+      auto PostTy = cast<MemRefType>(ReturnVal.getType()).getElementType();
+      if (auto PrevTy = dyn_cast<IntegerType>(Val.getType())) {
         const auto SrcTy = Stmt->getRetValue()->getType();
         const auto IsSigned =
             SrcTy->isBooleanType() ? false : SrcTy->isSignedIntegerType();
         Val = Rv.IntCast(Builder, getMLIRLocation(Stmt->getReturnLoc()), PostTy,
                          IsSigned)
                   .val;
-      } else if (Val.getType().isa<MemRefType>() &&
-                 PostTy.isa<LLVM::LLVMPointerType>())
+      } else if (isa<MemRefType>(Val.getType()) &&
+                 isa<LLVM::LLVMPointerType>(PostTy))
         Val = Builder.create<polygeist::Memref2PointerOp>(Loc, PostTy, Val);
-      else if (Val.getType().isa<LLVM::LLVMPointerType>() &&
-               PostTy.isa<MemRefType>())
+      else if (isa<LLVM::LLVMPointerType>(Val.getType()) &&
+               isa<MemRefType>(PostTy))
         Val = Builder.create<polygeist::Pointer2MemrefOp>(Loc, PostTy, Val);
       if (PostTy != Val.getType()) {
         Stmt->dump();

--- a/polygeist/tools/cgeist/Lib/ConstantFolder.cc
+++ b/polygeist/tools/cgeist/Lib/ConstantFolder.cc
@@ -13,8 +13,8 @@ using namespace mlirclang;
 
 Value ConstantFolder::foldFPCast(Location Loc, Type PromotionType,
                                  arith::ConstantOp C) {
-  assert(PromotionType.isa<FloatType>() && "Expecting FP type");
-  const auto Attr = C.getValueAttr().cast<FloatAttr>();
+  assert(isa<FloatType>(PromotionType) && "Expecting FP type");
+  const auto Attr = cast<FloatAttr>(C.getValueAttr());
   const auto NewAttr =
       FloatAttr::get(PromotionType, Attr.getValue().convertToDouble());
   return Builder.createOrFold<arith::ConstantOp>(Loc, NewAttr, PromotionType);

--- a/polygeist/tools/cgeist/Lib/TypeUtils.cc
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.cc
@@ -333,9 +333,8 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
                                       NumElems, Body);
     }
     case TypeEnum::SwizzleOp: {
-      const auto VecType =
-          CGT.getMLIRTypeForMem(CTS->getTemplateArgs().get(0).getAsType())
-              .cast<mlir::sycl::VecType>();
+      const auto VecType = cast<mlir::sycl::VecType>(
+          CGT.getMLIRTypeForMem(CTS->getTemplateArgs().get(0).getAsType()));
       const auto IndexesArgs = CTS->getTemplateArgs().get(4).getPackAsArray();
       SmallVector<int> Indexes;
       Indexes.reserve(IndexesArgs.size());
@@ -378,10 +377,10 @@ llvm::Type *getLLVMType(const clang::QualType QT,
 }
 
 template <typename MLIRTy> static bool isTyOrTyVectorTy(mlir::Type Ty) {
-  if (Ty.isa<MLIRTy>())
+  if (isa<MLIRTy>(Ty))
     return true;
-  const auto VecTy = Ty.dyn_cast<mlir::VectorType>();
-  return VecTy && VecTy.getElementType().isa<MLIRTy>();
+  const auto VecTy = dyn_cast<mlir::VectorType>(Ty);
+  return VecTy && isa<MLIRTy>(VecTy.getElementType());
 }
 
 bool isFPOrFPVectorTy(mlir::Type Ty) {

--- a/polygeist/tools/cgeist/Lib/TypeUtils.h
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.h
@@ -64,18 +64,20 @@ bool isFPOrFPVectorTy(mlir::Type Ty);
 bool isIntOrIntVectorTy(mlir::Type Ty);
 
 inline bool isPointerOrMemRefTy(mlir::Type Ty) {
-  return Ty.isa<mlir::MemRefType, mlir::LLVM::LLVMPointerType>();
+  return llvm::isa<mlir::MemRefType, mlir::LLVM::LLVMPointerType>(Ty);
 }
 
 inline bool isFirstClassType(mlir::Type Ty) {
-  return Ty.isa<mlir::IntegerType, mlir::IndexType, mlir::FloatType,
-                mlir::VectorType, mlir::MemRefType, mlir::LLVM::LLVMPointerType,
-                mlir::LLVM::LLVMStructType>() ||
+  return llvm::isa<mlir::IntegerType, mlir::IndexType, mlir::FloatType,
+                   mlir::VectorType, mlir::MemRefType,
+                   mlir::LLVM::LLVMPointerType, mlir::LLVM::LLVMStructType>(
+             Ty) ||
          mlir::sycl::isSYCLType(Ty);
 }
 
 inline bool isAggregateType(mlir::Type Ty) {
-  return Ty.isa<mlir::LLVM::LLVMStructType>() || mlir::sycl::isSYCLType(Ty);
+  return llvm::isa<mlir::LLVM::LLVMStructType>(Ty) ||
+         mlir::sycl::isSYCLType(Ty);
 }
 
 unsigned getPrimitiveSizeInBits(mlir::Type Ty);


### PR DESCRIPTION
Analog to https://github.com/intel/llvm/pull/8754, replace the use of the [deprecated](https://mlir.llvm.org/deprecation/) `.cast<>`/`.dyn_cast<>`/ `isa<>` member functions with the free function version in Polygeist.