### PR TITLE
[SYCL-MLIR] Deactivate debug assignment tracking

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5250,6 +5250,13 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       // doing the host pass.
       CmdArgs.push_back("-fsycl-is-host");
 
+      // Debug assignment tracking creates 'llvm.dbg.assign' intrinsics, which
+      // are currently not understood by mlir-translate. Therefore deactive the
+      // debug assignment tracking when we want to raise this host module later
+      // on to MLIR.
+      if (Args.hasArg(options::OPT_fsycl_raise_host))
+        CmdArgs.push_back("-fexperimental-assignment-tracking=disabled");
+
       if (!D.IsCLMode()) {
         // SYCL library is guaranteed to work correctly only with dynamic
         // MSVC runtime.

--- a/clang/test/Driver/sycl-mlir.cpp
+++ b/clang/test/Driver/sycl-mlir.cpp
@@ -275,4 +275,4 @@
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
 // RUN: | FileCheck -check-prefix=CHK-RAISE-HOST-CCMP %s
 
-// CHK-RAISE-HOST-CCMP: error: The combination of '-fsycl-raise-host' and '-fsycl-host-compiler=' is incompatible
+// CHK-RAISE-HOST-CCMP: error: the combination of '-fsycl-raise-host' and '-fsycl-host-compiler=' is incompatible


### PR DESCRIPTION
The experimental debug assignment tracking feature was recently enabled by default. 

When the feature is used, `llvm.dbg.assign` intrinsics are inserted. The `llvm.dbg.assign` intrinsic is currently not understood by `mlir-translate`. Therefore, deactivate the experimental debug assignment tracking in the Clang driver when the host module is intended to be raised to MLIR through `-fsycl-raise-host`. 