### PR TITLE
[SYCL-MLIR][KernelDisjointSpecialization] Disable zero dimensions accessors

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
@@ -562,6 +562,7 @@ createSYCLAccessorSubscriptOp(TypedValue<MemRefType> accessor,
                               Location loc) {
   const auto accTy =
       cast<sycl::AccessorType>(accessor.getType().getElementType());
+  assert(accTy.getDimension() != 0 && "Dimensions cannot be zero");
   const auto MT = cast<MemRefType>(
       cast<LLVM::LLVMStructType>(accTy.getBody()[1]).getBody()[0]);
   return createMethodOp<sycl::SYCLAccessorSubscriptOp>(


### PR DESCRIPTION
We cannot correctly handle accessors with zero dimensions, so disable that for now. We use `sycl.accessor.subscript` to obtain the begin and end pointer of an accessor buffer, which is illegal for zero dimension accessors. (https://github.com/intel/llvm/issues/9189)