### PR TITLE
[SYCL-MLIR][NFC] Change `AccessorType` to `AccessorPtrType`

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -268,13 +268,13 @@ public:
 /// overlap.
 class VersionConditionBuilder {
 public:
-  using AccessorType = TypedValue<MemRefType>;
-  using AccessorPairType = std::pair<AccessorType, AccessorType>;
+  using AccessorPtrType = TypedValue<MemRefType>;
+  using AccessorPtrPairType = std::pair<AccessorPtrType, AccessorPtrType>;
   using SCFCondition = VersionCondition::SCFCondition;
   using AffineCondition = VersionCondition::AffineCondition;
 
   VersionConditionBuilder(
-      ArrayRef<AccessorPairType> requireNoOverlapAccessorPairs,
+      ArrayRef<AccessorPtrPairType> requireNoOverlapAccessorPairs,
       OpBuilder builder, Location loc)
       : accessorPairs(requireNoOverlapAccessorPairs), builder(builder),
         loc(loc) {
@@ -291,7 +291,7 @@ private:
   /// Create a versioning condition suitable for scf::IfOp.
   SCFCondition createSCFCondition(OpBuilder builder, Location loc) const;
 
-  ArrayRef<AccessorPairType> accessorPairs;
+  ArrayRef<AccessorPtrPairType> accessorPairs;
   mutable OpBuilder builder;
   mutable Location loc;
 };

--- a/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
@@ -615,7 +615,7 @@ VersionConditionBuilder::createSCFCondition(OpBuilder builder,
   };
 
   Value condition;
-  for (const AccessorPairType &accessorPair : accessorPairs) {
+  for (const AccessorPtrPairType &accessorPair : accessorPairs) {
     Value begin1 = getSYCLAccessorBegin(accessorPair.first, builder, loc);
     Value end1 = getSYCLAccessorEnd(accessorPair.first, builder, loc);
     Value begin2 = getSYCLAccessorBegin(accessorPair.second, builder, loc);


### PR DESCRIPTION
To not confuse `sycl::AccessorType` and `VersionConditionBuilder::AccessorType`, which is a memref type, rename `VersionConditionBuilder::AccessorType` to `VersionConditionBuilder::AccessorPtrType` and `VersionConditionBuilder::AccessorPairType` to `VersionConditionBuilder::AccessorPtrPairType`.