### PR TITLE
[SYCL][InvokeSimd][E2E] Add new and fix existing InvokeSimd named barrier tests

### DIFF
--- a/sycl/test-e2e/InvokeSimd/Regression/nbarrier_basic.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/nbarrier_basic.cpp
@@ -4,7 +4,7 @@
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 //
-// VISALTO enable run
+// vISA LTO run
 // RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
@@ -56,7 +56,7 @@ ESIMD_INLINE void ESIMD_CALLEE_nbarrier(nd_item<1> *ndi) SYCL_ESIMD_FUNCTION {
     nd_item<1> *ndi) SYCL_ESIMD_FUNCTION;
 
 int main(void) {
-  auto Queue = queue{gpu_selector_v};
+  queue Queue;
   auto Device = Queue.get_device();
 
   std::cout << "Running on " << Device.get_info<sycl::info::device::name>()

--- a/sycl/test-e2e/InvokeSimd/Regression/nbarrier_exec_in_order.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/nbarrier_exec_in_order.cpp
@@ -44,8 +44,8 @@ template <int case_num> class KernelID;
 
 template <unsigned Threads, unsigned Size, bool UseSLM>
 ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> LocalAcc,
-		                        int localID,
-					int *o) SYCL_ESIMD_FUNCTION {
+                                        int localID,
+                                        int *o) SYCL_ESIMD_FUNCTION {
   // Threads - 1 named barriers required
   // but id 0 reserved for unnamed
   experimental_esimd::named_barrier_init<Threads>();
@@ -56,10 +56,9 @@ ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> LocalAcc,
 
   // overlaping offsets
   unsigned int off = VL * localID / 2;
-  unsigned int off_slm =
-      static_cast<uint32_t>(
-          reinterpret_cast<std::uintptr_t>(LocalAcc.get_pointer())) +
-      off * sizeof(int);
+  unsigned int off_slm = static_cast<uint32_t>(reinterpret_cast<std::uintptr_t>(
+                             LocalAcc.get_pointer())) +
+                         off * sizeof(int);
   esimd::simd<int, VL> val(localID);
 
   esimd::barrier();
@@ -134,7 +133,8 @@ bool test(QueueTY q) {
   }
 
   auto dev = q.get_device();
-  auto deviceSLMSize = dev.template get_info<sycl::info::device::local_mem_size>();
+  auto deviceSLMSize =
+      dev.template get_info<sycl::info::device::local_mem_size>();
   if constexpr (UseSLM)
     std::cout << "Local Memory Size: " << deviceSLMSize << std::endl;
 
@@ -165,7 +165,7 @@ bool test(QueueTY q) {
             // Thread local ID in ESIMD context
             int localID = sg.get_group_linear_id();
 
-	    // SLM init
+            // SLM init
             uint32_t slmID = item.get_local_id(0);
             auto LocalAccCopy = LocalAcc;
             LocalAccCopy[slmID] = -1;
@@ -227,4 +227,3 @@ int main() {
 
   return passed ? 0 : 1;
 }
-

--- a/sycl/test-e2e/InvokeSimd/Regression/nbarrier_loop.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/nbarrier_loop.cpp
@@ -1,0 +1,210 @@
+// TODO: enable on Windows once driver is ready
+// NOTE: named barrier supported only since PVC
+// REQUIRES: gpu-intel-pvc && linux
+// UNSUPPORTED: cuda || hip
+//
+// TODO: enable when Jira issue resolved, currently fail with VISALTO enable
+// XFAIL: gpu-intel-pvc
+//
+// RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
+// RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
+//
+// VISALTO enable run
+// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
+
+/*
+ * Test checks support of named barrier in a loop in invoke_simd context.
+ * First iteration has 1 barrier and 1 producer, second - 2 barriers and 2
+ * producers. Producer stores data to SLM, then all threads read SLM and store
+ * data to surface.
+ */
+
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
+#include <sycl/sycl.hpp>
+
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/intel/experimental/esimd/memory.hpp>
+#include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
+#include <sycl/sycl.hpp>
+
+#include <functional>
+#include <iostream>
+#include <type_traits>
+
+// TODO: When gpu driver can pass/accept accessor by value,
+// the work-around undef #ifdef US_ACC_PTR should be removed.
+#define USE_ACC_PTR
+
+using namespace sycl;
+using namespace sycl::ext::oneapi::experimental;
+namespace esimd = sycl::ext::intel::esimd;
+namespace experimental_esimd = sycl::ext::intel::experimental::esimd;
+
+constexpr int VL = 16;
+constexpr unsigned Groups = 1;
+constexpr unsigned Threads = 8;
+constexpr unsigned Size = Groups * Threads * VL;
+
+class KernelID;
+
+ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> LocalAcc,
+		                        int localID,
+					int *o) SYCL_ESIMD_FUNCTION {
+  // 2 named barriers, id 0 reserved for unnamed
+  constexpr unsigned bnum = 3;
+
+  experimental_esimd::named_barrier_init<bnum>();
+
+  // slm size used in kernel
+  constexpr unsigned slm_size = Size / 2;
+
+  // 2 producers on first iteration, 1 producer on second
+  unsigned int indexes[2][2] = {{1, 2}, {3, 3}}; // local ids of producers
+  unsigned int prods[2] = {2, 1};                // number of producers
+
+  unsigned int off = localID * VL;
+  // producer writes to SLM, consumer reads what producer wrote
+  unsigned int slm_base =
+      static_cast<uint32_t>(
+          reinterpret_cast<std::uintptr_t>(LocalAcc.get_pointer()));
+
+  esimd::barrier();
+
+  for (int b = bnum - 1; b > 0; b--) {
+    int j = bnum - b - 1; // iteration index
+
+    bool is_producer = localID == indexes[j][0] || localID == indexes[j][1];
+    bool is_consumer = !is_producer;
+    // only-consumer or only-producer modes
+    unsigned int flag = is_producer ? 0x1 : 0x2;
+
+    unsigned int producers = prods[j];
+    unsigned int consumers = Threads - producers;
+
+    if (is_producer) {
+      unsigned int slm_store_off = j * sizeof(int) * slm_size / 4;
+      // second iteration store partialy overlaps first iteration stores
+      unsigned int dx = producers == 2 ? (localID - 1) : 0;
+      slm_store_off += dx * sizeof(int) * slm_size / 2;
+      simd<int, slm_size / 2> init(localID);
+      // producer stores to SLM
+      experimental_esimd::lsc_slm_block_store<int, slm_size / 2>(slm_base + slm_store_off, init);
+    }
+
+    __ESIMD_ENS::named_barrier_signal(b, flag, producers, consumers);
+
+    if (is_consumer)
+      __ESIMD_ENS::named_barrier_wait(b);
+
+    auto val = experimental_esimd::lsc_slm_block_load<int, VL>(slm_base + off * sizeof(int));
+    // and storing it to output surface
+    experimental_esimd::lsc_fence();
+    experimental_esimd::lsc_block_store<int, VL>(o + off + j * slm_size, val);
+    experimental_esimd::lsc_fence();
+  }
+}
+
+[[intel::device_indirectly_callable]] SYCL_EXTERNAL void __regcall SIMD_CALLEE_nbarrier(
+#ifdef USE_ACC_PTR
+    local_accessor<int, 1> *LocalAcc,
+#else
+    local_accessor<int, 1> LocalAcc,
+#endif
+    int localID, int *o) SYCL_ESIMD_FUNCTION {
+#ifdef USE_ACC_PTR
+  ESIMD_CALLEE_nbarrier(*LocalAcc, localID, o);
+#else
+  ESIMD_CALLEE_nbarrier(LocalAcc, localID, o);
+#endif
+}
+
+int main() {
+  auto q = queue{gpu_selector_v};
+  auto dev = q.get_device();
+  std::cout << "Running on " << dev.get_info<sycl::info::device::name>()
+            << "\n";
+
+  auto deviceSLMSize = dev.template get_info<sycl::info::device::local_mem_size>();
+  std::cout << "Local Memory Size: " << deviceSLMSize << std::endl;
+
+  // The test is going to use Size elements of int type.
+  if (deviceSLMSize < Size * sizeof(int)) {
+    // Report an error - the test needs a fix.
+    std::cerr << "Error: Test needs more SLM memory than device has"
+              << std::endl;
+    return -1;
+  }
+
+  auto *out = malloc_shared<int>(Size, q);
+  for (int i = 0; i < Size; i++) {
+    out[i] = -1;
+  }
+
+  try {
+    // workgroups
+    sycl::range<1> GlobalRange{Size};
+    // threads in each group
+    sycl::range<1> LocalRange{Size / Groups};
+    sycl::nd_range<1> Range{GlobalRange * LocalRange, LocalRange};
+
+    auto e = q.submit([&](handler &cgh) {
+      auto LocalAcc = local_accessor<int, 1>(Size, cgh);
+      cgh.parallel_for<KernelID>(
+          nd_range<1>(GlobalRange, LocalRange),
+          // This test requires an explicit specification of the subgroup size
+          [=](nd_item<1> item) [[intel::reqd_sub_group_size(VL)]] {
+            sycl::group<1> g = item.get_group();
+            sycl::sub_group sg = item.get_sub_group();
+
+            // Thread local ID in ESIMD context
+            int localID = sg.get_group_linear_id();
+
+	    // SLM init
+            uint32_t slmID = item.get_local_id(0);
+            auto LocalAccCopy = LocalAcc;
+            LocalAccCopy[slmID] = -1;
+            item.barrier();
+
+#ifdef USE_ACC_PTR
+            auto LocalAccArg = uniform{&LocalAccCopy};
+#else
+            auto LocalAccArg = uniform{LocalAccCopy};
+#endif
+
+            invoke_simd(sg, SIMD_CALLEE_nbarrier, LocalAccArg, uniform{localID}, uniform{out});
+          });
+    });
+    e.wait();
+  } catch (sycl::exception const &e) {
+    std::cout << "SYCL exception caught: " << e.what() << '\n';
+    free(out, q);
+    return -1;
+  }
+
+  bool passed = true;
+  for (int i = 0; i < Size; i++) {
+    int etalon = 2;
+    if (i < Size / 4)
+      etalon = 1;
+    if (i >= Size / 2) {
+      if (i < (7 * Size / 8)) {
+        if (i < (5 * Size / 8))
+          etalon = 1;
+        else
+          etalon = 3;
+      }
+    }
+    if (out[i] != etalon) {
+      passed = false;
+      std::cout << "out[" << i << "]=" << std::hex << out[i] << " vs " << etalon
+                << std::dec << std::endl;
+    }
+  }
+
+  free(out, q);
+
+  std::cout << (passed ? " Passed\n" : " FAILED\n");
+  return passed ? 0 : 1;
+}
+

--- a/sycl/test-e2e/InvokeSimd/Regression/nbarrier_loop.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/nbarrier_loop.cpp
@@ -49,8 +49,8 @@ constexpr unsigned Size = Groups * Threads * VL;
 class KernelID;
 
 ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> LocalAcc,
-		                        int localID,
-					int *o) SYCL_ESIMD_FUNCTION {
+                                        int localID,
+                                        int *o) SYCL_ESIMD_FUNCTION {
   // 2 named barriers, id 0 reserved for unnamed
   constexpr unsigned bnum = 3;
 
@@ -65,9 +65,8 @@ ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> LocalAcc,
 
   unsigned int off = localID * VL;
   // producer writes to SLM, consumer reads what producer wrote
-  unsigned int slm_base =
-      static_cast<uint32_t>(
-          reinterpret_cast<std::uintptr_t>(LocalAcc.get_pointer()));
+  unsigned int slm_base = static_cast<uint32_t>(
+      reinterpret_cast<std::uintptr_t>(LocalAcc.get_pointer()));
 
   esimd::barrier();
 
@@ -89,7 +88,8 @@ ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> LocalAcc,
       slm_store_off += dx * sizeof(int) * slm_size / 2;
       simd<int, slm_size / 2> init(localID);
       // producer stores to SLM
-      experimental_esimd::lsc_slm_block_store<int, slm_size / 2>(slm_base + slm_store_off, init);
+      experimental_esimd::lsc_slm_block_store<int, slm_size / 2>(
+          slm_base + slm_store_off, init);
     }
 
     __ESIMD_ENS::named_barrier_signal(b, flag, producers, consumers);
@@ -97,7 +97,8 @@ ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> LocalAcc,
     if (is_consumer)
       __ESIMD_ENS::named_barrier_wait(b);
 
-    auto val = experimental_esimd::lsc_slm_block_load<int, VL>(slm_base + off * sizeof(int));
+    auto val = experimental_esimd::lsc_slm_block_load<int, VL>(
+        slm_base + off * sizeof(int));
     // and storing it to output surface
     experimental_esimd::lsc_fence();
     experimental_esimd::lsc_block_store<int, VL>(o + off + j * slm_size, val);
@@ -125,7 +126,8 @@ int main() {
   std::cout << "Running on " << dev.get_info<sycl::info::device::name>()
             << "\n";
 
-  auto deviceSLMSize = dev.template get_info<sycl::info::device::local_mem_size>();
+  auto deviceSLMSize =
+      dev.template get_info<sycl::info::device::local_mem_size>();
   std::cout << "Local Memory Size: " << deviceSLMSize << std::endl;
 
   // The test is going to use Size elements of int type.
@@ -160,7 +162,7 @@ int main() {
             // Thread local ID in ESIMD context
             int localID = sg.get_group_linear_id();
 
-	    // SLM init
+            // SLM init
             uint32_t slmID = item.get_local_id(0);
             auto LocalAccCopy = LocalAcc;
             LocalAccCopy[slmID] = -1;
@@ -172,7 +174,8 @@ int main() {
             auto LocalAccArg = uniform{LocalAccCopy};
 #endif
 
-            invoke_simd(sg, SIMD_CALLEE_nbarrier, LocalAccArg, uniform{localID}, uniform{out});
+            invoke_simd(sg, SIMD_CALLEE_nbarrier, LocalAccArg, uniform{localID},
+                        uniform{out});
           });
     });
     e.wait();
@@ -207,4 +210,3 @@ int main() {
   std::cout << (passed ? " Passed\n" : " FAILED\n");
   return passed ? 0 : 1;
 }
-

--- a/sycl/test-e2e/InvokeSimd/Regression/nbarrier_multiple_wg.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/nbarrier_multiple_wg.cpp
@@ -1,7 +1,5 @@
-// TODO: enable on Windows once driver is ready
 // NOTE: named barrier supported only since PVC
-// REQUIRES: gpu-intel-pvc && linux
-// UNSUPPORTED: cuda || hip
+// REQUIRES: gpu-intel-pvc
 //
 // TODO: enable when Jira issue resolved, currently fail with VISALTO enable
 // XFAIL: gpu-intel-pvc
@@ -9,7 +7,7 @@
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 //
-// VISALTO enable run
+// vISA LTO run
 // RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
@@ -32,7 +30,7 @@
 #include <type_traits>
 
 // TODO: When gpu driver can pass/accept accessor by value,
-// the work-around undef #ifdef US_ACC_PTR should be removed.
+// the work-around undef #ifdef USE_ACC_PTR should be removed.
 #define USE_ACC_PTR
 
 using namespace sycl;
@@ -41,11 +39,11 @@ namespace esimd = sycl::ext::intel::esimd;
 namespace experimental_esimd = sycl::ext::intel::experimental::esimd;
 
 constexpr int VL = 16;
-template <int case_num> class KernelID;
+template <int CaseNum> class KernelID;
 
 template <unsigned Groups, unsigned Threads, unsigned Size>
-ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> LocalAcc,
-                                        int groupID, int localID,
+ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> local_acc,
+                                        int groupID, int local_id,
                                         int *o) SYCL_ESIMD_FUNCTION {
   // 1 named barrier, id 0 reserved for unnamed
   constexpr unsigned bnum = 2;
@@ -53,32 +51,32 @@ ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> LocalAcc,
   experimental_esimd::named_barrier_init<bnum>();
 
   unsigned int group_off = VL * groupID * Threads;
-  unsigned int globalID = groupID * Threads + localID;
-  unsigned int global_off = VL * globalID;
+  unsigned int global_id = groupID * Threads + local_id;
+  unsigned int global_off = VL * global_id;
 
-  esimd::simd<int, VL> val(localID);
+  esimd::simd<int, VL> val(local_id);
 
   constexpr unsigned producers = Threads / 2;
   constexpr unsigned consumers = Threads / 2;
 
   // thread with even local id is producer in each work-group
-  bool is_producer = localID % 2 == 0;
+  bool is_producer = local_id % 2 == 0;
   bool is_consumer = !is_producer;
   // only-producer or only-comsumer modes
   unsigned int flag = is_producer ? 0x1 : 0x2;
 
   // producer writes to SLM, consumer reads what producer wrote
-  unsigned int off_slm =
+  unsigned int slm_base =
       static_cast<uint32_t>(
-          reinterpret_cast<std::uintptr_t>(LocalAcc.get_pointer())) +
-      (is_producer ? global_off : (global_off - VL)) * sizeof(int);
+          reinterpret_cast<std::uintptr_t>(local_acc.get_pointer()));
+  unsigned int slm_off = slm_base + (is_producer ? global_off : (global_off - VL)) * sizeof(int);
 
   esimd::barrier();
 
   if (is_producer) {
-    esimd::simd<int, VL> v(globalID);
+    esimd::simd<int, VL> v(global_id);
     // producer stores data to SLM
-    experimental_esimd::lsc_slm_block_store<int, VL>(off_slm, v);
+    experimental_esimd::lsc_slm_block_store<int, VL>(slm_off, v);
   }
 
   // signaling after data stored
@@ -88,7 +86,7 @@ ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> LocalAcc,
     // consumers waiting here for signal from producer
     __ESIMD_ENS::named_barrier_wait(bid);
     // read SLM and store to output
-    auto ret = experimental_esimd::lsc_slm_block_load<int, VL>(off_slm);
+    auto ret = experimental_esimd::lsc_slm_block_load<int, VL>(slm_off);
     // store SLM to output
     experimental_esimd::lsc_block_store<int, VL>(o + global_off - VL, ret);
     experimental_esimd::lsc_block_store<int, VL>(o + global_off, ret);
@@ -98,78 +96,79 @@ ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> LocalAcc,
 template <unsigned Groups, unsigned Threads, unsigned Size>
 [[intel::device_indirectly_callable]] SYCL_EXTERNAL void __regcall SIMD_CALLEE_nbarrier(
 #ifdef USE_ACC_PTR
-    local_accessor<int, 1> *LocalAcc,
+    local_accessor<int, 1> *local_acc,
 #else
-    local_accessor<int, 1> LocalAcc,
+    local_accessor<int, 1> local_acc,
 #endif
-    int groupID, int localID, int *o) SYCL_ESIMD_FUNCTION {
+    int groupID, int local_id, int *o) SYCL_ESIMD_FUNCTION {
 #ifdef USE_ACC_PTR
-  ESIMD_CALLEE_nbarrier<Groups, Threads, Size>(*LocalAcc, groupID, localID, o);
+  ESIMD_CALLEE_nbarrier<Groups, Threads, Size>(*local_acc, groupID, local_id, o);
 #else
-  ESIMD_CALLEE_nbarrier<Groups, Threads, Size>(LocalAcc, groupID, localID, o);
+  ESIMD_CALLEE_nbarrier<Groups, Threads, Size>(local_acc, groupID, local_id, o);
 #endif
 }
 
-template <int case_num, unsigned Groups, unsigned Threads, class QueueTY>
-bool test(QueueTY q) {
+template <int CaseNum, unsigned Groups, unsigned Threads>
+bool test(queue q) {
   constexpr unsigned Size = VL * Threads * Groups;
+
+  std::cout << "Case #" << CaseNum << "\n Treads: " << Threads
+            << ", Groups: " << Groups << ", Size: " << Size << "\n";
 
   static_assert(Threads > 1, "Threads number must be greater than 1");
   static_assert(Threads % 2 == 0, "Threads number expect to be even");
   static_assert(Groups > 1, "Threads number must be greater than 1");
 
-  auto *out = malloc_shared<int>(Size, q);
-  for (int i = 0; i < Size; i++) {
-    out[i] = -1;
-  }
-
   auto dev = q.get_device();
-  auto deviceSLMSize =
+  auto device_slm_size =
       dev.template get_info<sycl::info::device::local_mem_size>();
-  std::cout << "Local Memory Size: " << deviceSLMSize << std::endl;
 
   // The test is going to use Size elements of int type.
-  if (deviceSLMSize < Size * sizeof(int)) {
+  if (device_slm_size < Size * sizeof(int)) {
     // Report an error - the test needs a fix.
     std::cerr << "Error: Test needs more SLM memory than device has"
               << std::endl;
     return false;
   }
 
+  auto *out = malloc_shared<int>(Size, q);
+  for (int i = 0; i < Size; i++) {
+    out[i] = -1;
+  }
+
   try {
     // workgroups
-    sycl::range<1> GlobalRange{Size};
+    sycl::range<1> global_range{Size};
     // threads in each group
-    sycl::range<1> LocalRange{Size / Groups};
-    sycl::nd_range<1> Range{GlobalRange * LocalRange, LocalRange};
+    sycl::range<1> local_range{Size / Groups};
 
     auto e = q.submit([&](handler &cgh) {
-      auto LocalAcc = local_accessor<int, 1>(Size, cgh);
-      cgh.parallel_for<KernelID<case_num>>(
-          nd_range<1>(GlobalRange, LocalRange),
+      auto local_acc = local_accessor<int, 1>(Size, cgh);
+      cgh.parallel_for<KernelID<CaseNum>>(
+          nd_range<1>(global_range, local_range),
           // This test requires an explicit specification of the subgroup size
           [=](nd_item<1> item) [[intel::reqd_sub_group_size(VL)]] {
             sycl::group<1> g = item.get_group();
             sycl::sub_group sg = item.get_sub_group();
 
             // Thread local ID in ESIMD context
-            int localID = sg.get_group_linear_id();
+            int local_id = sg.get_group_linear_id();
             int groupID = g.get_group_linear_id();
 
             // SLM init
-            uint32_t slmID = item.get_local_id(0);
-            auto LocalAccCopy = LocalAcc;
-            LocalAccCopy[slmID] = -1;
+            uint32_t slm_id = item.get_local_id(0);
+            auto local_acc_copy = local_acc;
+            local_acc_copy[slm_id] = -1;
             item.barrier();
 
 #ifdef USE_ACC_PTR
-            auto LocalAccArg = uniform{&LocalAccCopy};
+            auto local_acc_arg = uniform{&local_acc_copy};
 #else
-            auto LocalAccArg = uniform{LocalAccCopy};
+            auto local_acc_arg = uniform{local_acc_copy};
 #endif
 
             invoke_simd(sg, SIMD_CALLEE_nbarrier<Groups, Threads, Size>,
-                        LocalAccArg, uniform{groupID}, uniform{localID},
+                        local_acc_arg, uniform{groupID}, uniform{local_id},
                         uniform{out});
           });
     });
@@ -196,10 +195,13 @@ bool test(QueueTY q) {
 }
 
 int main() {
-  auto q = queue{gpu_selector_v};
+  queue q;
   auto dev = q.get_device();
   std::cout << "Running on " << dev.get_info<sycl::info::device::name>()
             << "\n";
+  auto device_slm_size =
+      dev.template get_info<sycl::info::device::local_mem_size>();
+  std::cout << "Local Memory Size: " << device_slm_size << std::endl;
 
   bool passed = true;
 

--- a/sycl/test-e2e/InvokeSimd/Regression/nbarrier_multiple_wg.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/nbarrier_multiple_wg.cpp
@@ -45,8 +45,8 @@ template <int case_num> class KernelID;
 
 template <unsigned Groups, unsigned Threads, unsigned Size>
 ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> LocalAcc,
-		                        int groupID, int localID,
-					int *o) SYCL_ESIMD_FUNCTION {
+                                        int groupID, int localID,
+                                        int *o) SYCL_ESIMD_FUNCTION {
   // 1 named barrier, id 0 reserved for unnamed
   constexpr unsigned bnum = 2;
   constexpr unsigned bid = 1;
@@ -124,7 +124,8 @@ bool test(QueueTY q) {
   }
 
   auto dev = q.get_device();
-  auto deviceSLMSize = dev.template get_info<sycl::info::device::local_mem_size>();
+  auto deviceSLMSize =
+      dev.template get_info<sycl::info::device::local_mem_size>();
   std::cout << "Local Memory Size: " << deviceSLMSize << std::endl;
 
   // The test is going to use Size elements of int type.
@@ -153,9 +154,9 @@ bool test(QueueTY q) {
 
             // Thread local ID in ESIMD context
             int localID = sg.get_group_linear_id();
-	    int groupID = g.get_group_linear_id();
+            int groupID = g.get_group_linear_id();
 
-	    // SLM init
+            // SLM init
             uint32_t slmID = item.get_local_id(0);
             auto LocalAccCopy = LocalAcc;
             LocalAccCopy[slmID] = -1;
@@ -168,7 +169,8 @@ bool test(QueueTY q) {
 #endif
 
             invoke_simd(sg, SIMD_CALLEE_nbarrier<Groups, Threads, Size>,
-                        LocalAccArg, uniform{groupID}, uniform{localID}, uniform{out});
+                        LocalAccArg, uniform{groupID}, uniform{localID},
+                        uniform{out});
           });
     });
     e.wait();
@@ -210,4 +212,3 @@ int main() {
 
   return passed ? 0 : 1;
 }
-


### PR DESCRIPTION
Fixed:
* InvokeSimd/Regression/nbarrier_exec_in_order.cpp

Added new:
* InvokeSimd/Regression/nbarrier_loop.cpp
* InvokeSimd/Regression/nbarrier_multiple_wg.cpp