### PR TITLE
[ESIMD][LIT] Disable 2 e2e tests on Windows&Gen9

### DIFF
--- a/sycl/test-e2e/ESIMD/private_memory.cpp
+++ b/sycl/test-e2e/ESIMD/private_memory.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu && !gpu-intel-pvc
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 
 // TODO online_compiler check fails for esimd_emulator.

--- a/sycl/test-e2e/ESIMD/wait.cpp
+++ b/sycl/test-e2e/ESIMD/wait.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
 // UNSUPPORTED: cuda || hip
 
 // RUN: %clangxx -fsycl %s -o %t.out


### PR DESCRIPTION
The test must be not be started on Windows+Gen9 system because GPU vector backend dropped support for Gen9 on Windows.