### PR TITLE
[SYCL][E2E] Reduce memcpy2d e2e testing

### DIFF
--- a/sycl/test-e2e/USM/fill2d.cpp
+++ b/sycl/test-e2e/USM/fill2d.cpp
@@ -35,18 +35,6 @@ event doFill2D(queue &Q, void *Dest, size_t DestPitch, const T &Pattern,
       CGH.ext_oneapi_fill2d(Dest, DestPitch, Pattern, Width, Height);
     });
   }
-  if constexpr (PathKind == OperationPath::ShortcutNoEvent) {
-    sycl::event::wait(DepEvents);
-    return Q.ext_oneapi_fill2d(Dest, DestPitch, Pattern, Width, Height);
-  }
-  if constexpr (PathKind == OperationPath::ShortcutOneEvent) {
-    assert(DepEvents.size() && "No events in dependencies!");
-    // wait on all other events than the first.
-    for (size_t I = 1; I < DepEvents.size(); ++I)
-      DepEvents[I].wait();
-    return Q.ext_oneapi_fill2d(Dest, DestPitch, Pattern, Width, Height,
-                               DepEvents[0]);
-  }
   if constexpr (PathKind == OperationPath::ShortcutEventList) {
     return Q.ext_oneapi_fill2d(Dest, DestPitch, Pattern, Width, Height,
                                DepEvents);
@@ -194,10 +182,6 @@ int testForAllPaths(queue &Q, T ExpectedVal1, T ExpectedVal2) {
   Failures += test<T, AllocKind, OperationPath::Expanded>(Q, ExpectedVal1,
                                                           ExpectedVal2);
   Failures += test<T, AllocKind, OperationPath::ExpandedDependsOn>(
-      Q, ExpectedVal1, ExpectedVal2);
-  Failures += test<T, AllocKind, OperationPath::ShortcutNoEvent>(
-      Q, ExpectedVal1, ExpectedVal2);
-  Failures += test<T, AllocKind, OperationPath::ShortcutOneEvent>(
       Q, ExpectedVal1, ExpectedVal2);
   Failures += test<T, AllocKind, OperationPath::ShortcutEventList>(
       Q, ExpectedVal1, ExpectedVal2);

--- a/sycl/test-e2e/USM/memcpy2d.cpp
+++ b/sycl/test-e2e/USM/memcpy2d.cpp
@@ -39,18 +39,6 @@ event doMemcpy2D(queue &Q, void *Dest, size_t DestPitch, const void *Src,
       CGH.ext_oneapi_memcpy2d(Dest, DestPitch, Src, SrcPitch, Width, Height);
     });
   }
-  if constexpr (PathKind == OperationPath::ShortcutNoEvent) {
-    sycl::event::wait(DepEvents);
-    return Q.ext_oneapi_memcpy2d(Dest, DestPitch, Src, SrcPitch, Width, Height);
-  }
-  if constexpr (PathKind == OperationPath::ShortcutOneEvent) {
-    assert(DepEvents.size() && "No events in dependencies!");
-    // wait on all other events than the first.
-    for (size_t I = 1; I < DepEvents.size(); ++I)
-      DepEvents[I].wait();
-    return Q.ext_oneapi_memcpy2d(Dest, DestPitch, Src, SrcPitch, Width, Height,
-                                 DepEvents[0]);
-  }
   if constexpr (PathKind == OperationPath::ShortcutEventList) {
     return Q.ext_oneapi_memcpy2d(Dest, DestPitch, Src, SrcPitch, Width, Height,
                                  DepEvents);
@@ -410,12 +398,6 @@ int testForAllPaths(queue &Q, T ExpectedVal1, T ExpectedVal2) {
       Q, ExpectedVal1, ExpectedVal2);
   Failures +=
       test<T, SrcAllocKind, DstAllocKind, OperationPath::ExpandedDependsOn>(
-          Q, ExpectedVal1, ExpectedVal2);
-  Failures +=
-      test<T, SrcAllocKind, DstAllocKind, OperationPath::ShortcutNoEvent>(
-          Q, ExpectedVal1, ExpectedVal2);
-  Failures +=
-      test<T, SrcAllocKind, DstAllocKind, OperationPath::ShortcutOneEvent>(
           Q, ExpectedVal1, ExpectedVal2);
   Failures +=
       test<T, SrcAllocKind, DstAllocKind, OperationPath::ShortcutEventList>(

--- a/sycl/test-e2e/USM/memops2d_utils.hpp
+++ b/sycl/test-e2e/USM/memops2d_utils.hpp
@@ -15,8 +15,6 @@ using namespace sycl;
 enum OperationPath {
   Expanded,
   ExpandedDependsOn,
-  ShortcutNoEvent,
-  ShortcutOneEvent,
   ShortcutEventList
 };
 
@@ -33,10 +31,6 @@ std::string operationPathToString(OperationPath PathKind) {
     return "no shortcut and no depends_on";
   case ExpandedDependsOn:
     return "no shortcut";
-  case ShortcutNoEvent:
-    return "shortcut with no dependency events";
-  case ShortcutOneEvent:
-    return "shortcut with one dependency event";
   case ShortcutEventList:
     return "shortcut with dependency event list";
   default:


### PR DESCRIPTION
The memcpy2d and copy2d tests in the test suite are by far the dominant tests in execution time for the e2e tests. This is partially because of the thorough coverage of the tests. To reduce the footprint of these test cases, this commit removes some of the shortcut cases as they are somewhat trivial. More extensive coverage is expected from the SYCL-CTS.