### PR TITLE
[SYCL][Pulldown] Fix llvm-spirv pulldown

### DIFF
--- a/llvm-spirv/test/builtin-functions.ll
+++ b/llvm-spirv/test/builtin-functions.ll
@@ -1,5 +1,6 @@
 ; RUN: llvm-as %s -o %t.bc
-; RUN: llvm-spirv %t.bc -spirv-text -o %t
+; RUN: llvm-spirv %t.bc -o %t.spv
+; RUN: llvm-spirv --to-text %t.spv -o %t
 ; RUN: llvm-spirv -r %t -spirv-text --spirv-target-env=SPV-IR --spirv-builtin-format=function -o %t2_rev.bc
 ; RUN: llvm-spirv -r %t -spirv-text --spirv-target-env=SPV-IR --spirv-builtin-format=global -o %t3_rev.bc
 ; RUN: llvm-spirv -r %t -spirv-text --spirv-builtin-format=function -o %t2_rev_ocl.bc

--- a/llvm-spirv/test/transcoding/spirv-target-types-buffer.ll
+++ b/llvm-spirv/test/transcoding/spirv-target-types-buffer.ll
@@ -8,7 +8,7 @@ target triple = "spir-unknown-unknown"
 
 ; CHECK-SPIRV: Capability VectorComputeINTEL
 ; CHECK-SPIRV: Extension "SPV_INTEL_vector_compute"
-; CHECK-SPIRV: Name [[#FuncName:]] "foo"
+; CHECK-SPIRV: EntryPoint {{[0-9]+}} [[#FuncName:]] "foo"
 ; CHECK-SPIRV: Name [[#ParamName:]] "a"
 ; CHECK-SPIRV: TypeVoid  [[#VoidT:]]
 ; CHECK-SPIRV: TypeBufferSurfaceINTEL [[#BufferID:]]


### PR DESCRIPTION
the builtin-functions one is a real issue but it was introduced before just exposed by this test, i can reproduce it in current sycl branch HEAD, i will make an internal tracker

second one is expected because of entry point wrapper thing reverted here

@kchusha should be safe to pull this now