### PR TITLE
[SYCL] Implement std::hash specializations for local_accessor and host_accessor.

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -3300,4 +3300,34 @@ struct hash<sycl::accessor<DataT, Dimensions, AccessMode, AccessTarget,
   }
 };
 
+template <typename DataT, int Dimensions, sycl::access_mode AccessMode>
+struct hash<sycl::host_accessor<DataT, Dimensions, AccessMode>> {
+  using AccType = sycl::host_accessor<DataT, Dimensions, AccessMode>;
+
+  size_t operator()(const AccType &A) const {
+#ifndef __SYCL_DEVICE_ONLY__
+    // getSyclObjImpl() here returns a pointer to either AccessorImplHost
+    auto AccImplPtr = sycl::detail::getSyclObjImpl(A);
+    return hash<decltype(AccImplPtr)>()(AccImplPtr);
+#endif
+  }
+};
+
+template <typename DataT, int Dimensions>
+struct hash<sycl::local_accessor<DataT, Dimensions>> {
+  using AccType = sycl::local_accessor<DataT, Dimensions>;
+
+  size_t operator()(const AccType &A) const {
+#ifdef __SYCL_DEVICE_ONLY__
+    // Hash is not supported on DEVICE. Just return 0 here.
+    (void)A;
+    return 0;
+#else
+    // getSyclObjImpl() here returns a pointer to LocalAccessorImplHost.
+    auto AccImplPtr = sycl::detail::getSyclObjImpl(A);
+    return hash<decltype(AccImplPtr)>()(AccImplPtr);
+#endif
+  }
+};
+
 } // namespace std

--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -3305,8 +3305,12 @@ struct hash<sycl::host_accessor<DataT, Dimensions, AccessMode>> {
   using AccType = sycl::host_accessor<DataT, Dimensions, AccessMode>;
 
   size_t operator()(const AccType &A) const {
-#ifndef __SYCL_DEVICE_ONLY__
-    // getSyclObjImpl() here returns a pointer to either AccessorImplHost
+#ifdef __SYCL_DEVICE_ONLY__
+    // Hash is not supported on DEVICE. Just return 0 here.
+    (void)A;
+    return 0;
+#else
+    // getSyclObjImpl() here returns a pointer to AccessorImplHost.
     auto AccImplPtr = sycl::detail::getSyclObjImpl(A);
     return hash<decltype(AccImplPtr)>()(AccImplPtr);
 #endif

--- a/sycl/test-e2e/Basic/accessor/accessor.cpp
+++ b/sycl/test-e2e/Basic/accessor/accessor.cpp
@@ -1096,5 +1096,44 @@ int main() {
     assert(Data == 64);
   }
 
+  // host_accessor hash
+  {
+    sycl::buffer<int> buffer1{sycl::range<1>{1}};
+    sycl::buffer<int> buffer2{sycl::range<1>{1}};
+    sycl::host_accessor<int> host_acc1{buffer1};
+    auto host_acc2(host_acc1);
+    sycl::host_accessor<int> host_acc3{buffer2};
+
+    auto host_acc1_hash = std::hash<sycl::host_accessor<int>>{}(host_acc1);
+    auto host_acc2_hash = std::hash<sycl::host_accessor<int>>{}(host_acc2);
+    auto host_acc3_hash = std::hash<sycl::host_accessor<int>>{}(host_acc3);
+
+    assert(host_acc1_hash == host_acc2_hash && "Identical hash expected.");
+    assert(host_acc1_hash != host_acc3_hash &&
+           "Identical hash was not expected.");
+  }
+
+  // local_accessor hash
+  {
+    sycl::queue queue;
+
+    queue.submit([&](sycl::handler &cgh) {
+      sycl::local_accessor<int, 1> local_acc1(1, cgh);
+      auto local_acc2 = local_acc1;
+      sycl::local_accessor<int, 1> local_acc3(1, cgh);
+
+      auto local_acc1_hash =
+          std::hash<sycl::local_accessor<int, 1>>{}(local_acc1);
+      auto local_acc2_hash =
+          std::hash<sycl::local_accessor<int, 1>>{}(local_acc2);
+      auto local_acc3_hash =
+          std::hash<sycl::local_accessor<int, 1>>{}(local_acc3);
+
+      assert(local_acc1_hash == local_acc2_hash && "Identical hash expected.");
+      assert(local_acc1_hash != local_acc3_hash &&
+             "Identical hash was not expected.");
+    });
+  }
+
   std::cout << "Test passed" << std::endl;
 }


### PR DESCRIPTION
-  Implements std::hash specializations for local_accessor and host_accessor.
- Adds test