### PR TITLE
[SYCL][Matrix] Disable joint_matrix_bf16_fill_k_cache.cpp for cpu

### DIFF
--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_unroll.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_unroll.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: matrix
+// XFAIL: cpu
 
 // RUN: %{build} -mllvm -inline-threshold=2000 -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -DMANUAL_UNROLL
 // RUN: %{run} %t.out


### PR DESCRIPTION
we only have 8 tmm in saphirerapids, and now 4 tmm is for A, 4 tmm is for B, and there will be no more tmm for c. it will lead to "ran out of registers during register allocation" in cpu backend