### PR TITLE
[SYCL] Add tests for SYCL_DUMP_IMAGES/SYCL_USER_KERNEL_SPV

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1461,7 +1461,8 @@ ProgramManager::getKernelSetId(OSModuleHandle M,
 
 void ProgramManager::dumpImage(const RTDeviceBinaryImage &Img, KernelSetId KSId,
                                uint32_t SequenceID) const {
-  std::string Fname("sycl_");
+  const char *Prefix = std::getenv("SYCL_DUMP_IMAGES_PREFIX");
+  std::string Fname(Prefix ? Prefix : "sycl_");
   const pi_device_binary_struct &RawImg = Img.getRawData();
   Fname += RawImg.DeviceTargetSpec;
   Fname += std::to_string(KSId);

--- a/sycl/test-e2e/SPVDumpUse/basic.cpp
+++ b/sycl/test-e2e/SPVDumpUse/basic.cpp
@@ -1,0 +1,34 @@
+// REQUIRES: opencl || level_zero
+//
+// SYCL_USE_KERNEL_SPV assumes no dead arguments elimination, need to produce
+// SPV under the same conditions.
+// RUN: %{build} -fno-sycl-dead-args-optimization -fno-sycl-instrument-device-code -DVALUE=1 -o %t.out
+// RUN: %{run-unfiltered-devices} %t.out | FileCheck %s --check-prefix ONE
+// RUN: env SYCL_DUMP_IMAGES_PREFIX=%t.sycl_ SYCL_DUMP_IMAGES=1 %{run-unfiltered-devices} %t.out | FileCheck %s --check-prefix ONE
+// RUN: env SYCL_USE_KERNEL_SPV=%t.sycl_spir641.spv %{run-unfiltered-devices} %t.out | FileCheck %s --check-prefix ONE
+//
+// This can perform dead arguments elimination, SYCL RT will ignore the
+// ArgElimMask produced by the device compiler.
+// RUN: %{build} -fno-sycl-instrument-device-code -DVALUE=2 -o %t.out
+// RUN: %{run-unfiltered-devices} %t.out | FileCheck %s --check-prefix TWO
+// RUN: env SYCL_USE_KERNEL_SPV=%t.sycl_spir641.spv %{run-unfiltered-devices} %t.out | FileCheck %s --check-prefix ONE
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main() {
+  constexpr int N = 16;
+  buffer<int> b(N);
+  queue q;
+  q.submit([&](handler &cgh) {
+    accessor acc{b, cgh};
+    cgh.parallel_for(nd_range<1>{N, N},
+                     [=](nd_item<1> id) { acc[id.get_global_id(0)] = VALUE; });
+  });
+
+  // ONE: Result: 1
+  // TWO: Result: 2
+  std::cout << "Result: " << host_accessor{b}[0] << std::endl;
+
+  return 0;
+}

--- a/sycl/test-e2e/SPVDumpUse/kernel_bundle.cpp
+++ b/sycl/test-e2e/SPVDumpUse/kernel_bundle.cpp
@@ -1,0 +1,39 @@
+// REQUIRES: opencl || level_zero
+//
+// SYCL_USE_KERNEL_SPV assumes no dead arguments elimination, need to produce
+// SPV under the same conditions.
+// RUN: %{build} -fno-sycl-dead-args-optimization -fno-sycl-instrument-device-code -DVALUE=1 -o %t.out
+// RUN: %{run-unfiltered-devices} %t.out | FileCheck %s --check-prefix ONE
+// RUN: env SYCL_DUMP_IMAGES_PREFIX=%t.sycl_ SYCL_DUMP_IMAGES=1 %{run-unfiltered-devices} %t.out | FileCheck %s --check-prefix ONE
+// RUN: env SYCL_USE_KERNEL_SPV=%t.sycl_spir641.spv %{run-unfiltered-devices} %t.out | FileCheck %s --check-prefix ONE
+//
+// This can perform dead arguments elimination, SYCL RT will ignore the
+// ArgElimMask produced by the device compiler.
+// RUN: %{build} -fno-sycl-instrument-device-code -DVALUE=2 -o %t.out
+// RUN: %{run-unfiltered-devices} %t.out | FileCheck %s --check-prefix TWO
+// FIXME: SYCL_USE_KERNEL_SPV is ignored for kernel_bundles.
+// RUN: env SYCL_USE_KERNEL_SPV=%t.sycl_spir641.spv %{run-unfiltered-devices} %t.out | FileCheck %s --check-prefix TWO
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main() {
+  constexpr int N = 16;
+  buffer<int> b(N);
+  queue q;
+  auto bundle = get_kernel_bundle<bundle_state::executable>(
+      q.get_context(), {q.get_device()}, {get_kernel_id<class KernelName>()});
+  q.submit([&](handler &cgh) {
+    cgh.use_kernel_bundle(bundle);
+    accessor acc{b, cgh};
+    cgh.parallel_for<class KernelName>(nd_range<1>{N, N}, [=](nd_item<1> id) {
+      acc[id.get_global_id(0)] = VALUE;
+    });
+  });
+
+  // ONE: Result: 1
+  // TWO: Result: 2
+  std::cout << "Result: " << host_accessor{b}[0] << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION
That required to introduce an extra environment variable control - `SYCL_DUMP_IMAGES_PREFIX` to control location of the produced images.