### PR TITLE
[SYCL-MLIR][ReachingDefinition] Handle control flow if without else

### DIFF
--- a/mlir/lib/Analysis/DataFlow/DenseAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/DenseAnalysis.cpp
@@ -149,12 +149,12 @@ void AbstractDenseDataFlowAnalysis::visitRegionBranchOperation(
   };
 
   if (auto *op = point.dyn_cast<Operation *>()) {
-    if (op == branch)
+    if (op == branch) {
       // In this context, the known predecessors are the last operations along
-      // all execution paths that pass through the branch. If the number of
-      // branch regions is equal to the number of terminates (e.g., scf.yield)
-      // plus one, then we need to join the state before the branch, as the
-      // branch operation doesn't dominate the next operation.
+      // all execution paths that pass through the branch. When the number of
+      // terminators (e.g., `scf.yield`) is one less than the branch operation
+      // regions, we need to join the state before the branch, as the branch
+      // operation doesn't dominate the next operation.
       // For example (reaching definition):
       //  store x, p
       //  scf.if ()
@@ -162,13 +162,14 @@ void AbstractDenseDataFlowAnalysis::visitRegionBranchOperation(
       //    scf.yield
       //  load p
       // => the reaching definition for the load of p should be both stores.
-      // A `scf.if` has 2 regions, the "then" and "else" regions. The "else"
-      // region may have 0 or 1 block(, when no results are produced). For a
-      // `scf.if` with 0 blocks "else" region, there is only one `scf.yield`
-      // (explicit or implicit)`.
+      // A `scf.if` operation always has 2 regions (representing the "then" and
+      // "else" regions). The "else" region may have 0 blocks, in which case the
+      // operation will have only one terminator (the `scf.yield` in the "then"
+      // region).
       if (branch->getNumRegions() ==
           predecessors->getKnownPredecessors().size() + 1)
         join(after, *getBeforeBranchState(branch));
+    }
   }
 
   for (Operation *op : predecessors->getKnownPredecessors()) {

--- a/polygeist/test/polygeist-opt/reachingDefinitions.mlir
+++ b/polygeist/test/polygeist-opt/reachingDefinitions.mlir
@@ -222,31 +222,47 @@ func.func @test12(%cond: i1, %arg1: memref<i32>, %arg2: memref<i32>) {
   return
 }
 
+// COM: Test control flow if without else.
+// CHECK-LABEL: test_tag: test13_load1:
+// CHECK-NEXT:  operand #0
+// CHECK-NEXT:  - mods: test13_store1 test13_store2
+// CHECK-NEXT:  - pMods: <none>
+func.func @test13(%cond: i1, %arg1: memref<i32>) {
+  %val = arith.constant 0 : i32
+  memref.store %val, %arg1[] {tag_name = "test13_store1"}: memref<i32>
+  scf.if %cond {
+    memref.store %val, %arg1[] {tag_name = "test13_store2"}: memref<i32>
+    scf.yield
+  }
+  %1 = memref.load %arg1[] {tag = "test13_load1"} : memref<i32>
+  return
+}
+
 // COM: Test that a definition created by a sycl.constructor reaches a load.
-// CHECK-LABEL: test_tag: test13_load1
+// CHECK-LABEL: test_tag: test14_load1
 // CHECK: operand #0
-// CHECK-NEXT: - mods: test13_store1
+// CHECK-NEXT: - mods: test14_store1
 // CHECK-NEXT: - pMods: <none>
-func.func @test13(%val: i64) {
+func.func @test14(%val: i64) {
   %alloca = memref.alloca() : memref<1x!sycl_id_1>
   %addrspace_cast = memref.memory_space_cast %alloca : memref<1x!sycl_id_1> to memref<1x!sycl_id_1, 4>
-  sycl.constructor @id(%addrspace_cast, %val) {MangledFunctionName = @constr, tag_name = "test13_store1"} : (memref<1x!sycl_id_1, 4>, i64)
-  %2 = affine.load %alloca[0] {tag = "test13_load1"} : memref<1x!sycl_id_1>
+  sycl.constructor @id(%addrspace_cast, %val) {MangledFunctionName = @constr, tag_name = "test14_store1"} : (memref<1x!sycl_id_1, 4>, i64)
+  %2 = affine.load %alloca[0] {tag = "test14_load1"} : memref<1x!sycl_id_1>
   return
 }
 
 // COM: Test that a definition reaches a sycl.accessor.subscript operation.
-// CHECK-LABEL: test_tag: test14_sub1
+// CHECK-LABEL: test_tag: test15_sub1
 // CHECK: operand #0
 // CHECK-NEXT: - mods: <initial>
 // CHECK-NEXT: - pMods: <none>
 // CHECK: operand #1
-// CHECK-NEXT: - mods: test14_store1
+// CHECK-NEXT: - mods: test15_store1
 // CHECK-NEXT: - pMods: <none>
-func.func @test14(%val: !sycl_id_1, %arg0 : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
+func.func @test15(%val: !sycl_id_1, %arg0 : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_1>
   %cast = memref.cast %alloca : memref<1x!sycl_id_1> to memref<?x!sycl_id_1>  
-  affine.store %val, %alloca[0] {tag_name = "test14_store1"}: memref<1x!sycl_id_1>
-  %1 = sycl.accessor.subscript %arg0[%cast] {tag = "test14_sub1", ArgumentTypes = [memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1>], FunctionName = @"operator[]", MangledFunctionName = @subscript, TypeName = @accessor} : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
+  affine.store %val, %alloca[0] {tag_name = "test15_store1"}: memref<1x!sycl_id_1>
+  %1 = sycl.accessor.subscript %arg0[%cast] {tag = "test15_sub1", ArgumentTypes = [memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1>], FunctionName = @"operator[]", MangledFunctionName = @subscript, TypeName = @accessor} : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
   return
 }

--- a/sycl/test-e2e/Plugin/enqueue-arg-order-image.cpp
+++ b/sycl/test-e2e/Plugin/enqueue-arg-order-image.cpp
@@ -6,7 +6,6 @@
 // RUN: env SYCL_HOST_UNIFIED_MEMORY=1 SYCL_PI_TRACE=2 %{run} %t.out | FileCheck %s
 
 // https://github.com/intel/llvm/issues/7585 to fix the flaky failure:
-// XFAIL: cpu
 // UNSUPPORTED: gpu
 
 #include <iostream>


### PR DESCRIPTION
In the example below, both stores to `%arg1`should reach the use of `%arg1` in the load instruction, because the if-then region may not be entered.
```
  memref.store %val, %arg1[] {tag_name = "test13_store1"}: memref<i32>
  scf.if %cond {
    memref.store %val, %arg1[] {tag_name = "test13_store2"}: memref<i32>
  }
  %1 = memref.load %arg1[] {tag = "test13_load1"} : memref<i32>
```
Before this PR, only `test13_store2` reaches the load.
This PR corrects it, by joining the state before the `RegionBranchOpInterface`, with end states of all regions in the `RegionBranchOpInterface`.