### PR TITLE
[SYCL][Test E2E] Add missing legacy image requirements

### DIFF
--- a/sycl/test-e2e/Plugin/interop-level-zero-image-get-native-mem.cpp
+++ b/sycl/test-e2e/Plugin/interop-level-zero-image-get-native-mem.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, level_zero_dev_kit
+// REQUIRES: level_zero, level_zero_dev_kit, aspect-ext_intel_legacy_image
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: %{run} %t.out 2>&1 | FileCheck %s
 

--- a/sycl/test-e2e/Plugin/interop-level-zero-image-ownership.cpp
+++ b/sycl/test-e2e/Plugin/interop-level-zero-image-ownership.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, level_zero_dev_kit
+// REQUIRES: level_zero, level_zero_dev_kit, aspect-ext_intel_legacy_image
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: env ZE_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s
 

--- a/sycl/test-e2e/Plugin/interop-level-zero-image.cpp
+++ b/sycl/test-e2e/Plugin/interop-level-zero-image.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero, level_zero_dev_kit
+// REQUIRES: level_zero, level_zero_dev_kit, aspect-ext_intel_legacy_image
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
The interop-level-zero-image E2E tests uses SYCL 1.2.1 images but do not require the aspects correctly. This commit adds this requirement.