### PR TITLE
[SYCL] Fix CTAD-related issue with std::lock_guard

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1321,7 +1321,7 @@ void ProgramManager::addImages(pi_device_binaries DeviceBinary) {
       }
       // ... and initialize associated host_pipe information
       {
-        std::lock_guard HostPipesGuard(m_HostPipesMutex);
+        std::lock_guard<std::mutex> HostPipesGuard(m_HostPipesMutex);
         auto HostPipes = Img->getHostPipes();
         for (const pi_device_binary_property &HostPipe : HostPipes) {
           ByteArray HostPipeInfo = DeviceBinaryProperty(HostPipe).asByteArray();


### PR DESCRIPTION
This patch fixes post-commit failure introduced in https://github.com/intel/llvm/pull/7468:

```
/Users/runner/work/llvm/llvm/src/sycl/source/detail/program_manager/program_manager.cpp:1324:9: error: 'lock_guard' may not intend to support class template argument deduction [-Werror,-Wctad-maybe-unsupported]
        std::lock_guard HostPipesGuard(m_HostPipesMutex);
        ^
```