### PR TITLE
[SYCL] Build AMDGPU target if AMD libclc targets are enabled

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -125,6 +125,9 @@ def do_configure(args):
             # libclc passes `--nvvm-reflect-enable=false`, build NVPTX to enable it
             if 'NVPTX' not in llvm_targets_to_build:
                 llvm_targets_to_build += ';NVPTX'
+            # since we are building AMD libclc target we must have AMDGPU target
+            if 'AMDGPU' not in llvm_targets_to_build:
+                llvm_targets_to_build += ';AMDGPU'
             # Add both NVIDIA and AMD libclc targets
             if libclc_amd_target_names not in libclc_targets_to_build:
                 libclc_targets_to_build += libclc_amd_target_names


### PR DESCRIPTION
Building AMD libclc requires AMDGPU target to be enabled. Currently somehow AMD libclc is built without AMDGPU target enabling if --ci-defaults is used with configure.py.