### PR TITLE
Revert "[SYCL][CI] Cancel in-progress pre_commit job when PR is updated (#9706)"

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -26,10 +26,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   need_check:
     name: Decide which tests could be affected by the changes


### PR DESCRIPTION
This reverts commit 1db96de9f9b394fbed0b8953849108f255dd31d7.

CI seems to be stuck after this PR has been merged.