### PR TITLE
[SYCL] Disable test-e2e/DiscardEvents/invalid_event.cpp on opencl:gpu

### DIFF
--- a/sycl/test-e2e/DiscardEvents/invalid_event.cpp
+++ b/sycl/test-e2e/DiscardEvents/invalid_event.cpp
@@ -1,5 +1,9 @@
 // FIXME: Fails on HIP
 // UNSUPPORTED: hip
+//
+// Same hang as on Basic/barrier_order.cpp tracked in
+// https://github.com/intel/llvm/issues/7330.
+// UNSUPPORTED: opencl && gpu
 // RUN: %{build} -o %t.out
 //
 // RUN: %{run} %t.out


### PR DESCRIPTION
Same hang as in https://github.com/intel/llvm/issues/7330.