### PR TITLE
[SYCL-MLIR][LICM] Use index type

### DIFF
--- a/mlir-sycl/lib/Dialect/IR/SYCLTraits.cpp
+++ b/mlir-sycl/lib/Dialect/IR/SYCLTraits.cpp
@@ -43,7 +43,7 @@ mlir::LogicalResult mlir::sycl::verifySYCLGetComponentTrait(Operation *OpPtr) {
   const llvm::StringRef FunctionName = Op.getFunctionName();
   const bool IsSizeTCast = Op.getFunctionName() == "operator unsigned long";
   const mlir::Type RetTy = Op->getResult(0).getType();
-  const bool IsScalarReturn = RetTy.isInteger(64);
+  const bool IsScalarReturn = RetTy.isIntOrIndex();
   switch (Op->getNumOperands()) {
   case 1: {
     if (!IsSizeTCast) {

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
@@ -418,7 +418,7 @@ private:
                                              unsigned index, OpBuilder builder,
                                              Location loc) {
     const Value indexOp = builder.create<arith::ConstantIntOp>(loc, index, 32);
-    const auto resTy = builder.getI64Type();
+    const auto resTy = builder.getIndexType();
     return createMethodOp<sycl::SYCLIDGetOp>(
         builder, loc, MemRefType::get(ShapedType::kDynamic, resTy),
         {id, indexOp}, "operator[]", "id");
@@ -429,7 +429,7 @@ private:
                                                    OpBuilder builder,
                                                    Location loc) {
     const Value indexOp = builder.create<arith::ConstantIntOp>(loc, index, 32);
-    const auto resTy = builder.getI64Type();
+    const auto resTy = builder.getIndexType();
     return createMethodOp<sycl::SYCLRangeGetOp>(
         builder, loc, resTy, {range, indexOp}, "get", "range");
   }
@@ -464,11 +464,10 @@ private:
     const auto idTy = cast<sycl::IDType>(
         cast<sycl::AccessorImplDeviceType>(accTy.getBody()[0]).getBody()[0]);
     auto id = builder.create<memref::AllocaOp>(loc, MemRefType::get(1, idTy));
-    const Value zero = builder.create<arith::ConstantIntOp>(loc, 0, 64);
     const Value zeroIndex = builder.create<arith::ConstantIndexOp>(loc, 0);
     for (unsigned i = 0; i < accTy.getDimension(); ++i) {
       Value idGetOp = createSYCLIDGetOp(id, i, builder, loc);
-      builder.create<memref::StoreOp>(loc, zero, idGetOp, zeroIndex);
+      builder.create<memref::StoreOp>(loc, zeroIndex, idGetOp, zeroIndex);
     }
     return createSYCLAccessorSubscriptOp(accessor, id, builder, loc);
   }
@@ -485,7 +484,7 @@ private:
     const auto idTy = cast<sycl::IDType>(
         cast<sycl::AccessorImplDeviceType>(accTy.getBody()[0]).getBody()[0]);
     auto id = builder.create<memref::AllocaOp>(loc, MemRefType::get(1, idTy));
-    const Value one = builder.create<arith::ConstantIntOp>(loc, 1, 64);
+    const Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
     unsigned dim = accTy.getDimension();
     for (unsigned i = 0; i < dim; ++i) {
       Value idGetOp = createSYCLIDGetOp(id, i, builder, loc);

--- a/polygeist/test/polygeist-opt/sycl/licm-accessor-versioning.mlir
+++ b/polygeist/test/polygeist-opt/sycl/licm-accessor-versioning.mlir
@@ -38,10 +38,9 @@
 // COM: Obtain a pointer to the beginning of the accessor %arg1.
 // CHECK-DAG:  [[ID_ALLOCA:%.*]] = memref.alloca() : memref<1x[[ID:!sycl_id_1_]]>
 // CHECK-DAG:  [[C0_i32:%.*]] = arith.constant 0 : i32
-// CHECK-DAG:  [[C0_i64:%.*]] = arith.constant 0 : i64
 // CHECK-DAG:  [[C0_index:%.*]] = arith.constant 0 : index
-// CHECK-NEXT: [[ID_GET:%.*]] = sycl.id.get [[ID_ALLOCA]][[[C0_i32]]] {ArgumentTypes = [memref<1x[[ID]]>, i32], FunctionName = @"operator[]", TypeName = @id} : (memref<1x[[ID]]>, i32) -> memref<?xi64>
-// CHECK-NEXT: memref.store [[C0_i64]], [[ID_GET]][[[C0_index]]] : memref<?xi64>
+// CHECK-NEXT: [[ID_GET:%.*]] = sycl.id.get [[ID_ALLOCA]][[[C0_i32]]] {ArgumentTypes = [memref<1x[[ID]]>, i32], FunctionName = @"operator[]", TypeName = @id} : (memref<1x[[ID]]>, i32) -> memref<?xindex>
+// CHECK-NEXT: memref.store [[C0_index]], [[ID_GET]][[[C0_index]]] : memref<?xindex>
 // CHECK-NEXT: [[ARG1_BEGIN:%.*]] = sycl.accessor.subscript [[ARG1]][[[ID_ALLOCA]]] {ArgumentTypes = [memref<?x[[ACC_R]], 4>, memref<1x[[ID]]>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x[[ACC_R]], 4>, memref<1x[[ID]]>) -> memref<?xi32, 1>
 
 // COM: Obtain a pointer to the end of the accessor %arg1.
@@ -51,11 +50,11 @@
 // CHECK-NEXT: memref.store [[GET_RANGE]], [[RANGE_ALLOCA]][[[C0_index]]] : memref<1x[[RANGE]]>
 // CHECK-DAG:  [[ID_ALLOCA:%.*]] = memref.alloca() : memref<1x[[ID:!sycl_id_1_]]>
 // CHECK-DAG:  [[C0_i32:%.*]] = arith.constant 0 : i32
-// CHECK-DAG:  [[C1_i64:%.*]] = arith.constant 1 : i64
-// CHECK-NEXT: [[ID_GET:%.*]] = sycl.id.get [[ID_ALLOCA]][[[C0_i32]]] {ArgumentTypes = [memref<1x[[ID]]>, i32], FunctionName = @"operator[]", TypeName = @id} : (memref<1x[[ID]]>, i32) -> memref<?xi64>
+// CHECK-DAG:  [[C1_index:%.*]] = arith.constant 1 : index
+// CHECK-NEXT: [[ID_GET:%.*]] = sycl.id.get [[ID_ALLOCA]][[[C0_i32]]] {ArgumentTypes = [memref<1x[[ID]]>, i32], FunctionName = @"operator[]", TypeName = @id} : (memref<1x[[ID]]>, i32) -> memref<?xindex>
 // CHECK-NEXT: [[C0_i32:%.*]] = arith.constant 0 : i32
-// CHECK-NEXT: [[RANGE_GET:%.*]] = sycl.range.get [[RANGE_ALLOCA]][[[C0_i32]]] {ArgumentTypes = [memref<1x[[RANGE]]>, i32], FunctionName = @get, TypeName = @range} : (memref<1x[[RANGE]]>, i32) -> i64
-// CHECK-NEXT: memref.store [[RANGE_GET]], [[ID_GET]][[[C0_index]]] : memref<?xi64>
+// CHECK-NEXT: [[RANGE_GET:%.*]] = sycl.range.get [[RANGE_ALLOCA]][[[C0_i32]]] {ArgumentTypes = [memref<1x[[RANGE]]>, i32], FunctionName = @get, TypeName = @range} : (memref<1x[[RANGE]]>, i32) -> index
+// CHECK-NEXT: memref.store [[RANGE_GET]], [[ID_GET]][[[C0_index]]] : memref<?xindex>
 // CHECK-NEXT: [[ARG1_END:%.*]] = sycl.accessor.subscript [[ARG1]][[[ID_ALLOCA]]] {ArgumentTypes = [memref<?x[[ACC_R]], 4>, memref<1x[[ID]]>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x[[ACC_R]], 4>, memref<1x[[ID]]>) -> memref<?xi32, 1>
 
 // CHECK: [[ARG0_BEGIN:%.*]] = sycl.accessor.subscript [[ARG0]][{{.*}}] {ArgumentTypes = [memref<?x[[ACC_RW]], 4>, memref<1x[[ID]]>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x[[ACC_RW]], 4>, memref<1x[[ID]]>) -> memref<?xi32, 1>


### PR DESCRIPTION
Use index type instead of i64.