### PR TITLE
[NFC] Fix comment to describe proper behavior

### DIFF
--- a/llvm/tools/spirv-to-ir-wrapper/spirv-to-ir-wrapper.cpp
+++ b/llvm/tools/spirv-to-ir-wrapper/spirv-to-ir-wrapper.cpp
@@ -42,7 +42,7 @@ static cl::opt<std::string> InputFilename(cl::Positional,
 static cl::opt<std::string> Output("o", cl::value_desc("output IR filename"),
                                    cl::desc("output filename"));
 
-// LlvmSpirvOpts - The filename to output to.
+// LlvmSpirvOpts - Options to pass along to llvm-spirv.
 static cl::opt<std::string>
     LlvmSpirvOpts("llvm-spirv-opts", cl::value_desc("llvm-spirv options"),
                   cl::desc("options to pass to llvm-spirv"));


### PR DESCRIPTION
One of the options to spirv-to-ir-wrapper was not commented correctly