### PR TITLE
[SYCL][ESIMD] Fix gather/scatter with accessors when passing scalar

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -521,7 +521,6 @@ gather_impl(AccessorTy acc, simd<uint32_t, N> offsets, uint32_t glob_offset,
 ///   \c float.
 /// @tparam N The number of vector elements. Can be \c 1, \c 8, \c 16 or \c 32.
 /// @tparam AccessorTy The accessor type.
-/// @tparam Toffset The offset type.
 /// @param acc The accessor to gather from.
 /// @param offsets Per-element offsets in bytes.
 /// @param glob_offset Offset in bytes added to each individual element's offset
@@ -530,16 +529,16 @@ gather_impl(AccessorTy acc, simd<uint32_t, N> offsets, uint32_t glob_offset,
 ///   predicate are not accessed, their values in the resulting vector are
 ///   undefined.
 ///
-template <typename T, int N, typename AccessorTy, typename Toffset>
-__ESIMD_API std::enable_if_t<
-    (sizeof(T) <= 4) && (N == 1 || N == 8 || N == 16 || N == 32) &&
-        !std::is_pointer<AccessorTy>::value && std::is_integral_v<Toffset>,
-    simd<T, N>>
-gather(AccessorTy acc, simd<Toffset, N> offsets,
+template <typename T, int N, typename AccessorTy>
+__ESIMD_API std::enable_if_t<(sizeof(T) <= 4) &&
+                                 (N == 1 || N == 8 || N == 16 || N == 32) &&
+                                 !std::is_pointer<AccessorTy>::value,
+                             simd<T, N>>
+gather(AccessorTy acc,
 #ifdef __ESIMD_FORCE_STATELESS_MEM
-       uint64_t glob_offset = 0,
+       simd<uint64_t, N> offsets, uint64_t glob_offset = 0,
 #else
-       uint32_t glob_offset = 0,
+       simd<uint32_t, N> offsets, uint32_t glob_offset = 0,
 #endif
        simd_mask<N> mask = 1) {
 #ifdef __ESIMD_FORCE_STATELESS_MEM
@@ -560,7 +559,6 @@ gather(AccessorTy acc, simd<Toffset, N> offsets,
 ///   \c float.
 /// @tparam N The number of vector elements. Can be \c 1, \c 8, \c 16 or \c 32.
 /// @tparam AccessorTy The accessor type.
-/// @tparam Toffset The offset type.
 /// @param acc The accessor to scatter to.
 /// @param offsets Per-element offsets in bytes.
 /// @param vals Values to write.
@@ -570,11 +568,17 @@ gather(AccessorTy acc, simd<Toffset, N> offsets,
 ///   predicate are not accessed.
 ///
 ///
-template <typename T, int N, typename AccessorTy, typename Toffset>
-__ESIMD_API std::enable_if_t<
-    (sizeof(T) <= 4) && (N == 1 || N == 8 || N == 16 || N == 32) &&
-    !std::is_pointer<AccessorTy>::value && std::is_integral_v<Toffset>>
-scatter(AccessorTy acc, simd<Toffset, N> offsets, simd<T, N> vals,
+template <typename T, int N, typename AccessorTy>
+__ESIMD_API std::enable_if_t<(sizeof(T) <= 4) &&
+                             (N == 1 || N == 8 || N == 16 || N == 32) &&
+                             !std::is_pointer<AccessorTy>::value>
+scatter(AccessorTy acc,
+#ifdef __ESIMD_FORCE_STATELESS_MEM
+        simd<uint64_t, N> offsets,
+#else
+        simd<uint32_t, N> offsets,
+#endif
+        simd<T, N> vals,
 #ifdef __ESIMD_FORCE_STATELESS_MEM
         uint64_t glob_offset = 0,
 #else

--- a/sycl/test/esimd/gather_scatter.cpp
+++ b/sycl/test/esimd/gather_scatter.cpp
@@ -1,6 +1,9 @@
 // RUN: %clangxx -fsycl -fsycl-device-only -fsyntax-only -Xclang -verify %s
 // expected-no-diagnostics
 
+// RUN: %clangxx -fsycl -fsycl-device-only -fsyntax-only -fsycl-esimd-force-stateless-mem -Xclang -verify %s
+// expected-no-diagnostics
+
 #include <limits>
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>
@@ -50,4 +53,13 @@ void kernel(accessor<uint16_t, 1, access::mode::read_write,
   v0 = convert<uint16_t>(v0 + v1);
 
   scatter<uint16_t, 32>(buf, offsets, v0);
+}
+
+void conv_kernel(accessor<uint16_t, 1, access::mode::read_write,
+                          access::target::device> &buf) SYCL_ESIMD_FUNCTION {
+
+  // Make sure we can pass offsets as a scalar.
+  simd<uint16_t, 32> v0 = gather<uint16_t, 32>(buf, 0);
+
+  scatter<uint16_t, 32>(buf, 0, v0);
 }


### PR DESCRIPTION
This regressed in https://github.com/intel/llvm/commit/d04ebb03c1c891077974622c99027a72bad34b71 when we added a template arg. Since we have a template arg, we won't also call the constructor.