### PR TITLE
[SYCL][NFC] Remove default case in exhaustive switch

### DIFF
--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -58,6 +58,8 @@ backend convertBackend(pi_platform_backend PiBackend) {
   case PI_EXT_PLATFORM_BACKEND_ESIMD:
     return backend::ext_intel_esimd_emulator;
   }
+  throw sycl::runtime_error{"convertBackend: Unsupported backend",
+                            PI_ERROR_INVALID_OPERATION};
 }
 
 platform make_platform(pi_native_handle NativeHandle, backend Backend) {

--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -57,9 +57,6 @@ backend convertBackend(pi_platform_backend PiBackend) {
     return backend::ext_oneapi_hip;
   case PI_EXT_PLATFORM_BACKEND_ESIMD:
     return backend::ext_intel_esimd_emulator;
-  default:
-    throw sycl::runtime_error{"convertBackend: Unsupported backend",
-                              PI_ERROR_INVALID_OPERATION};
   }
 }
 


### PR DESCRIPTION
This commit removes the default case for the switch in convertBackend to avoid a compilation error due to the switch being exhaustive.