### PR TITLE
[CI] Add cleanup for workflows/sycl_gen_test_matrix.yml

### DIFF
--- a/.github/workflows/sycl_gen_test_matrix.yml
+++ b/.github/workflows/sycl_gen_test_matrix.yml
@@ -75,3 +75,5 @@ jobs:
         script: |
           const script = require('./generate_test_matrix.js');
           script({core, process});
+    - name: Cleanup
+      run: rm -rf generate_test_matrix.js test_configs.json dependencies.json dependencies.sycl.json


### PR DESCRIPTION
It's generally good when the task doesn't leave any leftovers after itself. That becomes even more important when using self-hosted runners where leftovers aren't cleared by the container destruction (if one is used at all).

This is also kind of related to the root/actions/checkout/lint issue that (I believe with about 90% confidence) is not caused by the actions/checkout. Instead, it's the difference under which user the job is executed due to the containers usage.

In a nutshell, I'm trying to move our ubuntu-* tasks onto local runners and this PR is one of several change I'm making/made. I'm currently using the cuda runner because we can get by with tasks not cleaning after themselves as no real jobs are being scheduled there. However, I'm working on implementing all the necessary cleanups so that we can schedule them on any Linux runner and returning the cuda runner back to the pool where we can run CUDA testing on it.