### PR TITLE
[SYCL] Fix unused variable warnings and unittests

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/pipes.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/pipes.hpp
@@ -68,6 +68,9 @@ public:
   // Host API
   static _dataT read(queue &Q, bool &Success,
                      memory_order Order = memory_order::seq_cst) {
+    // Order is currently unused.
+    std::ignore = Order;
+
     const device Dev = Q.get_device();
     bool IsPipeSupported =
         Dev.has_extension("cl_intel_program_scope_host_pipe");
@@ -95,6 +98,9 @@ public:
 
   static void write(queue &Q, const _dataT &Data, bool &Success,
                     memory_order Order = memory_order::seq_cst) {
+    // Order is currently unused.
+    std::ignore = Order;
+
     const device Dev = Q.get_device();
     bool IsPipeSupported =
         Dev.has_extension("cl_intel_program_scope_host_pipe");
@@ -221,6 +227,9 @@ public:
 
   // Host API
   static _dataT read(queue &Q, memory_order Order = memory_order::seq_cst) {
+    // Order is currently unused.
+    std::ignore = Order;
+
     const device Dev = Q.get_device();
     bool IsPipeSupported =
         Dev.has_extension("cl_intel_program_scope_host_pipe");
@@ -241,6 +250,9 @@ public:
 
   static void write(queue &Q, const _dataT &Data,
                     memory_order Order = memory_order::seq_cst) {
+    // Order is currently unused.
+    std::ignore = Order;
+
     const device Dev = Q.get_device();
     bool IsPipeSupported =
         Dev.has_extension("cl_intel_program_scope_host_pipe");

--- a/sycl/unittests/pipes/host_pipe_registration.cpp
+++ b/sycl/unittests/pipes/host_pipe_registration.cpp
@@ -100,6 +100,7 @@ pi_result after_piDeviceGetInfo(pi_device device, pi_device_info param_name,
   switch (param_name) {
   case PI_DEVICE_INFO_EXTENSIONS: {
     if (param_value) {
+      std::ignore = param_value_size;
       assert(param_value_size >= sizeof(MockSupportedExtensions));
       std::memcpy(param_value, MockSupportedExtensions,
                   sizeof(MockSupportedExtensions));
@@ -153,10 +154,10 @@ TEST_F(PipeTest, Basic) {
   // Testing read
   int HostPipeReadData;
   HostPipeReadData = Pipe::read(q);
-  assert(HostPipeReadData == PipeReadVal);
+  EXPECT_EQ(HostPipeReadData, PipeReadVal);
 
   // Testing write
   int HostPipeWriteData = 9;
   Pipe::write(q, HostPipeWriteData);
-  assert(PipeWriteVal == 9);
+  EXPECT_EQ(PipeWriteVal, 9);
 }


### PR DESCRIPTION
This commit fixes unusued variable warnings after
https://github.com/intel/llvm/pull/7468. Additionally it replaces asserts in the unittests with EXPECT_EQ.