### PR TITLE
[mlir][llvm] Add trap intrinsics to the dialect

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
@@ -712,6 +712,25 @@ def LLVM_masked_compressstore
   let arguments = (ins LLVM_AnyVector, LLVM_AnyPointer, LLVM_VectorOf<I1>);
 }
 
+/// Create a call to trap intrinsic
+def LLVM_Trap : LLVM_ZeroResultIntrOp<"trap">;
+
+/// Create a call to debugtrap intrinsic
+def LLVM_DebugTrap : LLVM_ZeroResultIntrOp<"debugtrap">;
+
+/// Create a call to ubsantrap intrinsic
+def LLVM_UBSanTrap : LLVM_ZeroResultIntrOp<"ubsantrap"> {
+  let arguments = (ins I8Attr:$failureKind);
+  string llvmBuilder = [{
+    builder.CreateIntrinsic(
+      llvm::Intrinsic::ubsantrap, {}, {builder.getInt8($failureKind)});
+  }];
+  string mlirBuilder = [{
+    $_op =
+      $_builder.create<LLVM::UBSanTrap>($_location, $_int_attr($failureKind));
+  }];
+}
+
 /// Create a call to vscale intrinsic.
 def LLVM_vscale : LLVM_IntrOp<"vscale", [0], [], [], 1>;
 

--- a/mlir/test/Target/LLVMIR/Import/intrinsic.ll
+++ b/mlir/test/Target/LLVMIR/Import/intrinsic.ll
@@ -357,13 +357,12 @@ define void @masked_expand_compress_intrinsics(ptr %0, <7 x i1> %1, <7 x float> 
 
 ; CHECK-LABEL:  llvm.func @trap_intrinsics
 define void @trap_intrinsics() {
-  ; CHECK: %[[ZERO:.*]] = llvm.mlir.constant(0 : i8) : i8
   ; CHECK: "llvm.intr.trap"() : () -> ()
   call void @llvm.trap()
   ; CHECK: "llvm.intr.debugtrap"() : () -> ()
   call void @llvm.debugtrap()
-  ; CHECK: "llvm.intr.ubsantrap"() {failureKind = 0 : i8} : () -> ()
-  call void @llvm.ubsantrap(i8 0)
+  ; CHECK: "llvm.intr.ubsantrap"() {failureKind = 1 : i8} : () -> ()
+  call void @llvm.ubsantrap(i8 1)
   ret void
 }
 

--- a/mlir/test/Target/LLVMIR/Import/intrinsic.ll
+++ b/mlir/test/Target/LLVMIR/Import/intrinsic.ll
@@ -355,6 +355,18 @@ define void @masked_expand_compress_intrinsics(ptr %0, <7 x i1> %1, <7 x float> 
   ret void
 }
 
+; CHECK-LABEL:  llvm.func @trap_intrinsics
+define void @trap_intrinsics() {
+  ; CHECK: %[[ZERO:.*]] = llvm.mlir.constant(0 : i8) : i8
+  ; CHECK: "llvm.intr.trap"() : () -> ()
+  call void @llvm.trap()
+  ; CHECK: "llvm.intr.debugtrap"() : () -> ()
+  call void @llvm.debugtrap()
+  ; CHECK: "llvm.intr.ubsantrap"() {failureKind = 0 : i8} : () -> ()
+  call void @llvm.ubsantrap(i8 0)
+  ret void
+}
+
 ; CHECK-LABEL:  llvm.func @memcpy_test
 define void @memcpy_test(i32 %0, ptr %1, ptr %2) {
   ; CHECK: %[[FALSE:.+]] = llvm.mlir.constant(false) : i1
@@ -743,6 +755,9 @@ declare <7 x float> @llvm.masked.gather.v7f32.v7p0(<7 x ptr>, i32 immarg, <7 x i
 declare void @llvm.masked.scatter.v7f32.v7p0(<7 x float>, <7 x ptr>, i32 immarg, <7 x i1>)
 declare <7 x float> @llvm.masked.expandload.v7f32(ptr, <7 x i1>, <7 x float>)
 declare void @llvm.masked.compressstore.v7f32(<7 x float>, ptr, <7 x i1>)
+declare void @llvm.trap()
+declare void @llvm.debugtrap()
+declare void @llvm.ubsantrap(i8 immarg)
 declare void @llvm.memcpy.p0.p0.i32(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i32, i1 immarg)
 declare void @llvm.memcpy.inline.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64 immarg, i1 immarg)
 declare void @llvm.memmove.p0.p0.i32(ptr nocapture writeonly, ptr nocapture readonly, i32, i1 immarg)

--- a/mlir/test/Target/LLVMIR/llvmir-intrinsics.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir-intrinsics.mlir
@@ -376,13 +376,12 @@ llvm.func @masked_expand_compress_intrinsics(%ptr: !llvm.ptr<f32>, %mask: vector
 
 // CHECK-LABEL: @trap_intrinsics
 llvm.func @trap_intrinsics() {
-  %0 = llvm.mlir.constant(0 : i8) : i8
   // CHECK: call void @llvm.trap()
   "llvm.intr.trap"() : () -> ()
   // CHECK: call void @llvm.debugtrap()
   "llvm.intr.debugtrap"() : () -> ()
-  // CHECK: call void @llvm.ubsantrap(i8 0)
-  "llvm.intr.ubsantrap"() {failureKind = 0 : i8} : () -> ()
+  // CHECK: call void @llvm.ubsantrap(i8 1)
+  "llvm.intr.ubsantrap"() {failureKind = 1 : i8} : () -> ()
   llvm.return
 }
 

--- a/mlir/test/Target/LLVMIR/llvmir-intrinsics.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir-intrinsics.mlir
@@ -374,6 +374,18 @@ llvm.func @masked_expand_compress_intrinsics(%ptr: !llvm.ptr<f32>, %mask: vector
   llvm.return
 }
 
+// CHECK-LABEL: @trap_intrinsics
+llvm.func @trap_intrinsics() {
+  %0 = llvm.mlir.constant(0 : i8) : i8
+  // CHECK: call void @llvm.trap()
+  "llvm.intr.trap"() : () -> ()
+  // CHECK: call void @llvm.debugtrap()
+  "llvm.intr.debugtrap"() : () -> ()
+  // CHECK: call void @llvm.ubsantrap(i8 0)
+  "llvm.intr.ubsantrap"() {failureKind = 0 : i8} : () -> ()
+  llvm.return
+}
+
 // CHECK-LABEL: @memcpy_test
 llvm.func @memcpy_test(%arg0: i32, %arg2: !llvm.ptr<i8>, %arg3: !llvm.ptr<i8>) {
   %i1 = llvm.mlir.constant(false) : i1
@@ -788,6 +800,9 @@ llvm.func @lifetime(%p: !llvm.ptr) {
 // CHECK-DAG: declare void @llvm.masked.scatter.v7f32.v7p0(<7 x float>, <7 x ptr>, i32 immarg, <7 x i1>)
 // CHECK-DAG: declare <7 x float> @llvm.masked.expandload.v7f32(ptr nocapture, <7 x i1>, <7 x float>)
 // CHECK-DAG: declare void @llvm.masked.compressstore.v7f32(<7 x float>, ptr nocapture, <7 x i1>)
+// CHECK-DAG: declare void @llvm.trap()
+// CHECK-DAG: declare void @llvm.debugtrap()
+// CHECK-DAG: declare void @llvm.ubsantrap(i8 immarg)
 // CHECK-DAG: declare void @llvm.memcpy.p0.p0.i32(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i32, i1 immarg)
 // CHECK-DAG: declare void @llvm.memcpy.inline.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64 immarg, i1 immarg)
 // CHECK-DAG: declare { i32, i1 } @llvm.sadd.with.overflow.i32(i32, i32)


### PR DESCRIPTION
Define `llvm.trap`, `llvm.debugtrap`, and `llvm.ubsantrap` intrinsics in the `llvm` dialect.