### PR TITLE
[SYCL][NFC] Update codeowners for InvokeSIMD

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -80,6 +80,7 @@ sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp @intel/dpcpp-esimd-rev
 sycl/include/std/experimental/simd.hpp @intel/dpcpp-esimd-reviewers @rolandschulz
 llvm/lib/SYCLLowerIR/LowerInvokeSimd.cpp @intel/dpcpp-esimd-reviewers
 llvm/include/llvm/SYCLLowerIR/LowerInvokeSimd.h @intel/dpcpp-esimd-reviewers
+invoke_simd/ @intel/dpcpp-esimd-reviewers
 
 # DevOps configs
 .github/workflows/ @intel/dpcpp-devops-reviewers


### PR DESCRIPTION
The sycl/test/invoke_simd directory is currently owned by the runtime team, so make any folder named invoke_simd owned by the ESIMD team.