### PR TITLE
[ESIMD][E2E] Fix ext_math test; add version of test with -ffast-math

### DIFF
--- a/sycl/test-e2e/ESIMD/ext_math_fast.cpp
+++ b/sycl/test-e2e/ESIMD/ext_math_fast.cpp
@@ -1,0 +1,21 @@
+//==----------- ext_math_fast.cpp  - DPC++ ESIMD extended math test --------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// REQUIRES: gpu
+// UNSUPPORTED: gpu-intel-gen9 && windows
+// UNSUPPORTED: cuda || hip
+// RUN: %clangxx -fsycl-device-code-split=per_kernel -fsycl -ffast-math %s -o %t.out
+// RUN: %GPU_RUN_PLACEHOLDER %t.out
+
+// This test checks extended math operations. Combinations of
+// - argument type - half, float
+// - math function - sin, cos, ..., div_ieee, pow
+// - SYCL vs ESIMD APIs
+
+#define TEST_FAST_MATH 1
+
+#include "ext_math.cpp"


### PR DESCRIPTION
The test ext_math.cpp may show fails with -ffast-math. There are 2 different reasons for that:
1) Usage of native_sin/cos/exp/log SYCL API that is not yet supported
   by GPU Vector Back-End.
2) Some ESIMD functions return values like 'non' or 'inf', which then
   do not pass check even if computed and expected results are the same.