### PR TITLE
[SYCL] Add sycl/test-e2e tests to in-tree build

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -507,3 +507,5 @@ add_custom_target(deploy-sycl-toolchain
 
 # SYCL Runtime documentation
 add_subdirectory(doc)
+# SYCL End-to-End tests
+add_subdirectory(test-e2e)


### PR DESCRIPTION
This change enables sycl/test-e2e test targets inside SYCL runtime library build workspace.