### PR TITLE
[SYCL-MLIR] Fix group ops SYCL to LLVM lowering

### DIFF
--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -42,6 +42,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "sycl-to-llvm"
@@ -523,6 +524,47 @@ public:
   }
 };
 
+template <typename IDGetter, typename RangeGetter>
+static void getLinearIDRewriter(Operation *op, unsigned dimension,
+                                IDGetter getID, RangeGetter getRange,
+                                ConversionPatternRewriter &rewriter) {
+  const auto loc = op->getLoc();
+  Value newValue;
+  switch (dimension) {
+  case 1:
+    // get_id(0)
+    newValue = getID(rewriter, loc, 0);
+    break;
+  case 2: {
+    // get_id(0) * get_range(1) + get_id(1)
+    const auto id0 = getID(rewriter, loc, 0);
+    const auto r1 = getRange(rewriter, loc, 1);
+    const Value prod = rewriter.create<arith::MulIOp>(loc, id0, r1);
+    const auto id1 = getID(rewriter, loc, 1);
+    newValue = rewriter.create<arith::AddIOp>(loc, prod, id1);
+    break;
+  }
+  case 3: {
+    // get_id(0) * get_range(1) * get_range(2) + get_id(1) * get_range(2) +
+    // get_id(2)
+    const auto id0 = getID(rewriter, loc, 0);
+    const auto r1 = getRange(rewriter, loc, 1);
+    const Value prod0 = rewriter.create<arith::MulIOp>(loc, id0, r1);
+    const auto r2 = getRange(rewriter, loc, 2);
+    const Value prod1 = rewriter.create<arith::MulIOp>(loc, prod0, r2);
+    const auto id1 = getID(rewriter, loc, 1);
+    const Value prod2 = rewriter.create<arith::MulIOp>(loc, id1, r2);
+    const Value add = rewriter.create<arith::AddIOp>(loc, prod1, prod2);
+    const auto id2 = getID(rewriter, loc, 2);
+    newValue = rewriter.create<arith::AddIOp>(loc, add, id2);
+    break;
+  }
+  default:
+    llvm_unreachable("Invalid number of dimensions");
+  }
+  rewriter.replaceOp(op, newValue);
+}
+
 template <typename Op>
 class GetLinearIDPattern : public ConvertOpToLLVMPattern<Op> {
 protected:
@@ -546,43 +588,17 @@ public:
                ConversionPatternRewriter &rewriter) const final {
     const auto thisArg = adaptor.getOperands()[0];
     const auto elTy = getTypeConverter()->convertType(op.getType());
-    const auto loc = op.getLoc();
     const auto dimension = getDimensions(op.getOperand().getType());
     const auto convBaseTy = getTypeConverter()->convertType(getBaseType(op));
-    Value newValue;
-    switch (dimension) {
-    case 1:
-      // get_id(0)
-      newValue = getID(rewriter, loc, convBaseTy, elTy, thisArg, 0);
-      break;
-    case 2: {
-      // get_id(0) * get_range(1) + get_id(1)
-      const auto id0 = getID(rewriter, loc, convBaseTy, elTy, thisArg, 0);
-      const auto r1 = getRange(rewriter, loc, convBaseTy, elTy, thisArg, 1);
-      const Value prod = rewriter.create<arith::MulIOp>(loc, id0, r1);
-      const auto id1 = getID(rewriter, loc, convBaseTy, elTy, thisArg, 1);
-      newValue = rewriter.create<arith::AddIOp>(loc, prod, id1);
-      break;
-    }
-    case 3: {
-      // get_id(0) * get_range(1) * get_range(2) + get_id(1) * get_range(2) +
-      // get_id(2)
-      const auto id0 = getID(rewriter, loc, convBaseTy, elTy, thisArg, 0);
-      const auto r1 = getRange(rewriter, loc, convBaseTy, elTy, thisArg, 1);
-      const Value prod0 = rewriter.create<arith::MulIOp>(loc, id0, r1);
-      const auto r2 = getRange(rewriter, loc, convBaseTy, elTy, thisArg, 2);
-      const Value prod1 = rewriter.create<arith::MulIOp>(loc, prod0, r2);
-      const auto id1 = getID(rewriter, loc, convBaseTy, elTy, thisArg, 1);
-      const Value prod2 = rewriter.create<arith::MulIOp>(loc, id1, r2);
-      const Value add = rewriter.create<arith::AddIOp>(loc, prod1, prod2);
-      const auto id2 = getID(rewriter, loc, convBaseTy, elTy, thisArg, 2);
-      newValue = rewriter.create<arith::AddIOp>(loc, add, id2);
-      break;
-    }
-    default:
-      llvm_unreachable("Invalid number of dimensions");
-    }
-    rewriter.replaceOp(op, newValue);
+    getLinearIDRewriter(
+        op, dimension,
+        [&](OpBuilder &builder, Location loc, int32_t index) {
+          return getID(builder, loc, convBaseTy, elTy, thisArg, index);
+        },
+        [&](OpBuilder &builder, Location loc, int32_t index) {
+          return getRange(builder, loc, convBaseTy, elTy, thisArg, index);
+        },
+        rewriter);
   }
 };
 
@@ -610,7 +626,9 @@ public:
 
 /// Base pattern for operations returning the result of a SYCL grid operation
 /// \tparam GridOp.
-template <typename Op, typename GridOp>
+template <typename Op, typename GridOp, typename Getter,
+          typename = std::enable_if_t<
+              llvm::is_one_of<Getter, SYCLIDGetOp, SYCLRangeGetOp>::value>>
 class GridOpInitDimPattern : public ConvertOpToLLVMPattern<Op> {
 protected:
   using ConvertOpToLLVMPattern<Op>::ConvertOpToLLVMPattern;
@@ -623,9 +641,28 @@ public:
 
   void rewrite(Op op, OpAdaptor adaptor,
                ConversionPatternRewriter &rewriter) const final {
-    const Value id = rewriter.create<GridOp>(
-        op.getLoc(), rewriter.getIndexType(), adaptor.getOperands()[1]);
-    rewriter.replaceOpWithNewOp<arith::IndexCastUIOp>(op, op.getType(), id);
+    const auto indexType =
+        ConvertOpToLLVMPattern<Op>::getTypeConverter()->getIndexType();
+    const auto dimensions = getDimensions(op.getOperands()[0].getType());
+    const auto arrayType = rewriter.getType<ArrayType>(
+        dimensions, MemRefType::get(dimensions, indexType));
+    const auto idType = rewriter.getType<IDType>(dimensions, arrayType);
+    const auto loc = op.getLoc();
+    Value idVal = rewriter.create<GridOp>(loc, idType, Value{});
+    Value id =
+        rewriter.create<memref::AllocaOp>(loc, MemRefType::get(1, idType));
+    rewriter.create<memref::StoreOp>(loc, idVal, id);
+    const auto offset = adaptor.getOperands()[1];
+    const auto argTypes =
+        rewriter.getTypeArrayAttr({id.getType(), offset.getType()});
+    const auto funcName = rewriter.getAttr<FlatSymbolRefAttr>("operator[]");
+    const auto mangledFuncName = funcName;
+    const auto typeName = rewriter.getAttr<FlatSymbolRefAttr>(
+        std::is_same_v<SYCLIDGetOp, Getter> ? "id" : "range");
+    Value res =
+        rewriter.create<Getter>(op.getLoc(), indexType, id, offset, argTypes,
+                                funcName, mangledFuncName, typeName);
+    rewriter.replaceOpWithNewOp<arith::IndexCastUIOp>(op, op.getType(), res);
   }
 };
 
@@ -2029,10 +2066,11 @@ public:
 
 /// Converts SYCLGroupGetLocalID with a scalar return type to LLVM
 class GroupGetLocalIDDimPattern
-    : public GridOpInitDimPattern<SYCLGroupGetLocalIDOp, SYCLLocalIDOp> {
+    : public GridOpInitDimPattern<SYCLGroupGetLocalIDOp, SYCLLocalIDOp,
+                                  SYCLIDGetOp> {
 public:
-  using GridOpInitDimPattern<SYCLGroupGetLocalIDOp,
-                             SYCLLocalIDOp>::GridOpInitDimPattern;
+  using GridOpInitDimPattern<SYCLGroupGetLocalIDOp, SYCLLocalIDOp,
+                             SYCLIDGetOp>::GridOpInitDimPattern;
 
   LogicalResult match(SYCLGroupGetLocalIDOp op) const final {
     return success(isa<IntegerType>(op.getRes().getType()));
@@ -2148,29 +2186,54 @@ public:
 
 /// Converts SYCLGroupGetLocalLinearIDOp to LLVM
 class GroupGetLocalLinearIDPattern
-    : public GetLinearIDPattern<SYCLGroupGetLocalLinearIDOp>,
-      public GetMemberPattern<GroupGetGroupRange, RangeGetDim> {
-  Value getID(OpBuilder &builder, Location loc, Type baseTy, Type ty, Value,
-              int32_t offset) const final {
-    const Value dim = builder.create<arith::ConstantIntOp>(loc, offset, 32);
-    const Value val =
-        builder.create<SYCLLocalIDOp>(loc, builder.getIndexType(), dim);
-    return builder.create<arith::IndexCastUIOp>(loc, ty, val);
-  }
-
-  Value getRange(OpBuilder &builder, Location loc, Type baseTy, Type ty,
-                 Value thisArg, int32_t offset) const final {
-    return GetMemberPattern<GroupGetGroupRange, RangeGetDim>::loadValue(
-        builder, loc, baseTy, ty, thisArg,
-        getTypeConverter()->useOpaquePointers(), offset);
-  }
-
-  Type getBaseType(SYCLGroupGetLocalLinearIDOp op) const final {
-    return op.getGroup().getType().getElementType();
-  }
-
+    : public ConvertOpToLLVMPattern<SYCLGroupGetLocalLinearIDOp>,
+      public GetMemberPattern<GroupGetLocalRange, RangeGetDim> {
 public:
-  using GetLinearIDPattern<SYCLGroupGetLocalLinearIDOp>::GetLinearIDPattern;
+  using ConvertOpToLLVMPattern<
+      SYCLGroupGetLocalLinearIDOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(SYCLGroupGetLocalLinearIDOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    const auto loc = op.getLoc();
+    const auto groupTy =
+        cast<GroupType>(op.getGroup().getType().getElementType());
+    const auto dimension = groupTy.getDimension();
+    auto indexType = getTypeConverter()->getIndexType();
+    const auto arrayType = rewriter.getType<ArrayType>(
+        dimension, MemRefType::get(dimension, indexType));
+    const auto idType = rewriter.getType<IDType>(dimension, arrayType);
+    Value localIDVal =
+        rewriter.create<SYCLLocalIDOp>(loc, idType, /*dimension=*/Value{});
+    Value localID =
+        rewriter.create<memref::AllocaOp>(loc, MemRefType::get(1, idType));
+    rewriter.create<memref::StoreOp>(loc, localIDVal, localID);
+    const auto group = adaptor.getGroup();
+    const auto convGroupTy =
+        typeConverter->convertType(op.getGroup().getType());
+    const auto useOpaquePointers = getTypeConverter()->useOpaquePointers();
+    const auto argTys =
+        rewriter.getTypeArrayAttr({localID.getType(), rewriter.getI32Type()});
+    const auto funcName = rewriter.getAttr<FlatSymbolRefAttr>("operator[]");
+    const auto mangledFuncName = funcName;
+    const auto typeName = rewriter.getAttr<FlatSymbolRefAttr>("id");
+    getLinearIDRewriter(
+        op, dimension,
+        [&](OpBuilder &builder, Location loc, int32_t index) -> Value {
+          return builder.create<SYCLIDGetOp>(
+              loc, indexType, localID,
+              builder.create<arith::ConstantIntOp>(loc, index,
+                                                   /*bitwidth=*/32),
+              argTys, funcName, mangledFuncName, typeName);
+        },
+        [&](OpBuilder &builder, Location loc, int32_t index) -> Value {
+          return GetMemberPattern<GroupGetLocalRange, RangeGetDim>::loadValue(
+              builder, loc, convGroupTy, indexType, group, useOpaquePointers,
+              index);
+        },
+        rewriter);
+    return success();
+  }
 };
 
 //===----------------------------------------------------------------------===//

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm-typed-pointer.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm-typed-pointer.mlir
@@ -1284,8 +1284,8 @@ module attributes {gpu.container} {
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<[[GROUP3:.*]]>) -> !llvm.[[ID3:.*]] {
 // CHECK:             %[[VAL_1:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>, 1>
 // CHECK:             %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<vector<3xi64>, 1>
-// CHECK:             %[[VAL_3:.*]] = llvm.mlir.null : !llvm.ptr<[[ID3]]>
-// CHECK:             %[[VAL_4:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK-DAG:         %[[VAL_3:.*]] = llvm.mlir.null : !llvm.ptr<[[ID3]]>
+// CHECK-DAG:         %[[VAL_4:.*]] = llvm.mlir.constant(1 : index) : i64
 // CHECK:             %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_3]]{{\[}}%[[VAL_4]]] : (!llvm.ptr<[[ID3]]>, i64) -> !llvm.ptr<[[ID3]]>
 // CHECK:             %[[VAL_6:.*]] = llvm.ptrtoint %[[VAL_5]] : !llvm.ptr<[[ID3]]> to i64
 // CHECK:             %[[VAL_7:.*]] = llvm.alloca %[[VAL_6]] x !llvm.[[ID3]] : (i64) -> !llvm.ptr<[[ID3]]>
@@ -1333,21 +1333,29 @@ module attributes {gpu.container} {
 // CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> i64 {
 // CHECK:             %[[VAL_2:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>, 1>
 // CHECK:             %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<vector<3xi64>, 1>
-// CHECK-DAG:         %[[VAL_4:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-DAG:         %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_6:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_5]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_7:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK:             %[[VAL_8:.*]] = llvm.insertelement %[[VAL_6]], %[[VAL_4]]{{\[}}%[[VAL_7]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_9:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK:             %[[VAL_10:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_9]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_11:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK:             %[[VAL_12:.*]] = llvm.insertelement %[[VAL_10]], %[[VAL_8]]{{\[}}%[[VAL_11]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_13:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK:             %[[VAL_14:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_13]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_15:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK:             %[[VAL_16:.*]] = llvm.insertelement %[[VAL_14]], %[[VAL_12]]{{\[}}%[[VAL_15]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_17:.*]] = llvm.extractelement %[[VAL_16]]{{\[}}%[[VAL_1]] : i32] : vector<3xi64>
-// CHECK:             llvm.return %[[VAL_17]] : i64
+// CHECK-DAG:         %[[VAL_4:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+// CHECK-DAG:         %[[VAL_5:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:             %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_4]]{{\[}}%[[VAL_5]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+// CHECK:             %[[VAL_7:.*]] = llvm.ptrtoint %[[VAL_6]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
+// CHECK:             %[[VAL_8:.*]] = llvm.alloca %[[VAL_7]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+// CHECK-DAG:         %[[VAL_9:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-DAG:         %[[VAL_10:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_11:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_12:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_11]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_13:.*]] = llvm.getelementptr inbounds %[[VAL_8]][0, 0, 0, %[[VAL_10]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_14:.*]] = llvm.getelementptr %[[VAL_13]]{{\[}}%[[VAL_9]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+// CHECK:             llvm.store %[[VAL_12]], %[[VAL_14]] : !llvm.ptr<i64>
+// CHECK:             %[[VAL_15:.*]] = llvm.getelementptr %[[VAL_8]]{{\[}}%[[VAL_9]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+// CHECK:             %[[VAL_16:.*]] = llvm.load %[[VAL_15]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+// CHECK-DAG:         %[[VAL_17:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+// CHECK-DAG:         %[[VAL_18:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:             %[[VAL_19:.*]] = llvm.getelementptr %[[VAL_17]]{{\[}}%[[VAL_18]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+// CHECK:             %[[VAL_20:.*]] = llvm.ptrtoint %[[VAL_19]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
+// CHECK:             %[[VAL_21:.*]] = llvm.alloca %[[VAL_20]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+// CHECK:             llvm.store %[[VAL_16]], %[[VAL_21]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+// CHECK:             %[[VAL_22:.*]] = llvm.getelementptr inbounds %[[VAL_21]][0, 0, 0, %[[VAL_1]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_23:.*]] = llvm.load %[[VAL_22]] : !llvm.ptr<i64>
+// CHECK:             llvm.return %[[VAL_23]] : i64
 // CHECK-NEXT:     }
     func.func @test(%group: memref<?x!sycl_group_1_>, %i: i32) -> i64 {
       %0 = sycl.group.get_local_id(%group, %i) { ArgumentTypes = [memref<?x!sycl_group_1_>, i32], FunctionName = @"get_local_id", MangledFunctionName = @"get_local_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>, i32) -> i64
@@ -1488,24 +1496,32 @@ module attributes {gpu.container} {
   gpu.module @kernels {
 // CHECK-LABEL:   llvm.func @test_1(
 // CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr<[[GROUP1]]>) -> i64 {
-// CHECK:             %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_2:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>, 1>
-// CHECK:             %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<vector<3xi64>, 1>
-// CHECK-DAG:         %[[VAL_4:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-DAG:         %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_6:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_5]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_7:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK:             %[[VAL_8:.*]] = llvm.insertelement %[[VAL_6]], %[[VAL_4]]{{\[}}%[[VAL_7]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_9:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK:             %[[VAL_10:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_9]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_11:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK:             %[[VAL_12:.*]] = llvm.insertelement %[[VAL_10]], %[[VAL_8]]{{\[}}%[[VAL_11]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_13:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK:             %[[VAL_14:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_13]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_15:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK:             %[[VAL_16:.*]] = llvm.insertelement %[[VAL_14]], %[[VAL_12]]{{\[}}%[[VAL_15]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_17:.*]] = llvm.extractelement %[[VAL_16]]{{\[}}%[[VAL_1]] : i32] : vector<3xi64>
-// CHECK:             llvm.return %[[VAL_17]] : i64
+// CHECK:             %[[VAL_1:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>, 1>
+// CHECK:             %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<vector<3xi64>, 1>
+// CHECK-DAG:         %[[VAL_3:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+// CHECK-DAG:         %[[VAL_4:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:             %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_3]]{{\[}}%[[VAL_4]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+// CHECK:             %[[VAL_6:.*]] = llvm.ptrtoint %[[VAL_5]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
+// CHECK:             %[[VAL_7:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+// CHECK-DAG:         %[[VAL_8:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-DAG:         %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_10:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_11:.*]] = llvm.extractelement %[[VAL_2]]{{\[}}%[[VAL_10]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_9]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_12]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+// CHECK:             llvm.store %[[VAL_11]], %[[VAL_13]] : !llvm.ptr<i64>
+// CHECK:             %[[VAL_14:.*]] = llvm.getelementptr %[[VAL_7]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+// CHECK:             %[[VAL_15:.*]] = llvm.load %[[VAL_14]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+// CHECK-DAG:         %[[VAL_16:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+// CHECK-DAG:         %[[VAL_17:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:             %[[VAL_18:.*]] = llvm.getelementptr %[[VAL_16]]{{\[}}%[[VAL_17]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+// CHECK:             %[[VAL_19:.*]] = llvm.ptrtoint %[[VAL_18]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>> to i64
+// CHECK:             %[[VAL_20:.*]] = llvm.alloca %[[VAL_19]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+// CHECK:             llvm.store %[[VAL_15]], %[[VAL_20]] : !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>
+// CHECK:             %[[VAL_21:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_22:.*]] = llvm.getelementptr inbounds %[[VAL_20]][0, 0, 0, %[[VAL_21]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_23:.*]] = llvm.load %[[VAL_22]] : !llvm.ptr<i64>
+// CHECK:             llvm.return %[[VAL_23]] : i64
 // CHECK-NEXT:     }
     func.func @test_1(%group: memref<?x!sycl_group_1_>) -> i64 {
       %0 = sycl.group.get_local_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> i64
@@ -1513,46 +1529,46 @@ module attributes {gpu.container} {
     }
 
 // CHECK-LABEL:   llvm.func @test_2(
-// CHECK-SAME:                      %[[VAL_18:.*]]: !llvm.ptr<[[GROUP2]]>) -> i64 {
-// CHECK:             %[[VAL_19:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_20:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>, 1>
-// CHECK:             %[[VAL_21:.*]] = llvm.load %[[VAL_20]] : !llvm.ptr<vector<3xi64>, 1>
-// CHECK-DAG:         %[[VAL_22:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-DAG:         %[[VAL_23:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_24:.*]] = llvm.extractelement %[[VAL_21]]{{\[}}%[[VAL_23]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_25:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK:             %[[VAL_26:.*]] = llvm.insertelement %[[VAL_24]], %[[VAL_22]]{{\[}}%[[VAL_25]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_27:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK:             %[[VAL_28:.*]] = llvm.extractelement %[[VAL_21]]{{\[}}%[[VAL_27]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_29:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK:             %[[VAL_30:.*]] = llvm.insertelement %[[VAL_28]], %[[VAL_26]]{{\[}}%[[VAL_29]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_31:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK:             %[[VAL_32:.*]] = llvm.extractelement %[[VAL_21]]{{\[}}%[[VAL_31]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_33:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK:             %[[VAL_34:.*]] = llvm.insertelement %[[VAL_32]], %[[VAL_30]]{{\[}}%[[VAL_33]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_35:.*]] = llvm.extractelement %[[VAL_34]]{{\[}}%[[VAL_19]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_36:.*]] = llvm.getelementptr inbounds %[[VAL_18]][0, 2, 0, 0, 1] : (!llvm.ptr<[[GROUP2]]>) -> !llvm.ptr<i64>
-// CHECK:             %[[VAL_37:.*]] = llvm.load %[[VAL_36]] : !llvm.ptr<i64>
-// CHECK:             %[[VAL_38:.*]] = llvm.mul %[[VAL_35]], %[[VAL_37]]  : i64
-// CHECK:             %[[VAL_39:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK:             %[[VAL_40:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>, 1>
-// CHECK:             %[[VAL_41:.*]] = llvm.load %[[VAL_40]] : !llvm.ptr<vector<3xi64>, 1>
-// CHECK-DAG:         %[[VAL_42:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-DAG:         %[[VAL_43:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_44:.*]] = llvm.extractelement %[[VAL_41]]{{\[}}%[[VAL_43]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_45:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK:             %[[VAL_46:.*]] = llvm.insertelement %[[VAL_44]], %[[VAL_42]]{{\[}}%[[VAL_45]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_47:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK:             %[[VAL_48:.*]] = llvm.extractelement %[[VAL_41]]{{\[}}%[[VAL_47]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_49:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK:             %[[VAL_50:.*]] = llvm.insertelement %[[VAL_48]], %[[VAL_46]]{{\[}}%[[VAL_49]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_51:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK:             %[[VAL_52:.*]] = llvm.extractelement %[[VAL_41]]{{\[}}%[[VAL_51]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_53:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK:             %[[VAL_54:.*]] = llvm.insertelement %[[VAL_52]], %[[VAL_50]]{{\[}}%[[VAL_53]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_55:.*]] = llvm.extractelement %[[VAL_54]]{{\[}}%[[VAL_39]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_56:.*]] = llvm.add %[[VAL_38]], %[[VAL_55]]  : i64
-// CHECK:             llvm.return %[[VAL_56]] : i64
+// CHECK-SAME:                      %[[VAL_24:.*]]: !llvm.ptr<[[GROUP2]]>) -> i64 {
+// CHECK:             %[[VAL_25:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>, 1>
+// CHECK:             %[[VAL_26:.*]] = llvm.load %[[VAL_25]] : !llvm.ptr<vector<3xi64>, 1>
+// CHECK-DAG:         %[[VAL_27:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+// CHECK-DAG:         %[[VAL_28:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:             %[[VAL_29:.*]] = llvm.getelementptr %[[VAL_27]]{{\[}}%[[VAL_28]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+// CHECK:             %[[VAL_30:.*]] = llvm.ptrtoint %[[VAL_29]] : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>> to i64
+// CHECK:             %[[VAL_31:.*]] = llvm.alloca %[[VAL_30]] x !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+// CHECK-DAG:         %[[VAL_32:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-DAG:         %[[VAL_33:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_34:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_35:.*]] = llvm.extractelement %[[VAL_26]]{{\[}}%[[VAL_34]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_36:.*]] = llvm.getelementptr inbounds %[[VAL_31]][0, 0, 0, %[[VAL_33]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_37:.*]] = llvm.getelementptr %[[VAL_36]]{{\[}}%[[VAL_32]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+// CHECK:             llvm.store %[[VAL_35]], %[[VAL_37]] : !llvm.ptr<i64>
+// CHECK-DAG:         %[[VAL_38:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-DAG:         %[[VAL_39:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_40:.*]] = llvm.extractelement %[[VAL_26]]{{\[}}%[[VAL_39]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_41:.*]] = llvm.getelementptr inbounds %[[VAL_31]][0, 0, 0, %[[VAL_38]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_42:.*]] = llvm.getelementptr %[[VAL_41]]{{\[}}%[[VAL_32]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+// CHECK:             llvm.store %[[VAL_40]], %[[VAL_42]] : !llvm.ptr<i64>
+// CHECK:             %[[VAL_43:.*]] = llvm.getelementptr %[[VAL_31]]{{\[}}%[[VAL_32]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+// CHECK:             %[[VAL_44:.*]] = llvm.load %[[VAL_43]] : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+// CHECK-DAG:         %[[VAL_45:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+// CHECK-DAG:         %[[VAL_46:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:             %[[VAL_47:.*]] = llvm.getelementptr %[[VAL_45]]{{\[}}%[[VAL_46]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+// CHECK:             %[[VAL_48:.*]] = llvm.ptrtoint %[[VAL_47]] : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>> to i64
+// CHECK:             %[[VAL_49:.*]] = llvm.alloca %[[VAL_48]] x !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+// CHECK:             llvm.store %[[VAL_44]], %[[VAL_49]] : !llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>
+// CHECK:             %[[VAL_50:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_51:.*]] = llvm.getelementptr inbounds %[[VAL_49]][0, 0, 0, %[[VAL_50]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_52:.*]] = llvm.load %[[VAL_51]] : !llvm.ptr<i64>
+// CHECK:             %[[VAL_53:.*]] = llvm.getelementptr inbounds %[[VAL_24]][0, 1, 0, 0, 1] : (!llvm.ptr<struct<"class.sycl::_V1::group.2", (struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>)>>) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_54:.*]] = llvm.load %[[VAL_53]] : !llvm.ptr<i64>
+// CHECK:             %[[VAL_55:.*]] = llvm.mul %[[VAL_52]], %[[VAL_54]]  : i64
+// CHECK:             %[[VAL_56:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_57:.*]] = llvm.getelementptr inbounds %[[VAL_49]][0, 0, 0, %[[VAL_56]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_58:.*]] = llvm.load %[[VAL_57]] : !llvm.ptr<i64>
+// CHECK:             %[[VAL_59:.*]] = llvm.add %[[VAL_55]], %[[VAL_58]]  : i64
+// CHECK:             llvm.return %[[VAL_59]] : i64
 // CHECK-NEXT:     }
     func.func @test_2(%group: memref<?x!sycl_group_2_>) -> i64 {
       %0 = sycl.group.get_local_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_2_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_2_>) -> i64
@@ -1560,68 +1576,60 @@ module attributes {gpu.container} {
     }
 
 // CHECK-LABEL:   llvm.func @test_3(
-// CHECK-SAME:                      %[[VAL_57:.*]]: !llvm.ptr<[[GROUP3]]>) -> i64 {
-// CHECK:             %[[VAL_58:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_59:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>, 1>
-// CHECK:             %[[VAL_60:.*]] = llvm.load %[[VAL_59]] : !llvm.ptr<vector<3xi64>, 1>
-// CHECK-DAG:         %[[VAL_61:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-DAG:         %[[VAL_62:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_63:.*]] = llvm.extractelement %[[VAL_60]]{{\[}}%[[VAL_62]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_64:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK:             %[[VAL_65:.*]] = llvm.insertelement %[[VAL_63]], %[[VAL_61]]{{\[}}%[[VAL_64]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_66:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK:             %[[VAL_67:.*]] = llvm.extractelement %[[VAL_60]]{{\[}}%[[VAL_66]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_68:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK:             %[[VAL_69:.*]] = llvm.insertelement %[[VAL_67]], %[[VAL_65]]{{\[}}%[[VAL_68]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_70:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK:             %[[VAL_71:.*]] = llvm.extractelement %[[VAL_60]]{{\[}}%[[VAL_70]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_72:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK:             %[[VAL_73:.*]] = llvm.insertelement %[[VAL_71]], %[[VAL_69]]{{\[}}%[[VAL_72]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_74:.*]] = llvm.extractelement %[[VAL_73]]{{\[}}%[[VAL_58]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_75:.*]] = llvm.getelementptr inbounds %[[VAL_57]][0, 2, 0, 0, 1] : (!llvm.ptr<[[GROUP3]]>) -> !llvm.ptr<i64>
-// CHECK:             %[[VAL_76:.*]] = llvm.load %[[VAL_75]] : !llvm.ptr<i64>
-// CHECK:             %[[VAL_77:.*]] = llvm.mul %[[VAL_74]], %[[VAL_76]]  : i64
-// CHECK:             %[[VAL_78:.*]] = llvm.getelementptr inbounds %[[VAL_57]][0, 2, 0, 0, 2] : (!llvm.ptr<[[GROUP3]]>) -> !llvm.ptr<i64>
-// CHECK:             %[[VAL_79:.*]] = llvm.load %[[VAL_78]] : !llvm.ptr<i64>
-// CHECK:             %[[VAL_80:.*]] = llvm.mul %[[VAL_77]], %[[VAL_79]]  : i64
-// CHECK:             %[[VAL_81:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK:             %[[VAL_82:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>, 1>
-// CHECK:             %[[VAL_83:.*]] = llvm.load %[[VAL_82]] : !llvm.ptr<vector<3xi64>, 1>
-// CHECK-DAG:         %[[VAL_84:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-DAG:         %[[VAL_85:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_86:.*]] = llvm.extractelement %[[VAL_83]]{{\[}}%[[VAL_85]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_87:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK:             %[[VAL_88:.*]] = llvm.insertelement %[[VAL_86]], %[[VAL_84]]{{\[}}%[[VAL_87]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_89:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK:             %[[VAL_90:.*]] = llvm.extractelement %[[VAL_83]]{{\[}}%[[VAL_89]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_91:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK:             %[[VAL_92:.*]] = llvm.insertelement %[[VAL_90]], %[[VAL_88]]{{\[}}%[[VAL_91]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_93:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK:             %[[VAL_94:.*]] = llvm.extractelement %[[VAL_83]]{{\[}}%[[VAL_93]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_95:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK:             %[[VAL_96:.*]] = llvm.insertelement %[[VAL_94]], %[[VAL_92]]{{\[}}%[[VAL_95]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_97:.*]] = llvm.extractelement %[[VAL_96]]{{\[}}%[[VAL_81]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_98:.*]] = llvm.mul %[[VAL_97]], %[[VAL_79]]  : i64
-// CHECK:             %[[VAL_99:.*]] = llvm.add %[[VAL_80]], %[[VAL_98]]  : i64
-// CHECK:             %[[VAL_100:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK:             %[[VAL_101:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>, 1>
-// CHECK:             %[[VAL_102:.*]] = llvm.load %[[VAL_101]] : !llvm.ptr<vector<3xi64>, 1>
-// CHECK-DAG:         %[[VAL_103:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-DAG:         %[[VAL_104:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_105:.*]] = llvm.extractelement %[[VAL_102]]{{\[}}%[[VAL_104]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_106:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK:             %[[VAL_107:.*]] = llvm.insertelement %[[VAL_105]], %[[VAL_103]]{{\[}}%[[VAL_106]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_108:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK:             %[[VAL_109:.*]] = llvm.extractelement %[[VAL_102]]{{\[}}%[[VAL_108]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_110:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK:             %[[VAL_111:.*]] = llvm.insertelement %[[VAL_109]], %[[VAL_107]]{{\[}}%[[VAL_110]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_112:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK:             %[[VAL_113:.*]] = llvm.extractelement %[[VAL_102]]{{\[}}%[[VAL_112]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_114:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK:             %[[VAL_115:.*]] = llvm.insertelement %[[VAL_113]], %[[VAL_111]]{{\[}}%[[VAL_114]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_116:.*]] = llvm.extractelement %[[VAL_115]]{{\[}}%[[VAL_100]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_117:.*]] = llvm.add %[[VAL_99]], %[[VAL_116]]  : i64
-// CHECK:             llvm.return %[[VAL_117]] : i64
+// CHECK-SAME:                      %[[VAL_60:.*]]: !llvm.ptr<[[GROUP3]]>) -> i64 {
+// CHECK:             %[[VAL_61:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<vector<3xi64>, 1>
+// CHECK:             %[[VAL_62:.*]] = llvm.load %[[VAL_61]] : !llvm.ptr<vector<3xi64>, 1>
+// CHECK-DAG:         %[[VAL_63:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+// CHECK-DAG:         %[[VAL_64:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:             %[[VAL_65:.*]] = llvm.getelementptr %[[VAL_63]]{{\[}}%[[VAL_64]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+// CHECK:             %[[VAL_66:.*]] = llvm.ptrtoint %[[VAL_65]] : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>> to i64
+// CHECK:             %[[VAL_67:.*]] = llvm.alloca %[[VAL_66]] x !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+// CHECK-DAG:         %[[VAL_68:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-DAG:         %[[VAL_69:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_70:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:             %[[VAL_71:.*]] = llvm.extractelement %[[VAL_62]]{{\[}}%[[VAL_70]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_72:.*]] = llvm.getelementptr inbounds %[[VAL_67]][0, 0, 0, %[[VAL_69]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_73:.*]] = llvm.getelementptr %[[VAL_72]]{{\[}}%[[VAL_68]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+// CHECK:             llvm.store %[[VAL_71]], %[[VAL_73]] : !llvm.ptr<i64>
+// CHECK-DAG:         %[[VAL_74:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-DAG:         %[[VAL_75:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_76:.*]] = llvm.extractelement %[[VAL_62]]{{\[}}%[[VAL_75]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_77:.*]] = llvm.getelementptr inbounds %[[VAL_67]][0, 0, 0, %[[VAL_74]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_78:.*]] = llvm.getelementptr %[[VAL_77]]{{\[}}%[[VAL_68]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+// CHECK:             llvm.store %[[VAL_76]], %[[VAL_78]] : !llvm.ptr<i64>
+// CHECK-DAG:         %[[VAL_79:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-DAG:         %[[VAL_80:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_81:.*]] = llvm.extractelement %[[VAL_62]]{{\[}}%[[VAL_80]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_82:.*]] = llvm.getelementptr inbounds %[[VAL_67]][0, 0, 0, %[[VAL_79]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_83:.*]] = llvm.getelementptr %[[VAL_82]]{{\[}}%[[VAL_68]]] : (!llvm.ptr<i64>, i64) -> !llvm.ptr<i64>
+// CHECK:             llvm.store %[[VAL_81]], %[[VAL_83]] : !llvm.ptr<i64>
+// CHECK:             %[[VAL_84:.*]] = llvm.getelementptr %[[VAL_67]]{{\[}}%[[VAL_68]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+// CHECK:             %[[VAL_85:.*]] = llvm.load %[[VAL_84]] : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+// CHECK-DAG:         %[[VAL_86:.*]] = llvm.mlir.null : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+// CHECK-DAG:         %[[VAL_87:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:             %[[VAL_88:.*]] = llvm.getelementptr %[[VAL_86]]{{\[}}%[[VAL_87]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+// CHECK:             %[[VAL_89:.*]] = llvm.ptrtoint %[[VAL_88]] : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>> to i64
+// CHECK:             %[[VAL_90:.*]] = llvm.alloca %[[VAL_89]] x !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+// CHECK:             llvm.store %[[VAL_85]], %[[VAL_90]] : !llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>
+// CHECK:             %[[VAL_91:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_92:.*]] = llvm.getelementptr inbounds %[[VAL_90]][0, 0, 0, %[[VAL_91]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_93:.*]] = llvm.load %[[VAL_92]] : !llvm.ptr<i64>
+// CHECK:             %[[VAL_94:.*]] = llvm.getelementptr inbounds %[[VAL_60]][0, 1, 0, 0, 1] : (!llvm.ptr<struct<"class.sycl::_V1::group.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>>) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_95:.*]] = llvm.load %[[VAL_94]] : !llvm.ptr<i64>
+// CHECK:             %[[VAL_96:.*]] = llvm.mul %[[VAL_93]], %[[VAL_95]]  : i64
+// CHECK:             %[[VAL_97:.*]] = llvm.getelementptr inbounds %[[VAL_60]][0, 1, 0, 0, 2] : (!llvm.ptr<struct<"class.sycl::_V1::group.3", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>>) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_98:.*]] = llvm.load %[[VAL_97]] : !llvm.ptr<i64>
+// CHECK:             %[[VAL_99:.*]] = llvm.mul %[[VAL_96]], %[[VAL_98]]  : i64
+// CHECK:             %[[VAL_100:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_101:.*]] = llvm.getelementptr inbounds %[[VAL_90]][0, 0, 0, %[[VAL_100]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_102:.*]] = llvm.load %[[VAL_101]] : !llvm.ptr<i64>
+// CHECK:             %[[VAL_103:.*]] = llvm.mul %[[VAL_102]], %[[VAL_98]]  : i64
+// CHECK:             %[[VAL_104:.*]] = llvm.add %[[VAL_99]], %[[VAL_103]]  : i64
+// CHECK:             %[[VAL_105:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:             %[[VAL_106:.*]] = llvm.getelementptr inbounds %[[VAL_90]][0, 0, 0, %[[VAL_105]]] : (!llvm.ptr<struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>>, i32) -> !llvm.ptr<i64>
+// CHECK:             %[[VAL_107:.*]] = llvm.load %[[VAL_106]] : !llvm.ptr<i64>
+// CHECK:             %[[VAL_108:.*]] = llvm.add %[[VAL_104]], %[[VAL_107]]  : i64
+// CHECK:             llvm.return %[[VAL_108]] : i64
 // CHECK-NEXT:     }
     func.func @test_3(%group: memref<?x!sycl_group_3_>) -> i64 {
       %0 = sycl.group.get_local_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -1315,23 +1315,31 @@ module attributes {gpu.container} {
 // CHECK-LABEL:      llvm.func @test(
 // CHECK-SAME:        %[[VAL_0:.*]]: !llvm.ptr
 // CHECK-SAME:        %[[VAL_1:.*]]: i32) -> i64 {
-// CHECK-NEXT:        %[[VAL_2:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<1>
-// CHECK-NEXT:        %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<1> -> vector<3xi64>
-// CHECK-DAG:         %[[VAL_4:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-DAG:         %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_6:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_5]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_7:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:        %[[VAL_8:.*]] = llvm.insertelement %[[VAL_6]], %[[VAL_4]]{{\[}}%[[VAL_7]] : i64] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_9:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:        %[[VAL_10:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_9]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_11:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:        %[[VAL_12:.*]] = llvm.insertelement %[[VAL_10]], %[[VAL_8]]{{\[}}%[[VAL_11]] : i64] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_13:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:        %[[VAL_14:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_13]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_15:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:        %[[VAL_16:.*]] = llvm.insertelement %[[VAL_14]], %[[VAL_12]]{{\[}}%[[VAL_15]] : i64] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_17:.*]] = llvm.extractelement %[[VAL_16]]{{\[}}%[[VAL_1]] : i32] : vector<3xi64>
-// CHECK-NEXT:        llvm.return %[[VAL_17]] : i64
+// CHECK:             %[[VAL_2:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<1>
+// CHECK:             %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<1> -> vector<3xi64>
+// CHECK-DAG:         %[[VAL_4:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-DAG:         %[[VAL_5:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:             %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_4]]{{\[}}%[[VAL_5]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+// CHECK:             %[[VAL_7:.*]] = llvm.ptrtoint %[[VAL_6]] : !llvm.ptr to i64
+// CHECK:             %[[VAL_8:.*]] = llvm.alloca %[[VAL_7]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr
+// CHECK-DAG:         %[[VAL_9:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-DAG:         %[[VAL_10:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_11:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_12:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_11]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_13:.*]] = llvm.getelementptr inbounds %[[VAL_8]][0, 0, 0, %[[VAL_10]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK:             %[[VAL_14:.*]] = llvm.getelementptr %[[VAL_13]]{{\[}}%[[VAL_9]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
+// CHECK:             llvm.store %[[VAL_12]], %[[VAL_14]] : i64, !llvm.ptr
+// CHECK:             %[[VAL_15:.*]] = llvm.getelementptr %[[VAL_8]]{{\[}}%[[VAL_9]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+// CHECK:             %[[VAL_16:.*]] = llvm.load %[[VAL_15]] : !llvm.ptr -> !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+// CHECK-DAG:         %[[VAL_17:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-DAG:         %[[VAL_18:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:             %[[VAL_19:.*]] = llvm.getelementptr %[[VAL_17]]{{\[}}%[[VAL_18]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+// CHECK:             %[[VAL_20:.*]] = llvm.ptrtoint %[[VAL_19]] : !llvm.ptr to i64
+// CHECK:             %[[VAL_21:.*]] = llvm.alloca %[[VAL_20]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr
+// CHECK:             llvm.store %[[VAL_16]], %[[VAL_21]] : !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, !llvm.ptr
+// CHECK:             %[[VAL_22:.*]] = llvm.getelementptr inbounds %[[VAL_21]][0, 0, 0, %[[VAL_1]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+// CHECK:             %[[VAL_23:.*]] = llvm.load %[[VAL_22]] : !llvm.ptr -> i64
+// CHECK:             llvm.return %[[VAL_23]] : i64
 // CHECK-NEXT:      }
     func.func @test(%group: memref<?x!sycl_group_1_>, %i: i32) -> i64 {
       %0 = sycl.group.get_local_id(%group, %i) { ArgumentTypes = [memref<?x!sycl_group_1_>, i32], FunctionName = @"get_local_id", MangledFunctionName = @"get_local_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>, i32) -> i64
@@ -1472,138 +1480,138 @@ module attributes {gpu.container} {
   gpu.module @kernels {
 // CHECK-LABEL:   llvm.func @test_1(
 // CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr) -> i64 {
-// CHECK:             %[[VAL_1:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_2:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<1>
-// CHECK:             %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<1> -> vector<3xi64>
-// CHECK-DAG:         %[[VAL_4:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-DAG:         %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_6:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_5]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_7:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK:             %[[VAL_8:.*]] = llvm.insertelement %[[VAL_6]], %[[VAL_4]]{{\[}}%[[VAL_7]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_9:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK:             %[[VAL_10:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_9]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_11:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK:             %[[VAL_12:.*]] = llvm.insertelement %[[VAL_10]], %[[VAL_8]]{{\[}}%[[VAL_11]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_13:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK:             %[[VAL_14:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_13]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_15:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK:             %[[VAL_16:.*]] = llvm.insertelement %[[VAL_14]], %[[VAL_12]]{{\[}}%[[VAL_15]] : i64] : vector<3xi64>
-// CHECK:             %[[VAL_17:.*]] = llvm.extractelement %[[VAL_16]]{{\[}}%[[VAL_1]] : i32] : vector<3xi64>
-// CHECK:             llvm.return %[[VAL_17]] : i64
+// CHECK:             %[[VAL_1:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<1>
+// CHECK:             %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<1> -> vector<3xi64>
+// CHECK-DAG:         %[[VAL_3:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-DAG:         %[[VAL_4:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:             %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_3]]{{\[}}%[[VAL_4]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+// CHECK:             %[[VAL_6:.*]] = llvm.ptrtoint %[[VAL_5]] : !llvm.ptr to i64
+// CHECK:             %[[VAL_7:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr
+// CHECK-DAG:         %[[VAL_8:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-DAG:         %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_10:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_11:.*]] = llvm.extractelement %[[VAL_2]]{{\[}}%[[VAL_10]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_9]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK:             %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_12]]{{\[}}%[[VAL_8]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
+// CHECK:             llvm.store %[[VAL_11]], %[[VAL_13]] : i64, !llvm.ptr
+// CHECK:             %[[VAL_14:.*]] = llvm.getelementptr %[[VAL_7]]{{\[}}%[[VAL_8]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+// CHECK:             %[[VAL_15:.*]] = llvm.load %[[VAL_14]] : !llvm.ptr -> !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+// CHECK-DAG:         %[[VAL_16:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-DAG:         %[[VAL_17:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:             %[[VAL_18:.*]] = llvm.getelementptr %[[VAL_16]]{{\[}}%[[VAL_17]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+// CHECK:             %[[VAL_19:.*]] = llvm.ptrtoint %[[VAL_18]] : !llvm.ptr to i64
+// CHECK:             %[[VAL_20:.*]] = llvm.alloca %[[VAL_19]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr
+// CHECK:             llvm.store %[[VAL_15]], %[[VAL_20]] : !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, !llvm.ptr
+// CHECK:             %[[VAL_21:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_22:.*]] = llvm.getelementptr inbounds %[[VAL_20]][0, 0, 0, %[[VAL_21]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+// CHECK:             %[[VAL_23:.*]] = llvm.load %[[VAL_22]] : !llvm.ptr -> i64
+// CHECK:             llvm.return %[[VAL_23]] : i64
 // CHECK-NEXT:     }
     func.func @test_1(%group: memref<?x!sycl_group_1_>) -> i64 {
       %0 = sycl.group.get_local_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> i64
       return %0 : i64
     }
 
-// CHECK-NEXT:      llvm.func @test_2(%[[VAL_18:.*]]: !llvm.ptr) -> i64 {
-// CHECK-NEXT:        %[[VAL_19:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:        %[[VAL_20:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<1>
-// CHECK-NEXT:        %[[VAL_21:.*]] = llvm.load %[[VAL_20]] : !llvm.ptr<1> -> vector<3xi64>
-// CHECK-DAG:         %[[VAL_22:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-DAG:         %[[VAL_23:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_24:.*]] = llvm.extractelement %[[VAL_21]]{{\[}}%[[VAL_23]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_25:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:        %[[VAL_26:.*]] = llvm.insertelement %[[VAL_24]], %[[VAL_22]]{{\[}}%[[VAL_25]] : i64] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_27:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:        %[[VAL_28:.*]] = llvm.extractelement %[[VAL_21]]{{\[}}%[[VAL_27]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_29:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:        %[[VAL_30:.*]] = llvm.insertelement %[[VAL_28]], %[[VAL_26]]{{\[}}%[[VAL_29]] : i64] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_31:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:        %[[VAL_32:.*]] = llvm.extractelement %[[VAL_21]]{{\[}}%[[VAL_31]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_33:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:        %[[VAL_34:.*]] = llvm.insertelement %[[VAL_32]], %[[VAL_30]]{{\[}}%[[VAL_33]] : i64] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_35:.*]] = llvm.extractelement %[[VAL_34]]{{\[}}%[[VAL_19]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_36:.*]] = llvm.getelementptr inbounds %[[VAL_18]][0, 2, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::group.2", {{.*}}>
-// CHECK-NEXT:        %[[VAL_37:.*]] = llvm.load %[[VAL_36]] : !llvm.ptr -> i64
-// CHECK-NEXT:        %[[VAL_38:.*]] = llvm.mul %[[VAL_35]], %[[VAL_37]]  : i64
-// CHECK-NEXT:        %[[VAL_39:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:        %[[VAL_40:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<1>
-// CHECK-NEXT:        %[[VAL_41:.*]] = llvm.load %[[VAL_40]] : !llvm.ptr<1> -> vector<3xi64>
-// CHECK-NEXT:        %[[VAL_42:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_43:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:        %[[VAL_44:.*]] = llvm.extractelement %[[VAL_41]]{{\[}}%[[VAL_43]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_45:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:        %[[VAL_46:.*]] = llvm.insertelement %[[VAL_44]], %[[VAL_42]]{{\[}}%[[VAL_45]] : i64] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_47:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:        %[[VAL_48:.*]] = llvm.extractelement %[[VAL_41]]{{\[}}%[[VAL_47]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_49:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:        %[[VAL_50:.*]] = llvm.insertelement %[[VAL_48]], %[[VAL_46]]{{\[}}%[[VAL_49]] : i64] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_51:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:        %[[VAL_52:.*]] = llvm.extractelement %[[VAL_41]]{{\[}}%[[VAL_51]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_53:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:        %[[VAL_54:.*]] = llvm.insertelement %[[VAL_52]], %[[VAL_50]]{{\[}}%[[VAL_53]] : i64] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_55:.*]] = llvm.extractelement %[[VAL_54]]{{\[}}%[[VAL_39]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_56:.*]] = llvm.add %[[VAL_38]], %[[VAL_55]]  : i64
-// CHECK-NEXT:        llvm.return %[[VAL_56]] : i64
+// CHECK-NEXT:      llvm.func @test_2(%[[VAL_24:.*]]: !llvm.ptr) -> i64 {
+// CHECK:             %[[VAL_25:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<1>
+// CHECK:             %[[VAL_26:.*]] = llvm.load %[[VAL_25]] : !llvm.ptr<1> -> vector<3xi64>
+// CHECK-DAG:         %[[VAL_27:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-DAG:         %[[VAL_28:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:             %[[VAL_29:.*]] = llvm.getelementptr %[[VAL_27]]{{\[}}%[[VAL_28]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK:             %[[VAL_30:.*]] = llvm.ptrtoint %[[VAL_29]] : !llvm.ptr to i64
+// CHECK:             %[[VAL_31:.*]] = llvm.alloca %[[VAL_30]] x !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr
+// CHECK-DAG:         %[[VAL_32:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-DAG:         %[[VAL_33:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_34:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_35:.*]] = llvm.extractelement %[[VAL_26]]{{\[}}%[[VAL_34]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_36:.*]] = llvm.getelementptr inbounds %[[VAL_31]][0, 0, 0, %[[VAL_33]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK:             %[[VAL_37:.*]] = llvm.getelementptr %[[VAL_36]]{{\[}}%[[VAL_32]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
+// CHECK:             llvm.store %[[VAL_35]], %[[VAL_37]] : i64, !llvm.ptr
+// CHECK-DAG:         %[[VAL_38:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-DAG:         %[[VAL_39:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_40:.*]] = llvm.extractelement %[[VAL_26]]{{\[}}%[[VAL_39]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_41:.*]] = llvm.getelementptr inbounds %[[VAL_31]][0, 0, 0, %[[VAL_38]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK:             %[[VAL_42:.*]] = llvm.getelementptr %[[VAL_41]]{{\[}}%[[VAL_32]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
+// CHECK:             llvm.store %[[VAL_40]], %[[VAL_42]] : i64, !llvm.ptr
+// CHECK:             %[[VAL_43:.*]] = llvm.getelementptr %[[VAL_31]]{{\[}}%[[VAL_32]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK:             %[[VAL_44:.*]] = llvm.load %[[VAL_43]] : !llvm.ptr -> !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK-DAG:         %[[VAL_45:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-DAG:         %[[VAL_46:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:             %[[VAL_47:.*]] = llvm.getelementptr %[[VAL_45]]{{\[}}%[[VAL_46]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK:             %[[VAL_48:.*]] = llvm.ptrtoint %[[VAL_47]] : !llvm.ptr to i64
+// CHECK:             %[[VAL_49:.*]] = llvm.alloca %[[VAL_48]] x !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr
+// CHECK:             llvm.store %[[VAL_44]], %[[VAL_49]] : !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, !llvm.ptr
+// CHECK:             %[[VAL_50:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_51:.*]] = llvm.getelementptr inbounds %[[VAL_49]][0, 0, 0, %[[VAL_50]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK:             %[[VAL_52:.*]] = llvm.load %[[VAL_51]] : !llvm.ptr -> i64
+// CHECK:             %[[VAL_53:.*]] = llvm.getelementptr inbounds %[[VAL_24]][0, 1, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
+// CHECK:             %[[VAL_54:.*]] = llvm.load %[[VAL_53]] : !llvm.ptr -> i64
+// CHECK:             %[[VAL_55:.*]] = llvm.mul %[[VAL_52]], %[[VAL_54]]  : i64
+// CHECK:             %[[VAL_56:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_57:.*]] = llvm.getelementptr inbounds %[[VAL_49]][0, 0, 0, %[[VAL_56]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK:             %[[VAL_58:.*]] = llvm.load %[[VAL_57]] : !llvm.ptr -> i64
+// CHECK:             %[[VAL_59:.*]] = llvm.add %[[VAL_55]], %[[VAL_58]]  : i64
+// CHECK:             llvm.return %[[VAL_59]] : i64
 // CHECK-NEXT:      }
     func.func @test_2(%group: memref<?x!sycl_group_2_>) -> i64 {
       %0 = sycl.group.get_local_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_2_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_2_>) -> i64
       return %0 : i64
     }
 
-// CHECK-NEXT:      llvm.func @test_3(%[[VAL_57:.*]]: !llvm.ptr) -> i64 {
-// CHECK-NEXT:        %[[VAL_58:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:        %[[VAL_59:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<1>
-// CHECK-NEXT:        %[[VAL_60:.*]] = llvm.load %[[VAL_59]] : !llvm.ptr<1> -> vector<3xi64>
-// CHECK-DAG:         %[[VAL_61:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-DAG:         %[[VAL_62:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK:             %[[VAL_63:.*]] = llvm.extractelement %[[VAL_60]]{{\[}}%[[VAL_62]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_64:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:        %[[VAL_65:.*]] = llvm.insertelement %[[VAL_63]], %[[VAL_61]]{{\[}}%[[VAL_64]] : i64] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_66:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:        %[[VAL_67:.*]] = llvm.extractelement %[[VAL_60]]{{\[}}%[[VAL_66]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_68:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:        %[[VAL_69:.*]] = llvm.insertelement %[[VAL_67]], %[[VAL_65]]{{\[}}%[[VAL_68]] : i64] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_70:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:        %[[VAL_71:.*]] = llvm.extractelement %[[VAL_60]]{{\[}}%[[VAL_70]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_72:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:        %[[VAL_73:.*]] = llvm.insertelement %[[VAL_71]], %[[VAL_69]]{{\[}}%[[VAL_72]] : i64] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_74:.*]] = llvm.extractelement %[[VAL_73]]{{\[}}%[[VAL_58]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_75:.*]] = llvm.getelementptr inbounds %[[VAL_57]][0, 2, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::group.3", {{.*}}>
-// CHECK-NEXT:        %[[VAL_76:.*]] = llvm.load %[[VAL_75]] : !llvm.ptr -> i64
-// CHECK-NEXT:        %[[VAL_77:.*]] = llvm.mul %[[VAL_74]], %[[VAL_76]]  : i64
-// CHECK-NEXT:        %[[VAL_78:.*]] = llvm.getelementptr inbounds %[[VAL_57]][0, 2, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::group.3", {{.*}}>
-// CHECK-NEXT:        %[[VAL_79:.*]] = llvm.load %[[VAL_78]] : !llvm.ptr -> i64
-// CHECK-NEXT:        %[[VAL_80:.*]] = llvm.mul %[[VAL_77]], %[[VAL_79]]  : i64
-// CHECK-NEXT:        %[[VAL_81:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:        %[[VAL_82:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<1>
-// CHECK-NEXT:        %[[VAL_83:.*]] = llvm.load %[[VAL_82]] : !llvm.ptr<1> -> vector<3xi64>
-// CHECK-NEXT:        %[[VAL_84:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_85:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:        %[[VAL_86:.*]] = llvm.extractelement %[[VAL_83]]{{\[}}%[[VAL_85]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_87:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:        %[[VAL_88:.*]] = llvm.insertelement %[[VAL_86]], %[[VAL_84]]{{\[}}%[[VAL_87]] : i64] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_89:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:        %[[VAL_90:.*]] = llvm.extractelement %[[VAL_83]]{{\[}}%[[VAL_89]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_91:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:        %[[VAL_92:.*]] = llvm.insertelement %[[VAL_90]], %[[VAL_88]]{{\[}}%[[VAL_91]] : i64] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_93:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:        %[[VAL_94:.*]] = llvm.extractelement %[[VAL_83]]{{\[}}%[[VAL_93]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_95:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:        %[[VAL_96:.*]] = llvm.insertelement %[[VAL_94]], %[[VAL_92]]{{\[}}%[[VAL_95]] : i64] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_97:.*]] = llvm.extractelement %[[VAL_96]]{{\[}}%[[VAL_81]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_98:.*]] = llvm.mul %[[VAL_97]], %[[VAL_79]]  : i64
-// CHECK-NEXT:        %[[VAL_99:.*]] = llvm.add %[[VAL_80]], %[[VAL_98]]  : i64
-// CHECK-NEXT:        %[[VAL_100:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:        %[[VAL_101:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<1>
-// CHECK-NEXT:        %[[VAL_102:.*]] = llvm.load %[[VAL_101]] : !llvm.ptr<1> -> vector<3xi64>
-// CHECK-NEXT:        %[[VAL_103:.*]] = llvm.mlir.constant(dense<0> : vector<3xindex>) : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_104:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:        %[[VAL_105:.*]] = llvm.extractelement %[[VAL_102]]{{\[}}%[[VAL_104]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_106:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:        %[[VAL_107:.*]] = llvm.insertelement %[[VAL_105]], %[[VAL_103]]{{\[}}%[[VAL_106]] : i64] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_108:.*]] = llvm.mlir.constant(1 : i32) : i32
-// CHECK-NEXT:        %[[VAL_109:.*]] = llvm.extractelement %[[VAL_102]]{{\[}}%[[VAL_108]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_110:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:        %[[VAL_111:.*]] = llvm.insertelement %[[VAL_109]], %[[VAL_107]]{{\[}}%[[VAL_110]] : i64] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_112:.*]] = llvm.mlir.constant(2 : i32) : i32
-// CHECK-NEXT:        %[[VAL_113:.*]] = llvm.extractelement %[[VAL_102]]{{\[}}%[[VAL_112]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_114:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK-NEXT:        %[[VAL_115:.*]] = llvm.insertelement %[[VAL_113]], %[[VAL_111]]{{\[}}%[[VAL_114]] : i64] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_116:.*]] = llvm.extractelement %[[VAL_115]]{{\[}}%[[VAL_100]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_117:.*]] = llvm.add %[[VAL_99]], %[[VAL_116]]  : i64
-// CHECK-NEXT:        llvm.return %[[VAL_117]] : i64
+// CHECK-NEXT:      llvm.func @test_3(%[[VAL_60:.*]]: !llvm.ptr) -> i64 {
+// CHECK:             %[[VAL_61:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<1>
+// CHECK:             %[[VAL_62:.*]] = llvm.load %[[VAL_61]] : !llvm.ptr<1> -> vector<3xi64>
+// CHECK-DAG:         %[[VAL_63:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-DAG:         %[[VAL_64:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:             %[[VAL_65:.*]] = llvm.getelementptr %[[VAL_63]]{{\[}}%[[VAL_64]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK:             %[[VAL_66:.*]] = llvm.ptrtoint %[[VAL_65]] : !llvm.ptr to i64
+// CHECK:             %[[VAL_67:.*]] = llvm.alloca %[[VAL_66]] x !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr
+// CHECK-DAG:         %[[VAL_68:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-DAG:         %[[VAL_69:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-DAG:         %[[VAL_70:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:             %[[VAL_71:.*]] = llvm.extractelement %[[VAL_62]]{{\[}}%[[VAL_70]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_72:.*]] = llvm.getelementptr inbounds %[[VAL_67]][0, 0, 0, %[[VAL_69]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK:             %[[VAL_73:.*]] = llvm.getelementptr %[[VAL_72]]{{\[}}%[[VAL_68]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
+// CHECK:             llvm.store %[[VAL_71]], %[[VAL_73]] : i64, !llvm.ptr
+// CHECK-DAG:         %[[VAL_74:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-DAG:         %[[VAL_75:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_76:.*]] = llvm.extractelement %[[VAL_62]]{{\[}}%[[VAL_75]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_77:.*]] = llvm.getelementptr inbounds %[[VAL_67]][0, 0, 0, %[[VAL_74]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK:             %[[VAL_78:.*]] = llvm.getelementptr %[[VAL_77]]{{\[}}%[[VAL_68]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
+// CHECK:             llvm.store %[[VAL_76]], %[[VAL_78]] : i64, !llvm.ptr
+// CHECK-DAG:         %[[VAL_79:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-DAG:         %[[VAL_80:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_81:.*]] = llvm.extractelement %[[VAL_62]]{{\[}}%[[VAL_80]] : i32] : vector<3xi64>
+// CHECK:             %[[VAL_82:.*]] = llvm.getelementptr inbounds %[[VAL_67]][0, 0, 0, %[[VAL_79]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK:             %[[VAL_83:.*]] = llvm.getelementptr %[[VAL_82]]{{\[}}%[[VAL_68]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
+// CHECK:             llvm.store %[[VAL_81]], %[[VAL_83]] : i64, !llvm.ptr
+// CHECK:             %[[VAL_84:.*]] = llvm.getelementptr %[[VAL_67]]{{\[}}%[[VAL_68]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK:             %[[VAL_85:.*]] = llvm.load %[[VAL_84]] : !llvm.ptr -> !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-DAG:         %[[VAL_86:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-DAG:         %[[VAL_87:.*]] = llvm.mlir.constant(1 : index) : i64
+// CHECK:             %[[VAL_88:.*]] = llvm.getelementptr %[[VAL_86]]{{\[}}%[[VAL_87]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK:             %[[VAL_89:.*]] = llvm.ptrtoint %[[VAL_88]] : !llvm.ptr to i64
+// CHECK:             %[[VAL_90:.*]] = llvm.alloca %[[VAL_89]] x !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr
+// CHECK:             llvm.store %[[VAL_85]], %[[VAL_90]] : !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, !llvm.ptr
+// CHECK:             %[[VAL_91:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK:             %[[VAL_92:.*]] = llvm.getelementptr inbounds %[[VAL_90]][0, 0, 0, %[[VAL_91]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK:             %[[VAL_93:.*]] = llvm.load %[[VAL_92]] : !llvm.ptr -> i64
+// CHECK:             %[[VAL_94:.*]] = llvm.getelementptr inbounds %[[VAL_60]][0, 1, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
+// CHECK:             %[[VAL_95:.*]] = llvm.load %[[VAL_94]] : !llvm.ptr -> i64
+// CHECK:             %[[VAL_96:.*]] = llvm.mul %[[VAL_93]], %[[VAL_95]]  : i64
+// CHECK:             %[[VAL_97:.*]] = llvm.getelementptr inbounds %[[VAL_60]][0, 1, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
+// CHECK:             %[[VAL_98:.*]] = llvm.load %[[VAL_97]] : !llvm.ptr -> i64
+// CHECK:             %[[VAL_99:.*]] = llvm.mul %[[VAL_96]], %[[VAL_98]]  : i64
+// CHECK:             %[[VAL_100:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:             %[[VAL_101:.*]] = llvm.getelementptr inbounds %[[VAL_90]][0, 0, 0, %[[VAL_100]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK:             %[[VAL_102:.*]] = llvm.load %[[VAL_101]] : !llvm.ptr -> i64
+// CHECK:             %[[VAL_103:.*]] = llvm.mul %[[VAL_102]], %[[VAL_98]]  : i64
+// CHECK:             %[[VAL_104:.*]] = llvm.add %[[VAL_99]], %[[VAL_103]]  : i64
+// CHECK:             %[[VAL_105:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK:             %[[VAL_106:.*]] = llvm.getelementptr inbounds %[[VAL_90]][0, 0, 0, %[[VAL_105]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK:             %[[VAL_107:.*]] = llvm.load %[[VAL_106]] : !llvm.ptr -> i64
+// CHECK:             %[[VAL_108:.*]] = llvm.add %[[VAL_104]], %[[VAL_107]]  : i64
+// CHECK:             llvm.return %[[VAL_108]] : i64
 // CHECK-NEXT:      }
     func.func @test_3(%group: memref<?x!sycl_group_3_>) -> i64 {
       %0 = sycl.group.get_local_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64


### PR DESCRIPTION
Apply OpenCL-SYCL mirroring in SYCL to LLVM conversion patterns.

Use local range instead of group range to calculate local linear ID.