### PR TITLE
[SYCL][OpaquePtrs] Convert some sycl tests to opaque pointers.

### DIFF
--- a/sycl/test/check_device_code/device_global_ptr_use.cpp
+++ b/sycl/test/check_device_code/device_global_ptr_use.cpp
@@ -13,7 +13,7 @@ const device_global<int> DeviceGlobalVar;
 int main() {
   queue Q;
   Q.single_task([]() {
-    // CHECK: load i32 {{.*}}({{.*}}* @_ZL15DeviceGlobalVar, i64 0, i32 0)
+    // CHECK: load {{.*}} @_ZL15DeviceGlobalVar
     volatile int ReadVal = DeviceGlobalVar;
   });
   return 0;

--- a/sycl/test/check_device_code/usm_pointers.cpp
+++ b/sycl/test/check_device_code/usm_pointers.cpp
@@ -1,30 +1,30 @@
-// RUN: %clangxx -fsycl-device-only -Xclang -fsycl-is-device -emit-llvm %s -S -o %t.ll -I %sycl_include -Wno-sycl-strict -Xclang -verify-ignore-unexpected=note,warning -Xclang -disable-llvm-passes
+// RUN: %clangxx -fsycl-device-only -Xclang -fsycl-is-device -emit-llvm %s -S -o %t.ll -I %sycl_include -Wno-sycl-strict -Xclang -verify-ignore-unexpected=note,warning -Xclang -disable-llvm-passes -Xclang -opaque-pointers
 // RUN: FileCheck %s --input-file %t.ll --check-prefixes=CHECK,CHECK-DISABLE
-// RUN: %clangxx -fsycl-device-only -Xclang -fsycl-is-device -emit-llvm %s -S -o %t.ll -I %sycl_include -Wno-sycl-strict -Xclang -verify-ignore-unexpected=note,warning -Xclang -disable-llvm-passes -D__ENABLE_USM_ADDR_SPACE__
+// RUN: %clangxx -fsycl-device-only -Xclang -fsycl-is-device -emit-llvm %s -S -o %t.ll -I %sycl_include -Wno-sycl-strict -Xclang -verify-ignore-unexpected=note,warning -Xclang -disable-llvm-passes -D__ENABLE_USM_ADDR_SPACE__ -Xclang -opaque-pointers
 // RUN: FileCheck %s --input-file %t.ll --check-prefixes=CHECK,CHECK-ENABLE
 //
 // Check the address space of the pointer in multi_ptr class
 //
-// CHECK-DISABLE: %[[DEVPTR_T:.*]] = type { i8 addrspace(1)* }
-// CHECK-DISABLE: %[[HOSTPTR_T:.*]] = type { i8 addrspace(1)* }
-// CHECK-ENABLE: %[[DEVPTR_T:.*]] = type { i8 addrspace(5)* }
-// CHECK-ENABLE: %[[HOSTPTR_T:.*]] = type { i8 addrspace(6)* }
+// CHECK-DISABLE: %[[DEVPTR_T:.*]] = type { ptr addrspace(1) }
+// CHECK-DISABLE: %[[HOSTPTR_T:.*]] = type { ptr addrspace(1) }
+// CHECK-ENABLE: %[[DEVPTR_T:.*]] = type { ptr addrspace(5) }
+// CHECK-ENABLE: %[[HOSTPTR_T:.*]] = type { ptr addrspace(6) }
 //
-// CHECK-LABEL: define {{.*}} spir_func noundef i8 addrspace(4)* @{{.*}}multi_ptr{{.*}}
+// CHECK-LABEL: define {{.*}} spir_func noundef ptr addrspace(4) @{{.*}}multi_ptr{{.*}}
 // CHECK: %[[M_PTR:.*]] = getelementptr inbounds %[[DEVPTR_T]]
-// CHECK-DISABLE-NEXT: %[[DEVLOAD:[0-9]+]] = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(4)* %[[M_PTR]]
-// CHECK-DISABLE-NEXT: %[[DEVCAST:[0-9]+]] = addrspacecast i8 addrspace(1)* %[[DEVLOAD]] to i8 addrspace(4)*
-// CHECK-ENABLE-NEXT: %[[DEVLOAD:[0-9]+]] = load i8 addrspace(5)*, i8 addrspace(5)* addrspace(4)* %[[M_PTR]]
-// CHECK-ENABLE-NEXT: %[[DEVCAST:[0-9]+]] = addrspacecast i8 addrspace(5)* %[[DEVLOAD]] to i8 addrspace(4)*
-// ret i8 addrspace(4)* %[[DEVCAST]]
+// CHECK-DISABLE-NEXT: %[[DEVLOAD:[0-9]+]] = load ptr addrspace(1), ptr addrspace(4) %[[M_PTR]]
+// CHECK-DISABLE-NEXT: %[[DEVCAST:[0-9]+]] = addrspacecast ptr addrspace(1) %[[DEVLOAD]] to ptr addrspace(4)
+// CHECK-ENABLE-NEXT: %[[DEVLOAD:[0-9]+]] = load ptr addrspace(5), ptr addrspace(4) %[[M_PTR]]
+// CHECK-ENABLE-NEXT: %[[DEVCAST:[0-9]+]] = addrspacecast ptr addrspace(5) %[[DEVLOAD]] to ptr addrspace(4)
+// ret ptr addrspace(4) %[[DEVCAST]]
 //
-// CHECK-LABEL: define {{.*}} spir_func noundef i8 addrspace(4)* @{{.*}}multi_ptr{{.*}}
+// CHECK-LABEL: define {{.*}} spir_func noundef ptr addrspace(4) @{{.*}}multi_ptr{{.*}}
 // CHECK: %[[M_PTR]] = getelementptr inbounds %[[HOSTPTR_T]]
-// CHECK-DISABLE-NEXT: %[[HOSTLOAD:[0-9]+]] = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(4)* %[[M_PTR]]
-// CHECK-DISABLE-NEXT: %[[HOSTCAST:[0-9]+]] = addrspacecast i8 addrspace(1)* %[[HOSTLOAD]] to i8 addrspace(4)*
-// CHECK-ENABLE-NEXT: %[[HOSTLOAD:[0-9]+]] = load i8 addrspace(6)*, i8 addrspace(6)* addrspace(4)* %[[M_PTR]]
-// CHECK-ENABLE-NEXT: %[[HOSTCAST:[0-9]+]] = addrspacecast i8 addrspace(6)* %[[HOSTLOAD]] to i8 addrspace(4)*
-// ret i8 addrspace(4)* %[[HOSTCAST]]
+// CHECK-DISABLE-NEXT: %[[HOSTLOAD:[0-9]+]] = load ptr addrspace(1), ptr addrspace(4) %[[M_PTR]]
+// CHECK-DISABLE-NEXT: %[[HOSTCAST:[0-9]+]] = addrspacecast ptr addrspace(1) %[[HOSTLOAD]] to ptr addrspace(4)
+// CHECK-ENABLE-NEXT: %[[HOSTLOAD:[0-9]+]] = load ptr addrspace(6), ptr addrspace(4) %[[M_PTR]]
+// CHECK-ENABLE-NEXT: %[[HOSTCAST:[0-9]+]] = addrspacecast ptr addrspace(6) %[[HOSTLOAD]] to ptr addrspace(4)
+// ret ptr addrspace(4) %[[HOSTCAST]]
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/extensions/bfloat16.cpp
+++ b/sycl/test/extensions/bfloat16.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl-device-only -fsycl-targets=%sycl_triple -S -Xclang -no-enable-noundef-analysis %s -o - | FileCheck %s
+// RUN: %clangxx -fsycl-device-only -fsycl-targets=%sycl_triple -S -Xclang -no-enable-noundef-analysis %s -Xclang -opaque-pointers -o - | FileCheck %s
 
 // UNSUPPORTED: cuda || hip_amd
 
@@ -13,41 +13,40 @@ SYCL_EXTERNAL void foo(long x, sycl::half y);
 __attribute__((noinline)) float op(float a, float b) {
   // CHECK: define {{.*}} spir_func float @_Z2opff(float [[a:%.*]], float [[b:%.*]])
   bfloat16 A{a};
-  // CHECK: [[A:%.*]] = call spir_func zeroext i16 @__devicelib_ConvertFToBF16INTEL(float {{.*}})
+  // CHECK: [[A:%.*]] = call spir_func zeroext i16 @__devicelib_ConvertFToBF16INTEL(ptr {{.*}})
   // CHECK-NOT: fptoui
 
   bfloat16 B{b};
-  // CHECK: [[B:%.*]] = call spir_func zeroext i16 @__devicelib_ConvertFToBF16INTEL(float {{.*}})
+  // CHECK: [[B:%.*]] = call spir_func zeroext i16 @__devicelib_ConvertFToBF16INTEL(ptr {{.*}})
   // CHECK-NOT: fptoui
 
   bfloat16 C = A + B;
-  // CHECK: [[RTCASTI:%.*]] = addrspacecast float* [[RT:%.*]] to float addrspace(4)*
-  // CHECK: [[A_float:%.*]] = call spir_func float @__devicelib_ConvertBF16ToFINTEL(i16 {{.*}})
-  // CHECK: [[B_float:%.*]] = call spir_func float @__devicelib_ConvertBF16ToFINTEL(i16 {{.*}})
+  // CHECK: store i16
+  // CHECK: [[RTCASTI:%.*]] = addrspacecast ptr [[RT:%.*]] to ptr addrspace(4)
+  // CHECK: [[A_float:%.*]] = call spir_func float @__devicelib_ConvertBF16ToFINTEL(ptr {{.*}})
+  // CHECK: [[B_float:%.*]] = call spir_func float @__devicelib_ConvertBF16ToFINTEL(ptr {{.*}})
   // CHECK: [[Add:%.*]] = fadd float [[A_float]], [[B_float]]
-  // CHECK: store float [[Add]], float* [[RT]], align 4
-  // CHECK: [[C:%.*]] = call spir_func zeroext i16 @__devicelib_ConvertFToBF16INTEL(float {{.*}}) [[RTCASTI]])
+  // CHECK: store float [[Add]], ptr [[RT]], align 4
+  // CHECK: [[C:%.*]] = call spir_func zeroext i16 @__devicelib_ConvertFToBF16INTEL(ptr {{.*}}) [[RTCASTI]])
 
   // CHECK-NOT: uitofp
   // CHECK-NOT: fptoui
 
   long L = bfloat16(3.14f);
-  // CHECK: [[L:%.*]] = call spir_func zeroext i16 @__devicelib_ConvertFToBF16INTEL(float {{.*}})
-  // CHECK: [[P8:%.*]] = addrspacecast i16* [[VI9:%.*]] to i16 addrspace(4)*
-  // CHECK: store i16 [[L]], i16* [[VI9]]
-  // CHECK: [[L_float:%.*]] = call spir_func float @__devicelib_ConvertBF16ToFINTEL(i16 {{.*}} [[P8]])
+  // CHECK: [[L:%.*]] = call spir_func zeroext i16 @__devicelib_ConvertFToBF16INTEL(ptr {{.*}})
+  // CHECK: store i16 [[L]]
+  // CHECK: [[L_float:%.*]] = call spir_func float @__devicelib_ConvertBF16ToFINTEL(ptr
   // CHECK: [[L:%.*]] = fptosi float [[L_float]] to i{{32|64}}
 
   sycl::half H = bfloat16(2.71f);
-  // CHECK: [[H:%.*]] = call spir_func zeroext i16 @__devicelib_ConvertFToBF16INTEL(float {{.*}})
-  // CHECK: [[P11:%.*]] = addrspacecast i16* [[VI13:%.*]] to i16 addrspace(4)*
-  // CHECK: store i16 [[H]], i16* [[VI13]], align 2
-  // CHECK: [[H_float:%.*]] = call spir_func float @__devicelib_ConvertBF16ToFINTEL(i16 {{.*}} [[P11]])
+  // CHECK: [[H:%.*]] = call spir_func zeroext i16 @__devicelib_ConvertFToBF16INTEL(ptr {{.*}})
+  // CHECK: store i16 [[H]], ptr {{.*}}, align 2
+  // CHECK: [[H_float:%.*]] = call spir_func float @__devicelib_ConvertBF16ToFINTEL(ptr
   // CHECK: [[H:%.*]] = fptrunc float [[H_float]] to half
   foo(L, H);
 
   return A;
-  // CHECK: [[RetVal:%.*]] = call spir_func float @__devicelib_ConvertBF16ToFINTEL(i16 {{.*}})
+  // CHECK: [[RetVal:%.*]] = call spir_func float @__devicelib_ConvertBF16ToFINTEL(ptr {{.*}})
   // CHECK: ret float [[RetVal]]
   // CHECK-NOT: uitofp
   // CHECK-NOT: fptoui


### PR DESCRIPTION
This does not fix all of the lit tests that fail with opaque pointers enabled, but it does fix those where the test is looking for IR whose form has changed with opaque pointers enabled.