### PR TITLE
[SYCL-MLIR] Remove `CallOpInterface` from `SYCLMethodOp`

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -84,7 +84,7 @@ class SYCL_Op<string mnemonic, list<Trait> traits = []>
 
 class SYCLMethodOpInterfaceImpl<
     string mnemonic, string type, list<string> methodNames, list<Trait> traits = []>
-        : SYCL_Op<mnemonic, !listconcat(traits, [SYCLMethodOpInterface, CallOpInterface])> {
+        : SYCL_Op<mnemonic, !listconcat(traits, [SYCLMethodOpInterface])> {
   string baseType = type;
   list<string> memberFunctionNames = methodNames;
   int arrSize = !size(memberFunctionNames);
@@ -95,21 +95,6 @@ class SYCLMethodOpInterfaceImpl<
      }};
     static ::mlir::TypeID getTypeID() { return ::mlir::sycl::}] # type # [{::getTypeID(); }
     static constexpr llvm::ArrayRef<llvm::StringLiteral> getMethodNames() { return methods; }
-
-    Operation::operand_iterator arg_operand_begin() { return (*this)->operand_begin(); }
-    Operation::operand_iterator arg_operand_end() { return (*this)->operand_end(); }
-
-    /// Return the callee of the generic SYCL call operation, this is required
-    /// by the call interface.
-    CallInterfaceCallable getCallableForCallee() {
-      return (*this)->getAttrOfType<FlatSymbolRefAttr>(getMangledFunctionNameAttrName());
-    }
-
-    /// Get the argument operands to the called function, this is required by
-    /// the call interface.
-    Operation::operand_range getArgOperands() {
-      return {arg_operand_begin(), arg_operand_end()};
-    }
   }];
 
   let extraClassDefinition = [{

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.td
@@ -31,9 +31,6 @@ def InlinePass : Pass<"inliner"> {
            "Remove callees that become unreachable after inlining them">,
     Option<"MaxIterationCount", "max-num-iters", "unsigned", /*default=*/"3",
            "Maximum number of inlining iterations for each SCC">,
-    Option<"InlineSYCLMethodOps", "inline-sycl-method-ops",
-           "bool", /*default=*/"true",
-           "Whether to inline SYCLMethodOp operations">,
   ];
   let dependentDialects = ["memref::MemRefDialect"];
 

--- a/mlir-sycl/test/Transforms/inliner.mlir
+++ b/mlir-sycl/test/Transforms/inliner.mlir
@@ -1,7 +1,6 @@
-// RUN: sycl-mlir-opt -split-input-file -inliner="mode=alwaysinline remove-dead-callees=false inline-sycl-method-ops=false" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefixes=ALWAYS-INLINE,CHECK-ALL %s
-// RUN: sycl-mlir-opt -split-input-file -inliner="mode=simple remove-dead-callees=true inline-sycl-method-ops=false" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefixes=INLINE,CHECK-ALL %s
-// RUN: sycl-mlir-opt -split-input-file -inliner="mode=aggressive remove-dead-callees=true inline-sycl-method-ops=false" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefixes=AGGRESSIVE,CHECK-ALL %s
-// RUN: sycl-mlir-opt -split-input-file -inliner="mode=aggressive remove-dead-callees=true inline-sycl-method-ops=true" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefixes=AGGRESSIVE-METHODOPS,CHECK-ALL %s
+// RUN: sycl-mlir-opt -split-input-file -inliner="mode=alwaysinline remove-dead-callees=false" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefixes=ALWAYS-INLINE,CHECK-ALL %s
+// RUN: sycl-mlir-opt -split-input-file -inliner="mode=simple remove-dead-callees=true" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefixes=INLINE,CHECK-ALL %s
+// RUN: sycl-mlir-opt -split-input-file -inliner="mode=aggressive remove-dead-callees=true" -verify-diagnostics -mlir-pass-statistics %s 2>&1 | FileCheck --check-prefixes=AGGRESSIVE,CHECK-ALL %s
 
 // COM: Ensure a func.func can be inlined in a func.func caller iff the callee is 'alwaysinline'.
 // COM: Ensure a gpu.func cannot be inlined in a func.func caller (even if it has the 'alwaysinline' attribute).
@@ -172,10 +171,6 @@ gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
 
 // -----
 
-// AGGRESSIVE-METHODOPS-NOT: func.func private @inline_hint_callee
-// AGGRESSIVE-METHODOPS-NOT: func.func private @private_callee
-// AGGRESSIVE-METHODOPS-NOT: func.func private @get
-
 // AGGRESSIVE-NOT: func.func private @inline_hint_callee
 // AGGRESSIVE-NOT: func.func private @private_callee
 
@@ -203,18 +198,6 @@ gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
 
 // INLINE-NOT: func.func private @inline_hint_callee
 // INLINE-NOT: func.func private @private_callee
-
-// AGGRESSIVE-METHODOPS-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i32
-// AGGRESSIVE-METHODOPS-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i32
-// AGGRESSIVE-METHODOPS-DAG:       %[[VAL_3:.*]] = arith.constant 2 : i32
-// AGGRESSIVE-METHODOPS:           %[[VAL_4:.*]] = sycl.call @main_() {MangledFunctionName = @main, TypeName = @A} : () -> i32
-// AGGRESSIVE-METHODOPS:           %[[VAL_5:.*]] = arith.addi %[[VAL_3]], %[[VAL_4]] : i32
-// AGGRESSIVE-METHODOPS:           %[[VAL_6:.*]] = arith.addi %[[VAL_2]], %[[VAL_5]] : i32
-// AGGRESSIVE-METHODOPS:           call @foo(%[[VAL_0]], %[[VAL_1]]) : (memref<?x!sycl_id_1_>, i32) -> ()
-// AGGRESSIVE-METHODOPS:           %[[VAL_7:.*]] = memref.memory_space_cast %[[VAL_0]] : memref<?x!sycl_id_1_> to memref<?x!sycl_id_1_, 4>
-// AGGRESSIVE-METHODOPS:           %[[VAL_8:.*]] = arith.constant 2 : i64
-// AGGRESSIVE-METHODOPS:           return %[[VAL_6]], %[[VAL_8]] : i32, i64
-// AGGRESSIVE-METHODOPS:         }
 
 // AGGRESSIVE:           %[[VAL_1:.*]] = arith.constant 1 : i32
 // AGGRESSIVE:           %[[VAL_2:.*]] = arith.constant 1 : i32

--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -222,11 +222,6 @@ static llvm::cl::opt<std::string> McpuOpt("mcpu", llvm::cl::init(""),
                                           llvm::cl::desc("Target CPU"),
                                           llvm::cl::cat(ToolOptions));
 
-static llvm::cl::opt<bool> InlineSYCLMethodOps(
-    "inline-sycl-method-ops", llvm::cl::init(true),
-    llvm::cl::desc("Whether to inline SYCLMethodOp operations"),
-    llvm::cl::cat(ToolOptions));
-
 llvm::cl::opt<bool> OmitOptionalMangledFunctionName(
     "no-mangled-function-name", llvm::cl::init(false),
     llvm::cl::desc("Whether to omit optional \"MangledFunctionName\" fields"));

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -401,14 +401,8 @@ static int optimize(mlir::MLIRContext &Ctx,
     if (RaiseToAffine)
       OptPM.addPass(mlir::createLowerAffinePass());
 
-    // Note: the inliner pass needs the `MangledFunctionName` attribute to build
-    // the call graph.
-    if (OmitOptionalMangledFunctionName)
-      PM.addPass(mlir::sycl::createSYCLMethodToSYCLCallPass());
-
     PM.addPass(sycl::createInlinePass({sycl::InlineMode::Simple,
-                                       /* RemoveDeadCallees */ true,
-                                       InlineSYCLMethodOps}));
+                                       /* RemoveDeadCallees */ true}));
 
     if (RaiseToAffine)
       OptPM.addPass(polygeist::createRaiseSCFToAffinePass());


### PR DESCRIPTION
`SYCLMethodOp` may not turn into a call (actually never after https://github.com/intel/llvm/pull/9005), so `CallOpInterface` can be removed from `SYCLMethodOp`. On top of removing the interface, this PR also removes the special handling of `SYCLMethodOp` in/for inline pass. 

This PR plans to be merged after https://github.com/intel/llvm/pull/9005.