### PR TITLE
[SYCL][Matrix] Clean-up for couple tests

### DIFF
--- a/sycl/test-e2e/Matrix/Legacy/XMX8/joint_matrix_bfloat16_32x64.cpp
+++ b/sycl/test-e2e/Matrix/Legacy/XMX8/joint_matrix_bfloat16_32x64.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: matrix
+// REQUIRES: matrix-xmx8
 
 // RUN: %clangxx -fsycl %s -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=1
 // RUN: %CPU_RUN_PLACEHOLDER %t.out

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_int8_packed.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_int8_packed.cpp
@@ -12,9 +12,6 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
 // This test stores the matrix B that is VNNIed (packed).
-// This is expected to fail on the GPU because some built-ins are missing still.
-
-// XFAIL: gpu
 
 #include <iostream>
 #include <random>


### PR DESCRIPTION
One test should start passing after the fix in IGC
Another test should run only if XMX8 is used