### PR TITLE
[SYCL][Test E2E] Allow multiple devices from different backends

### DIFF
--- a/sycl/test-e2e/Assert/assert_in_kernels_ndebug.cpp
+++ b/sycl/test-e2e/Assert/assert_in_kernels_ndebug.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -DNDEBUG %S/assert_in_kernels.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} -DNDEBUG %S/assert_in_kernels.cpp -o %t.out
 // RUN: %{run} %t.out | FileCheck %s
 //
 // CHECK-NOT: One shouldn't see this message

--- a/sycl/test-e2e/Assert/assert_in_multiple_tus_one_ndebug.cpp
+++ b/sycl/test-e2e/Assert/assert_in_multiple_tus_one_ndebug.cpp
@@ -3,7 +3,7 @@
 // https://github.com/intel/llvm/issues/7634
 // UNSUPPORTED: hip
 
-// RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%sycl_triple -DDEFINE_NDEBUG_INFILE2 -I %S/Inputs %S/assert_in_multiple_tus.cpp %S/Inputs/kernels_in_file2.cpp -o %t.out
+// RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%{sycl_triple} -DDEFINE_NDEBUG_INFILE2 -I %S/Inputs %S/assert_in_multiple_tus.cpp %S/Inputs/kernels_in_file2.cpp -o %t.out
 // Shouldn't fail on ACC as fallback assert isn't enqueued there
 // RUN: %{run} %t.out &> %t.txt ; FileCheck %s --input-file %t.txt %if acc %{ --check-prefix=CHECK-ACC %}
 //

--- a/sycl/test-e2e/Assert/assert_in_multiple_tus_one_ndebug_win.cpp
+++ b/sycl/test-e2e/Assert/assert_in_multiple_tus_one_ndebug_win.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: windows
-// RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%sycl_triple -DDEFINE_NDEBUG_INFILE2 -I %S/Inputs %S/assert_in_multiple_tus.cpp %S/Inputs/kernels_in_file2.cpp -o %t.out
+// RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%{sycl_triple} -DDEFINE_NDEBUG_INFILE2 -I %S/Inputs %S/assert_in_multiple_tus.cpp %S/Inputs/kernels_in_file2.cpp -o %t.out
 // Shouldn't fail on ACC as fallback assert isn't enqueued there
 // RUN: %{run} %t.out &> %t.txt ; FileCheck %s --input-file %t.txt %if acc %{ --check-prefix=CHECK-ACC %}
 //

--- a/sycl/test-e2e/Assert/assert_in_one_kernel_ndebug.cpp
+++ b/sycl/test-e2e/Assert/assert_in_one_kernel_ndebug.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -DNDEBUG  %S/assert_in_one_kernel.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} -DNDEBUG  %S/assert_in_one_kernel.cpp -o %t.out
 // RUN: %{run} %t.out | FileCheck %s
 //
 // CHECK-NOT: from assert statement

--- a/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus_one_ndebug.cpp
+++ b/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus_one_ndebug.cpp
@@ -2,7 +2,7 @@
 // FIXME HIP: https://github.com/intel/llvm/issues/7634
 // UNSUPPORTED: cuda, hip
 
-// RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%sycl_triple -DDEFINE_NDEBUG_INFILE2 -I %S/Inputs %S/assert_in_simultaneously_multiple_tus.cpp %S/Inputs/kernels_in_file2.cpp -o %t.out %threads_lib
+// RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%{sycl_triple} -DDEFINE_NDEBUG_INFILE2 -I %S/Inputs %S/assert_in_simultaneously_multiple_tus.cpp %S/Inputs/kernels_in_file2.cpp -o %t.out %threads_lib
 // RUN: %if cpu %{ %{run} %t.out &> %t.cpu.txt ; FileCheck %s --input-file %t.cpu.txt %}
 //
 // Since this is a multi-threaded application enable memory tracking and

--- a/sycl/test-e2e/BFloat16/bfloat16_builtins.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_builtins.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-ext_oneapi_bfloat16_math_functions
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %if any-device-is-cuda %{ -Xsycl-target-backend --cuda-gpu-arch=sm_80 %} %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %if any-device-is-cuda %{ -Xsycl-target-backend --cuda-gpu-arch=sm_80 %} %s -o %t.out
 // RUN: %{run} %t.out
 // Currently the feature isn't supported on FPGA.
 // UNSUPPORTED: accelerator

--- a/sycl/test-e2e/Basic/accessor/device_accessor_deduction.cpp
+++ b/sycl/test-e2e/Basic/accessor/device_accessor_deduction.cpp
@@ -1,2 +1,2 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Daccessor_new_api_test %S/Inputs/device_accessor.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} -Daccessor_new_api_test %S/Inputs/device_accessor.cpp -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Basic/accessor/get_device_access_deduction.cpp
+++ b/sycl/test-e2e/Basic/accessor/get_device_access_deduction.cpp
@@ -1,2 +1,2 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Dbuffer_new_api_test %S/Inputs/device_accessor.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} -Dbuffer_new_api_test %S/Inputs/device_accessor.cpp -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Basic/accessor/get_host_access_deduction.cpp
+++ b/sycl/test-e2e/Basic/accessor/get_host_access_deduction.cpp
@@ -1,2 +1,2 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Dbuffer_new_api_test %S/Inputs/host_accessor.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} -Dbuffer_new_api_test %S/Inputs/host_accessor.cpp -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Basic/accessor/get_host_task_access_deduction.cpp
+++ b/sycl/test-e2e/Basic/accessor/get_host_task_access_deduction.cpp
@@ -1,2 +1,2 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Dbuffer_new_api_test %S/Inputs/host_task_accessor.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} -Dbuffer_new_api_test %S/Inputs/host_task_accessor.cpp -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Basic/accessor/get_host_task_access_placeholder_deduction.cpp
+++ b/sycl/test-e2e/Basic/accessor/get_host_task_access_placeholder_deduction.cpp
@@ -1,2 +1,2 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Dbuffer_placeholder_new_api_test %S/Inputs/host_task_accessor.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} -Dbuffer_placeholder_new_api_test %S/Inputs/host_task_accessor.cpp -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Basic/accessor/host_accessor_deduction.cpp
+++ b/sycl/test-e2e/Basic/accessor/host_accessor_deduction.cpp
@@ -1,2 +1,2 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Daccessor_new_api_test %S/Inputs/host_accessor.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} -Daccessor_new_api_test %S/Inputs/host_accessor.cpp -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Basic/accessor/host_task_accessor_deduction.cpp
+++ b/sycl/test-e2e/Basic/accessor/host_task_accessor_deduction.cpp
@@ -1,2 +1,2 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Daccessor_new_api_test %S/Inputs/host_task_accessor.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} -Daccessor_new_api_test %S/Inputs/host_task_accessor.cpp -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Basic/accessor/host_task_accessor_placeholder_deduction.cpp
+++ b/sycl/test-e2e/Basic/accessor/host_task_accessor_placeholder_deduction.cpp
@@ -1,2 +1,2 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -Daccessor_placeholder_new_api_test %S/Inputs/host_task_accessor.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} -Daccessor_placeholder_new_api_test %S/Inputs/host_task_accessor.cpp -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Basic/multisource.cpp
+++ b/sycl/test-e2e/Basic/multisource.cpp
@@ -9,14 +9,14 @@
 // Separate kernel sources and host code sources
 // RUN: %{build} -c -o %t.kernel.o -DINIT_KERNEL -DCALC_KERNEL
 // RUN: %{build} -c -o %t.main.o -DMAIN_APP
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %t.kernel.o %t.main.o -o %t.fat
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.kernel.o %t.main.o -o %t.fat
 // RUN: %{run} %t.fat
 
 // Multiple sources with kernel code
 // RUN: %{build} -c -o %t.init.o -DINIT_KERNEL
 // RUN: %{build} -c -o %t.calc.o -DCALC_KERNEL
 // RUN: %{build} -c -o %t.main.o -DMAIN_APP
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %t.init.o %t.calc.o %t.main.o -o %t.fat
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.init.o %t.calc.o %t.main.o -o %t.fat
 // RUN: %{run} %t.fat
 
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/Basic/reqd_work_group_size_check_exception.cpp
+++ b/sycl/test-e2e/Basic/reqd_work_group_size_check_exception.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple  %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple}  %s -o %t.out
 // RUN: %{run} %t.out
 
 // UNSUPPORTED: hip

--- a/sycl/test-e2e/CMakeLists.txt
+++ b/sycl/test-e2e/CMakeLists.txt
@@ -55,37 +55,17 @@ if(NOT SYCL_TEST_E2E_STANDALONE)
   )
 endif() # Standalone.
 
-if(SYCL_TEST_E2E_TARGETS)
-  message("Configure iterative execution on multiple backends")
-  add_custom_target(check-sycl-e2e)
-  foreach(TARGET_STR ${SYCL_TEST_E2E_TARGETS})
-    string(REPLACE ":" ";" TARGET_LIST ${TARGET_STR})
-    list (GET TARGET_LIST 0 TARGET_BE)
-    list (GET TARGET_LIST 1 TARGET_DEVICES)
+if(NOT SYCL_TEST_E2E_TARGETS)
+  set(SYCL_TEST_E2E_TARGETS "all")
+endif()
 
-    if ("${TARGET_BE}" STREQUAL "")
-      message(FATAL_ERROR
-        "invalid empty target backend specification in SYCL_TEST_E2E_TARGETS")
-    elseif("${TARGET_DEVICES}" STREQUAL "")
-      message(FATAL_ERROR
-        "invalid empty target device specification in SYCL_TEST_E2E_TARGETS")
-    endif()
-    message("Run on ${TARGET_DEVICES} for ${TARGET_BE}")
-
-    string(REPLACE "," "_" TARGET check-sycl-e2e-${TARGET_BE}-${TARGET_DEVICES})
-
-    add_custom_target(${TARGET}
-      COMMAND ${Python3_EXECUTABLE} ${LLVM_LIT} ${SYCL_E2E_TESTS_LIT_FLAGS} --param sycl_be=${TARGET_BE} --param target_devices=${TARGET_DEVICES} .
-      COMMENT "Running the SYCL tests for ${TARGET} backend"
-      DEPENDS ${SYCL_E2E_TEST_DEPS}
-      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-      USES_TERMINAL
-    )
-    set_target_properties(${TARGET} PROPERTIES FOLDER "SYCL Level Zero tests")
-    add_dependencies(check-sycl-e2e ${TARGET})
-
-  endforeach()
-endif(SYCL_TEST_E2E_TARGETS)
+add_custom_target(check-sycl-e2e
+  COMMAND ${Python3_EXECUTABLE} ${LLVM_LIT} ${SYCL_E2E_TESTS_LIT_FLAGS} .
+  COMMENT "Running SYCL End-to-End tests"
+  DEPENDS ${SYCL_E2E_TEST_DEPS}
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  USES_TERMINAL
+)
 
 add_subdirectory(External)
 add_subdirectory(ExtraTests)

--- a/sycl/test-e2e/ESIMD/api/functional/lit.local.cfg
+++ b/sycl/test-e2e/ESIMD/api/functional/lit.local.cfg
@@ -1,3 +1,2 @@
 # TODO: Only this platform is supported so far.
-if config.sycl_be not in ['ext_oneapi_level_zero']:
-  config.unsupported = True
+config.required_features += ['level_zero']

--- a/sycl/test-e2e/ESIMD/lit.local.cfg
+++ b/sycl/test-e2e/ESIMD/lit.local.cfg
@@ -1,10 +1,7 @@
 import platform
 
-if config.sycl_be in ['ext_oneapi_cuda', 'ext_oneapi_hip']:
-   config.unsupported = True
-
-if 'gpu' not in config.target_devices.split(','):
-   config.unsupported = True
+config.unsupported_features += ['cuda', 'hip']
+config.required_features += ['gpu']
 
 if 'gpu-intel-gen9' in config.available_features and platform.system() == 'Windows':
   config.unsupported = True

--- a/sycl/test-e2e/InvokeSimd/lit.local.cfg
+++ b/sycl/test-e2e/InvokeSimd/lit.local.cfg
@@ -1,10 +1,7 @@
 import platform
 
-if config.sycl_be in ['ext_oneapi_cuda', 'ext_oneapi_hip']:
-   config.unsupported = True
-
-if 'gpu' not in config.target_devices.split(','):
-   config.unsupported = True
+config.unsupported_features += ['cuda', 'hip']
+config.required_features += ['gpu']
 
 # TODO: enable on Windows once driver is ready.
 if platform.system() != "Linux":

--- a/sycl/test-e2e/KernelFusion/lit.local.cfg
+++ b/sycl/test-e2e/KernelFusion/lit.local.cfg
@@ -1,2 +1,1 @@
-if config.sycl_be in ['ext_oneapi_hip']:
-   config.unsupported = True
+config.unsupported_features += ['hip']

--- a/sycl/test-e2e/OneapiDeviceSelector/backendonly_error.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/backendonly_error.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: level_zero
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %S/Inputs/trivial.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %S/Inputs/trivial.cpp -o %t.out
 // RUN: env ONEAPI_DEVICE_SELECTOR=level_zero %t.out
 // XFAIL: *
 

--- a/sycl/test-e2e/OneapiDeviceSelector/case_sensitivity.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/case_sensitivity.cpp
@@ -1,7 +1,7 @@
 
 // does not actually require OpenCL or GPU. Just testing parsing.
 
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %S/Inputs/trivial.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %S/Inputs/trivial.cpp -o %t.out
 // RUN: env ONEAPI_DEVICE_SELECTOR="OPENCL:*" %t.out
 // RUN: env ONEAPI_DEVICE_SELECTOR="opencl:*" %t.out
 // RUN: env ONEAPI_DEVICE_SELECTOR="*:GPU" %t.out

--- a/sycl/test-e2e/OneapiDeviceSelector/illegal_BE_error.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/illegal_BE_error.cpp
@@ -1,5 +1,5 @@
 
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %S/Inputs/trivial.cpp -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %S/Inputs/trivial.cpp -o %t.out
 // RUN: env ONEAPI_DEVICE_SELECTOR="macaroni:*"" %t.out
 // XFAIL: *
 

--- a/sycl/test-e2e/Regression/DAE-separate-compile.cpp
+++ b/sycl/test-e2e/Regression/DAE-separate-compile.cpp
@@ -5,7 +5,7 @@
 // The test checks that the scenario works correctly.
 //
 // RUN: %{build} -O2 -c -o %t.o
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %t.o -O0 -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.o -O0 -o %t.out
 // RUN: %{run} %t.out
 
 #include <iostream>

--- a/sycl/test-e2e/Regression/commandlist/gpu.cpp
+++ b/sycl/test-e2e/Regression/commandlist/gpu.cpp
@@ -2,5 +2,5 @@
 // UNSUPPORTED: hip
 // UNSUPPORTED: ze_debug
 //
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %S/Inputs/FindPrimesSYCL.cpp %S/Inputs/main.cpp -o %t.out -lpthread
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %S/Inputs/FindPrimesSYCL.cpp %S/Inputs/main.cpp -o %t.out -lpthread
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Regression/multiple-targets.cpp
+++ b/sycl/test-e2e/Regression/multiple-targets.cpp
@@ -3,16 +3,16 @@
 // The test is repeated for per_kernel device code splitting.
 //
 // REQUIRES: CUDA || HIP
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple,spirv64 -o %t.out %s
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple},spirv64 -o %t.out %s
 // RUN: %{run} %t.out
 //
-// RUN: %clangxx -fsycl -fsycl-targets=spirv64,%sycl_triple -o %t.out %s
+// RUN: %clangxx -fsycl -fsycl-targets=spirv64,%{sycl_triple} -o %t.out %s
 // RUN: %{run} %t.out
 //
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple,spirv64 -fsycl-device-code-split=per_kernel -o %t.out %s
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple},spirv64 -fsycl-device-code-split=per_kernel -o %t.out %s
 // RUN: %{run} %t.out
 //
-// RUN: %clangxx -fsycl -fsycl-targets=spirv64,%sycl_triple -fsycl-device-code-split=per_kernel -o %t.out %s
+// RUN: %clangxx -fsycl -fsycl-targets=spirv64,%{sycl_triple} -fsycl-device-code-split=per_kernel -o %t.out %s
 // RUN: %{run} %t.out
 //
 // XFAIL: hip_nvidia

--- a/sycl/test-e2e/SeparateCompile/same-kernel.cpp
+++ b/sycl/test-e2e/SeparateCompile/same-kernel.cpp
@@ -12,7 +12,7 @@
 // RUN: %{build} -DB_CPP=1 -c -o %t-same-kernel-b.o
 //
 // >> ---- link the full hetero app
-// RUN: %clangxx %t-same-kernel-a.o %t-same-kernel-b.o -o %t-same-kernel.exe -fsycl -fsycl-targets=%sycl_triple
+// RUN: %clangxx %t-same-kernel-a.o %t-same-kernel-b.o -o %t-same-kernel.exe -fsycl -fsycl-targets=%{sycl_triple}
 // RUN: %{run} %t-same-kernel.exe
 
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/SeparateCompile/sycl-external.cpp
+++ b/sycl/test-e2e/SeparateCompile/sycl-external.cpp
@@ -2,14 +2,14 @@
 // different object file.
 // RUN: %{build} -DSOURCE1 -c -o %t1.o
 // RUN: %{build} -DSOURCE2 -c -o %t2.o
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %t1.o %t2.o -o %t.exe
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t1.o %t2.o -o %t.exe
 // RUN: %{run} %t.exe
 //
 // Test2 - check that kernel can call a SYCL_EXTERNAL function defined in a
 // static library.
 // RUN: rm -f %t.a
 // RUN: llvm-ar crv %t.a %t1.o
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %t2.o -foffload-static-lib=%t.a -o %t.exe
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t2.o -foffload-static-lib=%t.a -o %t.exe
 // RUN: %{run} %t.exe
 
 #include <iostream>

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -47,19 +47,6 @@ possibly_dangerous_env_vars = ['COMPILER_PATH', 'RC_DEBUG_OPTIONS',
                                'LIBCLANG_RESOURCE_USAGE',
                                'LIBCLANG_CODE_COMPLETION_LOGGING']
 
-if not config.sycl_be:
-     lit_config.error("SYCL backend is not specified")
-
-# Replace deprecated backend names
-deprecated_names_mapping = {'cuda'       : 'ext_oneapi_cuda',
-                            'hip'        : 'ext_oneapi_hip',
-                            'level_zero' : 'ext_oneapi_level_zero',
-                            'esimd_cpu'  : 'ext_intel_esimd_emulator'}
-if config.sycl_be in deprecated_names_mapping.keys():
-    config.sycl_be = deprecated_names_mapping[config.sycl_be]
-
-lit_config.note("Backend: {BACKEND}".format(BACKEND=config.sycl_be))
-
 # Clang/Win32 may refer to %INCLUDE%. vsvarsall.bat sets it.
 if platform.system() != 'Windows':
     possibly_dangerous_env_vars.append('INCLUDE')
@@ -237,23 +224,36 @@ if not config.gpu_aot_target_opts:
 config.substitutions.append( ('%gpu_aot_target_opts',  config.gpu_aot_target_opts ) )
 
 if config.dump_ir_supported:
-   config.available_features.add('dump_ir')
+    config.available_features.add('dump_ir')
 
-supported_sycl_be = ['opencl',
-                     'ext_oneapi_cuda',
-                     'ext_oneapi_hip',
-                     'ext_oneapi_level_zero',
-                     'ext_intel_esimd_emulator']
+lit_config.note("Targeted devices: {}".format(', '.join(config.sycl_devices)))
 
-if config.sycl_be not in supported_sycl_be:
-   lit_config.error("Unknown SYCL BE specified '" +
-                    config.sycl_be +
-                    "'. Supported values are {}".format(', '.join(supported_sycl_be)))
+if len(config.sycl_devices) == 1 and config.sycl_devices[0] == 'all':
+    devices = set()
+    sp = subprocess.getstatusoutput('sycl-ls')
+    for line in sp[1].split('\n'):
+        (backend, device, _) = line[1:].split(':', 2)
+        devices.add('{}:{}'.format(backend, device))
+    config.sycl_devices = list(devices)
+
+if len(config.sycl_devices) > 1:
+    lit_config.note('Running on multiple devices, XFAIL-marked tests will be skipped on corresponding devices')
+
+available_devices = {'opencl': ('cpu', 'gpu', 'acc'),
+                     'ext_oneapi_cuda':('gpu'),
+                     'ext_oneapi_level_zero':('gpu'),
+                     'ext_oneapi_hip':('gpu'),
+                     'ext_intel_esimd_emulator':('gpu')}
+for d in config.sycl_devices:
+     be, dev = d.split(':')
+     if be not in available_devices or dev not in available_devices[be]:
+          lit_config.error('Unsupported device {}'.format(d))
 
 # Run only tests in ESIMD subforlder for the ext_intel_esimd_emulator
-if config.sycl_be == 'ext_intel_esimd_emulator':
-   config.test_source_root += "/ESIMD"
-   config.test_exec_root += "/ESIMD"
+# TODO: Can it work in multiple devices configuration at all?
+if len(config.sycl_devices) == 1 and config.sycl_devices[0] == 'ext_intel_esimd_emulator:gpu':
+     config.test_source_root += "/ESIMD"
+     config.test_exec_root += "/ESIMD"
 
 # If HIP_PLATFORM flag is not set, default to AMD, and check if HIP platform is supported
 supported_hip_platforms=["AMD", "NVIDIA"]
@@ -263,10 +263,10 @@ if config.hip_platform not in supported_hip_platforms:
     lit_config.error("Unknown HIP platform '" + config.hip_platform + "' supported platforms are " + ', '.join(supported_hip_platforms))
 
 # FIXME: This needs to be made per-device as well, possibly with a helper.
-if config.sycl_be == "ext_oneapi_hip" and config.hip_platform == "AMD":
+if "ext_oneapi_hip:gpu" in config.sycl_devices and config.hip_platform == "AMD":
     config.available_features.add('hip_amd')
     arch_flag = '-Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=' + config.amd_arch
-elif config.sycl_be == "ext_oneapi_hip" and config.hip_platform == "NVIDIA":
+elif "ext_oneapi_hip:gpu" in config.sycl_devices and config.hip_platform == "NVIDIA":
     config.available_features.add('hip_nvidia')
     arch_flag = ""
 else:
@@ -281,31 +281,11 @@ else:
 
 config.substitutions.append( ('%threads_lib', config.sycl_threads_lib) )
 
-supported_device_types=['cpu', 'gpu', 'acc']
-for target_device in config.target_devices.split(','):
-    if ( target_device not in supported_device_types ):
-        lit_config.error("Unknown SYCL target device type specified '" +
-                         target_device +
-                         "' supported devices are " + ', '.join(supported_device_types))
-
 if lit_config.params.get('ze_debug'):
     config.available_features.add('ze_debug')
 
-config.sycl_devices = ['{}:{}'.format(config.sycl_be, dev)
-                       for dev in config.target_devices.split(',')]
-lit_config.note("Targeted devices: {}".format(', '.join(config.sycl_devices)))
-if len(config.sycl_devices) > 1:
-    lit_config.note('Running on multiple devices, XFAIL-marked tests will be skipped on corresponding devices')
-
 if config.run_launcher:
     config.substitutions.append(('%e2e_tests_root', config.test_source_root))
-
-if config.sycl_be == 'ext_oneapi_cuda' or (config.sycl_be == 'ext_oneapi_hip' and config.hip_platform == 'NVIDIA'):
-    config.substitutions.append( ('%sycl_triple',  "nvptx64-nvidia-cuda" ) )
-elif config.sycl_be == 'ext_oneapi_hip' and config.hip_platform == 'AMD':
-    config.substitutions.append( ('%sycl_triple',  "amdgcn-amd-amdhsa" ) )
-else:
-    config.substitutions.append( ('%sycl_triple',  "spir64" ) )
 
 # TODO properly set XPTIFW include and runtime dirs
 xptifw_lib_dir = os.path.join(config.dpcpp_root_dir, 'lib')

--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -25,8 +25,12 @@ config.cuda_libs_dir = "@CUDA_LIBS_DIR@"
 config.cuda_include = "@CUDA_INCLUDE@"
 
 config.opencl_include_dir = os.path.join(config.sycl_include, 'sycl')
-config.target_devices = lit_config.params.get("target_devices", "@SYCL_TARGET_DEVICES@")
-config.sycl_be = lit_config.params.get("sycl_be", "@SYCL_BE@")
+
+config.sycl_devices = lit_config.params.get("sycl_devices", "@SYCL_TEST_E2E_TARGETS@").split(';')
+if lit_config.params.get("target_devices") and lit_config.params.get("sycl_be"):
+    config.sycl_devices = ['{}:{}'.format(lit_config.params.get("sycl_be"), d)
+                           for d in lit_config.params.get("target_devices").split(',')]
+
 config.hip_platform = "@HIP_PLATFORM@"
 config.amd_arch = "@AMD_ARCH@"
 config.sycl_threads_lib = '@SYCL_THREADS_LIB@'


### PR DESCRIPTION
I wasn't able to make `%sycl_triple` expand properly due to some inteference with the default `%s` substitution so I've changed it to `%{sycl_triple}`. However, most of the tests had been updated to use `%{build}` before so only a limited number of tests required changes.

Also, I've dropped support for the old deprecated spelling of some of the backends (`cuda/hip/level_zero`) in `sycl_be`/`sycl_devices` LIT parameters, use `ext_oneapi_*` spelling instead. LIT "features" used in `REQUIRES`/`UNSUPPORTED` directives remain the same as before (i.e., short versions).

The rest of the changes in this PR are additions/changes in the prefered/default usage but all the previous scenarios should keep working for now.

From now on, it is prefered to use `--param sycl_devices="be0:dev0[;beN:devN]*"` instead of `--param sycl_be=be0 --param target_devices=d0[,dN]*`. Note that the default value for `sycl_devices` is `SYCL_TEST_E2E_TARGETS` from the CMake configuration and we've already been using it at the CMake level to control the behavior of `ninja check-sycl-e2e`. Now that handling has been moved from CMake level to llvm-lit level. However, previous `sycl_be/target_devices` parameters could still be used to override `sycl_devices` for some short time to update infrastructure.

`sycl_devices` also supports and, in fact, defaults to the "all" value which means use the entire set of devices as listed by `sycl-ls` command. This is now the default configuration and the workspace created by `buildbot/configure.py` enables SYCL End-to-End tests target (`check-sycl-e2e`) unconditionally with the default behavior to run the tests on all available devices.