### PR TITLE
[SYCL][NFC] Ignore GCC compatibility warning for diagnose_if

### DIFF
--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -223,6 +223,15 @@ public:
   /// \return the backend associated with this device.
   backend get_backend() const noexcept;
 
+// Clang may warn about the use of diagnose_if in __SYCL_WARN_IMAGE_ASPECT, so
+// we disable that warning as we make appropriate checks to ensure its
+// existence.
+// TODO: Remove this diagnostics when __SYCL_WARN_IMAGE_ASPECT is removed.
+#if !defined(__SYCL_DEVICE_ONLY__) && defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgcc-compat"
+#endif // !defined(__SYCL_DEVICE_ONLY__) && defined(__clang__)
+
   /// Indicates if the SYCL device has the given feature.
   ///
   /// \param Aspect is one of the values in Table 4.20 of the SYCL 2020
@@ -230,6 +239,11 @@ public:
   ///
   /// \return true if the SYCL device has the given feature.
   bool has(aspect Aspect) const __SYCL_WARN_IMAGE_ASPECT(Aspect);
+
+// TODO: Remove this diagnostics when __SYCL_WARN_IMAGE_ASPECT is removed.
+#if !defined(__SYCL_DEVICE_ONLY__) && defined(__clang__)
+#pragma clang diagnostics pop
+#endif // !defined(__SYCL_DEVICE_ONLY__) && defined(__clang__)
 
 private:
   std::shared_ptr<detail::device_impl> impl;

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -227,10 +227,10 @@ public:
 // we disable that warning as we make appropriate checks to ensure its
 // existence.
 // TODO: Remove this diagnostics when __SYCL_WARN_IMAGE_ASPECT is removed.
-#if !defined(__SYCL_DEVICE_ONLY__) && defined(__clang__)
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgcc-compat"
-#endif // !defined(__SYCL_DEVICE_ONLY__) && defined(__clang__)
+#endif // defined(__clang__)
 
   /// Indicates if the SYCL device has the given feature.
   ///
@@ -241,9 +241,9 @@ public:
   bool has(aspect Aspect) const __SYCL_WARN_IMAGE_ASPECT(Aspect);
 
 // TODO: Remove this diagnostics when __SYCL_WARN_IMAGE_ASPECT is removed.
-#if !defined(__SYCL_DEVICE_ONLY__) && defined(__clang__)
+#if defined(__clang__)
 #pragma clang diagnostics pop
-#endif // !defined(__SYCL_DEVICE_ONLY__) && defined(__clang__)
+#endif // defined(__clang__)
 
 private:
   std::shared_ptr<detail::device_impl> impl;

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -242,7 +242,7 @@ public:
 
 // TODO: Remove this diagnostics when __SYCL_WARN_IMAGE_ASPECT is removed.
 #if defined(__clang__)
-#pragma clang diagnostics pop
+#pragma clang diagnostic pop
 #endif // defined(__clang__)
 
 private:

--- a/sycl/include/sycl/platform.hpp
+++ b/sycl/include/sycl/platform.hpp
@@ -141,6 +141,15 @@ public:
   /// \return the backend associated with this platform
   backend get_backend() const noexcept;
 
+// Clang may warn about the use of diagnose_if in __SYCL_WARN_IMAGE_ASPECT, so
+// we disable that warning as we make appropriate checks to ensure its
+// existence.
+// TODO: Remove this diagnostics when __SYCL_WARN_IMAGE_ASPECT is removed.
+#if !defined(__SYCL_DEVICE_ONLY__) && defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wgcc-compat"
+#endif // !defined(__SYCL_DEVICE_ONLY__) && defined(__clang__)
+
   /// Indicates if all of the SYCL devices on this platform have the
   /// given feature.
   ///
@@ -150,6 +159,11 @@ public:
   /// \return true if all of the SYCL devices on this platform have the
   /// given feature.
   bool has(aspect Aspect) const __SYCL_WARN_IMAGE_ASPECT(Aspect);
+
+// TODO: Remove this diagnostics when __SYCL_WARN_IMAGE_ASPECT is removed.
+#if !defined(__SYCL_DEVICE_ONLY__) && defined(__clang__)
+#pragma clang diagnostics pop
+#endif // !defined(__SYCL_DEVICE_ONLY__) && defined(__clang__)
 
   /// Return this platform's default context
   ///

--- a/sycl/include/sycl/platform.hpp
+++ b/sycl/include/sycl/platform.hpp
@@ -162,7 +162,7 @@ public:
 
 // TODO: Remove this diagnostics when __SYCL_WARN_IMAGE_ASPECT is removed.
 #if defined(__clang__)
-#pragma clang diagnostics pop
+#pragma clang diagnostic pop
 #endif // defined(__clang__)
 
   /// Return this platform's default context

--- a/sycl/include/sycl/platform.hpp
+++ b/sycl/include/sycl/platform.hpp
@@ -145,10 +145,10 @@ public:
 // we disable that warning as we make appropriate checks to ensure its
 // existence.
 // TODO: Remove this diagnostics when __SYCL_WARN_IMAGE_ASPECT is removed.
-#if !defined(__SYCL_DEVICE_ONLY__) && defined(__clang__)
+#if defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wgcc-compat"
-#endif // !defined(__SYCL_DEVICE_ONLY__) && defined(__clang__)
+#endif // defined(__clang__)
 
   /// Indicates if all of the SYCL devices on this platform have the
   /// given feature.
@@ -161,9 +161,9 @@ public:
   bool has(aspect Aspect) const __SYCL_WARN_IMAGE_ASPECT(Aspect);
 
 // TODO: Remove this diagnostics when __SYCL_WARN_IMAGE_ASPECT is removed.
-#if !defined(__SYCL_DEVICE_ONLY__) && defined(__clang__)
+#if defined(__clang__)
 #pragma clang diagnostics pop
-#endif // !defined(__SYCL_DEVICE_ONLY__) && defined(__clang__)
+#endif // defined(__clang__)
 
   /// Return this platform's default context
   ///


### PR DESCRIPTION
This commit ignores the warning about GCC compatibility produced by the use of diagnose_if in device::has and platform::has.