### PR TITLE
[ESIMD][LIT] Update LIT test for ESIMDVerifierPass

### DIFF
--- a/sycl/test/esimd/esimd_verify.cpp
+++ b/sycl/test/esimd/esimd_verify.cpp
@@ -1,5 +1,7 @@
-// RUN: not %clangxx -fsycl -fsycl-device-only -S %s -o /dev/null 2>&1 | FileCheck %s
-// RUN: not %clangxx -fsycl -fsycl-device-only -O0 -S %s -o /dev/null 2>&1 | FileCheck %s
+// RUN: not %clangxx -fsycl -fno-sycl-esimd-force-stateless-mem -fsycl-device-only -S %s -o /dev/null 2>&1 | FileCheck -check-prefix=CHECK-NEGATIVE %s
+// RUN: not %clangxx -fsycl -fno-sycl-esimd-force-stateless-mem -fsycl-device-only -O0 -S %s -o /dev/null 2>&1 | FileCheck -check-prefix=CHECK-NEGATIVE %s
+
+// RUN: not %clangxx -fsycl -fsycl-esimd-force-stateless-mem -fsycl-device-only -O0 -S %s -o /dev/null  2>&1 | FileCheck -check-prefix=CHECK-POSITIVE %s
 
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>
@@ -7,12 +9,16 @@
 using namespace sycl;
 using namespace sycl::ext::intel::esimd;
 
-// CHECK-DAG: error: function 'int* sycl::_V1::accessor<{{.+}}>::get_pointer<{{.+}}>() const' is not supported in ESIMD context
-// CHECK-DAG: error: function '{{.+}} sycl::_V1::accessor<{{.+}}>::operator[]<{{.+}}>({{.+}}) const' is not supported in ESIMD context
-// CHECK-DAG: error: function '{{.+}}combine(int const&)' is not supported in ESIMD context
+// CHECK-NEGATIVE-DAG: error: function 'int* sycl::_V1::accessor<{{.+}}>::get_pointer<{{.+}}>() const' is not supported in ESIMD context
+// CHECK-NEGATIVE-DAG: error: function '{{.+}} sycl::_V1::accessor<{{.+}}>::operator[]<{{.+}}>({{.+}}) const' is not supported in ESIMD context
+// CHECK-NEGATIVE-DAG: error: function '{{.+}}combine(int const&)' is not supported in ESIMD context
+
+// CHECK-POSITIVE-NOT: error: function 'int* sycl::_V1::accessor<{{.+}}>::get_pointer
+// CHECK-POSITIVE-NOT: error: function '{{.+}} sycl::_V1::accessor<{{.+}}>::operator[]
+// CHECK-POSITIVE-DAG: error: function '{{.+}}combine(int const&)' is not supported in ESIMD context
 
 SYCL_EXTERNAL auto
-test(accessor<int, 1, access::mode::read_write, access::target::device> &acc)
+test0(accessor<int, 1, access::mode::read_write, access::target::device> &acc)
     SYCL_ESIMD_FUNCTION {
   return acc.get_pointer();
 }

--- a/sycl/test/esimd/esimd_verify.cpp
+++ b/sycl/test/esimd/esimd_verify.cpp
@@ -1,7 +1,7 @@
 // RUN: not %clangxx -fsycl -fno-sycl-esimd-force-stateless-mem -fsycl-device-only -S %s -o /dev/null 2>&1 | FileCheck -check-prefix=CHECK-NEGATIVE %s
 // RUN: not %clangxx -fsycl -fno-sycl-esimd-force-stateless-mem -fsycl-device-only -O0 -S %s -o /dev/null 2>&1 | FileCheck -check-prefix=CHECK-NEGATIVE %s
 
-// RUN: not %clangxx -fsycl -fsycl-esimd-force-stateless-mem -fsycl-device-only -O0 -S %s -o /dev/null  2>&1 | FileCheck -check-prefix=CHECK-POSITIVE %s
+// RUN: not %clangxx -fsycl -fsycl-esimd-force-stateless-mem -fsycl-device-only -O0 -S %s -o /dev/null  2>&1 | FileCheck -check-prefix=CHECK-POSITIVE --implicit-check-not="error: function" %s
 
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>
@@ -13,9 +13,7 @@ using namespace sycl::ext::intel::esimd;
 // CHECK-NEGATIVE-DAG: error: function '{{.+}} sycl::_V1::accessor<{{.+}}>::operator[]<{{.+}}>({{.+}}) const' is not supported in ESIMD context
 // CHECK-NEGATIVE-DAG: error: function '{{.+}}combine(int const&)' is not supported in ESIMD context
 
-// CHECK-POSITIVE-NOT: error: function 'int* sycl::_V1::accessor<{{.+}}>::get_pointer
-// CHECK-POSITIVE-NOT: error: function '{{.+}} sycl::_V1::accessor<{{.+}}>::operator[]
-// CHECK-POSITIVE-DAG: error: function '{{.+}}combine(int const&)' is not supported in ESIMD context
+// CHECK-POSITIVE: error: function '{{.+}}combine(int const&)' is not supported in ESIMD context
 
 SYCL_EXTERNAL auto
 test0(accessor<int, 1, access::mode::read_write, access::target::device> &acc)


### PR DESCRIPTION
The updated test gets explicit options for stateless/stateful mode and gets basic check verifying that in force-stateless mode some of verifier checks still work.