### PR TITLE
[SYCL][Test E2E] Disable srgba-read.cpp for L0

### DIFF
--- a/sycl/test-e2e/Basic/image/srgba-read.cpp
+++ b/sycl/test-e2e/Basic/image/srgba-read.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: aspect-ext_oneapi_srgb, aspect-ext_intel_legacy_image
+// UNSUPPORTED: level_zero
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out | FileCheck %s
 


### PR DESCRIPTION
It catches "die" statement due to missing functionality in L0. Re-enable once L0 driver adds support.