### PR TITLE
[SYCL][ESIMD] Support 64-bit offsets for accessor block_load/block_store in stateless mode

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/detail/util.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/util.hpp
@@ -181,8 +181,8 @@ public:
 #ifdef __ESIMD_FORCE_STATELESS_MEM
 /// Returns the address referenced by the accessor \p Acc and
 /// the byte offset \p Offset.
-template <typename T, typename AccessorTy>
-T *accessorToPointer(AccessorTy Acc, uint32_t Offset = 0) {
+template <typename T, typename AccessorTy, typename OffsetTy = uint32_t>
+T *accessorToPointer(AccessorTy Acc, OffsetTy Offset = 0) {
   auto BytePtr = reinterpret_cast<char *>(Acc.get_pointer().get()) + Offset;
   return reinterpret_cast<T *>(BytePtr);
 }

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -326,7 +326,12 @@ template <typename Tx, int N, typename AccessorTy,
           typename Flags = vector_aligned_tag,
           typename = std::enable_if_t<is_simd_flag_type_v<Flags>>,
           class T = detail::__raw_t<Tx>>
-__ESIMD_API simd<Tx, N> block_load(AccessorTy acc, uint32_t offset,
+__ESIMD_API simd<Tx, N> block_load(AccessorTy acc,
+#ifdef __ESIMD_FORCE_STATELESS_MEM
+                                   uint64_t offset,
+#else
+                                   uint32_t offset,
+#endif
                                    Flags = {}) {
 #ifdef __ESIMD_FORCE_STATELESS_MEM
   return block_load<Tx, N>(__ESIMD_DNS::accessorToPointer<Tx>(acc, offset));
@@ -390,7 +395,12 @@ __ESIMD_API void block_store(Tx *p, simd<Tx, N> vals) {
 ///
 template <typename Tx, int N, typename AccessorTy,
           class T = detail::__raw_t<Tx>>
-__ESIMD_API void block_store(AccessorTy acc, uint32_t offset,
+__ESIMD_API void block_store(AccessorTy acc,
+#ifdef __ESIMD_FORCE_STATELESS_MEM
+                             uint64_t offset,
+#else
+                             uint32_t offset,
+#endif
                              simd<Tx, N> vals) {
 #ifdef __ESIMD_FORCE_STATELESS_MEM
   block_store<Tx, N>(__ESIMD_DNS::accessorToPointer<Tx>(acc, offset), vals);

--- a/sycl/test-e2e/ESIMD/accessor_load_store.hpp
+++ b/sycl/test-e2e/ESIMD/accessor_load_store.hpp
@@ -15,12 +15,6 @@
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>
 
-#ifdef USE_64_BIT_OFFSET
-using TOffset = uint64_t;
-#else
-using TOffset = uint32_t;
-#endif
-
 using namespace sycl;
 
 template <typename T>
@@ -32,7 +26,7 @@ template <typename T> struct Kernel {
 
   void operator()(id<1> i) const SYCL_ESIMD_KERNEL {
     using namespace sycl::ext::intel::esimd;
-    TOffset ii = static_cast<TOffset>(i.get(0));
+    uint32_t ii = static_cast<uint32_t>(i.get(0));
     T v = scalar_load<T>(acc, ii * sizeof(T));
     v += ii;
     scalar_store<T>(acc, ii * sizeof(T), v);

--- a/sycl/test-e2e/ESIMD/accessor_load_store.hpp
+++ b/sycl/test-e2e/ESIMD/accessor_load_store.hpp
@@ -15,6 +15,12 @@
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>
 
+#ifdef USE_64_BIT_OFFSET
+using TOffset = uint64_t;
+#else
+using TOffset = uint32_t;
+#endif
+
 using namespace sycl;
 
 template <typename T>
@@ -26,7 +32,7 @@ template <typename T> struct Kernel {
 
   void operator()(id<1> i) const SYCL_ESIMD_KERNEL {
     using namespace sycl::ext::intel::esimd;
-    uint32_t ii = static_cast<uint32_t>(i.get(0));
+    TOffset ii = static_cast<TOffset>(i.get(0));
     T v = scalar_load<T>(acc, ii * sizeof(T));
     v += ii;
     scalar_store<T>(acc, ii * sizeof(T), v);

--- a/sycl/test-e2e/ESIMD/accessor_load_store_stateless_64.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_load_store_stateless_64.cpp
@@ -5,12 +5,73 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===-------------------------------------------------------------------===//
-// REQUIRES: gpu
-// UNSUPPORTED: gpu-intel-gen9 && windows
+// REQUIRES: gpu, gpu-intel-pvc
 // UNSUPPORTED: cuda || hip || esimd_emulator
 // RUN: %clangxx -fsycl -fsycl-esimd-force-stateless-mem %s -o %t.out
 // RUN: %GPU_RUN_PLACEHOLDER %t.out
 
-#define USE_64_BIT_OFFSET
+#include <iostream>
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/sycl.hpp>
 
-#include "accessor_load_store.hpp"
+using namespace sycl;
+using namespace sycl::ext::intel::esimd;
+
+int main(void) {
+  constexpr unsigned VL = 16;
+  constexpr uint64_t Gig = 1024 * 1024 * 1024;
+
+  constexpr uint64_t Size = Gig / 2 + 16;
+  uint64_t *A = new uint64_t[Size];
+
+  for (uint64_t i = 0; i < Size; ++i)
+    A[i] = i;
+
+  buffer<uint64_t, 1> bufa(A, range<1>(Size));
+  queue q;
+
+  auto dev = q.get_device();
+  std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+  try {
+    q.submit([&](handler &cgh) {
+       auto PA = bufa.get_access<access::mode::read_write>(cgh);
+       cgh.single_task<class Test>([=]() SYCL_ESIMD_KERNEL {
+         uint64_t offset = (Size - VL) * sizeof(uint64_t);
+         simd<uint64_t, VL> va = block_load<uint64_t, VL>(PA, 0);
+         simd<uint64_t, VL> vb = block_load<uint64_t, VL>(PA, offset);
+         va *= 2;
+         vb *= 5;
+         block_store(PA, 0, va);
+         block_store(PA, offset, vb);
+       });
+     }).wait();
+  } catch (sycl::exception const &e) {
+    std::cout << "SYCL exception caught: " << e.what() << '\n';
+    delete[] A;
+    return 1;
+  }
+
+  bool failed = false;
+  host_accessor A_acc(bufa);
+  for (uint64_t I = 0; I < VL; I++) {
+    uint64_t Expected = I * 2;
+    if (A_acc[I] != Expected) {
+      std::cout << "FAILED: " << A_acc[I] << " != " << Expected << std::endl;
+      failed = true;
+    }
+  }
+  for (uint64_t I = Size - VL; I < Size; I++) {
+    uint64_t Expected = I * 5;
+    if (A_acc[I] != Expected) {
+      std::cout << "FAILED: " << A_acc[I] << " != " << Expected << std::endl;
+      failed = true;
+    }
+  }
+
+  if (!failed)
+    std::cout << "PASSED" << std::endl;
+
+  delete[] A;
+
+  return failed;
+}

--- a/sycl/test-e2e/ESIMD/accessor_load_store_stateless_64.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_load_store_stateless_64.cpp
@@ -1,0 +1,16 @@
+//===-accessor_load_store_stateless_64.cpp - DPC++ ESIMD on-device test-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===-------------------------------------------------------------------===//
+// REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
+// UNSUPPORTED: cuda || hip || esimd_emulator
+// RUN: %clangxx -fsycl -fsycl-esimd-force-stateless-mem %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+#define USE_64_BIT_OFFSET
+
+#include "accessor_load_store.hpp"


### PR DESCRIPTION
I tried to avoid changing the parameter based on a `#define`, but we want to preserve a warning thrown in stateful mode. My idea for that was to add a type template for the offset type, and in stateful mode copy the offset param to a local variable of `uint32_t` type, and that assignment would throw the shortening warning.

However it turns out we don't ever throw warnings in system headers because we pass `-Wno-system-headers` by default, so we need the warning to occur in customer code. I don't know any way to do that besides changing the parameter type like I do here. `#pragma clang diagnostic push/pop` unfortunately doesn't work for this case.