### PR TITLE
Revert "[ESIMD] Reenable the thread_id test after CI was updated"

### DIFF
--- a/sycl/test-e2e/ESIMD/thread_id_test.cpp
+++ b/sycl/test-e2e/ESIMD/thread_id_test.cpp
@@ -2,7 +2,7 @@
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
-// XFAIL: gpu && !esimd_emulator
+// XFAIL: linux && gpu && !esimd_emulator
 //==- thread_id_test.cpp - Test to verify thread id functionlity-==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/ESIMD/thread_id_test.cpp
+++ b/sycl/test-e2e/ESIMD/thread_id_test.cpp
@@ -2,6 +2,7 @@
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
+// XFAIL: gpu && !esimd_emulator
 //==- thread_id_test.cpp - Test to verify thread id functionlity-==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -11,6 +12,8 @@
 //===----------------------------------------------------------------------===//
 
 // This is basic test to validate thread id functions.
+// TODO: Enable the test once the GPU RT supporting the functionality reaches
+// the CI
 
 #include <cmath>
 #include <iostream>


### PR DESCRIPTION
Reverts intel/llvm#9037