### PR TITLE
[SYCL] Fix compilation line in fpga tests

### DIFF
--- a/sycl/test-e2e/Basic/context-with-multiple-devices.cpp
+++ b/sycl/test-e2e/Basic/context-with-multiple-devices.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: accelerator, opencl-aot
 
-// RUN: %{build} -fintelfpga -o %t2.out
+// RUN: %clangxx -fsycl -fintelfpga %s -o %t2.out
 // RUN: env CL_CONFIG_CPU_EMULATE_DEVICES=2 %t2.out
 
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/Basic/fpga_tests/fpga_dsp_control.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_dsp_control.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: accelerator, opencl-aot
-// RUN: %{build} -fintelfpga -o %t.out
+// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <iostream>

--- a/sycl/test-e2e/Basic/fpga_tests/fpga_latency_control_lsu.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_latency_control_lsu.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: opencl-aot, accelerator
-// RUN: %{build} -fintelfpga -o %t.out
+// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <iostream>

--- a/sycl/test-e2e/Basic/fpga_tests/fpga_latency_control_pipe.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_latency_control_pipe.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: opencl-aot, accelerator
-// RUN: %{build} -fintelfpga -o %t.out
+// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <iostream>

--- a/sycl/test-e2e/Basic/fpga_tests/fpga_lsu.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_lsu.cpp
@@ -6,7 +6,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: accelerator, opencl-aot
-// RUN: %{build} -fintelfpga -o %t.out
+// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <iostream>

--- a/sycl/test-e2e/Basic/fpga_tests/global_fpga_device_selector.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/global_fpga_device_selector.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: opencl-aot, accelerator
 
-// RUN: %{build} -fintelfpga -o %t.out
+// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/ext/intel/fpga_extensions.hpp>


### PR DESCRIPTION
Current version results in "The option -fsycl-targets= conflicts with -fintelfpga" error.