### PR TITLE
[SYCL-MLIR] Construct `MLIRScanner` with `InsertionContext`

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGDecl.cc
+++ b/polygeist/tools/cgeist/Lib/CGDecl.cc
@@ -120,7 +120,7 @@ ValueCategory MLIRScanner::VisitVarDecl(clang::VarDecl *Decl) {
     if (isa<LLVM::LLVMPointerType>(Glob.getTypes().getMLIRType(
             Glob.getCGM().getContext().getPointerType(Decl->getType())))) {
       auto GSF = Glob.getOrCreateLLVMGlobal(
-          Decl, (Function.getName() + "@static@").str());
+          Decl, (Function.getName() + "@static@").str(), FunctionContext::Host);
       Op = ABuilder.create<LLVM::AddressOfOp>(
           VarLoc,
           Glob.getTypes().getPointerType(GSF.getType(), GSF.getAddrSpace()),

--- a/polygeist/tools/cgeist/Lib/CGDecl.cc
+++ b/polygeist/tools/cgeist/Lib/CGDecl.cc
@@ -120,7 +120,8 @@ ValueCategory MLIRScanner::VisitVarDecl(clang::VarDecl *Decl) {
     if (isa<LLVM::LLVMPointerType>(Glob.getTypes().getMLIRType(
             Glob.getCGM().getContext().getPointerType(Decl->getType())))) {
       auto GSF = Glob.getOrCreateLLVMGlobal(
-          Decl, (Function.getName() + "@static@").str(), FunctionContext::Host);
+          Decl, (Function.getName() + "@static@").str(),
+          InsertionContext::Host);
       Op = ABuilder.create<LLVM::AddressOfOp>(
           VarLoc,
           Glob.getTypes().getPointerType(GSF.getType(), GSF.getAddrSpace()),
@@ -128,7 +129,7 @@ ValueCategory MLIRScanner::VisitVarDecl(clang::VarDecl *Decl) {
     } else {
       auto GV =
           Glob.getOrCreateGlobal(*Decl, (Function.getName() + "@static@").str(),
-                                 FunctionContext::Host);
+                                 InsertionContext::Host);
       auto GV2 = ABuilder.create<memref::GetGlobalOp>(
           VarLoc, GV.first.getType(), GV.first.getName());
       Op = reshapeRanklessGlobal(GV2);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -392,9 +392,9 @@ void MLIRScanner::setEntryAndAllocBlock(Block *B) {
   AllocationScope = EntryBlock = B;
   Builder.setInsertionPointToStart(B);
   // If block is linked, then the function contexts should match.
-  assert(!B->getParentOp() ||
-         FuncContext == mlirclang::getInputContext(Builder) &&
-             "Expecting function contexts to match");
+  assert((!B->getParentOp() ||
+          FuncContext == mlirclang::getInputContext(Builder)) &&
+         "Expecting function contexts to match");
 }
 
 Value MLIRScanner::createAllocOp(Type T, clang::VarDecl *Name,

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -90,8 +90,6 @@ static void checkFunctionParent(const FunctionOpInterface F,
 
 void MLIRScanner::init(FunctionOpInterface Func, const FunctionToEmit &FTE) {
   const clang::FunctionDecl *FD = &FTE.getDecl();
-  assert(FuncContext == mlirclang::getFuncContext(Func) &&
-         "Expecting function contexts to match");
 
   Function = Func;
   EmittingFunctionDecl = FD;
@@ -391,10 +389,6 @@ void MLIRScanner::init(FunctionOpInterface Func, const FunctionToEmit &FTE) {
 void MLIRScanner::setEntryAndAllocBlock(Block *B) {
   AllocationScope = EntryBlock = B;
   Builder.setInsertionPointToStart(B);
-  // If block is linked, then the function contexts should match.
-  assert((!B->getParentOp() ||
-          FuncContext == mlirclang::getInputContext(Builder)) &&
-         "Expecting function contexts to match");
 }
 
 Value MLIRScanner::createAllocOp(Type T, clang::VarDecl *Name,

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -62,10 +62,10 @@ struct LoopContext {
 
 class BinOpInfo;
 
-/// Context in which a function is located.
+/// Context in which a function or a global is located.
 enum class InsertionContext {
-  Host,      ///< Host function
-  SYCLDevice ///< SYCL Device function
+  Host,      ///< Host context
+  SYCLDevice ///< SYCL Device context
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &Out,

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -185,7 +185,8 @@ public:
   mlir::LLVM::LLVMFuncOp getOrCreateFreeFunction();
 
   mlir::LLVM::GlobalOp getOrCreateLLVMGlobal(const clang::ValueDecl *VD,
-                                             std::string Prefix = "");
+                                             std::string Prefix,
+                                             FunctionContext FuncContext);
 
   /// Return a value representing an access into a global string with the
   /// given name, creating the string if necessary.
@@ -254,6 +255,7 @@ class MLIRScanner : public clang::StmtVisitor<MLIRScanner, ValueCategory> {
 private:
   MLIRASTConsumer &Glob;
   mlir::FunctionOpInterface Function;
+  FunctionContext FuncContext;
   mlir::OwningOpRef<mlir::ModuleOp> &Module;
   mlir::OpBuilder Builder;
   mlir::Location Loc;
@@ -387,14 +389,11 @@ private:
 
 public:
   MLIRScanner(MLIRASTConsumer &Glob, mlir::OwningOpRef<mlir::ModuleOp> &Module,
-              LowerToInfo &LTInfo);
+              LowerToInfo &LTInfo, FunctionContext FuncContext);
 
   void init(mlir::FunctionOpInterface Function, const FunctionToEmit &FTE);
 
-  void setEntryAndAllocBlock(mlir::Block *B) {
-    AllocationScope = EntryBlock = B;
-    Builder.setInsertionPointToStart(B);
-  }
+  void setEntryAndAllocBlock(mlir::Block *B);
 
   mlir::OpBuilder &getBuilder() { return Builder; };
   std::vector<LoopContext> &getLoops() { return Loops; }

--- a/polygeist/tools/cgeist/Lib/utils.cc
+++ b/polygeist/tools/cgeist/Lib/utils.cc
@@ -73,14 +73,14 @@ NamespaceKind getNamespaceKind(const clang::DeclContext *DC) {
   return NamespaceKind::Other;
 }
 
-FunctionContext getInputContext(const OpBuilder &B) {
+InsertionContext getInputContext(const OpBuilder &B) {
   assert(B.getInsertionBlock() && B.getInsertionBlock()->getParentOp() &&
          "Expecting builder with linked insertion block");
   return B.getInsertionBlock()
                  ->getParentOp()
                  ->getParentOfType<gpu::GPUModuleOp>()
-             ? FunctionContext::SYCLDevice
-             : FunctionContext::Host;
+             ? InsertionContext::SYCLDevice
+             : InsertionContext::Host;
 }
 
 gpu::GPUModuleOp getDeviceModule(ModuleOp Module) {
@@ -88,21 +88,21 @@ gpu::GPUModuleOp getDeviceModule(ModuleOp Module) {
       Module.lookupSymbol(MLIRASTConsumer::DeviceModuleName));
 }
 
-FunctionContext getFuncContext(FunctionOpInterface Function) {
+InsertionContext getFuncContext(FunctionOpInterface Function) {
   assert(Function && "Expecting valid Function");
   return isa<mlir::gpu::GPUModuleOp>(Function->getParentOp())
-             ? FunctionContext::SYCLDevice
-             : FunctionContext::Host;
+             ? InsertionContext::SYCLDevice
+             : InsertionContext::Host;
 }
 
-void setInsertionPoint(OpBuilder &Builder, FunctionContext FuncContext,
+void setInsertionPoint(OpBuilder &Builder, InsertionContext FuncContext,
                        ModuleOp Module) {
   switch (FuncContext) {
-  case FunctionContext::SYCLDevice:
+  case InsertionContext::SYCLDevice:
     Builder.setInsertionPointToStart(
         mlirclang::getDeviceModule(Module).getBody());
     break;
-  case FunctionContext::Host:
+  case InsertionContext::Host:
     Builder.setInsertionPointToStart(Module.getBody());
     break;
   }

--- a/polygeist/tools/cgeist/Lib/utils.cc
+++ b/polygeist/tools/cgeist/Lib/utils.cc
@@ -74,7 +74,7 @@ NamespaceKind getNamespaceKind(const clang::DeclContext *DC) {
 }
 
 FunctionContext getInputContext(const OpBuilder &B) {
-  assert(B.getInsertionBlock()->getParentOp() &&
+  assert(B.getInsertionBlock() && B.getInsertionBlock()->getParentOp() &&
          "Expecting builder with linked insertion block");
   return B.getInsertionBlock()
                  ->getParentOp()

--- a/polygeist/tools/cgeist/Lib/utils.cc
+++ b/polygeist/tools/cgeist/Lib/utils.cc
@@ -73,26 +73,9 @@ NamespaceKind getNamespaceKind(const clang::DeclContext *DC) {
   return NamespaceKind::Other;
 }
 
-InsertionContext getInputContext(const OpBuilder &B) {
-  assert(B.getInsertionBlock() && B.getInsertionBlock()->getParentOp() &&
-         "Expecting builder with linked insertion block");
-  return B.getInsertionBlock()
-                 ->getParentOp()
-                 ->getParentOfType<gpu::GPUModuleOp>()
-             ? InsertionContext::SYCLDevice
-             : InsertionContext::Host;
-}
-
 gpu::GPUModuleOp getDeviceModule(ModuleOp Module) {
   return cast<gpu::GPUModuleOp>(
       Module.lookupSymbol(MLIRASTConsumer::DeviceModuleName));
-}
-
-InsertionContext getFuncContext(FunctionOpInterface Function) {
-  assert(Function && "Expecting valid Function");
-  return isa<mlir::gpu::GPUModuleOp>(Function->getParentOp())
-             ? InsertionContext::SYCLDevice
-             : InsertionContext::Host;
 }
 
 void setInsertionPoint(OpBuilder &Builder, InsertionContext FuncContext,

--- a/polygeist/tools/cgeist/Lib/utils.cc
+++ b/polygeist/tools/cgeist/Lib/utils.cc
@@ -74,6 +74,8 @@ NamespaceKind getNamespaceKind(const clang::DeclContext *DC) {
 }
 
 FunctionContext getInputContext(const OpBuilder &B) {
+  assert(B.getInsertionBlock()->getParentOp() &&
+         "Expecting builder with linked insertion block");
   return B.getInsertionBlock()
                  ->getParentOp()
                  ->getParentOfType<gpu::GPUModuleOp>()
@@ -87,6 +89,7 @@ gpu::GPUModuleOp getDeviceModule(ModuleOp Module) {
 }
 
 FunctionContext getFuncContext(FunctionOpInterface Function) {
+  assert(Function && "Expecting valid Function");
   return isa<mlir::gpu::GPUModuleOp>(Function->getParentOp())
              ? FunctionContext::SYCLDevice
              : FunctionContext::Host;

--- a/polygeist/tools/cgeist/Lib/utils.h
+++ b/polygeist/tools/cgeist/Lib/utils.h
@@ -69,14 +69,8 @@ replaceFuncByOperation(mlir::func::FuncOp F, llvm::StringRef OpName,
 
 NamespaceKind getNamespaceKind(const clang::DeclContext *DC);
 
-/// Return the insertion context of the input builder.
-InsertionContext getInputContext(const mlir::OpBuilder &Builder);
-
 /// Return the device module in the input module.
 mlir::gpu::GPUModuleOp getDeviceModule(mlir::ModuleOp Module);
-
-/// Return the function context
-InsertionContext getFuncContext(mlir::FunctionOpInterface Function);
 
 /// Set the OpBuilder \p Builder insertion point depending on the given
 /// InsertionContext \p FuncContext.

--- a/polygeist/tools/cgeist/Lib/utils.h
+++ b/polygeist/tools/cgeist/Lib/utils.h
@@ -44,7 +44,7 @@ template <typename> class SmallVectorImpl;
 class StringRef;
 } // namespace llvm
 
-enum class FunctionContext;
+enum class InsertionContext;
 
 namespace mlirclang {
 
@@ -70,17 +70,17 @@ replaceFuncByOperation(mlir::func::FuncOp F, llvm::StringRef OpName,
 NamespaceKind getNamespaceKind(const clang::DeclContext *DC);
 
 /// Return the insertion context of the input builder.
-FunctionContext getInputContext(const mlir::OpBuilder &Builder);
+InsertionContext getInputContext(const mlir::OpBuilder &Builder);
 
 /// Return the device module in the input module.
 mlir::gpu::GPUModuleOp getDeviceModule(mlir::ModuleOp Module);
 
 /// Return the function context
-FunctionContext getFuncContext(mlir::FunctionOpInterface Function);
+InsertionContext getFuncContext(mlir::FunctionOpInterface Function);
 
 /// Set the OpBuilder \p Builder insertion point depending on the given
-/// FunctionContext \p FuncContext.
-void setInsertionPoint(mlir::OpBuilder &Builder, FunctionContext FuncContext,
+/// InsertionContext \p FuncContext.
+void setInsertionPoint(mlir::OpBuilder &Builder, InsertionContext FuncContext,
                        mlir::ModuleOp Module);
 
 } // namespace mlirclang


### PR DESCRIPTION
Before this PR, member functions in `MLIRScanner` use `mlirclang::getFuncContext` or `mlirclang::getInputContext` to get the `InsertionContext`. They relies on a valid associate `Function` or a linked insertion block of the associate builder respectively, both of them are not always true, for example when `MLIRScanner` is used to create globals. 
In this PR, we construct `MLIRScanner` with `InsertionContext`, so we don't need to get it indirectly. 

Note: `FunctionContext` is renamed to `InsertionContext`.

There are 16 e2e tests affected by this problem. With this PR, they are failing somewhere else.