### PR TITLE
[SYCL][Driver] Set GRF mode to "auto" for PVC target.

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -981,6 +981,9 @@ void SYCLToolChain::AddImpliedTargetArgs(const llvm::Triple &Triple,
       }
       CmdArgs.push_back("-device");
       CmdArgs.push_back(Args.MakeArgString(DepInfo));
+      // Use "auto" GRF mode for PVC.
+      if (DepInfo.equals("pvc"))
+        BeArgs.push_back("-ze-intel-enable-auto-large-GRF-mode");
     }
     // -ftarget-compile-fast
     if (Args.hasArg(options::OPT_ftarget_compile_fast)) {

--- a/clang/test/Driver/sycl-oneapi-gpu.cpp
+++ b/clang/test/Driver/sycl-oneapi-gpu.cpp
@@ -391,3 +391,9 @@
 // CHECK_TOOLS_BEOPTS: ocloc{{.*}} "-device" "dg1" "-DDG1"
 // CHECK_TOOLS_BEOPTS: ocloc{{.*}} "-device" "skl" "-DSKL"
 // CHECK_TOOLS_BEOPTS: ocloc{{.*}} "-device" "skl" "-DSKL2"
+
+/// Check driver sets "auto" GRF mode for PVC target.
+// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_pvc \
+// RUN:   -target x86_64-unknown-linux-gnu -### %s 2>&1 | \
+// RUN:   FileCheck %s --check-prefix=CHECK_GRF_MODE
+// CHECK_GRF_MODE: ocloc{{.*}} "-ze-intel-enable-auto-large-GRF-mode"


### PR DESCRIPTION
GPU back-end compiler supports automatic selection of GRF mode (small or
large), which potentially provides better performance than fixed GRF
mode on PVC.
