### PR TITLE
[SYCL][ESIMD][E2E] Fix sporadic esimd emulator failure

### DIFF
--- a/sycl/test-e2e/ESIMD/regression/copyto_char_test.cpp
+++ b/sycl/test-e2e/ESIMD/regression/copyto_char_test.cpp
@@ -31,7 +31,7 @@ template <int NumElems, bool IsAcc, int ResultOffset = 0> int test_to_copy() {
   sycl::queue queue;
   constexpr int NumSelectedElems = NumElems / 3;
   constexpr int Stride = 2;
-  constexpr int Offset = 6;
+  constexpr int Offset = 4;
 
   shared_allocator<DataT> allocator(queue);
   shared_vector<DataT> result(NumElems + ResultOffset, allocator);


### PR DESCRIPTION
With NumEl 7, 8 and 10, a write of offset 6 stride 2 NumSelectedEl=NumEl/3 leads to an out of bound write, so just lower the offset so we have space.