### PR TITLE
[SYCL-MLIR][LICM] Support hoisting operations that require versioning more than one accessor pairs

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
@@ -740,8 +740,7 @@ public:
 
   void addPrerequisite(Operation &op) { prerequisites.push_back(&op); }
 
-  const SmallVector<AccessorPairType> &
-  getRequireNoOverlapAccessorPairs() const {
+  ArrayRef<AccessorPairType> getRequireNoOverlapAccessorPairs() const {
     return requireNoOverlapAccessorPairs;
   }
 
@@ -767,7 +766,7 @@ class SYCLAccessorVersionBuilder : public SCFLoopVersionBuilder {
 public:
   SYCLAccessorVersionBuilder(
       LoopLikeOpInterface loop,
-      const SmallVector<AccessorPairType> &requireNoOverlapAccessorPairs)
+      ArrayRef<AccessorPairType> requireNoOverlapAccessorPairs)
       : SCFLoopVersionBuilder(loop),
         accessorPairs(requireNoOverlapAccessorPairs) {}
 
@@ -905,7 +904,7 @@ private:
     return createSYCLAccessorSubscriptOp(accessor, id, builder, loc);
   }
 
-  const SmallVector<AccessorPairType> &accessorPairs;
+  ArrayRef<AccessorPairType> accessorPairs;
 };
 
 //===----------------------------------------------------------------------===//
@@ -1140,7 +1139,7 @@ collectHoistableOperations(LoopLikeOpInterface loop,
                }))
       continue;
 
-    const SmallVector<AccessorPairType> &accessorPairs =
+    ArrayRef<AccessorPairType> accessorPairs =
         candidate.getRequireNoOverlapAccessorPairs();
     bool requireVersioning = !accessorPairs.empty();
     // Currently only version for single accessor pair.
@@ -1175,7 +1174,7 @@ static size_t moveLoopInvariantCode(LoopLikeOpInterface loop,
   size_t numOpsHoisted = 0;
   std::set<const Operation *> opsHoisted;
   for (const LICMCandidate &candidate : LICMCandidates) {
-    const SmallVector<AccessorPairType> &accessorPairs =
+    ArrayRef<AccessorPairType> accessorPairs =
         candidate.getRequireNoOverlapAccessorPairs();
     if (!accessorPairs.empty())
       SYCLAccessorVersionBuilder(loop, accessorPairs).versionLoop();

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
@@ -45,7 +45,12 @@ static llvm::cl::opt<bool> EnableLICMSYCLAccessorVersioning(
     "enable-licm-sycl-accessor-versioning", llvm::cl::init(false),
     llvm::cl::desc("Enable loop versioning for SYCL accessors in LICM"));
 
-static llvm::cl::opt<bool> LICMVersionLimit(
+static llvm::cl::opt<unsigned> LICMSYCLAccessorPairsLimit(
+    "licm-sycl-accessor-pairs-limit", llvm::cl::init(1),
+    llvm::cl::desc(
+        "Maximum number of versioning accessor pairs per operation in LICM"));
+
+static llvm::cl::opt<unsigned> LICMVersionLimit(
     "licm-version-limit", llvm::cl::init(1),
     llvm::cl::desc("Maximum number of versioning allowed in LICM"));
 
@@ -762,12 +767,9 @@ class SYCLAccessorVersionBuilder : public SCFLoopVersionBuilder {
 public:
   SYCLAccessorVersionBuilder(
       LoopLikeOpInterface loop,
-      const SmallVectorImpl<AccessorPairType> &requireNoOverlapAccessorPairs)
+      const SmallVector<AccessorPairType> &requireNoOverlapAccessorPairs)
       : SCFLoopVersionBuilder(loop),
-        AccessorPair(requireNoOverlapAccessorPairs[0]) {
-    assert(requireNoOverlapAccessorPairs.size() == 1 &&
-           "Expecting only one pair");
-  }
+        accessorPairs(requireNoOverlapAccessorPairs) {}
 
 private:
   Value createCondition() const final {
@@ -782,17 +784,24 @@ private:
           op);
     };
 
-    Value begin1 = getSYCLAccessorBegin(AccessorPair.first, builder, loc);
-    Value end1 = getSYCLAccessorEnd(AccessorPair.first, builder, loc);
-    Value begin2 = getSYCLAccessorBegin(AccessorPair.second, builder, loc);
-    Value end2 = getSYCLAccessorEnd(AccessorPair.second, builder, loc);
-    auto beforeCond = builder.create<LLVM::ICmpOp>(
-        loc, LLVM::ICmpPredicate::ule, GetMemref2PointerOp(end1),
-        GetMemref2PointerOp(begin2));
-    auto afterCond = builder.create<LLVM::ICmpOp>(loc, LLVM::ICmpPredicate::uge,
-                                                  GetMemref2PointerOp(begin1),
-                                                  GetMemref2PointerOp(end2));
-    return builder.create<arith::OrIOp>(loc, beforeCond, afterCond);
+    Value condition;
+    for (const AccessorPairType &accessorPair : accessorPairs) {
+      Value begin1 = getSYCLAccessorBegin(accessorPair.first, builder, loc);
+      Value end1 = getSYCLAccessorEnd(accessorPair.first, builder, loc);
+      Value begin2 = getSYCLAccessorBegin(accessorPair.second, builder, loc);
+      Value end2 = getSYCLAccessorEnd(accessorPair.second, builder, loc);
+      auto beforeCond = builder.create<LLVM::ICmpOp>(
+          loc, LLVM::ICmpPredicate::ule, GetMemref2PointerOp(end1),
+          GetMemref2PointerOp(begin2));
+      auto afterCond = builder.create<LLVM::ICmpOp>(
+          loc, LLVM::ICmpPredicate::uge, GetMemref2PointerOp(begin1),
+          GetMemref2PointerOp(end2));
+      Value orOp = builder.create<arith::OrIOp>(loc, beforeCond, afterCond);
+      condition = condition
+                      ? builder.create<arith::AndIOp>(loc, condition, orOp)
+                      : orOp;
+    }
+    return condition;
   }
 
   template <typename OpTy>
@@ -896,7 +905,7 @@ private:
     return createSYCLAccessorSubscriptOp(accessor, id, builder, loc);
   }
 
-  std::pair<TypedValue<MemRefType>, TypedValue<MemRefType>> AccessorPair;
+  const SmallVector<AccessorPairType> &accessorPairs;
 };
 
 //===----------------------------------------------------------------------===//
@@ -1131,13 +1140,13 @@ collectHoistableOperations(LoopLikeOpInterface loop,
                }))
       continue;
 
-    const SmallVector<AccessorPairType> &AccessorPairs =
+    const SmallVector<AccessorPairType> &accessorPairs =
         candidate.getRequireNoOverlapAccessorPairs();
-    bool requireVersioning = !AccessorPairs.empty();
+    bool requireVersioning = !accessorPairs.empty();
     // Currently only version for single accessor pair.
-    bool willVersion = EnableLICMSYCLAccessorVersioning &&
+    bool willVersion = requireVersioning && EnableLICMSYCLAccessorVersioning &&
                        numVersion < LICMVersionLimit &&
-                       AccessorPairs.size() == 1;
+                       accessorPairs.size() <= LICMSYCLAccessorPairsLimit;
     if (willVersion)
       ++numVersion;
     else if (requireVersioning)
@@ -1166,10 +1175,10 @@ static size_t moveLoopInvariantCode(LoopLikeOpInterface loop,
   size_t numOpsHoisted = 0;
   std::set<const Operation *> opsHoisted;
   for (const LICMCandidate &candidate : LICMCandidates) {
-    const SmallVector<AccessorPairType> &AccessorPairs =
+    const SmallVector<AccessorPairType> &accessorPairs =
         candidate.getRequireNoOverlapAccessorPairs();
-    if (!AccessorPairs.empty())
-      SYCLAccessorVersionBuilder(loop, AccessorPairs).versionLoop();
+    if (!accessorPairs.empty())
+      SYCLAccessorVersionBuilder(loop, accessorPairs).versionLoop();
 
     loop.moveOutOfLoop(&candidate.getOperation());
     ++numOpsHoisted;

--- a/polygeist/test/polygeist-opt/sycl/licm-accessor-versioning.mlir
+++ b/polygeist/test/polygeist-opt/sycl/licm-accessor-versioning.mlir
@@ -7,7 +7,7 @@
 // }
 // Optimized loop:
 // if (0 < 8) {
-//   if (&A[A.get_range()] <= &B[0] || &A[0] >= B[B.get_range()]) {
+//   if (&A[A.get_range()] <= &B[0] || &A[0] >= &B[B.get_range()]) {
 //     b = B[0];
 //     for(size_t i = 0; i < 8; i++) {
 //       A[i] += b;
@@ -121,8 +121,8 @@ func.func private @test(%arg0: memref<?x!sycl_accessor_1_i32_rw_gb, 4>, %arg1: m
 // }
 // Optimized loop:
 // if (0 < 8) {
-//   if ((&A[A.get_range()] <= &B[0] || &A[0] >= B[B.get_range()])
-//       && (&A[A.get_range()] <= &C[0] || &A[0] >= C[C.get_range()])) {
+//   if ((&A[A.get_range()] <= &B[0] || &A[0] >= &B[B.get_range()])
+//       && (&A[A.get_range()] <= &C[0] || &A[0] >= &C[C.get_range()])) {
 //     A[0] = 1;
 //     for(size_t i = 0; i < 8; i++) {
 //       B[i] = 2;
@@ -143,12 +143,14 @@ func.func private @test(%arg0: memref<?x!sycl_accessor_1_i32_rw_gb, 4>, %arg1: m
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
 !sycl_accessor_1_i32_w_gb = !sycl.accessor<[1, i32, write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
 
-// COM: Store to %arg0 accessor cannot be hoisted.
+// COM: There is only one loop, i.e., the loop is not versioned.
 // 1PAIR-LABEL: test
 // 1PAIR-SAME:  ([[ARG0:%.*]]: memref<?x[[ACC_W:!sycl_accessor_1_i32_w_gb]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_W]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_W]], 4>) 
 // 1PAIR: [[C1_i32:%.*]] = arith.constant 1 : i32
 // 1PAIR: [[ARG0_ACC:%.*]] = sycl.accessor.subscript %arg0[{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+// 1PAIR: scf.for
 // 1PAIR: affine.store [[C1_i32]], [[ARG0_ACC]][0] : memref<?xi32, 4>
+// 1PAIR-NOT: } else {
 // 1PAIR-NOT: scf.for
 
 // 2PAIRS-LABEL: test

--- a/polygeist/test/polygeist-opt/sycl/licm-accessor-versioning.mlir
+++ b/polygeist/test/polygeist-opt/sycl/licm-accessor-versioning.mlir
@@ -18,6 +18,7 @@
 //     }
 //   }
 // }
+// Note: The version condition implementation doesn't do short-circuit evaluation.
 
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
@@ -135,6 +136,7 @@ func.func private @test(%arg0: memref<?x!sycl_accessor_1_i32_rw_gb, 4>, %arg1: m
 //     }
 //   }
 // }
+// Note: The version condition implementation doesn't do short-circuit evaluation.
 
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>


### PR DESCRIPTION
Some operations may require checking overlap of more than one accessor pairs to be hoisted. For example,
```
for(size_t i = 0; i < 8; i++) {
   A[0] = 1;
   B[i] = 2;
   C[i] = 3;
}
```
To hoist `A[0] = 1;` out of the loop, LICM need to ensure that `A` and `B` don't overlap, and `A` and `C` don't overlap.

By default, LICM only hoist operation that require checking of one accessor pair. It can be changed by `-licm-sycl-accessor-pairs-limit`.