### PR TITLE
[SYCL] Disable ESIMD/regression/variable_gather_mask.cpp on failing configuration

### DIFF
--- a/sycl/test-e2e/ESIMD/regression/variable_gather_mask.cpp
+++ b/sycl/test-e2e/ESIMD/regression/variable_gather_mask.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+
+// UNSUPPORTED: opencl && gpu-intel-pvc
 //
 // This is a regression test for the VC BE bug which generates incorrect code in
 // some cases in presence of variable (not compile-time constant) mask


### PR DESCRIPTION
The failure is tracked in the internal bug tracking system.