### PR TITLE
[SYCL] Disable test-e2e/AtomicRef/atomic_memory_order_acq_rel.cpp

### DIFF
--- a/sycl/test-e2e/AtomicRef/atomic_memory_order_acq_rel.cpp
+++ b/sycl/test-e2e/AtomicRef/atomic_memory_order_acq_rel.cpp
@@ -4,7 +4,7 @@
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
 // https://github.com/intel/llvm/issues/8847
-// UNSUPPORTED: *
+// REQUIRES: TEMPORARY_DISABLED
 // NOTE: Tests fetch_add for acquire and release memory ordering.
 
 #include "atomic_memory_order.h"

--- a/sycl/test-e2e/AtomicRef/atomic_memory_order_acq_rel.cpp
+++ b/sycl/test-e2e/AtomicRef/atomic_memory_order_acq_rel.cpp
@@ -3,7 +3,8 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
-// UNSUPPORTED: https://github.com/intel/llvm/issues/8847
+// https://github.com/intel/llvm/issues/8847
+// UNSUPPORTED: *
 // NOTE: Tests fetch_add for acquire and release memory ordering.
 
 #include "atomic_memory_order.h"

--- a/sycl/test-e2e/AtomicRef/atomic_memory_order_acq_rel.cpp
+++ b/sycl/test-e2e/AtomicRef/atomic_memory_order_acq_rel.cpp
@@ -3,6 +3,7 @@
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
 
+// UNSUPPORTED: https://github.com/intel/llvm/issues/8847
 // NOTE: Tests fetch_add for acquire and release memory ordering.
 
 #include "atomic_memory_order.h"


### PR DESCRIPTION
See https://github.com/intel/llvm/issues/8847