### PR TITLE
[SYCL] [DOC] Fix incorrect link in Get Started Guide 

### DIFF
--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -463,7 +463,7 @@ command:
 
 ### Obtain prerequisites for ahead of time (AOT) compilation
 
-[Ahead of time compilation](design/CompilerAndRuntimeDesign.md#ahead-of-time-aot-compilation)
+[Ahead of time compilation](design/CompilerAndRuntimeDesign.html#ahead-of-time-aot-compilation)
 requires ahead of time compiler available in `PATH`. There is
 AOT compiler for each device type:
 

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -690,7 +690,7 @@ clang++ -fsycl -fsycl-targets=spir64_gen,spir64_x86_64 simple-sycl-app.cpp -o si
 
 Additionally, user can pass specific options of AOT compiler to
 the DPC++ compiler using ```-Xsycl-target-backend``` option, see
-[Device code formats](design/CompilerAndRuntimeDesign.md#device-code-formats) for
+[Device code formats](design/CompilerAndRuntimeDesign.html#device-code-formats) for
 more. To find available options, execute:
 
 ```ocloc compile --help``` for GPU,

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -673,7 +673,7 @@ clang++ -fsycl -fsycl-targets=nvptx64-nvidia-cuda \
 To build simple-sycl-app ahead of time for GPU, CPU or Accelerator devices,
 specify the target architecture.  The examples provided use a supported
 alias for the target, representing a full triple.  Additional details can
-be found in the [Users Manual](UsersManual.md#generic-options).
+be found in the [Users Manual](UsersManual.html#generic-options).
 
 ```-fsycl-targets=spir64_gen``` for GPU,
 ```-fsycl-targets=spir64_x86_64``` for CPU,


### PR DESCRIPTION
link to design/CompilerAndRuntimeDesign.html#device-code-formats instead of design/CompilerAndRuntimeDesign.md#device-code-formats