### PR TITLE
[SYCL][Test E2E] Add stype to L0 structs

### DIFF
--- a/sycl/test-e2e/AtomicRef/device_has_aspect_atomic64_level_zero.cpp
+++ b/sycl/test-e2e/AtomicRef/device_has_aspect_atomic64_level_zero.cpp
@@ -12,6 +12,7 @@ int main() {
   device Dev = Queue.get_device();
   bool Result;
   ze_device_module_properties_t Properties{};
+  Properties.stype = ZE_STRUCTURE_TYPE_DEVICE_MODULE_PROPERTIES;
   zeDeviceGetModuleProperties(get_native<backend::ext_oneapi_level_zero>(Dev),
                               &Properties);
   if (Properties.flags & ZE_DEVICE_MODULE_FLAG_INT64_ATOMICS)

--- a/sycl/test-e2e/Plugin/interop-level-zero-interop-task-mem-buffer.cpp
+++ b/sycl/test-e2e/Plugin/interop-level-zero-interop-task-mem-buffer.cpp
@@ -30,6 +30,8 @@ int main() {
             void *device_ptr =
                 ih.get_mem<backend::ext_oneapi_level_zero>(buffer_acc);
             ze_memory_allocation_properties_t memAllocProperties{};
+            memAllocProperties.stype =
+                ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
             ze_result_t res = zeMemGetAllocProperties(
                 ze_context, device_ptr, &memAllocProperties, nullptr);
             assert(res == ZE_RESULT_SUCCESS);

--- a/sycl/test-e2e/Plugin/level_zero_uuid.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_uuid.cpp
@@ -23,6 +23,7 @@ int main() {
 
   auto zedev = sycl::get_native<sycl::backend::ext_oneapi_level_zero>(dev);
   ze_device_properties_t device_properties{};
+  device_properties.stype = ZE_STRUCTURE_TYPE_DEVICE_PROPERTIES;
   zeDeviceGetProperties(zedev, &device_properties);
   std::stringstream uuid_l0;
   for (int i = 0; i < ZE_MAX_DEVICE_UUID_SIZE; ++i)


### PR DESCRIPTION
device_has_aspect_atomic64_level_zero.cpp
interop-level-zero-interop-task-mem-buffer.cpp
level_zero_uuid.cpp

were missing to set L0 stype for a properties struct,
which would genereate an error in L0 validation layer when
enabled with ZE_DEBUG=6.