### PR TITLE
[SYCL] Enable improved code location for SYCL extensions

### DIFF
--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -104,10 +104,12 @@ private:
 
 #ifndef DISABLE_SYCL_INSTRUMENTATION_METADATA
 #define _CODELOCONLYPARAM(a)                                                   \
-  const detail::code_location a = detail::code_location::current()
+  const ::sycl::detail::code_location a =                                      \
+      ::sycl::detail::code_location::current()
 #define _CODELOCPARAM(a)                                                       \
-  , const detail::code_location a = detail::code_location::current()
-#define _CODELOCPARAMDEF(a) , const detail::code_location a
+  , const ::sycl::detail::code_location a =                                    \
+        ::sycl::detail::code_location::current()
+#define _CODELOCPARAMDEF(a) , const ::sycl::detail::code_location a
 
 #define _CODELOCARG(a)
 #define _CODELOCFW(a) , a
@@ -115,7 +117,7 @@ private:
 #define _CODELOCONLYPARAM(a)
 #define _CODELOCPARAM(a)
 
-#define _CODELOCARG(a) const detail::code_location a = {}
+#define _CODELOCARG(a) const ::sycl::detail::code_location a = {}
 #define _CODELOCFW(a)
 #endif
 


### PR DESCRIPTION
This patch enables an improved code location for vendor specific extensions nested inside the `sycl` namespace, i. e. `ext::oneapi::experimental`.