### PR TITLE
[SYCL] Add workaround for VS2019 to fix test/regression/bit_cast_win.cpp

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -1358,7 +1358,9 @@ public:
             typename... PropTypes,
             typename std::enable_if_t<
                 detail::IsCxPropertyList<PropertyListT>::value &&
-                std::is_same_v<T, DataT> && Dims == 0 &&
+                // VS2019 can't compile sycl/test/regression/bit_cast_win.cpp
+                // if std::is_same_v is used here.
+                std::is_same<T, DataT>::value && Dims == 0 &&
                 (IsHostBuf || IsHostTask || (IsGlobalBuf || IsConstantBuf))> * =
                 nullptr>
   accessor(


### PR DESCRIPTION
We use VS2019 in CI pipeline internally and
https://github.com/intel/llvm/pull/9183 and caused a regression. This PR fixes it.