### PR TITLE
[SYCL] Fix DeviceCodeSplit/grf.cpp when running on multiple devices

### DIFF
--- a/sycl/test-e2e/DeviceCodeSplit/grf.cpp
+++ b/sycl/test-e2e/DeviceCodeSplit/grf.cpp
@@ -13,7 +13,7 @@
 // - SYCL device binary images are compiled with the corresponding
 //   compiler option
 
-// REQUIRES: gpu-intel-pvc
+// REQUIRES: gpu && gpu-intel-pvc
 // UNSUPPORTED: cuda || hip
 // TODO/FIXME: esimd_emulator does not support online compilation that
 //             invokes 'piProgramBuild'/'piKernelCreate'


### PR DESCRIPTION
This scenario is expected to be encountered in interactive development only for now.