### PR TITLE
[SYCL] Lost data during implicit conversion in local and host accessors.

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -1340,6 +1340,8 @@ public:
             /*IsPlaceH=*/true,
             /*OffsetInBytes=*/0, /*IsSubBuffer=*/false, /*PropertyList=*/{}){};
 
+  template <typename, int, access_mode> friend class host_accessor;
+
 #endif // __SYCL_DEVICE_ONLY__
 
 private:
@@ -2948,6 +2950,9 @@ public:
                 std::is_same_v<DataT_, std::remove_const_t<DataT>>>>
   local_accessor(const local_accessor<DataT_, Dimensions> &other) {
     local_acc::impl = other.impl;
+#ifdef __SYCL_DEVICE_ONLY__
+    local_acc::MData = other.MData;
+#endif
   }
 
   using value_type = DataT;
@@ -3417,9 +3422,11 @@ public:
                                std::remove_const_t<DataT>>>>
   host_accessor(const host_accessor<DataT_, Dimensions, AccessMode> &other)
 #ifndef __SYCL_DEVICE_ONLY__
-      : host_accessor(other.impl)
-#endif // __SYCL_DEVICE_ONLY__
+      : host_accessor(other.impl) {
+    AccessorT::MAccData = other.MAccData;
+#else
   {
+#endif // __SYCL_DEVICE_ONLY__
   }
 
   // implicit conversion from read_write T accessor to read only T (const)
@@ -3430,9 +3437,11 @@ public:
                 std::is_same_v<DataT_, std::remove_const_t<DataT>>>>
   host_accessor(const host_accessor<DataT_, Dimensions, AccessMode_> &other)
 #ifndef __SYCL_DEVICE_ONLY__
-      : host_accessor(other.impl)
-#endif // __SYCL_DEVICE_ONLY__
+      : host_accessor(other.impl) {
+    AccessorT::MAccData = other.MAccData;
+#else
   {
+#endif // __SYCL_DEVICE_ONLY__
   }
 
   // host_accessor needs to explicitly define the owner_before member functions

--- a/sycl/test-e2e/Basic/accessor/accessor.cpp
+++ b/sycl/test-e2e/Basic/accessor/accessor.cpp
@@ -76,6 +76,18 @@ void implicit_conversion(const AccT &acc, const ResAccT &res_acc) {
   res_acc[0] = v;
 }
 
+void implicit_conversion(const sycl::local_accessor<const int, 1> &acc,
+                         const ResAccT &res_acc) {
+  auto v = acc[0];
+  res_acc[0] = v;
+}
+
+int implicit_conversion(
+    const sycl::host_accessor<const int, 1, sycl::access_mode::read> &acc) {
+  auto v = acc[0];
+  return v;
+}
+
 template <typename T> void TestAccSizeFuncs(const std::vector<T> &vec) {
   auto test = [=](auto &Res, const auto &Acc) {
     Res[0] = Acc.byte_size();
@@ -1340,7 +1352,8 @@ int main() {
     const int data = 123;
     int result = 0;
 
-    // accessor<const T, read_only> to accessor<T, read_only> implicit conversion.
+    // accessor<const T, read_only> to accessor<T, read_only> implicit
+    // conversion.
     {
       sycl::buffer<const int, 1> data_buf(&data, 1);
       sycl::buffer<int, 1> res_buf(&result, 1);
@@ -1357,6 +1370,37 @@ int main() {
           .wait_and_throw();
     }
     assert(result == 123 && "Expected value not seen.");
+  }
+
+  // local_accessor<T> to local_accessor<const T> implicit conversion.
+  {
+    int data = 123;
+    int result = 0;
+    {
+      sycl::buffer<int, 1> res_buf(&result, 1);
+      sycl::queue queue;
+      queue
+          .submit([&](sycl::handler &cgh) {
+            ResAccT res_acc = res_buf.get_access(cgh);
+            sycl::local_accessor<int, 1> locAcc(1, cgh);
+            cgh.parallel_for(sycl::nd_range<1>{1, 1}, [=](sycl::nd_item<1>) {
+              locAcc[0] = 123;
+              implicit_conversion(locAcc, res_acc);
+            });
+          })
+          .wait_and_throw();
+    }
+    assert(result == 123 && "Expected value not seen.");
+  }
+
+  // host_accessor<T, read_write> to host_accessor<const T, read> implicit
+  // conversion.
+  {
+    int data = -1;
+    sycl::buffer<int, 1> d(&data, sycl::range<1>(1));
+    sycl::host_accessor host_acc(d, sycl::read_write);
+    host_acc[0] = 399;
+    assert(implicit_conversion(host_acc) == 399);
   }
 
   // accessor swap


### PR DESCRIPTION
* Fix local_accessor and host_accessor lost data during implicit conversion.
* Add relevant test.