### PR TITLE
[SYCL][GDB] Enable pretty-printing of reference objects

### DIFF
--- a/sycl/gdb/libsycl.so-gdb.py
+++ b/sycl/gdb/libsycl.so-gdb.py
@@ -301,12 +301,13 @@ class SyclArrayPrinter:
             return ("[%d]" % count, elt)
 
     def __init__(self, value):
-        if value.type.code == gdb.TYPE_CODE_REF:
-            if hasattr(gdb.Value, "referenced_value"):
-                value = value.referenced_value()
 
         self.value = value
-        self.type = value.type.unqualified().strip_typedefs()
+        if self.value.type.code == gdb.TYPE_CODE_REF:
+            self.type = value.referenced_value().type.unqualified().strip_typedefs()
+        else:
+            self.type = value.type.unqualified().strip_typedefs()
+
         self.dimensions = self.type.template_argument(0)
 
     def children(self):
@@ -324,6 +325,10 @@ class SyclArrayPrinter:
             # error message otherwise. Individual array element access failures
             # will be caught by iterator itself.
             _ = self.value["common_array"]
+            if self.value.type.code == gdb.TYPE_CODE_REF:
+                return "({tag} &) @{address}: {tag}".format(
+                    tag=self.type.tag, address=self.value.address
+                )
             return self.type.tag
         except:
             return "<error reading variable>"
@@ -337,7 +342,11 @@ class SyclBufferPrinter:
 
     def __init__(self, value):
         self.value = value
-        self.type = value.type.unqualified().strip_typedefs()
+        if self.value.type.code == gdb.TYPE_CODE_REF:
+            self.type = value.referenced_value().type.unqualified().strip_typedefs()
+        else:
+            self.type = value.type.unqualified().strip_typedefs()
+
         self.elt_type = value.type.template_argument(0)
         self.dimensions = value.type.template_argument(1)
         self.typeregex = re.compile("^([a-zA-Z0-9_:]+)(<.*>)?$")
@@ -346,12 +355,15 @@ class SyclBufferPrinter:
         match = self.typeregex.match(self.type.tag)
         if not match:
             return "<error parsing type>"
-        return "%s<%s, %s> = {impl=%s}" % (
-            match.group(1),
-            self.elt_type,
-            self.dimensions,
-            self.value["impl"].address,
+        r_value = "{{impl={address}}}".format(address=self.value["impl"].address)
+        r_type = "{group}<{elt_type}, {dim}>".format(
+            group=match.group(1), elt_type=self.elt_type, dim=self.dimensions
         )
+        if self.value.type.code == gdb.TYPE_CODE_REF:
+            return "({type} &) @{address}: {type} = {value}".format(
+                type=r_type, address=self.value.address, value=r_value
+            )
+        return "{type} = {value}".format(type=r_type, value=r_value)
 
 
 sycl_printer = gdb.printing.RegexpCollectionPrettyPrinter("SYCL")


### PR DESCRIPTION
This commit modifies the output of sycl pretty-printers such that a reference can be distinguished from a non-reference object.  Printing of references is now in line with GDB's common way to print C++ references.

A sycl::id reference is now printed as:
'(sycl::_V1::id<3> &) @0x7fffffffd350: sycl::_V1::id<3> = {11, 22, 33}'

Before it was exactly the same output as for a non-reference object: 'sycl::_V1::id<3> = {11, 22, 33}'

Similar changes apply for sycl::range.

Printing sycl::buffer objects resulted in an exception 'Python Exception <class 'TypeError'>: expected string or bytes-like object' before this patch due to the 'None' type returned by GDB in case the type is a reference.  This is is also fixed by this commit.

Now the output looks like:
'(sycl::_V1::buffer<int, 3> &) @0x7fffffffd1d0: sycl::_V1::buffer<int, 3> = {impl=0x7fffffffd1d0}'

Non-reference objects are still printed as:
'sycl::_V1::buffer<int, 3> = {impl=0x7fffffffd070}'

Signed-off-by: Christina Schimpe <christina.schimpe@intel.com>