### PR TITLE
[SYCL-MLIR][NFC] Change constructor name for passes

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.h
@@ -51,7 +51,7 @@ std::unique_ptr<Pass> createOpenMPOptPass();
 std::unique_ptr<Pass> createParallelLowerPass();
 std::unique_ptr<Pass> createRaiseSCFToAffinePass();
 std::unique_ptr<Pass> createRemoveTrivialUsePass();
-std::unique_ptr<Pass> replaceAffineCFGPass();
+std::unique_ptr<Pass> createReplaceAffineCFGPass();
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.h
@@ -37,6 +37,7 @@ std::unique_ptr<Pass> createBarrierRemovalContinuation();
 std::unique_ptr<Pass> createCPUifyPass();
 std::unique_ptr<Pass> createCPUifyPass(const SCFCPUifyOptions &options);
 std::unique_ptr<Pass> createCanonicalizeForPass();
+std::unique_ptr<Pass> createDetectReductionPass();
 std::unique_ptr<Pass> createInnerSerializationPass();
 std::unique_ptr<Pass> createKernelDisjointSpecializationPass();
 std::unique_ptr<Pass> createKernelDisjointSpecializationPass(
@@ -50,7 +51,6 @@ std::unique_ptr<Pass> createOpenMPOptPass();
 std::unique_ptr<Pass> createParallelLowerPass();
 std::unique_ptr<Pass> createRaiseSCFToAffinePass();
 std::unique_ptr<Pass> createRemoveTrivialUsePass();
-std::unique_ptr<Pass> detectReductionPass();
 std::unique_ptr<Pass> replaceAffineCFGPass();
 
 //===----------------------------------------------------------------------===//

--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
@@ -13,7 +13,7 @@ include "mlir/Pass/PassBase.td"
 
 def AffineCFG : Pass<"affine-cfg"> {
   let summary = "Replace scf.if and similar with affine.if";
-  let constructor = "mlir::polygeist::replaceAffineCFGPass()";
+  let constructor = "mlir::polygeist::createReplaceAffineCFGPass()";
 }
 
 def ArgumentPromotion : Pass<"arg-promotion", "mlir::ModuleOp"> {

--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
@@ -44,7 +44,7 @@ def ArgumentPromotion : Pass<"arg-promotion", "mlir::ModuleOp"> {
 
 def DetectReduction : Pass<"detect-reduction"> {
   let summary = "Detect array reduction operations in a loop";
-  let constructor = "mlir::polygeist::detectReductionPass()";
+  let constructor = "mlir::polygeist::createDetectReductionPass()";
   let statistics = [
     Statistic<"numReductions", "num-reductions", "Number of reductions detected">
   ];

--- a/polygeist/lib/Dialect/Polygeist/Transforms/AffineCFG.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/AffineCFG.cpp
@@ -1462,6 +1462,6 @@ void AffineCFGPass::runOnOperation() {
   (void)applyPatternsAndFoldGreedily(getOperation(), std::move(rpl), config);
 }
 
-std::unique_ptr<Pass> mlir::polygeist::replaceAffineCFGPass() {
+std::unique_ptr<Pass> mlir::polygeist::createReplaceAffineCFGPass() {
   return std::make_unique<AffineCFGPass>();
 }

--- a/polygeist/lib/Dialect/Polygeist/Transforms/DetectReduction.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/DetectReduction.cpp
@@ -469,7 +469,7 @@ void DetectReductionPass::runOnOperation() {
 
 namespace mlir {
 namespace polygeist {
-std::unique_ptr<Pass> detectReductionPass() {
+std::unique_ptr<Pass> createDetectReductionPass() {
   return std::make_unique<DetectReductionPass>();
 }
 } // namespace polygeist

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -394,7 +394,7 @@ static LogicalResult optimize(mlir::MLIRContext &Ctx,
       OptPM.addPass(mlir::createLoopInvariantCodeMotionPass());
     OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
     if (DetectReduction)
-      OptPM.addPass(polygeist::detectReductionPass());
+      OptPM.addPass(polygeist::createDetectReductionPass());
 
     OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
     OptPM.addPass(mlir::createCSEPass());

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -303,7 +303,7 @@ static LogicalResult canonicalize(mlir::MLIRContext &Ctx,
   OptPM.addPass(polygeist::createMem2RegPass());
   OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
   OptPM.addPass(polygeist::createLoopRestructurePass());
-  OptPM.addPass(polygeist::replaceAffineCFGPass());
+  OptPM.addPass(polygeist::createReplaceAffineCFGPass());
   OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
   if (EnableLICM)
     OptPM.addPass(polygeist::createLICMPass(
@@ -332,7 +332,7 @@ static LogicalResult canonicalize(mlir::MLIRContext &Ctx,
     else
       OptPM.addPass(mlir::createLoopInvariantCodeMotionPass());
     OptPM.addPass(polygeist::createRaiseSCFToAffinePass());
-    OptPM.addPass(polygeist::replaceAffineCFGPass());
+    OptPM.addPass(polygeist::createReplaceAffineCFGPass());
     if (ScalarReplacement)
       addFunctionPass(createAffineScalarReplacementPass);
   }
@@ -384,7 +384,7 @@ static LogicalResult optimize(mlir::MLIRContext &Ctx,
     OptPM.addPass(polygeist::createCanonicalizeForPass());
     if (RaiseToAffine)
       OptPM.addPass(polygeist::createRaiseSCFToAffinePass());
-    OptPM.addPass(polygeist::replaceAffineCFGPass());
+    OptPM.addPass(polygeist::createReplaceAffineCFGPass());
     OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
     OptPM.addPass(mlir::createCSEPass());
     if (EnableLICM)
@@ -408,7 +408,7 @@ static LogicalResult optimize(mlir::MLIRContext &Ctx,
 
     if (RaiseToAffine)
       OptPM.addPass(polygeist::createRaiseSCFToAffinePass());
-    OptPM.addPass(polygeist::replaceAffineCFGPass());
+    OptPM.addPass(polygeist::createReplaceAffineCFGPass());
   }
 
   if (mlir::failed(PM.run(Module.get()))) {
@@ -476,7 +476,7 @@ static LogicalResult optimizeCUDA(mlir::MLIRContext &Ctx,
       NOptPM2.addPass(mlir::createLoopInvariantCodeMotionPass());
     NOptPM2.addPass(polygeist::createRaiseSCFToAffinePass());
     NOptPM2.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
-    NOptPM2.addPass(polygeist::replaceAffineCFGPass());
+    NOptPM2.addPass(polygeist::createReplaceAffineCFGPass());
     NOptPM2.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
     if (LoopUnroll)
       NOptPM2.addPass(mlir::createLoopUnrollPass(UnrollSize, false, true));
@@ -491,7 +491,7 @@ static LogicalResult optimizeCUDA(mlir::MLIRContext &Ctx,
       NOptPM2.addPass(mlir::createLoopInvariantCodeMotionPass());
     NOptPM2.addPass(polygeist::createRaiseSCFToAffinePass());
     NOptPM2.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
-    NOptPM2.addPass(polygeist::replaceAffineCFGPass());
+    NOptPM2.addPass(polygeist::createReplaceAffineCFGPass());
     NOptPM2.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
     if (ScalarReplacement)
       PM.addNestedPass<func::FuncOp>(mlir::createAffineScalarReplacementPass());
@@ -544,7 +544,7 @@ static LogicalResult finalizeCUDA(mlir::PassManager &PM, Options &options) {
       OptPM.addPass(mlir::createLoopInvariantCodeMotionPass());
     OptPM.addPass(polygeist::createRaiseSCFToAffinePass());
     OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
-    OptPM.addPass(polygeist::replaceAffineCFGPass());
+    OptPM.addPass(polygeist::createReplaceAffineCFGPass());
     OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
     if (ScalarReplacement)
       PM.addNestedPass<func::FuncOp>(mlir::createAffineScalarReplacementPass());
@@ -570,7 +570,7 @@ static LogicalResult finalizeCUDA(mlir::PassManager &PM, Options &options) {
       OptPM.addPass(mlir::createLoopInvariantCodeMotionPass());
     OptPM.addPass(polygeist::createRaiseSCFToAffinePass());
     OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
-    OptPM.addPass(polygeist::replaceAffineCFGPass());
+    OptPM.addPass(polygeist::createReplaceAffineCFGPass());
     OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
     if (LoopUnroll)
       OptPM.addPass(mlir::createLoopUnrollPass(UnrollSize, false, true));
@@ -585,7 +585,7 @@ static LogicalResult finalizeCUDA(mlir::PassManager &PM, Options &options) {
       OptPM.addPass(mlir::createLoopInvariantCodeMotionPass());
     OptPM.addPass(polygeist::createRaiseSCFToAffinePass());
     OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
-    OptPM.addPass(polygeist::replaceAffineCFGPass());
+    OptPM.addPass(polygeist::createReplaceAffineCFGPass());
     OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
     if (ScalarReplacement)
       PM.addNestedPass<func::FuncOp>(mlir::createAffineScalarReplacementPass());


### PR DESCRIPTION
Change from `detectReductionPass` to `createDetectReductionPass` to be consistent with other passes.
Change from `replaceAffineCFGPass` to `createReplaceAffineCFGPass` to be consistent with other passes.