### PR TITLE
[SYCL][UR][L0] Fix casting in UR for boolean

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_device.cpp
@@ -131,8 +131,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(
   }
   case UR_DEVICE_INFO_ATOMIC_64:
     return ReturnValue(
-        static_cast<ur_bool_t>(Device->ZeDeviceModuleProperties->flags &
-                               ZE_DEVICE_MODULE_FLAG_INT64_ATOMICS));
+        static_cast<uint32_t>(Device->ZeDeviceModuleProperties->flags &
+                              ZE_DEVICE_MODULE_FLAG_INT64_ATOMICS));
   case UR_DEVICE_INFO_EXTENSIONS: {
     // Convention adopted from OpenCL:
     //     "Returns a space separated list of extension names (the extension
@@ -196,9 +196,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(
   case UR_DEVICE_INFO_BUILD_ON_SUBDEVICE:
     return ReturnValue(uint32_t{0});
   case UR_DEVICE_INFO_COMPILER_AVAILABLE:
-    return ReturnValue(static_cast<ur_bool_t>(true));
+    return ReturnValue(static_cast<uint32_t>(true));
   case UR_DEVICE_INFO_LINKER_AVAILABLE:
-    return ReturnValue(static_cast<ur_bool_t>(true));
+    return ReturnValue(static_cast<uint32_t>(true));
   case UR_DEVICE_INFO_MAX_COMPUTE_UNITS: {
     uint32_t MaxComputeUnits =
         Device->ZeDeviceProperties->numEUsPerSubslice *
@@ -255,14 +255,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(
     return ReturnValue(
         uint64_t{Device->ZeDeviceComputeProperties->maxSharedLocalMemory});
   case UR_DEVICE_INFO_IMAGE_SUPPORTED:
-    return ReturnValue(static_cast<ur_bool_t>(
+    return ReturnValue(static_cast<uint32_t>(
         Device->ZeDeviceImageProperties->maxImageDims1D > 0));
   case UR_DEVICE_INFO_HOST_UNIFIED_MEMORY:
     return ReturnValue(
-        static_cast<ur_bool_t>((Device->ZeDeviceProperties->flags &
-                                ZE_DEVICE_PROPERTY_FLAG_INTEGRATED) != 0));
+        static_cast<uint32_t>((Device->ZeDeviceProperties->flags &
+                               ZE_DEVICE_PROPERTY_FLAG_INTEGRATED) != 0));
   case UR_DEVICE_INFO_AVAILABLE:
-    return ReturnValue(static_cast<ur_bool_t>(ZeDevice ? true : false));
+    return ReturnValue(static_cast<uint32_t>(ZeDevice ? true : false));
   case UR_DEVICE_INFO_VENDOR:
     // TODO: Level-Zero does not return vendor's name at the moment
     // only the ID.
@@ -349,7 +349,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(
   case UR_EXT_DEVICE_INFO_OPENCL_C_VERSION:
     return ReturnValue("");
   case UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC:
-    return ReturnValue(static_cast<ur_bool_t>(true));
+    return ReturnValue(static_cast<uint32_t>(true));
   case UR_DEVICE_INFO_PRINTF_BUFFER_SIZE:
     return ReturnValue(
         size_t{Device->ZeDeviceModuleProperties->printfBufferSize});
@@ -366,10 +366,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(
     return ReturnValue(ur_device_exec_capability_flag_t{
         UR_DEVICE_EXEC_CAPABILITY_FLAG_NATIVE_KERNEL});
   case UR_DEVICE_INFO_ENDIAN_LITTLE:
-    return ReturnValue(static_cast<ur_bool_t>(true));
+    return ReturnValue(static_cast<uint32_t>(true));
   case UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT:
-    return ReturnValue(static_cast<ur_bool_t>(
-        Device->ZeDeviceProperties->flags & ZE_DEVICE_PROPERTY_FLAG_ECC));
+    return ReturnValue(static_cast<uint32_t>(Device->ZeDeviceProperties->flags &
+                                             ZE_DEVICE_PROPERTY_FLAG_ECC));
   case UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION:
     return ReturnValue(
         static_cast<size_t>(Device->ZeDeviceProperties->timerResolution));
@@ -541,7 +541,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(
   }
   case UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS: {
     // TODO: Not supported yet. Needs to be updated after support is added.
-    return ReturnValue(static_cast<ur_bool_t>(false));
+    return ReturnValue(static_cast<uint32_t>(false));
   }
   case UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL: {
     // ze_device_compute_properties.subGroupSizes is in uint32_t whereas the

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_usm.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_usm.cpp
@@ -531,8 +531,8 @@ static ur_result_t USMAllocationMakeResident(
 ur_usm_pool_handle_t_::ur_usm_pool_handle_t_(ur_context_handle_t Context,
                                              ur_usm_pool_desc_t *PoolDesc) {
 
-  zeroInit = static_cast<ur_bool_t>(PoolDesc->flags &
-                                    UR_USM_POOL_FLAG_ZERO_INITIALIZE_BLOCK);
+  zeroInit = static_cast<uint32_t>(PoolDesc->flags &
+                                   UR_USM_POOL_FLAG_ZERO_INITIALIZE_BLOCK);
 
   void *pNext = const_cast<void *>(PoolDesc->pNext);
   while (pNext != nullptr) {


### PR DESCRIPTION
pi_bool is uint32_t and ur_bool_t is uint8_t, so to make sure correct functionality is maintained, use uint32_t as replacement for pi_bool, instead of ur_bool_t.