### PR TITLE
[SYCL-MLIR] Add `noalias` attribute for `kernel_args_restrict` kernel pointer arguments

### DIFF
--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1241,7 +1241,9 @@ void CodeGenTypes::constructAttributeList(
       auto DeclArgTy = getDeclArgTy(*FD, ArgNo, ParamType);
 
       // Set 'noalias' if an argument type has the `restrict` qualifier.
-      if (DeclArgTy.isRestrictQualified())
+      if (DeclArgTy.isRestrictQualified() ||
+          (FD->hasAttr<SYCLIntelKernelArgsRestrictAttr>() &&
+           DeclArgTy->isPointerType()))
         ParamAttrsBuilder.addAttribute(llvm::Attribute::NoAlias);
     }
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/restrict.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/restrict.cpp
@@ -36,7 +36,7 @@ int args_restrict(std::array<int, 1> &A, std::array<int, 1> &B) {
     auto bufB = buffer<int, 1>{B.data(), 1};
     q.submit([&](handler &cgh) {
       auto A = bufA.get_access<access::mode::write>(cgh);
-      auto B = bufB.get_access<access::mode::write>(cgh);
+      auto B = bufB.get_access<access::mode::read>(cgh);
       cgh.single_task<class kernel_args_restrict>(
           [=]() [[intel::kernel_args_restrict]]{
             A[0] = B[0];

--- a/polygeist/tools/cgeist/Test/Verification/sycl/restrict.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/restrict.cpp
@@ -3,25 +3,44 @@
 
 #include <sycl/sycl.hpp>
 
-// CHECK-MLIR: func.func @test_int(%arg0: memref<?xi32, 4> {{{.*}}llvm.noalias{{.*}}}, %arg1: memref<?xi32, 4> {{{.*}}llvm.noalias{{.*}}}) 
-// CHECK-LLVM: define spir_func {{.*}}i32 @test_int(i32 addrspace(4)* noalias {{.*}}%0, i32 addrspace(4)* noalias {{.*}}%1)
+// CHECK-MLIR-DAG: func.func @test_int(%arg0: memref<?xi32, 4> {{{.*}}llvm.noalias{{.*}}}, %arg1: memref<?xi32, 4> {{{.*}}llvm.noalias{{.*}}}) 
+// CHECK-LLVM-DAG: define spir_func {{.*}}i32 @test_int(i32 addrspace(4)* noalias {{.*}}%0, i32 addrspace(4)* noalias {{.*}}%1)
 
 extern "C" SYCL_EXTERNAL int test_int(int * __restrict__ a, int * __restrict__ b) {}
 
-// CHECK-MLIR: func.func @test_struct(%arg0: !llvm.ptr<struct<(i32)>, 4> {{{.*}}llvm.noalias{{.*}}}, %arg1: !llvm.ptr<struct<(i32)>, 4> {{{.*}}llvm.noalias{{.*}}})
-// CHECK-LLVM: define spir_func void @test_struct({ i32 } addrspace(4)* noalias {{.*}}%0, { i32 } addrspace(4)* noalias {{.*}}%1)
+// CHECK-MLIR-DAG: func.func @test_struct(%arg0: !llvm.ptr<struct<(i32)>, 4> {{{.*}}llvm.noalias{{.*}}}, %arg1: !llvm.ptr<struct<(i32)>, 4> {{{.*}}llvm.noalias{{.*}}})
+// CHECK-LLVM-DAG: define spir_func void @test_struct({ i32 } addrspace(4)* noalias {{.*}}%0, { i32 } addrspace(4)* noalias {{.*}}%1)
 struct S {
   int i;
 };
 extern "C" SYCL_EXTERNAL void test_struct(struct S * __restrict__ a, struct S * __restrict__ b) {}
 
-// CHECK-MLIR: func.func @test_vec(%arg0: memref<?x!sycl_vec_f64_16_, 4> {{{.*}}llvm.noalias{{.*}}}, %arg1: memref<?x!sycl_vec_f64_16_, 4> {{{.*}}llvm.noalias{{.*}}})
-// CHECK-LLVM: define spir_func void @test_vec(%"class.sycl::_V1::vec" addrspace(4)* noalias {{.*}}%0, %"class.sycl::_V1::vec" addrspace(4)* noalias {{.*}}%1)
+// CHECK-MLIR-DAG: func.func @test_vec(%arg0: memref<?x!sycl_vec_f64_16_, 4> {{{.*}}llvm.noalias{{.*}}}, %arg1: memref<?x!sycl_vec_f64_16_, 4> {{{.*}}llvm.noalias{{.*}}})
+// CHECK-LLVM-DAG: define spir_func void @test_vec(%"class.sycl::_V1::vec" addrspace(4)* noalias {{.*}}%0, %"class.sycl::_V1::vec" addrspace(4)* noalias {{.*}}%1)
 extern "C" SYCL_EXTERNAL void test_vec(sycl::vec<sycl::cl_double, 16> * __restrict__ a, const sycl::vec<sycl::cl_double, 16> * __restrict__ b) {}
 
-// CHECK-MLIR: func.func @_ZN1B10test_classEP1APS_(%arg0: !llvm.ptr<struct<(i8)>, 4> {{.*}}, %arg1: !llvm.ptr<struct<(i8)>, 4> {llvm.noalias{{.*}}}, %arg2: !llvm.ptr<struct<(i8)>, 4> {llvm.noalias{{.*}}})
-// CHECK-LLVM: define linkonce_odr spir_func void @_ZN1B10test_classEP1APS_({ i8 } addrspace(4)* {{.*}}%0, { i8 } addrspace(4)* noalias {{.*}}%1, { i8 } addrspace(4)* noalias {{.*}}%2)
+// CHECK-MLIR-DAG: func.func @_ZN1B10test_classEP1APS_(%arg0: !llvm.ptr<struct<(i8)>, 4> {{.*}}, %arg1: !llvm.ptr<struct<(i8)>, 4> {llvm.noalias{{.*}}}, %arg2: !llvm.ptr<struct<(i8)>, 4> {llvm.noalias{{.*}}})
+// CHECK-LLVM-DAG: define linkonce_odr spir_func void @_ZN1B10test_classEP1APS_({ i8 } addrspace(4)* {{.*}}%0, { i8 } addrspace(4)* noalias {{.*}}%1, { i8 } addrspace(4)* noalias {{.*}}%2)
 class A {};
 class B {
   SYCL_EXTERNAL void test_class(class A * __restrict__ a, class B * __restrict__ b) {}
 };
+
+// CHECK-MLIR-DAG: gpu.func @{{.*}}kernel_args_restrict(%arg0: memref<?xi32, 1> {{{.*}}llvm.noalias{{.*}}}, %arg1: memref<?x!sycl_range_1_>{{.*}}, %arg2: memref<?x!sycl_range_1_>{{.*}}, %arg3: memref<?x!sycl_id_1_>{{.*}})
+// CHECK-LLVM-DAG: define weak_odr spir_kernel void @{{.*}}kernel_args_restrict(i32 addrspace(1)* {{.*}}noalias{{.*}} %0, %"class.sycl::_V1::range.1"* {{.*}} %1, %"class.sycl::_V1::range.1"* {{.*}} %2, %"class.sycl::_V1::id.1"* {{.*}} %3)
+using namespace sycl;
+int args_restrict(std::array<int, 1> &A) {
+  queue q;
+  {
+    auto buf = buffer<int, 1>{A.data(), 1};
+    q.submit([&](handler &cgh) {
+      auto A = buf.get_access<access::mode::write>(cgh);
+      cgh.single_task<class kernel_args_restrict>(
+          [=]() [[intel::kernel_args_restrict]]{
+            A[0] = 1;
+          });
+
+    });
+  }
+  return 0;
+}


### PR DESCRIPTION
This PR handles `kernel_args_restrict` the same way as clang codegen.