### PR TITLE
[SYCL] Remove invalid `copy` test case

### DIFF
--- a/sycl/test-e2e/Basic/handler/handler_mem_op.cpp
+++ b/sycl/test-e2e/Basic/handler/handler_mem_op.cpp
@@ -255,20 +255,6 @@ template <typename T> void test_copy_ptr_acc() {
     assert(Data[I] == Values[I]);
   }
 
-  // Check copy from 'const void *' memory to accessor.
-  {
-    buffer<T, 1> Buffer(Size);
-    queue Queue;
-    Queue.submit([&](handler &Cgh) {
-      auto Acc = Buffer.template get_access<access::mode::discard_write>(Cgh);
-      Cgh.copy(reinterpret_cast<const void *>(Values), Acc);
-    });
-
-    auto Acc = Buffer.template get_access<access::mode::read>();
-    for (int I = 0; I < Size; ++I)
-      assert(Acc[I] == Values[I]);
-  }
-
   // Check copy from memory to 0-dimensional accessor.
   T SrcValue = 99;
   T DstValue = 0;


### PR DESCRIPTION
KhronosGroup/SYCL-Docs#425 clarifies that the source type for the `copy` must be device copyable. Remove the copy from `const void *` test case since it fails this assertion.