### PR TITLE
[SYCL] Remove undefined behavior in host-side abs_diff

### DIFF
--- a/sycl/source/detail/builtins_integer.cpp
+++ b/sycl/source/detail/builtins_integer.cpp
@@ -24,20 +24,17 @@ namespace {
 template <typename T> inline std::make_unsigned_t<T> __abs_diff(T x, T y) {
   static_assert(std::is_integral<T>::value,
                 "Only integral types are supported");
-  if constexpr (std::is_unsigned_v<T>) {
-    return (x > y) ? (x - y) : (y - x);
-  } else {
-    // We need to be careful too avoid undefined behavior from signed integer
-    // overflow.
-    using UT = std::make_unsigned_t<T>;
-    UT ax = std::abs(x);
-    UT ay = std::abs(y);
-    // If only one of them was negative, the distance is the sum.
+  using UT = std::make_unsigned_t<T>;
+
+  // We need to be careful too avoid undefined behavior from signed integer
+  // overflow. That is, if only one of the operands are negative we can overflow
+  // the distance when using signed values. Instead, compute the distance as the
+  // sum of absolule values.
+  if constexpr (std::is_signed_v<T>)
     if ((x < 0) != (y < 0))
-      return ax + ay;
-    // Otherwise it is simply the distance between the absolute values.
-    return (ax > ay) ? (ax - ay) : (ay - ax);
-  }
+      return static_cast<UT>(std::abs(x)) + static_cast<UT>(std::abs(y));
+
+  return (x > y) ? (x - y) : (y - x);
 }
 
 template <typename T> inline T __u_add_sat(T x, T y) {

--- a/sycl/source/detail/builtins_integer.cpp
+++ b/sycl/source/detail/builtins_integer.cpp
@@ -26,7 +26,7 @@ template <typename T> inline std::make_unsigned_t<T> __abs_diff(T x, T y) {
                 "Only integral types are supported");
   using UT = std::make_unsigned_t<T>;
 
-  // We need to be careful too avoid undefined behavior from signed integer
+  // We need to be careful to avoid undefined behavior from signed integer
   // overflow. That is, if only one of the operands are negative we can overflow
   // the distance when using signed values. Instead, compute the distance as the
   // sum of absolule values.

--- a/sycl/test/regression/abs_diff_host.cpp
+++ b/sycl/test/regression/abs_diff_host.cpp
@@ -1,0 +1,42 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %t.out
+
+// Test checks that sycl::abs_diff correctly handles signed operations that
+// might overflow.
+
+#include <sycl/sycl.hpp>
+
+#include <limits>
+#include <type_traits>
+
+template <typename T> void check() {
+  using UT = std::make_unsigned_t<T>;
+  constexpr T MaxVal = std::numeric_limits<T>::max();
+  constexpr T MinVal = std::numeric_limits<T>::min();
+  constexpr UT UMaxVal = MaxVal;
+  // Avoid unrepresentable negation.
+  constexpr UT UAbsMinVal = UMaxVal - (MaxVal + MinVal);
+
+  // Sanity checks to make sure simple distances work.
+  assert(sycl::abs_diff(MaxVal, T(10)) == UT(MaxVal - 10));
+  assert(sycl::abs_diff(T(10), MaxVal) == UT(MaxVal - 10));
+  assert(sycl::abs_diff(MinVal, T(-10)) == UT(MinVal - 10));
+  assert(sycl::abs_diff(T(-10), MinVal) == UT(MinVal - 10));
+
+  // Checks potential overflows.
+  assert(sycl::abs_diff(MaxVal, T(-10)) == (UMaxVal + 10));
+  assert(sycl::abs_diff(T(-10), MaxVal) == (UMaxVal + 10));
+  assert(sycl::abs_diff(MinVal, T(10)) == (UAbsMinVal + 10));
+  assert(sycl::abs_diff(T(10), MinVal) == (UAbsMinVal + 10));
+  assert(sycl::abs_diff(MaxVal, MinVal) == (UMaxVal + UAbsMinVal));
+  assert(sycl::abs_diff(MinVal, MaxVal) == (UMaxVal + UAbsMinVal));
+}
+
+int main() {
+  check<char>();
+  check<short>();
+  check<int>();
+  check<long>();
+  check<long long>();
+  return 0;
+}


### PR DESCRIPTION
The existing implementation of host-side abs_diff relies on undefined behavior when the signed operations overflow. This can mean that using different compilers to build DPC++ may break the implementation. This commit changes the implementation to avoid this undefined behavior.