### PR TITLE
[SYCL][ESIMD][NFC] Remove redundant 32-bit conversions

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -899,10 +899,9 @@ gather_rgba(AccessorT acc,
   // TODO (performance) use hardware-supported scale once BE supports it
   constexpr uint32_t Scale = 0;
   const auto SI = get_surface_index(acc);
-  auto loc_offsets = convert<uint32_t>(offsets);
   return __esimd_gather4_masked_scaled2<detail::__raw_t<T>, N, RGBAMask,
                                         decltype(SI), Scale>(
-      SI, global_offset, loc_offsets.data(), mask.data());
+      SI, global_offset, offsets.data(), mask.data());
 #endif
 }
 
@@ -962,9 +961,8 @@ scatter_rgba(AccessorT acc,
   // TODO (performance) use hardware-supported scale once BE supports it
   constexpr uint32_t Scale = 0;
   const auto SI = get_surface_index(acc);
-  auto loc_offsets = convert<uint32_t>(offsets);
   __esimd_scatter4_scaled<T, N, decltype(SI), RGBAMask, Scale>(
-      mask.data(), SI, global_offset, loc_offsets.data(), vals.data());
+      mask.data(), SI, global_offset, offsets.data(), vals.data());
 #endif
 }
 

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -796,10 +796,9 @@ lsc_gather(AccessorTy acc,
       detail::lsc_data_order::nontranspose;
   using MsgT = typename detail::lsc_expand_type<T>::type;
   auto si = __ESIMD_NS::get_surface_index(acc);
-  auto loc_offsets = convert<uint32_t>(offsets);
   __ESIMD_NS::simd<MsgT, N * NElts> Tmp =
       __esimd_lsc_load_bti<MsgT, L1H, L3H, _AddressScale, _ImmOffset, _DS, _VS,
-                           _Transposed, N>(pred.data(), loc_offsets.data(), si);
+                           _Transposed, N>(pred.data(), offsets.data(), si);
   return detail::lsc_format_ret<T>(Tmp);
 #endif
 }
@@ -870,13 +869,12 @@ lsc_gather(AccessorTy acc,
   constexpr auto _Transposed = detail::lsc_data_order::nontranspose;
   using MsgT = typename detail::lsc_expand_type<T>::type;
   auto SI = __ESIMD_NS::get_surface_index(acc);
-  auto loc_offsets = convert<uint32_t>(offsets);
   __ESIMD_NS::simd<MsgT, N * NElts> OldValuesExpanded =
       detail::lsc_format_input<MsgT>(old_values);
   __ESIMD_NS::simd<MsgT, N * NElts> Result =
       __esimd_lsc_load_merge_bti<MsgT, L1H, L3H, _AddressScale, _ImmOffset, _DS,
                                  _VS, _Transposed, N>(
-          pred.data(), loc_offsets.data(), SI, OldValuesExpanded.data());
+          pred.data(), offsets.data(), SI, OldValuesExpanded.data());
   return detail::lsc_format_ret<T>(Result);
 #endif
 }
@@ -1571,9 +1569,8 @@ lsc_prefetch(AccessorTy acc,
       detail::lsc_data_order::nontranspose;
   using MsgT = typename detail::lsc_expand_type<T>::type;
   auto si = __ESIMD_NS::get_surface_index(acc);
-  auto loc_offsets = convert<uint32_t>(offsets);
   __esimd_lsc_prefetch_bti<MsgT, L1H, L3H, _AddressScale, _ImmOffset, _DS, _VS,
-                           _Transposed, N>(pred.data(), loc_offsets.data(), si);
+                           _Transposed, N>(pred.data(), offsets.data(), si);
 #endif
 }
 
@@ -1829,10 +1826,9 @@ lsc_scatter(AccessorTy acc,
   using _CstT = typename detail::lsc_bitcast_type<T>::type;
   __ESIMD_NS::simd<MsgT, N * NElts> Tmp = vals.template bit_cast_view<_CstT>();
   auto si = __ESIMD_NS::get_surface_index(acc);
-  auto loc_offsets = convert<uint32_t>(offsets);
   __esimd_lsc_store_bti<MsgT, L1H, L3H, _AddressScale, _ImmOffset, _DS, _VS,
-                        _Transposed, N>(pred.data(), loc_offsets.data(),
-                                        Tmp.data(), si);
+                        _Transposed, N>(pred.data(), offsets.data(), Tmp.data(),
+                                        si);
 #endif
 }
 


### PR DESCRIPTION
These don't do anything since the offsets are already 32-bit. The `convert` function does nothing if source and dest type are equal.