### PR TITLE
[SYCL] Disable ESIMD/regression/dgetrf.cpp on gpu-intel-pvc

### DIFF
--- a/sycl/test-e2e/ESIMD/regression/dgetrf.cpp
+++ b/sycl/test-e2e/ESIMD/regression/dgetrf.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -I%S/.. -o %t.out
 // RUN: %{run} %t.out 3 2 1
 //
+// Failure is under investigation, tracked internally:
+// UNSUPPORTED: gpu-intel-pvc
+//
 // This test checks the correctness of ESIMD program for batched LU
 // decomposition without pivoting. The program contains multiple branches
 // corresponding to LU input sizes; all internal functions are inlined.


### PR DESCRIPTION
Failure is under investigation internally.