### PR TITLE
[SYCL][Matrix]Fix missing multi_ptr extraction in a joint matrix test

### DIFF
--- a/sycl/test-e2e/Matrix/element_wise_all_sizes_impl.hpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_sizes_impl.hpp
@@ -66,10 +66,10 @@ void matrix_verify_add(const T1 val1, const T1 val2, const T1 result) {
        for (int i = 0; i < wi_slice_a.length(); i++) {
          wi_slice_a[i] = wi_slice_a[i] + val2;
        }
-
        ext::intel::experimental::matrix::joint_matrix_store(
            sg, sub_a,
-           accA.get_pointer() + (sg_startx * TM) * K + sg_starty / SG_SZ * TK,
+           accA.template get_multi_ptr<access::decorated::no>() +
+               (sg_startx * TM) * K + sg_starty / SG_SZ * TK,
            K);
      }); // parallel for
    }).wait();


### PR DESCRIPTION
It looks like this test was not updated as part of https://github.com/intel/llvm/pull/8874