### PR TITLE
[SYCL][NFC] Remove unused variable

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -2449,7 +2449,7 @@ public:
       // Special case for zero-dim accessors.
       parallel_for<
           class __fill<T, Dims, AccessMode, AccessTarget, IsPlaceholder>>(
-          range<1>(1), [=](id<1> Index) { Dst = Pattern; });
+          range<1>(1), [=](id<1>) { Dst = Pattern; });
     } else {
       range<Dims> Range = Dst.get_range();
       parallel_for<


### PR DESCRIPTION
This fixes `-Werror` build failure in post-commit after intel/llvm#9287