### PR TITLE
[SYCL] [L0] Correct the device id check for PVC.

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero.hpp
@@ -182,7 +182,10 @@ struct _ur_device_handle_t : _ur_object {
   bool isSubDevice() { return RootDevice != nullptr; }
 
   // Is this a Data Center GPU Max series (aka PVC).
-  bool isPVC() { return (ZeDeviceProperties->deviceId & 0xff0) == 0xbd0; }
+  bool isPVC() {
+    return (ZeDeviceProperties->deviceId & 0xff0) == 0xbd0 ||
+           (ZeDeviceProperties->deviceId & 0xff0) == 0xb60;
+  }
 
   // Does this device represent a single compute slice?
   bool isCCS() const {

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero.hpp
@@ -181,7 +181,10 @@ struct _ur_device_handle_t : _ur_object {
 
   bool isSubDevice() { return RootDevice != nullptr; }
 
-  // Is this a Data Center GPU Max series (aka PVC).
+  // Is this a Data Center GPU Max series (aka PVC)?
+  // TODO: change to use
+  // https://spec.oneapi.io/level-zero/latest/core/api.html#ze-device-ip-version-ext-t
+  // when that is stable.
   bool isPVC() {
     return (ZeDeviceProperties->deviceId & 0xff0) == 0xbd0 ||
            (ZeDeviceProperties->deviceId & 0xff0) == 0xb60;


### PR DESCRIPTION
Account for the various device ids used for PVC GPUs.