### PR TITLE
[SYCL] Try to fix test-e2e/Basic/barrier_order.cpp

### DIFF
--- a/sycl/test-e2e/Basic/barrier_order.cpp
+++ b/sycl/test-e2e/Basic/barrier_order.cpp
@@ -37,7 +37,6 @@ int main() {
     q.ext_oneapi_submit_barrier();
   }
 
-  q.single_task([=]() {});
   q.wait_and_throw();
   auto Check = [&]() {
     std::bitset<8 * sizeof(*x)> bits(*x);


### PR DESCRIPTION
This was originally reported in
https://github.com/intel/llvm/issues/7330. I still have a problem with opencl:gpu device where it hangs, for which I've created an internal bug report as well. Keeping the Github issue open until the test is re-enabled everywhere.