### PR TITLE
[SYCL][UR] Use official device info property for c-slices

### DIFF
--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -210,7 +210,7 @@ inline pi_result ur2piInfoValue(ur_device_info_t ParamName,
         Map = {
             {UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN,
              PI_DEVICE_PARTITION_BY_AFFINITY_DOMAIN},
-            {UR_EXT_DEVICE_PARTITION_PROPERTY_FLAG_BY_CSLICE,
+            {UR_DEVICE_PARTITION_BY_CSLICE,
              PI_EXT_INTEL_DEVICE_PARTITION_BY_CSLICE},
             {(ur_device_partition_property_t)
                  UR_DEVICE_AFFINITY_DOMAIN_FLAG_NEXT_PARTITIONABLE,
@@ -224,7 +224,7 @@ inline pi_result ur2piInfoValue(ur_device_info_t ParamName,
         Map = {
             {UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN,
              PI_DEVICE_PARTITION_BY_AFFINITY_DOMAIN},
-            {UR_EXT_DEVICE_PARTITION_PROPERTY_FLAG_BY_CSLICE,
+            {UR_DEVICE_PARTITION_BY_CSLICE,
              PI_EXT_INTEL_DEVICE_PARTITION_BY_CSLICE},
         };
     return Value.convertArray(Map);
@@ -550,7 +550,7 @@ inline pi_result piDevicePartition(
           {PI_DEVICE_PARTITION_BY_AFFINITY_DOMAIN,
            UR_DEVICE_PARTITION_BY_AFFINITY_DOMAIN},
           {PI_EXT_INTEL_DEVICE_PARTITION_BY_CSLICE,
-           UR_EXT_DEVICE_PARTITION_PROPERTY_FLAG_BY_CSLICE},
+           UR_DEVICE_PARTITION_BY_CSLICE},
       };
 
   auto PropertyIt = PropertyMap.find(Properties[0]);

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero.cpp
@@ -582,8 +582,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(
     if (Device->isCCS()) {
       struct {
         ur_device_partition_property_t Arr[2];
-      } PartitionProperties = {{UR_EXT_DEVICE_PARTITION_PROPERTY_FLAG_BY_CSLICE,
-                                ur_device_partition_property_t(0)}};
+      } PartitionProperties = {
+          {UR_DEVICE_PARTITION_BY_CSLICE, ur_device_partition_property_t(0)}};
       return ReturnValue(PartitionProperties);
     }
 
@@ -1504,7 +1504,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDevicePartition(
          Properties[1] != UR_DEVICE_AFFINITY_DOMAIN_FLAG_NUMA)) {
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
-  } else if (Properties[0] == UR_EXT_DEVICE_PARTITION_PROPERTY_FLAG_BY_CSLICE) {
+  } else if (Properties[0] == UR_DEVICE_PARTITION_BY_CSLICE) {
     if (Properties[1] != 0) {
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
@@ -1535,7 +1535,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDevicePartition(
         return 0;
       }
     }
-    if (Properties[0] == UR_EXT_DEVICE_PARTITION_PROPERTY_FLAG_BY_CSLICE) {
+    if (Properties[0] == UR_DEVICE_PARTITION_BY_CSLICE) {
       // Not a CSlice-based partitioning.
       if (!Device->SubDevices[0]->isCCS()) {
         return 0;

--- a/sycl/plugins/unified_runtime/ur/ur.hpp
+++ b/sycl/plugins/unified_runtime/ur/ur.hpp
@@ -60,10 +60,6 @@ const int UR_EXT_USM_CAPS_ATOMIC_ACCESS = 1 << 1;
 const int UR_EXT_USM_CAPS_CONCURRENT_ACCESS = 1 << 2;
 const int UR_EXT_USM_CAPS_CONCURRENT_ATOMIC_ACCESS = 1 << 3;
 
-const ur_device_partition_property_t
-    UR_EXT_DEVICE_PARTITION_PROPERTY_FLAG_BY_CSLICE =
-        ur_device_partition_property_t(UR_DEVICE_PARTITION_FORCE_UINT32 - 1);
-
 // Terminates the process with a catastrophic error message.
 [[noreturn]] inline void die(const char *Message) {
   std::cerr << "die: " << Message << std::endl;


### PR DESCRIPTION
Spec has now UR_DEVICE_PARTITION_BY_CSLICE, so remove UR_EXT_DEVICE_PARTITION_PROPERTY_FLAG_BY_CSLICE.