### PR TITLE
[SYCL][E2E] Disable Basic/built-ins/marray_math E2E test on Windows

### DIFF
--- a/sycl/test-e2e/Basic/built-ins/marray_math.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_math.cpp
@@ -1,3 +1,6 @@
+// TODO: Re-enable this test on Windows after fixing the following issue:
+// https://github.com/intel/llvm/issues/8975
+// UNSUPPORTED: windows
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out


### PR DESCRIPTION
This test is failing on Windows thus, causing the post-commit to be in red.
See #8975 