### PR TITLE
[ESIMD][E2E] Temporarily disable -ffast-math option for 7 LIT tests

### DIFF
--- a/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_core.cpp
+++ b/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_core.cpp
@@ -8,7 +8,7 @@
 // TODO: remove fno-fast-math option once a compiler issue resulting
 // incorrect execution results when using fast-math is resolved.
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
-// RUN: %{build} -fsycl-device-code-split=per_kernel %{mathflags} -o %t.out 
+// RUN: %{build} -fsycl-device-code-split=per_kernel %{mathflags} -o %t.out
 // RUN: %{run} %t.out
 //
 // Test for simd fill constructor for core types.

--- a/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_core.cpp
+++ b/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_core.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
+// TODO: remove fno-fast-math option once a compiler issue is resolved
+// RUN: %{build} -fno-fast-math -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 //
 // Test for simd fill constructor for core types.

--- a/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_core.cpp
+++ b/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_core.cpp
@@ -146,4 +146,3 @@ int main(int, char **) {
   std::cout << (passed ? "=== Test passed\n" : "=== Test FAILED\n");
   return passed ? 0 : 1;
 }
-

--- a/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_core.cpp
+++ b/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_core.cpp
@@ -5,8 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO: remove fno-fast-math option once a compiler issue is resolved
-// RUN: %{build} -fno-fast-math -fsycl-device-code-split=per_kernel -o %t.out
+// TODO: remove fno-fast-math option once a compiler issue resulting
+// incorrect execution results when using fast-math is resolved.
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+// RUN: %{build} -fsycl-device-code-split=per_kernel %{mathflags} -o %t.out 
 // RUN: %{run} %t.out
 //
 // Test for simd fill constructor for core types.
@@ -144,3 +146,4 @@ int main(int, char **) {
   std::cout << (passed ? "=== Test passed\n" : "=== Test FAILED\n");
   return passed ? 0 : 1;
 }
+

--- a/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_core.cpp
+++ b/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_core.cpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO: remove fno-fast-math option once a compiler issue resulting
-// incorrect execution results when using fast-math is resolved.
+// TODO: remove fno-fast-math option once the issue is investigated and the test
+// is fixed.
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 // RUN: %{build} -fsycl-device-code-split=per_kernel %{mathflags} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_fp_extra.cpp
+++ b/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_fp_extra.cpp
@@ -5,8 +5,10 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO: remove fno-fast-math option once a compiler issue is resolved
-// RUN: %{build} -fno-fast-math -fsycl-device-code-split=per_kernel -o %t.out
+// TODO: remove fno-fast-math option once a compiler issue resulting
+// incorrect execution results when using fast-math is resolved.
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+// RUN: %{build} -fsycl-device-code-split=per_kernel %{mathflags} -o %t.out
 // RUN: %{run} %t.out
 //
 // Test for simd fill constructor for extra fp types.

--- a/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_fp_extra.cpp
+++ b/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_fp_extra.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
+// TODO: remove fno-fast-math option once a compiler issue is resolved
+// RUN: %{build} -fno-fast-math -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 //
 // Test for simd fill constructor for extra fp types.

--- a/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_fp_extra.cpp
+++ b/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_fp_extra.cpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO: remove fno-fast-math option once a compiler issue resulting
-// incorrect execution results when using fast-math is resolved.
+// TODO: remove fno-fast-math option once the issue is investigated and the test
+// is fixed.
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 // RUN: %{build} -fsycl-device-code-split=per_kernel %{mathflags} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/api/replicate_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/api/replicate_smoke.cpp
@@ -6,7 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: gpu-intel-pvc
-// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
+// TODO: remove fno-fast-math option once a compiler issue is resolved
+// RUN: %{build} -fno-fast-math -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 //
 // The test checks main functionality of the esimd::replicate_vs_w_hs function.

--- a/sycl/test-e2e/ESIMD/api/replicate_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/api/replicate_smoke.cpp
@@ -6,8 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: gpu-intel-pvc
-// TODO: remove fno-fast-math option once a compiler issue is resolved
-// RUN: %{build} -fno-fast-math -fsycl-device-code-split=per_kernel -o %t.out
+// TODO: remove fno-fast-math option once a compiler issue resulting
+// incorrect execution results when using fast-math is resolved.
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+// RUN: %{build} -fsycl-device-code-split=per_kernel %{mathflags} -o %t.out
 // RUN: %{run} %t.out
 //
 // The test checks main functionality of the esimd::replicate_vs_w_hs function.

--- a/sycl/test-e2e/ESIMD/api/replicate_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/api/replicate_smoke.cpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: gpu-intel-pvc
-// TODO: remove fno-fast-math option once a compiler issue resulting
-// incorrect execution results when using fast-math is resolved.
+// TODO: remove fno-fast-math option once the issue is investigated and the test
+// is fixed.
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 // RUN: %{build} -fsycl-device-code-split=per_kernel %{mathflags} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/api/saturation_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/api/saturation_smoke.cpp
@@ -7,8 +7,10 @@
 //===----------------------------------------------------------------------===//
 // TODO: esimd_emulator fails due to unimplemented 'half' type
 // XFAIL: esimd_emulator
-// TODO: remove fno-fast-math option once a compiler issue is resolved
-// RUN: %{build} -fno-fast-math -fsycl-device-code-split=per_kernel -o %t.out
+// TODO: remove fno-fast-math option once a compiler issue resulting
+// incorrect execution results when using fast-math is resolved.
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+// RUN: %{build} -fsycl-device-code-split=per_kernel %{mathflags} -o %t.out
 // RUN: %{run} %t.out
 //
 // The test checks main functionality of esimd::saturate function.

--- a/sycl/test-e2e/ESIMD/api/saturation_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/api/saturation_smoke.cpp
@@ -7,7 +7,8 @@
 //===----------------------------------------------------------------------===//
 // TODO: esimd_emulator fails due to unimplemented 'half' type
 // XFAIL: esimd_emulator
-// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
+// TODO: remove fno-fast-math option once a compiler issue is resolved
+// RUN: %{build} -fno-fast-math -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 //
 // The test checks main functionality of esimd::saturate function.

--- a/sycl/test-e2e/ESIMD/api/saturation_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/api/saturation_smoke.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 // TODO: esimd_emulator fails due to unimplemented 'half' type
 // XFAIL: esimd_emulator
-// TODO: remove fno-fast-math option once a compiler issue resulting
-// incorrect execution results when using fast-math is resolved.
+// TODO: remove fno-fast-math option once the issue is investigated and the test
+// is fixed.
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 // RUN: %{build} -fsycl-device-code-split=per_kernel %{mathflags} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot.cpp
+++ b/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot.cpp
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-
+// TODO: remove fno-fast-math option once a compiler issue is resolved
 // REQUIRES: aspect-ext_intel_legacy_image
-// RUN: %{build} -I%S/.. -o %t.out
+// RUN: %{build} -fno-fast-math -I%S/.. -o %t.out
 // RUN: %{run} %t.out %T/output.ppm %S/golden_hw.ppm
 
 #include "esimd_test_utils.hpp"

--- a/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot.cpp
+++ b/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot.cpp
@@ -5,9 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO: remove fno-fast-math option once a compiler issue is resolved
+// TODO: remove fno-fast-math option once a compiler issue resulting
+// incorrect execution results when using fast-math is resolved.
 // REQUIRES: aspect-ext_intel_legacy_image
-// RUN: %{build} -fno-fast-math -I%S/.. -o %t.out
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+// RUN: %{build} %{mathflags} -I%S/.. -o %t.out
 // RUN: %{run} %t.out %T/output.ppm %S/golden_hw.ppm
 
 #include "esimd_test_utils.hpp"

--- a/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot.cpp
+++ b/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot.cpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO: remove fno-fast-math option once a compiler issue resulting
-// incorrect execution results when using fast-math is resolved.
+// TODO: remove fno-fast-math option once the issue is investigated and the test
+// is fixed.
 // REQUIRES: aspect-ext_intel_legacy_image
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 // RUN: %{build} %{mathflags} -I%S/.. -o %t.out

--- a/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot_spec.cpp
+++ b/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot_spec.cpp
@@ -11,7 +11,8 @@
 // REQUIRES: aspect-ext_intel_legacy_image
 // TODO online_compiler check fails for esimd_emulator
 // XFAIL: esimd_emulator
-// RUN: %{build} -I%S/.. -o %t.out
+// TODO: remove fno-fast-math option once a compiler issue is resolved
+// RUN: %{build} -fno-fast-math -I%S/.. -o %t.out
 // RUN: %{run} %t.out %T/output_spec.ppm %S/golden_hw.ppm 512 -2.09798 -1.19798 0.004 4.0
 
 #include "esimd_test_utils.hpp"

--- a/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot_spec.cpp
+++ b/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot_spec.cpp
@@ -11,8 +11,10 @@
 // REQUIRES: aspect-ext_intel_legacy_image
 // TODO online_compiler check fails for esimd_emulator
 // XFAIL: esimd_emulator
-// TODO: remove fno-fast-math option once a compiler issue is resolved
-// RUN: %{build} -fno-fast-math -I%S/.. -o %t.out
+// TODO: remove fno-fast-math option once a compiler issue resulting
+// incorrect execution results when using fast-math is resolved.
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+// RUN: %{build} %{mathflags} -I%S/.. -o %t.out
 // RUN: %{run} %t.out %T/output_spec.ppm %S/golden_hw.ppm 512 -2.09798 -1.19798 0.004 4.0
 
 #include "esimd_test_utils.hpp"

--- a/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot_spec.cpp
+++ b/sycl/test-e2e/ESIMD/mandelbrot/mandelbrot_spec.cpp
@@ -11,8 +11,8 @@
 // REQUIRES: aspect-ext_intel_legacy_image
 // TODO online_compiler check fails for esimd_emulator
 // XFAIL: esimd_emulator
-// TODO: remove fno-fast-math option once a compiler issue resulting
-// incorrect execution results when using fast-math is resolved.
+// TODO: remove fno-fast-math option once the issue is investigated and the test
+// is fixed.
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 // RUN: %{build} %{mathflags} -I%S/.. -o %t.out
 // RUN: %{run} %t.out %T/output_spec.ppm %S/golden_hw.ppm 512 -2.09798 -1.19798 0.004 4.0

--- a/sycl/test-e2e/ESIMD/regression/dgetrf.cpp
+++ b/sycl/test-e2e/ESIMD/regression/dgetrf.cpp
@@ -5,9 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-
+// TODO: remove fno-fast-math option once a compiler issue is resolved
 // UNSUPPORTED: esimd_emulator
-// RUN: %{build} -I%S/.. -o %t.out
+// RUN: %{build} -fno-fast-math -I%S/.. -o %t.out
 // RUN: %{run} %t.out 3 2 1
 //
 // This test checks the correctness of ESIMD program for batched LU

--- a/sycl/test-e2e/ESIMD/regression/dgetrf.cpp
+++ b/sycl/test-e2e/ESIMD/regression/dgetrf.cpp
@@ -5,9 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO: remove fno-fast-math option once a compiler issue is resolved
+// TODO: remove fno-fast-math option once a compiler issue resulting
+// incorrect execution results when using fast-math is resolved.
 // UNSUPPORTED: esimd_emulator
-// RUN: %{build} -fno-fast-math -I%S/.. -o %t.out
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+// RUN: %{build} %{mathflags} -I%S/.. -o %t.out
 // RUN: %{run} %t.out 3 2 1
 //
 // This test checks the correctness of ESIMD program for batched LU

--- a/sycl/test-e2e/ESIMD/regression/dgetrf.cpp
+++ b/sycl/test-e2e/ESIMD/regression/dgetrf.cpp
@@ -5,8 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO: remove fno-fast-math option once a compiler issue resulting
-// incorrect execution results when using fast-math is resolved.
+// TODO: remove fno-fast-math option once the issue is investigated and the test
+// is fixed.
 // UNSUPPORTED: esimd_emulator
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 // RUN: %{build} %{mathflags} -I%S/.. -o %t.out

--- a/sycl/test-e2e/ESIMD/regression/math_const_fix_test.cpp
+++ b/sycl/test-e2e/ESIMD/regression/math_const_fix_test.cpp
@@ -1,6 +1,6 @@
-// RUN: %{build} -o %t.out
+// TODO: remove fno-fast-math option once a compiler issue is resolved
+// RUN: %{build} -fno-fast-math -o %t.out
 // RUN: %{run} %t.out
-
 //==- math_const_fix_test.cpp - Test to verify math functions correctness-==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/ESIMD/regression/math_const_fix_test.cpp
+++ b/sycl/test-e2e/ESIMD/regression/math_const_fix_test.cpp
@@ -1,4 +1,4 @@
-// TODO: remove fno-fast-math option once a compiler issue resulting 
+// TODO: remove fno-fast-math option once a compiler issue resulting
 // incorrect execution results when using fast-math is resolved.
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 // RUN: %{build} %{mathflags} -o %t.out

--- a/sycl/test-e2e/ESIMD/regression/math_const_fix_test.cpp
+++ b/sycl/test-e2e/ESIMD/regression/math_const_fix_test.cpp
@@ -1,5 +1,7 @@
-// TODO: remove fno-fast-math option once a compiler issue is resolved
-// RUN: %{build} -fno-fast-math -o %t.out
+// TODO: remove fno-fast-math option once a compiler issue resulting 
+// incorrect execution results when using fast-math is resolved.
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+// RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out
 //==- math_const_fix_test.cpp - Test to verify math functions correctness-==//
 //

--- a/sycl/test-e2e/ESIMD/regression/math_const_fix_test.cpp
+++ b/sycl/test-e2e/ESIMD/regression/math_const_fix_test.cpp
@@ -1,5 +1,5 @@
-// TODO: remove fno-fast-math option once a compiler issue resulting
-// incorrect execution results when using fast-math is resolved.
+// TODO: remove fno-fast-math option once the issue is investigated and the test
+// is fixed.
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 // RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
This PR is a work around for tests failing when compiled with icpx and succeeding when compiled with clang++. The root cause of that behavior is fast-math option that is enabled by default when using icpx and disabled by default when using clang++.  As a work around the affected tests will be compiled with no-fast-math option.