### PR TITLE
[SYCL-MLIR] Add `polygeist.struct` type

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistBase.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistBase.td
@@ -14,7 +14,7 @@ include "mlir/IR/OpBase.td"
 def Polygeist_Dialect : Dialect {
   let name = "polygeist";
   let cppNamespace = "::mlir::polygeist";
-  let description = [{}];
+  let useDefaultTypePrinterParser = 1;
 }
 
 #endif // POLYGEIST_BASE

--- a/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistOps.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistOps.td
@@ -12,6 +12,7 @@
 include "mlir/Dialect/LLVMIR/LLVMOpBase.td"
 include "mlir/Dialect/LLVMIR/LLVMInterfaces.td"
 include "mlir/Dialect/Polygeist/IR/PolygeistBase.td"
+include "mlir/Dialect/Polygeist/IR/PolygeistTypes.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/Interfaces/ViewLikeInterface.td"
 

--- a/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistTypes.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistTypes.h
@@ -9,6 +9,7 @@
 #ifndef MLIR_DIALECT_POLYGEIST_IR_POLYGEISTTYPES_H
 #define MLIR_DIALECT_POLYGEIST_IR_POLYGEISTTYPES_H
 
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/Polygeist/IR/PolygeistDialect.h"
 
 #define GET_TYPEDEF_CLASSES

--- a/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistTypes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistTypes.td
@@ -29,7 +29,7 @@ def Polygeist_StructType :
     Polygeist_Type<"Struct", "struct"> {
   let summary = "Polygeist Struct";
   let description = [{
-    Structure type that allowed to be the element type of MemRef and LLVM
+    Structure type that is allowed to be the element type of MemRef and LLVM
     Pointer.
   }];
   let parameters = (ins ArrayRefParameter<"mlir::Type">:$body);

--- a/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistTypes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistTypes.td
@@ -31,8 +31,9 @@ def Polygeist_StructType :
   let description = [{
     Type used to represent a collection of data members together in memory.
   }];
-  let parameters = (ins ArrayRefParameter<"mlir::Type">:$body);
-  let assemblyFormat = "`<` `(` $body `)` `>`";
+  let parameters = (ins ArrayRefParameter<"mlir::Type">:$body,
+                        OptionalParameter<"std::optional<StringAttr>">:$name);
+  let assemblyFormat = "`<` ($name^`,` )? `(` $body `)` `>`";
 }
 
 #endif // POLYGEIST_TYPES

--- a/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistTypes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistTypes.td
@@ -29,8 +29,7 @@ def Polygeist_StructType :
     Polygeist_Type<"Struct", "struct"> {
   let summary = "Polygeist Struct";
   let description = [{
-    Structure type that is allowed to be the element type of MemRef and LLVM
-    Pointer.
+    Type used to represent a collection of data members together in memory.
   }];
   let parameters = (ins ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `(` $body `)` `>`";

--- a/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistTypes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistTypes.td
@@ -25,4 +25,15 @@ class Polygeist_Type<string name, string typeMnemonic, list<Trait> traits = []>
   let mnemonic = typeMnemonic;
 }
 
+def Polygeist_StructType :
+    Polygeist_Type<"Struct", "struct"> {
+  let summary = "Polygeist Struct";
+  let description = [{
+    Structure type that allowed to be the element type of MemRef and LLVM
+    Pointer.
+  }];
+  let parameters = (ins ArrayRefParameter<"mlir::Type">:$body);
+  let assemblyFormat = "`<` `(` $body `)` `>`";
+}
+
 #endif // POLYGEIST_TYPES

--- a/polygeist/test/polygeist-opt/polygeist-types-to-llvm.mlir
+++ b/polygeist/test/polygeist-opt/polygeist-types-to-llvm.mlir
@@ -4,3 +4,10 @@
 func.func @test_struct(%arg0: !polygeist.struct<(memref<i32>, i32)>) {
   return
 }
+
+// -----
+
+// CHECK: llvm.func @test_struct(%arg0: !llvm.struct<"name", (ptr, i32)>)
+func.func @test_struct(%arg0: !polygeist.struct<"name", (memref<i32>, i32)>) {
+  return
+}

--- a/polygeist/test/polygeist-opt/polygeist-types-to-llvm.mlir
+++ b/polygeist/test/polygeist-opt/polygeist-types-to-llvm.mlir
@@ -1,0 +1,6 @@
+// RUN: polygeist-opt %s --convert-polygeist-to-llvm='use-opaque-pointers=1' --split-input-file | FileCheck %s
+
+// CHECK: llvm.func @test_struct(%arg0: !llvm.struct<(ptr, i32)>)
+func.func @test_struct(%arg0: !polygeist.struct<(memref<i32>, i32)>) {
+  return
+}


### PR DESCRIPTION
We want to have a structure type that is allowed to be the element type of MemRef.