### PR TITLE
[SYCL][Test E2E] Remove sycl_be/target_devices params support

### DIFF
--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -27,9 +27,6 @@ config.cuda_include = "@CUDA_INCLUDE@"
 config.opencl_include_dir = os.path.join(config.sycl_include, 'sycl')
 
 config.sycl_devices = lit_config.params.get("sycl_devices", "@SYCL_TEST_E2E_TARGETS@").split(';')
-if lit_config.params.get("target_devices") and lit_config.params.get("sycl_be"):
-    config.sycl_devices = ['{}:{}'.format(lit_config.params.get("sycl_be"), d)
-                           for d in lit_config.params.get("target_devices").split(',')]
 
 config.hip_platform = "@HIP_PLATFORM@"
 config.amd_arch = "@AMD_ARCH@"


### PR DESCRIPTION
sycl_devices is used instead now, including our public and internal CI.