### PR TITLE
Adds explicit conversion of multi_ptr<T> to multi_ptr<const T>.

### DIFF
--- a/sycl/include/sycl/multi_ptr.hpp
+++ b/sycl/include/sycl/multi_ptr.hpp
@@ -113,6 +113,16 @@ public:
       : m_Pointer(ptr) {}
   multi_ptr(std::nullptr_t) : m_Pointer(nullptr) {}
 
+  // Explicit conversion from multi_ptr<T> to multi_ptr<const T>
+  template <typename NonConstElementType = std::remove_const_t<ElementType>,
+            typename = typename std::enable_if_t<
+                std::is_const_v<ElementType> &&
+                std::is_same_v<NonConstElementType,
+                               std::remove_const_t<ElementType>>>>
+  explicit multi_ptr(
+      multi_ptr<NonConstElementType, Space, DecorateAddress> MPtr)
+      : m_Pointer(MPtr.get_decorated()) {}
+
   // Only if Space is in
   // {global_space, ext_intel_global_device_space, generic_space}
   template <


### PR DESCRIPTION
This ctor has been previously removed, as it had conflict with existing ones.
Not having the ctor produces failures to compile some cts tests. An investigation is required.