### PR TITLE
[SYCL][E2E LIT] Don't spoil current directory with temporary files

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -127,6 +127,11 @@ if lit_config.params.get('ze_debug'):
     config.ze_debug = lit_config.params.get('ze_debug')
     lit_config.note("ZE_DEBUG: "+config.ze_debug)
 
+# Make sure that any dynamic checks below are done in the build directory and
+# not where the sources are located. This is important for the in-tree
+# configuration (as opposite to the standalone one).
+os.chdir(config.sycl_obj_root)
+
 # check if compiler supports CL command line options
 cl_options=False
 sp = subprocess.getstatusoutput(config.dpcpp_compiler+' /help')


### PR DESCRIPTION
After https://github.com/intel/llvm/pull/8854 it's possible to run llvm-lit from anywhere and not be restricted to the end-to-end tests' build directory. However, lit.cfg.py performs auto-detection of some features by creating and compiling small test files. Make sure that those are kept in the build directory no matter where we run llvm-lit from.