### PR TITLE
[SYCL][E2E] Reenable get_backend test

### DIFF
--- a/sycl/test-e2e/Basic/get_backend.cpp
+++ b/sycl/test-e2e/Basic/get_backend.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: TEMPORARY_DISABLED
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: %t.out
 //
@@ -43,22 +42,24 @@ int main() {
       return_fail();
     }
 
-    queue q(c, default_selector_v);
-    if (q.get_backend() != plt.get_backend()) {
-      return_fail();
-    }
-
-    auto device = q.get_device();
+    auto device = c.get_devices()[0];
     if (device.get_backend() != plt.get_backend()) {
       return_fail();
     }
 
-    unsigned char *HostAlloc = (unsigned char *)malloc_host(1, c);
-    auto e = q.memset(HostAlloc, 42, 1);
+    queue q(c, device);
+    if (q.get_backend() != plt.get_backend()) {
+      return_fail();
+    }
+
+    buffer<int, 1> buf{range<1>(1)};
+    event e = q.submit([&](handler &cgh) {
+      auto acc = buf.get_access<access::mode::read_write>(cgh);
+      cgh.fill(acc, 0);
+    });
     if (e.get_backend() != plt.get_backend()) {
       return_fail();
     }
-    free(HostAlloc, c);
   }
   std::cout << "Passed" << std::endl;
   return 0;


### PR DESCRIPTION
This patch makes 2 changes: it removes the outdated usage of device selector (in SYCL 2020 it always picks from all available devices instead of being limited to the context passed along with it) and adds a workaround for the problem described below.

There is an issue with extension function pointer caching in OpenCL plugin: each extension function call helper keeps a pi_context-to-fptr map cache, however, these maps aren't cleaned up on context release. This can lead to the following situation:

- Context A is created
- An extension function is called in context A
- Context A is destroyed
- A new context B is created, which happens to have the same pi_context handle
- The cached function is called for context B

If these two contexts have different platforms (like in get_backend test), this will lead to an error. This patch removes the use of USM functions from the test to circumvent this issue.