### PR TITLE
[SYCL-MLIR] Remove L0 GEN9 LLVM Test Suite run

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -49,7 +49,7 @@ jobs:
     uses: ./.github/workflows/sycl_gen_test_matrix.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
-      lts_config: "ocl_x64;ocl_gen9;l0_gen9"
+      lts_config: "ocl_x64;ocl_gen9"
 
   linux_default:
     name: Linux


### PR DESCRIPTION
llvm-test-suite runs on machines with Intel GPU kills machines in CI. Here are a couple recent examples:
https://github.com/intel/llvm/actions/runs/4556039201/jobs/8037973612 - killed intel_sycl1
https://github.com/intel/llvm/actions/runs/4555538986/jobs/8035114502 - killed intel_sycl2

This PR removes L0 GEN9 LLVM Test Suite run to reduce the frequency of hitting the problem, before understanding the cause. 