### PR TITLE
[Driver][SYCL] Improve option restriction for device with Windows

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -834,8 +834,11 @@ SYCLToolChain::TranslateArgs(const llvm::opt::DerivedArgList &Args,
   DerivedArgList *DAL =
       HostTC.TranslateArgs(Args, BoundArch, DeviceOffloadKind);
 
-  if (!DAL)
+  bool IsNewDAL = false;
+  if (!DAL) {
     DAL = new DerivedArgList(Args.getBaseArgs());
+    IsNewDAL = true;
+  }
 
   for (Arg *A : Args) {
     // Filter out any options we do not want to pass along to the device
@@ -844,11 +847,12 @@ SYCLToolChain::TranslateArgs(const llvm::opt::DerivedArgList &Args,
     switch (Opt) {
     case options::OPT_fsanitize_EQ:
     case options::OPT_fcf_protection_EQ:
-      if (llvm::is_contained(*DAL, A))
+      if (!IsNewDAL)
         DAL->eraseArg(Opt);
       break;
     default:
-      DAL->append(A);
+      if (IsNewDAL)
+        DAL->append(A);
       break;
     }
   }

--- a/clang/test/Driver/sycl-unsupported.cpp
+++ b/clang/test/Driver/sycl-unsupported.cpp
@@ -1,6 +1,8 @@
 /// Diagnose unsupported options specific to SYCL compilations
 // RUN: %clangxx -fsycl -fsanitize=address -fsycl-targets=spir64 -### %s 2>&1 \
 // RUN:  | FileCheck %s -DARCH=spir64 -DOPT=-fsanitize=address
+// RUN: %clang_cl -fsycl -fsanitize=address -fsycl-targets=spir64 -### %s 2>&1 \
+// RUN:  | FileCheck %s -DARCH=spir64 -DOPT=-fsanitize=address
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -fsanitize=address -### %s 2>&1 \
 // RUN:  | FileCheck %s -DARCH=spir64_gen -DOPT=-fsanitize=address
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_fpga -fsanitize=address -### %s 2>&1 \
@@ -10,6 +12,8 @@
 
 // RUN: %clangxx -fsycl -fcf-protection -fsycl-targets=spir64 -### %s 2>&1 \
 // RUN:  | FileCheck %s -DARCH=spir64 -DOPT=-fcf-protection
+// RUN: %clang_cl -fsycl -fcf-protection -fsycl-targets=spir64 -### %s 2>&1 \
+// RUN:  | FileCheck %s -DARCH=spir64 -DOPT=-fcf-protection
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -fcf-protection -### %s 2>&1 \
 // RUN:  | FileCheck %s -DARCH=spir64_gen -DOPT=-fcf-protection
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_fpga -fcf-protection -### %s 2>&1 \
@@ -18,3 +22,5 @@
 // RUN:  | FileCheck %s -DARCH=spir64_x86_64 -DOPT=-fcf-protection
 
 // CHECK: ignoring '[[OPT]]' option as it is not currently supported for target '[[ARCH]]{{.*}}' [-Woption-ignored]
+// CHECK-NOT: clang{{.*}} "-fsycl-is-device"{{.*}} "[[OPT]]{{.*}}"
+// CHECK: clang{{.*}} "-fsycl-is-host"{{.*}} "[[OPT]]{{.*}}"


### PR DESCRIPTION
We restrict a couple of options for SYCL device compilations and provide a warning we are doing so.  This was not working completely on Windows as we were emitting the warning, but continuing to push the options to the device compilation.  The derived argument list that is used for the device compilation is where we filter these options out.  Due to a mismanage of only manipulating the argument list when we are creating a new one, we missed this capability with Windows.