### PR TITLE
[SYCL] Fix Plugin/level_zero_imm_cmdlist_per_thread.cpp test

### DIFF
--- a/sycl/test-e2e/Plugin/level_zero_imm_cmdlist_per_thread.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_imm_cmdlist_per_thread.cpp
@@ -4,8 +4,8 @@
 // UNSUPPORTED: windows
 
 // RUN: %{build} %level_zero_options %threads_lib -o %t.out
-// RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 SYCL_PI_LEVEL_ZERO_USE_COPY_ENGINE=0 ZE_DEBUG=-1 %{run} %t.out 2>&1 | FileCheck --check-prefixes=CHECK-ONE-CMDLIST %s
-// RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=2 SYCL_PI_LEVEL_ZERO_USE_COPY_ENGINE=0 ZE_DEBUG=-1 %{run} %t.out 2>&1 | FileCheck --check-prefixes=CHECK-PER-THREAD-CMDLIST %s
+// RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 SYCL_PI_LEVEL_ZERO_USE_COPY_ENGINE=0 ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck --check-prefixes=CHECK-ONE-CMDLIST %s
+// RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=2 SYCL_PI_LEVEL_ZERO_USE_COPY_ENGINE=0 ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck --check-prefixes=CHECK-PER-THREAD-CMDLIST %s
 
 // The test checks that immediate commandlists are created per-thread.
 // One immediate commandlist is created for device init, the rest for the queue.

--- a/sycl/test-e2e/Plugin/level_zero_imm_cmdlist_per_thread.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_imm_cmdlist_per_thread.cpp
@@ -4,8 +4,8 @@
 // UNSUPPORTED: windows
 
 // RUN: %{build} %level_zero_options %threads_lib -o %t.out
-// RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck --check-prefixes=CHECK-ONE-CMDLIST %s
-// RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=2 ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck --check-prefixes=CHECK-PER-THREAD-CMDLIST %s
+// RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 SYCL_PI_LEVEL_ZERO_USE_COPY_ENGINE=0 ZE_DEBUG=-1 %{run} %t.out 2>&1 | FileCheck --check-prefixes=CHECK-ONE-CMDLIST %s
+// RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=2 SYCL_PI_LEVEL_ZERO_USE_COPY_ENGINE=0 ZE_DEBUG=-1 %{run} %t.out 2>&1 | FileCheck --check-prefixes=CHECK-PER-THREAD-CMDLIST %s
 
 // The test checks that immediate commandlists are created per-thread.
 // One immediate commandlist is created for device init, the rest for the queue.


### PR DESCRIPTION
Make it pass on devices that have both compute and copy engines.