### PR TITLE
[SYCL][ESIMD][E2E] Fix ext_math_ieee_sqrt_div on emulator

### DIFF
--- a/sycl/test-e2e/ESIMD/ext_math_ieee_sqrt_div.cpp
+++ b/sycl/test-e2e/ESIMD/ext_math_ieee_sqrt_div.cpp
@@ -7,7 +7,8 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu-intel-gen9 || gpu-intel-pvc || esimd_emulator
 
-// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+// RUN: %{build} -fsycl-device-code-split=per_kernel %{mathflags} -o %t.out
 // RUN: %{run} %t.out
 
 // This test checks ieee_sqrt() and ieee_sqrt() with float and double types.


### PR DESCRIPTION
Similar to the other ext_math tests, this needs -fno-fast-math as well.