### PR TITLE
[SYCL] No L0_Loader in product.

### DIFF
--- a/sycl/plugins/level_zero/CMakeLists.txt
+++ b/sycl/plugins/level_zero/CMakeLists.txt
@@ -140,23 +140,6 @@ add_sycl_plugin(level_zero
     ${XPTI_LIBS}
 )
 
-#FIXME: We should stop shipping level zero loader and headers as part of the
-#       toolchain installation. Instead these should be avaialble in the system.
-#       We keep shipping it until all environments are updated.
-if (TARGET ze_loader)
-  install(TARGETS ze_loader
-      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT level-zero-sycl-dev
-      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT level-zero-sycl-dev
-      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT level-zero-sycl-dev
-  )
-  file(GLOB LEVEL_ZERO_API_HEADERS "${LEVEL_ZERO_INCLUDE_DIR}/*.h")
-  install(FILES ${LEVEL_ZERO_API_HEADERS}
-      DESTINATION ${CMAKE_INSTALL_PREFIX}/include/sycl/level_zero/
-      COMPONENT level-zero-sycl-dev
-  )
-endif()
-# end of FIXME
-
 add_dependencies(pi_level_zero ze-api)
 
 if (SYCL_ENABLE_XPTI_TRACING)


### PR DESCRIPTION
Was temporarily added to enable win GHA testing in December, but should no longer be necessary.