### PR TITLE
[SYCL-MLIR] Enable omit optional `MangledFunctionName` field by default

### DIFF
--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -223,7 +223,7 @@ static llvm::cl::opt<std::string> McpuOpt("mcpu", llvm::cl::init(""),
                                           llvm::cl::cat(ToolOptions));
 
 llvm::cl::opt<bool> OmitOptionalMangledFunctionName(
-    "no-mangled-function-name", llvm::cl::init(false),
+    "no-mangled-function-name", llvm::cl::init(true),
     llvm::cl::desc("Whether to omit optional \"MangledFunctionName\" fields"));
 
 #endif /* CGEIST_OPTIONS_H_ */

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -1,10 +1,7 @@
 // RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - -Xcgeist -no-mangled-function-name | FileCheck %s --check-prefix=CHECK-MLIR-NO-MANGLED-FUNCTION-NAME
-// RUN: clang++ -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-llvm %s -o %t -Xcgeist -no-mangled-function-name && rm %t
+// RUN: clang++ -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-llvm %s -o %t && rm %t
 
 #include <sycl/sycl.hpp>
-
-// CHECK-MLIR-NO-MANGLED-FUNCTION-NAME-NOT: {{^(sycl\.constructor|sycl\.call){,0}.*}} MangledFunctionName
 
 // CHECK-MLIR-DAG: !sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
 // CHECK-MLIR-DAG: !sycl_array_2_ = !sycl.array<[2], (memref<2xi64, 4>)>
@@ -28,11 +25,11 @@ template <typename T> SYCL_EXTERNAL void keep(T);
 // COM: Commenting out the checks below, this is the code that should be
 // generated. Currently the DPC++ SYCL RT implementation of
 // accessor::get_pointer is non-conforming. Once that problem is fixed we
-// enable the checks below (with the MangledFunctionName fixed).
+// enable the checks below.
 
 // COM-MLIR-LABEL: func.func @_Z20accessor_get_pointerN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
 // COM-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef})
-// COM-MLIR: %{{.*}} = sycl.accessor.get_pointer(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>], FunctionName = @get_pointer, MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE11get_pointerILS4_2014EvEENS0_9IiLNS2_13address_spaceE1ELNS2_9decoratedE2EEEv, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> memref<?xi32, 1>
+// COM-MLIR: %{{.*}} = sycl.accessor.get_pointer(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>], FunctionName = @get_pointer, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> memref<?xi32, 1>
 
 SYCL_EXTERNAL void accessor_get_pointer(sycl::accessor<sycl::cl_int, 2> acc) {
   keep(acc.get_pointer());
@@ -40,7 +37,7 @@ SYCL_EXTERNAL void accessor_get_pointer(sycl::accessor<sycl::cl_int, 2> acc) {
 
 // CHECK-MLIR-LABEL: func.func @_Z18accessor_get_rangeN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.get_range(%arg0) {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>], FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE9get_rangeILi2EvEENS0_5rangeILi2EEEv, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> !sycl_range_2_
+// CHECK-MLIR: %{{.*}} = sycl.accessor.get_range(%arg0) {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>], FunctionName = @get_range, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> !sycl_range_2_
 
 SYCL_EXTERNAL void accessor_get_range(sycl::accessor<sycl::cl_int, 2> acc) {
   keep(acc.get_range());
@@ -48,7 +45,7 @@ SYCL_EXTERNAL void accessor_get_range(sycl::accessor<sycl::cl_int, 2> acc) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13accessor_sizeN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.size(%arg0) {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>], FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE4sizeEv, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.accessor.size(%arg0) {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>], FunctionName = @size, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> i64
 
 SYCL_EXTERNAL void accessor_size(sycl::accessor<sycl::cl_int, 2> acc) {
   keep(acc.size());
@@ -57,7 +54,7 @@ SYCL_EXTERNAL void accessor_size(sycl::accessor<sycl::cl_int, 2> acc) {
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_0N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEENS0_2idILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef}, 
 // CHECK_MLIR_SAME:      %{{.*}}: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl_id_2_>], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEERiNS0_2idILi2EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl_id_2_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
 
 SYCL_EXTERNAL void accessor_subscript_operator_0(sycl::accessor<sycl::cl_int, 2> acc, sycl::id<2> index) {
   keep(acc[index]);
@@ -65,7 +62,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_0(sycl::accessor<sycl::cl_int, 2>
 
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_1N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK_MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb>, %{{.*}}: i64)
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>, i64], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi2EvEEDam, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>, i64) -> ![[ACC_SUBSCRIPT]]
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>, i64], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>, i64) -> ![[ACC_SUBSCRIPT]]
 
 SYCL_EXTERNAL void accessor_subscript_operator_1(sycl::accessor<sycl::cl_int, 2> acc, size_t index) {
   keep(acc[index]);
@@ -74,7 +71,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_1(sycl::accessor<sycl::cl_int, 2>
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_2N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_1_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_1_i32_rw_gb, llvm.noundef}, 
 // CHECK-MLIR-SAME:      %{{.*}}: i64 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERiNS0_2idILi1EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
 
 SYCL_EXTERNAL void accessor_subscript_operator_2(sycl::accessor<sycl::cl_int, 1> acc, size_t index) {
   keep(acc[index]);
@@ -83,7 +80,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_2(sycl::accessor<sycl::cl_int, 1>
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_3N4sycl3_V18accessorI6StructLi1ELNS0_6access4modeE1026ELNS3_6targetE2014ELNS3_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-MLIR:          %{{.*}}: memref<?x![[ACC_STRUCT]]> {llvm.align = 8 : i64, llvm.byval = ![[ACC_STRUCT]], llvm.noundef}, 
 // CHECK-MLIR-SAME:     %{{.*}}: i64 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x![[ACC_STRUCT]], 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorI6StructLi1ELNS0_6access4modeE1026ELNS3_6targetE2014ELNS3_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERS2_NS0_2idILi1EEE, TypeName = @accessor} : (memref<?x![[ACC_STRUCT]]>, memref<?x!sycl_id_1_>) -> !llvm.ptr<struct<(i32)>, 4> 
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x![[ACC_STRUCT]], 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x![[ACC_STRUCT]]>, memref<?x!sycl_id_1_>) -> !llvm.ptr<struct<(i32)>, 4> 
 
 typedef struct {
   unsigned field;
@@ -95,7 +92,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_3(sycl::accessor<Struct, 1> acc, 
 // CHECK-MLIR-LABEL: func.func @_Z11range_get_0N4sycl3_V15rangeILi2EEEi(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef}, 
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_range_2_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, TypeName = @array} : (memref<?x!sycl_range_2_>, i32) -> i64
 
 SYCL_EXTERNAL void range_get_0(sycl::range<2> r, int dimension) {
   keep(r.get(dimension));
@@ -104,7 +101,7 @@ SYCL_EXTERNAL void range_get_0(sycl::range<2> r, int dimension) {
 // CHECK-MLIR-LABEL: func.func @_Z11range_get_1N4sycl3_V15rangeILi2EEEi(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef}
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZN4sycl3_V16detail5arrayILi2EEixEi, TypeName = @array} : (memref<?x!sycl_range_2_>, i32) -> memref<?xi64, 4>
+// CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @"operator[]", TypeName = @array} : (memref<?x!sycl_range_2_>, i32) -> memref<?xi64, 4>
 
 
 SYCL_EXTERNAL void range_get_1(sycl::range<2> r, int dimension) {
@@ -114,7 +111,7 @@ SYCL_EXTERNAL void range_get_1(sycl::range<2> r, int dimension) {
 // CHECK-MLIR-LABEL: func.func @_Z11range_get_2N4sycl3_V15rangeILi2EEEi(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef}
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EEixEi, TypeName = @array} : (memref<?x!sycl_range_2_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @"operator[]", TypeName = @array} : (memref<?x!sycl_range_2_>, i32) -> i64
 
 SYCL_EXTERNAL void range_get_2(const sycl::range<2> r, int dimension) {
   keep(r[dimension]);
@@ -122,7 +119,7 @@ SYCL_EXTERNAL void range_get_2(const sycl::range<2> r, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z10range_sizeN4sycl3_V15rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.range.size(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_range_2_, 4>], FunctionName = @size, MangledFunctionName = @_ZNK4sycl3_V15rangeILi2EE4sizeEv, TypeName = @range} : (memref<?x!sycl_range_2_>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.range.size(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_range_2_, 4>], FunctionName = @size, TypeName = @range} : (memref<?x!sycl_range_2_>) -> i64
 
 
 SYCL_EXTERNAL void range_size(sycl::range<2> r) {
@@ -131,7 +128,7 @@ SYCL_EXTERNAL void range_size(sycl::range<2> r) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_range_get_global_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_range.get_global_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_range_2_, 4>], FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_>) -> !sycl_range_2_
+// CHECK-MLIR: %{{.*}} = sycl.nd_range.get_global_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_range_2_, 4>], FunctionName = @get_global_range, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_>) -> !sycl_range_2_
 
 // CHECK-MLIR:           func.func @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv(%[[VAL_0:.*]]: memref<?x!sycl_nd_range_2_, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 48 : i64, llvm.noundef}) -> !sycl_range_2_
 // CHECK-MLIR-NEXT:             %[[VAL_1:.*]] = arith.constant 0 : index
@@ -150,7 +147,7 @@ SYCL_EXTERNAL void nd_range_get_global_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-MLIR-LABEL: func.func @_Z24nd_range_get_local_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_range.get_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_range_2_, 4>], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE15get_local_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_>) -> !sycl_range_2_
+// CHECK-MLIR: %{{.*}} = sycl.nd_range.get_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_range_2_, 4>], FunctionName = @get_local_range, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_>) -> !sycl_range_2_
 
 SYCL_EXTERNAL void nd_range_get_local_range(sycl::nd_range<2> nd_range) {
   keep(nd_range.get_local_range());
@@ -158,7 +155,7 @@ SYCL_EXTERNAL void nd_range_get_local_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-MLIR-LABEL: func.func @_Z24nd_range_get_group_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_range.get_group_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_range_2_, 4>], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V18nd_rangeILi2EE15get_group_rangeEv, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_>) -> !sycl_range_2_
+// CHECK-MLIR: %{{.*}} = sycl.nd_range.get_group_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_range_2_, 4>], FunctionName = @get_group_range, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_>) -> !sycl_range_2_
 
 SYCL_EXTERNAL void nd_range_get_group_range(sycl::nd_range<2> nd_range) {
   keep(nd_range.get_group_range());
@@ -166,7 +163,7 @@ SYCL_EXTERNAL void nd_range_get_group_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_0N4sycl3_V12idILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] {ArgumentTypes = [memref<?x!sycl_array_1_, 4>, i32], FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi1EE3getEi, TypeName = @array} : (memref<?x!sycl_id_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] {ArgumentTypes = [memref<?x!sycl_array_1_, 4>, i32], FunctionName = @get, TypeName = @array} : (memref<?x!sycl_id_1_>, i32) -> i64
 
 SYCL_EXTERNAL void id_get_0(sycl::id<1> id, int dimension) {
   keep(id.get(dimension));
@@ -174,7 +171,7 @@ SYCL_EXTERNAL void id_get_0(sycl::id<1> id, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_1N4sycl3_V12idILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})  
-// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] {ArgumentTypes = [memref<?x!sycl_array_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZN4sycl3_V16detail5arrayILi1EEixEi, TypeName = @array} : (memref<?x!sycl_id_1_>, i32) -> memref<?xi64, 4>
+// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] {ArgumentTypes = [memref<?x!sycl_array_1_, 4>, i32], FunctionName = @"operator[]", TypeName = @array} : (memref<?x!sycl_id_1_>, i32) -> memref<?xi64, 4>
 
 SYCL_EXTERNAL void id_get_1(sycl::id<1> id, int dimension) {
   keep(id[dimension]);
@@ -182,7 +179,7 @@ SYCL_EXTERNAL void id_get_1(sycl::id<1> id, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_2N4sycl3_V12idILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})    
-// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] {ArgumentTypes = [memref<?x!sycl_array_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi1EEixEi, TypeName = @array} : (memref<?x!sycl_id_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] {ArgumentTypes = [memref<?x!sycl_array_1_, 4>, i32], FunctionName = @"operator[]", TypeName = @array} : (memref<?x!sycl_id_1_>, i32) -> i64
 
 SYCL_EXTERNAL void id_get_2(const sycl::id<1> id, int dimension) {
   keep(id[dimension]);
@@ -190,7 +187,7 @@ SYCL_EXTERNAL void id_get_2(const sycl::id<1> id, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_3N4sycl3_V12idILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}
-// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[] {ArgumentTypes = [memref<?x!sycl_id_1_, 4>], FunctionName = @"operator unsigned long", MangledFunctionName = @_ZNK4sycl3_V12idILi1EEcvmEv, TypeName = @id} : (memref<?x!sycl_id_1_>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[] {ArgumentTypes = [memref<?x!sycl_id_1_, 4>], FunctionName = @"operator unsigned long", TypeName = @id} : (memref<?x!sycl_id_1_>) -> i64
 
 SYCL_EXTERNAL void id_get_3(sycl::id<1> id) {
   keep(static_cast<size_t>(id));
@@ -198,7 +195,7 @@ SYCL_EXTERNAL void id_get_3(sycl::id<1> id) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEv, TypeName = @item} : (memref<?x![[ITEM1]]>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @get_id, TypeName = @item} : (memref<?x![[ITEM1]]>) -> !sycl_id_1_
 
 SYCL_EXTERNAL void item_get_id_0(sycl::item<1> item) {
   keep(item.get_id());
@@ -206,7 +203,7 @@ SYCL_EXTERNAL void item_get_id_0(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_1N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x![[ITEM1]], 4>, i32], FunctionName = @get_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE6get_idEi, TypeName = @item} : (memref<?x![[ITEM1]]>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x![[ITEM1]], 4>, i32], FunctionName = @get_id, TypeName = @item} : (memref<?x![[ITEM1]]>, i32) -> i64
 
 SYCL_EXTERNAL void item_get_id_1(sycl::item<1> item, int dimension) {
   keep(item.get_id(dimension));
@@ -214,7 +211,7 @@ SYCL_EXTERNAL void item_get_id_1(sycl::item<1> item, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_2N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x![[ITEM1]], 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EEixEi, TypeName = @item} : (memref<?x![[ITEM1]]>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x![[ITEM1]], 4>, i32], FunctionName = @"operator[]", TypeName = @item} : (memref<?x![[ITEM1]]>, i32) -> i64
 
 SYCL_EXTERNAL void item_get_id_2(sycl::item<1> item, int dimension) {
   keep(item[dimension]);
@@ -222,7 +219,7 @@ SYCL_EXTERNAL void item_get_id_2(sycl::item<1> item, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_3N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @"operator unsigned long", MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EEcvmEv, TypeName = @item} : (memref<?x![[ITEM1]]>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @"operator unsigned long", TypeName = @item} : (memref<?x![[ITEM1]]>) -> i64
 
 SYCL_EXTERNAL void item_get_id_3(sycl::item<1> item) {
   keep(static_cast<size_t>(item));
@@ -230,7 +227,7 @@ SYCL_EXTERNAL void item_get_id_3(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z16item_get_range_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_range(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEv, TypeName = @item} : (memref<?x![[ITEM1]]>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.item.get_range(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @get_range, TypeName = @item} : (memref<?x![[ITEM1]]>) -> !sycl_range_1_
 
 SYCL_EXTERNAL void item_get_range_0(sycl::item<1> item) {
   keep(item.get_range());
@@ -238,7 +235,7 @@ SYCL_EXTERNAL void item_get_range_0(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z16item_get_range_1N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x![[ITEM1]], 4>, i32], FunctionName = @get_range, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE9get_rangeEi, TypeName = @item} : (memref<?x![[ITEM1]]>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.item.get_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x![[ITEM1]], 4>, i32], FunctionName = @get_range, TypeName = @item} : (memref<?x![[ITEM1]]>, i32) -> i64
 
 SYCL_EXTERNAL void item_get_range_1(sycl::item<1> item, int dimension) {
   keep(item.get_range(dimension));
@@ -246,7 +243,7 @@ SYCL_EXTERNAL void item_get_range_1(sycl::item<1> item, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z18item_get_linear_idN4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @get_linear_id, MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EE13get_linear_idEv, TypeName = @item} : (memref<?x![[ITEM1]]>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.item.get_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @get_linear_id, TypeName = @item} : (memref<?x![[ITEM1]]>) -> i64
 
 SYCL_EXTERNAL void item_get_linear_id(sycl::item<1> item) {
   keep(item.get_linear_id());
@@ -254,7 +251,7 @@ SYCL_EXTERNAL void item_get_linear_id(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23nd_item_get_global_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_global_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_global_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
 
 SYCL_EXTERNAL void nd_item_get_global_id_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_global_id());
@@ -262,7 +259,7 @@ SYCL_EXTERNAL void nd_item_get_global_id_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23nd_item_get_global_id_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_global_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE13get_global_idEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_global_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
 
 SYCL_EXTERNAL void nd_item_get_global_id_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_global_id(dimension));
@@ -270,7 +267,7 @@ SYCL_EXTERNAL void nd_item_get_global_id_1(sycl::nd_item<1> nd_item, int dimensi
 
 // CHECK-MLIR-LABEL: func.func @_Z28nd_item_get_global_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_global_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE20get_global_linear_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_global_linear_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> i64
 
 SYCL_EXTERNAL void nd_item_get_global_linear_id(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_global_linear_id());
@@ -278,7 +275,7 @@ SYCL_EXTERNAL void nd_item_get_global_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z22nd_item_get_local_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_local_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
 
 SYCL_EXTERNAL void nd_item_get_local_id_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_local_id());
@@ -286,7 +283,7 @@ SYCL_EXTERNAL void nd_item_get_local_id_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z22nd_item_get_local_id_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_local_idEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_local_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
 
 SYCL_EXTERNAL void nd_item_get_local_id_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_local_id(dimension));
@@ -294,7 +291,7 @@ SYCL_EXTERNAL void nd_item_get_local_id_1(sycl::nd_item<1> nd_item, int dimensio
 
 // CHECK-MLIR-LABEL: func.func @_Z27nd_item_get_local_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_local_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE19get_local_linear_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_local_linear_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> i64
 
 SYCL_EXTERNAL void nd_item_get_local_linear_id(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_local_linear_id());
@@ -302,7 +299,7 @@ SYCL_EXTERNAL void nd_item_get_local_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z19nd_item_get_group_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})  
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_group, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_group_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_group, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_group_1_
 
 SYCL_EXTERNAL void nd_item_get_group_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_group());
@@ -310,7 +307,7 @@ SYCL_EXTERNAL void nd_item_get_group_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z19nd_item_get_group_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_group, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE9get_groupEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_group, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
 
 SYCL_EXTERNAL void nd_item_get_group_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_group(dimension));
@@ -318,7 +315,7 @@ SYCL_EXTERNAL void nd_item_get_group_1(sycl::nd_item<1> nd_item, int dimension) 
 
 // CHECK-MLIR-LABEL: func.func @_Z27nd_item_get_group_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_group_linear_id, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE19get_group_linear_idEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_group_linear_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> i64
 
 SYCL_EXTERNAL void nd_item_get_group_linear_id(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_group_linear_id());
@@ -326,7 +323,7 @@ SYCL_EXTERNAL void nd_item_get_group_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_group_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_group_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
 
 SYCL_EXTERNAL void nd_item_get_group_range_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_group_range());
@@ -334,7 +331,7 @@ SYCL_EXTERNAL void nd_item_get_group_range_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_group_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_group_rangeEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_group_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
 
 SYCL_EXTERNAL void nd_item_get_group_range_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_group_range(dimension));
@@ -342,7 +339,7 @@ SYCL_EXTERNAL void nd_item_get_group_range_1(sycl::nd_item<1> nd_item, int dimen
 
 // CHECK-MLIR-LABEL: func.func @_Z26nd_item_get_global_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_global_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
 
 SYCL_EXTERNAL void nd_item_get_global_range_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_global_range());
@@ -350,7 +347,7 @@ SYCL_EXTERNAL void nd_item_get_global_range_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z26nd_item_get_global_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_global_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE16get_global_rangeEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_global_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
 
 SYCL_EXTERNAL void nd_item_get_global_range_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_global_range(dimension));
@@ -358,7 +355,7 @@ SYCL_EXTERNAL void nd_item_get_global_range_1(sycl::nd_item<1> nd_item, int dime
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_local_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_local_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
 
 SYCL_EXTERNAL void nd_item_get_local_range_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_local_range());
@@ -366,7 +363,7 @@ SYCL_EXTERNAL void nd_item_get_local_range_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_local_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE15get_local_rangeEi, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_local_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
 
 SYCL_EXTERNAL void nd_item_get_local_range_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_local_range(dimension));
@@ -374,7 +371,7 @@ SYCL_EXTERNAL void nd_item_get_local_range_1(sycl::nd_item<1> nd_item, int dimen
 
 // CHECK-MLIR-LABEL: func.func @_Z20nd_item_get_nd_rangeN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_nd_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_nd_range, MangledFunctionName = @_ZNK4sycl3_V17nd_itemILi1EE12get_nd_rangeEv, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_nd_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_nd_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_nd_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_nd_range_1_
 
 SYCL_EXTERNAL void nd_item_get_nd_range(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_nd_range());
@@ -382,7 +379,7 @@ SYCL_EXTERNAL void nd_item_get_nd_range(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_group_idEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_id, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
 
 SYCL_EXTERNAL void group_get_group_id_0(sycl::group<1> group) {
   keep(group.get_group_id());
@@ -390,7 +387,7 @@ SYCL_EXTERNAL void group_get_group_id_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_group_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_group_idEi, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_group_id, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
 
 SYCL_EXTERNAL void group_get_group_id_1(sycl::group<1> group, int dimension) {
   keep(group.get_group_id(dimension));
@@ -398,7 +395,7 @@ SYCL_EXTERNAL void group_get_group_id_1(sycl::group<1> group, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_2N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V15groupILi1EEixEi, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @"operator[]", TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
 
 SYCL_EXTERNAL void group_get_group_id_2(sycl::group<1> group, int dimension) {
   keep(group[dimension]);
@@ -406,7 +403,7 @@ SYCL_EXTERNAL void group_get_group_id_2(sycl::group<1> group, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_local_id_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_local_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_local_idEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = sycl.group.get_local_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_id, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
 
 SYCL_EXTERNAL void group_get_local_id_0(sycl::group<1> group) {
   keep(group.get_local_id());
@@ -414,7 +411,7 @@ SYCL_EXTERNAL void group_get_local_id_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_local_id_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_local_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_local_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE12get_local_idEi, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_local_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_local_id, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
 
 SYCL_EXTERNAL void group_get_local_id_1(sycl::group<1> group, int dimension) {
   keep(group.get_local_id(dimension));
@@ -422,7 +419,7 @@ SYCL_EXTERNAL void group_get_local_id_1(sycl::group<1> group, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_local_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}
-// CHECK-MLIR: %{{.*}} = sycl.group.get_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.group.get_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_range, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
 
 SYCL_EXTERNAL void group_get_local_range_0(sycl::group<1> group) {
   keep(group.get_local_range());
@@ -430,7 +427,7 @@ SYCL_EXTERNAL void group_get_local_range_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_local_range_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_local_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_local_rangeEi, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_local_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_local_range, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
 
 SYCL_EXTERNAL void group_get_local_range_1(sycl::group<1> group, int dimension) {
   keep(group.get_local_range(dimension));
@@ -438,7 +435,7 @@ SYCL_EXTERNAL void group_get_local_range_1(sycl::group<1> group, int dimension) 
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_group_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}  
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_range, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
 
 SYCL_EXTERNAL void group_get_group_range_0(sycl::group<1> group) {
   keep(group.get_group_range());
@@ -446,7 +443,7 @@ SYCL_EXTERNAL void group_get_group_range_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_group_range_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}    
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_group_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE15get_group_rangeEi, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_group_range, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
 
 SYCL_EXTERNAL void group_get_group_range_1(sycl::group<1> group, int dimension) {
   keep(group.get_group_range(dimension));
@@ -454,7 +451,7 @@ SYCL_EXTERNAL void group_get_group_range_1(sycl::group<1> group, int dimension) 
 
 // CHECK-MLIR-LABEL: func.func @_Z25group_get_max_local_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}      
-// CHECK-MLIR: %{{.*}} = sycl.group.get_max_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_max_local_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_max_local_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.group.get_max_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_max_local_range, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
 
 SYCL_EXTERNAL void group_get_max_local_range(sycl::group<1> group) {
   keep(group.get_max_local_range());
@@ -462,7 +459,7 @@ SYCL_EXTERNAL void group_get_max_local_range(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25group_get_group_linear_idN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}        
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_linear_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_group_linear_idEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_linear_id, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
 
 SYCL_EXTERNAL void group_get_group_linear_id(sycl::group<1> group) {
   keep(group.get_group_linear_id());
@@ -470,7 +467,7 @@ SYCL_EXTERNAL void group_get_group_linear_id(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25group_get_local_linear_idN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}          
-// CHECK-MLIR: %{{.*}} = sycl.group.get_local_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_linear_id, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE19get_local_linear_idEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_local_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_linear_id, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
 
 SYCL_EXTERNAL void group_get_local_linear_id(sycl::group<1> group) {
   keep(group.get_local_linear_id());
@@ -478,7 +475,7 @@ SYCL_EXTERNAL void group_get_local_linear_id(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z28group_get_group_linear_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}            
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_linear_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_linear_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE22get_group_linear_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_linear_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_linear_range, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
 
 SYCL_EXTERNAL void group_get_group_linear_range(sycl::group<1> group) {
   keep(group.get_group_linear_range());
@@ -486,7 +483,7 @@ SYCL_EXTERNAL void group_get_group_linear_range(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z28group_get_local_linear_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_local_linear_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_linear_range, MangledFunctionName = @_ZNK4sycl3_V15groupILi1EE22get_local_linear_rangeEv, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_local_linear_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_linear_range, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
 
 SYCL_EXTERNAL void group_get_local_linear_range(sycl::group<1> group) {
   keep(group.get_local_linear_range());
@@ -519,8 +516,8 @@ SYCL_EXTERNAL void op_1(sycl::id<2> a, sycl::id<2> b) {
 // CHECK-MLIR:         %arg0: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef}, %arg1: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})
 // CHECK-MLIR-NEXT: %c1_i32 = arith.constant 1 : i32
 // CHECK-MLIR-NEXT: %c0_i32 = arith.constant 0 : i32
-// CHECK-MLIR-NEXT: %0 = sycl.id.get %arg0[%c0_i32] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_id_2_>, i32) -> i64
-// CHECK-MLIR-NEXT: %1 = sycl.id.get %arg0[%c1_i32] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, MangledFunctionName = @_ZNK4sycl3_V16detail5arrayILi2EE3getEi, TypeName = @array} : (memref<?x!sycl_id_2_>, i32) -> i64
+// CHECK-MLIR-NEXT: %0 = sycl.id.get %arg0[%c0_i32] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, TypeName = @array} : (memref<?x!sycl_id_2_>, i32) -> i64
+// CHECK-MLIR-NEXT: %1 = sycl.id.get %arg0[%c1_i32] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, TypeName = @array} : (memref<?x!sycl_id_2_>, i32) -> i64
 // CHECK-MLIR-NEXT: %2 = arith.addi %0, %1 : i64
 // CHECK-MLIR-NEXT: %3 = sycl.call @abs(%2) {MangledFunctionName = @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_} : (i64) -> i64
 // CHECK-MLIR-NEXT: return

--- a/polygeist/tools/cgeist/Test/Verification/sycl/image.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/image.cpp
@@ -18,7 +18,7 @@ static constexpr unsigned N = 8;
 // CHECK-DAG:     %0 = llvm.mlir.undef : i32
 // CHECK-NEXT:    affine.store %0, %alloca[0] : memref<1xi32>
 // CHECK-NEXT:    %1 = "polygeist.memref2pointer"(%arg0) : (memref<?x!llvm.struct<(!sycl_accessor_1_21sycl2Evec3C5Bf322C_45D2C_28vector3C4xf323E293E_r_i)>, 4>) -> !llvm.ptr<struct<(ptr<struct<"opencl.image1d_ro_t", opaque>, 1>, array<24 x i8>)>, 4>
-// CHECK-NEXT:    %2 = sycl.item.get_id(%arg1, %c0_i32) {ArgumentTypes = [memref<?x!sycl_item_1_, 4>, i32], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V14itemILi1ELb1EEixEi, TypeName = @item} : (memref<?x!sycl_item_1_>, i32) -> i64
+// CHECK-NEXT:    %2 = sycl.item.get_id(%arg1, %c0_i32) {ArgumentTypes = [memref<?x!sycl_item_1_, 4>, i32], FunctionName = @"operator[]", TypeName = @item} : (memref<?x!sycl_item_1_>, i32) -> i64
 // CHECK-NEXT:    %3 = arith.trunci %2 : i64 to i32
 // CHECK-NEXT:    %memspacecast = memref.memory_space_cast %cast : memref<?xi32> to memref<?xi32, 4>
 // CHECK-NEXT:    affine.store %3, %memspacecast[0] : memref<?xi32, 4>


### PR DESCRIPTION
`MangledFunctionName` field is currently not used as `SYCLMethodOp` don't turn into calls.