### PR TITLE
[SYCL] Fix reduce_sycl2020 e2e test

### DIFF
--- a/sycl/test-e2e/GroupAlgorithm/reduce_sycl2020.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/reduce_sycl2020.cpp
@@ -111,7 +111,7 @@ int main() {
 
   if (q.get_device().has(aspect::fp64)) {
     std::array<std::complex<double>, N> input_cd;
-    std::array<std::complex<double>, 4> output_cd;
+    std::array<std::complex<double>, 6> output_cd;
     std::iota(input_cd.begin(), input_cd.end(), 0);
     std::fill(output_cd.begin(), output_cd.end(), 0);
     test<class KernelNamePlusComplexD>(q, input_cd, output_cd,


### PR DESCRIPTION
Fixes changes made to `sycl_reduce2020.cpp` E2E test in #8786 - the output array passed to `test` in the `std::complex<double>` case was too small.