### PR TITLE
[SYCL-MLIR][LoopInternalization] Create a local barrier before the tiled loops

### DIFF
--- a/mlir/lib/Conversion/SPIRVToLLVM/SPIRVToLLVM.cpp
+++ b/mlir/lib/Conversion/SPIRVToLLVM/SPIRVToLLVM.cpp
@@ -1513,6 +1513,43 @@ public:
     return success();
   }
 };
+
+//===----------------------------------------------------------------------===//
+// ControlBarrierOp conversion
+//===----------------------------------------------------------------------===//
+
+class ControlBarrierPattern
+    : public SPIRVToLLVMConversion<spirv::ControlBarrierOp> {
+public:
+  using SPIRVToLLVMConversion<spirv::ControlBarrierOp>::SPIRVToLLVMConversion;
+  LogicalResult
+  matchAndRewrite(spirv::ControlBarrierOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto i32Ty = IntegerType::get(rewriter.getContext(), 32);
+    LLVM::LLVMFuncOp function = [&] {
+      auto *module = op->getParentWithTrait<OpTrait::SymbolTable>();
+      StringRef functionName = "_Z22__spirv_ControlBarrierjjj";
+      if (auto *function = SymbolTable::lookupSymbolIn(module, functionName))
+        return cast<LLVM::LLVMFuncOp>(function);
+      auto voidTy = LLVM::LLVMVoidType::get(rewriter.getContext());
+      return OpBuilder::atBlockBegin(&module->getRegion(0).front())
+          .create<LLVM::LLVMFuncOp>(
+              loc, functionName,
+              LLVM::LLVMFunctionType::get(voidTy, {i32Ty, i32Ty, i32Ty}));
+    }();
+    auto executionScope = rewriter.create<LLVM::ConstantOp>(
+        loc, i32Ty, static_cast<uint32_t>(op.getExecutionScope()));
+    auto memoryScope = rewriter.create<LLVM::ConstantOp>(
+        loc, i32Ty, static_cast<uint32_t>(op.getMemoryScope()));
+    auto memorySemantics = rewriter.create<LLVM::ConstantOp>(
+        loc, i32Ty, static_cast<uint32_t>(op.getMemorySemantics()));
+    SmallVector<Value> arguments = {executionScope, memoryScope,
+                                    memorySemantics};
+    rewriter.replaceOpWithNewOp<LLVM::CallOp>(op, function, arguments);
+    return success();
+  }
+};
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -1639,7 +1676,7 @@ void mlir::populateSPIRVToLLVMConversionPatterns(
       CompositeExtractPattern, CompositeInsertPattern,
       DirectConversionPattern<spirv::SelectOp, LLVM::SelectOp>,
       DirectConversionPattern<spirv::UndefOp, LLVM::UndefOp>,
-      VectorShufflePattern,
+      VectorShufflePattern, ControlBarrierPattern,
 
       // Shift ops
       ShiftPattern<spirv::ShiftRightArithmeticOp, LLVM::AShrOp>,

--- a/mlir/test/Conversion/SPIRVToLLVM/barrier-op-to-llvm.mlir
+++ b/mlir/test/Conversion/SPIRVToLLVM/barrier-op-to-llvm.mlir
@@ -4,9 +4,37 @@
 // spirv.ControlBarrier
 //===----------------------------------------------------------------------===//
 
+// COM: enum class Scope : uint32_t {
+// COM:   CrossDevice = 0,
+// COM:   Device = 1,
+// COM:   Workgroup = 2,
+// COM:   Subgroup = 3,
+// COM:   Invocation = 4,
+// COM:   QueueFamily = 5,
+// COM:   ShaderCallKHR = 6,
+// COM: };
+// COM: enum class MemorySemantics : uint32_t {
+// COM:   None = 0,
+// COM:   Acquire = 2,
+// COM:   Release = 4,
+// COM:   AcquireRelease = 8,
+// COM:   SequentiallyConsistent = 16,
+// COM:   UniformMemory = 64,
+// COM:   SubgroupMemory = 128,
+// COM:   WorkgroupMemory = 256,
+// COM:   CrossWorkgroupMemory = 512,
+// COM:   AtomicCounterMemory = 1024,
+// COM:   ImageMemory = 2048,
+// COM:   OutputMemory = 4096,
+// COM:   MakeAvailable = 8192,
+// COM:   MakeVisible = 16384,
+// COM:   Volatile = 32768,
+// COM: };
+
 // CHECK: llvm.func @_Z22__spirv_ControlBarrierjjj(i32, i32, i32)
 // CHECK-LABEL: @control_barrier
 spirv.func @control_barrier() "None" {
+  // COM: The constants below represent their corresponding scope or memory semantic.
   // CHECK-NEXT: %0 = llvm.mlir.constant(2 : i32) : i32
   // CHECK-NEXT: %1 = llvm.mlir.constant(2 : i32) : i32
   // CHECK-NEXT: %2 = llvm.mlir.constant(272 : i32) : i32

--- a/mlir/test/Conversion/SPIRVToLLVM/barrier-op-to-llvm.mlir
+++ b/mlir/test/Conversion/SPIRVToLLVM/barrier-op-to-llvm.mlir
@@ -1,0 +1,16 @@
+// RUN: mlir-opt -convert-spirv-to-llvm='use-opaque-pointers=1' %s | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// spirv.ControlBarrier
+//===----------------------------------------------------------------------===//
+
+// CHECK: llvm.func @_Z22__spirv_ControlBarrierjjj(i32, i32, i32)
+// CHECK-LABEL: @control_barrier
+spirv.func @control_barrier() "None" {
+  // CHECK-NEXT: %0 = llvm.mlir.constant(2 : i32) : i32
+  // CHECK-NEXT: %1 = llvm.mlir.constant(2 : i32) : i32
+  // CHECK-NEXT: %2 = llvm.mlir.constant(272 : i32) : i32
+  // CHECK-NEXT: llvm.call @_Z22__spirv_ControlBarrierjjj(%0, %1, %2) : (i32, i32, i32) -> ()
+  spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
+  spirv.Return
+}

--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
@@ -131,7 +131,7 @@ def LoopInternalization : Pass<"loop-internalization"> {
     memory by leveraging the loop tiling infrastructure.
   }];
   let constructor = "mlir::polygeist::createLoopInternalizationPass()";
-  let dependentDialects = ["affine::AffineDialect", "scf::SCFDialect"];
+  let dependentDialects = ["affine::AffineDialect", "scf::SCFDialect", "spirv::SPIRVDialect"];
 }
 
 def SCFBarrierRemovalContinuation : InterfacePass<"barrier-removal-continuation", "FunctionOpInterface"> {

--- a/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
@@ -40,6 +40,7 @@ add_mlir_dialect_library(MLIRPolygeistTransforms
   MLIRPolygeistDialect
   MLIRPolygeistUtils
   MLIRSCFUtils
+  MLIRSPIRVDialect
   MLIRSYCLAnalysis  
   MLIRSYCLDialect
   MLIRSideEffectInterfaces

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
@@ -143,6 +143,8 @@ void transform(T loop) {
   OpBuilder builder(loop);
   builder.setInsertionPointToStart(tiledNest.front()->getBlock());
   createLocalBarrier(builder);
+  builder.setInsertionPointAfter(tiledNest.front());
+  createLocalBarrier(builder);
 }
 
 void transform(LoopLikeOpInterface loop) {

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
@@ -13,7 +13,6 @@
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/LoopUtils.h"
-#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Polygeist/Transforms/Passes.h"
 #include "mlir/Dialect/SCF/Utils/Utils.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
@@ -108,14 +107,14 @@ LogicalResult tile(MutableArrayRef<affine::AffineForOp> nestedLoops,
       newNestedLoops.begin() + numLoops, newNestedLoops.end());
   return res;
 }
-LogicalResult tile(SmallVectorImpl<scf::ForOp> &nestedLoops,
-                   ArrayRef<Value> tileSizes,
+LogicalResult tile(ArrayRef<scf::ForOp> nestedLoops, ArrayRef<Value> tileSizes,
                    SmallVectorImpl<scf::ForOp> &tiledNest) {
   tiledNest = tile(nestedLoops, tileSizes, nestedLoops.back());
   return success();
 }
 
 void createLocalBarrier(OpBuilder builder) {
+  // TODO: Use gpu.barrier, require GPUToSPIRV conversion in the pipeline.
   builder.create<spirv::ControlBarrierOp>(
       builder.getUnknownLoc(), spirv::Scope::Workgroup, spirv::Scope::Workgroup,
       spirv::MemorySemantics::SequentiallyConsistent |

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
@@ -13,6 +13,7 @@
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/LoopUtils.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Polygeist/Transforms/Passes.h"
 #include "mlir/Dialect/SCF/Utils/Utils.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
@@ -72,6 +73,8 @@ bool isCandidate(LoopLikeOpInterface loop) {
     LLVM_DEBUG(llvm::dbgs() << "not candidate: not affine or scf for loop\n");
     return false;
   }
+
+  // TODO: check uniformity.
 
   return true;
 }

--- a/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
+++ b/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
@@ -8,6 +8,7 @@
 // SIZE1-NEXT:    [[TILESIZE:%.*]] = arith.constant 1 : index
 // SIZE2-NEXT:    [[TILESIZE:%.*]] = arith.constant 2 : index
 // CHECK-NEXT:    affine.for %arg0 = 0 to [[MAP1]]()[[[TILESIZE]]] {
+// CHECK-NEXT:      spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
 // CHECK-NEXT:      affine.for %arg1 = [[MAP2]](%arg0)[[[TILESIZE]]] to min [[MAP3]](%arg0)[[[TILESIZE]]] {
 // CHECK-NEXT:        "test.foo"(%arg1) : (index) -> ()
 // CHECK-NEXT:      }
@@ -35,6 +36,7 @@ func.func @affine_1d() {
 // SIZE2-NEXT:    %c1 = arith.constant 1 : index
 // CHECK-NEXT:    affine.for %arg0 = 0 to [[MAP1]]()[[[TILESIZE]]] {
 // CHECK-NEXT:      affine.for %arg1 = 1 to [[MAP2]]()[%c1] {
+// CHECK-NEXT:        spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
 // CHECK-NEXT:        affine.for %arg2 = [[MAP3]](%arg0)[[[TILESIZE]]] to min [[MAP4]](%arg0)[[[TILESIZE]]] {
 // CHECK-NEXT:          affine.for %arg3 = [[MAP5]](%arg1)[%c1] to min [[MAP6]](%arg1)[%c1] {
 // CHECK-NEXT:            "test.foo"(%arg2, %arg3) : (index, index) -> ()
@@ -63,6 +65,7 @@ func.func @affine_2d() {
 // SIZE2-DAG:     [[TILESIZE:%.*]] = arith.constant 2 : index
 // CHECK-NEXT:    %0 = arith.muli %c1, [[TILESIZE]] : index
 // CHECK-NEXT:    scf.for %arg1 = %c0 to %c256 step %0 {
+// CHECK-NEXT:      spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
 // CHECK-NEXT:      %1 = arith.addi %arg1, %0 : index
 // CHECK-NEXT:      %2 = arith.cmpi slt, %c256, %1 : index
 // CHECK-NEXT:      %3 = arith.select %2, %c256, %1 : index
@@ -96,6 +99,7 @@ func.func @scf_1d(%arg0: memref<?x?xf32>) {
 // CHECK-NEXT:    scf.for %arg1 = %c0 to %c256 step %0 {
 // CHECK-NEXT:      %1 = arith.muli %c1, %c1_0 : index
 // CHECK-NEXT:      scf.for %arg2 = %c1 to %c512 step %1 {
+// CHECK-NEXT:        spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
 // CHECK-NEXT:        %2 = arith.addi %arg1, %0 : index
 // CHECK-NEXT:        %3 = arith.cmpi slt, %c256, %2 : index
 // CHECK-NEXT:        %4 = arith.select %3, %c256, %2 : index

--- a/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
+++ b/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
@@ -66,10 +66,10 @@ func.func @affine_2d() {
 // CHECK-NEXT:    %0 = arith.muli %c1, [[TILESIZE]] : index
 // CHECK-NEXT:    scf.for %arg1 = %c0 to %c256 step %0 {
 // CHECK-NEXT:      spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
-// CHECK-NEXT:      %1 = arith.addi %arg1, %0 : index
-// CHECK-NEXT:      %2 = arith.cmpi slt, %c256, %1 : index
-// CHECK-NEXT:      %3 = arith.select %2, %c256, %1 : index
-// CHECK-NEXT:      scf.for %arg2 = %arg1 to %3 step %c1 {
+// CHECK-NEXT:      [[VAL_1:%.*]] = arith.addi %arg1, %0 : index
+// CHECK-NEXT:      [[VAL_2:%.*]] = arith.cmpi slt, %c256, [[VAL_1]] : index
+// CHECK-NEXT:      [[VAL_3:%.*]] = arith.select [[VAL_2]], %c256, [[VAL_1]] : index
+// CHECK-NEXT:      scf.for %arg2 = %arg1 to [[VAL_3]] step %c1 {
 // CHECK-NEXT:        "test.foo"(%arg2) : (index) -> ()
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
@@ -100,14 +100,14 @@ func.func @scf_1d(%arg0: memref<?x?xf32>) {
 // CHECK-NEXT:      %1 = arith.muli %c1, %c1_0 : index
 // CHECK-NEXT:      scf.for %arg2 = %c1 to %c512 step %1 {
 // CHECK-NEXT:        spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
-// CHECK-NEXT:        %2 = arith.addi %arg1, %0 : index
-// CHECK-NEXT:        %3 = arith.cmpi slt, %c256, %2 : index
-// CHECK-NEXT:        %4 = arith.select %3, %c256, %2 : index
-// CHECK-NEXT:        scf.for %arg3 = %arg1 to %4 step %c1 {
-// CHECK-NEXT:          %5 = arith.addi %arg2, %1 : index
-// CHECK-NEXT:          %6 = arith.cmpi slt, %c512, %5 : index
-// CHECK-NEXT:          %7 = arith.select %6, %c512, %5 : index
-// CHECK-NEXT:          scf.for %arg4 = %arg2 to %7 step %c1 {
+// CHECK-NEXT:        [[VAL_2:%.*]] = arith.addi %arg1, %0 : index
+// CHECK-NEXT:        [[VAL_3:%.*]] = arith.cmpi slt, %c256, [[VAL_2]] : index
+// CHECK-NEXT:        [[VAL_4:%.*]] = arith.select [[VAL_3]], %c256, [[VAL_2]] : index
+// CHECK-NEXT:        scf.for %arg3 = %arg1 to [[VAL_4]] step %c1 {
+// CHECK-NEXT:          [[VAL_5:%.*]] = arith.addi %arg2, %1 : index
+// CHECK-NEXT:          [[VAL_6:%.*]] = arith.cmpi slt, %c512, [[VAL_5]] : index
+// CHECK-NEXT:          [[VAL_7:%.*]] = arith.select [[VAL_6]], %c512, [[VAL_5]] : index
+// CHECK-NEXT:          scf.for %arg4 = %arg2 to [[VAL_7]] step %c1 {
 // CHECK-NEXT:            "test.foo"(%arg3, %arg4) : (index, index) -> ()
 // CHECK-NEXT:          }
 // CHECK-NEXT:        }

--- a/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
+++ b/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
@@ -12,6 +12,7 @@
 // CHECK-NEXT:      affine.for %arg1 = [[MAP2]](%arg0)[[[TILESIZE]]] to min [[MAP3]](%arg0)[[[TILESIZE]]] {
 // CHECK-NEXT:        "test.foo"(%arg1) : (index) -> ()
 // CHECK-NEXT:      }
+// CHECK-NEXT:      spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
@@ -42,6 +43,7 @@ func.func @affine_1d() {
 // CHECK-NEXT:            "test.foo"(%arg2, %arg3) : (index, index) -> ()
 // CHECK-NEXT:          }
 // CHECK-NEXT:        }
+// CHECK-NEXT:        spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:    return
@@ -72,6 +74,7 @@ func.func @affine_2d() {
 // CHECK-NEXT:      scf.for %arg2 = %arg1 to [[VAL_3]] step %c1 {
 // CHECK-NEXT:        "test.foo"(%arg2) : (index) -> ()
 // CHECK-NEXT:      }
+// CHECK-NEXT:      spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
 // CHECK-NEXT:    }
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
@@ -111,6 +114,7 @@ func.func @scf_1d(%arg0: memref<?x?xf32>) {
 // CHECK-NEXT:            "test.foo"(%arg3, %arg4) : (index, index) -> ()
 // CHECK-NEXT:          }
 // CHECK-NEXT:        }
+// CHECK-NEXT:        spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:    return


### PR DESCRIPTION
This PR only adds a local barrier before the tiled loops, as a preparation for promoting loop memory accesses to shared local memory.