### PR TITLE
[SYCL][Test E2E] Introduce %{build}/%{run} substitution/expansion

### DIFF
--- a/sycl/test-e2e/AtomicRef/add_generic.cpp
+++ b/sycl/test-e2e/AtomicRef/add_generic.cpp
@@ -1,7 +1,5 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
-// RUN: %GPU_RUN_PLACEHOLDER %t.out
-// RUN: %CPU_RUN_PLACEHOLDER %t.out
-// RUN: %ACC_RUN_PLACEHOLDER %t.out
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
 
 #include "add.h"
 

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -1,0 +1,48 @@
+import lit
+import lit.formats
+
+class SYCLEndToEndTest(lit.formats.ShTest):
+    def execute(self, test, litConfig):
+        filename = test.path_in_suite[-1]
+        tmpDir, tmpBase = lit.TestRunner.getTempPaths(test)
+        script = lit.TestRunner.parseIntegratedTestScript(test, require_script=True)
+        if isinstance(script, lit.Test.Result):
+            return script
+
+        substitutions = lit.TestRunner.getDefaultSubstitutions(test, tmpDir, tmpBase)
+        # -fsycl-targets is needed for CUDA/HIP, so just use it be default so
+        # -that new tests by default would runnable there (unless they have
+        # -other restrictions).
+        substitutions.append(('%{build}', '%clangxx -fsycl -fsycl-targets=%sycl_triple %s'))
+
+        devices_for_test = ['{}:{}'.format(test.config.sycl_be, dev)
+                            for dev in test.config.target_devices.split(',')]
+
+        new_script = []
+        for directive in script:
+            if not isinstance(directive, lit.TestRunner.CommandDirective):
+                new_script.append(directive)
+                continue
+
+            if '%{run}' not in directive.command:
+                new_script.append(directive)
+                continue
+
+            for sycl_device in devices_for_test:
+                cmd = directive.command.replace(
+                    '%{run}',
+                    'env ONEAPI_DEVICE_SELECTOR={} {}'.format(sycl_device, test.config.run_launcher))
+
+                new_script.append(
+                    lit.TestRunner.CommandDirective(
+                        directive.start_line_number,
+                        directive.end_line_number,
+                        directive.keyword,
+                        cmd))
+        script = new_script
+
+        conditions = { feature: True for feature in test.config.available_features }
+        script = lit.TestRunner.applySubstitutions(script, substitutions, conditions,
+                                                   recursion_limit=test.config.recursiveExpansionLimit)
+        useExternalSh = False
+        return lit.TestRunner._runShTest(test, litConfig, useExternalSh, script, tmpBase)

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -18,12 +18,6 @@ from lit.llvm.subst import ToolSubst, FindTool
 # name: The name of this test suite.
 config.name = 'SYCL'
 
-# testFormat: The test format to use to interpret tests.
-#
-# For now we require '&&' between commands, until they get globally killed and
-# the test runner updated.
-config.test_format = lit.formats.ShTest()
-
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = ['.c', '.cpp']
 

--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -3,6 +3,9 @@
 import sys
 import platform
 
+import site
+
+site.addsitedir("@CMAKE_CURRENT_SOURCE_DIR@")
 
 config.dpcpp_compiler = lit_config.params.get("dpcpp_compiler", "@SYCL_CXX_COMPILER@")
 config.dpcpp_root_dir= os.path.dirname(os.path.dirname(config.dpcpp_compiler))
@@ -40,3 +43,6 @@ import lit.llvm
 lit.llvm.initialize(lit_config, config)
 
 lit_config.load_config(config, "@CMAKE_CURRENT_SOURCE_DIR@/lit.cfg.py")
+
+from format import SYCLEndToEndTest
+config.test_format = SYCLEndToEndTest()


### PR DESCRIPTION
Standard LIT's ShTest format only supports substitution that can perform replacements in a single RUN directive, but cannot create multiple commands from a single RUN line. This PR introduces a new test format specific for the SYCL end-to-end tests that has such capability.

As part of this change I'm updating most of the tests to start using `%{build}` and switch the most trivial ones to benefit from `%{run}`.

This change is part of a longer term goal to enable targeting multiple SYCL backends in a single llvm-lit invocations. However, I'm starting with updating tests' RUN lines before doing the functional change. As such, current RUN lines are generated using `sycle_be` and `target_devices` LIT parameters.

I plan to create several dedicated PRs to update tests to switch to the new `%{build}`/`%{run}` syntax once this PR gets merged in.