### PR TITLE
[SYCL] ocloc64.dll added to win_proxy_loader.cpp.

### DIFF
--- a/sycl/win_proxy_loader/win_proxy_loader.cpp
+++ b/sycl/win_proxy_loader/win_proxy_loader.cpp
@@ -110,6 +110,7 @@ std::string getCurrentDSODir() {
 #define __SYCL_ESIMD_EMULATOR_PLUGIN_NAME "pi_esimd_emulator.dll"
 #define __SYCL_HIP_PLUGIN_NAME "libpi_hip.dll"
 #define __SYCL_UNIFIED_RUNTIME_PLUGIN_NAME "pi_unified_runtime.dll"
+#define __SYCL_ONLINE_COMPILER_LIBRARY_NAME "ocloc64.dll"
 #else // llvm-mingw
 #define __SYCL_OPENCL_PLUGIN_NAME "libpi_opencl.dll"
 #define __SYCL_LEVEL_ZERO_PLUGIN_NAME "libpi_level_zero.dll"
@@ -117,6 +118,7 @@ std::string getCurrentDSODir() {
 #define __SYCL_ESIMD_EMULATOR_PLUGIN_NAME "libpi_esimd_emulator.dll"
 #define __SYCL_HIP_PLUGIN_NAME "libpi_hip.dll"
 #define __SYCL_UNIFIED_RUNTIME_PLUGIN_NAME "libpi_unified_runtime.dll"
+#define __SYCL_ONLINE_COMPILER_LIBRARY_NAME "ocloc64.dll"
 #endif
 
 // ------------------------------------
@@ -167,6 +169,9 @@ void preloadLibraries() {
 
   std::string ur_path = LibSYCLDir + __SYCL_UNIFIED_RUNTIME_PLUGIN_NAME;
   dllMap.emplace(ur_path, LoadLibraryA(ur_path.c_str()));
+
+  std::string ocloc_path =  __SYCL_ONLINE_COMPILER_LIBRARY_NAME;
+  dllMap.emplace(ocloc_path, LoadLibraryA(ocloc_path.c_str()));
 
   // Restore system error handling.
   (void)SetErrorMode(SavedMode);


### PR DESCRIPTION
The online_compiler calls `pi::loadOsPluginLibrary("ocloc64.dll")` but the proxy loader doesn't know about that DLL. Adding it.  A test exists already to test this, but it has an unmet dependency and I don't think it's ever actually been run. 