### PR TITLE
[SYCL][CUDA][TEST-E2E] enable sycl-ls-gpu-default-any on CUDA

### DIFF
--- a/sycl/test-e2e/Plugin/sycl-ls-gpu-default-any.cpp
+++ b/sycl/test-e2e/Plugin/sycl-ls-gpu-default-any.cpp
@@ -19,8 +19,6 @@
 
 // This test checks that a valid GPU is returned by sycl-ls by default if one
 // is present.
-// The test crashed on CUDA CI machines with the latest OpenCL GPU RT
-// (21.19.19792).
 // UNSUPPORTED: hip
 // Temporarily disable on L0 due to fails in CI
 // UNSUPPORTED: level_zero


### PR DESCRIPTION
This is a migration of this PR https://github.com/intel/llvm-test-suite/pull/1144/commits