### PR TITLE
[SYCL-MLIR] Allow custom mangling of SPIRV built-in global variables

### DIFF
--- a/mlir-sycl/lib/Conversion/SYCLToSPIRV/SYCLToSPIRV.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToSPIRV/SYCLToSPIRV.cpp
@@ -89,6 +89,12 @@ template <typename OpTy>
 inline constexpr spirv::BuiltIn spirv_counterpart_builtin_v =
     spirv_counterpart_builtin<OpTy>::value;
 
+static Value getBuiltinVariableValue(Operation *op, spirv::BuiltIn builtin,
+                                     Type integerType, OpBuilder &builder) {
+  return spirv::getBuiltinVariableValue(op, builtin, integerType, builder,
+                                        "__spirv_BuiltIn", "");
+}
+
 /// Returns the result of creating an operation to get a reference to an element
 /// of a sycl::id or sycl::range.
 Value createGetOp(OpBuilder &builder, Location loc, Type dimMtTy, Value res,
@@ -137,7 +143,7 @@ void rewriteNDIndex(Operation *op, spirv::BuiltIn builtin, Value index,
   constexpr int64_t dimensions{3};
   constexpr std::array<int64_t, dimensions> vecInit{0, 0, 0};
 
-  const auto values = spirv::getBuiltinVariableValue(
+  const auto values = ::getBuiltinVariableValue(
       op, builtin, typeConverter.convertType(rewriter.getIndexType()),
       rewriter);
   const auto loc = op->getLoc();
@@ -181,7 +187,7 @@ void rewriteNDNoIndex(Operation *op, spirv::BuiltIn builtin,
                       ConversionPatternRewriter &rewriter) {
   // This conversion is platform dependent
   const auto dimensions = getDimensions(op->getResultTypes()[0]);
-  const auto values = spirv::getBuiltinVariableValue(
+  const auto values = ::getBuiltinVariableValue(
       op, builtin, typeConverter.convertType(rewriter.getIndexType()),
       rewriter);
   const auto loc = op->getLoc();
@@ -232,7 +238,7 @@ public:
 void rewrite1D(Operation *op, spirv::BuiltIn builtin,
                TypeConverter &typeConverter,
                ConversionPatternRewriter &rewriter) {
-  const auto res = spirv::getBuiltinVariableValue(
+  const auto res = ::getBuiltinVariableValue(
       op, builtin, typeConverter.convertType(rewriter.getIndexType()),
       rewriter);
   rewriter.replaceOp(op, convertScalarToDtype(

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm.mlir
@@ -9,21 +9,21 @@
 
 module attributes {gpu.container_module} {
   // CHECK:   gpu.module @kernels {
-    //CHECK-DAG:      llvm.mlir.global external constant @__builtin_var_SubgroupLocalInvocationId__() {addr_space = 0 : i32} : i64
-    //CHECK-DAG:      llvm.mlir.global external constant @__builtin_var_SubgroupMaxSize__() {addr_space = 0 : i32} : i64
-    //CHECK-DAG:      llvm.mlir.global external constant @__builtin_var_GlobalOffset__() {addr_space = 0 : i32} : vector<3xi64>
-    //CHECK-DAG:      llvm.mlir.global external constant @__builtin_var_SubgroupId__() {addr_space = 0 : i32} : i64
-    //CHECK-DAG:      llvm.mlir.global external constant @__builtin_var_SubgroupSize__() {addr_space = 0 : i32} : i64
-    //CHECK-DAG:      llvm.mlir.global external constant @__builtin_var_NumSubgroups__() {addr_space = 0 : i32} : i64
-    //CHECK-DAG:      llvm.mlir.global external constant @__builtin_var_WorkgroupId__() {addr_space = 0 : i32} : vector<3xi64>
-    //CHECK-DAG:      llvm.mlir.global external constant @__builtin_var_WorkgroupSize__() {addr_space = 0 : i32} : vector<3xi64>
-    //CHECK-DAG:      llvm.mlir.global external constant @__builtin_var_LocalInvocationId__() {addr_space = 0 : i32} : vector<3xi64>
-    //CHECK-DAG:      llvm.mlir.global external constant @__builtin_var_GlobalInvocationId__() {addr_space = 0 : i32} : vector<3xi64>
-    //CHECK-DAG:      llvm.mlir.global external constant @__builtin_var_NumWorkgroups__() {addr_space = 0 : i32} : vector<3xi64>
-    //CHECK-DAG:      llvm.mlir.global external constant @__builtin_var_GlobalSize__() {addr_space = 0 : i32} : vector<3xi64>
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupLocalInvocationId() {addr_space = 0 : i32} : i64
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupMaxSize() {addr_space = 0 : i32} : i64
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInGlobalOffset() {addr_space = 0 : i32} : vector<3xi64>
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupId() {addr_space = 0 : i32} : i64
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupSize() {addr_space = 0 : i32} : i64
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInNumSubgroups() {addr_space = 0 : i32} : i64
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInWorkgroupId() {addr_space = 0 : i32} : vector<3xi64>
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInWorkgroupSize() {addr_space = 0 : i32} : vector<3xi64>
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInLocalInvocationId() {addr_space = 0 : i32} : vector<3xi64>
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInGlobalInvocationId() {addr_space = 0 : i32} : vector<3xi64>
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInNumWorkgroups() {addr_space = 0 : i32} : vector<3xi64>
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInGlobalSize() {addr_space = 0 : i32} : vector<3xi64>
   gpu.module @kernels {
     // CHECK-LABEL:   llvm.func @test_num_work_items() -> !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> {
-    // CHECK-NEXT:        %[[VAL_0:.*]] = llvm.mlir.addressof @__builtin_var_GlobalSize__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_0:.*]] = llvm.mlir.addressof @__spirv_BuiltInGlobalSize : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_1:.*]] = llvm.load %[[VAL_0]] : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_2:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
     // CHECK-NEXT:        %[[VAL_3:.*]] = llvm.mlir.constant(1 : index) : i64
@@ -48,7 +48,7 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:     llvm.func @test_num_work_items_dim(
     // CHECK-SAME:                                         %[[VAL_15:.*]]: i32) -> i64 {
-    // CHECK-NEXT:        %[[VAL_16:.*]] = llvm.mlir.addressof @__builtin_var_GlobalSize__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_16:.*]] = llvm.mlir.addressof @__spirv_BuiltInGlobalSize : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_17:.*]] = llvm.load %[[VAL_16]] : !llvm.ptr<vector<3xi64>>
     // CHECK-DAG:         %[[VAL_18:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
     // CHECK-DAG:         %[[VAL_19:.*]] = llvm.mlir.constant(0 : i32) : i32
@@ -72,7 +72,7 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_global_id() -> !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> {
-    // CHECK-NEXT:        %[[VAL_32:.*]] = llvm.mlir.addressof @__builtin_var_GlobalInvocationId__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_32:.*]] = llvm.mlir.addressof @__spirv_BuiltInGlobalInvocationId : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_33:.*]] = llvm.load %[[VAL_32]] : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_34:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
     // CHECK-NEXT:        %[[VAL_35:.*]] = llvm.mlir.constant(1 : index) : i64
@@ -103,7 +103,7 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:     llvm.func @test_global_id_dim(
     // CHECK-SAME:                                    %[[VAL_52:.*]]: i32) -> i64 {
-    // CHECK-NEXT:        %[[VAL_53:.*]] = llvm.mlir.addressof @__builtin_var_GlobalInvocationId__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_53:.*]] = llvm.mlir.addressof @__spirv_BuiltInGlobalInvocationId : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_54:.*]] = llvm.load %[[VAL_53]] : !llvm.ptr<vector<3xi64>>
     // CHECK-DAG:         %[[VAL_55:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
     // CHECK-DAG:         %[[VAL_56:.*]] = llvm.mlir.constant(0 : i32) : i32
@@ -127,7 +127,7 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_local_id() -> !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> {
-    // CHECK-NEXT:        %[[VAL_69:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_69:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_70:.*]] = llvm.load %[[VAL_69]] : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_71:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
     // CHECK-NEXT:        %[[VAL_72:.*]] = llvm.mlir.constant(1 : index) : i64
@@ -164,7 +164,7 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:     llvm.func @test_local_id_dim(
     // CHECK-SAME:                                   %[[VAL_94:.*]]: i32) -> i64 {
-    // CHECK-NEXT:        %[[VAL_95:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_95:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_96:.*]] = llvm.load %[[VAL_95]] : !llvm.ptr<vector<3xi64>>
     // CHECK-DAG:         %[[VAL_97:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
     // CHECK-DAG:         %[[VAL_98:.*]] = llvm.mlir.constant(0 : i32) : i32
@@ -188,7 +188,7 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_work_group_size() -> !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> {
-    // CHECK-NEXT:        %[[VAL_111:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupSize__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_111:.*]] = llvm.mlir.addressof @__spirv_BuiltInWorkgroupSize : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_112:.*]] = llvm.load %[[VAL_111]] : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_113:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
     // CHECK-NEXT:        %[[VAL_114:.*]] = llvm.mlir.constant(1 : index) : i64
@@ -225,7 +225,7 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:     llvm.func @test_work_group_size_dim(
     // CHECK-SAME:                                          %[[VAL_136:.*]]: i32) -> i64 {
-    // CHECK-NEXT:        %[[VAL_137:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupSize__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_137:.*]] = llvm.mlir.addressof @__spirv_BuiltInWorkgroupSize : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_138:.*]] = llvm.load %[[VAL_137]] : !llvm.ptr<vector<3xi64>>
     // CHECK-DAG:         %[[VAL_139:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
     // CHECK-DAG:         %[[VAL_140:.*]] = llvm.mlir.constant(0 : i32) : i32
@@ -249,7 +249,7 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_work_group_id() -> !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> {
-    // CHECK-NEXT:        %[[VAL_153:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupId__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_153:.*]] = llvm.mlir.addressof @__spirv_BuiltInWorkgroupId : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_154:.*]] = llvm.load %[[VAL_153]] : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_155:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
     // CHECK-NEXT:        %[[VAL_156:.*]] = llvm.mlir.constant(1 : index) : i64
@@ -274,7 +274,7 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:     llvm.func @test_work_group_id_dim(
     // CHECK-SAME:                                        %[[VAL_168:.*]]: i32) -> i64 {
-    // CHECK-NEXT:        %[[VAL_169:.*]] = llvm.mlir.addressof @__builtin_var_WorkgroupId__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_169:.*]] = llvm.mlir.addressof @__spirv_BuiltInWorkgroupId : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_170:.*]] = llvm.load %[[VAL_169]] : !llvm.ptr<vector<3xi64>>
     // CHECK-DAG:         %[[VAL_171:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
     // CHECK-DAG:         %[[VAL_172:.*]] = llvm.mlir.constant(0 : i32) : i32
@@ -298,7 +298,7 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_num_sub_groups() -> i32 {
-    // CHECK-NEXT:        %[[VAL_200:.*]] = llvm.mlir.addressof @__builtin_var_NumSubgroups__ : !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_200:.*]] = llvm.mlir.addressof @__spirv_BuiltInNumSubgroups : !llvm.ptr<i64>
     // CHECK-NEXT:        %[[VAL_201:.*]] = llvm.load %[[VAL_200]] : !llvm.ptr<i64>
     // CHECK-NEXT:        %[[VAL_202:.*]] = llvm.trunc %[[VAL_201]] : i64 to i32
     // CHECK-NEXT:        llvm.return %[[VAL_202]] : i32
@@ -309,7 +309,7 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_sub_group_size() -> i32 {
-    // CHECK-NEXT:        %[[VAL_203:.*]] = llvm.mlir.addressof @__builtin_var_SubgroupSize__ : !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_203:.*]] = llvm.mlir.addressof @__spirv_BuiltInSubgroupSize : !llvm.ptr<i64>
     // CHECK-NEXT:        %[[VAL_204:.*]] = llvm.load %[[VAL_203]] : !llvm.ptr<i64>
     // CHECK-NEXT:        %[[VAL_205:.*]] = llvm.trunc %[[VAL_204]] : i64 to i32
     // CHECK-NEXT:        llvm.return %[[VAL_205]] : i32
@@ -320,7 +320,7 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_sub_group_id() -> i32 {
-    // CHECK-NEXT:        %[[VAL_206:.*]] = llvm.mlir.addressof @__builtin_var_SubgroupId__ : !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_206:.*]] = llvm.mlir.addressof @__spirv_BuiltInSubgroupId : !llvm.ptr<i64>
     // CHECK-NEXT:        %[[VAL_207:.*]] = llvm.load %[[VAL_206]] : !llvm.ptr<i64>
     // CHECK-NEXT:        %[[VAL_208:.*]] = llvm.trunc %[[VAL_207]] : i64 to i32
     // CHECK-NEXT:        llvm.return %[[VAL_208]] : i32
@@ -331,7 +331,7 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_global_offset() -> !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> {
-    // CHECK-NEXT:        %[[VAL_194:.*]] = llvm.mlir.addressof @__builtin_var_GlobalOffset__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_194:.*]] = llvm.mlir.addressof @__spirv_BuiltInGlobalOffset : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_195:.*]] = llvm.load %[[VAL_194]] : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_196:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
     // CHECK-NEXT:        %[[VAL_197:.*]] = llvm.mlir.constant(1 : index) : i64
@@ -356,7 +356,7 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:     llvm.func @test_global_offset_dim(
     // CHECK-SAME:                                        %[[VAL_222:.*]]: i32) -> i64 {
-    // CHECK-NEXT:        %[[VAL_223:.*]] = llvm.mlir.addressof @__builtin_var_GlobalOffset__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_223:.*]] = llvm.mlir.addressof @__spirv_BuiltInGlobalOffset : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_224:.*]] = llvm.load %[[VAL_223]] : !llvm.ptr<vector<3xi64>>
     // CHECK-DAG:         %[[VAL_225:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
     // CHECK-DAG:         %[[VAL_226:.*]] = llvm.mlir.constant(0 : i32) : i32
@@ -380,7 +380,7 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_num_work_groups() -> !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> {
-    // CHECK-NEXT:        %[[VAL_226:.*]] = llvm.mlir.addressof @__builtin_var_NumWorkgroups__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_226:.*]] = llvm.mlir.addressof @__spirv_BuiltInNumWorkgroups : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_227:.*]] = llvm.load %[[VAL_226]] : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_228:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
     // CHECK-NEXT:        %[[VAL_229:.*]] = llvm.mlir.constant(1 : index) : i64
@@ -411,7 +411,7 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:     llvm.func @test_num_work_groups_dim(
     // CHECK-SAME:                                          %[[VAL_246:.*]]: i32) -> i64 {
-    // CHECK-NEXT:        %[[VAL_247:.*]] = llvm.mlir.addressof @__builtin_var_NumWorkgroups__ : !llvm.ptr<vector<3xi64>>
+    // CHECK-NEXT:        %[[VAL_247:.*]] = llvm.mlir.addressof @__spirv_BuiltInNumWorkgroups : !llvm.ptr<vector<3xi64>>
     // CHECK-NEXT:        %[[VAL_248:.*]] = llvm.load %[[VAL_247]] : !llvm.ptr<vector<3xi64>>
     // CHECK-DAG:         %[[VAL_249:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
     // CHECK-DAG:         %[[VAL_250:.*]] = llvm.mlir.constant(0 : i32) : i32
@@ -435,7 +435,7 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_sub_group_max_size() -> i32 {
-    // CHECK-NEXT:        %[[VAL_273:.*]] = llvm.mlir.addressof @__builtin_var_SubgroupMaxSize__ : !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_273:.*]] = llvm.mlir.addressof @__spirv_BuiltInSubgroupMaxSize : !llvm.ptr<i64>
     // CHECK-NEXT:        %[[VAL_274:.*]] = llvm.load %[[VAL_273]] : !llvm.ptr<i64>
     // CHECK-NEXT:        %[[VAL_275:.*]] = llvm.trunc %[[VAL_274]] : i64 to i32
     // CHECK-NEXT:        llvm.return %[[VAL_275]] : i32
@@ -445,7 +445,7 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_sub_group_local_id() -> i32 {
-    // CHECK-NEXT:        %[[VAL_276:.*]] = llvm.mlir.addressof @__builtin_var_SubgroupLocalInvocationId__ : !llvm.ptr<i64>
+    // CHECK-NEXT:        %[[VAL_276:.*]] = llvm.mlir.addressof @__spirv_BuiltInSubgroupLocalInvocationId : !llvm.ptr<i64>
     // CHECK-NEXT:        %[[VAL_277:.*]] = llvm.load %[[VAL_276]] : !llvm.ptr<i64>
     // CHECK-NEXT:        %[[VAL_278:.*]] = llvm.trunc %[[VAL_277]] : i64 to i32
     // CHECK-NEXT:        llvm.return %[[VAL_278]] : i32

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -1237,7 +1237,7 @@ module attributes {gpu.container} {
   gpu.module @kernels {
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[GROUP3:.*]]>) -> !llvm.[[ID3:.*]] {
-// CHECK:             %[[VAL_1:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_1:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>>
 // CHECK:             %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<vector<3xi64>>
 // CHECK:             %[[VAL_3:.*]] = llvm.mlir.null : !llvm.ptr<[[ID3]]>
 // CHECK:             %[[VAL_4:.*]] = llvm.mlir.constant(1 : index) : i64
@@ -1286,7 +1286,7 @@ module attributes {gpu.container} {
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[GROUP1]]>,
 // CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> i64 {
-// CHECK:             %[[VAL_2:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_2:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>>
 // CHECK:             %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<vector<3xi64>>
 // CHECK-DAG:         %[[VAL_4:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
 // CHECK-DAG:         %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
@@ -1444,7 +1444,7 @@ module attributes {gpu.container} {
 // CHECK-LABEL:   llvm.func @test_1(
 // CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr<[[GROUP1]]>) -> i64 {
 // CHECK:             %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_2:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_2:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>>
 // CHECK:             %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<vector<3xi64>>
 // CHECK-DAG:         %[[VAL_4:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
 // CHECK-DAG:         %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
@@ -1470,7 +1470,7 @@ module attributes {gpu.container} {
 // CHECK-LABEL:   llvm.func @test_2(
 // CHECK-SAME:                      %[[VAL_18:.*]]: !llvm.ptr<[[GROUP2]]>) -> i64 {
 // CHECK:             %[[VAL_19:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_20:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_20:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>>
 // CHECK:             %[[VAL_21:.*]] = llvm.load %[[VAL_20]] : !llvm.ptr<vector<3xi64>>
 // CHECK-DAG:         %[[VAL_22:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
 // CHECK-DAG:         %[[VAL_23:.*]] = llvm.mlir.constant(0 : i32) : i32
@@ -1490,7 +1490,7 @@ module attributes {gpu.container} {
 // CHECK:             %[[VAL_37:.*]] = llvm.load %[[VAL_36]] : !llvm.ptr<i64>
 // CHECK:             %[[VAL_38:.*]] = llvm.mul %[[VAL_35]], %[[VAL_37]]  : i64
 // CHECK:             %[[VAL_39:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK:             %[[VAL_40:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_40:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>>
 // CHECK:             %[[VAL_41:.*]] = llvm.load %[[VAL_40]] : !llvm.ptr<vector<3xi64>>
 // CHECK-DAG:         %[[VAL_42:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
 // CHECK-DAG:         %[[VAL_43:.*]] = llvm.mlir.constant(0 : i32) : i32
@@ -1517,7 +1517,7 @@ module attributes {gpu.container} {
 // CHECK-LABEL:   llvm.func @test_3(
 // CHECK-SAME:                      %[[VAL_57:.*]]: !llvm.ptr<[[GROUP3]]>) -> i64 {
 // CHECK:             %[[VAL_58:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_59:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_59:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>>
 // CHECK:             %[[VAL_60:.*]] = llvm.load %[[VAL_59]] : !llvm.ptr<vector<3xi64>>
 // CHECK-DAG:         %[[VAL_61:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
 // CHECK-DAG:         %[[VAL_62:.*]] = llvm.mlir.constant(0 : i32) : i32
@@ -1540,7 +1540,7 @@ module attributes {gpu.container} {
 // CHECK:             %[[VAL_79:.*]] = llvm.load %[[VAL_78]] : !llvm.ptr<i64>
 // CHECK:             %[[VAL_80:.*]] = llvm.mul %[[VAL_77]], %[[VAL_79]]  : i64
 // CHECK:             %[[VAL_81:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK:             %[[VAL_82:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_82:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>>
 // CHECK:             %[[VAL_83:.*]] = llvm.load %[[VAL_82]] : !llvm.ptr<vector<3xi64>>
 // CHECK-DAG:         %[[VAL_84:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
 // CHECK-DAG:         %[[VAL_85:.*]] = llvm.mlir.constant(0 : i32) : i32
@@ -1559,7 +1559,7 @@ module attributes {gpu.container} {
 // CHECK:             %[[VAL_98:.*]] = llvm.mul %[[VAL_97]], %[[VAL_79]]  : i64
 // CHECK:             %[[VAL_99:.*]] = llvm.add %[[VAL_80]], %[[VAL_98]]  : i64
 // CHECK:             %[[VAL_100:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK:             %[[VAL_101:.*]] = llvm.mlir.addressof @__builtin_var_LocalInvocationId__ : !llvm.ptr<vector<3xi64>>
+// CHECK:             %[[VAL_101:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>>
 // CHECK:             %[[VAL_102:.*]] = llvm.load %[[VAL_101]] : !llvm.ptr<vector<3xi64>>
 // CHECK-DAG:         %[[VAL_103:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
 // CHECK-DAG:         %[[VAL_104:.*]] = llvm.mlir.constant(0 : i32) : i32

--- a/mlir/include/mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h
+++ b/mlir/include/mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h
@@ -131,8 +131,13 @@ class AccessChainOp;
 /// Returns the value for the given `builtin` variable. This function gets or
 /// inserts the global variable associated for the builtin within the nearest
 /// symbol table enclosing `op`. Returns null Value on error.
+///
+/// The global name being generated will be mangled using prefix \p prefix and
+/// suffix \p suffix.
 Value getBuiltinVariableValue(Operation *op, BuiltIn builtin, Type integerType,
-                              OpBuilder &builder);
+                              OpBuilder &builder,
+                              StringRef prefix = "__builtin_var_",
+                              StringRef suffix = "__");
 
 /// Gets the value at the given `offset` of the push constant storage with a
 /// total of `elementCount` `integerType` integers. A global variable will be

--- a/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
+++ b/mlir/lib/Dialect/SPIRV/Transforms/SPIRVConversion.cpp
@@ -602,14 +602,16 @@ static spirv::GlobalVariableOp getBuiltinVariable(Block &body,
 }
 
 /// Gets name of global variable for a builtin.
-static std::string getBuiltinVarName(spirv::BuiltIn builtin) {
-  return std::string("__builtin_var_") + stringifyBuiltIn(builtin).str() + "__";
+static std::string getBuiltinVarName(spirv::BuiltIn builtin, StringRef prefix,
+                                     StringRef suffix) {
+  return Twine(prefix).concat(stringifyBuiltIn(builtin)).concat(suffix).str();
 }
 
 /// Gets or inserts a global variable for a builtin within `body` block.
 static spirv::GlobalVariableOp
 getOrInsertBuiltinVariable(Block &body, Location loc, spirv::BuiltIn builtin,
-                           Type integerType, OpBuilder &builder) {
+                           Type integerType, OpBuilder &builder,
+                           StringRef prefix, StringRef suffix) {
   if (auto varOp = getBuiltinVariable(body, builtin))
     return varOp;
 
@@ -627,7 +629,7 @@ getOrInsertBuiltinVariable(Block &body, Location loc, spirv::BuiltIn builtin,
   case spirv::BuiltIn::GlobalSize: {
     auto ptrType = spirv::PointerType::get(VectorType::get({3}, integerType),
                                            spirv::StorageClass::Input);
-    std::string name = getBuiltinVarName(builtin);
+    std::string name = getBuiltinVarName(builtin, prefix, suffix);
     newVarOp =
         builder.create<spirv::GlobalVariableOp>(loc, ptrType, name, builtin);
     break;
@@ -639,7 +641,7 @@ getOrInsertBuiltinVariable(Block &body, Location loc, spirv::BuiltIn builtin,
   case spirv::BuiltIn::SubgroupLocalInvocationId: {
     auto ptrType =
         spirv::PointerType::get(integerType, spirv::StorageClass::Input);
-    std::string name = getBuiltinVarName(builtin);
+    std::string name = getBuiltinVarName(builtin, prefix, suffix);
     newVarOp =
         builder.create<spirv::GlobalVariableOp>(loc, ptrType, name, builtin);
     break;
@@ -653,8 +655,8 @@ getOrInsertBuiltinVariable(Block &body, Location loc, spirv::BuiltIn builtin,
 
 Value mlir::spirv::getBuiltinVariableValue(Operation *op,
                                            spirv::BuiltIn builtin,
-                                           Type integerType,
-                                           OpBuilder &builder) {
+                                           Type integerType, OpBuilder &builder,
+                                           StringRef prefix, StringRef suffix) {
   Operation *parent = SymbolTable::getNearestSymbolTable(op->getParentOp());
   if (!parent) {
     op->emitError("expected operation to be within a module-like op");
@@ -663,7 +665,7 @@ Value mlir::spirv::getBuiltinVariableValue(Operation *op,
 
   spirv::GlobalVariableOp varOp =
       getOrInsertBuiltinVariable(*parent->getRegion(0).begin(), op->getLoc(),
-                                 builtin, integerType, builder);
+                                 builtin, integerType, builder, prefix, suffix);
   Value ptr = builder.create<spirv::AddressOfOp>(op->getLoc(), varOp);
   return builder.create<spirv::LoadOp>(op->getLoc(), ptr);
 }


### PR DESCRIPTION
The SPIR-V spec does not specify the mangling for these variables, so the conversion to SPIR-V should be flexible enough to allow adding a custom prefix and suffix to the core name.

This custom mangling is utilized in `-convert-sycl-to-spirv`.