### PR TITLE
[SYCL] Do not diagnose undefined pure virtual functions

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -491,8 +491,10 @@ static bool isSYCLUndefinedAllowed(const FunctionDecl *Callee,
   if (!Callee->getIdentifier())
     return false;
 
-  // Pure virtual functions need not be diagnosed here. If a definition
-  // is not provided in derived classes, clang will diagnose the call.
+  // Pure virtual functions may be defined in a derived class. Therefore, do not
+  // diagnose missing SYCL_EXTERNAL macro on pure virtual functions. Please note
+  // that even if a definition is not provided by the derived class, the compiler
+  // will not diagnose the missing SYCL_EXTERNAL macro.
   if (Callee->isPure())
     return true;
 

--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -491,6 +491,11 @@ static bool isSYCLUndefinedAllowed(const FunctionDecl *Callee,
   if (!Callee->getIdentifier())
     return false;
 
+  // Pure virtual functions need not be diagnosed here. If a definition
+  // is not provided in derived classes, clang will diagnose the call.
+  if (Callee->isPure())
+    return true;
+
   // libstdc++-11 introduced an undefined function "void __failed_assertion()"
   // which may lead to SemaSYCL check failure. However, this undefined function
   // is used to trigger some compilation error when the check fails at compile

--- a/clang/test/SemaSYCL/virtual-function.cpp
+++ b/clang/test/SemaSYCL/virtual-function.cpp
@@ -1,10 +1,7 @@
 // RUN: %clang_cc1 -fsycl-is-device -fsycl-allow-virtual-functions -internal-isystem %S/Inputs -verify -fsyntax-only %s
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -verify=novirtualfunction -fsyntax-only %s
 
 // This test verifies that pure virtual functions are not
 // diagnosed if undefined in base class.
-
-// expected-no-diagnostics
 
 #include "sycl.hpp"
 
@@ -12,19 +9,35 @@ sycl::queue deviceQueue;
 
 class AbstractClass {
   public:
-  virtual void testVF() = 0;
+  virtual void testVF() = 0; //expected-note{{unimplemented pure virtual method 'testVF' in 'Derived2'}}
 };
 
-class Derived : public AbstractClass {
+class Derived1 : public AbstractClass {
     void testVF() {}
+};
+
+class Derived2 : public AbstractClass {
+};
+
+class Derived3 : public AbstractClass {
+    void testVF();
 };
 
 void foo() {
   deviceQueue.submit([&](sycl::handler &h) {
     h.single_task<class CallToUndefinedFnTester>([]() {
-      Derived d;
-      AbstractClass* obj = &d;
-      obj->testVF(); // novirtualfunction-error {{SYCL kernel cannot call a virtual function}}
+      Derived1 d1;
+      AbstractClass* obj1 = &d1;
+      obj1->testVF(); // No diagnostic
+
+      Derived2 d2; // expected-error{{variable type 'Derived2' is an abstract class}}
+
+      Derived3 d3;
+      AbstractClass* obj2 = &d3;
+      // Ideally we would want to diagnose the missing SYCL_EXTERNAL macro here since
+      // there is no definition for this function in this TU. However it is expensive
+      // to do so in the frontend, and a diagnostic is not currently emitted.
+      obj2->testVF();
     });
   });
 }

--- a/clang/test/SemaSYCL/virtual-function.cpp
+++ b/clang/test/SemaSYCL/virtual-function.cpp
@@ -1,0 +1,29 @@
+// RUN: %clang_cc1 -fsycl-is-device -fsycl-allow-virtual-functions -internal-isystem %S/Inputs -verify -fsyntax-only %s
+
+// This test verifies that pure virtual functions are not
+// diagnosed if undefined in base class.
+
+// expected-no-diagnostics
+
+#include "sycl.hpp"
+
+sycl::queue deviceQueue;
+
+class AbstractClass {
+  public:
+  virtual void testVF() = 0;
+};
+
+class Derived : public AbstractClass {
+    void testVF() {}
+};
+
+void foo() {
+  deviceQueue.submit([&](sycl::handler &h) {
+    h.single_task<class CallToUndefinedFnTester>([]() {
+      Derived d;
+      AbstractClass* obj = &d;
+      (*obj).testVF();
+    });
+  });
+}

--- a/clang/test/SemaSYCL/virtual-function.cpp
+++ b/clang/test/SemaSYCL/virtual-function.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsycl-is-device -fsycl-allow-virtual-functions -internal-isystem %S/Inputs -verify -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -verify=novirtualfunction -fsyntax-only %s
 
 // This test verifies that pure virtual functions are not
 // diagnosed if undefined in base class.
@@ -23,7 +24,7 @@ void foo() {
     h.single_task<class CallToUndefinedFnTester>([]() {
       Derived d;
       AbstractClass* obj = &d;
-      (*obj).testVF();
+      obj->testVF(); // novirtualfunction-error {{SYCL kernel cannot call a virtual function}}
     });
   });
 }


### PR DESCRIPTION
Deffered diagnostics in for SYCL device code diagnoses calls to undefined functions from kernel. Calls to pure virtual functions should not be diagnosed here since they will be defined in derived classes. If not, regular Clang diagnostics will catch the use of abstract type.