### PR TITLE
[SYCL-MLIR][ArgumentPromotion] Operations without MemoryEffectOpInterface have unknown memory effect

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Transforms/ArgumentPromotion.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/ArgumentPromotion.cpp
@@ -101,6 +101,8 @@ static bool existsSideEffectAfter(Value val, Operation *startOp,
     if (op.isBeforeInBlock(startOp) || isMemoryEffectFree(&op))
       continue;
 
+    // An operation with unknown side effects is conservatively assumed to have
+    // a side effect on `val`.
     auto MEI = dyn_cast<MemoryEffectOpInterface>(op);
     if (!MEI)
       return true;

--- a/polygeist/lib/Dialect/Polygeist/Transforms/ArgumentPromotion.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/ArgumentPromotion.cpp
@@ -98,9 +98,12 @@ static bool existsSideEffectAfter(Value val, Operation *startOp,
   assert(startOp && "Expecting a valid pointer");
 
   for (Operation &op : *startOp->getBlock()) {
-    auto MEI = dyn_cast<MemoryEffectOpInterface>(op);
-    if (op.isBeforeInBlock(startOp) || isMemoryEffectFree(&op) || !MEI)
+    if (op.isBeforeInBlock(startOp) || isMemoryEffectFree(&op))
       continue;
+
+    auto MEI = dyn_cast<MemoryEffectOpInterface>(op);
+    if (!MEI)
+      return true;
 
     // Conservatively assume an operation with a nested region has side effects
     // on 'val'.


### PR DESCRIPTION
Operations without `MemoryEffectOpInterface` have unknown memory effect, so `existsSideEffectAfter()` should conservatively return true.