### PR TITLE
[SYCL][ESIMD] Fix a test with a esimd private global pinned to GRF

### DIFF
--- a/sycl/test-e2e/ESIMD/regression/Inputs/dgetrf.hpp
+++ b/sycl/test-e2e/ESIMD/regression/Inputs/dgetrf.hpp
@@ -47,7 +47,7 @@ using namespace sycl;
 using namespace std;
 using namespace sycl::ext::intel::esimd;
 
-ESIMD_PRIVATE ESIMD_REGISTER(192) simd<double, 3 * 32 * 4> GRF;
+ESIMD_PRIVATE ESIMD_REGISTER(256) simd<double, 3 * 32 * 4> GRF;
 
 #define V(x, w, i) (x).template select<w, 1>(i)
 #define V1(x, i) V(x, 1, i)

--- a/sycl/test-e2e/ESIMD/regression/dgetrf.cpp
+++ b/sycl/test-e2e/ESIMD/regression/dgetrf.cpp
@@ -10,9 +10,6 @@
 // RUN: %{build} -I%S/.. -o %t.out
 // RUN: %{run} %t.out 3 2 1
 //
-// Failure is under investigation, tracked internally:
-// UNSUPPORTED: gpu-intel-pvc
-//
 // This test checks the correctness of ESIMD program for batched LU
 // decomposition without pivoting. The program contains multiple branches
 // corresponding to LU input sizes; all internal functions are inlined.


### PR DESCRIPTION
Private global in the test collides with kernel arguments in GRF.
The offset must be a multiple of the register size.