### PR TITLE
[SYCL][CI] Skip some checks depending on what files have changed

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -64,6 +64,30 @@ on:
         type: string
         required: false
         default: 'SYCL-2020'
+      check_llvm:
+        type: string
+        required: false
+        default: 'true'
+      check_clang:
+        type: string
+        required: false
+        default: 'true'
+      check_sycl:
+        type: string
+        required: false
+        default: 'true'
+      check_llvm_spirv:
+        type: string
+        required: false
+        default: 'true'
+      check_xptifw:
+        type: string
+        required: false
+        default: 'true'
+      check_libclc:
+        type: string
+        required: false
+        default: 'true'
 
 jobs:
   build:
@@ -110,30 +134,30 @@ jobs:
       run: cmake --build $GITHUB_WORKSPACE/build
     # TODO allow to optionally disable in-tree checks
     - name: check-llvm
-      if: ${{ always() && !cancelled() && steps.build.outcome == 'success' }}
+      if: ${{ always() && !cancelled() && steps.build.outcome == 'success' && inputs.check_llvm == 'true' }}
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target check-llvm
     - name: check-clang
-      if: ${{ always() && !cancelled() && steps.build.outcome == 'success' }}
+      if: ${{ always() && !cancelled() && steps.build.outcome == 'success' && inputs.check_clang == 'true' }}
       run: |
         export XDG_CACHE_HOME=$GITHUB_WORKSPACE/os_cache
         cmake --build $GITHUB_WORKSPACE/build --target check-clang
     - name: check-sycl
-      if: ${{ always() && !cancelled() && steps.build.outcome == 'success' }}
+      if: ${{ always() && !cancelled() && steps.build.outcome == 'success' && inputs.check_sycl == 'true' }}
       run: |
         # TODO consider moving this to Dockerfile
         export LD_LIBRARY_PATH=/usr/local/cuda/compat/:/usr/local/cuda/lib64:$LD_LIBRARY_PATH
         cmake --build $GITHUB_WORKSPACE/build --target check-sycl
     - name: check-llvm-spirv
-      if: ${{ always() && !cancelled() && steps.build.outcome == 'success' }}
+      if: ${{ always() && !cancelled() && steps.build.outcome == 'success' && inputs.check_llvm_spirv == 'true' }}
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target check-llvm-spirv
     - name: check-xptifw
-      if: ${{ always() && !cancelled() && steps.build.outcome == 'success' }}
+      if: ${{ always() && !cancelled() && steps.build.outcome == 'success' && inputs.check_xptifw == 'true' }}
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target check-xptifw
     - name: check-libclc
-      if: ${{ always() && !cancelled() && steps.build.outcome == 'success' }}
+      if: ${{ always() && !cancelled() && steps.build.outcome == 'success' && inputs.check_libclc == 'true' }}
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target check-libclc
     - name: Install
@@ -232,7 +256,7 @@ jobs:
 
   khronos_sycl_cts:
     needs: build
-    if: ${{ inputs.cts_matrix != '[]' }}
+    if: ${{ inputs.cts_matrix != '[]' && inputs.check_sycl == 'true' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -27,6 +27,49 @@ permissions:
   contents: read
 
 jobs:
+  need_check:
+    name: Decide which tests could be affected by the changes
+    runs-on: ubuntu-22.04
+    timeout-minutes: 3
+    outputs:
+      llvm: ${{ steps.changes.outputs.llvm == 'true' }}
+      llvm_spirv: ${{ steps.changes.outputs.llvm_spirv == 'true' }}
+      clang: ${{ steps.changes.outputs.clang == 'true' }}
+      xptifw: ${{ steps.changes.outputs.xptifw == 'true' }}
+      libclc: ${{ steps.changes.outputs.libclc == 'true' }}
+      sycl: ${{ steps.changes.outputs.sycl == 'true' }}
+    steps:
+      - name: Check file changes
+        uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50
+        id: changes
+        with:
+          filters: |
+            llvm: &llvm
+              - 'llvm/**'
+            llvm_spirv: &llvm_spirv
+              - *llvm
+              - 'llvm-spirv/**'
+            clang: &clang
+              - *llvm
+              - 'clang/**'
+            sycl_fusion: &sycl-fusion
+              - *llvm
+              - 'sycl-fusion/**'
+            xptifw: &xptifw
+              - 'xptifw/**'
+            libclc: &libclc
+              - *llvm_spirv
+              - *clang
+              - 'libclc/**'
+            sycl:
+              - *clang
+              - *sycl-fusion
+              - *llvm_spirv
+              - *xptifw
+              - *libclc
+              - 'sycl/*'
+              - 'sycl/!(test-e2e)/**'
+
   lint:
     runs-on: ubuntu-22.04
     container:
@@ -54,7 +97,7 @@ jobs:
     name: Linux
     # Only build and test patches, that have passed all linter checks, because
     # the next commit is likely to be a follow-up on that job.
-    needs: [lint, test_matrix]
+    needs: [lint, test_matrix, need_check]
     if: always() && (success() || contains(github.event.pull_request.labels.*.name, 'ignore-lint'))
     uses: ./.github/workflows/sycl_linux_build_and_test.yml
     secrets: inherit
@@ -66,6 +109,12 @@ jobs:
       build_cache_suffix: "default"
       lts_matrix: ${{ needs.test_matrix.outputs.lts_lx_matrix }}
       lts_aws_matrix: ${{ needs.test_matrix.outputs.lts_aws_matrix }}
+      check_llvm: ${{ needs.need_check.outputs.llvm }}
+      check_llvm_spirv: ${{ needs.need_check.outputs.llvm_spirv }}
+      check_clang: ${{ needs.need_check.outputs.clang }}
+      check_xptifw: ${{ needs.need_check.outputs.xptifw }}
+      check_libclc: ${{ needs.need_check.outputs.libclc }}
+      check_sycl: ${{ needs.need_check.outputs.sycl }}
 
   windows_default:
     name: Windows


### PR DESCRIPTION
I'm using https://github.com/dorny/paths-filter to implement it.

I decided to call it from `sycl_precommit.yml` so that we can potentially re-use its results between Linux/Windows tasks but that might have its own drawbacks. I don't see a possibility to just pass the result of the job between workflows (`sycl_precommit` -> `sycl_linux_build_and_test`) which means that for every value I have to thread it carefully via latter's inputs. That might complicate things in future if we'd want to run just the modified end-to-end tests instead of all of them. 

Another approach would be to run the job inside `sycl_linux_build_and_test` so that I'd have immediate access to its output from anywhere in the workflow.