### PR TITLE
Adjust CODEOWNERS for OffloadBundler.{h,cpp} files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,6 +66,8 @@ llvm/include/llvm/Transforms/SPMDTransforms/ @intel/ocl-cpu-rt-write
 llvm/test/Transforms/SPMDTransforms/ @intel/ocl-cpu-rt-write
 
 # Clang offload tools
+clang/**/OffloadBundler.h @intel/dpcpp-tools-reviewers
+clang/**/OffloadBundler.cpp @intel/dpcpp-tools-reviewers
 clang/tools/clang-offload-*/ @intel/dpcpp-tools-reviewers
 
 # Explicit SIMD


### PR DESCRIPTION
clang-offload-bundler functionality was taken out from tool into "library" here: https://reviews.llvm.org/D129873.
This commit adjusts CODEOWNERS file so that DPC++ tools team could track changes.