### PR TITLE
[SYCL-MLIR][LICM] Allow versioning on affine loop

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
@@ -743,7 +743,7 @@ collectHoistableOperations(LoopLikeOpInterface loop,
         candidate.getRequireNoOverlapAccessorPairs();
     bool requireVersioning = !accessorPairs.empty();
     bool willVersion = requireVersioning && EnableLICMSYCLAccessorVersioning &&
-                       isa<scf::ForOp>(loop) && numVersion < LICMVersionLimit &&
+                       numVersion < LICMVersionLimit &&
                        accessorPairs.size() <= LICMSYCLAccessorPairsLimit;
     if (willVersion)
       ++numVersion;


### PR DESCRIPTION
This PR fixes the lit failure on `llvm/polygeist/test/polygeist-opt/sycl/licm-accessor-versioning.mlir`. The failure is due to merging https://github.com/intel/llvm/pull/9030 without first rebasing it on https://github.com/intel/llvm/pull/9032.
No regressions on SYCL-Bench.