### PR TITLE
[SYCL] Avoid unnecessary kernel retain

### DIFF
--- a/sycl/source/kernel.cpp
+++ b/sycl/source/kernel.cpp
@@ -22,8 +22,10 @@ kernel::kernel(cl_kernel ClKernel, const context &SyclContext)
           detail::getSyclObjImpl(SyclContext), nullptr, nullptr)) {
   // This is a special interop constructor for OpenCL, so the kernel must be
   // retained.
-  impl->getPlugin()->call<detail::PiApiKind::piKernelRetain>(
-      detail::pi::cast<detail::RT::PiKernel>(ClKernel));
+  if (get_backend() == backend::opencl) {
+    impl->getPlugin()->call<detail::PiApiKind::piKernelRetain>(
+        detail::pi::cast<detail::RT::PiKernel>(ClKernel));
+  }
 }
 
 cl_kernel kernel::get() const { return impl->get(); }


### PR DESCRIPTION
We should retain the kernel only for opencl backend.