### PR TITLE
[SYCL] Fix operator& and operator[] in local_accessor<const T>

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -2646,18 +2646,24 @@ public:
     return detail::convertToArrayOfN<Dims, 1>(getSize());
   }
 
-  template <int Dims = Dimensions, typename = std::enable_if_t<Dims == 0>>
+  template <int Dims = Dimensions,
+            typename = std::enable_if_t<Dims == 0 &&
+                                        (IsAccessAnyWrite || IsAccessReadOnly)>>
   operator RefType() const {
     return *getQualifiedPtr();
   }
 
-  template <int Dims = Dimensions, typename = std::enable_if_t<(Dims > 0)>>
+  template <int Dims = Dimensions,
+            typename = std::enable_if_t<(Dims > 0) &&
+                                        (IsAccessAnyWrite || IsAccessReadOnly)>>
   RefType operator[](id<Dimensions> Index) const {
     const size_t LinearIndex = getLinearIndex(Index);
     return getQualifiedPtr()[LinearIndex];
   }
 
-  template <int Dims = Dimensions, typename = std::enable_if_t<Dims == 1>>
+  template <int Dims = Dimensions,
+            typename = std::enable_if_t<Dims == 1 &&
+                                        (IsAccessAnyWrite || IsAccessReadOnly)>>
   RefType operator[](size_t Index) const {
     return getQualifiedPtr()[Index];
   }

--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -2646,21 +2646,18 @@ public:
     return detail::convertToArrayOfN<Dims, 1>(getSize());
   }
 
-  template <int Dims = Dimensions,
-            typename = std::enable_if_t<Dims == 0 && IsAccessAnyWrite>>
+  template <int Dims = Dimensions, typename = std::enable_if_t<Dims == 0>>
   operator RefType() const {
     return *getQualifiedPtr();
   }
 
-  template <int Dims = Dimensions,
-            typename = std::enable_if_t<(Dims > 0) && IsAccessAnyWrite>>
+  template <int Dims = Dimensions, typename = std::enable_if_t<(Dims > 0)>>
   RefType operator[](id<Dimensions> Index) const {
     const size_t LinearIndex = getLinearIndex(Index);
     return getQualifiedPtr()[LinearIndex];
   }
 
-  template <int Dims = Dimensions,
-            typename = std::enable_if_t<Dims == 1 && IsAccessAnyWrite>>
+  template <int Dims = Dimensions, typename = std::enable_if_t<Dims == 1>>
   RefType operator[](size_t Index) const {
     return getQualifiedPtr()[Index];
   }

--- a/sycl/test-e2e/Basic/accessor/accessor.cpp
+++ b/sycl/test-e2e/Basic/accessor/accessor.cpp
@@ -1096,6 +1096,24 @@ int main() {
     assert(Data == 64);
   }
 
+  // local_accessor::operator& and local_accessor::operator[] with const DataT
+  {
+    using AccT_zero = sycl::local_accessor<const int, 0>;
+    using AccT_non_zero = sycl::local_accessor<const int, 1>;
+
+    sycl::queue queue;
+    {
+      queue.submit([&](sycl::handler &cgh) {
+        AccT_zero acc_zero(cgh);
+        AccT_non_zero acc_non_zero(sycl::range<1>(5), cgh);
+        cgh.single_task([=] {
+          const int &ref_zero = acc_zero;
+          const int &ref_non_zero = acc_non_zero[0];
+        });
+      });
+    }
+  }
+
   // host_accessor hash
   {
     sycl::buffer<int> buffer1{sycl::range<1>{1}};


### PR DESCRIPTION
* Address failure on local_accessor::operator& and local_accessor::opeator[] with const DataT.
* IsAccessAnyWrite in local_accessor with const type is false, which does not satisfy the enable_if conditions, add IsAccessReadOnly to condition.
* Adds test
