### PR TITLE
[SYCL][Driver] Assume SPV environment for SPIR-V based objects

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9539,8 +9539,11 @@ void SPIRVTranslator::ConstructJob(Compilation &C, const JobAction &JA,
         TCArgs.getLastArgValue(options::OPT_fsycl_device_obj_EQ)
             .equals_insensitive("spirv") &&
         !TCArgs.hasArg(options::OPT_fsycl_device_only);
-    if (CreatingSyclSPIRVFatObj)
+    if (CreatingSyclSPIRVFatObj) {
       TranslatorArgs.push_back("--spirv-preserve-auxdata");
+      //TranslatorArgs.push_back("--spirv-preserve-builtin-functions");
+
+    }
 
     // Disable all the extensions by default
     std::string ExtArg("-spirv-ext=-all");
@@ -9963,8 +9966,12 @@ void SpirvToIrWrapper::ConstructJob(Compilation &C, const JobAction &JA,
   addArgs(CmdArgs, TCArgs, {"-o", Output.getFilename()});
 
   // Make sure we preserve any auxiliary data which may be present in the
-  // SPIR-V object, which we need for SPIR-V-based fat objects.
-  addArgs(CmdArgs, TCArgs, {"-llvm-spirv-opts", "--spirv-preserve-auxdata"});
+  // SPIR-V object, which we need for SPIR-V-based fat objects, and we use a
+  // SPV-IR environment to prevent SPIR-V intrinsics being converted to OCL
+  // intrinsics.
+  addArgs(CmdArgs, TCArgs,
+          {"-llvm-spirv-opts",
+           "--spirv-preserve-auxdata --spirv-target-env=SPV-IR --spirv-preserve-builtin-functions"});
 
   auto Cmd = std::make_unique<Command>(
       JA, *this, ResponseFileSupport::None(),

--- a/clang/test/Driver/sycl-spirv-obj.cpp
+++ b/clang/test/Driver/sycl-spirv-obj.cpp
@@ -40,5 +40,5 @@
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fsycl-device-obj=spirv -### %t.o 2>&1 | \
 // RUN:  FileCheck %s -check-prefixes=OPT_WARNING,LLVM_SPIRV_R
 // OPT_WARNING: warning: argument unused during compilation: '-fsycl-device-obj=spirv'
-// LLVM_SPIRV_R: spirv-to-ir-wrapper{{.*}} "-llvm-spirv-opts" "--spirv-preserve-auxdata"
+// LLVM_SPIRV_R: spirv-to-ir-wrapper{{.*}} "-llvm-spirv-opts" "--spirv-preserve-auxdata --spirv-target-env=SPV-IR"
 // LLVM_SPIRV_R-NOT: llvm-spirv{{.*}} "-r"

--- a/llvm-spirv/include/LLVMSPIRVOpts.h
+++ b/llvm-spirv/include/LLVMSPIRVOpts.h
@@ -131,6 +131,10 @@ public:
 
   void setPreserveAuxData(bool ArgValue) { PreserveAuxData = ArgValue; }
 
+  bool preserveBuiltinFunctions() const { return PreserveBuiltinFunctions; }
+
+  void setPreserveBuiltinFunctions(bool ArgValue) { PreserveBuiltinFunctions = ArgValue; }
+
   void setGenKernelArgNameMDEnabled(bool ArgNameMD) {
     GenKernelArgNameMD = ArgNameMD;
   }
@@ -241,6 +245,8 @@ private:
   bool PreserveOCLKernelArgTypeMetadataThroughString = false;
 
   bool PreserveAuxData = false;
+
+  bool PreserveBuiltinFunctions = false;
 };
 
 } // namespace SPIRV

--- a/llvm-spirv/lib/SPIRV/SPIRVReader.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVReader.cpp
@@ -3345,7 +3345,7 @@ bool SPIRVToLLVM::translate() {
   //   e.g. load i32, i32* @__spirv_BuiltInGlobalLinearId, align 4
   // If the desired format is global variables, we don't have to lower them
   // as calls.
-  if (!lowerBuiltinVariablesToCalls(M))
+  if (!BM->preserveBuiltinFunctions() && !lowerBuiltinVariablesToCalls(M))
     return false;
   if (BM->getDesiredBIsRepresentation() == BIsRepresentation::SPIRVFriendlyIR) {
     SPIRVWord SrcLangVer = 0;

--- a/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
@@ -2929,6 +2929,8 @@ bool LLVMToSPIRVBase::transBuiltinSet() {
 ///  load WorkDim
 bool LLVMToSPIRVBase::transWorkItemBuiltinCallsToVariables() {
   LLVM_DEBUG(dbgs() << "Enter transWorkItemBuiltinCallsToVariables\n");
+  if(BM->preserveBuiltinFunctions())
+    return true;
   // Store instructions and functions that need to be removed.
   SmallVector<Value *, 16> ToRemove;
   for (auto &F : *M) {

--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVModule.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVModule.h
@@ -531,6 +531,10 @@ public:
     return TranslationOpts.preserveAuxData();
   }
 
+  bool preserveBuiltinFunctions() const noexcept {
+    return TranslationOpts.preserveBuiltinFunctions();
+  }
+
   SPIRVExtInstSetKind getDebugInfoEIS() const {
     switch (TranslationOpts.getDebugInfoEIS()) {
     case DebugInfoEIS::SPIRV_Debug:

--- a/llvm-spirv/tools/llvm-spirv/llvm-spirv.cpp
+++ b/llvm-spirv/tools/llvm-spirv/llvm-spirv.cpp
@@ -128,6 +128,8 @@ static cl::list<std::string> SPIRVAllowUnknownIntrinsics(
              "(default) would naturally allow all unknown intrinsics"),
     cl::value_desc("intrinsic_prefix_1,intrinsic_prefix_2"), cl::ValueOptional);
 
+static cl::opt<bool> SPIRVPreserveBuiltinFunctions("spirv-preserve-builtin-functions", cl::init(false), cl::desc(""));
+
 static cl::opt<bool> SPIRVGenKernelArgNameMD(
     "spirv-gen-kernel-arg-name-md", cl::init(false),
     cl::desc("Enable generating OpenCL kernel argument name "
@@ -719,6 +721,8 @@ int main(int Ac, char **Av) {
     Opts.setMemToRegEnabled(SPIRVMemToReg);
   if (SPIRVGenKernelArgNameMD)
     Opts.setGenKernelArgNameMDEnabled(SPIRVGenKernelArgNameMD);
+  if(SPIRVPreserveBuiltinFunctions)
+    Opts.setPreserveBuiltinFunctions(SPIRVPreserveBuiltinFunctions);
   if (IsReverse && !SpecConst.empty()) {
     if (parseSpecConstOpt(SpecConst, Opts))
       return -1;


### PR DESCRIPTION
This prevents us from translating SPIR-V intrinsics into OCL intrinsics, which is what happens by default.