### PR TITLE
[SYCL][CUDA] support launch bounds 

### DIFF
--- a/clang/lib/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CodeGen/TargetInfo.cpp
@@ -7384,6 +7384,15 @@ void NVPTXTargetCodeGenInfo::setTargetAttributes(
       // And kernel functions are not subject to inlining
       F->addFnAttr(llvm::Attribute::NoInline);
     }
+    if (const SYCLIntelMaxWorkGroupSizeAttr *A =
+          FD->getAttr<SYCLIntelMaxWorkGroupSizeAttr>()) {
+      uint64_t MaxThreads = (*A->getZDimVal()).getExtValue() *
+                            (*A->getYDimVal()).getExtValue() *
+                            (*A->getXDimVal()).getExtValue();
+      if (MaxThreads > 0) {
+          addNVVMMetadata(F, "maxntidx", MaxThreads);
+      }
+    }
   }
 
   // Perform special handling in CUDA mode.

--- a/clang/lib/CodeGen/TargetInfo.cpp
+++ b/clang/lib/CodeGen/TargetInfo.cpp
@@ -7386,11 +7386,11 @@ void NVPTXTargetCodeGenInfo::setTargetAttributes(
     }
     if (const SYCLIntelMaxWorkGroupSizeAttr *A =
           FD->getAttr<SYCLIntelMaxWorkGroupSizeAttr>()) {
-      uint64_t MaxThreads = (*A->getZDimVal()).getExtValue() *
-                            (*A->getYDimVal()).getExtValue() *
-                            (*A->getXDimVal()).getExtValue();
+      int64_t MaxThreads = (*A->getZDimVal()).getExtValue() *
+                           (*A->getYDimVal()).getExtValue() *
+                           (*A->getXDimVal()).getExtValue();
       if (MaxThreads > 0) {
-          addNVVMMetadata(F, "maxntidx", MaxThreads);
+        addNVVMMetadata(F, "maxntidx", MaxThreads);
       }
     }
   }


### PR DESCRIPTION
@steffenlarsen @npmiller  

Many users have requested the feature. I tried to get started. Help is needed to finish the definition and implementation of the kernel attribute for "minBlocksPerMultiprocessor" to support launch bounds in CUDA.  Thanks. 

```
def SYCLMinWorkGroupsPerComputeUnit : InheritableAttr {
  let Spellings = [CXX11<"sycl", "min_workgroups_per_cu">];
  let Args = [ExprArgument<"Value">];
  let LangOpts = [SYCLIsDevice, SilentlyIgnoreSYCLIsHost];
  let Subjects = SubjectList<[Function], ErrorDiag>;
  let Documentation = [Undocumented];
  let SupportsNonconformingLambdaSyntax = 1;
}
```