### PR TITLE
[SYCL] [E2E] Fix host access to result buffers

### DIFF
--- a/sycl/test-e2e/Regression/same_unnamed_kernels.cpp
+++ b/sycl/test-e2e/Regression/same_unnamed_kernels.cpp
@@ -2,7 +2,6 @@
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
-// XFAIL: gpu
 // UNSUPPORTED: hip
 
 //==----- same_unnamed_kernels.cpp - SYCL kernel naming variants test ------==//
@@ -41,7 +40,9 @@ int main() {
         acc[0] *= 2;
       });
 
-  if (A[0] != 0 || B[0] != 2)
+  sycl::host_accessor hostA{bufA, sycl::read_only};
+  sycl::host_accessor hostB{bufB, sycl::read_only};
+  if (hostA[0] != 0 || hostB[0] != 2)
     return -1;
 
   return 0;


### PR DESCRIPTION
The test was assuming that the SYCL buffers which wrapped host addresses would always be accessible to the host. This is not true for all devices. This fixes the test by using accessors.