### PR TITLE
[SYCL][InvokeSimd][E2E] Fix scale tests on hardware that doesn't support fp64

### DIFF
--- a/sycl/test-e2e/InvokeSimd/Feature/ImplicitSubgroup/scale_double.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/ImplicitSubgroup/scale_double.cpp
@@ -1,0 +1,13 @@
+// REQUIRES: aspect-fp64
+// Check that full compilation works:
+// RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../scale_double.cpp -o %t.out
+// RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
+//
+// VISALTO enable run
+// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
+
+/*
+ * This tests is the same as InvokeSimd/feature/scale_double.cpp, but compiles
+ * without optional subgroup attribute specified and intended to check that
+ * compiler is able to choose subgroup size correctly.
+ */

--- a/sycl/test-e2e/InvokeSimd/Feature/scale.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/scale.cpp
@@ -147,6 +147,7 @@ int main(void) {
   const bool SupportsDouble = dev.has(aspect::fp64);
 
   bool passed = true;
+#ifndef TEST_DOUBLE_TYPE
   passed &= test<unsigned char>(q);
   passed &= test<char>(q);
   passed &= test<unsigned short>(q);
@@ -157,9 +158,10 @@ int main(void) {
   passed &= test<long>(q);
 
   passed &= test<float>(q);
+#else
   if (SupportsDouble)
     passed &= test<double>(q);
-
+#endif
   std::cout << (passed ? "Passed\n" : "FAILED\n");
   return passed ? 0 : 1;
 }

--- a/sycl/test-e2e/InvokeSimd/Feature/scale_double.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/scale_double.cpp
@@ -1,0 +1,27 @@
+// REQUIRES: aspect-fp64
+// Check that full compilation works:
+// RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
+// RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
+//
+// VISALTO enable run
+// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
+
+/*
+ * Tests invoke_simd support in the compiler/headers
+ * Test case purpose:
+ * -----------------
+ * To verify that the simple scale example from the invoke_simd spec
+ * https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_invoke_simd.asciidoc
+ * works.
+ *
+ * Test case description:
+ * ---------------------
+ * Invoke a simple SIMD function that scales all elements of a SIMD type X by a
+ * scalar value n with double.
+ *
+ * This test also runs with all types of VISA link time optimizations enabled.
+ */
+
+#define TEST_DOUBLE_TYPE
+
+#include "scale.cpp"


### PR DESCRIPTION
We do a check with `dev.has(aspect::fp64)`, but that's a runtime check.

With InvokeSimd, we need to compile with `-fno-sycl-device-code-split-esimd` which disables any module splitting.

Usually modules are split into images based on optional device features, such as fp64, but because of the above option we only end up with a single device image that contains both fp64 and non-fp64 code because of the runtime check.

Since there can only be one image, we can't use fp64 at all on non-fp64 hardware, so a runtime check won't work.

Split the test into a non-fp64 and fp64-only version.

The above is what we do for other tests that test double conditionally on non-fp64 hardware, such as invoke_simd_conv_double.cpp