### PR TITLE
[CI] Generate test matrix on self-hosted runner

### DIFF
--- a/.github/workflows/sycl_gen_test_matrix.yml
+++ b/.github/workflows/sycl_gen_test_matrix.yml
@@ -49,7 +49,9 @@ on:
 jobs:
   test_matrix:
     name: Generate Test Matrix
-    runs-on: ubuntu-20.04
+    # Github's ubuntu-* runner are slow to allocate. Use our CUDA runner since
+    # we don't use it for anything right now.
+    runs-on: cuda
     outputs:
       lts_lx_matrix: ${{ steps.work.outputs.lts_lx_matrix }}
       lts_wn_matrix: ${{ steps.work.outputs.lts_wn_matrix }}


### PR DESCRIPTION
Github's ubuntu-* runners could take multiple hours to allocate in our organization. Switch to our self-hosted cuda runner that is sitting idle because we perform CUDA testing in AWS.