### PR TITLE
[SYCL][HIP] Temporarily disable HIP header deprecation warning

### DIFF
--- a/sycl/plugins/hip/CMakeLists.txt
+++ b/sycl/plugins/hip/CMakeLists.txt
@@ -98,6 +98,10 @@ add_sycl_plugin(hip
 )
 set_target_properties(pi_hip PROPERTIES LINKER_LANGUAGE CXX)
 
+if (not WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-cpp")
+endif()
+
 if("${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "AMD")
   # Import HIP runtime library
   add_library(rocmdrv SHARED IMPORTED GLOBAL)

--- a/sycl/plugins/hip/CMakeLists.txt
+++ b/sycl/plugins/hip/CMakeLists.txt
@@ -98,7 +98,9 @@ add_sycl_plugin(hip
 )
 set_target_properties(pi_hip PROPERTIES LINKER_LANGUAGE CXX)
 
-if (not WIN32)
+if (NOT WIN32)
+  # TODO: Temporarily disable deprecation warnings from the HIP headers. Remove
+  # this when https://github.com/intel/llvm/issues/9457 is addressed.
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-cpp")
 endif()
 


### PR DESCRIPTION
This commit temporarily disables the deprecation warning produced by the HIP headers to allow CI to build and run.