### PR TITLE
[SYCL-MLIR] Modify MLIR optimize pipeline

### DIFF
--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -388,13 +388,12 @@ static int optimize(mlir::MLIRContext &Ctx,
     if (DetectReduction)
       OptPM.addPass(polygeist::detectReductionPass());
 
-    mlir::OpPassManager &OptPM2 = PM.nestAny();
-    OptPM2.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
-    OptPM2.addPass(mlir::createCSEPass());
+    OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
+    OptPM.addPass(mlir::createCSEPass());
     // Note: affine dialects must be lowered to allow callees containing affine
     // operations to be inlined.
     if (RaiseToAffine)
-      OptPM2.addPass(mlir::createLowerAffinePass());
+      OptPM.addPass(mlir::createLowerAffinePass());
     if (OmitOptionalMangledFunctionName) {
       // Needed as the inliner pass needs the `MangledFunctionName` attribute to
       // build the call graph.


### PR DESCRIPTION
This PR attempts to change the optimization pipeline for the SYCL-MLIR compiler. The motivation is to remove a source workaround we had to make in SYCL-Bench in order to get the reduction performance opportunity. 
The pipeline ordering between key transformation is as follow:
```
`ArgumentPromotion` -> `CanonicalizeForPass` -> `LICM` -> `DetectReduction` -> `InlinePass`
```
Rationale: 
  - ArgumentPromotion to run first in order to peel struct argument into members and add the noalias attribute to the peeled argument
  - CanonicalizeForPass takes advantage of the `noalias` attribute to probe that load of loop upper bounds using a peeled argument is invariant. This allow WhileLICM to hoist the load and transform `scf.while` to `scf.for`
  - LICM operates on scf.for loops (or affine.for loops) and hoists invariant operation out of the reduction loops in the bmks
  - DetectReduction operates on reduction loops where invariant operation have been hoisted and will detect array reductions and scalarize them.
  - InlinePass need to run after the previous operations to avoid inlining operations and in doing so obfuscating their sematics