### PR TITLE
[SYCL-MLIR] Add `-sycl-use-host-module=<file>` option

### DIFF
--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -222,6 +222,11 @@ static llvm::cl::opt<std::string> McpuOpt("mcpu", llvm::cl::init(""),
                                           llvm::cl::desc("Target CPU"),
                                           llvm::cl::cat(ToolOptions));
 
+static llvm::cl::opt<std::string>
+    SYCLUseHostModule("sycl-use-host-module", llvm::cl::init(""),
+                      llvm::cl::desc("Use input file as host SYCL module"),
+                      llvm::cl::cat(ToolOptions));
+
 llvm::cl::opt<bool>
     UseOpaquePointers("use-opaque-pointers", llvm::cl::init(false),
                       llvm::cl::desc("Whether to use opaque pointers in MLIR"));

--- a/polygeist/tools/cgeist/Test/Verification/sycl/host_module.mlir
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/host_module.mlir
@@ -1,0 +1,7 @@
+module {
+memref.global constant @c : memref<i32, 1> {alignment = 4 : i64}
+func.func @do_nothing() -> memref<i32, 1> {
+  %0 = memref.get_global @c : memref<i32, 1>
+  return %0 : memref<i32, 1>
+}
+}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/non_sycl_use_host_module.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/non_sycl_use_host_module.cpp
@@ -1,4 +1,3 @@
-
 // RUN: not cgeist -sycl-use-host-module=%S/host_module.mlir -O0 -w -o - %s 2>&1 | FileCheck %s
 
 // CHECK: "-sycl-use-host-module" can only be used during SYCL device compilation

--- a/polygeist/tools/cgeist/Test/Verification/sycl/non_sycl_use_host_module.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/non_sycl_use_host_module.cpp
@@ -1,0 +1,6 @@
+
+// RUN: not cgeist -sycl-use-host-module=%S/host_module.mlir -O0 -w -o - %s 2>&1 | FileCheck %s
+
+// CHECK: "-sycl-use-host-module" can only be used during SYCL device compilation
+
+void do_nothing() {}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_use_host_module.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_use_host_module.cpp
@@ -1,0 +1,14 @@
+// RUN: clang++ -fsycl -fsycl-device-only -Xcgeist -sycl-use-host-module=%S/host_module.mlir -O0 -w -emit-mlir -o - %s | FileCheck %s
+
+#include <sycl/sycl.hpp>
+
+// CHECK:        gpu.module @device_functions
+// CHECK:        memref.global constant @c : memref<i32, 1> {alignment = 4 : i64}
+// CHECK-NEXT:   func.func @do_nothing() -> memref<i32, 1> {
+// CHECK-NEXT:     %0 = memref.get_global @c : memref<i32, 1>
+// CHECK-NEXT:     return %0 : memref<i32, 1>
+// CHECK-NEXT:   }
+// Check that the function is at the end of the top-level module
+// CHECK-NEXT: }
+// CHECK-NOT:  {{.+}}
+SYCL_EXTERNAL void do_nothing() {}

--- a/polygeist/tools/cgeist/Test/lit.cfg
+++ b/polygeist/tools/cgeist/Test/lit.cfg
@@ -18,7 +18,7 @@ config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files. This is overriden
 # by individual lit.local.cfg files in the test subdirectories.
-config.suffixes = ['.c', '.cpp', '.cu', '.mlir']
+config.suffixes = ['.c', '.cpp', '.cu']
 
 # excludes: A list of directories or files to exclude from the testsuite even
 # if they match the suffixes pattern.

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -48,6 +48,7 @@
 #include "mlir/Target/LLVMIR/Dialect/Builtin/BuiltinToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Export.h"
+#include "mlir/Tools/ParseUtilities.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 


### PR DESCRIPTION
Add option reading the host module from an input MLIR file and linking it with the device module.

This option will only be available when compiling SYCL device code. This will enable host-device optimizations.

The input file should correspond to the MLIR representation of the host code present in the input file.
