### PR TITLE
[SYCL-MLIR] Add `LoopInternalization` pass (part 1)

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.h
@@ -56,6 +56,7 @@ createParallelLowerPass(const ParallelLowerOptions &options);
 std::unique_ptr<Pass> createRaiseSCFToAffinePass();
 std::unique_ptr<Pass> createRemoveTrivialUsePass();
 std::unique_ptr<Pass> createReplaceAffineCFGPass();
+std::unique_ptr<Pass> createSYCLInternalization();
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.h
@@ -47,7 +47,7 @@ std::unique_ptr<Pass> createKernelDisjointSpecializationPass(
 std::unique_ptr<Pass> createLICMPass();
 std::unique_ptr<Pass> createLICMPass(const LICMOptions &options);
 std::unique_ptr<Pass> createLegalizeForSPIRVPass();
-std::unique_ptr<Pass> createLoopInternalization();
+std::unique_ptr<Pass> createLoopInternalizationPass();
 std::unique_ptr<Pass> createLoopRestructurePass();
 std::unique_ptr<Pass> createMem2RegPass();
 std::unique_ptr<Pass> createOpenMPOptPass();

--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.h
@@ -47,6 +47,7 @@ std::unique_ptr<Pass> createKernelDisjointSpecializationPass(
 std::unique_ptr<Pass> createLICMPass();
 std::unique_ptr<Pass> createLICMPass(const LICMOptions &options);
 std::unique_ptr<Pass> createLegalizeForSPIRVPass();
+std::unique_ptr<Pass> createLoopInternalization();
 std::unique_ptr<Pass> createLoopRestructurePass();
 std::unique_ptr<Pass> createMem2RegPass();
 std::unique_ptr<Pass> createOpenMPOptPass();
@@ -56,7 +57,6 @@ createParallelLowerPass(const ParallelLowerOptions &options);
 std::unique_ptr<Pass> createRaiseSCFToAffinePass();
 std::unique_ptr<Pass> createRemoveTrivialUsePass();
 std::unique_ptr<Pass> createReplaceAffineCFGPass();
-std::unique_ptr<Pass> createSYCLInternalization();
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
@@ -124,13 +124,13 @@ def LLVMLegalizeForSPIRV : Pass<"legalize-for-spirv"> {
   let dependentDialects = ["LLVM::LLVMDialect"];  
 }
 
-def LoopInternalization : InterfacePass<"loop-internalization", "LoopLikeOpInterface"> {
+def LoopInternalization : Pass<"loop-internalization"> {
   let summary = "Promote SYCL memory accesses in a loop nest to shared local memory";
   let description = [{
     SYCL memory accesses in perfectly nested loops are promoted to shared local
     memory by leveraging the loop tiling infrastructure.
   }];
-  let constructor = "mlir::polygeist::createLoopInternalization()";
+  let constructor = "mlir::polygeist::createLoopInternalizationPass()";
   let dependentDialects = ["affine::AffineDialect", "scf::SCFDialect"];
 }
 

--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
@@ -146,6 +146,15 @@ def SCFCanonicalizeFor : Pass<"canonicalize-scf-for"> {
   ];
 }
 
+def SYCLInternalization : InterfacePass<"sycl-internalization", "LoopLikeOpInterface"> {
+  let summary = "Perform local promotion of loop memory accesses";
+  let description = [{
+    Loop tiling is first performed to fit some loop memory accesses in local memory.
+  }];
+  let constructor = "mlir::polygeist::createSYCLInternalization()";
+  let dependentDialects = ["affine::AffineDialect", "scf::SCFDialect"];
+}
+
 def LICM : Pass<"licm"> {
   let summary = "Perform LICM on known parallel (and serial) loops";
   let dependentDialects =

--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
@@ -124,6 +124,16 @@ def LLVMLegalizeForSPIRV : Pass<"legalize-for-spirv"> {
   let dependentDialects = ["LLVM::LLVMDialect"];  
 }
 
+def LoopInternalization : InterfacePass<"loop-internalization", "LoopLikeOpInterface"> {
+  let summary = "Promote SYCL memory accesses in a loop nest to shared local memory";
+  let description = [{
+    SYCL memory accesses in perfectly nested loops are promoted to shared local
+    memory by leveraging the loop tiling infrastructure.
+  }];
+  let constructor = "mlir::polygeist::createLoopInternalization()";
+  let dependentDialects = ["affine::AffineDialect", "scf::SCFDialect"];
+}
+
 def SCFBarrierRemovalContinuation : InterfacePass<"barrier-removal-continuation", "FunctionOpInterface"> {
   let summary = "Remove scf.barrier using continuations";
   let constructor = "mlir::polygeist::createBarrierRemovalContinuation()";
@@ -144,15 +154,6 @@ def SCFCanonicalizeFor : Pass<"canonicalize-scf-for"> {
            /*default=*/"false", 
            "Whether to use strict aliasing (i.e. type-based aliasing) rules or not">
   ];
-}
-
-def SYCLInternalization : InterfacePass<"sycl-internalization", "LoopLikeOpInterface"> {
-  let summary = "Perform local promotion of loop memory accesses";
-  let description = [{
-    Loop tiling is first performed to fit some loop memory accesses in local memory.
-  }];
-  let constructor = "mlir::polygeist::createSYCLInternalization()";
-  let dependentDialects = ["affine::AffineDialect", "scf::SCFDialect"];
 }
 
 def LICM : Pass<"licm"> {

--- a/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
@@ -15,6 +15,7 @@ add_mlir_dialect_library(MLIRPolygeistTransforms
   ParallelLoopDistribute.cpp
   ParallelLower.cpp
   RaiseToAffine.cpp
+  SYCLInternalization.cpp
   TrivialUse.cpp
 
   ADDITIONAL_HEADER_DIRS
@@ -38,6 +39,7 @@ add_mlir_dialect_library(MLIRPolygeistTransforms
   MLIRPass
   MLIRPolygeistDialect
   MLIRPolygeistUtils
+  MLIRSCFUtils
   MLIRSYCLAnalysis  
   MLIRSYCLDialect
   MLIRSideEffectInterfaces

--- a/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
@@ -9,13 +9,13 @@ add_mlir_dialect_library(MLIRPolygeistTransforms
   KernelDisjointSpecialization.cpp
   LegalizeForSPIRV.cpp  
   LICM.cpp
+  LoopInternalization.cpp
   LoopRestructure.cpp
   Mem2Reg.cpp
   OpenMPOpt.cpp
   ParallelLoopDistribute.cpp
   ParallelLower.cpp
   RaiseToAffine.cpp
-  SYCLInternalization.cpp
   TrivialUse.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
@@ -40,6 +40,7 @@ template <typename T, typename = std::enable_if_t<llvm::is_one_of<
 void getPerfectlyNestedLoops(SmallVector<T> &nestedLoops, T root) {
   for (unsigned i = 0; i < std::numeric_limits<unsigned>::max(); ++i) {
     nestedLoops.push_back(root);
+    assert(root.getLoopBody().hasOneBlock() && "Expecting single block");
     Block &body = root.getLoopBody().front();
     if (body.begin() != std::prev(body.end(), 2))
       return;
@@ -83,7 +84,6 @@ LogicalResult getTileSizes(const SmallVector<T> &nestedLoops,
 }
 
 LogicalResult tile(MutableArrayRef<affine::AffineForOp> nestedLoops,
-
                    ArrayRef<Value> tileSizes,
                    SmallVectorImpl<affine::AffineForOp> &tiledNest) {
   return tilePerfectlyNestedParametric(nestedLoops, tileSizes, &tiledNest);

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLInternalization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLInternalization.cpp
@@ -1,0 +1,136 @@
+//===- SYCLInternalization.cpp - Promote loop access to local memory ------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass attempts to tile loops that are considered profitable to have some
+// of their loop memory access to local memory.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Affine/LoopUtils.h"
+#include "mlir/Dialect/Polygeist/Transforms/Passes.h"
+#include "mlir/Dialect/SCF/Utils/Utils.h"
+#include "mlir/Interfaces/LoopLikeInterface.h"
+#include "llvm/ADT/TypeSwitch.h"
+#include "llvm/Support/Debug.h"
+
+#define DEBUG_TYPE "sycl-internalization"
+
+namespace mlir {
+namespace polygeist {
+#define GEN_PASS_DEF_SYCLINTERNALIZATION
+#include "mlir/Dialect/Polygeist/Transforms/Passes.h.inc"
+} // namespace polygeist
+} // namespace mlir
+
+using namespace mlir;
+
+//===----------------------------------------------------------------------===//
+// SYCLInternalizationPass
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Collect perfectly nested loops starting from \p root.  Loops are
+/// perfectly nested if each loop is the first and only non-terminator operation
+/// in the parent loop.
+template <typename T, typename = std::enable_if_t<llvm::is_one_of<
+                          T, affine::AffineForOp, scf::ForOp>::value>>
+void getPerfectlyNestedLoops(SmallVector<T> &nestedLoops, T root) {
+  for (unsigned i = 0; i < std::numeric_limits<unsigned>::max(); ++i) {
+    nestedLoops.push_back(root);
+    Block &body = root.getLoopBody().front();
+    if (body.begin() != std::prev(body.end(), 2))
+      return;
+
+    root = dyn_cast<T>(&body.front());
+    if (!root)
+      return;
+  }
+}
+
+bool isOutermostLoop(LoopLikeOpInterface loop) {
+  return !loop->getParentRegion()->getParentOfType<LoopLikeOpInterface>();
+}
+
+bool isCandidate(LoopLikeOpInterface loop) {
+  if (!isOutermostLoop(loop)) {
+    LLVM_DEBUG(llvm::dbgs() << "not candidate: not outermost loop\n");
+    return false;
+  }
+
+  if (!isa<affine::AffineForOp, scf::ForOp>(loop)) {
+    LLVM_DEBUG(llvm::dbgs() << "not candidate: not affine or scf for loop\n");
+    return false;
+  }
+
+  return true;
+}
+
+template <typename T,
+          typename = std::enable_if_t<llvm::is_one_of<
+              T, affine::AffineForOp, scf::ForOp, LoopLikeOpInterface>::value>>
+LogicalResult getTileSizes(const SmallVector<T> &nestedLoops,
+                           SmallVectorImpl<Value> &tileSizes) {
+  // TODO: calculate proper tile sizes.
+  OpBuilder builder(nestedLoops.front());
+  Value one =
+      builder.create<arith::ConstantIndexOp>(builder.getUnknownLoc(), 1);
+  tileSizes.resize(nestedLoops.size(), one);
+  return success();
+}
+
+LogicalResult tile(MutableArrayRef<affine::AffineForOp> nestedLoops,
+                   ArrayRef<Value> tileSizes) {
+  return tilePerfectlyNestedParametric(nestedLoops, tileSizes);
+}
+LogicalResult tile(MutableArrayRef<scf::ForOp> nestedLoops,
+                   ArrayRef<Value> tileSizes) {
+  tile(nestedLoops, tileSizes, nestedLoops.back());
+  return success();
+}
+
+template <typename T, typename = std::enable_if_t<llvm::is_one_of<
+                          T, affine::AffineForOp, scf::ForOp>::value>>
+LogicalResult transform(T loop) {
+  SmallVector<T> nestedLoops;
+  getPerfectlyNestedLoops(nestedLoops, loop);
+  SmallVector<Value> tileSizes;
+  if (getTileSizes(nestedLoops, tileSizes).failed())
+    return failure();
+  if (tile(nestedLoops, tileSizes).failed())
+    return failure();
+  // TODO: promote loop accesses to local memory.
+  return success();
+}
+
+void transform(LoopLikeOpInterface loop) {
+  TypeSwitch<Operation *>(loop).Case<affine::AffineForOp, scf::ForOp>(
+      [&](auto loop) {
+        LogicalResult res = transform(loop);
+        assert(res.succeeded() && "Expecting transform to be successful");
+      });
+}
+
+struct SYCLInternalization
+    : public polygeist::impl::SYCLInternalizationBase<SYCLInternalization> {
+  void runOnOperation() override {
+    LoopLikeOpInterface loop = getOperation();
+    LLVM_DEBUG(llvm::dbgs()
+               << "SYCLInternalization: Visiting " << loop << "\n");
+
+    if (!isCandidate(loop))
+      return;
+
+    transform(loop);
+  }
+};
+} // namespace
+
+std::unique_ptr<Pass> polygeist::createSYCLInternalization() {
+  return std::make_unique<SYCLInternalization>();
+}

--- a/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
+++ b/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
@@ -1,0 +1,118 @@
+// RUN: polygeist-opt --loop-internalization --split-input-file -allow-unregistered-dialect %s | FileCheck %s
+
+// CHECK-DAG:   [[MAP1:#map.*]] = affine_map<()[s0] -> (256 ceildiv s0)>
+// CHECK-DAG:   [[MAP2:#map.*]] = affine_map<(d0)[s0] -> (d0 * s0)>
+// CHECK-DAG:   [[MAP3:#map.*]] = affine_map<(d0)[s0] -> (d0 * s0 + s0, 256)>
+// CHECK-LABEL: func.func @affine_1d() {
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    affine.for %arg0 = 0 to [[MAP1]]()[%c1] {
+// CHECK-NEXT:      affine.for %arg1 = [[MAP2]](%arg0)[%c1] to min [[MAP3]](%arg0)[%c1] {
+// CHECK-NEXT:        "test.foo"(%arg1) : (index) -> ()
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+func.func @affine_1d() {
+  affine.for %i = 0 to 256 {
+    "test.foo"(%i) : (index) -> ()
+  }
+  return
+}
+
+// -----
+
+// CHECK-DAG:   [[MAP1:#map.*]] = affine_map<()[s0] -> (256 ceildiv s0)>
+// CHECK-DAG:   [[MAP2:#map.*]] = affine_map<()[s0] -> (511 ceildiv s0 + 1)>
+// CHECK-DAG:   [[MAP3:#map.*]] = affine_map<(d0)[s0] -> (d0 * s0)>
+// CHECK-DAG:   [[MAP4:#map.*]] = affine_map<(d0)[s0] -> (d0 * s0 + s0, 256)>
+// CHECK-DAG:   [[MAP5:#map.*]] = affine_map<(d0)[s0] -> ((d0 - 1) * s0 + 1)>
+// CHECK-DAG:   [[MAP6:#map.*]] = affine_map<(d0)[s0] -> ((d0 - 1) * s0 + s0 + 1, 512)>
+// CHECK-LABEL: func.func @affine_2d() {
+// CHECK-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    affine.for %arg0 = 0 to [[MAP1]]()[%c1] {
+// CHECK-NEXT:      affine.for %arg1 = 1 to [[MAP2]]()[%c1] {
+// CHECK-NEXT:        affine.for %arg2 = [[MAP3]](%arg0)[%c1] to min [[MAP4]](%arg0)[%c1] {
+// CHECK-NEXT:          affine.for %arg3 = [[MAP5]](%arg1)[%c1] to min [[MAP6]](%arg1)[%c1] {
+// CHECK-NEXT:            "test.foo"(%arg2, %arg3) : (index, index) -> ()
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+func.func @affine_2d() {
+  affine.for %i = 0 to 256 {
+    affine.for %j = 1 to 512 {
+      "test.foo"(%i, %j) : (index, index) -> ()
+    }
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @scf_1d(%arg0: memref<?x?xf32>) {
+// CHECK-DAG:     %c0 = arith.constant 0 : index
+// CHECK-DAG:     %c1 = arith.constant 1 : index
+// CHECK-DAG:     %c256 = arith.constant 256 : index
+// CHECK-DAG:     %c1_0 = arith.constant 1 : index
+// CHECK-NEXT:    %0 = arith.muli %c1, %c1_0 : index
+// CHECK-NEXT:    scf.for %arg1 = %c0 to %c256 step %0 {
+// CHECK-NEXT:      %1 = arith.addi %arg1, %0 : index
+// CHECK-NEXT:      %2 = arith.cmpi slt, %c256, %1 : index
+// CHECK-NEXT:      %3 = arith.select %2, %c256, %1 : index
+// CHECK-NEXT:      scf.for %arg2 = %arg1 to %3 step %c1 {
+// CHECK-NEXT:        "test.foo"(%arg2) : (index) -> ()
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+func.func @scf_1d(%arg0: memref<?x?xf32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c256 = arith.constant 256 : index
+  scf.for %i = %c0 to %c256 step %c1 {
+    "test.foo"(%i) : (index) -> ()
+  }
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func @scf_2d(%arg0: memref<?x?xf32>) {
+// CHECK-DAG:     %c0 = arith.constant 0 : index
+// CHECK-DAG:     %c1 = arith.constant 1 : index
+// CHECK-DAG:     %c256 = arith.constant 256 : index
+// CHECK-DAG:     %c512 = arith.constant 512 : index
+// CHECK-DAG:     %c1_0 = arith.constant 1 : index
+// CHECK-NEXT:    %0 = arith.muli %c1, %c1_0 : index
+// CHECK-NEXT:    scf.for %arg1 = %c0 to %c256 step %0 {
+// CHECK-NEXT:      %1 = arith.muli %c1, %c1_0 : index
+// CHECK-NEXT:      scf.for %arg2 = %c1 to %c512 step %1 {
+// CHECK-NEXT:        %2 = arith.addi %arg1, %0 : index
+// CHECK-NEXT:        %3 = arith.cmpi slt, %c256, %2 : index
+// CHECK-NEXT:        %4 = arith.select %3, %c256, %2 : index
+// CHECK-NEXT:        scf.for %arg3 = %arg1 to %4 step %c1 {
+// CHECK-NEXT:          %5 = arith.addi %arg2, %1 : index
+// CHECK-NEXT:          %6 = arith.cmpi slt, %c512, %5 : index
+// CHECK-NEXT:          %7 = arith.select %6, %c512, %5 : index
+// CHECK-NEXT:          scf.for %arg4 = %arg2 to %7 step %c1 {
+// CHECK-NEXT:            "test.foo"(%arg3, %arg4) : (index, index) -> ()
+// CHECK-NEXT:          }
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return
+// CHECK-NEXT:  }
+func.func @scf_2d(%arg0: memref<?x?xf32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c256 = arith.constant 256 : index
+  %c512 = arith.constant 512 : index
+  scf.for %i = %c0 to %c256 step %c1 {
+    scf.for %j = %c1 to %c512 step %c1 {
+      "test.foo"(%i, %j) : (index, index) -> ()
+    }
+  }
+  return
+}

--- a/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
+++ b/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
@@ -1,12 +1,14 @@
-// RUN: polygeist-opt --loop-internalization --split-input-file -allow-unregistered-dialect %s | FileCheck %s
+// RUN: polygeist-opt --loop-internalization --split-input-file -allow-unregistered-dialect %s | FileCheck %s --check-prefixes=CHECK,SIZE1
+// RUN: polygeist-opt --loop-internalization --loop-internalization-tile-sizes=2 --split-input-file -allow-unregistered-dialect %s | FileCheck %s --check-prefixes=CHECK,SIZE2
 
 // CHECK-DAG:   [[MAP1:#map.*]] = affine_map<()[s0] -> (256 ceildiv s0)>
 // CHECK-DAG:   [[MAP2:#map.*]] = affine_map<(d0)[s0] -> (d0 * s0)>
 // CHECK-DAG:   [[MAP3:#map.*]] = affine_map<(d0)[s0] -> (d0 * s0 + s0, 256)>
 // CHECK-LABEL: func.func @affine_1d() {
-// CHECK-NEXT:    %c1 = arith.constant 1 : index
-// CHECK-NEXT:    affine.for %arg0 = 0 to [[MAP1]]()[%c1] {
-// CHECK-NEXT:      affine.for %arg1 = [[MAP2]](%arg0)[%c1] to min [[MAP3]](%arg0)[%c1] {
+// SIZE1-NEXT:    [[TILESIZE:%.*]] = arith.constant 1 : index
+// SIZE2-NEXT:    [[TILESIZE:%.*]] = arith.constant 2 : index
+// CHECK-NEXT:    affine.for %arg0 = 0 to [[MAP1]]()[[[TILESIZE]]] {
+// CHECK-NEXT:      affine.for %arg1 = [[MAP2]](%arg0)[[[TILESIZE]]] to min [[MAP3]](%arg0)[[[TILESIZE]]] {
 // CHECK-NEXT:        "test.foo"(%arg1) : (index) -> ()
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
@@ -28,10 +30,12 @@ func.func @affine_1d() {
 // CHECK-DAG:   [[MAP5:#map.*]] = affine_map<(d0)[s0] -> ((d0 - 1) * s0 + 1)>
 // CHECK-DAG:   [[MAP6:#map.*]] = affine_map<(d0)[s0] -> ((d0 - 1) * s0 + s0 + 1, 512)>
 // CHECK-LABEL: func.func @affine_2d() {
-// CHECK-NEXT:    %c1 = arith.constant 1 : index
-// CHECK-NEXT:    affine.for %arg0 = 0 to [[MAP1]]()[%c1] {
+// SIZE1-NEXT:    [[TILESIZE:%.*]] = arith.constant 1 : index
+// SIZE2-NEXT:    [[TILESIZE:%.*]] = arith.constant 2 : index
+// SIZE2-NEXT:    %c1 = arith.constant 1 : index
+// CHECK-NEXT:    affine.for %arg0 = 0 to [[MAP1]]()[[[TILESIZE]]] {
 // CHECK-NEXT:      affine.for %arg1 = 1 to [[MAP2]]()[%c1] {
-// CHECK-NEXT:        affine.for %arg2 = [[MAP3]](%arg0)[%c1] to min [[MAP4]](%arg0)[%c1] {
+// CHECK-NEXT:        affine.for %arg2 = [[MAP3]](%arg0)[[[TILESIZE]]] to min [[MAP4]](%arg0)[[[TILESIZE]]] {
 // CHECK-NEXT:          affine.for %arg3 = [[MAP5]](%arg1)[%c1] to min [[MAP6]](%arg1)[%c1] {
 // CHECK-NEXT:            "test.foo"(%arg2, %arg3) : (index, index) -> ()
 // CHECK-NEXT:          }
@@ -55,8 +59,9 @@ func.func @affine_2d() {
 // CHECK-DAG:     %c0 = arith.constant 0 : index
 // CHECK-DAG:     %c1 = arith.constant 1 : index
 // CHECK-DAG:     %c256 = arith.constant 256 : index
-// CHECK-DAG:     %c1_0 = arith.constant 1 : index
-// CHECK-NEXT:    %0 = arith.muli %c1, %c1_0 : index
+// SIZE1-DAG:     [[TILESIZE:%.*]] = arith.constant 1 : index
+// SIZE2-DAG:     [[TILESIZE:%.*]] = arith.constant 2 : index
+// CHECK-NEXT:    %0 = arith.muli %c1, [[TILESIZE]] : index
 // CHECK-NEXT:    scf.for %arg1 = %c0 to %c256 step %0 {
 // CHECK-NEXT:      %1 = arith.addi %arg1, %0 : index
 // CHECK-NEXT:      %2 = arith.cmpi slt, %c256, %1 : index
@@ -84,8 +89,10 @@ func.func @scf_1d(%arg0: memref<?x?xf32>) {
 // CHECK-DAG:     %c1 = arith.constant 1 : index
 // CHECK-DAG:     %c256 = arith.constant 256 : index
 // CHECK-DAG:     %c512 = arith.constant 512 : index
-// CHECK-DAG:     %c1_0 = arith.constant 1 : index
-// CHECK-NEXT:    %0 = arith.muli %c1, %c1_0 : index
+// SIZE1-DAG:     [[TILESIZE:%.*]] = arith.constant 1 : index
+// SIZE2-DAG:     [[TILESIZE:%.*]] = arith.constant 2 : index
+// SIZE2-DAG:     %c1_0 = arith.constant 1 : index
+// CHECK-NEXT:    %0 = arith.muli %c1, [[TILESIZE]] : index
 // CHECK-NEXT:    scf.for %arg1 = %c0 to %c256 step %0 {
 // CHECK-NEXT:      %1 = arith.muli %c1, %c1_0 : index
 // CHECK-NEXT:      scf.for %arg2 = %c1 to %c512 step %1 {


### PR DESCRIPTION
This new pass is only partially done. In this PR, only the pass infrastructure and loop tiling are done.
It still needs to 1. query the minimum local memory size of the device ([section 4.6.4.2](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_device_information_descriptors)), 2. calculate the beneficial tile sizes, 3. decide which memory accesses are beneficial to promote, 4. promote loop accesses to local memory. 