### PR TITLE
[SYCL][Test E2E] Remove some UNSUPPORTED: accelerator directives

### DIFF
--- a/sycl/test-e2e/AtomicRef/accessor.cpp
+++ b/sycl/test-e2e/AtomicRef/accessor.cpp
@@ -1,8 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: accelerator
-
 #include <algorithm>
 #include <cassert>
 #include <iostream>

--- a/sycl/test-e2e/Basic/barrier_order.cpp
+++ b/sycl/test-e2e/Basic/barrier_order.cpp
@@ -3,7 +3,6 @@
 
 // Temporarily disabled on HIP, CUDA and L0 due to sporadic failures.
 // UNSUPPORTED: hip, level_zero, cuda
-// UNSUPPORTED: accelerator
 
 #include <iostream>
 #include <stdlib.h>

--- a/sycl/test-e2e/Basic/event.cpp
+++ b/sycl/test-e2e/Basic/event.cpp
@@ -1,8 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: accelerator
-
 //==--------------- event.cpp - SYCL event test ----------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/Basic/event_creation.cpp
+++ b/sycl/test-e2e/Basic/event_creation.cpp
@@ -3,8 +3,6 @@
 // RUN: %{build} -o %t.out %opencl_lib
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: accelerator
-
 //==--------------- event.cpp - SYCL event test ----------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/Basic/half_builtins.cpp
+++ b/sycl/test-e2e/Basic/half_builtins.cpp
@@ -2,10 +2,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// Intel OpenCL CPU and FPGA emulator drivers do not support cl_khr_fp16
-// extension
-// UNSUPPORTED: (cpu || accelerator) && opencl
-
 #include <sycl/sycl.hpp>
 
 #include <cmath>

--- a/sycl/test-e2e/Basic/handler/handler_mem_op.cpp
+++ b/sycl/test-e2e/Basic/handler/handler_mem_op.cpp
@@ -1,8 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: accelerator
-
 //==- handler.cpp - SYCL handler explicit memory operations test -*- C++-*--==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/Basic/handler/interop_task.cpp
+++ b/sycl/test-e2e/Basic/handler/interop_task.cpp
@@ -2,8 +2,6 @@
 // RUN: %{build} -o %t.out %opencl_lib
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: accelerator
-
 //==------- interop_task.cpp -----------------------------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/Basic/interop/get_native_ocl.cpp
+++ b/sycl/test-e2e/Basic/interop/get_native_ocl.cpp
@@ -2,8 +2,6 @@
 // RUN: %{build} %opencl_options -o %t.ocl.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: accelerator
-
 #include <CL/cl.h>
 
 #include <sycl/backend/opencl.hpp>

--- a/sycl/test-e2e/Basic/sampler/sampler.cpp
+++ b/sycl/test-e2e/Basic/sampler/sampler.cpp
@@ -1,8 +1,6 @@
-// REQUIRES: opencl
+// TODO: Can we move it to sycl/test?
 // RUN: %{build} -fsycl-dead-args-optimization -o %t.out
 // RUN: %{run} %t.out
-
-// UNSUPPORTED: accelerator
 
 //==--------------- sampler.cpp - SYCL sampler basic test ------------------==//
 //

--- a/sycl/test-e2e/Basic/submit_barrier.cpp
+++ b/sycl/test-e2e/Basic/submit_barrier.cpp
@@ -2,8 +2,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: accelerator
-
 #include <stdlib.h>
 #include <sycl/sycl.hpp>
 

--- a/sycl/test-e2e/DiscardEvents/invalid_event.cpp
+++ b/sycl/test-e2e/DiscardEvents/invalid_event.cpp
@@ -1,5 +1,5 @@
-// FIXME: Fails on HIP and OpenCL accelerator
-// UNSUPPORTED: hip, (opencl && accelerator)
+// FIXME: Fails on HIP
+// UNSUPPORTED: hip
 // RUN: %{build} -o %t.out
 //
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Functor/kernel_functor.cpp
+++ b/sycl/test-e2e/Functor/kernel_functor.cpp
@@ -1,8 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: accelerator
-
 //==--- kernel_functor.cpp -
 // This test illustrates defining kernels as named function objects (functors)
 //

--- a/sycl/test-e2e/OnlineCompiler/online_compiler_OpenCL.cpp
+++ b/sycl/test-e2e/OnlineCompiler/online_compiler_OpenCL.cpp
@@ -3,8 +3,6 @@
 // RUN: %{build} -DRUN_KERNELS %opencl_lib -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: accelerator
-
 // This test checks ext::intel feature class online_compiler for OpenCL.
 // All OpenCL specific code is kept here and the common part that can be
 // re-used by other backends is kept in online_compiler_common.hpp file.

--- a/sycl/test-e2e/Plugin/enqueue-arg-order-buffer.cpp
+++ b/sycl/test-e2e/Plugin/enqueue-arg-order-buffer.cpp
@@ -1,5 +1,4 @@
 // UNSUPPORTED: hip_nvidia
-// UNSUPPORTED: accelerator
 // RUN: %{build} -o %t.out
 // RUN: env SYCL_PI_TRACE=2 %{run} %t.out | FileCheck %s
 

--- a/sycl/test-e2e/Reduction/reduction_range_1d_dw_64bit.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_1d_dw_64bit.cpp
@@ -1,8 +1,4 @@
 // RUN: %{build} -DENABLE_64_BIT=true -o %t.out -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60
 // RUN: %{run} %t.out
-// TODO: accelerator may not suport atomics required by the current
-// implementation. Once fixed, enable 64bit tests in the main test and remove
-// this file
-// UNSUPPORTED: accelerator
 
 #include "reduction_range_1d_dw.cpp"

--- a/sycl/test-e2e/Reduction/reduction_range_2d_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_2d_dw.cpp
@@ -1,10 +1,6 @@
 // RUN: %{build} -o %t.out -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60
 // RUN: %{run} %t.out
 
-// TODO: accelerator may not suport atomics required by the current
-// implementation. Enable testing when implementation is fixed.
-// UNSUPPORTED: accelerator
-
 // This test performs basic checks of parallel_for(range<2>, reduction, func)
 // with reductions initialized with a one element buffer and
 // an initialize_to_identity property.

--- a/sycl/test-e2e/Reduction/reduction_range_2d_dw_reducer_skip.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_2d_dw_reducer_skip.cpp
@@ -1,10 +1,6 @@
 // RUN: %{build} -o %t.out -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60
 // RUN: %{run} %t.out
 
-// TODO: accelerator may not suport atomics required by the current
-// implementation. Enable testing when implementation is fixed.
-// UNSUPPORTED: accelerator
-
 // This test performs basic checks of parallel_for(range<2>, reduction, func)
 // with reductions initialized with a one element buffer. Additionally, some
 // reducers will not be written to.

--- a/sycl/test-e2e/Reduction/reduction_range_2d_rw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_2d_rw.cpp
@@ -1,10 +1,6 @@
 // RUN: %{build} -o %t.out -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60
 // RUN: %{run} %t.out
 
-// TODO: accelerator may not suport atomics required by the current
-// implementation. Enable testing when implementation is fixed.
-// UNSUPPORTED: accelerator
-
 // This test performs basic checks of parallel_for(range<2>, reduction, func)
 // with reductions initialized with a one element buffer.
 

--- a/sycl/test-e2e/Reduction/reduction_range_3d_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_3d_dw.cpp
@@ -1,10 +1,6 @@
 // RUN: %{build} -o %t.out -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60
 // RUN: %{run} %t.out
 
-// TODO: accelerator may not suport atomics required by the current
-// implementation. Enable testing when implementation is fixed.
-// UNSUPPORTED: accelerator
-
 // This test performs basic checks of parallel_for(range<3>, reduction, func)
 // with reductions initialized with a one element buffer and a
 // initialize_to_identity property.

--- a/sycl/test-e2e/Reduction/reduction_range_3d_rw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_3d_rw.cpp
@@ -1,10 +1,6 @@
 // RUN: %{build} -o %t.out -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60
 // RUN: %{run} %t.out
 
-// TODO: accelerator may not suport atomics required by the current
-// implementation. Enable testing when implementation is fixed.
-// UNSUPPORTED: accelerator
-
 // This test performs basic checks of parallel_for(range<3>, reduction, func)
 // with reductions initialized with a one element buffer.
 

--- a/sycl/test-e2e/Reduction/reduction_range_3d_rw_reducer_skip.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_3d_rw_reducer_skip.cpp
@@ -1,10 +1,6 @@
 // RUN: %{build} -o %t.out -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60
 // RUN: %{run} %t.out
 
-// TODO: accelerator may not suport atomics required by the current
-// implementation. Enable testing when implementation is fixed.
-// UNSUPPORTED: accelerator
-
 // This test performs basic checks of parallel_for(range<3>, reduction, func)
 // with reductions initialized with a one element buffer. Additionally, some
 // reducers will not be written to.

--- a/sycl/test-e2e/Regression/local_accessor_3d_subscript.cpp
+++ b/sycl/test-e2e/Regression/local_accessor_3d_subscript.cpp
@@ -1,8 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: accelerator
-
 //==------------------ local_accessor_3d_subscript.cpp ---------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/Scheduler/DataMovement.cpp
+++ b/sycl/test-e2e/Scheduler/DataMovement.cpp
@@ -1,8 +1,6 @@
 // RUN: %{build} -o %t.out %debug_option
 // RUN: %{run} %t.out
 //
-// UNSUPPORTED: accelerator
-//
 //==-------------------------- DataMovement.cpp ----------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/Scheduler/MemObjRemapping.cpp
+++ b/sycl/test-e2e/Scheduler/MemObjRemapping.cpp
@@ -1,7 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: env SYCL_HOST_UNIFIED_MEMORY=1 SYCL_PI_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s
 //
-// UNSUPPORTED: accelerator
 // XFAIL: hip_nvidia
 #include <cassert>
 #include <cstddef>

--- a/sycl/test-e2e/SubGroup/info.cpp
+++ b/sycl/test-e2e/SubGroup/info.cpp
@@ -1,6 +1,5 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// UNSUPPORTED: accelerator
 
 //==------------- info.cpp - SYCL sub_group parameters test ----*- C++ -*---==//
 //

--- a/sycl/test-e2e/SubGroup/sub_groups_sycl2020.cpp
+++ b/sycl/test-e2e/SubGroup/sub_groups_sycl2020.cpp
@@ -1,7 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
-// UNSUPPORTED: accelerator
 // Assertion `!MHostPlatform && "Plugin is not available for Host."' failed on
 // Nvidia.
 // XFAIL: hip_nvidia

--- a/sycl/test-e2e/UserDefinedReductions/user_defined_reductions_wg_size_larger_than_data_size.cpp
+++ b/sycl/test-e2e/UserDefinedReductions/user_defined_reductions_wg_size_larger_than_data_size.cpp
@@ -1,8 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: accelerator
-
 #include <iostream>
 #include <numeric>
 


### PR DESCRIPTION
I tested those tests locally on `opencl:acc` device (which we don't have in GitHub CI, only in internal testing) on both Windows/Linux.