### PR TITLE
[SYCL] Remove an unnecessary multi_ptr conversion

### DIFF
--- a/sycl/include/sycl/multi_ptr.hpp
+++ b/sycl/include/sycl/multi_ptr.hpp
@@ -113,16 +113,6 @@ public:
       : m_Pointer(ptr) {}
   multi_ptr(std::nullptr_t) : m_Pointer(nullptr) {}
 
-  // Implicit conversion from multi_ptr<T> to multi_ptr<const T>
-  template <typename NonConstElementType = std::remove_const_t<ElementType>,
-            typename = typename std::enable_if_t<
-                std::is_const_v<ElementType> &&
-                std::is_same_v<NonConstElementType,
-                               std::remove_const_t<ElementType>>>>
-  explicit multi_ptr(
-      multi_ptr<NonConstElementType, Space, DecorateAddress> MPtr)
-      : m_Pointer(MPtr.get_decorated()) {}
-
   // Only if Space is in
   // {global_space, ext_intel_global_device_space, generic_space}
   template <

--- a/sycl/test/multi_ptr/ctad.cpp
+++ b/sycl/test/multi_ptr/ctad.cpp
@@ -9,6 +9,12 @@
 //===----------------------------------------------------------------------===//
 #include <sycl/sycl.hpp>
 
+using constTypeMPtr =
+    sycl::multi_ptr<const int, sycl::access::address_space::global_space,
+                    sycl::access::decorated::no>;
+
+void implicit_conversion(const constTypeMPtr &cmptr) { auto v = cmptr.get(); }
+
 int main() {
   using sycl::access::address_space;
   using sycl::access::mode;
@@ -39,7 +45,6 @@ int main() {
   static_assert(std::is_same<localCTADDep, localMPtr>::value);
 
   globlMPtr non_const_multi_ptr;
-  using constTypeMPtr = sycl::multi_ptr<const int, address_space::global_space,
-                                        sycl::access::decorated::no>;
   auto constTypeMultiPtr = constTypeMPtr(non_const_multi_ptr);
+  implicit_conversion(non_const_multi_ptr);
 }


### PR DESCRIPTION
* Remove unnecessary multi_ptr conversion. It has conflict with an existing one resulting in ambiguity on implicit conversion.
* Update test. 