### PR TITLE
[SYCL-MLIR][driver] Add `-fsycl-raise-host` option

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2978,6 +2978,9 @@ def fsycl_device_only : Flag<["-"], "fsycl-device-only">, Flags<[CoreOption]>,
   HelpText<"Compile SYCL kernels for device">;
 def fsycl_embed_ir : Flag<["-"], "fsycl-embed-ir">, Flags<[CoreOption]>,
   HelpText<"Embed LLVM IR for runtime kernel fusion">;
+def fsycl_raise_host : Flag<["-"], "fsycl-raise-host">,
+  Flags<[CC1Option, CoreOption]>,
+  HelpText<"Raise SYCL host code to MLIR after compiling to LLVM IR">;
 defm sycl_esimd_force_stateless_mem : BoolFOption<"sycl-esimd-force-stateless-mem",
     LangOpts<"SYCLESIMDForceStatelessMem">, DefaultFalse,
     PosFlag<SetTrue, [], "Enforce using stateless memory accesses. "

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -2978,8 +2978,7 @@ def fsycl_device_only : Flag<["-"], "fsycl-device-only">, Flags<[CoreOption]>,
   HelpText<"Compile SYCL kernels for device">;
 def fsycl_embed_ir : Flag<["-"], "fsycl-embed-ir">, Flags<[CoreOption]>,
   HelpText<"Embed LLVM IR for runtime kernel fusion">;
-def fsycl_raise_host : Flag<["-"], "fsycl-raise-host">,
-  Flags<[CC1Option, CoreOption]>,
+def fsycl_raise_host : Flag<["-"], "fsycl-raise-host">, Flags<[CoreOption]>,
   HelpText<"Raise SYCL host code to MLIR after compiling to LLVM IR">;
 defm sycl_esimd_force_stateless_mem : BoolFOption<"sycl-esimd-force-stateless-mem",
     LangOpts<"SYCLESIMDForceStatelessMem">, DefaultFalse,

--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -168,6 +168,7 @@ private:
   mutable std::unique_ptr<Tool> SpirvToIrWrapper;
   mutable std::unique_ptr<Tool> LinkerWrapper;
   mutable std::unique_ptr<Tool> Cgeist;
+  mutable std::unique_ptr<Tool> MLIRTranslate;
 
   Tool *getClang() const;
   Tool *getFlang() const;
@@ -189,6 +190,7 @@ private:
   Tool *getSpirvToIrWrapper() const;
   Tool *getLinkerWrapper() const;
   Tool *getCgeist() const;
+  Tool *getMLIRTranslate() const;
 
   mutable bool SanitizerArgsChecked = false;
   mutable std::unique_ptr<XRayArgs> XRayArguments;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4778,7 +4778,8 @@ class OffloadingActionBuilder final {
                       OffloadingActionBuilder &OAB,
                       bool OnlyCreateStubFile = false)
         : DeviceActionBuilder(C, Args, Inputs, Action::OFK_SYCL, OAB),
-          OnlyCreateStubFile(OnlyCreateStubFile), SYCLInstallation(C.getDriver()) {}
+          OnlyCreateStubFile(OnlyCreateStubFile),
+          SYCLInstallation(C.getDriver()) {}
 
     void withBoundArchForToolChain(const ToolChain *TC,
                                    llvm::function_ref<void(const char *)> Op) {
@@ -4869,7 +4870,7 @@ class OffloadingActionBuilder final {
           DeviceCompilerInput = A;
         }
         const DeviceTargetInfo &DevTarget = SYCLTargetInfoList.back();
-	bool SYCLRaiseHost = Args.hasArg(options::OPT_fsycl_raise_host);
+        bool SYCLRaiseHost = Args.hasArg(options::OPT_fsycl_raise_host);
         if (!SYCLRaiseHost || OnlyCreateStubFile)
           DA.add(*DeviceCompilerInput, *DevTarget.TC, DevTarget.BoundArch,
                  Action::OFK_SYCL);
@@ -5039,7 +5040,7 @@ class OffloadingActionBuilder final {
           isa<CompileJobAction>(HostAction) &&
           Args.hasArg(options::OPT_fsycl_raise_host)) {
         // Remove compile action from the list
-	Action *A = SYCLDeviceActions.back();
+        Action *A = SYCLDeviceActions.back();
         SYCLDeviceActions.pop_back();
         // Create new compile action using host module
         HostAction =
@@ -6616,8 +6617,8 @@ public:
       // device only compilation, HostAction is a null pointer, therefore only
       // do this when HostAction is not a null pointer.
       bool UseHostActionInput =
-	HostAction->getType() == types::TY_MLIR_IR &&
-	C.getArgs().hasArg(options::OPT_fsycl_raise_host);
+          HostAction->getType() == types::TY_MLIR_IR &&
+          C.getArgs().hasArg(options::OPT_fsycl_raise_host);
 
       if (UseHostActionInput) {
         assert(isa<CompileJobAction>(HostAction) &&

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4686,6 +4686,10 @@ class OffloadingActionBuilder final {
     /// Flag to signal if the user requested device code split.
     bool DeviceCodeSplit = false;
 
+    /// Flag to signal this builder's purpose is to produce the stub file to be
+    /// used by the host compilation.
+    bool OnlyCreateStubFile = false;
+
     /// List of offload device toolchain, bound arch needed to track for
     /// different binary constructions.
     /// POD to hold information about a SYCL device action.
@@ -4771,9 +4775,10 @@ class OffloadingActionBuilder final {
   public:
     SYCLActionBuilder(Compilation &C, DerivedArgList &Args,
                       const Driver::InputList &Inputs,
-                      OffloadingActionBuilder &OAB)
+                      OffloadingActionBuilder &OAB,
+                      bool OnlyCreateStubFile = false)
         : DeviceActionBuilder(C, Args, Inputs, Action::OFK_SYCL, OAB),
-          SYCLInstallation(C.getDriver()) {}
+          OnlyCreateStubFile(OnlyCreateStubFile), SYCLInstallation(C.getDriver()) {}
 
     void withBoundArchForToolChain(const ToolChain *TC,
                                    llvm::function_ref<void(const char *)> Op) {
@@ -4838,12 +4843,11 @@ class OffloadingActionBuilder final {
         for (auto TargetActionInfo :
              llvm::zip(SYCLDeviceActions, SYCLTargetInfoList)) {
           Action *&A = std::get<0>(TargetActionInfo);
-          auto &TargetInfo = std::get<1>(TargetActionInfo);
           types::ID OutputType = types::TY_LLVM_BC;
           if ((SYCLDeviceOnly || Args.hasArg(options::OPT_emit_llvm)) &&
               Args.hasArg(options::OPT_S))
             OutputType = types::TY_LLVM_IR;
-          if (SYCLDeviceOnly && Args.hasArg(options::OPT_emit_mlir)) {
+          if (!OnlyCreateStubFile && Args.hasArg(options::OPT_emit_mlir)) {
             OutputType = types::TY_MLIR_IR;
           }
           // Use of -fsycl-device-obj=spirv converts the original LLVM-IR
@@ -4865,9 +4869,12 @@ class OffloadingActionBuilder final {
           DeviceCompilerInput = A;
         }
         const DeviceTargetInfo &DevTarget = SYCLTargetInfoList.back();
-        DA.add(*DeviceCompilerInput, *DevTarget.TC, DevTarget.BoundArch,
-               Action::OFK_SYCL);
-        return SYCLDeviceOnly ? ABRT_Ignore_Host : ABRT_Success;
+	bool SYCLRaiseHost = Args.hasArg(options::OPT_fsycl_raise_host);
+        if (!SYCLRaiseHost || OnlyCreateStubFile)
+          DA.add(*DeviceCompilerInput, *DevTarget.TC, DevTarget.BoundArch,
+                 Action::OFK_SYCL);
+        return SYCLDeviceOnly && !SYCLRaiseHost ? ABRT_Ignore_Host
+                                                : ABRT_Success;
       }
 
       // Backend/Assemble actions are obsolete for the SYCL device side
@@ -5027,6 +5034,29 @@ class OffloadingActionBuilder final {
         return ABRT_Success;
       }
 
+      if (!SYCLDeviceActions.empty() && !OnlyCreateStubFile &&
+          isa<CompileJobAction>(SYCLDeviceActions.back()) &&
+          isa<CompileJobAction>(HostAction) &&
+          Args.hasArg(options::OPT_fsycl_raise_host)) {
+        // Remove compile action from the list
+	Action *A = SYCLDeviceActions.back();
+        SYCLDeviceActions.pop_back();
+        // Create new compile action using host module
+        HostAction =
+            C.MakeAction<CompileJobAction>(HostAction, types::TY_MLIR_IR);
+        OffloadAction::HostDependence HDep(
+            *HostAction, *C.getSingleOffloadToolChain<Action::OFK_Host>(),
+            /*BoundArch=*/nullptr, Action::OFK_SYCL);
+        const DeviceTargetInfo &TargetInfo = SYCLTargetInfoList.front();
+        OffloadAction::DeviceDependences DDep;
+        DDep.add(*A->getInputs().front(), *TargetInfo.TC, TargetInfo.BoundArch,
+                 Action::OFK_SYCL);
+        HostAction = C.MakeAction<OffloadAction>(HDep, DDep);
+        SYCLDeviceActions.push_back(
+            C.MakeAction<CompileJobAction>(HostAction, A->getType()));
+        return ABRT_Success;
+      }
+
       // If this is an unbundling action use it as is for each SYCL toolchain.
       if (auto *UA = dyn_cast<OffloadUnbundlingJobAction>(HostAction)) {
         SYCLDeviceActions.clear();
@@ -5082,7 +5112,10 @@ class OffloadingActionBuilder final {
 
     void appendTopLevelActions(ActionList &AL) override {
       // We should always have an action for each input.
-      if (!SYCLDeviceActions.empty()) {
+      // We should always have an action for each input.
+      // If the only purpose of this builder was to create the stuff file, we
+      // can simply return.
+      if (!OnlyCreateStubFile && !SYCLDeviceActions.empty()) {
         assert(SYCLDeviceActions.size() == SYCLTargetInfoList.size() &&
                "Number of SYCL actions and toolchains/boundarch pairs do not "
                "match.");
@@ -5409,6 +5442,9 @@ class OffloadingActionBuilder final {
     }
 
     void appendLinkDependences(OffloadAction::DeviceDependences &DA) override {
+      // This action's output should not be used to generate the final image
+      if (OnlyCreateStubFile)
+        return;
       // DeviceLinkerInputs holds binaries per ToolChain (TC) / bound-arch pair
       // The following will loop link and post process for each TC / bound-arch
       // to produce a final binary.
@@ -6271,6 +6307,14 @@ public:
     SpecializedBuilders.push_back(
         new SYCLActionBuilder(C, Args, Inputs, *this));
 
+    // We will need two specialized SYCL builders: one will run before host
+    // compilation just to produce the device stub and other to perform the
+    // actual compilation.
+    if (Args.hasArg(options::OPT_fsycl_raise_host)) {
+      SpecializedBuilders.push_back(new SYCLActionBuilder(
+          C, Args, Inputs, *this, /*OnlyCreateStubFile=*/true));
+    }
+
     //
     // TODO: Build other specialized builders here.
     //
@@ -6556,18 +6600,42 @@ public:
       SB->appendTopLevelActions(OffloadAL);
     }
 
-    // If we can use the bundler, replace the host action by the bundling one in
-    // the resulting list. Otherwise, just append the device actions. For
-    // device only compilation, HostAction is a null pointer, therefore only do
-    // this when HostAction is not a null pointer.
-    if (CanUseBundler && HostAction &&
-        HostAction->getType() != types::TY_Nothing && !OffloadAL.empty()) {
-      // Add the host action to the list in order to create the bundling action.
+    if (const llvm::opt::DerivedArgList &Args = C.getArgs();
+        Args.hasArg(options::OPT_fsycl_raise_host) &&
+        (Args.hasArg(options::OPT_fsycl_device_only) ||
+         Args.hasArg(options::OPT_emit_mlir))) {
+      // The host action will be discarded if it was created for instrumentation
+      // and it is not needed in the output
+      HostAction = nullptr;
+      AL = OffloadAL;
+    } else if (CanUseBundler && HostAction &&
+               HostAction->getType() != types::TY_Nothing &&
+               !OffloadAL.empty()) {
+      // If we can use the bundler, replace the host action by the bundling one
+      // in the resulting list. Otherwise, just append the device actions. For
+      // device only compilation, HostAction is a null pointer, therefore only
+      // do this when HostAction is not a null pointer.
+      bool UseHostActionInput =
+	HostAction->getType() == types::TY_MLIR_IR &&
+	C.getArgs().hasArg(options::OPT_fsycl_raise_host);
+
+      if (UseHostActionInput) {
+        assert(isa<CompileJobAction>(HostAction) &&
+               HostAction->getInputs().front()->getType() ==
+                   types::TY_LLVM_IR &&
+               HostAction->getType() == types::TY_MLIR_IR &&
+               "Expecting an MLIR raising action here");
+        HostAction = HostAction->getInputs().front();
+      }
+
+      // Add the host action to the list in order to create the bundling
+      // action.
       OffloadAL.push_back(HostAction);
 
       // We expect that the host action was just appended to the action list
       // before this method was called.
-      assert(HostAction == AL.back() && "Host action not in the list??");
+      assert((UseHostActionInput || HostAction == AL.back()) &&
+             "Host action not in the list??");
       HostAction = C.MakeAction<OffloadBundlingJobAction>(OffloadAL);
       recordHostAction(HostAction, InputArg);
       AL.back() = HostAction;
@@ -7728,6 +7796,10 @@ Action *Driver::ConstructPhaseAction(
               : types::TY_LLVM_BC;
       return C.MakeAction<BackendJobAction>(Input, Output);
     }
+    // We will need a compile action before to avoid compiling the host code
+    // twice in this scenario.
+    if (Args.hasArg(options::OPT_fsycl_raise_host))
+      Input = C.MakeAction<CompileJobAction>(Input, types::TY_PP_Asm);
     return C.MakeAction<BackendJobAction>(Input, types::TY_PP_Asm);
   }
   case phases::Assemble:

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -131,7 +131,8 @@ static bool shouldRaiseHost(const ArgList &Args) {
     constexpr bool Default = CLANG_ENABLE_OPAQUE_POINTERS_INTERNAL;
     return (Iter == FilteredArgs.end()) ? Default : Pos == (*Iter)->getValue();
   };
-  return Args.hasArg(options::OPT_fsycl_raise_host) && UseOpaquePointers();
+  return !Args.hasArg(options::OPT_fsyntax_only) &&
+         Args.hasArg(options::OPT_fsycl_raise_host) && UseOpaquePointers();
 }
 
 static std::optional<llvm::Triple> getOffloadTargetTriple(const Driver &D,
@@ -6327,7 +6328,8 @@ public:
     // We will need two specialized SYCL builders: one will run before host
     // compilation just to produce the device stub and other to perform the
     // actual compilation.
-    if (Args.hasArg(options::OPT_fsycl_raise_host)) {
+    if (!Args.hasArg(options::OPT_fsyntax_only) &&
+        Args.hasArg(options::OPT_fsycl_raise_host)) {
       if (shouldRaiseHost(Args)) {
         SpecializedBuilders.push_back(new SYCLActionBuilder(
             C, Args, Inputs, *this, /*OnlyCreateStubFile=*/true));

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4874,8 +4874,8 @@ class OffloadingActionBuilder final {
         if (!SYCLRaiseHost || OnlyCreateStubFile)
           DA.add(*DeviceCompilerInput, *DevTarget.TC, DevTarget.BoundArch,
                  Action::OFK_SYCL);
-        return SYCLDeviceOnly && !SYCLRaiseHost ? ABRT_Ignore_Host
-                                                : ABRT_Success;
+        return (SYCLDeviceOnly && !SYCLRaiseHost) ? ABRT_Ignore_Host
+                                                  : ABRT_Success;
       }
 
       // Backend/Assemble actions are obsolete for the SYCL device side
@@ -5114,8 +5114,8 @@ class OffloadingActionBuilder final {
     void appendTopLevelActions(ActionList &AL) override {
       // We should always have an action for each input.
       // We should always have an action for each input.
-      // If the only purpose of this builder was to create the stuff file, we
-      // can simply return.
+      // If the only purpose of this builder was to create the stub file, we can
+      // simply return.
       if (!OnlyCreateStubFile && !SYCLDeviceActions.empty()) {
         assert(SYCLDeviceActions.size() == SYCLTargetInfoList.size() &&
                "Number of SYCL actions and toolchains/boundarch pairs do not "

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -764,6 +764,8 @@ Tool *ToolChain::SelectTool(const JobAction &JA) const {
         (JA.getOffloadingToolChain() &&
          JA.getOffloadingToolChain()->getTriple().getEnvironment() ==
              llvm::Triple::SYCLMLIR)) {
+      // Compile jobs with a single LLVM input and MLIR output are handled by
+      // mlir-translate.
       const ActionList &Inputs = JA.getInputs();
       if (Inputs.size() == 1) {
         switch (Inputs.front()->getType()) {

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -341,6 +341,12 @@ Tool *ToolChain::getCgeist() const {
   return Cgeist.get();
 }
 
+Tool *ToolChain::getMLIRTranslate() const {
+  if (!MLIRTranslate)
+    MLIRTranslate.reset(new tools::MLIRTranslate(*this));
+  return MLIRTranslate.get();
+}
+
 Tool *ToolChain::getFlang() const {
   if (!Flang)
     Flang.reset(new tools::Flang(*this));
@@ -758,6 +764,16 @@ Tool *ToolChain::SelectTool(const JobAction &JA) const {
         (JA.getOffloadingToolChain() &&
          JA.getOffloadingToolChain()->getTriple().getEnvironment() ==
              llvm::Triple::SYCLMLIR)) {
+      const ActionList &Inputs = JA.getInputs();
+      if (Inputs.size() == 1) {
+        switch (Inputs.front()->getType()) {
+        case types::TY_LLVM_IR:
+        case types::TY_LLVM_BC:
+          return getMLIRTranslate();
+        default:
+          break;
+        }
+      }
       return getCgeist();
     }
     return getClang();

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7380,11 +7380,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                    false))
     CmdArgs.push_back("-fmodules-debuginfo");
 
-  // The output of this compilation will be the input to mlir-translate, which
-  // only works with opaque pointers.
-  if (Args.hasArg(options::OPT_fsycl_raise_host))
-    CmdArgs.push_back("-opaque-pointers");
-  else if (!CLANG_ENABLE_OPAQUE_POINTERS_INTERNAL)
+  if (!CLANG_ENABLE_OPAQUE_POINTERS_INTERNAL)
     CmdArgs.push_back("-no-opaque-pointers");
   else if ((Triple.isSPIRV() || Triple.isSPIR()) &&
            !SPIRV_ENABLE_OPAQUE_POINTERS)

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10209,7 +10209,7 @@ void MLIRTranslate::ConstructJob(Compilation &C, const JobAction &JA,
          "Only supporting LLVM IR to MLIR translation");
   addArgs(CmdArgs, TCArgs, {"-o", Output.getFilename()});
 
-  // Raising to MLIR is the only option accepted for now
+  // Raising from LLVM is the only option accepted for now
   addArgs(CmdArgs, TCArgs, {"--import-llvm"});
 
   // Input File

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10161,7 +10161,8 @@ void Cgeist::ConstructJob(Compilation &C, const JobAction &JA,
 
   const InputInfo *HostModule = nullptr;
   for (const InputInfo &I : Inputs) {
-    if (I.getType() == types::TY_MLIR_IR)
+    if (I.getType() == types::TY_MLIR_IR &&
+        I.getAction()->isHostOffloading(Action::OFK_SYCL))
       HostModule = &I;
     else if (I.isFilename())
       CmdArgs.push_back(I.getFilename());

--- a/clang/lib/Driver/ToolChains/Clang.h
+++ b/clang/lib/Driver/ToolChains/Clang.h
@@ -333,6 +333,24 @@ public:
                     const char *LinkingOutput) const override;
 };
 
+/// MLIRTranslate tool.
+class LLVM_LIBRARY_VISIBILITY MLIRTranslate final : public Tool {
+public:
+  MLIRTranslate(const ToolChain &TC)
+      : Tool("mlir-translate", "mlir-translate", TC) {}
+
+  bool hasGoodDiagnostics() const override { return true; }
+  bool hasIntegratedAssembler() const override { return false; }
+  bool hasIntegratedBackend() const override { return false; }
+  bool hasIntegratedCPP() const override { return false; }
+  bool canEmitIR() const override { return true; }
+
+  void ConstructJob(Compilation &C, const JobAction &JA,
+                    const InputInfo &Output, const InputInfoList &Inputs,
+                    const llvm::opt::ArgList &TCArgs,
+                    const char *LinkingOutput) const override;
+};
+
 enum class DwarfFissionKind { None, Split, Single };
 
 DwarfFissionKind getDebugFissionKind(const Driver &D,

--- a/clang/test/Driver/sycl-mlir.cpp
+++ b/clang/test/Driver/sycl-mlir.cpp
@@ -13,7 +13,7 @@
 
 // RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL             \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
-// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                               \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                      \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
 // RUN: | FileCheck -check-prefix=CHK-PHASES-LLVM-RAISE %s
 
@@ -44,7 +44,7 @@
 
 // RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL             \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
-// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                               \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                      \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-PHASES-MLIR-RAISE %s
 //
@@ -75,7 +75,7 @@
 
 // RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL             \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
-// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                               \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                      \
 // RUN: -fsycl-targets=spir64-unknown-unknown -emit-mlir %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-PHASES-MLIR-NO-TRIPLE-RAISE %s
 
@@ -103,7 +103,7 @@
 
 // RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
-// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                               \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                      \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
 // RUN: | FileCheck -check-prefix=CHK-BINDINGS-LLVM-RAISE %s
 
@@ -123,7 +123,7 @@
 // RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
-// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                               \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                      \
 // RUN: | FileCheck -check-prefix=CHK-BINDINGS-MLIR-RAISE %s
 
 // CHK-BINDINGS-MLIR-RAISE: # "spir64-unknown-unknown-syclmlir" - "cgeist", inputs: ["{{.*}}.cpp"], output: "{{.*}}.bc"
@@ -144,7 +144,7 @@
 
 // RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL      \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c                 \
-// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                          \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                 \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1     \
 // RUN: | FileCheck -check-prefix=CHK-BINDINGS-FULL-LLVM-RAISE %s
 //
@@ -168,7 +168,7 @@
 
 // RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
-// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                               \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                      \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-BINDINGS-FULL-MLIR-RAISE %s
 
@@ -187,11 +187,12 @@
 
 // RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
-// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                               \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                      \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
 // RUN: | FileCheck -check-prefix=CHK-INVOKE-LLVM-BC-RAISE %s
 //
 // CHK-INVOKE-LLVM-BC-RAISE: "{{.*}}cgeist" "-emit-llvm" "{{.*}}.cpp" "-o" "{{.*}}.bc" "--args" "-cc1"
+// CHK-INVOKE-LLVM-BC-RAISE: "{{.*}}clang{{.*}}"
 // CHK-INVOKE-LLVM-BC-RAISE: "{{.*}}mlir-translate" "-o" "{{.*}}.mlir" "--import-llvm" "{{.*}}.bc"
 // CHK-INVOKE-LLVM-BC-RAISE: "{{.*}}cgeist" "-emit-llvm" "{{.*}}.cpp" "-sycl-use-host-module" "{{.*}}.mlir"
 
@@ -204,11 +205,12 @@
 
 // RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
-// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                               \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                      \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
 // RUN: | FileCheck -check-prefix=CHK-INVOKE-LLVM-RAISE %s
 //
 // CHK-INVOKE-LLVM-RAISE: "{{.*}}cgeist" "-emit-llvm" "{{.*}}.cpp" "-o" "{{.*}}.bc"
+// CHK-INVOKE-LLVM-RAISE: "{{.*}}clang{{.*}}"
 // CHK-INVOKE-LLVM-RAISE: "{{.*}}mlir-translate" "-o" "{{.*}}.mlir" "--import-llvm" "{{.*}}.bc"
 // CHK-INVOKE-LLVM-RAISE: "{{.*}}cgeist" "-emit-llvm" "{{.*}}.cpp" "-sycl-use-host-module" "{{.*}}.mlir" "-o" "{{.*}}.bc"
 
@@ -222,11 +224,12 @@
 // RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only      \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -emit-mlir          \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s              \
-// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                              \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                     \
 // RUN: -o foo.mlir 2>&1                                               \
 // RUN: | FileCheck -check-prefix=CHK-INVOKE-MLIR-RAISE %s
 //
 // CHK-INVOKE-MLIR-RAISE: "{{.*}}cgeist" "-emit-llvm" "{{.*}}sycl-mlir.cpp" "-o" "{{.*}}.bc"
+// CHK-INVOKE-MLIR-RAISE: "{{.*}}clang{{.*}}"
 // CHK-INVOKE-MLIR-RAISE: "{{.*}}mlir-translate" "-o" "{{.*}}.mlir" "--import-llvm" "{{.*}}.bc"
 // CHK-INVOKE-MLIR-RAISE: "{{.*}}cgeist" "-S" "{{.*}}.cpp" "-sycl-use-host-module" "{{.*}}.mlir" "-o" "{{.*}}.mlir"
 
@@ -244,6 +247,7 @@
 // RUN: | FileCheck -check-prefix=CHK-INVOKE-ARG-PASS-RAISE %s
 
 // CHK-INVOKE-ARG-PASS-RAISE: "{{.*}}cgeist" "-emit-llvm" "-S" "{{.*}}.cpp" "-o" "{{.*}}.bc" "--args" "-cc1"
+// CHK-INVOKE-ARG-PASS-RAISE: "{{.*}}clang{{.*}}"
 // CHK-INVOKE-ARG-PASS-RAISE: "{{.*}}mlir-translate" "-o" "{{.*}}.mlir" "--import-llvm" "{{.*}}.bc"
 // CHK-INVOKE-ARG-PASS-RAISE:  "{{.*}}cgeist" "-emit-llvm" "-S" "{{.*}}.cpp" "-sycl-use-host-module" "{{.*}}.mlir"
 

--- a/clang/test/Driver/sycl-mlir.cpp
+++ b/clang/test/Driver/sycl-mlir.cpp
@@ -13,6 +13,27 @@
 
 // RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL             \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
+// RUN: -fsycl-raise-host                                               \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
+// RUN: | FileCheck -check-prefix=CHK-PHASES-LLVM-RAISE %s
+
+// CHK-PHASES-LLVM-RAISE: 0: input, "{{.*}}.cpp", c++, (host-sycl)
+// CHK-PHASES-LLVM-RAISE: 1: append-footer, {0}, c++, (host-sycl)
+// CHK-PHASES-LLVM-RAISE: 2: preprocessor, {1}, c++-cpp-output, (host-sycl)
+// CHK-PHASES-LLVM-RAISE: 3: input, "{{.*}}.cpp", c++, (device-sycl)
+// CHK-PHASES-LLVM-RAISE: 4: preprocessor, {3}, c++-cpp-output, (device-sycl)
+// CHK-PHASES-LLVM-RAISE: 5: compiler, {4}, ir, (device-sycl)
+// CHK-PHASES-LLVM-RAISE: 6: offload, "host-sycl (x86_64-unknown-linux-gnu)" {2}, "device-sycl (spir64-unknown-unknown-syclmlir)" {5}, c++-cpp-output
+// CHK-PHASES-LLVM-RAISE: 7: compiler, {6}, ir, (host-sycl)
+// CHK-PHASES-LLVM-RAISE: 8: compiler, {7}, mlir, (host-sycl)
+// CHK-PHASES-LLVM-RAISE: 9: input, "{{.*}}.cpp", c++, (device-sycl)
+// CHK-PHASES-LLVM-RAISE: 10: preprocessor, {9}, c++-cpp-output, (device-sycl)
+// CHK-PHASES-LLVM-RAISE: 11: offload, "host-sycl (x86_64-unknown-linux-gnu)" {8}, "device-sycl (spir64-unknown-unknown-syclmlir)" {10}, mlir
+// CHK-PHASES-LLVM-RAISE: 12: compiler, {11}, ir, (device-sycl)
+// CHK-PHASES-LLVM-RAISE: 13: offload, "device-sycl (spir64-unknown-unknown-syclmlir)" {12}, ir
+
+// RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL             \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-PHASES-MLIR %s
 //
@@ -21,6 +42,26 @@
 // CHK-PHASES-MLIR: 2: compiler, {1}, mlir, (device-sycl)
 // CHK-PHASES-MLIR: 3: offload, "device-sycl (spir64-unknown-unknown-syclmlir)" {2}, mlir
 
+// RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL             \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
+// RUN: -fsycl-raise-host                                               \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHK-PHASES-MLIR-RAISE %s
+//
+// CHK-PHASES-MLIR-RAISE: 0: input, "{{.*}}.cpp", c++, (host-sycl)
+// CHK-PHASES-MLIR-RAISE: 1: append-footer, {0}, c++, (host-sycl)
+// CHK-PHASES-MLIR-RAISE: 2: preprocessor, {1}, c++-cpp-output, (host-sycl)
+// CHK-PHASES-MLIR-RAISE: 3: input, "{{.*}}.cpp", c++, (device-sycl)
+// CHK-PHASES-MLIR-RAISE: 4: preprocessor, {3}, c++-cpp-output, (device-sycl)
+// CHK-PHASES-MLIR-RAISE: 5: compiler, {4}, ir, (device-sycl)
+// CHK-PHASES-MLIR-RAISE: 6: offload, "host-sycl (x86_64-unknown-linux-gnu)" {2}, "device-sycl (spir64-unknown-unknown-syclmlir)" {5}, c++-cpp-output
+// CHK-PHASES-MLIR-RAISE: 7: compiler, {6}, ir, (host-sycl)
+// CHK-PHASES-MLIR-RAISE: 8: compiler, {7}, mlir, (host-sycl)
+// CHK-PHASES-MLIR-RAISE: 9: input, "{{.*}}.cpp", c++, (device-sycl)
+// CHK-PHASES-MLIR-RAISE: 10: preprocessor, {9}, c++-cpp-output, (device-sycl)
+// CHK-PHASES-MLIR-RAISE: 11: offload, "host-sycl (x86_64-unknown-linux-gnu)" {8}, "device-sycl (spir64-unknown-unknown-syclmlir)" {10}, mlir
+// CHK-PHASES-MLIR-RAISE: 12: compiler, {11}, mlir, (device-sycl)
+// CHK-PHASES-MLIR-RAISE: 13: offload, "device-sycl (spir64-unknown-unknown-syclmlir)" {12}, mlir
 
 // RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL             \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
@@ -32,6 +73,27 @@
 // CHK-PHASES-MLIR-NO-TRIPLE: 2: compiler, {1}, mlir, (device-sycl)
 // CHK-PHASES-MLIR-NO-TRIPLE: 3: offload, "device-sycl (spir64-unknown-unknown)" {2}, mlir
 
+// RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL             \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
+// RUN: -fsycl-raise-host                                               \
+// RUN: -fsycl-targets=spir64-unknown-unknown -emit-mlir %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHK-PHASES-MLIR-NO-TRIPLE-RAISE %s
+
+// CHK-PHASES-MLIR-NO-TRIPLE-RAISE: 0: input, "{{.*}}.cpp", c++, (host-sycl)
+// CHK-PHASES-MLIR-NO-TRIPLE-RAISE: 1: append-footer, {0}, c++, (host-sycl)
+// CHK-PHASES-MLIR-NO-TRIPLE-RAISE: 2: preprocessor, {1}, c++-cpp-output, (host-sycl)
+// CHK-PHASES-MLIR-NO-TRIPLE-RAISE: 3: input, "{{.*}}.cpp", c++, (device-sycl)
+// CHK-PHASES-MLIR-NO-TRIPLE-RAISE: 4: preprocessor, {3}, c++-cpp-output, (device-sycl)
+// CHK-PHASES-MLIR-NO-TRIPLE-RAISE: 5: compiler, {4}, ir, (device-sycl)
+// CHK-PHASES-MLIR-NO-TRIPLE-RAISE: 6: offload, "host-sycl (x86_64-unknown-linux-gnu)" {2}, "device-sycl (spir64-unknown-unknown)" {5}, c++-cpp-output
+// CHK-PHASES-MLIR-NO-TRIPLE-RAISE: 7: compiler, {6}, ir, (host-sycl)
+// CHK-PHASES-MLIR-NO-TRIPLE-RAISE: 8: compiler, {7}, mlir, (host-sycl)
+// CHK-PHASES-MLIR-NO-TRIPLE-RAISE: 9: input, "{{.*}}.cpp", c++, (device-sycl)
+// CHK-PHASES-MLIR-NO-TRIPLE-RAISE: 10: preprocessor, {9}, c++-cpp-output, (device-sycl)
+// CHK-PHASES-MLIR-NO-TRIPLE-RAISE: 11: offload, "host-sycl (x86_64-unknown-linux-gnu)" {8}, "device-sycl (spir64-unknown-unknown)" {10}, mlir
+// CHK-PHASES-MLIR-NO-TRIPLE-RAISE: 12: compiler, {11}, mlir, (device-sycl)
+// CHK-PHASES-MLIR-NO-TRIPLE-RAISE: 13: offload, "device-sycl (spir64-unknown-unknown)" {12}, mlir
+
 // RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
@@ -41,25 +103,80 @@
 
 // RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
+// RUN: -fsycl-raise-host                                               \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
+// RUN: | FileCheck -check-prefix=CHK-BINDINGS-LLVM-RAISE %s
+
+// CHK-BINDINGS-LLVM-RAISE: # "spir64-unknown-unknown-syclmlir" - "cgeist", inputs: ["{{.*}}.cpp"], output: "{{.*}}.bc"
+// CHK-BINDINGS-LLVM-RAISE: # "x86_64-unknown-linux-gnu" - "Append Footer to source", inputs: ["{{.*}}.cpp"], output: "{{.*}}.cpp"
+// CHK-BINDINGS-LLVM-RAISE: # "x86_64-unknown-linux-gnu" - "clang", inputs: ["{{.*}}.cpp", "{{.*}}.bc"], output: "{{.*}}.bc"
+// CHK-BINDINGS-LLVM-RAISE: # "x86_64-unknown-linux-gnu" - "mlir-translate", inputs: ["{{.*}}.bc"], output: "{{.*}}.mlir"
+// CHK-BINDINGS-LLVM-RAISE: # "spir64-unknown-unknown-syclmlir" - "cgeist", inputs: ["{{.*}}.cpp", "{{.*}}.mlir"], output: "sycl-mlir-sycl-spir64-unknown-unknown-syclmlir.bc"
+
+// RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-BINDINGS-MLIR %s
 //
 // CHK-BINDINGS-MLIR: # "spir64-unknown-unknown-syclmlir" - "cgeist", inputs: ["{{.*}}.cpp"], output: "{{.*}}.mlir"
+
+// RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
+// RUN: -fsycl-raise-host                                               \
+// RUN: | FileCheck -check-prefix=CHK-BINDINGS-MLIR-RAISE %s
+
+// CHK-BINDINGS-MLIR-RAISE: # "spir64-unknown-unknown-syclmlir" - "cgeist", inputs: ["{{.*}}.cpp"], output: "{{.*}}.bc"
+// CHK-BINDINGS-MLIR-RAISE: # "x86_64-unknown-linux-gnu" - "Append Footer to source", inputs: ["{{.*}}.cpp"], output: "{{.*}}.cpp"
+// CHK-BINDINGS-MLIR-RAISE: # "x86_64-unknown-linux-gnu" - "clang", inputs: ["{{.*}}.cpp", "{{.*}}.bc"], output: "{{.*}}.bc"
+// CHK-BINDINGS-MLIR-RAISE: # "x86_64-unknown-linux-gnu" - "mlir-translate", inputs: ["{{.*}}.bc"], output: "{{.*}}.mlir"
+// CHK-BINDINGS-MLIR-RAISE: # "spir64-unknown-unknown-syclmlir" - "cgeist", inputs: ["{{.*}}.cpp", "{{.*}}.mlir"], output: "sycl-mlir-sycl-spir64-unknown-unknown-syclmlir.mlir"
 
 // RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL      \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c                 \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1     \
 // RUN: | FileCheck -check-prefix=CHK-BINDINGS-FULL-LLVM %s
 //
-// RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
-// RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
-// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
-// RUN: | FileCheck -check-prefix=CHK-BINDINGS-FULL-LLVM %s
-//
 // CHK-BINDINGS-FULL-LLVM: # "spir64-unknown-unknown-syclmlir" - "cgeist", inputs: ["{{.*}}.cpp"], output: "{{.*}}.bc"
 // CHK-BINDINGS-FULL-LLVM: # "x86_64-unknown-linux-gnu" - "Append Footer to source", inputs: ["{{.*}}.cpp"], output: "{{.*}}.cpp"
 // CHK-BINDINGS-FULL-LLVM: # "x86_64-unknown-linux-gnu" - "clang", inputs: ["{{.*}}.cpp", "{{.*}}.bc"], output: "{{.*}}.o"
 // CHK-BINDINGS-FULL-LLVM: # "x86_64-unknown-linux-gnu" - "offload bundler", inputs: ["{{.*}}.bc", "{{.*}}.o"], output: "{{.*}}.o"
+
+// RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL      \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c                 \
+// RUN: -fsycl-raise-host                                          \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1     \
+// RUN: | FileCheck -check-prefix=CHK-BINDINGS-FULL-LLVM-RAISE %s
+//
+// CHK-BINDINGS-FULL-LLVM-RAISE: # "spir64-unknown-unknown-syclmlir" - "cgeist", inputs: ["{{.*}}.cpp"], output: "{{.*}}.bc"
+// CHK-BINDINGS-FULL-LLVM-RAISE: # "x86_64-unknown-linux-gnu" - "Append Footer to source", inputs: ["{{.*}}.cpp"], output: "{{.*}}.cpp"
+// CHK-BINDINGS-FULL-LLVM-RAISE: # "x86_64-unknown-linux-gnu" - "clang", inputs: ["{{.*}}.cpp", "{{.*}}.bc"], output: "{{.*}}.bc"
+// CHK-BINDINGS-FULL-LLVM-RAISE: # "x86_64-unknown-linux-gnu" - "mlir-translate", inputs: ["{{.*}}.bc"], output: "{{.*}}.mlir"
+// CHK-BINDINGS-FULL-LLVM-RAISE: # "spir64-unknown-unknown-syclmlir" - "cgeist", inputs: ["{{.*}}.cpp", "{{.*}}.mlir"], output: "{{.*}}.bc"
+// CHK-BINDINGS-FULL-LLVM-RAISE: # "x86_64-unknown-linux-gnu" - "clang", inputs: ["{{.*}}.bc"], output: "{{.*}}.o"
+// CHK-BINDINGS-FULL-LLVM-RAISE: # "x86_64-unknown-linux-gnu" - "offload bundler", inputs: ["{{.*}}.bc", "{{.*}}.o"], output: "sycl-mlir.o"
+
+// RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHK-BINDINGS-FULL-MLIR %s
+
+// CHK-BINDINGS-FULL-MLIR: # "spir64-unknown-unknown-syclmlir" - "cgeist", inputs: ["{{.*}}.cpp"], output: "{{.*}}.mlir"
+// CHK-BINDINGS-FULL-MLIR: # "x86_64-unknown-linux-gnu" - "Append Footer to source", inputs: ["{{.*}}.cpp"], output: "{{.*}}.cpp"
+// CHK-BINDINGS-FULL-MLIR: # "x86_64-unknown-linux-gnu" - "clang", inputs: ["{{.*}}.cpp", "{{.*}}.mlir"], output: "{{.*}}.o"
+// CHK-BINDINGS-FULL-MLIR: # "x86_64-unknown-linux-gnu" - "offload bundler", inputs: ["{{.*}}.mlir", "{{.*}}.o"], output: "sycl-mlir.o"
+
+// RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
+// RUN: -fsycl-raise-host                                               \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHK-BINDINGS-FULL-MLIR-RAISE %s
+
+// CHK-BINDINGS-FULL-MLIR-RAISE: # "spir64-unknown-unknown-syclmlir" - "cgeist", inputs: ["{{.*}}.cpp"], output: "{{.*}}.bc"
+// CHK-BINDINGS-FULL-MLIR-RAISE: # "x86_64-unknown-linux-gnu" - "Append Footer to source", inputs: ["{{.*}}.cpp"], output: "{{.*}}.cpp"
+// CHK-BINDINGS-FULL-MLIR-RAISE: # "x86_64-unknown-linux-gnu" - "clang", inputs: ["{{.*}}.cpp", "{{.*}}.bc"], output: "{{.*}}.bc"
+// CHK-BINDINGS-FULL-MLIR-RAISE: # "x86_64-unknown-linux-gnu" - "mlir-translate", inputs: ["{{.*}}.bc"], output: "{{.*}}.mlir"
+// CHK-BINDINGS-FULL-MLIR-RAISE: # "spir64-unknown-unknown-syclmlir" - "cgeist", inputs: ["{{.*}}.cpp", "{{.*}}.mlir"], output: "sycl-mlir-sycl-spir64-unknown-unknown-syclmlir.mlir"
 
 // RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
@@ -69,11 +186,31 @@
 // CHK-INVOKE-LLVM-BC: "{{.*}}cgeist" "-emit-llvm" "{{.*}}.cpp" "-o" "{{.*}}.bc" "--args" "-cc1"
 
 // RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
+// RUN: -fsycl-raise-host                                               \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
+// RUN: | FileCheck -check-prefix=CHK-INVOKE-LLVM-BC-RAISE %s
+//
+// CHK-INVOKE-LLVM-BC-RAISE: "{{.*}}cgeist" "-emit-llvm" "{{.*}}.cpp" "-o" "{{.*}}.bc" "--args" "-cc1"
+// CHK-INVOKE-LLVM-BC-RAISE: "{{.*}}mlir-translate" "-o" "{{.*}}.mlir" "--import-llvm" "{{.*}}.bc"
+// CHK-INVOKE-LLVM-BC-RAISE: "{{.*}}cgeist" "-emit-llvm" "{{.*}}.cpp" "-sycl-use-host-module" "{{.*}}.mlir"
+
+// RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c  -S -emit-llvm       \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
 // RUN: | FileCheck -check-prefix=CHK-INVOKE-LLVM %s
 //
 // CHK-INVOKE-LLVM: "{{.*}}cgeist" "-emit-llvm" "-S" "{{.*}}.cpp" "-o" "{{.*}}.ll" "--args" "-cc1"
+
+// RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
+// RUN: -fsycl-raise-host                                               \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
+// RUN: | FileCheck -check-prefix=CHK-INVOKE-LLVM-RAISE %s
+//
+// CHK-INVOKE-LLVM-RAISE: "{{.*}}cgeist" "-emit-llvm" "{{.*}}.cpp" "-o" "{{.*}}.bc"
+// CHK-INVOKE-LLVM-RAISE: "{{.*}}mlir-translate" "-o" "{{.*}}.mlir" "--import-llvm" "{{.*}}.bc"
+// CHK-INVOKE-LLVM-RAISE: "{{.*}}cgeist" "-emit-llvm" "{{.*}}.cpp" "-sycl-use-host-module" "{{.*}}.mlir" "-o" "{{.*}}.bc"
 
 // RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only      \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -emit-mlir          \
@@ -85,10 +222,13 @@
 // RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only      \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -emit-mlir          \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s              \
+// RUN: -fsycl-raise-host                                              \
 // RUN: -o foo.mlir 2>&1                                               \
-// RUN: | FileCheck -check-prefix=CHK-INVOKE-MLIR %s
+// RUN: | FileCheck -check-prefix=CHK-INVOKE-MLIR-RAISE %s
 //
-// CHK-INVOKE-MLIR-O: "{{.*}}cgeist" "-S" "{{.*}}.cpp" "-o" "foo.mlir" "--args" "-cc1"
+// CHK-INVOKE-MLIR-RAISE: "{{.*}}cgeist" "-emit-llvm" "{{.*}}sycl-mlir.cpp" "-o" "{{.*}}.bc"
+// CHK-INVOKE-MLIR-RAISE: "{{.*}}mlir-translate" "-o" "{{.*}}.mlir" "--import-llvm" "{{.*}}.bc"
+// CHK-INVOKE-MLIR-RAISE: "{{.*}}cgeist" "-S" "{{.*}}.cpp" "-sycl-use-host-module" "{{.*}}.mlir" "-o" "{{.*}}.mlir"
 
 // RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -Xcgeist -S          \
@@ -96,3 +236,13 @@
 // RUN: | FileCheck -check-prefix=CHK-INVOKE-ARG-PASS %s
 //
 // CHK-INVOKE-ARG-PASS: "{{.*}}cgeist" "-emit-llvm" "-S" "{{.*}}.cpp" "-o" "{{.*}}.bc" "--args" "-cc1"
+
+// RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c -Xcgeist -S          \
+// RUN: -fsycl-raise-host                                               \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
+// RUN: | FileCheck -check-prefix=CHK-INVOKE-ARG-PASS-RAISE %s
+
+// CHK-INVOKE-ARG-PASS-RAISE: "{{.*}}cgeist" "-emit-llvm" "-S" "{{.*}}.cpp" "-o" "{{.*}}.bc" "--args" "-cc1"
+// CHK-INVOKE-ARG-PASS-RAISE: "{{.*}}mlir-translate" "-o" "{{.*}}.mlir" "--import-llvm" "{{.*}}.bc"
+// CHK-INVOKE-ARG-PASS-RAISE:  "{{.*}}cgeist" "-emit-llvm" "-S" "{{.*}}.cpp" "-sycl-use-host-module" "{{.*}}.mlir"

--- a/clang/test/Driver/sycl-mlir.cpp
+++ b/clang/test/Driver/sycl-mlir.cpp
@@ -13,7 +13,7 @@
 
 // RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL             \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
-// RUN: -fsycl-raise-host                                               \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                               \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
 // RUN: | FileCheck -check-prefix=CHK-PHASES-LLVM-RAISE %s
 
@@ -44,7 +44,7 @@
 
 // RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL             \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
-// RUN: -fsycl-raise-host                                               \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                               \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-PHASES-MLIR-RAISE %s
 //
@@ -75,7 +75,7 @@
 
 // RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL             \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
-// RUN: -fsycl-raise-host                                               \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                               \
 // RUN: -fsycl-targets=spir64-unknown-unknown -emit-mlir %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-PHASES-MLIR-NO-TRIPLE-RAISE %s
 
@@ -103,7 +103,7 @@
 
 // RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
-// RUN: -fsycl-raise-host                                               \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                               \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
 // RUN: | FileCheck -check-prefix=CHK-BINDINGS-LLVM-RAISE %s
 
@@ -123,7 +123,7 @@
 // RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
-// RUN: -fsycl-raise-host                                               \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                               \
 // RUN: | FileCheck -check-prefix=CHK-BINDINGS-MLIR-RAISE %s
 
 // CHK-BINDINGS-MLIR-RAISE: # "spir64-unknown-unknown-syclmlir" - "cgeist", inputs: ["{{.*}}.cpp"], output: "{{.*}}.bc"
@@ -144,7 +144,7 @@
 
 // RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL      \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c                 \
-// RUN: -fsycl-raise-host                                          \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                          \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1     \
 // RUN: | FileCheck -check-prefix=CHK-BINDINGS-FULL-LLVM-RAISE %s
 //
@@ -168,7 +168,7 @@
 
 // RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
-// RUN: -fsycl-raise-host                                               \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                               \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-BINDINGS-FULL-MLIR-RAISE %s
 
@@ -187,7 +187,7 @@
 
 // RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
-// RUN: -fsycl-raise-host                                               \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                               \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
 // RUN: | FileCheck -check-prefix=CHK-INVOKE-LLVM-BC-RAISE %s
 //
@@ -204,7 +204,7 @@
 
 // RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
-// RUN: -fsycl-raise-host                                               \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                               \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
 // RUN: | FileCheck -check-prefix=CHK-INVOKE-LLVM-RAISE %s
 //
@@ -222,7 +222,7 @@
 // RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only      \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -emit-mlir          \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s              \
-// RUN: -fsycl-raise-host                                              \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                              \
 // RUN: -o foo.mlir 2>&1                                               \
 // RUN: | FileCheck -check-prefix=CHK-INVOKE-MLIR-RAISE %s
 //
@@ -239,10 +239,18 @@
 
 // RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -Xcgeist -S          \
-// RUN: -fsycl-raise-host                                               \
+// RUN: -fsycl-raise-host -Xclang -opaque-pointers                                               \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
 // RUN: | FileCheck -check-prefix=CHK-INVOKE-ARG-PASS-RAISE %s
 
 // CHK-INVOKE-ARG-PASS-RAISE: "{{.*}}cgeist" "-emit-llvm" "-S" "{{.*}}.cpp" "-o" "{{.*}}.bc" "--args" "-cc1"
 // CHK-INVOKE-ARG-PASS-RAISE: "{{.*}}mlir-translate" "-o" "{{.*}}.mlir" "--import-llvm" "{{.*}}.bc"
 // CHK-INVOKE-ARG-PASS-RAISE:  "{{.*}}cgeist" "-emit-llvm" "-S" "{{.*}}.cpp" "-sycl-use-host-module" "{{.*}}.mlir"
+
+// RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c -Xcgeist -S          \
+// RUN: -fsycl-raise-host -Xclang -no-opaque-pointers                   \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
+// RUN: | FileCheck -check-prefix=CHK-RAISE-TYPED-PTR %s
+
+// CHK-RAISE-TYPED-PTR: error: invalid argument '-fsycl-raise-host' only allowed with '-Xclang -opaque-pointers'

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -2669,7 +2669,6 @@ public:
       : Module(Module), ModuleId(ModuleId) {
     EmitIfFound.insert(Fn);
   }
-  bool hasIRSupport() const final { return true; }
   std::unique_ptr<clang::ASTConsumer>
   CreateASTConsumer(clang::CompilerInstance &CI, StringRef InFile) override {
     return std::unique_ptr<clang::ASTConsumer>(new MLIRASTConsumer(

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -2669,6 +2669,7 @@ public:
       : Module(Module), ModuleId(ModuleId) {
     EmitIfFound.insert(Fn);
   }
+  bool hasIRSupport() const final { return true; }
   std::unique_ptr<clang::ASTConsumer>
   CreateASTConsumer(clang::CompilerInstance &CI, StringRef InFile) override {
     return std::unique_ptr<clang::ASTConsumer>(new MLIRASTConsumer(

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -316,7 +316,9 @@ static LogicalResult canonicalize(mlir::MLIRContext &Ctx,
   OptPM.addPass(polygeist::createRemoveTrivialUsePass());
   OptPM.addPass(polygeist::createMem2RegPass());
   OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
-  OptPM.addPass(polygeist::createLoopRestructurePass());
+  // FIXME: This is causing infinite recursion on host code.
+  if (SYCLUseHostModule == "")
+    OptPM.addPass(polygeist::createLoopRestructurePass());
   OptPM.addPass(polygeist::createReplaceAffineCFGPass());
   OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
   if (EnableLICM)


### PR DESCRIPTION
Modify driver behavior so that, if this option is found, the host code will always be compiled and raised to MLIR. Then, cgeist will receive this MLIR module as an argument via the `-sycl-use-host-module` option.

When this option is passed, two SYCL compilations are needed: one to generate the stub file to perform host compilation and another one to perform the actual device compilation (which will receive the host code as an input in MLIR format). The former one will only produce an LLVM module, so it will not be used to generate the final output.

For the device compilation to receive the host module as an input, we need to:
- Drop the regular compilation from the pipeline and add a new one which will receive both the regular input and the raised host module. This will be generated using the new `MLIRTranslate` tool.
- As the whole compilation pipeline will change if the new option is passed, the offloading should take care of it, so the host code should still be discarded if `-fsycl-device-only` is passed at this stage.
- If `-fsycl-device-only` is passed, `-sycl-device-only` will be passed to `cgeist`.
- If the host action expects an ASM output, the pipeline will be changed to avoid compiling the host twice:
  - An additional compile action with `Asm` output is inserted so that we compile the host code to LLVM bytecode and run two tools on this output: 1. `mlir-translate`, to raise to MLIR; 2. `clang` to produce the object file for the host.

![2023-05-08-host-compilation-flow-3(1)](https://github.com/intel/llvm/assets/22130075/d3ffd405-5488-4e00-958e-ef3518f6af15)
