### PR TITLE
[SYCL][CI] Improve compression performance

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -177,12 +177,12 @@ jobs:
         cmake --build $GITHUB_WORKSPACE/build --target install-compiler-rt
 
     - name: Pack toolchain
-      run: tar -cJf llvm_sycl.tar.xz -C $GITHUB_WORKSPACE/build/install .
+      run: tar -I 'zstd -9' -cf llvm_sycl.tar.zst -C $GITHUB_WORKSPACE/build/install .
     - name: Upload toolchain
       uses: actions/upload-artifact@v3
       with:
         name: sycl_linux_${{ inputs.build_artifact_suffix }}
-        path: llvm_sycl.tar.xz
+        path: llvm_sycl.tar.zst
 
   aws-start:
     name: Start AWS
@@ -250,7 +250,7 @@ jobs:
       name: Run SYCL End-to-End tests
       with:
         sycl_artifact: sycl_linux_${{ inputs.build_artifact_suffix }}
-        sycl_archive: llvm_sycl.tar.xz
+        sycl_archive: llvm_sycl.tar.zst
         targets: ${{ matrix.targets }}
         cmake_args: '${{ matrix.cmake_args }} ${{ inputs.lts_cmake_extra_args }}'
 
@@ -296,7 +296,7 @@ jobs:
       with:
         test_ref: ${{ inputs.cts_ref }}
         sycl_artifact: sycl_linux_${{ inputs.build_artifact_suffix }}
-        sycl_archive: llvm_sycl.tar.xz
+        sycl_archive: llvm_sycl.tar.zst
         sycl_device_filter: ${{ matrix.sycl_device_filter }}
         cmake_args: '${{ matrix.cmake_args }} ${{ inputs.cts_cmake_extra_args }}'
 

--- a/devops/actions/e2e-tests/action.yml
+++ b/devops/actions/e2e-tests/action.yml
@@ -7,7 +7,7 @@ inputs:
   sycl_archive:
     description: 'Name of SYCL toolchain archive file'
     required: false
-    default: 'llvm_sycl.tar.xz'
+    default: 'llvm_sycl.tar.zst'
   targets:
     description: 'List of SYCL backends with set of target devices per each to be tested iteratively'
     required: true
@@ -30,7 +30,7 @@ runs:
     shell: bash
     run: |
       mkdir toolchain
-      tar -xf ${{ inputs.sycl_archive }} -C toolchain
+      tar -I 'zstd -d' -xf ${{ inputs.sycl_archive }} -C toolchain
       rm -f ${{ inputs.sycl_archive }}
   - name: Configure
     shell: bash

--- a/devops/actions/khronos_cts_test/action.yml
+++ b/devops/actions/khronos_cts_test/action.yml
@@ -11,7 +11,7 @@ inputs:
   sycl_archive:
     description: 'Name of SYCL toolchain archive file'
     required: false
-    default: 'llvm_sycl.tar.xz'
+    default: 'llvm_sycl.tar.zst'
   sycl_device_filter:
     description: 'List of SYCL backends with set of target devices per each to be tested iteratively'
     required: true
@@ -49,7 +49,7 @@ runs:
     shell: bash
     run: |
       mkdir toolchain
-      tar -xf ${{ inputs.sycl_archive }} -C toolchain
+      tar -I 'zstd -d' -xf ${{ inputs.sycl_archive }} -C toolchain
       rm -f ${{ inputs.sycl_archive }}
   - name: Build SYCL-CTS
     shell: bash

--- a/devops/containers/ubuntu2204_preinstalled.Dockerfile
+++ b/devops/containers/ubuntu2204_preinstalled.Dockerfile
@@ -5,7 +5,8 @@ FROM $base_image:$base_tag
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 RUN mkdir -p /opt/sycl
-ADD llvm_sycl.tar.xz /opt/sycl
+ADD llvm_sycl.tar.zst /tmp
+RUN tar -I 'zstd -d' -xf /tmp/llvm_sycl.tar.zst -C /opt/sycl && rm /tmp/llvm_sycl.tar.zst
 
 ENV PATH /opt/sycl/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/sycl/lib:$LD_LIBRARY_PATH


### PR DESCRIPTION
This was originally implemented in https://github.com/intel/llvm/pull/5678.

Start with Linux only for now. Benchmarking several compression utilities for time/size:


|         | Pack time | Upload time | Size   |
| ------- | --------- | ----------- | ------ |
| xz      | 5m 20s    | 1m 30s      | 350 MB |
| lz4     | 3s        | 3m 10s      | 660 MB |
| zstd -9 | 25s       | 2m 4s       | 467 MB |

The difference in size between xz/lz4 would result in 1m30s -> 3m increase in artifacts upload time so the pack time gain would be partially offset by that.

I don't see a way to get data about unpack from the CI, but locally on a different machine (and likely with a different build) I had this:

|      | Pack time | Unpack time |
| ---- | --------- | ----------- |
| xz   | 28m 30s   | 1m 13s      |
| lz4  | 11s       | 6s          |
| zstd | 1m 22s    | 8s          |

Based on the data above we're switching to use `zstd -9` as our compression algorithm.