### PR TITLE
[SYCL][clang][NFC] Correct clang LIT tests

### DIFF
--- a/clang/test/CodeGenSYCL/kernel-op-calls.cpp
+++ b/clang/test/CodeGenSYCL/kernel-op-calls.cpp
@@ -41,19 +41,19 @@ int main() {
 
   Q.submit([&](sycl::handler& cgh) {
       Functor1 F;
-      // CHECK: define dso_local spir_kernel void @_ZTS8Functor1() #0 !srcloc !11 !kernel_arg_buffer_location !12 !intel_reqd_sub_group_size !13 !sycl_fixed_targets !12 {
+      // CHECK: define dso_local spir_kernel void @_ZTS8Functor1() {{.*}} !kernel_arg_buffer_location !{{[0-9]+}} !intel_reqd_sub_group_size !{{[0-9]+}} !sycl_fixed_targets !{{[0-9]+}} {
       cgh.parallel_for(sycl::range<1>(10), F);
     });
 
   Q.submit([&](sycl::handler& cgh) {
       kernels K;
-      // CHECK: define dso_local spir_kernel void @_ZTS7kernels() #0 !srcloc !15 !kernel_arg_buffer_location !12 !work_group_size_hint !16 !sycl_fixed_targets !12 {
+      // CHECK: define dso_local spir_kernel void @_ZTS7kernels() {{.*}} !kernel_arg_buffer_location !{{[0-9]+}} !work_group_size_hint !{{[0-9]+}} !sycl_fixed_targets !{{[0-9]+}} {
       cgh.parallel_for(sycl::range<1>(10), K);
     });
 
   Q.submit([&](sycl::handler& cgh) {
       ESIMDFunctor EF;
-      // CHECK: define dso_local spir_kernel void @_ZTS12ESIMDFunctor() #0 !srcloc !17 !intel_reqd_sub_group_size !18 !work_group_size_hint !16 !kernel_arg_addr_space !12 !kernel_arg_access_qual !12 !kernel_arg_type !12 !kernel_arg_base_type !12 !kernel_arg_type_qual !12 !kernel_arg_accessor_ptr !12 !sycl_explicit_simd !12 !sycl_fixed_targets !12 {
+      // CHECK: define dso_local spir_kernel void @_ZTS12ESIMDFunctor() {{.*}} !intel_reqd_sub_group_size !{{[0-9]+}} !work_group_size_hint !{{[0-9]+}} !kernel_arg_addr_space !{{[0-9]+}} !kernel_arg_access_qual !{{[0-9]+}} !kernel_arg_type !{{[0-9]+}} !kernel_arg_base_type !{{[0-9]+}} !kernel_arg_type_qual !{{[0-9]+}} !kernel_arg_accessor_ptr !{{[0-9]+}} !sycl_explicit_simd !{{[0-9]+}} !sycl_fixed_targets !{{[0-9]+}} {
       cgh.parallel_for(sycl::range<1>(10), EF);
     });
 

--- a/clang/test/CodeGenSYCL/sycl-add-opt-level-attrib.cpp
+++ b/clang/test/CodeGenSYCL/sycl-add-opt-level-attrib.cpp
@@ -6,7 +6,7 @@
 // This test checks adding of the attribute 'sycl-optlevel'
 // by the clang front-end
 
-#include <sycl/sycl.hpp>
+#include "Inputs/sycl.hpp"
 
 int main() {
   sycl::queue q;


### PR DESCRIPTION
CodeGenSYCL/kernel-op-calls.cpp :
Do not check exact numbers since they may vary if for example one more attribute is applied.

CodegenSYCL/sycl-add-opt-level-attrib.cpp :
Real SYCL headers should not be included into clang LIT tests, this may cause a lot of problems during testing. Include mock headers instead.