### PR TITLE
[SYCL-MLIR] Opaque pointer support in Polygeist transformations

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.h
@@ -51,6 +51,8 @@ std::unique_ptr<Pass> createLoopRestructurePass();
 std::unique_ptr<Pass> createMem2RegPass();
 std::unique_ptr<Pass> createOpenMPOptPass();
 std::unique_ptr<Pass> createParallelLowerPass();
+std::unique_ptr<Pass>
+createParallelLowerPass(const ParallelLowerOptions &options);
 std::unique_ptr<Pass> createRaiseSCFToAffinePass();
 std::unique_ptr<Pass> createRemoveTrivialUsePass();
 std::unique_ptr<Pass> createReplaceAffineCFGPass();

--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
@@ -50,8 +50,11 @@ def DetectReduction : Pass<"detect-reduction"> {
      "scf::SCFDialect", "sycl::SYCLDialect"];
   let options = [
     Option<"relaxedAliasing", "relaxed-aliasing", "bool", 
-           /*default=*/"false", 
-           "Whether to use strict aliasing (i.e. type-based aliasing) rules or not">
+            /*default=*/"false", 
+            "Whether to use strict aliasing (i.e. type-based aliasing) rules or not">,
+    Option<"useOpaquePointers", "use-opaque-pointers", "bool",
+            /*default=*/"false", "Generate LLVM IR using opaque pointers "
+            "instead of typed pointers">,
   ];
   let statistics = [
     Statistic<"numReductions", "num-reductions", "Number of reductions detected">
@@ -70,8 +73,11 @@ def KernelDisjointSpecialization : Pass<"kernel-disjoint-specialization", "mlir:
   let constructor = "mlir::polygeist::createKernelDisjointSpecializationPass()";
   let options = [
     Option<"relaxedAliasing", "relaxed-aliasing", "bool", 
-           /*default=*/"false", 
-           "Whether to use strict aliasing (i.e. type-based aliasing) rules or not">
+            /*default=*/"false", 
+            "Whether to use strict aliasing (i.e. type-based aliasing) rules or not">,
+    Option<"useOpaquePointers", "use-opaque-pointers", "bool",
+            /*default=*/"false", "Generate LLVM IR using opaque pointers "
+            "instead of typed pointers">,
   ];
   let statistics = [
     Statistic<"numFunctionSpecialized", "num-function-specialized", "Number of function specialized">
@@ -90,6 +96,11 @@ def ParallelLower : Pass<"parallel-lower", "mlir::ModuleOp"> {
       ["memref::MemRefDialect", "polygeist::PolygeistDialect",
        "LLVM::LLVMDialect", "scf::SCFDialect"];
   let constructor = "mlir::polygeist::createParallelLowerPass()";
+  let options = [
+    Option<"useOpaquePointers", "use-opaque-pointers", "bool",
+            /*default=*/"false", "Generate LLVM IR using opaque pointers "
+            "instead of typed pointers">,
+  ];
 }
 
 def SCFCPUify : Pass<"cpuify"> {
@@ -143,8 +154,11 @@ def LICM : Pass<"licm"> {
   let constructor = "mlir::polygeist::createLICMPass()";
   let options = [
     Option<"relaxedAliasing", "relaxed-aliasing", "bool", 
-           /*default=*/"false", 
-           "Whether to use strict aliasing (i.e. type-based aliasing) rules or not">
+            /*default=*/"false", 
+            "Whether to use strict aliasing (i.e. type-based aliasing) rules or not">,
+    Option<"useOpaquePointers", "use-opaque-pointers", "bool",
+            /*default=*/"false", "Generate LLVM IR using opaque pointers "
+            "instead of typed pointers">,
   ];
   let statistics = [
     Statistic<"numOpHoisted", "num-operations-hoisted", "Number of operations hoisted">

--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -287,14 +287,16 @@ public:
       std::set<sycl::AccessorPtrPair> requireNoOverlapAccessorPairs,
       OpBuilder builder, Location loc);
 
-  std::unique_ptr<VersionCondition> createCondition() const {
-    SCFCondition scfCond = createSCFCondition(builder, loc);
+  std::unique_ptr<VersionCondition>
+  createCondition(bool useOpaquePointers) const {
+    SCFCondition scfCond = createSCFCondition(builder, loc, useOpaquePointers);
     return std::make_unique<VersionCondition>(scfCond);
   }
 
 private:
   /// Create a versioning condition suitable for scf::IfOp.
-  SCFCondition createSCFCondition(OpBuilder builder, Location loc) const;
+  SCFCondition createSCFCondition(OpBuilder builder, Location loc,
+                                  bool useOpaquePointers) const;
 
   std::set<sycl::AccessorPtrPair> accessorPairs;
   mutable OpBuilder builder;

--- a/polygeist/lib/Dialect/Polygeist/IR/PolygeistOps.cpp
+++ b/polygeist/lib/Dialect/Polygeist/IR/PolygeistOps.cpp
@@ -1499,8 +1499,7 @@ public:
     if (idx) {
       Value idxs[] = {idx};
       val = rewriter.create<LLVM::GEPOp>(op.getLoc(), val.getType(),
-                                         mt.getElementType(), val,
-                                         idxs);
+                                         mt.getElementType(), val, idxs);
     }
 
     replaceOpWithNewOp(op, val, rewriter);

--- a/polygeist/lib/Dialect/Polygeist/IR/PolygeistOps.cpp
+++ b/polygeist/lib/Dialect/Polygeist/IR/PolygeistOps.cpp
@@ -1468,15 +1468,13 @@ public:
         return failure();
 
     Value val = src.getSource();
-    if (auto PtrTy = dyn_cast<LLVM::LLVMPointerType>(val.getType())) {
-      if (!PtrTy.isOpaque() && PtrTy.getElementType() != mt.getElementType()) {
-        val = rewriter.create<LLVM::BitcastOp>(
-            op.getLoc(),
-            LLVM::LLVMPointerType::get(mt.getElementType(),
-                                       PtrTy.getAddressSpace()),
-            val);
-      }
-    }
+    auto PtrTy = cast<LLVM::LLVMPointerType>(val.getType());
+    if (!PtrTy.isOpaque() && PtrTy.getElementType() != mt.getElementType())
+      val = rewriter.create<LLVM::BitcastOp>(
+          op.getLoc(),
+          LLVM::LLVMPointerType::get(mt.getElementType(),
+                                     PtrTy.getAddressSpace()),
+          val);
 
     Value idx = nullptr;
     auto shape = mt.getShape();

--- a/polygeist/lib/Dialect/Polygeist/IR/PolygeistOps.cpp
+++ b/polygeist/lib/Dialect/Polygeist/IR/PolygeistOps.cpp
@@ -1499,7 +1499,7 @@ public:
     if (idx) {
       Value idxs[] = {idx};
       val = rewriter.create<LLVM::GEPOp>(op.getLoc(), val.getType(),
-                                         src.getType().getElementType(), val,
+                                         mt.getElementType(), val,
                                          idxs);
     }
 

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LegalizeForSPIRV.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LegalizeForSPIRV.cpp
@@ -60,14 +60,12 @@ public:
         allocaOp.getLoc(), IntegerType::get(rewriter.getContext(), 32),
         rewriter.getIntegerAttr(rewriter.getI32Type(), constIndices.front()));
 
-    if (allocaOp.getElemType()) {
+    if (std::optional<Type> optElemType = allocaOp.getElemType())
       rewriter.replaceOpWithNewOp<LLVM::AllocaOp>(
-          allocaOp, allocaOp.getRes().getType(), allocaOp.getElemType().value(),
-          size);
-      return success();
-    }
-    rewriter.replaceOpWithNewOp<LLVM::AllocaOp>(
-        allocaOp, allocaOp.getRes().getType(), size);
+          allocaOp, allocaOp.getRes().getType(), *optElemType, size);
+    else
+      rewriter.replaceOpWithNewOp<LLVM::AllocaOp>(
+          allocaOp, allocaOp.getRes().getType(), size);
 
     return success();
   }

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LegalizeForSPIRV.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LegalizeForSPIRV.cpp
@@ -60,6 +60,12 @@ public:
         allocaOp.getLoc(), IntegerType::get(rewriter.getContext(), 32),
         rewriter.getIntegerAttr(rewriter.getI32Type(), constIndices.front()));
 
+    if (allocaOp.getElemType()) {
+      rewriter.replaceOpWithNewOp<LLVM::AllocaOp>(
+          allocaOp, allocaOp.getRes().getType(), allocaOp.getElemType().value(),
+          size);
+      return success();
+    }
     rewriter.replaceOpWithNewOp<LLVM::AllocaOp>(
         allocaOp, allocaOp.getRes().getType(), size);
 

--- a/polygeist/lib/Dialect/Polygeist/Transforms/Mem2Reg.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/Mem2Reg.cpp
@@ -217,7 +217,7 @@ struct Mem2Reg : public mlir::polygeist::impl::Mem2RegBase<Mem2Reg> {
 
   // return if changed
   bool forwardStoreToLoad(
-      mlir::Value AI, std::vector<Offset> idx,
+      mlir::Value AI, mlir::Type ElemTy, std::vector<Offset> idx,
       SmallVectorImpl<Operation *> &loadOpsToErase,
       DenseMap<Operation *, SmallVector<Operation *>> &capturedAliasing);
 };
@@ -1087,7 +1087,7 @@ std::set<std::string> NoWriteFunctions = {"exit", "__errno_location"};
 // This is a straightforward implementation not optimized for speed. Optimize
 // if needed.
 bool Mem2Reg::forwardStoreToLoad(
-    mlir::Value AI, std::vector<Offset> idx,
+    mlir::Value AI, mlir::Type ElemTy, std::vector<Offset> idx,
     SmallVectorImpl<Operation *> &loadOpsToErase,
     DenseMap<Operation *, SmallVector<Operation *>> &capturedAliasing) {
   bool changed = false;
@@ -1420,13 +1420,7 @@ bool Mem2Reg::forwardStoreToLoad(
     }
   }
 
-  Type elType;
-  if (auto MT = dyn_cast<MemRefType>(AI.getType()))
-    elType = MT.getElementType();
-  else
-    elType = cast<LLVM::LLVMPointerType>(AI.getType()).getElementType();
-
-  ReplacementHandler metaMap(elType);
+  ReplacementHandler metaMap(ElemTy);
 
   // Last value stored in an individual block and the operation which stored it
   BlockMap &valueAtEndOfBlock = metaMap.valueAtEndOfBlock;
@@ -1445,9 +1439,7 @@ bool Mem2Reg::forwardStoreToLoad(
       [&](Value orig, ValueOrPlaceholder *replacement) -> ValueOrPlaceholder * {
     assert(replacement);
     replacement->materialize(/*full*/ false);
-    // TODO(Lukas): The following assert has been deactivated, as elType will
-    // be 'null' for opaque pointers.
-    // assert(orig.getType() == elType);
+    assert(orig.getType() == ElemTy);
     if (replacement->overwritten) {
       loadOps.erase(orig.getDefiningOp());
       return metaMap.get(orig);
@@ -1455,9 +1447,7 @@ bool Mem2Reg::forwardStoreToLoad(
     if (replacement->val) {
       changed = true;
       assert(orig != replacement->val);
-      // TODO(Lukas): The following assert has been deactivated, as elType will
-      // be 'null' for opaque pointers.
-      // assert(replacement->val.getType() == elType);
+      assert(replacement->val.getType() == ElemTy);
       assert(orig.getType() == replacement->val.getType() &&
              "mismatched load type");
       LLVM_DEBUG(llvm::dbgs() << " replaced " << orig << " with "
@@ -1729,7 +1719,7 @@ bool Mem2Reg::forwardStoreToLoad(
 
     changed = true;
     assert(pair.first != val);
-    assert(val.getType() == elType);
+    assert(val.getType() == ElemTy);
     assert(pair.first.getType() == val.getType() && "mismatched load type");
     LLVM_DEBUG(llvm::dbgs()
                << " replaced " << pair.first << " with " << val << "\n");
@@ -1758,7 +1748,7 @@ bool Mem2Reg::forwardStoreToLoad(
       assert(valueAtEndOfBlock.find(pred)->second);
       mlir::Value pval =
           valueAtEndOfBlock.find(pred)->second->materialize(true);
-      if (!pval || pval.getType() != elType) {
+      if (!pval || pval.getType() != ElemTy) {
         AI.getDefiningOp()->getParentOfType<func::FuncOp>().dump();
         pred->dump();
         llvm::errs() << "pval: " << *valueAtEndOfBlock.find(pred)->second
@@ -1767,7 +1757,7 @@ bool Mem2Reg::forwardStoreToLoad(
           llvm::errs() << " mat pval: " << pval << "\n";
       }
       assert(pval && "Null last stored");
-      assert(pval.getType() == elType);
+      assert(pval.getType() == ElemTy);
       assert(pred->getTerminator());
 
       assert(blockArg.getOwner() == block);
@@ -1825,7 +1815,7 @@ bool Mem2Reg::forwardStoreToLoad(
     }
   }
 
-  removeRedundantBlockArgs(AI, elType, blocksWithAddedArgs);
+  removeRedundantBlockArgs(AI, ElemTy, blocksWithAddedArgs);
 
   for (auto *loadOp : llvm::make_early_inc_range(loadOps)) {
     assert(loadOp);
@@ -1954,28 +1944,42 @@ void Mem2Reg::runOnOperation() {
 
     // Walk all load's and perform store to load forwarding.
     SmallVector<mlir::Value, 4> toPromote;
+    SmallVector<mlir::Type, 4> typesToPromote;
     f->walk([&](mlir::memref::AllocaOp AI) {
       if (isPromotable(AI)) {
         toPromote.push_back(AI);
+        typesToPromote.push_back(AI.getMemref().getType().getElementType());
       }
     });
     f->walk([&](mlir::memref::AllocOp AI) {
       if (isPromotable(AI)) {
         toPromote.push_back(AI);
+        typesToPromote.push_back(AI.getMemref().getType().getElementType());
       }
     });
     f->walk([&](LLVM::AllocaOp AI) {
       if (isPromotable(AI)) {
         toPromote.push_back(AI);
+        if (AI.getElemType()) {
+          // Opaque pointer case.
+          typesToPromote.push_back(AI.getElemType().value());
+        } else {
+          // Typed pointer case.
+          assert(!AI.getType().isOpaque());
+          typesToPromote.push_back(AI.getType().getElementType());
+        }
       }
     });
     f->walk([&](memref::GetGlobalOp AI) {
       if (isPromotable(AI)) {
         toPromote.push_back(AI);
+        typesToPromote.push_back(AI.getResult().getType().getElementType());
       }
     });
     DenseMap<Operation *, SmallVector<Operation *>> capturedAliasing;
-    for (auto AI : toPromote) {
+    for (auto AllocAndType : llvm::zip(toPromote, typesToPromote)) {
+      auto AI = std::get<0>(AllocAndType);
+      auto AITy = std::get<1>(AllocAndType);
       LLVM_DEBUG(llvm::dbgs() << " attempting to promote " << AI << "\n");
       auto lastStored = getLastStored(AI);
       for (const auto &vec : lastStored) {
@@ -1987,7 +1991,7 @@ void Mem2Reg::runOnOperation() {
         // llvm::errs() << " PRE " << AI << "\n";
         // f.dump();
         changed |=
-            forwardStoreToLoad(AI, vec, loadOpsToErase, capturedAliasing);
+            forwardStoreToLoad(AI, AITy, vec, loadOpsToErase, capturedAliasing);
         // llvm::errs() << " POST " << AI << "\n";
         // f.dump();
       }

--- a/polygeist/lib/Dialect/Polygeist/Transforms/ParallelLoopDistribute.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/ParallelLoopDistribute.cpp
@@ -870,9 +870,9 @@ static LogicalResult distributeAroundBarrier(T op, BarrierOp barrier,
                                       rewriter.create<arith::IndexCastOp>(
                                           ao.getLoc(), sz.getType(), idx));
         SmallVector<Value> vec = {idx};
-        if (ao.getElemType()) {
-          u.set(rewriter.create<LLVM::GEPOp>(
-              ao.getLoc(), ao.getType(), ao.getElemType().value(), alloc, idx));
+        if (std::optional<Type> optElemType = ao.getElemType()) {
+          u.set(rewriter.create<LLVM::GEPOp>(ao.getLoc(), ao.getType(),
+                                             *optElemType, alloc, idx));
         } else {
           u.set(rewriter.create<LLVM::GEPOp>(ao.getLoc(), ao.getType(), alloc,
                                              idx));

--- a/polygeist/lib/Dialect/Polygeist/Transforms/ParallelLower.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/ParallelLower.cpp
@@ -81,6 +81,8 @@ namespace {
 //
 struct ParallelLower
     : public mlir::polygeist::impl::ParallelLowerBase<ParallelLower> {
+
+  using ParallelLowerBase<ParallelLower>::ParallelLowerBase;
   void runOnOperation() override;
 };
 
@@ -92,6 +94,11 @@ namespace mlir {
 namespace polygeist {
 std::unique_ptr<Pass> createParallelLowerPass() {
   return std::make_unique<ParallelLower>();
+}
+
+std::unique_ptr<Pass>
+createParallelLowerPass(const ParallelLowerOptions &options) {
+  return std::make_unique<ParallelLower>(options);
 }
 } // namespace polygeist
 } // namespace mlir

--- a/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
@@ -627,15 +627,16 @@ VersionConditionBuilder::VersionConditionBuilder(
 }
 
 VersionConditionBuilder::SCFCondition
-VersionConditionBuilder::createSCFCondition(OpBuilder builder,
-                                            Location loc) const {
+VersionConditionBuilder::createSCFCondition(OpBuilder builder, Location loc,
+                                            bool useOpaquePointers) const {
   auto GetMemref2PointerOp = [&](Value op) {
     auto MT = cast<MemRefType>(op.getType());
-    return builder.create<polygeist::Memref2PointerOp>(
-        loc,
-        LLVM::LLVMPointerType::get(MT.getElementType(),
-                                   MT.getMemorySpaceAsInt()),
-        op);
+    auto PtrTy = (useOpaquePointers)
+                     ? LLVM::LLVMPointerType::get(MT.getContext(),
+                                                  MT.getMemorySpaceAsInt())
+                     : LLVM::LLVMPointerType::get(MT.getElementType(),
+                                                  MT.getMemorySpaceAsInt());
+    return builder.create<polygeist::Memref2PointerOp>(loc, PtrTy, op);
   };
 
   Value condition;

--- a/polygeist/test/polygeist-opt/affinecfg.mlir
+++ b/polygeist/test/polygeist-opt/affinecfg.mlir
@@ -105,11 +105,11 @@ module {
 // -----
 
 module {
-  llvm.func @atoi(!llvm.ptr<i8>) -> i32
-func.func @_Z7runTestiPPc(%arg0: i32, %39: memref<?xi32>, %arg1: !llvm.ptr<i8>) attributes {llvm.linkage = #llvm.linkage<external>} {
+  llvm.func @atoi(!llvm.ptr) -> i32
+func.func @_Z7runTestiPPc(%arg0: i32, %39: memref<?xi32>, %arg1: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<external>} {
   %c2_i32 = arith.constant 2 : i32
   %c16_i32 = arith.constant 16 : i32
-    %58 = llvm.call @atoi(%arg1) : (!llvm.ptr<i8>) -> i32
+    %58 = llvm.call @atoi(%arg1) : (!llvm.ptr) -> i32
   %40 = arith.divsi %58, %c16_i32 : i32
   affine.for %arg2 = 1 to 10 {
       %62 = arith.index_cast %arg2 : index to i32
@@ -123,10 +123,10 @@ func.func @_Z7runTestiPPc(%arg0: i32, %39: memref<?xi32>, %arg1: !llvm.ptr<i8>) 
 }
 }
 
-// CHECK:   func.func @_Z7runTestiPPc(%arg0: i32, %arg1: memref<?xi32>, %arg2: !llvm.ptr<i8>) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK:   func.func @_Z7runTestiPPc(%arg0: i32, %arg1: memref<?xi32>, %arg2: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT:     %c2_i32 = arith.constant 2 : i32
 // CHECK-NEXT:     %c16_i32 = arith.constant 16 : i32
-// CHECK-NEXT:     %0 = llvm.call @atoi(%arg2) : (!llvm.ptr<i8>) -> i32
+// CHECK-NEXT:     %0 = llvm.call @atoi(%arg2) : (!llvm.ptr) -> i32
 // CHECK-NEXT:     %1 = arith.index_cast %0 : i32 to index
 // CHECK-NEXT:     %2 = arith.divsi %0, %c16_i32 : i32
 // CHECK-NEXT:     %3 = arith.index_cast %2 : i32 to index

--- a/polygeist/test/polygeist-opt/canonicalization.mlir
+++ b/polygeist/test/polygeist-opt/canonicalization.mlir
@@ -17,41 +17,40 @@ func.func @main(%arg0 : index) -> memref<1000xi32> {
   
 // -----
   
-  func.func @fold2ref(%arg0 : !llvm.ptr<struct<(i32, i32)>>) -> memref<?xi32> {
+  func.func @fold2ref(%arg0 : !llvm.ptr) -> memref<?xi32> {
         %c0_i32 = arith.constant 0 : i32
-        %11 = llvm.getelementptr %arg0[%c0_i32, 0] : (!llvm.ptr<struct<(i32, i32)>>, i32) -> !llvm.ptr<i32>
-        %12 = "polygeist.pointer2memref"(%11) : (!llvm.ptr<i32>) -> memref<?xi32>
+        %11 = llvm.getelementptr %arg0[%c0_i32, 0] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<(i32, i32)>
+        %12 = "polygeist.pointer2memref"(%11) : (!llvm.ptr) -> memref<?xi32>
     return %12 : memref<?xi32>
   }
 
-// CHECK:   func.func @fold2ref(%arg0: !llvm.ptr<struct<(i32, i32)>>) -> memref<?xi32> {
-// CHECK-NEXT:     %0 = "polygeist.pointer2memref"(%arg0) : (!llvm.ptr<struct<(i32, i32)>>) -> memref<?xi32>
+// CHECK:   func.func @fold2ref(%arg0: !llvm.ptr) -> memref<?xi32> {
+// CHECK-NEXT:     %0 = "polygeist.pointer2memref"(%arg0) : (!llvm.ptr) -> memref<?xi32>
 // CHECK-NEXT:     return %0 : memref<?xi32>
 // CHECK-NEXT:   }
 
-  func.func @nofold2ref(%arg0 : !llvm.ptr<struct<(i32, i32)>>) -> memref<?xi32> {
+  func.func @nofold2ref(%arg0 : !llvm.ptr) -> memref<?xi32> {
         %c0_i32 = arith.constant 0 : i32
-        %11 = llvm.getelementptr %arg0[%c0_i32, 1] : (!llvm.ptr<struct<(i32, i32)>>, i32) -> !llvm.ptr<i32>
-        %12 = "polygeist.pointer2memref"(%11) : (!llvm.ptr<i32>) -> memref<?xi32>
+        %11 = llvm.getelementptr %arg0[%c0_i32, 1] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<(i32, i32)>
+        %12 = "polygeist.pointer2memref"(%11) : (!llvm.ptr) -> memref<?xi32>
     return %12 : memref<?xi32>
   }
 
-// CHECK: @nofold2ref(%arg0: !llvm.ptr<struct<(i32, i32)>>) -> memref<?xi32> {
-// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 1] : (!llvm.ptr<struct<(i32, i32)>>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     %1 = "polygeist.pointer2memref"(%0) : (!llvm.ptr<i32>) -> memref<?xi32>
+// CHECK: @nofold2ref(%arg0: !llvm.ptr) -> memref<?xi32> {
+// CHECK-NEXT:     %0 = llvm.getelementptr %arg0[0, 1] : (!llvm.ptr) -> !llvm.ptr
+// CHECK-NEXT:     %1 = "polygeist.pointer2memref"(%0) : (!llvm.ptr) -> memref<?xi32>
 // CHECK-NEXT:     return %1 : memref<?xi32>
 // CHECK-NEXT:   }
 
-func.func @memref2ptr(%arg0: memref<10xi32>) -> !llvm.ptr<i8> {
+func.func @memref2ptr(%arg0: memref<10xi32>) -> !llvm.ptr {
      %c2 = arith.constant 2 : index
      %0 = "polygeist.subindex"(%arg0, %c2) : (memref<10xi32>, index) -> memref<?xi32>
-     %1 = "polygeist.memref2pointer"(%0) : (memref<?xi32>) -> !llvm.ptr<i8>
-     return %1 : !llvm.ptr<i8>
+     %1 = "polygeist.memref2pointer"(%0) : (memref<?xi32>) -> !llvm.ptr
+     return %1 : !llvm.ptr
 }
 // CHECK-LABEL:   func.func @memref2ptr(
-// CHECK-SAME:                          %[[VAL_0:.*]]: memref<10xi32>) -> !llvm.ptr<i8> {
-// CHECK-NEXT:      %[[VAL_1:.*]] = "polygeist.memref2pointer"(%[[VAL_0]]) : (memref<10xi32>) -> !llvm.ptr<i32>
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_1]][2] : (!llvm.ptr<i32>) -> !llvm.ptr<i32>
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.bitcast %[[VAL_2]] : !llvm.ptr<i32> to !llvm.ptr<i8>
-// CHECK-NEXT:      return %[[VAL_3]] : !llvm.ptr<i8>
+// CHECK-SAME:                          %[[VAL_0:.*]]: memref<10xi32>) -> !llvm.ptr {
+// CHECK-NEXT:      %[[VAL_1:.*]] = "polygeist.memref2pointer"(%[[VAL_0]]) : (memref<10xi32>) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_1]][2] : (!llvm.ptr) -> !llvm.ptr
+// CHECK-NEXT:      return %[[VAL_2]] : !llvm.ptr
 // CHECK-NEXT:    }

--- a/polygeist/test/polygeist-opt/copy2.mlir
+++ b/polygeist/test/polygeist-opt/copy2.mlir
@@ -1,14 +1,14 @@
 // RUN: polygeist-opt --canonicalize --split-input-file %s | FileCheck %s
 
 module  {
-  func.func private @_ZN11ACUDAStreamC1EOS_(%arg0: !llvm.ptr<struct<(struct<(i32, i32)>)>>, %arg1: !llvm.ptr<struct<(struct<(i32, i32)>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+  func.func private @_ZN11ACUDAStreamC1EOS_(%arg0: !llvm.ptr, %arg1: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
 	%c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c0_i32 = arith.constant 0 : i32
-    %0 = llvm.getelementptr %arg0[%c0_i32, 0] : (!llvm.ptr<struct<(struct<(i32, i32)>)>>, i32) -> !llvm.ptr<struct<(i32, i32)>>
-    %1 = llvm.getelementptr %arg1[%c0_i32, 0] : (!llvm.ptr<struct<(struct<(i32, i32)>)>>, i32) -> !llvm.ptr<struct<(i32, i32)>>
-    %2 = "polygeist.pointer2memref"(%0) : (!llvm.ptr<struct<(i32, i32)>>) -> memref<?x2xi32>
-    %3 = "polygeist.pointer2memref"(%1) : (!llvm.ptr<struct<(i32, i32)>>) -> memref<?x2xi32>
+    %0 = llvm.getelementptr %arg0[%c0_i32, 0] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<(struct<(i32, i32)>)>
+    %1 = llvm.getelementptr %arg1[%c0_i32, 0] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<(struct<(i32, i32)>)>
+    %2 = "polygeist.pointer2memref"(%0) : (!llvm.ptr) -> memref<?x2xi32>
+    %3 = "polygeist.pointer2memref"(%1) : (!llvm.ptr) -> memref<?x2xi32>
 	%a0 = memref.load %3[%c0, %c0] : memref<?x2xi32>
     memref.store %a0, %2[%c0, %c0] : memref<?x2xi32>
     %a1 = memref.load %3[%c0, %c1] : memref<?x2xi32>
@@ -17,16 +17,14 @@ module  {
   }
 }
 
-// CHECK:   func.func private @_ZN11ACUDAStreamC1EOS_(%arg0: !llvm.ptr<struct<(struct<(i32, i32)>)>>, %arg1: !llvm.ptr<struct<(struct<(i32, i32)>)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:     %[[i0:.+]] = llvm.bitcast %arg1 : !llvm.ptr<struct<(struct<(i32, i32)>)>> to !llvm.ptr<i32>
-// CHECK-NEXT:     %[[i2:.+]] = llvm.load %[[i0]] : !llvm.ptr<i32>
-// CHECK-NEXT:     %[[i3:.+]] = llvm.bitcast %arg0 : !llvm.ptr<struct<(struct<(i32, i32)>)>> to !llvm.ptr<i32>
-// CHECK-NEXT:     llvm.store %[[i2]], %[[i3]] : !llvm.ptr<i32>
-// CHECK-NEXT:     %[[i5:.+]] = llvm.bitcast %arg1 : !llvm.ptr<struct<(struct<(i32, i32)>)>> to !llvm.ptr<i32>
-// CHECK-NEXT:     %[[i6:.+]] = llvm.getelementptr %[[i5]][1] : (!llvm.ptr<i32>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     %[[i7:.+]] = llvm.load %[[i6]] : !llvm.ptr<i32>
-// CHECK-NEXT:     %[[i8:.+]] = llvm.bitcast %arg0 : !llvm.ptr<struct<(struct<(i32, i32)>)>> to !llvm.ptr<i32>
-// CHECK-NEXT:     %[[i9:.+]] = llvm.getelementptr %[[i8]][1] : (!llvm.ptr<i32>) -> !llvm.ptr<i32>
-// CHECK-NEXT:     llvm.store %[[i7]], %[[i9]] : !llvm.ptr<i32>
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func private @_ZN11ACUDAStreamC1EOS_(
+// CHECK-SAME:                                              %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                                              %[[VAL_1:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr -> i32
+// CHECK-NEXT:      llvm.store %[[VAL_2]], %[[VAL_0]] : i32, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_1]][1] : (!llvm.ptr) -> !llvm.ptr, i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> i32
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_0]][1] : (!llvm.ptr) -> !llvm.ptr, i32
+// CHECK-NEXT:      llvm.store %[[VAL_4]], %[[VAL_5]] : i32, !llvm.ptr
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/polygeist/test/polygeist-opt/cudalower.mlir
+++ b/polygeist/test/polygeist-opt/cudalower.mlir
@@ -1,13 +1,13 @@
 // RUN: polygeist-opt --parallel-lower --split-input-file %s | FileCheck %s
 
 module attributes {llvm.data_layout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64", llvm.target_triple = "nvptx64-nvidia-cuda"}  {
-  llvm.func @cudaMemcpy(!llvm.ptr<i8>, !llvm.ptr<i8>, i64, i32) -> i32
+  llvm.func @cudaMemcpy(!llvm.ptr, !llvm.ptr, i64, i32) -> i32
   func.func @_Z1aPiS_(%arg0: memref<?xi32>, %arg1: memref<?xi32>) -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
     %c1_i32 = arith.constant 1 : i32
     %c64_i64 = arith.constant 64 : i64
-    %0 = "polygeist.memref2pointer"(%arg0) : (memref<?xi32>) -> !llvm.ptr<i8>
-    %1 = "polygeist.memref2pointer"(%arg1) : (memref<?xi32>) -> !llvm.ptr<i8>
-    %2 = llvm.call @cudaMemcpy(%0, %1, %c64_i64, %c1_i32) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64, i32) -> i32
+    %0 = "polygeist.memref2pointer"(%arg0) : (memref<?xi32>) -> !llvm.ptr
+    %1 = "polygeist.memref2pointer"(%arg1) : (memref<?xi32>) -> !llvm.ptr
+    %2 = llvm.call @cudaMemcpy(%0, %1, %c64_i64, %c1_i32) : (!llvm.ptr, !llvm.ptr, i64, i32) -> i32
     return %2 : i32
   }
 }
@@ -16,38 +16,38 @@ module attributes {llvm.data_layout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64
 // CHECK-DAG:     %c64_i64 = arith.constant 64 : i64
 // CHECK-DAG:     %false = arith.constant false
 // CHECK-DAG:     %c0_i32 = arith.constant 0 : i32
-// CHECK-NEXT:     %0 = "polygeist.memref2pointer"(%arg0) : (memref<?xi32>) -> !llvm.ptr<i8>
-// CHECK-NEXT:     %1 = "polygeist.memref2pointer"(%arg1) : (memref<?xi32>) -> !llvm.ptr<i8>
-// CHECK-NEXT:     "llvm.intr.memcpy"(%0, %1, %c64_i64, %false) : (!llvm.ptr<i8>, !llvm.ptr<i8>, i64, i1) -> ()
+// CHECK-NEXT:     %0 = "polygeist.memref2pointer"(%arg0) : (memref<?xi32>) -> !llvm.ptr
+// CHECK-NEXT:     %1 = "polygeist.memref2pointer"(%arg1) : (memref<?xi32>) -> !llvm.ptr
+// CHECK-NEXT:     "llvm.intr.memcpy"(%0, %1, %c64_i64, %false) : (!llvm.ptr, !llvm.ptr, i64, i1) -> ()
 // CHECK-NEXT:     return %c0_i32 : i32
 // CHECK-NEXT:   }
 
 // -----
 
 module {
-  func.func private @S(%arg0: i8, %arg1: !llvm.ptr<i8>) -> i8 {
+  func.func private @S(%arg0: i8, %arg1: !llvm.ptr) -> i8 {
     cf.switch %arg0 : i8, [
       default: ^bb10(%arg0 : i8),
       0: ^bb1
     ]
   ^bb1:  // 2 preds: ^bb0, ^bb0
-    %6 = llvm.load %arg1 : !llvm.ptr<i8>
+    %6 = llvm.load %arg1 : !llvm.ptr -> i8
     cf.br ^bb10(%6 : i8)
   ^bb10(%50: i8):  // 10 preds: ^bb0, ^bb1, ^bb2, ^bb3, ^bb4, ^bb5, ^bb6, ^bb7, ^bb8, ^bb9
     return %50 : i8
   }
-  func.func @meta(%arg2: !llvm.ptr<i8>, %arg3: i8) {
+  func.func @meta(%arg2: !llvm.ptr, %arg3: i8) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %c2 = arith.constant 2 : index
     gpu.launch blocks(%arg4, %arg5, %arg6) in (%arg10 = %c2, %arg11 = %c1, %arg12 = %c1) threads(%arg7, %arg8, %arg9) in (%arg13 = %c1, %arg14 = %c1, %arg15 = %c1) {
-      func.call @S(%arg3, %arg2) : (i8, !llvm.ptr<i8>) -> (i8)
+      func.call @S(%arg3, %arg2) : (i8, !llvm.ptr) -> (i8)
       gpu.terminator
     }
     return
   }
 }
-// CHECK:   func.func @meta(%arg0: !llvm.ptr<i8>, %arg1: i8) {
+// CHECK:   func.func @meta(%arg0: !llvm.ptr, %arg1: i8) {
 // CHECK-DAG:     %c1 = arith.constant 1 : index
 // CHECK-DAG:     %c2 = arith.constant 2 : index
 // CHECK-DAG:     %c0 = arith.constant 0 : index
@@ -60,7 +60,7 @@ module {
 // CHECK-NEXT:             0: ^bb1
 // CHECK-NEXT:           ]
 // CHECK-NEXT:         ^bb1:  // pred: ^bb0
-// CHECK-NEXT:           %2 = llvm.load %arg0 : !llvm.ptr<i8>
+// CHECK-NEXT:           %2 = llvm.load %arg0 : !llvm.ptr -> i8
 // CHECK-NEXT:           cf.br ^bb2(%2 : i8)
 // CHECK-NEXT:         ^bb2(%3: i8):  // 2 preds: ^bb0, ^bb1
 // CHECK-NEXT:           cf.br ^bb3(%3 : i8)

--- a/polygeist/test/polygeist-opt/invalid_canonicalization.mlir
+++ b/polygeist/test/polygeist-opt/invalid_canonicalization.mlir
@@ -47,35 +47,35 @@ func.func @SimplifySubIndexUsers(%arg0: memref<?x!llvm.struct<(i32)>>) -> memref
 
 // -----
 
-// CHECK:  func.func @Memref2PointerIndex([[A0:%.*]]: memref<?x!llvm.struct<(i32, i32)>>) -> !llvm.ptr<i32> {
+// CHECK:  func.func @Memref2PointerIndex([[A0:%.*]]: memref<?x!llvm.struct<(i32, i32)>>) -> !llvm.ptr {
 // CHECK-NEXT:    [[C1:%.*]] = arith.constant 1 : index
 // CHECK-NEXT:    [[T0:%.*]] = "polygeist.subindex"([[A0]], [[C1]]) : (memref<?x!llvm.struct<(i32, i32)>>, index) -> memref<?xi32>
-// CHECK-NEXT:    [[T1:%.*]] = "polygeist.memref2pointer"([[T0]]) : (memref<?xi32>) -> !llvm.ptr<i32>
-// CHECK-NEXT:    return [[T1]] : !llvm.ptr<i32>
+// CHECK-NEXT:    [[T1:%.*]] = "polygeist.memref2pointer"([[T0]]) : (memref<?xi32>) -> !llvm.ptr
+// CHECK-NEXT:    return [[T1]] : !llvm.ptr
 // CHECK-NEXT:  }
 
-func.func @Memref2PointerIndex(%arg0: memref<?x!llvm.struct<(i32, i32)>>) -> !llvm.ptr<i32> {
+func.func @Memref2PointerIndex(%arg0: memref<?x!llvm.struct<(i32, i32)>>) -> !llvm.ptr {
   %c1 = arith.constant 1 : index
   %0 = "polygeist.subindex"(%arg0, %c1) : (memref<?x!llvm.struct<(i32, i32)>>, index) -> memref<?xi32>
-  %1 = "polygeist.memref2pointer"(%0) : (memref<?xi32>) -> !llvm.ptr<i32>
-  return %1 : !llvm.ptr<i32>
+  %1 = "polygeist.memref2pointer"(%0) : (memref<?xi32>) -> !llvm.ptr
+  return %1 : !llvm.ptr
 }
 
 // -----
 
-// CHECK:  func.func @Memref2PointerIndexSycl([[A0:%.*]]: memref<?x!sycl_array_1_, 4>) -> !llvm.ptr<i64, 4> {
+// CHECK:  func.func @Memref2PointerIndexSycl([[A0:%.*]]: memref<?x!sycl_array_1_, 4>) -> !llvm.ptr<4> {
 // CHECK-NEXT:    [[C1:%.*]] = arith.constant 1 : index
 // CHECK-NEXT:    [[T0:%.*]] = "polygeist.subindex"([[A0]], [[C1]]) : (memref<?x!sycl_array_1_, 4>, index) -> memref<?xi64, 4>
-// CHECK-NEXT:    [[T1:%.*]] = "polygeist.memref2pointer"([[T0]]) : (memref<?xi64, 4>) -> !llvm.ptr<i64, 4>
-// CHECK-NEXT:    return [[T1]] : !llvm.ptr<i64, 4>
+// CHECK-NEXT:    [[T1:%.*]] = "polygeist.memref2pointer"([[T0]]) : (memref<?xi64, 4>) -> !llvm.ptr<4>
+// CHECK-NEXT:    return [[T1]] : !llvm.ptr<4>
 // CHECK-NEXT:  }
 
 !sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
-func.func @Memref2PointerIndexSycl(%arg0: memref<?x!sycl_array_1_, 4>) -> !llvm.ptr<i64, 4> {
+func.func @Memref2PointerIndexSycl(%arg0: memref<?x!sycl_array_1_, 4>) -> !llvm.ptr<4> {
   %c1 = arith.constant 1 : index
   %0 = "polygeist.subindex"(%arg0, %c1) : (memref<?x!sycl.array<[1], (memref<1xi64, 4>)>, 4>, index) -> memref<?xi64, 4>
-  %1 = "polygeist.memref2pointer"(%0) : (memref<?xi64, 4>) -> !llvm.ptr<i64, 4>
-  return %1 : !llvm.ptr<i64, 4>
+  %1 = "polygeist.memref2pointer"(%0) : (memref<?xi64, 4>) -> !llvm.ptr<4>
+  return %1 : !llvm.ptr<4>
 }
 
 // -----

--- a/polygeist/test/polygeist-opt/llvmmem2reg.mlir
+++ b/polygeist/test/polygeist-opt/llvmmem2reg.mlir
@@ -1,16 +1,16 @@
 // RUN: polygeist-opt --mem2reg --split-input-file %s | FileCheck %s
 
 module {
-  func.func @ll(%arg0: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
+  func.func @ll(%arg0: !llvm.ptr) -> !llvm.ptr {
     %c1_i64 = arith.constant 1 : i64
-    %2 = llvm.alloca %c1_i64 x !llvm.ptr<i8> : (i64) -> !llvm.ptr<ptr<i8>>
-    llvm.store %arg0, %2 : !llvm.ptr<ptr<i8>>
-    %3 = llvm.load %2 : !llvm.ptr<ptr<i8>>
-	return %3 : !llvm.ptr<i8>
+    %2 = llvm.alloca %c1_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+    llvm.store %arg0, %2 : !llvm.ptr, !llvm.ptr
+    %3 = llvm.load %2 : !llvm.ptr -> !llvm.ptr
+	return %3 : !llvm.ptr
   }
 }
 
-// CHECK:   func.func @ll(%arg0: !llvm.ptr<i8>) -> !llvm.ptr<i8> {
+// CHECK:   func.func @ll(%arg0: !llvm.ptr) -> !llvm.ptr {
 // CHECK-NEXT:     %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:     return %arg0 : !llvm.ptr<i8>
+// CHECK-NEXT:     return %arg0 : !llvm.ptr
 // CHECK-NEXT:   }

--- a/polygeist/test/polygeist-opt/mem2regIf2.mlir
+++ b/polygeist/test/polygeist-opt/mem2regIf2.mlir
@@ -41,54 +41,54 @@ module {
 // ----
 
 module {
-  func.func private @gen() -> (!llvm.ptr<i8>)
+  func.func private @gen() -> (!llvm.ptr)
 
-func.func @_Z3runiPPc(%arg2: i1) -> !llvm.ptr<i8> {
+func.func @_Z3runiPPc(%arg2: i1) -> !llvm.ptr {
   %c1_i64 = arith.constant 1 : i64
-  %0 = llvm.alloca %c1_i64 x !llvm.ptr<i8> : (i64) -> !llvm.ptr<ptr<i8>>
-  %2 = llvm.mlir.null : !llvm.ptr<i8>
+  %0 = llvm.alloca %c1_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+  %2 = llvm.mlir.null : !llvm.ptr
   scf.if %arg2 {
-    %5 = llvm.load %0 : !llvm.ptr<ptr<i8>>
-    %6 = llvm.icmp "eq" %5, %2 : !llvm.ptr<i8>
-    %7 = scf.if %6 -> (!llvm.ptr<i8>) {
-      %8 = scf.if %arg2 -> (!llvm.ptr<i8>) {
-        %9 = func.call @gen() : () -> !llvm.ptr<i8>
-        llvm.store %9, %0 : !llvm.ptr<ptr<i8>>
-        scf.yield %9 : !llvm.ptr<i8>
+    %5 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+    %6 = llvm.icmp "eq" %5, %2 : !llvm.ptr
+    %7 = scf.if %6 -> (!llvm.ptr) {
+      %8 = scf.if %arg2 -> (!llvm.ptr) {
+        %9 = func.call @gen() : () -> !llvm.ptr
+        llvm.store %9, %0 : !llvm.ptr, !llvm.ptr
+        scf.yield %9 : !llvm.ptr
       } else {
-        scf.yield %5 : !llvm.ptr<i8>
+        scf.yield %5 : !llvm.ptr
       }
-      scf.yield %8 : !llvm.ptr<i8>
+      scf.yield %8 : !llvm.ptr
     } else {
-      scf.yield %5 : !llvm.ptr<i8>
+      scf.yield %5 : !llvm.ptr
     }
   }
-  %4 = llvm.load %0 : !llvm.ptr<ptr<i8>>
-  return %4 : !llvm.ptr<i8>
+  %4 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+  return %4 : !llvm.ptr
 }
 
 }
 
-// CHECK:     func.func @_Z3runiPPc(%arg0: i1) -> !llvm.ptr<i8> {
+// CHECK:     func.func @_Z3runiPPc(%arg0: i1) -> !llvm.ptr {
 // CHECK-NEXT:       %c1_i64 = arith.constant 1 : i64
-// CHECK-NEXT:       %0 = llvm.alloca %c1_i64 x !llvm.ptr<i8> : (i64) -> !llvm.ptr<ptr<i8>>
-// CHECK-NEXT:       %1 = llvm.mlir.null : !llvm.ptr<i8>
+// CHECK-NEXT:       %0 = llvm.alloca %c1_i64 x !llvm.ptr : (i64) -> !llvm.ptr
+// CHECK-NEXT:       %1 = llvm.mlir.null : !llvm.ptr
 // CHECK-NEXT:       scf.if %arg0 {
-// CHECK-NEXT:         %3 = llvm.load %0 : !llvm.ptr<ptr<i8>>
-// CHECK-NEXT:         %4 = llvm.icmp "eq" %3, %1 : !llvm.ptr<i8>
-// CHECK-NEXT:         %5 = scf.if %4 -> (!llvm.ptr<i8>) {
-// CHECK-NEXT:           %6 = scf.if %arg0 -> (!llvm.ptr<i8>) {
-// CHECK-NEXT:             %7 = func.call @gen() : () -> !llvm.ptr<i8>
-// CHECK-NEXT:             llvm.store %7, %0 : !llvm.ptr<ptr<i8>>
-// CHECK-NEXT:             scf.yield %7 : !llvm.ptr<i8>
+// CHECK-NEXT:         %3 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+// CHECK-NEXT:         %4 = llvm.icmp "eq" %3, %1 : !llvm.ptr
+// CHECK-NEXT:         %5 = scf.if %4 -> (!llvm.ptr) {
+// CHECK-NEXT:           %6 = scf.if %arg0 -> (!llvm.ptr) {
+// CHECK-NEXT:             %7 = func.call @gen() : () -> !llvm.ptr
+// CHECK-NEXT:             llvm.store %7, %0 : !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:             scf.yield %7 : !llvm.ptr
 // CHECK-NEXT:           } else {
-// CHECK-NEXT:             scf.yield %3 : !llvm.ptr<i8>
+// CHECK-NEXT:             scf.yield %3 : !llvm.ptr
 // CHECK-NEXT:           }
-// CHECK-NEXT:           scf.yield %6 : !llvm.ptr<i8>
+// CHECK-NEXT:           scf.yield %6 : !llvm.ptr
 // CHECK-NEXT:         } else {
-// CHECK-NEXT:           scf.yield %3 : !llvm.ptr<i8>
+// CHECK-NEXT:           scf.yield %3 : !llvm.ptr
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
-// CHECK-NEXT:       %2 = llvm.load %0 : !llvm.ptr<ptr<i8>>
-// CHECK-NEXT:       return %2 : !llvm.ptr<i8>
+// CHECK-NEXT:       %2 = llvm.load %0 : !llvm.ptr -> !llvm.ptr
+// CHECK-NEXT:       return %2 : !llvm.ptr
 

--- a/polygeist/test/polygeist-opt/paralleldistribute.mlir
+++ b/polygeist/test/polygeist-opt/paralleldistribute.mlir
@@ -12,14 +12,14 @@ module {
     %c5 = arith.constant 5 : index
     %c2 = arith.constant 2 : index
     scf.parallel (%arg2) = (%c0) to (%c5) step (%c1) {
-      %0 = llvm.alloca %c1_i64 x i8 : (i64) -> !llvm.ptr<i8>
+      %0 = llvm.alloca %c1_i64 x i8 : (i64) -> !llvm.ptr
       scf.parallel (%arg3) = (%c0) to (%c2) step (%c1) {
         %4 = scf.while (%arg4 = %c1_i8) : (i8) -> i8 {
           %6 = arith.cmpi ne, %arg4, %c0_i8 : i8
           scf.condition(%6) %arg4 : i8
         } do {
         ^bb0(%arg4: i8):  // no predecessors
-          llvm.store %c0_i8, %0 : !llvm.ptr<i8>
+          llvm.store %c0_i8, %0 : i8, !llvm.ptr
           "polygeist.barrier"(%arg3) : (index) -> ()
           scf.yield %c0_i8 : i8
         }
@@ -56,7 +56,7 @@ module {
 // CHECK-DAG:     %c5 = arith.constant 5 : index
 // CHECK-DAG:     %c2 = arith.constant 2 : index
 // CHECK-DAG:     scf.parallel (%arg0) = (%c0) to (%c5) step (%c1) {
-// CHECK-NEXT:       %0 = llvm.alloca %c1_i64 x i8 : (i64) -> !llvm.ptr<i8>
+// CHECK-NEXT:       %0 = llvm.alloca %c1_i64 x i8 : (i64) -> !llvm.ptr
 // CHECK-DAG:       %[[i1:.+]] = memref.alloca() : memref<2xi8>
 // CHECK-DAG:       %[[i2:.+]] = memref.alloca() : memref<2xi8>
 // CHECK-NEXT:       scf.parallel (%arg1) = (%c0) to (%c2) step (%c1) {
@@ -82,7 +82,7 @@ module {
 // CHECK-NEXT:         scf.condition(%1)
 // CHECK-NEXT:       } do {
 // CHECK-NEXT:         scf.parallel (%arg1) = (%c0) to (%c2) step (%c1) {
-// CHECK-NEXT:           llvm.store %c0_i8, %0 : !llvm.ptr<i8>
+// CHECK-NEXT:           llvm.store %c0_i8, %0 : i8, !llvm.ptr
 // CHECK-NEXT:           scf.yield
 // CHECK-NEXT:         }
 // CHECK-NEXT:         scf.parallel (%arg1) = (%c0) to (%c2) step (%c1) {

--- a/polygeist/test/polygeist-opt/sycl/detect-reduction-accessor-versioning.mlir
+++ b/polygeist/test/polygeist-opt/sycl/detect-reduction-accessor-versioning.mlir
@@ -1,4 +1,4 @@
-// RUN: polygeist-opt --detect-reduction --split-input-file %s | FileCheck %s
+// RUN: polygeist-opt --detect-reduction='use-opaque-pointers=1' --split-input-file %s | FileCheck %s
 
 // Original loop:
 // for(size_t i = 0; i < 8; i++)
@@ -48,12 +48,12 @@
 
 // CHECK:         [[ARG1_BEGIN:%.*]] = sycl.accessor.subscript %arg1[%alloca_15]
 // CHECK:         [[ARG1_END:%.*]] = sycl.accessor.subscript %arg1[%alloca_20]
-// CHECK-DAG:     [[ARG0_END_PTR:%.*]] = "polygeist.memref2pointer"([[ARG0_END]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
-// CHECK-DAG:     [[ARG1_BEGIN_PTR:%.*]] = "polygeist.memref2pointer"([[ARG1_BEGIN]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
-// CHECK-NEXT:    [[BEFORE_COND:%.*]] = llvm.icmp "ule" [[ARG0_END_PTR]], [[ARG1_BEGIN_PTR]] : !llvm.ptr<i32, 1>
-// CHECK-DAG:     [[ARG0_BEGIN_PTR:%.*]] = "polygeist.memref2pointer"([[ARG0_BEGIN]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
-// CHECK-DAG:     [[ARG1_END_PTR:%.*]] = "polygeist.memref2pointer"([[ARG1_END]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
-// CHECK-NEXT:    [[AFTER_COND:%.*]] = llvm.icmp "uge" [[ARG0_BEGIN_PTR]], [[ARG1_END_PTR]] : !llvm.ptr<i32, 1>
+// CHECK-DAG:     [[ARG0_END_PTR:%.*]] = "polygeist.memref2pointer"([[ARG0_END]]) : (memref<?xi32, 1>) -> !llvm.ptr<1>
+// CHECK-DAG:     [[ARG1_BEGIN_PTR:%.*]] = "polygeist.memref2pointer"([[ARG1_BEGIN]]) : (memref<?xi32, 1>) -> !llvm.ptr<1>
+// CHECK-NEXT:    [[BEFORE_COND:%.*]] = llvm.icmp "ule" [[ARG0_END_PTR]], [[ARG1_BEGIN_PTR]] : !llvm.ptr<1>
+// CHECK-DAG:     [[ARG0_BEGIN_PTR:%.*]] = "polygeist.memref2pointer"([[ARG0_BEGIN]]) : (memref<?xi32, 1>) -> !llvm.ptr<1>
+// CHECK-DAG:     [[ARG1_END_PTR:%.*]] = "polygeist.memref2pointer"([[ARG1_END]]) : (memref<?xi32, 1>) -> !llvm.ptr<1>
+// CHECK-NEXT:    [[AFTER_COND:%.*]] = llvm.icmp "uge" [[ARG0_BEGIN_PTR]], [[ARG1_END_PTR]] : !llvm.ptr<1>
 
 // COM: Version with condition: [[ARG0_END]] <= [[ARG1_BEGIN]] || [[ARG0_BEGIN]] >= [[ARG1_END]].
 // CHECK-NEXT:    [[COND:%.*]] = arith.ori [[BEFORE_COND]], [[AFTER_COND]] : i1

--- a/polygeist/test/polygeist-opt/sycl/kernel_disjoint_specialization.mlir
+++ b/polygeist/test/polygeist-opt/sycl/kernel_disjoint_specialization.mlir
@@ -1,4 +1,4 @@
-// RUN: polygeist-opt --kernel-disjoint-specialization="relaxed-aliasing=false" %s | FileCheck %s
+// RUN: polygeist-opt --kernel-disjoint-specialization="relaxed-aliasing=false use-opaque-pointers=1" %s | FileCheck %s
 
 !sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
@@ -51,14 +51,14 @@ gpu.module @device_func {
   // CHECK-NEXT:    [[ACC1_END:%.*]] = sycl.accessor.subscript %arg0[%alloca_2] : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
 
   // COM: Version with condition: [[ACC1_END]] <= [[ACC2_BEGIN]] || [[ACC1_BEGIN]] >= [[ACC2_END]].
-  // CHECK:         [[ACC2_BEGIN:%.*]] = sycl.accessor.subscript %arg1[{{.*}}] : (memref<?x!sycl_accessor_1_f32_w_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
+  // CHECK:         [[ACC2_BEGIN:%.*]] = sycl.accessor.subscript %arg1[{{.*}}]  : (memref<?x!sycl_accessor_1_f32_w_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
   // CHECK:         [[ACC2_END:%.*]] = sycl.accessor.subscript %arg1[{{.*}}] : (memref<?x!sycl_accessor_1_f32_w_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
-  // CHECK-DAG:     [[ACC1_END_PTR:%.*]] = "polygeist.memref2pointer"([[ACC1_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<f32, 1>
-  // CHECK-DAG:     [[ACC2_BEGIN_PTR:%.*]]  = "polygeist.memref2pointer"([[ACC2_BEGIN]]) : (memref<?xf32, 1>) -> !llvm.ptr<f32, 1>
-  // CHECK-NEXT:    %14 = llvm.icmp "ule" [[ACC1_END_PTR]], [[ACC2_BEGIN_PTR]] : !llvm.ptr<f32, 1>
-  // CHECK-DAG:     [[ACC1_BEGIN_PTR:%.*]] = "polygeist.memref2pointer"([[ACC1_BEGIN]]) : (memref<?xf32, 1>) -> !llvm.ptr<f32, 1>
-  // CHECK-DAG:     [[ACC2_END_PTR:%.*]] = "polygeist.memref2pointer"([[ACC2_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<f32, 1>
-  // CHECK-NEXT:    %17 = llvm.icmp "uge" [[ACC1_BEGIN_PTR]], [[ACC2_END_PTR]] : !llvm.ptr<f32, 1>
+  // CHECK-DAG:     [[ACC1_END_PTR:%.*]] = "polygeist.memref2pointer"([[ACC1_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
+  // CHECK-DAG:     [[ACC2_BEGIN_PTR:%.*]]  = "polygeist.memref2pointer"([[ACC2_BEGIN]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
+  // CHECK-NEXT:    %14 = llvm.icmp "ule" [[ACC1_END_PTR]], [[ACC2_BEGIN_PTR]] : !llvm.ptr<1>
+  // CHECK-DAG:     [[ACC1_BEGIN_PTR:%.*]] = "polygeist.memref2pointer"([[ACC1_BEGIN]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
+  // CHECK-DAG:     [[ACC2_END_PTR:%.*]] = "polygeist.memref2pointer"([[ACC2_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
+  // CHECK-NEXT:    %17 = llvm.icmp "uge" [[ACC1_BEGIN_PTR]], [[ACC2_END_PTR]] : !llvm.ptr<1>
   // CHECK-NEXT:    %18 = arith.ori %14, %17 : i1
   // CHECK-NEXT:    scf.if %18 {
   // CHECK-NEXT:      func.call @callee1.specialized(%arg0, %arg1) : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<?x!sycl_accessor_1_f32_w_gb>) -> ()
@@ -135,12 +135,12 @@ gpu.module @device_func {
   // COM: Version with condition: [[ACC1_END]] <= [[ACC2_BEGIN]] || [[ACC1_BEGIN]] >= [[ACC2_END]].
   // CHECK:         [[ACC2_BEGIN:%.*]] = sycl.accessor.subscript %arg1[%alloca_7] : (memref<?x!sycl_accessor_2_f32_w_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
   // CHECK:         [[ACC2_END:%.*]] = sycl.accessor.subscript %arg1[%alloca_13] : (memref<?x!sycl_accessor_2_f32_w_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
-  // CHECK-DAG:     [[ACC1_END_PTR:%.*]] = "polygeist.memref2pointer"([[ACC1_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<f32, 1>
-  // CHECK-DAG:     [[ACC2_BEGIN_PTR:%.*]]  = "polygeist.memref2pointer"([[ACC2_BEGIN]]) : (memref<?xf32, 1>) -> !llvm.ptr<f32, 1>
-  // CHECK-NEXT:    %22 = llvm.icmp "ule" [[ACC1_END_PTR]], [[ACC2_BEGIN_PTR]] : !llvm.ptr<f32, 1>
-  // CHECK-DAG:     [[ACC1_BEGIN_PTR:%.*]] = "polygeist.memref2pointer"([[ACC1_BEGIN]]) : (memref<?xf32, 1>) -> !llvm.ptr<f32, 1>
-  // CHECK-DAG:     [[ACC2_END_PTR:%.*]] = "polygeist.memref2pointer"([[ACC2_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<f32, 1>
-  // CHECK-NEXT:    %25 = llvm.icmp "uge" [[ACC1_BEGIN_PTR]], [[ACC2_END_PTR]] : !llvm.ptr<f32, 1>
+  // CHECK-DAG:     [[ACC1_END_PTR:%.*]] = "polygeist.memref2pointer"([[ACC1_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
+  // CHECK-DAG:     [[ACC2_BEGIN_PTR:%.*]]  = "polygeist.memref2pointer"([[ACC2_BEGIN]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
+  // CHECK-NEXT:    %22 = llvm.icmp "ule" [[ACC1_END_PTR]], [[ACC2_BEGIN_PTR]] : !llvm.ptr<1>
+  // CHECK-DAG:     [[ACC1_BEGIN_PTR:%.*]] = "polygeist.memref2pointer"([[ACC1_BEGIN]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
+  // CHECK-DAG:     [[ACC2_END_PTR:%.*]] = "polygeist.memref2pointer"([[ACC2_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
+  // CHECK-NEXT:    %25 = llvm.icmp "uge" [[ACC1_BEGIN_PTR]], [[ACC2_END_PTR]] : !llvm.ptr<1>
   // CHECK-NEXT:    %26 = arith.ori %22, %25 : i1
   // CHECK-NEXT:    scf.if %26 {
   // CHECK-NEXT:      func.call @callee3.specialized(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_accessor_2_f32_w_gb>) -> ()
@@ -202,12 +202,12 @@ gpu.module @device_func {
   // CHECK-NEXT:    %4 = sycl.accessor.get_pointer(%arg1) : (memref<?x!sycl_accessor_0_f32_w_gb>) -> memref<?xf32, 1>
   // CHECK-NEXT:    %c1_0 = arith.constant 1 : index
   // CHECK-NEXT:    [[ARG1_END:%.*]] = "polygeist.subindex"(%4, %c1_0) : (memref<?xf32, 1>, index) -> memref<?xf32, 1>
-  // CHECK-DAG:     [[ARG0_END_PTR:%.*]] = "polygeist.memref2pointer"([[ARG0_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<f32, 1>
-  // CHECK-DAG:     [[ARG1_BEGIN_PTR:%.*]] = "polygeist.memref2pointer"([[ARG1_BEGIN]]) : (memref<?xf32, 1>) -> !llvm.ptr<f32, 1>
-  // CHECK-NEXT:    %8 = llvm.icmp "ule" [[ARG0_END_PTR]], [[ARG1_BEGIN_PTR]] : !llvm.ptr<f32, 1>
-  // CHECK-DAG:     [[ARG0_BEGIN_PTR:%.*]] = "polygeist.memref2pointer"([[ARG0_BEGIN]]) : (memref<?xf32, 1>) -> !llvm.ptr<f32, 1>
-  // CHECK-DAG:     [[ARG1_END_PTR:%.*]] = "polygeist.memref2pointer"([[ARG1_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<f32, 1>
-  // CHECK-NEXT:    %11 = llvm.icmp "uge" [[ARG0_BEGIN_PTR]], [[ARG1_END_PTR]] : !llvm.ptr<f32, 1>
+  // CHECK-DAG:     [[ARG0_END_PTR:%.*]] = "polygeist.memref2pointer"([[ARG0_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
+  // CHECK-DAG:     [[ARG1_BEGIN_PTR:%.*]] = "polygeist.memref2pointer"([[ARG1_BEGIN]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
+  // CHECK-NEXT:    %8 = llvm.icmp "ule" [[ARG0_END_PTR]], [[ARG1_BEGIN_PTR]] : !llvm.ptr<1>
+  // CHECK-DAG:     [[ARG0_BEGIN_PTR:%.*]] = "polygeist.memref2pointer"([[ARG0_BEGIN]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
+  // CHECK-DAG:     [[ARG1_END_PTR:%.*]] = "polygeist.memref2pointer"([[ARG1_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
+  // CHECK-NEXT:    %11 = llvm.icmp "uge" [[ARG0_BEGIN_PTR]], [[ARG1_END_PTR]] : !llvm.ptr<1>
   // CHECK-NEXT:    %12 = arith.ori %8, %11 : i1
   // CHECK-NEXT:    scf.if %12 {
   // CHECK-NEXT:      func.call @callee5.specialized(%arg0, %arg1) : (memref<?x!sycl_accessor_0_f32_r_gb>, memref<?x!sycl_accessor_0_f32_w_gb>) -> ()

--- a/polygeist/tools/cgeist/Lib/TypeUtils.cc
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.cc
@@ -44,10 +44,13 @@ bool isRecursiveStruct(Type *T, Type *Meta, SmallPtrSetImpl<Type *> &Seen) {
 }
 
 Type *anonymize(Type *T) {
-  if (auto *PT = dyn_cast<PointerType>(T))
-    // TODO: Change this to complete move to opaque pointers.
-    return PointerType::get(anonymize(PT->getPointerElementType()),
+  if (auto *PT = dyn_cast<PointerType>(T)) {
+    if (PT->isOpaque())
+      return PT;
+    return PointerType::get(anonymize(PT->getNonOpaquePointerElementType()),
                             PT->getAddressSpace());
+  }
+
   if (auto *AT = dyn_cast<ArrayType>(T))
     return ArrayType::get(anonymize(AT->getElementType()),
                           AT->getNumElements());


### PR DESCRIPTION
Next step to add opaque pointer support for the SYCL-MLIR project: Make the Polygeist transformation passes compatible with opaque pointers. This also includes some passes added as part of the SYCL-MLIR project.

Passes that emit LLVM dialect pointers or other operations relating to opaque pointers (`load`/`getelementptr`/`alloca`/`store`/`addressof`) now have a `--use-opaque-pointers` option to control opaque/typed pointers.

