### PR TITLE
[SYCL-MLIR][LICM] Enable SYCL Accessor Versioning

### DIFF
--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -471,7 +471,7 @@ public:
   using ConvertOpToLLVMPattern<Op>::ConvertOpToLLVMPattern;
 
   LogicalResult match(Op op) const final {
-    return success(op.getNumOperands() == 1 && isa<IntegerType>(op.getType()));
+    return success(op.getNumOperands() == 1 && op.getType().isIntOrIndex());
   }
 
   void rewrite(Op op, OpAdaptor adaptor,
@@ -1564,7 +1564,7 @@ public:
   using LoadMemberDimPattern<SYCLIDGetOp, IDGetDim>::LoadMemberDimPattern;
 
   LogicalResult match(SYCLIDGetOp op) const final {
-    return success(op.getNumOperands() > 1 && isa<IntegerType>(op.getType()));
+    return success(op.getNumOperands() > 1 && op.getType().isIntOrIndex());
   }
 };
 

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/SYCLToLLVM.cpp
@@ -1437,7 +1437,7 @@ public:
   using LoadMemberDimPattern<SYCLRangeGetOp, RangeGetDim>::LoadMemberDimPattern;
 
   LogicalResult match(SYCLRangeGetOp op) const final {
-    return success(isa<IntegerType>(op.getType()));
+    return success(op.getType().isIntOrIndex());
   }
 };
 

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
@@ -734,9 +734,8 @@ collectHoistableOperations(LoopLikeOpInterface loop,
     ArrayRef<AccessorPairType> accessorPairs =
         candidate.getRequireNoOverlapAccessorPairs();
     bool requireVersioning = !accessorPairs.empty();
-    // Currently only version for single accessor pair.
     bool willVersion = requireVersioning && EnableLICMSYCLAccessorVersioning &&
-                       numVersion < LICMVersionLimit &&
+                       isa<scf::ForOp>(loop) && numVersion < LICMVersionLimit &&
                        accessorPairs.size() <= LICMSYCLAccessorPairsLimit;
     if (willVersion)
       ++numVersion;

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
@@ -43,7 +43,7 @@ namespace polygeist {
 using namespace mlir;
 
 static llvm::cl::opt<bool> EnableLICMSYCLAccessorVersioning(
-    "enable-licm-sycl-accessor-versioning", llvm::cl::init(false),
+    "enable-licm-sycl-accessor-versioning", llvm::cl::init(true),
     llvm::cl::desc("Enable loop versioning for SYCL accessors in LICM"));
 
 static llvm::cl::opt<unsigned> LICMSYCLAccessorPairsLimit(


### PR DESCRIPTION
`SYCL-Bench - gramschmidt` improves 18% on `Intel(R) Iris(R) Xe Graphics`.
No regressions on other SYCL-Bench benchmarks.