### PR TITLE
[SYCL-MLIR] Add -sycl-device-only option to cgeist

### DIFF
--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -232,7 +232,7 @@ llvm::cl::opt<bool>
                       llvm::cl::desc("Whether to use opaque pointers in MLIR"));
 
 static llvm::cl::opt<bool>
-    NoSYCLDeviceOnly("no-sycl-device-only", llvm::cl::init(false),
-                     llvm::cl::desc("Include host code in MLIR output"));
+    SYCLDeviceOnly("sycl-device-only", llvm::cl::init(true),
+                   llvm::cl::desc("Only emit device code in MLIR output"));
 
 #endif /* CGEIST_OPTIONS_H_ */

--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -232,7 +232,7 @@ llvm::cl::opt<bool>
                       llvm::cl::desc("Whether to use opaque pointers in MLIR"));
 
 static llvm::cl::opt<bool>
-    SYCLDeviceOnly("sycl-device-only", llvm::cl::init(false),
-                   llvm::cl::desc("Output SYCL kernels for device"));
+    NoSYCLDeviceOnly("no-sycl-device-only", llvm::cl::init(false),
+                     llvm::cl::desc("Include host code in MLIR output"));
 
 #endif /* CGEIST_OPTIONS_H_ */

--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -231,4 +231,8 @@ llvm::cl::opt<bool>
     UseOpaquePointers("use-opaque-pointers", llvm::cl::init(false),
                       llvm::cl::desc("Whether to use opaque pointers in MLIR"));
 
+static llvm::cl::opt<bool>
+    SYCLDeviceOnly("sycl-device-only", llvm::cl::init(false),
+                   llvm::cl::desc("Output SYCL kernels for device"));
+
 #endif /* CGEIST_OPTIONS_H_ */

--- a/polygeist/tools/cgeist/Test/Verification/sycl/host_module.mlir
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/host_module.mlir
@@ -1,6 +1,6 @@
 module {
 memref.global constant @c : memref<i32, 1> {alignment = 4 : i64}
-func.func @do_nothing() -> memref<i32, 1> {
+func.func @host_foo() -> memref<i32, 1> {
   %0 = memref.get_global @c : memref<i32, 1>
   return %0 : memref<i32, 1>
 }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_use_host_module.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_use_host_module.cpp
@@ -1,14 +1,23 @@
-// RUN: clang++ -fsycl -fsycl-device-only -Xcgeist -sycl-use-host-module=%S/host_module.mlir -O0 -w -emit-mlir -o - %s | FileCheck %s
+// RUN: clang++ -fsycl -fsycl-device-only -Xcgeist \
+// RUN:     -sycl-use-host-module=%S/host_module.mlir -O0 -w -emit-mlir -o - %s \
+// RUN:     | FileCheck %s
+// RUN: clang++ -fsycl -fsycl-device-only -Xcgeist \
+// RUN:     -sycl-use-host-module=%S/host_module.mlir -O0 -w -emit-mlir -o - %s \
+// RUN:     -Xcgeist -sycl-device-only | FileCheck %s --check-prefix=CHECK-DROP
 
 #include <sycl/sycl.hpp>
 
 // CHECK:        gpu.module @device_functions
 // CHECK:        memref.global constant @c : memref<i32, 1> {alignment = 4 : i64}
-// CHECK-NEXT:   func.func @do_nothing() -> memref<i32, 1> {
+// CHECK-NEXT:   func.func @host_foo() -> memref<i32, 1> {
 // CHECK-NEXT:     %0 = memref.get_global @c : memref<i32, 1>
 // CHECK-NEXT:     return %0 : memref<i32, 1>
 // CHECK-NEXT:   }
 // Check that the function is at the end of the top-level module
 // CHECK-NEXT: }
 // CHECK-NOT:  {{.+}}
+
+// CHECK-DROP:     gpu.module @device_functions
+// CHECK-DROP-NOT: memref.global constant @c : memref<i32, 1> {alignment = 4 : i64}
+// CHECK-DROP-NOT:   func.func @host_foo() -> memref<i32, 1> {
 SYCL_EXTERNAL void do_nothing() {}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_use_host_module.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_use_host_module.cpp
@@ -25,7 +25,7 @@
 
 // CHECK-DROP:     gpu.module @device_functions
 // CHECK-DROP-NOT: memref.global constant @c : memref<i32, 1> {alignment = 4 : i64}
-// CHECK-DROP-NOT:   func.func @host_foo() -> memref<i32, 1> {
+// CHECK-DROP-NOT: func.func @host_foo() -> memref<i32, 1> {
 
 // CHECK-LLVM-NOT: host_foo
 SYCL_EXTERNAL void do_nothing() {}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_use_host_module.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_use_host_module.cpp
@@ -1,12 +1,12 @@
 // RUN: clang++ -fsycl -fsycl-device-only -Xcgeist \
 // RUN:     -sycl-use-host-module=%S/host_module.mlir -O0 -w -emit-mlir -o - %s \
-// RUN:     -Xcgeist -no-sycl-device-only | FileCheck %s
+// RUN:     -Xcgeist -sycl-device-only=false | FileCheck %s
 // RUN: clang++ -fsycl -fsycl-device-only -Xcgeist \
 // RUN:     -sycl-use-host-module=%S/host_module.mlir -O0 -w -emit-mlir -o - %s \
 // RUN:     | FileCheck %s --check-prefix=CHECK-DROP
 // RUN: clang++ -fsycl -fsycl-device-only -Xcgeist \
 // RUN:     -sycl-use-host-module=%S/host_module.mlir -O0 -w -emit-llvm -o - %s \
-// RUN:     -Xcgeist -no-sycl-device-only | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN:     -Xcgeist -sycl-device-only=false | FileCheck %s --check-prefix=CHECK-LLVM
 // RUN: clang++ -fsycl -fsycl-device-only -Xcgeist \
 // RUN:     -sycl-use-host-module=%S/host_module.mlir -O0 -w -emit-llvm -o - %s \
 // RUN:     | FileCheck %s --check-prefix=CHECK-LLVM

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_use_host_module.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_use_host_module.cpp
@@ -1,9 +1,15 @@
 // RUN: clang++ -fsycl -fsycl-device-only -Xcgeist \
 // RUN:     -sycl-use-host-module=%S/host_module.mlir -O0 -w -emit-mlir -o - %s \
-// RUN:     | FileCheck %s
+// RUN:     -Xcgeist -no-sycl-device-only | FileCheck %s
 // RUN: clang++ -fsycl -fsycl-device-only -Xcgeist \
 // RUN:     -sycl-use-host-module=%S/host_module.mlir -O0 -w -emit-mlir -o - %s \
-// RUN:     -Xcgeist -sycl-device-only | FileCheck %s --check-prefix=CHECK-DROP
+// RUN:     | FileCheck %s --check-prefix=CHECK-DROP
+// RUN: clang++ -fsycl -fsycl-device-only -Xcgeist \
+// RUN:     -sycl-use-host-module=%S/host_module.mlir -O0 -w -emit-llvm -o - %s \
+// RUN:     -Xcgeist -no-sycl-device-only | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -fsycl -fsycl-device-only -Xcgeist \
+// RUN:     -sycl-use-host-module=%S/host_module.mlir -O0 -w -emit-llvm -o - %s \
+// RUN:     | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 
@@ -20,4 +26,6 @@
 // CHECK-DROP:     gpu.module @device_functions
 // CHECK-DROP-NOT: memref.global constant @c : memref<i32, 1> {alignment = 4 : i64}
 // CHECK-DROP-NOT:   func.func @host_foo() -> memref<i32, 1> {
+
+// CHECK-LLVM-NOT: host_foo
 SYCL_EXTERNAL void do_nothing() {}

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -723,7 +723,7 @@ static LogicalResult finalize(mlir::MLIRContext &Ctx,
     });
   }
 
-  if (SYCLDeviceOnly)
+  if (!NoSYCLDeviceOnly)
     eraseHostCode(*Module);
 
   return success();
@@ -840,6 +840,9 @@ static LogicalResult compileModule(mlir::OwningOpRef<mlir::ModuleOp> &Module,
                  << "*** Dumped MLIR in file '" << Output << "' ***\n");
     }
   } else {
+    // Host code is never output for non-MLIR format.
+    if (NoSYCLDeviceOnly)
+      eraseHostCode(*Module);
     // Generate LLVM IR.
     llvm::LLVMContext LLVMCtx;
     auto LLVMModule =

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -110,7 +110,7 @@ std::string GetExecutablePath(const char *Argv0, bool CanonicalPrefixes) {
       Argv0, reinterpret_cast<void *>(GetExecutablePath));
 }
 
-static void eraseHostCode(mlir::ModuleOp Module) {
+static void eraseHostCode(ModuleOp Module) {
   LLVM_DEBUG(llvm::dbgs() << "Erasing host code\n");
   SmallVector<std::reference_wrapper<Operation>> ToRemove;
   std::copy_if(Module.begin(), Module.end(), std::back_inserter(ToRemove),
@@ -723,7 +723,7 @@ static LogicalResult finalize(mlir::MLIRContext &Ctx,
     });
   }
 
-  if (!NoSYCLDeviceOnly)
+  if (SYCLDeviceOnly)
     eraseHostCode(*Module);
 
   return success();
@@ -840,8 +840,9 @@ static LogicalResult compileModule(mlir::OwningOpRef<mlir::ModuleOp> &Module,
                  << "*** Dumped MLIR in file '" << Output << "' ***\n");
     }
   } else {
-    // Host code is never output for non-MLIR format.
-    if (NoSYCLDeviceOnly)
+    // Host code is never output for non-MLIR format. If this option is set, the
+    // host code should have already been removed.
+    if (!SYCLDeviceOnly)
       eraseHostCode(*Module);
     // Generate LLVM IR.
     llvm::LLVMContext LLVMCtx;


### PR DESCRIPTION
This option should be similar to clang's `-fsycl-device-only`, but it won't ensure the host is not used for device compilation, it wil just ensure the output will only contain device code.