### PR TITLE
[SYCL-MLIR] Set private visibility when privatizing function

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -48,6 +48,9 @@ bool isValidIndex(Value val);
 /// Returns true if the given function has 'linkonce_odr' LLVM  linkage.
 bool isLinkonceODR(FunctionOpInterface);
 
+/// Change the linkage and visibility of the given function to private.
+void privatize(FunctionOpInterface);
+
 /// Returns true if the given call is a tail call.
 bool isTailCall(CallOpInterface);
 

--- a/polygeist/lib/Dialect/Polygeist/Transforms/ArgumentPromotion.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/ArgumentPromotion.cpp
@@ -326,10 +326,10 @@ void Candidate::modifyCallee() {
   funcOp.setType(newFuncType);
   funcOp.setAllArgAttrs(newArgAttrs);
 
-  // Change the linkage from linkonce_odr to internal.
+  // Change the linkage from linkonce_odr to private.
   // There can be globals of the same name (with linkonce_odr linkage) in
   // another translation unit. As they have different arguments, we need to
-  // change the linkage of the modified function to internal.
+  // change the linkage of the modified function to private.
   if (isLinkonceODR(funcOp))
     privatize(funcOp);
 

--- a/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
@@ -23,7 +23,7 @@ using namespace mlir;
 // Utilities functions
 //===----------------------------------------------------------------------===//
 
-static constexpr StringRef linkageAttrName = "llvm.linkage";
+static constexpr StringLiteral linkageAttrName = "llvm.linkage";
 bool mlir::isLinkonceODR(FunctionOpInterface func) {
   if (!func->hasAttr(linkageAttrName))
     return false;

--- a/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
@@ -23,12 +23,19 @@ using namespace mlir;
 // Utilities functions
 //===----------------------------------------------------------------------===//
 
+static constexpr StringRef linkageAttrName = "llvm.linkage";
 bool mlir::isLinkonceODR(FunctionOpInterface func) {
-  constexpr StringRef linkageAttrName = "llvm.linkage";
   if (!func->hasAttr(linkageAttrName))
     return false;
   auto attr = cast<LLVM::LinkageAttr>(func->getAttr(linkageAttrName));
   return attr.getLinkage() == LLVM::Linkage::LinkonceODR;
+}
+
+void mlir::privatize(FunctionOpInterface func) {
+  func->setAttr(
+      linkageAttrName,
+      LLVM::LinkageAttr::get(func->getContext(), LLVM::Linkage::Private));
+  func.setPrivate();
 }
 
 bool mlir::isTailCall(CallOpInterface call) {

--- a/polygeist/test/polygeist-opt/sycl/argpromotion.mlir
+++ b/polygeist/test/polygeist-opt/sycl/argpromotion.mlir
@@ -151,9 +151,9 @@ gpu.module @device_func {
   // COM: Test that the a call to a linkonce_odr function is modified.
   // COM: This function is a candidate, check that it is transformed correctly.
   func.func @callee6(%arg0: memref<?x!llvm.struct<(i32, i64)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-    // CHECK-LABEL: func.func @callee6
+    // CHECK-LABEL: func.func private @callee6
     // CHECK-SAME:    (%arg0: memref<?xi32> {llvm.noalias}, %arg1: memref<?xi64> {llvm.noalias})
-    // CHECK-SAME:    attributes {llvm.linkage = #llvm.linkage<internal>} {
+    // CHECK-SAME:    attributes {llvm.linkage = #llvm.linkage<private>} {
     func.return
   }
   gpu.func @test6() kernel {


### PR DESCRIPTION
1. Moved to `TransformUtils` for reuse.
2. Set linkage to `private` instead of `internal` when privatizing function, as we don't need to function to show up in the symbol table. 
3. Set private visibility when privatizing function,  as function with `private` linkage should have `private` visibility. 
4. Remove `isLinkonceODK` static function in `ArgumentPromotion`, as it can use the one in `TransformUtils`.