### PR TITLE
[SYCL][ESIMD][E2E] Fix esimd emulator timeout

### DIFF
--- a/sycl/test-e2e/ESIMD/matrix_transpose_glb.cpp
+++ b/sycl/test-e2e/ESIMD/matrix_transpose_glb.cpp
@@ -20,7 +20,7 @@ using namespace sycl;
 using namespace std;
 using namespace sycl::ext::intel::esimd;
 
-const unsigned int ESIMD_EMULATOR_SIZE_LIMIT = 1U << 10;
+const unsigned int ESIMD_EMULATOR_SIZE_LIMIT = 1U << 9;
 
 void initMatrix(int *M, unsigned N) {
   assert(N >= 8 && (((N - 1) & N) == 0) &&
@@ -340,14 +340,14 @@ int main(int argc, char *argv[]) {
   bool success = true;
   success &= runTest(MZ, 16, num_iters, kernel_times, total_times);
   if (argc == 1) {
+    success &= runTest(1U << 9, 8, num_iters, kernel_times, total_times);
     success &= runTest(1U << 10, 8, num_iters, kernel_times, total_times);
     success &= runTest(1U << 11, 8, num_iters, kernel_times, total_times);
     success &= runTest(1U << 12, 8, num_iters, kernel_times, total_times);
-    // success &= runTest(1U << 13, 8, num_iters, kernel_times, total_times);
+    success &= runTest(1U << 9, 16, num_iters, kernel_times, total_times);
     success &= runTest(1U << 10, 16, num_iters, kernel_times, total_times);
     success &= runTest(1U << 11, 16, num_iters, kernel_times, total_times);
     success &= runTest(1U << 12, 16, num_iters, kernel_times, total_times);
-    // success &= runTest(1U << 13, 16, num_iters, kernel_times, total_times);
   }
 
   const bool profiling =


### PR DESCRIPTION
This test is computationally intensive and when running with the esimd emulator backend on a slow CPU it may hit the timeout.

Add a 512x512 case and lower the existing esimd emulator limit to 512.

This brings the testing time from 4 minutes to 1 minute.

When run on a real GPU it runs in 1 second even on Gen9 so the extra 512 case shouldn't cause any issues there.