### PR TITLE
[SYCL][CUDA] Fix non decorated address space for cuda joint_matrix.

### DIFF
--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-tensorcores.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-tensorcores.hpp
@@ -8,6 +8,7 @@
 // ===-------------------------------------------------------------------=== //
 
 #pragma once
+#include "utils.hpp"
 #include "matrix-unified-utils.hpp"
 #include <sycl/ext/oneapi/bfloat16.hpp>
 


### PR DESCRIPTION
Corresponding changes to #9244 for cuda backend. I think I should update the check_device_code tests to also check for local address space here too, but I should probably wait until https://github.com/intel/llvm/pull/8874 is merged.
I haven't added any static asserts for private address space (which also isn't supported in the cuda backend), since we only ever call these load/store functions from joint_matrix_load/store which already has the appropriate asserts.