### PR TITLE
[SYCL-MLIR][LoopInternalization] Get local memory pointer without `reqd_work_group_size`

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
@@ -29,6 +29,7 @@
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/Debug.h"
+#include <variant>
 
 #define DEBUG_TYPE "loop-internalization"
 
@@ -43,6 +44,50 @@ using namespace mlir;
 using namespace mlir::polygeist;
 
 namespace {
+
+//===----------------------------------------------------------------------===//
+// WorkGroupSize
+//===----------------------------------------------------------------------===//
+
+/// Class to represent work group size of a kernel.
+class WorkGroupSize {
+public:
+  using ElemTy = std::variant<Value, unsigned>;
+  WorkGroupSize(Value ndItem, const sycl::ReqdWorkGroupSize &reqdWorkGroupSize,
+                OpBuilder builder) {
+    auto ndItemTy = cast<sycl::NdItemType>(
+        cast<MemRefType>(ndItem.getType()).getElementType());
+    for (unsigned dim = 0; dim < ndItemTy.getDimension(); ++dim) {
+      /// Use constants provided by reqd_work_group_size if given (non-empty).
+      if (!reqdWorkGroupSize.empty())
+        wgSizes.push_back(reqdWorkGroupSize[dim]);
+      else
+        wgSizes.push_back(builder.create<arith::IndexCastOp>(
+            builder.getUnknownLoc(), builder.getIndexType(),
+            getLocalRange(ndItem, dim, builder)));
+    }
+  }
+
+  /// Return true if the element holds the alternative T.
+  template <typename T> bool is() const {
+    return std::holds_alternative<T>(wgSizes.front());
+  }
+
+  ElemTy operator[](unsigned dim) const {
+    assert(dim < wgSizes.size() && "Expecting valid dim");
+    return wgSizes[dim];
+  }
+
+private:
+  Value getLocalRange(Value ndItem, unsigned dim, OpBuilder builder) {
+    return builder.create<sycl::SYCLNDItemGetLocalRangeOp>(
+        builder.getUnknownLoc(), builder.getI64Type(), ndItem,
+        builder.create<arith::ConstantIntOp>(builder.getUnknownLoc(), dim,
+                                             builder.getI32Type()));
+  }
+
+  SmallVector<ElemTy> wgSizes;
+};
 
 //===----------------------------------------------------------------------===//
 // Utilities functions
@@ -102,6 +147,14 @@ bool isCandidateLoopNest(LoopLikeOpInterface loop) {
   return true;
 }
 
+/// Get the argument of \p func with nd_item type.
+Value getNdItemArgument(FunctionOpInterface func) {
+  Value lastArg = func.getArguments().back();
+  assert(sycl::isPtrOf<sycl::NdItemType>(lastArg.getType()) &&
+         "Expecting last argument to be nd_item");
+  return lastArg;
+}
+
 /// Get the size of unused shared local memory arena in bytes.
 unsigned getLocalMemoryRemain(gpu::GPUModuleOp &module,
                               unsigned localMemorySize) {
@@ -124,11 +177,34 @@ unsigned getLocalMemoryRemain(gpu::GPUModuleOp &module,
   return localMemoryRemain;
 }
 
-/// Get the required local memory for \p accTy.
+/// Get the required local memory for \p accTy in bytes.
+std::variant<Value, unsigned>
+getReqdLocalMemory(sycl::AccessorType accTy, const WorkGroupSize &workGroupSize,
+                   OpBuilder builder) {
+  Location loc = builder.getUnknownLoc();
+  unsigned elemSize = accTy.getType().getIntOrFloatBitWidth() / 8;
+  std::variant<Value, unsigned> reqdLocalMemory;
+  if (workGroupSize.is<unsigned>())
+    reqdLocalMemory = elemSize;
+  else
+    reqdLocalMemory = builder.create<arith::ConstantIndexOp>(loc, elemSize);
+  for (unsigned dim = 0; dim < accTy.getDimension(); ++dim) {
+    if (workGroupSize.is<unsigned>())
+      std::get<unsigned>(reqdLocalMemory) *=
+          std::get<unsigned>(workGroupSize[dim]);
+    else
+      reqdLocalMemory = builder.create<arith::MulIOp>(
+          builder.getUnknownLoc(), std::get<Value>(reqdLocalMemory),
+          std::get<Value>(workGroupSize[dim]));
+  }
+  return reqdLocalMemory;
+}
+
+/// Get the required local memory for \p accTy in bytes.
 unsigned getReqdLocalMemory(sycl::AccessorType accTy,
-                            sycl::ReqdWorkGroupSize reqdWorkGroupSize) {
+                            const sycl::ReqdWorkGroupSize &reqdWorkGroupSize) {
   assert(!reqdWorkGroupSize.empty() && "Expecting non-empty reqdWorkGroupSize");
-  unsigned elemSize = accTy.getType().getIntOrFloatBitWidth();
+  unsigned elemSize = accTy.getType().getIntOrFloatBitWidth() / 8;
   unsigned memrefReqdLocalMemory = elemSize;
   for (unsigned dim = 0; dim < accTy.getDimension(); ++dim) {
     memrefReqdLocalMemory *= reqdWorkGroupSize[dim];
@@ -161,7 +237,7 @@ getReqdLocalMemory(const DenseMap<LoopLikeOpInterface, std::set<Operation *>>
 }
 
 /// Create a GlobalOp for workgroup local memory.
-memref::GlobalOp getworkGroupLocalMemory(gpu::GPUModuleOp module,
+memref::GlobalOp getWorkGroupLocalMemory(gpu::GPUModuleOp module,
                                          unsigned size) {
   assert(size != 0 && "Expecting non-zero size");
   std::string name("WGLocalMem");
@@ -180,21 +256,26 @@ memref::GlobalOp getworkGroupLocalMemory(gpu::GPUModuleOp module,
 
 /// Create ViewOp from source \p source, with offset \p offset, for AccessorType
 /// \p accTy.
-memref::ViewOp createViewOp(sycl::AccessorType accTy, unsigned offset,
+memref::ViewOp createViewOp(sycl::AccessorType accTy, Value offset,
                             memref::GetGlobalOp source,
-                            const sycl::ReqdWorkGroupSize &reqdWorkGroupSize,
+                            const WorkGroupSize &workGroupSize,
                             OpBuilder builder, Location loc) {
-  assert(!reqdWorkGroupSize.empty() && "Expecting non-empty reqdWorkGroupSize");
   SmallVector<int64_t> shape;
-  for (int dim = accTy.getDimension() - 1; dim >= 0; --dim)
-    shape.push_back(reqdWorkGroupSize[dim]);
+  SmallVector<Value> sizes;
+  for (int dim = accTy.getDimension() - 1; dim >= 0; --dim) {
+    std::variant<Value, unsigned> size = workGroupSize[dim];
+    if (workGroupSize.is<unsigned>()) {
+      shape.push_back(std::get<unsigned>(workGroupSize[dim]));
+    } else {
+      shape.push_back(ShapedType::kDynamic);
+      sizes.push_back(std::get<Value>(size));
+    }
+  }
   auto resTy = MemRefType::get(
       shape, accTy.getType(), MemRefLayoutAttrInterface(),
       sycl::AccessAddrSpaceAttr::get(builder.getContext(),
                                      sycl::AccessAddrSpace::LocalAccess));
-  auto offsetVal = builder.create<arith::ConstantIndexOp>(loc, offset);
-  return builder.create<memref::ViewOp>(loc, resTy, source, offsetVal,
-                                        ValueRange());
+  return builder.create<memref::ViewOp>(loc, resTy, source, offset, sizes);
 }
 
 /// Tile an affine for \p loop given the tile size \p tileSize.
@@ -479,7 +560,7 @@ private:
   /// Transform a candidate loop.
   template <typename T>
   void transform(T loop, memref::GlobalOp workGroupLocalMemory,
-                 const sycl::ReqdWorkGroupSize &reqdWorkGroupSize);
+                 const WorkGroupSize &workGroupSize);
 
 private:
   /// A map from a candidate loop to shared memref values used in the loop.
@@ -580,16 +661,21 @@ void LoopInternalization::runOnOperation() {
       return;
     }
 
-    memref::GlobalOp workGroupLocalMemory = getworkGroupLocalMemory(
+    memref::GlobalOp workGroupLocalMemory = getWorkGroupLocalMemory(
         gpuModule,
         reqdLocalMemory.has_value() ? *reqdLocalMemory : localMemoryRemain);
+
+    // Get or create work group size.
+    Value ndItem = getNdItemArgument(func);
+    OpBuilder builder(func->getRegion(0));
+    WorkGroupSize workGroupSize(ndItem, reqdWorkGroupSize, builder);
 
     // Now that we have a list of memref to promote to shared memory in each
     // loop nest's innermost loop, perform the transformation.
     for (auto &entry : loopToSharedMemref) {
       TypeSwitch<Operation *>(entry.first)
           .Case<affine::AffineForOp, scf::ForOp>([&](auto loop) {
-            transform(loop, workGroupLocalMemory, reqdWorkGroupSize);
+            transform(loop, workGroupLocalMemory, workGroupSize);
           });
     }
     loopToSharedMemref.clear();
@@ -638,9 +724,9 @@ Value LoopInternalization::getTileSize(LoopLikeOpInterface loop) const {
 }
 
 template <typename T>
-void LoopInternalization::transform(
-    T loop, memref::GlobalOp workGroupLocalMemory,
-    const sycl::ReqdWorkGroupSize &reqdWorkGroupSize) {
+void LoopInternalization::transform(T loop,
+                                    memref::GlobalOp workGroupLocalMemory,
+                                    const WorkGroupSize &workGroupSize) {
   static_assert(llvm::is_one_of<T, affine::AffineForOp, scf::ForOp>::value);
   assert(LoopTools::isInnermostLoop(loop) && "Expecting an innermost loop");
   assert(loopToSharedMemref.find(loop) != loopToSharedMemref.end() &&
@@ -662,19 +748,36 @@ void LoopInternalization::transform(
   builder.setInsertionPointToStart(loop->getBlock());
 
   // Get pointer to the local memory portion for each memref.
-  if (!reqdWorkGroupSize.empty()) {
-    unsigned offset = 0;
-    for (Operation *memref : memrefs) {
-      sycl::AccessorType accTy =
-          getAccessorType(cast<sycl::SYCLAccessorSubscriptOp>(memref));
-      createViewOp(accTy, offset, getGlobalOp, reqdWorkGroupSize, builder,
-                   memref->getLoc());
-      offset += getReqdLocalMemory(accTy, reqdWorkGroupSize);
-    }
-  } else {
-    LLVM_DEBUG(
-        llvm::dbgs()
-        << "TODO: loop internalization without reqd_work_group_size support\n");
+  std::variant<Value, unsigned> offset;
+  if (workGroupSize.is<unsigned>())
+    offset = (unsigned)0;
+  else
+    offset = builder.create<arith::ConstantIndexOp>(builder.getUnknownLoc(), 0);
+  for (Operation *memref : memrefs) {
+    sycl::AccessorType accTy =
+        getAccessorType(cast<sycl::SYCLAccessorSubscriptOp>(memref));
+    Value offsetVal;
+    if (std::holds_alternative<unsigned>(offset))
+      offsetVal = builder.create<arith::ConstantIndexOp>(
+          builder.getUnknownLoc(), std::get<unsigned>(offset));
+    else
+      offsetVal = std::get<Value>(offset);
+
+    createViewOp(accTy, offsetVal, getGlobalOp, workGroupSize, builder,
+                 memref->getLoc());
+
+    // Only increment offset when the current memref is not the last one.
+    if (memref == *memrefs.rbegin())
+      continue;
+
+    std::variant<Value, unsigned> reqdLocalMemory =
+        getReqdLocalMemory(accTy, workGroupSize, builder);
+    if (std::holds_alternative<unsigned>(offset))
+      std::get<unsigned>(offset) += std::get<unsigned>(reqdLocalMemory);
+    else
+      offset = builder.create<arith::AddIOp>(builder.getUnknownLoc(),
+                                             std::get<Value>(offset),
+                                             std::get<Value>(reqdLocalMemory));
   }
 
   // TODO: promote loop accesses to local memory.

--- a/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
+++ b/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
@@ -14,20 +14,20 @@
 // CHECK-DAG:   [[MAP1:#map.*]] = affine_map<()[s0] -> (256 ceildiv s0)>
 // CHECK-DAG:   [[MAP2:#map.*]] = affine_map<(d0)[s0] -> (d0 * s0)>
 // CHECK-DAG:   [[MAP3:#map.*]] = affine_map<(d0)[s0] -> (d0 * s0 + s0, 256)>
-// CHECK:       memref.global "private" @WGLocalMem : memref<512xi8, #sycl.access.address_space<local>>
+// CHECK:       memref.global "private" @WGLocalMem : memref<64xi8, #sycl.access.address_space<local>>
 // CHECK-LABEL: func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_2_>) {
 // CHECK:         %c0_i32 = arith.constant 0 : i32
 // CHECK-NEXT:    %c1_i32 = arith.constant 1 : i32
 // CHECK-NEXT:    [[TX:%.*]] = sycl.nd_item.get_global_id(%arg1, %c0_i32) : (memref<?x!sycl_nd_item_2_>, i32) -> i64  
 // CHECK-NEXT:    [[TY:%.*]] = sycl.nd_item.get_global_id(%arg1, %c1_i32) : (memref<?x!sycl_nd_item_2_>, i32) -> i64  
-// CHECK-NEXT:    %2 = memref.get_global @WGLocalMem : memref<512xi8, #sycl.access.address_space<local>>
+// CHECK-NEXT:    %2 = memref.get_global @WGLocalMem : memref<64xi8, #sycl.access.address_space<local>>
 // SIZE1-NEXT:    [[TILESIZE:%.*]] = arith.constant 1 : index
 // SIZE2-NEXT:    [[TILESIZE:%.*]] = arith.constant 2 : index
 // CHECK-NEXT:    affine.for [[IV1:%.*]] = 0 to [[MAP1]]()[[[TILESIZE]]] {
 // CHECK-NEXT:      %c0 = arith.constant 0 : index
-// CHECK-NEXT:      %view = memref.view %2[%c0][] : memref<512xi8, #sycl.access.address_space<local>> to memref<4x2xf32, #sycl.access.address_space<local>>
-// CHECK-NEXT:      %c256 = arith.constant 256 : index
-// CHECK-NEXT:      %view_0 = memref.view %2[%c256][] : memref<512xi8, #sycl.access.address_space<local>> to memref<4x2xf32, #sycl.access.address_space<local>>
+// CHECK-NEXT:      %view = memref.view %2[%c0][] : memref<64xi8, #sycl.access.address_space<local>> to memref<4x2xf32, #sycl.access.address_space<local>>
+// CHECK-NEXT:      %c32 = arith.constant 32 : index
+// CHECK-NEXT:      %view_0 = memref.view %2[%c32][] : memref<64xi8, #sycl.access.address_space<local>> to memref<4x2xf32, #sycl.access.address_space<local>>
 // CHECK-NEXT:      spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
 // CHECK-NEXT:      affine.for [[IV2:%.*]] = [[MAP2]]([[IV1]])[[[TILESIZE]]] to min [[MAP3]]([[IV1]])[[[TILESIZE]]] {
 // CHECK-NEXT:        [[IV2_CAST:%.*]] = arith.index_cast [[IV2]] : index to i64 
@@ -83,17 +83,28 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 // CHECK-DAG:   [[MAP3:#map.*]] = affine_map<(d0)[s0] -> ((d0 - 1) * s0 + s0 + 1, 512)>
 // CHECK:       memref.global "private" @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
 // CHECK-LABEL: func.func private @affine_3d(%arg0: memref<?x!sycl_accessor_3_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_3_>) {
-// CHECK:         %c0_i32 = arith.constant 0 : i32
-// CHECK-NEXT:    %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:    %c2_i32 = arith.constant 2 : i32
-// CHECK-NEXT:    [[TX:%.*]] = sycl.nd_item.get_global_id(%arg1, %c0_i32) : (memref<?x!sycl_nd_item_3_>, i32) -> i64  
-// CHECK-NEXT:    [[TY:%.*]] = sycl.nd_item.get_global_id(%arg1, %c1_i32) : (memref<?x!sycl_nd_item_3_>, i32) -> i64  
-// CHECK-NEXT:    [[TZ:%.*]] = sycl.nd_item.get_global_id(%arg1, %c2_i32) : (memref<?x!sycl_nd_item_3_>, i32) -> i64  
+// CHECK-NEXT:    [[C0:%.*]] = arith.constant 0 : i32
+// CHECK-NEXT:    %0 = sycl.nd_item.get_local_range(%arg1, [[C0]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64 
+// CHECK-NEXT:    %1 = arith.index_cast %0 : i64 to index 
+// CHECK-NEXT:    [[C1:%.*]] = arith.constant 1 : i32 
+// CHECK-NEXT:    %2 = sycl.nd_item.get_local_range(%arg1, [[C1]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64 
+// CHECK-NEXT:    %3 = arith.index_cast %2 : i64 to index
+// CHECK-NEXT:    [[C2:%.*]] = arith.constant 2 : i32 
+// CHECK-NEXT:    %4 = sycl.nd_item.get_local_range(%arg1, [[C2]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64 
+// CHECK-NEXT:    %5 = arith.index_cast %4 : i64 to index 
+// CHECK:         [[C0:%.*]] = arith.constant 0 : i32
+// CHECK-NEXT:    [[C1:%.*]] = arith.constant 1 : i32
+// CHECK-NEXT:    [[C2:%.*]] = arith.constant 2 : i32
+// CHECK-NEXT:    [[TX:%.*]] = sycl.nd_item.get_global_id(%arg1, [[C0]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64  
+// CHECK-NEXT:    [[TY:%.*]] = sycl.nd_item.get_global_id(%arg1, [[C1]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64  
+// CHECK-NEXT:    [[TZ:%.*]] = sycl.nd_item.get_global_id(%arg1, [[C2]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64  
 // CHECK-NEXT:    affine.for [[IV1:%.*]] = 0 to 256 {
-// CHECK-NEXT:      %3 = memref.get_global @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
+// CHECK-NEXT:      %9 = memref.get_global @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
 // SIZE1-NEXT:      [[TILESIZE:%.*]] = arith.constant 1 : index
 // SIZE2-NEXT:      [[TILESIZE:%.*]] = arith.constant 2 : index
 // CHECK-NEXT:      affine.for [[IV2:%.*]] = 1 to [[MAP1]]()[[[TILESIZE]]] {
+// CHECK-NEXT:        [[C0:%.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %view = memref.view %9[[[C0]]][%5, %3, %1] : memref<32000xi8, #sycl.access.address_space<local>> to memref<?x?x?xf32, #sycl.access.address_space<local>>
 // CHECK-NEXT:        spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
 // CHECK-NEXT:        affine.for [[IV3:%.*]] = [[MAP2]]([[IV2]])[[[TILESIZE]]] to min [[MAP3]]([[IV2]])[[[TILESIZE]]] {
 // CHECK-DAG:           [[IV1_CAST:%.*]] = arith.index_cast [[IV1]] : index to i64   
@@ -148,18 +159,31 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_3_f32_r_gb>, %arg1: memref<?x!sy
 
 // CHECK:       memref.global "private" @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
 // CHECK-LABEL: func.func private @scf_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_2_>) {
+// CHECK-NEXT:    [[C0:%.*]] = arith.constant 0 : i32
+// CHECK-NEXT:    %0 = sycl.nd_item.get_local_range(%arg1, [[C0]]) : (memref<?x!sycl_nd_item_2_>, i32) -> i64 
+// CHECK-NEXT:    %1 = arith.index_cast %0 : i64 to index 
+// CHECK-NEXT:    [[C1:%.*]] = arith.constant 1 : i32 
+// CHECK-NEXT:    %2 = sycl.nd_item.get_local_range(%arg1, [[C1]]) : (memref<?x!sycl_nd_item_2_>, i32) -> i64 
+// CHECK-NEXT:    %3 = arith.index_cast %2 : i64 to index
 // CHECK-DAG:     %c0 = arith.constant 0 : index
 // CHECK-DAG:     %c1 = arith.constant 1 : index
 // CHECK-DAG:     %c256 = arith.constant 256 : index
-// CHECK-DAG:     %c0_i32 = arith.constant 0 : i32
-// CHECK-DAG:     %c1_i32 = arith.constant 1 : i32
-// CHECK-NEXT:    [[TX:%.*]] = sycl.nd_item.get_global_id(%arg1, %c0_i32) : (memref<?x!sycl_nd_item_2_>, i32) -> i64  
-// CHECK-NEXT:    [[TY:%.*]] = sycl.nd_item.get_global_id(%arg1, %c1_i32) : (memref<?x!sycl_nd_item_2_>, i32) -> i64  
-// CHECK-NEXT:    %2 = memref.get_global @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
+// CHECK:         [[C0:%.*]] = arith.constant 0 : i32
+// CHECK-NEXT:    [[C1:%.*]] = arith.constant 1 : i32
+// CHECK-NEXT:    [[TX:%.*]] = sycl.nd_item.get_global_id(%arg1, [[C0]]) : (memref<?x!sycl_nd_item_2_>, i32) -> i64  
+// CHECK-NEXT:    [[TY:%.*]] = sycl.nd_item.get_global_id(%arg1, [[C1]]) : (memref<?x!sycl_nd_item_2_>, i32) -> i64  
+// CHECK-NEXT:    %6 = memref.get_global @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
 // SIZE1-NEXT:    [[TILESIZE:%.*]] = arith.constant 1 : index
 // SIZE2-NEXT:    [[TILESIZE:%.*]] = arith.constant 2 : index
 // CHECK-NEXT:    [[STEP:%.*]] = arith.muli %c1, [[TILESIZE]] : index
 // CHECK-NEXT:    scf.for [[IV1:%.*]] = %c0 to %c256 step [[STEP]] {
+// CHECK-NEXT:      [[C0:%.*]] = arith.constant 0 : index 
+// CHECK-NEXT:      %view = memref.view %6[[[C0]]][%3, %1] : memref<32000xi8, #sycl.access.address_space<local>> to memref<?x?xf32, #sycl.access.address_space<local>>
+// CHECK-NEXT:      %c4 = arith.constant 4 : index 
+// CHECK-NEXT:      %8 = arith.muli %c4, %1 : index 
+// CHECK-NEXT:      %9 = arith.muli %8, %3 : index 
+// CHECK-NEXT:      %10 = arith.addi [[C0]], %9 : index 
+// CHECK-NEXT:      %view{{.*}} = memref.view %6[%10][%3, %1] : memref<32000xi8, #sycl.access.address_space<local>> to memref<?x?xf32, #sycl.access.address_space<local>>
 // CHECK-NEXT:      spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
 // CHECK-NEXT:      [[VAL_1:%.*]] = arith.addi [[IV1]], [[STEP]] : index
 // CHECK-NEXT:      [[VAL_2:%.*]] = arith.cmpi slt, %c256, [[VAL_1]] : index
@@ -167,8 +191,10 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_3_f32_r_gb>, %arg1: memref<?x!sy
 // CHECK-NEXT:      scf.for [[IV2:%.*]] = [[IV1]] to [[VAL_3]] step %c1 {
 // CHECK-NEXT:        [[IV2_CAST:%.*]] = arith.index_cast [[IV2]] : index to i64   
 // CHECK-NEXT:        sycl.constructor @id([[ID:%.*]], [[TX]], [[IV2_CAST]]) {{.*}} : (memref<?x!sycl_id_2_>, i64, i64)
-// CHECK-NEXT:        [[SUBSCR:%.*]] = sycl.accessor.subscript %arg0[[[ID]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2_>) -> memref<?xf32>
-// CHECK-NEXT:        {{.*}} = affine.load [[SUBSCR]][0] : memref<?xf32>  
+// CHECK-NEXT:        [[SUBSCR1:%.*]] = sycl.accessor.subscript %arg0[[[ID]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2_>) -> memref<?xf32>
+// CHECK-NEXT:        {{.*}} = affine.load [[SUBSCR1]][0] : memref<?xf32>
+// CHECK-NEXT:        [[SUBSCR2:%.*]] = sycl.accessor.subscript %arg0[[[ID]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2_>) -> memref<?xf32>
+// CHECK-NEXT:        {{.*}} = affine.load [[SUBSCR2]][0] : memref<?xf32>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
 // CHECK-NEXT:    }
@@ -191,6 +217,8 @@ func.func private @scf_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: mem
     sycl.constructor @id(%id, %tx, %i) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2>, i64, i64)
     %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2>) -> memref<?xf32>
     %load1 = affine.load %subscr1[0] : memref<?xf32>
+    %subscr2 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2>) -> memref<?xf32>
+    %load2 = affine.load %subscr2[0] : memref<?xf32>
   }
   return
 }
@@ -213,22 +241,33 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 
 // CHECK:       memref.global "private" @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
 // CHECK-LABEL: func.func private @scf_3d(%arg0: memref<?x!sycl_accessor_3_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_3_>) {
+// CHECK-NEXT:    [[C0:%.*]] = arith.constant 0 : i32
+// CHECK-NEXT:    %0 = sycl.nd_item.get_local_range(%arg1, [[C0]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64 
+// CHECK-NEXT:    %1 = arith.index_cast %0 : i64 to index 
+// CHECK-NEXT:    [[C1:%.*]] = arith.constant 1 : i32 
+// CHECK-NEXT:    %2 = sycl.nd_item.get_local_range(%arg1, [[C1]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64 
+// CHECK-NEXT:    %3 = arith.index_cast %2 : i64 to index
+// CHECK-NEXT:    [[C2:%.*]] = arith.constant 2 : i32 
+// CHECK-NEXT:    %4 = sycl.nd_item.get_local_range(%arg1, [[C2]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64 
+// CHECK-NEXT:    %5 = arith.index_cast %4 : i64 to index 
 // CHECK-DAG:     %c0 = arith.constant 0 : index
 // CHECK-DAG:     %c1 = arith.constant 1 : index
 // CHECK-DAG:     %c256 = arith.constant 256 : index
 // CHECK-DAG:     %c512 = arith.constant 512 : index
-// CHECK-DAG:     %c0_i32 = arith.constant 0 : i32
-// CHECK-DAG:     %c1_i32 = arith.constant 1 : i32
-// CHECK-DAG:     %c2_i32 = arith.constant 2 : i32
-// CHECK-NEXT:    [[TX:%.*]] = sycl.nd_item.get_global_id(%arg1, %c0_i32) : (memref<?x!sycl_nd_item_3_>, i32) -> i64  
-// CHECK-NEXT:    [[TY:%.*]] = sycl.nd_item.get_global_id(%arg1, %c1_i32) : (memref<?x!sycl_nd_item_3_>, i32) -> i64  
-// CHECK-NEXT:    [[TZ:%.*]] = sycl.nd_item.get_global_id(%arg1, %c2_i32) : (memref<?x!sycl_nd_item_3_>, i32) -> i64  
+// CHECK-DAG:     [[C0:%.*]] = arith.constant 0 : i32
+// CHECK-DAG:     [[C1:%.*]] = arith.constant 1 : i32
+// CHECK-DAG:     [[C2:%.*]] = arith.constant 2 : i32
+// CHECK-NEXT:    [[TX:%.*]] = sycl.nd_item.get_global_id(%arg1, [[C0]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64  
+// CHECK-NEXT:    [[TY:%.*]] = sycl.nd_item.get_global_id(%arg1, [[C1]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64  
+// CHECK-NEXT:    [[TZ:%.*]] = sycl.nd_item.get_global_id(%arg1, [[C2]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64  
 // CHECK-NEXT:    scf.for [[IV1:.*]] = %c0 to %c256 step %c1 {
-// CHECK-NEXT:      %3 = memref.get_global @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
+// CHECK-NEXT:      %9 = memref.get_global @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
 // SIZE1-NEXT:      [[TILESIZE:%.*]] = arith.constant 1 : index
 // SIZE2-NEXT:      [[TILESIZE:%.*]] = arith.constant 2 : index
 // CHECK-NEXT:      [[STEP:%.*]] = arith.muli %c1, [[TILESIZE]] : index
 // CHECK-NEXT:      scf.for [[IV2:.*]] = %c1 to %c512 step [[STEP]] {
+// CHECK-NEXT:        [[C0:%.*]] = arith.constant 0 : index 
+// CHECK-NEXT:        %view = memref.view %9[[[C0]]][%5, %3, %1] : memref<32000xi8, #sycl.access.address_space<local>> to memref<?x?x?xf32, #sycl.access.address_space<local>>
 // CHECK-NEXT:        spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
 // CHECK-NEXT:        [[VAL_2:%.*]] = arith.addi [[IV2]], [[STEP]] : index
 // CHECK-NEXT:        [[VAL_6:%.*]] = arith.cmpi slt, %c512, [[VAL_2]] : index


### PR DESCRIPTION
When `reqd_work_group_size` is not given, query work group size with `nd_item.get_local_range(dim)`.