### PR TITLE
[SYCL][ESIMD] Fix invalid IR produced by ESIMDOptimizeVecArgCallConv

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/ESIMDOptimizeVecArgCallConv.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/ESIMDOptimizeVecArgCallConv.cpp
@@ -332,9 +332,18 @@ optimizeFunction(Function *OldF,
     const DataLayout &DL = NewF->getParent()->getDataLayout();
     Align Al = DL.getPrefTypeAlign(T);
     unsigned AddrSpace = DL.getAllocaAddrSpace();
+
     AllocaInst *Alloca = new AllocaInst(T, AddrSpace, 0 /*array size*/, Al);
-    VMap[OldF->getArg(PI.getFormalParam().getArgNo())] = Alloca;
     NewInsts.push_back(Alloca);
+    Instruction *ReplaceInst = Alloca;
+    if (auto *ArgPtrType = dyn_cast<PointerType>(PI.getFormalParam().getType());
+        ArgPtrType && ArgPtrType->getAddressSpace() != AddrSpace) {
+      // If the alloca addrspace and arg addrspace are different,
+      // insert a cast.
+      ReplaceInst = new AddrSpaceCastInst(Alloca, ArgPtrType);
+      NewInsts.push_back(ReplaceInst);
+    }
+    VMap[OldF->getArg(PI.getFormalParam().getArgNo())] = ReplaceInst;
 
     if (!PI.isSret()) {
       // Create a store of the new optimized parameter into the alloca to
@@ -365,7 +374,11 @@ optimizeFunction(Function *OldF,
       IRBuilder<> Bld(RI);
       const FormalParamInfo &PI = OptimizeableParams[SretInd];
       Argument *OldP = OldF->getArg(PI.getFormalParam().getArgNo());
-      auto *SretPtr = cast<AllocaInst>(VMap[OldP]);
+      auto *SretPtr = cast<Instruction>(VMap[OldP]);
+      if (!isa<AllocaInst>(SretPtr)) {
+        auto *AddrSpaceCast = cast<AddrSpaceCastInst>(SretPtr);
+        SretPtr = cast<AllocaInst>(AddrSpaceCast->getPointerOperand());
+      }
       LoadInst *Ld = Bld.CreateLoad(PI.getOptimizedType(), SretPtr);
       Bld.CreateRet(Ld);
     }

--- a/llvm/lib/SYCLLowerIR/ESIMD/ESIMDOptimizeVecArgCallConv.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/ESIMDOptimizeVecArgCallConv.cpp
@@ -332,7 +332,6 @@ optimizeFunction(Function *OldF,
     const DataLayout &DL = NewF->getParent()->getDataLayout();
     Align Al = DL.getPrefTypeAlign(T);
     unsigned AddrSpace = DL.getAllocaAddrSpace();
-
     AllocaInst *Alloca = new AllocaInst(T, AddrSpace, 0 /*array size*/, Al);
     NewInsts.push_back(Alloca);
     Instruction *ReplaceInst = Alloca;

--- a/llvm/test/SYCLLowerIR/ESIMD/vec_arg_call_conv.ll
+++ b/llvm/test/SYCLLowerIR/ESIMD/vec_arg_call_conv.ll
@@ -55,6 +55,7 @@ define dso_local spir_func void @_Z19callee__sret__param(ptr addrspace(4) noalia
 ; CHECK: define dso_local spir_func <16 x float> @_Z19callee__sret__param(<16 x float> %[[PARAM:.+]])
 entry:
 ; CHECK:  %[[ALLOCA1:.+]] = alloca <16 x float>, align 64
+; CHECK:  %[[CAST1:.+]] = addrspacecast ptr %[[ALLOCA1]] to ptr addrspace(4)
 ; CHECK:  %[[ALLOCA2:.+]] = alloca <16 x float>, align 64
 ; CHECK:  store <16 x float> %[[PARAM]], ptr %[[ALLOCA2]], align 64
   %x.ascast = addrspacecast ptr %x to ptr addrspace(4)
@@ -62,7 +63,7 @@ entry:
   %call.i.i.i1 = load <16 x float>, ptr addrspace(4) %x.ascast, align 64
 ; CHECK:  %[[VAL:.+]] = load <16 x float>, ptr addrspace(4) %[[ALLOCA2_4]], align 64
   store <16 x float> %call.i.i.i1, ptr addrspace(4) %agg.result, align 64
-; CHECK:  store <16 x float> %[[VAL]], ptr %[[ALLOCA1]], align 64
+; CHECK:  store <16 x float> %[[VAL]], ptr addrspace(4) %[[CAST1]], align 64
   ret void
 ; CHECK:  %[[RET:.+]] = load <16 x float>, ptr %[[ALLOCA1]], align 64
 ; CHECK:  ret <16 x float> %[[RET]]
@@ -74,6 +75,7 @@ define dso_local spir_func void @_Z29test__sret__fall_through__arr(ptr addrspace
 ; CHECK: define dso_local spir_func <16 x float> @_Z29test__sret__fall_through__arr(ptr addrspace(4) noundef %[[PARAM0:.+]], i32 noundef %{{.*}})
 entry:
 ; CHECK:  %[[ALLOCA1:.+]] = alloca <16 x float>, align 64
+; CHECK:  %[[CAST1:.+]] = addrspacecast ptr %[[ALLOCA1]] to ptr addrspace(4)
   %agg.tmp = alloca %"class.sycl::_V1::ext::intel::esimd::simd", align 64
 ; CHECK:  %[[ALLOCA2:.+]] = alloca %"class.sycl::_V1::ext::intel::esimd::simd", align 64
   %agg.tmp.ascast = addrspacecast ptr %agg.tmp to ptr addrspace(4)
@@ -85,7 +87,7 @@ entry:
 ; CHECK:  %[[VAL:.+]] = load <16 x float>, ptr %[[ALLOCA2]], align 64
   call spir_func void @_Z19callee__sret__param(ptr addrspace(4) sret(%"class.sycl::_V1::ext::intel::esimd::simd") align 64 %agg.result, ptr noundef nonnull %agg.tmp) #7
 ; CHECK:  %[[RES:.+]] = call spir_func <16 x float> @_Z19callee__sret__param(<16 x float> %[[VAL]])
-; CHECK:  store <16 x float> %[[RES]], ptr %[[ALLOCA1]], align 64
+; CHECK:  store <16 x float> %[[RES]], ptr addrspace(4) %[[CAST1]], align 64
   ret void
 ; CHECK:  %[[RET:.+]] = load <16 x float>, ptr %[[ALLOCA1]], align 64
 ; CHECK:  ret <16 x float> %[[RET]]
@@ -96,6 +98,7 @@ entry:
 define dso_local spir_func void @_Z30test__sret__fall_through__globv(ptr addrspace(4) noalias sret(%"class.sycl::_V1::ext::intel::esimd::simd") align 64 %agg.result) local_unnamed_addr #2 !sycl_explicit_simd !8 !intel_reqd_sub_group_size !9 {
 entry:
 ; CHECK:  %[[ALLOCA1:.+]] = alloca <16 x float>, align 64
+; CHECK:  %[[CAST1:.+]] = addrspacecast ptr %[[ALLOCA1]] to ptr addrspace(4)
   %agg.tmp = alloca %"class.sycl::_V1::ext::intel::esimd::simd", align 64
 ; CHECK:  %[[ALLOCA2:.+]] = alloca %"class.sycl::_V1::ext::intel::esimd::simd", align 64
   %agg.tmp.ascast = addrspacecast ptr %agg.tmp to ptr addrspace(4)
@@ -105,7 +108,7 @@ entry:
 ; CHECK:  %[[VAL:.+]] = load <16 x float>, ptr %[[ALLOCA2]], align 64
   call spir_func void @_Z19callee__sret__param(ptr addrspace(4) sret(%"class.sycl::_V1::ext::intel::esimd::simd") align 64 %agg.result, ptr noundef nonnull %agg.tmp) #7
 ; CHECK:  %[[RES:.+]] = call spir_func <16 x float> @_Z19callee__sret__param(<16 x float> %[[VAL]])
-; CHECK:  store <16 x float> %[[RES]], ptr %[[ALLOCA1]], align 64
+; CHECK:  store <16 x float> %[[RES]], ptr addrspace(4) %[[CAST1]], align 64
   ret void
 ; CHECK:  %[[RET:.+]] = load <16 x float>, ptr %[[ALLOCA1]], align 64
 ; CHECK:  ret <16 x float> %[[RET]]

--- a/llvm/test/SYCLLowerIR/ESIMD/vec_arg_call_conv_addrspace.ll
+++ b/llvm/test/SYCLLowerIR/ESIMD/vec_arg_call_conv_addrspace.ll
@@ -1,0 +1,28 @@
+; RUN: opt -passes=esimd-opt-call-conv -S < %s | FileCheck %s
+; This test checks the ESIMDOptimizeVecArgCallConvPass optimization with a
+; use of the sret argument relying on the address space.
+
+; ModuleID = 'opaque_ptr.bc'
+source_filename = "llvm-link"
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+%"class.sycl::_V1::ext::intel::esimd::simd.0" = type { %"class.sycl::_V1::ext::intel::esimd::detail::simd_obj_impl.1" }
+%"class.sycl::_V1::ext::intel::esimd::detail::simd_obj_impl.1" = type { <16 x float> }
+
+define linkonce_odr dso_local spir_func void @foo(ptr addrspace(4) noalias sret(%"class.sycl::_V1::ext::intel::esimd::simd.0") align 128 %agg.result,
+                                                  ptr noundef byval(%"class.sycl::_V1::ext::intel::esimd::simd.0") align 128 %val) {
+; CHECK: [[ALLOCA:%.*]] = alloca <16 x float>, align 64
+; CHECK: [[CAST:%.*]] = addrspacecast ptr [[ALLOCA]] to ptr addrspace(4)
+; CHECK: call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) align 128 [[CAST]], ptr addrspace(4) align 128 [[ARGCAST:%.*]], i64 128, i1 false)
+; CHECK: [[LOAD:%.*]] = load <16 x float>, ptr [[ALLOCA]], align 64
+; CHECK: ret <16 x float> [[LOAD]]
+
+entry:
+%val.ascast = addrspacecast ptr %val to ptr addrspace(4)
+call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) align 128 %agg.result, ptr addrspace(4) align 128 %val.ascast, i64 128, i1 false)
+ret void
+}
+
+; Function Attrs: alwaysinline nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) noalias nocapture writeonly %0, ptr addrspace(4) noalias nocapture readonly %1, i64 %2, i1 immarg %3)


### PR DESCRIPTION
This pass, among other things, replaces a sret pointer argument with an alloca. If the alloca addrspace
and argument addrspace do not match, we need to cast.

This fixes two cases of invalid IR produced by running tests with `-O0`.