### PR TITLE
[SYCL] Fix weak_object for host_accessor and stream

### DIFF
--- a/sycl/include/sycl/buffer.hpp
+++ b/sycl/include/sycl/buffer.hpp
@@ -722,6 +722,9 @@ private:
   detail::make_buffer_helper(pi_native_handle, const context &, event, bool);
   template <typename SYCLObjT> friend class ext::oneapi::weak_object;
 
+  // NOTE: These members are required for reconstructing the buffer, but are not
+  // part of the implementation class. If more members are added, they should
+  // also be added to the weak_object specialization for buffers.
   range<dimensions> Range;
   // Offset field specifies the origin of the sub buffer inside the parent
   // buffer

--- a/sycl/include/sycl/ext/oneapi/owner_less.hpp
+++ b/sycl/include/sycl/ext/oneapi/owner_less.hpp
@@ -61,6 +61,8 @@ struct owner_less<kernel_id> : public detail::owner_less_base<kernel_id> {};
 template <>
 struct owner_less<platform> : public detail::owner_less_base<platform> {};
 template <> struct owner_less<queue> : public detail::owner_less_base<queue> {};
+template <>
+struct owner_less<stream> : public detail::owner_less_base<stream> {};
 
 template <bundle_state State>
 struct owner_less<device_image<State>>
@@ -85,10 +87,6 @@ template <typename DataT, int Dimensions, access_mode AccessMode>
 struct owner_less<host_accessor<DataT, Dimensions, AccessMode>>
     : public detail::owner_less_base<
           host_accessor<DataT, Dimensions, AccessMode>> {};
-
-template <typename DataT, int Dimensions>
-struct owner_less<host_accessor<DataT, Dimensions>>
-    : public detail::owner_less_base<host_accessor<DataT, Dimensions>> {};
 
 template <typename DataT, int Dimensions>
 struct owner_less<local_accessor<DataT, Dimensions>>

--- a/sycl/include/sycl/ext/oneapi/weak_object.hpp
+++ b/sycl/include/sycl/ext/oneapi/weak_object.hpp
@@ -11,6 +11,7 @@
 #include <sycl/buffer.hpp>
 #include <sycl/detail/defines_elementary.hpp>
 #include <sycl/ext/oneapi/weak_object_base.hpp>
+#include <sycl/stream.hpp>
 
 #include <optional>
 
@@ -50,7 +51,8 @@ public:
 
   weak_object &operator=(const SYCLObjT &SYCLObj) noexcept {
     // Create weak_ptr from the shared_ptr to SYCLObj's implementation object.
-    this->MObjWeakPtr = GetWeakImpl(SYCLObj);
+    this->MObjWeakPtr =
+        detail::weak_object_base<SYCLObjT>::GetWeakImpl(SYCLObj);
     return *this;
   }
   weak_object &operator=(const weak_object &Other) noexcept = default;
@@ -103,7 +105,8 @@ public:
 
   weak_object &operator=(const buffer_type &SYCLObj) noexcept {
     // Create weak_ptr from the shared_ptr to SYCLObj's implementation object.
-    this->MObjWeakPtr = GetWeakImpl(SYCLObj);
+    this->MObjWeakPtr = detail::weak_object_base<
+        buffer<T, Dimensions, AllocatorT>>::GetWeakImpl(SYCLObj);
     this->MRange = SYCLObj.Range;
     this->MOffsetInBytes = SYCLObj.OffsetInBytes;
     this->MIsSubBuffer = SYCLObj.IsSubBuffer;
@@ -111,6 +114,13 @@ public:
   }
   weak_object &operator=(const weak_object &Other) noexcept = default;
   weak_object &operator=(weak_object &&Other) noexcept = default;
+
+  void swap(weak_object &Other) noexcept {
+    this->MObjWeakPtr.swap(Other.MObjWeakPtr);
+    std::swap(MRange, Other.MRange);
+    std::swap(MOffsetInBytes, Other.MOffsetInBytes);
+    std::swap(MIsSubBuffer, Other.MIsSubBuffer);
+  }
 
 #ifndef __SYCL_DEVICE_ONLY__
   std::optional<buffer_type> try_lock() const noexcept {
@@ -139,6 +149,78 @@ private:
   range<Dimensions> MRange;
   size_t MOffsetInBytes;
   bool MIsSubBuffer;
+};
+
+// Specialization of weak_object for stream as it needs additional members
+// to reconstruct the original stream.
+template <>
+class weak_object<stream> : public detail::weak_object_base<stream> {
+public:
+  using object_type = typename detail::weak_object_base<stream>::object_type;
+
+  constexpr weak_object() noexcept : detail::weak_object_base<stream>() {}
+  weak_object(const stream &SYCLObj) noexcept
+      : detail::weak_object_base<stream>(SYCLObj),
+        MWeakGlobalBuf{SYCLObj.GlobalBuf},
+        MWeakGlobalOffset{SYCLObj.GlobalOffset},
+        MWeakGlobalFlushBuf{SYCLObj.GlobalFlushBuf} {}
+  weak_object(const weak_object &Other) noexcept = default;
+  weak_object(weak_object &&Other) noexcept = default;
+
+  weak_object &operator=(const stream &SYCLObj) noexcept {
+    // Create weak_ptr from the shared_ptr to SYCLObj's implementation object.
+    this->MObjWeakPtr = detail::weak_object_base<stream>::GetWeakImpl(SYCLObj);
+    MWeakGlobalBuf = SYCLObj.GlobalBuf;
+    MWeakGlobalOffset = SYCLObj.GlobalOffset;
+    MWeakGlobalFlushBuf = SYCLObj.GlobalFlushBuf;
+    return *this;
+  }
+  weak_object &operator=(const weak_object &Other) noexcept = default;
+  weak_object &operator=(weak_object &&Other) noexcept = default;
+
+  void swap(weak_object &Other) noexcept {
+    this->MObjWeakPtr.swap(Other.MObjWeakPtr);
+    MWeakGlobalBuf.swap(Other.MWeakGlobalBuf);
+    MWeakGlobalOffset.swap(Other.MWeakGlobalOffset);
+    MWeakGlobalFlushBuf.swap(Other.MWeakGlobalFlushBuf);
+  }
+
+  void reset() noexcept {
+    this->MObjWeakPtr.reset();
+    MWeakGlobalBuf.reset();
+    MWeakGlobalOffset.reset();
+    MWeakGlobalFlushBuf.reset();
+  }
+
+#ifndef __SYCL_DEVICE_ONLY__
+  std::optional<stream> try_lock() const noexcept {
+    auto ObjImplPtr = this->MObjWeakPtr.lock();
+    auto GlobalBuf = MWeakGlobalBuf.try_lock();
+    auto GlobalOffset = MWeakGlobalOffset.try_lock();
+    auto GlobalFlushBuf = MWeakGlobalFlushBuf.try_lock();
+    if (!ObjImplPtr || !GlobalBuf || !GlobalOffset || !GlobalFlushBuf)
+      return std::nullopt;
+    return stream{ObjImplPtr, *GlobalBuf, *GlobalOffset, *GlobalFlushBuf};
+  }
+  stream lock() const {
+    std::optional<stream> OptionalObj = try_lock();
+    if (!OptionalObj)
+      throw sycl::exception(sycl::make_error_code(sycl::errc::invalid),
+                            "Referenced object has expired.");
+    return *OptionalObj;
+  }
+#else
+  // On device calls to these functions are disallowed, so declare them but
+  // don't define them to avoid compilation failures.
+  std::optional<stream> try_lock() const noexcept;
+  stream lock() const;
+#endif // __SYCL_DEVICE_ONLY__
+
+private:
+  // Additional members required for recreating stream.
+  weak_object<detail::GlobalBufAccessorT> MWeakGlobalBuf;
+  weak_object<detail::GlobalOffsetAccessorT> MWeakGlobalOffset;
+  weak_object<detail::GlobalBufAccessorT> MWeakGlobalFlushBuf;
 };
 
 } // namespace ext::oneapi

--- a/sycl/include/sycl/stream.hpp
+++ b/sycl/include/sycl/stream.hpp
@@ -743,6 +743,17 @@ inline __width_manipulator__ setw(int Width) {
 /// \ingroup sycl_api
 class __SYCL_EXPORT __SYCL_SPECIAL_CLASS __SYCL_TYPE(stream) stream
     : public detail::OwnerLessBase<stream> {
+private:
+#ifndef __SYCL_DEVICE_ONLY__
+  // Constructor for recreating a stream.
+  stream(std::shared_ptr<detail::stream_impl> Impl,
+         detail::GlobalBufAccessorT GlobalBuf,
+         detail::GlobalOffsetAccessorT GlobalOffset,
+         detail::GlobalBufAccessorT GlobalFlushBuf)
+      : impl{Impl}, GlobalBuf{GlobalBuf}, GlobalOffset{GlobalOffset},
+        GlobalFlushBuf{GlobalFlushBuf} {}
+#endif
+
 public:
 #ifdef __SYCL_DEVICE_ONLY__
   // Default constructor for objects later initialized with __init member.
@@ -941,6 +952,8 @@ private:
 #endif
 
   friend class handler;
+
+  template <typename SYCLObjT> friend class ext::oneapi::weak_object;
 
   friend const stream &operator<<(const stream &, const char);
   friend const stream &operator<<(const stream &, const char *);

--- a/sycl/include/sycl/stream.hpp
+++ b/sycl/include/sycl/stream.hpp
@@ -822,6 +822,10 @@ private:
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 #endif
 
+  // NOTE: Some members are required for reconstructing the stream, but are not
+  // part of the implementation class. If more members are added, they should
+  // also be added to the weak_object specialization for streams.
+
   // Accessor to the global stream buffer. Global buffer contains all output
   // from the kernel.
   mutable detail::GlobalBufAccessorT GlobalBuf;

--- a/sycl/test-e2e/WeakObject/weak_object_utils.hpp
+++ b/sycl/test-e2e/WeakObject/weak_object_utils.hpp
@@ -37,6 +37,9 @@ template <template <typename> typename CallableT> void runTest(sycl::queue Q) {
   sycl::accessor<int, 3, sycl::access::mode::read_write,
                  sycl::access::target::host_buffer>
       HAcc3D;
+  sycl::host_accessor<int, 1> HAcc1D_2020;
+  sycl::host_accessor<int, 2> HAcc2D_2020;
+  sycl::host_accessor<int, 3> HAcc3D_2020;
 
   CallableT<decltype(Plt)>()(Plt);
   CallableT<decltype(Dev)>()(Dev);
@@ -54,6 +57,9 @@ template <template <typename> typename CallableT> void runTest(sycl::queue Q) {
   CallableT<decltype(HAcc1D)>()(HAcc1D);
   CallableT<decltype(HAcc2D)>()(HAcc2D);
   CallableT<decltype(HAcc3D)>()(HAcc3D);
+  CallableT<decltype(HAcc1D_2020)>()(HAcc1D_2020);
+  CallableT<decltype(HAcc2D_2020)>()(HAcc2D_2020);
+  CallableT<decltype(HAcc3D_2020)>()(HAcc3D_2020);
 
   Q.submit([&](sycl::handler &CGH) {
     sycl::accessor DAcc1D{Buf1D, CGH, sycl::read_only};
@@ -62,6 +68,7 @@ template <template <typename> typename CallableT> void runTest(sycl::queue Q) {
     sycl::local_accessor<int> LAcc1D{1, CGH};
     sycl::local_accessor<int, 2> LAcc2D{sycl::range<2>{1, 2}, CGH};
     sycl::local_accessor<int, 3> LAcc3D{sycl::range<3>{1, 2, 3}, CGH};
+    sycl::stream Stream{1024, 32, CGH};
 
     CallableT<decltype(DAcc1D)>()(DAcc1D);
     CallableT<decltype(DAcc2D)>()(DAcc2D);
@@ -69,6 +76,7 @@ template <template <typename> typename CallableT> void runTest(sycl::queue Q) {
     CallableT<decltype(LAcc1D)>()(LAcc1D);
     CallableT<decltype(LAcc2D)>()(LAcc2D);
     CallableT<decltype(LAcc3D)>()(LAcc3D);
+    CallableT<decltype(Stream)>()(Stream);
   });
 }
 
@@ -120,6 +128,12 @@ void runTestMulti(sycl::queue Q1) {
   sycl::accessor<int, 3, sycl::access::mode::read_write,
                  sycl::access::target::host_buffer>
       HAcc3D2;
+  sycl::host_accessor<int, 1> HAcc1D1_2020;
+  sycl::host_accessor<int, 2> HAcc2D1_2020;
+  sycl::host_accessor<int, 3> HAcc3D1_2020;
+  sycl::host_accessor<int, 1> HAcc1D2_2020;
+  sycl::host_accessor<int, 2> HAcc2D2_2020;
+  sycl::host_accessor<int, 3> HAcc3D2_2020;
 
   CallableT<decltype(Ctx1)>()(Ctx1, Ctx2);
   CallableT<decltype(Q1)>()(Q1, Q2);
@@ -135,6 +149,9 @@ void runTestMulti(sycl::queue Q1) {
   CallableT<decltype(HAcc1D1)>()(HAcc1D1, HAcc1D2);
   CallableT<decltype(HAcc2D1)>()(HAcc2D1, HAcc2D2);
   CallableT<decltype(HAcc3D1)>()(HAcc3D1, HAcc3D2);
+  CallableT<decltype(HAcc1D1_2020)>()(HAcc1D1_2020, HAcc1D2_2020);
+  CallableT<decltype(HAcc2D1_2020)>()(HAcc2D1_2020, HAcc2D2_2020);
+  CallableT<decltype(HAcc3D1_2020)>()(HAcc3D1_2020, HAcc3D2_2020);
 
   Q1.submit([&](sycl::handler &CGH) {
     sycl::accessor DAcc1D1{Buf1D1, CGH, sycl::read_only};
@@ -149,6 +166,8 @@ void runTestMulti(sycl::queue Q1) {
     sycl::local_accessor<int, 2> LAcc2D2{sycl::range<2>{1, 2}, CGH};
     sycl::local_accessor<int, 3> LAcc3D1{sycl::range<3>{1, 2, 3}, CGH};
     sycl::local_accessor<int, 3> LAcc3D2{sycl::range<3>{1, 2, 3}, CGH};
+    sycl::stream Stream1{1024, 32, CGH};
+    sycl::stream Stream2{1024, 32, CGH};
 
     CallableT<decltype(DAcc1D1)>()(DAcc1D1, DAcc1D2);
     CallableT<decltype(DAcc2D1)>()(DAcc2D1, DAcc2D2);
@@ -156,5 +175,6 @@ void runTestMulti(sycl::queue Q1) {
     CallableT<decltype(LAcc1D1)>()(LAcc1D1, LAcc1D2);
     CallableT<decltype(LAcc2D1)>()(LAcc2D1, LAcc2D2);
     CallableT<decltype(LAcc3D1)>()(LAcc3D1, LAcc3D2);
+    CallableT<decltype(Stream1)>()(Stream1, Stream2);
   });
 }


### PR DESCRIPTION
This commit makes a specialization of weak_object for stream, similar to buffer, to help recreate a stream from its constituents. Additionally it fixes a problem for host_accessor where the bases would conflict with eachother as they defined the same functions.