### PR TITLE
[ESIMD] Fix compilation errors caused by type_name() function

### DIFF
--- a/sycl/test-e2e/ESIMD/dword_atomic_cmpxchg.cpp
+++ b/sycl/test-e2e/ESIMD/dword_atomic_cmpxchg.cpp
@@ -1,4 +1,4 @@
-//==---------------- dword_atomic_smoke.cpp  - DPC++ ESIMD on-device test --==//
+//==-------------- dword_atomic_cmpxchg.cpp  - DPC++ ESIMD on-device test --==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,15 +10,12 @@
 // REQUIRES: gpu
 // UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
-// TODO: Re-enable this test on Windows after the following issue gets fixed:
-// https://github.com/intel/llvm/issues/8934
-// UNSUPPORTED: windows
-// TODO: esimd_emulator fails due to random timeouts (_XFAIL_: esimd_emulator)
+// TODO: esimd_emulator fails due to random timeouts
 // UNSUPPORTED: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-// This macro enables only cmpxch tests. They may require more time to execute,
+// This macro enables only cmpxchg tests. They may require more time to execute,
 // and have higher probablity to hit kernel execution time limit, so they are
 // separated.
 #define CMPXCHG_TEST

--- a/sycl/test-e2e/ESIMD/dword_atomic_cmpxchg_scalar_off.cpp
+++ b/sycl/test-e2e/ESIMD/dword_atomic_cmpxchg_scalar_off.cpp
@@ -10,15 +10,12 @@
 // REQUIRES: gpu
 // UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
-// TODO: Re-enable this test on Windows after the following issue gets fixed:
-// https://github.com/intel/llvm/issues/8934
-// UNSUPPORTED: windows
-// TODO: esimd_emulator fails due to random timeouts (_XFAIL_: esimd_emulator)
+// TODO: esimd_emulator fails due to random timeouts
 // UNSUPPORTED: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-// This macro enables only cmpxch tests. They may require more time to execute,
+// This macro enables only cmpxchg tests. They may require more time to execute,
 // and have higher probablity to hit kernel execution time limit, so they are
 // separated.
 #define CMPXCHG_TEST

--- a/sycl/test-e2e/ESIMD/dword_atomic_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/dword_atomic_smoke.cpp
@@ -10,9 +10,7 @@
 // REQUIRES: gpu
 // UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
-// TODO: Re-enable this test on Windows after the following issue gets fixed:
-// https://github.com/intel/llvm/issues/8934
-// UNSUPPORTED: windows
+
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 

--- a/sycl/test-e2e/ESIMD/dword_atomic_smoke_scalar_off.cpp
+++ b/sycl/test-e2e/ESIMD/dword_atomic_smoke_scalar_off.cpp
@@ -10,9 +10,6 @@
 // REQUIRES: gpu
 // UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
-// TODO: Re-enable this test on Windows after the following issue gets fixed:
-// https://github.com/intel/llvm/issues/8934
-// UNSUPPORTED: windows
 // TODO: esimd_emulator fails due to random timeouts (_XFAIL_: esimd_emulator)
 // UNSUPPORTED: esimd_emulator
 // RUN: %clangxx -fsycl %s -o %t.out

--- a/sycl/test-e2e/ESIMD/esimd_test_utils.hpp
+++ b/sycl/test-e2e/ESIMD/esimd_test_utils.hpp
@@ -568,7 +568,7 @@ std::unique_ptr<T, USMDeleter> usm_malloc_shared(queue q, int n) {
   return std::move(res);
 }
 
-template <class T> static const char *type_name();
+template <class T> const char *type_name();
 #define TID(T)                                                                 \
   template <> const char *type_name<T>() { return #T; }
 TID(char) // for some reason, 'char' does not match 'int8_t' during

--- a/sycl/test-e2e/ESIMD/esimd_test_utils.hpp
+++ b/sycl/test-e2e/ESIMD/esimd_test_utils.hpp
@@ -568,7 +568,7 @@ std::unique_ptr<T, USMDeleter> usm_malloc_shared(queue q, int n) {
   return std::move(res);
 }
 
-template <class T> const char *type_name();
+template <class T> const char *type_name() { return typeid(T).name(); }
 #define TID(T)                                                                 \
   template <> const char *type_name<T>() { return #T; }
 TID(char) // for some reason, 'char' does not match 'int8_t' during


### PR DESCRIPTION
The usage of static for one of utility functions caused such warnings before: function 'esimd_test::type_name<unsigned long>' has internal linkage
      but is not defined [-Wundefined-internal]

Fixes https://github.com/intel/llvm/issues/8934