### PR TITLE
[SYCL] Fix incorrect `sycl::vec<bool, N>` constructor behavior

### DIFF
--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -739,7 +739,7 @@ template <typename Type, int NumElements> class vec {
   template <size_t... Is>
   constexpr vec(const std::array<vec_data_t<DataT>, NumElements> &Arr,
                 std::index_sequence<Is...>)
-      : m_Data{Arr[Is]...} {}
+      : m_Data{vec_data_t<DataT>(static_cast<DataT>(Arr[Is]))...} {}
 
 public:
   using element_type = DataT;

--- a/sycl/test/basic_tests/vectors/vectors.cpp
+++ b/sycl/test/basic_tests/vectors/vectors.cpp
@@ -129,6 +129,7 @@ int main() {
   check_convert_from<sycl::half>();
   check_convert_from<float>();
   check_convert_from<double>();
+  check_convert_from<bool>();
 
   return 0;
 }


### PR DESCRIPTION
Update a `sycl::vec` constructor to ensure that element values are first converted to `DataT` before being stored as `vec_data_t<DataT>`. Add a test case that uses the updated constructor. Fixes bug from #8942.