### PR TITLE
[SYCL][NFC] Disable aspect::image warning in sycl-ls build

### DIFF
--- a/sycl/tools/sycl-ls/CMakeLists.txt
+++ b/sycl/tools/sycl-ls/CMakeLists.txt
@@ -8,6 +8,9 @@ if (WIN32 AND "${build_type_lower}" MATCHES "debug")
   set(sycl_lib sycld)
 endif()
 
+# Disable aspect::image warning.
+target_compile_definitions(sycl-ls PRIVATE SYCL_DISABLE_IMAGE_ASPECT_WARNING)
+
 target_link_libraries(sycl-ls
   PRIVATE
     ${sycl_lib}


### PR DESCRIPTION
This commit defines SYCL_DISABLE_IMAGE_ASPECT_WARNING to avoid the warning produced from the use of aspect::image.