### PR TITLE
[SYCL-MLIR][LoopInternalization] Obtain local memory

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLAttributes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLAttributes.h
@@ -35,33 +35,16 @@ inline unsigned targetToAddressSpace(Target target) {
   }
 }
 
+/// Class to represent the sycl reqd_work_group_size attribute.
 class ReqdWorkGroupSize {
 public:
-  ReqdWorkGroupSize(ArrayRef<gpu::GPUFuncOp> kernels) {
-    init(kernels.front(), wgSizes);
-    for (gpu::GPUFuncOp kernel : drop_begin(kernels)) {
-      SmallVector<unsigned> wgSizes2;
-      init(kernel, wgSizes2);
-      assert(wgSizes == wgSizes2 && "Expecting same reqd_work_group_size");
-    }
-  }
-  bool empty() const { return wgSizes.empty(); }
-  unsigned operator[](unsigned dim) const {
-    assert(dim < wgSizes.size() && "Expecting valid dim");
-    return wgSizes[wgSizes.size() - 1 - dim];
-  }
+  ReqdWorkGroupSize(ArrayRef<gpu::GPUFuncOp> kernels);
+  bool empty() const;
+  unsigned operator[](unsigned dim) const;
 
 private:
   /// Populate \p wgSizes from kernel \p kernel.
-  static void init(gpu::GPUFuncOp kernel, SmallVector<unsigned> &wgSizes) {
-    if (ArrayAttr wgSizesAttr = dyn_cast_or_null<ArrayAttr>(
-            kernel->getAttr("reqd_work_group_size"))) {
-      for (IntegerAttr wgSizeAttr : wgSizesAttr.getAsRange<IntegerAttr>())
-        wgSizes.push_back(wgSizeAttr.getInt());
-      assert(!wgSizes.empty() && wgSizes.size() <= 3 &&
-             "Expecting non-empty wgSizes of size less than 3");
-    }
-  }
+  static void init(gpu::GPUFuncOp kernel, SmallVectorImpl<unsigned> &wgSizes);
 
   SmallVector<unsigned> wgSizes;
 };

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLAttributes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLAttributes.h
@@ -9,6 +9,7 @@
 #ifndef MLIR_DIALECT_SYCL_IR_SYCLATTRIBUTES_H
 #define MLIR_DIALECT_SYCL_IR_SYCLATTRIBUTES_H
 
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 
@@ -33,6 +34,37 @@ inline unsigned targetToAddressSpace(Target target) {
     llvm_unreachable("Invalid Target for an accessor");
   }
 }
+
+class ReqdWorkGroupSize {
+public:
+  ReqdWorkGroupSize(ArrayRef<gpu::GPUFuncOp> kernels) {
+    init(kernels.front(), wgSizes);
+    for (gpu::GPUFuncOp kernel : drop_begin(kernels)) {
+      SmallVector<unsigned> wgSizes2;
+      init(kernel, wgSizes2);
+      assert(wgSizes == wgSizes2 && "Expecting same reqd_work_group_size");
+    }
+  }
+  bool empty() const { return wgSizes.empty(); }
+  unsigned operator[](unsigned dim) const {
+    assert(dim < wgSizes.size() && "Expecting valid dim");
+    return wgSizes[wgSizes.size() - 1 - dim];
+  }
+
+private:
+  /// Populate \p wgSizes from kernel \p kernel.
+  static void init(gpu::GPUFuncOp kernel, SmallVector<unsigned> &wgSizes) {
+    if (ArrayAttr wgSizesAttr = dyn_cast_or_null<ArrayAttr>(
+            kernel->getAttr("reqd_work_group_size"))) {
+      for (IntegerAttr wgSizeAttr : wgSizesAttr.getAsRange<IntegerAttr>())
+        wgSizes.push_back(wgSizeAttr.getInt());
+      assert(!wgSizes.empty() && wgSizes.size() <= 3 &&
+             "Expecting non-empty wgSizes of size less than 3");
+    }
+  }
+
+  SmallVector<unsigned> wgSizes;
+};
 
 } // namespace sycl
 } // namespace mlir

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.h
@@ -34,4 +34,15 @@ inline bool isSYCLOperation(Operation *op) {
 #define GET_OP_CLASSES
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h.inc"
 
+namespace mlir {
+namespace sycl {
+
+/// Return type of the accessor of \p op.
+inline AccessorType getAccessorType(SYCLAccessorSubscriptOp op) {
+  return sycl::AccessorPtrValue(op.getAcc()).getAccessorType();
+}
+
+} // namespace sycl
+} // namespace mlir
+
 #endif // MLIR_DIALECT_SYCL_IR_SYCLOPS_H

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLAttributes.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLAttributes.cpp
@@ -10,3 +10,34 @@
 
 #include "mlir/Dialect/SYCL/IR/SYCLAttributes.cpp.inc"
 #include "mlir/Dialect/SYCL/IR/SYCLEnums.cpp.inc"
+
+using namespace mlir;
+using namespace mlir::sycl;
+
+ReqdWorkGroupSize::ReqdWorkGroupSize(ArrayRef<gpu::GPUFuncOp> kernels) {
+  init(kernels.front(), wgSizes);
+  for (gpu::GPUFuncOp kernel : drop_begin(kernels)) {
+    SmallVector<unsigned> wgSizes2;
+    init(kernel, wgSizes2);
+    assert(wgSizes == wgSizes2 && "Expecting same reqd_work_group_size");
+  }
+}
+
+bool ReqdWorkGroupSize::empty() const { return wgSizes.empty(); }
+
+unsigned ReqdWorkGroupSize::operator[](unsigned dim) const {
+  assert(dim < wgSizes.size() && "Expecting valid dim");
+  return wgSizes[wgSizes.size() - 1 - dim];
+}
+
+void ReqdWorkGroupSize::init(gpu::GPUFuncOp kernel,
+                             SmallVectorImpl<unsigned> &wgSizes) {
+  assert(wgSizes.empty() && "Expecting empty wgSizes");
+  if (ArrayAttr wgSizesAttr = dyn_cast_or_null<ArrayAttr>(
+          kernel->getAttr("reqd_work_group_size"))) {
+    for (IntegerAttr wgSizeAttr : wgSizesAttr.getAsRange<IntegerAttr>())
+      wgSizes.push_back(wgSizeAttr.getInt());
+    assert(!wgSizes.empty() && wgSizes.size() <= 3 &&
+           "Expecting non-empty wgSizes of size less than 3");
+  }
+}

--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
@@ -135,12 +135,16 @@ def LoopInternalization : Pass<"loop-internalization"> {
     Option<"relaxedAliasing", "relaxed-aliasing", "bool", 
            /*default=*/"false", 
            "Whether to use strict aliasing (i.e. type-based aliasing) rules or not">,
-    Option<"tileSize", "tile-size", "unsigned", /*default=*/"1", "Tile size">
+    Option<"tileSize", "tile-size", "unsigned", /*default=*/"1", "Tile size">,
+    Option<"localMemorySize", "local-memory-size", "unsigned",
+           /*default=*/"32000", "The size of local memory arena in bytes">
   ];
   let statistics = [
     Statistic<"numTiled", "num-tiled", "Number of loops tiled">,
   ];
-  let dependentDialects = ["affine::AffineDialect", "scf::SCFDialect", "spirv::SPIRVDialect"];
+  let dependentDialects =
+      ["affine::AffineDialect", "memref::MemRefDialect", "scf::SCFDialect", 
+       "spirv::SPIRVDialect"];
 }
 
 def SCFBarrierRemovalContinuation : InterfacePass<"barrier-removal-continuation", "FunctionOpInterface"> {

--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -136,12 +136,16 @@ public:
   void getKernelCallers(FunctionOpInterface func,
                         SmallVectorImpl<gpu::GPUFuncOp> &kernels) const;
 
+  /// Returns the kernel body function of \p kernel.
+  FunctionOpInterface getKernelBodyFunc(gpu::GPUFuncOp kernel) const;
+
 private:
-  /// Populate funcKernelCallerMap with the list of GPU kernels that can reach
+  /// Populate funcKernelInfosMap with the list of GPU kernels that can reach
   /// \p func and their associated depth.
   void populateGPUKernelInfo(FunctionOpInterface func);
 
-  DenseMap<FunctionOpInterface, SmallVector<KernelInfo>> funcKernelCallerMap;
+  DenseMap<FunctionOpInterface, SmallVector<KernelInfo>> funcKernelInfosMap;
+  DenseMap<gpu::GPUFuncOp, std::set<FunctionOpInterface>> kernelFuncsMap;
 };
 
 //===----------------------------------------------------------------------===//

--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -136,7 +136,9 @@ public:
   void getKernelCallers(FunctionOpInterface func,
                         SmallVectorImpl<gpu::GPUFuncOp> &kernels) const;
 
-  /// Returns the kernel body function of \p kernel.
+  /// Returns the kernel body function of \p kernel. The kernel body function is
+  /// the lambda/functor associated with the SYCL kernel construct (e.g.,
+  /// parallel_for).
   FunctionOpInterface getKernelBodyFunc(gpu::GPUFuncOp kernel) const;
 
 private:
@@ -144,7 +146,10 @@ private:
   /// \p func and their associated depth.
   void populateGPUKernelInfo(FunctionOpInterface func);
 
+  /// Map from a function to all kernels that can reach it and their
+  /// corresponding depths.
   DenseMap<FunctionOpInterface, SmallVector<KernelInfo>> funcKernelInfosMap;
+  /// Map from a kernel to all functions that can be reached from it.
   DenseMap<gpu::GPUFuncOp, std::set<FunctionOpInterface>> kernelFuncsMap;
 };
 


### PR DESCRIPTION
According to SYCL specification ([section 4.6.4.2](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_device_information_descriptors)), the minimum local memory size is 32KB. 

It first checks if any local memory is used, and calculate the remaining local memory available. 
If there are none, then the transformation is not performed.
Else, it creates a global with the minimum local memory size, or the require local memory if `reqd_work_group_size` is given.