### PR TITLE
[Driver][SYCL] Improve FPGA archive device unbundling with AOCO

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6747,11 +6747,6 @@ public:
         // not needed for emulation, as these are treated as regular archives.
         if (!C.getDriver().isFPGAEmulationMode())
           unbundleStaticLib(types::TY_FPGA_AOCO, LA);
-        // Do not unbundle any AOCO archive as a regular archive when we are
-        // in FPGA Hardware/Simulation mode.
-        if (!C.getDriver().isFPGAEmulationMode() &&
-            hasFPGABinary(C, LA.str(), types::TY_FPGA_AOCO))
-          continue;
         unbundleStaticLib(types::TY_Archive, LA);
       }
     }

--- a/clang/test/Driver/sycl-intelfpga-aoco-win.cpp
+++ b/clang/test/Driver/sycl-intelfpga-aoco-win.cpp
@@ -12,10 +12,10 @@
 // RUN:  %clangxx -target x86_64-pc-windows-msvc -fsycl -fno-sycl-instrument-device-code -fno-sycl-device-lib=all -fintelfpga -Xshardware %t_aoco.a %s -ccc-print-phases 2>&1 \
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCO-PHASES-WIN %s
 // CHK-FPGA-AOCO-PHASES-WIN: 0: input, "[[INPUTA:.+\.a]]", object, (host-sycl)
-// CHK-FPGA-AOCO-PHASES-WIN: 1: input, "[[INPUTSRC:.+\.cpp]]", c++, (host-sycl)
+// CHK-FPGA-AOCO-PHASES-WIN: 1: input, "[[INPUTCPP:.+\.cpp]]", c++, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 2: append-footer, {1}, c++, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 3: preprocessor, {2}, c++-cpp-output, (host-sycl)
-// CHK-FPGA-AOCO-PHASES-WIN: 4: input, "[[INPUTSRC]]", c++, (device-sycl)
+// CHK-FPGA-AOCO-PHASES-WIN: 4: input, "[[INPUTCPP]]", c++, (device-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 5: preprocessor, {4}, c++-cpp-output, (device-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 6: compiler, {5}, ir, (device-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 7: offload, "host-sycl (x86_64-pc-windows-msvc)" {3}, "device-sycl (spir64_fpga-unknown-unknown)" {6}, c++-cpp-output
@@ -25,29 +25,35 @@
 // CHK-FPGA-AOCO-PHASES-WIN: 11: linker, {0, 10}, image, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 12: linker, {0, 10}, host_dep_image, (host-sycl)
 // CHK-FPGA-AOCO-PHASES-WIN: 13: clang-offload-deps, {12}, ir, (host-sycl)
-// CHK-FPGA-AOCO-PHASES-WIN: 14: linker, {6, 13}, ir, (device-sycl)
-// CHK-FPGA-AOCO-PHASES-WIN: 15: sycl-post-link, {14}, tempfiletable, (device-sycl)
-// CHK-FPGA-AOCO-PHASES-WIN: 16: file-table-tform, {15}, tempfilelist, (device-sycl)
-// CHK-FPGA-AOCO-PHASES-WIN: 17: llvm-spirv, {16}, tempfilelist, (device-sycl)
-// CHK-FPGA-AOCO-PHASES-WIN: 18: input, "[[INPUTA]]", archive
-// CHK-FPGA-AOCO-PHASES-WIN: 19: clang-offload-unbundler, {18}, fpga_dep_list
-// CHK-FPGA-AOCO-PHASES-WIN: 20: input, "[[INPUTA]]", fpga_aoco
-// CHK-FPGA-AOCO-PHASES-WIN: 21: clang-offload-unbundler, {20}, fpga_aoco
-// CHK-FPGA-AOCO-PHASES-WIN: 22: backend-compiler, {17, 19, 21}, fpga_aocx, (device-sycl)
-// CHK-FPGA-AOCO-PHASES-WIN: 23: file-table-tform, {15, 22}, tempfiletable, (device-sycl)
-// CHK-FPGA-AOCO-PHASES-WIN: 24: clang-offload-wrapper, {23}, object, (device-sycl)
-// CHK-FPGA-AOCO-PHASES-WIN: 25: offload, "host-sycl (x86_64-pc-windows-msvc)" {11}, "device-sycl (spir64_fpga-unknown-unknown)" {24}, image
+// CHK-FPGA-AOCO-PHASES-WIN: 14: input, "[[INPUTA]]", archive
+// CHK-FPGA-AOCO-PHASES-WIN: 15: clang-offload-unbundler, {14}, tempfilelist
+// CHK-FPGA-AOCO-PHASES-WIN: 16: spirv-to-ir-wrapper, {15}, tempfilelist, (device-sycl)
+// CHK-FPGA-AOCO-PHASES-WIN: 17: linker, {6, 13, 16}, ir, (device-sycl)
+// CHK-FPGA-AOCO-PHASES-WIN: 18: sycl-post-link, {17}, tempfiletable, (device-sycl)
+// CHK-FPGA-AOCO-PHASES-WIN: 19: file-table-tform, {18}, tempfilelist, (device-sycl)
+// CHK-FPGA-AOCO-PHASES-WIN: 20: llvm-spirv, {19}, tempfilelist, (device-sycl)
+// CHK-FPGA-AOCO-PHASES-WIN: 21: input, "[[INPUTA]]", archive
+// CHK-FPGA-AOCO-PHASES-WIN: 22: clang-offload-unbundler, {21}, fpga_dep_list
+// CHK-FPGA-AOCO-PHASES-WIN: 23: input, "[[INPUTA]]", fpga_aoco
+// CHK-FPGA-AOCO-PHASES-WIN: 24: clang-offload-unbundler, {23}, fpga_aoco
+// CHK-FPGA-AOCO-PHASES-WIN: 25: backend-compiler, {20, 22, 24}, fpga_aocx, (device-sycl)
+// CHK-FPGA-AOCO-PHASES-WIN: 26: file-table-tform, {18, 25}, tempfiletable, (device-sycl)
+// CHK-FPGA-AOCO-PHASES-WIN: 27: clang-offload-wrapper, {26}, object, (device-sycl)
+// CHK-FPGA-AOCO-PHASES-WIN: 28: offload, "host-sycl (x86_64-pc-windows-msvc)" {11}, "device-sycl (spir64_fpga-unknown-unknown)" {27}, image
 
 /// aoco test, checking tools
 // RUN:  %clang_cl --target=x86_64-pc-windows-msvc -fsycl -fno-sycl-instrument-device-code -fno-sycl-device-lib=all -fintelfpga %t_aoco.a -Xshardware -### %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHK-FPGA-AOCO %s
 // RUN:  %clang_cl --target=x86_64-pc-windows-msvc -fsycl -fno-sycl-instrument-device-code -fno-sycl-device-lib=all -fintelfpga %t_aoco.a -Xshardware -### %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHK-FPGA-AOCO %s
+// CHK-FPGA-AOCO: clang-offload-bundler{{.*}} "-type=aoo" "-excluded-targets=sycl-fpga_aoco-intel-unknown" "-targets=sycl-spir64_fpga-unknown-unknown" "-input=[[INPUTLIB:.+\.a]]" "-output=[[LIBLIST:.+\.txt]]" "-unbundle"
+// CHK-FPGA-AOCO: spirv-to-ir-wrapper{{.*}} "[[LIBLIST]]" "-o" "[[LIBLIST2:.+\.txt]]"
 // CHK-FPGA-AOCO: llvm-link{{.*}} "-o" "[[LINKEDBC:.+\.bc]]"
-// CHK-FPGA-AOCO: sycl-post-link{{.*}} "-split-esimd"{{.*}} "-O2" "-spec-const=default" {{.*}} "-o" "[[SPLTABLE:.+\.table]]" "[[LINKEDBC]]"
+// CHK-FPGA-AOCO: llvm-link{{.*}} "--only-needed" "[[LINKEDBC]]" "@[[LIBLIST2]]" "-o" "[[LINKEDBC2:.+\.bc]]"
+// CHK-FPGA-AOCO: sycl-post-link{{.*}} "-split-esimd"{{.*}} "-O2" "-spec-const=default" "-device-globals" "-o" "[[SPLTABLE:.+\.table]]" "[[LINKEDBC2]]"
 // CHK-FPGA-AOCO: file-table-tform{{.*}} "-o" "[[TABLEOUT:.+\.txt]]" "[[SPLTABLE]]"
 // CHK-FPGA-AOCO: llvm-spirv{{.*}} "-o" "[[TARGSPV:.+\.txt]]" {{.*}} "[[TABLEOUT]]"
-// CHK-FPGA-AOCO: clang-offload-bundler{{.*}} "-type=aoo" "-targets=sycl-fpga_aoco-intel-unknown" "-input=[[INPUTLIB:.+\.a]]" "-output=[[AOCOLIST:.+\.txt]]" "-unbundle"
+// CHK-FPGA-AOCO: clang-offload-bundler{{.*}} "-type=aoo" "-targets=sycl-fpga_aoco-intel-unknown" "-input=[[INPUTLIB]]" "-output=[[AOCOLIST:.+\.txt]]" "-unbundle"
 // CHK-FPGA-AOCO: aoc{{.*}} "-o" "[[AOCXOUT:.+\.aocx]]" "[[TARGSPV]]" "-library-list=[[AOCOLIST]]" "-sycl"
 // CHK-FPGA-AOCO: file-table-tform{{.*}} "-o" "[[TABLEOUT2:.+\.table]]" "[[SPLTABLE]]" "[[AOCXOUT]]"
 // CHK-FPGA-AOCO: clang-offload-wrapper{{.*}} "-o=[[FINALBC:.+\.bc]]" {{.*}} "-target=spir64_fpga" "-kind=sycl" "-batch" "[[TABLEOUT2]]"

--- a/clang/test/Driver/sycl-intelfpga-aoco.cpp
+++ b/clang/test/Driver/sycl-intelfpga-aoco.cpp
@@ -29,18 +29,21 @@
 // CHK-FPGA-AOCO-PHASES: 11: linker, {0, 10}, image, (host-sycl)
 // CHK-FPGA-AOCO-PHASES: 12: linker, {0, 10}, host_dep_image, (host-sycl)
 // CHK-FPGA-AOCO-PHASES: 13: clang-offload-deps, {12}, ir, (host-sycl)
-// CHK-FPGA-AOCO-PHASES: 14: linker, {6, 13}, ir, (device-sycl)
-// CHK-FPGA-AOCO-PHASES: 15: sycl-post-link, {14}, tempfiletable, (device-sycl)
-// CHK-FPGA-AOCO-PHASES: 16: file-table-tform, {15}, tempfilelist, (device-sycl)
-// CHK-FPGA-AOCO-PHASES: 17: llvm-spirv, {16}, tempfilelist, (device-sycl)
-// CHK-FPGA-AOCO-PHASES: 18: input, "[[INPUTA]]", archive
-// CHK-FPGA-AOCO-PHASES: 19: clang-offload-unbundler, {18}, fpga_dep_list
-// CHK-FPGA-AOCO-PHASES: 20: input, "[[INPUTA]]", fpga_aoco
-// CHK-FPGA-AOCO-PHASES: 21: clang-offload-unbundler, {20}, fpga_aoco
-// CHK-FPGA-AOCO-PHASES: 22: backend-compiler, {17, 19, 21}, fpga_aocx, (device-sycl)
-// CHK-FPGA-AOCO-PHASES: 23: file-table-tform, {15, 22}, tempfiletable, (device-sycl)
-// CHK-FPGA-AOCO-PHASES: 24: clang-offload-wrapper, {23}, object, (device-sycl)
-// CHK-FPGA-AOCO-PHASES: 25: offload, "host-sycl (x86_64-unknown-linux-gnu)" {11}, "device-sycl (spir64_fpga-unknown-unknown)" {24}, image
+// CHK-FPGA-AOCO-PHASES: 14: input, "[[INPUTA]]", archive
+// CHK-FPGA-AOCO-PHASES: 15: clang-offload-unbundler, {14}, tempfilelist
+// CHK-FPGA-AOCO-PHASES: 16: spirv-to-ir-wrapper, {15}, tempfilelist, (device-sycl)
+// CHK-FPGA-AOCO-PHASES: 17: linker, {6, 13, 16}, ir, (device-sycl)
+// CHK-FPGA-AOCO-PHASES: 18: sycl-post-link, {17}, tempfiletable, (device-sycl)
+// CHK-FPGA-AOCO-PHASES: 19: file-table-tform, {18}, tempfilelist, (device-sycl)
+// CHK-FPGA-AOCO-PHASES: 20: llvm-spirv, {19}, tempfilelist, (device-sycl)
+// CHK-FPGA-AOCO-PHASES: 21: input, "[[INPUTA]]", archive
+// CHK-FPGA-AOCO-PHASES: 22: clang-offload-unbundler, {21}, fpga_dep_list
+// CHK-FPGA-AOCO-PHASES: 23: input, "[[INPUTA]]", fpga_aoco
+// CHK-FPGA-AOCO-PHASES: 24: clang-offload-unbundler, {23}, fpga_aoco
+// CHK-FPGA-AOCO-PHASES: 25: backend-compiler, {20, 22, 24}, fpga_aocx, (device-sycl)
+// CHK-FPGA-AOCO-PHASES: 26: file-table-tform, {18, 25}, tempfiletable, (device-sycl)
+// CHK-FPGA-AOCO-PHASES: 27: clang-offload-wrapper, {26}, object, (device-sycl)
+// CHK-FPGA-AOCO-PHASES: 28: offload, "host-sycl (x86_64-unknown-linux-gnu)" {11}, "device-sycl (spir64_fpga-unknown-unknown)" {27}, image
 
 /// aoco test, checking tools
 // RUN:  %clangxx -target x86_64-unknown-linux-gnu -fsycl -fno-sycl-instrument-device-code -fno-sycl-device-lib=all -fintelfpga -Xshardware -foffload-static-lib=%t_aoco.a -### %s 2>&1 \
@@ -51,11 +54,14 @@
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCO,CHK-FPGA-AOCO-WIN %s
 // RUN:  %clang_cl -fsycl -fno-sycl-instrument-device-code -fno-sycl-device-lib=all -fintelfpga -Xshardware %t_aoco_cl.a -### %s 2>&1 \
 // RUN:  | FileCheck -check-prefixes=CHK-FPGA-AOCO,CHK-FPGA-AOCO-WIN %s
+// CHK-FPGA-AOCO: clang-offload-bundler{{.*}} "-type=aoo" "-excluded-targets=sycl-fpga_aoco-intel-unknown" "-targets=sycl-spir64_fpga-unknown-unknown" "-input=[[INPUTLIB:.+\.a]]" "-output=[[LIBLIST:.+\.txt]]" "-unbundle"
+// CHK-FPGA-AOCO: spirv-to-ir-wrapper{{.*}} "[[LIBLIST]]" "-o" "[[LIBLIST2:.+\.txt]]"
 // CHK-FPGA-AOCO: llvm-link{{.*}} "-o" "[[LINKEDBC:.+\.bc]]"
-// CHK-FPGA-AOCO: sycl-post-link{{.*}} "-split-esimd"{{.*}} "-O2" "-spec-const=default" "-device-globals" "-o" "[[SPLTABLE:.+\.table]]" "[[LINKEDBC]]"
+// CHK-FPGA-AOCO: llvm-link{{.*}} "--only-needed" "[[LINKEDBC]]" "@[[LIBLIST2]]" "-o" "[[LINKEDBC2:.+\.bc]]"
+// CHK-FPGA-AOCO: sycl-post-link{{.*}} "-split-esimd"{{.*}} "-O2" "-spec-const=default" "-device-globals" "-o" "[[SPLTABLE:.+\.table]]" "[[LINKEDBC2]]"
 // CHK-FPGA-AOCO: file-table-tform{{.*}} "-o" "[[TABLEOUT:.+\.txt]]" "[[SPLTABLE]]"
 // CHK-FPGA-AOCO: llvm-spirv{{.*}} "-o" "[[TARGSPV:.+\.txt]]" {{.*}} "[[TABLEOUT]]"
-// CHK-FPGA-AOCO: clang-offload-bundler{{.*}} "-type=aoo" "-targets=sycl-fpga_aoco-intel-unknown" "-input=[[INPUTLIB:.+\.a]]" "-output=[[AOCOLIST:.+\.txt]]" "-unbundle"
+// CHK-FPGA-AOCO: clang-offload-bundler{{.*}} "-type=aoo" "-targets=sycl-fpga_aoco-intel-unknown" "-input=[[INPUTLIB]]" "-output=[[AOCOLIST:.+\.txt]]" "-unbundle"
 // CHK-FPGA-AOCO: aoc{{.*}} "-o" "[[AOCXOUT:.+\.aocx]]" "[[TARGSPV]]" "-library-list=[[AOCOLIST]]" "-sycl"
 // CHK-FPGA-AOCO: file-table-tform{{.*}} "-o" "[[TABLEOUT2:.+\.table]]" "[[SPLTABLE]]" "[[AOCXOUT]]"
 // CHK-FPGA-AOCO: clang-offload-wrapper{{.*}} "-o=[[FINALBC:.+\.bc]]" {{.*}} "-target=spir64_fpga" "-kind=sycl" "-batch" "[[TABLEOUT2]]"


### PR DESCRIPTION
AOCO specific objects can be added to an archive.  When this occurs, the archive was being completely ignored, causing issues with device compilation.  Take advantage of the additional -excluded-targets option from the clang-offload-bundler so we can process these archives for the needed device information, excluding potential unbundling of the target device in the presense of aoco binaries in that same object.