### PR TITLE
[SYCL] add unit tests for the HIP plugin

### DIFF
--- a/sycl/unittests/pi/CMakeLists.txt
+++ b/sycl/unittests/pi/CMakeLists.txt
@@ -16,3 +16,8 @@ target_include_directories(PiTests PRIVATE ${sycl_src_dir}/../tools/xpti_helpers
 if("cuda" IN_LIST SYCL_ENABLE_PLUGINS)
     add_subdirectory(cuda)
 endif()
+
+if("hip" IN_LIST SYCL_ENABLE_PLUGINS)
+    add_subdirectory(hip)
+endif()
+

--- a/sycl/unittests/pi/hip/CMakeLists.txt
+++ b/sycl/unittests/pi/hip/CMakeLists.txt
@@ -1,0 +1,40 @@
+add_sycl_unittest(PiHipTests OBJECT
+  test_base_objects.cpp
+  test_commands.cpp
+  test_contexts.cpp
+  test_device.cpp
+  test_interop_get_native.cpp
+  test_kernels.cpp
+  test_mem_obj.cpp
+  test_primary_context.cpp
+  test_sampler_properties.cpp
+)
+
+add_dependencies(PiHipTests sycl)
+
+target_compile_definitions(PiHipTests
+  PRIVATE
+    GTEST_HAS_COMBINE=1)
+
+target_include_directories(PiHipTests
+  PRIVATE
+    "../"
+    "${sycl_inc_dir}/sycl/detail/"
+    "${sycl_inc_dir}"
+    "${sycl_plugin_dir}/hip/"
+)
+
+if("${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "AMD")
+  # Set HIP define to select AMD platform
+  target_compile_definitions(PiHipTests PRIVATE __HIP_PLATFORM_AMD__)
+elseif("${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "NVIDIA")
+  # Set HIP define to select NVIDIA platform
+  target_compile_definitions(PiHipTests PRIVATE __HIP_PLATFORM_NVIDIA__)
+else()
+  message(FATAL_ERROR "Unspecified PI HIP platform please set SYCL_BUILD_PI_HIP_PLATFORM to 'AMD' or 'NVIDIA'")
+endif()
+
+target_link_libraries(PiHipTests
+  PRIVATE
+    rocmdrv
+)

--- a/sycl/unittests/pi/hip/HipUtils.hpp
+++ b/sycl/unittests/pi/hip/HipUtils.hpp
@@ -1,0 +1,20 @@
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <hip/hip_runtime.h>
+
+namespace pi {
+
+// utility function to clear the HIP context stack
+inline void clearHipContext() {
+  hipCtx_t ctxt = nullptr;
+  do {
+    hipCtxSetCurrent(nullptr);
+    hipCtxGetCurrent(&ctxt);
+  } while (ctxt != nullptr);
+}
+
+} // namespace pi

--- a/sycl/unittests/pi/hip/test_base_objects.cpp
+++ b/sycl/unittests/pi/hip/test_base_objects.cpp
@@ -1,0 +1,141 @@
+//==---- test_base_objects.cpp --- PI unit tests ---------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+
+#include <hip/hip_runtime.h>
+
+#include "TestGetPlugin.hpp"
+#include <detail/plugin.hpp>
+#include <pi_hip.hpp>
+#include <sycl/detail/pi.hpp>
+#include <sycl/sycl.hpp>
+
+#include <thread>
+
+// https://sep5.readthedocs.io/en/latest/ROCm_API_References/
+// HIP_API/Context-Management.html#_CPPv419hipCtxGetApiVersion8hipCtx_tPi
+const int HIP_DRIVER_API_VERSION = 4;
+
+using namespace sycl;
+
+class HipBaseObjectsTest : public ::testing::Test {
+protected:
+  std::optional<detail::plugin> plugin =
+      pi::initializeAndGet(backend::ext_oneapi_hip);
+
+  void SetUp() override {
+    // skip the tests if the CUDA backend is not available
+    if (!plugin.has_value()) {
+      GTEST_SKIP();
+    }
+  }
+
+  HipBaseObjectsTest() = default;
+
+  ~HipBaseObjectsTest() = default;
+};
+
+TEST_F(HipBaseObjectsTest, piContextCreate) {
+  pi_uint32 numPlatforms = 0;
+  pi_platform platform = nullptr;
+  pi_device device;
+  ASSERT_EQ(plugin->hasBackend(backend::ext_oneapi_hip), PI_SUCCESS);
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
+                0, nullptr, &numPlatforms)),
+            PI_SUCCESS)
+      << "piPlatformsGet failed.\n";
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
+                numPlatforms, &platform, nullptr)),
+            PI_SUCCESS)
+      << "piPlatformsGet failed.\n";
+
+  ASSERT_GE(numPlatforms, 1u);
+  ASSERT_NE(platform, nullptr);
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDevicesGet>(
+                platform, PI_DEVICE_TYPE_GPU, 1, &device, nullptr)),
+            PI_SUCCESS)
+      << "piDevicesGet failed.\n";
+
+  pi_context ctxt = nullptr;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
+                nullptr, 1, &device, nullptr, nullptr, &ctxt)),
+            PI_SUCCESS)
+      << "piContextCreate failed.\n";
+
+  EXPECT_NE(ctxt, nullptr);
+  EXPECT_EQ(ctxt->get_device(), device);
+
+  // Retrieve the hipCtxt to check information is correct
+  hipCtx_t hipContext = ctxt->get();
+  int version = 0;
+  auto hipErr = hipCtxGetApiVersion(hipContext, &version);
+  EXPECT_EQ(hipErr, PI_SUCCESS);
+  EXPECT_EQ(version, HIP_DRIVER_API_VERSION);
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextRelease>(ctxt)),
+            PI_SUCCESS);
+}
+
+TEST_F(HipBaseObjectsTest, piContextCreateChildThread) {
+  pi_uint32 numPlatforms = 0;
+  pi_platform platform;
+  pi_device device;
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
+                0, nullptr, &numPlatforms)),
+            PI_SUCCESS)
+      << "piPlatformsGet failed.\n";
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
+                numPlatforms, &platform, nullptr)),
+            PI_SUCCESS)
+      << "piPlatformsGet failed.\n";
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDevicesGet>(
+                platform, PI_DEVICE_TYPE_GPU, 1, &device, nullptr)),
+            PI_SUCCESS);
+
+  pi_context ctxt;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
+                nullptr, 1, &device, nullptr, nullptr, &ctxt)),
+            PI_SUCCESS);
+  EXPECT_NE(ctxt, nullptr);
+
+  // Retrieve the cuCtxt to check information is correct
+  auto checkValue = [=]() {
+    hipCtx_t hipContext = ctxt->get();
+    int version = 0;
+    auto hipErr = hipCtxGetApiVersion(hipContext, &version);
+    EXPECT_EQ(hipErr, PI_SUCCESS);
+    EXPECT_EQ(version, HIP_DRIVER_API_VERSION);
+
+    // The current context is different from the current thread
+    hipCtx_t current;
+    hipErr = hipCtxGetCurrent(&current);
+    EXPECT_EQ(hipErr, PI_SUCCESS);
+    EXPECT_NE(hipContext, current);
+
+    // Set the context from PI API as the current one
+    hipErr = hipCtxPushCurrent(hipContext);
+    EXPECT_EQ(hipErr, PI_SUCCESS);
+
+    hipErr = hipCtxGetCurrent(&current);
+    EXPECT_EQ(hipErr, PI_SUCCESS);
+    EXPECT_EQ(hipContext, current);
+  };
+  auto callContextFromOtherThread = std::thread(checkValue);
+
+  callContextFromOtherThread.join();
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextRelease>(ctxt)),
+            PI_SUCCESS);
+}

--- a/sycl/unittests/pi/hip/test_commands.cpp
+++ b/sycl/unittests/pi/hip/test_commands.cpp
@@ -1,0 +1,145 @@
+//==---- test_commands.cpp --- PI unit tests -------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+
+#include <hip/hip_runtime.h>
+
+#include "HipUtils.hpp"
+#include "TestGetPlugin.hpp"
+#include <detail/plugin.hpp>
+#include <pi_hip.hpp>
+#include <sycl/detail/pi.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+struct HipCommandsTest : public ::testing::Test {
+
+protected:
+  std::optional<detail::plugin> plugin =
+      pi::initializeAndGet(backend::ext_oneapi_hip);
+
+  pi_platform platform_;
+  pi_device device_;
+  pi_context context_;
+  pi_queue queue_;
+
+  void SetUp() override {
+    // skip the tests if the HIP backend is not available
+    if (!plugin.has_value()) {
+      GTEST_SKIP();
+    }
+
+    pi::clearHipContext();
+    pi_uint32 numPlatforms = 0;
+    ASSERT_EQ(plugin->hasBackend(backend::ext_oneapi_hip), PI_SUCCESS);
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
+                  0, nullptr, &numPlatforms)),
+              PI_SUCCESS)
+        << "piPlatformsGet failed.\n";
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
+                  numPlatforms, &platform_, nullptr)),
+              PI_SUCCESS)
+        << "piPlatformsGet failed.\n";
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDevicesGet>(
+                  platform_, PI_DEVICE_TYPE_GPU, 1, &device_, nullptr)),
+              PI_SUCCESS);
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
+                  nullptr, 1, &device_, nullptr, nullptr, &context_)),
+              PI_SUCCESS);
+    ASSERT_NE(context_, nullptr);
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueCreate>(
+                  context_, device_, 0, &queue_)),
+              PI_SUCCESS);
+    ASSERT_NE(queue_, nullptr);
+    auto tmpCtxt = queue_->get_context();
+    ASSERT_EQ(tmpCtxt, context_);
+  }
+
+  void TearDown() override {
+    if (plugin.has_value()) {
+      plugin->call<detail::PiApiKind::piQueueRelease>(queue_);
+      plugin->call<detail::PiApiKind::piContextRelease>(context_);
+    }
+  }
+
+  HipCommandsTest() = default;
+
+  ~HipCommandsTest() = default;
+};
+
+TEST_F(HipCommandsTest, PIEnqueueReadBufferBlocking) {
+  constexpr const size_t memSize = 10u;
+  constexpr const size_t bytes = memSize * sizeof(int);
+  const int data[memSize] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  int output[memSize] = {};
+
+  pi_mem memObj;
+  ASSERT_EQ(
+      (plugin->call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+          context_, PI_MEM_FLAGS_ACCESS_RW, bytes, nullptr, &memObj, nullptr)),
+      PI_SUCCESS);
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueMemBufferWrite>(
+                queue_, memObj, true, 0, bytes, data, 0, nullptr, nullptr)),
+            PI_SUCCESS);
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueMemBufferRead>(
+                queue_, memObj, true, 0, bytes, output, 0, nullptr, nullptr)),
+            PI_SUCCESS);
+
+  bool isSame =
+      std::equal(std::begin(output), std::end(output), std::begin(data));
+  EXPECT_TRUE(isSame);
+  if (!isSame) {
+    std::for_each(std::begin(output), std::end(output),
+                  [](int &elem) { std::cout << elem << ","; });
+    std::cout << std::endl;
+  }
+}
+
+TEST_F(HipCommandsTest, PIEnqueueReadBufferNonBlocking) {
+  constexpr const size_t memSize = 10u;
+  constexpr const size_t bytes = memSize * sizeof(int);
+  const int data[memSize] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+  int output[memSize] = {};
+
+  pi_mem memObj;
+  ASSERT_EQ(
+      (plugin->call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+          context_, PI_MEM_FLAGS_ACCESS_RW, bytes, nullptr, &memObj, nullptr)),
+      PI_SUCCESS);
+
+  pi_event cpIn, cpOut;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueMemBufferWrite>(
+                queue_, memObj, false, 0, bytes, data, 0, nullptr, &cpIn)),
+            PI_SUCCESS);
+  ASSERT_NE(cpIn, nullptr);
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueMemBufferRead>(
+                queue_, memObj, false, 0, bytes, output, 0, nullptr, &cpOut)),
+            PI_SUCCESS);
+  ASSERT_NE(cpOut, nullptr);
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEventsWait>(1, &cpOut)),
+            PI_SUCCESS);
+
+  bool isSame =
+      std::equal(std::begin(output), std::end(output), std::begin(data));
+  EXPECT_TRUE(isSame);
+  if (!isSame) {
+    std::for_each(std::begin(output), std::end(output),
+                  [](int &elem) { std::cout << elem << ","; });
+    std::cout << std::endl;
+  }
+}

--- a/sycl/unittests/pi/hip/test_contexts.cpp
+++ b/sycl/unittests/pi/hip/test_contexts.cpp
@@ -1,0 +1,249 @@
+//==---- test_contexts.cpp --- PI unit tests -------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+
+#include <condition_variable>
+#include <thread>
+#include <mutex>
+
+#include <hip/hip_runtime.h>
+
+#include "HipUtils.hpp"
+#include "TestGetPlugin.hpp"
+#include <detail/plugin.hpp>
+#include <pi_hip.hpp>
+#include <sycl/detail/pi.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+struct HipContextsTest : public ::testing::Test {
+
+protected:
+  std::optional<detail::plugin> plugin =
+      pi::initializeAndGet(backend::ext_oneapi_hip);
+
+  pi_platform platform_;
+  pi_device device_;
+
+  void SetUp() override {
+    // skip the tests if the HIP backend is not available
+    if (!plugin.has_value()) {
+      GTEST_SKIP();
+    }
+
+    pi_uint32 numPlatforms = 0;
+    ASSERT_EQ(plugin->hasBackend(backend::ext_oneapi_hip), PI_SUCCESS);
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
+                  0, nullptr, &numPlatforms)),
+              PI_SUCCESS)
+        << "piPlatformsGet failed.\n";
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
+                  numPlatforms, &platform_, nullptr)),
+              PI_SUCCESS)
+        << "piPlatformsGet failed.\n";
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDevicesGet>(
+                  platform_, PI_DEVICE_TYPE_GPU, 1, &device_, nullptr)),
+              PI_SUCCESS);
+  }
+
+  void TearDown() override {}
+
+  HipContextsTest() = default;
+
+  ~HipContextsTest() = default;
+};
+
+TEST_F(HipContextsTest, ContextLifetime) {
+  // start with no active context
+  pi::clearHipContext();
+
+  // create a context
+  pi_context context;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
+                nullptr, 1, &device_, nullptr, nullptr, &context)),
+            PI_SUCCESS);
+  ASSERT_NE(context, nullptr);
+
+  // create a queue from the context, this should use the ScopedContext
+  pi_queue queue;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueCreate>(
+                context, device_, 0, &queue)),
+            PI_SUCCESS);
+  ASSERT_NE(queue, nullptr);
+
+  // ensure the queue has the correct context
+  ASSERT_EQ(context, queue->get_context());
+
+  // check that the context is now the active HIP context
+  hipCtx_t hipCtxt = nullptr;
+  hipCtxGetCurrent(&hipCtxt);
+  ASSERT_EQ(hipCtxt, context->get());
+
+  plugin->call<detail::PiApiKind::piQueueRelease>(queue);
+  plugin->call<detail::PiApiKind::piContextRelease>(context);
+
+  // check that the context was cleaned up properly by the destructor
+  hipCtxGetCurrent(&hipCtxt);
+  ASSERT_EQ(hipCtxt, nullptr);
+}
+
+TEST_F(HipContextsTest, ContextLifetimeExisting) {
+  // start by setting up a HIP context on the thread
+  hipCtx_t original;
+  hipCtxCreate(&original, hipDeviceMapHost, device_->get());
+
+  // ensure the HIP context is active
+  hipCtx_t current = nullptr;
+  hipCtxGetCurrent(&current);
+  ASSERT_EQ(original, current);
+
+  // create a PI context
+  pi_context context;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
+                nullptr, 1, &device_, nullptr, nullptr, &context)),
+            PI_SUCCESS);
+  ASSERT_NE(context, nullptr);
+
+  // create a queue from the context, this should use the ScopedContext
+  pi_queue queue;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueCreate>(
+                context, device_, 0, &queue)),
+            PI_SUCCESS);
+  ASSERT_NE(queue, nullptr);
+
+  // ensure the queue has the correct context
+  ASSERT_EQ(context, queue->get_context());
+
+  // check that the context is now the active HIP context
+  hipCtxGetCurrent(&current);
+  ASSERT_EQ(current, context->get());
+
+  plugin->call<detail::PiApiKind::piQueueRelease>(queue);
+  plugin->call<detail::PiApiKind::piContextRelease>(context);
+
+  // check that the context was cleaned up, the old context will be restored
+  // automatically by hipCtxDestroy in piContextRelease, as it was pushed on the
+  // stack bu hipCtxCreate
+  hipCtxGetCurrent(&current);
+  ASSERT_EQ(current, original);
+
+  // release original context
+  hipCtxDestroy(original);
+}
+
+// In some cases (for host_task), the SYCL runtime may call PI API functions
+// from threads of the thread pool, this can cause issues because with the HIP
+// plugin these functions will set an active HIP context on these threads, but
+// never clean it up, as it will only get cleaned up in the main thread.
+//
+// So the following test aims to reproduce the scenario where there is a
+// dangling deleted context in a separate thread and seeing if the PI calls are
+// still able to work correctly in that thread.
+TEST_F(HipContextsTest, ContextThread) {
+  // start with no active context
+  pi::clearHipContext();
+
+  // create two PI contexts
+  pi_context context1;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
+                nullptr, 1, &device_, nullptr, nullptr, &context1)),
+            PI_SUCCESS);
+  ASSERT_NE(context1, nullptr);
+
+  pi_context context2;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
+                nullptr, 1, &device_, nullptr, nullptr, &context2)),
+            PI_SUCCESS);
+  ASSERT_NE(context2, nullptr);
+
+  // setup synchronization variables between the main thread and the testing
+  // thread
+  std::mutex m;
+  std::condition_variable cv;
+  bool released = false;
+  bool thread_done = false;
+
+  // create a testing thread that will create a queue with the first context,
+  // release the queue, then wait for the main thread to release the first
+  // context, and then create and release another queue with the second context
+  // this time
+  auto test_thread = std::thread([&] {
+    hipCtx_t current = nullptr;
+
+    // create a queue with the first context
+    pi_queue queue;
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueCreate>(
+                  context1, device_, 0, &queue)),
+              PI_SUCCESS);
+    ASSERT_NE(queue, nullptr);
+
+    // ensure the queue has the correct context
+    ASSERT_EQ(context1, queue->get_context());
+
+    // check that the first context is now the active HIP context
+    hipCtxGetCurrent(&current);
+    ASSERT_EQ(current, context1->get());
+
+    plugin->call<detail::PiApiKind::piQueueRelease>(queue);
+
+    // mark the first set of processing as done and notify the main thread
+    std::unique_lock<std::mutex> lock(m);
+    thread_done = true;
+    lock.unlock();
+    cv.notify_one();
+
+    // wait for the main thread to release the first context
+    lock.lock();
+    cv.wait(lock, [&] { return released; });
+
+    // check that the first context is still active, this is because deleting a
+    // context only cleans up the current thread
+    hipCtxGetCurrent(&current);
+    ASSERT_EQ(current, context1->get());
+
+    // create a queue with the second context
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueCreate>(
+                  context2, device_, 0, &queue)),
+              PI_SUCCESS);
+    ASSERT_NE(queue, nullptr);
+
+    // ensure the queue has the correct context
+    ASSERT_EQ(context2, queue->get_context());
+
+    // check that the second context is now the active HIP context
+    hipCtxGetCurrent(&current);
+    ASSERT_EQ(current, context2->get());
+
+    plugin->call<detail::PiApiKind::piQueueRelease>(queue);
+  });
+
+  // wait for the thread to be done with the first queue to release the first context
+  std::unique_lock<std::mutex> lock(m);
+  cv.wait(lock, [&] { return thread_done; });
+  plugin->call<detail::PiApiKind::piContextRelease>(context1);
+
+  // notify the other thread that the context was released
+  released = true;
+  lock.unlock();
+  cv.notify_one();
+
+  // wait for the thread to finish
+  test_thread.join();
+
+  plugin->call<detail::PiApiKind::piContextRelease>(context2);
+
+  // check that there is no context set on the main thread
+  hipCtx_t current = nullptr;
+  hipCtxGetCurrent(&current);
+  ASSERT_EQ(current, nullptr);
+}

--- a/sycl/unittests/pi/hip/test_device.cpp
+++ b/sycl/unittests/pi/hip/test_device.cpp
@@ -1,0 +1,111 @@
+//==---- test_device.cpp --- PI unit tests ---------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+
+#include <hip/hip_runtime.h>
+
+#include "TestGetPlugin.hpp"
+#include <detail/plugin.hpp>
+#include <pi_hip.hpp>
+#include <sycl/detail/pi.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+struct HipDeviceTests : public ::testing::Test {
+
+protected:
+  std::optional<detail::plugin> plugin =
+      pi::initializeAndGet(backend::ext_oneapi_hip);
+
+  pi_platform platform_;
+  pi_device device_;
+  pi_context context_;
+
+  void SetUp() override {
+    // skip the tests if the HIP backend is not available
+    if (!plugin.has_value()) {
+      GTEST_SKIP();
+    }
+
+    pi_uint32 numPlatforms = 0;
+    ASSERT_EQ(plugin->hasBackend(backend::ext_oneapi_hip), PI_SUCCESS);
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
+                  0, nullptr, &numPlatforms)),
+              PI_SUCCESS)
+        << "piPlatformsGet failed.\n";
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
+                  numPlatforms, &platform_, nullptr)),
+              PI_SUCCESS)
+        << "piPlatformsGet failed.\n";
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDevicesGet>(
+                  platform_, PI_DEVICE_TYPE_GPU, 1, &device_, nullptr)),
+              PI_SUCCESS);
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
+                  nullptr, 1, &device_, nullptr, nullptr, &context_)),
+              PI_SUCCESS);
+    EXPECT_NE(context_, nullptr);
+  }
+
+  void TearDown() override {
+    if (plugin.has_value()) {
+      plugin->call<detail::PiApiKind::piDeviceRelease>(device_);
+      plugin->call<detail::PiApiKind::piContextRelease>(context_);
+    }
+  }
+
+  HipDeviceTests() = default;
+  ~HipDeviceTests() = default;
+};
+
+TEST_F(HipDeviceTests, PIDeviceGetInfoSimple) {
+
+  size_t return_size = 0;
+  pi_device_type device_type;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDeviceGetInfo>(
+                device_, PI_DEVICE_INFO_TYPE, sizeof(pi_device_type),
+                &device_type, &return_size)),
+            PI_SUCCESS);
+  EXPECT_EQ(return_size, sizeof(pi_device_type));
+  EXPECT_EQ(
+      device_type,
+      PI_DEVICE_TYPE_GPU); // backend pre-defined value, device must be a GPU
+
+  pi_device parent_device = nullptr;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDeviceGetInfo>(
+                device_, PI_DEVICE_INFO_PARENT_DEVICE, sizeof(pi_device),
+                &parent_device, &return_size)),
+            PI_SUCCESS);
+  EXPECT_EQ(return_size, sizeof(pi_device));
+  EXPECT_EQ(parent_device,
+            nullptr); // backend pre-set value, device cannot have a parent
+
+  pi_platform platform = nullptr;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDeviceGetInfo>(
+                device_, PI_DEVICE_INFO_PLATFORM, sizeof(pi_platform),
+                &platform, &return_size)),
+            PI_SUCCESS);
+  EXPECT_EQ(return_size, sizeof(pi_platform));
+  EXPECT_EQ(platform, platform_); // test fixture device was created from the
+                                  // test fixture platform
+
+  cl_device_partition_property device_partition_property = -1;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDeviceGetInfo>(
+                device_, PI_DEVICE_INFO_PARTITION_TYPE,
+                sizeof(cl_device_partition_property),
+                &device_partition_property, &return_size)),
+            PI_SUCCESS);
+  EXPECT_EQ(device_partition_property,
+            0); // PI HIP backend will not support device partitioning, this
+                // function should just return 0.
+  EXPECT_EQ(return_size, sizeof(cl_device_partition_property));
+}

--- a/sycl/unittests/pi/hip/test_interop_get_native.cpp
+++ b/sycl/unittests/pi/hip/test_interop_get_native.cpp
@@ -1,0 +1,142 @@
+//==------- test_interop_get_native.cpp - SYCL CUDA get_native tests -------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+
+#include <hip/hip_runtime.h>
+
+#include <sycl/sycl.hpp>
+
+#include <sycl/ext/oneapi/backend/hip.hpp>
+
+#include "TestGetPlatforms.hpp"
+
+#include <iostream>
+
+using namespace sycl;
+
+struct HipInteropGetNativeTests : public ::testing::TestWithParam<platform> {
+
+protected:
+  std::unique_ptr<queue> syclQueue_;
+  device syclDevice_;
+
+  void SetUp() override {
+    syclDevice_ = GetParam().get_devices()[0];
+    syclQueue_ = std::unique_ptr<queue>{new queue{syclDevice_}};
+  }
+
+  void TearDown() override { syclQueue_.reset(); }
+};
+
+TEST_P(HipInteropGetNativeTests, getNativeDevice) {
+  hipDevice_t hipDevice = get_native<backend::ext_oneapi_hip>(syclDevice_);
+  char hipDeviceName[2] = {0, 0};
+  hipError_t result = hipDeviceGetName(hipDeviceName, 2, hipDevice);
+  ASSERT_EQ(result, PI_SUCCESS);
+  ASSERT_NE(hipDeviceName[0], 0);
+}
+
+TEST_P(HipInteropGetNativeTests, getNativeContext) {
+  hipCtx_t hipContext =
+      get_native<backend::ext_oneapi_hip>(syclQueue_->get_context());
+  ASSERT_NE(hipContext, nullptr);
+}
+
+/* hipStreamGetCtx not supported by HIP runtime
+TEST_P(HipInteropGetNativeTests, getNativeQueue) {
+  hipStream_t hipStream = get_native<backend::ext_oneapi_hip>(*syclQueue_);
+  ASSERT_NE(hipStream, nullptr);
+
+  hipCtx_t streamContext = nullptr;
+  CUresult result = hipStreamGetCtx(hipStream, &streamContext);
+  ASSERT_EQ(result, PI_SUCCESS);
+
+  hipCtx_t hipContext =
+      get_native<backend::ext_oneapi_hip>(syclQueue_->get_context());
+  ASSERT_EQ(streamContext, hipContext);
+}
+*/
+
+TEST_P(HipInteropGetNativeTests, interopTaskGetMem) {
+  buffer<int, 1> syclBuffer(range<1>{1});
+  syclQueue_->submit([&](handler &cgh) {
+    auto syclAccessor = syclBuffer.get_access<access::mode::read>(cgh);
+    cgh.host_task([=](interop_handle ih) {
+      hipDeviceptr_t hipPtr =
+          ih.get_native_mem<backend::ext_oneapi_hip>(syclAccessor);
+      hipDeviceptr_t hipPtrBase;
+      size_t hipPtrSize = 0;
+      hipCtx_t hipContext =
+          get_native<backend::ext_oneapi_hip>(syclQueue_->get_context());
+      ASSERT_EQ(PI_SUCCESS, hipCtxPushCurrent(hipContext));
+      ASSERT_EQ(PI_SUCCESS,
+                hipMemGetAddressRange(&hipPtrBase, &hipPtrSize, hipPtr));
+      ASSERT_EQ(PI_SUCCESS, hipCtxPopCurrent(nullptr));
+      ASSERT_EQ(sizeof(int), hipPtrSize);
+    });
+  });
+}
+
+TEST_P(HipInteropGetNativeTests, interopTaskGetQueue) {
+  hipStream_t hipStream = get_native<backend::ext_oneapi_hip>(*syclQueue_);
+  syclQueue_->submit([&](handler &cgh) {
+    cgh.host_task([=](interop_handle ih) {
+      hipStream_t hipInteropStream =
+          ih.get_native_queue<backend::ext_oneapi_hip>();
+      ASSERT_EQ(hipInteropStream, hipStream);
+    });
+  });
+}
+
+TEST_P(HipInteropGetNativeTests, hostTaskGetNativeMem) {
+  buffer<int, 1> syclBuffer(range<1>{1});
+  syclQueue_->submit([&](handler &cgh) {
+    auto syclAccessor = syclBuffer.get_access<access::mode::read>(cgh);
+    cgh.host_task([=](interop_handle ih) {
+      hipDeviceptr_t hipPtr =
+          ih.get_native_mem<backend::ext_oneapi_hip>(syclAccessor);
+      hipDeviceptr_t hipPtrBase;
+      size_t hipPtrSize = 0;
+      hipCtx_t hipContext =
+          get_native<backend::ext_oneapi_hip>(syclQueue_->get_context());
+      ASSERT_EQ(PI_SUCCESS, hipCtxPushCurrent(hipContext));
+      ASSERT_EQ(PI_SUCCESS,
+                hipMemGetAddressRange(&hipPtrBase, &hipPtrSize, hipPtr));
+      ASSERT_EQ(PI_SUCCESS, hipCtxPopCurrent(nullptr));
+      ASSERT_EQ(sizeof(int), hipPtrSize);
+    });
+  });
+}
+
+TEST_P(HipInteropGetNativeTests, hostTaskGetNativeQueue) {
+  hipStream_t hipStream = get_native<backend::ext_oneapi_hip>(*syclQueue_);
+  syclQueue_->submit([&](handler &cgh) {
+    cgh.host_task([=](interop_handle ih) {
+      hipStream_t hipInteropStream =
+          ih.get_native_queue<backend::ext_oneapi_hip>();
+      ASSERT_EQ(hipInteropStream, hipStream);
+    });
+  });
+}
+
+TEST_P(HipInteropGetNativeTests, hostTaskGetNativeContext) {
+  hipCtx_t hipContext =
+      get_native<backend::ext_oneapi_hip>(syclQueue_->get_context());
+  syclQueue_->submit([&](handler &cgh) {
+    cgh.host_task([=](interop_handle ih) {
+      hipCtx_t hipInteropContext =
+          ih.get_native_context<backend::ext_oneapi_hip>();
+      ASSERT_EQ(hipInteropContext, hipContext);
+    });
+  });
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    OnHipPlatform, HipInteropGetNativeTests,
+    ::testing::ValuesIn(pi::getPlatformsWithName("HIP BACKEND")));

--- a/sycl/unittests/pi/hip/test_kernels.cpp
+++ b/sycl/unittests/pi/hip/test_kernels.cpp
@@ -1,0 +1,80 @@
+//==---- test_kernels.cpp --- PI unit tests --------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+
+#include <hip/hip_runtime.h>
+
+#include "TestGetPlugin.hpp"
+#include <detail/plugin.hpp>
+#include <pi_hip.hpp>
+#include <sycl/detail/pi.hpp>
+#include <sycl/sycl.hpp>
+
+// PI HIP kernels carry an additional argument for the implicit global offset.
+#define NUM_IMPLICIT_ARGS 1
+
+using namespace sycl;
+
+struct HipKernelsTest : public ::testing::Test {
+
+protected:
+  std::optional<detail::plugin> plugin =
+      pi::initializeAndGet(backend::ext_oneapi_hip);
+  pi_platform platform_;
+  pi_device device_;
+  pi_context context_;
+  pi_queue queue_;
+
+  void SetUp() override {
+    // skip the tests if the HIP backend is not available
+    if (!plugin.has_value()) {
+      GTEST_SKIP();
+    }
+
+    pi_uint32 numPlatforms = 0;
+    ASSERT_EQ(plugin->hasBackend(backend::ext_oneapi_hip), PI_SUCCESS);
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
+                  0, nullptr, &numPlatforms)),
+              PI_SUCCESS)
+        << "piPlatformsGet failed.\n";
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
+                  numPlatforms, &platform_, nullptr)),
+              PI_SUCCESS)
+        << "piPlatformsGet failed.\n";
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDevicesGet>(
+                  platform_, PI_DEVICE_TYPE_GPU, 1, &device_, nullptr)),
+              PI_SUCCESS);
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
+                  nullptr, 1, &device_, nullptr, nullptr, &context_)),
+              PI_SUCCESS);
+    ASSERT_NE(context_, nullptr);
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueCreate>(
+                  context_, device_, 0, &queue_)),
+              PI_SUCCESS);
+    ASSERT_NE(queue_, nullptr);
+    ASSERT_EQ(queue_->get_context(), context_);
+  }
+
+  void TearDown() override {
+    if (plugin.has_value()) {
+      plugin->call<detail::PiApiKind::piDeviceRelease>(device_);
+      plugin->call<detail::PiApiKind::piQueueRelease>(queue_);
+      plugin->call<detail::PiApiKind::piContextRelease>(context_);
+    }
+  }
+
+  HipKernelsTest() = default;
+
+  ~HipKernelsTest() = default;
+};
+

--- a/sycl/unittests/pi/hip/test_mem_obj.cpp
+++ b/sycl/unittests/pi/hip/test_mem_obj.cpp
@@ -1,0 +1,206 @@
+//==---- test_mem_obj.cpp --- PI unit tests --------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+
+#include <hip/hip_runtime.h>
+
+#include "HipUtils.hpp"
+#include "TestGetPlugin.hpp"
+#include <detail/plugin.hpp>
+#include <pi_hip.hpp>
+#include <sycl/detail/pi.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+struct HipTestMemObj : public ::testing::Test {
+
+protected:
+  std::optional<detail::plugin> plugin =
+      pi::initializeAndGet(backend::ext_oneapi_hip);
+
+  pi_platform platform_;
+  pi_device device_;
+  pi_context context_;
+
+  void SetUp() override {
+    // skip the tests if the HIP backend is not available
+    if (!plugin.has_value()) {
+      GTEST_SKIP();
+    }
+
+    pi::clearHipContext();
+    pi_uint32 numPlatforms = 0;
+    ASSERT_EQ(plugin->hasBackend(backend::ext_oneapi_hip), PI_SUCCESS);
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
+                  0, nullptr, &numPlatforms)),
+              PI_SUCCESS)
+        << "piPlatformsGet failed.\n";
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
+                  numPlatforms, &platform_, nullptr)),
+              PI_SUCCESS)
+        << "piPlatformsGet failed.\n";
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDevicesGet>(
+                  platform_, PI_DEVICE_TYPE_GPU, 1, &device_, nullptr)),
+              PI_SUCCESS);
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
+                  nullptr, 1, &device_, nullptr, nullptr, &context_)),
+              PI_SUCCESS);
+    EXPECT_NE(context_, nullptr);
+  }
+
+  void TearDown() override {
+    if (plugin.has_value()) {
+      plugin->call<detail::PiApiKind::piDeviceRelease>(device_);
+      plugin->call<detail::PiApiKind::piContextRelease>(context_);
+    }
+  }
+
+  HipTestMemObj() = default;
+
+  ~HipTestMemObj() = default;
+};
+
+TEST_F(HipTestMemObj, piMemBufferCreateSimple) {
+  const size_t memSize = 1024u;
+  pi_mem memObj;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+                context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj,
+                nullptr)),
+            PI_SUCCESS);
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
+            PI_SUCCESS);
+}
+
+TEST_F(HipTestMemObj, piMemBufferAllocHost) {
+  const size_t memSize = 1024u;
+  pi_mem memObj;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+                context_, PI_MEM_FLAGS_ACCESS_RW | PI_MEM_FLAGS_HOST_PTR_ALLOC,
+                memSize, nullptr, &memObj, nullptr)),
+            PI_SUCCESS);
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
+            PI_SUCCESS);
+}
+
+TEST_F(HipTestMemObj, piMemBufferCreateNoActiveContext) {
+  const size_t memSize = 1024u;
+  // Context has been destroyed
+
+  hipCtx_t current = nullptr;
+
+  // pop HIP contexts until there is not a HIP context bound to the thread
+  do {
+    hipCtx_t oldContext = nullptr;
+    auto hipErr = hipCtxPopCurrent(&oldContext);
+    EXPECT_EQ(hipErr, PI_SUCCESS);
+
+    // There should not be any active CUDA context
+    hipErr = hipCtxGetCurrent(&current);
+    ASSERT_EQ(hipErr, PI_SUCCESS);
+  } while (current != nullptr);
+
+  // The context object is passed, even if its not active it should be used
+  // to allocate the memory object
+  pi_mem memObj;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+                context_, PI_MEM_FLAGS_ACCESS_RW, memSize, nullptr, &memObj,
+                nullptr)),
+            PI_SUCCESS);
+  ASSERT_NE(memObj, nullptr);
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
+            PI_SUCCESS);
+}
+
+TEST_F(HipTestMemObj, piMemBufferPinnedMappedRead) {
+  const size_t memSize = sizeof(int);
+  const int value = 20;
+
+  pi_queue queue;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueCreate>(
+                context_, device_, 0, &queue)),
+            PI_SUCCESS);
+  ASSERT_NE(queue, nullptr);
+  ASSERT_EQ(queue->get_context(), context_);
+
+  pi_mem memObj;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+                context_, PI_MEM_FLAGS_ACCESS_RW | PI_MEM_FLAGS_HOST_PTR_ALLOC,
+                memSize, nullptr, &memObj, nullptr)),
+            PI_SUCCESS);
+
+  ASSERT_EQ(
+      (plugin->call_nocheck<detail::PiApiKind::piEnqueueMemBufferWrite>(
+          queue, memObj, true, 0, sizeof(int), &value, 0, nullptr, nullptr)),
+      PI_SUCCESS);
+
+  int *host_ptr = nullptr;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueMemBufferMap>(
+                queue, memObj, true, PI_MAP_READ, 0, sizeof(int), 0, nullptr,
+                nullptr, (void **)&host_ptr)),
+            PI_SUCCESS);
+
+  ASSERT_EQ(*host_ptr, value);
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueMemUnmap>(
+                queue, memObj, host_ptr, 0, nullptr, nullptr)),
+            PI_SUCCESS);
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
+            PI_SUCCESS);
+  plugin->call<detail::PiApiKind::piQueueRelease>(queue);
+}
+
+TEST_F(HipTestMemObj, piMemBufferPinnedMappedWrite) {
+  const size_t memSize = sizeof(int);
+  const int value = 30;
+
+  pi_queue queue;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piQueueCreate>(
+                context_, device_, 0, &queue)),
+            PI_SUCCESS);
+  ASSERT_NE(queue, nullptr);
+  ASSERT_EQ(queue->get_context(), context_);
+
+  pi_mem memObj;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemBufferCreate>(
+                context_, PI_MEM_FLAGS_ACCESS_RW | PI_MEM_FLAGS_HOST_PTR_ALLOC,
+                memSize, nullptr, &memObj, nullptr)),
+            PI_SUCCESS);
+
+  int *host_ptr = nullptr;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueMemBufferMap>(
+                queue, memObj, true, PI_MAP_WRITE, 0, sizeof(int), 0, nullptr,
+                nullptr, (void **)&host_ptr)),
+            PI_SUCCESS);
+
+  *host_ptr = value;
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueMemUnmap>(
+                queue, memObj, host_ptr, 0, nullptr, nullptr)),
+            PI_SUCCESS);
+
+  int read_value = 0;
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piEnqueueMemBufferRead>(
+                queue, memObj, true, 0, sizeof(int), &read_value, 0, nullptr,
+                nullptr)),
+            PI_SUCCESS);
+
+  ASSERT_EQ(read_value, value);
+
+  ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piMemRelease>(memObj)),
+            PI_SUCCESS);
+  plugin->call<detail::PiApiKind::piQueueRelease>(queue);
+}

--- a/sycl/unittests/pi/hip/test_primary_context.cpp
+++ b/sycl/unittests/pi/hip/test_primary_context.cpp
@@ -1,0 +1,85 @@
+//==---------- pi_primary_context.cpp - PI unit tests ----------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+
+#include <hip/hip_runtime.h>
+
+#include "TestGetPlatforms.hpp"
+#include <pi_hip.hpp>
+#include <sycl/ext/oneapi/backend/hip.hpp>
+#include <sycl/sycl.hpp>
+
+#include <iostream>
+
+using namespace sycl;
+
+struct HipPrimaryContextTests : public ::testing::TestWithParam<platform> {
+
+protected:
+  device deviceA_;
+  device deviceB_;
+
+  void SetUp() override {
+    std::vector<device> HipDevices = GetParam().get_devices();
+
+    deviceA_ = HipDevices[0];
+    deviceB_ = HipDevices.size() > 1 ? HipDevices[1] : deviceA_;
+  }
+
+  void TearDown() override {}
+};
+
+TEST_P(HipPrimaryContextTests, piSingleContext) {
+  std::cout << "create single context" << std::endl;
+  context Context(deviceA_, async_handler{});
+
+  hipDevice_t HipDevice = get_native<backend::ext_oneapi_hip>(deviceA_);
+  hipCtx_t HipContext = get_native<backend::ext_oneapi_hip>(Context);
+
+  hipCtx_t PrimaryHipContext;
+  hipDevicePrimaryCtxRetain(&PrimaryHipContext, HipDevice);
+
+  ASSERT_EQ(HipContext, PrimaryHipContext);
+
+  hipDevicePrimaryCtxRelease(HipDevice);
+}
+
+TEST_P(HipPrimaryContextTests, piMultiContextSingleDevice) {
+  std::cout << "create multiple contexts for one device" << std::endl;
+  context ContextA(deviceA_, async_handler{});
+  context ContextB(deviceA_, async_handler{});
+
+  hipCtx_t HipContextA = get_native<backend::ext_oneapi_hip>(ContextA);
+  hipCtx_t HipContextB = get_native<backend::ext_oneapi_hip>(ContextB);
+
+  ASSERT_EQ(HipContextA, HipContextB);
+}
+
+TEST_P(HipPrimaryContextTests, piMultiContextMultiDevice) {
+  if (deviceA_ == deviceB_)
+    return;
+
+  hipDevice_t HipDeviceA = get_native<backend::ext_oneapi_hip>(deviceA_);
+  hipDevice_t HipDeviceB = get_native<backend::ext_oneapi_hip>(deviceB_);
+
+  ASSERT_NE(HipDeviceA, HipDeviceB);
+
+  std::cout << "create multiple contexts for multiple devices" << std::endl;
+  context ContextA(deviceA_, async_handler{});
+  context ContextB(deviceB_, async_handler{});
+
+  hipCtx_t HipContextA = get_native<backend::ext_oneapi_hip>(ContextA);
+  hipCtx_t HipContextB = get_native<backend::ext_oneapi_hip>(ContextB);
+
+  ASSERT_NE(HipContextA, HipContextB);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    OnHipPlatform, HipPrimaryContextTests,
+    ::testing::ValuesIn(pi::getPlatformsWithName("HIP BACKEND")));

--- a/sycl/unittests/pi/hip/test_sampler_properties.cpp
+++ b/sycl/unittests/pi/hip/test_sampler_properties.cpp
@@ -1,0 +1,135 @@
+//==---- PlatformTest.cpp --- PI unit tests --------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "gtest/gtest.h"
+
+#include "TestGetPlugin.hpp"
+#include <detail/plugin.hpp>
+#include <sycl/detail/pi.hpp>
+#include <sycl/sycl.hpp>
+
+#include <vector>
+
+namespace {
+
+using namespace sycl;
+
+class SamplerPropertiesTest
+    : public ::testing::TestWithParam<std::tuple<
+          pi_bool, pi_sampler_filter_mode, pi_sampler_addressing_mode>> {
+protected:
+  std::optional<detail::plugin> plugin =
+      pi::initializeAndGet(backend::ext_oneapi_hip);
+
+  pi_platform platform_;
+  pi_device device_;
+  pi_context context_;
+  pi_sampler sampler_;
+
+  pi_bool normalizedCoords_;
+  pi_sampler_filter_mode filterMode_;
+  pi_sampler_addressing_mode addressMode_;
+
+  SamplerPropertiesTest() = default;
+
+  ~SamplerPropertiesTest() override = default;
+
+  void SetUp() override {
+    // skip the tests if the HIP backend is not available
+    if (!plugin.has_value()) {
+      GTEST_SKIP();
+    }
+
+    std::tie(normalizedCoords_, filterMode_, addressMode_) = GetParam();
+
+    pi_uint32 numPlatforms = 0;
+    ASSERT_EQ(plugin->hasBackend(backend::ext_oneapi_hip), PI_SUCCESS);
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
+                  0, nullptr, &numPlatforms)),
+              PI_SUCCESS)
+        << "piPlatformsGet failed.\n";
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piPlatformsGet>(
+                  numPlatforms, &platform_, nullptr)),
+              PI_SUCCESS)
+        << "piPlatformsGet failed.\n";
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piDevicesGet>(
+                  platform_, PI_DEVICE_TYPE_GPU, 1, &device_, nullptr)),
+              PI_SUCCESS);
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piContextCreate>(
+                  nullptr, 1, &device_, nullptr, nullptr, &context_)),
+              PI_SUCCESS);
+    EXPECT_NE(context_, nullptr);
+
+    pi_sampler_properties sampler_properties[] = {
+        PI_SAMPLER_PROPERTIES_NORMALIZED_COORDS,
+        static_cast<pi_sampler_properties>(normalizedCoords_),
+        PI_SAMPLER_PROPERTIES_ADDRESSING_MODE,
+        static_cast<pi_sampler_properties>(addressMode_),
+        PI_SAMPLER_PROPERTIES_FILTER_MODE,
+        static_cast<pi_sampler_properties>(filterMode_),
+        0};
+
+    ASSERT_EQ((plugin->call_nocheck<detail::PiApiKind::piSamplerCreate>(
+                  context_, sampler_properties, &sampler_)),
+              PI_SUCCESS);
+  }
+
+  void TearDown() override {
+    if (plugin.has_value()) {
+      plugin->call<detail::PiApiKind::piSamplerRelease>(sampler_);
+      plugin->call<detail::PiApiKind::piDeviceRelease>(device_);
+      plugin->call<detail::PiApiKind::piContextRelease>(context_);
+    }
+  }
+};
+
+TEST_P(SamplerPropertiesTest, piCheckNormalizedCoords) {
+  pi_bool actualNormalizedCoords = !normalizedCoords_;
+
+  plugin->call<detail::PiApiKind::piSamplerGetInfo>(
+      sampler_, PI_SAMPLER_INFO_NORMALIZED_COORDS, sizeof(pi_bool),
+      &actualNormalizedCoords, nullptr);
+
+  ASSERT_EQ(actualNormalizedCoords, normalizedCoords_);
+}
+
+TEST_P(SamplerPropertiesTest, piCheckFilterMode) {
+  pi_sampler_filter_mode actualFilterMode;
+
+  plugin->call<detail::PiApiKind::piSamplerGetInfo>(
+      sampler_, PI_SAMPLER_INFO_FILTER_MODE, sizeof(pi_sampler_filter_mode),
+      &actualFilterMode, nullptr);
+
+  ASSERT_EQ(actualFilterMode, filterMode_);
+}
+
+TEST_P(SamplerPropertiesTest, piCheckAddressingMode) {
+  pi_sampler_addressing_mode actualAddressMode;
+
+  plugin->call<detail::PiApiKind::piSamplerGetInfo>(
+      sampler_, PI_SAMPLER_INFO_ADDRESSING_MODE,
+      sizeof(pi_sampler_addressing_mode), &actualAddressMode, nullptr);
+
+  ASSERT_EQ(actualAddressMode, addressMode_);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SamplerPropertiesTestImpl, SamplerPropertiesTest,
+    ::testing::Combine(
+        ::testing::Values(PI_TRUE, PI_FALSE),
+        ::testing::Values(PI_SAMPLER_FILTER_MODE_LINEAR,
+                          PI_SAMPLER_FILTER_MODE_NEAREST),
+        ::testing::Values(PI_SAMPLER_ADDRESSING_MODE_CLAMP,
+                          PI_SAMPLER_ADDRESSING_MODE_CLAMP_TO_EDGE,
+                          PI_SAMPLER_ADDRESSING_MODE_NONE,
+                          PI_SAMPLER_ADDRESSING_MODE_MIRRORED_REPEAT,
+                          PI_SAMPLER_ADDRESSING_MODE_REPEAT)));
+} // namespace


### PR DESCRIPTION
The kernel test (test_kernels.cpp) is incomplete because how to generate binary files properly for "piProgramCreateWithBinary" for the HIP backend is not clear to me. 
 