### PR TITLE
[SYCL-MLIR][NFC] Add dependency on mlir-translate

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -308,6 +308,7 @@ add_custom_target(sycl-compiler
           llvm-spirv
           llvm-link
           llvm-objcopy
+          mlir-translate
           spirv-to-ir-wrapper
           sycl-post-link
           opencl-aot


### PR DESCRIPTION
For the host raising, we use `mlir-translate` to raise from LLVM IR to MLIR when the `-fsycl-raise-host` option is passed. 

Therefore, the CMake target `sycl-toolchain`/`sycl-compiler` must have a dependency on `mlir-translate` to make sure the latest version is available for the SYCL compilation flow. 