### PR TITLE
[SYCL][Devops] Switch lint task to self-hosted runner

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -28,9 +28,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
-    container:
-      image: ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:no-drivers
+    runs-on: Linux
     steps:
     - name: 'PR commits + 1'
       run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"


### PR DESCRIPTION
Our previous attempt to do that has been reverted in https://github.com/intel/llvm/commit/ec064e6c8872689073c085c024656fd8ec7b95ff and we blamed the action/checkout@v3 for that.

However, we successfully use it in
.github/workflows/sycl_linux_build_and_test.yml so I suspect the real issue was related to the container usage that we don't actually need for the self-hosted runner.