### PR TITLE
[SYCL][CI] Create nightly container based on the "build" image

### DIFF
--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -78,3 +78,16 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:no-drivers-${{ github.sha }}
           ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:no-drivers
+    - name: Build and Push Container (Build image)
+      uses: ./devops/actions/build_container
+      with:
+        push: ${{ github.event_name != 'pull_request' }}
+        file: ubuntu2204_preinstalled
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        build-args: |
+          base_image=ghcr.io/intel/llvm/ubuntu2204_build
+          base_tag=latest
+        tags: |
+          ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:build-${{ github.sha }}
+          ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:build

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -37,12 +37,16 @@ identical for Docker and Podman. Choose whatever is available on your system.
 The following containers are publicly available for DPC++ compiler development:
 
 - `ghcr.io/intel/llvm/ubuntu2204_base`: contains basic environment setup for
-   building DPC++ compiler from source.
+   building SYCL compiler from source.
 - `ghcr.io/intel/llvm/ubuntu2204_intel_drivers`: contains everything from the
    base container + pre-installed Intel drivers.
+- `ghcr.io/intel/llvm/ubuntu2204_build`: has development kits installed for
+   Intel/NVidia/AMD and can be used for building SYCL compiler from source with
+   all backends enabled.
 - `ghcr.io/intel/llvm/sycl_ubuntu2204_nightly`: contains the latest successfully
-   built nightly build of DPC++ compiler. The image comes in two flavors:
-   with pre-installed Intel drivers (`latest`) and without them (`no-drivers`).
+   built nightly build of DPC++ compiler. The image comes in three flavors:
+   with pre-installed Intel drivers (`latest`), without them (`no-drivers`) and
+   with development kits installed (`build`).
 
 ## Running Docker container interactively
 

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -41,8 +41,9 @@ The following containers are publicly available for DPC++ compiler development:
 - `ghcr.io/intel/llvm/ubuntu2204_intel_drivers`: contains everything from the
    base container + pre-installed Intel drivers.
 - `ghcr.io/intel/llvm/ubuntu2204_build`: has development kits installed for
-   Intel/NVidia/AMD and can be used for building DPC++ compiler from source with
-   all backends enabled.
+   NVidia/AMD and can be used for building DPC++ compiler from source with all
+   backends enabled or for end-to-end testing with HIP/CUDA on machines with
+   corresponding GPUs available.
 - `ghcr.io/intel/llvm/sycl_ubuntu2204_nightly`: contains the latest successfully
    built nightly build of DPC++ compiler. The image comes in three flavors:
    with pre-installed Intel drivers (`latest`), without them (`no-drivers`) and

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -37,11 +37,11 @@ identical for Docker and Podman. Choose whatever is available on your system.
 The following containers are publicly available for DPC++ compiler development:
 
 - `ghcr.io/intel/llvm/ubuntu2204_base`: contains basic environment setup for
-   building SYCL compiler from source.
+   building DPC++ compiler from source.
 - `ghcr.io/intel/llvm/ubuntu2204_intel_drivers`: contains everything from the
    base container + pre-installed Intel drivers.
 - `ghcr.io/intel/llvm/ubuntu2204_build`: has development kits installed for
-   Intel/NVidia/AMD and can be used for building SYCL compiler from source with
+   Intel/NVidia/AMD and can be used for building DPC++ compiler from source with
    all backends enabled.
 - `ghcr.io/intel/llvm/sycl_ubuntu2204_nightly`: contains the latest successfully
    built nightly build of DPC++ compiler. The image comes in three flavors:


### PR DESCRIPTION
I plan to use it in post commit to merge two builds

[linux_default](https://github.com/intel/llvm/blob/ac8408c4761180835fb23ccd5183efd5c5c37d95/.github/workflows/sycl_post_commit.yml#L26-L38) and
[self_build](https://github.com/intel/llvm/blob/ac8408c4761180835fb23ccd5183efd5c5c37d95/.github/workflows/sycl_post_commit.yml#L39-L51) into one.

I can also imagine how we can use that in place of [HIP/CUDA image for E2E tests](https://github.com/intel/llvm/blob/24955697d9f08c0bc7e1f2b80182c7d967f53b70/.github/workflows/sycl_gen_test_matrix.yml#L10-L17) for PRs that only update E2E tests.