### PR TITLE
[SYCL] Don't use project's CMAKE_CXX_FLAGS for in-tree e2e-tests configuration

### DIFF
--- a/sycl/test-e2e/CMakeLists.txt
+++ b/sycl/test-e2e/CMakeLists.txt
@@ -17,6 +17,7 @@ if(SYCL_TEST_E2E_STANDALONE)
   set(SYCL_CXX_COMPILER ${CMAKE_CXX_COMPILER})
 else()
   set(SYCL_CXX_COMPILER "${LLVM_BINARY_DIR}/bin/clang++")
+  unset(CMAKE_CXX_FLAGS)
 endif() # Standalone.
 
 find_package(Threads REQUIRED)


### PR DESCRIPTION
It contains all our "-Werror/-W*/etc." that we use to build the project that have nothing to do with our end-to-end tests.