### PR TITLE
[SYCL] Disable AtomicRef/atomic_memory_order_seq_cst.cpp on PVC

### DIFF
--- a/sycl/test-e2e/AtomicRef/atomic_memory_order_seq_cst.cpp
+++ b/sycl/test-e2e/AtomicRef/atomic_memory_order_seq_cst.cpp
@@ -1,5 +1,8 @@
 // RUN: %{build} -O3 -o %t.out -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70
 // RUN: %{run} %t.out
+//
+// Tracked in the internal bug tracking system.
+// UNSUPPORTED: gpu-intel-pvc
 
 #include "atomic_memory_order.h"
 #include <iostream>


### PR DESCRIPTION
We have an internal bug report to track investigation.