### PR TITLE
[NFC] Use typed pointers for null function pointers debug info

### DIFF
--- a/llvm-spirv/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
+++ b/llvm-spirv/lib/SPIRV/LLVMToSPIRVDbgTran.cpp
@@ -1018,8 +1018,10 @@ LLVMToSPIRVDbgTran::transDbgTemplateParameter(const DITemplateParameter *TP) {
       Constant *C = cast<ConstantAsMetadata>(TVVal)->getValue();
       Ops[ValueIdx] = SPIRVWriter->transValue(C, nullptr)->getId();
     } else {
-      SPIRVType *TyPtr =
-          SPIRVWriter->transType(PointerType::get(M->getContext(), 0));
+      // intel/llvm customization for opaque pointers begin
+      SPIRVType *TyPtr = SPIRVWriter->transType(
+          PointerType::get(Type::getInt8Ty(M->getContext()), 0));
+      // customization end
       Ops[ValueIdx] = BM->addNullConstant(TyPtr)->getId();
     }
   }


### PR DESCRIPTION
It's customization on top of
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/1956

`PointerType::get(Context` will return typeless/opaque pointer. While it is OK for KHR translator since it's being built on top of LLVM trunk, where opaque pointers are enabled by default - it won't work for intel/llvm, where their generation is disabled.