### PR TITLE
[SYCL][NFC] Fix missed formatting

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/pipes.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/pipes.hpp
@@ -83,7 +83,8 @@ public:
     const std::string PipeName = pipe_base::get_pipe_name(HostPipePtr);
 
     event E = Q.submit([=](handler &CGH) {
-      CGH.ext_intel_read_host_pipe(PipeName, DataPtr, sizeof(_dataT) /* non-blocking */);
+      CGH.ext_intel_read_host_pipe(PipeName, DataPtr,
+                                   sizeof(_dataT) /* non-blocking */);
     });
     E.wait();
     if (E.get_info<sycl::info::event::command_execution_status>() ==
@@ -113,8 +114,8 @@ public:
     void *DataPtr = const_cast<_dataT *>(&Data);
 
     event E = Q.submit([=](handler &CGH) {
-      CGH.ext_intel_write_host_pipe(
-          PipeName, DataPtr, sizeof(_dataT) /* non-blocking */);
+      CGH.ext_intel_write_host_pipe(PipeName, DataPtr,
+                                    sizeof(_dataT) /* non-blocking */);
     });
     E.wait();
     Success = E.get_info<sycl::info::event::command_execution_status>() ==
@@ -242,7 +243,7 @@ public:
     const std::string PipeName = pipe_base::get_pipe_name(HostPipePtr);
     event E = Q.submit([=](handler &CGH) {
       CGH.ext_intel_read_host_pipe(PipeName, DataPtr, sizeof(_dataT),
-                                         true /*blocking*/);
+                                   true /*blocking*/);
     });
     E.wait();
     return *(_dataT *)DataPtr;
@@ -263,8 +264,8 @@ public:
     const std::string PipeName = pipe_base::get_pipe_name(HostPipePtr);
     void *DataPtr = const_cast<_dataT *>(&Data);
     event E = Q.submit([=](handler &CGH) {
-      CGH.ext_intel_write_host_pipe(PipeName, DataPtr,
-                                         sizeof(_dataT), true /*blocking */);
+      CGH.ext_intel_write_host_pipe(PipeName, DataPtr, sizeof(_dataT),
+                                    true /*blocking */);
     });
     E.wait();
   }

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -96,11 +96,10 @@ class handler;
 template <typename T, int Dimensions, typename AllocatorT, typename Enable>
 class buffer;
 
-namespace ext::intel::experimental
-{ 
-  template <class _name, class _dataT, int32_t _min_capacity,
-      class _propertiesT, class>
-  class pipe;
+namespace ext::intel::experimental {
+template <class _name, class _dataT, int32_t _min_capacity, class _propertiesT,
+          class>
+class pipe;
 }
 
 namespace detail {
@@ -2896,9 +2895,10 @@ private:
   friend class ::MockHandler;
   friend class detail::queue_impl;
 
-  // Make pipe class friend to be able to call ext_intel_read/write_host_pipe method.
+  // Make pipe class friend to be able to call ext_intel_read/write_host_pipe
+  // method.
   template <class _name, class _dataT, int32_t _min_capacity,
-          class _propertiesT, class> 
+            class _propertiesT, class>
   friend class ext::intel::experimental::pipe;
 
   /// Read from a host pipe given a host address and
@@ -2907,8 +2907,8 @@ private:
   /// expr m_Storage member \param Size the size of data getting read back / to.
   /// /// \param Size the size of data getting read back / to. \param Block
   /// if read opeartion is blocking, default to false.
-  void ext_intel_read_host_pipe(const std::string &Name, void *Ptr,
-                                      size_t Size, bool Block=false);
+  void ext_intel_read_host_pipe(const std::string &Name, void *Ptr, size_t Size,
+                                bool Block = false);
 
   /// Write to host pipes given a host address and
   /// \param Name name of the host pipe to be passed into lower level runtime
@@ -2917,7 +2917,7 @@ private:
   /// /// \param Size the size of data write / to. \param Block
   /// if write opeartion is blocking, default to false.
   void ext_intel_write_host_pipe(const std::string &Name, void *Ptr,
-                                      size_t Size, bool Block=false);
+                                 size_t Size, bool Block = false);
 
   bool DisableRangeRounding();
 

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -864,7 +864,7 @@ id<2> handler::computeFallbackKernelBounds(size_t Width, size_t Height) {
 }
 
 void handler::ext_intel_read_host_pipe(const std::string &Name, void *Ptr,
-                                             size_t Size, bool Block) {
+                                       size_t Size, bool Block) {
   MImpl->HostPipeName = Name;
   MImpl->HostPipePtr = Ptr;
   MImpl->HostPipeTypeSize = Size;
@@ -874,7 +874,7 @@ void handler::ext_intel_read_host_pipe(const std::string &Name, void *Ptr,
 }
 
 void handler::ext_intel_write_host_pipe(const std::string &Name, void *Ptr,
-                                             size_t Size, bool Block) {
+                                        size_t Size, bool Block) {
   MImpl->HostPipeName = Name;
   MImpl->HostPipePtr = Ptr;
   MImpl->HostPipeTypeSize = Size;


### PR DESCRIPTION
For some unknown reason, lint did not run for select files in some of previous commits. This commit amends this.