### PR TITLE
[SYCL][ESIMD][Driver] Pass -fsycl-esimd-force-stateless-mem to host

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5120,10 +5120,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-fsycl-allow-func-ptr");
     }
 
-    if (Args.hasFlag(options::OPT_fsycl_esimd_force_stateless_mem,
-                     options::OPT_fno_sycl_esimd_force_stateless_mem, false))
-      CmdArgs.push_back("-fsycl-esimd-force-stateless-mem");
-
     // Forward -fsycl-instrument-device-code option to cc1. This option will
     // only be used for SPIR-V-based targets.
     if (Triple.isSPIR())
@@ -5309,6 +5305,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       for (auto &Macro : D.getSYCLTargetMacroArgs())
         CmdArgs.push_back(Args.MakeArgString(Macro));
     }
+    if (Args.hasFlag(options::OPT_fsycl_esimd_force_stateless_mem,
+                     options::OPT_fno_sycl_esimd_force_stateless_mem, false))
+      CmdArgs.push_back("-fsycl-esimd-force-stateless-mem");
   }
 
   if (IsOpenMPDevice) {

--- a/clang/lib/Frontend/InitPreprocessor.cpp
+++ b/clang/lib/Frontend/InitPreprocessor.cpp
@@ -1309,12 +1309,12 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
       Builder.defineMacro("__ENABLE_USM_ADDR_SPACE__");
       Builder.defineMacro("SYCL_DISABLE_FALLBACK_ASSERT");
     }
-
-    if (LangOpts.SYCLESIMDForceStatelessMem)
-      Builder.defineMacro("__ESIMD_FORCE_STATELESS_MEM");
   }
   if (LangOpts.SYCLUnnamedLambda)
     Builder.defineMacro("__SYCL_UNNAMED_LAMBDA__");
+
+  if (LangOpts.SYCLESIMDForceStatelessMem)
+    Builder.defineMacro("__ESIMD_FORCE_STATELESS_MEM");
 
   // OpenCL definitions.
   if (LangOpts.OpenCL) {

--- a/clang/test/Driver/sycl-esimd-force-stateless-mem.cpp
+++ b/clang/test/Driver/sycl-esimd-force-stateless-mem.cpp
@@ -1,12 +1,12 @@
 
 /// Verify that the driver option is translated to corresponding options
-/// to device compilation and sycl-post-link.
+/// to host/device compilation and sycl-post-link.
 // RUN: %clang -### -fsycl -fsycl-esimd-force-stateless-mem \
 // RUN: %s 2>&1 | FileCheck -check-prefix=CHECK-PASS-TO-COMPS %s
 // CHECK-PASS-TO-COMPS: clang{{.*}} "-fsycl-esimd-force-stateless-mem"
 // CHECK-PASS-TO-COMPS: sycl-post-link{{.*}} "-lower-esimd-force-stateless-mem"
-// CHECK-PASS-TO-COMPS-NOT: clang{{.*}} "-fsycl-is-host" {{.*}}"-fsycl-esimd-force-stateless-mem"
-// CHECK-PASS-TO-COMPS-NOT: clang{{.*}} "-fsycl-esimd-force-stateless-mem" {{.*}}"-fsycl-is-host"
+// CHECK-PASS-TO-COMPS: clang{{.*}} "-fsycl-is-host" {{.*}}"-fsycl-esimd-force-stateless-mem"
+"
 
 /// Verify that stateless memory accesses mapping is not enforced by default
 // RUN: %clang -### -fsycl %s 2>&1 | FileCheck -check-prefix=CHECK-DEFAULT %s

--- a/sycl/test-e2e/ESIMD/acc_gather_scatter_rgba_stateless.cpp
+++ b/sycl/test-e2e/ESIMD/acc_gather_scatter_rgba_stateless.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+// UNSUPPORTED: esimd_emulator
 // Use -O2 to avoid huge stack usage under -O0.
 // RUN: %{build} -O2 -fsycl-esimd-force-stateless-mem -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/accessor_gather_scatter_stateless.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_gather_scatter_stateless.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+// UNSUPPORTED: esimd_emulator
 // Use -O2 to avoid huge stack usage under -O0.
 // RUN: %{build} -O2 -fsycl-esimd-force-stateless-mem -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/accessor_load_store_stateless.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_load_store_stateless.cpp
@@ -10,6 +10,7 @@
 // intrinsics when stateless memory accesses are enforced, i.e. accessor
 // based accesses are automatically converted to stateless accesses.
 
+// UNSUPPORTED: esimd_emulator
 // RUN: %{build} -fsycl-esimd-force-stateless-mem -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/accessor_stateless.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_stateless.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+// UNSUPPORTED: esimd_emulator
 // Use -O2 to avoid huge stack usage under -O0.
 // RUN: %{build} -O2 -fsycl-esimd-force-stateless-mem -D_CRT_SECURE_NO_WARNINGS=1 -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/lsc/lsc_predicate_stateless.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_predicate_stateless.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: gpu-intel-pvc || esimd_emulator
+// UNSUPPORTED: esimd_emulator
+// REQUIRES: gpu-intel-pvc
 // RUN: %{build} -fsycl-esimd-force-stateless-mem -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/lsc/lsc_surf_load_u32_stateless.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_surf_load_u32_stateless.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: gpu-intel-pvc || esimd_emulator
+// UNSUPPORTED: esimd_emulator
+// REQUIRES: gpu-intel-pvc
 // RUN: %{build} -fsycl-esimd-force-stateless-mem -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/lsc/lsc_surf_load_u64_stateless.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_surf_load_u64_stateless.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: gpu-intel-pvc || esimd_emulator
+// UNSUPPORTED: esimd_emulator
+// REQUIRES: gpu-intel-pvc
 // RUN: %{build} -fsycl-esimd-force-stateless-mem -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/lsc/lsc_surf_load_u8_u16_stateless.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_surf_load_u8_u16_stateless.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: gpu-intel-pvc || esimd_emulator
+// UNSUPPORTED: esimd_emulator
+// REQUIRES: gpu-intel-pvc
 // RUN: %{build} -fsycl-esimd-force-stateless-mem -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/lsc/lsc_surf_store_u32_stateless.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_surf_store_u32_stateless.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: gpu-intel-pvc || esimd_emulator
+// UNSUPPORTED: esimd_emulator
+// REQUIRES: gpu-intel-pvc
 // RUN: %{build} -fsycl-esimd-force-stateless-mem -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/lsc/lsc_surf_store_u64_stateless.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_surf_store_u64_stateless.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: gpu-intel-pvc || esimd_emulator
+// UNSUPPORTED: esimd_emulator
+// REQUIRES: gpu-intel-pvc
 // RUN: %{build} -fsycl-esimd-force-stateless-mem -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
Right now, the `-fsycl-esimd-force-stateless-mem` flag sets the `__ESIMD_FORCE_STATELESS_MEM` macro for the device compiler only. We have some APIs that have different arguments with `__ESIMD_FORCE_STATELESS_MEM` vs without it, so getting the host compiler to not error when calling one of those functions can be frustrating for the user.

Make `-fsycl-esimd-force-stateless-mem` set `__ESIMD_FORCE_STATELESS_MEM` for the host compiler too.

I also found we had some esimd_emulator tests that were testing stateless mode, but the emulator never uses the device code and always uses host code, so it wasn't even testing stateless mode. We discussed this internally and decided to disable the tests on the emulator.