### PR TITLE
[SYCL][ESIMD] More support for 64-bit offsets with accessors in stateless mode

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/detail/simd_obj_impl.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/simd_obj_impl.hpp
@@ -323,15 +323,27 @@ public:
   ///   the generated code. Auto-deduced from the unnamed alignment tag
   ///   argument.
   /// @param acc The accessor to read from.
-  /// @param offset 32-bit offset in bytes of the first element.
+  /// @param offset offset in bytes of the first element.
   template <
       typename AccessorT, typename Flags = element_aligned_tag,
       typename = std::enable_if_t<
           detail::is_sycl_accessor_with<AccessorT, accessor_mode_cap::can_read,
                                         sycl::access::target::device>::value &&
           is_simd_flag_type_v<Flags>>>
-  simd_obj_impl(AccessorT acc, uint32_t offset, Flags = {}) noexcept {
-    __esimd_dbg_print(simd_obj_impl(AccessorT acc, uint32_t offset, Flags));
+  simd_obj_impl(AccessorT acc,
+#ifdef __ESIMD_FORCE_STATELESS_MEM
+                uint64_t offset,
+#else
+                uint32_t offset,
+#endif
+                Flags = {}) noexcept {
+    __esimd_dbg_print(simd_obj_impl(AccessorT acc,
+#ifdef __ESIMD_FORCE_STATELESS_MEM
+                                    uint64_t offset,
+#else
+                                    uint32_t offset,
+#endif
+                                    Flags));
     copy_from(acc, offset, Flags{});
   }
 
@@ -727,7 +739,13 @@ public:
             typename = std::enable_if_t<is_simd_flag_type_v<Flags>>>
   ESIMD_INLINE EnableIfAccessor<AccessorT, accessor_mode_cap::can_read,
                                 sycl::access::target::device, void>
-  copy_from(AccessorT acc, uint32_t offset, Flags = {}) SYCL_ESIMD_FUNCTION;
+  copy_from(AccessorT acc,
+#ifdef __ESIMD_FORCE_STATELESS_MEM
+            uint64_t offset,
+#else
+            uint32_t offset,
+#endif
+            Flags = {}) SYCL_ESIMD_FUNCTION;
 
   /// Copy all vector elements of this object into a contiguous block in memory.
   /// None of the template parameters should be be specified by callers.
@@ -753,7 +771,13 @@ public:
             typename = std::enable_if_t<is_simd_flag_type_v<Flags>>>
   ESIMD_INLINE EnableIfAccessor<AccessorT, accessor_mode_cap::can_write,
                                 sycl::access::target::device, void>
-  copy_to(AccessorT acc, uint32_t offset, Flags = {}) const SYCL_ESIMD_FUNCTION;
+  copy_to(AccessorT acc,
+#ifdef __ESIMD_FORCE_STATELESS_MEM
+          uint64_t offset,
+#else
+          uint32_t offset,
+#endif
+          Flags = {}) const SYCL_ESIMD_FUNCTION;
 
   // Unary operations.
 

--- a/sycl/test-e2e/ESIMD/acc_gather_scatter_rgba_stateless_64.cpp
+++ b/sycl/test-e2e/ESIMD/acc_gather_scatter_rgba_stateless_64.cpp
@@ -1,0 +1,90 @@
+//==-acc_gather_scatter_rgba_stateless_64.cpp - DPC++ ESIMD on-device test-==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//==-----------------------------------------------------------------------==//
+// REQUIRES: gpu-intel-pvc
+// UNSUPPORTED: esimd_emulator
+// RUN: %{build} -fsycl-esimd-force-stateless-mem -o %t.out
+// RUN: %{run} %t.out
+//
+// The test checks functionality of the gather_rgba/scatter_rgba accessor-based
+// ESIMD intrinsics when stateless memory accesses are enforced, i.e. accessor
+// based accesses are automatically converted to stateless accesses with 64-bit
+// offsets.
+
+#include <iostream>
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+using namespace sycl::ext::intel::esimd;
+
+int main(void) {
+  constexpr unsigned VL = 16;
+  constexpr uint64_t Gig = 1024 * 1024 * 1024;
+
+  constexpr uint64_t Size = Gig / 2 + 16;
+  uint64_t *A = new uint64_t[Size];
+
+  for (uint64_t i = 0; i < Size; ++i)
+    A[i] = i;
+
+  buffer<uint64_t, 1> bufa(A, range<1>(Size));
+  queue q;
+
+  auto dev = q.get_device();
+  std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+  try {
+    q.submit([&](handler &cgh) {
+       auto PA = bufa.get_access<access::mode::read_write>(cgh);
+       cgh.single_task<class Test>([=]() SYCL_ESIMD_KERNEL {
+         uint64_t offsetStart = (Size - VL) * sizeof(uint64_t);
+         simd<uint64_t, VL> offset(offsetStart, sizeof(uint64_t));
+         simd<uint64_t, VL> beginning(0, sizeof(uint64_t));
+         simd<uint32_t, VL> va =
+             gather_rgba<rgba_channel_mask::R, decltype(PA), VL, uint32_t>(
+                 PA, beginning);
+         simd<uint32_t, VL> vb =
+             gather_rgba<rgba_channel_mask::R, decltype(PA), VL, uint32_t>(
+                 PA, offset);
+         va *= 2;
+         vb *= 5;
+         scatter_rgba<rgba_channel_mask::R, decltype(PA), VL, uint32_t>(
+             PA, beginning, va);
+         scatter_rgba<rgba_channel_mask::R, decltype(PA), VL, uint32_t>(
+             PA, offset, vb);
+       });
+     }).wait();
+  } catch (sycl::exception const &e) {
+    std::cout << "SYCL exception caught: " << e.what() << '\n';
+    delete[] A;
+    return 1;
+  }
+
+  bool failed = false;
+  host_accessor A_acc(bufa);
+  for (uint64_t I = 0; I < VL; I++) {
+    uint64_t Expected = static_cast<uint32_t>(I) * 2;
+    if (A_acc[I] != Expected) {
+      std::cout << "FAILED: " << A_acc[I] << " != " << Expected << std::endl;
+      failed = true;
+    }
+  }
+  for (uint64_t I = Size - VL; I < Size; I++) {
+    uint64_t Expected = static_cast<uint32_t>(I) * 5;
+    if (A_acc[I] != Expected) {
+      std::cout << "FAILED: " << A_acc[I] << " != " << Expected << std::endl;
+      failed = true;
+    }
+  }
+
+  if (!failed)
+    std::cout << "PASSED" << std::endl;
+
+  delete[] A;
+
+  return failed;
+}

--- a/sycl/test-e2e/ESIMD/accessor_stateless_64.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_stateless_64.cpp
@@ -1,0 +1,81 @@
+//==--- accessor_stateless_64.cpp  - DPC++ ESIMD on-device test---==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------------===//
+// REQUIRES: gpu-intel-pvc
+// UNSUPPORTED: esimd_emulator
+// RUN: %{build} -fsycl-esimd-force-stateless-mem -o %t.out
+// RUN: %{run} %t.out
+
+#include <iostream>
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+using namespace sycl::ext::intel::esimd;
+
+int main(void) {
+  constexpr unsigned VL = 16;
+  constexpr uint64_t Gig = 1024 * 1024 * 1024;
+
+  constexpr uint64_t Size = Gig / 2 + 16;
+
+  uint64_t *A = new uint64_t[Size];
+
+  for (uint64_t i = 0; i < Size; ++i)
+    A[i] = i;
+  buffer<uint64_t, 1> bufa(A, range<1>(Size));
+
+  try {
+    queue q;
+
+    auto dev = q.get_device();
+    std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+
+    q.submit([&](handler &cgh) {
+       auto PA = bufa.get_access<access::mode::read_write>(cgh);
+       cgh.single_task<class Test>([=]() SYCL_ESIMD_KERNEL {
+         uint64_t offset = (Size - VL) * sizeof(uint64_t);
+         simd<uint64_t, VL> va;
+         simd<uint64_t, VL> vb;
+         va.copy_from(PA, 0);
+         vb.copy_from(PA, offset);
+         va *= 2;
+         vb *= 5;
+         va.copy_to(PA, 0);
+         vb.copy_to(PA, offset);
+       });
+     }).wait();
+  } catch (sycl::exception const &e) {
+    std::cout << "SYCL exception caught: " << e.what() << '\n';
+    delete[] A;
+    return 1;
+  }
+
+  bool failed = false;
+  host_accessor A_acc(bufa);
+  for (uint64_t I = 0; I < VL; I++) {
+    uint64_t Expected = I * 2;
+    if (A_acc[I] != Expected) {
+      std::cout << "FAILED: " << A_acc[I] << " != " << Expected << std::endl;
+      failed = true;
+    }
+  }
+  for (uint64_t I = Size - VL; I < Size; I++) {
+    uint64_t Expected = I * 5;
+    if (A_acc[I] != Expected) {
+      std::cout << "FAILED: " << A_acc[I] << " != " << Expected << std::endl;
+      failed = true;
+    }
+  }
+
+  if (!failed)
+    std::cout << "PASSED" << std::endl;
+
+  delete[] A;
+
+  return failed;
+}

--- a/sycl/test-e2e/ESIMD/accessor_stateless_ctor_64.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_stateless_ctor_64.cpp
@@ -1,0 +1,79 @@
+//==--- accessor_stateless_ctor_64.cpp  - DPC++ ESIMD on-device test---==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------------===//
+// REQUIRES: gpu-intel-pvc
+// UNSUPPORTED: esimd_emulator
+// RUN: %{build} -fsycl-esimd-force-stateless-mem -o %t.out
+// RUN: %{run} %t.out
+
+#include <iostream>
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+using namespace sycl::ext::intel::esimd;
+
+int main(void) {
+  constexpr unsigned VL = 16;
+  constexpr uint64_t Gig = 1024 * 1024 * 1024;
+
+  constexpr uint64_t Size = Gig / 2 + 16;
+
+  uint64_t *A = new uint64_t[Size];
+
+  for (uint64_t i = 0; i < Size; ++i)
+    A[i] = i;
+  buffer<uint64_t, 1> bufa(A, range<1>(Size));
+
+  try {
+    queue q;
+
+    auto dev = q.get_device();
+    std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+
+    q.submit([&](handler &cgh) {
+       auto PA = bufa.get_access<access::mode::read_write>(cgh);
+       cgh.single_task<class Test>([=]() SYCL_ESIMD_KERNEL {
+         uint64_t offset = (Size - VL) * sizeof(uint64_t);
+         simd<uint64_t, VL> va(PA, 0);
+         simd<uint64_t, VL> vb(PA, offset);
+         va *= 2;
+         vb *= 5;
+         va.copy_to(PA, 0);
+         vb.copy_to(PA, offset);
+       });
+     }).wait();
+  } catch (sycl::exception const &e) {
+    std::cout << "SYCL exception caught: " << e.what() << '\n';
+    delete[] A;
+    return 1;
+  }
+
+  bool failed = false;
+  host_accessor A_acc(bufa);
+  for (uint64_t I = 0; I < VL; I++) {
+    uint64_t Expected = I * 2;
+    if (A_acc[I] != Expected) {
+      std::cout << "FAILED: " << A_acc[I] << " != " << Expected << std::endl;
+      failed = true;
+    }
+  }
+  for (uint64_t I = Size - VL; I < Size; I++) {
+    uint64_t Expected = I * 5;
+    if (A_acc[I] != Expected) {
+      std::cout << "FAILED: " << A_acc[I] << " != " << Expected << std::endl;
+      failed = true;
+    }
+  }
+
+  if (!failed)
+    std::cout << "PASSED" << std::endl;
+
+  delete[] A;
+
+  return failed;
+}

--- a/sycl/test-e2e/ESIMD/lsc/lsc_block_load_store_stateless_64.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_block_load_store_stateless_64.cpp
@@ -1,0 +1,83 @@
+//===-lsc_block_load_store_stateless_64 - DPC++ ESIMD on-device test-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===-------------------------------------------------------------------===//
+// REQUIRES: gpu-intel-pvc
+// UNSUPPORTED: esimd_emulator
+// RUN: %{build} -o %t.out -fsycl-esimd-force-stateless-mem
+// RUN: %{run} %t.out
+
+#include <iostream>
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+using namespace sycl::ext::intel::esimd;
+using namespace sycl::ext::intel::experimental::esimd;
+
+int main(void) {
+  constexpr unsigned VL = 16;
+  constexpr uint64_t Gig = 1024 * 1024 * 1024;
+
+  constexpr uint64_t Size = Gig / 2 + 16;
+  uint64_t *A = new uint64_t[Size];
+
+  for (uint64_t i = 0; i < Size; ++i)
+    A[i] = i;
+
+  buffer<uint64_t, 1> bufa(A, range<1>(Size));
+  queue q;
+
+  auto dev = q.get_device();
+  std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+  try {
+    q.submit([&](handler &cgh) {
+       auto PA = bufa.get_access<access::mode::read_write>(cgh);
+       cgh.single_task<class Test>([=]() SYCL_ESIMD_KERNEL {
+         uint64_t offset = (Size - VL) * sizeof(uint64_t);
+         simd<uint64_t, VL> va = lsc_block_load<uint64_t, VL>(PA, 0);
+         simd_mask<1> pred = 1;
+         simd<uint64_t, VL> old_values = 0;
+         lsc_prefetch<uint64_t, 1, lsc_data_size::default_size,
+                      cache_hint::cached, cache_hint::cached>(PA, offset);
+         simd<uint64_t, VL> vb =
+             lsc_block_load<uint64_t>(PA, offset, pred, old_values);
+         va *= 2;
+         vb *= 5;
+         lsc_block_store(PA, 0, va);
+         lsc_block_store(PA, offset, vb);
+       });
+     }).wait();
+  } catch (sycl::exception const &e) {
+    std::cout << "SYCL exception caught: " << e.what() << '\n';
+    delete[] A;
+    return 1;
+  }
+
+  bool failed = false;
+  host_accessor A_acc(bufa);
+  for (uint64_t I = 0; I < VL; I++) {
+    uint64_t Expected = I * 2;
+    if (A_acc[I] != Expected) {
+      std::cout << "FAILED: " << A_acc[I] << " != " << Expected << std::endl;
+      failed = true;
+    }
+  }
+  for (uint64_t I = Size - VL; I < Size; I++) {
+    uint64_t Expected = I * 5;
+    if (A_acc[I] != Expected) {
+      std::cout << "FAILED: " << A_acc[I] << " != " << Expected << std::endl;
+      failed = true;
+    }
+  }
+
+  if (!failed)
+    std::cout << "PASSED" << std::endl;
+
+  delete[] A;
+
+  return failed;
+}

--- a/sycl/test-e2e/ESIMD/lsc/lsc_block_load_store_stateless_flag_64.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_block_load_store_stateless_flag_64.cpp
@@ -1,0 +1,85 @@
+//===-lsc_block_load_store_stateless_64 - DPC++ ESIMD on-device test-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===-------------------------------------------------------------------===//
+// REQUIRES: gpu-intel-pvc
+// UNSUPPORTED: esimd_emulator
+// RUN: %{build} -o %t.out -fsycl-esimd-force-stateless-mem
+// RUN: %{run} %t.out
+
+#include <iostream>
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+using namespace sycl::ext::intel::esimd;
+using namespace sycl::ext::intel::experimental::esimd;
+
+int main(void) {
+  constexpr unsigned VL = 16;
+  constexpr uint64_t Gig = 1024 * 1024 * 1024;
+
+  constexpr uint64_t Size = Gig / 2 + 16;
+  uint64_t *A = new uint64_t[Size];
+
+  for (uint64_t i = 0; i < Size; ++i)
+    A[i] = i;
+
+  buffer<uint64_t, 1> bufa(A, range<1>(Size));
+  queue q;
+
+  auto dev = q.get_device();
+  std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+  try {
+    q.submit([&](handler &cgh) {
+       auto PA = bufa.get_access<access::mode::read_write>(cgh);
+       cgh.single_task<class Test>([=]() SYCL_ESIMD_KERNEL {
+         uint64_t offset = (Size - VL) * sizeof(uint64_t);
+         simd<uint64_t, VL> va = lsc_block_load<uint64_t, VL>(
+             PA, 0, sycl::ext::intel::esimd::detail::dqword_element_aligned);
+         simd<uint64_t, VL> vb = lsc_block_load<uint64_t, VL>(
+             PA, offset,
+             sycl::ext::intel::esimd::detail::dqword_element_aligned);
+         va *= 2;
+         vb *= 5;
+         lsc_block_store(
+             PA, 0, va,
+             sycl::ext::intel::esimd::detail::dqword_element_aligned);
+         lsc_block_store(
+             PA, offset, vb,
+             sycl::ext::intel::esimd::detail::dqword_element_aligned);
+       });
+     }).wait();
+  } catch (sycl::exception const &e) {
+    std::cout << "SYCL exception caught: " << e.what() << '\n';
+    delete[] A;
+    return 1;
+  }
+
+  bool failed = false;
+  host_accessor A_acc(bufa);
+  for (uint64_t I = 0; I < VL; I++) {
+    uint64_t Expected = I * 2;
+    if (A_acc[I] != Expected) {
+      std::cout << "FAILED: " << A_acc[I] << " != " << Expected << std::endl;
+      failed = true;
+    }
+  }
+  for (uint64_t I = Size - VL; I < Size; I++) {
+    uint64_t Expected = I * 5;
+    if (A_acc[I] != Expected) {
+      std::cout << "FAILED: " << A_acc[I] << " != " << Expected << std::endl;
+      failed = true;
+    }
+  }
+
+  if (!failed)
+    std::cout << "PASSED" << std::endl;
+
+  delete[] A;
+
+  return failed;
+}

--- a/sycl/test-e2e/ESIMD/lsc/lsc_block_load_store_stateless_flag_64.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_block_load_store_stateless_flag_64.cpp
@@ -1,4 +1,4 @@
-//===-lsc_block_load_store_stateless_64 - DPC++ ESIMD on-device test-===//
+//===-lsc_block_load_store_stateless_64_flag - DPC++ ESIMD on-device test-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,76 +10,6 @@
 // RUN: %{build} -o %t.out -fsycl-esimd-force-stateless-mem
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <sycl/ext/intel/esimd.hpp>
-#include <sycl/sycl.hpp>
+#define TEST_FLAG 1
 
-using namespace sycl;
-using namespace sycl::ext::intel::esimd;
-using namespace sycl::ext::intel::experimental::esimd;
-
-int main(void) {
-  constexpr unsigned VL = 16;
-  constexpr uint64_t Gig = 1024 * 1024 * 1024;
-
-  constexpr uint64_t Size = Gig / 2 + 16;
-  uint64_t *A = new uint64_t[Size];
-
-  for (uint64_t i = 0; i < Size; ++i)
-    A[i] = i;
-
-  buffer<uint64_t, 1> bufa(A, range<1>(Size));
-  queue q;
-
-  auto dev = q.get_device();
-  std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
-  try {
-    q.submit([&](handler &cgh) {
-       auto PA = bufa.get_access<access::mode::read_write>(cgh);
-       cgh.single_task<class Test>([=]() SYCL_ESIMD_KERNEL {
-         uint64_t offset = (Size - VL) * sizeof(uint64_t);
-         simd<uint64_t, VL> va = lsc_block_load<uint64_t, VL>(
-             PA, 0, sycl::ext::intel::esimd::detail::dqword_element_aligned);
-         simd<uint64_t, VL> vb = lsc_block_load<uint64_t, VL>(
-             PA, offset,
-             sycl::ext::intel::esimd::detail::dqword_element_aligned);
-         va *= 2;
-         vb *= 5;
-         lsc_block_store(
-             PA, 0, va,
-             sycl::ext::intel::esimd::detail::dqword_element_aligned);
-         lsc_block_store(
-             PA, offset, vb,
-             sycl::ext::intel::esimd::detail::dqword_element_aligned);
-       });
-     }).wait();
-  } catch (sycl::exception const &e) {
-    std::cout << "SYCL exception caught: " << e.what() << '\n';
-    delete[] A;
-    return 1;
-  }
-
-  bool failed = false;
-  host_accessor A_acc(bufa);
-  for (uint64_t I = 0; I < VL; I++) {
-    uint64_t Expected = I * 2;
-    if (A_acc[I] != Expected) {
-      std::cout << "FAILED: " << A_acc[I] << " != " << Expected << std::endl;
-      failed = true;
-    }
-  }
-  for (uint64_t I = Size - VL; I < Size; I++) {
-    uint64_t Expected = I * 5;
-    if (A_acc[I] != Expected) {
-      std::cout << "FAILED: " << A_acc[I] << " != " << Expected << std::endl;
-      failed = true;
-    }
-  }
-
-  if (!failed)
-    std::cout << "PASSED" << std::endl;
-
-  delete[] A;
-
-  return failed;
-}
+#include "lsc_block_load_store_stateless_64.cpp"

--- a/sycl/test-e2e/ESIMD/lsc/lsc_gather_scatter_stateless_64.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_gather_scatter_stateless_64.cpp
@@ -1,0 +1,86 @@
+//=---lsc_gather_scatter_stateless_64.cpp - DPC++ ESIMD on-device test---=//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//=----------------------------------------------------------------------=//
+// REQUIRES: gpu-intel-pvc
+// UNSUPPORTED: esimd_emulator
+// RUN: %{build} -o %t.out -fsycl-esimd-force-stateless-mem
+// RUN: %{run} %t.out
+
+#include <iostream>
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+using namespace sycl::ext::intel::esimd;
+using namespace sycl::ext::intel::experimental::esimd;
+
+int main() {
+  constexpr unsigned VL = 16;
+  constexpr uint64_t Gig = 1024 * 1024 * 1024;
+
+  constexpr uint64_t Size = Gig / 2 + 16;
+  uint64_t *A = new uint64_t[Size];
+
+  for (uint64_t i = 0; i < Size; ++i)
+    A[i] = i;
+
+  buffer<uint64_t, 1> bufa(A, range<1>(Size));
+  queue q;
+
+  auto dev = q.get_device();
+  std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+  try {
+    q.submit([&](handler &cgh) {
+       auto PA = bufa.get_access<access::mode::read_write>(cgh);
+       cgh.single_task<class Test>([=]() SYCL_ESIMD_KERNEL {
+         uint64_t offsetStart = (Size - VL) * sizeof(uint64_t);
+         simd<uint64_t, VL> offset(offsetStart, sizeof(uint64_t));
+         simd<uint64_t, VL> beginning(0, sizeof(uint64_t));
+         simd<uint64_t, VL> va = lsc_gather<uint64_t>(PA, beginning);
+         simd_mask<VL> pred = 1;
+         simd<uint64_t, VL> old_values = 0;
+         lsc_prefetch<uint64_t, 1, lsc_data_size::default_size,
+                      cache_hint::cached, cache_hint::cached>(PA, offset);
+         simd<uint64_t, VL> vb =
+             lsc_gather<uint64_t>(PA, offset, pred, old_values);
+         simd<uint64_t, VL> vc = lsc_gather<uint64_t>(PA, offset);
+         va *= 5;
+         vb += vc;
+         lsc_scatter<uint64_t>(PA, beginning, va);
+         lsc_scatter<uint64_t>(PA, offset, vb);
+       });
+     }).wait();
+  } catch (sycl::exception const &e) {
+    std::cout << "SYCL exception caught: " << e.what() << '\n';
+    delete[] A;
+    return 1;
+  }
+
+  bool failed = false;
+  host_accessor A_acc(bufa);
+  for (uint64_t I = 0; I < VL; I++) {
+    uint64_t Expected = static_cast<uint32_t>(I) * 5;
+    if (A_acc[I] != Expected) {
+      std::cout << "FAILED: " << A_acc[I] << " != " << Expected << std::endl;
+      failed = true;
+    }
+  }
+  for (uint64_t I = Size - VL; I < Size; I++) {
+    uint64_t Expected = static_cast<uint32_t>(I) * 2;
+    if (A_acc[I] != Expected) {
+      std::cout << "FAILED: " << A_acc[I] << " != " << Expected << std::endl;
+      failed = true;
+    }
+  }
+
+  if (!failed)
+    std::cout << "PASSED" << std::endl;
+
+  delete[] A;
+
+  return failed;
+}


### PR DESCRIPTION
This adds support for 64-bit offsets with accessors in stateless mode for the remaining APIs. Please let me know if I missed any.

Today, all of the APIs convert to 32-bit offsets with no error if passed a 64-bit offset, except for vector offset versions of `lsc_gather`, `lsc_scatter`, and `lsc_prefetch`. Do not error except in these three cases in order to preserve backward compatability.

I manually ran all of these tests on PVC and confirmed they pass with this change and fail without it.

In some cases, in stateful mode, the underlying intrinsic we call only supports 32-bit offests, so we need to convert.