### PR TITLE
[SYCL-MLIR] Fix warnings in polygeist

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/IR/Ops.cpp
+++ b/polygeist/lib/Dialect/Polygeist/IR/Ops.cpp
@@ -572,7 +572,7 @@ public:
     auto dims = srcMemRefType.getShape().size();
 
     // For now, restrict subview lowering to statically defined memref's
-    if (!srcMemRefType.hasStaticShape() | !resMemRefType.hasStaticShape())
+    if (!srcMemRefType.hasStaticShape() || !resMemRefType.hasStaticShape())
       return failure();
 
     // For now, restrict to simple rank-reducing indexing

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1416,15 +1416,11 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
 
     SmallVector<mlir::Type, 4> Types;
 
-    bool InnerLLVM = false;
-    bool InnerSYCL = false;
     if (CXRD) {
       for (auto F : CXRD->bases()) {
         bool SubRef = false;
         auto Ty = getMLIRTypeForMem(F.getType(), &SubRef, /*AllowMerge*/ false);
         assert(!SubRef);
-        InnerLLVM |= isa<LLVM::LLVMPointerType, LLVM::LLVMStructType,
-                         LLVM::LLVMArrayType>(Ty);
         Types.push_back(Ty);
       }
     }
@@ -1433,10 +1429,6 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
       bool SubRef = false;
       auto Ty = getMLIRTypeForMem(F->getType(), &SubRef, /*AllowMerge*/ false);
       assert(!SubRef);
-      InnerLLVM |=
-          isa<LLVM::LLVMPointerType, LLVM::LLVMStructType, LLVM::LLVMArrayType>(
-              Ty);
-      InnerSYCL |= mlir::sycl::isSYCLType(Ty);
       Types.push_back(Ty);
     }
 


### PR DESCRIPTION
```
polygeist/lib/Dialect/Polygeist/IR/Ops.cpp:575:9: warning: use of bitwise '|' with boolean operands [-Wbitwise-instead-of-logical]
    if (!srcMemRefType.hasStaticShape() | !resMemRefType.hasStaticShape())
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                        ||
```
Since https://github.com/intel/llvm/commit/645390978b316dc3ef4678ac431e24055ff13401, `InnerLLVM` and `InnerSYCL` are not used:
```
polygeist/lib/Dialect/Polygeist/IR/Ops.cpp:575:9: note: cast one or both operands to int to silence this warning
1 warning generated.
[6011/6074] Building CXX object tools/polygeist/tools/cgeist/CMakeFiles/cgeist.dir/Lib/CodeGenTypes.cc.o
/iusers/waihungt/llvm/polygeist/tools/cgeist/Lib/CodeGenTypes.cc:1419:10: warning: variable 'InnerLLVM' set but not used [-Wunused-but-set-variable]
    bool InnerLLVM = false;
         ^
polygeist/tools/cgeist/Lib/CodeGenTypes.cc:1420:10: warning: variable 'InnerSYCL' set but not used [-Wunused-but-set-variable]
    bool InnerSYCL = false;
         ^
```