### PR TITLE
[SYCL] Fix stack smashing due to different sizes of cl_bool and bool

### DIFF
--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -605,7 +605,9 @@ pi_result piDeviceGetInfo(pi_device device, pi_device_info paramName,
   }
   case PI_DEVICE_INFO_ATOMIC_64: {
     cl_int ret_err = CL_SUCCESS;
-    cl_bool result = CL_FALSE;
+    bool result = false;
+    if (paramValueSize < sizeof(result))
+      return PI_ERROR_INVALID_VALUE;
     bool supported = false;
 
     ret_err = checkDeviceExtensions(
@@ -616,18 +618,22 @@ pi_result piDeviceGetInfo(pi_device device, pi_device_info paramName,
       return static_cast<pi_result>(ret_err);
 
     result = supported;
-    std::memcpy(paramValue, &result, sizeof(cl_bool));
+    std::memcpy(paramValue, &result, sizeof(bool));
     return PI_SUCCESS;
   }
   case PI_EXT_ONEAPI_DEVICE_INFO_BFLOAT16_MATH_FUNCTIONS: {
     // bfloat16 math functions are not yet supported on Intel GPUs.
-    cl_bool result = false;
-    std::memcpy(paramValue, &result, sizeof(cl_bool));
+    bool result = false;
+    if (paramValueSize < sizeof(result))
+      return PI_ERROR_INVALID_VALUE;
+    std::memcpy(paramValue, &result, sizeof(bool));
     return PI_SUCCESS;
   }
   case PI_DEVICE_INFO_IMAGE_SRGB: {
-    cl_bool result = true;
-    std::memcpy(paramValue, &result, sizeof(cl_bool));
+    bool result = true;
+    if (paramValueSize < sizeof(result))
+      return PI_ERROR_INVALID_VALUE;
+    std::memcpy(paramValue, &result, sizeof(bool));
     return PI_SUCCESS;
   }
   case PI_DEVICE_INFO_BUILD_ON_SUBDEVICE: {
@@ -637,8 +643,10 @@ pi_result piDeviceGetInfo(pi_device device, pi_device_info paramName,
 
     // FIXME: here we assume that program built for a root GPU device can be
     // used on its sub-devices without re-building
-    cl_bool result = (res == CL_SUCCESS) && (devType == CL_DEVICE_TYPE_GPU);
-    std::memcpy(paramValue, &result, sizeof(cl_bool));
+    bool result = (res == CL_SUCCESS) && (devType == CL_DEVICE_TYPE_GPU);
+    if (paramValueSize < sizeof(result))
+      return PI_ERROR_INVALID_VALUE;
+    std::memcpy(paramValue, &result, sizeof(bool));
     return PI_SUCCESS;
   }
   case PI_EXT_ONEAPI_DEVICE_INFO_MAX_WORK_GROUPS_3D:
@@ -715,7 +723,9 @@ pi_result piDeviceGetInfo(pi_device device, pi_device_info paramName,
   }
   case PI_EXT_INTEL_DEVICE_INFO_MEM_CHANNEL_SUPPORT: {
     cl_int ret_err = CL_SUCCESS;
-    cl_bool result = CL_FALSE;
+    bool result = false;
+    if (paramValueSize < sizeof(result))
+      return PI_ERROR_INVALID_VALUE;
     bool supported = false;
 
     ret_err =

--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -735,7 +735,7 @@ pi_result piDeviceGetInfo(pi_device device, pi_device_info paramName,
       return static_cast<pi_result>(ret_err);
 
     result = supported;
-    std::memcpy(paramValue, &result, sizeof(cl_bool));
+    std::memcpy(paramValue, &result, sizeof(bool));
     return PI_SUCCESS;
   }
   default:

--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -618,7 +618,7 @@ pi_result piDeviceGetInfo(pi_device device, pi_device_info paramName,
       return static_cast<pi_result>(ret_err);
 
     result = supported;
-    std::memcpy(paramValue, &result, sizeof(bool));
+    std::memcpy(paramValue, &result, sizeof(result));
     return PI_SUCCESS;
   }
   case PI_EXT_ONEAPI_DEVICE_INFO_BFLOAT16_MATH_FUNCTIONS: {
@@ -626,14 +626,14 @@ pi_result piDeviceGetInfo(pi_device device, pi_device_info paramName,
     bool result = false;
     if (paramValueSize < sizeof(result))
       return PI_ERROR_INVALID_VALUE;
-    std::memcpy(paramValue, &result, sizeof(bool));
+    std::memcpy(paramValue, &result, sizeof(result));
     return PI_SUCCESS;
   }
   case PI_DEVICE_INFO_IMAGE_SRGB: {
     bool result = true;
     if (paramValueSize < sizeof(result))
       return PI_ERROR_INVALID_VALUE;
-    std::memcpy(paramValue, &result, sizeof(bool));
+    std::memcpy(paramValue, &result, sizeof(result));
     return PI_SUCCESS;
   }
   case PI_DEVICE_INFO_BUILD_ON_SUBDEVICE: {
@@ -646,7 +646,7 @@ pi_result piDeviceGetInfo(pi_device device, pi_device_info paramName,
     bool result = (res == CL_SUCCESS) && (devType == CL_DEVICE_TYPE_GPU);
     if (paramValueSize < sizeof(result))
       return PI_ERROR_INVALID_VALUE;
-    std::memcpy(paramValue, &result, sizeof(bool));
+    std::memcpy(paramValue, &result, sizeof(result));
     return PI_SUCCESS;
   }
   case PI_EXT_ONEAPI_DEVICE_INFO_MAX_WORK_GROUPS_3D:
@@ -735,7 +735,7 @@ pi_result piDeviceGetInfo(pi_device device, pi_device_info paramName,
       return static_cast<pi_result>(ret_err);
 
     result = supported;
-    std::memcpy(paramValue, &result, sizeof(bool));
+    std::memcpy(paramValue, &result, sizeof(result));
     return PI_SUCCESS;
   }
   default:


### PR DESCRIPTION
This patch fixes stack smashing happened during querying of available aspects list, and also during calling `sycl-ls --verbose`. The stack smashing happened due to different sizes of `cl_bool` and `bool` types. Patch changes `cl_bool` to `bool` because there is no need in `cl_bool` in this part of the code, and also adds a (probably unnecessary) diagnostic which returns `PI_ERROR_INVALID_VALUE` - the same diagnostic is a part of OpenCL spec for `clGetDeviceInfo` function.