### PR TITLE
[SYCL-MLIR] Create utilities from argument promotion for code reuse 

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -22,6 +22,7 @@ namespace mlir {
 class AffineForOp;
 class AffineIfOp;
 class AffineParallelOp;
+class CallOpInterface;
 class DominanceInfo;
 class FunctionOpInterface;
 class LoopLikeOpInterface;
@@ -44,13 +45,17 @@ void fully2ComposeAffineMapAndOperands(PatternRewriter &rewriter,
                                        DominanceInfo &DI);
 bool isValidIndex(Value val);
 
-/// Returns true if the given function has linkonce_odr linkage.
+/// Returns true if the given function has 'linkonce_odr' LLVM  linkage.
 bool isLinkonceODR(FunctionOpInterface);
 
-/// Return true if the given function is only called from GPU kernels.
-bool isOnlyCalledFromGPUKernel(FunctionOpInterface);
+/// Returns true if the given call is a tail call.
+bool isTailCall(CallOpInterface);
 
-/// Return true if the given function is potentially a SYCL kernel body
+/// Returns the maximum depth from a GPU kernel.
+/// Returns -1 if the call is not called from a GPU kernel.
+int getMaxDepthFromGPUKernel(FunctionOpInterface);
+
+/// Returns true if the given function is potentially a SYCL kernel body
 /// function. The SYCL kernel body function is created by SemaSYCL in clang for
 /// the body of the SYCL kernel, e.g., code in parallel_for.
 /// TODO: add an attribute to the call operator of the SYCL kernel functor in

--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -51,8 +51,15 @@ bool isLinkonceODR(FunctionOpInterface);
 /// Returns true if the given call is a tail call.
 bool isTailCall(CallOpInterface);
 
-/// Returns the maximum depth from a GPU kernel.
+/// Returns the maximum depth from any GPU kernel.
 /// Returns std::nullopt if the call is not called from a GPU kernel.
+/// For example:
+/// Call chains:
+///   GPUKernel1 -> func1 (depth 1) -> func2 (depth 2)
+///   GPUKernel2 -> func2 (depth 1)
+/// =>
+///   getMaxDepthFromAnyGPUKernel(func1) returns 1.
+///   getMaxDepthFromAnyGPUKernel(func2) returns 2.
 Optional<unsigned> getMaxDepthFromAnyGPUKernel(FunctionOpInterface);
 
 /// Returns true if the given function is potentially a SYCL kernel body

--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -52,8 +52,8 @@ bool isLinkonceODR(FunctionOpInterface);
 bool isTailCall(CallOpInterface);
 
 /// Returns the maximum depth from a GPU kernel.
-/// Returns -1 if the call is not called from a GPU kernel.
-int getMaxDepthFromGPUKernel(FunctionOpInterface);
+/// Returns std::nullopt if the call is not called from a GPU kernel.
+Optional<unsigned> getMaxDepthFromAnyGPUKernel(FunctionOpInterface);
 
 /// Returns true if the given function is potentially a SYCL kernel body
 /// function. The SYCL kernel body function is created by SemaSYCL in clang for

--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -44,8 +44,17 @@ void fully2ComposeAffineMapAndOperands(PatternRewriter &rewriter,
                                        DominanceInfo &DI);
 bool isValidIndex(Value val);
 
+/// Returns true if the given function has linkonce_odr linkage.
+bool isLinkonceODR(FunctionOpInterface);
+
+/// Return true if the given function is only called from GPU kernels.
+bool isOnlyCalledFromGPUKernel(FunctionOpInterface);
+
 /// Return true if the given function is potentially a SYCL kernel body
-/// function.
+/// function. The SYCL kernel body function is created by SemaSYCL in clang for
+/// the body of the SYCL kernel, e.g., code in parallel_for.
+/// TODO: add an attribute to the call operator of the SYCL kernel functor in
+/// SemaSYCL in clang, to identify SYCL kernel body function accurately.
 bool isPotentialKernelBodyFunc(FunctionOpInterface);
 
 //===----------------------------------------------------------------------===//

--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -23,6 +23,7 @@ class AffineForOp;
 class AffineIfOp;
 class AffineParallelOp;
 class DominanceInfo;
+class FunctionOpInterface;
 class LoopLikeOpInterface;
 class PatternRewriter;
 class RegionBranchOpInterface;
@@ -42,6 +43,10 @@ void fully2ComposeAffineMapAndOperands(PatternRewriter &rewriter,
                                        SmallVectorImpl<Value> *operands,
                                        DominanceInfo &DI);
 bool isValidIndex(Value val);
+
+/// Return true if the given function is potentially a SYCL kernel body
+/// function.
+bool isPotentialKernelBodyFunc(FunctionOpInterface);
 
 //===----------------------------------------------------------------------===//
 // Loop Versioning Utilities

--- a/polygeist/lib/Dialect/Polygeist/Transforms/ArgumentPromotion.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/ArgumentPromotion.cpp
@@ -592,10 +592,11 @@ bool ArgumentPromotionPass::isCandidateCallable(
   // in a function that is called directly by a GPU kernel.
   // TODO: Could generalize by checking that the call chain from the GPU kernel
   // are all candidates.
-  int maxDepth = getMaxDepthFromGPUKernel(funcOp);
-  assert(maxDepth > 0 && "Expecting func to be called from a GPU kernel and "
-                         "not itself a GPU kernel");
-  if (maxDepth > 2) {
+  Optional<unsigned> maxDepth = getMaxDepthFromAnyGPUKernel(funcOp);
+  assert(maxDepth.has_value() &&
+         "Expecting func to be called from a GPU kernel");
+  assert(maxDepth.value() != 0 && "Expecting func is not itself a GPU kernel");
+  if (maxDepth.value() > 2) {
     LLVM_DEBUG(llvm::dbgs().indent(2)
                << "not a candidate: found call site that is called by a GPU "
                   "kernel with depth more than 2.\n");

--- a/polygeist/lib/Dialect/Polygeist/Utils/CMakeLists.txt
+++ b/polygeist/lib/Dialect/Polygeist/Utils/CMakeLists.txt
@@ -5,6 +5,7 @@ add_mlir_dialect_library(MLIRPolygeistUtils
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Polygeist/Utils
 
   LINK_LIBS PUBLIC
+  MLIRGPUOps
   MLIRPolygeistDialect
   MLIRSYCLDialect
   MLIRDialect

--- a/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
@@ -34,7 +34,9 @@ bool mlir::isLinkonceODR(FunctionOpInterface func) {
 bool mlir::isTailCall(CallOpInterface call) {
   if (!call->getBlock()->hasNoSuccessors())
     return false;
-  return isRegionReturnLike(call->getNextNode());
+  Operation *nextOp = call->getNextNode();
+  return (nextOp->hasTrait<OpTrait::IsTerminator>() ||
+          isRegionReturnLike(nextOp));
 }
 
 /// Populate \p funcMaxDepthMap with the maximum depth from a GPU kernel for \p

--- a/polygeist/test/polygeist-opt/sycl/argpromotion.mlir
+++ b/polygeist/test/polygeist-opt/sycl/argpromotion.mlir
@@ -48,7 +48,7 @@ gpu.module @device_func {
     gpu.return
   }
 
-  // COM: Ensure that the peelable argument is peeled if there is a non-aliased instruction after the call.
+  // COM: Ensure that the peelable argument is peeled if it is called from a GPU kernel.
   func.func private @callee1_wrapper(%arg0: memref<?x!llvm.struct<(i32, i64)>>) -> i64 {
     // CHECK-LABEL: func.func private @callee1_wrapper
     // CHECK-SAME:    (%arg0: memref<?x!llvm.struct<(i32, i64)>>) -> i64
@@ -57,11 +57,8 @@ gpu.module @device_func {
     // CHECK-NEXT:    %c1 = arith.constant 1 : index
     // CHECK-NEXT:    [[ARG1:%.*]] = "polygeist.subindex"(%arg0, %c1) : (memref<?x!llvm.struct<(i32, i64)>>, index) -> memref<?xi64>
     // CHECK-NEXT:    {{.*}} = call @callee1([[ARG0]], [[ARG1]]) : (memref<?xi32>, memref<?xi64>) -> i64
-    %alloca = memref.alloca() : memref<i64>        
     %0 = func.call @callee1(%arg0) : (memref<?x!llvm.struct<(i32, i64)>>) -> i64
-    %1 = memref.load %alloca[] : memref<i64>
-    %add = arith.addi %0, %1 : i64
-    func.return %add : i64
+    func.return %0 : i64
   }
 
   // COM: Test that multiple peelable arguments are peeled correctly.

--- a/polygeist/test/polygeist-opt/sycl/argpromotion.mlir
+++ b/polygeist/test/polygeist-opt/sycl/argpromotion.mlir
@@ -48,7 +48,7 @@ gpu.module @device_func {
     gpu.return
   }
 
-  // COM: Ensure that the peelable argument is peeled if it is called from a GPU kernel.
+  // COM: Ensure that the peelable argument is peeled if there is a non-aliased instruction after the call.
   func.func private @callee1_wrapper(%arg0: memref<?x!llvm.struct<(i32, i64)>>) -> i64 {
     // CHECK-LABEL: func.func private @callee1_wrapper
     // CHECK-SAME:    (%arg0: memref<?x!llvm.struct<(i32, i64)>>) -> i64
@@ -57,8 +57,11 @@ gpu.module @device_func {
     // CHECK-NEXT:    %c1 = arith.constant 1 : index
     // CHECK-NEXT:    [[ARG1:%.*]] = "polygeist.subindex"(%arg0, %c1) : (memref<?x!llvm.struct<(i32, i64)>>, index) -> memref<?xi64>
     // CHECK-NEXT:    {{.*}} = call @callee1([[ARG0]], [[ARG1]]) : (memref<?xi32>, memref<?xi64>) -> i64
+    %alloca = memref.alloca() : memref<i64>
     %0 = func.call @callee1(%arg0) : (memref<?x!llvm.struct<(i32, i64)>>) -> i64
-    func.return %0 : i64
+    %1 = memref.load %alloca[] : memref<i64>
+    %add = arith.addi %0, %1 : i64
+    func.return %add : i64
   }
 
   // COM: Test that multiple peelable arguments are peeled correctly.


### PR DESCRIPTION
These utilities are created, so that there can be code reuse between `ArgumentPromotion` pass and the function versioning pass that is going to be added.