### PR TITLE
[SYCL][Test E2E] Process REQUIRES/SUPPORTED/XFAIL on per-device basis

### DIFF
--- a/sycl/test-e2e/BFloat16/bfloat16_builtins.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_builtins.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-ext_oneapi_bfloat16_math_functions
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %if cuda %{ -Xsycl-target-backend --cuda-gpu-arch=sm_80 %} %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %if any-device-is-cuda %{ -Xsycl-target-backend --cuda-gpu-arch=sm_80 %} %s -o %t.out
 // RUN: %{run} %t.out
 // Currently the feature isn't supported on FPGA.
 // UNSUPPORTED: accelerator

--- a/sycl/test-e2e/BFloat16/bfloat16_type.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_type.cpp
@@ -1,4 +1,4 @@
-// RUN: %if cuda %{%{build} -DUSE_CUDA_SM80=1 -Xsycl-target-backend --cuda-gpu-arch=sm_80 -o %t.out %}
+// RUN: %if any-device-is-cuda %{ %{build} -DUSE_CUDA_SM80=1 -Xsycl-target-backend --cuda-gpu-arch=sm_80 -o %t.out %}
 // RUN: %if ext_oneapi_cuda %{ %{run} %t.out %}
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/DeviceLib/assert.cpp
+++ b/sycl/test-e2e/DeviceLib/assert.cpp
@@ -69,15 +69,10 @@
 // extension is a new feature and may not be supported by the runtime used with
 // SYCL.
 //
-// Overall this sounds stable enough. What could possibly go wrong?
-//
-// With either a CPU run or a GPU run we reset the output file and append the
-// results of the runs. Otherwise a skipped GPU run may remove the output from
-// a CPU run prior to running FileCheck.
-// RUN: echo "" > %t.stderr.native
-// RUN: %if cpu %{ env SYCL_PI_TRACE=2 SHOULD_CRASH=1 EXPECTED_SIGNAL=SIGABRT ONEAPI_DEVICE_SELECTOR=\*:cpu %{run-unfiltered-devices} %t.out 2>> %t.stderr.native %}
-// RUN: %if gpu %{ env                 SHOULD_CRASH=1 EXPECTED_SIGNAL=SIGIOT  ONEAPI_DEVICE_SELECTOR=\*:gpu %{run-unfiltered-devices} %t.out 2>> %t.stderr.native %}
-// RUN: FileCheck %s --input-file %t.stderr.native --check-prefixes=CHECK-MESSAGE || FileCheck %s --input-file %t.stderr.native --check-prefix CHECK-NOTSUPPORTED
+// RUN: %if cpu %{ env SYCL_PI_TRACE=2 SHOULD_CRASH=1 EXPECTED_SIGNAL=SIGABRT %{run} %t.out 2> %t.stderr.native %}
+// RUN: %if cpu %{ FileCheck %s --input-file %t.stderr.native --check-prefixes=CHECK-MESSAGE || FileCheck %s --input-file %t.stderr.native --check-prefix CHECK-NOTSUPPORTED %}
+// RUN: %if gpu %{ env                 SHOULD_CRASH=1 EXPECTED_SIGNAL=SIGIOT  %{run} %t.out 2> %t.stderr.native %}
+// RUN: %if gpu %{ FileCheck %s --input-file %t.stderr.native --check-prefixes=CHECK-MESSAGE || FileCheck %s --input-file %t.stderr.native --check-prefix CHECK-NOTSUPPORTED %}
 //
 // Skip the test if the CPU RT doesn't support the extension yet:
 // CHECK-NOTSUPPORTED: Device has no support for cl_intel_devicelib_assert

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -1,21 +1,81 @@
 import lit
 import lit.formats
 
+from lit.BooleanExpression import BooleanExpression
+
 import os
 
 class SYCLEndToEndTest(lit.formats.ShTest):
+    def parseTestScript(self, test):
+        """This is based on lit.TestRunner.parseIntegratedTestScript but we
+        overload the semantics of REQUIRES/UNSUPPORTED/XFAIL directives so have
+        to implement it manually."""
+
+        # Parse the test sources and extract test properties
+        try:
+            parsed = lit.TestRunner._parseKeywords(test.getSourcePath(), require_script=True)
+        except ValueError as e:
+            return lit.Test.Result(Test.UNRESOLVED, str(e))
+        script = parsed['RUN:'] or []
+        assert parsed['DEFINE:'] == script
+        assert parsed['REDEFINE:'] == script
+
+        test.xfails += parsed['XFAIL:'] or []
+        test.requires += test.config.required_features
+        test.requires += parsed['REQUIRES:'] or []
+        test.unsupported += test.config.unsupported_features
+        test.unsupported += parsed['UNSUPPORTED:'] or []
+
+        return script
+
+    def getMatchedFromList(self, features, alist):
+        try:
+            return [item for item in alist
+                    if BooleanExpression.evaluate(item, features)]
+        except ValueError as e:
+            raise ValueError('Error in UNSUPPORTED list:\n%s' % str(e))
+
+    def select_devices_for_test(self, test):
+        devices = []
+        for d in test.config.sycl_devices:
+            features = test.config.sycl_dev_features[d]
+            if test.getMissingRequiredFeaturesFromList(features):
+                continue
+
+            if self.getMatchedFromList(features, test.unsupported):
+                continue
+
+            devices.append(d)
+
+        if len(devices) <= 1:
+            return devices
+
+        # Treat XFAIL as UNSUPPORTED if the test is to be executed on multiple
+        # devices.
+        #
+        # TODO: What if the entire list of devices consists of XFAILs only?
+
+        if '*' in test.xfails:
+            return []
+
+        devices_without_xfail = [d for d in devices
+                                 if not self.getMatchedFromList(test.config.sycl_dev_features[d], test.xfails)]
+
+        return devices_without_xfail
+
     def execute(self, test, litConfig):
         if test.config.unsupported:
             return lit.Test.Result(lit.Test.UNSUPPORTED, 'Test is unsupported')
 
         filename = test.path_in_suite[-1]
         tmpDir, tmpBase = lit.TestRunner.getTempPaths(test)
-        script = lit.TestRunner.parseIntegratedTestScript(test, require_script=True)
+        script = self.parseTestScript(test)
         if isinstance(script, lit.Test.Result):
             return script
 
-        devices_for_test = ['{}:{}'.format(test.config.sycl_be, dev)
-                            for dev in test.config.target_devices.split(',')]
+        devices_for_test = self.select_devices_for_test(test)
+        if not devices_for_test:
+            return lit.Test.Result(lit.Test.UNSUPPORTED, 'No supported devices to run the test on')
 
         substitutions = lit.TestRunner.getDefaultSubstitutions(test, tmpDir, tmpBase)
         # -fsycl-targets is needed for CUDA/HIP, so just use it be default so
@@ -95,4 +155,19 @@ class SYCLEndToEndTest(lit.formats.ShTest):
         script = lit.TestRunner.applySubstitutions(script, substitutions, conditions,
                                                    recursion_limit=test.config.recursiveExpansionLimit)
         useExternalSh = False
-        return lit.TestRunner._runShTest(test, litConfig, useExternalSh, script, tmpBase)
+        result = lit.TestRunner._runShTest(test, litConfig, useExternalSh, script, tmpBase)
+
+        if (len(devices_for_test) > 1):
+            return result
+
+        # Single device - might be an XFAIL.
+        device = devices_for_test[0]
+        if '*' in test.xfails or self.getMatchedFromList(test.config.sycl_dev_features[device], test.xfails):
+            if result.code is lit.Test.PASS:
+                result.code = lit.Test.XPASS
+            # fail -> expected fail
+            elif result.code is lit.Test.FAIL:
+                result.code = lit.Test.XFAIL
+            return result
+
+        return result

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -32,6 +32,10 @@ config.test_exec_root = config.sycl_obj_root
 # allow expanding substitutions that are based on other substitutions
 config.recursiveExpansionLimit = 10
 
+# To be filled by lit.local.cfg files.
+config.required_features = []
+config.unsupported_features = []
+
 # Cleanup environment variables which may affect tests
 possibly_dangerous_env_vars = ['COMPILER_PATH', 'RC_DEBUG_OPTIONS',
                                'CINDEXTEST_PREAMBLE_FILE', 'LIBRARY_PATH',
@@ -195,45 +199,6 @@ if sp[0] == 0:
 else:
     config.substitutions.append( ('%cuda_options', '') )
 
-# The code below is slightly more complex than currently necessary because of
-# the plans to allow running the same tests on multiple backends in a single
-# llvm-lit invocation.
-sycl_dev_aspects = []
-for be in [config.sycl_be]:
-    for device in config.target_devices.split(','):
-        cmd = 'env '
-        if be == 'ext_oneapi_cuda':
-            cmd += 'SYCL_PI_CUDA_ENABLE_IMAGE_SUPPORT=1 '
-        cmd += 'ONEAPI_DEVICE_SELECTOR={}:{} sycl-ls --verbose'.format(be, device)
-        sp = subprocess.run((cmd), env=llvm_config.config.environment,
-                            shell=True, capture_output=True, text=True)
-        if sp.returncode != 0:
-            lit_config.error('Cannot list device aspects for {}:{}\nstdout:\n{}\nstderr:\n'.format(
-                be, device, sp.stdout, sp.stderr))
-
-        dev_aspects = []
-        for line in sp.stdout.split('\n'):
-            if not re.search(r'^ *Aspects *:', line):
-                continue
-            _, aspects_str = line.split(':', 1)
-            dev_aspects.append(aspects_str.strip().split(' '))
-
-        if dev_aspects == []:
-            lit_config.error('Cannot detect device aspect for {}:{}\nstdout:\n{}\nstderr:\n'.format(
-                be, device, sp.stdout, sp.stderr))
-            sycl_dev_aspects.append(set())
-            continue
-
-        # We might have several devices matching the same filter in the system.
-        # Compute intersection of aspects.
-        result = set(dev_aspects[0]).intersection(*dev_aspects)
-        sycl_dev_aspects.append(result)
-
-resulting_aspects = sycl_dev_aspects[0].intersection(*sycl_dev_aspects)
-lit_config.note('Aspects: {}'.format(' '.join(resulting_aspects)))
-for aspect in resulting_aspects:
-    config.available_features.add('aspect-{}'.format(aspect))
-
 # Check for OpenCL ICD
 if config.opencl_libs_dir:
     if cl_options:
@@ -271,9 +236,6 @@ if not config.gpu_aot_target_opts:
 
 config.substitutions.append( ('%gpu_aot_target_opts',  config.gpu_aot_target_opts ) )
 
-# Use short names for LIT rules
-config.available_features.add(config.sycl_be.replace('ext_intel_', '').replace('ext_oneapi_', ''))
-
 if config.dump_ir_supported:
    config.available_features.add('dump_ir')
 
@@ -300,6 +262,7 @@ if config.hip_platform == "":
 if config.hip_platform not in supported_hip_platforms:
     lit_config.error("Unknown HIP platform '" + config.hip_platform + "' supported platforms are " + ', '.join(supported_hip_platforms))
 
+# FIXME: This needs to be made per-device as well, possibly with a helper.
 if config.sycl_be == "ext_oneapi_hip" and config.hip_platform == "AMD":
     config.available_features.add('hip_amd')
     arch_flag = '-Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=' + config.amd_arch
@@ -318,45 +281,21 @@ else:
 
 config.substitutions.append( ('%threads_lib', config.sycl_threads_lib) )
 
-# Configure device-specific substitutions based on availability of corresponding
-# devices/runtimes
-
-found_at_least_one_device = False
-
 supported_device_types=['cpu', 'gpu', 'acc']
-
 for target_device in config.target_devices.split(','):
-    if target_device == 'host':
-        lit_config.warning("Host device type is no longer supported.")
-    elif ( target_device not in supported_device_types ):
+    if ( target_device not in supported_device_types ):
         lit_config.error("Unknown SYCL target device type specified '" +
                          target_device +
                          "' supported devices are " + ', '.join(supported_device_types))
 
-if 'cpu' in config.target_devices.split(','):
-    found_at_least_one_device = True
-    lit_config.note("Test CPU device")
-    config.available_features.add('cpu')
-else:
-    lit_config.warning("CPU device not used")
+if lit_config.params.get('ze_debug'):
+    config.available_features.add('ze_debug')
 
-if 'gpu' in config.target_devices.split(','):
-    found_at_least_one_device = True
-    lit_config.note("Test GPU device")
-    config.available_features.add('gpu')
-
-    if config.sycl_be == "ext_oneapi_level_zero":
-        if lit_config.params.get('ze_debug'):
-            config.available_features.add('ze_debug')
-else:
-    lit_config.warning("GPU device not used")
-
-if 'acc' in config.target_devices.split(','):
-    found_at_least_one_device = True
-    lit_config.note("Tests accelerator device")
-    config.available_features.add('accelerator')
-else:
-    lit_config.warning("Accelerator device not used")
+config.sycl_devices = ['{}:{}'.format(config.sycl_be, dev)
+                       for dev in config.target_devices.split(',')]
+lit_config.note("Targeted devices: {}".format(', '.join(config.sycl_devices)))
+if len(config.sycl_devices) > 1:
+    lit_config.note('Running on multiple devices, XFAIL-marked tests will be skipped on corresponding devices')
 
 if config.run_launcher:
     config.substitutions.append(('%e2e_tests_root', config.test_source_root))
@@ -441,6 +380,53 @@ status = subprocess.getstatusoutput(config.dpcpp_compiler + ' -fsycl  ' +
 if status[0] == 0:
     lit_config.note('Kernel fusion extension enabled')
     config.available_features.add('fusion')
+
+for sycl_device in config.sycl_devices:
+    be, dev = sycl_device.split(':')
+    config.available_features.add('any-device-is-' + dev)
+    # Use short names for LIT rules.
+    config.available_features.add(
+        'any-device-is-' + be.replace('ext_intel_', '').replace('ext_oneapi_', ''))
+
+# That has to be executed last so that all device-independent features have been
+# discovered already.
+config.sycl_dev_features = {}
+for sycl_device in config.sycl_devices:
+    cmd = 'env '
+    if sycl_device.startswith('ext_oneapi_cuda:'):
+        cmd += 'SYCL_PI_CUDA_ENABLE_IMAGE_SUPPORT=1 '
+    cmd += 'ONEAPI_DEVICE_SELECTOR={} sycl-ls --verbose'.format(sycl_device)
+    sp = subprocess.run((cmd), env=llvm_config.config.environment,
+                        shell=True, capture_output=True, text=True)
+    if sp.returncode != 0:
+        lit_config.error('Cannot list device aspects for {}:{}\nstdout:\n{}\nstderr:\n'.format(
+            be, device, sp.stdout, sp.stderr))
+
+    dev_aspects = []
+    for line in sp.stdout.split('\n'):
+        if not re.search(r'^ *Aspects *:', line):
+            continue
+        _, aspects_str = line.split(':', 1)
+        dev_aspects.append(aspects_str.strip().split(' '))
+
+    if dev_aspects == []:
+        lit_config.error('Cannot detect device aspect for {}\nstdout:\n{}\nstderr:\n'.format(
+            sycl_device, sp.stdout, sp.stderr))
+        sycl_dev_aspects.append(set())
+        continue
+
+    # We might have several devices matching the same filter in the system.
+    # Compute intersection of aspects.
+    aspects = set(dev_aspects[0]).intersection(*dev_aspects)
+    lit_config.note('Aspects for {}: {}'.format(sycl_device, ', '.join(aspects)))
+
+    features = set('aspect-' + a for a in aspects)
+    be, dev = sycl_device.split(':')
+    features.add(dev)
+    # Use short names for LIT rules.
+    features.add(be.replace('ext_intel_', '').replace('ext_oneapi_', ''))
+
+    config.sycl_dev_features[sycl_device] = features.union(config.available_features)
 
 # Set timeout for a single test
 try:


### PR DESCRIPTION
This changes the behavior when running on multiple devices in a single llvm-lit invocation.

From now on, if the test's REQUIRES/UNSUPPORTED match more than one device from the targeted list, XFAILs are treated the same way as UNSUPPORTED. The behavior of XFAILs is unchanged if only one device matches the restrictions set by REQURIES/UNSUPPORTED, which is always true (if the test isn't skipped alltogether) when we run on a single device.