### PR TITLE
[SYCL] Modifies accessor::ConcreteASPtrType to be `const` for `readonly` accessor

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -1159,7 +1159,10 @@ protected:
       !IsConst || IsAccessReadOnly,
       "A const qualified DataT is only allowed for a read-only accessor");
 
-  using ConcreteASPtrType = typename detail::DecoratedType<DataT, AS>::type *;
+  using ConcreteASPtrType = typename detail::DecoratedType<
+      typename std::conditional_t<IsAccessReadOnly && !IsConstantBuf,
+                                  const DataT, DataT>,
+      AS>::type *;
 
   using RefType = detail::const_if_const_AS<AS, DataT> &;
   using ConstRefType = const DataT &;

--- a/sycl/test-e2e/Basic/accessor/accessor.cpp
+++ b/sycl/test-e2e/Basic/accessor/accessor.cpp
@@ -62,16 +62,16 @@ template <typename Acc> struct Wrapper3 {
   Wrapper2<Acc> w2;
 };
 
-void implicit_conversion(
-    const sycl::accessor<const int, 1, sycl::access::mode::read> &acc,
-    const sycl::accessor<int, 1, sycl::access::mode::read_write> &res_acc) {
+using ResAccT = sycl::accessor<int, 1, sycl::access::mode::read_write>;
+using AccT = sycl::accessor<int, 1, sycl::access::mode::read>;
+using AccCT = sycl::accessor<const int, 1, sycl::access::mode::read>;
+
+void implicit_conversion(const AccCT &acc, const ResAccT &res_acc) {
   auto v = acc[0];
   res_acc[0] = v;
 }
 
-void implicit_conversion(
-    const sycl::accessor<int, 1, sycl::access::mode::read> &acc,
-    const sycl::accessor<int, 1, sycl::access::mode::read_write> &res_acc) {
+void implicit_conversion(const AccT &acc, const ResAccT &res_acc) {
   auto v = acc[0];
   res_acc[0] = v;
 }
@@ -776,7 +776,6 @@ int main() {
   {
     sycl::queue q;
     try {
-      using AccT = sycl::accessor<int, 1, sycl::access::mode::read_write>;
       AccT acc;
 
       q.submit([&](sycl::handler &cgh) { cgh.require(acc); });
@@ -1320,9 +1319,6 @@ int main() {
 
   // accessor<T> to accessor<const T> implicit conversion.
   {
-    using ResAccT = sycl::accessor<int, 1, sycl::access::mode::read_write>;
-    using AccT = sycl::accessor<int, 1, sycl::access::mode::read>;
-
     int data = 123;
     int result = 0;
     {
@@ -1341,9 +1337,6 @@ int main() {
   }
 
   {
-    using ResAccT = sycl::accessor<int, 1, sycl::access::mode::read_write>;
-    using AccT = sycl::accessor<int, 1, sycl::access::mode::read>;
-    using AccCT = sycl::accessor<const int, 1, sycl::access::mode::read>;
     const int data = 123;
     int result = 0;
 
@@ -1367,9 +1360,6 @@ int main() {
 
   // accessor swap
   {
-    using ResAccT = sycl::accessor<int, 1, sycl::access::mode::read_write>;
-    using AccT = sycl::accessor<int, 1, sycl::access::mode::read>;
-
     int data[2] = {2, 100};
     int data2[2] = {23, 4};
     int results[2] = {0, 0};

--- a/sycl/test-e2e/Basic/accessor/accessor.cpp
+++ b/sycl/test-e2e/Basic/accessor/accessor.cpp
@@ -1340,6 +1340,7 @@ int main() {
     const int data = 123;
     int result = 0;
 
+    // accessor<const T, read_only> to accessor<T, read_only> implicit conversion.
     {
       sycl::buffer<const int, 1> data_buf(&data, 1);
       sycl::buffer<int, 1> res_buf(&result, 1);


### PR DESCRIPTION
* Modifies accessor::ConcreteASPtrType to be `const` for `readonly` accessor to fix failing case where copying accessor<const T>::MData does not compile when src type is `const` and dest is `non-const`.
* Add test 