### PR TITLE
[CI] Improve devops/actions/cached_checkout

### DIFF
--- a/devops/actions/cached_checkout/action.yml
+++ b/devops/actions/cached_checkout/action.yml
@@ -16,6 +16,9 @@ inputs:
   default_branch:
     description: 'Name of the default branch'
     default: 'sycl'
+  merge:
+    description: 'Merge default branch after the checkout'
+    default: true
 
 runs:
   using: 'composite'
@@ -41,10 +44,16 @@ runs:
       ref: ${{ inputs.ref }}
       path: ${{ inputs.path }}
       fetch-depth: 0
-  - name: Merge sycl HEAD into current branch
+  - name: Setup alternates
     shell: bash
     env:
       GIT_ALTERNATE_OBJECT_DIRECTORIES: ${{ inputs.cache_path }}/${{ inputs.repository }}/.git/objects
+    run: |
+      echo $GIT_ALTERNATE_OBJECT_DIRECTORIES > ${{ inputs.path }}/.git/objects/info/alternates
+  - name: Merge sycl HEAD into current branch
+    shell: bash
+    if: ${{ inputs.merge == 'true' }}
+    env:
       DEFAULT_BRANCH: ${{ inputs.default_branch }}
     run: |
       cd ${{ inputs.path }}


### PR DESCRIPTION
* Add ability to skip the merge
* Setup alternates on the filesystem level so that other jobs in the workflow could work with GIT without setting the environment variable.