### PR TITLE
[SYCL-MLIR] Always use ours when merging from other branches for CODEOWNERS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-.github/workflows/sycl_precommit.yml merge=ours
 .github/CODEOWNERS merge=ours

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+.github/workflows/sycl_precommit.yml merge=ours
+.github/CODEOWNERS merge=ours


### PR DESCRIPTION
This it to tell git merge.ours driver to always use sycl-mlir version.
It should be a nop op for default merge strategy.

To use merge.ours driver, you can set it in config once.

git config --global merge.ours.driver true
