### PR TITLE
[SYCL-MLIR] Add `isPacked` in `polygeist.struct`

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistTypes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistTypes.td
@@ -32,8 +32,14 @@ def Polygeist_StructType :
     Type used to represent a collection of data members together in memory.
   }];
   let parameters = (ins ArrayRefParameter<"mlir::Type">:$body,
-                        OptionalParameter<"std::optional<StringAttr>">:$name);
-  let assemblyFormat = "`<` ($name^`,` )? `(` $body `)` `>`";
+                        OptionalParameter<"std::optional<StringAttr>">:$name,
+                        DefaultValuedParameter<"bool", "false">:$isPacked);
+  let builders = [
+    TypeBuilder<(ins "llvm::ArrayRef<mlir::Type>":$body),[{
+      return $_get($_ctxt, body, std::nullopt, false);
+    }]>
+  ];
+  let assemblyFormat = "`<` ($name^ `,` ` `)? (`isPacked` `=` $isPacked^ ` `)? `(` $body `)` `>`";
 }
 
 #endif // POLYGEIST_TYPES

--- a/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistTypes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistTypes.td
@@ -39,6 +39,9 @@ def Polygeist_StructType :
       return $_get($_ctxt, body, std::nullopt, false);
     }]>
   ];
+  let extraClassDeclaration = [{
+    bool isPacked() { return getIsPacked(); }
+  }];
   let assemblyFormat = "`<` ($name^ `,` ` `)? (`isPacked` `=` $isPacked^ ` `)? `(` $body `)` `>`";
 }
 

--- a/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
+++ b/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
@@ -858,13 +858,12 @@ populatePolygeistToLLVMTypeConversion(LLVMTypeConverter &typeConverter) {
           auto ST = LLVM::LLVMStructType::getIdentified(
               &typeConverter.getContext(), *type.getName());
           if (!ST.isInitialized()) {
-            if (failed(ST.setBody(convertedElemTypes, /*isPacked=*/false)))
+            if (failed(ST.setBody(convertedElemTypes, type.getIsPacked())))
               return std::nullopt;
           } else if (convertedElemTypes != ST.getBody()) {
             ST = LLVM::LLVMStructType::getNewIdentified(
                 &typeConverter.getContext(), *type.getName(),
-                convertedElemTypes,
-                /*isPacked=*/false);
+                convertedElemTypes, type.getIsPacked());
           }
           return ST;
         }

--- a/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
+++ b/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
@@ -858,12 +858,12 @@ populatePolygeistToLLVMTypeConversion(LLVMTypeConverter &typeConverter) {
           auto ST = LLVM::LLVMStructType::getIdentified(
               &typeConverter.getContext(), *type.getName());
           if (!ST.isInitialized()) {
-            if (failed(ST.setBody(convertedElemTypes, type.getIsPacked())))
+            if (failed(ST.setBody(convertedElemTypes, type.isPacked())))
               return std::nullopt;
           } else if (convertedElemTypes != ST.getBody()) {
             ST = LLVM::LLVMStructType::getNewIdentified(
                 &typeConverter.getContext(), *type.getName(),
-                convertedElemTypes, type.getIsPacked());
+                convertedElemTypes, type.isPacked());
           }
           return ST;
         }

--- a/polygeist/test/polygeist-opt/polygeist-types-to-llvm.mlir
+++ b/polygeist/test/polygeist-opt/polygeist-types-to-llvm.mlir
@@ -11,3 +11,10 @@ func.func @test_struct(%arg0: !polygeist.struct<(memref<i32>, i32)>) {
 func.func @test_struct(%arg0: !polygeist.struct<"name", (memref<i32>, i32)>) {
   return
 }
+
+// -----
+
+// CHECK: llvm.func @test_struct(%arg0: !llvm.struct<"name", packed (ptr, i32)>)
+func.func @test_struct(%arg0: !polygeist.struct<"name", isPacked=true (memref<i32>, i32)>) {
+  return
+}


### PR DESCRIPTION
The `isPacked` field in the `polygeist.struct` type represent whether the structure has padding between its members or not.