### PR TITLE
[ESIMD][LIT] Fix usage of -fno-fast-math and -fno-slp-vectorize with cl

### DIFF
--- a/sycl/test-e2e/ESIMD/ext_math.cpp
+++ b/sycl/test-e2e/ESIMD/ext_math.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// RUN: %{build} -fsycl-device-code-split=per_kernel -fno-fast-math -o %t.out
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+// RUN: %{build} -fsycl-device-code-split=per_kernel %{mathflags} -o %t.out
 // RUN: %{run} %t.out
 
 // This test checks extended math operations. Combinations of

--- a/sycl/test-e2e/ESIMD/ext_math_fast.cpp
+++ b/sycl/test-e2e/ESIMD/ext_math_fast.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// RUN: %{build} -fsycl-device-code-split=per_kernel -ffast-math -fno-slp-vectorize -o %t.out
+// DEFINE: %{slpflags} = %if cl_options %{/clang:-fno-slp-vectorize%} %else %{-fno-slp-vectorize%}
+// RUN: %{build} -fsycl-device-code-split=per_kernel -ffast-math %{slpflags} -o %t.out
 // RUN: %{run} %t.out
 
 // This test checks extended math operations. Combinations of


### PR DESCRIPTION
clang-cl driver does not understand -fno-fast-math and -fno-slp-vectorize. Usage of those options requires adding "/clang:" before the option.