### PR TITLE
[SYCL-MLIR] Support opaque pointers in cgeist LLVM IR output

### DIFF
--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm.mlir
@@ -34,7 +34,7 @@ module attributes {gpu.container_module} {
     // CHECK-DAG:         %[[VAL_8:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT:        %[[VAL_10:.*]] = llvm.extractelement %[[VAL_1]]{{\[}}%[[VAL_9]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_6]][0, 0, 0, %[[VAL_8]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+    // CHECK-NEXT:        %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_6]][0, 0, 0, %[[VAL_8]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.1", {{.*}}>
     // CHECK-NEXT:        %[[VAL_12:.*]] = llvm.getelementptr %[[VAL_11]]{{\[}}%[[VAL_7]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
     // CHECK-NEXT:        llvm.store %[[VAL_10]], %[[VAL_12]] : i64, !llvm.ptr
     // CHECK-NEXT:        %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_6]]{{\[}}%[[VAL_7]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.1", {{.*}}>
@@ -58,13 +58,13 @@ module attributes {gpu.container_module} {
     // CHECK-DAG:         %[[VAL_40:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_41:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-NEXT:        %[[VAL_42:.*]] = llvm.extractelement %[[VAL_33]]{{\[}}%[[VAL_41]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_43:.*]] = llvm.getelementptr inbounds %[[VAL_38]][0, 0, 0, %[[VAL_40]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+    // CHECK-NEXT:        %[[VAL_43:.*]] = llvm.getelementptr inbounds %[[VAL_38]][0, 0, 0, %[[VAL_40]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", {{.*}}>
     // CHECK-NEXT:        %[[VAL_44:.*]] = llvm.getelementptr %[[VAL_43]]{{\[}}%[[VAL_39]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
     // CHECK-NEXT:        llvm.store %[[VAL_42]], %[[VAL_44]] : i64, !llvm.ptr
     // CHECK-DAG:         %[[VAL_45:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-DAG:         %[[VAL_46:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT:        %[[VAL_47:.*]] = llvm.extractelement %[[VAL_33]]{{\[}}%[[VAL_46]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_48:.*]] = llvm.getelementptr inbounds %[[VAL_38]][0, 0, 0, %[[VAL_45]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+    // CHECK-NEXT:        %[[VAL_48:.*]] = llvm.getelementptr inbounds %[[VAL_38]][0, 0, 0, %[[VAL_45]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", {{.*}}>
     // CHECK-NEXT:        %[[VAL_49:.*]] = llvm.getelementptr %[[VAL_48]]{{\[}}%[[VAL_39]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
     // CHECK-NEXT:        llvm.store %[[VAL_47]], %[[VAL_49]] : i64, !llvm.ptr
     // CHECK-NEXT:        %[[VAL_50:.*]] = llvm.getelementptr %[[VAL_38]]{{\[}}%[[VAL_39]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", {{.*}}>
@@ -88,19 +88,19 @@ module attributes {gpu.container_module} {
     // CHECK-DAG:         %[[VAL_77:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_78:.*]] = llvm.mlir.constant(2 : i32) : i32
     // CHECK-NEXT:        %[[VAL_79:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_78]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_80:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_77]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+    // CHECK-NEXT:        %[[VAL_80:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_77]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
     // CHECK-NEXT:        %[[VAL_81:.*]] = llvm.getelementptr %[[VAL_80]]{{\[}}%[[VAL_76]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
     // CHECK-NEXT:        llvm.store %[[VAL_79]], %[[VAL_81]] : i64, !llvm.ptr
     // CHECK-DAG:         %[[VAL_82:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-DAG:         %[[VAL_83:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-NEXT:        %[[VAL_84:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_83]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_85:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_82]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+    // CHECK-NEXT:        %[[VAL_85:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_82]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
     // CHECK-NEXT:        %[[VAL_86:.*]] = llvm.getelementptr %[[VAL_85]]{{\[}}%[[VAL_76]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
     // CHECK-NEXT:        llvm.store %[[VAL_84]], %[[VAL_86]] : i64, !llvm.ptr
     // CHECK-DAG:         %[[VAL_87:.*]] = llvm.mlir.constant(2 : i32) : i32
     // CHECK-DAG:         %[[VAL_88:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT:        %[[VAL_89:.*]] = llvm.extractelement %[[VAL_70]]{{\[}}%[[VAL_88]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_90:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_87]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+    // CHECK-NEXT:        %[[VAL_90:.*]] = llvm.getelementptr inbounds %[[VAL_75]][0, 0, 0, %[[VAL_87]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
     // CHECK-NEXT:        %[[VAL_91:.*]] = llvm.getelementptr %[[VAL_90]]{{\[}}%[[VAL_76]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
     // CHECK-NEXT:        llvm.store %[[VAL_89]], %[[VAL_91]] : i64, !llvm.ptr
     // CHECK-NEXT:        %[[VAL_92:.*]] = llvm.getelementptr %[[VAL_75]]{{\[}}%[[VAL_76]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
@@ -124,19 +124,19 @@ module attributes {gpu.container_module} {
     // CHECK-DAG:         %[[VAL_119:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_120:.*]] = llvm.mlir.constant(2 : i32) : i32
     // CHECK-NEXT:        %[[VAL_121:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_120]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_122:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_119]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+    // CHECK-NEXT:        %[[VAL_122:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_119]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.3", {{.*}}>
     // CHECK-NEXT:        %[[VAL_123:.*]] = llvm.getelementptr %[[VAL_122]]{{\[}}%[[VAL_118]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
     // CHECK-NEXT:        llvm.store %[[VAL_121]], %[[VAL_123]] : i64, !llvm.ptr
     // CHECK-DAG:         %[[VAL_124:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-DAG:         %[[VAL_125:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-NEXT:        %[[VAL_126:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_125]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_127:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_124]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+    // CHECK-NEXT:        %[[VAL_127:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_124]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.3", {{.*}}>
     // CHECK-NEXT:        %[[VAL_128:.*]] = llvm.getelementptr %[[VAL_127]]{{\[}}%[[VAL_118]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
     // CHECK-NEXT:        llvm.store %[[VAL_126]], %[[VAL_128]] : i64, !llvm.ptr
     // CHECK-DAG:         %[[VAL_129:.*]] = llvm.mlir.constant(2 : i32) : i32
     // CHECK-DAG:         %[[VAL_130:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT:        %[[VAL_131:.*]] = llvm.extractelement %[[VAL_112]]{{\[}}%[[VAL_130]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_132:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_129]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+    // CHECK-NEXT:        %[[VAL_132:.*]] = llvm.getelementptr inbounds %[[VAL_117]][0, 0, 0, %[[VAL_129]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.3", {{.*}}>
     // CHECK-NEXT:        %[[VAL_133:.*]] = llvm.getelementptr %[[VAL_132]]{{\[}}%[[VAL_118]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
     // CHECK-NEXT:        llvm.store %[[VAL_131]], %[[VAL_133]] : i64, !llvm.ptr
     // CHECK-NEXT:        %[[VAL_134:.*]] = llvm.getelementptr %[[VAL_117]]{{\[}}%[[VAL_118]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.3", {{.*}}>
@@ -160,7 +160,7 @@ module attributes {gpu.container_module} {
     // CHECK-DAG:         %[[VAL_161:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_162:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT:        %[[VAL_163:.*]] = llvm.extractelement %[[VAL_154]]{{\[}}%[[VAL_162]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_164:.*]] = llvm.getelementptr inbounds %[[VAL_159]][0, 0, 0, %[[VAL_161]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+    // CHECK-NEXT:        %[[VAL_164:.*]] = llvm.getelementptr inbounds %[[VAL_159]][0, 0, 0, %[[VAL_161]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
     // CHECK-NEXT:        %[[VAL_165:.*]] = llvm.getelementptr %[[VAL_164]]{{\[}}%[[VAL_160]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
     // CHECK-NEXT:        llvm.store %[[VAL_163]], %[[VAL_165]] : i64, !llvm.ptr
     // CHECK-NEXT:        %[[VAL_166:.*]] = llvm.getelementptr %[[VAL_159]]{{\[}}%[[VAL_160]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
@@ -214,7 +214,7 @@ module attributes {gpu.container_module} {
     // CHECK-DAG:         %[[VAL_202:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_203:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT:        %[[VAL_204:.*]] = llvm.extractelement %[[VAL_195]]{{\[}}%[[VAL_203]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_205:.*]] = llvm.getelementptr inbounds %[[VAL_200]][0, 0, 0, %[[VAL_202]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+    // CHECK-NEXT:        %[[VAL_205:.*]] = llvm.getelementptr inbounds %[[VAL_200]][0, 0, 0, %[[VAL_202]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
     // CHECK-NEXT:        %[[VAL_206:.*]] = llvm.getelementptr %[[VAL_205]]{{\[}}%[[VAL_201]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
     // CHECK-NEXT:        llvm.store %[[VAL_204]], %[[VAL_206]] : i64, !llvm.ptr
     // CHECK-NEXT:        %[[VAL_207:.*]] = llvm.getelementptr %[[VAL_200]]{{\[}}%[[VAL_201]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
@@ -238,13 +238,13 @@ module attributes {gpu.container_module} {
     // CHECK-DAG:         %[[VAL_234:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_235:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-NEXT:        %[[VAL_236:.*]] = llvm.extractelement %[[VAL_227]]{{\[}}%[[VAL_235]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_237:.*]] = llvm.getelementptr inbounds %[[VAL_232]][0, 0, 0, %[[VAL_234]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+    // CHECK-NEXT:        %[[VAL_237:.*]] = llvm.getelementptr inbounds %[[VAL_232]][0, 0, 0, %[[VAL_234]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.2", {{.*}}>
     // CHECK-NEXT:        %[[VAL_238:.*]] = llvm.getelementptr %[[VAL_237]]{{\[}}%[[VAL_233]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
     // CHECK-NEXT:        llvm.store %[[VAL_236]], %[[VAL_238]] : i64, !llvm.ptr
     // CHECK-DAG:         %[[VAL_239:.*]] = llvm.mlir.constant(1 : i32) : i32
     // CHECK-DAG:         %[[VAL_240:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-NEXT:        %[[VAL_241:.*]] = llvm.extractelement %[[VAL_227]]{{\[}}%[[VAL_240]] : i32] : vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_242:.*]] = llvm.getelementptr inbounds %[[VAL_232]][0, 0, 0, %[[VAL_239]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+    // CHECK-NEXT:        %[[VAL_242:.*]] = llvm.getelementptr inbounds %[[VAL_232]][0, 0, 0, %[[VAL_239]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.2", {{.*}}>
     // CHECK-NEXT:        %[[VAL_243:.*]] = llvm.getelementptr %[[VAL_242]]{{\[}}%[[VAL_233]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
     // CHECK-NEXT:        llvm.store %[[VAL_241]], %[[VAL_243]] : i64, !llvm.ptr
     // CHECK-NEXT:        %[[VAL_244:.*]] = llvm.getelementptr %[[VAL_232]]{{\[}}%[[VAL_233]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.2", {{.*}}>

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-flat-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-flat-to-llvm.mlir
@@ -10,7 +10,7 @@
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> !llvm.ptr<4> {
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.addrspacecast %[[VAL_0]] : !llvm.ptr to !llvm.ptr<4>
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, %[[VAL_1]]] : (!llvm.ptr<4>, i32) -> !llvm.ptr<4>, i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, %[[VAL_1]]] : (!llvm.ptr<4>, i32) -> !llvm.ptr<4>, !llvm.struct<"class.sycl::_V1::range.3", {{.*}}>
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : !llvm.ptr<4>
 // CHECK-NEXT:    }
 func.func @test(%range: memref<?x!sycl_range_3_>, %idx: i32) -> memref<?xi64, 4> {
@@ -30,7 +30,7 @@ func.func @test(%range: memref<?x!sycl_range_3_>, %idx: i32) -> memref<?xi64, 4>
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> !llvm.ptr<4> {
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.addrspacecast %[[VAL_0]] : !llvm.ptr to !llvm.ptr<4>
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, %[[VAL_1]]] : (!llvm.ptr<4>, i32) -> !llvm.ptr<4>, i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, %[[VAL_1]]] : (!llvm.ptr<4>, i32) -> !llvm.ptr<4>, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : !llvm.ptr<4>
 // CHECK-NEXT:    }
 func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> memref<?xi64, 4> {
@@ -52,7 +52,7 @@ func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> memref<?xi64, 4> {
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                    %[[VAL_1:.*]]: i64) -> !llvm.ptr<4> {
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_1_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.1", {{.*}}>
 // CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> !llvm.ptr<1>
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_3]][%[[VAL_1]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      %[[VAL_5:.*]] = llvm.addrspacecast %[[VAL_4]] : !llvm.ptr<1> to !llvm.ptr<4>
@@ -86,13 +86,13 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: i64) -> memref
 // CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                      %[[VAL_1:.*]]: !llvm.ptr) -> !llvm.ptr<4> {
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_1_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.1", {{.*}}>
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr,  !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]] : i64
 // CHECK-NEXT:      %[[VAL_8:.*]] = llvm.add %[[VAL_7]], %[[VAL_6]] : i64
-// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_1_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.1", {{.*}}>
 // CHECK-NEXT:      %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr -> !llvm.ptr<1>
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_10]][%[[VAL_8]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>
 // CHECK-NEXT:      %[[VAL_12:.*]] = llvm.addrspacecast %[[VAL_11]] : !llvm.ptr<1> to !llvm.ptr<4>
@@ -107,19 +107,19 @@ func.func @test_1(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                      %[[VAL_1:.*]]: !llvm.ptr) -> !llvm.ptr<4> {
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_2_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.2", {{.*}}>
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", {{.*}}>
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]] : i64
 // CHECK-NEXT:      %[[VAL_8:.*]] = llvm.add %[[VAL_7]], %[[VAL_6]] : i64
-// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_2_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.2", {{.*}}>
 // CHECK-NEXT:      %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", {{.*}}>
 // CHECK-NEXT:      %[[VAL_12:.*]] = llvm.load %[[VAL_11]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_13:.*]] = llvm.mul %[[VAL_8]], %[[VAL_10]] : i64
 // CHECK-NEXT:      %[[VAL_14:.*]] = llvm.add %[[VAL_13]], %[[VAL_12]] : i64
-// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_2_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.2", {{.*}}>
 // CHECK-NEXT:      %[[VAL_16:.*]] = llvm.load %[[VAL_15]] : !llvm.ptr -> !llvm.ptr<1>
 // CHECK-NEXT:      %[[VAL_17:.*]] = llvm.getelementptr inbounds %[[VAL_16]][%[[VAL_14]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      %[[VAL_18:.*]] = llvm.addrspacecast %[[VAL_17]] : !llvm.ptr<1> to !llvm.ptr<4>
@@ -134,25 +134,25 @@ func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                      %[[VAL_1:.*]]: !llvm.ptr) -> !llvm.ptr<4> {
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_3_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]] : i64
 // CHECK-NEXT:      %[[VAL_8:.*]] = llvm.add %[[VAL_7]], %[[VAL_6]] : i64
-// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_3_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_12:.*]] = llvm.load %[[VAL_11]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_13:.*]] = llvm.mul %[[VAL_8]], %[[VAL_10]] : i64
 // CHECK-NEXT:      %[[VAL_14:.*]] = llvm.add %[[VAL_13]], %[[VAL_12]] : i64
-// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_3_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_16:.*]] = llvm.load %[[VAL_15]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_17:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_18:.*]] = llvm.load %[[VAL_17]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_19:.*]] = llvm.mul %[[VAL_14]], %[[VAL_16]] : i64
 // CHECK-NEXT:      %[[VAL_20:.*]] = llvm.add %[[VAL_19]], %[[VAL_18]] : i64
-// CHECK-NEXT:      %[[VAL_21:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_3_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_21:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_22:.*]] = llvm.load %[[VAL_21]] : !llvm.ptr -> !llvm.ptr<1>
 // CHECK-NEXT:      %[[VAL_23:.*]] = llvm.getelementptr inbounds %[[VAL_22]][%[[VAL_20]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>
 // CHECK-NEXT:      %[[VAL_24:.*]] = llvm.addrspacecast %[[VAL_23]] : !llvm.ptr<1> to !llvm.ptr<4>

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -28,7 +28,7 @@ func.func @test(%range: memref<?x!sycl_range_3_>, %idx: i32) -> i64 {
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> !llvm.ptr {
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, %[[VAL_1]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, %[[VAL_1]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.3", {{.*}}>
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.ptr
 func.func @test(%range: memref<?x!sycl_range_3_>, %idx: i32) -> memref<?xi64> {
   %0 = sycl.range.get %range[%idx] : (memref<?x!sycl_range_3_>, i32) -> memref<?xi64>
@@ -139,7 +139,7 @@ func.func @test(%id: memref<?x!sycl_id_1_>) -> i64 {
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                    %[[VAL_1:.*]]: i32) -> !llvm.ptr {
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, %[[VAL_1]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, %[[VAL_1]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.ptr
 func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> memref<?xi64> {
   %0 = sycl.id.get %id[%idx] : (memref<?x!sycl_id_3_>, i32) -> memref<?xi64>
@@ -236,7 +236,7 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> i64 {
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                    %[[VAL_1:.*]]: i64) -> !llvm.ptr<1> {
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_1_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.1", {{.*}}>
 // CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> !llvm.ptr<1>
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      llvm.return %[[VAL_4]] : !llvm.ptr<1>
@@ -317,13 +317,13 @@ func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_gb>, %idx: i64) -> !syc
 // CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                      %[[VAL_1:.*]]: !llvm.ptr) -> !llvm.ptr<1> {
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_1_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.1", {{.*}}>
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]]  : i64
 // CHECK-NEXT:      %[[VAL_8:.*]] = llvm.add %[[VAL_7]], %[[VAL_6]]  : i64
-// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_1_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.1", {{.*}}>
 // CHECK-NEXT:      %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr -> !llvm.ptr<1>
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_10]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      llvm.return %[[VAL_11]] : !llvm.ptr<1>
@@ -336,19 +336,19 @@ func.func @test_1(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                      %[[VAL_1:.*]]: !llvm.ptr) -> !llvm.ptr<1> {
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_2_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.2", {{.*}}>
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", {{.*}}>
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]]  : i64
 // CHECK-NEXT:      %[[VAL_8:.*]] = llvm.add %[[VAL_7]], %[[VAL_6]]  : i64
-// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_2_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.2", {{.*}}>
 // CHECK-NEXT:      %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", {{.*}}>
 // CHECK-NEXT:      %[[VAL_12:.*]] = llvm.load %[[VAL_11]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_13:.*]] = llvm.mul %[[VAL_8]], %[[VAL_10]]  : i64
 // CHECK-NEXT:      %[[VAL_14:.*]] = llvm.add %[[VAL_13]], %[[VAL_12]]  : i64
-// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_2_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.2", {{.*}}>
 // CHECK-NEXT:      %[[VAL_16:.*]] = llvm.load %[[VAL_15]] : !llvm.ptr -> !llvm.ptr<1>
 // CHECK-NEXT:      %[[VAL_17:.*]] = llvm.getelementptr inbounds %[[VAL_16]]{{\[}}%[[VAL_14]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      llvm.return %[[VAL_17]] : !llvm.ptr<1>
@@ -361,25 +361,25 @@ func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                      %[[VAL_1:.*]]: !llvm.ptr) -> !llvm.ptr<1> {
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_3_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]]  : i64
 // CHECK-NEXT:      %[[VAL_8:.*]] = llvm.add %[[VAL_7]], %[[VAL_6]]  : i64
-// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_3_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_12:.*]] = llvm.load %[[VAL_11]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_13:.*]] = llvm.mul %[[VAL_8]], %[[VAL_10]]  : i64
 // CHECK-NEXT:      %[[VAL_14:.*]] = llvm.add %[[VAL_13]], %[[VAL_12]]  : i64
-// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_3_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_16:.*]] = llvm.load %[[VAL_15]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_17:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_18:.*]] = llvm.load %[[VAL_17]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_19:.*]] = llvm.mul %[[VAL_14]], %[[VAL_16]]  : i64
 // CHECK-NEXT:      %[[VAL_20:.*]] = llvm.add %[[VAL_19]], %[[VAL_18]]  : i64
-// CHECK-NEXT:      %[[VAL_21:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_3_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_21:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_22:.*]] = llvm.load %[[VAL_21]] : !llvm.ptr -> !llvm.ptr<1>
 // CHECK-NEXT:      %[[VAL_23:.*]] = llvm.getelementptr inbounds %[[VAL_22]]{{\[}}%[[VAL_20]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      llvm.return %[[VAL_23]] : !llvm.ptr<1>
@@ -392,13 +392,13 @@ func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-SAME:                           %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                           %[[VAL_1:.*]]: !llvm.ptr) -> !llvm.ptr<1> {
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_1_21llvm2Estruct3C28i322C_f32293E_rw_gb
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.1.1", {{.*}}>
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_2]], %[[VAL_4]]  : i64
 // CHECK-NEXT:      %[[VAL_8:.*]] = llvm.add %[[VAL_7]], %[[VAL_6]]  : i64
-// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_1_21llvm2Estruct3C28i322C_f32293E_rw_gb
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.1.1", {{.*}}>
 // CHECK-NEXT:      %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr -> !llvm.ptr<1>
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_10]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, !llvm.struct<(i32, f32)>
 // CHECK-NEXT:      llvm.return %[[VAL_11]] : !llvm.ptr<1>
@@ -425,13 +425,13 @@ func.func @test_struct(%acc: memref<?x!sycl_accessor_1_struct_rw_gb>, %idx: memr
 // CHECK-SAME:                    %[[VAL_1:.*]]: !llvm.ptr) -> !llvm.struct<"class.sycl::_V1::atomic", {{.*}}> {
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.undef : !llvm.struct<"class.sycl::_V1::atomic", {{.*}}>
 // CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_1_i32_ato_gb
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.1", {{.*}}>
 // CHECK-NEXT:      %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.load %[[VAL_6]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_8:.*]] = llvm.mul %[[VAL_3]], %[[VAL_5]]  : i64
 // CHECK-NEXT:      %[[VAL_9:.*]] = llvm.add %[[VAL_8]], %[[VAL_7]]  : i64
-// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_1_i32_ato_gb
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.1", {{.*}}>
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.load %[[VAL_10]] : !llvm.ptr -> !llvm.ptr<1>
 // CHECK-NEXT:      %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_11]]{{\[}}%[[VAL_9]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      %[[VAL_13:.*]] = llvm.insertvalue %[[VAL_12]], %[[VAL_2]][0] : !llvm.struct<"class.sycl::_V1::atomic", {{.*}}>
@@ -488,21 +488,21 @@ func.func @test(%nd: memref<?x!sycl_nd_range_1_>) -> !sycl_range_1_ {
 // CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.udiv %[[VAL_4]], %[[VAL_6]]  : i64
-// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, i64
+// CHECK-NEXT:       %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.3", {{.*}}>
 // CHECK-NEXT:      llvm.store %[[VAL_7]], %[[VAL_8]] : i64, !llvm.ptr
 // CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_12:.*]] = llvm.load %[[VAL_11]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_13:.*]] = llvm.udiv %[[VAL_10]], %[[VAL_12]]  : i64
-// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, i64
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.3", {{.*}}>
 // CHECK-NEXT:      llvm.store %[[VAL_13]], %[[VAL_14]] : i64, !llvm.ptr
 // CHECK-NEXT:      %[[VAL_15:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_16:.*]] = llvm.load %[[VAL_15]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_17:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_18:.*]] = llvm.load %[[VAL_17]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_19:.*]] = llvm.udiv %[[VAL_16]], %[[VAL_18]]  : i64
-// CHECK-NEXT:      %[[VAL_20:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, i64
+// CHECK-NEXT:      %[[VAL_20:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.3", {{.*}}>
 // CHECK-NEXT:      llvm.store %[[VAL_19]], %[[VAL_20]] : i64, !llvm.ptr
 // CHECK-NEXT:      %[[VAL_21:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> !llvm.struct<"class.sycl::_V1::range.3", {{.*}}>
 // CHECK-NEXT:      llvm.return %[[VAL_21]] : !llvm.struct<"class.sycl::_V1::range.3", {{.*}}>
@@ -1358,19 +1358,19 @@ module attributes {gpu.container} {
 // CHECK-DAG:         %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-DAG:         %[[VAL_10:.*]] = llvm.mlir.constant(2 : i32) : i32
 // CHECK:             %[[VAL_11:.*]] = llvm.extractelement %[[VAL_2]]{{\[}}%[[VAL_10]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_9]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:        %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_9]]] : (!llvm.ptr, i32) -> !llvm.ptr,  !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
 // CHECK-NEXT:        %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_12]]{{\[}}%[[VAL_8]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
 // CHECK-NEXT:        llvm.store %[[VAL_11]], %[[VAL_13]] : i64, !llvm.ptr
 // CHECK-DAG:         %[[VAL_14:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-DAG:         %[[VAL_15:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK:             %[[VAL_16:.*]] = llvm.extractelement %[[VAL_2]]{{\[}}%[[VAL_15]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_17:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_14]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:        %[[VAL_17:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_14]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
 // CHECK-NEXT:        %[[VAL_18:.*]] = llvm.getelementptr %[[VAL_17]]{{\[}}%[[VAL_8]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
 // CHECK-NEXT:        llvm.store %[[VAL_16]], %[[VAL_18]] : i64, !llvm.ptr
 // CHECK-DAG:         %[[VAL_19:.*]] = llvm.mlir.constant(2 : i32) : i32
 // CHECK-DAG:         %[[VAL_20:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_21:.*]] = llvm.extractelement %[[VAL_2]]{{\[}}%[[VAL_20]] : i32] : vector<3xi64>
-// CHECK-NEXT:        %[[VAL_22:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_19]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK-NEXT:        %[[VAL_22:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_19]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
 // CHECK-NEXT:        %[[VAL_23:.*]] = llvm.getelementptr %[[VAL_22]]{{\[}}%[[VAL_8]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
 // CHECK-NEXT:        llvm.store %[[VAL_21]], %[[VAL_23]] : i64, !llvm.ptr
 // CHECK-NEXT:        %[[VAL_24:.*]] = llvm.getelementptr %[[VAL_7]]{{\[}}%[[VAL_8]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
@@ -1408,7 +1408,7 @@ module attributes {gpu.container} {
 // CHECK-DAG:         %[[VAL_10:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-DAG:         %[[VAL_11:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_12:.*]] = llvm.extractelement %[[VAL_3]]{{\[}}%[[VAL_11]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_13:.*]] = llvm.getelementptr inbounds %[[VAL_8]][0, 0, 0, %[[VAL_10]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK:             %[[VAL_13:.*]] = llvm.getelementptr inbounds %[[VAL_8]][0, 0, 0, %[[VAL_10]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
 // CHECK:             %[[VAL_14:.*]] = llvm.getelementptr %[[VAL_13]]{{\[}}%[[VAL_9]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
 // CHECK:             llvm.store %[[VAL_12]], %[[VAL_14]] : i64, !llvm.ptr
 // CHECK:             %[[VAL_15:.*]] = llvm.getelementptr %[[VAL_8]]{{\[}}%[[VAL_9]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
@@ -1573,7 +1573,7 @@ module attributes {gpu.container} {
 // CHECK-DAG:         %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-DAG:         %[[VAL_10:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_11:.*]] = llvm.extractelement %[[VAL_2]]{{\[}}%[[VAL_10]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_9]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK:             %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_7]][0, 0, 0, %[[VAL_9]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
 // CHECK:             %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_12]]{{\[}}%[[VAL_8]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
 // CHECK:             llvm.store %[[VAL_11]], %[[VAL_13]] : i64, !llvm.ptr
 // CHECK:             %[[VAL_14:.*]] = llvm.getelementptr %[[VAL_7]]{{\[}}%[[VAL_8]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
@@ -1606,13 +1606,13 @@ module attributes {gpu.container} {
 // CHECK-DAG:         %[[VAL_33:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-DAG:         %[[VAL_34:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK:             %[[VAL_35:.*]] = llvm.extractelement %[[VAL_26]]{{\[}}%[[VAL_34]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_36:.*]] = llvm.getelementptr inbounds %[[VAL_31]][0, 0, 0, %[[VAL_33]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK:             %[[VAL_36:.*]] = llvm.getelementptr inbounds %[[VAL_31]][0, 0, 0, %[[VAL_33]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", {{.*}}>
 // CHECK:             %[[VAL_37:.*]] = llvm.getelementptr %[[VAL_36]]{{\[}}%[[VAL_32]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
 // CHECK:             llvm.store %[[VAL_35]], %[[VAL_37]] : i64, !llvm.ptr
 // CHECK-DAG:         %[[VAL_38:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-DAG:         %[[VAL_39:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_40:.*]] = llvm.extractelement %[[VAL_26]]{{\[}}%[[VAL_39]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_41:.*]] = llvm.getelementptr inbounds %[[VAL_31]][0, 0, 0, %[[VAL_38]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK:             %[[VAL_41:.*]] = llvm.getelementptr inbounds %[[VAL_31]][0, 0, 0, %[[VAL_38]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", {{.*}}>
 // CHECK:             %[[VAL_42:.*]] = llvm.getelementptr %[[VAL_41]]{{\[}}%[[VAL_32]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
 // CHECK:             llvm.store %[[VAL_40]], %[[VAL_42]] : i64, !llvm.ptr
 // CHECK:             %[[VAL_43:.*]] = llvm.getelementptr %[[VAL_31]]{{\[}}%[[VAL_32]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", {{.*}}>
@@ -1626,7 +1626,7 @@ module attributes {gpu.container} {
 // CHECK:             %[[VAL_50:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_51:.*]] = llvm.getelementptr inbounds %[[VAL_49]][0, 0, 0, %[[VAL_50]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", {{.*}}>
 // CHECK:             %[[VAL_52:.*]] = llvm.load %[[VAL_51]] : !llvm.ptr -> i64
-// CHECK:             %[[VAL_53:.*]] = llvm.getelementptr inbounds %[[VAL_24]][0, 1, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
+// CHECK:             %[[VAL_53:.*]] = llvm.getelementptr inbounds %[[VAL_24]][0, 1, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::group.2", {{.*}}>
 // CHECK:             %[[VAL_54:.*]] = llvm.load %[[VAL_53]] : !llvm.ptr -> i64
 // CHECK:             %[[VAL_55:.*]] = llvm.mul %[[VAL_52]], %[[VAL_54]]  : i64
 // CHECK:             %[[VAL_56:.*]] = llvm.mlir.constant(1 : i32) : i32
@@ -1652,19 +1652,19 @@ module attributes {gpu.container} {
 // CHECK-DAG:         %[[VAL_69:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-DAG:         %[[VAL_70:.*]] = llvm.mlir.constant(2 : i32) : i32
 // CHECK:             %[[VAL_71:.*]] = llvm.extractelement %[[VAL_62]]{{\[}}%[[VAL_70]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_72:.*]] = llvm.getelementptr inbounds %[[VAL_67]][0, 0, 0, %[[VAL_69]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK:             %[[VAL_72:.*]] = llvm.getelementptr inbounds %[[VAL_67]][0, 0, 0, %[[VAL_69]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
 // CHECK:             %[[VAL_73:.*]] = llvm.getelementptr %[[VAL_72]]{{\[}}%[[VAL_68]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
 // CHECK:             llvm.store %[[VAL_71]], %[[VAL_73]] : i64, !llvm.ptr
 // CHECK-DAG:         %[[VAL_74:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-DAG:         %[[VAL_75:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK:             %[[VAL_76:.*]] = llvm.extractelement %[[VAL_62]]{{\[}}%[[VAL_75]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_77:.*]] = llvm.getelementptr inbounds %[[VAL_67]][0, 0, 0, %[[VAL_74]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK:             %[[VAL_77:.*]] = llvm.getelementptr inbounds %[[VAL_67]][0, 0, 0, %[[VAL_74]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
 // CHECK:             %[[VAL_78:.*]] = llvm.getelementptr %[[VAL_77]]{{\[}}%[[VAL_68]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
 // CHECK:             llvm.store %[[VAL_76]], %[[VAL_78]] : i64, !llvm.ptr
 // CHECK-DAG:         %[[VAL_79:.*]] = llvm.mlir.constant(2 : i32) : i32
 // CHECK-DAG:         %[[VAL_80:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_81:.*]] = llvm.extractelement %[[VAL_62]]{{\[}}%[[VAL_80]] : i32] : vector<3xi64>
-// CHECK:             %[[VAL_82:.*]] = llvm.getelementptr inbounds %[[VAL_67]][0, 0, 0, %[[VAL_79]]] : (!llvm.ptr, i32) -> !llvm.ptr, i64
+// CHECK:             %[[VAL_82:.*]] = llvm.getelementptr inbounds %[[VAL_67]][0, 0, 0, %[[VAL_79]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
 // CHECK:             %[[VAL_83:.*]] = llvm.getelementptr %[[VAL_82]]{{\[}}%[[VAL_68]]] : (!llvm.ptr, i64) -> !llvm.ptr, i64
 // CHECK:             llvm.store %[[VAL_81]], %[[VAL_83]] : i64, !llvm.ptr
 // CHECK:             %[[VAL_84:.*]] = llvm.getelementptr %[[VAL_67]]{{\[}}%[[VAL_68]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
@@ -1678,10 +1678,10 @@ module attributes {gpu.container} {
 // CHECK:             %[[VAL_91:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_92:.*]] = llvm.getelementptr inbounds %[[VAL_90]][0, 0, 0, %[[VAL_91]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
 // CHECK:             %[[VAL_93:.*]] = llvm.load %[[VAL_92]] : !llvm.ptr -> i64
-// CHECK:             %[[VAL_94:.*]] = llvm.getelementptr inbounds %[[VAL_60]][0, 1, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
+// CHECK:             %[[VAL_94:.*]] = llvm.getelementptr inbounds %[[VAL_60]][0, 1, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::group.3", {{.*}}>
 // CHECK:             %[[VAL_95:.*]] = llvm.load %[[VAL_94]] : !llvm.ptr -> i64
 // CHECK:             %[[VAL_96:.*]] = llvm.mul %[[VAL_93]], %[[VAL_95]]  : i64
-// CHECK:             %[[VAL_97:.*]] = llvm.getelementptr inbounds %[[VAL_60]][0, 1, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.ptr
+// CHECK:             %[[VAL_97:.*]] = llvm.getelementptr inbounds %[[VAL_60]][0, 1, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::group.3", {{.*}}>
 // CHECK:             %[[VAL_98:.*]] = llvm.load %[[VAL_97]] : !llvm.ptr -> i64
 // CHECK:             %[[VAL_99:.*]] = llvm.mul %[[VAL_96]], %[[VAL_98]]  : i64
 // CHECK:             %[[VAL_100:.*]] = llvm.mlir.constant(1 : i32) : i32

--- a/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
+++ b/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
@@ -1662,15 +1662,15 @@ struct ConvertPolygeistToLLVMPass
         // translated to the corresponding LLVM types, for example the element
         // type attribute of GEP or alloca.
         std::optional<bool> noTyAttrConversion;
-        if (useOpaquePointers)
+        if (useOpaquePointers) {
           noTyAttrConversion = std::transform_reduce(
               op->getAttrs().begin(), op->getAttrs().end(),
               std::optional<bool>{true},
               [](std::optional<bool> b1,
                  std::optional<bool> b2) -> std::optional<bool> {
-                if (!b1.has_value() || !b2.has_value()) {
+                if (!b1.has_value() || !b2.has_value())
                   return std::nullopt;
-                }
+
                 return b1.value() && b2.value();
               },
               [&](const NamedAttribute &Attr) -> std::optional<bool> {
@@ -1683,7 +1683,7 @@ struct ConvertPolygeistToLLVMPass
                 }
                 return true;
               });
-        else
+        } else
           noTyAttrConversion = true;
 
         // Type conversion of at least one type attribute failed.

--- a/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
+++ b/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
@@ -640,8 +640,8 @@ struct SubIndexBarePtrOpLowering : public BaseSubIndexOpLowering {
     // polygeist.subindex operation should be a memref of the element type of
     // the struct.
 
-    rewriter.replaceOpWithNewOp<LLVM::GEPOp>(subViewOp, resType,
-                                             convViewElemType, target, indices);
+    rewriter.replaceOpWithNewOp<LLVM::GEPOp>(
+        subViewOp, resType, convSourceElemType, target, indices);
 
     return success();
   }

--- a/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
+++ b/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
@@ -926,8 +926,21 @@ struct LLVMOpLowering : public ConversionPattern {
                                        convertedOperandTypes))) {
       return failure();
     }
+
+    // With opaque pointers, type attributes also might need to be
+    // translated to the corresponding LLVM types, for example the element
+    // type attribute of GEP or alloca.
+    bool noTyAttrConversion =
+        llvm::all_of(op->getAttrs(), [&](const NamedAttribute &Attr) {
+          if (auto TyAttr = dyn_cast<TypeAttr>(Attr.getValue())) {
+            return converter->convertType(TyAttr.getValue()) ==
+                   TyAttr.getValue();
+          }
+          return true;
+        });
+
     if (convertedResultTypes == op->getResultTypes() &&
-        convertedOperandTypes == op->getOperandTypes()) {
+        convertedOperandTypes == op->getOperandTypes() && noTyAttrConversion) {
       return failure();
     }
     if (isa<UnrealizedConversionCastOp>(op))
@@ -936,7 +949,17 @@ struct LLVMOpLowering : public ConversionPattern {
     OperationState state(op->getLoc(), op->getName());
     state.addOperands(operands);
     state.addTypes(convertedResultTypes);
-    state.addAttributes(op->getAttrs());
+    SmallVector<NamedAttribute> Attrs;
+    for (const auto &NA : op->getAttrs()) {
+      if (auto tyAttr = dyn_cast<TypeAttr>(NA.getValue())) {
+        auto convTy = converter->convertType(tyAttr.getValue());
+        assert(convTy);
+        Attrs.emplace_back(NA.getName(), TypeAttr::get(convTy));
+      } else {
+        Attrs.push_back(NA);
+      }
+    }
+    state.addAttributes(Attrs);
     state.addSuccessors(op->getSuccessors());
     for (unsigned i = 0, e = op->getNumRegions(); i < e; ++i)
       state.addRegion();
@@ -1634,8 +1657,43 @@ struct ConvertPolygeistToLLVMPass
         if (failed(converter.convertTypes(op->getOperandTypes(),
                                           convertedOperandTypes)))
           return std::nullopt;
+
+        // With opaque pointers, type attributes also might need to be
+        // translated to the corresponding LLVM types, for example the element
+        // type attribute of GEP or alloca.
+        std::optional<bool> noTyAttrConversion;
+        if (useOpaquePointers)
+          noTyAttrConversion = std::transform_reduce(
+              op->getAttrs().begin(), op->getAttrs().end(),
+              std::optional<bool>{true},
+              [](std::optional<bool> b1,
+                 std::optional<bool> b2) -> std::optional<bool> {
+                if (!b1.has_value() || !b2.has_value()) {
+                  return std::nullopt;
+                }
+                return b1.value() && b2.value();
+              },
+              [&](const NamedAttribute &Attr) -> std::optional<bool> {
+                if (auto TyAttr = dyn_cast<TypeAttr>(Attr.getValue())) {
+                  auto ConvTy = converter.convertType(TyAttr.getValue());
+                  if (!ConvTy) {
+                    return std::nullopt;
+                  }
+                  return ConvTy == TyAttr.getValue();
+                }
+                return true;
+              });
+        else
+          noTyAttrConversion = true;
+
+        // Type conversion of at least one type attribute failed.
+        if (!noTyAttrConversion) {
+          return std::nullopt;
+        }
+
         return convertedResultTypes == op->getResultTypes() &&
-               convertedOperandTypes == op->getOperandTypes();
+               convertedOperandTypes == op->getOperandTypes() &&
+               noTyAttrConversion.value();
       };
 
       LLVMConversionTarget target(getContext());

--- a/polygeist/test/polygeist-opt/bareptrlowering.mlir
+++ b/polygeist/test/polygeist-opt/bareptrlowering.mlir
@@ -461,7 +461,7 @@ func.func private @subindexop_memref_same_dim(%arg0: memref<4x4xf32>, %arg1: ind
 // CHECK-SAME:                                        %[[VAL_0:.*]]: !llvm.ptr) -> !llvm.ptr
 // CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(0 : index) : i64
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]], %[[VAL_1]]] : (!llvm.ptr, i64, i64) -> !llvm.ptr, f32
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]], 0] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<(f32)>
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : !llvm.ptr
 // CHECK-NEXT:    }
 
@@ -477,7 +477,7 @@ func.func private @subindexop_memref_struct(%arg0: memref<4x!llvm.struct<(f32)>>
 // CHECK-SAME:                                               %[[VAL_0:.*]]: !llvm.ptr) -> !llvm.ptr
 // CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(0 : index) : i64
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]], %[[VAL_2]], %[[VAL_1]]] : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr, f32
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]], 0, 0] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<(struct<(f32)>)>
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : !llvm.ptr
 // CHECK-NEXT:    }
 
@@ -493,7 +493,7 @@ func.func private @subindexop_memref_nested_struct(%arg0: memref<4x!llvm.struct<
 // CHECK-SAME:     %[[VAL_0:.*]]: !llvm.ptr) -> !llvm.ptr
 // CHECK-NEXT:     %[[VAL_1:.*]] = llvm.mlir.constant(0 : index) : i64
 // CHECK-NEXT:     %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:     %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]], %[[VAL_1]]] : (!llvm.ptr, i64, i64) -> !llvm.ptr, !llvm.ptr
+// CHECK-NEXT:     %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]], 0] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<(ptr)>
 // CHECK-NEXT:     llvm.return %[[VAL_3]] : !llvm.ptr
 // CHECK-NEXT: }
 
@@ -509,7 +509,7 @@ func.func private @subindexop_memref_nested_ptr(%arg0: memref<4x!llvm.struct<(pt
 // CHECK-SAME:                                                     %[[VAL_0:.*]]: !llvm.ptr) -> !llvm.ptr
 // CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(0 : index) : i64
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]], %[[VAL_2]], %[[VAL_2]], %[[VAL_1]]] : (!llvm.ptr, i64, i64, i64, i64) -> !llvm.ptr, f32
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]], 0, %[[VAL_2]], 0] : (!llvm.ptr, i64, i64) -> !llvm.ptr,  !llvm.struct<(array<4 x struct<(f32)>>)>
 // CHECK-NEXT:      llvm.return %[[VAL_3]] : !llvm.ptr
 // CHECK-NEXT:    }
 

--- a/polygeist/test/polygeist-opt/sycl/subindex.mlir
+++ b/polygeist/test/polygeist-opt/sycl/subindex.mlir
@@ -2,7 +2,7 @@
 
 // CHECK-LABEL: @test_1
 // CHECK:      [[ZERO:%.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT: [[GEP:%.*]] = llvm.getelementptr %{{.*}}[[[ZERO]], 0] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}
+// CHECK-NEXT: [[GEP:%.*]] = llvm.getelementptr %{{.*}}[[[ZERO]], 0] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<(struct<"class.sycl::_V1::id.1", {{.*}}>
 // CHECK-NEXT: llvm.return [[GEP]]
 
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
@@ -15,7 +15,7 @@ func.func @test_1(%arg0: memref<?x!llvm.struct<(!sycl_id_1_)>>) -> memref<?x!syc
 // -----
 
 // CHECK-LABEL: @test_2
-// CHECK: [[GEP:%.*]] = llvm.getelementptr %{{.*}}[%{{.*}}, {{.*}}] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::detail::AccessorImplDevice.1", {{.*}}
+// CHECK: [[GEP:%.*]] = llvm.getelementptr %{{.*}}[%{{.*}}, {{.*}}] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.1", {{.*}}
 // CHECK-NEXT: llvm.return [[GEP]]
 
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
@@ -31,11 +31,13 @@ func.func @test_2(%arg0: memref<?x!sycl_accessor_1_>) -> memref<?x!sycl_accessor
 
 // -----
 
-// CHECK:  llvm.func @test_3([[A0:.*]]: !llvm.ptr) -> !llvm.ptr {
-// CHECK: [[IDX_ZERO:%.*]] = llvm.mlir.constant(0 : index) : i64
-// CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT: [[GEP:%.*]] = llvm.getelementptr [[A0]][[[ZERO]], [[IDX_ZERO]]] : (!llvm.ptr, i64, i64) -> !llvm.ptr, i32
-// CHECK-NEXT: llvm.return [[GEP]] : !llvm.ptr
+// CHECK-LABEL:   llvm.func @test_3(
+// CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr) -> !llvm.ptr {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]], 0] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<(i32)>
+// CHECK-NEXT:      llvm.return %[[VAL_3]] : !llvm.ptr
+// CHECK-NEXT:    }
 
 func.func @test_3(%arg0: memref<?x!llvm.struct<(i32)>>) -> memref<?xi32> {
   %c0 = arith.constant 0 : index
@@ -57,10 +59,12 @@ func.func @test_4(%arg0: memref<1x!llvm.struct<(!sycl_id_1_)>>, %arg1: index) ->
 
 // -----
 
-// CHECK: llvm.func @test_5([[A0:%.*]]: !llvm.ptr<4>) -> !llvm.ptr<4> {
-// CHECK-DAG: [[ZERO1:%.*]] = llvm.mlir.constant(0 : index) : i64
-// CHECK-DAG: [[ZERO2:%.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT: [[GEP:%.*]] = llvm.getelementptr [[A0]][[[ZERO2]], [[ZERO2]], [[ZERO1]]] : (!llvm.ptr<4>, i64, i64, i64) -> !llvm.ptr<4>, i64
+// CHECK-LABEL:   llvm.func @test_5(
+// CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr<4>) -> !llvm.ptr<4> {
+// CHECK-DAG:       %[[VAL_1:.*]] = llvm.mlir.constant(0 : index) : i64
+// CHECK-DAG:       %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_2]], 0, %[[VAL_1]]] : (!llvm.ptr<4>, i64, i64) -> !llvm.ptr<4>, !llvm.struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>
+// CHECK-NEXT:      llvm.return %[[VAL_3]] : !llvm.ptr<4>
 
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 func.func @test_5(%arg0: memref<?x!sycl.array<[1], (memref<1xi64, 4>)>, 4>) -> memref<1xi64, 4> {

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1372,12 +1372,8 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
     });
     llvm::StructType *ST = cast<llvm::StructType>(LT);
 
-    bool Recursive = false;
-    for (size_t I = 0; I < ST->getNumElements(); I++) {
-      SmallPtrSet<llvm::Type *, 4> Seen;
-      if (isRecursiveStruct(ST->getTypeAtIndex(I), ST, Seen))
-        Recursive = true;
-    }
+    SmallPtrSet<const clang::Type *, 4> RecordsEncountered;
+    bool Recursive = isRecursiveStruct(QT, RecordsEncountered);
 
     const auto *RD = RT->getAsRecordDecl();
     if (const mlirclang::NamespaceKind NamespaceKind =

--- a/polygeist/tools/cgeist/Lib/TypeUtils.cc
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.cc
@@ -43,6 +43,88 @@ bool isRecursiveStruct(Type *T, Type *Meta, SmallPtrSetImpl<Type *> &Seen) {
   return false;
 }
 
+bool isRecursiveStruct(
+    clang::QualType QT,
+    SmallPtrSetImpl<const clang::Type *> &RecordEncountered) {
+  if (const auto *ET = dyn_cast<clang::ElaboratedType>(QT))
+    return isRecursiveStruct(ET->getNamedType(), RecordEncountered);
+
+  if (const auto *ET = dyn_cast<clang::UsingType>(QT))
+    return isRecursiveStruct(ET->getUnderlyingType(), RecordEncountered);
+
+  if (const auto *ET = dyn_cast<clang::ParenType>(QT))
+    return isRecursiveStruct(ET->getInnerType(), RecordEncountered);
+
+  if (const auto *ET = dyn_cast<clang::DeducedType>(QT))
+    return isRecursiveStruct(ET->getDeducedType(), RecordEncountered);
+
+  if (const auto *ST = dyn_cast<clang::SubstTemplateTypeParmType>(QT))
+    return isRecursiveStruct(ST->getReplacementType(), RecordEncountered);
+
+  if (const auto *ST = dyn_cast<clang::TemplateSpecializationType>(QT))
+    return isRecursiveStruct(ST->desugar(), RecordEncountered);
+
+  if (const auto *ST = dyn_cast<clang::TypedefType>(QT))
+    return isRecursiveStruct(ST->desugar(), RecordEncountered);
+
+  if (const auto *DT = dyn_cast<clang::DecltypeType>(QT))
+    return isRecursiveStruct(DT->desugar(), RecordEncountered);
+
+  if (const auto *DT = dyn_cast<clang::DecayedType>(QT))
+    return isRecursiveStruct(DT->getOriginalType(), RecordEncountered);
+
+  if (const auto *CT = dyn_cast<clang::ComplexType>(QT))
+    return isRecursiveStruct(CT->getElementType(), RecordEncountered);
+
+  if (const auto *RT = dyn_cast<clang::RecordType>(QT)) {
+    if (RecordEncountered.count(RT))
+      return true;
+
+    RecordEncountered.insert(RT);
+    auto *CXRD = dyn_cast<clang::CXXRecordDecl>(RT->getDecl());
+    if (CXRD && CXRD->hasDefinition())
+      for (auto B : CXRD->bases())
+        if (isRecursiveStruct(B.getType(), RecordEncountered))
+          return true;
+
+    for (auto *F : RT->getDecl()->fields())
+      if (isRecursiveStruct(F->getType(), RecordEncountered))
+        return true;
+
+    RecordEncountered.erase(RT);
+    return false;
+  }
+
+  const clang::Type *T = QT->getUnqualifiedDesugaredType();
+
+  if (const auto *AT = dyn_cast<clang::ArrayType>(T))
+    return isRecursiveStruct(AT->getElementType(), RecordEncountered);
+
+  if (const auto *VT = dyn_cast<clang::VectorType>(T))
+    return isRecursiveStruct(VT->getElementType(), RecordEncountered);
+
+  if (const auto *FT = dyn_cast<clang::FunctionProtoType>(T))
+    return false;
+
+  if (const auto *FT = dyn_cast<clang::FunctionNoProtoType>(T))
+    return false;
+
+  if (isa<clang::PointerType, clang::ReferenceType>(T)) {
+    auto PointeeType = isa<clang::PointerType>(T)
+                           ? cast<clang::PointerType>(T)->getPointeeType()
+                           : cast<clang::ReferenceType>(T)->getPointeeType();
+    return isRecursiveStruct(PointeeType, RecordEncountered);
+  }
+
+  if (isa<clang::EnumType>(T))
+    return false;
+
+  if (T->isBuiltinType())
+    return false;
+
+  llvm_unreachable("Unhandled type");
+}
+
 Type *anonymize(Type *T) {
   if (auto *PT = dyn_cast<PointerType>(T)) {
     if (PT->isOpaque())

--- a/polygeist/tools/cgeist/Lib/TypeUtils.h
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.h
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/Dialect/SYCL/IR/SYCLTypes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "clang/AST/Type.h"
 #include "llvm/ADT/SmallPtrSet.h"
 
 namespace clang {
@@ -45,6 +46,10 @@ llvm::Type *anonymize(llvm::Type *T);
 
 bool isRecursiveStruct(llvm::Type *T, llvm::Type *Meta,
                        llvm::SmallPtrSetImpl<llvm::Type *> &Seen);
+
+bool isRecursiveStruct(
+    clang::QualType,
+    llvm::SmallPtrSetImpl<const clang::Type *> &RecordEncountered);
 
 mlir::IntegerAttr wrapIntegerMemorySpace(unsigned MemorySpace,
                                          mlir::MLIRContext *Ctx);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -129,7 +129,7 @@ private:
   std::deque<FunctionToEmit> FunctionsToEmit;
   mlir::OwningOpRef<mlir::ModuleOp> &Module;
   clang::SourceManager &SM;
-  llvm::LLVMContext Lcontext;
+  std::unique_ptr<llvm::LLVMContext> Lcontext;
   llvm::Module LLVMMod;
   clang::CodeGen::CodeGenModule CGM;
   mlirclang::CodeGen::CodeGenTypes CGTypes;
@@ -152,14 +152,14 @@ public:
       std::map<std::string, mlir::LLVM::GlobalOp> &LLVMGlobals,
       std::map<std::string, mlir::LLVM::LLVMFuncOp> &LLVMFunctions,
       clang::Preprocessor &PP, clang::ASTContext &AstContext,
-      mlir::OwningOpRef<mlir::ModuleOp> &Module, clang::SourceManager &SM,
+      mlir::OwningOpRef<mlir::ModuleOp> &Module, clang::SourceManager &SM, std::unique_ptr<llvm::LLVMContext>&& LCtx,
       clang::CodeGenOptions &Codegenops, std::string ModuleId)
       : EmitIfFound(EmitIfFound), Done(Done),
         LLVMStringGlobals(LLVMStringGlobals), Globals(Globals),
         Functions(Functions), DeviceFunctions(DeviceFunctions),
         LLVMGlobals(LLVMGlobals), LLVMFunctions(LLVMFunctions),
-        FunctionsToEmit(), Module(Module), SM(SM), Lcontext(),
-        LLVMMod(ModuleId, Lcontext),
+        FunctionsToEmit(), Module(Module), SM(SM), Lcontext(std::move(LCtx)),
+        LLVMMod(ModuleId, *Lcontext),
         CGM(AstContext, &SM.getFileManager().getVirtualFileSystem(),
             PP.getHeaderSearchInfo().getHeaderSearchOpts(),
             PP.getPreprocessorOpts(), Codegenops, LLVMMod, PP.getDiagnostics()),

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -152,7 +152,8 @@ public:
       std::map<std::string, mlir::LLVM::GlobalOp> &LLVMGlobals,
       std::map<std::string, mlir::LLVM::LLVMFuncOp> &LLVMFunctions,
       clang::Preprocessor &PP, clang::ASTContext &AstContext,
-      mlir::OwningOpRef<mlir::ModuleOp> &Module, clang::SourceManager &SM, std::unique_ptr<llvm::LLVMContext>&& LCtx,
+      mlir::OwningOpRef<mlir::ModuleOp> &Module, clang::SourceManager &SM,
+      std::unique_ptr<llvm::LLVMContext> &&LCtx,
       clang::CodeGenOptions &Codegenops, std::string ModuleId)
       : EmitIfFound(EmitIfFound), Done(Done),
         LLVMStringGlobals(LLVMStringGlobals), Globals(Globals),

--- a/polygeist/tools/cgeist/Test/Verification/base_with_virt.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/base_with_virt.cpp
@@ -35,16 +35,16 @@ void a() {
 
 // CHECK-LABEL:   func.func @_Z1av() attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 1 : i64
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<(struct<packed (ptr, i32, array<4 x i8>)>, struct<(ptr)>)> : (i64) -> !llvm.ptr
 // CHECK-NEXT:      call @_ZN16mbasic_stringbufC1Ev(%[[VAL_1]]) : (!llvm.ptr) -> ()
 // CHECK-NEXT:      return
 // CHECK-NEXT:    }
 
 // CHECK-LABEL:   func.func @_ZN16mbasic_stringbufC1Ev(
 // CHECK-SAME:                                         %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<packed (ptr, i32, array<4 x i8>)>, struct<(ptr)>)>
 // CHECK-NEXT:      call @_ZN1AC1Ev(%[[VAL_1]]) : (!llvm.ptr) -> ()
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>, struct<(ptr<i8>)>)>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<packed (ptr, i32, array<4 x i8>)>, struct<(ptr)>)>
 // CHECK-NEXT:      call @_ZN12_Alloc_hiderC1Ev(%[[VAL_2]]) : (!llvm.ptr) -> ()
 // CHECK-NEXT:      return
 // CHECK-NEXT:    }
@@ -52,7 +52,7 @@ void a() {
 // CHECK-LABEL:   func.func @_ZN1AC1Ev(
 // CHECK-SAME:                         %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 3 : i32
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<packed (ptr<ptr<func<i32 (...)>>>, i32, array<4 x i8>)>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<packed (ptr, i32, array<4 x i8>)>
 // CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_2]] : i32, !llvm.ptr
 // CHECK-NEXT:      return
 // CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/base_with_virt2.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/base_with_virt2.cpp
@@ -36,16 +36,16 @@ void a() {
 
 // CHECK-LABEL:   func.func @_Z1av() attributes {llvm.linkage = #llvm.linkage<external>} {
 // CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 1 : i64
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<(struct<(ptr<ptr<func<i32 (...)>>>)>, struct<(ptr<i8>)>)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<(struct<(ptr)>, struct<(ptr)>)> : (i64) -> !llvm.ptr
 // CHECK-NEXT:      call @_ZN16mbasic_stringbufC1Ev(%[[VAL_1]]) : (!llvm.ptr) -> ()
 // CHECK-NEXT:      return
 // CHECK-NEXT:    }
 
 // CHECK-LABEL:   func.func @_ZN16mbasic_stringbufC1Ev(
 // CHECK-SAME:                                         %[[VAL_0:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(ptr<ptr<func<i32 (...)>>>)>, struct<(ptr<i8>)>)>
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(ptr)>, struct<(ptr)>)>
 // CHECK-NEXT:      call @_ZN15basic_streambufC1Ev(%[[VAL_1]]) : (!llvm.ptr) -> ()
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(ptr<ptr<func<i32 (...)>>>)>, struct<(ptr<i8>)>)>
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(ptr)>, struct<(ptr)>)>
 // CHECK-NEXT:      call @_ZN12_Alloc_hiderC1Ev(%[[VAL_2]]) : (!llvm.ptr) -> ()
 // CHECK-NEXT:      return
 // CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/ext_vector_type.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/ext_vector_type.cpp
@@ -39,6 +39,6 @@ size_t evt2() {
 // LLVM-NEXT:   ret i64 undef
 
 // LLVM-LABEL: define i64 @_Z4evt2v() {
-// LLVM-NEXT:   %1 = load <3 x i64>, <3 x i64>* @stv, align 32
+// LLVM-NEXT:   %1 = load <3 x i64>, ptr @stv, align 32
 // LLVM-NEXT:   %2 = extractelement <3 x i64> %1, i64 0
 // LLVM-NEXT:   ret i64 %2

--- a/polygeist/tools/cgeist/Test/Verification/globals.c
+++ b/polygeist/tools/cgeist/Test/Verification/globals.c
@@ -50,6 +50,6 @@ void kernel_deriche() {
 // LLVM-DAG: @external = external global i32, align 4
 
 // LLVM-LABEL: define void @kernel_deriche() {
-// LLVM-NEXT:   call void @run(i32* @local, i32* @local_init, i32* @internal, i32* @internal_init, i32* @external)
+// LLVM-NEXT:   call void @run(ptr @local, ptr @local_init, ptr @internal, ptr @internal_init, ptr @external)
 // LLVM-NEXT:   ret void
-// LLVM-LABEL: declare void @run(i32*, i32*, i32*, i32*, i32*)
+// LLVM-LABEL: declare void @run(ptr, ptr, ptr, ptr, ptr)

--- a/polygeist/tools/cgeist/Test/Verification/lowerrecur.c
+++ b/polygeist/tools/cgeist/Test/Verification/lowerrecur.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s --function=* -emit-llvm -S | FileCheck %s
+// RUN: cgeist --use-opaque-pointers %s --function=* -emit-llvm -S | FileCheck %s
 
 // TODO: This test case does not yet work with opaque pointers,
 // as it requires the Polygeist transformations to work correctly

--- a/polygeist/tools/cgeist/Test/Verification/single_field_union.c
+++ b/polygeist/tools/cgeist/Test/Verification/single_field_union.c
@@ -17,9 +17,9 @@ union int_wrapper {
 // CHECK-MLIR-NEXT:      return %[[VAL_0]] : memref<?xi32>
 // CHECK-MLIR-NEXT:    }
 
-// CHECK-LLVM-LABEL:   define i32* @foo(
-// CHECK-LLVM-SAME:                     i32* %[[VAL_0:.*]]) {
-// CHECK-LLVM-NEXT:      ret i32* %[[VAL_0]]
+// CHECK-LLVM-LABEL:   define ptr @foo(
+// CHECK-LLVM-SAME:                     ptr %[[VAL_0:.*]]) {
+// CHECK-LLVM-NEXT:      ret ptr %[[VAL_0]]
 // CHECK-LLVM-NEXT:    }
 
 union int_wrapper foo(union int_wrapper w) {

--- a/polygeist/tools/cgeist/Test/Verification/single_field_union_for_mem.c
+++ b/polygeist/tools/cgeist/Test/Verification/single_field_union_for_mem.c
@@ -12,9 +12,9 @@ struct foo {
 // CHECK-MLIR-NEXT:      return %[[VAL_0]] : !llvm.struct<(!llvm.struct<(memref<?xi32>)>)>
 // CHECK-MLIR-NEXT:    }
 
-// CHECK-LLVM-LABEL:   define { { i32* } } @id(
-// CHECK-LLVM-SAME:                            { { i32* } } %[[VAL_0:.*]]) {
-// CHECK-LLVM-NEXT:      ret { { i32* } } %[[VAL_0]]
+// CHECK-LLVM-LABEL:   define { { ptr } } @id(
+// CHECK-LLVM-SAME:                            { { ptr } } %[[VAL_0:.*]]) {
+// CHECK-LLVM-NEXT:      ret { { ptr } } %[[VAL_0]]
 // CHECK-LLVM-NEXT:    }
 
 struct foo id(struct foo f) {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/builtin_cache.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/builtin_cache.cpp
@@ -1,5 +1,10 @@
 // RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir -o - %s | FileCheck %s
 
+// TODO: This test is currently not yet working with opaque pointers, 
+// as the MLIR LLVM dialect is lacking support for the LLVM IR 'TargetExtType'
+// that is used for OpenCL/SPIR-V image types.
+// XFAIL: *
+
 #include <sycl/sycl.hpp>
 using namespace sycl;
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/builtin_types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/builtin_types.cpp
@@ -1,5 +1,10 @@
 // RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir -o - %s | FileCheck %s
 
+// TODO: This test is currently not yet working with opaque pointers, 
+// as the MLIR LLVM dialect is lacking support for the LLVM IR 'TargetExtType'
+// that is used for OpenCL/SPIR-V image types.
+// XFAIL: *
+
 #include <sycl/sycl.hpp>
 
 using namespace sycl;

--- a/polygeist/tools/cgeist/Test/Verification/sycl/builtins.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/builtins.cpp
@@ -1,5 +1,5 @@
 // RUN: clang++ -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-mlir -o - %s | FileCheck %s
-// RUN: clang++ -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-llvm -S -o %t %s && rm %t
+// RUN: clang++ -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w -emit-llvm -S -o %t %s && rm %t
 
 #include <CL/__spirv/spirv_types.hpp>
 #include <CL/__spirv/spirv_vars.hpp>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/builtins.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/builtins.cpp
@@ -1,5 +1,5 @@
 // RUN: clang++ -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-mlir -o - %s | FileCheck %s
-// RUN: clang++ -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w -emit-llvm -S -o %t %s && rm %t
+// RUN: clang++ -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-llvm -S -o %t %s && rm %t
 
 #include <CL/__spirv/spirv_types.hpp>
 #include <CL/__spirv/spirv_vars.hpp>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -1,5 +1,5 @@
 // RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefixes=CHECK
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefixes=CHECK-LLVM
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefixes=CHECK-LLVM
 
 #include <sycl/aliases.hpp>
 #include <sycl/sycl.hpp>
@@ -83,14 +83,14 @@
 // CHECK-SAME:     attributes {[[SPIR_FUNCCC]], [[LINKONCE]], {{.*}}}
 // CHECK-NEXT:   %0 = sycl.cast %arg0 : memref<?x!sycl_range_1_, 4> to memref<?x!sycl_array_1_, 4>
 
-// CHECK-LLVM: define spir_func void @cons_0([[ID_TYPE:%"class.sycl::_V1::id.1"]]* noundef byval(%"class.sycl::_V1::id.1") align 8 [[ARG0:%.*]], 
-// CHECK-LLVM-SAME:                          [[RANGE_TYPE:%"class.sycl::_V1::range.1"]]* noundef byval(%"class.sycl::_V1::range.1") align 8 [[ARG1:%.*]]) #[[FUNCATTRS:[0-9]+]]
+// CHECK-LLVM: define spir_func void @cons_0(ptr noundef byval([[ID_TYPE:%"class.sycl::_V1::id.1"]]) align 8 [[ARG0:%.*]], 
+// CHECK-LLVM-SAME:                          ptr noundef byval([[RANGE_TYPE:%"class.sycl::_V1::range.1"]]) align 8 [[ARG1:%.*]]) #[[FUNCATTRS:[0-9]+]]
 // CHECK-LLVM-DAG: [[RANGE:%.*]] = alloca [[RANGE_TYPE]]
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE]]
-// CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID]] to [[ID_TYPE]] addrspace(4)*
-// CHECK-LLVM: call spir_func void @_ZN4sycl3_V12idILi1EEC1ERKS2_([[ID_TYPE]] addrspace(4)* [[ID1_AS]], 
-// CHECK-LLVM: [[RANGE1_AS:%.*]] = addrspacecast [[RANGE_TYPE]]* [[RANGE]] to [[RANGE_TYPE]] addrspace(4)*
-// CHECK-LLVM: call spir_func void @_ZN4sycl3_V15rangeILi1EEC1ERKS2_([[RANGE_TYPE]] addrspace(4)* [[RANGE1_AS]],
+// CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast ptr [[ID]] to ptr addrspace(4)
+// CHECK-LLVM: call spir_func void @_ZN4sycl3_V12idILi1EEC1ERKS2_(ptr addrspace(4) [[ID1_AS]], 
+// CHECK-LLVM: [[RANGE1_AS:%.*]] = addrspacecast ptr [[RANGE]] to ptr addrspace(4)
+// CHECK-LLVM: call spir_func void @_ZN4sycl3_V15rangeILi1EEC1ERKS2_(ptr addrspace(4) [[RANGE1_AS]],
 
 extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
   auto id = sycl::id<1>{i};
@@ -113,10 +113,9 @@ extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
 // CHECK-LLVM-LABEL: define spir_func void @cons_1()
 // CHECK-LLVM-SAME:  #[[FUNCATTRS]]
 // CHECK-LLVM: [[ID1:%.*]] = alloca [[ID_TYPE:%"class.sycl::_V1::id.2"]]
-// CHECK-LLVM: [[CAST1:%.*]] = bitcast [[ID_TYPE]]* %1 to i8*
-// CHECK-LLVM: call void @llvm.memset.p0i8.i64(i8* %2, i8 0, i64 16, i1 false)
-// CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID1]] to [[ID_TYPE]] addrspace(4)*
-// CHECK-LLVM: call spir_func void @_ZN4sycl3_V12idILi2EEC1Ev([[ID_TYPE]] addrspace(4)* [[ID1_AS]])  
+// CHECK-LLVM: call void @llvm.memset.p0.i64(ptr [[ID1]], i8 0, i64 16, i1 false)
+// CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast ptr [[ID1]] to ptr addrspace(4)
+// CHECK-LLVM: call spir_func void @_ZN4sycl3_V12idILi2EEC1Ev(ptr addrspace(4) [[ID1_AS]])  
 
 extern "C" SYCL_EXTERNAL void cons_1() {
   auto id = sycl::id<2>{};
@@ -132,8 +131,8 @@ extern "C" SYCL_EXTERNAL void cons_1() {
 // CHECK-LLVM-LABEL: define spir_func void @cons_2(i64 noundef %0, i64 noundef %1)
 // CHECK-LLVM-SAME:  #[[FUNCATTRS]]
 // CHECK-LLVM: [[ID1:%.*]] = alloca [[ID_TYPE:%"class.sycl::_V1::id.2"]]
-// CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID1]] to [[ID_TYPE]] addrspace(4)*
-// CHECK-LLVM: call spir_func void @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm([[ID_TYPE]] addrspace(4)* [[ID1_AS]], i64 %0, i64 %1)
+// CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast ptr [[ID1]] to ptr addrspace(4)
+// CHECK-LLVM: call spir_func void @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm(ptr addrspace(4) [[ID1_AS]], i64 %0, i64 %1)
 
 extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
   auto id = sycl::id<2>{a, b};
@@ -148,11 +147,11 @@ extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
 // CHECK-NEXT: %memspacecast_0 = memref.memory_space_cast %arg0 : memref<?x![[ITEM]]> to memref<?x![[ITEM]], 4>
 // CHECK-NEXT: sycl.constructor @id(%memspacecast, %memspacecast_0) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE} : (memref<?x!sycl_id_2_, 4>, memref<?x![[ITEM]], 4>)
 
-// CHECK-LLVM: define spir_func void @cons_3([[ITEM_TYPE:%"class.sycl::_V1::item.2.true"]]* noundef byval(%"class.sycl::_V1::item.2.true") align 8 [[ARG0:%.*]]) #[[FUNCATTRS]]
+// CHECK-LLVM: define spir_func void @cons_3(ptr noundef byval([[ITEM_TYPE:%"class.sycl::_V1::item.2.true"]]) align 8 [[ARG0:%.*]]) #[[FUNCATTRS]]
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE:%"class.sycl::_V1::id.2"]]  
-// CHECK-LLVM: [[ID_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID]] to [[ID_TYPE]] addrspace(4)*
-// CHECK-LLVM: [[ITEM_AS:%.*]] = addrspacecast [[ITEM_TYPE]]* [[ARG0]] to [[ITEM_TYPE]] addrspace(4)*
-// CHECK-LLVM: call spir_func void @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE([[ID_TYPE]] addrspace(4)* [[ID_AS]], [[ITEM_TYPE]] addrspace(4)* [[ITEM_AS]])
+// CHECK-LLVM: [[ID_AS:%.*]] = addrspacecast ptr [[ID]] to ptr addrspace(4)
+// CHECK-LLVM: [[ITEM_AS:%.*]] = addrspacecast ptr [[ARG0]] to ptr addrspace(4)
+// CHECK-LLVM: call spir_func void @_ZN4sycl3_V12idILi2EEC1ILi2ELb1EEERNSt9enable_ifIXeqT_Li2EEKNS0_4itemILi2EXT0_EEEE4typeE(ptr addrspace(4) [[ID_AS]], ptr addrspace(4) [[ITEM_AS]])
 
 extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
   auto id = sycl::id<2>{val};
@@ -166,11 +165,11 @@ extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
 // CHECK-NEXT: %memspacecast_0 = memref.memory_space_cast %arg0 : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
 // CHECK-NEXT: sycl.constructor @id(%memspacecast, %memspacecast_0) {MangledFunctionName = @_ZN4sycl3_V12idILi2EEC1ERKS2_} : (memref<?x!sycl_id_2_, 4>, memref<?x!sycl_id_2_, 4>)
 
-// CHECK-LLVM: define spir_func void @cons_4([[ID_TYPE:%"class.sycl::_V1::id.2"]]*  noundef byval(%"class.sycl::_V1::id.2") align 8 [[ARG0:%.*]]) #[[FUNCATTRS]]
+// CHECK-LLVM: define spir_func void @cons_4(ptr noundef byval([[ID_TYPE:%"class.sycl::_V1::id.2"]]) align 8 [[ARG0:%.*]]) #[[FUNCATTRS]]
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE]]
-// CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ID]] to [[ID_TYPE]] addrspace(4)*
-// CHECK-LLVM: [[ID2_AS:%.*]] = addrspacecast [[ID_TYPE]]* [[ARG0]] to [[ID_TYPE]] addrspace(4)*
-// CHECK-LLVM: call spir_func void @_ZN4sycl3_V12idILi2EEC1ERKS2_([[ID_TYPE]] addrspace(4)* [[ID1_AS]], [[ID_TYPE]] addrspace(4)* [[ID2_AS]])
+// CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast ptr [[ID]] to ptr addrspace(4)
+// CHECK-LLVM: [[ID2_AS:%.*]] = addrspacecast ptr [[ARG0]] to ptr addrspace(4)
+// CHECK-LLVM: call spir_func void @_ZN4sycl3_V12idILi2EEC1ERKS2_(ptr addrspace(4) [[ID1_AS]], ptr addrspace(4) [[ID2_AS]])
 
 extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
   auto id = sycl::id<2>{val};
@@ -184,8 +183,8 @@ extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
 // CHECK-LLVM-LABEL: define spir_func void @cons_5()
 // CHECK-LLVM-SAME:  #[[FUNCATTRS]]
 // CHECK-LLVM: [[ACCESSOR:%.*]] = alloca %"class.sycl::_V1::accessor.1", align 8
-// CHECK-LLVM: [[ACAST:%.*]] = addrspacecast %"class.sycl::_V1::accessor.1"* [[ACCESSOR]] to %"class.sycl::_V1::accessor.1" addrspace(4)*
-// CHECK-LLVM: call spir_func void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]])
+// CHECK-LLVM: [[ACAST:%.*]] = addrspacecast ptr [[ACCESSOR]] to ptr addrspace(4)
+// CHECK-LLVM: call spir_func void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(ptr addrspace(4) [[ACAST]])
 
 extern "C" SYCL_EXTERNAL void cons_5() {
   auto accessor = sycl::accessor<sycl::cl_int, 1, sycl::access::mode::write>{};
@@ -199,8 +198,8 @@ extern "C" SYCL_EXTERNAL void cons_5() {
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_6(
 // CHECK-LLVM-SAME:                                i32 noundef %{{.*}}) #[[FUNCATTRS]]
-// CHECK-LLVM:         call spir_func void @[[VEC_SPLAT_CTR:.*]](%"class.sycl::_V1::vec" addrspace(4)* %{{.*}}, i32 addrspace(4)* %{{.*}})
-// CHECK-LLVM:       define linkonce_odr spir_func void @[[VEC_SPLAT_CTR]](%"class.sycl::_V1::vec" addrspace(4)* noundef align 32 dereferenceable_or_null(32) %{{.*}}, i32 addrspace(4)* noundef align 4 dereferenceable(4) %{{.*}}) #[[FUNCATTRS]] {
+// CHECK-LLVM:         call spir_func void @[[VEC_SPLAT_CTR:.*]](ptr addrspace(4) %{{.*}}, ptr addrspace(4) %{{.*}})
+// CHECK-LLVM:       define linkonce_odr spir_func void @[[VEC_SPLAT_CTR]](ptr addrspace(4) noundef align 32 dereferenceable_or_null(32) %{{.*}}, ptr addrspace(4) noundef align 4 dereferenceable(4) %{{.*}}) #[[FUNCATTRS]] {
 // CHECK-LLVM:         %[[VECINIT:.*]] = insertelement <8 x i32> undef, i32 %{{.*}}, i32 0
 // CHECK-LLVM:         %{{.*}} = shufflevector <8 x i32> %[[VECINIT]], <8 x i32> undef, <8 x i32> zeroinitializer
 
@@ -215,8 +214,8 @@ extern "C" SYCL_EXTERNAL void cons_6(int Arg) {
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_7(
 // CHECK-LLVM-SAME:                                float noundef %[[ARG0:.*]], float noundef %[[ARG1:.*]], float noundef %[[ARG2:.*]], float noundef %[[ARG3:.*]]) #[[FUNCATTRS]]
-// CHECK-LLVM:         call spir_func void @[[VEC_INITLIST_CTR:.*]](%"class.sycl::_V1::vec.1" addrspace(4)* %{{.*}}, float %[[ARG0]], float %[[ARG1]], float %[[ARG2]], float %[[ARG3]])
-// CHECK-LLVM:       define linkonce_odr spir_func void @[[VEC_INITLIST_CTR]](%"class.sycl::_V1::vec.1" addrspace(4)* noundef align 16 {{.*}}, float noundef {{.*}}, float noundef {{.*}}, float noundef {{.*}}, float noundef {{.*}}) #[[FUNCATTRS]]
+// CHECK-LLVM:         call spir_func void @[[VEC_INITLIST_CTR:.*]](ptr addrspace(4) %{{.*}}, float %[[ARG0]], float %[[ARG1]], float %[[ARG2]], float %[[ARG3]])
+// CHECK-LLVM:       define linkonce_odr spir_func void @[[VEC_INITLIST_CTR]](ptr addrspace(4) noundef align 16 {{.*}}, float noundef {{.*}}, float noundef {{.*}}, float noundef {{.*}}, float noundef {{.*}}) #[[FUNCATTRS]]
 extern "C" SYCL_EXTERNAL void cons_7(float A, float B, float C, float D) {
   auto vec = sycl::vec<sycl::cl_float, 4>{A, B, C, D};
 }
@@ -227,9 +226,9 @@ extern "C" SYCL_EXTERNAL void cons_7(float A, float B, float C, float D) {
 // CHECK:       func.func @[[VEC_COPY_CTR]](%{{.*}}: memref<?x!sycl_vec_f64_16_, 4> {{{.*}}}, %{{.*}}: memref<?x!sycl_vec_f64_16_, 4> {{{.*}}}) attributes {[[SPIR_FUNCCC]], [[LINKONCE]], {{.*}}}
 
 // CHECK-LLVM-LABEL:  define spir_func void @cons_8(
-// CHECK-LLVM-SAME:                                 %"class.sycl::_V1::vec.2" addrspace(4)* noundef align 128 dereferenceable(128) %[[ARG0:.*]]) #[[FUNCATTRS]] {
-// CHECK-LLVM:          call spir_func void @_ZN4sycl3_V13vecIdLi16EEC1ERKS2_(%"class.sycl::_V1::vec.2" addrspace(4)* %{{.*}}, %"class.sycl::_V1::vec.2" addrspace(4)* %[[ARG0]])
-// CHECK-LLVM:        define linkonce_odr spir_func void @_ZN4sycl3_V13vecIdLi16EEC1ERKS2_(%"class.sycl::_V1::vec.2" addrspace(4)* noundef align 128 dereferenceable_or_null(128) %{{.*}}, %{{.*}}class.sycl::_V1::vec.2" addrspace(4)* noundef align 128 dereferenceable(128) %{{.*}}) #[[FUNCATTRS]] {
+// CHECK-LLVM-SAME:                                 ptr addrspace(4) noundef align 128 dereferenceable(128) %[[ARG0:.*]]) #[[FUNCATTRS]] {
+// CHECK-LLVM:          call spir_func void @_ZN4sycl3_V13vecIdLi16EEC1ERKS2_(ptr addrspace(4) %{{.*}}, ptr addrspace(4) %[[ARG0]])
+// CHECK-LLVM:        define linkonce_odr spir_func void @_ZN4sycl3_V13vecIdLi16EEC1ERKS2_(ptr addrspace(4) noundef align 128 dereferenceable_or_null(128) %{{.*}}, ptr addrspace(4) noundef align 128 dereferenceable(128) %{{.*}}) #[[FUNCATTRS]] {
 extern "C" SYCL_EXTERNAL void cons_8(const sycl::vec<sycl::cl_double, 16> &Other) {
   auto vec = sycl::vec<sycl::cl_double, 16>{Other};
 }
@@ -241,8 +240,8 @@ extern "C" SYCL_EXTERNAL void cons_8(const sycl::vec<sycl::cl_double, 16> &Other
 
 // CHECK-LLVM-LABEL:  define spir_func void @cons_9(
 // CHECK-LLVM-SAME:                                 <3 x i8> noundef %[[ARG0:.*]]) #[[FUNCATTRS]] {
-// CHECK-LLVM:          call spir_func void @[[VEC_NATIVE_CTR:.*]](%"class.sycl::_V1::vec.3" addrspace(4)* %{{.*}}, <3 x i8> %[[ARG0]])
-// CHECK-LLVM:        define linkonce_odr spir_func void @[[VEC_NATIVE_CTR]](%"class.sycl::_V1::vec.3" addrspace(4)* noundef align 4 dereferenceable_or_null(4) %{{.*}}, <3 x i8> noundef %{{.*}}) #[[FUNCATTRS]] {
+// CHECK-LLVM:          call spir_func void @[[VEC_NATIVE_CTR:.*]](ptr addrspace(4) %{{.*}}, <3 x i8> %[[ARG0]])
+// CHECK-LLVM:        define linkonce_odr spir_func void @[[VEC_NATIVE_CTR]](ptr addrspace(4) noundef align 4 dereferenceable_or_null(4) %{{.*}}, <3 x i8> noundef %{{.*}}) #[[FUNCATTRS]] {
 extern "C" SYCL_EXTERNAL void cons_9(const sycl::vec<sycl::cl_char, 3>::vector_t Native) {
   auto vec = sycl::vec<sycl::cl_char, 3>{Native};
 }
@@ -253,9 +252,9 @@ extern "C" SYCL_EXTERNAL void cons_9(const sycl::vec<sycl::cl_char, 3>::vector_t
 // CHECK:       func.func @[[VEC_INITLIST_VEC_CTR]](%{{.*}}: memref<?x!sycl_vec_i64_16_, 4> {{{.*}}}, %{{.*}}: memref<?x!sycl_vec_i64_8_, 4> {{{.*}}}, %{{.*}}: memref<?x!sycl_vec_i64_4_, 4> {{{.*}}}, %{{.*}}: memref<?x!sycl_vec_i64_2_, 4> {{{.*}}}, %{{.*}}: memref<?xi64, 4> {{{.*}}}, %{{.*}}: memref<?xi64, 4> {{{.*}}}) attributes {[[SPIR_FUNCCC]], [[LINKONCE]], {{.*}}}
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_10(
-// CHECK-LLVM-SAME:                                 %"class.sycl::_V1::vec.4" addrspace(4)* noundef align 64 dereferenceable(64) %[[ARG0:.*]], %"class.sycl::_V1::vec.5" addrspace(4)* noundef align 32 dereferenceable(32) %[[ARG1:.*]], %"class.sycl::_V1::vec.6" addrspace(4)* noundef align 16 dereferenceable(16) %[[ARG2:.*]], i64 noundef %{{.*}}, i64 noundef %{{.*}}) #[[FUNCATTRS]] {
-// CHECK-LLVM:         call spir_func void @[[VEC_INITLIST_VEC_CTR:.*]](%"class.sycl::_V1::vec.7" addrspace(4)* %{{.*}}, %"class.sycl::_V1::vec.4" addrspace(4)* %[[ARG0]], %"class.sycl::_V1::vec.5" addrspace(4)* %[[ARG1]], %"class.sycl::_V1::vec.6" addrspace(4)* %[[ARG2]], i64 addrspace(4)* %{{.*}}, i64 addrspace(4)* %{{.*}})
-// CHECK-LLVM:       define linkonce_odr spir_func void @[[VEC_INITLIST_VEC_CTR]](%"class.sycl::_V1::vec.7" addrspace(4)* noundef align 128 dereferenceable_or_null(128) %{{.*}}, %"class.sycl::_V1::vec.4" addrspace(4)* noundef align 64 dereferenceable(64) %{{.*}}, %"class.sycl::_V1::vec.5" addrspace(4)* noundef align 32 dereferenceable(32) %{{.*}}, %"class.sycl::_V1::vec.6" addrspace(4)* noundef align 16 dereferenceable(16) %{{.*}}, i64 addrspace(4)* noundef align 8 dereferenceable(8) %{{.*}}, i64 addrspace(4)* noundef align 8 dereferenceable(8) %{{.*}}) #[[FUNCATTRS]] {
+// CHECK-LLVM-SAME:                                 ptr addrspace(4) noundef align 64 dereferenceable(64) %[[ARG0:.*]], ptr addrspace(4) noundef align 32 dereferenceable(32) %[[ARG1:.*]], ptr addrspace(4) noundef align 16 dereferenceable(16) %[[ARG2:.*]], i64 noundef %{{.*}}, i64 noundef %{{.*}}) #[[FUNCATTRS]] {
+// CHECK-LLVM:         call spir_func void @[[VEC_INITLIST_VEC_CTR:.*]](ptr addrspace(4) %{{.*}}, ptr addrspace(4) %[[ARG0]], ptr addrspace(4) %[[ARG1]], ptr addrspace(4) %[[ARG2]], ptr addrspace(4) %{{.*}}, ptr addrspace(4) %{{.*}})
+// CHECK-LLVM:       define linkonce_odr spir_func void @[[VEC_INITLIST_VEC_CTR]](ptr addrspace(4) noundef align 128 dereferenceable_or_null(128) %{{.*}}, ptr addrspace(4) noundef align 64 dereferenceable(64) %{{.*}}, ptr addrspace(4) noundef align 32 dereferenceable(32) %{{.*}}, ptr addrspace(4) noundef align 16 dereferenceable(16) %{{.*}}, ptr addrspace(4) noundef align 8 dereferenceable(8) %{{.*}}, ptr addrspace(4) noundef align 8 dereferenceable(8) %{{.*}}) #[[FUNCATTRS]] {
 
 extern "C" SYCL_EXTERNAL void cons_10(const sycl::long8 &A,
 				      const sycl::long4 &B,
@@ -277,9 +276,8 @@ extern "C" SYCL_EXTERNAL void cons_10(const sycl::long8 &A,
 
 // CHECK-LLVM-LABEL:  define spir_func void @cons_11()
 // CHECK-LLVM-SAME:                                    #[[FUNCATTRS]] {
-// CHECK-LLVM:          %[[VAL1:.*]] = alloca %"class.sycl::_V1::vec.8", align 16
-// CHECK-LLVM:          %[[VAL2:.*]] = bitcast %"class.sycl::_V1::vec.8"* %[[VAL1]] to i8*
-// CHECK-LLVM:          call void @llvm.memset.p0i8.i64(i8* %[[VAL2]], i8 0, i64 16, i1 false)
+// CHECK-LLVM:          %[[VAL1:.*]] = alloca %"class.sycl::_V1::vec.5", align 16
+// CHECK-LLVM:          call void @llvm.memset.p0.i64(ptr %[[VAL1]], i8 0, i64 16, i1 false)
 
 extern "C" SYCL_EXTERNAL void cons_11() {
   auto vec = sycl::vec<sycl::cl_int, 4>{};

--- a/polygeist/tools/cgeist/Test/Verification/sycl/ex_particle_reduced.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/ex_particle_reduced.cpp
@@ -1,14 +1,14 @@
-// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -c %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=LLVM
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -c %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=LLVM
 
 // Test that the kernel named `kernel_likelihood` is generated with the correct signature.
 // LLVM: define weak_odr spir_kernel void {{.*}}kernel_likelihood(
-// LLVM-SAME: float addrspace(1)* noundef align 4 %0, %"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %1, 
-// LLVM-SAME: %"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %2, %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %3,
-// LLVM-SAME: float addrspace(1)* noundef align 4 %4, %"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %5, 
-// LLVM-SAME: %"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %6, %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %7, 
-// LLVM-SAME: i8 addrspace(1)* noundef align 1 %8, %"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %9, 
-// LLVM-SAME: %"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %10, %"class.sycl::_V1::id.1"* noundef byval(%"class.sycl::_V1::id.1") align 8 %11)
+// LLVM-SAME: ptr addrspace(1) noundef align 4 %0, ptr noundef byval(%"class.sycl::_V1::range.1") align 8 %1, 
+// LLVM-SAME: ptr noundef byval(%"class.sycl::_V1::range.1") align 8 %2, ptr noundef byval(%"class.sycl::_V1::id.1") align 8 %3,
+// LLVM-SAME: ptr addrspace(1) noundef align 4 %4, ptr noundef byval(%"class.sycl::_V1::range.1") align 8 %5, 
+// LLVM-SAME: ptr noundef byval(%"class.sycl::_V1::range.1") align 8 %6, ptr noundef byval(%"class.sycl::_V1::id.1") align 8 %7, 
+// LLVM-SAME: ptr addrspace(1) noundef align 1 %8, ptr noundef byval(%"class.sycl::_V1::range.1") align 8 %9, 
+// LLVM-SAME: ptr noundef byval(%"class.sycl::_V1::range.1") align 8 %10, ptr noundef byval(%"class.sycl::_V1::id.1") align 8 %11)
 
 #include <sycl/sycl.hpp>
 using namespace sycl;

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -1,5 +1,5 @@
 // RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-llvm %s -o %t && rm %t
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w -emit-llvm %s -o %t && rm %t
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/image.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/image.cpp
@@ -1,5 +1,10 @@
 // RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir -o - %s | FileCheck %s 
 
+// TODO: This test is currently not yet working with opaque pointers, 
+// as the MLIR LLVM dialect is lacking support for the LLVM IR 'TargetExtType'
+// that is used for OpenCL/SPIR-V image types.
+// XFAIL: *
+
 #include <sycl/accessor.hpp>
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
@@ -1,5 +1,5 @@
 // RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 
@@ -26,32 +26,31 @@
 // CHECK-MLIR:         sycl.call @"operator()"(%[[VAL_22]], %[[VAL_4:.*]]) {MangledFunctionName = @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_, TypeName = @RoundedRangeKernel} : (memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>, 4>, memref<?x!sycl_item_1_>) -> ()
 // CHECK-MLIR:         gpu.return
 
-// CHECK-LLVM-LABEL: define weak_odr spir_kernel void @_ZTSN4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EE
-// CHECK-LLVM-SAME:     (%"class.sycl::_V1::range.1"* noundef byval(%"class.sycl::_V1::range.1") align 8 %0, 
-// CHECK-LLVM-SAME:     { i32 addrspace(1)* }* noundef byval({ i32 addrspace(1)* }) align 8 %1) #1 {
-// CHECK-LLVM-NEXT:  %3 = alloca %"class.sycl::_V1::item.1.true", align 8
-// CHECK-LLVM-NEXT:  %4 = alloca { i32 addrspace(4)* }, i64 1, align 8
-// CHECK-LLVM-NEXT:  %5 = alloca %"class.sycl::_V1::range.1", align 8
-// CHECK-LLVM-NEXT:  %6 = alloca { %"class.sycl::_V1::range.1", { i32 addrspace(4)* } }, align 8
-// CHECK-LLVM-NEXT:  %7 = getelementptr { %"class.sycl::_V1::range.1", { i32 addrspace(4)* } }, { %"class.sycl::_V1::range.1", { i32 addrspace(4)* } }* %6, i32 0, i32 0
-// CHECK-LLVM-NEXT:  %8 = addrspacecast %"class.sycl::_V1::range.1"* %5 to %"class.sycl::_V1::range.1" addrspace(4)*
-// CHECK-LLVM-NEXT:  %9 = addrspacecast %"class.sycl::_V1::range.1"* %0 to %"class.sycl::_V1::range.1" addrspace(4)*
-// CHECK-LLVM-NEXT:  call spir_func void @_ZN4sycl3_V15rangeILi1EEC1ERKS2_(%"class.sycl::_V1::range.1" addrspace(4)* %8, %"class.sycl::_V1::range.1" addrspace(4)* %9)
-// CHECK-LLVM-NEXT:  %10 = load %"class.sycl::_V1::range.1", %"class.sycl::_V1::range.1"* %5, align 8
-// CHECK-LLVM-NEXT:  store %"class.sycl::_V1::range.1" %10, %"class.sycl::_V1::range.1"* %7, align 8
-// CHECK-LLVM-NEXT:  %11 = getelementptr { %"class.sycl::_V1::range.1", { i32 addrspace(4)* } }, { %"class.sycl::_V1::range.1", { i32 addrspace(4)* } }* %6, i32 0, i32 1
-// CHECK-LLVM-NEXT:  %12 = bitcast { i32 addrspace(1)* }* %1 to { i32 addrspace(4)* }*
-// CHECK-LLVM-NEXT:  %13 = addrspacecast { i32 addrspace(4)* }* %4 to { i32 addrspace(4)* } addrspace(4)*
-// CHECK-LLVM-NEXT:  %14 = addrspacecast { i32 addrspace(4)* }* %12 to { i32 addrspace(4)* } addrspace(4)*
-// CHECK-LLVM-NEXT:  call spir_func void @_ZZ4testRN4sycl3_V15queueEENUlNS0_2idILi1EEEE_C1ERKS5_({ i32 addrspace(4)* } addrspace(4)* %13, { i32 addrspace(4)* } addrspace(4)* %14)
-// CHECK-LLVM-NEXT:  %15 = load { i32 addrspace(4)* }, { i32 addrspace(4)* }* %4, align 8
-// CHECK-LLVM-NEXT:  store { i32 addrspace(4)* } %15, { i32 addrspace(4)* }* %11, align 8
-// CHECK-LLVM-NEXT:  %16 = call spir_func %"class.sycl::_V1::item.1.true" addrspace(4)* @_ZN4sycl3_V16detail7declptrINS0_4itemILi1ELb1EEEEEPT_v()
-// CHECK-LLVM-NEXT:  %17 = call spir_func %"class.sycl::_V1::item.1.true" @_ZN4sycl3_V16detail7Builder10getElementILi1ELb1EEEDTcl7getItemIXT_EXT0_EEEEPNS0_4itemIXT_EXT0_EEE(%"class.sycl::_V1::item.1.true" addrspace(4)* %16)
-// CHECK-LLVM-NEXT:  %18 = addrspacecast { %"class.sycl::_V1::range.1", { i32 addrspace(4)* } }* %6 to { %"class.sycl::_V1::range.1", { i32 addrspace(4)* } } addrspace(4)*
-// CHECK-LLVM-NEXT:  store %"class.sycl::_V1::item.1.true" %17, %"class.sycl::_V1::item.1.true"* %3, align 8
-// CHECK-LLVM-NEXT:  call spir_func void @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_({ %"class.sycl::_V1::range.1", { i32 addrspace(4)* } } addrspace(4)* %18, %"class.sycl::_V1::item.1.true"* %3)
-// CHECK-LLVM-NEXT:  ret void
+// CHECK-LLVM-LABEL: define weak_odr spir_kernel void @_ZTSN4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EE(
+// CHECK-LLVM-SAME:        ptr noundef byval(%"class.sycl::_V1::range.1") align 8 %0, 
+// CHECK-LLVM-SAME:        ptr noundef byval({ ptr addrspace(1) }) align 8 %1)
+// CHECK-LLVM-NEXT:    %3 = alloca %"class.sycl::_V1::item.1.true", align 8
+// CHECK-LLVM-NEXT:    %4 = alloca { ptr addrspace(4) }, i64 1, align 8
+// CHECK-LLVM-NEXT:    %5 = alloca %"class.sycl::_V1::range.1", align 8
+// CHECK-LLVM-NEXT:    %6 = alloca { %"class.sycl::_V1::range.1", { ptr addrspace(4) } }, align 8
+// CHECK-LLVM-NEXT:    %7 = getelementptr { %"class.sycl::_V1::range.1", { ptr addrspace(4) } }, ptr %6, i32 0, i32 0
+// CHECK-LLVM-NEXT:    %8 = addrspacecast ptr %5 to ptr addrspace(4)
+// CHECK-LLVM-NEXT:    %9 = addrspacecast ptr %0 to ptr addrspace(4)
+// CHECK-LLVM-NEXT:    call spir_func void @_ZN4sycl3_V15rangeILi1EEC1ERKS2_(ptr addrspace(4) %8, ptr addrspace(4) %9)
+// CHECK-LLVM-NEXT:    %10 = load %"class.sycl::_V1::range.1", ptr %5, align 8
+// CHECK-LLVM-NEXT:    store %"class.sycl::_V1::range.1" %10, ptr %7, align 8
+// CHECK-LLVM-NEXT:    %11 = getelementptr { %"class.sycl::_V1::range.1", { ptr addrspace(4) } }, ptr %6, i32 0, i32 1
+// CHECK-LLVM-NEXT:    %12 = addrspacecast ptr %4 to ptr addrspace(4)
+// CHECK-LLVM-NEXT:    %13 = addrspacecast ptr %1 to ptr addrspace(4)
+// CHECK-LLVM-NEXT:    call spir_func void @_ZZ4testRN4sycl3_V15queueEENUlNS0_2idILi1EEEE_C1ERKS5_(ptr addrspace(4) %12, ptr addrspace(4) %13)
+// CHECK-LLVM-NEXT:    %14 = load { ptr addrspace(4) }, ptr %4, align 8
+// CHECK-LLVM-NEXT:    store { ptr addrspace(4) } %14, ptr %11, align 8
+// CHECK-LLVM-NEXT:    %15 = call spir_func ptr addrspace(4) @_ZN4sycl3_V16detail7declptrINS0_4itemILi1ELb1EEEEEPT_v()
+// CHECK-LLVM-NEXT:    %16 = call spir_func %"class.sycl::_V1::item.1.true" @_ZN4sycl3_V16detail7Builder10getElementILi1ELb1EEEDTcl7getItemIXT_EXT0_EEEEPNS0_4itemIXT_EXT0_EEE(ptr addrspace(4) %15)
+// CHECK-LLVM-NEXT:    %17 = addrspacecast ptr %6 to ptr addrspace(4)
+// CHECK-LLVM-NEXT:    store %"class.sycl::_V1::item.1.true" %16, ptr %3, align 8
+// CHECK-LLVM-NEXT:    call spir_func void @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_(ptr addrspace(4) %17, ptr %3)
+// CHECK-LLVM-NEXT:    ret void
 
 int test(sycl::queue &q) {
   int *x = sycl::malloc_device<int>(10, q);

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -1,5 +1,5 @@
 // RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 
@@ -7,7 +7,7 @@
 // CHECK-MLIR-DAG: !sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
 // CHECK-MLIR-DAG: !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
 
-// CHECK-LLVM-DAG: %"class.sycl::_V1::accessor.1" = type { %"class.sycl::_V1::detail::AccessorImplDevice.1", { i32 addrspace(1)* } }
+// CHECK-LLVM-DAG: %"class.sycl::_V1::accessor.1" = type { %"class.sycl::_V1::detail::AccessorImplDevice.1", { ptr addrspace(1) } }
 // CHECK-LLVM-DAG: %"class.sycl::_V1::detail::AccessorImplDevice.1" = type { %"class.sycl::_V1::id.1", %"class.sycl::_V1::range.1", %"class.sycl::_V1::range.1" }
 // CHECK-LLVM-DAG: %"class.sycl::_V1::id.1" = type { %"class.sycl::_V1::detail::array.1" }
 // CHECK-LLVM-DAG: %"class.sycl::_V1::detail::array.1" = type { [1 x i64] }
@@ -24,8 +24,8 @@
 // CHECK-MLIR-SAME:  kernel attributes {[[CCONV:llvm.cconv = #llvm.cconv<spir_kernelcc>]], [[LINKAGE:llvm.linkage = #llvm.linkage<weak_odr>]],
 // CHECK-MLIR-NOT: gpu.func kernel
 
-// CHECK-LLVM: define weak_odr spir_kernel void @_ZTS8kernel_1(i32 addrspace(1)* {{.*}}, [[RANGE_TY:%"class.sycl::_V1::range.1"]]* noundef byval([[RANGE_TY]]) align 8 {{.*}}, [[RANGE_TY]]* noundef byval([[RANGE_TY]]) align 8 {{.*}}, 
-// CHECK-LLVM-SAME:  [[ID_TY:%"class.sycl::_V1::id.1"]]* noundef byval([[ID_TY]]) align 8 {{.*}}) #[[FUNCATTRS:[0-9]+]]
+// CHECK-LLVM: define weak_odr spir_kernel void @_ZTS8kernel_1(ptr addrspace(1) {{.*}}, ptr noundef byval([[RANGE_TY:%"class.sycl::_V1::range.1"]]) align 8 {{.*}}, ptr noundef byval([[RANGE_TY]]) align 8 {{.*}}, 
+// CHECK-LLVM-SAME:  ptr noundef byval([[ID_TY:%"class.sycl::_V1::id.1"]]) align 8 {{.*}}) #[[FUNCATTRS:[0-9]+]]
 class kernel_1 {
  sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write> A;
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
@@ -1,5 +1,5 @@
 // RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/options.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/options.cpp
@@ -1,5 +1,5 @@
 // COM: Ensure warnings are suppressed (-w)
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -w -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir %s -S -emit-llvm -o - 2>&1 | FileCheck %s --implicit-check-not="{{warning|Warning}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -w -fsycl -fsycl-device-only -fsycl-targets=spir64-unknown-unknown-syclmlir %s -S -emit-llvm -o - 2>&1 | FileCheck %s --implicit-check-not="{{warning|Warning}}:"
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/parallel_for.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/parallel_for.cpp
@@ -1,10 +1,10 @@
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.0fast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.0fast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
 
 // Test that the LLVMIR generated is verifiable.
 // RUN: opt -passes=verify -disable-output < %t.bc
@@ -12,9 +12,13 @@
 // Verify that LLVMIR generated is translatable to SPIRV.
 // RUN: llvm-spirv %t.bc
 
+// Test that all referenced sycl header functions are generated.
+// RUN: llvm-dis %t.bc
+// RUN: cat %t.ll | FileCheck %s --check-prefix=LLVM 
+
 // Test that the kernel named `kernel_parallel_for_id` is generated with the correct signature.
 // LLVM: define weak_odr spir_kernel void {{.*}}kernel_parallel_for_id(
-// LLVM-SAME:  i32 addrspace(1)* {{.*}}, [[RANGE_TY:%"class.sycl::_V1::range.1"]]* noundef byval([[RANGE_TY]]) {{.*}}, [[RANGE_TY]]* noundef byval([[RANGE_TY]]) {{.*}}, [[ID_TY:%"class.sycl::_V1::id.1"]]* noundef byval([[ID_TY]]) {{.*}})
+// LLVM-SAME:  ptr addrspace(1) {{.*}}, ptr noundef byval([[RANGE_TY:%"class.sycl::_V1::range.1"]]) {{.*}}, ptr noundef byval([[RANGE_TY]]) {{.*}}, ptr noundef byval([[ID_TY:%"class.sycl::_V1::id.1"]]) {{.*}})
 
 #include <sycl/sycl.hpp>
 using namespace sycl;

--- a/polygeist/tools/cgeist/Test/Verification/sycl/pure_const_attrs.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/pure_const_attrs.cpp
@@ -1,5 +1,5 @@
 // RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 // CHECK-MLIR-DAG: func.func private @func_const() {{.*}} attributes {{{.*}}passthrough = [{{.*}}"nounwind", {{.*}}"willreturn", {{.*}}["memory", "0"]{{.*}}]}
 // CHECK-MLIR-DAG: func.func private @func_pure() {{.*}} attributes {{{.*}}passthrough = [{{.*}}"nounwind", {{.*}}"willreturn", {{.*}}["memory", "21"]{{.*}}]}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/restrict.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/restrict.cpp
@@ -1,33 +1,33 @@
 // RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 
 // CHECK-MLIR-DAG: func.func @test_int(%arg0: memref<?xi32, 4> {{{.*}}llvm.noalias{{.*}}}, %arg1: memref<?xi32, 4> {{{.*}}llvm.noalias{{.*}}}) 
-// CHECK-LLVM-DAG: define spir_func {{.*}}i32 @test_int(i32 addrspace(4)* noalias {{.*}}%0, i32 addrspace(4)* noalias {{.*}}%1)
+// CHECK-LLVM-DAG: define spir_func {{.*}}i32 @test_int(ptr addrspace(4) noalias {{.*}}%0, ptr addrspace(4) noalias {{.*}}%1)
 
 extern "C" SYCL_EXTERNAL int test_int(int * __restrict__ a, int * __restrict__ b) {}
 
 // CHECK-MLIR-DAG: func.func @test_struct(%arg0: !llvm.ptr<4> {{{.*}}llvm.noalias{{.*}}}, %arg1: !llvm.ptr<4> {{{.*}}llvm.noalias{{.*}}})
-// CHECK-LLVM-DAG: define spir_func void @test_struct({ i32 } addrspace(4)* noalias {{.*}}%0, { i32 } addrspace(4)* noalias {{.*}}%1)
+// CHECK-LLVM-DAG: define spir_func void @test_struct(ptr addrspace(4) noalias {{.*}}%0, ptr addrspace(4) noalias {{.*}}%1)
 struct S {
   int i;
 };
 extern "C" SYCL_EXTERNAL void test_struct(struct S * __restrict__ a, struct S * __restrict__ b) {}
 
 // CHECK-MLIR-DAG: func.func @test_vec(%arg0: memref<?x!sycl_vec_f64_16_, 4> {{{.*}}llvm.noalias{{.*}}}, %arg1: memref<?x!sycl_vec_f64_16_, 4> {{{.*}}llvm.noalias{{.*}}})
-// CHECK-LLVM-DAG: define spir_func void @test_vec(%"class.sycl::_V1::vec" addrspace(4)* noalias {{.*}}%0, %"class.sycl::_V1::vec" addrspace(4)* noalias {{.*}}%1)
+// CHECK-LLVM-DAG: define spir_func void @test_vec(ptr addrspace(4) noalias {{.*}}%0, ptr addrspace(4) noalias {{.*}}%1)
 extern "C" SYCL_EXTERNAL void test_vec(sycl::vec<sycl::cl_double, 16> * __restrict__ a, const sycl::vec<sycl::cl_double, 16> * __restrict__ b) {}
 
 // CHECK-MLIR-DAG: func.func @_ZN1B10test_classEP1APS_(%arg0: !llvm.ptr<4> {{.*}}, %arg1: !llvm.ptr<4> {llvm.noalias{{.*}}}, %arg2: !llvm.ptr<4> {llvm.noalias{{.*}}})
-// CHECK-LLVM-DAG: define linkonce_odr spir_func void @_ZN1B10test_classEP1APS_({ i8 } addrspace(4)* {{.*}}%0, { i8 } addrspace(4)* noalias {{.*}}%1, { i8 } addrspace(4)* noalias {{.*}}%2)
+// CHECK-LLVM-DAG: define linkonce_odr spir_func void @_ZN1B10test_classEP1APS_(ptr addrspace(4) {{.*}}%0, ptr addrspace(4) noalias {{.*}}%1, ptr addrspace(4) noalias {{.*}}%2)
 class A {};
 class B {
   SYCL_EXTERNAL void test_class(class A * __restrict__ a, class B * __restrict__ b) {}
 };
 
 // CHECK-MLIR-DAG: gpu.func @{{.*}}kernel_args_restrict(%arg0: memref<?xi32, 1> {{{.*}}llvm.noalias{{.*}}}, %arg1: memref<?x!sycl_range_1_>{{.*}}, %arg2: memref<?x!sycl_range_1_>{{.*}}, %arg3: memref<?x!sycl_id_1_>{{.*}}, %arg4: memref<?xi32, 1> {{{.*}}llvm.noalias{{.*}}}, %arg5: memref<?x!sycl_range_1_>{{.*}}, %arg6: memref<?x!sycl_range_1_>{{.*}}, %arg7: memref<?x!sycl_id_1_>{{.*}})
-// CHECK-LLVM-DAG: define weak_odr spir_kernel void @{{.*}}kernel_args_restrict(i32 addrspace(1)* {{.*}}noalias{{.*}} %0, %"class.sycl::_V1::range.1"* {{.*}} %1, %"class.sycl::_V1::range.1"* {{.*}} %2, %"class.sycl::_V1::id.1"* {{.*}} %3, i32 addrspace(1)* {{.*}}noalias{{.*}} %4, %"class.sycl::_V1::range.1"* {{.*}} %5, %"class.sycl::_V1::range.1"* {{.*}} %6, %"class.sycl::_V1::id.1"* {{.*}} %7)
+// CHECK-LLVM-DAG: define weak_odr spir_kernel void @{{.*}}kernel_args_restrict(ptr addrspace(1) {{.*}}noalias{{.*}} %0, ptr {{.*}} %1, ptr {{.*}} %2, ptr {{.*}} %3, ptr addrspace(1) {{.*}}noalias{{.*}} %4, ptr {{.*}} %5, ptr {{.*}} %6, ptr {{.*}} %7)
 using namespace sycl;
 int args_restrict(std::array<int, 1> &A, std::array<int, 1> &B) {
   queue q;

--- a/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
@@ -1,10 +1,10 @@
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.Ofast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.Ofast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
 
 // Test that the LLVMIR generated is verifiable.
 // RUN: opt -passes=verify -disable-output < %t.bc
@@ -18,7 +18,7 @@
 
 // Test that the kernel named `kernel_single_task` is generated with the correct signature.
 // LLVM: define weak_odr spir_kernel void {{.*}}kernel_single_task(
-// LLVM-SAME:  i32 addrspace(1)* {{.*}}, [[RANGE_TY:%"class.sycl::_V1::range.1"]]* noundef byval([[RANGE_TY]]) {{.*}}, [[RANGE_TY]]* noundef byval([[RANGE_TY]]) {{.*}}, [[ID_TY:%"class.sycl::_V1::id.1"]]* noundef byval([[ID_TY]]) {{.*}})
+// LLVM-SAME:  ptr addrspace(1) {{.*}}, ptr noundef byval([[RANGE_TY:%"class.sycl::_V1::range.1"]]) {{.*}}, ptr noundef byval([[RANGE_TY]]) {{.*}}, ptr noundef byval([[ID_TY:%"class.sycl::_V1::id.1"]]) {{.*}})
 
 #include <sycl/sycl.hpp>
 using namespace sycl;

--- a/polygeist/tools/cgeist/Test/Verification/sycl/stream-copy.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/stream-copy.cpp
@@ -1,10 +1,10 @@
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.Ofast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.Ofast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
 
 // Test that the LLVMIR generated is verifiable.
 // RUN: opt -passes=verify -disable-output < %t.bc
@@ -12,9 +12,13 @@
 // Verify that LLVMIR generated is translatable to SPIRV.
 // RUN: llvm-spirv %t.bc
 
+// Test that all referenced sycl header functions are generated.
+// RUN: llvm-dis %t.bc
+// RUN: cat %t.ll | FileCheck %s --check-prefix=LLVM
+
 // Test that the kernel named `kernel_stream_copy` is generated with the correct signature.
 // LLVM: define weak_odr spir_kernel void {{.*}}kernel_stream_copy(
-// LLVM-SAME:  i32 addrspace(1)* {{.*}}, [[RANGE_TY:%"class.sycl::_V1::range.1"]]* noundef byval([[RANGE_TY]]) {{.*}}, [[RANGE_TY]]* noundef byval([[RANGE_TY]]) {{.*}}, [[ID_TY:%"class.sycl::_V1::id.1"]]* noundef byval([[ID_TY]]) {{.*}})
+// LLVM-SAME:  ptr addrspace(1) {{.*}}, ptr noundef byval([[RANGE_TY:%"class.sycl::_V1::range.1"]]) {{.*}}, ptr noundef byval([[RANGE_TY]]) {{.*}}, ptr noundef byval([[ID_TY:%"class.sycl::_V1::id.1"]]) {{.*}})
 
 #include <sycl/sycl.hpp>
 using namespace sycl;

--- a/polygeist/tools/cgeist/Test/Verification/sycl/stream-triad.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/stream-triad.cpp
@@ -1,10 +1,10 @@
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.Ofast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.Ofast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
 
 // Test that the LLVMIR generated is verifiable.
 // RUN: opt -passes=verify -disable-output < %t.bc
@@ -12,9 +12,13 @@
 // Verify that LLVMIR generated is translatable to SPIRV.
 // RUN: llvm-spirv %t.bc
 
+// Test that all referenced sycl header functions are generated.
+// RUN: llvm-dis %t.bc
+// RUN: cat %t.ll | FileCheck %s --check-prefix=LLVM 
+
 // Test that the kernel named `kernel_stream_triad` is generated with the correct signature.
 // LLVM: define weak_odr spir_kernel void {{.*}}kernel_stream_triad(
-// LLVM-SAME:  i32 addrspace(1)* {{.*}}, [[RANGE_TY:%"class.sycl::_V1::range.1"]]* noundef byval([[RANGE_TY]]) {{.*}}, [[RANGE_TY]]* noundef byval([[RANGE_TY]]) {{.*}}, [[ID_TY:%"class.sycl::_V1::id.1"]]* noundef byval([[ID_TY]]) {{.*}})
+// LLVM-SAME:  ptr addrspace(1) {{.*}}, ptr noundef byval([[RANGE_TY:%"class.sycl::_V1::range.1"]]) {{.*}}, ptr noundef byval([[RANGE_TY]]) {{.*}}, ptr noundef byval([[ID_TY:%"class.sycl::_V1::id.1"]]) {{.*}})
 
 #include <sycl/sycl.hpp>
 using namespace sycl;

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -1,5 +1,5 @@
 // RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 
@@ -18,8 +18,8 @@
 // CHECK-LLVM-LABEL: define spir_func void @cons_5()
 // CHECK-LLVM-SAME:  #[[FUNCATTRS0:[0-9]+]] {
 // CHECK-LLVM-NEXT:  [[ACCESSOR:%.*]] = alloca %"class.sycl::_V1::accessor.1", align 8
-// CHECK-LLVM-NEXT:  [[ACAST:%.*]] = addrspacecast %"class.sycl::_V1::accessor.1"* [[ACCESSOR]] to %"class.sycl::_V1::accessor.1" addrspace(4)*
-// CHECK-LLVM-NEXT:  call spir_func void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(%"class.sycl::_V1::accessor.1" addrspace(4)* [[ACAST]])
+// CHECK-LLVM-NEXT:  [[ACAST:%.*]] = addrspacecast ptr [[ACCESSOR]] to ptr addrspace(4)
+// CHECK-LLVM-NEXT:  call spir_func void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(ptr addrspace(4) [[ACAST]])
 
 // CHECK-LLVM-LABEL: define weak_odr spir_kernel void @_ZTSZZ16host_single_taskvENKUlRN4sycl3_V17handlerEE_clES2_E18kernel_single_task
 // CHECK-LLVM-SAME: #[[FUNCATTRS1:[0-9]+]]

--- a/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
@@ -1,5 +1,5 @@
 // RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
-// RUN: clang++ -Xcgeist --use-opaque-pointers=0 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
 
 #include <sycl/sycl.hpp>
 #define N 32
@@ -17,10 +17,10 @@
 // CHECK-MLIR:      affine.store [[RESULT]], {{.*}}[0] : memref<?xf32, 4>
 
 // CHECK-LLVM:       define internal spir_func void [[FUNC:@_ZZZ21vec_add_device_simpleRSt5arrayIfLm32EES1_S1_ENKUlRN4sycl3_V17handlerEE_clES5_ENKUlNS3_2idILi1EEEE_clES8_]]({{.*}}) #[[FUNCATTRS:[0-9]+]]
-// CHECK-LLVM-DAG:   [[V1:%.*]] = load float, float addrspace(4)* {{.*}}, align 4
-// CHECK-LLVM-DAG:   [[V2:%.*]] = load float, float addrspace(4)* {{.*}}, align 4
+// CHECK-LLVM-DAG:   [[V1:%.*]] = load float, ptr addrspace(4) {{.*}}, align 4
+// CHECK-LLVM-DAG:   [[V2:%.*]] = load float, ptr addrspace(4) {{.*}}, align 4
 // CHECK-LLVM:       [[RESULT:%.*]] = fadd float [[V1]], [[V2]]
-// CHECK-LLVM:       store float [[RESULT]], float addrspace(4)* {{.*}}, align 4
+// CHECK-LLVM:       store float [[RESULT]], ptr addrspace(4) {{.*}}, align 4
 
 // CHECK-LLVM:       define weak_odr spir_kernel void @{{.*}}vec_add_simple({{.*}}) #[[FUNCATTRS1:[0-9]+]]
 // CHECK-LLVM:       call spir_func void [[FUNC]]

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -403,7 +403,7 @@ static LogicalResult optimize(mlir::MLIRContext &Ctx,
     OptPM.addPass(mlir::createCSEPass());
     if (EnableLICM)
       OptPM.addPass(polygeist::createLICMPass(
-          {options.getCgeistOpts().getRelaxedAliasing()}));
+          {options.getCgeistOpts().getRelaxedAliasing(), UseOpaquePointers}));
     else
       OptPM.addPass(mlir::createLoopInvariantCodeMotionPass());
     OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
@@ -455,6 +455,9 @@ static LogicalResult optimizeCUDA(mlir::MLIRContext &Ctx,
   GreedyRewriteConfig CanonicalizerConfig;
   CanonicalizerConfig.maxIterations = CanonicalizeIterations;
 
+  polygeist::LICMOptions LICMOpt{options.getCgeistOpts().getRelaxedAliasing(),
+                                 UseOpaquePointers};
+
   mlir::PassManager PM(&Ctx);
   if (mlir::failed(enableOptionsPM(PM)))
     return failure();
@@ -476,8 +479,7 @@ static LogicalResult optimizeCUDA(mlir::MLIRContext &Ctx,
   NOptPM2.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
   NOptPM2.addPass(mlir::createCSEPass());
   if (EnableLICM)
-    NOptPM2.addPass(polygeist::createLICMPass(
-        {options.getCgeistOpts().getRelaxedAliasing(), UseOpaquePointers}));
+    NOptPM2.addPass(polygeist::createLICMPass(LICMOpt));
   else
     NOptPM2.addPass(mlir::createLoopInvariantCodeMotionPass());
   NOptPM2.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
@@ -485,8 +487,7 @@ static LogicalResult optimizeCUDA(mlir::MLIRContext &Ctx,
     NOptPM2.addPass(polygeist::createCanonicalizeForPass());
     NOptPM2.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
     if (EnableLICM)
-      NOptPM2.addPass(polygeist::createLICMPass(
-          {options.getCgeistOpts().getRelaxedAliasing(), UseOpaquePointers}));
+      NOptPM2.addPass(polygeist::createLICMPass(LICMOpt));
     else
       NOptPM2.addPass(mlir::createLoopInvariantCodeMotionPass());
     NOptPM2.addPass(polygeist::createRaiseSCFToAffinePass());
@@ -500,8 +501,7 @@ static LogicalResult optimizeCUDA(mlir::MLIRContext &Ctx,
     NOptPM2.addPass(polygeist::createMem2RegPass());
     NOptPM2.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
     if (EnableLICM)
-      NOptPM2.addPass(polygeist::createLICMPass(
-          {options.getCgeistOpts().getRelaxedAliasing(), UseOpaquePointers}));
+      NOptPM2.addPass(polygeist::createLICMPass(LICMOpt));
     else
       NOptPM2.addPass(mlir::createLoopInvariantCodeMotionPass());
     NOptPM2.addPass(polygeist::createRaiseSCFToAffinePass());

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -387,7 +387,7 @@ static LogicalResult optimize(mlir::MLIRContext &Ctx,
   if (OptLevel != llvm::OptimizationLevel::O0) {
     PM.addPass(polygeist::createArgumentPromotionPass());
     PM.addPass(polygeist::createKernelDisjointSpecializationPass(
-        {options.getCgeistOpts().getRelaxedAliasing()}));
+        {options.getCgeistOpts().getRelaxedAliasing(), UseOpaquePointers}));
 
     mlir::OpPassManager &OptPM = PM.nestAny();
     OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
@@ -409,7 +409,7 @@ static LogicalResult optimize(mlir::MLIRContext &Ctx,
     OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
     if (DetectReduction)
       OptPM.addPass(polygeist::createDetectReductionPass(
-          {options.getCgeistOpts().getRelaxedAliasing()}));
+          {options.getCgeistOpts().getRelaxedAliasing(), UseOpaquePointers}));
 
     OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
     OptPM.addPass(mlir::createCSEPass());
@@ -462,7 +462,7 @@ static LogicalResult optimizeCUDA(mlir::MLIRContext &Ctx,
   mlir::OpPassManager &OptPM = PM.nestAny();
   OptPM.addPass(mlir::createLowerAffinePass());
   OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
-  PM.addPass(polygeist::createParallelLowerPass());
+  PM.addPass(polygeist::createParallelLowerPass({UseOpaquePointers}));
   PM.addPass(mlir::createSymbolDCEPass());
   mlir::OpPassManager &NOptPM = PM.nestAny();
   NOptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
@@ -477,7 +477,7 @@ static LogicalResult optimizeCUDA(mlir::MLIRContext &Ctx,
   NOptPM2.addPass(mlir::createCSEPass());
   if (EnableLICM)
     NOptPM2.addPass(polygeist::createLICMPass(
-        {options.getCgeistOpts().getRelaxedAliasing()}));
+        {options.getCgeistOpts().getRelaxedAliasing(), UseOpaquePointers}));
   else
     NOptPM2.addPass(mlir::createLoopInvariantCodeMotionPass());
   NOptPM2.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
@@ -486,7 +486,7 @@ static LogicalResult optimizeCUDA(mlir::MLIRContext &Ctx,
     NOptPM2.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
     if (EnableLICM)
       NOptPM2.addPass(polygeist::createLICMPass(
-          {options.getCgeistOpts().getRelaxedAliasing()}));
+          {options.getCgeistOpts().getRelaxedAliasing(), UseOpaquePointers}));
     else
       NOptPM2.addPass(mlir::createLoopInvariantCodeMotionPass());
     NOptPM2.addPass(polygeist::createRaiseSCFToAffinePass());
@@ -501,7 +501,7 @@ static LogicalResult optimizeCUDA(mlir::MLIRContext &Ctx,
     NOptPM2.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
     if (EnableLICM)
       NOptPM2.addPass(polygeist::createLICMPass(
-          {options.getCgeistOpts().getRelaxedAliasing()}));
+          {options.getCgeistOpts().getRelaxedAliasing(), UseOpaquePointers}));
     else
       NOptPM2.addPass(mlir::createLoopInvariantCodeMotionPass());
     NOptPM2.addPass(polygeist::createRaiseSCFToAffinePass());
@@ -597,7 +597,7 @@ static LogicalResult finalizeCUDA(mlir::PassManager &PM, Options &options) {
     OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
     if (EnableLICM)
       OptPM.addPass(polygeist::createLICMPass(
-          {options.getCgeistOpts().getRelaxedAliasing()}));
+          {options.getCgeistOpts().getRelaxedAliasing(), UseOpaquePointers}));
     else
       OptPM.addPass(mlir::createLoopInvariantCodeMotionPass());
     OptPM.addPass(polygeist::createRaiseSCFToAffinePass());


### PR DESCRIPTION
Next step to add opaque pointer support for the SYCL-MLIR project: Enable `cgeist` to produce LLVM IR using opaque pointers as output from the compilation. 

Emitting LLVM IR with typed or opaque pointers is controlled by the `--use-opaque-pointers` option. 

Amongst others, the following steps were taken to enable this:
* Detect recursive structs based on Clang types, not LLVM types resulting from translation
* Fix some issues in the Polygeist and SYCL to LLVM lowerings
* Translate type attributes of `getelementptr` and `alloca` LLVM dialect operations