### PR TITLE
[SYCL] Do not install L0 loader

### DIFF
--- a/devops/actions/e2e-tests-win/action.yml
+++ b/devops/actions/e2e-tests-win/action.yml
@@ -30,7 +30,7 @@ runs:
     run: |
       mkdir build-e2e
       set PATH=%GITHUB_WORKSPACE%\install\bin;%PATH%
-      cmake -GNinja -B build-e2e -S.\llvm\sycl\test-e2e -DSYCL_TEST_E2E_TARGETS="${{ inputs.targets }}" -DCMAKE_CXX_COMPILER="clang++" -DLLVM_LIT="..\llvm\llvm\utils\lit\lit.py" ${{ inputs.cmake_args }}
+      cmake -GNinja -B build-e2e -S.\llvm\sycl\test-e2e -DSYCL_TEST_E2E_TARGETS="${{ inputs.targets }}" -DCMAKE_CXX_COMPILER="clang++" -DLEVEL_ZERO_LIBS_DIR="D:\github\level-zero_win-sdk\lib" -DLLVM_LIT="..\llvm\llvm\utils\lit\lit.py" ${{ inputs.cmake_args }}
   - name: Run testing
     shell: bash
     run: |

--- a/devops/actions/e2e-tests-win/action.yml
+++ b/devops/actions/e2e-tests-win/action.yml
@@ -30,7 +30,7 @@ runs:
     run: |
       mkdir build-e2e
       set PATH=%GITHUB_WORKSPACE%\install\bin;%PATH%
-      cmake -GNinja -B build-e2e -S.\llvm\sycl\test-e2e -DSYCL_TEST_E2E_TARGETS="${{ inputs.targets }}" -DCMAKE_CXX_COMPILER="clang++" -DLEVEL_ZERO_LIBS_DIR="D:\github\level-zero_win-sdk\lib.fake" -DLLVM_LIT="..\llvm\llvm\utils\lit\lit.py" ${{ inputs.cmake_args }}
+      cmake -GNinja -B build-e2e -S.\llvm\sycl\test-e2e -DSYCL_TEST_E2E_TARGETS="${{ inputs.targets }}" -DCMAKE_CXX_COMPILER="clang++" -DLEVEL_ZERO_LIBS_DIR="D:\github\level-zero_win-sdk\lib" -DLLVM_LIT="..\llvm\llvm\utils\lit\lit.py" ${{ inputs.cmake_args }}
   - name: Run testing
     shell: bash
     run: |

--- a/devops/actions/e2e-tests-win/action.yml
+++ b/devops/actions/e2e-tests-win/action.yml
@@ -30,7 +30,7 @@ runs:
     run: |
       mkdir build-e2e
       set PATH=%GITHUB_WORKSPACE%\install\bin;%PATH%
-      cmake -GNinja -B build-e2e -S.\llvm\sycl\test-e2e -DSYCL_TEST_E2E_TARGETS="${{ inputs.targets }}" -DCMAKE_CXX_COMPILER="clang++" -DLEVEL_ZERO_LIBS_DIR="D:\github\level-zero_win-sdk\lib" -DLLVM_LIT="..\llvm\llvm\utils\lit\lit.py" ${{ inputs.cmake_args }}
+      cmake -GNinja -B build-e2e -S.\llvm\sycl\test-e2e -DSYCL_TEST_E2E_TARGETS="${{ inputs.targets }}" -DCMAKE_CXX_COMPILER="clang++" -DLEVEL_ZERO_LIBS_DIR="D:\github\level-zero_win-sdk\lib.fake" -DLLVM_LIT="..\llvm\llvm\utils\lit\lit.py" ${{ inputs.cmake_args }}
   - name: Run testing
     shell: bash
     run: |

--- a/sycl/plugins/level_zero/CMakeLists.txt
+++ b/sycl/plugins/level_zero/CMakeLists.txt
@@ -140,15 +140,10 @@ add_sycl_plugin(level_zero
     ${XPTI_LIBS}
 )
 
-#FIXME: We should stop shipping level zero loader and headers as part of the
+#FIXME: We should stop shipping level zero headers as part of the
 #       toolchain installation. Instead these should be avaialble in the system.
 #       We keep shipping it until all environments are updated.
 if (TARGET ze_loader)
-  install(TARGETS ze_loader
-      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT level-zero-sycl-dev
-      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT level-zero-sycl-dev
-      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT level-zero-sycl-dev
-  )
   file(GLOB LEVEL_ZERO_API_HEADERS "${LEVEL_ZERO_INCLUDE_DIR}/*.h")
   install(FILES ${LEVEL_ZERO_API_HEADERS}
       DESTINATION ${CMAKE_INSTALL_PREFIX}/include/sycl/level_zero/


### PR DESCRIPTION
Currently the L0 loader version, if being installed/used, clashes with L0 validation and L0 GPU driver components already coming from the system. So, do the same for L0 loader.
