### PR TITLE
[SYCL-MLIR] Add SYCL `Utils.[cpp|h]`

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.h
@@ -34,15 +34,4 @@ inline bool isSYCLOperation(Operation *op) {
 #define GET_OP_CLASSES
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h.inc"
 
-namespace mlir {
-namespace sycl {
-
-/// Return type of the accessor of \p op.
-inline AccessorType getAccessorType(SYCLAccessorSubscriptOp op) {
-  return sycl::AccessorPtrValue(op.getAcc()).getAccessorType();
-}
-
-} // namespace sycl
-} // namespace mlir
-
 #endif // MLIR_DIALECT_SYCL_IR_SYCLOPS_H

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Utils/Utils.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Utils/Utils.h
@@ -1,0 +1,32 @@
+//===- Utils.h - General SYCL transformation utilities ----------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file defines prototypes for various transformation utilities for
+// the SYCL dialect. These are not passes by themselves but are used
+// either by passes, optimization sequences, or in turn by other transformation
+// utilities.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_SYCL_UTILS_UTILS_H
+#define MLIR_DIALECT_SYCL_UTILS_UTILS_H
+
+#include "mlir/Dialect/SYCL/IR/SYCLOps.h"
+
+namespace mlir {
+namespace sycl {
+
+/// Return type of the accessor of \p op.
+inline AccessorType getAccessorType(SYCLAccessorSubscriptOp op) {
+  return sycl::AccessorPtrValue(op.getAcc()).getAccessorType();
+}
+
+} // namespace sycl
+} // namespace mlir
+
+#endif // MLIR_DIALECT_SYCL_UTILS_UTILS_H

--- a/mlir-sycl/lib/Dialect/SYCL/CMakeLists.txt
+++ b/mlir-sycl/lib/Dialect/SYCL/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Analysis)
 add_subdirectory(IR)
 add_subdirectory(Transforms)
+add_subdirectory(Utils)

--- a/mlir-sycl/lib/Dialect/SYCL/Utils/CMakeLists.txt
+++ b/mlir-sycl/lib/Dialect/SYCL/Utils/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_mlir_dialect_library(MLIRSYCLUtils
+  Utils.cpp
+
+  ADDITIONAL_HEADER_DIRS
+  ${MLIR_SYCL_SOURCE_DIR}/include/mlir/Dialect/SYCL/Utils
+
+  LINK_LIBS PUBLIC
+  MLIRSYCLDialect
+  MLIRDialect
+  MLIRIR
+  )

--- a/mlir-sycl/lib/Dialect/SYCL/Utils/Utils.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Utils/Utils.cpp
@@ -1,0 +1,16 @@
+//===- Utils.cpp - Utilities to support the SYCL dialect ------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements utilities for the SYCL dialect.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/SYCL/Utils/Utils.h"
+
+using namespace mlir;
+using namespace mlir::sycl;

--- a/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
@@ -44,6 +44,7 @@ add_mlir_dialect_library(MLIRPolygeistTransforms
   MLIRSPIRVDialect
   MLIRSYCLAnalysis  
   MLIRSYCLDialect
+  MLIRSYCLUtils
   MLIRSideEffectInterfaces
   MLIRSCFToControlFlow
   MLIRTransformUtils

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
@@ -25,6 +25,7 @@
 #include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
 #include "mlir/Dialect/SYCL/Analysis/AliasAnalysis.h"
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"
+#include "mlir/Dialect/SYCL/Utils/Utils.h"
 #include "mlir/IR/FunctionInterfaces.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
 #include "llvm/ADT/TypeSwitch.h"


### PR DESCRIPTION
As suggested in https://github.com/intel/llvm/pull/9785#discussion_r1223240361, created `Utils.[cpp|h]` for SYCL utilities.