### PR TITLE
[SYCL][NFC] Fix dependencies of check-sycl-e2e

### DIFF
--- a/sycl/test-e2e/CMakeLists.txt
+++ b/sycl/test-e2e/CMakeLists.txt
@@ -50,6 +50,8 @@ endif() # Standalone.
 if(NOT SYCL_TEST_E2E_STANDALONE)
   list(APPEND SYCL_E2E_TEST_DEPS
     sycl-toolchain
+    FileCheck
+    not
   )
 endif() # Standalone.
 


### PR DESCRIPTION
Added testing utilities which are not part of `sycl-toolchain`.
This patch allows to build `check-sycl-e2e` target on a "clean" state
(i.e. without having built `check-sycl` or other similar target first).