### PR TITLE
[SYCL] Disable flaky test on win gen12

### DIFF
--- a/sycl/test-e2e/Plugin/level_zero_imm_cmdlist_per_thread.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_imm_cmdlist_per_thread.cpp
@@ -1,5 +1,8 @@
 // REQUIRES: gpu, level_zero
 
+// Flaky failure on windows && gen12
+// UNSUPPORTED: windows && gpu-intel-gen12
+
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %level_zero_options %threads_lib %s -o %t.out
 // RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 ZE_DEBUG=4 %GPU_RUN_PLACEHOLDER %t.out 2>&1 | FileCheck --check-prefixes=CHECK-ONE-CMDLIST %s
 // RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=2 ZE_DEBUG=4 %GPU_RUN_PLACEHOLDER %t.out 2>&1 | FileCheck --check-prefixes=CHECK-PER-THREAD-CMDLIST %s


### PR DESCRIPTION
Related: https://github.com/intel/llvm/issues/9117