### PR TITLE
[SYCL-MLIR] Lower SYCLMethodOps using conversion patterns

### DIFF
--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -223,7 +223,7 @@ static llvm::cl::opt<std::string> McpuOpt("mcpu", llvm::cl::init(""),
                                           llvm::cl::cat(ToolOptions));
 
 static llvm::cl::opt<bool> InlineSYCLMethodOps(
-    "inline-sycl-method-ops", llvm::cl::init(true),
+    "inline-sycl-method-ops", llvm::cl::init(false),
     llvm::cl::desc("Whether to inline SYCLMethodOp operations"),
     llvm::cl::cat(ToolOptions));
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -1,8 +1,5 @@
 // RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
 // RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - -Xcgeist -no-mangled-function-name | FileCheck %s --check-prefix=CHECK-MLIR-NO-MANGLED-FUNCTION-NAME
-// COM: These two should obtain the same results.
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - -Xcgeist -no-mangled-function-name | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 
@@ -25,19 +22,6 @@
 // CHECK-MLIR-DAG: ![[ITEM1:.*]] = !sycl.item<[1, true], (![[ITEM_BASE1]])>
 // CHECK-MLIR-DAG: ![[ITEM2:.*]] = !sycl.item<[2, true], (![[ITEM_BASE2]])>
 
-// CHECK-LLVM-DAG: %"class.sycl::_V1::detail::array.1" = type { [1 x i64] }
-// CHECK-LLVM-DAG: %"class.sycl::_V1::detail::array.2" = type { [2 x i64] }
-// CHECK-LLVM-DAG: %"class.sycl::_V1::id.1" = type { %"class.sycl::_V1::detail::array.1" }
-// CHECK-LLVM-DAG: %"class.sycl::_V1::id.2" = type { %"class.sycl::_V1::detail::array.2" }
-// CHECK-LLVM-DAG: %"class.sycl::_V1::range.1" = type { %"class.sycl::_V1::detail::array.1" }
-// CHECK-LLVM-DAG: %"class.sycl::_V1::range.2" = type { %"class.sycl::_V1::detail::array.2" }
-// CHECK-LLVM-DAG: %"class.sycl::_V1::detail::AccessorImplDevice.1" = type { %"class.sycl::_V1::id.1", %"class.sycl::_V1::range.1", %"class.sycl::_V1::range.1" }
-// CHECK-LLVM-DAG: %"class.sycl::_V1::detail::AccessorImplDevice.2" = type { %"class.sycl::_V1::id.2", %"class.sycl::_V1::range.2", %"class.sycl::_V1::range.2" }
-// CHECK-LLVM-DAG: %"class.sycl::_V1::accessor.1" = type { %"class.sycl::_V1::detail::AccessorImplDevice.1", { i32 addrspace(1)* } }
-// CHECK-LLVM-DAG: %"class.sycl::_V1::accessor.2" = type { %"class.sycl::_V1::detail::AccessorImplDevice.2", { i32 addrspace(1)* } }
-// CHECK-LLVM-DAG: %"class.sycl::_V1::accessor.1.1" = type { %"class.sycl::_V1::detail::AccessorImplDevice.1", { { i32 } addrspace(1)* } }
-// CHECK-LLVM-DAG: %"class.sycl::_V1::detail::accessor_common.AccessorSubscript.1" = type { %"class.sycl::_V1::id.2", %"class.sycl::_V1::accessor.2" }
-
 template <typename T> SYCL_EXTERNAL void keep(T);
 
 // COM: Commenting out the checks below, this is the code that should be
@@ -49,10 +33,6 @@ template <typename T> SYCL_EXTERNAL void keep(T);
 // COM-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef})
 // COM-MLIR: %{{.*}} = sycl.accessor.get_pointer(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>], FunctionName = @get_pointer, MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE11get_pointerILS4_2014EvEENS0_9IiLNS2_13address_spaceE1ELNS2_9decoratedE2EEEv, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> memref<?xi32, 1>
 
-// COM-LLVM-LABEL: define spir_func void @_Z20accessor_get_pointerN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
-// COM-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0) #[[FUNCATTRS:[0-9]+]] {
-// COM-LLVM:  %{{.*}} = call spir_func i32 addrspace(1)* @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE11get_pointerILS4_2014EvEENS0_9IiLNS2_13address_spaceE1ELNS2_9decoratedE2EEEv(%"class.sycl::_V1::accessor.2" addrspace(4)* %{{.*}})
-
 SYCL_EXTERNAL void accessor_get_pointer(sycl::accessor<sycl::cl_int, 2> acc) {
   keep(acc.get_pointer());
 }
@@ -61,10 +41,6 @@ SYCL_EXTERNAL void accessor_get_pointer(sycl::accessor<sycl::cl_int, 2> acc) {
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.accessor.get_range(%arg0) {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>], FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE9get_rangeILi2EvEENS0_5rangeILi2EEEv, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> !sycl_range_2_
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z18accessor_get_rangeN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
-// CHECK-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0) #[[FUNCATTRS:[0-9]+]] {
-// CHECK-LLVM:  %{{.*}} = call spir_func %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE9get_rangeILi2EvEENS0_5rangeILi2EEEv(%"class.sycl::_V1::accessor.2" addrspace(4)* %{{.*}})
-
 SYCL_EXTERNAL void accessor_get_range(sycl::accessor<sycl::cl_int, 2> acc) {
   keep(acc.get_range());
 }
@@ -72,10 +48,6 @@ SYCL_EXTERNAL void accessor_get_range(sycl::accessor<sycl::cl_int, 2> acc) {
 // CHECK-MLIR-LABEL: func.func @_Z13accessor_sizeN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.accessor.size(%arg0) {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>], FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE4sizeEv, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> i64
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z13accessor_sizeN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
-// CHECK-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0) #[[FUNCATTRS:[0-9]+]] {
-// CHECK-LLVM:  %{{.*}} = call spir_func i64 @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE4sizeEv(%"class.sycl::_V1::accessor.2" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void accessor_size(sycl::accessor<sycl::cl_int, 2> acc) {
   keep(acc.size());
@@ -86,10 +58,6 @@ SYCL_EXTERNAL void accessor_size(sycl::accessor<sycl::cl_int, 2> acc) {
 // CHECK_MLIR_SAME:      %{{.*}}: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl_id_2_>], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_0N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEENS0_2idILi2EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0, %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %1) #[[FUNCATTRS:[0-9]+]]
-// CHECK-LLVM:  %{{.*}} = call spir_func i32 addrspace(4)* @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE(%"class.sycl::_V1::accessor.2" addrspace(4)* %{{.*}}, %"class.sycl::_V1::id.2"* %{{.*}})
-
 SYCL_EXTERNAL void accessor_subscript_operator_0(sycl::accessor<sycl::cl_int, 2> acc, sycl::id<2> index) {
   keep(acc[index]);
 }
@@ -97,10 +65,6 @@ SYCL_EXTERNAL void accessor_subscript_operator_0(sycl::accessor<sycl::cl_int, 2>
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_1N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK_MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb>, %{{.*}}: i64)
 // CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>, i64], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEEDam, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>, i64) -> ![[ACC_SUBSCRIPT]]
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_1N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
-// CHECK-LLVM:           %"class.sycl::_V1::accessor.2"* noundef byval(%"class.sycl::_V1::accessor.2") align 8 %0, i64 noundef %1) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::detail::accessor_common.AccessorSubscript.1" @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEEDam(%"class.sycl::_V1::accessor.2" addrspace(4)* %{{.*}}, i64 %1)
 
 SYCL_EXTERNAL void accessor_subscript_operator_1(sycl::accessor<sycl::cl_int, 2> acc, size_t index) {
   keep(acc[index]);
@@ -111,10 +75,6 @@ SYCL_EXTERNAL void accessor_subscript_operator_1(sycl::accessor<sycl::cl_int, 2>
 // CHECK-MLIR-SAME:      %{{.*}}: i64 {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERiNS0_2idILi1EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_2N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
-// CHECK-LLVM:           %"class.sycl::_V1::accessor.1"* noundef byval(%"class.sycl::_V1::accessor.1") align 8 %0, i64 noundef %1) #[[FUNCATTRS]]  
-// CHECK-LLVM:  %{{.*}} = call spir_func i32 addrspace(4)* @_ZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERiNS0_2idILi1EEE(%"class.sycl::_V1::accessor.1" addrspace(4)* %{{.*}}, %"class.sycl::_V1::id.1"* %{{.*}})
-
 SYCL_EXTERNAL void accessor_subscript_operator_2(sycl::accessor<sycl::cl_int, 1> acc, size_t index) {
   keep(acc[index]);
 }
@@ -124,9 +84,6 @@ SYCL_EXTERNAL void accessor_subscript_operator_2(sycl::accessor<sycl::cl_int, 1>
 // CHECK-MLIR-SAME:     %{{.*}}: i64 {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x![[ACC_STRUCT]], 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorI6StructLi1ELNS0_6access4modeE1026ELNS3_6targetE2014ELNS3_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERS2_NS0_2idILi1EEE, TypeName = @accessor} : (memref<?x![[ACC_STRUCT]]>, memref<?x!sycl_id_1_>) -> !llvm.ptr<struct<(i32)>, 4> 
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z29accessor_subscript_operator_3N4sycl3_V18accessorI6StructLi1ELNS0_6access4modeE1026ELNS3_6targetE2014ELNS3_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
-// CHECK-LLVM:           %"class.sycl::_V1::accessor.1.1"* noundef byval(%"class.sycl::_V1::accessor.1.1") align 8 %0, i64 noundef %1) #[[FUNCATTRS]] 
-// CHECK-LLVM:  %{{.*}} = call spir_func { i32 } addrspace(4)* @_ZNK4sycl3_V18accessorI6StructLi1ELNS0_6access4modeE1026ELNS3_6targetE2014ELNS3_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERS2_NS0_2idILi1EEE(%"class.sycl::_V1::accessor.1.1" addrspace(4)* %{{.*}}, %"class.sycl::_V1::id.1"* %{{.*}})
 typedef struct {
   unsigned field;
 } Struct;
@@ -139,10 +96,6 @@ SYCL_EXTERNAL void accessor_subscript_operator_3(sycl::accessor<Struct, 1> acc, 
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_range_2_>, i32) -> i64
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z11range_get_0N4sycl3_V15rangeILi2EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #[[FUNCATTRS]] 
-// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V16detail5arrayILi2EE3getEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %{{.*}}, i32 %1)
-
 SYCL_EXTERNAL void range_get_0(sycl::range<2> r, int dimension) {
   keep(r.get(dimension));
 }
@@ -152,9 +105,6 @@ SYCL_EXTERNAL void range_get_0(sycl::range<2> r, int dimension) {
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZN4sycl3_V16detail5arrayILi2EEixEi, TypeName = @array} : (memref<?x!sycl_range_2_>, i32) -> memref<?xi64, 4>
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z11range_get_1N4sycl3_V15rangeILi2EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]   
-// CHECK-LLVM: %{{.*}} = call spir_func i64 addrspace(4)* @_ZN4sycl3_V16detail5arrayILi2EEixEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void range_get_1(sycl::range<2> r, int dimension) {
   keep(r[dimension]);
@@ -165,10 +115,6 @@ SYCL_EXTERNAL void range_get_1(sycl::range<2> r, int dimension) {
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EEixEi, TypeName = @array} : (memref<?x!sycl_range_2_>, i32) -> i64
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z11range_get_2N4sycl3_V15rangeILi2EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]     
-// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V16detail5arrayILi2EEixEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %{{.*}}, i32 %1)
-
 SYCL_EXTERNAL void range_get_2(const sycl::range<2> r, int dimension) {
   keep(r[dimension]);
 }
@@ -177,9 +123,6 @@ SYCL_EXTERNAL void range_get_2(const sycl::range<2> r, int dimension) {
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.range.size(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_range_2_, 4>], FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl_range_2_>) -> i64
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z10range_sizeN4sycl3_V15rangeILi2EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::range.2"* noundef byval(%"class.sycl::_V1::range.2") align 8 %0) #[[FUNCATTRS]]       
-// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15rangeILi2EE4sizeEv(%"class.sycl::_V1::range.2" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void range_size(sycl::range<2> r) {
   keep(r.size());
@@ -200,20 +143,6 @@ SYCL_EXTERNAL void range_size(sycl::range<2> r) {
 // CHECK-MLIR-NEXT:             return %[[VAL_7]] : !sycl_range_2_
 // CHECK-MLIR-NEXT:           }
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z25nd_range_get_global_rangeN4sycl3_V18nd_rangeILi2EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #[[FUNCATTRS]]  
-// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* %{{.*}})
-
-// VAL_3 has incorrect type. Issue 7972 open in GitHub to address this.
-// CHECK-LLVM: define linkonce_odr spir_func %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* noundef align 8 dereferenceable_or_null(48) [[VAL_0:%.*]]) #[[FUNCATTRS]] {
-// CHECK-LLVM-NEXT:   [[VAL_2:%.*]] = alloca %"class.sycl::_V1::range.2", align 8
-// CHECK-LLVM-NEXT:   [[VAL_3:%.*]] = getelementptr %"class.sycl::_V1::nd_range.2", %"class.sycl::_V1::nd_range.2" addrspace(4)* [[VAL_0]], i32 0, i32 0
-// CHECK-LLVM-NEXT:   [[VAL_4:%.*]] = addrspacecast %"class.sycl::_V1::range.2"* [[VAL_2]] to %"class.sycl::_V1::range.2" addrspace(4)*
-// CHECK-LLVM-NEXT:   call spir_func void @_ZN4sycl3_V15rangeILi2EEC1ERKS2_(%"class.sycl::_V1::range.2" addrspace(4)* [[VAL_4]], %"class.sycl::_V1::range.2" addrspace(4)* [[VAL_3]])
-// CHECK-LLVM-NEXT:   [[VAL_5:%.*]]  = load %"class.sycl::_V1::range.2", %"class.sycl::_V1::range.2"* [[VAL_2]], align 8
-// CHECK-LLVM-NEXT:   ret %"class.sycl::_V1::range.2" [[VAL_5]] 
-// CHECK-LLVM-NEXT: }
-
 SYCL_EXTERNAL void nd_range_get_global_range(sycl::nd_range<2> nd_range) {
   keep(nd_range.get_global_range());
 }
@@ -221,10 +150,6 @@ SYCL_EXTERNAL void nd_range_get_global_range(sycl::nd_range<2> nd_range) {
 // CHECK-MLIR-LABEL: func.func @_Z24nd_range_get_local_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.nd_range.get_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_range_2_, 4>], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE15get_local_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_>) -> !sycl_range_2_
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z24nd_range_get_local_rangeN4sycl3_V18nd_rangeILi2EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE15get_local_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_range_get_local_range(sycl::nd_range<2> nd_range) {
   keep(nd_range.get_local_range());
@@ -234,10 +159,6 @@ SYCL_EXTERNAL void nd_range_get_local_range(sycl::nd_range<2> nd_range) {
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.nd_range.get_group_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_range_2_, 4>], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE15get_group_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_>) -> !sycl_range_2_
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z24nd_range_get_group_rangeN4sycl3_V18nd_rangeILi2EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_range.2"* noundef byval(%"class.sycl::_V1::nd_range.2") align 8 %0) #[[FUNCATTRS]]  
-// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.2" @_ZNK4sycl3_V18nd_rangeILi2EE15get_group_rangeEv(%"class.sycl::_V1::nd_range.2" addrspace(4)* %{{.*}})
-
 SYCL_EXTERNAL void nd_range_get_group_range(sycl::nd_range<2> nd_range) {
   keep(nd_range.get_group_range());
 }
@@ -245,10 +166,6 @@ SYCL_EXTERNAL void nd_range_get_group_range(sycl::nd_range<2> nd_range) {
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_0N4sycl3_V12idILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] {ArgumentTypes = [memref<?x!sycl_array_1_, 4>, i32], FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi1EE3getEi, TypeName = @array} : (memref<?x!sycl_id_1_>, i32) -> i64
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_0N4sycl3_V12idILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V16detail5arrayILi1EE3getEi(%"class.sycl::_V1::detail::array.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void id_get_0(sycl::id<1> id, int dimension) {
   keep(id.get(dimension));
@@ -258,10 +175,6 @@ SYCL_EXTERNAL void id_get_0(sycl::id<1> id, int dimension) {
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})  
 // CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] {ArgumentTypes = [memref<?x!sycl_array_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZN4sycl3_V16detail5arrayILi1EEixEi, TypeName = @array} : (memref<?x!sycl_id_1_>, i32) -> memref<?xi64, 4>
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_1N4sycl3_V12idILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]  
-// CHECK-LLVM: %{{.*}} = call spir_func i64 addrspace(4)* @_ZN4sycl3_V16detail5arrayILi1EEixEi(%"class.sycl::_V1::detail::array.1" addrspace(4)* %{{.*}}, i32 %1)
-
 SYCL_EXTERNAL void id_get_1(sycl::id<1> id, int dimension) {
   keep(id[dimension]);
 }
@@ -269,10 +182,6 @@ SYCL_EXTERNAL void id_get_1(sycl::id<1> id, int dimension) {
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_2N4sycl3_V12idILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})    
 // CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] {ArgumentTypes = [memref<?x!sycl_array_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi1EEixEi, TypeName = @array} : (memref<?x!sycl_id_1_>, i32) -> i64
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z8id_get_2N4sycl3_V12idILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]    
-// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V16detail5arrayILi1EEixEi(%"class.sycl::_V1::detail::array.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void id_get_2(const sycl::id<1> id, int dimension) {
   keep(id[dimension]);
@@ -289,10 +198,6 @@ SYCL_EXTERNAL void id_get_3(sycl::id<1> id) {
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x![[ITEM1]]>) -> !sycl_id_1_
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_0N4sycl3_V14itemILi1ELb1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::id.1" @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void item_get_id_0(sycl::item<1> item) {
   keep(item.get_id());
@@ -318,10 +223,6 @@ SYCL_EXTERNAL void item_get_id_2(sycl::item<1> item, int dimension) {
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @"operator unsigned long", MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EEcvmEv, TypeName = @item} : (memref<?x![[ITEM1]]>) -> i64
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z13item_get_id_3N4sycl3_V14itemILi1ELb1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]  
-// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V14itemILi1ELb1EEcvmEv(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}})
-
 SYCL_EXTERNAL void item_get_id_3(sycl::item<1> item) {
   keep(static_cast<size_t>(item));
 }
@@ -329,10 +230,6 @@ SYCL_EXTERNAL void item_get_id_3(sycl::item<1> item) {
 // CHECK-MLIR-LABEL: func.func @_Z16item_get_range_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.item.get_range(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEv, TypeName = @item} : (memref<?x![[ITEM1]]>) -> !sycl_range_1_
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z16item_get_range_0N4sycl3_V14itemILi1ELb1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::item.1.true"* noundef byval(%"class.sycl::_V1::item.1.true") align 8 %0) #[[FUNCATTRS]]    
-// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.1" @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEv(%"class.sycl::_V1::item.1.true" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void item_get_range_0(sycl::item<1> item) {
   keep(item.get_range());
@@ -358,10 +255,6 @@ SYCL_EXTERNAL void item_get_linear_id(sycl::item<1> item) {
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_global_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z23nd_item_get_global_id_0N4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::id.1" @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
-
 SYCL_EXTERNAL void nd_item_get_global_id_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_global_id());
 }
@@ -386,10 +279,6 @@ SYCL_EXTERNAL void nd_item_get_global_linear_id(sycl::nd_item<1> nd_item) {
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z22nd_item_get_local_id_0N4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]  
-// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::id.1" @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
-
 SYCL_EXTERNAL void nd_item_get_local_id_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_local_id());
 }
@@ -406,10 +295,6 @@ SYCL_EXTERNAL void nd_item_get_local_id_1(sycl::nd_item<1> nd_item, int dimensio
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_local_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE19get_local_linear_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> i64
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z27nd_item_get_local_linear_idN4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]    
-// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V17nd_itemILi1EE19get_local_linear_idEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
-
 SYCL_EXTERNAL void nd_item_get_local_linear_id(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_local_linear_id());
 }
@@ -417,10 +302,6 @@ SYCL_EXTERNAL void nd_item_get_local_linear_id(sycl::nd_item<1> nd_item) {
 // CHECK-MLIR-LABEL: func.func @_Z19nd_item_get_group_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})  
 // CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_group, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_group_1_
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z19nd_item_get_group_0N4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]      
-// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::group.1" @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void nd_item_get_group_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_group());
@@ -446,10 +327,6 @@ SYCL_EXTERNAL void nd_item_get_group_linear_id(sycl::nd_item<1> nd_item) {
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_group_range_0N4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]        
-// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.1" @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
-
 SYCL_EXTERNAL void nd_item_get_group_range_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_group_range());
 }
@@ -466,10 +343,6 @@ SYCL_EXTERNAL void nd_item_get_group_range_1(sycl::nd_item<1> nd_item, int dimen
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z26nd_item_get_global_range_0N4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.1" @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
-
 SYCL_EXTERNAL void nd_item_get_global_range_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_global_range());
 }
@@ -477,10 +350,6 @@ SYCL_EXTERNAL void nd_item_get_global_range_0(sycl::nd_item<1> nd_item) {
 // CHECK-MLIR-LABEL: func.func @_Z26nd_item_get_global_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z26nd_item_get_global_range_1N4sycl3_V17nd_itemILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]      
-// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void nd_item_get_global_range_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_global_range(dimension));
@@ -490,10 +359,6 @@ SYCL_EXTERNAL void nd_item_get_global_range_1(sycl::nd_item<1> nd_item, int dime
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_local_range_0N4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.1" @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
-
 SYCL_EXTERNAL void nd_item_get_local_range_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_local_range());
 }
@@ -501,10 +366,6 @@ SYCL_EXTERNAL void nd_item_get_local_range_0(sycl::nd_item<1> nd_item) {
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_local_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z25nd_item_get_local_range_1N4sycl3_V17nd_itemILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]        
-// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEi(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void nd_item_get_local_range_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_local_range(dimension));
@@ -514,10 +375,6 @@ SYCL_EXTERNAL void nd_item_get_local_range_1(sycl::nd_item<1> nd_item, int dimen
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.nd_item.get_nd_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_nd_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_nd_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_nd_range_1_
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z20nd_item_get_nd_rangeN4sycl3_V17nd_itemILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::nd_item.1"* noundef byval(%"class.sycl::_V1::nd_item.1") align 8 %0) #[[FUNCATTRS]]          
-// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::nd_range.1" @_ZNK4sycl3_V17nd_itemILi1EE12get_nd_rangeEv(%"class.sycl::_V1::nd_item.1" addrspace(4)* %{{.*}})
-
 SYCL_EXTERNAL void nd_item_get_nd_range(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_nd_range());
 }
@@ -525,10 +382,6 @@ SYCL_EXTERNAL void nd_item_get_nd_range(sycl::nd_item<1> nd_item) {
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_group_idEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_0N4sycl3_V15groupILi1EEE(
-
-// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::id.1" @_ZNK4sycl3_V15groupILi1EE12get_group_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_group_id_0(sycl::group<1> group) {
   keep(group.get_group_id());
@@ -538,10 +391,6 @@ SYCL_EXTERNAL void group_get_group_id_0(sycl::group<1> group) {
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_group_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_group_idEi, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_1N4sycl3_V15groupILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15groupILi1EE12get_group_idEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
-
 SYCL_EXTERNAL void group_get_group_id_1(sycl::group<1> group, int dimension) {
   keep(group.get_group_id(dimension));
 }
@@ -549,10 +398,6 @@ SYCL_EXTERNAL void group_get_group_id_1(sycl::group<1> group, int dimension) {
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_2N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V15groupILi1EEixEi, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_group_id_2N4sycl3_V15groupILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]
-// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15groupILi1EEixEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void group_get_group_id_2(sycl::group<1> group, int dimension) {
   keep(group[dimension]);
@@ -562,10 +407,6 @@ SYCL_EXTERNAL void group_get_group_id_2(sycl::group<1> group, int dimension) {
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.group.get_local_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_local_idEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_local_id_0N4sycl3_V15groupILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]   
-// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::id.1" @_ZNK4sycl3_V15groupILi1EE12get_local_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
-
 SYCL_EXTERNAL void group_get_local_id_0(sycl::group<1> group) {
   keep(group.get_local_id());
 }
@@ -573,10 +414,6 @@ SYCL_EXTERNAL void group_get_local_id_0(sycl::group<1> group) {
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_local_id_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.group.get_local_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_local_idEi, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z20group_get_local_id_1N4sycl3_V15groupILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]  
-// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15groupILi1EE12get_local_idEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void group_get_local_id_1(sycl::group<1> group, int dimension) {
   keep(group.get_local_id(dimension));
@@ -586,10 +423,6 @@ SYCL_EXTERNAL void group_get_local_id_1(sycl::group<1> group, int dimension) {
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}
 // CHECK-MLIR: %{{.*}} = sycl.group.get_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_local_range_0N4sycl3_V15groupILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]     
-// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.1" @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
-
 SYCL_EXTERNAL void group_get_local_range_0(sycl::group<1> group) {
   keep(group.get_local_range());
 }
@@ -597,10 +430,6 @@ SYCL_EXTERNAL void group_get_local_range_0(sycl::group<1> group) {
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_local_range_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.group.get_local_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEi, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_local_range_1N4sycl3_V15groupILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]    
-// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void group_get_local_range_1(sycl::group<1> group, int dimension) {
   keep(group.get_local_range(dimension));
@@ -610,10 +439,6 @@ SYCL_EXTERNAL void group_get_local_range_1(sycl::group<1> group, int dimension) 
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}  
 // CHECK-MLIR: %{{.*}} = sycl.group.get_group_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_group_range_0N4sycl3_V15groupILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]       
-// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.1" @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
-
 SYCL_EXTERNAL void group_get_group_range_0(sycl::group<1> group) {
   keep(group.get_group_range());
 }
@@ -621,10 +446,6 @@ SYCL_EXTERNAL void group_get_group_range_0(sycl::group<1> group) {
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_group_range_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}    
 // CHECK-MLIR: %{{.*}} = sycl.group.get_group_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEi, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z23group_get_group_range_1N4sycl3_V15groupILi1EEEi(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0, i32 noundef %1) #[[FUNCATTRS]]      
-// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEi(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}}, i32 %1)
 
 SYCL_EXTERNAL void group_get_group_range_1(sycl::group<1> group, int dimension) {
   keep(group.get_group_range(dimension));
@@ -634,10 +455,6 @@ SYCL_EXTERNAL void group_get_group_range_1(sycl::group<1> group, int dimension) 
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}      
 // CHECK-MLIR: %{{.*}} = sycl.group.get_max_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_max_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_max_local_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_max_local_rangeN4sycl3_V15groupILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]         
-// CHECK-LLVM: %{{.*}} = call spir_func %"class.sycl::_V1::range.1" @_ZNK4sycl3_V15groupILi1EE19get_max_local_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
-
 SYCL_EXTERNAL void group_get_max_local_range(sycl::group<1> group) {
   keep(group.get_max_local_range());
 }
@@ -645,10 +462,6 @@ SYCL_EXTERNAL void group_get_max_local_range(sycl::group<1> group) {
 // CHECK-MLIR-LABEL: func.func @_Z25group_get_group_linear_idN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}        
 // CHECK-MLIR: %{{.*}} = sycl.group.get_group_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_linear_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_group_linear_idEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_group_linear_idN4sycl3_V15groupILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]           
-// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15groupILi1EE19get_group_linear_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_group_linear_id(sycl::group<1> group) {
   keep(group.get_group_linear_id());
@@ -658,10 +471,6 @@ SYCL_EXTERNAL void group_get_group_linear_id(sycl::group<1> group) {
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}          
 // CHECK-MLIR: %{{.*}} = sycl.group.get_local_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_linear_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_local_linear_idEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z25group_get_local_linear_idN4sycl3_V15groupILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]         
-// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15groupILi1EE19get_local_linear_idEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
-
 SYCL_EXTERNAL void group_get_local_linear_id(sycl::group<1> group) {
   keep(group.get_local_linear_id());
 }
@@ -670,10 +479,6 @@ SYCL_EXTERNAL void group_get_local_linear_id(sycl::group<1> group) {
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}            
 // CHECK-MLIR: %{{.*}} = sycl.group.get_group_linear_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_linear_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE22get_group_linear_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z28group_get_group_linear_rangeN4sycl3_V15groupILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]           
-// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15groupILi1EE22get_group_linear_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
-
 SYCL_EXTERNAL void group_get_group_linear_range(sycl::group<1> group) {
   keep(group.get_group_linear_range());
 }
@@ -681,10 +486,6 @@ SYCL_EXTERNAL void group_get_group_linear_range(sycl::group<1> group) {
 // CHECK-MLIR-LABEL: func.func @_Z28group_get_local_linear_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
 // CHECK-MLIR: %{{.*}} = sycl.group.get_local_linear_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_linear_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE22get_local_linear_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z28group_get_local_linear_rangeN4sycl3_V15groupILi1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::group.1"* noundef byval(%"class.sycl::_V1::group.1") align 8 %0) #[[FUNCATTRS]]             
-// CHECK-LLVM: %{{.*}} = call spir_func i64 @_ZNK4sycl3_V15groupILi1EE22get_local_linear_rangeEv(%"class.sycl::_V1::group.1" addrspace(4)* %{{.*}})
 
 SYCL_EXTERNAL void group_get_local_linear_range(sycl::group<1> group) {
   keep(group.get_local_linear_range());
@@ -697,13 +498,6 @@ SYCL_EXTERNAL void group_get_local_linear_range(sycl::group<1> group) {
 // CHECK-MLIR-NEXT: return
 // CHECK-MLIR-NEXT: }
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z8method_2N4sycl3_V14itemILi2ELb1EEE(
-// CHECK-LLVM:           %"class.sycl::_V1::item.2.true"* noundef byval(%"class.sycl::_V1::item.2.true") align 8 %0) #[[FUNCATTRS]]
-// CHECK-LLVM-NEXT:  %2 = addrspacecast %"class.sycl::_V1::item.2.true"* %0 to %"class.sycl::_V1::item.2.true" addrspace(4)*
-// CHECK-LLVM-NEXT:  %3 = call spir_func i1 @_ZNK4sycl3_V14itemILi2ELb1EEeqERKS2_(%"class.sycl::_V1::item.2.true" addrspace(4)* %2, %"class.sycl::_V1::item.2.true" addrspace(4)* %2)
-// CHECK-LLVM-NEXT:  ret void
-// CHECK-LLVM-NEXT: }
-
 SYCL_EXTERNAL void method_2(sycl::item<2, true> item) {
   auto id = item.operator==(item);
 }
@@ -715,14 +509,6 @@ SYCL_EXTERNAL void method_2(sycl::item<2, true> item) {
 // CHECK-MLIR-NEXT: %0 = sycl.call @"operator=="(%memspacecast, %memspacecast_0) {MangledFunctionName = @_ZNK4sycl3_V12idILi2EEeqERKS2_, TypeName = @id} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>) -> i1
 // CHECK-MLIR-NEXT: return
 // CHECK-MLIR-NEXT: }
-
-// CHECK-LLVM-LABEL: define spir_func void @_Z4op_1N4sycl3_V12idILi2EEES2_(
-// CHECK-LLVM            %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %0, %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %1) #[[FUNCATTRS]]
-// CHECK-LLVM-NEXT: %3 = addrspacecast %"class.sycl::_V1::id.2"* %0 to %"class.sycl::_V1::id.2" addrspace(4)*
-// CHECK-LLVM-NEXT: %4 = addrspacecast %"class.sycl::_V1::id.2"* %1 to %"class.sycl::_V1::id.2" addrspace(4)*
-// CHECK-LLVM-NEXT: %5 = call spir_func i1 @_ZNK4sycl3_V12idILi2EEeqERKS2_(%"class.sycl::_V1::id.2" addrspace(4)* %3, %"class.sycl::_V1::id.2" addrspace(4)* %4)
-// CHECK-LLVM-NEXT: ret void
-// CHECK-LLVM-NEXT: }
 
 SYCL_EXTERNAL void op_1(sycl::id<2> a, sycl::id<2> b) {
   auto id = a == b;
@@ -739,19 +525,6 @@ SYCL_EXTERNAL void op_1(sycl::id<2> a, sycl::id<2> b) {
 // CHECK-MLIR-NEXT: return
 // CHECK-MLIR-NEXT: }
 
-// CHECK-LLVM-LABEL: define spir_func void @_Z8static_1N4sycl3_V12idILi2EEES2_(
-// CHECK-LLVM-SAME:      %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %0, %"class.sycl::_V1::id.2"* noundef byval(%"class.sycl::_V1::id.2") align 8 %1) #[[FUNCATTRS]]  
-// CHECK-LLVM-NEXT:    %3 = addrspacecast %"class.sycl::_V1::id.2"* %0 to %"class.sycl::_V1::id.2" addrspace(4)*
-// CHECK-LLVM-NEXT:    %4 = bitcast %"class.sycl::_V1::id.2" addrspace(4)* %3 to %"class.sycl::_V1::detail::array.2" addrspace(4)*
-// CHECK-LLVM-NEXT:    %5 = call spir_func i64 @_ZNK4sycl3_V16detail5arrayILi2EE3getEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %4, i32 0)
-// CHECK-LLVM-NEXT:    %6 = call spir_func i64 @_ZNK4sycl3_V16detail5arrayILi2EE3getEi(%"class.sycl::_V1::detail::array.2" addrspace(4)* %4, i32 1)
-// CHECK-LLVM-NEXT:    %7 = add i64 %5, %6
-// CHECK-LLVM-NEXT:    %8 = call spir_func i64 @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_(i64 %7)
-// CHECK-LLVM-NEXT:    ret void
-// CHECK-LLVM-NEXT: }
-
 SYCL_EXTERNAL void static_1(sycl::id<2> a, sycl::id<2> b) {
   auto abs = sycl::abs(a.get(0) + a.get(1));
 }
-
-// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp" }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -1,5 +1,6 @@
 // RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
 // RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - -Xcgeist -no-mangled-function-name | FileCheck %s --check-prefix=CHECK-MLIR-NO-MANGLED-FUNCTION-NAME
+// RUN: clang++ -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-llvm %s -o %t -Xcgeist -no-mangled-function-name && rm %t
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -663,7 +663,6 @@ static int finalize(mlir::MLIRContext &Ctx,
     if (!EmitOpenMPIR) {
       Module->walk([&](mlir::omp::ParallelOp) { LinkOMP = true; });
       mlir::PassManager PM3(&Ctx);
-      PM3.addPass(mlir::sycl::createSYCLMethodToSYCLCallPass());
       ConvertPolygeistToLLVMOptions Options;
       Options.dataLayout = DL.getStringRepresentation();
       PM3.addPass(createConvertPolygeistToLLVM(Options));

--- a/sycl/test-e2e/Basic/buffer/reinterpret.cpp
+++ b/sycl/test-e2e/Basic/buffer/reinterpret.cpp
@@ -5,9 +5,6 @@
 //
 // XFAIL: level_zero&&gpu
 
-// https://github.com/intel/llvm/issues/7585 to fix the failure:
-// XFAIL: gpu
-
 //==---------- reinterpret.cpp --- SYCL buffer reinterpret basic test ------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/HostInteropTask/host-task-two-queues.cpp
+++ b/sycl/test-e2e/HostInteropTask/host-task-two-queues.cpp
@@ -6,9 +6,6 @@
 // TODO: Flaky fail on Level Zero that is why mark as unsupported temporarily.
 // UNSUPPORTED: level_zero
 
-// https://github.com/intel/llvm/issues/7585 to fix the failure:
-// XFAIL: gpu
-
 #include <iostream>
 #include <sycl/sycl.hpp>
 #include <vector>


### PR DESCRIPTION
Use conversion to LLVM patterns instead of lowering to a function call.

Dropped conversion to LLVM checks from `polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp` as this is already covered in `mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir`.