### PR TITLE
[SYCL][Test E2E] Fix tests not using %{run*}

### DIFF
--- a/sycl/test-e2e/Basic/library_loading.cpp
+++ b/sycl/test-e2e/Basic/library_loading.cpp
@@ -1,8 +1,8 @@
 // REQUIRES: linux
 // RUN: %{build} -o %t.out
-// RUN: env SYCL_PI_TRACE=-1 %t.out &> %t_trace_no_filter.txt || true
+// RUN: env SYCL_PI_TRACE=-1 %{run-unfiltered-devices} %t.out &> %t_trace_no_filter.txt || true
 // RUN: FileCheck --input-file=%t_trace_no_filter.txt --check-prefix=CHECK-NO-FILTER %s
-// RUN: env SYCL_PI_TRACE=-1 ONEAPI_DEVICE_SELECTOR='esimd_emulator:*' %t.out &> %t_trace_esimd_filter.txt || true
+// RUN: env SYCL_PI_TRACE=-1 ONEAPI_DEVICE_SELECTOR='esimd_emulator:*' %{run-unfiltered-devices} %t.out &> %t_trace_esimd_filter.txt || true
 // RUN: FileCheck --input-file=%t_trace_esimd_filter.txt --check-prefix=CHECK-ESIMD-FILTER %s
 // Checks pi traces on library loading
 

--- a/sycl/test-e2e/Basic/query_emulate_subdevice.cpp
+++ b/sycl/test-e2e/Basic/query_emulate_subdevice.cpp
@@ -1,6 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: env CreateMultipleSubDevices=2 EnableTimestampPacket=1 \
-// RUN: NEOReadDebugKeys=1 ONEAPI_DEVICE_SELECTOR="*:gpu" %t.out
+// RUN: NEOReadDebugKeys=1 ONEAPI_DEVICE_SELECTOR="*:gpu" %{run-unfiltered-devices} %t.out
 
 // UNSUPPORTED: gpu-intel-dg1,hip
 // Temporarily disable on L0 due to fails in CI

--- a/sycl/test-e2e/Config/allowlist.cpp
+++ b/sycl/test-e2e/Config/allowlist.cpp
@@ -1,14 +1,14 @@
 // REQUIRES: cpu
 // RUN: %{build} -o %t.out
 //
-// RUN: env PRINT_DEVICE_INFO=1 %t.out > %t1.conf
-// RUN: env TEST_DEVICE_AVAILABLE=1 env SYCL_CONFIG_FILE_NAME=%t1.conf %t.out
+// RUN: env PRINT_DEVICE_INFO=1 %{run-unfiltered-devices} %t.out > %t1.conf
+// RUN: env TEST_DEVICE_AVAILABLE=1 env SYCL_CONFIG_FILE_NAME=%t1.conf %{run-unfiltered-devices} %t.out
 //
-// RUN: env PRINT_PLATFORM_INFO=1 %t.out > %t2.conf
-// RUN: env TEST_DEVICE_AVAILABLE=1 env SYCL_CONFIG_FILE_NAME=%t2.conf %t.out
+// RUN: env PRINT_PLATFORM_INFO=1 %{run-unfiltered-devices} %t.out > %t2.conf
+// RUN: env TEST_DEVICE_AVAILABLE=1 env SYCL_CONFIG_FILE_NAME=%t2.conf %{run-unfiltered-devices} %t.out
 //
-// RUN: env TEST_DEVICE_IS_NOT_AVAILABLE=1 env SYCL_DEVICE_ALLOWLIST="PlatformName:{{SUCH NAME DOESN'T EXIST}}" %t.out
-// RUN: env TEST_INCORRECT_VALUE=1 env SYCL_DEVICE_ALLOWLIST="IncorrectKey:{{.*}}" %t.out
+// RUN: env TEST_DEVICE_IS_NOT_AVAILABLE=1 env SYCL_DEVICE_ALLOWLIST="PlatformName:{{SUCH NAME DOESN'T EXIST}}" %{run-unfiltered-devices} %t.out
+// RUN: env TEST_INCORRECT_VALUE=1 env SYCL_DEVICE_ALLOWLIST="IncorrectKey:{{.*}}" %{run-unfiltered-devices} %t.out
 
 #include <algorithm>
 #include <cstdlib>

--- a/sycl/test-e2e/DeprecatedFeatures/deprecated_sycl_device_filter.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/deprecated_sycl_device_filter.cpp
@@ -1,5 +1,5 @@
 // RUN: %{build} -o %t.out
-// RUN: env SYCL_DEVICE_FILTER='*' %t.out &> %t.log
+// RUN: env SYCL_DEVICE_FILTER='*' %{run-unfiltered-devices} %t.out &> %t.log
 // RUN: FileCheck %s < %t.log
 //
 // CHECK:      WARNING: The enviroment variable SYCL_DEVICE_FILTER is deprecated.

--- a/sycl/test-e2e/OneapiDeviceSelector/backendonly_error.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/backendonly_error.cpp
@@ -1,7 +1,6 @@
 // REQUIRES: level_zero
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %S/Inputs/trivial.cpp -o %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR=level_zero %t.out
-// XFAIL: *
 
 // Calling ONEAPI_DEVICE_SELECTOR with a backend and no device should result in
 // an error.
+// RUN: env ONEAPI_DEVICE_SELECTOR=level_zero %{run-unfiltered-devices} not %t.out

--- a/sycl/test-e2e/OneapiDeviceSelector/case_sensitivity.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/case_sensitivity.cpp
@@ -2,7 +2,7 @@
 // does not actually require OpenCL or GPU. Just testing parsing.
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %S/Inputs/trivial.cpp -o %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR="OPENCL:*" %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR="opencl:*" %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR="*:GPU" %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR="*:gpu" %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="OPENCL:*" %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="opencl:*" %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="*:GPU" %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="*:gpu" %{run-unfiltered-devices} %t.out

--- a/sycl/test-e2e/OneapiDeviceSelector/cuda_top.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/cuda_top.cpp
@@ -1,8 +1,8 @@
 // REQUIRES: cuda,gpu
 // RUN: %{build} -o %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR=cuda:gpu %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR='cuda:0' %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR="cuda:*" %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR=cuda:gpu %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR='cuda:0' %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="cuda:*" %{run-unfiltered-devices} %t.out
 
 //  At this time, CUDA only has one device (GPU). So this is easy to accept CUDA
 //  and GPU and reject anything else. This test is just testing top level

--- a/sycl/test-e2e/OneapiDeviceSelector/illegal_BE_error.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/illegal_BE_error.cpp
@@ -1,6 +1,6 @@
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %S/Inputs/trivial.cpp -o %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR="macaroni:*"" %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="macaroni:*"" %{run-unfiltered-devices} %t.out
 // XFAIL: *
 
 // Calling ONEAPI_DEVICE_SELECTOR with an illegal backend should result in an

--- a/sycl/test-e2e/OneapiDeviceSelector/level_zero_top.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/level_zero_top.cpp
@@ -1,8 +1,8 @@
 // REQUIRES: level_zero,gpu
 // RUN: %{build} -o %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR=level_zero:gpu %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR='level_zero:0' %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR="level_zero:*" %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR=level_zero:gpu %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR='level_zero:0' %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="level_zero:*" %{run-unfiltered-devices} %t.out
 
 //  At this time, LevelZero only has one device (GPU). So this is easy to accept
 //  L0 and GPU and reject anything else. This test is just testing top level

--- a/sycl/test-e2e/OneapiDeviceSelector/no_duplicate_devices.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/no_duplicate_devices.cpp
@@ -1,8 +1,8 @@
 // REQUIRES: opencl, cpu
 // RUN: %{build} -o %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR="opencl:*" %t.out 1 &> tmp.txt
-// RUN: env ONEAPI_DEVICE_SELECTOR="opencl:*,cpu" cat tmp.txt | %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR="opencl:cpu,cpu" cat tmp.txt | %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="opencl:*" %{run-unfiltered-devices} %t.out 1 &> tmp.txt
+// RUN: cat tmp.txt | env ONEAPI_DEVICE_SELECTOR="opencl:*,cpu" %{run-unfiltered-devices} %t.out
+// RUN: cat tmp.txt | env ONEAPI_DEVICE_SELECTOR="opencl:cpu,cpu" %{run-unfiltered-devices} %t.out
 
 // on the first run we pass a dummy arg to the app. On seeing that, we count the
 // number of CPU devices and output it. That is piped  to a file. On subsequent

--- a/sycl/test-e2e/OneapiDeviceSelector/sub-devices.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/sub-devices.cpp
@@ -11,12 +11,12 @@
 // select sub-devices
 //   ONEAPI_DEVICE_SELECTOR=(any backend):(any
 //   device).(all-the-sub-devices).(all-sub-sub-devices)
-// RUN: env ONEAPI_DEVICE_SELECTOR="*:*.*"  %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR="*:*.*.*"  %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="*:*.*" %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="*:*.*.*" %{run-unfiltered-devices} %t.out
 
 // select root devices and pass arg to test so it knows.
-// RUN: env ONEAPI_DEVICE_SELECTOR="*:gpu" %t.out 1
-// RUN: %t.out 1
+// RUN: env ONEAPI_DEVICE_SELECTOR="*:gpu" %{run-unfiltered-devices} %t.out 1
+// RUN: %{run-unfiltered-devices} %t.out 1
 
 #include <sycl/sycl.hpp>
 using namespace sycl;

--- a/sycl/test-e2e/Regression/device_num.cpp
+++ b/sycl/test-e2e/Regression/device_num.cpp
@@ -1,9 +1,9 @@
 // RUN: %{build} -o %t.out
-// RUN: env PRINT_FULL_DEVICE_INFO=1  %t.out > %t1.conf
-// RUN: env ONEAPI_DEVICE_SELECTOR="*:0" env TEST_DEV_CONFIG_FILE_NAME=%t1.conf %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR="*:1" env TEST_DEV_CONFIG_FILE_NAME=%t1.conf %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR="*:2" env TEST_DEV_CONFIG_FILE_NAME=%t1.conf %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR="*:3" env TEST_DEV_CONFIG_FILE_NAME=%t1.conf %t.out
+// RUN: env PRINT_FULL_DEVICE_INFO=1 %{run-unfiltered-devices} %t.out > %t1.conf
+// RUN: env ONEAPI_DEVICE_SELECTOR="*:0" env TEST_DEV_CONFIG_FILE_NAME=%t1.conf %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="*:1" env TEST_DEV_CONFIG_FILE_NAME=%t1.conf %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="*:2" env TEST_DEV_CONFIG_FILE_NAME=%t1.conf %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="*:3" env TEST_DEV_CONFIG_FILE_NAME=%t1.conf %{run-unfiltered-devices} %t.out
 
 // Temporarily disable on L0 and HIP due to fails in CI
 // UNSUPPORTED: level_zero, hip


### PR DESCRIPTION
These substitution/expansion must be used in order to run the test through run_launcher when one is specified in llvm-lit parameters.