### PR TITLE
[SYCL] Set the bug report URL appropriately for dpc++

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -167,7 +167,8 @@ def do_configure(args):
         "-DXPTI_ENABLE_WERROR={}".format(xpti_enable_werror),
         "-DSYCL_CLANG_EXTRA_FLAGS={}".format(sycl_clang_extra_flags),
         "-DSYCL_ENABLE_PLUGINS={}".format(';'.join(set(sycl_enabled_plugins))),
-        "-DSYCL_ENABLE_KERNEL_FUSION={}".format(sycl_enable_fusion)
+        "-DSYCL_ENABLE_KERNEL_FUSION={}".format(sycl_enable_fusion),
+        "-DBUG_REPORT_URL=https://github.com/intel/llvm/issues",
     ]
 
     if args.l0_headers and args.l0_loader:


### PR DESCRIPTION
When llvm tools crash they inform the user to report bugs to the cmake-configurable `${BUG_REPORT_URL}`, which defaults to upstream llvm's github issue tracker.

For dpc++ this should be the intel llvm upstream.

I wasn't sure if editing the default in the CMakeLists.txt itself was too invasive, but could be convinced; for now the buildbot configure script is the place.