### PR TITLE
[SYCL-MLIR] Allow `sycl.half` as data type in `sycl.vec`

### DIFF
--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLDialect.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLDialect.cpp
@@ -205,8 +205,11 @@ SYCLOpAsmInterface::getAlias(mlir::Type Type, llvm::raw_ostream &OS) const {
         return AliasResult::OverridableAlias;
       })
       .Case<mlir::sycl::VecType>([&](auto Ty) {
-        OS << "sycl_" << decltype(Ty)::getMnemonic() << "_" << Ty.getDataType()
-           << "_" << Ty.getNumElements() << "_";
+        OS << "sycl_" << decltype(Ty)::getMnemonic() << "_";
+        mlir::Type DataTy = Ty.getDataType();
+        if (getAlias(DataTy, OS) == AliasResult::NoAlias)
+          OS << DataTy;
+        OS << "_" << Ty.getNumElements() << "_";
         return AliasResult::FinalAlias;
       })
       .Default(AliasResult::NoAlias);

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLTypes.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLTypes.cpp
@@ -51,8 +51,8 @@ VecType::verify(llvm::function_ref<InFlightDiagnostic()> emitError, Type dataT,
       .Case<FloatType>([&](auto floatTy) -> LogicalResult {
         const unsigned width = dataT.cast<FloatType>().getWidth();
         if (width != 32 && width != 64) {
-          return emitError() << "FP SYCL vector element types can only be f16, "
-                                "f32 or f64. Got "
+          return emitError() << "FP SYCL vector element types can only be "
+                                "half, float or double. Got "
                              << width << ".";
         }
         return success();

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLTypes.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLTypes.cpp
@@ -44,7 +44,7 @@ VecType::verify(llvm::function_ref<InFlightDiagnostic()> emitError, Type dataT,
           return emitError()
                  << "Integer SYCL vector element types can only be i1, "
                     "i8, i16, i32 or i64. Got "
-                 << width << ".";
+                 << intTy << ".";
         }
         return success();
       })
@@ -53,7 +53,7 @@ VecType::verify(llvm::function_ref<InFlightDiagnostic()> emitError, Type dataT,
         if (width != 32 && width != 64) {
           return emitError() << "FP SYCL vector element types can only be "
                                 "half, float or double. Got "
-                             << width << ".";
+                             << floatTy << ".";
         }
         return success();
       })

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
@@ -223,9 +223,16 @@ func.func @test_stream(%arg0: !sycl_stream) {
 }
 // -----
 
+!sycl_half = !sycl.half<(f16)>
 !sycl_vec_f32_4_ = !sycl.vec<[f32, 4], (vector<4xf32>)>
+!sycl_vec_sycl_half_16_ = !sycl.vec<[!sycl_half, 16], (vector<16xf16>)>
+
 // CHECK: llvm.func @test_vec(%arg0: !llvm.[[VEC:struct<"class.sycl::_V1::vec", \(vector<4xf32>\)>]])
 func.func @test_vec(%arg0: !sycl_vec_f32_4_) {
+  return
+}
+// CHECK: llvm.func @test_half16(%arg0: !llvm.[[VEC1:struct<"class.sycl::_V1::vec.1", \(vector<16xf16>\)>]])
+func.func @test_half16(%arg0: !sycl_vec_sycl_half_16_) {
   return
 }
 !sycl_swizzled_vec_f32_4_ = !sycl.swizzled_vec<[!sycl_vec_f32_4_, 0, 2], (memref<?x!sycl_vec_f32_4_, 4>, !llvm.struct<(i8)>, !llvm.struct<(i8)>)>

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -283,3 +283,26 @@ func.func @test_get_group_bad_ret_type(%nd: memref<?x!sycl_nd_item_1_>, %i: i32)
   %0 = sycl.nd_item.get_group(%nd, %i) : (memref<?x!sycl_nd_item_1_>, i32) -> !sycl_group_1_
   return %0 : !sycl_group_1_
 }
+
+// -----
+
+// expected-error @below {{Integer SYCL vector element types can only be i1, i8, i16, i32 or i64. Got 'i2'.}}
+func.func @test_vec_i2(%v: !sycl.vec<[i2, 2], (vector<2xi2>)>) {
+  return
+}
+
+// -----
+
+// expected-error @below {{FP SYCL vector element types can only be half, float or double. Got 'f80'.}}
+func.func @test_vec_f80(%v: !sycl.vec<[f80, 2], (vector<2xi2>)>) {
+  return
+}
+
+// -----
+
+!sycl_vec_i8_1_ = !sycl.vec<[i8, 1], (vector<1xi8>)>
+
+// expected-error @below {{SYCL vector types can only hold basic scalar types. Got '!sycl.vec<[i8, 1], (vector<1xi8>)>'.}}
+func.func @test_vec_nonscalar(%v: !sycl.vec<[!sycl_vec_i8_1_, 2], (vector<2x1xi8>)>) {
+  return
+}

--- a/mlir-sycl/test/Dialect/SYCL/types.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/types.mlir
@@ -183,8 +183,10 @@ func.func @half(%arg0: !sycl_half) {
 // VEC
 ////////////////////////////////////////////////////////////////////////////////
 
+!sycl_half = !sycl.half<(f16)>
 !sycl_vec_i32_2_ = !sycl.vec<[i32, 2], (vector<2xi32>)>
 !sycl_vec_f32_4_ = !sycl.vec<[f32, 4], (vector<4xf32>)>
+!sycl_vec_sycl_half_8_ = !sycl.vec<[!sycl_half, 8], (vector<8xf16>)>
 
 // CHECK: func @vec_0(%arg0: !sycl_vec_i32_2_)
 func.func @vec_0(%arg0: !sycl_vec_i32_2_) attributes {llvm.linkage = #llvm.linkage<external>} {
@@ -194,7 +196,10 @@ func.func @vec_0(%arg0: !sycl_vec_i32_2_) attributes {llvm.linkage = #llvm.linka
 func.func @vec_1(%arg0: !sycl_vec_f32_4_) attributes {llvm.linkage = #llvm.linkage<external>} {
   return
 }
-
+// CHECK: func @vec_2(%arg0: !sycl_vec_sycl_half_8_)
+func.func @vec_2(%arg0: !sycl_vec_sycl_half_8_) attributes {llvm.linkage = #llvm.linkage<external>} {
+  return
+}
 ////////////////////////////////////////////////////////////////////////////////
 // SWIZZLED_VEC
 ////////////////////////////////////////////////////////////////////////////////

--- a/polygeist/tools/cgeist/Test/Verification/sycl/half.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/half.cpp
@@ -19,6 +19,21 @@ SYCL_EXTERNAL sycl::half identity(sycl::half h) {
   return h;
 }
 
+// CHECK-LABEL:     func.func @_Z8identityN4sycl3_V13vecINS0_6detail9half_impl4halfELi8EEE(
+// CHECK-SAME:                                                                             %[[VAL_163:.*]]: memref<?x!sycl_vec_sycl_half_8_> {llvm.align = 16 : i64, llvm.byval = !sycl_vec_sycl_half_8_, llvm.noundef}) -> !sycl_vec_sycl_half_8_
+// CHECK-NEXT:        %[[VAL_164:.*]] = memref.alloca() : memref<1x!sycl_vec_sycl_half_8_>
+// CHECK-NEXT:        %[[VAL_165:.*]] = memref.cast %[[VAL_164]] : memref<1x!sycl_vec_sycl_half_8_> to memref<?x!sycl_vec_sycl_half_8_>
+// CHECK-NEXT:        %[[VAL_166:.*]] = memref.memory_space_cast %[[VAL_165]] : memref<?x!sycl_vec_sycl_half_8_> to memref<?x!sycl_vec_sycl_half_8_, 4>
+// CHECK-NEXT:        %[[VAL_167:.*]] = memref.memory_space_cast %[[VAL_163]] : memref<?x!sycl_vec_sycl_half_8_> to memref<?x!sycl_vec_sycl_half_8_, 4>
+// CHECK-NEXT:        sycl.constructor @vec(%[[VAL_166]], %[[VAL_167]]) {MangledFunctionName = @_ZN4sycl3_V13vecINS0_6detail9half_impl4halfELi8EEC1EOS5_} : (memref<?x!sycl_vec_sycl_half_8_, 4>, memref<?x!sycl_vec_sycl_half_8_, 4>)
+// CHECK-NEXT:        %[[VAL_168:.*]] = affine.load %[[VAL_164]][0] : memref<1x!sycl_vec_sycl_half_8_>
+// CHECK-NEXT:        return %[[VAL_168]] : !sycl_vec_sycl_half_8_
+// CHECK-NEXT:      }
+
+SYCL_EXTERNAL sycl::half8 identity(sycl::half8 h) {
+  return h;
+}
+
 // CHECK-LABEL:     func.func @_Z6toHalff(
 // CHECK-SAME:                            %[[VAL_163:.*]]: f32 {llvm.noundef}) -> !sycl_half
 // CHECK-NEXT:        %[[VAL_164:.*]] = memref.alloca() : memref<1x!sycl_half>
@@ -177,6 +192,18 @@ SYCL_EXTERNAL sycl::half add(sycl::half lhs, sycl::half rhs) {
   return lhs + rhs;
 }
 
+// CHECK-LABEL:           func.func @_Z3addN4sycl3_V13vecINS0_6detail9half_impl4halfELi4EEES5_(
+// CHECK-SAME:                                                                                 %[[VAL_278:.*]]: memref<?x!sycl_vec_sycl_half_4_> {llvm.align = 8 : i64, llvm.byval = !sycl_vec_sycl_half_4_, llvm.noundef}, %[[VAL_279:.*]]: memref<?x!sycl_vec_sycl_half_4_> {llvm.align = 8 : i64, llvm.byval = !sycl_vec_sycl_half_4_, llvm.noundef}) -> !sycl_vec_sycl_half_4_
+// CHECK-NEXT:        %[[VAL_280:.*]] = memref.memory_space_cast %[[VAL_278]] : memref<?x!sycl_vec_sycl_half_4_> to memref<?x!sycl_vec_sycl_half_4_, 4>
+// CHECK-NEXT:        %[[VAL_281:.*]] = memref.memory_space_cast %[[VAL_279]] : memref<?x!sycl_vec_sycl_half_4_> to memref<?x!sycl_vec_sycl_half_4_, 4>
+// CHECK-NEXT:        %[[VAL_282:.*]] = sycl.call @"operator+"(%[[VAL_280]], %[[VAL_281]]) {MangledFunctionName = @_ZNK4sycl3_V13vecINS0_6detail9half_impl4halfELi4EEplIS5_EES5_RKNSt9enable_ifILb1ET_E4typeE, TypeName = @vec} : (memref<?x!sycl_vec_sycl_half_4_, 4>, memref<?x!sycl_vec_sycl_half_4_, 4>) -> !sycl_vec_sycl_half_4_
+// CHECK-NEXT:        return %[[VAL_282]] : !sycl_vec_sycl_half_4_
+// CHECK-NEXT:      }
+
+SYCL_EXTERNAL sycl::half4 add(sycl::half4 lhs, sycl::half4 rhs) {
+  return lhs + rhs;
+}
+
 // CHECK-LABEL:     func.func @_Z3subN4sycl3_V16detail9half_impl4halfES3_(
 // CHECK-SAME:                                                            %[[VAL_275:.*]]: memref<?x!sycl_half> {llvm.align = 2 : i64, llvm.byval = !sycl_half, llvm.noundef}, %[[VAL_276:.*]]: memref<?x!sycl_half> {llvm.align = 2 : i64, llvm.byval = !sycl_half, llvm.noundef}) -> !sycl_half
 // CHECK-NEXT:        %[[VAL_277:.*]] = memref.alloca() : memref<1x!sycl_half>
@@ -202,6 +229,18 @@ SYCL_EXTERNAL sycl::half add(sycl::half lhs, sycl::half rhs) {
 // CHECK-NEXT:      }
 
 SYCL_EXTERNAL sycl::half sub(sycl::half lhs, sycl::half rhs) {
+  return lhs - rhs;
+}
+
+// CHECK-LABEL:     func.func @_Z3subN4sycl3_V13vecINS0_6detail9half_impl4halfELi2EEES5_(
+// CHECK-SAME:                                                                           %[[VAL_330:.*]]: memref<?x!sycl_vec_sycl_half_2_> {llvm.align = 4 : i64, llvm.byval = !sycl_vec_sycl_half_2_, llvm.noundef}, %[[VAL_331:.*]]: memref<?x!sycl_vec_sycl_half_2_> {llvm.align = 4 : i64, llvm.byval = !sycl_vec_sycl_half_2_, llvm.noundef}) -> !sycl_vec_sycl_half_2_
+// CHECK-NEXT:        %[[VAL_332:.*]] = memref.memory_space_cast %[[VAL_330]] : memref<?x!sycl_vec_sycl_half_2_> to memref<?x!sycl_vec_sycl_half_2_, 4>
+// CHECK-NEXT:        %[[VAL_333:.*]] = memref.memory_space_cast %[[VAL_331]] : memref<?x!sycl_vec_sycl_half_2_> to memref<?x!sycl_vec_sycl_half_2_, 4>
+// CHECK-NEXT:        %[[VAL_334:.*]] = sycl.call @"operator-"(%[[VAL_332]], %[[VAL_333]]) {MangledFunctionName = @_ZNK4sycl3_V13vecINS0_6detail9half_impl4halfELi2EEmiIS5_EES5_RKNSt9enable_ifILb1ET_E4typeE, TypeName = @vec} : (memref<?x!sycl_vec_sycl_half_2_, 4>, memref<?x!sycl_vec_sycl_half_2_, 4>) -> !sycl_vec_sycl_half_2_
+// CHECK-NEXT:        return %[[VAL_334]] : !sycl_vec_sycl_half_2_
+// CHECK-NEXT:      }
+
+SYCL_EXTERNAL sycl::half2 sub(sycl::half2 lhs, sycl::half2 rhs) {
   return lhs - rhs;
 }
 
@@ -233,6 +272,18 @@ SYCL_EXTERNAL sycl::half mul(sycl::half lhs, sycl::half rhs) {
   return lhs * rhs;
 }
 
+// CHECK-LABEL:     func.func @_Z3mulN4sycl3_V13vecINS0_6detail9half_impl4halfELi4EEES5_(
+// CHECK-SAME:                                                                           %[[VAL_382:.*]]: memref<?x!sycl_vec_sycl_half_4_> {llvm.align = 8 : i64, llvm.byval = !sycl_vec_sycl_half_4_, llvm.noundef}, %[[VAL_383:.*]]: memref<?x!sycl_vec_sycl_half_4_> {llvm.align = 8 : i64, llvm.byval = !sycl_vec_sycl_half_4_, llvm.noundef}) -> !sycl_vec_sycl_half_4_
+// CHECK-NEXT:        %[[VAL_384:.*]] = memref.memory_space_cast %[[VAL_382]] : memref<?x!sycl_vec_sycl_half_4_> to memref<?x!sycl_vec_sycl_half_4_, 4>
+// CHECK-NEXT:        %[[VAL_385:.*]] = memref.memory_space_cast %[[VAL_383]] : memref<?x!sycl_vec_sycl_half_4_> to memref<?x!sycl_vec_sycl_half_4_, 4>
+// CHECK-NEXT:        %[[VAL_386:.*]] = sycl.call @"operator*"(%[[VAL_384]], %[[VAL_385]]) {MangledFunctionName = @_ZNK4sycl3_V13vecINS0_6detail9half_impl4halfELi4EEmlIS5_EES5_RKNSt9enable_ifILb1ET_E4typeE, TypeName = @vec} : (memref<?x!sycl_vec_sycl_half_4_, 4>, memref<?x!sycl_vec_sycl_half_4_, 4>) -> !sycl_vec_sycl_half_4_
+// CHECK-NEXT:        return %[[VAL_386]] : !sycl_vec_sycl_half_4_
+// CHECK-NEXT:      }
+
+SYCL_EXTERNAL sycl::half4 mul(sycl::half4 lhs, sycl::half4 rhs) {
+  return lhs * rhs;
+}
+
 // CHECK-LABEL:     func.func @_Z3divN4sycl3_V16detail9half_impl4halfES3_(
 // CHECK-SAME:                                                            %[[VAL_321:.*]]: memref<?x!sycl_half> {llvm.align = 2 : i64, llvm.byval = !sycl_half, llvm.noundef}, %[[VAL_322:.*]]: memref<?x!sycl_half> {llvm.align = 2 : i64, llvm.byval = !sycl_half, llvm.noundef}) -> !sycl_half
 // CHECK-NEXT:        %[[VAL_323:.*]] = memref.alloca() : memref<1x!sycl_half>
@@ -258,5 +309,17 @@ SYCL_EXTERNAL sycl::half mul(sycl::half lhs, sycl::half rhs) {
 // CHECK-NEXT:      }
 
 SYCL_EXTERNAL sycl::half div(sycl::half lhs, sycl::half rhs) {
+  return lhs / rhs;
+}
+
+// CHECK-LABEL:     func.func @_Z3divN4sycl3_V13vecINS0_6detail9half_impl4halfELi3EEES5_(
+// CHECK-SAME:                                                                           %[[VAL_434:.*]]: memref<?x!sycl_vec_sycl_half_3_> {llvm.align = 8 : i64, llvm.byval = !sycl_vec_sycl_half_3_, llvm.noundef}, %[[VAL_435:.*]]: memref<?x!sycl_vec_sycl_half_3_> {llvm.align = 8 : i64, llvm.byval = !sycl_vec_sycl_half_3_, llvm.noundef}) -> !sycl_vec_sycl_half_3_
+// CHECK-NEXT:        %[[VAL_436:.*]] = memref.memory_space_cast %[[VAL_434]] : memref<?x!sycl_vec_sycl_half_3_> to memref<?x!sycl_vec_sycl_half_3_, 4>
+// CHECK-NEXT:        %[[VAL_437:.*]] = memref.memory_space_cast %[[VAL_435]] : memref<?x!sycl_vec_sycl_half_3_> to memref<?x!sycl_vec_sycl_half_3_, 4>
+// CHECK-NEXT:        %[[VAL_438:.*]] = sycl.call @"operator/"(%[[VAL_436]], %[[VAL_437]]) {MangledFunctionName = @_ZNK4sycl3_V13vecINS0_6detail9half_impl4halfELi3EEdvIS5_EES5_RKNSt9enable_ifILb1ET_E4typeE, TypeName = @vec} : (memref<?x!sycl_vec_sycl_half_3_, 4>, memref<?x!sycl_vec_sycl_half_3_, 4>) -> !sycl_vec_sycl_half_3_
+// CHECK-NEXT:        return %[[VAL_438]] : !sycl_vec_sycl_half_3_
+// CHECK-NEXT:      }
+
+SYCL_EXTERNAL sycl::half3 div(sycl::half3 lhs, sycl::half3 rhs) {
   return lhs / rhs;
 }

--- a/sycl/test-e2e/xfail_tests.txt
+++ b/sycl/test-e2e/xfail_tests.txt
@@ -88,11 +88,9 @@ Basic/device_implicitly_copyable.cpp
 Basic/diagnostics/non-uniform-wk-gp-test.cpp
 Basic/group_async_copy.cpp
 Basic/group_async_copy_legacy.cpp
-Basic/half_builtins.cpp
 Basic/half_type.cpp
 Basic/image/image.cpp
 Basic/image/image_accessor_readsampler.cpp
-Basic/image/image_accessor_readwrite_half.cpp
 Basic/image/image_array.cpp
 Basic/image/image_max_size.cpp
 Basic/image/image_read.cpp
@@ -129,7 +127,6 @@ DeviceLib/built-ins/ext_native_math_fp16.cpp
 DeviceLib/built-ins/fast-math-flag.cpp
 DeviceLib/built-ins/marray_integer.cpp
 DeviceLib/built-ins/marray_relational.cpp
-DeviceLib/built-ins/nan.cpp
 DeviceLib/built-ins/printf.cpp
 DeviceLib/built-ins/scalar_relational.cpp
 DeviceLib/built-ins/vector_integer.cpp
@@ -141,7 +138,6 @@ DeviceLib/imf_bfloat16_integeral_convesions.cpp
 DeviceLib/imf_double2half.cpp
 DeviceLib/imf_double2bfloat16.cpp
 DeviceLib/imf_float2bfloat16.cpp
-DeviceLib/imf_fp16_trivial_test.cpp
 DeviceLib/imf_fp32_test.cpp
 DeviceLib/imf_fp64_test.cpp
 DeviceLib/imf_half_type_cast.cpp
@@ -490,7 +486,6 @@ SubGroup/generic_reduce.cpp
 SubGroup/generic-shuffle.cpp
 SubGroup/load_store.cpp
 SubGroup/shuffle.cpp
-SubGroup/shuffle_fp16.cpp
 SubGroup/sub_group_as.cpp
 SubGroup/sub_group_as_vec.cpp
 SubGroupMask/Basic.cpp


### PR DESCRIPTION
Allow usage of this type and performing operations between these vectors.

Conversion of this kind of vectors is not supported yet due to lack of codegen support.