### PR TITLE
[Draft][SYCL][E2E] Detect supported aspects at config time

### DIFF
--- a/sycl/test-e2e/Basic/half_builtins.cpp
+++ b/sycl/test-e2e/Basic/half_builtins.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp16
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
@@ -166,12 +167,7 @@ template <int N> bool check(vec<float, N> a, vec<float, N> b) {
 int main() {
   queue q;
 
-  if (!q.get_device().has(sycl::aspect::fp16)) {
-    std::cout
-        << "Test was skipped because the selected device does not support fp16"
-        << std::endl;
-    return 0;
-  }
+  assert(q.get_device().has(sycl::aspect::fp16) && "Requires fp16");
 
   float16 a, b, c, d;
   for (int i = 0; i < SZ_max; i++) {

--- a/sycl/test-e2e/Basic/half_type.cpp
+++ b/sycl/test-e2e/Basic/half_type.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp16
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
@@ -238,11 +239,7 @@ int main() {
   constexpr_verify_div();
 
   device dev{default_selector_v};
-  if (!dev.has(sycl::aspect::fp16)) {
-    std::cout << "This device doesn't support the extension cl_khr_fp16"
-              << std::endl;
-    return 0;
-  }
+  assert(dev.has(sycl::aspect::fp16) && "Requires fp16");
 
   std::vector<half> vec_a(N, 5.0);
   std::vector<half> vec_b(N, 2.0);

--- a/sycl/test-e2e/Basic/image/image_accessor_readwrite_half.cpp
+++ b/sycl/test-e2e/Basic/image/image_accessor_readwrite_half.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp16
 // UNSUPPORTED: cuda || hip || gpu-intel-pvc
 // CUDA cannot support SYCL 1.2.1 images.
 //
@@ -148,11 +149,7 @@ int main() {
   // Checking if default selected device supports half datatype.
   // Same device will be selected in the write/read functions.
   s::device Dev{s::default_selector_v};
-  if (!Dev.has(sycl::aspect::fp16)) {
-    std::cout << "This device doesn't support the extension cl_khr_fp16"
-              << std::endl;
-    return 0;
-  }
+  assert(Dev.has(sycl::aspect::fp16) && "Requires fp16");
   // Checking only for dimension=1.
   // create image:
   char HostPtr[100];

--- a/sycl/test-e2e/Basic/image/image_read_fp16.cpp
+++ b/sycl/test-e2e/Basic/image/image_read_fp16.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp16
 // UNSUPPORTED: hip || gpu-intel-pvc
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
@@ -9,8 +10,7 @@ int main() {
   s::queue myQueue(s::default_selector_v);
 
   // Device doesn't support cl_khr_fp16 extension - skip.
-  if (!myQueue.get_device().has(sycl::aspect::fp16))
-    return 0;
+  assert(myQueue.get_device().has(sycl::aspect::fp16) && "Requires fp16");
 
   // Half image
   if (!test<s::half4, s::image_channel_type::fp16>(myQueue))

--- a/sycl/test-e2e/DeviceLib/built-ins/ext_native_math_fp16.cpp
+++ b/sycl/test-e2e/DeviceLib/built-ins/ext_native_math_fp16.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp16
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsycl-device-code-split=per_kernel %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
@@ -15,11 +16,7 @@ int main() {
 
   sycl::queue q;
 
-  if (!q.get_device().has(sycl::aspect::fp16)) {
-    std::cout << "skipping fp16 tests: requires fp16 device aspect."
-              << std::endl;
-    return 0;
-  }
+  assert(q.get_device().has(sycl::aspect::fp16) && "Requires fp16");
 
   const sycl::half tv[16] = {-2.0, -1.5, -1.0, 0.0, 2.0,  1.5, 1.0,   0.0,
                              -1.7, 1.7,  -1.2, 1.2, -3.0, 3.0, -10.0, 10.0};

--- a/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp64
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
@@ -162,9 +163,8 @@ template <class T> void device_cmath_test(s::queue &deviceQueue) {
 
 int main() {
   s::queue deviceQueue;
-  if (deviceQueue.get_device().has(sycl::aspect::fp64)) {
-    device_cmath_test<double>(deviceQueue);
-    std::cout << "Pass" << std::endl;
-  }
+  assert(deviceQueue.get_device().has(sycl::aspect::fp64) && "Requires fp64");
+  device_cmath_test<double>(deviceQueue);
+  std::cout << "Pass" << std::endl;
   return 0;
 }

--- a/sycl/test-e2e/DeviceLib/imf_double2half.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_double2half.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp16 && fp64
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
@@ -19,15 +20,9 @@ int main() {
             << device_queue.get_device().get_info<sycl::info::device::name>()
             << "\n";
 
-  if (!device_queue.get_device().has(sycl::aspect::fp64)) {
-    std::cout << "Test skipped on platform without fp64 support." << std::endl;
-    return 0;
-  }
-
-  if (!device_queue.get_device().has(sycl::aspect::fp16)) {
-    std::cout << "Test skipped on platform without fp16 support." << std::endl;
-    return 0;
-  }
+  assert(device_queue.get_device().has(sycl::aspect::fp16) &&
+         device_queue.get_device().has(sycl::aspect::fp64) &&
+         "Requires fp16 and fp64");
 
   {
     std::initializer_list<uint64_t> input_vals = {

--- a/sycl/test-e2e/DeviceLib/imf_fp16_trivial_test.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_fp16_trivial_test.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp16
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
@@ -14,10 +15,7 @@ int main(int, char **) {
             << device_queue.get_device().get_info<sycl::info::device::name>()
             << "\n";
 
-  if (!device_queue.get_device().has(sycl::aspect::fp16)) {
-    std::cout << "Test skipped on platform without fp16 support." << std::endl;
-    return 0;
-  }
+  assert(device_queue.get_device().has(sycl::aspect::fp16) && "Requires fp16");
 
   {
     std::initializer_list<sycl::half> input_vals1 = {0.5f, -1.125f, 100.5f,

--- a/sycl/test-e2e/DeviceLib/imf_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_fp64_test.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp64
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
@@ -60,10 +61,7 @@ int main(int, char **) {
   std::cout << "Running on "
             << device_queue.get_device().get_info<s::info::device::name>()
             << "\n";
-  if (!device_queue.get_device().has(sycl::aspect::fp64)) {
-    std::cout << "Test skipped on platform without fp64 support." << std::endl;
-    return 0;
-  }
+  assert(device_queue.get_device().has(sycl::aspect::fp64) && "Requires fp64");
 
   {
     std::initializer_list<double> input_vals = {0.0,

--- a/sycl/test-e2e/DeviceLib/imf_half_type_cast.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_half_type_cast.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp16
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
@@ -70,10 +71,7 @@ int main() {
             << device_queue.get_device().get_info<sycl::info::device::name>()
             << "\n";
 
-  if (!device_queue.get_device().has(sycl::aspect::fp16)) {
-    std::cout << "Test skipped on platform without fp16 support." << std::endl;
-    return 0;
-  }
+  assert(device_queue.get_device().has(sycl::aspect::fp16) && "Requires fp16");
 
   // half2int tests
   {

--- a/sycl/test-e2e/DeviceLib/math_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/math_fp64_test.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp64
 // UNSUPPORTED: hip
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
@@ -165,9 +166,8 @@ void device_math_test(s::queue &deviceQueue) {
 
 int main() {
   s::queue deviceQueue;
-  if (deviceQueue.get_device().has(sycl::aspect::fp64)) {
-    device_math_test(deviceQueue);
-    std::cout << "Pass" << std::endl;
-  }
+  assert(deviceQueue.get_device().has(sycl::aspect::fp64) && "Requires fp64");
+  device_math_test(deviceQueue);
+  std::cout << "Pass" << std::endl;
   return 0;
 }

--- a/sycl/test-e2e/DeviceLib/math_fp64_windows_test.cpp
+++ b/sycl/test-e2e/DeviceLib/math_fp64_windows_test.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp64
 // UNSUPPORTED: windows
 // Disabled on windows due to bug VS 2019 missing math builtins
 
@@ -125,9 +126,8 @@ void device_math_test(s::queue &deviceQueue) {
 
 int main() {
   s::queue deviceQueue;
-  if (deviceQueue.get_device().has(sycl::aspect::fp64)) {
-    device_math_test(deviceQueue);
-    std::cout << "Pass" << std::endl;
-  }
+  assert(deviceQueue.get_device().has(sycl::aspect::fp64) && "Requires fp64");
+  device_math_test(deviceQueue);
+  std::cout << "Pass" << std::endl;
   return 0;
 }

--- a/sycl/test-e2e/DeviceLib/math_test_marray_vec_fp16.cpp
+++ b/sycl/test-e2e/DeviceLib/math_test_marray_vec_fp16.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp16
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
@@ -11,11 +12,8 @@
 int main() {
   queue deviceQueue;
 
-  if (!deviceQueue.get_device().has(sycl::aspect::fp16)) {
-    std::cout << "skipping fp16 tests: requires fp16 device aspect."
-              << std::endl;
-    return 0;
-  }
+  assert(deviceQueue.get_device().has(sycl::aspect::fp16) && "Requires fp16");
+
   math_tests_4<half4>(deviceQueue);
   math_tests_4<marray<half, 4>>(deviceQueue);
   math_tests_3<half3>(deviceQueue);

--- a/sycl/test-e2e/DeviceLib/std_complex_math_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/std_complex_math_fp64_test.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp64
 // RUN: %clangxx -fsycl  %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %ACC_RUN_PLACEHOLDER %t.out
@@ -198,8 +199,7 @@ void device_complex_test(s::queue &deviceQueue) {
 
 int main() {
   s::queue deviceQueue;
-  if (deviceQueue.get_device().has(sycl::aspect::fp64)) {
-    device_complex_test(deviceQueue);
-    std::cout << "Pass" << std::endl;
-  }
+  assert(deviceQueue.get_device().has(sycl::aspect::fp64) && "Requires fp64");
+  device_complex_test(deviceQueue);
+  std::cout << "Pass" << std::endl;
 }

--- a/sycl/test-e2e/ESIMD/vadd_half.cpp
+++ b/sycl/test-e2e/ESIMD/vadd_half.cpp
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: gpu
+// REQUIRES: gpu && fp16
 // UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl %s -o %t.out
@@ -60,12 +60,7 @@ int main(int argc, char **argv) {
   auto dev = q.get_device();
   std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
 
-  if (!dev.has(sycl::aspect::fp16)) {
-    std::cout << "Test was skipped becasue the selected device does not "
-                 "support sycl::aspect::fp16"
-              << std::endl;
-    return 0;
-  }
+  assert(dev.has(sycl::aspect::fp16) && "Requires fp16");
 
   TstT *A = malloc_shared<TstT>(Size, q);
   SrcT *B = malloc_shared<SrcT>(Size, q);

--- a/sycl/test-e2e/Regression/fp16-with-unnamed-lambda.cpp
+++ b/sycl/test-e2e/Regression/fp16-with-unnamed-lambda.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp16
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsycl-unnamed-lambda %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
@@ -20,8 +21,7 @@ int main() {
   sycl::queue Q(AsyncHandler);
 
   sycl::device D = Q.get_device();
-  if (!D.has(sycl::aspect::fp16))
-    return 0; // Skip the test if halfs are not supported
+  assert(D.has(sycl::aspect::fp16) && "Requires fp16");
 
   sycl::buffer<sycl::half> Buf(1);
 

--- a/sycl/test-e2e/SubGroup/broadcast_fp64.cpp
+++ b/sycl/test-e2e/SubGroup/broadcast_fp64.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp64
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
@@ -15,12 +16,8 @@
 
 int main() {
   queue Queue;
-  if (Queue.get_device().has(sycl::aspect::fp64)) {
-    check<double>(Queue);
-    std::cout << "Test passed." << std::endl;
-  } else {
-    std::cout << "Test skipped because device doesn't support aspect::fp64"
-              << std::endl;
-  }
+  assert(Queue.get_device().has(sycl::aspect::fp64) && "Requires fp64");
+  check<double>(Queue);
+  std::cout << "Test passed." << std::endl;
   return 0;
 }

--- a/sycl/test-e2e/SubGroup/reduce_fp16.cpp
+++ b/sycl/test-e2e/SubGroup/reduce_fp16.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp16
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
@@ -10,11 +11,11 @@
 
 int main() {
   queue Queue;
-  if (!core_sg_supported(Queue.get_device()) ||
-      !Queue.get_device().has(sycl::aspect::fp16)) {
+  if (!core_sg_supported(Queue.get_device())) {
     std::cout << "Skipping test\n";
     return 0;
   }
+  assert(Queue.get_device().has(sycl::aspect::fp16) && "Requires fp16");
   check<class KernelName_oMg, sycl::half>(Queue);
   std::cout << "Test passed." << std::endl;
   return 0;

--- a/sycl/test-e2e/SubGroup/reduce_fp64.cpp
+++ b/sycl/test-e2e/SubGroup/reduce_fp64.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp64
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
@@ -9,11 +10,11 @@
 
 int main() {
   queue Queue;
-  if (!core_sg_supported(Queue.get_device()) ||
-      !Queue.get_device().has(sycl::aspect::fp64)) {
+  if (!core_sg_supported(Queue.get_device())) {
     std::cout << "Skipping test\n";
     return 0;
   }
+  assert(Queue.get_device().has(sycl::aspect::fp64) && "Requires fp64");
   check<class KernelName_alTnImqzYasRyHjYg, double>(Queue);
   std::cout << "Test passed." << std::endl;
   return 0;

--- a/sycl/test-e2e/SubGroup/reduce_spirv13_fp16.cpp
+++ b/sycl/test-e2e/SubGroup/reduce_spirv13_fp16.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp16
 // UNSUPPORTED: hip
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
@@ -10,11 +11,11 @@
 
 int main() {
   queue Queue;
-  if (!core_sg_supported(Queue.get_device()) ||
-      !Queue.get_device().has(sycl::aspect::fp16)) {
+  if (!core_sg_supported(Queue.get_device())) {
     std::cout << "Skipping test\n";
     return 0;
   }
+  assert(Queue.get_device().has(sycl::aspect::fp16) && "Requires fp16");
   check_mul<class MulHalf, sycl::half>(Queue);
   std::cout << "Test passed." << std::endl;
   return 0;

--- a/sycl/test-e2e/SubGroup/reduce_spirv13_fp64.cpp
+++ b/sycl/test-e2e/SubGroup/reduce_spirv13_fp64.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp64
 // UNSUPPORTED: hip
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
@@ -12,11 +13,11 @@
 #include <iostream>
 int main() {
   queue Queue;
-  if (!core_sg_supported(Queue.get_device()) ||
-      !Queue.get_device().has(sycl::aspect::fp64)) {
+  if (!core_sg_supported(Queue.get_device())) {
     std::cout << "Skipping test\n";
     return 0;
   }
+  assert(Queue.get_device().has(sycl::aspect::fp64) && "Requires fp64");
   check_mul<class MulDouble, double>(Queue);
   std::cout << "Test passed." << std::endl;
   return 0;

--- a/sycl/test-e2e/SubGroup/scan_fp64.cpp
+++ b/sycl/test-e2e/SubGroup/scan_fp64.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp64
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
@@ -10,11 +11,11 @@
 #include <iostream>
 int main() {
   queue Queue;
-  if (!core_sg_supported(Queue.get_device()) ||
-      !Queue.get_device().has(sycl::aspect::fp64)) {
+  if (!core_sg_supported(Queue.get_device())) {
     std::cout << "Skipping test\n";
     return 0;
   }
+  assert(Queue.get_device().has(sycl::aspect::fp64) && "Requires fp64");
   check<class KernelName_cYZflKkIXS, double>(Queue);
   std::cout << "Test passed." << std::endl;
   return 0;

--- a/sycl/test-e2e/SubGroup/scan_spirv13_fp64.cpp
+++ b/sycl/test-e2e/SubGroup/scan_spirv13_fp64.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp64
 // UNSUPPORTED: hip
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
@@ -13,11 +14,11 @@
 
 int main() {
   queue Queue;
-  if (!core_sg_supported(Queue.get_device()) ||
-      !Queue.get_device().has(sycl::aspect::fp64)) {
+  if (!core_sg_supported(Queue.get_device())) {
     std::cout << "Skipping test\n";
     return 0;
   }
+  assert(Queue.get_device().has(sycl::aspect::fp64) && "Requires fp64");
   check<class MulDouble, double>(Queue);
   std::cout << "Test passed." << std::endl;
   return 0;

--- a/sycl/test-e2e/SubGroup/shuffle_fp16.cpp
+++ b/sycl/test-e2e/SubGroup/shuffle_fp16.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp16
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 //
@@ -22,12 +23,8 @@
 
 int main() {
   queue Queue;
-  if (Queue.get_device().has(sycl::aspect::fp16)) {
-    check<half>(Queue);
-    std::cout << "Test passed." << std::endl;
-  } else {
-    std::cout << "Test skipped because device doesn't support aspect::fp16"
-              << std::endl;
-  }
+  assert(Queue.get_device().has(sycl::aspect::fp16) && "Requires fp16");
+  check<half>(Queue);
+  std::cout << "Test passed." << std::endl;
   return 0;
 }

--- a/sycl/test-e2e/SubGroup/shuffle_fp64.cpp
+++ b/sycl/test-e2e/SubGroup/shuffle_fp64.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: fp64
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %CPU_RUN_PLACEHOLDER %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
@@ -16,16 +17,12 @@
 
 int main() {
   queue Queue;
-  if (Queue.get_device().has(sycl::aspect::fp64)) {
-    check<double>(Queue);
-    check<double, 2>(Queue);
-    check<double, 4>(Queue);
-    check<double, 8>(Queue);
-    check<double, 16>(Queue);
-    std::cout << "Test passed." << std::endl;
-  } else {
-    std::cout << "Test skipped because device doesn't support aspect::fp64"
-              << std::endl;
-  }
+  assert(Queue.get_device().has(sycl::aspect::fp64) && "Requires fp64");
+  check<double>(Queue);
+  check<double, 2>(Queue);
+  check<double, 4>(Queue);
+  check<double, 8>(Queue);
+  check<double, 16>(Queue);
+  std::cout << "Test passed." << std::endl;
   return 0;
 }


### PR DESCRIPTION
This commit introduces a framework to make better use of LIT's UNSUPPORTED test category by detecting supported aspects at LIT configuration time. Until now the E2E tests would exit early and PASS, which is arguably a misleading classification.

The method determines aspects at configuration time by compiling and then running a program. The output of this program is a semicolon-separated list of supported aspects *on the default device* as either '1' or '0', in an order determined by the python script. The script captures this output and sets features as available where the corresponding aspect is '1'.

As a proof of concept, several tests which silently pass when fp16 and fp64 are unsupported have been converted to use this system.

The method is easily extendible with new aspects. Several E2E tests make use of USM shared allocations without first checking the device, so a follow-up commit would likely make that aspect a feature too.