### PR TITLE
[SYCL-MLIR][DetectReduction] Disallow transformation when exists may alias operations in loop

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.h
@@ -38,6 +38,8 @@ std::unique_ptr<Pass> createCPUifyPass();
 std::unique_ptr<Pass> createCPUifyPass(const SCFCPUifyOptions &options);
 std::unique_ptr<Pass> createCanonicalizeForPass();
 std::unique_ptr<Pass> createDetectReductionPass();
+std::unique_ptr<Pass>
+createDetectReductionPass(const DetectReductionOptions &options);
 std::unique_ptr<Pass> createInnerSerializationPass();
 std::unique_ptr<Pass> createKernelDisjointSpecializationPass();
 std::unique_ptr<Pass> createKernelDisjointSpecializationPass(

--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
@@ -45,6 +45,11 @@ def ArgumentPromotion : Pass<"arg-promotion", "mlir::ModuleOp"> {
 def DetectReduction : Pass<"detect-reduction"> {
   let summary = "Detect array reduction operations in a loop";
   let constructor = "mlir::polygeist::createDetectReductionPass()";
+  let options = [
+    Option<"relaxedAliasing", "relaxed-aliasing", "bool", 
+           /*default=*/"false", 
+           "Whether to use strict aliasing (i.e. type-based aliasing) rules or not">
+  ];
   let statistics = [
     Statistic<"numReductions", "num-reductions", "Number of reductions detected">
   ];

--- a/polygeist/lib/Dialect/Polygeist/Transforms/DetectReduction.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/DetectReduction.cpp
@@ -377,24 +377,12 @@ private:
       Operation *MayAliasOp = nullptr;
       if (Loop.getLoopBody()
               .walk([&](Operation *Op) {
-                if (isMemoryEffectFree(Op) || Op == Load ||
-                    Op == CandidateStores[0] ||
+                if (Op == Load || Op == CandidateStores[0] ||
                     llvm::find(OtherLoads, Op) != OtherLoads.end())
                   return WalkResult::advance();
-
-                auto MEI = dyn_cast<MemoryEffectOpInterface>(Op);
-                if (!MEI || Op->hasTrait<OpTrait::HasRecursiveMemoryEffects>())
+                if (hasMayAliasEffects(Load, *Op, aliasAnalysis)) {
+                  MayAliasOp = Op;
                   return WalkResult::interrupt();
-
-                SmallVector<MemoryEffects::EffectInstance> effects;
-                MEI.getEffects(effects);
-                for (MemoryEffects::EffectInstance &effect : effects) {
-                  Value EffectVal = effect.getValue();
-                  if (!aliasAnalysis.alias(Load.getMemRef(), EffectVal)
-                           .isNo()) {
-                    MayAliasOp = Op;
-                    return WalkResult::interrupt();
-                  }
                 }
                 return WalkResult::advance();
               })
@@ -422,6 +410,27 @@ private:
     });
 
     return Result;
+  }
+
+  /// Return true if \p Op has memory effects that may alias with the memory
+  /// loaded from \p Load, return false otherwise.
+  static bool hasMayAliasEffects(AffineLoadOp &Load, Operation &Op,
+                                 AliasAnalysis &aliasAnalysis) {
+    if (isMemoryEffectFree(&Op))
+      return false;
+
+    auto MEI = dyn_cast<MemoryEffectOpInterface>(Op);
+    if (!MEI || Op.hasTrait<OpTrait::HasRecursiveMemoryEffects>())
+      return true;
+
+    SmallVector<MemoryEffects::EffectInstance> effects;
+    MEI.getEffects(effects);
+    for (MemoryEffects::EffectInstance &effect : effects) {
+      Value EffectVal = effect.getValue();
+      if (!aliasAnalysis.alias(Load.getMemRef(), EffectVal).isNo())
+        return true;
+    }
+    return false;
   }
 
   AliasAnalysis &aliasAnalysis;

--- a/polygeist/lib/Dialect/Polygeist/Transforms/DetectReduction.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/DetectReduction.cpp
@@ -528,7 +528,7 @@ std::unique_ptr<Pass> createDetectReductionPass() {
   return std::make_unique<DetectReductionPass>();
 }
 std::unique_ptr<Pass>
-detectReductionPass(const DetectReductionOptions &options) {
+createDetectReductionPass(const DetectReductionOptions &options) {
   return std::make_unique<DetectReductionPass>(options);
 }
 } // namespace polygeist

--- a/polygeist/lib/Dialect/Polygeist/Transforms/DetectReduction.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/DetectReduction.cpp
@@ -8,10 +8,12 @@
 
 #include "mlir/Dialect/Polygeist/Transforms/Passes.h"
 
+#include "mlir/Analysis/AliasAnalysis.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SYCL/Analysis/AliasAnalysis.h"
 #include "mlir/IR/Dominance.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -32,6 +34,8 @@ using namespace mlir;
 namespace {
 class DetectReductionPass
     : public polygeist::impl::DetectReductionBase<DetectReductionPass> {
+  using DetectReductionBase<DetectReductionPass>::DetectReductionBase;
+
 public:
   void runOnOperation() override;
 };
@@ -85,8 +89,10 @@ public:
 protected:
   Pass::Statistic &numReductionsDetected;
 
-  LoopReductionIter(Pass::Statistic &numReductionsDetected)
-      : numReductionsDetected(numReductionsDetected) {}
+  LoopReductionIter(Pass::Statistic &numReductionsDetected,
+                    AliasAnalysis &aliasAnalysis)
+      : numReductionsDetected(numReductionsDetected),
+        aliasAnalysis(aliasAnalysis) {}
   virtual ~LoopReductionIter() = default;
 
   Block::BlockArgListType getRegionIterArgs(LoopLikeOpInterface Loop) const {
@@ -368,10 +374,41 @@ private:
         return WalkResult::interrupt();
       }
 
+      Operation *MayAliasOp = nullptr;
+      if (Loop.getLoopBody()
+              .walk([&](Operation *Op) {
+                if (isMemoryEffectFree(Op) || Op == Load ||
+                    Op == CandidateStores[0] ||
+                    llvm::find(OtherLoads, Op) != OtherLoads.end())
+                  return WalkResult::advance();
+
+                auto MEI = dyn_cast<MemoryEffectOpInterface>(Op);
+                if (!MEI || Op->hasTrait<OpTrait::HasRecursiveMemoryEffects>())
+                  return WalkResult::interrupt();
+
+                SmallVector<MemoryEffects::EffectInstance> effects;
+                MEI.getEffects(effects);
+                for (MemoryEffects::EffectInstance &effect : effects) {
+                  Value EffectVal = effect.getValue();
+                  if (!aliasAnalysis.alias(Load.getMemRef(), EffectVal)
+                           .isNo()) {
+                    MayAliasOp = Op;
+                    return WalkResult::interrupt();
+                  }
+                }
+                return WalkResult::advance();
+              })
+              .wasInterrupted()) {
+        LLVM_DEBUG(llvm::dbgs().indent(2)
+                   << "Interrupting - loop contains may alias operation: "
+                   << *MayAliasOp << "\n");
+        return WalkResult::interrupt();
+      }
+
       // The load must dominate the single store.
       if (!properlyDominates(Load, CandidateStores[0])) {
         LLVM_DEBUG(llvm::dbgs().indent(2)
-                   << "Interrupting - store doesn't dominate load: "
+                   << "Interrupting - load doesn't dominate store: "
                    << CandidateStores[0] << "\n");
         return WalkResult::interrupt();
       }
@@ -386,15 +423,18 @@ private:
 
     return Result;
   }
+
+  AliasAnalysis &aliasAnalysis;
 };
 
 class SCFForReductionIter : public OpRewritePattern<scf::ForOp>,
                             public LoopReductionIter {
 public:
   SCFForReductionIter(MLIRContext *context,
-                      Pass::Statistic &numReductionsDetected)
+                      Pass::Statistic &numReductionsDetected,
+                      AliasAnalysis &aliasAnalysis)
       : OpRewritePattern<scf::ForOp>(context),
-        LoopReductionIter(numReductionsDetected) {}
+        LoopReductionIter(numReductionsDetected, aliasAnalysis) {}
 
   LogicalResult matchAndRewrite(scf::ForOp Loop,
                                 PatternRewriter &Rewriter) const final {
@@ -427,9 +467,10 @@ class AffineForReductionIter : public OpRewritePattern<AffineForOp>,
                                public LoopReductionIter {
 public:
   AffineForReductionIter(MLIRContext *context,
-                         Pass::Statistic &numReductionsDetected)
+                         Pass::Statistic &numReductionsDetected,
+                         AliasAnalysis &aliasAnalysis)
       : OpRewritePattern<AffineForOp>(context),
-        LoopReductionIter(numReductionsDetected) {}
+        LoopReductionIter(numReductionsDetected, aliasAnalysis) {}
 
   LogicalResult matchAndRewrite(AffineForOp Loop,
                                 PatternRewriter &Rewriter) const final {
@@ -463,8 +504,11 @@ public:
 
 void DetectReductionPass::runOnOperation() {
   MLIRContext *ctx = getOperation()->getContext();
+  AliasAnalysis &aliasAnalysis = getAnalysis<AliasAnalysis>();
+  aliasAnalysis.addAnalysisImplementation(sycl::AliasAnalysis(relaxedAliasing));
   RewritePatternSet RPS(ctx);
-  RPS.add<AffineForReductionIter, SCFForReductionIter>(ctx, numReductions);
+  RPS.add<AffineForReductionIter, SCFForReductionIter>(ctx, numReductions,
+                                                       aliasAnalysis);
   GreedyRewriteConfig Config;
   (void)applyPatternsAndFoldGreedily(getOperation(), std::move(RPS), Config);
 }
@@ -473,6 +517,10 @@ namespace mlir {
 namespace polygeist {
 std::unique_ptr<Pass> createDetectReductionPass() {
   return std::make_unique<DetectReductionPass>();
+}
+std::unique_ptr<Pass>
+detectReductionPass(const DetectReductionOptions &options) {
+  return std::make_unique<DetectReductionPass>(options);
 }
 } // namespace polygeist
 } // namespace mlir

--- a/polygeist/test/polygeist-opt/red.mlir
+++ b/polygeist/test/polygeist-opt/red.mlir
@@ -140,4 +140,23 @@ module  {
     }  
     return
   }
+
+  // COM: Ensure reduction is not detected (exist other may alias operations).
+  func.func @no_detect_reduction_affine_for_3(%arg0: memref<?xf32>, %arg1: memref<?xf32>) {
+    // CHECK-LABEL: func.func @no_detect_reduction_affine_for_3(%arg0: memref<?xf32>, %arg1: memref<?xf32>) {
+    // CHECK:         affine.for %arg2 = 0 to 8 {
+    // CHECK-NEXT:      %0 = affine.load %arg1[0] : memref<?xf32>
+    // CHECK-NEXT:      %1 = affine.load %arg0[%arg2] : memref<?xf32>
+    // CHECK-NEXT:      %2 = arith.addf %0, %1 : f32
+    // CHECK-NEXT:      affine.store %2, %arg1[0] : memref<?xf32>
+    // CHECK-NEXT:    }
+
+    affine.for %arg2 = 0 to 8 {
+      %0 = affine.load %arg1[0] : memref<?xf32>
+      %1 = affine.load %arg0[%arg2] : memref<?xf32>
+      %2 = arith.addf %0, %1 : f32
+      affine.store %2, %arg1[0] : memref<?xf32>
+    }
+    return
+  }
 }

--- a/polygeist/test/polygeist-opt/red.mlir
+++ b/polygeist/test/polygeist-opt/red.mlir
@@ -142,6 +142,7 @@ module  {
   }
 
   // COM: Ensure reduction is not detected (exist other may alias operations).
+  // %arg0 and %arg1 may alias. The loop contains %1, which loads from %arg0.
   func.func @no_detect_reduction_affine_for_3(%arg0: memref<?xf32>, %arg1: memref<?xf32>) {
     // CHECK-LABEL: func.func @no_detect_reduction_affine_for_3(%arg0: memref<?xf32>, %arg1: memref<?xf32>) {
     // CHECK:         affine.for %arg2 = 0 to 8 {
@@ -150,6 +151,28 @@ module  {
     // CHECK-NEXT:      %2 = arith.addf %0, %1 : f32
     // CHECK-NEXT:      affine.store %2, %arg1[0] : memref<?xf32>
     // CHECK-NEXT:    }
+
+    affine.for %arg2 = 0 to 8 {
+      %0 = affine.load %arg1[0] : memref<?xf32>
+      %1 = affine.load %arg0[%arg2] : memref<?xf32>
+      %2 = arith.addf %0, %1 : f32
+      affine.store %2, %arg1[0] : memref<?xf32>
+    }
+    return
+  }
+
+  // COM: Ensure reduction is detected when %arg0 and %arg1 have attribute llvm.noalias.
+  func.func @detect_reduction_affine_for_2(%arg0: memref<?xf32> {llvm.noalias}, %arg1: memref<?xf32> {llvm.noalias}) {
+    // CHECK-LABEL: func.func @detect_reduction_affine_for_2(%arg0: memref<?xf32> {llvm.noalias}, %arg1: memref<?xf32> {llvm.noalias}) {
+    // CHECK-NEXT:    %0 = affine.load %arg1[0] : memref<?xf32>
+    // CHECK-NEXT:    %1 = affine.for %arg2 = 0 to 8 iter_args(%arg3 = %0) -> (f32) {
+    // CHECK-NEXT:      %2 = affine.load %arg0[%arg2] : memref<?xf32>
+    // CHECK-NEXT:      %3 = arith.addf %arg3, %2 : f32
+    // CHECK-NEXT:      affine.yield %3 : f32
+    // CHECK-NEXT:    }
+    // CHECK-NEXT:    affine.store %1, %arg1[0] : memref<?xf32>
+    // CHECK-NEXT:    return
+    // CHECK-NEXT:  }
 
     affine.for %arg2 = 0 to 8 {
       %0 = affine.load %arg1[0] : memref<?xf32>

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -57,6 +57,10 @@ llvm::cl::opt<std::string>
     PrefixABI("prefix-abi", llvm::cl::init(""),
               llvm::cl::desc("Prefix for emitted symbols"));
 
+static llvm::cl::opt<bool>
+    EnableAttributes("enable-attributes", llvm::cl::init(false),
+                     llvm::cl::desc("Enable setting of attributes"));
+
 constexpr llvm::StringLiteral MLIRASTConsumer::DeviceModuleName;
 
 /******************************************************************************/
@@ -2462,7 +2466,7 @@ void MLIRASTConsumer::setMLIRFunctionAttributes(FunctionOpInterface Function,
   MLIRContext *Ctx = Module->getContext();
 
   bool IsDeviceContext = (FTE.getContext() == FunctionContext::SYCLDevice);
-  if (!IsDeviceContext) {
+  if (!EnableAttributes && !IsDeviceContext) {
     LLVM_DEBUG(llvm::dbgs()
                << "Not in a device context - skipping setting attributes for "
                << FD.getNameAsString() << "\n");

--- a/polygeist/tools/cgeist/Test/Verification/redstore.c
+++ b/polygeist/tools/cgeist/Test/Verification/redstore.c
@@ -1,8 +1,11 @@
-// RUN: cgeist -O2 %s --function=* -S | FileCheck %s
+// RUN: clang++ -fsycl -fsycl-device-only -O2 -w -emit-mlir %s -o - | FileCheck %s
 
-extern int print(double);
+// FIXME: Recognize __restrict__ attribute without SYCL. 
+#include <sycl/sycl.hpp>
 
-void sum(double *result, double* array, int N) {
+extern "C" SYCL_EXTERNAL int print(double);
+
+extern "C" SYCL_EXTERNAL void sum(double * __restrict__ result, double * __restrict__ array, int N) {
     #pragma scop
     for (int j=0; j<N; j++) {
         result[0] = 0;
@@ -14,19 +17,19 @@ void sum(double *result, double* array, int N) {
     #pragma endscop
 }
 
-// CHECK:  func.func @sum(%arg0: memref<?xf64>, %arg1: memref<?xf64>, %arg2: i32)
+// CHECK:  func.func @sum(%arg0: memref<?xf64, 4>{{.*}}llvm.noalias{{.*}}, %arg1: memref<?xf64, 4>{{.*}}llvm.noalias{{.*}}, %arg2: i32{{.*}})
 // CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f64
 // CHECK-NEXT:     %0 = arith.index_cast %arg2 : i32 to index
 // CHECK-NEXT:     affine.for %arg3 = 0 to %0 {
-// CHECK-NEXT:       affine.store %cst, %arg0[0] : memref<?xf64>
-// CHECK-NEXT:       %[[i2:.+]] = affine.load %arg0[0] : memref<?xf64>
+// CHECK-NEXT:       affine.store %cst, %arg0[0] : memref<?xf64, 4>
+// CHECK-NEXT:       %[[i2:.+]] = affine.load %arg0[0] : memref<?xf64, 4>
 // CHECK-NEXT:       %[[i3:.+]] = affine.for %arg4 = 0 to 10 iter_args(%arg5 = %[[i2]]) -> (f64) {
-// CHECK-NEXT:         %[[i6:.+]] = affine.load %arg1[%arg4] : memref<?xf64>
+// CHECK-NEXT:         %[[i6:.+]] = affine.load %arg1[%arg4] : memref<?xf64, 4>
 // CHECK-NEXT:         %[[i7:.+]] = arith.addf %arg5, %[[i6]] : f64
 // CHECK-NEXT:         affine.yield %[[i7]] : f64
 // CHECK-NEXT:       }
-// CHECK-NEXT:       affine.store %[[i3]], %arg0[0] : memref<?xf64>
-// CHECK-NEXT:       %[[i4:.+]] = affine.load %arg0[0] : memref<?xf64>
+// CHECK-NEXT:       affine.store %[[i3]], %arg0[0] : memref<?xf64, 4>
+// CHECK-NEXT:       %[[i4:.+]] = affine.load %arg0[0] : memref<?xf64, 4>
 // CHECK-NEXT:       %{{.*}} = func.call @print(%[[i4]]) : (f64) -> i32
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return

--- a/polygeist/tools/cgeist/Test/Verification/redstore.c
+++ b/polygeist/tools/cgeist/Test/Verification/redstore.c
@@ -1,11 +1,8 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O2 -w -emit-mlir %s -o - | FileCheck %s
+// RUN: cgeist -O2 %s --function=* -S -enable-attributes | FileCheck %s
 
-// FIXME: Recognize __restrict__ attribute without SYCL. 
-#include <sycl/sycl.hpp>
+extern int print(double);
 
-extern "C" SYCL_EXTERNAL int print(double);
-
-extern "C" SYCL_EXTERNAL void sum(double * __restrict__ result, double * __restrict__ array, int N) {
+void sum(double * __restrict__ result, double * __restrict__ array, int N) {
     #pragma scop
     for (int j=0; j<N; j++) {
         result[0] = 0;
@@ -17,19 +14,19 @@ extern "C" SYCL_EXTERNAL void sum(double * __restrict__ result, double * __restr
     #pragma endscop
 }
 
-// CHECK:  func.func @sum(%arg0: memref<?xf64, 4>{{.*}}llvm.noalias{{.*}}, %arg1: memref<?xf64, 4>{{.*}}llvm.noalias{{.*}}, %arg2: i32{{.*}})
+// CHECK:  func.func @sum(%arg0: memref<?xf64>{{.*}}llvm.noalias{{.*}}, %arg1: memref<?xf64>{{.*}}llvm.noalias{{.*}}, %arg2: i32{{.*}})
 // CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f64
 // CHECK-NEXT:     %0 = arith.index_cast %arg2 : i32 to index
 // CHECK-NEXT:     affine.for %arg3 = 0 to %0 {
-// CHECK-NEXT:       affine.store %cst, %arg0[0] : memref<?xf64, 4>
-// CHECK-NEXT:       %[[i2:.+]] = affine.load %arg0[0] : memref<?xf64, 4>
+// CHECK-NEXT:       affine.store %cst, %arg0[0] : memref<?xf64>
+// CHECK-NEXT:       %[[i2:.+]] = affine.load %arg0[0] : memref<?xf64>
 // CHECK-NEXT:       %[[i3:.+]] = affine.for %arg4 = 0 to 10 iter_args(%arg5 = %[[i2]]) -> (f64) {
-// CHECK-NEXT:         %[[i6:.+]] = affine.load %arg1[%arg4] : memref<?xf64, 4>
+// CHECK-NEXT:         %[[i6:.+]] = affine.load %arg1[%arg4] : memref<?xf64>
 // CHECK-NEXT:         %[[i7:.+]] = arith.addf %arg5, %[[i6]] : f64
 // CHECK-NEXT:         affine.yield %[[i7]] : f64
 // CHECK-NEXT:       }
-// CHECK-NEXT:       affine.store %[[i3]], %arg0[0] : memref<?xf64, 4>
-// CHECK-NEXT:       %[[i4:.+]] = affine.load %arg0[0] : memref<?xf64, 4>
+// CHECK-NEXT:       affine.store %[[i3]], %arg0[0] : memref<?xf64>
+// CHECK-NEXT:       %[[i4:.+]] = affine.load %arg0[0] : memref<?xf64>
 // CHECK-NEXT:       %{{.*}} = func.call @print(%[[i4]]) : (f64) -> i32
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return

--- a/polygeist/tools/cgeist/Test/Verification/redstore2.c
+++ b/polygeist/tools/cgeist/Test/Verification/redstore2.c
@@ -1,9 +1,6 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O2 -w -emit-mlir %s -o - | FileCheck %s
+// RUN: cgeist -O2 %s --function=* -S -enable-attributes | FileCheck %s
 
-// FIXME: Recognize __restrict__ attribute without SYCL. 
-#include <sycl/sycl.hpp>
-
-extern "C" SYCL_EXTERNAL void sum(double * __restrict__ result, double * __restrict__ array) {
+void sum(double * __restrict__ result, double * __restrict__ array) {
     result[0] = 0;
     #pragma scop
     for (int i=0; i<10; i++) {
@@ -12,15 +9,15 @@ extern "C" SYCL_EXTERNAL void sum(double * __restrict__ result, double * __restr
     #pragma endscop
 }
 
-// CHECK:  func @sum(%arg0: memref<?xf64, 4>{{.*}}llvm.noalias{{.*}}, %arg1: memref<?xf64, 4>{{.*}}llvm.noalias{{.*}})
+// CHECK:  func @sum(%arg0: memref<?xf64>{{.*}}llvm.noalias{{.*}}, %arg1: memref<?xf64>{{.*}}llvm.noalias{{.*}})
 // CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f64
-// CHECK-NEXT:    affine.store %cst, %arg0[0] : memref<?xf64, 4>
-// CHECK-NEXT:    %[[i1:.+]] = affine.load %arg0[0] : memref<?xf64, 4>
+// CHECK-NEXT:    affine.store %cst, %arg0[0] : memref<?xf64>
+// CHECK-NEXT:    %[[i1:.+]] = affine.load %arg0[0] : memref<?xf64>
 // CHECK-NEXT:    %[[i2:.+]] = affine.for %arg2 = 0 to 10 iter_args(%arg3 = %[[i1]]) -> (f64) {
-// CHECK-NEXT:      %[[i3:.+]] = affine.load %arg1[%arg2] : memref<?xf64, 4>
+// CHECK-NEXT:      %[[i3:.+]] = affine.load %arg1[%arg2] : memref<?xf64>
 // CHECK-NEXT:      %[[i4:.+]] = arith.addf %arg3, %[[i3]] : f64
 // CHECK-NEXT:      affine.yield %[[i4]] : f64
 // CHECK-NEXT:    }
-// CHECK-NEXT:    affine.store %[[i2]], %arg0[0] : memref<?xf64, 4>
+// CHECK-NEXT:    affine.store %[[i2]], %arg0[0] : memref<?xf64>
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }

--- a/polygeist/tools/cgeist/Test/Verification/redstore2.c
+++ b/polygeist/tools/cgeist/Test/Verification/redstore2.c
@@ -1,6 +1,9 @@
-// RUN: cgeist -O2 %s --function=* -S | FileCheck %s
+// RUN: clang++ -fsycl -fsycl-device-only -O2 -w -emit-mlir %s -o - | FileCheck %s
 
-void sum(double *result, double* array) {
+// FIXME: Recognize __restrict__ attribute without SYCL. 
+#include <sycl/sycl.hpp>
+
+extern "C" SYCL_EXTERNAL void sum(double * __restrict__ result, double * __restrict__ array) {
     result[0] = 0;
     #pragma scop
     for (int i=0; i<10; i++) {
@@ -9,15 +12,15 @@ void sum(double *result, double* array) {
     #pragma endscop
 }
 
-// CHECK:  func @sum(%arg0: memref<?xf64>, %arg1: memref<?xf64>)
+// CHECK:  func @sum(%arg0: memref<?xf64, 4>{{.*}}llvm.noalias{{.*}}, %arg1: memref<?xf64, 4>{{.*}}llvm.noalias{{.*}})
 // CHECK-NEXT:    %cst = arith.constant 0.000000e+00 : f64
-// CHECK-NEXT:    affine.store %cst, %arg0[0] : memref<?xf64>
-// CHECK-NEXT:    %[[i1:.+]] = affine.load %arg0[0] : memref<?xf64>
+// CHECK-NEXT:    affine.store %cst, %arg0[0] : memref<?xf64, 4>
+// CHECK-NEXT:    %[[i1:.+]] = affine.load %arg0[0] : memref<?xf64, 4>
 // CHECK-NEXT:    %[[i2:.+]] = affine.for %arg2 = 0 to 10 iter_args(%arg3 = %[[i1]]) -> (f64) {
-// CHECK-NEXT:      %[[i3:.+]] = affine.load %arg1[%arg2] : memref<?xf64>
+// CHECK-NEXT:      %[[i3:.+]] = affine.load %arg1[%arg2] : memref<?xf64, 4>
 // CHECK-NEXT:      %[[i4:.+]] = arith.addf %arg3, %[[i3]] : f64
 // CHECK-NEXT:      affine.yield %[[i4]] : f64
 // CHECK-NEXT:    }
-// CHECK-NEXT:    affine.store %[[i2]], %arg0[0] : memref<?xf64>
+// CHECK-NEXT:    affine.store %[[i2]], %arg0[0] : memref<?xf64, 4>
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }

--- a/polygeist/tools/cgeist/Test/Verification/sgesv.c
+++ b/polygeist/tools/cgeist/Test/Verification/sgesv.c
@@ -1,7 +1,5 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O2 -w -emit-mlir %s -o - | FileCheck %s
-
-// FIXME: Recognize __restrict__ attribute without SYCL. 
-#include <sycl/sycl.hpp>
+// RUN: cgeist %s -O2 --function=kernel_correlation -S -enable-attributes | FileCheck %s
+// RUN: cgeist %s -O2 --function=kernel_correlation -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 #define DATA_TYPE double
 
@@ -9,12 +7,12 @@
 
 /* Main computational kernel. The whole function will be timed,
    including the call and return. */
-extern "C" SYCL_EXTERNAL void kernel_correlation(int n, double alpha, double beta,
-                    double (&__restrict__ A)[28][28],
-                    double (&__restrict__ B)[28][28],
-                    double (&__restrict__ tmp)[28],
-                    double (&__restrict__ x)[28],
-                    double (&__restrict__ y)[28])
+void kernel_correlation(int n, double alpha, double beta,
+                    double A[restrict 28][28],
+                    double B[restrict 28][28],
+                    double tmp[restrict 28],
+                    double x[restrict 28],
+                    double y[restrict 28])
 {
   int i, j;
 
@@ -32,32 +30,34 @@ extern "C" SYCL_EXTERNAL void kernel_correlation(int n, double alpha, double bet
 
 }
 
-// CHECK:   func @kernel_correlation(%arg0: i32{{.*}}, %arg1: f64{{.*}}, %arg2: f64{{.*}}, %arg3: memref<28x28xf64, 4>{{.*}}llvm.noalias{{.*}}, %arg4: memref<28x28xf64, 4>{{.*}}llvm.noalias{{.*}}, %arg5: memref<28xf64, 4>{{.*}}llvm.noalias{{.*}}, %arg6: memref<28xf64, 4>{{.*}}llvm.noalias{{.*}}, %arg7: memref<28xf64, 4>{{.*}}llvm.noalias{{.*}})
+// CHECK:   func @{{.*}}kernel_correlation{{.*}}(%arg0: i32{{.*}}, %arg1: f64{{.*}}, %arg2: f64{{.*}}, %arg3: memref<?x28xf64>{{.*}}llvm.noalias{{.*}}, %arg4: memref<?x28xf64>{{.*}}llvm.noalias{{.*}}, %arg5: memref<?xf64>{{.*}}llvm.noalias{{.*}}, %arg6: memref<?xf64>{{.*}}llvm.noalias{{.*}}, %arg7: memref<?xf64>{{.*}}llvm.noalias{{.*}})
 // CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f64
 // CHECK-NEXT:     %0 = arith.index_cast %arg0 : i32 to index
 // CHECK-NEXT:     affine.for %arg8 = 0 to %0 {
-// CHECK-NEXT:       affine.store %cst, %arg5[%arg8] : memref<28xf64, 4>
-// CHECK-NEXT:       affine.store %cst, %arg7[%arg8] : memref<28xf64, 4>
-// CHECK-NEXT:       %1 = affine.load %arg5[%arg8] : memref<28xf64, 4>
-// CHECK-NEXT:       %2 = affine.load %arg7[%arg8] : memref<28xf64, 4>
+// CHECK-NEXT:       affine.store %cst, %arg5[%arg8] : memref<?xf64>
+// CHECK-NEXT:       affine.store %cst, %arg7[%arg8] : memref<?xf64>
+// CHECK-NEXT:       %1 = affine.load %arg5[%arg8] : memref<?xf64>
+// CHECK-NEXT:       %2 = affine.load %arg7[%arg8] : memref<?xf64>
 // CHECK-NEXT:       %3:2 = affine.for %arg9 = 0 to %0 iter_args(%arg10 = %1, %arg11 = %2) -> (f64, f64) {
-// CHECK-NEXT:         %9 = affine.load %arg3[%arg8, %arg9] : memref<28x28xf64, 4>
-// CHECK-NEXT:         %10 = affine.load %arg6[%arg9] : memref<28xf64, 4>
+// CHECK-NEXT:         %9 = affine.load %arg3[%arg8, %arg9] : memref<?x28xf64>
+// CHECK-NEXT:         %10 = affine.load %arg6[%arg9] : memref<?xf64>
 // CHECK-NEXT:         %11 = arith.mulf %9, %10 : f64
 // CHECK-NEXT:         %12 = arith.addf %11, %arg10 : f64
-// CHECK-NEXT:         %13 = affine.load %arg4[%arg8, %arg9] : memref<28x28xf64, 4>
+// CHECK-NEXT:         %13 = affine.load %arg4[%arg8, %arg9] : memref<?x28xf64>
 // CHECK-NEXT:         %14 = arith.mulf %13, %10 : f64
 // CHECK-NEXT:         %15 = arith.addf %14, %arg11 : f64
 // CHECK-NEXT:         affine.yield %12, %15 : f64, f64
 // CHECK-NEXT:       }
-// CHECK-NEXT:       affine.store %3#1, %arg7[%arg8] : memref<28xf64, 4>
-// CHECK-NEXT:       affine.store %3#0, %arg5[%arg8] : memref<28xf64, 4>
-// CHECK-NEXT:       %4 = affine.load %arg5[%arg8] : memref<28xf64, 4>
+// CHECK-NEXT:       affine.store %3#1, %arg7[%arg8] : memref<?xf64>
+// CHECK-NEXT:       affine.store %3#0, %arg5[%arg8] : memref<?xf64>
+// CHECK-NEXT:       %4 = affine.load %arg5[%arg8] : memref<?xf64>
 // CHECK-NEXT:       %5 = arith.mulf %arg1, %4 : f64
-// CHECK-NEXT:       %6 = affine.load %arg7[%arg8] : memref<28xf64, 4>
+// CHECK-NEXT:       %6 = affine.load %arg7[%arg8] : memref<?xf64>
 // CHECK-NEXT:       %7 = arith.mulf %arg2, %6 : f64
 // CHECK-NEXT:       %8 = arith.addf %5, %7 : f64
-// CHECK-NEXT:       affine.store %8, %arg7[%arg8] : memref<28xf64, 4>
+// CHECK-NEXT:       affine.store %8, %arg7[%arg8] : memref<?xf64>
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
+
+// FULLRANK: func @kernel_correlation(%{{.*}}: i32, %{{.*}}: f64, %{{.*}}: f64, %{{.*}}: memref<28x28xf64>, %{{.*}}: memref<28x28xf64>, %{{.*}}: memref<28xf64>, %{{.*}}: memref<28xf64>, %{{.*}}: memref<28xf64>)

--- a/polygeist/tools/cgeist/Test/Verification/sgesv.c
+++ b/polygeist/tools/cgeist/Test/Verification/sgesv.c
@@ -1,5 +1,7 @@
-// RUN: cgeist %s -O2 --function=kernel_correlation -S | FileCheck %s
-// RUN: cgeist %s -O2 --function=kernel_correlation -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: clang++ -fsycl -fsycl-device-only -O2 -w -emit-mlir %s -o - | FileCheck %s
+
+// FIXME: Recognize __restrict__ attribute without SYCL. 
+#include <sycl/sycl.hpp>
 
 #define DATA_TYPE double
 
@@ -7,12 +9,12 @@
 
 /* Main computational kernel. The whole function will be timed,
    including the call and return. */
-void kernel_correlation(int n, double alpha, double beta,
-                    double A[28][28],
-                    double B[28][28],
-                    double tmp[28],
-                    double x[28],
-                    double y[28])
+extern "C" SYCL_EXTERNAL void kernel_correlation(int n, double alpha, double beta,
+                    double (&__restrict__ A)[28][28],
+                    double (&__restrict__ B)[28][28],
+                    double (&__restrict__ tmp)[28],
+                    double (&__restrict__ x)[28],
+                    double (&__restrict__ y)[28])
 {
   int i, j;
 
@@ -30,34 +32,32 @@ void kernel_correlation(int n, double alpha, double beta,
 
 }
 
-// CHECK:   func @kernel_correlation(%arg0: i32, %arg1: f64, %arg2: f64, %arg3: memref<?x28xf64>, %arg4: memref<?x28xf64>, %arg5: memref<?xf64>, %arg6: memref<?xf64>, %arg7: memref<?xf64>)
+// CHECK:   func @kernel_correlation(%arg0: i32{{.*}}, %arg1: f64{{.*}}, %arg2: f64{{.*}}, %arg3: memref<28x28xf64, 4>{{.*}}llvm.noalias{{.*}}, %arg4: memref<28x28xf64, 4>{{.*}}llvm.noalias{{.*}}, %arg5: memref<28xf64, 4>{{.*}}llvm.noalias{{.*}}, %arg6: memref<28xf64, 4>{{.*}}llvm.noalias{{.*}}, %arg7: memref<28xf64, 4>{{.*}}llvm.noalias{{.*}})
 // CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f64
 // CHECK-NEXT:     %0 = arith.index_cast %arg0 : i32 to index
 // CHECK-NEXT:     affine.for %arg8 = 0 to %0 {
-// CHECK-NEXT:       affine.store %cst, %arg5[%arg8] : memref<?xf64>
-// CHECK-NEXT:       affine.store %cst, %arg7[%arg8] : memref<?xf64>
-// CHECK-NEXT:       %1 = affine.load %arg5[%arg8] : memref<?xf64>
-// CHECK-NEXT:       %2 = affine.load %arg7[%arg8] : memref<?xf64>
+// CHECK-NEXT:       affine.store %cst, %arg5[%arg8] : memref<28xf64, 4>
+// CHECK-NEXT:       affine.store %cst, %arg7[%arg8] : memref<28xf64, 4>
+// CHECK-NEXT:       %1 = affine.load %arg5[%arg8] : memref<28xf64, 4>
+// CHECK-NEXT:       %2 = affine.load %arg7[%arg8] : memref<28xf64, 4>
 // CHECK-NEXT:       %3:2 = affine.for %arg9 = 0 to %0 iter_args(%arg10 = %1, %arg11 = %2) -> (f64, f64) {
-// CHECK-NEXT:         %9 = affine.load %arg3[%arg8, %arg9] : memref<?x28xf64>
-// CHECK-NEXT:         %10 = affine.load %arg6[%arg9] : memref<?xf64>
+// CHECK-NEXT:         %9 = affine.load %arg3[%arg8, %arg9] : memref<28x28xf64, 4>
+// CHECK-NEXT:         %10 = affine.load %arg6[%arg9] : memref<28xf64, 4>
 // CHECK-NEXT:         %11 = arith.mulf %9, %10 : f64
 // CHECK-NEXT:         %12 = arith.addf %11, %arg10 : f64
-// CHECK-NEXT:         %13 = affine.load %arg4[%arg8, %arg9] : memref<?x28xf64>
+// CHECK-NEXT:         %13 = affine.load %arg4[%arg8, %arg9] : memref<28x28xf64, 4>
 // CHECK-NEXT:         %14 = arith.mulf %13, %10 : f64
 // CHECK-NEXT:         %15 = arith.addf %14, %arg11 : f64
 // CHECK-NEXT:         affine.yield %12, %15 : f64, f64
 // CHECK-NEXT:       }
-// CHECK-NEXT:       affine.store %3#1, %arg7[%arg8] : memref<?xf64>
-// CHECK-NEXT:       affine.store %3#0, %arg5[%arg8] : memref<?xf64>
-// CHECK-NEXT:       %4 = affine.load %arg5[%arg8] : memref<?xf64>
+// CHECK-NEXT:       affine.store %3#1, %arg7[%arg8] : memref<28xf64, 4>
+// CHECK-NEXT:       affine.store %3#0, %arg5[%arg8] : memref<28xf64, 4>
+// CHECK-NEXT:       %4 = affine.load %arg5[%arg8] : memref<28xf64, 4>
 // CHECK-NEXT:       %5 = arith.mulf %arg1, %4 : f64
-// CHECK-NEXT:       %6 = affine.load %arg7[%arg8] : memref<?xf64>
+// CHECK-NEXT:       %6 = affine.load %arg7[%arg8] : memref<28xf64, 4>
 // CHECK-NEXT:       %7 = arith.mulf %arg2, %6 : f64
 // CHECK-NEXT:       %8 = arith.addf %5, %7 : f64
-// CHECK-NEXT:       affine.store %8, %arg7[%arg8] : memref<?xf64>
+// CHECK-NEXT:       affine.store %8, %arg7[%arg8] : memref<28xf64, 4>
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
-
-// FULLRANK: func @kernel_correlation(%{{.*}}: i32, %{{.*}}: f64, %{{.*}}: f64, %{{.*}}: memref<28x28xf64>, %{{.*}}: memref<28x28xf64>, %{{.*}}: memref<28xf64>, %{{.*}}: memref<28xf64>, %{{.*}}: memref<28xf64>)

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/2mm/2mm.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/2mm/2mm.c
@@ -15,8 +15,6 @@
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
 
-// XFAIL: *
-
 /**
  * This version is stamped on May 10, 2016
  *
@@ -185,16 +183,15 @@ int main(int argc, char** argv)
 // CHECK-NEXT:  affine.for %arg11 = 0 to %3 {
 // CHECK-NEXT:    affine.for %arg12 = 0 to %2 {
 // CHECK-NEXT:      affine.store %cst, %arg6[%arg11, %arg12] : memref<?x900xf64>
-// CHECK-NEXT:      %4 = affine.load %arg6[%arg11, %arg12] : memref<?x900xf64>
-// CHECK-NEXT:      %5 = affine.for %arg13 = 0 to %0 iter_args(%arg14 = %4) -> (f64) {
-// CHECK-NEXT:        %6 = affine.load %arg7[%arg11, %arg13] : memref<?x1100xf64>
-// CHECK-NEXT:        %7 = arith.mulf %arg4, %6 : f64
-// CHECK-NEXT:        %8 = affine.load %arg8[%arg13, %arg12] : memref<?x900xf64>
-// CHECK-NEXT:        %9 = arith.mulf %7, %8 : f64
-// CHECK-NEXT:        %10 = arith.addf %arg14, %9 : f64
-// CHECK-NEXT:        affine.yield %10 : f64
+// CHECK-NEXT:      affine.for %arg13 = 0 to %0 {
+// CHECK-NEXT:        %4 = affine.load %arg7[%arg11, %arg13] : memref<?x1100xf64>
+// CHECK-NEXT:        %5 = arith.mulf %arg4, %4 : f64
+// CHECK-NEXT:        %6 = affine.load %arg8[%arg13, %arg12] : memref<?x900xf64>
+// CHECK-NEXT:        %7 = arith.mulf %5, %6 : f64
+// CHECK-NEXT:        %8 = affine.load %arg6[%arg11, %arg12] : memref<?x900xf64>
+// CHECK-NEXT:        %9 = arith.addf %8, %7 : f64
+// CHECK-NEXT:        affine.store %9, %arg6[%arg11, %arg12] : memref<?x900xf64> 
 // CHECK-NEXT:      }
-// CHECK-NEXT:      affine.store %5, %arg6[%arg11, %arg12] : memref<?x900xf64>
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 // CHECK-NEXT:  affine.for %arg11 = 0 to %3 {
@@ -202,15 +199,14 @@ int main(int argc, char** argv)
 // CHECK-NEXT:      %4 = affine.load %arg10[%arg11, %arg12] : memref<?x1200xf64>
 // CHECK-NEXT:      %5 = arith.mulf %4, %arg5 : f64
 // CHECK-NEXT:      affine.store %5, %arg10[%arg11, %arg12] : memref<?x1200xf64>
-// CHECK-NEXT:      %6 = affine.load %arg10[%arg11, %arg12] : memref<?x1200xf64>
-// CHECK-NEXT:      %7 = affine.for %arg13 = 0 to %2 iter_args(%arg14 = %6) -> (f64) {
-// CHECK-NEXT:        %8 = affine.load %arg6[%arg11, %arg13] : memref<?x900xf64>
-// CHECK-NEXT:        %9 = affine.load %arg9[%arg13, %arg12] : memref<?x1200xf64>
-// CHECK-NEXT:        %10 = arith.mulf %8, %9 : f64
-// CHECK-NEXT:        %11 = arith.addf %arg14, %10 : f64
-// CHECK-NEXT:        affine.yield %11 : f64
+// CHECK-NEXT:      affine.for %arg13 = 0 to %2 {
+// CHECK-NEXT:        %6 = affine.load %arg6[%arg11, %arg13] : memref<?x900xf64>
+// CHECK-NEXT:        %7 = affine.load %arg9[%arg13, %arg12] : memref<?x1200xf64>
+// CHECK-NEXT:        %8 = arith.mulf %6, %7 : f64
+// CHECK-NEXT:        %9 = affine.load %arg10[%arg11, %arg12] : memref<?x1200xf64>
+// CHECK-NEXT:        %10 = arith.addf %9, %8 : f64
+// CHECK-NEXT:        affine.store %10, %arg10[%arg11, %arg12] : memref<?x1200xf64>
 // CHECK-NEXT:      }
-// CHECK-NEXT:      affine.store %7, %arg10[%arg11, %arg12] : memref<?x1200xf64>
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/2mm/2mm.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/2mm/2mm.c
@@ -7,7 +7,8 @@
 // RUN: cgeist %s -O3 %polyexec %stdinclude -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
-// RUN: cgeist -O2 -raise-scf-to-affine %s %stdinclude -S | FileCheck %s
+// RUN: cgeist -O2 -raise-scf-to-affine %s %stdinclude -S -D POLYBENCH_USE_RESTRICT -enable-attributes | FileCheck %s --check-prefixes=CHECK,RESTRICT
+// RUN: cgeist -O2 -raise-scf-to-affine %s %stdinclude -S | FileCheck %s --check-prefixes=CHECK,NRESTRICT
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
 // RUN: cgeist %s -O3 %polyverify %stdinclude -detect-reduction -o %s.execm && %s.execm &> %s.out2
@@ -183,31 +184,49 @@ int main(int argc, char** argv)
 // CHECK-NEXT:  affine.for %arg11 = 0 to %3 {
 // CHECK-NEXT:    affine.for %arg12 = 0 to %2 {
 // CHECK-NEXT:      affine.store %cst, %arg6[%arg11, %arg12] : memref<?x900xf64>
-// CHECK-NEXT:      affine.for %arg13 = 0 to %0 {
-// CHECK-NEXT:        %4 = affine.load %arg7[%arg11, %arg13] : memref<?x1100xf64>
-// CHECK-NEXT:        %5 = arith.mulf %arg4, %4 : f64
-// CHECK-NEXT:        %6 = affine.load %arg8[%arg13, %arg12] : memref<?x900xf64>
-// CHECK-NEXT:        %7 = arith.mulf %5, %6 : f64
-// CHECK-NEXT:        %8 = affine.load %arg6[%arg11, %arg12] : memref<?x900xf64>
-// CHECK-NEXT:        %9 = arith.addf %8, %7 : f64
-// CHECK-NEXT:        affine.store %9, %arg6[%arg11, %arg12] : memref<?x900xf64> 
-// CHECK-NEXT:      }
-// CHECK-NEXT:    }
-// CHECK-NEXT:  }
-// CHECK-NEXT:  affine.for %arg11 = 0 to %3 {
+
+// NRESTRICT-NEXT:  affine.for %arg13 = 0 to %0 {
+// NRESTRICT-NEXT:    %4 = affine.load %arg7[%arg11, %arg13] : memref<?x1100xf64>
+// NRESTRICT-NEXT:    %5 = arith.mulf %arg4, %4 : f64
+// NRESTRICT-NEXT:    %6 = affine.load %arg8[%arg13, %arg12] : memref<?x900xf64>
+// NRESTRICT-NEXT:    %7 = arith.mulf %5, %6 : f64
+// NRESTRICT-NEXT:    %8 = affine.load %arg6[%arg11, %arg12] : memref<?x900xf64>
+// NRESTRICT-NEXT:    %9 = arith.addf %8, %7 : f64
+// NRESTRICT-NEXT:    affine.store %9, %arg6[%arg11, %arg12] : memref<?x900xf64> 
+// NRESTRICT-NEXT:  }
+// RESTRICT-NEXT:   %4 = affine.load %arg6[%arg11, %arg12] : memref<?x900xf64>
+// RESTRICT-NEXT:   %5 = affine.for %arg13 = 0 to %0 iter_args(%arg14 = %4) -> (f64) {
+// RESTRICT-NEXT:     %6 = affine.load %arg7[%arg11, %arg13] : memref<?x1100xf64>
+// RESTRICT-NEXT:     %7 = arith.mulf %arg4, %6 : f64
+// RESTRICT-NEXT:     %8 = affine.load %arg8[%arg13, %arg12] : memref<?x900xf64>
+// RESTRICT-NEXT:     %9 = arith.mulf %7, %8 : f64
+// RESTRICT-NEXT:     %10 = arith.addf %arg14, %9 : f64
+// RESTRICT-NEXT:     affine.yield %10 : f64
+// RESTRICT-NEXT:   }
+// RESTRICT-NEXT:   affine.store %5, %arg6[%arg11, %arg12] : memref<?x900xf64>
+
+// CHECK:       affine.for %arg11 = 0 to %3 {
 // CHECK-NEXT:    affine.for %arg12 = 0 to %1 {
 // CHECK-NEXT:      %4 = affine.load %arg10[%arg11, %arg12] : memref<?x1200xf64>
 // CHECK-NEXT:      %5 = arith.mulf %4, %arg5 : f64
 // CHECK-NEXT:      affine.store %5, %arg10[%arg11, %arg12] : memref<?x1200xf64>
-// CHECK-NEXT:      affine.for %arg13 = 0 to %2 {
-// CHECK-NEXT:        %6 = affine.load %arg6[%arg11, %arg13] : memref<?x900xf64>
-// CHECK-NEXT:        %7 = affine.load %arg9[%arg13, %arg12] : memref<?x1200xf64>
-// CHECK-NEXT:        %8 = arith.mulf %6, %7 : f64
-// CHECK-NEXT:        %9 = affine.load %arg10[%arg11, %arg12] : memref<?x1200xf64>
-// CHECK-NEXT:        %10 = arith.addf %9, %8 : f64
-// CHECK-NEXT:        affine.store %10, %arg10[%arg11, %arg12] : memref<?x1200xf64>
-// CHECK-NEXT:      }
-// CHECK-NEXT:    }
-// CHECK-NEXT:  }
+
+// NRESTRICT-NEXT:  affine.for %arg13 = 0 to %2 {
+// NRESTRICT-NEXT:    %6 = affine.load %arg6[%arg11, %arg13] : memref<?x900xf64>
+// NRESTRICT-NEXT:    %7 = affine.load %arg9[%arg13, %arg12] : memref<?x1200xf64>
+// NRESTRICT-NEXT:    %8 = arith.mulf %6, %7 : f64
+// NRESTRICT-NEXT:    %9 = affine.load %arg10[%arg11, %arg12] : memref<?x1200xf64>
+// NRESTRICT-NEXT:    %10 = arith.addf %9, %8 : f64
+// NRESTRICT-NEXT:    affine.store %10, %arg10[%arg11, %arg12] : memref<?x1200xf64>
+// NRESTRICT-NEXT:  }
+// RESTRICT-NEXT:   %6 = affine.load %arg10[%arg11, %arg12] : memref<?x1200xf64>
+// RESTRICT-NEXT:   %7 = affine.for %arg13 = 0 to %2 iter_args(%arg14 = %6) -> (f64) {
+// RESTRICT-NEXT:     %8 = affine.load %arg6[%arg11, %arg13] : memref<?x900xf64>
+// RESTRICT-NEXT:     %9 = affine.load %arg9[%arg13, %arg12] : memref<?x1200xf64>
+// RESTRICT-NEXT:     %10 = arith.mulf %8, %9 : f64
+// RESTRICT-NEXT:     %11 = arith.addf %arg14, %10 : f64
+// RESTRICT-NEXT:     affine.yield %11 : f64
+// RESTRICT-NEXT:   }
+// RESTRICT-NEXT:   affine.store %7, %arg10[%arg11, %arg12] : memref<?x1200xf64>
 
 // EXEC: {{[0-9]\.[0-9]+}}

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/2mm/2mm.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/2mm/2mm.c
@@ -15,6 +15,8 @@
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
 
+// XFAIL: *
+
 /**
  * This version is stamped on May 10, 2016
  *

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -394,7 +394,8 @@ static LogicalResult optimize(mlir::MLIRContext &Ctx,
       OptPM.addPass(mlir::createLoopInvariantCodeMotionPass());
     OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
     if (DetectReduction)
-      OptPM.addPass(polygeist::createDetectReductionPass());
+      OptPM.addPass(polygeist::createDetectReductionPass(
+          {options.getCgeistOpts().getRelaxedAliasing()}));
 
     OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
     OptPM.addPass(mlir::createCSEPass());


### PR DESCRIPTION
Original loop:
```
for (i) 
  A[0] += B[i];
```
Optimized loop:
```
a = A[0];
for (i)
  a += B[i];
A[0] = a;
```
This is incorrect if A and B may alias because `B[i]` may be different after updating `A[0]`.