### PR TITLE
[SYCL][ESIMD][E2E] Reenable AOT test

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -82,7 +82,7 @@ jobs:
             image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
             target_devices: ext_oneapi_cuda:gpu
           - name: Intel
-            runner: '["Linux", "gen12"]'
+            runner: '["Linux", "gen12-test"]'
             image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest
             image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
             target_devices: level_zero:gpu;opencl:gpu;opencl:cpu

--- a/.github/workflows/sycl-windows-precommit.yml
+++ b/.github/workflows/sycl-windows-precommit.yml
@@ -53,6 +53,6 @@ jobs:
     uses: ./.github/workflows/sycl-windows-run-tests.yml
     with:
       name: Intel GEN12 Graphics with Level Zero
-      runner: '["Windows","gen12"]'
+      runner: '["Windows","gen12-test"]'
       sycl_toolchain_archive: ${{ needs.build.outputs.artifact_archive_name }}
       extra_lit_opts: --param gpu-intel-gen12=True


### PR DESCRIPTION
The driver used in syclos is still old, from December, and this version isn't able to know it should take the VC path in this case.

Pass -vc-codegen until the driver is updated to make sure we have AOT coverage.

Also don't always compile for gen9, use the current device.