### PR TITLE
[SYCL-MLIR] Add `sycl.nd_item.get_group_linear_id` LLVM conversion

### DIFF
--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -1863,6 +1863,53 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
+// NDItemGetGroupLinearID - Converts `sycl.nd_item.get_group_linear_id` to LLVM.
+//===----------------------------------------------------------------------===//
+
+/// Converts SYCLNDItemGetGroupOp with an ID return type to LLVM
+class NDItemGetGroupLinearIDPattern
+    : public ConvertOpToLLVMPattern<SYCLNDItemGetGroupLinearIDOp>,
+      public GetMemberPattern<NDItemGroup> {
+public:
+  using ConvertOpToLLVMPattern<
+      SYCLNDItemGetGroupLinearIDOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(SYCLNDItemGetGroupLinearIDOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const final {
+    const auto loc = op.getLoc();
+    // TODO: We query the group type from the body. Not ideal. Drop this when
+    // body is dropped and we can create group type more easily.
+    const auto indices = GetMemberPattern<NDItemGroup>::getIndices();
+    assert(indices.size() == 1 && "Expecting a single index");
+    const auto groupTy =
+        cast<NdItemType>(op.getNDItem().getType().getElementType())
+            .getBody()[indices[0]];
+    const auto convGroupTy = getTypeConverter()->convertType(groupTy);
+    bool useOpaquePointers = getTypeConverter()->useOpaquePointers();
+    auto group = GetMemberPattern<NDItemGroup>::getRef(
+        rewriter, loc, convGroupTy, adaptor.getNDItem(), std::nullopt,
+        useOpaquePointers);
+    const auto thisTy = MemRefType::get(ShapedType::kDynamic, groupTy);
+    // We have the already converted group, but, in order to not replicate
+    // `sycl.group.get_group_linear_id` conversion to LLVM, we just reuse that
+    // using `builtin.unrealized_conversion_cast` to convert the pointer into a
+    // memref to sycl type.
+    const auto syclGroup =
+        rewriter.create<UnrealizedConversionCastOp>(loc, thisTy, group)
+            .getResult(0);
+    const auto argTys = rewriter.getTypeArrayAttr({thisTy});
+    const auto funcName =
+        rewriter.getAttr<FlatSymbolRefAttr>("get_group_linear_id");
+    const auto typeName = rewriter.getAttr<FlatSymbolRefAttr>("group");
+    rewriter.replaceOpWithNewOp<SYCLGroupGetGroupLinearIDOp>(
+        op, rewriter.getI64Type(), syclGroup, argTys, funcName,
+        FlatSymbolRefAttr{}, typeName);
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // NDItemGetGroupRange - Converts `sycl.nd_item.get_group_range` to LLVM.
 //===----------------------------------------------------------------------===//
 
@@ -2318,32 +2365,32 @@ void mlir::populateSYCLToLLVMConversionPatterns(
   patterns.add<CallPattern>(typeConverter);
   patterns.add<CastPattern>(typeConverter);
   patterns.add<BarePtrCastPattern>(typeConverter, /*benefit*/ 2);
-  patterns
-      .add<AccessorGetPointerPattern, AccessorGetRangePattern,
-           AccessorSizePattern, AddZeroArgPattern<SYCLIDGetOp>,
-           AddZeroArgPattern<SYCLItemGetIDOp>, AtomicSubscriptIDOffset,
-           BarePtrAddrSpaceCastPattern, GroupGetGroupIDPattern,
-           GroupGetGroupLinearRangePattern, GroupGetGroupRangeDimPattern,
-           GroupGetLocalIDPattern, GroupGetLocalLinearRangePattern,
-           GroupGetLocalRangeDimPattern, IDGetPattern, IDGetRefPattern,
-           ItemGetIDDimPattern, ItemGetRangeDimPattern, ItemGetRangePattern,
-           NDItemGetGlobalIDDimPattern, NDItemGetGlobalIDPattern,
-           NDItemGetGlobalRangeDimPattern, NDItemGetGlobalRangePattern,
-           NDItemGetGroupPattern, NDItemGetGroupRangeDimPattern,
-           NDItemGetLocalIDDimPattern, NDItemGetLocalLinearIDPattern,
-           NDItemGetNDRange, NDRangeGetGroupRangePattern,
-           NDRangeGetLocalRangePattern, RangeGetRefPattern, RangeSizePattern,
-           SubscriptScalarOffsetND, GroupGetGroupIDDimPattern,
-           GroupGetGroupLinearIDPattern, GroupGetGroupRangePattern,
-           GroupGetLocalIDDimPattern, GroupGetLocalLinearIDPattern,
-           GroupGetLocalRangePattern, GroupGetMaxLocalRangePattern,
-           ItemGetIDPattern, ItemNoOffsetGetLinearIDPattern,
-           ItemOffsetGetLinearIDPattern, NDItemGetGlobalLinearIDPattern,
-           NDItemGetGroupDimPattern, NDItemGetGroupRangePattern,
-           NDItemGetLocalIDPattern, NDItemGetLocalRangeDimPattern,
-           NDItemGetLocalRangePattern, NDRangeGetGlobalRangePattern,
-           RangeGetPattern, SubscriptIDOffset, SubscriptScalarOffset1D>(
-          typeConverter);
+  patterns.add<AccessorGetPointerPattern, AccessorGetRangePattern,
+               AccessorSizePattern, AddZeroArgPattern<SYCLIDGetOp>,
+               AddZeroArgPattern<SYCLItemGetIDOp>, AtomicSubscriptIDOffset,
+               BarePtrAddrSpaceCastPattern, GroupGetGroupIDPattern,
+               GroupGetGroupLinearRangePattern, GroupGetGroupRangeDimPattern,
+               GroupGetLocalIDPattern, GroupGetLocalLinearRangePattern,
+               GroupGetLocalRangeDimPattern, IDGetPattern, IDGetRefPattern,
+               ItemGetIDDimPattern, ItemGetRangeDimPattern, ItemGetRangePattern,
+               NDItemGetGlobalIDDimPattern, NDItemGetGlobalIDPattern,
+               NDItemGetGlobalRangeDimPattern, NDItemGetGlobalRangePattern,
+               NDItemGetGroupPattern, NDItemGetGroupRangeDimPattern,
+               NDItemGetLocalIDDimPattern, NDItemGetLocalLinearIDPattern,
+               NDItemGetNDRange, NDRangeGetGroupRangePattern,
+               NDRangeGetLocalRangePattern, RangeGetRefPattern,
+               RangeSizePattern, SubscriptScalarOffsetND,
+               GroupGetGroupIDDimPattern, GroupGetGroupLinearIDPattern,
+               GroupGetGroupRangePattern, GroupGetLocalIDDimPattern,
+               GroupGetLocalLinearIDPattern, GroupGetLocalRangePattern,
+               GroupGetMaxLocalRangePattern, ItemGetIDPattern,
+               ItemNoOffsetGetLinearIDPattern, ItemOffsetGetLinearIDPattern,
+               NDItemGetGlobalLinearIDPattern, NDItemGetGroupDimPattern,
+               NDItemGetGroupLinearIDPattern, NDItemGetGroupRangePattern,
+               NDItemGetLocalIDPattern, NDItemGetLocalRangeDimPattern,
+               NDItemGetLocalRangePattern, NDRangeGetGlobalRangePattern,
+               RangeGetPattern, SubscriptIDOffset, SubscriptScalarOffset1D>(
+      typeConverter);
   patterns.add<ConstructorPattern>(typeConverter);
 }
 

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -1866,7 +1866,7 @@ public:
 // NDItemGetGroupLinearID - Converts `sycl.nd_item.get_group_linear_id` to LLVM.
 //===----------------------------------------------------------------------===//
 
-/// Converts SYCLNDItemGetGroupOp with an ID return type to LLVM
+/// Converts SYCLNDItemGetGroupLinearIDOp to LLVM.
 class NDItemGetGroupLinearIDPattern
     : public ConvertOpToLLVMPattern<SYCLNDItemGetGroupLinearIDOp>,
       public GetMemberPattern<NDItemGroup> {

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm-typed-pointer.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm-typed-pointer.mlir
@@ -1026,6 +1026,88 @@ func.func @test_3(%nd: memref<?x!sycl_nd_item_3_>) -> i64 {
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
+!sycl_item_base_1_1_ = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1_)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+!sycl_item_base_2_ = !sycl.item_base<[2, true], (!sycl_range_2_, !sycl_id_2_, !sycl_id_2_)>
+!sycl_item_2_ = !sycl.item<[2, true], (!sycl_item_base_2_)>
+!sycl_item_base_2_1_ = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_2_1_ = !sycl.item<[1, false], (!sycl_item_base_2_1_)>
+!sycl_group_2_ = !sycl.group<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
+!sycl_nd_item_2_ = !sycl.nd_item<[2], (!sycl_item_2_, !sycl_item_2_1_, !sycl_group_2_)>
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64>)>)>
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64>)>)>
+!sycl_item_base_3_ = !sycl.item_base<[3, true], (!sycl_range_3_, !sycl_id_3_, !sycl_id_3_)>
+!sycl_item_3_ = !sycl.item<[3, true], (!sycl_item_base_3_)>
+!sycl_item_base_3_1_ = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_3_1_ = !sycl.item<[1, false], (!sycl_item_base_3_1_)>
+!sycl_group_3_ = !sycl.group<[3], (!sycl_range_3_, !sycl_range_3_, !sycl_range_3_, !sycl_id_3_)>
+!sycl_nd_item_3_ = !sycl.nd_item<[3], (!sycl_item_3_, !sycl_item_3_1_, !sycl_group_3_)>
+
+// CHECK-LABEL:   llvm.func @test_1(
+// CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr<struct<"class.sycl::_V1::nd_item.1", {{.*}}>>) -> i64 {
+// CHECK:           %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2] : (!llvm.ptr<struct<"class.sycl::_V1::nd_item.1", {{.*}}>>) -> !llvm.ptr<struct<"class.sycl::_V1::group.1", {{.*}}>>
+// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 3, 0, 0, 0] : (!llvm.ptr<struct<"class.sycl::_V1::group.1", {{.*}}>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i64>
+// CHECK:           llvm.return %[[VAL_4]] : i64
+// CHECK:         }
+func.func @test_1(%nd: memref<?x!sycl_nd_item_1_>) -> i64 {
+  %0 = sycl.nd_item.get_group_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> i64
+  return %0 : i64
+}
+
+// CHECK-LABEL:   llvm.func @test_2(
+// CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr<struct<"class.sycl::_V1::nd_item.2", {{.*}}>>) -> i64 {
+// CHECK:           %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2] : (!llvm.ptr<struct<"class.sycl::_V1::nd_item.2", {{.*}}>>) -> !llvm.ptr<struct<"class.sycl::_V1::group.2", {{.*}}>>
+// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 3, 0, 0, 0] : (!llvm.ptr<struct<"class.sycl::_V1::group.2", {{.*}}>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 2, 0, 0, 1] : (!llvm.ptr<struct<"class.sycl::_V1::group.2", {{.*}}>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_7:.*]] = llvm.mul %[[VAL_4]], %[[VAL_6]]  : i64
+// CHECK:           %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 3, 0, 0, 1] : (!llvm.ptr<struct<"class.sycl::_V1::group.2", {{.*}}>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_9:.*]] = llvm.load %[[VAL_8]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_10:.*]] = llvm.add %[[VAL_7]], %[[VAL_9]]  : i64
+// CHECK:           llvm.return %[[VAL_10]] : i64
+// CHECK:         }
+func.func @test_2(%nd: memref<?x!sycl_nd_item_2_>) -> i64 {
+  %0 = sycl.nd_item.get_group_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_2_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_2_>) -> i64
+  return %0 : i64
+}
+
+// CHECK-LABEL:   llvm.func @test_3(
+// CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr<struct<"class.sycl::_V1::nd_item.3", {{.*}}>>) -> i64 {
+// CHECK:           %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2] : (!llvm.ptr<struct<"class.sycl::_V1::nd_item.3", {{.*}}>>) -> !llvm.ptr<struct<"class.sycl::_V1::group.3", {{.*}}>>
+// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 3, 0, 0, 0] : (!llvm.ptr<struct<"class.sycl::_V1::group.3", {{.*}}>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 2, 0, 0, 1] : (!llvm.ptr<struct<"class.sycl::_V1::group.3", {{.*}}>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_7:.*]] = llvm.mul %[[VAL_4]], %[[VAL_6]]  : i64
+// CHECK:           %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 2, 0, 0, 2] : (!llvm.ptr<struct<"class.sycl::_V1::group.3", {{.*}}>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_9:.*]] = llvm.load %[[VAL_8]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_10:.*]] = llvm.mul %[[VAL_7]], %[[VAL_9]]  : i64
+// CHECK:           %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 3, 0, 0, 1] : (!llvm.ptr<struct<"class.sycl::_V1::group.3", {{.*}}>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_12:.*]] = llvm.load %[[VAL_11]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_13:.*]] = llvm.mul %[[VAL_12]], %[[VAL_9]]  : i64
+// CHECK:           %[[VAL_14:.*]] = llvm.add %[[VAL_10]], %[[VAL_13]]  : i64
+// CHECK:           %[[VAL_15:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 3, 0, 0, 2] : (!llvm.ptr<struct<"class.sycl::_V1::group.3", {{.*}}>>) -> !llvm.ptr<i64>
+// CHECK:           %[[VAL_16:.*]] = llvm.load %[[VAL_15]] : !llvm.ptr<i64>
+// CHECK:           %[[VAL_17:.*]] = llvm.add %[[VAL_14]], %[[VAL_16]]  : i64
+// CHECK:           llvm.return %[[VAL_17]] : i64
+// CHECK:         }
+func.func @test_3(%nd: memref<?x!sycl_nd_item_3_>) -> i64 {
+  %0 = sycl.nd_item.get_group_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_3_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_3_>) -> i64
+  return %0 : i64
+}
+
+// -----
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
 !sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
 !sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
 !sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1)>

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -1009,6 +1009,88 @@ func.func @test_3(%nd: memref<?x!sycl_nd_item_3_>) -> i64 {
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
+!sycl_item_base_1_1_ = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1_)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+!sycl_item_base_2_ = !sycl.item_base<[2, true], (!sycl_range_2_, !sycl_id_2_, !sycl_id_2_)>
+!sycl_item_2_ = !sycl.item<[2, true], (!sycl_item_base_2_)>
+!sycl_item_base_2_1_ = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_2_1_ = !sycl.item<[1, false], (!sycl_item_base_2_1_)>
+!sycl_group_2_ = !sycl.group<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
+!sycl_nd_item_2_ = !sycl.nd_item<[2], (!sycl_item_2_, !sycl_item_2_1_, !sycl_group_2_)>
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64>)>)>
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64>)>)>
+!sycl_item_base_3_ = !sycl.item_base<[3, true], (!sycl_range_3_, !sycl_id_3_, !sycl_id_3_)>
+!sycl_item_3_ = !sycl.item<[3, true], (!sycl_item_base_3_)>
+!sycl_item_base_3_1_ = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_3_1_ = !sycl.item<[1, false], (!sycl_item_base_3_1_)>
+!sycl_group_3_ = !sycl.group<[3], (!sycl_range_3_, !sycl_range_3_, !sycl_range_3_, !sycl_id_3_)>
+!sycl_nd_item_3_ = !sycl.nd_item<[3], (!sycl_item_3_, !sycl_item_3_1_, !sycl_group_3_)>
+
+// CHECK-LABEL:   llvm.func @test_1(
+// CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr) -> i64 {
+// CHECK:           %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::group.1", {{.*}}>
+// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 3, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::group.1", {{.*}}>
+// CHECK:           %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> i64
+// CHECK:           llvm.return %[[VAL_4]] : i64
+// CHECK:    }
+func.func @test_1(%nd: memref<?x!sycl_nd_item_1_>) -> i64 {
+  %0 = sycl.nd_item.get_group_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> i64
+  return %0 : i64
+}
+
+// CHECK-LABEL:   llvm.func @test_2(
+// CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr) -> i64 {
+// CHECK:           %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::group.2", {{.*}}>
+// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 3, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::group.2", {{.*}}>
+// CHECK:           %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> i64
+// CHECK:           %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 2, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::group.2", {{.*}}>
+// CHECK:           %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> i64
+// CHECK:           %[[VAL_7:.*]] = llvm.mul %[[VAL_4]], %[[VAL_6]]  : i64
+// CHECK:           %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 3, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::group.2", {{.*}}>
+// CHECK:           %[[VAL_9:.*]] = llvm.load %[[VAL_8]] : !llvm.ptr -> i64
+// CHECK:           %[[VAL_10:.*]] = llvm.add %[[VAL_7]], %[[VAL_9]]  : i64
+// CHECK:           llvm.return %[[VAL_10]] : i64
+// CHECK:    }
+func.func @test_2(%nd: memref<?x!sycl_nd_item_2_>) -> i64 {
+  %0 = sycl.nd_item.get_group_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_2_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_2_>) -> i64
+  return %0 : i64
+}
+
+// CHECK-LABEL:   llvm.func @test_3(
+// CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr) -> i64 {
+// CHECK:           %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::group.3", {{.*}}>
+// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 3, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::group.3", {{.*}}>
+// CHECK:           %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> i64
+// CHECK:           %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 2, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::group.3", {{.*}}>
+// CHECK:           %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> i64
+// CHECK:           %[[VAL_7:.*]] = llvm.mul %[[VAL_4]], %[[VAL_6]]  : i64
+// CHECK:           %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 2, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::group.3", {{.*}}>
+// CHECK:           %[[VAL_9:.*]] = llvm.load %[[VAL_8]] : !llvm.ptr -> i64
+// CHECK:           %[[VAL_10:.*]] = llvm.mul %[[VAL_7]], %[[VAL_9]]  : i64
+// CHECK:           %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 3, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::group.3", {{.*}}>
+// CHECK:           %[[VAL_12:.*]] = llvm.load %[[VAL_11]] : !llvm.ptr -> i64
+// CHECK:           %[[VAL_13:.*]] = llvm.mul %[[VAL_12]], %[[VAL_9]]  : i64
+// CHECK:           %[[VAL_14:.*]] = llvm.add %[[VAL_10]], %[[VAL_13]]  : i64
+// CHECK:           %[[VAL_15:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 3, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::group.3", {{.*}}>
+// CHECK:           %[[VAL_16:.*]] = llvm.load %[[VAL_15]] : !llvm.ptr -> i64
+// CHECK:           %[[VAL_17:.*]] = llvm.add %[[VAL_14]], %[[VAL_16]]  : i64
+// CHECK:           llvm.return %[[VAL_17]] : i64
+// CHECK:    }
+func.func @test_3(%nd: memref<?x!sycl_nd_item_3_>) -> i64 {
+  %0 = sycl.nd_item.get_group_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_3_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_3_>) -> i64
+  return %0 : i64
+}
+
+// -----
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
 !sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
 !sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
 !sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1)>


### PR DESCRIPTION
This conversion pattern reuses `sycl.group.get_group_linear_id`'s pattern. In order to do that, a `builtin.unrealized_conversion_cast` is inserted to perform the conversion from the converted type to the sycl one. This builtin will become a dead value as soon as this pass ends, which allows a legal and easy removal, so it is not included in the tests.