### PR TITLE
[SYCL-MLIR][ReachingDefinition] Fix potential modifiers map after free

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Analysis/ReachingDefinitionAnalysis.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Analysis/ReachingDefinitionAnalysis.cpp
@@ -212,6 +212,7 @@ void ReachingDefinitionAnalysis::visitOperation(
           // kills the potential definitions of values that may alias the
           // current value.
           result |= after->removeModifiers(val);
+          result |= after->removePotentialModifiers(val);
           for (Value aliasedVal : aliasQueries.getMustAlias(val))
             result |= after->removeModifiers(aliasedVal);
           for (Value aliasedVal : aliasQueries.getMayAlias(val))

--- a/polygeist/test/lib/Dialect/Polygeist/TestReachingDefinitionsAnalysis.cpp
+++ b/polygeist/test/lib/Dialect/Polygeist/TestReachingDefinitionsAnalysis.cpp
@@ -57,6 +57,8 @@ struct TestReachingDefinitionAnalysisPass
               llvm::errs() << "'" << *op << "'";
           },
           " ");
+      if (ops->empty())
+        llvm::errs() << "<none>";
       llvm::errs() << "\n";
     };
 

--- a/polygeist/test/polygeist-opt/reachingDefinitions.mlir
+++ b/polygeist/test/polygeist-opt/reachingDefinitions.mlir
@@ -4,11 +4,11 @@
 // CHECK-LABEL: test_tag: test1_load1
 // CHECK: operand #0
 // CHECK-NEXT: - mods: test1_store1
-// CHECK-NEXT: - pMods: 
+// CHECK-NEXT: - pMods: <none>
 // CHECK-LABEL: test_tag: test1_load2
 // CHECK: operand #0
 // CHECK-NEXT: - mods: test1_store2
-// CHECK-NEXT: - pMods: 
+// CHECK-NEXT: - pMods: <none>
 func.func @test1(%val: i32, %idx: index) {
   %alloca = memref.alloca() : memref<1xi32>
   %alloca_0 = memref.alloca() : memref<1xi32>
@@ -23,7 +23,7 @@ func.func @test1(%val: i32, %idx: index) {
 // CHECK-LABEL: test_tag: test2_load1
 // CHECK: operand #0
 // CHECK-NEXT: - mods: test2_store1
-// CHECK-NEXT: - pMods: 
+// CHECK-NEXT: - pMods: <none>
 func.func @test2(%val: i32, %idx: index) {
   %alloca = memref.alloca() : memref<1xi32>
   %cast = memref.cast %alloca : memref<1xi32> to memref<?xi32>
@@ -36,7 +36,7 @@ func.func @test2(%val: i32, %idx: index) {
 // CHECK-LABEL: test_tag: test3_load1
 // CHECK: operand #0
 // CHECK-NEXT: - mods: test3_store2
-// CHECK-NEXT: - pMods:
+// CHECK-NEXT: - pMods: <none>
 func.func @test3(%val : i32, %idx: index) {
   %alloca = memref.alloca()  : memref<1xi32>
   %cast = memref.cast %alloca : memref<1xi32> to memref<?xi32>
@@ -89,7 +89,7 @@ func.func @test5(%cond: i1, %arg1: memref<i32>, %arg2: memref<i32>) {
 // CHECK-LABEL: test_tag: test6_load1
 // CHECK: operand #0
 // CHECK-NEXT: - mods: test6_store2
-// CHECK-NEXT: - pMods:
+// CHECK-NEXT: - pMods: <none>
 func.func @test6(%arg1: memref<i32>, %arg2: memref<i32>) {
   %c0 = arith.constant 0 : i32
   memref.store %c0, %arg2[] {tag_name = "test6_store1"}: memref<i32>
@@ -101,11 +101,11 @@ func.func @test6(%arg1: memref<i32>, %arg2: memref<i32>) {
 // COM: Test that a deallocation kills a previous potential definition.
 // CHECK-LABEL: test_tag: test7_load1
 // CHECK: operand #0
-// CHECK-NEXT: - mods:
+// CHECK-NEXT: - mods: <unknown>
 // CHECK-NEXT: - pMods: test7_store1
 // CHECK: operand #0
-// CHECK-NEXT: - mods:
-// CHECK-NEXT: - pMods:
+// CHECK-NEXT: - mods: <unknown>
+// CHECK-NEXT: - pMods: <none>
 func.func @test7(%arg1: memref<i32>, %arg2: memref<i32>) {
   %c0 = arith.constant 0 : i32
   memref.store %c0, %arg2[] {tag_name = "test7_store1"} : memref<i32>
@@ -119,15 +119,15 @@ func.func @test7(%arg1: memref<i32>, %arg2: memref<i32>) {
 // CHECK-LABEL: test_tag: test8_load1
 // CHECK: operand #0
 // CHECK-NEXT: - mods: test8_store1
-// CHECK-NEXT: - pMods:
+// CHECK-NEXT: - pMods: <none>
 // CHECK-LABEL: test_tag: test8_load2
 // CHECK: operand #0
-// CHECK-NEXT: - mods:
-// CHECK-NEXT: - pMods:
+// CHECK-NEXT: - mods: <none>
+// CHECK-NEXT: - pMods: <none>
 // CHECK-LABEL: test_tag: test8_load3
 // CHECK: operand #0
-// CHECK-NEXT: - mods:
-// CHECK-NEXT: - pMods:
+// CHECK-NEXT: - mods: <none>
+// CHECK-NEXT: - pMods: <none>
 func.func @test8(%val: i32, %idx : index) {
   %alloc = memref.alloc() : memref<1xi32>
   %cast = memref.cast %alloc : memref<1xi32> to memref<?xi32>
@@ -154,7 +154,7 @@ func.func @test9(%arg1: memref<i32>) {
 // CHECK-LABEL: test_tag: test10_load1
 // CHECK: operand #0
 // CHECK-NEXT: - mods: test10_store1
-// CHECK-NEXT: - pMods:
+// CHECK-NEXT: - pMods: <none>
 // CHECK-LABEL: test_tag: test10_load2
 // CHECK: operand #0
 // CHECK-NEXT: - mods: <unknown>
@@ -174,11 +174,11 @@ func.func @test10(%val: i32) {
 // CHECK-LABEL: test_tag: test11_load1
 // CHECK: operand #0
 // CHECK-NEXT: - mods: test11_store2 test11_store1
-// CHECK-NEXT: - pMods:
+// CHECK-NEXT: - pMods: <none>
 // CHECK-LABEL: test_tag: test11_load2
 // CHECK: operand #0
-// CHECK-NEXT: - mods:
-// CHECK-NEXT: - pMods:
+// CHECK-NEXT: - mods: <none>
+// CHECK-NEXT: - pMods: <none>
 func.func @test11(%cond: i1, %val: i32, %arg1: memref<i32>, %arg2: memref<i32>) {
   memref.store %val, %arg1[] {tag_name = "test11_store1"} : memref<i32>
   scf.if %cond {


### PR DESCRIPTION
Need to remove all potential modifiers after freeing it. 
The `pmod` of `test11_load2` in `@test11` was not an empty list. 
Modified all test cases to explicitly check for empty list `<none>`, to avoid hidden bugs.