### PR TITLE
[SYCL][ESIMD] Fix two opaque pointer issues

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -1237,10 +1237,10 @@ translateSpirvGlobalUses(LoadInst *LI, StringRef SpirvGlobalName,
     NewInst = llvm::Constant::getNullValue(LI->getType());
   } else if (isa<GetElementPtrConstantExpr>(LI->getPointerOperand())) {
     // Translate the load that has getelementptr as an operand
-    auto *GEPCE = cast<GEPOperator>(LI->getPointerOperand());
+    auto *GEPOp = cast<GEPOperator>(LI->getPointerOperand());
     const DataLayout &DL = LI->getFunction()->getParent()->getDataLayout();
-    APInt Offset(DL.getIndexSizeInBits(GEPCE->getPointerAddressSpace()), 0);
-    if (!GEPCE->accumulateConstantOffset(DL, Offset))
+    APInt Offset(DL.getIndexSizeInBits(GEPOp->getPointerAddressSpace()), 0);
+    if (!GEPOp->accumulateConstantOffset(DL, Offset))
       llvm_unreachable("Illegal GEP of a SPIR-V builtin variable");
     APInt IndexValue;
     uint64_t Remainder;

--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -1198,7 +1198,7 @@ static Value *generateSpirvGlobalGenX(Instruction *EEI,
   } else if (SpirvGlobalName == "GlobalOffset") {
     // TODO: Support GlobalOffset SPIRV intrinsics
     // Currently all users of load of GlobalOffset are replaced with 0.
-    NewInst = llvm::Constant::getNullValue(EEI->getType());
+    NewInst = llvm::Constant::getNullValue(UseType ? UseType : EEI->getType());
   } else if (SpirvGlobalName == "NumWorkgroups") {
     NewInst = generateGenXCall(EEI, "group.count", true, IndexValue, UseType);
   }
@@ -1237,10 +1237,19 @@ translateSpirvGlobalUses(LoadInst *LI, StringRef SpirvGlobalName,
     NewInst = llvm::Constant::getNullValue(LI->getType());
   } else if (isa<GetElementPtrConstantExpr>(LI->getPointerOperand())) {
     // Translate the load that has getelementptr as an operand
-    auto *GEPCE = cast<GetElementPtrConstantExpr>(LI->getPointerOperand());
-    uint64_t IndexValue =
-        cast<Constant>(GEPCE->getOperand(2))->getUniqueInteger().getZExtValue();
-    NewInst = generateSpirvGlobalGenX(LI, SpirvGlobalName, IndexValue);
+    auto *GEPCE = cast<GEPOperator>(LI->getPointerOperand());
+    const DataLayout &DL = LI->getFunction()->getParent()->getDataLayout();
+    APInt Offset(DL.getIndexSizeInBits(GEPCE->getPointerAddressSpace()), 0);
+    if (!GEPCE->accumulateConstantOffset(DL, Offset))
+      llvm_unreachable("Illegal GEP of a SPIR-V builtin variable");
+    APInt IndexValue;
+    uint64_t Remainder;
+    APInt::udivrem(Offset, LI->getType()->getScalarSizeInBits() / 8, IndexValue,
+                   Remainder);
+    if (Remainder != 0)
+      llvm_unreachable("Illegal GEP of a SPIR-V builtin variable");
+    NewInst =
+        generateSpirvGlobalGenX(LI, SpirvGlobalName, IndexValue.getZExtValue());
   }
   if (NewInst) {
     LI->replaceAllUsesWith(NewInst);

--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -1235,9 +1235,8 @@ translateSpirvGlobalUses(LoadInst *LI, StringRef SpirvGlobalName,
                                               llvm::APInt(32, 1, true));
   } else if (SpirvGlobalName == "GlobalLinearId") {
     NewInst = llvm::Constant::getNullValue(LI->getType());
-  } else if (isa<GetElementPtrConstantExpr>(LI->getPointerOperand())) {
+  } else if (auto *GEPOp = dyn_cast<GEPOperator>(LI->getPointerOperand())) {
     // Translate the load that has getelementptr as an operand
-    auto *GEPOp = cast<GEPOperator>(LI->getPointerOperand());
     const DataLayout &DL = LI->getFunction()->getParent()->getDataLayout();
     APInt Offset(DL.getIndexSizeInBits(GEPOp->getPointerAddressSpace()), 0);
     if (!GEPOp->accumulateConstantOffset(DL, Offset))

--- a/llvm/test/SYCLLowerIR/ESIMD/lower_spirv_intrins_gep.ll
+++ b/llvm/test/SYCLLowerIR/ESIMD/lower_spirv_intrins_gep.ll
@@ -1,0 +1,32 @@
+; RUN: opt -opaque-pointers < %s -passes=LowerESIMD -S | FileCheck %s
+
+; This test checks we lower vector SPIRV globals with opaque pointers
+; and a GEP operand
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+@__spirv_BuiltInGlobalInvocationId = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
+
+define spir_kernel void @"__spirv_GlobalInvocationId_xyz"() {
+; CHECK-LABEL: @__spirv_GlobalInvocationId_xyz(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[DOTESIMD6:%.*]] = call <3 x i32> @llvm.genx.local.id.v3i32()
+; CHECK-NEXT:    [[LOCAL_ID_Y:%.*]] = extractelement <3 x i32> [[DOTESIMD6]], i32 1
+; CHECK-NEXT:    [[LOCAL_ID_Y_CAST_TY:%.*]] = zext i32 [[LOCAL_ID_Y]] to i64
+; CHECK-NEXT:    [[DOTESIMD7:%.*]] = call <3 x i32> @llvm.genx.local.size.v3i32()
+; CHECK-NEXT:    [[WGSIZE_Y:%.*]] = extractelement <3 x i32> [[DOTESIMD7]], i32 1
+; CHECK-NEXT:    [[WGSIZE_Y_CAST_TY:%.*]] = zext i32 [[WGSIZE_Y]] to i64
+; CHECK-NEXT:    [[GROUP_ID_Y:%.*]] = call i32 @llvm.genx.group.id.y()
+; CHECK-NEXT:    [[GROUP_ID_Y_CAST_TY:%.*]] = zext i32 [[GROUP_ID_Y]] to i64
+; CHECK-NEXT:    [[MUL8:%.*]] = mul i64 [[WGSIZE_Y_CAST_TY]], [[GROUP_ID_Y_CAST_TY]]
+; CHECK-NEXT:    [[ADD9:%.*]] = add i64 [[LOCAL_ID_Y_CAST_TY]], [[MUL8]]
+; CHECK-NEXT:    [[MUL10:%.*]] = shl nuw nsw i64 [[ADD9]], 5
+
+; Verify that the attribute is deleted from GenX declaration
+; CHECK-NOT: readnone
+entry:
+  %0 = load i64, ptr addrspace(1) getelementptr inbounds (i8, ptr addrspace(1) @__spirv_BuiltInGlobalInvocationId, i64 8), align 8
+  %mul.i = shl nuw nsw i64 %0, 5
+ ret void
+}

--- a/llvm/test/SYCLLowerIR/ESIMD/lower_spirv_intrins_globaloffset.ll
+++ b/llvm/test/SYCLLowerIR/ESIMD/lower_spirv_intrins_globaloffset.ll
@@ -1,0 +1,25 @@
+; RUN: opt -opaque-pointers < %s -passes=LowerESIMD -S | FileCheck %s
+
+; This test checks we lower vector the SPIRV global offset intrinsic with opaque pointers
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+@__spirv_BuiltInGlobalOffset = external dso_local local_unnamed_addr addrspace(1) constant <3 x i64>, align 32
+
+define spir_kernel void @foo() {
+; CHECK-LABEL: @foo(
+; CHECK-NEXT:  entry:
+; CHECK-NEXT:    [[TMP:%.*]] = alloca i64, align 8
+; CHECK-NEXT:    [[ADD:%.*]] = add i64 0, 5
+; CHECK-NEXT:   store i64 [[ADD]], ptr [[TMP]], align 8
+
+; Verify that the attribute is deleted from GenX declaration
+; CHECK-NOT: readnone
+entry:
+  %tmp = alloca i64, align 8
+  %0 = load i64, ptr addrspace(1) @__spirv_BuiltInGlobalOffset, align 32
+  %1 = add i64 %0, 5
+  store i64 %1, ptr %tmp, align 8
+ ret void
+}


### PR DESCRIPTION
Issue 1) We need to change how we compute the offset for a GEP. This code is based on code from @jcranmer-intel

Issue 2) Missed case from https://github.com/intel/llvm/commit/637d3d5b674126f3945eee8e335cbfcb840628e9, just need to use the correct type.