### PR TITLE
[SYCL] Fixup tests after %{build}/%{run} changes in tests

### DIFF
--- a/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus_one_ndebug.cpp
+++ b/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus_one_ndebug.cpp
@@ -17,7 +17,7 @@
 // RUN: %if gpu %{ %{gpu_env} %{run} %t.out &> %t.gpu.txt ; FileCheck %s --input-file %t.gpu.txt %}
 
 // Shouldn't fail on ACC as fallback assert isn't enqueued there
-// RUN: %if acc %{ %{run} %t.out &> %t.acc.txt ; FileCheck %s --input-file %t.acc.txt %}
+// RUN: %if acc %{ %{run} %t.out &> %t.acc.txt ; FileCheck %s --check-prefix=CHECK-ACC --input-file %t.acc.txt %}
 //
 // CHECK:      this message from file1
 // CHECK-NOT:  this message from file2

--- a/sycl/test-e2e/Plugin/interop-opencl-interop-task-mem.cpp
+++ b/sycl/test-e2e/Plugin/interop-opencl-interop-task-mem.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: opencl, opencl_icd
+// REQUIRES: aspect-ext_intel_legacy_image
 
 // RUN: %{build} -o %t.out %opencl_lib
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/PropagateOptionsToBackend/sycl-opt-level-opencl.cpp
+++ b/sycl/test-e2e/PropagateOptionsToBackend/sycl-opt-level-opencl.cpp
@@ -1,13 +1,13 @@
 // REQUIRES: opencl
 
 // RUN: %{build} -O0 -o %t0.out
-// RUN: env SYCL_PI_TRACE=-1 %{run} %t0.out 2>&1 | FileCheck %s --check-prefixes=CHECKOCL0
+// RUN: %if !acc %{ env SYCL_PI_TRACE=-1 %{run} %t0.out 2>&1 | FileCheck %s --check-prefixes=CHECKOCL0 %}
 // RUN: %{build} -O1 -o %t1.out
-// RUN: env SYCL_PI_TRACE=-1 %{run} %t1.out 2>&1 | FileCheck %s --check-prefixes=CHECKOCL1
+// RUN: %if !acc %{ env SYCL_PI_TRACE=-1 %{run} %t1.out 2>&1 | FileCheck %s --check-prefixes=CHECKOCL1 %}
 // RUN: %{build} -O2 -o %t2.out
-// RUN: env SYCL_PI_TRACE=-1 %{run} %t2.out 2>&1 | FileCheck %s --check-prefixes=CHECKOCL2
+// RUN: %if !acc %{ env SYCL_PI_TRACE=-1 %{run} %t2.out 2>&1 | FileCheck %s --check-prefixes=CHECKOCL2 %}
 // RUN: %{build} -O3 -o %t3.out
-// RUN: env SYCL_PI_TRACE=-1 %{run} %t3.out 2>&1 | FileCheck %s --check-prefixes=CHECKOCL3
+// RUN: %if !acc %{ env SYCL_PI_TRACE=-1 %{run} %t3.out 2>&1 | FileCheck %s --check-prefixes=CHECKOCL3 %}
 
 // RUN: %{build} -O0 -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
Some of the limitations regarding supported devices were accidentally dropped during recent changes in tests infrastructure. Tests started to fail. This PR returns these limitations back.