### PR TITLE
[SPIRV] Disable two PipeStorage tests

### DIFF
--- a/llvm-spirv/test/extensions/INTEL/SPV_INTEL_io_pipes/PipeStorageIOINTEL.ll
+++ b/llvm-spirv/test/extensions/INTEL/SPV_INTEL_io_pipes/PipeStorageIOINTEL.ll
@@ -1,3 +1,6 @@
+; https://github.com/intel/llvm/issues/9387
+; UNSUPPORTED: windows
+;
 ; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 --spirv-ext=+SPV_INTEL_io_pipes -o %t.spv
 ; RUN: llvm-spirv %t.spv -to-text -o %t.spt

--- a/llvm-spirv/test/transcoding/PipeStorage.ll
+++ b/llvm-spirv/test/transcoding/PipeStorage.ll
@@ -1,3 +1,6 @@
+; https://github.com/intel/llvm/issues/9387
+; UNSUPPORTED: windows
+;
 ; RUN: llvm-as -opaque-pointers=0 %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -opaque-pointers=0 -spirv-text -o %t.txt
 ; RUN: FileCheck < %t.txt %s --check-prefix=CHECK-SPIRV


### PR DESCRIPTION
The tests flaky fail in CI on
Windows (https://github.com/intel/llvm/issues/9387) preventing Windows testing from happening (check-spirv is condsidered to be part of the build).