### PR TITLE
[SYCL][libdevice] Move fabs, fabs to imf_fp32/64_dl.cpp and add llabs

### DIFF
--- a/libdevice/cmake/modules/ImfSrcConcate.cmake
+++ b/libdevice/cmake/modules/ImfSrcConcate.cmake
@@ -6,7 +6,8 @@ set(imf_fp32_fallback_src_list imf_utils/integer_misc.cpp
                                imf/imf_fp32_dl.cpp)
 
 set(imf_fp64_fallback_src_list imf_utils/double_convert.cpp
-                               imf/imf_inline_fp64.cpp)
+                               imf/imf_inline_fp64.cpp
+                               imf/imf_fp64_dl.cpp)
 
 set(imf_bf16_fallback_src_list imf_utils/bfloat16_convert.cpp
                                imf/imf_inline_bf16.cpp)

--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -151,7 +151,8 @@ set(imf_fallback_fp32_deps device.h device_imf.hpp imf_half.hpp
                            imf/imf_fp32_dl.cpp)
 set(imf_fallback_fp64_deps device.h device_imf.hpp imf_half.hpp
                            imf_utils/double_convert.cpp
-                           imf/imf_inline_fp64.cpp)
+                           imf/imf_inline_fp64.cpp
+                           imf/imf_fp64_dl.cpp)
 set(imf_fallback_bf16_deps device.h device_imf.hpp imf_bf16.hpp
                            imf_utils/bfloat16_convert.cpp
                            imf/imf_inline_bf16.cpp)

--- a/libdevice/imf/imf_fp64_dl.cpp
+++ b/libdevice/imf/imf_fp64_dl.cpp
@@ -1,4 +1,4 @@
-//===----------- imf_fp32_dl.cpp - fp32 functions required by DL ----------===//
+//===----------- imf_fp64_dl.cpp - fp64 functions required by DL ----------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -14,15 +14,8 @@
 #include "../device_imf.hpp"
 #ifdef __LIBDEVICE_IMF_ENABLED__
 
-DEVICE_EXTERN_C_INLINE int32_t __devicelib_imf_abs(int32_t x) {
-  return (x >= 0) ? x : -x;
-}
-
-DEVICE_EXTERN_C_INLINE float __devicelib_imf_fabsf(float x) {
+DEVICE_EXTERN_C_INLINE double __devicelib_imf_fabs(double x) {
   return __fabs(x);
 }
-
-DEVICE_EXTERN_C_INLINE
-int64_t __devicelib_imf_llabs(int64_t x) { return x >= 0 ? x : -x; }
 
 #endif /*__LIBDEVICE_IMF_ENABLED__*/

--- a/libdevice/imf/imf_inline_fp32.cpp
+++ b/libdevice/imf/imf_inline_fp32.cpp
@@ -131,10 +131,6 @@ DEVICE_EXTERN_C_INLINE float __devicelib_imf_fminf(float a, float b) {
   return __fmin(a, b);
 }
 
-DEVICE_EXTERN_C_INLINE float __devicelib_imf_fabsf(float x) {
-  return __fabs(x);
-}
-
 DEVICE_EXTERN_C_INLINE float __devicelib_imf_copysignf(float a, float b) {
   return __copysign(a, b);
 }

--- a/libdevice/imf/imf_inline_fp64.cpp
+++ b/libdevice/imf/imf_inline_fp64.cpp
@@ -51,10 +51,6 @@ DEVICE_EXTERN_C_INLINE double __devicelib_imf_fmin(double a, double b) {
   return __fmin(a, b);
 }
 
-DEVICE_EXTERN_C_INLINE double __devicelib_imf_fabs(double x) {
-  return __fabs(x);
-}
-
 DEVICE_EXTERN_C_INLINE double __devicelib_imf_copysign(double a, double b) {
   return __copysign(a, b);
 }

--- a/libdevice/imf_wrapper.cpp
+++ b/libdevice/imf_wrapper.cpp
@@ -550,6 +550,12 @@ DEVICE_EXTERN_C_INLINE
 int32_t __imf_abs(int32_t x) { return __devicelib_imf_abs(x); }
 
 DEVICE_EXTERN_C_INLINE
+int64_t __devicelib_imf_llabs(int64_t);
+
+DEVICE_EXTERN_C_INLINE
+int64_t __imf_llabs(int64_t x) { return __devicelib_imf_llabs(x); }
+
+DEVICE_EXTERN_C_INLINE
 float __devicelib_imf_fabsf(float);
 
 DEVICE_EXTERN_C_INLINE

--- a/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.cpp
+++ b/llvm/tools/sycl-post-link/SYCLDeviceLibReqMask.cpp
@@ -202,6 +202,7 @@ SYCLDeviceLibFuncMap SDLMap = {
     {"__devicelib_imf_floorf", DeviceLibExt::cl_intel_devicelib_imf},
     {"__devicelib_imf_ceilf", DeviceLibExt::cl_intel_devicelib_imf},
     {"__devicelib_imf_abs", DeviceLibExt::cl_intel_devicelib_imf},
+    {"__devicelib_imf_llabs", DeviceLibExt::cl_intel_devicelib_imf},
     {"__devicelib_imf_fabsf", DeviceLibExt::cl_intel_devicelib_imf},
     {"__devicelib_imf_truncf", DeviceLibExt::cl_intel_devicelib_imf},
     {"__devicelib_imf_rintf", DeviceLibExt::cl_intel_devicelib_imf},

--- a/sycl/include/sycl/builtins.hpp
+++ b/sycl/include/sycl/builtins.hpp
@@ -2699,6 +2699,7 @@ extern __DPCPP_SYCL_EXTERNAL long long int __imf_mul64hi(long long int x,
 extern __DPCPP_SYCL_EXTERNAL unsigned long long int
 __imf_umul64hi(unsigned long long int x, unsigned long long int y);
 extern __DPCPP_SYCL_EXTERNAL int __imf_abs(int x);
+extern __DPCPP_SYCL_EXTERNAL long long int __imf_llabs(long long int x);
 extern __DPCPP_SYCL_EXTERNAL float __imf_saturatef(float x);
 extern __DPCPP_SYCL_EXTERNAL float __imf_fmaf(float x, float y, float z);
 extern __DPCPP_SYCL_EXTERNAL float __imf_fabsf(float x);


### PR DESCRIPTION
fabsf, fabs and llabs are required by deep learning frameworks, so we move fabsf and fabs to separate file imf_fp32/64_dl.cpp and add llabs to imf_fp32_dl.cpp as well.