### PR TITLE
[SYCL-MLIR] Add intrinsics to LLVM dialect

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
@@ -130,6 +130,18 @@ def LLVM_PowIOp : LLVM_OneResultIntrOp<"powi", [], [0,1],
   let assemblyFormat = "`(` operands `)` custom<LLVMOpAttrs>(attr-dict) `:` "
       "functional-type(operands, results)";
 }
+def LLVM_Rint : LLVM_UnaryIntrOpF<"rint">;
+def LLVM_Nearbyint : LLVM_UnaryIntrOpF<"nearbyint">;
+class LLVM_IntRoundIntrOpBase<string func> :
+        LLVM_OneResultIntrOp<func, [0], [0], [Pure]> {
+  let arguments = (ins LLVM_AnyFloat:$val);
+  let assemblyFormat = "`(` operands `)` custom<LLVMOpAttrs>(attr-dict) `:` "
+      "functional-type(operands, results)";
+}
+def LLVM_Lround : LLVM_IntRoundIntrOpBase<"lround">;
+def LLVM_Llround : LLVM_IntRoundIntrOpBase<"llround">;
+def LLVM_Lrint : LLVM_IntRoundIntrOpBase<"lrint">;
+def LLVM_Llrint : LLVM_IntRoundIntrOpBase<"llrint">;
 def LLVM_BitReverseOp : LLVM_UnaryIntrOpI<"bitreverse">;
 def LLVM_ByteSwapOp : LLVM_UnaryIntrOpI<"bswap">;
 def LLVM_CountLeadingZerosOp : LLVM_CountZerosIntrOp<"ctlz">;
@@ -207,6 +219,15 @@ def LLVM_NoAliasScopeDeclOp
       $_location, (*scopeAttrs)[0]);
   }];
   let assemblyFormat = "$scope attr-dict";
+}
+
+//
+// General intrinsics
+//
+
+def LLVM_ThreadlocalAddress : LLVM_OneResultIntrOp<"threadlocal.address", [],
+                                [0], [Pure]> {
+  let arguments = (ins LLVM_AnyPointer:$global);
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
@@ -130,18 +130,18 @@ def LLVM_PowIOp : LLVM_OneResultIntrOp<"powi", [], [0,1],
   let assemblyFormat = "`(` operands `)` custom<LLVMOpAttrs>(attr-dict) `:` "
       "functional-type(operands, results)";
 }
-def LLVM_Rint : LLVM_UnaryIntrOpF<"rint">;
-def LLVM_Nearbyint : LLVM_UnaryIntrOpF<"nearbyint">;
+def LLVM_RintOp : LLVM_UnaryIntrOpF<"rint">;
+def LLVM_NearbyintOp : LLVM_UnaryIntrOpF<"nearbyint">;
 class LLVM_IntRoundIntrOpBase<string func> :
         LLVM_OneResultIntrOp<func, [0], [0], [Pure]> {
   let arguments = (ins LLVM_AnyFloat:$val);
   let assemblyFormat = "`(` operands `)` custom<LLVMOpAttrs>(attr-dict) `:` "
       "functional-type(operands, results)";
 }
-def LLVM_Lround : LLVM_IntRoundIntrOpBase<"lround">;
-def LLVM_Llround : LLVM_IntRoundIntrOpBase<"llround">;
-def LLVM_Lrint : LLVM_IntRoundIntrOpBase<"lrint">;
-def LLVM_Llrint : LLVM_IntRoundIntrOpBase<"llrint">;
+def LLVM_LroundOp : LLVM_IntRoundIntrOpBase<"lround">;
+def LLVM_LlroundOp : LLVM_IntRoundIntrOpBase<"llround">;
+def LLVM_LrintOp : LLVM_IntRoundIntrOpBase<"lrint">;
+def LLVM_LlrintOp : LLVM_IntRoundIntrOpBase<"llrint">;
 def LLVM_BitReverseOp : LLVM_UnaryIntrOpI<"bitreverse">;
 def LLVM_ByteSwapOp : LLVM_UnaryIntrOpI<"bswap">;
 def LLVM_CountLeadingZerosOp : LLVM_CountZerosIntrOp<"ctlz">;
@@ -219,15 +219,6 @@ def LLVM_NoAliasScopeDeclOp
       $_location, (*scopeAttrs)[0]);
   }];
   let assemblyFormat = "$scope attr-dict";
-}
-
-//
-// General intrinsics
-//
-
-def LLVM_ThreadlocalAddress : LLVM_OneResultIntrOp<"threadlocal.address", [],
-                                [0], [Pure]> {
-  let arguments = (ins LLVM_AnyPointer:$global);
 }
 
 //===----------------------------------------------------------------------===//
@@ -331,6 +322,11 @@ def LLVM_ExpectWithProbabilityOp
       $_location, $val, $expected, $_float_attr($prob));
   }];
   let assemblyFormat = "$val `,` $expected `,` $prob attr-dict `:` type($val)";
+}
+
+def LLVM_ThreadlocalAddressOp : LLVM_OneResultIntrOp<"threadlocal.address", [],
+                                [0], [Pure]> {
+  let arguments = (ins LLVM_AnyPointer:$global);
 }
 
 //

--- a/mlir/test/Target/LLVMIR/Import/intrinsic.ll
+++ b/mlir/test/Target/LLVMIR/Import/intrinsic.ll
@@ -129,6 +129,7 @@ define void @rint_test(float %0, double %1, <8 x float> %2, <8 x double> %3) {
   %8 = call <8 x double> @llvm.rint.v8f64(<8 x double> %3)
   ret void
 }
+; CHECK-LABEL: llvm.func @nearbyint_test
 define void @nearbyint_test(float %0, double %1, <8 x float> %2, <8 x double> %3) {
   ; CHECK: llvm.intr.nearbyint(%{{.*}}) : (f32) -> f32
   %5 = call float @llvm.nearbyint.f32(float %0)
@@ -457,13 +458,6 @@ define void @memset_test(i32 %0, ptr %1, i8 %2) {
   ret void
 }
 
-; CHECK-LABEL: llvm.func @threadlocal_test
-define void @threadlocal_test(ptr %0) {
-  ; CHECK: "llvm.intr.threadlocal.address"(%{{.*}}) : (!llvm.ptr) -> !llvm.ptr
-  %local = call ptr @llvm.threadlocal.address.p0(ptr %0)
-  ret void
-}
-
 ; CHECK-LABEL:  llvm.func @sadd_with_overflow_test
 define void @sadd_with_overflow_test(i32 %0, i32 %1, <8 x i32> %2, <8 x i32> %3) {
   ; CHECK: "llvm.intr.sadd.with.overflow"(%{{.*}}, %{{.*}}) : (i32, i32) -> !llvm.struct<(i32, i1)>
@@ -614,6 +608,13 @@ define void @expect_with_probability(i16 %0) {
   ; CHECK:  %[[EXP:.+]] = llvm.mlir.constant(42 : i16) : i16
   ; CHECK:  llvm.intr.expect.with.probability %[[VAL]], %[[EXP]], 5.000000e-01 : i16
   %2 = call i16 @llvm.expect.with.probability.i16(i16 %0, i16 42, double 0.5)
+  ret void
+}
+
+; CHECK-LABEL: llvm.func @threadlocal_test
+define void @threadlocal_test(ptr %0) {
+  ; CHECK: "llvm.intr.threadlocal.address"(%{{.*}}) : (!llvm.ptr) -> !llvm.ptr
+  %local = call ptr @llvm.threadlocal.address.p0(ptr %0)
   ret void
 }
 
@@ -932,7 +933,6 @@ declare void @llvm.memcpy.p0.p0.i32(ptr noalias nocapture writeonly, ptr noalias
 declare void @llvm.memcpy.inline.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64 immarg, i1 immarg)
 declare void @llvm.memmove.p0.p0.i32(ptr nocapture writeonly, ptr nocapture readonly, i32, i1 immarg)
 declare void @llvm.memset.p0.i32(ptr nocapture writeonly, i8, i32, i1 immarg)
-declare nonnull ptr @llvm.threadlocal.address.p0(ptr nonnull)
 declare { i32, i1 } @llvm.sadd.with.overflow.i32(i32, i32)
 declare { <8 x i32>, <8 x i1> } @llvm.sadd.with.overflow.v8i32(<8 x i32>, <8 x i32>)
 declare { i32, i1 } @llvm.uadd.with.overflow.i32(i32, i32)
@@ -960,6 +960,7 @@ declare <8 x i32> @llvm.ushl.sat.v8i32(<8 x i32>, <8 x i32>)
 declare i1 @llvm.is.constant.i32(i32)
 declare i32 @llvm.expect.i32(i32, i32)
 declare i16 @llvm.expect.with.probability.i16(i16, i16, double immarg)
+declare nonnull ptr @llvm.threadlocal.address.p0(ptr nonnull)
 declare token @llvm.coro.id(i32, ptr readnone, ptr nocapture readonly, ptr)
 declare ptr @llvm.coro.begin(token, ptr writeonly)
 declare i64 @llvm.coro.size.i64()

--- a/mlir/test/Target/LLVMIR/Import/intrinsic.ll
+++ b/mlir/test/Target/LLVMIR/Import/intrinsic.ll
@@ -117,6 +117,69 @@ define void @pow_test(float %0, float %1, <8 x float> %2, <8 x float> %3) {
   %6 = call <8 x float> @llvm.pow.v8f32(<8 x float> %2, <8 x float> %3)
   ret void
 }
+; CHECK-LABEL: llvm.func @rint_test
+define void @rint_test(float %0, double %1, <8 x float> %2, <8 x double> %3) {
+  ; CHECK: llvm.intr.rint(%{{.*}}) : (f32) -> f32
+  %5 = call float @llvm.rint.f32(float %0)
+  ; CHECK: llvm.intr.rint(%{{.*}}) : (f64) -> f64
+  %6 = call double @llvm.rint.f64(double %1)
+  ; CHECK: llvm.intr.rint(%{{.*}}) : (vector<8xf32>) -> vector<8xf32>
+  %7 = call <8 x float> @llvm.rint.v8f32(<8 x float> %2)
+  ; CHECK: llvm.intr.rint(%{{.*}}) : (vector<8xf64>) -> vector<8xf64>
+  %8 = call <8 x double> @llvm.rint.v8f64(<8 x double> %3)
+  ret void
+}
+define void @nearbyint_test(float %0, double %1, <8 x float> %2, <8 x double> %3) {
+  ; CHECK: llvm.intr.nearbyint(%{{.*}}) : (f32) -> f32
+  %5 = call float @llvm.nearbyint.f32(float %0)
+  ; CHECK: llvm.intr.nearbyint(%{{.*}}) : (f64) -> f64
+  %6 = call double @llvm.nearbyint.f64(double %1)
+  ; CHECK: llvm.intr.nearbyint(%{{.*}}) : (vector<8xf32>) -> vector<8xf32>
+  %7 = call <8 x float> @llvm.nearbyint.v8f32(<8 x float> %2)
+  ; CHECK: llvm.intr.nearbyint(%{{.*}}) : (vector<8xf64>) -> vector<8xf64>
+  %8 = call <8 x double> @llvm.nearbyint.v8f64(<8 x double> %3)
+  ret void
+}
+; CHECK-LABEL: llvm.func @lround_test
+define void @lround_test(float %0, double %1) {
+  ; CHECK: llvm.intr.lround(%{{.*}}) : (f32) -> i32
+  %3 = call i32 @llvm.lround.i32.f32(float %0)
+  ; CHECK: llvm.intr.lround(%{{.*}}) : (f32) -> i64
+  %4 = call i64 @llvm.lround.i64.f32(float %0)
+  ; CHECK: llvm.intr.lround(%{{.*}}) : (f64) -> i32
+  %5 = call i32 @llvm.lround.i32.f64(double %1)
+  ; CHECK: llvm.intr.lround(%{{.*}}) : (f64) -> i64
+  %6 = call i64 @llvm.lround.i64.f64(double %1)
+  ret void
+}
+; CHECK-LABEL: llvm.func @llround_test
+define void @llround_test(float %0, double %1) {
+  ; CHECK: llvm.intr.llround(%{{.*}}) : (f32) -> i64
+  %3 = call i64 @llvm.llround.i64.f32(float %0)
+  ; CHECK: llvm.intr.llround(%{{.*}}) : (f64) -> i64
+  %4 = call i64 @llvm.llround.i64.f64(double %1)
+  ret void
+}
+; CHECK-LABEL: llvm.func @lrint_test
+define void @lrint_test(float %0, double %1) {
+  ; CHECK: llvm.intr.lrint(%{{.*}}) : (f32) -> i32
+  %3 = call i32 @llvm.lrint.i32.f32(float %0)
+  ; CHECK: llvm.intr.lrint(%{{.*}}) : (f32) -> i64
+  %4 = call i64 @llvm.lrint.i64.f32(float %0)
+  ; CHECK: llvm.intr.lrint(%{{.*}}) : (f64) -> i32
+  %5 = call i32 @llvm.lrint.i32.f64(double %1)
+  ; CHECK: llvm.intr.lrint(%{{.*}}) : (f64) -> i64
+  %6 = call i64 @llvm.lrint.i64.f64(double %1)
+  ret void
+}
+; CHECK-LABEL: llvm.func @llrint_test
+define void @llrint_test(float %0, double %1) {
+  ; CHECK: llvm.intr.llrint(%{{.*}}) : (f32) -> i64
+  %3 = call i64 @llvm.llrint.i64.f32(float %0)
+  ; CHECK: llvm.intr.llrint(%{{.*}}) : (f64) -> i64
+  %4 = call i64 @llvm.llrint.i64.f64(double %1)
+  ret void
+}
 ; CHECK-LABEL:  llvm.func @bitreverse_test
 define void @bitreverse_test(i32 %0, <8 x i32> %1) {
   ; CHECK:   llvm.intr.bitreverse(%{{.*}}) : (i32) -> i32
@@ -391,6 +454,13 @@ define void @memset_test(i32 %0, ptr %1, i8 %2) {
   ; CHECK: %[[falseval:.+]] = llvm.mlir.constant(false) : i1
   ; CHECK: "llvm.intr.memset"(%{{.*}}, %{{.*}}, %{{.*}}, %[[falseval]]) : (!llvm.ptr, i8, i32, i1) -> ()
   call void @llvm.memset.p0.i32(ptr %1, i8 %2, i32 %0, i1 false)
+  ret void
+}
+
+; CHECK-LABEL: llvm.func @threadlocal_test
+define void @threadlocal_test(ptr %0) {
+  ; CHECK: "llvm.intr.threadlocal.address"(%{{.*}}) : (!llvm.ptr) -> !llvm.ptr
+  %local = call ptr @llvm.threadlocal.address.p0(ptr %0)
   ret void
 }
 
@@ -781,6 +851,26 @@ declare float @llvm.copysign.f32(float, float)
 declare <8 x float> @llvm.copysign.v8f32(<8 x float>, <8 x float>)
 declare float @llvm.pow.f32(float, float)
 declare <8 x float> @llvm.pow.v8f32(<8 x float>, <8 x float>)
+declare float @llvm.rint.f32(float)
+declare double @llvm.rint.f64(double)
+declare <8 x float> @llvm.rint.v8f32(<8 x float>)
+declare <8 x double> @llvm.rint.v8f64(<8 x double>)
+declare float @llvm.nearbyint.f32(float)
+declare double @llvm.nearbyint.f64(double)
+declare <8 x float> @llvm.nearbyint.v8f32(<8 x float>)
+declare <8 x double> @llvm.nearbyint.v8f64(<8 x double>)
+declare i32 @llvm.lround.i32.f32(float)
+declare i64 @llvm.lround.i64.f32(float)
+declare i32 @llvm.lround.i32.f64(double)
+declare i64 @llvm.lround.i64.f64(double)
+declare i64 @llvm.llround.i64.f32(float)
+declare i64 @llvm.llround.i64.f64(double)
+declare i32 @llvm.lrint.i32.f32(float)
+declare i64 @llvm.lrint.i64.f32(float)
+declare i32 @llvm.lrint.i32.f64(double)
+declare i64 @llvm.lrint.i64.f64(double)
+declare i64 @llvm.llrint.i64.f32(float)
+declare i64 @llvm.llrint.i64.f64(double)
 declare i32 @llvm.bitreverse.i32(i32)
 declare <8 x i32> @llvm.bitreverse.v8i32(<8 x i32>)
 declare i32 @llvm.bswap.i32(i32)
@@ -842,6 +932,7 @@ declare void @llvm.memcpy.p0.p0.i32(ptr noalias nocapture writeonly, ptr noalias
 declare void @llvm.memcpy.inline.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64 immarg, i1 immarg)
 declare void @llvm.memmove.p0.p0.i32(ptr nocapture writeonly, ptr nocapture readonly, i32, i1 immarg)
 declare void @llvm.memset.p0.i32(ptr nocapture writeonly, i8, i32, i1 immarg)
+declare nonnull ptr @llvm.threadlocal.address.p0(ptr nonnull)
 declare { i32, i1 } @llvm.sadd.with.overflow.i32(i32, i32)
 declare { <8 x i32>, <8 x i1> } @llvm.sadd.with.overflow.v8i32(<8 x i32>, <8 x i32>)
 declare { i32, i1 } @llvm.uadd.with.overflow.i32(i32, i32)

--- a/mlir/test/Target/LLVMIR/llvmir-intrinsics.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir-intrinsics.mlir
@@ -134,6 +134,72 @@ llvm.func @pow_test(%arg0: f32, %arg1: f32, %arg2: vector<8xf32>, %arg3: vector<
   llvm.return
 }
 
+// CHECK-LABEL: @rint_test
+llvm.func @rint_test(%arg0 : f32, %arg1 : f64, %arg2 : vector<8xf32>, %arg3 : vector<8xf64>) {
+  // CHECK: call float @llvm.rint.f32
+  "llvm.intr.rint"(%arg0) : (f32) -> f32
+  // CHECK: call double @llvm.rint.f64
+  "llvm.intr.rint"(%arg1) : (f64) -> f64
+  // CHECK: call <8 x float> @llvm.rint.v8f32
+  "llvm.intr.rint"(%arg2) : (vector<8xf32>) -> vector<8xf32>
+  // CHECK: call <8 x double> @llvm.rint.v8f64
+  "llvm.intr.rint"(%arg3) : (vector<8xf64>) -> vector<8xf64>
+  llvm.return
+}
+
+// CHECK-LABEL: @nearbyint_test
+llvm.func @nearbyint_test(%arg0 : f32, %arg1 : f64, %arg2 : vector<8xf32>, %arg3 : vector<8xf64>) {
+  // CHECK: call float @llvm.nearbyint.f32
+  "llvm.intr.nearbyint"(%arg0) : (f32) -> f32
+  // CHECK: call double @llvm.nearbyint.f64
+  "llvm.intr.nearbyint"(%arg1) : (f64) -> f64
+  // CHECK: call <8 x float> @llvm.nearbyint.v8f32
+  "llvm.intr.nearbyint"(%arg2) : (vector<8xf32>) -> vector<8xf32>
+  // CHECK: call <8 x double> @llvm.nearbyint.v8f64
+  "llvm.intr.nearbyint"(%arg3) : (vector<8xf64>) -> vector<8xf64>
+  llvm.return
+}
+
+llvm.func @lround_test(%arg0 : f32, %arg1 : f64) {
+  // CHECK: call i32 @llvm.lround.i32.f32
+  "llvm.intr.lround"(%arg0) : (f32) -> i32
+  // CHECK: call i64 @llvm.lround.i64.f32
+  "llvm.intr.lround"(%arg0) : (f32) -> i64
+  // CHECK: call i32 @llvm.lround.i32.f64
+  "llvm.intr.lround"(%arg1) : (f64) -> i32
+  // CHECK: call i64 @llvm.lround.i64.f64
+  "llvm.intr.lround"(%arg1) : (f64) -> i64
+  llvm.return
+}
+
+llvm.func @llround_test(%arg0 : f32, %arg1 : f64) {
+  // CHECK: call i64 @llvm.llround.i64.f32
+  "llvm.intr.llround"(%arg0) : (f32) -> i64
+  // CHECK: call i64 @llvm.llround.i64.f64
+  "llvm.intr.llround"(%arg1) : (f64) -> i64
+  llvm.return
+}
+
+llvm.func @lrint_test(%arg0 : f32, %arg1 : f64) {
+  // CHECK: call i32 @llvm.lrint.i32.f32
+  "llvm.intr.lrint"(%arg0) : (f32) -> i32
+  // CHECK: call i64 @llvm.lrint.i64.f32
+  "llvm.intr.lrint"(%arg0) : (f32) -> i64
+  // CHECK: call i32 @llvm.lrint.i32.f64
+  "llvm.intr.lrint"(%arg1) : (f64) -> i32
+  // CHECK: call i64 @llvm.lrint.i64.f64
+  "llvm.intr.lrint"(%arg1) : (f64) -> i64
+  llvm.return
+}
+
+llvm.func @llrint_test(%arg0 : f32, %arg1 : f64) {
+  // CHECK: call i64 @llvm.llrint.i64.f32
+  "llvm.intr.llrint"(%arg0) : (f32) -> i64
+  // CHECK: call i64 @llvm.llrint.i64.f64
+  "llvm.intr.llrint"(%arg1) : (f64) -> i64
+  llvm.return
+}
+
 // CHECK-LABEL: @bitreverse_test
 llvm.func @bitreverse_test(%arg0: i32, %arg1: vector<8xi32>) {
   // CHECK: call i32 @llvm.bitreverse.i32
@@ -409,6 +475,13 @@ llvm.func @memset_test(%arg0: i32, %arg2: !llvm.ptr<i8>, %arg3: i8) {
   %i1 = llvm.mlir.constant(false) : i1
   // CHECK: call void @llvm.memset.p0.i32(ptr %{{.*}}, i8 %{{.*}}, i32 %{{.*}}, i1 {{.*}})
   "llvm.intr.memset"(%arg2, %arg3, %arg0, %i1) : (!llvm.ptr<i8>, i8, i32, i1) -> ()
+  llvm.return
+}
+
+// CHECK-LABEL: @threadlocal_test
+llvm.func @threadlocal_test(%arg0 : !llvm.ptr) {
+  // CHECK: call ptr @llvm.threadlocal.address.p0(ptr %{{.*}})
+  "llvm.intr.threadlocal.address"(%arg0) : (!llvm.ptr) -> !llvm.ptr
   llvm.return
 }
 
@@ -865,6 +938,26 @@ llvm.func @lifetime(%p: !llvm.ptr) {
 // CHECK-DAG: declare float @llvm.cos.f32(float)
 // CHECK-DAG: declare <8 x float> @llvm.cos.v8f32(<8 x float>) #0
 // CHECK-DAG: declare float @llvm.copysign.f32(float, float)
+// CHECK-DAG: declare float @llvm.rint.f32(float)
+// CHECK-DAG: declare double @llvm.rint.f64(double)
+// CHECK-DAG: declare <8 x float> @llvm.rint.v8f32(<8 x float>)
+// CHECK-DAG: declare <8 x double> @llvm.rint.v8f64(<8 x double>)
+// CHECK-DAG: declare float @llvm.nearbyint.f32(float)
+// CHECK-DAG: declare double @llvm.nearbyint.f64(double)
+// CHECK-DAG: declare <8 x float> @llvm.nearbyint.v8f32(<8 x float>)
+// CHECK-DAG: declare <8 x double> @llvm.nearbyint.v8f64(<8 x double>)
+// CHECK-DAG: declare i32 @llvm.lround.i32.f32(float)
+// CHECK-DAG: declare i64 @llvm.lround.i64.f32(float)
+// CHECK-DAG: declare i32 @llvm.lround.i32.f64(double)
+// CHECK-DAG: declare i64 @llvm.lround.i64.f64(double)
+// CHECK-DAG: declare i64 @llvm.llround.i64.f32(float)
+// CHECK-DAG: declare i64 @llvm.llround.i64.f64(double)
+// CHECK-DAG: declare i32 @llvm.lrint.i32.f32(float)
+// CHECK-DAG: declare i64 @llvm.lrint.i64.f32(float)
+// CHECK-DAG: declare i32 @llvm.lrint.i32.f64(double)
+// CHECK-DAG: declare i64 @llvm.lrint.i64.f64(double)
+// CHECK-DAG: declare i64 @llvm.llrint.i64.f32(float)
+// CHECK-DAG: declare i64 @llvm.llrint.i64.f64(double)
 // CHECK-DAG: declare <12 x float> @llvm.matrix.multiply.v12f32.v64f32.v48f32(<64 x float>, <48 x float>, i32 immarg, i32 immarg, i32 immarg)
 // CHECK-DAG: declare <48 x float> @llvm.matrix.transpose.v48f32(<48 x float>, i32 immarg, i32 immarg)
 // CHECK-DAG: declare <48 x float> @llvm.matrix.column.major.load.v48f32.i64(ptr nocapture, i64, i1 immarg, i32 immarg, i32 immarg)
@@ -881,6 +974,7 @@ llvm.func @lifetime(%p: !llvm.ptr) {
 // CHECK-DAG: declare void @llvm.ubsantrap(i8 immarg)
 // CHECK-DAG: declare void @llvm.memcpy.p0.p0.i32(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i32, i1 immarg)
 // CHECK-DAG: declare void @llvm.memcpy.inline.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64 immarg, i1 immarg)
+// CHECK-DAG: declare nonnull ptr @llvm.threadlocal.address.p0(ptr nonnull)
 // CHECK-DAG: declare { i32, i1 } @llvm.sadd.with.overflow.i32(i32, i32)
 // CHECK-DAG: declare { <8 x i32>, <8 x i1> } @llvm.sadd.with.overflow.v8i32(<8 x i32>, <8 x i32>)
 // CHECK-DAG: declare { i32, i1 } @llvm.uadd.with.overflow.i32(i32, i32)

--- a/mlir/test/Target/LLVMIR/llvmir-intrinsics.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir-intrinsics.mlir
@@ -160,6 +160,7 @@ llvm.func @nearbyint_test(%arg0 : f32, %arg1 : f64, %arg2 : vector<8xf32>, %arg3
   llvm.return
 }
 
+// CHECK-LABEL: @lround_test
 llvm.func @lround_test(%arg0 : f32, %arg1 : f64) {
   // CHECK: call i32 @llvm.lround.i32.f32
   "llvm.intr.lround"(%arg0) : (f32) -> i32
@@ -172,6 +173,7 @@ llvm.func @lround_test(%arg0 : f32, %arg1 : f64) {
   llvm.return
 }
 
+// CHECK-LABEL: @llround_test
 llvm.func @llround_test(%arg0 : f32, %arg1 : f64) {
   // CHECK: call i64 @llvm.llround.i64.f32
   "llvm.intr.llround"(%arg0) : (f32) -> i64
@@ -180,6 +182,7 @@ llvm.func @llround_test(%arg0 : f32, %arg1 : f64) {
   llvm.return
 }
 
+// CHECK-LABEL: @lrint_test
 llvm.func @lrint_test(%arg0 : f32, %arg1 : f64) {
   // CHECK: call i32 @llvm.lrint.i32.f32
   "llvm.intr.lrint"(%arg0) : (f32) -> i32
@@ -192,6 +195,7 @@ llvm.func @lrint_test(%arg0 : f32, %arg1 : f64) {
   llvm.return
 }
 
+// CHECK-LABEL: @llrint_test
 llvm.func @llrint_test(%arg0 : f32, %arg1 : f64) {
   // CHECK: call i64 @llvm.llrint.i64.f32
   "llvm.intr.llrint"(%arg0) : (f32) -> i64


### PR DESCRIPTION
Add support for multiple intrinsics to the LLVM dialect.

These intrinsics are present in host LLVM IR, so for full host raising support, they need to be added to the LLVM dialect. 

The following intrinsics are added in this PR:
* `llvm.rint`, `llvm.nearbyint`, `llvm.lround`, `llvm.llround`, `llvm.lrint`, `llvm.llrint`
* `llvm.threadlocal.address`