### PR TITLE
[SYCL][Fusion] Add missing header

### DIFF
--- a/sycl-fusion/common/include/Kernel.h
+++ b/sycl-fusion/common/include/Kernel.h
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
This was causing build failures with some compilers.