### PR TITLE
Revert "[MLIR] Allow llvm.resume with non-landingpad input (#8590)"

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMDialect.cpp
@@ -1523,21 +1523,8 @@ LogicalResult ReturnOp::verify() {
 //===----------------------------------------------------------------------===//
 
 LogicalResult ResumeOp::verify() {
-  auto parentFunc = getOperation()->getParentOfType<FunctionOpInterface>();
-  assert(parentFunc && "Expecting parent function");
-  const auto ty = getOperand().getType();
-  if (!parentFunc
-           ->walk([ty](LandingpadOp landingpad) {
-             return landingpad.getType() == ty
-                        ? WalkResult::interrupt() // Just an operation needed
-                        : WalkResult::advance();
-           })
-           .wasInterrupted()) {
-    // No operation was found: emit error
-    return emitOpError("expects landingpad operation in the same function and "
-                       "with the same type as this operation's operand");
-  }
-
+  if (!getValue().getDefiningOp<LandingpadOp>())
+    return emitOpError("expects landingpad value as operand");
   // No check for personality of function - landingpad op verifies it.
   return success();
 }

--- a/mlir/test/Dialect/LLVMIR/invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/invalid.mlir
@@ -798,18 +798,7 @@ llvm.func @caller(%arg0: i32) -> i32 attributes { personality = @__gxx_personali
   llvm.return %0 : i32
 ^bb2: // pred: ^bb0
   %2 = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
-  // expected-error@+1 {{'llvm.resume' op expects landingpad operation in the same function and with the same type as this operation's operand}}
-  llvm.resume %0 : i32
-}
-
-// -----
-
-llvm.func @foo(i32) -> i32
-llvm.func @__gxx_personality_v0(...) -> i32
-
-llvm.func @caller(%arg0: i32) -> i32 attributes { personality = @__gxx_personality_v0 } {
-  %0 = llvm.mlir.constant(1 : i32) : i32
-  // expected-error@+1 {{'llvm.resume' op expects landingpad operation in the same function and with the same type as this operation's operand}}
+  // expected-error@+1 {{'llvm.resume' op expects landingpad value as operand}}
   llvm.resume %0 : i32
 }
 

--- a/mlir/test/Dialect/LLVMIR/roundtrip.mlir
+++ b/mlir/test/Dialect/LLVMIR/roundtrip.mlir
@@ -427,27 +427,6 @@ llvm.func @invokeLandingpad() -> i32 attributes { personality = @__gxx_personali
   llvm.return %0 : i32
 }
 
-llvm.func @foo2() -> !llvm.struct<(ptr<i8>, i32)>
-
-// CHECK-LABEL: llvm.func @resumeNoLandingpadValue(
-// CHECK-SAME:                                     %[[ARG:.*]]: i32)
-llvm.func @resumeNoLandingpadValue(%arg0: i32) -> i32 attributes { personality = @__gxx_personality_v0 } {
-// CHECK: %[[VAL_0:.*]] = llvm.call @foo2() : () -> !llvm.struct<(ptr<i8>, i32)>
-// CHECK: %[[VAL_1:.*]] = llvm.invoke @foo(%[[ARG]]) to ^[[BB1:.*]] unwind ^[[BB2:.*]] : (i32) -> i32
-  %0 = llvm.call @foo2() : () -> !llvm.struct<(ptr<i8>, i32)>
-  %1 = llvm.invoke @foo(%arg0) to ^bb1 unwind ^bb2 : (i32) -> i32
-// CHECK: ^[[BB1]]:
-// CHECK: llvm.return %[[VAL_1]] : i32
-^bb1: // pred: ^bb0
-  llvm.return %1 : i32
-// CHECK: ^[[BB2]]:
-// CHECK: %[[VAL_2:.*]] = llvm.landingpad cleanup : !llvm.struct<(ptr<i8>, i32)>
-// CHECK: llvm.resume %[[VAL_0]] : !llvm.struct<(ptr<i8>, i32)>
-^bb2: // pred: ^bb0
-  %2 = llvm.landingpad cleanup : !llvm.struct<(ptr<i8>, i32)>
-  llvm.resume %0 : !llvm.struct<(ptr<i8>, i32)>
-}
-
 // CHECK-LABEL: @useFreezeOp
 func.func @useFreezeOp(%arg0: i32) {
   // CHECK:  = llvm.freeze %[[ARG0:.*]] : i32


### PR DESCRIPTION
This reverts commit af822e25fa82b11470a25eac39ab18364ace3b06.