### PR TITLE
[SYCL-MLIR] Prevent name collision for sycl arrays

### DIFF
--- a/mlir-sycl/test/Conversion/SYCLToLLVM/check-collision-typed-pointer.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/check-collision-typed-pointer.mlir
@@ -1,0 +1,12 @@
+// RUN: sycl-mlir-opt -split-input-file -convert-sycl-to-llvm='use-opaque-pointers=0' %s | FileCheck %s
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+
+// Check that the lowering of sycl_id_1_ doesn't clash with "class.sycl::_V1::id.1"
+// CHECK: llvm.func @test_id(%arg0: !llvm.struct<"class.sycl::_V1::id.1.1", (struct<"class.sycl::_V1::detail::array.1.1", (array<1 x
+func.func @test_id(%arg0: !sycl_id_1_) {
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  %1 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr<struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)>>
+  %2 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<2 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr<struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<2 x i64>)>)>>
+  return
+}

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/check-collision.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/check-collision.mlir
@@ -1,0 +1,12 @@
+// RUN: sycl-mlir-opt -split-input-file -convert-sycl-to-llvm='use-opaque-pointers=1' %s | FileCheck %s
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+
+// Check that the lowering of sycl_id_1_ doesn't clash with "class.sycl::_V1::id.1"
+// CHECK: llvm.func @test_id(%arg0: !llvm.struct<"class.sycl::_V1::id.1.1", (struct<"class.sycl::_V1::detail::array.1.1", (array<1 x
+func.func @test_id(%arg0: !sycl_id_1_) {
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  %1 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %2 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<2 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  return
+}


### PR DESCRIPTION
The routine lowering sycl arrays doesn't handle collisions and assumed that, if a type is found and initialized, then it is the one expected.

Note 1: I kept naming of structs as they are even if the numbering is unrelated to dimensions, but it makes sense for reading IMO.

Note 2: I think there is still an issue with importing the host module in the cgiest generated as I doubt it cares about collisions. But that doesn't seem to impact our testing, so I'll look into it in another patch.