### PR TITLE
[SYCL][NFC] Fix static code analysis concerns

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4883,7 +4883,8 @@ class SYCLFwdDeclEmitter
   }
 
 public:
-  SYCLFwdDeclEmitter(raw_ostream &OS, LangOptions LO) : OS(OS), Policy(LO) {
+  SYCLFwdDeclEmitter(raw_ostream &OS, const LangOptions &LO)
+      : OS(OS), Policy(LO) {
     Policy.adjustForCPlusPlusFwdDecl();
     Policy.SuppressTypedefs = true;
     Policy.SuppressUnwrittenScope = true;


### PR DESCRIPTION
Found via a static-analysis tool:

Big parameter passed by value
Copying large values is inefficient, consider passing by reference.

Inside "SemaSYCL.cpp" file,
in SYCLFwdDeclEmitter::SYCLFwdDeclEmitter(llvm::raw_ostream &, clang::LangOptions): A very large function call parameter exceeding the high threshold is passed by value.

pass_by_value: Passing parameter LO of type clang::LangOptions (size 1696 bytes) by value, which exceeds the high threshold of 512 bytes.