### PR TITLE
[SYCL-MLIR]: Loop Versioning - introduce LoopVersionCondition

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -65,26 +65,29 @@ public:
 
   /// Create a loop versioning condition for SCF loops.
   LoopVersionCondition(SCFCondition scfCond)
-      : versionCondition({&scfCond, nullptr}) {}
+      : versionCondition({scfCond, std::nullopt}) {}
 
   LoopVersionCondition(AffineCondition affineCond)
-      : versionCondition({nullptr, &affineCond}) {}
+      : versionCondition({std::nullopt, affineCond}) {}
 
-  const SCFCondition &getSCFCondition() const {
-    assert(versionCondition.scfCond && "expecting valid pointer");
+  SCFCondition getSCFCondition() const {
+    assert(versionCondition.scfCond.has_value() &&
+           "expecting valid SCF condition");
     return *versionCondition.scfCond;
   }
-  const AffineCondition &getAffineCondition() const {
-    assert(versionCondition.affineCond && "expecting valid pointer");
+  AffineCondition getAffineCondition() const {
+    assert(versionCondition.affineCond.has_value() &&
+           "expecting valid affine condition");
     return *versionCondition.affineCond;
   }
 
 private:
   struct VersionCondition {
-    VersionCondition(SCFCondition *scfCond, AffineCondition *affineCond)
+    VersionCondition(Optional<SCFCondition> scfCond,
+                     Optional<AffineCondition> affineCond)
         : scfCond(scfCond), affineCond(affineCond) {}
-    SCFCondition *scfCond;
-    AffineCondition *affineCond;
+    Optional<SCFCondition> scfCond;
+    Optional<AffineCondition> affineCond;
   } versionCondition;
 };
 
@@ -238,6 +241,21 @@ private:
   OperandRange getUpperBoundsOperands() const final;
   AffineMap getLowerBoundsMap() const final;
   AffineMap getUpperBoundsMap() const final;
+};
+
+//===----------------------------------------------------------------------===//
+// Loop Tools
+//===----------------------------------------------------------------------===//
+
+/// A collection of tools for loop transformations.
+class LoopTools {
+public:
+  /// Guard the given loop \p loop.
+  void guardLoop(LoopLikeOpInterface loop) const;
+
+  /// Version the given loop \p loop using the condition \p versionCond.
+  void versionLoop(LoopLikeOpInterface loop,
+                   const LoopVersionCondition &versionCond) const;
 };
 
 } // namespace mlir

--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -15,6 +15,7 @@
 
 #include "mlir/IR/IntegerSet.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
+#include <variant>
 
 namespace mlir {
 class AffineForOp;
@@ -64,31 +65,24 @@ public:
   };
 
   /// Create a loop versioning condition for SCF loops.
-  LoopVersionCondition(SCFCondition scfCond)
-      : versionCondition({scfCond, std::nullopt}) {}
+  LoopVersionCondition(SCFCondition scfCond) : versionCondition(scfCond) {}
 
   LoopVersionCondition(AffineCondition affineCond)
-      : versionCondition({std::nullopt, affineCond}) {}
+      : versionCondition(affineCond) {}
 
   SCFCondition getSCFCondition() const {
-    assert(versionCondition.scfCond.has_value() &&
+    assert(std::holds_alternative<SCFCondition>(versionCondition) &&
            "expecting valid SCF condition");
-    return *versionCondition.scfCond;
+    return std::get<SCFCondition>(versionCondition);
   }
   AffineCondition getAffineCondition() const {
-    assert(versionCondition.affineCond.has_value() &&
+    assert(std::holds_alternative<AffineCondition>(versionCondition) &&
            "expecting valid affine condition");
-    return *versionCondition.affineCond;
+    return std::get<AffineCondition>(versionCondition);
   }
 
 private:
-  struct VersionCondition {
-    VersionCondition(Optional<SCFCondition> scfCond,
-                     Optional<AffineCondition> affineCond)
-        : scfCond(scfCond), affineCond(affineCond) {}
-    Optional<SCFCondition> scfCond;
-    Optional<AffineCondition> affineCond;
-  } versionCondition;
+  std::variant<SCFCondition, AffineCondition> versionCondition;
 };
 
 /// Abstract base class to version a loop like operation.

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
@@ -369,7 +369,7 @@ public:
   using SCFCondition = LoopVersionCondition::SCFCondition;
   using AffineCondition = LoopVersionCondition::AffineCondition;
 
-  std::unique_ptr<LoopVersionCondition> createCondition() {
+  std::unique_ptr<LoopVersionCondition> createCondition() const {
     OpBuilder builder(loop);
     Location loc = loop.getLoc();
 
@@ -524,7 +524,7 @@ private:
     return createSYCLAccessorSubscriptOp(accessor, id, builder, loc);
   }
 
-  LoopLikeOpInterface loop;
+  mutable LoopLikeOpInterface loop;
   ArrayRef<AccessorPairType> accessorPairs;
 };
 

--- a/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
@@ -55,6 +55,7 @@ struct SCFIfBuilder {
   static RegionBranchOpInterface createIfOp(Value condition,
                                             Operation::result_range results,
                                             OpBuilder &builder, Location loc) {
+    assert(condition && "Expecting a valid condition");
     return builder.create<scf::IfOp>(
         loc, condition,
         [&](OpBuilder &b, Location loc) {
@@ -416,4 +417,17 @@ AffineMap AffineParallelGuardBuilder::getLowerBoundsMap() const {
 
 AffineMap AffineParallelGuardBuilder::getUpperBoundsMap() const {
   return getLoop().getUpperBoundsMap();
+}
+
+//===----------------------------------------------------------------------===//
+// Loop Tools
+//===----------------------------------------------------------------------===//
+
+void LoopTools::guardLoop(LoopLikeOpInterface loop) const {
+  LoopGuardBuilder::create(loop)->guardLoop();
+}
+
+void LoopTools::versionLoop(LoopLikeOpInterface loop,
+                            const LoopVersionCondition &versionCond) const {
+  LoopVersionBuilder::create(loop)->versionLoop(versionCond);
 }

--- a/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
@@ -9,7 +9,6 @@
 #include "mlir/Dialect/Polygeist/Utils/TransformUtils.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/IR/IntegerSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 using namespace mlir;
@@ -94,15 +93,6 @@ LoopVersionBuilder::create(LoopLikeOpInterface loop) {
       });
 }
 
-void LoopVersionBuilder::versionLoop(Value) const {
-  llvm_unreachable("Can't version this kind of loop using this API");
-}
-
-void LoopVersionBuilder::versionLoop(IntegerSet,
-                                     SmallVectorImpl<Value> &) const {
-  llvm_unreachable("Can't version this kind of loop using this API");
-}
-
 void LoopVersionBuilder::versionLoop(RegionBranchOpInterface ifOp) const {
   createThenBody(ifOp);
   createElseBody(ifOp);
@@ -113,10 +103,12 @@ void LoopVersionBuilder::versionLoop(RegionBranchOpInterface ifOp) const {
 // SCFLoopVersionBuilder
 //===----------------------------------------------------------------------===//
 
-void SCFLoopVersionBuilder::versionLoop(Value condition) const {
+void SCFLoopVersionBuilder::versionLoop(
+    const LoopVersionCondition &versionCond) const {
   OpBuilder builder(loop);
-  RegionBranchOpInterface ifOp = SCFIfBuilder::createIfOp(
-      condition, loop->getResults(), builder, loop.getLoc());
+  RegionBranchOpInterface ifOp =
+      SCFIfBuilder::createIfOp(versionCond.getSCFCondition(),
+                               loop->getResults(), builder, loop.getLoc());
   LoopVersionBuilder::versionLoop(ifOp);
 }
 
@@ -137,10 +129,12 @@ void SCFLoopVersionBuilder::createElseBody(RegionBranchOpInterface ifOp) const {
 //===----------------------------------------------------------------------===//
 
 void AffineLoopVersionBuilder::versionLoop(
-    IntegerSet ifCondSet, SmallVectorImpl<Value> &setOperands) const {
+    const LoopVersionCondition &versionCond) const {
   OpBuilder builder(loop);
-  RegionBranchOpInterface ifOp = AffineIfBuilder::createIfOp(
-      ifCondSet, setOperands, loop->getResults(), builder, loop.getLoc());
+  const auto &affineCond = versionCond.getAffineCondition();
+  RegionBranchOpInterface ifOp =
+      AffineIfBuilder::createIfOp(affineCond.ifCondSet, affineCond.setOperands,
+                                  loop->getResults(), builder, loop.getLoc());
   LoopVersionBuilder::versionLoop(ifOp);
 }
 


### PR DESCRIPTION
Create the `LoopVersionCondition` class to abstract the loop versioning condition used to version a loop. 
Create the `LoopTools` class to collect tools useful for loop transformations.
Adapt `LICM` to create the  `LoopVersionCondition` class and use `LoopTools`. Loop versioning is now requested via: 
```
std::unique_ptr<LoopVersionCondition> condition =
   VersionConditionBuilder(loop, accessorPairs).createCondition();
loopTools.versionLoop(loop, *condition);
```

Now there is a single API for versioning SCF or Affine loops. The consumer uses a  `VersionConditionBuilder` to create an appropriate condition for the kind of loop being versioned and `LoopTools` take care of the rest.