### PR TITLE
[SYCL][COMPAT] First sycl_ext_oneapi_compat implementation

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/compat.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/compat.hpp
@@ -1,0 +1,35 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility extension
+ *
+ *  compat.hpp
+ *
+ *  Description:
+ *    Main include header for the SYCL compatibility extension
+ **************************************************************************/
+
+#pragma once
+
+#define SYCL_EXT_ONEAPI_COMPAT 1
+
+#include <sycl/ext/oneapi/experimental/compat/atomic.hpp>
+#include <sycl/ext/oneapi/experimental/compat/device.hpp>
+#include <sycl/ext/oneapi/experimental/compat/dims.hpp>
+#include <sycl/ext/oneapi/experimental/compat/dpct.hpp>
+#include <sycl/ext/oneapi/experimental/compat/kernel.hpp>
+#include <sycl/ext/oneapi/experimental/compat/kernel_function.hpp>
+#include <sycl/ext/oneapi/experimental/compat/launch.hpp>
+#include <sycl/ext/oneapi/experimental/compat/memory.hpp>
+#include <sycl/ext/oneapi/experimental/compat/util.hpp>

--- a/sycl/include/sycl/ext/oneapi/experimental/compat.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/compat.hpp
@@ -27,7 +27,7 @@
 #include <sycl/ext/oneapi/experimental/compat/atomic.hpp>
 #include <sycl/ext/oneapi/experimental/compat/device.hpp>
 #include <sycl/ext/oneapi/experimental/compat/dims.hpp>
-#include <sycl/ext/oneapi/experimental/compat/dpct.hpp>
+#include <sycl/ext/oneapi/experimental/compat/defs.hpp>
 #include <sycl/ext/oneapi/experimental/compat/kernel.hpp>
 #include <sycl/ext/oneapi/experimental/compat/kernel_function.hpp>
 #include <sycl/ext/oneapi/experimental/compat/launch.hpp>

--- a/sycl/include/sycl/ext/oneapi/experimental/compat/atomic.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/compat/atomic.hpp
@@ -1,0 +1,515 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility extension
+ *
+ *  atomic.hpp
+ *
+ *  Description:
+ *    Atomic functionality for the SYCL compatibility extension
+ **************************************************************************/
+
+// The original source was under the license below:
+//==---- atomic.hpp -------------------------------*- C++ -*----------------==//
+//
+// Copyright (C) Intel Corporation
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <sycl/access/access.hpp>
+#include <sycl/atomic_ref.hpp>
+#include <sycl/memory_enums.hpp>
+#include <sycl/multi_ptr.hpp>
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+namespace ext::oneapi::experimental::compat {
+
+template <typename T> struct arith {
+  using type = std::conditional_t<std::is_pointer_v<T>, std::ptrdiff_t, T>;
+};
+template <typename T> using arith_t = typename arith<T>::type;
+
+/// Atomically add the value operand to the value at the addr and assign the
+/// result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand The value to add to the value at \p addr.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+inline T atomic_fetch_add(T *addr, arith_t<T> operand) {
+  auto atm =
+      sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
+  return atm.fetch_add(operand);
+}
+
+/// Atomically add the value operand to the value at the addr and assign the
+/// result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand The value to add to the value at \p addr.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
+template <typename T, sycl::access::address_space addressSpace =
+                          sycl::access::address_space::global_space>
+inline T atomic_fetch_add(T *addr, arith_t<T> operand,
+                          sycl::memory_order memoryOrder) {
+  switch (memoryOrder) {
+  case sycl::memory_order::relaxed:
+    return atomic_fetch_add<T, addressSpace, sycl::memory_order::relaxed,
+                            sycl::memory_scope::device>(addr, operand);
+  case sycl::memory_order::acq_rel:
+    return atomic_fetch_add<T, addressSpace, sycl::memory_order::acq_rel,
+                            sycl::memory_scope::device>(addr, operand);
+  case sycl::memory_order::seq_cst:
+    return atomic_fetch_add<T, addressSpace, sycl::memory_order::seq_cst,
+                            sycl::memory_scope::device>(addr, operand);
+  default:
+    assert(false &&
+           "Invalid memory_order for atomics. Valid memory_order for "
+           "atomics are: sycl::memory_order::relaxed, "
+           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
+  }
+}
+
+/// Atomically subtract the value operand from the value at the addr and assign
+/// the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand The value to subtract from the value at \p addr
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+inline T atomic_fetch_sub(T *addr, arith_t<T> operand) {
+  auto atm =
+      sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
+  return atm.fetch_sub(operand);
+}
+
+/// Atomically subtract the value operand from the value at the addr and assign
+/// the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand The value to subtract from the value at \p addr
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
+template <typename T, sycl::access::address_space addressSpace =
+                          sycl::access::address_space::global_space>
+inline T atomic_fetch_sub(T *addr, arith_t<T> operand,
+                          sycl::memory_order memoryOrder) {
+  switch (memoryOrder) {
+  case sycl::memory_order::relaxed:
+    return atomic_fetch_sub<T, addressSpace, sycl::memory_order::relaxed,
+                            sycl::memory_scope::device>(addr, operand);
+  case sycl::memory_order::acq_rel:
+    return atomic_fetch_sub<T, addressSpace, sycl::memory_order::acq_rel,
+                            sycl::memory_scope::device>(addr, operand);
+  case sycl::memory_order::seq_cst:
+    return atomic_fetch_sub<T, addressSpace, sycl::memory_order::seq_cst,
+                            sycl::memory_scope::device>(addr, operand);
+  default:
+    assert(false &&
+           "Invalid memory_order for atomics. Valid memory_order for "
+           "atomics are: sycl::memory_order::relaxed, "
+           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
+  }
+}
+
+/// Atomically perform a bitwise AND between the value operand and the value at
+/// the addr and assign the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand The value to use in bitwise AND operation with the value at
+/// the \p addr.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+inline T atomic_fetch_and(T *addr, T operand) {
+  auto atm =
+      sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
+  return atm.fetch_and(operand);
+}
+
+/// Atomically perform a bitwise AND between the value operand and the value at
+/// the addr and assign the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand The value to use in bitwise AND operation with the value at
+/// the \p addr.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
+template <typename T, sycl::access::address_space addressSpace =
+                          sycl::access::address_space::global_space>
+inline T atomic_fetch_and(T *addr, T operand, sycl::memory_order memoryOrder) {
+  switch (memoryOrder) {
+  case sycl::memory_order::relaxed:
+    return atomic_fetch_and<T, addressSpace, sycl::memory_order::relaxed,
+                            sycl::memory_scope::device>(addr, operand);
+  case sycl::memory_order::acq_rel:
+    return atomic_fetch_and<T, addressSpace, sycl::memory_order::acq_rel,
+                            sycl::memory_scope::device>(addr, operand);
+  case sycl::memory_order::seq_cst:
+    return atomic_fetch_and<T, addressSpace, sycl::memory_order::seq_cst,
+                            sycl::memory_scope::device>(addr, operand);
+  default:
+    assert(false &&
+           "Invalid memory_order for atomics. Valid memory_order for "
+           "atomics are: sycl::memory_order::relaxed, "
+           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
+  }
+}
+
+/// Atomically or the value at the addr with the value operand, and assign
+/// the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand The value to use in bitwise OR operation with the value at
+/// the \p addr.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+inline T atomic_fetch_or(T *addr, T operand) {
+  auto atm =
+      sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
+  return atm.fetch_or(operand);
+}
+
+/// Atomically or the value at the addr with the value operand, and assign
+/// the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand The value to use in bitwise OR operation with the value at
+/// the \p addr.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
+template <typename T, sycl::access::address_space addressSpace =
+                          sycl::access::address_space::global_space>
+inline T atomic_fetch_or(T *addr, T operand, sycl::memory_order memoryOrder) {
+  switch (memoryOrder) {
+  case sycl::memory_order::relaxed:
+    return atomic_fetch_or<T, addressSpace, sycl::memory_order::relaxed,
+                           sycl::memory_scope::device>(addr, operand);
+  case sycl::memory_order::acq_rel:
+    return atomic_fetch_or<T, addressSpace, sycl::memory_order::acq_rel,
+                           sycl::memory_scope::device>(addr, operand);
+  case sycl::memory_order::seq_cst:
+    return atomic_fetch_or<T, addressSpace, sycl::memory_order::seq_cst,
+                           sycl::memory_scope::device>(addr, operand);
+  default:
+    assert(false &&
+           "Invalid memory_order for atomics. Valid memory_order for "
+           "atomics are: sycl::memory_order::relaxed, "
+           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
+  }
+}
+
+/// Atomically xor the value at the addr with the value operand, and assign
+/// the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand The value to use in bitwise XOR operation with the value at
+/// the \p addr.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+inline T atomic_fetch_xor(T *addr, T operand) {
+  auto atm =
+      sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
+  return atm.fetch_xor(operand);
+}
+
+/// Atomically xor the value at the addr with the value operand, and assign
+/// the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand The value to use in bitwise XOR operation with the value at
+/// the \p addr.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
+template <typename T, sycl::access::address_space addressSpace =
+                          sycl::access::address_space::global_space>
+inline T atomic_fetch_xor(T *addr, T operand, sycl::memory_order memoryOrder) {
+  switch (memoryOrder) {
+  case sycl::memory_order::relaxed:
+    return atomic_fetch_xor<T, addressSpace, sycl::memory_order::relaxed,
+                            sycl::memory_scope::device>(addr, operand);
+  case sycl::memory_order::acq_rel:
+    return atomic_fetch_xor<T, addressSpace, sycl::memory_order::acq_rel,
+                            sycl::memory_scope::device>(addr, operand);
+  case sycl::memory_order::seq_cst:
+    return atomic_fetch_xor<T, addressSpace, sycl::memory_order::seq_cst,
+                            sycl::memory_scope::device>(addr, operand);
+  default:
+    assert(false &&
+           "Invalid memory_order for atomics. Valid memory_order for "
+           "atomics are: sycl::memory_order::relaxed, "
+           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
+  }
+}
+
+/// Atomically calculate the minimum of the value at addr and the value operand
+/// and assign the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+inline T atomic_fetch_min(T *addr, T operand) {
+  auto atm =
+      sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
+  return atm.fetch_min(operand);
+}
+
+/// Atomically calculate the minimum of the value at addr and the value operand
+/// and assign the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
+template <typename T, sycl::access::address_space addressSpace =
+                          sycl::access::address_space::global_space>
+inline T atomic_fetch_min(T *addr, T operand, sycl::memory_order memoryOrder) {
+  switch (memoryOrder) {
+  case sycl::memory_order::relaxed:
+    return atomic_fetch_min<T, addressSpace, sycl::memory_order::relaxed,
+                            sycl::memory_scope::device>(addr, operand);
+  case sycl::memory_order::acq_rel:
+    return atomic_fetch_min<T, addressSpace, sycl::memory_order::acq_rel,
+                            sycl::memory_scope::device>(addr, operand);
+  case sycl::memory_order::seq_cst:
+    return atomic_fetch_min<T, addressSpace, sycl::memory_order::seq_cst,
+                            sycl::memory_scope::device>(addr, operand);
+  default:
+    assert(false &&
+           "Invalid memory_order for atomics. Valid memory_order for "
+           "atomics are: sycl::memory_order::relaxed, "
+           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
+  }
+}
+
+/// Atomically calculate the maximum of the value at addr and the value operand
+/// and assign the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+inline T atomic_fetch_max(T *addr, T operand) {
+  auto atm =
+      sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
+  return atm.fetch_max(operand);
+}
+
+/// Atomically calculate the maximum of the value at addr and the value operand
+/// and assign the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
+template <typename T, sycl::access::address_space addressSpace =
+                          sycl::access::address_space::global_space>
+inline T atomic_fetch_max(T *addr, T operand, sycl::memory_order memoryOrder) {
+  switch (memoryOrder) {
+  case sycl::memory_order::relaxed:
+    return atomic_fetch_max<T, addressSpace, sycl::memory_order::relaxed,
+                            sycl::memory_scope::device>(addr, operand);
+  case sycl::memory_order::acq_rel:
+    return atomic_fetch_max<T, addressSpace, sycl::memory_order::acq_rel,
+                            sycl::memory_scope::device>(addr, operand);
+  case sycl::memory_order::seq_cst:
+    return atomic_fetch_max<T, addressSpace, sycl::memory_order::seq_cst,
+                            sycl::memory_scope::device>(addr, operand);
+  default:
+    assert(false &&
+           "Invalid memory_order for atomics. Valid memory_order for "
+           "atomics are: sycl::memory_order::relaxed, "
+           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
+  }
+}
+
+/// Atomically increment the value stored in \p addr if old value stored in \p
+/// addr is less than \p operand, else set 0 to the value stored in \p addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand The threshold value.
+/// \param memoryOrder The memory ordering used.
+/// \returns The old value stored in \p addr.
+template <sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+inline unsigned int atomic_fetch_compare_inc(unsigned int *addr,
+                                             unsigned int operand) {
+  auto atm =
+      sycl::atomic_ref<unsigned int, memoryOrder, memoryScope, addressSpace>(
+          addr[0]);
+  unsigned int old;
+  while (true) {
+    old = atm.load();
+    if (old >= operand) {
+      if (atm.compare_exchange_strong(old, 0))
+        break;
+    } else if (atm.compare_exchange_strong(old, old + 1))
+      break;
+  }
+  return old;
+}
+
+/// Atomically increment the value stored in \p addr if old value stored in \p
+/// addr is less than \p operand, else set 0 to the value stored in \p addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand The threshold value.
+/// \param memoryOrder The memory ordering used.
+/// \returns The old value stored in \p addr.
+template <sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space>
+inline unsigned int atomic_fetch_compare_inc(unsigned int *addr,
+                                             unsigned int operand,
+                                             sycl::memory_order memoryOrder) {
+  switch (memoryOrder) {
+  case sycl::memory_order::relaxed:
+    return atomic_fetch_compare_inc<addressSpace, sycl::memory_order::relaxed,
+                                    sycl::memory_scope::device>(addr, operand);
+  case sycl::memory_order::acq_rel:
+    return atomic_fetch_compare_inc<addressSpace, sycl::memory_order::acq_rel,
+                                    sycl::memory_scope::device>(addr, operand);
+  case sycl::memory_order::seq_cst:
+    return atomic_fetch_compare_inc<addressSpace, sycl::memory_order::seq_cst,
+                                    sycl::memory_scope::device>(addr, operand);
+  default:
+    assert(false &&
+           "Invalid memory_order for atomics. Valid memory_order for "
+           "atomics are: sycl::memory_order::relaxed, "
+           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
+  }
+}
+
+/// Atomically exchange the value at the address addr with the value operand.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand The value to be exchanged with the value pointed by \p addr.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+inline T atomic_exchange(T *addr, T operand) {
+  auto atm =
+      sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
+  return atm.exchange(operand);
+}
+
+/// Atomically exchange the value at the address addr with the value operand.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand The value to be exchanged with the value pointed by \p addr.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
+template <typename T, sycl::access::address_space addressSpace =
+                          sycl::access::address_space::global_space>
+inline T atomic_exchange(T *addr, T operand, sycl::memory_order memoryOrder) {
+  switch (memoryOrder) {
+  case sycl::memory_order::relaxed:
+    return atomic_exchange<T, addressSpace, sycl::memory_order::relaxed,
+                           sycl::memory_scope::device>(addr, operand);
+  case sycl::memory_order::acq_rel:
+    return atomic_exchange<T, addressSpace, sycl::memory_order::acq_rel,
+                           sycl::memory_scope::device>(addr, operand);
+  case sycl::memory_order::seq_cst:
+    return atomic_exchange<T, addressSpace, sycl::memory_order::seq_cst,
+                           sycl::memory_scope::device>(addr, operand);
+  default:
+    assert(false &&
+           "Invalid memory_order for atomics. Valid memory_order for "
+           "atomics are: sycl::memory_order::relaxed, "
+           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
+  }
+}
+
+/// Atomically compare the value at \p addr to the value expected and exchange
+/// with the value desired if the value at \p addr is equal to the value
+/// expected. Returns the value at the \p addr before the call.
+/// \param [in, out] addr Multi_ptr.
+/// \param expected The value to compare against the value at \p addr.
+/// \param desired The value to assign to \p addr if the value at \p addr
+/// is expected.
+/// \param success The memory ordering used when comparison succeeds.
+/// \param fail The memory ordering used when comparison fails.
+/// \returns The value at the \p addr before the call.
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+T atomic_compare_exchange_strong(
+    sycl::multi_ptr<T, sycl::access::address_space::global_space> addr,
+    T expected, T desired,
+    sycl::memory_order success = sycl::memory_order::relaxed,
+    sycl::memory_order fail = sycl::memory_order::relaxed) {
+  auto atm = sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(*addr);
+
+  atm.compare_exchange_strong(expected, desired, success, fail);
+  return expected;
+}
+
+/// Atomically compare the value at \p addr to the value expected and exchange
+/// with the value desired if the value at \p addr is equal to the value
+/// expected. Returns the value at the \p addr before the call.
+/// \param [in] addr The pointer to the data.
+/// \param expected The value to compare against the value at \p addr.
+/// \param desired The value to assign to \p addr if the value at \p addr is
+/// expected.
+/// \param success The memory ordering used when comparison succeeds.
+/// \param fail The memory ordering used when comparison fails.
+/// \returns The value at the \p addr before the call.
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+T atomic_compare_exchange_strong(
+    T *addr, T expected, T desired,
+    sycl::memory_order success = sycl::memory_order::relaxed,
+    sycl::memory_order fail = sycl::memory_order::relaxed) {
+  auto atm =
+      sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
+  atm.compare_exchange_strong(expected, desired, success, fail);
+  return expected;
+}
+
+} // namespace ext::oneapi::experimental::compat
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
+} // namespace sycl

--- a/sycl/include/sycl/ext/oneapi/experimental/compat/defs.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/compat/defs.hpp
@@ -1,0 +1,43 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility extension
+ *
+ *  defs.hpp
+ *
+ *  Description:
+ *    helper aliases and definitions for the SYCL compatibility extension
+ *
+ **************************************************************************/
+
+// The original source was under the license below:
+//==---- dpct.hpp ---------------------------------*- C++ -*----------------==//
+//
+// Copyright (C) Intel Corporation
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+template <class... Args> class sycl_compat_kernel_name;
+template <int Arg> class sycl_compat_kernel_scalar;
+
+#define __sycl_compat_align__(n) __attribute__((aligned(n)))
+#define __sycl_compat_inline__ __inline__ __attribute__((always_inline))
+
+#define __sycl_compat_noinline__ __attribute__((noinline))
+
+#define SYCL_COMPAT_COMPATIBILITY_TEMP (600)

--- a/sycl/include/sycl/ext/oneapi/experimental/compat/device.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/compat/device.hpp
@@ -1,0 +1,550 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility extension
+ *
+ *  device.hpp
+ *
+ *  Description:
+ *    Device functionality for the SYCL compatibility extension
+ **************************************************************************/
+
+// The original source was under the license below:
+//==---- device.hpp -------------------------------*- C++ -*----------------==//
+//
+// Copyright (C) Intel Corporation
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <set>
+#include <sstream>
+#include <thread>
+#include <vector>
+#if defined(__linux__)
+#include <sys/syscall.h>
+#include <unistd.h>
+#endif
+#if defined(_WIN64)
+#define NOMINMAX
+#include <windows.h>
+#endif
+
+#include <sycl/detail/defines_elementary.hpp>
+#include <sycl/exception_list.hpp>
+#include <sycl/properties/queue_properties.hpp>
+#include <sycl/queue.hpp>
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+namespace ext::oneapi::experimental::compat {
+
+// Note: this is all code from SYCLomatic's device.hpp helper header
+namespace detail {
+
+/// SYCL default exception handler
+auto exception_handler = [](sycl::exception_list exceptions) {
+  for (std::exception_ptr const &e : exceptions) {
+    try {
+      std::rethrow_exception(e);
+    } catch (sycl::exception const &e) {
+      std::cerr << "[SYCLcompat] Caught asynchronous SYCL exception:"
+                << std::endl
+                << e.what() << std::endl
+                << "Exception caught at file:" << __FILE__
+                << ", line:" << __LINE__ << std::endl;
+    }
+  }
+};
+
+} // namespace detail
+
+using event_ptr = sycl::event *;
+
+using queue_ptr = sycl::queue *;
+
+/// Destroy \p event pointed memory.
+///
+/// \param event Pointer to the sycl::event address.
+static void destroy_event(event_ptr event) { delete event; }
+
+class device_info {
+public:
+  // get interface
+  const char *get_name() const { return _name; }
+  char *get_name() { return _name; }
+  template <typename WorkItemSizesTy = sycl::id<3>,
+            std::enable_if_t<std::is_same_v<WorkItemSizesTy, sycl::id<3>> ||
+                                 std::is_same_v<WorkItemSizesTy, int *>,
+                             int> = 0>
+  auto get_max_work_item_sizes() const {
+    if constexpr (std::is_same_v<WorkItemSizesTy, sycl::id<3>>)
+      return _max_work_item_sizes;
+    else
+      return _max_work_item_sizes_i;
+  }
+  template <typename WorkItemSizesTy = sycl::id<3>,
+            std::enable_if_t<std::is_same_v<WorkItemSizesTy, sycl::id<3>> ||
+                                 std::is_same_v<WorkItemSizesTy, int *>,
+                             int> = 0>
+  auto get_max_work_item_sizes() {
+    if constexpr (std::is_same_v<WorkItemSizesTy, sycl::id<3>>)
+      return _max_work_item_sizes;
+    else
+      return _max_work_item_sizes_i;
+  }
+  int get_major_version() const { return _major; }
+  int get_minor_version() const { return _minor; }
+  int get_integrated() const { return _integrated; }
+  int get_max_clock_frequency() const { return _frequency; }
+  int get_max_compute_units() const { return _max_compute_units; }
+  int get_max_work_group_size() const { return _max_work_group_size; }
+  int get_max_sub_group_size() const { return _max_sub_group_size; }
+  int get_max_work_items_per_compute_unit() const {
+    return _max_work_items_per_compute_unit;
+  }
+  template <typename NDRangeSizeTy = size_t *,
+            std::enable_if_t<std::is_same_v<NDRangeSizeTy, size_t *> ||
+                                 std::is_same_v<NDRangeSizeTy, int *>,
+                             int> = 0>
+  auto get_max_nd_range_size() const {
+    if constexpr (std::is_same_v<NDRangeSizeTy, size_t *>)
+      return _max_nd_range_size;
+    else
+      return _max_nd_range_size_i;
+  }
+  template <typename NDRangeSizeTy = size_t *,
+            std::enable_if_t<std::is_same_v<NDRangeSizeTy, size_t *> ||
+                                 std::is_same_v<NDRangeSizeTy, int *>,
+                             int> = 0>
+  auto get_max_nd_range_size() {
+    if constexpr (std::is_same_v<NDRangeSizeTy, size_t *>)
+      return _max_nd_range_size;
+    else
+      return _max_nd_range_size_i;
+  }
+  size_t get_global_mem_size() const { return _global_mem_size; }
+  size_t get_local_mem_size() const { return _local_mem_size; }
+  // set interface
+  void set_name(const char *name) { std::strncpy(_name, name, 256); }
+  void set_max_work_item_sizes(const sycl::id<3> max_work_item_sizes) {
+    _max_work_item_sizes = max_work_item_sizes;
+    for (int i = 0; i < 3; ++i)
+      _max_work_item_sizes_i[i] = max_work_item_sizes[i];
+  }
+  void set_major_version(int major) { _major = major; }
+  void set_minor_version(int minor) { _minor = minor; }
+  void set_integrated(int integrated) { _integrated = integrated; }
+  void set_max_clock_frequency(int frequency) { _frequency = frequency; }
+  void set_max_compute_units(int max_compute_units) {
+    _max_compute_units = max_compute_units;
+  }
+  void set_global_mem_size(size_t global_mem_size) {
+    _global_mem_size = global_mem_size;
+  }
+  void set_local_mem_size(size_t local_mem_size) {
+    _local_mem_size = local_mem_size;
+  }
+  void set_max_work_group_size(int max_work_group_size) {
+    _max_work_group_size = max_work_group_size;
+  }
+  void set_max_sub_group_size(int max_sub_group_size) {
+    _max_sub_group_size = max_sub_group_size;
+  }
+  void
+  set_max_work_items_per_compute_unit(int max_work_items_per_compute_unit) {
+    _max_work_items_per_compute_unit = max_work_items_per_compute_unit;
+  }
+  void set_max_nd_range_size(int max_nd_range_size[]) {
+    for (int i = 0; i < 3; i++) {
+      _max_nd_range_size[i] = max_nd_range_size[i];
+      _max_nd_range_size_i[i] = max_nd_range_size[i];
+    }
+  }
+
+private:
+  char _name[256];
+  sycl::id<3> _max_work_item_sizes;
+  int _max_work_item_sizes_i[3];
+  int _major;
+  int _minor;
+  int _integrated = 0;
+  int _frequency;
+  int _max_compute_units;
+  int _max_work_group_size;
+  int _max_sub_group_size;
+  int _max_work_items_per_compute_unit;
+  size_t _global_mem_size;
+  size_t _local_mem_size;
+  size_t _max_nd_range_size[3];
+  int _max_nd_range_size_i[3];
+};
+
+/// device extension
+class device_ext : public sycl::device {
+public:
+  device_ext() : sycl::device(), _ctx(*this) {}
+  ~device_ext() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    sycl::event::wait(_events);
+    _queues.clear();
+  }
+  device_ext(const sycl::device &base) : sycl::device(base), _ctx(*this) {
+    if (!this->has(sycl::aspect::usm_device_allocations)) {
+      throw std::invalid_argument(
+          "Device does not support device USM allocations");
+    }
+    _queues.push_back(
+        std::make_shared<sycl::queue>(_ctx, base, detail::exception_handler,
+                                      sycl::property::queue::in_order()));
+    _saved_queue = _default_queue = _queues[0].get();
+  }
+
+  bool is_native_host_atomic_supported() { return 0; }
+  int get_major_version() const {
+    int major, minor;
+    get_version(major, minor);
+    return major;
+  }
+
+  int get_minor_version() const {
+    int major, minor;
+    get_version(major, minor);
+    return minor;
+  }
+
+  int get_max_compute_units() const {
+    return get_device_info().get_max_compute_units();
+  }
+
+  int get_max_clock_frequency() const {
+    return get_device_info().get_max_clock_frequency();
+  }
+
+  int get_integrated() const { return get_device_info().get_integrated(); }
+
+  void get_device_info(device_info &out) const {
+    device_info prop;
+    prop.set_name(get_info<sycl::info::device::name>().c_str());
+
+    int major, minor;
+    get_version(major, minor);
+    prop.set_major_version(major);
+    prop.set_minor_version(minor);
+
+    prop.set_max_work_item_sizes(
+#if (__SYCL_COMPILER_VERSION && __SYCL_COMPILER_VERSION < 20220902)
+        // oneAPI DPC++ compiler older than 2022/09/02, where
+        // max_work_item_sizes is an enum class element
+        get_info<sycl::info::device::max_work_item_sizes>());
+#else
+        // SYCL 2020-conformant code, max_work_item_sizes is a struct templated
+        // by an int
+        get_info<sycl::info::device::max_work_item_sizes<3>>());
+#endif
+
+    prop.set_max_clock_frequency(
+        get_info<sycl::info::device::max_clock_frequency>());
+    prop.set_max_compute_units(
+        get_info<sycl::info::device::max_compute_units>());
+    prop.set_max_work_group_size(
+        get_info<sycl::info::device::max_work_group_size>());
+    prop.set_global_mem_size(get_info<sycl::info::device::global_mem_size>());
+    prop.set_local_mem_size(get_info<sycl::info::device::local_mem_size>());
+
+    size_t max_sub_group_size = 1;
+    std::vector<size_t> sub_group_sizes =
+        get_info<sycl::info::device::sub_group_sizes>();
+
+    for (const auto &sub_group_size : sub_group_sizes) {
+      if (max_sub_group_size < sub_group_size)
+        max_sub_group_size = sub_group_size;
+    }
+
+    prop.set_max_sub_group_size(max_sub_group_size);
+
+    prop.set_max_work_items_per_compute_unit(
+        get_info<sycl::info::device::max_work_group_size>());
+    int max_nd_range_size[] = {0x7FFFFFFF, 0x7FFFFFFF, 0x7FFFFFFF};
+    prop.set_max_nd_range_size(max_nd_range_size);
+
+    out = prop;
+  }
+
+  device_info get_device_info() const {
+    device_info prop;
+    get_device_info(prop);
+    return prop;
+  }
+
+  void reset() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    // The queues are shared_ptrs and the ref counts of the shared_ptrs increase
+    // only in wait_and_throw(). If there is no other thread calling
+    // wait_and_throw(), the queues will be destructed. The destructor waits for
+    // all commands executing on the queue to complete. It isn't possible to
+    // destroy a queue immediately. This is a synchronization point in SYCL.
+    _queues.clear();
+    // create new default queue.
+    _queues.push_back(
+        std::make_shared<sycl::queue>(_ctx, *this, detail::exception_handler,
+                                      sycl::property::queue::in_order()));
+    _saved_queue = _default_queue = _queues.front().get();
+  }
+
+  sycl::queue *default_queue() { return _default_queue; }
+
+  void queues_wait_and_throw() {
+    std::unique_lock<std::mutex> lock(m_mutex);
+    std::vector<std::shared_ptr<sycl::queue>> current_queues(_queues);
+    lock.unlock();
+    for (const auto &q : current_queues) {
+      q->wait_and_throw();
+    }
+    // Guard the destruct of current_queues to make sure the ref count is safe.
+    lock.lock();
+  }
+  queue_ptr create_queue(bool print_on_async_exceptions = false,
+                         bool in_order = true) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    sycl::async_handler eh = {};
+    sycl::property_list prop = {};
+    if (print_on_async_exceptions) {
+      eh = detail::exception_handler;
+    }
+    if (in_order) {
+      prop = {sycl::property::queue::in_order()};
+    }
+    _queues.push_back(std::make_shared<sycl::queue>(_ctx, *this, eh, prop));
+    return _queues.back().get();
+  }
+  void destroy_queue(queue_ptr &queue) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    _queues.erase(
+        std::remove_if(_queues.begin(), _queues.end(),
+                       [=](const std::shared_ptr<sycl::queue> &q) -> bool {
+                         return q.get() == queue;
+                       }),
+        _queues.end());
+    queue = nullptr;
+  }
+  void set_saved_queue(queue_ptr q) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    _saved_queue = q;
+  }
+  queue_ptr get_saved_queue() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return _saved_queue;
+  }
+  sycl::context get_context() const { return _ctx; }
+
+private:
+  void get_version(int &major, int &minor) const {
+    // Version string has the following format:
+    // a. OpenCL<space><major.minor><space><vendor-specific-information>
+    // b. <major.minor>
+    std::string ver;
+    ver = get_info<sycl::info::device::version>();
+    std::string::size_type i = 0;
+    while (i < ver.size()) {
+      if (isdigit(ver[i]))
+        break;
+      i++;
+    }
+    major = std::stoi(&(ver[i]));
+    while (i < ver.size()) {
+      if (ver[i] == '.')
+        break;
+      i++;
+    }
+    i++;
+    minor = std::stoi(&(ver[i]));
+  }
+  void add_event(sycl::event event) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    _events.push_back(event);
+  }
+  friend sycl::event free_async(const std::vector<void *> &,
+                                const std::vector<sycl::event> &, sycl::queue);
+  queue_ptr _default_queue;
+  queue_ptr _saved_queue;
+  sycl::context _ctx;
+  std::vector<std::shared_ptr<sycl::queue>> _queues;
+  mutable std::mutex m_mutex;
+  std::vector<sycl::event> _events;
+};
+
+namespace detail {
+
+static inline unsigned int get_tid() {
+#if defined(__linux__)
+  return syscall(SYS_gettid);
+#elif defined(_WIN64)
+  return GetCurrentThreadId();
+#else
+#error "Only support Windows and Linux."
+#endif
+}
+
+/// device manager
+class dev_mgr {
+public:
+  device_ext &current_device() {
+    unsigned int dev_id = current_device_id();
+    check_id(dev_id);
+    return *_devs[dev_id];
+  }
+  device_ext &cpu_device() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (_cpu_device == -1) {
+      throw std::runtime_error("no valid cpu device");
+    } else {
+      return *_devs[_cpu_device];
+    }
+  }
+  device_ext &get_device(unsigned int id) const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    check_id(id);
+    return *_devs[id];
+  }
+  unsigned int current_device_id() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    auto it = _thread2dev_map.find(get_tid());
+    if (it != _thread2dev_map.end())
+      return it->second;
+    return _default_device_id;
+  }
+  void select_device(unsigned int id) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    check_id(id);
+    _thread2dev_map[get_tid()] = id;
+  }
+  unsigned int device_count() { return _devs.size(); }
+
+  unsigned int get_device_id(const sycl::device &dev) {
+    unsigned int id = 0;
+    for (auto dev_item : _devs) {
+      if (*dev_item == dev) {
+        break;
+      }
+      id++;
+    }
+    return id;
+  }
+
+  /// Returns the instance of device manager singleton.
+  static dev_mgr &instance() {
+    static dev_mgr d_m;
+    return d_m;
+  }
+  dev_mgr(const dev_mgr &) = delete;
+  dev_mgr &operator=(const dev_mgr &) = delete;
+  dev_mgr(dev_mgr &&) = delete;
+  dev_mgr &operator=(dev_mgr &&) = delete;
+
+private:
+  mutable std::mutex m_mutex;
+  dev_mgr() {
+    sycl::device default_device = sycl::device(sycl::default_selector_v);
+    _devs.push_back(std::make_shared<device_ext>(default_device));
+
+    std::vector<sycl::device> sycl_all_devs =
+        sycl::device::get_devices(sycl::info::device_type::all);
+    // Collect other devices except for the default device.
+    if (default_device.is_cpu())
+      _cpu_device = 0;
+    for (auto &dev : sycl_all_devs) {
+      if (dev == default_device) {
+        continue;
+      }
+      _devs.push_back(std::make_shared<device_ext>(dev));
+      if (_cpu_device == -1 && dev.is_cpu()) {
+        _cpu_device = _devs.size() - 1;
+      }
+    }
+  }
+  void check_id(unsigned int id) const {
+    if (id >= _devs.size()) {
+      throw std::runtime_error("invalid device id");
+    }
+  }
+  std::vector<std::shared_ptr<device_ext>> _devs;
+  /// DEFAULT_DEVICE_ID is used, if current_device_id() can not find current
+  /// thread id in _thread2dev_map, which means default device should be used
+  /// for the current thread.
+  const unsigned int _default_device_id = 0;
+  /// thread-id to device-id map.
+  std::map<unsigned int, unsigned int> _thread2dev_map;
+  int _cpu_device = -1;
+};
+
+} // namespace detail
+
+inline sycl::queue create_queue(bool print_on_async_exceptions = false,
+                                bool in_order = true) {
+  return *detail::dev_mgr::instance().current_device().create_queue(
+      print_on_async_exceptions, in_order);
+}
+
+/// Util function to get the default queue of current device in
+/// device manager.
+static inline sycl::queue get_default_queue() {
+  return *detail::dev_mgr::instance().current_device().default_queue();
+}
+
+inline void wait(sycl::queue q = get_default_queue()) { q.wait(); }
+
+/// Util function to get the id of current device in
+/// device manager.
+static inline unsigned int get_current_device_id() {
+  return detail::dev_mgr::instance().current_device_id();
+}
+
+/// Util function to get the current device.
+static inline device_ext &get_current_device() {
+  return detail::dev_mgr::instance().current_device();
+}
+
+/// Util function to get a device by id.
+static inline device_ext &get_device(unsigned int id) {
+  return detail::dev_mgr::instance().get_device(id);
+}
+
+/// Util function to get the context of the default queue of current
+/// device in device manager.
+static inline sycl::context get_default_context() {
+  return get_current_device().get_context();
+}
+
+/// Util function to get a CPU device.
+static inline device_ext &cpu_device() {
+  return detail::dev_mgr::instance().cpu_device();
+}
+
+static inline unsigned int select_device(unsigned int id) {
+  detail::dev_mgr::instance().select_device(id);
+  return id;
+}
+
+} // namespace ext::oneapi::experimental::compat
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
+} // namespace sycl

--- a/sycl/include/sycl/ext/oneapi/experimental/compat/dims.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/compat/dims.hpp
@@ -1,0 +1,76 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility extension
+ *
+ *  dims.hpp
+ *
+ *  Description:
+ *    dim3 functionality for the SYCL compatibility extension
+ **************************************************************************/
+
+#pragma once
+
+#include <tuple>
+
+#include <sycl/range.hpp>
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+namespace ext::oneapi::experimental::compat {
+
+class dim3 {
+public:
+  const size_t x, y, z;
+
+  constexpr dim3(const sycl::range<3> &r) : x(r[2]), y(r[1]), z(r[0]) {}
+
+  constexpr dim3(const sycl::range<2> &r) : x(r[1]), y(r[0]), z(1) {}
+
+  constexpr dim3(const sycl::range<1> &r) : x(r[0]), y(1), z(1) {}
+
+  constexpr dim3(size_t x, size_t y = 1, size_t z = 1) : x(x), y(y), z(z) {}
+
+  constexpr size_t size() const { return x * y * z; }
+
+  operator sycl::range<3>() const { return sycl::range<3>(z, y, x); }
+  operator sycl::range<2>() const {
+    if (z != 1)
+      throw std::invalid_argument(
+          "Attempting to convert a 3D dim3 into sycl::range<2>");
+    return sycl::range<2>(y, x);
+  }
+  operator sycl::range<1>() const {
+    if (z != 1 || y != 1)
+      throw std::invalid_argument(
+          "Attempting to convert a 2D or 3D dim3 into sycl::range<1>");
+    return sycl::range<1>(x);
+  }
+};
+
+inline dim3 operator*(const dim3 &a, const dim3 &b) {
+  return dim3{a.x * b.x, a.y * b.y, a.z * b.z};
+}
+
+inline dim3 operator+(const dim3 &a, const dim3 &b) {
+  return dim3{a.x + b.x, a.y + b.y, a.z + b.z};
+}
+
+inline dim3 operator-(const dim3 &a, const dim3 &b) {
+  return dim3{a.x - b.x, a.y - b.y, a.z - b.z};
+}
+
+} // namespace ext::oneapi::experimental::compat
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
+} // namespace sycl

--- a/sycl/include/sycl/ext/oneapi/experimental/compat/kernel.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/compat/kernel.hpp
@@ -1,0 +1,73 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility extension
+ *
+ *  kernel.hpp
+ *
+ *  Description:
+ *    kernel functionality for the SYCL compatibility extension
+ **************************************************************************/
+
+#pragma once
+
+#include <sycl/nd_item.hpp>
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+namespace ext::oneapi::experimental::compat {
+
+using sycl::ext::oneapi::experimental::this_nd_item;
+
+inline void wg_barrier() { this_nd_item<3>().barrier(); }
+
+namespace local_id {
+inline size_t x() { return this_nd_item<3>().get_local_id(2); }
+inline size_t y() { return this_nd_item<3>().get_local_id(1); }
+inline size_t z() { return this_nd_item<3>().get_local_id(0); }
+} // namespace local_id
+
+namespace local_range {
+inline size_t x() { return this_nd_item<3>().get_local_range(2); }
+inline size_t y() { return this_nd_item<3>().get_local_range(1); }
+inline size_t z() { return this_nd_item<3>().get_local_range(0); }
+} // namespace local_range
+
+namespace work_group_id {
+inline size_t x() { return this_nd_item<3>().get_group(2); }
+inline size_t y() { return this_nd_item<3>().get_group(1); }
+inline size_t z() { return this_nd_item<3>().get_group(0); }
+} // namespace work_group_id
+
+namespace work_group_range {
+inline size_t x() { return this_nd_item<3>().get_group_range(2); }
+inline size_t y() { return this_nd_item<3>().get_group_range(1); }
+inline size_t z() { return this_nd_item<3>().get_group_range(0); }
+} // namespace work_group_range
+
+namespace global_range {
+inline size_t x() { return this_nd_item<3>().get_global_range(2); }
+inline size_t y() { return this_nd_item<3>().get_global_range(1); }
+inline size_t z() { return this_nd_item<3>().get_global_range(0); }
+} // namespace global_range
+
+namespace global_id {
+inline size_t x() { return this_nd_item<3>().get_global_id(2); }
+inline size_t y() { return this_nd_item<3>().get_global_id(1); }
+inline size_t z() { return this_nd_item<3>().get_global_id(0); }
+} // namespace global_id
+
+} // namespace ext::oneapi::experimental::compat
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
+} // namespace sycl

--- a/sycl/include/sycl/ext/oneapi/experimental/compat/kernel_function.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/compat/kernel_function.hpp
@@ -1,0 +1,67 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility extension
+ *
+ *  kernel_function.hpp
+ *
+ *  Description:
+ *    kernel functionality for the SYCL compatibility extension.
+ **************************************************************************/
+
+// The original source was under the license below:
+//==---- kernel.hpp -------------------------------*- C++ -*----------------==//
+//
+// Copyright (C) Intel Corporation
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <sycl/info/info_desc.hpp>
+#include <sycl/nd_range.hpp>
+#include <sycl/queue.hpp>
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+namespace ext::oneapi::experimental::compat {
+
+typedef void (*kernel_functor)(sycl::queue &, const sycl::nd_range<3> &,
+                               unsigned int, void **, void **);
+
+struct kernel_function_info {
+  int max_work_group_size = 0;
+};
+
+static void get_kernel_function_info(kernel_function_info *kernel_info,
+                                     const void *function) {
+  kernel_info->max_work_group_size =
+      detail::dev_mgr::instance()
+          .current_device()
+          .get_info<sycl::info::device::max_work_group_size>();
+}
+static kernel_function_info get_kernel_function_info(const void *function) {
+  kernel_function_info kernel_info;
+  kernel_info.max_work_group_size =
+      detail::dev_mgr::instance()
+          .current_device()
+          .get_info<sycl::info::device::max_work_group_size>();
+  return kernel_info;
+}
+
+} // namespace ext::oneapi::experimental::compat
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
+} // namespace sycl

--- a/sycl/include/sycl/ext/oneapi/experimental/compat/launch.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/compat/launch.hpp
@@ -1,0 +1,254 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility extension
+ *
+ *  launch.hpp
+ *
+ *  Description:
+ *    launch functionality for the SYCL compatibility extension
+ **************************************************************************/
+
+#pragma once
+
+#include <sycl/accessor.hpp>
+#include <sycl/event.hpp>
+#include <sycl/ext/oneapi/experimental/compat/dims.hpp>
+#include <sycl/nd_range.hpp>
+#include <sycl/queue.hpp>
+#include <sycl/range.hpp>
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+namespace ext::oneapi::experimental::compat {
+
+namespace detail {
+
+template <typename R, typename... Types>
+constexpr size_t getArgumentCount(R (*f)(Types...)) {
+  return sizeof...(Types);
+}
+
+// Extracts the type of the first argument of a variadic template parameter, if
+// it is a pointer. Used for user kernels with local_mem declarations
+template <typename T, typename... Rest> struct first_arg { using type = T; };
+
+template <typename T, typename... Rest>
+using first_arg_t = typename first_arg<T>::type;
+
+// Extracts the type of the local_mem pointer from the user kernel function
+// signature
+template <typename F> struct local_mem {};
+
+template <typename R, typename... Types> struct local_mem<R (*)(Types...)> {
+  using type = typename detail::first_arg<Types...>::type;
+};
+
+template <typename F> using local_mem_t = typename local_mem<F>::type;
+template <typename F>
+using noptr_local_mem_t =
+    typename std::remove_pointer_t<typename local_mem<F>::type>;
+
+template <typename F, typename... Args> struct invoke_result_local_mem {
+  using type = typename std::invoke_result_t<F, Args...>;
+};
+
+template <typename F, typename... Args>
+using invoke_result_local_mem_t =
+    typename invoke_result_local_mem<F, Args...>::type;
+
+template <int Dim>
+sycl::nd_range<3> transform_nd_range(const sycl::nd_range<Dim> &range) {
+  sycl::range<Dim> global_range = range.get_global_range();
+  sycl::range<Dim> local_range = range.get_local_range();
+  if constexpr (Dim == 3) {
+    return range;
+  } else if constexpr (Dim == 2) {
+    return sycl::nd_range<3>{{1, global_range[0], global_range[1]},
+                             {1, local_range[0], local_range[1]}};
+  }
+  return sycl::nd_range<3>{{1, 1, global_range[0]}, {1, 1, local_range[0]}};
+}
+
+template <auto F, typename... Args>
+std::enable_if_t<std::is_invocable_v<decltype(F), Args...>, sycl::event>
+launch(const sycl::nd_range<3> &range, sycl::queue q, Args... args) {
+  static_assert(detail::getArgumentCount(F) == sizeof...(args),
+                "Wrong number of arguments to SYCL kernel");
+  static_assert(
+      std::is_same<std::invoke_result_t<decltype(F), Args...>, void>::value,
+      "SYCL kernels should return void");
+
+  return q.parallel_for(range, [=](sycl::nd_item<3>) { F(args...); });
+}
+
+template <auto F, typename... Args>
+sycl::event launch(const sycl::nd_range<3> &range, size_t num_local_elements,
+                   sycl::queue q, Args... args) {
+  static_assert(detail::getArgumentCount(F) == sizeof...(args) + 1,
+                "Wrong number of arguments to SYCL kernel");
+
+  using F_t = decltype(F);
+  using f_return_t =
+      typename detail::invoke_result_local_mem_t<F_t, detail::local_mem_t<F_t>,
+                                                 Args...>;
+  static_assert(std::is_same<f_return_t, void>::value,
+                "SYCL kernels should return void");
+
+  return q.submit([&](sycl::handler &cgh) {
+    auto local_acc = sycl::local_accessor<detail::noptr_local_mem_t<F_t>, 1>(
+        num_local_elements, cgh);
+    cgh.parallel_for(range, [=](sycl::nd_item<3>) {
+      auto local_mem = local_acc.get_pointer();
+      F(local_mem, args...);
+    });
+  });
+}
+
+} // namespace detail
+
+template <int Dim>
+sycl::nd_range<Dim> compute_nd_range(sycl::range<Dim> global_size_in,
+                                     sycl::range<Dim> work_group_size) {
+
+  if (global_size_in.size() == 0 || work_group_size.size() == 0) {
+    throw std::invalid_argument("Global or local size is zero!");
+  }
+  for (size_t i = 0; i < Dim; ++i) {
+    if (global_size_in[i] < work_group_size[i])
+      throw std::invalid_argument("Work group size larger than global size");
+  }
+
+  auto global_size =
+      ((global_size_in + work_group_size - 1) / work_group_size) *
+      work_group_size;
+  return {global_size, work_group_size};
+}
+
+inline sycl::nd_range<1> compute_nd_range(int global_size_in,
+                                          int work_group_size) {
+  return compute_nd_range<1>(global_size_in, work_group_size);
+}
+
+template <auto F, int Dim, typename... Args>
+std::enable_if_t<std::is_invocable_v<decltype(F), Args...>, sycl::event>
+launch(const sycl::nd_range<Dim> &range, sycl::queue q, Args... args) {
+  return detail::launch<F>(detail::transform_nd_range<Dim>(range), q, args...);
+}
+
+template <auto F, int Dim, typename... Args>
+std::enable_if_t<std::is_invocable_v<decltype(F), Args...>, sycl::event>
+launch(const sycl::nd_range<Dim> &range, Args... args) {
+  return launch<F>(range, get_default_queue(), args...);
+}
+
+// Alternative launch through dim3 objects
+template <auto F, typename... Args>
+std::enable_if_t<std::is_invocable_v<decltype(F), Args...>, sycl::event>
+launch(const dim3 &grid, const dim3 &threads, sycl::queue q, Args... args) {
+  return launch<F>(sycl::nd_range<3>{grid * threads, threads}, q, args...);
+}
+
+template <auto F, typename... Args>
+std::enable_if_t<std::is_invocable_v<decltype(F), Args...>, sycl::event>
+launch(const dim3 &grid, const dim3 &threads, Args... args) {
+  return launch<F>(grid, threads, get_default_queue(), args...);
+}
+
+/// Launches a kernel with the templated F param and arguments on a
+/// device specified by the given nd_range and SYCL queue.
+/// @tparam F SYCL kernel to be executed, expects signature F(T* local_mem,
+/// Args... args).
+/// @tparam Dim nd_range dimension number.
+/// @tparam Args Types of the arguments to be passed to the kernel.
+/// @param range Nd_range specifying the work group and global sizes for the
+/// kernel.
+/// @param q The SYCL queue on which to execute the kernel.
+/// @param num_local_elements The size, in number of elements, of the local
+/// memory to be allocated for kernel.
+/// @param args The arguments to be passed to the kernel.
+/// @return A SYCL event object that can be used to synchronize with the
+/// kernel's execution.
+template <auto F, int Dim, typename... Args>
+sycl::event launch(const sycl::nd_range<Dim> &range, size_t num_local_elements,
+                   sycl::queue q, Args... args) {
+  return detail::launch<F>(detail::transform_nd_range<Dim>(range),
+                           num_local_elements, q, args...);
+}
+
+/// Launches a kernel with the templated F param and arguments on a
+/// device specified by the given nd_range using theSYCL default queue.
+/// @tparam F SYCL kernel to be executed, expects signature F(T* local_mem,
+/// Args... args).
+/// @tparam Dim nd_range dimension number.
+/// @tparam Args Types of the arguments to be passed to the kernel.
+/// @param range Nd_range specifying the work group and global sizes for the
+/// kernel.
+/// @param num_local_elements The size, in number of elements, of the local
+/// memory to be allocated for kernel.
+/// @param args The arguments to be passed to the kernel.
+/// @return A SYCL event object that can be used to synchronize with the
+/// kernel's execution.
+template <auto F, int Dim, typename... Args>
+sycl::event launch(const sycl::nd_range<Dim> &range, size_t num_local_elements,
+                   Args... args) {
+  return launch<F>(range, num_local_elements, get_default_queue(), args...);
+}
+
+/// Launches a kernel with the templated F param and arguments on a
+/// device with a user-specified grid and block dimensions following the
+/// standard of other programming models using a user-defined SYCL queue.
+/// @tparam F SYCL kernel to be executed, expects signature F(T* local_mem,
+/// Args... args).
+/// @tparam Dim nd_range dimension number.
+/// @tparam Args Types of the arguments to be passed to the kernel.
+/// @param grid Grid dimensions represented with an (x, y, z) iteration space.
+/// @param threads Block dimensions represented with an (x, y, z) iteration
+/// space.
+/// @param num_local_elements The size, in number of elements, of the local
+/// memory to be allocated for kernel.
+/// @param args The arguments to be passed to the kernel.
+/// @return A SYCL event object that can be used to synchronize with the
+/// kernel's execution.
+template <auto F, typename... Args>
+sycl::event launch(const dim3 &grid, const dim3 &threads,
+                   size_t num_local_elements, sycl::queue q, Args... args) {
+  return launch<F>(sycl::nd_range<3>{grid * threads, threads},
+                   num_local_elements, q, args...);
+}
+
+/// Launches a kernel with the templated F param and arguments on a
+/// device with a user-specified grid and block dimensions following the
+/// standard of other programming models using the default SYCL queue.
+/// @tparam F SYCL kernel to be executed, expects signature F(T* local_mem,
+/// Args... args).
+/// @tparam Dim nd_range dimension number.
+/// @tparam Args Types of the arguments to be passed to the kernel.
+/// @param grid Grid dimensions represented with an (x, y, z) iteration space.
+/// @param threads Block dimensions represented with an (x, y, z) iteration
+/// space./// @param num_local_elements The size, in number of elements, of the
+/// local memory to be allocated.
+/// @param args The arguments to be passed to the kernel.
+/// @return A SYCL event object that can be used to synchronize with the
+/// kernel's execution.
+template <auto F, typename... Args>
+sycl::event launch(const dim3 &grid, const dim3 &threads,
+                   size_t num_local_elements, Args... args) {
+  return launch<F>(grid, threads, num_local_elements, get_default_queue(),
+                   args...);
+}
+
+} // namespace ext::oneapi::experimental::compat
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
+} // namespace sycl

--- a/sycl/include/sycl/ext/oneapi/experimental/compat/memory.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/compat/memory.hpp
@@ -1,0 +1,1045 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility extension
+ *
+ *  memory.hpp
+ *
+ *  Description:
+ *    memory functionality for the SYCL compatibility extension
+ **************************************************************************/
+
+// The original source was under the license below:
+//==---- memory.hpp -------------------------------*- C++ -*----------------==//
+//
+// Copyright (C) Intel Corporation
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <mutex>
+#include <thread>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/compat/device.hpp>
+#include <sycl/ext/oneapi/group_local_memory.hpp>
+#include <sycl/usm.hpp>
+
+#if defined(__linux__)
+#include <sys/mman.h>
+#elif defined(_WIN64)
+#define NOMINMAX
+#include <windows.h>
+#else
+#error "Only support Windows and Linux."
+#endif
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+namespace ext::oneapi::experimental::compat {
+
+template <typename AllocT> auto *local_mem() {
+  sycl::multi_ptr<AllocT, sycl::access::address_space::local_space>
+      as_multi_ptr = sycl::ext::oneapi::group_local_memory<AllocT>(
+          this_nd_item<3>().get_group());
+  auto *as = *as_multi_ptr;
+  return as;
+}
+
+namespace detail {
+enum memcpy_direction {
+  host_to_host,
+  host_to_device,
+  device_to_host,
+  device_to_device,
+  automatic
+};
+}
+
+enum class memory_region {
+  global = 0, // device global memory
+  local,      // device local memory
+  usm_shared, // memory which can be accessed by host and device
+};
+
+enum class target { device, local };
+
+using byte_t = uint8_t;
+
+/// Pitched 2D/3D memory data.
+class pitched_data {
+public:
+  pitched_data() : pitched_data(nullptr, 0, 0, 0) {}
+  pitched_data(void *data, size_t pitch, size_t x, size_t y)
+      : _data(data), _pitch(pitch), _x(x), _y(y) {}
+
+  void *get_data_ptr() { return _data; }
+  void set_data_ptr(void *data) { _data = data; }
+
+  size_t get_pitch() { return _pitch; }
+  void set_pitch(size_t pitch) { _pitch = pitch; }
+
+  size_t get_x() { return _x; }
+  void set_x(size_t x) { _x = x; };
+
+  size_t get_y() { return _y; }
+  void set_y(size_t y) { _y = y; }
+
+private:
+  void *_data;
+  size_t _pitch, _x, _y;
+};
+
+namespace detail {
+
+template <class T, memory_region Memory, size_t Dimension> class accessor;
+template <memory_region Memory, class T = byte_t> class memory_traits {
+public:
+  static constexpr sycl::access::address_space asp =
+      (Memory == memory_region::local)
+          ? sycl::access::address_space::local_space
+          : sycl::access::address_space::global_space;
+  static constexpr sycl::ext::oneapi::experimental::compat::target target =
+      (Memory == memory_region::local)
+          ? sycl::ext::oneapi::experimental::compat::target::local
+          : sycl::ext::oneapi::experimental::compat::target::device;
+  static constexpr sycl::access_mode mode = sycl::access_mode::read_write;
+  static constexpr size_t type_size = sizeof(T);
+  using element_t = T;
+  using value_t = typename std::remove_cv<T>::type;
+  template <size_t Dimension = 1>
+  using accessor_t = typename std::conditional<
+      target == sycl::ext::oneapi::experimental::compat::target::local,
+      sycl::local_accessor<T, Dimension>,
+      sycl::accessor<T, Dimension, mode>>::type;
+  using pointer_t = T *;
+};
+
+static inline void *malloc(size_t size, sycl::queue q) {
+  return sycl::malloc_device(size, q.get_device(), q.get_context());
+}
+
+/// Calculate pitch (padded length of major dimension \p x) by rounding up to
+/// multiple of 32.
+/// \param x The dimension to be padded
+/// \returns size_t representing pitched length of dimension x.
+static inline constexpr size_t get_pitch(size_t x) {
+  return ((x) + 31) & ~(0x1F);
+}
+
+static inline void *malloc(size_t &pitch, size_t x, size_t y, size_t z,
+                           sycl::queue q) {
+  pitch = get_pitch(x);
+  return malloc(pitch * y * z, q);
+}
+
+/// Set \p pattern to the first \p count elements of type \p T starting from \p
+/// dev_ptr.
+///
+/// \tparam T Datatype of the pattern to be set.
+/// \param q The queue in which the operation is done.
+/// \param dev_ptr Pointer to the device memory address.
+/// \param pattern Pattern of type T to be set.
+/// \param count Number of elements to be set to the patten.
+/// \returns An event representing the fill operation.
+template <class T>
+static inline sycl::event fill(sycl::queue q, void *dev_ptr, const T &pattern,
+                               size_t count) {
+  return q.fill(dev_ptr, pattern, count);
+}
+
+/// Set \p value to the first \p size bytes starting from \p dev_ptr in \p q.
+///
+/// \param q The queue in which the operation is done.
+/// \param dev_ptr Pointer to the device memory address.
+/// \param value Value to be set.
+/// \param size Number of bytes to be set to the value.
+/// \returns An event representing the memset operation.
+static inline sycl::event memset(sycl::queue q, void *dev_ptr, int value,
+                                 size_t size) {
+  return q.memset(dev_ptr, value, size);
+}
+
+/// Set \p value to the 3D memory region pointed by \p data in \p q. \p size
+/// specifies the 3D memory size to set.
+///
+/// \param q The queue in which the operation is done.
+/// \param data Pointer to the device memory region.
+/// \param value Value to be set.
+/// \param size Memory region size.
+/// \returns An event list representing the memset operations.
+static inline std::vector<sycl::event> memset(sycl::queue q, pitched_data data,
+                                              int value, sycl::range<3> size) {
+  std::vector<sycl::event> event_list;
+  size_t slice = data.get_pitch() * data.get_y();
+  unsigned char *data_surface = (unsigned char *)data.get_data_ptr();
+  for (size_t z = 0; z < size.get(2); ++z) {
+    unsigned char *data_ptr = data_surface;
+    for (size_t y = 0; y < size.get(1); ++y) {
+      event_list.push_back(memset(q, data_ptr, value, size.get(0)));
+      data_ptr += data.get_pitch();
+    }
+    data_surface += slice;
+  }
+  return event_list;
+}
+
+/// memset 2D matrix with pitch.
+static inline std::vector<sycl::event>
+memset(sycl::queue q, void *ptr, size_t pitch, int val, size_t x, size_t y) {
+  return memset(q, pitched_data(ptr, pitch, x, 1), val,
+                sycl::range<3>(x, y, 1));
+}
+
+enum class pointer_access_attribute {
+  host_only = 0,
+  device_only,
+  host_device,
+  end
+};
+
+static pointer_access_attribute get_pointer_attribute(sycl::queue q,
+                                                      const void *ptr) {
+  switch (sycl::get_pointer_type(ptr, q.get_context())) {
+  case sycl::usm::alloc::unknown:
+    return pointer_access_attribute::host_only;
+  case sycl::usm::alloc::device:
+    return pointer_access_attribute::device_only;
+  case sycl::usm::alloc::shared:
+  case sycl::usm::alloc::host:
+    return pointer_access_attribute::host_device;
+  }
+}
+
+static memcpy_direction deduce_memcpy_direction(sycl::queue q, void *to_ptr,
+                                                const void *from_ptr) {
+  // table[to_attribute][from_attribute]
+  static const memcpy_direction
+      direction_table[static_cast<unsigned>(pointer_access_attribute::end)]
+                     [static_cast<unsigned>(pointer_access_attribute::end)] = {
+                         {memcpy_direction::host_to_host,
+                          memcpy_direction::device_to_host,
+                          memcpy_direction::host_to_host},
+                         {memcpy_direction::host_to_device,
+                          memcpy_direction::device_to_device,
+                          memcpy_direction::device_to_device},
+                         {memcpy_direction::host_to_host,
+                          memcpy_direction::device_to_device,
+                          memcpy_direction::device_to_device}};
+  return direction_table[static_cast<unsigned>(get_pointer_attribute(
+      q, to_ptr))][static_cast<unsigned>(get_pointer_attribute(q, from_ptr))];
+}
+
+static sycl::event memcpy(sycl::queue q, void *to_ptr, const void *from_ptr,
+                          size_t size,
+                          const std::vector<sycl::event> &dep_events = {}) {
+  if (!size)
+    return sycl::event{};
+  return q.memcpy(to_ptr, from_ptr, size, dep_events);
+}
+
+// Get actual copy range and make sure it will not exceed range.
+static inline size_t get_copy_range(sycl::range<3> size, size_t slice,
+                                    size_t pitch) {
+  return slice * (size.get(2) - 1) + pitch * (size.get(1) - 1) + size.get(0);
+}
+
+static inline size_t get_offset(sycl::id<3> id, size_t slice, size_t pitch) {
+  return slice * id.get(2) + pitch * id.get(1) + id.get(0);
+}
+
+/// copy 3D matrix specified by \p size from 3D matrix specified by \p from_ptr
+/// and \p from_range to another specified by \p to_ptr and \p to_range.
+static inline std::vector<sycl::event>
+memcpy(sycl::queue q, void *to_ptr, const void *from_ptr,
+       sycl::range<3> to_range, sycl::range<3> from_range, sycl::id<3> to_id,
+       sycl::id<3> from_id, sycl::range<3> size,
+       const std::vector<sycl::event> &dep_events = {}) {
+  // RAII for host pointer
+  class host_buffer {
+    void *_buf;
+    size_t _size;
+    sycl::queue _q;
+    const std::vector<sycl::event> &_deps; // free operation depends
+
+  public:
+    host_buffer(size_t size, sycl::queue q,
+                const std::vector<sycl::event> &deps)
+        : _buf(std::malloc(size)), _size(size), _q(q), _deps(deps) {}
+    void *get_ptr() const { return _buf; }
+    size_t get_size() const { return _size; }
+    ~host_buffer() {
+      if (_buf) {
+        _q.submit([&](sycl::handler &cgh) {
+          cgh.depends_on(_deps);
+          cgh.host_task([buf = _buf] { std::free(buf); });
+        });
+      }
+    }
+  };
+  std::vector<sycl::event> event_list;
+
+  size_t to_slice = to_range.get(1) * to_range.get(0);
+  size_t from_slice = from_range.get(1) * from_range.get(0);
+  unsigned char *to_surface =
+      (unsigned char *)to_ptr + get_offset(to_id, to_slice, to_range.get(0));
+  const unsigned char *from_surface =
+      (const unsigned char *)from_ptr +
+      get_offset(from_id, from_slice, from_range.get(0));
+
+  if (to_slice == from_slice && to_slice == size.get(1) * size.get(0)) {
+    return {memcpy(q, to_surface, from_surface, to_slice * size.get(2),
+                   dep_events)};
+  }
+  memcpy_direction direction = deduce_memcpy_direction(q, to_ptr, from_ptr);
+  size_t size_slice = size.get(1) * size.get(0);
+  switch (direction) {
+  case host_to_host:
+    for (size_t z = 0; z < size.get(2); ++z) {
+      unsigned char *to_ptr = to_surface;
+      const unsigned char *from_ptr = from_surface;
+      if (to_range.get(0) == from_range.get(0) &&
+          to_range.get(0) == size.get(0)) {
+        event_list.push_back(
+            memcpy(q, to_ptr, from_ptr, size_slice, dep_events));
+      } else {
+        for (size_t y = 0; y < size.get(1); ++y) {
+          event_list.push_back(
+              memcpy(q, to_ptr, from_ptr, size.get(0), dep_events));
+          to_ptr += to_range.get(0);
+          from_ptr += from_range.get(0);
+        }
+      }
+      to_surface += to_slice;
+      from_surface += from_slice;
+    }
+    break;
+  case host_to_device: {
+    host_buffer buf(get_copy_range(size, to_slice, to_range.get(0)), q,
+                    event_list);
+    std::vector<sycl::event> host_events;
+    if (to_slice == size_slice) {
+      // Copy host data to a temp host buffer with the shape of target.
+      host_events =
+          memcpy(q, buf.get_ptr(), from_surface, to_range, from_range,
+                 sycl::id<3>(0, 0, 0), sycl::id<3>(0, 0, 0), size, dep_events);
+    } else {
+      // Copy host data to a temp host buffer with the shape of target.
+      host_events =
+          memcpy(q, buf.get_ptr(), from_surface, to_range, from_range,
+                 sycl::id<3>(0, 0, 0), sycl::id<3>(0, 0, 0), size,
+                 // If has padding data, not sure whether it is useless. So fill
+                 // temp buffer with it.
+                 std::vector<sycl::event>{memcpy(q, buf.get_ptr(), to_surface,
+                                                 buf.get_size(), dep_events)});
+    }
+    // Copy from temp host buffer to device with only one submit.
+    event_list.push_back(
+        memcpy(q, to_surface, buf.get_ptr(), buf.get_size(), host_events));
+    break;
+  }
+  case device_to_host: {
+    host_buffer buf(get_copy_range(size, from_slice, from_range.get(0)), q,
+                    event_list);
+    // Copy from host temp buffer to host target with reshaping.
+    event_list =
+        memcpy(q, to_surface, buf.get_ptr(), to_range, from_range,
+               sycl::id<3>(0, 0, 0), sycl::id<3>(0, 0, 0), size,
+               // Copy from device to temp host buffer with only one submit.
+               std::vector<sycl::event>{memcpy(q, buf.get_ptr(), from_surface,
+                                               buf.get_size(), dep_events)});
+    break;
+  }
+  case device_to_device:
+    event_list.push_back(q.submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dep_events);
+      cgh.parallel_for<class memcpy_3d_detail>(size, [=](sycl::id<3> id) {
+        to_surface[get_offset(id, to_slice, to_range.get(0))] =
+            from_surface[get_offset(id, from_slice, from_range.get(0))];
+      });
+    }));
+    break;
+  default:
+    throw std::runtime_error("sycl::ext::oneapi::experimental::compat::"
+                             "memcpy: invalid direction value");
+  }
+  return event_list;
+}
+
+/// memcpy 2D/3D matrix specified by pitched_data.
+static inline std::vector<sycl::event>
+memcpy(sycl::queue q, pitched_data to, sycl::id<3> to_id, pitched_data from,
+       sycl::id<3> from_id, sycl::range<3> size) {
+  return memcpy(q, to.get_data_ptr(), from.get_data_ptr(),
+                sycl::range<3>(to.get_pitch(), to.get_y(), 1),
+                sycl::range<3>(from.get_pitch(), from.get_y(), 1), to_id,
+                from_id, size);
+}
+
+/// memcpy 2D matrix with pitch.
+static inline std::vector<sycl::event>
+memcpy(sycl::queue q, void *to_ptr, const void *from_ptr, size_t to_pitch,
+       size_t from_pitch, size_t x, size_t y) {
+  return memcpy(q, to_ptr, from_ptr, sycl::range<3>(to_pitch, y, 1),
+                sycl::range<3>(from_pitch, y, 1), sycl::id<3>(0, 0, 0),
+                sycl::id<3>(0, 0, 0), sycl::range<3>(x, y, 1));
+}
+
+// Takes a std::vector<sycl::event> & returns a single event
+// which simply depends on all of them
+static sycl::event combine_events(std::vector<sycl::event> &events,
+                                  sycl::queue q) {
+  return q.submit([&events](sycl::handler &cgh) {
+    cgh.depends_on(events);
+    cgh.host_task([]() {});
+  });
+}
+
+} // namespace detail
+
+/// Allocate memory block on the device.
+/// \param num_bytes Number of bytes to allocate.
+/// \param q Queue to execute the allocate task.
+/// \returns A pointer to the newly allocated memory.
+static inline void *malloc(size_t num_bytes,
+                           sycl::queue q = get_default_queue()) {
+  return detail::malloc(num_bytes, q);
+}
+
+/// Allocate memory block on the device.
+/// \param T Datatype to allocate
+/// \param count Number of elements to allocate.
+/// \param q Queue to execute the allocate task.
+/// \returns A pointer to the newly allocated memory.
+template <typename T>
+static inline T *malloc(size_t count, sycl::queue q = get_default_queue()) {
+  return static_cast<T *>(detail::malloc(count * sizeof(T), q));
+}
+
+/// Allocate memory block on the host.
+/// \param num_bytes Number of bytes to allocate.
+/// \param q Queue to execute the allocate task.
+/// \returns A pointer to the newly allocated memory.
+static inline void *malloc_host(size_t num_bytes,
+                                sycl::queue q = get_default_queue()) {
+  return sycl::malloc_host(num_bytes, q);
+}
+
+/// Allocate memory block on the host.
+/// \param T Datatype to allocate
+/// \param num_bytes Number of bytes to allocate.
+/// \param q Queue to execute the allocate task.
+/// \returns A pointer to the newly allocated memory.
+template <typename T>
+static inline T *malloc_host(size_t count,
+                             sycl::queue q = get_default_queue()) {
+  return static_cast<T *>(sycl::malloc_host(count * sizeof(T), q));
+}
+
+/// Allocate memory block of usm_shared memory.
+/// \param num_bytes Number of bytes to allocate.
+/// \param q Queue to execute the allocate task.
+/// \returns A pointer to the newly allocated memory.
+static inline void *malloc_shared(size_t num_bytes,
+                                  sycl::queue q = get_default_queue()) {
+  return sycl::malloc_shared(num_bytes, q);
+}
+
+/// Allocate memory block of usm_shared memory.
+/// \param num_bytes Number of bytes to allocate.
+/// \param q Queue to execute the allocate task.
+/// \returns A pointer to the newly allocated memory.
+template <typename T>
+static inline T *malloc_shared(size_t count,
+                               sycl::queue q = get_default_queue()) {
+  return static_cast<T *>(sycl::malloc_shared(count * sizeof(T), q));
+}
+
+/// Allocate memory block for 3D array on the device.
+/// \param size Size of the memory block, in bytes.
+/// \param q Queue to execute the allocate task.
+/// \returns A pitched_data object which stores the memory info.
+static inline pitched_data malloc(sycl::range<3> size,
+                                  sycl::queue q = get_default_queue()) {
+  pitched_data pitch(nullptr, 0, size.get(0), size.get(1));
+  size_t pitch_size;
+  pitch.set_data_ptr(
+      detail::malloc(pitch_size, size.get(0), size.get(1), size.get(2), q));
+  pitch.set_pitch(pitch_size);
+  return pitch;
+}
+
+/// Allocate memory block for 2D array on the device.
+/// \param [out] pitch Aligned size of x in bytes.
+/// \param x Range in dim x.
+/// \param y Range in dim y.
+/// \param q Queue to execute the allocate task.
+/// \returns A pointer to the newly allocated memory.
+static inline void *malloc(size_t &pitch, size_t x, size_t y,
+                           sycl::queue q = get_default_queue()) {
+  return detail::malloc(pitch, x, y, 1, q);
+}
+
+/// free
+/// \param ptr Point to free.
+/// \param q Queue to execute the free task.
+/// \returns no return value.
+static inline void free(void *ptr, sycl::queue q = get_default_queue()) {
+  if (ptr) {
+    sycl::free(ptr, q.get_context());
+  }
+}
+
+/// Free the device memory pointed by a batch of pointers in \p pointers which
+/// are related to \p q after \p events completed.
+///
+/// \param pointers The pointers point to the device memory requested to be
+/// freed. \param events The events to be waited. \param q The sycl::queue the
+/// memory relates to.
+inline sycl::event free_async(const std::vector<void *> &pointers,
+                              const std::vector<sycl::event> &events,
+                              sycl::queue q = get_default_queue()) {
+  auto event = q.submit(
+      [&pointers, &events, ctxt = q.get_context()](sycl::handler &cgh) {
+        cgh.depends_on(events);
+        cgh.host_task([=]() {
+          for (auto p : pointers)
+            sycl::free(p, ctxt);
+        });
+      });
+  get_current_device().add_event(event);
+  return event;
+}
+
+/// Synchronously copies \p size bytes from the address specified by \p from_ptr
+/// to the address specified by \p to_ptr. The function will
+/// return after the copy is completed.
+///
+/// \param to_ptr Pointer to destination memory address.
+/// \param from_ptr Pointer to source memory address.
+/// \param size Number of bytes to be copied.
+/// \param q Queue to execute the copy task.
+/// \returns no return value.
+static void memcpy(void *to_ptr, const void *from_ptr, size_t size,
+                   sycl::queue q = get_default_queue()) {
+  detail::memcpy(q, to_ptr, from_ptr, size).wait();
+}
+
+/// Asynchronously copies \p size bytes from the address specified by \p
+/// from_ptr to the address specified by \p to_ptr. The return of the function
+/// does NOT guarantee the copy is completed.
+///
+/// \param to_ptr Pointer to destination memory address.
+/// \param from_ptr Pointer to source memory address.
+/// \param size Number of bytes to be copied.
+/// \param q Queue to execute the copy task.
+/// \returns no return value.
+static sycl::event memcpy_async(void *to_ptr, const void *from_ptr, size_t size,
+                                sycl::queue q = get_default_queue()) {
+  return detail::memcpy(q, to_ptr, from_ptr, size);
+}
+
+namespace detail {
+template <class T> struct dont_deduce { using type = T; };
+template <class T> using dont_deduce_t = typename dont_deduce<T>::type;
+} // namespace detail
+
+/// Asynchronously copies \p count T's from the address specified by \p
+/// from_ptr to the address specified by \p to_ptr. The return of the function
+/// does NOT guarantee the copy is completed.
+///
+/// \tparam T Datatype to be copied.
+/// \param to_ptr Pointer to destination memory address.
+/// \param from_ptr Pointer to source memory address.
+/// \param count Number of T to be copied.
+/// \param q Queue to execute the copy task.
+/// \returns no return value.
+template <typename T>
+static sycl::event memcpy_async(detail::dont_deduce_t<T> *to_ptr,
+                                const detail::dont_deduce_t<T> *from_ptr,
+                                size_t count,
+                                sycl::queue q = get_default_queue()) {
+  return detail::memcpy(q, static_cast<void *>(to_ptr),
+                        static_cast<const void *>(from_ptr), count * sizeof(T));
+}
+
+/// Synchronously copies \p count T's from the address specified by \p from_ptr
+/// to the address specified by \p to_ptr. The function will
+/// return after the copy is completed.
+///
+/// \tparam T Datatype to be copied.
+/// \param to_ptr Pointer to destination memory address.
+/// \param from_ptr Pointer to source memory address.
+/// \param count Number of T to be copied.
+/// \param q Queue to execute the copy task.
+/// \returns no return value.
+template <typename T>
+static void memcpy(detail::dont_deduce_t<T> *to_ptr,
+                   const detail::dont_deduce_t<T> *from_ptr, size_t count,
+                   sycl::queue q = get_default_queue()) {
+  detail::memcpy(q, static_cast<void *>(to_ptr),
+                 static_cast<const void *>(from_ptr), count * sizeof(T))
+      .wait();
+}
+
+/// Synchronously copies 2D matrix specified by \p x and \p y from the address
+/// specified by \p from_ptr to the address specified by \p to_ptr, while \p
+/// from_pitch and \p to_pitch are the range of dim x in bytes of the matrix
+/// specified by \p from_ptr and \p to_ptr. The function will return after the
+/// copy is completed.
+///
+/// \param to_ptr Pointer to destination memory address.
+/// \param to_pitch Range of dim x in bytes of destination matrix.
+/// \param from_ptr Pointer to source memory address.
+/// \param from_pitch Range of dim x in bytes of source matrix.
+/// \param x Range of dim x of matrix to be copied.
+/// \param y Range of dim y of matrix to be copied.
+/// \param q Queue to execute the copy task.
+/// \returns no return value.
+static inline void memcpy(void *to_ptr, size_t to_pitch, const void *from_ptr,
+                          size_t from_pitch, size_t x, size_t y,
+                          sycl::queue q = get_default_queue()) {
+  sycl::event::wait(
+      detail::memcpy(q, to_ptr, from_ptr, to_pitch, from_pitch, x, y));
+}
+
+/// Asynchronously copies 2D matrix specified by \p x and \p y from the address
+/// specified by \p from_ptr to the address specified by \p to_ptr, while \p
+/// \p from_pitch and \p to_pitch are the range of dim x in bytes of the matrix
+/// specified by \p from_ptr and \p to_ptr. The return of the function does NOT
+/// guarantee the copy is completed.
+///
+/// \param to_ptr Pointer to destination memory address.
+/// \param to_pitch Range of dim x in bytes of destination matrix.
+/// \param from_ptr Pointer to source memory address.
+/// \param from_pitch Range of dim x in bytes of source matrix.
+/// \param x Range of dim x of matrix to be copied.
+/// \param y Range of dim y of matrix to be copied.
+/// \param q Queue to execute the copy task.
+/// \returns no return value.
+static inline sycl::event memcpy_async(void *to_ptr, size_t to_pitch,
+                                       const void *from_ptr, size_t from_pitch,
+                                       size_t x, size_t y,
+                                       sycl::queue q = get_default_queue()) {
+  auto events = detail::memcpy(q, to_ptr, from_ptr, to_pitch, from_pitch, x, y);
+  return detail::combine_events(events, q);
+}
+
+/// Synchronously copies a subset of a 3D matrix specified by \p to to another
+/// 3D matrix specified by \p from. The from and to position info are specified
+/// by \p from_pos and \p to_pos The copied matrix size is specified by \p size.
+// The function will return after the copy is completed.
+///
+/// \param to Destination matrix info.
+/// \param to_pos Position of destination.
+/// \param from Source matrix info.
+/// \param from_pos Position of destination.
+/// \param size Range of the submatrix to be copied.
+/// \param q Queue to execute the copy task.
+/// \returns no return value.
+static inline void memcpy(pitched_data to, sycl::id<3> to_pos,
+                          pitched_data from, sycl::id<3> from_pos,
+                          sycl::range<3> size,
+                          sycl::queue q = get_default_queue()) {
+  sycl::event::wait(detail::memcpy(q, to, to_pos, from, from_pos, size));
+}
+
+/// Asynchronously copies a subset of a 3D matrix specified by \p to to another
+/// 3D matrix specified by \p from. The from and to position info are specified
+/// by \p from_pos and \p to_pos The copied matrix size is specified by \p size.
+/// The return of the function does NOT guarantee the copy is completed.
+///
+/// \param to Destination matrix info.
+/// \param to_pos Position of destination.
+/// \param from Source matrix info.
+/// \param from_pos Position of destination.
+/// \param size Range of the submatrix to be copied.
+/// \param q Queue to execute the copy task.
+/// \returns no return value.
+static inline sycl::event memcpy_async(pitched_data to, sycl::id<3> to_pos,
+                                       pitched_data from, sycl::id<3> from_pos,
+                                       sycl::range<3> size,
+                                       sycl::queue q = get_default_queue()) {
+  auto events = detail::memcpy(q, to, to_pos, from, from_pos, size);
+  return detail::combine_events(events, q);
+}
+
+/// Synchronously sets \p pattern to the first \p count elements starting from
+/// \p dev_ptr. The function will return after the fill operation is completed.
+///
+/// \tparam T Datatype of the value to be set.
+/// \param dev_ptr Pointer to the device memory address.
+/// \param pattern Pattern of type \p T to be set.
+/// \param count Number of elements to be set to the patten.
+/// \param q The queue in which the operation is done.
+/// \returns no return value.
+template <class T>
+static void inline fill(void *dev_ptr, const T &pattern, size_t count,
+                        sycl::queue q = get_default_queue()) {
+  detail::fill(q, dev_ptr, pattern, count).wait();
+}
+
+/// Asynchronously sets \p pattern to the first \p count elements starting from
+/// \p dev_ptr.
+/// The return of the function does NOT guarantee the fill operation is
+/// completed.
+///
+/// \tparam T Datatype of the pattern to be set.
+/// \param dev_ptr Pointer to the device memory address.
+/// \param pattern Pattern of type \p T to be set.
+/// \param count Number of elements to be set to the patten.
+/// \param q The queue in which the operation is done.
+/// \returns no return value.
+template <class T>
+static sycl::event inline fill_async(void *dev_ptr, const T &pattern,
+                                     size_t count,
+                                     sycl::queue q = get_default_queue()) {
+  return detail::fill(q, dev_ptr, pattern, count);
+}
+
+/// Synchronously sets \p value to the first \p size bytes starting from \p
+/// dev_ptr. The function will return after the memset operation is completed.
+///
+/// \param dev_ptr Pointer to the device memory address.
+/// \param value Value to be set.
+/// \param size Number of bytes to be set to the value.
+/// \param q The queue in which the operation is done.
+/// \returns no return value.
+static void memset(void *dev_ptr, int value, size_t size,
+                   sycl::queue q = get_default_queue()) {
+  detail::memset(q, dev_ptr, value, size).wait();
+}
+
+/// Asynchronously sets \p value to the first \p size bytes starting from \p
+/// dev_ptr. The return of the function does NOT guarantee the memset operation
+/// is completed.
+///
+/// \param dev_ptr Pointer to the device memory address.
+/// \param value Value to be set.
+/// \param size Number of bytes to be set to the value.
+/// \returns no return value.
+static sycl::event memset_async(void *dev_ptr, int value, size_t size,
+                                sycl::queue q = get_default_queue()) {
+  return detail::memset(q, dev_ptr, value, size);
+}
+
+/// Sets \p value to the 2D memory region pointed by \p ptr in \p q. \p x and
+/// \p y specify the setted 2D memory size. \p pitch is the bytes in linear
+/// dimension, including padding bytes. The function will return after the
+/// memset operation is completed.
+///
+/// \param ptr Pointer to the device memory region.
+/// \param pitch Bytes in linear dimension, including padding bytes.
+/// \param value Value to be set.
+/// \param x The setted memory size in linear dimension.
+/// \param y The setted memory size in second dimension.
+/// \param q The queue in which the operation is done.
+/// \returns no return value.
+static inline void memset(void *ptr, size_t pitch, int val, size_t x, size_t y,
+                          sycl::queue q = get_default_queue()) {
+  sycl::event::wait(detail::memset(q, ptr, pitch, val, x, y));
+}
+
+/// Sets \p value to the 2D memory region pointed by \p ptr in \p q. \p x and
+/// \p y specify the setted 2D memory size. \p pitch is the bytes in linear
+/// dimension, including padding bytes. The return of the function does NOT
+/// guarantee the memset operation is completed.
+///
+/// \param ptr Pointer to the device memory region.
+/// \param pitch Bytes in linear dimension, including padding bytes.
+/// \param value Value to be set.
+/// \param x The setted memory size in linear dimension.
+/// \param y The setted memory size in second dimension.
+/// \param q The queue in which the operation is done.
+/// \returns no return value.
+static inline sycl::event memset_async(void *ptr, size_t pitch, int val,
+                                       size_t x, size_t y,
+                                       sycl::queue q = get_default_queue()) {
+  auto events = detail::memset(q, ptr, pitch, val, x, y);
+  return detail::combine_events(events, q);
+}
+
+/// Sets \p value to the 3D memory region specified by \p pitch in \p q. \p size
+/// specify the setted 3D memory size. The function will return after the
+/// memset operation is completed.
+///
+/// \param pitch Specify the 3D memory region.
+/// \param value Value to be set.
+/// \param size The setted 3D memory size.
+/// \param q The queue in which the operation is done.
+/// \returns no return value.
+static inline void memset(pitched_data pitch, int val, sycl::range<3> size,
+                          sycl::queue q = get_default_queue()) {
+  sycl::event::wait(detail::memset(q, pitch, val, size));
+}
+
+/// Sets \p value to the 3D memory region specified by \p pitch in \p q. \p size
+/// specify the setted 3D memory size. The return of the function does NOT
+/// guarantee the memset operation is completed.
+///
+/// \param pitch Specify the 3D memory region.
+/// \param value Value to be set.
+/// \param size The setted 3D memory size.
+/// \param q The queue in which the operation is done.
+/// \returns no return value.
+static inline sycl::event memset_async(pitched_data pitch, int val,
+                                       sycl::range<3> size,
+                                       sycl::queue q = get_default_queue()) {
+  auto events = detail::memset(q, pitch, val, size);
+  return detail::combine_events(events, q);
+}
+
+/// accessor used as device function parameter.
+template <class T, memory_region Memory, size_t Dimension> class accessor;
+template <class T, memory_region Memory> class accessor<T, Memory, 3> {
+public:
+  using memory_t = detail::memory_traits<Memory, T>;
+  using element_t = typename memory_t::element_t;
+  using pointer_t = typename memory_t::pointer_t;
+  using accessor_t = typename memory_t::template accessor_t<3>;
+  accessor(pointer_t data, const sycl::range<3> &in_range)
+      : _data(data), _range(in_range) {}
+  template <memory_region M = Memory>
+  accessor(typename std::enable_if<M != memory_region::local,
+                                   const accessor_t>::type &acc)
+      : accessor(acc, acc.get_range()) {}
+  accessor(const accessor_t &acc, const sycl::range<3> &in_range)
+      : accessor(acc.get_pointer(), in_range) {}
+  accessor<T, Memory, 2> operator[](size_t index) const {
+    sycl::range<2> sub(_range.get(1), _range.get(2));
+    return accessor<T, Memory, 2>(_data + index * sub.size(), sub);
+  }
+
+  pointer_t get_ptr() const { return _data; }
+
+private:
+  pointer_t _data;
+  sycl::range<3> _range;
+};
+template <class T, memory_region Memory> class accessor<T, Memory, 2> {
+public:
+  using memory_t = detail::memory_traits<Memory, T>;
+  using element_t = typename memory_t::element_t;
+  using pointer_t = typename memory_t::pointer_t;
+  using accessor_t = typename memory_t::template accessor_t<2>;
+  accessor(pointer_t data, const sycl::range<2> &in_range)
+      : _data(data), _range(in_range) {}
+  template <memory_region M = Memory>
+  accessor(typename std::enable_if<M != memory_region::local,
+                                   const accessor_t>::type &acc)
+      : accessor(acc, acc.get_range()) {}
+  accessor(const accessor_t &acc, const sycl::range<2> &in_range)
+      : accessor(acc.get_pointer(), in_range) {}
+
+  pointer_t operator[](size_t index) const {
+    return _data + _range.get(1) * index;
+  }
+
+  pointer_t get_ptr() const { return _data; }
+
+private:
+  pointer_t _data;
+  sycl::range<2> _range;
+};
+
+/// Device variable with address space of shared or global.
+template <class T, memory_region Memory, size_t Dimension> class device_memory {
+public:
+  using accessor_t =
+      typename detail::memory_traits<Memory, T>::template accessor_t<Dimension>;
+  using value_t = typename detail::memory_traits<Memory, T>::value_t;
+  using compat_accessor_t =
+      sycl::ext::oneapi::experimental::compat::accessor<T, Memory, Dimension>;
+
+  device_memory() : device_memory(sycl::range<Dimension>(1)) {}
+
+  /// Constructor of 1-D array with initializer list
+  device_memory(const sycl::range<Dimension> &in_range,
+                std::initializer_list<value_t> &&init_list)
+      : device_memory(in_range) {
+    assert(init_list.size() <= in_range.size());
+    _host_ptr = (value_t *)std::malloc(_size);
+    std::memset(_host_ptr, 0, _size);
+    std::memcpy(_host_ptr, init_list.begin(), init_list.size() * sizeof(T));
+  }
+
+  /// Constructor of 2-D array with initializer list
+  template <size_t D = Dimension>
+  device_memory(
+      const typename std::enable_if<D == 2, sycl::range<2>>::type &in_range,
+      std::initializer_list<std::initializer_list<value_t>> &&init_list)
+      : device_memory(in_range) {
+    assert(init_list.size() <= in_range[0]);
+    _host_ptr = (value_t *)std::malloc(_size);
+    std::memset(_host_ptr, 0, _size);
+    auto tmp_data = _host_ptr;
+    for (auto sub_list : init_list) {
+      assert(sub_list.size() <= in_range[1]);
+      std::memcpy(tmp_data, sub_list.begin(), sub_list.size() * sizeof(T));
+      tmp_data += in_range[1];
+    }
+  }
+
+  /// Constructor with range
+  device_memory(const sycl::range<Dimension> &range_in)
+      : _size(range_in.size() * sizeof(T)), _range(range_in), _reference(false),
+        _host_ptr(nullptr), _device_ptr(nullptr) {
+    static_assert((Memory == memory_region::global) ||
+                      (Memory == memory_region::usm_shared),
+                  "device memory region should be global or shared");
+    // Make sure that singleton class dev_mgr will destruct later than this.
+    detail::dev_mgr::instance();
+  }
+
+  /// Constructor with range
+  template <class... Args>
+  device_memory(Args... Arguments)
+      : device_memory(sycl::range<Dimension>(Arguments...)) {}
+
+  ~device_memory() {
+    if (_device_ptr && !_reference)
+      free(_device_ptr);
+    if (_host_ptr)
+      std::free(_host_ptr);
+  }
+
+  /// Allocate memory with default queue, and init memory if has initial value.
+  void init() { init(get_default_queue()); }
+  /// Allocate memory with specified queue, and init memory if has initial
+  /// value.
+  void init(sycl::queue q) {
+    if (_device_ptr)
+      return;
+    if (!_size)
+      return;
+    allocate_device(q);
+    if (_host_ptr)
+      detail::memcpy(q, _device_ptr, _host_ptr, _size);
+  }
+
+  /// The variable is assigned to a device pointer.
+  void assign(value_t *src, size_t size) {
+    this->~device_memory();
+    new (this) device_memory(src, size);
+  }
+
+  /// Get memory pointer of the memory object, which is virtual pointer when
+  /// usm is not used, and device pointer when usm is used.
+  value_t *get_ptr() { return get_ptr(get_default_queue()); }
+  /// Get memory pointer of the memory object, which is virtual pointer when
+  /// usm is not used, and device pointer when usm is used.
+  value_t *get_ptr(sycl::queue q) {
+    init(q);
+    return _device_ptr;
+  }
+
+  /// Get the device memory object size in bytes.
+  size_t get_size() { return _size; }
+
+  template <size_t D = Dimension>
+  typename std::enable_if<D == 1, T>::type &operator[](size_t index) {
+    init();
+    return _device_ptr[index];
+  }
+
+  /// Get compat_accessor with dimension info for the device memory object
+  /// when usm is used and dimension is greater than 1.
+  template <size_t D = Dimension>
+  typename std::enable_if<D != 1, compat_accessor_t>::type
+  get_access(sycl::handler &cgh) {
+    return compat_accessor_t((T *)_device_ptr, _range);
+  }
+
+private:
+  device_memory(value_t *memory_ptr, size_t size)
+      : _size(size), _range(size / sizeof(T)), _reference(true),
+        _device_ptr(memory_ptr) {}
+
+  void allocate_device(sycl::queue q) {
+    if (Memory == memory_region::usm_shared) {
+      _device_ptr = (value_t *)sycl::malloc_shared(_size, q.get_device(),
+                                                   q.get_context());
+      return;
+    }
+    _device_ptr = (value_t *)detail::malloc(_size, q);
+  }
+
+  size_t _size;
+  sycl::range<Dimension> _range;
+  bool _reference;
+  value_t *_host_ptr;
+  value_t *_device_ptr;
+};
+template <class T, memory_region Memory>
+class device_memory<T, Memory, 0> : public device_memory<T, Memory, 1> {
+public:
+  using base = device_memory<T, Memory, 1>;
+  using value_t = typename base::value_t;
+  using accessor_t =
+      typename detail::memory_traits<Memory, T>::template accessor_t<0>;
+
+  /// Constructor with initial value.
+  device_memory(const value_t &val) : base(sycl::range<1>(1), {val}) {}
+
+  /// Default constructor
+  device_memory() : base(1) {}
+};
+
+template <class T, size_t Dimension>
+using global_memory = device_memory<T, memory_region::global, Dimension>;
+template <class T, size_t Dimension>
+using shared_memory = device_memory<T, memory_region::usm_shared, Dimension>;
+
+class pointer_attributes {
+public:
+  void init(const void *ptr, sycl::queue q = get_default_queue()) {
+    memory_type = sycl::get_pointer_type(ptr, q.get_context());
+    device_pointer = (memory_type != sycl::usm::alloc::unknown) ? ptr : nullptr;
+    host_pointer = (memory_type != sycl::usm::alloc::unknown) &&
+                           (memory_type != sycl::usm::alloc::device)
+                       ? ptr
+                       : nullptr;
+    sycl::device device_obj = sycl::get_pointer_device(ptr, q.get_context());
+    device_id = detail::dev_mgr::instance().get_device_id(device_obj);
+  }
+
+  sycl::usm::alloc get_memory_type() { return memory_type; }
+
+  const void *get_device_pointer() { return device_pointer; }
+
+  const void *get_host_pointer() { return host_pointer; }
+
+  bool is_memory_shared() { return memory_type == sycl::usm::alloc::shared; }
+
+  unsigned int get_device_id() { return device_id; }
+
+private:
+  sycl::usm::alloc memory_type = sycl::usm::alloc::unknown;
+  const void *device_pointer = nullptr;
+  const void *host_pointer = nullptr;
+  unsigned int device_id = 0;
+};
+} // namespace ext::oneapi::experimental::compat
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
+} // namespace sycl

--- a/sycl/include/sycl/ext/oneapi/experimental/compat/util.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/compat/util.hpp
@@ -1,0 +1,545 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility extension
+ *
+ *  util.hpp
+ *
+ *  Description:
+ *    util functionality for the SYCL compatibility extension
+ **************************************************************************/
+
+// The original source was under the license below:
+//==---- util.hpp ---------------------------------*- C++ -*----------------==//
+//
+// Copyright (C) Intel Corporation
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#define SYCL_EXT_ONEAPI_COMPLEX
+
+#include <cassert>
+#include <complex>
+#include <sycl/ext/oneapi/experimental/sycl_complex.hpp>
+#include <sycl/sycl.hpp>
+#include <type_traits>
+
+namespace sycl::ext::oneapi::experimental::compat {
+
+namespace detail {
+template <int... Ints> struct integer_sequence {};
+template <int Size, int... Ints>
+struct make_index_sequence
+    : public make_index_sequence<Size - 1, Size - 1, Ints...> {};
+template <int... Ints>
+struct make_index_sequence<0, Ints...> : public integer_sequence<Ints...> {};
+
+template <typename T> struct DataType { using T2 = T; };
+template <typename T> struct DataType<sycl::vec<T, 2>> {
+  using T2 = sycl::ext::oneapi::experimental::complex<T>;
+};
+
+inline void matrix_mem_copy(void *to_ptr, const void *from_ptr, int to_ld,
+                            int from_ld, int rows, int cols, int elem_size,
+                            sycl::queue queue = get_default_queue(),
+                            bool async = false) {
+  if (to_ptr == from_ptr && to_ld == from_ld) {
+    return;
+  }
+
+  if (to_ld == from_ld) {
+    size_t cpoy_size = elem_size * ((cols - 1) * to_ld + rows);
+    if (async)
+      detail::memcpy(queue, (void *)to_ptr, (void *)from_ptr, cpoy_size);
+    else
+      detail::memcpy(queue, (void *)to_ptr, (void *)from_ptr, cpoy_size).wait();
+  } else {
+    if (async)
+      detail::memcpy(queue, to_ptr, from_ptr, elem_size * to_ld,
+                     elem_size * from_ld, elem_size * rows, cols);
+    else
+      sycl::event::wait(detail::memcpy(queue, to_ptr, from_ptr,
+                                       elem_size * to_ld, elem_size * from_ld,
+                                       elem_size * rows, cols));
+  }
+}
+
+/// Copy matrix data. The default leading dimension is column.
+/// \param [out] to_ptr A pointer points to the destination location.
+/// \param [in] from_ptr A pointer points to the source location.
+/// \param [in] to_ld The leading dimension the destination matrix.
+/// \param [in] from_ld The leading dimension the source matrix.
+/// \param [in] rows The number of rows of the source matrix.
+/// \param [in] cols The number of columns of the source matrix.
+/// \param [in] queue The queue where the routine should be executed.
+/// \param [in] async If this argument is true, the return of the function
+/// does NOT guarantee the copy is completed.
+template <typename T>
+inline void matrix_mem_copy(T *to_ptr, const T *from_ptr, int to_ld,
+                            int from_ld, int rows, int cols,
+                            sycl::queue queue = get_default_queue(),
+                            bool async = false) {
+  using Ty = typename DataType<T>::T2;
+  matrix_mem_copy((void *)to_ptr, (void *)from_ptr, to_ld, from_ld, rows, cols,
+                  sizeof(Ty), queue, async);
+}
+} // namespace detail
+
+/// Cast the high or low 32 bits of a double to an integer.
+/// \param [in] d The double value.
+/// \param [in] use_high32 Cast the high 32 bits of the double if true;
+/// otherwise cast the low 32 bits.
+inline int cast_double_to_int(double d, bool use_high32 = true) {
+  sycl::vec<double, 1> v0{d};
+  auto v1 = v0.as<sycl::int2>();
+  if (use_high32)
+    return v1[0];
+  return v1[1];
+}
+
+/// Combine two integers, the first as the high 32 bits and the second
+/// as the low 32 bits, into a double.
+/// \param [in] high32 The integer as the high 32 bits
+/// \param [in] low32 The integer as the low 32 bits
+inline double cast_ints_to_double(int high32, int low32) {
+  sycl::int2 v0{high32, low32};
+  auto v1 = v0.as<sycl::vec<double, 1>>();
+  return v1;
+}
+
+/// Compute fast_length for variable-length array
+/// \param [in] a The array
+/// \param [in] len Length of the array
+/// \returns The computed fast_length
+inline float fast_length(const float *a, int len) {
+  switch (len) {
+  case 1:
+    return sycl::fast_length(a[0]);
+  case 2:
+    return sycl::fast_length(sycl::float2(a[0], a[1]));
+  case 3:
+    return sycl::fast_length(sycl::float3(a[0], a[1], a[2]));
+  case 4:
+    return sycl::fast_length(sycl::float4(a[0], a[1], a[2], a[3]));
+  case 0:
+    return 0;
+  default:
+    float f = 0;
+    for (int i = 0; i < len; ++i)
+      f += a[i] * a[i];
+    return sycl::sqrt(f);
+  }
+}
+
+/// Compute vectorized max for two values, with each value treated as a vector
+/// type \p S
+/// \param [in] S The type of the vector
+/// \param [in] T The type of the original values
+/// \param [in] a The first value
+/// \param [in] b The second value
+/// \returns The vectorized max of the two values
+template <typename S, typename T> inline T vectorized_max(T a, T b) {
+  sycl::vec<T, 1> v0{a}, v1{b};
+  auto v2 = v0.template as<S>();
+  auto v3 = v1.template as<S>();
+  v2 = sycl::max(v2, v3);
+  v0 = v2.template as<sycl::vec<T, 1>>();
+  return v0;
+}
+
+/// Compute vectorized min for two values, with each value treated as a vector
+/// type \p S
+/// \param [in] S The type of the vector
+/// \param [in] T The type of the original values
+/// \param [in] a The first value
+/// \param [in] b The second value
+/// \returns The vectorized min of the two values
+template <typename S, typename T> inline T vectorized_min(T a, T b) {
+  sycl::vec<T, 1> v0{a}, v1{b};
+  auto v2 = v0.template as<S>();
+  auto v3 = v1.template as<S>();
+  v2 = sycl::min(v2, v3);
+  v0 = v2.template as<sycl::vec<T, 1>>();
+  return v0;
+}
+
+/// Compute vectorized isgreater for two values, with each value treated as a
+/// vector type \p S
+/// \param [in] S The type of the vector
+/// \param [in] T The type of the original values
+/// \param [in] a The first value
+/// \param [in] b The second value
+/// \returns The vectorized greater than of the two values
+template <typename S, typename T> inline T vectorized_isgreater(T a, T b) {
+  sycl::vec<T, 1> v0{a}, v1{b};
+  auto v2 = v0.template as<S>();
+  auto v3 = v1.template as<S>();
+  auto v4 = sycl::isgreater(v2, v3);
+  v0 = v4.template as<sycl::vec<T, 1>>();
+  return v0;
+}
+
+/// Compute vectorized isgreater for two unsigned int values, with each value
+/// treated as a vector of two unsigned short
+/// \param [in] a The first value
+/// \param [in] b The second value
+/// \returns The vectorized greater than of the two values
+template <>
+inline unsigned vectorized_isgreater<sycl::ushort2, unsigned>(unsigned a,
+                                                              unsigned b) {
+  sycl::vec<unsigned, 1> v0{a}, v1{b};
+  auto v2 = v0.template as<sycl::ushort2>();
+  auto v3 = v1.template as<sycl::ushort2>();
+  sycl::ushort2 v4;
+  v4[0] = v2[0] > v3[0];
+  v4[1] = v2[1] > v3[1];
+  v0 = v4.template as<sycl::vec<unsigned, 1>>();
+  return v0;
+}
+
+/// Reverse the bit order of an unsigned integer
+/// \param [in] a Input unsigned integer value
+/// \returns Value of a with the bit order reversed
+template <typename T> inline T reverse_bits(T a) {
+  static_assert(std::is_unsigned<T>::value && std::is_integral<T>::value,
+                "unsigned integer required");
+  if (!a)
+    return 0;
+  T mask = 0;
+  size_t count = 4 * sizeof(T);
+  mask = ~mask >> count;
+  while (count) {
+    a = ((a & mask) << count) | ((a & ~mask) >> count);
+    count = count >> 1;
+    mask = mask ^ (mask << count);
+  }
+  return a;
+}
+
+/// \param [in] a The first value contains 4 bytes
+/// \param [in] b The second value contains 4 bytes
+/// \param [in] s The selector value, only lower 16bit used
+/// \returns the permutation result of 4 bytes selected in the way
+/// specified by \p s from \p a and \p b
+inline unsigned int byte_level_permute(unsigned int a, unsigned int b,
+                                       unsigned int s) {
+  unsigned int ret;
+  ret =
+      ((((std::uint64_t)b << 32 | a) >> (s & 0x7) * 8) & 0xff) |
+      (((((std::uint64_t)b << 32 | a) >> ((s >> 4) & 0x7) * 8) & 0xff) << 8) |
+      (((((std::uint64_t)b << 32 | a) >> ((s >> 8) & 0x7) * 8) & 0xff) << 16) |
+      (((((std::uint64_t)b << 32 | a) >> ((s >> 12) & 0x7) * 8) & 0xff) << 24);
+  return ret;
+}
+
+/// Find position of first least significant set bit in an integer.
+/// ffs(0) returns 0.
+///
+/// \param [in] a Input integer value
+/// \returns The position
+template <typename T> inline int ffs(T a) {
+  static_assert(std::is_integral<T>::value, "integer required");
+  return (sycl::ctz(a) + 1) % (sizeof(T) * 8 + 1);
+}
+
+/// select_from_sub_group allows work-items to obtain a copy of a value held by
+/// any other work-item in the sub_group. The input sub_group will be divided
+/// into several logical sub_groups with id range [0, \p logical_sub_group_size
+/// - 1]. Each work-item in logical sub_group gets value from another work-item
+/// whose id is \p remote_local_id. If \p remote_local_id is outside the
+/// logical sub_group id range, \p remote_local_id will modulo with \p
+/// logical_sub_group_size. The \p logical_sub_group_size must be a power of 2
+/// and not exceed input sub_group size.
+/// \tparam T Input value type
+/// \param [in] g Input sub_group
+/// \param [in] x Input value
+/// \param [in] remote_local_id Input source work item id
+/// \param [in] logical_sub_group_size Input logical sub_group size
+/// \returns The result
+template <typename T>
+T select_from_sub_group(sycl::sub_group g, T x, int remote_local_id,
+                        int logical_sub_group_size = 32) {
+  unsigned int start_index =
+      g.get_local_linear_id() / logical_sub_group_size * logical_sub_group_size;
+  return sycl::select_from_group(
+      g, x, start_index + remote_local_id % logical_sub_group_size);
+}
+
+/// shift_sub_group_left move values held by the work-items in a sub_group
+/// directly to another work-item in the sub_group, by shifting values a fixed
+/// number of work-items to the left. The input sub_group will be divided into
+/// several logical sub_groups with id range [0, \p logical_sub_group_size - 1].
+/// Each work-item in logical sub_group gets value from another work-item whose
+/// id is caller's id adds \p delta. If calculated id is outside the logical
+/// sub_group id range, the work-item will get value from itself. The \p
+/// logical_sub_group_size must be a power of 2 and not exceed input sub_group
+/// size.
+/// \tparam T Input value type
+/// \param [in] g Input sub_group
+/// \param [in] x Input value
+/// \param [in] delta Input delta
+/// \param [in] logical_sub_group_size Input logical sub_group size
+/// \returns The result
+template <typename T>
+T shift_sub_group_left(sycl::sub_group g, T x, unsigned int delta,
+                       int logical_sub_group_size = 32) {
+  unsigned int id = g.get_local_linear_id();
+  unsigned int end_index =
+      (id / logical_sub_group_size + 1) * logical_sub_group_size;
+  T result = sycl::shift_group_left(g, x, delta);
+  if ((id + delta) >= end_index) {
+    result = x;
+  }
+  return result;
+}
+
+/// shift_sub_group_right move values held by the work-items in a sub_group
+/// directly to another work-item in the sub_group, by shifting values a fixed
+/// number of work-items to the right. The input sub_group will be divided into
+/// several logical_sub_groups with id range [0, \p logical_sub_group_size - 1].
+/// Each work-item in logical_sub_group gets value from another work-item whose
+/// id is caller's id subtracts \p delta. If calculated id is outside the
+/// logical sub_group id range, the work-item will get value from itself. The \p
+/// logical_sub_group_size must be a power of 2 and not exceed input sub_group
+/// size.
+/// \tparam T Input value type
+/// \param [in] g Input sub_group
+/// \param [in] x Input value
+/// \param [in] delta Input delta
+/// \param [in] logical_sub_group_size Input logical sub_group size
+/// \returns The result
+template <typename T>
+T shift_sub_group_right(sycl::sub_group g, T x, unsigned int delta,
+                        int logical_sub_group_size = 32) {
+  unsigned int id = g.get_local_linear_id();
+  unsigned int start_index =
+      id / logical_sub_group_size * logical_sub_group_size;
+  T result = sycl::shift_group_right(g, x, delta);
+  if ((id - start_index) < delta) {
+    result = x;
+  }
+  return result;
+}
+
+/// permute_sub_group_by_xor permutes values by exchanging values held by pairs
+/// of work-items identified by computing the bitwise exclusive OR of the
+/// work-item id and some fixed mask. The input sub_group will be divided into
+/// several logical sub_groups with id range [0, \p logical_sub_group_size - 1].
+/// Each work-item in logical sub_group gets value from another work-item whose
+/// id is bitwise exclusive OR of the caller's id and \p mask. If calculated id
+/// is outside the logical sub_group id range, the work-item will get value from
+/// itself. The \p logical_sub_group_size must be a power of 2 and not exceed
+/// input sub_group size.
+/// \tparam T Input value type
+/// \param [in] g Input sub_group
+/// \param [in] x Input value
+/// \param [in] mask Input mask
+/// \param [in] logical_sub_group_size Input logical sub_group size
+/// \returns The result
+template <typename T>
+T permute_sub_group_by_xor(sycl::sub_group g, T x, unsigned int mask,
+                           int logical_sub_group_size = 32) {
+  unsigned int id = g.get_local_linear_id();
+  unsigned int start_index =
+      id / logical_sub_group_size * logical_sub_group_size;
+  unsigned int target_offset = (id % logical_sub_group_size) ^ mask;
+  return sycl::select_from_group(g, x,
+                                 target_offset < logical_sub_group_size
+                                     ? start_index + target_offset
+                                     : id);
+}
+
+/// Computes the multiplication of two complex numbers.
+/// \tparam T Complex element type
+/// \param [in] x The first input complex number
+/// \param [in] y The second input complex number
+/// \returns The result
+template <typename T>
+sycl::vec<T, 2> cmul(sycl::vec<T, 2> x, sycl::vec<T, 2> y) {
+  sycl::ext::oneapi::experimental::complex<T> t1(x[0], x[1]), t2(y[0], y[1]);
+  t1 = t1 * t2;
+  return sycl::vec<T, 2>(t1.real(), t1.imag());
+}
+
+/// Computes the division of two complex numbers.
+/// \tparam T Complex element type
+/// \param [in] x The first input complex number
+/// \param [in] y The second input complex number
+/// \returns The result
+template <typename T>
+sycl::vec<T, 2> cdiv(sycl::vec<T, 2> x, sycl::vec<T, 2> y) {
+  sycl::ext::oneapi::experimental::complex<T> t1(x[0], x[1]), t2(y[0], y[1]);
+  t1 = t1 / t2;
+  return sycl::vec<T, 2>(t1.real(), t1.imag());
+}
+
+/// Computes the magnitude of a complex number.
+/// \tparam T Complex element type
+/// \param [in] x The input complex number
+/// \returns The result
+template <typename T> T cabs(sycl::vec<T, 2> x) {
+  sycl::ext::oneapi::experimental::complex<T> t(x[0], x[1]);
+  return abs(t);
+}
+
+/// Computes the complex conjugate of a complex number.
+/// \tparam T Complex element type
+/// \param [in] x The input complex number
+/// \returns The result
+template <typename T> sycl::vec<T, 2> conj(sycl::vec<T, 2> x) {
+  sycl::ext::oneapi::experimental::complex<T> t(x[0], x[1]);
+  t = conj(t);
+  return sycl::vec<T, 2>(t.real(), t.imag());
+}
+
+/// Inherited from the original SYCLomatic compatibility headers.
+/// @return compiler's SYCL version if defined, 202000 otherwise.
+inline int get_sycl_language_version() {
+#ifdef SYCL_LANGUAGE_VERSION
+  return SYCL_LANGUAGE_VERSION;
+#else
+  return 202000;
+#endif
+}
+
+namespace experimental {
+/// Synchronize work items from all work groups within a SYCL kernel.
+/// \param [in] item:  Represents a work group.
+/// \param [in] counter: An atomic object defined on a device memory which can
+/// be accessed by work items in all work groups. The initial value of the
+/// counter should be zero.
+/// Note: Please make sure that all the work items of all work groups within
+/// a SYCL kernel can be scheduled actively at the same time on a device.
+template <int dimensions = 3>
+inline void nd_range_barrier(
+    sycl::nd_item<dimensions> item,
+    sycl::atomic_ref<unsigned int, sycl::memory_order::acq_rel,
+                     sycl::memory_scope::device,
+                     sycl::access::address_space::global_space> &counter) {
+
+  static_assert(dimensions == 3, "dimensions must be 3.");
+  constexpr unsigned int MSB32_MASK = 0x80000000;
+
+  unsigned int num_groups = item.get_group_range(2) * item.get_group_range(1) *
+                            item.get_group_range(0);
+
+  item.barrier();
+
+  if (item.get_local_linear_id() == 0) {
+    unsigned int inc = 1;
+    unsigned int old_arrive = 0;
+    bool is_group0 =
+        (item.get_group(2) + item.get_group(1) + item.get_group(0) == 0);
+    if (is_group0) {
+      inc = MSB32_MASK - (num_groups - 1);
+    }
+
+    old_arrive = counter.fetch_add(inc);
+    // Synchronize all the work groups
+    while (((old_arrive ^ counter.load()) & MSB32_MASK) == 0)
+      ;
+  }
+
+  item.barrier();
+}
+
+/// Synchronize work items from all work groups within a SYCL kernel.
+/// \param [in] item:  Represents a work group.
+/// \param [in] counter: An atomic object defined on a device memory which can
+/// be accessed by work items in all work groups. The initial value of the
+/// counter should be zero.
+/// Note: Please make sure that all the work items of all work groups within
+/// a SYCL kernel can be scheduled actively at the same time on a device.
+template <>
+inline void nd_range_barrier(
+    sycl::nd_item<1> item,
+    sycl::atomic_ref<unsigned int, sycl::memory_order::acq_rel,
+                     sycl::memory_scope::device,
+                     sycl::access::address_space::global_space> &counter) {
+  unsigned int num_groups = item.get_group_range(0);
+  constexpr unsigned int MSB32_MASK = 0x80000000;
+
+  item.barrier();
+
+  if (item.get_local_linear_id() == 0) {
+    unsigned int inc = 1;
+    unsigned int old_arrive = 0;
+    bool is_group0 = (item.get_group(0) == 0);
+    if (is_group0) {
+      inc = MSB32_MASK - (num_groups - 1);
+    }
+
+    old_arrive = counter.fetch_add(inc);
+    // Synchronize all the work groups
+    while (((old_arrive ^ counter.load()) & MSB32_MASK) == 0)
+      ;
+  }
+
+  item.barrier();
+}
+
+/// The logical-group is a logical collection of some work-items within a
+/// work-group.
+/// Note: Please make sure that the logical-group size is a power of 2 in the
+/// range [1, current_sub_group_size].
+class logical_group {
+  sycl::nd_item<3> _item;
+  sycl::group<3> _g;
+  uint32_t _logical_group_size;
+  uint32_t _group_linear_range_in_parent;
+
+public:
+  /// Dividing \p parent_group into several logical-groups.
+  /// \param [in] item Current work-item.
+  /// \param [in] parent_group The group to be divided.
+  /// \param [in] size The logical-group size.
+  logical_group(sycl::nd_item<3> item, sycl::group<3> parent_group,
+                uint32_t size)
+      : _item(item), _g(parent_group), _logical_group_size(size) {
+    _group_linear_range_in_parent =
+        (_g.get_local_linear_range() - 1) / _logical_group_size + 1;
+  }
+  /// Returns the index of the work-item within the logical-group.
+  uint32_t get_local_linear_id() const {
+    return _item.get_local_linear_id() % _logical_group_size;
+  }
+  /// Returns the index of the logical-group in the parent group.
+  uint32_t get_group_linear_id() const {
+    return _item.get_local_linear_id() / _logical_group_size;
+  }
+  /// Returns the number of work-items in the logical-group.
+  uint32_t get_local_linear_range() const {
+    if (_g.get_local_linear_range() % _logical_group_size == 0) {
+      return _logical_group_size;
+    }
+    uint32_t last_item_group_id =
+        _g.get_local_linear_range() / _logical_group_size;
+    uint32_t first_of_last_group = last_item_group_id * _logical_group_size;
+    if (_item.get_local_linear_id() >= first_of_last_group) {
+      return _g.get_local_linear_range() - first_of_last_group;
+    } else {
+      return _logical_group_size;
+    }
+  }
+  /// Returns the number of logical-group in the parent group.
+  uint32_t get_group_linear_range() const {
+    return _group_linear_range_in_parent;
+  }
+};
+} // namespace experimental
+} // namespace sycl::ext::oneapi::experimental::compat

--- a/sycl/unittests/Extensions/CMakeLists.txt
+++ b/sycl/unittests/Extensions/CMakeLists.txt
@@ -9,3 +9,4 @@ add_sycl_unittest(ExtensionsTests OBJECT
   OneAPISubGroupMask.cpp
 )
 
+add_subdirectory(compat)

--- a/sycl/unittests/Extensions/compat/CMakeLists.txt
+++ b/sycl/unittests/Extensions/compat/CMakeLists.txt
@@ -1,0 +1,38 @@
+#
+# Copyright (C) Codeplay Software Ltd.
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SYCL compatibility API
+#
+
+set(SYCL_COMPAT_TEST_FLAGS -fsycl -fsycl-unnamed-lambda
+                           -fsycl-device-code-split=per_kernel)
+
+macro(add_sycl_unittest_with_extra_flags test_dirname link_variant)
+  add_sycl_unittest(${test_dirname} ${link_variant} ${ARGN})
+
+  target_compile_options(${test_dirname} PRIVATE ${SYCL_COMPAT_TEST_FLAGS})
+  target_link_options(${test_dirname} PRIVATE ${SYCL_COMPAT_TEST_FLAGS})
+endmacro()
+
+add_sycl_unittest_with_extra_flags(Extensionscompattests SHARED
+  Device.cpp
+  Dim.cpp
+  Defs.cpp
+  IdQuery.cpp
+  Launch.cpp
+)
+
+add_subdirectory(atomic)
+add_subdirectory(kernel)
+add_subdirectory(memory)
+add_subdirectory(util)

--- a/sycl/unittests/Extensions/compat/Defs.cpp
+++ b/sycl/unittests/Extensions/compat/Defs.cpp
@@ -1,0 +1,33 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  Defs.cpp
+ *
+ *  Description:
+ *     __sycl_compat_align__ tests
+ **************************************************************************/
+
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+TEST(DPCT, Align) {
+  struct {
+    int a;
+    char c;
+  } __sycl_compat_align__(16) s;
+  EXPECT_EQ(sizeof(s), 16);
+}

--- a/sycl/unittests/Extensions/compat/Device.cpp
+++ b/sycl/unittests/Extensions/compat/Device.cpp
@@ -1,0 +1,205 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  Device.cpp
+ *
+ *  Description:
+ *    Device info and selection tests
+ **************************************************************************/
+
+// The original source was under the license below:
+//===-- Device.cpp -  -*- C++ -* ------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+
+/*
+  Device Tests
+*/
+
+class DeviceTestsFixt : public ::testing::Test {
+protected:
+  unsigned int n_devices{};
+  sycl::queue def_q_;
+
+public:
+  DeviceTestsFixt()
+      : n_devices{compat::detail::dev_mgr::instance().device_count()},
+        def_q_{compat::get_default_queue()} {}
+};
+
+TEST_F(DeviceTestsFixt, AtLeastOneDevice) { EXPECT_GT(n_devices, 0); }
+
+// Check multiple threads get same device by default
+TEST(Device, Threads) {
+  unsigned int thread_dev_id{};
+  std::thread other_thread{
+      [&]() { thread_dev_id = compat::get_current_device_id(); }};
+  other_thread.join();
+  EXPECT_EQ(thread_dev_id, compat::get_current_device_id());
+}
+
+// Check a thread is able to select a non-default device
+TEST_F(DeviceTestsFixt, DeviceSelect) {
+  if (n_devices == 1)
+    GTEST_SKIP(); // Can only test this w/ multiple devices
+
+  constexpr unsigned int TARGET_DEV = 1;
+  unsigned int thread_dev_id{};
+  std::thread other_thread{[&]() {
+    compat::select_device(TARGET_DEV);
+    thread_dev_id = compat::get_current_device_id();
+  }};
+  other_thread.join();
+  EXPECT_EQ(thread_dev_id, TARGET_DEV);
+}
+
+// Check the device returned matches the device ID
+TEST(Device, MatchesID) {
+  EXPECT_EQ(compat::get_device(compat::get_current_device_id()),
+            compat::get_current_device());
+}
+
+// Check error on insufficient devices
+TEST_F(DeviceTestsFixt, NotEnoughDevices) {
+  EXPECT_THROW(compat::select_device(n_devices), std::runtime_error);
+}
+
+// Check the default context matches default queue's context
+TEST_F(DeviceTestsFixt, DefaultContext) {
+  EXPECT_EQ(def_q_.get_context(), compat::get_default_context());
+}
+
+/*
+  Queue Tests
+*/
+
+class DefaultQueueTest : public ::testing::Test {
+protected:
+  sycl::queue q_;
+
+public:
+  DefaultQueueTest() : q_{compat::get_default_queue()} {}
+};
+
+TEST_F(DefaultQueueTest, MakeInOrderQueue) { EXPECT_TRUE(q_.is_in_order()); }
+
+TEST_F(DefaultQueueTest, CheckDefaultDevice) {
+  EXPECT_EQ(q_.get_device(), sycl::device{sycl::default_selector_v});
+}
+
+// Check behaviour of in order & out of order queue construction
+TEST(Queues, QueuePropOrder) {
+  sycl::queue q_create_def{compat::create_queue()};
+  EXPECT_TRUE(q_create_def.is_in_order());
+  sycl::queue q_in_order{compat::create_queue(false, true)};
+  EXPECT_TRUE(q_in_order.is_in_order());
+  sycl::queue q_out_order{compat::create_queue(false, false)};
+  EXPECT_FALSE(q_out_order.is_in_order());
+}
+
+class DeviceExtFixt : public ::testing::Test {
+protected:
+  compat::device_ext &dev_;
+
+public:
+  DeviceExtFixt() : dev_{compat::get_current_device()} {}
+
+  void SetUp() { dev_.reset(); }
+};
+
+TEST_F(DeviceExtFixt, DeviceExtAPI) {
+  dev_.is_native_host_atomic_supported();
+  dev_.get_major_version();
+  dev_.get_minor_version();
+  dev_.get_max_compute_units();
+  dev_.get_max_clock_frequency();
+  dev_.get_integrated();
+  compat::device_info Info;
+  dev_.get_device_info(Info);
+  Info = dev_.get_device_info();
+  dev_.reset();
+  auto QueuePtr = dev_.default_queue();
+  dev_.queues_wait_and_throw();
+  QueuePtr = dev_.create_queue();
+  dev_.destroy_queue(QueuePtr);
+  QueuePtr = dev_.create_queue();
+  dev_.set_saved_queue(QueuePtr);
+  QueuePtr = dev_.get_saved_queue();
+  auto Context = dev_.get_context();
+}
+
+TEST_F(DeviceExtFixt, DefaultSavedQueue) {
+  EXPECT_EQ(*dev_.default_queue(), *dev_.get_saved_queue());
+}
+
+TEST_F(DeviceExtFixt, SavedQueue) {
+  auto q = *dev_.create_queue();
+  dev_.set_saved_queue(&q);
+  EXPECT_EQ(q, *dev_.get_saved_queue());
+}
+
+// Check reset() resets the queues etc
+TEST_F(DeviceExtFixt, Reset) {
+  auto q = *dev_.create_queue();
+  dev_.set_saved_queue(&q);
+  dev_.reset();
+  EXPECT_NE(q, *dev_.get_saved_queue());
+}
+
+TEST(DeviceInfo, DeviceInfoAPI) {
+  compat::device_info Info;
+  const char *Name = "DEVNAME";
+  Info.set_name(Name);
+  sycl::id<3> max_work_item_sizes;
+  Info.set_max_work_item_sizes(max_work_item_sizes);
+  Info.set_major_version(1);
+  Info.set_minor_version(1);
+  Info.set_integrated(1);
+  Info.set_max_clock_frequency(1000);
+  Info.set_max_compute_units(32);
+  Info.set_global_mem_size(1000);
+  Info.set_local_mem_size(1000);
+  Info.set_max_work_group_size(32);
+  Info.set_max_sub_group_size(16);
+  Info.set_max_work_items_per_compute_unit(16);
+  int SizeArray[3] = {1, 2, 3};
+  Info.set_max_nd_range_size(SizeArray);
+
+  EXPECT_STREQ(Info.get_name(), Name);
+  EXPECT_EQ(Info.get_max_work_item_sizes(), max_work_item_sizes);
+  EXPECT_EQ(Info.get_minor_version(), 1);
+  EXPECT_EQ(Info.get_integrated(), 1);
+  EXPECT_EQ(Info.get_max_clock_frequency(), 1000);
+  EXPECT_EQ(Info.get_max_compute_units(), 32);
+  EXPECT_EQ(Info.get_max_work_group_size(), 32);
+  EXPECT_EQ(Info.get_max_sub_group_size(), 16);
+  EXPECT_EQ(Info.get_max_work_items_per_compute_unit(), 16);
+  EXPECT_EQ(Info.get_max_nd_range_size()[0], SizeArray[0]);
+  EXPECT_EQ(Info.get_max_nd_range_size()[1], SizeArray[1]);
+  EXPECT_EQ(Info.get_max_nd_range_size()[2], SizeArray[2]);
+  EXPECT_EQ(Info.get_global_mem_size(), 1000);
+  EXPECT_EQ(Info.get_local_mem_size(), 1000);
+}

--- a/sycl/unittests/Extensions/compat/Dim.cpp
+++ b/sycl/unittests/Extensions/compat/Dim.cpp
@@ -1,0 +1,113 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  Dim.cpp
+ *
+ *  Description:
+ *     dim3 tests
+ **************************************************************************/
+
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+
+TEST(DimTest, Construct) {
+  compat::dim3 d3(512);
+  EXPECT_EQ(d3.x, 512);
+  EXPECT_EQ(d3.y, 1);
+  EXPECT_EQ(d3.z, 1);
+}
+
+TEST(DimTest, Convert) {
+  compat::dim3 d3(512);
+  sycl::range<3> r3 = d3;
+  EXPECT_EQ(d3.x, r3[2]);
+  EXPECT_EQ(d3.y, r3[1]);
+  EXPECT_EQ(d3.z, r3[0]);
+
+  sycl::range<2> r2{1, 2};
+  compat::dim3 d3_from_range2(r2);
+  EXPECT_EQ(d3_from_range2.x, 2);
+  EXPECT_EQ(d3_from_range2.y, 1);
+  EXPECT_EQ(d3_from_range2.z, 1);
+
+  sycl::range<1> r1{2};
+  compat::dim3 d3_from_range1(r1);
+  EXPECT_EQ(d3_from_range2.x, 2);
+  EXPECT_EQ(d3_from_range2.y, 1);
+  EXPECT_EQ(d3_from_range2.z, 1);
+}
+
+TEST(DimTest, ConvertBack) {
+  // Dimension-dependent conversions and
+  // check that exceptions are thrown when trying to convert
+  // higher dimensional dim3 to sycl::range
+  {
+    compat::dim3 dim_3D(512, 4, 2);
+
+    sycl::range<3> range_3D{dim_3D};
+    sycl::range<3> exp_3D{2, 4, 512};
+    EXPECT_EQ(range_3D, exp_3D);
+
+    EXPECT_THROW(sycl::range<2> range_2D{dim_3D}, std::invalid_argument);
+    EXPECT_THROW(sycl::range<1> range_1D{dim_3D}, std::invalid_argument);
+  }
+  {
+    compat::dim3 dim_2D(512, 2);
+
+    sycl::range<3> range_3D{dim_2D};
+    sycl::range<3> exp_3D{1, 2, 512};
+    EXPECT_EQ(range_3D, exp_3D);
+
+    sycl::range<2> range_2D{dim_2D};
+    sycl::range<2> exp_2D{2, 512};
+    EXPECT_EQ(range_2D, exp_2D);
+
+    EXPECT_THROW(sycl::range<1> range_1D{dim_2D}, std::invalid_argument);
+  }
+  {
+    compat::dim3 dim_1D{512};
+    sycl::range<3> range_3D{dim_1D};
+    sycl::range<3> exp_3D{1, 1, 512};
+    EXPECT_EQ(range_3D, exp_3D);
+
+    sycl::range<2> range_2D{dim_1D};
+    sycl::range<2> exp_2D{1, 512};
+    EXPECT_EQ(range_2D, exp_2D);
+
+    sycl::range<1> range_1D{dim_1D};
+    sycl::range<1> exp_1D{512};
+    EXPECT_EQ(range_1D, exp_1D);
+  }
+}
+
+// Check that an nd_range is correctly constructed
+// from pair of dim3
+TEST(DimTest, ConvertMulti) {
+  compat::dim3 threads(32, 4, 2);
+  compat::dim3 grid(4, 1, 1);
+
+  sycl::nd_range<3> range{grid * threads, threads};
+
+  EXPECT_EQ(range.get_global_range()[0], 2);
+  EXPECT_EQ(range.get_global_range()[1], 4);
+  EXPECT_EQ(range.get_global_range()[2], 128);
+  EXPECT_EQ(range.get_local_range()[0], 2);
+  EXPECT_EQ(range.get_local_range()[1], 4);
+  EXPECT_EQ(range.get_local_range()[2], 32);
+}

--- a/sycl/unittests/Extensions/compat/IdQuery.cpp
+++ b/sycl/unittests/Extensions/compat/IdQuery.cpp
@@ -1,0 +1,149 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  IdQuery.cpp
+ *
+ *  Description:
+ *    global_id query tests
+ **************************************************************************/
+
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <numeric>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+
+// Class to launch a kernel and run a lambda on output data
+template <auto F> class QueryLauncher {
+protected:
+  compat::dim3 grid_;
+  compat::dim3 threads_;
+  size_t size_;
+  int *data_;
+  std::vector<int> host_data_;
+  using CheckLambda = std::function<void(std::vector<int>)>;
+
+public:
+  QueryLauncher(compat::dim3 grid, compat::dim3 threads)
+      : grid_{grid}, threads_{threads}, size_{grid_.size() * threads_.size()},
+        host_data_(size_) {
+    data_ = (int *)compat::malloc(size_ * sizeof(int));
+    compat::memset(data_, 0, size_ * sizeof(int));
+  };
+  ~QueryLauncher() { compat::free(data_); }
+  template <typename... Args>
+  void launch_dim3(CheckLambda checker, Args... args) {
+    compat::launch<F>(grid_, threads_, data_, args...);
+    compat::memcpy(host_data_.data(), data_, size_ * sizeof(int));
+    compat::wait();
+    checker(host_data_);
+  }
+  template <int Dim, typename... Args>
+  void launch_ndrange(CheckLambda checker, Args... args) {
+    sycl::nd_range<Dim> range = {grid_ * threads_, grid_};
+    compat::launch<F>(range, data_, args...);
+    compat::memcpy(host_data_.data(), data_, size_ * sizeof(int));
+    compat::wait();
+    checker(host_data_);
+  }
+};
+
+void global_id_x_query(int *data) {
+  data[compat::global_id::x()] = compat::global_id::x();
+}
+void global_id_y_query(int *data) {
+  data[compat::global_id::y()] = compat::global_id::y();
+}
+void global_id_z_query(int *data) {
+  data[compat::global_id::z()] = compat::global_id::z();
+}
+
+TEST(queries, global_id_query) {
+  constexpr compat::dim3 grid{4};
+  constexpr compat::dim3 threads{32};
+
+  auto checker = [](std::vector<int> input) {
+    std::vector<int> expected(input.size());
+    std::iota(expected.begin(), expected.end(), 0);
+    EXPECT_TRUE(std::equal(expected.begin(), expected.end(), input.begin()));
+  };
+  // Check we can query x, y, z components of global_id
+  QueryLauncher<global_id_x_query>({4, 1, 1}, {32, 1, 1}).launch_dim3(checker);
+  QueryLauncher<global_id_y_query>({1, 4, 1}, {1, 32, 1}).launch_dim3(checker);
+  QueryLauncher<global_id_z_query>({1, 1, 4}, {1, 1, 32}).launch_dim3(checker);
+
+  // Check that we can query x component, irrespective of the kernel dimension
+  QueryLauncher<global_id_x_query>({4, 1, 1}, {32, 1, 1})
+      .launch_ndrange<3>(checker);
+  QueryLauncher<global_id_x_query>({4, 1, 1}, {32, 1, 1})
+      .launch_ndrange<2>(checker);
+  QueryLauncher<global_id_x_query>({4, 1, 1}, {32, 1, 1})
+      .launch_ndrange<1>(checker);
+
+  // Check we can query y component for 2D kernel
+  QueryLauncher<global_id_y_query>({1, 4, 1}, {1, 32, 1})
+      .launch_ndrange<2>(checker);
+}
+
+void range_x_query(int *data) {
+  data[compat::global_id::x()] = compat::global_range::x() *
+                                 compat::work_group_range::x() *
+                                 compat::local_range::x();
+}
+
+TEST(queries, ranges_query) {
+  constexpr compat::dim3 grid{4};
+  constexpr compat::dim3 threads{32};
+
+  // global_range::x() * work_group_range::x() * local_range::x();
+  int target = grid.x * threads.x * grid.x * threads.x;
+
+  auto checker = [&](std::vector<int> input) {
+    EXPECT_TRUE(std::all_of(input.begin(), input.end(),
+                            [=](int a) { return a == target; }));
+  };
+  QueryLauncher<range_x_query>(grid, threads).launch_dim3(checker);
+}
+
+void wgroup_id_x_query(int *data) {
+  data[compat::global_id::x()] = compat::work_group_id::x();
+}
+void local_id_x_query(int *data) {
+  data[compat::global_id::x()] = compat::local_id::x();
+}
+
+TEST(queries, ids_query) {
+  constexpr compat::dim3 grid{4};
+  constexpr compat::dim3 threads{32};
+
+  auto wgroup_checker = [&](std::vector<int> input) {
+    for (int i = 0; i < input.size(); ++i) {
+      if (input[i] != i / threads.x)
+        FAIL();
+    }
+  };
+  QueryLauncher<wgroup_id_x_query>(grid, threads).launch_dim3(wgroup_checker);
+
+  auto local_checker = [&](std::vector<int> input) {
+    for (int i = 0; i < input.size(); ++i) {
+      if (input[i] != i % threads.x)
+        FAIL();
+    }
+  };
+  QueryLauncher<local_id_x_query>(grid, threads).launch_dim3(local_checker);
+}

--- a/sycl/unittests/Extensions/compat/Launch.cpp
+++ b/sycl/unittests/Extensions/compat/Launch.cpp
@@ -1,0 +1,403 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  Launch.cpp
+ *
+ *  Description:
+ *     launch<F> and launch<F> with dinamyc local memory tests
+ **************************************************************************/
+
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+#include <type_traits>
+
+using namespace sycl::ext::oneapi::experimental;
+
+// Struct containing test case data (local & global ranges)
+template <int Dim> struct RangeParams {
+  RangeParams(sycl::range<Dim> global_range_in, sycl::range<Dim> local_range,
+              sycl::range<Dim> expect_global_range_out, bool pass)
+      : global_range_in_{global_range_in}, local_range_in_{local_range},
+        expect_global_range_out_{expect_global_range_out}, shouldPass_{pass} {}
+  // Gtest requires explicit default ctor
+  RangeParams()
+      : global_range_in_{1, 1, 1}, local_range_in_{1, 1, 1},
+        expect_global_range_out_{1, 1, 1}, shouldPass_{true} {};
+
+  sycl::range<Dim> local_range_in_;
+  sycl::range<Dim> global_range_in_;
+  sycl::range<Dim> expect_global_range_out_;
+  bool shouldPass_;
+
+  // Pretty printing of RangeParams
+  friend std::ostream &operator<<(std::ostream &os, const RangeParams &range) {
+    auto print_range = [](std::ostream &os, const sycl::range<Dim> range) {
+      os << " {";
+      for (int i = 0; i < Dim; ++i) {
+        os << range[i];
+        os << ((Dim - i == 1) ? "} " : ", ");
+      }
+    };
+    os << "Local:";
+    print_range(os, range.local_range_in_);
+    os << "Global (in): ";
+    print_range(os, range.global_range_in_);
+    os << "Global (out): ";
+    print_range(os, range.expect_global_range_out_);
+    os << (range.shouldPass_ ? "Should Work" : "Should Throw");
+    return os;
+  }
+};
+
+class RangeParamsTestFixture3D
+    : public ::testing::TestWithParam<RangeParams<3>> {
+protected:
+  RangeParams<3> params;
+};
+
+TEST_P(RangeParamsTestFixture3D, ComputeNDRange3D) {
+  RangeParams<3> r = GetParam();
+  try {
+    auto g_out =
+        compat::compute_nd_range(r.global_range_in_, r.local_range_in_);
+    sycl::nd_range<3> x_out = {r.expect_global_range_out_, r.local_range_in_};
+    if (r.shouldPass_) {
+      ASSERT_EQ(g_out, x_out);
+    } else {
+      FAIL() << "Expected std::invalid_argument";
+    }
+  } catch (std::invalid_argument const &err) {
+    if (r.shouldPass_) {
+      FAIL();
+    } else {
+      SUCCEED();
+    }
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ComputeNDRangeTests, RangeParamsTestFixture3D,
+    ::testing::Values(
+        // Round up
+        RangeParams<3>{{11, 1, 1}, {2, 1, 1}, {12, 1, 1}, true},
+        // Even size
+        RangeParams<3>{{320, 1, 1}, {32, 1, 1}, {320, 1, 1}, true},
+        // Round up
+        RangeParams<3>{{32, 193, 1}, {16, 32, 1}, {32, 224, 1}, true},
+        // zero size
+        RangeParams<3>{{10, 0, 0}, {1, 0, 0}, {10, 0, 0}, false},
+        // zero size
+        RangeParams<3>{{0, 10, 10}, {0, 10, 10}, {0, 10, 10}, false},
+        // local > global
+        RangeParams<3>{{2, 1, 1}, {32, 1, 1}, {32, 1, 1}, false},
+        // local > global
+        RangeParams<3>{{1, 2, 1}, {1, 32, 1}, {1, 32, 1}, false},
+        // local > global
+        RangeParams<3>{{1, 1, 2}, {1, 1, 32}, {1, 1, 32}, false}));
+
+// Fixture for launch tests - initializes a few different
+// range-like members & a queue.
+class LaunchTest1 : public testing::Test {
+public:
+  LaunchTest1()
+      : q_{compat::get_default_queue()}, grid_{4, 2, 2}, thread_{32, 2, 2},
+        range_1_{128, 32}, range_2_{{4, 128}, {2, 32}}, range_3_{{2, 4, 64},
+                                                                 {2, 2, 32}} {}
+
+protected:
+  sycl::queue const q_;
+  compat::dim3 const grid_;
+  compat::dim3 const thread_;
+  sycl::nd_range<1> const range_1_;
+  sycl::nd_range<2> const range_2_;
+  sycl::nd_range<3> const range_3_;
+};
+
+// Dummy kernel functions for testing
+void empty_kernel(){};
+void int_kernel(int a){};
+void int_ptr_kernel(int *a){};
+
+TEST_F(LaunchTest1, NoArgLaunch) {
+  compat::launch<empty_kernel>(range_1_);
+  compat::launch<empty_kernel>(range_2_);
+  compat::launch<empty_kernel>(range_3_);
+  compat::launch<empty_kernel>(grid_, thread_);
+
+  compat::launch<empty_kernel>(range_1_, q_);
+  compat::launch<empty_kernel>(range_2_, q_);
+  compat::launch<empty_kernel>(range_3_, q_);
+  compat::launch<empty_kernel>(grid_, thread_, q_);
+}
+
+TEST_F(LaunchTest1, OneArgLaunch) {
+  int my_int;
+  compat::launch<int_kernel>(range_1_, my_int);
+  compat::launch<int_kernel>(range_2_, my_int);
+  compat::launch<int_kernel>(range_3_, my_int);
+  compat::launch<int_kernel>(grid_, thread_, my_int);
+
+  compat::launch<int_kernel>(range_1_, q_, my_int);
+  compat::launch<int_kernel>(range_2_, q_, my_int);
+  compat::launch<int_kernel>(range_3_, q_, my_int);
+  compat::launch<int_kernel>(grid_, thread_, q_, my_int);
+}
+
+TEST_F(LaunchTest1, PtrArgLaunch) {
+  int *int_ptr;
+  compat::launch<int_ptr_kernel>(range_1_, int_ptr);
+  compat::launch<int_ptr_kernel>(range_2_, int_ptr);
+  compat::launch<int_ptr_kernel>(range_3_, int_ptr);
+  compat::launch<int_ptr_kernel>(grid_, thread_, int_ptr);
+
+  compat::launch<int_ptr_kernel>(range_1_, q_, int_ptr);
+  compat::launch<int_ptr_kernel>(range_2_, q_, int_ptr);
+  compat::launch<int_ptr_kernel>(range_3_, q_, int_ptr);
+  compat::launch<int_ptr_kernel>(grid_, thread_, q_, int_ptr);
+}
+
+template <typename T> class LocalMemLaunchTest1_t : public LaunchTest1 {
+public:
+  LocalMemLaunchTest1_t()
+      : LaunchTest1(), memsize_{LocalMemLaunchTest1_t<T>::LOCAL_MEM_SIZE},
+        in_order_q_{{sycl::property::queue::in_order()}} {}
+
+  void SetUp() {
+    if (!sycl::ext::oneapi::experimental::compat::get_current_device().has(
+            sycl::aspect::fp64) &&
+        std::is_same_v<T, double>)
+      GTEST_SKIP() << "sycl::aspect::fp64 not supported by the SYCL device.";
+    if (!sycl::ext::oneapi::experimental::compat::get_current_device().has(
+            sycl::aspect::fp16) &&
+        std::is_same_v<T, sycl::half>)
+      GTEST_SKIP() << "sycl::aspect::fp16 not supported by the SYCL device.";
+  }
+
+  constexpr static size_t LOCAL_MEM_SIZE = 32;
+
+protected:
+  size_t const memsize_;
+  sycl::queue const in_order_q_;
+};
+
+using value_type_list =
+    testing::Types<int, unsigned int, short, unsigned short, long,
+                   unsigned long, long long, unsigned long long, float, double,
+                   sycl::half>;
+TYPED_TEST_SUITE(LocalMemLaunchTest1_t, value_type_list);
+
+template <typename T> void local_mem_empty_kernel(T *local_mem){};
+template <typename T> void local_mem_basicdt_kernel(T *local_mem, T value){};
+template <typename T> void local_mem_typed_kernel(T *local_mem, T *data) {
+  constexpr size_t memsize = LocalMemLaunchTest1_t<T>::LOCAL_MEM_SIZE;
+  const int id = sycl::ext::oneapi::experimental::this_item<1>();
+  if (id < memsize) {
+    local_mem[id] = static_cast<T>(id);
+    sycl::group_barrier(sycl::ext::oneapi::experimental::this_group<1>());
+    data[id] = local_mem[memsize - id - 1];
+  }
+};
+
+TYPED_TEST(LocalMemLaunchTest1_t, NoArgLaunch) {
+  compat::launch<local_mem_empty_kernel<TypeParam>>(this->range_1_,
+                                                    this->memsize_);
+  compat::launch<local_mem_empty_kernel<TypeParam>>(this->range_2_,
+                                                    this->memsize_);
+  compat::launch<local_mem_empty_kernel<TypeParam>>(this->range_3_,
+                                                    this->memsize_);
+  compat::launch<local_mem_empty_kernel<TypeParam>>(this->grid_, this->thread_,
+                                                    this->memsize_);
+}
+
+TYPED_TEST(LocalMemLaunchTest1_t, NoArgLaunch_q) {
+  compat::launch<local_mem_empty_kernel<TypeParam>>(
+      this->range_1_, this->memsize_, this->in_order_q_);
+  compat::launch<local_mem_empty_kernel<TypeParam>>(
+      this->range_2_, this->memsize_, this->in_order_q_);
+  compat::launch<local_mem_empty_kernel<TypeParam>>(
+      this->range_3_, this->memsize_, this->in_order_q_);
+  compat::launch<local_mem_empty_kernel<TypeParam>>(
+      this->grid_, this->thread_, this->memsize_, this->in_order_q_);
+}
+
+TYPED_TEST(LocalMemLaunchTest1_t, BasicdtLaunch) {
+  TypeParam d_a = TypeParam(1);
+
+  compat::launch<local_mem_basicdt_kernel<TypeParam>>(this->range_1_,
+                                                      this->memsize_, d_a);
+  compat::launch<local_mem_basicdt_kernel<TypeParam>>(this->range_2_,
+                                                      this->memsize_, d_a);
+  compat::launch<local_mem_basicdt_kernel<TypeParam>>(this->range_3_,
+                                                      this->memsize_, d_a);
+  compat::launch<local_mem_basicdt_kernel<TypeParam>>(
+      this->grid_, this->thread_, this->memsize_, d_a);
+}
+
+TYPED_TEST(LocalMemLaunchTest1_t, BasicdtLaunch_q) {
+  TypeParam d_a = TypeParam(1);
+
+  compat::launch<local_mem_basicdt_kernel<TypeParam>>(
+      this->range_1_, this->memsize_, this->in_order_q_, d_a);
+  compat::launch<local_mem_basicdt_kernel<TypeParam>>(
+      this->range_2_, this->memsize_, this->in_order_q_, d_a);
+  compat::launch<local_mem_basicdt_kernel<TypeParam>>(
+      this->range_3_, this->memsize_, this->in_order_q_, d_a);
+  compat::launch<local_mem_basicdt_kernel<TypeParam>>(
+      this->grid_, this->thread_, this->memsize_, this->in_order_q_, d_a);
+}
+
+TYPED_TEST(LocalMemLaunchTest1_t, ArgLaunch) {
+  TypeParam *d_a = (TypeParam *)sycl::ext::oneapi::experimental::compat::malloc(
+      this->memsize_ * sizeof(TypeParam));
+
+  compat::launch<local_mem_typed_kernel<TypeParam>>(this->range_1_,
+                                                    this->memsize_, d_a);
+  compat::launch<local_mem_typed_kernel<TypeParam>>(this->range_2_,
+                                                    this->memsize_, d_a);
+  compat::launch<local_mem_typed_kernel<TypeParam>>(this->range_3_,
+                                                    this->memsize_, d_a);
+  compat::launch<local_mem_typed_kernel<TypeParam>>(this->grid_, this->thread_,
+                                                    this->memsize_, d_a);
+
+  sycl::ext::oneapi::experimental::compat::free((void *)d_a);
+}
+
+TYPED_TEST(LocalMemLaunchTest1_t, ArgLaunch_q) {
+  TypeParam *d_a =
+      (TypeParam *)sycl::ext::oneapi::experimental::compat::malloc<TypeParam>(
+          this->memsize_, this->in_order_q_);
+
+  compat::launch<local_mem_typed_kernel<TypeParam>>(
+      this->range_1_, this->memsize_, this->in_order_q_, d_a);
+  compat::launch<local_mem_typed_kernel<TypeParam>>(
+      this->range_2_, this->memsize_, this->in_order_q_, d_a);
+  compat::launch<local_mem_typed_kernel<TypeParam>>(
+      this->range_3_, this->memsize_, this->in_order_q_, d_a);
+  compat::launch<local_mem_typed_kernel<TypeParam>>(
+      this->grid_, this->thread_, this->memsize_, this->in_order_q_, d_a);
+
+  sycl::ext::oneapi::experimental::compat::free((void *)d_a, this->in_order_q_);
+}
+
+TYPED_TEST(LocalMemLaunchTest1_t, LocalMemUsage) {
+  TypeParam *h_a = (TypeParam *)std::malloc(this->memsize_ * sizeof(TypeParam));
+  TypeParam *d_a =
+      (TypeParam *)sycl::ext::oneapi::experimental::compat::malloc<TypeParam>(
+          this->memsize_);
+
+  // d_a is not used in the kernel
+  // no init or memcpy to initialize is needed
+  compat::launch<local_mem_typed_kernel<TypeParam>>(this->grid_, this->thread_,
+                                                    this->memsize_, d_a);
+
+  sycl::ext::oneapi::experimental::compat::memcpy(
+      (void *)h_a, (void *)d_a, this->memsize_ * sizeof(TypeParam));
+  sycl::ext::oneapi::experimental::compat::free((void *)d_a);
+
+  for (int i = 0; i < this->memsize_; i++) {
+    EXPECT_EQ(h_a[i], TypeParam(this->memsize_ - i - 1));
+  }
+
+  std::free(h_a);
+}
+
+TYPED_TEST(LocalMemLaunchTest1_t, LocalMemUsage_q) {
+
+  TypeParam *h_a = (TypeParam *)std::malloc(this->memsize_ * sizeof(TypeParam));
+  TypeParam *d_a =
+      (TypeParam *)sycl::ext::oneapi::experimental::compat::malloc<TypeParam>(
+          this->memsize_, this->in_order_q_);
+
+  // d_a is not used in the kernel
+  // no init or memcpy to initialize is needed
+  compat::launch<local_mem_typed_kernel<TypeParam>>(
+      this->grid_, this->thread_, this->memsize_, this->in_order_q_, d_a);
+
+  sycl::ext::oneapi::experimental::compat::memcpy(
+      (void *)h_a, (void *)d_a, this->memsize_ * sizeof(TypeParam),
+      this->in_order_q_);
+  sycl::ext::oneapi::experimental::compat::free((void *)d_a, this->in_order_q_);
+
+  for (size_t i = 0; i < this->memsize_; i++) {
+    EXPECT_EQ(h_a[i], TypeParam(this->memsize_ - i - 1));
+  }
+
+  std::free(h_a);
+}
+
+template <typename T> class LocalMemTypesTest1 : public LaunchTest1 {
+public:
+  LocalMemTypesTest1() : LaunchTest1() {}
+
+  constexpr static size_t LOCAL_MEM_SIZE = 32;
+};
+
+using memsize_type_list = testing::Types<int, unsigned int, short,
+                                         unsigned short, long, unsigned long>;
+TYPED_TEST_SUITE(LocalMemTypesTest1, memsize_type_list);
+
+TYPED_TEST(LocalMemTypesTest1, NoArgLaunch) {
+  TypeParam memsize =
+      static_cast<TypeParam>(LocalMemTypesTest1<TypeParam>::LOCAL_MEM_SIZE);
+
+  compat::launch<local_mem_empty_kernel<int>>(this->range_1_, memsize);
+  compat::launch<local_mem_empty_kernel<int>>(this->range_2_, memsize);
+  compat::launch<local_mem_empty_kernel<int>>(this->range_3_, memsize);
+  compat::launch<local_mem_empty_kernel<int>>(this->grid_, this->thread_,
+                                              memsize);
+}
+
+TYPED_TEST(LocalMemTypesTest1, NoArgLaunch_q) {
+  TypeParam memsize =
+      static_cast<TypeParam>(LocalMemTypesTest1<TypeParam>::LOCAL_MEM_SIZE);
+
+  compat::launch<local_mem_empty_kernel<int>>(this->range_1_, memsize,
+                                              this->q_);
+  compat::launch<local_mem_empty_kernel<int>>(this->range_2_, memsize,
+                                              this->q_);
+  compat::launch<local_mem_empty_kernel<int>>(this->range_3_, memsize,
+                                              this->q_);
+  compat::launch<local_mem_empty_kernel<int>>(this->grid_, this->thread_,
+                                              memsize, this->q_);
+}
+
+TYPED_TEST(LocalMemTypesTest1, OneArgLaunch) {
+  TypeParam memsize =
+      static_cast<TypeParam>(LocalMemTypesTest1<TypeParam>::LOCAL_MEM_SIZE);
+  int d_a;
+
+  compat::launch<local_mem_basicdt_kernel<int>>(this->range_1_, memsize, d_a);
+  compat::launch<local_mem_basicdt_kernel<int>>(this->range_2_, memsize, d_a);
+  compat::launch<local_mem_basicdt_kernel<int>>(this->range_3_, memsize, d_a);
+  compat::launch<local_mem_basicdt_kernel<int>>(this->grid_, this->thread_,
+                                                memsize, d_a);
+}
+
+TYPED_TEST(LocalMemTypesTest1, OneArgLaunch_q) {
+  TypeParam memsize =
+      static_cast<TypeParam>(LocalMemTypesTest1<TypeParam>::LOCAL_MEM_SIZE);
+  int d_a;
+
+  compat::launch<local_mem_basicdt_kernel<int>>(this->range_1_, memsize,
+                                                this->q_, d_a);
+  compat::launch<local_mem_basicdt_kernel<int>>(this->range_2_, memsize,
+                                                this->q_, d_a);
+  compat::launch<local_mem_basicdt_kernel<int>>(this->range_3_, memsize,
+                                                this->q_, d_a);
+  compat::launch<local_mem_basicdt_kernel<int>>(this->grid_, this->thread_,
+                                                memsize, this->q_, d_a);
+}

--- a/sycl/unittests/Extensions/compat/atomic/Atomic.cpp
+++ b/sycl/unittests/Extensions/compat/atomic/Atomic.cpp
@@ -1,0 +1,510 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  Atomic.cpp
+ *
+ *  Description:
+ *    atomic operations API tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ Atomic.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+#include <type_traits>
+
+using namespace sycl::ext::oneapi::experimental;
+
+// Simple atomic kernels for testing
+// In every case we test two API overloads, one taking an explicit runtime
+// memory_order argument. We use `relaxed` in every case because these tests
+// are *not* checking the memory_order semantics, just the API.
+template <typename T, bool orderArg = false>
+void atomic_fetch_add_kernel(T *data, compat::arith_t<T> operand) {
+  if constexpr (orderArg) {
+    compat::atomic_fetch_add(data, operand, sycl::memory_order::relaxed);
+  } else {
+    compat::atomic_fetch_add(data, operand);
+  }
+}
+template <typename T, bool orderArg = false>
+void atomic_fetch_sub_kernel(T *data, compat::arith_t<T> operand) {
+  if constexpr (orderArg) {
+    compat::atomic_fetch_sub(data, operand, sycl::memory_order::relaxed);
+  } else {
+    compat::atomic_fetch_sub(data, operand);
+  }
+}
+template <typename T, bool orderArg = false>
+void atomic_fetch_and_kernel(T *data, T operand, T operand0) {
+  if constexpr (orderArg) {
+    compat::atomic_fetch_and(data,
+                             (compat::global_id::x() == 0 ? operand0 : operand),
+                             sycl::memory_order::relaxed);
+  } else {
+    compat::atomic_fetch_and(
+        data, (compat::global_id::x() == 0 ? operand0 : operand));
+  }
+}
+template <typename T, bool orderArg = false>
+void atomic_fetch_or_kernel(T *data, T operand, T operand0) {
+  if constexpr (orderArg) {
+    compat::atomic_fetch_or(data,
+                            (compat::global_id::x() == 0 ? operand0 : operand),
+                            sycl::memory_order::relaxed);
+  } else {
+    compat::atomic_fetch_or(data,
+                            (compat::global_id::x() == 0 ? operand0 : operand));
+  }
+}
+template <typename T, bool orderArg = false>
+void atomic_fetch_xor_kernel(T *data, T operand, T operand0) {
+  if constexpr (orderArg) {
+    compat::atomic_fetch_xor(data,
+                             (compat::global_id::x() == 0 ? operand0 : operand),
+                             sycl::memory_order::relaxed);
+  } else {
+    compat::atomic_fetch_xor(
+        data, (compat::global_id::x() == 0 ? operand0 : operand));
+  }
+}
+template <typename T, bool orderArg = false>
+void atomic_fetch_min_kernel(T *data, T operand, T operand0) {
+  if constexpr (orderArg) {
+    compat::atomic_fetch_min(data,
+                             (compat::global_id::x() == 0 ? operand0 : operand),
+                             sycl::memory_order::relaxed);
+  } else {
+    compat::atomic_fetch_min(
+        data, (compat::global_id::x() == 0 ? operand0 : operand));
+  }
+}
+template <typename T, bool orderArg = false>
+void atomic_fetch_max_kernel(T *data, T operand, T operand0) {
+  if constexpr (orderArg) {
+    compat::atomic_fetch_max(data,
+                             (compat::global_id::x() == 0 ? operand0 : operand),
+                             sycl::memory_order::relaxed);
+  } else {
+    compat::atomic_fetch_max(
+        data, (compat::global_id::x() == 0 ? operand0 : operand));
+  }
+}
+template <typename T, bool orderArg = false>
+void atomic_fetch_compare_inc_kernel(T *data, T operand) {
+  if constexpr (orderArg) {
+    compat::atomic_fetch_compare_inc(data, operand,
+                                     sycl::memory_order::relaxed);
+  } else {
+    compat::atomic_fetch_compare_inc(data, operand);
+  }
+}
+template <typename T, bool orderArg = false>
+void atomic_exchange_kernel(T *data, T operand) {
+  if constexpr (orderArg) {
+    compat::atomic_exchange(data, operand, sycl::memory_order::relaxed);
+  } else {
+    compat::atomic_exchange(data, operand);
+  }
+}
+template <typename T, bool orderArg = false>
+void atomic_compare_exchange_strong_kernel(T *data, T expected, T desired) {
+  if constexpr (orderArg) {
+    compat::atomic_compare_exchange_strong(data, expected, desired,
+                                           sycl::memory_order::relaxed);
+  } else {
+    compat::atomic_compare_exchange_strong(data, expected, desired);
+  }
+}
+
+template <auto F, typename T> class AtomicLauncher {
+protected:
+  compat::dim3 grid_;
+  compat::dim3 threads_;
+  T *data_;
+
+public:
+  AtomicLauncher(compat::dim3 grid, compat::dim3 threads)
+      : grid_{grid}, threads_{threads} {
+    data_ = (T *)compat::malloc(sizeof(T));
+  };
+  ~AtomicLauncher() { compat::free(data_); }
+  template <typename... Args>
+  void launch_test(T init_val, T expected_result, Args... args) {
+    if (!compat::get_current_device().has(sycl::aspect::fp64) &&
+        (std::is_same_v<T, double> || std::is_same_v<T, double *>))
+      GTEST_SKIP();
+    compat::memcpy(data_, &init_val, sizeof(T));
+    compat::launch<F>(grid_, threads_, data_, args...);
+    T result_val;
+    compat::memcpy(&result_val, data_, sizeof(T));
+    compat::wait();
+    EXPECT_EQ(result_val, expected_result);
+  }
+};
+
+using atomic_type_list =
+    testing::Types<int, unsigned int, long, unsigned long, long long,
+                   unsigned long long, float, double, int *, long *,
+                   long long *, float *, double *>;
+template <class> struct atomic_suite : testing::Test {};
+TYPED_TEST_SUITE(atomic_suite, atomic_type_list);
+
+using atomic_value_type_list =
+    testing::Types<int, unsigned int, long, unsigned long, long long,
+                   unsigned long long, float, double>;
+template <class> struct atomic_value_suite : testing::Test {};
+TYPED_TEST_SUITE(atomic_value_suite, atomic_value_type_list);
+
+using atomic_ptr_type_list =
+    testing::Types<int *, long *, long long *, float *, double *>;
+template <class> struct atomic_ptr_suite : testing::Test {};
+TYPED_TEST_SUITE(atomic_ptr_suite, atomic_ptr_type_list);
+
+using signed_type_list = testing::Types<int, long, long long, float, double>;
+template <class> struct atomic_signed_suite : testing::Test {};
+TYPED_TEST_SUITE(atomic_signed_suite, signed_type_list);
+
+using integral_type_list =
+    testing::Types<int, unsigned int, long, unsigned long, long long,
+                   unsigned long long>;
+template <class> struct atomic_logic_suite : testing::Test {};
+TYPED_TEST_SUITE(atomic_logic_suite, integral_type_list);
+
+TYPED_TEST(atomic_value_suite, atomic_arith) {
+  constexpr compat::dim3 grid{4};
+  constexpr compat::dim3 threads{32};
+  constexpr TypeParam sum = static_cast<TypeParam>(grid.x * threads.x);
+  constexpr TypeParam init = static_cast<TypeParam>(0);
+  constexpr TypeParam operand = static_cast<TypeParam>(1);
+
+  AtomicLauncher<atomic_fetch_add_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(init, sum, operand);
+  AtomicLauncher<atomic_fetch_sub_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(sum, init, operand);
+  AtomicLauncher<atomic_fetch_add_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                      threads)
+      .launch_test(init, sum, operand);
+  AtomicLauncher<atomic_fetch_sub_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                      threads)
+      .launch_test(sum, init, operand);
+}
+
+TYPED_TEST(atomic_ptr_suite, atomic_arith) {
+  constexpr compat::dim3 grid{4};
+  constexpr compat::dim3 threads{32};
+
+  using ValType = std::remove_pointer_t<TypeParam>;
+
+  TypeParam init = (TypeParam)compat::malloc(sizeof(ValType));
+  TypeParam final = init + (grid.x * threads.x);
+  constexpr std::ptrdiff_t operand = static_cast<std::ptrdiff_t>(1);
+
+  AtomicLauncher<atomic_fetch_add_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(init, final, operand);
+
+  AtomicLauncher<atomic_fetch_sub_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(final, init, operand);
+
+  AtomicLauncher<atomic_fetch_add_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                      threads)
+      .launch_test(init, final, operand);
+
+  AtomicLauncher<atomic_fetch_sub_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                      threads)
+      .launch_test(final, init, operand);
+  compat::free(init);
+}
+
+TYPED_TEST(atomic_value_suite, atomic_minmax) {
+  constexpr compat::dim3 grid{4};
+  constexpr compat::dim3 threads{32};
+
+  AtomicLauncher<atomic_fetch_min_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(100), static_cast<TypeParam>(1),
+                   static_cast<TypeParam>(200), static_cast<TypeParam>(1));
+  AtomicLauncher<atomic_fetch_max_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(100), static_cast<TypeParam>(200),
+                   static_cast<TypeParam>(200), static_cast<TypeParam>(1));
+  AtomicLauncher<atomic_fetch_min_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                      threads)
+      .launch_test(static_cast<TypeParam>(100), static_cast<TypeParam>(1),
+                   static_cast<TypeParam>(200), static_cast<TypeParam>(1));
+  AtomicLauncher<atomic_fetch_max_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                      threads)
+      .launch_test(static_cast<TypeParam>(100), static_cast<TypeParam>(200),
+                   static_cast<TypeParam>(200), static_cast<TypeParam>(1));
+}
+
+TYPED_TEST(atomic_signed_suite, signed_atomic_minmax) {
+  constexpr compat::dim3 grid{4};
+  constexpr compat::dim3 threads{32};
+
+  AtomicLauncher<atomic_fetch_min_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(-1), static_cast<TypeParam>(-4),
+                   static_cast<TypeParam>(-4), static_cast<TypeParam>(100));
+  AtomicLauncher<atomic_fetch_max_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(-40), static_cast<TypeParam>(-30),
+                   static_cast<TypeParam>(-30), static_cast<TypeParam>(-100));
+  AtomicLauncher<atomic_fetch_min_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                      threads)
+      .launch_test(static_cast<TypeParam>(-1), static_cast<TypeParam>(-4),
+                   static_cast<TypeParam>(-4), static_cast<TypeParam>(100));
+  AtomicLauncher<atomic_fetch_max_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                      threads)
+      .launch_test(static_cast<TypeParam>(-40), static_cast<TypeParam>(-30),
+                   static_cast<TypeParam>(-30), static_cast<TypeParam>(-100));
+}
+
+TYPED_TEST(atomic_logic_suite, atomic_and) {
+  constexpr compat::dim3 grid{4};
+  constexpr compat::dim3 threads{32};
+
+  // All 0 -> 0
+  AtomicLauncher<atomic_fetch_and_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(0), static_cast<TypeParam>(0),
+                   static_cast<TypeParam>(0), static_cast<TypeParam>(0));
+
+  // All 1 -> 1
+  AtomicLauncher<atomic_fetch_and_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(1), static_cast<TypeParam>(1),
+                   static_cast<TypeParam>(1), static_cast<TypeParam>(1));
+  // Most 1, one 0 -> 0
+  AtomicLauncher<atomic_fetch_and_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(1), static_cast<TypeParam>(0),
+                   static_cast<TypeParam>(1), static_cast<TypeParam>(0));
+
+  // All 0 -> 0
+  AtomicLauncher<atomic_fetch_and_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                      threads)
+      .launch_test(static_cast<TypeParam>(0), static_cast<TypeParam>(0),
+                   static_cast<TypeParam>(0), static_cast<TypeParam>(0));
+
+  // All 1 -> 1
+  AtomicLauncher<atomic_fetch_and_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                      threads)
+      .launch_test(static_cast<TypeParam>(1), static_cast<TypeParam>(1),
+                   static_cast<TypeParam>(1), static_cast<TypeParam>(1));
+  // Most 1, one 0 -> 0
+  AtomicLauncher<atomic_fetch_and_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                      threads)
+      .launch_test(static_cast<TypeParam>(1), static_cast<TypeParam>(0),
+                   static_cast<TypeParam>(1), static_cast<TypeParam>(0));
+}
+
+TYPED_TEST(atomic_logic_suite, atomic_or) {
+  constexpr compat::dim3 grid{4};
+  constexpr compat::dim3 threads{32};
+
+  // All 0 -> 0
+  AtomicLauncher<atomic_fetch_or_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(0), static_cast<TypeParam>(0),
+                   static_cast<TypeParam>(0), static_cast<TypeParam>(0));
+  // All 1 -> 1
+  AtomicLauncher<atomic_fetch_or_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(1), static_cast<TypeParam>(1),
+                   static_cast<TypeParam>(1), static_cast<TypeParam>(1));
+  // Most 1, one 0 -> 1
+  AtomicLauncher<atomic_fetch_or_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(1), static_cast<TypeParam>(1),
+                   static_cast<TypeParam>(1), static_cast<TypeParam>(0));
+  // Init 1, all 0 -> 1
+  AtomicLauncher<atomic_fetch_or_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(1), static_cast<TypeParam>(1),
+                   static_cast<TypeParam>(0), static_cast<TypeParam>(0));
+
+  // All 0 -> 0
+  AtomicLauncher<atomic_fetch_or_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                     threads)
+      .launch_test(static_cast<TypeParam>(0), static_cast<TypeParam>(0),
+                   static_cast<TypeParam>(0), static_cast<TypeParam>(0));
+  // All 1 -> 1
+  AtomicLauncher<atomic_fetch_or_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                     threads)
+      .launch_test(static_cast<TypeParam>(1), static_cast<TypeParam>(1),
+                   static_cast<TypeParam>(1), static_cast<TypeParam>(1));
+  // Most 1, one 0 -> 1
+  AtomicLauncher<atomic_fetch_or_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                     threads)
+      .launch_test(static_cast<TypeParam>(1), static_cast<TypeParam>(1),
+                   static_cast<TypeParam>(1), static_cast<TypeParam>(0));
+  // Init 1, all 0 -> 1
+  AtomicLauncher<atomic_fetch_or_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                     threads)
+      .launch_test(static_cast<TypeParam>(1), static_cast<TypeParam>(1),
+                   static_cast<TypeParam>(0), static_cast<TypeParam>(0));
+}
+
+TYPED_TEST(atomic_logic_suite, atomic_xor) {
+  constexpr compat::dim3 grid{1};
+  constexpr compat::dim3 threads{2}; // 2 threads, 3 values inc. init
+
+  // 000 -> 0
+  AtomicLauncher<atomic_fetch_xor_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(0), static_cast<TypeParam>(0),
+                   static_cast<TypeParam>(0), static_cast<TypeParam>(0));
+  // 111 -> 1
+  AtomicLauncher<atomic_fetch_xor_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(1), static_cast<TypeParam>(1),
+                   static_cast<TypeParam>(1), static_cast<TypeParam>(1));
+  // 110 -> 0
+  AtomicLauncher<atomic_fetch_xor_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(1), static_cast<TypeParam>(0),
+                   static_cast<TypeParam>(1), static_cast<TypeParam>(0));
+  // 010 -> 1
+  AtomicLauncher<atomic_fetch_xor_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(0), static_cast<TypeParam>(1),
+                   static_cast<TypeParam>(1), static_cast<TypeParam>(0));
+
+  // 000 -> 0
+  AtomicLauncher<atomic_fetch_xor_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                      threads)
+      .launch_test(static_cast<TypeParam>(0), static_cast<TypeParam>(0),
+                   static_cast<TypeParam>(0), static_cast<TypeParam>(0));
+  // 111 -> 1
+  AtomicLauncher<atomic_fetch_xor_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                      threads)
+      .launch_test(static_cast<TypeParam>(1), static_cast<TypeParam>(1),
+                   static_cast<TypeParam>(1), static_cast<TypeParam>(1));
+  // 110 -> 0
+  AtomicLauncher<atomic_fetch_xor_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                      threads)
+      .launch_test(static_cast<TypeParam>(1), static_cast<TypeParam>(0),
+                   static_cast<TypeParam>(1), static_cast<TypeParam>(0));
+  // 010 -> 1
+  AtomicLauncher<atomic_fetch_xor_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                      threads)
+      .launch_test(static_cast<TypeParam>(0), static_cast<TypeParam>(1),
+                   static_cast<TypeParam>(1), static_cast<TypeParam>(0));
+}
+
+TEST(atomic_compex, atomic_comp) {
+  constexpr compat::dim3 grid{1};
+  constexpr compat::dim3 threads{6};
+
+  AtomicLauncher<atomic_fetch_compare_inc_kernel<unsigned int>, unsigned int>(
+      grid, threads)
+      .launch_test(0, 6, 6);
+  AtomicLauncher<atomic_fetch_compare_inc_kernel<unsigned int>, unsigned int>(
+      grid, threads)
+      .launch_test(1, 0, 6);
+
+  AtomicLauncher<atomic_fetch_compare_inc_kernel<unsigned int, true>,
+                 unsigned int>(grid, threads)
+      .launch_test(0, 6, 6);
+  AtomicLauncher<atomic_fetch_compare_inc_kernel<unsigned int, true>,
+                 unsigned int>(grid, threads)
+      .launch_test(1, 0, 6);
+}
+
+TYPED_TEST(atomic_value_suite, atomic_exch) {
+  constexpr compat::dim3 grid{4};
+  constexpr compat::dim3 threads{32};
+
+  AtomicLauncher<atomic_exchange_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(0), static_cast<TypeParam>(1),
+                   static_cast<TypeParam>(1));
+  AtomicLauncher<atomic_exchange_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(0), static_cast<TypeParam>(0),
+                   static_cast<TypeParam>(0));
+  AtomicLauncher<atomic_exchange_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                     threads)
+      .launch_test(static_cast<TypeParam>(0), static_cast<TypeParam>(1),
+                   static_cast<TypeParam>(1));
+  AtomicLauncher<atomic_exchange_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                     threads)
+      .launch_test(static_cast<TypeParam>(0), static_cast<TypeParam>(0),
+                   static_cast<TypeParam>(0));
+}
+
+TYPED_TEST(atomic_ptr_suite, atomic_exch) {
+  constexpr compat::dim3 grid{4};
+  constexpr compat::dim3 threads{32};
+
+  using ValType = std::remove_pointer_t<TypeParam>;
+  TypeParam ptr1 = (TypeParam)compat::malloc(sizeof(ValType));
+  TypeParam ptr2 = (TypeParam)compat::malloc(sizeof(ValType));
+
+  AtomicLauncher<atomic_exchange_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(ptr1, ptr2, ptr2);
+  AtomicLauncher<atomic_exchange_kernel<TypeParam>, TypeParam>(grid, threads)
+      .launch_test(ptr1, ptr1, ptr1);
+  AtomicLauncher<atomic_exchange_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                     threads)
+      .launch_test(ptr1, ptr2, ptr2);
+  AtomicLauncher<atomic_exchange_kernel<TypeParam, true>, TypeParam>(grid,
+                                                                     threads)
+      .launch_test(ptr1, ptr1, ptr1);
+  compat::free(ptr1);
+  compat::free(ptr2);
+}
+
+TYPED_TEST(atomic_value_suite, atomic_exch_strong) {
+  constexpr compat::dim3 grid{4};
+  constexpr compat::dim3 threads{32};
+
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<TypeParam>, TypeParam>(
+      grid, threads)
+      .launch_test(static_cast<TypeParam>(0), static_cast<TypeParam>(1),
+                   static_cast<TypeParam>(0), static_cast<TypeParam>(1));
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<TypeParam>, TypeParam>(
+      grid, threads)
+      .launch_test(static_cast<TypeParam>(0), static_cast<TypeParam>(0),
+                   static_cast<TypeParam>(1), static_cast<TypeParam>(2));
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<TypeParam, true>,
+                 TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(0), static_cast<TypeParam>(1),
+                   static_cast<TypeParam>(0), static_cast<TypeParam>(1));
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<TypeParam, true>,
+                 TypeParam>(grid, threads)
+      .launch_test(static_cast<TypeParam>(0), static_cast<TypeParam>(0),
+                   static_cast<TypeParam>(1), static_cast<TypeParam>(2));
+}
+
+TYPED_TEST(atomic_ptr_suite, atomic_exch_strong) {
+  constexpr compat::dim3 grid{4};
+  constexpr compat::dim3 threads{32};
+
+  using ValType = std::remove_pointer_t<TypeParam>;
+  TypeParam ptr1 = (TypeParam)compat::malloc(sizeof(ValType));
+  TypeParam ptr2 = (TypeParam)compat::malloc(sizeof(ValType));
+  TypeParam ptr3 = (TypeParam)compat::malloc(sizeof(ValType));
+
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<TypeParam>, TypeParam>(
+      grid, threads)
+      .launch_test(ptr1, ptr2, ptr1, ptr2);
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<TypeParam>, TypeParam>(
+      grid, threads)
+      .launch_test(ptr1, ptr1, ptr2, ptr3);
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<TypeParam, true>,
+                 TypeParam>(grid, threads)
+      .launch_test(ptr1, ptr2, ptr1, ptr2);
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<TypeParam, true>,
+                 TypeParam>(grid, threads)
+      .launch_test(ptr1, ptr1, ptr2, ptr3);
+  compat::free(ptr1);
+  compat::free(ptr2);
+  compat::free(ptr3);
+}

--- a/sycl/unittests/Extensions/compat/atomic/AtomicMemoryOrderAcqRel.cpp
+++ b/sycl/unittests/Extensions/compat/atomic/AtomicMemoryOrderAcqRel.cpp
@@ -1,0 +1,290 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  AtomicMemoryOrderAcqRel.cpp
+ *
+ *  Description:
+ *    Tests fetch_add for acquire and release memory ordering
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====-------------------------------------------------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <iostream>
+#include <numeric>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+#include "atomic_memory_order.hpp"
+
+using namespace sycl;
+using namespace sycl::ext::oneapi::experimental;
+
+using address_space = sycl::access::address_space;
+
+template <memory_order order, bool orderArg = false>
+void test_acquire_global() {
+  const size_t N_items = 1024;
+  const size_t N_iters = 1000;
+
+  int error = 0;
+  int val[] = {0, 0};
+
+  queue q;
+  {
+    buffer<int> error_buf(&error, 1);
+    buffer<int> val_buf(val, 2);
+
+    q.submit([&](handler &cgh) {
+       auto error =
+           error_buf.template get_access<access::mode::read_write>(cgh);
+       auto val = val_buf.template get_access<access::mode::read_write>(cgh);
+       cgh.parallel_for(range<1>(N_items), [=](item<1> it) {
+         volatile int *val_p = val.get_pointer();
+         auto atm0 =
+             atomic_ref<int, memory_order::relaxed, memory_scope::device,
+                        address_space::global_space>(val[0]);
+         auto atm1 =
+             atomic_ref<int, memory_order::relaxed, memory_scope::device,
+                        address_space::global_space>(val[1]);
+         for (int i = 0; i < N_iters; i++) {
+           if (it.get_id(0) == 0) {
+             if constexpr (orderArg) {
+               compat::atomic_fetch_add<int, address_space::global_space>(
+                   &val[0], 1, order);
+             } else {
+               compat::atomic_fetch_add<int, address_space::global_space,
+                                        order>(&val[0], 1);
+             }
+             val_p[1]++;
+           } else {
+             // compat:: doesn't offer load/store so using sycl::atomic_ref here
+             int tmp1 = atm1.load(memory_order::acquire);
+             int tmp0 = atm0.load(memory_order::relaxed);
+             if (tmp0 < tmp1) {
+               error[0] = 1;
+             }
+           }
+         }
+       });
+     }).wait_and_throw();
+  }
+  EXPECT_EQ(error, 0);
+}
+
+template <memory_order order, bool orderArg = false> void test_acquire_local() {
+  const size_t local_size = 512;
+  const size_t N_wgs = 16;
+  const size_t global_size = local_size * N_wgs;
+  const size_t N_iters = 1000;
+
+  int error = 0;
+  int val[] = {0, 0};
+
+  queue q;
+  {
+    buffer<int> error_buf(&error, 1);
+    buffer<int> val_buf(val, 2);
+
+    q.submit([&](handler &cgh) {
+       auto error =
+           error_buf.template get_access<access::mode::read_write>(cgh);
+       local_accessor<int, 1> val(2, cgh);
+       cgh.parallel_for(nd_range<1>(global_size, local_size), [=](nd_item<1>
+                                                                      it) {
+         size_t lid = it.get_local_id(0);
+         val[0] = 0;
+         val[1] = 0;
+         it.barrier(access::fence_space::local_space);
+         volatile int *val_p = val.get_pointer();
+         auto atm0 =
+             atomic_ref<int, memory_order::relaxed, memory_scope::device,
+                        address_space::local_space>(val[0]);
+         auto atm1 =
+             atomic_ref<int, memory_order::relaxed, memory_scope::device,
+                        address_space::local_space>(val[1]);
+         for (int i = 0; i < N_iters; i++) {
+           if (it.get_local_id(0) == 0) {
+             if constexpr (orderArg) {
+               compat::atomic_fetch_add<int, address_space::local_space>(
+                   &val[0], 1, order);
+             } else {
+               compat::atomic_fetch_add<int, address_space::local_space, order>(
+                   &val[0], 1);
+             }
+             val_p[1]++;
+           } else {
+             // compat:: doesn't offer load/store so using sycl::atomic_ref here
+             int tmp1 = atm1.load(memory_order::acquire);
+             int tmp0 = atm0.load(memory_order::relaxed);
+             if (tmp0 < tmp1) {
+               error[0] = 1;
+             }
+           }
+         }
+       });
+     }).wait_and_throw();
+  }
+  EXPECT_EQ(error, 0);
+}
+
+template <memory_order order, bool orderArg = false>
+void test_release_global() {
+  const size_t N_items = 1024;
+  const size_t N_iters = 1000;
+
+  int error = 0;
+  int val[] = {0, 0};
+
+  queue q;
+  {
+    buffer<int> error_buf(&error, 1);
+    buffer<int> val_buf(val, 2);
+
+    q.submit([&](handler &cgh) {
+       auto error =
+           error_buf.template get_access<access::mode::read_write>(cgh);
+       auto val = val_buf.template get_access<access::mode::read_write>(cgh);
+       cgh.parallel_for(range<1>(N_items), [=](item<1> it) {
+         volatile int *val_p = val.get_pointer();
+         auto atm0 =
+             atomic_ref<int, memory_order::relaxed, memory_scope::device,
+                        address_space::global_space>(val[0]);
+         auto atm1 =
+             atomic_ref<int, memory_order::relaxed, memory_scope::device,
+                        address_space::global_space>(val[1]);
+         for (int i = 0; i < N_iters; i++) {
+           if (it.get_id(0) == 0) {
+             val_p[0]++;
+             if constexpr (orderArg) {
+               compat::atomic_fetch_add<int, address_space::global_space>(
+                   &val[1], 1, order);
+             } else {
+               compat::atomic_fetch_add<int, address_space::global_space,
+                                        order>(&val[1], 1);
+             }
+           } else {
+             // compat:: doesn't offer load/store so using sycl::atomic_ref here
+             int tmp1 = atm1.load(memory_order::acquire);
+             int tmp0 = atm0.load(memory_order::relaxed);
+             if (tmp0 < tmp1) {
+               error[0] = 1;
+             }
+           }
+         }
+       });
+     }).wait_and_throw();
+  }
+  EXPECT_EQ(error, 0);
+}
+
+template <memory_order order, bool orderArg = false> void test_release_local() {
+  const size_t local_size = 512;
+  const size_t N_wgs = 16;
+  const size_t global_size = local_size * N_wgs;
+  const size_t N_iters = 1000;
+
+  int error = 0;
+  int val[] = {0, 0};
+
+  queue q;
+  {
+    buffer<int> error_buf(&error, 1);
+    buffer<int> val_buf(val, 2);
+
+    q.submit([&](handler &cgh) {
+       auto error =
+           error_buf.template get_access<access::mode::read_write>(cgh);
+       local_accessor<int, 1> val(2, cgh);
+       cgh.parallel_for(nd_range<1>(global_size, local_size), [=](nd_item<1>
+                                                                      it) {
+         size_t lid = it.get_local_id(0);
+         val[0] = 0;
+         val[1] = 0;
+         it.barrier(access::fence_space::local_space);
+         volatile int *val_p = val.get_pointer();
+         auto atm0 =
+             atomic_ref<int, memory_order::relaxed, memory_scope::device,
+                        address_space::local_space>(val[0]);
+         auto atm1 =
+             atomic_ref<int, memory_order::relaxed, memory_scope::device,
+                        address_space::local_space>(val[1]);
+         for (int i = 0; i < N_iters; i++) {
+           if (it.get_local_id(0) == 0) {
+             val_p[0]++;
+             if constexpr (orderArg) {
+               compat::atomic_fetch_add<int, address_space::local_space>(
+                   &val[1], 1, order);
+             } else {
+               compat::atomic_fetch_add<int, address_space::local_space, order>(
+                   &val[1], 1);
+             }
+           } else {
+             // compat:: doesn't offer load/store so using sycl::atomic_ref here
+             int tmp1 = atm1.load(memory_order::acquire);
+             int tmp0 = atm0.load(memory_order::relaxed);
+             if (tmp0 < tmp1) {
+               error[0] = 1;
+             }
+           }
+         }
+       });
+     }).wait_and_throw();
+  }
+  EXPECT_EQ(error, 0);
+}
+
+TEST(Atomic_Order, AcqRel) {
+  queue q;
+  std::vector<memory_order> supported_memory_orders =
+      q.get_device()
+          .get_info<sycl::info::device::atomic_memory_order_capabilities>();
+
+  if (is_supported(supported_memory_orders, memory_order::acq_rel)) {
+    // Acquire-release memory order must also support both acquire and release
+    // orderings.
+    assert(is_supported(supported_memory_orders, memory_order::acquire) &&
+           is_supported(supported_memory_orders, memory_order::release));
+    test_acquire_global<memory_order::acq_rel>();
+    test_acquire_local<memory_order::acq_rel>();
+    test_release_global<memory_order::acq_rel>();
+    test_release_local<memory_order::acq_rel>();
+    // Test alternative API
+    test_acquire_global<memory_order::acq_rel, true>();
+    test_acquire_local<memory_order::acq_rel, true>();
+    test_release_global<memory_order::acq_rel, true>();
+    test_release_local<memory_order::acq_rel, true>();
+  }
+  if (is_supported(supported_memory_orders, memory_order::seq_cst)) {
+    test_acquire_global<memory_order::seq_cst>();
+    test_acquire_local<memory_order::seq_cst>();
+    test_release_global<memory_order::seq_cst>();
+    test_release_local<memory_order::seq_cst>();
+    // Test alternative API
+    test_acquire_global<memory_order::seq_cst, true>();
+    test_acquire_local<memory_order::seq_cst, true>();
+    test_release_global<memory_order::seq_cst, true>();
+    test_release_local<memory_order::seq_cst, true>();
+  }
+}

--- a/sycl/unittests/Extensions/compat/atomic/CMakeLists.txt
+++ b/sycl/unittests/Extensions/compat/atomic/CMakeLists.txt
@@ -1,0 +1,23 @@
+#
+# Copyright (C) Codeplay Software Ltd.
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SYCL compatibility API
+#
+
+add_sycl_unittest_with_extra_flags(Extensionscompatatomictests SHARED 
+  Atomic.cpp
+  AtomicMemoryOrderAcqRel.cpp
+)
+
+target_include_directories(Extensionscompatatomictests 
+                           PRIVATE ${CURRENT_DIR})

--- a/sycl/unittests/Extensions/compat/atomic/atomic_memory_order.hpp
+++ b/sycl/unittests/Extensions/compat/atomic/atomic_memory_order.hpp
@@ -1,0 +1,34 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  atomic_memory_order.hpp
+ *
+ *  Description:
+ *    Memory Order helper for the Atomic functionality tests
+ **************************************************************************/
+
+#pragma once
+
+#include <algorithm>
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+bool is_supported(std::vector<memory_order> capabilities,
+                  memory_order mem_order) {
+  return std::find(capabilities.begin(), capabilities.end(), mem_order) !=
+         capabilities.end();
+}

--- a/sycl/unittests/Extensions/compat/kernel/CMakeLists.txt
+++ b/sycl/unittests/Extensions/compat/kernel/CMakeLists.txt
@@ -1,0 +1,19 @@
+add_sycl_unittest_with_extra_flags(Extensionscompatkerneltests SHARED
+  KernelFunctionLin.cpp
+  KernelModuleLin.cpp
+)
+
+add_library(Extensionscompat_kernel_function_test SHARED KernelModuleLin.cpp)
+set_property(TARGET Extensionscompat_kernel_function_test
+             PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_property(TARGET Extensionscompat_kernel_function_test
+             PROPERTY LIBRARY_OUTPUT_DIRECTORY ${CURRENT_DIR})
+target_compile_options(Extensionscompat_kernel_function_test
+                       PRIVATE ${SYCL_COMPAT_TEST_FLAGS})
+target_link_options(Extensionscompat_kernel_function_test 
+                    PRIVATE ${SYCL_COMPAT_TEST_FLAGS})
+
+add_dependencies(Extensionscompatkerneltests
+                 Extensionscompat_kernel_function_test)
+target_link_libraries(Extensionscompatkerneltests 
+                      PRIVATE dl)

--- a/sycl/unittests/Extensions/compat/kernel/KernelFunctionLin.cpp
+++ b/sycl/unittests/Extensions/compat/kernel/KernelFunctionLin.cpp
@@ -1,0 +1,115 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  KernelFunctionLin.cpp
+ *
+ *  Description:
+ *    kernel_function header API tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ KernelFunctionLin.cpp---------- -*- C++ -* ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===---------------------------------------------------------------------===//
+
+#include <CL/sycl.hpp>
+#include <dlfcn.h>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <string>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+
+template <class T> void testTemplateKernel(T *data) {}
+
+void testKernel(void *data) {}
+
+template <class T> int getTemplateFuncAttrs() {
+  // test_feature:kernel_function_info
+  compat::kernel_function_info attrs;
+  // test_feature:get_kernel_function_info
+  compat::get_kernel_function_info(&attrs, (const void *)testTemplateKernel<T>);
+
+  int threadPerBlock = attrs.max_work_group_size;
+
+  return threadPerBlock;
+}
+
+int getFuncAttrs() {
+  // test_feature:kernel_function_info
+  compat::kernel_function_info attrs;
+  // test_feature:get_kernel_function_info
+  compat::get_kernel_function_info(&attrs, (const void *)testKernel);
+
+  int threadPerBlock = attrs.max_work_group_size;
+
+  return threadPerBlock;
+}
+
+TEST(kernel_functor, kernel_functor_ptr) {
+  compat::device_ext &dev_ct1 = compat::get_current_device();
+  sycl::queue *q_ct1 = dev_ct1.default_queue();
+
+  int Size = dev_ct1.get_info<sycl::info::device::max_work_group_size>();
+  EXPECT_EQ(getTemplateFuncAttrs<int>(), Size);
+  EXPECT_EQ(getFuncAttrs(), Size);
+
+  void *M;
+  // test_feature:kernel_functor
+  compat::kernel_functor F;
+
+  M = dlopen("./libExtensionscompat_kernel_function_test.so", RTLD_LAZY);
+  if (M == NULL) {
+    std::cout << "Could not load the library" << '\n';
+    FAIL();
+  }
+
+  std::string FunctionName = "foo_wrapper";
+  F = (compat::kernel_functor)dlsym(M, FunctionName.c_str());
+  if (F == NULL) {
+    std::cout << "Could not load function pointer" << '\n';
+    dlclose(M);
+    FAIL();
+  }
+
+  int sharedSize = 10;
+  void **param = nullptr, **extra = nullptr;
+
+  int *dev = sycl::malloc_shared<int>(16, *q_ct1);
+  for (int i = 0; i < 16; i++) {
+    dev[i] = 0;
+  }
+  param = (void **)(&dev);
+  F(*q_ct1,
+    sycl::nd_range<3>(sycl::range<3>(1, 1, 2) * sycl::range<3>(1, 1, 8),
+                      sycl::range<3>(1, 1, 8)),
+    sharedSize, param, extra);
+  q_ct1->wait_and_throw();
+
+  for (int i = 0; i < 16; i++) {
+    EXPECT_EQ(dev[i], i);
+  }
+
+  sycl::free(dev, *q_ct1);
+  dlclose(M);
+}

--- a/sycl/unittests/Extensions/compat/kernel/KernelModuleLin.cpp
+++ b/sycl/unittests/Extensions/compat/kernel/KernelModuleLin.cpp
@@ -1,0 +1,52 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  KernelModuleLin.cpp
+ *
+ *  Description:
+ *    function implementation used in kernel_function header API tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ KernelModuleLin.cpp------------------------ -*- C++ -* ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===---------------------------------------------------------------------===//
+
+#include <sycl/sycl.hpp>
+
+void foo(int *k, sycl::nd_item<3> item_ct1, uint8_t *local_mem) {
+  k[item_ct1.get_global_linear_id()] = item_ct1.get_global_linear_id();
+}
+
+extern "C" {
+void foo_wrapper(sycl::queue &queue, const sycl::nd_range<3> &nr,
+                 unsigned int localMemSize, void **kernelParams, void **extra) {
+  int *k;
+  k = (int *)kernelParams[0];
+  queue.submit([&](sycl::handler &cgh) {
+    sycl::local_accessor<uint8_t, 1> local_acc_ct1(sycl::range<1>(localMemSize),
+                                                   cgh);
+    cgh.parallel_for(nr, [=](sycl::nd_item<3> item_ct1) {
+      foo(k, item_ct1, local_acc_ct1.get_pointer());
+    });
+  });
+}
+}

--- a/sycl/unittests/Extensions/compat/memory/CMakeLists.txt
+++ b/sycl/unittests/Extensions/compat/memory/CMakeLists.txt
@@ -1,0 +1,29 @@
+#
+# Copyright (C) Codeplay Software Ltd.
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SYCL compatibility API
+#
+
+add_sycl_unittest_with_extra_flags(Extensionscompatmemorytests SHARED
+  LocalMemory.cpp
+  Memcpy3D.cpp
+  Memcpy3D2.cpp
+  MemoryAsync.cpp
+  MemoryManagementTest1.cpp
+  MemoryManagementTest2.cpp
+  MemoryManagementTest3.cpp
+  UsmAllocations.cpp
+)
+
+target_include_directories(Extensionscompatmemorytests 
+                           PRIVATE ${CURRENT_DIR})

--- a/sycl/unittests/Extensions/compat/memory/LocalMemory.cpp
+++ b/sycl/unittests/Extensions/compat/memory/LocalMemory.cpp
@@ -1,0 +1,137 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  LocalMemory.cpp
+ *
+ *  Description:
+ *    launch<F> tests with static local memory
+ **************************************************************************/
+
+#include <gtest/gtest.h>
+#include <numeric>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+
+template <auto F> class LocalMemTest {
+public:
+  LocalMemTest(compat::dim3 grid, compat::dim3 threads)
+      : grid_{grid}, threads_{threads}, size_{grid_.size() * threads_.size()},
+        host_data_(size_) {
+    data_ = (int *)compat::malloc(size_ * sizeof(int));
+  };
+  ~LocalMemTest() { compat::free(data_); };
+
+  template <typename Lambda, typename... Args>
+  void launch_test(Lambda checker, Args... args) {
+    compat::launch<F>(grid_, threads_, data_, args...);
+    compat::memcpy(host_data_.data(), data_, size_ * sizeof(int));
+    checker(host_data_);
+  }
+
+private:
+  compat::dim3 grid_;
+  compat::dim3 threads_;
+  size_t size_;
+  sycl::queue q_;
+  int *data_;
+  std::vector<int> host_data_;
+  using CheckLambda = std::function<void(std::vector<int>)>;
+};
+
+// 1D test
+// Write id to linear block, then reverse order
+template <int BLOCK_SIZE> void local_mem_1d(int *d_A) {
+  int *as = compat::local_mem<int[BLOCK_SIZE]>();
+  int id = compat::local_id::x();
+  as[id] = id;
+  compat::wg_barrier();
+  int val = as[BLOCK_SIZE - id - 1];
+  d_A[compat::global_id::x()] = val;
+}
+
+TEST(LocalMemTest, local_1d) {
+  auto checker = [](std::vector<int> input) {
+    std::vector<int> expected(input.size());
+    std::iota(expected.rbegin(), expected.rend(), 0);
+    EXPECT_TRUE(std::equal(expected.begin(), expected.end(), input.begin()));
+  };
+  LocalMemTest<local_mem_1d<32>>(1, 32).launch_test(checker);
+}
+
+// 2D test
+// Write id to 2D block, then reverse order
+template <int BLOCK_SIZE> void local_mem_2d(int *d_A) {
+  auto as = compat::local_mem<int[BLOCK_SIZE][BLOCK_SIZE]>();
+  int id_x = compat::local_id::x();
+  int id_y = compat::local_id::y();
+  as[id_y][id_x] = id_x * BLOCK_SIZE + id_y;
+  compat::wg_barrier();
+  int val = as[BLOCK_SIZE - id_y - 1][BLOCK_SIZE - id_x - 1];
+  d_A[compat::global_id::y() * BLOCK_SIZE + compat::global_id::x()] = val;
+}
+
+TEST(LocalMemTest, local_2d) {
+  constexpr int TILE_SIZE = 16;
+  auto checker = [](std::vector<int> input) {
+    for (int y = 0; y < TILE_SIZE; ++y) {
+      for (int x = 0; x < TILE_SIZE; ++x) {
+        int linear_id = y * TILE_SIZE + x;
+        int expected = ((TILE_SIZE - x - 1) * TILE_SIZE) + (TILE_SIZE - y - 1);
+        EXPECT_EQ(input[linear_id], expected);
+      }
+    }
+  };
+  LocalMemTest<local_mem_2d<TILE_SIZE>>({1, 1}, {TILE_SIZE, TILE_SIZE})
+      .launch_test(checker);
+}
+
+// 3D test
+// Write id to 3D block, then reverse order
+template <int BLOCK_SIZE> void local_mem_3d(int *d_A) {
+  auto as = compat::local_mem<int[BLOCK_SIZE][BLOCK_SIZE][BLOCK_SIZE]>();
+  int id_x = compat::local_id::x();
+  int id_y = compat::local_id::y();
+  int id_z = compat::local_id::z();
+  as[id_z][id_y][id_x] =
+      (id_x * (BLOCK_SIZE * BLOCK_SIZE)) + (id_y * BLOCK_SIZE) + id_z;
+  compat::wg_barrier();
+  int val =
+      as[BLOCK_SIZE - id_z - 1][BLOCK_SIZE - id_y - 1][BLOCK_SIZE - id_x - 1];
+  d_A[compat::global_id::z() * BLOCK_SIZE * BLOCK_SIZE +
+      compat::global_id::y() * BLOCK_SIZE + compat::global_id::x()] = val;
+}
+
+TEST(LocalMemTest, local_3d) {
+  constexpr int TILE_SIZE = 4;
+  auto checker = [](std::vector<int> input) {
+    for (int z = 0; z < TILE_SIZE; ++z) {
+      for (int y = 0; y < TILE_SIZE; ++y) {
+        for (int x = 0; x < TILE_SIZE; ++x) {
+          int linear_id = z * TILE_SIZE * TILE_SIZE + y * TILE_SIZE + x;
+          int expected = ((TILE_SIZE - x - 1) * TILE_SIZE * TILE_SIZE) +
+                         ((TILE_SIZE - y - 1) * TILE_SIZE) +
+                         (TILE_SIZE - z - 1);
+          EXPECT_EQ(input[linear_id], expected);
+        }
+      }
+    }
+  };
+  LocalMemTest<local_mem_3d<TILE_SIZE>>({1, 1, 1},
+                                        {TILE_SIZE, TILE_SIZE, TILE_SIZE})
+      .launch_test(checker);
+}

--- a/sycl/unittests/Extensions/compat/memory/Memcpy3D.cpp
+++ b/sycl/unittests/Extensions/compat/memory/Memcpy3D.cpp
@@ -1,0 +1,703 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  Memcpy3D.cpp
+ *
+ *  Description:
+ *    3D memory copy tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ Memcpy3D.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+#include <gtest/gtest.h>
+#include <malloc.h>
+#include <stdio.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+#include "memory_check.hpp"
+
+using namespace sycl::ext::oneapi::experimental;
+
+TEST(Memory, memcpy3D_memset) {
+  size_t width = 6;
+  size_t height = 8;
+  size_t depth = 10;
+  float *h_data;
+  float *h_ref;
+
+  compat::pitched_data d_data;
+  sycl::range<3> extent = sycl::range<3>(sizeof(float) * 1, 1, 1);
+  compat::pitched_data cpyParm_from_data_ct1, cpyParm_to_data_ct1;
+  sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
+  sycl::range<3> cpyParm_size_ct1(0, 0, 0);
+
+  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  for (int i = 0; i < width * height * depth; i++)
+    h_data[i] = (float)i;
+
+  h_ref = (float *)malloc(sizeof(float) * width * height * depth);
+  for (int i = 0; i < width * height * depth; i++)
+    h_ref[i] = (float)i;
+
+  // alloc memory.
+  extent = sycl::range<3>(sizeof(float) * width, height, depth);
+  d_data = (compat::pitched_data)compat::malloc(extent);
+
+  // copy to Device.
+  cpyParm_from_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_to_data_ct1 = d_data;
+  cpyParm_size_ct1 = extent;
+  compat::memcpy(cpyParm_to_data_ct1, cpyParm_to_pos_ct1, cpyParm_from_data_ct1,
+                 cpyParm_from_pos_ct1, cpyParm_size_ct1);
+
+  // copy back to host.
+  cpyParm_from_data_ct1 = d_data;
+  cpyParm_to_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_size_ct1 = extent;
+  compat::memcpy(cpyParm_to_data_ct1, cpyParm_to_pos_ct1, cpyParm_from_data_ct1,
+                 cpyParm_from_pos_ct1, cpyParm_size_ct1);
+
+  check(h_data, h_ref, width, height, depth);
+  // memset device data.
+  compat::memset(d_data, 0x1, extent);
+
+  // copy back to host
+  cpyParm_from_data_ct1 = d_data;
+  cpyParm_to_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_size_ct1 = extent;
+  compat::memcpy(cpyParm_to_data_ct1, cpyParm_to_pos_ct1, cpyParm_from_data_ct1,
+                 cpyParm_from_pos_ct1, cpyParm_size_ct1);
+  // memset reference data.
+  memset(h_ref, 0x1, width * height * depth * sizeof(float));
+  check(h_data, h_ref, width, height, depth);
+
+  free(h_data);
+  free(h_ref);
+  sycl::free(d_data.get_data_ptr(), compat::get_default_context());
+}
+
+TEST(Memory, memcpy3D_offset) {
+  size_t width = 4;
+  size_t height = 4;
+  size_t depth = 5;
+  float *h_data;
+
+  compat::pitched_data d_data;
+  sycl::range<3> extent = sycl::range<3>(sizeof(float) * 1, 1, 1);
+  compat::pitched_data cpyParm_from_data_ct1, cpyParm_to_data_ct1;
+  sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
+  sycl::range<3> cpyParm_size_ct1(0, 0, 0);
+
+  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  /*
+    0.000000        1.000000        2.000000        3.000000
+    4.000000        5.000000        6.000000        7.000000
+    8.000000        9.000000        10.000000       11.000000
+    12.000000       13.000000       14.000000       15.000000
+
+    16.000000       17.000000       18.000000       19.000000
+    20.000000       21.000000       22.000000       23.000000
+    24.000000       25.000000       26.000000       27.000000
+    28.000000       29.000000       30.000000       31.000000
+
+    32.000000       33.000000       34.000000       35.000000
+    36.000000       37.000000       38.000000       39.000000
+    40.000000       41.000000       42.000000       43.000000
+    44.000000       45.000000       46.000000       47.000000
+
+    48.000000       49.000000       50.000000       51.000000
+    52.000000       53.000000       54.000000       55.000000
+    56.000000       57.000000       58.000000       59.000000
+    60.000000       61.000000       62.000000       63.000000
+
+    64.000000       65.000000       66.000000       67.000000
+    68.000000       69.000000       70.000000       71.000000
+    72.000000       73.000000       74.000000       75.000000
+    76.000000       77.000000       78.000000       79.000000
+  */
+  for (int i = 0; i < width * height * depth; i++)
+    h_data[i] = (float)i;
+
+  /*
+    5.000000        6.000000
+    9.000000        10.000000
+
+    21.000000       22.000000
+    25.000000       26.000000
+
+    37.000000       38.000000
+    41.000000       42.000000
+  */
+  float Ref[12] = {5, 6, 9, 10, 21, 22, 25, 26, 37, 38, 41, 42};
+
+  size_t out_width = 2;
+  size_t out_height = 2;
+  size_t out_depth = 3;
+
+  // alloc memory.
+  extent = sycl::range<3>(sizeof(float) * width, height, depth);
+  d_data = (compat::pitched_data)compat::malloc(extent);
+
+  // copy to Device.
+  cpyParm_from_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_to_data_ct1 = d_data;
+  cpyParm_size_ct1 = extent;
+  compat::memcpy(cpyParm_to_data_ct1, cpyParm_to_pos_ct1, cpyParm_from_data_ct1,
+                 cpyParm_from_pos_ct1, cpyParm_size_ct1);
+
+  cpyParm_from_pos_ct1 = {1 * sizeof(float), 1, 0}; // set offset on x/y/z.
+  cpyParm_size_ct1 = {out_width * sizeof(float), out_height, out_depth};
+
+  for (int i = 0; i < out_width * out_height * out_depth; i++)
+    h_data[i] = -1;
+  // copy back to host.
+  cpyParm_from_data_ct1 = d_data;
+  cpyParm_to_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * out_width, out_width, out_height);
+
+  compat::memcpy(cpyParm_to_data_ct1, cpyParm_to_pos_ct1, cpyParm_from_data_ct1,
+                 cpyParm_from_pos_ct1, cpyParm_size_ct1);
+
+  // Copy back to host data.
+  check(h_data, Ref, out_width, out_height, out_depth);
+  free(h_data);
+  sycl::free(d_data.get_data_ptr(), compat::get_default_context());
+}
+
+TEST(Memory, memcpy3D_offsetZ) {
+  size_t width = 4;
+  size_t height = 4;
+  size_t depth = 5;
+  float *h_data;
+
+  compat::pitched_data d_data;
+  sycl::range<3> extent = sycl::range<3>(sizeof(float) * 1, 1, 1);
+  compat::pitched_data cpyParm_from_data_ct1, cpyParm_to_data_ct1;
+  sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
+  sycl::range<3> cpyParm_size_ct1(0, 0, 0);
+
+  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  /*
+    0.000000        1.000000        2.000000        3.000000
+    4.000000        5.000000        6.000000        7.000000
+    8.000000        9.000000        10.000000       11.000000
+    12.000000       13.000000       14.000000       15.000000
+
+    16.000000       17.000000       18.000000       19.000000
+    20.000000       21.000000       22.000000       23.000000
+    24.000000       25.000000       26.000000       27.000000
+    28.000000       29.000000       30.000000       31.000000
+
+    32.000000       33.000000       34.000000       35.000000
+    36.000000       37.000000       38.000000       39.000000
+    40.000000       41.000000       42.000000       43.000000
+    44.000000       45.000000       46.000000       47.000000
+
+    48.000000       49.000000       50.000000       51.000000
+    52.000000       53.000000       54.000000       55.000000
+    56.000000       57.000000       58.000000       59.000000
+    60.000000       61.000000       62.000000       63.000000
+
+    64.000000       65.000000       66.000000       67.000000
+    68.000000       69.000000       70.000000       71.000000
+    72.000000       73.000000       74.000000       75.000000
+    76.000000       77.000000       78.000000       79.000000
+  */
+  for (int i = 0; i < width * height * depth; i++)
+    h_data[i] = (float)i;
+
+  /*
+    21.000000       22.000000
+    25.000000       26.000000
+
+    37.000000       38.000000
+    41.000000       42.000000
+
+    53.000000       54.000000
+    57.000000       58.000000
+  */
+  float Ref[12] = {21, 22, 25, 26, 37, 38, 41, 42, 53, 54, 57, 58};
+
+  size_t out_width = 2;
+  size_t out_height = 2;
+  size_t out_depth = 3;
+
+  // alloc memory.
+  extent = sycl::range<3>(sizeof(float) * width, height, depth);
+  d_data = (compat::pitched_data)compat::malloc(extent);
+
+  // copy to Device.
+  cpyParm_from_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_to_data_ct1 = d_data;
+  cpyParm_size_ct1 = extent;
+  compat::memcpy(cpyParm_to_data_ct1, cpyParm_to_pos_ct1, cpyParm_from_data_ct1,
+                 cpyParm_from_pos_ct1, cpyParm_size_ct1);
+
+  cpyParm_from_pos_ct1 = {1 * sizeof(float), 1, 1}; // set offset on x/y/z.
+  cpyParm_size_ct1 = {out_width * sizeof(float), out_height, out_depth};
+
+  for (int i = 0; i < out_width * out_height * out_depth; i++)
+    h_data[i] = -1;
+  // copy back to host.
+  cpyParm_from_data_ct1 = d_data;
+  cpyParm_to_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * out_width, out_width, out_height);
+
+  compat::memcpy(cpyParm_to_data_ct1, cpyParm_to_pos_ct1, cpyParm_from_data_ct1,
+                 cpyParm_from_pos_ct1, cpyParm_size_ct1);
+
+  // Copy back to host data.
+  check(h_data, Ref, out_width, out_height, out_depth);
+  free(h_data);
+  sycl::free(d_data.get_data_ptr(), compat::get_default_context());
+}
+
+// short path1
+// test copy 3D data special case
+// for continuous plane, we can copy it as linear data
+TEST(Memory, memcpy3D_plane) {
+  size_t width = 4;
+  size_t height = 4;
+  size_t depth = 5;
+  float *h_data;
+
+  compat::pitched_data d_data;
+  sycl::range<3> extent = sycl::range<3>(sizeof(float) * 1, 1, 1);
+  compat::pitched_data cpyParm_from_data_ct1, cpyParm_to_data_ct1;
+  sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
+  sycl::range<3> cpyParm_size_ct1(0, 0, 0);
+
+  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  /*
+    0.000000        1.000000        2.000000        3.000000
+    4.000000        5.000000        6.000000        7.000000
+    8.000000        9.000000        10.000000       11.000000
+    12.000000       13.000000       14.000000       15.000000
+
+    16.000000       17.000000       18.000000       19.000000
+    20.000000       21.000000       22.000000       23.000000
+    24.000000       25.000000       26.000000       27.000000
+    28.000000       29.000000       30.000000       31.000000
+
+    32.000000       33.000000       34.000000       35.000000
+    36.000000       37.000000       38.000000       39.000000
+    40.000000       41.000000       42.000000       43.000000
+    44.000000       45.000000       46.000000       47.000000
+
+    48.000000       49.000000       50.000000       51.000000
+    52.000000       53.000000       54.000000       55.000000
+    56.000000       57.000000       58.000000       59.000000
+    60.000000       61.000000       62.000000       63.000000
+
+    64.000000       65.000000       66.000000       67.000000
+    68.000000       69.000000       70.000000       71.000000
+    72.000000       73.000000       74.000000       75.000000
+    76.000000       77.000000       78.000000       79.000000
+  */
+  for (int i = 0; i < width * height * depth; i++)
+    h_data[i] = (float)i;
+
+  /*
+    0.000000        1.000000        2.000000        3.000000
+    4.000000        5.000000        6.000000        7.000000
+    8.000000        9.000000        10.000000       11.000000
+    12.000000       13.000000       14.000000       15.000000
+
+    16.000000       17.000000       18.000000       19.000000
+    20.000000       21.000000       22.000000       23.000000
+    24.000000       25.000000       26.000000       27.000000
+    28.000000       29.000000       30.000000       31.000000
+  */
+  float Ref[32] = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
+                   11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+                   22, 23, 24, 25, 26, 27, 28, 29, 30, 31};
+
+  size_t out_width = 4;
+  size_t out_height = 4;
+  size_t out_depth = 2;
+
+  // alloc memory.
+  extent = sycl::range<3>(sizeof(float) * width, height, depth);
+  d_data = (compat::pitched_data)compat::malloc(extent);
+
+  // copy to Device.
+  cpyParm_from_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_to_data_ct1 = d_data;
+  cpyParm_size_ct1 = extent;
+  compat::memcpy(cpyParm_to_data_ct1, cpyParm_to_pos_ct1, cpyParm_from_data_ct1,
+                 cpyParm_from_pos_ct1, cpyParm_size_ct1);
+
+  cpyParm_from_pos_ct1 = {0, 0, 0}; // set offset on x/y/z.
+  cpyParm_size_ct1 = {out_width * sizeof(float), out_height, out_depth};
+
+  for (int i = 0; i < out_width * out_height * out_depth; i++)
+    h_data[i] = -1;
+  // copy back to host.
+  cpyParm_from_data_ct1 = d_data;
+  cpyParm_to_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * out_width, out_width, out_height);
+  compat::memcpy(cpyParm_to_data_ct1, cpyParm_to_pos_ct1, cpyParm_from_data_ct1,
+                 cpyParm_from_pos_ct1, cpyParm_size_ct1);
+
+  // Copy back to host data.
+  check(h_data, Ref, out_width, out_height, out_depth);
+  free(h_data);
+  sycl::free(d_data.get_data_ptr(), compat::get_default_context());
+}
+
+// short path2
+// test copy 3D data special case
+// for continuous row, we can copy it as linear data
+TEST(Memory, memcpy3D_row) {
+  size_t width = 4;
+  size_t height = 4;
+  size_t depth = 5;
+  float *h_data;
+
+  compat::pitched_data d_data;
+  sycl::range<3> extent = sycl::range<3>(sizeof(float) * 1, 1, 1);
+  compat::pitched_data cpyParm_from_data_ct1, cpyParm_to_data_ct1;
+  sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
+  sycl::range<3> cpyParm_size_ct1(0, 0, 0);
+
+  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  /*
+    0.000000        1.000000        2.000000        3.000000
+    4.000000        5.000000        6.000000        7.000000
+    8.000000        9.000000        10.000000       11.000000
+    12.000000       13.000000       14.000000       15.000000
+
+    16.000000       17.000000       18.000000       19.000000
+    20.000000       21.000000       22.000000       23.000000
+    24.000000       25.000000       26.000000       27.000000
+    28.000000       29.000000       30.000000       31.000000
+
+    32.000000       33.000000       34.000000       35.000000
+    36.000000       37.000000       38.000000       39.000000
+    40.000000       41.000000       42.000000       43.000000
+    44.000000       45.000000       46.000000       47.000000
+
+    48.000000       49.000000       50.000000       51.000000
+    52.000000       53.000000       54.000000       55.000000
+    56.000000       57.000000       58.000000       59.000000
+    60.000000       61.000000       62.000000       63.000000
+
+    64.000000       65.000000       66.000000       67.000000
+    68.000000       69.000000       70.000000       71.000000
+    72.000000       73.000000       74.000000       75.000000
+    76.000000       77.000000       78.000000       79.000000
+  */
+  for (int i = 0; i < width * height * depth; i++)
+    h_data[i] = (float)i;
+
+  /*
+    0.000000        1.000000        2.000000        3.000000
+    4.000000        5.000000        6.000000        7.000000
+
+    16.000000       17.000000       18.000000       19.000000
+    20.000000       21.000000       22.000000       23.000000
+  */
+  float Ref[16] = {0, 1, 2, 3, 4, 5, 6, 7, 16, 17, 18, 19, 20, 21, 22, 23};
+
+  size_t out_width = 4;
+  size_t out_height = 2;
+  size_t out_depth = 2;
+
+  // alloc memory.
+  extent = sycl::range<3>(sizeof(float) * width, height, depth);
+  d_data = (compat::pitched_data)compat::malloc(extent);
+
+  // copy to Device.
+  cpyParm_from_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_to_data_ct1 = d_data;
+  cpyParm_size_ct1 = extent;
+  compat::memcpy(cpyParm_to_data_ct1, cpyParm_to_pos_ct1, cpyParm_from_data_ct1,
+                 cpyParm_from_pos_ct1, cpyParm_size_ct1);
+
+  cpyParm_from_pos_ct1 = {0, 0, 0}; // set offset on x/y/z.
+  cpyParm_size_ct1 = {out_width * sizeof(float), out_height, out_depth};
+
+  for (int i = 0; i < out_width * out_height * out_depth; i++)
+    h_data[i] = -1;
+  // copy back to host.
+  cpyParm_from_data_ct1 = d_data;
+  cpyParm_to_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * out_width, out_width, out_height);
+  compat::memcpy(cpyParm_to_data_ct1, cpyParm_to_pos_ct1, cpyParm_from_data_ct1,
+                 cpyParm_from_pos_ct1, cpyParm_size_ct1);
+
+  // Copy back to host data.
+  check(h_data, Ref, out_width, out_height, out_depth);
+  free(h_data);
+  sycl::free(d_data.get_data_ptr(), compat::get_default_context());
+}
+
+TEST(Memory, memcpy3D_memset_q) {
+  sycl::queue q{{sycl::property::queue::in_order()}};
+  size_t width = 6;
+  size_t height = 8;
+  size_t depth = 10;
+  float *h_data;
+  float *h_ref;
+
+  compat::pitched_data d_data;
+  sycl::range<3> extent = sycl::range<3>(sizeof(float) * 1, 1, 1);
+  compat::pitched_data cpyParm_from_data_ct1, cpyParm_to_data_ct1;
+  sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
+  sycl::range<3> cpyParm_size_ct1(0, 0, 0);
+
+  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  for (int i = 0; i < width * height * depth; i++)
+    h_data[i] = (float)i;
+
+  h_ref = (float *)malloc(sizeof(float) * width * height * depth);
+  for (int i = 0; i < width * height * depth; i++)
+    h_ref[i] = (float)i;
+
+  // alloc memory.
+  extent = sycl::range<3>(sizeof(float) * width, height, depth);
+  d_data = (compat::pitched_data)compat::malloc(extent, q);
+
+  // copy to Device.
+  cpyParm_from_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_to_data_ct1 = d_data;
+  cpyParm_size_ct1 = extent;
+  compat::memcpy(cpyParm_to_data_ct1, cpyParm_to_pos_ct1, cpyParm_from_data_ct1,
+                 cpyParm_from_pos_ct1, cpyParm_size_ct1, q);
+
+  // copy back to host.
+  cpyParm_from_data_ct1 = d_data;
+  cpyParm_to_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_size_ct1 = extent;
+  compat::memcpy(cpyParm_to_data_ct1, cpyParm_to_pos_ct1, cpyParm_from_data_ct1,
+                 cpyParm_from_pos_ct1, cpyParm_size_ct1, q);
+
+  check(h_data, h_ref, width, height, depth);
+  // memset device data.
+  compat::memset(d_data, 0x1, extent, q);
+
+  // copy back to host
+  cpyParm_from_data_ct1 = d_data;
+  cpyParm_to_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_size_ct1 = extent;
+  compat::memcpy(cpyParm_to_data_ct1, cpyParm_to_pos_ct1, cpyParm_from_data_ct1,
+                 cpyParm_from_pos_ct1, cpyParm_size_ct1, q);
+  // memset reference data.
+  memset(h_ref, 0x1, width * height * depth * sizeof(float));
+  check(h_data, h_ref, width, height, depth);
+
+  free(h_data);
+  free(h_ref);
+  compat::free(d_data.get_data_ptr(), q);
+}
+
+TEST(Memory, memcpy3D_offset_q) {
+  sycl::queue q{{sycl::property::queue::in_order()}};
+  size_t width = 4;
+  size_t height = 4;
+  size_t depth = 5;
+  float *h_data;
+
+  compat::pitched_data d_data;
+  sycl::range<3> extent = sycl::range<3>(sizeof(float) * 1, 1, 1);
+  compat::pitched_data cpyParm_from_data_ct1, cpyParm_to_data_ct1;
+  sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
+  sycl::range<3> cpyParm_size_ct1(0, 0, 0);
+
+  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  /*
+    0.000000        1.000000        2.000000        3.000000
+    4.000000        5.000000        6.000000        7.000000
+    8.000000        9.000000        10.000000       11.000000
+    12.000000       13.000000       14.000000       15.000000
+
+    16.000000       17.000000       18.000000       19.000000
+    20.000000       21.000000       22.000000       23.000000
+    24.000000       25.000000       26.000000       27.000000
+    28.000000       29.000000       30.000000       31.000000
+
+    32.000000       33.000000       34.000000       35.000000
+    36.000000       37.000000       38.000000       39.000000
+    40.000000       41.000000       42.000000       43.000000
+    44.000000       45.000000       46.000000       47.000000
+
+    48.000000       49.000000       50.000000       51.000000
+    52.000000       53.000000       54.000000       55.000000
+    56.000000       57.000000       58.000000       59.000000
+    60.000000       61.000000       62.000000       63.000000
+
+    64.000000       65.000000       66.000000       67.000000
+    68.000000       69.000000       70.000000       71.000000
+    72.000000       73.000000       74.000000       75.000000
+    76.000000       77.000000       78.000000       79.000000
+  */
+  for (int i = 0; i < width * height * depth; i++)
+    h_data[i] = (float)i;
+
+  /*
+    5.000000        6.000000
+    9.000000        10.000000
+
+    21.000000       22.000000
+    25.000000       26.000000
+
+    37.000000       38.000000
+    41.000000       42.000000
+  */
+  float Ref[12] = {5, 6, 9, 10, 21, 22, 25, 26, 37, 38, 41, 42};
+
+  size_t out_width = 2;
+  size_t out_height = 2;
+  size_t out_depth = 3;
+
+  // alloc memory.
+  extent = sycl::range<3>(sizeof(float) * width, height, depth);
+  d_data = (compat::pitched_data)compat::malloc(extent, q);
+
+  // copy to Device.
+  cpyParm_from_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_to_data_ct1 = d_data;
+  cpyParm_size_ct1 = extent;
+  compat::memcpy(cpyParm_to_data_ct1, cpyParm_to_pos_ct1, cpyParm_from_data_ct1,
+                 cpyParm_from_pos_ct1, cpyParm_size_ct1, q);
+
+  cpyParm_from_pos_ct1 = {1 * sizeof(float), 1, 0}; // set offset on x/y/z.
+  cpyParm_size_ct1 = {out_width * sizeof(float), out_height, out_depth};
+
+  for (int i = 0; i < out_width * out_height * out_depth; i++)
+    h_data[i] = -1;
+  // copy back to host.
+  cpyParm_from_data_ct1 = d_data;
+  cpyParm_to_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * out_width, out_width, out_height);
+
+  compat::memcpy(cpyParm_to_data_ct1, cpyParm_to_pos_ct1, cpyParm_from_data_ct1,
+                 cpyParm_from_pos_ct1, cpyParm_size_ct1, q);
+
+  // Copy back to host data.
+  check(h_data, Ref, out_width, out_height, out_depth);
+  free(h_data);
+  compat::free(d_data.get_data_ptr(), q);
+}
+
+TEST(Memory, memcpy3D_offsetZ_q) {
+  sycl::queue q{{sycl::property::queue::in_order()}};
+  size_t width = 4;
+  size_t height = 4;
+  size_t depth = 5;
+  float *h_data;
+
+  compat::pitched_data d_data;
+  sycl::range<3> extent = sycl::range<3>(sizeof(float) * 1, 1, 1);
+  compat::pitched_data cpyParm_from_data_ct1, cpyParm_to_data_ct1;
+  sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
+  sycl::range<3> cpyParm_size_ct1(0, 0, 0);
+
+  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  /*
+    0.000000        1.000000        2.000000        3.000000
+    4.000000        5.000000        6.000000        7.000000
+    8.000000        9.000000        10.000000       11.000000
+    12.000000       13.000000       14.000000       15.000000
+
+    16.000000       17.000000       18.000000       19.000000
+    20.000000       21.000000       22.000000       23.000000
+    24.000000       25.000000       26.000000       27.000000
+    28.000000       29.000000       30.000000       31.000000
+
+    32.000000       33.000000       34.000000       35.000000
+    36.000000       37.000000       38.000000       39.000000
+    40.000000       41.000000       42.000000       43.000000
+    44.000000       45.000000       46.000000       47.000000
+
+    48.000000       49.000000       50.000000       51.000000
+    52.000000       53.000000       54.000000       55.000000
+    56.000000       57.000000       58.000000       59.000000
+    60.000000       61.000000       62.000000       63.000000
+
+    64.000000       65.000000       66.000000       67.000000
+    68.000000       69.000000       70.000000       71.000000
+    72.000000       73.000000       74.000000       75.000000
+    76.000000       77.000000       78.000000       79.000000
+  */
+  for (int i = 0; i < width * height * depth; i++)
+    h_data[i] = (float)i;
+
+  /*
+    21.000000       22.000000
+    25.000000       26.000000
+
+    37.000000       38.000000
+    41.000000       42.000000
+
+    53.000000       54.000000
+    57.000000       58.000000
+  */
+  float Ref[12] = {21, 22, 25, 26, 37, 38, 41, 42, 53, 54, 57, 58};
+
+  size_t out_width = 2;
+  size_t out_height = 2;
+  size_t out_depth = 3;
+
+  // alloc memory.
+  extent = sycl::range<3>(sizeof(float) * width, height, depth);
+  d_data = (compat::pitched_data)compat::malloc(extent, q);
+
+  // copy to Device.
+  cpyParm_from_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_to_data_ct1 = d_data;
+  cpyParm_size_ct1 = extent;
+  compat::memcpy(cpyParm_to_data_ct1, cpyParm_to_pos_ct1, cpyParm_from_data_ct1,
+                 cpyParm_from_pos_ct1, cpyParm_size_ct1, q);
+
+  cpyParm_from_pos_ct1 = {1 * sizeof(float), 1, 1}; // set offset on x/y/z.
+  cpyParm_size_ct1 = {out_width * sizeof(float), out_height, out_depth};
+
+  for (int i = 0; i < out_width * out_height * out_depth; i++)
+    h_data[i] = -1;
+  // copy back to host.
+  cpyParm_from_data_ct1 = d_data;
+  cpyParm_to_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * out_width, out_width, out_height);
+
+  compat::memcpy(cpyParm_to_data_ct1, cpyParm_to_pos_ct1, cpyParm_from_data_ct1,
+                 cpyParm_from_pos_ct1, cpyParm_size_ct1, q);
+
+  // Copy back to host data.
+  check(h_data, Ref, out_width, out_height, out_depth);
+  free(h_data);
+  compat::free(d_data.get_data_ptr(), q);
+}

--- a/sycl/unittests/Extensions/compat/memory/Memcpy3D2.cpp
+++ b/sycl/unittests/Extensions/compat/memory/Memcpy3D2.cpp
@@ -1,0 +1,592 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  Memcpy3D2.cpp
+ *
+ *  Description:
+ *    3D memory copy tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ Memcpy3D2.cpp ------------------------------ -*- C++ -* ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===---------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <malloc.h>
+#include <stdio.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+#include "memory_check.hpp"
+
+using namespace sycl::ext::oneapi::experimental;
+
+TEST(Memory, memcpy3D_async_pitchedAPI) {
+  size_t width = 6;
+  size_t height = 8;
+  size_t depth = 10;
+  float *h_data;
+  float *h_ref;
+  // test_feature:byte_t
+  compat::byte_t a = 'a';
+  EXPECT_EQ(sizeof(compat::byte_t), 1);
+
+  compat::pitched_data d_data;
+  sycl::range<3> extent = sycl::range<3>(sizeof(float) * 1, 1, 1);
+  compat::pitched_data cpyParm_from_data_ct1, cpyParm_to_data_ct1;
+  sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
+  sycl::range<3> cpyParm_size_ct1(0, 0, 0);
+
+  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  for (int i = 0; i < width * height * depth; i++)
+    h_data[i] = (float)i;
+
+  h_ref = (float *)malloc(sizeof(float) * width * height * depth);
+  for (int i = 0; i < width * height * depth; i++)
+    h_ref[i] = (float)i;
+
+  // alloc memory.
+  extent = sycl::range<3>(sizeof(float) * width, height, depth);
+  // test_feature:malloc
+  d_data = (compat::pitched_data)compat::malloc(extent);
+
+  // copy to Device.
+  cpyParm_from_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+
+  // test_feature:get_data_ptr
+  // test_feature:get_pitch
+  // test_feature:get_x
+  // test_feature:get_y
+  if (cpyParm_from_data_ct1.get_data_ptr() != h_data ||
+      cpyParm_from_data_ct1.get_pitch() != sizeof(float) * width ||
+      cpyParm_from_data_ct1.get_x() != width ||
+      cpyParm_from_data_ct1.get_y() != height) {
+    FAIL();
+  }
+  // test_feature:set_data_ptr
+  // test_feature:set_pitch
+  // test_feature:set_x
+  // test_feature:set_y
+  cpyParm_from_data_ct1.set_data_ptr((void *)h_data);
+  cpyParm_from_data_ct1.set_pitch(sizeof(float) * width);
+  cpyParm_from_data_ct1.set_x(width);
+  cpyParm_from_data_ct1.set_y(height);
+
+  // test_feature:get_data_ptr
+  // test_feature:get_pitch
+  // test_feature:get_x
+  // test_feature:get_y
+  if (cpyParm_from_data_ct1.get_data_ptr() != h_data ||
+      cpyParm_from_data_ct1.get_pitch() != sizeof(float) * width ||
+      cpyParm_from_data_ct1.get_x() != width ||
+      cpyParm_from_data_ct1.get_y() != height) {
+    FAIL();
+  }
+
+  cpyParm_to_data_ct1 = d_data;
+  cpyParm_size_ct1 = extent;
+  // test_feature:memcpy_async
+  compat::memcpy_async(cpyParm_to_data_ct1, cpyParm_to_pos_ct1,
+                       cpyParm_from_data_ct1, cpyParm_from_pos_ct1,
+                       cpyParm_size_ct1);
+  compat::get_default_queue().wait_and_throw();
+  // copy back to host.
+  cpyParm_from_data_ct1 = d_data;
+  cpyParm_to_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_size_ct1 = extent;
+  // test_feature:memcpy_async
+  compat::memcpy_async(cpyParm_to_data_ct1, cpyParm_to_pos_ct1,
+                       cpyParm_from_data_ct1, cpyParm_from_pos_ct1,
+                       cpyParm_size_ct1);
+  compat::get_default_queue().wait_and_throw();
+  check(h_data, h_ref, width, height, depth);
+  // memset device data.
+  // test_feature:memset_async
+  compat::memset_async(d_data, 0x1, extent);
+  compat::get_default_queue().wait_and_throw();
+  // copy back to host
+  cpyParm_from_data_ct1 = d_data;
+  cpyParm_to_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_size_ct1 = extent;
+  // test_feature:memcpy_async
+  compat::memcpy_async(cpyParm_to_data_ct1, cpyParm_to_pos_ct1,
+                       cpyParm_from_data_ct1, cpyParm_from_pos_ct1,
+                       cpyParm_size_ct1);
+  compat::get_default_queue().wait_and_throw();
+  // memset reference data.
+  memset(h_ref, 0x1, width * height * depth * sizeof(float));
+  check(h_data, h_ref, width, height, depth);
+
+  free(h_data);
+  free(h_ref);
+  sycl::free(d_data.get_data_ptr(), compat::get_default_context());
+}
+
+TEST(Memory, memcpy3D_async_offset) {
+  size_t width = 4;
+  size_t height = 4;
+  size_t depth = 5;
+  float *h_data;
+
+  compat::pitched_data d_data;
+  sycl::range<3> extent = sycl::range<3>(sizeof(float) * 1, 1, 1);
+  compat::pitched_data cpyParm_from_data_ct1, cpyParm_to_data_ct1;
+  sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
+  sycl::range<3> cpyParm_size_ct1(0, 0, 0);
+
+  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  /*
+    0.000000        1.000000        2.000000        3.000000
+    4.000000        5.000000        6.000000        7.000000
+    8.000000        9.000000        10.000000       11.000000
+    12.000000       13.000000       14.000000       15.000000
+
+    16.000000       17.000000       18.000000       19.000000
+    20.000000       21.000000       22.000000       23.000000
+    24.000000       25.000000       26.000000       27.000000
+    28.000000       29.000000       30.000000       31.000000
+
+    32.000000       33.000000       34.000000       35.000000
+    36.000000       37.000000       38.000000       39.000000
+    40.000000       41.000000       42.000000       43.000000
+    44.000000       45.000000       46.000000       47.000000
+
+    48.000000       49.000000       50.000000       51.000000
+    52.000000       53.000000       54.000000       55.000000
+    56.000000       57.000000       58.000000       59.000000
+    60.000000       61.000000       62.000000       63.000000
+
+    64.000000       65.000000       66.000000       67.000000
+    68.000000       69.000000       70.000000       71.000000
+    72.000000       73.000000       74.000000       75.000000
+    76.000000       77.000000       78.000000       79.000000
+  */
+  for (int i = 0; i < width * height * depth; i++)
+    h_data[i] = (float)i;
+
+  /*
+    5.000000        6.000000
+    9.000000        10.000000
+
+    21.000000       22.000000
+    25.000000       26.000000
+
+    37.000000       38.000000
+    41.000000       42.000000
+  */
+  float Ref[12] = {5, 6, 9, 10, 21, 22, 25, 26, 37, 38, 41, 42};
+
+  size_t out_width = 2;
+  size_t out_height = 2;
+  size_t out_depth = 3;
+
+  // alloc memory.
+  extent = sycl::range<3>(sizeof(float) * width, height, depth);
+  // test_feature:malloc
+  d_data = (compat::pitched_data)compat::malloc(extent);
+
+  // copy to Device.
+  cpyParm_from_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_to_data_ct1 = d_data;
+  cpyParm_size_ct1 = extent;
+  // test_feature:memcpy_async
+  compat::memcpy_async(cpyParm_to_data_ct1, cpyParm_to_pos_ct1,
+                       cpyParm_from_data_ct1, cpyParm_from_pos_ct1,
+                       cpyParm_size_ct1);
+  compat::get_default_queue().wait_and_throw();
+  cpyParm_from_pos_ct1 = {1 * sizeof(float), 1, 0}; // set offset on x/y/z.
+  cpyParm_size_ct1 = {out_width * sizeof(float), out_height, out_depth};
+
+  for (int i = 0; i < out_width * out_height * out_depth; i++)
+    h_data[i] = -1;
+  // copy back to host.
+  cpyParm_from_data_ct1 = d_data;
+  cpyParm_to_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * out_width, out_width, out_height);
+  // test_feature:memcpy_async
+  compat::memcpy_async(cpyParm_to_data_ct1, cpyParm_to_pos_ct1,
+                       cpyParm_from_data_ct1, cpyParm_from_pos_ct1,
+                       cpyParm_size_ct1);
+  compat::get_default_queue().wait_and_throw();
+  // Copy back to host data.
+  check(h_data, Ref, out_width, out_height, out_depth);
+  free(h_data);
+  sycl::free(d_data.get_data_ptr(), compat::get_default_context());
+}
+
+TEST(Memory, memcpy3D_async_offsetZ) {
+  size_t width = 4;
+  size_t height = 4;
+  size_t depth = 5;
+  float *h_data;
+
+  compat::pitched_data d_data;
+  sycl::range<3> extent = sycl::range<3>(sizeof(float) * 1, 1, 1);
+  compat::pitched_data cpyParm_from_data_ct1, cpyParm_to_data_ct1;
+  sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
+  sycl::range<3> cpyParm_size_ct1(0, 0, 0);
+
+  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  /*
+    0.000000        1.000000        2.000000        3.000000
+    4.000000        5.000000        6.000000        7.000000
+    8.000000        9.000000        10.000000       11.000000
+    12.000000       13.000000       14.000000       15.000000
+
+    16.000000       17.000000       18.000000       19.000000
+    20.000000       21.000000       22.000000       23.000000
+    24.000000       25.000000       26.000000       27.000000
+    28.000000       29.000000       30.000000       31.000000
+
+    32.000000       33.000000       34.000000       35.000000
+    36.000000       37.000000       38.000000       39.000000
+    40.000000       41.000000       42.000000       43.000000
+    44.000000       45.000000       46.000000       47.000000
+
+    48.000000       49.000000       50.000000       51.000000
+    52.000000       53.000000       54.000000       55.000000
+    56.000000       57.000000       58.000000       59.000000
+    60.000000       61.000000       62.000000       63.000000
+
+    64.000000       65.000000       66.000000       67.000000
+    68.000000       69.000000       70.000000       71.000000
+    72.000000       73.000000       74.000000       75.000000
+    76.000000       77.000000       78.000000       79.000000
+  */
+  for (int i = 0; i < width * height * depth; i++)
+    h_data[i] = (float)i;
+
+  /*
+    21.000000       22.000000
+    25.000000       26.000000
+
+    37.000000       38.000000
+    41.000000       42.000000
+
+    53.000000       54.000000
+    57.000000       58.000000
+  */
+  float Ref[12] = {21, 22, 25, 26, 37, 38, 41, 42, 53, 54, 57, 58};
+
+  size_t out_width = 2;
+  size_t out_height = 2;
+  size_t out_depth = 3;
+
+  // alloc memory.
+  extent = sycl::range<3>(sizeof(float) * width, height, depth);
+  // test_feature:malloc
+  d_data = (compat::pitched_data)compat::malloc(extent);
+
+  // copy to Device.
+  cpyParm_from_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_to_data_ct1 = d_data;
+  cpyParm_size_ct1 = extent;
+  // test_feature:memcpy_async
+  compat::memcpy_async(cpyParm_to_data_ct1, cpyParm_to_pos_ct1,
+                       cpyParm_from_data_ct1, cpyParm_from_pos_ct1,
+                       cpyParm_size_ct1);
+  compat::get_default_queue().wait_and_throw();
+  cpyParm_from_pos_ct1 = {1 * sizeof(float), 1, 1}; // set offset on x/y/z.
+  cpyParm_size_ct1 = {out_width * sizeof(float), out_height, out_depth};
+
+  for (int i = 0; i < out_width * out_height * out_depth; i++)
+    h_data[i] = -1;
+  // copy back to host.
+  cpyParm_from_data_ct1 = d_data;
+  cpyParm_to_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * out_width, out_width, out_height);
+  // test_feature:memcpy_async
+  compat::memcpy_async(cpyParm_to_data_ct1, cpyParm_to_pos_ct1,
+                       cpyParm_from_data_ct1, cpyParm_from_pos_ct1,
+                       cpyParm_size_ct1);
+  compat::get_default_queue().wait_and_throw();
+  // Copy back to host data.
+  check(h_data, Ref, out_width, out_height, out_depth);
+  free(h_data);
+  sycl::free(d_data.get_data_ptr(), compat::get_default_context());
+}
+
+TEST(Memory, memcpy3D_async_pitchedAPI_q) {
+  sycl::queue q{{sycl::property::queue::in_order()}};
+  size_t width = 6;
+  size_t height = 8;
+  size_t depth = 10;
+  float *h_data;
+  float *h_ref;
+
+  compat::pitched_data d_data;
+  sycl::range<3> extent = sycl::range<3>(sizeof(float) * 1, 1, 1);
+  compat::pitched_data cpyParm_from_data_ct1, cpyParm_to_data_ct1;
+  sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
+  sycl::range<3> cpyParm_size_ct1(0, 0, 0);
+
+  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  for (int i = 0; i < width * height * depth; i++)
+    h_data[i] = (float)i;
+
+  h_ref = (float *)malloc(sizeof(float) * width * height * depth);
+  for (int i = 0; i < width * height * depth; i++)
+    h_ref[i] = (float)i;
+
+  // alloc memory.
+  extent = sycl::range<3>(sizeof(float) * width, height, depth);
+  // test_feature:malloc
+  d_data = (compat::pitched_data)compat::malloc(extent, q);
+
+  // copy to Device.
+  cpyParm_from_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_to_data_ct1 = d_data;
+  cpyParm_size_ct1 = extent;
+  // test_feature:memcpy_async
+  compat::memcpy_async(cpyParm_to_data_ct1, cpyParm_to_pos_ct1,
+                       cpyParm_from_data_ct1, cpyParm_from_pos_ct1,
+                       cpyParm_size_ct1, q);
+  q.wait_and_throw();
+  // copy back to host.
+  cpyParm_from_data_ct1 = d_data;
+  cpyParm_to_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_size_ct1 = extent;
+  // test_feature:memcpy_async
+  compat::memcpy_async(cpyParm_to_data_ct1, cpyParm_to_pos_ct1,
+                       cpyParm_from_data_ct1, cpyParm_from_pos_ct1,
+                       cpyParm_size_ct1, q);
+
+  q.wait_and_throw();
+
+  check(h_data, h_ref, width, height, depth);
+  // memset device data.
+  // test_feature:memset_async
+  compat::memset_async(d_data, 0x1, extent, q);
+  q.wait_and_throw();
+  // copy back to host
+  cpyParm_from_data_ct1 = d_data;
+  cpyParm_to_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_size_ct1 = extent;
+  // test_feature:memcpy_async
+  compat::memcpy_async(cpyParm_to_data_ct1, cpyParm_to_pos_ct1,
+                       cpyParm_from_data_ct1, cpyParm_from_pos_ct1,
+                       cpyParm_size_ct1, q);
+
+  q.wait_and_throw();
+  // memset reference data.
+  memset(h_ref, 0x1, width * height * depth * sizeof(float));
+  check(h_data, h_ref, width, height, depth);
+
+  free(h_data);
+  free(h_ref);
+  compat::free(d_data.get_data_ptr(), q);
+}
+
+TEST(Memory, memcpy3D_async_offset_q) {
+  sycl::queue q{{sycl::property::queue::in_order()}};
+  size_t width = 4;
+  size_t height = 4;
+  size_t depth = 5;
+  float *h_data;
+
+  compat::pitched_data d_data;
+  sycl::range<3> extent = sycl::range<3>(sizeof(float) * 1, 1, 1);
+  compat::pitched_data cpyParm_from_data_ct1, cpyParm_to_data_ct1;
+  sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
+  sycl::range<3> cpyParm_size_ct1(0, 0, 0);
+
+  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  /*
+    0.000000        1.000000        2.000000        3.000000
+    4.000000        5.000000        6.000000        7.000000
+    8.000000        9.000000        10.000000       11.000000
+    12.000000       13.000000       14.000000       15.000000
+
+    16.000000       17.000000       18.000000       19.000000
+    20.000000       21.000000       22.000000       23.000000
+    24.000000       25.000000       26.000000       27.000000
+    28.000000       29.000000       30.000000       31.000000
+
+    32.000000       33.000000       34.000000       35.000000
+    36.000000       37.000000       38.000000       39.000000
+    40.000000       41.000000       42.000000       43.000000
+    44.000000       45.000000       46.000000       47.000000
+
+    48.000000       49.000000       50.000000       51.000000
+    52.000000       53.000000       54.000000       55.000000
+    56.000000       57.000000       58.000000       59.000000
+    60.000000       61.000000       62.000000       63.000000
+
+    64.000000       65.000000       66.000000       67.000000
+    68.000000       69.000000       70.000000       71.000000
+    72.000000       73.000000       74.000000       75.000000
+    76.000000       77.000000       78.000000       79.000000
+  */
+  for (int i = 0; i < width * height * depth; i++)
+    h_data[i] = (float)i;
+
+  /*
+    5.000000        6.000000
+    9.000000        10.000000
+
+    21.000000       22.000000
+    25.000000       26.000000
+
+    37.000000       38.000000
+    41.000000       42.000000
+  */
+  float Ref[12] = {5, 6, 9, 10, 21, 22, 25, 26, 37, 38, 41, 42};
+
+  size_t out_width = 2;
+  size_t out_height = 2;
+  size_t out_depth = 3;
+
+  // alloc memory.
+  extent = sycl::range<3>(sizeof(float) * width, height, depth);
+  // test_feature:malloc
+  d_data = (compat::pitched_data)compat::malloc(extent, q);
+
+  // copy to Device.
+  cpyParm_from_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_to_data_ct1 = d_data;
+  cpyParm_size_ct1 = extent;
+  // test_feature:memcpy_async
+  compat::memcpy_async(cpyParm_to_data_ct1, cpyParm_to_pos_ct1,
+                       cpyParm_from_data_ct1, cpyParm_from_pos_ct1,
+                       cpyParm_size_ct1, q);
+  q.wait_and_throw();
+  cpyParm_from_pos_ct1 = {1 * sizeof(float), 1, 0}; // set offset on x/y/z.
+  cpyParm_size_ct1 = {out_width * sizeof(float), out_height, out_depth};
+
+  for (int i = 0; i < out_width * out_height * out_depth; i++)
+    h_data[i] = -1;
+  // copy back to host.
+  cpyParm_from_data_ct1 = d_data;
+  cpyParm_to_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * out_width, out_width, out_height);
+  // test_feature:memcpy_async
+  compat::memcpy_async(cpyParm_to_data_ct1, cpyParm_to_pos_ct1,
+                       cpyParm_from_data_ct1, cpyParm_from_pos_ct1,
+                       cpyParm_size_ct1, q);
+  q.wait_and_throw();
+  // Copy back to host data.
+  check(h_data, Ref, out_width, out_height, out_depth);
+  free(h_data);
+  compat::free(d_data.get_data_ptr(), q);
+}
+
+TEST(Memory, memcpy3D_async_offsetZ_q) {
+  sycl::queue q{{sycl::property::queue::in_order()}};
+  size_t width = 4;
+  size_t height = 4;
+  size_t depth = 5;
+  float *h_data;
+
+  compat::pitched_data d_data;
+  sycl::range<3> extent = sycl::range<3>(sizeof(float) * 1, 1, 1);
+  compat::pitched_data cpyParm_from_data_ct1, cpyParm_to_data_ct1;
+  sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
+  sycl::range<3> cpyParm_size_ct1(0, 0, 0);
+
+  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  /*
+    0.000000        1.000000        2.000000        3.000000
+    4.000000        5.000000        6.000000        7.000000
+    8.000000        9.000000        10.000000       11.000000
+    12.000000       13.000000       14.000000       15.000000
+
+    16.000000       17.000000       18.000000       19.000000
+    20.000000       21.000000       22.000000       23.000000
+    24.000000       25.000000       26.000000       27.000000
+    28.000000       29.000000       30.000000       31.000000
+
+    32.000000       33.000000       34.000000       35.000000
+    36.000000       37.000000       38.000000       39.000000
+    40.000000       41.000000       42.000000       43.000000
+    44.000000       45.000000       46.000000       47.000000
+
+    48.000000       49.000000       50.000000       51.000000
+    52.000000       53.000000       54.000000       55.000000
+    56.000000       57.000000       58.000000       59.000000
+    60.000000       61.000000       62.000000       63.000000
+
+    64.000000       65.000000       66.000000       67.000000
+    68.000000       69.000000       70.000000       71.000000
+    72.000000       73.000000       74.000000       75.000000
+    76.000000       77.000000       78.000000       79.000000
+  */
+  for (int i = 0; i < width * height * depth; i++)
+    h_data[i] = (float)i;
+
+  /*
+    21.000000       22.000000
+    25.000000       26.000000
+
+    37.000000       38.000000
+    41.000000       42.000000
+
+    53.000000       54.000000
+    57.000000       58.000000
+  */
+  float Ref[12] = {21, 22, 25, 26, 37, 38, 41, 42, 53, 54, 57, 58};
+
+  size_t out_width = 2;
+  size_t out_height = 2;
+  size_t out_depth = 3;
+
+  // alloc memory.
+  extent = sycl::range<3>(sizeof(float) * width, height, depth);
+  // test_feature:malloc
+  d_data = (compat::pitched_data)compat::malloc(extent, q);
+
+  // copy to Device.
+  cpyParm_from_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * width, width, height);
+  cpyParm_to_data_ct1 = d_data;
+  cpyParm_size_ct1 = extent;
+  // test_feature:memcpy_async
+  compat::memcpy_async(cpyParm_to_data_ct1, cpyParm_to_pos_ct1,
+                       cpyParm_from_data_ct1, cpyParm_from_pos_ct1,
+                       cpyParm_size_ct1, q);
+  q.wait_and_throw();
+  cpyParm_from_pos_ct1 = {1 * sizeof(float), 1, 1}; // set offset on x/y/z.
+  cpyParm_size_ct1 = {out_width * sizeof(float), out_height, out_depth};
+
+  for (int i = 0; i < out_width * out_height * out_depth; i++)
+    h_data[i] = -1;
+  // copy back to host.
+  cpyParm_from_data_ct1 = d_data;
+  cpyParm_to_data_ct1 = compat::pitched_data(
+      (void *)h_data, sizeof(float) * out_width, out_width, out_height);
+  // test_feature:memcpy_async
+  compat::memcpy_async(cpyParm_to_data_ct1, cpyParm_to_pos_ct1,
+                       cpyParm_from_data_ct1, cpyParm_from_pos_ct1,
+                       cpyParm_size_ct1, q);
+  q.wait_and_throw();
+  // Copy back to host data.
+  check(h_data, Ref, out_width, out_height, out_depth);
+  free(h_data);
+  compat::free(d_data.get_data_ptr(), q);
+}

--- a/sycl/unittests/Extensions/compat/memory/MemoryAsync.cpp
+++ b/sycl/unittests/Extensions/compat/memory/MemoryAsync.cpp
@@ -1,0 +1,222 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  MemoryAsync.cpp
+ *
+ *  Description:
+ *    Asynchronous memory operations tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ MemoryAsync.cpp------------------- -*- C++ -* ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===---------------------------------------------------------------------===//
+
+// Tests for the sycl::events returned from compat::*Async API calls
+
+#include <gtest/gtest.h>
+#include <stdio.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+#define WG_SIZE 256
+#define NUM_WG 32
+
+using namespace sycl::ext::oneapi::experimental;
+
+void VectorAddKernel(float *A, float *B, float *C) {
+  auto id = compat::local_id::x();
+  A[id] = id + 1.0f;
+  B[id] = id + 1.0f;
+  C[id] = A[id] + B[id];
+}
+
+// Fixture to set up & launch a kernel to depend on, or
+// a host_task which depends on something else
+class AsyncTest : public ::testing::Test {
+protected:
+  AsyncTest()
+      : q_{compat::get_default_queue()}, grid_{NUM_WG}, thread_{WG_SIZE},
+        size_{WG_SIZE * NUM_WG} {
+    d_A = sycl::malloc_device<float>(size_, q_);
+    d_B = sycl::malloc_device<float>(size_, q_);
+    d_C = sycl::malloc_device<float>(size_, q_);
+  }
+
+  ~AsyncTest() {
+    sycl::free(d_A, q_);
+    sycl::free(d_B, q_);
+    sycl::free(d_C, q_);
+  }
+  sycl::event launch_kernel() {
+    return launch<VectorAddKernel>(grid_, thread_, q_, d_A, d_B, d_C);
+  }
+
+  sycl::event launch_host_task(std::vector<sycl::event> dep_events) {
+    return q_.submit([&](sycl::handler &cgh) {
+      cgh.depends_on(dep_events);
+      cgh.host_task([]() {});
+    });
+  }
+
+  // Check that a dependent event (e2) doesn't start until after the dependee
+  // (e1)
+  void check_events(sycl::event e1, sycl::event e2) {
+    using namespace sycl::info;
+
+    event_command_status e2_status =
+        e2.get_info<event::command_execution_status>();
+    event_command_status e1_status =
+        e1.get_info<event::command_execution_status>();
+
+    // Check event 2 hasn't started iff event 1 hasn't finished
+    if (e1_status != event_command_status::complete) {
+      EXPECT_EQ(e2_status, event_command_status::submitted);
+    }
+
+    // Once event 2 is running, check event 1 has finished
+    while (e2_status != event_command_status::running &&
+           e2_status != event_command_status::complete) {
+      e2_status = e2.get_info<event::command_execution_status>();
+    }
+    EXPECT_EQ(e1.get_info<event::command_execution_status>(),
+              event_command_status::complete);
+  }
+
+  sycl::queue q_;
+  compat::dim3 const grid_;
+  compat::dim3 const thread_;
+  float *d_A;
+  float *d_B;
+  float *d_C;
+  size_t size_;
+};
+
+// free_async is a host task, so we are really testing the event dependency here
+TEST_F(AsyncTest, free_async) {
+  float *d_D = (float *)compat::malloc(sizeof(float));
+  sycl::event kernel_ev = launch_kernel();
+  sycl::event free_ev = compat::free_async({d_D}, {kernel_ev});
+
+  check_events(kernel_ev, free_ev);
+}
+
+// The following tests are simply testing (as best possible) that
+// the sycl::event returned from *Async really corresponds to the task
+// We don't check that the memory operation does what it's supposed to,
+// this is tested elsewhere.
+TEST_F(AsyncTest, memcpy_async1) {
+  sycl::event memcpy_ev = compat::memcpy_async(d_A, d_C, sizeof(float) * size_);
+  sycl::event host_ev = launch_host_task({memcpy_ev});
+
+  check_events(memcpy_ev, host_ev);
+}
+
+TEST_F(AsyncTest, memcpy_async2) {
+  sycl::event memcpy_ev = compat::memcpy_async(d_A, 32, d_C, 32, 32, 4);
+  sycl::event host_ev = launch_host_task({memcpy_ev});
+
+  check_events(memcpy_ev, host_ev);
+}
+
+TEST_F(AsyncTest, memcpy_async3) {
+  size_t width = 4;
+  size_t height = 4;
+  size_t depth = 4;
+  assert(width * height * depth <= size_);
+
+  compat::pitched_data d_A_pitched{d_A, sizeof(float) * width, width, height};
+  compat::pitched_data d_B_pitched{d_B, sizeof(float) * width, width, height};
+  sycl::id<3> pos_A(0, 0, 0);
+  sycl::id<3> pos_B(0, 0, 0);
+  sycl::event memcpy_ev =
+      compat::memcpy_async(d_A_pitched, pos_A, d_B_pitched, pos_B, {2, 2, 2});
+  sycl::event host_ev = launch_host_task({memcpy_ev});
+
+  check_events(memcpy_ev, host_ev);
+}
+
+TEST_F(AsyncTest, memset_async1) {
+  sycl::event memset_ev = compat::memset_async(d_C, 1, sizeof(int) * size_);
+  sycl::event host_ev = launch_host_task({memset_ev});
+
+  check_events(memset_ev, host_ev);
+}
+
+TEST_F(AsyncTest, memset_async2) {
+  sycl::event memset_ev = compat::memset_async(d_C, 32, 1, sizeof(int) * 32, 4);
+  sycl::event host_ev = launch_host_task({memset_ev});
+
+  check_events(memset_ev, host_ev);
+}
+
+TEST_F(AsyncTest, memset_async3) {
+  size_t width = 4;
+  size_t height = 4;
+  size_t depth = 4;
+  assert(width * height * depth <= size_);
+
+  compat::pitched_data d_A_pitched{d_A, sizeof(int) * width, width, height};
+  sycl::event memset_ev =
+      compat::memset_async(d_A_pitched, 1, {sizeof(int) * 2, 2, 2});
+  sycl::event host_ev = launch_host_task({memset_ev});
+
+  check_events(memset_ev, host_ev);
+}
+
+TEST_F(AsyncTest, fill_event) {
+  sycl::event fill_ev = compat::fill_async(d_A, 1.0f, size_);
+  sycl::event host_ev = launch_host_task({fill_ev});
+
+  check_events(fill_ev, host_ev);
+}
+
+TEST_F(AsyncTest, CombineEvents) {
+  std::vector<sycl::event> evs;
+  for (int i = 0; i < 5; i++)
+    evs.push_back(launch_kernel());
+
+  sycl::event combined = compat::detail::combine_events(evs, q_);
+
+  using namespace sycl::info;
+
+  // Lambda returns true if all events 'complete'
+  auto all_done = [&](std::vector<sycl::event> evs) {
+    return std::all_of(evs.begin(), evs.end(), [](sycl::event ev) {
+      return ev.get_info<event::command_execution_status>() ==
+             event_command_status::complete;
+    });
+  };
+
+  event_command_status combined_status =
+      combined.get_info<event::command_execution_status>();
+  bool prerequisites_done = all_done(evs);
+
+  // Check combined event remains 'submitted' if not all prerequisites completed
+  if (!prerequisites_done)
+    EXPECT_EQ(combined_status, event_command_status::submitted);
+
+  // Check all prerequisites completed once combined is completed
+  while (combined_status != event_command_status::running &&
+         combined_status != event_command_status::complete) {
+    combined_status = combined.get_info<event::command_execution_status>();
+  }
+  EXPECT_TRUE(all_done(evs));
+}

--- a/sycl/unittests/Extensions/compat/memory/MemoryManagementTest1.cpp
+++ b/sycl/unittests/Extensions/compat/memory/MemoryManagementTest1.cpp
@@ -1,0 +1,371 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  MemoryManagementTest1.cpp
+ *
+ *  Description:
+ *    memory operations tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ MemoryManagementTest1.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+#include "memory_check.hpp"
+
+using namespace sycl::ext::oneapi::experimental;
+
+TEST(Memory, memcpy) {
+
+  constexpr int Num = 5000;
+  constexpr int N1 = 1000;
+  float *h_A = (float *)malloc(Num * sizeof(float));
+  float *h_B = (float *)malloc(Num * sizeof(float));
+  float *h_C = (float *)malloc(Num * sizeof(float));
+
+  for (int i = 0; i < Num; i++) {
+    h_A[i] = 1.0f;
+    h_B[i] = 2.0f;
+  }
+
+  float *d_A = nullptr;
+  // hostA[0..999] -> deviceA[0..999]
+  // hostB[0..3999] -> deviceA[1000..4999]
+  // deviceA[0..4999] -> hostC[0..4999]
+  d_A = (float *)compat::malloc(Num * sizeof(float));
+  compat::memcpy((void *)d_A, (void *)h_A, N1 * sizeof(float));
+  compat::memcpy((void *)(d_A + N1), (void *)h_B, (Num - N1) * sizeof(float));
+  compat::memcpy((void *)h_C, (void *)d_A, Num * sizeof(float));
+  compat::free((void *)d_A);
+
+  compat::free(0);
+  compat::free(NULL);
+  compat::free(nullptr);
+
+  // verify
+  for (int i = 0; i < N1; i++) {
+    EXPECT_EQ(h_A[i], h_C[i]);
+  }
+
+  for (int i = N1; i < Num; i++) {
+    EXPECT_EQ(h_B[i], h_C[i]);
+  }
+
+  free(h_A);
+  free(h_B);
+  free(h_C);
+}
+
+template <typename T> class Memory_t : public ::testing::Test {};
+using value_type_list =
+    testing::Types<int, unsigned int, short, unsigned short, long,
+                   unsigned long, long long, unsigned long long, float, double,
+                   sycl::half>;
+TYPED_TEST_SUITE(Memory_t, value_type_list);
+
+template <typename T> class Fill_t : public ::testing::Test {
+  void SetUp() {
+    if (!compat::get_current_device().has(sycl::aspect::fp64) &&
+        std::is_same_v<T, double>)
+      GTEST_SKIP();
+    if (!compat::get_current_device().has(sycl::aspect::fp16) &&
+        std::is_same_v<T, sycl::half>)
+      GTEST_SKIP();
+  }
+};
+TYPED_TEST_SUITE(Fill_t, value_type_list);
+
+TYPED_TEST(Memory_t, memcpy_t) {
+
+  constexpr int Num = 5000;
+  constexpr int N1 = 1000;
+  TypeParam *h_A = (TypeParam *)malloc(Num * sizeof(TypeParam));
+  TypeParam *h_B = (TypeParam *)malloc(Num * sizeof(TypeParam));
+  TypeParam *h_C = (TypeParam *)malloc(Num * sizeof(TypeParam));
+
+  for (int i = 0; i < Num; i++) {
+    h_A[i] = TypeParam(1);
+    h_B[i] = TypeParam(2);
+  }
+
+  TypeParam *d_A = nullptr;
+  // hostA[0..999] -> deviceA[0..999]
+  // hostB[0..3999] -> deviceA[1000..4999]
+  // deviceA[0..4999] -> hostC[0..4999]
+  d_A = compat::malloc<TypeParam>(Num);
+  compat::memcpy<TypeParam>(d_A, h_A, N1);
+  compat::memcpy<TypeParam>((d_A + N1), h_B, (Num - N1));
+  compat::memcpy<TypeParam>(h_C, d_A, Num);
+  compat::free((void *)d_A);
+
+  compat::free(0);
+  compat::free(NULL);
+  compat::free(nullptr);
+
+  // verify
+  for (int i = 0; i < N1; i++) {
+    EXPECT_EQ(h_A[i], h_C[i]);
+  }
+
+  for (int i = N1; i < Num; i++) {
+    EXPECT_EQ(h_B[i], h_C[i]);
+  }
+
+  free(h_A);
+  free(h_B);
+  free(h_C);
+}
+
+TEST(Memory, memset) {
+
+  constexpr int Num = 10;
+  int *h_A = (int *)malloc(Num * sizeof(int));
+
+  for (int i = 0; i < Num; i++) {
+    h_A[i] = 4;
+  }
+
+  int *d_A = nullptr;
+
+  d_A = (int *)compat::malloc(Num * sizeof(int));
+  // hostA -> deviceA
+  compat::memcpy((void *)d_A, (void *)h_A, Num * sizeof(int));
+
+  // set d_A[0,..., 6] = 0
+  compat::memset((void *)d_A, 0, (Num - 3) * sizeof(int));
+
+  // deviceA -> hostA
+  compat::memcpy((void *)h_A, (void *)d_A, Num * sizeof(int));
+
+  compat::free((void *)d_A);
+
+  // check d_A[0,..., 6] = 0
+  for (int i = 0; i < Num - 3; i++) {
+    EXPECT_EQ(h_A[i], 0);
+  }
+
+  // check d_A[7,..., 9] = 4
+  for (int i = Num - 3; i < Num; i++) {
+    EXPECT_EQ(h_A[i], 4);
+  }
+
+  free(h_A);
+}
+
+TYPED_TEST(Fill_t, fill) {
+
+  constexpr int Num = 10;
+  TypeParam *h_A = (TypeParam *)malloc(Num * sizeof(TypeParam));
+
+  for (int i = 0; i < Num; i++) {
+    h_A[i] = TypeParam(4);
+  }
+
+  TypeParam *d_A = nullptr;
+
+  d_A = compat::malloc<TypeParam>(Num);
+  // hostA -> deviceA
+  compat::memcpy((void *)d_A, (void *)h_A, Num * sizeof(TypeParam));
+
+  // set d_A[0,..., 6] = 0
+  compat::fill((void *)d_A, TypeParam(0), (Num - 3));
+
+  // deviceA -> hostA
+  compat::memcpy((void *)h_A, (void *)d_A, Num * sizeof(TypeParam));
+
+  compat::free((void *)d_A);
+
+  // check d_A[0,..., 6] = 0
+  for (int i = 0; i < Num - 3; i++) {
+    EXPECT_EQ(h_A[i], TypeParam(0));
+  }
+
+  // check d_A[7,..., 9] = 4
+  for (int i = Num - 3; i < Num; i++) {
+    EXPECT_EQ(h_A[i], TypeParam(4));
+  }
+
+  free(h_A);
+}
+
+TEST(Memory, memcpy_q) {
+
+  sycl::queue q{{sycl::property::queue::in_order()}};
+  constexpr int Num = 5000;
+  constexpr int N1 = 1000;
+  float *h_A = (float *)malloc(Num * sizeof(float));
+  float *h_B = (float *)malloc(Num * sizeof(float));
+  float *h_C = (float *)malloc(Num * sizeof(float));
+
+  for (int i = 0; i < Num; i++) {
+    h_A[i] = 1.0f;
+    h_B[i] = 2.0f;
+  }
+
+  float *d_A = nullptr;
+  // hostA[0..999] -> deviceA[0..999]
+  // hostB[0..3999] -> deviceA[1000..4999]
+  // deviceA[0..4999] -> hostC[0..4999]
+  d_A = (float *)compat::malloc(Num * sizeof(float), q);
+  compat::memcpy((void *)d_A, (void *)h_A, N1 * sizeof(float), q);
+  compat::memcpy((void *)(d_A + N1), (void *)h_B, (Num - N1) * sizeof(float),
+                 q);
+  compat::memcpy((void *)h_C, (void *)d_A, Num * sizeof(float), q);
+  compat::free((void *)d_A, q);
+
+  compat::free(0, q);
+  compat::free(NULL, q);
+  compat::free(nullptr, q);
+
+  // verify
+  for (int i = 0; i < N1; i++) {
+    EXPECT_EQ(h_A[i], h_C[i]);
+  }
+
+  for (int i = N1; i < Num; i++) {
+    EXPECT_EQ(h_B[i], h_C[i]);
+  }
+
+  free(h_A);
+  free(h_B);
+  free(h_C);
+}
+
+TYPED_TEST(Memory_t, memcpy_t_q) {
+
+  sycl::queue q{{sycl::property::queue::in_order()}};
+  constexpr int Num = 5000;
+  constexpr int N1 = 1000;
+  TypeParam *h_A = (TypeParam *)malloc(Num * sizeof(TypeParam));
+  TypeParam *h_B = (TypeParam *)malloc(Num * sizeof(TypeParam));
+  TypeParam *h_C = (TypeParam *)malloc(Num * sizeof(TypeParam));
+
+  for (int i = 0; i < Num; i++) {
+    h_A[i] = TypeParam(1);
+    h_B[i] = TypeParam(2);
+  }
+
+  TypeParam *d_A = nullptr;
+  // hostA[0..999] -> deviceA[0..999]
+  // hostB[0..3999] -> deviceA[1000..4999]
+  // deviceA[0..4999] -> hostC[0..4999]
+  d_A = compat::malloc<TypeParam>(Num, q);
+  compat::memcpy<TypeParam>(d_A, h_A, N1, q);
+  compat::memcpy<TypeParam>((d_A + N1), h_B, (Num - N1), q);
+  compat::memcpy<TypeParam>(h_C, d_A, Num, q);
+  compat::free((void *)d_A, q);
+
+  compat::free(0, q);
+  compat::free(NULL, q);
+  compat::free(nullptr, q);
+
+  // verify
+  for (int i = 0; i < N1; i++) {
+    EXPECT_EQ(h_A[i], h_C[i]);
+  }
+
+  for (int i = N1; i < Num; i++) {
+    EXPECT_EQ(h_B[i], h_C[i]);
+  }
+
+  free(h_A);
+  free(h_B);
+  free(h_C);
+}
+
+TEST(Memory, memset_q) {
+
+  sycl::queue q{{sycl::property::queue::in_order()}};
+  constexpr int Num = 10;
+  int *h_A = (int *)malloc(Num * sizeof(int));
+
+  for (int i = 0; i < Num; i++) {
+    h_A[i] = 4;
+  }
+
+  int *d_A = nullptr;
+
+  d_A = (int *)compat::malloc(Num * sizeof(int), q);
+  // hostA -> deviceA
+  compat::memcpy((void *)d_A, (void *)h_A, Num * sizeof(int), q);
+
+  // set d_A[0,..., 6] = 0
+  compat::memset((void *)d_A, 0, (Num - 3) * sizeof(int), q);
+
+  // deviceA -> hostA
+  compat::memcpy((void *)h_A, (void *)d_A, Num * sizeof(int), q);
+
+  compat::free((void *)d_A, q);
+
+  // check d_A[0,..., 6] = 0
+  for (int i = 0; i < Num - 3; i++) {
+    EXPECT_EQ(h_A[i], 0);
+  }
+
+  // check d_A[7,..., 9] = 4
+  for (int i = Num - 3; i < Num; i++) {
+    EXPECT_EQ(h_A[i], 4);
+  }
+
+  free(h_A);
+}
+
+TYPED_TEST(Fill_t, fill_q) {
+
+  sycl::queue q{{sycl::property::queue::in_order()}};
+  constexpr int Num = 10;
+  TypeParam *h_A = (TypeParam *)malloc(Num * sizeof(TypeParam));
+
+  for (int i = 0; i < Num; i++) {
+    h_A[i] = TypeParam(4);
+  }
+
+  TypeParam *d_A = nullptr;
+
+  d_A = compat::malloc<TypeParam>(Num, q);
+  // hostA -> deviceA
+  compat::memcpy((void *)d_A, (void *)h_A, Num * sizeof(TypeParam), q);
+
+  // set d_A[0,..., 6] = 0
+  compat::fill((void *)d_A, TypeParam(0), (Num - 3), q);
+
+  // deviceA -> hostA
+  compat::memcpy((void *)h_A, (void *)d_A, Num * sizeof(TypeParam), q);
+
+  compat::free((void *)d_A, q);
+
+  // check d_A[0,..., 6] = 0
+  for (int i = 0; i < Num - 3; i++) {
+    EXPECT_EQ(h_A[i], TypeParam(0));
+  }
+
+  // check d_A[7,..., 9] = 4
+  for (int i = Num - 3; i < Num; i++) {
+    EXPECT_EQ(h_A[i], TypeParam(4));
+  }
+
+  free(h_A);
+}

--- a/sycl/unittests/Extensions/compat/memory/MemoryManagementTest2.cpp
+++ b/sycl/unittests/Extensions/compat/memory/MemoryManagementTest2.cpp
@@ -1,0 +1,294 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  MemoryManagementTest2.cpp
+ *
+ *  Description:
+ *    memory operations tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ MemoryManagementTest2.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+#include "memory_check.hpp"
+
+using namespace sycl::ext::oneapi::experimental;
+
+TEST(Memory, memcpy_pitched) {
+  size_t width = 6;
+  size_t height = 8;
+  float *h_data;
+  float *h_ref;
+  size_t h_pitch = sizeof(float) * width;
+  h_data = (float *)malloc(sizeof(float) * width * height);
+  for (int i = 0; i < width * height; i++)
+    h_data[i] = (float)i;
+
+  h_ref = (float *)malloc(sizeof(float) * width * height);
+  for (int i = 0; i < width * height; i++)
+    h_ref[i] = (float)i;
+
+  // alloc device memory.
+  size_t d_pitch;
+  float *d_data;
+  d_data = (float *)compat::malloc(d_pitch, sizeof(float) * width, height);
+
+  // copy to Device.
+  compat::memcpy(d_data, d_pitch, h_data, h_pitch, sizeof(float) * width,
+                 height);
+
+  // copy back to host.
+  compat::memcpy(h_data, h_pitch, d_data, d_pitch, sizeof(float) * width,
+                 height);
+
+  check(h_data, h_ref, width, height, 1);
+
+  // memset device data.
+  compat::memset(d_data, d_pitch, 0x1, sizeof(float) * width, height);
+
+  // copy back to host
+  compat::memcpy(h_data, h_pitch, d_data, d_pitch, sizeof(float) * width,
+                 height);
+
+  // memset reference data.
+  memset(h_ref, 0x1, width * height * sizeof(float));
+  check(h_data, h_ref, width, height, 1);
+
+  free(h_data);
+  free(h_ref);
+  compat::free((void *)d_data);
+}
+
+TEST(Memory, memcpy_kernel) {
+
+  int Num = 5000;
+  int Offset =
+      0; // Current dpcpp version in ics environment has bugs with Offset >
+         // 0, CORC-6222 has fixed this issue, but the version of dpcpp used in
+         // ics environment has not cover this patch. After it has this patch,
+         // Offest could be set to 100, and current test case will pass.
+
+  float *h_A = (float *)malloc(Num * sizeof(float));
+  float *h_B = (float *)malloc(Num * sizeof(float));
+  float *h_C = (float *)malloc(Num * sizeof(float));
+
+  // compat::dev_mgr::instance().select_device(0);
+
+  for (int i = 0; i < Num; i++) {
+    h_A[i] = 1.0f;
+    h_B[i] = 2.0f;
+  }
+
+  float *d_A, *d_B, *d_C;
+  // hostA -> deviceA
+  // hostB -> deviceB
+  // kernel: deviceC = deviceA + deviceB
+  // deviceA -> hostC
+  d_A = (float *)compat::malloc(Num * sizeof(float));
+  d_B = (float *)compat::malloc(Num * sizeof(float));
+  d_C = (float *)compat::malloc(Num * sizeof(float));
+  compat::memcpy((void *)d_A, (void *)h_A, Num * sizeof(float));
+  compat::memcpy((void *)d_B, (void *)h_B, Num * sizeof(float));
+
+  d_A += Offset;
+  d_B += Offset;
+  d_C += Offset;
+
+  {
+    compat::get_default_queue().submit([&](sycl::handler &cgh) {
+      cgh.parallel_for(sycl::range<1>(Num - Offset), [=](sycl::id<1> id) {
+        float *A = d_A;
+        float *B = d_B;
+        float *C = d_C;
+        int i = id[0];
+        C[i] = A[i] + B[i];
+      });
+    });
+    compat::get_default_queue().wait_and_throw();
+  }
+
+  compat::memcpy((void *)(h_C + Offset), (void *)d_C,
+                 (Num - Offset) * sizeof(float));
+  compat::free((void *)d_A);
+  compat::free((void *)d_B);
+  compat::free((void *)d_C);
+
+  // verify
+  for (int i = Offset; i < Num; i++) {
+    EXPECT_LE(fabs(h_C[i] - h_A[i] - h_B[i]), 1e-5);
+  }
+
+  free(h_A);
+  free(h_B);
+  free(h_C);
+}
+
+#define DataW 100
+#define DataH 100
+
+compat::global_memory<float, 2> g_A(DataW, DataH);
+compat::global_memory<float, 2> g_B(DataW, DataH);
+compat::global_memory<float, 2> g_C(DataW, DataH);
+
+TEST(Memory, global_memory) {
+
+  float h_A[DataW][DataH];
+  float h_B[DataW][DataH];
+  float h_C[DataW][DataH];
+
+  for (int i = 0; i < DataW; i++) {
+    for (int j = 0; j < DataH; j++) {
+      h_A[i][j] = 1.0f;
+      h_B[i][j] = 2.0f;
+    }
+  }
+
+  g_A.init();
+  g_B.init();
+  g_C.init();
+
+  compat::memcpy((void *)g_A.get_ptr(), (void *)&h_A[0][0],
+                 DataW * DataH * sizeof(float));
+  compat::memcpy((void *)g_B.get_ptr(), (void *)&h_B[0][0],
+                 DataW * DataH * sizeof(float));
+
+  {
+    compat::get_default_queue().submit([&](sycl::handler &cgh) {
+      auto g_A_acc = g_A.get_access(cgh);
+      auto g_B_acc = g_B.get_access(cgh);
+      auto g_C_acc = g_C.get_access(cgh);
+      cgh.parallel_for(sycl::range<2>(DataW, DataH), [=](sycl::id<2> id) {
+        // test_feature:accessor
+        // test_feature:memory_region
+        compat::accessor<float, compat::memory_region::global, 2> A(g_A_acc);
+        // test_feature:accessor
+        // test_feature:memory_region
+        compat::accessor<float, compat::memory_region::global, 2> B(g_B_acc);
+        // test_feature:accessor
+        // test_feature:memory_region
+        compat::accessor<float, compat::memory_region::global, 2> C(g_C_acc);
+        int i = id[0], j = id[1];
+        C[i][j] = A[i][j] + B[i][j];
+      });
+    });
+    compat::get_default_queue().wait_and_throw();
+  }
+  compat::memcpy((void *)&h_C[0][0], (void *)g_C.get_ptr(),
+                 DataW * DataH * sizeof(float));
+
+  // verify hostD
+  for (int i = 0; i < DataW; i++) {
+    for (int j = 0; j < DataH; j++) {
+      EXPECT_LE(fabs(h_C[i][j] - h_A[i][j] - h_B[i][j]), 1e-5);
+    }
+  }
+}
+
+compat::shared_memory<float, 1> s_A(DataW);
+compat::shared_memory<float, 1> s_B(DataW);
+compat::shared_memory<float, 1> s_C(DataW);
+
+TEST(Memory, shared_memory) {
+
+  s_A.init();
+  s_B.init();
+  s_C.init();
+
+  for (int i = 0; i < DataW; i++) {
+    s_A[i] = 1.0f;
+    s_B[i] = 2.0f;
+  }
+
+  {
+    compat::get_default_queue().submit([&](sycl::handler &cgh) {
+      float *d_A = s_A.get_ptr();
+      float *d_B = s_B.get_ptr();
+      float *d_C = s_C.get_ptr();
+      cgh.parallel_for(sycl::range<1>(DataW), [=](sycl::id<1> id) {
+        int i = id[0];
+        float *A = d_A;
+        float *B = d_B;
+        float *C = d_C;
+        C[i] = A[i] + B[i];
+      });
+    });
+    compat::get_default_queue().wait_and_throw();
+  }
+
+  // verify hostD
+  for (int i = 0; i < DataW; i++) {
+    for (int j = 0; j < DataH; j++) {
+      EXPECT_LE(fabs(s_C[i] - s_A[i] - s_B[i]), 1e-5);
+    }
+  }
+}
+
+TEST(Memory, memcpy_pitched_q) {
+  sycl::queue q{{sycl::property::queue::in_order()}};
+  size_t width = 6;
+  size_t height = 8;
+  float *h_data;
+  float *h_ref;
+  size_t h_pitch = sizeof(float) * width;
+  h_data = (float *)malloc(sizeof(float) * width * height);
+  for (int i = 0; i < width * height; i++)
+    h_data[i] = (float)i;
+
+  h_ref = (float *)malloc(sizeof(float) * width * height);
+  for (int i = 0; i < width * height; i++)
+    h_ref[i] = (float)i;
+
+  // alloc device memory.
+  size_t d_pitch;
+  float *d_data;
+  d_data = (float *)compat::malloc(d_pitch, sizeof(float) * width, height, q);
+
+  // copy to Device.
+  compat::memcpy(d_data, d_pitch, h_data, h_pitch, sizeof(float) * width,
+                 height, q);
+
+  // copy back to host.
+  compat::memcpy(h_data, h_pitch, d_data, d_pitch, sizeof(float) * width,
+                 height, q);
+
+  check(h_data, h_ref, width, height, 1);
+
+  // memset device data.
+  compat::memset(d_data, d_pitch, 0x1, sizeof(float) * width, height, q);
+
+  // copy back to host
+  compat::memcpy(h_data, h_pitch, d_data, d_pitch, sizeof(float) * width,
+                 height, q);
+
+  // memset reference data.
+  memset(h_ref, 0x1, width * height * sizeof(float));
+  check(h_data, h_ref, width, height, 1);
+
+  free(h_data);
+  free(h_ref);
+  compat::free((void *)d_data, q);
+}

--- a/sycl/unittests/Extensions/compat/memory/MemoryManagementTest3.cpp
+++ b/sycl/unittests/Extensions/compat/memory/MemoryManagementTest3.cpp
@@ -1,0 +1,475 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  MemoryManagementTest3.cpp
+ *
+ *  Description:
+ *    memory operations tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ MemoryManagementTest3.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+#include "memory_check.hpp"
+
+using namespace sycl::ext::oneapi::experimental;
+
+TEST(Memory, memcpy_async) {
+
+  int Num = 5000;
+  int N1 = 1000;
+  float *h_A = (float *)malloc(Num * sizeof(float));
+  float *h_B = (float *)malloc(Num * sizeof(float));
+  float *h_C = (float *)malloc(Num * sizeof(float));
+
+  for (int i = 0; i < Num; i++) {
+    h_A[i] = 1.0f;
+    h_B[i] = 2.0f;
+  }
+
+  // hostA[0..999] -> deviceA[0..999]
+  // hostB[0..3999] -> deviceA[1000..4999]
+  // deviceA[0..4999] -> hostC[0..4999]
+  float *d_A = (float *)compat::malloc(Num * sizeof(float));
+
+  compat::memcpy_async((void *)d_A, (void *)h_A, N1 * sizeof(float));
+  compat::memcpy_async((void *)(d_A + N1), (void *)h_B,
+                       (Num - N1) * sizeof(float));
+  compat::memcpy_async((void *)h_C, (void *)d_A, Num * sizeof(float));
+
+  compat::wait();
+
+  compat::free((void *)d_A);
+
+  // verify
+  for (int i = 0; i < N1; i++) {
+    EXPECT_LE(fabs(h_A[i] - h_C[i]), 1e-5);
+  }
+
+  for (int i = N1; i < Num; i++) {
+    EXPECT_LE(fabs(h_B[i] - h_C[i]), 1e-5);
+  }
+
+  free(h_A);
+  free(h_B);
+  free(h_C);
+}
+
+template <typename T> class Memory_t : public ::testing::Test {};
+using value_type_list =
+    testing::Types<int, unsigned int, short, unsigned short, long,
+                   unsigned long, long long, unsigned long long, float, double,
+                   sycl::half>;
+TYPED_TEST_SUITE(Memory_t, value_type_list);
+
+template <typename T> class Fill_t : public ::testing::Test {
+  void SetUp() {
+    if (!compat::get_current_device().has(sycl::aspect::fp64) &&
+        std::is_same_v<T, double>)
+      GTEST_SKIP();
+    if (!compat::get_current_device().has(sycl::aspect::fp16) &&
+        std::is_same_v<T, sycl::half>)
+      GTEST_SKIP();
+  }
+};
+TYPED_TEST_SUITE(Fill_t, value_type_list);
+
+TYPED_TEST(Memory_t, memcpy_async_t) {
+
+  int Num = 5000;
+  int N1 = 1000;
+  TypeParam *h_A = (TypeParam *)malloc(Num * sizeof(TypeParam));
+  TypeParam *h_B = (TypeParam *)malloc(Num * sizeof(TypeParam));
+  TypeParam *h_C = (TypeParam *)malloc(Num * sizeof(TypeParam));
+
+  for (int i = 0; i < Num; i++) {
+    h_A[i] = TypeParam(1);
+    h_B[i] = TypeParam(2);
+  }
+
+  // hostA[0..999] -> deviceA[0..999]
+  // hostB[0..3999] -> deviceA[1000..4999]
+  // deviceA[0..4999] -> hostC[0..4999]
+  TypeParam *d_A = compat::malloc<TypeParam>(Num);
+  compat::memcpy_async<TypeParam>(d_A, h_A, N1);
+  compat::memcpy_async<TypeParam>((d_A + N1), h_B, (Num - N1));
+  compat::memcpy_async<TypeParam>(h_C, d_A, Num);
+
+  compat::wait();
+
+  compat::free((void *)d_A);
+
+  // verify
+  for (int i = 0; i < N1; i++) {
+    EXPECT_EQ(h_A[i], h_C[i]);
+  }
+
+  for (int i = N1; i < Num; i++) {
+    EXPECT_EQ(h_B[i], h_C[i]);
+  }
+
+  free(h_A);
+  free(h_B);
+  free(h_C);
+}
+
+TEST(Memory, free_memory) {
+
+  float *d_A = (float *)compat::malloc(sizeof(float));
+
+  compat::free(d_A);
+
+  compat::free(0);
+  compat::free(NULL);
+  compat::free(nullptr);
+}
+
+TEST(Memory, memset_async) {
+
+  int Num = 10;
+  int *h_A = (int *)malloc(Num * sizeof(int));
+
+  for (int i = 0; i < Num; i++) {
+    h_A[i] = 4;
+  }
+
+  int *d_A = (int *)compat::malloc(Num * sizeof(int));
+  // hostA -> deviceA
+  compat::memcpy_async((void *)d_A, (void *)h_A, Num * sizeof(int));
+
+  // set d_A[0,..., 6] = 0
+  compat::memset_async((void *)d_A, 0, (Num - 3) * sizeof(int));
+
+  // deviceA -> hostA
+  compat::memcpy_async((void *)h_A, (void *)d_A, Num * sizeof(int));
+
+  compat::get_default_queue().wait_and_throw();
+
+  compat::free((void *)d_A);
+
+  // check d_A[0,..., 6] = 0
+  for (int i = 0; i < Num - 3; i++) {
+    EXPECT_EQ(h_A[i], 0);
+  }
+
+  // check d_A[7,..., 9] = 4
+  for (int i = Num - 3; i < Num; i++) {
+    EXPECT_EQ(h_A[i], 4);
+  }
+
+  free(h_A);
+}
+
+TYPED_TEST(Fill_t, fill_async) {
+
+  constexpr int Num = 10;
+  TypeParam *h_A = (TypeParam *)malloc(Num * sizeof(TypeParam));
+
+  for (int i = 0; i < Num; i++) {
+    h_A[i] = TypeParam(4);
+  }
+
+  TypeParam *d_A = nullptr;
+
+  d_A = compat::malloc<TypeParam>(Num);
+  // hostA -> deviceA
+  compat::memcpy((void *)d_A, (void *)h_A, Num * sizeof(TypeParam));
+
+  // set d_A[0,..., 6] = 0
+  compat::fill_async((void *)d_A, TypeParam(0), (Num - 3));
+
+  // deviceA -> hostA
+  compat::memcpy((void *)h_A, (void *)d_A, Num * sizeof(TypeParam));
+
+  compat::get_default_queue().wait_and_throw();
+
+  compat::free((void *)d_A);
+
+  // check d_A[0,..., 6] = 0
+  for (int i = 0; i < Num - 3; i++) {
+    EXPECT_EQ(h_A[i], TypeParam(0));
+  }
+
+  // check d_A[7,..., 9] = 4
+  for (int i = Num - 3; i < Num; i++) {
+    EXPECT_EQ(h_A[i], TypeParam(4));
+  }
+
+  free(h_A);
+}
+
+TEST(Memory, memcpy_async_pitched) {
+  size_t width = 6;
+  size_t height = 8;
+  float *h_data = nullptr;
+  float *h_ref = nullptr;
+  size_t h_pitch = sizeof(float) * width;
+  h_data = (float *)malloc(sizeof(float) * width * height);
+  for (int i = 0; i < width * height; i++)
+    h_data[i] = (float)i;
+
+  h_ref = (float *)malloc(sizeof(float) * width * height);
+  for (int i = 0; i < width * height; i++)
+    h_ref[i] = (float)i;
+
+  // alloc device memory.
+  size_t d_pitch;
+  float *d_data =
+      (float *)compat::malloc(d_pitch, sizeof(float) * width, height);
+
+  // copy to Device.
+  compat::memcpy_async(d_data, d_pitch, h_data, h_pitch, sizeof(float) * width,
+                       height);
+
+  // copy back to host.
+  compat::memcpy_async(h_data, h_pitch, d_data, d_pitch, sizeof(float) * width,
+                       height);
+
+  compat::get_default_queue().wait_and_throw();
+  check(h_data, h_ref, width, height, 1);
+
+  // memset device data.
+  compat::memset_async(d_data, d_pitch, 0x1, sizeof(float) * width, height);
+
+  // copy back to host
+  compat::memcpy_async(h_data, h_pitch, d_data, d_pitch, sizeof(float) * width,
+                       height);
+  compat::get_default_queue().wait_and_throw();
+  // memset reference data.
+  memset(h_ref, 0x1, width * height * sizeof(float));
+  check(h_data, h_ref, width, height, 1);
+
+  free(h_data);
+  free(h_ref);
+  compat::free((void *)d_data);
+}
+
+TEST(Memory, memcpy_async_q) {
+  sycl::queue q{{sycl::property::queue::in_order()}};
+  int Num = 5000;
+  int N1 = 1000;
+  float *h_A = (float *)malloc(Num * sizeof(float));
+  float *h_B = (float *)malloc(Num * sizeof(float));
+  float *h_C = (float *)malloc(Num * sizeof(float));
+
+  for (int i = 0; i < Num; i++) {
+    h_A[i] = 1.0f;
+    h_B[i] = 2.0f;
+  }
+
+  // hostA[0..999] -> deviceA[0..999]
+  // hostB[0..3999] -> deviceA[1000..4999]
+  // deviceA[0..4999] -> hostC[0..4999]
+  float *d_A = (float *)compat::malloc(Num * sizeof(float), q);
+  compat::memcpy_async((void *)d_A, (void *)h_A, N1 * sizeof(float), q);
+  compat::memcpy_async((void *)(d_A + N1), (void *)h_B,
+                       (Num - N1) * sizeof(float), q);
+  compat::memcpy_async((void *)h_C, (void *)d_A, Num * sizeof(float), q);
+  q.wait_and_throw();
+  compat::free((void *)d_A, q);
+
+  // verify
+  for (int i = 0; i < N1; i++) {
+    EXPECT_LE(fabs(h_A[i] - h_C[i]), 1e-5);
+  }
+
+  for (int i = N1; i < Num; i++) {
+    EXPECT_LE(fabs(h_B[i] - h_C[i]), 1e-5);
+  }
+
+  free(h_A);
+  free(h_B);
+  free(h_C);
+}
+
+TYPED_TEST(Memory_t, memcpy_async_t_q) {
+
+  sycl::queue q{{sycl::property::queue::in_order()}};
+  int Num = 5000;
+  int N1 = 1000;
+  TypeParam *h_A = (TypeParam *)malloc(Num * sizeof(TypeParam));
+  TypeParam *h_B = (TypeParam *)malloc(Num * sizeof(TypeParam));
+  TypeParam *h_C = (TypeParam *)malloc(Num * sizeof(TypeParam));
+
+  for (int i = 0; i < Num; i++) {
+    h_A[i] = TypeParam(1);
+    h_B[i] = TypeParam(2);
+  }
+
+  TypeParam *d_A = nullptr;
+  // hostA[0..999] -> deviceA[0..999]
+  // hostB[0..3999] -> deviceA[1000..4999]
+  // deviceA[0..4999] -> hostC[0..4999]
+  d_A = compat::malloc<TypeParam>(Num, q);
+  compat::memcpy_async<TypeParam>(d_A, h_A, N1, q);
+  compat::memcpy_async<TypeParam>((d_A + N1), h_B, (Num - N1), q);
+  compat::memcpy_async<TypeParam>(h_C, d_A, Num, q);
+  q.wait_and_throw();
+  compat::free((void *)d_A, q);
+
+  // verify
+  for (int i = 0; i < N1; i++) {
+    EXPECT_EQ(h_A[i], h_C[i]);
+  }
+
+  for (int i = N1; i < Num; i++) {
+    EXPECT_EQ(h_B[i], h_C[i]);
+  }
+
+  free(h_A);
+  free(h_B);
+  free(h_C);
+}
+
+TEST(Memory, free_memory_q) {
+  sycl::queue q{{sycl::property::queue::in_order()}};
+  float *d_A = (float *)compat::malloc(sizeof(float), q);
+  compat::free((void *)d_A, q);
+
+  compat::free(0, q);
+  compat::free(NULL, q);
+  compat::free(nullptr, q);
+}
+
+TEST(Memory, memset_async_q) {
+  sycl::queue q{{sycl::property::queue::in_order()}};
+  int Num = 10;
+  int *h_A = (int *)malloc(Num * sizeof(int));
+
+  for (int i = 0; i < Num; i++) {
+    h_A[i] = 4;
+  }
+
+  int *d_A = (int *)compat::malloc(Num * sizeof(int), q);
+  // hostA -> deviceA
+  compat::memcpy_async((void *)d_A, (void *)h_A, Num * sizeof(int), q);
+
+  // set d_A[0,..., 6] = 0
+  compat::memset_async((void *)d_A, 0, (Num - 3) * sizeof(int), q);
+
+  // deviceA -> hostA
+  compat::memcpy_async((void *)h_A, (void *)d_A, Num * sizeof(int), q);
+  q.wait_and_throw();
+  compat::free((void *)d_A, q);
+
+  // check d_A[0,..., 6] = 0
+  for (int i = 0; i < Num - 3; i++) {
+    EXPECT_EQ(h_A[i], 0);
+  }
+
+  // check d_A[7,..., 9] = 4
+  for (int i = Num - 3; i < Num; i++) {
+    EXPECT_EQ(h_A[i], 4);
+  }
+
+  free(h_A);
+}
+
+TYPED_TEST(Fill_t, fill_async_q) {
+
+  sycl::queue q{{sycl::property::queue::in_order()}};
+  constexpr int Num = 10;
+  TypeParam *h_A = (TypeParam *)malloc(Num * sizeof(TypeParam));
+
+  for (int i = 0; i < Num; i++) {
+    h_A[i] = TypeParam(4);
+  }
+
+  TypeParam *d_A = nullptr;
+
+  d_A = compat::malloc<TypeParam>(Num, q);
+  // hostA -> deviceA
+  compat::memcpy((void *)d_A, (void *)h_A, Num * sizeof(TypeParam), q);
+
+  // set d_A[0,..., 6] = 0
+  compat::fill_async((void *)d_A, TypeParam(0), (Num - 3), q);
+
+  // deviceA -> hostA
+  compat::memcpy((void *)h_A, (void *)d_A, Num * sizeof(TypeParam), q);
+
+  q.wait_and_throw();
+
+  compat::free((void *)d_A, q);
+
+  // check d_A[0,..., 6] = 0
+  for (int i = 0; i < Num - 3; i++) {
+    EXPECT_EQ(h_A[i], TypeParam(0));
+  }
+
+  // check d_A[7,..., 9] = 4
+  for (int i = Num - 3; i < Num; i++) {
+    EXPECT_EQ(h_A[i], TypeParam(4));
+  }
+
+  free(h_A);
+}
+
+TEST(Memory, memcpy_async_pitched_q) {
+  sycl::queue q{{sycl::property::queue::in_order()}};
+  size_t width = 6;
+  size_t height = 8;
+  float *h_data = nullptr;
+  float *h_ref = nullptr;
+  size_t h_pitch = sizeof(float) * width;
+  h_data = (float *)malloc(sizeof(float) * width * height);
+  for (int i = 0; i < width * height; i++)
+    h_data[i] = (float)i;
+
+  h_ref = (float *)malloc(sizeof(float) * width * height);
+  for (int i = 0; i < width * height; i++)
+    h_ref[i] = (float)i;
+
+  // alloc device memory.
+  size_t d_pitch;
+  float *d_data =
+      (float *)compat::malloc(d_pitch, sizeof(float) * width, height, q);
+
+  // copy to Device.
+  compat::memcpy_async(d_data, d_pitch, h_data, h_pitch, sizeof(float) * width,
+                       height, q);
+
+  // copy back to host.
+  compat::memcpy_async(h_data, h_pitch, d_data, d_pitch, sizeof(float) * width,
+                       height, q);
+  q.wait_and_throw();
+  check(h_data, h_ref, width, height, 1);
+
+  // memset device data.
+  compat::memset_async(d_data, d_pitch, 0x1, sizeof(float) * width, height, q);
+
+  // copy back to host
+  compat::memcpy_async(h_data, h_pitch, d_data, d_pitch, sizeof(float) * width,
+                       height, q);
+  q.wait_and_throw();
+  // memset reference data.
+  memset(h_ref, 0x1, width * height * sizeof(float));
+  check(h_data, h_ref, width, height, 1);
+
+  free(h_data);
+  free(h_ref);
+  compat::free((void *)d_data, q);
+}

--- a/sycl/unittests/Extensions/compat/memory/UsmAllocations.cpp
+++ b/sycl/unittests/Extensions/compat/memory/UsmAllocations.cpp
@@ -1,0 +1,216 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  UsmAllocations.cpp
+ *
+ *  Description:
+ *    USM allocation tests
+ **************************************************************************/
+
+#include <gtest/gtest.h>
+#include <numeric>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+#define WG_SIZE 256
+#define NUM_WG 32
+
+using namespace sycl::ext::oneapi::experimental;
+
+template <typename T> void VectorKernel(T *A) {
+  auto id = compat::global_id::x();
+  A[id] = id;
+}
+
+// Fixture to set up & launch VectorAdd kernel
+template <typename T> class USMTest : public ::testing::Test {
+protected:
+  USMTest()
+      : q_{compat::get_default_queue()}, grid_{NUM_WG}, thread_{WG_SIZE},
+        size_{WG_SIZE * NUM_WG} {}
+  void SetUp() {
+    if ((std::is_same_v<T, double>)&&!q_.get_device().has(sycl::aspect::fp64))
+      GTEST_SKIP();
+    if ((std::is_same_v<T, sycl::half>)&&!q_.get_device().has(
+            sycl::aspect::fp16))
+      GTEST_SKIP();
+  }
+  void launch_kernel() {
+    return launch<VectorKernel<T>>(grid_, thread_, q_, d_A).wait();
+  }
+
+  // Check result is identity vector
+  // Handles memcpy for USM device alloc
+  void check_result() {
+    sycl::usm::alloc ptr_type = sycl::get_pointer_type(d_A, q_.get_context());
+    ASSERT_NE(ptr_type, sycl::usm::alloc::unknown);
+
+    T *result;
+    if (ptr_type == sycl::usm::alloc::device) {
+      result = static_cast<T *>(std::malloc(sizeof(T) * size_));
+      compat::memcpy(result, d_A, sizeof(T) * size_);
+    } else {
+      result = d_A;
+    }
+
+    for (size_t i = 0; i < size_; i++) {
+      EXPECT_EQ(result[i], static_cast<T>(i));
+    }
+
+    if (ptr_type == sycl::usm::alloc::device)
+      std::free(result);
+  }
+
+  sycl::queue q_;
+  compat::dim3 const grid_;
+  compat::dim3 const thread_;
+  T *d_A;
+  size_t size_;
+};
+
+// Test template compat::malloc<T> on multiple
+// value types
+using value_type_list =
+    testing::Types<int, unsigned int, short, unsigned short, long,
+                   unsigned long, long long, unsigned long long, float, double,
+                   sycl::half>;
+TYPED_TEST_SUITE(USMTest, value_type_list);
+
+TYPED_TEST(USMTest, malloc) {
+  this->d_A = compat::malloc<TypeParam>(this->size_);
+  this->launch_kernel();
+  this->check_result();
+  compat::free(this->d_A);
+}
+
+TYPED_TEST(USMTest, host) {
+  if (!this->q_.get_device().has(sycl::aspect::usm_host_allocations))
+    GTEST_SKIP();
+  this->d_A = compat::malloc_host<TypeParam>(this->size_);
+  this->launch_kernel();
+  this->check_result();
+  compat::free(this->d_A);
+}
+
+TYPED_TEST(USMTest, shared) {
+  if (!this->q_.get_device().has(sycl::aspect::usm_shared_allocations))
+    GTEST_SKIP();
+  this->d_A = compat::malloc_shared<TypeParam>(this->size_);
+  this->launch_kernel();
+  this->check_result();
+  compat::free(this->d_A);
+}
+
+// Avoid combinatorial explosion by only testing non-templated
+// compat::malloc with int type
+using int_type_list = testing::Types<int>;
+template <class T> struct USMTest_noT : public USMTest<T> {};
+TYPED_TEST_SUITE(USMTest_noT, int_type_list);
+
+TYPED_TEST(USMTest_noT, malloc) {
+  this->d_A =
+      static_cast<TypeParam *>(compat::malloc(this->size_ * sizeof(TypeParam)));
+  this->launch_kernel();
+  this->check_result();
+  compat::free(this->d_A);
+}
+
+TYPED_TEST(USMTest_noT, host) {
+  if (!this->q_.get_device().has(sycl::aspect::usm_host_allocations))
+    GTEST_SKIP();
+  this->d_A = static_cast<TypeParam *>(
+      compat::malloc_host(this->size_ * sizeof(TypeParam)));
+  this->launch_kernel();
+  this->check_result();
+  compat::free(this->d_A);
+}
+
+TYPED_TEST(USMTest_noT, shared) {
+  if (!this->q_.get_device().has(sycl::aspect::usm_shared_allocations))
+    GTEST_SKIP();
+  this->d_A = static_cast<TypeParam *>(
+      compat::malloc_shared(this->size_ * sizeof(TypeParam)));
+  this->launch_kernel();
+  this->check_result();
+  compat::free(this->d_A);
+}
+
+// Test deduce direction
+TEST(USM_Deduction, deduce) {
+  using memcpy_direction = compat::detail::memcpy_direction;
+  auto default_queue = compat::get_default_queue();
+
+  int *h_ptr = (int *)compat::malloc_host(sizeof(int));
+  int *sys_ptr = (int *)std::malloc(sizeof(int));
+  int *d_ptr = (int *)compat::malloc(sizeof(int));
+  int *s_ptr = (int *)compat::malloc_shared(sizeof(int));
+
+  // * to host
+  EXPECT_EQ(
+      compat::detail::deduce_memcpy_direction(default_queue, h_ptr, h_ptr),
+      memcpy_direction::device_to_device);
+  EXPECT_EQ(
+      compat::detail::deduce_memcpy_direction(default_queue, h_ptr, sys_ptr),
+      memcpy_direction::host_to_host);
+  EXPECT_EQ(
+      compat::detail::deduce_memcpy_direction(default_queue, h_ptr, d_ptr),
+      memcpy_direction::device_to_device);
+  EXPECT_EQ(
+      compat::detail::deduce_memcpy_direction(default_queue, h_ptr, s_ptr),
+      memcpy_direction::device_to_device);
+
+  // * to sys
+  EXPECT_EQ(
+      compat::detail::deduce_memcpy_direction(default_queue, sys_ptr, h_ptr),
+      memcpy_direction::host_to_host);
+  EXPECT_EQ(
+      compat::detail::deduce_memcpy_direction(default_queue, sys_ptr, sys_ptr),
+      memcpy_direction::host_to_host);
+  EXPECT_EQ(
+      compat::detail::deduce_memcpy_direction(default_queue, sys_ptr, d_ptr),
+      memcpy_direction::device_to_host);
+  EXPECT_EQ(
+      compat::detail::deduce_memcpy_direction(default_queue, sys_ptr, s_ptr),
+      memcpy_direction::host_to_host);
+
+  // * to dev
+  EXPECT_EQ(
+      compat::detail::deduce_memcpy_direction(default_queue, d_ptr, h_ptr),
+      memcpy_direction::device_to_device);
+  EXPECT_EQ(
+      compat::detail::deduce_memcpy_direction(default_queue, d_ptr, sys_ptr),
+      memcpy_direction::host_to_device);
+  EXPECT_EQ(
+      compat::detail::deduce_memcpy_direction(default_queue, d_ptr, d_ptr),
+      memcpy_direction::device_to_device);
+  EXPECT_EQ(
+      compat::detail::deduce_memcpy_direction(default_queue, d_ptr, s_ptr),
+      memcpy_direction::device_to_device);
+
+  // * to shared
+  EXPECT_EQ(
+      compat::detail::deduce_memcpy_direction(default_queue, s_ptr, h_ptr),
+      memcpy_direction::device_to_device);
+  EXPECT_EQ(
+      compat::detail::deduce_memcpy_direction(default_queue, s_ptr, sys_ptr),
+      memcpy_direction::host_to_host);
+  EXPECT_EQ(
+      compat::detail::deduce_memcpy_direction(default_queue, s_ptr, d_ptr),
+      memcpy_direction::device_to_device);
+  EXPECT_EQ(
+      compat::detail::deduce_memcpy_direction(default_queue, s_ptr, s_ptr),
+      memcpy_direction::device_to_device);
+}

--- a/sycl/unittests/Extensions/compat/memory/memory_check.hpp
+++ b/sycl/unittests/Extensions/compat/memory/memory_check.hpp
@@ -1,0 +1,33 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  memory_check.hpp
+ *
+ *  Description:
+ *    Memory content helper for the Memory functionality tests
+ **************************************************************************/
+
+#pragma once
+
+#include <gtest/gtest.h>
+
+inline void check(float *h_data, float *h_ref, size_t width, size_t height,
+                  size_t depth) {
+  for (size_t i = 0; i < width * height * depth; i++) {
+    float diff = fabs(h_data[i] - h_ref[i]);
+    EXPECT_LE(diff, 1.e-6);
+  }
+}

--- a/sycl/unittests/Extensions/compat/util/CMakeLists.txt
+++ b/sycl/unittests/Extensions/compat/util/CMakeLists.txt
@@ -1,0 +1,35 @@
+#
+# Copyright (C) Codeplay Software Ltd.
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# SYCL compatibility API
+#
+
+add_sycl_unittest_with_extra_flags(Extensionscompatutiltests SHARED
+  UtilCastValueTest.cpp
+  UtilComplex.cpp
+  UtilFastLengthTest.cpp
+  UtilFindFirstSet.cpp
+  UtilLogicalGroup.cpp
+  UtilMakeIndexSequenceTest.cpp
+  UtilMatrixMemCopyTest.cpp
+  UtilNdRangeBarrierTest.cpp
+  UtilPermByteTest.cpp
+  UtilPermuteSubGroupByXor.cpp
+  UtilReverseBitsTest.cpp
+  UtilSelectFromSubGroup.cpp
+  UtilShiftSubGroupLeft.cpp
+  UtilShiftSubGroupRight.cpp
+  UtilVectorizedIsgreaterTest.cpp
+  UtilVectorizedMaxTest.cpp
+  UtilVectorizedMinTest.cpp
+)

--- a/sycl/unittests/Extensions/compat/util/UtilCastValueTest.cpp
+++ b/sycl/unittests/Extensions/compat/util/UtilCastValueTest.cpp
@@ -1,0 +1,85 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  UtilCastValueTest.cpp
+ *
+ *  Description:
+ *    cast_value tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ UtilCastValueTest.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+double cast_value(const double &val) {
+  int lo =
+      sycl::ext::oneapi::experimental::compat::cast_double_to_int(val, false);
+  int hi = sycl::ext::oneapi::experimental::compat::cast_double_to_int(val);
+  return sycl::ext::oneapi::experimental::compat::cast_ints_to_double(hi, lo);
+}
+
+void test_kernel_cast_value(double *g_odata) {
+  double a = 1.12123515e-25f;
+  g_odata[0] = cast_value(a);
+
+  a = 0.000000000000000000000000112123515f;
+  g_odata[1] = cast_value(a);
+
+  a = 3.1415926f;
+  g_odata[2] = cast_value(a);
+}
+
+TEST(Casting, double_int2_cast_test) {
+  if (!sycl::ext::oneapi::experimental::compat::get_current_device().has(
+          sycl::aspect::fp64))
+    GTEST_SKIP();
+  sycl::queue q = sycl::ext::oneapi::experimental::compat::get_default_queue();
+
+  unsigned int num_data = 3;
+  unsigned int mem_size = sizeof(double) * num_data;
+
+  double *h_out_data = (double *)malloc(mem_size);
+
+  for (unsigned int i = 0; i < num_data; i++)
+    h_out_data[i] = 0;
+
+  double *d_out_data;
+  d_out_data = (double *)sycl::malloc_device(mem_size, q);
+  q.memcpy(d_out_data, h_out_data, mem_size).wait();
+
+  q.parallel_for(
+      sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
+      [=](sycl::nd_item<3> item_ct1) { test_kernel_cast_value(d_out_data); });
+
+  q.memcpy(h_out_data, d_out_data, mem_size).wait();
+
+  EXPECT_EQ(h_out_data[0], 1.12123515e-25f);
+  EXPECT_EQ(h_out_data[1], 0.000000000000000000000000112123515f);
+  EXPECT_EQ(h_out_data[2], 3.1415926f);
+
+  free(h_out_data);
+  sycl::free(d_out_data, q);
+}

--- a/sycl/unittests/Extensions/compat/util/UtilComplex.cpp
+++ b/sycl/unittests/Extensions/compat/util/UtilComplex.cpp
@@ -1,0 +1,194 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  UtilComplex.cpp
+ *
+ *  Description:
+ *    Complex operations tests
+ **************************************************************************/
+
+// The original source was under the license below:
+//===-------------- UtilComplex.cpp --------------------*- C++ -*----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===---------------------------------------------------------------===//
+// test_feature:Util_cabs
+
+#include <complex>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+#include <cmath>
+
+using namespace sycl::ext::oneapi::experimental;
+
+template <typename T> bool check(T x, float e[], int &index) {
+  float precison = 0.001f;
+  if ((std::abs(x.x() - e[index++]) < precison) &&
+      (std::abs(x.y() - e[index++]) < precison)) {
+    return true;
+  }
+  return false;
+}
+
+template <> bool check<float>(float x, float e[], int &index) {
+  float precison = 0.001f;
+  if (std::abs(x - e[index++]) < precison) {
+    return true;
+  }
+  return false;
+}
+
+template <> bool check<double>(double x, float e[], int &index) {
+  float precison = 0.001f;
+  if (std::abs(x - e[index++]) < precison) {
+    return true;
+  }
+  return false;
+}
+
+// Class to launch a kernel and run a lambda on output data
+template <auto F> class ComplexLauncher {
+protected:
+  int *result_;
+  int cpu_result_{0};
+
+public:
+  ComplexLauncher() {
+    result_ = (int *)compat::malloc_shared(sizeof(int));
+    *result_ = 0;
+  };
+  ~ComplexLauncher() { compat::free(result_); }
+  void launch() {
+    if (!compat::get_current_device().has(sycl::aspect::fp64))
+      GTEST_SKIP();
+    F(&cpu_result_);                  // Run on host
+    compat::launch<F>(1, 1, result_); // Run on device
+    compat::wait();
+    EXPECT_EQ(*result_, 1);
+    EXPECT_EQ(cpu_result_, 1);
+  }
+};
+
+void kernel_abs(int *result) {
+
+  sycl::float2 f1, f2;
+  sycl::double2 d1, d2;
+
+  f1 = sycl::float2(1.8, -2.7);
+  f2 = sycl::float2(-3.6, 4.5);
+  d1 = sycl::double2(5.4, -6.3);
+  d2 = sycl::double2(-7.2, 8.1);
+
+  int index = 0;
+  bool r = true;
+  float expect[2] = {8.297590, 3.244996};
+
+  auto a1 = compat::cabs(d1);
+  r = r && check(a1, expect, index);
+
+  auto a2 = compat::cabs(f1);
+  r = r && check(a2, expect, index);
+
+  *result = r;
+}
+
+void kernel_conj(int *result) {
+
+  sycl::float2 f1, f2;
+  sycl::double2 d1, d2;
+
+  f1 = sycl::float2(1.8, -2.7);
+  f2 = sycl::float2(-3.6, 4.5);
+  d1 = sycl::double2(5.4, -6.3);
+  d2 = sycl::double2(-7.2, 8.1);
+
+  int index = 0;
+  bool r = true;
+  float expect[4] = {5.400000, 6.300000, 1.800000, 2.700000};
+
+  auto a1 = compat::conj(d1);
+  r = r && check(a1, expect, index);
+
+  auto a2 = compat::conj(f1);
+  r = r && check(a2, expect, index);
+
+  *result = r;
+}
+
+void kernel_div(int *result) {
+
+  sycl::float2 f1, f2;
+  sycl::double2 d1, d2;
+
+  f1 = sycl::float2(1.8, -2.7);
+  f2 = sycl::float2(-3.6, 4.5);
+  d1 = sycl::double2(5.4, -6.3);
+  d2 = sycl::double2(-7.2, 8.1);
+
+  int index = 0;
+  bool r = true;
+  float expect[4] = {-0.765517, 0.013793, -0.560976, 0.048780};
+
+  auto a1 = compat::cdiv(d1, d2);
+  r = r && check(a1, expect, index);
+
+  auto a2 = compat::cdiv(f1, f2);
+  r = r && check(a2, expect, index);
+
+  *result = r;
+}
+
+void kernel_mul(int *result) {
+
+  sycl::float2 f1, f2;
+  sycl::double2 d1, d2;
+
+  f1 = sycl::float2(1.8, -2.7);
+  f2 = sycl::float2(-3.6, 4.5);
+  d1 = sycl::double2(5.4, -6.3);
+  d2 = sycl::double2(-7.2, 8.1);
+
+  int index = 0;
+  bool r = true;
+  float expect[4] = {12.150000, 89.100000, 5.670001, 17.820000};
+
+  auto a1 = compat::cmul(d1, d2);
+  r = r && check(a1, expect, index);
+
+  auto a2 = compat::cmul(f1, f2);
+  r = r && check(a2, expect, index);
+
+  *result = r;
+}
+
+TEST(Complex, abs) { ComplexLauncher<kernel_abs>().launch(); }
+TEST(Complex, mul) { ComplexLauncher<kernel_mul>().launch(); }
+TEST(Complex, div) { ComplexLauncher<kernel_div>().launch(); }
+TEST(Complex, conj) { ComplexLauncher<kernel_conj>().launch(); }
+
+TEST(Complex, DataType) {
+  if (!std::is_same<compat::detail::DataType<float>::T2, float>::value)
+    FAIL();
+  if (!std::is_same<compat::detail::DataType<sycl::float2>::T2,
+                    complex<float>>::value)
+    FAIL();
+}

--- a/sycl/unittests/Extensions/compat/util/UtilFastLengthTest.cpp
+++ b/sycl/unittests/Extensions/compat/util/UtilFastLengthTest.cpp
@@ -1,0 +1,92 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  UtilFastLengthTest.cpp
+ *
+ *  Description:
+ *    Fast length tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ UtilFastLengthTest.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <numeric>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+#define MAX_LEN 5
+
+void compute_length(float *d_A, size_t n, float *ans) {
+  *ans = sycl::ext::oneapi::experimental::compat::fast_length(d_A, n);
+}
+
+class FastLengthLauncher {
+protected:
+  float *data_;
+  float *result_;
+  float host_result_{0.0};
+
+public:
+  FastLengthLauncher() {
+    data_ = (float *)sycl::ext::oneapi::experimental::compat::malloc(
+        MAX_LEN * sizeof(float));
+    result_ =
+        (float *)sycl::ext::oneapi::experimental::compat::malloc(sizeof(float));
+  };
+  ~FastLengthLauncher() {
+    sycl::ext::oneapi::experimental::compat::free(data_);
+    sycl::ext::oneapi::experimental::compat::free(result_);
+  }
+
+  void check_result(std::vector<float> result) {
+    float sum =
+        std::inner_product(result.begin(), result.end(), result.begin(), 0.0f);
+    float diff = fabs(sqrtf(sum)) - host_result_;
+    EXPECT_LE(diff, 1.e-5);
+  }
+
+  void launch(std::vector<float> vec) {
+    size_t n = vec.size();
+    sycl::ext::oneapi::experimental::compat::memcpy(data_, vec.data(),
+                                                    sizeof(float) * n);
+    auto data = data_;
+    auto result = result_;
+    sycl::ext::oneapi::experimental::compat::get_default_queue().single_task(
+        [data, result, n]() { compute_length(data, n, result); });
+    sycl::ext::oneapi::experimental::compat::memcpy(&host_result_, result_,
+                                                    sizeof(float));
+    check_result(vec);
+  }
+};
+
+TEST(Util, fast_length) {
+  auto launcher = FastLengthLauncher();
+  launcher.launch(std::vector<float>{0.8970062715});
+  launcher.launch(std::vector<float>{0.8335529744, 0.7346600673});
+  launcher.launch(std::vector<float>{0.1658983906, 0.590226484, 0.4891553616});
+  launcher.launch(std::vector<float>{0.6041178723, 0.7760620605, 0.2944284976,
+                                     0.6851913766});
+  launcher.launch(std::vector<float>{0.6041178723, 0.7760620605, 0.2944284976,
+                                     0.6851913766, 0.6851913766});
+}

--- a/sycl/unittests/Extensions/compat/util/UtilFindFirstSet.cpp
+++ b/sycl/unittests/Extensions/compat/util/UtilFindFirstSet.cpp
@@ -1,0 +1,117 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  UtilFindFirstSet.cpp
+ *
+ *  Description:
+ *    Find_first_set tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ UtilFindFirstSet.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+
+void find_first_set_test(int *test_result) {
+  int a;
+  unsigned long long int lla;
+  int result;
+  a = 0;
+  result = compat::ffs(a);
+  if (result != 0) {
+    *test_result = 1;
+    return;
+  }
+
+  a = -2147483648;
+  result = compat::ffs(a);
+  if (result != 32) {
+    *test_result = 1;
+    return;
+  }
+
+  a = 128;
+  result = compat::ffs(a);
+  if (result != 8) {
+    *test_result = 1;
+    return;
+  }
+
+  a = 2147483647;
+  result = compat::ffs(a);
+  if (result != 1) {
+    *test_result = 1;
+    return;
+  }
+
+  lla = -9223372036854775808Ull;
+  result = compat::ffs(lla);
+  if (result != 64) {
+    *test_result = 1;
+    return;
+  }
+
+  lla = -9223372036854775807Ull;
+  result = compat::ffs(lla);
+  if (result != 1) {
+    *test_result = 1;
+    return;
+  }
+
+  lla = -9223372034707292160Ull;
+  result = compat::ffs(lla);
+  if (result != 32) {
+    *test_result = 1;
+    return;
+  }
+
+  lla = 2147483648Ull;
+  result = compat::ffs(lla);
+  if (result != 32) {
+    *test_result = 1;
+    return;
+  }
+}
+
+TEST(Util, find_first_set) {
+
+  compat::device_ext &dev_ct1 = compat::get_current_device();
+  sycl::queue *q_ct1 = dev_ct1.default_queue();
+  int *test_result, host_test_result = 0;
+
+  test_result = sycl::malloc_shared<int>(sizeof(int), *q_ct1);
+  *test_result = 0;
+
+  q_ct1->parallel_for(
+      sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
+      [=](sycl::nd_item<3> item_ct1) { find_first_set_test(test_result); });
+
+  dev_ct1.queues_wait_and_throw();
+  find_first_set_test(&host_test_result);
+  EXPECT_EQ(*test_result, 0);
+  EXPECT_EQ(host_test_result, 0);
+}

--- a/sycl/unittests/Extensions/compat/util/UtilLogicalGroup.cpp
+++ b/sycl/unittests/Extensions/compat/util/UtilLogicalGroup.cpp
@@ -1,0 +1,76 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  UtilLogicalGroup.cpp
+ *
+ *  Description:
+ *    logical_group tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ UtilLogicalGroup.cpp -------------------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <cstdio>
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+
+// work-item:
+// 0 ... 7, 8 ... 15, 16 ... 23, 24 ... 31, 32 ... 39, 40 ... 47, 48 ... 51
+// -------  --------  ---------  ---------  ---------  ---------  ---------
+// 0        1         2          3          4          5          6
+
+void kernel(unsigned int *result, sycl::nd_item<3> item_ct1) {
+  auto ttb = item_ct1.get_group();
+  compat::experimental::logical_group tbt =
+      compat::experimental::logical_group(item_ct1, item_ct1.get_group(), 8);
+
+  if (item_ct1.get_local_id(2) == 50) {
+    result[0] = tbt.get_local_linear_range();
+    result[1] = tbt.get_local_linear_id();
+    result[2] = tbt.get_group_linear_range();
+    result[3] = tbt.get_group_linear_id();
+  }
+}
+
+TEST(Util, logical_group) {
+  compat::device_ext &dev_ct1 = compat::get_current_device();
+  sycl::queue *q_ct1 = dev_ct1.default_queue();
+  unsigned int result_host[4];
+  unsigned int *result_device;
+  result_device = sycl::malloc_device<unsigned int>(4, *q_ct1);
+  q_ct1->parallel_for(
+      sycl::nd_range<3>(sycl::range<3>(1, 1, 52), sycl::range<3>(1, 1, 52)), [=
+  ](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+        kernel(result_device, item_ct1);
+      });
+  q_ct1->memcpy(result_host, result_device, sizeof(unsigned int) * 4).wait();
+  sycl::free(result_device, *q_ct1);
+
+  EXPECT_EQ(result_host[0], 4);
+  EXPECT_EQ(result_host[1], 2);
+  EXPECT_EQ(result_host[2], 7);
+  EXPECT_EQ(result_host[3], 6);
+}

--- a/sycl/unittests/Extensions/compat/util/UtilMakeIndexSequenceTest.cpp
+++ b/sycl/unittests/Extensions/compat/util/UtilMakeIndexSequenceTest.cpp
@@ -1,0 +1,56 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  UtilMakeIndexSequenceTest.cpp
+ *
+ *  Description:
+ *    make_index_sequence tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ UtilMakeIndexSequenceTest.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+
+const int ref_range[3] = {1, 2, 3};
+
+template <int... DimIdx>
+sycl::range<sizeof...(DimIdx)>
+get_range(compat::detail::integer_sequence<DimIdx...>) {
+  return sycl::range<sizeof...(DimIdx)>(ref_range[DimIdx]...);
+}
+
+TEST(Util, make_index_sequence) {
+  const int dimensions = 3;
+  auto index = compat::detail::make_index_sequence<dimensions>();
+
+  auto value = get_range(index);
+
+  for (int i = 0; i < dimensions; i++) {
+    EXPECT_EQ(value[i], ref_range[i]);
+  }
+}

--- a/sycl/unittests/Extensions/compat/util/UtilMatrixMemCopyTest.cpp
+++ b/sycl/unittests/Extensions/compat/util/UtilMatrixMemCopyTest.cpp
@@ -1,0 +1,103 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  UtilMatrixMemCopyTest.cpp
+ *
+ *  Description:
+ *    matrix_mem_copy tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ UtilMatrixMemCopyTest.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <iostream>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+#define M 3
+#define N 2
+
+using namespace sycl::ext::oneapi::experimental;
+
+TEST(Util, matrix_mem_copy_1) {
+  compat::device_ext &dev_ct1 = compat::get_current_device();
+  sycl::queue *q_ct1 = dev_ct1.default_queue();
+  float *devPtrA;
+  devPtrA = (float *)sycl::malloc_device(M * N * sizeof(float), *q_ct1);
+  float host_a[6] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  float host_b[6] = {-1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f};
+  float host_c[6] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+
+  compat::detail::matrix_mem_copy((void *)devPtrA, (void *)host_a, M, M, M, N,
+                                  sizeof(float));
+  compat::detail::matrix_mem_copy((void *)host_b, (void *)devPtrA, M, M, M, N,
+                                  sizeof(float));
+
+  for (int i = 0; i < M * N; i++) {
+    EXPECT_LE(fabs(host_b[i] - host_c[i]), 1e-5);
+  }
+
+  // Because to_ld == from_ld, matrix_mem_copy just do one copy.
+  // All padding data is also copied except the last padding.
+  float host_d[6] = {-2.0f, -2.0f, -2.0f, -2.0f, -2.0f, -2.0f};
+  float host_e[6] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, -2.0f};
+  compat::detail::matrix_mem_copy((void *)host_d, (void *)devPtrA, M /*to_ld*/,
+                                  M /*from_ld*/, M - 1 /*rows*/, N /*cols*/,
+                                  sizeof(float));
+
+  for (int i = 0; i < M * N; i++) {
+    EXPECT_LE(fabs(host_d[i] - host_e[i]), 1e-5);
+  }
+
+  sycl::free(devPtrA, *q_ct1);
+}
+
+TEST(Util, matrix_mem_copy2) {
+  compat::device_ext &dev_ct1 = compat::get_current_device();
+  sycl::queue *q_ct1 = dev_ct1.default_queue();
+
+  float *devPtrA;
+  devPtrA = (float *)sycl::malloc_device(M * N * sizeof(float), *q_ct1);
+  float host_a[6] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+  float host_b[6] = {-1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f};
+  float host_c[6] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+
+  compat::detail::matrix_mem_copy(devPtrA, host_a, M, M, M, N);
+  compat::detail::matrix_mem_copy(host_b, devPtrA, M, M, M, N);
+
+  for (int i = 0; i < M * N; i++) {
+    EXPECT_LE(fabs(host_b[i] - host_c[i]), 1e-5);
+  }
+
+  float host_d[4] = {-2.0f, -2.0f, -2.0f, -2.0f};
+  float host_e[4] = {1.0f, 2.0f, 4.0f, 5.0f};
+  compat::detail::matrix_mem_copy(host_d, devPtrA, M - 1 /*to_ld*/,
+                                  M /*from_ld*/, M - 1 /*rows*/, N /*cols*/);
+
+  for (int i = 0; i < (M - 1) * (N - 1); i++) {
+    EXPECT_LE(fabs(host_d[i] - host_e[i]), 1e-5);
+  }
+
+  sycl::free(devPtrA, *q_ct1);
+}

--- a/sycl/unittests/Extensions/compat/util/UtilNdRangeBarrierTest.cpp
+++ b/sycl/unittests/Extensions/compat/util/UtilNdRangeBarrierTest.cpp
@@ -1,0 +1,181 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  UtilNdRangeBarrierTest.cpp
+ *
+ *  Description:
+ *    nd_range_barrier tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ UtilNdRangeBarrierTest.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <cstring>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <stdio.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+
+void kernel_1(
+    sycl::nd_item<3> item_ct1,
+    sycl::atomic_ref<unsigned int, sycl::memory_order::acq_rel,
+                     sycl::memory_scope::device,
+                     sycl::access::address_space::global_space> &sync_ct1) {
+  compat::experimental::nd_range_barrier(item_ct1, sync_ct1);
+}
+
+void kernel_2(
+    sycl::nd_item<3> item_ct1,
+    sycl::atomic_ref<unsigned int, sycl::memory_order::acq_rel,
+                     sycl::memory_scope::device,
+                     sycl::access::address_space::global_space> &sync_ct1) {
+  compat::experimental::nd_range_barrier(item_ct1, sync_ct1);
+
+  compat::experimental::nd_range_barrier(item_ct1, sync_ct1);
+}
+
+TEST(Util, nd_range_barrier_dim3) {
+
+  compat::device_ext &dev_ct1 = compat::get_current_device();
+  sycl::queue *q_ct1 = dev_ct1.default_queue();
+  {
+    compat::global_memory<unsigned int, 0> d_sync_ct1;
+    unsigned *sync_ct1 = d_sync_ct1.get_ptr(compat::get_default_queue());
+    compat::get_default_queue().memset(sync_ct1, 0, sizeof(int)).wait();
+
+    q_ct1
+        ->submit([&](sycl::handler &cgh) {
+          cgh.parallel_for(
+              sycl::nd_range<3>(sycl::range<3>(1, 1, 4) *
+                                    sycl::range<3>(1, 1, 4),
+                                sycl::range<3>(1, 1, 4)),
+              [=](sycl::nd_item<3> item_ct1) {
+                auto atm_sync_ct1 =
+                    sycl::atomic_ref<unsigned int, sycl::memory_order::acq_rel,
+                                     sycl::memory_scope::device,
+                                     sycl::access::address_space::global_space>(
+                        sync_ct1[0]);
+                kernel_1(item_ct1, atm_sync_ct1);
+              });
+        })
+        .wait();
+  }
+  dev_ct1.queues_wait_and_throw();
+
+  {
+
+    compat::global_memory<unsigned int, 0> d_sync_ct1;
+    unsigned *sync_ct1 = d_sync_ct1.get_ptr(compat::get_default_queue());
+    compat::get_default_queue().memset(sync_ct1, 0, sizeof(int)).wait();
+
+    q_ct1
+        ->submit([&](sycl::handler &cgh) {
+          cgh.parallel_for(
+              sycl::nd_range<3>(sycl::range<3>(1, 1, 4) *
+                                    sycl::range<3>(1, 1, 4),
+                                sycl::range<3>(1, 1, 4)),
+              [=](sycl::nd_item<3> item_ct1) {
+                auto atm_sync_ct1 =
+                    sycl::atomic_ref<unsigned int, sycl::memory_order::acq_rel,
+                                     sycl::memory_scope::device,
+                                     sycl::access::address_space::global_space>(
+                        sync_ct1[0]);
+                kernel_2(item_ct1, atm_sync_ct1);
+              });
+        })
+        .wait();
+  }
+  dev_ct1.queues_wait_and_throw();
+}
+
+void kernel_1(
+    sycl::nd_item<1> item_ct1,
+    sycl::atomic_ref<unsigned int, sycl::memory_order::acq_rel,
+                     sycl::memory_scope::device,
+                     sycl::access::address_space::global_space> &sync_ct1) {
+  compat::experimental::nd_range_barrier(item_ct1, sync_ct1);
+}
+
+void kernel_2(
+    sycl::nd_item<1> item_ct1,
+    sycl::atomic_ref<unsigned int, sycl::memory_order::acq_rel,
+                     sycl::memory_scope::device,
+                     sycl::access::address_space::global_space> &sync_ct1) {
+  compat::experimental::nd_range_barrier(item_ct1, sync_ct1);
+
+  compat::experimental::nd_range_barrier(item_ct1, sync_ct1);
+}
+
+TEST(Util, nd_range_barrier_dim1_test) {
+  compat::device_ext &dev_ct1 = compat::get_current_device();
+  sycl::queue *q_ct1 = dev_ct1.default_queue();
+
+  {
+    compat::global_memory<unsigned int, 0> d_sync_ct1;
+    unsigned *sync_ct1 = d_sync_ct1.get_ptr(compat::get_default_queue());
+    compat::get_default_queue().memset(sync_ct1, 0, sizeof(int)).wait();
+
+    q_ct1
+        ->submit([&](sycl::handler &cgh) {
+          cgh.parallel_for(
+              sycl::nd_range<1>(sycl::range<1>(4) * sycl::range<1>(4),
+                                sycl::range<1>(4)),
+              [=](sycl::nd_item<1> item_ct1) {
+                auto atm_sync_ct1 =
+                    sycl::atomic_ref<unsigned int, sycl::memory_order::acq_rel,
+                                     sycl::memory_scope::device,
+                                     sycl::access::address_space::global_space>(
+                        sync_ct1[0]);
+                kernel_1(item_ct1, atm_sync_ct1);
+              });
+        })
+        .wait();
+  }
+
+  dev_ct1.queues_wait_and_throw();
+  {
+    compat::global_memory<unsigned int, 0> d_sync_ct1;
+    unsigned *sync_ct1 = d_sync_ct1.get_ptr(compat::get_default_queue());
+    compat::get_default_queue().memset(sync_ct1, 0, sizeof(int)).wait();
+
+    q_ct1
+        ->submit([&](sycl::handler &cgh) {
+          cgh.parallel_for(
+              sycl::nd_range<1>(sycl::range<1>(4) * sycl::range<1>(4),
+                                sycl::range<1>(4)),
+              [=](sycl::nd_item<1> item_ct1) {
+                auto atm_sync_ct1 =
+                    sycl::atomic_ref<unsigned int, sycl::memory_order::acq_rel,
+                                     sycl::memory_scope::device,
+                                     sycl::access::address_space::global_space>(
+                        sync_ct1[0]);
+                kernel_2(item_ct1, atm_sync_ct1);
+              });
+        })
+        .wait();
+  }
+  dev_ct1.queues_wait_and_throw();
+}

--- a/sycl/unittests/Extensions/compat/util/UtilPermByteTest.cpp
+++ b/sycl/unittests/Extensions/compat/util/UtilPermByteTest.cpp
@@ -1,0 +1,76 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  UtilPermByteTest.cpp
+ *
+ *  Description:
+ *    byte_level_permute tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ UtilPermByteTest.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+void byte_perm_ref(unsigned int *d_data) {
+
+  unsigned int lo;
+  unsigned int hi;
+
+  lo = 0x33221100;
+  hi = 0x77665544;
+
+  lo = 0x33221100;
+  hi = 0x77665544;
+
+  for (int i = 0; i < 17; i++)
+    d_data[i] = sycl::ext::oneapi::experimental::compat::byte_level_permute(
+        lo, hi, 0x1111 * i);
+
+  d_data[17] = sycl::ext::oneapi::experimental::compat::byte_level_permute(
+      lo, 0, 0x0123);
+  d_data[18] = sycl::ext::oneapi::experimental::compat::byte_level_permute(
+      lo, hi, 0x7531);
+  d_data[19] = sycl::ext::oneapi::experimental::compat::byte_level_permute(
+      lo, hi, 0x6420);
+}
+
+TEST(Util, byte_level_permute) {
+  const int N = 20;
+  unsigned int refer[N] = {0x0,        0x11111111, 0x22222222, 0x33333333,
+                           0x44444444, 0x55555555, 0x66666666, 0x77777777,
+                           0x0,        0x11111111, 0x22222222, 0x33333333,
+                           0x44444444, 0x55555555, 0x66666666, 0x77777777,
+                           0x11111100, 0x112233,   0x77553311, 0x66442200};
+  unsigned int data[N];
+
+  byte_perm_ref(data);
+
+  for (int i = 0; i < N; i++) {
+    EXPECT_EQ(refer[i], data[i]);
+  }
+}

--- a/sycl/unittests/Extensions/compat/util/UtilPermuteSubGroupByXor.cpp
+++ b/sycl/unittests/Extensions/compat/util/UtilPermuteSubGroupByXor.cpp
@@ -1,0 +1,137 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  UtilPermuteSubGroupByXor.cpp
+ *
+ *  Description:
+ *    permute_sub_group_by_xor tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ UtilPermuteSubGroupByXor.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+#define WARP_SIZE 32
+#define DATA_NUM 128
+
+using namespace sycl::ext::oneapi::experimental;
+
+template <typename T = int> void init_data(T *data, int num) {
+  for (int i = 0; i < num; i++)
+    data[i] = i;
+}
+
+template <typename T = int>
+void verify_data(T *data, T *expect, int num, int step = 1) {
+  for (int i = 0; i < num; i = i + step) {
+    EXPECT_EQ(data[i], expect[i]);
+  }
+}
+
+void permute_sub_group_by_xor1(unsigned int *data, sycl::nd_item<3> item_ct1) {
+  int threadid = item_ct1.get_local_id(2) +
+                 item_ct1.get_local_id(1) * item_ct1.get_local_range(2) +
+                 item_ct1.get_local_id(0) * item_ct1.get_local_range(2) *
+                     item_ct1.get_local_range(1) +
+                 item_ct1.get_group(2) * item_ct1.get_local_range(2) *
+                     item_ct1.get_local_range(1) * item_ct1.get_local_range(0);
+  int output = 0;
+  output =
+      compat::permute_sub_group_by_xor(item_ct1.get_sub_group(), threadid, 2);
+  data[threadid] = output;
+}
+
+void permute_sub_group_by_xor2(unsigned int *data, sycl::nd_item<3> item_ct1) {
+  int threadid = item_ct1.get_local_id(2) +
+                 item_ct1.get_local_id(1) * item_ct1.get_local_range(2) +
+                 item_ct1.get_local_id(0) * item_ct1.get_local_range(2) *
+                     item_ct1.get_local_range(1) +
+                 item_ct1.get_group(2) * item_ct1.get_local_range(2) *
+                     item_ct1.get_local_range(1) * item_ct1.get_local_range(0);
+  int output = 0;
+  output = compat::permute_sub_group_by_xor(item_ct1.get_sub_group(), threadid,
+                                            1, 8);
+  data[threadid] = output;
+}
+
+TEST(Util, permute_sub_group_by_xor) {
+
+  compat::device_ext &dev_ct1 = compat::get_current_device();
+  sycl::queue *q_ct1 = dev_ct1.default_queue();
+  bool Result = true;
+  int *dev_data = nullptr;
+  unsigned int *dev_data_u = nullptr;
+  sycl::range<3> GridSize(1, 1, 1);
+  sycl::range<3> BlockSize(1, 1, 1);
+  dev_data = sycl::malloc_shared<int>(DATA_NUM, *q_ct1);
+  dev_data_u = sycl::malloc_shared<unsigned int>(DATA_NUM, *q_ct1);
+
+  GridSize = sycl::range<3>(1, 1, 2);
+  BlockSize = sycl::range<3>(1, 2, 32);
+  unsigned int expect1[DATA_NUM] = {
+      2,   3,   0,   1,   6,   7,   4,   5,   10,  11,  8,   9,   14,  15,  12,
+      13,  18,  19,  16,  17,  22,  23,  20,  21,  26,  27,  24,  25,  30,  31,
+      28,  29,  34,  35,  32,  33,  38,  39,  36,  37,  42,  43,  40,  41,  46,
+      47,  44,  45,  50,  51,  48,  49,  54,  55,  52,  53,  58,  59,  56,  57,
+      62,  63,  60,  61,  66,  67,  64,  65,  70,  71,  68,  69,  74,  75,  72,
+      73,  78,  79,  76,  77,  82,  83,  80,  81,  86,  87,  84,  85,  90,  91,
+      88,  89,  94,  95,  92,  93,  98,  99,  96,  97,  102, 103, 100, 101, 106,
+      107, 104, 105, 110, 111, 108, 109, 114, 115, 112, 113, 118, 119, 116, 117,
+      122, 123, 120, 121, 126, 127, 124, 125};
+  init_data<unsigned int>(dev_data_u, DATA_NUM);
+
+  q_ct1->parallel_for(
+      sycl::nd_range<3>(GridSize * BlockSize, BlockSize), [=
+  ](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+        permute_sub_group_by_xor1(dev_data_u, item_ct1);
+      });
+
+  dev_ct1.queues_wait_and_throw();
+  verify_data<unsigned int>(dev_data_u, expect1, DATA_NUM);
+
+  GridSize = sycl::range<3>(1, 1, 2);
+  BlockSize = sycl::range<3>(1, 2, 32);
+  unsigned int expect2[DATA_NUM] = {
+      1,   0,   3,   2,   5,   4,   7,   6,   9,   8,   11,  10,  13,  12,  15,
+      14,  17,  16,  19,  18,  21,  20,  23,  22,  25,  24,  27,  26,  29,  28,
+      31,  30,  33,  32,  35,  34,  37,  36,  39,  38,  41,  40,  43,  42,  45,
+      44,  47,  46,  49,  48,  51,  50,  53,  52,  55,  54,  57,  56,  59,  58,
+      61,  60,  63,  62,  65,  64,  67,  66,  69,  68,  71,  70,  73,  72,  75,
+      74,  77,  76,  79,  78,  81,  80,  83,  82,  85,  84,  87,  86,  89,  88,
+      91,  90,  93,  92,  95,  94,  97,  96,  99,  98,  101, 100, 103, 102, 105,
+      104, 107, 106, 109, 108, 111, 110, 113, 112, 115, 114, 117, 116, 119, 118,
+      121, 120, 123, 122, 125, 124, 127, 126};
+  init_data<unsigned int>(dev_data_u, DATA_NUM);
+
+  q_ct1->parallel_for(
+      sycl::nd_range<3>(GridSize * BlockSize, BlockSize), [=
+  ](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+        permute_sub_group_by_xor2(dev_data_u, item_ct1);
+      });
+
+  dev_ct1.queues_wait_and_throw();
+  verify_data<unsigned int>(dev_data_u, expect2, DATA_NUM);
+}

--- a/sycl/unittests/Extensions/compat/util/UtilReverseBitsTest.cpp
+++ b/sycl/unittests/Extensions/compat/util/UtilReverseBitsTest.cpp
@@ -1,0 +1,45 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  UtilReverseBitsTest.cpp
+ *
+ *  Description:
+ *    reverse_bits tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ UtilReverseBitsTest.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+TEST(Util, reverse_bits) {
+  unsigned int a = 1;
+  unsigned int b = sycl::ext::oneapi::experimental::compat::reverse_bits(a);
+  EXPECT_EQ(b, 0x80000000);
+
+  a = 0x12345678;
+  b = sycl::ext::oneapi::experimental::compat::reverse_bits(a);
+  EXPECT_EQ(b, 0x1e6a2c48);
+}

--- a/sycl/unittests/Extensions/compat/util/UtilSelectFromSubGroup.cpp
+++ b/sycl/unittests/Extensions/compat/util/UtilSelectFromSubGroup.cpp
@@ -1,0 +1,137 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  UtilSelectFromSubGroup.cpp
+ *
+ *  Description:
+ *    select_from_sub_group tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ UtilSelectFromSubGroup.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+
+#define WARP_SIZE 32
+#define DATA_NUM 128
+
+template <typename T = int> void init_data(T *data, int num) {
+  for (int i = 0; i < num; i++)
+    data[i] = i;
+}
+
+template <typename T = int>
+void verify_data(T *data, T *expect, int num, int step = 1) {
+  for (int i = 0; i < num; i = i + step) {
+    EXPECT_EQ(data[i], expect[i]);
+  }
+}
+
+void select_from_sub_group1(unsigned int *data, sycl::nd_item<3> item_ct1) {
+  int threadid = item_ct1.get_local_id(2) +
+                 item_ct1.get_local_id(1) * item_ct1.get_local_range(2) +
+                 item_ct1.get_local_id(0) * item_ct1.get_local_range(2) *
+                     item_ct1.get_local_range(1) +
+                 item_ct1.get_group(2) * item_ct1.get_local_range(2) *
+                     item_ct1.get_local_range(1) * item_ct1.get_local_range(0);
+  int output = 0;
+  output = compat::select_from_sub_group(item_ct1.get_sub_group(), threadid,
+                                         threadid + 1);
+  data[threadid] = output;
+}
+
+void select_from_sub_group2(unsigned int *data, sycl::nd_item<3> item_ct1) {
+  int threadid = item_ct1.get_local_id(2) +
+                 item_ct1.get_local_id(1) * item_ct1.get_local_range(2) +
+                 item_ct1.get_local_id(0) * item_ct1.get_local_range(2) *
+                     item_ct1.get_local_range(1) +
+                 item_ct1.get_group(2) * item_ct1.get_local_range(2) *
+                     item_ct1.get_local_range(1) * item_ct1.get_local_range(0);
+  int output = 0;
+  output = compat::select_from_sub_group(item_ct1.get_sub_group(), threadid,
+                                         threadid + 1, 8);
+  data[threadid] = output;
+}
+
+TEST(Util, select_from_sub_group) {
+
+  compat::device_ext &dev_ct1 = compat::get_current_device();
+  sycl::queue *q_ct1 = dev_ct1.default_queue();
+  bool Result = true;
+  int *dev_data = nullptr;
+  unsigned int *dev_data_u = nullptr;
+  sycl::range<3> GridSize(1, 1, 1);
+  sycl::range<3> BlockSize(1, 1, 1);
+  dev_data = sycl::malloc_shared<int>(DATA_NUM, *q_ct1);
+  dev_data_u = sycl::malloc_shared<unsigned int>(DATA_NUM, *q_ct1);
+
+  GridSize = sycl::range<3>(1, 1, 2);
+  BlockSize = sycl::range<3>(1, 2, 32);
+  unsigned int expect1[DATA_NUM] = {
+      1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11,  12,  13,  14,  15,
+      16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,
+      31,  0,   33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,  45,
+      46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,  60,
+      61,  62,  63,  32,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,
+      76,  77,  78,  79,  80,  81,  82,  83,  84,  85,  86,  87,  88,  89,  90,
+      91,  92,  93,  94,  95,  64,  97,  98,  99,  100, 101, 102, 103, 104, 105,
+      106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120,
+      121, 122, 123, 124, 125, 126, 127, 96};
+  init_data<unsigned int>(dev_data_u, DATA_NUM);
+
+  q_ct1->parallel_for(
+      sycl::nd_range<3>(GridSize * BlockSize, BlockSize), [=
+  ](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+        select_from_sub_group1(dev_data_u, item_ct1);
+      });
+
+  dev_ct1.queues_wait_and_throw();
+  verify_data<unsigned int>(dev_data_u, expect1, DATA_NUM);
+
+  GridSize = sycl::range<3>(1, 1, 2);
+  BlockSize = sycl::range<3>(1, 2, 32);
+  unsigned int expect2[DATA_NUM] = {
+      1,   2,   3,   4,   5,   6,   7,   0,   9,   10,  11,  12,  13,  14,  15,
+      8,   17,  18,  19,  20,  21,  22,  23,  16,  25,  26,  27,  28,  29,  30,
+      31,  24,  33,  34,  35,  36,  37,  38,  39,  32,  41,  42,  43,  44,  45,
+      46,  47,  40,  49,  50,  51,  52,  53,  54,  55,  48,  57,  58,  59,  60,
+      61,  62,  63,  56,  65,  66,  67,  68,  69,  70,  71,  64,  73,  74,  75,
+      76,  77,  78,  79,  72,  81,  82,  83,  84,  85,  86,  87,  80,  89,  90,
+      91,  92,  93,  94,  95,  88,  97,  98,  99,  100, 101, 102, 103, 96,  105,
+      106, 107, 108, 109, 110, 111, 104, 113, 114, 115, 116, 117, 118, 119, 112,
+      121, 122, 123, 124, 125, 126, 127, 120};
+  init_data<unsigned int>(dev_data_u, DATA_NUM);
+
+  q_ct1->parallel_for(
+      sycl::nd_range<3>(GridSize * BlockSize, BlockSize), [=
+  ](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+        select_from_sub_group2(dev_data_u, item_ct1);
+      });
+
+  dev_ct1.queues_wait_and_throw();
+  verify_data<unsigned int>(dev_data_u, expect2, DATA_NUM);
+}

--- a/sycl/unittests/Extensions/compat/util/UtilShiftSubGroupLeft.cpp
+++ b/sycl/unittests/Extensions/compat/util/UtilShiftSubGroupLeft.cpp
@@ -1,0 +1,135 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  UtilShiftSubGroupLeft.cpp
+ *
+ *  Description:
+ *    shift_sub_group_left tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ UtilShiftSubGroupLeft.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+#define DATA_NUM 128
+
+using namespace sycl::ext::oneapi::experimental;
+
+template <typename T = int> void init_data(T *data, int num) {
+  for (int i = 0; i < num; i++)
+    data[i] = i;
+}
+
+template <typename T = int>
+void verify_data(T *data, T *expect, int num, int step = 1) {
+  for (int i = 0; i < num; i = i + step) {
+    EXPECT_EQ(data[i], expect[i]);
+  }
+}
+
+void shift_sub_group_left1(unsigned int *data, sycl::nd_item<3> item_ct1) {
+  int threadid = item_ct1.get_local_id(2) +
+                 item_ct1.get_local_id(1) * item_ct1.get_local_range(2) +
+                 item_ct1.get_local_id(0) * item_ct1.get_local_range(2) *
+                     item_ct1.get_local_range(1) +
+                 item_ct1.get_group(2) * item_ct1.get_local_range(2) *
+                     item_ct1.get_local_range(1) * item_ct1.get_local_range(0);
+  int output = 0;
+  output = compat::shift_sub_group_left(item_ct1.get_sub_group(), threadid, 1);
+  data[threadid] = output;
+}
+
+void shift_sub_group_left2(unsigned int *data, sycl::nd_item<3> item_ct1) {
+  int threadid = item_ct1.get_local_id(2) +
+                 item_ct1.get_local_id(1) * item_ct1.get_local_range(2) +
+                 item_ct1.get_local_id(0) * item_ct1.get_local_range(2) *
+                     item_ct1.get_local_range(1) +
+                 item_ct1.get_group(2) * item_ct1.get_local_range(2) *
+                     item_ct1.get_local_range(1) * item_ct1.get_local_range(0);
+  int output = 0;
+  output =
+      compat::shift_sub_group_left(item_ct1.get_sub_group(), threadid, 1, 8);
+  data[threadid] = output;
+}
+
+TEST(Util, shift_sub_group_left) {
+
+  compat::device_ext &dev_ct1 = compat::get_current_device();
+  sycl::queue *q_ct1 = dev_ct1.default_queue();
+  bool Result = true;
+  int *dev_data = nullptr;
+  unsigned int *dev_data_u = nullptr;
+  sycl::range<3> GridSize(1, 1, 1);
+  sycl::range<3> BlockSize(1, 1, 1);
+  dev_data = sycl::malloc_shared<int>(DATA_NUM, *q_ct1);
+  dev_data_u = sycl::malloc_shared<unsigned int>(DATA_NUM, *q_ct1);
+
+  GridSize = sycl::range<3>(1, 1, 2);
+  BlockSize = sycl::range<3>(1, 2, 32);
+  unsigned int expect1[DATA_NUM] = {
+      1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11,  12,  13,  14,  15,
+      16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,  29,  30,
+      31,  31,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,  45,
+      46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,  59,  60,
+      61,  62,  63,  63,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,  75,
+      76,  77,  78,  79,  80,  81,  82,  83,  84,  85,  86,  87,  88,  89,  90,
+      91,  92,  93,  94,  95,  95,  97,  98,  99,  100, 101, 102, 103, 104, 105,
+      106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120,
+      121, 122, 123, 124, 125, 126, 127, 127};
+  init_data<unsigned int>(dev_data_u, DATA_NUM);
+
+  q_ct1->parallel_for(
+      sycl::nd_range<3>(GridSize * BlockSize, BlockSize), [=
+  ](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+        shift_sub_group_left1(dev_data_u, item_ct1);
+      });
+
+  dev_ct1.queues_wait_and_throw();
+  verify_data<unsigned int>(dev_data_u, expect1, DATA_NUM);
+
+  GridSize = sycl::range<3>(1, 1, 2);
+  BlockSize = sycl::range<3>(1, 2, 32);
+  unsigned int expect2[DATA_NUM] = {
+      1,   2,   3,   4,   5,   6,   7,   7,   9,   10,  11,  12,  13,  14,  15,
+      15,  17,  18,  19,  20,  21,  22,  23,  23,  25,  26,  27,  28,  29,  30,
+      31,  31,  33,  34,  35,  36,  37,  38,  39,  39,  41,  42,  43,  44,  45,
+      46,  47,  47,  49,  50,  51,  52,  53,  54,  55,  55,  57,  58,  59,  60,
+      61,  62,  63,  63,  65,  66,  67,  68,  69,  70,  71,  71,  73,  74,  75,
+      76,  77,  78,  79,  79,  81,  82,  83,  84,  85,  86,  87,  87,  89,  90,
+      91,  92,  93,  94,  95,  95,  97,  98,  99,  100, 101, 102, 103, 103, 105,
+      106, 107, 108, 109, 110, 111, 111, 113, 114, 115, 116, 117, 118, 119, 119,
+      121, 122, 123, 124, 125, 126, 127, 127};
+  init_data<unsigned int>(dev_data_u, DATA_NUM);
+
+  q_ct1->parallel_for(
+      sycl::nd_range<3>(GridSize * BlockSize, BlockSize), [=
+  ](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+        shift_sub_group_left2(dev_data_u, item_ct1);
+      });
+
+  dev_ct1.queues_wait_and_throw();
+  verify_data<unsigned int>(dev_data_u, expect2, DATA_NUM);
+}

--- a/sycl/unittests/Extensions/compat/util/UtilShiftSubGroupRight.cpp
+++ b/sycl/unittests/Extensions/compat/util/UtilShiftSubGroupRight.cpp
@@ -1,0 +1,134 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  UtilShiftSubGroupRight.cpp
+ *
+ *  Description:
+ *    shift_sub_group_right tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ UtilShiftSubGroupRight.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+
+#define DATA_NUM 128
+
+template <typename T = int> void init_data(T *data, int num) {
+  for (int i = 0; i < num; i++)
+    data[i] = i;
+}
+
+template <typename T = int>
+void verify_data(T *data, T *expect, int num, int step = 1) {
+  for (int i = 0; i < num; i = i + step) {
+    EXPECT_EQ(data[i], expect[i]);
+  }
+}
+
+void shift_sub_group_right1(unsigned int *data, sycl::nd_item<3> item_ct1) {
+  int threadid = item_ct1.get_local_id(2) +
+                 item_ct1.get_local_id(1) * item_ct1.get_local_range(2) +
+                 item_ct1.get_local_id(0) * item_ct1.get_local_range(2) *
+                     item_ct1.get_local_range(1) +
+                 item_ct1.get_group(2) * item_ct1.get_local_range(2) *
+                     item_ct1.get_local_range(1) * item_ct1.get_local_range(0);
+  int output = 0;
+  output = compat::shift_sub_group_right(item_ct1.get_sub_group(), threadid, 1);
+  data[threadid] = output;
+}
+
+void shift_sub_group_right2(unsigned int *data, sycl::nd_item<3> item_ct1) {
+  int threadid = item_ct1.get_local_id(2) +
+                 item_ct1.get_local_id(1) * item_ct1.get_local_range(2) +
+                 item_ct1.get_local_id(0) * item_ct1.get_local_range(2) *
+                     item_ct1.get_local_range(1) +
+                 item_ct1.get_group(2) * item_ct1.get_local_range(2) *
+                     item_ct1.get_local_range(1) * item_ct1.get_local_range(0);
+  int output = 0;
+  output =
+      compat::shift_sub_group_right(item_ct1.get_sub_group(), threadid, 1, 8);
+  data[threadid] = output;
+}
+
+TEST(Util, shift_sub_group_right) {
+
+  compat::device_ext &dev_ct1 = compat::get_current_device();
+  sycl::queue *q_ct1 = dev_ct1.default_queue();
+  bool Result = true;
+  int *dev_data = nullptr;
+  unsigned int *dev_data_u = nullptr;
+  sycl::range<3> GridSize(1, 1, 1);
+  sycl::range<3> BlockSize(1, 1, 1);
+  dev_data = sycl::malloc_shared<int>(DATA_NUM, *q_ct1);
+  dev_data_u = sycl::malloc_shared<unsigned int>(DATA_NUM, *q_ct1);
+
+  GridSize = sycl::range<3>(1, 1, 2);
+  BlockSize = sycl::range<3>(1, 2, 32);
+  unsigned int expect1[DATA_NUM] = {
+      0,   0,   1,   2,   3,   4,   5,   6,   7,   8,   9,   10,  11,  12,  13,
+      14,  15,  16,  17,  18,  19,  20,  21,  22,  23,  24,  25,  26,  27,  28,
+      29,  30,  32,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,
+      44,  45,  46,  47,  48,  49,  50,  51,  52,  53,  54,  55,  56,  57,  58,
+      59,  60,  61,  62,  64,  64,  65,  66,  67,  68,  69,  70,  71,  72,  73,
+      74,  75,  76,  77,  78,  79,  80,  81,  82,  83,  84,  85,  86,  87,  88,
+      89,  90,  91,  92,  93,  94,  96,  96,  97,  98,  99,  100, 101, 102, 103,
+      104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118,
+      119, 120, 121, 122, 123, 124, 125, 126};
+  init_data<unsigned int>(dev_data_u, DATA_NUM);
+
+  q_ct1->parallel_for(
+      sycl::nd_range<3>(GridSize * BlockSize, BlockSize), [=
+  ](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+        shift_sub_group_right1(dev_data_u, item_ct1);
+      });
+
+  dev_ct1.queues_wait_and_throw();
+  verify_data<unsigned int>(dev_data_u, expect1, DATA_NUM);
+
+  GridSize = sycl::range<3>(1, 1, 2);
+  BlockSize = sycl::range<3>(1, 2, 32);
+  unsigned int expect2[DATA_NUM] = {
+      0,   0,   1,   2,   3,   4,   5,   6,   8,   8,   9,   10,  11,  12,  13,
+      14,  16,  16,  17,  18,  19,  20,  21,  22,  24,  24,  25,  26,  27,  28,
+      29,  30,  32,  32,  33,  34,  35,  36,  37,  38,  40,  40,  41,  42,  43,
+      44,  45,  46,  48,  48,  49,  50,  51,  52,  53,  54,  56,  56,  57,  58,
+      59,  60,  61,  62,  64,  64,  65,  66,  67,  68,  69,  70,  72,  72,  73,
+      74,  75,  76,  77,  78,  80,  80,  81,  82,  83,  84,  85,  86,  88,  88,
+      89,  90,  91,  92,  93,  94,  96,  96,  97,  98,  99,  100, 101, 102, 104,
+      104, 105, 106, 107, 108, 109, 110, 112, 112, 113, 114, 115, 116, 117, 118,
+      120, 120, 121, 122, 123, 124, 125, 126};
+  init_data<unsigned int>(dev_data_u, DATA_NUM);
+
+  q_ct1->parallel_for(
+      sycl::nd_range<3>(GridSize * BlockSize, BlockSize), [=
+  ](sycl::nd_item<3> item_ct1) [[intel::reqd_sub_group_size(32)]] {
+        shift_sub_group_right2(dev_data_u, item_ct1);
+      });
+
+  dev_ct1.queues_wait_and_throw();
+  verify_data<unsigned int>(dev_data_u, expect2, DATA_NUM);
+}

--- a/sycl/unittests/Extensions/compat/util/UtilVectorizedIsgreaterTest.cpp
+++ b/sycl/unittests/Extensions/compat/util/UtilVectorizedIsgreaterTest.cpp
@@ -1,0 +1,188 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  UtilVectorizedIsgreaterTest.cpp
+ *
+ *  Description:
+ *    vectorized_isgreater tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====---- UtilVectorizedIsgreaterTest.cpp----------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+
+void test_kernel_vect_is_greater_1(unsigned int vect_count,
+                                   unsigned int *input_1, unsigned int *input_2,
+                                   unsigned int *output,
+                                   sycl::nd_item<3> item_ct1) {
+
+  int index = item_ct1.get_local_range().get(2) * item_ct1.get_group(2) +
+              item_ct1.get_local_id(2);
+
+  if (index < vect_count) {
+    output[index] = compat::vectorized_isgreater<sycl::ushort2, unsigned int>(
+        input_1[index], input_2[index]);
+  }
+}
+
+TEST(Util, vec_gt_1) {
+  compat::device_ext &dev_ct1 = compat::get_current_device();
+  sycl::queue *q_ct1 = dev_ct1.default_queue();
+
+  const unsigned int num_data = 7;
+  unsigned int mem_size = sizeof(unsigned int) * num_data;
+
+  unsigned int *h_out_data = (unsigned int *)malloc(mem_size);
+  unsigned int *h_data = (unsigned int *)malloc(mem_size);
+
+  for (unsigned int i = 0; i < num_data; i++)
+    h_out_data[i] = 0;
+
+  unsigned int *d_out_data;
+  d_out_data = (unsigned int *)sycl::malloc_device(mem_size, *q_ct1);
+
+  unsigned int *d_in_data_1;
+  d_in_data_1 = (unsigned int *)sycl::malloc_device(mem_size, *q_ct1);
+
+  unsigned int *d_in_data_2;
+  d_in_data_2 = (unsigned int *)sycl::malloc_device(mem_size, *q_ct1);
+
+  for (unsigned int i = 0; i < num_data; i++)
+    h_data[i] = i;
+  q_ct1->memcpy(d_in_data_1, h_data, mem_size).wait();
+
+  for (unsigned int i = 0; i < num_data; i++)
+    h_data[i] = num_data - 1 - i;
+  q_ct1->memcpy(d_in_data_2, h_data, mem_size).wait();
+
+  q_ct1->submit([&](sycl::handler &cgh) {
+    cgh.parallel_for(
+        sycl::nd_range<3>(sycl::range<3>(1, 1, 3) * sycl::range<3>(1, 1, 3),
+                          sycl::range<3>(1, 1, 3)),
+        [=](sycl::nd_item<3> item_ct1) {
+          test_kernel_vect_is_greater_1(num_data, d_in_data_1, d_in_data_2,
+                                        d_out_data, item_ct1);
+        });
+  });
+  dev_ct1.queues_wait_and_throw();
+
+  q_ct1->memcpy(h_out_data, d_out_data, mem_size).wait();
+
+  unsigned int ref_data[num_data] = {0, 0, 0, 0, 1, 1, 1};
+  for (unsigned int i = 0; i < num_data; i++) {
+    if (h_out_data[i] != ref_data[i]) {
+      printf("vec_max_test_1 failed!\n");
+      exit(-1);
+    }
+  }
+
+  free(h_out_data);
+  free(h_data);
+  sycl::free(d_out_data, *q_ct1);
+  sycl::free(d_in_data_1, *q_ct1);
+  sycl::free(d_in_data_2, *q_ct1);
+}
+
+void test_kernel_vect_is_greater_2(unsigned int vect_count,
+                                   unsigned int *input_1, unsigned int *input_2,
+                                   unsigned int *output,
+                                   sycl::nd_item<3> item_ct1) {
+
+  int index = item_ct1.get_local_range().get(2) * item_ct1.get_group(2) +
+              item_ct1.get_local_id(2);
+
+  if (index < vect_count) {
+    output[index] = compat::vectorized_isgreater<sycl::half2, unsigned int>(
+        input_1[index], input_2[index]);
+  }
+}
+
+TEST(Util, vec_gt_2) {
+  compat::device_ext &dev_ct1 = compat::get_current_device();
+  sycl::queue *q_ct1 = dev_ct1.default_queue();
+
+  const unsigned int num_data = 7;
+  unsigned int mem_size = sizeof(unsigned int) * num_data;
+
+  unsigned int *h_out_data = (unsigned int *)malloc(mem_size);
+  unsigned int *h_data = (unsigned int *)malloc(mem_size);
+  unsigned int a_array[num_data] = {6 + 65535, 1 + 65535, 2 + 65535, 3,
+                                    4,         5,         6};
+  unsigned int b_array[num_data] = {0 + 65535, 5 + 65535, 4 + 65535, 3,
+                                    2,         1,         0};
+
+  for (unsigned int i = 0; i < num_data; i++)
+    h_out_data[i] = 0;
+
+  unsigned int *d_out_data;
+  d_out_data = (unsigned int *)sycl::malloc_device(mem_size, *q_ct1);
+
+  unsigned int *d_in_data_1;
+  d_in_data_1 = (unsigned int *)sycl::malloc_device(mem_size, *q_ct1);
+
+  unsigned int *d_in_data_2;
+  d_in_data_2 = (unsigned int *)sycl::malloc_device(mem_size, *q_ct1);
+
+  for (unsigned int i = 0; i < num_data; i++)
+    h_data[i] = a_array[i];
+
+  q_ct1->memcpy(d_in_data_1, h_data, mem_size).wait();
+
+  for (unsigned int i = 0; i < num_data; i++)
+    h_data[i] = b_array[i];
+
+  q_ct1->memcpy(d_in_data_2, h_data, mem_size).wait();
+
+  q_ct1->submit([&](sycl::handler &cgh) {
+    cgh.parallel_for(
+        sycl::nd_range<3>(sycl::range<3>(1, 1, 3) * sycl::range<3>(1, 1, 3),
+                          sycl::range<3>(1, 1, 3)),
+        [=](sycl::nd_item<3> item_ct1) {
+          test_kernel_vect_is_greater_2(num_data, d_in_data_1, d_in_data_2,
+                                        d_out_data, item_ct1);
+        });
+  });
+  dev_ct1.queues_wait_and_throw();
+
+  q_ct1->memcpy(h_out_data, d_out_data, mem_size).wait();
+
+  unsigned int ref_data[num_data] = {0xffff0000, 0x0,    0x0,   0x0,
+                                     0xffff,     0xffff, 0xffff};
+  for (unsigned int i = 0; i < num_data; i++) {
+    if (h_out_data[i] != ref_data[i]) {
+      printf("vec_max_test_2 failed!\n");
+      exit(-1);
+    }
+  }
+
+  free(h_out_data);
+  free(h_data);
+  sycl::free(d_out_data, *q_ct1);
+  sycl::free(d_in_data_1, *q_ct1);
+  sycl::free(d_in_data_2, *q_ct1);
+}

--- a/sycl/unittests/Extensions/compat/util/UtilVectorizedMaxTest.cpp
+++ b/sycl/unittests/Extensions/compat/util/UtilVectorizedMaxTest.cpp
@@ -1,0 +1,106 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  UtilVectorizedMaxTest.cpp
+ *
+ *  Description:
+ *    vectorized_max tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ UtilVectorizedMaxTest.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+
+void test_kernel_vect_max(unsigned int vect_count, unsigned int *input_1,
+                          unsigned int *input_2, unsigned int *output,
+                          sycl::nd_item<3> item_ct1) {
+
+  int index = item_ct1.get_local_range().get(2) * item_ct1.get_group(2) +
+              item_ct1.get_local_id(2);
+
+  if (index < vect_count) {
+    output[index] =
+        compat::vectorized_max<sycl::char4>(input_1[index], input_2[index]);
+  }
+}
+
+TEST(Util, vec_max) {
+  compat::device_ext &dev_ct1 = compat::get_current_device();
+  sycl::queue *q_ct1 = dev_ct1.default_queue();
+
+  const unsigned int num_data = 7;
+  unsigned int mem_size = sizeof(unsigned int) * num_data;
+
+  unsigned int *h_out_data = (unsigned int *)malloc(mem_size);
+  unsigned int *h_data = (unsigned int *)malloc(mem_size);
+
+  for (unsigned int i = 0; i < num_data; i++)
+    h_out_data[i] = 0;
+
+  unsigned int *d_out_data;
+  d_out_data = (unsigned int *)sycl::malloc_device(mem_size, *q_ct1);
+
+  unsigned int *d_in_data_1;
+  d_in_data_1 = (unsigned int *)sycl::malloc_device(mem_size, *q_ct1);
+
+  unsigned int *d_in_data_2;
+  d_in_data_2 = (unsigned int *)sycl::malloc_device(mem_size, *q_ct1);
+
+  for (unsigned int i = 0; i < num_data; i++)
+    h_data[i] = i;
+  q_ct1->memcpy(d_in_data_1, h_data, mem_size).wait();
+
+  for (unsigned int i = 0; i < num_data; i++)
+    h_data[i] = num_data - 1 - i;
+  q_ct1->memcpy(d_in_data_2, h_data, mem_size).wait();
+
+  q_ct1->submit([&](sycl::handler &cgh) {
+    cgh.parallel_for(
+        sycl::nd_range<3>(sycl::range<3>(1, 1, 3) * sycl::range<3>(1, 1, 3),
+                          sycl::range<3>(1, 1, 3)),
+        [=](sycl::nd_item<3> item_ct1) {
+          test_kernel_vect_max(num_data, d_in_data_1, d_in_data_2, d_out_data,
+                               item_ct1);
+        });
+  });
+  dev_ct1.queues_wait_and_throw();
+
+  q_ct1->memcpy(h_out_data, d_out_data, mem_size).wait();
+
+  unsigned int ref_data[num_data] = {6, 5, 4, 3, 4, 5, 6};
+  for (unsigned int i = 0; i < num_data; i++) {
+    if (h_out_data[i] != ref_data[i])
+      exit(-1);
+  }
+
+  free(h_out_data);
+  free(h_data);
+  sycl::free(d_out_data, *q_ct1);
+  sycl::free(d_in_data_1, *q_ct1);
+  sycl::free(d_in_data_2, *q_ct1);
+}

--- a/sycl/unittests/Extensions/compat/util/UtilVectorizedMinTest.cpp
+++ b/sycl/unittests/Extensions/compat/util/UtilVectorizedMinTest.cpp
@@ -1,0 +1,106 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility API
+ *
+ *  UtilVectorizedMinTest.cpp
+ *
+ *  Description:
+ *    vectorized_min tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ UtilVectorizedMinTest.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+#include <gtest/gtest.h>
+#include <sycl/ext/oneapi/experimental/compat.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+
+void test_kernel_vect_min(unsigned int vect_count, unsigned int *input_1,
+                          unsigned int *input_2, unsigned int *output,
+                          sycl::nd_item<3> item_ct1) {
+
+  int index = item_ct1.get_local_range().get(2) * item_ct1.get_group(2) +
+              item_ct1.get_local_id(2);
+
+  if (index < vect_count) {
+    output[index] =
+        compat::vectorized_min<sycl::char4>(input_1[index], input_2[index]);
+  }
+}
+
+TEST(Util, vec_min) {
+  compat::device_ext &dev_ct1 = compat::get_current_device();
+  sycl::queue *q_ct1 = dev_ct1.default_queue();
+
+  const unsigned int num_data = 7;
+  unsigned int mem_size = sizeof(unsigned int) * num_data;
+
+  unsigned int *h_out_data = (unsigned int *)malloc(mem_size);
+  unsigned int *h_data = (unsigned int *)malloc(mem_size);
+
+  for (unsigned int i = 0; i < num_data; i++)
+    h_out_data[i] = 0;
+
+  unsigned int *d_out_data;
+  d_out_data = (unsigned int *)sycl::malloc_device(mem_size, *q_ct1);
+
+  unsigned int *d_in_data_1;
+  d_in_data_1 = (unsigned int *)sycl::malloc_device(mem_size, *q_ct1);
+
+  unsigned int *d_in_data_2;
+  d_in_data_2 = (unsigned int *)sycl::malloc_device(mem_size, *q_ct1);
+
+  for (unsigned int i = 0; i < num_data; i++)
+    h_data[i] = i;
+  q_ct1->memcpy(d_in_data_1, h_data, mem_size).wait();
+
+  for (unsigned int i = 0; i < num_data; i++)
+    h_data[i] = num_data - 1 - i;
+  q_ct1->memcpy(d_in_data_2, h_data, mem_size).wait();
+
+  q_ct1->submit([&](sycl::handler &cgh) {
+    cgh.parallel_for(
+        sycl::nd_range<3>(sycl::range<3>(1, 1, 3) * sycl::range<3>(1, 1, 3),
+                          sycl::range<3>(1, 1, 3)),
+        [=](sycl::nd_item<3> item_ct1) {
+          test_kernel_vect_min(num_data, d_in_data_1, d_in_data_2, d_out_data,
+                               item_ct1);
+        });
+  });
+  dev_ct1.queues_wait_and_throw();
+
+  q_ct1->memcpy(h_out_data, d_out_data, mem_size).wait();
+
+  unsigned int ref_data[num_data] = {0, 1, 2, 3, 2, 1, 0};
+  for (unsigned int i = 0; i < num_data; i++) {
+    if (h_out_data[i] != ref_data[i])
+      exit(-1);
+  }
+
+  free(h_out_data);
+  free(h_data);
+  sycl::free(d_out_data, *q_ct1);
+  sycl::free(d_in_data_1, *q_ct1);
+  sycl::free(d_in_data_2, *q_ct1);
+}


### PR DESCRIPTION
This is an implementation of the experimental extension proposed in https://github.com/intel/llvm/pull/9646.

The compat extension has two primary goals:

- Improve the adoption of SYCL. The compat extension is designed to provide a familiar programming interface that resembles other popular heterogeneous programming models. By reducing the learning curve, it enables developers to leverage SYCL's power and features more easily.

- Source-to-Source Translation Support. compat is also designed to facilitate automatic source-to-source translation from other heterogeneous programming models to SYCL and offer a more standardized and consistent programming interface. This feature can significantly streamline the migration and integration of existing codebases into the SYCL ecosystem.

The PR also includes testing for the `compat` extension.

As we stated in the proposal PR, we are open to any suggestions, concerns, or improvements you may have, so please, let us know if you have any.