### PR TITLE
[SYCL][Driver] Add hidden option to specify llvm-spirv arguments

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -879,6 +879,11 @@ def Xopenmp_target : Separate<["-"], "Xopenmp-target">, Group<CompileOnly_Group>
 def Xopenmp_target_EQ : JoinedAndSeparate<["-"], "Xopenmp-target=">, Group<CompileOnly_Group>,
   HelpText<"Pass <arg> to the target offloading toolchain identified by <triple>.">,
   MetaVarName<"<triple> <arg>">;
+def Xspirv_translator : Separate<["-"], "Xspirv-translator">,
+  HelpText<"Pass <arg> to the LLVM IR to SPIR-V translation backend.">, MetaVarName<"<arg>">, Flags<[CoreOption, HelpHidden]>;
+def Xspirv_translator_EQ : JoinedAndSeparate<["-"], "Xspirv-translator=">,
+  HelpText<"Pass <arg> to the LLVM IR to SPIR-V translation backend identified by <triple>.">,
+  MetaVarName<"<triple> <arg>">, Flags<[CoreOption, HelpHidden]>;
 def Xsycl_backend : Separate<["-"], "Xsycl-target-backend">,
   HelpText<"Pass <arg> to the SYCL based target backend.">, MetaVarName<"<arg>">, Flags<[CoreOption]>;
 def Xsycl_backend_EQ : JoinedAndSeparate<["-"], "Xsycl-target-backend=">,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9651,6 +9651,14 @@ void SPIRVTranslator::ConstructJob(Compilation &C, const JobAction &JA,
       ExtArg += ",+SPV_KHR_non_semantic_info";
 
     TranslatorArgs.push_back(TCArgs.MakeArgString(ExtArg));
+
+    const toolchains::SYCLToolChain &TC =
+        static_cast<const toolchains::SYCLToolChain &>(getToolChain());
+
+    // Handle -Xspirv-translator
+    TC.TranslateTargetOpt(
+        TCArgs, TranslatorArgs, options::OPT_Xspirv_translator,
+        options::OPT_Xspirv_translator_EQ, JA.getOffloadingArch());
   }
   for (auto I : Inputs) {
     std::string Filename(I.getFilename());

--- a/clang/lib/Driver/ToolChains/SYCL.h
+++ b/clang/lib/Driver/ToolChains/SYCL.h
@@ -172,6 +172,11 @@ public:
   void TranslateLinkerTargetArgs(const llvm::Triple &Triple,
                                  const llvm::opt::ArgList &Args,
                                  llvm::opt::ArgStringList &CmdArgs) const;
+  void TranslateTargetOpt(const llvm::opt::ArgList &Args,
+                          llvm::opt::ArgStringList &CmdArgs,
+                          llvm::opt::OptSpecifier Opt,
+                          llvm::opt::OptSpecifier Opt_EQ,
+                          StringRef Device) const;
 
   bool useIntegratedAs() const override { return true; }
   bool isPICDefault() const override { return false; }
@@ -198,11 +203,6 @@ protected:
   Tool *buildLinker() const override;
 
 private:
-  void TranslateTargetOpt(const llvm::opt::ArgList &Args,
-                          llvm::opt::ArgStringList &CmdArgs,
-                          llvm::opt::OptSpecifier Opt,
-                          llvm::opt::OptSpecifier Opt_EQ,
-                          StringRef Device) const;
   void TranslateGPUTargetOpt(const llvm::opt::ArgList &Args,
                              llvm::opt::ArgStringList &CmdArgs,
                              llvm::opt::OptSpecifier Opt_EQ) const;

--- a/clang/test/Driver/sycl-spirv-opt.cpp
+++ b/clang/test/Driver/sycl-spirv-opt.cpp
@@ -8,11 +8,14 @@
 // RUN: %clangxx -fsycl -Xspirv-translator=spir64_gen "foo" -### %s 2>&1 | \
 // RUN:  FileCheck %s -check-prefix CHECK-SINGLE-TARGET-UNUSED --implicit-check-not 'llvm-spirv{{.*}} "foo"'
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64,spir64_gen -Xspirv-translator=spir64 "foo" -Xspirv-translator=spir64_gen "bar" -### %s 2>&1 | \
+// RUN: %clangxx -fsycl -fsycl-targets=spir64,spir64_gen -Xspirv-translator=spir64_gen "foo" -Xspirv-translator=spir64 "bar" -### %s 2>&1 | \
 // RUN:  FileCheck %s -check-prefix CHECK-MULTIPLE-TARGET --implicit-check-not 'llvm-spirv{{.*}} "foo" "bar"'
+
 // CHECK-SINGLE-TARGET: llvm-spirv{{.*}} "foo"
 
 // CHECK-SINGLE-TARGET-UNUSED: argument unused during compilation: '-Xspirv-translator=spir64_gen foo'
 
-// CHECK-MULTIPLE-TARGET: llvm-spirv{{.*}} "foo"
+// CHECK-MULTIPLE-TARGET: clang-offload-bundler{{.*}} "-targets=sycl-spir64-unknown-unknown" {{.*}} "-unbundle"
 // CHECK-MULTIPLE-TARGET: llvm-spirv{{.*}} "bar"
+// CHECK-MULTIPLE-TARGET: clang-offload-bundler{{.*}} "-targets=sycl-spir64_gen-unknown-unknown" {{.*}} "-unbundle"
+// CHECK-MULTIPLE-TARGET: llvm-spirv{{.*}} "foo"

--- a/clang/test/Driver/sycl-spirv-opt.cpp
+++ b/clang/test/Driver/sycl-spirv-opt.cpp
@@ -15,7 +15,7 @@
 
 // CHECK-SINGLE-TARGET-UNUSED: argument unused during compilation: '-Xspirv-translator=spir64_gen foo'
 
-// CHECK-MULTIPLE-TARGET: clang-offload-bundler{{.*}} "-targets=sycl-spir64-unknown-unknown" {{.*}} "-unbundle"
 // CHECK-MULTIPLE-TARGET: llvm-spirv{{.*}} "bar"
-// CHECK-MULTIPLE-TARGET: clang-offload-bundler{{.*}} "-targets=sycl-spir64_gen-unknown-unknown" {{.*}} "-unbundle"
+// CHECK-MULTIPLE-TARGET: clang-offload-wrapper{{.*}} "-target=spir64" "-kind=sycl"
 // CHECK-MULTIPLE-TARGET: llvm-spirv{{.*}} "foo"
+// CHECK-MULTIPLE-TARGET: clang-offload-wrapper{{.*}} "-target=spir64_gen" "-kind=sycl"

--- a/clang/test/Driver/sycl-spirv-opt.cpp
+++ b/clang/test/Driver/sycl-spirv-opt.cpp
@@ -1,0 +1,18 @@
+///
+/// Tests for -Xspirv-translator
+///
+
+// RUN: %clangxx -fsycl -Xspirv-translator "foo" -### %s 2>&1 | \
+// RUN:  FileCheck %s -check-prefix CHECK-SINGLE-TARGET
+
+// RUN: %clangxx -fsycl -Xspirv-translator=spir64_gen "foo" -### %s 2>&1 | \
+// RUN:  FileCheck %s -check-prefix CHECK-SINGLE-TARGET-UNUSED --implicit-check-not 'llvm-spirv{{.*}} "foo"'
+
+// RUN: %clangxx -fsycl -fsycl-targets=spir64,spir64_gen -Xspirv-translator=spir64 "foo" -Xspirv-translator=spir64_gen "bar" -### %s 2>&1 | \
+// RUN:  FileCheck %s -check-prefix CHECK-MULTIPLE-TARGET --implicit-check-not 'llvm-spirv{{.*}} "foo" "bar"'
+// CHECK-SINGLE-TARGET: llvm-spirv{{.*}} "foo"
+
+// CHECK-SINGLE-TARGET-UNUSED: argument unused during compilation: '-Xspirv-translator=spir64_gen foo'
+
+// CHECK-MULTIPLE-TARGET: llvm-spirv{{.*}} "foo"
+// CHECK-MULTIPLE-TARGET: llvm-spirv{{.*}} "bar"


### PR DESCRIPTION
This is a hidden option and is not intended for use by end users. It has value for local testing and validation of the generated SPIR-V.

Note this is only current for forward translation. I can extend this in the future if we have a use case for reverse translation (spirv-to-ir-wrapper).