### PR TITLE
[SYCL-MLIR] Use i32 for 1D SPIRV builtin variables in SYCL lowering

### DIFF
--- a/mlir-sycl/lib/Conversion/SYCLToSPIRV/SYCLToSPIRV.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToSPIRV/SYCLToSPIRV.cpp
@@ -238,15 +238,10 @@ public:
   }
 };
 
-void rewrite1D(Operation *op, spirv::BuiltIn builtin,
-               TypeConverter &typeConverter,
-               ConversionPatternRewriter &rewriter) {
-  const auto res =
-      ::getBuiltinVariableValue(op, builtin, rewriter.getI32Type(), rewriter);
-  rewriter.replaceOp(op, convertScalarToDtype(
-                             rewriter, op->getLoc(), res,
-                             typeConverter.convertType(op->getResultTypes()[0]),
-                             /*isUnsignedCast*/ true));
+static void rewrite1D(Operation *op, spirv::BuiltIn builtin,
+                      ConversionPatternRewriter &rewriter) {
+  rewriter.replaceOp(op, ::getBuiltinVariableValue(
+                             op, builtin, rewriter.getI32Type(), rewriter));
 }
 
 /// Converts one-dimensional operations of type \tparam OpTy to calls to a SPIRV
@@ -259,8 +254,7 @@ public:
   LogicalResult
   matchAndRewrite(OpTy op, typename OpTy::Adaptor,
                   ConversionPatternRewriter &rewriter) const final {
-    rewrite1D(op, GridOpPattern<OpTy>::spirvBuiltin,
-              *GridOpPattern<OpTy>::getTypeConverter(), rewriter);
+    rewrite1D(op, GridOpPattern<OpTy>::spirvBuiltin, rewriter);
     return success();
   }
 };

--- a/mlir-sycl/lib/Conversion/SYCLToSPIRV/SYCLToSPIRV.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToSPIRV/SYCLToSPIRV.cpp
@@ -241,9 +241,8 @@ public:
 void rewrite1D(Operation *op, spirv::BuiltIn builtin,
                TypeConverter &typeConverter,
                ConversionPatternRewriter &rewriter) {
-  const auto res = ::getBuiltinVariableValue(
-      op, builtin, typeConverter.convertType(rewriter.getIndexType()),
-      rewriter);
+  const auto res =
+      ::getBuiltinVariableValue(op, builtin, rewriter.getI32Type(), rewriter);
   rewriter.replaceOp(op, convertScalarToDtype(
                              rewriter, op->getLoc(), res,
                              typeConverter.convertType(op->getResultTypes()[0]),

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm-typed-pointer.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm-typed-pointer.mlir
@@ -9,12 +9,12 @@
 
 module attributes {gpu.container_module} {
   // CHECK:   gpu.module @kernels {
-    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupLocalInvocationId() {addr_space = 1 : i32} : i64
-    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupMaxSize() {addr_space = 1 : i32} : i64
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupLocalInvocationId() {addr_space = 1 : i32} : i32
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupMaxSize() {addr_space = 1 : i32} : i32
     //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInGlobalOffset() {addr_space = 1 : i32} : vector<3xi64>
-    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupId() {addr_space = 1 : i32} : i64
-    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupSize() {addr_space = 1 : i32} : i64
-    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInNumSubgroups() {addr_space = 1 : i32} : i64
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupId() {addr_space = 1 : i32} : i32
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupSize() {addr_space = 1 : i32} : i32
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInNumSubgroups() {addr_space = 1 : i32} : i32
     //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInWorkgroupId() {addr_space = 1 : i32} : vector<3xi64>
     //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInWorkgroupSize() {addr_space = 1 : i32} : vector<3xi64>
     //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInLocalInvocationId() {addr_space = 1 : i32} : vector<3xi64>
@@ -298,10 +298,9 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_num_sub_groups() -> i32 {
-    // CHECK-NEXT:        %[[VAL_200:.*]] = llvm.mlir.addressof @__spirv_BuiltInNumSubgroups : !llvm.ptr<i64, 1>
-    // CHECK-NEXT:        %[[VAL_201:.*]] = llvm.load %[[VAL_200]] : !llvm.ptr<i64, 1>
-    // CHECK-NEXT:        %[[VAL_202:.*]] = llvm.trunc %[[VAL_201]] : i64 to i32
-    // CHECK-NEXT:        llvm.return %[[VAL_202]] : i32
+    // CHECK-NEXT:        %[[VAL_200:.*]] = llvm.mlir.addressof @__spirv_BuiltInNumSubgroups : !llvm.ptr<i32, 1>
+    // CHECK-NEXT:        %[[VAL_201:.*]] = llvm.load %[[VAL_200]] : !llvm.ptr<i32, 1>
+    // CHECK-NEXT:        llvm.return %[[VAL_201]] : i32
     // CHECK-NEXT:      }
     func.func @test_num_sub_groups() -> i32 {
       %0 = sycl.num_sub_groups : i32
@@ -309,10 +308,9 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_sub_group_size() -> i32 {
-    // CHECK-NEXT:        %[[VAL_203:.*]] = llvm.mlir.addressof @__spirv_BuiltInSubgroupSize : !llvm.ptr<i64, 1>
-    // CHECK-NEXT:        %[[VAL_204:.*]] = llvm.load %[[VAL_203]] : !llvm.ptr<i64, 1>
-    // CHECK-NEXT:        %[[VAL_205:.*]] = llvm.trunc %[[VAL_204]] : i64 to i32
-    // CHECK-NEXT:        llvm.return %[[VAL_205]] : i32
+    // CHECK-NEXT:        %[[VAL_203:.*]] = llvm.mlir.addressof @__spirv_BuiltInSubgroupSize : !llvm.ptr<i32, 1>
+    // CHECK-NEXT:        %[[VAL_204:.*]] = llvm.load %[[VAL_203]] : !llvm.ptr<i32, 1>
+    // CHECK-NEXT:        llvm.return %[[VAL_204]] : i32
     // CHECK-NEXT:      }
     func.func @test_sub_group_size() -> i32 {
       %0 = sycl.sub_group_size : i32
@@ -320,10 +318,9 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_sub_group_id() -> i32 {
-    // CHECK-NEXT:        %[[VAL_206:.*]] = llvm.mlir.addressof @__spirv_BuiltInSubgroupId : !llvm.ptr<i64, 1>
-    // CHECK-NEXT:        %[[VAL_207:.*]] = llvm.load %[[VAL_206]] : !llvm.ptr<i64, 1>
-    // CHECK-NEXT:        %[[VAL_208:.*]] = llvm.trunc %[[VAL_207]] : i64 to i32
-    // CHECK-NEXT:        llvm.return %[[VAL_208]] : i32
+    // CHECK-NEXT:        %[[VAL_206:.*]] = llvm.mlir.addressof @__spirv_BuiltInSubgroupId : !llvm.ptr<i32, 1>
+    // CHECK-NEXT:        %[[VAL_207:.*]] = llvm.load %[[VAL_206]] : !llvm.ptr<i32, 1>
+    // CHECK-NEXT:        llvm.return %[[VAL_207]] : i32
     // CHECK-NEXT:      }
     func.func @test_sub_group_id() -> i32 {
       %0 = sycl.sub_group_id : i32
@@ -435,20 +432,18 @@ module attributes {gpu.container_module} {
     }
 
     // CHECK-LABEL:     llvm.func @test_sub_group_max_size() -> i32 {
-    // CHECK-NEXT:        %[[VAL_273:.*]] = llvm.mlir.addressof @__spirv_BuiltInSubgroupMaxSize : !llvm.ptr<i64, 1>
-    // CHECK-NEXT:        %[[VAL_274:.*]] = llvm.load %[[VAL_273]] : !llvm.ptr<i64, 1>
-    // CHECK-NEXT:        %[[VAL_275:.*]] = llvm.trunc %[[VAL_274]] : i64 to i32
-    // CHECK-NEXT:        llvm.return %[[VAL_275]] : i32
+    // CHECK-NEXT:        %[[VAL_273:.*]] = llvm.mlir.addressof @__spirv_BuiltInSubgroupMaxSize : !llvm.ptr<i32, 1>
+    // CHECK-NEXT:        %[[VAL_274:.*]] = llvm.load %[[VAL_273]] : !llvm.ptr<i32, 1>
+    // CHECK-NEXT:        llvm.return %[[VAL_274]] : i32
     func.func @test_sub_group_max_size() -> i32 {
       %0 = sycl.sub_group_max_size : i32
       return %0 : i32
     }
 
     // CHECK-LABEL:     llvm.func @test_sub_group_local_id() -> i32 {
-    // CHECK-NEXT:        %[[VAL_276:.*]] = llvm.mlir.addressof @__spirv_BuiltInSubgroupLocalInvocationId : !llvm.ptr<i64, 1>
-    // CHECK-NEXT:        %[[VAL_277:.*]] = llvm.load %[[VAL_276]] : !llvm.ptr<i64, 1>
-    // CHECK-NEXT:        %[[VAL_278:.*]] = llvm.trunc %[[VAL_277]] : i64 to i32
-    // CHECK-NEXT:        llvm.return %[[VAL_278]] : i32
+    // CHECK-NEXT:        %[[VAL_276:.*]] = llvm.mlir.addressof @__spirv_BuiltInSubgroupLocalInvocationId : !llvm.ptr<i32, 1>
+    // CHECK-NEXT:        %[[VAL_277:.*]] = llvm.load %[[VAL_276]] : !llvm.ptr<i32, 1>
+    // CHECK-NEXT:        llvm.return %[[VAL_277]] : i32
     // CHECK-NEXT:      }
     func.func @test_sub_group_local_id() -> i32 {
       %0 = sycl.sub_group_local_id : i32

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm.mlir
@@ -9,12 +9,12 @@
 
 module attributes {gpu.container_module} {
   // CHECK:   gpu.module @kernels {
-    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupLocalInvocationId() {addr_space = 1 : i32} : i64
-    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupMaxSize() {addr_space = 1 : i32} : i64
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupLocalInvocationId() {addr_space = 1 : i32} : i32
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupMaxSize() {addr_space = 1 : i32} : i32
     //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInGlobalOffset() {addr_space = 1 : i32} : vector<3xi64>
-    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupId() {addr_space = 1 : i32} : i64
-    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupSize() {addr_space = 1 : i32} : i64
-    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInNumSubgroups() {addr_space = 1 : i32} : i64
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupId() {addr_space = 1 : i32} : i32
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInSubgroupSize() {addr_space = 1 : i32} : i32
+    //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInNumSubgroups() {addr_space = 1 : i32} : i32
     //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInWorkgroupId() {addr_space = 1 : i32} : vector<3xi64>
     //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInWorkgroupSize() {addr_space = 1 : i32} : vector<3xi64>
     //CHECK-DAG:      llvm.mlir.global external constant @__spirv_BuiltInLocalInvocationId() {addr_space = 1 : i32} : vector<3xi64>
@@ -299,9 +299,8 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:     llvm.func @test_num_sub_groups() -> i32 {
     // CHECK-NEXT:        %[[VAL_200:.*]] = llvm.mlir.addressof @__spirv_BuiltInNumSubgroups : !llvm.ptr<1>
-    // CHECK-NEXT:        %[[VAL_201:.*]] = llvm.load %[[VAL_200]] : !llvm.ptr<1> -> i64
-    // CHECK-NEXT:        %[[VAL_202:.*]] = llvm.trunc %[[VAL_201]] : i64 to i32
-    // CHECK-NEXT:        llvm.return %[[VAL_202]] : i32
+    // CHECK-NEXT:        %[[VAL_201:.*]] = llvm.load %[[VAL_200]] : !llvm.ptr<1> -> i32
+    // CHECK-NEXT:        llvm.return %[[VAL_201]] : i32
     // CHECK-NEXT:      }
     func.func @test_num_sub_groups() -> i32 {
       %0 = sycl.num_sub_groups : i32
@@ -310,9 +309,8 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:     llvm.func @test_sub_group_size() -> i32 {
     // CHECK-NEXT:        %[[VAL_203:.*]] = llvm.mlir.addressof @__spirv_BuiltInSubgroupSize : !llvm.ptr<1>
-    // CHECK-NEXT:        %[[VAL_204:.*]] = llvm.load %[[VAL_203]] : !llvm.ptr<1> -> i64
-    // CHECK-NEXT:        %[[VAL_205:.*]] = llvm.trunc %[[VAL_204]] : i64 to i32
-    // CHECK-NEXT:        llvm.return %[[VAL_205]] : i32
+    // CHECK-NEXT:        %[[VAL_204:.*]] = llvm.load %[[VAL_203]] : !llvm.ptr<1> -> i32
+    // CHECK-NEXT:        llvm.return %[[VAL_204]] : i32
     // CHECK-NEXT:      }
     func.func @test_sub_group_size() -> i32 {
       %0 = sycl.sub_group_size : i32
@@ -321,9 +319,8 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:     llvm.func @test_sub_group_id() -> i32 {
     // CHECK-NEXT:        %[[VAL_206:.*]] = llvm.mlir.addressof @__spirv_BuiltInSubgroupId : !llvm.ptr<1>
-    // CHECK-NEXT:        %[[VAL_207:.*]] = llvm.load %[[VAL_206]] : !llvm.ptr<1> -> i64
-    // CHECK-NEXT:        %[[VAL_208:.*]] = llvm.trunc %[[VAL_207]] : i64 to i32
-    // CHECK-NEXT:        llvm.return %[[VAL_208]] : i32
+    // CHECK-NEXT:        %[[VAL_207:.*]] = llvm.load %[[VAL_206]] : !llvm.ptr<1> -> i32
+    // CHECK-NEXT:        llvm.return %[[VAL_207]] : i32
     // CHECK-NEXT:      }
     func.func @test_sub_group_id() -> i32 {
       %0 = sycl.sub_group_id : i32
@@ -436,9 +433,8 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:     llvm.func @test_sub_group_max_size() -> i32 {
     // CHECK-NEXT:        %[[VAL_273:.*]] = llvm.mlir.addressof @__spirv_BuiltInSubgroupMaxSize : !llvm.ptr<1>
-    // CHECK-NEXT:        %[[VAL_274:.*]] = llvm.load %[[VAL_273]] : !llvm.ptr<1> -> i64
-    // CHECK-NEXT:        %[[VAL_275:.*]] = llvm.trunc %[[VAL_274]] : i64 to i32
-    // CHECK-NEXT:        llvm.return %[[VAL_275]] : i32
+    // CHECK-NEXT:        %[[VAL_274:.*]] = llvm.load %[[VAL_273]] : !llvm.ptr<1> -> i32
+    // CHECK-NEXT:        llvm.return %[[VAL_274]] : i32
     func.func @test_sub_group_max_size() -> i32 {
       %0 = sycl.sub_group_max_size : i32
       return %0 : i32
@@ -446,9 +442,8 @@ module attributes {gpu.container_module} {
 
     // CHECK-LABEL:     llvm.func @test_sub_group_local_id() -> i32 {
     // CHECK-NEXT:        %[[VAL_276:.*]] = llvm.mlir.addressof @__spirv_BuiltInSubgroupLocalInvocationId : !llvm.ptr<1>
-    // CHECK-NEXT:        %[[VAL_277:.*]] = llvm.load %[[VAL_276]] : !llvm.ptr<1> -> i64
-    // CHECK-NEXT:        %[[VAL_278:.*]] = llvm.trunc %[[VAL_277]] : i64 to i32
-    // CHECK-NEXT:        llvm.return %[[VAL_278]] : i32
+    // CHECK-NEXT:        %[[VAL_277:.*]] = llvm.load %[[VAL_276]] : !llvm.ptr<1> -> i32
+    // CHECK-NEXT:        llvm.return %[[VAL_277]] : i32
     // CHECK-NEXT:      }
     func.func @test_sub_group_local_id() -> i32 {
       %0 = sycl.sub_group_local_id : i32


### PR DESCRIPTION
According to [the spec](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_Env.html#_built_in_variables), these variables should be 32 bit wide.