### PR TITLE
[SYCL] Update cm commit hash

### DIFF
--- a/sycl/plugins/esimd_emulator/CMakeLists.txt
+++ b/sycl/plugins/esimd_emulator/CMakeLists.txt
@@ -41,7 +41,7 @@ if ((DEFINED USE_DEFAULT_CM_EMU_SOURCE) OR (DEFINED USE_LOCAL_CM_EMU_SOURCE))
     message(STATUS "CM_EMU library package will be built online with source codes downloaded from ${DEFAULT_CM_EMU_SOURCE_URL}")
     ExternalProject_Add(cm-emu
       GIT_REPOSITORY    ${DEFAULT_CM_EMU_SOURCE_URL}
-      GIT_TAG           f9d167edbcb995e713d5a8
+      GIT_TAG           38f070a7e1de00d0398224
       BINARY_DIR        ${CMAKE_CURRENT_BINARY_DIR}/cm-emu_build
       INSTALL_DIR       ${CMAKE_CURRENT_BINARY_DIR}/cm-emu_install
       CMAKE_ARGS        -DLIBVA_INSTALL_PATH=/usr


### PR DESCRIPTION
We have the `-DUSE_DEFAULT_CM_EMU_SOURCE` flag to build cm from source. The hash that we use from cm wasn't updated with the move to 1.0.31.

We should use https://github.com/intel/cm-cpu-emulation/commit/38f070a7e1de00d0398224e9d6306cc59010d147