### PR TITLE
[SYCL][E2E] Disable flaky test on Windows

### DIFF
--- a/sycl/test-e2e/Plugin/level_zero_imm_cmdlist_per_thread.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_imm_cmdlist_per_thread.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: gpu, level_zero
 
-// Flaky failure on windows && gen12
-// UNSUPPORTED: windows && gpu-intel-gen12
+// Flaky failure on windows
+// UNSUPPORTED: windows
 
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %level_zero_options %threads_lib %s -o %t.out
 // RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 ZE_DEBUG=4 %GPU_RUN_PLACEHOLDER %t.out 2>&1 | FileCheck --check-prefixes=CHECK-ONE-CMDLIST %s


### PR DESCRIPTION
Originally I wanted to disable this on Gen12 Windows only, but it seems there are a ton of device IDs we would need to check  and based on https://github.com/intel/llvm/issues/9117#issuecomment-1515070784 we don't care about Windows anyway.

Related: https://github.com/intel/llvm/issues/9117