### PR TITLE
[SYCL][Driver] Pass two more options to spirv-to-ir-wrapper for SPIR-V fat objects

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10030,10 +10030,10 @@ void SpirvToIrWrapper::ConstructJob(Compilation &C, const JobAction &JA,
   // SPIR-V object, use SPIR-V style IR as opposed to OpenCL, and represent
   // SPIR-V globals as global variables instead of functions, all of which we
   // need for SPIR-V-based fat objects.
-  addArgs(
-      CmdArgs, TCArgs,
-      {"-llvm-spirv-opts", "--spirv-preserve-auxdata --spirv-target-env=SPV-IR "
-                           "--spirv-builtin-format=global"});
+  addArgs(CmdArgs, TCArgs,
+          {"-llvm-spirv-opts",
+           "--spirv-preserve-auxdata --spirv-target-env=SPV-IR "
+           "--spirv-builtin-format=global"});
 
   auto Cmd = std::make_unique<Command>(
       JA, *this, ResponseFileSupport::None(),

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10027,8 +10027,13 @@ void SpirvToIrWrapper::ConstructJob(Compilation &C, const JobAction &JA,
   addArgs(CmdArgs, TCArgs, {"-o", Output.getFilename()});
 
   // Make sure we preserve any auxiliary data which may be present in the
-  // SPIR-V object, which we need for SPIR-V-based fat objects.
-  addArgs(CmdArgs, TCArgs, {"-llvm-spirv-opts", "--spirv-preserve-auxdata"});
+  // SPIR-V object, use SPIR-V style IR as opposed to OpenCL, and represent
+  // SPIR-V globals as global variables instead of functions, all of which we
+  // need for SPIR-V-based fat objects.
+  addArgs(
+      CmdArgs, TCArgs,
+      {"-llvm-spirv-opts", "--spirv-preserve-auxdata --spirv-target-env=SPV-IR "
+                           "--spirv-builtin-format=global"});
 
   auto Cmd = std::make_unique<Command>(
       JA, *this, ResponseFileSupport::None(),

--- a/clang/test/Driver/sycl-spirv-obj.cpp
+++ b/clang/test/Driver/sycl-spirv-obj.cpp
@@ -40,5 +40,5 @@
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fsycl-device-obj=spirv -### %t.o 2>&1 | \
 // RUN:  FileCheck %s -check-prefixes=OPT_WARNING,LLVM_SPIRV_R
 // OPT_WARNING: warning: argument unused during compilation: '-fsycl-device-obj=spirv'
-// LLVM_SPIRV_R: spirv-to-ir-wrapper{{.*}} "-llvm-spirv-opts" "--spirv-preserve-auxdata"
+// LLVM_SPIRV_R: spirv-to-ir-wrapper{{.*}} "-llvm-spirv-opts" "--spirv-preserve-auxdata --spirv-target-env=SPV-IR --spirv-builtin-format=global"
 // LLVM_SPIRV_R-NOT: llvm-spirv{{.*}} "-r"


### PR DESCRIPTION
We need to pass both of these options for correct reverse translation of SPIR-V fat objects. It should have no effect otherwise.