### PR TITLE
[SYCL] Throw exception when empty accessor calls require().

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1558,6 +1558,9 @@ public:
   template <typename DataT, int Dims, access::mode AccMode,
             access::target AccTarget, access::placeholder isPlaceholder>
   void require(accessor<DataT, Dims, AccMode, AccTarget, isPlaceholder> Acc) {
+    if (Acc.empty())
+      throw sycl::exception(make_error_code(errc::invalid),
+                            "require() cannot be called on empty accessors");
     if (Acc.is_placeholder())
       associateWithHandler(&Acc, AccTarget);
   }

--- a/sycl/test-e2e/Basic/accessor/accessor.cpp
+++ b/sycl/test-e2e/Basic/accessor/accessor.cpp
@@ -760,7 +760,7 @@ int main() {
     }
   }
 
-  // empty accessor exception calling require() // SYCL2020 4.9.4.1
+  // SYCL2020 4.9.4.1: calling require() on empty accessor should throw
   {
     sycl::queue q;
     try {

--- a/sycl/test-e2e/Basic/accessor/accessor.cpp
+++ b/sycl/test-e2e/Basic/accessor/accessor.cpp
@@ -763,7 +763,6 @@ int main() {
   // empty accessor exception calling require() // SYCL2020 4.9.4.1
   {
     sycl::queue q;
-    // host device executes kernels via a different method and there
     try {
       using AccT = sycl::accessor<int, 1, sycl::access::mode::read_write>;
       AccT acc;


### PR DESCRIPTION
According to SYCL2020 4.9.4.1 calling `require()` on an empty accessor should throw.