### PR TITLE
[SYCL] Add simple abs(int) to imf libdevice

### DIFF
--- a/libdevice/device_imf.hpp
+++ b/libdevice/device_imf.hpp
@@ -13,6 +13,7 @@
 #include "imf_bf16.hpp"
 #include "imf_half.hpp"
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <type_traits>
 #ifdef __LIBDEVICE_IMF_ENABLED__

--- a/libdevice/imf/imf_inline_fp32.cpp
+++ b/libdevice/imf/imf_inline_fp32.cpp
@@ -132,7 +132,7 @@ DEVICE_EXTERN_C_INLINE float __devicelib_imf_fminf(float a, float b) {
 }
 
 DEVICE_EXTERN_C_INLINE int32_t __devicelib_imf_abs(int32_t x) {
-  return (x > 0) ? x : -x;
+  return (x >= 0) ? x : -x;
 }
 
 DEVICE_EXTERN_C_INLINE float __devicelib_imf_fabsf(float x) {

--- a/libdevice/imf/imf_inline_fp32.cpp
+++ b/libdevice/imf/imf_inline_fp32.cpp
@@ -131,6 +131,10 @@ DEVICE_EXTERN_C_INLINE float __devicelib_imf_fminf(float a, float b) {
   return __fmin(a, b);
 }
 
+DEVICE_EXTERN_C_INLINE int32_t __devicelib_imf_abs(int32_t x) {
+  return (x > 0) ? x : -x;
+}
+
 DEVICE_EXTERN_C_INLINE float __devicelib_imf_fabsf(float x) {
   return __fabs(x);
 }

--- a/libdevice/imf_wrapper.cpp
+++ b/libdevice/imf_wrapper.cpp
@@ -544,6 +544,12 @@ DEVICE_EXTERN_C_INLINE
 float __imf_invf(float x) { return __devicelib_imf_invf(x); }
 
 DEVICE_EXTERN_C_INLINE
+int32_t __devicelib_imf_abs(int32_t);
+
+DEVICE_EXTERN_C_INLINE
+int32_t __imf_abs(int32_t x) { return __devicelib_imf_abs(x); }
+
+DEVICE_EXTERN_C_INLINE
 float __devicelib_imf_fabsf(float);
 
 DEVICE_EXTERN_C_INLINE

--- a/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.cpp
+++ b/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.cpp
@@ -201,6 +201,7 @@ SYCLDeviceLibFuncMap SDLMap = {
     {"__devicelib_imf_fmaf", DeviceLibExt::cl_intel_devicelib_imf},
     {"__devicelib_imf_floorf", DeviceLibExt::cl_intel_devicelib_imf},
     {"__devicelib_imf_ceilf", DeviceLibExt::cl_intel_devicelib_imf},
+    {"__devicelib_imf_abs", DeviceLibExt::cl_intel_devicelib_imf},
     {"__devicelib_imf_fabsf", DeviceLibExt::cl_intel_devicelib_imf},
     {"__devicelib_imf_truncf", DeviceLibExt::cl_intel_devicelib_imf},
     {"__devicelib_imf_rintf", DeviceLibExt::cl_intel_devicelib_imf},

--- a/sycl/include/sycl/builtins.hpp
+++ b/sycl/include/sycl/builtins.hpp
@@ -2693,6 +2693,7 @@ extern __DPCPP_SYCL_EXTERNAL long long int __imf_mul64hi(long long int x,
                                                          long long int y);
 extern __DPCPP_SYCL_EXTERNAL unsigned long long int
 __imf_umul64hi(unsigned long long int x, unsigned long long int y);
+extern __DPCPP_SYCL_EXTERNAL int __imf_abs(int x);
 extern __DPCPP_SYCL_EXTERNAL float __imf_saturatef(float x);
 extern __DPCPP_SYCL_EXTERNAL float __imf_fmaf(float x, float y, float z);
 extern __DPCPP_SYCL_EXTERNAL float __imf_fabsf(float x);


### PR DESCRIPTION
This PR aims to add a simple "int32_t abs(int32_t)" to imf libdevice. The request is from DL framework developers.