### PR TITLE
[SYCL][CUDA] Check make_device doesn't create duplicate sycl::device

### DIFF
--- a/sycl/test-e2e/Plugin/interop-cuda-experimental.cpp
+++ b/sycl/test-e2e/Plugin/interop-cuda-experimental.cpp
@@ -67,10 +67,13 @@ int main() {
   CUDA_CHECK(cuDeviceGet(&cu_dev, 0));
   auto sycl_dev = sycl::make_device<sycl::backend::ext_oneapi_cuda>(cu_dev);
   auto native_dev = sycl::get_native<sycl::backend::ext_oneapi_cuda>(sycl_dev);
+  auto sycl_dev2 =
+      sycl::make_device<sycl::backend::ext_oneapi_cuda>(native_dev);
 
   check_type<sycl::device>(sycl_dev);
   check_type<CUdevice>(native_dev);
   assert(native_dev == cu_dev);
+  assert(sycl_dev == sycl_dev2);
 
   // Create sycl queue with new device and submit some work
   {


### PR DESCRIPTION
[SYCL][CUDA] Check make_device doesn't create duplicate sycl::device.

Migration of https://github.com/intel/llvm-test-suite/pull/1419

Tests https://github.com/intel/llvm/pull/7550. Checks that make_device doesn't return a duplicate sycl::device if one already exists.