### PR TITLE
[CI] Enable pre-commit testing on Windows

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -74,3 +74,4 @@ jobs:
     uses: ./.github/workflows/sycl_windows_build_and_test.yml
     with:
       lts_matrix: ${{ needs.test_matrix.outputs.lts_wn_matrix }}
+      build_ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -48,7 +48,7 @@ jobs:
     uses: ./.github/workflows/sycl_gen_test_matrix.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
-      lts_config: "hip_amdgpu;ocl_x64;ocl_gen9;l0_gen9;esimd_emu;cuda_aws"
+      lts_config: "hip_amdgpu;ocl_x64;ocl_gen9;l0_gen9;esimd_emu;cuda_aws;win_l0_gen12"
 
   linux_default:
     name: Linux
@@ -66,3 +66,11 @@ jobs:
       build_cache_suffix: "default"
       lts_matrix: ${{ needs.test_matrix.outputs.lts_lx_matrix }}
       lts_aws_matrix: ${{ needs.test_matrix.outputs.lts_aws_matrix }}
+
+  windows_default:
+    name: Windows
+    needs: test_matrix
+    if: github.repository == 'intel/llvm'
+    uses: ./.github/workflows/sycl_windows_build_and_test.yml
+    with:
+      lts_matrix: ${{ needs.test_matrix.outputs.lts_wn_matrix }}

--- a/.github/workflows/windows_test_comment_trigger.yml
+++ b/.github/workflows/windows_test_comment_trigger.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   windows_test_preparation:
     runs-on: ubuntu-20.04
-    if: ${{ false && github.event.issue.pull_request && github.event.comment.body == '/testwin' }}
+    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/testwin' }}
     steps:
     - name: react_to_comment
       uses: actions/github-script@v6
@@ -44,11 +44,11 @@ jobs:
 
   test_matrix:
     name: Generate Test Matrix
-    if: ${{ false && github.repository == 'intel/llvm' }}
+    needs: [windows_test_preparation]
+    if: github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl_gen_test_matrix.yml
     with:
       lts_config: "win_l0_gen12"
-      cts_config: "cuda"
 
   windows_default:
     name: Windows
@@ -62,7 +62,6 @@ jobs:
   windows_test_completion:
     runs-on: ubuntu-20.04
     needs: [windows_test_preparation, windows_default]
-    if: always()
     steps:
     - name: update_pr_status_success
       if: needs.windows_default.result == 'success'

--- a/.github/workflows/windows_test_comment_trigger.yml
+++ b/.github/workflows/windows_test_comment_trigger.yml
@@ -47,7 +47,7 @@ jobs:
     if: github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl_gen_test_matrix.yml
     with:
-      lts_config: "l0_gen9;win_l0_gen12"
+      lts_config: "win_l0_gen12"
       cts_config: "cuda"
 
   windows_default:

--- a/.github/workflows/windows_test_comment_trigger.yml
+++ b/.github/workflows/windows_test_comment_trigger.yml
@@ -62,6 +62,7 @@ jobs:
   windows_test_completion:
     runs-on: ubuntu-20.04
     needs: [windows_test_preparation, windows_default]
+    if: ${{ always() && needs.windows_test_preparation.result != 'skipped' }}
     steps:
     - name: update_pr_status_success
       if: needs.windows_default.result == 'success'

--- a/.github/workflows/windows_test_comment_trigger.yml
+++ b/.github/workflows/windows_test_comment_trigger.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   windows_test_preparation:
     runs-on: ubuntu-20.04
-    if: ${{ github.event.issue.pull_request && github.event.comment.body == '/testwin' }}
+    if: ${{ false && github.event.issue.pull_request && github.event.comment.body == '/testwin' }}
     steps:
     - name: react_to_comment
       uses: actions/github-script@v6
@@ -44,7 +44,7 @@ jobs:
 
   test_matrix:
     name: Generate Test Matrix
-    if: github.repository == 'intel/llvm'
+    if: ${{ false && github.repository == 'intel/llvm' }}
     uses: ./.github/workflows/sycl_gen_test_matrix.yml
     with:
       lts_config: "win_l0_gen12"

--- a/.github/workflows/windows_test_comment_trigger.yml
+++ b/.github/workflows/windows_test_comment_trigger.yml
@@ -42,7 +42,7 @@ jobs:
     outputs:
       PR_SHA: ${{ steps.sha.outputs.result }}
 
- test_matrix:
+  test_matrix:
     name: Generate Test Matrix
     if: github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl_gen_test_matrix.yml

--- a/.github/workflows/windows_test_comment_trigger.yml
+++ b/.github/workflows/windows_test_comment_trigger.yml
@@ -42,14 +42,22 @@ jobs:
     outputs:
       PR_SHA: ${{ steps.sha.outputs.result }}
 
+ test_matrix:
+    name: Generate Test Matrix
+    if: github.repository == 'intel/llvm'
+    uses: ./.github/workflows/sycl_gen_test_matrix.yml
+    with:
+      lts_config: "l0_gen9;win_l0_gen12"
+      cts_config: "cuda"
 
   windows_default:
     name: Windows
-    needs: [windows_test_preparation]
+    needs: [windows_test_preparation, test_matrix]
     if: github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl_windows_build_and_test.yml
     with:
       build_ref: ${{ needs.windows_test_preparation.outputs.PR_SHA }}
+      lts_matrix: ${{ needs.test_matrix.outputs.lts_wn_matrix }}
 
   windows_test_completion:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This PR (1) enables running Windows Build + LIT + E2E tests during pre-commit testing, (2) Fix windows_test_comment_trigger workflow after #8656 