### PR TITLE
[SYCL] Add decorated async_work_group_copy overloads

### DIFF
--- a/sycl/include/CL/__spirv/spirv_ops.hpp
+++ b/sycl/include/CL/__spirv/spirv_ops.hpp
@@ -1229,7 +1229,7 @@ extern __DPCPP_SYCL_EXTERNAL int32_t __spirv_BuiltInSubDeviceIDINTEL();
 template <typename dataT>
 __SYCL_CONVERGENT__ extern __ocl_event_t
 __SYCL_OpGroupAsyncCopyGlobalToLocal(__spv::Scope::Flag, dataT *Dest,
-                                     dataT *Src, size_t NumElements,
+                                     const dataT *Src, size_t NumElements,
                                      size_t Stride, __ocl_event_t) noexcept {
   for (size_t i = 0; i < NumElements; i++) {
     Dest[i] = Src[i * Stride];
@@ -1241,7 +1241,7 @@ __SYCL_OpGroupAsyncCopyGlobalToLocal(__spv::Scope::Flag, dataT *Dest,
 template <typename dataT>
 __SYCL_CONVERGENT__ extern __ocl_event_t
 __SYCL_OpGroupAsyncCopyLocalToGlobal(__spv::Scope::Flag, dataT *Dest,
-                                     dataT *Src, size_t NumElements,
+                                     const dataT *Src, size_t NumElements,
                                      size_t Stride, __ocl_event_t) noexcept {
   for (size_t i = 0; i < NumElements; i++) {
     Dest[i * Stride] = Src[i];

--- a/sycl/include/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/sycl/detail/generic_type_traits.hpp
@@ -505,7 +505,7 @@ using select_cl_scalar_t = std::conditional_t<
         // half is a special case: it is implemented differently on
         // host and device and therefore, might lower to different
         // types
-        std::conditional_t<std::is_same_v<T, half>,
+        std::conditional_t<is_half<T>::value,
                            sycl::detail::half_impl::BIsRepresentationT,
                            select_cl_scalar_complex_or_T_t<T>>>>;
 
@@ -522,7 +522,7 @@ struct select_cl_vector_or_scalar_or_ptr<
       // select_cl_scalar_t returns _Float16, so, we try to instantiate vec
       // class with _Float16 DataType, which is not expected there
       // So, leave vector<half, N> as-is
-      vec<std::conditional_t<std::is_same_v<mptr_or_vec_elem_type_t<T>, half>,
+      vec<std::conditional_t<is_half<mptr_or_vec_elem_type_t<T>>::value,
                              mptr_or_vec_elem_type_t<T>,
                              select_cl_scalar_t<mptr_or_vec_elem_type_t<T>>>,
           T::size()>;
@@ -566,6 +566,18 @@ template <> struct TypeHelper<std::byte> {
   using RetType = std::uint8_t;
 };
 #endif
+
+template <typename T> struct TypeHelper<const T> {
+  using RetType = const typename TypeHelper<T>::RetType;
+};
+
+template <typename T> struct TypeHelper<volatile T> {
+  using RetType = volatile typename TypeHelper<T>::RetType;
+};
+
+template <typename T> struct TypeHelper<const volatile T> {
+  using RetType = const volatile typename TypeHelper<T>::RetType;
+};
 
 template <typename T> using type_helper = typename TypeHelper<T>::RetType;
 

--- a/sycl/include/sycl/nd_item.hpp
+++ b/sycl/include/sycl/nd_item.hpp
@@ -131,30 +131,65 @@ public:
   }
 
   template <typename dataT>
-  device_event async_work_group_copy(local_ptr<dataT> dest,
-                                     global_ptr<dataT> src,
-                                     size_t numElements) const {
+  __SYCL2020_DEPRECATED("Use decorated multi_ptr arguments instead")
+  device_event
+      async_work_group_copy(local_ptr<dataT> dest, global_ptr<dataT> src,
+                            size_t numElements) const {
     return Group.async_work_group_copy(dest, src, numElements);
   }
 
   template <typename dataT>
-  device_event async_work_group_copy(global_ptr<dataT> dest,
-                                     local_ptr<dataT> src,
-                                     size_t numElements) const {
+  __SYCL2020_DEPRECATED("Use decorated multi_ptr arguments instead")
+  device_event
+      async_work_group_copy(global_ptr<dataT> dest, local_ptr<dataT> src,
+                            size_t numElements) const {
     return Group.async_work_group_copy(dest, src, numElements);
   }
 
   template <typename dataT>
-  device_event async_work_group_copy(local_ptr<dataT> dest,
-                                     global_ptr<dataT> src, size_t numElements,
-                                     size_t srcStride) const {
+  __SYCL2020_DEPRECATED("Use decorated multi_ptr arguments instead")
+  device_event
+      async_work_group_copy(local_ptr<dataT> dest, global_ptr<dataT> src,
+                            size_t numElements, size_t srcStride) const {
 
     return Group.async_work_group_copy(dest, src, numElements, srcStride);
   }
 
   template <typename dataT>
-  device_event async_work_group_copy(global_ptr<dataT> dest,
-                                     local_ptr<dataT> src, size_t numElements,
+  __SYCL2020_DEPRECATED("Use decorated multi_ptr arguments instead")
+  device_event
+      async_work_group_copy(global_ptr<dataT> dest, local_ptr<dataT> src,
+                            size_t numElements, size_t destStride) const {
+    return Group.async_work_group_copy(dest, src, numElements, destStride);
+  }
+
+  template <typename DestDataT, typename SrcDataT>
+  device_event async_work_group_copy(decorated_local_ptr<DestDataT> dest,
+                                     decorated_global_ptr<SrcDataT> src,
+                                     size_t numElements) const {
+    return Group.async_work_group_copy(dest, src, numElements);
+  }
+
+  template <typename DestDataT, typename SrcDataT>
+  device_event async_work_group_copy(decorated_global_ptr<DestDataT> dest,
+                                     decorated_local_ptr<SrcDataT> src,
+                                     size_t numElements) const {
+    return Group.async_work_group_copy(dest, src, numElements);
+  }
+
+  template <typename DestDataT, typename SrcDataT>
+  device_event async_work_group_copy(decorated_local_ptr<DestDataT> dest,
+                                     decorated_global_ptr<SrcDataT> src,
+                                     size_t numElements,
+                                     size_t srcStride) const {
+
+    return Group.async_work_group_copy(dest, src, numElements, srcStride);
+  }
+
+  template <typename DestDataT, typename SrcDataT>
+  device_event async_work_group_copy(decorated_global_ptr<DestDataT> dest,
+                                     decorated_local_ptr<SrcDataT> src,
+                                     size_t numElements,
                                      size_t destStride) const {
     return Group.async_work_group_copy(dest, src, numElements, destStride);
   }

--- a/sycl/test-e2e/GroupAlgorithm/barrier.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/barrier.cpp
@@ -84,8 +84,9 @@ void interface() {
         }
         item.barrier(access::fence_space::local_space);
 
-        item.async_work_group_copy(loc.get_pointer(), data_acc.get_pointer(),
-                                   N);
+        item.async_work_group_copy(
+            loc.get_multi_ptr<access::decorated::yes>(),
+            data_acc.get_multi_ptr<access::decorated::yes>(), N);
         loc_barrier[1].arrive_copy_async();
         barrier::arrival_token arr = loc_barrier[1].arrive_no_complete(N - 1);
         loc_barrier[1].arrive_and_wait();
@@ -114,8 +115,9 @@ void interface() {
         loc[dst_idx] = val;
         loc_barrier[0].wait(loc_barrier[0].arrive());
 
-        item.async_work_group_copy(data_acc.get_pointer(), loc.get_pointer(),
-                                   N);
+        item.async_work_group_copy(
+            data_acc.get_multi_ptr<access::decorated::yes>(),
+            loc.get_multi_ptr<access::decorated::yes>(), N);
         loc_barrier[1].arrive_copy_async_no_inc();
         loc_barrier[1].arrive_no_complete(N - 3);
         arr = loc_barrier[1].arrive();

--- a/sycl/test-e2e/Regression/group.cpp
+++ b/sycl/test-e2e/Regression/group.cpp
@@ -192,8 +192,9 @@ bool group__async_work_group_copy() {
               const auto NumElem = AccLocal.get_count();
               const auto Off = Group[0] * I.get_group_range(1) * NumElem +
                                Group[1] * I.get_local_range(1);
-              auto PtrGlobal = AccGlobal.get_pointer() + Off;
-              auto PtrLocal = local_ptr<DataType>(AccLocal);
+              auto PtrGlobal =
+                  AccGlobal.get_multi_ptr<access::decorated::yes>() + Off;
+              auto PtrLocal = AccLocal.get_multi_ptr<access::decorated::yes>();
               if (I.get_local_range(0) == 1) {
                 Group.async_work_group_copy(PtrLocal, PtrGlobal, NumElem);
               } else {

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -317,77 +317,107 @@ int main() {
   Queue.submit([&](sycl::handler &CGH) {
     sycl::accessor GlobalAcc{Buffer, CGH, sycl::write_only};
     sycl::local_accessor<int, 1> LocalAcc{1, CGH};
-    CGH.single_task([=]() {
-      int PrivateVal = 0;
+    CGH.parallel_for(
+        sycl::nd_range<1>{sycl::range<1>{1}, sycl::range<1>{1}},
+        [=](sycl::nd_item<1> Idx) {
+          int PrivateVal = 0;
 
-      // expected-warning@+4{{'make_ptr<int, sycl::access::address_space::global_space, sycl::access::decorated::legacy, std::enable_if<true>>' is deprecated: make_ptr is deprecated since SYCL 2020. Please use address_space_cast instead.}}
-      sycl::multi_ptr<int, sycl::access::address_space::global_space,
-                      sycl::access::decorated::legacy>
-          LegacyGlobalMptr =
-              sycl::make_ptr<int, sycl::access::address_space::global_space,
-                             sycl::access::decorated::legacy>(
-                  GlobalAcc.get_pointer());
-      // expected-warning@+4{{'make_ptr<int, sycl::access::address_space::local_space, sycl::access::decorated::legacy, std::enable_if<true>>' is deprecated: make_ptr is deprecated since SYCL 2020. Please use address_space_cast instead.}}
-      sycl::multi_ptr<int, sycl::access::address_space::local_space,
-                      sycl::access::decorated::legacy>
-          LegacyLocalMptr =
-              sycl::make_ptr<int, sycl::access::address_space::local_space,
-                             sycl::access::decorated::legacy>(
-                  LocalAcc.get_pointer());
-      // expected-warning@+4{{'make_ptr<int, sycl::access::address_space::private_space, sycl::access::decorated::legacy, std::enable_if<true>>' is deprecated: make_ptr is deprecated since SYCL 2020. Please use address_space_cast instead.}}
-      sycl::multi_ptr<int, sycl::access::address_space::private_space,
-                      sycl::access::decorated::legacy>
-          LegacyPrivateMptr =
-              sycl::make_ptr<int, sycl::access::address_space::private_space,
-                             sycl::access::decorated::legacy>(&PrivateVal);
+          // expected-warning@+4{{'make_ptr<int, sycl::access::address_space::global_space, sycl::access::decorated::legacy, std::enable_if<true>>' is deprecated: make_ptr is deprecated since SYCL 2020. Please use address_space_cast instead.}}
+          sycl::multi_ptr<int, sycl::access::address_space::global_space,
+                          sycl::access::decorated::legacy>
+              LegacyGlobalMptr =
+                  sycl::make_ptr<int, sycl::access::address_space::global_space,
+                                 sycl::access::decorated::legacy>(
+                      GlobalAcc.get_pointer());
+          // expected-warning@+4{{'make_ptr<int, sycl::access::address_space::local_space, sycl::access::decorated::legacy, std::enable_if<true>>' is deprecated: make_ptr is deprecated since SYCL 2020. Please use address_space_cast instead.}}
+          sycl::multi_ptr<int, sycl::access::address_space::local_space,
+                          sycl::access::decorated::legacy>
+              LegacyLocalMptr =
+                  sycl::make_ptr<int, sycl::access::address_space::local_space,
+                                 sycl::access::decorated::legacy>(
+                      LocalAcc.get_pointer());
+          // expected-warning@+4{{'make_ptr<int, sycl::access::address_space::private_space, sycl::access::decorated::legacy, std::enable_if<true>>' is deprecated: make_ptr is deprecated since SYCL 2020. Please use address_space_cast instead.}}
+          sycl::multi_ptr<int, sycl::access::address_space::private_space,
+                          sycl::access::decorated::legacy>
+              LegacyPrivateMptr =
+                  sycl::make_ptr<int,
+                                 sycl::access::address_space::private_space,
+                                 sycl::access::decorated::legacy>(&PrivateVal);
 
-      sycl::multi_ptr<int, sycl::access::address_space::global_space,
-                      sycl::access::decorated::yes>
-          DecoratedGlobalMptr{GlobalAcc};
-      sycl::multi_ptr<int, sycl::access::address_space::local_space,
-                      sycl::access::decorated::yes>
-          DecoratedLocalMptr{LocalAcc};
-      sycl::multi_ptr<int, sycl::access::address_space::private_space,
-                      sycl::access::decorated::yes>
-          DecoratedPrivateMptr = sycl::address_space_cast<
-              sycl::access::address_space::private_space,
-              sycl::access::decorated::yes>(&PrivateVal);
+          sycl::multi_ptr<int, sycl::access::address_space::global_space,
+                          sycl::access::decorated::yes>
+              DecoratedGlobalMptr{GlobalAcc};
+          sycl::multi_ptr<int, sycl::access::address_space::local_space,
+                          sycl::access::decorated::yes>
+              DecoratedLocalMptr{LocalAcc};
+          sycl::multi_ptr<int, sycl::access::address_space::private_space,
+                          sycl::access::decorated::yes>
+              DecoratedPrivateMptr = sycl::address_space_cast<
+                  sycl::access::address_space::private_space,
+                  sycl::access::decorated::yes>(&PrivateVal);
 
-      sycl::multi_ptr<int, sycl::access::address_space::global_space,
-                      sycl::access::decorated::yes>
-          UndecoratedGlobalMptr = DecoratedGlobalMptr;
-      sycl::multi_ptr<int, sycl::access::address_space::local_space,
-                      sycl::access::decorated::yes>
-          UndecoratedLocalMptr = DecoratedLocalMptr;
-      sycl::multi_ptr<int, sycl::access::address_space::private_space,
-                      sycl::access::decorated::yes>
-          UndecoratedPrivateMptr = DecoratedPrivateMptr;
+          sycl::multi_ptr<int, sycl::access::address_space::global_space,
+                          sycl::access::decorated::yes>
+              UndecoratedGlobalMptr = DecoratedGlobalMptr;
+          sycl::multi_ptr<int, sycl::access::address_space::local_space,
+                          sycl::access::decorated::yes>
+              UndecoratedLocalMptr = DecoratedLocalMptr;
+          sycl::multi_ptr<int, sycl::access::address_space::private_space,
+                          sycl::access::decorated::yes>
+              UndecoratedPrivateMptr = DecoratedPrivateMptr;
 
-      // expected-warning@+2{{'operator int *' is deprecated: Conversion to pointer type is deprecated since SYCL 2020. Please use get() instead.}}
-      auto DecoratedGlobalPtr =
-          static_cast<typename decltype(DecoratedGlobalMptr)::pointer>(
-              DecoratedGlobalMptr);
-      // expected-warning@+2{{'operator int *' is deprecated: Conversion to pointer type is deprecated since SYCL 2020. Please use get() instead.}}
-      auto DecoratedLocalPtr =
-          static_cast<typename decltype(DecoratedLocalMptr)::pointer>(
-              DecoratedLocalMptr);
-      // expected-warning@+2{{'operator int *' is deprecated: Conversion to pointer type is deprecated since SYCL 2020. Please use get() instead.}}
-      auto DecoratedPrivatePtr =
-          static_cast<typename decltype(DecoratedPrivateMptr)::pointer>(
-              DecoratedPrivateMptr);
-      // expected-warning@+2{{'operator int *' is deprecated: Conversion to pointer type is deprecated since SYCL 2020. Please use get() instead.}}
-      auto UndecoratedGlobalPtr =
-          static_cast<typename decltype(UndecoratedGlobalMptr)::pointer>(
-              UndecoratedGlobalMptr);
-      // expected-warning@+2{{'operator int *' is deprecated: Conversion to pointer type is deprecated since SYCL 2020. Please use get() instead.}}
-      auto UndecoratedLocalPtr =
-          static_cast<typename decltype(UndecoratedLocalMptr)::pointer>(
-              UndecoratedLocalMptr);
-      // expected-warning@+2{{'operator int *' is deprecated: Conversion to pointer type is deprecated since SYCL 2020. Please use get() instead.}}
-      auto UndecoratedPrivatePtr =
-          static_cast<typename decltype(UndecoratedPrivateMptr)::pointer>(
-              UndecoratedPrivateMptr);
-    });
+          // expected-warning@+2{{'operator int *' is deprecated: Conversion to pointer type is deprecated since SYCL 2020. Please use get() instead.}}
+          auto DecoratedGlobalPtr =
+              static_cast<typename decltype(DecoratedGlobalMptr)::pointer>(
+                  DecoratedGlobalMptr);
+          // expected-warning@+2{{'operator int *' is deprecated: Conversion to pointer type is deprecated since SYCL 2020. Please use get() instead.}}
+          auto DecoratedLocalPtr =
+              static_cast<typename decltype(DecoratedLocalMptr)::pointer>(
+                  DecoratedLocalMptr);
+          // expected-warning@+2{{'operator int *' is deprecated: Conversion to pointer type is deprecated since SYCL 2020. Please use get() instead.}}
+          auto DecoratedPrivatePtr =
+              static_cast<typename decltype(DecoratedPrivateMptr)::pointer>(
+                  DecoratedPrivateMptr);
+          // expected-warning@+2{{'operator int *' is deprecated: Conversion to pointer type is deprecated since SYCL 2020. Please use get() instead.}}
+          auto UndecoratedGlobalPtr =
+              static_cast<typename decltype(UndecoratedGlobalMptr)::pointer>(
+                  UndecoratedGlobalMptr);
+          // expected-warning@+2{{'operator int *' is deprecated: Conversion to pointer type is deprecated since SYCL 2020. Please use get() instead.}}
+          auto UndecoratedLocalPtr =
+              static_cast<typename decltype(UndecoratedLocalMptr)::pointer>(
+                  UndecoratedLocalMptr);
+          // expected-warning@+2{{'operator int *' is deprecated: Conversion to pointer type is deprecated since SYCL 2020. Please use get() instead.}}
+          auto UndecoratedPrivatePtr =
+              static_cast<typename decltype(UndecoratedPrivateMptr)::pointer>(
+                  UndecoratedPrivateMptr);
+
+          // expected-warning@+2{{'async_work_group_copy' is deprecated: Use decorated multi_ptr arguments instead}}
+          // expected-warning@+1{{'async_work_group_copy<int>' is deprecated: Use decorated multi_ptr arguments instead}}
+          Idx.async_work_group_copy(LegacyGlobalMptr, LegacyLocalMptr, 10);
+          // expected-warning@+2{{'async_work_group_copy' is deprecated: Use decorated multi_ptr arguments instead}}
+          // expected-warning@+1{{'async_work_group_copy<int>' is deprecated: Use decorated multi_ptr arguments instead}}
+          Idx.async_work_group_copy(LegacyLocalMptr, LegacyGlobalMptr, 10);
+          // expected-warning@+2{{'async_work_group_copy' is deprecated: Use decorated multi_ptr arguments instead}}
+          // expected-warning@+1{{'async_work_group_copy<int>' is deprecated: Use decorated multi_ptr arguments instead}}
+          Idx.async_work_group_copy(LegacyGlobalMptr, LegacyLocalMptr, 10, 2);
+          // expected-warning@+2{{'async_work_group_copy' is deprecated: Use decorated multi_ptr arguments instead}}
+          // expected-warning@+1{{'async_work_group_copy<int>' is deprecated: Use decorated multi_ptr arguments instead}}
+          Idx.async_work_group_copy(LegacyLocalMptr, LegacyGlobalMptr, 10, 2);
+
+          auto Group = Idx.get_group();
+          // expected-warning@+2{{'async_work_group_copy' is deprecated: Use decorated multi_ptr arguments instead}}
+          // expected-warning@+1{{'async_work_group_copy<int>' is deprecated: Use decorated multi_ptr arguments instead}}
+          Group.async_work_group_copy(LegacyGlobalMptr, LegacyLocalMptr, 10);
+          // expected-warning@+2{{'async_work_group_copy' is deprecated: Use decorated multi_ptr arguments instead}}
+          // expected-warning@+1{{'async_work_group_copy<int>' is deprecated: Use decorated multi_ptr arguments instead}}
+          Group.async_work_group_copy(LegacyLocalMptr, LegacyGlobalMptr, 10);
+          // expected-warning@+2{{'async_work_group_copy' is deprecated: Use decorated multi_ptr arguments instead}}
+          // expected-warning@+1{{'async_work_group_copy<int>' is deprecated: Use decorated multi_ptr arguments instead}}
+          Group.async_work_group_copy(LegacyGlobalMptr, LegacyLocalMptr, 10, 2);
+          // expected-warning@+2{{'async_work_group_copy' is deprecated: Use decorated multi_ptr arguments instead}}
+          // expected-warning@+1{{'async_work_group_copy<int>' is deprecated: Use decorated multi_ptr arguments instead}}
+          Group.async_work_group_copy(LegacyLocalMptr, LegacyGlobalMptr, 10, 2);
+        });
   });
 
   Queue.submit([&](sycl::handler &CGH) {


### PR DESCRIPTION
This commit adds new overloads to async_work_group_copy on both group and nd_item, in accordance with the change in the corresponding interface introduced by SYCL 2020 and https://github.com/KhronosGroup/SYCL-Docs/pull/402. Additionally, this commit deprecates the old 1.2.1 interfaces, instructing the user to switch to the new decorated variants.