### PR TITLE
[CI] Align installation steps between Linux/Windows

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -174,13 +174,12 @@ jobs:
         cmake --build $GITHUB_WORKSPACE/build --target install-llvm-profdata
         cmake --build $GITHUB_WORKSPACE/build --target install-compiler-rt
 
-    - name: Install clang-format/clang-tidy
-      # We install these into our nightly container that is later used in CI to
-      # run lint task.
+    - name: Install lint utilities
+      # We install these into our nightly container that CI uses to run lint
+      # checks.
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target install-clang-format
         cmake --build $GITHUB_WORKSPACE/build --target install-clang-tidy
-
 
     - name: Pack toolchain
       run: tar -I 'zstd -9' -cf llvm_sycl.tar.zst -C $GITHUB_WORKSPACE/build/install .

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -169,12 +169,18 @@ jobs:
         cmake --build $GITHUB_WORKSPACE/build --target utils/not/install
         cmake --build $GITHUB_WORKSPACE/build --target utils/lit/install
         cmake --build $GITHUB_WORKSPACE/build --target utils/llvm-lit/install
-        cmake --build $GITHUB_WORKSPACE/build --target install-clang-format
-        cmake --build $GITHUB_WORKSPACE/build --target install-clang-tidy
         cmake --build $GITHUB_WORKSPACE/build --target install-llvm-size
         cmake --build $GITHUB_WORKSPACE/build --target install-llvm-cov
         cmake --build $GITHUB_WORKSPACE/build --target install-llvm-profdata
         cmake --build $GITHUB_WORKSPACE/build --target install-compiler-rt
+
+    - name: Install clang-format/clang-tidy
+      # We install these into our nightly container that is later used in CI to
+      # run lint task.
+      run: |
+        cmake --build $GITHUB_WORKSPACE/build --target install-clang-format
+        cmake --build $GITHUB_WORKSPACE/build --target install-clang-tidy
+
 
     - name: Pack toolchain
       run: tar -I 'zstd -9' -cf llvm_sycl.tar.zst -C $GITHUB_WORKSPACE/build/install .

--- a/.github/workflows/sycl_windows_build_and_test.yml
+++ b/.github/workflows/sycl_windows_build_and_test.yml
@@ -82,7 +82,8 @@ jobs:
           --cmake-opt="-DCMAKE_CXX_COMPILER=cl" ^
           --cmake-opt="-DCMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\install" ^
           --cmake-opt="-DCMAKE_CXX_COMPILER_LAUNCHER=sccache" ^
-          --cmake-opt="-DCMAKE_C_COMPILER_LAUNCHER=sccache"
+          --cmake-opt="-DCMAKE_C_COMPILER_LAUNCHER=sccache" ^
+          --cmake-opt="-DLLVM_INSTALL_UTILS=ON"
     - name: Build
       id: build
       shell: bash
@@ -115,8 +116,10 @@ jobs:
         cmake --build build --target check-xptifw
     - name: Install
       shell: bash
+      # TODO replace utility installation with a single CMake target
       run: |
-        # TODO replace utility installation with a single CMake target
+        cmake --build build --target deploy-sycl-toolchain
+        cmake --build build --target utils/FileCheck/install
         cmake --build build --target utils/count/install
         cmake --build build --target utils/not/install
         cmake --build build --target utils/lit/install
@@ -124,13 +127,7 @@ jobs:
         cmake --build build --target install-llvm-size
         cmake --build build --target install-llvm-cov
         cmake --build build --target install-llvm-profdata
-        # TODO: Figure out why installing FileCheck does not install
-        # the FileCheck binary in the install/bin directory.
-        cmake --build build --target utils/FileCheck/install
         cmake --build build --target install-compiler-rt
-        cmake --build build --target deploy-sycl-toolchain
-        # Copy FileCheck to install/bin for use by E2E tests.
-        cp build/bin/FileCheck.exe install/bin/.
     - name: Pack toolchain
       shell: bash
       run: |


### PR DESCRIPTION
* Use LLVM_INSTALL_UTILS=ON on Windows
* Move clang-{format,tidy} installation into its own step
* Reorder lines to match between Linux/Windows