### PR TITLE
[SYCL-MLIR] Generalize `LoopVersionCondition` to `VersionCondition` for more reuse

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
@@ -621,8 +621,9 @@ static size_t moveLoopInvariantCode(LoopLikeOpInterface loop,
         candidate.getRequireNoOverlapAccessorPairs();
     if (!accessorPairs.empty()) {
       OpBuilder builder(loop);
-      std::unique_ptr<LoopVersionCondition> condition =
-          VersionConditionBuilder(loop, accessorPairs).createCondition();
+      std::unique_ptr<VersionCondition> condition =
+          VersionConditionBuilder(accessorPairs, builder, loop->getLoc())
+              .createCondition();
       loopTools.versionLoop(loop, *condition);
     }
 

--- a/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
@@ -86,7 +86,7 @@ struct AffineIfBuilder {
 //===----------------------------------------------------------------------===//
 
 void LoopVersionBuilder::versionLoop(
-    const LoopVersionCondition &versionCond) const {
+    const VersionCondition &versionCond) const {
   OpBuilder builder(loop);
 
   if (versionCond.hasSCFCondition()) {
@@ -399,7 +399,7 @@ void LoopTools::guardLoop(LoopLikeOpInterface loop) const {
 }
 
 void LoopTools::versionLoop(LoopLikeOpInterface loop,
-                            const LoopVersionCondition &versionCond) const {
+                            const VersionCondition &versionCond) const {
   LoopVersionBuilder(loop).versionLoop(versionCond);
 }
 


### PR DESCRIPTION
`VersionCondition` can be used to version loop or any other region of code, e.g., a call site.