### PR TITLE
[SYCL-MLIR] Fix CI failure

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -67,12 +67,3 @@ jobs:
       build_cache_suffix: "default"
       lts_matrix: ${{ needs.test_matrix.outputs.lts_lx_matrix }}
       lts_aws_matrix: ${{ needs.test_matrix.outputs.lts_aws_matrix }}
-
-  windows_default:
-    name: Windows
-    needs: test_matrix
-    if: github.repository == 'intel/llvm'
-    uses: ./.github/workflows/sycl_windows_build_and_test.yml
-    with:
-      lts_matrix: ${{ needs.test_matrix.outputs.lts_wn_matrix }}
-      build_ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
https://github.com/intel/llvm/commit/26e449331e0d60a80da9a0f572050f371214177f enables running Windows Build + LIT + E2E tests during pre-commit testing. 
As we only run E2E on `lts_config: "ocl_x64;ocl_gen9"` for SYCL-MLIR, we currently get the error below:
```
[SYCL Pre Commit: .github#L1](https://github.com/intel/llvm/pull/9029/files#annotation_10434356560)
Error when evaluating 'strategy' for job 'build'. intel/llvm/.github/workflows/sycl_windows_build_and_test.yml@a0b5cb7137aa7bbba94c742fedb5d631a7fab155 (Line: 28, Col: 9): Matrix must define at least one vector
```
We could add `win_l0_gen12` in `lts_config`, or remove `windows_default`. This PR removes `windows_default`.