### PR TITLE
[SYCL-MLIR][LoopInternalization] Change to `gpuModule` pass

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
@@ -124,7 +124,7 @@ def LLVMLegalizeForSPIRV : Pass<"legalize-for-spirv"> {
   let dependentDialects = ["LLVM::LLVMDialect"];  
 }
 
-def LoopInternalization : Pass<"loop-internalization"> {
+def LoopInternalization : Pass<"loop-internalization", "gpu::GPUModuleOp"> {
   let summary = "Promote SYCL memory accesses in a loop nest to shared local memory";
   let description = [{
     SYCL memory accesses in perfectly nested loops are promoted to shared local

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
@@ -628,18 +628,13 @@ private:
 };
 
 void LoopInternalization::runOnOperation() {
-  Operation *module = getOperation();
-  ModuleAnalysisManager mam(module, /*passInstrumentor=*/nullptr);
+  gpu::GPUModuleOp gpuModule = getOperation();
+  ModuleAnalysisManager mam(gpuModule, /*passInstrumentor=*/nullptr);
   AnalysisManager am = mam;
   auto &memAccessAnalysis =
       am.getAnalysis<MemoryAccessAnalysis>().initialize(relaxedAliasing);
   AliasAnalysis &aliasAnalysis = getAnalysis<AliasAnalysis>();
   aliasAnalysis.addAnalysisImplementation(sycl::AliasAnalysis(relaxedAliasing));
-  auto gpuModule = dyn_cast<gpu::GPUModuleOp>(
-      module->getRegion(0).front().getOperations().front());
-  if (!gpuModule)
-    return;
-
   FunctionKernelInfo funcKernelInfo(gpuModule);
 
   // Collect kernel body functions of candidate kernels.


### PR DESCRIPTION
As `LoopInternalization` only operate on `gpuModule`, change the pass to a `gpuModule` pass.