### PR TITLE
[Driver][SYCL] Add predefines for /MDd for certain build issues

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -4784,6 +4784,11 @@ static void ProcessVSRuntimeLibrary(const ArgList &Args,
       CmdArgs.push_back("-D_MT");
     if (Defines & addDLL && !isSPIR)
       CmdArgs.push_back("-D_DLL");
+    // for /MDd with spir targets
+    if ((Defines & addDLL) && (Defines & addDEBUG) && isSPIR) {
+      CmdArgs.push_back("-D_CONTAINER_DEBUG_LEVEL=0");
+      CmdArgs.push_back("-D_ITERATOR_DEBUG_LEVEL=0");
+    }
   };
   StringRef FlagForCRT;
   switch (RTOptionID) {

--- a/clang/test/Driver/sycl-MD-default.cpp
+++ b/clang/test/Driver/sycl-MD-default.cpp
@@ -8,10 +8,12 @@
 // RUN: %clang_cl -### -fsycl -c %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DEFAULT-CL %s
 // RUN: %clang_cl -### -MD -fsycl -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-DEFAULT-CL %s
+// RUN:   | FileCheck -check-prefixes=CHK-DEFAULT-CL,CHK-DEFAULT-CL-MD %s
 // RUN: %clang_cl -### -MDd -fsycl -c %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-DEFAULT-CL %s
+// RUN:   | FileCheck -check-prefixes=CHK-DEFAULT-CL,CHK-DEFAULT-CL-MDd %s
 // CHK-DEFAULT-CL-NOT: "-fsycl-is-device" {{.*}} "-D_MT" "-D_DLL"
+// CHK-DEFAULT-CL-MD-NOT: "-D_CONTAINER_DEBUG_LEVEL=0" "-D_ITERATOR_DEBUG_LEVEL=0"
+// CHK-DEFAULT-CL-MDd: "-D_CONTAINER_DEBUG_LEVEL=0" "-D_ITERATOR_DEBUG_LEVEL=0"
 // CHK-DEFAULT-CL: "-fsycl-is-host"{{.*}} "-D_MT" "-D_DLL" "--dependent-lib=msvcrt{{d*}}"
 
 // RUN: %clang_cl -### -MT -fsycl -c %s 2>&1 \


### PR DESCRIPTION
When building with /MDd (debug enabled library), predefine the following:
  -D_CONTAINER_DEBUG_LEVEL=0
  -D_ITERATOR_DEBUG_LEVEL=0

Compiling with /MDd enables certain checks within the MSVC headers which are not supported in device code. Adding these predefines gets us around these problems.