### PR TITLE
[SYCL-MLIR] Add support of `sycl::reqd_work_group_size`

### DIFF
--- a/polygeist/tools/cgeist/Test/Verification/sycl/reqd_work_group_size.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/reqd_work_group_size.cpp
@@ -1,0 +1,27 @@
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+
+#include <sycl/sycl.hpp>
+using namespace sycl;
+static constexpr unsigned N = 8;
+
+// CHECK-MLIR-LABEL: parallel_for_id
+// CHECK-SAME:         reqd_work_group_size = [4, 2]
+
+// CHECK-LLVM-LABEL: parallel_for_id
+// CHECK-SAME:         !reqd_work_group_size [[MD:!.*]] {
+// CHECK: [[MD]] = !{i32 4, i32 2}
+
+void parallel_for_id(std::array<int, N * N> &A, queue q) {
+  auto range = sycl::range<2>{N, N};
+
+  {
+    buffer a(A.data(), range);
+    q.submit([&](handler &cgh) {
+      auto A = a.get_access<access::mode::write>(cgh);
+      cgh.parallel_for<class kernel_parallel_for_id>(range, [=](id<2> Id) [[sycl::reqd_work_group_size(2, 4)]] {
+        A[Id] = Id.get(0) + Id.get(1);
+      });
+    });
+  }
+}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/reqd_work_group_size.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/reqd_work_group_size.cpp
@@ -5,10 +5,10 @@
 using namespace sycl;
 static constexpr unsigned N = 8;
 
-// CHECK-MLIR-LABEL: parallel_for_id
+// CHECK-MLIR-LABEL: kernel_parallel_for_id
 // CHECK-SAME:         reqd_work_group_size = [4, 2]
 
-// CHECK-LLVM-LABEL: parallel_for_id
+// CHECK-LLVM-LABEL: kernel_parallel_for_id
 // CHECK-SAME:         !reqd_work_group_size [[MD:!.*]] {
 // CHECK: [[MD]] = !{i32 4, i32 2}
 

--- a/sycl/test-e2e/xfail_tests.txt
+++ b/sycl/test-e2e/xfail_tests.txt
@@ -104,8 +104,6 @@ Basic/image/srgba-read.cpp
 Basic/multi_ptr.cpp
 Basic/multi_ptr_legacy_usm_addr_ext.cpp
 Basic/multi_ptr_usm_addr_ext.cpp
-Basic/reqd_work_group_size.cpp
-Basic/reqd_work_group_size_check_exception.cpp
 Basic/scalar_vec_access.cpp
 Basic/span.cpp
 Basic/stream/auto_flush.cpp
@@ -481,7 +479,6 @@ Sampler/unnormalized-clampedge-linear-float.cpp
 Sampler/unnormalized-clampedge-nearest.cpp
 Sampler/unnormalized-none-linear-float.cpp
 Sampler/unnormalized-none-nearest.cpp
-Scheduler/HandleException.cpp
 SpecConstants/2020/handler-api.cpp
 SpecConstants/2020/host_apis.cpp
 SpecConstants/2020/kernel-bundle-api.cpp


### PR DESCRIPTION
According to https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:kernel.attributes, `reqd_work_group_size` indicates that the kernel must be launched with the specified work-group size. 