### PR TITLE
[SYCL][Doc] Add draft of sycl_ext_oneapi_prefetch

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_prefetch.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_prefetch.asciidoc
@@ -1,0 +1,420 @@
+= sycl_ext_oneapi_prefetch
+
+:source-highlighter: coderay
+:coderay-linenums-mode: table
+
+// This section needs to be after the document title.
+:doctype: book
+:toc2:
+:toc: left
+:encoding: utf-8
+:lang: en
+:dpcpp: pass:[DPC++]
+
+// Set the default source code type in this document to C++,
+// for syntax highlighting purposes.  This is needed because
+// docbook uses c++ and html5 uses cpp.
+:language: {basebackend@docbook:c++:cpp}
+
+
+== Notice
+
+[%hardbreaks]
+Copyright (C) 2023-2023 Intel Corporation.  All rights reserved.
+
+Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
+of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by
+permission by Khronos.
+
+
+== Contact
+
+To report problems with this extension, please open a new issue at:
+
+https://github.com/intel/llvm/issues
+
+
+== Dependencies
+
+This extension is written against the SYCL 2020 revision 7 specification.  All
+references below to the "core SYCL specification" or to section numbers in the
+SYCL specification refer to that revision.
+
+This extension also depends on the following other SYCL extensions:
+
+* link:../experimental/sycl_ext_oneapi_properties.asciidoc[
+  sycl_ext_oneapi_properties]
+
+
+== Status
+
+This is a proposed extension specification, intended to gather community
+feedback.  Interfaces defined in this specification may not be implemented yet
+or may be in a preliminary state.  The specification itself may also change in
+incompatible ways before it is finalized.  *Shipping software products should
+not rely on APIs defined in this specification.*
+
+
+== Overview
+
+Many devices targeted by SYCL support software prefetch operations, which
+act as asynchronous memory reads intended to populate cache(s). Prefetches are
+generally used to hide memory latency, and their deployment may be a critical
+component for software tuning on some hardware.
+
+The `multi_ptr::prefetch` function provided by SYCL 2020 is insufficient to
+cover many real use-cases -- it does not acknowledge the existence of a cache
+hierarchy, and does not provide a mechanism for cooperative (i.e. group)
+prefetches.
+
+This proposal addresses these shortcomings by introducing a set of
+free functions that groups of work-items can use to prefetch data into specific
+levels of cache (controlled via compile-time properties).
+
+
+== Specification
+
+=== Feature test macro
+
+This extension provides a feature-test macro as described in the core SYCL
+specification.  An implementation supporting this extension must predefine the
+macro `SYCL_EXT_ONEAPI_PREFETCH` to one of the values defined in the table
+below.  Applications can test for the existence of this macro to determine if
+the implementation supports this feature, or applications can test the macro's
+value to determine which of the extension's features the implementation
+supports.
+
+[%header,cols="1,5"]
+|===
+|Value
+|Description
+
+|1
+|The APIs of this experimental extension are not versioned, so the
+ feature-test macro always has this value.
+|===
+
+
+=== Specifying cache levels
+
+The level of cache targeted by a prefetch is specified using compile-time
+properties. This extension defines hints for four levels of cache,
+corresponding to the four levels of cache currently defined in SYCL (e.g.
+as used by `info::partition_affinity_domain`).
+
+[NOTE]
+====
+Not all devices targeted by SYCL will have four levels of cache. Some of these
+hints may have no meaning on some devices. However, implementations are
+encouraged to map these constants to the closest level of cache available.
+====
+
+When multiple cache levels are specified, the lowest level takes precedence
+(e.g. a request to prefetch into L1 and L4 is treated as a request to prefetch
+into L1). When no cache levels are specified, the default behavior is to
+prefetch into the highest level cache supported by the device.
+
+[NOTE]
+====
+Future hints may alter the default behavior of prefetches with respect to cache
+levels. Any such alterations are expected to be documented in the definition
+of those new hints.
+====
+
+[source,c++]
+----
+namespace sycl::ext::oneapi::experimental {
+
+enum class prefetch_hint_enum {
+  L1,
+  L2,
+  L3,
+  L4,
+};
+
+template <prefetch_hint_enum Hint>
+struct prefetch_hint_key {
+  using value_t = property_value<prefetch_hint_key,
+                                 std::integral_constant<prefetch_hint_enum, Hint>>;
+};
+
+template <prefetch_hint_enum Hint>
+inline constexpr prefetch_hint_key::value_t<Hint> prefetch_hint;
+
+inline constexpr prefetch_hint_key::value_t<prefetch_hint_enum::L1> prefetch_hint_L1;
+inline constexpr prefetch_hint_key::value_t<prefetch_hint_enum::L2> prefetch_hint_L2;
+inline constexpr prefetch_hint_key::value_t<prefetch_hint_enum::L3> prefetch_hint_L3;
+inline constexpr prefetch_hint_key::value_t<prefetch_hint_enum::L4> prefetch_hint_L4;
+
+} // namespace sycl::ext::oneapi::experimental
+----
+
+
+=== Work-item prefetches
+
+The functions in this section allow individual work-items to prefetch data.
+
+[source,c++]
+----
+namespace sycl::ext::oneapi::experimental {
+
+template <typename Properties = ext::oneapi::experimental::properties<>>
+void prefetch(void* ptr, Properties properties = {});
+
+template <typename Properties = ext::oneapi::experimental::properties<>>
+void prefetch(void* ptr, size_t bytes, Properties properties = {});
+
+template <typename T, typename Properties = ext::oneapi::experimental::properties<>>
+void prefetch(T* ptr, Properties properties = {});
+
+template <typename T, typename Properties = ext::oneapi::experimental::properties<>>
+void prefetch(T* ptr, size_t count, Properties properties = {});
+
+// Only available if Accessor::dimensions == 1 and Accessor::access_mode != write
+template <typename Accessor, typename Properties = ext::oneapi::experimental::properties<>>
+void prefetch(Accessor* acc, size_t offset, Properties properties = {});
+
+// Only available if Accessor::dimensions == 1 and Accessor::access_mode != write
+template <typename Accessor, typename Properties = ext::oneapi::experimental::properties<>>
+void prefetch(Accessor* acc, size_t offset, size_t count, Properties properties = {});
+
+} // namespace sycl::ext::oneapi::experimental
+----
+
+[source,c++]
+----
+template <typename Properties = ext::oneapi::experimental::properties<>>
+void prefetch(void* ptr, Properties properties = {});
+----
+_Effects_: Acts as a hint to the implementation that the cacheline containing
+the byte at `ptr` should be prefetched into the levels of cache specified by
+`properties`.
+
+[source,c++]
+----
+template <typename Properties = ext::oneapi::experimental::properties<>>
+void prefetch(void* ptr, size_t bytes, Properties properties = {});
+----
+_Effects_: Acts as a hint to the implementation that the cachelines containing
+the `bytes` bytes starting at `ptr` should be prefetched into the levels of
+cache specified by `properties`.
+
+[source,c++]
+----
+template <typename T, typename Properties = ext::oneapi::experimental::properties<>>
+void prefetch(T* ptr, Properties properties = {});
+----
+_Effects_: Equivalent to `prefetch((void*) ptr, sizeof(T), properties)`.
+
+[source,c++]
+----
+template <typename T, typename Properties = ext::oneapi::experimental::properties<>>
+void prefetch(T* ptr, size_t count, Properties properties = {});
+----
+_Effects_: Equivalent to `prefetch((void*) ptr, count * sizeof(T), properties)`.
+
+[source,c++]
+----
+template <typename Accessor, typename Properties = ext::oneapi::experimental::properties<>>
+void prefetch(Accessor* acc, size_t offset, Properties properties = {});
+----
+_Effects_: Equivalent to `prefetch((void*) (acc.get_pointer() + offset),
+sizeof(Accessor::value_type), properties)`.
+
+[source,c++]
+----
+template <typename Accessor, typename Properties = ext::oneapi::experimental::properties<>>
+void prefetch(Accessor* acc, size_t offset, size_t count, Properties properties = {});
+----
+_Effects_: Equivalent to `prefetch((void*) (acc.get_pointer() + offset), count
+* sizeof(Accessor::value_type), properties)`.
+
+
+==== Usage examples
+
+[source,c++]
+----
+using syclex = sycl::ext::oneapi::experimental;
+
+q.parallel_for(N, [=](auto i) {
+  for (int j = 0; j < M; ++j) {
+    syclex::prefetch(&data[j + 10], syclex::properties{syclex::prefetch_hint_L1});
+    syclex::prefetch(&data[j + 100], syclex::properties{syclex::prefetch_hint_L3});
+    foo(data[j]);
+  }
+});
+----
+
+=== Group prefetches
+
+The functions in this section allow groups of work-items to cooperatively
+prefetch the same data.
+
+[NOTE]
+====
+Although calling `joint_prefetch` is functionally equivalent to calling
+`prefetch` from every work-item in a group, some implementations may be able
+to issue cooperative prefetches more efficiently on some hardware.
+====
+
+[source,c++]
+----
+namespace sycl::ext::oneapi::experimental {
+
+template <typename Group, typename Properties = ext::oneapi::experimental::properties<>>
+void joint_prefetch(Group g, void* ptr, Properties properties = {});
+
+template <typename Group, typename Properties = ext::oneapi::experimental::properties<>>
+void joint_prefetch(Group g, void* ptr, size_t bytes, Properties properties = {});
+
+template <typename Group, typename T, typename Properties = ext::oneapi::experimental::properties<>>
+void joint_prefetch(Group g, T* ptr, Properties properties = {});
+
+template <typename Group, typename T, typename Properties = ext::oneapi::experimental::properties<>>
+void joint_prefetch(Group g, T* ptr, size_t count, Properties properties = {});
+
+// Only available if Accessor::dimensions == 1 and Accessor::access_mode != write
+template <typename Group, typename Accessor, typename Properties = ext::oneapi::experimental::properties<>>
+void joint_prefetch(Group g, Accessor* acc, size_t offset, Properties properties = {});
+
+// Only available if Accessor::dimensions == 1 and Accessor::access_mode != write
+template <typename Group, typename Accessor, typename Properties = ext::oneapi::experimental::properties<>>
+void joint_prefetch(Group g, Accessor* acc, size_t offset, size_t count, Properties properties = {});
+
+} // namespace sycl::ext::oneapi::experimental
+----
+
+[source,c++]
+----
+template <typename Group, typename Properties = ext::oneapi::experimental::properties<>>
+void joint_prefetch(Group g, void* ptr, Properties properties = {});
+----
+_Constraints_: Available only if `sycl::is_group_v<std::decay_t<Group>>` is
+`true`.
+
+_Preconditions_: `ptr` and `properties` must be the same for all work-items in
+group `g`.
+
+_Effects_: Acts as a hint to the implementation that the cacheline containing
+the byte at `ptr` should be prefetched into the levels of cache specified by
+`properties`.
+
+[source,c++]
+----
+template <typename Group, typename Properties = ext::oneapi::experimental::properties<>>
+void joint_prefetch(Group g, void* ptr, size_t bytes, Properties properties = {});
+----
+_Constraints_: Available only if `sycl::is_group_v<std::decay_t<Group>>` is
+`true`.
+
+_Preconditions_: `ptr`, `bytes` and `properties` must be the same for all
+work-items in group `g`.
+
+_Effects_: Acts as a hint to the implementation that the cachelines containing
+the `bytes` bytes starting at `ptr` should be prefetched into the levels of
+cache specified by `properties`.
+
+[source,c++]
+----
+template <typename Group, typename T, typename Properties = ext::oneapi::experimental::properties<>>
+void joint_prefetch(Group g, T* ptr, Properties properties = {});
+----
+_Constraints_: Available only if `sycl::is_group_v<std::decay_t<Group>>` is
+`true`.
+
+_Preconditions_: `ptr` and `properties` must be the same for all work-items in
+group `g`.
+
+_Effects_: Equivalent to `joint_prefetch(g, (void*) ptr, sizeof(T),
+properties)`.
+
+[source,c++]
+----
+template <typename Group, typename T, typename Properties = ext::oneapi::experimental::properties<>>
+void joint_prefetch(Group g, T* ptr, size_t count, Properties properties = {});
+----
+_Constraints_: Available only if `sycl::is_group_v<std::decay_t<Group>>` is
+`true`.
+
+_Preconditions_: `ptr`, `count` and `properties` must be the same for all
+work-items in group `g`.
+
+_Effects_: Equivalent to `joint_prefetch(g, (void*) ptr, count * sizeof(T),
+properties)`.
+
+[source,c++]
+----
+template <typename Group, typename Accessor, typename Properties = ext::oneapi::experimental::properties<>>
+void joint_prefetch(Group g, Accessor* acc, size_t offset, Properties properties = {});
+----
+_Constraints_: Available only if `sycl::is_group_v<std::decay_t<Group>>` is
+`true`.
+
+_Preconditions_: `acc`, `offset` and `properties` must be the same for all
+work-items in group `g`.
+
+_Effects_: Equivalent to `joint_prefetch(g, (void*) (acc.get_pointer() +
+offset), sizeof(Accessor::value_type), properties)`.
+
+[source,c++]
+----
+template <typename Group, typename Accessor, typename Properties = ext::oneapi::experimental::properties<>>
+void joint_prefetch(Group g, Accessor* acc, size_t offset, size_t count, Properties properties = {});
+----
+_Constraints_: Available only if `sycl::is_group_v<std::decay_t<Group>>` is
+`true`.
+
+_Preconditions_: `acc`, `offset`, `count` and `properties` must be the same for
+all work-items in group `g`.
+
+_Effects_: Equivalent to `joint_prefetch(g, (void*) (acc.get_pointer() +
+offset), count * sizeof(Accessor::value_type), properties)`.
+
+
+==== Usage examples
+
+[source,c++]
+----
+using syclex = sycl::ext::oneapi::experimental;
+
+q.parallel_for(sycl::nd_range{N, L}, [=](sycl::nd_item<1> it) {
+  auto sg = it.get_sub_group();
+  for (int j = sg.get_local_id(); j < M; j += sg.get_max_local_range()) {
+    syclex::joint_prefetch(sg, &data[j + 100], sg.get_max_local_range(), syclex::properties{syclex::prefetch_hint_L3});
+    foo(sg, data[j]);
+  }
+});
+----
+
+
+== Issues
+
+. Which level of cache should be targeted for an empty property list?
++
+--
+*UNRESOLVED*:
+Defaulting to the lowest level of cache may be expected by some users, who
+would like the prefetch to place data as close to the compute units as
+possible. Defaulting to the highest level of cache may be expected by other
+users, since that level typically has the highest capacity and may contain
+data from all other levels -- naive usage of prefetches in this case would be
+less likely to cause thrashing across multiple levels of cache.
+
+The current draft of this extension sets the default as the highest level.
+Developers who want to prefetch data into the closest level instead can simply
+override the behavior by specifying `prefetch_hint_L1`.
+--
+
+. How should multi-dimensional prefetches be handled?
++
+--
+*UNRESOLVED*:
+Some developers think of multi-dimensional accessors in terms of the underlying
+(linearized) memory, and would expect to describe prefetches in terms of scalar
+offsets and counts. Other developers might expect prefetches using
+multi-dimensional accessors to accept offsets and counts decribed using `id`
+and `range` objects.
+
+The current draft of this extension limits functionality to one-dimensional
+accessors.
+--


### PR DESCRIPTION
Adds prefetch and joint_prefetch functions for providing prefetch hints associated with specific levels of cache.