### PR TITLE
[SYCL-MLIR] Use `std::set` to store accessor pairs for versioning

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.h
@@ -26,37 +26,6 @@ inline bool isSYCLOperation(Operation *op) {
   return isa<sycl::SYCLDialect>(op->getDialect());
 }
 
-/// Return true if type is 'memref<?x!sycl.accessor>'.
-inline bool isAccessorPtrType(Type type) {
-  auto mt = dyn_cast<MemRefType>(type);
-  bool isMemRefWithExpectedShape =
-      (mt && mt.hasRank() && (mt.getRank() == 1) &&
-       ShapedType::isDynamic(mt.getShape()[0]) && mt.getLayout().isIdentity());
-  if (!isMemRefWithExpectedShape)
-    return false;
-
-  return isa<sycl::AccessorType>(mt.getElementType());
-}
-
-/// Represent Value of type 'memref<?x!sycl.accessor>'.
-class AccessorPtr : public Value {
-public:
-  AccessorPtr(Value accessorPtr) : Value(accessorPtr) {
-    assert(classof(accessorPtr) &&
-           "Expecting to construct with an AccessorPtr");
-  }
-
-  sycl::AccessorType getAccessorType() {
-    return mlir::cast<sycl::AccessorType>(
-        mlir::cast<MemRefType>(getType()).getElementType());
-  }
-
-  bool operator<(const AccessorPtr &other) const { return impl < other.impl; }
-
-  static bool classof(Value v) { return isAccessorPtrType(v.getType()); }
-};
-using AccessorPtrPair = std::pair<AccessorPtr, AccessorPtr>;
-
 } // namespace sycl
 } // namespace mlir
 

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.h
@@ -26,6 +26,37 @@ inline bool isSYCLOperation(Operation *op) {
   return isa<sycl::SYCLDialect>(op->getDialect());
 }
 
+/// Return true if type is 'memref<?x!sycl.accessor>'.
+inline bool isAccessorPtrType(Type type) {
+  auto mt = dyn_cast<MemRefType>(type);
+  bool isMemRefWithExpectedShape =
+      (mt && mt.hasRank() && (mt.getRank() == 1) &&
+       ShapedType::isDynamic(mt.getShape()[0]) && mt.getLayout().isIdentity());
+  if (!isMemRefWithExpectedShape)
+    return false;
+
+  return isa<sycl::AccessorType>(mt.getElementType());
+}
+
+/// Represent Value of type 'memref<?x!sycl.accessor>'.
+class AccessorPtr : public Value {
+public:
+  AccessorPtr(Value accessorPtr) : Value(accessorPtr) {
+    assert(classof(accessorPtr) &&
+           "Expecting to construct with an AccessorPtr");
+  }
+
+  sycl::AccessorType getAccessorType() {
+    return mlir::cast<sycl::AccessorType>(
+        mlir::cast<MemRefType>(getType()).getElementType());
+  }
+
+  bool operator<(const AccessorPtr &other) const { return impl < other.impl; }
+
+  static bool classof(Value v) { return isAccessorPtrType(v.getType()); }
+};
+using AccessorPtrPair = std::pair<AccessorPtr, AccessorPtr>;
+
 } // namespace sycl
 } // namespace mlir
 

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLTypes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLTypes.h
@@ -44,4 +44,33 @@ llvm::SmallVector<mlir::TypeID> getDerivedTypes(mlir::TypeID TypeID);
 #define GET_TYPEDEF_CLASSES
 #include "mlir/Dialect/SYCL/IR/SYCLOpsTypes.h.inc"
 
+namespace mlir {
+namespace sycl {
+
+/// Return true if type is 'memref<?x!sycl.accessor>'.
+bool isAccessorPtrType(Type type);
+
+/// Represent Value of type 'memref<?x!sycl.accessor>'.
+class AccessorPtrValue : public Value {
+public:
+  AccessorPtrValue(Value val) : Value(val) {
+    assert(classof(val) && "val should be an 'AccessorPtrValue");
+  }
+
+  AccessorType getAccessorType() {
+    return mlir::cast<AccessorType>(
+        mlir::cast<MemRefType>(getType()).getElementType());
+  }
+
+  bool operator<(const AccessorPtrValue &other) const {
+    return impl < other.impl;
+  }
+
+  static bool classof(Value v);
+};
+using AccessorPtrPair = std::pair<AccessorPtrValue, AccessorPtrValue>;
+
+} // namespace sycl
+} // namespace mlir
+
 #endif // MLIR_DIALECT_SYCL_IR_SYCLTYPES_H

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLTypes.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLTypes.cpp
@@ -64,3 +64,18 @@ unsigned mlir::sycl::getDimensions(mlir::Type Type) {
       .Case<AccessorType, GroupType, IDType, ItemType, NdItemType, NdRangeType,
             RangeType>([](auto Ty) { return Ty.getDimension(); });
 }
+
+bool mlir::sycl::isAccessorPtrType(Type type) {
+  auto mt = dyn_cast<MemRefType>(type);
+  bool isMemRefWithExpectedShape =
+      (mt && mt.hasRank() && (mt.getRank() == 1) &&
+       ShapedType::isDynamic(mt.getShape()[0]) && mt.getLayout().isIdentity());
+  if (!isMemRefWithExpectedShape)
+    return false;
+
+  return isa<sycl::AccessorType>(mt.getElementType());
+}
+
+bool mlir::sycl::AccessorPtrValue::classof(Value v) {
+  return isAccessorPtrType(v.getType());
+}

--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -37,7 +37,7 @@ class ParallelOp;
 } // namespace scf
 
 namespace sycl {
-class AccessorPtr;
+class AccessorPtrValue;
 } // namespace sycl
 
 namespace polygeist {
@@ -276,7 +276,8 @@ public:
 /// overlap.
 class VersionConditionBuilder {
 public:
-  using AccessorPtrPairType = std::pair<sycl::AccessorPtr, sycl::AccessorPtr>;
+  using AccessorPtrPairType =
+      std::pair<sycl::AccessorPtrValue, sycl::AccessorPtrValue>;
   using SCFCondition = VersionCondition::SCFCondition;
   using AffineCondition = VersionCondition::AffineCondition;
 

--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -13,6 +13,7 @@
 #ifndef MLIR_DIALECT_POLYGEIST_UTILS_TRANSFORMUTILS_H
 #define MLIR_DIALECT_POLYGEIST_UTILS_TRANSFORMUTILS_H
 
+#include "mlir/Dialect/SYCL/IR/SYCLTypes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/IntegerSet.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
@@ -276,13 +277,11 @@ public:
 /// overlap.
 class VersionConditionBuilder {
 public:
-  using AccessorPtrPairType =
-      std::pair<sycl::AccessorPtrValue, sycl::AccessorPtrValue>;
   using SCFCondition = VersionCondition::SCFCondition;
   using AffineCondition = VersionCondition::AffineCondition;
 
   VersionConditionBuilder(
-      std::set<AccessorPtrPairType> requireNoOverlapAccessorPairs,
+      std::set<sycl::AccessorPtrPair> requireNoOverlapAccessorPairs,
       OpBuilder builder, Location loc);
 
   std::unique_ptr<VersionCondition> createCondition() const {
@@ -294,7 +293,7 @@ private:
   /// Create a versioning condition suitable for scf::IfOp.
   SCFCondition createSCFCondition(OpBuilder builder, Location loc) const;
 
-  std::set<AccessorPtrPairType> accessorPairs;
+  std::set<sycl::AccessorPtrPair> accessorPairs;
   mutable OpBuilder builder;
   mutable Location loc;
 };

--- a/polygeist/lib/Dialect/Polygeist/Transforms/KernelDisjointSpecialization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/KernelDisjointSpecialization.cpp
@@ -33,9 +33,6 @@ namespace polygeist {
 } // namespace mlir
 
 using namespace mlir;
-using AccessorPtrType = polygeist::VersionConditionBuilder::AccessorPtrType;
-using AccessorPtrPairType =
-    polygeist::VersionConditionBuilder::AccessorPtrPairType;
 
 static llvm::cl::opt<unsigned> KernelDisjointSpecializationAccessorLimit(
     DEBUG_TYPE "-accessor-limit", llvm::cl::init(5),
@@ -49,45 +46,31 @@ static llvm::cl::opt<unsigned> KernelDisjointSpecializationAccessorLimit(
 /// Returns true if \p type is 'memref<?x!sycl.accessor>' with dimension != 0,
 /// and false otherwise.
 static bool isValidMemRefType(Type type) {
-  auto mt = dyn_cast<MemRefType>(type);
-  bool isMemRefWithExpectedShape =
-      (mt && mt.hasRank() && (mt.getRank() == 1) &&
-       ShapedType::isDynamic(mt.getShape()[0]) && mt.getLayout().isIdentity());
-  if (!isMemRefWithExpectedShape)
-    return false;
-
-  auto accTy = dyn_cast<sycl::AccessorType>(mt.getElementType());
-  if (!accTy)
+  if (!sycl::isAccessorPtrType(type))
     return false;
 
   // Temporary limitation before we can correctly calculate the beginning and
   // end pointer of a zero dimensional accessor.
-  if (accTy.getDimension() == 0)
-    return false;
-
-  return true;
+  auto accTy =
+      cast<sycl::AccessorType>(cast<MemRefType>(type).getElementType());
+  return (accTy.getDimension() != 0);
 }
 
 /// Returns true if \p arg is a candidate argument. Currently, all arguments
 /// with valid memref type determined by isValidMemRefType is a candidate
 /// argument, i.e., 'memref<?x!sycl.accessor>`.
 static bool isCandidateArg(Value arg) {
-  if (isValidMemRefType(arg.getType())) {
-    assert(isa<AccessorPtrType>(arg) &&
-           "Expecting valid memref type to be AccessorPtrType");
-    return true;
-  }
-  return false;
+  return isValidMemRefType(arg.getType());
 }
 
 /// Populates \p candArgs with candidate arguments from \p call.
 static void
 collectCandidateArguments(CallOpInterface call,
-                          SmallVectorImpl<AccessorPtrType> &candArgs) {
+                          SmallVectorImpl<sycl::AccessorPtr> &candArgs) {
   assert(candArgs.empty() && "Expecting empty candArgs");
   for (Value arg : call.getArgOperands())
     if (isCandidateArg(arg))
-      candArgs.push_back(cast<AccessorPtrType>(arg));
+      candArgs.push_back(cast<sycl::AccessorPtr>(arg));
 }
 
 /// Updates \p newFnName to a unique function name if it is already defined.
@@ -172,13 +155,13 @@ private:
   /// Returns true if \p acc1 and \p acc2 need to be checked for no overlap. For
   /// example, under strict aliasing rule, accessors with different element
   /// types are not alias, so return false.
-  bool isCandidateAccessorPair(AccessorPtrType acc1,
-                               AccessorPtrType acc2) const;
+  bool isCandidateAccessorPair(sycl::AccessorPtr acc1,
+                               sycl::AccessorPtr acc2) const;
   /// Populate \p accessorPairs with accessor pairs that should be checked for
   /// no overlap for \p call.
   void collectMayOverlapAccessorPairs(
       CallOpInterface call,
-      SmallVectorImpl<AccessorPtrPairType> &accessorPairs) const;
+      std::set<sycl::AccessorPtrPair> &accessorPairs) const;
   /// Version \p call.
   void versionCall(CallOpInterface call) const;
 };
@@ -244,11 +227,11 @@ bool KernelDisjointSpecializationPass::isCandidateFunction(
 }
 
 bool KernelDisjointSpecializationPass::isCandidateAccessorPair(
-    AccessorPtrType acc1, AccessorPtrType acc2) const {
+    sycl::AccessorPtr acc1, sycl::AccessorPtr acc2) const {
   assert(acc1 != acc2 && "Expecting the input accessors to be different");
   if (!relaxedAliasing) {
-    auto acc1Ty = cast<sycl::AccessorType>(acc1.getType().getElementType());
-    auto acc2Ty = cast<sycl::AccessorType>(acc2.getType().getElementType());
+    sycl::AccessorType acc1Ty = acc1.getAccessorType();
+    sycl::AccessorType acc2Ty = acc2.getAccessorType();
     if (acc1Ty.getType() != acc2Ty.getType())
       return false;
   }
@@ -258,17 +241,17 @@ bool KernelDisjointSpecializationPass::isCandidateAccessorPair(
 
 void KernelDisjointSpecializationPass::collectMayOverlapAccessorPairs(
     CallOpInterface call,
-    SmallVectorImpl<AccessorPtrPairType> &accessorPairs) const {
-  SmallVector<AccessorPtrType> candArgs;
+    std::set<sycl::AccessorPtrPair> &accessorPairs) const {
+  SmallVector<sycl::AccessorPtr> candArgs;
   collectCandidateArguments(call, candArgs);
   for (auto *i = candArgs.begin(); i != candArgs.end(); ++i)
     for (auto *j = i + 1; j != candArgs.end(); ++j)
       if (isCandidateAccessorPair(*i, *j))
-        accessorPairs.push_back({*i, *j});
+        accessorPairs.insert({*i, *j});
 }
 
 void KernelDisjointSpecializationPass::versionCall(CallOpInterface call) const {
-  SmallVector<AccessorPtrPairType> accessorPairs;
+  std::set<sycl::AccessorPtrPair> accessorPairs;
   collectMayOverlapAccessorPairs(call, accessorPairs);
   if (accessorPairs.empty())
     return;

--- a/polygeist/lib/Dialect/Polygeist/Transforms/KernelDisjointSpecialization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/KernelDisjointSpecialization.cpp
@@ -66,11 +66,11 @@ static bool isCandidateArg(Value arg) {
 /// Populates \p candArgs with candidate arguments from \p call.
 static void
 collectCandidateArguments(CallOpInterface call,
-                          SmallVectorImpl<sycl::AccessorPtr> &candArgs) {
+                          SmallVectorImpl<sycl::AccessorPtrValue> &candArgs) {
   assert(candArgs.empty() && "Expecting empty candArgs");
   for (Value arg : call.getArgOperands())
     if (isCandidateArg(arg))
-      candArgs.push_back(cast<sycl::AccessorPtr>(arg));
+      candArgs.push_back(cast<sycl::AccessorPtrValue>(arg));
 }
 
 /// Updates \p newFnName to a unique function name if it is already defined.
@@ -155,8 +155,8 @@ private:
   /// Returns true if \p acc1 and \p acc2 need to be checked for no overlap. For
   /// example, under strict aliasing rule, accessors with different element
   /// types are not alias, so return false.
-  bool isCandidateAccessorPair(sycl::AccessorPtr acc1,
-                               sycl::AccessorPtr acc2) const;
+  bool isCandidateAccessorPair(sycl::AccessorPtrValue acc1,
+                               sycl::AccessorPtrValue acc2) const;
   /// Populate \p accessorPairs with accessor pairs that should be checked for
   /// no overlap for \p call.
   void collectMayOverlapAccessorPairs(
@@ -227,7 +227,7 @@ bool KernelDisjointSpecializationPass::isCandidateFunction(
 }
 
 bool KernelDisjointSpecializationPass::isCandidateAccessorPair(
-    sycl::AccessorPtr acc1, sycl::AccessorPtr acc2) const {
+    sycl::AccessorPtrValue acc1, sycl::AccessorPtrValue acc2) const {
   assert(acc1 != acc2 && "Expecting the input accessors to be different");
   if (!relaxedAliasing) {
     sycl::AccessorType acc1Ty = acc1.getAccessorType();
@@ -242,7 +242,7 @@ bool KernelDisjointSpecializationPass::isCandidateAccessorPair(
 void KernelDisjointSpecializationPass::collectMayOverlapAccessorPairs(
     CallOpInterface call,
     std::set<sycl::AccessorPtrPair> &accessorPairs) const {
-  SmallVector<sycl::AccessorPtr> candArgs;
+  SmallVector<sycl::AccessorPtrValue> candArgs;
   collectCandidateArguments(call, candArgs);
   for (auto *i = candArgs.begin(); i != candArgs.end(); ++i)
     for (auto *j = i + 1; j != candArgs.end(); ++j)

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
@@ -337,8 +337,8 @@ public:
     return requireNoOverlapAccessorPairs;
   }
 
-  void addRequireNoOverlapAccessorPairs(sycl::AccessorPtr acc1,
-                                        sycl::AccessorPtr acc2) {
+  void addRequireNoOverlapAccessorPairs(sycl::AccessorPtrValue acc1,
+                                        sycl::AccessorPtrValue acc2) {
     requireNoOverlapAccessorPairs.insert({acc1, acc2});
   }
 
@@ -352,7 +352,7 @@ private:
 };
 
 /// Return the accessor used by \p op if found, and nullptr otherwise.
-static Optional<sycl::AccessorPtr>
+static Optional<sycl::AccessorPtrValue>
 getAccessorUsedByOperation(const Operation &op) {
   auto getMemrefOp = [](const Operation &op) {
     return TypeSwitch<const Operation &, Operation *>(op)
@@ -397,8 +397,9 @@ static bool hasConflictsInLoop(LICMCandidate &candidate,
       continue;
     }
 
-    Optional<sycl::AccessorPtr> opAccessor = getAccessorUsedByOperation(op);
-    Optional<sycl::AccessorPtr> otherAccessor =
+    Optional<sycl::AccessorPtrValue> opAccessor =
+        getAccessorUsedByOperation(op);
+    Optional<sycl::AccessorPtrValue> otherAccessor =
         getAccessorUsedByOperation(other);
     if (opAccessor.has_value() && otherAccessor.has_value())
       if (*opAccessor != *otherAccessor &&

--- a/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
@@ -546,7 +546,7 @@ static sycl::SYCLRangeGetOp createSYCLRangeGetOp(TypedValue<MemRefType> range,
 }
 
 static sycl::SYCLAccessorGetRangeOp
-createSYCLAccessorGetRangeOp(sycl::AccessorPtr accessor, OpBuilder builder,
+createSYCLAccessorGetRangeOp(sycl::AccessorPtrValue accessor, OpBuilder builder,
                              Location loc) {
   const sycl::AccessorType accTy = accessor.getAccessorType();
   const auto rangeTy = cast<sycl::RangeType>(
@@ -556,7 +556,7 @@ createSYCLAccessorGetRangeOp(sycl::AccessorPtr accessor, OpBuilder builder,
 }
 
 static sycl::SYCLAccessorSubscriptOp
-createSYCLAccessorSubscriptOp(sycl::AccessorPtr accessor,
+createSYCLAccessorSubscriptOp(sycl::AccessorPtrValue accessor,
                               TypedValue<MemRefType> id, OpBuilder builder,
                               Location loc) {
   const sycl::AccessorType accTy = accessor.getAccessorType();
@@ -568,8 +568,8 @@ createSYCLAccessorSubscriptOp(sycl::AccessorPtr accessor,
       builder, loc, MT, {accessor, id}, "operator[]", "accessor");
 }
 
-static Value getSYCLAccessorBegin(sycl::AccessorPtr accessor, OpBuilder builder,
-                                  Location loc) {
+static Value getSYCLAccessorBegin(sycl::AccessorPtrValue accessor,
+                                  OpBuilder builder, Location loc) {
   const sycl::AccessorType accTy = accessor.getAccessorType();
   const auto idTy = cast<sycl::IDType>(
       cast<sycl::AccessorImplDeviceType>(accTy.getBody()[0]).getBody()[0]);
@@ -582,8 +582,8 @@ static Value getSYCLAccessorBegin(sycl::AccessorPtr accessor, OpBuilder builder,
   return createSYCLAccessorSubscriptOp(accessor, id, builder, loc);
 }
 
-static Value getSYCLAccessorEnd(sycl::AccessorPtr accessor, OpBuilder builder,
-                                Location loc) {
+static Value getSYCLAccessorEnd(sycl::AccessorPtrValue accessor,
+                                OpBuilder builder, Location loc) {
   const sycl::AccessorType accTy = accessor.getAccessorType();
   Value getRangeOp = createSYCLAccessorGetRangeOp(accessor, builder, loc);
   auto range = builder.create<memref::AllocaOp>(


### PR DESCRIPTION
Use `std::set` to store accessor pointer pairs for versioning to avoid duplication. 
Implemented `class AccessorPtrValue`, so we can implement `operator<` to have pointer to accessor as element of `std::set`.
Instead of `using AccessorPtrType = TypedValue<MemRefType>;`, using `AccessorPtrValue` can ensure the value is indeed of type `memref<?x!sycl.accessor>`, and not just any memref type.