### PR TITLE
[SYCL][DevOps] Switch GEN9 Linux pre-commit to fused L0/OCL task

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -48,7 +48,7 @@ jobs:
     uses: ./.github/workflows/sycl_gen_test_matrix.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
-      lts_config: "hip_amdgpu;ocl_x64;ocl_gen9;l0_gen9;esimd_emu;cuda_aws;win_l0_gen12"
+      lts_config: "hip_amdgpu;ocl_x64;l0_ocl_gen9;esimd_emu;cuda_aws;win_l0_gen12"
 
   linux_default:
     name: Linux

--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -48,7 +48,7 @@ jobs:
     uses: ./.github/workflows/sycl_gen_test_matrix.yml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
-      lts_config: "hip_amdgpu;ocl_x64;l0_ocl_gen9;esimd_emu;cuda_aws;win_l0_gen12"
+      lts_config: "hip_amdgpu;ocl_x64;lin_gen9;esimd_emu;cuda_aws;win_l0_gen12"
 
   linux_default:
     name: Linux

--- a/devops/test_configs.json
+++ b/devops/test_configs.json
@@ -1,8 +1,8 @@
 {
   "lts": [
     {
-      "config": "l0_ocl_gen9",
-      "name": "L0/OCL GEN9 LLVM Test Suite",
+      "config": "lin_gen9",
+      "name": "SYCL End-to-End tests on Intel GEN9 GPU on Linux",
       "runs-on": [
         "Linux",
         "gen9"

--- a/devops/test_configs.json
+++ b/devops/test_configs.json
@@ -2,7 +2,7 @@
   "lts": [
     {
       "config": "lin_gen9",
-      "name": "SYCL End-to-End tests on Intel GEN9 GPU on Linux",
+      "name": "SYCL E2E on Intel GEN9 GPU",
       "runs-on": [
         "Linux",
         "gen9"

--- a/devops/test_configs.json
+++ b/devops/test_configs.json
@@ -1,6 +1,18 @@
 {
   "lts": [
     {
+      "config": "l0_ocl_gen9",
+      "name": "L0/OCL GEN9 LLVM Test Suite",
+      "runs-on": [
+        "Linux",
+        "gen9"
+      ],
+      "image": "${{ inputs.intel_drivers_image }}",
+      "container_options": "-u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN",
+      "targets": "ext_oneapi_level_zero:gpu;opencl:gpu",
+      "cmake_args": ""
+    },
+    {
       "config": "l0_gen9",
       "name": "L0 GEN9 LLVM Test Suite",
       "runs-on": [


### PR DESCRIPTION
SYCL End-to-End test spend most of the time on compilation. Running them against two targets with a single compilation can reduced the load generated in half.