### PR TITLE
[Driver][SYCL] Fix crash when using libraries with -fsycl

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6713,8 +6713,7 @@ public:
     return C.MakeAction<OffloadAction>(HDep, DDeps);
   }
 
-  void unbundleStaticArchives(Compilation &C, DerivedArgList &Args,
-                              DeviceActionBuilder::PhasesTy &PL) {
+  void unbundleStaticArchives(Compilation &C, DerivedArgList &Args) {
     if (!Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false))
       return;
 
@@ -6727,6 +6726,7 @@ public:
       Arg *InputArg = MakeInputArg(Args, Opts, Args.MakeArgString(A));
       Action *Current = C.MakeAction<InputAction>(*InputArg, T);
       addHostDependenceToDeviceActions(Current, InputArg, Args);
+      auto PL = types::getCompilationPhases(T);
       addDeviceDependencesToHostAction(Current, InputArg, phases::Link,
                                        PL.back(), PL);
     };
@@ -7120,7 +7120,7 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
     if (!LinkerInputs.empty() && C.getDriver().getOffloadStaticLibSeen())
       OffloadBuilder->addDeviceLinkDependenciesFromHost(LinkerInputs);
 
-    OffloadBuilder->unbundleStaticArchives(C, Args, PL);
+    OffloadBuilder->unbundleStaticArchives(C, Args);
   }
 
   // For an FPGA archive, we add the unbundling step above to take care of

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -160,3 +160,13 @@
 // RUN:   %clangxx -### -fsycl-device-only %s 2>&1 | FileCheck -check-prefixes=CHECK_BITFIELD_OPTION %s
 // CHECK_BITFIELD_OPTION: clang{{.*}} "-ffine-grained-bitfield-accesses"
 
+/// Using linker specific items at the end of the command should not fail when
+/// we are performing a non-linking compilation behavior
+// RUN: %clangxx -E -fsycl %S/Inputs/SYCL/liblin64.a \
+// RUN:          -target x86_64-unknown-linux-gnu -### 2>&1 \
+// RUN:  | FileCheck -check-prefix IGNORE_INPUT %s
+// RUN: %clangxx -c -fsycl %S/Inputs/SYCL/liblin64.a \
+// RUN:          -target x86_64-unknown-linux-gnu -### 2>&1 \
+// RUN:  | FileCheck -check-prefix IGNORE_INPUT %s
+// IGNORE_INPUT: input unused
+


### PR DESCRIPTION
When performing any non-linking behaviors with -fsycl (like -c or -E) and adding any non-compiled input value such as a library the driver would crash due to invalid phase information.

Update the usage of the phase information to be more accurate depending on the input (i.e. Archive)