### PR TITLE
[SYCL-MLIR] Mark `image_max_size.cpp` as unsupported on `level_zero`

### DIFF
--- a/sycl/test-e2e/Basic/image/image_max_size.cpp
+++ b/sycl/test-e2e/Basic/image/image_max_size.cpp
@@ -6,6 +6,9 @@
 // CUDA does not support info::device::image3d_max_width query.
 // TODO: Irregular runtime fails on Windows/opencl:gpu require analysis.
 
+// https://github.com/intel/llvm/issues/7585 to fix the time out failure:
+// UNSUPPORTED: level_zero
+
 // The test checks that 'image' with max allowed sizes is handled correctly.
 
 #include <iostream>


### PR DESCRIPTION
`image_max_size.cpp` sometimes time out, so marking it as unsupported, for more stable CI results.