### PR TITLE
[SYCL] Make Windows DLLs proxy loader optional

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -152,6 +152,11 @@ if(SYCL_ENABLE_KERNEL_FUSION AND WIN32)
       BOOL "Kernel fusion not yet supported on Windows" FORCE)
 endif()
 
+option(SYCL_ENABLE_WIN_PROXY_LOADER "Enable Windows DLLs proxy loader" ON)
+if (WIN32 AND SYCL_ENABLE_WIN_PROXY_LOADER)
+  add_definitions(-DWIN_PROXY_LOADER=1)
+endif()
+
 # Needed for feature_test.hpp
 if ("cuda" IN_LIST SYCL_ENABLE_PLUGINS)
   set(SYCL_BUILD_PI_CUDA ON)
@@ -361,7 +366,7 @@ add_custom_target( sycl-toolchain
   COMMENT "Building SYCL compiler toolchain..."
 )
 
-if (WIN32)
+if (WIN32 AND SYCL_ENABLE_WIN_PROXY_LOADER)
   add_dependencies(sycl-toolchain pi_win_proxy_loader)
 endif()
 
@@ -397,7 +402,7 @@ add_subdirectory( plugins )
 
 add_subdirectory(tools)
 
-if (WIN32)
+if (WIN32 AND SYCL_ENABLE_WIN_PROXY_LOADER)
   add_subdirectory(pi_win_proxy_loader)
 endif()
 
@@ -446,7 +451,7 @@ set( SYCL_TOOLCHAIN_DEPLOY_COMPONENTS
      ${SYCL_TOOLCHAIN_DEPS}
 )
 
-if (WIN32)
+if (WIN32 AND SYCL_ENABLE_WIN_PROXY_LOADER)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS pi_win_proxy_loader)
 endif()
 

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -72,7 +72,7 @@ function(add_sycl_rt_library LIB_NAME LIB_OBJ_NAME)
   target_include_directories(${LIB_OBJ_NAME} PRIVATE ${BOOST_UNORDERED_INCLUDE_DIRS})
 
   # pi_win_proxy_loader
-  if (WIN32)
+  if (WIN32 AND SYCL_ENABLE_WIN_PROXY_LOADER)
     include_directories(${LLVM_EXTERNAL_SYCL_SOURCE_DIR}/pi_win_proxy_loader)
     if(WIN_DUPE)
       target_link_libraries(${LIB_NAME} PUBLIC pi_win_proxy_loaderd)

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -356,7 +356,16 @@ extern "C" __SYCL_EXPORT BOOL WINAPI DllMain(HINSTANCE hinstDLL,
                    // TODO: figure out what XPTI is doing that prevents release.
 #endif
 
+#ifdef WIN_PROXY_LOADER
     shutdown();
+#else
+    // When handling DLL_PROCESS_DETACH, a DLL should free resources such as
+    // heap memory only if the DLL is being unloaded dynamically
+    // (the lpvReserved parameter is NULL)
+    // https://learn.microsoft.com/en-us/windows/win32/dlls/dllmain
+    if (!lpReserved)
+      shutdown();
+#endif
     break;
   case DLL_PROCESS_ATTACH:
     if (PrintPiTrace)


### PR DESCRIPTION
Customers who don't keep static refs to sycl objects don't specifically need this proxy loader workaround and may want to avoid having to distribute one more DLL.
This change keeps default behavior unchanged, the proxy loader stays enabled by default on Windows.