### PR TITLE
[SYCL-MLIR] Opaque pointer support in cgeist code generation

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/IR/PolygeistOps.cpp
+++ b/polygeist/lib/Dialect/Polygeist/IR/PolygeistOps.cpp
@@ -1131,9 +1131,9 @@ public:
                                                  rewriter.getI64Type(), idx[0]);
 
     auto PtrTy = cast<LLVM::LLVMPointerType>(op.getType());
-    if (!PtrTy.isOpaque()) {
+    if (!PtrTy.isOpaque())
       PtrTy = LLVM::LLVMPointerType::get(MET, PtrTy.getAddressSpace());
-    }
+
     Value GEP = rewriter.create<LLVM::GEPOp>(
         op->getLoc(), PtrTy, MET,
         rewriter.create<Memref2PointerOp>(op.getLoc(), PtrTy, src.getSource()),

--- a/polygeist/lib/Dialect/Polygeist/IR/PolygeistOps.cpp
+++ b/polygeist/lib/Dialect/Polygeist/IR/PolygeistOps.cpp
@@ -1127,19 +1127,10 @@ public:
       return failure();
 
     Value idx[] = {src.getIndex()};
-    auto PET = cast<LLVM::LLVMPointerType>(op.getType()).getElementType();
-    if (PET != MET) {
-      auto ps = rewriter.create<polygeist::TypeSizeOp>(
-          op.getLoc(), rewriter.getIndexType(), mlir::TypeAttr::get(PET));
-      auto ms = rewriter.create<polygeist::TypeSizeOp>(
-          op.getLoc(), rewriter.getIndexType(), mlir::TypeAttr::get(MET));
-      idx[0] = rewriter.create<MulIOp>(op.getLoc(), idx[0], ms);
-      idx[0] = rewriter.create<DivUIOp>(op.getLoc(), idx[0], ps);
-    }
     idx[0] = rewriter.create<arith::IndexCastOp>(op.getLoc(),
                                                  rewriter.getI64Type(), idx[0]);
     rewriter.replaceOpWithNewOp<LLVM::GEPOp>(
-        op, op.getType(),
+        op, op.getType(), MET,
         rewriter.create<Memref2PointerOp>(op.getLoc(), op.getType(),
                                           src.getSource()),
         idx);

--- a/polygeist/lib/Dialect/Polygeist/Transforms/Mem2Reg.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/Mem2Reg.cpp
@@ -1445,14 +1445,19 @@ bool Mem2Reg::forwardStoreToLoad(
       [&](Value orig, ValueOrPlaceholder *replacement) -> ValueOrPlaceholder * {
     assert(replacement);
     replacement->materialize(/*full*/ false);
-    assert(orig.getType() == elType);
+    // TODO(Lukas): The following assert has been deactivated, as elType will
+    // be 'null' for opaque pointers.
+    // assert(orig.getType() == elType);
     if (replacement->overwritten) {
       loadOps.erase(orig.getDefiningOp());
       return metaMap.get(orig);
-    } else if (replacement->val) {
+    }
+    if (replacement->val) {
       changed = true;
       assert(orig != replacement->val);
-      assert(replacement->val.getType() == elType);
+      // TODO(Lukas): The following assert has been deactivated, as elType will
+      // be 'null' for opaque pointers.
+      // assert(replacement->val.getType() == elType);
       assert(orig.getType() == replacement->val.getType() &&
              "mismatched load type");
       LLVM_DEBUG(llvm::dbgs() << " replaced " << orig << " with "

--- a/polygeist/test/polygeist-opt/canonicalization.mlir
+++ b/polygeist/test/polygeist-opt/canonicalization.mlir
@@ -48,8 +48,10 @@ func.func @memref2ptr(%arg0: memref<10xi32>) -> !llvm.ptr<i8> {
      %1 = "polygeist.memref2pointer"(%0) : (memref<?xi32>) -> !llvm.ptr<i8>
      return %1 : !llvm.ptr<i8>
 }
-// CHECK: func.func @memref2ptr(%arg0: memref<10xi32>) -> !llvm.ptr<i8> {
-// CHECK-NEXT: %0 = "polygeist.memref2pointer"(%arg0) : (memref<10xi32>) -> !llvm.ptr<i8>
-// CHECK-NEXT: %1 = llvm.getelementptr %0[8] : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
-// CHECK-NEXT: return %1 : !llvm.ptr<i8>
-// CHECK-NEXT: }
+// CHECK-LABEL:   func.func @memref2ptr(
+// CHECK-SAME:                          %[[VAL_0:.*]]: memref<10xi32>) -> !llvm.ptr<i8> {
+// CHECK-NEXT:      %[[VAL_1:.*]] = "polygeist.memref2pointer"(%[[VAL_0]]) : (memref<10xi32>) -> !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_1]][2] : (!llvm.ptr<i32>) -> !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.bitcast %[[VAL_2]] : !llvm.ptr<i32> to !llvm.ptr<i8>
+// CHECK-NEXT:      return %[[VAL_3]] : !llvm.ptr<i8>
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -420,12 +420,12 @@ ValueCategory MLIRScanner::callHelper(
   }
 
   if (Op->getNumResults()) {
-    if (RetReference) {
+    if (RetReference)
       ElementType = Glob.getTypes().getMLIRType(RetType);
-    } else if (const auto *PtTy = dyn_cast<clang::PointerType>(
-                   RetType->getUnqualifiedDesugaredType())) {
+    else if (const auto *PtTy = dyn_cast<clang::PointerType>(
+                 RetType->getUnqualifiedDesugaredType()))
       ElementType = Glob.getTypes().getMLIRType(PtTy->getPointeeType());
-    }
+
     return ValueCategory(Op->getResult(0),
                          /*isReference*/ RetReference, ElementType);
   }
@@ -1094,13 +1094,13 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
 
         bool IsReference = Expr->isLValue() || Expr->isXValue();
         std::optional<mlir::Type> ElementType = std::nullopt;
-        if (IsReference) {
+        if (IsReference)
           ElementType = Glob.getTypes().getMLIRType(
               cast<clang::ReferenceType>(Expr->getType())->getPointeeType());
-        } else if (const auto *PtTy =
-                       dyn_cast<clang::PointerType>(Expr->getType())) {
+        else if (const auto *PtTy =
+                     dyn_cast<clang::PointerType>(Expr->getType()))
           ElementType = Glob.getTypes().getMLIRType(PtTy->getPointeeType());
-        }
+
         return ValueCategory(Called, IsReference, ElementType);
       }
     }
@@ -1610,11 +1610,10 @@ MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
   } break;
   }
 
-  if (V.has_value()) {
+  if (V.has_value())
     return std::make_pair(ValueCategory(V.value(),
                                         /*isReference*/ false, ElemTy),
                           true);
-  }
 
   return std::make_pair(ValueCategory(), false);
 }

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -342,8 +342,7 @@ ValueCategory MLIRScanner::callHelper(
                 Builder.create<LLVM::GEPOp>(
                     Loc,
                     Glob.getTypes().getPointerType(ET, PT.getAddressSpace()),
-                    L0.getElemTy(),
-                    Val,
+                    L0.getElemTy(), Val,
                     ValueRange(
                         {Builder.create<arith::ConstantIntOp>(Loc, 0, 32),
                          Builder.create<arith::ConstantIntOp>(Loc, I, 32)}))));
@@ -372,8 +371,7 @@ ValueCategory MLIRScanner::callHelper(
                 Builder.create<LLVM::GEPOp>(
                     Loc,
                     Glob.getTypes().getPointerType(ET, PT.getAddressSpace()),
-                    T0.getElemTy(),
-                    Val,
+                    T0.getElemTy(), Val,
                     ValueRange(
                         {Builder.create<arith::ConstantIntOp>(Loc, 0, 32),
                          Builder.create<arith::ConstantIntOp>(Loc, I, 32)}))));
@@ -618,6 +616,11 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
       auto Nt = cast<LLVM::LLVMPointerType>(
           TypeTranslator.translateType(mlirclang::anonymize(
               mlirclang::getLLVMType(E->getType(), Glob.getCGM()))));
+      if (UseOpaquePointers) {
+        // Temporary workaround, until the move to opaque pointers is completed
+        // and we can put the LLVMContext into opaque pointer mode.
+        Nt = LLVM::LLVMPointerType::get(Nt.getContext(), Nt.getAddressSpace());
+      }
       assert(Nt.getAddressSpace() == MT.getMemorySpaceAsInt() &&
              "val does not have the same memory space as nt");
       Val = Builder.create<polygeist::Memref2PointerOp>(Loc, Nt, Val);

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -415,7 +415,7 @@ ValueCategory MLIRScanner::callHelper(
     if (RetReference)
       Expr->dump();
     assert(!RetReference);
-    assert(ElementType);
+    assert(ElementType && "Expecting element type");
     return ValueCategory(Alloc, /*isReference*/ true, ElementType);
   }
 

--- a/polygeist/tools/cgeist/Lib/CGDecl.cc
+++ b/polygeist/tools/cgeist/Lib/CGDecl.cc
@@ -29,11 +29,11 @@ ValueCategory MLIRScanner::VisitVarDecl(clang::VarDecl *Decl) {
   mlir::Type SubType = Glob.getTypes().getMLIRTypeForMem(Decl->getType());
   std::optional<mlir::Type> ElementTy = std::nullopt;
   if (const auto *CArrTy = dyn_cast<clang::ArrayType>(
-          Decl->getType()->getUnqualifiedDesugaredType())) {
+          Decl->getType()->getUnqualifiedDesugaredType()))
     ElementTy = Glob.getTypes().getMLIRTypeForMem(CArrTy->getElementType());
-  } else {
+  else
     ElementTy = SubType;
-  }
+
   const unsigned MemType = Decl->hasAttr<clang::CUDASharedAttr>() ? 5 : 0;
   bool LLVMABI = false, IsArray = false;
 
@@ -165,9 +165,8 @@ ValueCategory MLIRScanner::VisitVarDecl(clang::VarDecl *Decl) {
           VarLoc, Builder.create<arith::ConstantIntOp>(VarLoc, false, 1), V,
           std::vector<Value>({getConstantIndex(0)}));
     }
-  } else {
+  } else
     Op = createAllocOp(SubType, Decl, MemType, IsArray, LLVMABI);
-  }
 
   if (InitExpr.val)
     ValueCategory(Op, /*isReference*/ true, ElementTy)

--- a/polygeist/tools/cgeist/Lib/CGDecl.cc
+++ b/polygeist/tools/cgeist/Lib/CGDecl.cc
@@ -118,11 +118,14 @@ ValueCategory MLIRScanner::VisitVarDecl(clang::VarDecl *Decl) {
     Location VarLoc = getMLIRLocation(Decl->getBeginLoc());
 
     if (isa<LLVM::LLVMPointerType>(Glob.getTypes().getMLIRType(
-            Glob.getCGM().getContext().getPointerType(Decl->getType()))))
+            Glob.getCGM().getContext().getPointerType(Decl->getType())))) {
+      auto GSF = Glob.getOrCreateLLVMGlobal(
+          Decl, (Function.getName() + "@static@").str());
       Op = ABuilder.create<LLVM::AddressOfOp>(
-          VarLoc, Glob.getOrCreateLLVMGlobal(
-                      Decl, (Function.getName() + "@static@").str()));
-    else {
+          VarLoc,
+          Glob.getTypes().getPointerType(GSF.getType(), GSF.getAddrSpace()),
+          GSF.getSymName());
+    } else {
       auto GV =
           Glob.getOrCreateGlobal(*Decl, (Function.getName() + "@static@").str(),
                                  FunctionContext::Host);

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -273,7 +273,6 @@ mlir::Attribute MLIRScanner::InitializeValueByInitListExpr(mlir::Value ToInit,
                                        MemRefLayoutAttrInterface(),
                                        MT.getMemorySpace());
           } else if (sycl::isSYCLType(ElemTy)) {
-
             std::pair<mlir::MemRefType, mlir::Type> Types =
                 TypeSwitch<mlir::Type, std::pair<mlir::MemRefType, mlir::Type>>(
                     MRET)
@@ -1890,12 +1889,11 @@ ValueCategory MLIRScanner::VisitCastExpr(CastExpr *E) {
     auto ElemTy = Prev.ElementType;
     if (ElemTy && isa<LLVM::LLVMPointerType, MemRefType>(*ElemTy)) {
       if (const auto *PtrTy = dyn_cast<clang::PointerType>(
-              E->getType()->getUnqualifiedDesugaredType())) {
+              E->getType()->getUnqualifiedDesugaredType()))
         ElemTy = Glob.getTypes().getMLIRType(PtrTy->getPointeeType());
-      } else if (isa<clang::BuiltinType>(
-                     E->getType()->getUnqualifiedDesugaredType())) {
+      else if (isa<clang::BuiltinType>(
+                   E->getType()->getUnqualifiedDesugaredType()))
         ElemTy = Glob.getTypes().getMLIRType(E->getType());
-      }
     }
     return ValueCategory(Lres, /*isReference*/ false, ElemTy);
   }
@@ -2543,9 +2541,9 @@ std::pair<ValueCategory, ValueCategory> MLIRScanner::EmitCompoundAssignLValue(
   });
 
   auto ET = LHSLV.ElementType;
-  if (ET && isa<MemRefType>(*ET)) {
+  if (ET && isa<MemRefType>(*ET))
     ET = cast<MemRefType>(*ET).getElementType();
-  }
+
   ValueCategory LHS{LHSLV.getValue(Builder), false, ET};
   if (!PromotionTypeLHS.isNull())
     LHS = EmitScalarConversion(LHS, LHSTy, PromotionTypeLHS, E->getExprLoc());

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1385,8 +1385,11 @@ ValueCategory MLIRScanner::VisitDeclRefExpr(DeclRefExpr *E) {
   FunctionContext FuncContext = mlirclang::getFuncContext(Function);
   if (auto *Tocall = dyn_cast<FunctionDecl>(E->getDecl())) {
     auto Func = Glob.getOrCreateLLVMFunction(Tocall, FuncContext);
-    return ValueCategory(Builder.create<LLVM::AddressOfOp>(Loc, Func),
-                         /*isReference*/ true, Func.getFunctionType());
+    return ValueCategory(
+        Builder.create<LLVM::AddressOfOp>(
+            Loc, Glob.getTypes().getPointerType(Func.getFunctionType()),
+            Func.getName()),
+        /*isReference*/ true, Func.getFunctionType());
   }
 
   if (auto *VD = dyn_cast<VarDecl>(E->getDecl())) {
@@ -1426,7 +1429,11 @@ ValueCategory MLIRScanner::VisitDeclRefExpr(DeclRefExpr *E) {
         (E->hasQualifier())) {
       auto LLVMGlobal = Glob.getOrCreateLLVMGlobal(VD);
       return ValueCategory(
-          Builder.create<mlir::LLVM::AddressOfOp>(Loc, LLVMGlobal),
+          Builder.create<mlir::LLVM::AddressOfOp>(
+              Loc,
+              Glob.getTypes().getPointerType(LLVMGlobal.getType(),
+                                             LLVMGlobal.getAddrSpace()),
+              LLVMGlobal.getSymName()),
           /*isReference*/ true, LLVMGlobal.getType());
     }
 

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -140,7 +140,7 @@ ValueCategory MLIRScanner::VisitStringLiteral(clang::StringLiteral *Expr) {
       Glob.getOrCreateGlobalLLVMString(Loc, Builder, Expr->getString(),
                                        mlirclang::getFuncContext(Function)),
       /*isReference*/ true,
-      LLVM::LLVMArrayType::get(IntegerType::get(Builder.getContext(), 8),
+      LLVM::LLVMArrayType::get(Builder.getI8Type(),
                                Expr->getString().size() + 1));
 }
 

--- a/polygeist/tools/cgeist/Lib/CGStmt.cc
+++ b/polygeist/tools/cgeist/Lib/CGStmt.cc
@@ -499,7 +499,7 @@ ValueCategory MLIRScanner::VisitOMPForDirective(clang::OMPForDirective *Fors) {
 
     auto AllocOp = createAllocOp(Idx.getType(), Name, /*memtype*/ 0,
                                  /*isArray*/ IsArray, /*LLVMABI*/ LLVMABI);
-    Params[Name] = ValueCategory(AllocOp, true);
+    Params[Name] = ValueCategory(AllocOp, true, Idx.getType());
     Params[Name].store(Builder, Idx);
   }
 
@@ -566,7 +566,7 @@ MLIRScanner::VisitOMPParallelDirective(clang::OMPParallelDirective *Par) {
 
         auto AllocOp = createAllocOp(Ty, Name, /*memtype*/ 0,
                                      /*isArray*/ IsArray, /*LLVMABI*/ LLVMABI);
-        Params[Name] = ValueCategory(AllocOp, true);
+        Params[Name] = ValueCategory(AllocOp, true, Ty);
         Params[Name].store(Builder, PrevInduction[Name], IsArray);
       }
       break;
@@ -672,7 +672,7 @@ ValueCategory MLIRScanner::VisitOMPParallelForDirective(
 
     auto AllocOp = createAllocOp(Idx.getType(), Name, /*memtype*/ 0,
                                  /*isArray*/ IsArray, /*LLVMABI*/ LLVMABI);
-    Params[Name] = ValueCategory(AllocOp, true);
+    Params[Name] = ValueCategory(AllocOp, true, Idx.getType());
     Params[Name].store(Builder, Idx);
   }
 

--- a/polygeist/tools/cgeist/Lib/CGStmt.cc
+++ b/polygeist/tools/cgeist/Lib/CGStmt.cc
@@ -825,7 +825,7 @@ ValueCategory MLIRScanner::VisitIfStmt(clang::IfStmt *Stmt) {
   auto *OldBlock = Builder.getInsertionBlock();
   if (auto LT = dyn_cast<MemRefType>(Cond.getType())) {
     Cond = Builder.create<polygeist::Memref2PointerOp>(
-        Loc, LLVM::LLVMPointerType::get(Builder.getI8Type()), Cond);
+        Loc, Glob.getTypes().getPointerType(Builder.getI8Type()), Cond);
   }
   if (auto LT = dyn_cast<LLVM::LLVMPointerType>(Cond.getType())) {
     auto NullptrLlvm = Builder.create<LLVM::NullOp>(Loc, LT);

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1521,6 +1521,13 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
     const clang::Type *PTT = PointeeType->getUnqualifiedDesugaredType();
 
     if (PTT->isVoidType()) {
+      if (UseOpaquePointers) {
+        // No need to determine the correct element type for void* in an opaque
+        // pointer world.
+        return LLVM::LLVMPointerType::get(
+            TheModule->getContext(), CGM.getContext().getTargetAddressSpace(
+                                         PointeeType.getAddressSpace()));
+      }
       llvm::Type *Ty = CGM.getTypes().ConvertType(QualType(T, 0));
       return TypeTranslator.translateType(Ty);
     }

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -55,6 +55,8 @@ static cl::opt<bool>
                             cl::desc("Whether to allow types in the sycl "
                                      "namespace and not in the SYCL dialect"));
 
+extern llvm::cl::opt<bool> UseOpaquePointers;
+
 /******************************************************************************/
 /*            Flags affecting code generation of function types.              */
 /******************************************************************************/
@@ -1791,8 +1793,9 @@ mlir::Type CodeGenTypes::getPointerOrMemRefType(mlir::Type Ty,
   if (!ST || IsSYCLType)
     return mlir::MemRefType::get(IsAlloc ? 1 : ShapedType::kDynamic, Ty, {},
                                  AddressSpace);
-  // TODO(Lukas)
-  return LLVM::LLVMPointerType::get(Ty, AddressSpace);
+  return (UseOpaquePointers)
+             ? LLVM::LLVMPointerType::get(Ty.getContext(), AddressSpace)
+             : LLVM::LLVMPointerType::get(Ty, AddressSpace);
 }
 
 const clang::CodeGen::CGFunctionInfo &

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1791,7 +1791,7 @@ mlir::Type CodeGenTypes::getPointerOrMemRefType(mlir::Type Ty,
   if (!ST || IsSYCLType)
     return mlir::MemRefType::get(IsAlloc ? 1 : ShapedType::kDynamic, Ty, {},
                                  AddressSpace);
-
+  // TODO(Lukas)
   return LLVM::LLVMPointerType::get(Ty, AddressSpace);
 }
 

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1714,11 +1714,11 @@ mlir::Type CodeGenTypes::getMLIRType(const clang::BuiltinType *BT) const {
   case BuiltinType::OCLQueue:
   case BuiltinType::OCLReserveID: {
     auto *OCLTy = CGM.getOpenCLRuntime().convertOpenCLSpecificType(BT);
-    if (UseOpaquePointers && isa<llvm::PointerType>(OCLTy)) {
+    if (UseOpaquePointers && isa<llvm::PointerType>(OCLTy))
       return LLVM::LLVMPointerType::get(
           TheModule->getContext(),
           cast<llvm::PointerType>(OCLTy)->getAddressSpace());
-    }
+
     return TypeTranslator.translateType(OCLTy);
   }
 

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1488,10 +1488,10 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
                                      AT->getElementType().getAddressSpace()));
   }
 
-  if (const auto *AT = dyn_cast<clang::VectorType>(T)) {
+  if (const auto *VT = dyn_cast<clang::VectorType>(T)) {
     bool SubRef = false;
-    auto ET = getMLIRType(AT->getElementType(), &SubRef, AllowMerge);
-    int64_t Size = AT->getNumElements();
+    auto ET = getMLIRType(VT->getElementType(), &SubRef, AllowMerge);
+    int64_t Size = VT->getNumElements();
     return mlir::VectorType::get(Size, ET);
   }
 

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.h
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.h
@@ -45,7 +45,8 @@ class Type;
 
 namespace LLVM {
 class LLVMStructType;
-}
+class LLVMPointerType;
+} // namespace LLVM
 } // namespace mlir
 
 namespace mlirclang {
@@ -98,6 +99,9 @@ public:
 
   mlir::Type getPointerOrMemRefType(mlir::Type Ty, unsigned AddressSpace,
                                     bool IsAlloca = false) const;
+
+  mlir::LLVM::LLVMPointerType getPointerType(mlir::Type ElementType,
+                                             unsigned AddressSpace = 0) const;
 
   const clang::CodeGen::CGFunctionInfo &
   arrangeGlobalDeclaration(clang::GlobalDecl GD);

--- a/polygeist/tools/cgeist/Lib/TypeUtils.cc
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.cc
@@ -21,7 +21,9 @@
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/CommandLine.h"
 
+extern llvm::cl::opt<bool> UseOpaquePointers;
 namespace mlirclang {
 
 using namespace llvm;
@@ -93,8 +95,11 @@ mlir::Type getPtrTyWithNewType(mlir::Type Orig, mlir::Type NewElementType) {
                                      Ty.getLayout(), Ty.getMemorySpace());
       })
       .Case<mlir::LLVM::LLVMPointerType>([NewElementType](auto Ty) {
-        return mlir::LLVM::LLVMPointerType::get(NewElementType,
-                                                Ty.getAddressSpace());
+        return (UseOpaquePointers)
+                   ? mlir::LLVM::LLVMPointerType::get(
+                         NewElementType.getContext(), Ty.getAddressSpace())
+                   : mlir::LLVM::LLVMPointerType::get(NewElementType,
+                                                      Ty.getAddressSpace());
       });
 }
 

--- a/polygeist/tools/cgeist/Lib/TypeUtils.cc
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.cc
@@ -45,6 +45,7 @@ bool isRecursiveStruct(Type *T, Type *Meta, SmallPtrSetImpl<Type *> &Seen) {
 
 Type *anonymize(Type *T) {
   if (auto *PT = dyn_cast<PointerType>(T))
+    // TODO: Change this to complete move to opaque pointers.
     return PointerType::get(anonymize(PT->getPointerElementType()),
                             PT->getAddressSpace());
   if (auto *AT = dyn_cast<ArrayType>(T))

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -41,8 +41,7 @@ ValueCategory::ValueCategory(mlir::Value val, bool isReference,
       isa<LLVM::LLVMPointerType>(val.getType())) {
     assert(ElementType && "Must provide an element type for LLVM pointers");
   }
-  if (!ElementType && val.getDefiningOp() &&
-      val.getDefiningOp()->getNumResults() && isa<MemRefType>(val.getType())) {
+  if (!ElementType && val.getDefiningOp() && isa<MemRefType>(val.getType())) {
     ElementType = cast<MemRefType>(val.getType()).getElementType();
   }
 }

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -64,7 +64,7 @@ mlir::Value ValueCategory::getValue(mlir::OpBuilder &builder) const {
     return val;
   auto loc = builder.getUnknownLoc();
   if (isa<mlir::LLVM::LLVMPointerType>(val.getType())) {
-    return builder.create<mlir::LLVM::LoadOp>(loc, val);
+    return builder.create<mlir::LLVM::LoadOp>(loc, getElemTy(), val);
   }
   if (auto mt = dyn_cast<mlir::MemRefType>(val.getType())) {
     assert(mt.getShape().size() == 1 && "must have shape 1");

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -20,7 +20,8 @@ class ValueCategory {
 private:
   template <typename OpTy>
   ValueCategory Cast(mlir::OpBuilder &Builder, mlir::Location Loc,
-                     mlir::Type PromotionType) const {
+                     mlir::Type PromotionType,
+                     std::optional<mlir::Type> ElemTy = std::nullopt) const {
     if (val.getType() == PromotionType)
       return *this;
     if (const auto C = val.getDefiningOp<mlir::arith::ConstantOp>()) {
@@ -29,7 +30,7 @@ private:
               Folder.fold<OpTy>(Loc, PromotionType, C))
         return {FoldedRes, false};
     }
-    return {Builder.createOrFold<OpTy>(Loc, PromotionType, val), false};
+    return {Builder.createOrFold<OpTy>(Loc, PromotionType, val), false, ElemTy};
   }
 
   ValueCategory ICmp(mlir::OpBuilder &builder, mlir::Location Loc,
@@ -106,9 +107,9 @@ public:
   ValueCategory PtrToInt(mlir::OpBuilder &Builder, mlir::Location Loc,
                          mlir::Type DestTy) const;
   ValueCategory IntToPtr(mlir::OpBuilder &Builder, mlir::Location Loc,
-                         mlir::Type DestTy) const;
+                         mlir::Type DestTy, mlir::Type ElemType) const;
   ValueCategory BitCast(mlir::OpBuilder &Builder, mlir::Location Loc,
-                        mlir::Type DestTy) const;
+                        mlir::Type DestTy, mlir::Type ElemTy) const;
   ValueCategory MemRef2Ptr(mlir::OpBuilder &Builder, mlir::Location Loc) const;
   ValueCategory
   Ptr2MemRef(mlir::OpBuilder &Builder, mlir::Location Loc,

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -40,6 +40,11 @@ private:
                      mlir::arith::CmpFPredicate predicate,
                      mlir::Value RHS) const;
 
+  mlir::Type getElemTy() const {
+    assert(ElementType && "No element type defined");
+    return ElementType.value();
+  }
+
 public:
   mlir::Value val;
   bool isReference;

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -44,12 +44,17 @@ public:
   bool isReference;
   /// Holds the index the lvalue to a vector element refers to.
   llvm::Optional<mlir::Value> Index{std::nullopt};
+  /// Holds the element type of memrefs or pointers. This is particularly
+  /// important with opaque pointers.
+  std::optional<mlir::Type> ElementType{std::nullopt};
 
 public:
   ValueCategory() : val(nullptr), isReference(false) {}
   ValueCategory(std::nullptr_t) : val(nullptr), isReference(false) {}
-  ValueCategory(mlir::Value val, bool isReference);
-  ValueCategory(mlir::Value Val, mlir::Value Index);
+  ValueCategory(mlir::Value val, bool isReference,
+                std::optional<mlir::Type> elementType = std::nullopt);
+  ValueCategory(mlir::Value Val, mlir::Value Index,
+                std::optional<mlir::Type> elementType = std::nullopt);
 
   static ValueCategory getNullValue(mlir::OpBuilder &Builder,
                                     mlir::Location Loc, mlir::Type Type);

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -40,10 +40,8 @@ private:
                      mlir::arith::CmpFPredicate predicate,
                      mlir::Value RHS) const;
 
-  mlir::Type getElemTy() const {
-    assert(ElementType && "No element type defined");
-    return ElementType.value();
-  }
+  mlir::Type getPointerType(mlir::Type ElementType,
+                            unsigned AddressSpace) const;
 
 public:
   mlir::Value val;
@@ -53,6 +51,11 @@ public:
   /// Holds the element type of memrefs or pointers. This is particularly
   /// important with opaque pointers.
   std::optional<mlir::Type> ElementType{std::nullopt};
+
+  mlir::Type getElemTy() const {
+    assert(ElementType && "No element type defined");
+    return ElementType.value();
+  }
 
 public:
   ValueCategory() : val(nullptr), isReference(false) {}

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1253,8 +1253,8 @@ ValueCategory MLIRScanner::CommonFieldLookup(clang::QualType CT,
                       .getValue(Builder);
       if (auto MT = dyn_cast<MemRefType>(*ElemTy)) {
         ElemTy = MT.getElementType();
-      } else if(auto PT = dyn_cast<LLVM::LLVMPointerType>(*ElemTy)){
-        if(!PT.isOpaque()){
+      } else if (auto PT = dyn_cast<LLVM::LLVMPointerType>(*ElemTy)) {
+        if (!PT.isOpaque()) {
           ElemTy = PT.getElementType();
         }
       }

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1649,6 +1649,12 @@ MLIRASTConsumer::getOrCreateLLVMFunction(const clang::FunctionDecl *FD,
 
   auto RT = TypeTranslator.translateType(
       mlirclang::anonymize(mlirclang::getLLVMType(FD->getReturnType(), CGM)));
+  if (auto RTPtrTy = dyn_cast<LLVM::LLVMPointerType>(RT)) {
+    // Temporary workaround until the translation to LLVM/MLIR types from Clang
+    // types completes migration to opaque pointers.
+    RT = getTypes().getPointerType(RTPtrTy.getElementType(),
+                                   RTPtrTy.getAddressSpace());
+  }
   auto LLVMFnType = LLVM::LLVMFunctionType::get(RT, Types,
                                                 /*isVarArg=*/FD->isVariadic());
   // Insert the function into the body of the parent module.

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1824,7 +1824,7 @@ MLIRASTConsumer::getOrCreateGlobal(const clang::ValueDecl &VD,
 
     if (isa<clang::InitListExpr>(InitExpr)) {
       Attribute InitValAttr = MS.InitializeValueByInitListExpr(
-          Op, const_cast<clang::Expr *>(InitExpr));
+          Op, VarTy.getElementType(), const_cast<clang::Expr *>(InitExpr));
       GlobalOp.setInitialValueAttr(InitValAttr);
     } else {
       ValueCategory VC = MS.Visit(const_cast<clang::Expr *>(InitExpr));

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1192,7 +1192,7 @@ Value MLIRScanner::SYCLCommonFieldLookup(Value V, size_t FNum,
 ValueCategory MLIRScanner::CommonFieldLookup(clang::QualType CT,
                                              const clang::FieldDecl *FD,
                                              Value Val, Type ElementType,
-                                             bool IsLValue) {
+                                             bool IsLValue, Type BaseType) {
   assert(FD && "Attempting to lookup field of nullptr");
 
   const clang::RecordDecl *RD = FD->getParent();
@@ -1249,15 +1249,10 @@ ValueCategory MLIRScanner::CommonFieldLookup(clang::QualType CT,
     }
 
     if (IsLValue) {
+      assert(BaseType && "Expecting base type to be specified");
       CommonGep = ValueCategory(CommonGep, /*isReference*/ true, ElemTy)
                       .getValue(Builder);
-      if (auto MT = dyn_cast<MemRefType>(*ElemTy)) {
-        ElemTy = MT.getElementType();
-      } else if (auto PT = dyn_cast<LLVM::LLVMPointerType>(*ElemTy)) {
-        if (!PT.isOpaque()) {
-          ElemTy = PT.getElementType();
-        }
-      }
+      ElemTy = BaseType;
     }
 
     return ValueCategory(CommonGep, /*isReference*/ true, ElemTy);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1253,6 +1253,10 @@ ValueCategory MLIRScanner::CommonFieldLookup(clang::QualType CT,
                       .getValue(Builder);
       if (auto MT = dyn_cast<MemRefType>(*ElemTy)) {
         ElemTy = MT.getElementType();
+      } else if(auto PT = dyn_cast<LLVM::LLVMPointerType>(*ElemTy)){
+        if(!PT.isOpaque()){
+          ElemTy = PT.getElementType();
+        }
       }
     }
 

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1755,7 +1755,10 @@ MLIRASTConsumer::getOrCreateLLVMGlobal(const clang::ValueDecl *FD,
       Builder.setInsertionPointToEnd(Blk);
       Builder.create<LLVM::StoreOp>(
           Module->getLoc(), Res,
-          Builder.create<LLVM::AddressOfOp>(Module->getLoc(), Glob));
+          Builder.create<LLVM::AddressOfOp>(
+              Module->getLoc(),
+              CGTypes.getPointerType(Glob.getType(), Glob.getAddrSpace()),
+              Glob.getSymName()));
       Builder.create<LLVM::ReturnOp>(Module->getLoc(), ValueRange());
     }
   }
@@ -1908,8 +1911,10 @@ Value MLIRASTConsumer::getOrCreateGlobalLLVMString(
   }
 
   LLVM::GlobalOp Global = LLVMStringGlobals[Value.str()];
-  // Get the pointer to the first character in the global string.
-  return Builder.create<LLVM::AddressOfOp>(Loc, Global);
+  // Get the pointer to the first character in the global string
+  return Builder.create<LLVM::AddressOfOp>(
+      Loc, CGTypes.getPointerType(Global.getType(), Global.getAddrSpace()),
+      Global.getSymName());
 }
 
 FunctionOpInterface

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -633,7 +633,8 @@ public:
 
   ValueCategory CommonFieldLookup(clang::QualType OT,
                                   const clang::FieldDecl *FD, mlir::Value Val,
-                                  mlir::Type ElementType, bool IsLValue);
+                                  mlir::Type ElementType, bool IsLValue,
+                                  mlir::Type BaseType = nullptr);
 
   ValueCategory CommonArrayLookup(ValueCategory Val, mlir::Value Idx,
                                   bool IsImplicitRefResult,

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -632,7 +632,7 @@ public:
 
   ValueCategory CommonFieldLookup(clang::QualType OT,
                                   const clang::FieldDecl *FD, mlir::Value Val,
-                                  bool IsLValue);
+                                  mlir::Type ElementType, bool IsLValue);
 
   ValueCategory CommonArrayLookup(ValueCategory Val, mlir::Value Idx,
                                   bool IsImplicitRefResult,

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -615,6 +615,7 @@ public:
   ValueCategory VisitCXXFunctionalCastExpr(clang::CXXFunctionalCastExpr *Expr);
 
   mlir::Attribute InitializeValueByInitListExpr(mlir::Value ToInit,
+                                                mlir::Type ElemTy,
                                                 clang::Expr *Expr);
 
   ValueCategory VisitInitListExpr(clang::InitListExpr *Expr);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -379,6 +379,7 @@ private:
                                                 ValueCategory Src);
   ValueCategory EmitIntegralToPointerConversion(mlir::Location Loc,
                                                 mlir::Type DestTy,
+                                                mlir::Type ElemTy,
                                                 ValueCategory Src);
   ValueCategory EmitVectorInitList(clang::InitListExpr *Expr,
                                    mlir::VectorType VType);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -279,7 +279,8 @@ private:
   mlir::Value SYCLCommonFieldLookup(mlir::Value V, size_t FNum,
                                     llvm::ArrayRef<int64_t> Shape);
 
-  mlir::LLVM::AllocaOp allocateBuffer(size_t I, mlir::LLVM::LLVMPointerType T) {
+  mlir::LLVM::AllocaOp allocateBuffer(size_t I, mlir::LLVM::LLVMPointerType T,
+                                      mlir::Type ElemTy) {
     auto &Vec = Bufs[T.getAsOpaquePointer()];
     if (I < Vec.size())
       return Vec[I];
@@ -288,7 +289,7 @@ private:
     Subbuilder.setInsertionPointToStart(AllocationScope);
 
     auto One = Subbuilder.create<mlir::arith::ConstantIntOp>(Loc, 1, 64);
-    auto Rs = Subbuilder.create<mlir::LLVM::AllocaOp>(Loc, T, One, 0);
+    auto Rs = Subbuilder.create<mlir::LLVM::AllocaOp>(Loc, T, ElemTy, One, 0);
     Vec.push_back(Rs);
     return Rs;
   }

--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -222,4 +222,8 @@ static llvm::cl::opt<std::string> McpuOpt("mcpu", llvm::cl::init(""),
                                           llvm::cl::desc("Target CPU"),
                                           llvm::cl::cat(ToolOptions));
 
+llvm::cl::opt<bool>
+    UseOpaquePointers("use-opaque-pointers", llvm::cl::init(false),
+                      llvm::cl::desc("Whether to use opaque pointers in MLIR"));
+
 #endif /* CGEIST_OPTIONS_H_ */

--- a/polygeist/tools/cgeist/Test/Verification/add.c
+++ b/polygeist/tools/cgeist/Test/Verification/add.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+// RUN: cgeist -O0 -use-opaque-pointers %s --function=* -S | FileCheck %s
 
 typedef char char_vec __attribute__((ext_vector_type(3)));
 typedef short short_vec __attribute__((ext_vector_type(3)));

--- a/polygeist/tools/cgeist/Test/Verification/addressspace.c
+++ b/polygeist/tools/cgeist/Test/Verification/addressspace.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist -use-opaque-pointers %s --function=* -S | FileCheck %s
 
 // CHECK:  func.func @test() -> memref<?xi32, 4> attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK:    [[CALL:%.*]] = call @foo() : () -> memref<?xi32, 1>

--- a/polygeist/tools/cgeist/Test/Verification/affine_loop.c
+++ b/polygeist/tools/cgeist/Test/Verification/affine_loop.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O2 --function=kernel_deriche -S | FileCheck %s
+// RUN: cgeist -use-opaque-pointers %s -O2 --function=kernel_deriche -S | FileCheck %s
 
 void kernel_deriche(int w, int h, double alpha, double** y2) {
     int i,j;

--- a/polygeist/tools/cgeist/Test/Verification/affun.c
+++ b/polygeist/tools/cgeist/Test/Verification/affun.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=okernel_2mm -S | FileCheck %s
+// RUN: cgeist -use-opaque-pointers %s --function=okernel_2mm -S | FileCheck %s
 
 void okernel_2mm(unsigned int ni,
                  double *tmp) {

--- a/polygeist/tools/cgeist/Test/Verification/alignof.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/alignof.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist -std=c++11 %s --function=* -S | FileCheck %s
+// RUN: cgeist -use-opaque-pointers -std=c++11 %s --function=* -S | FileCheck %s
 
 struct Meta {
     float* f;

--- a/polygeist/tools/cgeist/Test/Verification/and.c
+++ b/polygeist/tools/cgeist/Test/Verification/and.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+// RUN: cgeist -O0 -use-opaque-pointers %s --function=* -S | FileCheck %s
 
 typedef char char_vec __attribute__((ext_vector_type(3)));
 typedef short short_vec __attribute__((ext_vector_type(3)));

--- a/polygeist/tools/cgeist/Test/Verification/arrayconsllvm.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/arrayconsllvm.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
+// RUN: cgeist -use-opaque-pointers %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
 
 struct AIntDivider {
     AIntDivider() : divisor(3) {}
@@ -10,23 +10,25 @@ void kern() {
     AIntDivider sizes_[25];
 }
 
-// CHECK:   func @_Z4kernv() attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-DAG:     %c1_i64 = arith.constant 1 : i64
-// CHECK-DAG:     %c25 = arith.constant 25 : index
-// CHECK-DAG:     %c1 = arith.constant 1 : index
-// CHECK-DAG:     %c0 = arith.constant 0 : index
-// CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.array<25 x struct<(i32, f64)>> : (i64) -> !llvm.ptr<array<25 x struct<(i32, f64)>>>
-// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<array<25 x struct<(i32, f64)>>>) -> !llvm.ptr<struct<(i32, f64)>>
-// CHECK-NEXT:     scf.for %arg0 = %c0 to %c25 step %c1 {
-// CHECK-NEXT:       %2 = arith.index_cast %arg0 : index to i64
-// CHECK-NEXT:       %3 = llvm.getelementptr %1[%2] : (!llvm.ptr<struct<(i32, f64)>>, i64) -> !llvm.ptr<struct<(i32, f64)>>
-// CHECK-NEXT:       call @_ZN11AIntDividerC1Ev(%3) : (!llvm.ptr<struct<(i32, f64)>>) -> ()
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN11AIntDividerC1Ev(%arg0: !llvm.ptr<struct<(i32, f64)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-DAG:     %c3_i32 = arith.constant 3 : i32
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     llvm.store %c3_i32, %0 : !llvm.ptr<i32>
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @_Z4kernv() attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 25 : index
+// CHECK-DAG:      %[[VAL_3:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.array<25 x struct<(i32, f64)>> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<25 x struct<(i32, f64)>>
+// CHECK-NEXT:      scf.for %[[VAL_6:.*]] = %[[VAL_1]] to %[[VAL_2]] step %[[VAL_0]] {
+// CHECK-NEXT:        %[[VAL_7:.*]] = arith.index_cast %[[VAL_6]] : index to i64
+// CHECK-NEXT:        %[[VAL_8:.*]] = llvm.getelementptr %[[VAL_5]]{{\[}}%[[VAL_7]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<(i32, f64)>
+// CHECK-NEXT:        func.call @_ZN11AIntDividerC1Ev(%[[VAL_8]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN11AIntDividerC1Ev(
+// CHECK-SAME:                                    %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 3 : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, f64)>
+// CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_2]] : i32, !llvm.ptr
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/arrayconsmemref.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/arrayconsmemref.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 -w %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
+// RUN: cgeist -O0 -w --use-opaque-pointers %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
 
 struct AIntDivider {
     AIntDivider() : divisor(3) {}
@@ -9,23 +9,25 @@ void kern() {
     AIntDivider sizes_[25];
 }
 
-// CHECK:   func @_Z4kernv() attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-DAG:     %c25 = arith.constant 25 : index
-// CHECK-DAG:     %c1 = arith.constant 1 : index
-// CHECK-DAG:     %c0 = arith.constant 0 : index
-// CHECK-DAG:      %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:     llvm.alloca %c1_i64 x !llvm.array<25 x struct<(i32)>> : (i64) -> !llvm.ptr<array<25 x struct<(i32)>>>
-// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<array<25 x struct<(i32)>>>) -> !llvm.ptr<struct<(i32)>>
-// CHECK-NEXT:     scf.for %arg0 = %c0 to %c25 s
-// CHECK-NEXT:      %2 = arith.index_cast %arg0 : index to i64
-// CHECK-NEXT:      %3 = llvm.getelementptr %1[%2] : (!llvm.ptr<struct<(i32)>>, i64) -> !llvm.ptr<struct<(i32)>>
-// CHECK-NEXT:      call @_ZN11AIntDividerC1Ev(%3) : (!llvm.ptr<struct<(i32)>>) -> ()
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN11AIntDividerC1Ev(%arg0: !llvm.ptr<struct<(i32)>>)
-// CHECK-NEXT:     %c3_i32 = arith.constant 3 : i32
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     llvm.store %c3_i32, %0 : !llvm.ptr<i32>
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @_Z4kernv() attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 25 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.array<25 x struct<(i32)>> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<25 x struct<(i32)>>
+// CHECK-NEXT:      scf.for %[[VAL_6:.*]] = %[[VAL_1]] to %[[VAL_2]] step %[[VAL_0]] {
+// CHECK-NEXT:        %[[VAL_7:.*]] = arith.index_cast %[[VAL_6]] : index to i64
+// CHECK-NEXT:        %[[VAL_8:.*]] = llvm.getelementptr %[[VAL_5]]{{\[}}%[[VAL_7]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<(i32)>
+// CHECK-NEXT:        func.call @_ZN11AIntDividerC1Ev(%[[VAL_8]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN11AIntDividerC1Ev(
+// CHECK-SAME:                                    %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 3 : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32)>
+// CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_2]] : i32, !llvm.ptr
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/arrayconsmemrefinner.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/arrayconsmemrefinner.cpp
@@ -23,9 +23,9 @@ void kern() {
 
 // CHECK-LABEL:   func.func @_ZN4MetaC1Ev(
 // CHECK-SAME:                            %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : index
-// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 25 : index
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : index
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 25 : index
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(array<25 x struct<(i32)>>, f64)>
 // CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<25 x struct<(i32)>>
 // CHECK-NEXT:      scf.for %[[VAL_6:.*]] = %[[VAL_2]] to %[[VAL_3]] step %[[VAL_1]] {

--- a/polygeist/tools/cgeist/Test/Verification/arrayconsmemrefinner.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/arrayconsmemrefinner.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 -w %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
+// RUN: cgeist -O0 -w --use-opaque-pointers %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
 
 struct AIntDivider {
     AIntDivider() : divisor(3) {}
@@ -14,28 +14,32 @@ void kern() {
     Meta m;
 }
 
-// CHECK:   func @_Z4kernv() attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(array<25 x struct<(i32)>>, f64)> : (i64) -> !llvm.ptr<struct<(array<25 x struct<(i32)>>, f64)>>
-// CHECK-NEXT:     call @_ZN4MetaC1Ev(%0) : (!llvm.ptr<struct<(array<25 x struct<(i32)>>, f64)>>) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN4MetaC1Ev(%arg0: !llvm.ptr<struct<(array<25 x struct<(i32)>>, f64)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-DAG:     %c25 = arith.constant 25 : index
-// CHECK-DAG:     %c1 = arith.constant 1 : index
-// CHECK-DAG:     %c0 = arith.constant 0 : index
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(array<25 x struct<(i32)>>, f64)>>) -> !llvm.ptr<array<25 x struct<(i32)>>>
-// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<array<25 x struct<(i32)>>>) -> !llvm.ptr<struct<(i32)>>
-// CHECK-NEXT:     scf.for %arg1 = %c0 to %c25 step %c1 {
-// CHECK-NEXT:       %2 = arith.index_cast %arg1 : index to i64
-// CHECK-NEXT:       %3 = llvm.getelementptr %1[%2] : (!llvm.ptr<struct<(i32)>>, i64) -> !llvm.ptr<struct<(i32)>>
-// CHECK-NEXT:       call @_ZN11AIntDividerC1Ev(%3) : (!llvm.ptr<struct<(i32)>>) -> ()
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func.func @_ZN11AIntDividerC1Ev(%arg0: !llvm.ptr<struct<(i32)>>)  attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %c3_i32 = arith.constant 3 : i32
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     llvm.store %c3_i32, %0 : !llvm.ptr<i32>
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @_Z4kernv() attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<(array<25 x struct<(i32)>>, f64)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      call @_ZN4MetaC1Ev(%[[VAL_1]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN4MetaC1Ev(
+// CHECK-SAME:                            %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 25 : index
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(array<25 x struct<(i32)>>, f64)>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<25 x struct<(i32)>>
+// CHECK-NEXT:      scf.for %[[VAL_6:.*]] = %[[VAL_2]] to %[[VAL_3]] step %[[VAL_1]] {
+// CHECK-NEXT:        %[[VAL_7:.*]] = arith.index_cast %[[VAL_6]] : index to i64
+// CHECK-NEXT:        %[[VAL_8:.*]] = llvm.getelementptr %[[VAL_5]]{{\[}}%[[VAL_7]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<(i32)>
+// CHECK-NEXT:        func.call @_ZN11AIntDividerC1Ev(%[[VAL_8]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN11AIntDividerC1Ev(
+// CHECK-SAME:                                    %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 3 : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32)>
+// CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_2]] : i32, !llvm.ptr
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/assign.c
+++ b/polygeist/tools/cgeist/Test/Verification/assign.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S -o - | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S -o - | FileCheck %s
 
 // CHECK-LABEL: func.func @f0(%arg0: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32

--- a/polygeist/tools/cgeist/Test/Verification/base_nostructabi.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/base_nostructabi.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* --struct-abi=0 -memref-abi=0 -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* --struct-abi=0 -memref-abi=0 -S | FileCheck %s
 
 void run0(void*);
 void run1(void*);
@@ -27,28 +27,33 @@ void a() {
     ::basic_ostringstream a;
 }
 
-// CHECK:   func @_Z1av() attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(struct<(i8)>)> : (i64) -> !llvm.ptr<struct<(struct<(i8)>)>>
-// CHECK-NEXT:     call @_ZN19basic_ostringstreamC1Ev(%0) : (!llvm.ptr<struct<(struct<(i8)>)>>) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN19basic_ostringstreamC1Ev(%arg0: !llvm.ptr<struct<(struct<(i8)>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(i8)>)>>) -> !llvm.ptr<struct<(i8)>>
-// CHECK-NEXT:     call @_ZN12_Alloc_hiderC1Ev(%0) : (!llvm.ptr<struct<(i8)>>) -> ()
-// CHECK-NEXT:     %1 = llvm.bitcast %arg0 : !llvm.ptr<struct<(struct<(i8)>)>> to !llvm.ptr<i8>
-// CHECK-NEXT:     call @_Z4run2Pv(%1) : (!llvm.ptr<i8>) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN12_Alloc_hiderC1Ev(%arg0: !llvm.ptr<struct<(i8)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     call @_ZN1MC1Ev(%arg0) : (!llvm.ptr<struct<(i8)>>) -> ()
-// CHECK-NEXT:     %0 = llvm.bitcast %arg0 : !llvm.ptr<struct<(i8)>> to !llvm.ptr<i8>
-// CHECK-NEXT:     call @_Z4run1Pv(%0) : (!llvm.ptr<i8>) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func private @_Z4run2Pv(!llvm.ptr<i8>) attributes {llvm.linkage = #llvm.linkage<external>}
-// CHECK-NEXT:   func @_ZN1MC1Ev(%arg0: !llvm.ptr<struct<(i8)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.bitcast %arg0 : !llvm.ptr<struct<(i8)>> to !llvm.ptr<i8>
-// CHECK-NEXT:     call @_Z4run0Pv(%0) : (!llvm.ptr<i8>) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @_Z1av() attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<(struct<(i8)>)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      call @_ZN19basic_ostringstreamC1Ev(%[[VAL_1]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN19basic_ostringstreamC1Ev(
+// CHECK-SAME:                                            %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(i8)>)>
+// CHECK-NEXT:      call @_ZN12_Alloc_hiderC1Ev(%[[VAL_1]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      call @_Z4run2Pv(%[[VAL_0]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN12_Alloc_hiderC1Ev(
+// CHECK-SAME:                                     %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      call @_ZN1MC1Ev(%[[VAL_0]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      call @_Z4run1Pv(%[[VAL_0]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+// CHECK-NEXT:    func.func private @_Z4run2Pv(!llvm.ptr) attributes {llvm.linkage = #llvm.linkage<external>}
+
+// CHECK-LABEL:   func.func @_ZN1MC1Ev(
+// CHECK-SAME:                         %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      call @_Z4run0Pv(%[[VAL_0]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+// CHECK-NEXT:    func.func private @_Z4run1Pv(!llvm.ptr) attributes {llvm.linkage = #llvm.linkage<external>}
+// CHECK-NEXT:    func.func private @_Z4run0Pv(!llvm.ptr) attributes {llvm.linkage = #llvm.linkage<external>}

--- a/polygeist/tools/cgeist/Test/Verification/base_with_virt.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/base_with_virt.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O2 --function=* -S | FileCheck %s
 
 class M {
 };
@@ -33,25 +33,31 @@ void a() {
     mbasic_stringbuf a;
 }
 
-// clang-format off
-// CHECK:   func @_Z1av() attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)> : (i64) -> !llvm.ptr<struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)>>
-// CHECK-NEXT:     call @_ZN16mbasic_stringbufC1Ev(%0) : (!llvm.ptr<struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)>>) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN16mbasic_stringbufC1Ev(%arg0: !llvm.ptr<struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)>>) -> !llvm.ptr<struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>>
-// CHECK-NEXT:     call @_ZN1AC1Ev(%0) : (!llvm.ptr<struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>>) -> ()
-// CHECK:          call @_ZN12_Alloc_hiderC1Ev
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN1AC1Ev(%arg0: !llvm.ptr<struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-DAG:     %c3_i32 = arith.constant 3 : i32
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     llvm.store %c3_i32, %0 : !llvm.ptr<i32>
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK-NEXT:   func @_ZN12_Alloc_hiderC1Ev(%arg0: !llvm.ptr<struct<(ptr<i8>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @_Z1av() attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      call @_ZN16mbasic_stringbufC1Ev(%[[VAL_1]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN16mbasic_stringbufC1Ev(
+// CHECK-SAME:                                         %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)>
+// CHECK-NEXT:      call @_ZN1AC1Ev(%[[VAL_1]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)>
+// CHECK-NEXT:      call @_ZN12_Alloc_hiderC1Ev(%[[VAL_2]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN1AC1Ev(
+// CHECK-SAME:                         %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 3 : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>
+// CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_2]] : i32, !llvm.ptr
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN12_Alloc_hiderC1Ev(
+// CHECK-SAME:                                     %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/base_with_virt2.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/base_with_virt2.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O2 --function=* -S | FileCheck %s
 
 class M {
 };
@@ -34,19 +34,28 @@ void a() {
     mbasic_stringbuf a;
 }
 
-// clang-format off
-// CHECK:   func @_Z1av() attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK:          call @_ZN16mbasic_stringbufC1Ev
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN16mbasic_stringbufC1Ev(%arg0: !llvm.ptr<struct<(struct<(ptr<ptr<func<i32 (...)>>>)>, struct<(ptr<i8>)>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK:          call @_ZN15basic_streambufC1Ev
-// CHECK:          call @_ZN12_Alloc_hiderC1Ev
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN15basic_streambufC1Ev(%arg0: !llvm.ptr<struct<(ptr<ptr<func<i32 (...)>>>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN12_Alloc_hiderC1Ev(%arg0: !llvm.ptr<struct<(ptr<i8>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @_Z1av() attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<(struct<(ptr<ptr<func<i32 (...)>>>)>, struct<(ptr<i8>)>)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      call @_ZN16mbasic_stringbufC1Ev(%[[VAL_1]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN16mbasic_stringbufC1Ev(
+// CHECK-SAME:                                         %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(ptr<ptr<func<i32 (...)>>>)>, struct<(ptr<i8>)>)>
+// CHECK-NEXT:      call @_ZN15basic_streambufC1Ev(%[[VAL_1]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(ptr<ptr<func<i32 (...)>>>)>, struct<(ptr<i8>)>)>
+// CHECK-NEXT:      call @_ZN12_Alloc_hiderC1Ev(%[[VAL_2]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN15basic_streambufC1Ev(
+// CHECK-SAME:                                        %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN12_Alloc_hiderC1Ev(
+// CHECK-SAME:                                     %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/binop.c
+++ b/polygeist/tools/cgeist/Test/Verification/binop.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S -o - | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S -o - | FileCheck %s
 
 // COM: Checking evaluation order of binary operations.
 // COM: Each operation must be further tested in separate files.

--- a/polygeist/tools/cgeist/Test/Verification/booleanconversion.c
+++ b/polygeist/tools/cgeist/Test/Verification/booleanconversion.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S -O0 -w | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S -O0 -w | FileCheck %s
 
 #include <stdbool.h>
 
@@ -35,18 +35,18 @@ bool float_conversion(float i) { return (bool)i; }
 bool double_conversion(double i) { return (bool)i; }
 
 // CHECK-LABEL:   func.func @ptr_conversion(
-// CHECK-SAME:                              %[[VAL_0:.*]]: !llvm.ptr<i8>) -> i1
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.null : !llvm.ptr<i8>
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.icmp "ne" %[[VAL_0]], %[[VAL_1]] : !llvm.ptr<i8>
+// CHECK-SAME:                              %[[VAL_0:.*]]: !llvm.ptr) -> i1
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.icmp "ne" %[[VAL_0]], %[[VAL_1]] : !llvm.ptr
 // CHECK-NEXT:      return %[[VAL_2]] : i1
 // CHECK-NEXT:    }
 bool ptr_conversion(void *i) { return (bool)i; }
 
 // CHECK-LABEL:   func.func @memref_conversion(
 // CHECK-SAME:                                 %[[VAL_0:.*]]: memref<?xi32>) -> i1
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.null : !llvm.ptr<i32>
-// CHECK-NEXT:      %[[VAL_2:.*]] = "polygeist.memref2pointer"(%[[VAL_0]]) : (memref<?xi32>) -> !llvm.ptr<i32>
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.icmp "ne" %[[VAL_2]], %[[VAL_1]] : !llvm.ptr<i32>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-NEXT:      %[[VAL_2:.*]] = "polygeist.memref2pointer"(%[[VAL_0]]) : (memref<?xi32>) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.icmp "ne" %[[VAL_2]], %[[VAL_1]] : !llvm.ptr
 // CHECK-NEXT:      return %[[VAL_3]] : i1
 // CHECK-NEXT:    }
 bool memref_conversion(int *i) { return (bool)i; }

--- a/polygeist/tools/cgeist/Test/Verification/booleanmem.c
+++ b/polygeist/tools/cgeist/Test/Verification/booleanmem.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s -w -O0 --function=* -S | FileCheck %s
-// RUN: cgeist %s -w -O0 --memref-fullrank --function=* -S | FileCheck %s --check-prefix=CHECK-FULLRANK
+// RUN: cgeist --use-opaque-pointers %s -w -O0 --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -w -O0 --memref-fullrank --function=* -S | FileCheck %s --check-prefix=CHECK-FULLRANK
 
 #include <stdbool.h>
 #include <stdlib.h>
@@ -81,10 +81,10 @@ struct foo {
 // CHECK-LABEL:   func.func @struct_get(
 // CHECK-SAME:                          %[[VAL_0:.*]]: !llvm.struct<(i32, i8)>) -> i1
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(i32, i8)> : (i64) -> !llvm.ptr<struct<(i32, i8)>>
-// CHECK-NEXT:      llvm.store %[[VAL_0]], %[[VAL_2]] : !llvm.ptr<struct<(i32, i8)>>
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 1] : (!llvm.ptr<struct<(i32, i8)>>) -> !llvm.ptr<i8>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %c1_i64 x !llvm.struct<(i32, i8)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      llvm.store %[[VAL_0]], %[[VAL_2]] : !llvm.struct<(i32, i8)>, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i8)>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> i8
 // CHECK-NEXT:      %[[VAL_5:.*]] = arith.trunci %[[VAL_4]] : i8 to i1
 // CHECK-NEXT:      return %[[VAL_5]] : i1
 // CHECK-NEXT:    }
@@ -93,9 +93,9 @@ bool struct_get(struct foo s) {
 }
 
 // CHECK-LABEL:   func.func @struct_ptr_get(
-// CHECK-SAME:                              %[[VAL_0:.*]]: !llvm.ptr<struct<(i32, i8)>>) -> i1
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr<struct<(i32, i8)>>) -> !llvm.ptr<i8>
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<i8>
+// CHECK-SAME:                              %[[VAL_0:.*]]: !llvm.ptr) -> i1
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i8)>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr -> i8
 // CHECK-NEXT:      %[[VAL_3:.*]] = arith.trunci %[[VAL_2]] : i8 to i1
 // CHECK-NEXT:      return %[[VAL_3]] : i1
 // CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/booleanmem.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/booleanmem.cpp
@@ -1,23 +1,23 @@
-// RUN: cgeist %s -w -O0 --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -w -O0 --function=* -S | FileCheck %s
 
 // CHECK-LABEL:   func.func @_Z14lambda_capturebb(
 // CHECK-SAME:                                    %[[VAL_0:.*]]: i1,
-// CHECK-SAME:                                    %[[VAL_1:.*]]: i1)
+// CHECK-SAME:                                    %[[VAL_1:.*]]: i1) attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 1 : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(i8, memref<?xi8>)> : (i64) -> !llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(i8, memref<?xi8>)> : (i64) -> !llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0] : (!llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(i8, memref<?xi8>)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(i8, memref<?xi8>)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i8, memref<?xi8>)>
 // CHECK-NEXT:      %[[VAL_6:.*]] = arith.extui %[[VAL_0]] : i1 to i8
-// CHECK-NEXT:      llvm.store %[[VAL_6]], %[[VAL_5]] : !llvm.ptr<i8>
+// CHECK-NEXT:      llvm.store %[[VAL_6]], %[[VAL_5]] : i8, !llvm.ptr
 // CHECK-NEXT:      %[[VAL_7:.*]] = arith.extui %[[VAL_1]] : i1 to i8
 // CHECK-NEXT:      %[[VAL_8:.*]] = memref.alloca() : memref<1xi8>
 // CHECK-NEXT:      affine.store %[[VAL_7]], %[[VAL_8]][0] : memref<1xi8>
 // CHECK-NEXT:      %[[VAL_9:.*]] = memref.cast %[[VAL_8]] : memref<1xi8> to memref<?xi8>
-// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 1] : (!llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>) -> !llvm.ptr<memref<?xi8>>
-// CHECK-NEXT:      llvm.store %[[VAL_9]], %[[VAL_10]] : !llvm.ptr<memref<?xi8>>
-// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>
-// CHECK-NEXT:      llvm.store %[[VAL_11]], %[[VAL_3]] : !llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>
-// CHECK-NEXT:      call @_ZZ14lambda_capturebbENK3$_0clEv(%[[VAL_3]]) : (!llvm.ptr<!llvm.struct<(i8, memref<?xi8>)>>) -> ()
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i8, memref<?xi8>)>
+// CHECK-NEXT:      llvm.store %[[VAL_9]], %[[VAL_10]] : memref<?xi8>, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr -> !llvm.struct<(i8, memref<?xi8>)>
+// CHECK-NEXT:      llvm.store %[[VAL_11]], %[[VAL_3]] : !llvm.struct<(i8, memref<?xi8>)>, !llvm.ptr
+// CHECK-NEXT:      call @_ZZ14lambda_capturebbENK3$_0clEv(%[[VAL_3]]) : (!llvm.ptr) -> ()
 // CHECK-NEXT:      return
 // CHECK-NEXT:    }
 

--- a/polygeist/tools/cgeist/Test/Verification/caff.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/caff.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 struct AOperandInfo {
   void* data;
@@ -30,21 +30,22 @@ unsigned long long int div_kernel_cuda(ASmallVectorTemplateCommon<AOperandInfo> 
 }
 
 
-// CHECK:   func @_Z15div_kernel_cudaR26ASmallVectorTemplateCommonI12AOperandInfoE(%arg0: !llvm.ptr<struct<(ptr<i8>, ptr<i8>)>>) -> i64 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-DAG:     %c16_i64 = arith.constant 16 : i64
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<struct<(ptr<i8>, ptr<i8>)>>) -> !llvm.ptr<ptr<i8>>
-// CHECK-NEXT:     %1 = llvm.load %0 : !llvm.ptr<ptr<i8>>
-// CHECK-NEXT:     %2 = llvm.bitcast %1 : !llvm.ptr<i8> to !llvm.ptr<struct<(ptr<i8>, i8, i8)>>
-// CHECK-NEXT:     %3 = call @_ZNK26ASmallVectorTemplateCommonI12AOperandInfoE5beginEv(%arg0) : (!llvm.ptr<struct<(ptr<i8>, ptr<i8>)>>) -> !llvm.ptr<struct<(ptr<i8>, i8, i8)>>
-// CHECK-DAG:     %[[i4:.+]] = llvm.ptrtoint %3 : !llvm.ptr<struct<(ptr<i8>, i8, i8)>> to i64
-// CHECK-DAG:     %[[i5:.+]] = llvm.ptrtoint %2 : !llvm.ptr<struct<(ptr<i8>, i8, i8)>> to i64
-// CHECK-DAG:     %[[i6:.+]] = arith.subi %[[i5]], %[[i4]] : i64
-// CHECK-NEXT:    %[[i7:.+]] = arith.divsi %[[i6]], %c16_i64 : i64
-// CHECK-NEXT:     return %[[i7]] : i64
-// CHECK-NEXT:   }
-// CHECK:   func @_ZNK26ASmallVectorTemplateCommonI12AOperandInfoE5beginEv(%arg0: !llvm.ptr<struct<(ptr<i8>, ptr<i8>)>>) -> !llvm.ptr<struct<(ptr<i8>, i8, i8)>> attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(ptr<i8>, ptr<i8>)>>) -> !llvm.ptr<ptr<i8>>
-// CHECK-NEXT:     %1 = llvm.load %0 : !llvm.ptr<ptr<i8>>
-// CHECK-NEXT:     %2 = llvm.bitcast %1 : !llvm.ptr<i8> to !llvm.ptr<struct<(ptr<i8>, i8, i8)>>
-// CHECK-NEXT:     return %2 : !llvm.ptr<struct<(ptr<i8>, i8, i8)>>
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @_Z15div_kernel_cudaR26ASmallVectorTemplateCommonI12AOperandInfoE(
+// CHECK-SAME:                                                                                %[[VAL_0:.*]]: !llvm.ptr) -> i64 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 16 : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = call @_ZNK26ASmallVectorTemplateCommonI12AOperandInfoE5beginEv(%[[VAL_0]]) : (!llvm.ptr) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.ptrtoint %[[VAL_3]] : !llvm.ptr to i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.ptrtoint %[[VAL_4]] : !llvm.ptr to i64
+// CHECK-NEXT:      %[[VAL_7:.*]] = arith.subi %[[VAL_5]], %[[VAL_6]] : i64
+// CHECK-NEXT:      %[[VAL_8:.*]] = arith.divsi %[[VAL_7]], %[[VAL_1]] : i64
+// CHECK-NEXT:      return %[[VAL_8]] : i64
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZNK26ASmallVectorTemplateCommonI12AOperandInfoE5beginEv(
+// CHECK-SAME:                                                                        %[[VAL_0:.*]]: !llvm.ptr) -> !llvm.ptr attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr -> !llvm.ptr
+// CHECK-NEXT:      return %[[VAL_2]] : !llvm.ptr
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/call.c
+++ b/polygeist/tools/cgeist/Test/Verification/call.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
-// RUN: cgeist %s --function=* -S -memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S -memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 void sub0(int a[2]);
 void sub(int a[2]) { a[2]++; }

--- a/polygeist/tools/cgeist/Test/Verification/calloc.c
+++ b/polygeist/tools/cgeist/Test/Verification/calloc.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
 
 void* calloc(unsigned long a, unsigned long b);
 

--- a/polygeist/tools/cgeist/Test/Verification/canonicalization.c
+++ b/polygeist/tools/cgeist/Test/Verification/canonicalization.c
@@ -1,4 +1,4 @@
-// RUN: cgeist --S -O2 --function=* --memref-fullrank %s --raise-scf-to-affine=false | FileCheck %s
+// RUN: cgeist --use-opaque-pointers --S -O2 --function=* --memref-fullrank %s --raise-scf-to-affine=false | FileCheck %s
 
 // The following should be able to fully lower to memref ops without memref
 // subviews.

--- a/polygeist/tools/cgeist/Test/Verification/capture.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/capture.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O0 --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O0 --function=* -S | FileCheck %s
 
 extern "C" {
 
@@ -11,33 +11,37 @@ double kernel_deriche(int x, float y) {
 
 }
 
-// CHECK:   func @kernel_deriche(%arg0: i32, %arg1: f32) -> f64 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-DAG:     %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(memref<?xf32>, i32)> : (i64) -> !llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>
-// CHECK-NEXT:     %1 = llvm.alloca %c1_i64 x !llvm.struct<(memref<?xf32>, i32)> : (i64) -> !llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>
-// CHECK-NEXT:     %alloca = memref.alloca() : memref<1xf32>
-// CHECK-NEXT:     %2 = llvm.mlir.undef : f32
-// CHECK-NEXT:     affine.store %arg1, %alloca[0] : memref<1xf32>
-// CHECK-NEXT:     %cast = memref.cast %alloca : memref<1xf32> to memref<?xf32>
-// CHECK-NEXT:     [[GEP1:%.*]] = llvm.getelementptr inbounds %1[0, 0] : (!llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>) -> !llvm.ptr<memref<?xf32>>
-// CHECK-NEXT:     llvm.store %cast, [[GEP1]] : !llvm.ptr<memref<?xf32>>
-// CHECK-NEXT:     [[GEP2:%.*]] = llvm.getelementptr inbounds %1[0, 1] : (!llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     llvm.store %arg0, [[GEP2]] : !llvm.ptr<i32>
-// CHECK-NEXT:     [[LOAD1:%.*]] = llvm.load %1 : !llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>
-// CHECK-NEXT:     llvm.store [[LOAD1]], %0 : !llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>
-// CHECK-NEXT:     call @_ZZ14kernel_dericheENK3$_0clEv(%0) : (!llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>) -> ()
-// CHECK-NEXT:     [[LOAD2:%.*]] = affine.load %alloca[0] : memref<1xf32>
-// CHECK-NEXT:     [[RES:%.*]] = arith.extf [[LOAD2]] : f32 to f64
-// CHECK-NEXT:     return [[RES]] : f64
-// CHECK-NEXT:   }
-// CHECK:   func private @_ZZ14kernel_dericheENK3$_0clEv(%arg0: !llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>) attributes {llvm.linkage = #llvm.linkage<internal>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     %1 = llvm.load %0 : !llvm.ptr<i32>
-// CHECK-NEXT:     %2 = arith.sitofp %1 : i32 to f32
-// CHECK-NEXT:     %3 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<!llvm.struct<(memref<?xf32>, i32)>>) -> !llvm.ptr<memref<?xf32>>
-// CHECK-NEXT:     %4 = llvm.load %3 : !llvm.ptr<memref<?xf32>>
-// CHECK-NEXT:     %5 = affine.load %4[0] : memref<?xf32>
-// CHECK-NEXT:     %6 = arith.mulf %5, %2 : f32
-// CHECK-NEXT:     affine.store %6, %4[0] : memref<?xf32>
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @kernel_deriche(
+// CHECK-SAME:                              %[[VAL_0:.*]]: i32,
+// CHECK-SAME:                              %[[VAL_1:.*]]: f32) -> f64 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(memref<?xf32>, i32)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(memref<?xf32>, i32)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = memref.alloca() : memref<1xf32>
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.mlir.undef : f32
+// CHECK-NEXT:      affine.store %[[VAL_1]], %[[VAL_5]][0] : memref<1xf32>
+// CHECK-NEXT:      %[[VAL_7:.*]] = memref.cast %[[VAL_5]] : memref<1xf32> to memref<?xf32>
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(memref<?xf32>, i32)>
+// CHECK-NEXT:      llvm.store %[[VAL_7]], %[[VAL_8]] : memref<?xf32>, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(memref<?xf32>, i32)>
+// CHECK-NEXT:      llvm.store %[[VAL_0]], %[[VAL_9]] : i32, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr -> !llvm.struct<(memref<?xf32>, i32)>
+// CHECK-NEXT:      llvm.store %[[VAL_10]], %[[VAL_3]] : !llvm.struct<(memref<?xf32>, i32)>, !llvm.ptr
+// CHECK-NEXT:      call @_ZZ14kernel_dericheENK3$_0clEv(%[[VAL_3]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      %[[VAL_11:.*]] = affine.load %[[VAL_5]][0] : memref<1xf32>
+// CHECK-NEXT:      %[[VAL_12:.*]] = arith.extf %[[VAL_11]] : f32 to f64
+// CHECK-NEXT:      return %[[VAL_12]] : f64
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func private @_ZZ14kernel_dericheENK3$_0clEv(
+// CHECK-SAME:                                                      %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<internal>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(memref<?xf32>, i32)>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr -> i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.sitofp %[[VAL_2]] : i32 to f32
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(memref<?xf32>, i32)>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr -> memref<?xf32>
+// CHECK-NEXT:      %[[VAL_6:.*]] = affine.load %[[VAL_5]][0] : memref<?xf32>
+// CHECK-NEXT:      %[[VAL_7:.*]] = arith.mulf %[[VAL_6]], %[[VAL_3]] : f32
+// CHECK-NEXT:      affine.store %[[VAL_7]], %[[VAL_5]][0] : memref<?xf32>
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/charswitch.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/charswitch.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=foo -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=foo -S | FileCheck %s
 
 extern "C" {
 int foo(char t) {

--- a/polygeist/tools/cgeist/Test/Verification/clangbuiltin.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/clangbuiltin.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 #include <utility>
 

--- a/polygeist/tools/cgeist/Test/Verification/classrefmem.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/classrefmem.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O0 -w --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O0 -w --function=* -S | FileCheck %s
 
 extern int& moo;
 void oadd(int& x) {
@@ -16,20 +16,25 @@ void Q(A& a) {
     a.add();
 }
 
-// CHECK:   func @_Z4oaddRi(%arg0: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:     %0 = affine.load %arg0[0] : memref<?xi32>
-// CHECK-NEXT:     %1 = arith.addi %0, %c1_i32 : i32
-// CHECK-NEXT:     affine.store %1, %arg0[0] : memref<?xi32>
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_Z1QR1A(%arg0: !llvm.ptr<!llvm.struct<(memref<?xi32>)>>) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     call @_ZN1A3addEv(%arg0) : (!llvm.ptr<!llvm.struct<(memref<?xi32>)>>) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN1A3addEv(%arg0: !llvm.ptr<!llvm.struct<(memref<?xi32>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<!llvm.struct<(memref<?xi32>)>>) -> !llvm.ptr<memref<?xi32>>
-// CHECK-NEXT:     %1 = llvm.load %0 : !llvm.ptr<memref<?xi32>>
-// CHECK-NEXT:     call @_Z4oaddRi(%1) : (memref<?xi32>) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @_Z4oaddRi(
+// CHECK-SAME:                         %[[VAL_0:.*]]: memref<?xi32>) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = affine.load %[[VAL_0]][0] : memref<?xi32>
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.addi %[[VAL_2]], %[[VAL_1]] : i32
+// CHECK-NEXT:      affine.store %[[VAL_3]], %[[VAL_0]][0] : memref<?xi32>
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_Z1QR1A(
+// CHECK-SAME:                       %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      call @_ZN1A3addEv(%[[VAL_0]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN1A3addEv(
+// CHECK-SAME:                           %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(memref<?xi32>)>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr -> memref<?xi32>
+// CHECK-NEXT:      call @_Z4oaddRi(%[[VAL_2]]) : (memref<?xi32>) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/cmp.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/cmp.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O0 -w --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O0 -w --function=* -S | FileCheck %s
 
 struct Compare {
   bool lt;

--- a/polygeist/tools/cgeist/Test/Verification/combif.c
+++ b/polygeist/tools/cgeist/Test/Verification/combif.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 // TODO handle negation on if combine
 // TODO remove unused cyclic phi

--- a/polygeist/tools/cgeist/Test/Verification/compoundassign.c
+++ b/polygeist/tools/cgeist/Test/Verification/compoundassign.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S -o - | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S -o - | FileCheck %s
 
 #include <stdbool.h>
 

--- a/polygeist/tools/cgeist/Test/Verification/compoundassign.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/compoundassign.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S -o - | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S -o - | FileCheck %s
 
 // COM: Return value of compound assignment differs in C and C++.
 

--- a/polygeist/tools/cgeist/Test/Verification/cond.c
+++ b/polygeist/tools/cgeist/Test/Verification/cond.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s %stdinclude --function=set -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s %stdinclude --function=set -S | FileCheck %s
 
 #include <stdio.h>
 #include <unistd.h>

--- a/polygeist/tools/cgeist/Test/Verification/cond2.c
+++ b/polygeist/tools/cgeist/Test/Verification/cond2.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s %stdinclude --function=set -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s %stdinclude --function=set -S | FileCheck %s
 
 #include <stdio.h>
 #include <unistd.h>

--- a/polygeist/tools/cgeist/Test/Verification/consabi.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/consabi.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 -w %s  --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 -w %s  --function=* -S | FileCheck %s
 
 class D {
   double a;
@@ -14,31 +14,38 @@ QStream ilaunch_kernel(QStream x) {
   return x;
 }
 
-// CHECK:   func @_Z14ilaunch_kernel7QStream(%arg0: !llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> !llvm.struct<(struct<(f64, f64)>, i32)> attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(struct<(f64, f64)>, i32)> : (i64) -> !llvm.ptr<struct<(struct<(f64, f64)>, i32)>>
-// CHECK-NEXT:     call @_ZN7QStreamC1EOS_(%0, %arg0) : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>, !llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> ()
-// CHECK-NEXT:     %1 = llvm.load %0 : !llvm.ptr<struct<(struct<(f64, f64)>, i32)>>
-// CHECK-NEXT:     return %1 : !llvm.struct<(struct<(f64, f64)>, i32)>
-// CHECK-NEXT:   }
-// CHECK-NEXT:   func @_ZN7QStreamC1EOS_(%arg0: !llvm.ptr<struct<(struct<(f64, f64)>, i32)>>, %arg1: !llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> !llvm.ptr<struct<(f64, f64)>>
-// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %arg1[0, 0] : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> !llvm.ptr<struct<(f64, f64)>>
-// CHECK-NEXT:     call @_ZN1DC1EOS_(%0, %1) : (!llvm.ptr<struct<(f64, f64)>>, !llvm.ptr<struct<(f64, f64)>>) -> ()
-// CHECK-NEXT:     %2 = llvm.getelementptr inbounds %arg1[0, 1] : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     %3 = llvm.load %2 : !llvm.ptr<i32>
-// CHECK-NEXT:     %4 = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<struct<(struct<(f64, f64)>, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     llvm.store %3, %4 : !llvm.ptr<i32>
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK-NEXT:   func @_ZN1DC1EOS_(%arg0: !llvm.ptr<struct<(f64, f64)>>, %arg1: !llvm.ptr<struct<(f64, f64)>>)
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg1[0, 0] : (!llvm.ptr<struct<(f64, f64)>>) -> !llvm.ptr<f64>
-// CHECK-NEXT:     %1 = llvm.load %0 : !llvm.ptr<f64>
-// CHECK-NEXT:     %2 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(f64, f64)>>) -> !llvm.ptr<f64>
-// CHECK-NEXT:     llvm.store %1, %2 : !llvm.ptr<f64>
-// CHECK-NEXT:     %3 = llvm.getelementptr inbounds %arg1[0, 1] : (!llvm.ptr<struct<(f64, f64)>>) -> !llvm.ptr<f64>
-// CHECK-NEXT:     %4 = llvm.load %3 : !llvm.ptr<f64>
-// CHECK-NEXT:     %5 = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<struct<(f64, f64)>>) -> !llvm.ptr<f64>
-// CHECK-NEXT:     llvm.store %4, %5 : !llvm.ptr<f64>
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @_Z14ilaunch_kernel7QStream(
+// CHECK-SAME:                                          %[[VAL_0:.*]]: !llvm.ptr) -> !llvm.struct<(struct<(f64, f64)>, i32)> attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(struct<(f64, f64)>, i32)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      call @_ZN7QStreamC1EOS_(%[[VAL_2]], %[[VAL_0]]) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> !llvm.struct<(struct<(f64, f64)>, i32)>
+// CHECK-NEXT:      return %[[VAL_3]] : !llvm.struct<(struct<(f64, f64)>, i32)>
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN7QStreamC1EOS_(
+// CHECK-SAME:                                 %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                                 %[[VAL_1:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(f64, f64)>, i32)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(f64, f64)>, i32)>
+// CHECK-NEXT:      call @_ZN1DC1EOS_(%[[VAL_2]], %[[VAL_3]]) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(f64, f64)>, i32)>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr -> i32
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(f64, f64)>, i32)>
+// CHECK-NEXT:      llvm.store %[[VAL_5]], %[[VAL_6]] : i32, !llvm.ptr
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN1DC1EOS_(
+// CHECK-SAME:                           %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                           %[[VAL_1:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f64, f64)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> f64
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f64, f64)>
+// CHECK-NEXT:      llvm.store %[[VAL_3]], %[[VAL_4]] : f64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f64, f64)>
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> f64
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f64, f64)>
+// CHECK-NEXT:      llvm.store %[[VAL_6]], %[[VAL_7]] : f64, !llvm.ptr
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/constexpr.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/constexpr.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
 constexpr int num = 10 + 4;
 
 int sum(int*);

--- a/polygeist/tools/cgeist/Test/Verification/constfolding.c
+++ b/polygeist/tools/cgeist/Test/Verification/constfolding.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S -O0 -w | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S -O0 -w | FileCheck %s
 
 // CHECK-LABEL:   func.func @foldTrunc() -> f32
 // CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 1.000000e+01 : f32

--- a/polygeist/tools/cgeist/Test/Verification/continue.c
+++ b/polygeist/tools/cgeist/Test/Verification/continue.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
 
 int get();
 void other();

--- a/polygeist/tools/cgeist/Test/Verification/cudaglobalcodegen.cu
+++ b/polygeist/tools/cgeist/Test/Verification/cudaglobalcodegen.cu
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O0 -w --cuda-gpu-arch=sm_60 -nocudalib -nocudainc %resourcedir --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O0 -w --cuda-gpu-arch=sm_60 -nocudalib -nocudainc %resourcedir --function=* -S | FileCheck %s
 
 #include "Inputs/cuda.h"
 

--- a/polygeist/tools/cgeist/Test/Verification/defines.c
+++ b/polygeist/tools/cgeist/Test/Verification/defines.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -DPASS -DTEST0 -DTEST1 -DTEST2 %s -S -o -
+// RUN: cgeist --use-opaque-pointers -DPASS -DTEST0 -DTEST1 -DTEST2 %s -S -o -
 
 // CHECK-LABEL: func.func @main() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32

--- a/polygeist/tools/cgeist/Test/Verification/der.c
+++ b/polygeist/tools/cgeist/Test/Verification/der.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=kernel_deriche -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=kernel_deriche -S | FileCheck %s
 
 float kernel_deriche() {
     float a2, a6;

--- a/polygeist/tools/cgeist/Test/Verification/deref.c
+++ b/polygeist/tools/cgeist/Test/Verification/deref.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=kernel_deriche -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=kernel_deriche -S | FileCheck %s
 
 int deref(int a);
 

--- a/polygeist/tools/cgeist/Test/Verification/derived.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/derived.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 struct A {
     int x;
@@ -17,15 +17,18 @@ int ptr(struct B* v) {
     return v->x;
 }
 
-// CHECK:   func @_Z3refR1B(%arg0: !llvm.ptr<struct<(struct<(i32, f64)>, ptr<i8>)>>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(i32, f64)>, ptr<i8>)>>) -> !llvm.ptr<struct<(i32, f64)>>
-// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     %2 = llvm.load %1 : !llvm.ptr<i32>
-// CHECK-NEXT:     return %2 : i32
-// CHECK-NEXT:   }
-// CHECK:   func @_Z3ptrP1B(%arg0: !llvm.ptr<struct<(struct<(i32, f64)>, ptr<i8>)>>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(i32, f64)>, ptr<i8>)>>) -> !llvm.ptr<struct<(i32, f64)>>
-// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     %2 = llvm.load %1 : !llvm.ptr<i32>
-// CHECK-NEXT:     return %2 : i32
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @_Z3refR1B(
+// CHECK-SAME:                         %[[VAL_0:.*]]: !llvm.ptr) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(i32, f64)>, ptr)>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, f64)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> i32
+// CHECK-NEXT:      return %[[VAL_3]] : i32
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_Z3ptrP1B(
+// CHECK-SAME:                         %[[VAL_0:.*]]: !llvm.ptr) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(i32, f64)>, ptr)>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, f64)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> i32
+// CHECK-NEXT:      return %[[VAL_3]] : i32
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/div.c
+++ b/polygeist/tools/cgeist/Test/Verification/div.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 %s --function=* -S | FileCheck %s
 
 typedef char char_vec __attribute__((ext_vector_type(3)));
 typedef short short_vec __attribute__((ext_vector_type(3)));

--- a/polygeist/tools/cgeist/Test/Verification/dynalloc.c
+++ b/polygeist/tools/cgeist/Test/Verification/dynalloc.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O2 --function=create_matrix -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O2 --function=create_matrix -S | FileCheck %s
 
 void create_matrix(float *m, int size) {
   float coe[2 * size + 1];

--- a/polygeist/tools/cgeist/Test/Verification/ext.c
+++ b/polygeist/tools/cgeist/Test/Verification/ext.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 int c2i(char x) {
     return x;

--- a/polygeist/tools/cgeist/Test/Verification/ext_vector_type.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/ext_vector_type.cpp
@@ -1,5 +1,5 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
-// RUN: cgeist %s --function=* -S -emit-llvm | FileCheck %s --check-prefix=LLVM
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S -emit-llvm | FileCheck %s --check-prefix=LLVM
 
 #include <cstddef>
 

--- a/polygeist/tools/cgeist/Test/Verification/float16.c
+++ b/polygeist/tools/cgeist/Test/Verification/float16.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s --function=* -S -march=x86-64         2>&1 | FileCheck %s --check-prefix=CHECK-EXTEND
-// RUN: cgeist %s --function=* -S -march=sapphirerapids 2>&1 | FileCheck %s --check-prefix=CHECK-NATIVE
+// RUN: cgeist --use-opaque-pointers %s --function=* -S -march=x86-64         2>&1 | FileCheck %s --check-prefix=CHECK-EXTEND
+// RUN: cgeist --use-opaque-pointers %s --function=* -S -march=sapphirerapids 2>&1 | FileCheck %s --check-prefix=CHECK-NATIVE
 
 // COM: sapphirerapids supports _Float16 natively
 

--- a/polygeist/tools/cgeist/Test/Verification/free.c
+++ b/polygeist/tools/cgeist/Test/Verification/free.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 void free(void*);
 
@@ -8,10 +8,11 @@ void metafree(void* x, void (*foo)(int), void (*bar)(void)) {
     free(x);
 }
 
-// CHECK:   func @metafree(%arg0: !llvm.ptr<i8>, %arg1: !llvm.ptr<func<void (i32)>>, %arg2: !llvm.ptr<func<void ()>>) 
-// CHECK-NEXT:     %c0_i32 = arith.constant 0 : i32
-// CHECK-NEXT:     llvm.call %arg1(%c0_i32) : !llvm.ptr<func<void (i32)>>, (i32) -> ()
-// CHECK-NEXT:     llvm.call %arg2() : !llvm.ptr<func<void ()>>, () -> ()
-// CHECK-NEXT:     llvm.call @free(%arg0) : (!llvm.ptr<i8>) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+
+// CHECK:      func.func @metafree(%[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: !llvm.ptr, %[[VAL_2:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      llvm.call %[[VAL_1]](%[[VAL_3]]) : !llvm.ptr, (i32) -> ()
+// CHECK-NEXT:      llvm.call %[[VAL_2]]() : !llvm.ptr, () -> ()
+// CHECK-NEXT:      llvm.call @free(%[[VAL_0]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/freecst.c
+++ b/polygeist/tools/cgeist/Test/Verification/freecst.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 #include <stdlib.h>
     struct band {
@@ -12,8 +12,8 @@ void writeNStage2DDWT(struct dimensions* bandDims)
     free(bandDims);
 }
 
-// CHECK:   func @writeNStage2DDWT(%arg0: !llvm.ptr<struct<(struct<(i32)>)>>) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %[[a1:.+]] = llvm.bitcast %arg0 : !llvm.ptr<struct<(struct<(i32)>)>> to !llvm.ptr<i8>
-// CHECK-NEXT:     llvm.call @free(%[[a1]]) : (!llvm.ptr<i8>) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @writeNStage2DDWT(
+// CHECK-SAME:                                %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      llvm.call @free(%[[VAL_0]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/fscanf.c
+++ b/polygeist/tools/cgeist/Test/Verification/fscanf.c
@@ -1,6 +1,4 @@
-// RUN: cgeist %s -O2 %stdinclude --function=alloc -S --raise-scf-to-affine=false | FileCheck %s
-
-// TODO(Lukas): Failure related to addressof?
+// RUN: cgeist --use-opaque-pointers %s -O2 %stdinclude --function=alloc -S --raise-scf-to-affine=false | FileCheck %s
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -21,32 +19,34 @@ int* alloc() {
 	return h_graph_nodes;
 }
 
-// CHECK: llvm.mlir.global internal constant @str1("%d\0A\00")
-// CHECK-NEXT: llvm.mlir.global internal constant @str0("%d\00")
-// CHECK-NEXT: llvm.func @__isoc99_scanf(!llvm.ptr<i8>, ...) -> i32
-// CHECK:  func @alloc() -> memref<?xi32>
-// CHECK-DAG:    %c1 = arith.constant 1 : index
-// CHECK-DAG:    %c0 = arith.constant 0 : index
-// CHECK-DAG:    %c4 = arith.constant 4 : index
-// CHECK-DAG:    %c4_i64 = arith.constant 4 : i6
-// CHECK-DAG:    %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:    %0 = llvm.alloca %c1_i64 x i32 : (i64) -> !llvm.ptr<i32>
-// CHECK-NEXT:    %1 = llvm.mlir.addressof @str0 : !llvm.ptr<array<3 x i8>>
-// CHECK-NEXT:    %2 = llvm.getelementptr inbounds %1[0, 0] : (!llvm.ptr<array<3 x i8>>) -> !llvm.ptr<i8>
-// CHECK-NEXT:    %3 = llvm.call @__isoc99_scanf(%2, %0) : (!llvm.ptr<i8>, !llvm.ptr<i32>) -> i32
-// CHECK-NEXT:    %4 = llvm.load %0 : !llvm.ptr<i32>
-// CHECK-NEXT:    %5 = arith.extsi %4 : i32 to i64
-// CHECK-NEXT:    %6 = arith.muli %5, %c4_i64 : i64
-// CHECK-NEXT:    %7 = arith.index_cast %6 : i64 to index
-// CHECK-NEXT:    %8 = arith.divui %7, %c4 : index
-// CHECK-NEXT:    %[[i8:.+]] = memref.alloc(%8) : memref<?xi32>
-// CHECK-DAG:     %[[n:.+]] = arith.index_cast %4 : i32 to index
-// CHECK-DAG:     %[[i9:.+]] = llvm.mlir.addressof @str1 : !llvm.ptr<array<4 x i8>>
-// CHECK-DAG:     %[[i10:.+]] = llvm.getelementptr inbounds %[[i9]][0, 0] : (!llvm.ptr<array<4 x i8>>) -> !llvm.ptr<i8>
-// CHECK-NEXT:    scf.for %arg0 = %c0 to %[[n]] step %c1 {
-// CHECK-NEXT:      %[[i13:.+]] = llvm.call @__isoc99_scanf(%[[i10]], %0) : (!llvm.ptr<i8>, !llvm.ptr<i32>) -> i32
-// CHECK-NEXT:      %[[i12:.+]] = llvm.load %0 : !llvm.ptr<i32>
-// CHECK-NEXT:      memref.store %[[i12]], %[[i8]][%arg0] : memref<?xi32>
+// CHECK-LABEL:   llvm.mlir.global internal constant @str1("
+// CHECK-SAME:                                              %d\0A\00") {addr_space = 0 : i32}
+// CHECK-NEXT:    llvm.mlir.global internal constant @str0("%d\00") {addr_space = 0 : i32}
+// CHECK-NEXT:    llvm.func @__isoc99_scanf(!llvm.ptr, ...) -> i32 attributes {sym_visibility = "private"}
+
+// CHECK-LABEL:   func.func @alloc() -> memref<?xi32> attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 4 : index
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant 4 : i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.alloca %[[VAL_4]] x i32 : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.mlir.addressof @str0 : !llvm.ptr
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.getelementptr inbounds %[[VAL_6]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<3 x i8>
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.call @__isoc99_scanf(%[[VAL_7]], %[[VAL_5]]) : (!llvm.ptr, !llvm.ptr) -> i32
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> i32
+// CHECK-NEXT:      %[[VAL_10:.*]] = arith.extsi %[[VAL_9]] : i32 to i64
+// CHECK-NEXT:      %[[VAL_11:.*]] = arith.muli %[[VAL_10]], %[[VAL_3]] : i64
+// CHECK-NEXT:      %[[VAL_12:.*]] = arith.index_cast %[[VAL_11]] : i64 to index
+// CHECK-NEXT:      %[[VAL_13:.*]] = arith.divui %[[VAL_12]], %[[VAL_2]] : index
+// CHECK-NEXT:      %[[VAL_14:.*]] = memref.alloc(%[[VAL_13]]) : memref<?xi32>
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.mlir.addressof @str1 : !llvm.ptr
+// CHECK-NEXT:      %[[VAL_16:.*]] = llvm.getelementptr inbounds %[[VAL_15]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<4 x i8>
+// CHECK-NEXT:      %[[VAL_17:.*]] = arith.index_cast %[[VAL_9]] : i32 to index
+// CHECK-NEXT:      scf.for %[[VAL_18:.*]] = %[[VAL_0]] to %[[VAL_17]] step %[[VAL_1]] {
+// CHECK-NEXT:        %[[VAL_19:.*]] = llvm.call @__isoc99_scanf(%[[VAL_16]], %[[VAL_5]]) : (!llvm.ptr, !llvm.ptr) -> i32
+// CHECK-NEXT:        %[[VAL_20:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> i32
+// CHECK-NEXT:        memref.store %[[VAL_20]], %[[VAL_14]]{{\[}}%[[VAL_18]]] : memref<?xi32>
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return %[[VAL_14]] : memref<?xi32>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    return %[[i8]] : memref<?xi32>
-// CHECK-NEXT:  }

--- a/polygeist/tools/cgeist/Test/Verification/fscanf.c
+++ b/polygeist/tools/cgeist/Test/Verification/fscanf.c
@@ -1,5 +1,7 @@
 // RUN: cgeist %s -O2 %stdinclude --function=alloc -S --raise-scf-to-affine=false | FileCheck %s
 
+// TODO(Lukas): Failure related to addressof?
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/polygeist/tools/cgeist/Test/Verification/fw.c
+++ b/polygeist/tools/cgeist/Test/Verification/fw.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s %stdinclude -S | FileCheck %s
-// RUN: cgeist %s %stdinclude  -S -memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist --use-opaque-pointers %s %stdinclude -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s %stdinclude  -S -memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 #include <stdio.h>
 #include <unistd.h>

--- a/polygeist/tools/cgeist/Test/Verification/fwfree.c
+++ b/polygeist/tools/cgeist/Test/Verification/fwfree.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s %stdinclude -S | FileCheck %s
-// RUN: cgeist %s %stdinclude -S -memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist --use-opaque-pointers %s %stdinclude -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s %stdinclude -S -memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 #include <stdio.h>
 #include <unistd.h>

--- a/polygeist/tools/cgeist/Test/Verification/gcd.c
+++ b/polygeist/tools/cgeist/Test/Verification/gcd.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=gcd -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=gcd -S | FileCheck %s
 
 int gcd(int m, int n) {
   while (n > 0) {

--- a/polygeist/tools/cgeist/Test/Verification/gettimeofday.c
+++ b/polygeist/tools/cgeist/Test/Verification/gettimeofday.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 -w %s %stdinclude --function=alloc -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 -w %s %stdinclude --function=alloc -S | FileCheck %s
 
 #include <time.h>
 #include <sys/time.h>
@@ -8,19 +8,19 @@ double alloc() {
   return Tp.tv_sec + Tp.tv_usec * 1.0e-6;
 }
 
-// CHECK:   func @alloc() -> f64
-// CHECK-NEXT:     %cst = arith.constant 9.9999999999999995E-7 : f64
-// CHECK-NEXT:     %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(i64, i64)> : (i64) -> !llvm.ptr<struct<(i64, i64)>>
-// CHECK-NEXT:     %1 = llvm.mlir.null : !llvm.ptr<{{.*}}>
-// CHECK:          %{{.*}} = llvm.call @gettimeofday(%0, %{{.*}}) : (!llvm.ptr<struct<(i64, i64)>>, {{.*}}) -> i32
-// CHECK-NEXT:     [[T3:%.*]] = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<struct<(i64, i64)>>) -> !llvm.ptr<i64>
-// CHECK-NEXT:     [[T4:%.*]] = llvm.load [[T3]] : !llvm.ptr<i64>
-// CHECK-NEXT:     [[T5:%.*]] = arith.sitofp [[T4]] : i64 to f64
-// CHECK-NEXT:     [[T6:%.*]] = llvm.getelementptr inbounds %0[0, 1] : (!llvm.ptr<struct<(i64, i64)>>) -> !llvm.ptr<i64>
-// CHECK-NEXT:     [[T7:%.*]] = llvm.load [[T6]] : !llvm.ptr<i64>
-// CHECK-NEXT:     [[T8:%.*]] = arith.sitofp [[T7]] : i64 to f64
-// CHECK-NEXT:     [[T9:%.*]] = arith.mulf [[T8]], %cst : f64
-// CHECK-NEXT:     [[T10:%.*]] = arith.addf [[T5]], [[T9]] : f64
-// CHECK-NEXT:     return [[T10]] : f64
-// CHECK-NEXT:   }
+// CHECK:         func.func @alloc() -> f64 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 9.9999999999999995E-7 : f64
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(i64, i64)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.call @gettimeofday(%[[VAL_2]], %[[VAL_3]]) : (!llvm.ptr, !llvm.ptr) -> i32
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i64, i64)>
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> i64
+// CHECK-NEXT:      %[[VAL_7:.*]] = arith.sitofp %[[VAL_6]] : i64 to f64
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i64, i64)>
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.load %[[VAL_8]] : !llvm.ptr -> i64
+// CHECK-NEXT:      %[[VAL_10:.*]] = arith.sitofp %[[VAL_9]] : i64 to f64
+// CHECK-NEXT:      %[[VAL_11:.*]] = arith.mulf %[[VAL_10]], %[[VAL_0]] : f64
+// CHECK-NEXT:      %[[VAL_12:.*]] = arith.addf %[[VAL_7]], %[[VAL_11]] : f64
+// CHECK-NEXT:      return %[[VAL_12]] : f64
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/global.c
+++ b/polygeist/tools/cgeist/Test/Verification/global.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s %stdinclude -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s %stdinclude -S | FileCheck %s
 
 float A[64][32];
 

--- a/polygeist/tools/cgeist/Test/Verification/globals.c
+++ b/polygeist/tools/cgeist/Test/Verification/globals.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s --function=kernel_deriche -S | FileCheck %s
-// RUN: cgeist %s --function=kernel_deriche -S -emit-llvm | FileCheck %s --check-prefix=LLVM
+// RUN: cgeist --use-opaque-pointers %s --function=kernel_deriche -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=kernel_deriche -S -emit-llvm | FileCheck %s --check-prefix=LLVM
 
 int local;
 int local_init = 4;

--- a/polygeist/tools/cgeist/Test/Verification/hist.c
+++ b/polygeist/tools/cgeist/Test/Verification/hist.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O2 --function=* -S --raise-scf-to-affine=false | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O2 --function=* -S --raise-scf-to-affine=false | FileCheck %s
 
 void histo_kernel(int i);
 

--- a/polygeist/tools/cgeist/Test/Verification/ident.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/ident.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O0 -w --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O0 -w --function=* -S | FileCheck %s
 
 struct MOperandInfo {
   char device;
@@ -41,58 +41,71 @@ void lt_kernel_cuda(MTensorIterator& iter) {
 }
 }
 
-// CHECK:   func.func @lt_kernel_cuda(%arg0: !llvm.ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-DAG:     %c0_i8 = arith.constant 0 : i8
-// CHECK-DAG:     %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>)> : (i64) -> !llvm.ptr<struct<(ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>)>>
-// CHECK-NEXT:     %1 = llvm.alloca %c1_i64 x !llvm.struct<(ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>)> : (i64) -> !llvm.ptr<struct<(ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>)>>
-// CHECK-NEXT:     %2 = call @_ZNK15MTensorIterator11input_dtypeEv(%arg0) : (!llvm.ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>) -> i8
-// CHECK-NEXT:     %3 = arith.cmpi ne, %2, %c0_i8 : i8
-// CHECK-NEXT:     scf.if %3 {
-// CHECK-NEXT:       %4 = llvm.getelementptr inbounds %1[0, 0] : (!llvm.ptr<struct<(ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>)>>) -> !llvm.ptr<ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>>
-// CHECK-NEXT:       llvm.store %arg0, %4 : !llvm.ptr<ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>>
-// CHECK-NEXT:       %5 = llvm.load %1 : !llvm.ptr<struct<(ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>)>>
-// CHECK-NEXT:       llvm.store %5, %0 : !llvm.ptr<struct<(ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>)>>
-// CHECK-NEXT:       call @_ZZ14lt_kernel_cudaENK3$_0clEv(%0) : (!llvm.ptr<struct<(ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>)>>) -> ()
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func.func @_ZNK15MTensorIterator11input_dtypeEv(%arg0: !llvm.ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>) -> i8 attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %c0_i32 = arith.constant 0 : i32
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>) -> !llvm.ptr<struct<(ptr<struct<(i8, i8)>>)>>
-// CHECK-NEXT:     %1 = call @_ZNK12MSmallVectorI12MOperandInfoEixEi(%0, %c0_i32) : (!llvm.ptr<struct<(ptr<struct<(i8, i8)>>)>>, i32) -> !llvm.ptr<struct<(i8, i8)>>
-// CHECK-NEXT:     %2 = llvm.getelementptr inbounds %1[0, 1] : (!llvm.ptr<struct<(i8, i8)>>) -> !llvm.ptr<i8>
-// CHECK-NEXT:     %3 = llvm.load %2 : !llvm.ptr<i8>
-// CHECK-NEXT:     return %3 : i8
-// CHECK-NEXT:   }
-// CHECK:   func.func private @_ZZ14lt_kernel_cudaENK3$_0clEv(%arg0: !llvm.ptr<struct<(ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>)>>) attributes {llvm.linkage = #llvm.linkage<internal>} {
-// CHECK-NEXT:     %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(i8)> : (i64) -> !llvm.ptr<struct<(i8)>>
-// CHECK-NEXT:     %1 = llvm.alloca %c1_i64 x !llvm.struct<(i8)> : (i64) -> !llvm.ptr<struct<(i8)>>
-// CHECK-NEXT:     %2 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>)>>) -> !llvm.ptr<ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>>
-// CHECK-NEXT:     %3 = llvm.load %2 : !llvm.ptr<ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>>
-// CHECK-NEXT:     %4 = llvm.load %1 : !llvm.ptr<struct<(i8)>>
-// CHECK-NEXT:     llvm.store %4, %0 : !llvm.ptr<struct<(i8)>>
-// CHECK-NEXT:     call @_Z11igpu_kernelIZZ14lt_kernel_cudaENK3$_0clEvEUlvE_EvR15MTensorIteratorRKT_(%3, %0) : (!llvm.ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>, !llvm.ptr<struct<(i8)>>) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func.func @_ZNK12MSmallVectorI12MOperandInfoEixEi(%arg0: !llvm.ptr<struct<(ptr<struct<(i8, i8)>>)>>, %arg1: i32) -> !llvm.ptr<struct<(i8, i8)>> attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:    %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(ptr<struct<(i8, i8)>>)>>) -> !llvm.ptr<ptr<struct<(i8, i8)>>>
-// CHECK-NEXT:    %1 = llvm.load %0 : !llvm.ptr<ptr<struct<(i8, i8)>>>
-// CHECK-NEXT:    %2 = arith.index_cast %arg1 : i32 to index
-// CHECK-NEXT:    %3 = arith.index_cast %2 : index to i64
-// CHECK-NEXT:    %4 = llvm.getelementptr %1[%3] : (!llvm.ptr<struct<(i8, i8)>>, i64) -> !llvm.ptr<struct<(i8, i8)>>
-// CHECK-NEXT:    return %4 : !llvm.ptr<struct<(i8, i8)>>
-// CHECK-NEXT:  }
-// CHECK:    func.func private @_Z11igpu_kernelIZZ14lt_kernel_cudaENK3$_0clEvEUlvE_EvR15MTensorIteratorRKT_(%arg0: !llvm.ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>, %arg1: !llvm.ptr<struct<(i8)>>) attributes {llvm.linkage = #llvm.linkage<internal>} {
-// CHECK-NEXT:    %0 = call @_ZNK15MTensorIterator6deviceEv(%arg0) : (!llvm.ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>) -> i8
-// CHECK-NEXT:    return
-// CHECK-NEXT:  }
-// CHECK:      func.func @_ZNK15MTensorIterator6deviceEv(%arg0: !llvm.ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>) -> i8 attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
-// CHECK-NEXT:    %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(ptr<struct<(i8, i8)>>)>)>>) -> !llvm.ptr<struct<(ptr<struct<(i8, i8)>>)>>
-// CHECK-NEXT:    %1 = call @_ZNK12MSmallVectorI12MOperandInfoEixEi(%0, %c0_i32) : (!llvm.ptr<struct<(ptr<struct<(i8, i8)>>)>>, i32) -> !llvm.ptr<struct<(i8, i8)>>
-// CHECK-NEXT:    %2 = llvm.getelementptr inbounds %1[0, 0] : (!llvm.ptr<struct<(i8, i8)>>) -> !llvm.ptr<i8>
-// CHECK-NEXT:    %3 = llvm.load %2 : !llvm.ptr<i8>
-// CHECK-NEXT:    return %3 : i8
-// CHECK-NEXT:  }
+// CHECK-LABEL:   func.func @lt_kernel_cuda(
+// CHECK-SAME:                              %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : i8
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(ptr)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(ptr)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = call @_ZNK15MTensorIterator11input_dtypeEv(%[[VAL_0]]) : (!llvm.ptr) -> i8
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.cmpi ne, %[[VAL_5]], %[[VAL_1]] : i8
+// CHECK-NEXT:      scf.if %[[VAL_6]] {
+// CHECK-NEXT:        %[[VAL_7:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(ptr)>
+// CHECK-NEXT:        llvm.store %[[VAL_0]], %[[VAL_7]] : !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:        %[[VAL_8:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr -> !llvm.struct<(ptr)>
+// CHECK-NEXT:        llvm.store %[[VAL_8]], %[[VAL_3]] : !llvm.struct<(ptr)>, !llvm.ptr
+// CHECK-NEXT:        func.call @_ZZ14lt_kernel_cudaENK3$_0clEv(%[[VAL_3]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZNK15MTensorIterator11input_dtypeEv(
+// CHECK-SAME:                                                    %[[VAL_0:.*]]: !llvm.ptr) -> i8 attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(ptr)>)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = call @_ZNK12MSmallVectorI12MOperandInfoEixEi(%[[VAL_2]], %[[VAL_1]]) : (!llvm.ptr, i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i8, i8)>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr -> i8
+// CHECK-NEXT:      return %[[VAL_5]] : i8
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func private @_ZZ14lt_kernel_cudaENK3$_0clEv(
+// CHECK-SAME:                                                      %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<internal>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(i8)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(i8)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(ptr)>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> !llvm.struct<(i8)>
+// CHECK-NEXT:      llvm.store %[[VAL_6]], %[[VAL_2]] : !llvm.struct<(i8)>, !llvm.ptr
+// CHECK-NEXT:      call @_Z11igpu_kernelIZZ14lt_kernel_cudaENK3$_0clEvEUlvE_EvR15MTensorIteratorRKT_(%[[VAL_5]], %[[VAL_2]]) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZNK12MSmallVectorI12MOperandInfoEixEi(
+// CHECK-SAME:      %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:      %[[VAL_1:.*]]: i32) -> !llvm.ptr attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(ptr)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_1]] : i32 to index
+// CHECK-NEXT:      %[[VAL_5:.*]] = arith.index_cast %[[VAL_4]] : index to i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_3]]{{\[}}%[[VAL_5]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<(i8, i8)>
+// CHECK-NEXT:      return %[[VAL_6]] : !llvm.ptr
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func private @_Z11igpu_kernelIZZ14lt_kernel_cudaENK3$_0clEvEUlvE_EvR15MTensorIteratorRKT_(
+// CHECK-SAME:      %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:         %[[VAL_1:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<internal>} {
+// CHECK-NEXT:      %[[VAL_2:.*]] = call @_ZNK15MTensorIterator6deviceEv(%[[VAL_0]]) : (!llvm.ptr) -> i8
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZNK15MTensorIterator6deviceEv(
+// CHECK-SAME:                                              %[[VAL_0:.*]]: !llvm.ptr) -> i8 attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(ptr)>)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = call @_ZNK12MSmallVectorI12MOperandInfoEixEi(%[[VAL_2]], %[[VAL_1]]) : (!llvm.ptr, i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i8, i8)>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr -> i8
+// CHECK-NEXT:      return %[[VAL_5]] : i8
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/ident2.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/ident2.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 -w %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 -w %s --function=* -S | FileCheck %s
 
 struct MOperandInfo {
   char device;
@@ -11,8 +11,8 @@ struct MOperandInfo& inner() {
   return begin()[0];
 }
 
-// CHECK:   func.func @_Z5innerv() -> !llvm.ptr<struct<(i8, i8)>> attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %0 = call @_Z5beginv() : () -> !llvm.ptr<struct<(i8, i8)>>
-// CHECK-NEXT:     return %0 : !llvm.ptr<struct<(i8, i8)>>
-// CHECK-NEXT:   }
-// CHECK-NEXT:   func.func private @_Z5beginv() -> !llvm.ptr<struct<(i8, i8)>> attributes {llvm.linkage = #llvm.linkage<external>}
+// CHECK-LABEL:   func.func @_Z5innerv() -> !llvm.ptr attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_0:.*]] = call @_Z5beginv() : () -> !llvm.ptr
+// CHECK-NEXT:      return %[[VAL_0]] : !llvm.ptr
+// CHECK-NEXT:    }
+// CHECK-NEXT:    func.func private @_Z5beginv() -> !llvm.ptr attributes {llvm.linkage = #llvm.linkage<external>}

--- a/polygeist/tools/cgeist/Test/Verification/imag.c
+++ b/polygeist/tools/cgeist/Test/Verification/imag.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 #include <complex.h>
 

--- a/polygeist/tools/cgeist/Test/Verification/integral2ptr.c
+++ b/polygeist/tools/cgeist/Test/Verification/integral2ptr.c
@@ -1,36 +1,36 @@
-// RUN: cgeist %s --function=* -S -O0 -w | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S -O0 -w | FileCheck %s
 
 #include <stdint.h>
 #include <stdlib.h>
 
 // CHECK-LABEL:   func.func @size_t2ptr(
-// CHECK-SAME:                          %[[VAL_0:.*]]: i64) -> !llvm.ptr<i8>
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.inttoptr %[[VAL_0]] : i64 to !llvm.ptr<i8>
-// CHECK-NEXT:      return %[[VAL_1]] : !llvm.ptr<i8>
+// CHECK-SAME:                          %[[VAL_0:.*]]: i64) -> !llvm.ptr attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.inttoptr %[[VAL_0]] : i64 to !llvm.ptr
+// CHECK-NEXT:      return %[[VAL_1]] : !llvm.ptr
 // CHECK-NEXT:    }
 void *size_t2ptr(size_t i) { return (void *)i; }
 
 // CHECK-LABEL:   func.func @int8_t2ptr(
-// CHECK-SAME:                          %[[VAL_0:.*]]: i8) -> !llvm.ptr<i8>
+// CHECK-SAME:                          %[[VAL_0:.*]]: i8) -> !llvm.ptr attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.extsi %[[VAL_0]] : i8 to i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.inttoptr %[[VAL_1]] : i64 to !llvm.ptr<i8>
-// CHECK-NEXT:      return %[[VAL_2]] : !llvm.ptr<i8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.inttoptr %[[VAL_1]] : i64 to !llvm.ptr
+// CHECK-NEXT:      return %[[VAL_2]] : !llvm.ptr
 // CHECK-NEXT:    }
 void *int8_t2ptr(int8_t i) { return (void *)i; }
 
 // CHECK-LABEL:   func.func @size_t2memref(
-// CHECK-SAME:                             %[[VAL_0:.*]]: i64) -> memref<?xi32>
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.inttoptr %[[VAL_0]] : i64 to !llvm.ptr<i32>
-// CHECK-NEXT:      %[[VAL_2:.*]] = "polygeist.pointer2memref"(%[[VAL_1]]) : (!llvm.ptr<i32>) -> memref<?xi32>
+// CHECK-SAME:                             %[[VAL_0:.*]]: i64) -> memref<?xi32> attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.inttoptr %[[VAL_0]] : i64 to !llvm.ptr
+// CHECK-NEXT:      %[[VAL_2:.*]] = "polygeist.pointer2memref"(%[[VAL_1]]) : (!llvm.ptr) -> memref<?xi32>
 // CHECK-NEXT:      return %[[VAL_2]] : memref<?xi32>
 // CHECK-NEXT:    }
 int *size_t2memref(size_t i) { return (int *)i; }
 
 // CHECK-LABEL:   func.func @int8_t2memref(
-// CHECK-SAME:                             %[[VAL_0:.*]]: i8) -> memref<?xi32>
+// CHECK-SAME:                             %[[VAL_0:.*]]: i8) -> memref<?xi32> attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.extui %[[VAL_0]] : i8 to i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.inttoptr %[[VAL_1]] : i64 to !llvm.ptr<i32>
-// CHECK-NEXT:      %[[VAL_3:.*]] = "polygeist.pointer2memref"(%[[VAL_2]]) : (!llvm.ptr<i32>) -> memref<?xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.inttoptr %[[VAL_1]] : i64 to !llvm.ptr
+// CHECK-NEXT:      %[[VAL_3:.*]] = "polygeist.pointer2memref"(%[[VAL_2]]) : (!llvm.ptr) -> memref<?xi32>
 // CHECK-NEXT:      return %[[VAL_3]] : memref<?xi32>
 // CHECK-NEXT:    }
 int *int8_t2memref(uint8_t i) { return (int *)i; }

--- a/polygeist/tools/cgeist/Test/Verification/ker.c
+++ b/polygeist/tools/cgeist/Test/Verification/ker.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s --function=kernel_deriche -S | FileCheck %s
-// RUN: cgeist %s --function=kernel_deriche -S -memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist --use-opaque-pointers %s --function=kernel_deriche -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=kernel_deriche -S -memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 int kernel_deriche(int a[30][40]) {
     a[3][5]++;

--- a/polygeist/tools/cgeist/Test/Verification/label.c
+++ b/polygeist/tools/cgeist/Test/Verification/label.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
 
 int fir (int d_i[1000], int idx[1000] ) {
 	int i;

--- a/polygeist/tools/cgeist/Test/Verification/ler.c
+++ b/polygeist/tools/cgeist/Test/Verification/ler.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=kernel_deriche -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=kernel_deriche -S | FileCheck %s
 
 int kernel_deriche(int *a) {
     a[3]++;

--- a/polygeist/tools/cgeist/Test/Verification/loop.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/loop.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O2 --function=* -S | FileCheck %s
 
 int MAX_DIMS;
 static short S;
@@ -16,42 +16,43 @@ void div_(int* sizes, short k) {
   }
 }
 
-// CHECK-LABEL: memref.global @MAX_DIMS : memref<i32> = dense<0> {alignment = 4 : i64}
-// CHECK-LABEL: memref.global "private" @_ZL1S : memref<i16> = dense<0> {alignment = 2 : i64}
+// CHECK-LABEL:   memref.global @MAX_DIMS : memref<i32> = dense<0> {alignment = 4 : i64}
+// CHECK-NEXT:    memref.global "private" @_ZL1S : memref<i16> = dense<0> {alignment = 2 : i64}
 
-// CHECK-LABEL: func.func @_Z4div_Pis(
-// CHECK-SAME:    %[[VAL_0:.*]]: memref<?xi32>, %[[ARG_K:.*]]: i16) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-DAG:        %[[VAL_1:.*]] = arith.constant 1 : i32
-// CHECK-DAG:        %[[VAL_2:.*]] = arith.constant 0 : i32
-// CHECK-DAG:        %[[VAL_3:.*]] = arith.constant 1 : i64
-// CHECK-NEXT:       %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.array<25 x struct<(i32, f64)>> : (i64) -> !llvm.ptr<array<25 x struct<(i32, f64)>>>
-// CHECK-NEXT:       %[[VAL_K:.*]] = memref.get_global @_ZL1S : memref<i16>
-// CHECK-NEXT:       %alloca = memref.alloca() : memref<1xindex>
-// CHECK-NEXT:       %reshape = memref.reshape %[[VAL_K]](%alloca) : (memref<i16>, memref<1xindex>) -> memref<1xi16>
-// CHECK-NEXT:       affine.store %[[ARG_K]], %reshape[0] : memref<1xi16>
-// CHECK-NEXT:       %[[VAL_5:.*]] = memref.get_global @MAX_DIMS : memref<i32>
-// CHECK-NEXT:       %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0] : (!llvm.ptr<array<25 x struct<(i32, f64)>>>) -> !llvm.ptr<struct<(i32, f64)>>
-// CHECK-NEXT:       %[[VAL_7:.*]] = scf.while (%[[VAL_8:.*]] = %[[VAL_2]]) : (i32) -> i32 {
-// CHECK-NEXT:         %[[VAL_9:.*]] = memref.alloca() : memref<1xindex>
-// CHECK-NEXT:         %[[VAL_10:.*]] = memref.reshape %[[VAL_5]](%[[VAL_9]]) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
-// CHECK-NEXT:         %[[VAL_11:.*]] = affine.load %[[VAL_10]][0] : memref<1xi32>
-// CHECK-NEXT:         %[[VAL_12:.*]] = arith.cmpi slt, %[[VAL_8]], %[[VAL_11]] : i32
-// CHECK-NEXT:         scf.condition(%[[VAL_12]]) %[[VAL_8]] : i32
-// CHECK-NEXT:       } do {
-// CHECK-NEXT:       ^bb0(%[[VAL_13:.*]]: i32):
-// CHECK-NEXT:         %[[VAL_14:.*]] = arith.index_cast %[[VAL_13]] : i32 to index
-// CHECK-NEXT:         %[[VAL_15:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_14]]] : memref<?xi32>
-// CHECK-NEXT:         %alloca_0 = memref.alloca() : memref<1xindex>
-// CHECK-NEXT:         %reshape_1 = memref.reshape %1(%alloca_0) : (memref<i16>, memref<1xindex>) -> memref<1xi16>
-// CHECK-NEXT:         %[[LOAD:.*]] = affine.load %reshape_1[0] : memref<1xi16>
-// CHECK-NEXT:         %[[EXTSI:.*]] = arith.extsi %[[LOAD]] : i16 to i32
-// CHECK-NEXT:         %[[ADDI:.*]] = arith.addi %[[VAL_15]], %[[EXTSI]] : i32
-// CHECK-NEXT:         %[[VAL_16:.*]] = arith.index_cast %[[VAL_14]] : index to i64
-// CHECK-NEXT:         %[[VAL_17:.*]] = llvm.getelementptr %[[VAL_6]]{{\[}}%[[VAL_16]]] : (!llvm.ptr<struct<(i32, f64)>>, i64) -> !llvm.ptr<struct<(i32, f64)>>
-// CHECK-NEXT:         %[[VAL_18:.*]] = llvm.getelementptr inbounds %[[VAL_17]][0, 0] : (!llvm.ptr<struct<(i32, f64)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:         llvm.store %[[ADDI]], %[[VAL_18]] : !llvm.ptr<i32>
-// CHECK-NEXT:         %[[VAL_19:.*]] = arith.addi %[[VAL_13]], %[[VAL_1]] : i32
-// CHECK-NEXT:         scf.yield %[[VAL_19]] : i32
-// CHECK-NEXT:       }
-// CHECK-NEXT:       return
-// CHECK-NEXT:     }
+// CHECK-LABEL:   func.func @_Z4div_Pis(
+// CHECK-SAME:                          %[[VAL_0:.*]]: memref<?xi32>,
+// CHECK-SAME:                          %[[VAL_1:.*]]: i16) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i32
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.alloca %[[VAL_4]] x !llvm.array<25 x struct<(i32, f64)>> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_6:.*]] = memref.get_global @_ZL1S : memref<i16>
+// CHECK-NEXT:      %[[VAL_7:.*]] = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:      %[[VAL_8:.*]] = memref.reshape %[[VAL_6]](%[[VAL_7]]) : (memref<i16>, memref<1xindex>) -> memref<1xi16>
+// CHECK-NEXT:      affine.store %[[VAL_1]], %[[VAL_8]][0] : memref<1xi16>
+// CHECK-NEXT:      %[[VAL_9:.*]] = memref.get_global @MAX_DIMS : memref<i32>
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_5]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<25 x struct<(i32, f64)>>
+// CHECK-NEXT:      %[[VAL_11:.*]] = scf.while (%[[VAL_12:.*]] = %[[VAL_3]]) : (i32) -> i32 {
+// CHECK-NEXT:        %[[VAL_13:.*]] = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:        %[[VAL_14:.*]] = memref.reshape %[[VAL_9]](%[[VAL_13]]) : (memref<i32>, memref<1xindex>) -> memref<1xi32>
+// CHECK-NEXT:        %[[VAL_15:.*]] = affine.load %[[VAL_14]][0] : memref<1xi32>
+// CHECK-NEXT:        %[[VAL_16:.*]] = arith.cmpi slt, %[[VAL_12]], %[[VAL_15]] : i32
+// CHECK-NEXT:        scf.condition(%[[VAL_16]]) %[[VAL_12]] : i32
+// CHECK-NEXT:      } do {
+// CHECK-NEXT:      ^bb0(%[[VAL_17:.*]]: i32):
+// CHECK-NEXT:        %[[VAL_18:.*]] = arith.index_cast %[[VAL_17]] : i32 to index
+// CHECK-NEXT:        %[[VAL_19:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_18]]] : memref<?xi32>
+// CHECK-NEXT:        %[[VAL_20:.*]] = memref.alloca() : memref<1xindex>
+// CHECK-NEXT:        %[[VAL_21:.*]] = memref.reshape %[[VAL_6]](%[[VAL_20]]) : (memref<i16>, memref<1xindex>) -> memref<1xi16>
+// CHECK-NEXT:        %[[VAL_22:.*]] = affine.load %[[VAL_21]][0] : memref<1xi16>
+// CHECK-NEXT:        %[[VAL_23:.*]] = arith.extsi %[[VAL_22]] : i16 to i32
+// CHECK-NEXT:        %[[VAL_24:.*]] = arith.addi %[[VAL_19]], %[[VAL_23]] : i32
+// CHECK-NEXT:        %[[VAL_25:.*]] = arith.index_cast %[[VAL_18]] : index to i64
+// CHECK-NEXT:        %[[VAL_26:.*]] = llvm.getelementptr %[[VAL_10]]{{\[}}%[[VAL_25]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<(i32, f64)>
+// CHECK-NEXT:        %[[VAL_27:.*]] = llvm.getelementptr inbounds %[[VAL_26]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, f64)>
+// CHECK-NEXT:        llvm.store %[[VAL_24]], %[[VAL_27]] : i32, !llvm.ptr
+// CHECK-NEXT:        %[[VAL_28:.*]] = arith.addi %[[VAL_17]], %[[VAL_2]] : i32
+// CHECK-NEXT:        scf.yield %[[VAL_28]] : i32
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/loopinc.c
+++ b/polygeist/tools/cgeist/Test/Verification/loopinc.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=test -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=test -S | FileCheck %s
 
 // TODO
 // XFAIL: * 

--- a/polygeist/tools/cgeist/Test/Verification/lower-to-linalg-op.c
+++ b/polygeist/tools/cgeist/Test/Verification/lower-to-linalg-op.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -S | FileCheck %s
 
 #pragma lower_to(copy_op, "memref.copy") "input"(a), "output"(b)
 void copy_op(int b[3][3], int a[3][3]) {

--- a/polygeist/tools/cgeist/Test/Verification/lower_to.c
+++ b/polygeist/tools/cgeist/Test/Verification/lower_to.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=foo -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=foo -S | FileCheck %s
 
 #pragma lower_to(bar, "arith.addf")
 extern float bar(float a, float b);

--- a/polygeist/tools/cgeist/Test/Verification/lowerrecur.c
+++ b/polygeist/tools/cgeist/Test/Verification/lowerrecur.c
@@ -1,5 +1,9 @@
 // RUN: cgeist %s --function=* -emit-llvm -S | FileCheck %s
 
+// TODO: This test case does not yet work with opaque pointers,
+// as it requires the Polygeist transformations to work correctly
+// with opaque pointers.
+
 struct X{
  double* a;
  double* b;

--- a/polygeist/tools/cgeist/Test/Verification/lum.c
+++ b/polygeist/tools/cgeist/Test/Verification/lum.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=test -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=test -S | FileCheck %s
 
 int test() {
     return -3;

--- a/polygeist/tools/cgeist/Test/Verification/malloc.c
+++ b/polygeist/tools/cgeist/Test/Verification/malloc.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=caller %stdinclude -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=caller %stdinclude -S | FileCheck %s
 
 #include <stdlib.h>
 

--- a/polygeist/tools/cgeist/Test/Verification/memcpystruct.c
+++ b/polygeist/tools/cgeist/Test/Verification/memcpystruct.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 -w %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 -w %s --function=* -S | FileCheck %s
 
 struct N {
     int a;
@@ -9,11 +9,12 @@ void copy(struct N* dst, void* src) {
     __builtin_memcpy(dst, src, sizeof(struct N));
 }
 
-// CHECK:   func @copy(%arg0: !llvm.ptr<struct<(i32, i32)>>, %arg1: !llvm.ptr<i8>) attributes {llvm.linkage = #llvm.linkage<external>}
-// CHECK-DAG:      %false = arith.constant false
-// CHECK-DAG:      %c8_i64 = arith.constant 8 : i64
-// CHECK-DAG:      %0 = llvm.bitcast %arg0 : !llvm.ptr<struct<(i32, i32)>> to !llvm.ptr<i8>
-// CHECK-NEXT:     "llvm.intr.memcpy"(%0, %arg1, %c8_i64, %false) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64, i1) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @copy(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                    %[[VAL_1:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 8 : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.constant false
+// CHECK-NEXT:      "llvm.intr.memcpy"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]]) : (!llvm.ptr, !llvm.ptr, i64, i1) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
 

--- a/polygeist/tools/cgeist/Test/Verification/memref-fullrank.c
+++ b/polygeist/tools/cgeist/Test/Verification/memref-fullrank.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -S -memref-fullrank -O0 | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -S -memref-fullrank -O0 | FileCheck %s
 
 #include <stdio.h>
 

--- a/polygeist/tools/cgeist/Test/Verification/memrefaddassign.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/memrefaddassign.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -c -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -c -S | FileCheck %s
 
 float *foo(float *a) {
 	a += 32;

--- a/polygeist/tools/cgeist/Test/Verification/mer.c
+++ b/polygeist/tools/cgeist/Test/Verification/mer.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s --function=kernel_deriche -S | FileCheck %s
-// RUN: cgeist %s --function=kernel_deriche -S -memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist --use-opaque-pointers %s --function=kernel_deriche -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=kernel_deriche -S -memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 int kernel_deriche(int a[30]) {
     a[0]++;

--- a/polygeist/tools/cgeist/Test/Verification/min.c
+++ b/polygeist/tools/cgeist/Test/Verification/min.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=min -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=min -S | FileCheck %s
 
 // TODO combine selects
 

--- a/polygeist/tools/cgeist/Test/Verification/minus.c
+++ b/polygeist/tools/cgeist/Test/Verification/minus.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 %s --function=* -S | FileCheck %s
 
 typedef char char_vec __attribute__((ext_vector_type(3)));
 typedef short short_vec __attribute__((ext_vector_type(3)));

--- a/polygeist/tools/cgeist/Test/Verification/mul.c
+++ b/polygeist/tools/cgeist/Test/Verification/mul.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 %s --function=* -S | FileCheck %s
 
 typedef char char_vec __attribute__((ext_vector_type(3)));
 typedef short short_vec __attribute__((ext_vector_type(3)));

--- a/polygeist/tools/cgeist/Test/Verification/multidim_init.c
+++ b/polygeist/tools/cgeist/Test/Verification/multidim_init.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -S --function=* --raise-scf-to-affine=false | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -S --function=* --raise-scf-to-affine=false | FileCheck %s
 
   float glob_A[][4] = {
       {1.0f, 2.0, 3.0, 4.0}, 

--- a/polygeist/tools/cgeist/Test/Verification/nestloop.c
+++ b/polygeist/tools/cgeist/Test/Verification/nestloop.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s %stdinclude --function=init_array -S --raise-scf-to-affine=false | FileCheck %s
-// RUN: cgeist %s %stdinclude --function=init_array -S -memref-fullrank --raise-scf-to-affine=false | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist --use-opaque-pointers %s %stdinclude --function=init_array -S --raise-scf-to-affine=false | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s %stdinclude --function=init_array -S -memref-fullrank --raise-scf-to-affine=false | FileCheck %s --check-prefix=FULLRANK
 
 #include <stdio.h>
 #include <unistd.h>

--- a/polygeist/tools/cgeist/Test/Verification/new.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/new.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 -w %s %stdinclude --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 -w %s %stdinclude --function=* -S | FileCheck %s
 
 #include <stdio.h>
 
@@ -9,18 +9,18 @@ struct A {
 void f(A *a) { printf("a.x = %f, a.y = %f\n", a->x, a->y); }
 
 int main(int argc, char const *argv[]) {
-  // CHECK-DAG:    %c8_i64 = arith.constant 8 : i64
-  // CHECK-DAG:    %cst = arith.constant 2.000000e+00 : f32
-  // CHECK-DAG:    %cst_0 = arith.constant 1.000000e+00 : f32
-  // CHECK-DAG:    %c0_i32 = arith.constant 0 : i32
-  // CHECK:        %0 = llvm.call @malloc(%c8_i64) : (i64) -> !llvm.ptr<i8>
-  // CHECK-NEXT:   %1 = llvm.bitcast %0 : !llvm.ptr<i8> to !llvm.ptr<struct<(f32, f32)>>
-  // CHECK-NEXT:   %2 = llvm.getelementptr inbounds %1[0, 0] : (!llvm.ptr<struct<(f32, f32)>>) -> !llvm.ptr<f32>
-  // CHECK-NEXT:   llvm.store %cst_0, %2 : !llvm.ptr<f32>
-  // CHECK-NEXT:   %3 = llvm.getelementptr inbounds %1[0, 1] : (!llvm.ptr<struct<(f32, f32)>>) -> !llvm.ptr<f32>
-  // CHECK-NEXT:   llvm.store %cst, %3 : !llvm.ptr<f32>
-  // CHECK-NEXT:   call @_Z1fP1A(%1) : (!llvm.ptr<struct<(f32, f32)>>) -> ()
-  // CHECK-NEXT:   return %c0_i32 : i32
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 8 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 0 : i32
+// CHECK-DAG:       %[[VAL_4:.*]] = arith.constant 2.000000e+00 : f32
+// CHECK-DAG:       %[[VAL_5:.*]] = arith.constant 1.000000e+00 : f32
+// CHECK:           %[[VAL_6:.*]] = llvm.call @malloc(%[[VAL_2]]) : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.getelementptr inbounds %[[VAL_6]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f32, f32)>
+// CHECK-NEXT:      llvm.store %[[VAL_5]], %[[VAL_7]] : f32, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_6]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f32, f32)>
+// CHECK-NEXT:      llvm.store %[[VAL_4]], %[[VAL_8]] : f32, !llvm.ptr
+// CHECK-NEXT:      call @_Z1fP1A(%[[VAL_6]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      return %[[VAL_3]] : i32
+// CHECK-NEXT:    }
 
   auto *a = new A{1.0f, 2.0f};
   f(a);

--- a/polygeist/tools/cgeist/Test/Verification/no_inline.c
+++ b/polygeist/tools/cgeist/Test/Verification/no_inline.c
@@ -1,5 +1,5 @@
-// RUN: cgeist -S -O0 %s | FileCheck %s
-// RUN: cgeist -S -O1 %s | FileCheck %s --check-prefix=OPT1
+// RUN: cgeist --use-opaque-pointers -S -O0 %s | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -S -O1 %s | FileCheck %s --check-prefix=OPT1
 
 void foo(int A[10]) {
 #pragma scop

--- a/polygeist/tools/cgeist/Test/Verification/nocond.c
+++ b/polygeist/tools/cgeist/Test/Verification/nocond.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 int run();
 

--- a/polygeist/tools/cgeist/Test/Verification/nulretstruct.c
+++ b/polygeist/tools/cgeist/Test/Verification/nulretstruct.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -S --function=* %s | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -S --function=* %s | FileCheck %s
 
 struct C {
   int a;
@@ -13,12 +13,13 @@ float* makeF() {
     return (float*)0;
 }
 
-// CHECK:   func @make() -> !llvm.ptr<!llvm.struct<(i32, memref<?xf64>)>> attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %0 = llvm.mlir.null : !llvm.ptr<!llvm.struct<(i32, memref<?xf64>)>>
-// CHECK-NEXT:     return %0 : !llvm.ptr<!llvm.struct<(i32, memref<?xf64>)>>
-// CHECK-NEXT:   }
-// CHECK:   func @makeF() -> memref<?xf32> attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %0 = llvm.mlir.null : !llvm.ptr<i8>
-// CHECK-NEXT:     %1 = "polygeist.pointer2memref"(%0) : (!llvm.ptr<i8>) -> memref<?xf32>
-// CHECK-NEXT:     return %1 : memref<?xf32>
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @make() -> !llvm.ptr attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-NEXT:      return %[[VAL_0]] : !llvm.ptr
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @makeF() -> memref<?xf32> attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-NEXT:      %[[VAL_1:.*]] = "polygeist.pointer2memref"(%[[VAL_0]]) : (!llvm.ptr) -> memref<?xf32>
+// CHECK-NEXT:      return %[[VAL_1]] : memref<?xf32>
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/nus.c
+++ b/polygeist/tools/cgeist/Test/Verification/nus.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s -O2 --function=kernel_nussinov -S | FileCheck %s
-// RUN: cgeist %s -O2 --function=kernel_nussinov -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist --use-opaque-pointers %s -O2 --function=kernel_nussinov -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O2 --function=kernel_nussinov -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 #define N 5500
 #define max_score(s1, s2) ((s1 >= s2) ? s1 : s2)

--- a/polygeist/tools/cgeist/Test/Verification/omp.c
+++ b/polygeist/tools/cgeist/Test/Verification/omp.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -fopenmp -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -fopenmp -S | FileCheck %s
 
 void square(double* x, int sstart, int send, int sinc) {
     #pragma omp parallel for

--- a/polygeist/tools/cgeist/Test/Verification/omp2.c
+++ b/polygeist/tools/cgeist/Test/Verification/omp2.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -fopenmp -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -fopenmp -S | FileCheck %s
 
 void square2(double** x, int sstart, int send, int sinc, int tstart, int tend, int tinc) {
     #pragma omp parallel for collapse(2)

--- a/polygeist/tools/cgeist/Test/Verification/omp3.c
+++ b/polygeist/tools/cgeist/Test/Verification/omp3.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -fopenmp -S --raise-scf-to-affine=false | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -fopenmp -S --raise-scf-to-affine=false | FileCheck %s
 
 void square(double* x) {
     int i;

--- a/polygeist/tools/cgeist/Test/Verification/omp4.c
+++ b/polygeist/tools/cgeist/Test/Verification/omp4.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -fopenmp -S --raise-scf-to-affine=false | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -fopenmp -S --raise-scf-to-affine=false | FileCheck %s
 
 int get(int);
 void square(double* x, int ss) {

--- a/polygeist/tools/cgeist/Test/Verification/omp5.c
+++ b/polygeist/tools/cgeist/Test/Verification/omp5.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -fopenmp -S --raise-scf-to-affine=false | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -fopenmp -S --raise-scf-to-affine=false | FileCheck %s
 
 void square(double* x, int sstart, int send, int sinc) {
     #pragma omp parallel for

--- a/polygeist/tools/cgeist/Test/Verification/or.c
+++ b/polygeist/tools/cgeist/Test/Verification/or.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 %s --function=* -S | FileCheck %s
 
 typedef char char_vec __attribute__((ext_vector_type(3)));
 typedef short short_vec __attribute__((ext_vector_type(3)));

--- a/polygeist/tools/cgeist/Test/Verification/packedstruct.c
+++ b/polygeist/tools/cgeist/Test/Verification/packedstruct.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 struct meta {
     long long a;
@@ -16,12 +16,13 @@ void compute(struct fin f) {
     run(f.f, f.dtype);
 }
 
-// CHECK:   func @compute(%arg0: !llvm.ptr<struct<(struct<(i64, i8)>, i8)>>) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(i64, i8)>, i8)>>) -> !llvm.ptr<struct<(i64, i8)>>
-// CHECK-NEXT:     %1 = llvm.load %0 : !llvm.ptr<struct<(i64, i8)>>
-// CHECK-NEXT:     %2 = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<struct<(struct<(i64, i8)>, i8)>>) -> !llvm.ptr<i8>
-// CHECK-NEXT:     %3 = llvm.load %2 : !llvm.ptr<i8>
-// CHECK-NEXT:     %4 = call @run(%1, %3) : (!llvm.struct<(i64, i8)>, i8) -> i64
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @compute(
+// CHECK-SAME:                       %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(i64, i8)>, i8)>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr -> !llvm.struct<(i64, i8)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(i64, i8)>, i8)>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> i8
+// CHECK-NEXT:      %[[VAL_5:.*]] = call @run(%[[VAL_2]], %[[VAL_4]]) : (!llvm.struct<(i64, i8)>, i8) -> i64
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
 

--- a/polygeist/tools/cgeist/Test/Verification/pair.c
+++ b/polygeist/tools/cgeist/Test/Verification/pair.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 -w %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 -w %s --function=* -S | FileCheck %s
 
 typedef struct {
   int a, b;
@@ -18,30 +18,33 @@ int create() {
   return p2.a;
 }
 
-// CHECK:    func.func @byval(%arg0: !llvm.struct<(i32, i32)>, %arg1: i32) -> !llvm.struct<(i32, i32)>
-// CHECK-NEXT:    %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:    %0 = llvm.alloca %c1_i64 x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    llvm.store %arg0, %0 : !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    %1 = llvm.getelementptr inbounds %0[0, 1] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:    llvm.store %arg1, %1 : !llvm.ptr<i32>
-// CHECK-NEXT:    %2 = llvm.load %0 : !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    return %2 : !llvm.struct<(i32, i32)>
-// CHECK-NEXT:   }
-// CHECK:   func @create() -> i32
-// CHECK-DAG:     %c2_i32 = arith.constant 2 : i32
-// CHECK-DAG:     %c1_i32 = arith.constant 1 : i32
-// CHECK-DAG:     %c0_i32 = arith.constant 0 : i32
-// CHECK-DAG:     %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:    %0 = llvm.alloca %c1_i64 x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    %1 = llvm.alloca %c1_i64 x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    %2 = llvm.getelementptr inbounds %1[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:    llvm.store %c0_i32, %2 : !llvm.ptr<i32>
-// CHECK-NEXT:    %3 = llvm.getelementptr inbounds %1[0, 1] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:    llvm.store %c1_i32, %3 : !llvm.ptr<i32>
-// CHECK-NEXT:    %4 = llvm.load %1 : !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    %5 = call @byval0(%4, %c2_i32) : (!llvm.struct<(i32, i32)>, i32) -> !llvm.struct<(i32, i32)>
-// CHECK-NEXT:    llvm.store %5, %0 : !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    %6 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:    %7 = llvm.load %6 : !llvm.ptr<i32>
-// CHECK-NEXT:    return %7 : i32
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @byval(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.struct<(i32, i32)>,
+// CHECK-SAME:                     %[[VAL_1:.*]]: i32) -> !llvm.struct<(i32, i32)> attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      llvm.store %[[VAL_0]], %[[VAL_3]] : !llvm.struct<(i32, i32)>, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i32)>
+// CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_4]] : i32, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> !llvm.struct<(i32, i32)>
+// CHECK-NEXT:      return %[[VAL_5]] : !llvm.struct<(i32, i32)>
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @create() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : i32
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_5]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i32)>
+// CHECK-NEXT:      llvm.store %[[VAL_2]], %[[VAL_6]] : i32, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.getelementptr inbounds %[[VAL_5]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i32)>
+// CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_7]] : i32, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> !llvm.struct<(i32, i32)>
+// CHECK-NEXT:      %[[VAL_9:.*]] = call @byval0(%[[VAL_8]], %[[VAL_0]]) : (!llvm.struct<(i32, i32)>, i32) -> !llvm.struct<(i32, i32)>
+// CHECK-NEXT:      llvm.store %[[VAL_9]], %[[VAL_4]] : !llvm.struct<(i32, i32)>, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i32)>
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.load %[[VAL_10]] : !llvm.ptr -> i32
+// CHECK-NEXT:      return %[[VAL_11]] : i32
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/pairinit.c
+++ b/polygeist/tools/cgeist/Test/Verification/pairinit.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 -w %s --function=func -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 -w %s --function=func -S | FileCheck %s
 
 struct pair {
     int x, y;
@@ -9,14 +9,15 @@ struct pair func() {
     return tmp;
 }
 
-// CHECK:    func.func @func() -> !llvm.struct<(i32, i32)> attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-DAG:     %c3_i32 = arith.constant 3 : i32
-// CHECK-DAG:     %c2_i32 = arith.constant 2 : i32
-// CHECK-DAG:     %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:    %0 = llvm.alloca %c1_i64 x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:    llvm.store %c2_i32, %1 : !llvm.ptr<i32>
-// CHECK-NEXT:    %2 = llvm.getelementptr inbounds %0[0, 1] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:    llvm.store %c3_i32, %2 : !llvm.ptr<i32>
-// CHECK-NEXT:    %3 = llvm.load %0 : !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    return %3 : !llvm.struct<(i32, i32)>
+// CHECK-LABEL:   func.func @func() -> !llvm.struct<(i32, i32)> attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 3 : i32
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 2 : i32
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i32)>
+// CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_4]] : i32, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_3]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i32)>
+// CHECK-NEXT:      llvm.store %[[VAL_0]], %[[VAL_5]] : i32, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> !llvm.struct<(i32, i32)>
+// CHECK-NEXT:      return %[[VAL_6]] : !llvm.struct<(i32, i32)>
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/pairptr.c
+++ b/polygeist/tools/cgeist/Test/Verification/pairptr.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 -w %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 -w %s --function=* -S | FileCheck %s
 
 typedef struct {
   int a, b;
@@ -17,24 +17,28 @@ int create() {
   return p2.a;
 }
 
-// CHECK:     func.func @byval(%arg0: !llvm.ptr<struct<(i32, i32)>>, %arg1: i32) -> !llvm.struct<(i32, i32)> attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:    %0 = llvm.load %arg0 : !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    return %0 : !llvm.struct<(i32, i32)>
-// CHECK-NEXT:  }
-// CHECK:   func @create() -> i32
-// CHECK-DAG:     %c2_i32 = arith.constant 2 : i32
-// CHECK-DAG:     %c1_i32 = arith.constant 1 : i32
-// CHECK-DAG:     %c0_i32 = arith.constant 0 : i32
-// CHECK-DAG:     %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:    %0 = llvm.alloca %c1_i64 x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    %1 = llvm.alloca %c1_i64 x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    %2 = llvm.getelementptr inbounds %1[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:    llvm.store %c0_i32, %2 : !llvm.ptr<i32>
-// CHECK-NEXT:    %3 = llvm.getelementptr inbounds %1[0, 1] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:    llvm.store %c1_i32, %3 : !llvm.ptr<i32>
-// CHECK-NEXT:    %4 = call @byval0(%1, %c2_i32) : (!llvm.ptr<struct<(i32, i32)>>, i32) -> !llvm.struct<(i32, i32)>
-// CHECK-NEXT:    llvm.store %4, %0 : !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:    %5 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:    %6 = llvm.load %5 : !llvm.ptr<i32>
-// CHECK-NEXT:    return %6 : i32
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @byval(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                     %[[VAL_1:.*]]: i32) -> !llvm.struct<(i32, i32)> attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_0]] : !llvm.ptr -> !llvm.struct<(i32, i32)>
+// CHECK-NEXT:      return %[[VAL_2]] : !llvm.struct<(i32, i32)>
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @create() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 2 : i32
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i32
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_5]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i32)>
+// CHECK-NEXT:      llvm.store %[[VAL_2]], %[[VAL_6]] : i32, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.getelementptr inbounds %[[VAL_5]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i32)>
+// CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_7]] : i32, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_8:.*]] = call @byval0(%[[VAL_5]], %[[VAL_0]]) : (!llvm.ptr, i32) -> !llvm.struct<(i32, i32)>
+// CHECK-NEXT:      llvm.store %[[VAL_8]], %[[VAL_4]] : !llvm.struct<(i32, i32)>, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i32)>
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr -> i32
+// CHECK-NEXT:      return %[[VAL_10]] : i32
+// CHECK-NEXT:    }
+// CHECK-NEXT:    func.func private @byval0(!llvm.ptr, i32) -> !llvm.struct<(i32, i32)> attributes {llvm.linkage = #llvm.linkage<external>}

--- a/polygeist/tools/cgeist/Test/Verification/palloc.c
+++ b/polygeist/tools/cgeist/Test/Verification/palloc.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s %stdinclude --function=init_array -S | FileCheck %s
-// RUN: cgeist %s %stdinclude --function=init_array -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist --use-opaque-pointers %s %stdinclude --function=init_array -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s %stdinclude --function=init_array -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 #include <stdio.h>
 #include <unistd.h>

--- a/polygeist/tools/cgeist/Test/Verification/plus.c
+++ b/polygeist/tools/cgeist/Test/Verification/plus.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+// RUN: cgeist -O0 --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 typedef char char_vec __attribute__((ext_vector_type(3)));
 typedef short short_vec __attribute__((ext_vector_type(3)));

--- a/polygeist/tools/cgeist/Test/Verification/ptr2integral.c
+++ b/polygeist/tools/cgeist/Test/Verification/ptr2integral.c
@@ -1,34 +1,34 @@
-// RUN: cgeist %s --function=* -S -O0 -w | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S -O0 -w | FileCheck %s
 
 #include <stdint.h>
 #include <stdlib.h>
 
 // CHECK-LABEL:   func.func @ptr2size_t(
-// CHECK-SAME:                          %[[VAL_0:.*]]: !llvm.ptr<i8>) -> i64
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.ptrtoint %[[VAL_0]] : !llvm.ptr<i8> to i64
+// CHECK-SAME:                          %[[VAL_0:.*]]: !llvm.ptr) -> i64 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.ptrtoint %[[VAL_0]] : !llvm.ptr to i64
 // CHECK-NEXT:      return %[[VAL_1]] : i64
 // CHECK-NEXT:    }
 size_t ptr2size_t(void * i) { return (size_t)i; }
 
 // CHECK-LABEL:   func.func @ptr2int8_t(
-// CHECK-SAME:                          %[[VAL_0:.*]]: !llvm.ptr<i8>) -> i8
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.ptrtoint %[[VAL_0]] : !llvm.ptr<i8> to i8
+// CHECK-SAME:                          %[[VAL_0:.*]]: !llvm.ptr) -> i8 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.ptrtoint %[[VAL_0]] : !llvm.ptr to i8
 // CHECK-NEXT:      return %[[VAL_1]] : i8
 // CHECK-NEXT:    }
 int8_t ptr2int8_t(void * i) { return (int8_t)i; }
 
 // CHECK-LABEL:   func.func @memref2size_t(
-// CHECK-SAME:                             %[[VAL_0:.*]]: memref<?xi32>) -> i64
-// CHECK-NEXT:      %[[VAL_1:.*]] = "polygeist.memref2pointer"(%[[VAL_0]]) : (memref<?xi32>) -> !llvm.ptr<i32>
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.ptrtoint %[[VAL_1]] : !llvm.ptr<i32> to i64
+// CHECK-SAME:                             %[[VAL_0:.*]]: memref<?xi32>) -> i64 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = "polygeist.memref2pointer"(%[[VAL_0]]) : (memref<?xi32>) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.ptrtoint %[[VAL_1]] : !llvm.ptr to i64
 // CHECK-NEXT:      return %[[VAL_2]] : i64
 // CHECK-NEXT:    }
 size_t memref2size_t(int * i) { return (size_t)i; }
 
 // CHECK-LABEL:   func.func @memref2int8_t(
-// CHECK-SAME:                             %[[VAL_0:.*]]: memref<?xi32>) -> i8
-// CHECK-NEXT:      %[[VAL_1:.*]] = "polygeist.memref2pointer"(%[[VAL_0]]) : (memref<?xi32>) -> !llvm.ptr<i32>
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.ptrtoint %[[VAL_1]] : !llvm.ptr<i32> to i8
+// CHECK-SAME:                             %[[VAL_0:.*]]: memref<?xi32>) -> i8 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = "polygeist.memref2pointer"(%[[VAL_0]]) : (memref<?xi32>) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.ptrtoint %[[VAL_1]] : !llvm.ptr to i8
 // CHECK-NEXT:      return %[[VAL_2]] : i8
 // CHECK-NEXT:    }
 uint8_t memref2int8_t(int * i) { return (uint8_t)i; }

--- a/polygeist/tools/cgeist/Test/Verification/ptraddsub.c
+++ b/polygeist/tools/cgeist/Test/Verification/ptraddsub.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O2 --function=* -S | FileCheck %s
 
 int sub() {
     int data[10];
@@ -11,21 +11,22 @@ int* add (int* in) {
 	return &in[7];
 }
 
-// CHECK:   func @sub() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-DAG:     %c4_i64 = arith.constant 4 : i64
-// CHECK-NEXT:     %alloca = memref.alloca() : memref<10xi32>
-// CHECK-NEXT:     %0 = "polygeist.memref2pointer"(%alloca) : (memref<10xi32>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     %1 = llvm.getelementptr %0[7] : (!llvm.ptr<i32>) -> !llvm.ptr<i32>
-// CHECK-DAG:     %[[i3:.+]] = llvm.ptrtoint %0 : !llvm.ptr<i32> to i64
-// CHECK-DAG:     %[[i4:.+]] = llvm.ptrtoint %1 : !llvm.ptr<i32> to i64
-// CHECK-NEXT:     %4 = arith.subi %[[i4]], %[[i3]] : i64
-// CHECK-NEXT:     %5 = arith.divsi %4, %c4_i64 : i64
-// CHECK-NEXT:     %6 = arith.trunci %5 : i64 to i32
-// CHECK-NEXT:     return %6 : i32
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @sub() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 4 : i64
+// CHECK-NEXT:      %[[VAL_1:.*]] = memref.alloca() : memref<10xi32>
+// CHECK-NEXT:      %[[VAL_2:.*]] = "polygeist.memref2pointer"(%[[VAL_1]]) : (memref<10xi32>) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_2]][7] : (!llvm.ptr) -> !llvm.ptr, i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.ptrtoint %[[VAL_3]] : !llvm.ptr to i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.ptrtoint %[[VAL_2]] : !llvm.ptr to i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.subi %[[VAL_4]], %[[VAL_5]] : i64
+// CHECK-NEXT:      %[[VAL_7:.*]] = arith.divsi %[[VAL_6]], %[[VAL_0]] : i64
+// CHECK-NEXT:      %[[VAL_8:.*]] = arith.trunci %[[VAL_7]] : i64 to i32
+// CHECK-NEXT:      return %[[VAL_8]] : i32
+// CHECK-NEXT:    }
 
-// CHECK:   func @add(%arg0: memref<?xi32>) -> memref<?xi32> attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %c7 = arith.constant 7 : index
-// CHECK-NEXT:     %0 = "polygeist.subindex"(%arg0, %c7) : (memref<?xi32>, index) -> memref<?xi32>
-// CHECK-NEXT:     return %0 : memref<?xi32>
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @add(
+// CHECK-SAME:                   %[[VAL_0:.*]]: memref<?xi32>) -> memref<?xi32> attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 7 : index
+// CHECK-NEXT:      %[[VAL_2:.*]] = "polygeist.subindex"(%[[VAL_0]], %[[VAL_1]]) : (memref<?xi32>, index) -> memref<?xi32>
+// CHECK-NEXT:      return %[[VAL_2]] : memref<?xi32>
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/ptrarith.c
+++ b/polygeist/tools/cgeist/Test/Verification/ptrarith.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 #include <stddef.h>
 
@@ -27,9 +27,9 @@ int *f1(size_t index, int *ptr) {
 }
 
 // CHECK-LABEL:   func.func @f2(
-// CHECK-SAME:                  %[[VAL_0:.*]]: i64) -> !llvm.ptr<i8>
-// CHECK:           %[[PTR_0:.*]] = llvm.inttoptr %[[VAL_0]] : i64 to !llvm.ptr<i8>
-// CHECK:           return %[[PTR_0]] : !llvm.ptr<i8>
+// CHECK-SAME:                  %[[VAL_0:.*]]: i64) -> !llvm.ptr
+// CHECK:           %[[PTR_0:.*]] = llvm.inttoptr %[[VAL_0]] : i64 to !llvm.ptr
+// CHECK:           return %[[PTR_0]] : !llvm.ptr
 // CHECK:         }
 
 void *f2(size_t index) {
@@ -51,10 +51,10 @@ int *f3(int *ptr, size_t index) {
 }
 
 // CHECK-LABEL:   func.func @f4(
-// CHECK-SAME:                  %[[VAL_0:.*]]: !llvm.ptr<i8>,
-// CHECK-SAME:                  %[[VAL_1:.*]]: i64) -> !llvm.ptr<i8>
-// CHECK:           %[[ADD:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<i8>, i64) -> !llvm.ptr<i8>
-// CHECK:           return %[[ADD]] : !llvm.ptr<i8>
+// CHECK-SAME:                  %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                  %[[VAL_1:.*]]: i64) -> !llvm.ptr attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK:           %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+// CHECK:           return %[[VAL_2]] : !llvm.ptr
 // CHECK:         }
 
 void *f4(void *ptr, size_t index) {
@@ -62,15 +62,12 @@ void *f4(void *ptr, size_t index) {
 }
 
 // CHECK-LABEL:   func.func @f5(
-// CHECK-SAME:                  %[[VAL_0:.*]]: !llvm.ptr<func<i32 ()>>,
-// CHECK-SAME:                  %[[VAL_1:.*]]: i64) -> i32
-// CHECK:           %[[VOIDPTR_0:.*]] = llvm.bitcast %[[VAL_0]] : !llvm.ptr<func<i32 ()>> to !llvm.ptr<i8>
-// CHECK:           %[[PTR:.*]] = llvm.getelementptr %[[VOIDPTR_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<i8>, i64) -> !llvm.ptr<i8>
-// CHECK:           %[[FUNCPTR:.*]] = llvm.bitcast %[[PTR]] : !llvm.ptr<i8> to !llvm.ptr<func<i32 ()>>
-// CHECK:           %[[RES:.*]] = llvm.call %[[FUNCPTR]]() : !llvm.ptr<func<i32 ()>>, () -> i32
-// CHECK:           return %[[RES]] : i32
+// CHECK-SAME:                  %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                  %[[VAL_1:.*]]: i64) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK:           %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+// CHECK:           %[[VAL_3:.*]] = llvm.call %[[VAL_2]]() : !llvm.ptr, () -> i32
+// CHECK:           return %[[VAL_3]] : i32
 // CHECK:         }
-
 int f5(int (*ptr)(void), size_t index) {
   return (ptr + index)();
 }

--- a/polygeist/tools/cgeist/Test/Verification/raiseToAffine.c
+++ b/polygeist/tools/cgeist/Test/Verification/raiseToAffine.c
@@ -1,7 +1,7 @@
 // RUN: split-file %s %t
 
-// RUN: cgeist %t/matmul_signed_cmp.c --function=matmul --raise-scf-to-affine -S | FileCheck %s -check-prefix=GEMMSIGNED
-// RUN: cgeist %t/matmul_unsigned_cmp.c --function=matmul_unsigned_cmp --raise-scf-to-affine -S | FileCheck %s -check-prefix=GEMMUNSIGNED
+// RUN: cgeist --use-opaque-pointers %t/matmul_signed_cmp.c --function=matmul --raise-scf-to-affine -S | FileCheck %s -check-prefix=GEMMSIGNED
+// RUN: cgeist --use-opaque-pointers %t/matmul_unsigned_cmp.c --function=matmul_unsigned_cmp --raise-scf-to-affine -S | FileCheck %s -check-prefix=GEMMUNSIGNED
 
 //--- matmul_signed_cmp.c
 #define N 200

--- a/polygeist/tools/cgeist/Test/Verification/raiseToAffineUnsignedCmp.c
+++ b/polygeist/tools/cgeist/Test/Verification/raiseToAffineUnsignedCmp.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=matmul --raise-scf-to-affine -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=matmul --raise-scf-to-affine -S | FileCheck %s
 
 void matmul(float A[100][200], float B[200][300], float C[100][300]) {
   int i, j, k;

--- a/polygeist/tools/cgeist/Test/Verification/real.c
+++ b/polygeist/tools/cgeist/Test/Verification/real.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 #include <complex.h>
 

--- a/polygeist/tools/cgeist/Test/Verification/recurstruct.c
+++ b/polygeist/tools/cgeist/Test/Verification/recurstruct.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=sum -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=sum -S | FileCheck %s
 
 struct Node {
     struct Node* next;
@@ -10,20 +10,21 @@ double sum(struct Node* n) {
     return n->value + sum(n->next);
 }
 
-// CHECK:   func.func @sum(%arg0: !llvm.ptr<struct<"polygeist@mlir@struct.Node", (ptr<struct<"polygeist@mlir@struct.Node">>, f64)>>) -> f64 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-DAG:     %cst = arith.constant 0.000000e+00 : f64
-// CHECK-DAG:     %0 = llvm.mlir.null : !llvm.ptr<struct<"polygeist@mlir@struct.Node", (ptr<struct<"polygeist@mlir@struct.Node">>, f64)>>
-// CHECK-NEXT:     %1 = llvm.icmp "eq" %arg0, %0 : !llvm.ptr<struct<"polygeist@mlir@struct.Node", (ptr<struct<"polygeist@mlir@struct.Node">>, f64)>>
-// CHECK-NEXT:     %2 = scf.if %1 -> (f64) {
-// CHECK-NEXT:       scf.yield %cst : f64
-// CHECK-NEXT:     } else {
-// CHECK-NEXT:       %3 = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<struct<"polygeist@mlir@struct.Node", (ptr<struct<"polygeist@mlir@struct.Node">>, f64)>>) -> !llvm.ptr<f64>
-// CHECK-NEXT:       %4 = llvm.load %3 : !llvm.ptr<f64>
-// CHECK-NEXT:       %5 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<"polygeist@mlir@struct.Node", (ptr<struct<"polygeist@mlir@struct.Node">>, f64)>>) -> !llvm.ptr<ptr<struct<"polygeist@mlir@struct.Node", (ptr<struct<"polygeist@mlir@struct.Node">>, f64)>>>
-// CHECK-NEXT:       %6 = llvm.load %5 : !llvm.ptr<ptr<struct<"polygeist@mlir@struct.Node", (ptr<struct<"polygeist@mlir@struct.Node">>, f64)>>>
-// CHECK-NEXT:       %7 = func.call @sum(%6) : (!llvm.ptr<struct<"polygeist@mlir@struct.Node", (ptr<struct<"polygeist@mlir@struct.Node">>, f64)>>) -> f64
-// CHECK-NEXT:       %8 = arith.addf %4, %7 : f64
-// CHECK-NEXT:       scf.yield %8 : f64
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return %2 : f64
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @sum(
+// CHECK-SAME:                   %[[VAL_0:.*]]: !llvm.ptr) -> f64 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.icmp "eq" %[[VAL_0]], %[[VAL_2]] : !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = scf.if %[[VAL_3]] -> (f64) {
+// CHECK-NEXT:        scf.yield %[[VAL_1]] : f64
+// CHECK-NEXT:      } else {
+// CHECK-NEXT:        %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"polygeist@mlir@struct.Node", (ptr, f64)>
+// CHECK-NEXT:        %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> f64
+// CHECK-NEXT:        %[[VAL_7:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"polygeist@mlir@struct.Node", (ptr, f64)>
+// CHECK-NEXT:        %[[VAL_8:.*]] = llvm.load %[[VAL_7]] : !llvm.ptr -> !llvm.ptr
+// CHECK-NEXT:        %[[VAL_9:.*]] = func.call @sum(%[[VAL_8]]) : (!llvm.ptr) -> f64
+// CHECK-NEXT:        %[[VAL_10:.*]] = arith.addf %[[VAL_6]], %[[VAL_9]] : f64
+// CHECK-NEXT:        scf.yield %[[VAL_10]] : f64
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return %[[VAL_11:.*]] : f64
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/redstore.c
+++ b/polygeist/tools/cgeist/Test/Verification/redstore.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O2 %s --function=* -S -enable-attributes | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O2 %s --function=* -S -enable-attributes | FileCheck %s
 
 extern int print(double);
 

--- a/polygeist/tools/cgeist/Test/Verification/redstore2.c
+++ b/polygeist/tools/cgeist/Test/Verification/redstore2.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O2 %s --function=* -S -enable-attributes | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O2 %s --function=* -S -enable-attributes | FileCheck %s
 
 void sum(double * __restrict__ result, double * __restrict__ array) {
     result[0] = 0;

--- a/polygeist/tools/cgeist/Test/Verification/ref.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/ref.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O2 --function=* -S | FileCheck %s
 
 extern "C" {
 

--- a/polygeist/tools/cgeist/Test/Verification/refpair.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/refpair.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 -w %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 -w %s --function=* -S | FileCheck %s
 
 extern "C" {
 
@@ -19,21 +19,22 @@ void kernel_deriche() {
 
 }
 
-// CHECK:   func @sub(%arg0: !llvm.ptr<struct<(i32, i32)>>)
-// CHECK-NEXT:     %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     %1 = llvm.load %0 : !llvm.ptr<i32>
-// CHECK-NEXT:     %2 = arith.addi %1, %c1_i32 : i32
-// CHECK-NEXT:     llvm.store %2, %0 : !llvm.ptr<i32>
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @sub(
+// CHECK-SAME:                   %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i32)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.addi %[[VAL_3]], %[[VAL_1]] : i32
+// CHECK-NEXT:      llvm.store %[[VAL_4]], %[[VAL_2]] : i32, !llvm.ptr
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
 
-// CHECK:   func @kernel_deriche()
-// CHECK-DAG:      %c32_i32 = arith.constant 32 : i32
-// CHECK-DAG:      %c1_i64 = arith.constant 1 : i64
-// CHECK:          %0 = llvm.alloca %c1_i64 x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr<struct<(i32, i32)>>
-// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     llvm.store %c32_i32, %1 : !llvm.ptr<i32>
-// CHECK-NEXT:     call @sub0(%0) : (!llvm.ptr<struct<(i32, i32)>>) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @kernel_deriche() attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 32 : i32
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(i32, i32)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i32)>
+// CHECK-NEXT:      llvm.store %[[VAL_0]], %[[VAL_3]] : i32, !llvm.ptr
+// CHECK-NEXT:      call @sub0(%[[VAL_2]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/refptrabi.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/refptrabi.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 -w %s  --function=ll -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 -w %s  --function=ll -S | FileCheck %s
 
 struct alignas(2) Half {
   unsigned short x;
@@ -16,12 +16,12 @@ float ll(void* data) {
 
 }
 
-// CHECK:   func @ll(%arg0: !llvm.ptr<i8>) -> f32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(i16)> : (i64) -> !llvm.ptr<struct<(i16)>>
-// CHECK-NEXT:     %1 = llvm.bitcast %arg0 : !llvm.ptr<i8> to !llvm.ptr<struct<(i16)>>
-// CHECK-NEXT:     call @_ZN4HalfC1ERKS_(%0, %1) : (!llvm.ptr<struct<(i16)>>, !llvm.ptr<struct<(i16)>>) -> ()
-// CHECK-NEXT:     %2 = llvm.load %0 : !llvm.ptr<struct<(i16)>>
-// CHECK-NEXT:     %3 = call @thing(%2) : (!llvm.struct<(i16)>) -> f32
-// CHECK-NEXT:     return %3 : f32
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @ll(
+// CHECK-SAME:                  %[[VAL_0:.*]]: !llvm.ptr) -> f32 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(i16)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      call @_ZN4HalfC1ERKS_(%[[VAL_2]], %[[VAL_0]]) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> !llvm.struct<(i16)>
+// CHECK-NEXT:      %[[VAL_4:.*]] = call @thing(%[[VAL_3]]) : (!llvm.struct<(i16)>) -> f32
+// CHECK-NEXT:      return %[[VAL_4]] : f32
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/rem.c
+++ b/polygeist/tools/cgeist/Test/Verification/rem.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 %s --function=* -S | FileCheck %s
 
 typedef char char_vec __attribute__((ext_vector_type(3)));
 typedef short short_vec __attribute__((ext_vector_type(3)));

--- a/polygeist/tools/cgeist/Test/Verification/reverseRaise.c
+++ b/polygeist/tools/cgeist/Test/Verification/reverseRaise.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O2 --function=kernel_correlation --raise-scf-to-affine -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O2 --function=kernel_correlation --raise-scf-to-affine -S | FileCheck %s
 
 #define DATA_TYPE double
 

--- a/polygeist/tools/cgeist/Test/Verification/scalarconversion.c
+++ b/polygeist/tools/cgeist/Test/Verification/scalarconversion.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S -O0 -w | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S -O0 -w | FileCheck %s
 
 // CHECK-LABEL:   func.func @unsigned2float(
 // CHECK-SAME:                              %[[VAL_0:.*]]: i32) -> f32

--- a/polygeist/tools/cgeist/Test/Verification/scor.c
+++ b/polygeist/tools/cgeist/Test/Verification/scor.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s -O2 --function=kernel_correlation -S | FileCheck %s
-// RUN: cgeist %s -O2 --function=kernel_correlation -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist --use-opaque-pointers %s -O2 --function=kernel_correlation -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O2 --function=kernel_correlation -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 #define DATA_TYPE double
 

--- a/polygeist/tools/cgeist/Test/Verification/scor2.c
+++ b/polygeist/tools/cgeist/Test/Verification/scor2.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s --function=kernel_correlation --raise-scf-to-affine -S | FileCheck %s
-// RUN: cgeist %s --function=kernel_correlation --raise-scf-to-affine -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist --use-opaque-pointers %s --function=kernel_correlation --raise-scf-to-affine -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=kernel_correlation --raise-scf-to-affine -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 #define DATA_TYPE double
 

--- a/polygeist/tools/cgeist/Test/Verification/scor3.c
+++ b/polygeist/tools/cgeist/Test/Verification/scor3.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s --function=kernel_correlation --raise-scf-to-affine -S | FileCheck %s
-// RUN: cgeist %s --function=kernel_correlation --raise-scf-to-affine -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist --use-opaque-pointers %s --function=kernel_correlation --raise-scf-to-affine -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=kernel_correlation --raise-scf-to-affine -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 #define DATA_TYPE double
 

--- a/polygeist/tools/cgeist/Test/Verification/scor4.c
+++ b/polygeist/tools/cgeist/Test/Verification/scor4.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s --function=kernel_correlation --raise-scf-to-affine -S | FileCheck %s
-// RUN: cgeist %s --function=kernel_correlation --raise-scf-to-affine -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist --use-opaque-pointers %s --function=kernel_correlation --raise-scf-to-affine -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=kernel_correlation --raise-scf-to-affine -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 #define DATA_TYPE double
 

--- a/polygeist/tools/cgeist/Test/Verification/sec.c
+++ b/polygeist/tools/cgeist/Test/Verification/sec.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 int compute_tran_temp(int total_iterations, int num_iterations)
 {

--- a/polygeist/tools/cgeist/Test/Verification/setter.c
+++ b/polygeist/tools/cgeist/Test/Verification/setter.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 void sub0(int *a);
 void sub(int *a) {

--- a/polygeist/tools/cgeist/Test/Verification/sgesv.c
+++ b/polygeist/tools/cgeist/Test/Verification/sgesv.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s -O2 --function=kernel_correlation -S -enable-attributes | FileCheck %s
-// RUN: cgeist %s -O2 --function=kernel_correlation -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist --use-opaque-pointers %s -O2 --function=kernel_correlation -S -enable-attributes | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O2 --function=kernel_correlation -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 #define DATA_TYPE double
 

--- a/polygeist/tools/cgeist/Test/Verification/shl.c
+++ b/polygeist/tools/cgeist/Test/Verification/shl.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 %s --function=* -S | FileCheck %s
 
 typedef char char_vec __attribute__((ext_vector_type(3)));
 typedef short short_vec __attribute__((ext_vector_type(3)));

--- a/polygeist/tools/cgeist/Test/Verification/shl.cl
+++ b/polygeist/tools/cgeist/Test/Verification/shl.cl
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 %s --function=* -S | FileCheck %s
 
 typedef char char_vec __attribute__((ext_vector_type(3)));
 typedef short short_vec __attribute__((ext_vector_type(3)));

--- a/polygeist/tools/cgeist/Test/Verification/shr.c
+++ b/polygeist/tools/cgeist/Test/Verification/shr.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 %s --function=* -S | FileCheck %s
 
 typedef char char_vec __attribute__((ext_vector_type(3)));
 typedef short short_vec __attribute__((ext_vector_type(3)));

--- a/polygeist/tools/cgeist/Test/Verification/shr.cl
+++ b/polygeist/tools/cgeist/Test/Verification/shr.cl
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 %s --function=* -S | FileCheck %s
 
 typedef char char_vec __attribute__((ext_vector_type(3)));
 typedef short short_vec __attribute__((ext_vector_type(3)));

--- a/polygeist/tools/cgeist/Test/Verification/signcmp.c
+++ b/polygeist/tools/cgeist/Test/Verification/signcmp.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O2 --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O2 --function=* -S | FileCheck %s
 
 void run();
 unsigned int cmp(int a, int b) {

--- a/polygeist/tools/cgeist/Test/Verification/single_field_union.c
+++ b/polygeist/tools/cgeist/Test/Verification/single_field_union.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s -O0 --function=* -S | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: cgeist %s -O0 --function=* -S -emit-llvm | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: cgeist --use-opaque-pointers %s -O0 --function=* -S | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: cgeist --use-opaque-pointers %s -O0 --function=* -S -emit-llvm | FileCheck %s --check-prefix=CHECK-LLVM
 // XFAIL: *
 
 // Our type generation currently does not differ between scalar and memory

--- a/polygeist/tools/cgeist/Test/Verification/single_field_union_for_mem.c
+++ b/polygeist/tools/cgeist/Test/Verification/single_field_union_for_mem.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s -O0 --function=* -S | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: cgeist %s -O0 --function=* -S -emit-llvm | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: cgeist --use-opaque-pointers %s -O0 --function=* -S | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: cgeist --use-opaque-pointers %s -O0 --function=* -S -emit-llvm | FileCheck %s --check-prefix=CHECK-LLVM
 
 struct foo {
   union int_wrapper {

--- a/polygeist/tools/cgeist/Test/Verification/size.c
+++ b/polygeist/tools/cgeist/Test/Verification/size.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 struct X {
    int a;

--- a/polygeist/tools/cgeist/Test/Verification/sizeof.c
+++ b/polygeist/tools/cgeist/Test/Verification/sizeof.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 void* malloc(unsigned long);
 
@@ -11,10 +11,9 @@ struct Meta* create() {
     return (struct Meta*)malloc(sizeof(struct Meta));
 }
 
-// CHECK:   func @create() -> !llvm.ptr<!llvm.struct<(memref<?xf32>, i8)>> attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %0 = "polygeist.typeSize"() {source = !llvm.struct<(memref<?xf32>, i8)>} : () -> index
-// CHECK-NEXT:     %1 = arith.index_cast %0 : index to i64
-// CHECK-NEXT:     %2 = llvm.call @malloc(%1) : (i64) -> !llvm.ptr<i8>
-// CHECK-NEXT:     %3 = llvm.bitcast %2 : !llvm.ptr<i8> to !llvm.ptr<!llvm.struct<(memref<?xf32>, i8)>>
-// CHECK-NEXT:     return %3 : !llvm.ptr<!llvm.struct<(memref<?xf32>, i8)>>
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @create() -> !llvm.ptr attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_0:.*]] = "polygeist.typeSize"() {source = !llvm.struct<(memref<?xf32>, i8)>} : () -> index
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.index_cast %[[VAL_0]] : index to i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.call @malloc(%[[VAL_1]]) : (i64) -> !llvm.ptr
+// CHECK-NEXT:      return %[[VAL_2]] : !llvm.ptr
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/sizeofpack.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sizeofpack.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S -O0 | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S -O0 | FileCheck %s
 
 #include <cstddef>
 

--- a/polygeist/tools/cgeist/Test/Verification/snus.c
+++ b/polygeist/tools/cgeist/Test/Verification/snus.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s -O2 -detect-reduction --function=kernel_nussinov -S | FileCheck %s
-// RUN: cgeist %s -O2 -detect-reduction --function=kernel_nussinov -S -memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist --use-opaque-pointers %s -O2 -detect-reduction --function=kernel_nussinov -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O2 -detect-reduction --function=kernel_nussinov -S -memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 #define max_score(s1, s2) ((s1 >= s2) ? s1 : s2)
 

--- a/polygeist/tools/cgeist/Test/Verification/static.c
+++ b/polygeist/tools/cgeist/Test/Verification/static.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=foo -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=foo -S | FileCheck %s
 
 #define N 8
 int foo() {

--- a/polygeist/tools/cgeist/Test/Verification/staticint.c
+++ b/polygeist/tools/cgeist/Test/Verification/staticint.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 int adder(int x) {
     static int cur = 0;

--- a/polygeist/tools/cgeist/Test/Verification/str.c
+++ b/polygeist/tools/cgeist/Test/Verification/str.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 -w %s --function=meta -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 -w %s --function=meta -S | FileCheck %s
 
 int foo(const char*);
 
@@ -6,17 +6,17 @@ int meta() {
     return foo("bar") + foo(__PRETTY_FUNCTION__);
 }
 
-// CHECK:   llvm.mlir.global internal constant @str1("int meta()\00")
-// CHECK:   llvm.mlir.global internal constant @str0("bar\00")
-// CHECK:   func @meta() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %0 = llvm.mlir.addressof @str0 : !llvm.ptr<array<4 x i8>>
-// CHECK-NEXT:     %1 = "polygeist.pointer2memref"(%0) : (!llvm.ptr<array<4 x i8>>) -> memref<?xi8>
-// CHECK-NEXT:     %2 = call @foo(%1) : (memref<?xi8>) -> i32
-// CHECK-NEXT:     %3 = llvm.mlir.addressof @str1 : !llvm.ptr<array<11 x i8>>
-// CHECK-NEXT:     %4 = "polygeist.pointer2memref"(%3) : (!llvm.ptr<array<11 x i8>>) -> memref<?xi8>
-// CHECK-NEXT:     %5 = call @foo(%4) : (memref<?xi8>) -> i32
-// CHECK-NEXT:     %6 = arith.addi %2, %5 : i32
-// CHECK-NEXT:     return %6 : i32
-// CHECK-NEXT:   }
+// CHECK-LABEL:   llvm.mlir.global internal constant @str1("int meta()\00") {addr_space = 0 : i32}
+// CHECK-NEXT:    llvm.mlir.global internal constant @str0("bar\00") {addr_space = 0 : i32}
 
-// CHECK:   func.func private @foo(memref<?xi8>) -> i32
+// CHECK-LABEL:   func.func @meta() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.addressof @str0 : !llvm.ptr
+// CHECK-NEXT:      %[[VAL_1:.*]] = "polygeist.pointer2memref"(%[[VAL_0]]) : (!llvm.ptr) -> memref<?xi8>
+// CHECK-NEXT:      %[[VAL_2:.*]] = call @foo(%[[VAL_1]]) : (memref<?xi8>) -> i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.addressof @str1 : !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = "polygeist.pointer2memref"(%[[VAL_3]]) : (!llvm.ptr) -> memref<?xi8>
+// CHECK-NEXT:      %[[VAL_5:.*]] = call @foo(%[[VAL_4]]) : (memref<?xi8>) -> i32
+// CHECK-NEXT:      %[[VAL_6:.*]] = arith.addi %[[VAL_2]], %[[VAL_5]] : i32
+// CHECK-NEXT:      return %[[VAL_6]] : i32
+// CHECK-NEXT:    }
+// CHECK-LABEL:   func.func private @foo(memref<?xi8>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>}

--- a/polygeist/tools/cgeist/Test/Verification/stream.cu
+++ b/polygeist/tools/cgeist/Test/Verification/stream.cu
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O0 -w --cuda-gpu-arch=sm_60 -nocudalib -nocudainc %resourcedir --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O0 -w --cuda-gpu-arch=sm_60 -nocudalib -nocudainc %resourcedir --function=* -S | FileCheck %s
 
 #include "Inputs/cuda.h"
 
@@ -13,8 +13,8 @@ void run(cudaStream_t stream1, int *array, int n) {
     square<<< 10, 20, 0, stream1>>> (array, n) ;
 }
 
-// CHECK:   func.func @_Z3runP10cudaStreamPii(%arg0: !llvm.ptr<struct<()>>, %arg1: memref<?xi32>, %arg2: i32) attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK:          %26 = "polygeist.stream2token"(%arg0) : (!llvm.ptr<struct<()>>) -> !gpu.async.token
+// CHECK:   func.func @_Z3runP10cudaStreamPii(%arg0: !llvm.ptr, %arg1: memref<?xi32>, %arg2: i32) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK:          %26 = "polygeist.stream2token"(%arg0) : (!llvm.ptr) -> !gpu.async.token
 // CHECK-NEXT:     %27 = gpu.launch async [%26] blocks(%arg3, %arg4, %arg5) in (%arg9 = {{.*}}, %arg10 = {{.*}}, %arg11 = {{.*}}) threads(%arg6, %arg7, %arg8) in (%arg12 = {{.*}}, %arg13 = {{.*}}, %arg14 = {{.*}}) {
 // CHECK-NEXT:       func.call @_Z21__device_stub__squarePii(%arg1, %arg2) : (memref<?xi32>, i32) -> ()
 // CHECK-NEXT:       gpu.terminator

--- a/polygeist/tools/cgeist/Test/Verification/struct.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/struct.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s %stdinclude --function=func -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s %stdinclude --function=func -S | FileCheck %s
 
 float hload(const void* data);
 
@@ -16,9 +16,10 @@ float func(struct OperandInfo* op) {
 }
 }
 
-// CHECK:   func @func(%arg0: !llvm.ptr<struct<(i8, ptr<i8>, i8)>>) -> f32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %[[i2:.+]] = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<struct<(i8, ptr<i8>, i8)>>) -> !llvm.ptr<ptr<i8>>
-// CHECK-NEXT:     %[[i3:.+]] = llvm.load %[[i2]] : !llvm.ptr<ptr<i8>>
-// CHECK-NEXT:     %[[i4:.+]] = call @_Z5hloadPKv(%[[i3]]) : (!llvm.ptr<i8>) -> f32
-// CHECK-NEXT:     return %[[i4]] : f32
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @func(
+// CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr) -> f32 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i8, ptr, i8)>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_3:.*]] = call @_Z5hloadPKv(%[[VAL_2]]) : (!llvm.ptr) -> f32
+// CHECK-NEXT:      return %[[VAL_3]] : f32
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/sub.c
+++ b/polygeist/tools/cgeist/Test/Verification/sub.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 -w %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 -w %s --function=* -S | FileCheck %s
 
 #include <stddef.h>
 
@@ -154,10 +154,10 @@ double_vec sub_vf64(double_vec a, double_vec b) {
 // CHECK-LABEL:   func.func @ptr_diff_i8(
 // CHECK-SAME:                  %[[VAL_0:.*]]: memref<?xi8>,
 // CHECK-SAME:                  %[[VAL_1:.*]]: memref<?xi8>) -> i64
-// CHECK:           %[[VAL_0:.*]] = "polygeist.memref2pointer"(%arg0) : (memref<?xi8>) -> !llvm.ptr<i8>
-// CHECK:           %[[VAL_1:.*]] = llvm.ptrtoint %[[VAL_0]] : !llvm.ptr<i8> to i64
-// CHECK:           %[[VAL_2:.*]] = "polygeist.memref2pointer"(%arg1) : (memref<?xi8>) -> !llvm.ptr<i8>
-// CHECK:           %[[VAL_3:.*]] = llvm.ptrtoint %[[VAL_2]] : !llvm.ptr<i8> to i64
+// CHECK:           %[[VAL_0:.*]] = "polygeist.memref2pointer"(%arg0) : (memref<?xi8>) -> !llvm.ptr
+// CHECK:           %[[VAL_1:.*]] = llvm.ptrtoint %[[VAL_0]] : !llvm.ptr to i64
+// CHECK:           %[[VAL_2:.*]] = "polygeist.memref2pointer"(%arg1) : (memref<?xi8>) -> !llvm.ptr
+// CHECK:           %[[VAL_3:.*]] = llvm.ptrtoint %[[VAL_2]] : !llvm.ptr to i64
 // CHECK:           %[[VAL_4:.*]] = arith.subi %[[VAL_1]], %[[VAL_3]] : i64
 // CHECK:           return %[[VAL_4]] : i64
 // CHECK:         }
@@ -170,10 +170,10 @@ size_t ptr_diff_i8(char *a, char *b) {
 // CHECK-SAME:                  %[[VAL_0:.*]]: memref<?xf32>,
 // CHECK-SAME:                  %[[VAL_1:.*]]: memref<?xf32>) -> i64
 // CHECK:           %[[I64_0:.*]] = arith.constant 4 : i64
-// CHECK:           %[[PTR_0:.*]] = "polygeist.memref2pointer"(%[[VAL_0]]) : (memref<?xf32>) -> !llvm.ptr<f32>
-// CHECK:           %[[INT_0:.*]] = llvm.ptrtoint %[[PTR_0]] : !llvm.ptr<f32> to i64
-// CHECK:           %[[PTR_1:.*]] = "polygeist.memref2pointer"(%[[VAL_1]]) : (memref<?xf32>) -> !llvm.ptr<f32>
-// CHECK:           %[[INT_1:.*]] = llvm.ptrtoint %[[PTR_1]] : !llvm.ptr<f32> to i64
+// CHECK:           %[[PTR_0:.*]] = "polygeist.memref2pointer"(%[[VAL_0]]) : (memref<?xf32>) -> !llvm.ptr
+// CHECK:           %[[INT_0:.*]] = llvm.ptrtoint %[[PTR_0]] : !llvm.ptr to i64
+// CHECK:           %[[PTR_1:.*]] = "polygeist.memref2pointer"(%[[VAL_1]]) : (memref<?xf32>) -> !llvm.ptr
+// CHECK:           %[[INT_1:.*]] = llvm.ptrtoint %[[PTR_1]] : !llvm.ptr to i64
 // CHECK:           %[[DIFF:.*]] = arith.subi %[[INT_0]], %[[INT_1]] : i64
 // CHECK:           %[[SUB:.*]] = arith.divsi %[[DIFF]], %[[I64_0]] : i64
 // CHECK:           return %[[SUB]] : i64

--- a/polygeist/tools/cgeist/Test/Verification/switcherr.c
+++ b/polygeist/tools/cgeist/Test/Verification/switcherr.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=foo -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=foo -S | FileCheck %s
 
 int foo(int t) {
   int n = 10;

--- a/polygeist/tools/cgeist/Test/Verification/switchnone.c
+++ b/polygeist/tools/cgeist/Test/Verification/switchnone.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=foo -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=foo -S | FileCheck %s
 
 int foo(int t) {
   switch (t) {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/assert-typed-pointers.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/assert-typed-pointers.cpp
@@ -1,0 +1,23 @@
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s
+
+#include <sycl/sycl.hpp>
+using namespace sycl;
+
+// CHECK-LABEL:  gpu.module @device_functions {
+// CHECK-LABEL:    llvm.func @__assert_fail(!llvm.ptr<i8, 4>, !llvm.ptr<i8, 4>, i32, !llvm.ptr<i8, 4>)
+// CHECK-LABEL:    func.func @_Z12check_assertN4sycl3_V12idILi1EEES2_(%arg0: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef})
+// CHECK-NEXT:        [[C22:%.*]] = arith.constant 22 : i32
+// CHECK:             %1 = llvm.mlir.addressof @str0 : !llvm.ptr<array<11 x i8>>
+// CHECK-NEXT:        %2 = llvm.getelementptr inbounds %1[0, 0] : (!llvm.ptr<array<11 x i8>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:        %3 = llvm.mlir.addressof @str1 : !llvm.ptr<array<[[PATH_LENGTH:.*]] x i8>>
+// CHECK-NEXT:        %4 = llvm.getelementptr inbounds %3[0, 0] : (!llvm.ptr<array<[[PATH_LENGTH]] x i8>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:        %5 = llvm.mlir.addressof @str2 : !llvm.ptr<array<32 x i8>>
+// CHECK-NEXT:        %6 = llvm.getelementptr inbounds %5[0, 0] : (!llvm.ptr<array<32 x i8>>) -> !llvm.ptr<i8>
+// CHECK-NEXT:        %7 = llvm.addrspacecast %2 : !llvm.ptr<i8> to !llvm.ptr<i8, 4>
+// CHECK-NEXT:        %8 = llvm.addrspacecast %4 : !llvm.ptr<i8> to !llvm.ptr<i8, 4>
+// CHECK-NEXT:        %9 = llvm.addrspacecast %6 : !llvm.ptr<i8> to !llvm.ptr<i8, 4>
+// CHECK-NEXT:        llvm.call @__assert_fail(%7, %8, [[C22]], %9) : (!llvm.ptr<i8, 4>, !llvm.ptr<i8, 4>, i32, !llvm.ptr<i8, 4>) -> ()
+
+SYCL_EXTERNAL void check_assert(id<1> id1, id<1> id2) {
+  assert(id1 == id2);
+}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/assert.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/assert.cpp
@@ -1,22 +1,26 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s
 
 #include <sycl/sycl.hpp>
 using namespace sycl;
 
-// CHECK-LABEL:  gpu.module @device_functions {
-// CHECK-LABEL:    llvm.func @__assert_fail(!llvm.ptr<i8, 4>, !llvm.ptr<i8, 4>, i32, !llvm.ptr<i8, 4>)
-// CHECK-LABEL:    func.func @_Z12check_assertN4sycl3_V12idILi1EEES2_(%arg0: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef})
-// CHECK-NEXT:        [[C22:%.*]] = arith.constant 22 : i32
-// CHECK:             %1 = llvm.mlir.addressof @str0 : !llvm.ptr<array<11 x i8>>
-// CHECK-NEXT:        %2 = llvm.getelementptr inbounds %1[0, 0] : (!llvm.ptr<array<11 x i8>>) -> !llvm.ptr<i8>
-// CHECK-NEXT:        %3 = llvm.mlir.addressof @str1 : !llvm.ptr<array<[[PATH_LENGTH:.*]] x i8>>
-// CHECK-NEXT:        %4 = llvm.getelementptr inbounds %3[0, 0] : (!llvm.ptr<array<[[PATH_LENGTH]] x i8>>) -> !llvm.ptr<i8>
-// CHECK-NEXT:        %5 = llvm.mlir.addressof @str2 : !llvm.ptr<array<32 x i8>>
-// CHECK-NEXT:        %6 = llvm.getelementptr inbounds %5[0, 0] : (!llvm.ptr<array<32 x i8>>) -> !llvm.ptr<i8>
-// CHECK-NEXT:        %7 = llvm.addrspacecast %2 : !llvm.ptr<i8> to !llvm.ptr<i8, 4>
-// CHECK-NEXT:        %8 = llvm.addrspacecast %4 : !llvm.ptr<i8> to !llvm.ptr<i8, 4>
-// CHECK-NEXT:        %9 = llvm.addrspacecast %6 : !llvm.ptr<i8> to !llvm.ptr<i8, 4>
-// CHECK-NEXT:        llvm.call @__assert_fail(%7, %8, [[C22]], %9) : (!llvm.ptr<i8, 4>, !llvm.ptr<i8, 4>, i32, !llvm.ptr<i8, 4>) -> ()
+// CHECK-LABEL:   gpu.module @device_functions {
+
+// CHECK-LABEL:     llvm.func @__assert_fail(!llvm.ptr<4>, !llvm.ptr<4>, i32, !llvm.ptr<4>)
+
+// CHECK-LABEL:     func.func @_Z12check_assertN4sycl3_V12idILi1EEES2_(
+// CHECK-SAME:          %[[VAL_151:.*]]: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef},
+// CHECK-SAME:          %[[VAL_152:.*]]: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef})
+// CHECK-NEXT:        %[[C26:.*]] = arith.constant 26 : i32
+// CHECK:               %[[VAL_157:.*]] = llvm.mlir.addressof @str0 : !llvm.ptr
+// CHECK-NEXT:          %[[VAL_158:.*]] = llvm.getelementptr inbounds %[[VAL_157]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<11 x i8>
+// CHECK-NEXT:          %[[VAL_159:.*]] = llvm.mlir.addressof @str1 : !llvm.ptr
+// CHECK-NEXT:          %[[VAL_160:.*]] = llvm.getelementptr inbounds %[[VAL_159]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<[[#PATHLENGTH:]] x i8>
+// CHECK-NEXT:          %[[VAL_161:.*]] = llvm.mlir.addressof @str2 : !llvm.ptr
+// CHECK-NEXT:          %[[VAL_162:.*]] = llvm.getelementptr inbounds %[[VAL_161]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<32 x i8>
+// CHECK-NEXT:          %[[VAL_163:.*]] = llvm.addrspacecast %[[VAL_158]] : !llvm.ptr to !llvm.ptr<4>
+// CHECK-NEXT:          %[[VAL_164:.*]] = llvm.addrspacecast %[[VAL_160]] : !llvm.ptr to !llvm.ptr<4>
+// CHECK-NEXT:          %[[VAL_165:.*]] = llvm.addrspacecast %[[VAL_162]] : !llvm.ptr to !llvm.ptr<4>
+// CHECK-NEXT:          llvm.call @__assert_fail(%[[VAL_163]], %[[VAL_164]], %[[C26]], %[[VAL_165]]) : (!llvm.ptr<4>, !llvm.ptr<4>, i32, !llvm.ptr<4>) -> ()
 
 SYCL_EXTERNAL void check_assert(id<1> id1, id<1> id2) {
   assert(id1 == id2);

--- a/polygeist/tools/cgeist/Test/Verification/sycl/builtin_cache-typed-pointers.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/builtin_cache-typed-pointers.cpp
@@ -1,0 +1,17 @@
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -emit-mlir -o - %s | FileCheck %s
+
+#include <sycl/sycl.hpp>
+using namespace sycl;
+
+// CHECK-LABEL: func.func @_Z6callee38__spirv_SampledImage__image1d_array_ro(%arg0: !llvm.ptr<struct<"spirv.SampledImage.image1d_array_ro_t.0", opaque>, 1>)
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+// CHECK-LABEL: func.func @_Z6caller38__spirv_SampledImage__image1d_array_ro(%arg0: !llvm.ptr<struct<"spirv.SampledImage.image1d_array_ro_t.0", opaque>, 1>)
+// CHECK-NEXT:    call @_Z6callee38__spirv_SampledImage__image1d_array_ro(%arg0) : (!llvm.ptr<struct<"spirv.SampledImage.image1d_array_ro_t.0", opaque>, 1>) -> ()
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+
+SYCL_EXTERNAL void callee(__ocl_sampled_image1d_array_ro_t var) {}
+SYCL_EXTERNAL void caller(__ocl_sampled_image1d_array_ro_t var) {
+  callee(var);
+}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/builtin_cache.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/builtin_cache.cpp
@@ -1,15 +1,18 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir -o - %s | FileCheck %s
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir -o - %s | FileCheck %s
 
 #include <sycl/sycl.hpp>
 using namespace sycl;
 
-// CHECK-LABEL: func.func @_Z6callee38__spirv_SampledImage__image1d_array_ro(%arg0: !llvm.ptr<struct<"spirv.SampledImage.image1d_array_ro_t.0", opaque>, 1>)
-// CHECK-NEXT:    return
-// CHECK-NEXT:  }
-// CHECK-LABEL: func.func @_Z6caller38__spirv_SampledImage__image1d_array_ro(%arg0: !llvm.ptr<struct<"spirv.SampledImage.image1d_array_ro_t.0", opaque>, 1>)
-// CHECK-NEXT:    call @_Z6callee38__spirv_SampledImage__image1d_array_ro(%arg0) : (!llvm.ptr<struct<"spirv.SampledImage.image1d_array_ro_t.0", opaque>, 1>) -> ()
-// CHECK-NEXT:    return
-// CHECK-NEXT:  }
+// CHECK-LABEL:     func.func @_Z6callee38__spirv_SampledImage__image1d_array_ro
+// CHECK-SAME:          (%[[VAL_151:.*]]: !llvm.ptr<1>)
+// CHECK-NEXT:        return
+// CHECK-NEXT:      }
+
+// CHECK-LABEL:     func.func @_Z6caller38__spirv_SampledImage__image1d_array_ro
+// CHECK-SAME:          (%[[VAL_152:.*]]: !llvm.ptr<1>)
+// CHECK-NEXT:        call @_Z6callee38__spirv_SampledImage__image1d_array_ro(%[[VAL_152]]) : (!llvm.ptr<1>) -> ()
+// CHECK-NEXT:        return
+// CHECK-NEXT:      }
 
 SYCL_EXTERNAL void callee(__ocl_sampled_image1d_array_ro_t var) {}
 SYCL_EXTERNAL void caller(__ocl_sampled_image1d_array_ro_t var) {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/builtin_types-typed-pointers.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/builtin_types-typed-pointers.cpp
@@ -1,4 +1,4 @@
-// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir -o - %s | FileCheck %s
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -emit-mlir -o - %s | FileCheck %s
 
 #include <sycl/sycl.hpp>
 
@@ -29,27 +29,27 @@ SYCL_EXTERNAL void float128(__float128 var) {}
 SYCL_EXTERNAL void int128(__int128 var) {}
 
 // CHECK-LABEL: func.func @_Z19opencl_image1d_ro_t14ocl_image1d_ro(
-// CHECK:         %arg0: !llvm.ptr<1>)
+// CHECK:         %arg0: !llvm.ptr<struct<"opencl.image1d_ro_t", opaque>, 1>)
 SYCL_EXTERNAL void opencl_image1d_ro_t(detail::opencl_image_type<1, access::mode::read, access::target::image>::type var) {}
 
 // CHECK-LABEL: func.func @_Z19opencl_image1d_wo_t14ocl_image1d_wo(
-// CHECK:         %arg0: !llvm.ptr<1>)
+// CHECK:         %arg0: !llvm.ptr<struct<"opencl.image1d_wo_t", opaque>, 1>)
 SYCL_EXTERNAL void opencl_image1d_wo_t(detail::opencl_image_type<1, access::mode::write, access::target::image>::type var) {}
 
 // CHECK-LABEL: func.func @_Z25opencl_image1d_array_ro_t20ocl_image1d_array_ro(
-// CHECK:         %arg0: !llvm.ptr<1>)
+// CHECK:         %arg0: !llvm.ptr<struct<"opencl.image1d_array_ro_t", opaque>, 1>)
 SYCL_EXTERNAL void opencl_image1d_array_ro_t(detail::opencl_image_type<1, access::mode::read, access::target::image_array>::type var) {}
 
 // CHECK-LABEL: func.func @_Z25opencl_image1d_array_wo_t20ocl_image1d_array_wo(
-// CHECK:         %arg0: !llvm.ptr<1>)
+// CHECK:         %arg0: !llvm.ptr<struct<"opencl.image1d_array_wo_t", opaque>, 1>)
 SYCL_EXTERNAL void opencl_image1d_array_wo_t(detail::opencl_image_type<1, access::mode::write, access::target::image_array>::type var) {}
 
 // CHECK-LABEL: func.func @_Z16opencl_sampler_t11ocl_sampler(
-// CHECK:         %arg0: !llvm.ptr<2>)
+// CHECK:         %arg0: !llvm.ptr<struct<"opencl.sampler_t", opaque>, 2>)
 SYCL_EXTERNAL void opencl_sampler_t(__ocl_sampler_t var) {}
 
 // CHECK-LABEL: func.func @_Z33opencl_sampled_image_array1d_ro_t38__spirv_SampledImage__image1d_array_ro(
-// CHECK:         %arg0: !llvm.ptr<1>)
+// CHECK:         %arg0: !llvm.ptr<struct<"spirv.SampledImage.image1d_array_ro_t.1", opaque>, 1>)
 SYCL_EXTERNAL void opencl_sampled_image_array1d_ro_t(__ocl_sampled_image1d_array_ro_t var) {}
 
 // CHECK-LABEL: func.func @_Z12opencl_vec_tDv4_j(
@@ -57,5 +57,5 @@ SYCL_EXTERNAL void opencl_sampled_image_array1d_ro_t(__ocl_sampled_image1d_array
 SYCL_EXTERNAL void opencl_vec_t(__ocl_vec_t<uint32_t, 4> var) {}
 
 // CHECK-LABEL: func.func @_Z14opencl_event_t9ocl_event(
-// CHECK:         %arg0: !llvm.ptr<4>)
+// CHECK:         %arg0: !llvm.ptr<struct<"opencl.event_t", opaque>, 4>)
 SYCL_EXTERNAL void opencl_event_t(__ocl_event_t var) {}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -1,5 +1,5 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefixes=CHECK
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefixes=CHECK-LLVM
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefixes=CHECK
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefixes=CHECK-LLVM
 
 #include <sycl/aliases.hpp>
 #include <sycl/sycl.hpp>
@@ -103,10 +103,10 @@ extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
 // CHECK-NEXT: %c0_i8 = arith.constant 0 : i8
 // CHECK-NEXT: %alloca = memref.alloca() : memref<1x!sycl_id_2_>
 // CHECK-NEXT: %cast = memref.cast %alloca : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
-// CHECK-NEXT: %0 = "polygeist.memref2pointer"(%alloca) : (memref<1x!sycl_id_2_>) -> !llvm.ptr<i8>
+// CHECK-NEXT: %0 = "polygeist.memref2pointer"(%alloca) : (memref<1x!sycl_id_2_>) -> !llvm.ptr
 // CHECK-NEXT: %1 = "polygeist.typeSize"() {source = !sycl_id_2_} : () -> index
 // CHECK-NEXT: %2 = arith.index_cast %1 : index to i64
-// CHECK-NEXT: "llvm.intr.memset"(%0, %c0_i8, %2, %false) : (!llvm.ptr<i8>, i8, i64, i1) -> ()
+// CHECK-NEXT: "llvm.intr.memset"(%0, %c0_i8, %2, %false) : (!llvm.ptr, i8, i64, i1) -> ()
 // CHECK-NEXT: %memspacecast = memref.memory_space_cast %cast : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
 // CHECK-NEXT: sycl.constructor @id(%memspacecast) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1Ev} : (memref<?x!sycl_id_2_, 4>)
 
@@ -270,10 +270,10 @@ extern "C" SYCL_EXTERNAL void cons_10(const sycl::long8 &A,
 // CHECK-DAG:     %[[FALSE:.*]] = arith.constant false
 // CHECK-DAG:     %[[C0_I8:.*]] = arith.constant 0 : i8
 // CHECK-NEXT:    %[[ALLOCA:.*]] = memref.alloca() : memref<1x!sycl_vec_i32_4_>
-// CHECK-NEXT:    %[[VAL0:.*]] = "polygeist.memref2pointer"(%[[ALLOCA]]) : (memref<1x!sycl_vec_i32_4_>) -> !llvm.ptr<i8>
+// CHECK-NEXT:    %[[VAL0:.*]] = "polygeist.memref2pointer"(%[[ALLOCA]]) : (memref<1x!sycl_vec_i32_4_>) -> !llvm.ptr
 // CHECK-NEXT:    %[[VAL1:.*]] = "polygeist.typeSize"() {source = !sycl_vec_i32_4_} : () -> index
 // CHECK-NEXT:    %[[VAL2:.*]] = arith.index_cast %[[VAL1]] : index to i64
-// CHECK-NEXT:    "llvm.intr.memset"(%[[VAL0]], %[[C0_I8]], %[[VAL2]], %[[FALSE]]) : (!llvm.ptr<i8>, i8, i64, i1) -> ()
+// CHECK-NEXT:    "llvm.intr.memset"(%[[VAL0]], %[[C0_I8]], %[[VAL2]], %[[FALSE]]) : (!llvm.ptr, i8, i64, i1) -> ()
 
 // CHECK-LLVM-LABEL:  define spir_func void @cons_11()
 // CHECK-LLVM-SAME:                                    #[[FUNCATTRS]] {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/function_filter.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/function_filter.cpp
@@ -1,5 +1,5 @@
-// RUN: clang++ -fsycl -fsycl-device-only -emit-mlir -Xcgeist -function=match %s -o - | FileCheck %s
-// RUN: clang++ -fsycl -fsycl-device-only -emit-mlir -Xcgeist -function=match$ %s -o - | FileCheck %s --check-prefix=CHECK-END
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -emit-mlir -Xcgeist -function=match %s -o - | FileCheck %s
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -emit-mlir -Xcgeist -function=match$ %s -o - | FileCheck %s --check-prefix=CHECK-END
 
 // COM: No GPU functions.
 // CHECK-NOT: gpu.func

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -1,5 +1,5 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-llvm %s -o %t && rm %t
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-llvm %s -o %t && rm %t
 
 #include <sycl/sycl.hpp>
 
@@ -13,7 +13,7 @@
 // CHECK-MLIR-DAG: !sycl_accessor_impl_device_2_ = !sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>
 // CHECK-MLIR-DAG: !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
 // CHECK-MLIR-DAG: !sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(memref<?xi32, 1>)>)>
-// CHECK-MLIR-DAG: ![[ACC_STRUCT:.*]] = !sycl.accessor<[1, !llvm.struct<(i32)>, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<struct<(i32)>, 1>)>)>
+// CHECK-MLIR-DAG: ![[ACC_STRUCT:.*]] = !sycl.accessor<[1, !llvm.struct<(i32)>, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<1>)>)>
 // CHECK-MLIR-DAG: ![[ACC_SUBSCRIPT:.*]] = !sycl.accessor_subscript<[1], (!sycl_id_2_, !sycl_accessor_2_i32_rw_gb)>
 // CHECK-MLIR-DAG: ![[ITEM_BASE1:.*]] = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)
 // CHECK-MLIR-DAG: ![[ITEM_BASE2:.*]] = !sycl.item_base<[2, true], (!sycl_range_2_, !sycl_id_2_, !sycl_id_2_)>
@@ -80,7 +80,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_2(sycl::accessor<sycl::cl_int, 1>
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_3N4sycl3_V18accessorI6StructLi1ELNS0_6access4modeE1026ELNS3_6targetE2014ELNS3_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-MLIR:          %{{.*}}: memref<?x![[ACC_STRUCT]]> {llvm.align = 8 : i64, llvm.byval = ![[ACC_STRUCT]], llvm.noundef}, 
 // CHECK-MLIR-SAME:     %{{.*}}: i64 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x![[ACC_STRUCT]], 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x![[ACC_STRUCT]]>, memref<?x!sycl_id_1_>) -> !llvm.ptr<struct<(i32)>, 4> 
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x![[ACC_STRUCT]], 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x![[ACC_STRUCT]]>, memref<?x!sycl_id_1_>) -> !llvm.ptr<4> 
 
 typedef struct {
   unsigned field;

--- a/polygeist/tools/cgeist/Test/Verification/sycl/global_string.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/global_string.cpp
@@ -1,4 +1,4 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=MLIR
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=MLIR
 #include <sycl/sycl.hpp>
 
 void test_global_string(sycl::device d) {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/illegal_methodop.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/illegal_methodop.cpp
@@ -1,4 +1,4 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/image.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/image.cpp
@@ -1,4 +1,4 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir -o - %s | FileCheck %s 
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir -o - %s | FileCheck %s 
 
 #include <sycl/accessor.hpp>
 #include <sycl/sycl.hpp>
@@ -6,9 +6,9 @@
 using namespace sycl;
 static constexpr unsigned N = 8;
 
-// CHECK-LABEL:  func.func @_ZN4sycl3_V18accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS4_6targetE2017ELNS4_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initE14ocl_image1d_ro(%arg0: memref<?x!sycl_accessor_1_21sycl2Evec3C5Bf322C_45D2C_28vector3C4xf323E293E_r_i, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 32 : i64, llvm.noundef}, %arg1: !llvm.ptr<struct<"opencl.image1d_ro_t", opaque>, 1>)
-// CHECK-NEXT:    %0 = "polygeist.memref2pointer"(%arg0) : (memref<?x!sycl_accessor_1_21sycl2Evec3C5Bf322C_45D2C_28vector3C4xf323E293E_r_i, 4>) -> !llvm.ptr<struct<(ptr<struct<"opencl.image1d_ro_t", opaque>, 1>, array<24 x i8>)>, 4>
-// CHECK-NEXT:    sycl.call @imageAccessorInit(%0, %arg1) {MangledFunctionName = @_ZN4sycl3_V16detail14image_accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS5_6targetE2017ELNS5_11placeholderE0EE17imageAccessorInitE14ocl_image1d_ro, TypeName = @image_accessor} : (!llvm.ptr<struct<(ptr<struct<"opencl.image1d_ro_t", opaque>, 1>, array<24 x i8>)>, 4>, !llvm.ptr<struct<"opencl.image1d_ro_t", opaque>, 1>) -> ()
+// CHECK-LABEL:  func.func @_ZN4sycl3_V18accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS4_6targetE2017ELNS4_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initE14ocl_image1d_ro(%arg0: memref<?x!sycl_accessor_1_21sycl2Evec3C5Bf322C_45D2C_28vector3C4xf323E293E_r_i, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 32 : i64, llvm.noundef}, %arg1: !llvm.ptr<1>)
+// CHECK-NEXT:    %0 = "polygeist.memref2pointer"(%arg0) : (memref<?x!sycl_accessor_1_21sycl2Evec3C5Bf322C_45D2C_28vector3C4xf323E293E_r_i, 4>) -> !llvm.ptr<4>
+// CHECK-NEXT:    sycl.call @imageAccessorInit(%0, %arg1) {MangledFunctionName = @_ZN4sycl3_V16detail14image_accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS5_6targetE2017ELNS5_11placeholderE0EE17imageAccessorInitE14ocl_image1d_ro, TypeName = @image_accessor} : (!llvm.ptr<4>, !llvm.ptr<1>) -> ()
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 
@@ -17,12 +17,12 @@ static constexpr unsigned N = 8;
 // CHECK-DAG:     %alloca = memref.alloca() : memref<1xi32>
 // CHECK-DAG:     %0 = llvm.mlir.undef : i32
 // CHECK-NEXT:    affine.store %0, %alloca[0] : memref<1xi32>
-// CHECK-NEXT:    %1 = "polygeist.memref2pointer"(%arg0) : (memref<?x!llvm.struct<(!sycl_accessor_1_21sycl2Evec3C5Bf322C_45D2C_28vector3C4xf323E293E_r_i)>, 4>) -> !llvm.ptr<struct<(ptr<struct<"opencl.image1d_ro_t", opaque>, 1>, array<24 x i8>)>, 4>
+// CHECK-NEXT:    %1 = "polygeist.memref2pointer"(%arg0) : (memref<?x!llvm.struct<(!sycl_accessor_1_21sycl2Evec3C5Bf322C_45D2C_28vector3C4xf323E293E_r_i)>, 4>) -> !llvm.ptr<4>
 // CHECK-NEXT:    %2 = sycl.item.get_id(%arg1, %c0_i32) {ArgumentTypes = [memref<?x!sycl_item_1_, 4>, i32], FunctionName = @"operator[]", TypeName = @item} : (memref<?x!sycl_item_1_>, i32) -> i64
 // CHECK-NEXT:    %3 = arith.trunci %2 : i64 to i32
 // CHECK-NEXT:    %memspacecast = memref.memory_space_cast %cast : memref<?xi32> to memref<?xi32, 4>
 // CHECK-NEXT:    affine.store %3, %memspacecast[0] : memref<?xi32, 4>
-// CHECK-NEXT:    %4 = sycl.call @read(%1, %memspacecast) {MangledFunctionName = @_ZNK4sycl3_V16detail14image_accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS5_6targetE2017ELNS5_11placeholderE0EE4readIiLi1EvEES4_RKT_, TypeName = @image_accessor} : (!llvm.ptr<struct<(ptr<struct<"opencl.image1d_ro_t", opaque>, 1>, array<24 x i8>)>, 4>, memref<?xi32, 4>) -> !sycl_vec_f32_4_
+// CHECK-NEXT:    %4 = sycl.call @read(%1, %memspacecast) {MangledFunctionName = @_ZNK4sycl3_V16detail14image_accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS5_6targetE2017ELNS5_11placeholderE0EE4readIiLi1EvEES4_RKT_, TypeName = @image_accessor} : (!llvm.ptr<4>, memref<?xi32, 4>) -> !sycl_vec_f32_4_
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
@@ -1,5 +1,5 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 
@@ -7,25 +7,24 @@
 
 // CHECK-MLIR-LABEL: gpu.func @_ZTSN4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EE
 // CHECK-MLIR-SAME:     (%arg0: memref<?x!sycl_range_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_1_, llvm.noundef}, 
-// CHECK-MLIR-SAME:      %arg1: !llvm.ptr<!llvm.struct<(memref<?xi32, 1>)>> {llvm.align = 8 : i64, llvm.byval = !llvm.struct<(memref<?xi32, 1>)>, llvm.noundef}) 
+// CHECK-MLIR-SAME:      %arg1: !llvm.ptr {llvm.align = 8 : i64, llvm.byval = !llvm.struct<(memref<?xi32, 1>)>, llvm.noundef}) 
 // CHECK-MLIR-SAME:      kernel attributes {llvm.cconv = #llvm.cconv<spir_kernelcc>, llvm.linkage = #llvm.linkage<weak_odr>
 
-// CHECK-MLIR: sycl.constructor @range(%memspacecast, %memspacecast_4) {MangledFunctionName = @_ZN4sycl3_V15rangeILi1EEC1ERKS2_} : (memref<?x!sycl_range_1_, 4>, memref<?x!sycl_range_1_, 4>)
-// CHECK-MLIR: %2 = affine.load %alloca_0[0] : memref<1x!sycl_range_1_>
-// CHECK-MLIR: affine.store %2, %1[0] : memref<?x!sycl_range_1_>
-// CHECK-MLIR: %3 = "polygeist.subindex"(%cast_3, %c1) : (memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>>, index) -> memref<?x!llvm.struct<(memref<?xi32, 4>)>>
-// CHECK-MLIR: %4 = llvm.bitcast %arg1 : !llvm.ptr<!llvm.struct<(memref<?xi32, 1>)>> to !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>>
-// CHECK-MLIR: %5 = llvm.addrspacecast %0 : !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>> to !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>, 4>
-// CHECK-MLIR: %6 = llvm.addrspacecast %4 : !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>> to !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>, 4>
-// CHECK-MLIR: func.call @_ZZ4testRN4sycl3_V15queueEENUlNS0_2idILi1EEEE_C1ERKS5_(%5, %6) : (!llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>, 4>, !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>, 4>) -> ()
-// CHECK-MLIR: %7 = llvm.load %0 : !llvm.ptr<!llvm.struct<(memref<?xi32, 4>)>>
-// CHECK-MLIR: affine.store %7, %3[0] : memref<?x!llvm.struct<(memref<?xi32, 4>)>>
-// CHECK-MLIR: %8 = sycl.call @declptr() {MangledFunctionName = @_ZN4sycl3_V16detail7declptrINS0_4itemILi1ELb1EEEEEPT_v} : () -> memref<?x!sycl_item_1_, 4>
-// CHECK-MLIR: %9 = sycl.call @getElement(%8) {MangledFunctionName = @_ZN4sycl3_V16detail7Builder10getElementILi1ELb1EEEDTcl7getItemIXT_EXT0_EEEEPNS0_4itemIXT_EXT0_EEE, TypeName = @Builder} : (memref<?x!sycl_item_1_, 4>) -> !sycl_item_1_
-// CHECK-MLIR: %memspacecast_5 = memref.memory_space_cast %cast_3 : memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>> to memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>, 4>
-// CHECK-MLIR: affine.store %9, %alloca[0] : memref<1x!sycl_item_1_>
-// CHECK-MLIR: sycl.call @"operator()"(%memspacecast_5, %cast) {MangledFunctionName = @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_, TypeName = @RoundedRangeKernel} : (memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>, 4>, memref<?x!sycl_item_1_>) -> ()
-// CHECK-MLIR: gpu.return
+// CHECK-MLIR:         sycl.constructor @range(%[[VAL_11:.*]], %[[VAL_12:.*]]) {MangledFunctionName = @_ZN4sycl3_V15rangeILi1EEC1ERKS2_} : (memref<?x!sycl_range_1_, 4>, memref<?x!sycl_range_1_, 4>)
+// CHECK-MLIR:         %[[VAL_14:.*]] = affine.load %[[VAL_6:.*]][0] : memref<1x!sycl_range_1_>
+// CHECK-MLIR:         affine.store %[[VAL_14]], %[[VAL_10:.*]][0] : memref<?x!sycl_range_1_>
+// CHECK-MLIR:         %[[VAL_15:.*]] = "polygeist.subindex"(%[[VAL_9:.*]], %[[VAL_1:.*]]) : (memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>>, index) -> memref<?x!llvm.struct<(memref<?xi32, 4>)>>
+// CHECK-MLIR:         %[[VAL_16:.*]] = llvm.addrspacecast %[[VAL_5:.*]] : !llvm.ptr to !llvm.ptr<4>
+// CHECK-MLIR:         %[[VAL_17:.*]] = llvm.addrspacecast %[[VAL_18:.*]] : !llvm.ptr to !llvm.ptr<4>
+// CHECK-MLIR:         func.call @_ZZ4testRN4sycl3_V15queueEENUlNS0_2idILi1EEEE_C1ERKS5_(%[[VAL_16]], %[[VAL_17]]) : (!llvm.ptr<4>, !llvm.ptr<4>) -> ()
+// CHECK-MLIR:         %[[VAL_19:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> !llvm.struct<(memref<?xi32, 4>)>
+// CHECK-MLIR:         affine.store %[[VAL_19]], %[[VAL_15]][0] : memref<?x!llvm.struct<(memref<?xi32, 4>)>>
+// CHECK-MLIR:         %[[VAL_20:.*]] = sycl.call @declptr() {MangledFunctionName = @_ZN4sycl3_V16detail7declptrINS0_4itemILi1ELb1EEEEEPT_v} : () -> memref<?x!sycl_item_1_, 4>
+// CHECK-MLIR:         %[[VAL_21:.*]] = sycl.call @getElement(%[[VAL_20]]) {MangledFunctionName = @_ZN4sycl3_V16detail7Builder10getElementILi1ELb1EEEDTcl7getItemIXT_EXT0_EEEEPNS0_4itemIXT_EXT0_EEE, TypeName = @Builder} : (memref<?x!sycl_item_1_, 4>) -> !sycl_item_1_
+// CHECK-MLIR:         %[[VAL_22:.*]] = memref.memory_space_cast %[[VAL_9]] : memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>> to memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>, 4>
+// CHECK-MLIR:         affine.store %[[VAL_21]], %[[VAL_3:.*]][0] : memref<1x!sycl_item_1_>
+// CHECK-MLIR:         sycl.call @"operator()"(%[[VAL_22]], %[[VAL_4:.*]]) {MangledFunctionName = @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_, TypeName = @RoundedRangeKernel} : (memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>, 4>, memref<?x!sycl_item_1_>) -> ()
+// CHECK-MLIR:         gpu.return
 
 // CHECK-LLVM-LABEL: define weak_odr spir_kernel void @_ZTSN4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EE
 // CHECK-LLVM-SAME:     (%"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %0, 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -1,5 +1,5 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
@@ -1,5 +1,5 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/minimum.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/minimum.cpp
@@ -1,24 +1,28 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s
 
-// CHECK-LABEL:    func.func @_ZNKSt4lessIvEclIRiS2_EEDTltclsr3stdE7forwardIT_Efp_Eclsr3stdE7forwardIT0_Efp0_EEOS3_OS4_(%arg0: !llvm.ptr<struct<(i8)>, 4> {llvm.align = 1 : i64, llvm.dereferenceable_or_null = 1 : i64, llvm.noundef}, %arg1: memref<?xi32, 4> {llvm.align = 4 : i64, llvm.dereferenceable = 4 : i64, llvm.noundef}, %arg2: memref<?xi32, 4> {llvm.align = 4 : i64, llvm.dereferenceable = 4 : i64, llvm.noundef}) -> (i1 {llvm.noundef, llvm.zeroext})
-// CHECK-DAG:        %c1_i64 = arith.constant 1 : i64
-// CHECK-DAG:        %0 = llvm.alloca %c1_i64 x !llvm.struct<(i8)> : (i64) -> !llvm.ptr<struct<(i8)>>
-// CHECK-DAG:        %1 = llvm.alloca %c1_i64 x !llvm.struct<(i8)> : (i64) -> !llvm.ptr<struct<(i8)>>
-// CHECK-DAG:        %2 = llvm.alloca %c1_i64 x !llvm.struct<(i8)> : (i64) -> !llvm.ptr<struct<(i8)>>
-// CHECK-DAG:        %3 = llvm.alloca %c1_i64 x !llvm.struct<(i8)> : (i64) -> !llvm.ptr<struct<(i8)>>
-// CHECK-NEXT:       %4 = llvm.addrspacecast %1 : !llvm.ptr<struct<(i8)>> to !llvm.ptr<struct<(i8)>, 4>
-// CHECK-NEXT:       %5 = llvm.load %2 : !llvm.ptr<struct<(i8)>>
-// CHECK-NEXT:       llvm.store %5, %4 : !llvm.ptr<struct<(i8)>, 4>
-// CHECK-NEXT:       %6 = llvm.mlir.null : !llvm.ptr<struct<(i8)>, 4>
-// CHECK-NEXT:       %7 = llvm.icmp "ne" %4, %6 : !llvm.ptr<struct<(i8)>, 4>
-// CHECK-NEXT:       %8 = arith.select %7, %4, %6 : !llvm.ptr<struct<(i8)>, 4>
-// CHECK-NEXT:       %9 = llvm.addrspacecast %3 : !llvm.ptr<struct<(i8)>> to !llvm.ptr<struct<(i8)>, 4>
-// CHECK-NEXT:       call @_ZNSt17integral_constantIbLb0EEC1EOS0_(%9, %8) : (!llvm.ptr<struct<(i8)>, 4>, !llvm.ptr<struct<(i8)>, 4>) -> ()
-// CHECK-NEXT:       %10 = llvm.load %3 : !llvm.ptr<struct<(i8)>>
-// CHECK-NEXT:       llvm.store %10, %0 : !llvm.ptr<struct<(i8)>>
-// CHECK-NEXT:       %11 = call @_ZNSt4lessIvE6_S_cmpIRiS2_EEDcOT_OT0_St17integral_constantIbLb0EE(%arg1, %arg2, %0) : (memref<?xi32, 4>, memref<?xi32, 4>, !llvm.ptr<struct<(i8)>>) -> i1
-// CHECK-NEXT:       return %11 : i1
-// CHECK-NEXT:     }
+// CHECK-LABEL:     func.func @_ZNKSt4lessIvEclIRiS2_EEDTltclsr3stdE7forwardIT_Efp_Eclsr3stdE7forwardIT0_Efp0_EEOS3_OS4_(
+// CHECK-SAME:        %[[VAL_735:.*]]: !llvm.ptr<4> {llvm.align = 1 : i64, llvm.dereferenceable_or_null = 1 : i64, llvm.noundef},
+// CHECK-SAME:        %[[VAL_736:.*]]: memref<?xi32, 4> {llvm.align = 4 : i64, llvm.dereferenceable = 4 : i64, llvm.noundef}, 
+// CHECK-SAME:        %[[VAL_737:.*]]: memref<?xi32, 4> {llvm.align = 4 : i64, llvm.dereferenceable = 4 : i64, llvm.noundef})
+// CHECK-SAME:          -> (i1 {llvm.noundef, llvm.zeroext})
+// CHECK-DAG:         %[[VAL_738:.*]] = arith.constant 1 : i64
+// CHECK-DAG:         %[[VAL_739:.*]] = llvm.alloca %[[VAL_738]] x !llvm.struct<(i8)> : (i64) -> !llvm.ptr
+// CHECK-DAG:         %[[VAL_740:.*]] = llvm.alloca %[[VAL_738]] x !llvm.struct<(i8)> : (i64) -> !llvm.ptr
+// CHECK-DAG:         %[[VAL_741:.*]] = llvm.alloca %[[VAL_738]] x !llvm.struct<(i8)> : (i64) -> !llvm.ptr
+// CHECK-DAG:         %[[VAL_742:.*]] = llvm.alloca %[[VAL_738]] x !llvm.struct<(i8)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:        %[[VAL_743:.*]] = llvm.addrspacecast %[[VAL_740]] : !llvm.ptr to !llvm.ptr<4>
+// CHECK-NEXT:        %[[VAL_744:.*]] = llvm.load %[[VAL_741]] : !llvm.ptr -> !llvm.struct<(i8)>
+// CHECK-NEXT:        llvm.store %[[VAL_744]], %[[VAL_743]] : !llvm.struct<(i8)>, !llvm.ptr<4>
+// CHECK-NEXT:        %[[VAL_745:.*]] = llvm.mlir.null : !llvm.ptr<4>
+// CHECK-NEXT:        %[[VAL_746:.*]] = llvm.icmp "ne" %[[VAL_743]], %[[VAL_745]] : !llvm.ptr<4>
+// CHECK-NEXT:        %[[VAL_747:.*]] = arith.select %[[VAL_746]], %[[VAL_743]], %[[VAL_745]] : !llvm.ptr<4>
+// CHECK-NEXT:        %[[VAL_748:.*]] = llvm.addrspacecast %[[VAL_742]] : !llvm.ptr to !llvm.ptr<4>
+// CHECK-NEXT:        call @_ZNSt17integral_constantIbLb0EEC1EOS0_(%[[VAL_748]], %[[VAL_747]]) : (!llvm.ptr<4>, !llvm.ptr<4>) -> ()
+// CHECK-NEXT:        %[[VAL_749:.*]] = llvm.load %[[VAL_742]] : !llvm.ptr -> !llvm.struct<(i8)>
+// CHECK-NEXT:        llvm.store %[[VAL_749]], %[[VAL_739]] : !llvm.struct<(i8)>, !llvm.ptr
+// CHECK-NEXT:        %[[VAL_750:.*]] = call @_ZNSt4lessIvE6_S_cmpIRiS2_EEDcOT_OT0_St17integral_constantIbLb0EE(%[[VAL_736]], %[[VAL_737]], %[[VAL_739]]) : (memref<?xi32, 4>, memref<?xi32, 4>, !llvm.ptr) -> i1
+// CHECK-NEXT:        return %[[VAL_750]] : i1
+// CHECK-NEXT:      }
 
 #include <sycl/sycl.hpp>
 using namespace sycl;

--- a/polygeist/tools/cgeist/Test/Verification/sycl/options.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/options.cpp
@@ -1,5 +1,5 @@
 // COM: Ensure warnings are suppressed (-w)
-// RUN: clang++ -w -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir %s -S -emit-llvm -o - 2>&1 | FileCheck %s --implicit-check-not="{{warning|Warning}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -w -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir %s -S -emit-llvm -o - 2>&1 | FileCheck %s --implicit-check-not="{{warning|Warning}}:"
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/parallel_for.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/parallel_for.cpp
@@ -1,10 +1,10 @@
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.0fast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.0fast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
 
 // Test that the LLVMIR generated is verifiable.
 // RUN: opt -passes=verify -disable-output < %t.bc

--- a/polygeist/tools/cgeist/Test/Verification/sycl/pure_const_attrs.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/pure_const_attrs.cpp
@@ -1,5 +1,5 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 // CHECK-MLIR-DAG: func.func private @func_const() {{.*}} attributes {{{.*}}passthrough = [{{.*}}"nounwind", {{.*}}"willreturn", {{.*}}["memory", "0"]{{.*}}]}
 // CHECK-MLIR-DAG: func.func private @func_pure() {{.*}} attributes {{{.*}}passthrough = [{{.*}}"nounwind", {{.*}}"willreturn", {{.*}}["memory", "21"]{{.*}}]}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/restrict.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/restrict.cpp
@@ -1,5 +1,5 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 
@@ -8,7 +8,7 @@
 
 extern "C" SYCL_EXTERNAL int test_int(int * __restrict__ a, int * __restrict__ b) {}
 
-// CHECK-MLIR-DAG: func.func @test_struct(%arg0: !llvm.ptr<struct<(i32)>, 4> {{{.*}}llvm.noalias{{.*}}}, %arg1: !llvm.ptr<struct<(i32)>, 4> {{{.*}}llvm.noalias{{.*}}})
+// CHECK-MLIR-DAG: func.func @test_struct(%arg0: !llvm.ptr<4> {{{.*}}llvm.noalias{{.*}}}, %arg1: !llvm.ptr<4> {{{.*}}llvm.noalias{{.*}}})
 // CHECK-LLVM-DAG: define spir_func void @test_struct({ i32 } addrspace(4)* noalias {{.*}}%0, { i32 } addrspace(4)* noalias {{.*}}%1)
 struct S {
   int i;
@@ -19,7 +19,7 @@ extern "C" SYCL_EXTERNAL void test_struct(struct S * __restrict__ a, struct S * 
 // CHECK-LLVM-DAG: define spir_func void @test_vec(%"class.sycl::_V1::vec" addrspace(4)* noalias {{.*}}%0, %"class.sycl::_V1::vec" addrspace(4)* noalias {{.*}}%1)
 extern "C" SYCL_EXTERNAL void test_vec(sycl::vec<sycl::cl_double, 16> * __restrict__ a, const sycl::vec<sycl::cl_double, 16> * __restrict__ b) {}
 
-// CHECK-MLIR-DAG: func.func @_ZN1B10test_classEP1APS_(%arg0: !llvm.ptr<struct<(i8)>, 4> {{.*}}, %arg1: !llvm.ptr<struct<(i8)>, 4> {llvm.noalias{{.*}}}, %arg2: !llvm.ptr<struct<(i8)>, 4> {llvm.noalias{{.*}}})
+// CHECK-MLIR-DAG: func.func @_ZN1B10test_classEP1APS_(%arg0: !llvm.ptr<4> {{.*}}, %arg1: !llvm.ptr<4> {llvm.noalias{{.*}}}, %arg2: !llvm.ptr<4> {llvm.noalias{{.*}}})
 // CHECK-LLVM-DAG: define linkonce_odr spir_func void @_ZN1B10test_classEP1APS_({ i8 } addrspace(4)* {{.*}}%0, { i8 } addrspace(4)* noalias {{.*}}%1, { i8 } addrspace(4)* noalias {{.*}}%2)
 class A {};
 class B {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
@@ -1,10 +1,10 @@
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.Ofast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.Ofast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
 
 // Test that the LLVMIR generated is verifiable.
 // RUN: opt -passes=verify -disable-output < %t.bc

--- a/polygeist/tools/cgeist/Test/Verification/sycl/stream-copy.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/stream-copy.cpp
@@ -1,10 +1,10 @@
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.Ofast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.Ofast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
 
 // Test that the LLVMIR generated is verifiable.
 // RUN: opt -passes=verify -disable-output < %t.bc

--- a/polygeist/tools/cgeist/Test/Verification/sycl/stream-triad.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/stream-triad.cpp
@@ -1,10 +1,10 @@
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.Ofast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.Ofast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
 
 // Test that the LLVMIR generated is verifiable.
 // RUN: opt -passes=verify -disable-output < %t.bc

--- a/polygeist/tools/cgeist/Test/Verification/sycl/structvec.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/structvec.cpp
@@ -46,7 +46,7 @@ SYCL_EXTERNAL structvec test_store(structvec sv, int idx, char el) {
   return sv;
 }
 
-// CHECK-LABEL:     func.func @_Z9test_initv() -> !llvm.struct<(vector<2xi8>)> attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["convergent", "mustprogress", "noinline", "norecurse", "nounwind", "optnone", ["frame-pointer", "all"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["sycl-module-id", "/home/lukas/Code/MLIR-SYCL/upstream/sycl-mlir/polygeist/tools/cgeist/Test/Verification/sycl/structvec.cpp"]]} {
+// CHECK-LABEL:     func.func @_Z9test_initv() -> !llvm.struct<(vector<2xi8>)>
 // CHECK-DAG:         %[[VAL_167:.*]] = arith.constant 2 : i64
 // CHECK-DAG:         %[[VAL_168:.*]] = arith.constant 1 : i8
 // CHECK-DAG:         %[[VAL_169:.*]] = arith.constant 0 : i8
@@ -84,7 +84,9 @@ SYCL_EXTERNAL structvec test_store(structvec sv, int idx, char el) {
 // CHECK-NEXT:      }
 
 
-// CHECK-NEXT:      func.func @_ZN9structvecC1ESt16initializer_listIcE(%[[VAL_191:.*]]: !llvm.ptr<4> {llvm.align = 2 : i64, llvm.dereferenceable_or_null = 2 : i64, llvm.noundef}, %[[VAL_192:.*]]: !llvm.ptr {llvm.align = 8 : i64, llvm.byval = !llvm.struct<(memref<?xi8, 4>, i64)>, llvm.noundef}) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<linkonce_odr>, passthrough = ["convergent", "mustprogress", "noinline", "norecurse", "nounwind", "optnone", ["frame-pointer", "all"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["sycl-module-id", "/home/lukas/Code/MLIR-SYCL/upstream/sycl-mlir/polygeist/tools/cgeist/Test/Verification/sycl/structvec.cpp"]]} {
+// CHECK-LABEL:     func.func @_ZN9structvecC1ESt16initializer_listIcE(
+// CHECK-SAME:          %[[VAL_191:.*]]: !llvm.ptr<4> {llvm.align = 2 : i64, llvm.dereferenceable_or_null = 2 : i64, llvm.noundef}
+// CHECK-SAME:          %[[VAL_192:.*]]: !llvm.ptr {llvm.align = 8 : i64, llvm.byval = !llvm.struct<(memref<?xi8, 4>, i64)>, llvm.noundef})
 // CHECK-DAG:         %[[VAL_193:.*]] = arith.constant -1 : i32
 // CHECK-DAG:         %[[VAL_194:.*]] = arith.constant 0 : i32
 // CHECK-DAG:         %[[VAL_195:.*]] = arith.constant 0 : i8

--- a/polygeist/tools/cgeist/Test/Verification/sycl/structvec.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/structvec.cpp
@@ -1,4 +1,4 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s
 
 #include <initializer_list>
 #include <sycl/sycl.hpp>
@@ -14,90 +14,96 @@ struct structvec {
   }
 };
 
-// CHECK-LABEL: func.func @_Z10test_store9structvecic(%arg0: !llvm.ptr<struct<(vector<2xi8>)>> {llvm.align = 2 : i64, llvm.byval = !llvm.struct<(vector<2xi8>)>, llvm.noundef}, %arg1: i32 {llvm.noundef}, %arg2: i8 {llvm.noundef, llvm.signext}) -> !llvm.struct<(vector<2xi8>)>
-// CHECK-NEXT:    %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:    %0 = llvm.alloca %c1_i64 x !llvm.struct<(vector<2xi8>)> : (i64) -> !llvm.ptr<struct<(vector<2xi8>)>>
-// CHECK-NEXT:    %1 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(vector<2xi8>)>>) -> !llvm.ptr<vector<2xi8>>
-// CHECK-NEXT:    %2 = llvm.load %1 : !llvm.ptr<vector<2xi8>>
-// CHECK-NEXT:    %3 = vector.insertelement %arg2, %2[%arg1 : i32] : vector<2xi8>
-// CHECK-NEXT:    llvm.store %3, %1 : !llvm.ptr<vector<2xi8>>
-// CHECK-NEXT:    %4 = llvm.addrspacecast %0 : !llvm.ptr<struct<(vector<2xi8>)>> to !llvm.ptr<struct<(vector<2xi8>)>, 4>
-// CHECK-NEXT:    %5 = llvm.addrspacecast %arg0 : !llvm.ptr<struct<(vector<2xi8>)>> to !llvm.ptr<struct<(vector<2xi8>)>, 4>
-// CHECK-NEXT:    call @_ZN9structvecC1EOS_(%4, %5) : (!llvm.ptr<struct<(vector<2xi8>)>, 4>, !llvm.ptr<struct<(vector<2xi8>)>, 4>) -> ()
-// CHECK-NEXT:    %6 = llvm.load %0 : !llvm.ptr<struct<(vector<2xi8>)>>
-// CHECK-NEXT:    return %6 : !llvm.struct<(vector<2xi8>)>
-// CHECK-NEXT:  }
+// CHECK-LABEL:     func.func @_Z10test_store9structvecic(
+// CHECK-SAME:          %[[VAL_151:.*]]: !llvm.ptr {llvm.align = 2 : i64, llvm.byval = !llvm.struct<(vector<2xi8>)>, llvm.noundef}, 
+// CHECK-SAME:          %[[VAL_152:.*]]: i32 {llvm.noundef}, %[[VAL_153:.*]]: i8 {llvm.noundef, llvm.signext}) -> !llvm.struct<(vector<2xi8>)>
+// CHECK-NEXT:        %[[VAL_154:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:        %[[VAL_155:.*]] = llvm.alloca %[[VAL_154]] x !llvm.struct<(vector<2xi8>)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:        %[[VAL_156:.*]] = llvm.getelementptr inbounds %[[VAL_151]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(vector<2xi8>)>
+// CHECK-NEXT:        %[[VAL_157:.*]] = llvm.load %[[VAL_156]] : !llvm.ptr -> vector<2xi8>
+// CHECK-NEXT:        %[[VAL_158:.*]] = vector.insertelement %[[VAL_153]], %[[VAL_157]]{{\[}}%[[VAL_152]] : i32] : vector<2xi8>
+// CHECK-NEXT:        llvm.store %[[VAL_158]], %[[VAL_156]] : vector<2xi8>, !llvm.ptr
+// CHECK-NEXT:        %[[VAL_159:.*]] = llvm.addrspacecast %[[VAL_155]] : !llvm.ptr to !llvm.ptr<4>
+// CHECK-NEXT:        %[[VAL_160:.*]] = llvm.addrspacecast %[[VAL_151]] : !llvm.ptr to !llvm.ptr<4>
+// CHECK-NEXT:        call @_ZN9structvecC1EOS_(%[[VAL_159]], %[[VAL_160]]) : (!llvm.ptr<4>, !llvm.ptr<4>) -> ()
+// CHECK-NEXT:        %[[VAL_161:.*]] = llvm.load %[[VAL_155]] : !llvm.ptr -> !llvm.struct<(vector<2xi8>)>
+// CHECK-NEXT:        return %[[VAL_161]] : !llvm.struct<(vector<2xi8>)>
+// CHECK-NEXT:      }
 
-// CHECK-LABEL: func.func @_ZN9structvecC1EOS_(%arg0: !llvm.ptr<struct<(vector<2xi8>)>, 4> {llvm.align = 2 : i64, llvm.dereferenceable_or_null = 2 : i64, llvm.noundef}, %arg1: !llvm.ptr<struct<(vector<2xi8>)>, 4> {llvm.align = 2 : i64, llvm.dereferenceable = 2 : i64, llvm.noundef})
-// CHECK-NEXT:    %0 = llvm.getelementptr inbounds %arg1[0, 0] : (!llvm.ptr<struct<(vector<2xi8>)>, 4>) -> !llvm.ptr<vector<2xi8>, 4>
-// CHECK-NEXT:    %1 = llvm.load %0 : !llvm.ptr<vector<2xi8>, 4>
-// CHECK-NEXT:    %2 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(vector<2xi8>)>, 4>) -> !llvm.ptr<vector<2xi8>, 4>
-// CHECK-NEXT:    llvm.store %1, %2 : !llvm.ptr<vector<2xi8>, 4>
-// CHECK-NEXT:    return
-// CHECK-NEXT:  }
+
+// CHECK-LABEL:     func.func @_ZN9structvecC1EOS_(
+// CHECK-SAME:          %[[VAL_162:.*]]: !llvm.ptr<4> {llvm.align = 2 : i64, llvm.dereferenceable_or_null = 2 : i64, llvm.noundef}
+// CHECK-SAME:          %[[VAL_163:.*]]: !llvm.ptr<4> {llvm.align = 2 : i64, llvm.dereferenceable = 2 : i64, llvm.noundef})
+// CHECK-NEXT:        %[[VAL_164:.*]] = llvm.getelementptr inbounds %[[VAL_163]][0, 0] : (!llvm.ptr<4>) -> !llvm.ptr<4>, !llvm.struct<(vector<2xi8>)>
+// CHECK-NEXT:        %[[VAL_165:.*]] = llvm.load %[[VAL_164]] : !llvm.ptr<4> -> vector<2xi8>
+// CHECK-NEXT:        %[[VAL_166:.*]] = llvm.getelementptr inbounds %[[VAL_162]][0, 0] : (!llvm.ptr<4>) -> !llvm.ptr<4>, !llvm.struct<(vector<2xi8>)>
+// CHECK-NEXT:        llvm.store %[[VAL_165]], %[[VAL_166]] : vector<2xi8>, !llvm.ptr<4>
+// CHECK-NEXT:        return
+// CHECK-NEXT:      }
 
 SYCL_EXTERNAL structvec test_store(structvec sv, int idx, char el) {
   sv.v[idx] = el;
   return sv;
 }
 
-// CHECK-LABEL: func.func @_Z9test_initv() -> !llvm.struct<(vector<2xi8>)>
-// CHECK-DAG:     %c2_i64 = arith.constant 2 : i64
-// CHECK-DAG:     %c1_i8 = arith.constant 1 : i8
-// CHECK-DAG:     %c0_i8 = arith.constant 0 : i8
-// CHECK-DAG:     %c1_i64 = arith.constant 1 : i64
-// CHECK-DAG:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(vector<2xi8>)> : (i64) -> !llvm.ptr<struct<(vector<2xi8>)>>
-// CHECK-DAG:     %1 = llvm.alloca %c1_i64 x !llvm.struct<(vector<2xi8>)> : (i64) -> !llvm.ptr<struct<(vector<2xi8>)>>
-// CHECK-DAG:     %2 = llvm.alloca %c1_i64 x !llvm.struct<(memref<?xi8, 4>, i64)> : (i64) -> !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>>
-// CHECK-DAG:     %3 = llvm.alloca %c1_i64 x !llvm.struct<(memref<?xi8, 4>, i64)> : (i64) -> !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>>
-// CHECK-DAG:     %4 = llvm.alloca %c1_i64 x !llvm.array<2 x i8> : (i64) -> !llvm.ptr<array<2 x i8>>
-// CHECK-DAG:     %5 = llvm.alloca %c1_i64 x !llvm.array<2 x i8> : (i64) -> !llvm.ptr<array<2 x i8>>
-// CHECK-DAG:     %6 = llvm.alloca %c1_i64 x !llvm.struct<(vector<2xi8>)> : (i64) -> !llvm.ptr<struct<(vector<2xi8>)>>
-// CHECK-NEXT:    %7 = llvm.getelementptr inbounds %5[0, 0] : (!llvm.ptr<array<2 x i8>>) -> !llvm.ptr<i8>
-// CHECK-NEXT:    llvm.store %c0_i8, %7 : !llvm.ptr<i8>
-// CHECK-NEXT:    %8 = llvm.getelementptr inbounds %5[0, 1] : (!llvm.ptr<array<2 x i8>>) -> !llvm.ptr<i8>
-// CHECK-NEXT:    llvm.store %c1_i8, %8 : !llvm.ptr<i8>
-// CHECK-NEXT:    %9 = llvm.addrspacecast %4 : !llvm.ptr<array<2 x i8>> to !llvm.ptr<array<2 x i8>, 4>
-// CHECK-NEXT:    %10 = llvm.load %5 : !llvm.ptr<array<2 x i8>>
-// CHECK-NEXT:    llvm.store %10, %9 : !llvm.ptr<array<2 x i8>, 4>
-// CHECK-NEXT:    %11 = "polygeist.pointer2memref"(%9) : (!llvm.ptr<array<2 x i8>, 4>) -> memref<?xi8, 4 : i32>
-// CHECK-NEXT:    %12 = llvm.getelementptr inbounds %3[0, 0] : (!llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>>) -> !llvm.ptr<memref<?xi8, 4>>
-// CHECK-NEXT:    llvm.store %11, %12 : !llvm.ptr<memref<?xi8, 4>>
-// CHECK-NEXT:    %13 = llvm.getelementptr inbounds %3[0, 1] : (!llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>>) -> !llvm.ptr<i64>
-// CHECK-NEXT:    llvm.store %c2_i64, %13 : !llvm.ptr<i64>
-// CHECK-NEXT:    %14 = llvm.load %3 : !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>>
-// CHECK-NEXT:    %15 = llvm.addrspacecast %6 : !llvm.ptr<struct<(vector<2xi8>)>> to !llvm.ptr<struct<(vector<2xi8>)>, 4>
-// CHECK-NEXT:    llvm.store %14, %2 : !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>>
-// CHECK-NEXT:    call @_ZN9structvecC1ESt16initializer_listIcE(%15, %2) : (!llvm.ptr<struct<(vector<2xi8>)>, 4>, !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>>) -> ()
-// CHECK-NEXT:    %16 = llvm.load %6 : !llvm.ptr<struct<(vector<2xi8>)>>
-// CHECK-NEXT:    llvm.store %16, %1 : !llvm.ptr<struct<(vector<2xi8>)>>
-// CHECK-NEXT:    %17 = llvm.addrspacecast %0 : !llvm.ptr<struct<(vector<2xi8>)>> to !llvm.ptr<struct<(vector<2xi8>)>, 4>
-// CHECK-NEXT:    %18 = llvm.addrspacecast %1 : !llvm.ptr<struct<(vector<2xi8>)>> to !llvm.ptr<struct<(vector<2xi8>)>, 4>
-// CHECK-NEXT:    call @_ZN9structvecC1EOS_(%17, %18) : (!llvm.ptr<struct<(vector<2xi8>)>, 4>, !llvm.ptr<struct<(vector<2xi8>)>, 4>) -> ()
-// CHECK-NEXT:    %19 = llvm.load %0 : !llvm.ptr<struct<(vector<2xi8>)>>
-// CHECK-NEXT:    return %19 : !llvm.struct<(vector<2xi8>)>
-// CHECK-NEXT:  }
+// CHECK-LABEL:     func.func @_Z9test_initv() -> !llvm.struct<(vector<2xi8>)> attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<external>, passthrough = ["convergent", "mustprogress", "noinline", "norecurse", "nounwind", "optnone", ["frame-pointer", "all"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["sycl-module-id", "/home/lukas/Code/MLIR-SYCL/upstream/sycl-mlir/polygeist/tools/cgeist/Test/Verification/sycl/structvec.cpp"]]} {
+// CHECK-DAG:         %[[VAL_167:.*]] = arith.constant 2 : i64
+// CHECK-DAG:         %[[VAL_168:.*]] = arith.constant 1 : i8
+// CHECK-DAG:         %[[VAL_169:.*]] = arith.constant 0 : i8
+// CHECK-DAG:         %[[VAL_170:.*]] = arith.constant 1 : i64
+// CHECK-DAG:         %[[VAL_171:.*]] = llvm.alloca %[[VAL_170]] x !llvm.struct<(vector<2xi8>)> : (i64) -> !llvm.ptr
+// CHECK-DAG:         %[[VAL_172:.*]] = llvm.alloca %[[VAL_170]] x !llvm.struct<(vector<2xi8>)> : (i64) -> !llvm.ptr
+// CHECK-DAG:         %[[VAL_173:.*]] = llvm.alloca %[[VAL_170]] x !llvm.struct<(memref<?xi8, 4>, i64)> : (i64) -> !llvm.ptr
+// CHECK-DAG:         %[[VAL_174:.*]] = llvm.alloca %[[VAL_170]] x !llvm.struct<(memref<?xi8, 4>, i64)> : (i64) -> !llvm.ptr
+// CHECK-DAG:         %[[VAL_175:.*]] = llvm.alloca %[[VAL_170]] x !llvm.array<2 x i8> : (i64) -> !llvm.ptr
+// CHECK-DAG:         %[[VAL_176:.*]] = llvm.alloca %[[VAL_170]] x !llvm.array<2 x i8> : (i64) -> !llvm.ptr
+// CHECK-DAG:         %[[VAL_177:.*]] = llvm.alloca %[[VAL_170]] x !llvm.struct<(vector<2xi8>)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:        %[[VAL_178:.*]] = llvm.getelementptr inbounds %[[VAL_176]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<2 x i8>
+// CHECK-NEXT:        llvm.store %[[VAL_169]], %[[VAL_178]] : i8, !llvm.ptr
+// CHECK-NEXT:        %[[VAL_179:.*]] = llvm.getelementptr inbounds %[[VAL_176]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<2 x i8>
+// CHECK-NEXT:        llvm.store %[[VAL_168]], %[[VAL_179]] : i8, !llvm.ptr
+// CHECK-NEXT:        %[[VAL_180:.*]] = llvm.addrspacecast %[[VAL_175]] : !llvm.ptr to !llvm.ptr<4>
+// CHECK-NEXT:        %[[VAL_181:.*]] = llvm.load %[[VAL_176]] : !llvm.ptr -> !llvm.array<2 x i8>
+// CHECK-NEXT:        llvm.store %[[VAL_181]], %[[VAL_180]] : !llvm.array<2 x i8>, !llvm.ptr<4>
+// CHECK-NEXT:        %[[VAL_182:.*]] = "polygeist.pointer2memref"(%[[VAL_180]]) : (!llvm.ptr<4>) -> memref<?xi8, 4 : i32>
+// CHECK-NEXT:        %[[VAL_183:.*]] = llvm.getelementptr inbounds %[[VAL_174]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(memref<?xi8, 4>, i64)>
+// CHECK-NEXT:        llvm.store %[[VAL_182]], %[[VAL_183]] : memref<?xi8, 4 : i32>, !llvm.ptr
+// CHECK-NEXT:        %[[VAL_184:.*]] = llvm.getelementptr inbounds %[[VAL_174]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(memref<?xi8, 4>, i64)>
+// CHECK-NEXT:        llvm.store %[[VAL_167]], %[[VAL_184]] : i64, !llvm.ptr
+// CHECK-NEXT:        %[[VAL_185:.*]] = llvm.load %[[VAL_174]] : !llvm.ptr -> !llvm.struct<(memref<?xi8, 4>, i64)>
+// CHECK-NEXT:        %[[VAL_186:.*]] = llvm.addrspacecast %[[VAL_177]] : !llvm.ptr to !llvm.ptr<4>
+// CHECK-NEXT:        llvm.store %[[VAL_185]], %[[VAL_173]] : !llvm.struct<(memref<?xi8, 4>, i64)>, !llvm.ptr
+// CHECK-NEXT:        call @_ZN9structvecC1ESt16initializer_listIcE(%[[VAL_186]], %[[VAL_173]]) : (!llvm.ptr<4>, !llvm.ptr) -> ()
+// CHECK-NEXT:        %[[VAL_187:.*]] = llvm.load %[[VAL_177]] : !llvm.ptr -> !llvm.struct<(vector<2xi8>)>
+// CHECK-NEXT:        llvm.store %[[VAL_187]], %[[VAL_172]] : !llvm.struct<(vector<2xi8>)>, !llvm.ptr
+// CHECK-NEXT:        %[[VAL_188:.*]] = llvm.addrspacecast %[[VAL_171]] : !llvm.ptr to !llvm.ptr<4>
+// CHECK-NEXT:        %[[VAL_189:.*]] = llvm.addrspacecast %[[VAL_172]] : !llvm.ptr to !llvm.ptr<4>
+// CHECK-NEXT:        call @_ZN9structvecC1EOS_(%[[VAL_188]], %[[VAL_189]]) : (!llvm.ptr<4>, !llvm.ptr<4>) -> ()
+// CHECK-NEXT:        %[[VAL_190:.*]] = llvm.load %[[VAL_171]] : !llvm.ptr -> !llvm.struct<(vector<2xi8>)>
+// CHECK-NEXT:        return %[[VAL_190]] : !llvm.struct<(vector<2xi8>)>
+// CHECK-NEXT:      }
 
-// CHECK-LABEL: func.func @_ZN9structvecC1ESt16initializer_listIcE(%arg0: !llvm.ptr<struct<(vector<2xi8>)>, 4> {llvm.align = 2 : i64, llvm.dereferenceable_or_null = 2 : i64, llvm.noundef}, %arg1: !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>> {llvm.align = 8 : i64, llvm.byval = !llvm.struct<(memref<?xi8, 4>, i64)>, llvm.noundef})
-// CHECK-DAG:     %c-1_i32 = arith.constant -1 : i32
-// CHECK-DAG:     %c0_i32 = arith.constant 0 : i32
-// CHECK-DAG:     %c0_i8 = arith.constant 0 : i8
-// CHECK-NEXT:    %0 = llvm.addrspacecast %arg1 : !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>> to !llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>, 4>
-// CHECK-NEXT:    %1 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(vector<2xi8>)>, 4>) -> !llvm.ptr<vector<2xi8>, 4>
-// CHECK-NEXT:    affine.for %arg2 = 0 to 2 {
-// CHECK-NEXT:      %2 = arith.index_cast %arg2 : index to i32
-// CHECK-NEXT:      %3 = func.call @_ZNKSt16initializer_listIcE5beginEv(%0) : (!llvm.ptr<!llvm.struct<(memref<?xi8, 4>, i64)>, 4>) -> memref<?xi8, 4>
-// CHECK-NEXT:      %4 = arith.index_castui %2 : i32 to index
-// CHECK-NEXT:      %5 = memref.load %3[%4] : memref<?xi8, 4>
-// CHECK-NEXT:      %6 = arith.cmpi ne, %5, %c0_i8 : i8
-// CHECK-NEXT:      %7 = arith.select %6, %c-1_i32, %c0_i32 : i32
-// CHECK-NEXT:      %8 = arith.trunci %7 : i32 to i8
-// CHECK-NEXT:      %9 = llvm.load %1 : !llvm.ptr<vector<2xi8>, 4>
-// CHECK-NEXT:      %10 = vector.insertelement %8, %9[%2 : i32] : vector<2xi8>
-// CHECK-NEXT:      llvm.store %10, %1 : !llvm.ptr<vector<2xi8>, 4>
-// CHECK-NEXT:    }
-// CHECK-NEXT:    return
-// CHECK-NEXT:  }
+
+// CHECK-NEXT:      func.func @_ZN9structvecC1ESt16initializer_listIcE(%[[VAL_191:.*]]: !llvm.ptr<4> {llvm.align = 2 : i64, llvm.dereferenceable_or_null = 2 : i64, llvm.noundef}, %[[VAL_192:.*]]: !llvm.ptr {llvm.align = 8 : i64, llvm.byval = !llvm.struct<(memref<?xi8, 4>, i64)>, llvm.noundef}) attributes {llvm.cconv = #llvm.cconv<spir_funccc>, llvm.linkage = #llvm.linkage<linkonce_odr>, passthrough = ["convergent", "mustprogress", "noinline", "norecurse", "nounwind", "optnone", ["frame-pointer", "all"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["sycl-module-id", "/home/lukas/Code/MLIR-SYCL/upstream/sycl-mlir/polygeist/tools/cgeist/Test/Verification/sycl/structvec.cpp"]]} {
+// CHECK-DAG:         %[[VAL_193:.*]] = arith.constant -1 : i32
+// CHECK-DAG:         %[[VAL_194:.*]] = arith.constant 0 : i32
+// CHECK-DAG:         %[[VAL_195:.*]] = arith.constant 0 : i8
+// CHECK-NEXT:        %[[VAL_196:.*]] = llvm.addrspacecast %[[VAL_192]] : !llvm.ptr to !llvm.ptr<4>
+// CHECK-NEXT:        %[[VAL_197:.*]] = llvm.getelementptr inbounds %[[VAL_191]][0, 0] : (!llvm.ptr<4>) -> !llvm.ptr<4>, !llvm.struct<(vector<2xi8>)>
+// CHECK-NEXT:        affine.for %[[VAL_198:.*]] = 0 to 2 {
+// CHECK-NEXT:          %[[VAL_199:.*]] = arith.index_cast %[[VAL_198]] : index to i32
+// CHECK-NEXT:          %[[VAL_200:.*]] = func.call @_ZNKSt16initializer_listIcE5beginEv(%[[VAL_196]]) : (!llvm.ptr<4>) -> memref<?xi8, 4>
+// CHECK-NEXT:          %[[VAL_201:.*]] = arith.index_castui %[[VAL_199]] : i32 to index
+// CHECK-NEXT:          %[[VAL_202:.*]] = memref.load %[[VAL_200]]{{\[}}%[[VAL_201]]] : memref<?xi8, 4>
+// CHECK-NEXT:          %[[VAL_203:.*]] = arith.cmpi ne, %[[VAL_202]], %[[VAL_195]] : i8
+// CHECK-NEXT:          %[[VAL_204:.*]] = arith.select %[[VAL_203]], %[[VAL_193]], %[[VAL_194]] : i32
+// CHECK-NEXT:          %[[VAL_205:.*]] = arith.trunci %[[VAL_204]] : i32 to i8
+// CHECK-NEXT:          %[[VAL_206:.*]] = llvm.load %[[VAL_197]] : !llvm.ptr<4> -> vector<2xi8>
+// CHECK-NEXT:          %[[VAL_207:.*]] = vector.insertelement %[[VAL_205]], %[[VAL_206]]{{\[}}%[[VAL_199]] : i32] : vector<2xi8>
+// CHECK-NEXT:          llvm.store %[[VAL_207]], %[[VAL_197]] : vector<2xi8>, !llvm.ptr<4>
+// CHECK-NEXT:        }
+// CHECK-NEXT:        return
+// CHECK-NEXT:      }
 
 SYCL_EXTERNAL structvec test_init() {
   structvec sv{0, 1};

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -1,5 +1,5 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -1,4 +1,4 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir -o - %s | FileCheck %s
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir -o - %s | FileCheck %s
 // COM: Keep the tests in alphabetical order !
 
 #include <sycl/sycl.hpp>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/undeftypes.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/undeftypes.cpp
@@ -1,7 +1,7 @@
-// RUN: clang++ -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-mlir -o - -Xcgeist -allow-undefined-sycl-types %s | FileCheck %s
-// RUN: clang++ -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-mlir -o - -Xcgeist -allow-undefined-sycl-types -D DETAIL_NS %s | FileCheck %s
-// RUN: not clang++ -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-mlir -o - %s 2> >(FileCheck %s --check-prefix=CHECK-ERROR)
-// RUN: clang++ -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-mlir -o - -D DETAIL_NS %s | FileCheck %s
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-mlir -o - -Xcgeist -allow-undefined-sycl-types %s | FileCheck %s
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-mlir -o - -Xcgeist -allow-undefined-sycl-types -D DETAIL_NS %s | FileCheck %s
+// RUN: not clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-mlir -o - %s 2> >(FileCheck %s --check-prefix=CHECK-ERROR)
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-mlir -o - -D DETAIL_NS %s | FileCheck %s
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
@@ -1,5 +1,5 @@
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 #define N 32

--- a/polygeist/tools/cgeist/Test/Verification/templatemember.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/templatemember.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 class House;
 

--- a/polygeist/tools/cgeist/Test/Verification/threeInt.c
+++ b/polygeist/tools/cgeist/Test/Verification/threeInt.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 -w %s --function=struct_pass_all_same -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 -w %s --function=struct_pass_all_same -S | FileCheck %s
 
 typedef struct {
   int a, b, c;
@@ -8,8 +8,9 @@ int struct_pass_all_same(threeInt* a) {
   return a->b;
 }
 
-// CHECK:  func @struct_pass_all_same(%arg0: !llvm.ptr<struct<(i32, i32, i32)>>) -> i32
-// CHECK-NEXT:    %0 = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<struct<(i32, i32, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:    %1 = llvm.load %0 : !llvm.ptr<i32>
-// CHECK-NEXT:    return %1 : i32
-// CHECK-NEXT:  }
+// CHECK-LABEL:   func.func @struct_pass_all_same(
+// CHECK-SAME:                                    %[[VAL_0:.*]]: !llvm.ptr) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, i32, i32)>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr -> i32
+// CHECK-NEXT:      return %[[VAL_2]] : i32
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/tobits.c
+++ b/polygeist/tools/cgeist/Test/Verification/tobits.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s -O2 --function=fp32_from_bits -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O2 --function=fp32_from_bits -S | FileCheck %s
 
 #include <stdint.h>
 float fp32_from_bits(uint32_t w) {
@@ -9,12 +9,12 @@ float fp32_from_bits(uint32_t w) {
     return fp32.as_value;
 }
 
-// CHECK:   func @fp32_from_bits(%arg0: i32) -> f32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-DAG:     %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(i32)> : (i64) -> !llvm.ptr<struct<(i32)>>
-// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<struct<(i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     llvm.store %arg0, %1 : !llvm.ptr<i32>
-// CHECK-NEXT:     %2 = llvm.bitcast %1 : !llvm.ptr<i32> to !llvm.ptr<f32>
-// CHECK-NEXT:     %3 = llvm.load %2 : !llvm.ptr<f32>
-// CHECK-NEXT:     return %3 : f32
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @fp32_from_bits(
+// CHECK-SAME:                              %[[VAL_0:.*]]: i32) -> f32 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(i32)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32)>
+// CHECK-NEXT:      llvm.store %[[VAL_0]], %[[VAL_3]] : i32, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> f32
+// CHECK-NEXT:      return %[[VAL_4]] : f32
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/triple.cu
+++ b/polygeist/tools/cgeist/Test/Verification/triple.cu
@@ -1,5 +1,5 @@
-// RUN: cgeist --target aarch64-unknown-linux-gnu %s %stdinclude -S -o - | FileCheck %s -check-prefix=MLIR
-// RUN: cgeist --target aarch64-unknown-linux-gnu %s %stdinclude -emit-llvm -S -o - | FileCheck %s -check-prefix=LLVM
+// RUN: cgeist --use-opaque-pointers --target aarch64-unknown-linux-gnu %s %stdinclude -S -o - | FileCheck %s -check-prefix=MLIR
+// RUN: cgeist --use-opaque-pointers --target aarch64-unknown-linux-gnu %s %stdinclude -emit-llvm -S -o - | FileCheck %s -check-prefix=LLVM
 
 // MLIR:  llvm.target_triple = "aarch64-unknown-linux-gnu"
 // LLVM:  target triple = "aarch64-unknown-linux-gnu"

--- a/polygeist/tools/cgeist/Test/Verification/twotemplatevardecls.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/twotemplatevardecls.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
   
 template<typename _Tp, _Tp __v>
     struct integral_constant

--- a/polygeist/tools/cgeist/Test/Verification/unioncopy.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/unioncopy.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 union S {
 	double d;
@@ -19,41 +19,48 @@ void meta() {
 	use(alpha_scalar.v.d);
 }
 
-// CHECK:   func @_Z4metav() attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-DAG:     %c1_i64 = arith.constant 1 : i64
-// CHECK-DAG:     %[[cst:.+]] = arith.constant 1.000000e+00 : f64
-// CHECK-DAG:     %[[cst_0:.+]] = arith.constant 3.000000e+00 : f64
-// CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(struct<(f64)>)> : (i64) -> !llvm.ptr<struct<(struct<(f64)>)>>
-// CHECK-NEXT:     %1 = llvm.alloca %c1_i64 x !llvm.struct<(struct<(f64)>)> : (i64) -> !llvm.ptr<struct<(struct<(f64)>)>>
-// CHECK-NEXT:     %2 = llvm.alloca %c1_i64 x !llvm.struct<(struct<(f64)>)> : (i64) -> !llvm.ptr<struct<(struct<(f64)>)>>
-// CHECK-NEXT:     call @_ZN8MyScalarC1Ed(%2, %[[cst]]) : (!llvm.ptr<struct<(struct<(f64)>)>>, f64) -> ()
-// CHECK-NEXT:     call @_ZN8MyScalarC1Ed(%1, %[[cst_0]]) : (!llvm.ptr<struct<(struct<(f64)>)>>, f64) -> ()
-// CHECK-NEXT:     %3 = llvm.load %1 : !llvm.ptr<struct<(struct<(f64)>)>>
-// CHECK-NEXT:     llvm.store %3, %0 : !llvm.ptr<struct<(struct<(f64)>)>>
-// CHECK-NEXT:     %4 = call @_ZN8MyScalaraSEOS_(%2, %0) : (!llvm.ptr<struct<(struct<(f64)>)>>, !llvm.ptr<struct<(struct<(f64)>)>>) -> !llvm.ptr<struct<(struct<(f64)>)>>
-// CHECK-NEXT:     %5 = llvm.getelementptr inbounds %2[0, 0] : (!llvm.ptr<struct<(struct<(f64)>)>>) -> !llvm.ptr<struct<(f64)>>
-// CHECK-NEXT:     %6 = llvm.getelementptr inbounds %5[0, 0] : (!llvm.ptr<struct<(f64)>>) -> !llvm.ptr<f64>
-// CHECK-NEXT:     %7 = llvm.load %6 : !llvm.ptr<f64>
-// CHECK-NEXT:     call @_Z3used(%7) : (f64) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN8MyScalarC1Ed(%arg0: !llvm.ptr<struct<(struct<(f64)>)>>, %arg1: f64) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(f64)>)>>) -> !llvm.ptr<struct<(f64)>>
-// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<struct<(f64)>>) -> !llvm.ptr<f64>
-// CHECK-NEXT:     llvm.store %arg1, %1 : !llvm.ptr<f64>
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN8MyScalaraSEOS_(%arg0: !llvm.ptr<struct<(struct<(f64)>)>>, %arg1: !llvm.ptr<struct<(struct<(f64)>)>>) -> !llvm.ptr<struct<(struct<(f64)>)>> attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(f64)>)>>) -> !llvm.ptr<struct<(f64)>>
-// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %arg1[0, 0] : (!llvm.ptr<struct<(struct<(f64)>)>>) -> !llvm.ptr<struct<(f64)>>
-// CHECK-NEXT:     %2 = call @_ZN1SaSEOS_(%0, %1) : (!llvm.ptr<struct<(f64)>>, !llvm.ptr<struct<(f64)>>) -> !llvm.ptr<struct<(f64)>>
-// CHECK-NEXT:     return %arg0 : !llvm.ptr<struct<(struct<(f64)>)>>
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN1SaSEOS_(%arg0: !llvm.ptr<struct<(f64)>>, %arg1: !llvm.ptr<struct<(f64)>>) -> !llvm.ptr<struct<(f64)>> attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-DAG:     %c8_i64 = arith.constant 8 : i64
-// CHECK-DAG:     %false = arith.constant false
-// CHECK-NEXT:     %[[i0:.+]] = llvm.bitcast %arg0 : !llvm.ptr<struct<(f64)>> to !llvm.ptr<i8>
-// CHECK-NEXT:     %[[i1:.+]] = llvm.bitcast %arg1 : !llvm.ptr<struct<(f64)>> to !llvm.ptr<i8>
-// CHECK-NEXT:     "llvm.intr.memcpy"(%[[i0]], %[[i1]], %c8_i64, %false) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64, i1) -> ()
-// CHECK-NEXT:     return %arg0 : !llvm.ptr<struct<(f64)>>
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @_Z4metav() attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 3.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 1.000000e+00 : f64
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(f64)>)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(f64)>)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(f64)>)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      call @_ZN8MyScalarC1Ed(%[[VAL_5]], %[[VAL_1]]) : (!llvm.ptr, f64) -> ()
+// CHECK-NEXT:      call @_ZN8MyScalarC1Ed(%[[VAL_4]], %[[VAL_0]]) : (!llvm.ptr, f64) -> ()
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr -> !llvm.struct<(struct<(f64)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_6]], %[[VAL_3]] : !llvm.struct<(struct<(f64)>)>, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_7:.*]] = call @_ZN8MyScalaraSEOS_(%[[VAL_5]], %[[VAL_3]]) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_5]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(f64)>)>
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_8]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f64)>
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr -> f64
+// CHECK-NEXT:      call @_Z3used(%[[VAL_10]]) : (f64) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN8MyScalarC1Ed(
+// CHECK-SAME:                                %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                                %[[VAL_1:.*]]: f64) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(f64)>)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f64)>
+// CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_3]] : f64, !llvm.ptr
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN8MyScalaraSEOS_(
+// CHECK-SAME:                                  %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                                  %[[VAL_1:.*]]: !llvm.ptr) -> !llvm.ptr attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(f64)>)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(f64)>)>
+// CHECK-NEXT:      %[[VAL_4:.*]] = call @_ZN1SaSEOS_(%[[VAL_2]], %[[VAL_3]]) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+// CHECK-NEXT:      return %[[VAL_0]] : !llvm.ptr
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN1SaSEOS_(
+// CHECK-SAME:                           %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                           %[[VAL_1:.*]]: !llvm.ptr) -> !llvm.ptr attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 8 : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = arith.constant false
+// CHECK-NEXT:      "llvm.intr.memcpy"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]]) : (!llvm.ptr, !llvm.ptr, i64, i1) -> ()
+// CHECK-NEXT:      return %[[VAL_0]] : !llvm.ptr
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/unlinked.c
+++ b/polygeist/tools/cgeist/Test/Verification/unlinked.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s --function=kernel_correlation --raise-scf-to-affine -S | FileCheck %s
-// RUN: cgeist %s --function=kernel_correlation --raise-scf-to-affine -S -memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist --use-opaque-pointers %s --function=kernel_correlation --raise-scf-to-affine -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=kernel_correlation --raise-scf-to-affine -S -memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 #define DATA_TYPE double
 

--- a/polygeist/tools/cgeist/Test/Verification/vecaccess.c
+++ b/polygeist/tools/cgeist/Test/Verification/vecaccess.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 %s --function=* -S | FileCheck %s
 
 typedef int int_vec __attribute__((ext_vector_type(3)));
 

--- a/polygeist/tools/cgeist/Test/Verification/vecinit.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/vecinit.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 %s --function=* -S | FileCheck %s
 
 typedef float float4 __attribute__((ext_vector_type(4)));
 typedef float float8 __attribute__((ext_vector_type(8)));

--- a/polygeist/tools/cgeist/Test/Verification/vecsplat.c
+++ b/polygeist/tools/cgeist/Test/Verification/vecsplat.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
-// RUN: cgeist %s --function=* -S -emit-llvm | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S -emit-llvm | FileCheck %s --check-prefix=CHECK-LLVM
 
 typedef int int_t_vec __attribute__((ext_vector_type(3)));
 typedef float float_t_vec __attribute__((ext_vector_type(4)));

--- a/polygeist/tools/cgeist/Test/Verification/virt.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/virt.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 -w %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 -w %s --function=* -S | FileCheck %s
 
 extern void print(char*);
 
@@ -30,40 +30,50 @@ void make() {
     Sub s(3, 3.14);
 }
 
-// CHECK:   func @_Z4makev() attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-DAG:     %cst = arith.constant 3.140000e+00 : f64
-// CHECK-DAG:     %c3_i32 = arith.constant 3 : i32
-// CHECK-DAG:     %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:     %0 = llvm.alloca %c1_i64 x !llvm.struct<(struct<(i32)>, struct<(f32)>, f64)> : (i64) -> !llvm.ptr<struct<(struct<(i32)>, struct<(f32)>, f64)>>
-// CHECK-NEXT:     call @_ZN3SubC1Eid(%0, %c3_i32, %cst) : (!llvm.ptr<struct<(struct<(i32)>, struct<(f32)>, f64)>>, i32, f64) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN3SubC1Eid(%arg0: !llvm.ptr<struct<(struct<(i32)>, struct<(f32)>, f64)>>, %arg1: i32, %arg2: f64) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(struct<(i32)>, struct<(f32)>, f64)>>) -> !llvm.ptr<struct<(i32)>>
-// CHECK-NEXT:     call @_ZN4RootC1Ei(%0, %arg1) : (!llvm.ptr<struct<(i32)>>, i32) -> ()
-// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %arg0[0, 1] : (!llvm.ptr<struct<(struct<(i32)>, struct<(f32)>, f64)>>) -> !llvm.ptr<struct<(f32)>>
-// CHECK-NEXT:     call @_ZN5FRootC1Ev(%1) : (!llvm.ptr<struct<(f32)>>) -> ()
-// CHECK-NEXT:     %2 = llvm.getelementptr inbounds %arg0[0, 2] : (!llvm.ptr<struct<(struct<(i32)>, struct<(f32)>, f64)>>) -> !llvm.ptr<f64>
-// CHECK-NEXT:     llvm.store %arg2, %2 : !llvm.ptr<f64>
-// CHECK-NEXT:     %3 = llvm.mlir.addressof @str0 : !llvm.ptr<array<12 x i8>>
-// CHECK-NEXT:     %4 = "polygeist.pointer2memref"(%3) : (!llvm.ptr<array<12 x i8>>) -> memref<?xi8>
-// CHECK-NEXT:     call @_Z5printPc(%4) : (memref<?xi8>) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN4RootC1Ei(%arg0: !llvm.ptr<struct<(i32)>>, %arg1: i32) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     llvm.store %arg1, %0 : !llvm.ptr<i32>
-// CHECK-NEXT:     %1 = llvm.mlir.addressof @str1 : !llvm.ptr<array<13 x i8>>
-// CHECK-NEXT:     %2 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<array<13 x i8>>) -> memref<?xi8>
-// CHECK-NEXT:     call @_Z5printPc(%2) : (memref<?xi8>) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func.func @_ZN5FRootC1Ev(%arg0: !llvm.ptr<struct<(f32)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-DAG:      %cst = arith.constant 2.180000e+00 : f32
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(f32)>>) -> !llvm.ptr<f32>
-// CHECK-NEXT:     llvm.store %cst, %0 : !llvm.ptr<f32>
-// CHECK-NEXT:     %[[i1:.+]] = llvm.mlir.addressof @str2 : !llvm.ptr<array<14 x i8>>
-// CHECK-NEXT:     %[[i2:.+]] = "polygeist.pointer2memref"(%1) : (!llvm.ptr<array<14 x i8>>) -> memref<?xi8>
-// CHECK-NEXT:     call @_Z5printPc(%[[i2]]) : (memref<?xi8>) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @_Z4makev() attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 3.140000e+00 : f64
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 3 : i32
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(i32)>, struct<(f32)>, f64)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      call @_ZN3SubC1Eid(%[[VAL_3]], %[[VAL_1]], %[[VAL_0]]) : (!llvm.ptr, i32, f64) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN3SubC1Eid(
+// CHECK-SAME:                            %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                            %[[VAL_1:.*]]: i32,
+// CHECK-SAME:                            %[[VAL_2:.*]]: f64) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(i32)>, struct<(f32)>, f64)>
+// CHECK-NEXT:      call @_ZN4RootC1Ei(%[[VAL_3]], %[[VAL_1]]) : (!llvm.ptr, i32) -> ()
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(i32)>, struct<(f32)>, f64)>
+// CHECK-NEXT:      call @_ZN5FRootC1Ev(%[[VAL_4]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(i32)>, struct<(f32)>, f64)>
+// CHECK-NEXT:      llvm.store %[[VAL_2]], %[[VAL_5]] : f64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.mlir.addressof @str0 : !llvm.ptr
+// CHECK-NEXT:      %[[VAL_7:.*]] = "polygeist.pointer2memref"(%[[VAL_6]]) : (!llvm.ptr) -> memref<?xi8>
+// CHECK-NEXT:      call @_Z5printPc(%[[VAL_7]]) : (memref<?xi8>) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN4RootC1Ei(
+// CHECK-SAME:                            %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                            %[[VAL_1:.*]]: i32) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32)>
+// CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_2]] : i32, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.addressof @str1 : !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = "polygeist.pointer2memref"(%[[VAL_3]]) : (!llvm.ptr) -> memref<?xi8>
+// CHECK-NEXT:      call @_Z5printPc(%[[VAL_4]]) : (memref<?xi8>) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN5FRootC1Ev(
+// CHECK-SAME:                             %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 2.180000e+00 : f32
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f32)>
+// CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_2]] : f32, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.addressof @str2 : !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = "polygeist.pointer2memref"(%[[VAL_3]]) : (!llvm.ptr) -> memref<?xi8>
+// CHECK-NEXT:      call @_Z5printPc(%[[VAL_4]]) : (memref<?xi8>) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+// CHECK-NEXT:    func.func private @_Z5printPc(memref<?xi8>) attributes {llvm.linkage = #llvm.linkage<external>}

--- a/polygeist/tools/cgeist/Test/Verification/virt2.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/virt2.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 
 extern void print(char*);
 
@@ -27,32 +27,41 @@ void make() {
     Sub s(3, 3.14);
 }
 
-// clang-format off
-// CHECK:   func @_Z4makev() attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-DAG:     %cst = arith.constant 3.140000e+00 : f64
-// CHECK-DAG:     %c3_i32 = arith.constant 3 : i32
-// CHECK-DAG:     %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:    %0 = llvm.alloca %c1_i64 x !llvm.struct<(i8)> : (i64) -> !llvm.ptr<struct<(i8)>>
-// CHECK-NEXT:     call @_ZN3SubC1Eid(%0, %c3_i32, %cst) : (!llvm.ptr<struct<(i8)>>, i32, f64) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN3SubC1Eid(%arg0: !llvm.ptr<struct<(i8)>>, %arg1: i32, %arg2: f64) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>}
-// CHECK-NEXT:     call @_ZN4RootC1Ei(%arg0, %arg1) : (!llvm.ptr<struct<(i8)>>, i32) -> ()
-// CHECK-NEXT:     call @_ZN5FRootC1Ev(%arg0) : (!llvm.ptr<struct<(i8)>>) -> ()
-// CHECK-NEXT:     %0 = llvm.mlir.addressof @str0 : !llvm.ptr<array<12 x i8>>
-// CHECK-NEXT:     %1 = "polygeist.pointer2memref"(%0) : (!llvm.ptr<array<12 x i8>>) -> memref<?xi8>
-// CHECK-NEXT:     call @_Z5printPc(%1) : (memref<?xi8>) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN4RootC1Ei(%arg0: !llvm.ptr<struct<(i8)>>, %arg1: i32) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.mlir.addressof @str1 : !llvm.ptr<array<13 x i8>>
-// CHECK-NEXT:     %1 = "polygeist.pointer2memref"(%0) : (!llvm.ptr<array<13 x i8>>) -> memref<?xi8> 
-// CHECK-NEXT:     call @_Z5printPc(%1) : (memref<?xi8>) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
-// CHECK:   func @_ZN5FRootC1Ev(%arg0: !llvm.ptr<struct<(i8)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %0 = llvm.mlir.addressof @str2 : !llvm.ptr<array<14 x i8>>
-// CHECK-NEXT:     %1 = "polygeist.pointer2memref"(%0) : (!llvm.ptr<array<14 x i8>>) -> memref<?xi8> 
-// CHECK-NEXT:     call @_Z5printPc(%1) : (memref<?xi8>) -> ()
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @_Z4makev() attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-DAG:       %[[VAL_0:.*]] = arith.constant 3.140000e+00 : f64
+// CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 3 : i32
+// CHECK-DAG:       %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(i8)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      call @_ZN3SubC1Eid(%[[VAL_3]], %[[VAL_1]], %[[VAL_0]]) : (!llvm.ptr, i32, f64) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN3SubC1Eid(
+// CHECK-SAME:                            %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                            %[[VAL_1:.*]]: i32,
+// CHECK-SAME:                            %[[VAL_2:.*]]: f64) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      call @_ZN4RootC1Ei(%[[VAL_0]], %[[VAL_1]]) : (!llvm.ptr, i32) -> ()
+// CHECK-NEXT:      call @_ZN5FRootC1Ev(%[[VAL_0]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.addressof @str0 : !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = "polygeist.pointer2memref"(%[[VAL_3]]) : (!llvm.ptr) -> memref<?xi8>
+// CHECK-NEXT:      call @_Z5printPc(%[[VAL_4]]) : (memref<?xi8>) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN4RootC1Ei(
+// CHECK-SAME:                            %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                            %[[VAL_1:.*]]: i32) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.addressof @str1 : !llvm.ptr
+// CHECK-NEXT:      %[[VAL_3:.*]] = "polygeist.pointer2memref"(%[[VAL_2]]) : (!llvm.ptr) -> memref<?xi8>
+// CHECK-NEXT:      call @_Z5printPc(%[[VAL_3]]) : (memref<?xi8>) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+// CHECK-LABEL:   func.func @_ZN5FRootC1Ev(
+// CHECK-SAME:                             %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.addressof @str2 : !llvm.ptr
+// CHECK-NEXT:      %[[VAL_2:.*]] = "polygeist.pointer2memref"(%[[VAL_1]]) : (!llvm.ptr) -> memref<?xi8>
+// CHECK-NEXT:      call @_Z5printPc(%[[VAL_2]]) : (memref<?xi8>) -> ()
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+// CHECK-NEXT:    func.func private @_Z5printPc(memref<?xi8>) attributes {llvm.linkage = #llvm.linkage<external>}

--- a/polygeist/tools/cgeist/Test/Verification/whileset.c
+++ b/polygeist/tools/cgeist/Test/Verification/whileset.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s %stdinclude --function=set -S | FileCheck %s
-// RUN: cgeist %s %stdinclude --function=set -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist --use-opaque-pointers %s %stdinclude --function=set -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s %stdinclude --function=set -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 
 #include <stdio.h>
 #include <unistd.h>

--- a/polygeist/tools/cgeist/Test/Verification/whiletofor.c
+++ b/polygeist/tools/cgeist/Test/Verification/whiletofor.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s -O2 --function=whiletofor -S --raise-scf-to-affine=false | FileCheck %s
-// RUN: cgeist %s -O2 --function=whiletofor -S --memref-fullrank --raise-scf-to-affine=false | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist --use-opaque-pointers %s -O2 --function=whiletofor -S --raise-scf-to-affine=false | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s -O2 --function=whiletofor -S --memref-fullrank --raise-scf-to-affine=false | FileCheck %s --check-prefix=FULLRANK
 
 void use(int a[100][100]);
 

--- a/polygeist/tools/cgeist/Test/Verification/x.c
+++ b/polygeist/tools/cgeist/Test/Verification/x.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=kernel_deriche -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=kernel_deriche -S | FileCheck %s
 
 int kernel_deriche(int x) {
     x++;

--- a/polygeist/tools/cgeist/Test/Verification/xor.c
+++ b/polygeist/tools/cgeist/Test/Verification/xor.c
@@ -1,4 +1,4 @@
-// RUN: cgeist -O0 %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
+// RUN: cgeist --use-opaque-pointers -O0 %s --function=* -S --raise-scf-to-affine=false | FileCheck %s
 
 typedef char char_vec __attribute__((ext_vector_type(3)));
 typedef short short_vec __attribute__((ext_vector_type(3)));

--- a/polygeist/tools/cgeist/Test/addressoff_call.cpp
+++ b/polygeist/tools/cgeist/Test/addressoff_call.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -S | FileCheck %s
 unsigned long foo(unsigned);
 inline unsigned long inlineFunc(unsigned i) noexcept {
   return foo(i);

--- a/polygeist/tools/cgeist/Test/elaborated-init.cpp
+++ b/polygeist/tools/cgeist/Test/elaborated-init.cpp
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function='*' -S -std=c++14 | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function='*' -S -std=c++14 | FileCheck %s
 struct A {
   using TheType = int[4];
 };
@@ -10,17 +10,19 @@ void testArrayInitExpr()
   };
 }
 
-// CHECK: func.func private @_ZZ17testArrayInitExprvEN3$_0C1EOS_(%arg0: !llvm.ptr<struct<(array<4 x i32>)>>, %arg1: !llvm.ptr<struct<(array<4 x i32>)>>) attributes {llvm.linkage = #llvm.linkage<internal>} {
-// CHECK-NEXT:     %0 = llvm.getelementptr inbounds %arg0[0, 0] : (!llvm.ptr<struct<(array<4 x i32>)>>) -> !llvm.ptr<array<4 x i32>>
-// CHECK-NEXT:     %1 = llvm.getelementptr inbounds %0[0, 0] : (!llvm.ptr<array<4 x i32>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     %2 = llvm.getelementptr inbounds %arg1[0, 0] : (!llvm.ptr<struct<(array<4 x i32>)>>) -> !llvm.ptr<array<4 x i32>>
-// CHECK-NEXT:     %3 = llvm.getelementptr inbounds %2[0, 0] : (!llvm.ptr<array<4 x i32>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     affine.for %arg2 = 0 to 4 {
-// CHECK-NEXT:       %4 = arith.index_cast %arg2 : index to i64
-// CHECK-NEXT:       %5 = llvm.getelementptr %1[%4] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
-// CHECK-NEXT:       %6 = llvm.getelementptr %3[%4] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
-// CHECK-NEXT:       %7 = llvm.load %6 : !llvm.ptr<i32>
-// CHECK-NEXT:       llvm.store %7, %5 : !llvm.ptr<i32>
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func private @_ZZ17testArrayInitExprvEN3$_0C1EOS_(
+// CHECK-SAME:                                                           %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                                                           %[[VAL_1:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<internal>} {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(array<4 x i32>)>
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<4 x i32>
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(array<4 x i32>)>
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<4 x i32>
+// CHECK-NEXT:      affine.for %[[VAL_6:.*]] = 0 to 4 {
+// CHECK-NEXT:        %[[VAL_7:.*]] = arith.index_cast %[[VAL_6]] : index to i64
+// CHECK-NEXT:        %[[VAL_8:.*]] = llvm.getelementptr %[[VAL_3]]{{\[}}%[[VAL_7]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+// CHECK-NEXT:        %[[VAL_9:.*]] = llvm.getelementptr %[[VAL_5]]{{\[}}%[[VAL_7]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+// CHECK-NEXT:        %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr -> i32
+// CHECK-NEXT:        llvm.store %[[VAL_10]], %[[VAL_8]] : i32, !llvm.ptr
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }


### PR DESCRIPTION
Next step to add opaque pointer support for the SYCL-MLIR project: Make the `cgeist` code generation compatible with opaque pointers.

Emitting typed or opaque pointers is controlled by the `use-opaque-pointers` flag that was added to `cgeist`. 

Main changes are: 
* Create typed or opaque LLVM pointer types depending on the flag 
* Attach an optional element type to `ValueCategory`
* Generate `load`/`getelementptr`/`alloca`/`store`/`addressof` operations compatible with opaque pointers using that element type
