### PR TITLE
[SYCL-MLIR] Drop mandatory SYCLMethodOp attributes

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLBase.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLBase.td
@@ -27,7 +27,6 @@ def SYCL_Dialect : Dialect {
   let extraClassDeclaration = [{
     MethodRegistry methods;
 
-    static constexpr llvm::StringRef getArgumentTypesAttrName() { return "ArgumentTypes"; }
     static constexpr llvm::StringRef getFunctionNameAttrName() { return "FunctionName"; }
     static constexpr llvm::StringRef getMangledFunctionNameAttrName() { return "MangledFunctionName"; }
     static constexpr llvm::StringRef getTypeNameAttrName() { return "TypeName"; }

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLMethodOpInterface.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLMethodOpInterface.td
@@ -19,13 +19,7 @@ def SYCLMethodOpInterface : SYCL_OpInterface<"SYCLMethodOpInterface"> {
     type.
 
     Operations implementing this interface should inherit
-    `SYCLMethodOpInterfaceImpl` and also implement the `ArgumentTypes` method,
-    returning the function argument types to be passed to the function
-    implementing this operation; the `MangledFunctionName` method, returning the
-    mangled name of the function implementing this operation; the `FunctionName`
-    method, returning the unmangled name of the function implementing this
-    operation; and the `TypeName` method, returning the original name of the
-    type this operation is a member of.
+    `SYCLMethodOpInterfaceImpl`.
 
     Operations implementing this interface are registered as methods in the
     `SYCLDialect`. See the `SYCLDialect` documentation.
@@ -39,50 +33,7 @@ def SYCLMethodOpInterface : SYCL_OpInterface<"SYCLMethodOpInterface"> {
       Return the list of the method names to be replaced by this
       operation.
     }], "llvm::ArrayRef<llvm::StringLiteral>", "getMethodNames">,
-    InterfaceMethod<[{
-      Return the SYCL type this method is a member of.
-    }], "::mlir::Type", "getBaseType", /*args=*/ (ins),
-    /*methodBody=*/ [{
-      return $_op.getArgumentTypes()[0].template cast<::mlir::TypeAttr>().getValue();
-    }]
-    >,
-    InterfaceMethod<[{
-      Returns the argument types of the function implementing this operation.
-    }], "::mlir::SmallVector<::mlir::Type>", "getArgumentTypes",
-    /*args=*/ (ins), /*methodBody=*/ [{
-      SmallVector<Type> Res;
-      const auto Tys =
-        $_op.getArgumentTypes().template getAsRange<::mlir::TypeAttr>();
-      std::transform(Tys.begin(), Tys.end(), std::back_inserter(Res),
-                     [](auto Attr) { return Attr.getValue(); });
-      return Res;
-    }]
-    >,
-    InterfaceMethod<[{
-      Return the mangled name of the function implementing this operation.
-    }], "llvm::Optional<llvm::StringRef>", "getMangledFunctionName">,
-    InterfaceMethod<[{
-      Return the name of the function implementing this operation.
-    }], "llvm::StringRef", "getFunctionName">,
-    InterfaceMethod<[{
-      Return the original name of the type this method is implemented in.
-    }], "llvm::StringRef", "getTypeName">
   ];
-  // We cannot easily verify other attributes.
-  let verify = [{
-    if (static_cast<SYCLMethodOpInterface>($_op).getArgumentTypes().size() !=
-          $_op->getNumOperands()) {
-      return $_op->emitOpError("mismatch between number of arguments and input types");
-    }
-    auto interface = cast<mlir::sycl::SYCLMethodOpInterface>(op);
-    const llvm::ArrayRef<llvm::StringLiteral> methods = interface.getMethodNames();
-    const StringRef functionName = interface.getFunctionName();
-    const auto iter = std::find(methods.begin(), methods.end(), functionName);
-    if (iter == methods.end()) {
-      return $_op->emitOpError("invalid function name for this operation: ") << functionName;
-    }
-    return mlir::success();
-  }];
 }
 
 #endif // SYCL_METHOD_OP_INTERFACE

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -440,11 +440,7 @@ def SYCLAccessorGetPointerOp
     Returns a pointer to the start of this accessor's memory.
   }];
 
-  let arguments = (ins Arg<AccessorMemRef, "The accessor", [MemRead]>:$Acc,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+  let arguments = (ins Arg<AccessorMemRef, "The accessor", [MemRead]>:$Acc);
 
   let hasVerifier = 1;
 
@@ -464,11 +460,7 @@ def SYCLAccessorGetRangeOp
     that this accessor may access.
   }];
 
-  let arguments = (ins Arg<AccessorMemRef, "The accessor", [MemRead]>:$Acc,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+  let arguments = (ins Arg<AccessorMemRef, "The accessor", [MemRead]>:$Acc);
 
   let hasVerifier = 1;
 
@@ -488,11 +480,7 @@ def SYCLAccessorSizeOp
     access.
   }];
 
-  let arguments = (ins Arg<AccessorMemRef, "The accessor", [MemRead]>:$Acc,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+  let arguments = (ins Arg<AccessorMemRef, "The accessor", [MemRead]>:$Acc);
 
   let results = (outs IndexType:$Res);
 }
@@ -512,11 +500,7 @@ def SYCLAccessorSubscriptOp
   }];
 
   let arguments = (ins Arg<AccessorMemRef, "The accessor", [MemRead]>:$Acc,
-                       Arg<SYCLAccessorSubscriptIndex, "The offset", [MemRead]>:$Index,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+                       Arg<SYCLAccessorSubscriptIndex, "The offset", [MemRead]>:$Index);
 
   let results = (outs AnyType:$Res);
 
@@ -541,11 +525,7 @@ def SYCLRangeGetOp
   }];
 
   let arguments = (ins Arg<RangeMemRef, "The input range", [MemRead]>:$Range,
-                       I32:$Index,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+                       I32:$Index);
 
   let results = (outs SYCLGetResult:$Res);
 
@@ -566,11 +546,7 @@ def SYCLRangeSizeOp
     This operation represents a call to the range::size[] function.
   }];
 
-  let arguments = (ins Arg<RangeMemRef, "The input range", [MemRead]>:$Range,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+  let arguments = (ins Arg<RangeMemRef, "The input range", [MemRead]>:$Range);
 
   let results = (outs I64:$Res);
 }
@@ -587,11 +563,7 @@ def SYCLNdRangeGetGlobalRange
     This operation represents a call to the nd_range::get_global_range function.
   }];
 
-  let arguments = (ins Arg<NDRangeMemRef, "The input ND-range", [MemRead]>:$ND,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+  let arguments = (ins Arg<NDRangeMemRef, "The input ND-range", [MemRead]>:$ND);
 
   let results = (outs SYCL_RangeType:$Res);
 }
@@ -608,11 +580,7 @@ def SYCLNdRangeGetLocalRange
     This operation represents a call to the nd_range::get_local_range function.
   }];
 
-  let arguments = (ins Arg<NDRangeMemRef, "The input ND-range", [MemRead]>:$ND,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+  let arguments = (ins Arg<NDRangeMemRef, "The input ND-range", [MemRead]>:$ND);
 
   let results = (outs SYCL_RangeType:$Res);
 }
@@ -629,11 +597,7 @@ def SYCLNdRangeGetGroupRange
     This operation represents a call to the nd_range::get_group_range function.
   }];
 
-  let arguments = (ins Arg<NDRangeMemRef, "The input ND-range", [MemRead]>:$ND,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+  let arguments = (ins Arg<NDRangeMemRef, "The input ND-range", [MemRead]>:$ND);
 
   let results = (outs SYCL_RangeType:$Res);
 }
@@ -652,11 +616,7 @@ def SYCLIDGetOp
   }];
 
   let arguments = (ins Arg<IDMemRef, "The input ID", [MemRead]>:$ID,
-                       Optional<I32>:$Index,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+                       Optional<I32>:$Index);
 
   let results = (outs SYCLGetResult:$Res);
 
@@ -679,11 +639,7 @@ def SYCLItemGetIDOp
   }];
 
   let arguments = (ins Arg<ItemMemRef, "The input item", [MemRead]>:$Item,
-                       Optional<I32>:$Index,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+                       Optional<I32>:$Index);
 
   let results = (outs SYCLGetIDResult:$Res);
 }
@@ -702,11 +658,7 @@ def SYCLItemGetRangeOp
   }];
 
   let arguments = (ins Arg<ItemMemRef, "The input item", [MemRead]>:$Item,
-                       Optional<I32>:$Index,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+                       Optional<I32>:$Index);
 
   let results = (outs SYCLGetRangeResult:$Res);
 }
@@ -723,11 +675,7 @@ def SYCLItemGetLinearIDOp
     This operation represents a call to the item::get_linear_id function.
   }];
 
-  let arguments = (ins Arg<ItemMemRef, "The input item", [MemRead]>:$Item,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+  let arguments = (ins Arg<ItemMemRef, "The input item", [MemRead]>:$Item);
 
   let results = (outs I64:$Res);
 }
@@ -746,11 +694,7 @@ def SYCLNDItemGetGlobalIDOp
   }];
 
   let arguments = (ins Arg<NDItemMemRef, "The input ND-item", [MemRead]>:$NDItem,
-                       Optional<I32>:$Index,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+                       Optional<I32>:$Index);
 
   let results = (outs SYCLGetIDResult:$Res);
 }
@@ -767,11 +711,7 @@ def SYCLNDItemGetGlobalLinearIDOp
     This operation represents a call to the nd_item::get_global_linear_id function.
   }];
 
-  let arguments = (ins Arg<NDItemMemRef, "The input ND-item", [MemRead]>:$NDItem,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+  let arguments = (ins Arg<NDItemMemRef, "The input ND-item", [MemRead]>:$NDItem);
 
   let results = (outs I64:$Res);
 }
@@ -790,11 +730,7 @@ def SYCLNDItemGetLocalIDOp
   }];
 
   let arguments = (ins Arg<NDItemMemRef, "The input ND-item", [MemRead]>:$NDItem,
-                       Optional<I32>:$Index,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+                       Optional<I32>:$Index);
 
   let results = (outs SYCLGetIDResult:$Res);
 }
@@ -811,11 +747,7 @@ def SYCLNDItemGetLocalLinearIDOp
     This operation represents a call to the nd_item::get_local_linear_id function.
   }];
 
-  let arguments = (ins Arg<NDItemMemRef, "The input ND-item", [MemRead]>:$NDItem,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+  let arguments = (ins Arg<NDItemMemRef, "The input ND-item", [MemRead]>:$NDItem);
 
   let results = (outs I64:$Res);
 }
@@ -834,11 +766,7 @@ def SYCLNDItemGetGroupOp
   }];
 
   let arguments = (ins Arg<NDItemMemRef, "The input ND-item", [MemRead]>:$NDItem,
-                       Optional<I32>:$Index,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+                       Optional<I32>:$Index);
 
   let results = (outs AnyTypeOf<[I64, SYCL_GroupType]>:$Res);
 }
@@ -855,11 +783,7 @@ def SYCLNDItemGetGroupLinearIDOp
     This operation represents a call to the nd_item::get_group_linear_id function.
   }];
 
-  let arguments = (ins Arg<NDItemMemRef, "The input ND-item", [MemRead]>:$NDItem,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+  let arguments = (ins Arg<NDItemMemRef, "The input ND-item", [MemRead]>:$NDItem);
 
   let results = (outs I64:$Res);
 }
@@ -878,11 +802,7 @@ def SYCLNDItemGetGroupRangeOp
   }];
 
   let arguments = (ins Arg<NDItemMemRef, "The input ND-item", [MemRead]>:$NDItem,
-                       Optional<I32>:$Index,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+                       Optional<I32>:$Index);
 
   let results = (outs SYCLGetRangeResult:$Res);
 }
@@ -901,11 +821,7 @@ def SYCLNDItemGetGlobalRangeOp
   }];
 
   let arguments = (ins Arg<NDItemMemRef, "The input ND-item", [MemRead]>:$NDItem,
-                       Optional<I32>:$Index,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+                       Optional<I32>:$Index);
 
   let results = (outs SYCLGetRangeResult:$Res);
 }
@@ -924,11 +840,7 @@ def SYCLNDItemGetLocalRangeOp
   }];
 
   let arguments = (ins Arg<NDItemMemRef, "The input ND-item", [MemRead]>:$NDItem,
-                       Optional<I32>:$Index,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+                       Optional<I32>:$Index);
 
   let results = (outs SYCLGetRangeResult:$Res);
 }
@@ -945,11 +857,7 @@ def SYCLNDItemGetNdRangeOp
     This operation represents a call to the nd_item::get_nd_range function.
   }];
 
-  let arguments = (ins Arg<NDItemMemRef, "The input ND-item", [MemRead]>:$NDItem,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+  let arguments = (ins Arg<NDItemMemRef, "The input ND-item", [MemRead]>:$NDItem);
 
   let results = (outs SYCL_NdRangeType:$Res);
 }
@@ -968,11 +876,7 @@ def SYCLGroupGetGroupIDOp
   }];
 
   let arguments = (ins Arg<GroupMemRef, "The input group", [MemRead]>:$Group,
-                       Optional<I32>:$Index,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+                       Optional<I32>:$Index);
 
   let results = (outs SYCLGetIDResult:$Res);
 }
@@ -991,11 +895,7 @@ def SYCLGroupGetLocalIDOp
   }];
 
   let arguments = (ins Arg<GroupMemRef, "The input group", [MemRead]>:$Group,
-                       Optional<I32>:$Index,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+                       Optional<I32>:$Index);
 
   let results = (outs SYCLGetIDResult:$Res);
 }
@@ -1014,11 +914,7 @@ def SYCLGroupGetLocalRangeOp
   }];
 
   let arguments = (ins Arg<GroupMemRef, "The input group", [MemRead]>:$Group,
-                       Optional<I32>:$Index,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+                       Optional<I32>:$Index);
 
   let results = (outs SYCLGetRangeResult:$Res);
 }
@@ -1037,11 +933,7 @@ def SYCLGroupGetGroupRangeOp
   }];
 
   let arguments = (ins Arg<GroupMemRef, "The input group", [MemRead]>:$Group,
-                       Optional<I32>:$Index,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+                       Optional<I32>:$Index);
 
   let results = (outs SYCLGetRangeResult:$Res);
 }
@@ -1058,11 +950,7 @@ def SYCLGroupGetMaxLocalRangeOp
     This operation represents a call to the group::get_max_local_range function.
   }];
 
-  let arguments = (ins Arg<GroupMemRef, "The input group", [MemRead]>:$Group,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+  let arguments = (ins Arg<GroupMemRef, "The input group", [MemRead]>:$Group);
 
   let results = (outs SYCL_RangeType:$Res);
 }
@@ -1079,11 +967,7 @@ def SYCLGroupGetGroupLinearIDOp
     This operation represents a call to the group::get_group_linear_id function.
   }];
 
-  let arguments = (ins Arg<GroupMemRef, "The input group", [MemRead]>:$Group,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+  let arguments = (ins Arg<GroupMemRef, "The input group", [MemRead]>:$Group);
 
   let results = (outs I64:$Res);
 }
@@ -1100,11 +984,7 @@ def SYCLGroupGetLocalLinearIDOp
     This operation represents a call to the group::get_local_linear_id function.
   }];
 
-  let arguments = (ins Arg<GroupMemRef, "The input group", [MemRead]>:$Group,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+  let arguments = (ins Arg<GroupMemRef, "The input group", [MemRead]>:$Group);
 
   let results = (outs I64:$Res);
 }
@@ -1121,11 +1001,7 @@ def SYCLGroupGetLocalLinearIDOp
     This operation represents a call to the group::get_group_linear_range function.
   }];
 
-  let arguments = (ins Arg<GroupMemRef, "The input group", [MemRead]>:$Group,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+  let arguments = (ins Arg<GroupMemRef, "The input group", [MemRead]>:$Group);
 
   let results = (outs I64:$Res);
 }
@@ -1142,11 +1018,7 @@ def SYCLGroupGetLocalLinearRangeOp
     This operation represents a call to the group::get_local_linear_range function.
   }];
 
-  let arguments = (ins Arg<GroupMemRef, "The input group", [MemRead]>:$Group,
-                       TypeArrayAttr:$ArgumentTypes,
-                       FlatSymbolRefAttr:$FunctionName,
-                       OptionalAttr<FlatSymbolRefAttr>:$MangledFunctionName,
-                       FlatSymbolRefAttr:$TypeName);
+  let arguments = (ins Arg<GroupMemRef, "The input group", [MemRead]>:$Group);
 
   let results = (outs I64:$Res);
 }

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLTraits.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLTraits.cpp
@@ -36,9 +36,12 @@ LogicalResult mlir::sycl::verifySYCLGetComponentTrait(Operation *op) {
   // size_t operator[](int dimension) const;
   // only available if Dimensions == 1
   // size_t operator size_t() const;
+  const unsigned numOperands = op->getNumOperands();
+  assert((numOperands == 1 || numOperands == 2) &&
+         "This operation can only accept one or two operands");
   const auto resultTypes = op->getResultTypes();
   const auto operandTypes = op->getOperandTypes();
-  if (operandTypes.size() == 1) {
+  if (numOperands == 1) {
     Type type = resultTypes[0];
     if (!type.isIntOrIndex())
       return op->emitOpError(
@@ -54,6 +57,9 @@ static LogicalResult
 verifyGetSYCLTyOperation(Operation *op, llvm::StringRef expectedRetTyName) {
   // SYCLTy *() const;
   // size_t *(int dimension) const;
+  const unsigned numOperands = op->getNumOperands();
+  assert((numOperands == 1 || numOperands == 2) &&
+         "This operation can only accept one or two operands");
   const Type retTy = op->getResult(0).getType();
   const bool isI64RetTy = retTy.isInteger(64);
   switch (op->getNumOperands()) {
@@ -79,15 +85,18 @@ LogicalResult mlir::sycl::verifySYCLGetIDTrait(Operation *op) {
   // size_t operator[](int dimension) const;
   // only available if Dimensions == 1
   // operator size_t() const;
+  const unsigned numOperands = op->getNumOperands();
+  assert((numOperands == 1 || numOperands == 2) &&
+         "This operation can only accept one or two operands");
   Type retTy = op->getResultTypes()[0];
   auto operandTypes = op->getOperandTypes();
   if (retTy.isIntOrIndex()) {
-    if (operandTypes.size() == 1 && getDimensions(operandTypes[0]) != 1)
+    if (numOperands == 1 && getDimensions(operandTypes[0]) != 1)
       return op->emitOpError(
           "operand 0 must have a single dimension to be passed as the single "
           "argument to this operation");
   } else if (isa<IDType>(retTy)) {
-    if (operandTypes.size() != 1)
+    if (numOperands != 1)
       return op->emitOpError(
           "must be passed a single argument in order to define an id value");
     return verifyEqualDimensions(op);

--- a/mlir-sycl/test/Conversion/SYCLToGPU/grid-ops.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToGPU/grid-ops.mlir
@@ -13,12 +13,12 @@
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.global_id  x
 // CHECK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : index to i64
-// CHECK-NEXT:      %[[VAL_5:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_2]]] {ArgumentTypes = [memref<1x!sycl_id_2_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_2_>, i32) -> memref<2xi64>
+// CHECK-NEXT:      %[[VAL_5:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_2]]] : (memref<1x!sycl_id_2_>, i32) -> memref<2xi64>
 // CHECK-NEXT:      memref.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<2xi64>
 // CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 1 : i32
 // CHECK-NEXT:      %[[VAL_7:.*]] = gpu.global_id  y
 // CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_7]] : index to i64
-// CHECK-NEXT:      %[[VAL_9:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_6]]] {ArgumentTypes = [memref<1x!sycl_id_2_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_2_>, i32) -> memref<2xi64>
+// CHECK-NEXT:      %[[VAL_9:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_6]]] : (memref<1x!sycl_id_2_>, i32) -> memref<2xi64>
 // CHECK-NEXT:      memref.store %[[VAL_8]], %[[VAL_9]]{{\[}}%[[VAL_1]]] : memref<2xi64>
 // CHECK-NEXT:      %[[VAL_10:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_2_>
 // CHECK-NEXT:      return %[[VAL_10]] : !sycl_id_2_
@@ -34,17 +34,17 @@ func.func @test_global_id() -> !sycl_id_2_ {
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.thread_id  x
 // CHECK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : index to i64
-// CHECK-NEXT:      %[[VAL_5:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_2]]] {ArgumentTypes = [memref<1x!sycl_id_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_3_>, i32) -> memref<3xi64>
+// CHECK-NEXT:      %[[VAL_5:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_2]]] : (memref<1x!sycl_id_3_>, i32) -> memref<3xi64>
 // CHECK-NEXT:      memref.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<3xi64>
 // CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 1 : i32
 // CHECK-NEXT:      %[[VAL_7:.*]] = gpu.thread_id  y
 // CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_7]] : index to i64
-// CHECK-NEXT:      %[[VAL_9:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_6]]] {ArgumentTypes = [memref<1x!sycl_id_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_3_>, i32) -> memref<3xi64>
+// CHECK-NEXT:      %[[VAL_9:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_6]]] : (memref<1x!sycl_id_3_>, i32) -> memref<3xi64>
 // CHECK-NEXT:      memref.store %[[VAL_8]], %[[VAL_9]]{{\[}}%[[VAL_1]]] : memref<3xi64>
 // CHECK-NEXT:      %[[VAL_10:.*]] = arith.constant 2 : i32
 // CHECK-NEXT:      %[[VAL_11:.*]] = gpu.thread_id  z
 // CHECK-NEXT:      %[[VAL_12:.*]] = arith.index_cast %[[VAL_11]] : index to i64
-// CHECK-NEXT:      %[[VAL_13:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_10]]] {ArgumentTypes = [memref<1x!sycl_id_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_3_>, i32) -> memref<3xi64>
+// CHECK-NEXT:      %[[VAL_13:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_10]]] : (memref<1x!sycl_id_3_>, i32) -> memref<3xi64>
 // CHECK-NEXT:      memref.store %[[VAL_12]], %[[VAL_13]]{{\[}}%[[VAL_1]]] : memref<3xi64>
 // CHECK-NEXT:      %[[VAL_14:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_3_>
 // CHECK-NEXT:      return %[[VAL_14]] : !sycl_id_3_
@@ -60,17 +60,17 @@ func.func @test_local_id() -> !sycl_id_3_ {
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.block_dim  x
 // CHECK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : index to i64
-// CHECK-NEXT:      %[[VAL_5:.*]] = sycl.range.get %[[VAL_0]]{{\[}}%[[VAL_2]]] {ArgumentTypes = [memref<1x!sycl_range_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64>
+// CHECK-NEXT:      %[[VAL_5:.*]] = sycl.range.get %[[VAL_0]]{{\[}}%[[VAL_2]]] : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64>
 // CHECK-NEXT:      memref.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<3xi64>
 // CHECK-NEXT:      %[[VAL_6:.*]] = arith.constant 1 : i32
 // CHECK-NEXT:      %[[VAL_7:.*]] = gpu.block_dim  y
 // CHECK-NEXT:      %[[VAL_8:.*]] = arith.index_cast %[[VAL_7]] : index to i64
-// CHECK-NEXT:      %[[VAL_9:.*]] = sycl.range.get %[[VAL_0]]{{\[}}%[[VAL_6]]] {ArgumentTypes = [memref<1x!sycl_range_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64>
+// CHECK-NEXT:      %[[VAL_9:.*]] = sycl.range.get %[[VAL_0]]{{\[}}%[[VAL_6]]] : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64>
 // CHECK-NEXT:      memref.store %[[VAL_8]], %[[VAL_9]]{{\[}}%[[VAL_1]]] : memref<3xi64>
 // CHECK-NEXT:      %[[VAL_10:.*]] = arith.constant 2 : i32
 // CHECK-NEXT:      %[[VAL_11:.*]] = gpu.block_dim  z
 // CHECK-NEXT:      %[[VAL_12:.*]] = arith.index_cast %[[VAL_11]] : index to i64
-// CHECK-NEXT:      %[[VAL_13:.*]] = sycl.range.get %[[VAL_0]]{{\[}}%[[VAL_10]]] {ArgumentTypes = [memref<1x!sycl_range_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64>
+// CHECK-NEXT:      %[[VAL_13:.*]] = sycl.range.get %[[VAL_0]]{{\[}}%[[VAL_10]]] : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64>
 // CHECK-NEXT:      memref.store %[[VAL_12]], %[[VAL_13]]{{\[}}%[[VAL_1]]] : memref<3xi64>
 // CHECK-NEXT:      %[[VAL_14:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_range_3_>
 // CHECK-NEXT:      return %[[VAL_14]] : !sycl_range_3_
@@ -86,7 +86,7 @@ func.func @test_work_group_size() -> !sycl_range_3_ {
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : i32
 // CHECK-NEXT:      %[[VAL_3:.*]] = gpu.block_id  x
 // CHECK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : index to i64
-// CHECK-NEXT:      %[[VAL_5:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_2]]] {ArgumentTypes = [memref<1x!sycl_id_1_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_1_>, i32) -> memref<1xi64>
+// CHECK-NEXT:      %[[VAL_5:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_2]]] : (memref<1x!sycl_id_1_>, i32) -> memref<1xi64>
 // CHECK-NEXT:      memref.store %[[VAL_4]], %[[VAL_5]]{{\[}}%[[VAL_1]]] : memref<1xi64>
 // CHECK-NEXT:      %[[VAL_6:.*]] = memref.load %[[VAL_0]]{{\[}}%[[VAL_1]]] : memref<1x!sycl_id_1_>
 // CHECK-NEXT:      return %[[VAL_6]] : !sycl_id_1_

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-flat-to-llvm-typed-pointer.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-flat-to-llvm-typed-pointer.mlir
@@ -14,7 +14,7 @@
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : !llvm.ptr<i64, 4>
 // CHECK-NEXT:    }
 func.func @test(%range: memref<?x!sycl_range_3_>, %idx: i32) -> memref<?xi64, 4> {
-  %0 = sycl.range.get %range[%idx] { ArgumentTypes = [memref<?x!sycl_range_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"range" }  : (memref<?x!sycl_range_3_>, i32) -> memref<?xi64, 4>
+  %0 = sycl.range.get %range[%idx] : (memref<?x!sycl_range_3_>, i32) -> memref<?xi64, 4>
   return %0 : memref<?xi64, 4>
 }
 
@@ -34,7 +34,7 @@ func.func @test(%range: memref<?x!sycl_range_3_>, %idx: i32) -> memref<?xi64, 4>
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : !llvm.ptr<i64, 4>
 // CHECK-NEXT:    }
 func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> memref<?xi64, 4> {
-  %0 = sycl.id.get %id[%idx] { ArgumentTypes = [memref<?x!sycl_id_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_id_3_>, i32) -> memref<?xi64, 4>
+  %0 = sycl.id.get %id[%idx] : (memref<?x!sycl_id_3_>, i32) -> memref<?xi64, 4>
   return %0 : memref<?xi64, 4>
 }
 
@@ -59,7 +59,7 @@ func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> memref<?xi64, 4> {
 // CHECK-NEXT:      llvm.return %[[VAL_5]] : !llvm.ptr<i32, 4>
 // CHECK-NEXT:    }
 func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: i64) -> memref<?xi32, 4> {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>, i64) -> memref<?xi32, 4>
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_rw_gb>, i64) -> memref<?xi32, 4>
   return %0 : memref<?xi32, 4>
 }
 
@@ -99,7 +99,7 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: i64) -> memref
 // CHECK-NEXT:      llvm.return %[[VAL_12]] : !llvm.ptr<i32, 4>
 // CHECK-NEXT:    }
 func.func @test_1(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: memref<?x!sycl_id_1_>) -> memref<?xi32, 4> {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
   return %0 : memref<?xi32, 4>
 }
 
@@ -126,7 +126,7 @@ func.func @test_1(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-NEXT:      llvm.return %[[VAL_18]] : !llvm.ptr<i32, 4>
 // CHECK-NEXT:    }
 func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: memref<?x!sycl_id_2_>) -> memref<?xi32, 4> {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
   return %0 : memref<?xi32, 4>
 }
 
@@ -159,6 +159,6 @@ func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-NEXT:      llvm.return %[[VAL_24]] : !llvm.ptr<i32, 4>
 // CHECK-NEXT:    }
 func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_gb>, %idx: memref<?x!sycl_id_3_>) -> memref<?xi32, 4> {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_3_i32_rw_gb>, memref<?x!sycl_id_3_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_3_i32_rw_gb>, memref<?x!sycl_id_3_>) -> memref<?xi32, 4>
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_3_i32_rw_gb>, memref<?x!sycl_id_3_>) -> memref<?xi32, 4>
   return %0 : memref<?xi32, 4>
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-flat-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-flat-to-llvm.mlir
@@ -14,7 +14,7 @@
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : !llvm.ptr<4>
 // CHECK-NEXT:    }
 func.func @test(%range: memref<?x!sycl_range_3_>, %idx: i32) -> memref<?xi64, 4> {
-  %0 = sycl.range.get %range[%idx] { ArgumentTypes = [memref<?x!sycl_range_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"range" }  : (memref<?x!sycl_range_3_>, i32) -> memref<?xi64, 4>
+  %0 = sycl.range.get %range[%idx] : (memref<?x!sycl_range_3_>, i32) -> memref<?xi64, 4>
   return %0 : memref<?xi64, 4>
 }
 
@@ -34,7 +34,7 @@ func.func @test(%range: memref<?x!sycl_range_3_>, %idx: i32) -> memref<?xi64, 4>
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : !llvm.ptr<4>
 // CHECK-NEXT:    }
 func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> memref<?xi64, 4> {
-  %0 = sycl.id.get %id[%idx] { ArgumentTypes = [memref<?x!sycl_id_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_id_3_>, i32) -> memref<?xi64, 4>
+  %0 = sycl.id.get %id[%idx] : (memref<?x!sycl_id_3_>, i32) -> memref<?xi64, 4>
   return %0 : memref<?xi64, 4>
 }
 
@@ -59,7 +59,7 @@ func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> memref<?xi64, 4> {
 // CHECK-NEXT:      llvm.return %[[VAL_5]] : !llvm.ptr<4>
 // CHECK-NEXT:    }
 func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: i64) -> memref<?xi32, 4> {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>, i64) -> memref<?xi32, 4>
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_rw_gb>, i64) -> memref<?xi32, 4>
   return %0 : memref<?xi32, 4>
 }
 
@@ -99,7 +99,7 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: i64) -> memref
 // CHECK-NEXT:      llvm.return %[[VAL_12]] : !llvm.ptr<4>
 // CHECK-NEXT:    }
 func.func @test_1(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: memref<?x!sycl_id_1_>) -> memref<?xi32, 4> {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
   return %0 : memref<?xi32, 4>
 }
 
@@ -126,7 +126,7 @@ func.func @test_1(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-NEXT:      llvm.return %[[VAL_18]] : !llvm.ptr<4>
 // CHECK-NEXT:    }
 func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: memref<?x!sycl_id_2_>) -> memref<?xi32, 4> {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
   return %0 : memref<?xi32, 4>
 }
 
@@ -159,6 +159,6 @@ func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-NEXT:      llvm.return %[[VAL_24]] : !llvm.ptr<4>
 // CHECK-NEXT:    }
 func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_gb>, %idx: memref<?x!sycl_id_3_>) -> memref<?xi32, 4> {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_3_i32_rw_gb>, memref<?x!sycl_id_3_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_3_i32_rw_gb>, memref<?x!sycl_id_3_>) -> memref<?xi32, 4>
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_3_i32_rw_gb>, memref<?x!sycl_id_3_>) -> memref<?xi32, 4>
   return %0 : memref<?xi32, 4>
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm-m32-typed-pointer.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm-m32-typed-pointer.mlir
@@ -26,6 +26,6 @@
 // CHECK-NEXT:      llvm.return %11 : !llvm.ptr<i32, 1>
 // CHECK-NEXT:    }
 func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.get_pointer(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>], FunctionName = @"get_pointer", MangledFunctionName = @"get_pointer", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1>
+  %0 = sycl.accessor.get_pointer(%acc) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm-m32.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm-m32.mlir
@@ -26,6 +26,6 @@
 // CHECK-NEXT:      llvm.return %11 : !llvm.ptr<1>
 // CHECK-NEXT:    }
 func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.get_pointer(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>], FunctionName = @"get_pointer", MangledFunctionName = @"get_pointer", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1>
+  %0 = sycl.accessor.get_pointer(%acc) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm-typed-pointer.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm-typed-pointer.mlir
@@ -14,7 +14,7 @@
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:    }
 func.func @test(%range: memref<?x!sycl_range_3_>, %idx: i32) -> i64 {
-  %0 = sycl.range.get %range[%idx] { ArgumentTypes = [memref<?x!sycl_range_3_>, i32], FunctionName = @"get", MangledFunctionName = @"get", TypeName = @"range" }  : (memref<?x!sycl_range_3_>, i32) -> i64
+  %0 = sycl.range.get %range[%idx] : (memref<?x!sycl_range_3_>, i32) -> i64
   return %0 : i64
 }
 
@@ -33,7 +33,7 @@ func.func @test(%range: memref<?x!sycl_range_3_>, %idx: i32) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.ptr<i64>
 // CHECK-NEXT:    }
 func.func @test(%range: memref<?x!sycl_range_3_>, %idx: i32) -> memref<?xi64> {
-  %0 = sycl.range.get %range[%idx] { ArgumentTypes = [memref<?x!sycl_range_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"range" }  : (memref<?x!sycl_range_3_>, i32) -> memref<?xi64>
+  %0 = sycl.range.get %range[%idx] : (memref<?x!sycl_range_3_>, i32) -> memref<?xi64>
   return %0 : memref<?xi64>
 }
 
@@ -56,7 +56,7 @@ func.func @test(%range: memref<?x!sycl_range_3_>, %idx: i32) -> memref<?xi64> {
 // CHECK-NEXT:      llvm.return %[[VAL_4]] : i64
 // CHECK-NEXT:    }
 func.func @test_1(%range: memref<?x!sycl_range_1_>) -> i64 {
-  %0 = sycl.range.size(%range) { ArgumentTypes = [memref<?x!sycl_range_1_>], FunctionName = @"size", MangledFunctionName = @"size", TypeName = @"range" }  : (memref<?x!sycl_range_1_>) -> i64
+  %0 = sycl.range.size(%range) : (memref<?x!sycl_range_1_>) -> i64
   return %0 : i64
 }
 
@@ -72,7 +72,7 @@ func.func @test_1(%range: memref<?x!sycl_range_1_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_7]] : i64
 // CHECK-NEXT:    }
 func.func @test_2(%range: memref<?x!sycl_range_2_>) -> i64 {
-  %0 = sycl.range.size(%range) { ArgumentTypes = [memref<?x!sycl_range_2_>], FunctionName = @"size", MangledFunctionName = @"size", TypeName = @"range" }  : (memref<?x!sycl_range_2_>) -> i64
+  %0 = sycl.range.size(%range) : (memref<?x!sycl_range_2_>) -> i64
   return %0 : i64
 }
 
@@ -91,7 +91,7 @@ func.func @test_2(%range: memref<?x!sycl_range_2_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_10]] : i64
 // CHECK-NEXT:    }
 func.func @test_3(%range: memref<?x!sycl_range_3_>) -> i64 {
-  %0 = sycl.range.size(%range) { ArgumentTypes = [memref<?x!sycl_range_3_>], FunctionName = @"size", MangledFunctionName = @"size", TypeName = @"range" }  : (memref<?x!sycl_range_3_>) -> i64
+  %0 = sycl.range.size(%range) : (memref<?x!sycl_range_3_>) -> i64
   return %0 : i64
 }
 
@@ -111,7 +111,7 @@ func.func @test_3(%range: memref<?x!sycl_range_3_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:    }
 func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> i64 {
-  %0 = sycl.id.get %id[%idx] { ArgumentTypes = [memref<?x!sycl_id_3_>, i32], FunctionName = @"get", MangledFunctionName = @"get", TypeName = @"id" }  : (memref<?x!sycl_id_3_>, i32) -> i64
+  %0 = sycl.id.get %id[%idx] : (memref<?x!sycl_id_3_>, i32) -> i64
   return %0 : i64
 }
 
@@ -131,7 +131,7 @@ func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:    }
 func.func @test(%id: memref<?x!sycl_id_1_>) -> i64 {
-  %0 = sycl.id.get %id[] { ArgumentTypes = [memref<?x!sycl_id_1_>], FunctionName = @"operator unsigned long", MangledFunctionName = @"operator unsigned long", TypeName = @"id" }  : (memref<?x!sycl_id_1_>) -> i64
+  %0 = sycl.id.get %id[] : (memref<?x!sycl_id_1_>) -> i64
   return %0 : i64
 }
 
@@ -150,7 +150,7 @@ func.func @test(%id: memref<?x!sycl_id_1_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.ptr<i64>
 // CHECK-NEXT:    }
 func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> memref<?xi64> {
-  %0 = sycl.id.get %id[%idx] { ArgumentTypes = [memref<?x!sycl_id_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_id_3_>, i32) -> memref<?xi64>
+  %0 = sycl.id.get %id[%idx] : (memref<?x!sycl_id_3_>, i32) -> memref<?xi64>
   return %0 : memref<?xi64>
 }
 
@@ -182,7 +182,7 @@ func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> memref<?xi64> {
 // CHECK-NEXT:      llvm.return %[[VAL_12]] : !llvm.ptr<i32, 1>
 // CHECK-NEXT:    }
 func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.get_pointer(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>], FunctionName = @"get_pointer", MangledFunctionName = @"get_pointer", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1>
+  %0 = sycl.accessor.get_pointer(%acc) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
@@ -204,7 +204,7 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1> 
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.[[RANGE1]]
 // CHECK-NEXT:    }
 func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_1_ {
-  %0 = sycl.accessor.get_range(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>], FunctionName = @"get_range", MangledFunctionName = @"get_range", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_1_
+  %0 = sycl.accessor.get_range(%acc) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
@@ -228,7 +228,7 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_1_ {
 // CHECK-NEXT:      llvm.return %[[VAL_4]] : i64
 // CHECK-NEXT:    }
 func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> i64 {
-  %0 = sycl.accessor.size(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>], FunctionName = @"size", MangledFunctionName = @"size", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> i64
+  %0 = sycl.accessor.size(%acc) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> i64
   return %0 : i64
 }
 
@@ -252,7 +252,7 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_4]] : !llvm.ptr<i32, 1>
 // CHECK-NEXT:    }
 func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: i64) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>, i64) -> memref<?xi32, 1>
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_rw_gb>, i64) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
@@ -284,7 +284,7 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: i64) -> memref
 // CHECK-NEXT:      llvm.return %[[VAL_6]] : !llvm.[[ACCESSORSUBS2]]
 // CHECK-NEXT:    }
 func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: i64) -> !sycl_accessor_subscript_2_ {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb>, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_2_i32_rw_gb>, i64) -> !sycl_accessor_subscript_2_
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_2_i32_rw_gb>, i64) -> !sycl_accessor_subscript_2_
   return %0 : !sycl_accessor_subscript_2_
 }
 
@@ -299,7 +299,7 @@ func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: i64) -> !syc
 // CHECK-NEXT:      llvm.return %[[VAL_7]] : !llvm.[[ACCESSORSUBS3]]
 // CHECK-NEXT:    }
 func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_gb>, %idx: i64) -> !sycl_accessor_subscript_3_ {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_3_i32_rw_gb>, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_3_i32_rw_gb>, i64) -> !sycl_accessor_subscript_3_
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_3_i32_rw_gb>, i64) -> !sycl_accessor_subscript_3_
   return %0 : !sycl_accessor_subscript_3_
 }
 
@@ -340,7 +340,7 @@ func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_gb>, %idx: i64) -> !syc
 // CHECK-NEXT:      llvm.return %[[VAL_11]] : !llvm.ptr<i32, 1>
 // CHECK-NEXT:    }
 func.func @test_1(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: memref<?x!sycl_id_1_>) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>) -> memref<?xi32, 1>
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
@@ -366,7 +366,7 @@ func.func @test_1(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-NEXT:      llvm.return %[[VAL_17]] : !llvm.ptr<i32, 1>
 // CHECK-NEXT:    }
 func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: memref<?x!sycl_id_2_>) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>) -> memref<?xi32, 1>
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
@@ -398,7 +398,7 @@ func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-NEXT:      llvm.return %[[VAL_23]] : !llvm.ptr<i32, 1>
 // CHECK-NEXT:    }
 func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_gb>, %idx: memref<?x!sycl_id_3_>) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_3_i32_rw_gb>, memref<?x!sycl_id_3_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_3_i32_rw_gb>, memref<?x!sycl_id_3_>) -> memref<?xi32, 1>
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_3_i32_rw_gb>, memref<?x!sycl_id_3_>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
@@ -417,7 +417,7 @@ func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-NEXT:      llvm.return %[[VAL_11]] : !llvm.ptr<struct<(i32, f32)>, 1>
 // CHECK-NEXT:    }
 func.func @test_struct(%acc: memref<?x!sycl_accessor_1_struct_rw_gb>, %idx: memref<?x!sycl_id_1_>) -> !llvm.ptr<struct<(i32, f32)>, 1> {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_1_struct_rw_gb>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_1_struct_rw_gb>, memref<?x!sycl_id_1_>) -> !llvm.ptr<struct<(i32, f32)>, 1>
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_struct_rw_gb>, memref<?x!sycl_id_1_>) -> !llvm.ptr<struct<(i32, f32)>, 1>
   return %0 : !llvm.ptr<struct<(i32, f32)>, 1>
 }
 
@@ -451,7 +451,7 @@ func.func @test_struct(%acc: memref<?x!sycl_accessor_1_struct_rw_gb>, %idx: memr
 // CHECK:           %[[VAL_13:.*]] = llvm.insertvalue %[[VAL_12]], %[[VAL_2]][0] : !llvm.[[ATOM1]]
 // CHECK:           llvm.return %[[VAL_13]] : !llvm.[[ATOM1]]
 func.func @test(%acc: memref<?x!sycl_accessor_1_i32_ato_gb>, %idx: memref<?x!sycl_id_1_>) -> !sycl_atomic_i32_glo {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_ato_gb>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_1_i32_ato_gb>, memref<?x!sycl_id_1_>) -> !sycl_atomic_i32_glo
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_ato_gb>, memref<?x!sycl_id_1_>) -> !sycl_atomic_i32_glo
   return %0 : !sycl_atomic_i32_glo
 }
 
@@ -468,7 +468,7 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_ato_gb>, %idx: memref<?x!syc
 // CHECK-NEXT:       llvm.return %[[VAL_2]] : !llvm.[[RANGE1]]
 // CHECK-NEXT:     }
 func.func @test(%nd: memref<?x!sycl_nd_range_1_>) -> !sycl_range_1_ {
-  %0 = sycl.nd_range.get_global_range(%nd) { ArgumentTypes = [memref<?x!sycl_nd_range_1_>], FunctionName = @"get_global_range", MangledFunctionName = @"get_global_range", TypeName = @"nd_range" }  : (memref<?x!sycl_nd_range_1_>) -> !sycl_range_1_
+  %0 = sycl.nd_range.get_global_range(%nd) : (memref<?x!sycl_nd_range_1_>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
@@ -485,7 +485,7 @@ func.func @test(%nd: memref<?x!sycl_nd_range_1_>) -> !sycl_range_1_ {
 // CHECK-NEXT:       llvm.return %[[VAL_2]] : !llvm.[[RANGE1]]
 // CHECK-NEXT:     }
 func.func @test(%nd: memref<?x!sycl_nd_range_1_>) -> !sycl_range_1_ {
-  %0 = sycl.nd_range.get_local_range(%nd) { ArgumentTypes = [memref<?x!sycl_nd_range_1_>], FunctionName = @"get_local_range", MangledFunctionName = @"get_local_range", TypeName = @"nd_range" }  : (memref<?x!sycl_nd_range_1_>) -> !sycl_range_1_
+  %0 = sycl.nd_range.get_local_range(%nd) : (memref<?x!sycl_nd_range_1_>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
@@ -524,7 +524,7 @@ func.func @test(%nd: memref<?x!sycl_nd_range_1_>) -> !sycl_range_1_ {
 // CHECK-NEXT:       llvm.return %[[VAL_21]] : !llvm.[[RANGE3]]
 // CHECK-NEXT:     }
 func.func @test(%nd: memref<?x!sycl_nd_range_3_>) -> !sycl_range_3_ {
-  %0 = sycl.nd_range.get_group_range(%nd) { ArgumentTypes = [memref<?x!sycl_nd_range_3_>], FunctionName = @"get_group_range", MangledFunctionName = @"get_group_range", TypeName = @"nd_range" }  : (memref<?x!sycl_nd_range_3_>) -> !sycl_range_3_
+  %0 = sycl.nd_range.get_group_range(%nd) : (memref<?x!sycl_nd_range_3_>) -> !sycl_range_3_
   return %0 : !sycl_range_3_
 }
 
@@ -542,7 +542,7 @@ func.func @test(%nd: memref<?x!sycl_nd_range_3_>) -> !sycl_range_3_ {
 // CHECK-NEXT:       llvm.return %[[VAL_2]] : !llvm.[[ID1]]
 // CHECK-NEXT:     }
 func.func @test(%item: memref<?x!sycl_item_1_>) -> !sycl_id_1_ {
-  %0 = sycl.item.get_id(%item) { ArgumentTypes = [memref<?x!sycl_item_1_>], FunctionName = @"get_id", MangledFunctionName = @"get_id", TypeName = @"item" }  : (memref<?x!sycl_item_1_>) -> !sycl_id_1_
+  %0 = sycl.item.get_id(%item) : (memref<?x!sycl_item_1_>) -> !sycl_id_1_
   return %0 : !sycl_id_1_
 }
 
@@ -561,7 +561,7 @@ func.func @test(%item: memref<?x!sycl_item_1_>) -> !sycl_id_1_ {
 // CHECK-NEXT:       llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:     }
 func.func @test(%item: memref<?x!sycl_item_1_>, %i: i32) -> i64 {
-  %0 = sycl.item.get_id(%item, %i) { ArgumentTypes = [memref<?x!sycl_item_1_>, i32], FunctionName = @"get_id", MangledFunctionName = @"get_id", TypeName = @"item" }  : (memref<?x!sycl_item_1_>, i32) -> i64
+  %0 = sycl.item.get_id(%item, %i) : (memref<?x!sycl_item_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -580,7 +580,7 @@ func.func @test(%item: memref<?x!sycl_item_1_>, %i: i32) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:     }
 func.func @test(%item: memref<?x!sycl_item_1_>) -> i64 {
-  %0 = sycl.item.get_id(%item) { ArgumentTypes = [memref<?x!sycl_item_1_>], FunctionName = @"operator unsigned long", MangledFunctionName = @"operator unsigned long", TypeName = @"item" }  : (memref<?x!sycl_item_1_>) -> i64
+  %0 = sycl.item.get_id(%item) : (memref<?x!sycl_item_1_>) -> i64
   return %0 : i64
 }
 
@@ -598,7 +598,7 @@ func.func @test(%item: memref<?x!sycl_item_1_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_2]] : !llvm.[[RANGE1]]
 // CHECK-NEXT:     }
 func.func @test(%item: memref<?x!sycl_item_1_>) -> !sycl_range_1_ {
-  %0 = sycl.item.get_range(%item) { ArgumentTypes = [memref<?x!sycl_item_1_>], FunctionName = @"get_range", MangledFunctionName = @"get_range", TypeName = @"item" }  : (memref<?x!sycl_item_1_>) -> !sycl_range_1_
+  %0 = sycl.item.get_range(%item) : (memref<?x!sycl_item_1_>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
@@ -617,7 +617,7 @@ func.func @test(%item: memref<?x!sycl_item_1_>) -> !sycl_range_1_ {
 // CHECK-NEXT:       llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:     }
 func.func @test(%item: memref<?x!sycl_item_1_>, %i: i32) -> i64 {
-  %0 = sycl.item.get_range(%item, %i) { ArgumentTypes = [memref<?x!sycl_item_1_>, i32], FunctionName = @"get_range", MangledFunctionName = @"get_range", TypeName = @"item" }  : (memref<?x!sycl_item_1_>, i32) -> i64
+  %0 = sycl.item.get_range(%item, %i) : (memref<?x!sycl_item_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -643,7 +643,7 @@ func.func @test(%item: memref<?x!sycl_item_1_>, %i: i32) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_2]] : i64
 // CHECK-NEXT:     }
 func.func @test_1(%item: memref<?x!sycl_item_1_>) -> i64 {
-  %0 = sycl.item.get_linear_id(%item) { ArgumentTypes = [memref<?x!sycl_item_1_>], FunctionName = @"get_linear_id", MangledFunctionName = @"get_linear_id", TypeName = @"item" }  : (memref<?x!sycl_item_1_>) -> i64
+  %0 = sycl.item.get_linear_id(%item) : (memref<?x!sycl_item_1_>) -> i64
   return %0 : i64
 }
 
@@ -660,7 +660,7 @@ func.func @test_1(%item: memref<?x!sycl_item_1_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_8]] : i64
 // CHECK-NEXT:     }
 func.func @test_2(%item: memref<?x!sycl_item_2_>) -> i64 {
-  %0 = sycl.item.get_linear_id(%item) { ArgumentTypes = [memref<?x!sycl_item_2_>], FunctionName = @"get_linear_id", MangledFunctionName = @"get_linear_id", TypeName = @"item" }  : (memref<?x!sycl_item_2_>) -> i64
+  %0 = sycl.item.get_linear_id(%item) : (memref<?x!sycl_item_2_>) -> i64
   return %0 : i64
 }
 
@@ -684,7 +684,7 @@ func.func @test_2(%item: memref<?x!sycl_item_2_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_15]] : i64
 // CHECK-NEXT:     }
 func.func @test_3(%item: memref<?x!sycl_item_3_>) -> i64 {
-  %0 = sycl.item.get_linear_id(%item) { ArgumentTypes = [memref<?x!sycl_item_3_>], FunctionName = @"get_linear_id", MangledFunctionName = @"get_linear_id", TypeName = @"item" }  : (memref<?x!sycl_item_3_>) -> i64
+  %0 = sycl.item.get_linear_id(%item) : (memref<?x!sycl_item_3_>) -> i64
   return %0 : i64
 }
 
@@ -713,7 +713,7 @@ func.func @test_3(%item: memref<?x!sycl_item_3_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_5]] : i64
 // CHECK-NEXT:     }
 func.func @test_1(%item: memref<?x!sycl_item_1_>) -> i64 {
-  %0 = sycl.item.get_linear_id(%item) { ArgumentTypes = [memref<?x!sycl_item_1_>], FunctionName = @"get_linear_id", MangledFunctionName = @"get_linear_id", TypeName = @"item" }  : (memref<?x!sycl_item_1_>) -> i64
+  %0 = sycl.item.get_linear_id(%item) : (memref<?x!sycl_item_1_>) -> i64
   return %0 : i64
 }
 
@@ -736,7 +736,7 @@ func.func @test_1(%item: memref<?x!sycl_item_1_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_14]] : i64
 // CHECK-NEXT:     }
 func.func @test_2(%item: memref<?x!sycl_item_2_>) -> i64 {
-  %0 = sycl.item.get_linear_id(%item) { ArgumentTypes = [memref<?x!sycl_item_2_>], FunctionName = @"get_linear_id", MangledFunctionName = @"get_linear_id", TypeName = @"item" }  : (memref<?x!sycl_item_2_>) -> i64
+  %0 = sycl.item.get_linear_id(%item) : (memref<?x!sycl_item_2_>) -> i64
   return %0 : i64
 }
 
@@ -769,7 +769,7 @@ func.func @test_2(%item: memref<?x!sycl_item_2_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_24]] : i64
 // CHECK-NEXT:     }
 func.func @test_3(%item: memref<?x!sycl_item_3_>) -> i64 {
-  %0 = sycl.item.get_linear_id(%item) { ArgumentTypes = [memref<?x!sycl_item_3_>], FunctionName = @"get_linear_id", MangledFunctionName = @"get_linear_id", TypeName = @"item" }  : (memref<?x!sycl_item_3_>) -> i64
+  %0 = sycl.item.get_linear_id(%item) : (memref<?x!sycl_item_3_>) -> i64
   return %0 : i64
 }
 
@@ -791,7 +791,7 @@ func.func @test_3(%item: memref<?x!sycl_item_3_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_2]] : !llvm.[[ID1]]
 // CHECK-NEXT:     }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_ {
-  %0 = sycl.nd_item.get_global_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_global_id", MangledFunctionName = @"get_global_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
+  %0 = sycl.nd_item.get_global_id(%nd) : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
   return %0 : !sycl_id_1_
 }
 
@@ -814,7 +814,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_ {
 // CHECK-NEXT:       llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:     }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
-  %0 = sycl.nd_item.get_global_id(%nd, %i) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>, i32], FunctionName = @"get_global_id", MangledFunctionName = @"get_global_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+  %0 = sycl.nd_item.get_global_id(%nd, %i) : (memref<?x!sycl_nd_item_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -852,7 +852,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_2]] : i64
 // CHECK-NEXT:     }
 func.func @test_1(%nd: memref<?x!sycl_nd_item_1_>) -> i64 {
-  %0 = sycl.nd_item.get_global_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_global_linear_id", MangledFunctionName = @"get_global_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> i64
+  %0 = sycl.nd_item.get_global_linear_id(%nd) : (memref<?x!sycl_nd_item_1_>) -> i64
   return %0 : i64
 }
 
@@ -869,7 +869,7 @@ func.func @test_1(%nd: memref<?x!sycl_nd_item_1_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_8]] : i64
 // CHECK-NEXT:     }
 func.func @test_2(%nd: memref<?x!sycl_nd_item_2_>) -> i64 {
-  %0 = sycl.nd_item.get_global_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_2_>], FunctionName = @"get_global_linear_id", MangledFunctionName = @"get_global_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_2_>) -> i64
+  %0 = sycl.nd_item.get_global_linear_id(%nd) : (memref<?x!sycl_nd_item_2_>) -> i64
   return %0 : i64
 }
 
@@ -893,7 +893,7 @@ func.func @test_2(%nd: memref<?x!sycl_nd_item_2_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_15]] : i64
 // CHECK-NEXT:     }
 func.func @test_3(%nd: memref<?x!sycl_nd_item_3_>) -> i64 {
-  %0 = sycl.nd_item.get_global_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_3_>], FunctionName = @"get_global_linear_id", MangledFunctionName = @"get_global_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_3_>) -> i64
+  %0 = sycl.nd_item.get_global_linear_id(%nd) : (memref<?x!sycl_nd_item_3_>) -> i64
   return %0 : i64
 }
 
@@ -915,7 +915,7 @@ func.func @test_3(%nd: memref<?x!sycl_nd_item_3_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_2]] : !llvm.[[ID1]]
 // CHECK-NEXT:     }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_ {
-  %0 = sycl.nd_item.get_local_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_local_id", MangledFunctionName = @"get_local_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
+  %0 = sycl.nd_item.get_local_id(%nd) : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
   return %0 : !sycl_id_1_
 }
 
@@ -938,7 +938,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_ {
 // CHECK-NEXT:       llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:     }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
-  %0 = sycl.nd_item.get_local_id(%nd, %i) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>, i32], FunctionName = @"get_local_id", MangledFunctionName = @"get_local_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+  %0 = sycl.nd_item.get_local_id(%nd, %i) : (memref<?x!sycl_nd_item_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -976,7 +976,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_2]] : i64
 // CHECK-NEXT:     }
 func.func @test_1(%nd: memref<?x!sycl_nd_item_1_>) -> i64 {
-  %0 = sycl.nd_item.get_local_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> i64
+  %0 = sycl.nd_item.get_local_linear_id(%nd) : (memref<?x!sycl_nd_item_1_>) -> i64
   return %0 : i64
 }
 
@@ -993,7 +993,7 @@ func.func @test_1(%nd: memref<?x!sycl_nd_item_1_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_8]] : i64
 // CHECK-NEXT:     }
 func.func @test_2(%nd: memref<?x!sycl_nd_item_2_>) -> i64 {
-  %0 = sycl.nd_item.get_local_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_2_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_2_>) -> i64
+  %0 = sycl.nd_item.get_local_linear_id(%nd) : (memref<?x!sycl_nd_item_2_>) -> i64
   return %0 : i64
 }
 
@@ -1017,7 +1017,7 @@ func.func @test_2(%nd: memref<?x!sycl_nd_item_2_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_15]] : i64
 // CHECK-NEXT:     }
 func.func @test_3(%nd: memref<?x!sycl_nd_item_3_>) -> i64 {
-  %0 = sycl.nd_item.get_local_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_3_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_3_>) -> i64
+  %0 = sycl.nd_item.get_local_linear_id(%nd) : (memref<?x!sycl_nd_item_3_>) -> i64
   return %0 : i64
 }
 
@@ -1056,7 +1056,7 @@ func.func @test_3(%nd: memref<?x!sycl_nd_item_3_>) -> i64 {
 // CHECK:           llvm.return %[[VAL_4]] : i64
 // CHECK:         }
 func.func @test_1(%nd: memref<?x!sycl_nd_item_1_>) -> i64 {
-  %0 = sycl.nd_item.get_group_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> i64
+  %0 = sycl.nd_item.get_group_linear_id(%nd) : (memref<?x!sycl_nd_item_1_>) -> i64
   return %0 : i64
 }
 
@@ -1074,7 +1074,7 @@ func.func @test_1(%nd: memref<?x!sycl_nd_item_1_>) -> i64 {
 // CHECK:           llvm.return %[[VAL_10]] : i64
 // CHECK:         }
 func.func @test_2(%nd: memref<?x!sycl_nd_item_2_>) -> i64 {
-  %0 = sycl.nd_item.get_group_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_2_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_2_>) -> i64
+  %0 = sycl.nd_item.get_group_linear_id(%nd) : (memref<?x!sycl_nd_item_2_>) -> i64
   return %0 : i64
 }
 
@@ -1099,7 +1099,7 @@ func.func @test_2(%nd: memref<?x!sycl_nd_item_2_>) -> i64 {
 // CHECK:           llvm.return %[[VAL_17]] : i64
 // CHECK:         }
 func.func @test_3(%nd: memref<?x!sycl_nd_item_3_>) -> i64 {
-  %0 = sycl.nd_item.get_group_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_3_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_3_>) -> i64
+  %0 = sycl.nd_item.get_group_linear_id(%nd) : (memref<?x!sycl_nd_item_3_>) -> i64
   return %0 : i64
 }
 
@@ -1121,7 +1121,7 @@ func.func @test_3(%nd: memref<?x!sycl_nd_item_3_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.struct<"class.sycl::_V1::range.1", {{.*}}>
 // CHECK-NEXT:    }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_ {
-  %0 = sycl.nd_item.get_global_range(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_global_range", MangledFunctionName = @"get_global_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
+  %0 = sycl.nd_item.get_global_range(%nd) : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
@@ -1144,7 +1144,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_ {
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:    }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
-  %0 = sycl.nd_item.get_global_range(%nd, %i) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>, i32], FunctionName = @"get_global_range", MangledFunctionName = @"get_global_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+  %0 = sycl.nd_item.get_global_range(%nd, %i) : (memref<?x!sycl_nd_item_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -1166,7 +1166,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_2]] : !llvm.[[GROUP1]]
 // CHECK-NEXT:     }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_group_1_ {
-  %0 = sycl.nd_item.get_group(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_group", MangledFunctionName = @"get_group", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_group_1_
+  %0 = sycl.nd_item.get_group(%nd) : (memref<?x!sycl_nd_item_1_>) -> !sycl_group_1_
   return %0 : !sycl_group_1_
 }
 
@@ -1189,7 +1189,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_group_1_ {
 // CHECK-NEXT:       llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:     }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
-  %0 = sycl.nd_item.get_group(%nd, %i) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>, i32], FunctionName = @"get_group", MangledFunctionName = @"get_group", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+  %0 = sycl.nd_item.get_group(%nd, %i) : (memref<?x!sycl_nd_item_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -1211,7 +1211,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_2]] : !llvm.[[RANGE1]]
 // CHECK-NEXT:     }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_ {
-  %0 = sycl.nd_item.get_group_range(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_group_range", MangledFunctionName = @"get_group_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
+  %0 = sycl.nd_item.get_group_range(%nd) : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
@@ -1234,7 +1234,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_ {
 // CHECK-NEXT:       llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:     }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
-  %0 = sycl.nd_item.get_group_range(%nd, %i) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>, i32], FunctionName = @"get_group_range", MangledFunctionName = @"get_group_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+  %0 = sycl.nd_item.get_group_range(%nd, %i) : (memref<?x!sycl_nd_item_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -1256,7 +1256,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_2]] : !llvm.[[RANGE1]]
 // CHECK-NEXT:     }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_ {
-  %0 = sycl.nd_item.get_local_range(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_local_range", MangledFunctionName = @"get_local_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
+  %0 = sycl.nd_item.get_local_range(%nd) : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
@@ -1279,7 +1279,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_ {
 // CHECK-NEXT:       llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:     }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
-  %0 = sycl.nd_item.get_local_range(%nd, %i) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>, i32], FunctionName = @"get_local_range", MangledFunctionName = @"get_local_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+  %0 = sycl.nd_item.get_local_range(%nd, %i) : (memref<?x!sycl_nd_item_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -1315,7 +1315,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_12]] : !llvm.[[NDRANGE1]]
 // CHECK-NEXT:     }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_nd_range_1_ {
-  %0 = sycl.nd_item.get_nd_range(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_nd_range", MangledFunctionName = @"get_nd_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_nd_range_1_
+  %0 = sycl.nd_item.get_nd_range(%nd) : (memref<?x!sycl_nd_item_1_>) -> !sycl_nd_range_1_
   return %0 : !sycl_nd_range_1_
 }
 
@@ -1332,7 +1332,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_nd_range_1_ {
 // CHECK-NEXT:       llvm.return %[[VAL_2]] : !llvm.[[ID1]]
 // CHECK-NEXT:     }
 func.func @test(%group: memref<?x!sycl_group_1_>) -> !sycl_id_1_ {
-  %0 = sycl.group.get_group_id(%group) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_group_id", MangledFunctionName = @"get_group_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
+  %0 = sycl.group.get_group_id(%group) : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
   return %0 : !sycl_id_1_
 }
 
@@ -1350,7 +1350,7 @@ func.func @test(%group: memref<?x!sycl_group_1_>) -> !sycl_id_1_ {
 // CHECK-NEXT:       llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:     }
 func.func @test(%group: memref<?x!sycl_group_1_>, %i: i32) -> i64 {
-  %0 = sycl.group.get_group_id(%group, %i) { ArgumentTypes = [memref<?x!sycl_group_1_>, i32], FunctionName = @"get_group_id", MangledFunctionName = @"get_group_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>, i32) -> i64
+  %0 = sycl.group.get_group_id(%group, %i) : (memref<?x!sycl_group_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -1395,7 +1395,7 @@ module attributes {gpu.container} {
 // CHECK:             llvm.return %[[VAL_25]] : !llvm.[[ID3]]
 // CHECK-NEXT:     }
     func.func @test(%group: memref<?x!sycl_group_3_>) -> !sycl_id_3_ {
-      %0 = sycl.group.get_local_id(%group) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_local_id", MangledFunctionName = @"get_local_id", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> !sycl_id_3_
+      %0 = sycl.group.get_local_id(%group) : (memref<?x!sycl_group_3_>) -> !sycl_id_3_
       return %0 : !sycl_id_3_
     }
   }
@@ -1440,7 +1440,7 @@ module attributes {gpu.container} {
 // CHECK:             llvm.return %[[VAL_23]] : i64
 // CHECK-NEXT:     }
     func.func @test(%group: memref<?x!sycl_group_1_>, %i: i32) -> i64 {
-      %0 = sycl.group.get_local_id(%group, %i) { ArgumentTypes = [memref<?x!sycl_group_1_>, i32], FunctionName = @"get_local_id", MangledFunctionName = @"get_local_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>, i32) -> i64
+      %0 = sycl.group.get_local_id(%group, %i) : (memref<?x!sycl_group_1_>, i32) -> i64
       return %0 : i64
     }
   }
@@ -1459,7 +1459,7 @@ module attributes {gpu.container} {
 // CHECK-NEXT:       llvm.return %[[VAL_2]] : !llvm.[[RANGE3]]
 // CHECK-NEXT:     }
 func.func @test(%group: memref<?x!sycl_group_3_>) -> !sycl_range_3_ {
-  %0 = sycl.group.get_local_range(%group) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_local_range", MangledFunctionName = @"get_local_range", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> !sycl_range_3_
+  %0 = sycl.group.get_local_range(%group) : (memref<?x!sycl_group_3_>) -> !sycl_range_3_
   return %0 : !sycl_range_3_
 }
 
@@ -1477,7 +1477,7 @@ func.func @test(%group: memref<?x!sycl_group_3_>) -> !sycl_range_3_ {
 // CHECK-NEXT:       llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:     }
 func.func @test(%group: memref<?x!sycl_group_1_>, %i: i32) -> i64 {
-  %0 = sycl.group.get_local_range(%group, %i) { ArgumentTypes = [memref<?x!sycl_group_1_>, i32], FunctionName = @"get_local_range", MangledFunctionName = @"get_local_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>, i32) -> i64
+  %0 = sycl.group.get_local_range(%group, %i) : (memref<?x!sycl_group_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -1494,7 +1494,7 @@ func.func @test(%group: memref<?x!sycl_group_1_>, %i: i32) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_2]] : !llvm.[[RANGE3]]
 // CHECK-NEXT:     }
 func.func @test(%group: memref<?x!sycl_group_3_>) -> !sycl_range_3_ {
-  %0 = sycl.group.get_max_local_range(%group) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_max_local_range", MangledFunctionName = @"get_max_local_range", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> !sycl_range_3_
+  %0 = sycl.group.get_max_local_range(%group) : (memref<?x!sycl_group_3_>) -> !sycl_range_3_
   return %0 : !sycl_range_3_
 }
 
@@ -1517,7 +1517,7 @@ func.func @test(%group: memref<?x!sycl_group_3_>) -> !sycl_range_3_ {
 // CHECK-NEXT:       llvm.return %[[VAL_2]] : i64
 // CHECK-NEXT:     }
 func.func @test_1(%group: memref<?x!sycl_group_1_>) -> i64 {
-  %0 = sycl.group.get_group_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> i64
+  %0 = sycl.group.get_group_linear_id(%group) : (memref<?x!sycl_group_1_>) -> i64
   return %0 : i64
 }
 
@@ -1534,7 +1534,7 @@ func.func @test_1(%group: memref<?x!sycl_group_1_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_8]] : i64
 // CHECK-NEXT:     }
 func.func @test_2(%group: memref<?x!sycl_group_2_>) -> i64 {
-  %0 = sycl.group.get_group_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_2_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_2_>) -> i64
+  %0 = sycl.group.get_group_linear_id(%group) : (memref<?x!sycl_group_2_>) -> i64
   return %0 : i64
 }
 
@@ -1558,7 +1558,7 @@ func.func @test_2(%group: memref<?x!sycl_group_2_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_15]] : i64
 // CHECK-NEXT:     }
 func.func @test_3(%group: memref<?x!sycl_group_3_>) -> i64 {
-  %0 = sycl.group.get_group_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64
+  %0 = sycl.group.get_group_linear_id(%group) : (memref<?x!sycl_group_3_>) -> i64
   return %0 : i64
 }
 
@@ -1606,7 +1606,7 @@ module attributes {gpu.container} {
 // CHECK:             llvm.return %[[VAL_23]] : i64
 // CHECK-NEXT:     }
     func.func @test_1(%group: memref<?x!sycl_group_1_>) -> i64 {
-      %0 = sycl.group.get_local_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> i64
+      %0 = sycl.group.get_local_linear_id(%group) : (memref<?x!sycl_group_1_>) -> i64
       return %0 : i64
     }
 
@@ -1653,7 +1653,7 @@ module attributes {gpu.container} {
 // CHECK:             llvm.return %[[VAL_59]] : i64
 // CHECK-NEXT:     }
     func.func @test_2(%group: memref<?x!sycl_group_2_>) -> i64 {
-      %0 = sycl.group.get_local_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_2_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_2_>) -> i64
+      %0 = sycl.group.get_local_linear_id(%group) : (memref<?x!sycl_group_2_>) -> i64
       return %0 : i64
     }
 
@@ -1714,7 +1714,7 @@ module attributes {gpu.container} {
 // CHECK:             llvm.return %[[VAL_108]] : i64
 // CHECK-NEXT:     }
     func.func @test_3(%group: memref<?x!sycl_group_3_>) -> i64 {
-      %0 = sycl.group.get_local_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64
+      %0 = sycl.group.get_local_linear_id(%group) : (memref<?x!sycl_group_3_>) -> i64
       return %0 : i64
     }
   }
@@ -1741,7 +1741,7 @@ module attributes {gpu.container} {
 // CHECK-NEXT:       llvm.return %[[VAL_4]] : i64
 // CHECK-NEXT:     }
 func.func @test_1(%group: memref<?x!sycl_group_1_>) -> i64 {
-  %0 = sycl.group.get_group_linear_range(%group) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_group_linear_range", MangledFunctionName = @"get_group_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> i64
+  %0 = sycl.group.get_group_linear_range(%group) : (memref<?x!sycl_group_1_>) -> i64
   return %0 : i64
 }
 
@@ -1757,7 +1757,7 @@ func.func @test_1(%group: memref<?x!sycl_group_1_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_7]] : i64
 // CHECK-NEXT:     }
 func.func @test_2(%group: memref<?x!sycl_group_2_>) -> i64 {
-  %0 = sycl.group.get_group_linear_range(%group) { ArgumentTypes = [memref<?x!sycl_group_2_>], FunctionName = @"get_group_linear_range", MangledFunctionName = @"get_group_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_2_>) -> i64
+  %0 = sycl.group.get_group_linear_range(%group) : (memref<?x!sycl_group_2_>) -> i64
   return %0 : i64
 }
 
@@ -1776,7 +1776,7 @@ func.func @test_2(%group: memref<?x!sycl_group_2_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_10]] : i64
 // CHECK-NEXT:     }
 func.func @test_3(%group: memref<?x!sycl_group_3_>) -> i64 {
-  %0 = sycl.group.get_group_linear_range(%group) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_group_linear_range", MangledFunctionName = @"get_group_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64
+  %0 = sycl.group.get_group_linear_range(%group) : (memref<?x!sycl_group_3_>) -> i64
   return %0 : i64
 }
 
@@ -1801,7 +1801,7 @@ func.func @test_3(%group: memref<?x!sycl_group_3_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_4]] : i64
 // CHECK-NEXT:     }
 func.func @test_1(%group: memref<?x!sycl_group_1_>) -> i64 {
-  %0 = sycl.group.get_local_linear_range(%group) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_local_linear_range", MangledFunctionName = @"get_local_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> i64
+  %0 = sycl.group.get_local_linear_range(%group) : (memref<?x!sycl_group_1_>) -> i64
   return %0 : i64
 }
 
@@ -1817,7 +1817,7 @@ func.func @test_1(%group: memref<?x!sycl_group_1_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_7]] : i64
 // CHECK-NEXT:     }
 func.func @test_2(%group: memref<?x!sycl_group_2_>) -> i64 {
-  %0 = sycl.group.get_local_linear_range(%group) { ArgumentTypes = [memref<?x!sycl_group_2_>], FunctionName = @"get_local_linear_range", MangledFunctionName = @"get_local_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_2_>) -> i64
+  %0 = sycl.group.get_local_linear_range(%group) : (memref<?x!sycl_group_2_>) -> i64
   return %0 : i64
 }
 
@@ -1836,6 +1836,6 @@ func.func @test_2(%group: memref<?x!sycl_group_2_>) -> i64 {
 // CHECK-NEXT:       llvm.return %[[VAL_10]] : i64
 // CHECK-NEXT:     }
 func.func @test_3(%group: memref<?x!sycl_group_3_>) -> i64 {
-  %0 = sycl.group.get_local_linear_range(%group) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_local_linear_range", MangledFunctionName = @"get_local_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64
+  %0 = sycl.group.get_local_linear_range(%group) : (memref<?x!sycl_group_3_>) -> i64
   return %0 : i64
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -13,7 +13,7 @@
 // CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> i64
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 func.func @test(%range: memref<?x!sycl_range_3_>, %idx: i32) -> i64 {
-  %0 = sycl.range.get %range[%idx] { ArgumentTypes = [memref<?x!sycl_range_3_>, i32], FunctionName = @"get", MangledFunctionName = @"get", TypeName = @"range" }  : (memref<?x!sycl_range_3_>, i32) -> i64
+  %0 = sycl.range.get %range[%idx] : (memref<?x!sycl_range_3_>, i32) -> i64
   return %0 : i64
 }
 
@@ -31,7 +31,7 @@ func.func @test(%range: memref<?x!sycl_range_3_>, %idx: i32) -> i64 {
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, %[[VAL_1]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.ptr
 func.func @test(%range: memref<?x!sycl_range_3_>, %idx: i32) -> memref<?xi64> {
-  %0 = sycl.range.get %range[%idx] { ArgumentTypes = [memref<?x!sycl_range_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"range" }  : (memref<?x!sycl_range_3_>, i32) -> memref<?xi64>
+  %0 = sycl.range.get %range[%idx] : (memref<?x!sycl_range_3_>, i32) -> memref<?xi64>
   return %0 : memref<?xi64>
 }
 
@@ -53,7 +53,7 @@ func.func @test(%range: memref<?x!sycl_range_3_>, %idx: i32) -> memref<?xi64> {
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mul %[[VAL_1]], %[[VAL_3]]  : i64
 // CHECK-NEXT:      llvm.return %[[VAL_4]] : i64
 func.func @test_1(%range: memref<?x!sycl_range_1_>) -> i64 {
-  %0 = sycl.range.size(%range) { ArgumentTypes = [memref<?x!sycl_range_1_>], FunctionName = @"size", MangledFunctionName = @"size", TypeName = @"range" }  : (memref<?x!sycl_range_1_>) -> i64
+  %0 = sycl.range.size(%range) : (memref<?x!sycl_range_1_>) -> i64
   return %0 : i64
 }
 
@@ -68,7 +68,7 @@ func.func @test_1(%range: memref<?x!sycl_range_1_>) -> i64 {
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_4]], %[[VAL_6]]  : i64
 // CHECK-NEXT:      llvm.return %[[VAL_7]] : i64
 func.func @test_2(%range: memref<?x!sycl_range_2_>) -> i64 {
-  %0 = sycl.range.size(%range) { ArgumentTypes = [memref<?x!sycl_range_2_>], FunctionName = @"size", MangledFunctionName = @"size", TypeName = @"range" }  : (memref<?x!sycl_range_2_>) -> i64
+  %0 = sycl.range.size(%range) : (memref<?x!sycl_range_2_>) -> i64
   return %0 : i64
 }
 
@@ -86,7 +86,7 @@ func.func @test_2(%range: memref<?x!sycl_range_2_>) -> i64 {
 // CHECK-NEXT:      %[[VAL_10:.*]] = llvm.mul %[[VAL_7]], %[[VAL_9]]  : i64
 // CHECK-NEXT:      llvm.return %[[VAL_10]] : i64
 func.func @test_3(%range: memref<?x!sycl_range_3_>) -> i64 {
-  %0 = sycl.range.size(%range) { ArgumentTypes = [memref<?x!sycl_range_3_>], FunctionName = @"size", MangledFunctionName = @"size", TypeName = @"range" }  : (memref<?x!sycl_range_3_>) -> i64
+  %0 = sycl.range.size(%range) : (memref<?x!sycl_range_3_>) -> i64
   return %0 : i64
 }
 
@@ -105,7 +105,7 @@ func.func @test_3(%range: memref<?x!sycl_range_3_>) -> i64 {
 // CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> i64
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> i64 {
-  %0 = sycl.id.get %id[%idx] { ArgumentTypes = [memref<?x!sycl_id_3_>, i32], FunctionName = @"get", MangledFunctionName = @"get", TypeName = @"id" }  : (memref<?x!sycl_id_3_>, i32) -> i64
+  %0 = sycl.id.get %id[%idx] : (memref<?x!sycl_id_3_>, i32) -> i64
   return %0 : i64
 }
 
@@ -124,7 +124,7 @@ func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> i64 {
 // CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> i64
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 func.func @test(%id: memref<?x!sycl_id_1_>) -> i64 {
-  %0 = sycl.id.get %id[] { ArgumentTypes = [memref<?x!sycl_id_1_>], FunctionName = @"operator unsigned long", MangledFunctionName = @"operator unsigned long", TypeName = @"id" }  : (memref<?x!sycl_id_1_>) -> i64
+  %0 = sycl.id.get %id[] : (memref<?x!sycl_id_1_>) -> i64
   return %0 : i64
 }
 
@@ -142,7 +142,7 @@ func.func @test(%id: memref<?x!sycl_id_1_>) -> i64 {
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, %[[VAL_1]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.ptr
 func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> memref<?xi64> {
-  %0 = sycl.id.get %id[%idx] { ArgumentTypes = [memref<?x!sycl_id_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_id_3_>, i32) -> memref<?xi64>
+  %0 = sycl.id.get %id[%idx] : (memref<?x!sycl_id_3_>, i32) -> memref<?xi64>
   return %0 : memref<?xi64>
 }
 
@@ -173,7 +173,7 @@ func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> memref<?xi64> {
 // CHECK-NEXT:      %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_11]]{{\[}}%[[VAL_9]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      llvm.return %[[VAL_12]] : !llvm.ptr<1>
 func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.get_pointer(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>], FunctionName = @"get_pointer", MangledFunctionName = @"get_pointer", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1>
+  %0 = sycl.accessor.get_pointer(%acc) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
@@ -194,7 +194,7 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1> 
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr -> !llvm.struct<"class.sycl::_V1::range.1", {{.*}}>
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.struct<"class.sycl::_V1::range.1", {{.*}}>
 func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_1_ {
-  %0 = sycl.accessor.get_range(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>], FunctionName = @"get_range", MangledFunctionName = @"get_range", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_1_
+  %0 = sycl.accessor.get_range(%acc) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
@@ -218,7 +218,7 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_1_ {
 // CHECK-NEXT:      llvm.return %[[VAL_4]] : i64
 // CHECK-NEXT:    }
 func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> i64 {
-  %0 = sycl.accessor.size(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>], FunctionName = @"size", MangledFunctionName = @"size", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> i64
+  %0 = sycl.accessor.size(%acc) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> i64
   return %0 : i64
 }
 
@@ -241,7 +241,7 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> i64 {
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      llvm.return %[[VAL_4]] : !llvm.ptr<1>
 func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: i64) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>, i64) -> memref<?xi32, 1>
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_rw_gb>, i64) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
@@ -273,7 +273,7 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: i64) -> memref
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.insertvalue %[[VAL_5]], %[[VAL_3]][1] : !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.2", {{.*}}>
 // CHECK-NEXT:      llvm.return %[[VAL_6]] : !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.2", {{.*}}>
 func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: i64) -> !sycl_accessor_subscript_2_ {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb>, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_2_i32_rw_gb>, i64) -> !sycl_accessor_subscript_2_
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_2_i32_rw_gb>, i64) -> !sycl_accessor_subscript_2_
   return %0 : !sycl_accessor_subscript_2_
 }
 
@@ -288,7 +288,7 @@ func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: i64) -> !syc
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.insertvalue %[[VAL_6]], %[[VAL_5]][1] : !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.3", {{.*}}>
 // CHECK-NEXT:      llvm.return %[[VAL_7]] : !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.3", {{.*}}>
 func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_gb>, %idx: i64) -> !sycl_accessor_subscript_3_ {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_3_i32_rw_gb>, i64], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_3_i32_rw_gb>, i64) -> !sycl_accessor_subscript_3_
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_3_i32_rw_gb>, i64) -> !sycl_accessor_subscript_3_
   return %0 : !sycl_accessor_subscript_3_
 }
 
@@ -328,7 +328,7 @@ func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_gb>, %idx: i64) -> !syc
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_10]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      llvm.return %[[VAL_11]] : !llvm.ptr<1>
 func.func @test_1(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: memref<?x!sycl_id_1_>) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>) -> memref<?xi32, 1>
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
@@ -353,7 +353,7 @@ func.func @test_1(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-NEXT:      %[[VAL_17:.*]] = llvm.getelementptr inbounds %[[VAL_16]]{{\[}}%[[VAL_14]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      llvm.return %[[VAL_17]] : !llvm.ptr<1>
 func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: memref<?x!sycl_id_2_>) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>) -> memref<?xi32, 1>
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
@@ -384,7 +384,7 @@ func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-NEXT:      %[[VAL_23:.*]] = llvm.getelementptr inbounds %[[VAL_22]]{{\[}}%[[VAL_20]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      llvm.return %[[VAL_23]] : !llvm.ptr<1>
 func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_gb>, %idx: memref<?x!sycl_id_3_>) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_3_i32_rw_gb>, memref<?x!sycl_id_3_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_3_i32_rw_gb>, memref<?x!sycl_id_3_>) -> memref<?xi32, 1>
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_3_i32_rw_gb>, memref<?x!sycl_id_3_>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
@@ -403,7 +403,7 @@ func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_10]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, !llvm.struct<(i32, f32)>
 // CHECK-NEXT:      llvm.return %[[VAL_11]] : !llvm.ptr<1>
 func.func @test_struct(%acc: memref<?x!sycl_accessor_1_struct_rw_gb>, %idx: memref<?x!sycl_id_1_>) -> !llvm.ptr<1> {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_1_struct_rw_gb>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_1_struct_rw_gb>, memref<?x!sycl_id_1_>) -> !llvm.ptr<1>
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_struct_rw_gb>, memref<?x!sycl_id_1_>) -> !llvm.ptr<1>
   return %0 : !llvm.ptr<1>
 }
 
@@ -437,7 +437,7 @@ func.func @test_struct(%acc: memref<?x!sycl_accessor_1_struct_rw_gb>, %idx: memr
 // CHECK-NEXT:      %[[VAL_13:.*]] = llvm.insertvalue %[[VAL_12]], %[[VAL_2]][0] : !llvm.struct<"class.sycl::_V1::atomic", {{.*}}>
 // CHECK-NEXT:      llvm.return %[[VAL_13]] : !llvm.struct<"class.sycl::_V1::atomic", {{.*}}>
 func.func @test(%acc: memref<?x!sycl_accessor_1_i32_ato_gb>, %idx: memref<?x!sycl_id_1_>) -> !sycl_atomic_i32_glo {
-  %0 = sycl.accessor.subscript %acc[%idx] { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_ato_gb>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_1_i32_ato_gb>, memref<?x!sycl_id_1_>) -> !sycl_atomic_i32_glo
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_ato_gb>, memref<?x!sycl_id_1_>) -> !sycl_atomic_i32_glo
   return %0 : !sycl_atomic_i32_glo
 }
 
@@ -453,7 +453,7 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_ato_gb>, %idx: memref<?x!syc
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr -> !llvm.struct<"class.sycl::_V1::range.1", {{.*}}>
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.struct<"class.sycl::_V1::range.1", {{.*}}>
 func.func @test(%nd: memref<?x!sycl_nd_range_1_>) -> !sycl_range_1_ {
-  %0 = sycl.nd_range.get_global_range(%nd) { ArgumentTypes = [memref<?x!sycl_nd_range_1_>], FunctionName = @"get_global_range", MangledFunctionName = @"get_global_range", TypeName = @"nd_range" }  : (memref<?x!sycl_nd_range_1_>) -> !sycl_range_1_
+  %0 = sycl.nd_range.get_global_range(%nd) : (memref<?x!sycl_nd_range_1_>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
@@ -469,7 +469,7 @@ func.func @test(%nd: memref<?x!sycl_nd_range_1_>) -> !sycl_range_1_ {
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr -> !llvm.struct<"class.sycl::_V1::range.1", {{.*}}>
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.struct<"class.sycl::_V1::range.1", {{.*}}>
 func.func @test(%nd: memref<?x!sycl_nd_range_1_>) -> !sycl_range_1_ {
-  %0 = sycl.nd_range.get_local_range(%nd) { ArgumentTypes = [memref<?x!sycl_nd_range_1_>], FunctionName = @"get_local_range", MangledFunctionName = @"get_local_range", TypeName = @"nd_range" }  : (memref<?x!sycl_nd_range_1_>) -> !sycl_range_1_
+  %0 = sycl.nd_range.get_local_range(%nd) : (memref<?x!sycl_nd_range_1_>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
@@ -507,7 +507,7 @@ func.func @test(%nd: memref<?x!sycl_nd_range_1_>) -> !sycl_range_1_ {
 // CHECK-NEXT:      %[[VAL_21:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> !llvm.struct<"class.sycl::_V1::range.3", {{.*}}>
 // CHECK-NEXT:      llvm.return %[[VAL_21]] : !llvm.struct<"class.sycl::_V1::range.3", {{.*}}>
 func.func @test(%nd: memref<?x!sycl_nd_range_3_>) -> !sycl_range_3_ {
-  %0 = sycl.nd_range.get_group_range(%nd) { ArgumentTypes = [memref<?x!sycl_nd_range_3_>], FunctionName = @"get_group_range", MangledFunctionName = @"get_group_range", TypeName = @"nd_range" }  : (memref<?x!sycl_nd_range_3_>) -> !sycl_range_3_
+  %0 = sycl.nd_range.get_group_range(%nd) : (memref<?x!sycl_nd_range_3_>) -> !sycl_range_3_
   return %0 : !sycl_range_3_
 }
 
@@ -525,7 +525,7 @@ func.func @test(%nd: memref<?x!sycl_nd_range_3_>) -> !sycl_range_3_ {
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
 // CHECK-NEXT:    }
 func.func @test(%item: memref<?x!sycl_item_1_>) -> !sycl_id_1_ {
-  %0 = sycl.item.get_id(%item) { ArgumentTypes = [memref<?x!sycl_item_1_>], FunctionName = @"get_id", MangledFunctionName = @"get_id", TypeName = @"item" }  : (memref<?x!sycl_item_1_>) -> !sycl_id_1_
+  %0 = sycl.item.get_id(%item) : (memref<?x!sycl_item_1_>) -> !sycl_id_1_
   return %0 : !sycl_id_1_
 }
 
@@ -544,7 +544,7 @@ func.func @test(%item: memref<?x!sycl_item_1_>) -> !sycl_id_1_ {
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:    }
 func.func @test(%item: memref<?x!sycl_item_1_>, %i: i32) -> i64 {
-  %0 = sycl.item.get_id(%item, %i) { ArgumentTypes = [memref<?x!sycl_item_1_>, i32], FunctionName = @"get_id", MangledFunctionName = @"get_id", TypeName = @"item" }  : (memref<?x!sycl_item_1_>, i32) -> i64
+  %0 = sycl.item.get_id(%item, %i) : (memref<?x!sycl_item_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -563,7 +563,7 @@ func.func @test(%item: memref<?x!sycl_item_1_>, %i: i32) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:    }
 func.func @test(%item: memref<?x!sycl_item_1_>) -> i64 {
-  %0 = sycl.item.get_id(%item) { ArgumentTypes = [memref<?x!sycl_item_1_>], FunctionName = @"operator unsigned long", MangledFunctionName = @"operator unsigned long", TypeName = @"item" }  : (memref<?x!sycl_item_1_>) -> i64
+  %0 = sycl.item.get_id(%item) : (memref<?x!sycl_item_1_>) -> i64
   return %0 : i64
 }
 
@@ -581,7 +581,7 @@ func.func @test(%item: memref<?x!sycl_item_1_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.struct<"class.sycl::_V1::range.1", {{.*}}>
 // CHECK-NEXT:    }
 func.func @test(%item: memref<?x!sycl_item_1_>) -> !sycl_range_1_ {
-  %0 = sycl.item.get_range(%item) { ArgumentTypes = [memref<?x!sycl_item_1_>], FunctionName = @"get_range", MangledFunctionName = @"get_range", TypeName = @"item" }  : (memref<?x!sycl_item_1_>) -> !sycl_range_1_
+  %0 = sycl.item.get_range(%item) : (memref<?x!sycl_item_1_>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
@@ -600,7 +600,7 @@ func.func @test(%item: memref<?x!sycl_item_1_>) -> !sycl_range_1_ {
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:    }
 func.func @test(%item: memref<?x!sycl_item_1_>, %i: i32) -> i64 {
-  %0 = sycl.item.get_range(%item, %i) { ArgumentTypes = [memref<?x!sycl_item_1_>, i32], FunctionName = @"get_range", MangledFunctionName = @"get_range", TypeName = @"item" }  : (memref<?x!sycl_item_1_>, i32) -> i64
+  %0 = sycl.item.get_range(%item, %i) : (memref<?x!sycl_item_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -626,7 +626,7 @@ func.func @test(%item: memref<?x!sycl_item_1_>, %i: i32) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : i64
 // CHECK-NEXT:    }
 func.func @test_1(%item: memref<?x!sycl_item_1_>) -> i64 {
-  %0 = sycl.item.get_linear_id(%item) { ArgumentTypes = [memref<?x!sycl_item_1_>], FunctionName = @"get_linear_id", MangledFunctionName = @"get_linear_id", TypeName = @"item" }  : (memref<?x!sycl_item_1_>) -> i64
+  %0 = sycl.item.get_linear_id(%item) : (memref<?x!sycl_item_1_>) -> i64
   return %0 : i64
 }
 
@@ -643,7 +643,7 @@ func.func @test_1(%item: memref<?x!sycl_item_1_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_8]] : i64
 // CHECK-NEXT:    }
 func.func @test_2(%item: memref<?x!sycl_item_2_>) -> i64 {
-  %0 = sycl.item.get_linear_id(%item) { ArgumentTypes = [memref<?x!sycl_item_2_>], FunctionName = @"get_linear_id", MangledFunctionName = @"get_linear_id", TypeName = @"item" }  : (memref<?x!sycl_item_2_>) -> i64
+  %0 = sycl.item.get_linear_id(%item) : (memref<?x!sycl_item_2_>) -> i64
   return %0 : i64
 }
 
@@ -667,7 +667,7 @@ func.func @test_2(%item: memref<?x!sycl_item_2_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_15]] : i64
 // CHECK-NEXT:    }
 func.func @test_3(%item: memref<?x!sycl_item_3_>) -> i64 {
-  %0 = sycl.item.get_linear_id(%item) { ArgumentTypes = [memref<?x!sycl_item_3_>], FunctionName = @"get_linear_id", MangledFunctionName = @"get_linear_id", TypeName = @"item" }  : (memref<?x!sycl_item_3_>) -> i64
+  %0 = sycl.item.get_linear_id(%item) : (memref<?x!sycl_item_3_>) -> i64
   return %0 : i64
 }
 
@@ -696,7 +696,7 @@ func.func @test_3(%item: memref<?x!sycl_item_3_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_5]] : i64
 // CHECK-NEXT:    }
 func.func @test_1(%item: memref<?x!sycl_item_1_>) -> i64 {
-  %0 = sycl.item.get_linear_id(%item) { ArgumentTypes = [memref<?x!sycl_item_1_>], FunctionName = @"get_linear_id", MangledFunctionName = @"get_linear_id", TypeName = @"item" }  : (memref<?x!sycl_item_1_>) -> i64
+  %0 = sycl.item.get_linear_id(%item) : (memref<?x!sycl_item_1_>) -> i64
   return %0 : i64
 }
 
@@ -719,7 +719,7 @@ func.func @test_1(%item: memref<?x!sycl_item_1_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_14]] : i64
 // CHECK-NEXT:    }
 func.func @test_2(%item: memref<?x!sycl_item_2_>) -> i64 {
-  %0 = sycl.item.get_linear_id(%item) { ArgumentTypes = [memref<?x!sycl_item_2_>], FunctionName = @"get_linear_id", MangledFunctionName = @"get_linear_id", TypeName = @"item" }  : (memref<?x!sycl_item_2_>) -> i64
+  %0 = sycl.item.get_linear_id(%item) : (memref<?x!sycl_item_2_>) -> i64
   return %0 : i64
 }
 
@@ -752,7 +752,7 @@ func.func @test_2(%item: memref<?x!sycl_item_2_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_24]] : i64
 // CHECK-NEXT:    }
 func.func @test_3(%item: memref<?x!sycl_item_3_>) -> i64 {
-  %0 = sycl.item.get_linear_id(%item) { ArgumentTypes = [memref<?x!sycl_item_3_>], FunctionName = @"get_linear_id", MangledFunctionName = @"get_linear_id", TypeName = @"item" }  : (memref<?x!sycl_item_3_>) -> i64
+  %0 = sycl.item.get_linear_id(%item) : (memref<?x!sycl_item_3_>) -> i64
   return %0 : i64
 }
 
@@ -774,7 +774,7 @@ func.func @test_3(%item: memref<?x!sycl_item_3_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
 // CHECK-NEXT:    }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_ {
-  %0 = sycl.nd_item.get_global_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_global_id", MangledFunctionName = @"get_global_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
+  %0 = sycl.nd_item.get_global_id(%nd) : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
   return %0 : !sycl_id_1_
 }
 
@@ -797,7 +797,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_ {
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:    }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
-  %0 = sycl.nd_item.get_global_id(%nd, %i) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>, i32], FunctionName = @"get_global_id", MangledFunctionName = @"get_global_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+  %0 = sycl.nd_item.get_global_id(%nd, %i) : (memref<?x!sycl_nd_item_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -835,7 +835,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : i64
 // CHECK-NEXT:    }
 func.func @test_1(%nd: memref<?x!sycl_nd_item_1_>) -> i64 {
-  %0 = sycl.nd_item.get_global_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_global_linear_id", MangledFunctionName = @"get_global_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> i64
+  %0 = sycl.nd_item.get_global_linear_id(%nd) : (memref<?x!sycl_nd_item_1_>) -> i64
   return %0 : i64
 }
 
@@ -852,7 +852,7 @@ func.func @test_1(%nd: memref<?x!sycl_nd_item_1_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_8]] : i64
 // CHECK-NEXT:    }
 func.func @test_2(%nd: memref<?x!sycl_nd_item_2_>) -> i64 {
-  %0 = sycl.nd_item.get_global_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_2_>], FunctionName = @"get_global_linear_id", MangledFunctionName = @"get_global_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_2_>) -> i64
+  %0 = sycl.nd_item.get_global_linear_id(%nd)  : (memref<?x!sycl_nd_item_2_>) -> i64
   return %0 : i64
 }
 
@@ -876,7 +876,7 @@ func.func @test_2(%nd: memref<?x!sycl_nd_item_2_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_15]] : i64
 // CHECK-NEXT:    }
 func.func @test_3(%nd: memref<?x!sycl_nd_item_3_>) -> i64 {
-  %0 = sycl.nd_item.get_global_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_3_>], FunctionName = @"get_global_linear_id", MangledFunctionName = @"get_global_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_3_>) -> i64
+  %0 = sycl.nd_item.get_global_linear_id(%nd) : (memref<?x!sycl_nd_item_3_>) -> i64
   return %0 : i64
 }
 
@@ -898,7 +898,7 @@ func.func @test_3(%nd: memref<?x!sycl_nd_item_3_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
 // CHECK-NEXT:    }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_ {
-  %0 = sycl.nd_item.get_local_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_local_id", MangledFunctionName = @"get_local_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
+  %0 = sycl.nd_item.get_local_id(%nd) : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
   return %0 : !sycl_id_1_
 }
 
@@ -921,7 +921,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_ {
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:    }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
-  %0 = sycl.nd_item.get_local_id(%nd, %i) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>, i32], FunctionName = @"get_local_id", MangledFunctionName = @"get_local_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+  %0 = sycl.nd_item.get_local_id(%nd, %i) : (memref<?x!sycl_nd_item_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -959,7 +959,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : i64
 // CHECK-NEXT:    }
 func.func @test_1(%nd: memref<?x!sycl_nd_item_1_>) -> i64 {
-  %0 = sycl.nd_item.get_local_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> i64
+  %0 = sycl.nd_item.get_local_linear_id(%nd) : (memref<?x!sycl_nd_item_1_>) -> i64
   return %0 : i64
 }
 
@@ -976,7 +976,7 @@ func.func @test_1(%nd: memref<?x!sycl_nd_item_1_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_8]] : i64
 // CHECK-NEXT:    }
 func.func @test_2(%nd: memref<?x!sycl_nd_item_2_>) -> i64 {
-  %0 = sycl.nd_item.get_local_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_2_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_2_>) -> i64
+  %0 = sycl.nd_item.get_local_linear_id(%nd) : (memref<?x!sycl_nd_item_2_>) -> i64
   return %0 : i64
 }
 
@@ -1000,7 +1000,7 @@ func.func @test_2(%nd: memref<?x!sycl_nd_item_2_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_15]] : i64
 // CHECK-NEXT:    }
 func.func @test_3(%nd: memref<?x!sycl_nd_item_3_>) -> i64 {
-  %0 = sycl.nd_item.get_local_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_3_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_3_>) -> i64
+  %0 = sycl.nd_item.get_local_linear_id(%nd) : (memref<?x!sycl_nd_item_3_>) -> i64
   return %0 : i64
 }
 
@@ -1039,7 +1039,7 @@ func.func @test_3(%nd: memref<?x!sycl_nd_item_3_>) -> i64 {
 // CHECK:           llvm.return %[[VAL_4]] : i64
 // CHECK:    }
 func.func @test_1(%nd: memref<?x!sycl_nd_item_1_>) -> i64 {
-  %0 = sycl.nd_item.get_group_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> i64
+  %0 = sycl.nd_item.get_group_linear_id(%nd) : (memref<?x!sycl_nd_item_1_>) -> i64
   return %0 : i64
 }
 
@@ -1057,7 +1057,7 @@ func.func @test_1(%nd: memref<?x!sycl_nd_item_1_>) -> i64 {
 // CHECK:           llvm.return %[[VAL_10]] : i64
 // CHECK:    }
 func.func @test_2(%nd: memref<?x!sycl_nd_item_2_>) -> i64 {
-  %0 = sycl.nd_item.get_group_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_2_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_2_>) -> i64
+  %0 = sycl.nd_item.get_group_linear_id(%nd) : (memref<?x!sycl_nd_item_2_>) -> i64
   return %0 : i64
 }
 
@@ -1082,7 +1082,7 @@ func.func @test_2(%nd: memref<?x!sycl_nd_item_2_>) -> i64 {
 // CHECK:           llvm.return %[[VAL_17]] : i64
 // CHECK:    }
 func.func @test_3(%nd: memref<?x!sycl_nd_item_3_>) -> i64 {
-  %0 = sycl.nd_item.get_group_linear_id(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_3_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_3_>) -> i64
+  %0 = sycl.nd_item.get_group_linear_id(%nd) : (memref<?x!sycl_nd_item_3_>) -> i64
   return %0 : i64
 }
 
@@ -1104,7 +1104,7 @@ func.func @test_3(%nd: memref<?x!sycl_nd_item_3_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.struct<"class.sycl::_V1::range.1", {{.*}}>
 // CHECK-NEXT:    }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_ {
-  %0 = sycl.nd_item.get_global_range(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_global_range", MangledFunctionName = @"get_global_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
+  %0 = sycl.nd_item.get_global_range(%nd) : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
@@ -1127,7 +1127,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_ {
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:    }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
-  %0 = sycl.nd_item.get_global_range(%nd, %i) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>, i32], FunctionName = @"get_global_range", MangledFunctionName = @"get_global_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+  %0 = sycl.nd_item.get_global_range(%nd, %i) : (memref<?x!sycl_nd_item_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -1149,7 +1149,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.struct<"class.sycl::_V1::group.1", {{.*}}>
 // CHECK-NEXT:    }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_group_1_ {
-  %0 = sycl.nd_item.get_group(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_group", MangledFunctionName = @"get_group", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_group_1_
+  %0 = sycl.nd_item.get_group(%nd) : (memref<?x!sycl_nd_item_1_>) -> !sycl_group_1_
   return %0 : !sycl_group_1_
 }
 
@@ -1172,7 +1172,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_group_1_ {
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:    }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
-  %0 = sycl.nd_item.get_group(%nd, %i) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>, i32], FunctionName = @"get_group", MangledFunctionName = @"get_group", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+  %0 = sycl.nd_item.get_group(%nd, %i) : (memref<?x!sycl_nd_item_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -1194,7 +1194,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.struct<"class.sycl::_V1::range.1", {{.*}}>
 // CHECK-NEXT:    }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_ {
-  %0 = sycl.nd_item.get_group_range(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_group_range", MangledFunctionName = @"get_group_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
+  %0 = sycl.nd_item.get_group_range(%nd) : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
@@ -1217,7 +1217,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_ {
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:    }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
-  %0 = sycl.nd_item.get_group_range(%nd, %i) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>, i32], FunctionName = @"get_group_range", MangledFunctionName = @"get_group_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+  %0 = sycl.nd_item.get_group_range(%nd, %i) : (memref<?x!sycl_nd_item_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -1239,7 +1239,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.struct<"class.sycl::_V1::range.1", {{.*}}>
 // CHECK-NEXT:    }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_ {
-  %0 = sycl.nd_item.get_local_range(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_local_range", MangledFunctionName = @"get_local_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
+  %0 = sycl.nd_item.get_local_range(%nd) : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
@@ -1262,7 +1262,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_ {
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:    }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
-  %0 = sycl.nd_item.get_local_range(%nd, %i) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>, i32], FunctionName = @"get_local_range", MangledFunctionName = @"get_local_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+  %0 = sycl.nd_item.get_local_range(%nd, %i) : (memref<?x!sycl_nd_item_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -1298,7 +1298,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_12]] : !llvm.struct<"class.sycl::_V1::nd_range.1", {{.*}}>
 // CHECK-NEXT:    }
 func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_nd_range_1_ {
-  %0 = sycl.nd_item.get_nd_range(%nd) { ArgumentTypes = [memref<?x!sycl_nd_item_1_>], FunctionName = @"get_nd_range", MangledFunctionName = @"get_nd_range", TypeName = @"nd_item" }  : (memref<?x!sycl_nd_item_1_>) -> !sycl_nd_range_1_
+  %0 = sycl.nd_item.get_nd_range(%nd) : (memref<?x!sycl_nd_item_1_>) -> !sycl_nd_range_1_
   return %0 : !sycl_nd_range_1_
 }
 
@@ -1315,7 +1315,7 @@ func.func @test(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_nd_range_1_ {
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
 // CHECK-NEXT:    }
 func.func @test(%group: memref<?x!sycl_group_1_>) -> !sycl_id_1_ {
-  %0 = sycl.group.get_group_id(%group) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_group_id", MangledFunctionName = @"get_group_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
+  %0 = sycl.group.get_group_id(%group) : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
   return %0 : !sycl_id_1_
 }
 
@@ -1333,7 +1333,7 @@ func.func @test(%group: memref<?x!sycl_group_1_>) -> !sycl_id_1_ {
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:    }
 func.func @test(%group: memref<?x!sycl_group_1_>, %i: i32) -> i64 {
-  %0 = sycl.group.get_group_id(%group, %i) { ArgumentTypes = [memref<?x!sycl_group_1_>, i32], FunctionName = @"get_group_id", MangledFunctionName = @"get_group_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>, i32) -> i64
+  %0 = sycl.group.get_group_id(%group, %i) : (memref<?x!sycl_group_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -1379,7 +1379,7 @@ module attributes {gpu.container} {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
     func.func @test(%group: memref<?x!sycl_group_3_>) -> !sycl_id_3_ {
-      %0 = sycl.group.get_local_id(%group) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_local_id", MangledFunctionName = @"get_local_id", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> !sycl_id_3_
+      %0 = sycl.group.get_local_id(%group) : (memref<?x!sycl_group_3_>) -> !sycl_id_3_
       return %0 : !sycl_id_3_
     }
   }
@@ -1424,7 +1424,7 @@ module attributes {gpu.container} {
 // CHECK:             llvm.return %[[VAL_23]] : i64
 // CHECK-NEXT:      }
     func.func @test(%group: memref<?x!sycl_group_1_>, %i: i32) -> i64 {
-      %0 = sycl.group.get_local_id(%group, %i) { ArgumentTypes = [memref<?x!sycl_group_1_>, i32], FunctionName = @"get_local_id", MangledFunctionName = @"get_local_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>, i32) -> i64
+      %0 = sycl.group.get_local_id(%group, %i) : (memref<?x!sycl_group_1_>, i32) -> i64
       return %0 : i64
     }
   }
@@ -1443,7 +1443,7 @@ module attributes {gpu.container} {
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.struct<"class.sycl::_V1::range.3", {{.*}}>
 // CHECK-NEXT:    }
 func.func @test(%group: memref<?x!sycl_group_3_>) -> !sycl_range_3_ {
-  %0 = sycl.group.get_local_range(%group) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_local_range", MangledFunctionName = @"get_local_range", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> !sycl_range_3_
+  %0 = sycl.group.get_local_range(%group) : (memref<?x!sycl_group_3_>) -> !sycl_range_3_
   return %0 : !sycl_range_3_
 }
 
@@ -1461,7 +1461,7 @@ func.func @test(%group: memref<?x!sycl_group_3_>) -> !sycl_range_3_ {
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : i64
 // CHECK-NEXT:    }
 func.func @test(%group: memref<?x!sycl_group_1_>, %i: i32) -> i64 {
-  %0 = sycl.group.get_local_range(%group, %i) { ArgumentTypes = [memref<?x!sycl_group_1_>, i32], FunctionName = @"get_local_range", MangledFunctionName = @"get_local_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>, i32) -> i64
+  %0 = sycl.group.get_local_range(%group, %i) : (memref<?x!sycl_group_1_>, i32) -> i64
   return %0 : i64
 }
 
@@ -1478,7 +1478,7 @@ func.func @test(%group: memref<?x!sycl_group_1_>, %i: i32) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.struct<"class.sycl::_V1::range.3", {{.*}}>
 // CHECK-NEXT:    }
 func.func @test(%group: memref<?x!sycl_group_3_>) -> !sycl_range_3_ {
-  %0 = sycl.group.get_max_local_range(%group) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_max_local_range", MangledFunctionName = @"get_max_local_range", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> !sycl_range_3_
+  %0 = sycl.group.get_max_local_range(%group) : (memref<?x!sycl_group_3_>) -> !sycl_range_3_
   return %0 : !sycl_range_3_
 }
 
@@ -1501,7 +1501,7 @@ func.func @test(%group: memref<?x!sycl_group_3_>) -> !sycl_range_3_ {
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : i64
 // CHECK-NEXT:    }
 func.func @test_1(%group: memref<?x!sycl_group_1_>) -> i64 {
-  %0 = sycl.group.get_group_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> i64
+  %0 = sycl.group.get_group_linear_id(%group) : (memref<?x!sycl_group_1_>) -> i64
   return %0 : i64
 }
 
@@ -1518,7 +1518,7 @@ func.func @test_1(%group: memref<?x!sycl_group_1_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_8]] : i64
 // CHECK-NEXT:    }
 func.func @test_2(%group: memref<?x!sycl_group_2_>) -> i64 {
-  %0 = sycl.group.get_group_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_2_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_2_>) -> i64
+  %0 = sycl.group.get_group_linear_id(%group) : (memref<?x!sycl_group_2_>) -> i64
   return %0 : i64
 }
 
@@ -1542,7 +1542,7 @@ func.func @test_2(%group: memref<?x!sycl_group_2_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_15]] : i64
 // CHECK-NEXT:    }
 func.func @test_3(%group: memref<?x!sycl_group_3_>) -> i64 {
-  %0 = sycl.group.get_group_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_group_linear_id", MangledFunctionName = @"get_group_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64
+  %0 = sycl.group.get_group_linear_id(%group) : (memref<?x!sycl_group_3_>) -> i64
   return %0 : i64
 }
 
@@ -1590,7 +1590,7 @@ module attributes {gpu.container} {
 // CHECK:             llvm.return %[[VAL_23]] : i64
 // CHECK-NEXT:     }
     func.func @test_1(%group: memref<?x!sycl_group_1_>) -> i64 {
-      %0 = sycl.group.get_local_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> i64
+      %0 = sycl.group.get_local_linear_id(%group) : (memref<?x!sycl_group_1_>) -> i64
       return %0 : i64
     }
 
@@ -1636,7 +1636,7 @@ module attributes {gpu.container} {
 // CHECK:             llvm.return %[[VAL_59]] : i64
 // CHECK-NEXT:      }
     func.func @test_2(%group: memref<?x!sycl_group_2_>) -> i64 {
-      %0 = sycl.group.get_local_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_2_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_2_>) -> i64
+      %0 = sycl.group.get_local_linear_id(%group) : (memref<?x!sycl_group_2_>) -> i64
       return %0 : i64
     }
 
@@ -1696,7 +1696,7 @@ module attributes {gpu.container} {
 // CHECK:             llvm.return %[[VAL_108]] : i64
 // CHECK-NEXT:      }
     func.func @test_3(%group: memref<?x!sycl_group_3_>) -> i64 {
-      %0 = sycl.group.get_local_linear_id(%group) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_local_linear_id", MangledFunctionName = @"get_local_linear_id", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64
+      %0 = sycl.group.get_local_linear_id(%group) : (memref<?x!sycl_group_3_>) -> i64
       return %0 : i64
     }
   }
@@ -1723,7 +1723,7 @@ module attributes {gpu.container} {
 // CHECK-NEXT:      llvm.return %[[VAL_4]] : i64
 // CHECK-NEXT:    }
 func.func @test_1(%group: memref<?x!sycl_group_1_>) -> i64 {
-  %0 = sycl.group.get_group_linear_range(%group) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_group_linear_range", MangledFunctionName = @"get_group_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> i64
+  %0 = sycl.group.get_group_linear_range(%group) : (memref<?x!sycl_group_1_>) -> i64
   return %0 : i64
 }
 
@@ -1739,7 +1739,7 @@ func.func @test_1(%group: memref<?x!sycl_group_1_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_7]] : i64
 // CHECK-NEXT:    }
 func.func @test_2(%group: memref<?x!sycl_group_2_>) -> i64 {
-  %0 = sycl.group.get_group_linear_range(%group) { ArgumentTypes = [memref<?x!sycl_group_2_>], FunctionName = @"get_group_linear_range", MangledFunctionName = @"get_group_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_2_>) -> i64
+  %0 = sycl.group.get_group_linear_range(%group) : (memref<?x!sycl_group_2_>) -> i64
   return %0 : i64
 }
 
@@ -1758,7 +1758,7 @@ func.func @test_2(%group: memref<?x!sycl_group_2_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_10]] : i64
 // CHECK-NEXT:    }
 func.func @test_3(%group: memref<?x!sycl_group_3_>) -> i64 {
-  %0 = sycl.group.get_group_linear_range(%group) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_group_linear_range", MangledFunctionName = @"get_group_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64
+  %0 = sycl.group.get_group_linear_range(%group) : (memref<?x!sycl_group_3_>) -> i64
   return %0 : i64
 }
 
@@ -1783,7 +1783,7 @@ func.func @test_3(%group: memref<?x!sycl_group_3_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_4]] : i64
 // CHECK-NEXT:    }
 func.func @test_1(%group: memref<?x!sycl_group_1_>) -> i64 {
-  %0 = sycl.group.get_local_linear_range(%group) { ArgumentTypes = [memref<?x!sycl_group_1_>], FunctionName = @"get_local_linear_range", MangledFunctionName = @"get_local_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_1_>) -> i64
+  %0 = sycl.group.get_local_linear_range(%group) : (memref<?x!sycl_group_1_>) -> i64
   return %0 : i64
 }
 
@@ -1799,7 +1799,7 @@ func.func @test_1(%group: memref<?x!sycl_group_1_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_7]] : i64
 // CHECK-NEXT:    }
 func.func @test_2(%group: memref<?x!sycl_group_2_>) -> i64 {
-  %0 = sycl.group.get_local_linear_range(%group) { ArgumentTypes = [memref<?x!sycl_group_2_>], FunctionName = @"get_local_linear_range", MangledFunctionName = @"get_local_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_2_>) -> i64
+  %0 = sycl.group.get_local_linear_range(%group) : (memref<?x!sycl_group_2_>) -> i64
   return %0 : i64
 }
 
@@ -1818,6 +1818,6 @@ func.func @test_2(%group: memref<?x!sycl_group_2_>) -> i64 {
 // CHECK-NEXT:      llvm.return %[[VAL_10]] : i64
 // CHECK-NEXT:    }
 func.func @test_3(%group: memref<?x!sycl_group_3_>) -> i64 {
-  %0 = sycl.group.get_local_linear_range(%group) { ArgumentTypes = [memref<?x!sycl_group_3_>], FunctionName = @"get_local_linear_range", MangledFunctionName = @"get_local_linear_range", TypeName = @"group" }  : (memref<?x!sycl_group_3_>) -> i64
+  %0 = sycl.group.get_local_linear_range(%group) : (memref<?x!sycl_group_3_>) -> i64
   return %0 : i64
 }

--- a/mlir-sycl/test/Conversion/SYCLToSPIRV/grid-ops.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToSPIRV/grid-ops.mlir
@@ -29,7 +29,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:            %[[VAL_5:.*]] = arith.constant 0 : i32
     // CHECK-NEXT:            %[[VAL_6:.*]] = spirv.CompositeExtract %[[VAL_1]][0 : i32] : vector<3xi32>
     // CHECK-NEXT:            %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-    // CHECK-NEXT:            %[[VAL_8:.*]] = sycl.id.get %[[VAL_2]][%[[VAL_5]]] {ArgumentTypes = [memref<1x!sycl_id_1_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_1_>, i32) -> memref<1xi64>
+    // CHECK-NEXT:            %[[VAL_8:.*]] = sycl.id.get %[[VAL_2]][%[[VAL_5]]] : (memref<1x!sycl_id_1_>, i32) -> memref<1xi64>
     // CHECK-NEXT:            memref.store %[[VAL_7]], %[[VAL_8]]{{\[}}%[[VAL_3]]] : memref<1xi64>
     // CHECK-NEXT:            %[[VAL_4:.*]] = memref.load %[[VAL_2]]{{\[}}%[[VAL_3]]] : memref<1x!sycl_id_1_>
     // CHECK-NEXT:            gpu.return
@@ -48,12 +48,12 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:            %[[VAL_29:.*]] = arith.constant 0 : i32
     // CHECK-NEXT:            %[[VAL_30:.*]] = spirv.CompositeExtract %[[VAL_25]][1 : i32] : vector<3xi32>
     // CHECK-NEXT:            %[[VAL_31:.*]] = arith.extsi %[[VAL_30]] : i32 to i64
-    // CHECK-NEXT:            %[[VAL_32:.*]] = sycl.range.get %[[VAL_26]][%[[VAL_29]]] {ArgumentTypes = [memref<1x!sycl_range_2_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_2_>, i32) -> memref<2xi64>
+    // CHECK-NEXT:            %[[VAL_32:.*]] = sycl.range.get %[[VAL_26]][%[[VAL_29]]] : (memref<1x!sycl_range_2_>, i32) -> memref<2xi64>
     // CHECK-NEXT:            memref.store %[[VAL_31]], %[[VAL_32]]{{\[}}%[[VAL_27]]] : memref<2xi64>
     // CHECK-NEXT:            %[[VAL_33:.*]] = arith.constant 1 : i32
     // CHECK-NEXT:            %[[VAL_34:.*]] = spirv.CompositeExtract %[[VAL_25]][0 : i32] : vector<3xi32>
     // CHECK-NEXT:            %[[VAL_35:.*]] = arith.extsi %[[VAL_34]] : i32 to i64
-    // CHECK-NEXT:            %[[VAL_36:.*]] = sycl.range.get %[[VAL_26]][%[[VAL_33]]] {ArgumentTypes = [memref<1x!sycl_range_2_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_2_>, i32) -> memref<2xi64>
+    // CHECK-NEXT:            %[[VAL_36:.*]] = sycl.range.get %[[VAL_26]][%[[VAL_33]]] : (memref<1x!sycl_range_2_>, i32) -> memref<2xi64>
     // CHECK-NEXT:            memref.store %[[VAL_35]], %[[VAL_36]]{{\[}}%[[VAL_27]]] : memref<2xi64>
     // CHECK-NEXT:            %[[VAL_28:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_27]]] : memref<1x!sycl_range_2_>
     // CHECK-NEXT:            gpu.return
@@ -72,7 +72,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:            %[[VAL_5:.*]] = arith.constant 0 : i32
     // CHECK-NEXT:            %[[VAL_6:.*]] = spirv.CompositeExtract %[[VAL_1]][0 : i32] : vector<3xi32>
     // CHECK-NEXT:            %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-    // CHECK-NEXT:            %[[VAL_8:.*]] = sycl.id.get %[[VAL_2]][%[[VAL_5]]] {ArgumentTypes = [memref<1x!sycl_id_1_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_1_>, i32) -> memref<1xi64>
+    // CHECK-NEXT:            %[[VAL_8:.*]] = sycl.id.get %[[VAL_2]][%[[VAL_5]]] : (memref<1x!sycl_id_1_>, i32) -> memref<1xi64>
     // CHECK-NEXT:            memref.store %[[VAL_7]], %[[VAL_8]]{{\[}}%[[VAL_3]]] : memref<1xi64>
     // CHECK-NEXT:            %[[VAL_4:.*]] = memref.load %[[VAL_2]]{{\[}}%[[VAL_3]]] : memref<1x!sycl_id_1_>
     // CHECK-NEXT:            gpu.return
@@ -91,7 +91,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:            %[[VAL_5:.*]] = arith.constant 0 : i32
     // CHECK-NEXT:            %[[VAL_6:.*]] = spirv.CompositeExtract %[[VAL_1]][0 : i32] : vector<3xi32>
     // CHECK-NEXT:            %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-    // CHECK-NEXT:            %[[VAL_8:.*]] = sycl.range.get %[[VAL_2]][%[[VAL_5]]] {ArgumentTypes = [memref<1x!sycl_range_1_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_1_>, i32) -> memref<1xi64>
+    // CHECK-NEXT:            %[[VAL_8:.*]] = sycl.range.get %[[VAL_2]][%[[VAL_5]]] : (memref<1x!sycl_range_1_>, i32) -> memref<1xi64>
     // CHECK-NEXT:            memref.store %[[VAL_7]], %[[VAL_8]]{{\[}}%[[VAL_3]]] : memref<1xi64>
     // CHECK-NEXT:            %[[VAL_4:.*]] = memref.load %[[VAL_2]]{{\[}}%[[VAL_3]]] : memref<1x!sycl_range_1_>
     // CHECK-NEXT:            gpu.return
@@ -110,7 +110,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:            %[[VAL_5:.*]] = arith.constant 0 : i32
     // CHECK-NEXT:            %[[VAL_6:.*]] = spirv.CompositeExtract %[[VAL_1]][0 : i32] : vector<3xi32>
     // CHECK-NEXT:            %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-    // CHECK-NEXT:            %[[VAL_8:.*]] = sycl.range.get %[[VAL_2]][%[[VAL_5]]] {ArgumentTypes = [memref<1x!sycl_range_1_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_1_>, i32) -> memref<1xi64>
+    // CHECK-NEXT:            %[[VAL_8:.*]] = sycl.range.get %[[VAL_2]][%[[VAL_5]]] : (memref<1x!sycl_range_1_>, i32) -> memref<1xi64>
     // CHECK-NEXT:            memref.store %[[VAL_7]], %[[VAL_8]]{{\[}}%[[VAL_3]]] : memref<1xi64>
     // CHECK-NEXT:            %[[VAL_4:.*]] = memref.load %[[VAL_2]]{{\[}}%[[VAL_3]]] : memref<1x!sycl_range_1_>
     // CHECK-NEXT:            gpu.return
@@ -129,17 +129,17 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:             %[[VAL_109:.*]] = arith.constant 0 : i32
     // CHECK-NEXT:             %[[VAL_110:.*]] = spirv.CompositeExtract %[[VAL_106]][2 : i32] : vector<3xi32>
     // CHECK-NEXT:             %[[VAL_111:.*]] = arith.extsi %[[VAL_110]] : i32 to i64
-    // CHECK-NEXT:             %[[VAL_112:.*]] = sycl.range.get %[[VAL_107]]{{\[}}%[[VAL_109]]] {ArgumentTypes = [memref<1x!sycl_range_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64>
+    // CHECK-NEXT:             %[[VAL_112:.*]] = sycl.range.get %[[VAL_107]]{{\[}}%[[VAL_109]]] : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64>
     // CHECK-NEXT:             memref.store %[[VAL_111]], %[[VAL_112]]{{\[}}%[[VAL_108]]] : memref<3xi64>
     // CHECK-NEXT:             %[[VAL_113:.*]] = arith.constant 1 : i32
     // CHECK-NEXT:             %[[VAL_114:.*]] = spirv.CompositeExtract %[[VAL_106]][1 : i32] : vector<3xi32>
     // CHECK-NEXT:             %[[VAL_115:.*]] = arith.extsi %[[VAL_114]] : i32 to i64
-    // CHECK-NEXT:             %[[VAL_116:.*]] = sycl.range.get %[[VAL_107]]{{\[}}%[[VAL_113]]] {ArgumentTypes = [memref<1x!sycl_range_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64>
+    // CHECK-NEXT:             %[[VAL_116:.*]] = sycl.range.get %[[VAL_107]]{{\[}}%[[VAL_113]]] : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64>
     // CHECK-NEXT:             memref.store %[[VAL_115]], %[[VAL_116]]{{\[}}%[[VAL_108]]] : memref<3xi64>
     // CHECK-NEXT:             %[[VAL_117:.*]] = arith.constant 2 : i32
     // CHECK-NEXT:             %[[VAL_118:.*]] = spirv.CompositeExtract %[[VAL_106]][0 : i32] : vector<3xi32>
     // CHECK-NEXT:             %[[VAL_119:.*]] = arith.extsi %[[VAL_118]] : i32 to i64
-    // CHECK-NEXT:             %[[VAL_120:.*]] = sycl.range.get %[[VAL_107]]{{\[}}%[[VAL_117]]] {ArgumentTypes = [memref<1x!sycl_range_3_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @range} : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64>
+    // CHECK-NEXT:             %[[VAL_120:.*]] = sycl.range.get %[[VAL_107]]{{\[}}%[[VAL_117]]] : (memref<1x!sycl_range_3_>, i32) -> memref<3xi64>
     // CHECK-NEXT:             memref.store %[[VAL_119]], %[[VAL_120]]{{\[}}%[[VAL_108]]] : memref<3xi64>
     // CHECK-NEXT:             %[[VAL_121:.*]] = memref.load %[[VAL_107]]{{\[}}%[[VAL_108]]] : memref<1x!sycl_range_3_>
     // CHECK-NEXT:             gpu.return
@@ -158,7 +158,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:            %[[VAL_5:.*]] = arith.constant 0 : i32
     // CHECK-NEXT:            %[[VAL_6:.*]] = spirv.CompositeExtract %[[VAL_1]][0 : i32] : vector<3xi32>
     // CHECK-NEXT:            %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-    // CHECK-NEXT:            %[[VAL_8:.*]] = sycl.id.get %[[VAL_2]][%[[VAL_5]]] {ArgumentTypes = [memref<1x!sycl_id_1_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_1_>, i32) -> memref<1xi64>
+    // CHECK-NEXT:            %[[VAL_8:.*]] = sycl.id.get %[[VAL_2]][%[[VAL_5]]] : (memref<1x!sycl_id_1_>, i32) -> memref<1xi64>
     // CHECK-NEXT:            memref.store %[[VAL_7]], %[[VAL_8]]{{\[}}%[[VAL_3]]] : memref<1xi64>
     // CHECK-NEXT:            %[[VAL_4:.*]] = memref.load %[[VAL_2]]{{\[}}%[[VAL_3]]] : memref<1x!sycl_id_1_>
     // CHECK-NEXT:            gpu.return
@@ -177,7 +177,7 @@ module attributes {gpu.container_module} {
     // CHECK-NEXT:            %[[VAL_5:.*]] = arith.constant 0 : i32
     // CHECK-NEXT:            %[[VAL_6:.*]] = spirv.CompositeExtract %[[VAL_1]][0 : i32] : vector<3xi32>
     // CHECK-NEXT:            %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
-    // CHECK-NEXT:            %[[VAL_8:.*]] = sycl.id.get %[[VAL_2]][%[[VAL_5]]] {ArgumentTypes = [memref<1x!sycl_id_1_>, i32], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_1_>, i32) -> memref<1xi64>
+    // CHECK-NEXT:            %[[VAL_8:.*]] = sycl.id.get %[[VAL_2]][%[[VAL_5]]] : (memref<1x!sycl_id_1_>, i32) -> memref<1xi64>
     // CHECK-NEXT:            memref.store %[[VAL_7]], %[[VAL_8]]{{\[}}%[[VAL_3]]] : memref<1xi64>
     // CHECK-NEXT:            %[[VAL_4:.*]] = memref.load %[[VAL_2]]{{\[}}%[[VAL_3]]] : memref<1x!sycl_id_1_>
     // CHECK-NEXT:            gpu.return

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -79,7 +79,7 @@ func.func @test_non_memref_arg_constructor(%range: !sycl_range_1_) {
 // -----
 
 func.func @test_non_sycl_arg_constructor(%i: memref<1xi32>) {
-  // expected-error @+1 {{'sycl.constructor' op operand #0 must be memref}}  
+  // expected-error @+1 {{'sycl.constructor' op operand #0 must be memref}}
   sycl.constructor @range(%i) {MangledFunctionName = @rangev} : (memref<1xi32>)
 }
 
@@ -92,7 +92,7 @@ func.func @test_non_sycl_arg_constructor(%i: memref<1xi32>) {
 
 func.func @test_accessor_get_pointer(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi64, 1> {
   // expected-error @+1 {{'sycl.accessor.get_pointer' op Expecting a reference to this accessor's value type}}
-  %0 = sycl.accessor.get_pointer(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>], FunctionName = @"get_pointer", MangledFunctionName = @"get_pointer", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi64, 1>
+  %0 = sycl.accessor.get_pointer(%acc) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi64, 1>
   return %0 : memref<?xi64, 1>
 }
 
@@ -106,7 +106,7 @@ func.func @test_accessor_get_pointer(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>)
 
 func.func @test_accessor_get_range(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_2_ {
   // expected-error @+1 {{'sycl.accessor.get_range' op Both the result and the accessor must have the same number of dimensions, but the accessor has 1 dimension(s) and the result has 2 dimension(s)}}
-  %0 = sycl.accessor.get_range(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb>], FunctionName = @"get_range", MangledFunctionName = @"get_range", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_2_
+  %0 = sycl.accessor.get_range(%acc) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_2_
   return %0 : !sycl_range_2_
 }
 
@@ -119,13 +119,167 @@ func.func @test_accessor_get_range(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -
 !sycl_atomic_i64_glo = !sycl.atomic<[i64, global], (memref<?xi64, 1>)>
 
 func.func @test_accessor_subscript_atomic(
-  %acc: memref<?x!sycl_accessor_1_i32_ato_gb>, 
+  %acc: memref<?x!sycl_accessor_1_i32_ato_gb>,
   %idx: memref<?x!sycl_id_1_>) -> !sycl_atomic_i64_glo {
   // expected-error @+1 {{'sycl.accessor.subscript' op Expecting a reference to this accessor's value type}}
-  %0 = sycl.accessor.subscript %acc[%idx] { 
-        ArgumentTypes = [memref<?x!sycl_accessor_1_i32_ato_gb>, 
-                          memref<?x!sycl_id_1_>], 
-        FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_1_i32_ato_gb>, 
-                                memref<?x!sycl_id_1_>) -> !sycl_atomic_i64_glo
+  %0 = sycl.accessor.subscript %acc[%idx]
+      : (memref<?x!sycl_accessor_1_i32_ato_gb>, memref<?x!sycl_id_1_>)
+      -> !sycl_atomic_i64_glo
   return %0 : !sycl_atomic_i64_glo
+}
+
+// -----
+
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+!sycl_item_base_2_ = !sycl.item_base<[2, false], (!sycl_range_2_, !sycl_id_2_)>
+!sycl_item_2_ = !sycl.item<[2, false], (!sycl_item_base_2_)>
+
+func.func @test_get_id_bad_dimensions(%item: memref<?x!sycl_item_2_>) -> i64 {
+  // expected-error @below {{'sycl.item.get_id' op operand 0 must have a single dimension to be passed as the single argument to this operation}}
+  %0 = sycl.item.get_id(%item) : (memref<?x!sycl_item_2_>) -> i64
+  return %0 : i64
+}
+
+// -----
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_item_base_1_ = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, false], (!sycl_item_base_1_)>
+
+func.func @test_get_id_diff_dim(%item: memref<?x!sycl_item_1_>) -> !sycl_id_2_ {
+  // expected-error @below {{'sycl.item.get_id' op base type and return type dimensions mismatch: 1 vs 2}}
+  %0 = sycl.item.get_id(%item) : (memref<?x!sycl_item_1_>) -> !sycl_id_2_
+  return %0 : !sycl_id_2_
+}
+
+// -----
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_item_base_1_ = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, false], (!sycl_item_base_1_)>
+
+func.func @test_get_id_bad_type(%item: memref<?x!sycl_item_1_>, %i: i32) -> !sycl_id_1_ {
+  // expected-error @below {{'sycl.item.get_id' op must be passed a single argument in order to define an id value}}
+  %0 = sycl.item.get_id(%item, %i) : (memref<?x!sycl_item_1_>, i32) -> !sycl_id_1_
+  return %0 : !sycl_id_1_
+}
+
+// -----
+
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64>)>)>
+
+func.func @test_get_component_bad_dimensions(%id: memref<?x!sycl_id_3_>) -> i64 {
+  // expected-error @below {{'sycl.id.get' op operand 0 must have a single dimension to be passed as the single argument to this operation}}
+  %0 = sycl.id.get %id[] : (memref<?x!sycl_id_3_>) -> i64
+  return %0 : i64
+}
+
+// -----
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+
+func.func @test_get_component_bad_type(%id: memref<?x!sycl_id_1_>) -> memref<?xi64> {
+  // expected-error @below {{'sycl.id.get' op must return a scalar type when a single argument is provided}}
+  %0 = sycl.id.get %id[] : (memref<?x!sycl_id_1_>) -> memref<?xi64>
+  return %0 : memref<?xi64>
+}
+
+// -----
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_item_base_1_ = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, false], (!sycl_item_base_1_)>
+
+func.func @test_get_range_bad_scalar_type(%item: memref<?x!sycl_item_1_>) -> i64 {
+  // expected-error @below {{'sycl.item.get_range' op expecting range result type. Got 'i64'}}
+  %0 = sycl.item.get_range(%item) : (memref<?x!sycl_item_1_>) -> i64
+  return %0 : i64
+}
+
+// -----
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+!sycl_item_base_1_ = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, false], (!sycl_item_base_1_)>
+
+func.func @test_get_range_diff_dimensions(%item: memref<?x!sycl_item_1_>) -> !sycl_range_2_ {
+  // expected-error @below {{'sycl.item.get_range' op base type and return type dimensions mismatch: 1 vs 2}}
+  %0 = sycl.item.get_range(%item) : (memref<?x!sycl_item_1_>) -> !sycl_range_2_
+  return %0 : !sycl_range_2_
+}
+
+// -----
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+!sycl_item_base_1_ = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, false], (!sycl_item_base_1_)>
+
+func.func @test_get_range_bad_ret_type(%item: memref<?x!sycl_item_1_>, %i: i32) -> !sycl_range_1_ {
+  // expected-error @below {{'sycl.item.get_range' op expecting an I64 result type. Got '!sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>'}}
+  %0 = sycl.item.get_range(%item, %i) : (memref<?x!sycl_item_1_>, i32) -> !sycl_range_1_
+  return %0 : !sycl_range_1_
+}
+
+// -----
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
+!sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
+!sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
+
+func.func @test_get_group_bad_scalar_type(%nd: memref<?x!sycl_nd_item_1_>) -> i64 {
+  // expected-error @below {{'sycl.nd_item.get_group' op expecting group result type. Got 'i64'}}
+  %0 = sycl.nd_item.get_group(%nd) : (memref<?x!sycl_nd_item_1_>) -> i64
+  return %0 : i64
+}
+
+// -----
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
+!sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
+!sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_group_2_ = !sycl.group<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
+
+func.func @test_get_group_diff_dimensions(%nd: memref<?x!sycl_nd_item_1_>) -> !sycl_group_2_ {
+  // expected-error @below {{'sycl.nd_item.get_group' op base type and return type dimensions mismatch: 1 vs 2}}
+  %0 = sycl.nd_item.get_group(%nd) : (memref<?x!sycl_nd_item_1_>) -> !sycl_group_2_
+  return %0 : !sycl_group_2_
+}
+
+// -----
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_item_base_1_ = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
+!sycl_item_base_1_1 = !sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
+!sycl_item_1_1_ = !sycl.item<[1, false], (!sycl_item_base_1_1)>
+!sycl_group_1_ = !sycl.group<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+!sycl_nd_item_1_ = !sycl.nd_item<[1], (!sycl_item_1_, !sycl_item_1_1_, !sycl_group_1_)>
+
+func.func @test_get_group_bad_ret_type(%nd: memref<?x!sycl_nd_item_1_>, %i: i32) -> !sycl_group_1_ {
+  // expected-error @below {{'sycl.nd_item.get_group' op expecting an I64 result type. Got '!sycl.group<[1], (!sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>, !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>, !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>, !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>)>'}}
+  %0 = sycl.nd_item.get_group(%nd, %i) : (memref<?x!sycl_nd_item_1_>, i32) -> !sycl_group_1_
+  return %0 : !sycl_group_1_
 }

--- a/mlir-sycl/test/Dialect/SYCL/ops.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/ops.mlir
@@ -179,13 +179,13 @@ func.func @test_sub_group_local_id() -> i32 {
 
 // CHECK-LABEL: test_accessor_get_pointer
 func.func @test_accessor_get_pointer(%acc: memref<?x!sycl_accessor_1_i32_w_gb>) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.get_pointer(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_w_gb>], FunctionName = @"get_pointer", MangledFunctionName = @"get_pointer", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_w_gb>) -> memref<?xi32, 1>
+  %0 = sycl.accessor.get_pointer(%acc) : (memref<?x!sycl_accessor_1_i32_w_gb>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
 // CHECK-LABEL: test_accessor_get_range
 func.func @test_accessor_get_range(%acc: memref<?x!sycl_accessor_1_i32_w_gb>) -> !sycl_range_1_ {
-  %0 = sycl.accessor.get_range(%acc) { ArgumentTypes = [memref<?x!sycl_accessor_1_i32_w_gb>], FunctionName = @"get_range", MangledFunctionName = @"get_range", TypeName = @"accessor" }  : (memref<?x!sycl_accessor_1_i32_w_gb>) -> !sycl_range_1_
+  %0 = sycl.accessor.get_range(%acc) : (memref<?x!sycl_accessor_1_i32_w_gb>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
@@ -193,10 +193,8 @@ func.func @test_accessor_get_range(%acc: memref<?x!sycl_accessor_1_i32_w_gb>) ->
 func.func @test_accessor_subscript_atomic(
   %acc: memref<?x!sycl_accessor_1_i32_ato_gb>, 
   %idx: memref<?x!sycl_id_1_>) -> !sycl_atomic_i32_glo {
-  %0 = sycl.accessor.subscript %acc[%idx] { 
-        ArgumentTypes = [memref<?x!sycl_accessor_1_i32_ato_gb>, 
-                          memref<?x!sycl_id_1_>], 
-        FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @"id" }  : (memref<?x!sycl_accessor_1_i32_ato_gb>, 
-                                memref<?x!sycl_id_1_>) -> !sycl_atomic_i32_glo
+  %0 = sycl.accessor.subscript %acc[%idx]
+      : (memref<?x!sycl_accessor_1_i32_ato_gb>, memref<?x!sycl_id_1_>)
+      -> !sycl_atomic_i32_glo
   return %0 : !sycl_atomic_i32_glo
 }

--- a/mlir-sycl/test/Transforms/inliner.mlir
+++ b/mlir-sycl/test/Transforms/inliner.mlir
@@ -181,7 +181,7 @@ gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
 // ALWAYS-INLINE:           %[[VAL_1:.*]] = arith.constant 1 : i32
 // ALWAYS-INLINE:           %[[VAL_2:.*]] = sycl.call @inline_hint_callee_() {MangledFunctionName = @inline_hint_callee, TypeName = @A} : () -> i32
 // ALWAYS-INLINE:           call @foo(%[[VAL_0]], %[[VAL_1]]) : (memref<?x!sycl_id_1_>, i32) -> ()
-// ALWAYS-INLINE:           %[[VAL_3:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_1]]] {ArgumentTypes = [memref<?x!sycl_id_1_, 4>, i32], FunctionName = @get, MangledFunctionName = @get, TypeName = @id} : (memref<?x!sycl_id_1_>, i32) -> i64
+// ALWAYS-INLINE:           %[[VAL_3:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_1]]] : (memref<?x!sycl_id_1_>, i32) -> i64
 // ALWAYS-INLINE:           return %[[VAL_2]], %[[VAL_3]] : i32, i64
 // ALWAYS-INLINE:         }
 
@@ -192,7 +192,7 @@ gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
 // INLINE:           %[[VAL_5:.*]] = arith.addi %[[VAL_3]], %[[VAL_4]] : i32
 // INLINE:           %[[VAL_6:.*]] = arith.addi %[[VAL_2]], %[[VAL_5]] : i32
 // INLINE:           call @foo(%[[VAL_0]], %[[VAL_1]]) : (memref<?x!sycl_id_1_>, i32) -> ()
-// INLINE:           %[[VAL_7:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_1]]] {ArgumentTypes = [memref<?x!sycl_id_1_, 4>, i32], FunctionName = @get, MangledFunctionName = @get, TypeName = @id} : (memref<?x!sycl_id_1_>, i32) -> i64
+// INLINE:           %[[VAL_7:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_1]]] : (memref<?x!sycl_id_1_>, i32) -> i64
 // INLINE:           return %[[VAL_6]], %[[VAL_7]] : i32, i64
 // INLINE:         }
 
@@ -206,7 +206,7 @@ gpu.func @gpu_func_callee() -> i32 attributes {passthrough = ["alwaysinline"]} {
 // AGGRESSIVE:           %[[VAL_5:.*]] = arith.addi %[[VAL_3]], %[[VAL_4]] : i32
 // AGGRESSIVE:           %[[VAL_6:.*]] = arith.addi %[[VAL_2]], %[[VAL_5]] : i32
 // AGGRESSIVE:           call @foo(%[[VAL_0]], %[[VAL_1]]) : (memref<?x!sycl_id_1_>, i32) -> ()
-// AGGRESSIVE:           %[[VAL_7:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_1]]] {ArgumentTypes = [memref<?x!sycl_id_1_, 4>, i32], FunctionName = @get, MangledFunctionName = @get, TypeName = @id} : (memref<?x!sycl_id_1_>, i32) -> i64
+// AGGRESSIVE:           %[[VAL_7:.*]] = sycl.id.get %[[VAL_0]]{{\[}}%[[VAL_1]]] : (memref<?x!sycl_id_1_>, i32) -> i64
 // AGGRESSIVE:           return %[[VAL_6]], %[[VAL_7]] : i32, i64
 // AGGRESSIVE:         }
 
@@ -243,6 +243,6 @@ func.func @main(%id: memref<?x!sycl_id_1_>) -> (i32, i64) {
   %c1_i32 = arith.constant 1 : i32
   %res1 = sycl.call @inline_hint_callee_() {MangledFunctionName = @inline_hint_callee, TypeName = @A} : () -> i32    
   sycl.constructor @id(%id, %c1_i32) {MangledFunctionName = @id} : (memref<?x!sycl_id_1_>, i32)
-  %res2 = sycl.id.get %id[%c1_i32] {ArgumentTypes = [memref<?x!sycl_id_1_, 4>, i32], FunctionName = @get, MangledFunctionName = @get, TypeName = @id} : (memref<?x!sycl_id_1_>, i32) -> i64
+  %res2 = sycl.id.get %id[%c1_i32] : (memref<?x!sycl_id_1_>, i32) -> i64
   return %res1, %res2 : i32, i64
 }

--- a/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
@@ -521,31 +521,13 @@ void LoopTools::versionLoop(LoopLikeOpInterface loop,
 // VersionConditionBuilder
 //===----------------------------------------------------------------------===//
 
-template <typename OpTy>
-static OpTy createMethodOp(OpBuilder builder, Location loc, Type resTy,
-                           ValueRange arguments, StringRef functionName,
-                           StringRef typeName) {
-  NamedAttrList attrs;
-  SmallVector<Type> argumentTypes;
-  for (Value argument : arguments)
-    argumentTypes.push_back(argument.getType());
-  attrs.set(sycl::SYCLDialect::getArgumentTypesAttrName(),
-            builder.getTypeArrayAttr(argumentTypes));
-  attrs.set(sycl::SYCLDialect::getFunctionNameAttrName(),
-            FlatSymbolRefAttr::get(builder.getStringAttr(functionName)));
-  attrs.set(sycl::SYCLDialect::getTypeNameAttrName(),
-            FlatSymbolRefAttr::get(builder.getStringAttr(typeName)));
-  return builder.create<OpTy>(loc, resTy, ValueRange(arguments), attrs);
-}
-
 static sycl::SYCLIDGetOp createSYCLIDGetOp(TypedValue<MemRefType> id,
                                            unsigned index, OpBuilder builder,
                                            Location loc) {
   const Value indexOp = builder.create<arith::ConstantIntOp>(loc, index, 32);
   const auto resTy = builder.getIndexType();
-  return createMethodOp<sycl::SYCLIDGetOp>(
-      builder, loc, MemRefType::get(ShapedType::kDynamic, resTy), {id, indexOp},
-      "operator[]", "id");
+  return builder.create<sycl::SYCLIDGetOp>(
+      loc, MemRefType::get(ShapedType::kDynamic, resTy), id, indexOp);
 }
 
 static sycl::SYCLRangeGetOp createSYCLRangeGetOp(TypedValue<MemRefType> range,
@@ -554,8 +536,7 @@ static sycl::SYCLRangeGetOp createSYCLRangeGetOp(TypedValue<MemRefType> range,
                                                  Location loc) {
   const Value indexOp = builder.create<arith::ConstantIntOp>(loc, index, 32);
   const auto resTy = builder.getIndexType();
-  return createMethodOp<sycl::SYCLRangeGetOp>(builder, loc, resTy,
-                                              {range, indexOp}, "get", "range");
+  return builder.create<sycl::SYCLRangeGetOp>(loc, resTy, range, indexOp);
 }
 
 static sycl::SYCLAccessorGetRangeOp
@@ -564,8 +545,7 @@ createSYCLAccessorGetRangeOp(sycl::AccessorPtrValue accessor, OpBuilder builder,
   const sycl::AccessorType accTy = accessor.getAccessorType();
   const auto rangeTy = cast<sycl::RangeType>(
       cast<sycl::AccessorImplDeviceType>(accTy.getBody()[0]).getBody()[1]);
-  return createMethodOp<sycl::SYCLAccessorGetRangeOp>(
-      builder, loc, rangeTy, accessor, "get_range", "accessor");
+  return builder.create<sycl::SYCLAccessorGetRangeOp>(loc, rangeTy, accessor);
 }
 
 static sycl::SYCLAccessorSubscriptOp
@@ -577,8 +557,7 @@ createSYCLAccessorSubscriptOp(sycl::AccessorPtrValue accessor,
   const auto MT = MemRefType::get(
       ShapedType::kDynamic, accTy.getType(), MemRefLayoutAttrInterface(),
       builder.getI64IntegerAttr(targetToAddressSpace(accTy.getTargetMode())));
-  return createMethodOp<sycl::SYCLAccessorSubscriptOp>(
-      builder, loc, MT, {accessor, id}, "operator[]", "accessor");
+  return builder.create<sycl::SYCLAccessorSubscriptOp>(loc, MT, accessor, id);
 }
 
 static sycl::SYCLAccessorGetPointerOp
@@ -588,8 +567,7 @@ createSYCLAccessorGetPointerOp(sycl::AccessorPtrValue accessor,
   const auto MT = MemRefType::get(
       ShapedType::kDynamic, accTy.getType(), MemRefLayoutAttrInterface(),
       builder.getI64IntegerAttr(targetToAddressSpace(accTy.getTargetMode())));
-  return createMethodOp<sycl::SYCLAccessorGetPointerOp>(
-      builder, loc, MT, accessor, "get_pointer", "accessor");
+  return builder.create<sycl::SYCLAccessorGetPointerOp>(loc, MT, accessor);
 }
 
 static Value getSYCLAccessorBegin(sycl::AccessorPtrValue accessor,

--- a/polygeist/test/polygeist-opt/licm.mlir
+++ b/polygeist/test/polygeist-opt/licm.mlir
@@ -302,7 +302,7 @@ func.func @affine_for_hoist5(%arg0: memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
   // CHECK:          affine.if #set1() {
   // CHECK-NEXT:       %0 = affine.load %alloca[0] : memref<1x!sycl_id_1_>
   // CHECK-NEXT:       affine.store %0, %alloca_0[0] : memref<1x!sycl_id_1_>
-  // CHECK-NEXT:       %1 = sycl.accessor.subscript %arg0[%alloca_0] {{.*}} : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<1x!sycl_id_1_>) -> memref<?xf32, 4>
+  // CHECK-NEXT:       %1 = sycl.accessor.subscript %arg0[%alloca_0] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<1x!sycl_id_1_>) -> memref<?xf32, 4>
   // CHECK-NEXT:       affine.for %arg1 = 0 to 10 {
   // CHECK-NEXT:         %2 = affine.load %1[0] : memref<?xf32, 4>
   // CHECK-NEXT:         %3 = arith.addf %2, {{.*}} : f32
@@ -317,7 +317,7 @@ func.func @affine_for_hoist5(%arg0: memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
   // CHECK-RELAXED-ALIASING-NEXT:     affine.for %arg1 = 0 to 10 {
   // CHECK-RELAXED-ALIASING-NEXT:      %0 = affine.load %alloca[0] : memref<1x!sycl_id_1_>
   // CHECK-RELAXED-ALIASING-NEXT:      affine.store %0, %alloca_0[0] : memref<1x!sycl_id_1_>
-  // CHECK-RELAXED-ALIASING-NEXT:      %1 = sycl.accessor.subscript %arg0[%alloca_0] {ArgumentTypes = [memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<1x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIfLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERfNS0_2idILi1EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<1x!sycl_id_1_>) -> memref<?xf32, 4>
+  // CHECK-RELAXED-ALIASING-NEXT:      %1 = sycl.accessor.subscript %arg0[%alloca_0] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<1x!sycl_id_1_>) -> memref<?xf32, 4>
   // CHECK-RELAXED-ALIASING-NEXT:      %2 = affine.load %1[0] : memref<?xf32, 4>
   // CHECK-RELAXED-ALIASING-NEXT:      %3 = arith.addf %2, %cst : f32
   // CHECK-RELAXED-ALIASING-NEXT:      affine.store %3, %1[0] : memref<?xf32, 4>
@@ -335,7 +335,7 @@ func.func @affine_for_hoist5(%arg0: memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
   affine.for %arg1 = 0 to 10 {    
     %2 = affine.load %alloca[0] : memref<1x!sycl_id_1>
     affine.store %2, %alloca_0[0] : memref<1x!sycl_id_1>
-    %3 = sycl.accessor.subscript %arg0[%alloca_0] {ArgumentTypes = [memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<1x!sycl_id_1>], FunctionName = @"operator[]", MangledFunctionName = @_ZNK4sycl3_V18accessorIfLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEixILi1EvEERfNS0_2idILi1EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<1x!sycl_id_1>) -> memref<?xf32, 4>
+    %3 = sycl.accessor.subscript %arg0[%alloca_0] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<1x!sycl_id_1>) -> memref<?xf32, 4>
     %4 = affine.load %3[0] : memref<?xf32, 4>
     %5 = arith.addf %4, %cst : f32
     affine.store %5, %3[0] : memref<?xf32, 4>

--- a/polygeist/test/polygeist-opt/sycl/detect-reduction-accessor-versioning.mlir
+++ b/polygeist/test/polygeist-opt/sycl/detect-reduction-accessor-versioning.mlir
@@ -28,23 +28,23 @@
 // CHECK:         %alloca_7 = memref.alloca() : memref<1x!sycl_id_1_>
 // CHECK-NEXT:    %c0_8 = arith.constant 0 : index
 // CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
-// CHECK-NEXT:    %2 = sycl.id.get %alloca_7[%c0_i32] {ArgumentTypes = [memref<1x!sycl_id_1_>, i32], FunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_1_>, i32) -> memref<?xindex>
+// CHECK-NEXT:    %2 = sycl.id.get %alloca_7[%c0_i32] : (memref<1x!sycl_id_1_>, i32) -> memref<?xindex>
 // CHECK-NEXT:    memref.store %c0_8, %2[%c0_8] : memref<?xindex>
-// CHECK-NEXT:    [[ARG0_BEGIN:%.*]] = sycl.accessor.subscript %arg0[%alloca_7] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<1x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<1x!sycl_id_1_>) -> memref<?xi32, 1>
+// CHECK-NEXT:    [[ARG0_BEGIN:%.*]] = sycl.accessor.subscript %arg0[%alloca_7] : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<1x!sycl_id_1_>) -> memref<?xi32, 1>
 
 // COM: Obtain a pointer to the end of the accessor %arg0.
-// CHECK-NEXT:    %4 = sycl.accessor.get_range(%arg0) {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb, 4>], FunctionName = @get_range, TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>) -> !sycl_range_1_
+// CHECK-NEXT:    %4 = sycl.accessor.get_range(%arg0) : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>) -> !sycl_range_1_
 // CHECK-NEXT:    %alloca_9 = memref.alloca() : memref<1x!sycl_range_1_>
 // CHECK-NEXT:    %c0_10 = arith.constant 0 : index
 // CHECK-NEXT:    memref.store %4, %alloca_9[%c0_10] : memref<1x!sycl_range_1_>
 // CHECK-NEXT:    %alloca_11 = memref.alloca() : memref<1x!sycl_id_1_>
 // CHECK-NEXT:    %c1_12 = arith.constant 1 : index
 // CHECK-NEXT:    %c0_i32_13 = arith.constant 0 : i32
-// CHECK-NEXT:    %5 = sycl.id.get %alloca_11[%c0_i32_13] {ArgumentTypes = [memref<1x!sycl_id_1_>, i32], FunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_1_>, i32) -> memref<?xindex>
+// CHECK-NEXT:    %5 = sycl.id.get %alloca_11[%c0_i32_13] : (memref<1x!sycl_id_1_>, i32) -> memref<?xindex>
 // CHECK-NEXT:    %c0_i32_14 = arith.constant 0 : i32
-// CHECK-NEXT:    %6 = sycl.range.get %alloca_9[%c0_i32_14] {ArgumentTypes = [memref<1x!sycl_range_1_>, i32], FunctionName = @get, TypeName = @range} : (memref<1x!sycl_range_1_>, i32) -> index
+// CHECK-NEXT:    %6 = sycl.range.get %alloca_9[%c0_i32_14] : (memref<1x!sycl_range_1_>, i32) -> index
 // CHECK-NEXT:    memref.store %6, %5[%c0_10] : memref<?xindex>
-// CHECK-NEXT:    [[ARG0_END:%.*]] = sycl.accessor.subscript %arg0[%alloca_11] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<1x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<1x!sycl_id_1_>) -> memref<?xi32, 1>
+// CHECK-NEXT:    [[ARG0_END:%.*]] = sycl.accessor.subscript %arg0[%alloca_11] : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<1x!sycl_id_1_>) -> memref<?xi32, 1>
 
 // CHECK:         [[ARG1_BEGIN:%.*]] = sycl.accessor.subscript %arg1[%alloca_15]
 // CHECK:         [[ARG1_END:%.*]] = sycl.accessor.subscript %arg1[%alloca_20]
@@ -92,13 +92,13 @@ func.func private @test(%arg0: memref<?x!sycl_accessor_1_i32_rw_gb, 4>, %arg1: m
   sycl.constructor @id(%memspacecast_6, %c0_i64) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
   %0 = affine.load %alloca_0[0] : memref<1x!sycl_id_1_>
   affine.store %0, %alloca[0] : memref<1x!sycl_id_1_>
-  %1 = sycl.accessor.subscript %arg0[%cast] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+  %1 = sycl.accessor.subscript %arg0[%cast] : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
   scf.for %i = %c0 to %c8 step %c1 {
     %2 = arith.index_cast %i : index to i64
     sycl.constructor @id(%memspacecast, %2) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
     %3 = affine.load %alloca_4[0] : memref<1x!sycl_id_1_>
     affine.store %3, %alloca_2[0] : memref<1x!sycl_id_1_>
-    %4 = sycl.accessor.subscript %arg1[%cast_3] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+    %4 = sycl.accessor.subscript %arg1[%cast_3] : (memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
     %5 = affine.load %4[0] : memref<?xi32, 4>
     %6 = affine.load %1[0] : memref<?xi32, 4>
     %7 = arith.addi %6, %5 : i32

--- a/polygeist/test/polygeist-opt/sycl/kernel_disjoint_specialization.mlir
+++ b/polygeist/test/polygeist-opt/sycl/kernel_disjoint_specialization.mlir
@@ -32,27 +32,27 @@ gpu.module @device_func {
   // CHECK-NEXT:    %alloca = memref.alloca() : memref<1x!sycl_id_1_>
   // CHECK-NEXT:    %c0 = arith.constant 0 : index
   // CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
-  // CHECK-NEXT:    %0 = sycl.id.get %alloca[%c0_i32] {ArgumentTypes = [memref<1x!sycl_id_1_>, i32], FunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_1_>, i32) -> memref<?xindex>
+  // CHECK-NEXT:    %0 = sycl.id.get %alloca[%c0_i32] : (memref<1x!sycl_id_1_>, i32) -> memref<?xindex>
   // CHECK-NEXT:    memref.store %c0, %0[%c0] : memref<?xindex>
-  // CHECK-NEXT:    [[ACC1_BEGIN:%.*]] = sycl.accessor.subscript %arg0[%alloca] {ArgumentTypes = [memref<?x!sycl_accessor_1_f32_r_gb>, memref<1x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
+  // CHECK-NEXT:    [[ACC1_BEGIN:%.*]] = sycl.accessor.subscript %arg0[%alloca] : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
 
   // COM: Obtain a pointer to the end of the first accessor.
-  // CHECK-NEXT:    %2 = sycl.accessor.get_range(%arg0) {ArgumentTypes = [memref<?x!sycl_accessor_1_f32_r_gb>], FunctionName = @get_range, TypeName = @accessor} : (memref<?x!sycl_accessor_1_f32_r_gb>) -> !sycl_range_1_
+  // CHECK-NEXT:    %2 = sycl.accessor.get_range(%arg0) : (memref<?x!sycl_accessor_1_f32_r_gb>) -> !sycl_range_1_
   // CHECK-NEXT:    %alloca_0 = memref.alloca() : memref<1x!sycl_range_1_>
   // CHECK-NEXT:    %c0_1 = arith.constant 0 : index
   // CHECK-NEXT:    memref.store %2, %alloca_0[%c0_1] : memref<1x!sycl_range_1_>
   // CHECK-NEXT:    %alloca_2 = memref.alloca() : memref<1x!sycl_id_1_>
   // CHECK-NEXT:    %c1 = arith.constant 1 : index
   // CHECK-NEXT:    %c0_i32_3 = arith.constant 0 : i32
-  // CHECK-NEXT:    %3 = sycl.id.get %alloca_2[%c0_i32_3] {ArgumentTypes = [memref<1x!sycl_id_1_>, i32], FunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_1_>, i32) -> memref<?xindex>
+  // CHECK-NEXT:    %3 = sycl.id.get %alloca_2[%c0_i32_3] : (memref<1x!sycl_id_1_>, i32) -> memref<?xindex>
   // CHECK-NEXT:    %c0_i32_4 = arith.constant 0 : i32
-  // CHECK-NEXT:    %4 = sycl.range.get %alloca_0[%c0_i32_4] {ArgumentTypes = [memref<1x!sycl_range_1_>, i32], FunctionName = @get, TypeName = @range} : (memref<1x!sycl_range_1_>, i32) -> index
+  // CHECK-NEXT:    %4 = sycl.range.get %alloca_0[%c0_i32_4] : (memref<1x!sycl_range_1_>, i32) -> index
   // CHECK-NEXT:    memref.store %4, %3[%c0_1] : memref<?xindex>
-  // CHECK-NEXT:    [[ACC1_END:%.*]] = sycl.accessor.subscript %arg0[%alloca_2] {ArgumentTypes = [memref<?x!sycl_accessor_1_f32_r_gb>, memref<1x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
+  // CHECK-NEXT:    [[ACC1_END:%.*]] = sycl.accessor.subscript %arg0[%alloca_2] : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
 
   // COM: Version with condition: [[ACC1_END]] <= [[ACC2_BEGIN]] || [[ACC1_BEGIN]] >= [[ACC2_END]].
-  // CHECK:         [[ACC2_BEGIN:%.*]] = sycl.accessor.subscript %arg1[{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_1_f32_w_gb>, memref<1x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_f32_w_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
-  // CHECK:         [[ACC2_END:%.*]] = sycl.accessor.subscript %arg1[{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_1_f32_w_gb>, memref<1x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_f32_w_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
+  // CHECK:         [[ACC2_BEGIN:%.*]] = sycl.accessor.subscript %arg1[{{.*}}] : (memref<?x!sycl_accessor_1_f32_w_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
+  // CHECK:         [[ACC2_END:%.*]] = sycl.accessor.subscript %arg1[{{.*}}] : (memref<?x!sycl_accessor_1_f32_w_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
   // CHECK-DAG:     [[ACC1_END_PTR:%.*]] = "polygeist.memref2pointer"([[ACC1_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<f32, 1>
   // CHECK-DAG:     [[ACC2_BEGIN_PTR:%.*]]  = "polygeist.memref2pointer"([[ACC2_BEGIN]]) : (memref<?xf32, 1>) -> !llvm.ptr<f32, 1>
   // CHECK-NEXT:    %14 = llvm.icmp "ule" [[ACC1_END_PTR]], [[ACC2_BEGIN_PTR]] : !llvm.ptr<f32, 1>
@@ -105,36 +105,36 @@ gpu.module @device_func {
   // CHECK-NEXT:    %alloca = memref.alloca() : memref<1x!sycl_id_2_>
   // CHECK-NEXT:    %c0 = arith.constant 0 : index
   // CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
-  // CHECK-NEXT:    %0 = sycl.id.get %alloca[%c0_i32] {ArgumentTypes = [memref<1x!sycl_id_2_>, i32], FunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
+  // CHECK-NEXT:    %0 = sycl.id.get %alloca[%c0_i32] : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
   // CHECK-NEXT:    memref.store %c0, %0[%c0] : memref<?xindex>
   // CHECK-NEXT:    %c1_i32 = arith.constant 1 : i32
-  // CHECK-NEXT:    %1 = sycl.id.get %alloca[%c1_i32] {ArgumentTypes = [memref<1x!sycl_id_2_>, i32], FunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
+  // CHECK-NEXT:    %1 = sycl.id.get %alloca[%c1_i32] : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
   // CHECK-NEXT:    memref.store %c0, %1[%c0] : memref<?xindex>
-  // CHECK-NEXT:    [[ACC1_BEGIN:%.*]] = sycl.accessor.subscript %arg0[%alloca] {ArgumentTypes = [memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
+  // CHECK-NEXT:    [[ACC1_BEGIN:%.*]] = sycl.accessor.subscript %arg0[%alloca] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
 
   // COM: Obtain a pointer to the end of the first accessor.
-  // CHECK-NEXT:    %3 = sycl.accessor.get_range(%arg0) {ArgumentTypes = [memref<?x!sycl_accessor_2_f32_r_gb>], FunctionName = @get_range, TypeName = @accessor} : (memref<?x!sycl_accessor_2_f32_r_gb>) -> !sycl_range_2_
+  // CHECK-NEXT:    %3 = sycl.accessor.get_range(%arg0) : (memref<?x!sycl_accessor_2_f32_r_gb>) -> !sycl_range_2_
   // CHECK-NEXT:    %alloca_0 = memref.alloca() : memref<1x!sycl_range_2_>
   // CHECK-NEXT:    %c0_1 = arith.constant 0 : index
   // CHECK-NEXT:    memref.store %3, %alloca_0[%c0_1] : memref<1x!sycl_range_2_>
   // CHECK-NEXT:    %alloca_2 = memref.alloca() : memref<1x!sycl_id_2_>
   // CHECK-NEXT:    %c1 = arith.constant 1 : index
   // CHECK-NEXT:    %c0_i32_3 = arith.constant 0 : i32
-  // CHECK-NEXT:    %4 = sycl.id.get %alloca_2[%c0_i32_3] {ArgumentTypes = [memref<1x!sycl_id_2_>, i32], FunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
+  // CHECK-NEXT:    %4 = sycl.id.get %alloca_2[%c0_i32_3] : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
   // CHECK-NEXT:    %c0_i32_4 = arith.constant 0 : i32
-  // CHECK-NEXT:    %5 = sycl.range.get %alloca_0[%c0_i32_4] {ArgumentTypes = [memref<1x!sycl_range_2_>, i32], FunctionName = @get, TypeName = @range} : (memref<1x!sycl_range_2_>, i32) -> index
+  // CHECK-NEXT:    %5 = sycl.range.get %alloca_0[%c0_i32_4] : (memref<1x!sycl_range_2_>, i32) -> index
   // CHECK-NEXT:    %6 = arith.subi %5, %c1 : index
   // CHECK-NEXT:    memref.store %6, %4[%c0_1] : memref<?xindex>
   // CHECK-NEXT:    %c1_i32_5 = arith.constant 1 : i32
-  // CHECK-NEXT:    %7 = sycl.id.get %alloca_2[%c1_i32_5] {ArgumentTypes = [memref<1x!sycl_id_2_>, i32], FunctionName = @"operator[]", TypeName = @id} : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
+  // CHECK-NEXT:    %7 = sycl.id.get %alloca_2[%c1_i32_5] : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
   // CHECK-NEXT:    %c1_i32_6 = arith.constant 1 : i32
-  // CHECK-NEXT:    %8 = sycl.range.get %alloca_0[%c1_i32_6] {ArgumentTypes = [memref<1x!sycl_range_2_>, i32], FunctionName = @get, TypeName = @range} : (memref<1x!sycl_range_2_>, i32) -> index
+  // CHECK-NEXT:    %8 = sycl.range.get %alloca_0[%c1_i32_6] : (memref<1x!sycl_range_2_>, i32) -> index
   // CHECK-NEXT:    memref.store %8, %7[%c0_1] : memref<?xindex>
-  // CHECK-NEXT:    [[ACC1_END:%.*]] = sycl.accessor.subscript %arg0[%alloca_2] {ArgumentTypes = [memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
+  // CHECK-NEXT:    [[ACC1_END:%.*]] = sycl.accessor.subscript %arg0[%alloca_2] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
 
   // COM: Version with condition: [[ACC1_END]] <= [[ACC2_BEGIN]] || [[ACC1_BEGIN]] >= [[ACC2_END]].
-  // CHECK:         [[ACC2_BEGIN:%.*]] = sycl.accessor.subscript %arg1[%alloca_7] {ArgumentTypes = [memref<?x!sycl_accessor_2_f32_w_gb>, memref<1x!sycl_id_2_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_2_f32_w_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
-  // CHECK:         [[ACC2_END:%.*]] = sycl.accessor.subscript %arg1[%alloca_13] {ArgumentTypes = [memref<?x!sycl_accessor_2_f32_w_gb>, memref<1x!sycl_id_2_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_2_f32_w_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
+  // CHECK:         [[ACC2_BEGIN:%.*]] = sycl.accessor.subscript %arg1[%alloca_7] : (memref<?x!sycl_accessor_2_f32_w_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
+  // CHECK:         [[ACC2_END:%.*]] = sycl.accessor.subscript %arg1[%alloca_13] : (memref<?x!sycl_accessor_2_f32_w_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
   // CHECK-DAG:     [[ACC1_END_PTR:%.*]] = "polygeist.memref2pointer"([[ACC1_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<f32, 1>
   // CHECK-DAG:     [[ACC2_BEGIN_PTR:%.*]]  = "polygeist.memref2pointer"([[ACC2_BEGIN]]) : (memref<?xf32, 1>) -> !llvm.ptr<f32, 1>
   // CHECK-NEXT:    %22 = llvm.icmp "ule" [[ACC1_END_PTR]], [[ACC2_BEGIN_PTR]] : !llvm.ptr<f32, 1>
@@ -194,12 +194,12 @@ gpu.module @device_func {
   // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_0_f32_r_gb>,
   // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_0_f32_w_gb>)
   // CHECK-LABEL: gpu.func @caller5(%arg0: memref<?x!sycl_accessor_0_f32_r_gb>, %arg1: memref<?x!sycl_accessor_0_f32_w_gb>) kernel {
-  // CHECK-NEXT:    [[ARG0_BEGIN:%.*]] = sycl.accessor.get_pointer(%arg0) {ArgumentTypes = [memref<?x!sycl_accessor_0_f32_r_gb>], FunctionName = @get_pointer, TypeName = @accessor} : (memref<?x!sycl_accessor_0_f32_r_gb>) -> memref<?xf32, 1>
-  // CHECK-NEXT:    %1 = sycl.accessor.get_pointer(%arg0) {ArgumentTypes = [memref<?x!sycl_accessor_0_f32_r_gb>], FunctionName = @get_pointer, TypeName = @accessor} : (memref<?x!sycl_accessor_0_f32_r_gb>) -> memref<?xf32, 1>
+  // CHECK-NEXT:    [[ARG0_BEGIN:%.*]] = sycl.accessor.get_pointer(%arg0) : (memref<?x!sycl_accessor_0_f32_r_gb>) -> memref<?xf32, 1>
+  // CHECK-NEXT:    %1 = sycl.accessor.get_pointer(%arg0) : (memref<?x!sycl_accessor_0_f32_r_gb>) -> memref<?xf32, 1>
   // CHECK-NEXT:    %c1 = arith.constant 1 : index
   // CHECK-NEXT:    [[ARG0_END:%.*]] = "polygeist.subindex"(%1, %c1) : (memref<?xf32, 1>, index) -> memref<?xf32, 1>
-  // CHECK-NEXT:    [[ARG1_BEGIN:%.*]] = sycl.accessor.get_pointer(%arg1) {ArgumentTypes = [memref<?x!sycl_accessor_0_f32_w_gb>], FunctionName = @get_pointer, TypeName = @accessor} : (memref<?x!sycl_accessor_0_f32_w_gb>) -> memref<?xf32, 1>
-  // CHECK-NEXT:    %4 = sycl.accessor.get_pointer(%arg1) {ArgumentTypes = [memref<?x!sycl_accessor_0_f32_w_gb>], FunctionName = @get_pointer, TypeName = @accessor} : (memref<?x!sycl_accessor_0_f32_w_gb>) -> memref<?xf32, 1>
+  // CHECK-NEXT:    [[ARG1_BEGIN:%.*]] = sycl.accessor.get_pointer(%arg1) : (memref<?x!sycl_accessor_0_f32_w_gb>) -> memref<?xf32, 1>
+  // CHECK-NEXT:    %4 = sycl.accessor.get_pointer(%arg1) : (memref<?x!sycl_accessor_0_f32_w_gb>) -> memref<?xf32, 1>
   // CHECK-NEXT:    %c1_0 = arith.constant 1 : index
   // CHECK-NEXT:    [[ARG1_END:%.*]] = "polygeist.subindex"(%4, %c1_0) : (memref<?xf32, 1>, index) -> memref<?xf32, 1>
   // CHECK-DAG:     [[ARG0_END_PTR:%.*]] = "polygeist.memref2pointer"([[ARG0_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<f32, 1>

--- a/polygeist/test/polygeist-opt/sycl/licm-accessor-versioning.mlir
+++ b/polygeist/test/polygeist-opt/sycl/licm-accessor-versioning.mlir
@@ -29,32 +29,32 @@
 // CHECK-DAG:  [[C8:%.*]] = arith.constant 8 : index
 // CHECK:      [[GUARD_COND:%.*]] = arith.cmpi slt, [[C0]], [[C8]] : index
 // CHECK-NEXT: scf.if [[GUARD_COND]] {
-// CHECK: [[ARG1_ACC:%.*]] = sycl.accessor.subscript %arg1[{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+// CHECK: [[ARG1_ACC:%.*]] = sycl.accessor.subscript %arg1[{{.*}}] : (memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
 
 // COM: Obtain a pointer to the beginning of the accessor %arg1.
 // CHECK-DAG:  [[ID_ALLOCA:%.*]] = memref.alloca() : memref<1x[[ID:!sycl_id_1_]]>
 // CHECK-DAG:  [[C0_i32:%.*]] = arith.constant 0 : i32
 // CHECK-DAG:  [[C0_index:%.*]] = arith.constant 0 : index
-// CHECK-NEXT: [[ID_GET:%.*]] = sycl.id.get [[ID_ALLOCA]][[[C0_i32]]] {ArgumentTypes = [memref<1x[[ID]]>, i32], FunctionName = @"operator[]", TypeName = @id} : (memref<1x[[ID]]>, i32) -> memref<?xindex>
+// CHECK-NEXT: [[ID_GET:%.*]] = sycl.id.get [[ID_ALLOCA]][[[C0_i32]]] : (memref<1x[[ID]]>, i32) -> memref<?xindex>
 // CHECK-NEXT: memref.store [[C0_index]], [[ID_GET]][[[C0_index]]] : memref<?xindex>
-// CHECK-NEXT: [[ARG1_BEGIN:%.*]] = sycl.accessor.subscript [[ARG1]][[[ID_ALLOCA]]] {ArgumentTypes = [memref<?x[[ACC_R]], 4>, memref<1x[[ID]]>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x[[ACC_R]], 4>, memref<1x[[ID]]>) -> memref<?xi32, 1>
+// CHECK-NEXT: [[ARG1_BEGIN:%.*]] = sycl.accessor.subscript [[ARG1]][[[ID_ALLOCA]]] : (memref<?x[[ACC_R]], 4>, memref<1x[[ID]]>) -> memref<?xi32, 1>
 
 // COM: Obtain a pointer to the end of the accessor %arg1.
 // CHECK-DAG:  [[RANGE_ALLOCA:%.*]] = memref.alloca() : memref<1x[[RANGE:!sycl_range_1_]]>
 // CHECK-DAG:  [[C0_index:%.*]] = arith.constant 0 : index
-// CHECK-DAG:  [[GET_RANGE:%.*]] = sycl.accessor.get_range([[ARG1]]) {ArgumentTypes = [memref<?x[[ACC_R]], 4>], FunctionName = @get_range, TypeName = @accessor} : (memref<?x[[ACC_R]], 4>) -> [[RANGE]]
+// CHECK-DAG:  [[GET_RANGE:%.*]] = sycl.accessor.get_range([[ARG1]]) : (memref<?x[[ACC_R]], 4>) -> [[RANGE]]
 // CHECK-NEXT: memref.store [[GET_RANGE]], [[RANGE_ALLOCA]][[[C0_index]]] : memref<1x[[RANGE]]>
 // CHECK-DAG:  [[ID_ALLOCA:%.*]] = memref.alloca() : memref<1x[[ID:!sycl_id_1_]]>
 // CHECK-DAG:  [[C0_i32:%.*]] = arith.constant 0 : i32
 // CHECK-DAG:  [[C1_index:%.*]] = arith.constant 1 : index
-// CHECK-NEXT: [[ID_GET:%.*]] = sycl.id.get [[ID_ALLOCA]][[[C0_i32]]] {ArgumentTypes = [memref<1x[[ID]]>, i32], FunctionName = @"operator[]", TypeName = @id} : (memref<1x[[ID]]>, i32) -> memref<?xindex>
+// CHECK-NEXT: [[ID_GET:%.*]] = sycl.id.get [[ID_ALLOCA]][[[C0_i32]]] : (memref<1x[[ID]]>, i32) -> memref<?xindex>
 // CHECK-NEXT: [[C0_i32:%.*]] = arith.constant 0 : i32
-// CHECK-NEXT: [[RANGE_GET:%.*]] = sycl.range.get [[RANGE_ALLOCA]][[[C0_i32]]] {ArgumentTypes = [memref<1x[[RANGE]]>, i32], FunctionName = @get, TypeName = @range} : (memref<1x[[RANGE]]>, i32) -> index
+// CHECK-NEXT: [[RANGE_GET:%.*]] = sycl.range.get [[RANGE_ALLOCA]][[[C0_i32]]] : (memref<1x[[RANGE]]>, i32) -> index
 // CHECK-NEXT: memref.store [[RANGE_GET]], [[ID_GET]][[[C0_index]]] : memref<?xindex>
-// CHECK-NEXT: [[ARG1_END:%.*]] = sycl.accessor.subscript [[ARG1]][[[ID_ALLOCA]]] {ArgumentTypes = [memref<?x[[ACC_R]], 4>, memref<1x[[ID]]>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x[[ACC_R]], 4>, memref<1x[[ID]]>) -> memref<?xi32, 1>
+// CHECK-NEXT: [[ARG1_END:%.*]] = sycl.accessor.subscript [[ARG1]][[[ID_ALLOCA]]] : (memref<?x[[ACC_R]], 4>, memref<1x[[ID]]>) -> memref<?xi32, 1>
 
-// CHECK: [[ARG0_BEGIN:%.*]] = sycl.accessor.subscript [[ARG0]][{{.*}}] {ArgumentTypes = [memref<?x[[ACC_RW]], 4>, memref<1x[[ID]]>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x[[ACC_RW]], 4>, memref<1x[[ID]]>) -> memref<?xi32, 1>
-// CHECK: [[ARG0_END:%.*]] = sycl.accessor.subscript [[ARG0]][{{.*}}] {ArgumentTypes = [memref<?x[[ACC_RW]], 4>, memref<1x[[ID]]>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x[[ACC_RW]], 4>, memref<1x[[ID]]>) -> memref<?xi32, 1>
+// CHECK: [[ARG0_BEGIN:%.*]] = sycl.accessor.subscript [[ARG0]][{{.*}}] : (memref<?x[[ACC_RW]], 4>, memref<1x[[ID]]>) -> memref<?xi32, 1>
+// CHECK: [[ARG0_END:%.*]] = sycl.accessor.subscript [[ARG0]][{{.*}}] : (memref<?x[[ACC_RW]], 4>, memref<1x[[ID]]>) -> memref<?xi32, 1>
 // CHECK-DAG:  [[ARG1_END_PTR:%.*]] = "polygeist.memref2pointer"([[ARG1_END]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
 // CHECK-DAG:  [[ARG0_BEGIN_PTR:%.*]] = "polygeist.memref2pointer"([[ARG0_BEGIN]]) : (memref<?xi32, 1>) -> !llvm.ptr<i32, 1>
 // CHECK-NEXT: [[BEFORE_COND:%.*]] = llvm.icmp "ule" [[ARG1_END_PTR]], [[ARG0_BEGIN_PTR]] : !llvm.ptr<i32, 1>
@@ -92,12 +92,12 @@ func.func private @testSCFLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32_rw
     sycl.constructor @id(%memspacecast, %c0_i64) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
     %3 = affine.load %alloca_4[0] : memref<1x!sycl_id_1_>
     affine.store %3, %alloca_2[0] : memref<1x!sycl_id_1_>
-    %4 = sycl.accessor.subscript %arg1[%cast_3] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+    %4 = sycl.accessor.subscript %arg1[%cast_3] : (memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
     %5 = affine.load %4[0] : memref<?xi32, 4>
     sycl.constructor @id(%memspacecast_6, %2) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
     %6 = affine.load %alloca_0[0] : memref<1x!sycl_id_1_>
     affine.store %6, %alloca[0] : memref<1x!sycl_id_1_>
-    %7 = sycl.accessor.subscript %arg0[%cast] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+    %7 = sycl.accessor.subscript %arg0[%cast] : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
     %8 = affine.load %7[0] : memref<?xi32, 4>
     %9 = arith.addi %8, %5 : i32
     affine.store %9, %7[0] : memref<?xi32, 4>
@@ -119,7 +119,7 @@ func.func private @testSCFLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32_rw
 // CHECK-SAME:  ([[ARG0:%.*]]: memref<?x[[ACC_RW:!sycl_accessor_1_i32_rw_gb]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_R:!sycl_accessor_1_i32_r_gb]], 4>)
 
 // CHECK: affine.if [[GUARD_COND]]() {
-// CHECK: [[ARG1_ACC:%.*]] = sycl.accessor.subscript %arg1[{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+// CHECK: [[ARG1_ACC:%.*]] = sycl.accessor.subscript %arg1[{{.*}}] : (memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
 
 // COM: Version with condition: [[ARG1_END]] <= [[ARG0_BEGIN]] || [[ARG1_BEGIN]] >= [[ARG0_END]].
 // CHECK:      [[BEFORE_COND:%.*]] = llvm.icmp "ule" {{.*}}, {{.*}} : !llvm.ptr<i32, 1>
@@ -150,12 +150,12 @@ func.func private @testAffineLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32
     sycl.constructor @id(%memspacecast, %c0_i64) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
     %3 = affine.load %alloca_4[0] : memref<1x!sycl_id_1_>
     affine.store %3, %alloca_2[0] : memref<1x!sycl_id_1_>
-    %4 = sycl.accessor.subscript %arg1[%cast_3] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+    %4 = sycl.accessor.subscript %arg1[%cast_3] : (memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
     %5 = affine.load %4[0] : memref<?xi32, 4>
     sycl.constructor @id(%memspacecast_6, %2) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
     %6 = affine.load %alloca_0[0] : memref<1x!sycl_id_1_>
     affine.store %6, %alloca[0] : memref<1x!sycl_id_1_>
-    %7 = sycl.accessor.subscript %arg0[%cast] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+    %7 = sycl.accessor.subscript %arg0[%cast] : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
     %8 = affine.load %7[0] : memref<?xi32, 4>
     %9 = arith.addi %8, %5 : i32
     affine.store %9, %7[0] : memref<?xi32, 4>
@@ -199,7 +199,7 @@ func.func private @testAffineLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32
 // 1PAIR-LABEL: testSCFLoopVersioning
 // 1PAIR-SAME:  ([[ARG0:%.*]]: memref<?x[[ACC_W:!sycl_accessor_1_i32_w_gb]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_W]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_W]], 4>) 
 // 1PAIR: [[C1_i32:%.*]] = arith.constant 1 : i32
-// 1PAIR: [[ARG0_ACC:%.*]] = sycl.accessor.subscript %arg0[{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+// 1PAIR: [[ARG0_ACC:%.*]] = sycl.accessor.subscript %arg0[{{.*}}] : (memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
 // 1PAIR: scf.for
 // 1PAIR: affine.store [[C1_i32]], [[ARG0_ACC]][0] : memref<?xi32, 4>
 // 1PAIR-NOT: } else {
@@ -209,7 +209,7 @@ func.func private @testAffineLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32
 // 2PAIRS-SAME:  ([[ARG0:%.*]]: memref<?x[[ACC_W:!sycl_accessor_1_i32_w_gb]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_W]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_W]], 4>) 
 
 // 2PAIRS: [[C1_i32:%.*]] = arith.constant 1 : i32
-// 2PAIRS: [[ARG0_ACC:%.*]] = sycl.accessor.subscript %arg0[{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+// 2PAIRS: [[ARG0_ACC:%.*]] = sycl.accessor.subscript %arg0[{{.*}}] : (memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
 
 // COM: Version with condition: ([[ARG0_END]] <= [[ARG1_BEGIN]] || [[ARG0_BEGIN]] >= [[ARG1_END]])
 // COM:                          && ([[ARG0_END]] <= [[ARG2_BEGIN]] || [[ARG0_BEGIN]] >= [[ARG2_END]]).
@@ -256,17 +256,17 @@ func.func private @testSCFLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32_w_
     sycl.constructor @id(%memspacecast, %c0_i64) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
     %3 = affine.load %alloca_8[0] : memref<1x!sycl_id_1_>
     affine.store %3, %alloca_6[0] : memref<1x!sycl_id_1_>
-    %4 = sycl.accessor.subscript %arg0[%cast_7] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+    %4 = sycl.accessor.subscript %arg0[%cast_7] : (memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
     affine.store %c1_i32, %4[0] : memref<?xi32, 4>
     sycl.constructor @id(%memspacecast_10, %2) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
     %5 = affine.load %alloca_4[0] : memref<1x!sycl_id_1_>
     affine.store %5, %alloca_2[0] : memref<1x!sycl_id_1_>
-    %6 = sycl.accessor.subscript %arg1[%cast_3] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+    %6 = sycl.accessor.subscript %arg1[%cast_3] : (memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
     affine.store %c2_i32, %6[0] : memref<?xi32, 4>
     sycl.constructor @id(%memspacecast_11, %2) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
     %7 = affine.load %alloca_0[0] : memref<1x!sycl_id_1_>
     affine.store %7, %alloca[0] : memref<1x!sycl_id_1_>
-    %8 = sycl.accessor.subscript %arg2[%cast] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+    %8 = sycl.accessor.subscript %arg2[%cast] : (memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
     affine.store %c3_i32, %8[0] : memref<?xi32, 4>
   }
   return

--- a/polygeist/test/polygeist-opt/sycl/matrix_multiply_reduction.mlir
+++ b/polygeist/test/polygeist-opt/sycl/matrix_multiply_reduction.mlir
@@ -67,7 +67,7 @@ gpu.module @device_func {
       sycl.constructor @id(%memspacecast, %8) {MangledFunctionName = @id} : (memref<?x!sycl_id_1_, 4>, i64)
       %9 = affine.load %alloca_8[0] : memref<1x!sycl_id_1_>
       affine.store %9, %alloca_6[0] : memref<1x!sycl_id_1_>
-      %10 = sycl.accessor.subscript %5[%cast_7] {ArgumentTypes = [memref<?x!sycl_accessor_read_1_, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_read_1_, 4>, memref<?x!sycl_id_1_>) -> memref<?xf32, 4>
+      %10 = sycl.accessor.subscript %5[%cast_7] : (memref<?x!sycl_accessor_read_1_, 4>, memref<?x!sycl_id_1_>) -> memref<?xf32, 4>
       %11 = affine.load %10[0] : memref<?xf32, 4>
       %12 = "polygeist.subindex"(%arg0, %c2) : (memref<?x!llvm.struct<(!sycl_accessor_write_1_, !sycl_accessor_read_1_, !sycl_accessor_read_1_)>, 4>, index) -> memref<?x!sycl_accessor_read_1_, 4>
       %13 = arith.muli %4, %c2048_i32 : i32
@@ -77,7 +77,7 @@ gpu.module @device_func {
       sycl.constructor @id(%memspacecast_10, %15) {MangledFunctionName = @id} : (memref<?x!sycl_id_1_, 4>, i64)
       %16 = affine.load %alloca_4[0] : memref<1x!sycl_id_1_>
       affine.store %16, %alloca_2[0] : memref<1x!sycl_id_1_>
-      %17 = sycl.accessor.subscript %12[%cast_3] {ArgumentTypes = [memref<?x!sycl_accessor_read_1_, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_read_1_, 4>, memref<?x!sycl_id_1_>) -> memref<?xf32, 4>
+      %17 = sycl.accessor.subscript %12[%cast_3] : (memref<?x!sycl_accessor_read_1_, 4>, memref<?x!sycl_id_1_>) -> memref<?xf32, 4>
       %18 = affine.load %17[0] : memref<?xf32, 4>
       %19 = arith.mulf %11, %18 : f32
       %20 = "polygeist.subindex"(%arg0, %c0) : (memref<?x!llvm.struct<(!sycl_accessor_write_1_, !sycl_accessor_read_1_, !sycl_accessor_read_1_)>, 4>, index) -> memref<?x!sycl_accessor_write_1_, 4>
@@ -87,7 +87,7 @@ gpu.module @device_func {
       sycl.constructor @id(%memspacecast_11, %22) {MangledFunctionName = @id} : (memref<?x!sycl_id_1_, 4>, i64)
       %23 = affine.load %alloca_0[0] : memref<1x!sycl_id_1_>
       affine.store %23, %alloca[0] : memref<1x!sycl_id_1_>
-      %24 = sycl.accessor.subscript %20[%cast] {ArgumentTypes = [memref<?x!sycl_accessor_write_1_, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", MangledFunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_write_1_, 4>, memref<?x!sycl_id_1_>) -> memref<?xf32, 4>
+      %24 = sycl.accessor.subscript %20[%cast] : (memref<?x!sycl_accessor_write_1_, 4>, memref<?x!sycl_id_1_>) -> memref<?xf32, 4>
       %25 = affine.load %24[0] : memref<?xf32, 4>
       %26 = arith.addf %25, %19 : f32
       affine.store %26, %24[0] : memref<?xf32, 4>

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1080,21 +1080,6 @@ const clang::FunctionDecl *MLIRScanner::EmitCallee(const Expr *E) {
   return nullptr;
 }
 
-static NamedAttrList getSYCLMethodOpAttrs(OpBuilder &Builder,
-                                          TypeRange ArgumentTypes,
-                                          llvm::StringRef TypeName,
-                                          llvm::StringRef FunctionName,
-                                          llvm::StringRef MangledFunctionName) {
-  NamedAttrList Attrs;
-  Attrs.set(mlir::sycl::SYCLDialect::getArgumentTypesAttrName(),
-            Builder.getTypeArrayAttr(ArgumentTypes));
-  Attrs.set(mlir::sycl::SYCLDialect::getFunctionNameAttrName(),
-            FlatSymbolRefAttr::get(Builder.getStringAttr(FunctionName)));
-  Attrs.set(mlir::sycl::SYCLDialect::getTypeNameAttrName(),
-            FlatSymbolRefAttr::get(Builder.getStringAttr(TypeName)));
-  return Attrs;
-}
-
 static Operation *
 tryToCreateOperation(OpBuilder &builder, Location loc, StringAttr opName,
                      ValueRange operands, TypeRange types = {},
@@ -1111,10 +1096,10 @@ tryToCreateOperation(OpBuilder &builder, Location loc, StringAttr opName,
   return op;
 }
 
-llvm::Optional<sycl::SYCLMethodOpInterface> MLIRScanner::createSYCLMethodOp(
-    llvm::StringRef TypeName, llvm::StringRef FunctionName,
-    mlir::ValueRange Operands, llvm::Optional<mlir::Type> ReturnType,
-    llvm::StringRef MangledFunctionName) {
+llvm::Optional<sycl::SYCLMethodOpInterface>
+MLIRScanner::createSYCLMethodOp(llvm::StringRef FunctionName,
+                                mlir::ValueRange Operands,
+                                llvm::Optional<mlir::Type> ReturnType) {
   // Expecting a MemRef as the first argument, as the first operand to a method
   // call should be a pointer to `this`.
   if (Operands.empty() || !isa<MemRefType>(Operands[0].getType()))
@@ -1146,9 +1131,7 @@ llvm::Optional<sycl::SYCLMethodOpInterface> MLIRScanner::createSYCLMethodOp(
 
   Operation *op = tryToCreateOperation(
       Builder, Loc, Builder.getStringAttr(*OptOpName), OperandsCpy,
-      ReturnType ? mlir::TypeRange{*ReturnType} : mlir::TypeRange{},
-      getSYCLMethodOpAttrs(Builder, Operands.getTypes(), TypeName, FunctionName,
-                           MangledFunctionName));
+      ReturnType ? mlir::TypeRange{*ReturnType} : mlir::TypeRange{});
   if (!op)
     return std::nullopt;
   return op;
@@ -1256,8 +1239,7 @@ MLIRScanner::emitSYCLOps(const clang::Expr *Expr,
       // generic SYCLCallOp.
       std::string Name = MLIRScanner::getMangledFuncName(*Func, Glob.getCGM());
       if (OptFuncType)
-        Op = createSYCLMethodOp(*OptFuncType, Func->getNameAsString(), Args,
-                                OptRetType, Name)
+        Op = createSYCLMethodOp(Func->getNameAsString(), Args, OptRetType)
                  .value_or(nullptr);
       if (!Op)
         Op = Builder.create<mlir::sycl::SYCLCallOp>(

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -336,18 +336,15 @@ private:
                            mlir::Value LB, mlir::Value UB,
                            const mlirclang::AffineLoopDescriptor &Descr);
 
-  /// Creates an instance of SYCLMethodOpInterface if the SYCLCallOp with base
-  /// type name \param typeName, function name \param functionName, mangled
-  /// function name \param mangledFunctionName, parameters \param operands and
+  /// Creates an instance of SYCLMethodOpInterface if the SYCLCallOp with
+  /// function name \param functionName, parameters \param operands and
   /// (optional) return type \param returnType can be represented as such.
   ///
   /// E.g., the SYCLCallOp to the accessor member function
   /// accessor::operator[] can be represented using a SYCLAccessorSubscriptOp.
   llvm::Optional<mlir::sycl::SYCLMethodOpInterface>
-  createSYCLMethodOp(llvm::StringRef TypeName, llvm::StringRef FunctionName,
-                     mlir::ValueRange Operands,
-                     llvm::Optional<mlir::Type> ReturnType,
-                     llvm::StringRef MangledFunctionName);
+  createSYCLMethodOp(llvm::StringRef FunctionName, mlir::ValueRange Operands,
+                     llvm::Optional<mlir::Type> ReturnType);
 
   /// Creates an instance of a SYCL grid operation replacing a call to \param
   /// Callee.

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -29,7 +29,7 @@ template <typename T> SYCL_EXTERNAL void keep(T);
 
 // COM-MLIR-LABEL: func.func @_Z20accessor_get_pointerN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
 // COM-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef})
-// COM-MLIR: %{{.*}} = sycl.accessor.get_pointer(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>], FunctionName = @get_pointer, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> memref<?xi32, 1>
+// COM-MLIR: %{{.*}} = sycl.accessor.get_pointer(%{{.*}}) : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> memref<?xi32, 1>
 
 SYCL_EXTERNAL void accessor_get_pointer(sycl::accessor<sycl::cl_int, 2> acc) {
   keep(acc.get_pointer());
@@ -37,7 +37,7 @@ SYCL_EXTERNAL void accessor_get_pointer(sycl::accessor<sycl::cl_int, 2> acc) {
 
 // CHECK-MLIR-LABEL: func.func @_Z18accessor_get_rangeN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.get_range(%arg0) {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>], FunctionName = @get_range, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> !sycl_range_2_
+// CHECK-MLIR: %{{.*}} = sycl.accessor.get_range(%arg0) : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> !sycl_range_2_
 
 SYCL_EXTERNAL void accessor_get_range(sycl::accessor<sycl::cl_int, 2> acc) {
   keep(acc.get_range());
@@ -45,7 +45,7 @@ SYCL_EXTERNAL void accessor_get_range(sycl::accessor<sycl::cl_int, 2> acc) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13accessor_sizeN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.size(%arg0) {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>], FunctionName = @size, TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.accessor.size(%arg0) : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> i64
 
 SYCL_EXTERNAL void accessor_size(sycl::accessor<sycl::cl_int, 2> acc) {
   keep(acc.size());
@@ -54,7 +54,7 @@ SYCL_EXTERNAL void accessor_size(sycl::accessor<sycl::cl_int, 2> acc) {
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_0N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEENS0_2idILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef}, 
 // CHECK_MLIR_SAME:      %{{.*}}: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>, memref<?x!sycl_id_2_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] : (memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
 
 SYCL_EXTERNAL void accessor_subscript_operator_0(sycl::accessor<sycl::cl_int, 2> acc, sycl::id<2> index) {
   keep(acc[index]);
@@ -62,7 +62,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_0(sycl::accessor<sycl::cl_int, 2>
 
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_1N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK_MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb>, %{{.*}}: i64)
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_2_i32_rw_gb, 4>, i64], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_2_i32_rw_gb>, i64) -> ![[ACC_SUBSCRIPT]]
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] : (memref<?x!sycl_accessor_2_i32_rw_gb>, i64) -> ![[ACC_SUBSCRIPT]]
 
 SYCL_EXTERNAL void accessor_subscript_operator_1(sycl::accessor<sycl::cl_int, 2> acc, size_t index) {
   keep(acc[index]);
@@ -71,7 +71,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_1(sycl::accessor<sycl::cl_int, 2>
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_2N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_1_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_1_i32_rw_gb, llvm.noundef}, 
 // CHECK-MLIR-SAME:      %{{.*}}: i64 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
 
 SYCL_EXTERNAL void accessor_subscript_operator_2(sycl::accessor<sycl::cl_int, 1> acc, size_t index) {
   keep(acc[index]);
@@ -80,7 +80,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_2(sycl::accessor<sycl::cl_int, 1>
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_3N4sycl3_V18accessorI6StructLi1ELNS0_6access4modeE1026ELNS3_6targetE2014ELNS3_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
 // CHECK-MLIR:          %{{.*}}: memref<?x![[ACC_STRUCT]]> {llvm.align = 8 : i64, llvm.byval = ![[ACC_STRUCT]], llvm.noundef}, 
 // CHECK-MLIR-SAME:     %{{.*}}: i64 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x![[ACC_STRUCT]], 4>, memref<?x!sycl_id_1_>], FunctionName = @"operator[]", TypeName = @accessor} : (memref<?x![[ACC_STRUCT]]>, memref<?x!sycl_id_1_>) -> !llvm.ptr<4> 
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] : (memref<?x![[ACC_STRUCT]]>, memref<?x!sycl_id_1_>) -> !llvm.ptr<4> 
 
 typedef struct {
   unsigned field;
@@ -92,7 +92,7 @@ SYCL_EXTERNAL void accessor_subscript_operator_3(sycl::accessor<Struct, 1> acc, 
 // CHECK-MLIR-LABEL: func.func @_Z11range_get_0N4sycl3_V15rangeILi2EEEi(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef}, 
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, TypeName = @array} : (memref<?x!sycl_range_2_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] : (memref<?x!sycl_range_2_>, i32) -> i64
 
 SYCL_EXTERNAL void range_get_0(sycl::range<2> r, int dimension) {
   keep(r.get(dimension));
@@ -101,7 +101,7 @@ SYCL_EXTERNAL void range_get_0(sycl::range<2> r, int dimension) {
 // CHECK-MLIR-LABEL: func.func @_Z11range_get_1N4sycl3_V15rangeILi2EEEi(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef}
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @"operator[]", TypeName = @array} : (memref<?x!sycl_range_2_>, i32) -> memref<?xi64, 4>
+// CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] : (memref<?x!sycl_range_2_>, i32) -> memref<?xi64, 4>
 
 
 SYCL_EXTERNAL void range_get_1(sycl::range<2> r, int dimension) {
@@ -111,7 +111,7 @@ SYCL_EXTERNAL void range_get_1(sycl::range<2> r, int dimension) {
 // CHECK-MLIR-LABEL: func.func @_Z11range_get_2N4sycl3_V15rangeILi2EEEi(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef}
 // CHECK-MLIR-SAME:      %{{.*}}: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @"operator[]", TypeName = @array} : (memref<?x!sycl_range_2_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.range.get %{{.*}}[%{{.*}}] : (memref<?x!sycl_range_2_>, i32) -> i64
 
 SYCL_EXTERNAL void range_get_2(const sycl::range<2> r, int dimension) {
   keep(r[dimension]);
@@ -119,7 +119,7 @@ SYCL_EXTERNAL void range_get_2(const sycl::range<2> r, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z10range_sizeN4sycl3_V15rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.range.size(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_range_2_, 4>], FunctionName = @size, TypeName = @range} : (memref<?x!sycl_range_2_>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.range.size(%{{.*}}) : (memref<?x!sycl_range_2_>) -> i64
 
 
 SYCL_EXTERNAL void range_size(sycl::range<2> r) {
@@ -128,7 +128,7 @@ SYCL_EXTERNAL void range_size(sycl::range<2> r) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_range_get_global_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_range.get_global_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_range_2_, 4>], FunctionName = @get_global_range, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_>) -> !sycl_range_2_
+// CHECK-MLIR: %{{.*}} = sycl.nd_range.get_global_range(%{{.*}}) : (memref<?x!sycl_nd_range_2_>) -> !sycl_range_2_
 
 // CHECK-MLIR:           func.func @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv(%[[VAL_0:.*]]: memref<?x!sycl_nd_range_2_, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 48 : i64, llvm.noundef}) -> !sycl_range_2_
 // CHECK-MLIR-NEXT:             %[[VAL_1:.*]] = arith.constant 0 : index
@@ -147,7 +147,7 @@ SYCL_EXTERNAL void nd_range_get_global_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-MLIR-LABEL: func.func @_Z24nd_range_get_local_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_range.get_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_range_2_, 4>], FunctionName = @get_local_range, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_>) -> !sycl_range_2_
+// CHECK-MLIR: %{{.*}} = sycl.nd_range.get_local_range(%{{.*}}) : (memref<?x!sycl_nd_range_2_>) -> !sycl_range_2_
 
 SYCL_EXTERNAL void nd_range_get_local_range(sycl::nd_range<2> nd_range) {
   keep(nd_range.get_local_range());
@@ -155,7 +155,7 @@ SYCL_EXTERNAL void nd_range_get_local_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-MLIR-LABEL: func.func @_Z24nd_range_get_group_rangeN4sycl3_V18nd_rangeILi2EEE(
 // CHECK-MLIR:           %{{.*}}: memref<?x!sycl_nd_range_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_range_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_range.get_group_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_range_2_, 4>], FunctionName = @get_group_range, TypeName = @nd_range} : (memref<?x!sycl_nd_range_2_>) -> !sycl_range_2_
+// CHECK-MLIR: %{{.*}} = sycl.nd_range.get_group_range(%{{.*}}) : (memref<?x!sycl_nd_range_2_>) -> !sycl_range_2_
 
 SYCL_EXTERNAL void nd_range_get_group_range(sycl::nd_range<2> nd_range) {
   keep(nd_range.get_group_range());
@@ -163,7 +163,7 @@ SYCL_EXTERNAL void nd_range_get_group_range(sycl::nd_range<2> nd_range) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_0N4sycl3_V12idILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] {ArgumentTypes = [memref<?x!sycl_array_1_, 4>, i32], FunctionName = @get, TypeName = @array} : (memref<?x!sycl_id_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] : (memref<?x!sycl_id_1_>, i32) -> i64
 
 SYCL_EXTERNAL void id_get_0(sycl::id<1> id, int dimension) {
   keep(id.get(dimension));
@@ -171,7 +171,7 @@ SYCL_EXTERNAL void id_get_0(sycl::id<1> id, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_1N4sycl3_V12idILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})  
-// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] {ArgumentTypes = [memref<?x!sycl_array_1_, 4>, i32], FunctionName = @"operator[]", TypeName = @array} : (memref<?x!sycl_id_1_>, i32) -> memref<?xi64, 4>
+// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] : (memref<?x!sycl_id_1_>, i32) -> memref<?xi64, 4>
 
 SYCL_EXTERNAL void id_get_1(sycl::id<1> id, int dimension) {
   keep(id[dimension]);
@@ -179,7 +179,7 @@ SYCL_EXTERNAL void id_get_1(sycl::id<1> id, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_2N4sycl3_V12idILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_>  {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %arg1: i32  {llvm.noundef})    
-// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] {ArgumentTypes = [memref<?x!sycl_array_1_, 4>, i32], FunctionName = @"operator[]", TypeName = @array} : (memref<?x!sycl_id_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[%arg1] : (memref<?x!sycl_id_1_>, i32) -> i64
 
 SYCL_EXTERNAL void id_get_2(const sycl::id<1> id, int dimension) {
   keep(id[dimension]);
@@ -187,7 +187,7 @@ SYCL_EXTERNAL void id_get_2(const sycl::id<1> id, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z8id_get_3N4sycl3_V12idILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}
-// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[] {ArgumentTypes = [memref<?x!sycl_id_1_, 4>], FunctionName = @"operator unsigned long", TypeName = @id} : (memref<?x!sycl_id_1_>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.id.get %{{.*}}[] : (memref<?x!sycl_id_1_>) -> i64
 
 SYCL_EXTERNAL void id_get_3(sycl::id<1> id) {
   keep(static_cast<size_t>(id));
@@ -195,7 +195,7 @@ SYCL_EXTERNAL void id_get_3(sycl::id<1> id) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @get_id, TypeName = @item} : (memref<?x![[ITEM1]]>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}) : (memref<?x![[ITEM1]]>) -> !sycl_id_1_
 
 SYCL_EXTERNAL void item_get_id_0(sycl::item<1> item) {
   keep(item.get_id());
@@ -203,7 +203,7 @@ SYCL_EXTERNAL void item_get_id_0(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_1N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x![[ITEM1]], 4>, i32], FunctionName = @get_id, TypeName = @item} : (memref<?x![[ITEM1]]>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}, %arg1) : (memref<?x![[ITEM1]]>, i32) -> i64
 
 SYCL_EXTERNAL void item_get_id_1(sycl::item<1> item, int dimension) {
   keep(item.get_id(dimension));
@@ -211,7 +211,7 @@ SYCL_EXTERNAL void item_get_id_1(sycl::item<1> item, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_2N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x![[ITEM1]], 4>, i32], FunctionName = @"operator[]", TypeName = @item} : (memref<?x![[ITEM1]]>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}, %arg1) : (memref<?x![[ITEM1]]>, i32) -> i64
 
 SYCL_EXTERNAL void item_get_id_2(sycl::item<1> item, int dimension) {
   keep(item[dimension]);
@@ -219,7 +219,7 @@ SYCL_EXTERNAL void item_get_id_2(sycl::item<1> item, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z13item_get_id_3N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @"operator unsigned long", TypeName = @item} : (memref<?x![[ITEM1]]>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.item.get_id(%{{.*}}) : (memref<?x![[ITEM1]]>) -> i64
 
 SYCL_EXTERNAL void item_get_id_3(sycl::item<1> item) {
   keep(static_cast<size_t>(item));
@@ -227,7 +227,7 @@ SYCL_EXTERNAL void item_get_id_3(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z16item_get_range_0N4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_range(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @get_range, TypeName = @item} : (memref<?x![[ITEM1]]>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.item.get_range(%{{.*}}) : (memref<?x![[ITEM1]]>) -> !sycl_range_1_
 
 SYCL_EXTERNAL void item_get_range_0(sycl::item<1> item) {
   keep(item.get_range());
@@ -235,7 +235,7 @@ SYCL_EXTERNAL void item_get_range_0(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z16item_get_range_1N4sycl3_V14itemILi1ELb1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x![[ITEM1]], 4>, i32], FunctionName = @get_range, TypeName = @item} : (memref<?x![[ITEM1]]>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.item.get_range(%{{.*}}, %arg1) : (memref<?x![[ITEM1]]>, i32) -> i64
 
 SYCL_EXTERNAL void item_get_range_1(sycl::item<1> item, int dimension) {
   keep(item.get_range(dimension));
@@ -243,7 +243,7 @@ SYCL_EXTERNAL void item_get_range_1(sycl::item<1> item, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z18item_get_linear_idN4sycl3_V14itemILi1ELb1EEE(
 // CHECK-MLIR:           %arg0: memref<?x![[ITEM1]]> {llvm.align = 8 : i64, llvm.byval = ![[ITEM1]], llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.item.get_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x![[ITEM1]], 4>], FunctionName = @get_linear_id, TypeName = @item} : (memref<?x![[ITEM1]]>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.item.get_linear_id(%{{.*}}) : (memref<?x![[ITEM1]]>) -> i64
 
 SYCL_EXTERNAL void item_get_linear_id(sycl::item<1> item) {
   keep(item.get_linear_id());
@@ -251,7 +251,7 @@ SYCL_EXTERNAL void item_get_linear_id(sycl::item<1> item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23nd_item_get_global_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_global_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_id(%{{.*}}) : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
 
 SYCL_EXTERNAL void nd_item_get_global_id_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_global_id());
@@ -259,7 +259,7 @@ SYCL_EXTERNAL void nd_item_get_global_id_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23nd_item_get_global_id_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_global_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_id(%{{.*}}, %arg1) : (memref<?x!sycl_nd_item_1_>, i32) -> i64
 
 SYCL_EXTERNAL void nd_item_get_global_id_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_global_id(dimension));
@@ -267,7 +267,7 @@ SYCL_EXTERNAL void nd_item_get_global_id_1(sycl::nd_item<1> nd_item, int dimensi
 
 // CHECK-MLIR-LABEL: func.func @_Z28nd_item_get_global_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_global_linear_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_linear_id(%{{.*}}) : (memref<?x!sycl_nd_item_1_>) -> i64
 
 SYCL_EXTERNAL void nd_item_get_global_linear_id(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_global_linear_id());
@@ -275,7 +275,7 @@ SYCL_EXTERNAL void nd_item_get_global_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z22nd_item_get_local_id_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_local_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_id(%{{.*}}) : (memref<?x!sycl_nd_item_1_>) -> !sycl_id_1_
 
 SYCL_EXTERNAL void nd_item_get_local_id_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_local_id());
@@ -283,7 +283,7 @@ SYCL_EXTERNAL void nd_item_get_local_id_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z22nd_item_get_local_id_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_local_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_id(%{{.*}}, %arg1) : (memref<?x!sycl_nd_item_1_>, i32) -> i64
 
 SYCL_EXTERNAL void nd_item_get_local_id_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_local_id(dimension));
@@ -291,7 +291,7 @@ SYCL_EXTERNAL void nd_item_get_local_id_1(sycl::nd_item<1> nd_item, int dimensio
 
 // CHECK-MLIR-LABEL: func.func @_Z27nd_item_get_local_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_local_linear_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_linear_id(%{{.*}}) : (memref<?x!sycl_nd_item_1_>) -> i64
 
 SYCL_EXTERNAL void nd_item_get_local_linear_id(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_local_linear_id());
@@ -299,7 +299,7 @@ SYCL_EXTERNAL void nd_item_get_local_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z19nd_item_get_group_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})  
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_group, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_group_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group(%{{.*}}) : (memref<?x!sycl_nd_item_1_>) -> !sycl_group_1_
 
 SYCL_EXTERNAL void nd_item_get_group_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_group());
@@ -307,7 +307,7 @@ SYCL_EXTERNAL void nd_item_get_group_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z19nd_item_get_group_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_group, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group(%{{.*}}, %arg1) : (memref<?x!sycl_nd_item_1_>, i32) -> i64
 
 SYCL_EXTERNAL void nd_item_get_group_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_group(dimension));
@@ -315,7 +315,7 @@ SYCL_EXTERNAL void nd_item_get_group_1(sycl::nd_item<1> nd_item, int dimension) 
 
 // CHECK-MLIR-LABEL: func.func @_Z27nd_item_get_group_linear_idN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_group_linear_id, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_linear_id(%{{.*}}) : (memref<?x!sycl_nd_item_1_>) -> i64
 
 SYCL_EXTERNAL void nd_item_get_group_linear_id(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_group_linear_id());
@@ -323,7 +323,7 @@ SYCL_EXTERNAL void nd_item_get_group_linear_id(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_group_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_group_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_range(%{{.*}}) : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
 
 SYCL_EXTERNAL void nd_item_get_group_range_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_group_range());
@@ -331,7 +331,7 @@ SYCL_EXTERNAL void nd_item_get_group_range_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_group_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_group_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_group_range(%{{.*}}, %arg1) : (memref<?x!sycl_nd_item_1_>, i32) -> i64
 
 SYCL_EXTERNAL void nd_item_get_group_range_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_group_range(dimension));
@@ -339,7 +339,7 @@ SYCL_EXTERNAL void nd_item_get_group_range_1(sycl::nd_item<1> nd_item, int dimen
 
 // CHECK-MLIR-LABEL: func.func @_Z26nd_item_get_global_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_global_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_range(%{{.*}}) : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
 
 SYCL_EXTERNAL void nd_item_get_global_range_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_global_range());
@@ -347,7 +347,7 @@ SYCL_EXTERNAL void nd_item_get_global_range_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z26nd_item_get_global_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_global_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_global_range(%{{.*}}, %arg1) : (memref<?x!sycl_nd_item_1_>, i32) -> i64
 
 SYCL_EXTERNAL void nd_item_get_global_range_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_global_range(dimension));
@@ -355,7 +355,7 @@ SYCL_EXTERNAL void nd_item_get_global_range_1(sycl::nd_item<1> nd_item, int dime
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_local_range_0N4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_local_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_range(%{{.*}}) : (memref<?x!sycl_nd_item_1_>) -> !sycl_range_1_
 
 SYCL_EXTERNAL void nd_item_get_local_range_0(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_local_range());
@@ -363,7 +363,7 @@ SYCL_EXTERNAL void nd_item_get_local_range_0(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25nd_item_get_local_range_1N4sycl3_V17nd_itemILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>, i32], FunctionName = @get_local_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_local_range(%{{.*}}, %arg1) : (memref<?x!sycl_nd_item_1_>, i32) -> i64
 
 SYCL_EXTERNAL void nd_item_get_local_range_1(sycl::nd_item<1> nd_item, int dimension) {
   keep(nd_item.get_local_range(dimension));
@@ -371,7 +371,7 @@ SYCL_EXTERNAL void nd_item_get_local_range_1(sycl::nd_item<1> nd_item, int dimen
 
 // CHECK-MLIR-LABEL: func.func @_Z20nd_item_get_nd_rangeN4sycl3_V17nd_itemILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_nd_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_nd_item_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_nd_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_nd_item_1_, 4>], FunctionName = @get_nd_range, TypeName = @nd_item} : (memref<?x!sycl_nd_item_1_>) -> !sycl_nd_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.nd_item.get_nd_range(%{{.*}}) : (memref<?x!sycl_nd_item_1_>) -> !sycl_nd_range_1_
 
 SYCL_EXTERNAL void nd_item_get_nd_range(sycl::nd_item<1> nd_item) {
   keep(nd_item.get_nd_range());
@@ -379,7 +379,7 @@ SYCL_EXTERNAL void nd_item_get_nd_range(sycl::nd_item<1> nd_item) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_id, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}) : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
 
 SYCL_EXTERNAL void group_get_group_id_0(sycl::group<1> group) {
   keep(group.get_group_id());
@@ -387,7 +387,7 @@ SYCL_EXTERNAL void group_get_group_id_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_group_id, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}, %arg1) : (memref<?x!sycl_group_1_>, i32) -> i64
 
 SYCL_EXTERNAL void group_get_group_id_1(sycl::group<1> group, int dimension) {
   keep(group.get_group_id(dimension));
@@ -395,7 +395,7 @@ SYCL_EXTERNAL void group_get_group_id_1(sycl::group<1> group, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_group_id_2N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @"operator[]", TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_id(%{{.*}}, %arg1) : (memref<?x!sycl_group_1_>, i32) -> i64
 
 SYCL_EXTERNAL void group_get_group_id_2(sycl::group<1> group, int dimension) {
   keep(group[dimension]);
@@ -403,7 +403,7 @@ SYCL_EXTERNAL void group_get_group_id_2(sycl::group<1> group, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_local_id_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_local_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_id, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
+// CHECK-MLIR: %{{.*}} = sycl.group.get_local_id(%{{.*}}) : (memref<?x!sycl_group_1_>) -> !sycl_id_1_
 
 SYCL_EXTERNAL void group_get_local_id_0(sycl::group<1> group) {
   keep(group.get_local_id());
@@ -411,7 +411,7 @@ SYCL_EXTERNAL void group_get_local_id_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z20group_get_local_id_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_local_id(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_local_id, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_local_id(%{{.*}}, %arg1) : (memref<?x!sycl_group_1_>, i32) -> i64
 
 SYCL_EXTERNAL void group_get_local_id_1(sycl::group<1> group, int dimension) {
   keep(group.get_local_id(dimension));
@@ -419,7 +419,7 @@ SYCL_EXTERNAL void group_get_local_id_1(sycl::group<1> group, int dimension) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_local_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}
-// CHECK-MLIR: %{{.*}} = sycl.group.get_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_range, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.group.get_local_range(%{{.*}}) : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
 
 SYCL_EXTERNAL void group_get_local_range_0(sycl::group<1> group) {
   keep(group.get_local_range());
@@ -427,7 +427,7 @@ SYCL_EXTERNAL void group_get_local_range_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_local_range_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}, %arg1: i32 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_local_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_local_range, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_local_range(%{{.*}}, %arg1) : (memref<?x!sycl_group_1_>, i32) -> i64
 
 SYCL_EXTERNAL void group_get_local_range_1(sycl::group<1> group, int dimension) {
   keep(group.get_local_range(dimension));
@@ -435,7 +435,7 @@ SYCL_EXTERNAL void group_get_local_range_1(sycl::group<1> group, int dimension) 
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_group_range_0N4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}  
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_range, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_range(%{{.*}}) : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
 
 SYCL_EXTERNAL void group_get_group_range_0(sycl::group<1> group) {
   keep(group.get_group_range());
@@ -443,7 +443,7 @@ SYCL_EXTERNAL void group_get_group_range_0(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z23group_get_group_range_1N4sycl3_V15groupILi1EEEi(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}    
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_range(%{{.*}}, %arg1) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>, i32], FunctionName = @get_group_range, TypeName = @group} : (memref<?x!sycl_group_1_>, i32) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_range(%{{.*}}, %arg1) : (memref<?x!sycl_group_1_>, i32) -> i64
 
 SYCL_EXTERNAL void group_get_group_range_1(sycl::group<1> group, int dimension) {
   keep(group.get_group_range(dimension));
@@ -451,7 +451,7 @@ SYCL_EXTERNAL void group_get_group_range_1(sycl::group<1> group, int dimension) 
 
 // CHECK-MLIR-LABEL: func.func @_Z25group_get_max_local_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}      
-// CHECK-MLIR: %{{.*}} = sycl.group.get_max_local_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_max_local_range, TypeName = @group} : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
+// CHECK-MLIR: %{{.*}} = sycl.group.get_max_local_range(%{{.*}}) : (memref<?x!sycl_group_1_>) -> !sycl_range_1_
 
 SYCL_EXTERNAL void group_get_max_local_range(sycl::group<1> group) {
   keep(group.get_max_local_range());
@@ -459,7 +459,7 @@ SYCL_EXTERNAL void group_get_max_local_range(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25group_get_group_linear_idN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}        
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_linear_id, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_linear_id(%{{.*}}) : (memref<?x!sycl_group_1_>) -> i64
 
 SYCL_EXTERNAL void group_get_group_linear_id(sycl::group<1> group) {
   keep(group.get_group_linear_id());
@@ -467,7 +467,7 @@ SYCL_EXTERNAL void group_get_group_linear_id(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z25group_get_local_linear_idN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}          
-// CHECK-MLIR: %{{.*}} = sycl.group.get_local_linear_id(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_linear_id, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_local_linear_id(%{{.*}}) : (memref<?x!sycl_group_1_>) -> i64
 
 SYCL_EXTERNAL void group_get_local_linear_id(sycl::group<1> group) {
   keep(group.get_local_linear_id());
@@ -475,7 +475,7 @@ SYCL_EXTERNAL void group_get_local_linear_id(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z28group_get_group_linear_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef}            
-// CHECK-MLIR: %{{.*}} = sycl.group.get_group_linear_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_group_linear_range, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_group_linear_range(%{{.*}}) : (memref<?x!sycl_group_1_>) -> i64
 
 SYCL_EXTERNAL void group_get_group_linear_range(sycl::group<1> group) {
   keep(group.get_group_linear_range());
@@ -483,7 +483,7 @@ SYCL_EXTERNAL void group_get_group_linear_range(sycl::group<1> group) {
 
 // CHECK-MLIR-LABEL: func.func @_Z28group_get_local_linear_rangeN4sycl3_V15groupILi1EEE(
 // CHECK-MLIR:           %arg0: memref<?x!sycl_group_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_group_1_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.group.get_local_linear_range(%{{.*}}) {ArgumentTypes = [memref<?x!sycl_group_1_, 4>], FunctionName = @get_local_linear_range, TypeName = @group} : (memref<?x!sycl_group_1_>) -> i64
+// CHECK-MLIR: %{{.*}} = sycl.group.get_local_linear_range(%{{.*}}) : (memref<?x!sycl_group_1_>) -> i64
 
 SYCL_EXTERNAL void group_get_local_linear_range(sycl::group<1> group) {
   keep(group.get_local_linear_range());
@@ -516,8 +516,8 @@ SYCL_EXTERNAL void op_1(sycl::id<2> a, sycl::id<2> b) {
 // CHECK-MLIR:         %arg0: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef}, %arg1: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})
 // CHECK-MLIR-NEXT: %c1_i32 = arith.constant 1 : i32
 // CHECK-MLIR-NEXT: %c0_i32 = arith.constant 0 : i32
-// CHECK-MLIR-NEXT: %0 = sycl.id.get %arg0[%c0_i32] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, TypeName = @array} : (memref<?x!sycl_id_2_>, i32) -> i64
-// CHECK-MLIR-NEXT: %1 = sycl.id.get %arg0[%c1_i32] {ArgumentTypes = [memref<?x!sycl_array_2_, 4>, i32], FunctionName = @get, TypeName = @array} : (memref<?x!sycl_id_2_>, i32) -> i64
+// CHECK-MLIR-NEXT: %0 = sycl.id.get %arg0[%c0_i32] : (memref<?x!sycl_id_2_>, i32) -> i64
+// CHECK-MLIR-NEXT: %1 = sycl.id.get %arg0[%c1_i32] : (memref<?x!sycl_id_2_>, i32) -> i64
 // CHECK-MLIR-NEXT: %2 = arith.addi %0, %1 : i64
 // CHECK-MLIR-NEXT: %3 = sycl.call @abs(%2) {MangledFunctionName = @_ZN4sycl3_V13absImEENSt9enable_ifIXsr6detail14is_ugenintegerIT_EE5valueES3_E4typeES3_} : (i64) -> i64
 // CHECK-MLIR-NEXT: return

--- a/polygeist/tools/cgeist/Test/Verification/sycl/image.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/image.cpp
@@ -18,7 +18,7 @@ static constexpr unsigned N = 8;
 // CHECK-DAG:     %0 = llvm.mlir.undef : i32
 // CHECK-NEXT:    affine.store %0, %alloca[0] : memref<1xi32>
 // CHECK-NEXT:    %1 = "polygeist.memref2pointer"(%arg0) : (memref<?x!llvm.struct<(!sycl_accessor_1_21sycl2Evec3C5Bf322C_45D2C_28vector3C4xf323E293E_r_i)>, 4>) -> !llvm.ptr<4>
-// CHECK-NEXT:    %2 = sycl.item.get_id(%arg1, %c0_i32) {ArgumentTypes = [memref<?x!sycl_item_1_, 4>, i32], FunctionName = @"operator[]", TypeName = @item} : (memref<?x!sycl_item_1_>, i32) -> i64
+// CHECK-NEXT:    %2 = sycl.item.get_id(%arg1, %c0_i32) : (memref<?x!sycl_item_1_>, i32) -> i64
 // CHECK-NEXT:    %3 = arith.trunci %2 : i64 to i32
 // CHECK-NEXT:    %memspacecast = memref.memory_space_cast %cast : memref<?xi32> to memref<?xi32, 4>
 // CHECK-NEXT:    affine.store %3, %memspacecast[0] : memref<?xi32, 4>


### PR DESCRIPTION
Attributes `ArgumentTypes`, `FunctionName`, `MangledFunctionName` and `TypeName` are no longer used, so they can be dropped. 

As verification for these operations was trait-based and relied on the `FunctionName` attribute, this had to be changed too. Invalidity tests covering all possible failures for each trait added.