### PR TITLE
[SYCL] Add e2e test for native_specialization_constant()

### DIFF
--- a/sycl/test-e2e/SpecConstants/2020/native_specialization_constant.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/native_specialization_constant.cpp
@@ -20,8 +20,9 @@ constexpr sycl::specialization_id<float> float_id(3.14f);
 int main() {
   sycl::queue Q;
   Q.submit([&](sycl::handler &cgh) {
-          cgh.single_task<class Kernel>([=](sycl::kernel_handler h) {
-        h.get_specialization_constant<float_id>();
+    cgh.single_task<class Kernel>([=](sycl::kernel_handler h) {
+      h.get_specialization_constant<float_id>();
+    });
   });
 
 #ifdef JIT

--- a/sycl/test-e2e/SpecConstants/2020/native_specialization_constant.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/native_specialization_constant.cpp
@@ -1,0 +1,38 @@
+// native_specialization_constant() returns true only in JIT mode
+// on opencl & level-zero backends
+// (because only SPIR-V supports specialization constants natively)
+
+// REQUIRES: opencl, level-zero, cpu, gpu, opencl-aot, ocloc
+
+// RUN: %clangxx -DJIT -fsycl %s -o %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR=opencl:cpu %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR=opencl:gpu %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR=level_zero:gpu %t.out
+
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64,spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts %s -o %t.out
+// RUN: %CPU_RUN_PLACEHOLDER %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+#include <sycl/sycl.hpp>
+
+constexpr sycl::specialization_id<float> float_id(3.14f);
+
+int main() {
+  sycl::queue Q;
+  Q.submit([&](sycl::handler &cgh) {
+          cgh.single_task<class Kernel>([=](sycl::kernel_handler h) {
+        h.get_specialization_constant<float_id>();
+  });
+
+#ifdef JIT
+  auto bundle =
+      sycl::get_kernel_bundle<sycl::bundle_state::input>(Q.get_context());
+  assert(bundle.native_specialization_constant());
+#else
+  auto bundle =
+      sycl::get_kernel_bundle<sycl::bundle_state::executable>(Q.get_context());
+  assert(!bundle.native_specialization_constant());
+#endif // JIT
+
+  return 0;
+}


### PR DESCRIPTION
This test was missed during e2e tests migration:
https://github.com/intel/llvm-test-suite/pull/1651