### PR TITLE
[SYCL-MLIR][KernelDisjointSpecialization] Allow functions called indirectly from GPU kernel

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Transforms/KernelDisjointSpecialization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/KernelDisjointSpecialization.cpp
@@ -197,11 +197,6 @@ void KernelDisjointSpecializationPass::runOnOperation() {
     setInnerDisjointAttribute(clonedFunc, isCandidateArg);
 
     for (Operation *op : userMap.getUsers(func)) {
-      // Due to temporary condition to only allow function called directly by a
-      // GPU kernel.
-      assert(op->getParentOfType<gpu::GPUFuncOp>() &&
-             "Expecting calls only in GPU kernel");
-
       auto call = cast<CallOpInterface>(op);
       versionCall(call);
 
@@ -220,13 +215,6 @@ bool KernelDisjointSpecializationPass::isCandidateFunction(
                << "not a candidate: not a potential kernel body function\n");
     return false;
   }
-
-  // Temporary condition to only allow function called directly by a GPU kernel.
-  // TODO: allow maximum depth of 2.
-  Optional<unsigned> maxDepth = polygeist::getMaxDepthFromAnyGPUKernel(func);
-  assert(maxDepth.has_value() && "Expecting valid maxDepth");
-  if (maxDepth != 1)
-    return false;
 
   unsigned numCandidateArgs = count_if(func.getArguments(), isCandidateArg);
   if (numCandidateArgs < 2) {


### PR DESCRIPTION
The SYCL kernel body function could be called indirectly from GPU kernel, `GPUKernel` -> `Function` -> `KernelBody`.
This PR modifies the pass to allow versioning either in `GPUKernel` (when `KernelBody` is called directly from it) or `Function`. 