### PR TITLE
[SYCL][ESIMD] Adjust static restriction checks for block_2d APIs

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -1989,7 +1989,6 @@ constexpr void check_lsc_block_2d_restrictions() {
     static_assert(
         __ESIMD_DNS::isPowerOf2(NBlocks, sizeof(T) == 1 ? 4 : 8 / sizeof(T)),
         "Unsupported number of blocks");
-    static_assert(BlockHeight >= 1, "Unsupported block height");
     if constexpr (IsStore)
       static_assert(BlockHeight <= 8, "Unsupported block height for store");
     else

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -1956,6 +1956,9 @@ template <typename T, int BlockWidth, int BlockHeight, int NBlocks,
           bool Transposed, bool Transformed, bool IsStore = false>
 constexpr void check_lsc_block_2d_restrictions() {
   constexpr int GRFByteSize = BlockWidth * BlockHeight * NBlocks * sizeof(T);
+  static_assert(BlockWidth > 0, "Block width must be positive");
+  static_assert(BlockHeight > 0, "Block height must be positive");
+  // Restrictions based on documentation.
   static_assert(!IsStore || GRFByteSize <= 512,
                 "2D store supports 512 bytes max");
   static_assert(IsStore || GRFByteSize <= 2048,
@@ -1966,11 +1969,11 @@ constexpr void check_lsc_block_2d_restrictions() {
     static_assert(NBlocks == 1, "Transposed expected to be 1 block only");
     static_assert(sizeof(T) == 4 || sizeof(T) == 8,
                   "Transposed load is supported only for data size u32 or u64");
-    static_assert(sizeof(T) == 64 ? BlockHeight == 8
-                                  : BlockHeight >= 1 && BlockHeight <= 32,
+    static_assert(sizeof(T) == 8 ? BlockHeight == 8
+                                 : BlockHeight >= 1 && BlockHeight <= 32,
                   "Unsupported block height");
-    static_assert(sizeof(T) == 64 ? __ESIMD_DNS::isPowerOf2(BlockWidth, 4)
-                                  : BlockWidth >= 1 && BlockWidth <= 8,
+    static_assert(sizeof(T) == 8 ? __ESIMD_DNS::isPowerOf2(BlockWidth, 4)
+                                 : BlockWidth >= 1 && BlockWidth <= 8,
                   "Unsupported block width");
   } else if constexpr (Transformed) {
     static_assert(sizeof(T) == 1 || sizeof(T) == 2,
@@ -1979,15 +1982,18 @@ constexpr void check_lsc_block_2d_restrictions() {
                   "Unsupported number of blocks");
     static_assert(BlockHeight * sizeof(T) >= 4 && BlockHeight <= 32,
                   "Unsupported block height");
-    static_assert(BlockWidth * sizeof(T) >= 4 &&
+    static_assert(BlockWidth * sizeof(T) >= 4 && BlockWidth <= 16 &&
                       BlockWidth * NBlocks * sizeof(T) <= 64,
                   "Unsupported block width");
   } else {
     static_assert(
         __ESIMD_DNS::isPowerOf2(NBlocks, sizeof(T) == 1 ? 4 : 8 / sizeof(T)),
         "Unsupported number of blocks");
-    static_assert(BlockHeight >= 1 && BlockHeight <= 32,
-                  "Unsupported block height");
+    static_assert(BlockHeight >= 1, "Unsupported block height");
+    if constexpr (IsStore)
+      static_assert(BlockHeight <= 8, "Unsupported block height for store");
+    else
+      static_assert(BlockHeight <= 32, "Unsupported block height for load");
     static_assert(BlockWidth * sizeof(T) >= 4 &&
                       BlockWidth * NBlocks * sizeof(T) <= 64,
                   "Unsupported block width");

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -1965,6 +1965,8 @@ constexpr void check_lsc_block_2d_restrictions() {
                 "2D load supports 2048 bytes max");
   static_assert(!Transposed || !Transformed,
                 "Transposed and transformed is not supported");
+  static_assert((sizeof(T) * BlockWidth) % 4 == 0,
+                "Block width must be aligned by DW");
   if constexpr (Transposed) {
     static_assert(NBlocks == 1, "Transposed expected to be 1 block only");
     static_assert(sizeof(T) == 4 || sizeof(T) == 8,

--- a/sycl/test-e2e/ESIMD/lsc/Inputs/lsc_store_2d.hpp
+++ b/sycl/test-e2e/ESIMD/lsc/Inputs/lsc_store_2d.hpp
@@ -56,13 +56,6 @@ template <int case_num, typename T, uint32_t Groups, uint32_t Threads,
           cache_hint L1H = cache_hint::none, cache_hint L3H = cache_hint::none>
 bool test(unsigned SurfaceWidth, unsigned SurfaceHeight, unsigned SurfacePitch,
           int X, int Y) {
-  static_assert(BlockWidth > 0, "Block width must be positive");
-  static_assert(BlockHeight > 0, "Block height must be positive");
-  static_assert((sizeof(T) * BlockWidth) % 4 == 0,
-                "Block width must be aligned by DW");
-  static_assert(sizeof(T) * BlockWidth <= 64,
-                "Block width must be 64B or less");
-  static_assert(BlockHeight <= 8, "Block height must be 8 or less");
 
   T old_val = get_rand<T>();
   T new_val = get_rand<T>();

--- a/sycl/test/esimd/check_lsc.cpp
+++ b/sycl/test/esimd/check_lsc.cpp
@@ -24,8 +24,8 @@ template <class T, int BLOCK_WIDTH, int BLOCK_HEIGHT, int NUM_BLOCKS,
 SYCL_EXTERNAL auto test_load(T *ptr, int width, int height,
                              int pitch) SYCL_ESIMD_FUNCTION {
   return lsc_load_2d<T, BLOCK_WIDTH, BLOCK_HEIGHT, NUM_BLOCKS, TRANSPOSE,
-                    TRANSFORM, L1H, L3H>(ptr, width * sizeof(T) - 1, height - 1,
-                                         pitch * sizeof(T) - 1, 0, 0);
+                     TRANSFORM, L1H, L3H>(
+      ptr, width * sizeof(T) - 1, height - 1, pitch * sizeof(T) - 1, 0, 0);
 }
 
 template <class T, int BLOCK_WIDTH, int BLOCK_HEIGHT, int NUM_BLOCKS,

--- a/sycl/test/esimd/check_lsc.cpp
+++ b/sycl/test/esimd/check_lsc.cpp
@@ -2,7 +2,7 @@
 // RUN: not %clangxx %fsycl-host-only -fsyntax-only -Wno-unused-command-line-argument %s 2>&1 | FileCheck %s --implicit-check-not="error:"
 
 // This test checks that both host and device compilers can:
-// - successfully compile lsc_load2d/lsc_store2d APIs
+// - successfully compile lsc_load_2d/lsc_store_2d APIs
 // - emit an error if some of the restrictions on template parameters are
 //   violated
 
@@ -23,7 +23,7 @@ template <class T, int BLOCK_WIDTH, int BLOCK_HEIGHT, int NUM_BLOCKS,
               T, NUM_BLOCKS, BLOCK_HEIGHT, BLOCK_WIDTH, TRANSPOSE, TRANSFORM>()>
 SYCL_EXTERNAL auto test_load(T *ptr, int width, int height,
                              int pitch) SYCL_ESIMD_FUNCTION {
-  return lsc_load2d<T, BLOCK_WIDTH, BLOCK_HEIGHT, NUM_BLOCKS, TRANSPOSE,
+  return lsc_load_2d<T, BLOCK_WIDTH, BLOCK_HEIGHT, NUM_BLOCKS, TRANSPOSE,
                     TRANSFORM, L1H, L3H>(ptr, width * sizeof(T) - 1, height - 1,
                                          pitch * sizeof(T) - 1, 0, 0);
 }
@@ -34,7 +34,7 @@ template <class T, int BLOCK_WIDTH, int BLOCK_HEIGHT, int NUM_BLOCKS,
               T, NUM_BLOCKS, BLOCK_HEIGHT, BLOCK_WIDTH, false, false>()>
 SYCL_EXTERNAL void test_store(T *ptr, simd<T, N> v, int width, int height,
                               int pitch) SYCL_ESIMD_FUNCTION {
-  lsc_store2d<T, BLOCK_WIDTH, BLOCK_HEIGHT, L1H, L3H>(
+  lsc_store_2d<T, BLOCK_WIDTH, BLOCK_HEIGHT, L1H, L3H>(
       ptr, width * sizeof(T) - 1, height - 1, pitch * sizeof(T) - 1, 0, 0, v);
 }
 
@@ -45,8 +45,8 @@ test_load<float, 16, 16, 1, false, false, cache_hint::none, cache_hint::none>(
     float *, int, int, int) SYCL_ESIMD_FUNCTION;
 
 constexpr int N16_8 =
-    __ESIMD_EDNS::get_lsc_block_2d_data_size<float, 1, 16, 8, false, false>();
-template void test_store<float, 8, 16, 1, cache_hint::none, cache_hint::none>(
+    __ESIMD_EDNS::get_lsc_block_2d_data_size<float, 1, 8, 16, false, false>();
+template void test_store<float, 16, 8, 1, cache_hint::none, cache_hint::none>(
     float *, simd<float, N16_8>, int, int, int) SYCL_ESIMD_FUNCTION;
 
 // --- Negative tests.
@@ -62,3 +62,4 @@ template void test_store<float, 16, 16, 1, cache_hint::none, cache_hint::none>(
     float *, simd<float, N16_16>, int, int, int) SYCL_ESIMD_FUNCTION;
 // CHECK: {{.*}}error: {{.*}}Unsupported block width
 // CHECK: {{.*}}error: {{.*}}2D store supports 512 bytes max
+// CHECK: {{.*}}error: {{.*}}Unsupported block height for store


### PR DESCRIPTION
Patch fixes several bugs in the restrictions checks, alignes the checks
with documentation requirements, and removes duplicating checks from the test.