### PR TITLE
[SYCL] Made access::decorated::no default for get_multi_ptr.

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -2246,7 +2246,7 @@ public:
     return constant_ptr<DataT>(getPointerAdjusted());
   }
 
-  template <access::decorated IsDecorated>
+  template <access::decorated IsDecorated = access::decorated::no>
   accessor_ptr<IsDecorated> get_multi_ptr() const noexcept {
     return accessor_ptr<IsDecorated>(getPointerAdjusted());
   }
@@ -3010,7 +3010,7 @@ public:
     return std::add_pointer_t<value_type>(local_acc::getQualifiedPtr());
   }
 
-  template <access::decorated IsDecorated>
+  template <access::decorated IsDecorated = access::decorated::no>
   accessor_ptr<IsDecorated> get_multi_ptr() const noexcept {
     return accessor_ptr<IsDecorated>(local_acc::getQualifiedPtr());
   }


### PR DESCRIPTION
At the moment users always need to specify the decorated mode (on/off) for `get_multi_ptr()`, which is not ideal, since it is an unnecessary complication since in common usage SYCL programmers do not need to worry about `access::decorated`. From what I can tell it seems that it was intended to have a default value `access::decorated::no`.