### PR TITLE
[SYCL] Fix detection of opaque pointer aspect usage

### DIFF
--- a/llvm/lib/SYCLLowerIR/SYCLPropagateAspectsUsage.cpp
+++ b/llvm/lib/SYCLLowerIR/SYCLPropagateAspectsUsage.cpp
@@ -245,6 +245,16 @@ AspectsSetTy getAspectsUsedByInstruction(const Instruction &I,
     Result.insert(Aspects.begin(), Aspects.end());
   }
 
+  // Opaque pointer arguments may hide types of pointer arguments until elements
+  // inside the types are accessed through a GEP instruction. However, this will
+  // not be caught by the operands check above, so we must extract the
+  // information directly from the GEP.
+  if (auto *GEPI = dyn_cast<const GetElementPtrInst>(&I)) {
+    const AspectsSetTy &Aspects =
+        getAspectsFromType(GEPI->getSourceElementType(), Types);
+    Result.insert(Aspects.begin(), Aspects.end());
+  }
+
   return Result;
 }
 

--- a/llvm/test/SYCLLowerIR/PropagateAspectsUsage/gep-prop.ll
+++ b/llvm/test/SYCLLowerIR/PropagateAspectsUsage/gep-prop.ll
@@ -1,0 +1,42 @@
+; RUN: opt -passes=sycl-propagate-aspects-usage < %s -S | FileCheck %s
+;
+; Test checks that the pass is able to propagate information about used aspects
+; from getelementptr accesses to types that uses aspects.
+
+%struct.StructWithAspect = type { i32 }
+
+; CHECK: spir_kernel void @Kernel() !sycl_used_aspects ![[MDID:[0-9]+]]
+define spir_kernel void @Kernel() {
+entry:
+  call spir_func void @ImmFunc()
+  ret void
+}
+
+; CHECK: spir_func void @ImmFunc() !sycl_used_aspects ![[MDID]]
+define spir_func void @ImmFunc() {
+entry:
+  %s = alloca %struct.StructWithAspect, align 4
+  %s.ascast = addrspacecast ptr %s to ptr addrspace(4)
+  call spir_func void @StructWithAspectCtor(ptr addrspace(4) noundef align 4 dereferenceable_or_null(4) %s.ascast)
+  ret void
+}
+
+; CHECK: spir_func void @StructWithAspectCtor(ptr addrspace(4) noundef align 4 dereferenceable_or_null(4) %this) !sycl_used_aspects ![[MDID]]
+define spir_func void @StructWithAspectCtor(ptr addrspace(4) noundef align 4 dereferenceable_or_null(4) %this) {
+entry:
+  %this.addr = alloca ptr addrspace(4), align 8
+  %this.addr.ascast = addrspacecast ptr %this.addr to ptr addrspace(4)
+  store ptr addrspace(4) %this, ptr addrspace(4) %this.addr.ascast, align 8
+  %this1 = load ptr addrspace(4), ptr addrspace(4) %this.addr.ascast, align 8
+  %a = getelementptr inbounds %struct.StructWithAspect, ptr addrspace(4) %this1, i32 0, i32 0
+  store i32 0, ptr addrspace(4) %a, align 4
+  ret void
+}
+
+!sycl_types_that_use_aspects = !{!1}
+!sycl_aspects = !{!2}
+
+!1 = !{!"struct.StructWithAspect", i32 5}
+!2 = !{!"fp64", i32 6}
+
+; CHECK: ![[MDID]] = !{i32 5}

--- a/sycl/test/extensions/properties/properties_kernel_device_has_warning.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_device_has_warning.cpp
@@ -1,4 +1,5 @@
 // RUN: %clangxx -fsycl-device-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
+// RUN: %clangxx -fsycl-device-only -Xclang -opaque-pointers -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
 
 // Tests for warnings when propagated aspects do not match the aspects available
 // in a function, as specified through the 'sycl::device_has' property.

--- a/sycl/test/extensions/properties/properties_kernel_device_has_warning.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_device_has_warning.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl-device-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
+// RUN: %clangxx -fsycl-device-only -Xclang -no-opaque-pointers -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
 // RUN: %clangxx -fsycl-device-only -Xclang -opaque-pointers -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
 
 // Tests for warnings when propagated aspects do not match the aspects available

--- a/sycl/test/warnings/aspect_perserve_srcloc.cpp
+++ b/sycl/test/warnings/aspect_perserve_srcloc.cpp
@@ -1,4 +1,5 @@
 // RUN: %clangxx -fsycl-device-only -fsycl-early-optimizations -Xclang -verify %s
+// RUN: %clangxx -fsycl-device-only -fsycl-early-optimizations -Xclang -opaque-pointers -Xclang -verify %s
 
 // Tests for the preservation of source location information when warning
 // diagnostics are issued due to mismatches in aspects used and those specified

--- a/sycl/test/warnings/aspect_perserve_srcloc.cpp
+++ b/sycl/test/warnings/aspect_perserve_srcloc.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl-device-only -fsycl-early-optimizations -Xclang -verify %s
+// RUN: %clangxx -fsycl-device-only -fsycl-early-optimizations -Xclang -no-opaque-pointers -Xclang -verify %s
 // RUN: %clangxx -fsycl-device-only -fsycl-early-optimizations -Xclang -opaque-pointers -Xclang -verify %s
 
 // Tests for the preservation of source location information when warning


### PR DESCRIPTION
When opaque pointers are enabled, the aspect propagation pass may not currently detect the use of types in calls to functions where the type is passed as an opaque pointer. In these cases, the type can usually be detected through the source type in GEP instructions inside the corresponding functions. A common example of this is the constructors for classes marked as using aspects.

This commit fixes the detection of usage inside functions using opaque pointer arguments by extracting information about the source type from GEP instructions inside the functions.