### PR TITLE
[ESIMD][E2E] Fix error in ext_math_fast test on emulator

### DIFF
--- a/sycl/test-e2e/ESIMD/ext_math_fast.cpp
+++ b/sycl/test-e2e/ESIMD/ext_math_fast.cpp
@@ -5,13 +5,18 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// RUN: %{build} -fsycl-device-code-split=per_kernel -ffast-math -o %t.out
+// RUN: %{build} -fsycl-device-code-split=per_kernel -ffast-math -fno-slp-vectorize -o %t.out
 // RUN: %{run} %t.out
 
 // This test checks extended math operations. Combinations of
 // - argument type - half, float
 // - math function - sin, cos, ..., div_ieee, pow
 // - SYCL vs ESIMD APIs
+
+// This version of the test checks -ffast-math option which may cause code-gen
+// of different-precision variants of math functions.
+// The option -fno-slp-vectorize prevents vectorization of code in kernel
+// operator() to avoid the extra difficulties in results verification.
 
 #define TEST_FAST_MATH 1
 


### PR DESCRIPTION
The test gave different results for data computed inside parallel_for because of SLP vectorizer. It was turned off as SLP vectorization on host was not the purpose of this test.