### PR TITLE
[SYCL-MLIR] Take into account SYCL-OpenCL different unit stride conventions

### DIFF
--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm-typed-pointer.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm-typed-pointer.mlir
@@ -81,13 +81,13 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:        %[[VAL_38:.*]] = llvm.alloca %[[VAL_37]] x !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
     // CHECK-DAG:         %[[VAL_39:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_40:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-DAG:         %[[VAL_41:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_41:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-NEXT:        %[[VAL_42:.*]] = llvm.extractelement %[[VAL_33]]{{\[}}%[[VAL_41]] : i32] : vector<3xi64>
     // CHECK-NEXT:        %[[VAL_43:.*]] = llvm.getelementptr inbounds %[[VAL_38]][0, 0, 0, %[[VAL_40]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK-NEXT:        %[[VAL_44:.*]] = llvm.getelementptr %[[VAL_43]]{{\[}}%[[VAL_39]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
     // CHECK-NEXT:        llvm.store %[[VAL_42]], %[[VAL_44]] : !llvm.ptr<i64>
     // CHECK-DAG:         %[[VAL_45:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK-DAG:         %[[VAL_46:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-DAG:         %[[VAL_46:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT:        %[[VAL_47:.*]] = llvm.extractelement %[[VAL_33]]{{\[}}%[[VAL_46]] : i32] : vector<3xi64>
     // CHECK-NEXT:        %[[VAL_48:.*]] = llvm.getelementptr inbounds %[[VAL_38]][0, 0, 0, %[[VAL_45]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK-NEXT:        %[[VAL_49:.*]] = llvm.getelementptr %[[VAL_48]]{{\[}}%[[VAL_39]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
@@ -136,7 +136,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:        %[[VAL_75:.*]] = llvm.alloca %[[VAL_74]] x !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
     // CHECK-DAG:         %[[VAL_76:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_77:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-DAG:         %[[VAL_78:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_78:.*]] = llvm.mlir.constant(2 : i32) : i32
     // CHECK-NEXT:        %[[VAL_79:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_78]] : i32] : vector<3xi64>
     // CHECK-NEXT:        %[[VAL_80:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_77]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK-NEXT:        %[[VAL_81:.*]] = llvm.getelementptr %[[VAL_80]]{{\[}}%[[VAL_76]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
@@ -148,7 +148,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:        %[[VAL_86:.*]] = llvm.getelementptr %[[VAL_85]]{{\[}}%[[VAL_76]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
     // CHECK-NEXT:        llvm.store %[[VAL_84]], %[[VAL_86]] : !llvm.ptr<i64>
     // CHECK-DAG:         %[[VAL_87:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK-DAG:         %[[VAL_88:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK-DAG:         %[[VAL_88:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT:        %[[VAL_89:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_88]] : i32] : vector<3xi64>
     // CHECK-NEXT:        %[[VAL_90:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_87]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK-NEXT:        %[[VAL_91:.*]] = llvm.getelementptr %[[VAL_90]]{{\[}}%[[VAL_76]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
@@ -197,7 +197,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:        %[[VAL_117:.*]] = llvm.alloca %[[VAL_116]] x !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
     // CHECK-DAG:         %[[VAL_118:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_119:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-DAG:         %[[VAL_120:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_120:.*]] = llvm.mlir.constant(2 : i32) : i32
     // CHECK-NEXT:        %[[VAL_121:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_120]] : i32] : vector<3xi64>
     // CHECK-NEXT:        %[[VAL_122:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_119]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK-NEXT:        %[[VAL_123:.*]] = llvm.getelementptr %[[VAL_122]]{{\[}}%[[VAL_118]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
@@ -209,7 +209,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:        %[[VAL_128:.*]] = llvm.getelementptr %[[VAL_127]]{{\[}}%[[VAL_118]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
     // CHECK-NEXT:        llvm.store %[[VAL_126]], %[[VAL_128]] : !llvm.ptr<i64>
     // CHECK-DAG:         %[[VAL_129:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK-DAG:         %[[VAL_130:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK-DAG:         %[[VAL_130:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT:        %[[VAL_131:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_130]] : i32] : vector<3xi64>
     // CHECK-NEXT:        %[[VAL_132:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_129]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK-NEXT:        %[[VAL_133:.*]] = llvm.getelementptr %[[VAL_132]]{{\[}}%[[VAL_118]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
@@ -386,13 +386,13 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:        %[[VAL_232:.*]] = llvm.alloca %[[VAL_231]] x !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
     // CHECK-DAG:         %[[VAL_233:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_234:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-DAG:         %[[VAL_235:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_235:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-NEXT:        %[[VAL_236:.*]] = llvm.extractelement %[[VAL_227]]{{\[}}%[[VAL_235]] : i32] : vector<3xi64>
     // CHECK-NEXT:        %[[VAL_237:.*]] = llvm.getelementptr inbounds %[[VAL_232]][0, 0, 0, %[[VAL_234]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK-NEXT:        %[[VAL_238:.*]] = llvm.getelementptr %[[VAL_237]]{{\[}}%[[VAL_233]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
     // CHECK-NEXT:        llvm.store %[[VAL_236]], %[[VAL_238]] : !llvm.ptr<i64>
     // CHECK-DAG:         %[[VAL_239:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK-DAG:         %[[VAL_240:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-DAG:         %[[VAL_240:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT:        %[[VAL_241:.*]] = llvm.extractelement %[[VAL_227]]{{\[}}%[[VAL_240]] : i32] : vector<3xi64>
     // CHECK-NEXT:        %[[VAL_242:.*]] = llvm.getelementptr inbounds %[[VAL_232]][0, 0, 0, %[[VAL_239]]] : (!llvm.ptr<struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
     // CHECK-NEXT:        %[[VAL_243:.*]] = llvm.getelementptr %[[VAL_242]]{{\[}}%[[VAL_233]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm.mlir
@@ -81,13 +81,13 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:        %[[VAL_38:.*]] = llvm.alloca %[[VAL_37]] x !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr
     // CHECK-DAG:         %[[VAL_39:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_40:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-DAG:         %[[VAL_41:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_41:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-NEXT:        %[[VAL_42:.*]] = llvm.extractelement %[[VAL_33]]{{\[}}%[[VAL_41]] : i32] : vector<3xi64>
     // CHECK-NEXT:        %[[VAL_43:.*]] = llvm.getelementptr inbounds %[[VAL_38]][0, 0, 0, %[[VAL_40]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
     // CHECK-NEXT:        %[[VAL_44:.*]] = llvm.getelementptr %[[VAL_43]]{{\[}}%[[VAL_39]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
     // CHECK-NEXT:        llvm.store %[[VAL_42]], %[[VAL_44]] : i64, !llvm.ptr
     // CHECK-DAG:         %[[VAL_45:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK-DAG:         %[[VAL_46:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-DAG:         %[[VAL_46:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT:        %[[VAL_47:.*]] = llvm.extractelement %[[VAL_33]]{{\[}}%[[VAL_46]] : i32] : vector<3xi64>
     // CHECK-NEXT:        %[[VAL_48:.*]] = llvm.getelementptr inbounds %[[VAL_38]][0, 0, 0, %[[VAL_45]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
     // CHECK-NEXT:        %[[VAL_49:.*]] = llvm.getelementptr %[[VAL_48]]{{\[}}%[[VAL_39]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
@@ -136,7 +136,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:        %[[VAL_75:.*]] = llvm.alloca %[[VAL_74]] x !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr
     // CHECK-DAG:         %[[VAL_76:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_77:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-DAG:         %[[VAL_78:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_78:.*]] = llvm.mlir.constant(2 : i32) : i32
     // CHECK-NEXT:        %[[VAL_79:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_78]] : i32] : vector<3xi64>
     // CHECK-NEXT:        %[[VAL_80:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_77]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
     // CHECK-NEXT:        %[[VAL_81:.*]] = llvm.getelementptr %[[VAL_80]]{{\[}}%[[VAL_76]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
@@ -148,7 +148,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:        %[[VAL_86:.*]] = llvm.getelementptr %[[VAL_85]]{{\[}}%[[VAL_76]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
     // CHECK-NEXT:        llvm.store %[[VAL_84]], %[[VAL_86]] : i64, !llvm.ptr
     // CHECK-DAG:         %[[VAL_87:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK-DAG:         %[[VAL_88:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK-DAG:         %[[VAL_88:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT:        %[[VAL_89:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_88]] : i32] : vector<3xi64>
     // CHECK-NEXT:        %[[VAL_90:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_87]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
     // CHECK-NEXT:        %[[VAL_91:.*]] = llvm.getelementptr %[[VAL_90]]{{\[}}%[[VAL_76]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
@@ -197,7 +197,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:        %[[VAL_117:.*]] = llvm.alloca %[[VAL_116]] x !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr
     // CHECK-DAG:         %[[VAL_118:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_119:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-DAG:         %[[VAL_120:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_120:.*]] = llvm.mlir.constant(2 : i32) : i32
     // CHECK-NEXT:        %[[VAL_121:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_120]] : i32] : vector<3xi64>
     // CHECK-NEXT:        %[[VAL_122:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_119]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
     // CHECK-NEXT:        %[[VAL_123:.*]] = llvm.getelementptr %[[VAL_122]]{{\[}}%[[VAL_118]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
@@ -209,7 +209,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:        %[[VAL_128:.*]] = llvm.getelementptr %[[VAL_127]]{{\[}}%[[VAL_118]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
     // CHECK-NEXT:        llvm.store %[[VAL_126]], %[[VAL_128]] : i64, !llvm.ptr
     // CHECK-DAG:         %[[VAL_129:.*]] = llvm.mlir.constant(2 : i32) : i32
-    // CHECK-DAG:         %[[VAL_130:.*]] = llvm.mlir.constant(2 : i32) : i32
+    // CHECK-DAG:         %[[VAL_130:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT:        %[[VAL_131:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_130]] : i32] : vector<3xi64>
     // CHECK-NEXT:        %[[VAL_132:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_129]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
     // CHECK-NEXT:        %[[VAL_133:.*]] = llvm.getelementptr %[[VAL_132]]{{\[}}%[[VAL_118]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
@@ -386,13 +386,13 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:        %[[VAL_232:.*]] = llvm.alloca %[[VAL_231]] x !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr
     // CHECK-DAG:         %[[VAL_233:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_234:.*]] = llvm.mlir.constant(0 : i32) : i32
-    // CHECK-DAG:         %[[VAL_235:.*]] = llvm.mlir.constant(0 : i32) : i32
+    // CHECK-DAG:         %[[VAL_235:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-NEXT:        %[[VAL_236:.*]] = llvm.extractelement %[[VAL_227]]{{\[}}%[[VAL_235]] : i32] : vector<3xi64>
     // CHECK-NEXT:        %[[VAL_237:.*]] = llvm.getelementptr inbounds %[[VAL_232]][0, 0, 0, %[[VAL_234]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
     // CHECK-NEXT:        %[[VAL_238:.*]] = llvm.getelementptr %[[VAL_237]]{{\[}}%[[VAL_233]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
     // CHECK-NEXT:        llvm.store %[[VAL_236]], %[[VAL_238]] : i64, !llvm.ptr
     // CHECK-DAG:         %[[VAL_239:.*]] = llvm.mlir.constant(1 : i32) : i32
-    // CHECK-DAG:         %[[VAL_240:.*]] = llvm.mlir.constant(1 : i32) : i32
+    // CHECK-DAG:         %[[VAL_240:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT:        %[[VAL_241:.*]] = llvm.extractelement %[[VAL_227]]{{\[}}%[[VAL_240]] : i32] : vector<3xi64>
     // CHECK-NEXT:        %[[VAL_242:.*]] = llvm.getelementptr inbounds %[[VAL_232]][0, 0, 0, %[[VAL_239]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
     // CHECK-NEXT:        %[[VAL_243:.*]] = llvm.getelementptr %[[VAL_242]]{{\[}}%[[VAL_233]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm-typed-pointer.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm-typed-pointer.mlir
@@ -1291,7 +1291,7 @@ module attributes {gpu.container} {
 // CHECK:             %[[VAL_7:.*]] = llvm.alloca %[[VAL_6]] x !llvm.[[ID3]] : (i64) -> !llvm.ptr<[[ID3]]>
 // CHECK-DAG:         %[[VAL_8:.*]] = llvm.mlir.constant(0 : index) : i64
 // CHECK-DAG:         %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-DAG:         %[[VAL_10:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_10:.*]] = llvm.mlir.constant(2 : i32) : i32
 // CHECK:             %[[VAL_11:.*]] = llvm.extractelement %[[VAL_2]]{{\[}}%[[VAL_10]] : i32] : vector<3xi64>
 // CHECK:             %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_9]]] : (!llvm.ptr<[[ID3]]>, i32) -> !llvm.ptr<i64>
 // CHECK:             %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_12]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
@@ -1303,7 +1303,7 @@ module attributes {gpu.container} {
 // CHECK:             %[[VAL_18:.*]] = llvm.getelementptr %[[VAL_17]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
 // CHECK:             llvm.store %[[VAL_16]], %[[VAL_18]] : !llvm.ptr<i64>
 // CHECK-DAG:         %[[VAL_19:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-DAG:         %[[VAL_20:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-DAG:         %[[VAL_20:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_21:.*]] = llvm.extractelement %[[VAL_2]]{{\[}}%[[VAL_20]] : i32] : vector<3xi64>
 // CHECK:             %[[VAL_22:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_19]]] : (!llvm.ptr<[[ID3]]>, i32) -> !llvm.ptr<i64>
 // CHECK:             %[[VAL_23:.*]] = llvm.getelementptr %[[VAL_22]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -1274,7 +1274,7 @@ module attributes {gpu.container} {
 // CHECK-NEXT:        %[[VAL_7:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::id.3", {{.*}}> : (i64) -> !llvm.ptr
 // CHECK-DAG:         %[[VAL_8:.*]] = llvm.mlir.constant(0 : index) : i64
 // CHECK-DAG:         %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-DAG:         %[[VAL_10:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_10:.*]] = llvm.mlir.constant(2 : i32) : i32
 // CHECK:             %[[VAL_11:.*]] = llvm.extractelement %[[VAL_2]]{{\[}}%[[VAL_10]] : i32] : vector<3xi64>
 // CHECK-NEXT:        %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_9]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
 // CHECK-NEXT:        %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_12]]{{\[}}%[[VAL_8]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
@@ -1286,7 +1286,7 @@ module attributes {gpu.container} {
 // CHECK-NEXT:        %[[VAL_18:.*]] = llvm.getelementptr %[[VAL_17]]{{\[}}%[[VAL_8]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
 // CHECK-NEXT:        llvm.store %[[VAL_16]], %[[VAL_18]] : i64, !llvm.ptr
 // CHECK-DAG:         %[[VAL_19:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-DAG:         %[[VAL_20:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-DAG:         %[[VAL_20:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_21:.*]] = llvm.extractelement %[[VAL_2]]{{\[}}%[[VAL_20]] : i32] : vector<3xi64>
 // CHECK-NEXT:        %[[VAL_22:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_19]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
 // CHECK-NEXT:        %[[VAL_23:.*]] = llvm.getelementptr %[[VAL_22]]{{\[}}%[[VAL_8]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64

--- a/mlir-sycl/test/Conversion/SYCLToSPIRV/grid-ops.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToSPIRV/grid-ops.mlir
@@ -3,6 +3,7 @@
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64>)>)>
 
 module attributes {gpu.container_module} {
   // CHECK:   gpu.module @kernels {
@@ -68,12 +69,12 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:            %[[VAL_26:.*]] = memref.alloca() : memref<1x!sycl_range_2_>
     // CHECK-NEXT:            %[[VAL_27:.*]] = arith.constant 0 : index
     // CHECK-NEXT:            %[[VAL_29:.*]] = arith.constant 0 : i32
-    // CHECK-NEXT:            %[[VAL_30:.*]] = spirv.CompositeExtract %[[VAL_25]][0 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_30:.*]] = spirv.CompositeExtract %[[VAL_25]][1 : i32] : vector<3xi32>
     // CHECK-NEXT:            %[[VAL_31:.*]] = arith.extsi %[[VAL_30]] : i32 to i64
     // CHECK-NEXT:            %[[VAL_32:.*]] = sycl.range.get %[[VAL_26]][%[[VAL_29]]] {ArgumentTypes = [memref<1x!sycl_range_2_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_2_>, i32) -> memref<2xi64>
     // CHECK-NEXT:            memref.store %[[VAL_31]], %[[VAL_32]]{{\[}}%[[VAL_27]]] : memref<2xi64>
     // CHECK-NEXT:            %[[VAL_33:.*]] = arith.constant 1 : i32
-    // CHECK-NEXT:            %[[VAL_34:.*]] = spirv.CompositeExtract %[[VAL_25]][1 : i32] : vector<3xi32>
+    // CHECK-NEXT:            %[[VAL_34:.*]] = spirv.CompositeExtract %[[VAL_25]][0 : i32] : vector<3xi32>
     // CHECK-NEXT:            %[[VAL_35:.*]] = arith.extsi %[[VAL_34]] : i32 to i64
     // CHECK-NEXT:            %[[VAL_36:.*]] = sycl.range.get %[[VAL_26]][%[[VAL_33]]] {ArgumentTypes = [memref<1x!sycl_range_2_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_2_>, i32) -> memref<2xi64>
     // CHECK-NEXT:            memref.store %[[VAL_35]], %[[VAL_36]]{{\[}}%[[VAL_27]]] : memref<2xi64>
@@ -209,6 +210,35 @@ module attributes {gpu.container_module} {
     gpu.func @test_work_group_size() kernel
       attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
       %0 = sycl.work_group_size : !sycl_range_1_
+      gpu.return
+    }
+
+    // CHECK-LABEL:         gpu.func @test_work_group_size_3D() kernel
+    // CHECK-NEXT:             %[[VAL_105:.*]] = spirv.mlir.addressof @__spirv_BuiltInWorkgroupSize : !spirv.ptr<vector<3xi32>, Input>
+    // CHECK-NEXT:             %[[VAL_106:.*]] = spirv.Load "Input" %[[VAL_105]] : vector<3xi32>
+    // CHECK-NEXT:             %[[VAL_107:.*]] = memref.alloca() : memref<1x!sycl_range_3_>
+    // CHECK-NEXT:             %[[VAL_108:.*]] = arith.constant 0 : index
+    // CHECK-NEXT:             %[[VAL_109:.*]] = arith.constant 0 : i32
+    // CHECK-NEXT:             %[[VAL_110:.*]] = spirv.CompositeExtract %[[VAL_106]][2 : i32] : vector<3xi32>
+    // CHECK-NEXT:             %[[VAL_111:.*]] = arith.extsi %[[VAL_110]] : i32 to i64
+    // CHECK-NEXT:             %[[VAL_112:.*]] = sycl.range.get %[[VAL_107]]{{\[}}%[[VAL_109]]] {ArgumentTypes = [memref<1x!sycl_range_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64>
+    // CHECK-NEXT:             memref.store %[[VAL_111]], %[[VAL_112]]{{\[}}%[[VAL_108]]] : memref<3xi64>
+    // CHECK-NEXT:             %[[VAL_113:.*]] = arith.constant 1 : i32
+    // CHECK-NEXT:             %[[VAL_114:.*]] = spirv.CompositeExtract %[[VAL_106]][1 : i32] : vector<3xi32>
+    // CHECK-NEXT:             %[[VAL_115:.*]] = arith.extsi %[[VAL_114]] : i32 to i64
+    // CHECK-NEXT:             %[[VAL_116:.*]] = sycl.range.get %[[VAL_107]]{{\[}}%[[VAL_113]]] {ArgumentTypes = [memref<1x!sycl_range_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64>
+    // CHECK-NEXT:             memref.store %[[VAL_115]], %[[VAL_116]]{{\[}}%[[VAL_108]]] : memref<3xi64>
+    // CHECK-NEXT:             %[[VAL_117:.*]] = arith.constant 2 : i32
+    // CHECK-NEXT:             %[[VAL_118:.*]] = spirv.CompositeExtract %[[VAL_106]][0 : i32] : vector<3xi32>
+    // CHECK-NEXT:             %[[VAL_119:.*]] = arith.extsi %[[VAL_118]] : i32 to i64
+    // CHECK-NEXT:             %[[VAL_120:.*]] = sycl.range.get %[[VAL_107]]{{\[}}%[[VAL_117]]] {ArgumentTypes = [memref<1x!sycl_range_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64>
+    // CHECK-NEXT:             memref.store %[[VAL_119]], %[[VAL_120]]{{\[}}%[[VAL_108]]] : memref<3xi64>
+    // CHECK-NEXT:             %[[VAL_121:.*]] = memref.load %[[VAL_107]]{{\[}}%[[VAL_108]]] : memref<1x!sycl_range_3_>
+    // CHECK-NEXT:             gpu.return
+    // CHECK-NEXT:           }
+    gpu.func @test_work_group_size_3D() kernel
+      attributes {spirv.entry_point_abi = #spirv.entry_point_abi<>} {
+      %0 = sycl.work_group_size : !sycl_range_3_
       gpu.return
     }
 


### PR DESCRIPTION
While SYCL aligns with C++ array subscript ordering (`arr[a][b][c]`), quite the opposite to what OpenCL does (`arr[c][b][a]`). This way, it is necessary to apply a mirroring when building the resulting N-dimensional `id`/`range` resulting from a SYCL grid operation (`sycl.global_id`, `sycl.local_id`, etc.).

See
https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:opencl:kernel-conventions-sycl.