### PR TITLE
[SYCL] Add ipo component into deps because SYCLLowerIR uses AlwaysInliner

### DIFF
--- a/llvm/lib/SYCLLowerIR/CMakeLists.txt
+++ b/llvm/lib/SYCLLowerIR/CMakeLists.txt
@@ -91,6 +91,7 @@ add_llvm_component_library(LLVMSYCLLowerIR
   Analysis
   Core
   Support
+  ipo
   )
 
 target_include_directories(LLVMSYCLLowerIR


### PR DESCRIPTION
Necessary to fix shared libs build.