### PR TITLE
[SYCL][ESIMD] Allow implicit conversion from std::experimental::simd_mask to ESIMD::simd_mask

### DIFF
--- a/sycl/include/std/experimental/simd.hpp
+++ b/sycl/include/std/experimental/simd.hpp
@@ -854,6 +854,9 @@ public:
   void __set(size_t __index, _Tp __val) noexcept {
     __storage_[__index] = __val;
   }
+#ifdef ENABLE_SYCL_EXT_ONEAPI_INVOKE_SIMD
+  const _StorageType& data() const noexcept { return __storage_; }
+#endif
 };
 
 #endif // _LIBCPP_HAS_NO_VECTOR_EXTENSION
@@ -1665,6 +1668,10 @@ public:
 #else
   static constexpr size_t size() noexcept;
 #endif // ENABLE_SYCL_EXT_ONEAPI_INVOKE_SIMD
+
+#ifdef ENABLE_SYCL_EXT_ONEAPI_INVOKE_SIMD
+  const auto& data() const noexcept { return __s_.data(); }
+#endif
 
   simd_mask() = default;
 

--- a/sycl/include/sycl/ext/intel/esimd/detail/simd_mask_impl.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/simd_mask_impl.hpp
@@ -12,6 +12,7 @@
 
 #include <sycl/ext/intel/esimd/detail/simd_obj_impl.hpp>
 #include <sycl/ext/intel/esimd/detail/types.hpp>
+#include <sycl/ext/oneapi/experimental/detail/invoke_simd_types.hpp>
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
@@ -94,6 +95,11 @@ public:
 
   /// Implicit conversion from simd.
   simd_mask_impl(const simd<T, N> &Val) : base_type(Val.data()) {}
+
+  /// Implicit conversion from std::experimental::simd_mask
+  template <typename T1>
+  simd_mask_impl(const ext::oneapi::experimental::simd_mask<T1, N> &Val)
+      : base_type(convert_vector<T, T1, N>(Val.data())) {}
 
 private:
   /// @cond ESIMD_DETAIL

--- a/sycl/include/sycl/ext/oneapi/experimental/detail/invoke_simd_types.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/detail/invoke_simd_types.hpp
@@ -1,0 +1,46 @@
+//==- invoke_simd_types.hpp - SYCL invoke_simd extension types --*- C++ -*-==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===--------------------------------------------------------------------=== //
+// Part of the implemenation of the sycl_ext_oneapi_invoke_simd extension.
+// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_invoke_simd.asciidoc
+// ===--------------------------------------------------------------------=== //
+
+#pragma once
+
+// SYCL extension macro definition as required by the SYCL specification.
+// 1 - Initial extension version. Base features are supported.
+#define SYCL_EXT_ONEAPI_INVOKE_SIMD 1
+
+#include <std/experimental/simd.hpp>
+#include <sycl/detail/defines_elementary.hpp>
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+
+namespace ext::oneapi::experimental {
+
+// --- Basic definitions prescribed by the spec.
+namespace simd_abi {
+// "Fixed-size simd width of N" ABI based on clang vectors - used as the ABI for
+// SIMD objects this implementation of invoke_simd spec is based on.
+template <class T, int N>
+using native_fixed_size = typename std::experimental::__simd_abi<
+    std::experimental::_StorageKind::_VecExt, N>;
+} // namespace simd_abi
+
+// The SIMD object type, which is the generic std::experimental::simd type with
+// the native fixed size ABI.
+template <class T, int N>
+using simd = std::experimental::simd<T, simd_abi::native_fixed_size<T, N>>;
+
+// The SIMD mask object type.
+template <class T, int N>
+using simd_mask =
+    std::experimental::simd_mask<T, simd_abi::native_fixed_size<T, N>>;
+} // namespace ext::oneapi::experimental
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
+} // namespace sycl

--- a/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
@@ -11,13 +11,9 @@
 
 #pragma once
 
-// SYCL extension macro definition as required by the SYCL specification.
-// 1 - Initial extension version. Base features are supported.
-#define SYCL_EXT_ONEAPI_INVOKE_SIMD 1
-
+#include <sycl/ext/oneapi/experimental/detail/invoke_simd_types.hpp>
 #include <sycl/ext/oneapi/experimental/uniform.hpp>
 
-#include <std/experimental/simd.hpp>
 #include <sycl/detail/boost/mp11.hpp>
 #include <sycl/sub_group.hpp>
 
@@ -71,25 +67,6 @@ namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 
 namespace ext::oneapi::experimental {
-
-// --- Basic definitions prescribed by the spec.
-namespace simd_abi {
-// "Fixed-size simd width of N" ABI based on clang vectors - used as the ABI for
-// SIMD objects this implementation of invoke_simd spec is based on.
-template <class T, int N>
-using native_fixed_size = typename std::experimental::__simd_abi<
-    std::experimental::_StorageKind::_VecExt, N>;
-} // namespace simd_abi
-
-// The SIMD object type, which is the generic std::experimental::simd type with
-// the native fixed size ABI.
-template <class T, int N>
-using simd = std::experimental::simd<T, simd_abi::native_fixed_size<T, N>>;
-
-// The SIMD mask object type.
-template <class T, int N>
-using simd_mask =
-    std::experimental::simd_mask<T, simd_abi::native_fixed_size<T, N>>;
 
 // --- Helpers
 namespace detail {

--- a/sycl/test-e2e/InvokeSimd/Spec/simd_mask_merge.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/simd_mask_merge.cpp
@@ -17,9 +17,7 @@ constexpr int VL = 16;
 [[intel::device_indirectly_callable]] simd<float, VL>
 SIMD_CALLEE(simd<float, VL> va, simd_mask<float, VL> mask) SYCL_ESIMD_FUNCTION {
   esimd::simd<float, VL> ret(0);
-  esimd::simd_mask<VL> emask;
-  for(int i = 0; i < VL; i++)
-    emask[i] = static_cast<bool>(mask[i]);
+  esimd::simd_mask<VL> emask = mask;
   ret.merge(va, !emask);
   return ret;
 }


### PR DESCRIPTION
Users of `invoke_simd` need to use `std::experimental::simd_mask` for masks as per the spec, but once they enter ESIMD code they will likely want to use the ESIMD classes. Provide an implicit conversion from  `std::experimental::simd_mask` to `esimd::simd_mask`

Without this change, you need to use a manual loop, as all you can do is access `std::experimental::simd_mask` element-by-element.