### PR TITLE
[SYCL] Add native half type flag for NVPTX >= SM_53

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5029,6 +5029,14 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   Arg *SYCLStdArg = Args.getLastArg(options::OPT_sycl_std_EQ);
 
   if (IsSYCLOffloadDevice) {
+    if (Triple.isNVPTX()) {
+      StringRef GPUArchName = JA.getOffloadingArch();
+      // TODO: Once default arch is moved to at least SM_53, empty arch should
+      // also result in the flag added.
+      if (!GPUArchName.empty() &&
+          StringToCudaArch(GPUArchName) >= CudaArch::SM_53)
+        CmdArgs.push_back("-fnative-half-type");
+    }
     // Pass the triple of host when doing SYCL
     llvm::Triple AuxT = C.getDefaultToolChain().getTriple();
     std::string NormalizedTriple = AuxT.normalize();

--- a/clang/test/Driver/sycl-nvptx-native-half-ty-opt.cpp
+++ b/clang/test/Driver/sycl-nvptx-native-half-ty-opt.cpp
@@ -1,0 +1,18 @@
+/// Check that -fnative-half-type is added automatically for SM versions
+/// greater or equal to 53.
+// RUN: %clangxx -fsycl -fsycl-targets=nvidia_gpu_sm_53 %s -### 2>&1 | \
+// RUN: FileCheck --check-prefix=CHECK-53 %s
+// CHECK-53: clang{{.*}} "-triple" "nvptx64-nvidia-cuda"{{.*}}"-fnative-half-type"
+// RUN: %clangxx -fsycl -fsycl-targets=nvidia_gpu_sm_70 %s -### 2>&1 | \
+// RUN: FileCheck --check-prefix=CHECK-70 %s
+// CHECK-70: clang{{.*}} "-triple" "nvptx64-nvidia-cuda"{{.*}}"-fnative-half-type"
+
+/// As the default is set to SM_50, make sure that the option is not added.
+// RUN: %clangxx -fsycl -fsycl -fsycl-targets=nvidia64-nvidia-cuda %s -### 2>&1 | \
+// RUN: FileCheck --check-prefix=CHECK-DEFAULT %s
+// CHECK-DEFAULT-NOT: {{.*}}"-fnative-half-type"
+
+/// SM < 53
+// RUN: %clangxx -fsycl -fsycl-targets=nvidia_gpu_sm_50 %s -### 2>&1 | \
+// RUN: FileCheck --check-prefix=CHECK-50 %s
+// CHECK-50-NOT: {{.*}}"-fnative-half-type"


### PR DESCRIPTION
LLVM will now error out if builtins operating on half types are used without explicitly passing `-fnative-half-type` (see: https://reviews.llvm.org/D146715). PTX supports half types since [SM_53](https://docs.nvidia.com/cuda/parallel-thread-execution/index.html?highlight=half%20precision#half-precision-floating-point-instructions).