### PR TITLE
[SYCL] Fix lost data in accessor implicit conversion.

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -1107,6 +1107,11 @@ protected:
             std::is_same<TagT, mode_tag_t<AccessMode>>,
             std::is_same<TagT, mode_target_tag_t<AccessMode, AccessTarget>>> {};
 
+  template <typename DataT_, int Dimensions_, access::mode AccessMode_,
+            access::target AccessTarget_, access::placeholder IsPlaceholder_,
+            typename PropertyListT_>
+  friend class accessor;
+
 #ifdef __SYCL_DEVICE_ONLY__
 
   id<AdjustedDim> &getOffset() { return impl.Offset; }
@@ -1155,11 +1160,6 @@ protected:
   }
 
   ConcreteASPtrType getQualifiedPtr() const noexcept { return MData; }
-
-  template <typename DataT_, int Dimensions_, access::mode AccessMode_,
-            access::target AccessTarget_, access::placeholder IsPlaceholder_,
-            typename PropertyListT_>
-  friend class accessor;
 
 #ifndef __SYCL_DEVICE_ONLY__
   using AccessorBaseHost::impl;
@@ -1303,7 +1303,7 @@ public:
   accessor(const accessor<DataT_, Dimensions, AccessMode, AccessTarget,
                           IsPlaceholder, PropertyListT> &other)
 #ifdef __SYCL_DEVICE_ONLY__
-      : impl(other.impl) {
+      : impl(other.impl), MData(other.MData) {
 #else
       : accessor(other.impl) {
 #endif // __SYCL_DEVICE_ONLY__
@@ -1319,7 +1319,7 @@ public:
   accessor(const accessor<DataT_, Dimensions, AccessMode_, AccessTarget,
                           IsPlaceholder, PropertyListT> &other)
 #ifdef __SYCL_DEVICE_ONLY__
-      : impl(other.impl) {
+      : impl(other.impl), MData(other.MData) {
 #else
       : accessor(other.impl) {
 #endif // __SYCL_DEVICE_ONLY__
@@ -1996,9 +1996,9 @@ public:
                      ext::oneapi::accessor_property_list<NewPropsT...>> &Other,
       const detail::code_location CodeLoc = detail::code_location::current())
 #ifdef __SYCL_DEVICE_ONLY__
-      : impl(Other.impl)
+      : impl(Other.impl), MData(Other.MData)
 #else
-      : detail::AccessorBaseHost(Other)
+      : detail::AccessorBaseHost(Other), MAccData(Other.MAccData)
 #endif
   {
     static_assert(detail::IsCxPropertyList<PropertyListT>::value,
@@ -2009,13 +2009,17 @@ public:
 #ifndef __SYCL_DEVICE_ONLY__
     detail::constructorNotification(getMemoryObject(), impl.get(), AccessTarget,
                                     AccessMode, CodeLoc);
+    std::strcpy(padding, Other.padding, std::strlen(padding));
 #endif
   }
 
   void swap(accessor &other) {
     std::swap(impl, other.impl);
-#ifndef __SYCL_DEVICE_ONLY__
+#ifdef __SYCL_DEVICE_ONLY__
+    std::swap(MData, other.MData);
+#else
     std::swap(MAccData, other.MAccData);
+    std::swap(padding, other.padding);
 #endif
   }
 


### PR DESCRIPTION
• Fix lost data in implicit conversion from accessor<T> to accessor<const T>
• The problem was an issue in copy ctor of accessor which did not copy all class members.
• Add test

