### PR TITLE
[SYCL-MLIR] Add `isOpaque` in `polygeist.struct`

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistTypes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistTypes.td
@@ -56,6 +56,7 @@ def Polygeist_StructType :
         (`isOpaque` `=` $isOpaque^)?
         (`(` $body^ `)`)? `>`
   }];
+  let genVerifyDecl = 1;
 }
 
 #endif // POLYGEIST_TYPES

--- a/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistTypes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistTypes.td
@@ -31,18 +31,31 @@ def Polygeist_StructType :
   let description = [{
     Type used to represent a collection of data members together in memory.
   }];
-  let parameters = (ins ArrayRefParameter<"mlir::Type">:$body,
+  let parameters = (ins OptionalArrayRefParameter<"mlir::Type">:$body,
                         OptionalParameter<"std::optional<StringAttr>">:$name,
-                        DefaultValuedParameter<"bool", "false">:$isPacked);
+                        DefaultValuedParameter<"bool", "false">:$isPacked,
+                        DefaultValuedParameter<"bool", "false">:$isOpaque);
   let builders = [
     TypeBuilder<(ins "llvm::ArrayRef<mlir::Type>":$body),[{
-      return $_get($_ctxt, body, std::nullopt, false);
+      return $_get($_ctxt, body, std::nullopt, false, false);
+    }]>,
+    TypeBuilder<(ins "llvm::ArrayRef<mlir::Type>":$body, "std::optional<StringAttr>":$name, "bool":$isPacked),[{
+      return $_get($_ctxt, body, name, isPacked, false);
     }]>
   ];
   let extraClassDeclaration = [{
     bool isPacked() { return getIsPacked(); }
+    bool isOpaque() { return getIsOpaque(); }
+    static StructType getOpaque(StringAttr name, mlir::MLIRContext *context) {
+      return get(context, std::nullopt, name, false, true);
+    }
   }];
-  let assemblyFormat = "`<` ($name^ `,` ` `)? (`isPacked` `=` $isPacked^ ` `)? `(` $body `)` `>`";
+  let assemblyFormat = [{
+    `<` ($name^ `,` ` `)?
+        (`isPacked` `=` $isPacked^ ` `)?
+        (`isOpaque` `=` $isOpaque^)?
+        (`(` $body^ `)`)? `>`
+  }];
 }
 
 #endif // POLYGEIST_TYPES

--- a/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
+++ b/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
@@ -855,6 +855,9 @@ populatePolygeistToLLVMTypeConversion(LLVMTypeConverter &typeConverter) {
         if (failed(typeConverter.convertTypes(body, convertedElemTypes)))
           return std::nullopt;
         if (type.getName().has_value()) {
+          if (type.isOpaque())
+            return LLVM::LLVMStructType::getOpaque(*type.getName(),
+                                                   &typeConverter.getContext());
           auto ST = LLVM::LLVMStructType::getIdentified(
               &typeConverter.getContext(), *type.getName());
           if (!ST.isInitialized()) {

--- a/polygeist/lib/Dialect/Polygeist/IR/PolygeistTypes.cpp
+++ b/polygeist/lib/Dialect/Polygeist/IR/PolygeistTypes.cpp
@@ -7,3 +7,15 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/Polygeist/IR/PolygeistTypes.h"
+
+using namespace mlir;
+using namespace mlir::polygeist;
+
+LogicalResult StructType::verify(function_ref<InFlightDiagnostic()> emitError,
+                                 llvm::ArrayRef<Type> body,
+                                 std::optional<StringAttr> name, bool isPacked,
+                                 bool isOpaque) {
+  if (isOpaque && !name)
+    return emitError() << "opaque struct type must have name";
+  return success();
+}

--- a/polygeist/lib/Dialect/Polygeist/IR/PolygeistTypes.cpp
+++ b/polygeist/lib/Dialect/Polygeist/IR/PolygeistTypes.cpp
@@ -16,6 +16,6 @@ LogicalResult StructType::verify(function_ref<InFlightDiagnostic()> emitError,
                                  std::optional<StringAttr> name, bool isPacked,
                                  bool isOpaque) {
   if (isOpaque && !name)
-    return emitError() << "opaque struct type must have name";
+    return emitError() << "opaque struct type must have a name";
   return success();
 }

--- a/polygeist/test/polygeist-opt/polygeist-types-invalid.mlir
+++ b/polygeist/test/polygeist-opt/polygeist-types-invalid.mlir
@@ -1,0 +1,6 @@
+// RUN: polygeist-opt %s --split-input-file -verify-diagnostics
+
+// expected-error @+1 {{opaque struct type must have name}}
+func.func @test_struct(%arg0: !polygeist.struct<isOpaque=true>) {
+  return
+}

--- a/polygeist/test/polygeist-opt/polygeist-types-invalid.mlir
+++ b/polygeist/test/polygeist-opt/polygeist-types-invalid.mlir
@@ -1,6 +1,6 @@
 // RUN: polygeist-opt %s --split-input-file -verify-diagnostics
 
-// expected-error @+1 {{opaque struct type must have name}}
+// expected-error @+1 {{opaque struct type must have a name}}
 func.func @test_struct(%arg0: !polygeist.struct<isOpaque=true>) {
   return
 }

--- a/polygeist/test/polygeist-opt/polygeist-types-to-llvm.mlir
+++ b/polygeist/test/polygeist-opt/polygeist-types-to-llvm.mlir
@@ -18,3 +18,10 @@ func.func @test_struct(%arg0: !polygeist.struct<"name", (memref<i32>, i32)>) {
 func.func @test_struct(%arg0: !polygeist.struct<"name", isPacked=true (memref<i32>, i32)>) {
   return
 }
+
+// -----
+
+// CHECK: llvm.func @test_struct(%arg0: !llvm.struct<"name", opaque>)
+func.func @test_struct(%arg0: !polygeist.struct<"name", isOpaque=true>) {
+  return
+}


### PR DESCRIPTION
`isOpaque` indicate if a struct type is an intentionally-opaque identified struct, such a struct cannot have its body set. 
To represent all `llvm.struct` as `polygeist.struct`, we need to also allow opaque struct type.