### PR TITLE
[SYCL] Free allocated memory

### DIFF
--- a/sycl/test-e2e/ESIMD/slm_alloc_many_kernels_one_func.cpp
+++ b/sycl/test-e2e/ESIMD/slm_alloc_many_kernels_one_func.cpp
@@ -89,5 +89,6 @@ int main(void) {
     std::cout << test << " == " << gold << "(gold)\n";
   }
   std::cout << (err_cnt ? "FAILED\n" : "Passed\n");
+  free(arr, ctxt);
   return err_cnt ? 1 : 0;
 }


### PR DESCRIPTION
Added the missing free call to avoid memory leak.