### PR TITLE
[SYCL] Disable ESIMD/regression/copyto_char_test.cpp on failing configuration

### DIFF
--- a/sycl/test-e2e/ESIMD/regression/copyto_char_test.cpp
+++ b/sycl/test-e2e/ESIMD/regression/copyto_char_test.cpp
@@ -1,6 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// UNSUPPORTED: opencl && gpu-intel-pvc
+
 //==- copyto_char_test.cpp - Test for using copy_to to copy char buffers -==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
The failure is tracked in the internal bug tracking system.