### PR TITLE
[SYCL-MLIR] Refine isPromotable for polygeist mem2reg

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Transforms/Mem2Reg.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/Mem2Reg.cpp
@@ -1857,7 +1857,7 @@ bool isPromotable(mlir::Value AI) {
   while (list.size()) {
     auto val = list.front();
     list.pop_front();
-    assert(AI.getDefiningOp());
+    assert(AI.getDefiningOp() && "allocation unknown");
     auto elemType = getElementType(AI.getDefiningOp());
     for (auto *U : val.getUsers()) {
       if (auto LO = dyn_cast<memref::LoadOp>(U)) {

--- a/polygeist/test/polygeist-opt/llvmmem2reg.mlir
+++ b/polygeist/test/polygeist-opt/llvmmem2reg.mlir
@@ -14,3 +14,27 @@ module {
 // CHECK-NEXT:     %c1_i64 = arith.constant 1 : i64
 // CHECK-NEXT:     return %arg0 : !llvm.ptr
 // CHECK-NEXT:   }
+
+// -----
+
+// COM: For the following example, mem2reg should not perform promotion of the
+//      alloca, as the types of the store and load do not match the allocatd
+//      type.
+module {
+  func.func @no_promotion(%arg0 : f32) -> i32 {
+    %0 = llvm.mlir.constant(1 : i32) : i32
+    %1 = llvm.alloca %0 x !llvm.struct<"union.anon", (i32)> {alignment = 4 : i64} : (i32) -> !llvm.ptr
+    llvm.store %arg0, %1 {alignment = 4 : i64} : f32, !llvm.ptr
+    %2 = llvm.load %1 {alignment = 4 : i64} : !llvm.ptr -> i32
+    llvm.return %2 : i32
+  }
+}
+
+// CHECK-LABEL:   func.func @no_promotion(
+// CHECK-SAME:                            %[[VAL_0:.*]]: f32) -> i32 {
+// CHECK:           %[[VAL_1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:           %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<"union.anon", (i32)> {alignment = 4 : i64} : (i32) -> !llvm.ptr
+// CHECK:           llvm.store %[[VAL_0]], %[[VAL_2]] {alignment = 4 : i64} : f32, !llvm.ptr
+// CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_2]] {alignment = 4 : i64} : !llvm.ptr -> i32
+// CHECK:           llvm.return %[[VAL_3]] : i32
+// CHECK:         }


### PR DESCRIPTION
Polygeist's `mem2reg` pass currently allows allocations to be promoted even if load or store operations access a different type than allocated. This is problematic, as loads cannot be replaced by values of a different type. 

This change therefore further restricts which allocations can be promoted and only allows promotion if all loads/stores use the allocated type. This matches the implementation of LLVM's `mem2reg`.