### PR TITLE
[SYCL-MLIR] Drop `-no-mangled-function-name` option

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -27,7 +27,6 @@ using namespace clang;
 using namespace mlir;
 
 extern llvm::cl::opt<bool> GenerateAllSYCLFuncs;
-extern llvm::cl::opt<bool> OmitOptionalMangledFunctionName;
 
 ValueCategory
 MLIRScanner::VisitExtVectorElementExpr(clang::ExtVectorElementExpr *Expr) {
@@ -1055,11 +1054,6 @@ static NamedAttrList getSYCLMethodOpAttrs(OpBuilder &Builder,
             Builder.getTypeArrayAttr(ArgumentTypes));
   Attrs.set(mlir::sycl::SYCLDialect::getFunctionNameAttrName(),
             FlatSymbolRefAttr::get(Builder.getStringAttr(FunctionName)));
-  if (!OmitOptionalMangledFunctionName)
-    Attrs.set(
-        mlir::sycl::SYCLDialect::getMangledFunctionNameAttrName(),
-        FlatSymbolRefAttr::get(Builder.getStringAttr(MangledFunctionName)));
-
   Attrs.set(mlir::sycl::SYCLDialect::getTypeNameAttrName(),
             FlatSymbolRefAttr::get(Builder.getStringAttr(TypeName)));
   return Attrs;

--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -222,8 +222,4 @@ static llvm::cl::opt<std::string> McpuOpt("mcpu", llvm::cl::init(""),
                                           llvm::cl::desc("Target CPU"),
                                           llvm::cl::cat(ToolOptions));
 
-llvm::cl::opt<bool> OmitOptionalMangledFunctionName(
-    "no-mangled-function-name", llvm::cl::init(true),
-    llvm::cl::desc("Whether to omit optional \"MangledFunctionName\" fields"));
-
 #endif /* CGEIST_OPTIONS_H_ */


### PR DESCRIPTION
Drop no longer used option. This will enable dropping this attribute altogether in the future.