### PR TITLE
[SYCL] Update native_specialization_constant when no specialization constants are present

### DIFF
--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -402,7 +402,8 @@ public:
   }
 
   bool native_specialization_constant() const noexcept {
-    return std::all_of(MDeviceImages.begin(), MDeviceImages.end(),
+    return contains_specialization_constants() &&
+           std::all_of(MDeviceImages.begin(), MDeviceImages.end(),
                        [](const device_image_plain &DeviceImage) {
                          return getSyclObjImpl(DeviceImage)
                              ->all_specialization_constant_native();

--- a/sycl/test-e2e/SpecConstants/2020/kernel-bundle-api.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/kernel-bundle-api.cpp
@@ -31,6 +31,7 @@ class TestSetAndGetOnDevice;
 bool test_default_values(sycl::queue q);
 bool test_set_and_get_on_host(sycl::queue q);
 bool test_set_and_get_on_device(sycl::queue q);
+bool test_native_specialization_constant(sycl::queue q);
 
 int main() {
   auto exception_handler = [&](sycl::exception_list exceptions) {
@@ -60,6 +61,12 @@ int main() {
 
   if (!test_set_and_get_on_device(q)) {
     std::cout << "Test for set and get API on device failed!" << std::endl;
+    return 1;
+  }
+
+  if (!test_native_specialization_constant(q)) {
+    std::cout << "Test for native specialization constants failed!"
+              << std::endl;
     return 1;
   }
 
@@ -255,5 +262,15 @@ bool test_set_and_get_on_device(sycl::queue q) {
                    "custom_type specialization constant"))
     return false;
 
+  return true;
+}
+
+bool test_native_specialization_constant(sycl::queue q) {
+  const auto always_false_selector = [](auto device_image) { return false; };
+  auto bundle = sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+      q.get_context(), always_false_selector);
+  if (!check_value(bundle.native_specialization_constant(), false,
+                   "empty bundle native specialization constant"))
+    return false;
   return true;
 }


### PR DESCRIPTION
From the spec update https://github.com/KhronosGroup/SYCL-Docs/pull/346, `native_specialization_constant()` should return false when the kernel bundle contains no specialization constants.