### PR TITLE
[Driver][SYCL] Fix arguments associated with -ftarget-compile-fast

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -979,8 +979,7 @@ void SYCLToolChain::AddImpliedTargetArgs(const llvm::Triple &Triple,
     }
     // -ftarget-compile-fast
     if (Args.hasArg(options::OPT_ftarget_compile_fast)) {
-      BeArgs.push_back(
-          "-igc_opts 'PartitionUnit=1,SubroutineThreshold=50000'");
+      BeArgs.push_back("-igc_opts 'PartitionUnit=1,SubroutineThreshold=50000'");
     }
   }
   if (BeArgs.empty())

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -980,7 +980,7 @@ void SYCLToolChain::AddImpliedTargetArgs(const llvm::Triple &Triple,
     // -ftarget-compile-fast
     if (Args.hasArg(options::OPT_ftarget_compile_fast)) {
       BeArgs.push_back(
-          "\"-igc_opts PartitionUnit=1,SubroutineThreshold=50000\"");
+          "-igc_opts 'PartitionUnit=1,SubroutineThreshold=50000'");
     }
   }
   if (BeArgs.empty())

--- a/clang/test/Driver/ftarget-compile-fast.cpp
+++ b/clang/test/Driver/ftarget-compile-fast.cpp
@@ -8,4 +8,4 @@
 // RUN:   | FileCheck -check-prefix=TARGET_COMPILE_FAST_GEN %s
 
 // TARGET_COMPILE_FAST_GEN: ocloc{{.*}} "-output"
-// TARGET_COMPILE_FAST_GEN: "-options" "{{.*}}-igc_opts PartitionUnit=1,SubroutineThreshold=50000{{.*}}"
+// TARGET_COMPILE_FAST_GEN: "-options" "-igc_opts 'PartitionUnit=1,SubroutineThreshold=50000'"


### PR DESCRIPTION
Update the arguments used when passing to 'ocloc' with -ftarget-compile-fast.  Original syntax was not quite correct.