### PR TITLE
[CI] Skip Windows checks if linter fails

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -69,7 +69,7 @@ jobs:
 
   windows_default:
     name: Windows
-    needs: test_matrix
+    needs: [lint, test_matrix]
     if: github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl_windows_build_and_test.yml
     with:


### PR DESCRIPTION
Align Windows checks behavior with Linux i.e. don't run build and testing if lint check fails.