### PR TITLE
[SYCL][ESIMD][LIT] Fix opaque pointer failures

### DIFF
--- a/sycl/test/esimd/ctor_codegen_opaque.cpp
+++ b/sycl/test/esimd/ctor_codegen_opaque.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -Xclang -no-opaque-pointers -fsycl -fsycl-device-only -S %s -o - | FileCheck %s
+// RUN: %clangxx -Xclang -opaque-pointers -fsycl -fsycl-device-only -S %s -o - | FileCheck %s
 
 // Check efficiency of LLVM IR generated for various simd constructors.
 
@@ -19,8 +19,7 @@ SYCL_EXTERNAL auto foo(double i) SYCL_ESIMD_FUNCTION {
   return val;
 // CHECK: %[[V0:[a-zA-Z0-9_\.]+]] = insertelement <2 x double> undef, double %[[I]], i64 0
 // CHECK-NEXT: %[[V1:[a-zA-Z0-9_\.]+]] = shufflevector <2 x double> %[[V0]], <2 x double> poison, <2 x i32> zeroinitializer
-// CHECK-NEXT: %[[MDATA:[a-zA-Z0-9_\.]+]] = getelementptr inbounds {{.*}} %[[RES]], i64 0, i32 0, i32 0
-// CHECK-NEXT: store <2 x double> %[[V1]], <2 x double> addrspace(4)* %[[MDATA]]
+// CHECK-NEXT: store <2 x double> %[[V1]], ptr addrspace(4) %[[RES]]
 // CHECK-NEXT: ret void
 // CHECK-NEXT: }
 }
@@ -36,8 +35,7 @@ SYCL_EXTERNAL auto baz() SYCL_ESIMD_FUNCTION {
   // CHECK: define dso_local spir_func void @_Z3bazv({{.*}} %[[RES:[a-zA-Z0-9_\.]+]]){{.*}} {
   simd<int, 2> val(17, 3);
   return val;
-  // CHECK: %[[MDATA:[a-zA-Z0-9_\.]+]] = getelementptr inbounds {{.*}} %[[RES]], i64 0, i32 0, i32 0
-  // CHECK-NEXT: store <2 x i32> <i32 17, i32 20>, <2 x i32> addrspace(4)* %[[MDATA]]
+  // CHECK: store <2 x i32> <i32 17, i32 20>, ptr addrspace(4) %[[RES]]
   // CHECK-NEXT: ret void
   // CHECK-NEXT: }
 }
@@ -47,8 +45,7 @@ SYCL_EXTERNAL auto gee() SYCL_ESIMD_FUNCTION {
 // CHECK: define dso_local spir_func void @_Z3geev({{.*}} %[[RES:[a-zA-Z0-9_\.]+]]){{.*}} {
   simd<float, 2> val(-7);
   return val;
-// CHECK: %[[MDATA:[a-zA-Z0-9_\.]+]] = getelementptr inbounds {{.*}} %[[RES]], i64 0, i32 0, i32 0
-// CHECK-NEXT: store <2 x float> <float -7.000000e+00, float -7.000000e+00>, <2 x float> addrspace(4)* %[[MDATA]]
+// CHECK: store <2 x float> <float -7.000000e+00, float -7.000000e+00>, ptr addrspace(4) %[[RES]]
 // CHECK-NEXT: ret void
 // CHECK-NEXT: }
 }
@@ -58,8 +55,7 @@ SYCL_EXTERNAL auto foomask() SYCL_ESIMD_FUNCTION {
 // CHECK: define dso_local spir_func void @_Z7foomaskv({{.*}} %[[RES:[a-zA-Z0-9_\.]+]]){{.*}} {
   simd_mask<2> val({ 1, 0 });
   return val;
-// CHECK: %[[MDATA:[a-zA-Z0-9_\.]+]] = getelementptr inbounds {{.*}} %[[RES]], i64 0, i32 0, i32 0
-// CHECK-NEXT: store <2 x i16> <i16 1, i16 0>, <2 x i16> addrspace(4)* %[[MDATA]]
+// CHECK: store <2 x i16> <i16 1, i16 0>, ptr addrspace(4) %[[RES]]
 // CHECK-NEXT: ret void
 // CHECK-NEXT: }
 }
@@ -69,8 +65,7 @@ SYCL_EXTERNAL auto geemask() SYCL_ESIMD_FUNCTION {
 // CHECK: define dso_local spir_func void @_Z7geemaskv({{.*}} %[[RES:[a-zA-Z0-9_\.]+]]){{.*}} {
   simd_mask<2> val(1);
   return val;
-// CHECK: %[[MDATA:[a-zA-Z0-9_\.]+]] = getelementptr inbounds {{.*}} %[[RES]], i64 0, i32 0, i32 0
-// CHECK-NEXT: store <2 x i16> <i16 1, i16 1>, <2 x i16> addrspace(4)* %[[MDATA]]
+// CHECK: store <2 x i16> <i16 1, i16 1>, ptr addrspace(4) %[[RES]]
 // CHECK-NEXT: ret void
 // CHECK-NEXT: }
 }
@@ -95,8 +90,7 @@ SYCL_EXTERNAL auto geehalf() SYCL_ESIMD_FUNCTION {
 // CHECK: define dso_local spir_func void @_Z7geehalfv({{.*}} %[[RES:[a-zA-Z0-9_\.]+]]){{.*}} {
   simd<half, 2> val(-7);
   return val;
-// CHECK: %[[MDATA:[a-zA-Z0-9_\.]+]] = getelementptr inbounds {{.*}} %[[RES]], i64 0, i32 0, i32 0
-// CHECK-NEXT: store <2 x half> <half 0xHC700, half 0xHC700>, <2 x half> addrspace(4)* %[[MDATA]]
+// CHECK: store <2 x half> <half 0xHC700, half 0xHC700>, ptr addrspace(4) %[[RES]]
 // CHECK-NEXT: ret void
 // CHECK-NEXT: }
 }

--- a/sycl/test/esimd/slm_init_specconst_size.cpp
+++ b/sycl/test/esimd/slm_init_specconst_size.cpp
@@ -1,7 +1,9 @@
-// RUN: %clangxx -O2 -fsycl -fsycl-device-only -Xclang -emit-llvm %s -o %t
+// RUN: %clangxx -O2 -fsycl -fsycl-device-only -Xclang -no-opaque-pointers -emit-llvm %s -o %t
 // RUN: sycl-post-link -split-esimd -lower-esimd -O2 -S %t -o %t.table
-// RUN: FileCheck %s -input-file=%t_esimd_0.ll
-
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-TYPED %s -input-file=%t_esimd_0.ll
+// RUN: %clangxx -O2 -fsycl -fsycl-device-only -Xclang -opaque-pointers -emit-llvm %s -o %t
+// RUN: sycl-post-link -split-esimd -lower-esimd -O2 -S %t -o %t.table
+// RUN: FileCheck --check-prefixes=CHECK,CHECK-OPAQUE %s -input-file=%t_esimd_0.ll
 // Checks that we set 0 as VCSLMSize when slm_init is used with
 // non-constant operand, like with specialization constant.
 
@@ -22,7 +24,8 @@ int main() {
           [=](sycl::kernel_handler kh) SYCL_ESIMD_KERNEL {
             slm_init(kh.get_specialization_constant<Size>());
           });
-      // CHECK: define weak_odr dso_local spir_kernel void @{{.*}}(i8 addrspace(1)* noundef align 1 "VCArgumentIOKind"="0" %{{.*}}) local_unnamed_addr #1
+      // CHECK-TYPED: define weak_odr dso_local spir_kernel void @{{.*}}(i8 addrspace(1)* noundef align 1 "VCArgumentIOKind"="0" %{{.*}}) local_unnamed_addr #1
+      // CHECK-OPAQUE: define weak_odr dso_local spir_kernel void @{{.*}}(ptr addrspace(1) noundef align 1 "VCArgumentIOKind"="0" %{{.*}}) local_unnamed_addr #1
     });
   }
 

--- a/sycl/test/esimd/sycl_half_basic_ops.cpp
+++ b/sycl/test/esimd/sycl_half_basic_ops.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-device-only -S %s -o %t
+// RUN: %clangxx -Xclang -no-opaque-pointers -fsycl -fsycl-device-only -S %s -o %t
 // RUN: sycl-post-link -split-esimd -lower-esimd -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll
 

--- a/sycl/test/esimd/sycl_half_basic_ops_opaque.cpp
+++ b/sycl/test/esimd/sycl_half_basic_ops_opaque.cpp
@@ -1,0 +1,63 @@
+// RUN: %clangxx -Xclang -opaque-pointers -fsycl -fsycl-device-only -S %s -o %t
+// RUN: sycl-post-link -split-esimd -lower-esimd -S %t -o %t.table
+// RUN: FileCheck %s -input-file=%t_esimd_0.ll
+
+// The test checks that there are no unexpected extra conversions or intrinsic
+// calls added by the API headers or compiler when generating code
+// for basic C++ operations on simd<sycl::half, N> values.
+
+#include <sycl/ext/intel/esimd.hpp>
+
+using namespace sycl::ext::intel::esimd;
+using namespace sycl::ext::intel;
+using namespace sycl;
+
+// clang-format off
+// --- Unary operation
+SYCL_EXTERNAL auto test_unary_op(simd<sycl::half, 8> val) SYCL_ESIMD_FUNCTION {
+// CHECK: define dso_local spir_func <8 x half> @_Z13test_unary_op{{.*}}(
+//   CHECK: {{.*}} %[[VAL_VEC:[a-zA-Z0-9_\.]+]]){{.*}} {
+  return -val;
+// CHECK: %[[RES:[a-zA -Z0-9_\.]+]] = fneg <8 x half> %[[VAL_VEC]]
+// CHECK-NEXT: ret <8 x half> %[[RES]]
+// CHECK-LABEL: }
+}
+
+// --- Binary operation on <half, half> pair
+SYCL_EXTERNAL auto test_binary_op1(simd<sycl::half, 8> val1, simd<sycl::half, 8> val2) SYCL_ESIMD_FUNCTION {
+// CHECK: define dso_local spir_func <8 x half> @_Z15test_binary_op1{{.*}}(
+//   CHECK: {{[^,]*}} %[[VAL1_VEC:[a-zA-Z0-9_\.]+]],
+//   CHECK: %[[VAL2_VEC:[a-zA-Z0-9_\.]+]]{{.*}} {
+  return val1 + val2;
+// CHECK: %[[RES:[a-zA -Z0-9_\.]+]] = fadd <8 x half> %[[VAL1_VEC]], %[[VAL2_VEC]]
+// CHECK-NEXT: ret <8 x half> %[[RES]]
+// CHECK-LABEL: }
+}
+
+// --- Binary operation on <half, int64_t> pair
+// The integer operand is expected to be converted to half type.
+SYCL_EXTERNAL auto test_binary_op2(simd<sycl::half, 8> val1, simd<long long, 8> val2) SYCL_ESIMD_FUNCTION {
+// CHECK: define dso_local spir_func <8 x half> @_Z15test_binary_op2{{[^\(]*}}(
+//   CHECK: <8 x half> %[[VAL1_VEC:[a-zA-Z0-9_\.]+]],
+//   CHECK: <8 x i64> %[[VAL2_VEC:[a-zA-Z0-9_\.]+]]{{.*}} {
+  return val1 + val2;
+// CHECK: %[[CONV:[a-zA-Z0-9_\.]+]] = sitofp <8 x i64> %[[VAL2_VEC]] to <8 x half>
+// CHECK-NEXT: %[[RES:[a-zA-Z0-9_\.]+]] = fadd <8 x half> %[[CONV]], %[[VAL1_VEC]]
+// CHECK-NEXT: ret <8 x half> %[[RES]]
+// CHECK-LABEL: }
+}
+
+// --- Comparison operation on <half, int64_t> pair
+// The integer operand is expected to be converted to half type.
+SYCL_EXTERNAL auto test_cmp_op(simd<sycl::half, 8> val1, simd<long long, 8> val2) SYCL_ESIMD_FUNCTION {
+// CHECK: define dso_local spir_func <8 x i16> @_Z11test_cmp_op{{[^\(]*}}(
+//   CHECK: <8 x half> %[[VAL1_VEC:[a-zA-Z0-9_\.]+]],
+//   CHECK: <8 x i64> %[[VAL2_VEC:[a-zA-Z0-9_\.]+]]{{.*}} {
+  return val1 < val2;
+// CHECK: %[[CONV:[a-zA-Z0-9_\.]+]] = sitofp <8 x i64> %[[VAL2_VEC]] to <8 x half>
+// CHECK-NEXT: %[[CMP:[a-zA-Z0-9_\.]+]] = fcmp ogt <8 x half> %[[CONV]], %[[VAL1_VEC]]
+// CHECK-NEXT: %[[RES:[a-zA-Z0-9_\.]+]] = zext <8 x i1> %[[CMP]] to <8 x i16>
+// CHECK-NEXT: ret <8 x i16>{{.*}}%[[RES]]
+// CHECK-LABEL: }
+}
+// clang-format on

--- a/sycl/test/esimd/sycl_half_math_ops.cpp
+++ b/sycl/test/esimd/sycl_half_math_ops.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-device-only -S %s -o %t.ll
+// RUN: %clangxx -Xclang -no-opaque-pointers -fsycl -fsycl-device-only -S %s -o %t.ll
 // RUN: sycl-post-link -split-esimd -lower-esimd -S %t.ll -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll
 

--- a/sycl/test/esimd/sycl_half_math_ops_opaque.cpp
+++ b/sycl/test/esimd/sycl_half_math_ops_opaque.cpp
@@ -1,0 +1,24 @@
+// RUN: %clangxx -Xclang -opaque-pointers -fsycl -fsycl-device-only -S %s -o %t.ll
+// RUN: sycl-post-link -split-esimd -lower-esimd -S %t.ll -o %t.table
+// RUN: FileCheck %s -input-file=%t_esimd_0.ll
+
+// The test checks that there are no unexpected extra conversions or intrinsic
+// calls added by the API headers or compiler when generating code
+// for math operations on simd<sycl::half, N> values.
+
+#include <sycl/ext/intel/esimd.hpp>
+
+using namespace sycl::ext::intel::esimd;
+using namespace sycl::ext::intel;
+using namespace sycl;
+
+// clang-format off
+SYCL_EXTERNAL auto test_ext_math_op(simd<sycl::half, 8> val) SYCL_ESIMD_FUNCTION {
+// CHECK: define dso_local spir_func <8 x half> @_Z16test_ext_math_op{{[^\(]*}}(
+//   CHECK: <8 x half> %[[VAL_VEC:[a-zA-Z0-9_\.]+]]){{.*}} {
+  return esimd::cos(val);
+// CHECK: %[[RES:[a-zA-Z0-9_\.]+]] = call <8 x half> @llvm.genx.cos.v8f16(<8 x half> %[[VAL_VEC]])
+// CHECK-NEXT: ret <8 x half> %[[RES]]
+// CHECK-LABEL: }
+}
+// clang-format on


### PR DESCRIPTION
The IR is different so the tests failed. Just make the old tests use typed pointers and add new tests for opaque pointers. We can remove the typed pointer tests at some point in the future.

There's still one ESIMD failure, I'm working on that seperately.