### PR TITLE
[SYCL-MLIR] Allow cast to generic for memref call arguments

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -74,6 +74,10 @@ static Value castCallerMemRefArg(Value CallerArg, Type CalleeArgType,
         assert(memref::MemorySpaceCastOp::areCastCompatible(Arg.getType(),
                                                             DstTy) &&
                "Incompatible cast");
+        assert(
+            DstTy.getMemorySpaceAsInt() ==
+                static_cast<unsigned>(sycl::AccessAddrSpace::GenericAccess) &&
+            "Expecting generic address space");
         B.setInsertionPointAfterValue(Arg);
         Arg = B.create<memref::MemorySpaceCastOp>(Arg.getLoc(), DstTy, Arg);
       }

--- a/sycl/test-e2e/xfail_tests.txt
+++ b/sycl/test-e2e/xfail_tests.txt
@@ -133,7 +133,6 @@ DeviceLib/built-ins/marray_integer.cpp
 DeviceLib/built-ins/marray_relational.cpp
 DeviceLib/built-ins/nan.cpp
 DeviceLib/built-ins/printf.cpp
-DeviceLib/built-ins/scalar_math_2.cpp
 DeviceLib/built-ins/scalar_relational.cpp
 DeviceLib/built-ins/vector_integer.cpp
 DeviceLib/built-ins/vector_math.cpp


### PR DESCRIPTION
Allow cast to the generic address space when calling a function with a `memref` argument. Address space casts to the generic address space are legal, so the cast can happen before the function call. 